### PR TITLE
feat(setup): [HIMMEL-365] setup propagates marketplace autoUpdate to new users

### DIFF
--- a/docs/setup/settings-template.json
+++ b/docs/setup/settings-template.json
@@ -89,22 +89,28 @@
   },
   "extraKnownMarketplaces": {
     "obsidian-skills": {
-      "source": { "source": "github", "repo": "kepano/obsidian-skills" }
+      "source": { "source": "github", "repo": "kepano/obsidian-skills" },
+      "autoUpdate": true
     },
     "qmd": {
-      "source": { "source": "github", "repo": "tobi/qmd" }
+      "source": { "source": "github", "repo": "tobi/qmd" },
+      "autoUpdate": true
     },
     "caveman": {
-      "source": { "source": "github", "repo": "JuliusBrussee/caveman" }
+      "source": { "source": "github", "repo": "JuliusBrussee/caveman" },
+      "autoUpdate": true
     },
     "claude-code-warp": {
-      "source": { "source": "github", "repo": "warpdotdev/claude-code-warp" }
+      "source": { "source": "github", "repo": "warpdotdev/claude-code-warp" },
+      "autoUpdate": true
     },
     "himmel": {
-      "source": { "source": "directory", "path": "<himmel-path>/marketplace" }
+      "source": { "source": "directory", "path": "<himmel-path>/marketplace" },
+      "autoUpdate": true
     },
     "claude-obsidian-marketplace": {
-      "source": { "source": "github", "repo": "yotamleo/claude-obsidian" }
+      "source": { "source": "github", "repo": "yotamleo/claude-obsidian" },
+      "autoUpdate": true
     }
   },
   "autoUpdatesChannel": "latest",

--- a/scripts/machine-setup/install-plugins.ps1
+++ b/scripts/machine-setup/install-plugins.ps1
@@ -3,9 +3,12 @@
 # install-plugins.sh.
 #
 # Reads `enabledPlugins` and `extraKnownMarketplaces` from the template,
-# registers each marketplace via `claude plugin marketplace add`, then
-# installs each plugin via `claude plugin install <plugin>@<marketplace>
-# --scope <scope>`. Both CLI calls are idempotent.
+# registers each marketplace via `claude plugin marketplace add`, sets
+# `autoUpdate: true` on every template-flagged marketplace already registered in
+# the scope's settings.json (the CLI has no auto-update flag, so this is patched
+# straight into that file — HIMMEL-365), then installs each plugin via
+# `claude plugin install <plugin>@<marketplace> --scope <scope>`. Both CLI calls
+# are idempotent.
 #
 # Usage:
 #   pwsh install-plugins.ps1 [-DryRun] [-Scope SCOPE] [-Template PATH] [-HimmelPath PATH]
