### PR TITLE
feat(arm-resume): [HIMMEL-386/387] pre-trust arm cwd + worktree isolation

### DIFF
--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -74,6 +74,7 @@ DRY_RUN=0
 RESUME_CWD_OVERRIDE=""
 CHANNELS=""
 DEDUP_ANY=0
+WORKTREE_BRANCH=""
 
 # Local HH:MM from an epoch (armored python3 — portable, no GNU `date -d`;
 # capture via file so a wedged Store stub can't hang the $() call sites).
@@ -107,12 +108,20 @@ Optional:
                      file. Override when the handover lives in a
                      different repo than the one claude should run
                      from (e.g. hop.sh writes the snapshot under
-                     yotam_docs but the origin session was in himmel).
+                     the state repo but the origin session was in himmel).
                      If the handover file's YAML frontmatter contains
                      'resume_cwd: <path>', that value is used when
                      --cwd is omitted (set this for cross-repo
                      handovers so the correct repo is used without
                      requiring an explicit --cwd every time).
+  --worktree <branch>  Run the relaunch in a FRESH himmel worktree for
+                     <branch> (type/slug) instead of a shared checkout —
+                     for code arms that must not collide with concurrent
+                     github-sync / Telegram-bridge sessions. Creates the
+                     worktree at arm time and resumes there. Mutually
+                     exclusive with --cwd (the worktree IS the cwd). A
+                     handover 'resume_worktree: <branch>' frontmatter key
+                     does the same when the flag is omitted. (HIMMEL-387)
   --channels <spec>  Pass --channels <spec> to the relaunched claude so
                      the spawned session opens that channel. NOT for
                      Telegram: the always-on bun bridge (HIMMEL-207/208)
@@ -149,6 +158,8 @@ while [ $# -gt 0 ]; do
         --handover=*)  HANDOVER_PATH="${1#--handover=}"; shift ;;
         --cwd)         RESUME_CWD_OVERRIDE="${2:-}"; shift 2 ;;
         --cwd=*)       RESUME_CWD_OVERRIDE="${1#--cwd=}"; shift ;;
+        --worktree)    WORKTREE_BRANCH="${2:-}"; shift 2 ;;
+        --worktree=*)  WORKTREE_BRANCH="${1#--worktree=}"; shift ;;
         --channels)    CHANNELS="${2:-}"; shift 2 ;;
         --channels=*)  CHANNELS="${1#--channels=}"; shift ;;
         --force)       FORCE=1; shift ;;
@@ -471,14 +482,75 @@ RESUME_PROMPT="load $HANDOVER_PATH overnight mode"
 #
 # Priority:
 #   1. --cwd override. hop.sh (HIMMEL-130) passes the ORIGIN repo here
-#      because the handover lives in yotam_docs but claude must run
-#      from the origin repo, not yotam_docs.
+#      because the handover lives in the state repo but claude must run
+#      from the origin repo, not the state repo.
 #   2. resume_cwd: in the handover file's YAML frontmatter. Lets a
-#      handover in yotam_docs declare its own work-repo without
+#      handover in the state repo declare its own work-repo without
 #      requiring an explicit --cwd at every arm-resume call.
 #   3. Auto-detect: git toplevel containing the handover file.
 #   4. Fallback: handover's parent dir if it isn't tracked by git.
