### PR TITLE
feat(vault): [HIMMEL-389] /luna-upgrade skill + generic template resolver (Phase 2)

### DIFF
--- a/.claude/commands/luna-upgrade.md
+++ b/.claude/commands/luna-upgrade.md
@@ -1,0 +1,19 @@
+---
+allowed-tools: Bash, Read, Skill
+description: Content-preserving upgrade of an existing luna-second-brain vault to the current himmel template (dry-run → confirm → apply). Thin wrapper that delegates to the obsidian-triage:luna-upgrade skill (HIMMEL-389 Phase 2 — see marketplace/plugins/obsidian-triage/skills/luna-upgrade/SKILL.md for the runbook).
+argument-hint: [--vault <path>] [--template-dir <path>]
+---
+
+# /luna-upgrade — slash-command wrapper (HIMMEL-389 Phase 2)
+
+Invoke the `obsidian-triage:luna-upgrade` skill via the `Skill` tool with `$ARGUMENTS` as the literal `args` parameter — do NOT inline or paraphrase the runbook body here, the skill is the single source of truth.
+
+Execute exactly this tool call (substituting `$ARGUMENTS` literally — Claude Code's slash-command preprocessor replaces it with whatever the operator typed after `/luna-upgrade`):
+
+```
+Skill { skill: "obsidian-triage:luna-upgrade", args: "$ARGUMENTS" }
+```
+
+This wrapper exists so the operator can keep typing `/luna-upgrade` at the user prompt without learning the `/<plugin>:<skill>` form, mirroring `/luna-ingest`. Keep it a thin wrapper — never duplicate the runbook body.
+
+If the `obsidian-triage` plugin is not installed (the `Skill` tool refuses with "skill not found" or similar): fail loudly with `ERR luna-upgrade: obsidian-triage plugin not installed; /plugin install obsidian-triage from the himmel marketplace, or run bash templates/luna-second-brain/scripts/upgrade.sh directly.` Do NOT attempt to inline the runbook as a fallback.

--- a/docs/commands-catalog.md
+++ b/docs/commands-catalog.md
@@ -70,6 +70,7 @@ and their rows are paraphrased one-liners rather than verbatim frontmatter
 | /luna-ingest | Chain-following triage for a github repo URL. Thin wrapper that delegates to the obsidian-triage:luna-ingest skill (LUNA-9 skill conversion — see marketplace/plugins/obsidian-triage/skills/luna-ingest/SKILL.md for the runbook). |
 | /telegram-clip | File a Telegram message (text / bare URL / forward) as a harvest-ready LUNA-2 clip note in the luna vault's Clippings/. Thin wrapper that delegates to the obsidian-triage:telegram-clip skill (LUNA-58 — see marketplace/plugins/obsidian-triage/skills/telegram-clip/SKILL.md for the runbook). |
 | /roadmap-clips | Aggregate actionable items across the luna vault (daily action items, _deferred.md backlog, synthesis proposals, promotion candidates, component inventory), cluster into a sequenced roadmap mapped to tools, dedup candidate tickets against open Jira, and write a 60-Maps/ roadmap note. Proposals only. Thin wrapper that delegates to the obsidian-triage:roadmap-clips skill (LUNA-59 — see marketplace/plugins/obsidian-triage/skills/roadmap-clips/SKILL.md for the runbook). |
+| /luna-upgrade | Content-preserving upgrade of an existing luna-second-brain vault to the current himmel template (dry-run → confirm → apply). Thin wrapper that delegates to the obsidian-triage:luna-upgrade skill (HIMMEL-389 Phase 2 — see marketplace/plugins/obsidian-triage/skills/luna-upgrade/SKILL.md for the runbook). |
 
 ## Clipper pipeline (obsidian-triage plugin)
 

--- a/marketplace/plugins/obsidian-triage/skills/luna-upgrade/SKILL.md
+++ b/marketplace/plugins/obsidian-triage/skills/luna-upgrade/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: luna-upgrade
+description: Use when an existing luna-second-brain vault needs to pull newer himmel template updates — refreshed bundled-plugin assets, .obsidian config, _CLAUDE.md operating-manual changes, scripts/hooks, scaffold docs, and the PLUGINS-SETUP manual-install list — WITHOUT touching user content (journal, notes, clips). Previews the change plan (dry-run), surfaces any _CLAUDE.md merge conflict or changed manual-install table, asks the operator to confirm, then applies. Triggers on /luna-upgrade at the user prompt OR programmatic Skill-tool dispatch. Distinct from himmel harness self-update and Claude Code marketplace autoUpdate — this is VAULT content/config (HIMMEL-389).
+---
+
+# luna-upgrade — content-preserving vault/template upgrade (HIMMEL-389 Phase 2)
+
+You bring an EXISTING luna-second-brain vault up to the current himmel template
+without clobbering the user's own content. Vaults are scaffolded once and never
+re-read the template; this is the upgrade path. The engine that does all the
+work is `templates/luna-second-brain/scripts/upgrade.sh` — this skill is the
+ergonomic **dry-run → confirm → apply** surface around it. ALL classification,
+3-way merge, conflict handling, and fail-closed recovery logic lives in
+`upgrade.sh`; this runbook only orchestrates the preview/confirm/apply sequence
+and surfaces the engine's output. Do NOT reimplement any merge logic here.
+
+## Invocation surfaces
+
+- **User prompt:** `/luna-upgrade [--vault <path>] [--template-dir <path>]` —
+  handled by the thin wrapper at `.claude/commands/luna-upgrade.md` which
+  delegates here.
+- **Programmatic Skill-tool dispatch (HIMMEL-128 compliant — no headless
+  claude):** `Skill { skill: "obsidian-triage:luna-upgrade", args: "<flags...>" }`.
+
+Wherever this document references `$ARGUMENTS`, treat it as the literal arg
+string supplied via either path.
+
+## Inputs
+
+`$ARGUMENTS` is `[--vault <path>] [--template-dir <path>]` (both optional).
+
+- `--vault <path>` — the vault to upgrade. Default: resolve from the current
+  session (see Step 1).
+- `--template-dir <path>` — explicit himmel template root override. Default:
+  resolve the himmel checkout (see Step 0). The engine's own resolver order is
+  `--template-dir` > `$HIMMEL_DIR` > generic `$HOME`-relative candidate paths >
+  sibling scan, so on a normal layout you pass neither flag.
+
+## Step 0 — Locate himmel's upgrade.sh
+
+A vault scaffolded BEFORE this feature has no `scripts/upgrade.sh` of its own
+yet, so always invoke **himmel's** copy (the first upgrade then installs
+`upgrade.sh` into the vault — it is overwrite-class). Resolve the himmel
+checkout the same way the engine resolves the template (explicit config wins,
+then generic home-relative candidates):
+
+```bash
+HIMMEL=""
+for d in "${HIMMEL_DIR:-}" "$HOME/github/himmel" "$HOME/github/Himmel" \
+         "$HOME/Documents/github/himmel" "$HOME/Documents/github/Himmel"; do
+  [ -n "$d" ] && [ -f "$d/templates/luna-second-brain/scripts/upgrade.sh" ] \
+    && { HIMMEL="$d"; break; }
+done
+```
+
+If `--template-dir <path>` was passed, set `HIMMEL` so that
+`$HIMMEL/templates/luna-second-brain` equals that path (or pass the flag
+straight through). If `HIMMEL` stays empty, stop and tell the operator to set
+`HIMMEL_DIR` or pass `--template-dir` — do NOT guess a path. Define:
+
+```bash
+TEMPLATE="$HIMMEL/templates/luna-second-brain"
+UPGRADE="$TEMPLATE/scripts/upgrade.sh"
+```
+
+This probe is best-effort and only locates `upgrade.sh`; the engine re-resolves
+and re-validates the template itself (and warns if multiple checkouts match), so
+the engine's resolution is authoritative — do not treat this snippet's result as
+final.
+
+## Step 1 — Resolve the vault root
+
+If `--vault <path>` was passed, use it. Otherwise resolve the current session's
+vault: walk up from `$PWD` to the nearest ancestor that contains a `.obsidian/`
+directory or a `.vault-template.json` stamp; if none is found, use `$PWD`.
+Confirm the resolved `$VAULT` looks like a vault (it has `.obsidian/` or
+`.vault-template.json`); if it clearly is not one, stop and ask the operator to
+pass `--vault`.
+
+## Step 2 — Dry-run (preview)
+
+Run the engine in preview mode — it touches nothing:
+
+```bash
+bash "$UPGRADE" --template-dir "$TEMPLATE" --vault-dir "$VAULT" --dry-run
+```
+
+## Step 3 — Surface the plan
+
+Show the operator the engine's plan output verbatim (which files WRITE /
+WRITE-NEW / MERGE-JSON / MERGE-3WAY / REPORT, and the template-vs-vault
+versions). Call out explicitly if the plan includes:
+- a `MERGE-3WAY _CLAUDE.md` line (their operating manual may merge or conflict), or
+- a changed `.obsidian/PLUGINS-SETUP.md` (the manual-install list reprints on apply).
+
+If the dry-run reports the vault is already current (exit 0, "already current"),
+say so and STOP — nothing to do.
+
+## Step 4 — Confirm
+
+Ask the operator to confirm they want to apply this plan to `$VAULT`. Wait for
+an explicit yes. If they decline, STOP — make no changes.
+
+## Step 5 — Apply
+
+On confirmation, re-run the engine with `--yes` (same resolution, no prompt):
+
+```bash
+bash "$UPGRADE" --template-dir "$TEMPLATE" --vault-dir "$VAULT" --yes
+```
+
+## Step 6 — Surface the result
+
+Report the engine's outcome, preserving its loud signals:
+- **Success (exit 0):** "Upgrade complete — vault is now vX.Y.Z."
+- **`_CLAUDE.md` conflict / write failure (non-zero exit):** the engine did NOT
+  write the version stamp (fail-closed) and printed the reason. Surface that
+  loud alert verbatim — on a `_CLAUDE.md` conflict the original is kept and the
+  conflicted 3-way merge is in `_CLAUDE.md.template-merge`; the operator
+  resolves it by hand, deletes the sidecar, and re-runs (writes are idempotent).
+- **PLUGINS-SETUP reprint:** if the engine reprinted the manual-install table,
+  pass it through so the operator can install/update the AGPL/proprietary
+  plugins (Charts, Templater, …) that cannot be bundled.
+
+Do NOT attempt to resolve a conflict or re-run automatically — the
+content-preserving contract is the engine's; your job is to surface its result.
+
+## Exit codes (from the engine)
+
+- `0` — applied (or dry-run completed, or already current).
+- `1` — a partial upgrade: write failure or `_CLAUDE.md` conflict — stamp NOT
+  written, re-run after resolving.
+- `2` — env/usage error (e.g. template not located, vault dir missing, unknown
+  flag, unreadable marketplace.json, missing python3/git/sha256sum). On "could
+  not locate the himmel template", set `HIMMEL_DIR` or pass `--template-dir`.
+
+## Notes
+
+- The build of this skill was autonomous; its USE is interactive (the confirm
+  in Step 4 is the load-bearing safety gate).
+- Never edit user content. The engine only ever enumerates template-owned files;
+  this skill never writes vault files directly.

