### PR TITLE
feat(minerva): [HIMMEL-428] /minerva pipeline skill — brainstorm→critic→spec→critic→plan (Piece 1)

### DIFF
--- a/marketplace/plugins/himmel-ops/.claude-plugin/plugin.json
+++ b/marketplace/plugins/himmel-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "himmel-ops",
-  "version": "0.1.0",
-  "description": "Harness-meta operational skills for himmel. Load-on-trigger guardrail-recovery playbook (stuck-playbook) that surfaces escape-hatches when an auto-mode write is denied, a Bash command falls through to the classifier, a permission prompt hangs, or a pre-push gate fails — so operational/troubleshooting rules stay out of the always-on root CLAUDE.md (HIMMEL-211).",
+  "version": "0.2.0",
+  "description": "Harness-meta operational skills for himmel. Load-on-trigger guardrail-recovery playbook (stuck-playbook) that surfaces escape-hatches when an auto-mode write is denied, a Bash command falls through to the classifier, a permission prompt hangs, or a pre-push gate fails — so operational/troubleshooting rules stay out of the always-on root CLAUDE.md (HIMMEL-211). Plus the minerva pipeline skill (/minerva): brainstorm→critic→spec→critic→plan with adversarial critic loops between stages (HIMMEL-428).",
   "author": {
     "name": "yotamleo"
   },
@@ -10,6 +10,8 @@
     "guardrails",
     "operational",
     "stuck",
-    "load-on-trigger"
+    "load-on-trigger",
+    "minerva",
+    "pipeline"
   ]
 }

--- a/marketplace/plugins/himmel-ops/README.md
+++ b/marketplace/plugins/himmel-ops/README.md
@@ -81,14 +81,16 @@ red-teamed before it advances:
    criteria); loop fix→re-critic, cap 2 rounds.
 3. **Plan** — drives `superpowers:writing-plans` on the approved spec.
 4. **Plan critic** — adversarial subagent red-teams the plan (unordered deps,
-   untestable steps, missing verification, over/under-decomposition); cap 2 rounds.
+   untestable steps, missing verification, over/under-decomposition, assumptions
+   not grounded in the spec); cap 2 rounds.
 5. **Terminal** — a critic-hardened plan; offers hand-off to
    `superpowers:subagent-driven-development` / `executing-plans`. minerva does
    not implement.
 
 **Gates are mode-driven.** `scripts/autonomy-mode.sh` reports `autonomous` when
-`HIMMEL_INITIATIVE` or `HIMMEL_INITIATIVE_OVERNIGHT` is set (initiative mode,
-HIMMEL-425) — then the critics are the only gate and the pipeline auto-advances.
+`HIMMEL_INITIATIVE` or `HIMMEL_INITIATIVE_OVERNIGHT` is set to a non-falsy value
+(non-empty, not `0`/`false`/`off`/`no`; initiative mode, HIMMEL-425) — then the
+critics are the only gate and the pipeline auto-advances.
 Otherwise it reports `interactive` and minerva pauses for the operator after each
 critic-cleaned artifact.
 

--- a/marketplace/plugins/himmel-ops/README.md
+++ b/marketplace/plugins/himmel-ops/README.md
@@ -67,3 +67,32 @@ guidance available the moment it is relevant (memory:
 
 - Full playbook: [`docs/internals/stuck-playbook.md`](../../../docs/internals/stuck-playbook.md)
 - Enforcement detail (hooks + gates + classifier): [`docs/internals/enforcement.md`](../../../docs/internals/enforcement.md)
+
+## minerva — brainstorm → critic → spec → critic → plan (`/minerva`)
+
+`/minerva` (skill `himmel-ops:minerva`) runs the recurring idea→plan workflow as
+one pipeline with an adversarial critic between each stage, so every artifact is
+red-teamed before it advances:
+
+1. **Brainstorm → spec** — drives `superpowers:brainstorming`, halted before its
+   auto-handoff to writing-plans.
+2. **Spec critic** — a fresh adversarial subagent red-teams the spec (hidden
+   assumptions, scope creep, feasibility, contradictions, missing success
+   criteria); loop fix→re-critic, cap 2 rounds.
+3. **Plan** — drives `superpowers:writing-plans` on the approved spec.
+4. **Plan critic** — adversarial subagent red-teams the plan (unordered deps,
+   untestable steps, missing verification, over/under-decomposition); cap 2 rounds.
+5. **Terminal** — a critic-hardened plan; offers hand-off to
+   `superpowers:subagent-driven-development` / `executing-plans`. minerva does
+   not implement.
+
+**Gates are mode-driven.** `scripts/autonomy-mode.sh` reports `autonomous` when
+`HIMMEL_INITIATIVE` or `HIMMEL_INITIATIVE_OVERNIGHT` is set (initiative mode,
+HIMMEL-425) — then the critics are the only gate and the pipeline auto-advances.
+Otherwise it reports `interactive` and minerva pauses for the operator after each
+critic-cleaned artifact.
+
+**Distribution:** ships in this plugin (skill + command + helper), so it installs
+system-wide and works in any repo, with no `superpowers` fork. A deferred
+companion (HIMMEL-429) adds a Skill-tool hook so the critic also fires when
+brainstorming/writing-plans is triggered without `/minerva`.

--- a/marketplace/plugins/himmel-ops/commands/minerva.md
+++ b/marketplace/plugins/himmel-ops/commands/minerva.md
@@ -1,0 +1,5 @@
+---
+description: Run the brainstorm→critic→spec→critic→plan pipeline — one idea to a critic-hardened implementation plan
+---
+
+Invoke the `himmel-ops:minerva` skill and follow its runbook for: $ARGUMENTS

--- a/marketplace/plugins/himmel-ops/scripts/autonomy-mode.sh
+++ b/marketplace/plugins/himmel-ops/scripts/autonomy-mode.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# autonomy-mode.sh — print "autonomous" if any autonomy flag is set, else "interactive".
+# Signals (HIMMEL-428): initiative mode (HIMMEL_INITIATIVE, HIMMEL-425) and its overnight
+# part (HIMMEL_INITIATIVE_OVERNIGHT). HIMMEL_INITIATIVE is a CHAIN SPEC (e.g. "pr,ticket"),
+# not a boolean, so treat any non-empty, non-falsy value as active (blocklist, not allowlist).
+set -euo pipefail
+active() { case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in ""|0|false|off|no) return 1;; *) return 0;; esac; }
+if active "${HIMMEL_INITIATIVE:-}" || active "${HIMMEL_INITIATIVE_OVERNIGHT:-}"; then
+  echo "autonomous"
+else
+  echo "interactive"
+fi

