### PR TITLE
feat(setup): choose user vs project plugin install scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,19 @@ relevant, it belongs in a doc, not here.
 
 ## RULES
 
+### Working principles (general defaults)
+These ship in the repo so a project-scope clone gets them even without the
+operator's user-scope `~/.claude/CLAUDE.md`. Use judgement on trivial tasks.
+1. **Think before coding** — state assumptions; if multiple readings exist,
+   ask, don't pick silently; if a simpler approach exists, say so.
+2. **Simplicity first** — minimum code that solves the problem; nothing
+   speculative (no unrequested features, abstractions, or config).
+3. **Surgical changes** — touch only what the task requires; match existing
+   style; don't refactor what isn't broken; remove only the orphans your own
+   change created.
+4. **Goal-driven execution** — turn the task into a verifiable success
+   criterion, then loop until it passes.
+
 ### Git workflow
 - All feature work in git worktrees. Never commit directly to main.
 - All changes via PR. No direct pushes to main. PRs need ≥1 approval before merge.

--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -240,6 +240,33 @@ After restoring plugins, verify skills load:
 
 Note: `obsidian` and `claude-obsidian` are pinned to commit SHAs in himmel's `marketplace/.claude-plugin/marketplace.json` per supply-chain policy. To update either, bump the `ref` field in a deliberate PR (same gate as a dep bump).
 
