### PR TITLE
fix(handover): arm-resume launcher self-cleans its scheduler entry on fire

### DIFF
--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -20,6 +20,11 @@
 #      body so POSIX dedup actually matches (v1 grepped for a marker
 #      that schedule-resume.sh never emitted)
 #   4. emits a loud post-arm banner reminding operator to /exit
+#   5. makes the relaunch self-cleaning: the spawned launcher deletes
+#      its OWN scheduler entry as its first action (schtasks .bat
+#      self-/delete; crontab entry self-removes; at auto-removes), so a
+#      fired slot never lingers to block a same-handover re-arm or fire
+#      twice.
 #
 # This is the *arm* half of HIMMEL-122 (auto-resume on usage-cap
 # detection). The *detect* half (monitoring claude-statusline / API
@@ -838,6 +843,15 @@ schedule_arm() {
                 cs="${cs//|/^|}"
                 ch=" --channels \"$cs\""
             fi
+            # Self-clean FIRST: a /sc ONCE task lingers in Task Scheduler
+            # after it fires (Ready/completed), accumulating stale jobs and
+            # blocking a future same-handover arm without --force. So the
+            # launcher deletes its OWN task as its first action. Deleting a
+            # one-shot task's registration does NOT terminate the already-
+            # spawned action process, so claude still launches below.
+            # Non-fatal (>nul 2>&1, no `|| exit`): a failed cleanup must
+            # never block the relaunch. TASK_NAME is sanitized to
+            # [:alnum:]_- so it carries no CMD metacharacters.
             # cd /d switches drive + path in one step; quoted to survive
             # spaces. `|| exit /b 1` ensures the .bat aborts instead of
             # silently falling through to claude.exe in the wrong CWD
@@ -847,6 +861,7 @@ schedule_arm() {
             # (consumes following args), so a trailing positional prompt
             # gets parsed as a bogus channel entry ("must be tagged" → exit 1).
             {
+                printf 'schtasks /delete /tn "%s" /f >nul 2>&1\r\n' "$TASK_NAME"
                 printf 'cd /d "%s" || exit /b 1\r\n' "$c"
                 printf '"%s" "%s"%s\r\n' "$claude_cmd_win" "$p" "$ch"
             } > "$bat_path"
@@ -872,6 +887,9 @@ schedule_arm() {
             ;;
         linux|macos)
             if command -v at >/dev/null 2>&1; then
+                # at jobs are one-shot and atd removes them from the queue
+                # after they run, so (unlike schtasks ONCE and crontab) the
+                # at body needs no self-clean line — the queue cleans itself.
                 # at heredoc body INCLUDES the HIMMEL-Resume-<name>
                 # marker as a comment line so list_existing's grep
                 # actually matches. v1 omitted this; dedup was dead.
@@ -919,21 +937,36 @@ CMD
                 fi
                 rm -f "$err_file"
             else
-                # crontab fallback — recurring entry tagged with the
-                # marker so we can find + remove it. Operator manually
-                # cleans up after first fire. printf '%q' shell-quotes
-                # the prompt so cron's /bin/sh -c can't re-interpret
-                # $/backticks/etc in a handover path.
+                # crontab fallback — crontab entries are RECURRING, so the
+                # entry SELF-REMOVES as its first action (the cron analogue of
+                # the schtasks .bat self-/delete above): it rewrites the
+                # crontab without its own marker line before running cd+claude,
+                # turning the recurring entry into a one-shot. The running
+                # /bin/sh -c continues after the rewrite, so claude still
+                # launches. The marker match is ANCHORED at end-of-line
+                # (grep -vE '# <TASK_NAME>$'), mirroring the dedup detector's
+                # crontab branch in list_existing so a sibling slot whose
+                # TASK_NAME is a strict PREFIX of this one is not cross-matched
+                # and survives. TASK_NAME is sanitized to [:alnum:]_- so it
+                # carries no ERE specials. The terminal `crontab -` is NOT
+                # error-suppressed: a silently-failed rewrite would leave the
+                # entry RECURRING (a daily relaunch loop) while we told the
+                # operator it is one-shot, so let cron surface the failure
+                # (mail/log) — the manual-prune hint printed below is the
+                # backstop. printf '%q' shell-quotes the prompt so cron's
+                # /bin/sh -c can't re-interpret $/backticks/etc in a handover
+                # path.
                 local hh="${RESUME_TIME%:*}" mm="${RESUME_TIME#*:}"
                 local q_prompt q_cwd q_channels=""
                 q_prompt=$(printf '%q' "$RESUME_PROMPT")
                 q_cwd=$(printf '%q' "$RESUME_CWD")
                 [ -n "$CHANNELS" ] && q_channels="--channels $(printf '%q' "$CHANNELS") "
-                local entry="$mm $hh * * * cd $q_cwd && claude $q_prompt $q_channels # $TASK_NAME"
+                local self_clean="crontab -l 2>/dev/null | grep -vE '# ${TASK_NAME}\$' | crontab -;"
+                local entry="$mm $hh * * * $self_clean cd $q_cwd && claude $q_prompt $q_channels # $TASK_NAME"
                 if [ "$DRY_RUN" -eq 1 ]; then
                     echo "DRY arm-resume: would add crontab entry:"
                     echo "    $entry"
-                    echo "DRY arm-resume: NOTE: crontab is RECURRING; remove after first fire."
+                    echo "DRY arm-resume: NOTE: entry self-removes on first fire (one-shot)."
                     return 0
                 fi
                 local snap
@@ -949,7 +982,8 @@ CMD
                     exit 4
                 }
                 rm -f "$snap"
-                echo "arm-resume: NOTE: crontab is RECURRING; remove after first fire with:"
+                echo "arm-resume: NOTE: crontab entry self-removes on first fire (one-shot)."
+                echo "    If it never fires, prune manually with:"
                 echo "    crontab -l | grep -v 'HIMMEL-Resume' | crontab -"
             fi
             ;;

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -972,6 +972,47 @@ out=$(TMPDIR="$TMP" SCHED_DB="$DB31" SCHED_DB_DIR="$DB31D" PATH="$STATEFUL_STUB:
 assert_rc "T31d re-arm 'jobcollide' dedups exactly itself (rc 3)" 3 "$?"
 
 # ---------------------------------------------------------------------------
+# T32: the relaunch is SELF-CLEANING — the spawned launcher deletes its own
+#      scheduler entry as its first action so a fired /sc ONCE task (or a
+#      recurring crontab entry) never lingers to block a same-handover re-arm
+#      or fire twice. --force --dry-run isolates from the live scheduler and
+#      prints the launcher body. Platform-branched: schtasks .bat carries a
+#      self-/delete; the crontab fallback entry self-removes its marker line;
+#      the at path needs nothing (atd auto-removes one-shot jobs).
+# ---------------------------------------------------------------------------
+HO=$(make_handover "$WORK_REPO")
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --force --dry-run 2>&1)
+rc=$?
+assert_rc "T32 self-clean dry-run exits 0" 0 "$rc"
+case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
+    msys*|cygwin*|win32*|MINGW*)
+        assert_contains "T32 .bat self-deletes its own task" 'schtasks /delete /tn "HIMMEL-Resume-' "$out"
+        # The delete must be the FIRST line of the .bat body (not merely
+        # somewhere before cd) — extract the first body line printed after the
+        # ".bat content:" header and assert it is the delete. A weaker "before
+        # cd" check would still pass if a future edit inserted a command
+        # between the delete and cd.
+        first_bat_line=$(printf '%s\n' "$out" | awk '/\.bat content:/{getline; print; exit}')
+        assert_contains "T32 self-delete is the FIRST .bat line" "schtasks /delete" "$first_bat_line"
+        ;;
+    *)
+        if command -v at >/dev/null 2>&1; then
+            # at queue auto-removes the job after it runs, so the body must
+            # carry NO self-delete line — adding one would be wrong.
+            assert_contains "T32 at body emitted" "would at -t" "$out"
+            assert_not_contains "T32 at body has no spurious self-delete" "schtasks /delete" "$out"
+        else
+            # crontab fallback: the entry self-removes its own marker line
+            # first, ANCHORED (grep -vE …$) so a prefix-related sibling
+            # survives — must NOT regress to the unanchored grep -vF.
+            assert_contains "T32 crontab entry self-removes its marker (anchored)" "grep -vE '# HIMMEL-Resume-" "$out"
+            assert_not_contains "T32 crontab self-clean is not unanchored grep -vF" "grep -vF '# HIMMEL-Resume-" "$out"
+            assert_contains "T32 crontab note says one-shot" "self-removes on first fire" "$out"
+        fi
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 if [ "$FAILED" -gt 0 ]; then


