### PR TITLE
fix(guardrails): [HIMMEL-323] harden pre-push gates (fail-closed base + _branch + default_branch tie-break)

### DIFF
--- a/scripts/guardrails/lib.sh
+++ b/scripts/guardrails/lib.sh
@@ -43,10 +43,15 @@ guard_call() {
     return "$rc"
 }
 
-# Internal: current branch name from the worktree-specific HEAD file.
-# `git branch --show-current` resolves main-repo HEAD from linked worktrees,
-# which is the wrong answer when we want THIS worktree's branch. Read HEAD
-# directly to match the existing check-worktree-isolation.sh logic.
+# Internal: current branch name from the resolved git-dir's HEAD file. Reading
+# HEAD here (rather than `git branch --show-current`) keeps every guardrail on
+# ONE branch-read path and exposes an rc distinction show-current lacks
+# (0=branch, 1=detached, 2=cannot read) for fail-closed callers under `set -e`.
+# `git branch --show-current` is worktree-correct under normal invocation; it
+# misreads the PRIMARY worktree's HEAD only when GIT_DIR is aimed at the shared
+# .git — and reading HEAD via `--absolute-git-dir` follows that same GIT_DIR, so
+# this is consistency + rc semantics, NOT a defense against a mis-aimed GIT_DIR
+# (HIMMEL-323).
 #
 # Detached-HEAD handling: prints empty string and returns rc=1 (no current
 # branch). Callers MUST distinguish empty branch from a valid branch name -
@@ -84,18 +89,34 @@ _branch() {
 # -> init.defaultBranch -> "main". Used as the diff base by the merged/behind
 # predicates + the CR diff-base scripts so they work on either default
 # (HIMMEL-297: support main AND master). Always prints a non-empty name.
+#
+# Tie-break (HIMMEL-323): when origin/HEAD is UNSET *and* BOTH local `main` and
+# `master` exist, the local-ref order silently prefers `main` — wrong on a
+# master-default mirror that picked up a stray local `main`. We still return
+# `main` (stable, documented default) but emit a one-line stderr ambiguity note
+# so the wrong answer is no longer SILENT. origin/HEAD (set by `clone`, or
+# `git remote set-head origin -a`) resolves the ambiguity deterministically and
+# short-circuits this branch entirely. The note goes to stderr (fd 2), so it
+# never pollutes the stdout callers capture via `$(default_branch)`.
 default_branch() {
     local dir="${1:-.}" ref b
     if ref=$(git -C "$dir" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null); then
         b="${ref#origin/}"
         [ -n "$b" ] && { printf '%s' "$b"; return 0; }
     fi
-    if git -C "$dir" rev-parse --verify --quiet refs/heads/main >/dev/null 2>&1; then
+    # `if` form (not `cmd && flag=1`) so a missing ref — `git rev-parse` exits 1
+    # — never trips a caller's `set -e`: an `if` condition is exempt, an `&&`
+    # list's non-final failure is murkier. Both candidates are probed before the
+    # tie-break decision.
+    local has_main=0 has_master=0
+    if git -C "$dir" rev-parse --verify --quiet refs/heads/main   >/dev/null 2>&1; then has_main=1; fi
+    if git -C "$dir" rev-parse --verify --quiet refs/heads/master >/dev/null 2>&1; then has_master=1; fi
+    if [ "$has_main" = 1 ] && [ "$has_master" = 1 ]; then
+        echo "guardrails: default_branch - both local 'main' and 'master' exist and origin/HEAD is unset; defaulting to 'main' (run 'git remote set-head origin -a' to disambiguate)" >&2
         printf 'main'; return 0
     fi
-    if git -C "$dir" rev-parse --verify --quiet refs/heads/master >/dev/null 2>&1; then
-        printf 'master'; return 0
-    fi
+    if [ "$has_main" = 1 ];   then printf 'main';   return 0; fi
+    if [ "$has_master" = 1 ]; then printf 'master'; return 0; fi
     b=$(git -C "$dir" config init.defaultBranch 2>/dev/null)
     [ -n "$b" ] && { printf '%s' "$b"; return 0; }
     printf 'main'

--- a/scripts/guardrails/test-lib.sh
+++ b/scripts/guardrails/test-lib.sh
@@ -234,6 +234,32 @@ git -C "$work" fetch -q origin
 if is_behind_origin_main "$work"; then pass "behind (master default) -> true"; else fail "behind (master default) -> expected 0 got $?"; fi
 rm -rf "$work" "$origin"
 
+echo "== default_branch: both local main+master, origin/HEAD unset -> main + stderr ambiguity note (HIMMEL-323) =="
+# A repo with NO remote (so origin/HEAD is unset) that has BOTH local main and
+# master. The local-ref order returns main, but silently — HIMMEL-323 adds a
+# stderr ambiguity note so the wrong-on-a-master-default-mirror guess is visible.
+d=$(mktemp -d)
+git -C "$d" init -q -b main
+git -C "$d" config user.email t@t
+git -C "$d" config user.name t
+git -C "$d" commit --allow-empty -q -m "init"
+git -C "$d" branch master   # both refs/heads/main and refs/heads/master now exist
+errf=$(mktemp)
+db_out=$(default_branch "$d" 2>"$errf")
+db_err=$(cat "$errf"); rm -f "$errf"
+if [ "$db_out" = "main" ]; then pass "ambiguous main+master -> stdout 'main' (stable default)"; else fail "ambiguous main+master -> expected stdout 'main' got [$db_out]"; fi
+case "$db_err" in
+    *"both local 'main' and 'master' exist"*) pass "ambiguous main+master -> stderr ambiguity note emitted (no longer silent)" ;;
+    *) fail "ambiguous main+master -> expected stderr ambiguity note, got [$db_err]" ;;
+esac
+# Counter-case: only one default-candidate ref present -> NO note (no ambiguity).
+git -C "$d" branch -D master >/dev/null 2>&1
+errf=$(mktemp)
+db_out=$(default_branch "$d" 2>"$errf")
+db_err=$(cat "$errf"); rm -f "$errf"
+if [ "$db_out" = "main" ] && [ -z "$db_err" ]; then pass "single default-candidate -> 'main', no ambiguity note"; else fail "single default-candidate -> expected 'main' + no note, got out=[$db_out] err=[$db_err]"; fi
+rm -rf "$d"
+
 if [ "$failures" -eq 0 ]; then
     echo "OK: all cases passed"
     exit 0

