### PR TITLE
Propagate: HIMMEL-418 trust-write race + HIMMEL-389 vault upgrade (Phase 0+1)

### DIFF
--- a/scripts/lib/ensure-workspace-trust.sh
+++ b/scripts/lib/ensure-workspace-trust.sh
@@ -15,12 +15,21 @@
 #
 # Config path: $WORKSPACE_TRUST_CONFIG, else $HOME/.claude.json.
 #
+# Concurrency (HIMMEL-418): the read-modify-write commits via write-to-temp +
+# atomic rename, so a coincident reader/writer never sees a half-written file.
+# A small randomized jitter (TRUST_WRITE_JITTER_MS, default 500, 0 disables)
+# runs before the read to de-synchronize two launches that fire within ~1s,
+# reducing the residual lost-update race (both read the old file, last write
+# wins, one trust entry lost) that minute-granularity collision checks miss.
+#
 # Exit codes:
 #   0  flag is set (already-true is a no-op that also exits 0)
 #   2  bad usage / dir does not exist / node missing
 #   3  config exists but is unreadable, not parseable JSON, or not a JSON
 #      object — REFUSES to overwrite (never clobber Claude's state on a
 #      transient read or parse error)
+#   4  the temp write or atomic rename failed — warns, leaves any existing
+#      config untouched (rename never happened), and orphans no temp file
 #
 # Callers MUST treat a non-zero exit as NON-FATAL (warn, then continue): a
 # trust pre-seed problem must never block an arm. The exit codes exist so
@@ -57,6 +66,16 @@ fi
 
 config="${WORKSPACE_TRUST_CONFIG:-$HOME/.claude.json}"
 
+# HIMMEL-418: jitter the read-modify-write so two launches within ~1s don't
+# read the same old file and lose one update (atomic rename below already
+# prevents corruption; this addresses the residual lost-update race). Default
+# 500ms cap; 0 disables (test seam). Git Bash `sleep` accepts fractional secs.
+jitter_ms="${TRUST_WRITE_JITTER_MS:-500}"
+if [ "$jitter_ms" -gt 0 ] 2>/dev/null; then
+    ms=$(( RANDOM % (jitter_ms + 1) ))          # 0..jitter_ms milliseconds
+    sleep "$(printf '%d.%03d' "$(( ms / 1000 ))" "$(( ms % 1000 ))")" 2>/dev/null || true
+fi
+
 # node does the read-modify-write: tolerant of a missing file (fresh create),
 # strict on a present-but-unparseable file (refuse to clobber), atomic via
 # write-to-temp + rename. Key/config passed by env to avoid all shell quoting.
