### PR TITLE
fix(hooks): anchor block-edit-on-main to the edited file's repo (#45)

### DIFF
--- a/scripts/hooks/block-edit-on-main.sh
+++ b/scripts/hooks/block-edit-on-main.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # PreToolUse hook for Edit/Write/MultiEdit/NotebookEdit.
 #
-# Blocks edits that target the primary worktree when HEAD == main. Forces
-# all feature work into a `.claude/worktrees/<name>/` subdir per CLAUDE.md
-# ("All feature work in git worktrees. Never commit directly to main.").
+# Blocks edits whose target FILE lives in a git repo that is currently on
+# main/master, forcing all feature work into a worktree per CLAUDE.md ("All
+# feature work in git worktrees. Never commit directly to main.").
+#
+# The repo is resolved from the EDITED FILE's path (walking up its own ancestors
+# for a `.git`), NOT from CLAUDE_PROJECT_DIR / the launch dir. That way it still
+# protects a nested repo on main even when Claude Code is launched from a
+# directory ABOVE it (Himmel#45) — anchoring to the launch dir silently read the
+# wrong repo's branch and let the edit through.
 #
 # Pre-existing pre-commit `check-worktree-isolation.sh` catches this at
 # commit time. This hook catches it at EDIT time so the operator gets
@@ -13,7 +19,7 @@
 #   0 — allow (default for any non-blocking path)
 #   2 — block; stderr is shown to Claude and the user
 #
-# Refs: handovers/yotam/backlog.md B1 (pre-edit worktree guard)
+# Refs: handovers/<USER_SLUG>/backlog.md B1 (pre-edit worktree guard)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -39,6 +45,13 @@ fi
 # --- Capability checks (fail CLOSED on missing deps; security boundary) ---
 if ! command -v jq >/dev/null 2>&1; then
     echo "block-edit-on-main: jq not on PATH — refusing to evaluate; install jq or comment the hook in .claude/settings.json" >&2
+    exit 2
+fi
+# git drives the branch read (is_on_main → lib.sh). Missing git would otherwise
+# surface only as a confusing rc=2 deep in the branch check — fail CLOSED here
+# with a clear message instead (matches the jq check; HIMMEL-401 CR).
+if ! command -v git >/dev/null 2>&1; then
+    echo "block-edit-on-main: git not on PATH — refusing to evaluate; install git or comment the hook in .claude/settings.json" >&2
     exit 2
 fi
 
@@ -104,67 +117,78 @@ input=$(cat)
 file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' 2>/dev/null || true)
 [ -z "$file_path" ] && exit 0
 
-project_dir="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-
-# `|| proj_real=""` suppresses set -e on canon failure so the empty-check
-# below catches the case with its actionable message instead of `set -e`
-# aborting with rc=1 and no diagnostic.
-proj_real=""; proj_real=$(canon "$project_dir") || proj_real=""
+# `|| file_real=""` suppresses set -e on canon failure so the empty-check below
+# catches it with an actionable message instead of set -e aborting rc=1.
 file_real=""; file_real=$(canon "$file_path") || file_real=""
 
-# Fail CLOSED on empty canonicalisation results — a permission error or odd
-# input that returns empty would otherwise prefix-match nothing and exit 0,
-# functionally re-opening the bypass we just plugged.
-if [ -z "$proj_real" ] || [ -z "$file_real" ]; then
+# Fail CLOSED on empty canonicalisation — an odd input that returns empty would
+# otherwise prefix-match nothing and exit 0, re-opening the `worktrees/../foo.sh`
+# traversal bypass.
+if [ -z "$file_real" ]; then
     _hint=""
     if [ -n "${CANON_FORCE:-}" ]; then
         _hint=" (CANON_FORCE=$CANON_FORCE — likely a wedged python3/python Store stub; unset CANON_FORCE or kill the stub process)"
     fi
-    echo "block-edit-on-main: canonicalisation returned empty (proj='$proj_real', file='$file_real')${_hint} — refusing to evaluate" >&2
+    echo "block-edit-on-main: canonicalisation returned empty (file='$file_real')${_hint} — refusing to evaluate" >&2
     exit 2
 fi
 
