### PR TITLE
fix(rtk): [HIMMEL-399] standalone idempotent reconcile for rtk hook registration

### DIFF
--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -374,6 +374,24 @@ their own fixture spec, `scripts/machine-setup/test-ubuntu-settings-jq.sh`
 (22 asserts, drift-guarded mirrors; the win11.ps1 PowerShell twin is
 manually verified only).
 
+**Standalone reconcile (HIMMEL-399).** The inline swap above only runs
+inside full machine-setup, which invokes `rtk init -g` exactly once. When
+an operator runs `rtk init -g` on its own it can stack duplicate bare
+entries, and the swap by itself never collapses the result (guard + a
+freshly re-added bare entry, swapped again, = two guard entries).
+`scripts/lib/reconcile-rtk-hook.sh <settings-json> <himmel-path>` is the
+on-demand reconcile: swap every bare `rtk hook claude` entry to the guard
+AND collapse to exactly ONE guard entry, idempotently (spec:
+`scripts/hooks/test-reconcile-rtk-hook.sh`, 16 asserts). Reconcile **user
+scope only** — `rtk init -g` is global and the guard is an absolute path,
+so a project-scope copy would only double-fire the hook. Expected
+side effect: rtk identifies its own hook by the `rtk hook claude`
+signature, which the guard wrapper replaces, so `rtk init --show` reports
+`Hook: not found` and rewritten commands print a `[rtk] /!\ No hook
+installed` banner to stderr — benign noise (the guard is installed and rewriting
+works), with no rtk flag to quiet it. Do not "resolve" it by re-running
+`rtk init -g`; that just re-adds the bare entry the reconcile removes.
+
 ### `check-platforms-tested.sh` — pre-push gate (`.pre-commit-config.yaml`)
 
 Not a Claude PreToolUse hook — runs from the pre-commit framework at

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -278,6 +278,8 @@ Specs saved to: `docs/superpowers/specs/YYYY-MM-DD-feature.md`
 **Auto-rewriting:** Requires `rtk init -g` to install the shell hook. Without it, prefix commands manually with `rtk`.
 **Verify:** `rtk gain` — shows token savings analytics.
 **Note:** Name collision risk — `reachingforthejack/rtk` (Rust Type Kit) is a different tool. If `rtk gain` fails, check which binary is installed.
+**Reconcile after a standalone `rtk init -g` (HIMMEL-399):** `rtk init -g` appends a bare `rtk hook claude` entry without checking for an existing one, so running it outside full machine-setup can stack duplicates. himmel swaps that bare entry for the `rtk-hook-guard.sh` wrapper (HIMMEL-241). The full machine-setup scripts run `rtk init -g` once and reconcile inline; for an on-demand reconcile run `bash scripts/lib/reconcile-rtk-hook.sh ~/.claude/settings.json <himmel-path>` — idempotent + duplicate-safe (collapses to exactly one guard entry). Reconcile **user scope only** (`~/.claude/settings.json`): `rtk init -g` is global and the guard is an absolute path, so a project-scope copy would just double-fire the hook.
+**Expected banner noise:** after the guard swap, `rtk init --show` reports `Hook: not found` and every rewritten command prints `[rtk] /!\ No hook installed — run rtk init -g` to stderr. This is benign: rtk detects its hook by its own `rtk hook claude` signature, which the guard wrapper replaces by design. The guard IS installed and rewriting works; rtk exposes no flag/config to quiet the banner (an upstream limitation). Not a real missing-hook signal — do not "fix" it by re-running `rtk init -g` (that just re-adds the bare entry).
 
 ---
 

