### PR TITLE
feat(hooks): [HIMMEL-425] opt-in HIMMEL_INITIATIVE drive-to-ship SessionStart hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,10 @@ himmel enforces structurally, not by prose: **6 PreToolUse hooks**
 **pre-commit/commit-msg/pre-push gates** (source of truth
 `.pre-commit-config.yaml`; pre-push incl. `check-platforms-tested`), a
 `UserPromptSubmit` hook (`improve-on-submit.sh`,
-default OFF), and shared **guardrail predicates** (`scripts/guardrails/lib.sh`).
+default OFF), a `SessionStart` hook (`inject-initiative.sh` — opt-in
+`HIMMEL_INITIATIVE` drive-to-ship directive: `1`/`all` for the full chain or a
+comma-separated subset of `prcheck,pr,ticket,handover`, default OFF, advisory
+only; HIMMEL-425), and shared **guardrail predicates** (`scripts/guardrails/lib.sh`).
 Hook bypass = session env var set in the LAUNCHING shell (e.g.
 `EDIT_ON_MAIN_OK=1 claude`); a per-call prefix does NOT work. Per-repo opt-out:
 a local gitignored `.single-writer` at a repo root allows on-main edits there

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -325,6 +325,48 @@ Spec: `scripts/hooks/test-auto-arm-on-cap.sh` (paired smoke suite).
    twice per tool call — harmless (the throttle marker is shared, so
    the second invocation is a single stat() no-op).
 
+## Claude SessionStart Hooks
+
+Wired in the `SessionStart` array of `.claude/settings.json`; fires once when a
+session starts. Stdout on exit 0 is injected as additional context.
+`check-update-available.sh` (the himmel-update nudge) also runs here.
+
+### `inject-initiative.sh` — opt-in initiative mode (HIMMEL-425)
+
+Default: OFF. When `HIMMEL_INITIATIVE=1` is set in the launching shell, the
+session is given a scoped "drive to ship" directive so a normal session
+proactively runs the `/pr-check` → open PR → transition ticket → handover
+sequence at *natural completion points*, without the operator saying "ship it"
+each time. Drains stdin; never blocks session start (always exits 0).
+
+Master switch: `1`, `true`, `on`, `yes`, `all` (case-insensitive) → all four
+parts. All falsy / unset values (`0`, `false`, `off`, `no`, empty) leave it
+off — a byte-identical no-op, so default behaviour is unchanged.
+
+**Per-part control (mirrors `CRITIC_PANEL_TIERS`):** set `HIMMEL_INITIATIVE`
+to a comma-separated subset of the canonical parts
+`prcheck,pr,ticket,handover` to inject only those steps (e.g.
+`HIMMEL_INITIATIVE=prcheck,pr` = run CR + open the PR, but don't auto-transition
+the ticket or write the handover). Parsing is case-insensitive and
+whitespace-tolerant (`PR, ticket` works); unknown tokens are ignored, and a
+value that resolves to no recognized part is treated as off; steps always
+render in canonical chain order regardless of input order. The directive
+echoes the recognized tokens (`Active steps: …`) so a typo is visible
+in-session. No dependency enforcement — a degenerate subset (e.g. `handover`
+alone) just narrows the advice; the structural rails still apply, so it
+degrades gracefully rather than doing anything unsafe.
+
+The injected text is **advisory context, not a permission change** — it cannot
+widen what the hooks allow. The rails still HARD-block: `check-cr-marker-on-pr-
+create` gates `gh pr create` until a clean `/pr-check`; attestation trailers
+must be in the FIRST commit; reactive `git commit --amend` and self-editing
+`.claude/settings.json` to widen rules are still vetoed; **merge stays an
+operator action** (the directive explicitly excludes merge).
+
+Companion: `scripts/hooks/test-inject-initiative.sh` (paired smoke suite).
+Sits alongside the bypass/opt-in flags (`EDIT_ON_MAIN_OK`, `READ_SECRETS_OK`,
+`IMPROVE_ON_SUBMIT`) — all set in the shell that LAUNCHED Claude.
+
 ## Claude PostToolUse Hooks
 
 One hook wired in `.claude/settings.json` fires AFTER a tool call completes.