@@ -65,6 +68,51 @@ foreach ($name in $cfg.extraKnownMarketplaces.PSObject.Properties.Name) {
     Write-Host "  marketplace add: $val"
     try { Invoke-OrDry @('claude', 'plugin', 'marketplace', 'add', $val, '--scope', $Scope) }
     catch { Write-Host "    (non-zero — already registered or transient failure)" }
+}
+
+# ── Enable marketplace auto-update (HIMMEL-365) ──────────────────────────────
+# `claude plugin marketplace add` writes each settings.json entry WITHOUT
+# autoUpdate, so a fresh install leaves auto-update OFF (only a manual /plugin UI
+# toggle ever turned it on, and that never propagated to new machines). The CLI
+# has no auto-update flag, so set the canonical field
+# (extraKnownMarketplaces.<name>.autoUpdate, mirrored into the runtime
+# known_marketplaces.json) directly in the scope's settings file, for every
+# template entry flagged autoUpdate. Patch only entries already registered there,
+# so a marketplace-name vs template-key mismatch can't create an orphan entry.
+$settingsFile = switch ($Scope) {
+    'user'    { Join-Path $HOME '.claude\settings.json' }
+    'project' { Join-Path $PWD.Path '.claude\settings.json' }
+    'local'   { Join-Path $PWD.Path '.claude\settings.local.json' }
+}
+Write-Host "──── Enabling marketplace auto-update ($settingsFile) ────"
+$autoNames = @($cfg.extraKnownMarketplaces.PSObject.Properties |
+    Where-Object { $_.Value.autoUpdate -eq $true } |
+    ForEach-Object { $_.Name })
+foreach ($name in $autoNames) {
+    if ($DryRun) {
+        Write-Host "DRY: set autoUpdate=true for '$name' in $settingsFile"
+        continue
+    }
+    if (-not (Test-Path $settingsFile)) {
+        Write-Host "  skip: $name (no $settingsFile)"; continue
+    }
+    try { $settings = Get-Content $settingsFile -Raw | ConvertFrom-Json }
+    catch { Write-Host "  skip: $settingsFile not valid JSON — refusing to patch"; continue }
+    $mkts = $settings.extraKnownMarketplaces
+    if (-not $mkts -or ($mkts.PSObject.Properties.Name -notcontains $name)) {
+        Write-Host "  skip: '$name' not registered in $settingsFile"; continue
+    }
+    $mkts.$name | Add-Member -NotePropertyName autoUpdate -NotePropertyValue $true -Force
+    # Write UTF-8 WITHOUT BOM, to a temp then atomic Move-Item: `Set-Content
+    # -Encoding utf8` emits a BOM on Windows PowerShell 5.1 (none on pwsh 7),
+    # and a leading BOM makes Node's JSON.parse reject the file — so a manual
+    # 5.1 run would corrupt the operator's real settings.json. WriteAllText with
+    # UTF8Encoding($false) is BOM-free on both; the temp+move mirrors the bash
+    # twin's crash-safety (-Depth 100 covers settings.json's nesting).
+    $tmp = "$settingsFile.autoupdate.tmp"
+    [System.IO.File]::WriteAllText($tmp, ($settings | ConvertTo-Json -Depth 100), (New-Object System.Text.UTF8Encoding $false))
+    Move-Item -Force -LiteralPath $tmp -Destination $settingsFile
+    Write-Host "  autoUpdate=true: $name"
 }
 
 # ── Install plugins ─────────────────────────────────────────────────────────

--- a/scripts/machine-setup/install-plugins.sh
+++ b/scripts/machine-setup/install-plugins.sh
@@ -4,8 +4,11 @@
 #
 # Reads `enabledPlugins` (plugin@marketplace keys) and
 # `extraKnownMarketplaces` from the template, registers each marketplace
-# via `claude plugin marketplace add`, then installs each plugin via
-# `claude plugin install <plugin>@<marketplace> --scope <scope>`.
+# via `claude plugin marketplace add`, sets `autoUpdate: true` on every
+# template-flagged marketplace already registered in the scope's settings.json
+# (the CLI has no auto-update flag, so this is patched straight into that file —
+# HIMMEL-365), then installs each plugin via `claude plugin install
+# <plugin>@<marketplace> --scope <scope>`.
 #
 # Both CLI calls are idempotent — re-running this script on a fully
 # installed machine is a no-op.
@@ -93,6 +96,59 @@ echo "$EXPANDED" | jq -r '
   run claude plugin marketplace add "$SRC" --scope "$SCOPE" \
     || echo "    (non-zero — already registered or transient failure)"
 done
