### PR TITLE
feat(handover): portable bootstrap — de-hardcode operator state repo, add /handover-setup + dotenv config

### DIFF
--- a/.claude/commands/context-hop.md
+++ b/.claude/commands/context-hop.md
@@ -15,7 +15,7 @@ Use this when the current session is approaching ~75–80% of its context window
 Written to `<handover-root>/context-hop-<UTC-timestamp>.md`. Body:
 
 - Operator message (if `--message` passed) — short text describing what the hopped session should pick up.
-- Origin context: cwd, git branch + HEAD short, pointer to `yotam_docs/handovers/yotam/next-session-resume.md` for the persistent next-session plan.
+- Origin context: cwd, git branch + HEAD short, pointer to `<handover-root>/next-session-resume.md` for the persistent next-session plan.
 - Cold-start prompt block (used by the spawned claude on relaunch).
 
 The snapshot is **NOT** a substitute for `next-session-resume.md` — it's a thin point-in-time pin so the hopped session knows what the immediately-prior session was doing. For long-running state, edit `next-session-resume.md` directly before hopping.
@@ -45,13 +45,16 @@ bash scripts/handover/hop.sh $ARGUMENTS
 
 ## Handover root resolution
 
-In priority order:
+In priority order (HIMMEL-335):
 
-1. `--handover-root <dir>` flag.
-2. `$HANDOVER_DIR/yotam` env var.
-3. `$HOME/Documents/github/yotam_docs/handovers/yotam` (post-HIMMEL-124 default).
+1. `--handover-root <dir>` flag (used verbatim).
+2. The shared resolver `scripts/lib/handover-path.sh` joined to `USER_SLUG` —
+   `<HANDOVER_DIR or <repo>/handovers>/<USER_SLUG>`. `HANDOVER_DIR` /
+   `USER_SLUG` are read from the launching shell or `<repo>/.env` (via
+   `scripts/lib/load-dotenv.sh`).
 
-Fails (`rc=2`) if the resolved root does not exist.
+Fails (`rc=2`) if neither resolves or the resolved root does not exist — no
+hardcoded fallback path.
 
 ## Exit codes
 

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,16 @@
 #   3. fail-loud with a hint
 USER_SLUG=your-slug
 
+# Handover state root (HIMMEL-335). Where the handover system reads/writes
+# epics, tasks, standalones, and session snapshots. Two modes:
+#   - Unset (Mode A, default): inline at <this-repo>/handovers/.
+#   - Set   (Mode B): an external directory, typically a separate state repo
+#     so handover commits don't land on your feature branches.
+# Resolved by scripts/lib/handover-path.sh; loaded from this file by
+# scripts/lib/load-dotenv.sh when the launching shell didn't export it.
+# Run `/handover-setup` to be prompted for the path and have it written here.
+# HANDOVER_DIR=/c/path/to/your/handover-repo/handovers
+
 JIRA_BASE_URL=https://<your-site>.atlassian.net
 JIRA_EMAIL=<your-email@example.com>
 JIRA_API_TOKEN=your_api_token_here

--- a/marketplace/plugins/handover/README.md
+++ b/marketplace/plugins/handover/README.md
@@ -41,6 +41,7 @@ though the himmel repo also wires explicit `/handover *` commands.
 
 | Command | Purpose |
 |---|---|
+| `/handover-setup` | **First-time bootstrap.** Asks where handover state should live (inline vs an external state repo), persists a Mode-B choice to `.env` as `HANDOVER_DIR`, then runs `init`/`register`. No hardcoded repo. |
 | `/handover init` | Bootstrap a **new** repo (no existing state). Seeds `_templates/`, `status.md`, `roadmap.md`, registers in the registry. |
 | `/handover register` | Adopt **existing** state in a repo (idempotent — scans for `#N` dirs, derives the next ID, detects duplicates). |
 | `/handover repos <list\|add\|remove\|where>` | Manage the repo registry (read-only `list`/`where`; `add`/`remove` touch the registry only, never repo files). |

