### PR TITLE
chore(hooks): [HIMMEL-371] block stray-artifact leakage into commits (gitignore + pre-commit hook)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,17 @@
 /.claude/worktrees
 .env
 scripts/jira/dist/
-scripts/jira/node_modules/
-scripts/luna-vitals/node_modules/
-/node_modules/
+# node_modules anywhere — none are tracked. A per-package list let
+# marketplace/plugins/*/node_modules/ slip through and be sweepable (HIMMEL-371).
+node_modules/
 /.claude/settings.local.json
+# Generated/junk artifacts that must never be committed (HIMMEL-371).
+# NOT package-lock.json — 6 legit npm packages track theirs; the wrong-PM
+# lockfile case (a package-lock.json inside a bun package) is caught by the
+# check-artifact-leakage pre-commit hook instead.
+*.tsbuildinfo
+.DS_Store
+Thumbs.db
 # end-session-wiki hook local artifacts — contain raw transcript excerpts (potential secrets).
 # Match any .claude/ dir (the hook writes into the cwd's .claude/, e.g. scripts/telegram/.claude/).
 **/.claude/end-session-wiki.log

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,6 +86,14 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+      - id: artifact-leakage
+        name: block stray generated artifacts from being committed (HIMMEL-371)
+        language: system
+        entry: bash scripts/hooks/check-artifact-leakage.sh
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+
       - id: no-push-to-main
         name: Block direct push to main
         language: system

