### PR TITLE
refactor(luna-correlate): own KpPoint in kp.ts, derive AggMetric

### DIFF
--- a/marketplace/plugins/luna-correlate/src/cli.ts
+++ b/marketplace/plugins/luna-correlate/src/cli.ts
@@ -1,7 +1,7 @@
 import { parseSeriesCsv } from "./series";
-import { parseKpAuto, KP_CACHE } from "./kp";
+import { parseKpAuto, KP_CACHE, type KpPoint } from "./kp";
 import { correlate } from "./correlate";
-import type { KpPoint, FactorPoint, Signal } from "./correlate";
+import type { FactorPoint, Signal } from "./correlate";
 
 // This CLI is the manual Kp path; location factors go through the MCP. Map the
 // {date,kp} cache shape to the generic {date,value} factor and keep the Kp split

--- a/marketplace/plugins/luna-correlate/src/correlate.ts
+++ b/marketplace/plugins/luna-correlate/src/correlate.ts
@@ -1,8 +1,8 @@
-export type KpPoint = { date: string; kp: number };
 export type SeriesPoint = { date: string; value: number };
 // A generic factor sample: a date-keyed value. Kp maps {date,kp}->{date,value};
 // location factors (pressure/pollen/aq) arrive in this shape from the proximity
-// index. The join below is identical regardless of factor.
+// index. The join below is identical regardless of factor. (KpPoint lives in
+// kp.ts now — this module is factor-agnostic.)
 export type FactorPoint = { date: string; value: number };
 export type Signal = {
   series: string; factor: string; lagDays: number;

--- a/marketplace/plugins/luna-correlate/src/fetchFactors.ts
+++ b/marketplace/plugins/luna-correlate/src/fetchFactors.ts
@@ -12,7 +12,9 @@ export type BBox = { latMin: number; lonMin: number; latMax: number; lonMax: num
 export type GridCell = { lat: number; lon: number };
 export type DateRange = { start: string; end: string };
 export type CachedCell = { lat: number; lon: number; daily: DailyAgg[] };
-export type AggMetric = "min" | "mean" | "max";
+// Derived from DailyAgg so the metric set can't drift from the available daily
+// aggregates (adding/removing a DailyAgg field updates this in lockstep).
+export type AggMetric = keyof Omit<DailyAgg, "date">;
 export type FactorCache = {
   factor: string; field: string; unit: string; metric: AggMetric; label: string;
   bbox: BBox; dateRange: DateRange; cells: CachedCell[];

--- a/marketplace/plugins/luna-correlate/src/kp.ts
+++ b/marketplace/plugins/luna-correlate/src/kp.ts
@@ -1,5 +1,8 @@
 import { join } from "path";
-import type { KpPoint } from "./correlate";
+
+// Kp-specific factor sample. Owned here (the kp parser/cache module) rather than
+// in correlate.ts, which is now factor-agnostic (joins the generic FactorPoint).
+export type KpPoint = { date: string; kp: number };
 
 // Resolve the cache against this module's dir (not cwd) so the cache location
 // is stable no matter where the MCP server / CLI is launched from (#541 nit).

--- a/marketplace/plugins/luna-correlate/src/mcp.ts
+++ b/marketplace/plugins/luna-correlate/src/mcp.ts
@@ -1,8 +1,8 @@
 import { fetchKpToCache } from "./fetchKp";
-import { KP_CACHE } from "./kp";
+import { KP_CACHE, type KpPoint } from "./kp";
 import { loadSeries } from "./loadSeries";
 import { correlate } from "./correlate";
-import type { KpPoint, FactorPoint, SeriesPoint, Signal } from "./correlate";
+import type { FactorPoint, SeriesPoint, Signal } from "./correlate";
 import { formatSignalsNote } from "./signalsNote";
 import {
   fetchFactorToCache, factorCachePath, LOCATION_FACTORS, type FactorCache, type DateRange,


### PR DESCRIPTION
## luna-correlate — type-only CR follow-up polish

No behavior change.

- **Relocate `KpPoint`** → `src/kp.ts` (the Kp parser/cache module). `correlate.ts` is now factor-agnostic — it joins the generic `FactorPoint`; import sites updated. No circular import.
- **Derive `AggMetric`** = `keyof Omit<DailyAgg,"date">` so the metric set tracks the daily aggregates structurally.

83 tests pass; `tsc --noEmit` clean.

Security reviewed: pr-review-toolkit