@@ -90,6 +109,14 @@ if (!j.projects[key] || typeof j.projects[key] !== "object" || Array.isArray(j.p
 if (j.projects[key].hasTrustDialogAccepted === true) process.exit(0);
 j.projects[key].hasTrustDialogAccepted = true;
 const tmp = p + ".tmp-trust-" + process.pid;
-fs.writeFileSync(tmp, JSON.stringify(j, null, 2));
-fs.renameSync(tmp, p);
+try {
+    fs.writeFileSync(tmp, JSON.stringify(j, null, 2));
+    fs.renameSync(tmp, p);
+} catch (e) {
+    // Fail-open (HIMMEL-386/418): warn, leave any existing config untouched
+    // (the rename is the commit point and never ran), orphan no temp file.
+    try { fs.unlinkSync(tmp); } catch (_) {}
+    console.error("ensure-workspace-trust: could not write " + p + ": " + e.message);
+    process.exit(4);
+}
 '

--- a/scripts/lib/test-ensure-workspace-trust.sh
+++ b/scripts/lib/test-ensure-workspace-trust.sh
@@ -94,5 +94,56 @@ assert_eq "T6 missing-dir rc" "2" "$rc"
 WORKSPACE_TRUST_CONFIG="$TMP/x.json" bash "$HELPER" 2>/dev/null; rc=$?
 assert_eq "T7 no-arg rc" "2" "$rc"
 
+# --- HIMMEL-418: atomic-write hardening + launch-race jitter ---
+
+# T8: a successful write leaves NO temp file behind (renamed away, not orphaned).
+CFG="$TMP/notmp.json"
+WORKSPACE_TRUST_CONFIG="$CFG" bash "$HELPER" "$WORKDIR" >/dev/null; rc=$?
+leftover=$(find "$TMP" -maxdepth 1 -name 'notmp.json.tmp-trust-*' | wc -l | tr -d ' ')
+assert_eq "T8 success rc" "0" "$rc"
+assert_eq "T8 no temp file orphaned" "0" "$leftover"
+
+# T9: jitter seam is named in the helper and disabled cleanly with =0 (functional).
+grep -q 'TRUST_WRITE_JITTER_MS' "$HELPER"; assert_eq "T9 jitter env seam present" "0" "$?"
+CFG="$TMP/jit0.json"
+TRUST_WRITE_JITTER_MS=0 WORKSPACE_TRUST_CONFIG="$CFG" bash "$HELPER" "$WORKDIR"; rc=$?
+assert_eq "T9 jitter=0 rc" "0" "$rc"
+assert_eq "T9 jitter=0 sets flag" "true" "$(read_flag "$CFG" "$KEY")"
+
+# T10: jitter is bounded in MILLISECONDS, not seconds (catch a units bug). A
+# 900ms cap must complete well under 5s even with node startup; a `sleep 900`
+# (seconds) units bug would blow past it.
+CFG="$TMP/jitbound.json"
+start=$(date +%s%3N)
+TRUST_WRITE_JITTER_MS=900 WORKSPACE_TRUST_CONFIG="$CFG" bash "$HELPER" "$WORKDIR" >/dev/null; rc=$?
+end=$(date +%s%3N)
+elapsed=$(( end - start ))
+assert_eq "T10 jitter-bound rc" "0" "$rc"
+if [ "$elapsed" -lt 5000 ]; then echo "PASS T10 jitter bounded in ms (${elapsed}ms)"; else echo "FAIL T10 jitter bounded in ms — took ${elapsed}ms (units bug?)"; FAILED=$((FAILED + 1)); fi
+
+# T11: write failure (config parent dir missing) → fail-open: clean warning on
+# stderr, non-fatal non-zero rc, NO orphaned temp file. Read returns ENOENT
+# (treated as fresh {}), then the temp write under the missing parent fails.
+CFG="$TMP/ghost/sub.json"   # $TMP/ghost does not exist
+err=$(TRUST_WRITE_JITTER_MS=0 WORKSPACE_TRUST_CONFIG="$CFG" bash "$HELPER" "$WORKDIR" 2>&1 >/dev/null); rc=$?
+assert_eq "T11 write-failure rc (documented exit 4)" "4" "$rc"
+case "$err" in
+  *ensure-workspace-trust:*) echo "PASS T11 write-failure warns on stderr" ;;
+  *) echo "FAIL T11 write-failure warns on stderr — got '$err'"; FAILED=$((FAILED + 1)) ;;
+esac
+leftover=$(find "$TMP" -name 'sub.json.tmp-trust-*' 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "T11 no temp file orphaned on failure" "0" "$leftover"
+
+# T12 (best-effort): two coincident calls against the same config never corrupt
+# it. Atomic rename guarantees the file is ALWAYS valid JSON; both-entries is a
+# probabilistic property (jitter reduces lost-update) and is NOT asserted here.
+CFG="$TMP/race.json"; printf '%s\n' '{"projects":{}}' > "$CFG"
+DIRA="$TMP/ra"; DIRB="$TMP/rb"; mkdir -p "$DIRA" "$DIRB"
+WORKSPACE_TRUST_CONFIG="$CFG" bash "$HELPER" "$DIRA" >/dev/null 2>&1 &
+WORKSPACE_TRUST_CONFIG="$CFG" bash "$HELPER" "$DIRB" >/dev/null 2>&1 &
+wait
+valid=$(F="$CFG" node -e 'try{const j=JSON.parse(require("fs").readFileSync(process.env.F,"utf8"));process.stdout.write(j&&typeof j.projects==="object"?"ok":"bad")}catch(e){process.stdout.write("bad")}')
+assert_eq "T12 concurrent writes never corrupt the file" "ok" "$valid"
+
 echo
 if [ "$FAILED" -eq 0 ]; then echo "All ensure-workspace-trust tests passed."; else echo "$FAILED test(s) failed."; exit 1; fi

--- a/templates/luna-second-brain/.gitignore
+++ b/templates/luna-second-brain/.gitignore
@@ -33,3 +33,11 @@ __pycache__/
 
 # Handover scratch state
 .last-consolidate.json
+
+# Vault-template upgrade state (HIMMEL-389). The version stamp (.vault-template.json)
+# IS tracked — it travels with the vault. These are upgrade-managed scratch:
+# the 3-way-merge base snapshot, an unresolved _CLAUDE.md conflict sidecar, and
+# any temp left by an interrupted atomic write.
+.vault-template.base/
+*.template-merge
+*.upgrade-tmp.*

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,0 +1,5 @@
+{
+  "template": "luna-second-brain",
+  "version": "0.1.0",
+  "upgraded_at": "2026-06-19T00:00:00Z"
+}

--- a/templates/luna-second-brain/scripts/test-upgrade.ps1
+++ b/templates/luna-second-brain/scripts/test-upgrade.ps1
@@ -1,0 +1,51 @@
+<#
+  Smoke test for upgrade.ps1 (HIMMEL-389) — verifies the PowerShell twin locates
+  Git Bash and delegates to upgrade.sh: a --dry-run mutates nothing, and a --yes
+  run applies the engine's overwrite policy. The exhaustive per-file behavior is
+  covered by test-upgrade.sh; this only proves the twin wires through correctly.
+  Run: pwsh scripts/test-upgrade.ps1
+#>
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ps1  = Join-Path $here 'upgrade.ps1'
+$failed = 0
+function Assert([string]$label, [bool]$cond, [string]$detail = '') {
+    if ($cond) { Write-Host "PASS $label" }
+    else { Write-Host "FAIL $label $detail"; $script:failed++ }
+}
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("upgps-" + [System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+try {
+    $T = Join-Path $tmp 'tmpl'; $V = Join-Path $tmp 'vault'
+    New-Item -ItemType Directory -Force -Path (Join-Path $T 'marketplace\.claude-plugin') | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $T 'scripts\hooks') | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $V 'scripts\hooks') | Out-Null
+    Set-Content -NoNewline -Path (Join-Path $T 'marketplace\.claude-plugin\marketplace.json') -Value '{"metadata":{"version":"1.0.0"}}'
+    Set-Content -NoNewline -Path (Join-Path $T 'scripts\hooks\check-commit-msg.sh') -Value "TEMPLATE-VERSION`n"
+    Set-Content -NoNewline -Path (Join-Path $T '_CLAUDE.md') -Value "# Manual`n"
+    Set-Content -NoNewline -Path (Join-Path $V '.vault-template.json') -Value '{"template":"luna-second-brain","version":"0.9.0","upgraded_at":"2026-01-01T00:00:00Z"}'
+    Set-Content -NoNewline -Path (Join-Path $V 'scripts\hooks\check-commit-msg.sh') -Value "STALE`n"
+
+    $hook = Join-Path $V 'scripts\hooks\check-commit-msg.sh'
+    $before = (Get-FileHash $hook -Algorithm SHA256).Hash
+
+    # Dry-run: exit 0, prints the banner, mutates nothing.
+    $out = & pwsh -NoProfile -File $ps1 --template-dir $T --vault-dir $V --dry-run 2>&1 | Out-String
+    Assert 'dry-run exit 0' ($LASTEXITCODE -eq 0) "rc=$LASTEXITCODE"
+    Assert 'dry-run prints upgrade banner' ($out -match 'luna-second-brain upgrade') "out=$out"
+    Assert 'dry-run mutates nothing' ((Get-FileHash $hook -Algorithm SHA256).Hash -eq $before)
+
+    # Apply: the diverged hook is restored to the template version.
+    & pwsh -NoProfile -File $ps1 --template-dir $T --vault-dir $V --yes *> $null
+    Assert 'apply exit 0' ($LASTEXITCODE -eq 0) "rc=$LASTEXITCODE"
+    $tmplHash = (Get-FileHash (Join-Path $T 'scripts\hooks\check-commit-msg.sh') -Algorithm SHA256).Hash
+    Assert 'apply restores hook to template' ((Get-FileHash $hook -Algorithm SHA256).Hash -eq $tmplHash)
+}
+finally {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+if ($failed -eq 0) { Write-Host 'All upgrade.ps1 smoke tests passed.' }
+else { Write-Host "$failed test(s) failed."; exit 1 }

--- a/templates/luna-second-brain/scripts/test-upgrade.sh
+++ b/templates/luna-second-brain/scripts/test-upgrade.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Tests for templates/luna-second-brain/scripts/upgrade.sh (HIMMEL-389).
+# Content-preserving vault/template upgrade. Each case builds a throwaway
+# template + vault fixture under a temp dir and runs upgrade.sh against them
+# with explicit --template-dir / --vault-dir so nothing touches a real vault.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+UPGRADE="$HERE/upgrade.sh"
+
+FAILED=0
+pass() { echo "PASS $1"; }
+fail() { echo "FAIL $1 — $2"; FAILED=$((FAILED + 1)); }
+assert_eq() { if [ "$2" = "$3" ]; then pass "$1"; else fail "$1" "expected '$2', got '$3'"; fi; }
+
+command -v node >/dev/null 2>&1 || { echo "SKIP all — node not on PATH"; exit 0; }
+command -v python3 >/dev/null 2>&1 || { echo "SKIP all — python3 not on PATH"; exit 0; }
+command -v git >/dev/null 2>&1 || { echo "SKIP all — git not on PATH"; exit 0; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+sha_of() { if [ -f "$1" ]; then sha256sum "$1" | cut -d' ' -f1; else echo MISSING; fi; }
+
+# Build a minimal but representative template fixture at $1 with version $2.
+make_template() {
+    local d="$1" ver="$2"
+    mkdir -p "$d/marketplace/.claude-plugin" "$d/scripts/hooks" "$d/.obsidian/plugins/calendar" "$d/_Templates" "$d/docs" "$d/50-Journal"
+    printf '{"metadata":{"version":"%s"}}\n' "$ver" > "$d/marketplace/.claude-plugin/marketplace.json"
+    printf '# Operating Manual\n\nline-a\nline-b\nline-c\n' > "$d/_CLAUDE.md"
+    printf '#!/usr/bin/env bash\necho "template commit-msg vTEMPLATE"\n' > "$d/scripts/hooks/check-commit-msg.sh"
+    printf '%s\n' '["dataview","calendar","new"]' > "$d/.obsidian/community-plugins.json"
+    printf '{"weekStart":"locale","wordsPerDot":250}\n' > "$d/.obsidian/plugins/calendar/data.json"
+    printf 'CALENDAR-MAIN-JS-TEMPLATE\n' > "$d/.obsidian/plugins/calendar/main.js"
+    printf '# Optional plugins\n\n| Plugin | License |\n| --- | --- |\n| Charts | AGPL |\n' > "$d/.obsidian/PLUGINS-SETUP.md"
+    printf '# Daily Note Template\n{{date}}\n' > "$d/_Templates/Daily-Note.md"
+    printf '.env\n.env.*\n' > "$d/.gitignore"
+    printf 'DEFAULT_X=1\n' > "$d/.env.example"
+    printf '# Vault README vTEMPLATE\n' > "$d/README.md"
+    printf '# template doc\n' > "$d/docs/guide.md"
+}
+
+# Stamp a vault as version $2 (skip if $2 is empty = pre-versioning).
+stamp_vault() {
+    local d="$1" ver="$2"
+    [ -z "$ver" ] && return 0
+    printf '{"template":"luna-second-brain","version":"%s","upgraded_at":"2026-01-01T00:00:00Z"}\n' "$ver" > "$d/.vault-template.json"
+}
+
+run_upgrade() { bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" "$@"; }
+
+# ---------------------------------------------------------------------------
+# T1: version equal => no-op exit 0; vault behind => runs (exit 0, mutates).
+T="$TMP/t1-tmpl"; V="$TMP/t1-vault"; make_template "$T" "1.0.0"; mkdir -p "$V"; stamp_vault "$V" "1.0.0"
+out=$(run_upgrade --yes 2>&1); rc=$?
+assert_eq "T1 equal-version rc" "0" "$rc"
+case "$out" in *already*current*) pass "T1 equal-version reports already-current" ;; *) fail "T1 equal-version reports already-current" "got: $out" ;; esac
+
+T="$TMP/t1b-tmpl"; V="$TMP/t1b-vault"; make_template "$T" "1.0.0"; mkdir -p "$V/scripts/hooks"; stamp_vault "$V" "0.9.0"
+printf 'STALE\n' > "$V/scripts/hooks/check-commit-msg.sh"
+run_upgrade --yes >/dev/null 2>&1; rc=$?
+assert_eq "T1b behind-version rc" "0" "$rc"
+assert_eq "T1b behind-version ran (hook updated)" "$(sha_of "$T/scripts/hooks/check-commit-msg.sh")" "$(sha_of "$V/scripts/hooks/check-commit-msg.sh")"
+
+# ---------------------------------------------------------------------------
+# T2: overwrite-safe — a user-diverged template-owned script is restored.
+T="$TMP/t2-tmpl"; V="$TMP/t2-vault"; make_template "$T" "1.0.0"; mkdir -p "$V/scripts/hooks"; stamp_vault "$V" "0.1.0"
+printf '#!/usr/bin/env bash\necho "USER HACKED THIS"\n' > "$V/scripts/hooks/check-commit-msg.sh"
+run_upgrade --yes >/dev/null 2>&1
+assert_eq "T2 diverged script restored to template" "$(sha_of "$T/scripts/hooks/check-commit-msg.sh")" "$(sha_of "$V/scripts/hooks/check-commit-msg.sh")"
+
+# ---------------------------------------------------------------------------
+# T3: community-plugins.json add-only merge — never drop a user-added id.
+T="$TMP/t3-tmpl"; V="$TMP/t3-vault"; make_template "$T" "1.0.0"; mkdir -p "$V/.obsidian"; stamp_vault "$V" "0.1.0"
+printf '%s\n' '["dataview","calendar","user-added"]' > "$V/.obsidian/community-plugins.json"
+run_upgrade --yes >/dev/null 2>&1
+merged=$(python3 -c 'import json,sys;print(",".join(sorted(json.load(open(sys.argv[1])))))' "$V/.obsidian/community-plugins.json")
+assert_eq "T3 merge keeps user-added + adds new" "calendar,dataview,new,user-added" "$merged"
+
+# ---------------------------------------------------------------------------
+# T4: data.json skip-if-exists — user-tuned plugin data is untouched.
+T="$TMP/t4-tmpl"; V="$TMP/t4-vault"; make_template "$T" "1.0.0"; mkdir -p "$V/.obsidian/plugins/calendar"; stamp_vault "$V" "0.1.0"
+printf '{"weekStart":"monday","wordsPerDot":999}\n' > "$V/.obsidian/plugins/calendar/data.json"
+before=$(sha_of "$V/.obsidian/plugins/calendar/data.json")
+run_upgrade --yes >/dev/null 2>&1
+assert_eq "T4 existing data.json untouched" "$before" "$(sha_of "$V/.obsidian/plugins/calendar/data.json")"
+
+# ---------------------------------------------------------------------------
+# T5: _CLAUDE.md clean 3-way merge (non-overlapping edits) => replaced, no sidecar.
+T="$TMP/t5-tmpl"; V="$TMP/t5-vault"; make_template "$T" "1.0.0"; mkdir -p "$V/.vault-template.base"; stamp_vault "$V" "0.1.0"
+# base = pristine template _CLAUDE.md
+cp "$T/_CLAUDE.md" "$V/.vault-template.base/_CLAUDE.md"
+# ours = base + an edit at the END (non-overlapping with template's edit at the TOP)
+printf '# Operating Manual\n\nline-a\nline-b\nline-c\nVAULT-ADDED-TAIL\n' > "$V/_CLAUDE.md"
+# theirs = base + an edit at the TOP
+printf '# Operating Manual v2\n\nline-a\nline-b\nline-c\n' > "$T/_CLAUDE.md"
+run_upgrade --yes >/dev/null 2>&1
+merged="$V/_CLAUDE.md"
+if grep -q 'VAULT-ADDED-TAIL' "$merged" && grep -q 'Operating Manual v2' "$merged"; then pass "T5 clean merge keeps both edits"; else fail "T5 clean merge keeps both edits" "got: $(cat "$merged")"; fi
+if [ ! -f "$V/_CLAUDE.md.template-merge" ]; then pass "T5 no conflict sidecar on clean merge"; else fail "T5 no conflict sidecar on clean merge" "sidecar present"; fi
+# base snapshot is advanced to the new template _CLAUDE.md so the NEXT run's
+# 3-way has a real ancestor (not the ours-wins fallback).
+assert_eq "T5 base snapshot advanced to theirs" "$(sha_of "$T/_CLAUDE.md")" "$(sha_of "$V/.vault-template.base/_CLAUDE.md")"
+
+# ---------------------------------------------------------------------------
+# T6: _CLAUDE.md conflict (overlapping edits) => original untouched + sidecar + alert.
+T="$TMP/t6-tmpl"; V="$TMP/t6-vault"; make_template "$T" "1.0.0"; mkdir -p "$V/.vault-template.base"; stamp_vault "$V" "0.1.0"
+cp "$T/_CLAUDE.md" "$V/.vault-template.base/_CLAUDE.md"
+# ours and theirs edit the SAME line differently => conflict
+printf '# Operating Manual OURS\n\nline-a\nline-b\nline-c\n' > "$V/_CLAUDE.md"
+printf '# Operating Manual THEIRS\n\nline-a\nline-b\nline-c\n' > "$T/_CLAUDE.md"
+ours_before=$(sha_of "$V/_CLAUDE.md")
+out=$(run_upgrade --yes 2>&1); rc=$?
+assert_eq "T6 conflict leaves _CLAUDE.md untouched" "$ours_before" "$(sha_of "$V/_CLAUDE.md")"
+if [ -f "$V/_CLAUDE.md.template-merge" ]; then pass "T6 conflict writes sidecar"; else fail "T6 conflict writes sidecar" "no sidecar"; fi
+case "$out" in *_CLAUDE.md.template-merge*|*conflict*|*CONFLICT*) pass "T6 conflict alerts loudly" ;; *) fail "T6 conflict alerts loudly" "got: $out" ;; esac
+# A conflicted run must NOT advance the version stamp (else the conflict is
+# silently masked on the next run) and must exit non-zero.
+if [ "$rc" -ne 0 ]; then pass "T6 conflict exits non-zero"; else fail "T6 conflict exits non-zero" "rc=0"; fi
+got_ver=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["version"])' "$V/.vault-template.json" 2>/dev/null)
+assert_eq "T6 conflict does not advance the stamp" "0.1.0" "$got_ver"
+
+# ---------------------------------------------------------------------------
+# T7: PLUGINS-SETUP.md reprint fires when the manual-install table changed.
+T="$TMP/t7-tmpl"; V="$TMP/t7-vault"; make_template "$T" "1.0.0"; mkdir -p "$V/.obsidian"; stamp_vault "$V" "0.1.0"
+printf '# Optional plugins\n\n| Plugin | License |\n| --- | --- |\n| OldPlugin | MIT |\n' > "$V/.obsidian/PLUGINS-SETUP.md"
+out=$(run_upgrade --yes 2>&1)
+# Match the reprint block's unique banner, NOT just the basename (which also
+# appears in the WRITE plan line) — so the test fails if the reprint is dropped.
+case "$out" in *"manual-install table"*) pass "T7 reprints PLUGINS-SETUP when changed" ;; *) fail "T7 reprints PLUGINS-SETUP when changed" "got: $out" ;; esac
+
+# ---------------------------------------------------------------------------
+# T8: idempotency — second run reports already-current.
+T="$TMP/t8-tmpl"; V="$TMP/t8-vault"; make_template "$T" "1.0.0"; mkdir -p "$V"; stamp_vault "$V" "0.1.0"
+run_upgrade --yes >/dev/null 2>&1
+out=$(run_upgrade --yes 2>&1); rc=$?
+assert_eq "T8 second-run rc" "0" "$rc"
+case "$out" in *already*current*) pass "T8 second run is a no-op" ;; *) fail "T8 second run is a no-op" "got: $out" ;; esac
+
+# ---------------------------------------------------------------------------
+# T9: --dry-run mutates nothing.
+T="$TMP/t9-tmpl"; V="$TMP/t9-vault"; make_template "$T" "1.0.0"; mkdir -p "$V/scripts/hooks"; stamp_vault "$V" "0.1.0"
+printf 'STALE\n' > "$V/scripts/hooks/check-commit-msg.sh"
+before=$(find "$V" -type f -exec sha256sum {} \; | sort)
+run_upgrade --dry-run >/dev/null 2>&1; rc=$?
+after=$(find "$V" -type f -exec sha256sum {} \; | sort)
+assert_eq "T9 dry-run rc" "0" "$rc"
+assert_eq "T9 dry-run made zero changes" "$before" "$after"
+
+# ---------------------------------------------------------------------------
+# T10: pre-versioning vault (no stamp) => full pass + stamp written at end.
+T="$TMP/t10-tmpl"; V="$TMP/t10-vault"; make_template "$T" "1.0.0"; mkdir -p "$V/scripts/hooks"
+printf 'STALE\n' > "$V/scripts/hooks/check-commit-msg.sh"
+[ ! -f "$V/.vault-template.json" ] || rm -f "$V/.vault-template.json"
+run_upgrade --yes >/dev/null 2>&1; rc=$?
+assert_eq "T10 pre-versioning rc" "0" "$rc"
+if [ -f "$V/.vault-template.json" ]; then pass "T10 stamp written at end"; else fail "T10 stamp written at end" "no stamp"; fi
+got_ver=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["version"])' "$V/.vault-template.json" 2>/dev/null)
+assert_eq "T10 stamp records template version" "1.0.0" "$got_ver"
+
+# ---------------------------------------------------------------------------
+# T12: NEVER-TOUCH invariant (fast unit) — user content is left byte-identical.
+# Covers both never-enumerated paths (a note the template doesn't ship) and
+# skip-classed files the template DOES ship (index.md, 50-Journal/_index.md).
+T="$TMP/t12-tmpl"; V="$TMP/t12-vault"; make_template "$T" "1.0.0"
+mkdir -p "$T/50-Journal" "$V/50-Journal/Daily" "$V/scripts/hooks"; stamp_vault "$V" "0.1.0"
+# Template SHIPS these skip-classed scaffold files; the vault has user-edited them.
+printf '# Vault Index (template ships this; skip-classed)\n' > "$T/index.md"
+printf '# Journal index template\n' > "$T/50-Journal/_index.md"
+printf '# MY EDITED INDEX — keep me\n' > "$V/index.md"
+printf '# MY EDITED JOURNAL INDEX\n' > "$V/50-Journal/_index.md"
+# Pure user content the template never ships at all.
+printf 'my private daily note body\n' > "$V/50-Journal/Daily/2026-06-19.md"
+printf 'SECRET=should-never-be-touched\n' > "$V/.env"
+# Give it a real reason to run (a diverged owned file).
+printf 'STALE\n' > "$V/scripts/hooks/check-commit-msg.sh"
+ut_before=$( { sha_of "$V/index.md"; sha_of "$V/50-Journal/_index.md"; sha_of "$V/50-Journal/Daily/2026-06-19.md"; sha_of "$V/.env"; } )
+run_upgrade --yes >/dev/null 2>&1
+ut_after=$( { sha_of "$V/index.md"; sha_of "$V/50-Journal/_index.md"; sha_of "$V/50-Journal/Daily/2026-06-19.md"; sha_of "$V/.env"; } )
+assert_eq "T12 user content (shipped-skip + never-shipped + .env) untouched" "$ut_before" "$ut_after"
+assert_eq "T12 the run still applied the owned file" "$(sha_of "$T/scripts/hooks/check-commit-msg.sh")" "$(sha_of "$V/scripts/hooks/check-commit-msg.sh")"
+
+# ---------------------------------------------------------------------------
+# T13: vault AHEAD of template => no-op (downgrade protection), zero mutations.
+T="$TMP/t13-tmpl"; V="$TMP/t13-vault"; make_template "$T" "1.0.0"; mkdir -p "$V/scripts/hooks"; stamp_vault "$V" "2.0.0"
+printf 'STALE\n' > "$V/scripts/hooks/check-commit-msg.sh"
+before=$(find "$V" -type f -exec sha256sum {} \; | sort)
+out=$(run_upgrade --yes 2>&1); rc=$?
+after=$(find "$V" -type f -exec sha256sum {} \; | sort)
+assert_eq "T13 vault-ahead rc" "0" "$rc"
+case "$out" in *already*current*) pass "T13 vault-ahead reports already-current" ;; *) fail "T13 vault-ahead reports already-current" "got: $out" ;; esac
+assert_eq "T13 vault-ahead made zero changes" "$before" "$after"
+
+# ---------------------------------------------------------------------------
+# T14: a malformed (non-array) community-plugins.json is left UNTOUCHED + warns,
+# never coerced to a template-only list (would destroy the user's plugin set).
+T="$TMP/t14-tmpl"; V="$TMP/t14-vault"; make_template "$T" "1.0.0"; mkdir -p "$V/.obsidian"; stamp_vault "$V" "0.1.0"
+printf '%s\n' '{"corrupt":"not an array"}' > "$V/.obsidian/community-plugins.json"
+cp_before=$(sha_of "$V/.obsidian/community-plugins.json")
+out=$(run_upgrade --yes 2>&1)
+assert_eq "T14 malformed community-plugins untouched" "$cp_before" "$(sha_of "$V/.obsidian/community-plugins.json")"
+case "$out" in *"not a JSON array"*|*"unreadable"*) pass "T14 malformed community-plugins warns" ;; *) fail "T14 malformed community-plugins warns" "got: $out" ;; esac
+
+# ---------------------------------------------------------------------------
+# T15: a write failure is fail-closed — refuse the stamp + exit non-zero, so a
+# partial upgrade re-runs instead of being masked "current". Forced portably by
+# making a target's parent a regular FILE (mkdir/cp under it fails).
+T="$TMP/t15-tmpl"; V="$TMP/t15-vault"; make_template "$T" "1.0.0"
+mkdir -p "$T/scripts/extra" "$V/scripts" "$V/.obsidian"; stamp_vault "$V" "0.1.0"
+printf '#!/usr/bin/env bash\necho extra\n' > "$T/scripts/extra/tool.sh"
+printf '%s\n' '["dataview"]' > "$V/.obsidian/community-plugins.json"
+printf 'I AM A FILE NOT A DIR\n' > "$V/scripts/extra"   # blocks the write of scripts/extra/tool.sh
+out=$(run_upgrade --yes 2>&1); rc=$?
+if [ "$rc" -ne 0 ]; then pass "T15 write-failure exits non-zero"; else fail "T15 write-failure exits non-zero" "rc=0"; fi
+case "$out" in *"NOT writing the version stamp"*) pass "T15 write-failure refuses the stamp" ;; *) fail "T15 write-failure refuses the stamp" "got: $out" ;; esac
+got_ver=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["version"])' "$V/.vault-template.json" 2>/dev/null)
+assert_eq "T15 write-failure does not advance stamp" "0.1.0" "$got_ver"
+
+# ---------------------------------------------------------------------------
+# T11: ACCEPTANCE — run against a COPY of the real luna vault, never the live one.
+LUNA="$HOME/Documents/luna"
+if [ -d "$LUNA" ] && [ -d "$LUNA/50-Journal" ]; then
+    VC="$TMP/luna-copy"
+    cp -r "$LUNA" "$VC" 2>/dev/null
+    # Remove any nested .git to keep the copy a plain dir (avoid worktree confusion).
+    rm -rf "$VC/.git"
+    REALTMPL="$(cd "$HERE/.." && pwd)"   # this template's own root (scripts/..)
+    journal_before=$(find "$VC/50-Journal" -type f -exec sha256sum {} \; 2>/dev/null | sort)
+    claude_before=$(sha_of "$VC/_CLAUDE.md")
+    bash "$UPGRADE" --template-dir "$REALTMPL" --vault-dir "$VC" --yes >/dev/null 2>&1; rc=$?
+    journal_after=$(find "$VC/50-Journal" -type f -exec sha256sum {} \; 2>/dev/null | sort)
+    assert_eq "T11 acceptance rc" "0" "$rc"
+    assert_eq "T11 journal bodies unchanged" "$journal_before" "$journal_after"
+    assert_eq "T11 _CLAUDE.md user content unchanged (no base => ours wins)" "$claude_before" "$(sha_of "$VC/_CLAUDE.md")"
+    if [ -f "$VC/.vault-template.json" ]; then pass "T11 stamp written on real-vault copy"; else fail "T11 stamp written on real-vault copy" "no stamp"; fi
+    assert_eq "T11 template-owned setup.sh updated to template" "$(sha_of "$REALTMPL/scripts/setup.sh")" "$(sha_of "$VC/scripts/setup.sh")"
+else
+    echo "SKIP T11 acceptance — no real luna vault at $LUNA"
+fi
+
+echo
+if [ "$FAILED" -eq 0 ]; then echo "All upgrade tests passed."; else echo "$FAILED test(s) failed."; exit 1; fi