--- a/scripts/hooks/check-cr-before-push.sh
+++ b/scripts/hooks/check-cr-before-push.sh
@@ -36,11 +36,21 @@ if ! . "$SCRIPT_DIR/../guardrails/lib.sh" 2>/dev/null; then
     exit 2
 fi
 
-branch=$(git branch --show-current)
+# Resolve THIS worktree's branch via lib.sh::_branch (HIMMEL-323). `git branch
+# --show-current` is worktree-correct under a normal pre-push but reads the
+# PRIMARY worktree's HEAD if GIT_DIR is aimed at the shared .git; routing through
+# _branch keeps the pre-push gates' branch reads on one path, and its rc=2 lets us fail
+# CLOSED on an unreadable HEAD instead of letting `set -e` abort opaquely.
+rc=0
+branch=$(_branch) || rc=$?
+if [ "$rc" -eq 2 ]; then
+    echo "→ code-review: cannot resolve current branch (lib.sh::_branch rc=2) — refusing the push (fix the repo state or bypass with SKIP_CR=1)" >&2
+    exit 2
+fi
 
 # Skip on a protected default (main OR master) / detached HEAD — pushing the
 # default branch is blocked elsewhere and there's no meaningful diff to review.
-if [ -z "$branch" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+if [ -z "$branch" ] || is_on_main; then
     exit 0
 fi
 
@@ -56,7 +66,7 @@ fi
 # 'origin/db' (i.e. origin is ahead), use 'origin/db' so we don't diff against a
 # stale local copy and generate false-positive markers. No network call — git
 # merge-base --is-ancestor uses only locally-fetched refs. If neither ref
-# exists, skip with WARNING.
+# exists, fail CLOSED (HIMMEL-323) — see the else arm.
 db=$(default_branch)
 diff_base=""
 if git rev-parse --verify --quiet "$db" >/dev/null && \
@@ -71,12 +81,25 @@ elif git rev-parse --verify --quiet "$db" >/dev/null; then
 elif git rev-parse --verify --quiet "origin/$db" >/dev/null; then
     diff_base="origin/$db"
 else
-    echo "→ code-review: no '$db' or 'origin/$db' ref — skipping (WARNING: cannot compute diff for review)" >&2
-    exit 0
+    # Neither '$db' nor 'origin/$db' resolves: we cannot compute a diff, so we
+    # cannot write a meaningful CR marker — and skipping silently would let an
+    # unreviewed change reach `gh pr create` ungated. Fail CLOSED (HIMMEL-323).
+    # This hook does no fetch, so an unresolvable base is a genuinely broken
+    # state (a normal clone always has origin/<default>). Bypass with SKIP_CR=1.
+    echo "→ code-review: no '$db' or 'origin/$db' ref — refusing the push (cannot compute diff for review; bypass with SKIP_CR=1 or git push --no-verify)" >&2
+    exit 2
 fi
 
-# Skip on docs-only / merge-only diffs to avoid pointless review gating
-changed=$(git diff --name-only "${diff_base}...HEAD")
+# Skip on docs-only / merge-only diffs to avoid pointless review gating.
+# Fail CLOSED if the diff can't be computed (HIMMEL-323) — the 3-dot range needs
+# a merge base, so an orphan/unrelated-history branch makes `git diff` exit
+# non-zero. Without the guard `set -e` would abort with git's opaque exit code;
+# refuse the push with a clear rc=2 instead so an unreviewable change can't slip
+# past the CR marker ungated. A genuinely empty diff still skips below.
+if ! changed=$(git diff --name-only "${diff_base}...HEAD" 2>/dev/null); then
+    echo "→ code-review: cannot compute diff vs ${diff_base} (no merge base / git error) — refusing the push (bypass with SKIP_CR=1 or git push --no-verify)" >&2
+    exit 2
+fi
 if [ -z "$changed" ]; then
     echo "→ code-review: no diff vs ${diff_base} — skipping" >&2
     exit 0

--- a/scripts/hooks/check-merged-branch.sh
+++ b/scripts/hooks/check-merged-branch.sh
@@ -15,9 +15,10 @@ is_merged_into_main
 rc=$?
 case "$rc" in
     0)