--- a/marketplace/plugins/handover/commands/handover-setup.md
+++ b/marketplace/plugins/handover/commands/handover-setup.md
@@ -1,0 +1,101 @@
+---
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, Skill
+description: First-time handover bootstrap — asks where handover state should live, persists it to .env as HANDOVER_DIR, then runs init (new) or register (existing). Use on a fresh machine/repo before /handover new-epic etc.
+argument-hint: "[handover-dir]"
+---
+
+## Your task
+
+Bootstrap the handover system for this operator/repo. The job of this command
+is the one-time **setup** the rest of the handover skill assumes is already
+done: pick *where* handover state lives, persist that choice so every later
+session resolves it the same way, and hand off to the skill's `init`/`register`
+flow. Do **not** hardcode any specific repo (e.g. `yotam_docs`) — always ask.
+
+### 1. Resolve the target repo root
+
+Run `git rev-parse --git-common-dir` and take its parent — that is the primary
+checkout root (`<repo-root>`), where the gitignored `.env` lives even when you
+are inside a worktree. If git fails, stop and tell the user to run from inside a
+git repo.
+
+### 2. Detect whether setup already ran
+
+Check both signals:
+
+- **Config:** is `HANDOVER_DIR` already set in the environment, or present as an
+  active (uncommented) line in `<repo-root>/.env`?
+- **Registry:** does `~/.claude/handover/registry.json` already contain an entry
+  whose `path` canonicalises to `<repo-root>`?
+
+If **both** are present, report the resolved state root and stop with: "Handover
+already set up for this repo (HANDOVER_DIR=<…>, registered as '<name>'). Re-run a
+specific step with `/handover register` or edit `.env` manually if you need to
+change the location." Do not silently re-prompt.
+
+If only one is present, continue — you will fill the missing half.
+
+### 3. Ask where handover state should live
+
+If `$1` (the `handover-dir` argument) was provided, treat it as the operator's
+explicit Mode-B path and skip the prompt. Otherwise ask via `AskUserQuestion`:
+
+> **Where should handover state live?**
+> - **Inline (this repo)** — state under `<repo-root>/handovers/`. Simplest; no
+>   `.env` change. Best for a single-repo setup. (Mode A)
+> - **External state repo** — a separate directory (typically a dedicated repo)
+>   so handover commits never land on your feature branches. You'll enter the
+>   path. (Mode B)
+
+For the **External** choice, get the absolute path (the user types it via the
+"Other" option or a follow-up). Expect a path ending in `/handovers` inside a
+git repo, e.g. `/c/Users/<you>/Documents/github/<your-state-repo>/handovers`.
+
+### 4. Persist the choice
+
+- **Inline (Mode A):** nothing to write — `HANDOVER_DIR` stays unset and the
+  resolver (`scripts/lib/handover-path.sh`) defaults to `<repo-root>/handovers`.
+  Continue to step 5 with `<state-root-host>` = `<repo-root>`.
+- **External (Mode B):** if the chosen directory does not exist yet, ask whether
+  to create it (`mkdir -p`) — do not write a `HANDOVER_DIR` that points at a
+  missing path. Then run the idempotent writer (this never echoes secret values,
+  so it passes the secrets guard):
+
+  ```bash
+  bash <repo-root>/scripts/handover/set-handover-dir.sh "<chosen-path>"
+  ```
+
+  It creates-or-updates the `HANDOVER_DIR=` line in `<repo-root>/.env`. Confirm
+  the printed `OK set-handover-dir:` line. `<state-root-host>` = the chosen path.
+
+  Note for the current session: `.env` is read by tools at launch, so the new
+  `HANDOVER_DIR` takes effect for shell scripts the next time Claude is launched
+  from this repo (the loader `scripts/lib/load-dotenv.sh` picks it up); the
+  skill steps below use the path directly.
+
+### 5. Initialise or adopt the state
+
+Resolve `<state-root>` = `<state-root-host>/<USER_SLUG>` (USER_SLUG via
+`scripts/lib/user-slug.sh`; ask if it cannot be resolved).
+
+- If `<state-root>` has no `.md` items yet → invoke the **handover** skill's
+  `init` flow (`Skill` tool, handover) against `<state-root-host>` to seed
+  `_templates/`, `status.md`, `roadmap.md`, and register the repo.
+- If `<state-root>` already contains handover items (existing state being
+  adopted) → invoke the skill's `register` flow instead (idempotent).
+
+Pass the resolved path so the skill does not re-prompt for it. Follow the full
+specs in the skill's `references/init-register.md`.
+
+### 6. Confirm
+
+Print a one-line summary: the mode (inline/external), the resolved `<state-root>`,
+and the registered repo name. Suggest the next step: `/handover new-epic <name>`.
+
+### Notes
+
+- This command is the **only** place the state-root location is chosen
+  interactively. Everything downstream resolves it from `.env` (Mode B) or the
+  inline default (Mode A) — never a hardcoded path.
+- Re-running is safe: step 2 short-circuits when setup is already complete, and
+  `set-handover-dir.sh` + the skill's `register` flow are both idempotent.

