### PR TITLE
fix(jira): make himmel-jira plugin project-portable (no hardcoded HIMMEL/LUNA)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ JIRA_EMAIL=<your-email@example.com>
 JIRA_API_TOKEN=your_api_token_here
 # Example value — replace with YOUR Jira project key (e.g. ACME).
 JIRA_PROJECT_KEY=HIMMEL
+# Optional: extra projects whose metadata /jira-init caches (comma-list).
+# Defaults to JIRA_PROJECT_KEY alone.
+# JIRA_PROJECTS=ACME,BETA
 JIRA_CLOUD_ID=<your-cloud-id>
 ORGANIZATION_ID=your_org_id_here
 

--- a/plugins/himmel-jira/commands/jira-create.md
+++ b/plugins/himmel-jira/commands/jira-create.md
@@ -8,10 +8,11 @@ argument-hint: "<type> \"<title>\" [--parent KEY] [--desc \"...\"] [--attach pat
 
 ## Your task
 
-Resolve required fields for the type from the metadata cache:
+Resolve required fields for the type from the metadata cache (no `--project` —
+it resolves to the cache's `default_project`, set from your `JIRA_PROJECT_KEY`):
 
 ```
-node $CLAUDE_PROJECT_DIR/plugins/himmel-jira/lib/check-required.mjs --type "$1" --project HIMMEL
+node $CLAUDE_PROJECT_DIR/plugins/himmel-jira/lib/check-required.mjs --type "$1"
 ```
 
 If any required field is missing from the user's command, ask the user to supply it via AskUserQuestion. Then (note the regex now also matches the `(attachments: N)` suffix):
@@ -20,7 +21,7 @@ If any required field is missing from the user's command, ask the user to supply
 himmel-run jira \
   --summary-regex '^Created ([A-Z]+-\d+)' \
   --on-stderr-match 'field .* is required' \
-  --then-cmd-json '["node","'"$CLAUDE_PROJECT_DIR"'/plugins/himmel-jira/lib/init-cli.mjs","--discover","--projects","HIMMEL"]' \
+  --then-cmd-json '["node","'"$CLAUDE_PROJECT_DIR"'/plugins/himmel-jira/lib/init-cli.mjs","--discover"]' \
   -- node $CLAUDE_PROJECT_DIR/scripts/jira/dist/index.js create --type "$1" --title "$2" "${@:3}"
 ```
 

--- a/plugins/himmel-jira/commands/jira-init.md
+++ b/plugins/himmel-jira/commands/jira-init.md
@@ -15,5 +15,5 @@ description: "Bootstrap Jira auth (.env) + metadata cache (~/.cache/himmel-cli/j
      - `JIRA_API_TOKEN` — your Atlassian API token (do NOT echo back to the user).
      - `JIRA_BASE_URL` — your Jira cloud base URL, e.g. `https://<your-org>.atlassian.net` (no trailing slash).
    - Then run `node plugins/himmel-jira/lib/init-cli.mjs --write-env --email <e> --token <t> --base-url <url>` with whichever flags correspond to missing keys.
-2. Re-run `node plugins/himmel-jira/lib/init-cli.mjs --discover --projects HIMMEL,LUNA`. This writes the metadata cache.
+2. Re-run `node plugins/himmel-jira/lib/init-cli.mjs --discover`. This discovers the project(s) from `JIRA_PROJECT_KEY` (or `JIRA_PROJECTS=A,B` in `.env` to cache several) and writes the metadata cache. If no project is configured it exits 2 with a hint — set the key and re-run.
 3. Output the single one-line summary the command prints. Do NOT add commentary.

--- a/plugins/himmel-jira/commands/jira-list.md
+++ b/plugins/himmel-jira/commands/jira-list.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(himmel-run:*), Bash(node:*)
 description: List Jira issues in a project, optionally filtered by status. Returns one-line summary; full table in normal.log.
-argument-hint: "[project=HIMMEL] [status]"
+argument-hint: "[project] [status]"
 ---
 
 > **Note (Windows):** the body uses bash parameter expansion / subshell syntax. Claude Code's `Bash` tool invokes Git Bash on Windows — works as long as Git Bash is on PATH (which it is when this repo's `setup/win11.ps1` ran successfully).