-# Strip any trailing slash defensively (canon should already normalise, but
-# belt-and-suspenders against odd inputs).
-proj_real="${proj_real%/}"
+# Resolve the EDITED FILE's git repo root — NOT the launch/project dir
+# (CLAUDE_PROJECT_DIR). Anchoring to the launch dir silently no-oped the guard
+# when Claude was started ABOVE the repo: a nested repo on main went unguarded
+# because the OUTER dir's branch was read instead (Himmel#45). Walk up the
+# file's OWN canonicalised ancestors looking for a `.git` (a directory in a
+# normal checkout, a FILE in a linked worktree or submodule). Walking
+# file_real's ancestors — rather than `git -C <dir> rev-parse --show-toplevel`
+# — keeps repo_real a literal PREFIX of file_real (no git-vs-canon path-form
+# mismatch on the handovers/ check) AND lets us distinguish "inside a repo whose
+# branch we cannot read" (→ fail CLOSED in the branch check) from "not inside
+# any repo" (→ allow) — `git rev-parse` collapses both to rc=128. The check is
+# `.git`-EXISTENCE only (no git invocation), so a not-yet-created Write target
+# whose parent dirs are missing simply keeps walking up to the repo root, and
+# the loop terminates at the filesystem root where dirname stops changing
+# (robust on both `/...` and bare-drive `C:/...` forms — no `git -C C:` foot-gun).
+repo_real=""
+_d=$(dirname "$file_real")
+_prev=""
+while [ "$_d" != "$_prev" ]; do
+    if [ -e "$_d/.git" ]; then repo_real="$_d"; break; fi
+    _prev="$_d"
+    # `|| _d="$_prev"` keeps a (near-impossible) dirname failure from aborting
+    # the hook with no stderr under set -e — it just terminates the loop.
+    _d=$(dirname "$_d") || _d="$_prev"
+done
 
-# Skip if the edit is outside the project (global config, system files, etc.)
+# File is not inside any git repo (global config, /tmp, system files) → allow.
+[ -z "$repo_real" ] && exit 0
+repo_real="${repo_real%/}"
+
+# Skip handover/status doc edits — pure docs the operator may update from the
+# primary checkout on main. Anchored to the FILE's repo root (Himmel#45).
 case "$file_real" in
