### PR TITLE
feat(commands): [HIMMEL-426] rename /update to /himmel-update + add /himmel-update-all combo

### DIFF
--- a/.claude/commands/himmel-update-all.md
+++ b/.claude/commands/himmel-update-all.md
@@ -1,0 +1,33 @@
+---
+allowed-tools: Bash, Read, Skill
+description: Update BOTH surfaces in one shot — the himmel harness (/himmel-update) then the luna vault (/luna-upgrade). Pass --check to dry-run both without changing anything.
+argument-hint: [--check] [--vault <path>] [--template-dir <path>]
+---
+
+# /himmel-update-all — update the himmel harness AND the luna vault (HIMMEL-426)
+
+himmel has two independent update surfaces:
+- **harness** (hooks, slash commands, scripts, plugins) — pulled by `/himmel-update` / `scripts/himmel-update.sh`.
+- **luna vault** (bundled-plugin assets, `.obsidian` config, `_CLAUDE.md`, scaffold) — refreshed by the `obsidian-triage:luna-upgrade` skill, content-preserving.
+
+This combo runs both, **harness first** (so the latest template + skill are on disk before the vault upgrade reads them), then the vault. Run the two steps in order:
+
+**Step 1 — harness.** If `$ARGUMENTS` contains `--check`, run the dry-run form; otherwise the real update:
+
+```bash
+bash scripts/himmel-update.sh --check   # when --check was passed
+# otherwise:
+bash scripts/himmel-update.sh
+```
+
+Only `--check` is forwarded to the harness step — the vault-specific flags (`--vault`, `--template-dir`) are not understood by `himmel-update.sh` and must NOT be passed to it.
+
+**Step 2 — luna vault.** Delegate to the skill, forwarding the full `$ARGUMENTS` (the skill handles `--check` / `--vault` / `--template-dir` itself, and runs its own dry-run → confirm → apply gate):
+
+```
+Skill { skill: "obsidian-triage:luna-upgrade", args: "$ARGUMENTS" }
+```
+
+If the `obsidian-triage` plugin is not installed (the `Skill` tool refuses with "skill not found" or similar): report the harness result, then fail the vault step loudly with `ERR himmel-update-all: obsidian-triage plugin not installed; /plugin install obsidian-triage from the himmel marketplace, or run bash templates/luna-second-brain/scripts/upgrade.sh directly.` Do NOT inline the runbook as a fallback.
+
+After both steps: harness hooks are live immediately; **restart any running Claude session** to pick up plugin / slash-command / skill changes.

--- a/.claude/commands/himmel-update.md
+++ b/.claude/commands/himmel-update.md
@@ -1,5 +1,5 @@
 ---
-description: Update this himmel checkout — git pull + marketplace re-sync. autoUpdate does NOT deliver himmel updates.
+description: Update this himmel checkout (harness) — git pull + marketplace re-sync. autoUpdate does NOT deliver himmel updates. For the luna vault, use /luna-upgrade; for both at once, /himmel-update-all.
 ---
 
 Updates an existing himmel install. **`git pull` is the only thing that
@@ -15,7 +15,7 @@ freshly-pulled dir.
 Run:
 
 ```bash
-bash scripts/update.sh
+bash scripts/himmel-update.sh
 ```
 
 After it finishes: hooks are live immediately; **restart any running Claude

--- a/docs/commands-catalog.md
+++ b/docs/commands-catalog.md
@@ -92,4 +92,5 @@ the github-repo ingest skill these dispatch to.
 | Command | What it does |
 |---|---|
 | /quiet-run | Run a noisy command quietly — one OK/ERR line + log path |
-| /update | Update this himmel checkout — git pull + marketplace re-sync. autoUpdate does NOT deliver himmel updates. |
+| /himmel-update | Update this himmel checkout (harness) — git pull + marketplace re-sync. autoUpdate does NOT deliver himmel updates. |
+| /himmel-update-all | Update BOTH the himmel harness (/himmel-update) and the luna vault (/luna-upgrade) in one shot; `--check` dry-runs both. |

--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -171,7 +171,7 @@ bash scripts/setup.sh
 
 `scripts/setup.sh` handles: pre-commit install, Jira CLI build, `.env` from `.env.example`.
 
-To **update** an existing checkout later, run `/update` (or `bash scripts/update.sh`):
+To **update** an existing checkout later, run `/himmel-update` (or `bash scripts/himmel-update.sh`):
 `git pull` is what delivers himmel updates — marketplace `autoUpdate` does not.
 See [`updating.md`](updating.md).
 

--- a/docs/setup/updating.md
+++ b/docs/setup/updating.md
@@ -1,8 +1,12 @@
 # Updating himmel
 
 **TL;DR — `git pull` your himmel checkout. Marketplace `autoUpdate` does NOT