--- a/marketplace/plugins/obsidian-triage/tests/test-luna-upgrade-skill.sh
+++ b/marketplace/plugins/obsidian-triage/tests/test-luna-upgrade-skill.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Invariant tests for the obsidian-triage:luna-upgrade skill (HIMMEL-389 Phase 2).
+#
+# Scope: validates the structural invariants the skill + its slash-command
+# wrapper must hold. Does NOT exercise the runbook end-to-end (the upgrade
+# engine itself is covered by templates/luna-second-brain/scripts/test-upgrade.sh).
+# Mirrors test-luna-ingest-skill.sh (the established obsidian-triage skill-test
+# convention). What this gives us:
+#
+#   1. SKILL.md exists at the canonical skills/luna-upgrade/ path.
+#   2. SKILL.md frontmatter parses and contains `name` + `description`.
+#   3. `name` matches the skill directory name (loader convention).
+#   4. `description` starts with "Use when" (CSO best practice).
+#   5. Slash-command wrapper exists AND delegates to the skill (no body dup).
+#   6. The skill body documents the dry-run -> confirm -> apply contract,
+#      references the upgrade.sh engine, and uses --vault-dir (so a
+#      pre-Phase-0+1 vault without its own upgrade.sh still upgrades).
+
+set -u -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Plugin path: marketplace/plugins/obsidian-triage/ -> repo root is ../../..
+REPO_DIR="$(cd "$PLUGIN_DIR/../../.." && pwd)"
+
+SKILL="$PLUGIN_DIR/skills/luna-upgrade/SKILL.md"
+WRAPPER="$REPO_DIR/.claude/commands/luna-upgrade.md"
+
+pass=0
+fail=0
+
+assert() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  PASS  $desc"; pass=$((pass+1))
+    else
+        echo "  FAIL  $desc"; echo "         expected: $expected"; echo "         actual:   $actual"; fail=$((fail+1))
+    fi
+}
+
+echo "Test 1: SKILL.md exists at canonical path"
+[ -r "$SKILL" ] && exists=yes || exists=no
+assert "$SKILL exists" "yes" "$exists"
+if [ "$exists" = "no" ]; then
+    echo "Results: $pass passed, $fail failed"; exit 1
+fi
+
+echo "Test 2: SKILL.md frontmatter has required fields"
+fm_lines=$(awk '/^---$/{c++; next} c==1' "$SKILL")
+if printf '%s\n' "$fm_lines" | grep -qE "^name:[[:space:]]+luna-upgrade[[:space:]]*$"; then name_ok=yes; else name_ok=no; fi
+assert "frontmatter name: luna-upgrade" "yes" "$name_ok"
+if printf '%s\n' "$fm_lines" | grep -qE "^description:[[:space:]]+\S"; then desc_ok=yes; else desc_ok=no; fi
+assert "frontmatter description: present + non-empty" "yes" "$desc_ok"
+
+echo "Test 3: name matches skill directory (loader convention)"
+skill_dir_name="$(basename "$(dirname "$SKILL")")"
+assert "skill dir = luna-upgrade" "luna-upgrade" "$skill_dir_name"
+
+echo "Test 4: description starts with 'Use when' (CSO best practice)"
+if printf '%s\n' "$fm_lines" | grep -qE "^description:[[:space:]]+Use when"; then cso_ok=yes; else cso_ok=no; fi
+assert "description starts with 'Use when'" "yes" "$cso_ok"
+
+echo "Test 5: slash-command wrapper exists"
+[ -r "$WRAPPER" ] && wrap_exists=yes || wrap_exists=no
+assert "$WRAPPER exists" "yes" "$wrap_exists"
+
+echo "Test 6: wrapper delegates via actual Skill-tool invocation (does NOT duplicate runbook body)"
+if [ "$wrap_exists" = "yes" ]; then
+    # shellcheck disable=SC2016
+    if grep -qE 'Skill[[:space:]]*\{[[:space:]]*skill:[[:space:]]*"obsidian-triage:luna-upgrade"' "$WRAPPER" \
+       && grep -qE 'args:[[:space:]]*"\$ARGUMENTS"' "$WRAPPER"; then invokes=yes; else invokes=no; fi
+    assert "wrapper issues Skill { skill: \"obsidian-triage:luna-upgrade\", args: \"\$ARGUMENTS\" }" "yes" "$invokes"
+
+    if awk '/^---$/{c++; next} c==1' "$WRAPPER" | grep -qE "^allowed-tools:.*\bSkill\b"; then allowed=yes; else allowed=no; fi
+    assert "wrapper frontmatter allowed-tools: includes Skill" "yes" "$allowed"
+
+    skill_lines=$(wc -l < "$SKILL" | tr -d ' ')
+    wrap_lines=$(wc -l < "$WRAPPER" | tr -d ' ')
+    if [ "$wrap_lines" -lt $((skill_lines / 5)) ]; then is_thin=yes; else is_thin=no; fi
+    assert "wrapper is >=5x shorter than the skill (no body duplication)" "yes" "$is_thin"
+fi
+
+echo "Test 7: skill body documents the upgrade contract (engine + dry-run -> confirm -> apply + --vault-dir)"
+for marker in "upgrade.sh" "--dry-run" "--vault-dir" "--yes"; do
+    if grep -qF -e "$marker" "$SKILL"; then present=yes; else present=no; fi
+    assert "skill body references: $marker" "yes" "$present"
+done
+# The confirm step is the load-bearing UX invariant — assert it's documented.
+if grep -qiE "confirm" "$SKILL"; then confirm_ok=yes; else confirm_ok=no; fi
+assert "skill body documents a confirm step" "yes" "$confirm_ok"
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+if [ "$fail" -gt 0 ]; then exit 1; fi

