### PR TITLE
feat(telegram): [HIMMEL-424] remote /arm auto-actions (B2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,8 +192,12 @@ Hook bypass = session env var set in the LAUNCHING shell (e.g.
 `EDIT_ON_MAIN_OK=1 claude`); a per-call prefix does NOT work. Per-repo opt-out:
 a local gitignored `.single-writer` at a repo root allows on-main edits there
 (single-writer repos — personal vaults, state repos — that commit straight to
-main by design); clones without the marker stay protected. Per-hook
-behaviour, the full gate list, and the guardrail matrix:
+main by design); clones without the marker stay protected. Remote auto-actions
+(Telegram `/arm`, HIMMEL-424): the trusted bridge parses + invokes directly (agent
+out of the trust path); operator-identity (DM or allowlisted group), typed-only,
+forwarded-refused; default OFF behind `TELEGRAM_AUTO_ACTIONS` (per-op flag, grammar
+mirrors `HIMMEL_INITIATIVE`). Per-hook
+behaviour, the full gate list, the guardrail matrix, and the `/arm` surface:
 [`docs/internals/enforcement.md`](docs/internals/enforcement.md). Required
 environment (HIMMEL-123):
 [`docs/setup/new-machine.md`](docs/setup/new-machine.md#1-required-environment-himmel-123).

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -491,6 +491,59 @@ before forwarding to `gh`). `--admin` is INSPECTED but forwarded.
 
 Run after any edit to `lib.sh` or `guard-gh.sh` before pushing.
 
+## Remote auto-actions — Telegram `/arm` (HIMMEL-424)
+
+A sanctioned surface for the operator to trigger a bounded privileged action from
+Telegram. Auth model **B2**: the **trusted bridge** (`scripts/telegram/`) parses a
+structured command and invokes the action DIRECTLY — the spawned `claude` agent is
+**never in the trust path**. So a conversational "resume HIMMEL-x" to the agent does
+NOT arm anything; only the bridge-parsed `/arm` does. Auth = **operator-identity**: the
+allowlisted operator (sender ∈ global `allowFrom`) sent a non-forwarded, typed `/arm`
+in a DM **or an allowlisted group** — never body content an attacker could inject.
+
+**Command:** `/arm <ticket|path> [at HH:MM | auto | smart]` (default `smart`).
+A ticket (`^[A-Z][A-Z0-9]+-[0-9]+$`) resolves to a resume handover under
+`handover_root` (case-insensitive, `specs/` excluded, `type: handover` preferred,
+ambiguity refused — never silently picked); a path must exist and resolve **under**
+`handover_root`. The bridge shells `auto-action.sh` → `arm-resume.sh` (per-handover
+dedup; no `--force`/`--dedup-any` remotely).
+
+**Activation flag — `TELEGRAM_AUTO_ACTIONS` (default OFF, operator-only).** A per-op
+enable-list whose grammar **mirrors `HIMMEL_INITIATIVE`** (so users learn one
+convention): unset / `0`/`off`/`no` → no ops (inert; `/arm` is ordinary chat);
+`1`/`all`/`on`/`yes` → every op; else a comma-list of op names (case-insensitive,
+unknown tokens dropped, pure-typo → off). v1 ships one op (`arm-resume`), so `=1`
+and `=arm-resume` are equivalent. The dispatch-table keys (`OPS`/`KNOWN_OPS` in
+`auto-action.ts`) are the closed op allow-list, re-asserted in `auto-action.sh`.
+Set it in the bridge's launching env + restart the bridge to activate.
+
+**Guards (fail-closed):**
+- **Operator-identity** — an auto-command runs only when the SENDER is the allowlisted
+  operator (`isAllowed(access, from)` — the global `allowFrom`). This authorizes `/arm`
+  from the operator in a DM **or an allowlisted group** (groups carry distinct per-group
+  context). A non-operator member of a shared group has a `from` not in `allowFrom`, so
+  their `/arm` falls through to ordinary (powerless) chat. The chat is *also* already
+  allowlisted upstream by `makeAllow` at ingest, so this is operator-identity on top of
+  chat-allowlisting. The reply routes back to the originating chat (group → its own
+  `group_<id>` session). (Earlier DM-only restriction relaxed for hardcoded
+  operator-only groups; identity check keeps it safe if a third party ever joins.)
+- **Typed-only** — a media-caption or voice-transcript `/arm` (`caption: true`) is
+  not eligible; only a genuinely typed `m.text` command is.
+- **Forward-refuse** — a forwarded `/arm` (any Telegram forward marker) is refused
+  and audited (`refused-forwarded`); this kills the prompt-injection vector.
+- The arm runs fire-and-forget off the ingest loop (a slow `--time smart` arm can't
+  stall polling); the operator reply goes via the chat outbox + flush.
+
+**Audit:** one append-only, sanitized line per attempt (executed OR refused) to
+`bridgeRoot()/auto-action-audit.log`:
+`<iso-ts> chat=<id> user=<id> fwd=<0|1> op=<op> arg=<arg> resolved=<basename> time=<t> rc=<n> result=<armed|already-armed|ambiguous|refused-forwarded|no-match|error>`.
+
+**Still HARD-blocked (out of scope):** editing `access.json`/`settings.json`,
+`--force`/`--dedup-any` arms, merging PRs, ops other than `arm-resume`.
+
+Tests: `scripts/telegram/{router,auto-action,poller}.test.ts` (bun) +
+`scripts/telegram/test-auto-action.sh` (privileged-script smoke).
+
 ## Claude invocation billing (HIMMEL-128)
 
 From **2026-06-15** onward, Anthropic splits headless Claude Code

