### PR TITLE
chore(end-session-wiki): ~/-expansion test + vault-config doc cross-links

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,7 +87,9 @@ himmel needs almost nothing to start:
   [`templates/luna-second-brain/`](../templates/luna-second-brain/) — copy it
   out into its own git repo and run its `setup.sh`. Its
   [README](../templates/luna-second-brain/README.md#quickstart) has the
-  install steps.
+  install steps. With the vault in place, each Claude session is auto-captured
+  into it — [point the capture at a specific vault](luna/end-session-wiki.md#choosing-the-target-vault)
+  if it doesn't live at the default `~/Documents/luna`.
 
 **For your first loop you need none of this** — `setup.sh` already did the work.
 Skip straight to step 3.

--- a/docs/luna/end-session-wiki.md
+++ b/docs/luna/end-session-wiki.md
@@ -88,7 +88,7 @@ Every hook invocation appends one line: `[<UTC-ISO timestamp>] <message>`. Messa
 
 ## Inspecting captured notes
 
-Notes live under `<luna-vault>/sessions/YYYY/MM/`. Default vault root: `$HOME/Documents/luna` (override with `LUNA_VAULT_PATH`).
+Notes live under `<luna-vault>/sessions/YYYY/MM/`. Default vault root: `$HOME/Documents/luna`, overridable per-repo with `vault_path` in `.claude/end-session-wiki.json` or globally with `LUNA_VAULT_PATH` (see [Choosing the target vault](#choosing-the-target-vault)).
 
 Search across captured sessions via the Obsidian MCP:
 

--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -168,6 +168,8 @@ pre-commit run --all-files
 
 Hooks: `gitleaks` (secrets scan) + standard hooks. Luna-specific rules live in `~/Documents/luna/CLAUDE.md` (not linked here — it's in a different repo).
 
+> Vault not at `~/Documents/luna`, or want to route a repo's session notes to a different vault? Point the end-session-wiki capture at it — see [Choosing the target vault](../luna/end-session-wiki.md#choosing-the-target-vault) (and §7 below).
+
 ### 5a. Optional — Obsidian Web Clipper templates ([Jira LUNA-2](https://yotamleo.atlassian.net/browse/LUNA-2))
 
 If you'll be clipping web pages into Luna (X posts, articles, Reddit threads, newsletters, YouTube videos), install the Obsidian Web Clipper Chrome extension + drop in the 6 pre-built JSON templates that ship with Luna. **Skip if you only want to use Luna for native notes.**

--- a/scripts/hooks/test-end-session-wiki.sh
+++ b/scripts/hooks/test-end-session-wiki.sh
@@ -104,6 +104,21 @@ else
 fi
 rm -rf "$SB"
 
+# --- Case 1d: a leading ~/ in config.vault_path expands to $HOME --------------
+# A JSON config value can't rely on shell tilde expansion, so the hook expands a
+# leading "~/" itself. HOME is pinned to a sandbox so the note must land under it.
+SB="$(make_sandbox)"
+mkdir -p "$SB/proj/.claude" "$SB/home"
+printf '{"vault_path":"~/myvault"}\n' > "$SB/proj/.claude/end-session-wiki.json"
+payload=$(printf '{"transcript_path":"%s","cwd":"%s","session_id":"t","reason":"other"}' "$SB/transcript.jsonl" "$SB/proj")
+printf '%s' "$payload" | env -u LUNA_VAULT_PATH OSTYPE="linux-gnu" OS="" HOME="$SB/home" OBSIDIAN_API_KEY="" CLAUDE_PROJECT_DIR="$SB/proj" bash "$HOOK"
+if [ -n "$(find "$SB/home/myvault/sessions" -type f -name '*.md' 2>/dev/null | head -1)" ]; then
+    pass "config.vault_path leading ~/ expands to \$HOME/myvault"
+else
+    fail "config.vault_path ~/ did not expand under \$HOME/myvault"
+fi
+rm -rf "$SB"
+
 # --- Case 2: FS fallback writes a note when no API key is available ----------
 SB="$(make_sandbox)"
 RC="$(run_hook "$SB")"


### PR DESCRIPTION
## What

Public mirror of private PR #543 — CR follow-ups for the end-session-wiki configurable-vault feature.

- **`~/`-expansion test**: `scripts/hooks/test-end-session-wiki.sh` Case 1d asserts a leading `~/` in `config.vault_path` expands to `$HOME`.
- **Doc**: `docs/luna/end-session-wiki.md` "Inspecting captured notes" now names the per-repo `vault_path` override.
- **Cross-links**: `docs/getting-started.md` + `docs/setup/new-machine.md` §5 link the "Choosing the target vault" section.

## Verification

- `bash scripts/hooks/test-end-session-wiki.sh` → `ALL PASS` (incl. new Case 1d) on Windows Git Bash.
- Multi-agent CR ran clean on the byte-identical private PR #543 (0 Critical / 0 Important; gemini + code-reviewer + pr-test-analyzer + comment-analyzer; the test was mutation-verified as a genuine guard).

Platforms tested: Windows
Security reviewed: manual