+
+# ── Enable marketplace auto-update (HIMMEL-365) ──────────────────────────────
+# `claude plugin marketplace add` writes each settings.json extraKnownMarketplaces
+# entry WITHOUT autoUpdate, so a fresh install leaves every marketplace's
+# auto-update OFF (only a manual /plugin UI toggle ever turned it on, and that
+# never propagated to new machines). The CLI exposes no auto-update flag, so set
+# the canonical field — extraKnownMarketplaces.<name>.autoUpdate, which the
+# runtime known_marketplaces.json mirrors — directly in the scope's settings
+# file, for every template entry flagged autoUpdate:true. Patch only entries that
+# already exist there, so a marketplace-name vs template-key mismatch can't
+# create an orphan entry.
+case "$SCOPE" in
+  user)    SETTINGS_FILE="$HOME/.claude/settings.json" ;;
+  project) SETTINGS_FILE="$PWD/.claude/settings.json" ;;
+  local)   SETTINGS_FILE="$PWD/.claude/settings.local.json" ;;
+esac
+
+echo "──── Enabling marketplace auto-update ($SETTINGS_FILE) ────"
+# tr -d '\r': jq emits CRLF on Windows; a trailing \r would corrupt the name key.
+AUTO_NAMES=$(echo "$EXPANDED" | jq -r '
+  .extraKnownMarketplaces // {}
+  | to_entries[]
+  | select(.value.autoUpdate == true)
+  | .key
+' | tr -d '\r')
+while IFS= read -r NAME; do
+  [[ -z "$NAME" ]] && continue
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "DRY: set autoUpdate=true for '$NAME' in $SETTINGS_FILE"
+    continue
+  fi
+  [[ -f "$SETTINGS_FILE" ]] || { echo "  skip: $NAME (no $SETTINGS_FILE)"; continue; }
+  if ! jq -e . "$SETTINGS_FILE" >/dev/null 2>&1; then
+    echo "  skip: $SETTINGS_FILE not valid JSON — refusing to patch" >&2
+    continue
+  fi
+  if [[ "$(jq --arg n "$NAME" '(.extraKnownMarketplaces // {}) | has($n)' "$SETTINGS_FILE")" != "true" ]]; then
+    echo "  skip: '$NAME' not registered in $SETTINGS_FILE"
+    continue
+  fi
+  # if/else (not `&& mv`): a bare `jq … && mv` is a standalone statement, so a
+  # jq failure trips `set -e` and aborts the whole script mid-run — skipping the
+  # install + verify steps for a merely-cosmetic patch. Tolerate it like the
+  # `marketplace add` / `install` steps do, and clean up the temp on failure.
+  if jq --arg n "$NAME" '.extraKnownMarketplaces[$n].autoUpdate = true' \
+       "$SETTINGS_FILE" > "$SETTINGS_FILE.autoupdate.tmp"; then
+    mv "$SETTINGS_FILE.autoupdate.tmp" "$SETTINGS_FILE"
+    echo "  autoUpdate=true: $NAME"
+  else
+    rm -f "$SETTINGS_FILE.autoupdate.tmp"
+    echo "  skip: $NAME (jq patch failed — $SETTINGS_FILE left unchanged)" >&2
+  fi
+done <<< "$AUTO_NAMES"
 
 # ── Install plugins ─────────────────────────────────────────────────────────
 echo "──── Installing plugins ($SCOPE scope) ────"

--- a/scripts/machine-setup/test-install-plugins-autoupdate.ps1
+++ b/scripts/machine-setup/test-install-plugins-autoupdate.ps1
@@ -1,0 +1,136 @@
+# test-install-plugins-autoupdate.ps1 — hermetic test for the HIMMEL-365
+# marketplace auto-update patch in scripts/machine-setup/install-plugins.ps1
+# (PowerShell twin of test-install-plugins-autoupdate.sh).
+#
+# Stubs the `claude` CLI on PATH (a claude.cmd; marketplace add / install no-op,
+# `plugin list` reports the enabled specs so verify passes), seeds a scope
+# settings file as `marketplace add` would have, runs the REAL script
+# (-Scope local from a temp cwd), and asserts:
+#   1. flagged + registered marketplace → autoUpdate:true added
+#   2. unflagged marketplace            → left untouched
+#   3. flagged but NOT registered       → skipped (no orphan entry)
+#   4. unrelated keys                   → preserved
+#   5. re-run                           → idempotent (stays true, exit 0)
+#
+# Keep in lockstep with test-install-plugins-autoupdate.sh when changing either.
+#
+# Run: pwsh -NoProfile -File scripts/machine-setup/test-install-plugins-autoupdate.ps1
+
+$ErrorActionPreference = 'Continue'
+$script:Failed = 0
+$Cli = Join-Path $PSScriptRoot 'install-plugins.ps1'
+
+if (-not $IsWindows) {
+    Write-Host 'SKIP: not Windows — the claude.cmd stub needs cmd.exe'
+    Write-Host 'PASS (skipped)'
+    exit 0
+}
+
+function Assert-True {
+    param([string]$Label, [bool]$Cond)
+    if ($Cond) { Write-Host "PASS $Label" }
+    else { Write-Host "FAIL $Label"; $script:Failed++ }
+}
+
+$Tmp = Join-Path ([IO.Path]::GetTempPath()) ('himmel-autoupdate-' + [Guid]::NewGuid().ToString('N').Substring(0, 8))
+New-Item -ItemType Directory -Force $Tmp | Out-Null
+$StubDir = Join-Path $Tmp 'bin'
+New-Item -ItemType Directory -Force $StubDir | Out-Null
+
+# Stub claude.cmd: `plugin list` reports the enabled specs; everything else 0.
+@'
+@echo off
+if not "%1"=="plugin" exit /b 0
+if not "%2"=="list" exit /b 0
+echo   good@flagged
+echo   good@unflagged
+exit /b 0
+'@ | Set-Content -Path (Join-Path $StubDir 'claude.cmd')
+
+# Template: flagged + unflagged + ghost; enabledPlugins match the stub's list.
+$Template = Join-Path $Tmp 'settings-template.json'
+@'
+{
+  "enabledPlugins": { "good@flagged": true, "good@unflagged": true },
+  "extraKnownMarketplaces": {
+    "flagged":   { "source": { "source": "github", "repo": "a/flagged" }, "autoUpdate": true },
+    "unflagged": { "source": { "source": "github", "repo": "a/unflagged" } },
+    "ghost":     { "source": { "source": "github", "repo": "a/ghost" }, "autoUpdate": true }
+  }
+}
+'@ | Set-Content -Path $Template
+
+# Seed settings.local.json as `marketplace add` would: flagged + unflagged
+# registered, ghost absent (exercises the existence guard).
+$Work = Join-Path $Tmp 'work'
+New-Item -ItemType Directory -Force (Join-Path $Work '.claude') | Out-Null
+$SF = Join-Path $Work '.claude\settings.local.json'
+@'
+{
+  "theme": "dark",
+  "extraKnownMarketplaces": {
+    "flagged":   { "source": { "source": "github", "repo": "a/flagged" } },
+    "unflagged": { "source": { "source": "github", "repo": "a/unflagged" } }
+  }
+}
+'@ | Set-Content -Path $SF
+
+$Pwsh = (Get-Command pwsh).Source
+$SavedPath = $env:PATH
+
+# Set-Location in the child so the script's $PWD (hence the local settings path)
+# resolves to $Work — a child process does not inherit a Set-Location done here.
+function Invoke-Install {
+    $cmd = "Set-Location -LiteralPath '$Work'; & '$Cli' -Scope local -Template '$Template'"
+    & $Pwsh -NoProfile -Command $cmd 2>&1 | Out-String | Out-Null
+    return $LASTEXITCODE
+}
+
+try {
+    $env:PATH = "$StubDir;$env:PATH"
+
+    $rc = Invoke-Install
+    Assert-True 'first run exits 0' ($rc -eq 0)
+
+    $patched = Get-Content $SF -Raw | ConvertFrom-Json
+    $mkts = $patched.extraKnownMarketplaces
+    Assert-True 'flagged marketplace patched' ($mkts.flagged.autoUpdate -eq $true)
+    Assert-True 'unflagged marketplace untouched' (-not ($mkts.unflagged.PSObject.Properties.Name -contains 'autoUpdate'))
+    Assert-True 'ghost (unregistered) entry not created' (-not ($mkts.PSObject.Properties.Name -contains 'ghost'))
+    Assert-True 'unrelated keys preserved' ($patched.theme -eq 'dark')
+    # The PS patch round-trips the WHOLE file through ConvertFrom/ConvertTo-Json,
+    # so assert a nested sub-object survives (the bash twin's jq is surgical).
+    Assert-True 'flagged.source survives reserialization' ($mkts.flagged.source.repo -eq 'a/flagged')
+
+    $rc = Invoke-Install
+    Assert-True 'second run (idempotency) exits 0' ($rc -eq 0)
+    $patched2 = Get-Content $SF -Raw | ConvertFrom-Json
+    Assert-True 'idempotent re-run keeps autoUpdate' ($patched2.extraKnownMarketplaces.flagged.autoUpdate -eq $true)
+
+    # Guard: an existing but invalid-JSON settings file → skipped, left byte-
+    # identical (protects a hand-edited settings.json from a clobber). Use
+    # WriteAllText/ReadAllText for byte-exact, BOM-free comparison.
+    $bad = '{ this is not valid json'
+    [System.IO.File]::WriteAllText($SF, $bad)
+    $rc = Invoke-Install
+    Assert-True 'invalid-JSON run exits 0' ($rc -eq 0)
+    Assert-True 'invalid-JSON settings left untouched' ([System.IO.File]::ReadAllText($SF) -eq $bad)
+
+    # Guard: no settings file present → skipped cleanly, file not created.
+    Remove-Item -Force $SF
+    $rc = Invoke-Install
+    Assert-True 'missing-file run exits 0' ($rc -eq 0)
+    Assert-True 'missing settings file not created' (-not (Test-Path $SF))
+} finally {
+    $env:PATH = $SavedPath
+    Remove-Item -Recurse -Force $Tmp -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+if ($script:Failed -eq 0) {
+    Write-Host 'ALL PASS'
+    exit 0
+} else {
+    Write-Host "$script:Failed FAILURE(S)"
+    exit 1
+}

--- a/scripts/machine-setup/test-install-plugins-autoupdate.sh
+++ b/scripts/machine-setup/test-install-plugins-autoupdate.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# test-install-plugins-autoupdate.sh — hermetic test for the HIMMEL-365
+# marketplace auto-update patch in scripts/machine-setup/install-plugins.sh.
+#
+# Stubs the `claude` CLI on PATH (marketplace add / install no-op; `plugin list`
+# reports the enabled specs so the verify step passes), seeds a scope settings
+# file as `marketplace add` would have written it, runs the REAL script
+# (--scope local from a temp cwd), and asserts the patch:
+#   1. flagged + registered marketplace → autoUpdate:true added
+#   2. unflagged marketplace            → left untouched (no autoUpdate)
+#   3. flagged but NOT registered       → skipped (no orphan entry created)
+#   4. unrelated keys                   → preserved
+#   5. re-run                           → idempotent (stays true, exit 0)
+#
+# install-plugins.ps1 carries the SAME patch as a PowerShell twin — covered by
+# test-install-plugins-autoupdate.ps1; keep both in lockstep when changing either.
+
+set -uo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+script="$repo_root/scripts/machine-setup/install-plugins.sh"
+[ -f "$script" ] || { echo "FAIL: $script not found" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not on PATH"; echo "PASS (skipped)"; exit 0; }
+
+FAILED=0
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $1"; FAILED=$((FAILED + 1)); }
+
+# Stub `claude`: install/marketplace add are no-ops; `plugin list` prints the
+# enabled specs so the post-install verify passes.
+STUB_DIR="$TMP/bin"
+mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/claude" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "list" ]; then
+  printf '  %s\n' "good@flagged" "good@unflagged"
+fi
+exit 0
+STUB
+chmod +x "$STUB_DIR/claude"
+
+# Template: flagged + unflagged + ghost marketplaces; enabledPlugins match the
+# stub's `plugin list` so verify is satisfied.
+TEMPLATE="$TMP/settings-template.json"
+cat > "$TEMPLATE" <<'JSON'
+{
+  "enabledPlugins": { "good@flagged": true, "good@unflagged": true },
+  "extraKnownMarketplaces": {
+    "flagged":   { "source": { "source": "github", "repo": "a/flagged" }, "autoUpdate": true },
+    "unflagged": { "source": { "source": "github", "repo": "a/unflagged" } },
+    "ghost":     { "source": { "source": "github", "repo": "a/ghost" }, "autoUpdate": true }
+  }
+}
+JSON
+
+# Seed settings.local.json as `marketplace add` would: flagged + unflagged
+# registered, ghost absent (exercises the existence guard).
+WORK="$TMP/work"
+mkdir -p "$WORK/.claude"
+SF="$WORK/.claude/settings.local.json"
+cat > "$SF" <<'JSON'
+{
+  "theme": "dark",
+  "extraKnownMarketplaces": {
+    "flagged":   { "source": { "source": "github", "repo": "a/flagged" } },
+    "unflagged": { "source": { "source": "github", "repo": "a/unflagged" } }
+  }
+}
+JSON
+
+( cd "$WORK" && PATH="$STUB_DIR:$PATH" bash "$script" --scope local --template "$TEMPLATE" ) \
+  >/dev/null 2>&1 || fail "first run exited non-zero"
+
+[ "$(jq -r '.extraKnownMarketplaces.flagged.autoUpdate' "$SF")" = "true" ] \
+  || fail "flagged marketplace not patched"
+[ "$(jq -r '.extraKnownMarketplaces.unflagged.autoUpdate // "absent"' "$SF")" = "absent" ] \
+  || fail "unflagged marketplace wrongly patched"
+[ "$(jq -r '.extraKnownMarketplaces | has("ghost")' "$SF")" = "false" ] \
+  || fail "ghost (unregistered) entry wrongly created"
+[ "$(jq -r '.theme' "$SF")" = "dark" ] \
+  || fail "unrelated keys not preserved"
+[ "$(jq -r '.extraKnownMarketplaces.flagged.source.repo' "$SF")" = "a/flagged" ] \
+  || fail "flagged.source sub-object not preserved through the patch"
+[ "$FAILED" -eq 0 ] && echo "ok: flagged patched, unflagged + ghost skipped, keys + source preserved"
+
+# Idempotent re-run: still true, exit 0.
+( cd "$WORK" && PATH="$STUB_DIR:$PATH" bash "$script" --scope local --template "$TEMPLATE" ) \
+  >/dev/null 2>&1 || fail "second run (idempotency) exited non-zero"
+[ "$(jq -r '.extraKnownMarketplaces.flagged.autoUpdate' "$SF")" = "true" ] \
+  || fail "idempotent re-run lost autoUpdate"
+[ "$FAILED" -eq 0 ] && echo "ok: idempotent re-run"
+
+# Guard: an existing but invalid-JSON settings file → skipped, left byte-identical
+# (this is the branch that protects a hand-edited settings.json from a clobber).
+BAD='{ this is not valid json'
+printf '%s' "$BAD" > "$SF"
+( cd "$WORK" && PATH="$STUB_DIR:$PATH" bash "$script" --scope local --template "$TEMPLATE" ) \
+  >/dev/null 2>&1 || fail "invalid-JSON run exited non-zero"
+[ "$(cat "$SF")" = "$BAD" ] || fail "invalid-JSON settings file was modified"
+[ "$FAILED" -eq 0 ] && echo "ok: invalid-JSON settings left untouched"
+
+# Guard: no settings file present → skipped cleanly, file not created.
+rm -f "$SF"
+( cd "$WORK" && PATH="$STUB_DIR:$PATH" bash "$script" --scope local --template "$TEMPLATE" ) \
+  >/dev/null 2>&1 || fail "missing-file run exited non-zero"
+[ ! -f "$SF" ] || fail "missing settings file was created"
+[ "$FAILED" -eq 0 ] && echo "ok: missing settings file stays absent"
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+    echo "ALL PASS"; exit 0
+else
+    echo "$FAILED FAILURE(S)"; exit 1
+fi

--- a/scripts/machine-setup/test-install-plugins-scope.sh
+++ b/scripts/machine-setup/test-install-plugins-scope.sh
@@ -15,6 +15,8 @@
 #   1. Default (no flag) → `--scope user` on install + marketplace add.
 #   2. `--scope project` → `--scope project` on both.
 #   3. Invalid `--scope bogus` → exit 2 (validation rejects before preflight).
+#   4. autoUpdate patch (HIMMEL-365) → dry-run emits the autoUpdate intent for a
+#      template-flagged marketplace, targeting the scope-correct settings file.
 
 set -euo pipefail
 
@@ -48,6 +50,19 @@ assert_scope() {
     printf '%s' "$out" | grep -q "DRY: claude plugin install .* --scope $want" \
         || fail "plugin install missing --scope $want (args: $*)"
     echo "ok: scope '$want' threads through (args: ${*:-<default>})"
+
+    # autoUpdate (HIMMEL-365): dry-run prints the patch intent for a flagged
+    # marketplace (himmel) against the scope-correct settings file. $HOME/$PWD
+    # are inherited by the child script, so they match what it computes.
+    local sf
+    case "$want" in
+      user)    sf="$HOME/.claude/settings.json" ;;
+      project) sf="$PWD/.claude/settings.json" ;;
+      local)   sf="$PWD/.claude/settings.local.json" ;;
+    esac
+    printf '%s' "$out" | grep -qF "DRY: set autoUpdate=true for 'himmel' in $sf" \
+        || fail "autoUpdate dry line missing/wrong file for scope $want (want $sf)"
+    echo "ok: autoUpdate targets $sf for scope '$want'"
 }
 
 assert_scope user                      # default


