### PR TITLE
feat(update): /update helper + update-process doc

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -1,0 +1,22 @@
+---
+description: Update this himmel checkout — git pull + marketplace re-sync. autoUpdate does NOT deliver himmel updates.
+---
+
+Updates an existing himmel install. **`git pull` is the only thing that
+delivers a himmel update** — the marketplace is registered from a local
+`directory` source, so Claude Code's `autoUpdate` only re-syncs plugins from
+the on-disk dir; and the core hooks + slash commands aren't plugins at all.
+Full model: [`docs/setup/updating.md`](../../docs/setup/updating.md).
+
+Does two steps: fast-forward pull of this checkout, then
+`claude plugin marketplace update himmel` to refresh plugins from the
+freshly-pulled dir.
+
+Run:
+
+```bash
+bash scripts/update.sh
+```
+
+After it finishes: hooks are live immediately; **restart any running Claude
+session** to pick up plugin / slash-command / skill changes.

--- a/docs/commands-catalog.md
+++ b/docs/commands-catalog.md
@@ -93,3 +93,4 @@ the github-repo ingest skill these dispatch to.
 | /open-warp | Open a new Warp tab at a directory, optionally pre-loading a command |
 | /oz-offload | Offload a long-running independent task to a separate local Warp tab running `warp agent run` (fire-and-forget; same-machine only) |
 | /quiet-run | Run a noisy command quietly — one OK/ERR line + log path |
+| /update | Update this himmel checkout — git pull + marketplace re-sync. autoUpdate does NOT deliver himmel updates. |

--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -134,6 +134,10 @@ bash scripts/setup.sh
 
 `scripts/setup.sh` handles: pre-commit install, Jira CLI build, `.env` from `.env.example`.
 
