### PR TITLE
docs(luna): complete public vault install path in luna-second-brain template

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,6 +55,12 @@ himmel needs almost nothing to start:
   later by filling `JIRA_*` in `.env` (see the
   [env table](../README.md#quickstart)); the local CLI needs only four values
   and **no cloud ID**.
+- **Want the companion vault?** himmel ships a ready-to-use AI-first Obsidian
+  vault skeleton at
+  [`templates/luna-second-brain/`](../templates/luna-second-brain/) — copy it
+  out into its own git repo and run its `setup.sh`. Its
+  [README](../templates/luna-second-brain/README.md#quickstart) has the
+  install steps.
 
 **For your first loop you need none of this** — `setup.sh` already did the work.
 Skip straight to step 3.

--- a/templates/luna-second-brain/README.md
+++ b/templates/luna-second-brain/README.md
@@ -6,24 +6,32 @@ guardrails, and a SHA-pinned plugin marketplace so a fresh clone
 becomes a working AI-first second brain in under five minutes.
 
 luna-brain is the **skeleton**: the inert structure that turns into a
-personal vault on first run. Your live vault starts as a clone of this
-repo and accumulates content over time. The skeleton does not ship
+personal vault on first run. Your live vault starts as a copy of this
+template and accumulates content over time. The skeleton does not ship
 content — only the bones, hooks, and plugin pointers.
 
-> **Companion repo:** [himmel](https://github.com/yotamleo/Himmel) is
-> the dev engine that ships the worktree / handover / PR-flow tooling
-> luna-brain inherits. luna-brain reuses the subset that applies to a
-> vault repo (pre-commit, guardrails, handover-path resolver).
+> **Where this lives:** this template ships inside the public
+> [Himmel](https://github.com/yotamleo/Himmel) repo (the dev engine that
+> provides the worktree / handover / PR-flow tooling the vault inherits).
+> To create a vault, copy this folder *out* of Himmel into its own git
+> repo — see Quickstart.
 
 ## Quickstart
 
 Requires `bash`, `git`, `python3` (verified by `scripts/setup.sh` step
 `[1/6]`). See `docs/setup/new-machine.md` for per-platform install notes.
 
+This template lives inside Himmel, so the install is "copy the folder out,
+make it its own repo, run setup." Your vault **must** be its own git repo:
+`setup.sh` resolves `git rev-parse --show-toplevel`, so running it while the
+folder is still nested inside the Himmel checkout would target Himmel, not
+your vault.
+
 ```bash
 git clone https://github.com/yotamleo/Himmel
 cp -r Himmel/templates/luna-second-brain my-vault
 cd my-vault
+git init                                            # your vault is its own repo
 
 # Linux / macOS / Git Bash
 bash scripts/setup.sh
@@ -47,7 +55,14 @@ Optional: install `obsidian-second-brain` for PARA capture/daily/project
 skills. Operator-driven (3rd-party install.sh):
 <https://github.com/eugeniughelbur/obsidian-second-brain#install>
 
-Open the cloned folder in Obsidian to start using the vault.
+Open your vault folder in Obsidian to start using the vault.
+
+> **Keep your vault out of Himmel's history.** If you created the vault
+> *inside* the Himmel checkout (e.g. `Himmel/my-vault`) rather than as a
+> sibling, add its path to Himmel's `.gitignore` so your personal vault
+> content never lands in a Himmel commit. The cleanest layout is to keep
+> the vault as its own repo in a separate directory and delete the Himmel
+> clone you copied it from.
 
 **Plugin credentials:** `obsidian-local-rest-api`'s `data.json` is
 gitignored. When you enable that plugin in Obsidian the first time, it
@@ -125,9 +140,10 @@ See `docs/contributing.md` for the full contribution workflow.
 
 ## Relationship to other repos
 
-- **himmel** — dev engine. Source of the pre-commit + guardrails
-  patterns ported here.
-- **luna** — personal vault. Clone of luna-brain that has accumulated
+- **Himmel** — dev engine and **host repo**: this template ships under
+  `templates/luna-second-brain/` and inherits Himmel's pre-commit +
+  guardrails patterns.
+- **luna** — personal vault. A copy of this template that has accumulated
   content. Stays private.
 - **claude-obsidian** (upstream) — knowledge-companion plugin pinned
   in `marketplace/`.


### PR DESCRIPTION
## What

Completes the public vault install path in the `luna-second-brain` template.

The Quickstart already cloned Himmel and copied the template folder out, but
was **missing `git init`** — so `setup.sh`'s `git rev-parse --show-toplevel`
would fail on the freshly-copied vault (it isn't a git repo until you init it).

## Changes (docs-only)

- **`templates/luna-second-brain/README.md`**
  - Add the missing `git init` step to the Quickstart.
  - Add a short note explaining *why* the vault must be its own git repo
    (the `git rev-parse --show-toplevel` resolution in `setup.sh`).
  - Add `.gitignore` advice: if the vault is kept *inside* the Himmel
    checkout, add its path to Himmel's `.gitignore` so personal vault
    content never lands in a Himmel commit.
  - Reframe the template as an in-Himmel artifact ("Where this lives",
    "host repo", "copy of this template").
- **`docs/getting-started.md`** — add a discoverable "Want the companion
  vault?" pointer to the template + its install steps.

Mirrors the himmel-private fix (HIMMEL-324). Docs-only; `Himmel`
capitalization preserved to match existing public convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
