### PR TITLE
docs: de-personalize handover state-repo refs + getting-started /handover-setup

### DIFF
--- a/.claude/commands/handover-link.md
+++ b/.claude/commands/handover-link.md
@@ -7,7 +7,7 @@ Wraps `scripts/handover-link.sh`. Default verb is `status`.
 
 Modes:
 - **A — inline**: `HANDOVER_DIR` unset; handovers live in `<repo>/handovers/`. Default for fresh clones.
-- **B — external**: `HANDOVER_DIR` points to an existing directory (typically a separate repo like `yotam_docs/handovers`). Set in the shell that launched Claude Code — env is session-sticky.
+- **B — external**: `HANDOVER_DIR` points to an existing directory (typically a separate repo like `<state-repo>/handovers`). Set in the shell that launched Claude Code — env is session-sticky.
 
 Verbs:
 - `/handover-link` — print resolved root + mode (default `status`).

--- a/.claude/commands/improve.md
+++ b/.claude/commands/improve.md
@@ -111,6 +111,6 @@ refinements when the operator wants to tweak.
 **Sensitivity note:** artifacts contain the original draft + refined prompt
 verbatim. If the operator pasted credentials, API keys, or sensitive context
 into the draft, those values land on disk inside the artifact. Mode A
-artifacts are gitignored; Mode B writes to private `yotam_docs`. Treat the
+artifacts are gitignored; Mode B writes to private `<state-repo>`. Treat the
 `.improve/` directory as sensitive regardless — do not commit + do not copy
 off-disk without redacting first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,11 +134,11 @@ Three tiers for luna-touching artifacts:
    day 1; plugin specs stay in `plugins/<plugin>/README.md`).
 2. **Personal-state work artifacts** (handovers, work/decision logs,
    journal-style decision records, next-session-resume) →
-   `yotam_docs/handovers/<USER_SLUG>/<repo-bucket>/` (cross-cutting → `…/cross/`).
+   `<state-repo>/handovers/<USER_SLUG>/<repo-bucket>/` (cross-cutting → `…/cross/`).
 3. **Vault content** (clips, notes, daily entries) → unchanged, stays in luna.
 
 Author new luna-touching reference docs in `docs/luna/`; author
-journal-style decision records under the appropriate yotam_docs bucket.
+journal-style decision records under the appropriate <state-repo> bucket.
 
 **Luna recent context (HIMMEL-254):** read `~/Documents/luna/hot.md` (if present)
 first for recent vault context (~500-word Tier-2 hot cache) before crawling luna
