### PR TITLE
fix(setup): [HIMMEL-359] wire statusLine via shared helper; setup/adopt install plugins+statusline

### DIFF
--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -126,6 +126,25 @@ function Install-Plugins {
     }
 }
 
+# statusLine — part of the core harness (HIMMEL-359). Wired into the
+# scope-appropriate settings.json via the shared helper. Both scopes reference
+# THIS himmel clone's vendored statusline (never copied per-repo).
+function Wire-StatuslineCore {
+    $settings = if ($Scope -eq 'project') {
+        Join-Path $Target '.claude\settings.json'
+    } else {
+        Join-Path $HOME '.claude\settings.json'
+    }
+    if ($DryRun) {
+        Write-Host "DRY: wire statusLine → $settings (himmel: $HimmelRoot)"
+        return
+    }
+    $wsl = Join-Path $HimmelRoot 'scripts\lib\wire-statusline.ps1'
+    & pwsh -NoProfile -File $wsl -SettingsPath $settings -HimmelPath $HimmelRoot
+    # Parity with adopt.sh (set -e aborts on a non-zero helper): surface failure.
+    if ($LASTEXITCODE -ne 0) { throw "wire-statusline failed (exit $LASTEXITCODE)" }
+}
+
 function Do-Core {
     Require-Tools
     if ($Scope -eq 'project') {
@@ -137,6 +156,7 @@ function Do-Core {
         Write-Host "  worktree commands run from the himmel clone: bash $HimmelRoot/scripts/worktree.sh feat/slug"
     }
     Install-Plugins
+    Wire-StatuslineCore
     Write-Host "  (optional) pre-commit gates: see $HimmelRoot\docs\setup\use-on-your-project.md"
 }
 

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -145,6 +145,24 @@ install_plugins() {
   fi
 }
 
+# statusLine — part of the core harness (HIMMEL-359). Wired into the
+# scope-appropriate settings.json. Both scopes reference THIS himmel clone's
+# vendored statusline (it is never copied per-repo), so a project-scope
+# settings.json carries this machine's clone path by design.
+wire_statusline_core() {
+  local settings
+  if [[ "$SCOPE" == "project" ]]; then
+    settings="$TARGET/.claude/settings.json"
+  else
+    settings="$HOME/.claude/settings.json"
+  fi
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "DRY: wire statusLine → $settings (himmel: $HIMMEL_ROOT)"
+    return
+  fi
+  bash "$HIMMEL_ROOT/scripts/lib/wire-statusline.sh" "$settings" "$HIMMEL_ROOT"
+}
+
 do_core() {
   require_tools
   if [[ "$SCOPE" == "project" ]]; then
@@ -159,6 +177,7 @@ do_core() {
     echo "  worktree commands run from the himmel clone: bash $HIMMEL_ROOT/scripts/worktree.sh feat/slug"
   fi
   install_plugins
+  wire_statusline_core
   echo "  (optional) pre-commit gates: see $HIMMEL_ROOT/docs/setup/use-on-your-project.md (Pre-commit hooks)"
 }
 

--- a/scripts/lib/test-wire-statusline.ps1
+++ b/scripts/lib/test-wire-statusline.ps1
@@ -1,0 +1,51 @@
+# Hermetic test for wire-statusline.ps1 (HIMMEL-359). Temp dir only, no network.
+# Mirrors test-wire-statusline.sh so the bash/PowerShell twins stay in parity —
+# in particular case 5 pins the invalid-JSON exit code (the bug the CR caught:
+# Write-Error+return exited 0, masking the refusal from -File callers).
+$ErrorActionPreference = 'Stop'
+$here   = Split-Path -Parent $MyInvocation.MyCommand.Path
+$helper = Join-Path $here 'wire-statusline.ps1'
+$tmp    = Join-Path ([IO.Path]::GetTempPath()) ("twsl-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Force $tmp | Out-Null
+$script:fail = 0
+function Check([bool]$cond, [string]$msg) {
+    if ($cond) { Write-Host "ok $msg" } else { Write-Host "FAIL $msg"; $script:fail = 1 }
+}
+# Invoke the helper the way production callers do (-File) so $LASTEXITCODE is real.
+function Wire([string]$path, [string]$himmel) {
+    & pwsh -NoProfile -File $helper -SettingsPath $path -HimmelPath $himmel *> $null
+    return $LASTEXITCODE
+}
+
+# 1 fresh file + backslash path normalized
+Wire "$tmp\s1.json" 'C:\fake\himmel' | Out-Null
+$s1 = Get-Content "$tmp\s1.json" -Raw | ConvertFrom-Json
+Check ($s1.statusLine.command -eq 'bash "C:/fake/himmel/scripts/statusline/bin/statusline.sh"') "1 fresh+backslash-normalized"
+
+# 2 existing keys preserved
+'{"theme":"dark"}' | Set-Content "$tmp\s2.json"
+Wire "$tmp\s2.json" 'C:\fake\himmel' | Out-Null
+$s2 = Get-Content "$tmp\s2.json" -Raw | ConvertFrom-Json
+Check ($s2.theme -eq 'dark' -and $s2.statusLine.type -eq 'command') "2 existing keys preserved"
+
+# 3 idempotent
+Wire "$tmp\s3.json" 'C:\fake\himmel' | Out-Null
+$a = Get-Content "$tmp\s3.json" -Raw
+Wire "$tmp\s3.json" 'C:\fake\himmel' | Out-Null
+Check ((Get-Content "$tmp\s3.json" -Raw) -eq $a) "3 idempotent"
+
+# 4 empty file -> {}
+New-Item -ItemType File "$tmp\s4.json" | Out-Null
+Wire "$tmp\s4.json" 'C:\fake\himmel' | Out-Null
+$s4 = Get-Content "$tmp\s4.json" -Raw | ConvertFrom-Json
+Check ($s4.statusLine.type -eq 'command') "4 empty file handled"
+
+# 5 non-empty INVALID json -> exit non-zero + not clobbered (parity with bash case 7)
+'{not valid' | Set-Content "$tmp\s5.json"
+$rc = Wire "$tmp\s5.json" 'C:\fake\himmel'
+Check ($rc -ne 0) "5a invalid json exits non-zero"
+Check ((Get-Content "$tmp\s5.json" -Raw).Trim() -eq '{not valid') "5b invalid json not clobbered"
+
+Get-ChildItem $tmp -Recurse | Remove-Item -Force -Recurse
+Remove-Item $tmp -Force
+if ($script:fail) { Write-Host "FAILURES"; exit 1 } else { Write-Host "ALL PASS"; exit 0 }

--- a/scripts/lib/test-wire-statusline.sh
+++ b/scripts/lib/test-wire-statusline.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Hermetic test for wire-statusline.sh (HIMMEL-359). No network, temp dir only.
+set -euo pipefail
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$HERE/wire-statusline.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# 1. fresh file gets a valid statusLine
+bash "$HELPER" "$TMP/s1.json" "/c/Users/me/himmel" >/dev/null
+[ "$(jq -r .statusLine.type "$TMP/s1.json")" = "command" ] || fail "fresh type"
+[ "$(jq -r .statusLine.command "$TMP/s1.json")" = 'bash "/c/Users/me/himmel/scripts/statusline/bin/statusline.sh"' ] || fail "fresh command"
+echo "ok 1 fresh file"
+
+# 2. existing keys preserved
+echo '{"theme":"dark","hooks":{"PreToolUse":[1]}}' > "$TMP/s2.json"
+bash "$HELPER" "$TMP/s2.json" "/c/Users/me/himmel" >/dev/null
+[ "$(jq -r .theme "$TMP/s2.json")" = "dark" ] || fail "theme preserved"
+[ "$(jq -r '.hooks.PreToolUse[0]' "$TMP/s2.json")" = "1" ] || fail "hooks preserved"
+[ "$(jq -r .statusLine.type "$TMP/s2.json")" = "command" ] || fail "statusLine added"
+echo "ok 2 existing keys preserved"
+
+# 3. idempotent
+bash "$HELPER" "$TMP/s3.json" "/c/Users/me/himmel" >/dev/null
+A="$(cat "$TMP/s3.json")"
+bash "$HELPER" "$TMP/s3.json" "/c/Users/me/himmel" >/dev/null
+[ "$A" = "$(cat "$TMP/s3.json")" ] || fail "not idempotent"
+echo "ok 3 idempotent"
+
+# 4. backslash himmel path normalized to forward slashes
+bash "$HELPER" "$TMP/s4.json" 'C:\Users\me\himmel' >/dev/null
+[ "$(jq -r .statusLine.command "$TMP/s4.json")" = 'bash "C:/Users/me/himmel/scripts/statusline/bin/statusline.sh"' ] || fail "backslash normalize"
+echo "ok 4 backslash normalized"
+
+# 5. overwrites a stale statusLine (authoritative)
+echo '{"statusLine":{"type":"command","command":"OLD"}}' > "$TMP/s5.json"
+bash "$HELPER" "$TMP/s5.json" "/c/Users/me/himmel" >/dev/null
+[ "$(jq -r .statusLine.command "$TMP/s5.json")" != "OLD" ] || fail "stale not refreshed"
+echo "ok 5 stale refreshed"
+
+# 6. empty file → treated as {}, gets a valid statusLine (gemini-1/2)
+: > "$TMP/s6.json"
+bash "$HELPER" "$TMP/s6.json" "/c/Users/me/himmel" >/dev/null
+[ "$(jq -r .statusLine.type "$TMP/s6.json")" = "command" ] || fail "empty file not handled"
+echo "ok 6 empty file handled"
+
+# 7. non-empty INVALID json → refuse (exit non-zero), do not clobber
+printf '{not valid' > "$TMP/s7.json"
+if bash "$HELPER" "$TMP/s7.json" "/c/Users/me/himmel" >/dev/null 2>&1; then
+  fail "invalid json was not refused"
+fi
+[ "$(cat "$TMP/s7.json")" = '{not valid' ] || fail "invalid json was clobbered"
+echo "ok 7 invalid json refused"
+
+# 8. whitespace-only file (non-empty bytes, all blank) → treated as {}
+printf '  \n\t ' > "$TMP/s8.json"
+bash "$HELPER" "$TMP/s8.json" "/c/Users/me/himmel" >/dev/null
+[ "$(jq -r .statusLine.type "$TMP/s8.json")" = "command" ] || fail "whitespace-only not handled"
+echo "ok 8 whitespace-only handled"
+
+# 9. nested parent dir created when absent
+bash "$HELPER" "$TMP/nested/deep/s9.json" "/c/Users/me/himmel" >/dev/null
+[ "$(jq -r .statusLine.type "$TMP/nested/deep/s9.json")" = "command" ] || fail "nested dir not created"
+echo "ok 9 nested parent dir created"
+
+echo "ALL PASS"

--- a/scripts/lib/wire-statusline.ps1
+++ b/scripts/lib/wire-statusline.ps1
@@ -1,0 +1,85 @@
+# wire-statusline.ps1 — PowerShell counterpart of wire-statusline.sh
+# (HIMMEL-359). Single source of truth for wiring the himmel statusLine into a
+# Claude Code settings.json. Used by adopt.ps1, setup.ps1, and
+# machine-setup/win11.ps1.
+#
+# Dot-source to get Set-HimmelStatusLine, or invoke directly:
+#   pwsh -File wire-statusline.ps1 -SettingsPath <path> -HimmelPath <path>
+#
+# Sets .statusLine = { type: "command",
+#   command: 'bash "<himmel>/scripts/statusline/bin/statusline.sh"' }
+# Idempotent, atomic (temp + move), non-destructive (other keys preserved;
+# file + parent dir created if absent). Normalizes JSON through `jq --indent 2`
+# when jq is on PATH (matches win11.ps1's Write-SettingsJson), else falls back
+# to ConvertTo-Json.
+
+[CmdletBinding()]
+param(
+    [string]$SettingsPath,
+    [string]$HimmelPath
+)
+
+function Set-HimmelStatusLine {
+    param(
+        [Parameter(Mandatory = $true)] [string]$SettingsPath,
+        [Parameter(Mandatory = $true)] [string]$HimmelPath
+    )
+
+    # Forward-slash the himmel path so the `bash "..."` command is valid.
+    $himmelFwd = $HimmelPath.Replace('\', '/')
+    $cmd = "bash `"$himmelFwd/scripts/statusline/bin/statusline.sh`""
+
+    if (Test-Path $SettingsPath) {
+        $raw = Get-Content $SettingsPath -Raw
+        if ([string]::IsNullOrWhiteSpace($raw)) {
+            # Empty / whitespace-only file → start from {} (ConvertFrom-Json
+            # returns $null on empty input, which then throws on property access).
+            $cfg = [pscustomobject]@{}
+        } else {
+            try {
+                $cfg = $raw | ConvertFrom-Json
+            } catch {
+                # Throw (not Write-Error+return): the script entry point converts
+                # this to `exit 1` so `-File` callers see a non-zero code, matching
+                # the bash twin's `return 1`. Write-Error alone exits 0 under the
+                # default child $ErrorActionPreference='Continue'.
+                throw "wire-statusline: $SettingsPath is not valid JSON — refusing to overwrite"
+            }
+        }
+    } else {
+        # Split-Path returns '' for a bare filename with no directory — guard so
+        # New-Item is not handed an empty path.
+        $dir = Split-Path $SettingsPath
+        if ($dir) { New-Item -ItemType Directory -Force $dir | Out-Null }
+        $cfg = [pscustomobject]@{}
+    }
+
+    $statusLine = [pscustomobject]@{ type = 'command'; command = $cmd }
+    if ($cfg.PSObject.Properties['statusLine']) {
+        $cfg.statusLine = $statusLine
+    } else {
+        $cfg | Add-Member -NotePropertyName statusLine -NotePropertyValue $statusLine -Force
+    }
+
+    $json = $cfg | ConvertTo-Json -Depth 20
+    if (Get-Command jq -ErrorAction SilentlyContinue) {
+        $normalized = $json | jq --indent 2 .
+        if ($LASTEXITCODE -eq 0 -and $normalized) { $json = $normalized -join "`n" }
+    }
+    Set-Content -Path "$SettingsPath.new" -Value $json -Encoding utf8
+    Move-Item -Path "$SettingsPath.new" -Destination $SettingsPath -Force
+    Write-Host "  wired statusLine → $SettingsPath"
+}
+
+# Direct invocation (both args supplied) runs the function. Dot-sourcing with
+# no args just defines it.
+if ($SettingsPath -and $HimmelPath) {
+    try {
+        Set-HimmelStatusLine -SettingsPath $SettingsPath -HimmelPath $HimmelPath
+    } catch {
+        # Surface as a non-zero exit so `-File` callers (setup.ps1 etc.) can
+        # detect the refusal — dot-source callers catch the throw themselves.
+        Write-Error $_
+        exit 1
+    }
+}

--- a/scripts/lib/wire-statusline.sh
+++ b/scripts/lib/wire-statusline.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# wire-statusline.sh — single source of truth for wiring the himmel statusLine
+# into a Claude Code settings.json (HIMMEL-359). Used by adopt.sh, setup.sh,
+# and machine-setup/ubuntu.sh so the command string + merge logic live in one
+# place instead of being duplicated per installer.
+#
+# Usage:
+#   bash wire-statusline.sh <settings-json-path> <himmel-path>
+#
+# Sets:
+#   .statusLine = { type: "command",
+#                   command: "bash \"<himmel>/scripts/statusline/bin/statusline.sh\"" }
+#
+# Idempotent (re-setting the same value is a no-op), atomic (temp file + mv),
+# and non-destructive (all other keys preserved; file + parent dir created if
+# absent). Requires jq. The statusline binary is referenced by absolute path —
+# it is vendored in the himmel clone, never copied per-repo.
+set -euo pipefail
+
+wire_statusline() {
+  local settings="$1" himmel="$2"
+  command -v jq >/dev/null 2>&1 || { echo "wire-statusline: jq required" >&2; return 1; }
+
+  # Forward-slash the himmel path so the `bash "..."` command is valid even
+  # when a caller passes a Windows backslash path (Git Bash tolerates /c/... ).
+  local himmel_fwd="${himmel//\\//}"
+  local cmd="bash \"${himmel_fwd}/scripts/statusline/bin/statusline.sh\""
+
+  mkdir -p "$(dirname "$settings")"
+  local base="{}"
+  if [ -s "$settings" ]; then
+    base=$(cat "$settings")
+    # An empty / whitespace-only file → treat as {} (jq would choke on it).
+    # A non-empty but INVALID file → refuse, rather than clobber data.
+    if [ -z "$(printf '%s' "$base" | tr -d '[:space:]')" ]; then
+      base="{}"
+    elif ! printf '%s' "$base" | jq -e . >/dev/null 2>&1; then
+      echo "wire-statusline: $settings is not valid JSON — refusing to overwrite" >&2
+      return 1
+    fi
+  fi
+
+  printf '%s' "$base" | jq --arg cmd "$cmd" \
+    '.statusLine = { type: "command", command: $cmd }' \
+    > "$settings.statusline.tmp" && mv "$settings.statusline.tmp" "$settings"
+  echo "  wired statusLine → $settings"
+}
+
+# Allow both `source wire-statusline.sh` (to call wire_statusline directly) and
+# direct invocation `bash wire-statusline.sh <settings> <himmel>`.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  if [ "$#" -ne 2 ]; then
+    echo "usage: wire-statusline.sh <settings-json-path> <himmel-path>" >&2
+    exit 2
+  fi
+  wire_statusline "$1" "$2"
+fi

--- a/scripts/machine-setup/ubuntu.sh
+++ b/scripts/machine-setup/ubuntu.sh
@@ -19,7 +19,6 @@ fi
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # shellcheck disable=SC2034
 HIMMEL_PATH="$HOME/github/himmel"
-STATUSLINE_PATH="$HIMMEL_PATH/scripts/statusline"  # vendored in himmel (HIMMEL-331)
 LUNA_VAULT_PATH="$HOME/Documents/luna"
 CLAUDE_DIR="$HOME/.claude"
 
@@ -326,7 +325,6 @@ step "Patch ~/.claude/settings.json"
 {
   SETTINGS="$CLAUDE_DIR/settings.json"
   TEMPLATE="$HIMMEL_PATH/docs/setup/settings-template.json"
-  STATUSLINE_CMD="bash \"$STATUSLINE_PATH/bin/statusline.sh\""
 
   # Strip SessionEnd from template — the next step ("Configure end-session-wiki
   # SessionEnd hook") owns that key end-to-end and prompts the user. Writing
@@ -350,12 +348,13 @@ step "Patch ~/.claude/settings.json"
     # PowerShell installed (Ubuntu's default), logging a confusing warning.
     # The Windows path adds the pwsh entry via win11.ps1; the cross-platform
     # template carries neither so each setup script can register the right one.
+    # statusLine is wired separately via scripts/lib/wire-statusline.sh after
+    # this patch (HIMMEL-359) — single source of truth, so it is NOT in this
+    # jq object.
     PATCH=$(jq \
-      --arg sl "$STATUSLINE_CMD" \
       --arg lv "$LUNA_VAULT_PATH" \
       --arg hp "$HIMMEL_PATH" \
       '. + {
-        statusLine: { type: "command", command: $sl },
         mcpServers: {
           "obsidian-vault": { command: "uvx", args: ["mcp-obsidian", $lv] }
         },
@@ -391,8 +390,12 @@ step "Patch ~/.claude/settings.json"
       # Deep-merge: existing settings win on key conflict (idempotent re-runs)
       MERGED=$(printf '%s\n' "$PATCH" | jq -s '.[0] * .[1]' - "$SETTINGS")
       write_settings_json "$MERGED" "$SETTINGS"
+      # statusLine via the shared helper (HIMMEL-359) — runs after the merge so
+      # it is authoritative and refreshes any stale path on idempotent re-runs.
+      bash "$HIMMEL_PATH/scripts/lib/wire-statusline.sh" "$SETTINGS" "$HIMMEL_PATH"
     else
       write_settings_json "$PATCH" "$SETTINGS"
+      bash "$HIMMEL_PATH/scripts/lib/wire-statusline.sh" "$SETTINGS" "$HIMMEL_PATH"
     fi
   fi
 } || fail_nonfatal "patch settings.json"

--- a/scripts/machine-setup/win11.ps1
+++ b/scripts/machine-setup/win11.ps1
@@ -8,7 +8,6 @@ $ErrorActionPreference = 'Stop'
 
 # ── Paths ───────────────────────────────────────────────────────────────────
 $HimmelPath     = "$env:USERPROFILE\Documents\github\himmel"
-$StatuslinePath = "$HimmelPath\scripts\statusline"  # vendored in himmel (HIMMEL-331)
 $LunaVaultPath  = "$env:USERPROFILE\Documents\luna"
 $ClaudeDir      = "$env:USERPROFILE\.claude"
 $RepoRoot       = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
@@ -286,8 +285,8 @@ Invoke-NonFatal "patch settings.json" {
     $TemplatePath = "$HimmelPath\docs\setup\settings-template.json"
     $Template = Get-Content $TemplatePath -Raw | ConvertFrom-Json
 
-    $StatuslineCmd = "bash `"$($StatuslinePath.Replace('\', '/'))/bin/statusline.sh`""
-    $Template.statusLine = [PSCustomObject]@{ type = "command"; command = $StatuslineCmd }
+    # statusLine is wired separately via scripts/lib/wire-statusline.ps1 after
+    # this patch (HIMMEL-359) — single source of truth, so it is NOT set here.
     $Template | Add-Member -NotePropertyName "mcpServers" -NotePropertyValue ([PSCustomObject]@{
         "obsidian-vault" = [PSCustomObject]@{
             command = "uvx"
@@ -372,6 +371,14 @@ Invoke-NonFatal "patch settings.json" {
     } else {
         Write-SettingsJson $SettingsFile $Template
     }
+
+    # statusLine via the shared helper (HIMMEL-359) — runs after the write so it
+    # is authoritative and refreshes any stale path on idempotent re-runs.
+    & pwsh -NoProfile -File "$HimmelPath\scripts\lib\wire-statusline.ps1" `
+        -SettingsPath $SettingsFile -HimmelPath $HimmelPath
+    # Surface a helper failure so the enclosing Invoke-NonFatal logs it (parity
+    # with ubuntu.sh's `|| fail_nonfatal`); native exit codes don't auto-throw.
+    if ($LASTEXITCODE -ne 0) { throw "wire-statusline failed (exit $LASTEXITCODE)" }
 }
 
 Write-Step "Configure end-session-wiki SessionEnd hook"

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -30,7 +30,7 @@ Write-Host ""
 # PS-friendly path (pre-commit + jira plugin); operator-facing tooling
 # expects Git Bash for the bash-driven scripts. We still verify the
 # foundational tools so the operator knows what's missing.
-Write-Host "[0/8] Verifying foundational tools on PATH..."
+Write-Host "[0/10] Verifying foundational tools on PATH..."
 $missing = @()
 $hints = @{
     'git'     = 'https://git-scm.com (includes Git Bash on Windows)'
@@ -70,7 +70,7 @@ if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
 
 # --- JIRA_PROJECT_KEY verify (HIMMEL-146; gated per HIMMEL-285) ---
 # Mirrors scripts/setup/check-jira-key.sh: hard-fail only with -WithJira.
-Write-Host "[0.4/8] Verifying JIRA_PROJECT_KEY..."
+Write-Host "[0.4/10] Verifying JIRA_PROJECT_KEY..."
 if ($env:JIRA_PROJECT_KEY) {
     Write-Host "  JIRA_PROJECT_KEY=$($env:JIRA_PROJECT_KEY)"
 } elseif ($WithJira) {
@@ -86,7 +86,7 @@ if ($env:JIRA_PROJECT_KEY) {
 Write-Host ""
 
 # --- Python / pre-commit ---
-Write-Host "[1/8] Installing pre-commit..."
+Write-Host "[1/10] Installing pre-commit..."
 if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
     Write-Error "python not found. Install Python 3.10+ first."
     exit 1
@@ -97,12 +97,12 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-Write-Host "[2/8] Installing git hooks (pre-commit, pre-push, commit-msg)..."
+Write-Host "[2/10] Installing git hooks (pre-commit, pre-push, commit-msg)..."
 python -m pre_commit install
 python -m pre_commit install --hook-type pre-push
 python -m pre_commit install --hook-type commit-msg
 
-Write-Host "[3/8] Installing Jira CLI..."
+Write-Host "[3/10] Installing Jira CLI..."
 if (Get-Command node -ErrorAction SilentlyContinue) {
     if ((Test-Path "$RepoRoot\scripts\jira\node_modules") -and (Test-Path "$RepoRoot\scripts\jira\dist\index.js")) {
         Write-Host "  jira CLI already built (node_modules + dist present) -- skipping install + build"
@@ -150,10 +150,10 @@ function Test-Qmd {
     return [bool](Get-Command qmd -ErrorAction SilentlyContinue)
 }
 
-Write-Host "[4/8] Registering qmd collection 'himmel'..."
+Write-Host "[4/10] Registering qmd collection 'himmel'..."
 # Neutralize the broken qmd plugin-cache stub first so plain `qmd` works
 # inside Claude's Bash tool too (HIMMEL-163). The fixer is bash; Git Bash is
-# a verified prereq ([0/8]) so it is always present here. Native exe non-zero
+# a verified prereq ([0/10]) so it is always present here. Native exe non-zero
 # exits do NOT throw in pwsh -- check $LASTEXITCODE explicitly.
 & bash "$RepoRoot/scripts/lib/fix-qmd-stub.sh"
 if ($LASTEXITCODE -ne 0) {
@@ -184,7 +184,7 @@ if (Test-Qmd) {
 }
 
 # --- .env ---
-Write-Host "[5/8] Checking .env..."
+Write-Host "[5/10] Checking .env..."
 if (-not (Test-Path ".env")) {
     if (Test-Path ".env.example") {
         Copy-Item ".env.example" ".env"
@@ -210,7 +210,7 @@ if (-not (Test-Path ".env")) {
 # common in CI / scripted contexts. The misconfig branch is the whole
 # point of step 6 -- if it can be silenced by a caller's preference,
 # the gate has no teeth.
-Write-Host "[6/8] Handover root check..."
+Write-Host "[6/10] Handover root check..."
 $GitBash = "C:\Program Files\Git\bin\bash.exe"
 if (-not (Test-Path $GitBash)) {
     $BashCmd = Get-Command bash -ErrorAction SilentlyContinue
@@ -260,7 +260,7 @@ Write-Host ""
 # writes access.json and NEVER starts the bridge (operator-managed --
 # injection surface + single-getUpdates-owner rule). Non-fatal: a fresh
 # machine legitimately has none of this configured yet.
-Write-Host "[7/8] Telegram bridge + Warp onboarding..."
+Write-Host "[7/10] Telegram bridge + Warp onboarding..."
 $savedEAP = $ErrorActionPreference
 try {
     $ErrorActionPreference = 'Continue'
@@ -273,12 +273,54 @@ try {
 }
 Write-Host ""
 
+# --- Claude plugins (HIMMEL-359) ---
+# The standalone-himmel path (this script) is what README + getting-started
+# point new users at, then tell them to run /handover — so it installs the
+# marketplace plugins (handover, triage, obsidian, …), not just the repo
+# tooling. User scope (~/.claude); setup.ps1 has no scope/profile flag.
+# Idempotent. Skipped with a notice when claude is not on PATH.
+Write-Host "[8/10] Installing Claude plugins (user scope)..."
+if (Get-Command claude -ErrorAction SilentlyContinue) {
+    $savedEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        & pwsh -NoProfile -File (Join-Path $RepoRoot "scripts\machine-setup\install-plugins.ps1") `
+            -Scope user -HimmelPath $RepoRoot
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  WARNING: install-plugins reported a problem; setup continues." -ForegroundColor Yellow
+        }
+    } finally {
+        $ErrorActionPreference = $savedEAP
+    }
+} else {
+    Write-Host "  Skipped: 'claude' not on PATH (install it, then re-run setup)."
+}
+Write-Host ""
+
+# --- statusline (HIMMEL-359) ---
+# Wire the himmel statusline into ~/.claude/settings.json via the shared helper.
+# Independent of the plugin step (writes settings.json, needs no claude binary);
+# idempotent.
+Write-Host "[9/10] Wiring statusline (user scope)..."
+$savedEAP = $ErrorActionPreference
+try {
+    $ErrorActionPreference = 'Continue'
+    & pwsh -NoProfile -File (Join-Path $RepoRoot "scripts\lib\wire-statusline.ps1") `
+        -SettingsPath (Join-Path $HOME ".claude\settings.json") -HimmelPath $RepoRoot
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  WARNING: wire-statusline failed; setup continues." -ForegroundColor Yellow
+    }
+} finally {
+    $ErrorActionPreference = $savedEAP
+}
+Write-Host ""
+
 # --- claude-squad (cs) -- OPTIONAL (HIMMEL-151) ---
 # Opt-in only. Triggered by -WithCs OR interactive prompt (default N).
 # Non-interactive shells without the switch skip silently.
 #
 # Failure here is non-fatal: cs is optional. WARN and continue.
-Write-Host "[8/8] OPTIONAL: claude-squad (cs)..."
+Write-Host "[10/10] OPTIONAL: claude-squad (cs)..."
 $installCs = $false
 if ($WithCs) {
     $installCs = $true

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -61,7 +61,7 @@ echo ""
 # in docs/setup/new-machine.md but NOT failed-on here because the
 # scripts that use them already include fallbacks (python3 for
 # realpath; arm-resume picks the available scheduler).
-echo "[0/8] Verifying foundational tools on PATH..."
+echo "[0/10] Verifying foundational tools on PATH..."
 _missing=()
 for _tool in bash git node npm bun python3 jq gh mktemp; do
   if ! command -v "$_tool" >/dev/null 2>&1; then
@@ -130,7 +130,7 @@ echo ""
 # Hard-fail only with --with-jira; default is skip-with-notice so a
 # no-Jira adopter completes setup. Logic lives in the sub-script so it
 # is hermetic-testable (test-check-jira-key.sh).
-echo "[0.4/8] Verifying JIRA_PROJECT_KEY..."
+echo "[0.4/10] Verifying JIRA_PROJECT_KEY..."
 _jira_mode=optional
 if [ "$WITH_JIRA" = "1" ]; then _jira_mode=required; fi
 if ! bash "$REPO_ROOT/scripts/setup/check-jira-key.sh" "$_jira_mode"; then
@@ -144,7 +144,7 @@ echo ""
 # handover bucket layout, registry.json, and overnight artifacts line
 # up. Fail loud rather than letting downstream scripts pick the wrong
 # directory.
-echo "[0.5/8] Resolving USER_SLUG..."
+echo "[0.5/10] Resolving USER_SLUG..."
 # shellcheck source=lib/user-slug.sh
 # shellcheck disable=SC1091
 . "$REPO_ROOT/scripts/lib/user-slug.sh"
@@ -159,7 +159,7 @@ echo ""
 # PEP 668 (externally-managed-environment, default on Ubuntu 24.04+ and most
 # 2025+ distros) blocks `pip install` system-wide. Install via uv first, fall
 # back to pipx — both manage isolated venvs, both put `pre-commit` on PATH.
-echo "[1/8] Installing pre-commit..."
+echo "[1/10] Installing pre-commit..."
 if command -v pre-commit &>/dev/null; then
   echo "  pre-commit already on PATH — skipping install"
 elif command -v uv &>/dev/null; then
@@ -172,12 +172,12 @@ else
   exit 1
 fi
 
-echo "[2/8] Installing git hooks (pre-commit, pre-push, commit-msg)..."
+echo "[2/10] Installing git hooks (pre-commit, pre-push, commit-msg)..."
 pre-commit install
 pre-commit install --hook-type pre-push
 pre-commit install --hook-type commit-msg
 
-echo "[3/8] Installing Jira + Bitbucket CLIs..."
+echo "[3/10] Installing Jira + Bitbucket CLIs..."
 if command -v node &>/dev/null; then
   if [ -d "$REPO_ROOT/scripts/jira/node_modules" ] && [ -f "$REPO_ROOT/scripts/jira/dist/index.js" ]; then
     echo "  jira CLI already built (node_modules + dist present) -- skipping install + build"
@@ -216,7 +216,7 @@ if command -v node &>/dev/null && [ -f "$REPO_ROOT/scripts/bitbucket/package.jso
 fi
 
 # --- qmd collection ---
-echo "[4/8] Registering qmd collection 'himmel'..."
+echo "[4/10] Registering qmd collection 'himmel'..."
 # Neutralize the broken qmd plugin-cache stub first so plain `qmd` works
 # inside Claude's Bash tool too (HIMMEL-163). No-op when the plugin is
 # absent, already patched, or upstream has shipped a fixed stub.
@@ -251,7 +251,7 @@ else
 fi
 
 # --- .env ---
-echo "[5/8] Checking .env..."
+echo "[5/10] Checking .env..."
 if [ ! -f ".env" ]; then
   if [ -f ".env.example" ]; then
     cp .env.example .env
@@ -273,7 +273,7 @@ fi
 # Use `doctor` (not `status`) so misconfig exits non-zero and we take
 # the WARNING branch — `status` always rc=0 even when HANDOVER_DIR is
 # unresolvable.
-echo "[6/8] Handover root check..."
+echo "[6/10] Handover root check..."
 if handover_output=$(bash "$REPO_ROOT/scripts/handover-link.sh" doctor 2>&1); then
   while IFS= read -r _line; do echo "  $_line"; done <<< "$handover_output"
 else
@@ -292,9 +292,36 @@ echo ""
 # writes access.json and NEVER starts the bridge (operator-managed —
 # injection surface + single-getUpdates-owner rule). Non-fatal: a fresh
 # machine legitimately has none of this configured yet.
-echo "[7/8] Telegram bridge + Warp onboarding..."
+echo "[7/10] Telegram bridge + Warp onboarding..."
 if ! bash "$REPO_ROOT/scripts/setup/onboard-telegram.sh"; then
   echo "  WARNING: onboard-telegram reported a problem; setup continues." >&2
+fi
+echo ""
+
+# --- Claude plugins (HIMMEL-359) ---
+# The standalone-himmel path (this script) is what README + getting-started
+# point new users at, then tell them to run /handover — so it installs the
+# marketplace plugins (handover, triage, obsidian, …), not just the repo
+# tooling. User scope (~/.claude, every project); setup.sh has no scope/profile
+# flag. Idempotent. Skipped with a notice when claude is not on PATH (the
+# soft-check at the top already warned).
+echo "[8/10] Installing Claude plugins (user scope)..."
+if command -v claude >/dev/null 2>&1; then
+  if ! bash "$REPO_ROOT/scripts/machine-setup/install-plugins.sh" --scope user; then
+    echo "  WARNING: install-plugins reported a problem; setup continues." >&2
+  fi
+else
+  echo "  Skipped: 'claude' not on PATH (install it, then re-run setup)."
+fi
+echo ""
+
+# --- statusline (HIMMEL-359) ---
+# Wire the himmel statusline into ~/.claude/settings.json via the shared helper.
+# Independent of the plugin step (writes settings.json, needs no claude binary);
+# idempotent.
+echo "[9/10] Wiring statusline (user scope)..."
+if ! bash "$REPO_ROOT/scripts/lib/wire-statusline.sh" "$HOME/.claude/settings.json" "$REPO_ROOT"; then
+  echo "  WARNING: wire-statusline failed; setup continues." >&2
 fi
 echo ""
 
@@ -305,7 +332,7 @@ echo ""
 #
 # Failure here is non-fatal: cs is optional, so a network hiccup or missing
 # brew/apt shouldn't abort the rest of setup. We WARN and continue.
-echo "[8/8] OPTIONAL: claude-squad (cs)..."
+echo "[10/10] OPTIONAL: claude-squad (cs)..."
 _install_cs=0
 if [ "$WITH_CS" = "1" ]; then
   _install_cs=1


### PR DESCRIPTION
Public propagation of private HIMMEL-359 (code-only).

A fresh getting-started install wired **neither `/handover` nor the statusline**: the `statusLine` template key was wired by nothing in the adopt/setup paths, and `setup.{sh,ps1}` installed no marketplace plugins at all.

- New shared helper `scripts/lib/wire-statusline.{sh,ps1}` — single source of truth for the statusLine command + settings.json merge. Idempotent, atomic, treats empty/whitespace as `{}`, refuses to clobber an invalid file, exits non-zero on refusal (bash `return 1` / PowerShell `exit 1`, in parity).
- `adopt.{sh,ps1}` — wire statusLine in `core` (profile+scope governed; full/`all` installs everything).
- `setup.{sh,ps1}` — install plugins + wire statusline as two standalone steps (user scope; skipped when `claude` absent).
- `ubuntu.sh`/`win11.ps1` — route statusLine through the shared helper (kill duplication).
- Tests: `scripts/lib/test-wire-statusline.{sh,ps1}`.

Reviewed via the himmel multi-agent CR on the identical private change (0 Critical / 0 Important).

Platforms tested: windows (Git Bash + PowerShell 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
