### PR TITLE
fix(jira): harden discoverMetadata — /search/jql endpoint + warn on dropped project key

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,11 @@ gotchas (macOS bash 4, Windows MSYS_NO_PATHCONV, realpath fallbacks),
 per-platform shell setup — lives at
 [`docs/setup/new-machine.md`](docs/setup/new-machine.md).
 
-Adopting the portable core (hooks + worktree workflow) in your own repo:
+Adopting himmel in your own repo (or user scope) is one command —
+`bash scripts/adopt.sh --profile core --scope project --target /path/to/repo`
+brings the harness (hooks + guardrails + worktree commands + marketplace
+plugins/skills) over in one shot. Profiles, scopes, the Windows `adopt.ps1`
+twin, and the à-la-carte parts:
 [`docs/setup/use-on-your-project.md`](docs/setup/use-on-your-project.md).
 
 Claude Code global config (`~/.claude/`) setup: see

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,8 +41,17 @@ it any time; it is idempotent.
 > `export PATH="$HOME/.local/bin:$PATH"` to your shell rc (setup reminds you at
 > the end).
 
-Prefer to add himmel's portable core (hooks + worktree workflow) to an existing
-repo instead? See [use-on-your-project.md](setup/use-on-your-project.md).
+Prefer to add himmel to an **existing repo** (or just your user scope)? One
+command from a himmel clone brings the harness over — hooks + guardrails +
+worktree commands + marketplace plugins/skills:
+
+```bash
+bash scripts/adopt.sh --profile core --scope project --target /path/to/your/repo
+```
+
+Profiles (`core` / `luna` / `all`), scopes (`project` / `user`), the Windows
+`adopt.ps1` twin, and the à-la-carte parts are all in
+[use-on-your-project.md](setup/use-on-your-project.md).
 
 Installing the Claude Code plugins (handover, triage, obsidian, …)? You choose
 where they're recorded: **user scope** (`~/.claude`, available in every project

--- a/plugins/himmel-jira/lib/init-flow.mjs
+++ b/plugins/himmel-jira/lib/init-flow.mjs
@@ -88,7 +88,16 @@ export async function discoverMetadata(projectsToTrack) {
   // (= JIRA_PROJECT_KEY for single-project users) since check-required now
   // resolves to default_project when --project is omitted.
   const tracked = projectsToTrack
-    .map((k) => allProjects.find((p) => p.key === k))
+    .map((k) => {
+      const found = allProjects.find((p) => p.key === k);
+      if (!found) {
+        // Don't silently drop a configured key — every other degraded path in
+        // this function warns; a typo'd/no-access key would otherwise cache 0
+        // projects with no clue why (HIMMEL-334).
+        process.stderr.write(`[jira-init] warning: configured project '${k}' not found via /project/search (typo or no access?) — skipping; it will NOT be cached\n`);
+      }
+      return found;
+    })
     .filter(Boolean);
   out.default_project = tracked[0]?.key;
   for (const p of tracked) {
@@ -111,7 +120,10 @@ export async function discoverMetadata(projectsToTrack) {
     }
     let transitions = {};
     try {
-      const search = await jiraFetch('GET', `/search?jql=project=${p.key}&maxResults=1&fields=summary`);
+      // Enhanced JQL search endpoint — the old /search?jql= was removed
+      // (Atlassian CHANGE-2046, HTTP 410); /search/jql returns the same
+      // `issues` shape (HIMMEL-337).
+      const search = await jiraFetch('GET', `/search/jql?jql=project=${p.key}&maxResults=1&fields=summary`);
       if (search.issues?.[0]) {
         const tx = await jiraFetch('GET', `/issue/${search.issues[0].key}/transitions`);
         transitions = Object.fromEntries(tx.transitions.map((tr) => [tr.to?.name ?? tr.name, tr.id]));

--- a/plugins/himmel-jira/tests/discover-metadata.test.mjs
+++ b/plugins/himmel-jira/tests/discover-metadata.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Stub the network layer so discoverMetadata runs offline. /project/search
 // deliberately returns the projects in a DIFFERENT order than configured
@@ -14,12 +14,24 @@ vi.mock('../lib/jira-fetch.mjs', () => ({
       ] };
     }
     if (path.includes('/issuetypes')) return { issueTypes: [] };
-    if (path.startsWith('/search')) return { issues: [] };
+    if (path.includes('/transitions')) {
+      return { transitions: [
+        { id: '11', to: { name: 'To Do' } },
+        { id: '21', to: { name: 'In Progress' } },
+        { id: '31', to: { name: 'Done' } },
+      ] };
+    }
+    // The enhanced /search/jql returns the same `{ issues: [...] }` shape;
+    // return a sample issue so the transitions-parse success path is exercised.
+    if (path.startsWith('/search')) return { issues: [{ key: 'ACME-1' }] };
     return {};
   }),
 }));
 
 const { discoverMetadata } = await import('../lib/init-flow.mjs');