--- a/marketplace/plugins/himmel-ops/scripts/test-autonomy-mode.sh
+++ b/marketplace/plugins/himmel-ops/scripts/test-autonomy-mode.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# test-autonomy-mode.sh
+set -uo pipefail
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/autonomy-mode.sh"
+fail=0
+check() { [ "$1" = "$2" ] || { echo "FAIL: $3 (got '$1' want '$2')"; fail=1; }; }
+
+out=$(env -u HIMMEL_INITIATIVE -u HIMMEL_INITIATIVE_OVERNIGHT bash "$SCRIPT"); check "$out" "interactive" "unset -> interactive"
+out=$(HIMMEL_INITIATIVE=1 bash "$SCRIPT"); check "$out" "autonomous" "initiative=1 -> autonomous"
+out=$(HIMMEL_INITIATIVE=true bash "$SCRIPT"); check "$out" "autonomous" "initiative=true -> autonomous"
+out=$(HIMMEL_INITIATIVE="pr,ticket" bash "$SCRIPT"); check "$out" "autonomous" "initiative=chain-list -> autonomous"
+out=$(HIMMEL_INITIATIVE=0 bash "$SCRIPT"); check "$out" "interactive" "initiative=0 -> interactive"
+out=$(HIMMEL_INITIATIVE=false bash "$SCRIPT"); check "$out" "interactive" "initiative=false -> interactive"
+out=$(HIMMEL_INITIATIVE=off bash "$SCRIPT"); check "$out" "interactive" "initiative=off -> interactive"
+out=$(HIMMEL_INITIATIVE=no bash "$SCRIPT"); check "$out" "interactive" "initiative=no -> interactive"
+out=$(HIMMEL_INITIATIVE="" bash "$SCRIPT"); check "$out" "interactive" "initiative='' -> interactive"
+out=$(HIMMEL_INITIATIVE_OVERNIGHT=1 bash "$SCRIPT"); check "$out" "autonomous" "overnight=1 -> autonomous"
+[ "$fail" = "0" ] && echo "ALL PASS"; exit "$fail"

--- a/marketplace/plugins/himmel-ops/scripts/test-autonomy-mode.sh
+++ b/marketplace/plugins/himmel-ops/scripts/test-autonomy-mode.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # test-autonomy-mode.sh
-set -uo pipefail
+set -euo pipefail
 SCRIPT="$(cd "$(dirname "$0")" && pwd)/autonomy-mode.sh"
 fail=0
 check() { [ "$1" = "$2" ] || { echo "FAIL: $3 (got '$1' want '$2')"; fail=1; }; }
@@ -14,5 +14,7 @@ out=$(HIMMEL_INITIATIVE=false bash "$SCRIPT"); check "$out" "interactive" "initi
 out=$(HIMMEL_INITIATIVE=off bash "$SCRIPT"); check "$out" "interactive" "initiative=off -> interactive"
 out=$(HIMMEL_INITIATIVE=no bash "$SCRIPT"); check "$out" "interactive" "initiative=no -> interactive"
 out=$(HIMMEL_INITIATIVE="" bash "$SCRIPT"); check "$out" "interactive" "initiative='' -> interactive"
