### PR TITLE
feat(setup): one-click adopt.sh installer (profiles x scope)

### DIFF
--- a/docs/setup/use-on-your-project.md
+++ b/docs/setup/use-on-your-project.md
@@ -12,6 +12,47 @@ is operator-personal and safely skippable.
 
 ---
 
+## Quickest path — one-shot adopt
+
+From a himmel clone, `scripts/adopt.sh` (or `adopt.ps1` on Windows) brings the
+whole harness over in **one command**. Pick a **profile** (a logical block) and
+a **scope**:
+
+```bash
+# The himmel harness — portable hooks + guardrails + worktree commands +
+# marketplace plugins/skills — wired into YOUR repo (project scope). Commit the
+# result and anyone who clones the repo gets it:
+bash scripts/adopt.sh --profile core --scope project --target /path/to/your/repo
+
+# ...or at user scope (enabled for you in every project on this machine):
+bash scripts/adopt.sh --profile core --scope user
+
+# core + the luna second-brain vault scaffold (the vault goes to --luna-target,
+# default ~/Documents/luna; core still goes to --target):
+bash scripts/adopt.sh --profile all --scope project --target /path/to/your/repo
+```
+
+Windows: `pwsh scripts/adopt.ps1 -Profile core -Scope project -Target C:\path\to\repo`.
+
+| Profile | Brings |
+|---------|--------|
+| `core` | portable hooks + guardrails + worktree commands + the marketplace plugins/skills + a requirements check |
+| `luna` | the luna second-brain vault scaffold (`templates/luna-second-brain`) |
+| `all`  | `core` + `luna` |
+
+`--scope project` copies the scripts into your repo and wires its
+`.claude/settings.json`; `--scope user` wires `~/.claude/settings.json` to
+reference the himmel clone. `--dry-run` previews; re-running is idempotent.
+(jira / qmd / telegram / handover stay à-la-carte — install those separately.)
+
+**Want only PARTS?** The manual steps below install just the portable hooks +
+worktree workflow; [`new-machine.md §6`](new-machine.md#scope-user-vs-project)
+covers installing just the plugins at a chosen scope; the
+[luna template README](../../templates/luna-second-brain/README.md) covers just
+the vault.
+
+---
+
 ## What you get out of the box
 
 Three hooks are portable — they have no himmel-specific dependencies and

--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -1,0 +1,162 @@
+# adopt.ps1 — one-click installer: bring the himmel harness and/or the luna
+# vault scaffold into your own repo (project scope) or user scope.
+# PowerShell counterpart of adopt.sh — keep both in lockstep.
+#
+# Usage:
+#   pwsh adopt.ps1 -Profile <core|luna|all> -Scope <project|user> `
+#                  [-Target PATH] [-LunaTarget PATH] [-DryRun]
+#
+# Profiles (logical blocks):
+#   core  Portable hooks + guardrails lib + worktree commands + the marketplace
+#         plugins/skills + a requirements check. (NOT jira/qmd/telegram/handover.)
+#   luna  The luna second-brain vault scaffold (templates/luna-second-brain).
+#   all   core + luna.
+#
+# Scope (applies to `core`):
+#   project  Copy portable scripts into <Target>, wire the PreToolUse hooks into
+#            <Target>/.claude/settings.json, install plugins -Scope project.
+#   user     Install plugins -Scope user and wire ~/.claude/settings.json hooks
+#            to reference THIS himmel clone (scripts not copied per-repo).
+#
+# Flags:
+#   -Target PATH      Where core lands (project scope) / vault dir for
+#                     -Profile luna. Default: current directory.
+#   -LunaTarget PATH  Vault dir when -Profile all. Default: ~/Documents/luna.
+#   -DryRun           Print actions instead of doing them.
+#
+# Idempotent: re-running adds nothing already present.
+
+[CmdletBinding()]
+param(
+    [ValidateSet('core', 'luna', 'all')]
+    [string]$Profile = 'core',
+    [ValidateSet('project', 'user')]
+    [string]$Scope = 'project',
+    [string]$Target,
+    [string]$LunaTarget,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
+$HimmelRoot  = (Resolve-Path (Join-Path $ScriptDir '..')).Path
+if (-not $Target)     { $Target     = (Get-Location).Path }
+if (-not $LunaTarget) { $LunaTarget = Join-Path $HOME 'Documents\luna' }
+
+$PortableFiles = @(
+    'scripts/hooks/auto-approve-safe-bash.sh',
+    'scripts/hooks/block-edit-on-main.sh',
+    'scripts/hooks/block-read-secrets.sh',
+    'scripts/guardrails/lib.sh',
+    'scripts/guardrails/guard-gh.sh',
+    'scripts/lib/py-armor.sh',
+    'scripts/clean-garden.sh',
+    'scripts/worktree.sh',
+    'scripts/clean.sh',
+    'scripts/_new-worktree.sh'
+)
+
+function Require-Tools {
+    $missing = @()
+    foreach ($t in @('git', 'jq', 'python3', 'claude')) {
+        if (-not (Get-Command $t -ErrorAction SilentlyContinue)) { $missing += $t }
+    }
+    if ($missing.Count -gt 0) {
+        Write-Error "missing required tools: $($missing -join ', ') (see $HimmelRoot\docs\setup\new-machine.md)"
+    }
+}
+
+function Copy-Portable {
+    Write-Host "──── Copying portable core into $Target ────"
+    foreach ($f in $PortableFiles) {
+        $src = Join-Path $HimmelRoot $f
+        $dst = Join-Path $Target $f
+        if ($DryRun) { Write-Host "DRY: copy $f"; continue }
+        New-Item -ItemType Directory -Force (Split-Path $dst) | Out-Null
+        Copy-Item -Force $src $dst
+        Write-Host "  $f"
+    }
+}
+
+# Merge the three PreToolUse hook stanzas into a settings.json, idempotently.
+function Wire-Settings([string]$SettingsPath, [string]$Prefix) {
+    $desired = @(
+        [pscustomobject]@{ matcher = 'Bash'; hooks = @([pscustomobject]@{ type = 'command'; command = "bash $Prefix/scripts/hooks/auto-approve-safe-bash.sh" }) },
+        [pscustomobject]@{ matcher = 'Edit|Write|MultiEdit|NotebookEdit'; hooks = @([pscustomobject]@{ type = 'command'; command = "bash $Prefix/scripts/hooks/block-edit-on-main.sh" }) },
+        [pscustomobject]@{ matcher = 'Bash|PowerShell|Read|Grep'; hooks = @([pscustomobject]@{ type = 'command'; command = "bash $Prefix/scripts/hooks/block-read-secrets.sh" }) }
+    )
+    if ($DryRun) { Write-Host "DRY: merge 3 PreToolUse hook stanzas into $SettingsPath (prefix: $Prefix)"; return }
+    New-Item -ItemType Directory -Force (Split-Path $SettingsPath) | Out-Null
+
+    if (Test-Path $SettingsPath) {
+        $cfg = Get-Content $SettingsPath -Raw | ConvertFrom-Json
+    } else {
+        $cfg = [pscustomobject]@{}
+    }
+    if (-not $cfg.PSObject.Properties['hooks']) {
+        $cfg | Add-Member -NotePropertyName hooks -NotePropertyValue ([pscustomobject]@{})
+    }
+    if (-not $cfg.hooks.PSObject.Properties['PreToolUse']) {
+        $cfg.hooks | Add-Member -NotePropertyName PreToolUse -NotePropertyValue @()
+    }
+    $existing = @($cfg.hooks.PreToolUse)
+    $existingCmds = @($existing | ForEach-Object { $_.hooks } | ForEach-Object { $_.command })
+    $toAdd = @()
+    foreach ($d in $desired) {
+        if ($existingCmds -notcontains $d.hooks[0].command) { $toAdd += $d }
+    }
+    $cfg.hooks.PreToolUse = @($existing + $toAdd)
+    $cfg | ConvertTo-Json -Depth 12 | Set-Content $SettingsPath -Encoding utf8
+    Write-Host "  wired PreToolUse hooks → $SettingsPath"
+}
+
+function Install-Plugins {
+    Write-Host "──── Installing plugins (-Scope $Scope) ────"
+    $pluginArgs = @('-Scope', $Scope)
+    if ($DryRun) { $pluginArgs += '-DryRun' }
+    $ip = Join-Path $HimmelRoot 'scripts\machine-setup\install-plugins.ps1'
+    if ($Scope -eq 'project') {
+        # project scope writes to the CWD's .claude/settings.json — run from
+        # $Target so plugins land in the adopted repo, not the himmel clone.
+        Push-Location $Target
+        try { & pwsh -NoProfile -File $ip @pluginArgs } finally { Pop-Location }
+    } else {
+        & pwsh -NoProfile -File $ip @pluginArgs
+    }
+}
+
+function Do-Core {
+    Require-Tools
+    if ($Scope -eq 'project') {
+        Copy-Portable
+        Wire-Settings (Join-Path $Target '.claude\settings.json') '$CLAUDE_PROJECT_DIR'
+        Write-Host "  worktree commands: bash $Target/scripts/worktree.sh feat/slug"
+    } else {
+        Wire-Settings (Join-Path $HOME '.claude\settings.json') $HimmelRoot
+        Write-Host "  worktree commands run from the himmel clone: bash $HimmelRoot/scripts/worktree.sh feat/slug"
+    }
+    Install-Plugins
+    Write-Host "  (optional) pre-commit gates: see $HimmelRoot\docs\setup\use-on-your-project.md"
+}
+
+function Do-Luna([string]$Dest) {
+    Write-Host "──── Scaffolding luna vault → $Dest ────"
+    if ((Test-Path $Dest) -and -not $DryRun) {
+        Write-Host "  $Dest already exists — skipping copy (re-run the vault's own setup to update)"
+    } elseif (-not $DryRun) {
+        Copy-Item -Recurse -Force (Join-Path $HimmelRoot 'templates\luna-second-brain') $Dest
+    } else {
+        Write-Host "DRY: copy templates\luna-second-brain → $Dest"
+    }
+    Write-Host "  next: cd `"$Dest`"; bash scripts/setup.sh   (idempotent; prints the plugin-install commands)"
+}
+
+$dryNote = if ($DryRun) { ' (dry-run)' } else { '' }
+Write-Host "==> himmel adopt — profile=$Profile scope=$Scope$dryNote"
+switch ($Profile) {
+    'core' { Do-Core }
+    'luna' { Do-Luna $Target }
+    'all'  { Do-Core; Do-Luna $LunaTarget }
+}
+Write-Host "──── Done ────"

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# adopt.sh — one-click installer: bring the himmel harness and/or the luna
+# vault scaffold into your own repo (project scope) or user scope, in one
+# command. Consolidates the three à-la-carte paths (setup.sh base,
+# install-plugins.sh, manual use-on-your-project copy, luna template) behind a
+# single profile + scope choice. The à-la-carte paths stay available for
+# partial installs.
+#
+# Usage:
+#   bash adopt.sh --profile <core|luna|all> --scope <project|user> \
+#                 [--target PATH] [--luna-target PATH] [--dry-run]
+#
+# Profiles (logical blocks):
+#   core   Portable hooks (block-edit-on-main, block-read-secrets,
+#          auto-approve-safe-bash) + guardrails lib + worktree commands
+#          (worktree/clean/clean-garden) + the marketplace plugins/skills +
+#          a requirements check. (NOT jira/qmd/telegram/handover — à-la-carte.)
+#   luna   The luna second-brain vault scaffold (templates/luna-second-brain).
+#   all    core + luna.
+#
+# Scope (applies to the `core` profile):
+#   project  Copy the portable scripts into <target>, wire the PreToolUse hooks
+#            into <target>/.claude/settings.json, install plugins --scope project.
+#   user     Install plugins --scope user and wire ~/.claude/settings.json hooks
+#            to reference THIS himmel clone (scripts are not copied per-repo).
+#
+# Flags:
+#   --target PATH       Where core lands (project scope) / vault dir for
+#                       `--profile luna`. Default: current directory.
+#   --luna-target PATH  Vault dir when `--profile all`. Default: ~/Documents/luna.
+#   --dry-run           Print actions instead of doing them.
+#
+# Idempotent: re-running adds nothing already present.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+HIMMEL_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+PROFILE="core"
+SCOPE="project"
+TARGET="$PWD"
+LUNA_TARGET=""
+DRY_RUN=0
+
+# ── Parse args ───────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)      PROFILE="$2"; shift 2 ;;
+    --scope)        SCOPE="$2"; shift 2 ;;
+    --target)       TARGET="$2"; shift 2 ;;
+    --luna-target)  LUNA_TARGET="$2"; shift 2 ;;
+    --dry-run)      DRY_RUN=1; shift ;;
+    -h|--help)      sed -n '2,/^set -e/p' "$0" | sed 's/^# \{0,1\}//' | sed '$d'; exit 0 ;;
+    *) echo "ERROR: unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$PROFILE" in core|luna|all) ;; *) echo "ERROR: invalid --profile: $PROFILE (expected core|luna|all)" >&2; exit 2 ;; esac
+case "$SCOPE"   in project|user)  ;; *) echo "ERROR: invalid --scope: $SCOPE (expected project|user)" >&2; exit 2 ;; esac
+[ -n "$LUNA_TARGET" ] || LUNA_TARGET="$HOME/Documents/luna"
+
+run() { if [[ $DRY_RUN -eq 1 ]]; then echo "DRY: $*"; else "$@"; fi; }
+
+# Portable files copied into a project-scope target (relative paths preserved).
+PORTABLE_FILES=(
+  scripts/hooks/auto-approve-safe-bash.sh
+  scripts/hooks/block-edit-on-main.sh
+  scripts/hooks/block-read-secrets.sh
+  scripts/guardrails/lib.sh
+  scripts/guardrails/guard-gh.sh
+  scripts/lib/py-armor.sh
+  scripts/clean-garden.sh
+  scripts/worktree.sh
+  scripts/clean.sh
+  scripts/_new-worktree.sh
+)
+
+require_tools() {
+  local missing=() t
+  for t in bash git jq python3 claude; do
+    command -v "$t" >/dev/null 2>&1 || missing+=("$t")
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "ERROR: missing required tools: ${missing[*]}" >&2
+    echo "  see $HIMMEL_ROOT/docs/setup/new-machine.md (Required environment)" >&2
+    exit 1
+  fi
+}
+
+copy_portable() {
+  echo "──── Copying portable core into $TARGET ────"
+  local f
+  for f in "${PORTABLE_FILES[@]}"; do
+    run mkdir -p "$TARGET/$(dirname "$f")"
+    run cp "$HIMMEL_ROOT/$f" "$TARGET/$f"
+    run chmod +x "$TARGET/$f"
+    echo "  $f"
+  done
+}
+
+# Merge the three PreToolUse hook stanzas into a settings.json, idempotently.
+# $1 = settings.json path, $2 = command path prefix (literal, e.g.
+# '$CLAUDE_PROJECT_DIR' for project scope or the himmel abs path for user scope).
+wire_settings() {
+  local settings="$1" prefix="$2"
+  local desired
+  desired=$(cat <<JSON
+[
+  {"matcher":"Bash","hooks":[{"type":"command","command":"bash ${prefix}/scripts/hooks/auto-approve-safe-bash.sh"}]},
+  {"matcher":"Edit|Write|MultiEdit|NotebookEdit","hooks":[{"type":"command","command":"bash ${prefix}/scripts/hooks/block-edit-on-main.sh"}]},
+  {"matcher":"Bash|PowerShell|Read|Grep","hooks":[{"type":"command","command":"bash ${prefix}/scripts/hooks/block-read-secrets.sh"}]}
+]
+JSON
+)
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "DRY: merge 3 PreToolUse hook stanzas into $settings (prefix: $prefix)"
+    return
+  fi
+  mkdir -p "$(dirname "$settings")"
+  local base="{}"
+  [[ -f "$settings" ]] && base=$(cat "$settings")
+  printf '%s' "$base" | jq --argjson add "$desired" '
+    .hooks = (.hooks // {})
+    | .hooks.PreToolUse = (
+        (.hooks.PreToolUse // []) as $ex
+        | $ex + [ $add[]
+                  | select( (.hooks[0].command) as $c
+                            | ($ex | map(.hooks[]?.command) | index($c)) | not ) ]
+      )
+  ' > "$settings.adopt.tmp" && mv "$settings.adopt.tmp" "$settings"
+  echo "  wired PreToolUse hooks → $settings"
+}
+
+install_plugins() {
+  echo "──── Installing plugins (--scope $SCOPE) ────"
+  local args=(--scope "$SCOPE")
+  [[ $DRY_RUN -eq 1 ]] && args+=(--dry-run)
+  if [[ "$SCOPE" == "project" ]]; then
+    # project scope writes to the CWD's .claude/settings.json — run from $TARGET
+    # so plugins land in the adopted repo, not wherever adopt was invoked.
+    ( cd "$TARGET" && bash "$HIMMEL_ROOT/scripts/machine-setup/install-plugins.sh" "${args[@]}" )
+  else
+    bash "$HIMMEL_ROOT/scripts/machine-setup/install-plugins.sh" "${args[@]}"
+  fi
+}
+
+do_core() {
+  require_tools
+  if [[ "$SCOPE" == "project" ]]; then
+    copy_portable
+    # Literal $CLAUDE_PROJECT_DIR — Claude Code expands it at hook-fire time.
+    # shellcheck disable=SC2016
+    wire_settings "$TARGET/.claude/settings.json" '$CLAUDE_PROJECT_DIR'
+    echo "  worktree commands: bash $TARGET/scripts/worktree.sh feat/slug"
+  else
+    # user scope: reference this himmel clone, don't copy per-repo.
+    wire_settings "$HOME/.claude/settings.json" "$HIMMEL_ROOT"
+    echo "  worktree commands run from the himmel clone: bash $HIMMEL_ROOT/scripts/worktree.sh feat/slug"
+  fi
+  install_plugins
+  echo "  (optional) pre-commit gates: see $HIMMEL_ROOT/docs/setup/use-on-your-project.md (Pre-commit hooks)"
+}
+
+do_luna() {
+  local dest="$1"
+  echo "──── Scaffolding luna vault → $dest ────"
+  if [[ -e "$dest" && $DRY_RUN -ne 1 ]]; then
+    echo "  $dest already exists — skipping copy (re-run the vault's own setup to update)"
+  else
+    run cp -r "$HIMMEL_ROOT/templates/luna-second-brain" "$dest"
+  fi
+  echo "  next: cd \"$dest\" && bash scripts/setup.sh   (idempotent; prints the plugin-install commands)"
+}
+
+_dry_note=""; [[ $DRY_RUN -eq 1 ]] && _dry_note=" (dry-run)"
+echo "==> himmel adopt — profile=$PROFILE scope=$SCOPE${_dry_note}"
+case "$PROFILE" in
+  core) do_core ;;
+  luna) do_luna "$TARGET" ;;
+  all)  do_core; do_luna "$LUNA_TARGET" ;;
+esac
+echo "──── Done ────"

--- a/scripts/test-adopt.sh
+++ b/scripts/test-adopt.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# test-adopt.sh — smoke tests for scripts/adopt.sh (the one-click harness
+# installer). Self-contained: stubs `claude` on PATH so the plugin-install
+# step doesn't hit the network, and uses throwaway temp dirs + a fake HOME so
+# nothing touches the real ~/.claude.
+#
+# adopt.ps1 carries the same profile/scope logic for PowerShell — that twin is
+# NOT covered here; keep both in lockstep when changing either.
+#
+# Covers:
+#   1. core/project — copies the portable files, wires 3 PreToolUse hooks
+#      ($CLAUDE_PROJECT_DIR prefix), idempotent on re-run.
+#   2. merge — pre-existing settings.json keys + hooks are preserved.
+#   3. core/user — wires ~/.claude/settings.json to the himmel abs path,
+#      copies NO scripts into a repo.
+#   4. luna — copies the vault scaffold to the target.
+#   5. invalid --profile / --scope exit 2.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+adopt="$repo_root/scripts/adopt.sh"
+[ -f "$adopt" ] || { echo "FAIL: $adopt not found" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq required" >&2; exit 1; }
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# Stub claude so adopt's install-plugins step is a no-op.
+mkdir -p "$work/bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$work/bin/claude"
+chmod +x "$work/bin/claude"
+export PATH="$work/bin:$PATH"
+
+# ── 5. invalid args (run first — validated before any tool preflight) ────────
+set +e
+out=$(bash "$adopt" --profile bogus --scope project 2>&1); rc=$?
+set -e
+[ "$rc" -eq 2 ] || fail "invalid --profile should exit 2 (got $rc)"
+printf '%s' "$out" | grep -q "invalid --profile" || fail "missing invalid-profile diagnostic"
+set +e
+out=$(bash "$adopt" --profile core --scope bogus 2>&1); rc=$?
+set -e
+[ "$rc" -eq 2 ] || fail "invalid --scope should exit 2 (got $rc)"
+echo "ok: invalid --profile / --scope rejected (exit 2)"
+
+# ── 1. core/project ──────────────────────────────────────────────────────────
+proj="$work/proj"; mkdir -p "$proj"
+bash "$adopt" --profile core --scope project --target "$proj" >/dev/null
+for f in scripts/hooks/block-edit-on-main.sh scripts/guardrails/lib.sh scripts/worktree.sh; do
+  [ -f "$proj/$f" ] || fail "core/project did not copy $f"
+done
+s="$proj/.claude/settings.json"
+[ -f "$s" ] || fail "core/project did not write $s"
+[ "$(jq '.hooks.PreToolUse | length' "$s")" = "3" ] || fail "expected 3 PreToolUse hooks"
+jq -e '.hooks.PreToolUse[].hooks[].command | select(contains("$CLAUDE_PROJECT_DIR"))' "$s" >/dev/null \
+  || fail "project-scope hooks must use \$CLAUDE_PROJECT_DIR"
+echo "ok: core/project copies portable files + wires 3 \$CLAUDE_PROJECT_DIR hooks"
+
+# idempotency
+cp "$s" "$work/before.json"
+bash "$adopt" --profile core --scope project --target "$proj" >/dev/null
+diff -q "$work/before.json" "$s" >/dev/null || fail "core/project not idempotent"
+echo "ok: core/project idempotent on re-run"
+
+# ── 2. merge preserves existing settings ─────────────────────────────────────
+proj2="$work/proj2"; mkdir -p "$proj2/.claude"
+printf '%s' '{"permissions":{"allow":["Bash(ls)"]},"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"bash /pre/existing.sh"}]}]}}' > "$proj2/.claude/settings.json"
+bash "$adopt" --profile core --scope project --target "$proj2" >/dev/null
+[ "$(jq -r '.permissions.allow[0]' "$proj2/.claude/settings.json")" = "Bash(ls)" ] || fail "merge dropped existing permissions"
+[ "$(jq '.hooks.PreToolUse | length' "$proj2/.claude/settings.json")" = "4" ] || fail "merge expected 4 PreToolUse hooks (1 existing + 3)"
+echo "ok: merge preserves existing keys + hooks"
+
+# ── 3. core/user (fake HOME) ─────────────────────────────────────────────────
+home="$work/home"; mkdir -p "$home"
+HOME="$home" bash "$adopt" --profile core --scope user --target "$work/ignored" >/dev/null
+us="$home/.claude/settings.json"
+[ -f "$us" ] || fail "core/user did not write ~/.claude/settings.json"
+[ "$(jq '.hooks.PreToolUse | length' "$us")" = "3" ] || fail "core/user expected 3 PreToolUse hooks"
+us_cmd=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$us")
+# shellcheck disable=SC2016  # literal $CLAUDE_PROJECT_DIR globs below, not expansions
+case "$us_cmd" in
+  *'$CLAUDE_PROJECT_DIR'*) fail "user-scope must not use \$CLAUDE_PROJECT_DIR ($us_cmd)" ;;
+  */scripts/hooks/*) : ;;  # absolute himmel path
+  *) fail "user-scope hook command unexpected: $us_cmd" ;;
+esac
+[ ! -d "$work/ignored/scripts" ] || fail "core/user must NOT copy scripts into a repo"
+echo "ok: core/user wires ~/.claude to himmel abs path, copies no scripts"
+
+# ── 4. luna scaffold ─────────────────────────────────────────────────────────
+vault="$work/vault"
+bash "$adopt" --profile luna --target "$vault" >/dev/null
+[ -f "$vault/README.md" ] || fail "luna profile did not scaffold the vault (README.md missing)"
+echo "ok: luna scaffolds the vault to the target"
+
+# ── 6. all — core→--target, vault→--luna-target (no leak) ────────────────────
+allrepo="$work/allrepo"; allvault="$work/allvault"; mkdir -p "$allrepo"
+bash "$adopt" --profile all --scope project --target "$allrepo" --luna-target "$allvault" >/dev/null
+[ -f "$allrepo/scripts/worktree.sh" ] || fail "all: core did not land in --target"
+[ -f "$allvault/README.md" ] || fail "all: vault did not land in --luna-target"
+[ ! -f "$allrepo/README.md" ] || fail "all: vault scaffold leaked into the core --target"
+echo "ok: all routes core→--target, vault→--luna-target (no leak)"
+
+# ── 7. core/user idempotency (re-run into populated ~/.claude keeps 3) ────────
+HOME="$home" bash "$adopt" --profile core --scope user --target "$work/ignored" >/dev/null
+[ "$(jq '.hooks.PreToolUse | length' "$us")" = "3" ] || fail "core/user not idempotent on re-run"
+echo "ok: core/user idempotent on re-run"
+
+echo "PASS"


### PR DESCRIPTION
Bring the himmel harness and/or luna vault to your own repo (project scope) or user scope in one command, choosing a profile.

```
bash scripts/adopt.sh --profile core --scope project --target /path/to/repo
bash scripts/adopt.sh --profile core --scope user
bash scripts/adopt.sh --profile all  --scope project --target /path/to/repo
```

Profiles: core (hooks+guardrails+worktrees+plugins/skills+reqs), luna (vault scaffold), all. Scope: project (copy scripts + wire repo .claude/settings.json) / user (wire ~/.claude to the himmel clone). Idempotent jq/PS settings merge; --dry-run previews. Windows twin: adopt.ps1. Consolidates the prior a-la-carte paths (still available); use-on-your-project.md leads with the one-shot. test-adopt.sh = 8 cases.

Platforms tested: windows, gitbash, powershell
Security reviewed: manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)