### PR TITLE
feat(sessions): sessions-reindex.sh — connect captures into the vault graph

### DIFF
--- a/docs/luna/end-session-wiki.md
+++ b/docs/luna/end-session-wiki.md
@@ -98,6 +98,17 @@ mcp__obsidian-vault__obsidian_simple_search query:"end-session-wiki"
 
 Or filter by branch in the file path: `sessions/2026/05/2026-05-18-*-feat-end-session-wiki-*.md`.
 
+## Connecting notes into the graph
+
+The hook files each note but does not maintain an index, so a fresh capture is an *orphan* (no inbound links) and its `[[<repo>]]` preamble link dangles until a hub note exists. Run `scripts/sessions-reindex.sh` to fix both, idempotently:
+
+```bash
+bash scripts/sessions-reindex.sh                       # default ~/Documents/luna
+bash scripts/sessions-reindex.sh --vault ~/Documents/luna-medic
+```
+
+It regenerates `<vault>/sessions/_index.md` (links every session note → no orphans) and creates a `sessions/<repo>.md` hub for each repo that doesn't already resolve `[[<repo>]]` somewhere in the vault. Lean-invoke: run on demand after a batch of captures (or wire it into the clip-pipeline cadence).
+
 ## Disabling per-session
 
 One-shot disable for a single Claude run, no config edit needed:

--- a/scripts/sessions-reindex.sh
+++ b/scripts/sessions-reindex.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# sessions-reindex.sh - connect auto-captured session notes into the vault graph.
+#
+# The end-session-wiki hook files a note per Claude session under
+# <vault>/sessions/YYYY/MM/ but does NOT maintain an index, so each note is an
+# orphan (no inbound links) and its `[[<repo>]]` preamble link dangles until a
+# hub note exists. This script (lean-invoke; run on demand or on the
+# pipeline-cadence) fixes both, idempotently:
+#
+#   1. Regenerates <vault>/sessions/_index.md linking every session note,
+#      grouped by month (gives each note an inbound link -> not an orphan).
+#   2. Ensures a hub note <vault>/sessions/<repo>.md exists for each distinct
+#      `repo:` value (resolves the `[[<repo>]]` links). Existing hubs are left
+#      untouched - only missing ones are created, and never when a note of that
+#      basename already resolves elsewhere in the vault.
+#
+# A "session note" is any *.md under sessions/ with `type: session` in
+# frontmatter; index/hub notes (type: backfill-index / repo-hub, or any
+# basename starting with "_") are skipped.
+#
+# Usage: sessions-reindex.sh [--vault <path>]   (default: ~/Documents/luna)
+set -uo pipefail
+
+VAULT="${HOME}/Documents/luna"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --vault) VAULT="$2"; shift 2 ;;
+        -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+# Expand a leading tilde (a CLI value can't rely on shell tilde expansion):
+# bare "~" -> $HOME, and "~/..." -> "$HOME/...".
+# shellcheck disable=SC2088  # the "~" patterns are literal case-pattern matches, not expansions
+case "$VAULT" in
+    "~")    VAULT="$HOME" ;;
+    "~/"*)  VAULT="${HOME}/${VAULT#\~/}" ;;
+esac
+
+SESS="${VAULT}/sessions"
+if [ ! -d "$SESS" ]; then
+    echo "sessions-reindex: no sessions/ dir under $VAULT - nothing to do" >&2
+    exit 0
+fi
+
+tmp_rows="$(mktemp)"; repos="$(mktemp)"; allmd="$(mktemp)"
+trap 'rm -f "$tmp_rows" "$repos" "$allmd"' EXIT
+
+# Build the vault-wide markdown basename list ONCE (used for hub-existence
+# checks below, so we don't re-`find` the whole vault per repo).
+find "$VAULT" -type f -name '*.md' -not -path '*/.git/*' -not -path '*/.worktrees/*' 2>/dev/null \
+    | sed 's#.*/##' > "$allmd"
+
+# read_fm <file> — emit "type<TAB>repo<TAB>date" read ONLY from the YAML
+# frontmatter block (first `---` to the next `---`), in a single awk pass.
+# Scoping to the block avoids matching `type:`/`repo:`/`date:` lines that appear
+# in a note's body (e.g. quoted transcript text); one process per file, not six.
+read_fm() {
+    awk '
+        NR==1 && $0 !~ /^---[[:space:]]*$/ { exit }
+        NR==1 { infm=1; next }
+        infm && $0 ~ /^---[[:space:]]*$/ { exit }
+        infm && /^type:/ { v=$0; sub(/^type:[[:space:]]*/,"",v); gsub(/\r/,"",v); t=v }
+        infm && /^repo:/ { v=$0; sub(/^repo:[[:space:]]*/,"",v); gsub(/\r/,"",v); r=v }
+        infm && /^date:/ { v=$0; sub(/^date:[[:space:]]*/,"",v); gsub(/\r/,"",v); d=v }
+        END { printf "%s\t%s\t%s", t, r, d }
+    ' "$1" 2>/dev/null
+}
+
+# --- 1. Collect session notes -------------------------------------------------
+count=0
+while IFS= read -r f; do
+    base="${f##*/}"
+    case "$base" in _*) continue ;; esac           # skip _index / _backfill / etc.
+    IFS=$'\t' read -r ftype repo d < <(read_fm "$f")
+    [ "$ftype" = "session" ] || continue
+    [ -n "$repo" ] || repo="unknown-repo"
+    ym="${d:0:7}"                                   # YYYY-MM from ISO date
+    case "$ym" in [0-9][0-9][0-9][0-9]-[0-9][0-9]) : ;; *) ym="undated" ;; esac
+    printf '%s\t%s\t%s\t%s\n' "$ym" "$d" "${base%.md}" "$repo" >> "$tmp_rows"
+    printf '%s\n' "$repo" >> "$repos"
+    count=$((count + 1))
+done < <(find "$SESS" -type f -name '*.md')
+
+if [ "$count" -eq 0 ]; then
+    echo "sessions-reindex: no session notes found under $SESS" >&2
+    exit 0
+fi
+
+# --- 2. Ensure a hub note per repo -------------------------------------------
+hubs_created=0
+while IFS= read -r repo; do
+    [ -n "$repo" ] || continue
+    # Skip if a note named <repo>.md already exists ANYWHERE in the vault: then
+    # [[<repo>]] already resolves, and a new sessions/<repo>.md would be a
+    # duplicate basename (ambiguous link + a vault-health duplicate flag).
+    grep -qxF "${repo}.md" "$allmd" && continue
+    hub="${SESS}/${repo}.md"
+    cat > "$hub" <<EOF
+---
+type: repo-hub
+repo: ${repo}
+tags:
+  - session
+  - hub
+ai-first: true
+---
+
+# ${repo}
+
+Hub for auto-captured Claude Code session notes from the \`${repo}\` repo. Each
+session note under \`sessions/\` links here via \`[[${repo}]]\`; the full list is
+in [[_index]].
+EOF
+    hubs_created=$((hubs_created + 1))
+done < <(sort -u "$repos")
+
+# --- 3. Regenerate _index.md --------------------------------------------------
+INDEX="${SESS}/_index.md"
+{
+    printf -- '---\ntype: session-index\ngenerated: sessions-reindex\ncount: %s\ntags:\n  - session\n  - index\nai-first: true\n---\n\n' "$count"
+    printf '# Session Notes\n\n'
+    # List repo hubs inline.
+    hub_links=""
+    while IFS= read -r repo; do
+        [ -n "$repo" ] || continue
+        if [ -z "$hub_links" ]; then hub_links="[[${repo}]]"; else hub_links="${hub_links}, [[${repo}]]"; fi
+    done < <(sort -u "$repos")
+    printf 'Auto-generated by scripts/sessions-reindex.sh - links every captured session note so none are orphaned. Re-run after new captures. Repo hubs: %s.\n\n' "$hub_links"
+    # Group by month, newest first.
+    prev_ym=""
+    while IFS=$'\t' read -r ym d base repo; do
+        if [ "$ym" != "$prev_ym" ]; then
+            printf '\n## %s\n\n' "$ym"
+            prev_ym="$ym"
+        fi
+        printf -- '- [[%s]]\n' "$base"
+    done < <(sort -t"$(printf '\t')" -k1,1r -k2,2r "$tmp_rows")
+} > "$INDEX"
+
+echo "sessions-reindex: indexed $count session note(s) into ${INDEX#"$VAULT"/}; hubs created: $hubs_created"

--- a/scripts/test-sessions-reindex.sh
+++ b/scripts/test-sessions-reindex.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/sessions-reindex.sh.
+# Usage: bash scripts/test-sessions-reindex.sh
+# shellcheck disable=SC2015  # `cond && pass || fail` is the intended idiom here; pass never fails
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/sessions-reindex.sh"
+[ -r "$SCRIPT" ] || { echo "FAIL: script not found at $SCRIPT"; exit 1; }
+
+FAILED=0
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1"; FAILED=1; }
+
+VAULT="$(mktemp -d)"
+trap 'rm -rf "$VAULT"' EXIT
+mkdir -p "$VAULT/sessions/2026/05" "$VAULT/sessions/2026/06"
+
+note() {  # note <relpath> <type> <repo> <date>
+    cat > "$VAULT/sessions/$1" <<EOF
+---
+date: $4
+type: $2
+repo: $3
+---
+body
+EOF
+}
+note "2026/05/2026-05-10-1200-himmel-private-main.md" session himmel-private 2026-05-10T12:00:00Z
+note "2026/06/2026-06-02-0900-himmel-private-main.md" session himmel-private 2026-06-02T09:00:00Z
+note "2026/06/2026-06-03-1000-luna-medic-master.md"   session luna-medic     2026-06-03T10:00:00Z
+# A non-session note + an index-style note that MUST be ignored:
+note "2026/06/some-concept.md" note himmel-private 2026-06-04T10:00:00Z
+printf -- '---\ntype: backfill-index\n---\n' > "$VAULT/sessions/_backfill-old.md"
+# A pre-existing hub that MUST NOT be clobbered:
+printf -- '---\ntype: repo-hub\n---\n\n# himmel-private\n\nCURATED PROSE KEEP ME\n' > "$VAULT/sessions/himmel-private.md"
+# A note named like a repo but living OUTSIDE sessions/ — [[ext-repo]] already
+# resolves there, so NO sessions/ext-repo.md hub should be created.
+mkdir -p "$VAULT/30-Resources"
+printf -- '---\ntype: note\n---\n# ext-repo\n' > "$VAULT/30-Resources/ext-repo.md"
+note "2026/06/2026-06-05-1100-ext-repo-main.md" session ext-repo 2026-06-05T11:00:00Z
+# A session note whose BODY contains decoy `repo:`/`type:` lines — the parser
+# must read ONLY frontmatter, so repo stays himmel-private (no `evil` hub).
+cat > "$VAULT/sessions/2026/06/2026-06-06-1200-himmel-private-main.md" <<'NOTE'
+---
+date: 2026-06-06T12:00:00Z
+type: session
+repo: himmel-private
+---
+Quoted transcript discussing frontmatter:
+repo: evil
+type: decoy
+NOTE
+
+bash "$SCRIPT" --vault "$VAULT" >/dev/null 2>&1
+
+IDX="$VAULT/sessions/_index.md"
+[ -f "$IDX" ] && pass "_index.md created" || fail "_index.md not created"
+
+# All three session notes linked; the non-session + index notes not linked.
+for b in 2026-05-10-1200-himmel-private-main 2026-06-02-0900-himmel-private-main 2026-06-03-1000-luna-medic-master; do
+    grep -q "\[\[$b\]\]" "$IDX" && pass "indexed $b" || fail "missing $b in index"
+done
+grep -q '\[\[some-concept\]\]' "$IDX" && fail "non-session note wrongly indexed" || pass "non-session note skipped"
+grep -q '\[\[_backfill-old\]\]' "$IDX" && fail "index-note wrongly indexed" || pass "index note skipped"
+
+# Count == 5 session notes (3 himmel-private/luna-medic + ext-repo + decoy-body).
+grep -q '^count: 5' "$IDX" && pass "count is 5" || fail "count wrong ($(grep '^count:' "$IDX"))"
+
+# Newest month first (2026-06 section appears before 2026-05).
+if [ "$(grep -n '^## 2026-06' "$IDX" | cut -d: -f1)" -lt "$(grep -n '^## 2026-05' "$IDX" | cut -d: -f1)" ]; then
+    pass "months sorted newest-first"
+else
+    fail "months not newest-first"
+fi
+# Within a month, newest-first too (2026-06-06 link precedes 2026-06-02 link).
+if [ "$(grep -n '\[\[2026-06-06-1200-himmel-private-main\]\]' "$IDX" | cut -d: -f1)" -lt "$(grep -n '\[\[2026-06-02-0900-himmel-private-main\]\]' "$IDX" | cut -d: -f1)" ]; then
+    pass "within-month newest-first"
+else
+    fail "within-month not newest-first"
+fi
+# The "Repo hubs:" line links each repo, and the no-hub ext-repo note is still indexed.
+grep -q 'Repo hubs:.*\[\[himmel-private\]\]' "$IDX" && pass "index links repo hubs" || fail "index missing repo-hub links"
+grep -q '\[\[2026-06-05-1100-ext-repo-main\]\]' "$IDX" && pass "ext-repo note indexed despite no hub" || fail "ext-repo note dropped"
+
+# Missing hub auto-created; existing hub NOT clobbered.
+[ -f "$VAULT/sessions/luna-medic.md" ] && pass "luna-medic hub created" || fail "luna-medic hub missing"
+grep -q 'CURATED PROSE KEEP ME' "$VAULT/sessions/himmel-private.md" && pass "existing hub not clobbered" || fail "existing hub was clobbered"
+# No duplicate hub when a note named <repo>.md already exists elsewhere.
+[ -f "$VAULT/sessions/ext-repo.md" ] && fail "duplicate hub created despite vault-wide ext-repo.md" || pass "no dup hub when <repo>.md exists elsewhere"
+# Frontmatter-scoped parsing: body `repo: evil` must NOT create an evil hub.
+[ -f "$VAULT/sessions/evil.md" ] && fail "body repo: line leaked into parsing (evil hub created)" || pass "body repo:/type: lines ignored (frontmatter-scoped)"
+
+# Idempotent: second run leaves the curated hub intact and still count 4.
+bash "$SCRIPT" --vault "$VAULT" >/dev/null 2>&1
+grep -q 'CURATED PROSE KEEP ME' "$VAULT/sessions/himmel-private.md" && pass "idempotent: hub still intact" || fail "second run clobbered hub"
+grep -q '^count: 5' "$IDX" && pass "idempotent: count stable" || fail "second run changed count"
+
+if [ "$FAILED" -eq 0 ]; then echo "ALL PASS"; exit 0; fi
+echo "SOME FAILED"; exit 1


### PR DESCRIPTION
## What

Public mirror of private PR #550. Adds `scripts/sessions-reindex.sh` — a lean-invoke tool that connects auto-captured end-session-wiki notes into the vault graph: regenerates `<vault>/sessions/_index.md` (links every `type: session` note → no orphans) and creates a `sessions/<repo>.md` hub only when `[[<repo>]]` doesn't already resolve vault-wide. Idempotent; frontmatter parsed from the `---` block in one CRLF-safe awk pass. Vault-parameterized via `--vault` (serves luna + luna-medic).

## Verification

- `bash scripts/test-sessions-reindex.sh` → `ALL PASS` (16 assertions). shellcheck clean.
- CR clean on the byte-identical private PR #550 (0 Critical; gemini + code-reviewer + pr-test-analyzer + comment-analyzer; mutation-verified).

Platforms tested: Windows
Security reviewed: manual