--- a/scripts/hooks/inject-initiative.sh
+++ b/scripts/hooks/inject-initiative.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# inject-initiative.sh — SessionStart hook for opt-in initiative mode (HIMMEL-425).
+#
+# Gated by the HIMMEL_INITIATIVE env var (must be set in the shell that
+# LAUNCHED Claude — bypass convention per scripts/hooks/CLAUDE.md; a per-call
+# prefix does NOT reach the hook process). When active, the session is given a
+# scoped "drive to ship" directive so a normal session proactively runs the
+# /pr-check → open PR → transition ticket → handover sequence at natural
+# completion points, without the operator saying "ship it" each time.
+#
+# Per-part control (mirrors CRITIC_PANEL_TIERS): the value is either a master
+# switch (1/true/on/yes/all → all four parts) or a comma-separated subset of
+# the canonical parts `prcheck,pr,ticket,handover`. Parsing is
+# case-insensitive and whitespace-tolerant; unknown tokens are ignored; steps
+# always render in canonical order regardless of input order. The directive
+# echoes the recognized tokens (`Active steps: …`) so a typo is visible.
+#
+# Default: OFF. Exit silently when the env is unset, falsy, or resolves to no
+# recognized part — behaviour then is byte-identical to a session without the
+# directive.
+#
+# This is ADVISORY injected context, not a permission change: it cannot widen
+# what the hooks allow. The safety rails still HARD-block (check-cr-marker-on-
+# pr-create gates gh pr create; the persistence classifier vetoes reactive
+# --amend and settings.json self-edits; merge stays an operator action).
+#
+# Hook contract (SessionStart):
+#   - Reads the SessionStart JSON payload from stdin (we don't consume fields).
+#   - Exit 0 with stdout → stdout is injected as additional context.
+#   - Non-zero exit → would surface an error; we never block, only ever exit 0.
+#
+# Wiring (in .claude/settings.json):
+#   {
+#     "hooks": {
+#       "SessionStart": [
+#         { "hooks": [ { "type": "command",
+#                        "command": "bash $CLAUDE_PROJECT_DIR/scripts/hooks/inject-initiative.sh"
+#                      } ] }
+#       ]
+#     }
+#   }
+
+set -euo pipefail
+
+# Always exit clean; never block session start.
+trap 'exit 0' ERR
+
+# Drain stdin so the hook contract doesn't break the runtime if it pipes a
+# payload. We don't currently need the JSON body.
+if [ -t 0 ]; then
+    :
+else
+    cat >/dev/null 2>&1 || true
+fi
+
+# --- Parse HIMMEL_INITIATIVE into the set of active chain parts -------------
+# The value is either a whole-string master switch or a comma-separated subset
+# of the four canonical parts (mirrors CRITIC_PANEL_TIERS). Normalize once:
+# lowercase + strip all whitespace so "PR, ticket" == "pr,ticket". Bash 3.2-safe.
+_norm=$(printf '%s' "${HIMMEL_INITIATIVE:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+
+# Resolve the active parts (canonical order is fixed by the loop below, not by
+# input order). `active` is a space-separated list drawn from the canonical set.
+case "$_norm" in
+    ""|0|false|off|no)
+        exit 0
+        ;;
+    1|true|on|yes|all)
+        active="prcheck pr ticket handover"
+        ;;
+    *)
+        # Comma subset: keep only canonical tokens (membership test against the
+        # input dedups, drops empty/trailing fields, and ignores unknowns).
+        active=""
+        for _tok in prcheck pr ticket handover; do
+            case ",$_norm," in
+                *,"$_tok",*) active="$active $_tok" ;;
+            esac
+        done
+        active="${active# }"
+        # A non-empty value that resolved to nothing (all-unknown / typo) is off.
+        [ -n "$active" ] || exit 0
+        ;;
+esac
+
+# CSV of recognized tokens for the in-session echo (typo visibility).
+_steps_csv=$(printf '%s' "$active" | tr ' ' ',')
+
+# --- Assemble the directive ------------------------------------------------
+# Invariant prose stays in quoted heredocs (it contains backticks that an
+# unquoted heredoc would try to command-substitute). Only the numbered step
+# list is built dynamically, so it renumbers to the active subset.
+cat <<'EOF'
+<system-reminder>
+HIMMEL_INITIATIVE is active for this Claude Code session.
+EOF
+printf 'Active steps: %s\n' "$_steps_csv"
+cat <<'EOF'
+
+Take initiative: drive the current work to done without waiting for an
+explicit "ship it" each time. At a *natural completion point* (a logical chunk
+of work is finished AND verified):
+EOF
+
+_n=0
+# shellcheck disable=SC2016 # backticks in the format strings are literal directive prose, not expansions
+for _tok in $active; do
+    _n=$((_n + 1))
+    case "$_tok" in
+        prcheck)  printf '%d. Run `/pr-check` and loop — fix every finding, re-run — until CR is clean.\n' "$_n" ;;
+        pr)       printf '%d. When CR is clean, open or refresh the PR.\n' "$_n" ;;
+        ticket)   printf '%d. Transition the Jira ticket to the appropriate status.\n' "$_n" ;;
+        handover) printf '%d. Write the handover.\n' "$_n" ;;
+    esac
+done
+
+cat <<'EOF'
+
+Scope and limits:
+- Fire only at completion points, NOT on every small edit. Don't interrupt
+  mid-task.
+- Do NOT merge — merge stays an operator action.
+- This directive does NOT relax any safety rail. The CR-marker hook still
+  HARD-blocks `gh pr create` until a clean /pr-check; attestation trailers must
+  be in the FIRST commit; reactive `git commit --amend` and self-editing
+  `.claude/settings.json` to widen rules are still HARD-vetoed.
+
+To disable for the rest of the session, unset HIMMEL_INITIATIVE in the
+launching shell + restart claude (env vars don't propagate into a running
+session). For per-part control, set HIMMEL_INITIATIVE to a comma-separated
+subset of: prcheck, pr, ticket, handover (e.g. HIMMEL_INITIATIVE=prcheck,pr).
+</system-reminder>
+EOF
+
+exit 0