+### Scope: user vs project
+
+The `/plugin install` flow above records the plugin at **user scope** (`~/.claude/settings.json`) — enabled for you across every project. That's the right default for personal-workflow plugins. The alternative is **project scope**: declare the marketplace + plugins in a *repo's* `.claude/settings.json`, so anyone who clones that repo gets them auto-known and enabled (each person is still prompted to trust the marketplace on first use).
+
+The setup scripts let you pick: `scripts/machine-setup/install-plugins.{sh,ps1}` take `--scope user|project|local` (default `user`), and the top-level `ubuntu.sh` / `win11.ps1` setup prompts you to choose. For project/local the target is the **current directory**, so run from the repo you want the plugins scoped to. The CLI does it directly too — `claude plugin install <name>@himmel --scope project` writes the block below for you. Same keys, different file:
+
+```jsonc
+// <repo>/.claude/settings.json
+{
+  "extraKnownMarketplaces": {
+    "himmel": { "source": { "source": "github", "repo": "yotamleo/himmel" } }
+  },
+  "enabledPlugins": {
+    "obsidian-triage@himmel": true
+  }
+}
+```
+
+Pick by intent: *yours, everywhere* → user scope; *part of this project, shared on clone* → project scope. Committing `extraKnownMarketplaces` ships a "trust this third-party registry" into the repo — fine for your own repos, a supply-chain call if it has outside contributors. (The JSON above is the illustrative hand-edit form. himmel's setup scripts instead read [`settings-template.json`](settings-template.json) — which registers the marketplace from a local `directory` source rather than the GitHub repo shown above — and apply the plugin set at whichever `--scope` you pick.)
+
+### Remove / move between scopes
+
+- **Remove (user scope):** `/plugin uninstall <name>@himmel`.
+- **Remove (project scope):** delete that plugin's `enabledPlugins` line from the repo's `.claude/settings.json` (and drop the `extraKnownMarketplaces.himmel` block once no himmel plugin is left).
+- **Move user → project:** `/plugin uninstall <name>@himmel`, then add it to the repo's `.claude/settings.json` as above.
+- **Move project → user:** remove its `enabledPlugins` line from the repo settings, then `/plugin install <name>@himmel`.
+
 ---
 
 ## 7. End-session wiki hook (auto-capture to Luna vault)

--- a/marketplace/README.md
+++ b/marketplace/README.md
@@ -11,6 +11,13 @@ take none and just read the source.
 
 ## Install just one plugin
 
+`<name>` is the plugin name from the table below (e.g. `obsidian-triage`).
+Each plugin is independent — you install only what you name; nothing else
+comes along. Pick a **scope** — both use the same marketplace, they just
+differ in *where* the choice is recorded:
+
+### User scope — available in every project (the simple default)
+
 From inside any Claude Code session:
 
 ```text
@@ -18,12 +25,54 @@ From inside any Claude Code session:
 /plugin install <name>@himmel                 # grab a single plugin
 ```
 
-`<name>` is the plugin name from the table below (e.g.
-`/plugin install obsidian-triage@himmel`). Each plugin is independent — you
-install only what you name; nothing else comes along.
+The plugin is enabled for **you**, across all your projects, recorded in
+`~/.claude/settings.json`. Best when it's your own setup and you want it
+everywhere.
 
-Prefer a local checkout? Point the marketplace at the cloned path instead:
-`/plugin marketplace add /path/to/himmel`.
+### Project scope — pinned to one repo, shared with collaborators
+
+Commit the marketplace + the plugins you want into the repo's
+`.claude/settings.json`, so anyone who clones it gets them auto-known and
+enabled (Claude Code still prompts each person to trust the marketplace on
+first use):
+
+```jsonc
+{
+  "extraKnownMarketplaces": {
+    "himmel": { "source": { "source": "github", "repo": "yotamleo/himmel" } }
+  },
+  "enabledPlugins": {
+    "obsidian-triage@himmel": true
+  }
+}
+```
+
+Or let the CLI write that block for you — run from the target repo:
+`claude plugin install <name>@himmel --scope project` (also accepts `--scope
+local` for the gitignored `.claude/settings.local.json`). The himmel setup
+scripts expose the same choice: `scripts/machine-setup/install-plugins.{sh,ps1}
+--scope project`, and the top-level setup prompts for it.
+
+Best when the plugin is part of *this project's* workflow and you want
+contributors to pick it up on clone. (Heads-up: committing
+`extraKnownMarketplaces` ships a "trust this third-party registry" into the
+repo — fine for your own repos, a supply-chain call to make if it has
+outside contributors.)
+
+### Remove, or move between scopes
+
+- **Remove (user scope):** `/plugin uninstall <name>@himmel`.
+- **Remove (project scope):** delete that plugin's `enabledPlugins` line from
+  the repo's `.claude/settings.json` (drop the `extraKnownMarketplaces.himmel`
+  block too once no himmel plugin is left).
+- **Move user → project:** `/plugin uninstall <name>@himmel`, then add it to
+  the repo's `.claude/settings.json` as shown above.
+- **Move project → user:** remove its `enabledPlugins` line from the repo
+  settings, then `/plugin install <name>@himmel` in a session.
+
+Prefer a local checkout over GitHub? Point the marketplace at the cloned path
+instead: `/plugin marketplace add /path/to/himmel` (user scope), or use
+`{ "source": "/path/to/himmel" }` as the project-scope source.
 
 ## What's in here
 

--- a/scripts/machine-setup/install-plugins.ps1
+++ b/scripts/machine-setup/install-plugins.ps1
@@ -5,14 +5,21 @@
 # Reads `enabledPlugins` and `extraKnownMarketplaces` from the template,
 # registers each marketplace via `claude plugin marketplace add`, then
 # installs each plugin via `claude plugin install <plugin>@<marketplace>
-# --scope user`. Both CLI calls are idempotent.
+# --scope <scope>`. Both CLI calls are idempotent.
 #
 # Usage:
-#   pwsh install-plugins.ps1 [-DryRun] [-Template PATH] [-HimmelPath PATH]
+#   pwsh install-plugins.ps1 [-DryRun] [-Scope SCOPE] [-Template PATH] [-HimmelPath PATH]
+#
+# -Scope is user (default, ~/.claude — every project), project (this repo's
+# .claude/settings.json, shared on clone), or local (this repo's gitignored
+# .claude/settings.local.json). For project/local the target is the CURRENT
+# directory — run from the repo you want the plugins scoped to.
 
 [CmdletBinding()]
 param(
     [switch]$DryRun,
+    [ValidateSet('user', 'project', 'local')]
+    [string]$Scope = 'user',
     [string]$Template,
     [string]$HimmelPath
 )