+To **update** an existing checkout later, run `/update` (or `bash scripts/update.sh`):
+`git pull` is what delivers himmel updates — marketplace `autoUpdate` does not.
+See [`updating.md`](updating.md).
+
 After setup:
 ```bash
 # Fill in Jira token

--- a/docs/setup/updating.md
+++ b/docs/setup/updating.md
@@ -1,0 +1,75 @@
+# Updating himmel
+
+**TL;DR — `git pull` your himmel checkout. Marketplace `autoUpdate` does NOT
+deliver himmel updates on its own.** Run `/update` (or `bash scripts/update.sh`)
+to do the pull + marketplace re-sync in one step.
+
+## Why a pull is required
+
+himmel ships as two delivery layers, and only one of them is a "plugin":
+
+| Surface | Where it lives | Updated by |
+|---------|----------------|------------|
+| Core hooks (`scripts/hooks/*`) | your checkout, run from `$CLAUDE_PROJECT_DIR` | **`git pull`** |
+| Slash commands (`.claude/commands/*`) | your checkout | **`git pull`** |
+| `settings.json` wiring, `scripts/*`, `CLAUDE.md`, docs | your checkout | **`git pull`** |
+| himmel plugins (`marketplace/plugins/*`) | your checkout, sourced `./plugins/*` | see below |
+| Vendored plugins (`claude-obsidian`, `obsidian`) | GitHub, **SHA-pinned** | only when the pin is bumped (= a `git pull`) |
+
+The hooks and commands are **not plugins** — they execute out of your repo
+checkout, so nothing but a pull changes them.
+
+The himmel *plugins* depend on **how the marketplace was registered**:
+
+- **Default setup** ([`settings-template.json`](settings-template.json)) registers
+  the marketplace from a local **`directory`** source
+  (`path: <himmel-path>/marketplace`) with `autoUpdate: true`. A directory source
+  has nothing to fetch over the network — `autoUpdate` only **re-syncs plugins
+  from the on-disk dir**, which changes only when you `git pull`. So with the
+  default setup, **everything is pull-gated**, plugins included.
+- **Direct-install path** (`claude plugin marketplace add yotamleo/himmel`) uses a
+  **github** source. There `autoUpdate` pulls a separate Claude-managed clone from
+  GitHub, so *plugin* updates arrive without pulling your working checkout — but
+  the core hooks and commands still run from your checkout and **still need a
+  pull**.
+
+Either way: **a `git pull` is required for the full update; `autoUpdate` never
+covers the core hooks.**
+
+## How to update
+
+```bash
+/update                 # inside Claude Code
+# or
+bash scripts/update.sh  # from a shell, in the himmel checkout
+```
+
+`scripts/update.sh`:
+1. `git pull --ff-only` (fails loudly if your branch has diverged from upstream
+   or local edits block the update — reconcile manually, updates land on the
+   default branch).
+2. `claude plugin marketplace update himmel` — refresh plugins from the
+   freshly-pulled local dir.
+
+Plain `git pull` works too if you don't need the marketplace re-sync.
+
+## When changes take effect
+
+- **Hooks**: immediately on the next tool call — PreToolUse/etc. re-read the
+  script from disk each invocation. (This is why the [HIMMEL-392] hook fix needs
+  only a pull, no restart.)
+- **Plugins / slash commands / skills**: loaded at session start — **restart**
+  any running Claude session to pick them up.
+
+## Notes
+
+- **On a feature branch?** A pull lands updates on the default branch; merge or
+  rebase it into your branch as you would any upstream change. The hook files
+  resolve from `$CLAUDE_PROJECT_DIR`, so the updated file is on disk as long as
+  the default branch is checked out at pull time.
+- **Forked `yotamleo/Himmel`** instead of cloning it directly? Add an `upstream`
+  remote and `git pull upstream main` — a plain `git pull origin` only pulls your
+  fork.
+- Whether the *default* registration should switch to a github (floating) source
+  so plugins auto-deliver without a pull is tracked as a deliberate trade-off in
+  HIMMEL-398 (it would leave the core hooks pull-only regardless).

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Update an existing himmel checkout (HIMMEL-397).
+#
+# WHY this exists: himmel's marketplace is registered from a LOCAL `directory`
+# source (see docs/setup/settings-template.json), so Claude Code's marketplace
+# `autoUpdate` only RE-SYNCS plugins from the on-disk dir — it never fetches
+# from GitHub. And the core hooks + slash commands aren't plugins at all;
+# they run from $CLAUDE_PROJECT_DIR. So `git pull` of THIS checkout is the only
+# thing that delivers a himmel update. This wraps the two steps that follow it:
+# pull, then refresh the marketplace from the freshly-pulled local dir.
+#
+# Full model: docs/setup/updating.md.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+
+# 1. Pull. --ff-only so a diverged/feature branch fails loudly instead of
+#    opening a merge — the operator decides how to reconcile in that case.
+echo "==> git pull --ff-only (branch: $branch)"
+if ! git pull --ff-only; then
+    echo "" >&2
+    echo "update: pull was not a fast-forward (branch '$branch' has diverged from upstream, or local edits block the update)." >&2
+    echo "        Resolve manually: stash/commit local work, or 'git checkout main' first," >&2
+    echo "        then re-run. himmel updates land on the default branch." >&2
+    exit 1
+fi
+
+# 2. Re-sync the himmel marketplace from the (now-updated) local dir so a
+#    running install picks up plugin changes. Best-effort: skip cleanly if the
+#    claude CLI is absent. `marketplace update` is non-interactive.
+if command -v claude >/dev/null 2>&1; then
+    echo "==> claude plugin marketplace update himmel"
+    claude plugin marketplace update himmel || \
+        echo "update: marketplace re-sync failed (non-fatal) — run 'claude plugin marketplace update himmel' yourself." >&2
+else
+    echo "update: claude CLI not on PATH — skipping marketplace re-sync." >&2
+fi
+
+cat <<'EOF'
+
+==> himmel updated.
+    - Hooks are live immediately (PreToolUse/etc. re-read from disk per call).
+    - Plugins / slash commands / skills load at session start — RESTART any
+      running Claude session to pick them up.
+EOF


### PR DESCRIPTION
git pull is what delivers himmel updates — marketplace autoUpdate only re-syncs plugins from the local directory source, and core hooks/commands aren't plugins. Adds scripts/update.sh (pull + marketplace re-sync), /update wrapper, and docs/setup/updating.md.