### PR TITLE
feat(luna-vitals): [HIMMEL-356] CR follow-ups — table robustness, conflict provenance, merge warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 scripts/jira/dist/
 scripts/jira/node_modules/
+scripts/luna-vitals/node_modules/
 /node_modules/
 /.claude/settings.local.json
 # end-session-wiki hook local artifacts — contain raw transcript excerpts (potential secrets).

--- a/scripts/luna-vitals/cli.ts
+++ b/scripts/luna-vitals/cli.ts
@@ -46,6 +46,10 @@ async function main(): Promise<void> {
         const art = await readArtifact(a);
         pool.push(...art.rows);
         buckets.push(art.bucket);
+      } else if (!a.endsWith(".json")) {
+        // A bare positional that is not a .json artifact is not an input — warn
+        // (naming it) instead of silently dropping it, so a typo'd path is visible.
+        console.error(`[luna-vitals] warning: ignoring positional argument that is not a .json artifact: ${a}`);
       }
     }
     if (!det.length && !llm.length) { console.error("usage: merge [--det <det.json>...] [--llm <llm.json>...] --out <merged.json> (no input artifacts found)"); process.exit(1); }

--- a/scripts/luna-vitals/src/merge.ts
+++ b/scripts/luna-vitals/src/merge.ts
@@ -20,7 +20,14 @@ export function mergeRows(
     rows.push(pool[0]);
     const distinct = [...new Set(pool.map(r => r.value))];
     if (distinct.length > 1) {
-      conflicts.push({ metric: pool[0].metric, date: pool[0].date, values: pool.map(r => ({ value: r.value, source: r.source })) });
+      // `chosen` mirrors the emitted row (pool[0]) so the artifact records which
+      // candidate won, not just that there was a disagreement.
+      conflicts.push({
+        metric: pool[0].metric,
+        date: pool[0].date,
+        values: pool.map(r => ({ value: r.value, source: r.source })),
+        chosen: { value: pool[0].value, source: pool[0].source },
+      });
     }
   }
   rows.sort((a, b) => (a.metric < b.metric ? -1 : a.metric > b.metric ? 1 : a.date < b.date ? -1 : a.date > b.date ? 1 : 0));