@@ -156,8 +156,9 @@ Pick by intent: fresh feature = `/worktree`, prune cycle = `/clean`,
 both = `/clean_garden`. (Superseded, don't use: `/new-worktree`, `/clean_gone`.)
 
 ### Handover
-All personal handover state is centralized in the `yotam_docs` repo
-(himmel `handovers/` is a stub). The v2 handover skill +
+All personal handover state is centralized in your handover state repo
+(configured via `/handover-setup` / `$HANDOVER_DIR`; himmel `handovers/`
+is a stub). The v2 handover skill +
 `~/.claude/handover/registry.json` are the live source of truth —
 inspect/change via `/handover repos|register|init`, never by editing
 docs. Branched auto-commit + PR-open + flush flows + the single-root

--- a/docs/daily-loop.md
+++ b/docs/daily-loop.md
@@ -298,7 +298,7 @@ state:
 
 The handover skill writes a structured summary of what was done, what is
 in-flight, and what the next session should pick up. State is stored in
-the `yotam_docs` repo (not in himmel's `handovers/` stub). To resume in
+your handover state repo (not in himmel's `handovers/` stub). To resume in
 a future session, use `/handover-resume-armed` or browse the handover
 registry via `/handover repos`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,6 +109,11 @@ inside an active session. Then the day-to-day loop is:
                              #   next session (or a teammate) resumes with full context
 ```
 
+> **First time using `/handover`?** Run **`/handover-setup`** once to point it at
+> your own state store — an inline `handovers/` folder in the repo, or a separate
+> git repo (via `HANDOVER_DIR`). It's configurable, not hardcoded, so your
+> cross-session notes land wherever you want them.
+
 **How to tell it's working:** `pre-commit run --all-files` should pass, and if you
 try to edit a file on `main` you'll get a `block-edit-on-main` message pointing you
 back into a worktree (`/clean_garden` or `/worktree`). That message is the guardrail

--- a/docs/handover/overnight-mode.md
+++ b/docs/handover/overnight-mode.md
@@ -1,6 +1,6 @@
 # Overnight Mode — Autonomous Pipeline
 
-> **Trigger phrase:** when a user prompt includes the phrase **"overnight mode"** alongside a `next-session-*.md` path (e.g. `load handovers/yotam/himmel/epics/HIMMEL-XX-…/next-session-N.md overnight mode`), execute this pipeline end-to-end without pausing for confirmation between phases.
+> **Trigger phrase:** when a user prompt includes the phrase **"overnight mode"** alongside a `next-session-*.md` path (e.g. `load handovers/<USER_SLUG>/himmel/epics/HIMMEL-XX-…/next-session-N.md overnight mode`), execute this pipeline end-to-end without pausing for confirmation between phases.
 
 ## When to use it
 
@@ -14,7 +14,7 @@ Do **not** use overnight mode when:
 ## The 11 phases
 
 1. **Plan** — `superpowers:writing-plans` on the active brief; commit to `<plans-root>/YYYY-MM-DD-<slug>.md` where `<plans-root>` resolves as:
-   - `$HANDOVER_DIR/plans/` when `HANDOVER_DIR` is set (Mode B — plans live with handover state in `yotam_docs/handovers/plans/`).
+   - `$HANDOVER_DIR/plans/` when `HANDOVER_DIR` is set (Mode B — plans live with handover state in `<state-repo>/handovers/plans/`).
    - `<repo>/docs/superpowers/plans/` otherwise (Mode A default — backwards-compat;
      this path is **gitignored**, so Mode-A plans stay local and are never committed
      to the public repo, per HIMMEL-297).

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -86,7 +86,7 @@ Companion artifacts:
 operator's original draft + refined prompt verbatim. If a draft
 includes credentials, API keys, or sensitive context, those land on
 disk. Mode A artifacts are gitignored (`/.improve/` in `.gitignore`);
-Mode B writes to `yotam_docs` which is also private. Treat the
+Mode B writes to `<state-repo>` which is also private. Treat the
 `.improve/` directory as sensitive regardless — do not commit it,
 do not copy it off-disk without redacting first.
 
@@ -292,7 +292,7 @@ Spec: `scripts/hooks/test-auto-arm-on-cap.sh` (paired smoke suite).
    absolute himmel path (idempotent, prompt-gated, mirrors the
    end-session-wiki registration). The hook resolves its lib +
    arm-resume relative to its own location, so it works from any
-   project's session — luna and yotam_docs sessions get cap protection
+   project's session — luna and <state-repo> sessions get cap protection
    too. NOTE: with both layers active, himmel sessions run the hook
    twice per tool call — harmless (the throttle marker is shared, so
    the second invocation is a single stat() no-op).

--- a/docs/internals/handover-system.md
+++ b/docs/internals/handover-system.md
@@ -9,7 +9,8 @@
 > `/handover repos|register|init` slash commands, not by editing docs.
 
 **Post-HIMMEL-124 (2026-05-25):** all personal handover state has been
-centralized in the `yotam_docs` repo. himmel `handovers/yotam/` is
+centralized in your handover state repo (configured via `/handover-setup`
+/ `$HANDOVER_DIR`). himmel `handovers/<USER_SLUG>/` is
 empty except for a README pointer. Three resolution layers — the v2
 handover skill's multi-repo registry (preferred for skills), the
 HIMMEL-118 single-root resolver (still wired for scripts), and a
@@ -134,7 +135,7 @@ Smoke test: `bash scripts/hooks/test-check-cr-before-push.sh`
 
 Pre-HIMMEL-124 the skill resolved per-repo state under
 `<repo-root>/handovers/<user>/`. Post-HIMMEL-124 the expected target
-is **yotam_docs** for any personal state regardless of which repo
+is the **`<state-repo>`** for any personal state regardless of which repo
 triggered the skill. HIMMEL-129 added the bucket layer
 (`<state-root>/<repo>/{epics,standalones}/` where `<repo>` ∈
 himmel | luna | luna_brain | cross) — SKILL.md resolver auto-detects
@@ -152,7 +153,7 @@ shell scripts use when they only know about one root:
 - **Mode B — external**: `HANDOVER_DIR` set → that path. **Recommended
   default** post-HIMMEL-124:
   ```bash
-  export HANDOVER_DIR="$HOME/Documents/github/yotam_docs/handovers"
+  export HANDOVER_DIR="$HOME/Documents/github/<state-repo>/handovers"
   ```
 
 Consumed by `scripts/handover/auto-commit.sh`,
@@ -171,16 +172,16 @@ misconfiguration).
 
 - **HIMMEL-13** (done) — initial migration of cross-project subset
   (luna/, manual_notes.md, random_dreams.md) from himmel/handovers/
-  → yotam_docs/handovers/.
+  → <state-repo>/handovers/.
 - **HIMMEL-124** (in progress) — full centralization. 234 files
-  migrated from himmel/handovers/yotam/* → yotam_docs/handovers/yotam/
+  migrated from himmel/handovers/<USER_SLUG>/* → <state-repo>/handovers/<USER_SLUG>/
   (PR #138). himmel side reduced to a stub README. **Remaining:**
-  registry.json + SKILL.md updates to make yotam_docs the resolved
+  registry.json + SKILL.md updates to make <state-repo> the resolved
   default for personal-state ops.
 - **HIMMEL-129** (done 2026-05-25) — split flat
-  `yotam_docs/handovers/yotam/` layout into `cross/himmel/luna/luna_brain/`
+  `<state-repo>/handovers/<USER_SLUG>/` layout into `cross/himmel/luna/luna_brain/`
   subfolders. 17 standalones + 15 epics routed by ticket prefix.
-  `yotam_docs/README.md` + SKILL.md resolver updated; bucket layer is
+  `<state-repo>/README.md` + SKILL.md resolver updated; bucket layer is
   opt-in (activated by presence of any bucket dir under `<state-root>`).
 
 ## User-slug resolution (HIMMEL-145)

--- a/docs/jira-projects.md
+++ b/docs/jira-projects.md
@@ -7,7 +7,7 @@ PR introducing this file).
 | Key | ID | Name | Scope | Notes |
 |-----|----|------|-------|-------|
 | HIMMEL | 10033 | Himmel | himmel repo — engineering, infra, tooling. | Default project for the `jira` CLI (`JIRA_PROJECT_KEY=HIMMEL` in `.env`). All Epics for himmel work live here. Standalones historically NOT tracked here. |
-| LUNA | 10066 | Luna | Luna vault (personal second brain). | Created 2026-05-19 via `jira project-create`. Template: Kanban classic. For tickets tracking Luna-specific work. Vault content lives in the `luna` repo; Luna handover docs live in himmel `handovers/yotam/`. |
+| LUNA | 10066 | Luna | Luna vault (personal second brain). | Created 2026-05-19 via `jira project-create`. Template: Kanban classic. For tickets tracking Luna-specific work. Vault content lives in the `luna` repo; Luna handover docs live in himmel `handovers/<USER_SLUG>/`. |
 
 ## Usage
 
@@ -20,8 +20,8 @@ PR introducing this file).
 
 - Epics: `<PROJECT>-N` (e.g. `HIMMEL-29` for VirtualBox VM Management).
 - Standalones (himmel concept): historically not in Jira — tracked only in
-  `yotam_docs/handovers/yotam/<repo>/standalones/` (`<repo>` ∈ himmel | luna |
+  `<state-repo>/handovers/<USER_SLUG>/<repo>/standalones/` (`<repo>` ∈ himmel | luna |
   luna_brain | cross; post-HIMMEL-129 bucket layout). New convention from
   2026-05-19 forward files standalones as Stories in their topical project
   (e.g. Luna-related standalones → LUNA-N Story under
-  `yotam_docs/handovers/yotam/luna/standalones/`).
+  `<state-repo>/handovers/<USER_SLUG>/luna/standalones/`).

--- a/docs/luna/README.md
+++ b/docs/luna/README.md
@@ -6,7 +6,7 @@ Per the luna-area docs convention locked 2026-05-25 (HIMMEL-138 +
 `CLAUDE.md` "Luna-area docs convention" section): operator-facing
 reference docs (guides, runbooks, architecture) for luna-touching
 features in this repo live here. Personal-state work artifacts
-(handovers, decision logs, journal entries) live in `yotam_docs`.
+(handovers, decision logs, journal entries) live in `<state-repo>`.
 
 ## Contents
 
@@ -24,5 +24,5 @@ features in this repo live here. Personal-state work artifacts
 | Luna repo's own reference docs | `luna/docs/` |
 | luna_brain reference docs (OSS-bootstrap-ready) | `luna_brain/docs/` |
 | Plugin specs | `plugins/<plugin>/README.md` |
-| Handovers / work logs / decision journals | `yotam_docs/handovers/<USER_SLUG>/<repo-bucket>/` |
+| Handovers / work logs / decision journals | `<state-repo>/handovers/<USER_SLUG>/<repo-bucket>/` |
 | Luna vault content (clips, human notes) | luna vault itself (unchanged) |

--- a/marketplace/plugins/handover/commands/handover-setup.md
+++ b/marketplace/plugins/handover/commands/handover-setup.md
@@ -10,7 +10,7 @@ Bootstrap the handover system for this operator/repo. The job of this command
 is the one-time **setup** the rest of the handover skill assumes is already
 done: pick *where* handover state lives, persist that choice so every later
 session resolves it the same way, and hand off to the skill's `init`/`register`
-flow. Do **not** hardcode any specific repo (e.g. `yotam_docs`) — always ask.
+flow. Do **not** hardcode any specific repo (e.g. `<state-repo>`) — always ask.
 
 ### 1. Resolve the target repo root
 

--- a/marketplace/plugins/handover/skills/handover/SKILL.md
+++ b/marketplace/plugins/handover/skills/handover/SKILL.md
@@ -23,7 +23,7 @@ Full algorithm + canonicalisation rules: `references/routing.md` (load only on a
 
 ## Bucket Resolution (HIMMEL-129)
 
-Some registered repos — the **state-root host** an operator chose at `/handover-setup` (for this maintainer's setup, a repo named `yotam_docs`) — split `<state-root>` into per-source-repo buckets to keep work from multiple code repos disambiguated:
+Some registered repos — the **state-root host** an operator chose at `/handover-setup` (e.g. a repo named `<state-repo>`) — split `<state-root>` into per-source-repo buckets to keep work from multiple code repos disambiguated:
 
 ```
 <state-root>/
@@ -65,7 +65,7 @@ Top-level files (`status.md`, `roadmap.md`, `backlog.md`, `tech-debt.md`, `count
 
 **v2 additions:** each repo entry may also carry `bucket_vocab`, `buckets_custom`, `defaults: {}`, and `stale_thresholds_days: {}`. See `references/init-register.md` for the full schema and key reference. Absence of any v2 field means "use built-in default".
 
-**`source_buckets_extra` (HIMMEL-307):** the state-root **host** repo entry (e.g. `yotam_docs`) may carry `source_buckets_extra` — an optional array of extra source-bucket names (kebab-case) that extends the recognized source-bucket set beyond the four built-ins (see Bucket Resolution). This is a **different axis** from `buckets_custom` (which renames the time-horizon vocab) and from `bucket_name` (a per-source-repo label used by the prefix rule). Absent or empty ⇒ the four built-ins only.
+**`source_buckets_extra` (HIMMEL-307):** the state-root **host** repo entry (e.g. `<state-repo>`) may carry `source_buckets_extra` — an optional array of extra source-bucket names (kebab-case) that extends the recognized source-bucket set beyond the four built-ins (see Bucket Resolution). This is a **different axis** from `buckets_custom` (which renames the time-horizon vocab) and from `bucket_name` (a per-source-repo label used by the prefix rule). Absent or empty ⇒ the four built-ins only.
 
 ### Reading and writing the registry
 

--- a/marketplace/plugins/handover/skills/handover/references/init-register.md
+++ b/marketplace/plugins/handover/skills/handover/references/init-register.md
@@ -28,7 +28,7 @@ Mode-B choice writes `HANDOVER_DIR=` into `<repo-root>/.env` (via
 `scripts/handover/set-handover-dir.sh`) so every later session resolves the same
 location. `init` then operates on the resolved `<state-root-host>` — the
 `HANDOVER_DIR` host when set, else the inline default. Never hardcode a specific
-state repo (e.g. `yotam_docs`); it is always the operator-chosen location. The
+state repo (e.g. `<state-repo>`); it is always the operator-chosen location. The
 `path` input below is the **code repo being tracked**, not the state-root host.
 
 ### Inputs (interactive prompt via `AskUserQuestion` or text)
@@ -230,7 +230,7 @@ jira:   <KEY or —>
 
 ## Migration recipe — himmel
 
-Porting the existing `himmel/handovers/yotam/` state into the registry:
+Porting the existing `himmel/handovers/<USER_SLUG>/` state into the registry:
 
 ```bash
 # Inside any cwd:
@@ -279,7 +279,7 @@ v2 adds four optional fields to each repo entry. All have safe defaults; absence
         "zombie": 90
       },
 
-      // HIMMEL-307 — host-repo-only addition (set on the state-root host, e.g. yotam_docs):
+      // HIMMEL-307 — host-repo-only addition (set on the state-root host, e.g. <state-repo>):
       "source_buckets_extra": ["luna-medic"] // optional; extra source-bucket names beyond the 4 built-ins. Absent/empty ⇒ 4-set.
     }
   }
@@ -300,8 +300,8 @@ v2 adds four optional fields to each repo entry. All have safe defaults; absence
 ### `source_buckets_extra` (HIMMEL-307)
 
 Optional **host-repo-only** field — set it on the registry entry whose
-`<state-root>` actually hosts the per-source-repo bucket directories (for this
-operator, `yotam_docs`). It extends the **recognized source-bucket set** (see
+`<state-root>` actually hosts the per-source-repo bucket directories (e.g.
+`<state-repo>`). It extends the **recognized source-bucket set** (see
 SKILL.md "Bucket Resolution") beyond the four built-ins
 (`himmel`/`luna`/`luna_brain`/`cross`).
 

--- a/scripts/handover/CLAUDE.md
+++ b/scripts/handover/CLAUDE.md
@@ -9,7 +9,8 @@ to resolve the handover directory. **Never hardcode `./handovers/`** — the
 single-root resolver + `HANDOVER_DIR` bridge depend on it.
 
 ## Conventions
-- Personal handover state is centralized in the `yotam_docs` repo; himmel
+- Personal handover state is centralized in your handover state repo
+  (configured via `/handover-setup` / `$HANDOVER_DIR`); himmel
   `handovers/` is a stub. Don't write durable state into himmel.
 - The live source of truth is the v2 handover skill +
   `~/.claude/handover/registry.json` — change it via `/handover`, never by

--- a/tests/fixtures/cr-verify-before-critical/README.md
+++ b/tests/fixtures/cr-verify-before-critical/README.md
@@ -68,4 +68,4 @@ git branch -D fixture/cr-verify-before-critical
 - `marketplace/plugins/pr-review-toolkit-himmel/agents/code-reviewer.md` § Verify-before-critical
 - `.claude/commands/pr-check.md` step 3 (the wire that uses this agent)
 - HIMMEL-178 ticket
-- ADR: `yotam_docs/handovers/yotam/cross/HIMMEL-178-reviewer-verify-before-critical.md`
+- ADR: `<state-repo>/handovers/<USER_SLUG>/cross/HIMMEL-178-reviewer-verify-before-critical.md`


### PR DESCRIPTION
Replaces the hardcoded operator state-repo name `yotam_docs` with the generic `<state-repo>` placeholder across the handover docs/plugin .md files (path is configurable via /handover-setup + $HANDOVER_DIR). Adjacent `handovers/yotam/` slugs -> `handovers/<USER_SLUG>/`. Adds a getting-started /handover-setup highlight.