--- a/templates/luna-second-brain/scripts/test-upgrade.sh
+++ b/templates/luna-second-brain/scripts/test-upgrade.sh
@@ -217,6 +217,71 @@ got_ver=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["versio
 assert_eq "T15 write-failure does not advance stamp" "0.1.0" "$got_ver"
 
 # ---------------------------------------------------------------------------
+# T16: resolver — generic known-path discovery (HIMMEL-389 Phase 2). With
+# --template-dir AND $HIMMEL_DIR unset and no himmel sibling, the resolver finds
+# the template via a generic $HOME-relative candidate path. Simulate by pointing
+# $HOME at a temp tree that holds github/himmel/templates/luna-second-brain.
+T16HOME="$TMP/t16-home"; T="$T16HOME/github/himmel/templates/luna-second-brain"; make_template "$T" "1.0.0"
+V="$TMP/t16-vault"; mkdir -p "$V/scripts/hooks"; stamp_vault "$V" "0.1.0"
+printf 'STALE\n' > "$V/scripts/hooks/check-commit-msg.sh"
+out=$(env -u HIMMEL_DIR HOME="$T16HOME" bash "$UPGRADE" --vault-dir "$V" --dry-run 2>&1); rc=$?
+assert_eq "T16 candidate-path rc" "0" "$rc"
+case "$out" in *"t16-home/github/himmel/templates/luna-second-brain"*) pass "T16 resolves via generic candidate path" ;; *) fail "T16 resolves via generic candidate path" "got: $out" ;; esac
+# A SINGLE clone must never false-warn. On a case-insensitive FS (Windows/macOS)
+# the `himmel` and `Himmel` candidate spellings BOTH resolve to this one dir, so
+# this case exercises the device:inode dedup branch (same key => no warn).
+case "$out" in *"multiple himmel checkouts"*) fail "T16 single clone: no false multi-checkout warn" "warned: $out" ;; *) pass "T16 single clone: no false multi-checkout warn (dedup branch)" ;; esac
+
+# ---------------------------------------------------------------------------
+# T17: resolver — explicit config ALWAYS wins over the candidate paths.
+#   (a) $HIMMEL_DIR beats a candidate-path template.
+#   (b) --template-dir beats both $HIMMEL_DIR and the candidate.
+T17HOME="$TMP/t17-home"; CAND="$T17HOME/github/himmel/templates/luna-second-brain"; make_template "$CAND" "9.9.9"
+HD="$TMP/t17-hd"; make_template "$HD/templates/luna-second-brain" "2.0.0"
+TDARG="$TMP/t17-td"; make_template "$TDARG" "3.0.0"
+V="$TMP/t17-vault"; mkdir -p "$V"; stamp_vault "$V" "0.1.0"
+out=$(HOME="$T17HOME" HIMMEL_DIR="$HD" bash "$UPGRADE" --vault-dir "$V" --dry-run 2>&1)
+case "$out" in *"t17-hd/templates/luna-second-brain"*) pass "T17a HIMMEL_DIR wins over candidate path" ;; *) fail "T17a HIMMEL_DIR wins over candidate path" "got: $out" ;; esac
+case "$out" in *"t17-home/github/himmel"*) fail "T17a HIMMEL_DIR wins over candidate path" "candidate leaked: $out" ;; *) pass "T17a candidate path not used when HIMMEL_DIR set" ;; esac
+out=$(HOME="$T17HOME" HIMMEL_DIR="$HD" bash "$UPGRADE" --template-dir "$TDARG" --vault-dir "$V" --dry-run 2>&1)
+case "$out" in *"t17-td"*) pass "T17b --template-dir wins over HIMMEL_DIR + candidate" ;; *) fail "T17b --template-dir wins over HIMMEL_DIR + candidate" "got: $out" ;; esac
+
+# ---------------------------------------------------------------------------
+# T18: resolver — clear error + hint when nothing resolves (no --template-dir,
+# $HIMMEL_DIR unset, $HOME has no candidate, vault has no himmel sibling).
+V="$TMP/t18-iso/vault"; mkdir -p "$V"
+out=$(env -u HIMMEL_DIR HOME="$TMP/t18-emptyhome" bash "$UPGRADE" --vault-dir "$V" --dry-run 2>&1); rc=$?
+assert_eq "T18 no-resolve rc" "2" "$rc"
+case "$out" in *"set HIMMEL_DIR"*) pass "T18 prints the set-HIMMEL_DIR hint" ;; *) fail "T18 prints the set-HIMMEL_DIR hint" "got: $out" ;; esac
+
+# ---------------------------------------------------------------------------
+# T19: resolver — TWO physically-distinct candidate checkouts under $HOME warn
+# and resolve to the FIRST in loop order (github/himmel before Documents/...).
+# Guards the silent dual-clone auto-pick (HIMMEL-389 Phase 2 CR).
+T19HOME="$TMP/t19-home"
+make_template "$T19HOME/github/himmel/templates/luna-second-brain" "1.1.1"
+make_template "$T19HOME/Documents/github/himmel/templates/luna-second-brain" "2.2.2"
+V="$TMP/t19-vault"; mkdir -p "$V"; stamp_vault "$V" "0.1.0"
+out=$(env -u HIMMEL_DIR HOME="$T19HOME" bash "$UPGRADE" --vault-dir "$V" --dry-run 2>&1); rc=$?
+assert_eq "T19 multi-checkout rc" "0" "$rc"
+case "$out" in *"multiple himmel checkouts"*) pass "T19 warns on multiple distinct checkouts" ;; *) fail "T19 warns on multiple distinct checkouts" "got: $out" ;; esac
+case "$out" in *"(v1.1.1)"*) pass "T19 resolves to first candidate (github/himmel, v1.1.1)" ;; *) fail "T19 resolves to first candidate (github/himmel, v1.1.1)" "got: $out" ;; esac
+case "$out" in *"(v2.2.2)"*) fail "T19 must not pick the later Documents candidate" "v2.2.2 leaked: $out" ;; *) pass "T19 does not pick the later Documents candidate" ;; esac
+
+# ---------------------------------------------------------------------------
+# T20: resolver — a candidate dir WITHOUT marketplace.json is a decoy: skip it
+# and resolve a later valid candidate instead of selecting-then-aborting. One
+# valid candidate => no multi-checkout warning.
+T20HOME="$TMP/t20-home"
+mkdir -p "$T20HOME/github/himmel/templates/luna-second-brain"   # decoy: dir, no marketplace.json
+make_template "$T20HOME/Documents/github/himmel/templates/luna-second-brain" "3.3.3"
+V="$TMP/t20-vault"; mkdir -p "$V"; stamp_vault "$V" "0.1.0"
+out=$(env -u HIMMEL_DIR HOME="$T20HOME" bash "$UPGRADE" --vault-dir "$V" --dry-run 2>&1); rc=$?
+assert_eq "T20 decoy-skip rc" "0" "$rc"
+case "$out" in *"(v3.3.3)"*) pass "T20 skips the decoy and resolves the valid candidate" ;; *) fail "T20 skips the decoy and resolves the valid candidate" "got: $out" ;; esac
+case "$out" in *"multiple himmel checkouts"*) fail "T20 must not warn (only one valid)" "warned: $out" ;; *) pass "T20 no false multi-checkout warn with a decoy present" ;; esac
+
+# ---------------------------------------------------------------------------
 # T11: ACCEPTANCE — run against a COPY of the real luna vault, never the live one.
 LUNA="$HOME/Documents/luna"
 if [ -d "$LUNA" ] && [ -d "$LUNA/50-Journal" ]; then

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -14,8 +14,10 @@
 #
 #   --template-dir DIR  fresh himmel template root (contains marketplace/ +
 #                       _CLAUDE.md). Default resolution: --template-dir >
