### PR TITLE
chore: [HIMMEL-297] remaining diff-base main-hardcoders → main+master (code sync)

### DIFF
--- a/scripts/cr/gemini-first-pass.sh
+++ b/scripts/cr/gemini-first-pass.sh
@@ -26,7 +26,8 @@ esac
 
 usage() {
     cat >&2 <<'EOF'
-Usage: git diff main...HEAD | gemini-first-pass.sh [--model <name>]
+Usage: git diff origin/HEAD...HEAD | gemini-first-pass.sh [--model <name>]
+       (origin/HEAD resolves to the default branch — main OR master)
 
 Reads a unified diff on stdin, runs the gemini first-pass review, prints
 findings in the /pr-check heading contract (stable [gemini-N] IDs).

--- a/scripts/handover/flush.sh
+++ b/scripts/handover/flush.sh
@@ -7,8 +7,9 @@
 #   - Unpushed (HEAD ahead of origin/<branch>, or origin/<branch>
 #     missing): `git push -u origin <branch>`.
 #   - No open PR: invoke `scripts/handover/pr-open.sh` to open one.
-#   - Merged into origin/main: report (default) or delete the local
-#     branch via `git branch -D` when --cleanup is passed.
+#   - Merged into the default branch (origin/main or origin/master): report
+#     (default) or delete the local branch via `git branch -D` when
+#     --cleanup is passed.
 #
 # Wired into `/context-hop` so cap-resume hand-off cannot leave un-pushed
 # state; explicit `/handover-flush` covers the manual case.
@@ -29,13 +30,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/handover-path.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/../lib/handover-path.sh"
+# default_branch() resolves the handover repo's default (main OR master,
+# HIMMEL-297) for the PR base / merged-check below.
+# shellcheck source=../guardrails/lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../guardrails/lib.sh"
 
 GH_CMD="${GH_CMD:-gh}"
 GIT_CMD="${GIT_CMD:-git}"
 DRY_RUN=0
 CLEANUP=0
 NO_PR_OPEN=0
-DEFAULT_BASE="${HANDOVER_PR_BASE:-main}"
+# Empty unless explicitly pinned; resolved to the handover repo's default
+# branch (main OR master) once the repo root is known (HIMMEL-297).
+DEFAULT_BASE="${HANDOVER_PR_BASE:-}"
 
 usage() {
     cat <<'EOF'
@@ -51,13 +59,15 @@ Always prints a per-branch status table and a footer summary.
 
 Optional:
   --dry-run      Print intended actions; touch nothing.
-  --cleanup      Delete local handover/* branches merged into origin/main.
+  --cleanup      Delete local handover/* branches merged into the default
+                 branch (origin/main or origin/master).
   --no-pr-open   Skip the pr-open step. Useful when gh is unreachable;
                  flush still pushes + reports.
 
 Environment:
   HANDOVER_DIR            Required (Mode B only).
-  HANDOVER_PR_BASE        Default base for new PRs. Default `main`.
+  HANDOVER_PR_BASE        Default base for new PRs. Defaults to the handover
+                          repo's default branch (main or master).
   GH_CMD / GIT_CMD        Test overrides.
 EOF
 }
@@ -90,6 +100,12 @@ if ! handover_repo=$($GIT_CMD -C "$root" rev-parse --show-toplevel 2>&1); then
     exit 2
 fi
 
+# Resolve the PR base = the handover repo's default branch (main OR master,
+# HIMMEL-297), unless HANDOVER_PR_BASE pinned it explicitly above.
+if [ -z "$DEFAULT_BASE" ]; then
+    DEFAULT_BASE=$(default_branch "$handover_repo")
+fi
+
 # Detect whether gh is usable (auth + on PATH). When unusable, fall
 # back to "report + dump commands" mode for the PR step.
 gh_usable=1
@@ -110,7 +126,7 @@ if [ ${#branches[@]} -eq 0 ]; then
     exit 0
 fi
 
-# Ensure origin/main is up-to-date for the merged check. Best-effort.
+# Ensure origin/<default> is up-to-date for the merged check. Best-effort.
 $GIT_CMD -C "$handover_repo" fetch -q origin "$DEFAULT_BASE" 2>/dev/null || true
 
 # Per-branch reconciliation -------------------------------------------
@@ -197,17 +213,17 @@ for branch in "${branches[@]}"; do
     fi
 
     # 3. Merged state ---------------------------------------------------
-    # `git branch --merged origin/main` lists branches whose tip is an
-    # ancestor of origin/main — covers fast-forward + merge-commit. For
-    # squash-merged branches (which is the HIMMEL-141 mode), the tip is
-    # NOT an ancestor; instead detect via `git cherry origin/main <branch>`
-    # — all commits with a `-` prefix means everything was applied to main.
+    # `merge-base --is-ancestor <branch> origin/<default>` covers
+    # fast-forward + merge-commit (tip is an ancestor of the default branch).
+    # For squash-merged branches (the HIMMEL-141 mode), the tip is NOT an
+    # ancestor; instead detect via `git cherry origin/<default> <branch>`
+    # — all commits with a `-` prefix means everything was applied upstream.
     is_merged=0
     if $GIT_CMD -C "$handover_repo" merge-base --is-ancestor "$branch" "origin/$DEFAULT_BASE" 2>/dev/null; then
         is_merged=1
     else
         # Squash detection: are all commits on <branch> patch-equivalent to
-        # commits on origin/main? `git cherry` prints `+` for missing,
+        # commits on origin/<default>? `git cherry` prints `+` for missing,
         # `-` for applied. Empty `+` output → all applied → merged.
         if $GIT_CMD -C "$handover_repo" rev-parse --verify --quiet "origin/$DEFAULT_BASE" >/dev/null 2>&1; then
             cherry_missing=$($GIT_CMD -C "$handover_repo" cherry "origin/$DEFAULT_BASE" "$branch" 2>/dev/null | grep -c '^+' || true)

--- a/scripts/hooks/check-platforms-tested.sh
+++ b/scripts/hooks/check-platforms-tested.sh
@@ -33,13 +33,25 @@
 # Exit codes:
 #   0 — pass (no sensitive files, attestation present, or bypass)
 #   1 — block (sensitive files changed + no attestation + no bypass)
+#   2 — block (cannot source guardrails/lib.sh — fail-closed, cannot evaluate)
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# default_branch() resolves the protected default (main OR master, HIMMEL-297)
+# used as the diff base below. Fail-closed: a missing guardrail substrate means
+# we cannot compute the right base, so refuse the push.
+# shellcheck source=../guardrails/lib.sh
+# shellcheck disable=SC1091
+if ! . "$SCRIPT_DIR/../guardrails/lib.sh" 2>/dev/null; then
+    echo "→ platforms-check: cannot source guardrails/lib.sh — refusing the push (rc=2 = cannot evaluate; bypass with git push --no-verify)" >&2
+    exit 2
+fi
 
 branch=$(git branch --show-current)
 
-# Detached HEAD or main push: skip — `no-push-to-main` covers main, and we
-# can't compute a sensible diff base on detached HEAD.
-if [ -z "$branch" ] || [ "$branch" = "main" ]; then
+# Detached HEAD or default-branch push: skip — `no-push-to-main` covers
+# main/master, and we can't compute a sensible diff base on detached HEAD.
+if [ -z "$branch" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
     exit 0
 fi
 
@@ -48,32 +60,33 @@ if [ "${PLATFORMS_TESTED_OK:-0}" = "1" ]; then
     exit 0
 fi
 
-# Resolve diff base. HIMMEL-113: prefer origin/main, NOT local main.
-# Rationale: linked git worktrees cannot fast-forward their local `main`
-# ref while the primary worktree owns the `main` checkout. That made
-# `git diff main...HEAD` re-flag every shell/script file that was
-# already on origin/main but not yet in the linked worktree's local
-# main - producing the friction we hit on HIMMEL-104, -110, -108 etc.
-# origin/main is the actual push target; comparing against it is what
-# the gate is conceptually about.
+# Resolve diff base. HIMMEL-113: prefer origin/<default>, NOT local <default>.
+# Rationale: linked git worktrees cannot fast-forward their local default-branch
+# ref while the primary worktree owns that checkout. That made
+# `git diff <default>...HEAD` re-flag every shell/script file that was
+# already on origin/<default> but not yet in the linked worktree's local
+# copy - producing the friction we hit on HIMMEL-104, -110, -108 etc.
+# origin/<default> is the actual push target; comparing against it is what
+# the gate is conceptually about. <default> = main OR master (HIMMEL-297).
 #
-# Refresh origin/main first (silent, single ref, ~1s) so offline / very
+# Refresh origin/<default> first (silent, single ref, ~1s) so offline / very
 # stale clones still get a fair comparison. Failure (no network, no
-# remote, etc.) is non-fatal - we fall back to whatever origin/main is
+# remote, etc.) is non-fatal - we fall back to whatever origin/<default> is
 # locally.
 #
 # PLATFORMS_TESTED_NO_FETCH=1 skips the fetch for offline workflows.
+db=$(default_branch)
 if [ "${PLATFORMS_TESTED_NO_FETCH:-0}" != "1" ]; then
-    git fetch -q origin main 2>/dev/null || true
+    git fetch -q origin "$db" 2>/dev/null || true
 fi
 
 diff_base=""
-if git rev-parse --verify --quiet origin/main >/dev/null; then
-    diff_base=origin/main
-elif git rev-parse --verify --quiet main >/dev/null; then
-    diff_base=main
+if git rev-parse --verify --quiet "origin/$db" >/dev/null; then
+    diff_base="origin/$db"
+elif git rev-parse --verify --quiet "$db" >/dev/null; then
+    diff_base="$db"
 else
-    echo "→ platforms-check: no 'origin/main' or local 'main' ref — skipping (cannot compute diff)" >&2
+    echo "→ platforms-check: no 'origin/$db' or local '$db' ref — skipping (cannot compute diff)" >&2
     exit 0
 fi
 

--- a/scripts/hooks/check-pr-mergeable.sh
+++ b/scripts/hooks/check-pr-mergeable.sh
@@ -10,8 +10,9 @@
 # - Drains stdin so the pre-commit framework doesn't deadlock when the
 #   push contains many refs.
 # - Resolves the current branch via `git symbolic-ref HEAD`.
-# - Skips on main / detached HEAD (no PR ever opens for main; detached
-#   pushes have no head ref to query).
+# - Skips on a protected default (main OR master — HIMMEL-297) / detached
+#   HEAD (no PR ever opens for the default branch; detached pushes have no
+#   head ref to query).
 # - Queries `gh pr view --head <branch> --json mergeable`. When no PR
 #   exists, exits 0 (nothing to gate on).
 # - Refuses (exit 1) when `mergeable` is `CONFLICTING`. Surfaces the
@@ -34,7 +35,7 @@ if [ "${SKIP_PR_MERGEABLE:-0}" = "1" ]; then
 fi
 
 branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
-if [ -z "$branch" ] || [ "$branch" = "main" ]; then
+if [ -z "$branch" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
     exit 0
 fi
 

--- a/scripts/hooks/check-security-reviewed.sh
+++ b/scripts/hooks/check-security-reviewed.sh
@@ -58,13 +58,25 @@
 # Exit codes:
 #   0 — pass (docs-only diff, attestation present, or bypass)
 #   1 — block (code changed + no attestation + no bypass)
+#   2 — block (cannot source guardrails/lib.sh — fail-closed, cannot evaluate)
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# default_branch() resolves the protected default (main OR master, HIMMEL-297)
+# used as the diff base below. Fail-closed: a missing guardrail substrate means
+# we cannot compute the right base, so refuse the push.
+# shellcheck source=../guardrails/lib.sh
+# shellcheck disable=SC1091
+if ! . "$SCRIPT_DIR/../guardrails/lib.sh" 2>/dev/null; then
+    echo "→ security-review: cannot source guardrails/lib.sh — refusing the push (rc=2 = cannot evaluate; bypass with git push --no-verify)" >&2
+    exit 2
+fi
 
 branch=$(git branch --show-current)
 
-# Detached HEAD or main push: skip. no-push-to-main covers main, and we
-# can't compute a sensible diff base on detached HEAD.
-if [ -z "$branch" ] || [ "$branch" = "main" ]; then
+# Detached HEAD or default-branch push: skip. no-push-to-main covers
+# main/master, and we can't compute a sensible diff base on detached HEAD.
+if [ -z "$branch" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
     exit 0
 fi
 
@@ -73,20 +85,21 @@ if [ "${SKIP_SECURITY_REVIEW:-0}" = "1" ]; then
     exit 0
 fi
 
-# Resolve diff base. Mirror check-platforms-tested.sh — prefer origin/main
-# over local main so linked worktrees do not re-flag work already on the
-# push target.
+# Resolve diff base. Mirror check-platforms-tested.sh — prefer origin/<default>
+# over local <default> so linked worktrees do not re-flag work already on the
+# push target. <default> = main OR master (HIMMEL-297).
+db=$(default_branch)
 if [ "${SECURITY_REVIEW_NO_FETCH:-0}" != "1" ]; then
-    git fetch -q origin main 2>/dev/null || true
+    git fetch -q origin "$db" 2>/dev/null || true
 fi
 
 diff_base=""
-if git rev-parse --verify --quiet origin/main >/dev/null; then
-    diff_base=origin/main
-elif git rev-parse --verify --quiet main >/dev/null; then
-    diff_base=main
+if git rev-parse --verify --quiet "origin/$db" >/dev/null; then
+    diff_base="origin/$db"
+elif git rev-parse --verify --quiet "$db" >/dev/null; then
+    diff_base="$db"
 else
-    echo "→ security-review: no 'origin/main' or local 'main' ref — skipping (cannot compute diff)" >&2
+    echo "→ security-review: no 'origin/$db' or local '$db' ref — skipping (cannot compute diff)" >&2
     exit 0
 fi
 

--- a/scripts/hooks/test-check-platforms-tested.sh
+++ b/scripts/hooks/test-check-platforms-tested.sh
@@ -208,6 +208,53 @@ d=$(mktemp -d)
 assert_rc "on main branch — skip"                     0 "$(run_in "$d")"
 rm -rf "$d"
 
+# --- HIMMEL-297: master-default repo ---
+# A repo whose default branch is master (no main ref at all). Pre-fix the hook
+# found neither origin/main nor local main and SKIPPED (false pass). Post-fix
+# default_branch resolves master, so a sensitive file with no attestation still
+# BLOCKS, and a push while sitting on master is skipped.
+make_master_repo() {
+    local files="$1" msg="$2" dir
+    dir=$(mktemp -d)
+    (
+        cd "$dir" || exit 1
+        git init -q -b master
+        git config user.email t@t
+        git config user.name t
+        echo r > README.md
+        git add README.md
+        git -c commit.gpgsign=false commit -q -m "init"
+        git checkout -q -b feat/x
+        # shellcheck disable=SC2086 # files is space-separated, intentional split
+        for f in $files; do
+            mkdir -p "$(dirname "$f")"
+            echo "x" > "$f"
+        done
+        git add -A
+        git -c commit.gpgsign=false commit -q -m "$msg"
+    )
+    echo "$dir"
+}
+
+d=$(make_master_repo "scripts/foo.sh" "feat: add foo")
+assert_rc "master-default: sensitive .sh + no attestation = block (base resolved to master)" 1 "$(run_in "$d" "PLATFORMS_TESTED_NO_FETCH=1")"
+rm -rf "$d"
+
+# On master branch: skip (master is a protected default too).
+d=$(mktemp -d)
+(
+    cd "$d" || exit 1
+    git init -q -b master
+    git config user.email t@t
+    git config user.name t
+    mkdir -p scripts
+    echo r > scripts/foo.sh
+    git add -A
+    git -c commit.gpgsign=false commit -q -m "feat: foo"
+) >/dev/null 2>&1
+assert_rc "on master branch — skip"                   0 "$(run_in "$d")"
+rm -rf "$d"
+
 echo ""
 if [ "$FAILED" -eq 0 ]; then
     echo "All cases passed."

--- a/scripts/hooks/test-check-pr-mergeable.sh
+++ b/scripts/hooks/test-check-pr-mergeable.sh
@@ -90,6 +90,14 @@ out=$( cd "$REPO" || exit 99; printf '' | bash "$HOOK" 2>&1 ) || rc=$?
 assert_rc "main rc=0" "0" "$rc"
 ( cd "$REPO" || exit 99; git checkout -q feat/test )
 
+# Test 1b: master branch -> exit 0 (HIMMEL-297) -----------------------
+echo "TEST: master branch exits 0 (HIMMEL-297 — master is a protected default too)"
+( cd "$REPO" || exit 99; git checkout -q -b master )
+rc=0
+out=$( cd "$REPO" || exit 99; printf '' | bash "$HOOK" 2>&1 ) || rc=$?
+assert_rc "master rc=0" "0" "$rc"
+( cd "$REPO" || exit 99; git checkout -q feat/test; git branch -D master 2>/dev/null || true )
+
 # Test 2: gh missing -> exit 0 ----------------------------------------
 echo "TEST: gh missing -> best-effort exit 0"
 rc=0

--- a/scripts/hooks/test-check-security-reviewed.sh
+++ b/scripts/hooks/test-check-security-reviewed.sh
@@ -250,6 +250,52 @@ origin=$(mktemp -d)
 assert_rc "linked-worktree: docs-only feat, ignore origin-only code" 0 "$(run_in "$d" "SECURITY_REVIEW_NO_FETCH=1")"
 rm -rf "$d" "$origin"
 
+# --- HIMMEL-297: master-default repo ---
+# A repo whose default branch is master (no main ref). Pre-fix the hook found
+# neither origin/main nor local main and SKIPPED (false pass). Post-fix
+# default_branch resolves master, so a code file with no attestation BLOCKS,
+# and a push while sitting on master is skipped.
+make_master_repo() {
+    local files="$1" msg="$2" dir
+    dir=$(mktemp -d)
+    (
+        cd "$dir" || exit 1
+        git init -q -b master
+        git config user.email t@t
+        git config user.name t
+        echo r > README.md
+        git add README.md
+        git -c commit.gpgsign=false commit -q -m "init"
+        git checkout -q -b feat/x
+        # shellcheck disable=SC2086 # files is space-separated, intentional split
+        for f in $files; do
+            mkdir -p "$(dirname "$f")"
+            echo "x" > "$f"
+        done
+        git add -A
+        git -c commit.gpgsign=false commit -q -m "$msg"
+    )
+    echo "$dir"
+}
+
+d=$(make_master_repo "src/foo.ts" "feat: add foo")
+assert_rc "master-default: code + no attestation = block (base resolved to master)" 1 "$(run_in "$d" "SECURITY_REVIEW_NO_FETCH=1")"
+rm -rf "$d"
+
+d=$(mktemp -d)
+(
+    cd "$d" || exit 1
+    git init -q -b master
+    git config user.email t@t
+    git config user.name t
+    mkdir -p src
+    echo r > src/foo.ts
+    git add -A
+    git -c commit.gpgsign=false commit -q -m "feat: foo"
+) >/dev/null 2>&1
+assert_rc "on master branch — skip"                  0 "$(run_in "$d")"
+rm -rf "$d"
+
 echo ""
 if [ "$FAILED" -eq 0 ]; then
     echo "All cases passed."


### PR DESCRIPTION
Follow-up to PR #2: widens the remaining diff-base / skip-on-main hardcoders so the whole guardrail surface protects master too. Code only.

- check-platforms-tested.sh / check-security-reviewed.sh: source lib.sh (fail-closed exit 2), skip on main OR master, diff base via default_branch.
- check-pr-mergeable.sh: skip on master too.
- handover/flush.sh: default PR base / merged-check via default_branch (HANDOVER_PR_BASE still pins it).
- cr/gemini-first-pass.sh: portable usage string.
- paired tests: master-default cases + master skip.

3-agent CR on private PR #513 (code-reviewer + silent-failure-hunter + comment-analyzer): 0 Critical, 0 Important. Verified in-clone: shellcheck -S error clean + all 4 suites pass.

Platforms tested: windows, gitbash
Security reviewed: CR (3-agent, 0 Critical)