@@ -11,7 +11,7 @@ argument-hint: "[project=HIMMEL] [status]"
 Run exactly:
 
 ```
-himmel-run jira --summary-regex '^(\d+) issues?' -- node $CLAUDE_PROJECT_DIR/scripts/jira/dist/index.js list --project $1 ${2:+--status "$2"}
+himmel-run jira --summary-regex '^(\d+) issues?' -- node $CLAUDE_PROJECT_DIR/scripts/jira/dist/index.js list ${1:+--project "$1"} ${2:+--status "$2"}
 ```
 
 Output only the runner's one-line summary. Do not add commentary. If the user asks for details, read `~/.cache/himmel-cli/jira/normal.log` (POSIX) / `%LOCALAPPDATA%\himmel-cli\jira\normal.log` (Windows) (latest entries at bottom) or run `himmel-run jira --inspect <run-id>`.

--- a/plugins/himmel-jira/commands/jira-refresh.md
+++ b/plugins/himmel-jira/commands/jira-refresh.md
@@ -6,7 +6,7 @@ description: Re-fetch Jira metadata cache (projects, issue types, transitions).
 ## Your task
 
 ```
-node $CLAUDE_PROJECT_DIR/plugins/himmel-jira/lib/init-cli.mjs --discover --projects HIMMEL,LUNA
+node $CLAUDE_PROJECT_DIR/plugins/himmel-jira/lib/init-cli.mjs --discover
 ```
 
 Output the one-line summary only.

