### PR TITLE
chore: add CODEOWNERS (@yotamleo)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners for Himmel.
+# The owner listed here is automatically requested for review on every PR that
+# touches matching paths. Enable "Require review from Code Owners" in the
+# branch-protection ruleset for `main` to make that review mandatory.
+
+# Everything is owned by the maintainer.
+* @yotamleo


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @yotamleo` so the maintainer is auto-requested on every PR. After merge, enable **Require review from Code Owners** in the `main` branch-protection ruleset to enforce it.

Single-file change; no code.