### PR TITLE
feat(statusline): [HIMMEL-331] vendor claude-statusline into himmel + rewire setup to in-repo copy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,10 @@ repos:
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1
     hooks:
+      # Vendored statusline (HIMMEL-331) is kept byte-identical to the
+      # yotamleo/claude-statusline fork — don't lint third-party code.
       - id: shellcheck
+        exclude: '^scripts/statusline/'
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.2

--- a/docs/setup/settings-template.json
+++ b/docs/setup/settings-template.json
@@ -56,7 +56,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bash \"<statusline-path>/bin/statusline.sh\""
+    "command": "bash \"<himmel-path>/scripts/statusline/bin/statusline.sh\""
   },
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true,

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -227,16 +227,15 @@ On every new session: writes `~/.claude/.caveman-active` flag, emits the full ca
 
 ---
 
-## claude-statusline (yotamleo fork)
+## claude-statusline (vendored, HIMMEL-331)
 
-**Repo:** `yotamleo/claude-statusline` (fork of `nilbuild/claude-statusline`)
-**Path:** `C:\Users\<user>\Documents\github\claude-statusline\`
-**Script:** `bin/statusline.sh`
-**Config:** `~/.claude/settings.json` → `statusLine.command`
+**Vendored in himmel:** `scripts/statusline/` (`bin/statusline.sh`, `test/`, `LICENSE`, `README.md`, provenance in `VENDORED.md`).
+**Config:** `~/.claude/settings.json` → `statusLine.command` (machine-setup points it at `<himmel-path>/scripts/statusline/bin/statusline.sh` — no external clone).
 **What:** Bash script receiving Claude Code session JSON via stdin, outputs formatted status bar.
 
 Displays: model, context %, git branch, rate-limit bars (current/weekly/extra), cache TTL countdown, per-session and all-sessions cache read/write/hit/savings.
 
+**Source fork:** `yotamleo/claude-statusline` (fork of `nilbuild/claude-statusline`) — kept as upstream-tracking source; edits to the vendored script are pushed back to the fork so both mirror.
 **Patch applied:** `docs/patches/2026-05-16-cache-statusline.md`
 **Upstream:** `nilbuild/claude-statusline` (PR not yet opened)
 

--- a/scripts/machine-setup/ubuntu.sh
+++ b/scripts/machine-setup/ubuntu.sh
@@ -19,7 +19,7 @@ fi
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # shellcheck disable=SC2034
 HIMMEL_PATH="$HOME/github/himmel"
-STATUSLINE_PATH="$HOME/github/claude-statusline"
+STATUSLINE_PATH="$HIMMEL_PATH/scripts/statusline"  # vendored in himmel (HIMMEL-331)
 LUNA_VAULT_PATH="$HOME/Documents/luna"
 CLAUDE_DIR="$HOME/.claude"
 
@@ -31,7 +31,7 @@ mkdir -p "$HOME/.local/bin"
 export PATH="$HOME/.local/bin:$PATH"
 
 # ── Progress ────────────────────────────────────────────────────────────────
-TOTAL_STEPS=20
+TOTAL_STEPS=19
 STEP=0
 FAILURES=()
 
@@ -151,11 +151,7 @@ ln -sf "$HIMMEL_PATH/scripts/himmel-run/bin/himmel-run" "$HOME/.local/bin/himmel
 # Non-fatal from here — failures logged but don't abort
 set +e
 
-step "Clone claude-statusline"
-{
-  mkdir -p "$(dirname "$STATUSLINE_PATH")"
-  git clone https://github.com/yotamleo/claude-statusline.git "$STATUSLINE_PATH"
-} || fail_nonfatal "clone statusline"
+# statusline is vendored at $HIMMEL_PATH/scripts/statusline (HIMMEL-331) — no clone needed.
 
 step "Copy Claude config"
 {

--- a/scripts/machine-setup/win11.ps1
+++ b/scripts/machine-setup/win11.ps1
@@ -8,13 +8,13 @@ $ErrorActionPreference = 'Stop'
 
 # ── Paths ───────────────────────────────────────────────────────────────────
 $HimmelPath     = "$env:USERPROFILE\Documents\github\himmel"
-$StatuslinePath = "$env:USERPROFILE\Documents\github\claude-statusline"
+$StatuslinePath = "$HimmelPath\scripts\statusline"  # vendored in himmel (HIMMEL-331)
 $LunaVaultPath  = "$env:USERPROFILE\Documents\luna"
 $ClaudeDir      = "$env:USERPROFILE\.claude"
 $RepoRoot       = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 
 # ── Progress ────────────────────────────────────────────────────────────────
-$TotalSteps = 19
+$TotalSteps = 18
 $Script:Step = 0
 $Script:Failures = @()
 
@@ -167,12 +167,7 @@ if ($UserPath -notlike "*$BinDir*") {
 }
 
 # ── Non-fatal steps (9–16) ──────────────────────────────────────────────────
-Write-Step "Clone claude-statusline"
-Invoke-NonFatal "clone statusline" {
-    $StatuslineParent = Split-Path $StatuslinePath -Parent
-    New-Item -ItemType Directory -Force $StatuslineParent | Out-Null
-    git clone https://github.com/yotamleo/claude-statusline.git $StatuslinePath
-}
+# statusline is vendored at $HimmelPath\scripts\statusline (HIMMEL-331) — no clone needed.
 
 Write-Step "Copy Claude config"
 Invoke-NonFatal "copy Claude config" {

--- a/scripts/statusline/LICENSE
+++ b/scripts/statusline/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kamran Ahmed
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/statusline/README.md
+++ b/scripts/statusline/README.md
@@ -1,0 +1,39 @@
+# claude-statusline
+
+Configure your Claude Code statusline to show limits, directory and git info
+
+![demo](./.github/demo.png)
+
+## Install
+
+Run the command below to set it up
+
+```bash
+npx @kamranahmedse/claude-statusline
+```
+
+It backups your old status line if any and copies the status line script to `~/.claude/statusline.sh` and configures your Claude Code settings.
+
+## Requirements
+
+- [jq](https://jqlang.github.io/jq/) — for parsing JSON
+- curl — for fetching rate limit data
+- git — for branch info
+
+On macOS:
+
+```bash
+brew install jq
+```
+
+## Uninstall
+
+```bash
+npx @kamranahmedse/claude-statusline --uninstall
+```
+
+If you had a previous statusline, it restores it from the backup. Otherwise it removes the script and cleans up your settings.
+
+## License
+
+MIT

--- a/scripts/statusline/VENDORED.md
+++ b/scripts/statusline/VENDORED.md
@@ -1,0 +1,36 @@
+# Vendored: claude-statusline
+
+This directory is a **vendored copy** of the statusline, bound into himmel so
+that himmel (and public-himmel) users get the status bar without cloning an
+external repo or hand-editing global `~/.claude/settings.json`.
+
+- **Source fork:** `yotamleo/claude-statusline` (origin)
+- **Upstream:** `nilbuild/claude-statusline` (`Kamran Ahmed`, MIT — see `LICENSE`)
+- **Vendored at commit:** `dd68f9b` (`fix(cache): incremental all-sessions scan + hide stale cache tier`)
+- **himmel cache-metrics patch:** `docs/patches/2026-05-16-cache-statusline.md`
+
+## What's here
+
+| File | Purpose |
+|------|---------|
+| `bin/statusline.sh` | The status line script. Self-contained; reads Claude Code's stdin JSON, manages its own cache under `/tmp/claude`. |
+| `test/test_cache.sh` | Cache-metrics test harness (the suite is the source of truth for the count). Run: `bash test/test_cache.sh`. Note: a few cache-healing cases read the live `/tmp/claude` usage cache, so they can report spurious failures on a machine with active Claude sessions; run against a clean `/tmp/claude` for a hermetic pass. |
+| `LICENSE` | MIT, retained for attribution. |
+| `README.md` | Upstream README (kept identical to the fork). |
+
+Runtime deps: `jq`, `curl`, `git`. Not vendored from the fork: its own dev git
+hooks (`scripts/hooks/`) and the npm installer (`bin/install.js`) — himmel
+references the script directly rather than npm-installing it.
+
+## Wiring
+
+`docs/setup/settings-template.json` and `scripts/machine-setup/{win11.ps1,ubuntu.sh}`
+point `statusLine.command` at `<himmel-path>/scripts/statusline/bin/statusline.sh`.
+There is no longer an external clone step.
+
+## Keeping in sync with the fork
+
+This copy is the deployed artifact. **Edits to `bin/statusline.sh` here must be
+pushed back to `yotamleo/claude-statusline`** so the fork mirrors the
+himmel-bound version (and stays a viable standalone / upstream-tracking repo).
+Pull upstream `nilbuild` fixes into the fork first, then re-vendor here.

--- a/scripts/statusline/bin/statusline.sh
+++ b/scripts/statusline/bin/statusline.sh
@@ -1,0 +1,783 @@
+#!/bin/bash
+set -f
+
+input=$(cat)
+
+if [ -z "$input" ]; then
+    printf "Claude"
+    exit 0
+fi
+
+# ── Colors ──────────────────────────────────────────────
+blue='\033[38;2;0;153;255m'
+orange='\033[38;2;255;176;85m'
+green='\033[38;2;0;175;80m'
+cyan='\033[38;2;86;182;194m'
+red='\033[38;2;255;85;85m'
+yellow='\033[38;2;230;200;0m'
+white='\033[38;2;220;220;220m'
+magenta='\033[38;2;180;140;255m'
+dim='\033[2m'
+reset='\033[0m'
+
+sep=" ${dim}│${reset} "
+
+# ── Helpers ─────────────────────────────────────────────
+color_for_pct() {
+    local pct=$1
+    if [ "$pct" -ge 90 ]; then printf "$red"
+    elif [ "$pct" -ge 70 ]; then printf "$yellow"
+    elif [ "$pct" -ge 50 ]; then printf "$orange"
+    else printf "$green"
+    fi
+}
+
+build_bar() {
+    local pct=$1
+    local width=$2
+    [ "$pct" -lt 0 ] 2>/dev/null && pct=0
+    [ "$pct" -gt 100 ] 2>/dev/null && pct=100
+
+    local filled=$(( pct * width / 100 ))
+    local empty=$(( width - filled ))
+    local bar_color
+    bar_color=$(color_for_pct "$pct")
+
+    local filled_str="" empty_str=""
+    for ((i=0; i<filled; i++)); do filled_str+="●"; done
+    for ((i=0; i<empty; i++)); do empty_str+="○"; done
+
+    printf "${bar_color}${filled_str}${dim}${empty_str}${reset}"
+}
+
+format_epoch_time() {
+    local epoch=$1
+    local style=$2
+    [ -z "$epoch" ] || [ "$epoch" = "null" ] || [ "$epoch" = "0" ] && return
+
+    local result=""
+    case "$style" in
+        time)
+            result=$(date -j -r "$epoch" +"%l:%M%p" 2>/dev/null)
+            [ -z "$result" ] && result=$(date -d "@$epoch" +"%l:%M%P" 2>/dev/null)
+            result=$(echo "$result" | sed 's/^ //; s/\.//g' | tr '[:upper:]' '[:lower:]')
+            ;;
+        datetime)
+            result=$(date -j -r "$epoch" +"%b %-d, %l:%M%p" 2>/dev/null)
+            [ -z "$result" ] && result=$(date -d "@$epoch" +"%b %-d, %l:%M%P" 2>/dev/null)
+            result=$(echo "$result" | sed 's/  / /g; s/^ //; s/\.//g' | tr '[:upper:]' '[:lower:]')
+            ;;
+        *)
+            result=$(date -j -r "$epoch" +"%b %-d" 2>/dev/null)
+            [ -z "$result" ] && result=$(date -d "@$epoch" +"%b %-d" 2>/dev/null)
+            result=$(echo "$result" | tr '[:upper:]' '[:lower:]')
+            ;;
+    esac
+    printf "%s" "$result"
+}
+
+iso_to_epoch() {
+    local iso_str="$1"
+
+    local epoch
+    epoch=$(date -d "${iso_str}" +%s 2>/dev/null)
+    if [ -n "$epoch" ]; then
+        echo "$epoch"
+        return 0
+    fi
+
+    local stripped="${iso_str%%.*}"
+    stripped="${stripped%%Z}"
+    stripped="${stripped%%+*}"
+    stripped="${stripped%%-[0-9][0-9]:[0-9][0-9]}"
+
+    if [[ "$iso_str" == *"Z"* ]] || [[ "$iso_str" == *"+00:00"* ]] || [[ "$iso_str" == *"-00:00"* ]]; then
+        epoch=$(env TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$stripped" +%s 2>/dev/null)
+        [ -z "$epoch" ] && epoch=$(env TZ=UTC date -d "${stripped/T/ }" +%s 2>/dev/null)
+    else
+        epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$stripped" +%s 2>/dev/null)
+        [ -z "$epoch" ] && epoch=$(date -d "${stripped/T/ }" +%s 2>/dev/null)
+    fi
+
+    if [ -n "$epoch" ]; then
+        echo "$epoch"
+        return 0
+    fi
+
+    return 1
+}
+
+epoch_to_iso() {
+    local epoch="$1"
+    [ -z "$epoch" ] || [ "$epoch" = "null" ] || [ "$epoch" = "0" ] && return
+
+    if [[ ! "$epoch" =~ ^[0-9]+$ ]]; then
+        # Pass through only if it already looks ISO-shaped; anything else
+        # (fractional epochs, garbage) would leak a non-ISO resets_at into
+        # the cache schema — emit nothing so the caller stores null.
+        [[ "$epoch" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]] && printf "%s" "$epoch"
+        return
+    fi
+
+    local iso
+    iso=$(date -u -d "@${epoch}" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)
+    [ -z "$iso" ] && iso=$(date -u -r "$epoch" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)
+    printf "%s" "$iso"
+}
+
+# Append a one-line failure breadcrumb to the debug log. Capped at ~100KB
+# (truncate-on-overflow) because the failure modes it logs repeat every
+# render — a stuck mv on the shared cache must not fill /tmp over a long
+# session. Known blind spot: if /tmp/claude itself is unwritable, the
+# cache write AND this breadcrumb vanish together — there is nowhere
+# else for a statusline to report, so the log is not a complete record.
+cache_breadcrumb() {
+    local log="/tmp/claude/statusline-debug.log"
+    [ -f "$log" ] && [ "$(wc -c < "$log" 2>/dev/null || echo 0)" -gt 100000 ] && : > "$log"
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) cache-write failed: $1" >> "$log" 2>/dev/null
+}
+
+# ── Extract JSON data ───────────────────────────────────
+model_name=$(echo "$input" | jq -r '.model.display_name // "Claude"')
+model_id=$(echo "$input" | jq -r '.model.id // "claude-sonnet"')
+transcript_path=$(echo "$input" | jq -r '.transcript_path // ""')
+session_cost=$(echo "$input" | jq -r '.cost.total_cost_usd // ""')
+
+size=$(echo "$input" | jq -r '.context_window.context_window_size // 200000')
+[ "$size" -eq 0 ] 2>/dev/null && size=200000
+
+input_tokens=$(echo "$input" | jq -r '.context_window.current_usage.input_tokens // 0')
+cache_create=$(echo "$input" | jq -r '.context_window.current_usage.cache_creation_input_tokens // 0')
+cache_read=$(echo "$input" | jq -r '.context_window.current_usage.cache_read_input_tokens // 0')
+current=$(( input_tokens + cache_create + cache_read ))
+
+if [ "$size" -gt 0 ]; then
+    pct_used=$(( current * 100 / size ))
+else
+    pct_used=0
+fi
+
+effort="default"
+settings_path="$HOME/.claude/settings.json"
+if [ -f "$settings_path" ]; then
+    effort=$(jq -r '.effortLevel // "default"' "$settings_path" 2>/dev/null)
+fi
+
+# ── LINE 1: Model │ Context % │ Directory (branch) │ Session │ Effort ──
+pct_color=$(color_for_pct "$pct_used")
+cwd=$(echo "$input" | jq -r '.cwd // ""')
+[ -z "$cwd" ] || [ "$cwd" = "null" ] && cwd=$(pwd)
+dirname=$(basename "$cwd")
+
+git_branch=""
+git_dirty=""
+if git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git_branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null)
+    if [ -n "$(git -C "$cwd" --no-optional-locks status --porcelain 2>/dev/null)" ]; then
+        git_dirty="*"
+    fi
+fi
+
+session_duration=""
+session_start=$(echo "$input" | jq -r '.session.start_time // empty')
+if [ -n "$session_start" ] && [ "$session_start" != "null" ]; then
+    start_epoch=$(iso_to_epoch "$session_start")
+    if [ -n "$start_epoch" ]; then
+        now_epoch=$(date +%s)
+        elapsed=$(( now_epoch - start_epoch ))
+        if [ "$elapsed" -ge 3600 ]; then
+            session_duration="$(( elapsed / 3600 ))h$(( (elapsed % 3600) / 60 ))m"
+        elif [ "$elapsed" -ge 60 ]; then
+            session_duration="$(( elapsed / 60 ))m"
+        else
+            session_duration="${elapsed}s"
+        fi
+    fi
+fi
+
+skip_perms=""
+parent_cmd=$(ps -o args= -p "$PPID" 2>/dev/null)
+if [[ "$parent_cmd" == *"--dangerously-skip-permissions"* ]]; then
+    skip_perms="⚡  "
+fi
+
+line1="${blue}${model_name}${reset}"
+line1+="${sep}"
+line1+="✍️ ${pct_color}${pct_used}%${reset}"
+line1+="${sep}"
+line1+="${skip_perms}${cyan}${dirname}${reset}"
+if [ -n "$git_branch" ]; then
+    line1+=" ${green}(${git_branch}${red}${git_dirty}${green})${reset}"
+fi
+if [ -n "$session_duration" ]; then
+    line1+="${sep}"
+    line1+="${dim}⏱ ${reset}${white}${session_duration}${reset}"
+fi
+line1+="${sep}"
+case "$effort" in
+    high)   line1+="${magenta}● ${effort}${reset}" ;;
+    medium) line1+="${dim}◑ ${effort}${reset}" ;;
+    low)    line1+="${dim}◔ ${effort}${reset}" ;;
+    *)      line1+="${dim}◑ ${effort}${reset}" ;;
+esac
+
+# ── Rate limits from stdin (primary) ───────────────────
+has_stdin_rates=false
+five_hour_pct=""
+five_hour_reset_epoch=""
+seven_day_pct=""
+seven_day_reset_epoch=""
+
+stdin_five_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+stdin_seven_pct=""
+if [ -n "$stdin_five_pct" ]; then
+    has_stdin_rates=true
+    five_hour_pct=$(printf "%.0f" "$stdin_five_pct")
+    five_hour_reset_epoch=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+    stdin_seven_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+    seven_day_pct=$(printf "%s" "$stdin_seven_pct" | awk '{printf "%.0f", $1}')
+    seven_day_reset_epoch=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
+fi
+
+# ── Fallback: API call (cached) ────────────────────────
+cache_file="/tmp/claude/statusline-usage-cache.json"
+cache_max_age=60
+mkdir -p /tmp/claude
+
+usage_data=""
+extra_enabled="false"
+
+if ! $has_stdin_rates; then
+    needs_refresh=true
+
+    if [ -f "$cache_file" ]; then
+        cache_mtime=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null)
+        now=$(date +%s)
+        cache_age=$(( now - cache_mtime ))
+        if [ "$cache_age" -lt "$cache_max_age" ]; then
+            needs_refresh=false
+            usage_data=$(cat "$cache_file" 2>/dev/null)
+        fi
+    fi
+
+    if $needs_refresh; then
+        token=""
+        if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            token="$CLAUDE_CODE_OAUTH_TOKEN"
+        elif command -v security >/dev/null 2>&1; then
+            blob=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)
+            if [ -n "$blob" ]; then
+                token=$(echo "$blob" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+            fi
+        fi
+        if [ -z "$token" ] || [ "$token" = "null" ]; then
+            creds_file="${HOME}/.claude/.credentials.json"
+            if [ -f "$creds_file" ]; then
+                token=$(jq -r '.claudeAiOauth.accessToken // empty' "$creds_file" 2>/dev/null)
+            fi
+        fi
+        if [ -z "$token" ] || [ "$token" = "null" ]; then
+            if command -v secret-tool >/dev/null 2>&1; then
+                blob=$(timeout 2 secret-tool lookup service "Claude Code-credentials" 2>/dev/null)
+                if [ -n "$blob" ]; then
+                    token=$(echo "$blob" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+                fi
+            fi
+        fi
+
+        if [ -n "$token" ] && [ "$token" != "null" ]; then
+            response=$(curl -s --max-time 5 \
+                -H "Accept: application/json" \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $token" \
+                -H "anthropic-beta: oauth-2025-04-20" \
+                -H "User-Agent: claude-code/2.1.34" \
+                "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
+            if [ -n "$response" ] && echo "$response" | jq -e '.five_hour' >/dev/null 2>&1; then
+                usage_data="$response"
+                # Atomic tmp+mv — a reader hitting a torn write would treat
+                # the cache as corrupt and silently drop extra_usage.
+                tmp_cache="${cache_file}.$$.tmp"
+                api_write_fail=""
+                if echo "$response" > "$tmp_cache" 2>/dev/null; then
+                    mv -f "$tmp_cache" "$cache_file" 2>/dev/null \
+                        || { rm -f "$tmp_cache" 2>/dev/null; api_write_fail="api-mv"; }
+                else
+                    rm -f "$tmp_cache" 2>/dev/null
+                    api_write_fail="api-tmp-write"
+                fi
+                [ -n "$api_write_fail" ] && cache_breadcrumb "$api_write_fail"
+            fi
+        fi
+        if [ -z "$usage_data" ] && [ -f "$cache_file" ]; then
+            usage_data=$(cat "$cache_file" 2>/dev/null)
+        fi
+    fi
+
+    if [ -n "$usage_data" ] && echo "$usage_data" | jq -e . >/dev/null 2>&1; then
+        five_hour_pct=$(echo "$usage_data" | jq -r '.five_hour.utilization // 0' | awk '{printf "%.0f", $1}')
+        five_hour_reset_iso=$(echo "$usage_data" | jq -r '.five_hour.resets_at // empty')
+        five_hour_reset_epoch=$(iso_to_epoch "$five_hour_reset_iso")
+        seven_day_pct=$(echo "$usage_data" | jq -r '.seven_day.utilization // 0' | awk '{printf "%.0f", $1}')
+        seven_day_reset_iso=$(echo "$usage_data" | jq -r '.seven_day.resets_at // empty')
+        seven_day_reset_epoch=$(iso_to_epoch "$seven_day_reset_iso")
+
+        extra_enabled=$(echo "$usage_data" | jq -r '.extra_usage.is_enabled // false')
+    fi
+else
+    if [ -f "$cache_file" ]; then
+        usage_data=$(cat "$cache_file" 2>/dev/null)
+        # Require an object, not just valid JSON — a bare string/number/array
+        # would make the ($prev // {}) + {} merge below a type error on every
+        # render, freezing the cache permanently.
+        if [ -n "$usage_data" ] && echo "$usage_data" | jq -e 'type == "object"' >/dev/null 2>&1; then
+            extra_enabled=$(echo "$usage_data" | jq -r '.extra_usage.is_enabled // false')
+        else
+            usage_data=""
+        fi
+    fi
+
+    # Keep the cache fresh from stdin rates. During live sessions stdin
+    # carries rate_limits, so the API branch above never runs — without
+    # this write the cache freezes at its last pre-session value for the
+    # whole session (external consumers read this file). Same schema as
+    # the API response (utilization + ISO resets_at), same 60s throttle,
+    # atomic tmp+mv so concurrent sessions never leave a torn file.
+    needs_refresh=true
+    if [ -f "$cache_file" ]; then
+        cache_mtime=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo 0)
+        now=$(date +%s)
+        cache_age=$(( now - cache_mtime ))
+        [ "$cache_age" -lt "$cache_max_age" ] && needs_refresh=false
+    fi
+
+    if $needs_refresh; then
+        five_hour_reset_iso=$(epoch_to_iso "$five_hour_reset_epoch")
+        seven_day_reset_iso=$(epoch_to_iso "$seven_day_reset_epoch")
+        # Per-field tonumber? guards: one malformed field (e.g. "63%") must
+        # degrade to null, not abort the whole jq program and lose the write.
+        stdin_cache=$(jq -n \
+            --argjson prev "${usage_data:-null}" \
+            --arg fh_util "$stdin_five_pct" \
+            --arg fh_reset "$five_hour_reset_iso" \
+            --arg sd_util "$stdin_seven_pct" \
+            --arg sd_reset "$seven_day_reset_iso" \
+            '($prev // {}) +
+             { five_hour: { utilization: ($fh_util | tonumber? // null),
+                            resets_at: (if $fh_reset == "" then null else $fh_reset end) } } +
+             (if $sd_util == "" then {} else
+               { seven_day: { utilization: ($sd_util | tonumber? // null),
+                              resets_at: (if $sd_reset == "" then null else $sd_reset end) } } end)' \
+            2>/dev/null)
+        write_fail=""
+        if [ -n "$stdin_cache" ]; then
+            tmp_cache="${cache_file}.$$.tmp"
+            if echo "$stdin_cache" > "$tmp_cache" 2>/dev/null; then
+                mv -f "$tmp_cache" "$cache_file" 2>/dev/null \
+                    || { rm -f "$tmp_cache" 2>/dev/null; write_fail="mv"; }
+            else
+                rm -f "$tmp_cache" 2>/dev/null
+                write_fail="tmp-write"
+            fi
+        else
+            write_fail="jq-build"
+        fi
+        # Breadcrumb on failure — otherwise "no write" here is field-
+        # indistinguishable from the frozen-cache bug this branch fixes.
+        [ -n "$write_fail" ] && cache_breadcrumb "stdin-${write_fail}"
+    fi
+fi
+
+# ── Rate limit lines ────────────────────────────────────
+rate_lines=""
+cache_lines=""
+bar_width=10
+
+if [ -n "$five_hour_pct" ]; then
+    five_hour_reset=$(format_epoch_time "$five_hour_reset_epoch" "time")
+    five_hour_bar=$(build_bar "$five_hour_pct" "$bar_width")
+    five_hour_pct_color=$(color_for_pct "$five_hour_pct")
+    five_hour_pct_fmt=$(printf "%3d" "$five_hour_pct")
+
+    rate_lines+="${white}current${reset} ${five_hour_bar} ${five_hour_pct_color}${five_hour_pct_fmt}%${reset}"
+    [ -n "$five_hour_reset" ] && rate_lines+=" ${dim}⟳${reset} ${white}${five_hour_reset}${reset}"
+fi
+
+if [ -n "$seven_day_pct" ]; then
+    seven_day_reset=$(format_epoch_time "$seven_day_reset_epoch" "datetime")
+    seven_day_bar=$(build_bar "$seven_day_pct" "$bar_width")
+    seven_day_pct_color=$(color_for_pct "$seven_day_pct")
+    seven_day_pct_fmt=$(printf "%3d" "$seven_day_pct")
+
+    [ -n "$rate_lines" ] && rate_lines+="\n"
+    rate_lines+="${white}weekly${reset}  ${seven_day_bar} ${seven_day_pct_color}${seven_day_pct_fmt}%${reset}"
+    [ -n "$seven_day_reset" ] && rate_lines+=" ${dim}⟳${reset} ${white}${seven_day_reset}${reset}"
+fi
+
+if [ "$extra_enabled" = "true" ] && [ -n "$usage_data" ]; then
+    extra_pct=$(echo "$usage_data" | jq -r '.extra_usage.utilization // 0' | awk '{printf "%.0f", $1}')
+    extra_used=$(echo "$usage_data" | jq -r '.extra_usage.used_credits // 0' | awk '{printf "%.2f", $1/100}')
+    extra_limit=$(echo "$usage_data" | jq -r '.extra_usage.monthly_limit // 0' | awk '{printf "%.2f", $1/100}')
+    extra_bar=$(build_bar "$extra_pct" "$bar_width")
+    extra_pct_color=$(color_for_pct "$extra_pct")
+
+    extra_reset=$(date -v+1m -v1d +"%b %-d" 2>/dev/null | tr '[:upper:]' '[:lower:]')
+    if [ -z "$extra_reset" ]; then
+        extra_reset=$(date -d "$(date +%Y-%m-01) +1 month" +"%b %-d" 2>/dev/null | tr '[:upper:]' '[:lower:]')
+    fi
+
+    [ -n "$rate_lines" ] && rate_lines+="\n"
+    rate_lines+="${white}extra${reset}   ${extra_bar} ${extra_pct_color}\$${extra_used}${dim}/${reset}${white}\$${extra_limit}${reset} ${dim}⟳${reset} ${white}${extra_reset}${reset}"
+fi
+
+# ── Cache metrics functions ──────────────────────────────
+format_tokens() {
+    local n="${1:-0}"
+    [[ "$n" =~ ^[0-9]+$ ]] || n=0
+    if   [ "$n" -ge 1000000 ]; then awk -v n="$n" 'BEGIN{printf "%.1fM", n/1000000}'
+    elif [ "$n" -ge 1000 ];    then awk -v n="$n" 'BEGIN{printf "%.0fk", n/1000}'
+    else printf "%s" "$n"
+    fi
+}
+# Sets read_savings_rate and write_overhead_rate (USD per token, float)
+get_model_savings_rate() {
+    local model_id="${1:-claude-sonnet}"
+    local input_price cache_read_price cache_write_price
+    case "$model_id" in
+        claude-opus*)   input_price=15.00; cache_read_price=1.50;  cache_write_price=30.00 ;;
+        claude-haiku*)  input_price=0.80;  cache_read_price=0.08;  cache_write_price=1.60  ;;
+        claude-sonnet*) input_price=3.00;  cache_read_price=0.30;  cache_write_price=6.00  ;;
+        *)              input_price=3.00;  cache_read_price=0.30;  cache_write_price=6.00  ;;
+    esac
+    read_savings_rate=$(awk  -v i="$input_price" -v r="$cache_read_price"  'BEGIN{printf "%.8f",(i-r)/1000000}')
+    write_overhead_rate=$(awk -v w="$cache_write_price" -v i="$input_price" 'BEGIN{printf "%.8f",(w-i)/1000000}')
+}
+# Sets cache_ttl_str (e.g. "47m12s", "expired", "") and cache_ttl_pct (0-100)
+# Args: $1=last_write_iso  $2=ttl_seconds (300 for 5m-cache, 3600 for 1h-cache)
+compute_cache_ttl() {
+    local last_write_iso="$1" ttl_seconds="$2"
+    cache_ttl_str=""; cache_ttl_pct=0
+    [ -z "$last_write_iso" ] || [ "$last_write_iso" = "null" ] && return
+
+    local write_epoch now elapsed remaining
+    write_epoch=$(iso_to_epoch "$last_write_iso") || return
+    [ -z "$write_epoch" ] && return
+
+    now=$(date +%s)
+    elapsed=$(( now - write_epoch ))
+    remaining=$(( ttl_seconds - elapsed ))
+
+    if [ "$remaining" -le 0 ]; then
+        cache_ttl_str="expired"; cache_ttl_pct=0; return
+    fi
+
+    cache_ttl_pct=$(( remaining * 100 / ttl_seconds ))
+    [ "$cache_ttl_pct" -gt 100 ] && cache_ttl_pct=100
+
+    local h=$(( remaining / 3600 ))
+    local m=$(( (remaining % 3600) / 60 ))
+    local s=$(( remaining % 60 ))
+
+    if   [ "$h" -gt 0 ]; then cache_ttl_str=$(printf "%dh%02dm%02ds" "$h" "$m" "$s")
+    elif [ "$m" -gt 0 ]; then cache_ttl_str=$(printf "%dm%02ds" "$m" "$s")
+    else                       cache_ttl_str=$(printf "%ds" "$s")
+    fi
+}
+# Renders one cache-TTL row (label + bar + remaining) as a string ending in a
+# literal "\n", for the caller to accumulate and emit via printf %b.
+# Args: $1=label  $2=ttl_str ("expired" | "47m12s" | "")  $3=ttl_pct (0-100)
+format_ttl_line() {
+    local lbl="$1" ttl_str="$2" ttl_pct="$3"
+    if [ "$ttl_str" = "expired" ]; then
+        printf '%s' "${white}${lbl}${reset} $(build_bar 0 10) ${red}expired${reset}\n"
+    elif [ -n "$ttl_str" ]; then
+        local pct_color ttl_filled ttl_empty ttl_fs="" ttl_es="" ttl_i
+        pct_color=$(color_for_pct $(( 100 - ttl_pct )))
+        ttl_filled=$(( ttl_pct * 10 / 100 ))
+        ttl_empty=$(( 10 - ttl_filled ))
+        for (( ttl_i=0; ttl_i<ttl_filled; ttl_i++ )); do ttl_fs+="●"; done
+        for (( ttl_i=0; ttl_i<ttl_empty;  ttl_i++ )); do ttl_es+="○"; done
+        printf '%s' "${white}${lbl}${reset} ${pct_color}${ttl_fs}${dim}${ttl_es}${reset} ${pct_color}${ttl_str}${reset}\n"
+    fi
+}
+# Reads session cache stats from transcript JSONL.
+# Sets: sess_reads sess_writes sess_inputs last_5m_iso last_1h_iso
+read_session_cache_stats() {
+    local transcript="$1"
+    sess_reads=0; sess_writes=0; sess_inputs=0; last_5m_iso=""; last_1h_iso=""
+    [ -z "$transcript" ] || [ ! -f "$transcript" ] && return
+
+    local stats
+    stats=$(jq -s '{
+        reads:   ([.[] | select(.type == "assistant") | .message.usage.cache_read_input_tokens   // 0] | add // 0),
+        writes:  ([.[] | select(.type == "assistant") | .message.usage.cache_creation_input_tokens // 0] | add // 0),
+        inputs:  ([.[] | select(.type == "assistant") | .message.usage.input_tokens              // 0] | add // 0),
+        last_5m: ([.[] | select(.type == "assistant" and ((.message.usage.cache_creation.ephemeral_5m_input_tokens // 0) > 0))] | last | .timestamp // ""),
+        last_1h: ([.[] | select(.type == "assistant" and ((.message.usage.cache_creation.ephemeral_1h_input_tokens // 0) > 0))] | last | .timestamp // "")
+    }' "$transcript" 2>/dev/null) || return
+
+    sess_reads=$(echo  "$stats" | jq -r '.reads   // 0')
+    sess_writes=$(echo "$stats" | jq -r '.writes  // 0')
+    sess_inputs=$(echo "$stats" | jq -r '.inputs  // 0')
+    last_5m_iso=$(echo "$stats" | jq -r '.last_5m // ""')
+    last_1h_iso=$(echo "$stats" | jq -r '.last_1h // ""')
+}
+# Rebuilds the all-sessions cache incrementally. Sets nothing; writes totals
+# to $2 (cache_file) and a per-file sums index to $3 (index_file), atomically.
+#
+# Why this is not a one-line glob: the old version ran
+#   cat "$HOME/.claude/projects"/*/*.jsonl | timeout 10 jq -s ...
+# which has two fatal flaws once a few hundred sessions accumulate:
+#   1. The glob expands to hundreds of paths — on Windows/MSYS that overflows
+#      the ~32KB argv limit, so `cat` dies with "Argument list too long",
+#      stderr is swallowed, jq slurps empty input, and every field sums to 0
+#      (the "all = 0" bug).
+#   2. Even on Linux/macOS it re-reads the entire, ever-growing history (100s
+#      of MB) every refresh — far slower than the 10s timeout, which then
+#      kills it and again writes 0.
+# This version scans with `find` (streams, no argv limit), recomputes only the
+# files changed since the last index (`-newer`), and memoizes per-file sums so
+# steady-state refreshes touch just the active session. All bulk data flows
+# through temp files / stdin, never jq args, to stay under the argv limit.
+rebuild_all_sessions_index() {
+    local proj_root="$1" cache_file="$2" index_file="$3"
+    local old_index all_paths recompute_paths recomputed out
+    local tmp_old tmp_all tmp_rc tmp
+
+    old_index=$(cat "$index_file" 2>/dev/null)
+    echo "$old_index" | jq -e 'type == "object"' >/dev/null 2>&1 || old_index='{}'
+
+    # Current transcripts (one dir level down). `find` streams paths, so this
+    # never hits the argv limit the glob did.
+    all_paths=$(find "$proj_root" -mindepth 2 -maxdepth 2 -name '*.jsonl' 2>/dev/null)
+    [ -z "$all_paths" ] && return
+
+    # Files to recompute: those modified since the last index write (so the
+    # active session and any new files), or everything on a cold first run.
+    if [ -f "$index_file" ]; then
+        recompute_paths=$(find "$proj_root" -mindepth 2 -maxdepth 2 -name '*.jsonl' -newer "$index_file" 2>/dev/null)
+    else
+        recompute_paths="$all_paths"
+    fi
+
+    # Recompute changed files one at a time → path<TAB>reads<TAB>writes<TAB>inputs.
+    # Cheap in steady state (usually just the active transcript).
+    recomputed=""
+    if [ -n "$recompute_paths" ]; then
+        local fpath sums line
+        while IFS= read -r fpath; do
+            [ -z "$fpath" ] && continue
+            sums=$(jq -rs '[ ([.[] | select(.type == "assistant") | .message.usage.cache_read_input_tokens   // 0] | add // 0),
+                             ([.[] | select(.type == "assistant") | .message.usage.cache_creation_input_tokens // 0] | add // 0),
+                             ([.[] | select(.type == "assistant") | .message.usage.input_tokens               // 0] | add // 0)
+                           ] | @tsv' "$fpath" 2>/dev/null)
+            [ -z "$sums" ] && sums=$(printf '0\t0\t0')
+            line=$(printf '%s\t%s' "$fpath" "$sums")
+            recomputed="${recomputed}${line}"$'\n'
+        done <<EOF
+$recompute_paths
+EOF
+    fi
+
+    # Assemble the new index (recomputed entries override carried-forward ones,
+    # deleted files drop out because we only iterate current paths) and the
+    # totals. Everything large goes through temp files, never jq args.
+    tmp_old=$(mktemp 2>/dev/null) || return
+    tmp_all=$(mktemp 2>/dev/null) || { rm -f "$tmp_old"; return; }
+    tmp_rc=$(mktemp  2>/dev/null) || { rm -f "$tmp_old" "$tmp_all"; return; }
+    printf '%s'   "$old_index"   > "$tmp_old"
+    printf '%s\n' "$all_paths"   > "$tmp_all"
+    printf '%s'   "$recomputed"  > "$tmp_rc"
+
+    out=$(jq -n --rawfile old "$tmp_old" --rawfile allp "$tmp_all" --rawfile recomp "$tmp_rc" '
+        ($old | fromjson? // {}) as $oldidx
+        | ($recomp | split("\n") | map(select(length > 0) | split("\t"))
+            | map({ key: .[0], value: { reads:  (.[1] | tonumber? // 0),
+                                        writes: (.[2] | tonumber? // 0),
+                                        inputs: (.[3] | tonumber? // 0) } })
+            | from_entries) as $rc
+        | ($allp | split("\n") | map(select(length > 0))) as $files
+        | reduce $files[] as $p
+            ({ index: {}, reads: 0, writes: 0, inputs: 0 };
+             ($rc[$p] // $oldidx[$p] // null) as $e
+             | if $e == null then .
+               else .index[$p] = { reads: $e.reads, writes: $e.writes, inputs: $e.inputs }
+                  | .reads  += $e.reads
+                  | .writes += $e.writes
+                  | .inputs += $e.inputs
+               end)' 2>/dev/null)
+    rm -f "$tmp_old" "$tmp_all" "$tmp_rc"
+    [ -z "$out" ] && return
+
+    # Atomic tmp+mv so a concurrent reader never sees a torn file.
+    tmp="${index_file}.$$.tmp"
+    if echo "$out" | jq -c '.index' > "$tmp" 2>/dev/null; then
+        mv -f "$tmp" "$index_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    else
+        rm -f "$tmp" 2>/dev/null
+    fi
+    tmp="${cache_file}.$$.tmp"
+    if echo "$out" | jq -c '{ reads, writes, inputs }' > "$tmp" 2>/dev/null; then
+        mv -f "$tmp" "$cache_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    else
+        rm -f "$tmp" 2>/dev/null
+    fi
+}
+# Returns all-sessions cache totals, refreshing via a single locked background
+# rebuild (30s throttle). Sets: all_reads all_writes all_inputs
+read_all_sessions_cache_stats() {
+    all_reads=0; all_writes=0; all_inputs=0
+
+    local cache_file="/tmp/claude/cache-all-stats.json"
+    local index_file="/tmp/claude/cache-all-stats-index.json"
+    local cache_max_age=30
+    local needs_refresh=true
+
+    mkdir -p /tmp/claude
+    if [ -f "$cache_file" ]; then
+        local cache_mtime now cache_age
+        cache_mtime=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo 0)
+        now=$(date +%s)
+        cache_age=$(( now - cache_mtime ))
+        [ "$cache_age" -lt "$cache_max_age" ] && needs_refresh=false
+    fi
+
+    if $needs_refresh; then
+        local proj_root="$HOME/.claude/projects" lock="${index_file}.lock"
+        # Clear a stale lock left by a crashed rebuild so refresh can't wedge.
+        if [ -d "$lock" ]; then
+            local lock_mtime
+            lock_mtime=$(stat -c %Y "$lock" 2>/dev/null || stat -f %m "$lock" 2>/dev/null || echo 0)
+            [ "$(( $(date +%s) - lock_mtime ))" -gt 300 ] && rmdir "$lock" 2>/dev/null
+        fi
+        # mkdir is atomic → exactly one rebuild at a time; prevents pile-up
+        # while a slow cold-start scan of a large history is in flight.
+        if mkdir "$lock" 2>/dev/null; then
+            local _pr="$proj_root" _cf="$cache_file" _if="$index_file" _lk="$lock"
+            ( trap 'rmdir "$_lk" 2>/dev/null' EXIT
+              rebuild_all_sessions_index "$_pr" "$_cf" "$_if"
+            ) & disown 2>/dev/null || true
+        fi
+    fi
+
+    # Return last cached totals immediately (may be one render stale during refresh).
+    [ ! -f "$cache_file" ] && return
+    local data
+    data=$(cat "$cache_file" 2>/dev/null) || return
+    all_reads=$(echo  "$data" | jq -r '.reads  // 0')
+    all_writes=$(echo "$data" | jq -r '.writes // 0')
+    all_inputs=$(echo "$data" | jq -r '.inputs // 0')
+}
+# Assembles cache display lines (TTL bars + session + all-sessions rows).
+# Sets: cache_lines (multi-line string with ANSI codes)
+# Args: $1=transcript_path  $2=model_id  $3=session_cost_usd
+build_cache_lines() {
+    local transcript_path="$1" model_id="$2" session_cost="${3:-}"
+    local read_savings_rate write_overhead_rate
+    local sess_reads sess_writes sess_inputs last_5m_iso last_1h_iso
+    local all_reads all_writes all_inputs
+    local cache_ttl_str cache_ttl_pct
+    cache_lines=""
+
+    read_session_cache_stats "$transcript_path"
+    get_model_savings_rate "$model_id"
+
+    # ── TTL lines ──────────────────────────────────────────
+    # Compute both tiers up front, then hide an *expired* tier when the other
+    # is still live — otherwise a single early 5m-cache write leaves a permanent
+    # "5m-cache expired" row cluttering an otherwise-1h-cache session.
+    local ttl_lines=""
+    local h1_str="" h1_pct=0 m5_str="" m5_pct=0
+    local present_1h=false present_5m=false h1_live=false m5_live=false
+
+    if [ -n "$last_1h_iso" ] && [ "$last_1h_iso" != "" ]; then
+        compute_cache_ttl "$last_1h_iso" 3600
+        h1_str="$cache_ttl_str"; h1_pct="$cache_ttl_pct"; present_1h=true
+        [ "$h1_str" != "expired" ] && [ -n "$h1_str" ] && h1_live=true
+    fi
+    if [ -n "$last_5m_iso" ] && [ "$last_5m_iso" != "" ]; then
+        compute_cache_ttl "$last_5m_iso" 300
+        m5_str="$cache_ttl_str"; m5_pct="$cache_ttl_pct"; present_5m=true
+        [ "$m5_str" != "expired" ] && [ -n "$m5_str" ] && m5_live=true
+    fi
+
+    local show_1h=false show_5m=false
+    if $present_1h && ! { [ "$h1_str" = "expired" ] && $m5_live; }; then show_1h=true; fi
+    if $present_5m && ! { [ "$m5_str" = "expired" ] && $h1_live; }; then show_5m=true; fi
+
+    local both_shown=false
+    $show_1h && $show_5m && both_shown=true
+
+    if $show_1h; then
+        local lbl="cache   "
+        $both_shown && lbl="1h-cache"
+        ttl_lines+="$(format_ttl_line "$lbl" "$h1_str" "$h1_pct")"
+    fi
+    if $show_5m; then
+        ttl_lines+="$(format_ttl_line "5m-cache" "$m5_str" "$m5_pct")"
+    fi
+
+    # ── Session stats line ─────────────────────────────────
+    local r_fmt w_fmt hit_pct net_usd net_abs net_sign net_color
+    r_fmt=$(format_tokens "$sess_reads")
+    w_fmt=$(format_tokens "$sess_writes")
+
+    local denom=$(( sess_inputs + sess_reads ))
+    [ "$denom" -gt 0 ] && hit_pct=$(( sess_reads * 100 / denom )) || hit_pct=0
+
+    net_usd=$(awk -v r="$sess_reads" -v w="$sess_writes" \
+              -v rs="$read_savings_rate" -v wo="$write_overhead_rate" \
+              'BEGIN{printf "%.4f", r*rs - w*wo}')
+    net_abs=$(awk -v n="$net_usd" 'BEGIN{if(n<0)n=-n; printf "%.4f",n}')
+    if awk -v n="$net_usd" 'BEGIN{exit !(n >= 0)}'; then
+        net_sign="+"; net_color="$green"
+    else
+        net_sign="-"; net_color="$red"
+    fi
+
+    local cost_part=""
+    if [ -n "$session_cost" ] && [ "$session_cost" != "null" ] && \
+       awk -v c="$session_cost" 'BEGIN{exit !(c+0 > 0)}'; then
+        cost_part="  ${dim}cost${reset} ${white}$(printf '$%.4f' "$session_cost")${reset}"
+    fi
+
+    local sess_line="${white}session${reset}  "
+    sess_line+="${dim}r:${reset}${white}${r_fmt}${reset}  ${dim}w:${reset}${white}${w_fmt}${reset}  "
+    sess_line+="${dim}hit:${reset}${white}${hit_pct}%${reset}  "
+    sess_line+="${dim}net${reset} ${net_color}${net_sign}\$${net_abs}${reset}${cost_part}"
+
+    # ── All-sessions stats line ────────────────────────────
+    read_all_sessions_cache_stats
+    local ar_fmt aw_fmt all_hit all_net all_abs all_sign all_color
+    ar_fmt=$(format_tokens "$all_reads")
+    aw_fmt=$(format_tokens "$all_writes")
+
+    local all_denom=$(( all_inputs + all_reads ))
+    [ "$all_denom" -gt 0 ] && all_hit=$(( all_reads * 100 / all_denom )) || all_hit=0
+
+    all_net=$(awk -v r="$all_reads" -v w="$all_writes" \
+              -v rs="$read_savings_rate" -v wo="$write_overhead_rate" \
+              'BEGIN{printf "%.4f", r*rs - w*wo}')
+    all_abs=$(awk -v n="$all_net" 'BEGIN{if(n<0)n=-n; printf "%.4f",n}')
+    if awk -v n="$all_net" 'BEGIN{exit !(n >= 0)}'; then
+        all_sign="+"; all_color="$green"
+    else
+        all_sign="-"; all_color="$red"
+    fi
+
+    local all_line="${white}all${reset}      "
+    all_line+="${dim}r:${reset}${white}${ar_fmt}${reset}  ${dim}w:${reset}${white}${aw_fmt}${reset}  "
+    all_line+="${dim}hit:${reset}${white}${all_hit}%${reset}  "
+    all_line+="${dim}net${reset} ${all_color}${all_sign}\$${all_abs}${reset}"
+
+    cache_lines="${ttl_lines}${sess_line}\n${all_line}"
+}
+# ── End cache metrics functions ──────────────────────────
+
+# ── Output ──────────────────────────────────────────────
+build_cache_lines "$transcript_path" "$model_id" "$session_cost"
+printf "%b" "$line1"
+[ -n "$rate_lines" ] && printf "\n\n%b" "$rate_lines"
+[ -n "$cache_lines" ] && printf "\n%b" "$cache_lines"
+
+exit 0

--- a/scripts/statusline/test/test_cache.sh
+++ b/scripts/statusline/test/test_cache.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATUSLINE="$SCRIPT_DIR/../bin/statusline.sh"
+
+# ── Inline deps from original script ──────────────────────
+iso_to_epoch() {
+    local iso_str="$1"
+    local epoch stripped
+    epoch=$(date -d "${iso_str}" +%s 2>/dev/null)
+    [ -n "$epoch" ] && echo "$epoch" && return 0
+    stripped="${iso_str%%.*}"; stripped="${stripped%%Z}"; stripped="${stripped%%+*}"
+    stripped="${stripped%%-[0-9][0-9]:[0-9][0-9]}"
+    if [[ "$iso_str" == *"Z"* ]] || [[ "$iso_str" == *"+00:00"* ]]; then
+        epoch=$(env TZ=UTC date -d "${stripped/T/ }" +%s 2>/dev/null)
+    else
+        epoch=$(date -d "${stripped/T/ }" +%s 2>/dev/null)
+    fi
+    [ -n "$epoch" ] && echo "$epoch" && return 0
+    return 1
+}
+
+red='\033[38;2;255;85;85m'; green='\033[38;2;0;175;80m'
+orange='\033[38;2;255;176;85m'; yellow='\033[38;2;230;200;0m'
+white='\033[38;2;220;220;220m'; dim='\033[2m'; reset='\033[0m'
+
+color_for_pct() {
+    local pct=$1
+    if   [ "$pct" -ge 90 ]; then printf "$red"
+    elif [ "$pct" -ge 70 ]; then printf "$yellow"
+    elif [ "$pct" -ge 50 ]; then printf "$orange"
+    else printf "$green"; fi
+}
+
+build_bar() {
+    local pct=$1 width=$2 filled empty bar_color fs="" es=""
+    [ "$pct" -lt 0 ] 2>/dev/null && pct=0
+    [ "$pct" -gt 100 ] 2>/dev/null && pct=100
+    filled=$(( pct * width / 100 )); empty=$(( width - filled ))
+    bar_color=$(color_for_pct "$pct")
+    for ((i=0; i<filled; i++)); do fs+="●"; done
+    for ((i=0; i<empty; i++)); do es+="○"; done
+    printf "${bar_color}${fs}${dim}${es}${reset}"
+}
+
+# ── Source cache functions from statusline.sh ──────────────
+eval "$(sed -n '/^# ── Cache metrics functions/,/^# ── End cache metrics functions/p' "$STATUSLINE")"
+if ! declare -f format_tokens >/dev/null 2>&1; then
+    echo "ERROR: failed to source cache functions from $STATUSLINE" >&2; exit 1
+fi
+
+# ── Test framework ─────────────────────────────────────────
+PASS=0; FAIL=0
+assert_eq() {
+    local desc="$1" got="$2" want="$3"
+    if [ "$got" = "$want" ]; then
+        echo "PASS: $desc"; PASS=$(( PASS + 1 ))
+    else
+        echo "FAIL: $desc"; echo "  got:  '$got'"; echo "  want: '$want'"; FAIL=$(( FAIL + 1 ))
+    fi
+}
+
+# ── format_tokens tests ────────────────────────────────────
+assert_eq "format 0"       "$(format_tokens 0)"       "0"
+assert_eq "format 999"     "$(format_tokens 999)"     "999"
+assert_eq "format 1000"    "$(format_tokens 1000)"    "1k"
+assert_eq "format 45321"   "$(format_tokens 45321)"   "45k"
+assert_eq "format 1000000" "$(format_tokens 1000000)" "1.0M"
+assert_eq "format 1234567" "$(format_tokens 1234567)" "1.2M"
+assert_eq "format empty"   "$(format_tokens '')"      "0"
+assert_eq "format bad"     "$(format_tokens abc)"     "0"
+
+# ── get_model_savings_rate tests ───────────────────────────
+get_model_savings_rate "claude-sonnet-4-6"
+assert_eq "sonnet read_savings_rate"   "$read_savings_rate"   "0.00000270"
+assert_eq "sonnet write_overhead_rate" "$write_overhead_rate" "0.00000300"
+
+get_model_savings_rate "claude-opus-4-7"
+assert_eq "opus read_savings_rate"     "$read_savings_rate"   "0.00001350"
+assert_eq "opus write_overhead_rate"   "$write_overhead_rate" "0.00001500"
+
+get_model_savings_rate "claude-haiku-4-5"
+assert_eq "haiku read_savings_rate"    "$read_savings_rate"   "0.00000072"
+assert_eq "haiku write_overhead_rate"  "$write_overhead_rate" "0.00000080"
+
+get_model_savings_rate "unknown-model"
+assert_eq "fallback read_savings_rate" "$read_savings_rate"   "0.00000270"
+
+# ── compute_cache_ttl tests ────────────────────────────────
+NOW=$(date +%s)
+
+# 1h cache: wrote 30 minutes ago → ~30m remaining, pct ~50%
+WROTE_30M_AGO=$(date -d "@$(( NOW - 1800 ))" -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u -r $(( NOW - 1800 )) +"%Y-%m-%dT%H:%M:%SZ")
+compute_cache_ttl "$WROTE_30M_AGO" 3600
+if [ "$cache_ttl_pct" -ge 45 ] && [ "$cache_ttl_pct" -le 55 ]; then
+    echo "PASS: 1h cache 30m ago pct ~50% (got ${cache_ttl_pct}%)"; PASS=$(( PASS + 1 ))
+else
+    echo "FAIL: 1h cache 30m ago pct want 45-55%, got ${cache_ttl_pct}%"; FAIL=$(( FAIL + 1 ))
+fi
+if [ "$cache_ttl_str" != "expired" ] && [ -n "$cache_ttl_str" ]; then
+    echo "PASS: 1h cache 30m ago not expired (got $cache_ttl_str)"; PASS=$(( PASS + 1 ))
+else
+    echo "FAIL: 1h cache 30m ago should not be expired, got '$cache_ttl_str'"; FAIL=$(( FAIL + 1 ))
+fi
+
+# 5m cache: wrote 6 minutes ago → expired
+WROTE_6M_AGO=$(date -d "@$(( NOW - 360 ))" -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u -r $(( NOW - 360 )) +"%Y-%m-%dT%H:%M:%SZ")
+compute_cache_ttl "$WROTE_6M_AGO" 300
+assert_eq "5m cache expired str" "$cache_ttl_str" "expired"
+assert_eq "5m cache expired pct" "$cache_ttl_pct" "0"
+
+# Empty ISO → silent skip (str stays empty)
+compute_cache_ttl "" 3600
+assert_eq "empty iso: ttl_str empty" "$cache_ttl_str" ""
+
+# "null" ISO → silent skip
+compute_cache_ttl "null" 3600
+assert_eq "null iso: ttl_str empty" "$cache_ttl_str" ""
+
+# Fresh write (2s ago) → pct >= 99
+WROTE_2S_AGO=$(date -d "@$(( NOW - 2 ))" -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u -r $(( NOW - 2 )) +"%Y-%m-%dT%H:%M:%SZ")
+compute_cache_ttl "$WROTE_2S_AGO" 3600
+if [ "$cache_ttl_pct" -ge 99 ]; then
+    echo "PASS: fresh 1h write pct>=99 (got ${cache_ttl_pct}%)"; PASS=$(( PASS + 1 ))
+else
+    echo "FAIL: fresh write want pct>=99, got ${cache_ttl_pct}%"; FAIL=$(( FAIL + 1 ))
+fi
+
+# ── read_session_cache_stats tests ────────────────────────
+TMPDIR_TEST=$(mktemp -d)
+TRANSCRIPT="$TMPDIR_TEST/session.jsonl"
+
+cat > "$TRANSCRIPT" <<'EOF'
+{"type":"user","message":{"role":"user","content":"hello"}}
+{"type":"assistant","timestamp":"2026-05-16T10:00:00.000Z","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":100,"cache_creation_input_tokens":5000,"cache_read_input_tokens":0,"output_tokens":50,"cache_creation":{"ephemeral_1h_input_tokens":5000,"ephemeral_5m_input_tokens":0}}}}
+{"type":"assistant","timestamp":"2026-05-16T10:05:00.000Z","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":18000,"output_tokens":80,"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0}}}}
+{"type":"assistant","timestamp":"2026-05-16T10:10:00.000Z","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":20,"cache_creation_input_tokens":2000,"cache_read_input_tokens":22000,"output_tokens":60,"cache_creation":{"ephemeral_1h_input_tokens":2000,"ephemeral_5m_input_tokens":0}}}}
+EOF
+
+read_session_cache_stats "$TRANSCRIPT"
+assert_eq "sess_reads"   "$sess_reads"   "40000"
+assert_eq "sess_writes"  "$sess_writes"  "7000"
+assert_eq "sess_inputs"  "$sess_inputs"  "170"
+assert_eq "last_1h_iso"  "$last_1h_iso"  "2026-05-16T10:10:00.000Z"
+assert_eq "last_5m_iso"  "$last_5m_iso"  ""
+
+read_session_cache_stats "/nonexistent/path.jsonl"
+assert_eq "missing file reads"  "$sess_reads"  "0"
+assert_eq "missing file writes" "$sess_writes" "0"
+
+read_session_cache_stats ""
+assert_eq "empty path reads"  "$sess_reads"  "0"
+
+rm -rf "$TMPDIR_TEST"
+
+# ── read_all_sessions_cache_stats tests ───────────────────
+TMPDIR_ALL=$(mktemp -d)
+
+mkdir -p "$TMPDIR_ALL/.claude/projects/proj-a" "$TMPDIR_ALL/.claude/projects/proj-b"
+cat > "$TMPDIR_ALL/.claude/projects/proj-a/sess1.jsonl" <<'EOF'
+{"type":"assistant","timestamp":"2026-05-16T09:00:00.000Z","message":{"usage":{"input_tokens":200,"cache_creation_input_tokens":10000,"cache_read_input_tokens":5000,"output_tokens":100}}}
+EOF
+cat > "$TMPDIR_ALL/.claude/projects/proj-b/sess2.jsonl" <<'EOF'
+{"type":"assistant","timestamp":"2026-05-16T10:00:00.000Z","message":{"usage":{"input_tokens":50,"cache_creation_input_tokens":3000,"cache_read_input_tokens":30000,"output_tokens":40}}}
+EOF
+
+# Pre-populate cache file with known data (tests the cache-read path;
+# background refresh is async so we can't assert on a cold-cache write in tests)
+mkdir -p /tmp/claude
+echo '{"reads":35000,"writes":13000,"inputs":250}' > /tmp/claude/cache-all-stats.json
+
+HOME="$TMPDIR_ALL" read_all_sessions_cache_stats
+assert_eq "all_reads"  "$all_reads"  "35000"
+assert_eq "all_writes" "$all_writes" "13000"
+assert_eq "all_inputs" "$all_inputs" "250"
+
+rm -rf "$TMPDIR_ALL"
+
+# ── build_cache_lines integration test ────────────────────
+TMPDIR_BL=$(mktemp -d)
+BL_TRANSCRIPT="$TMPDIR_BL/sess.jsonl"
+NOW_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+cat > "$BL_TRANSCRIPT" <<EOF
+{"type":"assistant","timestamp":"${NOW_ISO}","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":100,"cache_creation_input_tokens":5000,"cache_read_input_tokens":20000,"output_tokens":50,"cache_creation":{"ephemeral_1h_input_tokens":5000,"ephemeral_5m_input_tokens":0}}}}
+EOF
+
+mkdir -p "$TMPDIR_BL/.claude/projects/test"
+cp "$BL_TRANSCRIPT" "$TMPDIR_BL/.claude/projects/test/sess.jsonl"
+rm -f /tmp/claude/cache-all-stats.json
+
+HOME="$TMPDIR_BL" build_cache_lines "$BL_TRANSCRIPT" "claude-sonnet-4-6" "0.05"
+
+# Strip ANSI codes for assertion
+plain=$(printf "%b" "$cache_lines" | sed 's/\x1b\[[0-9;]*m//g')
+
+echo "$plain" | grep -q "session" && { echo "PASS: session line present"; PASS=$(( PASS + 1 )); } || \
+    { echo "FAIL: session line missing"; FAIL=$(( FAIL + 1 )); }
+echo "$plain" | grep -q "r:20k" && { echo "PASS: reads shown as 20k"; PASS=$(( PASS + 1 )); } || \
+    { echo "FAIL: reads not 20k in: $plain"; FAIL=$(( FAIL + 1 )); }
+echo "$plain" | grep -q "w:5k" && { echo "PASS: writes shown as 5k"; PASS=$(( PASS + 1 )); } || \
+    { echo "FAIL: writes not 5k"; FAIL=$(( FAIL + 1 )); }
+echo "$plain" | grep -q "hit:" && { echo "PASS: hit rate present"; PASS=$(( PASS + 1 )); } || \
+    { echo "FAIL: hit rate missing"; FAIL=$(( FAIL + 1 )); }
+echo "$plain" | grep -q "cache" && { echo "PASS: TTL line present"; PASS=$(( PASS + 1 )); } || \
+    { echo "FAIL: TTL line missing"; FAIL=$(( FAIL + 1 )); }
+echo "$plain" | grep -q "cost" && { echo "PASS: cost present"; PASS=$(( PASS + 1 )); } || \
+    { echo "FAIL: cost missing"; FAIL=$(( FAIL + 1 )); }
+
+rm -rf "$TMPDIR_BL"
+
+# ── rebuild_all_sessions_index: argv-safe + incremental ───
+# Regression: the old glob `cat .../projects/*/*.jsonl` overflowed the argv
+# limit at scale → empty input → 0/0/0. This scans with find and memoizes
+# per-file sums, recomputing only files newer than the index.
+TMPDIR_RB=$(mktemp -d)
+RB_PROJ="$TMPDIR_RB/.claude/projects"
+mkdir -p "$RB_PROJ/proj-a" "$RB_PROJ/proj-b"
+cat > "$RB_PROJ/proj-a/s1.jsonl" <<'EOF'
+{"type":"assistant","message":{"usage":{"input_tokens":100,"cache_creation_input_tokens":1000,"cache_read_input_tokens":2000}}}
+EOF
+cat > "$RB_PROJ/proj-b/s2.jsonl" <<'EOF'
+{"type":"assistant","message":{"usage":{"input_tokens":50,"cache_creation_input_tokens":3000,"cache_read_input_tokens":4000}}}
+EOF
+RB_CACHE="$TMPDIR_RB/cache.json"
+RB_INDEX="$TMPDIR_RB/index.json"
+
+rebuild_all_sessions_index "$RB_PROJ" "$RB_CACHE" "$RB_INDEX" || true
+assert_eq "rebuild totals reads"   "$(jq -r '.reads'  "$RB_CACHE" 2>/dev/null)" "6000"
+assert_eq "rebuild totals writes"  "$(jq -r '.writes' "$RB_CACHE" 2>/dev/null)" "4000"
+assert_eq "rebuild totals inputs"  "$(jq -r '.inputs' "$RB_CACHE" 2>/dev/null)" "150"
+assert_eq "rebuild index has 2 files" "$(jq -r 'length' "$RB_INDEX" 2>/dev/null)" "2"
+
+# Incremental: a new session newer than the index is folded in; unchanged
+# files are carried from the index, not re-read.
+sleep 1
+cat > "$RB_PROJ/proj-a/s3.jsonl" <<'EOF'
+{"type":"assistant","message":{"usage":{"input_tokens":10,"cache_creation_input_tokens":500,"cache_read_input_tokens":700}}}
+EOF
+rebuild_all_sessions_index "$RB_PROJ" "$RB_CACHE" "$RB_INDEX" || true
+assert_eq "incremental reads include new file"  "$(jq -r '.reads'  "$RB_CACHE" 2>/dev/null)" "6700"
+assert_eq "incremental writes include new file" "$(jq -r '.writes' "$RB_CACHE" 2>/dev/null)" "4500"
+assert_eq "incremental index has 3 files" "$(jq -r 'length' "$RB_INDEX" 2>/dev/null)" "3"
+
+# Deleted files drop out (rebuild iterates only currently-present paths).
+rm -f "$RB_PROJ/proj-b/s2.jsonl"
+rebuild_all_sessions_index "$RB_PROJ" "$RB_CACHE" "$RB_INDEX" || true
+assert_eq "deleted file removed from reads" "$(jq -r '.reads' "$RB_CACHE" 2>/dev/null)" "2700"
+assert_eq "deleted index has 2 files" "$(jq -r 'length' "$RB_INDEX" 2>/dev/null)" "2"
+
+rm -rf "$TMPDIR_RB"
+
+# ── build_cache_lines: hide expired tier when the other is live ──
+TMPDIR_T1=$(mktemp -d)
+mkdir -p "$TMPDIR_T1/.claude/projects/x"
+NOW2=$(date +%s)
+ISO_NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+ISO_6M_AGO=$(date -d "@$(( NOW2 - 360 ))" -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u -r $(( NOW2 - 360 )) +"%Y-%m-%dT%H:%M:%SZ")
+ISO_1M_AGO=$(date -d "@$(( NOW2 - 60 ))" -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u -r $(( NOW2 - 60 )) +"%Y-%m-%dT%H:%M:%SZ")
+
+# 5m write 6min ago (expired) + 1h write now (live) → only the 1h tier shows
+T1_TX="$TMPDIR_T1/sess.jsonl"
+cat > "$T1_TX" <<EOF
+{"type":"assistant","timestamp":"${ISO_6M_AGO}","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":10,"cache_creation_input_tokens":100,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":100,"ephemeral_1h_input_tokens":0}}}}
+{"type":"assistant","timestamp":"${ISO_NOW}","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":20,"cache_creation_input_tokens":5000,"cache_read_input_tokens":1000,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":5000}}}}
+EOF
+rm -f /tmp/claude/cache-all-stats.json /tmp/claude/cache-all-stats-index.json
+HOME="$TMPDIR_T1" build_cache_lines "$T1_TX" "claude-sonnet-4-6" ""
+plain1=$(printf "%b" "$cache_lines" | sed 's/\x1b\[[0-9;]*m//g')
+if echo "$plain1" | grep -q "5m-cache"; then
+    echo "FAIL: expired 5m tier shown while 1h live"; echo "  got: $plain1"; FAIL=$(( FAIL + 1 ))
+else
+    echo "PASS: expired 5m tier hidden while 1h live"; PASS=$(( PASS + 1 ))
+fi
+echo "$plain1" | grep -q "cache" && { echo "PASS: live 1h tier shown"; PASS=$(( PASS + 1 )); } || \
+    { echo "FAIL: live 1h tier missing in: $plain1"; FAIL=$(( FAIL + 1 )); }
+
+# Both tiers live → both shown, with explicit 1h/5m labels
+T1_TX2="$TMPDIR_T1/sess2.jsonl"
+cat > "$T1_TX2" <<EOF
+{"type":"assistant","timestamp":"${ISO_1M_AGO}","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":10,"cache_creation_input_tokens":100,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":100,"ephemeral_1h_input_tokens":0}}}}
+{"type":"assistant","timestamp":"${ISO_NOW}","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":20,"cache_creation_input_tokens":5000,"cache_read_input_tokens":1000,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":5000}}}}
+EOF
+rm -f /tmp/claude/cache-all-stats.json /tmp/claude/cache-all-stats-index.json
+HOME="$TMPDIR_T1" build_cache_lines "$T1_TX2" "claude-sonnet-4-6" ""
+plain2=$(printf "%b" "$cache_lines" | sed 's/\x1b\[[0-9;]*m//g')
+echo "$plain2" | grep -q "1h-cache" && { echo "PASS: both-live shows 1h-cache label"; PASS=$(( PASS + 1 )); } || \
+    { echo "FAIL: 1h-cache label missing when both live: $plain2"; FAIL=$(( FAIL + 1 )); }
+echo "$plain2" | grep -q "5m-cache" && { echo "PASS: both-live shows 5m-cache label"; PASS=$(( PASS + 1 )); } || \
+    { echo "FAIL: 5m-cache label missing when both live: $plain2"; FAIL=$(( FAIL + 1 )); }
+
+rm -rf "$TMPDIR_T1"
+
+# ── stdin rate_limits → usage cache write (regression) ────
+# Bug: the only usage-cache write lived in the API-fallback branch, so the
+# cache froze for the whole session once stdin carried rate_limits.
+USAGE_CACHE=/tmp/claude/statusline-usage-cache.json
+USAGE_BACKUP=$(mktemp)
+SL_ERR=$(mktemp)
+USAGE_HAD_FILE=false
+if [ -f "$USAGE_CACHE" ]; then
+    USAGE_HAD_FILE=true
+    cp "$USAGE_CACHE" "$USAGE_BACKUP"
+fi
+# Restore the live cache exactly as it was — trap so a mid-test failure
+# under set -e can't destroy it. Presence flag (not -s) so an originally
+# empty cache file is restored as an empty file, not deleted.
+restore_usage_cache() {
+    if $USAGE_HAD_FILE; then
+        mv -f "$USAGE_BACKUP" "$USAGE_CACHE"
+    else
+        rm -f "$USAGE_CACHE" "$USAGE_BACKUP"
+    fi
+    rm -f "$SL_ERR"
+}
+trap restore_usage_cache EXIT
+
+run_statusline() {  # $1 = stdin payload; stderr kept for FAIL output
+    printf '%s' "$1" | bash "$STATUSLINE" >/dev/null 2>"$SL_ERR" || true
+}
+fail_with_stderr() {
+    echo "FAIL: $1"
+    [ -s "$SL_ERR" ] && sed 's/^/  stderr: /' "$SL_ERR"
+    FAIL=$(( FAIL + 1 ))
+}
+age_cache() {  # push the cache mtime past the 60s write throttle
+    local past=$(( $(date +%s) - 3600 ))
+    touch -d "@${past}" "$USAGE_CACHE" 2>/dev/null \
+        || touch -t "$(date -r "$past" +%Y%m%d%H%M.%S)" "$USAGE_CACHE"
+}
+
+# 1) Cold cache + full payload → write lands, numeric types, ISO resets_at
+rm -f "$USAGE_CACHE"
+RESET_EPOCH=$(( NOW + 7200 ))
+WANT_ISO=$(date -u -d "@$RESET_EPOCH" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u -r "$RESET_EPOCH" +"%Y-%m-%dT%H:%M:%SZ")
+PAYLOAD_FULL=$(printf '{"model":{"display_name":"T","id":"claude-sonnet-4-6"},"cwd":"/tmp","rate_limits":{"five_hour":{"used_percentage":42.7,"resets_at":%s},"seven_day":{"used_percentage":63.2,"resets_at":%s}}}' \
+    "$RESET_EPOCH" "$RESET_EPOCH")
+run_statusline "$PAYLOAD_FULL"
+
+if [ -f "$USAGE_CACHE" ]; then
+    assert_eq "stdin rates: five_hour.utilization cached" \
+        "$(jq -r '.five_hour.utilization' "$USAGE_CACHE")" "42.7"
+    assert_eq "stdin rates: utilization is a JSON number" \
+        "$(jq -r '.five_hour.utilization | type' "$USAGE_CACHE")" "number"
+    assert_eq "stdin rates: seven_day.utilization cached" \
+        "$(jq -r '.seven_day.utilization' "$USAGE_CACHE")" "63.2"
+    assert_eq "stdin rates: five_hour.resets_at stored as ISO" \
+        "$(jq -r '.five_hour.resets_at' "$USAGE_CACHE")" "$WANT_ISO"
+    assert_eq "stdin rates: seven_day.resets_at stored as ISO" \
+        "$(jq -r '.seven_day.resets_at' "$USAGE_CACHE")" "$WANT_ISO"
+else
+    fail_with_stderr "stdin rates did not create usage cache"
+fi
+
+# 2) 60s throttle: an immediate second render must NOT rewrite the cache
+if [ -f "$USAGE_CACHE" ]; then
+    MTIME_BEFORE=$(stat -c %Y "$USAGE_CACHE" 2>/dev/null || stat -f %m "$USAGE_CACHE")
+    run_statusline "${PAYLOAD_FULL/42.7/55.5}"
+    MTIME_AFTER=$(stat -c %Y "$USAGE_CACHE" 2>/dev/null || stat -f %m "$USAGE_CACHE")
+    assert_eq "throttle: mtime unchanged within 60s" "$MTIME_AFTER" "$MTIME_BEFORE"
+    assert_eq "throttle: utilization unchanged within 60s" \
+        "$(jq -r '.five_hour.utilization' "$USAGE_CACHE")" "42.7"
+fi
+
+# 3) Merge semantics: extra_usage + prior seven_day survive a
+#    five_hour-only stdin write (external consumers read extra_usage)
+printf '{"five_hour":{"utilization":1,"resets_at":null},"seven_day":{"utilization":63.2,"resets_at":"%s"},"extra_usage":{"is_enabled":true}}' \
+    "$WANT_ISO" > "$USAGE_CACHE"
+age_cache
+PAYLOAD_FH_ONLY='{"model":{"display_name":"T","id":"claude-sonnet-4-6"},"cwd":"/tmp","rate_limits":{"five_hour":{"used_percentage":48.1,"resets_at":'"$RESET_EPOCH"'}}}'
+run_statusline "$PAYLOAD_FH_ONLY"
+assert_eq "merge: five_hour updated from stdin" \
+    "$(jq -r '.five_hour.utilization' "$USAGE_CACHE")" "48.1"
+assert_eq "merge: extra_usage preserved across stdin write" \
+    "$(jq -r '.extra_usage.is_enabled' "$USAGE_CACHE")" "true"
+assert_eq "merge: prior seven_day retained when stdin lacks it" \
+    "$(jq -r '.seven_day.utilization' "$USAGE_CACHE")" "63.2"
+
+# 4a) Corrupt prev (invalid JSON) heals on next aged render
+printf 'not json{{{' > "$USAGE_CACHE"
+age_cache
+run_statusline "$PAYLOAD_FULL"
+if jq -e 'type == "object"' "$USAGE_CACHE" >/dev/null 2>&1; then
+    assert_eq "heal invalid-JSON prev: five_hour written" \
+        "$(jq -r '.five_hour.utilization' "$USAGE_CACHE")" "42.7"
+else
+    fail_with_stderr "invalid-JSON cache not healed to an object"
+fi
+
+# 4b) Corrupt prev (valid JSON but non-object) heals too
+printf '"just a string"' > "$USAGE_CACHE"
+age_cache
+run_statusline "$PAYLOAD_FULL"
+if jq -e 'type == "object"' "$USAGE_CACHE" >/dev/null 2>&1; then
+    assert_eq "heal non-object prev: five_hour written" \
+        "$(jq -r '.five_hour.utilization' "$USAGE_CACHE")" "42.7"
+else
+    fail_with_stderr "non-object cache not healed to an object"
+fi
+
+# 5) One malformed stdin field degrades to null, doesn't kill the write
+rm -f "$USAGE_CACHE"
+PAYLOAD_BAD_SD='{"model":{"display_name":"T","id":"claude-sonnet-4-6"},"cwd":"/tmp","rate_limits":{"five_hour":{"used_percentage":42.7,"resets_at":'"$RESET_EPOCH"'},"seven_day":{"used_percentage":"63%","resets_at":'"$RESET_EPOCH"'}}}'
+run_statusline "$PAYLOAD_BAD_SD"
+assert_eq "per-field guard: valid five_hour cached despite bad seven_day" \
+    "$(jq -r '.five_hour.utilization' "$USAGE_CACHE" 2>/dev/null)" "42.7"
+assert_eq "per-field guard: bad seven_day stored as null, not aborted" \
+    "$(jq -r '.seven_day.utilization' "$USAGE_CACHE" 2>/dev/null)" "null"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Propagates himmel-private PR #521 (HIMMEL-331) to public: vendor the
`yotamleo/claude-statusline` fork into `scripts/statusline/` and rewire
machine-setup + settings-template to the in-repo copy (no external clone).

- `scripts/statusline/` — vendored `bin/statusline.sh`, `test/`, LICENSE, README, provenance in VENDORED.md
- `scripts/machine-setup/{ubuntu.sh,win11.ps1}` — drop the clone step, point `STATUSLINE_PATH` at `$HIMMEL_PATH/scripts/statusline`, decrement step count
- `docs/setup/settings-template.json` — `statusLine.command` → in-repo path
- `docs/tooling-catalog.md` — describe vendored layout
- `.pre-commit-config.yaml` — shellcheck excludes the byte-identical vendored tree

Code-only propagation; no private state. Already CR-clean + tested (windows, gitbash) in private #521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