### PR DESCRIPTION
## Summary
Makes the arm-resume scheduled-relaunch launcher self-clean its **own** scheduler entry as its **first action** when it fires — the structural fix (in the launcher, not a prose instruction to the resumed session).

## Problem
When an armed resume fired, the OS scheduler entry it created was never cleaned up:
- **Windows `schtasks /sc ONCE`**: the task lingers in Task Scheduler (Ready/completed) — accumulating stale `HIMMEL-Resume-*` jobs and blocking a same-handover re-arm without `--force`.
- **POSIX `crontab` fallback**: recurring — fires daily until manually pruned.
- **POSIX `at`**: already self-removes.

## Fix (`scripts/handover/arm-resume.sh`)
- **schtasks `.bat`**: prepend `schtasks /delete /tn "<TASK_NAME>" /f >nul 2>&1` before `cd`/`claude`. Deleting a one-shot task's registration does not kill the already-spawned action process, so claude still launches; non-fatal.
- **crontab fallback**: entry rewrites the crontab without its own marker line first — **anchored** (`grep -vE '# <TASK_NAME>$'`, mirroring the dedup detector) so a prefix-related sibling slot survives — turning the recurring entry into a one-shot. The terminal `crontab -` is not error-suppressed so a failed rewrite surfaces.
- **at**: unchanged (atd auto-removes one-shot jobs).

## Tests
Added **T32** (platform-branched) to `scripts/handover/test-arm-resume.sh` — asserts the `.bat` self-delete is the first body line; the crontab entry uses the anchored `grep -vE …$` form (rejects a regression to `grep -vF`); the `at` body carries no spurious delete. Full suite green on Windows; shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
