### PR TITLE
fix(telegram): [HIMMEL-353] label transient run failures (529) as transient, not usage cap

### DIFF
--- a/scripts/telegram/poller.test.ts
+++ b/scripts/telegram/poller.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readNewLines, readMeta, writeMeta, ensureSession, appendLine, sessionDir } from "./bus";
-import { ingestUpdates, loadOffset, handleInbound, runAndSettle, reconcile, flushOutboxes, isRetryDue, peekPending, commitPending, makeRunFn, makeAllow, makeDispatcher, makeFetchVoice, sweepStuckRunning, signalTyping, guarded, deliverAllPending, sweepAttachments, resolveRetentionMs, type FetchImageFn } from "./poller";
+import { ingestUpdates, loadOffset, handleInbound, runAndSettle, reconcile, flushOutboxes, isRetryDue, peekPending, commitPending, makeRunFn, makeAllow, makeDispatcher, makeFetchVoice, sweepStuckRunning, signalTyping, guarded, deliverAllPending, sweepAttachments, resolveRetentionMs, noticeText, type FetchImageFn } from "./poller";
 import { readFile, writeFile, mkdir, utimes } from "node:fs/promises";
 
 const root = () => mkdtempSync(join(tmpdir(), "poller-"));
@@ -28,7 +28,7 @@ test("retry cap: after maxRetries consecutive failures the session parks as fail
   await runFn("S");                                            // parked → no spawn
   expect(spawns).toBe(3);
   expect(notices.filter((k) => k === "giveup").length).toBe(1);
-  expect(notices.filter((k) => k === "backoff").length).toBe(1);   // first failure of the episode
+  expect(notices.filter((k) => k === "transient").length).toBe(1);   // capped:false → transient, not cap (HIMMEL: first failure of the episode)
   expect((await peekPending(r, "S")).count).toBe(1);           // message preserved, not lost
 });
 