--- a/scripts/hooks/test-reconcile-rtk-hook.sh
+++ b/scripts/hooks/test-reconcile-rtk-hook.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# test-reconcile-rtk-hook.sh — smoke test for
+# scripts/lib/reconcile-rtk-hook.sh (HIMMEL-399).
+#
+# The standalone "reconcile now" path: after an operator runs `rtk init -g`
+# OUTSIDE full machine-setup (which appends a bare `rtk hook claude`
+# PreToolUse entry without checking for an existing one), this helper makes
+# the rtk hook registration idempotent + duplicate-safe — swap every bare
+# entry to the rtk-hook-guard wrapper AND collapse the result to EXACTLY ONE
+# guard entry, with re-runs a no-op.
+#
+# bash 3.2-safe (no mapfile / associative arrays). Requires jq.
+#
+# Covers:
+#   1.  Fresh: one bare `rtk hook claude` → exactly ONE guard entry, zero bare.
+#   2.  Idempotency: re-running case 1 changes nothing (no-op, rc 0).
+#   3.  Guard + bare coexist (HIMMEL-264 leftover) → collapse to ONE guard.
+#   4.  Two bare entries (rtk init -g run twice) → ONE guard.
+#   5.  Two guard entries already present → collapse to ONE.
+#   6.  Unrelated PreToolUse hooks + sibling keys preserved.
+#   7.  Missing settings file → no-op, rc 0, file NOT created.
+#   8.  Invalid JSON → refuse (rc 1), file left byte-for-byte unchanged.
+#   9.  No rtk entry at all → no-op, rc 0, unchanged.
+#   10. Empty / whitespace-only file → no-op, rc 0 (nothing to reconcile).
+#   11. Scope isolation: reconciling one settings file never touches another
+#       (the "no cross-scope dup" guarantee is per-file — user vs project are
+#       reconciled independently).
+#   12. No hooks.PreToolUse key → byte-for-byte unchanged (no spurious []).
+#   13. Two guards in the SAME hooks array → collapse (intra-array branch).
+#   14. Bare entry beside a non-rtk hook → matcher + sibling preserved.
+
+set -uo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "FAIL: jq not on PATH — required by these fixtures" >&2
+    exit 1
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+helper="$repo_root/scripts/lib/reconcile-rtk-hook.sh"
+HIMMEL='/opt/himmel'
+GUARD="bash \"$HIMMEL/scripts/hooks/rtk-hook-guard.sh\""
+
+[ -f "$helper" ] || { echo "FAIL: $helper not found" >&2; exit 1; }
+
+pass=0
+fail=0
+assert_pass() { pass=$((pass + 1)); echo "  PASS: $1"; }
+assert_fail() { fail=$((fail + 1)); echo "  FAIL: $1"; }
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# guard_count <file>  — number of PreToolUse hook objects pointing at the guard
+guard_count() {
+    jq '[.hooks.PreToolUse[]?.hooks[]? | select((.command // "") | contains("rtk-hook-guard.sh"))] | length' "$1"
+}
+# bare_count <file>  — number of PreToolUse hook objects still bare `rtk hook claude`
+bare_count() {
+    jq '[.hooks.PreToolUse[]?.hooks[]?
+         | select((.command // "") | test("^[[:space:]]*rtk[[:space:]]+hook[[:space:]]+claude([[:space:]]|$)"))]
+        | length' "$1"
+}
+reconcile() { bash "$helper" "$1" "$HIMMEL" >/dev/null 2>&1; }
+
+# ---------- 1. Fresh: one bare entry → one guard ----------
+echo "Test 1: a single bare 'rtk hook claude' becomes one guard entry"
+f="$work/fresh.json"
+jq -n '{hooks:{PreToolUse:[{matcher:"Bash",hooks:[{type:"command",command:"rtk hook claude"}]}]}}' > "$f"
+reconcile "$f"
+if [ "$(guard_count "$f")" -eq 1 ] && [ "$(bare_count "$f")" -eq 0 ]; then
+    assert_pass "1 guard, 0 bare after reconcile"
+else
+    assert_fail "expected 1 guard / 0 bare, got guard=$(guard_count "$f") bare=$(bare_count "$f")"
+fi
+
+# ---------- 2. Idempotency ----------
+echo "Test 2: re-running on an already-reconciled file is a no-op"
+before=$(jq -S . "$f")
+reconcile "$f"
+after=$(jq -S . "$f")
+if [ "$before" = "$after" ] && [ "$(guard_count "$f")" -eq 1 ]; then
+    assert_pass "second run left the document unchanged (still 1 guard)"
+else
+    assert_fail "re-run changed the document or count drifted (guard=$(guard_count "$f"))"
+fi
+
+# ---------- 3. Guard + bare coexist → collapse to one ----------
+echo "Test 3: a guard entry next to a bare entry collapses to ONE guard"
+f="$work/mixed.json"
+jq -n --arg g "$GUARD" '{hooks:{PreToolUse:[
+    {matcher:"Bash",hooks:[{type:"command",command:$g}]},
+    {matcher:"Bash",hooks:[{type:"command",command:"rtk hook claude"}]}
+]}}' > "$f"
+reconcile "$f"
+if [ "$(guard_count "$f")" -eq 1 ] && [ "$(bare_count "$f")" -eq 0 ]; then
+    assert_pass "collapsed to exactly 1 guard (bare swapped, dup dropped)"
+else
+    assert_fail "expected 1 guard / 0 bare, got guard=$(guard_count "$f") bare=$(bare_count "$f")"
+fi
+
+# ---------- 4. Two bare entries (rtk init -g twice) → one guard ----------
+echo "Test 4: two bare entries collapse to ONE guard"
+f="$work/twobare.json"
+jq -n '{hooks:{PreToolUse:[
+    {matcher:"Bash",hooks:[{type:"command",command:"rtk hook claude"}]},
+    {matcher:"Bash",hooks:[{type:"command",command:"rtk hook claude --foo"}]}
+]}}' > "$f"
+reconcile "$f"
+if [ "$(guard_count "$f")" -eq 1 ] && [ "$(bare_count "$f")" -eq 0 ]; then
+    assert_pass "two bare entries → 1 guard"
+else
+    assert_fail "expected 1 guard / 0 bare, got guard=$(guard_count "$f") bare=$(bare_count "$f")"
+fi
+
+# ---------- 5. Two guard entries already → collapse ----------
+echo "Test 5: two pre-existing guard entries collapse to ONE"
+f="$work/twoguard.json"
+jq -n --arg g "$GUARD" '{hooks:{PreToolUse:[
+    {matcher:"Bash",hooks:[{type:"command",command:$g}]},
+    {matcher:"Bash",hooks:[{type:"command",command:$g}]}
+]}}' > "$f"
+reconcile "$f"
+if [ "$(guard_count "$f")" -eq 1 ]; then
+    assert_pass "two guards → 1 guard"
+else
+    assert_fail "expected 1 guard, got $(guard_count "$f")"
+fi
+
+# ---------- 6. Unrelated hooks + sibling keys preserved ----------
+echo "Test 6: unrelated PreToolUse hooks and sibling keys survive"
+f="$work/preserve.json"
+jq -n '{hooks:{PreToolUse:[
+    {matcher:"*",hooks:[{type:"command",command:"bash /x/auto-arm-on-cap.sh"}]},
+    {matcher:"Bash",hooks:[{type:"command",command:"rtk hook claude"}]}
+]},theme:"dark"}' > "$f"
+reconcile "$f"
+if jq -e '.theme == "dark"
+          and ([.hooks.PreToolUse[]?.hooks[]?.command] | any(. == "bash /x/auto-arm-on-cap.sh"))' "$f" >/dev/null \
+   && [ "$(guard_count "$f")" -eq 1 ]; then
+    assert_pass "auto-arm hook + theme preserved, 1 guard added"
+else
+    assert_fail "unrelated content disturbed: $(jq -c . "$f")"
+fi
+
+# ---------- 7. Missing file → no-op, not created ----------
+echo "Test 7: missing settings file → no-op, file not created"
+f="$work/does-not-exist.json"
+if reconcile "$f" && [ ! -e "$f" ]; then
+    assert_pass "missing file tolerated, not created"
+else
+    assert_fail "missing-file path either errored or created the file"
+fi
+
+# ---------- 8. Invalid JSON → refuse, unchanged ----------
+echo "Test 8: invalid JSON → refuse (rc 1), file unchanged"
+f="$work/broken.json"
+printf '{not valid json' > "$f"
+orig=$(cat "$f")
+set +e
+reconcile "$f"
+rc=$?
+if [ "$rc" -ne 0 ] && [ "$(cat "$f")" = "$orig" ]; then
+    assert_pass "refused invalid JSON, left file byte-for-byte"
+else
+    assert_fail "expected rc!=0 and unchanged file, got rc=$rc"
+fi
+
+# ---------- 9. No rtk entry → no-op ----------
+echo "Test 9: settings with no rtk entry → no-op, rc 0, unchanged"
+f="$work/nortk.json"
+jq -n '{hooks:{PreToolUse:[{matcher:"*",hooks:[{type:"command",command:"bash /x/other.sh"}]}]}}' > "$f"
+before=$(jq -S . "$f")
+reconcile "$f"
+if [ "$before" = "$(jq -S . "$f")" ] && [ "$(guard_count "$f")" -eq 0 ]; then
+    assert_pass "no rtk entry → unchanged, no guard injected"
+else
+    assert_fail "no-rtk file was modified: $(jq -c . "$f")"
+fi
+
+# ---------- 10. Empty / whitespace-only file → no-op ----------
+echo "Test 10: empty file → no-op, rc 0"
+f="$work/empty.json"
+printf '   \n' > "$f"
+set +e
+reconcile "$f"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    assert_pass "empty file tolerated (nothing to reconcile)"
+else
+    assert_fail "expected rc 0 on empty file, got rc=$rc"
+fi
+
+# ---------- 11. Scope isolation ----------
+echo "Test 11: reconciling one file never touches another (per-scope)"
+user="$work/user.json"
+proj="$work/project.json"
+jq -n '{hooks:{PreToolUse:[{matcher:"Bash",hooks:[{type:"command",command:"rtk hook claude"}]}]}}' > "$user"
+jq -n '{hooks:{PreToolUse:[{matcher:"Bash",hooks:[{type:"command",command:"bash /x/proj.sh"}]}]}}' > "$proj"
+proj_before=$(jq -S . "$proj")
+reconcile "$user"
+if [ "$(guard_count "$user")" -eq 1 ] && [ "$proj_before" = "$(jq -S . "$proj")" ]; then
+    assert_pass "user reconciled to 1 guard; project file untouched"
+else
+    assert_fail "scope isolation broken: project changed or user count wrong"
+fi
+
+# ---------- 12. No PreToolUse key at all → byte-for-byte unchanged ----------
+# Regression: the DEDUP assignment must not inject a spurious "PreToolUse": []
+# into a settings file that has none (non-destructive / no-op contract).
+echo "Test 12: settings with no hooks.PreToolUse stays byte-for-byte"
+for fixture in '{"theme":"dark"}' '{"hooks":{}}' \
+    '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"rtk hook claude"}]}]}}'; do
+    f="$work/noptu.json"
+    printf '%s' "$fixture" > "$f"
+    orig=$(cat "$f")
+    reconcile "$f"
+    if [ "$(cat "$f")" = "$orig" ]; then
+        assert_pass "unchanged: $fixture"
+    else
+        assert_fail "spurious mutation of '$fixture' → $(cat "$f")"
+    fi
+done
+
+# ---------- 13. Two guard entries in the SAME hooks array → collapse ----------
+# Exercises the intra-array dedup branch (the across-group case is Test 5).
+echo "Test 13: two guards inside one group's hooks array collapse to ONE"
+f="$work/samegroup.json"
+jq -n --arg g "$GUARD" '{hooks:{PreToolUse:[
+    {matcher:"Bash",hooks:[{type:"command",command:$g},{type:"command",command:$g}]}
+]}}' > "$f"
+reconcile "$f"
+if [ "$(guard_count "$f")" -eq 1 ]; then
+    assert_pass "intra-array duplicate guard collapsed to 1"
+else
+    assert_fail "expected 1 guard, got $(guard_count "$f")"
+fi
+
+# ---------- 14. matcher + sibling hook preserved when bare swapped in place ----------
+echo "Test 14: a bare entry beside a non-rtk hook keeps matcher + sibling"
+f="$work/matcher.json"
+jq -n '{hooks:{PreToolUse:[
+    {matcher:"Bash",hooks:[
+        {type:"command",command:"rtk hook claude"},
+        {type:"command",command:"bash /x/sibling.sh"}
+    ]}
+]}}' > "$f"
+reconcile "$f"
+if [ "$(guard_count "$f")" -eq 1 ] \
+   && jq -e '.hooks.PreToolUse[0].matcher == "Bash"
+             and ([.hooks.PreToolUse[]?.hooks[]?.command] | any(. == "bash /x/sibling.sh"))' "$f" >/dev/null; then
+    assert_pass "matcher 'Bash' + sibling hook preserved, 1 guard"
+else
+    assert_fail "matcher/sibling not preserved: $(jq -c . "$f")"
+fi
+
+# ---------- summary ----------
+echo ""
+echo "reconcile-rtk-hook: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/lib/reconcile-rtk-hook.sh
+++ b/scripts/lib/reconcile-rtk-hook.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# reconcile-rtk-hook.sh — standalone "reconcile now" path for the rtk
+# PreToolUse hook in a Claude Code settings.json (HIMMEL-399).
+#
+# WHY this exists separately from machine-setup:
+#   `rtk init -g` (the external rtk tool, rtk-ai/rtk) appends a bare
+#   `rtk hook claude` PreToolUse(Bash) entry to ~/.claude/settings.json
+#   WITHOUT checking for an existing one — so running it twice stacks two
+#   entries. himmel swaps that bare entry for the rtk-hook-guard.sh wrapper
+#   (HIMMEL-241, the compound-find fix), but the swap by itself never
+#   COLLAPSES the result: a guard entry plus a freshly re-added bare entry,
+#   swapped again, yields two guard entries. The full machine-setup scripts
+#   (ubuntu.sh / win11.ps1) run `rtk init -g` exactly once so they never hit
+#   this; the gap is when an operator runs `rtk init -g` on its own, OUTSIDE
+#   machine-setup. This helper is the on-demand reconcile for that case.
+#
+# CONTRACT: after this runs, the settings file holds EXACTLY ONE PreToolUse
+#   hook object pointing at rtk-hook-guard.sh. It is idempotent (a second run
+#   is a no-op) and duplicate-safe across every starting shape — fresh bare,
+#   guard+bare leftover, N bare, N guard.
+#
+# SCOPE: operates on the ONE settings.json passed as $1. The rtk guard belongs
+#   at USER scope only (~/.claude/settings.json): `rtk init -g` is global and
+#   the guard is referenced by an absolute himmel path, so a project-scope copy
+#   would only make the hook fire twice. Reconcile the user file; do not
+#   register the guard at project scope. "No cross-scope dup" is therefore a
+#   per-file guarantee — this helper never reaches outside its argument.
+#
+# Idempotent, atomic (temp + mv), non-destructive (all other keys/hooks
+# preserved). Refuses to touch a non-JSON file. A missing/empty file means rtk
+# registered nothing yet → no-op (run `rtk init -g` first). Requires jq.
+#
+# Usage:
+#   bash reconcile-rtk-hook.sh <settings-json-path> <himmel-path>
+set -uo pipefail
+
+# Bare `rtk hook claude` (extra flags included) — mirrors the BARE_RTK_RE in
+# scripts/machine-setup/ubuntu.sh so the standalone path and the in-setup swap
+# agree on what counts as a raw rtk entry.
+BARE_RTK_RE='^[[:space:]]*rtk[[:space:]]+hook[[:space:]]+claude([[:space:]]|$)'
+
+reconcile_rtk_hook() {
+  local settings="$1" himmel="$2"
+  command -v jq >/dev/null 2>&1 || { echo "reconcile-rtk-hook: jq required" >&2; return 1; }
+
+  # Missing or empty file → rtk has registered nothing to reconcile. Do NOT
+  # create it (this helper reconciles an existing rtk registration; it does not
+  # bootstrap one — that is `rtk init -g`'s job).
+  if [ ! -s "$settings" ] || [ -z "$(tr -d '[:space:]' < "$settings")" ]; then
+    echo "  reconcile-rtk-hook: no rtk hook to reconcile in $settings (run 'rtk init -g' first)."
+    return 0
+  fi
+  if ! jq -e . "$settings" >/dev/null 2>&1; then
+    echo "reconcile-rtk-hook: $settings is not valid JSON — refusing to modify" >&2
+    return 1
+  fi
+
+  # Forward-slash the himmel path so `bash "..."` is valid even from a Windows
+  # backslash path (Git Bash tolerates /c/...), matching wire-statusline.sh.
+  local himmel_fwd="${himmel//\\//}"
+  local guard="bash \"${himmel_fwd}/scripts/hooks/rtk-hook-guard.sh\""
+
+  local before after
+  before=$(jq -S . "$settings")
+
+  # Two-stage transform:
+  #   1. SWAP — every bare `rtk hook claude` hook object's command becomes the
+  #      guard command (mirrors ubuntu.sh's inline swap filter, line ~548).
+  #   2. DEDUP — keep only the FIRST guard hook object in document order; drop
+  #      every later guard hook object, then prune any group whose hooks array
+  #      went empty. Non-guard hooks and group fields (matcher, …) are untouched.
+  # The DEDUP assignment is gated on `.hooks.PreToolUse` already existing so a
+  # settings file that has no PreToolUse key is left byte-for-byte (no spurious
+  # `PreToolUse: []` injected) — matching ubuntu.sh's "skip when absent" and the
+  # non-destructive contract above.
+  after=$(jq --arg re "$BARE_RTK_RE" --arg guard "$guard" '
+    (.hooks.PreToolUse[]?.hooks[]? | select((.command // "") | test($re))).command = $guard
+    | if ((.hooks? // {}) | has("PreToolUse")) then
+        .hooks.PreToolUse |= (
+          reduce .[] as $g ({out: [], seen: false};
+            ( reduce ($g.hooks // [])[] as $h ({hooks: [], seen: .seen};
+                if (($h.command // "") | contains("rtk-hook-guard.sh"))
+                then (if .seen then . else {hooks: (.hooks + [$h]), seen: true} end)
+                else {hooks: (.hooks + [$h]), seen: .seen}
+                end)
+            ) as $r
+            | {out: (.out + [$g + {hooks: $r.hooks}]), seen: $r.seen})
+          | .out
+          | map(select(((.hooks // []) | length) > 0))
+        )
+      else . end
+  ' "$settings") || { echo "reconcile-rtk-hook: jq transform failed — $settings unchanged" >&2; return 1; }
+
+  if [ "$(printf '%s' "$after" | jq -S .)" = "$before" ]; then
+    echo "  reconcile-rtk-hook: already reconciled (1 guard entry) — no change."
+    return 0
+  fi
+
+  # Gate the success report on the write actually landing — a failed printf/mv
+  # (read-only dir, disk full) must not report success, and must not orphan the
+  # temp file next to the user's settings.
+  if printf '%s\n' "$after" > "$settings.rtk-reconcile.tmp" \
+     && mv "$settings.rtk-reconcile.tmp" "$settings"; then
+    echo "  reconcile-rtk-hook: reconciled $settings → exactly one rtk-hook-guard entry."
+  else
+    rm -f "$settings.rtk-reconcile.tmp"
+    echo "reconcile-rtk-hook: failed to write $settings — left unchanged" >&2
+    return 1
+  fi
+}
+
+# Allow both `source reconcile-rtk-hook.sh` and direct invocation.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  if [ "$#" -ne 2 ]; then
+    echo "usage: reconcile-rtk-hook.sh <settings-json-path> <himmel-path>" >&2
+    exit 2
+  fi
+  reconcile_rtk_hook "$1" "$2"
+fi


### PR DESCRIPTION
## HIMMEL-399 — rtk install: idempotent + duplicate-safe hook registration

### Problem
`rtk init -g` appends a bare `rtk hook claude` PreToolUse entry to
`~/.claude/settings.json` without checking for an existing one, so running it
outside full machine-setup can stack duplicates. himmel swaps that bare entry
for the `rtk-hook-guard.sh` wrapper (HIMMEL-241), but the swap alone never
collapses the result — a guard entry plus a re-added bare entry, swapped again,
yields two guard entries. The machine-setup scripts run `rtk init -g` once and
reconcile inline (HIMMEL-264); the gap was a standalone reconcile for an
on-demand `rtk init -g`.

### Change
- `scripts/lib/reconcile-rtk-hook.sh` (new) — swap every bare `rtk hook claude`
  → guard wrapper AND collapse to exactly ONE guard entry (jq SWAP + `reduce`
  dedup). Idempotent, atomic, refuses non-JSON, no-op on missing/empty/no-rtk
  files. User scope only (global + absolute-path guard → project scope would
  double-fire).
- `scripts/hooks/test-reconcile-rtk-hook.sh` (new) — 16 asserts, bash 3.2-safe.
- docs — reconcile path, user-scope decision, expected benign `[rtk] No hook
  installed` banner.

### Verification
- reconcile suite 16/16, guard suite 25/25, shellcheck clean.
