### PR TITLE
chore(github): add bug-report and feature-request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report something in himmel that isn't working as expected
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill out the sections
+        below so we can reproduce and fix it.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected instead.
+      placeholder: When I run /worktree, the branch is created but ...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands / slash commands / prompts that trigger the bug.
+      placeholder: |
+        1. Run `...`
+        2. Invoke `/...`
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: component
+    attributes:
+      label: Which part of himmel?
+      description: e.g. a hook, a slash command, the Jira CLI, the handover system, a plugin.
+      placeholder: scripts/jira CLI
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, shell, and Claude Code version (`claude --version`).
+      placeholder: |
+        - OS: Windows 11 / macOS 14 / Ubuntu 22.04
+        - Shell: PowerShell / bash / zsh
+        - Claude Code: x.y.z
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Paste any error output. This is automatically formatted, so no backticks needed.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/yotamleo/Himmel/blob/main/README.md
+    about: Setup, architecture, and the internals docs — check here before filing.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest a new capability or improvement for himmel
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! himmel biases toward *structural* safety and
+        repeatability over prose, so it helps to frame requests as a problem
+        first, then a proposed mechanism.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The pain point or gap you're hitting. What can't you do today?
+      placeholder: When running overnight mode, there's no way to ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like to see. A hook, a slash command, a gate, a doc — whatever fits.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why they fall short.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, screenshots, related issues, or anything else useful.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds GitHub issue templates so people can open structured issues on the repo:

- **Bug report** (`bug_report.yml`) — what happened, repro steps, component, environment, logs.
- **Feature request** (`feature_request.yml`) — problem-first framing, proposal, alternatives, context.
- **config.yml** — keeps blank issues enabled and links to the README.

Uses GitHub's YAML issue-form format (structured fields) rather than plain markdown.

## Test plan

- All three YAML files parse cleanly (`yaml.safe_load`).
- Form schema follows GitHub's issue-forms spec (field types: `markdown`, `textarea`, `input`).

Security reviewed: manual