-deliver himmel updates on its own.** Run `/update` (or `bash scripts/update.sh`)
-to do the pull + marketplace re-sync in one step.
+deliver himmel updates on its own.** Run `/himmel-update` (or `bash
+scripts/himmel-update.sh`) to do the pull + marketplace re-sync in one step.
+
+> This updates the himmel **harness**. To refresh an existing **luna vault**
+> from the current template, use [`/luna-upgrade`](../../marketplace/plugins/obsidian-triage/skills/luna-upgrade/SKILL.md);
+> to do both in one shot, use `/himmel-update-all`.
 
 ## Why a pull is required
 
@@ -39,12 +43,12 @@ covers the core hooks.**
 ## How to update
 
 ```bash
-/update                 # inside Claude Code
+/himmel-update                 # inside Claude Code
 # or
-bash scripts/update.sh  # from a shell, in the himmel checkout
+bash scripts/himmel-update.sh  # from a shell, in the himmel checkout
 ```
 
-`scripts/update.sh`:
+`scripts/himmel-update.sh`:
 1. `git pull --ff-only` (fails loudly if your branch has diverged from upstream
    or local edits block the update — reconcile manually, updates land on the
    default branch).

--- a/marketplace/plugins/obsidian-triage/skills/vault-lint/SKILL.md
+++ b/marketplace/plugins/obsidian-triage/skills/vault-lint/SKILL.md
@@ -37,5 +37,5 @@ Run the vault-lint engine against a vault root. Deterministic, report-only, file
 the profile location; `--no-report` suppresses the written report (stdout-only run).
 
 **Vendor-drift guard:** `marketplace/plugins/obsidian-triage/skills/vault-lint/check-vendor-drift.sh`
-(lean-invoke — run manually or via `/update`; not a pre-commit hook) flags when the upstream
+(lean-invoke — run manually or via `/himmel-update`; not a pre-commit hook) flags when the upstream
 `claude-obsidian:wiki-lint` this skill generalizes has changed, so capability gaps surface for review.

--- a/scripts/himmel-update.sh
+++ b/scripts/himmel-update.sh
@@ -36,7 +36,7 @@ if [ "${1:-}" = "--check" ] || [ "${1:-}" = "--dry-run" ]; then
     if [ "$behind" = "0" ]; then
         echo "status:   up to date — nothing to pull."
     elif [ "$behind" != "?" ]; then
-        echo "status:   $behind commit(s) behind — run /update (or bash scripts/update.sh) to pull."
+        echo "status:   $behind commit(s) behind — run /himmel-update (or bash scripts/himmel-update.sh) to pull."
     fi
     exit 0
 fi

--- a/scripts/hooks/check-update-available.sh
+++ b/scripts/hooks/check-update-available.sh
@@ -97,7 +97,7 @@ case "$behind" in ''|*[!0-9]*) exit 0 ;; esac
 # ─── emit nudge ──────────────────────────────────────────────────────────────
 cat <<EOF
 <system-reminder>