### PR DESCRIPTION
## setup propagates marketplace autoUpdate to new users (HIMMEL-365)

### Problem
New-user setup registers extra marketplaces via `claude plugin marketplace add`
(in `install-plugins.{sh,ps1}`), which writes a `settings.json`
`extraKnownMarketplaces` entry **without** `autoUpdate`. A fresh install therefore
leaves every marketplace's auto-update OFF — the only way it gets turned on is a
manual `/plugin` UI toggle, which never propagates to a new machine. The CLI
exposes no auto-update flag; the canonical field is
`extraKnownMarketplaces.<name>.autoUpdate` (the runtime
`known_marketplaces.json` mirrors it).

### Change
- **template:** declare `"autoUpdate": true` on each `extraKnownMarketplaces`
  entry in `docs/setup/settings-template.json`.
- **installers:** after `claude plugin marketplace add`,
  `install-plugins.{sh,ps1}` patch that field into the scope's settings file
  (user→`~/.claude/settings.json`, project→`./.claude/settings.json`,
  local→`./.claude/settings.local.json`) for every flagged entry **already
  registered there** (existence-guarded — no orphan entries), with a
  JSON-validity guard, atomic write, and CRLF-safety. Bash uses jq (surgical);
  PowerShell writes UTF-8 **without BOM** (the `Set-Content -Encoding utf8` BOM
  breaks Node's `JSON.parse` on Windows PowerShell 5.1) to a temp + `Move-Item`.

### Tests
- `test-install-plugins-scope.sh`: asserts the dry-run autoUpdate intent targets
  the scope-correct settings file for user/project/local.
- New hermetic `test-install-plugins-autoupdate.{sh,ps1}`: stub `claude`, seed a
  settings file, run the real script — flagged-only patch, ghost/unregistered
  skip, unflagged untouched, keys + `source` sub-object preserved, idempotent
  re-run, invalid-JSON guard (left untouched), missing-file guard.

Platforms tested: windows (Git Bash + PowerShell 7)
Security reviewed: manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