--- a/marketplace/plugins/handover/skills/handover/SKILL.md
+++ b/marketplace/plugins/handover/skills/handover/SKILL.md
@@ -23,7 +23,7 @@ Full algorithm + canonicalisation rules: `references/routing.md` (load only on a
 
 ## Bucket Resolution (HIMMEL-129)
 
-Some registered repos (notably `yotam_docs`) split `<state-root>` into per-source-repo buckets to keep work from multiple code repos disambiguated:
+Some registered repos — the **state-root host** an operator chose at `/handover-setup` (for this maintainer's setup, a repo named `yotam_docs`) — split `<state-root>` into per-source-repo buckets to keep work from multiple code repos disambiguated:
 
 ```
 <state-root>/
@@ -108,6 +108,10 @@ Before any file write to `<state-root>`:
 `handover-resume` and `/handover repos` are read-only — no worktree gate.
 
 ## Commands
+
+### `/handover-setup`
+
+**First-time bootstrap (run this once per machine/operator before anything else).** Asks *where* handover state should live — inline at `<repo-root>/handovers/` (Mode A) or an external state repo (Mode B) — then persists a Mode-B choice to `<repo-root>/.env` as `HANDOVER_DIR` via `scripts/handover/set-handover-dir.sh` (idempotent), and hands off to `init` (new state) or `register` (existing state). Never assumes a specific repo name — the location is always prompted. Full runbook: the plugin's `commands/handover-setup.md`. The downstream resolver (`scripts/lib/handover-path.sh`) + the shell loader (`scripts/lib/load-dotenv.sh`) read that `HANDOVER_DIR`; `init`/`register` below assume setup already chose the location.
 
 ### `/handover init`
 
@@ -535,12 +539,12 @@ Templates carry `template_version: <integer>` frontmatter. Parsers read the vers
 
 ## Supplementary Files
 
-Two freeform files. **As of HIMMEL-13 + HIMMEL-124 (2026-05-25)** all personal handover state — including these freeform files — lives in the centralized `yotam_docs` repo:
+Two freeform files. They live at the **state-root host**'s `handovers/` root — the external repo chosen at `/handover-setup` (Mode B) when one is configured, else the inline `<repo-root>/handovers/` (Mode A):
 
-- **`<yotam_docs-root>/handovers/manual_notes.md`** — running TODO list. Human-maintained.
-- **`<yotam_docs-root>/handovers/random_dreams.md`** — product ideas / roadmap seeds. Human-maintained.
+- **`<state-root-host>/handovers/manual_notes.md`** — running TODO list. Human-maintained.
+- **`<state-root-host>/handovers/random_dreams.md`** — product ideas / roadmap seeds. Human-maintained.
 
-Resolution: if `yotam_docs` is registered (expected post-HIMMEL-124), read from its `<repo-root>/handovers/`. Otherwise fall back to looking for these files at any registered repo's `<repo-root>/handovers/` root — early registries (pre-HIMMEL-13) had them in himmel.
+Resolution: read from the `HANDOVER_DIR` host repo's `handovers/` root if Mode B is configured; otherwise fall back to looking for these files at any registered repo's `<repo-root>/handovers/` root.
 
 Rules:
 - Never auto-generate or overwrite.
@@ -552,8 +556,8 @@ Rules:
 ```
 <repo-root>/
   handovers/
-    manual_notes.md                      ← freeform, human-maintained (now in yotam_docs per HIMMEL-13)
-    random_dreams.md                     ← freeform, human-maintained (now in yotam_docs per HIMMEL-13)
+    manual_notes.md                      ← freeform, human-maintained (at the state-root host; Mode B if configured)
+    random_dreams.md                     ← freeform, human-maintained (at the state-root host; Mode B if configured)
     <user>/                              ← <state-root>
       status.md                          ← auto-generated
       roadmap.md                         ← auto-generated (NEW in v2)

--- a/marketplace/plugins/handover/skills/handover/references/init-register.md
+++ b/marketplace/plugins/handover/skills/handover/references/init-register.md
@@ -21,6 +21,16 @@ leaves no partial disk state.
 
 Bootstraps a **new** repo (no existing handover state on disk).
 
+**Where state lives is chosen by `/handover-setup`, not here (HIMMEL-335).**
+`/handover-setup` is the first-time entry point: it prompts inline (Mode A,
+`<repo-root>/handovers/`) vs external (Mode B, a separate state repo), and on a
+Mode-B choice writes `HANDOVER_DIR=` into `<repo-root>/.env` (via
+`scripts/handover/set-handover-dir.sh`) so every later session resolves the same
+location. `init` then operates on the resolved `<state-root-host>` — the
+`HANDOVER_DIR` host when set, else the inline default. Never hardcode a specific
+state repo (e.g. `yotam_docs`); it is always the operator-chosen location. The
+`path` input below is the **code repo being tracked**, not the state-root host.
+
 ### Inputs (interactive prompt via `AskUserQuestion` or text)
 
 | Field | Default | Validation |

--- a/scripts/handover/auto-commit.sh
+++ b/scripts/handover/auto-commit.sh
@@ -122,9 +122,11 @@ supported by this MVP. Auto-committing there would land handover noise
 on your active himmel feature branch and risk leaking into a feature PR.
 
 To use auto-commit:
-  1. Move handover state to a separate repo (e.g., yotam_docs/handovers).
-  2. export HANDOVER_DIR=/abs/path/to/that/repo/handovers (in the shell
-     that launches Claude Code).
+  1. Keep handover state in a separate repo (run /handover-setup to choose
+     the location — it writes HANDOVER_DIR to .env).
+  2. export HANDOVER_DIR=/abs/path/to/that/repo/handovers in the shell that
+     launches Claude Code (or set it in .env; scripts/lib/load-dotenv.sh
+     loads it).
   3. Re-run.
 
 See HIMMEL-118 (handover root resolver) and HIMMEL-59 (this Epic) for
@@ -141,8 +143,8 @@ if ! root=$(handover_root_ensure); then
 fi
 
 # Find the git repo that owns the root. Root may be a subdir of the
-# external repo (yotam_docs/handovers/ inside yotam_docs/), so walk
-# up to the toplevel rather than assuming root == toplevel.
+# external state repo (e.g. <state-repo>/handovers/ inside <state-repo>/),
+# so walk up to the toplevel rather than assuming root == toplevel.
 if ! handover_repo=$(git -C "$root" rev-parse --show-toplevel 2>&1); then
     echo "ERR auto-commit: handover root is not inside a git repo:" >&2
     echo "    root=$root" >&2

--- a/scripts/handover/hop.sh
+++ b/scripts/handover/hop.sh
@@ -36,8 +36,9 @@
 #   bash scripts/handover/hop.sh [--message "what to pick up"] [--delay 2] [--print] [--dry-run]
 #
 # Optional:
-#   --handover-root <dir>  Override snapshot destination. Default: $HANDOVER_DIR
-#                          if set, else yotam_docs/handovers/yotam/.
+#   --handover-root <dir>  Override snapshot destination. Default: the shared
+#                          resolver (HANDOVER_DIR Mode B, else <repo>/handovers)
+#                          joined to your USER_SLUG.
 #   --message <text>       Text embedded into the snapshot body.
 #                          Use this for "load this todo list" handoffs.
 #   --delay <minutes>      Schedule mode only. Default 2.
@@ -55,6 +56,22 @@
 #   4  scheduler invocation failed
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/load-dotenv.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/load-dotenv.sh"
+# shellcheck source=../lib/user-slug.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/user-slug.sh"
+# shellcheck source=../lib/handover-path.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/handover-path.sh"
+
+# HIMMEL-335: pull HANDOVER_DIR / USER_SLUG from <repo>/.env when the
+# launching shell didn't export them (a live env value still wins). Makes
+# .env a real config source for the handover root instead of a hardcode.
+load_dotenv HANDOVER_DIR USER_SLUG
+
 MESSAGE=""
 DELAY_MINUTES=2
 MODE=schedule
@@ -63,10 +80,10 @@ FORCE=0
 HANDOVER_ROOT=""
 
 # Capture ORIGIN repo BEFORE any work — this is the repo claude should
-# run from in the relaunched session. The snapshot lives under
-# yotam_docs/handovers/ but arm-resume's default RESUME_CWD derivation
-# would land claude in yotam_docs (wrong repo). Pass through arm-resume's
-# --cwd flag to override.
+# run from in the relaunched session. The snapshot lives under the
+# handover root (often a separate state repo), but arm-resume's default
+# RESUME_CWD derivation would land claude in that repo (wrong repo). Pass
+# through arm-resume's --cwd flag to override.
 if ! ORIGIN_REPO=$(git rev-parse --show-toplevel 2>/dev/null); then
     ORIGIN_REPO="$(pwd)"
 fi
@@ -80,9 +97,9 @@ Mid-session jump to a fresh claude session. Writes a context-hop
 snapshot then either schedules a relaunch via arm-resume.sh (default)
 or prints the command to run manually (--print).
 
-Default: writes snapshot to $HANDOVER_DIR/context-hop-<ts>.md (or
-yotam_docs/handovers/yotam/ fallback), then schedules a relaunch in
-2 minutes via arm-resume.sh.
+Default: writes the snapshot under the resolved handover root
+(<HANDOVER_DIR or repo/handovers>/<USER_SLUG>/context-hop-<ts>.md), then
+schedules a relaunch in 2 minutes via arm-resume.sh.
 EOF
 }
 
@@ -109,15 +126,22 @@ if ! [[ "$DELAY_MINUTES" =~ ^[0-9]+$ ]] || [ "$DELAY_MINUTES" -lt 1 ] || [ "$DEL
 fi
 
 # Resolve handover root. Priority:
-#   1. --handover-root flag
-#   2. $HANDOVER_DIR
-#   3. yotam_docs/handovers/yotam/ at the conventional path
+#   1. --handover-root flag (explicit override; used verbatim)
+#   2. shared resolver (HANDOVER_DIR Mode B, else <repo>/handovers inline)
+#      joined to the operator's user slug — <state-root> = <root>/<slug>.
 if [ -z "$HANDOVER_ROOT" ]; then
-    if [ -n "${HANDOVER_DIR:-}" ]; then
-        HANDOVER_ROOT="$HANDOVER_DIR/yotam"
-    else
-        HANDOVER_ROOT="$HOME/Documents/github/yotam_docs/handovers/yotam"
+    if ! _hop_root=$(handover_root); then
+        echo "ERR hop: cannot resolve handover root." >&2
+        echo "    Set HANDOVER_DIR (in .env or the launching shell) or pass" >&2
+        echo "    --handover-root <existing-dir>." >&2
+        exit 2
     fi
+    if ! _hop_slug=$(user_slug); then
+        echo "ERR hop: cannot resolve USER_SLUG (set it in .env or the" >&2
+        echo "    launching shell), or pass --handover-root <existing-dir>." >&2
+        exit 2
+    fi
+    HANDOVER_ROOT="$_hop_root/$_hop_slug"
 fi
 if [ ! -d "$HANDOVER_ROOT" ]; then
     echo "ERR hop: handover root does not exist: $HANDOVER_ROOT" >&2
@@ -162,14 +186,14 @@ write_snapshot() {
         # shellcheck disable=SC2016  # backticks here are inline markdown, not shell substitution
         printf -- '- Open PRs: query via `gh pr list --author @me`\n'
         # shellcheck disable=SC2016
-        printf -- '- See `yotam_docs/handovers/yotam/next-session-resume.md` for the persistent next-session plan.\n\n'
+        printf -- '- See `%s/next-session-resume.md` for the persistent next-session plan.\n\n' "$HANDOVER_ROOT"
         printf -- '## Cold-start prompt for the hopped session\n\n'
         printf -- '```\n'
         printf -- 'Cold-start context-hop. Read this snapshot top-to-bottom.\n'
         printf -- 'Pick up from the operator message above. Your cwd is the\n'
         printf -- 'origin repo recorded in the Origin section. Active state\n'
         printf -- 'of the origin session is in\n'
-        printf -- 'yotam_docs/handovers/yotam/next-session-resume.md.\n'
+        printf -- '%s/next-session-resume.md.\n' "$HANDOVER_ROOT"
         printf -- '```\n'
     } > "$target"
 }

--- a/scripts/handover/set-handover-dir.sh
+++ b/scripts/handover/set-handover-dir.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# set-handover-dir.sh — idempotently set HANDOVER_DIR in the repo .env (HIMMEL-335).
+#
+# Writes (create-or-update) the `HANDOVER_DIR=<path>` line in the primary
+# checkout's .env so the handover shell tooling (via scripts/lib/load-dotenv.sh)
+# and the handover skill resolve state from one configured location instead of
+# a hardcoded path. This is the auto-write step behind `/handover-setup`.
+#
+# Usage:
+#   set-handover-dir.sh <handover-dir> [--env-file <path>]
+#
+#   <handover-dir>   Absolute path to the handover state root (Mode B). Must be
+#                    an existing directory (fail-closed — matches the resolver
+#                    in scripts/lib/handover-path.sh).
+#   --env-file <p>   Target .env (default: <primary-checkout-root>/.env).
+#
+# Idempotent: re-running with the same value reaches the same end-state (the
+# line is rewritten to the same value); a new value replaces the existing line
+# in place (file order preserved). Commented example lines (`# HANDOVER_DIR=...`)
+# are left untouched — an active line is appended.
+#
+# Exit codes:
+#   0  written (or already correct)
+#   1  usage / input error
+#   2  handover dir does not exist
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+HDIR=""
+ENV_FILE=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --env-file)   ENV_FILE="${2:-}"; shift 2 ;;
+        --env-file=*) ENV_FILE="${1#--env-file=}"; shift ;;
+        -*)           echo "ERR set-handover-dir: unknown flag: $1" >&2; exit 1 ;;
+        *)
+            if [ -z "$HDIR" ]; then HDIR="$1"; shift
+            else echo "ERR set-handover-dir: unexpected arg: $1" >&2; exit 1; fi
+            ;;
+    esac
+done
+
+if [ -z "$HDIR" ]; then
+    echo "Usage: set-handover-dir.sh <handover-dir> [--env-file <path>]" >&2
+    exit 1
+fi
+
+if [ ! -d "$HDIR" ]; then
+    echo "ERR set-handover-dir: handover dir does not exist: $HDIR" >&2
+    echo "    Create it first (e.g. a 'handovers' dir in your state repo), then re-run." >&2
+    exit 2
+fi
+
+# Canonicalize (absolute, forward slashes — some Windows bash builds emit
+# backslashes from pwd; normalize so the stored value is shell-safe).
+# shellcheck disable=SC1003  # '\\' is a literal backslash for tr, not a quote escape
+HDIR="$(cd "$HDIR" && pwd | tr '\\' '/')"
+
+# Resolve the target .env: explicit --env-file, else the primary checkout root
+# (parent of git-common-dir — finds the real .env from inside a worktree too).
+if [ -z "$ENV_FILE" ]; then
+    if common=$(git rev-parse --git-common-dir 2>/dev/null); then
+        ENV_FILE="$(cd "$common/.." && pwd)/.env"
+    else
+        ENV_FILE="$SCRIPT_DIR/../../.env"
+    fi
+fi
+
+if [ ! -e "$ENV_FILE" ]; then
+    mkdir -p "$(dirname "$ENV_FILE")"
+    : > "$ENV_FILE"
+elif [ ! -f "$ENV_FILE" ]; then
+    # Exists but is a directory / symlink-to-dir / device — refuse rather than
+    # clobber or write into something unexpected.
+    echo "ERR set-handover-dir: target is not a regular file: $ENV_FILE" >&2
+    exit 1
+fi
+
+new_line="HANDOVER_DIR=$HDIR"
+
+if grep -qE '^[[:space:]]*HANDOVER_DIR=' "$ENV_FILE"; then
+    tmp="$ENV_FILE.tmp.$$"
+    awk -v repl="$new_line" '
+        !done && /^[[:space:]]*HANDOVER_DIR=/ { print repl; done=1; next }
+        { print }
+    ' "$ENV_FILE" > "$tmp"
+    mv "$tmp" "$ENV_FILE"
+    echo "OK set-handover-dir: updated HANDOVER_DIR in $ENV_FILE"
+else
+    printf '%s\n' "$new_line" >> "$ENV_FILE"
+    echo "OK set-handover-dir: appended HANDOVER_DIR to $ENV_FILE"
+fi