--- a/scripts/luna-vitals/src/parse.ts
+++ b/scripts/luna-vitals/src/parse.ts
@@ -15,14 +15,25 @@ export function parseStructured(
   const rows: ExtractedRow[] = [];
   const lines = text.split("\n");
 
-  // (a) markdown table with a `date` column + metric columns
-  const headerIdx = lines.findIndex(l => /\|/.test(l) && /\bdate\b/i.test(l));
+  const cells = (l: string): string[] => l.split("|").map(c => c.trim()).filter((_, i, a) => i > 0 && i < a.length - 1);
+
+  // (a) markdown table with a `date` column + metric columns. Header detection
+  // guards against a prose/bullet line that merely contains a pipe and "date":
+  // require the literal lowercase word `date`, at least two pipe-delimited cells,
+  // and that the line is not a `-`/`*` bullet.
+  const headerIdx = lines.findIndex(
+    l => !/^\s*[-*]\s/.test(l) && /\bdate\b/.test(l) && cells(l).length >= 2,
+  );
   if (headerIdx !== -1) {
-    const cells = (l: string): string[] => l.split("|").map(c => c.trim()).filter((_, i, a) => i > 0 && i < a.length - 1);
     const header = cells(lines[headerIdx]).map(h => h.toLowerCase());
     const di = header.indexOf("date");
     if (di !== -1) {
-      for (let i = headerIdx + 2; i < lines.length && lines[i].includes("|"); i++) {
+      // A well-formed table has a `|---|` separator at headerIdx+1; some notes omit
+      // it. Start at +2 when the separator is present, +1 when absent, so the first
+      // data row is never silently dropped.
+      const sep = lines[headerIdx + 1];
+      const start = headerIdx + (sep !== undefined && /^\s*\|[\s\-:|]+\|/.test(sep) ? 2 : 1);
+      for (let i = start; i < lines.length && lines[i].includes("|"); i++) {
         const c = cells(lines[i]);
         const date = (c[di] ?? "").trim();
         if (!ISO.test(date)) continue;

--- a/scripts/luna-vitals/src/types.ts
+++ b/scripts/luna-vitals/src/types.ts
@@ -1,5 +1,15 @@
 export type ExtractedRow = { metric: string; date: string; value: number; source: string };
-export type Conflict = { metric: string; date: string; values: { value: number; source: string }[] };
+// One competing (value, source) candidate for a (metric, date) cell.
+export type Candidate = { value: number; source: string };
+// `chosen` records WHICH candidate value mergeRows emitted into `rows` (the
+// deterministic-wins / first-row pick), so an operator resolving the conflict in
+// the review artifact can see the auto-selected provenance, not just the rejects.
+export type Conflict = {
+  metric: string;
+  date: string;
+  values: Candidate[];
+  chosen: Candidate;
+};
 export type ReviewArtifact = { bucket: string; rows: ExtractedRow[]; conflicts: Conflict[] };
 
 const ISO = /^\d{4}-\d{2}-\d{2}$/;
@@ -21,8 +31,31 @@ export function validateRow(r: ExtractedRow): void {
   if (typeof r.value !== "number" || !Number.isFinite(r.value)) throw new Error(`row value is not numeric: ${JSON.stringify(r)}`);
 }
 
+function validateCandidate(cand: Candidate, label: string, ctx: Conflict): void {
+  if (!cand || typeof cand.value !== "number" || !Number.isFinite(cand.value) || !cand.source) {
+    throw new Error(`conflict ${label} is not a well-formed {value, source} candidate: ${JSON.stringify(ctx)}`);
+  }
+}
+
+export function validateConflict(c: Conflict): void {
+  if (!c.metric) throw new Error(`conflict has empty metric: ${JSON.stringify(c)}`);
+  if (!isValidISODate(c.date)) throw new Error(`conflict date is not a valid ISO calendar date: "${c.date}"`);
+  // A conflict only exists because ≥2 distinct candidate values were seen, so the
+  // values list must carry at least two well-formed candidates — `chosen` alone is
+  // not enough provenance for an operator resolving medical-series disagreement.
+  if (!Array.isArray(c.values) || c.values.length < 2) throw new Error(`conflict "values" must list at least two candidates: ${JSON.stringify(c)}`);
+  c.values.forEach(v => validateCandidate(v, '"values" entry', c));
+  validateCandidate(c.chosen, '"chosen" provenance entry', c);
+  // The emitted candidate must be one of the recorded candidates; a `chosen` that
+  // names no listed value is corruption (e.g. a bad hand-edit of the artifact).
+  if (!c.values.some(v => v.value === c.chosen.value && v.source === c.chosen.source)) {
+    throw new Error(`conflict "chosen" is not one of the recorded "values": ${JSON.stringify(c)}`);
+  }
+}
+
 export async function writeArtifact(path: string, a: ReviewArtifact): Promise<void> {
   a.rows.forEach(validateRow);
+  a.conflicts.forEach(validateConflict);
   await Bun.write(path, JSON.stringify(a, null, 2));
 }
 
@@ -38,5 +71,6 @@ export async function readArtifact(path: string): Promise<ReviewArtifact> {
   if (typeof a.bucket !== "string" || !a.bucket) throw new Error(`malformed artifact at ${path}: missing or empty "bucket"`);
   if (!Array.isArray(a.rows) || !Array.isArray(a.conflicts)) throw new Error(`malformed artifact at ${path}: "rows" and "conflicts" must be arrays`);
   a.rows.forEach(validateRow);
+  a.conflicts.forEach(validateConflict);
   return a;
 }

--- a/scripts/luna-vitals/tests/cli.test.ts
+++ b/scripts/luna-vitals/tests/cli.test.ts
@@ -40,6 +40,19 @@ test("parse --note-date anchors inline fields, then merge --det/--llm keeps dete
   expect(m.conflicts).toEqual([]);
 });
 
+test("merge warns on stderr (naming the file) for a positional arg that is not a .json artifact", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "luna-vitals-cli-warn-"));
+  const det = join(dir, "det.json");
+  await Bun.write(det, JSON.stringify({ bucket: "x", conflicts: [], rows: [{ metric: "migraine", date: "2024-06-14", value: 3, source: "s" }] }));
+  const merged = join(dir, "merged.json");
+  const p = Bun.spawn(["bun", "run", "cli.ts", "merge", det, "notes.md", "--out", merged], { cwd: ROOT, stderr: "pipe" });
+  const err = await new Response(p.stderr).text();
+  expect(await p.exited).toBe(0);
+  expect(err).toContain("notes.md");
+  // the ignored positional must not corrupt the real merge — det.json's row survives
+  expect((await readJson(merged)).rows).toContainEqual({ metric: "migraine", date: "2024-06-14", value: 3, source: "s" });
+});
+
 test("CLI exits non-zero (not 0) when the parse input file is missing", async () => {
   const p = Bun.spawn(["bun", "run", "cli.ts", "parse", join(tmpdir(), "does-not-exist-xyz.md"), "--out", join(tmpdir(), "o.json")], { cwd: ROOT, stderr: "pipe" });
   expect(await p.exited).toBe(1);

--- a/scripts/luna-vitals/tests/merge.test.ts
+++ b/scripts/luna-vitals/tests/merge.test.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
 import { mergeRows } from "../src/merge";
+import { writeArtifact } from "../src/types";
 
 const r = (metric: string, date: string, value: number, source: string) => ({ metric, date, value, source });
 
@@ -31,11 +34,22 @@ test("identical values from overlap dedup silently", () => {
 test("non-authoritative LLM disagreement is flagged, first row still emitted", () => {
   const out = mergeRows({ deterministic: [], llm: [r("migraine", "2024-06-14", 2, "a.md"), r("migraine", "2024-06-14", 3, "b.md")], bucket: "x" });
   expect(out.rows).toEqual([r("migraine", "2024-06-14", 2, "a.md")]);
-  expect(out.conflicts).toEqual([{ metric: "migraine", date: "2024-06-14", values: [{ value: 2, source: "a.md" }, { value: 3, source: "b.md" }] }]);
+  expect(out.conflicts).toEqual([{ metric: "migraine", date: "2024-06-14", values: [{ value: 2, source: "a.md" }, { value: 3, source: "b.md" }], chosen: { value: 2, source: "a.md" } }]);
 });
 
 test("two deterministic sources disagreeing is flagged, first row emitted (no LLM)", () => {
   const out = mergeRows({ deterministic: [r("migraine", "2024-06-14", 2, "table.md"), r("migraine", "2024-06-14", 3, "bullet.md")], llm: [], bucket: "x" });
   expect(out.rows).toEqual([r("migraine", "2024-06-14", 2, "table.md")]);
-  expect(out.conflicts).toEqual([{ metric: "migraine", date: "2024-06-14", values: [{ value: 2, source: "table.md" }, { value: 3, source: "bullet.md" }] }]);
+  expect(out.conflicts).toEqual([{ metric: "migraine", date: "2024-06-14", values: [{ value: 2, source: "table.md" }, { value: 3, source: "bullet.md" }], chosen: { value: 2, source: "table.md" } }]);
+});
+
+test("the conflict's chosen entry mirrors the emitted row", () => {
+  const out = mergeRows({ deterministic: [], llm: [r("migraine", "2024-06-14", 2, "a.md"), r("migraine", "2024-06-14", 3, "b.md")], bucket: "x" });
+  expect(out.conflicts[0].chosen).toEqual({ value: out.rows[0].value, source: out.rows[0].source });
+});
+
+test("a mergeRows-produced conflict passes the writeArtifact validation gate", async () => {
+  const out = mergeRows({ deterministic: [], llm: [r("migraine", "2024-06-14", 2, "a.md"), r("migraine", "2024-06-14", 3, "b.md")], bucket: "x" });
+  expect(out.conflicts.length).toBe(1);
+  await writeArtifact(join(tmpdir(), "luna-vitals-merge-conflict-writepath.json"), out); // must not throw
 });

--- a/scripts/luna-vitals/tests/parse.test.ts
+++ b/scripts/luna-vitals/tests/parse.test.ts
@@ -35,3 +35,30 @@ test("parses dated bullets", () => {
 test("inline fields without a note date are skipped (no date to anchor)", () => {
   expect(parseStructured("migraine:: 3\n", { source: "n.md", metrics: ["migraine"] })).toEqual([]);
 });
+
+test("parses a table that omits the |---| separator row (first data row not dropped)", () => {
+  const rows = parseStructured("| date | migraine |\n| 2024-06-15 | 1 |\n", { source: "n.md", metrics: METRICS });
+  expect(rows).toEqual([{ metric: "migraine", date: "2024-06-15", value: 1, source: "n.md" }]);
+});
+
+test("a prose line with a pipe and the word date is not mistaken for a table header", () => {
+  const rows = parseStructured("Pick a date | maybe tomorrow\n- 2024-06-20 migraine 2\n", { source: "n.md", metrics: METRICS });
+  expect(rows).toEqual([{ metric: "migraine", date: "2024-06-20", value: 2, source: "n.md" }]);
+});
+
+test("a `-`/`*` bullet line is not mistaken for a table header even with a `date` cell and >=2 cells", () => {
+  // Without the bullet guard this would be read as a header (date col 0) and the
+  // next line parsed as a data row → a spurious migraine=0 row. The guard rejects it.
+  const rows = parseStructured("- x | date | migraine | extra\n| 2024-06-15 | 0 | 9\n", { source: "n.md", metrics: METRICS });
+  expect(rows).toEqual([]);
+});
+
+test("date-header match is case-sensitive: an uppercase `Date` column is not parsed as a table", () => {
+  const rows = parseStructured("| Date | migraine |\n|---|---|\n| 2024-06-15 | 1 |\n", { source: "n.md", metrics: METRICS });
+  expect(rows).toEqual([]);
+});
+
+test("parses a decimal value in a dated bullet", () => {
+  const rows = parseStructured("- 2024-06-14 sleep_hours 7.5\n", { source: "n.md", metrics: METRICS });
+  expect(rows).toEqual([{ metric: "sleep_hours", date: "2024-06-14", value: 7.5, source: "n.md" }]);
+});

--- a/scripts/luna-vitals/tests/types.test.ts
+++ b/scripts/luna-vitals/tests/types.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "bun:test";
 import { join } from "path";
 import { tmpdir } from "os";
-import { validateRow, readArtifact, writeArtifact, type ReviewArtifact } from "../src/types";
+import { validateRow, validateConflict, readArtifact, writeArtifact, type ReviewArtifact } from "../src/types";
 
 test("validateRow rejects non-ISO date, non-finite value, empty metric/source", () => {
   expect(() => validateRow({ metric: "migraine", date: "06/14/2024", value: 3, source: "x" })).toThrow(/ISO/);
@@ -43,4 +43,40 @@ test("readArtifact throws on an invalid row in the file", async () => {
   const p = join(tmpdir(), "luna-vitals-bad-artifact.json");
   await Bun.write(p, JSON.stringify({ bucket: "x", conflicts: [], rows: [{ metric: "m", date: "nope", value: 1, source: "s" }] }));
   await expect(readArtifact(p)).rejects.toThrow(/ISO/);
+});
+
+test("validateConflict requires a well-formed chosen provenance entry", () => {
+  const good = { metric: "migraine", date: "2024-06-14", values: [{ value: 2, source: "a" }, { value: 3, source: "b" }], chosen: { value: 2, source: "a" } };
+  expect(() => validateConflict(good)).not.toThrow();
+  expect(() => validateConflict({ ...good, chosen: undefined as any })).toThrow(/chosen/);
+  expect(() => validateConflict({ ...good, chosen: { value: NaN, source: "a" } })).toThrow(/chosen/);
+});
+
+test("validateConflict rejects a malformed values candidate (NaN/empty-source) and a too-short values list", () => {
+  const base = { metric: "migraine", date: "2024-06-14", chosen: { value: 2, source: "a" } };
+  expect(() => validateConflict({ ...base, values: [{ value: 2, source: "a" }, { value: NaN, source: "b" }] } as any)).toThrow(/values/);
+  expect(() => validateConflict({ ...base, values: [{ value: 2, source: "a" }, { value: 3, source: "" }] } as any)).toThrow(/values/);
+  expect(() => validateConflict({ ...base, values: [{ value: 2, source: "a" }] } as any)).toThrow(/at least two/);
+});
+
+test("validateConflict rejects a chosen that is not one of the recorded values", () => {
+  const c = { metric: "migraine", date: "2024-06-14", values: [{ value: 2, source: "a" }, { value: 3, source: "b" }], chosen: { value: 9, source: "z" } };
+  expect(() => validateConflict(c)).toThrow(/not one of/);
+});
+
+test("writeArtifact/readArtifact round-trips a conflict with its chosen provenance", async () => {
+  const a: ReviewArtifact = {
+    bucket: "x",
+    rows: [{ metric: "migraine", date: "2024-06-14", value: 2, source: "a" }],
+    conflicts: [{ metric: "migraine", date: "2024-06-14", values: [{ value: 2, source: "a" }, { value: 3, source: "b" }], chosen: { value: 2, source: "a" } }],
+  };
+  const p = join(tmpdir(), "luna-vitals-conflict-roundtrip.json");
+  await writeArtifact(p, a);
+  expect(await readArtifact(p)).toEqual(a);
+});
+
+test("readArtifact rejects a conflict missing the chosen field", async () => {
+  const p = join(tmpdir(), "luna-vitals-conflict-nochosen.json");
+  await Bun.write(p, JSON.stringify({ bucket: "x", rows: [], conflicts: [{ metric: "migraine", date: "2024-06-14", values: [{ value: 2, source: "a" }, { value: 3, source: "b" }] }] }));
+  await expect(readArtifact(p)).rejects.toThrow(/chosen/);
 });

--- a/scripts/luna-vitals/tests/writeSeries.test.ts
+++ b/scripts/luna-vitals/tests/writeSeries.test.ts
@@ -35,7 +35,7 @@ test("refuses to write a metric that has an unresolved conflict", async () => {
   const dir = tmp();
   const a: ReviewArtifact = {
     bucket: "x",
-    conflicts: [{ metric: "migraine", date: "2024-06-14", values: [{ value: 2, source: "a" }, { value: 3, source: "b" }] }],
+    conflicts: [{ metric: "migraine", date: "2024-06-14", values: [{ value: 2, source: "a" }, { value: 3, source: "b" }], chosen: { value: 2, source: "a" } }],
     rows: [{ metric: "migraine", date: "2024-06-14", value: 2, source: "a" }],
   };
   await expect(writeSeries(a, dir)).rejects.toThrow(/unresolved conflict/);
@@ -45,11 +45,17 @@ test("allowConflicts:true bypasses the conflict guard and writes", async () => {
   const dir = tmp();
   const a: ReviewArtifact = {
     bucket: "x",
-    conflicts: [{ metric: "migraine", date: "2024-06-14", values: [{ value: 2, source: "a" }, { value: 3, source: "b" }] }],
+    conflicts: [{ metric: "migraine", date: "2024-06-14", values: [{ value: 2, source: "a" }, { value: 3, source: "b" }], chosen: { value: 2, source: "a" } }],
     rows: [{ metric: "migraine", date: "2024-06-14", value: 2, source: "a" }],
   };
   await writeSeries(a, dir, { allowConflicts: true });
   expect(await Bun.file(join(dir, "migraine.csv")).text()).toBe("date,value\n2024-06-14,2\n");
+});
+
+test("an empty artifact (rows: []) writes nothing and returns []", async () => {
+  const dir = tmp();
+  const res = await writeSeries({ bucket: "x", conflicts: [], rows: [] }, dir);
+  expect(res).toEqual([]);
 });
 
 test("skips malformed rows in an existing CSV (no NaN / misaligned values seeded)", async () => {


### PR DESCRIPTION
## HIMMEL-356 — luna-vitals CR follow-ups (code propagation)

Propagates the HIMMEL-356 luna-vitals follow-ups (code-only) from the private harness repo. Builds on the luna-vitals package shipped in #32 (HIMMEL-355).

### Changes
- **parse.ts** — header detection requires literal lowercase `date`, ≥2 pipe cells, and not a bullet line; missing-`|---|`-separator detection so a separator-less table no longer drops its first data row.
- **types.ts / merge.ts** — `Conflict.chosen` provenance field, shared `Candidate` type, `validateConflict` (≥2 well-formed candidates + `chosen ∈ values`) wired into read/write gates.
- **cli.ts** — `merge` warns to stderr (naming the file) on a non-`.json` positional.
- **tests** — decimal dated bullet, empty artifact→`[]`, header false-positive guards, conflict validation, write-path gate.
- **.gitignore** — ignore `scripts/luna-vitals/node_modules/`.

### Verification
`bun test` → **39 pass / 0 fail**; `bunx tsc --noEmit` clean. Reviewed via the private heavy CR (6 reviewers + re-CR → 0 Critical / 0 Important) on the identical code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