@@ -56,15 +63,15 @@ foreach ($name in $cfg.extraKnownMarketplaces.PSObject.Properties.Name) {
     }
     if (-not $val) { Write-Host "  skip: $name (unknown source type)"; continue }
     Write-Host "  marketplace add: $val"
-    try { Invoke-OrDry @('claude', 'plugin', 'marketplace', 'add', $val) }
+    try { Invoke-OrDry @('claude', 'plugin', 'marketplace', 'add', $val, '--scope', $Scope) }
     catch { Write-Host "    (non-zero — already registered or transient failure)" }
 }
 
 # ── Install plugins ─────────────────────────────────────────────────────────
-Write-Host '──── Installing plugins ────'
+Write-Host "──── Installing plugins ($Scope scope) ────"
 foreach ($spec in $cfg.enabledPlugins.PSObject.Properties.Name) {
     Write-Host "  install: $spec"
-    try { Invoke-OrDry @('claude', 'plugin', 'install', $spec, '--scope', 'user') }
+    try { Invoke-OrDry @('claude', 'plugin', 'install', $spec, '--scope', $Scope) }
     catch { Write-Host "    (non-zero — already installed or transient failure)" }
 }
 

--- a/scripts/machine-setup/install-plugins.sh
+++ b/scripts/machine-setup/install-plugins.sh
@@ -5,16 +5,23 @@
 # Reads `enabledPlugins` (plugin@marketplace keys) and
 # `extraKnownMarketplaces` from the template, registers each marketplace
 # via `claude plugin marketplace add`, then installs each plugin via
-# `claude plugin install <plugin>@<marketplace> --scope user`.
+# `claude plugin install <plugin>@<marketplace> --scope <scope>`.
 #
 # Both CLI calls are idempotent — re-running this script on a fully
 # installed machine is a no-op.
 #
 # Usage:
-#   bash install-plugins.sh [--dry-run] [--template PATH] [--himmel-path PATH]
+#   bash install-plugins.sh [--dry-run] [--scope SCOPE] [--template PATH] [--himmel-path PATH]
 #
 # Flags:
 #   --dry-run            Print commands instead of running them.
+#   --scope SCOPE        Where to declare the marketplaces + plugins:
+#                        user (default, ~/.claude — every project),
+#                        project (this repo's .claude/settings.json,
+#                        shared on clone), or local (this repo's gitignored
+#                        .claude/settings.local.json). For project/local the
+#                        target is the CURRENT directory — run from the repo
+#                        you want the plugins scoped to.
 #   --template PATH      Override default template path.
 #   --himmel-path PATH   Override $HIMMEL_PATH used for <himmel-path>
 #                        placeholder expansion (defaults to repo root
@@ -27,6 +34,7 @@ REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 
 # ── Defaults ────────────────────────────────────────────────────────────────
 DRY_RUN=0
+SCOPE="user"
 TEMPLATE="$REPO_ROOT/docs/setup/settings-template.json"
 HIMMEL_PATH="$REPO_ROOT"
 
@@ -34,6 +42,7 @@ HIMMEL_PATH="$REPO_ROOT"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run)       DRY_RUN=1; shift ;;
+    --scope)         SCOPE="$2"; shift 2 ;;
     --template)      TEMPLATE="$2"; shift 2 ;;
     --himmel-path)   HIMMEL_PATH="$2"; shift 2 ;;
     -h|--help)