--- a/scripts/handover/test-hop.sh
+++ b/scripts/handover/test-hop.sh
@@ -125,6 +125,25 @@ out=$(bash "$HOP" --handover-root "$TMP/handovers/yotam" --message "force-test" 
 arm_line=$(printf '%s\n' "$out" | grep -E '^DRY hop: would invoke' | head -1)
 assert_contains "T14 dry-run with --force includes --force flag" " --force" "$arm_line"
 
+# --- HIMMEL-335: de-hardcoded HANDOVER_DIR + USER_SLUG resolution ---
+
+# T15: HANDOVER_DIR (Mode B) joined to USER_SLUG → <dir>/<slug>/ snapshot.
+mkdir -p "$TMP/state/tester"
+out=$(HANDOVER_DIR="$TMP/state" USER_SLUG=tester bash "$HOP" --message "h335" --print --dry-run 2>&1)
+rc=$?
+assert_rc "T15 HANDOVER_DIR resolution rc=0" 0 "$rc"
+assert_contains "T15 snapshot under <HANDOVER_DIR>/<USER_SLUG>" "$TMP/state/tester/context-hop-" "$out"
+
+# T16: snapshot body cites the resolved root, never a hardcoded repo name.
+assert_contains "T16 body cites resolved root" "$TMP/state/tester/next-session-resume.md" "$out"
+assert_not_contains "T16 no yotam_docs in output" "yotam_docs" "$out"
+
+# T17: HANDOVER_DIR pointing at a missing dir → fail-closed rc=2 (no hardcode).
+out=$(HANDOVER_DIR="$TMP/state-missing" USER_SLUG=tester bash "$HOP" --print --dry-run 2>&1)
+rc=$?
+assert_rc "T17 missing HANDOVER_DIR fail-closed rc=2" 2 "$rc"
+assert_contains "T17 diagnostic" "cannot resolve handover root" "$out"
+
 if [ "$FAILED" -gt 0 ]; then
     echo "---"
     echo "FAIL $FAILED case(s)"

--- a/scripts/handover/test-set-handover-dir.sh
+++ b/scripts/handover/test-set-handover-dir.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Tests for scripts/handover/set-handover-dir.sh (HIMMEL-335).
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/set-handover-dir.sh"
+
+FAILED=0
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then echo "PASS $label"
+    else echo "FAIL $label — expected '$expected', got '$actual'"; FAILED=$((FAILED + 1)); fi
+}
+assert_rc() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then echo "PASS $label (rc=$actual)"
+    else echo "FAIL $label — expected rc=$expected, got rc=$actual"; FAILED=$((FAILED + 1)); fi
+}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+HDIR="$TMP/state/handovers"
+mkdir -p "$HDIR"
+HDIR_CANON="$(cd "$HDIR" && pwd)"
+
+# T1: appended to a .env that lacks the key (other lines preserved).
+ENV="$TMP/a.env"
+printf 'USER_SLUG=tester\nJIRA_PROJECT_KEY=HIMMEL\n' > "$ENV"
+bash "$SCRIPT" "$HDIR" --env-file "$ENV" >/dev/null 2>&1
+assert_rc "T1 append rc=0" 0 "$?"
+assert_eq "T1 key value" "HANDOVER_DIR=$HDIR_CANON" "$(grep '^HANDOVER_DIR=' "$ENV")"
+assert_eq "T1 preserved other lines" "2" "$(grep -cE '^(USER_SLUG|JIRA_PROJECT_KEY)=' "$ENV")"
+
+# T2: idempotent — second identical run keeps exactly one line.
+bash "$SCRIPT" "$HDIR" --env-file "$ENV" >/dev/null 2>&1
+assert_eq "T2 single HANDOVER_DIR line" "1" "$(grep -cE '^[[:space:]]*HANDOVER_DIR=' "$ENV")"
+
+# T3: update in place — new value replaces old, line count unchanged.
+OTHER="$TMP/state2/handovers"
+mkdir -p "$OTHER"
+OTHER_CANON="$(cd "$OTHER" && pwd)"
+bash "$SCRIPT" "$OTHER" --env-file "$ENV" >/dev/null 2>&1
+assert_eq "T3 updated value" "HANDOVER_DIR=$OTHER_CANON" "$(grep '^HANDOVER_DIR=' "$ENV")"
+assert_eq "T3 still one line" "1" "$(grep -cE '^[[:space:]]*HANDOVER_DIR=' "$ENV")"
+
+# T4: creates the .env when missing.
+ENV2="$TMP/new-dir/fresh.env"
+bash "$SCRIPT" "$HDIR" --env-file "$ENV2" >/dev/null 2>&1
+assert_rc "T4 create .env rc=0" 0 "$?"
+assert_eq "T4 created with key" "HANDOVER_DIR=$HDIR_CANON" "$(grep '^HANDOVER_DIR=' "$ENV2" 2>/dev/null)"
+
+# T5: non-existent handover dir → fail-closed rc=2.
+bash "$SCRIPT" "$TMP/nope" --env-file "$ENV" >/dev/null 2>&1
+assert_rc "T5 missing dir rc=2" 2 "$?"
+
+# T6: no arg → usage error rc=1.
+bash "$SCRIPT" --env-file "$ENV" >/dev/null 2>&1
+assert_rc "T6 usage rc=1" 1 "$?"
+
+# T7b: stored path is forward-slash normalized (no backslashes).
+case "$(grep '^HANDOVER_DIR=' "$ENV")" in
+    *\\*) echo "FAIL T7b no backslashes in stored path"; FAILED=$((FAILED + 1)) ;;
+    *)    echo "PASS T7b no backslashes in stored path" ;;
+esac
+
+# T7: a commented example line is left intact; an active line is appended.
+ENV3="$TMP/commented.env"
+printf '# HANDOVER_DIR=/c/example/path\n' > "$ENV3"
+bash "$SCRIPT" "$HDIR" --env-file "$ENV3" >/dev/null 2>&1
+assert_eq "T7 comment preserved" "1" "$(grep -c '^# HANDOVER_DIR=' "$ENV3")"
+assert_eq "T7 active line added" "HANDOVER_DIR=$HDIR_CANON" "$(grep '^HANDOVER_DIR=' "$ENV3")"
+
+# T8: --env-file=<path> equals form parses the same as the space form.
+ENV4="$TMP/eq.env"
+bash "$SCRIPT" "$HDIR" --env-file="$ENV4" >/dev/null 2>&1
+assert_eq "T8 equals-form --env-file" "HANDOVER_DIR=$HDIR_CANON" "$(grep '^HANDOVER_DIR=' "$ENV4" 2>/dev/null)"
+
+# T9: unknown flag → usage error rc=1.
+bash "$SCRIPT" "$HDIR" --bogus >/dev/null 2>&1
+assert_rc "T9 unknown flag rc=1" 1 "$?"
+
+# T10: target exists but is not a regular file (a directory) → refuse rc=1
+# with the specific guard diagnostic (asserting the message, not just rc=1,
+# locks in the guard — a bare set -e fall-through would also yield rc=1).
+mkdir -p "$TMP/envdir"
+t10_out=$(bash "$SCRIPT" "$HDIR" --env-file "$TMP/envdir" 2>&1); t10_rc=$?
+assert_rc "T10 non-regular-file target rc=1" 1 "$t10_rc"
+case "$t10_out" in
+    *"not a regular file"*) echo "PASS T10 emits guard diagnostic" ;;
+    *) echo "FAIL T10 emits guard diagnostic — got: $t10_out"; FAILED=$((FAILED + 1)) ;;
+esac
+
+echo
+if [ "$FAILED" -eq 0 ]; then echo "All set-handover-dir tests passed."
+else echo "$FAILED set-handover-dir test(s) failed."; exit 1; fi

