### PR TITLE
chore: de-personalize yotam slug — docs/<USER_SLUG>, manifests/yotamleo, tests/generated

### DIFF
--- a/.claude/commands/handover-arm-resume.md
+++ b/.claude/commands/handover-arm-resume.md
@@ -32,10 +32,10 @@ multi-day sentinel) is scheduled correctly — schtasks gets `/sd <date>`, `at`
 gets `-t <stamp>` (fixes the old "time already passed today → never fires" bug).
 
 Common invocations:
-- `/handover-arm-resume --time smart --handover handovers/yotam/status.md`
-- `/handover-arm-resume --time 07:22 --handover handovers/yotam/himmel/epics/HIMMEL-70-github-warp/next-session-12.md`
-- `/handover-arm-resume --time auto --handover handovers/yotam/himmel/standalones/HIMMEL-44-windows-install-test/next-session.md --force`
-- `/handover-arm-resume --time 14:00 --handover handovers/yotam/status.md --dry-run`
+- `/handover-arm-resume --time smart --handover handovers/<USER_SLUG>/status.md`
+- `/handover-arm-resume --time 07:22 --handover handovers/<USER_SLUG>/himmel/epics/HIMMEL-70-github-warp/next-session-12.md`
+- `/handover-arm-resume --time auto --handover handovers/<USER_SLUG>/himmel/standalones/HIMMEL-44-windows-install-test/next-session.md --force`
+- `/handover-arm-resume --time 14:00 --handover handovers/<USER_SLUG>/status.md --dry-run`
 
 Exit codes: 0 armed, 1 usage error, 2 env unusable, 3 dedup block, 4 scheduler failed.
 

--- a/docs/internals/handover-system.md
+++ b/docs/internals/handover-system.md
@@ -205,6 +205,6 @@ Doc references to operator-specific paths should use the
 `{{USER_SLUG}}` placeholder in templates + `<USER_SLUG>` in prose.
 `scripts/test-user-slug-resolve.sh` smoke-tests all paths (18/18 pass).
 