--- a/scripts/telegram/auto-action.sh
+++ b/scripts/telegram/auto-action.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# auto-action.sh <op> <arg> <time> — privileged remote auto-action executor (HIMMEL-424 B2).
+#
+# The TRUSTED Telegram bridge invokes this DIRECTLY (argv array) after parsing a
+# structured `/arm` command; the spawned `claude` agent is never in the trust path.
+# This script owns the privileged half: resolve a ticket|path to a resume handover,
+# then shell arm-resume.sh. It runs in the real himmel shell environment (.env,
+# handover-path.sh, py-armor, schtasks) — "inherit the system".
+#
+# Exit-code namespace (kept DISTINCT from arm-resume's own rc space so a dedup/
+# already-armed result doesn't collide with a resolution failure):
+#   0  armed
+#   1  bad input (missing args / bad time)
+#   2  unknown op (closed op allow-list, defense-in-depth)
+#   3  no resume handover / bad path / path outside handover_root
+#   4  ambiguous (>1 genuine handover — never silently pick)
+#   5  already armed (arm-resume dedup rc=3)
+#   6  arm-resume failed (any other non-zero)
+#
+# Args ALWAYS land as the VALUE of `arm-resume --handover`, never a bare positional
+# (so a path like `--force` can't be misread as a flag). Test seam:
+# AUTO_ACTION_ARM_CMD overrides the arm command (default the real arm-resume.sh).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+OP="${1:-}"; ARG="${2:-}"; TIME="${3:-}"
+if [ -z "$OP" ] || [ -z "$ARG" ] || [ -z "$TIME" ]; then
+    echo "ERR auto-action: usage: auto-action.sh <op> <arg> <time>" >&2
+    exit 1
+fi
+
+# Closed op allow-list (defense-in-depth vs the bridge parse layer).
+case "$OP" in
+    arm-resume) ;;
+    *) echo "ERR auto-action: unknown op: $OP" >&2; exit 2 ;;
+esac
+
+# Validate time FIRST (identical regex to arm-resume's HH:MM, so the early reject
+# can't diverge from the real validator).
+case "$TIME" in
+    smart|auto) ;;
+    *)
+        if ! printf '%s' "$TIME" | grep -Eq '^([01][0-9]|2[0-3]):[0-5][0-9]$'; then
+            echo "ERR auto-action: bad time '$TIME' (expected HH:MM, 'auto', or 'smart')" >&2
+            exit 1
+        fi
+        ;;
+esac
+
+# Resolve the handover root via the shared resolver (subtree hard rule: never
+# hardcode ./handovers/ — source handover-path.sh + call handover_root).
+# shellcheck source=../lib/handover-path.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/handover-path.sh"
+if ! ROOT=$(handover_root); then
+    echo "ERR auto-action: handover_root unresolved (set HANDOVER_DIR or create handovers/)" >&2
+    exit 3
+fi
+ROOT=$(realpath "$ROOT" 2>/dev/null) || ROOT=$(cd "$ROOT" && pwd)
+
+RESOLVED=""
+if printf '%s' "$ARG" | grep -Eq '^[A-Z][A-Z0-9]+-[0-9]+$'; then
+    # Ticket: case-insensitive match (files are lowercase, the arg is upper),
+    # EXCLUDE anything under a specs/ path (design/plan docs are not resume
+    # targets), then PREFER files carrying `type: handover` frontmatter.
+    _matches=()
+    while IFS= read -r _f; do
+        [ -n "$_f" ] && _matches+=("$_f")
+    done < <(find "$ROOT" -type f -iname "*$ARG*.md" 2>/dev/null | grep -v '/specs/' | sort)
+    if [ "${#_matches[@]}" -eq 0 ]; then
+        echo "ERR auto-action: no resume handover for $ARG" >&2
+        exit 3
+    fi
+    _preferred=()
+    for _f in "${_matches[@]}"; do
+        if head -20 "$_f" 2>/dev/null | grep -qiE '^type:[[:space:]]*handover[[:space:]]*$'; then
+            _preferred+=("$_f")
+        fi
+    done
+    _pool=("${_matches[@]}")
+    [ "${#_preferred[@]}" -gt 0 ] && _pool=("${_preferred[@]}")
+    if [ "${#_pool[@]}" -gt 1 ]; then
+        # Never silently pick among genuine handovers — list basenames and refuse.
+        _list=""
+        for _f in "${_pool[@]}"; do _list="${_list:+$_list, }$(basename "$_f")"; done
+        echo "$_list" >&2
+        exit 4
+    fi
+    RESOLVED="${_pool[0]}"
+else
+    # Path: must exist AND canonicalize UNDER handover_root (containment, fix I3 —
+    # blocks /etc/passwd and ../../x, which arm-resume would otherwise read
+    # resume_cwd/resume_worktree frontmatter from). Fail closed if realpath is
+    # unavailable (can't verify containment).
+    if [ ! -e "$ARG" ]; then
+        echo "ERR auto-action: path not found: $ARG" >&2
+        exit 3
+    fi
+    if ! _real=$(realpath "$ARG" 2>/dev/null) || [ -z "$_real" ]; then
+        echo "ERR auto-action: could not canonicalize path (containment unverifiable): $ARG" >&2
+        exit 3
+    fi
+    case "$_real" in
+        "$ROOT"/*) RESOLVED="$_real" ;;
+        *) echo "ERR auto-action: path outside handover_root: $ARG" >&2; exit 3 ;;
+    esac
+fi
+
+# Machine-readable line the bridge parses for the audit + reply.
+echo "resolved=$(basename "$RESOLVED")"
+
+# Invoke arm-resume.sh with the resolved handover as the --handover VALUE. Strip the
+# bot token (and TELEGRAM_OWN_POLLER) from the child env (M3 — arm doesn't need them).
+# Default per-handover dedup; no --force, no --dedup-any (remote arms can't force/clobber).
+ARM_CMD="${AUTO_ACTION_ARM_CMD:-bash $SCRIPT_DIR/../handover/arm-resume.sh}"
+# ARM_CMD is an intentional command+args split — word-splitting wanted.
+# shellcheck disable=SC2086
+out=$(TELEGRAM_BOT_TOKEN="" TELEGRAM_OWN_POLLER="" $ARM_CMD --handover "$RESOLVED" --time "$TIME" 2>&1)
+arm_rc=$?
+
+case "$arm_rc" in
+    0) exit 0 ;;
+    3) echo "ERR auto-action: already armed for $(basename "$RESOLVED")" >&2; exit 5 ;;
+    *) echo "ERR auto-action: arm-resume failed (rc=$arm_rc): $(printf '%s' "$out" | tail -1)" >&2; exit 6 ;;
+esac

--- a/scripts/telegram/auto-action.test.ts
+++ b/scripts/telegram/auto-action.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  OPS, KNOWN_OPS, parseEnabledOps, isExecutableAutoCommand,
+  dispatchAutoAction, formatAuditLine, appendAuditLine, type AuditFields,
+} from "./auto-action";
+import type { Route } from "./router";
+
+const armRoute = (over: Partial<{ arg: string; time: string }> = {}): Route =>
+  ({ kind: "auto", op: "arm-resume", arg: over.arg ?? "HIMMEL-389", time: over.time ?? "smart" });
+
+test("OPS table seeds the closed op allow-list", () => {
+  expect([...KNOWN_OPS]).toEqual(["arm-resume"]);
+  expect(OPS["arm-resume"].script).toBe("arm-resume");
+});
+
+test("parseEnabledOps mirrors the initiative-mode grammar (fail toward inert)", () => {
+  const k = KNOWN_OPS;
+  // off / inert
+  for (const v of [undefined, "", "0", "off", "no", "false", "  ", "bogus", "prchek"])
+    expect([...parseEnabledOps(v, k)]).toEqual([]);
+  // whole-value enable-all aliases
+  for (const v of ["1", "all", "on", "yes", "true", "ALL"])
+    expect([...parseEnabledOps(v, k)]).toEqual(["arm-resume"]);
+  // explicit op token, case-insensitive + whitespace-stripped
+  expect([...parseEnabledOps("arm-resume", k)]).toEqual(["arm-resume"]);
+  expect([...parseEnabledOps("ARM-RESUME", k)]).toEqual(["arm-resume"]);
+  expect([...parseEnabledOps("  arm-resume  ", k)]).toEqual(["arm-resume"]);
+  // unknown tokens dropped
+  expect([...parseEnabledOps("arm-resume,bogus", k)]).toEqual(["arm-resume"]);
+  // "all" as a COMMA token is NOT enable-all (only the whole value is) — fix M1
+  expect([...parseEnabledOps("all,arm-resume", k)]).toEqual(["arm-resume"]);
+});
+
+test("isExecutableAutoCommand: only a typed (caption=false), non-forwarded auto route", () => {
+  expect(isExecutableAutoCommand(armRoute(), false, false)).toBe(true);
+  // forwarded → refuse (injection)
+  expect(isExecutableAutoCommand(armRoute(), true, false)).toBe(false);
+  // caption/voice origin → refuse (fix C2)
+  expect(isExecutableAutoCommand(armRoute(), false, true)).toBe(false);
+  // strict === false: unknown/undefined flags refuse (fix R2#5, no fail-open)
+  expect(isExecutableAutoCommand(armRoute(), undefined as any, undefined as any)).toBe(false);
+  // non-auto route never executable
+  expect(isExecutableAutoCommand({ kind: "chat", text: "hi" }, false, false)).toBe(false);
+});
+
+test("dispatchAutoAction maps the auto-action.sh rc namespace to operator messages", async () => {
+  const stub = (code: number, stdout = "", stderr = "") =>
+    ({ runScript: async () => ({ code, stdout, stderr }) });
+
+  const armed = await dispatchAutoAction(stub(0, "resolved=2026-06-20-x.md\n"), armRoute());
+  expect(armed.ok).toBe(true);
+  expect(armed.rc).toBe(0);
+  expect(armed.resolved).toBe("2026-06-20-x.md");
+  expect(armed.message).toContain("armed");
+  expect(armed.message).toContain("2026-06-20-x.md");
+
+  const noHandover = await dispatchAutoAction(stub(3), armRoute({ arg: "HIMMEL-999" }));
+  expect(noHandover.ok).toBe(false);
+  expect(noHandover.message).toContain("HIMMEL-999");
+
+  const ambiguous = await dispatchAutoAction(stub(4, "", "a.md, b.md"), armRoute());
+  expect(ambiguous.ok).toBe(false);
+  expect(ambiguous.rc).toBe(4);
+  expect(ambiguous.message.toLowerCase()).toContain("ambiguous");
+
+  const already = await dispatchAutoAction(stub(5), armRoute());
+  expect(already.ok).toBe(false);
+  expect(already.message.toLowerCase()).toContain("already armed");
+
+  const failed = await dispatchAutoAction(stub(6, "", "scheduler boom"), armRoute());
+  expect(failed.ok).toBe(false);
+  expect(failed.message).toContain("scheduler boom");
+});
+
+test("dispatchAutoAction re-asserts the op against KNOWN_OPS (defense-in-depth)", async () => {
+  let called = false;
+  const res = await dispatchAutoAction(
+    { runScript: async () => { called = true; return { code: 0, stdout: "", stderr: "" }; } },
+    { kind: "auto", op: "run-named-skill" as any, arg: "x", time: "smart" } as Route,
+  );
+  expect(called).toBe(false);     // never reaches the script
+  expect(res.ok).toBe(false);
+});
+
+test("formatAuditLine emits the exact sanitized field shape", () => {
+  const f: AuditFields = {
+    chat_id: 5, user: 42, forwarded: true, op: "arm-resume",
+    arg: "HIMMEL-1\nINJECTED", resolved: "x.md", time: "smart", rc: 0, result: "refused-forwarded",
+  };
+  const line = formatAuditLine(f, "2026-06-20T00:00:00.000Z");
+  expect(line).toBe(
+    "2026-06-20T00:00:00.000Z chat=5 user=42 fwd=1 op=arm-resume arg=HIMMEL-1 INJECTED resolved=x.md time=smart rc=0 result=refused-forwarded",
+  );
+  expect(line.split("\n").length).toBe(1);   // newline in arg can't forge a 2nd line (fix I4)
+});
+
+test("appendAuditLine appends a line and swallows a write failure (best-effort)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "auto-audit-"));
+  const audit = appendAuditLine(dir, { now: () => "2026-06-20T00:00:00.000Z" });
+  const base: AuditFields = { chat_id: 1, user: 2, forwarded: false, op: "arm-resume", arg: "HIMMEL-9", time: "smart", rc: 0, result: "armed" };
+  await audit(base);
+  await audit({ ...base, result: "already-armed", rc: 5 });
+  const log = await readFile(join(dir, "auto-action-audit.log"), "utf8");
+  expect(log.trim().split("\n").length).toBe(2);   // append, not overwrite
+  expect(log).toContain("result=armed");
+  expect(log).toContain("result=already-armed");
+
+  // injected writer that rejects → swallowed, no throw (best-effort contract)
+  const boom = appendAuditLine(dir, { write: async () => { throw new Error("disk full"); } });
+  await expect(boom(base)).resolves.toBeUndefined();
+});

--- a/scripts/telegram/auto-action.ts
+++ b/scripts/telegram/auto-action.ts
@@ -1,0 +1,120 @@
+// Remote auto-action dispatch for the Telegram bridge (HIMMEL-424, auth model B2).
+// The TRUSTED bridge parses a structured `/arm` command and invokes the privileged
+// action DIRECTLY — the spawned `claude` agent is never in the trust path. This module
+// owns the bridge-side concerns: the closed op allow-list, the per-op enable-list flag,
+// the typed/non-forwarded eligibility guard, rc->message mapping, and the audit line.
+// The privileged resolution + scheduler invocation live in auto-action.sh (it needs the
+// real himmel shell env: .env, handover-path.sh, py-armor, schtasks).
+import { join } from "node:path";
+import { appendLine } from "./bus";
+import type { Route } from "./router";
+
+// Dispatch table — a thin marker keyed by op name. Its keys ARE the closed op
+// allow-list (= KNOWN_OPS = the valid `TELEGRAM_AUTO_ACTIONS` tokens). v1 ships one op;
+// adding an op later = one entry + its auto-action.sh validator + tests (no structural
+// change). No per-op arg validators in the table yet (YAGNI until op #2) — validation
+// lives in auto-action.sh.
+export const OPS: Record<string, { script: string }> = { "arm-resume": { script: "arm-resume" } };
+export const KNOWN_OPS = new Set(Object.keys(OPS));
+
+// parseEnabledOps — the per-op activation flag parser. Grammar mirrors HIMMEL_INITIATIVE
+// (425) so users learn one convention. Fails toward inert (empty set): unset / falsy /
+// pure-typo all yield no enabled ops. The enable-all aliases match ONLY on the whole
+// value, so `all` as a comma-token is just an unknown token (does NOT enable every op).
+export function parseEnabledOps(raw: string | undefined, knownOps: Set<string>): Set<string> {
+  const v = (raw ?? "").trim().toLowerCase();
+  if (v === "" || v === "0" || v === "off" || v === "no" || v === "false") return new Set();
+  if (v === "1" || v === "all" || v === "on" || v === "yes" || v === "true") return new Set(knownOps);
+  const out = new Set<string>();
+  for (const tok of v.split(",")) {
+    const t = tok.trim();
+    if (knownOps.has(t)) out.add(t);
+  }
+  return out;
+}
+
+// The injection-test seam (pure). An auto-command executes ONLY when it is a typed
+// (caption === false), non-forwarded (forwarded === false) auto route. Strict `=== false`
+// so an unknown/undefined flag refuses rather than fail-open — this is THE security
+// boundary. DM-only + op-enabled are checked by the caller (handleInbound).
+export function isExecutableAutoCommand(route: Route, forwarded: boolean, caption: boolean): boolean {
+  return route.kind === "auto" && forwarded === false && caption === false;
+}
+
+// auto-action.sh exit-code namespace (kept distinct from arm-resume's own rc space so
+// "dedup/already-armed" doesn't collide with "resolution failed"):
+//   0 armed · 1 bad input · 2 unknown op · 3 no handover / bad path · 4 ambiguous (>1) ·
+//   5 already armed (arm-resume dedup) · 6 arm failed (arm-resume non-zero)
+export type RunScriptResult = { code: number; stdout: string; stderr: string };
+export type RunScriptFn = (op: string, arg: string, time: string) => Promise<RunScriptResult>;
+export type AutoActionRoute = { op: string; arg: string; time: string };
+export type AutoResult = { ok: boolean; rc: number; message: string; resolved?: string };
+
+const firstLine = (s: string) => (s || "").split("\n").map((x) => x.trim()).find(Boolean) ?? "";
+function parseResolved(stdout: string): string | undefined {
+  const m = stdout.match(/^resolved=(.+)$/m);
+  const v = m?.[1]?.trim();
+  return v && v !== "-" ? v : undefined;
+}
+
+// Re-assert the op against KNOWN_OPS (defense-in-depth vs the router parse layer), spawn
+// auto-action.sh (the injected runScript spawns it argv-array in prod), then map its rc
+// to an operator-facing message. The resolved handover basename is parsed from stdout.
+export async function dispatchAutoAction(deps: { runScript: RunScriptFn }, route: AutoActionRoute): Promise<AutoResult> {
+  if (!KNOWN_OPS.has(route.op)) return { ok: false, rc: 2, message: `⚠️ unknown op: ${route.op}` };
+  const { code, stdout, stderr } = await deps.runScript(route.op, route.arg, route.time);
+  const resolved = parseResolved(stdout);
+  switch (code) {
+    case 0:  return { ok: true, rc: 0, resolved, message: `✅ armed: ${resolved ?? route.arg} (${route.time})` };
+    case 3:  return { ok: false, rc: 3, message: `⚠️ no resume handover for ${route.arg}` };
+    case 4:  return { ok: false, rc: 4, message: `⚠️ ambiguous: ${firstLine(stderr)} — re-send /arm <full-path>` };
+    case 5:  return { ok: false, rc: 5, message: `ℹ️ already armed for that handover — use the terminal to --force/replace` };
+    default: return { ok: false, rc: code, message: `⚠️ couldn't arm ${route.arg}: ${firstLine(stderr) || `exit ${code}`}` };
+  }
+}
+
+// --- Audit (one append-only line per attempt, executed OR refused) ---
+export type AuditResult = "armed" | "already-armed" | "ambiguous" | "refused-forwarded" | "no-match" | "error";
+export type AuditFields = {
+  chat_id: number; user: number; forwarded: boolean; op: string;
+  arg: string; resolved?: string; time: string; rc: number; result: string;
+};
+
+// Strip control chars (newlines/tabs/etc.) so a crafted arg can't forge a second audit
+// line. Filters by code point (< 0x20 -> space) to avoid a control-char regex literal,
+// then collapses whitespace.
+function sanitize(s: string): string {
+  return Array.from(s ?? "", (c) => ((c.codePointAt(0) ?? 0) < 0x20 ? " " : c))
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function formatAuditLine(f: AuditFields, now: string): string {
+  return [
+    now,
+    `chat=${f.chat_id}`,
+    `user=${f.user}`,
+    `fwd=${f.forwarded ? 1 : 0}`,
+    `op=${sanitize(f.op)}`,
+    `arg=${sanitize(f.arg)}`,
+    `resolved=${sanitize(f.resolved ?? "-") || "-"}`,
+    `time=${sanitize(f.time)}`,
+    `rc=${f.rc}`,
+    `result=${sanitize(f.result)}`,
+  ].join(" ");
+}
+
+// Best-effort: an audit-write failure is logged, never thrown (it must not block the
+// reply or wedge the poller) — consistent with the bridge's other best-effort sinks.
+export function appendAuditLine(
+  root: string,
+  deps: { write?: (file: string, line: string) => Promise<void>; now?: () => string } = {},
+) {
+  const write = deps.write ?? appendLine;
+  const now = deps.now ?? (() => new Date().toISOString());
+  return async (f: AuditFields): Promise<void> => {
+    try { await write(join(root, "auto-action-audit.log"), formatAuditLine(f, now())); }
+    catch (e) { console.error(`[auto-action] audit write failed: ${e}`); }
+  };
+}

--- a/scripts/telegram/poller.test.ts
+++ b/scripts/telegram/poller.test.ts
@@ -3,8 +3,9 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readNewLines, readMeta, writeMeta, ensureSession, appendLine, sessionDir } from "./bus";
-import { ingestUpdates, loadOffset, handleInbound, runAndSettle, reconcile, flushOutboxes, isRetryDue, peekPending, commitPending, makeRunFn, makeAllow, makeDispatcher, makeFetchVoice, sweepStuckRunning, signalTyping, guarded, deliverAllPending, sweepAttachments, resolveRetentionMs, noticeText, type FetchImageFn } from "./poller";
+import { ingestUpdates, loadOffset, handleInbound, handleAutoCommand, replyViaOutbox, runAndSettle, reconcile, flushOutboxes, isRetryDue, peekPending, commitPending, makeRunFn, makeAllow, makeDispatcher, makeFetchVoice, sweepStuckRunning, signalTyping, guarded, deliverAllPending, sweepAttachments, resolveRetentionMs, noticeText, type FetchImageFn } from "./poller";
 import { readFile, writeFile, mkdir, utimes } from "node:fs/promises";
+import { isAllowed } from "./gate";
 
 const root = () => mkdtempSync(join(tmpdir(), "poller-"));
 const allowAll = () => true;
@@ -1260,4 +1261,171 @@ test("ingest: is_automatic_forward drop still advances the offset (no retry loop
   const lines = await readNewLines(join(r,"inbound.jsonl"), join(r,"inbound.jsonl.cursor"));
   expect(lines.length).toBe(0);
   expect(await loadOffset(r)).toBe(71);   // confirmed — no re-delivery
+});
+
+// --- HIMMEL-424 B2: remote auto-actions (forwarded/caption bits + /arm routing) ---
+
+test("ingest marks forwarded (from a forward marker) + caption explicitly on each record", async () => {
+  const r = root();
+  await ingestUpdates(r, [
+    { update_id: 1, message: { chat:{id:5}, from:{id:5}, text:"/arm HIMMEL-1", forward_origin:{type:"user"} } },
+    { update_id: 2, message: { chat:{id:5}, from:{id:5}, text:"/arm HIMMEL-2" } },                     // typed, not forwarded
+    { update_id: 3, message: { chat:{id:5}, from:{id:5}, text:"legacy fwd", forward_date: 123 } },     // deprecated marker
+  ], allowAll);
+  const lines = await readNewLines(join(r,"inbound.jsonl"), join(r,"inbound.jsonl.cursor"));
+  expect(lines[0].forwarded).toBe(true);  expect(lines[0].caption).toBe(false);
+  expect(lines[1].forwarded).toBe(false); expect(lines[1].caption).toBe(false);
+  expect(lines[2].forwarded).toBe(true);
+});
+
+test("ingest marks caption=true when the text came from a media caption (not m.text)", async () => {
+  const r = root();
+  const fetchImg: FetchImageFn = async () => "/tmp/x.jpg";
+  await ingestUpdates(r, [
+    { update_id: 1, message: { chat:{id:5}, from:{id:5}, caption:"/arm HIMMEL-1", photo:[{file_id:"a"}] } },
+  ], allowAll, fetchImg);
+  const lines = await readNewLines(join(r,"inbound.jsonl"), join(r,"inbound.jsonl.cursor"));
+  expect(lines[0].caption).toBe(true);
+  expect(lines[0].forwarded).toBe(false);
+});
+
+const autoGate = (ops: string[], fired: any[], authorize: (from: number, chat_id: number) => boolean = () => true) => ({
+  enabledOps: new Set(ops),
+  authorize,
+  fire: (msg: any, route: any) => { fired.push({ msg, route }); },
+});
+
+test("handleInbound routes a DM + operator + typed + enabled /arm to the auto fire, NOT run", async () => {
+  const r = root(); const fired: any[] = []; let ran = false;
+  await handleInbound(r, { from:5, chat_id:5, text:"/arm HIMMEL-1", forwarded:false, caption:false },
+    async () => { ran = true; }, autoGate(["arm-resume"], fired));
+  expect(fired.length).toBe(1);
+  expect(fired[0].route.op).toBe("arm-resume");
+  expect(ran).toBe(false);
+});
+
+test("autoGate.authorize composition: operator + allowlisted-chat only (CR S1 self-sufficiency)", () => {
+  const access = { allowFrom: ["5"], groups: { "-50": {} } };
+  const allow = makeAllow(access);
+  const authorize = (from: number, chat_id: number) => isAllowed(access, from) && allow(from, chat_id);
+  expect(authorize(5, 5)).toBe(true);     // operator DM
+  expect(authorize(5, -50)).toBe(true);   // operator in an allowlisted group
+  expect(authorize(9, -50)).toBe(false);  // non-operator in the group → refused (not operator)
+  expect(authorize(5, -99)).toBe(false);  // operator in a NON-allowlisted group → refused (chat gate)
+});
+
+test("handleInbound: an OPERATOR /arm in an allowlisted GROUP fires (operator-identity, HIMMEL-424 groups)", async () => {
+  const r = root(); const fired: any[] = []; let ran = false;
+  // operator (from=5) in a group (chat_id<0); isOperator(5)=true → arms
+  await handleInbound(r, { from:5, chat_id:-50, text:"/arm HIMMEL-1", forwarded:false, caption:false },
+    async () => { ran = true; }, autoGate(["arm-resume"], fired, (from) => from === 5));
+  expect(fired.length).toBe(1);
+  expect(ran).toBe(false);
+});
+
+test("handleInbound: a NON-operator /arm in a shared group falls through to chat, never arms — fix C1", async () => {
+  const r = root(); const fired: any[] = []; const ran: string[] = [];
+  // a different member (from=9) of the same group; isOperator(9)=false → powerless chat
+  await handleInbound(r, { from:9, chat_id:-50, text:"/arm HIMMEL-1", forwarded:false, caption:false },
+    async (s:string) => { ran.push(s); }, autoGate(["arm-resume"], fired, (from) => from === 5));
+  expect(fired.length).toBe(0);
+  expect(ran).toEqual(["group_-50"]);   // ordinary chat
+});
+
+test("handleInbound: a media-caption /arm in a DM falls through to chat, never arms — fix C2", async () => {
+  const r = root(); const fired: any[] = []; const ran: string[] = [];
+  await handleInbound(r, { from:5, chat_id:5, text:"/arm HIMMEL-1", forwarded:false, caption:true },
+    async (s:string) => { ran.push(s); }, autoGate(["arm-resume"], fired));
+  expect(fired.length).toBe(0);
+  expect(ran).toEqual(["__chat__"]);
+});
+
+test("handleInbound: empty enabledOps (default) → /arm is ordinary chat (inert)", async () => {
+  const r = root(); const fired: any[] = []; const ran: string[] = [];
+  await handleInbound(r, { from:5, chat_id:5, text:"/arm HIMMEL-1", forwarded:false, caption:false },
+    async (s:string) => { ran.push(s); }, autoGate([], fired));
+  expect(fired.length).toBe(0);
+  expect(ran).toEqual(["__chat__"]);
+});
+
+test("handleInbound: a DIFFERENT op enabled but /arm (arm-resume) disabled → chat", async () => {
+  const r = root(); const fired: any[] = []; const ran: string[] = [];
+  await handleInbound(r, { from:5, chat_id:5, text:"/arm HIMMEL-1", forwarded:false, caption:false },
+    async (s:string) => { ran.push(s); }, autoGate(["file-ticket"], fired));
+  expect(fired.length).toBe(0);
+  expect(ran).toEqual(["__chat__"]);
+});
+
+test("handleInbound: no auto deps wired → /arm is ordinary chat (back-compat)", async () => {
+  const r = root(); const ran: string[] = [];
+  await handleInbound(r, { from:5, chat_id:5, text:"/arm HIMMEL-1" }, async (s:string) => { ran.push(s); });
+  expect(ran).toEqual(["__chat__"]);
+});
+
+const autoDeps = () => {
+  const replies: any[] = []; const audits: any[] = []; let dispatched = 0;
+  return {
+    replies, audits, dispatched: () => dispatched,
+    deps: {
+      runScript: async () => { dispatched++; return { code: 0, stdout: "resolved=2026-x.md\n", stderr: "" }; },
+      reply: async (chat: number, text: string) => { replies.push({ chat, text }); },
+      audit: async (f: any) => { audits.push(f); },
+    },
+  };
+};
+const armRoute = { kind: "auto" as const, op: "arm-resume", arg: "HIMMEL-1", time: "smart" };
+
+test("handleAutoCommand: a non-forwarded /arm arms, replies success, audits 'armed'", async () => {
+  const r = root(); const a = autoDeps();
+  await handleAutoCommand(r, { from:5, chat_id:5, text:"/arm HIMMEL-1", forwarded:false, caption:false }, armRoute, a.deps);
+  expect(a.dispatched()).toBe(1);
+  expect(a.replies[0].chat).toBe(5);
+  expect(a.replies[0].text).toContain("armed");
+  expect(a.audits[0].result).toBe("armed");
+  expect(a.audits[0].resolved).toBe("2026-x.md");
+});
+
+test("handleAutoCommand: a FORWARDED /arm refuses — NO dispatch, reply + audit 'refused-forwarded' (THE injection test)", async () => {
+  const r = root(); const a = autoDeps();
+  await handleAutoCommand(r, { from:5, chat_id:5, text:"/arm HIMMEL-1", forwarded:true, caption:false }, armRoute, a.deps);
+  expect(a.dispatched()).toBe(0);                                   // never armed
+  expect(a.replies[0].text.toLowerCase()).toContain("forward");
+  expect(a.audits[0].result).toBe("refused-forwarded");
+  expect(a.audits[0].fwd ?? a.audits[0].forwarded).toBeTruthy();
+});
+
+test("handleAutoCommand: arm-resume dedup (rc 5) audits 'already-armed', no false success", async () => {
+  const r = root(); const a = autoDeps();
+  const deps = { ...a.deps, runScript: async () => ({ code: 5, stdout: "", stderr: "" }) };
+  await handleAutoCommand(r, { from:5, chat_id:5, text:"/arm HIMMEL-1", forwarded:false, caption:false }, armRoute, deps);
+  expect(a.replies[0].text.toLowerCase()).toContain("already armed");
+  expect(a.audits[0].result).toBe("already-armed");
+});
+
+test("replyViaOutbox routes a group reply to group_<id> and a DM reply to __chat__; flush delivers each to its chat", async () => {
+  const r = root();
+  await replyViaOutbox(r, -50, "grp reply");
+  await replyViaOutbox(r, 7, "dm reply");
+  expect((await readMeta(r, "group_-50"))?.chat_id).toBe(-50);
+  expect((await readMeta(r, "__chat__"))?.chat_id).toBe(7);
+  const sent: any[] = [];
+  await flushOutboxes(r, async (c: number, t: string) => { sent.push([c, t]); });
+  expect(sent).toContainEqual([-50, "grp reply"]);   // group arm reply lands in the GROUP
+  expect(sent).toContainEqual([7, "dm reply"]);
+});
+
+test("handleAutoCommand: a reply-delivery failure does NOT swallow the audit nor throw (CR I1)", async () => {
+  const r = root(); const audits: any[] = [];
+  const deps = {
+    runScript: async () => ({ code: 0, stdout: "resolved=x.md\n", stderr: "" }),
+    reply: async () => { throw new Error("telegram down"); },   // reply fails AFTER the arm
+    audit: async (f: any) => { audits.push(f); },
+  };
+  await handleAutoCommand(r, { from:5, chat_id:5, text:"/arm HIMMEL-1", forwarded:false, caption:false }, armRoute, deps);
+  expect(audits.length).toBe(1);              // the privileged arm is still durably recorded
+  expect(audits[0].result).toBe("armed");
+  // and the forwarded-refuse branch likewise audits before the (failing) reply
+  audits.length = 0;
+  await handleAutoCommand(r, { from:5, chat_id:5, text:"/arm HIMMEL-1", forwarded:true, caption:false }, armRoute, deps);
+  expect(audits[0].result).toBe("refused-forwarded");
 });

--- a/scripts/telegram/poller.ts
+++ b/scripts/telegram/poller.ts
@@ -2,7 +2,8 @@ import { readFile, writeFile, rename, mkdir, readdir, unlink, stat } from "node:
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { appendLine, atomicWrite, bridgeRoot, ensureSession, readMeta, writeMeta, sessionDir, readNewLines, truncateFullyConsumed, type Meta } from "./bus";
-import { classify } from "./router";
+import { classify, type Route } from "./router";
+import { dispatchAutoAction, parseEnabledOps, KNOWN_OPS, appendAuditLine, type RunScriptFn, type AuditFields } from "./auto-action";
 import { getUpdates, sendMessage, sendChatAction, getFile, downloadFile } from "./telegram-api";
 import { isAllowed, isGroupAllowed, loadAccess, vaultForChat, type Access } from "./gate";
 import { runSession, buildPrompt, type BusPaths } from "./run";
@@ -20,7 +21,12 @@ const RETRY_MS = Number(process.env.TELEGRAM_RETRY_MS ?? 15 * 60 * 1000);
 // Invariant: document_path is only ever present alongside document_name (set as
 // a pair); document_name without document_path means the download failed and the
 // message degraded to caption-only forwarding.
-export type Inbound = { from: number; chat_id: number; text: string; ts: number; update_id: number; image_path?: string; document_path?: string; document_name?: string };
+// forwarded/caption (HIMMEL-424 B2): always explicit booleans, never optional — they
+// gate the privileged `/arm` auto-command. `forwarded` = any Telegram forward marker
+// present (the injection-refuse signal). `caption` = the text came from a media caption
+// or voice transcript, NOT a genuinely typed m.text. Both fail toward "not a typed
+// command" so an undefined-deserialized value can never fail OPEN.
+export type Inbound = { from: number; chat_id: number; text: string; ts: number; update_id: number; forwarded: boolean; caption: boolean; image_path?: string; document_path?: string; document_name?: string };
 export type AllowFn = (fromId: number, chatId: number) => boolean;
 // Downloads a photo by file_id, returns the local path (null on failure).
 export type FetchImageFn = (file_id: string, update_id: number) => Promise<string | null>;
@@ -159,6 +165,10 @@ export async function ingestUpdates(root: string, updates: any[], allow: AllowFn
       continue;
     }
     const caption = typeof m.caption === "string" ? m.caption.trim() : "";
+    // forwarded (HIMMEL-424): any Telegram forward marker. forward_origin is the
+    // authoritative modern field; the rest are deprecated back-compat. (is_automatic_forward
+    // posts are already dropped at the top of the loop.) Presence => forwarded, the safe side.
+    const forwarded = !!(m.forward_origin ?? m.forward_date ?? m.forward_from ?? m.forward_from_chat ?? m.forward_sender_name);
     let text: string;
     if (voice) {
       // transcription not wired → drop like other unsupported media (stickers)
@@ -182,14 +192,15 @@ export async function ingestUpdates(root: string, updates: any[], allow: AllowFn
       } else {
         text = (caption ? caption + "\n" : "") + "[voice transcript] " + transcript;
       }
-      ready.push({ from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id });
+      // caption:true — a voice transcript is never a typed command (auto-ineligible).
+      ready.push({ from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id, forwarded, caption: true });
     } else if (doc && fetchDoc) {
       // Document (e.g. PDF) — same concurrent, time-bounded download as photos (HIMMEL-321).
       const docName = typeof doc.file_name === "string" ? doc.file_name : "file";
       text = caption || `[document: ${docName}]`;
       const downloadP = fetchDoc(doc.file_id, u.update_id, docName)
         .catch((e: unknown) => { console.error(`[poller] document download failed for update ${u.update_id}: ${e}`); return null; });
-      pendingDocs.push({ rec: { from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id, document_name: docName }, p: downloadP });
+      pendingDocs.push({ rec: { from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id, document_name: docName, forwarded, caption: true }, p: downloadP });
     } else if (photo && fetchImage) {
       // Start the download immediately (after allow gate) but do NOT await it here —
       // downloads run concurrently across the batch (HIMMEL-266); each one is
@@ -197,13 +208,15 @@ export async function ingestUpdates(root: string, updates: any[], allow: AllowFn
       text = caption || "[photo]";
       const downloadP = fetchImage(photo.file_id, u.update_id)
         .catch((e: unknown) => { console.error(`[poller] photo download failed for update ${u.update_id}: ${e}`); return null; });
-      pendingPhotos.push({ rec: { from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id }, p: downloadP });
+      pendingPhotos.push({ rec: { from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id, forwarded, caption: true }, p: downloadP });
     } else {
       // plain text, or photo/document with no fetch fn wired (forward caption text only)
       text = photo ? (caption || "[photo]")
            : doc ? (caption || `[document: ${typeof doc.file_name === "string" ? doc.file_name : "file"}]`)
            : m.text;
-      ready.push({ from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id });
+      // caption:true iff the text came from a media caption (photo/doc present), else it
+      // is a genuinely typed m.text (caption:false) — the only auto-command-eligible shape.
+      ready.push({ from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id, forwarded, caption: !!(photo || doc) });
     }
   }
   // Write all non-photo inbox entries.
@@ -245,12 +258,24 @@ export async function ingestUpdates(root: string, updates: any[], allow: AllowFn
   if (maxId >= offset) await saveOffset(root, maxId + 1);
 }
 
-export type DeliveredMsg = { from: number; chat_id: number; text: string; ts?: number; image_path?: string; document_path?: string; document_name?: string };
+export type DeliveredMsg = { from: number; chat_id: number; text: string; ts?: number; forwarded?: boolean; caption?: boolean; image_path?: string; document_path?: string; document_name?: string };
 export type RunFn = (session: string) => Promise<void>;
+
+// Auto-command gate (HIMMEL-424 B2). `fire` is FIRE-AND-FORGET so a slow arm never
+// blocks the ingest loop; `enabledOps` is parsed from TELEGRAM_AUTO_ACTIONS (empty by
+// default ⇒ inert). `authorize(from, chat_id)` is the SELF-SUFFICIENT auth check: the
+// SENDER must be the allowlisted operator (global allowFrom) AND the chat must be
+// allowlisted (a DM or an allowlisted group). This authorizes `/arm` from the operator
+// in a DM or an allowlisted group (groups carry distinct per-group context), refuses a
+// non-operator member of a shared group, and does NOT depend on the upstream ingest
+// gate as the chat-scope check (defense-in-depth, CR S1). Wired only in main(); absent
+// in unit tests that don't exercise /arm.
+export type AutoFire = (msg: DeliveredMsg, route: Extract<Route, { kind: "auto" }>) => void;
+export type AutoGate = { enabledOps: Set<string>; authorize: (from: number, chat_id: number) => boolean; fire: AutoFire };
 
 // Single-threaded dispatch: the poller calls handleInbound serially, so the
 // "status === running" in-flight check needs no atomic CAS.
-export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn): Promise<void> {
+export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn, auto?: AutoGate): Promise<void> {
   const route = classify(msg.text);
   // control verbs act directly; minimal handling for v2.2 (status/sessions/stop)
   if (route.kind === "control") {
@@ -260,11 +285,24 @@ export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn)
     }
     return; // status/sessions reporting is wired in the main loop (replies via outbox)
   }
+  // Auto-command (HIMMEL-424 B2): a message AUTHORIZED by auto.authorize(from, chat_id)
+  // — the sender is the allowlisted operator (global allowFrom) AND the chat is
+  // allowlisted (DM or allowlisted group); a non-operator member of a shared group is
+  // refused (fix C1) — that is genuinely TYPED (caption===false — a media-caption/voice
+  // /arm is refused, fix C2) and an ENABLED op is invoked DIRECTLY by the trusted bridge
+  // — the agent never sees it. The forwarded-refuse decision lives in handleAutoCommand.
+  // Any condition false ⇒ falls through to ordinary (powerless) chat below (so a
+  // non-operator/caption/disabled-op /arm is just chat).
+  if (route.kind === "auto" && auto && auto.authorize(msg.from, msg.chat_id) && msg.caption === false && auto.enabledOps.has(route.op)) {
+    auto.fire(msg, route);
+    return;
+  }
   // Non-DM chats (negative chat_id = group/channel) get their own session keyed
   // by chat_id so meta.chat_id pins replies to that chat, not the operator DM
   // (HIMMEL-238). "_" not ":" — the session id is an NTFS directory name.
   const chatSession = msg.chat_id < 0 ? `group_${msg.chat_id}` : "__chat__";
-  const session = route.kind === "chat" ? chatSession : route.ticket;
+  // A non-eligible auto-command (group / caption / disabled-op) routes as chat.
+  const session = (route.kind === "chat" || route.kind === "auto") ? chatSession : route.ticket;
   const { created } = await ensureSession(root, session);
   let meta = await readMeta(root, session);
   if (created || !meta) {
@@ -279,6 +317,47 @@ export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn)
   const line = route.kind === "followup" ? route.text : msg.text;
   await appendLine(join(sessionDir(root, session), "inbox.jsonl"), JSON.stringify({ text: line, from: msg.from, ts: msg.ts ?? 0, ...(msg.image_path ? { image_path: msg.image_path } : {}), ...(msg.document_path ? { document_path: msg.document_path, document_name: msg.document_name } : {}) }));
   if (meta.status === "idle" || meta.status === "done") await run(session);
+}
+
+// Map the auto-action.sh exit code to an audit result label.
+function auditResult(rc: number): string {
+  switch (rc) {
+    case 0:  return "armed";
+    case 3:  return "no-match";
+    case 4:  return "ambiguous";
+    case 5:  return "already-armed";
+    default: return "error";
+  }
+}
+
+export type AutoCommandDeps = {
+  runScript: RunScriptFn;
+  reply: (chat_id: number, text: string) => Promise<void>;
+  audit: (f: AuditFields) => Promise<void>;
+};
+
+// The auto-command flow (HIMMEL-424 B2). Run FIRE-AND-FORGET off the ingest loop (via
+// the gate's `fire`) so a slow `--time smart` arm can't stall polling. A FORWARDED /arm
+// is refused + audited (the injection kill-switch — `root` reserved for future use);
+// otherwise the bridge invokes auto-action.sh and relays the result. Every attempt —
+// executed OR refused — is audited.
+export async function handleAutoCommand(root: string, msg: DeliveredMsg, route: Extract<Route, { kind: "auto" }>, deps: AutoCommandDeps): Promise<void> {
+  void root;
+  // The AUDIT is the security event and is written FIRST; the operator reply is
+  // best-effort and must NEVER swallow the audit (CR I1: a reply-delivery failure
+  // after a successful privileged arm would otherwise leave no durable record).
+  const reply = async (text: string) => {
+    try { await deps.reply(msg.chat_id, text); }
+    catch (e) { console.error(`[poller] auto-action reply could not be delivered for chat ${msg.chat_id}: ${e}`); }
+  };
+  if (msg.forwarded === true) {
+    await deps.audit({ chat_id: msg.chat_id, user: msg.from, forwarded: true, op: route.op, arg: route.arg, time: route.time, rc: -1, result: "refused-forwarded" });
+    await reply("⚠️ forwarded commands are not executed");
+    return;
+  }
+  const res = await dispatchAutoAction({ runScript: deps.runScript }, route);
+  await deps.audit({ chat_id: msg.chat_id, user: msg.from, forwarded: false, op: route.op, arg: route.arg, resolved: res.resolved, time: route.time, rc: res.rc, result: auditResult(res.rc) });
+  await reply(res.message);
 }
 
 // tail: last chunk of the run's stdout+stderr (HIMMEL-262) — persisted to run.log
@@ -665,6 +744,22 @@ async function sessionsList(root: string): Promise<string[]> {
   try { return await readdir(join(root, "sessions")); } catch { return []; }
 }
 
+// Reply via the originating chat's outbox (HIMMEL-424): consistent with every other
+// operator-facing message in the bridge (send-then-commit durability + per-chat throttle
+// via flushOutboxes), and — unlike a direct sendMessage in the ingest loop — it does not
+// block polling. Routes to the SAME session the chat uses (group_<id> for a group, so a
+// group `/arm` reply lands in that group and its per-group context is preserved;
+// __chat__ for a DM) — mirrors handleInbound's chatSession routing.
+export async function replyViaOutbox(root: string, chat_id: number, text: string): Promise<void> {
+  const session = chat_id < 0 ? `group_${chat_id}` : "__chat__";
+  const { created } = await ensureSession(root, session);
+  const meta = await readMeta(root, session);
+  if (created || !meta) {
+    await writeMeta(root, session, { chat_id, status: "idle", last_run_pid: null, last_run_at: null, task_name: null, retry_at: null });
+  }
+  await appendLine(join(sessionDir(root, session), "outbox.jsonl"), JSON.stringify({ text }));
+}
+
 export async function main(): Promise<void> {
   const root = bridgeRoot();
   const repoCwd = process.env.HIMMEL_REPO ?? process.cwd();
@@ -728,6 +823,42 @@ export async function main(): Promise<void> {
     await sendMessage(token, chatId, `⚠️ couldn't download "${name}" (it may exceed Telegram's ~20MB limit) — I forwarded your caption only.`);
   };
   const send = async (chat: number, text: string) => { await sendMessage(token, chat, text); };
+  // Remote auto-actions (HIMMEL-424 B2): the trusted bridge parses a structured `/arm`
+  // and invokes auto-action.sh DIRECTLY — the agent is never in the trust path. Inert
+  // unless TELEGRAM_AUTO_ACTIONS enables an op (default OFF). `runScript` spawns the
+  // privileged script argv-array (no shell string — fix I2) with cwd=repoCwd. The child
+  // INHERITS the full bridge env BY DESIGN ("inherit the system" — the operator
+  // requirement): arm-resume.sh needs .env/HANDOVER_DIR/PATH/py-armor, and anticipated
+  // future ops need more (file-ticket → Jira token, run-named-skill → ANTHROPIC) — so a
+  // secret denylist is wrong here. The env is NOT an attacker surface: the child is
+  // himmel's own trusted script and the /arm arg is passed as validated positional args,
+  // never into env. We strip only TELEGRAM_BOT_TOKEN (+ TELEGRAM_OWN_POLLER) — the one
+  // credential the arm path demonstrably never needs (fix M3). The arm runs
+  // FIRE-AND-FORGET (autoFire) so a slow `--time smart` arm never stalls the ingest loop.
+  const enabledOps = parseEnabledOps(process.env.TELEGRAM_AUTO_ACTIONS, KNOWN_OPS);
+  if (enabledOps.size > 0) console.error(`[poller] auto-actions enabled: ${[...enabledOps].join(",")}`);
+  const autoScript = join(import.meta.dir, "auto-action.sh");
+  const runScript: RunScriptFn = async (op, arg, time) => {
+    const env: Record<string, string> = { ...process.env } as Record<string, string>;
+    delete env.TELEGRAM_BOT_TOKEN;
+    delete env.TELEGRAM_OWN_POLLER;
+    const p = Bun.spawn(["bash", autoScript, op, arg, time], { cwd: repoCwd, env, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(p.stdout).text(),
+      new Response(p.stderr).text(),
+      p.exited,
+    ]);
+    return { code, stdout, stderr };
+  };
+  const auditFn = appendAuditLine(root);
+  const autoFire: AutoFire = (msg, route) => {
+    void handleAutoCommand(root, msg, route, { runScript, reply: (chat, text) => replyViaOutbox(root, chat, text), audit: auditFn })
+      .catch((e) => console.error(`[poller] auto-action failed for op ${route.op}: ${e}`));
+  };
+  // authorize = operator-identity (global allowFrom) AND chat-allowlisted (makeAllow):
+  // the operator in a DM or an allowlisted group arms; a non-operator group member or a
+  // non-allowlisted chat is refused. Self-sufficient — re-asserts the chat gate (CR S1).
+  const autoGate: AutoGate = { enabledOps, authorize: (from, chat_id) => isAllowed(access, from) && allow(from, chat_id), fire: autoFire };
   // typing indicator while a session's bounded child works (HIMMEL-260)
   const TYPING_MS = Number(process.env.TELEGRAM_TYPING_MS ?? 4000);
   const typingTimer = setInterval(guarded(() => signalTyping(root, dispatch.isInFlight, () => sessionsList(root), (chat) => sendChatAction(token, chat))), TYPING_MS);
@@ -748,7 +879,7 @@ export async function main(): Promise<void> {
     const fresh = await readNewLines(join(root, "inbound.jsonl"), join(root, "inbound.jsonl.cursor"));
     // dispatch (not runFn) everywhere: runs fire WITHOUT blocking this loop —
     // ingest keeps polling while bounded children work (HIMMEL-246)
-    for (const i of fresh) await handleInbound(root, { from: i.from, chat_id: i.chat_id, text: i.text, ts: i.ts, image_path: i.image_path, document_path: i.document_path, document_name: i.document_name }, dispatch);
+    for (const i of fresh) await handleInbound(root, { from: i.from, chat_id: i.chat_id, text: i.text, ts: i.ts, forwarded: i.forwarded, caption: i.caption, image_path: i.image_path, document_path: i.document_path, document_name: i.document_name }, dispatch, autoGate);
     await deliverAllPending(root, dispatch, new Date(), () => sessionsList(root));
     await sweepStuckRunning(root, dispatch.isInFlight, () => sessionsList(root));
   }

--- a/scripts/telegram/router.test.ts
+++ b/scripts/telegram/router.test.ts
@@ -8,3 +8,28 @@ test("classifies control/dispatch/followup/chat + validates key", () => {
   expect(classify("hello there")).toEqual({ kind: "chat", text: "hello there" });
   expect(classify("work on lol-rm -rf")).toEqual({ kind: "chat", text: "work on lol-rm -rf" });
 });
+
+test("classifies /arm auto-commands (ticket|path + optional time), default smart", () => {
+  // ticket arg, no time suffix → smart
+  expect(classify("/arm HIMMEL-389")).toEqual({ kind: "auto", op: "arm-resume", arg: "HIMMEL-389", time: "smart" });
+  // path arg → smart
+  expect(classify("/arm handovers/yotam/x.md")).toEqual({ kind: "auto", op: "arm-resume", arg: "handovers/yotam/x.md", time: "smart" });
+  // explicit time forms
+  expect(classify("/arm HIMMEL-389 at 02:00")).toEqual({ kind: "auto", op: "arm-resume", arg: "HIMMEL-389", time: "02:00" });
+  expect(classify("/arm HIMMEL-389 auto")).toEqual({ kind: "auto", op: "arm-resume", arg: "HIMMEL-389", time: "auto" });
+  expect(classify("/arm HIMMEL-389 smart")).toEqual({ kind: "auto", op: "arm-resume", arg: "HIMMEL-389", time: "smart" });
+  // leading/trailing whitespace tolerated (whole-message trim)
+  expect(classify("  /arm HIMMEL-389  ")).toEqual({ kind: "auto", op: "arm-resume", arg: "HIMMEL-389", time: "smart" });
+});
+
+test("/arm with bad/missing pieces or mid-text falls through to chat (never auto)", () => {
+  // garbage time → not auto
+  expect(classify("/arm HIMMEL-389 at 99:99")).toEqual({ kind: "chat", text: "/arm HIMMEL-389 at 99:99" });
+  expect(classify("/arm HIMMEL-389 at 2pm")).toEqual({ kind: "chat", text: "/arm HIMMEL-389 at 2pm" });
+  // unknown trailing modifier → not auto
+  expect(classify("/arm HIMMEL-389 now")).toEqual({ kind: "chat", text: "/arm HIMMEL-389 now" });
+  // no arg → chat
+  expect(classify("/arm")).toEqual({ kind: "chat", text: "/arm" });
+  // mid-text /arm → chat (not anchored at start)
+  expect(classify("please /arm HIMMEL-389")).toEqual({ kind: "chat", text: "please /arm HIMMEL-389" });
+});

--- a/scripts/telegram/router.ts
+++ b/scripts/telegram/router.ts
@@ -12,7 +12,18 @@ export type Route =
   | { kind: "control"; verb: "stop"; ticket: string }
   | { kind: "dispatch"; ticket: string }
   | { kind: "followup"; ticket: string; text: string }
+  | { kind: "auto"; op: "arm-resume"; arg: string; time: string }
   | { kind: "chat"; text: string };
+
+// Structured auto-command (HIMMEL-424 B2): `/arm <ticket|path> [at HH:MM|auto|smart]`.
+// Anchored on the WHOLE trimmed message so a mid-text `/arm` never matches. SECURITY:
+// the bridge invokes this op directly (agent OUT of the trust path), so the command
+// must be a deliberate, message-fact-authenticated instruction — never text embedded
+// in chat. `arg` is freeform (ticket OR path); it is validated/resolved downstream by
+// auto-action.sh, NOT here. `time` defaults to "smart"; an unrecognized trailing
+// modifier (e.g. "now", "at 99:99") fails the match → falls through to chat. `/arm`
+// is the v1 alias for op `arm-resume` (the closed op allow-list at the parse layer).
+const ARM = /^\/arm\s+(\S+)(?:\s+(?:at\s+((?:[01][0-9]|2[0-3]):[0-5][0-9])|(auto|smart)))?$/;
 
 export function classify(raw: string): Route {
   const t = raw.trim();
@@ -21,6 +32,8 @@ export function classify(raw: string): Route {
   if (stop && KEY.test(stop[1])) return { kind: "control", verb: "stop", ticket: stop[1] };
   const disp = t.match(/^work on\s+(\S+)$/i);
   if (disp && KEY.test(disp[1])) return { kind: "dispatch", ticket: disp[1] };
+  const arm = t.match(ARM);
+  if (arm) return { kind: "auto", op: "arm-resume", arg: arm[1], time: arm[2] ?? arm[3] ?? "smart" };
   const fu = t.match(/^([A-Z][A-Z0-9]+-[0-9]+):\s*([\s\S]+)$/);
   if (fu) return { kind: "followup", ticket: fu[1], text: fu[2] };
   return { kind: "chat", text: t };

--- a/scripts/telegram/test-auto-action.sh
+++ b/scripts/telegram/test-auto-action.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Smoke / invariant tests for scripts/telegram/auto-action.sh (HIMMEL-424 B2).
+#
+# auto-action.sh is the privileged half of the remote auto-action surface: the
+# trusted bridge invokes it (argv array) to resolve a ticket|path to a resume
+# handover and shell arm-resume.sh. These tests stub the arm command
+# (AUTO_ACTION_ARM_CMD) so no real scheduler job is ever created, and use a
+# fixture HANDOVER_DIR so resolution is deterministic.
+set -uo pipefail
+
+AA="$(cd "$(dirname "$0")" && pwd)/auto-action.sh"
+[ -x "$AA" ] || chmod +x "$AA" 2>/dev/null || true
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+assert_rc() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then echo "PASS $label (rc=$actual)"
+    else echo "FAIL $label — expected rc=$expected, got rc=$actual"; FAILED=$((FAILED + 1)); fi
+}
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    case "$haystack" in *"$needle"*) echo "PASS $label" ;; *) echo "FAIL $label — missing: $needle"; FAILED=$((FAILED + 1)) ;; esac
+}
+FAILED=0
+
+# --- Fixtures -------------------------------------------------------------
+export HANDOVER_DIR="$TMP/handovers"
+mkdir -p "$HANDOVER_DIR/yotam/himmel/specs/design"
+
+# A genuine resume handover (lowercase filename, type: handover frontmatter).
+cat > "$HANDOVER_DIR/yotam/himmel/2026-06-20-himmel-777-resume.md" <<'EOF'
+---
+type: handover
+ticket: HIMMEL-777
+---
+resume me
+EOF
+
+# A design doc under specs/ — must NOT be a resolution candidate.
+cat > "$HANDOVER_DIR/yotam/himmel/specs/design/2026-06-20-himmel-888-design.md" <<'EOF'
+# HIMMEL-888 design
+not a resume target
+EOF
+
+# Two genuine handovers for the same ticket → ambiguous.
+cat > "$HANDOVER_DIR/yotam/himmel/2026-06-19-himmel-999-a.md" <<'EOF'
+---
+type: handover
+---
+a
+EOF
+cat > "$HANDOVER_DIR/yotam/himmel/2026-06-20-himmel-999-b.md" <<'EOF'
+---
+type: handover
+---
+b
+EOF
+
+# arm-resume stub: records argv, exits with ARM_STUB_RC (default 0).
+ARM_STUB="$TMP/arm-stub.sh"
+cat > "$ARM_STUB" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ARM_ARGS_FILE"
+exit "${ARM_STUB_RC:-0}"
+EOF
+chmod +x "$ARM_STUB"
+export AUTO_ACTION_ARM_CMD="bash $ARM_STUB"
+export ARM_ARGS_FILE="$TMP/arm-args"
+
+run() { ARM_STUB_RC="${ARM_STUB_RC:-0}" bash "$AA" "$@" 2>"$TMP/err"; }
+
+# --- T1: unknown op -------------------------------------------------------
+out=$(run bogus-op HIMMEL-777 smart); rc=$?
+assert_rc "T1 unknown op" 2 "$rc"
+
+# --- T2: bad time ---------------------------------------------------------
+out=$(run arm-resume HIMMEL-777 nope); rc=$?
+assert_rc "T2 bad time" 1 "$rc"
+out=$(run arm-resume HIMMEL-777 25:00); rc=$?
+assert_rc "T2b bad HH:MM" 1 "$rc"
+
+# --- T3: case-insensitive ticket resolve (UPPER arg, lowercase file) ------
+out=$(run arm-resume HIMMEL-777 smart); rc=$?
+assert_rc "T3 ticket resolves (case-insensitive)" 0 "$rc"
+assert_contains "T3 echoes resolved basename" "resolved=2026-06-20-himmel-777-resume.md" "$out"
+args=$(cat "$ARM_ARGS_FILE" 2>/dev/null)
+assert_contains "T3 arm got --handover resolved path" "2026-06-20-himmel-777-resume.md" "$args"
+assert_contains "T3 arm got --time smart" "--time smart" "$args"
+
+# --- T4: ticket only matched under specs/ → excluded → no handover --------
+out=$(run arm-resume HIMMEL-888 smart); rc=$?
+assert_rc "T4 specs/ excluded → no handover" 3 "$rc"
+
+# --- T5: >1 genuine handover → ambiguous, never silently pick -------------
+out=$(run arm-resume HIMMEL-999 smart); rc=$?
+assert_rc "T5 ambiguous" 4 "$rc"
+assert_contains "T5 lists a candidate" "himmel-999" "$(cat "$TMP/err")"
+
+# --- T6: no match → exit 3 ------------------------------------------------
+out=$(run arm-resume HIMMEL-000 smart); rc=$?
+assert_rc "T6 no match" 3 "$rc"
+
+# --- T7: non-existent path → exit 3 ---------------------------------------
+out=$(run arm-resume "$HANDOVER_DIR/nope.md" smart); rc=$?
+assert_rc "T7 non-existent path" 3 "$rc"
+
+# --- T8: path OUTSIDE handover_root → exit 3 (containment) -----------------
+OUTSIDE="$TMP/outside.md"; echo "x" > "$OUTSIDE"
+out=$(run arm-resume "$OUTSIDE" smart); rc=$?
+assert_rc "T8 path outside handover_root rejected" 3 "$rc"
+
+# --- T9: valid path INSIDE root → arms ------------------------------------
+INSIDE="$HANDOVER_DIR/yotam/himmel/2026-06-20-himmel-777-resume.md"
+out=$(run arm-resume "$INSIDE" 02:00); rc=$?
+assert_rc "T9 valid in-root path arms" 0 "$rc"
+assert_contains "T9 arm got --time 02:00" "--time 02:00" "$(cat "$ARM_ARGS_FILE")"
+
+# --- T10: arm-resume dedup (rc 3) → auto-action rc 5 (already armed) -------
+out=$(ARM_STUB_RC=3 run arm-resume HIMMEL-777 smart); rc=$?
+assert_rc "T10 already-armed maps to rc 5" 5 "$rc"
+
+# --- T11: arm-resume other failure (rc 2) → auto-action rc 6 --------------
+out=$(ARM_STUB_RC=2 run arm-resume HIMMEL-777 smart); rc=$?
+assert_rc "T11 arm failure maps to rc 6" 6 "$rc"
+
+echo "----"
+if [ "$FAILED" -eq 0 ]; then echo "ALL PASS"; else echo "$FAILED FAILED"; exit 1; fi


### PR DESCRIPTION
Allowlisted operator arms a resume from Telegram via `/arm <ticket|path> [at HH:MM|auto|smart]`. The trusted bridge parses + invokes arm-resume.sh directly (agent out of the trust path). Guards: operator-identity (DM or allowlisted group; non-operator group members refused), typed-only, forwarded-refuse (audited). Gated by `TELEGRAM_AUTO_ACTIONS` (per-op enable-list, default OFF). Closed op allow-list + path containment + argv-array spawn + sanitized audit. Full bun suite + auto-action.sh smoke + shellcheck green.