### PR TITLE
fix(vault): [HIMMEL-420] route sibling scan through the same template-pick gate

### DIFF
--- a/templates/luna-second-brain/scripts/test-upgrade.sh
+++ b/templates/luna-second-brain/scripts/test-upgrade.sh
@@ -282,6 +282,33 @@ case "$out" in *"(v3.3.3)"*) pass "T20 skips the decoy and resolves the valid ca
 case "$out" in *"multiple himmel checkouts"*) fail "T20 must not warn (only one valid)" "warned: $out" ;; *) pass "T20 no false multi-checkout warn with a decoy present" ;; esac
 
 # ---------------------------------------------------------------------------
+# T21: sibling scan — a decoy sibling (dir, no marketplace.json) is SKIPPED and a
+# later valid sibling resolves; one valid => no warning (HIMMEL-420 — the sibling
+# surface now matches the $HOME-candidate surface). Forces the sibling path with
+# $HIMMEL_DIR unset + a $HOME holding no candidate, and the vault under $base.
+T21BASE="$TMP/t21-base"
+mkdir -p "$T21BASE/himmel/templates/luna-second-brain"   # decoy sibling: no marketplace.json
+make_template "$T21BASE/ztools-himmel/templates/luna-second-brain" "4.4.4"
+V="$T21BASE/vault"; mkdir -p "$V"; stamp_vault "$V" "0.1.0"
+out=$(env -u HIMMEL_DIR HOME="$TMP/t21-emptyhome" bash "$UPGRADE" --vault-dir "$V" --dry-run 2>&1); rc=$?
+assert_eq "T21 sibling decoy-skip rc" "0" "$rc"
+case "$out" in *"(v4.4.4)"*) pass "T21 sibling scan skips the decoy and resolves the valid sibling" ;; *) fail "T21 sibling scan skips the decoy and resolves the valid sibling" "got: $out" ;; esac
+case "$out" in *"multiple himmel checkouts"*) fail "T21 sibling must not warn (only one valid)" "warned: $out" ;; *) pass "T21 sibling no false multi-checkout warn with a decoy present" ;; esac
+
+# ---------------------------------------------------------------------------
+# T22: sibling scan — TWO physically-distinct valid sibling checkouts warn and
+# resolve to the explicit `himmel` first (HIMMEL-420).
+T22BASE="$TMP/t22-base"
+make_template "$T22BASE/himmel/templates/luna-second-brain" "5.5.5"
+make_template "$T22BASE/zzz-himmel/templates/luna-second-brain" "6.6.6"
+V="$T22BASE/vault"; mkdir -p "$V"; stamp_vault "$V" "0.1.0"
+out=$(env -u HIMMEL_DIR HOME="$TMP/t22-emptyhome" bash "$UPGRADE" --vault-dir "$V" --dry-run 2>&1); rc=$?
+assert_eq "T22 sibling multi rc" "0" "$rc"
+case "$out" in *"multiple himmel checkouts"*) pass "T22 sibling scan warns on multiple distinct checkouts" ;; *) fail "T22 sibling scan warns on multiple distinct checkouts" "got: $out" ;; esac
+case "$out" in *"(v5.5.5)"*) pass "T22 sibling resolves to explicit 'himmel' first" ;; *) fail "T22 sibling resolves to explicit 'himmel' first" "got: $out" ;; esac
+case "$out" in *"(v6.6.6)"*) fail "T22 must not pick the later glob match zzz-himmel" "v6.6.6 leaked: $out" ;; *) pass "T22 sibling does not pick the later glob match" ;; esac
+
+# ---------------------------------------------------------------------------
 # T11: ACCEPTANCE — run against a COPY of the real luna vault, never the live one.
 LUNA="$HOME/Documents/luna"
 if [ -d "$LUNA" ] && [ -d "$LUNA/50-Journal" ]; then

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -69,52 +69,69 @@ USAGE
 done
 
 # ---------------------------------------------------------------------------