--- a/scripts/lib/handover-path.sh
+++ b/scripts/lib/handover-path.sh
@@ -37,16 +37,15 @@
 #     which uses pure; flush.sh refuses Mode A explicitly and only runs
 #     in Mode B where pure and _ensure behave identically.)
 #
-# Post-HIMMEL-124 deployment guidance:
-#   All personal handover state has been centralized in the yotam_docs
-#   repo (see yotam_docs/README.md). The inline default (Mode A) in this
-#   resolver still works for any script that lives in himmel, but it
-#   now points at a near-empty himmel/handovers/ — only the README stub
-#   that points at yotam_docs remains there. To get the migrated
-#   content, set HANDOVER_DIR to yotam_docs/handovers in the shell that
-#   launches Claude:
+# Deployment guidance (HIMMEL-335):
+#   Mode A (inline <repo>/handovers/) is the default and works out of the
+#   box. To centralize handover state in a separate repo (Mode B) — so
+#   handover commits don't land on your feature branches — run
+#   `/handover-setup`: it prompts for the location and writes HANDOVER_DIR
+#   into <repo>/.env. The shell loader scripts/lib/load-dotenv.sh feeds
+#   that value to handover scripts; you can also export it directly:
 #
-#       export HANDOVER_DIR="$HOME/Documents/github/yotam_docs/handovers"
+#       export HANDOVER_DIR="/abs/path/to/your-state-repo/handovers"
 #
 #   HIMMEL-129 (done 2026-05-25) shipped the bucket-layout layer that
 #   splits <state-root>/ into per-repo subfolders