-himmel is $behind commit(s) behind $upstream. Run /update to pull the latest fixes and hooks.
+himmel is $behind commit(s) behind $upstream. Run /himmel-update to pull the latest fixes and hooks.
 (This check won't repeat for another ${INTERVAL}s.)
 </system-reminder>
 EOF

--- a/scripts/hooks/test-check-update-available.sh
+++ b/scripts/hooks/test-check-update-available.sh
@@ -140,7 +140,7 @@ SD="$TMP/s4"; mkdir -p "$SD"
 out=$(UPDATE_CHECK_STATE_DIR="$SD" CLAUDE_PROJECT_DIR="$CHECKOUT_DIR" bash "$HOOK" 2>/dev/null) || true
 assert_contains "behind=2: system-reminder tag" "system-reminder" "$out"
 assert_contains "behind=2: count in output" "2 commit" "$out"
-assert_contains "behind=2: /update mention" "/update" "$out"
+assert_contains "behind=2: /himmel-update mention" "/himmel-update" "$out"
 
 # ─── Test 5: no remote at all → silent (fetch-exit path) ───────────────────────────────────
 echo "Test 5: no remote → silent (fetch-exit path)"

--- a/scripts/test-himmel-update.sh
+++ b/scripts/test-himmel-update.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# test-himmel-update.sh — smoke test for the --check (read-only) path of
+# scripts/himmel-update.sh (HIMMEL-426).
+#
+# himmel-update.sh resolves its own repo root via BASH_SOURCE/.. and cd's there,
+# so we test it by COPYING it into a throwaway mock clone and running it from
+# inside that clone. This exercises the real --check logic (git fetch + behind
+# count + the operator-facing wording) with no network and without touching the
+# himmel checkout itself.
+#
+# Covers:
+#   1. --check, behind=N → reports "behind:   N" + points at /himmel-update.
+#   2. --check, behind=0 → reports "up to date".
+#
+# Bash 3.2 compatible.
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/himmel-update.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "FAIL: $SCRIPT not found" >&2
+    exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+assert_pass() { pass=$((pass + 1)); echo "  PASS: $1"; }
+assert_fail() { fail=$((fail + 1)); echo "  FAIL: $1"; }
+assert_contains() {
+    local desc="$1" pattern="$2" actual="$3"
+    if printf '%s' "$actual" | grep -q "$pattern"; then
+        assert_pass "$desc"
+    else
+        assert_fail "$desc — expected pattern '$pattern', got: $actual"
+    fi
+}
+
+_repo_counter=0
+
+# Build a mock upstream bare repo + a clone that is N commits behind it, with
+# himmel-update.sh dropped into the clone's scripts/ dir so it resolves the
+# clone as its root. Sets CHECKOUT_DIR.
+make_repo_behind() {
+    local n="${1:-1}"
+    _repo_counter=$((_repo_counter + 1))
+    local base="$TMP/repo_${n}_${_repo_counter}"
+    local bare="$base/upstream.git"
+    local clone="$base/checkout"
+    mkdir -p "$bare" "$clone"
+
+    git init --bare --quiet "$bare"
+    git init --quiet "$clone"
+    git -C "$clone" config user.email "test@test.test"
+    git -C "$clone" config user.name "Test"
+    git -C "$clone" remote add origin "$bare"
+    printf 'init\n' > "$clone/file.txt"
+    git -C "$clone" add file.txt
+    git -C "$clone" commit --quiet -m "init"
+
+    local defbranch
+    defbranch=$(git -C "$clone" rev-parse --abbrev-ref HEAD)
+    git -C "$clone" push --quiet origin "HEAD:$defbranch" 2>/dev/null
+    git -C "$clone" branch --quiet --set-upstream-to="origin/$defbranch" "$defbranch" 2>/dev/null || \
+        git -C "$clone" branch --quiet -u "origin/$defbranch" "$defbranch" 2>/dev/null || true
+
+    if [ "$n" -gt 0 ]; then
+        local work="$base/work"
+        git clone --quiet "$bare" "$work" 2>/dev/null
+        git -C "$work" config user.email "test@test.test"
+        git -C "$work" config user.name "Test"
+        local i
+        for i in $(seq 1 "$n"); do
+            printf '%s\n' "upstream-commit-$i" > "$work/file.txt"
+            git -C "$work" add file.txt
+            git -C "$work" commit --quiet -m "upstream $i"
+        done
+        git -C "$work" push --quiet origin "$defbranch" 2>/dev/null
+    fi
+
+    # Drop the script under test into the clone so BASH_SOURCE/.. == clone root.
+    mkdir -p "$clone/scripts"
+    cp "$SCRIPT" "$clone/scripts/himmel-update.sh"
+    CHECKOUT_DIR="$clone"
+}
+
+# ─── Test 1: --check, behind=2 ───────────────────────────────────────────────
+echo "Test 1: --check behind=2 → reports count + /himmel-update"
+make_repo_behind 2
+out=$(bash "$CHECKOUT_DIR/scripts/himmel-update.sh" --check 2>&1) || true
+assert_contains "behind=2: behind count reported" "behind:   2" "$out"
+assert_contains "behind=2: points at /himmel-update" "/himmel-update" "$out"
+assert_contains "behind=2: references himmel-update.sh" "scripts/himmel-update.sh" "$out"
+
+# ─── Test 2: --check, behind=0 ───────────────────────────────────────────────
+echo "Test 2: --check behind=0 → reports up to date"
+make_repo_behind 0
+out=$(bash "$CHECKOUT_DIR/scripts/himmel-update.sh" --check 2>&1) || true
+assert_contains "behind=0: behind count is 0" "behind:   0" "$out"
+assert_contains "behind=0: up to date message" "up to date" "$out"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo
+echo "RESULTS: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## What

Hard rename (no alias) of the himmel-**harness** update command to disambiguate it from `/luna-upgrade` (vault content):

- `/update` → `/himmel-update` — `.claude/commands/update.md` → `himmel-update.md`, `scripts/update.sh` → `scripts/himmel-update.sh`, the SessionStart update nudge (`check-update-available.sh`) + its test, and operator-facing docs.
- New **`/himmel-update-all`** combo command: runs the harness update (forwarding only `--check`) then delegates to the `obsidian-triage:luna-upgrade` skill (forwarding full args); degrades loudly if `obsidian-triage` is absent.
- Adds `scripts/test-himmel-update.sh` — mock-repo `--check` coverage the script previously lacked.

## Test plan

- `scripts/test-himmel-update.sh` — 5/5 pass.
- `scripts/hooks/test-check-update-available.sh` — 13/13 pass.
- No `/update` or `scripts/update.sh` references remain.

Reviewed via the multi-agent CR (free cross-model panel + code-reviewer/pr-test-analyzer/comment-analyzer): 0 Critical / 0 Important.

Platforms tested: windows
Security reviewed: pr-review-toolkit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