+# Pick a template dir from a list of candidate himmel-checkout ROOTS read on
+# stdin (one per line; "$rel" is appended to each). Echo the FIRST root that
+# carries a real template (marketplace.json present) — a half-populated decoy
+# root is skipped rather than selected-then-aborted. If more than one
+# PHYSICALLY-distinct checkout matches (e.g. a stale clone beside the live one
+# — the dual-clone trap), warn to stderr and use the first; the operator
+# disambiguates with --template-dir / $HIMMEL_DIR. Returns 1 (echoes nothing)
+# when none match. Used for BOTH the $HOME-candidate step and the sibling scan
+# so the two surfaces behave identically (HIMMEL-420). Loop/input order is
+# contractual: earlier roots win on a tie (tests T19/T22 pin this).
+pick_template_root() {
+    local rel="$1" root tdir key first_dir="" first_key=""
+    while IFS= read -r root; do
+        [ -n "$root" ] || continue
+        tdir="$root/$rel"
+        [ -f "$tdir/marketplace/.claude-plugin/marketplace.json" ] || continue
+        # Identity key dedupes case-spelling variants of ONE physical dir
+        # (case-insensitive FS on Windows/macOS) so a single clone never looks
+        # like "multiple checkouts". device:inode via GNU then BSD stat;
+        # lowercased-path fallback when stat is unavailable.
+        key="$(stat -c '%d:%i' "$tdir" 2>/dev/null || stat -f '%d:%i' "$tdir" 2>/dev/null)"
+        [ -n "$key" ] || key="$(printf '%s' "$tdir" | tr '[:upper:]' '[:lower:]')"
+        if [ -z "$first_dir" ]; then
+            first_dir="$tdir"; first_key="$key"
+        elif [ "$key" != "$first_key" ]; then
+            echo "upgrade: WARNING — multiple himmel checkouts found; using $first_dir. Pass --template-dir or set HIMMEL_DIR to disambiguate." >&2
+            break
+        fi
+    done
+    [ -n "$first_dir" ] || return 1
+    printf '%s' "$first_dir"
+}
+
+# ---------------------------------------------------------------------------
 # Resolve template dir: --template-dir > $HIMMEL_DIR > generic $HOME-relative
 # candidate paths > sibling-dir scan. Explicit config (--template-dir /
