### PR TITLE
fix(marketplace): bump claude-obsidian pin past prompt-type SessionStart hook

### DIFF
--- a/marketplace/.claude-plugin/marketplace.json
+++ b/marketplace/.claude-plugin/marketplace.json
@@ -65,7 +65,7 @@
       "source": {
         "source": "github",
         "repo": "yotamleo/claude-obsidian",
-        "ref": "8958b25164de18e235b8ba56d003425a7bcafd1b"
+        "ref": "f102ee61bf5c00f78bb0af134501bc3020cdf66e"
       },
       "description": "[yotamleo fork — vendor + attribution only, no upstream PR] Claude + Obsidian knowledge companion. Wiki query, save, ingest, lint, autoresearch. Companion to obsidian-triage — its wiki-query skill optionally powers the Phase 4 Related Notes link-graph traversal. Pinned to a commit SHA per himmel supply-chain policy (see marketplace/plugins/obsidian-triage/README.md § Pin update workflow). Original: AgriciDaniel/claude-obsidian.",
       "author": {


### PR DESCRIPTION
## Problem

New fork users get `claude-obsidian` pinned at `8958b25`, whose `hooks.json` declares a **prompt-type `SessionStart` hook**. Newer Claude Code rejects those, so every fork user hits this on launch:

```
SessionStart:startup hook error
Failed to run: prompt-type hooks are not supported for SessionStart events
(no conversation context is available). Use a command-type hook instead.
```

## Fix

Bump the pin to `f102ee6` (= `main` of yotamleo/claude-obsidian after [PR #2](https://github.com/yotamleo/claude-obsidian/pull/2)), which removes the redundant prompt-type hook. The sibling command-type `SessionStart` hook still injects `wiki/hot.md`, so behavior is unchanged. Same owner/repo, full immutable SHA — trust posture unchanged.

Security reviewed: manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)