--- a/plugins/himmel-jira/lib/init-cli.mjs
+++ b/plugins/himmel-jira/lib/init-cli.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { ensureEnvKeys, appendEnvKeys, runInit, loadEnvIntoProcess } from './init-flow.mjs';
+import { ensureEnvKeys, appendEnvKeys, runInit, loadEnvIntoProcess, resolveProjects } from './init-flow.mjs';
 import { envFilePath } from './jira-fetch.mjs';
 
 const args = Object.fromEntries(process.argv.slice(2).map((a, i, arr) => {
@@ -39,7 +39,16 @@ if (args['write-env']) {
 if (args.discover) {
   const envFile = envFilePath(args['env-path']);
   loadEnvIntoProcess(envFile);
-  const projects = (args.projects || 'HIMMEL').split(',');
+  // No hardcoded HIMMEL/LUNA — resolve the project(s) to cache from config so
+  // the plugin is portable for users who don't work on himmel (mirrors the
+  // CLI's HIMMEL-146 JIRA_PROJECT_KEY portability). resolveProjects honours
+  // --projects > JIRA_PROJECTS (comma-list) > JIRA_PROJECT_KEY. No project
+  // configured → fail loud, never silently default to HIMMEL.
+  const projects = resolveProjects({ rawArg: args.projects, env: process.env });
+  if (!projects.length) {
+    console.error('no project configured: set JIRA_PROJECT_KEY (or JIRA_PROJECTS=A,B for several) in your .env, then re-run');
+    process.exit(2);
+  }
   try {
     const res = await runInit({ projects });
     console.log(res.summary || 'OK');
@@ -50,5 +59,5 @@ if (args.discover) {
   }
 }
 
-console.error('usage: init-cli.mjs --check | --write-env --email E --token T | --discover --projects P,Q');
+console.error('usage: init-cli.mjs --check | --write-env --email E --token T | --discover [--projects P,Q]');
 process.exit(2);

--- a/plugins/himmel-jira/lib/init-flow.mjs
+++ b/plugins/himmel-jira/lib/init-flow.mjs
@@ -34,6 +34,19 @@ export function ensureEnvKeys(envPath, keys) {
   return keys.filter((k) => !current[k]);
 }
 
+// Resolve the project key(s) to discover, in precedence order:
+//   --projects flag  >  JIRA_PROJECTS (comma-list)  >  JIRA_PROJECT_KEY
+// Returns a clean array (whitespace trimmed, empties dropped). An empty array
+// means "nothing configured" — the caller must fail loud, never default to a
+// project. `rawArg` may be the boolean `true` when `--projects` is passed with
+// no value (arg parser quirk); coerce non-strings to '' so that misuse routes
+// to the empty-array path instead of a TypeError.
+export function resolveProjects({ rawArg, env = process.env } = {}) {
+  const raw = (typeof rawArg === 'string' ? rawArg : '')
+    || env.JIRA_PROJECTS || env.JIRA_PROJECT_KEY || '';
+  return raw.split(',').map((p) => p.trim()).filter(Boolean);
+}
+
 export const UNSAFE_VALUE_RE = /[=\n\r]|^["'](?!.*\1$)/;
 
 export function appendEnvKeys(envPath, kvs) {
@@ -70,7 +83,13 @@ export async function discoverMetadata(projectsToTrack) {
     process.stderr.write('[jira-init] warning: /project/search returned no projects\n');
     return out;
   }
-  const tracked = allProjects.filter((p) => projectsToTrack.includes(p.key));
+  // Order by the configured projectsToTrack (not the API's response order) so
+  // default_project is deterministic — it must equal the first configured key
+  // (= JIRA_PROJECT_KEY for single-project users) since check-required now
+  // resolves to default_project when --project is omitted.
+  const tracked = projectsToTrack
+    .map((k) => allProjects.find((p) => p.key === k))
+    .filter(Boolean);
   out.default_project = tracked[0]?.key;
   for (const p of tracked) {
     // Use paginated createmeta endpoints (old combined endpoint deprecated June 2024).
@@ -126,7 +145,10 @@ export async function autoFetchAccountId(email) {
   }
 }
 
-export async function runInit({ envOverride, projects = ['HIMMEL'], emails = [] } = {}) {
+export async function runInit({ envOverride, projects = [], emails = [] } = {}) {
+  if (!projects.length) {
+    throw new Error('runInit: no projects to discover — set JIRA_PROJECT_KEY (or JIRA_PROJECTS) and re-run');
+  }
   const envFile = envFilePath(envOverride);
   loadEnvIntoProcess(envFile);
   const missing = ensureEnvKeys(envFile, ['JIRA_EMAIL', 'JIRA_API_TOKEN', 'JIRA_BASE_URL']);

--- a/plugins/himmel-jira/skills/jira-list/SKILL.md
+++ b/plugins/himmel-jira/skills/jira-list/SKILL.md
@@ -3,4 +3,4 @@ name: jira-list
 description: Use when user asks to list, show, or enumerate Jira issues (e.g. "what jira tickets are open", "list HIMMEL stories", "show me in-progress jira"). MUST mention "jira" or a project key (HIMMEL, LUNA, etc.) or an explicit ticket pattern. Do NOT trigger on "list PRs", "show issues" without context, or GitHub references.
 ---
 
-Run `/jira-list <project> [status]` with the project and (optional) status the user mentioned. Default project is HIMMEL when not specified.
+Run `/jira-list [project] [status]` with the project and (optional) status the user mentioned. When no project is given, the CLI falls back to `JIRA_PROJECT_KEY`.

--- a/plugins/himmel-jira/tests/check-required.test.mjs
+++ b/plugins/himmel-jira/tests/check-required.test.mjs
@@ -63,6 +63,25 @@ describe('check-required', () => {
     expect(r.stdout).toContain('required: summary,issuetype');
   });
 
+  it('falls back to default_project when --project is omitted (portable: no hardcoded HIMMEL)', () => {
+    const env = cacheEnv(dir);
+    const meta = {
+      fetched_at: new Date().toISOString(),
+      default_project: 'ACME',
+      projects: {
+        ACME: {
+          issue_types: {
+            Task: { required_fields: ['summary'] },
+          },
+        },
+      },
+    };
+    writeStubMeta(dir, meta);
+    const r = run(['--type', 'Task'], env);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('required: summary');
+  });
+
   it('prints (cache stale...) to stderr when fetched_at is >30 days old', () => {
     const env = cacheEnv(dir);
     const fortyDaysAgo = new Date(Date.now() - 40 * 86400_000).toISOString();

--- a/plugins/himmel-jira/tests/discover-metadata.test.mjs
+++ b/plugins/himmel-jira/tests/discover-metadata.test.mjs
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Stub the network layer so discoverMetadata runs offline. /project/search
+// deliberately returns the projects in a DIFFERENT order than configured
+// (BETA before ACME) to prove default_project follows the configured order,
+// not the API response order.
+vi.mock('../lib/jira-fetch.mjs', () => ({
+  envFilePath: () => '/tmp/unused.env',
+  jiraFetch: vi.fn(async (_method, path) => {
+    if (path === '/project/search') {
+      return { values: [
+        { key: 'BETA', id: '2', name: 'Beta' },
+        { key: 'ACME', id: '1', name: 'Acme' },
+      ] };
+    }
+    if (path.includes('/issuetypes')) return { issueTypes: [] };
+    if (path.startsWith('/search')) return { issues: [] };
+    return {};
+  }),
+}));
+
+const { discoverMetadata } = await import('../lib/init-flow.mjs');
+
+describe('discoverMetadata default_project ordering', () => {
+  it('default_project follows configured order, not API response order', async () => {
+    const out = await discoverMetadata(['ACME', 'BETA']);
+    expect(out.default_project).toBe('ACME');
+    expect(Object.keys(out.projects)).toEqual(['ACME', 'BETA']);
+  });
+
+  it('drops a configured key the API does not return, default_project stays first-resolved', async () => {
+    const out = await discoverMetadata(['ACME', 'NOPE']);
+    expect(out.default_project).toBe('ACME');
+    expect(Object.keys(out.projects)).toEqual(['ACME']);
+  });
+});

--- a/plugins/himmel-jira/tests/init-cli.test.mjs
+++ b/plugins/himmel-jira/tests/init-cli.test.mjs
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const initCli = resolve(__dirname, '..', 'lib', 'init-cli.mjs');
+
+let emptyEnv;
+
+beforeEach(() => {
+  // An env file with no JIRA_* keys, so loadEnvIntoProcess sets nothing.
+  const dir = mkdtempSync(join(tmpdir(), 'himmel-initcli-'));
+  emptyEnv = join(dir, '.env');
+  writeFileSync(emptyEnv, '# no jira keys\n');
+});
+
+function discover(extraArgs, envOverrides) {
+  // Clear inherited JIRA_PROJECT* so the test machine's real env can't leak in.
+  const env = { ...process.env, JIRA_PROJECT_KEY: '', JIRA_PROJECTS: '', ...envOverrides };
+  return spawnSync(process.execPath, [initCli, '--discover', '--env-path', emptyEnv, ...extraArgs], {
+    encoding: 'utf8',
+    env,
+  });
+}
+
+describe('init-cli --discover project resolution (portability)', () => {
+  it('exits 2 with a hint when no project is configured (no HIMMEL default)', () => {
+    const r = discover([], {});
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain('no project configured');
+    expect(r.stderr).toContain('JIRA_PROJECT_KEY');
+    // Must NOT silently fall back to the himmel project.
+    expect(r.stderr).not.toContain('HIMMEL');
+  });
+});

--- a/plugins/himmel-jira/tests/init-flow.test.mjs
+++ b/plugins/himmel-jira/tests/init-flow.test.mjs
@@ -2,10 +2,50 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { mkdtempSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { ensureEnvKeys, appendEnvKeys, UNSAFE_VALUE_RE, loadEnvIntoProcess } from '../lib/init-flow.mjs';
+import { ensureEnvKeys, appendEnvKeys, UNSAFE_VALUE_RE, loadEnvIntoProcess, resolveProjects, runInit } from '../lib/init-flow.mjs';
 
 let dir;
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'himmel-init-')); });
+
+describe('resolveProjects (config-driven, no hardcoded HIMMEL)', () => {
+  it('uses JIRA_PROJECT_KEY when no flag and no JIRA_PROJECTS', () => {
+    expect(resolveProjects({ env: { JIRA_PROJECT_KEY: 'ACME' } })).toEqual(['ACME']);
+  });
+
+  it('prefers --projects flag over both env vars', () => {
+    const env = { JIRA_PROJECTS: 'X,Y', JIRA_PROJECT_KEY: 'Z' };
+    expect(resolveProjects({ rawArg: 'ACME', env })).toEqual(['ACME']);
+  });
+
+  it('prefers JIRA_PROJECTS over JIRA_PROJECT_KEY', () => {
+    const env = { JIRA_PROJECTS: 'A,B', JIRA_PROJECT_KEY: 'Z' };
+    expect(resolveProjects({ env })).toEqual(['A', 'B']);
+  });
+
+  it('splits a comma-list and trims whitespace / drops empties', () => {
+    expect(resolveProjects({ rawArg: ' A , ,B, ' })).toEqual(['A', 'B']);
+  });
+
+  it('returns [] when nothing is configured (caller fails loud)', () => {
+    expect(resolveProjects({ env: {} })).toEqual([]);
+  });
+
+  it('treats an empty-string env value as unset', () => {
+    expect(resolveProjects({ env: { JIRA_PROJECT_KEY: '' } })).toEqual([]);
+  });
+
+  it('coerces a valueless --projects (boolean true) to [] instead of throwing', () => {
+    // arg parser maps `--projects` with no value to `true`; must not crash.
+    expect(() => resolveProjects({ rawArg: true, env: {} })).not.toThrow();
+    expect(resolveProjects({ rawArg: true, env: {} })).toEqual([]);
+  });
+});
+
+describe('runInit project guard (defense in depth)', () => {
+  it('rejects when called with no projects (no network)', async () => {
+    await expect(runInit({ projects: [] })).rejects.toThrow(/no projects/);
+  });
+});
 
 describe('ensureEnvKeys', () => {
   it('returns all keys when file missing', () => {


### PR DESCRIPTION
## Make the himmel-jira plugin project-portable

The bundled Jira CLI already resolves the project from `JIRA_PROJECT_KEY` (portable across repos/projects), but the **himmel-jira plugin wrapper** hardcoded the maintainer's `HIMMEL`/`LUNA` project keys. A user who installs the plugin for their own Jira project got `HIMMEL` suggested when filing tickets, and `LUNA` assumed for vault work — projects they don't have.

### Changes
- Project(s) for `--discover` now resolve via a new exported, unit-tested `resolveProjects()` helper — precedence `--projects` > `JIRA_PROJECTS` (comma-list) > `JIRA_PROJECT_KEY`. **No project configured → exit 2 with a hint**, never a silent `HIMMEL` default.
- `runInit` drops the `['HIMMEL']` default and throws if empty (defense in depth).
- `/jira-create` drops the `--project HIMMEL` literals (falls back to the cache's `default_project`); `/jira-init` and `/jira-refresh` discover from config; `/jira-list` omits `--project` when none given (CLI falls back to `JIRA_PROJECT_KEY`).
- `discoverMetadata` orders tracked projects by configured order so `default_project` is deterministic.
- `.env.example` documents the optional `JIRA_PROJECTS` (comma-list) var.

### Tests
63 plugin tests pass (+10): `resolveProjects` precedence/comma-split/whitespace/valueless-flag guard, `runInit` empty-projects guard, `init-cli` exit-2 (asserts no `HIMMEL` leak), `check-required` default_project fallback, and `discoverMetadata` ordering (offline-mocked, fails on revert to API order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