--- a/scripts/hooks/check-artifact-leakage.sh
+++ b/scripts/hooks/check-artifact-leakage.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Pre-commit hook: block stray generated artifacts from being committed
+# (HIMMEL-371).
+#
+# Why: himmel runs concurrent sessions sharing one repo tree, and build/test
+# steps (sometimes the wrong package manager) drop untracked artifacts. A
+# blanket `git add -A` then sweeps them into a commit — on HIMMEL-366 an npm
+# `package-lock.json` landed in the bun package scripts/luna-vitals/ and rode
+# into a commit, caught only by reading `git show --stat` after the fact.
+#
+# The hardened .gitignore is the primary defense (it makes `git add -A` safe
+# for the generated-artifact class). This hook is the defense-in-depth
+# backstop for what .gitignore can't catch generically: a force-added artifact,
+# or the wrong-PM lockfile case — a package-lock.json can't be globally ignored
+# because 6 legit npm packages track theirs, so it's only leakage when it sits
+# next to a bun.lock (i.e. the dir is a bun package).
+#
+# Only NEWLY-ADDED files (git status A) are checked — modifying an
+# already-tracked file is never leakage. Fail-closed: a match blocks the commit.
+# NOT a universal "any file" guard (a hook can't know intent); it covers the
+# generated-artifact class only — arbitrary hand-written leakage stays staging
+# discipline. bash 3.2-safe (no mapfile/associative arrays).
+set -euo pipefail
+
+# Newly-added staged paths (NUL-safe for paths with spaces).
+bad=""
+while IFS= read -r -d '' f; do
+    base=$(basename "$f")
+    dir=$(dirname "$f")
+
+    case "$f" in
+        node_modules/*|*/node_modules/*)
+            bad="${bad}  $f  [node_modules — never commit]"$'\n'; continue ;;
+    esac
+    case "$base" in
+        .DS_Store|Thumbs.db)
+            bad="${bad}  $f  [OS junk — never commit]"$'\n'; continue ;;
+        *.tsbuildinfo)
+            bad="${bad}  $f  [TS build artifact — never commit]"$'\n'; continue ;;
+    esac
+    # Wrong-package-manager lockfile: an npm/yarn/pnpm lock staged inside a dir
+    # that already has a bun lockfile (so the dir is a bun package).
+    case "$base" in
+        package-lock.json|yarn.lock|pnpm-lock.yaml)
+            if [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; then
+                bad="${bad}  $f  [wrong-PM lockfile next to bun.lock — $dir is a bun package]"$'\n'
+                continue
+            fi ;;
+    esac
+done < <(git diff --cached --name-only --diff-filter=A -z)
+
+if [ -n "$bad" ]; then
+    echo "ERROR: artifact-leakage — these staged NEW files look like stray/generated artifacts:" >&2
+    printf '%s' "$bad" >&2
+    echo "" >&2
+    echo "If a concurrent session or build step dropped these, unstage them:" >&2
+    echo "  git restore --staged <file>" >&2
+    echo "If one is genuinely intended, stage it explicitly (use 'git add -f' if ignored) and re-commit." >&2
+    echo "" >&2
+    echo "Commit blocked." >&2
+    exit 1
+fi
+exit 0

--- a/scripts/hooks/test-check-artifact-leakage.sh
+++ b/scripts/hooks/test-check-artifact-leakage.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/hooks/check-artifact-leakage.sh (HIMMEL-371).
+# The hook reads `git diff --cached` of the cwd, so each case stages fixtures in
+# a throwaway git repo and runs the hook there, asserting the exit code.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/hooks/check-artifact-leakage.sh"
+fails=0
+ok() { echo "ok - $1"; }
+bad() { echo "FAIL - $1" >&2; fails=$((fails + 1)); }
+
+# 1. Syntax.
+if bash -n "$SCRIPT"; then ok "syntax (bash -n)"; else bad "syntax"; fi
+
+# Fresh throwaway repo per run. Staging needs no identity/commit; the modify
+# case below sets identity inline.
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+git -C "$TMP" init -q
+
+# Stage the already-set-up fixtures, run the hook in the repo, assert its exit
+# code, then unstage. $1 = expected rc, $2 = label.
+expect() {
+    local want="$1" label="$2" got
+    got=$( cd "$TMP" && bash "$SCRIPT" >/dev/null 2>&1; echo $? )
+    if [ "$got" = "$want" ]; then ok "$label"; else bad "$label (want rc=$want, got rc=$got)"; fi
+    git -C "$TMP" reset -q
+}
+
+# 2. Nothing staged -> exit 0.
+expect 0 "empty staged set -> 0"
+
+# 3. A normal new source file -> exit 0.
+mkdir -p "$TMP/src" && echo 'export const x = 1' > "$TMP/src/foo.ts"
+git -C "$TMP" add src/foo.ts
+expect 0 "normal new file -> 0"
+
+# 4. node_modules/ -> blocked (force-add, since real gitignore would skip it).
+mkdir -p "$TMP/node_modules/pkg" && echo '{}' > "$TMP/node_modules/pkg/package.json"
+git -C "$TMP" add -f node_modules/pkg/package.json
+expect 1 "node_modules -> blocked"
+
+# 5. OS junk -> blocked.
+echo junk > "$TMP/.DS_Store"
+git -C "$TMP" add -f .DS_Store
+expect 1 ".DS_Store -> blocked"
+
+# 6. *.tsbuildinfo -> blocked.
+echo '{}' > "$TMP/tsconfig.tsbuildinfo"
+git -C "$TMP" add -f tsconfig.tsbuildinfo
+expect 1 "*.tsbuildinfo -> blocked"
+
+# 7. Wrong-PM lockfile: package-lock.json in a dir WITH bun.lock -> blocked.
+mkdir -p "$TMP/bunpkg" && echo '{}' > "$TMP/bunpkg/bun.lock" && echo '{}' > "$TMP/bunpkg/package-lock.json"
+git -C "$TMP" add -f bunpkg/package-lock.json
+expect 1 "package-lock.json next to bun.lock -> blocked"
+
+# 8. Legit npm: package-lock.json in a dir WITHOUT bun.lock -> exit 0.
+mkdir -p "$TMP/npmpkg" && echo '{}' > "$TMP/npmpkg/package-lock.json"
+git -C "$TMP" add npmpkg/package-lock.json
+expect 0 "package-lock.json without bun.lock -> 0 (legit npm)"
+
+# 8a/8b. The wrong-PM arm is shared across three lockfile names — pin yarn.lock
+#        and pnpm-lock.yaml too, so narrowing/mistyping the glob can't ship green.
+mkdir -p "$TMP/bunpkg2" && echo '{}' > "$TMP/bunpkg2/bun.lock"
+echo '{}' > "$TMP/bunpkg2/yarn.lock"
+git -C "$TMP" add -f bunpkg2/yarn.lock
+expect 1 "yarn.lock next to bun.lock -> blocked"
+echo '{}' > "$TMP/bunpkg2/pnpm-lock.yaml"
+git -C "$TMP" add -f bunpkg2/pnpm-lock.yaml
+expect 1 "pnpm-lock.yaml next to bun.lock -> blocked"
+
+# 8c. The alternate bun marker (binary bun.lockb) also triggers the wrong-PM arm.
+mkdir -p "$TMP/bunpkg3" && echo 'bin' > "$TMP/bunpkg3/bun.lockb"
+echo '{}' > "$TMP/bunpkg3/package-lock.json"
+git -C "$TMP" add -f bunpkg3/package-lock.json
+expect 1 "package-lock.json next to bun.lockb -> blocked"
+
+# 8d. OS-junk other arm: Thumbs.db (the Windows half of the .DS_Store|Thumbs.db arm).
+echo junk > "$TMP/Thumbs.db"
+git -C "$TMP" add -f Thumbs.db
+expect 1 "Thumbs.db -> blocked"
+
+# 8e. NUL-safe parsing: a path containing a space must still be caught (the hook
+#     reads `git diff -z` via `read -r -d ''` precisely for this).
+mkdir -p "$TMP/node_modules/scoped pkg"
+echo '{}' > "$TMP/node_modules/scoped pkg/package.json"
+git -C "$TMP" add -f "node_modules/scoped pkg/package.json"
+expect 1 "node_modules path with a space -> blocked (NUL-safe read)"
+
+# 9. Only MODIFYING an already-tracked artifact-named file is not leakage
+#    (the hook only inspects NEW adds, diff-filter=A). Commit one, then modify.
+echo first > "$TMP/legacy.tsbuildinfo"
+git -C "$TMP" add -f legacy.tsbuildinfo
+git -C "$TMP" -c user.email=t@t -c user.name=t commit -q -m "legacy artifact (pre-existing)"
+echo second > "$TMP/legacy.tsbuildinfo"
+git -C "$TMP" add legacy.tsbuildinfo
+expect 0 "modifying a pre-tracked artifact -> 0 (only NEW adds blocked)"
+
+echo ""
+if [ "$fails" -ne 0 ]; then echo "$fails check(s) failed."; exit 1; fi
+echo "all checks passed."


### PR DESCRIPTION
## What

Two structural defenses against untracked artifacts being swept into a commit.

## Why

A concurrent session or build step drops an untracked artifact; a blanket `git add -A` then commits it (e.g. an npm `package-lock.json` landing in a bun package and riding into a commit).

## How

1. **`.gitignore` hardening** (primary): global `node_modules/` (was a 3-dir list) + `.DS_Store`, `Thumbs.db`, `*.tsbuildinfo`. Makes `git add -A` safe-by-default for the generated-artifact class. **Not** `package-lock.json` — legit npm packages track theirs.
2. **`scripts/hooks/check-artifact-leakage.sh`** (pre-commit backstop): blocks NEWLY-ADDED staged files (`--diff-filter=A -z`, NUL-safe) under `node_modules/`, OS junk, `*.tsbuildinfo`, or a wrong-PM lockfile (`package-lock.json`/`yarn.lock`/`pnpm-lock.yaml`) next to a sibling `bun.lock`/`bun.lockb` — which gitignore can't express generically. Fail-closed, clear remediation. Wired in `.pre-commit-config.yaml`.

Not a universal "any file" guard — covers the generated-artifact class; arbitrary hand-written leakage stays staging discipline.

## Verification

Paired smoke test `scripts/hooks/test-check-artifact-leakage.sh` (throwaway-repo fixtures): **14/14 green** — every artifact class, both lockfile-marker branches, yarn/pnpm + `bun.lockb` arms, NUL-safe spaced path, modify-vs-add discrimination. `shellcheck` clean. The wrong-PM rule has zero false positives on tracked packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