--- a/scripts/lib/load-dotenv.sh
+++ b/scripts/lib/load-dotenv.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# load-dotenv.sh — shell-side .env key loader (HIMMEL-335).
+#
+# Mirrors the Jira CLI's loadEnv() (scripts/jira/src/client.ts): reads the
+# primary checkout's .env and exports requested keys into the environment
+# ONLY if they are currently unset (a value already in the live env wins,
+# same as JS `??=`). This makes <repo-root>/.env a real config source for the
+# handover shell tooling (HANDOVER_DIR, USER_SLUG) — not just for the Jira CLI.
+#
+# Usage — source this file, then:
+#   load_dotenv [KEY ...]
+# With no args, loads the default keys: HANDOVER_DIR USER_SLUG.
+#
+# The .env path is resolved like the Jira CLI: the parent of
+# `git rev-parse --git-common-dir`, so from inside a git worktree it still
+# finds the PRIMARY checkout's .env (the gitignored .env is not copied into
+# worktrees). Falls back to two levels up from this script if git is absent.
+#
+# Safety: never `source`s the file (no arbitrary code execution). Extracts
+# only the requested `KEY=` lines; skips comments, blanks, and lines without
+# '='; strips surrounding whitespace and a trailing CR (CRLF-safe).
+
+# Strip leading/trailing whitespace + trailing CR. Pure (stdout only).
+_load_dotenv_trim() {
+    local s="$1"
+    s="${s%$'\r'}"
+    s="${s#"${s%%[![:space:]]*}"}"   # ltrim
+    s="${s%"${s##*[![:space:]]}"}"   # rtrim
+    printf '%s' "$s"
+}
+
+# Resolve the primary checkout root (where the gitignored .env lives).
+_load_dotenv_root() {
+    local common
+    if common=$(git rev-parse --git-common-dir 2>/dev/null); then
+        ( cd "$common/.." && pwd ) && return 0
+    fi
+    ( cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd )
+}
+
+load_dotenv() {
+    local keys=("$@")
+    [ "${#keys[@]}" -eq 0 ] && keys=(HANDOVER_DIR USER_SLUG)
+
+    local root envfile
+    root=$(_load_dotenv_root) || return 0
+    envfile="$root/.env"
+    [ -f "$envfile" ] || return 0
+
+    local line key val want
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in ''|'#'*) continue ;; esac
+        [ "${line#*=}" = "$line" ] && continue   # no '=' → not a KEY=VALUE line
+        key=$(_load_dotenv_trim "${line%%=*}")
+        for want in "${keys[@]}"; do
+            # First match wins: once exported, ${!want} is non-empty so the
+            # next matching line for the same key is skipped here too.
+            if [ "$key" = "$want" ] && [ -z "${!want:-}" ]; then
+                val=$(_load_dotenv_trim "${line#*=}")
+                export "$want=$val"
+            fi
+        done
+    done < "$envfile"
+}