@@ -43,6 +52,12 @@ while [[ $# -gt 0 ]]; do
     *) echo "ERROR: unknown flag: $1" >&2; exit 2 ;;
   esac
 done
+
+# ── Validate scope ───────────────────────────────────────────────────────────
+case "$SCOPE" in
+  user|project|local) ;;
+  *) echo "ERROR: invalid --scope: $SCOPE (expected user|project|local)" >&2; exit 2 ;;
+esac
 
 # ── Pre-flight ──────────────────────────────────────────────────────────────
 [[ -f "$TEMPLATE" ]] || { echo "ERROR: template missing: $TEMPLATE" >&2; exit 1; }
@@ -75,15 +90,15 @@ echo "$EXPANDED" | jq -r '
 ' | while read -r SRC; do
   [[ -z "$SRC" || "$SRC" == UNKNOWN:* ]] && { echo "  skip: $SRC"; continue; }
   echo "  marketplace add: $SRC"
-  run claude plugin marketplace add "$SRC" \
+  run claude plugin marketplace add "$SRC" --scope "$SCOPE" \
     || echo "    (non-zero — already registered or transient failure)"
 done
 
 # ── Install plugins ─────────────────────────────────────────────────────────
-echo "──── Installing plugins ────"
+echo "──── Installing plugins ($SCOPE scope) ────"
 echo "$EXPANDED" | jq -r '.enabledPlugins | keys[]' | while read -r SPEC; do
   echo "  install: $SPEC"
-  run claude plugin install "$SPEC" --scope user \
+  run claude plugin install "$SPEC" --scope "$SCOPE" \
     || echo "    (non-zero — already installed or transient failure)"
 done
 

--- a/scripts/machine-setup/test-install-plugins-scope.sh
+++ b/scripts/machine-setup/test-install-plugins-scope.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# test-install-plugins-scope.sh — smoke tests for the --scope flag added to
+# scripts/machine-setup/install-plugins.sh (dual-scope install).
+#
+# Drives the real script in --dry-run so no plugin is actually installed,
+# and asserts the chosen scope threads through to BOTH the
+# `claude plugin marketplace add` and `claude plugin install` calls.
+#
+# install-plugins.ps1 carries the same -Scope param as a PowerShell
+# ValidateSet — that twin is NOT covered here; keep both in lockstep when
+# changing either (sanity-check with `pwsh install-plugins.ps1 -DryRun
+# -Scope project`).
+#
+# Covers:
+#   1. Default (no flag) → `--scope user` on install + marketplace add.
+#   2. `--scope project` → `--scope project` on both.
+#   3. Invalid `--scope bogus` → exit 2 (validation rejects before preflight).
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+script="$repo_root/scripts/machine-setup/install-plugins.sh"
+[ -f "$script" ] || { echo "FAIL: $script not found" >&2; exit 1; }
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# Test 3 first — validation runs before the claude/jq preflight, so it works
+# even on a host without the CLI.
+set +e
+out=$(bash "$script" --dry-run --scope bogus 2>&1); rc=$?
+set -e
+[ "$rc" -eq 2 ] || fail "invalid scope should exit 2, got $rc"
+printf '%s' "$out" | grep -q "invalid --scope: bogus" || fail "missing invalid-scope diagnostic"
+echo "ok: invalid scope rejected (exit 2)"
+
+# Tests 1 + 2 need the claude + jq preflight to pass.
+if ! command -v jq >/dev/null 2>&1 || ! command -v claude >/dev/null 2>&1; then
+    echo "SKIP: claude and/or jq not on PATH — dry-run scope assertions skipped"
+    echo "PASS (validation-only)"
+    exit 0
+fi
+
+assert_scope() {
+    local want="$1"; shift
+    local out; out=$(bash "$script" --dry-run "$@" 2>&1)
+    printf '%s' "$out" | grep -q "DRY: claude plugin marketplace add .* --scope $want" \
+        || fail "marketplace add missing --scope $want (args: $*)"
+    printf '%s' "$out" | grep -q "DRY: claude plugin install .* --scope $want" \
+        || fail "plugin install missing --scope $want (args: $*)"
+    echo "ok: scope '$want' threads through (args: ${*:-<default>})"
+}
+
+assert_scope user                      # default
+assert_scope project --scope project
+assert_scope local   --scope local
+
+echo "PASS"