-#                       $HIMMEL_DIR/templates/luna-second-brain > a sibling-dir
-#                       scan for a himmel checkout carrying the template.
+#                       $HIMMEL_DIR/templates/luna-second-brain > generic
+#                       $HOME-relative candidate paths ($HOME[/Documents]/github/
+#                       {himmel,Himmel}) > a sibling-dir scan for a himmel
+#                       checkout carrying the template.
 #   --vault-dir DIR     the vault to upgrade. Default: the parent of this
 #                       script's dir (scripts/.. — i.e. run from inside a vault).
 #   --dry-run           print the plan, make zero filesystem changes.
@@ -51,7 +53,8 @@ upgrade.sh — content-preserving vault/template upgrade (HIMMEL-389)
   bash scripts/upgrade.sh [--template-dir DIR] [--vault-dir DIR] [--dry-run] [--yes]
 
   --template-dir DIR  fresh himmel template root (default: --template-dir >
-                      $HIMMEL_DIR/templates/luna-second-brain > sibling scan).
+                      $HIMMEL_DIR/templates/luna-second-brain > $HOME-relative
+                      candidate paths (github/{himmel,Himmel}) > sibling scan).
   --vault-dir DIR     the vault to upgrade (default: scripts/.. — run from a vault).
   --dry-run           print the plan, make zero filesystem changes.
   --yes, -y           skip the confirm prompt.