--- a/scripts/lib/test-load-dotenv.sh
+++ b/scripts/lib/test-load-dotenv.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Tests for scripts/lib/load-dotenv.sh (HIMMEL-335).
+# Each case runs load_dotenv in its own $(...) subshell to isolate the
+# exported env between cases — the subshell-scoped export is intentional.
+# shellcheck disable=SC2030,SC2031
+set -uo pipefail
+
+LIB="$(cd "$(dirname "$0")" && pwd)/load-dotenv.sh"
+# shellcheck source=load-dotenv.sh
+# shellcheck disable=SC1091
+. "$LIB"
+
+FAILED=0
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "PASS $label"
+    else
+        echo "FAIL $label — expected '$expected', got '$actual'"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+REPO="$TMP/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init --quiet
+
+# T1: sets a key that is currently unset.
+printf 'HANDOVER_DIR=/c/some/path/handovers\n' > "$REPO/.env"
+got=$( cd "$REPO" && unset HANDOVER_DIR && load_dotenv HANDOVER_DIR && printf '%s' "${HANDOVER_DIR:-<unset>}" )
+assert_eq "T1 sets unset key" "/c/some/path/handovers" "$got"
+
+# T2: a value already in the live env wins (??= semantics).
+got=$( cd "$REPO" && export HANDOVER_DIR=/live/value && load_dotenv HANDOVER_DIR && printf '%s' "$HANDOVER_DIR" )
+assert_eq "T2 live env wins" "/live/value" "$got"
+
+# T3: missing .env → no-op, key stays unset, rc=0.
+rm -f "$REPO/.env"
+out=$( cd "$REPO" && unset HANDOVER_DIR && load_dotenv HANDOVER_DIR; rc=$?; printf '%s|%s' "${HANDOVER_DIR:-<unset>}" "$rc" )
+assert_eq "T3 missing .env no-op" "<unset>|0" "$out"
+
+# T4: CRLF-safe (trailing CR stripped from value).
+printf 'HANDOVER_DIR=/c/crlf/path\r\n' > "$REPO/.env"
+got=$( cd "$REPO" && unset HANDOVER_DIR && load_dotenv HANDOVER_DIR && printf '[%s]' "$HANDOVER_DIR" )
+assert_eq "T4 CRLF stripped" "[/c/crlf/path]" "$got"
+
+# T5: comments / blanks / non-KV lines skipped; surrounding whitespace trimmed.
+printf '# comment\n\nnot-a-kv-line\n  HANDOVER_DIR =  /c/spaced/path  \n' > "$REPO/.env"
+got=$( cd "$REPO" && unset HANDOVER_DIR && load_dotenv HANDOVER_DIR && printf '[%s]' "$HANDOVER_DIR" )
+assert_eq "T5 trims + skips noise" "[/c/spaced/path]" "$got"
+
+# T6: first match wins on a duplicated key.
+printf 'HANDOVER_DIR=/first\nHANDOVER_DIR=/second\n' > "$REPO/.env"
+got=$( cd "$REPO" && unset HANDOVER_DIR && load_dotenv HANDOVER_DIR && printf '%s' "$HANDOVER_DIR" )
+assert_eq "T6 first match wins" "/first" "$got"
+
+# T7: default keys (no args) load HANDOVER_DIR + USER_SLUG.
+printf 'HANDOVER_DIR=/c/h\nUSER_SLUG=tester\n' > "$REPO/.env"
+got=$( cd "$REPO" && unset HANDOVER_DIR USER_SLUG && load_dotenv && printf '%s|%s' "$HANDOVER_DIR" "$USER_SLUG" )
+assert_eq "T7 default keys" "/c/h|tester" "$got"
+
+# T8: only requested keys are loaded (others stay unset).
+printf 'HANDOVER_DIR=/c/h\nOTHER_KEY=should-not-load\n' > "$REPO/.env"
+got=$( cd "$REPO" && unset HANDOVER_DIR OTHER_KEY && load_dotenv HANDOVER_DIR && printf '%s|%s' "$HANDOVER_DIR" "${OTHER_KEY:-<unset>}" )
+assert_eq "T8 only requested keys" "/c/h|<unset>" "$got"
+
+# T9: from inside a git WORKTREE, the loader resolves the PRIMARY checkout's
+# .env (the headline guarantee — a gitignored .env is never copied into a
+# worktree, so git-common-dir resolution must reach back to the main repo).
+git -C "$REPO" config user.email t@example.com
+git -C "$REPO" config user.name tester
+git -C "$REPO" commit --allow-empty -q -m init
+printf 'HANDOVER_DIR=/c/primary/handovers\n' > "$REPO/.env"
+WT="$TMP/wt"
+git -C "$REPO" worktree add -q "$WT" -b wt-branch
+got=$( cd "$WT" && unset HANDOVER_DIR && load_dotenv HANDOVER_DIR && printf '%s' "${HANDOVER_DIR:-<unset>}" )
+assert_eq "T9 worktree reads primary .env" "/c/primary/handovers" "$got"
+git -C "$REPO" worktree remove --force "$WT" 2>/dev/null || true
+
+# T10: outside any git repo, _load_dotenv_root falls back to the script-
+# relative root and no-ops cleanly when no .env is found there (rc=0, no crash).
+NONGIT="$TMP/nongit"
+mkdir -p "$NONGIT"
+out=$( cd "$NONGIT" && unset HANDOVER_DIR && load_dotenv HANDOVER_DIR; rc=$?; printf '%s|%s' "${HANDOVER_DIR:-<unset>}" "$rc" )
+assert_eq "T10 git-absent fallback clean no-op" "<unset>|0" "$out"
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+    echo "All load-dotenv tests passed."
+else
+    echo "$FAILED load-dotenv test(s) failed."
+    exit 1
+fi