-# $HIMMEL_DIR) ALWAYS wins over the candidate paths.
+# $HIMMEL_DIR) ALWAYS wins over the discovered candidates.
 resolve_template() {
-    local rel="templates/luna-second-brain"
+    local rel="templates/luna-second-brain" got
     if [ -n "$TEMPLATE_DIR" ]; then printf '%s' "$TEMPLATE_DIR"; return; fi
     if [ -n "${HIMMEL_DIR:-}" ] && [ -d "$HIMMEL_DIR/$rel" ]; then printf '%s' "$HIMMEL_DIR/$rel"; return; fi
-    # Generic $HOME-relative candidate paths: common himmel clone conventions so
-    # the skill/CLI work zero-config when the vault and himmel are NOT siblings.
-    # Public-safe — derived from $HOME, never an operator-specific string. Both
-    # the lowercase `himmel` and capitalized `Himmel` clone-dir conventions. A
-    # candidate must carry a real template (marketplace.json present), so a
-    # half-populated decoy dir is skipped rather than selected-then-aborted. If
-    # more than one PHYSICALLY-distinct checkout matches (e.g. a stale clone
-    # beside the live one — the dual-clone trap), warn and use the first; the
-    # operator disambiguates with --template-dir / $HIMMEL_DIR.
-    # Loop order is contractual: earlier entries win on a tie (github/ before
-    # Documents/github/); test T19 pins this. Do not reorder without updating it.
+    # Generic $HOME-relative candidate checkouts: common himmel clone conventions
+    # so the skill/CLI work zero-config when the vault and himmel are NOT
+    # siblings. Public-safe — derived from $HOME, never an operator-specific
+    # string. Both the lowercase `himmel` and capitalized `Himmel` conventions.
+    # Order is contractual: github/ before Documents/github/ (test T19 pins it).
     if [ -n "${HOME:-}" ]; then
-        local h cand_dir cand_key first_dir="" first_key=""
-        for h in "$HOME/github/himmel" "$HOME/github/Himmel" \
-                 "$HOME/Documents/github/himmel" "$HOME/Documents/github/Himmel"; do
-            cand_dir="$h/$rel"
-            [ -f "$cand_dir/marketplace/.claude-plugin/marketplace.json" ] || continue
-            # Identity key dedupes case-spelling variants of ONE physical dir
-            # (case-insensitive FS on Windows/macOS) so a single clone never
-            # looks like "multiple checkouts". device:inode via GNU then BSD
-            # stat; lowercased-path fallback when stat is unavailable.
-            cand_key="$(stat -c '%d:%i' "$cand_dir" 2>/dev/null || stat -f '%d:%i' "$cand_dir" 2>/dev/null)"
-            [ -n "$cand_key" ] || cand_key="$(printf '%s' "$cand_dir" | tr '[:upper:]' '[:lower:]')"
-            if [ -z "$first_dir" ]; then
-                first_dir="$cand_dir"; first_key="$cand_key"
-            elif [ "$cand_key" != "$first_key" ]; then
-                echo "upgrade: WARNING — multiple himmel checkouts found under \$HOME; using $first_dir. Pass --template-dir or set HIMMEL_DIR to disambiguate." >&2
-                break
-            fi
-        done
-        [ -n "$first_dir" ] && { printf '%s' "$first_dir"; return; }
+        if got="$(printf '%s\n' \
+                "$HOME/github/himmel" "$HOME/github/Himmel" \
+                "$HOME/Documents/github/himmel" "$HOME/Documents/github/Himmel" \
+                | pick_template_root "$rel")"; then
+            printf '%s' "$got"; return
+        fi
     fi
-    # Sibling scan: look one level up from the vault for a himmel checkout.
+    # Sibling scan: look one level up from the vault for a himmel checkout. Goes
+    # through pick_template_root too, so it is decoy-safe and warns on multiple
+    # distinct sibling checkouts, matching the $HOME surface (HIMMEL-420).
     local base; base="$(cd "$VAULT_DIR/.." 2>/dev/null && pwd)"
     if [ -n "$base" ]; then
         local c
-        for c in "$base"/himmel "$base"/Himmel "$base"/*/; do
-            [ -d "$c/$rel" ] && { printf '%s' "$c/$rel"; return; }
-        done
+        if got="$( { for c in "$base"/himmel "$base"/Himmel "$base"/*/; do printf '%s\n' "${c%/}"; done; } | pick_template_root "$rel")"; then
+            printf '%s' "$got"; return
+        fi
     fi
     return 1
 }


### PR DESCRIPTION
fix(vault): [HIMMEL-420] route sibling scan through the same template-pick gate

Follow-up to HIMMEL-389 Phase 2: the $HOME-candidate step was decoy-safe and
warned on multiple distinct checkouts, but the pre-existing sibling scan was
neither, leaving upgrade.sh's resolver inconsistent.

- Extract pick_template_root(): reads candidate checkout roots on stdin, skips
  any without a real template (marketplace.json), dedupes case-spelling variants
  of one dir by device:inode (GNU then BSD stat; lowercased-path fallback), warns
  once on >1 physically-distinct match, uses the first.
- Both the $HOME-candidate step AND the sibling scan call it now → identical
  behavior. Resolution order unchanged.
- Tests T21/T22; T16-T20 still pass; shellcheck clean.

Platforms tested: windows
Security reviewed: manual


[HIMMEL-420]: https://yotamleo.atlassian.net/browse/HIMMEL-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