--- a/scripts/machine-setup/ubuntu.sh
+++ b/scripts/machine-setup/ubuntu.sh
@@ -191,8 +191,19 @@ step "Rewrite git@github.com SSH URLs to HTTPS (public-repo clone fix)"
 
 step "Install Claude plugins from manifest"
 {
+  # Scope choice: user = ~/.claude (every project); project = this repo's
+  # .claude/settings.json (shared on clone). The third scope `local` is
+  # reachable only via install-plugins.sh --scope local, not this prompt.
+  # `|| true` so a non-interactive run (no TTY / EOF) falls through to the
+  # default instead of aborting.
+  read -r -p "Install plugins at [u]ser scope (all projects) or [p]roject scope (this repo only)? [default: user]: " PLUGIN_SCOPE_CHOICE || true
+  case "${PLUGIN_SCOPE_CHOICE:-u}" in
+    [Pp]*) PLUGIN_SCOPE="project" ;;
+    *)     PLUGIN_SCOPE="user" ;;
+  esac
+  echo "  → installing at $PLUGIN_SCOPE scope"
   bash "$HIMMEL_PATH/scripts/machine-setup/install-plugins.sh" \
-    --himmel-path "$HIMMEL_PATH"
+    --scope "$PLUGIN_SCOPE" --himmel-path "$HIMMEL_PATH"
 } || fail_nonfatal "install plugins from manifest"
 
 step "Clone Luna vault + install pre-commit hooks"

--- a/scripts/machine-setup/win11.ps1
+++ b/scripts/machine-setup/win11.ps1
@@ -212,9 +212,16 @@ Invoke-NonFatal "git insteadOf" {
 }
 
 Write-Step "Install Claude plugins from manifest"
+# Scope choice: user = ~/.claude (every project); project = this repo's
+# .claude/settings.json (shared on clone). The third scope `local` is
+# reachable only via install-plugins.ps1 -Scope local, not this prompt.
+# Empty input keeps the user default.
+$scopeRaw = Read-Host "Install plugins at [u]ser scope (all projects) or [p]roject scope (this repo only)? [default: user]"
+$PluginScope = if (-not [string]::IsNullOrWhiteSpace($scopeRaw) -and $scopeRaw.Trim() -match '^[Pp]') { 'project' } else { 'user' }
+Write-Host "  -> installing at $PluginScope scope"
 Invoke-NonFatal "install plugins from manifest" {
     & pwsh -NoProfile -File "$HimmelPath\scripts\machine-setup\install-plugins.ps1" `
-        -HimmelPath $HimmelPath
+        -Scope $PluginScope -HimmelPath $HimmelPath
 }
 
 Invoke-NonFatal "caveman Windows patch" {


### PR DESCRIPTION
Let a clone choose user vs project scope when installing the himmel marketplace + plugins, using the claude CLI's native `--scope user|project|local`.

- `install-plugins.{sh,ps1}`: add `--scope` / `-Scope` (default user, validated), threaded into both `marketplace add` and `install`.
- `ubuntu.sh` / `win11.ps1`: prompt user vs project at setup time (default user).
- `test-install-plugins-scope.sh`: dry-run smoke test (default/project/local thread through; invalid scope exits 2).
- Docs: `new-machine.md` §6 + `marketplace/README.md` document both scopes + remove/move; `CLAUDE.md` ships 4 general working principles for project-scope clones.

Verified: shellcheck clean + smoke test passes under Git Bash; PowerShell worker under Windows. Reviewed via multi-agent CR (0 actionable findings).

Platforms tested: windows, gitbash
Security reviewed: manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)