### PR TITLE
chore: [HIMMEL-297] main+master branch protection + user-slug + audit-fix (code sync)

### DIFF
--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -38,8 +38,10 @@ Steps:
 
    **Step 3.0 — gemini first-pass (decimal substep, runs BEFORE any Agent dispatch):**
    ```bash
+   # Resolve the protected default (main OR master, HIMMEL-297) for the diff base.
+   db=$(. scripts/guardrails/lib.sh 2>/dev/null && default_branch || echo main)
    diff_rc=0
-   diff_out=$(git diff main...HEAD) || diff_rc=$?
+   diff_out=$(git diff "$db...HEAD") || diff_rc=$?
    if [ "$diff_rc" -ne 0 ]; then
        # git itself failed — treat as gemini first-pass unavailable, not empty-diff skip.
        echo "gemini first-pass unavailable — claude-only review (git diff failed rc=$diff_rc: $diff_out)" >&2
@@ -54,7 +56,7 @@ Steps:
        #       retry once with the rtk proxy form below before falling back.)
    fi
    ```
-   If the environment token-proxies git (rtk), the plain git diff above returns a stat summary, not a unified diff — the script exits 2 ('stdin is not a unified diff'). Produce the diff with `rtk proxy git diff main...HEAD` in that case.
+   If the environment token-proxies git (rtk), the plain git diff above returns a stat summary, not a unified diff — the script exits 2 ('stdin is not a unified diff'). Produce the diff with `rtk proxy git diff "$db...HEAD"` in that case.
 
    The script's `[gemini-N]` Critical/Important findings are BLOCKING
    CANDIDATES under the adjudication rules below. Its Suggestions are NOT

--- a/docs/internals/handover-system.md
+++ b/docs/internals/handover-system.md
@@ -190,9 +190,11 @@ Handover bucket paths (`<state-root>/<USER_SLUG>/...`), registry.json
 Resolved by `scripts/lib/user-slug.sh`:
 
 1. `$USER_SLUG` env var (preferred — explicit operator intent).