-This is the HIMMEL-132 Phase 2 envification. Existing `yotam`-hardcoded
+This is the HIMMEL-132 Phase 2 envification. Existing `<USER_SLUG>`-hardcoded
 references in journal/docs/* paths are out of scope — sweep deferred
 to a follow-up ticket if/when an alternate operator joins.

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -168,7 +168,7 @@ Installed via `extraKnownMarketplaces` in `settings.json`.
 
 #### handover (`handover@himmel`)
 
-**What:** Session handover and work tracking system for Claude Code. Operationalizes `handovers/yotam/` via a skill.
+**What:** Session handover and work tracking system for Claude Code. Operationalizes `handovers/<USER_SLUG>/` via a skill.
 **Skill:** `handover:handover` — invoke with phrases like "new epic", "new task", "end session", "update status"
 **Skill file:** `marketplace/plugins/handover/skills/handover/SKILL.md`
 **Commands:**
@@ -182,7 +182,7 @@ Installed via `extraKnownMarketplaces` in `settings.json`.
 | `end-session [id]` | Creates `next-session-N.md` (sequential, never overwrites) with cold-start prompt |
 
 **Session files:** `next-session-1.md`, `next-session-2.md` ... (append-only, highest = latest).
-**Tracking root:** `handovers/yotam/` — all state is versioned markdown.
+**Tracking root:** `handovers/<USER_SLUG>/` — all state is versioned markdown.
 
 #### obsidian-triage (`obsidian-triage@himmel`)
 

--- a/marketplace/.claude-plugin/marketplace.json
+++ b/marketplace/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "himmel",
   "owner": {
-    "name": "yotam"
+    "name": "yotamleo"
   },
   "plugins": [
     {
@@ -9,7 +9,7 @@
       "source": "./plugins/himmel-ops",
       "description": "Harness-meta operational skills for himmel. Load-on-trigger guardrail-recovery playbook (stuck-playbook) that surfaces escape-hatches when an auto-mode write is denied, a Bash command falls through to the classifier, a permission prompt hangs, or a pre-push gate fails — so operational/troubleshooting rules stay out of the always-on root CLAUDE.md (HIMMEL-211).",
       "author": {
-        "name": "yotam"
+        "name": "yotamleo"
       },
       "keywords": [
         "himmel",
@@ -22,9 +22,9 @@
     {
       "name": "handover",
       "source": "./plugins/handover",
-      "description": "Handover tracking system for yotam sessions — manages epics, tasks, standalones, and session handovers",
+      "description": "Handover tracking system — manages epics, tasks, standalones, and session handovers",
       "author": {
-        "name": "yotam"
+        "name": "yotamleo"
       }
     },
     {
@@ -50,7 +50,7 @@
       "source": "./plugins/obsidian-triage",
       "description": "Autonomous triage + cross-clip synthesis for Obsidian Web Clipper output. /triage-clips summarizes each clip, infers tags from the existing vault tag set, suggests Related Notes via link-graph proximity, extracts Action Items to today's daily note, annotates a Promotion candidate, marks processed:true (idempotent). /synthesize-clips finds recurring patterns across processed clips and writes vault-restructuring proposals.",
       "author": {
-        "name": "yotam"
+        "name": "yotamleo"
       },
       "keywords": [
         "obsidian",

--- a/marketplace/README.md
+++ b/marketplace/README.md
@@ -81,7 +81,7 @@ The **Travels** column tells you how portable a plugin is on its own:
 - **✅ standalone** — works in any repo/vault, no himmel assumptions.
 - **🔶 fork** — a vendored fork of an upstream plugin; portable, but read the
   plugin's README for the fork delta and upstream-watch note.
-- **🔗 harness-coupled** — assumes the himmel harness or yotam's personal
+- **🔗 harness-coupled** — assumes the himmel harness or the operator's personal
   setup. Installable anywhere, but only useful in context.
 
 | Plugin | What you get | Travels | License |
@@ -92,7 +92,7 @@ The **Travels** column tells you how portable a plugin is on its own:
 | **pr-review-toolkit-himmel** | Vendored `code-reviewer` agent + a verify-before-critical sub-rule patch (HIMMEL-178). The other 5 agents stay on upstream `pr-review-toolkit:*`. | 🔶 fork | Apache-2.0 |
 | **telegram-himmel** | Telegram channel MCP plugin with the `getUpdates` poller gated behind `TELEGRAM_OWN_POLLER=1`, so only the owner session polls the single bot-token slot. Fork of `telegram@claude-plugins-official` v0.0.6. | 🔶 fork | Apache-2.0 |
 | **himmel-ops** | Harness-meta operational skill: `stuck-playbook` surfaces guardrail-recovery escape-hatches when an auto-mode write is denied, a Bash command falls through to the classifier, a permission prompt hangs, or a pre-push gate fails (HIMMEL-211). | 🔗 harness-coupled | — |
-| **handover** | Session handover tracking — manages epics, tasks, standalones, and session handovers via `~/.claude/handover/registry.json`. Built around yotam's multi-session workflow. | 🔗 harness-coupled | — |
+| **handover** | Session handover tracking — manages epics, tasks, standalones, and session handovers via `~/.claude/handover/registry.json`. Built around the operator's multi-session workflow. | 🔗 harness-coupled | — |
 
 Per-plugin detail (and fork rationale / upstream-watch protocol where it
 applies) lives in each plugin's own README under

--- a/marketplace/plugins/handover/.claude-plugin/plugin.json
+++ b/marketplace/plugins/handover/.claude-plugin/plugin.json
@@ -3,6 +3,6 @@
   "version": "2.0.0",
   "description": "Multi-repo handover tracking — epics, tasks, standalones, session handovers across any registered repo. State lives per-repo under <repo>/handovers/<user>/. Registry at ~/.claude/handover/registry.json.",
   "author": {
-    "name": "yotam"
+    "name": "yotamleo"
   }
 }

--- a/marketplace/plugins/handover/scripts/test-migrate-v1-to-v2.sh
+++ b/marketplace/plugins/handover/scripts/test-migrate-v1-to-v2.sh
@@ -7,6 +7,7 @@
 #   0 — all cases passed
 #   1 — at least one case failed
 set -uo pipefail
+SLUG="hbtest$$"   # generated neutral test user-slug (not hardcoded)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MIGRATE="$SCRIPT_DIR/migrate-v1-to-v2.sh"
@@ -18,11 +19,11 @@ fail=0
 fixture_setup() {
   local dir="$1"
   rm -rf "$dir"
-  mkdir -p "$dir/handovers/yotam/epics" "$dir/handovers/yotam/standalones"
+  mkdir -p "$dir/handovers/$SLUG/epics" "$dir/handovers/$SLUG/standalones"
 
   # v1 item WITH Jira key
-  mkdir -p "$dir/handovers/yotam/epics/#15-rename-himmel-and-jira/tasks"
-  cat > "$dir/handovers/yotam/epics/#15-rename-himmel-and-jira/master-plan.md" <<'EOF'
+  mkdir -p "$dir/handovers/$SLUG/epics/#15-rename-himmel-and-jira/tasks"
+  cat > "$dir/handovers/$SLUG/epics/#15-rename-himmel-and-jira/master-plan.md" <<'EOF'
 ---
 template_version: 1
 ---
@@ -33,8 +34,8 @@ template_version: 1
 EOF
 
   # v1 item WITHOUT Jira key (will be marked pending_jira_link with --no-jira-create)
-  mkdir -p "$dir/handovers/yotam/standalones/#3-legacy-item"
-  cat > "$dir/handovers/yotam/standalones/#3-legacy-item/brief.md" <<'EOF'
+  mkdir -p "$dir/handovers/$SLUG/standalones/#3-legacy-item"
+  cat > "$dir/handovers/$SLUG/standalones/#3-legacy-item/brief.md" <<'EOF'
 ---
 template_version: 1
 ---
@@ -44,7 +45,7 @@ template_version: 1
 EOF
 
   # Init the v1 counter
-  printf "# Counter\nNext: 16\n" > "$dir/handovers/yotam/counter.md"
+  printf "# Counter\nNext: 16\n" > "$dir/handovers/$SLUG/counter.md"
 }
 
 assert_dir_exists() {
@@ -80,19 +81,19 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 fixture_setup "$TMP"
 "$MIGRATE" --root "$TMP" --no-jira-create --quiet >/dev/null 2>&1 || true
-assert_dir_exists "$TMP/handovers/yotam/epics/HIMMEL-15-rename-himmel-and-jira"
-assert_dir_absent "$TMP/handovers/yotam/epics/#15-rename-himmel-and-jira"
-assert_grep "$TMP/handovers/yotam/epics/HIMMEL-15-rename-himmel-and-jira/master-plan.md" "template_version: 2"
-assert_grep "$TMP/handovers/yotam/epics/HIMMEL-15-rename-himmel-and-jira/master-plan.md" "^jira: HIMMEL-15"
+assert_dir_exists "$TMP/handovers/$SLUG/epics/HIMMEL-15-rename-himmel-and-jira"
+assert_dir_absent "$TMP/handovers/$SLUG/epics/#15-rename-himmel-and-jira"
+assert_grep "$TMP/handovers/$SLUG/epics/HIMMEL-15-rename-himmel-and-jira/master-plan.md" "template_version: 2"
+assert_grep "$TMP/handovers/$SLUG/epics/HIMMEL-15-rename-himmel-and-jira/master-plan.md" "^jira: HIMMEL-15"
 
 # Case 2: items without Jira keys stay #N when --no-jira-create
-assert_dir_exists "$TMP/handovers/yotam/standalones/#3-legacy-item"
-assert_grep "$TMP/handovers/yotam/standalones/#3-legacy-item/brief.md" "pending_jira_link: true"
+assert_dir_exists "$TMP/handovers/$SLUG/standalones/#3-legacy-item"
+assert_grep "$TMP/handovers/$SLUG/standalones/#3-legacy-item/brief.md" "pending_jira_link: true"
 
 # Case 3: re-running is idempotent
 "$MIGRATE" --root "$TMP" --no-jira-create --quiet >/dev/null 2>&1 || true
-assert_dir_exists "$TMP/handovers/yotam/epics/HIMMEL-15-rename-himmel-and-jira"
-assert_dir_absent "$TMP/handovers/yotam/epics/#15-rename-himmel-and-jira"
+assert_dir_exists "$TMP/handovers/$SLUG/epics/HIMMEL-15-rename-himmel-and-jira"
+assert_dir_absent "$TMP/handovers/$SLUG/epics/#15-rename-himmel-and-jira"
 
 echo "pass=$pass fail=$fail"
 [ "$fail" -eq 0 ]

--- a/marketplace/plugins/handover/scripts/test-skill-e2e.sh
+++ b/marketplace/plugins/handover/scripts/test-skill-e2e.sh
@@ -7,6 +7,7 @@
 #   0 — all checks pass
 #   1 — at least one check failed
 set -uo pipefail
+SLUG="hbtest$$"   # generated neutral test user-slug (not hardcoded)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
@@ -53,17 +54,17 @@ done
 if [ "$missing" -eq 0 ]; then ok "SKILL.md references all v2 docs"; else ko "$missing references missing from SKILL.md"; fi
 
 # 6. Post-migration himmel state: zero #N dirs (excluding .gitkeep)
-nstale=$(find "$ROOT/handovers/yotam" -type d -name '#*' 2>/dev/null | wc -l)
+nstale=$(find "$ROOT/handovers/$SLUG" -type d -name '#*' 2>/dev/null | wc -l)
 if [ "$nstale" -eq 0 ]; then ok "no #N dirs in himmel state"; else ko "$nstale stray #N dirs in himmel state"; fi
 
 # 7. status.md / roadmap.md / tech-debt.md all present in himmel
-STATE="$ROOT/handovers/yotam"
+STATE="$ROOT/handovers/$SLUG"
 for f in status.md roadmap.md tech-debt.md counter.md; do
   if [ -f "$STATE/$f" ]; then ok "$f exists"; else ko "$f missing"; fi
 done
 
 # 8. Every item has v2 frontmatter (template_version: 2)
-v1_items=$(find "$ROOT/handovers/yotam" -type f -name '*.md' -exec grep -lE '^template_version: 1$' {} \; 2>/dev/null | wc -l)
+v1_items=$(find "$ROOT/handovers/$SLUG" -type f -name '*.md' -exec grep -lE '^template_version: 1$' {} \; 2>/dev/null | wc -l)
 if [ "$v1_items" -eq 0 ]; then ok "no v1 frontmatter in items"; else ko "$v1_items items still v1"; fi
 
 echo "Total: pass=$pass fail=$fail"

--- a/marketplace/plugins/handover/skills/handover/references/init-register.md
+++ b/marketplace/plugins/handover/skills/handover/references/init-register.md
@@ -193,8 +193,8 @@ Output as table:
 
 ```
 NAME      PATH                                                              USER     ALIASES                       JIRA
-himmel    c:/users/<user>/documents/github/himmel                             yotam    himmel,internal                HIMMEL
-luna      c:/users/<user>/documents/github/luna                               yotam    luna,vault,second-brain        —
+himmel    c:/users/<user>/documents/github/himmel                             <USER_SLUG>    himmel,internal                HIMMEL
+luna      c:/users/<user>/documents/github/luna                               <USER_SLUG>    luna,vault,second-brain        —
 ```
 
 If empty: `No repos registered. Run /handover init or /handover register.`
@@ -238,7 +238,7 @@ Porting the existing `himmel/handovers/<USER_SLUG>/` state into the registry:
 # Prompts:
 #   name = himmel
 #   path = c:/users/<user>/documents/github/himmel
-#   user = yotam
+#   user = <USER_SLUG>
 #   aliases = himmel, internal
 #   keywords = (empty)
 #   branch_prefix = handover/    # default as of HIMMEL-139 (was feat/ pre-HIMMEL-139)

--- a/marketplace/plugins/himmel-ops/.claude-plugin/plugin.json
+++ b/marketplace/plugins/himmel-ops/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Harness-meta operational skills for himmel. Load-on-trigger guardrail-recovery playbook (stuck-playbook) that surfaces escape-hatches when an auto-mode write is denied, a Bash command falls through to the classifier, a permission prompt hangs, or a pre-push gate fails — so operational/troubleshooting rules stay out of the always-on root CLAUDE.md (HIMMEL-211).",
   "author": {
-    "name": "yotam"
+    "name": "yotamleo"
   },
   "keywords": [
     "himmel",

--- a/marketplace/plugins/obsidian-triage/.claude-plugin/plugin.json
+++ b/marketplace/plugins/obsidian-triage/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Autonomous triage of Obsidian Web Clipper output. /triage-clips processes Clippings/ — summarize, infer tags, suggest Related Notes from the link graph, extract action items to today's daily note, annotate promotion candidates. Idempotent via processed:true marker. /synthesize-clips finds cross-clip patterns and suggests vault restructuring. Designed to fork cleanly back to eugeniughelbur/obsidian-second-brain — pure-markdown commands, no himmel-specific runtime deps.",
   "author": {
-    "name": "yotam"
+    "name": "yotamleo"
   },
   "homepage": "https://github.com/yotamleo/Himmel",
   "keywords": [

--- a/plugins/himmel-gemini/.claude-plugin/plugin.json
+++ b/plugins/himmel-gemini/.claude-plugin/plugin.json
@@ -2,6 +2,6 @@
   "name": "himmel-gemini",
   "version": "0.1.0",
   "description": "Claude Code plugin wrapping gemini-cli via scripts/gemini/invoke.sh. /gemini runs gemini synchronously; /gemini-bg dispatches a background Warp tab. Thin wrapper — auth/model/flags resolved in the shared chokepoint.",
-  "author": "yotam",
+  "author": "yotamleo",
   "homepage": "https://github.com/yotamleo/Himmel"
 }

--- a/plugins/himmel-gh/.claude-plugin/plugin.json
+++ b/plugins/himmel-gh/.claude-plugin/plugin.json
@@ -2,6 +2,6 @@
   "name": "himmel-gh",
   "version": "0.2.0",
   "description": "Claude Code plugin wrapping the gh CLI over himmel-run. Skills auto-trigger on GitHub PR intent; /gh-* slash commands for explicit invocation. Phase 3 adds CR loop: /gh-pr-review, /gh-pr-comment, /gh-pr-comments, /gh-pr-reply, /gh-pr-resolve.",
-  "author": "yotam",
+  "author": "yotamleo",
   "homepage": "https://github.com/yotamleo/Himmel"
 }

--- a/plugins/himmel-jira/.claude-plugin/plugin.json
+++ b/plugins/himmel-jira/.claude-plugin/plugin.json
@@ -2,6 +2,6 @@
   "name": "himmel-jira",
   "version": "0.1.0",
   "description": "Claude Code plugin wrapping the himmel jira CLI over himmel-run. Skills auto-trigger on Jira intent; /jira-* slash commands for explicit invocation.",
-  "author": "yotam",
+  "author": "yotamleo",
   "homepage": "https://github.com/yotamleo/Himmel"
 }


### PR DESCRIPTION
Docs slug `yotam` -> `<USER_SLUG>`; plugin/marketplace author/owner -> `yotamleo` (capital-Himmel homepages preserved); handover-skill tests use a generated slug instead of hardcoding one. JSON validated; test-migrate 8/0.