-    "$proj_real"/*) ;;
-    "$proj_real") ;;
-    *) exit 0 ;;
+    "$repo_real"/handovers/*) exit 0 ;;
 esac
 
-# Skip if the edit is inside any worktree subdir.
-case "$file_real" in
-    "$proj_real"/.claude/worktrees/*) exit 0 ;;
-esac
+# No explicit `.claude/worktrees/` skip is needed: a git worktree carries its
+# own `.git` file, so the walk above resolves repo_real to the worktree dir
+# (checked out on a feature branch) and the branch check below ALLOWS the edit
+# via rc=1. The old launch-dir-anchored worktrees skip was itself part of the
+# Himmel#45 mis-anchoring.
 
-# Skip if the edit is a handover/status doc edit (operator may legitimately
-# update those from primary). These are pure docs, never code.
-case "$file_real" in
-    "$proj_real"/handovers/*) exit 0 ;;
-esac
-
-# At this point: edit is inside primary worktree, not in a sub-worktree, not a
-# handover file. Check the branch via the shared predicate. rc=2 means we
-# could not determine the branch (git missing, .git unreadable, etc.) - fail
-# CLOSED on that case to match the rest of this script's security posture
-# (jq/realpath capability checks above also fail closed). Bare `if is_on_main`
-# would collapse rc=2 into "not on main" and silently allow the edit.
-#
-# The call MUST go through `|| branch_rc=$?` (not a bare `is_on_main`): under
-# `set -e` a bare predicate call returning rc=1 (feature branch) aborts the
-# script rc=1 with NO stderr — before the rc=1 ALLOW path below — surfacing as
-# Claude Code's "hook error: No stderr output" on every primary-checkout
-# feature-branch edit (HIMMEL-392).
+# Check the branch of the FILE's repo. rc=2 (branch unreadable — e.g. a repo
+# with a corrupt/removed HEAD) fails CLOSED to match this script's security
+# posture (jq/git/realpath capability checks above also fail closed). The call
+# MUST go through `|| branch_rc=$?` (not a bare `is_on_main`): under set -e a
+# bare call returning rc=1 (feature branch) aborts the script rc=1 with NO
+# stderr — before the rc=1 ALLOW path below — surfacing as Claude Code's "hook
+# error: No stderr output" (HIMMEL-392).
 branch_rc=0
-is_on_main "$project_dir" || branch_rc=$?
+is_on_main "$repo_real" || branch_rc=$?
 if [ "$branch_rc" -eq 1 ]; then
     exit 0
 fi
 if [ "$branch_rc" -ne 0 ]; then
-    echo "block-edit-on-main: is_on_main returned rc=$branch_rc (cannot determine branch) - refusing to evaluate" >&2
+    echo "block-edit-on-main: is_on_main returned rc=$branch_rc (cannot determine branch for '$repo_real') - refusing to evaluate" >&2
     exit 2
 fi
 
@@ -176,8 +200,8 @@ if [ "${EDIT_ON_MAIN_OK:-0}" = "1" ]; then
 fi
 
 cat >&2 <<EOF
-⛔ block-edit-on-main: refusing to edit \`$file_path\` from PRIMARY worktree while HEAD == main.
-(resolved path: $file_real)
+⛔ block-edit-on-main: refusing to edit \`$file_path\` — its repo is on main/master.
+(file: $file_real — repo: $repo_real)
 
 Feature work must go in a worktree per CLAUDE.md. To start one:
 

--- a/scripts/hooks/test-block-edit-on-main.sh
+++ b/scripts/hooks/test-block-edit-on-main.sh
@@ -3,6 +3,16 @@
 #
 # Usage: bash scripts/hooks/test-block-edit-on-main.sh
 #
+# The hook resolves the repo from the EDITED FILE's path (Himmel#45) by walking
+# the file's own ancestors for a `.git`, NOT from CLAUDE_PROJECT_DIR. So the
+# cases below build real throwaway repos under a sandbox and assert the hook
+# reads the FILE's repo branch (not the launch dir's). Because repo_real is a
+# literal prefix of the canonicalised file path, no GIT_CEILING/cygpath
+# normalisation is needed (the resolution never calls `git -C <dir>
+# --show-toplevel`, so there is no path-form mismatch to bridge). The only
+# environmental assumption is that the runner's TMPDIR is not itself inside a
+# git repo — asserted with a WARN at setup.
+#
 # Exit codes:
 #   0 — all cases passed
 #   1 — at least one case failed
@@ -11,17 +21,7 @@ set -uo pipefail
 HOOK="$(cd "$(dirname "$0")" && pwd)/block-edit-on-main.sh"
 [ -x "$HOOK" ] || chmod +x "$HOOK"
 
-# Run the hook with the given JSON on stdin + env, capture exit code only.
-run_case() {
-    local input="$1"
-    local env_assign="$2"
-    if [ -n "$env_assign" ]; then
-        printf '%s' "$input" | env "$env_assign" CLAUDE_PROJECT_DIR="$PROJDIR" bash "$HOOK" >/dev/null 2>&1
-    else
-        printf '%s' "$input" | env CLAUDE_PROJECT_DIR="$PROJDIR" bash "$HOOK" >/dev/null 2>&1
-    fi
-    echo "$?"
-}
+FAILED=0
 
 assert_rc() {
     local label="$1" expected="$2" actual="$3"
@@ -33,87 +33,184 @@ assert_rc() {
     fi
 }
 
-# Need a real-looking primary; the script's own primary works.
-PROJDIR=$(git rev-parse --show-toplevel 2>/dev/null)
-# If we're already inside a worktree (common when running this from a
-# feat/* branch), walk to the actual primary.
-if PRIMARY_CANDIDATE=$(git rev-parse --git-common-dir 2>/dev/null); then
-    PROJDIR=$(cd "$(dirname "$PRIMARY_CANDIDATE")" && pwd)
+SANDBOX=$(mktemp -d)
+# Two unbounded upward walks resolve the repo + read its branch: the hook's own
+# `.git`-ancestor walk, and is_on_main → `git rev-parse` inside it. Both are
+# correct for production (find the file's nearest enclosing repo) but mean the
+# cases that depend on "this file is NOT inside any readable repo" — T4 (outside
+# any repo → allow), T13 (traversal out → allow), and T14 (broken HEAD →
+# fail-closed; its git walk-up would otherwise escape to an enclosing repo and
+# read a real branch) — only hold when no ancestor of SANDBOX is itself a git
+# repo. True on every real runner (TMPDIR = /tmp, /var/folders,
+# AppData\Local\Temp). If not (a pathological TMPDIR inside a checkout), SKIP
+# those three rather than mis-assert a security-load-bearing fail-closed case.
+SANDBOX_IN_REPO=0
+if git -C "$SANDBOX" rev-parse --show-toplevel >/dev/null 2>&1; then
+    SANDBOX_IN_REPO=1
+    echo "WARN: SANDBOX ($SANDBOX) is inside a git repo — SKIPPING the unbounded-walk-up cases T4/T13/T14 (they would escape into the enclosing repo and mis-assert)."
 fi
 
-FAILED=0
+mkrepo() { # $1=path $2=branch  (unborn HEAD on the given branch — no commit)
+    mkdir -p "$1"
+    git -C "$1" init -q
+    git -C "$1" symbolic-ref HEAD "refs/heads/$2"
+}
 
-# T1: traversal worktrees/../foo.sh should BLOCK (rc=2)
-rc=$(run_case "{\"tool_input\":{\"file_path\":\"$PROJDIR/.claude/worktrees/../foo.sh\"}}" "")
-assert_rc "T1 worktrees/.. traversal" 2 "$rc"
+# rc_of FILE [EXTRA_ENV...] — run the hook on FILE, echo its exit code. Extra
+# `KEY=VAL` env assignments (CLAUDE_PROJECT_DIR, CANON_FORCE, EDIT_ON_MAIN_OK …)
+# may follow; CLAUDE_PROJECT_DIR is deliberately set to misleading values in the
+# nesting/sibling cases to prove the hook ignores it.
+rc_of() {
+    local file="$1"; shift
+    printf '%s' "{\"tool_input\":{\"file_path\":\"$file\"}}" \
+        | env "$@" bash "$HOOK" >/dev/null 2>&1
+    echo "$?"
+}
 
-# T2: traversal handovers/../scripts/foo.sh should BLOCK (rc=2)
-rc=$(run_case "{\"tool_input\":{\"file_path\":\"$PROJDIR/handovers/../scripts/foo.sh\"}}" "")
-assert_rc "T2 handovers/.. traversal" 2 "$rc"
+# Repos under the sandbox.
+mkrepo "$SANDBOX/mainrepo" main
+mkrepo "$SANDBOX/featrepo" feat/x
+mkrepo "$SANDBOX/masterrepo" master
+mkdir -p "$SANDBOX/mainrepo/src" "$SANDBOX/mainrepo/handovers" "$SANDBOX/plain"
 
-# T3: trailing slash on CLAUDE_PROJECT_DIR should still BLOCK (rc=2)
-rc=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$PROJDIR/scripts/foo.sh\"}}" | CLAUDE_PROJECT_DIR="$PROJDIR/" bash "$HOOK" >/dev/null 2>&1; echo "$?")
-assert_rc "T3 trailing slash on PROJDIR" 2 "$rc"
+# Himmel#45: a nested repo on main, inside an OUTER repo on a feature branch
+# (the launch dir the OLD code read).
+mkrepo "$SANDBOX/outer" feat/o
+mkrepo "$SANDBOX/outer/sc/nested" main
+mkdir -p "$SANDBOX/outer/sc/nested/src"
 
-# T4: bypass set + primary edit should ALLOW silently (rc=0)
-rc=$(run_case "{\"tool_input\":{\"file_path\":\"$PROJDIR/scripts/foo.sh\"}}" "EDIT_ON_MAIN_OK=1")
-assert_rc "T4 bypass set" 0 "$rc"
+# Inverse nesting: a nested repo on a FEATURE branch inside an OUTER repo on main.
+mkrepo "$SANDBOX/outer2" main
+mkrepo "$SANDBOX/outer2/sc/nested" feat/n
+mkdir -p "$SANDBOX/outer2/sc/nested/src"
 
-# T4b: bypass produces ZERO stderr
-stderr_bytes=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$PROJDIR/scripts/foo.sh\"}}" | EDIT_ON_MAIN_OK=1 CLAUDE_PROJECT_DIR="$PROJDIR" bash "$HOOK" 2>&1 >/dev/null | wc -c)
-assert_rc "T4b bypass silent stderr" 0 "$stderr_bytes"
+# A real git worktree on a feature branch (needs a commit to add the worktree).
+mkrepo "$SANDBOX/wtrepo" main
+git -C "$SANDBOX/wtrepo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$SANDBOX/wtrepo" worktree add -q "$SANDBOX/wtrepo/.claude/worktrees/feat+x" -b feat/x >/dev/null 2>&1
+mkdir -p "$SANDBOX/wtrepo/.claude/worktrees/feat+x/src"
 
-# T5: legitimate worktree edit should ALLOW (rc=0)
-WT_PATH="$PROJDIR/.claude/worktrees/feat+infra-b1-b2/scripts/foo.sh"
-rc=$(run_case "{\"tool_input\":{\"file_path\":\"$WT_PATH\"}}" "")
-assert_rc "T5 worktree edit" 0 "$rc"
+# A repo with a removed HEAD → branch unreadable (is_on_main rc=2).
+mkrepo "$SANDBOX/brokenrepo" main
+mkdir -p "$SANDBOX/brokenrepo/src"
+rm -f "$SANDBOX/brokenrepo/.git/HEAD"
 
-# T6: handover edit on main should ALLOW (rc=0)
-rc=$(run_case "{\"tool_input\":{\"file_path\":\"$PROJDIR/handovers/yotam/status.md\"}}" "")
-assert_rc "T6 handover edit" 0 "$rc"
+# T1: file in a repo on main → BLOCK
+assert_rc "T1 main-repo edit blocks" 2 "$(rc_of "$SANDBOX/mainrepo/src/foo.js")"
 
-# T7: plain primary edit on main should BLOCK (rc=2)
-rc=$(run_case "{\"tool_input\":{\"file_path\":\"$PROJDIR/scripts/foo.sh\"}}" "")
-assert_rc "T7 plain primary edit" 2 "$rc"
+# T2: file in a repo on a feature branch → ALLOW
+assert_rc "T2 feature-repo edit allows" 0 "$(rc_of "$SANDBOX/featrepo/foo.js")"
 
-# T8: outside project should ALLOW (rc=0)
-rc=$(run_case "{\"tool_input\":{\"file_path\":\"/tmp/foo.sh\"}}" "")
-assert_rc "T8 outside project" 0 "$rc"
+# T3 (Himmel#45 regression): nested repo on main, launched from the OUTER repo
+# (on a feature branch). The hook must read the NESTED repo's branch → BLOCK,
+# even though CLAUDE_PROJECT_DIR points at the outer feature-branch dir. The old
+# launch-dir-anchored code returned rc=0 (ALLOW) here — the reported bug.
+assert_rc "T3 nested-on-main under outer-feature blocks (Himmel#45)" 2 \
+    "$(rc_of "$SANDBOX/outer/sc/nested/src/foo.js" CLAUDE_PROJECT_DIR="$SANDBOX/outer")"
 
-# T9: NotebookEdit uses notebook_path
-rc=$(run_case "{\"tool_input\":{\"notebook_path\":\"$PROJDIR/x.ipynb\"}}" "")
-assert_rc "T9 NotebookEdit blocked" 2 "$rc"
+# T3b (inverse): nested repo on a FEATURE branch inside an outer repo on MAIN —
+# must ALLOW. Guards against a regression that re-anchors to a parent/outer repo
+# instead of the launch dir specifically (which would wrongly BLOCK this edit).
+assert_rc "T3b nested-on-feature under outer-main allows" 0 \
+    "$(rc_of "$SANDBOX/outer2/sc/nested/src/foo.js" CLAUDE_PROJECT_DIR="$SANDBOX/outer2")"
 
-# T10: missing file_path should ALLOW silently (rc=0)
-rc=$(run_case '{"tool_input":{}}' "")
-assert_rc "T10 missing file_path" 0 "$rc"
+# T3c (sibling): launched in a feature-branch repo, editing a file in an
+# UNRELATED repo on main → BLOCK. Proves the launch dir is ignored even with no
+# nesting relationship.
+assert_rc "T3c sibling repo on main blocks (launch dir ignored)" 2 \
+    "$(rc_of "$SANDBOX/mainrepo/src/foo.js" CLAUDE_PROJECT_DIR="$SANDBOX/featrepo")"
 
-# --- Cross-canonicaliser coverage (python branch was silently broken
-# in round-2 — `python -c '...' -- "$1"` made sys.argv[1]=="--" instead
-# of the path). Force CANON_FORCE=python3 to exercise the fallback branch
-# end-to-end. Skip if python3 not available on the runner.
-if command -v python3 >/dev/null 2>&1; then
-    rc=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$PROJDIR/.claude/worktrees/../foo.sh\"}}" | CANON_FORCE=python3 CLAUDE_PROJECT_DIR="$PROJDIR" bash "$HOOK" >/dev/null 2>&1; echo "$?")
-    assert_rc "T11 python3 branch — traversal block" 2 "$rc"
-
-    rc=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$PROJDIR/.claude/worktrees/feat+infra-b1-b2/scripts/foo.sh\"}}" | CANON_FORCE=python3 CLAUDE_PROJECT_DIR="$PROJDIR" bash "$HOOK" >/dev/null 2>&1; echo "$?")
-    assert_rc "T12 python3 branch — worktree allow" 0 "$rc"
-
-    rc=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$PROJDIR/scripts/foo.sh\"}}" | CANON_FORCE=python3 CLAUDE_PROJECT_DIR="$PROJDIR" bash "$HOOK" >/dev/null 2>&1; echo "$?")
-    assert_rc "T13 python3 branch — primary block" 2 "$rc"
+# T4: file not inside any git repo → ALLOW
+if [ "$SANDBOX_IN_REPO" -eq 0 ]; then
+    assert_rc "T4 outside any repo allows" 0 "$(rc_of "$SANDBOX/plain/foo.js")"
 else
-    echo "SKIP T11-T13 (no python3 on PATH)"
+    echo "SKIP T4 (SANDBOX inside a repo)"
 fi
 
-# --- Fail-CLOSED coverage. CANON_FORCE to an unknown mode triggers the
-# `*) return 1` arm of canon(), proj_real ends up empty, and the empty-
-# check arm should exit 2 with the actionable message.
-rc=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$PROJDIR/scripts/foo.sh\"}}" | CANON_FORCE=does-not-exist CLAUDE_PROJECT_DIR="$PROJDIR" bash "$HOOK" >/dev/null 2>&1; echo "$?")
-assert_rc "T14 unknown CANON_MODE — fail closed" 2 "$rc"
+# T5: file inside a real git worktree (feature branch) → ALLOW (the worktree's
+# own `.git` file is found by the walk; branch check allows via rc=1).
+assert_rc "T5 worktree (feature branch) edit allows" 0 \
+    "$(rc_of "$SANDBOX/wtrepo/.claude/worktrees/feat+x/src/foo.js")"
 
-# --- Wedged-stub coverage (HIMMEL-249). A python3 that wedges (ignores
-# TERM) must read as a fail-CLOSED block (rc=2 via empty canon output),
-# bounded by the armor — never a hung hook hanging the whole session.
+# T6: handover doc in a main repo → ALLOW (operator may edit docs from primary).
+assert_rc "T6 handover doc on main allows" 0 "$(rc_of "$SANDBOX/mainrepo/handovers/status.md")"
+
+# T7: new file in a not-yet-existing nested dir of a main repo → BLOCK
+# (the `.git` walk skips the missing dirs and finds the repo root).
+assert_rc "T7 new file in new subdir on main blocks" 2 "$(rc_of "$SANDBOX/mainrepo/new/deep/foo.js")"
+
+# T7b: same shape but in a FEATURE repo → ALLOW (the walk doesn't over-shoot to a
+# parent; it stops at the feature repo's own .git).
+assert_rc "T7b new file in new subdir on feature allows" 0 "$(rc_of "$SANDBOX/featrepo/new/deep/foo.js")"
+
+# T8: bypass on a main repo → ALLOW, and T8b: with zero stderr.
+assert_rc "T8 bypass allows" 0 "$(rc_of "$SANDBOX/mainrepo/src/foo.js" EDIT_ON_MAIN_OK=1)"
+stderr_bytes=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$SANDBOX/mainrepo/src/foo.js\"}}" \
+    | env EDIT_ON_MAIN_OK=1 bash "$HOOK" 2>&1 >/dev/null | wc -c)
+assert_rc "T8b bypass silent stderr" 0 "$stderr_bytes"
+
+# T9: NotebookEdit uses notebook_path → BLOCK on main.
+rc=$(printf '%s' "{\"tool_input\":{\"notebook_path\":\"$SANDBOX/mainrepo/x.ipynb\"}}" \
+    | bash "$HOOK" >/dev/null 2>&1; echo "$?")
+assert_rc "T9 NotebookEdit on main blocks" 2 "$rc"
+
+# T10: missing file_path → ALLOW silently.
+rc=$(printf '%s' '{"tool_input":{}}' | bash "$HOOK" >/dev/null 2>&1; echo "$?")
+assert_rc "T10 missing file_path allows" 0 "$rc"
+
+# T11: master is protected too → BLOCK.
+assert_rc "T11 master-repo edit blocks" 2 "$(rc_of "$SANDBOX/masterrepo/foo.js")"
+
+# T12: traversal that resolves INTO a main repo → BLOCK (canon applied; `..`
+# cannot escape the worktrees/ prefix into an allow).
+assert_rc "T12 traversal into main repo blocks" 2 \
+    "$(rc_of "$SANDBOX/mainrepo/.claude/worktrees/../foo.sh")"
+
+# T13: traversal that resolves OUT to a non-repo path → ALLOW.
+if [ "$SANDBOX_IN_REPO" -eq 0 ]; then
+    assert_rc "T13 traversal out to non-repo allows" 0 \
+        "$(rc_of "$SANDBOX/mainrepo/../plain/foo.js")"
+else
+    echo "SKIP T13 (SANDBOX inside a repo)"
+fi
+
+# T14: branch-unreadable repo (HEAD removed) → fail CLOSED (rc=2) with the
+# "cannot determine branch" message. The `.git` walk finds the (broken) repo's
+# `.git`, so is_on_main is invoked on it; with HEAD gone, _branch's very first
+# step (`git rev-parse --absolute-git-dir`) returns rc=128 → _branch returns 2 →
+# is_on_main rc=2 → fail closed. Distinct from "not a repo" (T4 → allow). SKIP
+# when SANDBOX is inside a repo: there git's walk-up would escape the broken
+# .git to the enclosing repo and read a real branch (masking the fail-closed).
+if [ "$SANDBOX_IN_REPO" -eq 0 ]; then
+    err=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$SANDBOX/brokenrepo/src/foo.js\"}}" | bash "$HOOK" 2>&1 >/dev/null); rc=$?
+    assert_rc "T14 unreadable branch fails closed" 2 "$rc"
+    case "$err" in
+        *"cannot determine branch"*) echo "PASS T14 refusal message" ;;
+        *) echo "FAIL T14 refusal message — got: $err"; FAILED=$((FAILED + 1)) ;;
+    esac
+else
+    echo "SKIP T14 (SANDBOX inside a repo)"
+fi
+
+# --- Cross-canonicaliser coverage: force the python3 canon branch end-to-end
+# (main → block, feature → allow). Skip if python3 not on the runner.
+if command -v python3 >/dev/null 2>&1; then
+    assert_rc "T15 python3 canon — main blocks" 2 \
+        "$(rc_of "$SANDBOX/mainrepo/src/foo.js" CANON_FORCE=python3)"
+    assert_rc "T15b python3 canon — feature allows" 0 \
+        "$(rc_of "$SANDBOX/featrepo/foo.js" CANON_FORCE=python3)"
+else
+    echo "SKIP T15 (no python3 on PATH)"
+fi
+
+# --- Fail-CLOSED coverage. CANON_FORCE to an unknown mode triggers canon()'s
+# `*) return 1` arm → file_real empty → fail-closed exit 2.
+assert_rc "T16 unknown CANON_MODE — fail closed" 2 \
+    "$(rc_of "$SANDBOX/mainrepo/src/foo.js" CANON_FORCE=does-not-exist)"
+
+# --- Wedged-stub coverage (HIMMEL-249). A python3 that wedges (ignores TERM)
+# must read as a fail-CLOSED block (rc=2 via empty canon output), bounded by the
+# armor — never a hung hook.
 if timeout --version 2>/dev/null | grep -qi coreutils; then
     WEDGE_BIN=$(mktemp -d)
     cat > "$WEDGE_BIN/python3" <<'EOF'
@@ -123,102 +220,54 @@ sleep 30
 EOF
     chmod +x "$WEDGE_BIN/python3"
     start=$(date +%s)
-    rc=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$PROJDIR/scripts/foo.sh\"}}" \
-        | PATH="$WEDGE_BIN:$PATH" PY_ARMOR_TIMEOUT=1 PY_ARMOR_KILL_AFTER=1 \
-          CANON_FORCE=python3 CLAUDE_PROJECT_DIR="$PROJDIR" bash "$HOOK" >/dev/null 2>&1; echo "$?")
+    rc=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$SANDBOX/mainrepo/src/foo.js\"}}" \
+        | env PATH="$WEDGE_BIN:$PATH" PY_ARMOR_TIMEOUT=1 PY_ARMOR_KILL_AFTER=1 \
+          CANON_FORCE=python3 bash "$HOOK" >/dev/null 2>&1; echo "$?")
     elapsed=$(( $(date +%s) - start ))
-    assert_rc "T15 wedged python3 stub fails closed" 2 "$rc"
+    assert_rc "T17 wedged python3 stub fails closed" 2 "$rc"
     if [ "$elapsed" -lt 15 ]; then
-        echo "PASS T15 bounded (${elapsed}s)"
+        echo "PASS T17 bounded (${elapsed}s)"
     else
-        echo "FAIL T15 bounded — took ${elapsed}s"
+        echo "FAIL T17 bounded — took ${elapsed}s"
         FAILED=$((FAILED + 1))
     fi
     rm -rf "$WEDGE_BIN" 2>/dev/null || true
 else
-    echo "SKIP T15 (no GNU coreutils timeout on this runner)"
+    echo "SKIP T17 (no GNU coreutils timeout on this runner)"
 fi
 
-# --- Missing py-armor lib (HIMMEL-249 CR). An unguarded source under
-# set -e would exit rc=1, which PreToolUse does NOT block on — the hook
-# would fail OPEN. Copy the hook into a tree that has guardrails/lib.sh
-# but NO lib/py-armor.sh: it must fail CLOSED (rc=2 + refusal message).
+# --- Missing py-armor lib (HIMMEL-249). An unguarded source under set -e exits
+# rc=1, which PreToolUse does NOT block on — fail OPEN. The guard must fail
+# CLOSED (rc=2 + recognisable message).
 LIBLESS=$(mktemp -d)
 mkdir -p "$LIBLESS/hooks" "$LIBLESS/guardrails"
 cp "$HOOK" "$LIBLESS/hooks/"
 cp "$(dirname "$HOOK")/../guardrails/lib.sh" "$LIBLESS/guardrails/"
-err=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$PROJDIR/scripts/foo.sh\"}}" | CLAUDE_PROJECT_DIR="$PROJDIR" bash "$LIBLESS/hooks/block-edit-on-main.sh" 2>&1 >/dev/null); rc=$?
-assert_rc "T16 missing py-armor lib fails closed" 2 "$rc"
+err=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$SANDBOX/mainrepo/src/foo.js\"}}" | bash "$LIBLESS/hooks/block-edit-on-main.sh" 2>&1 >/dev/null); rc=$?
+assert_rc "T18 missing py-armor lib fails closed" 2 "$rc"
 case "$err" in
-    *"cannot source py-armor.sh"*) echo "PASS T16 refusal message" ;;
-    *) echo "FAIL T16 refusal message — got: $err"; FAILED=$((FAILED + 1)) ;;
+    *"cannot source py-armor.sh"*) echo "PASS T18 refusal message" ;;
+    *) echo "FAIL T18 refusal message — got: $err"; FAILED=$((FAILED + 1)) ;;
 esac
 rm -rf "$LIBLESS" 2>/dev/null || true
 
-# --- Missing guardrails/lib.sh (issue #323). An unguarded source under
-# set -e exits rc=1, which PreToolUse does NOT block on — fail OPEN.
-# The guard must produce rc=2 + a recognisable message (fail CLOSED).
+# --- Missing guardrails/lib.sh. Same fail-CLOSED contract.
 GUARDRAILLESS=$(mktemp -d)
 mkdir -p "$GUARDRAILLESS/hooks" "$GUARDRAILLESS/lib"
 cp "$HOOK" "$GUARDRAILLESS/hooks/"
 cp "$(dirname "$HOOK")/../lib/py-armor.sh" "$GUARDRAILLESS/lib/" 2>/dev/null || true
-err=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$PROJDIR/scripts/foo.sh\"}}" | CLAUDE_PROJECT_DIR="$PROJDIR" bash "$GUARDRAILLESS/hooks/block-edit-on-main.sh" 2>&1 >/dev/null); rc=$?
-assert_rc "T17 missing guardrails lib fails closed" 2 "$rc"
+err=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$SANDBOX/mainrepo/src/foo.js\"}}" | bash "$GUARDRAILLESS/hooks/block-edit-on-main.sh" 2>&1 >/dev/null); rc=$?
+assert_rc "T19 missing guardrails lib fails closed" 2 "$rc"
 case "$err" in
-    *"cannot source guardrails/lib.sh"*) echo "PASS T17 refusal message" ;;
-    *) echo "FAIL T17 refusal message — got: $err"; FAILED=$((FAILED + 1)) ;;
+    *"cannot source guardrails/lib.sh"*) echo "PASS T19 refusal message" ;;
+    *) echo "FAIL T19 refusal message — got: $err"; FAILED=$((FAILED + 1)) ;;
 esac
 rm -rf "$GUARDRAILLESS" 2>/dev/null || true
 
-# --- T18: primary checkout on a FEATURE branch must ALLOW (rc=0) with no
-# stderr (HIMMEL-392). Regression guard for the set -e crash: a bare
-# `is_on_main` call returning rc=1 aborted the script rc=1 with empty stderr
-# BEFORE the rc=1 ALLOW path, surfacing as "hook error: No stderr output" on
-# every primary-checkout feature-branch edit. The existing T7 only ever
-# exercises primary-on-main (see the WARN below), so this path was untested.
-# A throwaway repo on a feature branch isolates the scenario from the runner's
-# own HEAD. T18 (the rc check) is what actually catches the crash — the buggy
-# bare-call version exits rc=1 here. T18b (empty stderr) does NOT discriminate
-# the bug (the set -e abort was silent too); it guards against a FUTURE change
-# that leaks stderr onto the ALLOW path.
-FEATREPO=$(mktemp -d)
-git -C "$FEATREPO" init -q
-git -C "$FEATREPO" symbolic-ref HEAD refs/heads/feat/regress-392
-mkdir -p "$FEATREPO/src"
-rc=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$FEATREPO/src/foo.jsx\"}}" | CLAUDE_PROJECT_DIR="$FEATREPO" bash "$HOOK" >/dev/null 2>&1; echo "$?")
-assert_rc "T18 feature-branch primary edit allows" 0 "$rc"
-stderr_bytes=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$FEATREPO/src/foo.jsx\"}}" | CLAUDE_PROJECT_DIR="$FEATREPO" bash "$HOOK" 2>&1 >/dev/null | wc -c)
-assert_rc "T18b feature-branch primary edit silent stderr" 0 "$stderr_bytes"
-rm -rf "$FEATREPO" 2>/dev/null || true
-
-# --- T19: unreadable branch (is_on_main rc=2) must fail CLOSED (rc=2) with the
-# "cannot determine branch" message (HIMMEL-392 CR). This is the OTHER consumer
-# of the branch_rc plumbing the fix touched — the security-load-bearing arm
-# that exits 2 when the branch can't be read. A git repo with HEAD removed
-# makes _branch's `git rev-parse --absolute-git-dir` reject THIS dir — but git
-# would then walk UP and find an enclosing repo if the runner's TMPDIR sits
-# inside one (a real CI corner case), reading the OUTER HEAD and yielding rc=0/1
-# instead of rc=2. GIT_CEILING_DIRECTORIES=dirname pins the discovery to this
-# dir so rc=2 is deterministic regardless of where mktemp lands.
-RC2REPO=$(mktemp -d)
-git -C "$RC2REPO" init -q
-rm -f "$RC2REPO/.git/HEAD"
-mkdir -p "$RC2REPO/src"
-err=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$RC2REPO/src/foo.jsx\"}}" | GIT_CEILING_DIRECTORIES="$(dirname "$RC2REPO")" CLAUDE_PROJECT_DIR="$RC2REPO" bash "$HOOK" 2>&1 >/dev/null); rc=$?
-assert_rc "T19 unreadable branch fails closed" 2 "$rc"
-case "$err" in
-    *"cannot determine branch"*) echo "PASS T19 refusal message" ;;
-    *) echo "FAIL T19 refusal message — got: $err"; FAILED=$((FAILED + 1)) ;;
-esac
-rm -rf "$RC2REPO" 2>/dev/null || true
-
-# --- T7 env-dep note. T7 only blocks if the runner's primary repo HEAD is
-# actually `main`. Surface a clear SKIP if it isn't, so the test passing
-# on a non-main runner doesn't mask a regression.
-primary_head=$(git -C "$PROJDIR" symbolic-ref --short HEAD 2>/dev/null || echo "")
-if [ "$primary_head" != "main" ]; then
-    echo "WARN T7 — primary HEAD is '$primary_head' (not 'main'); T7 passed via the branch-check short-circuit, NOT the block path. Re-run on a runner with primary on main to exercise it."
-fi
+# Clean up the worktree registration before removing the sandbox (avoids a
+# dangling `git worktree` admin record under SANDBOX/wtrepo).
+git -C "$SANDBOX/wtrepo" worktree remove --force "$SANDBOX/wtrepo/.claude/worktrees/feat+x" 2>/dev/null || true
+rm -rf "$SANDBOX" 2>/dev/null || true
 
 if [ "$FAILED" -gt 0 ]; then
     echo "---"


### PR DESCRIPTION
block-edit-on-main anchored its branch check to CLAUDE_PROJECT_DIR, so launching Claude above a nested repo left it unguarded on main. Resolve the repo from the edited file's own .git ancestor walk; distinguish unreadable-repo (fail closed) from no-repo (allow); add a command -v git check. 28-case suite incl. the #45 regression guard. Fixes #45.