-        # Use lib's _branch (worktree-aware) rather than `git branch
-        # --show-current`, which resolves the MAIN-REPO HEAD when run from
-        # a linked worktree.
+        # Use lib's _branch (single shared branch-read path) rather than
+        # `git branch --show-current`; show-current is worktree-correct under
+        # normal invocation but misreads the PRIMARY worktree's HEAD when
+        # GIT_DIR is aimed at the shared .git (HIMMEL-323).
         branch=$(_branch)
         echo "WARNING: Branch '${branch}' appears to be already merged into 'main' (direct or squash)."
         echo "         You may be editing stale code. Check out a fresh branch off main if so."

--- a/scripts/hooks/check-platforms-tested.sh
+++ b/scripts/hooks/check-platforms-tested.sh
@@ -33,7 +33,9 @@
 # Exit codes:
 #   0 — pass (no sensitive files, attestation present, or bypass)
 #   1 — block (sensitive files changed + no attestation + no bypass)
-#   2 — block (cannot source guardrails/lib.sh — fail-closed, cannot evaluate)
+#   2 — block (cannot evaluate — fail-closed: can't source guardrails/lib.sh,
+#       can't read the current branch, or no diff base resolves on the online
+#       path; HIMMEL-323)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -47,11 +49,22 @@ if ! . "$SCRIPT_DIR/../guardrails/lib.sh" 2>/dev/null; then
     exit 2
 fi
 
-branch=$(git branch --show-current)
+# Resolve THIS worktree's branch via lib.sh::_branch (HIMMEL-323). `git branch
+# --show-current` is worktree-correct under a normal pre-push (git points GIT_DIR
+# at the worktree's own gitdir) but reads the PRIMARY worktree's HEAD if GIT_DIR
+# is aimed at the shared .git; routing through _branch keeps the pre-push gates'
+# branch reads on one path. _branch also returns rc=2 on an unreadable HEAD so we fail
+# CLOSED with a clear diagnostic instead of letting `set -e` abort opaquely.
+rc=0
+branch=$(_branch) || rc=$?
+if [ "$rc" -eq 2 ]; then
+    echo "→ platforms-check: cannot resolve current branch (lib.sh::_branch rc=2) — refusing the push (cannot evaluate; bypass with git push --no-verify)" >&2
+    exit 2
+fi
 