--- a/templates/luna-second-brain/scripts/upgrade.ps1
+++ b/templates/luna-second-brain/scripts/upgrade.ps1
@@ -1,0 +1,70 @@
+<#
+.SYNOPSIS
+  Content-preserving vault/template upgrade (HIMMEL-389) — PowerShell twin.
+
+.DESCRIPTION
+  Windows entry point for the vault upgrade. The upgrade engine is upgrade.sh
+  (bash): it needs git merge-file (3-way _CLAUDE.md merge), sha256sum, and
+  python3 — the same toolchain every other himmel hook already requires. Rather
+  than maintain a second, drifting implementation of the merge/classification
+  logic, this twin locates Git Bash and runs upgrade.sh with the same arguments.
+
+.PARAMETER Args
+  Forwarded verbatim to upgrade.sh: --template-dir DIR, --vault-dir DIR,
+  --dry-run, --yes.
+
+.EXAMPLE
+  pwsh scripts/upgrade.ps1 --dry-run
+  pwsh scripts/upgrade.ps1 --template-dir C:\src\himmel\templates\luna-second-brain --yes
+#>
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Args
+)
+
+$ErrorActionPreference = 'Stop'
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$upgradeSh = Join-Path $scriptDir 'upgrade.sh'
+
+if (-not (Test-Path -LiteralPath $upgradeSh)) {
+    Write-Error "upgrade.ps1: cannot find upgrade.sh next to this script at $upgradeSh"
+    exit 2
+}
+
+# Locate GIT BASH specifically. A bare `bash` on PATH is often the WSL stub
+# (C:\Windows\System32\bash.exe), which can't see C:/... paths — so prefer the
+# Git for Windows install, then bash derived from the `git` command, and only
+# fall back to a PATH `bash` last.
+$bash = $null
+$cands = @(
+    "$env:ProgramFiles\Git\bin\bash.exe",
+    "${env:ProgramFiles(x86)}\Git\bin\bash.exe",
+    "$env:LOCALAPPDATA\Programs\Git\bin\bash.exe"
+)
+$gitCmd = (Get-Command git -ErrorAction SilentlyContinue).Source
+if ($gitCmd) {
+    # git.exe is at <GitRoot>\cmd\git.exe; bash is at <GitRoot>\bin\bash.exe.
+    $gitRoot = Split-Path -Parent (Split-Path -Parent $gitCmd)
+    $cands += (Join-Path $gitRoot 'bin\bash.exe')
+}
+foreach ($cand in $cands) {
+    if ($cand -and (Test-Path -LiteralPath $cand)) { $bash = $cand; break }
+}
+if (-not $bash) {
+    $pathBash = (Get-Command bash -ErrorAction SilentlyContinue).Source
+    if ($pathBash -and $pathBash -notmatch 'System32') { $bash = $pathBash }
+}
+if (-not $bash) {
+    Write-Error "upgrade.ps1: Git Bash not found. Install Git for Windows (it provides bash + sha256sum + git), or run 'bash scripts/upgrade.sh' directly."
+    exit 2
+}
+
+# Git Bash mangles Windows backslash paths in argv; forward-slash form
+# (C:/Users/...) is accepted by bash and by the engine's cd/find. Convert the
+# script path and every forwarded arg (path values like --template-dir C:\...).
+$shArgs = @($upgradeSh.Replace('\', '/'))
+foreach ($a in $Args) { $shArgs += $a.Replace('\', '/') }
+
+& $bash @shArgs
+exit $LASTEXITCODE

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+# upgrade.sh — content-preserving vault/template upgrade (HIMMEL-389).
+#
+# Refreshes template-owned files in a luna-second-brain vault from a fresh
+# himmel template, WITHOUT touching user content (journal, notes, clips).
+# Vaults are scaffolded once and never updated; this brings later template
+# fixes (e.g. a new PLUGINS-SETUP note) to existing vaults safely.
+#
+# Distinct from himmel harness self-update (HIMMEL-413) and marketplace
+# autoUpdate (HIMMEL-365): this is VAULT CONTENT/config, not the harness.
+#
+# Usage:
+#   bash scripts/upgrade.sh [--template-dir DIR] [--vault-dir DIR] [--dry-run] [--yes]
+#
+#   --template-dir DIR  fresh himmel template root (contains marketplace/ +
+#                       _CLAUDE.md). Default resolution: --template-dir >
+#                       $HIMMEL_DIR/templates/luna-second-brain > a sibling-dir
+#                       scan for a himmel checkout carrying the template.
+#   --vault-dir DIR     the vault to upgrade. Default: the parent of this
+#                       script's dir (scripts/.. — i.e. run from inside a vault).
+#   --dry-run           print the plan, make zero filesystem changes.
+#   --yes               skip the confirm prompt (used by the /luna-upgrade skill).
+#
+# Version source = the template's marketplace/.claude-plugin/marketplace.json
+# metadata.version. The vault records its level in .vault-template.json; a
+# missing stamp is treated as 0.0.0 (full pass). The stamp is written LAST so
+# an aborted run re-runs cleanly (idempotent).
+#
+# Self-upgrading: this script is template-owned (scripts/** overwrite class),
+# so a run also refreshes the upgrader itself.
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+TEMPLATE_DIR=""
+VAULT_DIR=""
+DRY_RUN=0
+ASSUME_YES=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --template-dir) TEMPLATE_DIR="${2:-}"; shift 2 ;;
+        --vault-dir)    VAULT_DIR="${2:-}"; shift 2 ;;
+        --dry-run)      DRY_RUN=1; shift ;;
+        --yes|-y)       ASSUME_YES=1; shift ;;
+        -h|--help)
+            cat <<'USAGE'
+upgrade.sh — content-preserving vault/template upgrade (HIMMEL-389)
+
+  bash scripts/upgrade.sh [--template-dir DIR] [--vault-dir DIR] [--dry-run] [--yes]
+
+  --template-dir DIR  fresh himmel template root (default: --template-dir >
+                      $HIMMEL_DIR/templates/luna-second-brain > sibling scan).
+  --vault-dir DIR     the vault to upgrade (default: scripts/.. — run from a vault).
+  --dry-run           print the plan, make zero filesystem changes.
+  --yes, -y           skip the confirm prompt.
+
+Refreshes template-owned files (scripts, .obsidian config, plugin assets, docs)
+WITHOUT touching user content (journal, notes, clips). Version source = the
+template's marketplace.json metadata.version vs the vault's .vault-template.json.
+USAGE
+            exit 0 ;;
+        *) echo "upgrade: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve template dir: --template-dir > $HIMMEL_DIR > sibling-dir scan.
+resolve_template() {
+    local rel="templates/luna-second-brain"
+    if [ -n "$TEMPLATE_DIR" ]; then printf '%s' "$TEMPLATE_DIR"; return; fi
+    if [ -n "${HIMMEL_DIR:-}" ] && [ -d "$HIMMEL_DIR/$rel" ]; then printf '%s' "$HIMMEL_DIR/$rel"; return; fi
+    # Sibling scan: look one level up from the vault for a himmel checkout.
+    local base; base="$(cd "$VAULT_DIR/.." 2>/dev/null && pwd)"
+    if [ -n "$base" ]; then
+        local c
+        for c in "$base"/himmel "$base"/Himmel "$base"/*/; do
+            [ -d "$c/$rel" ] && { printf '%s' "$c/$rel"; return; }
+        done
+    fi
+    return 1
+}
+
+# Default vault = scripts/.. (run from inside the vault).
+if [ -z "$VAULT_DIR" ]; then VAULT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"; fi
+if [ ! -d "$VAULT_DIR" ]; then echo "upgrade: vault dir does not exist: $VAULT_DIR" >&2; exit 2; fi
+VAULT_DIR="$(cd "$VAULT_DIR" && pwd)"
+
+if ! TEMPLATE_DIR="$(resolve_template)"; then
+    echo "upgrade: could not locate the himmel template. Pass --template-dir DIR or set HIMMEL_DIR." >&2
+    exit 2
+fi
+if [ ! -d "$TEMPLATE_DIR" ]; then echo "upgrade: template dir does not exist: $TEMPLATE_DIR" >&2; exit 2; fi
+TEMPLATE_DIR="$(cd "$TEMPLATE_DIR" && pwd)"
+
+MARKETPLACE_JSON="$TEMPLATE_DIR/marketplace/.claude-plugin/marketplace.json"
+if [ ! -f "$MARKETPLACE_JSON" ]; then
+    echo "upgrade: template marketplace.json not found at $MARKETPLACE_JSON — not a luna-second-brain template?" >&2
+    exit 2
+fi
+
+for _t in python3 git sha256sum; do
+    command -v "$_t" >/dev/null 2>&1 || { echo "upgrade: required tool not on PATH: $_t" >&2; exit 2; }
+done
+
+# ---------------------------------------------------------------------------
+# Versions
+TEMPLATE_VERSION="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["metadata"]["version"])' "$MARKETPLACE_JSON" 2>/dev/null)"
+if [ -z "$TEMPLATE_VERSION" ]; then echo "upgrade: could not read metadata.version from $MARKETPLACE_JSON" >&2; exit 2; fi
+
+STAMP="$VAULT_DIR/.vault-template.json"
+if [ -f "$STAMP" ]; then
+    # A present-but-unreadable stamp is distinct from no stamp: warn (so a
+    # corrupt stamp doesn't silently escalate to a from-scratch full pass).
+    if ! VAULT_VERSION="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("version",""))' "$STAMP" 2>/dev/null)" || [ -z "$VAULT_VERSION" ]; then
+        echo "upgrade: WARNING — $STAMP is unreadable or has no version; treating vault as un-stamped (full pass)." >&2
+        VAULT_VERSION="0.0.0"
+    fi
+else
+    VAULT_VERSION="0.0.0"
+fi
+
+# semver-ish compare: return 0 iff $1 < $2.
+ver_lt() {
+    [ "$1" = "$2" ] && return 1
+    local lo; lo="$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)"
+    [ "$lo" = "$1" ]
+}
+
+echo "==> luna-second-brain upgrade"
+echo "    template : $TEMPLATE_DIR (v$TEMPLATE_VERSION)"
+echo "    vault    : $VAULT_DIR (v$VAULT_VERSION)"
+echo ""
+
+if [ "$VAULT_VERSION" = "$TEMPLATE_VERSION" ] || ! ver_lt "$VAULT_VERSION" "$TEMPLATE_VERSION"; then
+    echo "Vault is already current (v$VAULT_VERSION) — nothing to do."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Per-file classification. Returns one of:
+#   overwrite | jsonmerge | skipexists | threeway | report | skip
+# Extensible per-profile (HIMMEL-389 scope §8): a future wiki profile keys off
+# the .vault-template.json "template" field and swaps this classifier.
+classify() {
+    case "$1" in
+        _CLAUDE.md)                                   echo threeway ;;
+        _Templates/*.md)                              echo report ;;
+        .obsidian/community-plugins.json)             echo jsonmerge ;;
+        .obsidian/plugins/*/data.json)                echo skipexists ;;
+        .obsidian/plugins/*/main.js|.obsidian/plugins/*/manifest.json|.obsidian/plugins/*/styles.css) echo overwrite ;;
+        .obsidian/PLUGINS-SETUP.md)                   echo overwrite ;;
+        .obsidian/app.json|.obsidian/appearance.json|.obsidian/graph.json|.obsidian/core-plugins.json) echo overwrite ;;
+        scripts/*)                                    echo overwrite ;;
+        docs/*)                                       echo overwrite ;;
+        .pre-commit-config.yaml)                      echo overwrite ;;
+        marketplace/.claude-plugin/marketplace.json)  echo overwrite ;;
+        .env.example|.gitignore|.gitattributes|.gitleaks.toml|README.md) echo overwrite ;;
+        *)                                            echo skip ;;
+    esac
+}
+
+# Atomic write: copy src over dst via temp + rename (handles self-overwrite of
+# this running script: POSIX keeps the open inode; Windows rename-over may fail,
+# which we treat as non-fatal).
+write_file() {
+    local src="$1" dst="$2"
+    mkdir -p "$(dirname "$dst")"
+    local tmp="$dst.upgrade-tmp.$$"
+    if cp "$src" "$tmp" 2>/dev/null && mv "$tmp" "$dst" 2>/dev/null; then
+        return 0
+    fi
+    rm -f "$tmp" 2>/dev/null
+    echo "  WARN: could not update $dst (left as-is)" >&2
+    return 1
+}
+
+sha_of() { if [ -f "$1" ]; then sha256sum "$1" | cut -d' ' -f1; else echo MISSING; fi; }
+
+# Capture the vault's prior PLUGINS-SETUP.md sha BEFORE any overwrite, so the
+# reprint check (step 4) can tell whether the manual-install table changed.
+PLUGINS_SETUP_REL=".obsidian/PLUGINS-SETUP.md"
+PLUGINS_SETUP_PRIOR_SHA="$(sha_of "$VAULT_DIR/$PLUGINS_SETUP_REL")"
+
+# ---------------------------------------------------------------------------
+# Build + print plan, then execute (unless --dry-run). One pass over the
+# template-owned files; user content is never enumerated so it can't be touched.
+n_write=0 n_skip_identical=0 n_skip_exists=0 n_jsonmerge=0 n_report=0 n_threeway=0
+WRITE_FAILURES=0
+declare -a PLAN
+
+CLAUDE_MERGE_RESULT=""   # set to clean|copied|conflict|error during execute
+
+# JSON add-only merge for community-plugins.json. Prints the ids it would add
+# (one per line) to stdout; with EXECUTE=1 also writes the merged file.
+plugins_merge() {
+    local vault_f="$1" tmpl_f="$2" execute="$3"
+    EXECUTE="$execute" python3 - "$vault_f" "$tmpl_f" <<'PY'
+import json, os, sys
+vault_p, tmpl_p = sys.argv[1], sys.argv[2]
+execute = os.environ.get("EXECUTE") == "1"
+# Safety: a present-but-unreadable or non-array vault file is left UNTOUCHED
+# (never coerced to [] and overwritten — that would destroy the user's plugin
+# list). Only a clean JSON array is merged into; a missing file starts as [].
+if os.path.exists(vault_p):
+    try:
+        vault = json.load(open(vault_p, encoding="utf-8"))
+    except (ValueError, OSError) as e:
+        sys.stderr.write("  WARN: %s is unreadable (%s); leaving untouched\n" % (vault_p, e))
+        sys.exit(0)
+    if not isinstance(vault, list):
+        sys.stderr.write("  WARN: %s is not a JSON array; leaving untouched\n" % vault_p)
+        sys.exit(0)
+else:
+    vault = []
+tmpl = json.load(open(tmpl_p, encoding="utf-8"))
+seen = set(vault)
+added = [x for x in tmpl if x not in seen]
+for a in added:
+    print(a)
+if execute and added:
+    merged = list(vault) + added
+    with open(vault_p, "w", encoding="utf-8") as fh:
+        json.dump(merged, fh, indent=2)
+        fh.write("\n")
+PY
+}
+
+# 3-way merge _CLAUDE.md into a temp. git merge-file -p exit code: 0 = clean,
+# 1 = conflict, >1 = error (missing/unreadable input, etc.). clean/copied =>
+# replace + advance the base snapshot; conflict => sidecar + alert; error =>
+# surface git's stderr. The base snapshot is advanced ONLY on a clean/copied
+# result — leaving it on conflict/error means a future template bump re-runs the
+# same 3-way and re-surfaces the unresolved change rather than silently
+# resolving it ours-wins.
+claude_threeway() {
+    local execute="$1"
+    local ours="$VAULT_DIR/_CLAUDE.md"
+    local theirs="$TEMPLATE_DIR/_CLAUDE.md"
+    local base_dir="$VAULT_DIR/.vault-template.base"
+    local base="$base_dir/_CLAUDE.md"
+    [ -f "$theirs" ] || return 0
+    # Advance the base snapshot to theirs (best-effort; a failure here means the
+    # NEXT run can't 3-way and falls back to ours-wins, so warn but don't fail).
+    advance_base() {
+        mkdir -p "$base_dir" && cp "$theirs" "$base" \
+            || echo "  WARN: base snapshot for _CLAUDE.md not updated (next run uses ours-wins fallback)" >&2
+    }
+    # Vault has no _CLAUDE.md at all => copy theirs (additive).
+    if [ ! -f "$ours" ]; then
+        CLAUDE_MERGE_RESULT="copied"
+        if [ "$execute" = 1 ]; then
+            write_file "$theirs" "$ours" || { WRITE_FAILURES=$((WRITE_FAILURES+1)); return 0; }
+            advance_base
+        fi
+        return 0
+    fi
+    # No recorded base => use pristine template as base (=> ours wins, safe).
+    local base_use="$base"
+    [ -f "$base" ] || base_use="$theirs"
+    local merged mf_err rc
+    merged="$(mktemp)"; mf_err="$(mktemp)"
+    git merge-file -p "$ours" "$base_use" "$theirs" > "$merged" 2>"$mf_err"; rc=$?
+    if [ "$rc" -eq 0 ]; then
+        CLAUDE_MERGE_RESULT="clean"
+        if [ "$execute" = 1 ]; then
+            # Route the merged write through write_file so a failed write counts
+            # toward WRITE_FAILURES (fail-closed) and the base only advances if
+            # _CLAUDE.md was actually replaced — never a lying stamp + lost merge.
+            if write_file "$merged" "$ours"; then
+                advance_base
+            else
+                WRITE_FAILURES=$((WRITE_FAILURES+1))
+            fi
+        fi
+    elif [ "$rc" -eq 1 ]; then
+        CLAUDE_MERGE_RESULT="conflict"
+        # Leave _CLAUDE.md untouched; write the conflicted merge to a sidecar.
+        # Do NOT advance the base snapshot (so the conflict re-surfaces).
+        [ "$execute" = 1 ] && cp "$merged" "$VAULT_DIR/_CLAUDE.md.template-merge"
+    else
+        CLAUDE_MERGE_RESULT="error"
+        echo "  ERROR: git merge-file failed for _CLAUDE.md (rc=$rc):" >&2
+        sed 's/^/    /' "$mf_err" >&2
+    fi
+    rm -f "$merged" "$mf_err"
+}
+
+process() {
+    local execute="$1" rel class src dst
+    while IFS= read -r src; do
+        rel="${src#"$TEMPLATE_DIR"/}"
+        class="$(classify "$rel")"
+        dst="$VAULT_DIR/$rel"
+        case "$class" in
+            skip) ;;
+            overwrite)
+                if [ "$(sha_of "$src")" != "$(sha_of "$dst")" ]; then
+                    PLAN+=("WRITE        $rel"); n_write=$((n_write+1))
+                    [ "$execute" = 1 ] && { write_file "$src" "$dst" || WRITE_FAILURES=$((WRITE_FAILURES+1)); }
+                else
+                    n_skip_identical=$((n_skip_identical+1))
+                fi ;;
+            skipexists)
+                if [ -f "$dst" ]; then
+                    n_skip_exists=$((n_skip_exists+1))
+                else
+                    PLAN+=("WRITE-NEW    $rel"); n_write=$((n_write+1))
+                    [ "$execute" = 1 ] && { write_file "$src" "$dst" || WRITE_FAILURES=$((WRITE_FAILURES+1)); }
+                fi ;;
+            report)
+                if [ ! -f "$dst" ]; then
+                    PLAN+=("WRITE-NEW    $rel"); n_write=$((n_write+1))
+                    [ "$execute" = 1 ] && { write_file "$src" "$dst" || WRITE_FAILURES=$((WRITE_FAILURES+1)); }
+                elif [ "$(sha_of "$src")" != "$(sha_of "$dst")" ]; then
+                    PLAN+=("REPORT       $rel (template changed; review — not overwritten)"); n_report=$((n_report+1))
+                fi ;;
+            jsonmerge|threeway) : ;;  # handled out-of-loop below
+        esac
+    done < <(find "$TEMPLATE_DIR" -type f 2>/dev/null)
+
+    # community-plugins.json add-only merge.
+    local cp_rel=".obsidian/community-plugins.json"
+    if [ -f "$TEMPLATE_DIR/$cp_rel" ]; then
+        local added; added="$(plugins_merge "$VAULT_DIR/$cp_rel" "$TEMPLATE_DIR/$cp_rel" "0")"
+        if [ -n "$added" ]; then
+            PLAN+=("MERGE-JSON   $cp_rel (+$(echo "$added" | tr '\n' ',' | sed 's/,$//'))"); n_jsonmerge=$((n_jsonmerge+1))
+            [ "$execute" = 1 ] && plugins_merge "$VAULT_DIR/$cp_rel" "$TEMPLATE_DIR/$cp_rel" "1" >/dev/null
+        fi
+    fi
+
+    # _CLAUDE.md 3-way.
+    claude_threeway "$execute"
+    case "$CLAUDE_MERGE_RESULT" in
+        copied)   PLAN+=("WRITE-NEW    _CLAUDE.md"); n_threeway=$((n_threeway+1)) ;;
+        clean)    PLAN+=("MERGE-3WAY   _CLAUDE.md (clean — merged)"); n_threeway=$((n_threeway+1)) ;;
+        conflict) PLAN+=("MERGE-3WAY   _CLAUDE.md (CONFLICT — original kept, see _CLAUDE.md.template-merge)"); n_threeway=$((n_threeway+1)) ;;
+        error)    PLAN+=("MERGE-3WAY   _CLAUDE.md (ERROR — git merge-file failed, original kept)"); n_threeway=$((n_threeway+1)) ;;
+    esac
+}
+
+# --- Plan pass (no writes) ---
+process 0
+
+if [ "${#PLAN[@]}" -eq 0 ]; then
+    echo "No template-owned files differ — vault content is current. Writing version stamp."
+else
+    echo "Plan ($((n_write)) write, $n_jsonmerge json-merge, $n_threeway _CLAUDE.md, $n_report report, $n_skip_identical identical, $n_skip_exists user-kept):"
+    printf '  %s\n' "${PLAN[@]}"
+fi
+echo ""
+
+if [ "$DRY_RUN" = 1 ]; then
+    echo "--dry-run: no changes made."
+    exit 0
+fi
+
+if [ "$ASSUME_YES" != 1 ]; then
+    printf 'Proceed and upgrade this vault to v%s? [y/N] ' "$TEMPLATE_VERSION"
+    read -r _ans || _ans=""
+    case "$_ans" in [yY]|[yY][eE][sS]) ;; *) echo "aborted — no changes made."; exit 0 ;; esac
+fi
+
+# --- Execute pass ---
+PLAN=()
+n_write=0 n_skip_identical=0 n_skip_exists=0 n_jsonmerge=0 n_report=0 n_threeway=0
+WRITE_FAILURES=0
+CLAUDE_MERGE_RESULT=""
+process 1
+
+# Step 4: reprint the manual-install table if PLUGINS-SETUP.md changed.
+if [ "$(sha_of "$TEMPLATE_DIR/$PLUGINS_SETUP_REL")" != "$PLUGINS_SETUP_PRIOR_SHA" ] && [ -f "$VAULT_DIR/$PLUGINS_SETUP_REL" ]; then
+    echo ""
+    echo "================= PLUGINS-SETUP.md changed — manual-install table ================="
+    cat "$VAULT_DIR/$PLUGINS_SETUP_REL"
+    echo "==================================================================================="
+fi
+
+# Loud alert if _CLAUDE.md merge conflicted.
+if [ "$CLAUDE_MERGE_RESULT" = "conflict" ]; then
+    echo "" >&2
+    echo "!! _CLAUDE.md had a MERGE CONFLICT with the new template. Your _CLAUDE.md was" >&2
+    echo "!! left UNTOUCHED. The conflicted 3-way merge is in: _CLAUDE.md.template-merge" >&2
+    echo "!! Resolve it by hand, then delete the .template-merge sidecar, and re-run." >&2
+fi
+
+# Only stamp the vault as upgraded when the run FULLY succeeded. A conflict, a
+# git merge-file error, or any failed write means the vault did not reach the
+# target version — leave the stamp behind so a re-run re-processes (and
+# re-alerts) instead of a "current" stamp silently masking the gap. The stamp
+# is the last write, so an aborted run also re-runs cleanly (idempotent).
+if [ "$WRITE_FAILURES" -gt 0 ] || [ "$CLAUDE_MERGE_RESULT" = "conflict" ] || [ "$CLAUDE_MERGE_RESULT" = "error" ]; then
+    echo "" >&2
+    echo "upgrade: NOT writing the version stamp — the vault is partially upgraded" >&2
+    echo "  (write failures: $WRITE_FAILURES; _CLAUDE.md: ${CLAUDE_MERGE_RESULT:-ok}). Resolve the" >&2
+    echo "  issues above and re-run; template-owned writes are idempotent." >&2
+    exit 1
+fi
+
+if ! python3 - "$STAMP" "$TEMPLATE_VERSION" <<'PY'
+import json, sys, datetime
+stamp_p, ver = sys.argv[1], sys.argv[2]
+now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+with open(stamp_p, "w", encoding="utf-8") as fh:
+    json.dump({"template": "luna-second-brain", "version": ver, "upgraded_at": now}, fh, indent=2)
+    fh.write("\n")
+PY
+then
+    echo "upgrade: ERROR — files updated but the version stamp could not be written to $STAMP." >&2
+    echo "  The vault content IS upgraded; re-run to record the stamp." >&2
+    exit 1
+fi
+
+echo ""
+echo "Upgrade complete — vault is now v$TEMPLATE_VERSION."


### PR DESCRIPTION
Code-only propagation of two private PRs (#591, #592).

## HIMMEL-418 — close the `~/.claude.json` launch-race
`scripts/lib/ensure-workspace-trust.sh`: a small randomized jitter (`TRUST_WRITE_JITTER_MS`, default 500ms, 0 disables) before the read-modify-write de-syncs two coincident `claude` launches, plus fail-open hardening of the temp-write + atomic-rename (clean warn, exit 4, no orphaned temp). The atomic write itself predates this change. 5 new test cases.

## HIMMEL-389 (Phase 0+1) — content-preserving vault/template upgrade
`templates/luna-second-brain/`: a version stamp (`.vault-template.json`, source = `marketplace.json` `metadata.version`) + an upgrade engine (`scripts/upgrade.sh` + Windows twin `upgrade.ps1`) that refreshes template-owned files **without touching user content**. A closed allow-list classifier (default = skip) means user content is never enumerated; overwrite-if-SHA-differs / JSON add-only plugin merge / skip-if-exists plugin data / 3-way `_CLAUDE.md` merge (clean replace, conflict sidecar + alert) / report-only templates. Fail-closed: the version stamp is written last and only on a fully-clean run. `--dry-run` / `--yes`. 15-case bash suite (incl. a real-vault-copy acceptance test) + a PowerShell smoke test.

Both reviewed via multi-agent CR on the private side (HIMMEL-418: 0 Critical/0 Important; HIMMEL-389: 3 heavy-CR rounds to clean).

Platforms tested: windows · Security reviewed: manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