@@ -66,11 +69,45 @@ USAGE
 done
 
 # ---------------------------------------------------------------------------
-# Resolve template dir: --template-dir > $HIMMEL_DIR > sibling-dir scan.
+# Resolve template dir: --template-dir > $HIMMEL_DIR > generic $HOME-relative
+# candidate paths > sibling-dir scan. Explicit config (--template-dir /
+# $HIMMEL_DIR) ALWAYS wins over the candidate paths.
 resolve_template() {
     local rel="templates/luna-second-brain"
     if [ -n "$TEMPLATE_DIR" ]; then printf '%s' "$TEMPLATE_DIR"; return; fi
     if [ -n "${HIMMEL_DIR:-}" ] && [ -d "$HIMMEL_DIR/$rel" ]; then printf '%s' "$HIMMEL_DIR/$rel"; return; fi
+    # Generic $HOME-relative candidate paths: common himmel clone conventions so
+    # the skill/CLI work zero-config when the vault and himmel are NOT siblings.
+    # Public-safe — derived from $HOME, never an operator-specific string. Both
+    # the lowercase `himmel` and capitalized `Himmel` clone-dir conventions. A
+    # candidate must carry a real template (marketplace.json present), so a
+    # half-populated decoy dir is skipped rather than selected-then-aborted. If
+    # more than one PHYSICALLY-distinct checkout matches (e.g. a stale clone
+    # beside the live one — the dual-clone trap), warn and use the first; the
+    # operator disambiguates with --template-dir / $HIMMEL_DIR.
+    # Loop order is contractual: earlier entries win on a tie (github/ before
+    # Documents/github/); test T19 pins this. Do not reorder without updating it.
+    if [ -n "${HOME:-}" ]; then
+        local h cand_dir cand_key first_dir="" first_key=""
+        for h in "$HOME/github/himmel" "$HOME/github/Himmel" \
+                 "$HOME/Documents/github/himmel" "$HOME/Documents/github/Himmel"; do
+            cand_dir="$h/$rel"
+            [ -f "$cand_dir/marketplace/.claude-plugin/marketplace.json" ] || continue
+            # Identity key dedupes case-spelling variants of ONE physical dir
+            # (case-insensitive FS on Windows/macOS) so a single clone never
+            # looks like "multiple checkouts". device:inode via GNU then BSD
+            # stat; lowercased-path fallback when stat is unavailable.
+            cand_key="$(stat -c '%d:%i' "$cand_dir" 2>/dev/null || stat -f '%d:%i' "$cand_dir" 2>/dev/null)"
+            [ -n "$cand_key" ] || cand_key="$(printf '%s' "$cand_dir" | tr '[:upper:]' '[:lower:]')"
+            if [ -z "$first_dir" ]; then
+                first_dir="$cand_dir"; first_key="$cand_key"
+            elif [ "$cand_key" != "$first_key" ]; then
+                echo "upgrade: WARNING — multiple himmel checkouts found under \$HOME; using $first_dir. Pass --template-dir or set HIMMEL_DIR to disambiguate." >&2
+                break
+            fi
+        done
+        [ -n "$first_dir" ] && { printf '%s' "$first_dir"; return; }
+    fi
     # Sibling scan: look one level up from the vault for a himmel checkout.
     local base; base="$(cd "$VAULT_DIR/.." 2>/dev/null && pwd)"
     if [ -n "$base" ]; then


### PR DESCRIPTION
## HIMMEL-389 Phase 2 — `/luna-upgrade` skill + generic template resolver

Adds the ergonomic **dry-run → confirm → apply** surface over the Phase 0+1
`upgrade.sh` engine, so an operator can pull template updates into an existing
luna-second-brain vault from inside a vault session.

- **`upgrade.sh` resolver**: generic `$HOME`-relative candidate-path discovery
  (`github/{himmel,Himmel}`, ±`Documents/`) between `$HIMMEL_DIR` and the sibling
  scan — works zero-config when the vault and himmel aren't siblings. Explicit
  config always wins; candidates require a real template (`marketplace.json`,
  decoys skipped); >1 physically-distinct checkout warns (device:inode dedup
  avoids false-warn on case-insensitive FS). Public-safe paths.
- **`obsidian-triage:luna-upgrade` SKILL.md**: dry-run → surface plan + any
  `_CLAUDE.md` conflict / PLUGINS-SETUP reprint → confirm → apply; invokes the
  engine with `--vault-dir` so a pre-Phase-0+1 vault upgrades; all merge logic
  stays in the engine.
- Thin `.claude/commands/luna-upgrade.md` wrapper + `docs/commands-catalog.md` row.
- Tests: `test-upgrade.sh` T16–T20 + new `test-luna-upgrade-skill.sh`; shellcheck
  clean; pwsh smoke green.

Platforms tested: windows (POSIX best-effort). Security reviewed: manual.