-# Detached HEAD or default-branch push: skip — `no-push-to-main` covers
-# main/master, and we can't compute a sensible diff base on detached HEAD.
-if [ -z "$branch" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+# Detached HEAD (empty branch, rc=1) or a protected default (main/master): skip.
+# no-push-to-main covers main/master; detached HEAD has no sensible diff base.
+if [ -z "$branch" ] || is_on_main; then
     exit 0
 fi
 
@@ -85,12 +98,33 @@ if git rev-parse --verify --quiet "origin/$db" >/dev/null; then
     diff_base="origin/$db"
 elif git rev-parse --verify --quiet "$db" >/dev/null; then
     diff_base="$db"
-else
-    echo "→ platforms-check: no 'origin/$db' or local '$db' ref — skipping (cannot compute diff)" >&2
+elif [ "${PLATFORMS_TESTED_NO_FETCH:-0}" = "1" ]; then
+    # No resolvable base AND the operator opted into offline mode (NO_FETCH):
+    # a shallow/offline clone legitimately may not carry the default ref. We
+    # cannot evaluate the gate, but blocking here would break the documented
+    # offline workflow — skip with a LOUD warning (HIMMEL-323).
+    echo "→ platforms-check: no 'origin/$db' or local '$db' ref and PLATFORMS_TESTED_NO_FETCH=1 — cannot compute diff; SKIPPING the gate (WARNING: cross-platform surface NOT checked — verify manually before merge)" >&2
     exit 0
+else
+    # Online path: we attempted `git fetch origin $db` and STILL cannot resolve
+    # any base. That is a genuinely broken state (default renamed and origin/HEAD
+    # not pointing at it, corrupt refs) — not a normal clone, which always has
+    # origin/<default>. Fail CLOSED (HIMMEL-323): refusing the push beats silently
+    # skipping the gate on an unattested change.
+    echo "→ platforms-check: no 'origin/$db' or local '$db' ref after fetch — refusing the push (rc=2 = cannot evaluate the gate). Set PLATFORMS_TESTED_NO_FETCH=1 for a known-offline/shallow clone, or bypass with PLATFORMS_TESTED_OK=1 / git push --no-verify." >&2
+    exit 2
 fi
 
-changed=$(git diff --name-only "${diff_base}...HEAD" || true)
+# Fail CLOSED if the diff itself can't be computed (HIMMEL-323). The 3-dot
+# range needs a merge base; an orphan/unrelated-history branch makes `git diff`
+# exit non-zero. The old `|| true` swallowed that to an empty list, which the
+# `[ -z ]` line below then treated as "no changes" → a silent PASS on a branch
+# we never actually inspected. An empty diff (genuinely no changes) still exits
+# 0 via rev-parse'd success + the `[ -z ]` skip.
+if ! changed=$(git diff --name-only "${diff_base}...HEAD" 2>/dev/null); then
+    echo "→ platforms-check: cannot compute diff vs ${diff_base} (no merge base / git error) — refusing the push (rc=2 = cannot evaluate; bypass with PLATFORMS_TESTED_OK=1 or git push --no-verify)" >&2
+    exit 2
+fi
 [ -z "$changed" ] && exit 0
 
 # Filter sensitive paths.

--- a/scripts/hooks/check-security-reviewed.sh
+++ b/scripts/hooks/check-security-reviewed.sh
@@ -58,7 +58,9 @@
 # Exit codes:
 #   0 — pass (docs-only diff, attestation present, or bypass)
 #   1 — block (code changed + no attestation + no bypass)
-#   2 — block (cannot source guardrails/lib.sh — fail-closed, cannot evaluate)
+#   2 — block (cannot evaluate — fail-closed: can't source guardrails/lib.sh,
+#       can't read the current branch, or no diff base resolves on the online
+#       path; HIMMEL-323)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -72,11 +74,22 @@ if ! . "$SCRIPT_DIR/../guardrails/lib.sh" 2>/dev/null; then
     exit 2
 fi
 
-branch=$(git branch --show-current)
+# Resolve THIS worktree's branch via lib.sh::_branch (HIMMEL-323). `git branch
+# --show-current` is worktree-correct under a normal pre-push (git points GIT_DIR
+# at the worktree's own gitdir) but reads the PRIMARY worktree's HEAD if GIT_DIR
+# is aimed at the shared .git; routing through _branch keeps the pre-push gates'
+# branch reads on one path. _branch also returns rc=2 on an unreadable HEAD so we fail
+# CLOSED with a clear diagnostic instead of letting `set -e` abort opaquely.
+rc=0
+branch=$(_branch) || rc=$?
+if [ "$rc" -eq 2 ]; then
+    echo "→ security-review: cannot resolve current branch (lib.sh::_branch rc=2) — refusing the push (cannot evaluate; bypass with git push --no-verify)" >&2
+    exit 2
+fi
 
-# Detached HEAD or default-branch push: skip. no-push-to-main covers
-# main/master, and we can't compute a sensible diff base on detached HEAD.
-if [ -z "$branch" ] || [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+# Detached HEAD (empty branch, rc=1) or a protected default (main/master): skip.
+# no-push-to-main covers main/master; detached HEAD has no sensible diff base.
+if [ -z "$branch" ] || is_on_main; then
     exit 0
 fi
 
@@ -98,12 +111,33 @@ if git rev-parse --verify --quiet "origin/$db" >/dev/null; then
     diff_base="origin/$db"
 elif git rev-parse --verify --quiet "$db" >/dev/null; then
     diff_base="$db"
-else
-    echo "→ security-review: no 'origin/$db' or local '$db' ref — skipping (cannot compute diff)" >&2
+elif [ "${SECURITY_REVIEW_NO_FETCH:-0}" = "1" ]; then
+    # No resolvable base AND the operator opted into offline mode (NO_FETCH):
+    # a shallow/offline clone legitimately may not carry the default ref. We
+    # cannot evaluate the gate, but blocking here would break the documented
+    # offline workflow — skip with a LOUD warning (HIMMEL-323).
+    echo "→ security-review: no 'origin/$db' or local '$db' ref and SECURITY_REVIEW_NO_FETCH=1 — cannot compute diff; SKIPPING the gate (WARNING: security surface NOT checked — confirm review ran before merge)" >&2
     exit 0
+else
+    # Online path: we attempted `git fetch origin $db` and STILL cannot resolve
+    # any base. That is a genuinely broken state (default renamed and origin/HEAD
+    # not pointing at it, corrupt refs) — not a normal clone, which always has
+    # origin/<default>. Fail CLOSED (HIMMEL-323): refusing the push beats silently
+    # skipping the gate on an unattested code change.
+    echo "→ security-review: no 'origin/$db' or local '$db' ref after fetch — refusing the push (rc=2 = cannot evaluate the gate). Set SECURITY_REVIEW_NO_FETCH=1 for a known-offline/shallow clone, or bypass with SKIP_SECURITY_REVIEW=1 / git push --no-verify." >&2
+    exit 2
 fi
 
-changed=$(git diff --name-only "${diff_base}...HEAD" || true)
+# Fail CLOSED if the diff itself can't be computed (HIMMEL-323). The 3-dot
+# range needs a merge base; an orphan/unrelated-history branch makes `git diff`
+# exit non-zero. The old `|| true` swallowed that to an empty list, which the
+# `[ -z ]` line below then treated as "no changes" → a silent PASS on a branch
+# we never actually inspected. An empty diff (genuinely no changes) still exits
+# 0 via rev-parse'd success + the `[ -z ]` skip.
+if ! changed=$(git diff --name-only "${diff_base}...HEAD" 2>/dev/null); then
+    echo "→ security-review: cannot compute diff vs ${diff_base} (no merge base / git error) — refusing the push (rc=2 = cannot evaluate; bypass with SKIP_SECURITY_REVIEW=1 or git push --no-verify)" >&2
+    exit 2
+fi
 [ -z "$changed" ] && exit 0
 
 # Docs-only skip — same filter shape as check-cr-before-push.sh:

--- a/scripts/hooks/test-check-cr-before-push.sh
+++ b/scripts/hooks/test-check-cr-before-push.sh
@@ -347,6 +347,79 @@ else
     fail "diverged: expected marker for code diff" "out: $hook_out3"
 fi
 
+# ── HIMMEL-323 item 1: fail-CLOSED when no diff base resolves ───────────────
+# A repo with no main/master ref and no remote: default_branch falls back to
+# "main", which doesn't exist. This hook does no fetch, so an unresolvable base
+# is a genuinely-broken state -> fail CLOSED (exit 2), not a silent skip that
+# would let an unreviewed change reach `gh pr create` ungated. Bypass: SKIP_CR=1.
+echo "TEST: unresolvable diff base -> fail CLOSED (exit 2)"
+NB="$TMP_ROOT/nobase"
+git init -q -b feat/x "$NB"
+(
+    cd "$NB"
+    git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+    echo 'function f(){}' > code.sh
+    git -c user.email=t@t -c user.name=t add code.sh
+    git -c user.email=t@t -c user.name=t commit -q -m "code"
+)
+rc=0; out=$(cd "$NB" && bash "$HOOK" 2>&1) || rc=$?
+if [ "$rc" -eq 2 ]; then pass "unresolvable base -> exit 2 (fail closed)"; else fail "unresolvable base -> expected exit 2 got $rc" "out: $out"; fi
+rc=0; out=$(cd "$NB" && SKIP_CR=1 bash "$HOOK" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then pass "unresolvable base + SKIP_CR=1 -> exit 0 (bypass)"; else fail "SKIP_CR bypass -> expected exit 0 got $rc" "out: $out"; fi
+
+# ── HIMMEL-323 item 2: branch resolved via lib.sh::_branch ──────────────────
+echo "TEST: non-git dir -> rc=2 fail-closed (cannot read branch)"
+NG="$TMP_ROOT/nongit"; mkdir -p "$NG"
+rc=0; out=$(cd "$NG" && bash "$HOOK" 2>&1) || rc=$?
+if [ "$rc" -eq 2 ]; then pass "non-git dir -> exit 2"; else fail "non-git dir -> expected exit 2 got $rc" "out: $out"; fi
+
+# Regression-PIN, not a fix-prover: `git branch --show-current` is already
+# worktree-correct in the natural env (GIT_DIR at the worktree's own gitdir), so
+# this passes on old code too. The genuine new-behaviour prover for the _branch
+# switch is the non-git-dir rc=2 case above (old code aborted via set -e, rc=128).
+echo "TEST: linked worktree (primary on main) -> reads worktree branch, writes marker"
+WB="$TMP_ROOT/wtbase"
+git init -q -b main "$WB"
+( cd "$WB"; git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init )
+git -C "$WB" worktree add -q -b feat/wt "$TMP_ROOT/wtbase-wt" >/dev/null 2>&1
+(
+    cd "$TMP_ROOT/wtbase-wt"
+    echo 'function f(){}' > code.sh
+    git -c user.email=t@t -c user.name=t add code.sh
+    git -c user.email=t@t -c user.name=t commit -q -m "code on worktree"
+)
+wtgd="$WB/.git/worktrees/$(basename "$TMP_ROOT/wtbase-wt")"
+rc=0; out=$(cd "$TMP_ROOT/wtbase-wt" && env GIT_DIR="$wtgd" bash "$HOOK" 2>&1) || rc=$?
+wm="$WB/.git/cr-pending/feat/wt"
+if [ "$rc" -eq 0 ] && [ -f "$wm" ]; then
+    pass "linked worktree: read worktree branch (feat/wt) + wrote marker"
+else
+    fail "linked worktree: expected exit 0 + marker at $wm got rc=$rc" "out: $out"
+fi
+git -C "$WB" worktree remove --force "$TMP_ROOT/wtbase-wt" >/dev/null 2>&1 || true
+
+# ── HIMMEL-323 item 1 (CR follow-up): fail-CLOSED when the diff itself errors ──
+# An orphan/unrelated-history branch has no merge base, so `git diff base...HEAD`
+# exits non-zero. Without the guard `set -e` would abort with git's opaque code;
+# the hook now refuses the push with a clear rc=2 so an unreviewable change can't
+# slip past the CR marker ungated. Bypass: SKIP_CR=1.
+echo "TEST: orphan branch (no merge base) -> fail CLOSED (exit 2)"
+OB="$TMP_ROOT/orphan"
+git init -q -b main "$OB"
+(
+    cd "$OB"
+    git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+    git checkout -q --orphan feat/x
+    git rm -rfq . 2>/dev/null || true
+    echo 'function f(){}' > code.sh
+    git -c user.email=t@t -c user.name=t add code.sh
+    git -c user.email=t@t -c user.name=t commit -q -m "orphan code"
+)
+rc=0; out=$(cd "$OB" && bash "$HOOK" 2>&1) || rc=$?
+if [ "$rc" -eq 2 ]; then pass "orphan branch -> exit 2 (fail closed)"; else fail "orphan branch -> expected exit 2 got $rc" "out: $out"; fi
+rc=0; out=$(cd "$OB" && SKIP_CR=1 bash "$HOOK" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then pass "orphan branch + SKIP_CR=1 -> exit 0 (bypass)"; else fail "orphan SKIP_CR bypass -> expected exit 0 got $rc" "out: $out"; fi
+
 # Summary ------------------------------------------------------------
 
 echo

--- a/scripts/hooks/test-check-platforms-tested.sh
+++ b/scripts/hooks/test-check-platforms-tested.sh
@@ -255,6 +255,85 @@ d=$(mktemp -d)
 assert_rc "on master branch — skip"                   0 "$(run_in "$d")"
 rm -rf "$d"
 
+# --- HIMMEL-323 item 1: fail-CLOSED on an unresolvable diff base ---
+# A repo with NO main/master ref and NO remote: default_branch falls back to
+# "main", which doesn't exist, so no diff base resolves. ONLINE (no *_NO_FETCH)
+# this is a genuinely-broken state -> fail CLOSED (exit 2). With NO_FETCH the
+# operator opted into offline mode -> skip (exit 0) with a loud warning, so
+# offline/shallow workflows are preserved.
+make_no_default_repo() {
+    local files="$1" msg="$2" dir
+    dir=$(mktemp -d)
+    (
+        cd "$dir" || exit 1
+        git init -q -b feat/x   # HEAD on a feature branch; no main/master ref ever created
+        git config user.email t@t
+        git config user.name t
+        # shellcheck disable=SC2086 # files is space-separated, intentional split
+        for f in $files; do mkdir -p "$(dirname "$f")"; echo x > "$f"; done
+        git add -A
+        git -c commit.gpgsign=false commit -q -m "$msg"
+    )
+    echo "$dir"
+}
+
+d=$(make_no_default_repo "scripts/foo.sh" "feat: add foo")
+assert_rc "unresolvable base, online -> fail CLOSED (exit 2)"         2 "$(run_in "$d")"
+assert_rc "unresolvable base, NO_FETCH -> skip + warn (exit 0)"       0 "$(run_in "$d" "PLATFORMS_TESTED_NO_FETCH=1")"
+rm -rf "$d"
+
+# --- HIMMEL-323 item 2: branch resolved via lib.sh::_branch (worktree-correct) ---
+# Non-git dir: _branch returns rc=2 -> hook fails CLOSED (exit 2) with a clear
+# diagnostic, rather than letting `set -e` abort on git's opaque exit 128.
+ngd=$(mktemp -d)
+assert_rc "non-git dir -> rc=2 fail-closed (cannot read branch)"     2 "$(run_in "$ngd")"
+rm -rf "$ngd"
+
+# Pin that the gate FIRES from a LINKED worktree on a feature branch while the
+# PRIMARY checkout sits on main: under the natural pre-push env (git points
+# GIT_DIR at the worktree's own gitdir) the gate must read the worktree branch
+# (feat/x), see the sensitive .sh, and BLOCK — never read the primary's 'main'
+# and skip. Pins worktree-correct behaviour so future branch-resolution changes
+# can't silently regress it.
+origin=$(mktemp -d); base=$(mktemp -d)
+( cd "$origin" || exit 1; git init -q --bare -b main ) >/dev/null 2>&1
+(
+    cd "$base" || exit 1
+    git clone -q "$origin" . >/dev/null 2>&1
+    git config user.email t@t
+    git config user.name t
+    echo r > README.md; git add -A; git -c commit.gpgsign=false commit -q -m init
+    git push -q origin main >/dev/null 2>&1
+    git worktree add -q -b feat/x "${base}-wt" >/dev/null 2>&1
+    mkdir -p "${base}-wt/scripts"; echo 'echo hi' > "${base}-wt/scripts/new.sh"
+    git -C "${base}-wt" add -A
+    git -C "${base}-wt" -c commit.gpgsign=false commit -q -m "feat: shell, no attestation"
+) >/dev/null 2>&1
+wtgd="${base}/.git/worktrees/$(basename "${base}-wt")"
+rc_wt=$( cd "${base}-wt" && env GIT_DIR="$wtgd" PLATFORMS_TESTED_NO_FETCH=1 bash "$HOOK" >/dev/null 2>&1; echo $? )
+assert_rc "linked worktree (primary on main): reads worktree branch + blocks" 1 "$rc_wt"
+git -C "$base" worktree remove --force "${base}-wt" >/dev/null 2>&1 || true
+rm -rf "$origin" "$base" "${base}-wt"
+
+# --- HIMMEL-323 item 1 (CR follow-up): fail-CLOSED when the diff itself errors ---
+# An orphan/unrelated-history branch has no merge base, so `git diff base...HEAD`
+# exits non-zero. The old `|| true` swallowed that to an empty changed-set -> a
+# silent PASS on a branch never inspected. Now it fails CLOSED (exit 2).
+d=$(mktemp -d)
+(
+    cd "$d" || exit 1
+    git init -q -b main
+    git config user.email t@t
+    git config user.name t
+    echo r > README.md; git add -A; git -c commit.gpgsign=false commit -q -m init
+    git checkout -q --orphan feat/x
+    git rm -rfq . 2>/dev/null || true
+    mkdir -p scripts; echo 'echo x' > scripts/foo.sh
+    git add -A; git -c commit.gpgsign=false commit -q -m "feat: orphan sensitive"
+) >/dev/null 2>&1
+assert_rc "orphan branch (no merge base) -> fail CLOSED (exit 2)"    2 "$(run_in "$d" "PLATFORMS_TESTED_NO_FETCH=1")"
+rm -rf "$d"
+
 echo ""
 if [ "$FAILED" -eq 0 ]; then
     echo "All cases passed."

--- a/scripts/hooks/test-check-security-reviewed.sh
+++ b/scripts/hooks/test-check-security-reviewed.sh
@@ -296,6 +296,95 @@ d=$(mktemp -d)
 assert_rc "on master branch — skip"                  0 "$(run_in "$d")"
 rm -rf "$d"
 
+# --- HIMMEL-323 item 1: fail-CLOSED on an unresolvable diff base ---
+# A repo with NO main/master ref and NO remote: default_branch falls back to
+# "main", which doesn't exist, so no diff base resolves. ONLINE (no *_NO_FETCH)
+# this is a genuinely-broken state -> fail CLOSED (exit 2). With NO_FETCH the
+# operator opted into offline mode -> skip (exit 0) with a loud warning, so
+# offline/shallow workflows are preserved.
+make_no_default_repo() {
+    local files="$1" msg="$2" dir
+    dir=$(mktemp -d)
+    (
+        cd "$dir" || exit 1
+        git init -q -b feat/x   # HEAD on a feature branch; no main/master ref ever created
+        git config user.email t@t
+        git config user.name t
+        # shellcheck disable=SC2086 # files is space-separated, intentional split
+        for f in $files; do mkdir -p "$(dirname "$f")"; echo x > "$f"; done
+        git add -A
+        git -c commit.gpgsign=false commit -q -m "$msg"
+    )
+    echo "$dir"
+}
+
+d=$(make_no_default_repo "src/foo.ts" "feat: add foo")
+assert_rc "unresolvable base, online -> fail CLOSED (exit 2)"         2 "$(run_in "$d")"
+assert_rc "unresolvable base, NO_FETCH -> skip + warn (exit 0)"       0 "$(run_in "$d" "SECURITY_REVIEW_NO_FETCH=1")"
+rm -rf "$d"
+
+# --- HIMMEL-323 item 2: branch resolved via lib.sh::_branch (worktree-correct) ---
+# Non-git dir: _branch returns rc=2 -> hook fails CLOSED (exit 2) with a clear
+# diagnostic, rather than letting `set -e` abort on git's opaque exit 128.
+ngd=$(mktemp -d)
+assert_rc "non-git dir -> rc=2 fail-closed (cannot read branch)"     2 "$(run_in "$ngd")"
+rm -rf "$ngd"
+
+# Pin that the gate FIRES from a LINKED worktree on a feature branch while the
+# PRIMARY checkout sits on main: under the natural pre-push env (GIT_DIR points
+# at the worktree's own gitdir) the gate must read the worktree branch (feat/x),
+# see the non-docs code, and BLOCK — never read the primary's 'main' and skip.
+# NOTE: this is a regression-PIN, not a fix-prover — `git branch --show-current`
+# is already worktree-correct in the natural env, so this passes on old code too.
+# The genuine new-behaviour prover for the _branch switch is the non-git-dir
+# rc=2 case above (old code aborted via set -e with git's opaque exit 128).
+origin=$(mktemp -d); base=$(mktemp -d)
+( cd "$origin" || exit 1; git init -q --bare -b main ) >/dev/null 2>&1
+(
+    cd "$base" || exit 1
+    git clone -q "$origin" . >/dev/null 2>&1
+    git config user.email t@t
+    git config user.name t
+    echo r > README.md; git add -A; git -c commit.gpgsign=false commit -q -m init
+    git push -q origin main >/dev/null 2>&1
+    git worktree add -q -b feat/x "${base}-wt" >/dev/null 2>&1
+    mkdir -p "${base}-wt/src"; echo 'export const x = 1' > "${base}-wt/src/new.ts"
+    git -C "${base}-wt" add -A
+    git -C "${base}-wt" -c commit.gpgsign=false commit -q -m "feat: code, no attestation"
+) >/dev/null 2>&1
+wtgd="${base}/.git/worktrees/$(basename "${base}-wt")"
+rc_wt=$( cd "${base}-wt" && env GIT_DIR="$wtgd" SECURITY_REVIEW_NO_FETCH=1 bash "$HOOK" >/dev/null 2>&1; echo $? )
+assert_rc "linked worktree (primary on main): reads worktree branch + blocks" 1 "$rc_wt"
+git -C "$base" worktree remove --force "${base}-wt" >/dev/null 2>&1 || true
+rm -rf "$origin" "$base" "${base}-wt"
+
+# --- HIMMEL-323: NO_FETCH only suppresses the fetch, NOT the gate ---
+# A repo with a resolvable LOCAL base + code + no attestation, run with
+# SECURITY_REVIEW_NO_FETCH=1, must still BLOCK (rc=1) — NO_FETCH skips only the
+# network refresh, it must never short-circuit the gate when a base resolves.
+d=$(make_repo "src/foo.ts" "feat: code, no attestation")
+assert_rc "NO_FETCH with a resolvable base still gates (block rc=1)"  1 "$(run_in "$d" "SECURITY_REVIEW_NO_FETCH=1")"
+rm -rf "$d"
+
+# --- HIMMEL-323 item 1 (CR follow-up): fail-CLOSED when the diff itself errors ---
+# An orphan/unrelated-history branch has no merge base, so `git diff base...HEAD`
+# exits non-zero. The old `|| true` swallowed that to an empty changed-set -> a
+# silent PASS on code never inspected. Now it fails CLOSED (exit 2).
+d=$(mktemp -d)
+(
+    cd "$d" || exit 1
+    git init -q -b main
+    git config user.email t@t
+    git config user.name t
+    echo r > README.md; git add -A; git -c commit.gpgsign=false commit -q -m init
+    git checkout -q --orphan feat/x
+    git rm -rfq . 2>/dev/null || true
+    mkdir -p src; echo 'export const x = 1' > src/foo.ts
+    git add -A; git -c commit.gpgsign=false commit -q -m "feat: orphan code"
+) >/dev/null 2>&1
+assert_rc "orphan branch (no merge base) -> fail CLOSED (exit 2)"    2 "$(run_in "$d" "SECURITY_REVIEW_NO_FETCH=1")"
+rm -rf "$d"
+
 echo ""
 if [ "$FAILED" -eq 0 ]; then
     echo "All cases passed."


### PR DESCRIPTION
Code-only propagation from himmel-private (#516). Pre-push guardrail hardening, 3 items:

1. **Fail-CLOSED on unresolvable diff base** — attestation gates exit 2 on the online path; skip + loud warn under `*_NO_FETCH` (offline opt-in); `check-cr-before-push.sh` fails closed (SKIP_CR bypass). The `git diff <base>...HEAD` calls also fail closed on a diff error (orphan / no merge base), replacing a fail-open `|| true`.
2. **Branch read via `lib.sh::_branch` + `is_on_main`** — one shared predicate + rc=2 fail-closed on an unreadable HEAD. Honest note: consistency + fail-closed hardening, not a behavioral bugfix (`git branch --show-current` is worktree-correct under a normal pre-push; the misread only occurs with GIT_DIR aimed at the shared .git, which `_branch` follows too).
3. **`default_branch()` ambiguity note** — stderr note when origin/HEAD unset and both local main+master exist (still returns main).

shellcheck -S error clean; 4 paired suites green incl. new cases; heavy CR (5 reviewers) = 0 Critical.