-out=$(HIMMEL_INITIATIVE_OVERNIGHT=1 bash "$SCRIPT"); check "$out" "autonomous" "overnight=1 -> autonomous"
+out=$(env -u HIMMEL_INITIATIVE HIMMEL_INITIATIVE_OVERNIGHT=1 bash "$SCRIPT"); check "$out" "autonomous" "overnight=1 (isolated) -> autonomous"
+out=$(env -u HIMMEL_INITIATIVE HIMMEL_INITIATIVE_OVERNIGHT=false bash "$SCRIPT"); check "$out" "interactive" "overnight=false -> interactive"
+out=$(HIMMEL_INITIATIVE=0 HIMMEL_INITIATIVE_OVERNIGHT=1 bash "$SCRIPT"); check "$out" "autonomous" "initiative=0 overnight=1 (OR) -> autonomous"
 [ "$fail" = "0" ] && echo "ALL PASS"; exit "$fail"

--- a/marketplace/plugins/himmel-ops/skills/minerva/SKILL.md
+++ b/marketplace/plugins/himmel-ops/skills/minerva/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: minerva
+description: Use when turning an idea into an implementation plan — runs brainstorm → spec → plan as ONE pipeline with an ADVERSARIAL CRITIC LOOP between each stage. Trigger on "build/implement/design X", "/minerva", or any feature/capability work that should pass through a spec + plan before code. Composes superpowers brainstorming + writing-plans (no fork); adds a spec-critic and a plan-critic.
+---
+
+# minerva — brainstorm → critic → spec → critic → plan (HIMMEL-428)
+
+Orchestrate a hardened path from idea to implementation plan. You drive the
+superpowers sub-skills and insert an adversarial critic between each stage, so
+every artifact is red-teamed before it advances. minerva pairs the Roman
+goddess of wisdom + strategic planning with himmel's critic discipline.
+
+**You are the orchestrator.** Do not let the sub-skills auto-chain past their
+stage — you decide when each critic runs and when to advance.
+
+## Mode (gates)
+
+Determine once, up front, whether to pause for the operator between stages:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/autonomy-mode.sh"
+```
+
+- Output `interactive` → after each critic-cleaned artifact, PAUSE for the
+  operator to approve or redirect before advancing.
+- Output `autonomous` → do NOT pause; the critics are the gate; auto-advance
+  through to the terminal.
+
+## Stage 1 — brainstorm → spec
+
+Invoke `superpowers:brainstorming` for the interactive design (clarifying
+questions, approaches, the design, and the written spec).
+
+**HALT it before its auto-handoff to writing-plans.** When brainstorming has
+written + self-reviewed the spec and the design is approved, return HERE
+instead of letting it invoke writing-plans — minerva runs the spec-critic
+first.
+
+## Stage 2 — spec critic (adversarial)
+
+Dispatch a fresh subagent (Agent tool) against the written spec file. Loop
+fix → re-critic until it returns clean, **cap 2 rounds** (then advance with
+any residual findings noted).
+
+CHARTER — paste into the subagent prompt verbatim:
+
+> Red-team this design spec. You are adversarial: find problems, do not
+> rubber-stamp. Check ONLY these dimensions and return findings as a list
+> (or "SPEC CLEAN" if none):
+> 1. Hidden/unstated assumptions.
+> 2. Scope creep — features not justified by the stated goal (YAGNI).
+> 3. Feasibility gaps — does the proposed approach actually work?
+> 4. Internal contradictions between sections.
+> 5. Missing or untestable success criteria.
+> For each finding: the section + the problem + a concrete fix.
+
+After the loop: if `interactive`, present the hardened spec for approve/redirect;
+if `autonomous`, proceed.
+
+## Stage 3 — plan
+
+Invoke `superpowers:writing-plans` on the approved spec to produce the
+implementation plan.
+
+## Stage 4 — plan critic (adversarial)
+
+Dispatch a fresh subagent (Agent tool) against the written plan file. Loop
+fix → re-critic until clean, **cap 2 rounds**.
+
+CHARTER — paste into the subagent prompt verbatim:
+
+> Red-team this implementation plan. You are adversarial. Check ONLY these
+> dimensions and return findings as a list (or "PLAN CLEAN" if none):
+> 1. Unordered or missing dependencies between tasks/steps.
+> 2. Untestable / unverifiable steps (no clear done-check).
+> 3. Missing verification at the end of a task.
+> 4. Over-decomposition (busywork) or under-decomposition (a step too big to verify).
+> 5. Assumptions embedded in steps that were not present in the spec.
+> For each finding: the task/step + the problem + a concrete fix.
+
+After the loop: if `interactive`, present the hardened plan for approve/redirect;
+if `autonomous`, proceed.
+
+## Terminal
+
+You now hold a critic-hardened, approved implementation plan. minerva STOPS
+here — it does not start implementation. Offer the hand-off:
+
+> Plan ready. Execute with `superpowers:subagent-driven-development`
+> (recommended) or `superpowers:executing-plans`?


### PR DESCRIPTION
himmel-ops `/minerva` skill: runs brainstorm → spec → plan as one pipeline with an adversarial critic loop between each stage. Composes superpowers brainstorming/writing-plans (no fork); ships in the plugin so it installs system-wide and works in any repo. Mode-driven gates via `HIMMEL_INITIATIVE` / `HIMMEL_INITIATIVE_OVERNIGHT`. Reviewed via /pr-check (3 reviewers, findings fixed). Piece 2 (Skill-tool critic-injection hook) deferred to HIMMEL-429.