### PR TITLE
fix(luna-template): smooth new-user install (gitleaks false-positive + first-commit block)

### DIFF
--- a/templates/luna-second-brain/.gitleaks.toml
+++ b/templates/luna-second-brain/.gitleaks.toml
@@ -1,0 +1,17 @@
+# gitleaks config for the luna second-brain vault.
+# Keeps the full built-in ruleset and only adds a path allowlist for the
+# vendored third-party Obsidian plugin bundles shipped under .obsidian/plugins/.
+# Those bundles are minified upstream code; gitleaks' generic-api-key rule flags
+# high-entropy minified identifiers (e.g. node-forge's pki.setRsaPrivateKey in
+# obsidian-local-rest-api) as false-positive "secrets". The pre-commit
+# `exclude: '^\.obsidian/'` does NOT reach gitleaks (the hook scans the staged
+# diff directly), so the allowlist has to live here. Real credentials
+# (.env, plugins' data.json) are gitignored.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Vendored third-party Obsidian plugin bundles (minified upstream code)"
+paths = [
+  '''\.obsidian/plugins/''',
+]

--- a/templates/luna-second-brain/scripts/hooks/check-worktree-isolation.sh
+++ b/templates/luna-second-brain/scripts/hooks/check-worktree-isolation.sh
@@ -8,6 +8,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/../guardrails/lib.sh"
 
+# Bootstrap exemption: a repo's first-ever commit legitimately lands on the
+# initial branch (main) — there is no existing main to protect yet, so
+# worktree-isolation does not apply. An unborn HEAD (zero commits) means the
+# scaffold is being committed for the first time; allow it. Without this, a
+# fresh vault (git init + run setup.sh, then commit the scaffold) is blocked
+# on its very first commit and has to be committed on a throwaway branch and
+# have main recreated by hand.
+if ! git rev-parse --verify -q HEAD >/dev/null 2>&1; then
+    exit 0
+fi
+
 is_on_main
 rc=$?
 case "$rc" in


### PR DESCRIPTION
## Problem

Two recurring friction points hit by every new user scaffolding the `luna-second-brain` template:

1. **gitleaks false-positive** — the bundled `obsidian-local-rest-api` plugin (`.obsidian/plugins/.../main.js`, node-forge minified crypto) trips gitleaks. The pre-commit `exclude: '^\.obsidian/'` does **not** reach gitleaks (the hook scans the staged diff directly), so every new user had to hand-write a `.gitleaks.toml`.
2. **First-commit blocked** — `worktree-isolation` refuses commits on `main`; a fresh vault (`git init` + `setup.sh`, then commit the scaffold) is on `main` with zero commits, so the very first commit was blocked.

## Fix

1. Ship `templates/luna-second-brain/.gitleaks.toml` — allowlists `\.obsidian/plugins/` while keeping the full default ruleset. Mirrors himmel's own root config.
2. Add a **bootstrap exemption** to `check-worktree-isolation.sh`: an unborn HEAD (zero commits) has no `main` to protect, so the first commit is allowed. Existing-repo commits on `main` are still blocked.

## Testing

Windows / Git Bash: unborn HEAD on main → allow; committed repo on main → block; feature branch → allow. shellcheck clean.

Platforms tested: windows (Git Bash)
Security reviewed: manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)