-2. `git config user.name` slugified (kebab-case, lowercase, non-alnum
-   → dash, ≤30 chars).
-3. Fail with a hint pointing at `.env.example` + `git config` setup.
+2. GitHub username via `gh api user -q .login`, slugified (HIMMEL-297 — the
+   slug is the GitHub user id; one network call, gated behind `$USER_SLUG`).
+3. `git config user.name` slugified (kebab-case, lowercase, non-alnum
+   → dash, ≤30 chars) — offline fallback when gh is absent/unauthenticated.
+4. Fail with a hint pointing at `.env.example` + `gh auth` / `git config` setup.
 
 Callers source the lib + call `user_slug` (raw) or `user_slug_verify`
 (prints resolved value + source to stderr; used in `setup.sh`'s

--- a/marketplace/plugins/handover/skills/handover/SKILL.md
+++ b/marketplace/plugins/handover/skills/handover/SKILL.md
@@ -115,7 +115,7 @@ Bootstrap a **new** target repo (no existing state). Refuses if `<repo-root>/han
 
 Full spec: `references/init-register.md`.
 
-Short flow: prompt for name, path (default = `parent(--git-common-dir)` of cwd, canonicalised), user (default = slugged `git config user.name`), aliases. Create state dirs (`epics/`, `standalones/`, `_templates/`). Seed default templates from `${CLAUDE_PLUGIN_ROOT}/templates/` into `<state-root>/_templates/`. Write empty `status.md`, `backlog.md`. Register in `~/.claude/handover/registry.json` (atomic write).
+Short flow: prompt for name, path (default = `parent(--git-common-dir)` of cwd, canonicalised), user (default = resolved via `scripts/lib/user-slug.sh`: GitHub username via `gh api user`, else slugged `git config user.name`), aliases. Create state dirs (`epics/`, `standalones/`, `_templates/`). Seed default templates from `${CLAUDE_PLUGIN_ROOT}/templates/` into `<state-root>/_templates/`. Write empty `status.md`, `backlog.md`. Register in `~/.claude/handover/registry.json` (atomic write).
 
 - After seeding `_templates/`, generate the first `roadmap.md` and `tech-debt.md` in `<state-root>/` by copying the `_templates/roadmap.md` and `_templates/tech-debt.md` files and filling in the active bucket vocab names + empty sections.
 

--- a/scripts/_new-worktree.sh
+++ b/scripts/_new-worktree.sh
@@ -16,11 +16,22 @@
 # log file. Pass --verbose to stream everything to the terminal too.
 #
 # Side effects:
-#   1. git fetch origin main (refresh refs only — does not modify local main)
-#   2. git worktree add <path> -b <branch> origin/main
+#   1. git fetch origin <default> (refresh refs only — does not modify local
+#      default branch; <default> = main OR master, resolved per HIMMEL-297)
+#   2. git worktree add <path> -b <branch> origin/<default>
 #   3. Unless --no-install: npm install --omit=dev in scripts/jira/ so the
 #      pre-push license-check hook can validate without per-push setup.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# default_branch() resolves the repo's default integration branch (main OR
+# master) so new worktrees branch off the real default (HIMMEL-297).
+# shellcheck source=guardrails/lib.sh
+# shellcheck disable=SC1091
+if ! . "$SCRIPT_DIR/guardrails/lib.sh" 2>/dev/null; then
+    echo "ERR new-worktree: cannot source guardrails/lib.sh" >&2
+    exit 1
+fi
 
 usage() {
     echo "Usage: $0 <branch-name> [--no-install] [--verbose]" >&2
@@ -62,6 +73,10 @@ COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) || { echo "ERR new-work
 # resolve to absolute via `cd`-and-`pwd` so PRIMARY_WORKTREE is reliable.
 PRIMARY_WORKTREE=$(cd "$(dirname "$COMMON_DIR")" && pwd)
 
+# Resolve the repo's default integration branch (main OR master, HIMMEL-297)
+# so the fetch + worktree-add below target the real default.
+DEFAULT_BRANCH=$(default_branch "$PRIMARY_WORKTREE")
+
 WORKTREE_RELATIVE=".claude/worktrees/${BRANCH//\//+}"
 WORKTREE_PATH="$PRIMARY_WORKTREE/$WORKTREE_RELATIVE"
 LOG="${TMPDIR:-/tmp}/new-worktree-$(date +%Y%m%d-%H%M%S)-$$.log"
@@ -88,7 +103,7 @@ fi
     echo "=== new-worktree $BRANCH @ $(date -Iseconds) ==="
 } >>"$LOG"
 
-if ! run git -C "$PRIMARY_WORKTREE" fetch origin main --quiet; then
+if ! run git -C "$PRIMARY_WORKTREE" fetch origin "$DEFAULT_BRANCH" --quiet; then
     # Common unattended-run failure (e.g. arm-resume relaunch): git's stored
     # credential (Windows Git Credential Manager, or an expired PAT git uses) is
     # stale while `gh` holds a SEPARATE valid token. `gh auth setup-git` wires git
@@ -102,7 +117,7 @@ if ! run git -C "$PRIMARY_WORKTREE" fetch origin main --quiet; then
     if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
         echo "WARN new-worktree: git fetch failed; gh is authenticated — running 'gh auth setup-git' and retrying" >&2
         run gh auth setup-git || true
-        if ! run git -C "$PRIMARY_WORKTREE" fetch origin main --quiet; then
+        if ! run git -C "$PRIMARY_WORKTREE" fetch origin "$DEFAULT_BRANCH" --quiet; then
             echo "ERR new-worktree: git fetch still failing after gh auth setup-git retry — auth may not be the cause; see log: $LOG" >&2
             exit 1
         fi
@@ -111,7 +126,7 @@ if ! run git -C "$PRIMARY_WORKTREE" fetch origin main --quiet; then
         exit 1
     fi
 fi
-if ! run git -C "$PRIMARY_WORKTREE" worktree add "$WORKTREE_RELATIVE" -b "$BRANCH" origin/main; then
+if ! run git -C "$PRIMARY_WORKTREE" worktree add "$WORKTREE_RELATIVE" -b "$BRANCH" "origin/$DEFAULT_BRANCH"; then
     echo "ERR new-worktree: worktree add failed (log: $LOG)" >&2
     exit 1
 fi

--- a/scripts/cr/hermes-critic.sh
+++ b/scripts/cr/hermes-critic.sh
@@ -27,7 +27,8 @@
 #   hermes-critic.sh [--repo <dir>] [--base <ref>] [--goal "<text>"|--goal-file <p>]
 #                    [--model <name>] [--max-pack-bytes <n>]
 #
-# Defaults: repo = cwd; base = merge-base with origin/main (fallback main);
+# Defaults: repo = cwd; base = merge-base with the default branch — origin/main,
+# origin/master, main, then master in order (HIMMEL-297);
 # model = nvidia/nemotron-3-nano-30b-a3b (spike 2026-06-12: 8s latency,
 # strict JSON obedience on NIM free tier; the 550b ultra took 105s+ on a
 # trivial prompt and times out on review-shaped ones).
@@ -81,15 +82,20 @@ if [ -n "$goal_file" ]; then
 fi
 [ -n "$goal" ] || goal="(no task goal provided — review the change on its own merits)"
 
-# Resolve the diff base: explicit --base, else merge-base with origin/main,
-# else main. The diff is the FINAL code change only (reviewer isolation).
-# Two-dot semantics ($base HEAD) everywhere: with a merge-base SHA the result
-# equals three-dot, and with an explicit --base ref two-dot is what the
-# caller literally asked to compare against.
+# Resolve the diff base: explicit --base, else merge-base with the default
+# branch (main OR master, HIMMEL-297) — origin first, then local. The diff is
+# the FINAL code change only (reviewer isolation). Two-dot semantics ($base
+# HEAD) everywhere: with a merge-base SHA the result equals three-dot, and with
+# an explicit --base ref two-dot is what the caller literally asked to compare
+# against.
 if [ -z "$base" ]; then
-    base="$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main 2>/dev/null || echo "")"
+    base="$(git merge-base HEAD origin/main 2>/dev/null \
+        || git merge-base HEAD origin/master 2>/dev/null \
+        || git merge-base HEAD main 2>/dev/null \
+        || git merge-base HEAD master 2>/dev/null \
+        || echo "")"
 fi
-[ -n "$base" ] || { echo "hermes-critic.sh: could not resolve a diff base (no origin/main or main merge-base — pass --base)" >&2; exit 2; }
+[ -n "$base" ] || { echo "hermes-critic.sh: could not resolve a diff base (no origin/main, origin/master, main, or master merge-base — pass --base)" >&2; exit 2; }
 
 diff_text="$(git diff "$base" HEAD)" || { echo "hermes-critic.sh: git diff failed for base $base" >&2; exit 2; }
 if [ -z "$diff_text" ]; then

--- a/scripts/cr/test-hermes-critic.sh
+++ b/scripts/cr/test-hermes-critic.sh
@@ -104,5 +104,25 @@ unset STUB_PROMPT_CAPTURE
 grep -q "CONTEXT PACK TRUNCATED AT 200 BYTES" "$work/pack-capture" || fail "truncation: sentinel missing from pack"
 echo "  ok" >&2
 
+# 7. Master-default repo, NO --base → auto-resolves the diff base via the
+#    master arm of the merge-base fallback chain (HIMMEL-297). With no `main`
+#    anywhere, origin/main / origin/master / main all miss and `master` is the
+#    arm that resolves; reaching the stub at all (exit 0) proves a base was
+#    found rather than the "could not resolve a diff base" exit 2.
+echo "test: master-default auto-resolve base" >&2
+mrepo="$work/mrepo"
+mkdir -p "$mrepo"
+git -C "$mrepo" init -q -b master
+git -C "$mrepo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m base
+git -C "$mrepo" checkout -q -b feat/x
+printf 'echo hi\n' > "$mrepo/app.sh"
+git -C "$mrepo" add app.sh
+git -C "$mrepo" -c user.email=t@t -c user.name=t commit -q -m change
+out="$(STUB_RESPONSE='{"passed": true, "security_concerns": [], "logic_errors": [], "architectural_mismatches": [], "suggestions": [], "summary": "ok"}' \
+    bash "$CRITIC" --repo "$mrepo" --goal "test goal")"
+rc=$?
+[ "$rc" -eq 0 ] || fail "master-default auto-resolve: expected exit 0 (base resolved via master arm), got $rc"
+echo "  ok" >&2
+
 echo "PASS: all hermes-critic.sh tests passed." >&2
 exit 0

--- a/scripts/guardrails/lib.sh
+++ b/scripts/guardrails/lib.sh
@@ -50,7 +50,7 @@ guard_call() {
 #
 # Detached-HEAD handling: prints empty string and returns rc=1 (no current
 # branch). Callers MUST distinguish empty branch from a valid branch name -
-# `is_on_main` does this via the string compare to "main".
+# `is_on_main` does this via the string compare to main/master.
 _branch() {
     local dir="${1:-.}"
     local git_dir
@@ -78,22 +78,47 @@ _branch() {
     esac
 }
 
+# default_branch [DIR]
+# Resolves the repo's default/integration branch name (main or master).
+# Order: origin/HEAD symbolic-ref -> whichever of main/master exists locally
+# -> init.defaultBranch -> "main". Used as the diff base by the merged/behind
+# predicates + the CR diff-base scripts so they work on either default
+# (HIMMEL-297: support main AND master). Always prints a non-empty name.
+default_branch() {
+    local dir="${1:-.}" ref b
+    if ref=$(git -C "$dir" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null); then
+        b="${ref#origin/}"
+        [ -n "$b" ] && { printf '%s' "$b"; return 0; }
+    fi
+    if git -C "$dir" rev-parse --verify --quiet refs/heads/main >/dev/null 2>&1; then
+        printf 'main'; return 0
+    fi
+    if git -C "$dir" rev-parse --verify --quiet refs/heads/master >/dev/null 2>&1; then
+        printf 'master'; return 0
+    fi
+    b=$(git -C "$dir" config init.defaultBranch 2>/dev/null)
+    [ -n "$b" ] && { printf '%s' "$b"; return 0; }
+    printf 'main'
+}
+
 # is_on_main [DIR]
-# True iff current branch is exactly "main".
-# Returns 1 on detached HEAD (no current branch is "main").
+# True iff current branch is a protected default branch (main OR master).
+# Returns 1 on detached HEAD / feature branch; rc=2 if branch can't be read.
+# (Name kept for caller stability; semantics widened to main+master — HIMMEL-297.)
 is_on_main() {
     local b rc
     b=$(_branch "${1:-.}"); rc=$?
     if [ "$rc" -eq 2 ]; then return 2; fi
-    [ "$b" = "main" ]
+    [ "$b" = "main" ] || [ "$b" = "master" ]
 }
 
 # is_main_ref REF
-# True iff REF is refs/heads/main. Used by check-push-target.sh which reads
-# remote refs from git's pre-push stdin contract.
-# UNLIKE the other predicates, this takes a REF string (not a directory).
+# True iff REF is refs/heads/main OR refs/heads/master. Used by
+# check-push-target.sh which reads remote refs from git's pre-push stdin.
+# Both protected branches match so a direct push to either is blocked
+# (HIMMEL-297). UNLIKE the other predicates, this takes a REF string.
 is_main_ref() {
-    [ "${1:-}" = "refs/heads/main" ]
+    [ "${1:-}" = "refs/heads/main" ] || [ "${1:-}" = "refs/heads/master" ]
 }
 
 # is_dirty [DIR]
@@ -108,6 +133,9 @@ is_dirty() {
 }
 
 # is_merged_into_main [DIR]
+# NOTE (HIMMEL-297): "main" throughout this docstring denotes the resolved
+# default branch (main OR master) per default_branch() — the predicate operates
+# against whichever is the repo's default, not literally "main".
 # True iff current branch is reachable from main via either:
 #   (a) direct merge: `git branch --merged main` lists it
 #   (b) squash-merge: every commit on this branch has a patch-equivalent
@@ -117,8 +145,9 @@ is_dirty() {
 #   - detached HEAD
 #   - branches at main's tip with NO divergence either way
 #     (ahead=0 AND behind=0); see HIMMEL-114 short-circuit
-# Returns 2 if local `main` ref is missing or git plumbing fails (predicate
-# cannot be evaluated - e.g., shallow clones missing the merge base).
+# Returns 2 if the resolved default-branch ref (main or master) is missing or
+# git plumbing fails (predicate cannot be evaluated - e.g., shallow clones
+# missing the merge base).
 #
 # Known limitations (chosen tradeoffs, NOT bugs):
 # - FAST-FORWARD MERGE AMBIGUITY (HIMMEL-114): a branch that was FF-merged
@@ -142,13 +171,16 @@ is_merged_into_main() {
     local b rc
     b=$(_branch "$dir"); rc=$?
     if [ "$rc" -eq 2 ]; then return 2; fi
-    # rc=1 (detached HEAD) or empty/main branch => not a merged feature branch.
-    if [ -z "$b" ] || [ "$b" = "main" ]; then
+    # rc=1 (detached HEAD) or empty/default branch => not a merged feature branch.
+    if [ -z "$b" ] || [ "$b" = "main" ] || [ "$b" = "master" ]; then
         return 1
     fi
-    # Bail with rc=2 when we cannot resolve `main` - the rest of this function
-    # would silently produce a false answer otherwise.
-    if ! git -C "$dir" rev-parse --verify --quiet refs/heads/main >/dev/null 2>&1; then
+    # Resolve the default branch (main or master) to use as the merge base.
+    local db
+    db=$(default_branch "$dir")
+    # Bail with rc=2 when we cannot resolve the default branch - the rest of
+    # this function would silently produce a false answer otherwise.
+    if ! git -C "$dir" rev-parse --verify --quiet "refs/heads/$db" >/dev/null 2>&1; then
         return 2
     fi
 
@@ -162,8 +194,8 @@ is_merged_into_main() {
     # SHA because `git branch --merged main` lists every ref at main's SHA,
     # which blocked the FIRST commit on docs/feat branches.
     local ahead behind
-    ahead=$(git -C "$dir" rev-list main..HEAD --count 2>/dev/null) || return 2
-    behind=$(git -C "$dir" rev-list HEAD..main --count 2>/dev/null) || return 2
+    ahead=$(git -C "$dir" rev-list "$db..HEAD" --count 2>/dev/null) || return 2
+    behind=$(git -C "$dir" rev-list "HEAD..$db" --count 2>/dev/null) || return 2
     if [ "$ahead" = "0" ] && [ "$behind" = "0" ]; then
         # Branch is at main's SHA with no divergence in either direction.
         return 1
@@ -176,7 +208,7 @@ is_merged_into_main() {
     # earlier pipeline element gets killed mid-write and the pipeline rc is
     # misread as success.
     local merged_raw merged
-    merged_raw=$(git -C "$dir" branch --merged main 2>/dev/null) || return 2
+    merged_raw=$(git -C "$dir" branch --merged "$db" 2>/dev/null) || return 2
     merged=$(printf '%s\n' "$merged_raw" | sed 's/^[* ]*//' | grep -Fx -- "$b" || true)
     if [ -n "$merged" ]; then
         return 0
@@ -185,7 +217,7 @@ is_merged_into_main() {
     # Squash-merge arm: every commit cherry-pick-equivalent on main.
     # Capture first to avoid SIGPIPE races (see merged_raw note above).
     local unique_raw unique
-    unique_raw=$(git -C "$dir" log --cherry-pick --right-only --no-merges "main...HEAD" --pretty=format:'%h' 2>/dev/null) || return 2
+    unique_raw=$(git -C "$dir" log --cherry-pick --right-only --no-merges "$db...HEAD" --pretty=format:'%h' 2>/dev/null) || return 2
     unique=$(printf '%s' "$unique_raw" | head -1)
     if [ -z "$unique" ]; then
         return 0
@@ -194,16 +226,19 @@ is_merged_into_main() {
 }
 
 # is_behind_origin_main [DIR]
-# True iff origin/main has commits not in HEAD. Caller is responsible for
-# running `git fetch` first if freshness matters - this predicate reads the
-# current refs as-is.
-# Returns 1 (not behind) if origin/main ref doesn't exist locally.
+# True iff origin/<default> has commits not in HEAD, where <default> is the
+# resolved default branch (main OR master) per default_branch() — HIMMEL-297.
+# Caller is responsible for running `git fetch` first if freshness matters -
+# this predicate reads the current refs as-is.
+# Returns 1 (not behind) if the origin/<default> ref doesn't exist locally.
 is_behind_origin_main() {
     local dir="${1:-.}"
-    if ! git -C "$dir" rev-parse --verify --quiet refs/remotes/origin/main >/dev/null 2>&1; then
+    local db
+    db=$(default_branch "$dir")
+    if ! git -C "$dir" rev-parse --verify --quiet "refs/remotes/origin/$db" >/dev/null 2>&1; then
         return 1
     fi
     local behind
-    behind=$(git -C "$dir" rev-list HEAD..origin/main --count 2>/dev/null) || return 2
+    behind=$(git -C "$dir" rev-list "HEAD..origin/$db" --count 2>/dev/null) || return 2
     [ "${behind:-0}" -gt 0 ]
 }

--- a/scripts/guardrails/test-lib.sh
+++ b/scripts/guardrails/test-lib.sh
@@ -173,6 +173,67 @@ is_merged_into_main "$d"; rc=$?
 if [ "$rc" -eq 0 ]; then pass "squash-merged -> true"; else fail "squash-merged -> expected 0 got $rc"; fi
 rm -rf "$d"
 
+# HIMMEL-297: master is a protected default too. A repo whose default branch is
+# `master` (no `main` ref at all) must resolve default_branch=master, treat
+# master as on-main, and use master as the merge/behind base.
+setup_master_repo() {
+    # $1 = branch name to leave HEAD on
+    local dir
+    dir="$(mktemp -d)"
+    git -C "$dir" init -q -b master
+    git -C "$dir" config user.email t@t
+    git -C "$dir" config user.name t
+    git -C "$dir" commit --allow-empty -q -m "init"
+    if [ "$1" != "master" ]; then
+        git -C "$dir" checkout -q -b "$1"
+    fi
+    printf '%s' "$dir"
+}
+
+echo "== master-default repo (HIMMEL-297) =="
+d=$(setup_master_repo master)
+db=$(default_branch "$d")
+if [ "$db" = "master" ]; then pass "default_branch -> master"; else fail "default_branch -> expected master got [$db]"; fi
+if is_on_main "$d"; then pass "is_on_main on master -> true"; else fail "is_on_main master -> expected 0 got $?"; fi
+if is_main_ref refs/heads/master; then pass "is_main_ref master -> true"; else fail "is_main_ref master -> expected 0"; fi
+rm -rf "$d"
+
+echo "== is_merged_into_main: master base =="
+d=$(setup_master_repo feat/m)
+git -C "$d" commit --allow-empty -q -m "feat: m"
+git -C "$d" checkout -q master
+git -C "$d" merge --no-ff -q feat/m -m "merge"
+git -C "$d" checkout -q feat/m
+is_merged_into_main "$d"; rc=$?
+if [ "$rc" -eq 0 ]; then pass "merged into master -> true"; else fail "merged into master -> expected 0 got $rc"; fi
+rm -rf "$d"
+
+d=$(setup_master_repo feat/n)
+git -C "$d" commit --allow-empty -q -m "feat: n"
+is_merged_into_main "$d"; rc=$?
+if [ "$rc" -eq 1 ]; then pass "unmerged (master base) -> false"; else fail "unmerged (master base) -> expected 1 got $rc"; fi
+rm -rf "$d"
+
+echo "== is_behind_origin_main: master default =="
+# Bare origin whose default is master; clone wires origin/HEAD -> origin/master,
+# so default_branch resolves master and the behind check reads origin/master.
+origin=$(mktemp -d)
+git -C "$origin" init -q --bare -b master
+work=$(mktemp -d)
+git clone -q "$origin" "$work"
+git -C "$work" config user.email t@t
+git -C "$work" config user.name t
+git -C "$work" commit --allow-empty -q -m "base"
+git -C "$work" push -q origin master
+git -C "$work" checkout -q -b feat/z
+git -C "$work" checkout -q master
+git -C "$work" commit --allow-empty -q -m "advance"
+git -C "$work" push -q origin master
+git -C "$work" checkout -q feat/z
+git -C "$work" fetch -q origin
+if is_behind_origin_main "$work"; then pass "behind (master default) -> true"; else fail "behind (master default) -> expected 0 got $?"; fi
+rm -rf "$work" "$origin"
+
 if [ "$failures" -eq 0 ]; then
     echo "OK: all cases passed"
     exit 0

--- a/scripts/hooks/auto-approve-safe-bash.sh
+++ b/scripts/hooks/auto-approve-safe-bash.sh
@@ -156,12 +156,14 @@ git_subcmd_is_read() {
 #   * subcommand is `push` AND a `--force-with-lease[=…]` flag is present;
 #   * NO bare `--force` / `-f` anywhere (the no-lease form clobbers without the
 #     stale-tip check, so it stays deny-listed);
-#   * NO token names main as the push target (`main`, `origin/main`,
-#     `refs/heads/main`, `…:main`, `main:…`);
-#   * current HEAD resolves to a branch that is NOT main (detached HEAD, empty,
-#     or non-repo → NOT granted; fail safe).
+#   * NO token names main OR master as the push target (`main`, `origin/main`,
+#     `refs/heads/main`, `…:main`, `main:…`, and the `master` equivalents —
+#     HIMMEL-297, both are protected defaults);
+#   * current HEAD resolves to a branch that is NOT main/master (detached HEAD,
+#     empty, or non-repo → NOT granted; fail safe).
 # Not granted → falls through to the normal prompt; the pre-push hook still
-# hard-refuses any force to main, so this is defense in depth, not the sole gate.
+# hard-refuses any force to main/master, so this is defense in depth, not the
+# sole gate.
 git_push_force_with_lease_is_safe() {
     local -a g=("$@")            # g[0] == git
     local n=${#g[@]} j=1 t
@@ -184,10 +186,13 @@ git_push_force_with_lease_is_safe() {
         case "$k" in
             --force-with-lease|--force-with-lease=*) has_lease=1 ;;
             --force|-f)                              has_bare_force=1 ;;
-            # Any refspec that writes remote main — incl. the `+`-force prefix
-            # (`+main` ≡ `+main:main`) and explicit `src:main` colon forms.
+            # Any refspec that writes remote main OR master (both protected
+            # defaults, HIMMEL-297) — incl. the `+`-force prefix (`+main` ≡
+            # `+main:main`) and explicit `src:main` colon forms.
             main|+main|origin/main|+origin/main|refs/heads/main|+refs/heads/main|\
-            *:main|*:refs/heads/main|main:*) targets_main=1 ;;
+            *:main|*:refs/heads/main|main:*|\
+            master|+master|origin/master|+origin/master|refs/heads/master|+refs/heads/master|\
+            *:master|*:refs/heads/master|master:*) targets_main=1 ;;
         esac
     done
     [ "$has_lease" -eq 1 ]      || return 1
@@ -195,8 +200,10 @@ git_push_force_with_lease_is_safe() {
     [ "$targets_main" -eq 1 ]   && return 1
     local br
     br=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || return 1
+    # main AND master are both protected defaults (HIMMEL-297) — never
+    # auto-approve a lease push made while sitting on either.
     case "$br" in
-        ''|HEAD|main) return 1 ;;
+        ''|HEAD|main|master) return 1 ;;
     esac
     return 0
 }

--- a/scripts/hooks/check-cr-before-push.sh
+++ b/scripts/hooks/check-cr-before-push.sh
@@ -25,11 +25,22 @@
 # subprocess block is gone.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# default_branch() resolves the repo's protected default (main OR master,
+# HIMMEL-297) used as the diff base below. Fail-closed: a missing guardrail
+# substrate means we cannot compute the right base, so refuse the push.
+# shellcheck source=../guardrails/lib.sh
+# shellcheck disable=SC1091
+if ! . "$SCRIPT_DIR/../guardrails/lib.sh" 2>/dev/null; then
+    echo "→ code-review: cannot source guardrails/lib.sh — refusing the push (fix the guardrail lib or bypass with SKIP_CR=1)" >&2
+    exit 2
+fi
+
 branch=$(git branch --show-current)
 
-# Skip on main / detached HEAD — pushing main is blocked elsewhere and there's
-# no meaningful diff to review.
-if [ -z "$branch" ] || [ "$branch" = "main" ]; then
+# Skip on a protected default (main OR master) / detached HEAD — pushing the
+# default branch is blocked elsewhere and there's no meaningful diff to review.
+if [ -z "$branch" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
     exit 0
 fi
 
@@ -40,25 +51,27 @@ if [ "${SKIP_CR:-0}" = "1" ]; then
 fi
 
 # Resolve diff base: prefer the more up-to-date ref.
-# When both 'main' and 'origin/main' exist and local 'main' is an ancestor of
-# 'origin/main' (i.e. origin is ahead), use 'origin/main' so we don't diff
-# against a stale local copy and generate false-positive markers. No network
-# call — git merge-base --is-ancestor uses only locally-fetched refs.
-# If neither ref exists, skip with WARNING.
+# 'db' is the repo's protected default (main OR master, HIMMEL-297). When both
+# the local 'db' and 'origin/db' exist and local 'db' is an ancestor of
+# 'origin/db' (i.e. origin is ahead), use 'origin/db' so we don't diff against a
+# stale local copy and generate false-positive markers. No network call — git
+# merge-base --is-ancestor uses only locally-fetched refs. If neither ref
+# exists, skip with WARNING.
+db=$(default_branch)
 diff_base=""
-if git rev-parse --verify --quiet main >/dev/null && \
-   git rev-parse --verify --quiet origin/main >/dev/null; then
-    if git merge-base --is-ancestor main origin/main 2>/dev/null; then
-        diff_base=origin/main
+if git rev-parse --verify --quiet "$db" >/dev/null && \
+   git rev-parse --verify --quiet "origin/$db" >/dev/null; then
+    if git merge-base --is-ancestor "$db" "origin/$db" 2>/dev/null; then
+        diff_base="origin/$db"
     else
-        diff_base=main
+        diff_base="$db"
     fi
-elif git rev-parse --verify --quiet main >/dev/null; then
-    diff_base=main
-elif git rev-parse --verify --quiet origin/main >/dev/null; then
-    diff_base=origin/main
+elif git rev-parse --verify --quiet "$db" >/dev/null; then
+    diff_base="$db"
+elif git rev-parse --verify --quiet "origin/$db" >/dev/null; then
+    diff_base="origin/$db"
 else
-    echo "→ code-review: no 'main' or 'origin/main' ref — skipping (WARNING: cannot compute diff for review)" >&2
+    echo "→ code-review: no '$db' or 'origin/$db' ref — skipping (WARNING: cannot compute diff for review)" >&2
     exit 0
 fi
 

--- a/scripts/hooks/test-auto-approve-safe-bash.sh
+++ b/scripts/hooks/test-auto-approve-safe-bash.sh
@@ -240,6 +240,13 @@ assert "lease+bare force on feat"  PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git
 assert "fwl targets main ref"      PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git push --force-with-lease origin main')")"
 assert "fwl targets origin/main"   PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git push --force-with-lease origin HEAD:main')")"
 assert "fwl +main force refspec"   PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git push --force-with-lease origin +main')")"
+# HIMMEL-297: master is a protected default too — targeting it is refused
+# even from a feature branch, same as main.
+assert "fwl targets master ref"    PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git push --force-with-lease origin master')")"
+assert "fwl targets HEAD:master"   PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git push --force-with-lease origin HEAD:master')")"
+assert "fwl +master force refspec" PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git push --force-with-lease origin +master')")"
+assert "fwl targets origin/master" PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git push --force-with-lease origin/master')")"
+assert "fwl master:* refspec"      PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git push --force-with-lease origin master:feat/x')")"
 # Exec-sink global flags refuse even with a lease push.
 assert "fwl with -c pager sink"    PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git -c core.pager=sh push --force-with-lease')")"
 # A plain (non-force) push still falls through — unchanged behavior.
@@ -248,6 +255,10 @@ assert "plain push still PASS"     PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git
 # On main: even a lease push is NOT auto-approved (fail safe; pre-push refuses).
 git -C "$FWL_REPO" checkout -q main
 assert "fwl on main branch"        PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git push --force-with-lease')")"
+# On master: master is a protected default too (HIMMEL-297) — a lease push made
+# while sitting on master is NOT auto-approved either.
+git -C "$FWL_REPO" checkout -q -b master
+assert "fwl on master branch"      PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git push --force-with-lease')")"
 # Detached HEAD: branch unresolvable → NOT granted.
 git -C "$FWL_REPO" checkout -q --detach
 assert "fwl detached HEAD"         PASS  "$(decide_in "$FWL_REPO" "$(j_bash 'git push --force-with-lease')")"

--- a/scripts/hooks/test-check-cr-before-push.sh
+++ b/scripts/hooks/test-check-cr-before-push.sh
@@ -208,6 +208,56 @@ else
 fi
 git -C "$REPO" checkout -q main
 
+# ── HIMMEL-297: master-default repo ─────────────────────────────────────────
+# A repo whose default branch is `master` (no `main` ref at all). Pre-fix the
+# hook diffed against a non-existent `main` and skipped with a WARNING (false
+# no-marker). Post-fix default_branch resolves master, so: master branch skips,
+# and a feature branch with code writes a full-lane marker against master.
+
+echo "TEST: master-default repo — master branch -> exit 0, no marker"
+MREPO="$TMP_ROOT/mrepo"
+git init -q --initial-branch=master "$MREPO" 2>/dev/null || {
+    git init -q "$MREPO"
+    git -C "$MREPO" symbolic-ref HEAD refs/heads/master || true
+}
+git -C "$MREPO" -c user.email=t@test.com -c user.name=test commit -q --allow-empty -m "init"
+git -C "$MREPO" branch -m master 2>/dev/null || true
+
+run_hook_m() { ( cd "$MREPO" && bash "$HOOK" 2>&1 ); }
+mmarker_path() {
+    local branch="$1" git_dir
+    git_dir=$(git -C "$MREPO" rev-parse --git-common-dir)
+    case "$git_dir" in /*|?:/*|?:\\*) ;; *) git_dir="$MREPO/$git_dir" ;; esac
+    echo "${git_dir}/cr-pending/${branch}"
+}
+
+rc=0
+out=$(run_hook_m) || rc=$?
+mm=$(mmarker_path master)
+if [ "$rc" -eq 0 ] && [ ! -f "$mm" ]; then
+    pass "master branch -> exit 0, no marker"
+else
+    fail "master branch -> expected exit 0 + no marker" "rc=$rc marker=$mm out=$out"
+fi
+
+echo "TEST: master-default repo — feat branch with code diff -> full marker (diff_base=master)"
+git -C "$MREPO" checkout -q -b feat/on-master
+echo "function f() {}" > "$MREPO/code.sh"
+git -C "$MREPO" -c user.email=t@test.com -c user.name=test add code.sh
+git -C "$MREPO" -c user.email=t@test.com -c user.name=test commit -q -m "code"
+out=$(run_hook_m)
+mfeat=$(mmarker_path feat/on-master)
+if [ -f "$mfeat" ]; then
+    lane_m=$(awk -F' [|] ' '{print $3; exit}' "$mfeat" 2>/dev/null || true)
+    if [ "$lane_m" = "full" ]; then
+        pass "master-default feat+code -> full marker (resolved master as diff base)"
+    else
+        fail "master-default marker lane '$lane_m' != full" "out: $out"
+    fi
+else
+    fail "expected marker for code diff in master-default repo (proves master base resolved, not skipped)" "out: $out"
+fi
+
 # ── HIMMEL-295: ancestor-preference for diff_base ───────────────────────────
 #
 # Set up a second repo that acts as origin, advance it ahead of local main,

--- a/scripts/jira/package-lock.json
+++ b/scripts/jira/package-lock.json
@@ -115,14 +115,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -144,9 +144,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -161,9 +161,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -195,9 +195,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -229,13 +229,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -246,13 +249,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -263,13 +269,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -280,13 +289,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -297,13 +309,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -314,13 +329,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -331,9 +349,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -348,9 +366,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -367,9 +385,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -384,9 +402,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1184,9 +1202,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1763,9 +1781,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1783,7 +1801,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1853,13 +1871,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.130.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -1869,21 +1887,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.1",
-        "@rolldown/binding-darwin-arm64": "1.0.1",
-        "@rolldown/binding-darwin-x64": "1.0.1",
-        "@rolldown/binding-freebsd-x64": "1.0.1",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
-        "@rolldown/binding-linux-arm64-musl": "1.0.1",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-musl": "1.0.1",
-        "@rolldown/binding-openharmony-arm64": "1.0.1",
-        "@rolldown/binding-wasm32-wasi": "1.0.1",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
-        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/router": {
@@ -2110,9 +2128,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2224,17 +2242,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
-        "rolldown": "1.0.1",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/scripts/lib/user-slug.sh
+++ b/scripts/lib/user-slug.sh
@@ -11,10 +11,12 @@
 #
 # Resolution order (first hit wins):
 #   1. $USER_SLUG env var (preferred — explicit operator intent).
-#   2. `git config user.name`, slugified (kebab-case, lowercase, non-alnum
-#      stripped). Useful for fresh-clone operators who haven't set the env
-#      var yet.
-#   3. Refuse with a helpful error pointing at the env-template.
+#   2. GitHub username via `gh api user -q .login`, slugified (the operator's
+#      identity — HIMMEL-297 home-base: the slug is the GitHub user id). Needs
+#      gh installed + authed; one network call, so callers capture once.
+#   3. `git config user.name`, slugified (kebab-case, lowercase, non-alnum
+#      stripped) — offline fallback for fresh clones without gh auth.
+#   4. Refuse with a helpful error pointing at the env-template.
 #
 # Return codes:
 #   0  printed a non-empty slug to stdout
@@ -29,21 +31,40 @@
 # `user_slug_verify` (prints the resolved slug + source to stderr; returns
 # rc=0 if resolved, rc=2 otherwise).
 
+# Slugify: lowercase, non-alnum -> dash, trim ends, 30-char cap.
+_user_slug_slugify() {
+    printf '%s' "$1" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+        | cut -c1-30 \
+        | sed -E 's/-+$//'
+}
+
 user_slug() {
     if [ -n "${USER_SLUG:-}" ]; then
         printf '%s' "$USER_SLUG"
         return 0
     fi
-    local gname
+    # GitHub username — the operator's identity (HIMMEL-297 home-base: the slug
+    # is the GitHub user id). One network call, gated behind USER_SLUG so anyone
+    # who sets it skips this; fails through to git config when gh is absent or
+    # unauthenticated.
+    local ghlogin gslug
+    if command -v gh >/dev/null 2>&1; then
+        ghlogin=$(gh api user -q .login 2>/dev/null) || ghlogin=""
+        if [ -n "$ghlogin" ] && [ "$ghlogin" != "null" ]; then
+            gslug=$(_user_slug_slugify "$ghlogin")
+            if [ -n "$gslug" ]; then
+                printf '%s' "$gslug"
+                return 0
+            fi
+        fi
+    fi
+    # Offline fallback: git config user.name slugified.
+    local gname slug
     if gname=$(git config user.name 2>/dev/null); then
         if [ -n "$gname" ]; then
-            # Slugify: lowercase, non-alnum -> dash, trim ends, 30-char cap.
-            local slug
-            slug=$(printf '%s' "$gname" \
-                | tr '[:upper:]' '[:lower:]' \
-                | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
-                | cut -c1-30 \
-                | sed -E 's/-+$//')
+            slug=$(_user_slug_slugify "$gname")
             if [ -n "$slug" ]; then
                 printf '%s' "$slug"
                 return 0
@@ -58,6 +79,8 @@ user_slug_verify() {
     if slug=$(user_slug); then
         if [ -n "${USER_SLUG:-}" ]; then
             echo "user-slug: '$slug' (source: \$USER_SLUG env)" >&2
+        elif command -v gh >/dev/null 2>&1 && [ -n "$(gh api user -q .login 2>/dev/null)" ]; then
+            echo "user-slug: '$slug' (source: GitHub username via gh api user)" >&2
         else
             echo "user-slug: '$slug' (source: git config user.name, slugified)" >&2
         fi
@@ -69,11 +92,13 @@ ERR user-slug: cannot resolve USER_SLUG.
 
 Tried (in order):
   1. $USER_SLUG env var: unset or empty.
-  2. git config user.name: missing or empty.
+  2. GitHub username (gh api user): gh unavailable, unauthenticated, or no login.
+  3. git config user.name: missing or empty.
 
 Fix one of these:
   - Set USER_SLUG=<your-kebab-slug> in the shell that launches Claude
     (and persist to .env / your dotfiles).
+  - Authenticate gh: `gh auth login` (the slug becomes your GitHub username).
   - Set a git identity: `git config --global user.name "Your Name"`
     (gets slugified to lowercase + dashes automatically).
 

--- a/scripts/test-user-slug-resolve.sh
+++ b/scripts/test-user-slug-resolve.sh
@@ -44,6 +44,21 @@ export HOME="$ISOLATED_HOME"
 # Also clear GIT_CONFIG_GLOBAL for git 2.32+ which has its own override.
 unset GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM 2>/dev/null || true
 
+# Stub `gh` as an exported shell function so the resolver's GitHub-username
+# source is deterministic (a real gh would resolve to the operator's login and
+# mask the git-config fallback + refuse paths). A function shadows gh portably —
+# no PATH/.exe lookup quirks on Git Bash. Prints $STUB_GH_LOGIN when set, else
+# returns non-zero (= gh unauthenticated). export -f so the resolve() subshell
+# and `bash -c` children inherit it.
+gh() {
+    if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+        if [ -n "${STUB_GH_LOGIN:-}" ]; then printf '%s' "$STUB_GH_LOGIN"; return 0; fi
+        return 1
+    fi
+    return 1
+}
+export -f gh
+
 # Each test runs in an isolated tmp repo so git config doesn't pollute
 # globally.
 REPO="$TMP_ROOT/repo"
@@ -113,6 +128,20 @@ echo "TEST: empty USER_SLUG falls through"
 out=$(USER_SLUG='' resolve 2>/dev/null) && rc=0 || rc=$?
 assert_eq "empty env rc=0" "0" "$rc"
 assert_eq "empty env -> git" "fred" "$out"
+
+# Test 7: GitHub username (gh) takes precedence over git config ------
+echo "TEST: gh api user login -> slugified, preferred over git config"
+( cd "$REPO" && git config user.name "Should Not Win" )
+out=$(USER_SLUG='' STUB_GH_LOGIN='Octocat-Hub' resolve 2>/dev/null) && rc=0 || rc=$?
+assert_eq "gh source rc=0" "0" "$rc"
+assert_eq "gh login slugified, beats git config" "octocat-hub" "$out"
+
+# Test 8: verify reports the GitHub username source -----------------
+echo "TEST: user_slug_verify reports the gh source"
+out=$(USER_SLUG='' STUB_GH_LOGIN='Octocat-Hub' bash -c "set -uo pipefail; cd '$REPO'; . '$LIB'; user_slug_verify" 2>&1) && rc=0 || rc=$?
+assert_eq "verify gh rc=0" "0" "$rc"
+assert_contains "verify mentions gh source" "GitHub username via gh api user" "$out"
+assert_contains "verify reports gh slug" "octocat-hub" "$out"
 
 echo
 echo "===================================="


### PR DESCRIPTION
## HIMMEL-297 — main+master branch protection (+ user-slug + audit-fix) — code sync

Re-applies (disjoint-history) the harness changes from the private mirror that aren't yet in Himmel. **Code only** — private state (handovers, feedback) stays private.

### Prod-bug fix: branch protection now covers `master`, not just `main`
- `scripts/guardrails/lib.sh` — new `default_branch()` resolver (origin/HEAD → main/master → init.defaultBranch → main); `is_on_main` / `is_main_ref` / `is_merged_into_main` / `is_behind_origin_main` now match main **OR** master.
- Direct hardcoders routed through the resolved default / widened to protect master: `scripts/hooks/check-cr-before-push.sh`, `scripts/_new-worktree.sh`, `scripts/cr/hermes-critic.sh`, `scripts/hooks/auto-approve-safe-bash.sh`, `.claude/commands/pr-check.md`.
- Tests: `test-lib.sh`, `test-check-cr-before-push.sh`, `test-auto-approve-safe-bash.sh`, `test-hermes-critic.sh` (master cases).

### Also synced
- **user-slug**: resolve `USER_SLUG` from the GitHub username (`gh api user`) with git-config slugify as offline fallback — `scripts/lib/user-slug.sh`, `scripts/test-user-slug-resolve.sh`, the handover `SKILL.md`, `docs/internals/handover-system.md`.
- **audit-fix**: `scripts/jira/package-lock.json` (hono + vite transitive vuln patch).

### Verification
Heavy 4-agent CR on the private PR (code-reviewer + silent-failure-hunter + comment-analyzer + pr-test-analyzer, HIMMEL-178 verify-before-critical): **0 Critical**. Verified in this clone: `shellcheck -S error` clean on all touched scripts + all four guardrail test suites pass.

Follow-up (separate PR): the remaining diff-base main-hardcoders (`check-platforms-tested.sh`, `check-security-reviewed.sh`, `check-pr-mergeable.sh`, `cr/gemini-first-pass.sh`, `handover/flush.sh`).

Platforms tested: windows, gitbash
Security reviewed: CR (4-agent on private PR, 0 Critical)