@@ -71,6 +71,57 @@ test("content-filter block takes precedence over a simultaneous cap (blocked win
   expect(m?.retry_at).toBe(null);          // not the capped back-off
   expect(spawns).toBe(1);                  // one run, no retry climb
   expect(notices).toEqual(["blocked"]);    // not "backoff"
+});
+
+test("transient non-zero exit (e.g. 529 Overloaded) notifies 'transient' not 'cap', and still backs off + retries", async () => {
+  // Regression guard for the 529-mislabeled-as-cap bug: a run that exits non-zero
+  // WITHOUT a genuine cap sentinel (capped:false) must surface the transient notice,
+  // never the usage-cap one — while still backing off (status=capped is the shared
+  // generic back-off state) and re-peeking the still-uncommitted pending.
+  const r = root(); await ensureSession(r, "S");
+  await writeMeta(r, "S", freshMeta(9));
+  await appendLine(join(sessionDir(r, "S"), "inbox.jsonl"), JSON.stringify({ text: "5 X links" }));
+  const overloaded = async () => ({ code: 1, capped: false, blocked: false, pid: 1, tail: "API Error: 529 Overloaded" });
+  const notices: Array<[string, string]> = [];
+  const notify = async (_s: string, retryAt: string, kind: string) => { notices.push([kind, retryAt]); };
+  const runFn = makeRunFn(r, "/repo", overloaded, 5000, notify, 3);
+  await runFn("S");
+  const m = await readMeta(r, "S");
+  expect(notices.map((n) => n[0])).toEqual(["transient"]);   // honest label — NOT "cap"
+  expect(notices[0][1]).toBeTruthy();              // carries retry_at so the notice renders a real time
+  expect(m?.status).toBe("capped");                // shared back-off state retained
+  expect(m?.retry_at).toBeTruthy();                // retry scheduled
+  expect(m?.fail_count).toBe(1);                   // counted toward the cap
+  expect((await peekPending(r, "S")).count).toBe(1);   // pending preserved, re-peekable
+});
+
+test("noticeText: cap vs transient strings are honest (529 must not read as a usage cap)", () => {
+  // The literal point of HIMMEL-353 — assert the operator-facing wording, not just
+  // the kind token. A future edit that swapped the two arms or dropped the disclaimer
+  // would otherwise ship green.
+  const cap = noticeText("cap", "01:49 UTC", 3);
+  expect(cap).toContain("usage cap");
+  expect(cap).not.toContain("NOT a usage cap");
+  expect(cap).toContain("01:49 UTC");              // renders the retry time
+
+  const transient = noticeText("transient", "01:49 UTC", 3);
+  expect(transient).toContain("NOT a usage cap");  // the honest disclaimer
+  expect(transient).toContain("transiently");
+  expect(transient).toContain("01:49 UTC");
+
+  expect(noticeText("giveup", "", 3)).toContain("gave up after 3 failed runs");
+  expect(noticeText("blocked", "", 3)).toContain("content-filter policy");
+});
+
+test("genuine cap (capped:true) notifies 'cap'", async () => {
+  const r = root(); await ensureSession(r, "S");
+  await writeMeta(r, "S", freshMeta(9));
+  await appendLine(join(sessionDir(r, "S"), "inbox.jsonl"), JSON.stringify({ text: "a" }));
+  const cappedRun = async () => ({ code: 1, capped: true, pid: 1 });
+  const notices: string[] = [];
+  const notify = async (_s: string, _r: string, kind: string) => { notices.push(kind); };
+  await makeRunFn(r, "/repo", cappedRun, 5000, notify, 3)("S");
+  expect(notices).toEqual(["cap"]);                // genuine cap keeps the cap wording
 });
 
 test("retry cap: a message arriving DURING the final failing run prevents the park (no stranding)", async () => {

--- a/scripts/telegram/poller.ts
+++ b/scripts/telegram/poller.ts
@@ -462,12 +462,32 @@ export function withDeadline(p: Promise<RunResult>, ms: number): Promise<RunResu
 // Default deadline: the child's own timeout + a minute of grace for clean settle.
 const RUN_DEADLINE_MS = Number(process.env.RUN_TIMEOUT_MS ?? 30 * 60 * 1000) + 60 * 1000;
 
-// notify (HIMMEL-260/263): called with kind "backoff" once per BACKOFF EPISODE
-// when a run settles unsuccessful, and with kind "giveup" once when the retry
-// cap parks the session. main wires it to a direct poller-side sendMessage so
-// the chat is told instead of going silent. A clean run ends the episode. The
-// episode set is in-memory: a bridge restart may re-notice once — harmless.
-export type NotifyFn = (session: string, retryAt: string, kind: "backoff" | "giveup" | "blocked") => Promise<void>;
+// notify (HIMMEL-260/263): called once per BACKOFF EPISODE when a run settles
+// unsuccessful — kind "cap" for a genuine usage cap (CAP_SENTINELS in run.ts),
+// kind "transient" for any other non-zero exit (server overload, timeout, crash)
+// — and with kind "giveup" once when the retry cap parks the session. The
+// cap/transient split keeps the notice honest: a 529 Overloaded must not read as
+// a quota cap (HIMMEL-261/263/313 family — transient mislabeled as cap). main
+// wires it to a direct poller-side sendMessage so the chat is told instead of
+// going silent. A clean run ends the episode. The episode set is in-memory: a
+// bridge restart may re-notice once — harmless.
+export type NotifyKind = "cap" | "transient" | "giveup" | "blocked";
+export type NotifyFn = (session: string, retryAt: string, kind: NotifyKind) => Promise<void>;
+// noticeText (HIMMEL-353): the operator-facing notice string per kind. Pure +
+// exported so the cap-vs-transient honesty (a 529 must say "NOT a usage cap",
+// never the cap wording) is unit-testable, and the `never` default makes a new
+// kind that forgets its notice a COMPILE error — not a silent transient mislabel
+// (the very class HIMMEL-261/263/313 exists to kill). `when` is the pre-rendered
+// retry time; `maxRetries` only used by the giveup wording.
+export function noticeText(kind: NotifyKind, when: string, maxRetries: number): string {
+  switch (kind) {
+    case "giveup":    return `❌ gave up after ${maxRetries} failed runs — your message is still queued. Reply here to retry, or handle it from the terminal (see run.log in the session dir).`;
+    case "blocked":   return `⛔ a reply was blocked by the content-filter policy (this is NOT a usage cap). Retrying won't help — the same output is blocked each time. Your message is still queued; investigate from the terminal (see run.log in the session dir).`;
+    case "cap":       return `⏳ hit the usage cap — your message is queued, retrying ~${when}.`;
+    case "transient": return `⏳ a run failed transiently (e.g. server overload) — your message is queued, retrying ~${when}. This is NOT a usage cap.`;
+    default:          return ((_: never) => { throw new Error(`unhandled notify kind: ${String(_)}`); })(kind);
+  }
+}
 // Retry cap (HIMMEL-263): a shipping-class ask that exceeds the bounded-run
 // deadline would otherwise loop forever (kill → 15-min backoff → re-peek the
 // SAME pending → restart from scratch — observed live: "ship 241+249" died at
@@ -483,7 +503,7 @@ export type VaultForFn = (chatId: number) => string | null;
 export function makeRunFn(root: string, repoCwd: string, runImpl: (prompt: string, cwd: string) => Promise<RunResult> = runSession, deadlineMs: number = RUN_DEADLINE_MS, notify?: NotifyFn, maxRetries: number = MAX_RETRIES, vaultFor?: VaultForFn): RunFn {
   const retryAt = () => new Date(Date.now() + RETRY_MS).toISOString();
   const noticed = new Set<string>();
-  const safeNotify = async (session: string, retryAtIso: string, kind: "backoff" | "giveup" | "blocked") => {
+  const safeNotify = async (session: string, retryAtIso: string, kind: NotifyKind) => {
     if (!notify) return;
     try { await notify(session, retryAtIso, kind); }
     catch (e) { console.error("[poller] " + kind + " notify failed for " + session + ": " + e); }
@@ -544,7 +564,8 @@ export function makeRunFn(root: string, repoCwd: string, runImpl: (prompt: strin
       await writeMeta(root, session, { ...m, fail_count: fails });
       if (!noticed.has(session)) {                              // first failure of an episode → tell the chat
         noticed.add(session);
-        await safeNotify(session, m.retry_at ?? "", "backoff");
+        // genuine cap vs generic transient failure (529, timeout, crash) — keep the notice honest
+        await safeNotify(session, m.retry_at ?? "", res.capped ? "cap" : "transient");
       }
     }
   };
@@ -650,18 +671,14 @@ export async function main(): Promise<void> {
   const token = await loadToken();
   const access = await loadAccess();
   const allow = makeAllow(access);
-  // backoff/giveup notice (HIMMEL-260/263): poller-side direct send — works
-  // exactly when the claude layer can't run (quota cap), so failure is never silent
+  // cap/transient/giveup/blocked notice (HIMMEL-260/263/353): poller-side direct
+  // send — works exactly when the claude layer can't run (quota cap), so failure
+  // is never silent. Text per kind lives in the exported pure noticeText().
   const notify: NotifyFn = async (session, retryAt, kind) => {
     const m = await readMeta(root, session);
     if (!m) return;
     const when = retryAt ? retryAt.slice(11, 16) + " UTC" : "soon";
-    const text = kind === "giveup"
-      ? `❌ gave up after ${MAX_RETRIES} failed runs — your message is still queued. Reply here to retry, or handle it from the terminal (see run.log in the session dir).`
-      : kind === "blocked"
-      ? `⛔ a reply was blocked by the content-filter policy (this is NOT a usage cap). Retrying won't help — the same output is blocked each time. Your message is still queued; investigate from the terminal (see run.log in the session dir).`
-      : `⏳ run failed or hit the usage cap — your message is queued, retrying ~${when}.`;
-    await sendMessage(token, m.chat_id, text);
+    await sendMessage(token, m.chat_id, noticeText(kind, when, MAX_RETRIES));
   };
   // documents sent to a chat are filed into the vault resolved from access.json (HIMMEL-321)
   const vaultFor: VaultForFn = (chatId) => vaultForChat(access, chatId);


### PR DESCRIPTION
## telegram bridge: transient 529 no longer mislabeled as usage cap

### Problem
A bounded run that exits non-zero because of a **transient** Anthropic error
(e.g. `529 Overloaded`) was reported to the operator as a usage cap. `run.ts`
logged it correctly (`capped=false blocked=false`), but the poller collapsed
every non-zero exit into `status=capped` and the backoff notice hard-coded
"run failed or hit the usage cap" — so a transient server overload read as a
quota cap.

### Fix (label only — retry/backoff mechanism unchanged)
- Split the `NotifyFn` kind into `cap | transient` (+ a `NotifyKind` alias) and
  thread `res.capped` at the first-failure notify, so a transient failure says
  "This is NOT a usage cap" while a genuine cap keeps the cap wording.
- Extracted the notice strings into an exported pure `noticeText(kind, when,
  maxRetries)` with a `never` exhaustiveness default, so a future kind that
  forgets its notice is a compile error rather than a silent transient mislabel.
- `status=capped` remains the shared generic back-off state (deliberate); only
  the operator-facing label changed.

### Tests
`bun test scripts/telegram/` — 95 pass / 0 fail. New: a 529-style
`{code:1,capped:false}` run notifies `transient` (not `cap`) and still backs
off + retries + carries `retry_at`; a genuine cap notifies `cap`; `noticeText`
asserts the cap string says "usage cap" while the transient string says
"NOT a usage cap".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
