### PR TITLE
docs(forge): surface GitHub + Bitbucket Cloud forge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ The payoff of running Claude Code through himmel rather than bare:
   context window (and the bill) small.
 - **Memory you can read and edit by hand.** A plain-markdown Camp-2 substrate — no
   vector DB to trust, debug, or re-embed.
+- **Forge-agnostic.** The worktree→PR→merge loop, PR review threads, and
+  luna-ingest work the same on GitHub or Bitbucket Cloud — the backend is chosen
+  per-repo from the `origin` remote, so nothing in the day-to-day loop changes.
 - **Cross-platform.** Linux, macOS, and Windows Git Bash, with the platform gotchas
   already handled.
 
@@ -181,6 +184,7 @@ detail. This README points at them; the full map is in
 | **Handover system (multi-repo registry + auto-branch + PR + flush)** | [`docs/internals/handover-system.md`](docs/internals/handover-system.md) |
 | **Overnight mode (unattended dispatch)**   | [`docs/handover/overnight-mode.md`](docs/handover/overnight-mode.md)  |
 | **Jira plugin (token-cheap local CLI)**    | [`scripts/jira/`](scripts/jira/) + [`docs/internals/jira-plugin.md`](docs/internals/jira-plugin.md) |
+| **Forge support (GitHub + Bitbucket Cloud, auto-detected from `origin`)** | [`scripts/bitbucket/`](scripts/bitbucket/) + [`plugins/himmel-gh/`](plugins/himmel-gh/) |
 | **Guardrails (shared git-state predicates)** | [`scripts/guardrails/`](scripts/guardrails/) + [`docs/internals/enforcement.md`](docs/internals/enforcement.md) |
 | **`/improve` prompt-refinement hook**      | [`.claude/commands/improve.md`](.claude/commands/improve.md) (HIMMEL-127) |
 | **`/overnight-shift` ticket fanout**       | [`.claude/commands/overnight-shift.md`](.claude/commands/overnight-shift.md) (HIMMEL-134) |

--- a/plugins/himmel-gh/README.md
+++ b/plugins/himmel-gh/README.md
@@ -1,6 +1,8 @@
 # himmel-gh
 
-Thin Claude Code plugin wrapping `gh` CLI through `scripts/himmel-run/`.
+Thin Claude Code plugin wrapping the `gh` CLI through `scripts/himmel-run/`.
+Forge-aware: commands route to `gh` on GitHub repos and to the himmel `bitbucket`
+CLI on Bitbucket Cloud repos, chosen per-repo from the `origin` remote.
 
 ## Install
 


### PR DESCRIPTION
## What

Make himmel's multi-forge support discoverable. The bitbucket forge work shipped GitHub + Bitbucket Cloud routing, but the docs never advertised it — and the `himmel-gh` README opener still described the plugin as a plain `gh` wrapper.

- **`plugins/himmel-gh/README.md`** — opener now states commands route to `gh` (GitHub) or the himmel `bitbucket` CLI (Bitbucket Cloud), chosen per-repo from `origin`. Corrects a now-stale GitHub-only framing.
- **`README.md` "What you get"** — adds a *Forge-agnostic* bullet.
- **`README.md` Features table** — adds a forge-support row → `scripts/bitbucket/` + `plugins/himmel-gh/`.

Docs-only (markdown); no code touched. Mirrors the private himmel docs change to keep public/private in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)