+const { jiraFetch } = await import('../lib/jira-fetch.mjs');
+
+beforeEach(() => { jiraFetch.mockClear(); });
 
 describe('discoverMetadata default_project ordering', () => {
   it('default_project follows configured order, not API response order', async () => {
@@ -32,5 +44,34 @@ describe('discoverMetadata default_project ordering', () => {
     const out = await discoverMetadata(['ACME', 'NOPE']);
     expect(out.default_project).toBe('ACME');
     expect(Object.keys(out.projects)).toEqual(['ACME']);
+  });
+
+  it('warns (not silently) when a configured key is not returned (HIMMEL-334)', async () => {
+    const errs = [];
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation((s) => { errs.push(String(s)); return true; });
+    try {
+      await discoverMetadata(['ACME', 'NOPE']);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(errs.join('')).toContain("configured project 'NOPE' not found");
+  });
+
+  it('queries transitions via the enhanced /search/jql endpoint, not the removed /search?jql (HIMMEL-337)', async () => {
+    await discoverMetadata(['ACME']);
+    const searchCalls = jiraFetch.mock.calls.filter(([, path]) => path.startsWith('/search'));
+    expect(searchCalls.length).toBeGreaterThan(0);
+    for (const [, path] of searchCalls) {
+      expect(path).toContain('/search/jql?jql=');
+      expect(path).not.toMatch(/\/search\?jql=/);
+    }
+  });
+
+  it('consumes the /search/jql response shape — transitions parse into the cache (HIMMEL-337)', async () => {
+    // Guards against a silent regression: if the new endpoint returned a
+    // different shape, search.issues[0].key would be undefined and transitions
+    // would silently stay empty. Proves the success path still works.
+    const out = await discoverMetadata(['ACME']);
+    expect(out.projects.ACME.transitions).toEqual({ 'To Do': '11', 'In Progress': '21', 'Done': '31' });
   });
 });


### PR DESCRIPTION
## Harden `discoverMetadata` (jira metadata cache)

Two related fixes in `plugins/himmel-jira/lib/init-flow.mjs` `discoverMetadata`:

- **Removed-endpoint migration:** the transitions cache-warming step called Atlassian's removed `/search?jql` endpoint (CHANGE-2046 → `HTTP 410`), leaving the transitions cache empty on every `/jira-init` / `/jira-refresh`. Migrated to the enhanced `/search/jql` endpoint (same `issues` response shape).
- **No more silent drop:** a configured project key not returned by `/project/search` (typo / no access) was silently dropped via `.filter(Boolean)`. Now emits a `[jira-init] warning:` like every other degraded path in the function — behavior-preserving (key still dropped, just diagnosed).

### Tests
66 plugin tests pass (+3): warn on dropped key; transitions query hits `/search/jql` not `/search?jql`; and the `/search/jql` response is consumed (transitions parse into the cache — guards against a silent empty-cache regression on a shape change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