--- a/scripts/hooks/test-inject-initiative.sh
+++ b/scripts/hooks/test-inject-initiative.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# test-inject-initiative.sh — smoke test for scripts/hooks/inject-initiative.sh.
+#
+# Covers (HIMMEL-425):
+#   1. Default (env unset) → exits 0 with empty stdout (no directive injected).
+#   2. HIMMEL_INITIATIVE=1 → exits 0, prints the initiative directive.
+#   3. Other truthy values (true/on/yes/all/...) also activate (all four steps).
+#   4. Falsy values (0/false/empty/no/off) do NOT activate.
+#   5. No stdin payload still works (SessionStart may pipe a JSON body or not).
+#   6. The injected directive must NOT instruct merging (operator gate).
+#   7. Hook always exits 0 (never blocks session start).
+#
+# Per-part toggles (HIMMEL-425 extension — mirrors CRITIC_PANEL_TIERS):
+#   8.  A single-token subset injects only that step and omits the others.
+#   9.  A multi-token subset injects exactly the named steps.
+#   10. Steps render in canonical order regardless of input order.
+#   11. Unknown tokens mixed with valid ones are ignored, valid ones still fire.
+#   12. Tokens parse case-insensitively and tolerate surrounding whitespace.
+#   13. The directive echoes the recognized tokens (Active steps: ...).
+#   14. Safety invariants (no-merge, no-rail-relaxation) appear in EVERY subset.
+#   15. `all` activates all four steps.
+#   16. Duplicate / trailing-comma tokens collapse to a single rendered step.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+hook="$repo_root/scripts/hooks/inject-initiative.sh"
+
+if [ ! -f "$hook" ]; then
+    echo "FAIL: $hook not found" >&2
+    exit 1
+fi
+
+pass=0
+fail=0
+
+assert_pass() {
+    pass=$((pass + 1))
+    echo "  PASS: $1"
+}
+
+assert_fail() {
+    fail=$((fail + 1))
+    echo "  FAIL: $1"
+}
+
+# assert_has <desc> <bre-needle> <haystack> — haystack must contain the needle.
+assert_has() {
+    if printf '%s' "$3" | grep -q "$2"; then
+        assert_pass "$1"
+    else
+        assert_fail "$1 (missing: $2)"
+    fi
+}
+
+# assert_lacks <desc> <bre-needle> <haystack> — haystack must NOT contain it.
+assert_lacks() {
+    if printf '%s' "$3" | grep -q "$2"; then
+        assert_fail "$1 (unexpected: $2)"
+    else
+        assert_pass "$1"
+    fi
+}
+
+# ---------- 1. Default OFF ----------
+echo "Test 1: default OFF (env unset)"
+out=$(unset HIMMEL_INITIATIVE; printf '{"source":"startup"}' | bash "$hook")
+if [ -z "$out" ]; then
+    assert_pass "no directive injected when env unset"
+else
+    assert_fail "expected empty stdout, got: $out"
+fi
+
+# ---------- 2. HIMMEL_INITIATIVE=1 → active ----------
+echo "Test 2: HIMMEL_INITIATIVE=1 → active"
+out=$(printf '{}' | HIMMEL_INITIATIVE=1 bash "$hook")
+if echo "$out" | grep -q "HIMMEL_INITIATIVE is active"; then
+    assert_pass "directive injected when env=1"
+else
+    assert_fail "expected 'HIMMEL_INITIATIVE is active' in output, got: $out"
+fi
+
+# ---------- 3. Other truthy values ----------
+echo "Test 3: other truthy values activate"
+for val in true TRUE on ON yes YES; do
+    out=$(printf '{}' | HIMMEL_INITIATIVE="$val" bash "$hook")
+    if echo "$out" | grep -q "HIMMEL_INITIATIVE is active"; then
+        assert_pass "truthy value '$val' activates"
+    else
+        assert_fail "truthy value '$val' should activate but did not"
+    fi
+done
+
+# ---------- 4. Falsy / unrecognized values stay off ----------
+# Includes garbage tokens (maybe/2/enabled) to lock in the contract that
+# "truthy" is an explicit allow-list — anything NOT on it is off, not merely
+# the known-falsy words. ',,,' exercises the subset path that resolves to no
+# recognized part (the explicit `[ -n "$active" ] || exit 0` branch).
+echo "Test 4: falsy and unrecognized values stay off"
+for val in 0 false "" no off maybe 2 enabled ",,,"; do
+    out=$(printf '{}' | HIMMEL_INITIATIVE="$val" bash "$hook")
+    if [ -z "$out" ]; then
+        assert_pass "falsy/unrecognized value '$val' stays off"
+    else
+        assert_fail "value '$val' should be off but injected: $out"
+    fi
+done
+
+# ---------- 5. No stdin payload ----------
+echo "Test 5: no stdin payload still works"
+out=$(HIMMEL_INITIATIVE=1 bash "$hook" </dev/null)
+if echo "$out" | grep -q "HIMMEL_INITIATIVE is active"; then
+    assert_pass "no stdin payload tolerated"
+else
+    assert_fail "expected activation even without stdin, got: $out"
+fi
+
+# ---------- 6. Directive does not authorize merge ----------
+echo "Test 6: directive does not instruct merge (operator gate preserved)"
+out=$(HIMMEL_INITIATIVE=1 bash "$hook" </dev/null)
+if echo "$out" | grep -qi "do NOT merge"; then
+    assert_pass "directive explicitly excludes merge"
+else
+    assert_fail "directive must explicitly exclude merge, got: $out"
+fi
+
+# ---------- 7. Always exits 0 (never blocks session start) ----------
+# The load-bearing safety property: a SessionStart hook must never block the
+# session, so it must exit 0 on every path — active, off, and unset.
+echo "Test 7: hook always exits 0 (never blocks session start)"
+printf '{}' | bash "$hook" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ]; then
+    assert_pass "exit 0 when env unset"
+else
+    assert_fail "expected exit 0 when unset, got rc=$rc"
+fi
+printf '{}' | HIMMEL_INITIATIVE=0 bash "$hook" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ]; then
+    assert_pass "exit 0 on falsy value"
+else
+    assert_fail "expected exit 0 on falsy, got rc=$rc"
+fi
+printf '{}' | HIMMEL_INITIATIVE=1 bash "$hook" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ]; then
+    assert_pass "exit 0 when active"
+else
+    assert_fail "expected exit 0 when active, got rc=$rc"
+fi
+
+# Unique per-step markers (must not collide with the invariant trailer prose):
+#   prcheck  → "fix every finding"
+#   pr       → "open or refresh the PR"
+#   ticket   → "Transition the Jira ticket"
+#   handover → "Write the handover"
+
+# ---------- 8. Single-token subset → only that step ----------
+echo "Test 8: subset 'prcheck' injects only the pr-check step"
+out=$(printf '{}' | HIMMEL_INITIATIVE=prcheck bash "$hook")
+assert_has   "prcheck step present"  "fix every finding"        "$out"
+assert_lacks "pr step omitted"       "open or refresh the PR"   "$out"
+assert_lacks "ticket step omitted"   "Transition the Jira ticket" "$out"
+assert_lacks "handover step omitted" "Write the handover"       "$out"
+
+# ---------- 9. Multi-token subset → exactly the named steps ----------
+echo "Test 9: subset 'prcheck,pr' injects prcheck + pr only"
+out=$(printf '{}' | HIMMEL_INITIATIVE=prcheck,pr bash "$hook")
+assert_has   "prcheck step present"  "fix every finding"        "$out"
+assert_has   "pr step present"       "open or refresh the PR"   "$out"
+assert_lacks "ticket step omitted"   "Transition the Jira ticket" "$out"
+assert_lacks "handover step omitted" "Write the handover"       "$out"
+
+# ---------- 10. Canonical order regardless of input order ----------
+echo "Test 10: 'handover,prcheck' renders prcheck first (canonical order)"
+out=$(printf '{}' | HIMMEL_INITIATIVE=handover,prcheck bash "$hook")
+assert_has "prcheck numbered first"  "1\. Run"                  "$out"
+assert_has "handover numbered second" "2\. Write the handover"  "$out"
+
+# ---------- 11. Unknown token ignored, valid one still fires ----------
+echo "Test 11: 'prcheck,bogus' ignores bogus, keeps prcheck"
+out=$(printf '{}' | HIMMEL_INITIATIVE=prcheck,bogus bash "$hook")
+assert_has   "prcheck step present"  "fix every finding"        "$out"
+assert_lacks "no bogus echoed as step" "bogus"                  "$out"
+
+# ---------- 12. Case-insensitive + whitespace-tolerant ----------
+echo "Test 12: 'PR, ticket' parses case-insensitively, trims spaces"
+out=$(printf '{}' | HIMMEL_INITIATIVE="PR, ticket" bash "$hook")
+assert_has   "pr step present"       "open or refresh the PR"   "$out"
+assert_has   "ticket step present"   "Transition the Jira ticket" "$out"
+assert_lacks "prcheck step omitted"  "fix every finding"        "$out"
+assert_lacks "handover step omitted" "Write the handover"       "$out"
+
+# ---------- 13. Directive echoes recognized tokens ----------
+echo "Test 13: directive echoes the active tokens (typo visibility)"
+out=$(printf '{}' | HIMMEL_INITIATIVE=prcheck,pr bash "$hook")
+assert_has "active-steps line present" "Active steps:"          "$out"
+# Exact match (not "...pr") so a dropped pr token can't hide behind prcheck.
+assert_has "active-steps lists both tokens in order" "Active steps: prcheck,pr" "$out"
+
+# ---------- 14. Safety invariants present in EVERY subset ----------
+# The load-bearing property: no subset may ever drop the no-merge / no-rail-
+# relaxation guards. Parametrized so a renumber/assembly bug can't regress it.
+echo "Test 14: safety invariants present in every subset"
+for val in prcheck pr pr,ticket handover all 1; do
+    out=$(printf '{}' | HIMMEL_INITIATIVE="$val" bash "$hook")
+    assert_has "[$val] excludes merge"       "Do NOT merge"                  "$out"
+    assert_has "[$val] no rail relaxation"   "does NOT relax any safety rail" "$out"
+done
+
+# ---------- 15. `all` activates all four steps ----------
+echo "Test 15: 'all' activates the full chain"
+out=$(printf '{}' | HIMMEL_INITIATIVE=all bash "$hook")
+assert_has "prcheck step present"  "fix every finding"          "$out"
+assert_has "pr step present"       "open or refresh the PR"     "$out"
+assert_has "ticket step present"   "Transition the Jira ticket" "$out"
+assert_has "handover step present" "Write the handover"         "$out"
+
+# ---------- 16. Duplicate / trailing-comma collapses to one step ----------
+echo "Test 16: 'pr,pr,' renders a single pr step"
+out=$(printf '{}' | HIMMEL_INITIATIVE=pr,pr, bash "$hook")
+assert_has   "pr step present"       "open or refresh the PR"   "$out"
+assert_lacks "no second numbered step" "2\."                    "$out"
+
+echo
+echo "RESULTS: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
SessionStart hook that injects a scoped drive-to-ship directive only when `HIMMEL_INITIATIVE=1` (byte-identical no-op otherwise). Advisory only; merge excluded; rails untouched. Ships the hook script + test + docs; the settings.json wiring is operator-personal (users wire it per docs/internals/enforcement.md) — excluded from public propagation by convention.