-if [ -n "$RESUME_CWD_OVERRIDE" ]; then
+#
+# Priority 0 (HIMMEL-387): --worktree <branch> / 'resume_worktree:' frontmatter
+# short-circuits all of the above — the relaunch runs in a FRESH himmel
+# worktree instead of a shared checkout. Required when github-sync / the
+# Telegram bridge run concurrently, so an autonomous code arm never mutates a
+# checkout another session has open. Explicit opt-in only: vault arms
+# (luna/luna-medic) must stay single-tree, so this is never inferred.
+
+# Resolve the worktree branch from frontmatter when not given on the CLI
+# (flag wins, same precedence as --cwd over resume_cwd).
+if [ -z "$WORKTREE_BRANCH" ]; then
+    _fm_wt=$(awk '/^---[[:space:]]*$/{c++; next} c==1' "$HANDOVER_PATH" \
+        | sed -n 's/^resume_worktree:[[:space:]]*//p' | head -1)
+    _fm_wt="${_fm_wt%"${_fm_wt##*[![:space:]]}"}"   # rtrim (incl trailing \r)
+    _fm_wt="${_fm_wt#\'}" ; _fm_wt="${_fm_wt%\'}"
+    _fm_wt="${_fm_wt#\"}" ; _fm_wt="${_fm_wt%\"}"
+    WORKTREE_BRANCH="$_fm_wt"
+    unset _fm_wt
+fi
+
+if [ -n "$WORKTREE_BRANCH" ]; then
+    if [ -n "$RESUME_CWD_OVERRIDE" ]; then
+        echo "ERR arm-resume: --cwd and --worktree are mutually exclusive (the worktree IS the cwd)" >&2
+        exit 1
+    fi
+    if ! printf '%s' "$WORKTREE_BRANCH" | grep -qE '^(feat|fix|chore|docs|refactor|test)/[A-Za-z0-9._-]+$'; then
+        echo "ERR arm-resume: --worktree branch must be type/slug (type in feat|fix|chore|docs|refactor|test): '$WORKTREE_BRANCH'" >&2
+        exit 1
+    fi
+    # clean-garden.sh (which worktree.sh wraps) creates the worktree under the
+    # checkout's own .claude/worktrees/<type>+<slug>/. Compute that path so the
+    # dry-run can report it and the pre-trust below can target it. SCRIPT_DIR is
+    # scripts/handover, so ../.. is the repo root of THIS checkout (run from the
+    # primary checkout per the operator rule).
+    _wt_root=$(cd "$SCRIPT_DIR/../.." && pwd)
+    _wt_path="$_wt_root/.claude/worktrees/${WORKTREE_BRANCH/\//+}"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRY arm-resume: would create worktree '$WORKTREE_BRANCH' at '$_wt_path' and resume there"
+        RESUME_CWD="$_wt_path"
+    else
+        if [ -d "$_wt_path" ]; then
+            echo "arm-resume: reusing existing worktree at '$_wt_path'"
+        else
+            # ARM_WORKTREE_CMD is a test seam (default: the real worktree.sh).
+            # ARM_WORKTREE_PATH lets a stub create the exact computed dir; the
+            # real worktree.sh ignores it (it computes the same path itself).
+            _wt_cmd="${ARM_WORKTREE_CMD:-bash $SCRIPT_DIR/../worktree.sh}"
+            # _wt_cmd is an intentional cmd+args split — word-splitting wanted.
+            # shellcheck disable=SC2086
+            if ! ARM_WORKTREE_PATH="$_wt_path" $_wt_cmd "$WORKTREE_BRANCH"; then
+                echo "ERR arm-resume: worktree create failed for branch '$WORKTREE_BRANCH'" >&2
+                exit 4
+            fi
+        fi
+        if [ ! -d "$_wt_path" ]; then
+            echo "ERR arm-resume: expected worktree dir not found after create: '$_wt_path'" >&2
+            exit 4
+        fi
+        RESUME_CWD=$(_arm_realpath "$_wt_path")
+    fi
+    unset _wt_root _wt_path
+elif [ -n "$RESUME_CWD_OVERRIDE" ]; then
     if [ ! -d "$RESUME_CWD_OVERRIDE" ]; then
         echo "ERR arm-resume: --cwd path does not exist: $RESUME_CWD_OVERRIDE" >&2
         exit 1
@@ -527,6 +599,18 @@ else
         fi
     fi
     unset _fm_cwd _fm_cwd_found
+fi
+
+# Pre-trust the resolved cwd (HIMMEL-386) so the fired relaunch doesn't stall
+# on Claude Code's interactive workspace-trust prompt ("Is this a project you
+# trust?"). An autonomous relaunch has no human to answer it and its stdin is
+# closed, so an untrusted cwd silently wastes the whole run. Non-fatal: a
+# pre-seed failure must never block the arm itself.
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo "DRY arm-resume: would pre-trust workspace '$RESUME_CWD' in ~/.claude.json"
+else
+    "$SCRIPT_DIR/../lib/ensure-workspace-trust.sh" "$RESUME_CWD" \
+        || echo "WARN arm-resume: workspace-trust pre-seed failed for '$RESUME_CWD' (arm continues; first relaunch may prompt to trust the folder)" >&2
 fi
 
 # Dedup: list existing HIMMEL-Resume jobs. Fail-CLOSED if the listing

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -23,6 +23,11 @@ export SKILL_TELEMETRY_DIR="$TMP/telemetry-default"
 # Unset the kill switch so T21/T23 (which assert a record IS written) are
 # not spuriously broken by an operator shell that exports it (HIMMEL-384).
 unset SKILL_TELEMETRY_DISABLE 2>/dev/null || true
+# Global workspace-trust shield (HIMMEL-386): arm-resume now pre-trusts the
+# resolved cwd in ~/.claude.json. The non-dry-run arm cases below (T14-T20
+# bridge/channel checks, dedup-any) would otherwise write the operator's real
+# config — redirect the pre-seed at a throwaway file for the whole suite.
+export WORKSPACE_TRUST_CONFIG="$TMP/claude-trust.json"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -64,10 +69,10 @@ WORK_REPO="$TMP/work-repo"
 mkdir -p "$WORK_REPO"
 git init -q "$WORK_REPO"
 
-# A separate directory for handover files (simulates yotam_docs).
-HANDOVER_DIR="$TMP/yotam-docs/handovers"
+# A separate directory for handover files (simulates the state repo).
+HANDOVER_DIR="$TMP/statedocs/handovers"
 mkdir -p "$HANDOVER_DIR"
-git init -q "$TMP/yotam-docs"
+git init -q "$TMP/statedocs"
 
 # A fixed time in the future (HH:MM format) — just needs to parse.
 FUTURE_TIME="23:59"
@@ -121,7 +126,9 @@ out=$(PATH="$SCHED_STUB_T17:$PATH" bash "$ARM" --time "$FUTURE_TIME" --handover 
 rc=$?
 assert_rc "T1 --cwd flag exits 0" 0 "$rc"
 assert_contains "T1 RESUME_CWD matches --cwd arg" "RESUME_CWD=$WORK_REPO" "$out"
-assert_not_contains "T1 --cwd does not resolve to yotam-docs" "RESUME_CWD=$HANDOVER_DIR" "$out"
+assert_not_contains "T1 --cwd does not resolve to statedocs" "RESUME_CWD=$HANDOVER_DIR" "$out"
+# HIMMEL-386: the arm pre-trusts the resolved cwd (dry-run reports, doesn't mutate).
+assert_contains "T1 dry-run pre-trusts resolved cwd" "would pre-trust workspace '$WORK_REPO'" "$out"
 
 # ---------------------------------------------------------------------------
 # T2: handover WITH resume_cwd pointing to a valid dir, NO --cwd
@@ -158,10 +165,10 @@ out=$(PATH="$SCHED_STUB_T17:$PATH" bash "$ARM" --time "$FUTURE_TIME" --handover 
 rc=$?
 assert_rc "T4 no-cwd fallback exits 0" 0 "$rc"
 assert_contains "T4 emits discoverability warning" "no --cwd and no 'resume_cwd:' in handover frontmatter" "$out"
-# RESUME_CWD should resolve to the git toplevel of $TMP/yotam-docs.
+# RESUME_CWD should resolve to the git toplevel of $TMP/statedocs.
 # Compute the expected value the same way arm-resume does (git rev-parse).
-EXPECTED_T4=$(git -C "$TMP/yotam-docs" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$TMP/yotam-docs")
-assert_contains "T4 RESUME_CWD resolves to yotam-docs git-toplevel" "RESUME_CWD=$EXPECTED_T4" "$out"
+EXPECTED_T4=$(git -C "$TMP/statedocs" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$TMP/statedocs")
+assert_contains "T4 RESUME_CWD resolves to statedocs git-toplevel" "RESUME_CWD=$EXPECTED_T4" "$out"
 
 # ---------------------------------------------------------------------------
 # T5: resume_cwd value with surrounding double quotes is handled correctly
@@ -1011,6 +1018,86 @@ case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
         fi
         ;;
 esac
+
+# ---------------------------------------------------------------------------
+# W1-W5: --worktree isolation for code arms (HIMMEL-387)
+# ---------------------------------------------------------------------------
+# W1: --worktree dry-run computes the type+slug path, resumes there, pre-trusts it.
+HO=$(make_handover "")
+out=$(PATH="$SCHED_STUB_T17:$PATH" bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --worktree feat/wt-test --dry-run 2>&1)
+rc=$?
+assert_rc "W1 --worktree dry-run exits 0" 0 "$rc"
+assert_contains "W1 announces worktree create" "would create worktree 'feat/wt-test'" "$out"
+assert_contains "W1 path uses type+slug dir" ".claude/worktrees/feat+wt-test" "$out"
+assert_contains "W1 RESUME_CWD set to worktree" "RESUME_CWD=" "$out"
+assert_contains "W1 pre-trusts the worktree (HIMMEL-386 wiring)" "would pre-trust workspace" "$out"
+
+# W2: invalid branch (no type/slug) → loud rc 1, no scheduler touched.
+out=$(PATH="$SCHED_STUB_T17:$PATH" bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --worktree not-valid --dry-run 2>&1)
+rc=$?
+assert_rc "W2 invalid worktree branch exits 1" 1 "$rc"
+assert_contains "W2 explains type/slug requirement" "must be type/slug" "$out"
+
+# W3: --cwd and --worktree together → rc 1 (the worktree IS the cwd).
+out=$(PATH="$SCHED_STUB_T17:$PATH" bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --worktree feat/wt-test --cwd "$WORK_REPO" --dry-run 2>&1)
+rc=$?
+assert_rc "W3 --cwd + --worktree exits 1" 1 "$rc"
+assert_contains "W3 says mutually exclusive" "mutually exclusive" "$out"
+
+# W4: resume_worktree frontmatter used when the flag is omitted.
+HO_WT="$HANDOVER_DIR/handover-wt-fm.md"
+{ printf -- '---\n'; printf 'resume_worktree: fix/wt-fm\n'; printf -- '---\n'; printf '# fm worktree\n'; } > "$HO_WT"
+out=$(PATH="$SCHED_STUB_T17:$PATH" bash "$ARM" --time "$FUTURE_TIME" --handover "$HO_WT" --dry-run 2>&1)
+rc=$?
+assert_rc "W4 resume_worktree frontmatter exits 0" 0 "$rc"
+assert_contains "W4 frontmatter worktree used" ".claude/worktrees/fix+wt-fm" "$out"
+
+# W5: non-dry-run — a stub worktree cmd creates the dir; the arm resumes there
+# and pre-trusts the worktree path in the (shielded) config.
+WT_STUB="$TMP/wt-stub.sh"
+# The literal $ARM_WORKTREE_PATH is intentional — the stub expands it at runtime.
+# shellcheck disable=SC2016
+printf '#!/usr/bin/env bash\nmkdir -p "$ARM_WORKTREE_PATH"\n' > "$WT_STUB"
+chmod +x "$WT_STUB"
+HO=$(make_handover "")
+out=$(PATH="$SCHED_STUB_T17:$PATH" ARM_WORKTREE_CMD="bash $WT_STUB" bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --worktree feat/wt-real 2>&1)
+rc=$?
+assert_rc "W5 non-dry worktree arm exits 0" 0 "$rc"
+# The non-dry arm doesn't echo RESUME_CWD (that's dry-run only); proof the
+# worktree path was used as cwd is that it got pre-trusted in the config below.
+if command -v node >/dev/null 2>&1; then
+    trust=$(WT_F="$WORKSPACE_TRUST_CONFIG" node -e 'try{const j=JSON.parse(require("fs").readFileSync(process.env.WT_F,"utf8"));const hit=Object.entries(j.projects||{}).some(([k,v])=>k.includes("feat+wt-real")&&v&&v.hasTrustDialogAccepted===true);process.stdout.write(String(hit))}catch(e){process.stdout.write("ERR")}')
+    assert_contains "W5 worktree pre-trusted in config" "true" "$trust"
+fi
+# Tidy the empty stub-created worktree dir (gitignored, but don't leave litter).
+rm -rf "$(cd "$(dirname "$ARM")/../.." && pwd)/.claude/worktrees/feat+wt-real" 2>/dev/null || true
+
+# Stub worktree commands (real scripts — an inline `bash -c '...'` would be
+# word-split by the seam's intentional cmd+args split, mangling the quotes).
+WT_FAIL_STUB="$TMP/wt-fail-stub.sh"; printf '#!/usr/bin/env bash\nexit 1\n' > "$WT_FAIL_STUB"; chmod +x "$WT_FAIL_STUB"
+WT_NODIR_STUB="$TMP/wt-nodir-stub.sh"; printf '#!/usr/bin/env bash\nexit 0\n' > "$WT_NODIR_STUB"; chmod +x "$WT_NODIR_STUB"
+
+# W6: worktree cmd fails → arm aborts loudly with rc 4 (no silent half-arm).
+out=$(PATH="$SCHED_STUB_T17:$PATH" ARM_WORKTREE_CMD="bash $WT_FAIL_STUB" bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --worktree feat/wt-fail 2>&1)
+rc=$?
+assert_rc "W6 worktree create failure exits 4" 4 "$rc"
+assert_contains "W6 reports create failure" "worktree create failed" "$out"
+
+# W7: worktree cmd returns 0 but creates no dir → post-create check exits 4.
+out=$(PATH="$SCHED_STUB_T17:$PATH" ARM_WORKTREE_CMD="bash $WT_NODIR_STUB" bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --worktree feat/wt-nodir 2>&1)
+rc=$?
+assert_rc "W7 create-but-no-dir exits 4" 4 "$rc"
+assert_contains "W7 reports missing worktree dir" "expected worktree dir not found" "$out"
+
+# W8: existing worktree dir → reused (create cmd NOT invoked), arm still succeeds.
+# The stub would exit 1 IF called; rc 0 proves the reuse branch skipped it.
+W8_DIR="$(cd "$(dirname "$ARM")/../.." && pwd)/.claude/worktrees/feat+wt-reuse"
+mkdir -p "$W8_DIR"
+out=$(PATH="$SCHED_STUB_T17:$PATH" ARM_WORKTREE_CMD="bash $WT_FAIL_STUB" bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --worktree feat/wt-reuse 2>&1)
+rc=$?
+assert_rc "W8 reuse existing worktree exits 0 (cmd not called)" 0 "$rc"
+assert_contains "W8 announces reuse" "reusing existing worktree" "$out"
+rm -rf "$W8_DIR"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/lib/ensure-workspace-trust.sh
+++ b/scripts/lib/ensure-workspace-trust.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# ensure-workspace-trust.sh <dir>  (HIMMEL-386)
+#
+# Pre-trust <dir> in Claude Code's config (~/.claude.json) so an autonomous
+# `claude` launch with that dir as cwd does NOT stall on the interactive
+# workspace-trust prompt ("Is this a project you created or one you trust?").
+# Autonomous arms (handover resume via arm-resume.sh, clip-pipeline cadence
+# via pipeline-cadence.sh) have no human to answer it and their stdin is
+# absent or /dev/null, so an untrusted cwd silently wastes the whole run.
+#
+# Sets projects[<key>].hasTrustDialogAccepted = true via an atomic
+# read-modify-write. <key> matches how Claude stores it (observed as of
+# HIMMEL-386): on Windows the `cygpath -m` mixed form (C:/Users/...),
+# elsewhere the absolute path from `cd "$dir" && pwd`.
+#
+# Config path: $WORKSPACE_TRUST_CONFIG, else $HOME/.claude.json.
+#
+# Exit codes:
+#   0  flag is set (already-true is a no-op that also exits 0)
+#   2  bad usage / dir does not exist / node missing
+#   3  config exists but is unreadable, not parseable JSON, or not a JSON
+#      object — REFUSES to overwrite (never clobber Claude's state on a
+#      transient read or parse error)
+#
+# Callers MUST treat a non-zero exit as NON-FATAL (warn, then continue): a
+# trust pre-seed problem must never block an arm. The exit codes exist so
+# the test harness can assert behaviour, not so callers can abort on them.
+set -uo pipefail
+
+dir="${1:-}"
+if [ -z "$dir" ]; then
+    echo "ensure-workspace-trust: usage: ensure-workspace-trust.sh <dir>" >&2
+    exit 2
+fi
+if [ ! -d "$dir" ]; then
+    echo "ensure-workspace-trust: not a directory: $dir" >&2
+    exit 2
+fi
+if ! command -v node >/dev/null 2>&1; then
+    echo "ensure-workspace-trust: node not on PATH" >&2
+    exit 2
+fi
+
+# Absolute path, then normalize to the key form Claude persists.
+abs=$(cd "$dir" && pwd)
+if [ -z "$abs" ]; then
+    # cd succeeded the -d check but pwd came back empty (dir vanished mid-run);
+    # never write an empty trust key.
+    echo "ensure-workspace-trust: could not resolve absolute path for: $dir" >&2
+    exit 2
+fi
+if command -v cygpath >/dev/null 2>&1; then
+    key=$(cygpath -m "$abs")   # /c/Users/... -> C:/Users/...
+else
+    key="$abs"
+fi
+
+config="${WORKSPACE_TRUST_CONFIG:-$HOME/.claude.json}"
+
+# node does the read-modify-write: tolerant of a missing file (fresh create),
+# strict on a present-but-unparseable file (refuse to clobber), atomic via
+# write-to-temp + rename. Key/config passed by env to avoid all shell quoting.
+WT_KEY="$key" WT_CONFIG="$config" node -e '
+const fs = require("fs");
+const p = process.env.WT_CONFIG, key = process.env.WT_KEY;
+let raw = null;
+try {
+    raw = fs.readFileSync(p, "utf8");
+} catch (e) {
+    if (e.code !== "ENOENT") {
+        console.error("ensure-workspace-trust: cannot read " + p + ": " + e.message);
+        process.exit(3);
+    }
+}
+let j = {};
+if (raw !== null) {
+    try {
+        j = JSON.parse(raw);
+    } catch (e) {
+        console.error("ensure-workspace-trust: " + p + " is not valid JSON - refusing to overwrite");
+        process.exit(3);
+    }
+    if (typeof j !== "object" || j === null || Array.isArray(j)) {
+        console.error("ensure-workspace-trust: " + p + " is not a JSON object - refusing to overwrite");
+        process.exit(3);
+    }
+}
+if (!j.projects || typeof j.projects !== "object" || Array.isArray(j.projects)) j.projects = {};
+if (!j.projects[key] || typeof j.projects[key] !== "object" || Array.isArray(j.projects[key])) j.projects[key] = {};
+if (j.projects[key].hasTrustDialogAccepted === true) process.exit(0);
+j.projects[key].hasTrustDialogAccepted = true;
+const tmp = p + ".tmp-trust-" + process.pid;
+fs.writeFileSync(tmp, JSON.stringify(j, null, 2));
+fs.renameSync(tmp, p);
+'

--- a/scripts/lib/test-ensure-workspace-trust.sh
+++ b/scripts/lib/test-ensure-workspace-trust.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Tests for scripts/lib/ensure-workspace-trust.sh (HIMMEL-386).
+# The helper is invoked as a subprocess (it shells out to node), so each
+# case runs `bash "$HELPER" <dir>` against a throwaway $WORKSPACE_TRUST_CONFIG.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HELPER="$HERE/ensure-workspace-trust.sh"
+
+FAILED=0
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "PASS $label"
+    else
+        echo "FAIL $label — expected '$expected', got '$actual'"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+command -v node >/dev/null 2>&1 || { echo "SKIP all — node not on PATH"; exit 0; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Mirror the helper's key-normalization so assertions compare apples to apples.
+norm_key() {
+    local d abs
+    d="$1"
+    abs=$(cd "$d" && pwd)
+    if command -v cygpath >/dev/null 2>&1; then cygpath -m "$abs"; else printf '%s' "$abs"; fi
+}
+
+# Read projects[<key>].hasTrustDialogAccepted back out of a config file.
+read_flag() {
+    F="$1" K="$2" node -e '
+const fs=require("fs");
+const j=JSON.parse(fs.readFileSync(process.env.F,"utf8"));
+const v=j.projects && j.projects[process.env.K] && j.projects[process.env.K].hasTrustDialogAccepted;
+process.stdout.write(String(v));
+'
+}
+
+WORKDIR="$TMP/work"; mkdir -p "$WORKDIR"
+KEY=$(norm_key "$WORKDIR")
+
+# T1: config file missing → created, key trusted, rc 0.
+CFG="$TMP/missing.json"
+WORKSPACE_TRUST_CONFIG="$CFG" bash "$HELPER" "$WORKDIR"; rc=$?
+assert_eq "T1 missing-config rc" "0" "$rc"
+assert_eq "T1 missing-config sets flag" "true" "$(read_flag "$CFG" "$KEY")"
+
+# T2: existing config with OTHER projects → key added, others preserved.
+CFG="$TMP/other.json"
+printf '%s\n' '{"numStartups":7,"projects":{"C:/other/repo":{"hasTrustDialogAccepted":true,"foo":1}}}' > "$CFG"
+WORKSPACE_TRUST_CONFIG="$CFG" bash "$HELPER" "$WORKDIR"; rc=$?
+assert_eq "T2 preserve-others rc" "0" "$rc"
+assert_eq "T2 new key set" "true" "$(read_flag "$CFG" "$KEY")"
+assert_eq "T2 sibling project kept" "true" "$(read_flag "$CFG" "C:/other/repo")"
+assert_eq "T2 top-level key kept" "7" "$(F="$CFG" node -e 'process.stdout.write(String(JSON.parse(require("fs").readFileSync(process.env.F,"utf8")).numStartups))')"
+
+# T3: already-true → no-op, rc 0, content byte-identical.
+CFG="$TMP/already.json"
+WT_K="$KEY" node -e 'const fs=require("fs");fs.writeFileSync(process.env.F,JSON.stringify({projects:{[process.env.WT_K]:{hasTrustDialogAccepted:true}}},null,2))' F="$CFG" >/dev/null 2>&1 || \
+  F="$CFG" WT_K="$KEY" node -e 'const fs=require("fs");fs.writeFileSync(process.env.F,JSON.stringify({projects:{[process.env.WT_K]:{hasTrustDialogAccepted:true}}},null,2))'
+before=$(cat "$CFG")
+WORKSPACE_TRUST_CONFIG="$CFG" bash "$HELPER" "$WORKDIR"; rc=$?
+after=$(cat "$CFG")
+assert_eq "T3 already-true rc" "0" "$rc"
+assert_eq "T3 already-true no rewrite" "$before" "$after"
+
+# T4: project entry exists but flag absent → flag set, sibling field preserved.
+CFG="$TMP/partial.json"
+F="$CFG" WT_K="$KEY" node -e 'const fs=require("fs");fs.writeFileSync(process.env.F,JSON.stringify({projects:{[process.env.WT_K]:{exampleFilesGenerated:true}}}))'
+WORKSPACE_TRUST_CONFIG="$CFG" bash "$HELPER" "$WORKDIR"; rc=$?
+assert_eq "T4 partial rc" "0" "$rc"
+assert_eq "T4 flag set" "true" "$(read_flag "$CFG" "$KEY")"
+assert_eq "T4 sibling field kept" "true" "$(F="$CFG" K="$KEY" node -e 'process.stdout.write(String(JSON.parse(require("fs").readFileSync(process.env.F,"utf8")).projects[process.env.K].exampleFilesGenerated))')"
+
+# T5: config is invalid JSON → rc 3, file NOT overwritten (clobber guard).
+CFG="$TMP/broken.json"
+printf '%s' '{ this is not json' > "$CFG"
+before=$(cat "$CFG")
+WORKSPACE_TRUST_CONFIG="$CFG" bash "$HELPER" "$WORKDIR" 2>/dev/null; rc=$?
+after=$(cat "$CFG")
+assert_eq "T5 invalid-json rc" "3" "$rc"
+assert_eq "T5 invalid-json not overwritten" "$before" "$after"
+
+# T6: dir does not exist → rc 2.
+WORKSPACE_TRUST_CONFIG="$TMP/x.json" bash "$HELPER" "$TMP/nope" 2>/dev/null; rc=$?
+assert_eq "T6 missing-dir rc" "2" "$rc"
+
+# T7: no argument → rc 2.
+WORKSPACE_TRUST_CONFIG="$TMP/x.json" bash "$HELPER" 2>/dev/null; rc=$?
+assert_eq "T7 no-arg rc" "2" "$rc"
+
+echo
+if [ "$FAILED" -eq 0 ]; then echo "All ensure-workspace-trust tests passed."; else echo "$FAILED test(s) failed."; exit 1; fi

--- a/scripts/luna/pipeline-cadence.sh
+++ b/scripts/luna/pipeline-cadence.sh
@@ -7,19 +7,25 @@
 # ingests" — but nothing was scheduled; every run was operator-
 # remembered. The pipeline is idempotent at every stage by design
 # (markers: harvested_at, processed, synthesis dedup window, _done/
-# move) — exactly the cron-safe shape. This script registers the two
+# move) — exactly the cron-safe shape. This script registers the three
 # recurring jobs with the OS scheduler, following the
 # scripts/handover/arm-resume.sh precedent (HIMMEL-122):
 #
+#   HIMMEL-Pipeline-Harvest     daily   (default 02:00)            HIMMEL-357
+#       claude "/harvest-clips … then /triage-clips …" < NUL
 #   HIMMEL-Pipeline-Synthesize  weekly  (default Sun 03:00)
 #       claude "/synthesize-clips … then /archive-clips …" < NUL
 #   HIMMEL-Pipeline-Health      monthly (default 1st 04:00)
 #       claude "/obsidian-health …" < NUL
 #
-# Defaults are the operator decision pinned on HIMMEL-255 (2026-06-10):
-# synthesize weekly Sunday 03:00 with /archive-clips chained after in
-# the SAME session; health monthly on the 1st at 04:00; machine assumed
-# awake. Both overridable via flags.
+# Defaults are the operator decision pinned on HIMMEL-255 (2026-06-10),
+# plus the daily harvest+triage leg added on HIMMEL-357 (2026-06-17):
+# harvest+triage daily at 02:00 (cheap, idempotent, keeps the Clippings/
+# inbox flowing); synthesize weekly Sunday 03:00 with /archive-clips
+# chained after in the SAME session (synthesis needs a batch to find
+# cross-clip themes, so it runs weekly not daily; archive only graduates
+# clips synthesis has wikilinked, so it follows synth); health monthly
+# on the 1st at 04:00; machine assumed awake. All overridable via flags.
 #
 # The armed command is interactive-claude shaped — `claude "<prompt>"`
 # with stdin redirected from NUL (the bounded-run primitive: the session
@@ -41,9 +47,9 @@
 # arm-resume's crontab entry).
 #
 # Usage:
-#   bash scripts/luna/pipeline-cadence.sh arm [--synth-day DAY]
-#       [--synth-time HH:MM] [--health-day N] [--health-time HH:MM]
-#       [--vault PATH] [--force] [--dry-run]
+#   bash scripts/luna/pipeline-cadence.sh arm [--harvest-time HH:MM]
+#       [--synth-day DAY] [--synth-time HH:MM] [--health-day N]
+#       [--health-time HH:MM] [--vault PATH] [--force] [--dry-run]
 #   bash scripts/luna/pipeline-cadence.sh status
 #   bash scripts/luna/pipeline-cadence.sh disarm
 #
@@ -62,6 +68,7 @@
 set -euo pipefail
 
 TASK_PREFIX="HIMMEL-Pipeline-"
+TASK_HARVEST="${TASK_PREFIX}Harvest"
 TASK_SYNTH="${TASK_PREFIX}Synthesize"
 TASK_HEALTH="${TASK_PREFIX}Health"
 SCHTASKS_BIN="${PIPELINE_SCHTASKS:-schtasks}"
@@ -72,7 +79,9 @@ CRONTAB_BIN="${PIPELINE_CRONTAB:-crontab}"
 # the cadence.
 BAT_DIR="${PIPELINE_BAT_DIR:-$HOME/.claude/pipeline-cadence}"
 
-# Operator-decision defaults (HIMMEL-255 pinned comment, 2026-06-10).
+# Operator-decision defaults (HIMMEL-255 pinned comment, 2026-06-10;
+# harvest leg added on HIMMEL-357, 2026-06-17).
+HARVEST_TIME="02:00"
 SYNTH_DAY="SUN"
 SYNTH_TIME="03:00"
 HEALTH_DAY="1"
@@ -83,6 +92,7 @@ DRY_RUN=0
 
 # Prompts are ASCII-only on purpose: the .bat is parsed by cmd.exe under
 # the OEM codepage, where UTF-8 punctuation mojibakes into the prompt.
+HARVEST_PROMPT="Run /harvest-clips to completion, then run /triage-clips. This is the scheduled daily pipeline cadence run (HIMMEL-357) - fully autonomous, no user prompts; report results and exit."
 SYNTH_PROMPT="Run /synthesize-clips to completion, then run /archive-clips. This is the scheduled weekly pipeline cadence run (HIMMEL-255) - fully autonomous, no user prompts; report results and exit."
 HEALTH_PROMPT="Run /obsidian-health to completion. This is the scheduled monthly pipeline cadence run (HIMMEL-255) - fully autonomous, no user prompts; report results and exit."
 
@@ -91,17 +101,20 @@ usage() {
 Usage: pipeline-cadence.sh <arm|status|disarm> [flags]
 
 Arm the OS scheduler with the recurring clip-pipeline cadence
-(HIMMEL-255): weekly /synthesize-clips (+ /archive-clips chained after
-in the same session) and monthly /obsidian-health, run against the luna
-vault as interactive bounded claude sessions.
+(HIMMEL-255/357): daily /harvest-clips (+ /triage-clips chained after in
+the same session), weekly /synthesize-clips (+ /archive-clips chained
+after) and monthly /obsidian-health, run against the luna vault as
+interactive bounded claude sessions.
 
 Subcommands:
-  arm      Register both recurring tasks. Dedup-guarded: refuses (rc=3)
-           if any HIMMEL-Pipeline-* task already exists; --force replaces.
+  arm      Register all three recurring tasks. Dedup-guarded: refuses
+           (rc=3) if any HIMMEL-Pipeline-* task already exists; --force
+           replaces.
   status   Show which cadence tasks are armed (+ next run time).
-  disarm   Remove both tasks (idempotent; rc=0 if nothing was armed).
+  disarm   Remove all tasks (idempotent; rc=0 if nothing was armed).
 
 Flags (arm only, except --dry-run):
+  --harvest-time <HH:MM> Daily harvest+triage time, 24h local (default 02:00)
   --synth-day <DAY>      Weekly synthesize day: MON..SUN   (default SUN)
   --synth-time <HH:MM>   Weekly synthesize time, 24h local (default 03:00)
   --health-day <N>       Monthly health day-of-month, 1-28 (default 1;
@@ -134,6 +147,8 @@ esac
 
 while [ $# -gt 0 ]; do
     case "$1" in
+        --harvest-time)   HARVEST_TIME="${2:-}"; shift 2 ;;
+        --harvest-time=*) HARVEST_TIME="${1#--harvest-time=}"; shift ;;
         --synth-day)     SYNTH_DAY="${2:-}"; shift 2 ;;
         --synth-day=*)   SYNTH_DAY="${1#--synth-day=}"; shift ;;
         --synth-time)    SYNTH_TIME="${2:-}"; shift 2 ;;
@@ -364,6 +379,8 @@ cmd_status() {
     # scripted callers read a broken query tool as "all fine").
     local status_rc=0
     echo "pipeline-cadence status:"
+    status_one "$TASK_HARVEST" || status_rc=2
+    status_log "$BAT_DIR/pipeline-harvest.log"
     status_one "$TASK_SYNTH" || status_rc=2
     status_log "$BAT_DIR/pipeline-synthesize.log"
     status_one "$TASK_HEALTH" || status_rc=2
@@ -373,7 +390,7 @@ cmd_status() {
 
 cmd_disarm() {
     local name found=0 qrc
-    for name in "$TASK_SYNTH" "$TASK_HEALTH"; do
+    for name in "$TASK_HARVEST" "$TASK_SYNTH" "$TASK_HEALTH"; do
         qrc=0
         query_one "$name" || qrc=$?
         case "$qrc" in
@@ -398,7 +415,7 @@ cmd_disarm() {
     # every delete succeeded (delete_task exits 4 otherwise) — safe to
     # remove the runners now.
     if [ "$DRY_RUN" -eq 0 ]; then
-        rm -f "$BAT_DIR/pipeline-synthesize.bat" "$BAT_DIR/pipeline-health.bat"
+        rm -f "$BAT_DIR/pipeline-harvest.bat" "$BAT_DIR/pipeline-synthesize.bat" "$BAT_DIR/pipeline-health.bat"
     fi
     if [ "$found" -eq 0 ]; then
         echo "pipeline-cadence: nothing armed — disarm is a no-op"
@@ -429,10 +446,130 @@ emit_bat() {
     printf '"%s" "%s" < NUL >> "%s" 2>&1\r\n' "$claude_win" "$prompt_esc" "$log_win_esc"
 }
 
+# --- schtasks task XML (HIMMEL-362) ---------------------------------------
+#
+# schtasks /create has no flag for StartWhenAvailable ("run the task as
+# soon as possible after a missed scheduled start"), so a daily 02:00 run
+# is SILENTLY SKIPPED if the machine was off/asleep at 02:00. The only way
+# to set it from the CLI is to build the task from an XML definition and
+# create via `schtasks /create /xml`. We keep the existing per-task .bat
+# runner as the task's Exec Command and wrap it in XML that carries
+# StartWhenAvailable=true. Catch-up only (operator decision 2026-06-17):
+# we do NOT add a wake timer, and DisallowStartIfOnBatteries keeps its
+# schema default (true) so a battery laptop catches up when next on AC
+# rather than draining on battery.
+
+# Escape the three XML-significant characters for text interpolated into an
+# element body (the Exec <Command> path — a BAT_DIR path may legally
+# contain `&`). `&` first so the `&` in the &lt;/&gt; entities isn't
+# re-escaped. Implemented with sed, NOT bash `${s//&/&amp;}`: bash 5.1+
+# treats a literal `&` in a substitution REPLACEMENT as the matched text
+# (so `${s//</&lt;}` yields `<lt;`, dropping the ampersand) — a version-
+# dependent trap. In sed, `\&` is an unambiguous literal ampersand on every
+# bash version (incl. the macOS 3.2 baseline).
+xml_escape() {
+    printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
+# SUN..SAT -> the Task Scheduler XML day-element name.
+dow_long() {
+    case "$1" in
+        SUN) echo Sunday ;;    MON) echo Monday ;;  TUE) echo Tuesday ;;
+        WED) echo Wednesday ;; THU) echo Thursday ;; FRI) echo Friday ;;
+        SAT) echo Saturday ;;
+    esac
+}
+
+# Per-cadence <CalendarTrigger> schedule fragments. SYNTH_DAY / HEALTH_DAY
+# are already validated (MON..SUN / 1-28) by validate_arm_inputs.
+schedule_daily_xml() {
+    printf '      <ScheduleByDay>\n        <DaysInterval>1</DaysInterval>\n      </ScheduleByDay>'
+}
+schedule_weekly_xml() {
+    printf '      <ScheduleByWeek>\n        <DaysOfWeek>\n          <%s />\n        </DaysOfWeek>\n        <WeeksInterval>1</WeeksInterval>\n      </ScheduleByWeek>' "$(dow_long "$SYNTH_DAY")"
+}
+schedule_monthly_xml() {
+    printf '      <ScheduleByMonth>\n        <DaysOfMonth>\n          <Day>%s</Day>\n        </DaysOfMonth>\n        <Months>\n          <January /><February /><March /><April /><May /><June /><July /><August /><September /><October /><November /><December />\n        </Months>\n      </ScheduleByMonth>' "$HEALTH_DAY"
+}
+
+# Emit one task XML: a CalendarTrigger at the given local time with the
+# supplied schedule fragment, StartWhenAvailable=true, and the .bat runner
+# as the Exec Command. StartBoundary's date is a fixed past sentinel — the
+# schedule fragment (not the date) governs which days fire; the date only
+# marks when the schedule became active.
+#
+# Encoding: the prolog declares UTF-16 (what `schtasks /create /xml`
+# expects) but the bytes we write are plain ASCII — every value in this
+# document is ASCII (fixed tags, an ASCII HH:MM, and the .bat path under
+# ~/.claude/pipeline-cadence). schtasks accepts that combination; declaring
+# `encoding="UTF-8"` instead is REJECTED on Win11 with
+# "(1,40):: unable to switch the encoding" (verified). Keep this ASCII-only
+# — a non-ASCII byte here would need a real UTF-16LE+BOM file.
+emit_task_xml() {
+    local command_raw="$1" start_time="$2" schedule_xml="$3" command
+    command=$(xml_escape "$command_raw")
+    cat <<XML
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>himmel pipeline-cadence (HIMMEL-255/357/362)</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <CalendarTrigger>
+      <StartBoundary>2020-01-01T${start_time}:00</StartBoundary>
+      <Enabled>true</Enabled>
+${schedule_xml}
+    </CalendarTrigger>
+  </Triggers>
+  <Settings>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <Enabled>true</Enabled>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>${command}</Command>
+    </Exec>
+  </Actions>
+</Task>
+XML
+}
+
+# Create one task from an XML definition (so StartWhenAvailable applies).
+# Writes the XML to a temp file, converts the path for schtasks, creates,
+# then removes the temp. stderr -> $5 (shared err_file); returns the
+# schtasks rc so callers keep the existing failure/rollback flow.
+schtasks_create_xml() {
+    local name="$1" bat_win="$2" schedule_xml="$3" start_time="$4" err_file="$5"
+    local xml_file xml_win rc
+    # Self-contained error handling (does not rely on the caller's `if !`
+    # to suspend set -e): a failed mktemp/cygpath returns 1 with the temp
+    # cleaned up; the create's rc is captured under `set +e` so it is
+    # returned (not aborted on) even if called bare. Mirrors list_existing.
+    if ! xml_file=$(mktemp -t pipeline-cadence.xml.XXXXXX 2>"$err_file"); then
+        return 1
+    fi
+    emit_task_xml "$bat_win" "$start_time" "$schedule_xml" > "$xml_file"
+    if ! xml_win=$(cygpath -w "$xml_file" 2>"$err_file"); then
+        rm -f "$xml_file"
+        return 1
+    fi
+    set +e
+    run_schtasks /create /tn "$name" /xml "$xml_win" /f 2>"$err_file"
+    rc=$?
+    set -e
+    rm -f "$xml_file"
+    return "$rc"
+}
+
 # Input validation shared by the schtasks and cron arm paths. Upcases
 # SYNTH_DAY in place.
 validate_arm_inputs() {
     local day_ok=0 d
+    if ! [[ "$HARVEST_TIME" =~ ^([01][0-9]|2[0-3]):[0-5][0-9]$ ]]; then
+        echo "ERR pipeline-cadence: --harvest-time must be HH:MM (24h), got: $HARVEST_TIME" >&2
+        exit 1
+    fi
     SYNTH_DAY=$(printf '%s' "$SYNTH_DAY" | tr '[:lower:]' '[:upper:]')
     for d in MON TUE WED THU FRI SAT SUN; do
         [ "$SYNTH_DAY" = "$d" ] && day_ok=1
@@ -485,6 +622,21 @@ cmd_arm() {
         exit 4
     fi
 
+    # Pre-trust the vault dir (HIMMEL-386) so the fired cadence runs don't stall
+    # on Claude Code's interactive workspace-trust prompt ("Is this a project
+    # you trust?"). An autonomous run has no human to answer it and its stdin is
+    # NUL (cmd.exe's /dev/null — see the runner below), so an untrusted cwd
+    # silently wastes the run. Non-fatal: a pre-seed failure must never block
+    # the arm.
+    local _pc_lib
+    _pc_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)/ensure-workspace-trust.sh"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRY pipeline-cadence: would pre-trust workspace '$VAULT' in ~/.claude.json"
+    else
+        "$_pc_lib" "$VAULT" \
+            || echo "WARN pipeline-cadence: workspace-trust pre-seed failed for '$VAULT' (arm continues; first run may prompt to trust the folder)" >&2
+    fi
+
     # Dedup guard — never double-register the cadence.
     local existing
     existing=$(list_existing)
@@ -513,39 +665,42 @@ cmd_arm() {
         fi
     fi
 
-    local vault_esc synth_esc health_esc
+    local vault_esc harvest_esc synth_esc health_esc
     vault_esc=$(cmd_escape "$vault_win")
+    harvest_esc=$(cmd_escape "$HARVEST_PROMPT")
     synth_esc=$(cmd_escape "$SYNTH_PROMPT")
     health_esc=$(cmd_escape "$HEALTH_PROMPT")
+    local bat_harvest="$BAT_DIR/pipeline-harvest.bat"
     local bat_synth="$BAT_DIR/pipeline-synthesize.bat"
     local bat_health="$BAT_DIR/pipeline-health.bat"
 
     # Fire-time run logs live next to the .bats (cmd-escaped for the
     # `>>` redirect target inside the .bat).
-    local bat_dir_win log_synth_esc log_health_esc
+    local bat_dir_win log_harvest_esc log_synth_esc log_health_esc
     if ! bat_dir_win=$(cygpath -w "$BAT_DIR" 2>&1); then
         echo "ERR pipeline-cadence: cygpath -w failed for bat dir: $bat_dir_win" >&2
         exit 4
     fi
+    log_harvest_esc=$(cmd_escape "$bat_dir_win\\pipeline-harvest.log")
     log_synth_esc=$(cmd_escape "$bat_dir_win\\pipeline-synthesize.log")
     log_health_esc=$(cmd_escape "$bat_dir_win\\pipeline-health.log")
 
-    if [ "$DRY_RUN" -eq 1 ]; then
-        echo "DRY pipeline-cadence: would write $bat_synth:"
-        emit_bat "$vault_esc" "$claude_win" "$synth_esc" "$log_synth_esc" | sed 's/^/    /'
-        echo "DRY pipeline-cadence: would write $bat_health:"
-        emit_bat "$vault_esc" "$claude_win" "$health_esc" "$log_health_esc" | sed 's/^/    /'
-        echo "DRY pipeline-cadence: would schtasks /create /tn $TASK_SYNTH /sc WEEKLY /d $SYNTH_DAY /st $SYNTH_TIME /f"
-        echo "DRY pipeline-cadence: would schtasks /create /tn $TASK_HEALTH /sc MONTHLY /d $HEALTH_DAY /st $HEALTH_TIME /f"
-        echo "pipeline-cadence: dry-run complete (no changes made)"
-        return 0
+    # Per-cadence schedule fragments for the task XML (HIMMEL-362). Built
+    # once and reused by the dry-run preview and the real create below.
+    local sched_harvest sched_synth sched_health
+    sched_harvest=$(schedule_daily_xml)
+    sched_synth=$(schedule_weekly_xml)
+    sched_health=$(schedule_monthly_xml)
+
+    # The .bat runner is the task's Exec Command. cygpath -w is a pure
+    # string transform (the .bat need not exist yet), so resolve the win
+    # paths before the dry-run preview too — the XML preview must show the
+    # real Exec Command.
+    local bat_harvest_win bat_synth_win bat_health_win
+    if ! bat_harvest_win=$(cygpath -w "$bat_harvest" 2>&1); then
+        echo "ERR pipeline-cadence: cygpath -w failed: $bat_harvest_win" >&2
+        exit 4
     fi
-
-    mkdir -p "$BAT_DIR"
-    emit_bat "$vault_esc" "$claude_win" "$synth_esc"  "$log_synth_esc"  > "$bat_synth"
-    emit_bat "$vault_esc" "$claude_win" "$health_esc" "$log_health_esc" > "$bat_health"
-
-    local bat_synth_win bat_health_win
     if ! bat_synth_win=$(cygpath -w "$bat_synth" 2>&1); then
         echo "ERR pipeline-cadence: cygpath -w failed: $bat_synth_win" >&2
         exit 4
@@ -555,24 +710,59 @@ cmd_arm() {
         exit 4
     fi
 
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRY pipeline-cadence: would write $bat_harvest:"
+        emit_bat "$vault_esc" "$claude_win" "$harvest_esc" "$log_harvest_esc" | sed 's/^/    /'
+        echo "DRY pipeline-cadence: would write $bat_synth:"
+        emit_bat "$vault_esc" "$claude_win" "$synth_esc" "$log_synth_esc" | sed 's/^/    /'
+        echo "DRY pipeline-cadence: would write $bat_health:"
+        emit_bat "$vault_esc" "$claude_win" "$health_esc" "$log_health_esc" | sed 's/^/    /'
+        echo "DRY pipeline-cadence: would schtasks /create /tn $TASK_HARVEST /xml <daily $HARVEST_TIME, StartWhenAvailable=true> /f"
+        emit_task_xml "$bat_harvest_win" "$HARVEST_TIME" "$sched_harvest" | sed 's/^/    /'
+        echo "DRY pipeline-cadence: would schtasks /create /tn $TASK_SYNTH /xml <weekly $SYNTH_DAY $SYNTH_TIME, StartWhenAvailable=true> /f"
+        emit_task_xml "$bat_synth_win" "$SYNTH_TIME" "$sched_synth" | sed 's/^/    /'
+        echo "DRY pipeline-cadence: would schtasks /create /tn $TASK_HEALTH /xml <monthly day $HEALTH_DAY $HEALTH_TIME, StartWhenAvailable=true> /f"
+        emit_task_xml "$bat_health_win" "$HEALTH_TIME" "$sched_health" | sed 's/^/    /'
+        echo "pipeline-cadence: dry-run complete (no changes made)"
+        return 0
+    fi
+
+    mkdir -p "$BAT_DIR"
+    emit_bat "$vault_esc" "$claude_win" "$harvest_esc" "$log_harvest_esc" > "$bat_harvest"
+    emit_bat "$vault_esc" "$claude_win" "$synth_esc"  "$log_synth_esc"  > "$bat_synth"
+    emit_bat "$vault_esc" "$claude_win" "$health_esc" "$log_health_esc" > "$bat_health"
+
     local err_file
     err_file=$(mktemp -t pipeline-cadence.err.XXXXXX)
-    if ! run_schtasks /create /tn "$TASK_SYNTH" /tr "$bat_synth_win" \
-            /sc WEEKLY /d "$SYNTH_DAY" /st "$SYNTH_TIME" /f 2>"$err_file"; then
-        echo "ERR pipeline-cadence: schtasks /create $TASK_SYNTH failed:" >&2
+    if ! schtasks_create_xml "$TASK_HARVEST" "$bat_harvest_win" "$sched_harvest" "$HARVEST_TIME" "$err_file"; then
+        echo "ERR pipeline-cadence: schtasks /create $TASK_HARVEST failed:" >&2
         cat "$err_file" >&2
         rm -f "$err_file"
         exit 4
     fi
     # Surface success-path /create warnings instead of deleting them unread.
     if [ -s "$err_file" ]; then cat "$err_file" >&2; fi
-    if ! run_schtasks /create /tn "$TASK_HEALTH" /tr "$bat_health_win" \
-            /sc MONTHLY /d "$HEALTH_DAY" /st "$HEALTH_TIME" /f 2>"$err_file"; then
+    if ! schtasks_create_xml "$TASK_SYNTH" "$bat_synth_win" "$sched_synth" "$SYNTH_TIME" "$err_file"; then
+        echo "ERR pipeline-cadence: schtasks /create $TASK_SYNTH failed:" >&2
+        cat "$err_file" >&2
+        rm -f "$err_file"
+        # Don't leave a half-armed cadence behind: roll back the daily
+        # task that DID register so status/dedup stay truthful.
+        if ! run_schtasks /delete /tn "$TASK_HARVEST" /f >/dev/null 2>&1; then
+            echo "WARN: rollback of $TASK_HARVEST failed — run disarm" >&2
+        fi
+        exit 4
+    fi
+    if [ -s "$err_file" ]; then cat "$err_file" >&2; fi
+    if ! schtasks_create_xml "$TASK_HEALTH" "$bat_health_win" "$sched_health" "$HEALTH_TIME" "$err_file"; then
         echo "ERR pipeline-cadence: schtasks /create $TASK_HEALTH failed:" >&2
         cat "$err_file" >&2
         rm -f "$err_file"
-        # Don't leave a half-armed cadence behind: roll back the weekly
-        # task that DID register so status/dedup stay truthful.
+        # Roll back the daily + weekly tasks that DID register so
+        # status/dedup stay truthful.
+        if ! run_schtasks /delete /tn "$TASK_HARVEST" /f >/dev/null 2>&1; then
+            echo "WARN: rollback of $TASK_HARVEST failed — run disarm" >&2
+        fi
         if ! run_schtasks /delete /tn "$TASK_SYNTH" /f >/dev/null 2>&1; then
             echo "WARN: rollback of $TASK_SYNTH failed — run disarm" >&2
         fi
@@ -584,14 +774,17 @@ cmd_arm() {
     cat <<EOF
 
 ================================================================
-  PIPELINE CADENCE ARMED (HIMMEL-255)
+  PIPELINE CADENCE ARMED (HIMMEL-255 / HIMMEL-357)
+  $TASK_HARVEST     daily   $HARVEST_TIME       -> /harvest-clips + /triage-clips
   $TASK_SYNTH  weekly  $SYNTH_DAY $SYNTH_TIME  -> /synthesize-clips + /archive-clips
   $TASK_HEALTH      monthly day $HEALTH_DAY $HEALTH_TIME -> /obsidian-health
   Vault: $vault_win
   Runner .bats: $BAT_DIR
 
   Sessions launch as bounded interactive claude runs (stdin from NUL)
-  in the vault directory. Disarm anytime with:
+  in the vault directory. StartWhenAvailable=true (HIMMEL-362): a run
+  missed because the PC was off/asleep fires when the PC is next on.
+  Disarm anytime with:
       bash scripts/luna/pipeline-cadence.sh disarm
 ================================================================
 EOF
@@ -605,6 +798,7 @@ EOF
 # state to roll back. Runner .sh files mirror the .bat runners: log
 # rotation, fire stamp, cd-into-vault, bounded interactive claude run.
 
+CRON_RUNNER_HARVEST="$BAT_DIR/pipeline-harvest.sh"
 CRON_RUNNER_SYNTH="$BAT_DIR/pipeline-synthesize.sh"
 CRON_RUNNER_HEALTH="$BAT_DIR/pipeline-health.sh"
 
@@ -725,8 +919,9 @@ cron_status() {
     cron_read
     echo "pipeline-cadence status:"
     local name log entry sched
-    for name in "$TASK_SYNTH" "$TASK_HEALTH"; do
+    for name in "$TASK_HARVEST" "$TASK_SYNTH" "$TASK_HEALTH"; do
         case "$name" in
+            "$TASK_HARVEST") log="$BAT_DIR/pipeline-harvest.log" ;;
             "$TASK_SYNTH")  log="$BAT_DIR/pipeline-synthesize.log" ;;
             *)              log="$BAT_DIR/pipeline-health.log" ;;
         esac
@@ -749,7 +944,7 @@ cron_disarm() {
         # Trusted-empty read (cron_read exits 2 otherwise) — safe to
         # sweep the runners like the schtasks path does.
         if [ "$DRY_RUN" -eq 0 ]; then
-            rm -f "$CRON_RUNNER_SYNTH" "$CRON_RUNNER_HEALTH"
+            rm -f "$CRON_RUNNER_HARVEST" "$CRON_RUNNER_SYNTH" "$CRON_RUNNER_HEALTH"
         fi
         echo "pipeline-cadence: nothing armed — disarm is a no-op"
         return 0
@@ -770,7 +965,7 @@ cron_disarm() {
     # removed — a failed install (exit 4) leaves the entries live and
     # they must keep pointing at existing runner files.
     cron_install "$newtab" || exit 4
-    rm -f "$CRON_RUNNER_SYNTH" "$CRON_RUNNER_HEALTH"
+    rm -f "$CRON_RUNNER_HARVEST" "$CRON_RUNNER_SYNTH" "$CRON_RUNNER_HEALTH"
     echo "pipeline-cadence: cadence disarmed"
 }
 
@@ -789,6 +984,19 @@ cron_arm() {
     node_dir=""
     if node_bin=$(command -v node 2>/dev/null); then
         node_dir=$(dirname "$node_bin")
+    fi
+
+    # Pre-trust the vault dir (HIMMEL-386) — same rationale as cmd_arm: a
+    # cron-fired claude run (stdin /dev/null) has no human to answer Claude
+    # Code's interactive workspace-trust prompt, so an untrusted cwd wastes
+    # the run. Non-fatal: a pre-seed failure must never block the arm.
+    local _pc_lib
+    _pc_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)/ensure-workspace-trust.sh"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRY pipeline-cadence: would pre-trust workspace '$VAULT' in ~/.claude.json"
+    else
+        "$_pc_lib" "$VAULT" \
+            || echo "WARN pipeline-cadence: workspace-trust pre-seed failed for '$VAULT' (arm continues; first run may prompt to trust the folder)" >&2
     fi
 
     # Dedup guard — never double-register the cadence. The actual
@@ -820,29 +1028,36 @@ cron_arm() {
         fi
     fi
 
-    local q_vault q_claude q_node_dir q_synth_prompt q_health_prompt q_log_synth q_log_health
+    local q_vault q_claude q_node_dir q_harvest_prompt q_synth_prompt q_health_prompt q_log_harvest q_log_synth q_log_health
     q_vault=$(printf '%q' "$VAULT")
     q_claude=$(printf '%q' "$claude_bin")
     q_node_dir=$([ -n "$node_dir" ] && printf '%q' "$node_dir" || printf '')
+    q_harvest_prompt=$(printf '%q' "$HARVEST_PROMPT")
     q_synth_prompt=$(printf '%q' "$SYNTH_PROMPT")
     q_health_prompt=$(printf '%q' "$HEALTH_PROMPT")
+    q_log_harvest=$(printf '%q' "$BAT_DIR/pipeline-harvest.log")
     q_log_synth=$(printf '%q' "$BAT_DIR/pipeline-synthesize.log")
     q_log_health=$(printf '%q' "$BAT_DIR/pipeline-health.log")
 
-    local dow synth_hh synth_mm health_hh health_mm
+    local dow harvest_hh harvest_mm synth_hh synth_mm health_hh health_mm
     dow=$(dow_num "$SYNTH_DAY")
+    harvest_hh="${HARVEST_TIME%:*}"; harvest_mm="${HARVEST_TIME#*:}"
     synth_hh="${SYNTH_TIME%:*}"; synth_mm="${SYNTH_TIME#*:}"
     health_hh="${HEALTH_TIME%:*}"; health_mm="${HEALTH_TIME#*:}"
-    local entry_synth entry_health
+    local entry_harvest entry_synth entry_health
+    entry_harvest="$harvest_mm $harvest_hh * * * $(cron_escape "$CRON_RUNNER_HARVEST") # $TASK_HARVEST"
     entry_synth="$synth_mm $synth_hh * * $dow $(cron_escape "$CRON_RUNNER_SYNTH") # $TASK_SYNTH"
     entry_health="$health_mm $health_hh $HEALTH_DAY * * $(cron_escape "$CRON_RUNNER_HEALTH") # $TASK_HEALTH"
 
     if [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRY pipeline-cadence: would write $CRON_RUNNER_HARVEST:"
+        emit_runner "$TASK_HARVEST" "$q_vault" "$q_claude" "$q_harvest_prompt" "$q_log_harvest" "$q_node_dir" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $CRON_RUNNER_SYNTH:"
         emit_runner "$TASK_SYNTH" "$q_vault" "$q_claude" "$q_synth_prompt" "$q_log_synth" "$q_node_dir" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $CRON_RUNNER_HEALTH:"
         emit_runner "$TASK_HEALTH" "$q_vault" "$q_claude" "$q_health_prompt" "$q_log_health" "$q_node_dir" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would add crontab entries:"
+        echo "    $entry_harvest"
         echo "    $entry_synth"
         echo "    $entry_health"
         echo "pipeline-cadence: dry-run complete (no changes made)"
@@ -855,12 +1070,13 @@ cron_arm() {
     # let a failed install (exit 4) leave the OLD crontab live while
     # the runner files already carry the NEW config — a silent
     # half-state under --force re-arm.
-    local tmp_synth="$CRON_RUNNER_SYNTH.tmp.$$" tmp_health="$CRON_RUNNER_HEALTH.tmp.$$"
+    local tmp_harvest="$CRON_RUNNER_HARVEST.tmp.$$" tmp_synth="$CRON_RUNNER_SYNTH.tmp.$$" tmp_health="$CRON_RUNNER_HEALTH.tmp.$$"
+    emit_runner "$TASK_HARVEST" "$q_vault" "$q_claude" "$q_harvest_prompt" "$q_log_harvest" "$q_node_dir" > "$tmp_harvest"
     emit_runner "$TASK_SYNTH"  "$q_vault" "$q_claude" "$q_synth_prompt"  "$q_log_synth"  "$q_node_dir" > "$tmp_synth"
     emit_runner "$TASK_HEALTH" "$q_vault" "$q_claude" "$q_health_prompt" "$q_log_health" "$q_node_dir" > "$tmp_health"
-    chmod +x "$tmp_synth" "$tmp_health"
+    chmod +x "$tmp_harvest" "$tmp_synth" "$tmp_health"
 
-    # Single atomic rewrite: everything that isn't ours, then both
+    # Single atomic rewrite: everything that isn't ours, then all three
     # cadence entries.
     local newtab
     newtab=$(mktemp -t pipeline-cadence.cron.XXXXXX)
@@ -868,22 +1084,24 @@ cron_arm() {
         if [ -n "$CRON_TAB" ]; then
             printf '%s\n' "$CRON_TAB" | grep -vF "$TASK_PREFIX" || true
         fi
-        printf '%s\n' "$entry_synth" "$entry_health"
+        printf '%s\n' "$entry_harvest" "$entry_synth" "$entry_health"
     } > "$newtab"
     if ! cron_install "$newtab"; then
         # Pre-existing runners were never touched; sweep the staged
         # new-config ones so no half-state survives the failed install.
-        rm -f "$tmp_synth" "$tmp_health"
+        rm -f "$tmp_harvest" "$tmp_synth" "$tmp_health"
         echo "    existing runner files left untouched" >&2
         exit 4
     fi
+    mv -f "$tmp_harvest" "$CRON_RUNNER_HARVEST"
     mv -f "$tmp_synth"  "$CRON_RUNNER_SYNTH"
     mv -f "$tmp_health" "$CRON_RUNNER_HEALTH"
 
     cat <<EOF
 
 ================================================================
-  PIPELINE CADENCE ARMED (HIMMEL-255 / HIMMEL-265 cron)
+  PIPELINE CADENCE ARMED (HIMMEL-255 / HIMMEL-265 cron / HIMMEL-357)
+  $TASK_HARVEST     daily   $HARVEST_TIME       -> /harvest-clips + /triage-clips
   $TASK_SYNTH  weekly  $SYNTH_DAY $SYNTH_TIME  -> /synthesize-clips + /archive-clips
   $TASK_HEALTH      monthly day $HEALTH_DAY $HEALTH_TIME -> /obsidian-health
   Vault: $VAULT

--- a/scripts/luna/test-pipeline-cadence.sh
+++ b/scripts/luna/test-pipeline-cadence.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 # Smoke test for scripts/luna/pipeline-cadence.sh (HIMMEL-255 schtasks
-# path + HIMMEL-265 cron path).
+# path + HIMMEL-265 cron path + HIMMEL-357 daily harvest+triage leg +
+# HIMMEL-362 XML-based schtasks create carrying StartWhenAvailable).
+#
+# Three cadence tasks are armed: HIMMEL-Pipeline-Harvest (daily 02:00 ->
+# /harvest-clips + /triage-clips), HIMMEL-Pipeline-Synthesize (weekly Sun
+# 03:00 -> /synthesize-clips + /archive-clips), HIMMEL-Pipeline-Health
+# (monthly 1st 04:00 -> /obsidian-health). The harvest leg is exercised
+# alongside synth/health throughout the dry-run / arm / shape / status /
+# dedup / force / disarm / rollback tests below.
 #
 # Strategy: replace the scheduler with a fake — schtasks via the
 # PIPELINE_SCHTASKS seam (records /create args + simulates /query and
@@ -53,9 +61,11 @@
 #   1.  Missing/unknown subcommand -> exit 1.
 #   2.  Invalid --synth-time / --synth-day / --health-day / vault -> exit 1.
 #   3.  status with empty scheduler -> both tasks "not armed".
-#   4.  arm --dry-run prints both creates + .bat bodies, registers nothing.
-#   5.  arm registers both tasks with the operator-decision defaults
-#       (WEEKLY SUN 03:00, MONTHLY 1 04:00) + writes both .bats.
+#   4.  arm --dry-run prints the XML creates (trigger + StartWhenAvailable)
+#       + .bat bodies, registers nothing.
+#   5.  arm registers all three tasks from XML carrying StartWhenAvailable
+#       (HIMMEL-362) at the operator-decision defaults (DAILY 02:00, WEEKLY
+#       SUN 03:00, MONTHLY 1 04:00) + writes the .bats.
 #   6.  Armed .bats are interactive-claude shaped: bounded `< NUL`,
 #       chained synthesize->archive prompt, NO -p/--print/--bg.
 #   7.  status after arm -> both ARMED.
@@ -66,8 +76,10 @@
 #   10. disarm removes both tasks + .bats; second disarm is a no-op (rc 0).
 #   11. cmd_escape: hostile-but-legal vault dirname (% & ^) lands escaped
 #       in the .bat (%%, ^&, ^^) — no fire-time injection.
-#   12. Half-arm: second /create fails -> rc 4, first task rolled back,
-#       no task state left.
+#   12. Half-arm: last /create (health) fails -> rc 4, harvest + synth
+#       rolled back, no task state left.
+#   12b. Mid-create (synth) fails -> rc 4, harvest rolled back, health
+#        never attempted, no task state left.
 #   13. Fail-closed dedup: /query listing fails (rc 1 + stderr) -> arm
 #       exits 2 instead of treating the scheduler as empty.
 #   14. Disarm under /query failure -> nonzero exit, .bats NOT deleted,
@@ -134,11 +146,28 @@ printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP_ROOT/bin/claude"
 chmod +x "$TMP_ROOT/bin/claude"
 export PATH="$TMP_ROOT/bin:$PATH"
 
+# HIMMEL-386: redirect the workspace-trust pre-seed (cmd_arm / cron_arm now
+# pre-trust the vault) at a throwaway config so non-dry-run arm tests never
+# mutate the operator's real ~/.claude.json.
+export WORKSPACE_TRUST_CONFIG="$TMP_ROOT/claude-trust.json"
+
 VAULT="$TMP_ROOT/vault"
 mkdir -p "$VAULT"
 
 # Same pattern the no-headless-claude pre-commit gate uses (HIMMEL-128).
 HEADLESS_RE='(^|[^A-Za-z0-9_-])claude[[:space:]]+(-p|--print|--bg)($|[^A-Za-z0-9_-])'
+
+# ============================================================================
+# xml_escape unit (HIMMEL-362) — the one non-trivial new string transform.
+# Pure + platform-agnostic, so it runs on EVERY platform: extract the
+# function from the script and call it directly. Pins the &-first ordering
+# (escaping & last would double-escape the &lt;/&gt; entities) so a
+# BAT_DIR path containing & / < / > yields well-formed task XML.
+# ============================================================================
+echo "TEST: xml_escape escapes & < > with & ordered first"
+xesc=$( { sed -n '/^xml_escape()/,/^}/p' "$SCRIPT"; echo "xml_escape 'a & b < c > d'"; } | bash )
+assert_contains "xml_escape produces well-formed entities (& first)" "a &amp; b &lt; c &gt; d" "$xesc"
+assert_not_contains "xml_escape leaves no bare ampersand" "a & b" "$xesc"
 
 # ============================================================================
 # POSIX (cron) suite — HIMMEL-265. Runs on EVERY platform: the cron code
@@ -205,12 +234,15 @@ run_cron() {
 
 echo "TEST: cron status with no crontab installed"
 out=$(run_cron status)
+assert_contains "cron harvest not armed"    "not armed  HIMMEL-Pipeline-Harvest"    "$out"
 assert_contains "cron synthesize not armed" "not armed  HIMMEL-Pipeline-Synthesize" "$out"
 assert_contains "cron health not armed"     "not armed  HIMMEL-Pipeline-Health"     "$out"
 
 # Test C12: shared validation wired into the cron path -----------------------
 
 echo "TEST: cron arm rejects invalid input (shared validation)"
+rc=0; out=$(run_cron arm --vault "$VAULT" --harvest-time 24:61 2>&1) || rc=$?
+assert_rc "cron bad --harvest-time -> rc 1" 1 "$rc"
 rc=0; out=$(run_cron arm --vault "$VAULT" --synth-time 25:00 2>&1) || rc=$?
 assert_rc "cron bad --synth-time -> rc 1" 1 "$rc"
 rc=0; out=$(run_cron arm --vault "$VAULT" --health-day 31 2>&1) || rc=$?
@@ -220,10 +252,13 @@ assert_rc "cron bad --health-day (31) -> rc 1" 1 "$rc"
 
 echo "TEST: cron arm --dry-run prints plan, installs nothing"
 out=$(run_cron arm --vault "$VAULT" --dry-run)
+assert_contains "dry-run daily harvest entry" "00 02 * * *" "$out"
 assert_contains "dry-run weekly entry"  "00 03 * * 0" "$out"
 assert_contains "dry-run monthly entry" "00 04 1 * *" "$out"
+assert_contains "dry-run harvest marker" "# HIMMEL-Pipeline-Harvest" "$out"
 assert_contains "dry-run synth marker"  "# HIMMEL-Pipeline-Synthesize" "$out"
 assert_contains "dry-run shows bounded run" "< /dev/null" "$out"
+assert_contains "dry-run pre-trusts vault (HIMMEL-386)" "would pre-trust workspace '$VAULT'" "$out"
 if [ ! -f "$CSTATE/crontab" ]; then
     pass "dry-run installed no crontab"
 else
@@ -241,15 +276,23 @@ echo "TEST: cron arm installs entries with defaults, preserves unrelated lines"
 printf '5 5 * * * /usr/bin/true # keep-me\n' > "$CSTATE/crontab"
 out=$(run_cron arm --vault "$VAULT")
 assert_contains "cron arm banner" "PIPELINE CADENCE ARMED" "$out"
+# HIMMEL-386: the real (non-dry-run) arm pre-trusts the vault in the (temp) config.
+if command -v node >/dev/null 2>&1; then
+    trust=$(WT_F="$WORKSPACE_TRUST_CONFIG" WT_K="$VAULT" node -e 'try{const j=JSON.parse(require("fs").readFileSync(process.env.WT_F,"utf8"));process.stdout.write(String(j.projects&&j.projects[process.env.WT_K]&&j.projects[process.env.WT_K].hasTrustDialogAccepted))}catch(e){process.stdout.write("ERR")}')
+    assert_contains "cron arm pre-trusts vault in config" "true" "$trust"
+fi
 tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
+assert_contains "daily harvest entry 02:00"  "00 02 * * *" "$tab"
 assert_contains "weekly entry SUN 03:00"  "00 03 * * 0" "$tab"
 assert_contains "monthly entry 1st 04:00" "00 04 1 * *" "$tab"
+assert_contains "harvest entry marker-tagged" "# HIMMEL-Pipeline-Harvest"     "$tab"
 assert_contains "synth entry marker-tagged"  "# HIMMEL-Pipeline-Synthesize" "$tab"
 assert_contains "health entry marker-tagged" "# HIMMEL-Pipeline-Health"     "$tab"
+assert_contains "harvest entry fires the runner" "pipeline-harvest.sh"    "$tab"
 assert_contains "synth entry fires the runner"  "pipeline-synthesize.sh" "$tab"
 assert_contains "health entry fires the runner" "pipeline-health.sh"     "$tab"
 assert_contains "unrelated entry preserved" "keep-me" "$tab"
-if [ -x "$CRON_DIR/pipeline-synthesize.sh" ] && [ -x "$CRON_DIR/pipeline-health.sh" ]; then
+if [ -x "$CRON_DIR/pipeline-harvest.sh" ] && [ -x "$CRON_DIR/pipeline-synthesize.sh" ] && [ -x "$CRON_DIR/pipeline-health.sh" ]; then
     pass "runner .sh files written + executable"
 else
     fail "runner .sh files missing or not executable" "$(ls -l "$CRON_DIR" 2>/dev/null || true)"
@@ -258,8 +301,13 @@ fi
 # Test C4: runner .sh is interactive-claude shaped -----------------------------
 
 echo "TEST: runner .sh is bounded interactive claude (no headless flags)"
+harvest_sh=$(cat "$CRON_DIR/pipeline-harvest.sh" 2>/dev/null || echo MISSING)
 synth_sh=$(cat "$CRON_DIR/pipeline-synthesize.sh" 2>/dev/null || echo MISSING)
 health_sh=$(cat "$CRON_DIR/pipeline-health.sh" 2>/dev/null || echo MISSING)
+assert_contains "harvest runner cds into vault" "cd $VAULT || exit 1" "$harvest_sh"
+assert_contains "harvest runner runs /harvest-clips" "/harvest-clips" "$harvest_sh"
+assert_contains "harvest runner chains /triage-clips" "/triage-clips" "$harvest_sh"
+assert_contains "harvest runner bounded run"         "< /dev/null"    "$harvest_sh"
 assert_contains "synth runner cds into vault" "cd $VAULT || exit 1" "$synth_sh"
 assert_contains "synth runner runs /synthesize-clips" "/synthesize-clips" "$synth_sh"
 assert_contains "synth runner chains /archive-clips"  "/archive-clips"    "$synth_sh"
@@ -271,7 +319,7 @@ assert_contains "synth runner stamps every fire" '[fired' "$synth_sh"
 assert_contains "synth runner captures output to log" '>> "$log" 2>&1' "$synth_sh"
 assert_contains "health runner runs /obsidian-health" "/obsidian-health" "$health_sh"
 assert_contains "health runner bounded run"           "< /dev/null"      "$health_sh"
-for what in synth health; do
+for what in harvest synth health; do
     body=$(eval "printf '%s' \"\$${what}_sh\"")
     if printf '%s\n' "$body" | grep -E "$HEADLESS_RE" >/dev/null 2>&1; then
         fail "$what runner is headless-shaped" "$body"
@@ -284,6 +332,7 @@ done
 
 echo "TEST: cron status reflects armed entries"
 out=$(run_cron status)
+assert_contains "cron harvest armed"    "ARMED      HIMMEL-Pipeline-Harvest"    "$out"
 assert_contains "cron synthesize armed" "ARMED      HIMMEL-Pipeline-Synthesize" "$out"
 assert_contains "cron health armed"     "ARMED      HIMMEL-Pipeline-Health"     "$out"
 assert_contains "cron status surfaces run log state" "run log" "$out"
@@ -314,7 +363,7 @@ echo "TEST: cron re-arm without --force blocked (rc 3)"
 rc=0; out=$(run_cron arm --vault "$VAULT" 2>&1) || rc=$?
 assert_rc "cron dedup block rc 3" 3 "$rc"
 assert_contains "cron dedup message names existing entries" "HIMMEL-Pipeline-Synthesize" "$out"
-if [ "$(grep -c 'HIMMEL-Pipeline-' "$CSTATE/crontab")" -eq 2 ]; then
+if [ "$(grep -c 'HIMMEL-Pipeline-' "$CSTATE/crontab")" -eq 3 ]; then
     pass "no duplicate entries after blocked re-arm"
 else
     fail "entry count changed on blocked re-arm" "$(cat "$CSTATE/crontab")"
@@ -324,13 +373,14 @@ fi
 
 echo "TEST: cron re-arm --force applies flag overrides"
 out=$(run_cron arm --vault "$VAULT" --force \
-    --synth-day mon --synth-time 02:30 --health-day 15 --health-time 05:00 2>&1)
+    --harvest-time 01:15 --synth-day mon --synth-time 02:30 --health-day 15 --health-time 05:00 2>&1)
 tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
+assert_contains "cron daily harvest override"                  "15 01 * * *" "$tab"
 assert_contains "cron weekly override (lowercase day upcased)" "30 02 * * 1" "$tab"
 assert_contains "cron monthly override"                        "00 05 15 * *" "$tab"
 assert_contains "unrelated entry survives --force re-arm" "keep-me" "$tab"
-if [ "$(grep -c 'HIMMEL-Pipeline-' "$CSTATE/crontab")" -eq 2 ]; then
-    pass "still exactly two entries after --force re-arm"
+if [ "$(grep -c 'HIMMEL-Pipeline-' "$CSTATE/crontab")" -eq 3 ]; then
+    pass "still exactly three entries after --force re-arm"
 else
     fail "duplicate entries after --force re-arm" "$(cat "$CSTATE/crontab")"
 fi
@@ -341,7 +391,7 @@ echo "TEST: cron dry-run disarm prints DRY tail, touches nothing"
 out=$(run_cron disarm --dry-run)
 assert_contains "cron dry disarm lists removals" "would remove crontab entry" "$out"
 assert_contains "cron dry disarm closing summary" "no changes made" "$out"
-if [ "$(grep -c 'HIMMEL-Pipeline-' "$CSTATE/crontab")" -eq 2 ]; then
+if [ "$(grep -c 'HIMMEL-Pipeline-' "$CSTATE/crontab")" -eq 3 ]; then
     pass "dry-run disarm removed no entries"
 else
     fail "dry-run disarm changed crontab state" "$(cat "$CSTATE/crontab")"
@@ -360,7 +410,7 @@ assert_contains "cron disarm reports" "cadence disarmed" "$out"
 tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
 assert_not_contains "cadence entries removed" "HIMMEL-Pipeline-" "$tab"
 assert_contains "unrelated entry survives disarm" "keep-me" "$tab"
-if [ ! -f "$CRON_DIR/pipeline-synthesize.sh" ] && [ ! -f "$CRON_DIR/pipeline-health.sh" ]; then
+if [ ! -f "$CRON_DIR/pipeline-harvest.sh" ] && [ ! -f "$CRON_DIR/pipeline-synthesize.sh" ] && [ ! -f "$CRON_DIR/pipeline-health.sh" ]; then
     pass "runner .sh files removed"
 else
     fail "runner .sh files left after disarm"
@@ -421,7 +471,7 @@ if ! grep -q 'HIMMEL-Pipeline-' "$CSTATE/crontab" 2>/dev/null; then
 else
     fail "cadence entries installed despite write failure" "$(cat "$CSTATE/crontab")"
 fi
-if [ ! -f "$CRON_DIR/pipeline-synthesize.sh" ] && [ ! -f "$CRON_DIR/pipeline-health.sh" ]; then
+if [ ! -f "$CRON_DIR/pipeline-harvest.sh" ] && [ ! -f "$CRON_DIR/pipeline-synthesize.sh" ] && [ ! -f "$CRON_DIR/pipeline-health.sh" ]; then
     pass "no runner promoted to its final path on write failure"
 else
     fail "runner files left despite write failure" "$(ls "$CRON_DIR" 2>/dev/null || true)"
@@ -454,7 +504,7 @@ if ! compgen -G "$CRON_DIR/*.tmp.*" >/dev/null; then
 else
     fail "staged .tmp runner litter left" "$(ls "$CRON_DIR")"
 fi
-if [ "$(grep -c 'HIMMEL-Pipeline-' "$CSTATE/crontab")" -eq 2 ]; then
+if [ "$(grep -c 'HIMMEL-Pipeline-' "$CSTATE/crontab")" -eq 3 ]; then
     pass "old entries still armed after failed --force re-arm"
 else
     fail "entry count changed on failed --force re-arm" "$(cat "$CSTATE/crontab")"
@@ -473,7 +523,7 @@ touch "$CSTATE/fail-write"
 rc=0; out=$(run_cron disarm 2>&1) || rc=$?
 assert_rc "cron disarm install failure rc 4" 4 "$rc"
 assert_contains "disarm install failure surfaces stderr" "error writing new crontab" "$out"
-if [ "$(grep -c 'HIMMEL-Pipeline-' "$CSTATE/crontab")" -eq 2 ]; then
+if [ "$(grep -c 'HIMMEL-Pipeline-' "$CSTATE/crontab")" -eq 3 ]; then
     pass "entries still in crontab after failed disarm install"
 else
     fail "entries lost despite failed disarm install" "$(cat "$CSTATE/crontab")"
@@ -651,7 +701,7 @@ cat >"$FAKE_SCHTASKS" <<FAKE
 STATE="$STATE"
 FAKE
 cat >>"$FAKE_SCHTASKS" <<'FAKE'
-tn=""; mode=""; fmt=""
+tn=""; mode=""; fmt=""; xmlpath=""
 args=("$@")
 i=0
 while [ $i -lt ${#args[@]} ]; do
@@ -659,6 +709,7 @@ while [ $i -lt ${#args[@]} ]; do
         /create|/delete|/query) mode="${args[$i]}" ;;
         /tn) i=$((i+1)); tn="${args[$i]}" ;;
         /fo) i=$((i+1)); fmt="${args[$i]}" ;;
+        /xml) i=$((i+1)); xmlpath="${args[$i]}" ;;
     esac
     i=$((i+1))
 done
@@ -670,7 +721,18 @@ case "$mode" in
             echo "ERROR: Access is denied." >&2
             exit 1
         fi
-        printf '%s\n' "$*" > "$STATE/tasks/$tn"
+        # HIMMEL-362: real arm now creates from XML (/create /tn X /xml F).
+        # Store the XML file's CONTENT under $STATE/tasks/<tn> so assertions
+        # can inspect the trigger + StartWhenAvailable + Exec command. The
+        # xml path arrives Windows-form (schtasks gets a cygpath -w'd path);
+        # convert back to POSIX to read it. Fall back to recording the argv
+        # for any non-/xml create (back-compat).
+        if [ -n "$xmlpath" ]; then
+            xml_posix=$(cygpath -u "$xmlpath" 2>/dev/null || echo "$xmlpath")
+            cat "$xml_posix" > "$STATE/tasks/$tn"
+        else
+            printf '%s\n' "$*" > "$STATE/tasks/$tn"
+        fi
         echo "SUCCESS: The scheduled task \"$tn\" has successfully been created."
         ;;
     /delete)
@@ -746,6 +808,8 @@ assert_rc "unknown subcommand -> rc 1" 1 "$rc"
 # Test 2: input validation --------------------------------------------------
 
 echo "TEST: invalid inputs rejected"
+rc=0; out=$(run_pc arm --vault "$VAULT" --harvest-time 9:00 2>&1) || rc=$?
+assert_rc "bad --harvest-time (no leading zero) -> rc 1" 1 "$rc"
 rc=0; out=$(run_pc arm --vault "$VAULT" --synth-time 25:00 2>&1) || rc=$?
 assert_rc "bad --synth-time -> rc 1" 1 "$rc"
 rc=0; out=$(run_pc arm --vault "$VAULT" --synth-day FUNDAY 2>&1) || rc=$?
@@ -766,8 +830,15 @@ assert_contains "health not armed"     "not armed  HIMMEL-Pipeline-Health"     "
 
 echo "TEST: arm --dry-run prints plan, registers nothing"
 out=$(run_pc arm --vault "$VAULT" --dry-run)
-assert_contains "dry-run weekly create"  "/tn HIMMEL-Pipeline-Synthesize /sc WEEKLY /d SUN /st 03:00" "$out"
-assert_contains "dry-run monthly create" "/tn HIMMEL-Pipeline-Health /sc MONTHLY /d 1 /st 04:00"      "$out"
+# HIMMEL-362: create is now XML-based; dry-run previews the /xml create line
+# + the generated task XML (trigger + StartWhenAvailable).
+assert_contains "dry-run daily create"   "/tn HIMMEL-Pipeline-Harvest /xml" "$out"
+assert_contains "dry-run weekly create"  "/tn HIMMEL-Pipeline-Synthesize /xml" "$out"
+assert_contains "dry-run monthly create" "/tn HIMMEL-Pipeline-Health /xml" "$out"
+assert_contains "dry-run XML has StartWhenAvailable" "<StartWhenAvailable>true</StartWhenAvailable>" "$out"
+assert_contains "dry-run XML daily schedule"   "<ScheduleByDay>"   "$out"
+assert_contains "dry-run XML weekly Sunday"    "<Sunday />"        "$out"
+assert_contains "dry-run XML monthly day 1"    "<Day>1</Day>"      "$out"
 assert_contains "dry-run shows bounded run" "< NUL" "$out"
 if [ -z "$(ls -A "$STATE/tasks" 2>/dev/null)" ]; then
     pass "dry-run registered no tasks"
@@ -785,18 +856,36 @@ fi
 echo "TEST: arm registers weekly SUN 03:00 + monthly 1st 04:00"
 out=$(run_pc arm --vault "$VAULT")
 assert_contains "arm banner" "PIPELINE CADENCE ARMED" "$out"
+harvest_args=$(cat "$STATE/tasks/HIMMEL-Pipeline-Harvest" 2>/dev/null || echo MISSING)
 synth_args=$(cat "$STATE/tasks/HIMMEL-Pipeline-Synthesize" 2>/dev/null || echo MISSING)
 health_args=$(cat "$STATE/tasks/HIMMEL-Pipeline-Health" 2>/dev/null || echo MISSING)
-assert_contains "weekly schedule"  "/sc WEEKLY /d SUN /st 03:00"  "$synth_args"
-assert_contains "monthly schedule" "/sc MONTHLY /d 1 /st 04:00"   "$health_args"
-assert_contains "synth /tr points at runner bat"  "pipeline-synthesize.bat" "$synth_args"
-assert_contains "health /tr points at runner bat" "pipeline-health.bat"     "$health_args"
+# HIMMEL-362: tasks are created from XML; the fake records the XML content.
+assert_contains "daily schedule (XML)"   "<ScheduleByDay>"  "$harvest_args"
+assert_contains "daily time (XML)"       "T02:00:00"        "$harvest_args"
+assert_contains "weekly schedule (XML)"  "<Sunday />"       "$synth_args"
+assert_contains "weekly time (XML)"      "T03:00:00"        "$synth_args"
+assert_contains "monthly schedule (XML)" "<Day>1</Day>"     "$health_args"
+assert_contains "monthly time (XML)"     "T04:00:00"        "$health_args"
+assert_contains "harvest XML StartWhenAvailable" "<StartWhenAvailable>true</StartWhenAvailable>" "$harvest_args"
+assert_contains "synth XML StartWhenAvailable"   "<StartWhenAvailable>true</StartWhenAvailable>" "$synth_args"
+assert_contains "health XML StartWhenAvailable"  "<StartWhenAvailable>true</StartWhenAvailable>" "$health_args"
+assert_contains "harvest Exec points at runner bat" "pipeline-harvest.bat"  "$harvest_args"
+assert_contains "synth Exec points at runner bat"  "pipeline-synthesize.bat" "$synth_args"
+assert_contains "health Exec points at runner bat" "pipeline-health.bat"     "$health_args"
 
 # Test 6: .bat runners are interactive-claude shaped ------------------------
 
 echo "TEST: .bat runners are bounded interactive claude (no headless flags)"
+harvest_bat=$(cat "$BAT_DIR/pipeline-harvest.bat" 2>/dev/null || echo MISSING)
 synth_bat=$(cat "$BAT_DIR/pipeline-synthesize.bat" 2>/dev/null || echo MISSING)
 health_bat=$(cat "$BAT_DIR/pipeline-health.bat" 2>/dev/null || echo MISSING)
+assert_contains "harvest bat cds into vault" 'cd /d "' "$harvest_bat"
+assert_contains "harvest bat runs /harvest-clips" "/harvest-clips" "$harvest_bat"
+assert_contains "harvest bat chains /triage-clips" "/triage-clips" "$harvest_bat"
+assert_contains "harvest bat bounded run"          "< NUL"         "$harvest_bat"
+assert_contains "harvest bat appends run log" 'pipeline-harvest.log" 2>&1' "$harvest_bat"
+assert_contains "harvest bat rotates the log before firing" 'move /y' "$harvest_bat"
+assert_contains "harvest bat stamps every fire" 'echo [fired %DATE% %TIME%]' "$harvest_bat"
 assert_contains "synth bat cds into vault" 'cd /d "' "$synth_bat"
 assert_contains "synth bat runs /synthesize-clips" "/synthesize-clips" "$synth_bat"
 assert_contains "synth bat chains /archive-clips"  "/archive-clips"    "$synth_bat"
@@ -812,7 +901,7 @@ fi
 assert_contains "health bat runs /obsidian-health" "/obsidian-health"  "$health_bat"
 assert_contains "health bat bounded run"           "< NUL"             "$health_bat"
 assert_contains "health bat appends run log" 'pipeline-health.log" 2>&1'     "$health_bat"
-for what in synth health; do
+for what in harvest synth health; do
     body=$(eval "printf '%s' \"\$${what}_bat\"")
     if printf '%s\n' "$body" | grep -E "$HEADLESS_RE" >/dev/null 2>&1; then
         fail "$what bat is headless-shaped" "$body"
@@ -825,6 +914,7 @@ done
 
 echo "TEST: status reflects armed tasks"
 out=$(run_pc status)
+assert_contains "harvest armed"    "ARMED      HIMMEL-Pipeline-Harvest"    "$out"
 assert_contains "synthesize armed" "ARMED      HIMMEL-Pipeline-Synthesize" "$out"
 assert_contains "health armed"     "ARMED      HIMMEL-Pipeline-Health"     "$out"
 assert_contains "status surfaces run log state" "run log" "$out"
@@ -851,7 +941,7 @@ echo "TEST: re-arm without --force blocked (rc 3)"
 rc=0; out=$(run_pc arm --vault "$VAULT" 2>&1) || rc=$?
 assert_rc "dedup block rc 3" 3 "$rc"
 assert_contains "dedup message names existing tasks" "HIMMEL-Pipeline-Synthesize" "$out"
-if [ "$(find "$STATE/tasks" -mindepth 1 | wc -l)" -eq 2 ]; then
+if [ "$(find "$STATE/tasks" -mindepth 1 | wc -l)" -eq 3 ]; then
     pass "no duplicate tasks after blocked re-arm"
 else
     fail "task count changed on blocked re-arm" "$(ls "$STATE/tasks")"
@@ -861,13 +951,17 @@ fi
 
 echo "TEST: re-arm --force applies flag overrides"
 out=$(run_pc arm --vault "$VAULT" --force \
-    --synth-day mon --synth-time 02:30 --health-day 15 --health-time 05:00 2>&1)
+    --harvest-time 01:15 --synth-day mon --synth-time 02:30 --health-day 15 --health-time 05:00 2>&1)
+harvest_args=$(cat "$STATE/tasks/HIMMEL-Pipeline-Harvest" 2>/dev/null || echo MISSING)
 synth_args=$(cat "$STATE/tasks/HIMMEL-Pipeline-Synthesize" 2>/dev/null || echo MISSING)
 health_args=$(cat "$STATE/tasks/HIMMEL-Pipeline-Health" 2>/dev/null || echo MISSING)
-assert_contains "weekly override (lowercase day upcased)" "/sc WEEKLY /d MON /st 02:30" "$synth_args"
-assert_contains "monthly override"                        "/sc MONTHLY /d 15 /st 05:00" "$health_args"
-if [ "$(find "$STATE/tasks" -mindepth 1 | wc -l)" -eq 2 ]; then
-    pass "still exactly two tasks after --force re-arm"
+assert_contains "daily override (XML time)"               "T01:15:00"   "$harvest_args"
+assert_contains "weekly override (lowercase day upcased)" "<Monday />"  "$synth_args"
+assert_contains "weekly override (XML time)"              "T02:30:00"   "$synth_args"
+assert_contains "monthly override (XML day)"              "<Day>15</Day>" "$health_args"
+assert_contains "monthly override (XML time)"             "T05:00:00"   "$health_args"
+if [ "$(find "$STATE/tasks" -mindepth 1 | wc -l)" -eq 3 ]; then
+    pass "still exactly three tasks after --force re-arm"
 else
     fail "duplicate tasks after --force re-arm" "$(ls "$STATE/tasks")"
 fi
@@ -882,7 +976,7 @@ if [ -z "$(ls -A "$STATE/tasks" 2>/dev/null)" ]; then
 else
     fail "tasks left after disarm" "$(ls "$STATE/tasks")"
 fi
-if [ ! -f "$BAT_DIR/pipeline-synthesize.bat" ] && [ ! -f "$BAT_DIR/pipeline-health.bat" ]; then
+if [ ! -f "$BAT_DIR/pipeline-harvest.bat" ] && [ ! -f "$BAT_DIR/pipeline-synthesize.bat" ] && [ ! -f "$BAT_DIR/pipeline-health.bat" ]; then
     pass ".bat runners removed"
 else
     fail ".bat runners left after disarm"
@@ -902,11 +996,16 @@ assert_contains "percent doubled (%% in bat)" '%%X%%' "$synth_bat"
 assert_contains "ampersand careted (^& in bat)" '^&' "$synth_bat"
 assert_contains "caret doubled (^^ in bat)" '^^' "$synth_bat"
 assert_not_contains "raw &ult survives unescaped" 'va&ult' "$synth_bat"
+# Harvest .bat goes through the same cmd_escape path — assert it too.
+harvest_bat=$(cat "$BAT_DIR/pipeline-harvest.bat" 2>/dev/null || echo MISSING)
+assert_contains "harvest: percent doubled (%% in bat)" '%%X%%' "$harvest_bat"
+assert_contains "harvest: ampersand careted (^& in bat)" '^&' "$harvest_bat"
+assert_not_contains "harvest: raw &ult survives unescaped" 'va&ult' "$harvest_bat"
 run_pc disarm >/dev/null
 
 # Test 12: half-arm rollback when the SECOND /create fails --------------------
 
-echo "TEST: health /create failure rolls back the synthesize task (rc 4)"
+echo "TEST: health /create failure rolls back harvest + synthesize (rc 4)"
 touch "$STATE/fail-create-HIMMEL-Pipeline-Health"
 rc=0; out=$(run_pc arm --vault "$VAULT" 2>&1) || rc=$?
 assert_rc "half-arm fails rc 4" 4 "$rc"
@@ -917,6 +1016,22 @@ else
     fail "task state left after rollback" "$(ls "$STATE/tasks")"
 fi
 rm -f "$STATE/fail-create-HIMMEL-Pipeline-Health"
+
+# Test 12b: middle-create (synthesize) failure rolls back the harvest task
+# that DID register; health is never attempted. Pins the harvest-only
+# rollback branch.
+
+echo "TEST: synth /create failure rolls back the harvest task (rc 4)"
+touch "$STATE/fail-create-HIMMEL-Pipeline-Synthesize"
+rc=0; out=$(run_pc arm --vault "$VAULT" 2>&1) || rc=$?
+assert_rc "mid half-arm fails rc 4" 4 "$rc"
+assert_contains "failure names the synth create" "HIMMEL-Pipeline-Synthesize failed" "$out"
+if [ -z "$(ls -A "$STATE/tasks" 2>/dev/null)" ]; then
+    pass "no task state left after harvest rollback"
+else
+    fail "task state left after harvest rollback" "$(ls "$STATE/tasks")"
+fi
+rm -f "$STATE/fail-create-HIMMEL-Pipeline-Synthesize"
 
 # Test 13: dedup listing failure is fail-CLOSED (pins the inverted classifier)
 
@@ -992,7 +1107,7 @@ echo "TEST: dry-run disarm prints DRY tail, touches nothing"
 out=$(run_pc disarm --dry-run)
 assert_contains "dry disarm lists deletions" "would delete" "$out"
 assert_contains "dry disarm closing summary" "no changes made" "$out"
-if [ "$(find "$STATE/tasks" -mindepth 1 | wc -l)" -eq 2 ]; then
+if [ "$(find "$STATE/tasks" -mindepth 1 | wc -l)" -eq 3 ]; then
     pass "dry-run disarm deleted no tasks"
 else
     fail "dry-run disarm changed task state" "$(ls "$STATE/tasks")"


### PR DESCRIPTION
Public propagation of private #570. Code-only.

- `ensure-workspace-trust.sh` (new): pre-trust the resolved cwd in `~/.claude.json` at arm time (clobber-safe, non-fatal, dry-run-safe) so a fired autonomous arm never stalls on the interactive workspace-trust prompt.
- `arm-resume.sh`: `--worktree` code-arm isolation + wire the pre-trust call.
- `pipeline-cadence.sh`: wire the pre-trust call. Also catches public up on HIMMEL-255/265/289/291/299/357/362 (luna pipeline-cadence PRs never previously propagated).

Tests: 233 passed, 0 failed (Git Bash on Windows). Added lines leak-scanned: no personal paths, tokens, chat IDs, or emails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)