--- a/templates/luna-second-brain/.env.example
+++ b/templates/luna-second-brain/.env.example
@@ -7,6 +7,6 @@
 
 # External handover directory (Mode B). When set, scripts read/write
 # handover state under this path instead of <repo>/handovers/. Useful if
-# you keep cross-repo handover state in a separate repo (e.g. yotam_docs).
+# you keep cross-repo handover state in a separate, dedicated state repo.
 # Path must exist; resolver fails closed if it doesn't.
-# HANDOVER_DIR=/c/path/to/your/handovers
+# HANDOVER_DIR=/c/path/to/your/handover-repo/handovers


### PR DESCRIPTION
## Portable handover bootstrap

Makes the handover system's bootstrap operator-agnostic — it no longer assumes
a specific personal "state" repo, so any user can adopt it cleanly.

### What changed

- **`scripts/lib/load-dotenv.sh` (+test)** — a shell-side `.env` key loader
  mirroring the Jira CLI's `loadEnv()`. Exports `HANDOVER_DIR` / `USER_SLUG`
  from `<repo>/.env` only if unset (live env wins). Previously the shell
  tooling read only the live env var, so "config in `.env`" didn't reach it.
- **`scripts/handover/hop.sh`** — removed a hardcoded fallback path; now
  resolves the handover root via the shared `handover-path` resolver +
  `user-slug` (`<HANDOVER_DIR or <repo>/handovers>/<USER_SLUG>`). Fails closed.
- **`scripts/handover/set-handover-dir.sh` (+test)** — idempotent
  `HANDOVER_DIR` writer (create-or-update in place, forward-slash normalized,
  refuses a non-regular-file target).
- **`/handover-setup` command** — first-time bootstrap: prompts inline
  (Mode A) vs external state repo (Mode B), persists a Mode-B choice to `.env`
  as `HANDOVER_DIR`, then runs `init`/`register`. The location is always
  prompted, never hardcoded.
- **Config/docs** — root `.env.example` documents `HANDOVER_DIR`; skill docs,
  command runbook, and the luna template genericized.

### Verification

- New suites green (`test-load-dotenv.sh`, `test-set-handover-dir.sh`,
  `test-hop.sh` incl. a real `git worktree` resolution case + fail-closed
  paths). `shellcheck` clean on all changed/new shell files. Verified on
  Windows Git Bash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
