### PR TITLE
fix(scripts): [HIMMEL-366] plugin-test.sh — self-bootstrapping green baseline for marketplace plugins

### DIFF
--- a/marketplace/plugins/CLAUDE.md
+++ b/marketplace/plugins/CLAUDE.md
@@ -17,6 +17,11 @@ needs (`commands/`, `skills/`, `agents/`, `tools/`). Live plugins:
   the plugin's `README.md`, so the divergence from upstream is auditable.
 - A plugin's skills follow the same authoring rules as any skill — invoke
   the `skill-creator` / `plugin-dev` skills rather than hand-rolling.
+- **Test a plugin that declares its own deps via `bash scripts/plugin-test.sh
+  <plugin>`**, not raw `bun test` (HIMMEL-366). A fresh worktree only installs
+  `scripts/jira/` deps, so raw `bun test` here starts RED ("Cannot find module
+  '@modelcontextprotocol/sdk/…'") and masks real regressions; the helper
+  `bun install`s first so the baseline is GREEN.
 
 ## Reference
 - Tooling catalog (what each plugin does):

--- a/scripts/plugin-test.sh
+++ b/scripts/plugin-test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# scripts/plugin-test.sh — self-bootstrapping test entry point for a
+# marketplace plugin that declares its own deps (HIMMEL-366).
+#
+# A fresh worktree only gets scripts/jira/ deps installed (by
+# _new-worktree.sh), so a raw `bun test` in marketplace/plugins/<plugin>/
+# fails with "Cannot find module '@modelcontextprotocol/sdk/...'" until
+# someone runs `bun install` by hand. That RED baseline masks real
+# regressions — a developer (or an overnight subagent) can't tell a
+# pre-existing env failure from a change they just introduced.
+#
+# This helper installs the plugin's deps THEN runs its tests, so a fresh
+# checkout reaches a GREEN baseline in one command. Opt-in per plugin: no
+# per-worktree cost (you only `bun install` the plugin you actually test),
+# and it self-bootstraps because `bun test` (the runner subcommand) never
+# runs the package.json `start` script — the one that would `bun install`.
+#
+# Usage:
+#   bash scripts/plugin-test.sh <plugin>      # dir name under marketplace/plugins/
+#   bash scripts/plugin-test.sh luna-correlate
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+usage() {
+  echo "Usage: $0 <plugin>" >&2
+  echo "  <plugin> = a directory name under marketplace/plugins/ that has a package.json" >&2
+  exit 2
+}
+
+[ $# -eq 1 ] || usage
+PLUGIN="$1"
+DIR="$ROOT/marketplace/plugins/$PLUGIN"
+
+[ -d "$DIR" ] || { echo "ERR plugin-test: no such plugin dir: marketplace/plugins/$PLUGIN" >&2; exit 2; }
+[ -f "$DIR/package.json" ] || { echo "ERR plugin-test: $PLUGIN has no package.json (nothing to bootstrap/test)" >&2; exit 2; }
+command -v bun >/dev/null 2>&1 || { echo "ERR plugin-test: bun not on PATH (install: https://bun.sh)" >&2; exit 127; }
+
+echo "== plugin-test: $PLUGIN =="
+echo "-- bun install --no-summary"
+( cd "$DIR" && bun install --no-summary )
+echo "-- bun test"
+( cd "$DIR" && bun test )

--- a/scripts/test-plugin-test.sh
+++ b/scripts/test-plugin-test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/plugin-test.sh (HIMMEL-366).
+# Structural arg-handling checks + one end-to-end run that proves the helper
+# self-bootstraps a plugin's deps and reaches a GREEN baseline.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/scripts/plugin-test.sh"
+fails=0
+ok() { echo "ok - $1"; }
+bad() { echo "FAIL - $1" >&2; fails=$((fails + 1)); }
+
+# 1. Syntax.
+if bash -n "$SCRIPT"; then ok "syntax (bash -n)"; else bad "syntax"; fi
+
+# 2. No args -> usage exit 2.
+bash "$SCRIPT" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ]; then ok "no args -> exit 2"; else bad "no args exited $rc (want 2)"; fi
+
+# 3. Unknown plugin -> exit 2.
+bash "$SCRIPT" definitely-not-a-plugin >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ]; then ok "unknown plugin -> exit 2"; else bad "unknown plugin exited $rc (want 2)"; fi
+
+# 4. A plugin dir with no package.json -> exit 2 (CLAUDE.md is a real dir-less
+#    case: the marketplace/plugins/ root itself has no package.json).
+bash "$SCRIPT" . >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ]; then ok "no package.json -> exit 2"; else bad "no-package.json exited $rc (want 2)"; fi
+
+# 5. End-to-end: run against luna-correlate (declares @modelcontextprotocol/sdk
+#    + a test suite). The helper must install deps and exit 0 with a green run.
+#    This is the headline property — a fresh worktree reaches GREEN in one shot.
+if [ -f "$ROOT/marketplace/plugins/luna-correlate/package.json" ]; then
+  out="$(bash "$SCRIPT" luna-correlate 2>&1)"; rc=$?
+  if [ "$rc" -eq 0 ]; then ok "luna-correlate end-to-end exits 0 (green baseline)"; else bad "luna-correlate exited $rc; output tail: $(printf '%s' "$out" | tail -5)"; fi
+  if printf '%s' "$out" | grep -q "0 fail"; then ok "luna-correlate test run reports 0 fail"; else bad "no '0 fail' line in output"; fi
+else
+  ok "luna-correlate absent — skipping end-to-end (no plugin to test)"
+fi
+
+echo ""
+if [ "$fails" -ne 0 ]; then echo "$fails check(s) failed."; exit 1; fi
+echo "all checks passed."


### PR DESCRIPTION
## What

Adds `scripts/plugin-test.sh <plugin>` — a self-bootstrapping test entry point that runs `bun install --no-summary && bun test` for one marketplace plugin, so a fresh checkout/worktree reaches a GREEN test baseline in one command.

## Why

A fresh checkout only installs `scripts/jira/` deps, so a raw `bun test` in `marketplace/plugins/<plugin>/` (e.g. `luna-correlate`) starts RED with `Cannot find module '@modelcontextprotocol/sdk/...'` until someone runs `bun install` by hand. That red baseline masks real regressions — you can't tell a pre-existing env failure from a change you introduced.

Not user-facing: a plugin's `.mcp.json` launches via the `start` script (`bun install … && bun server.ts`), which auto-installs on first MCP launch. This is purely DEV/CI friction — the `bun test` runner bypasses the package.json `start` script.

## How

- `scripts/plugin-test.sh` — the helper (exit codes: bad input -> 2, missing `bun` -> 127, test failures propagate).
- `scripts/test-plugin-test.sh` — paired smoke test: syntax, arg-handling exits, end-to-end run on `luna-correlate`.
- `marketplace/plugins/CLAUDE.md` — one-line convention pointer.

## Verification

`shellcheck` clean; smoke test 6/6; end-to-end `luna-correlate` run 113 pass / 0 fail / exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
