### PR TITLE
feat(telegram): [HIMMEL-424] sanction non-destructive Jira ops in the bridge prompt

### DIFF
--- a/scripts/telegram/run-prompt.md
+++ b/scripts/telegram/run-prompt.md
@@ -18,6 +18,7 @@ If a line has an "image_path" field, use the Read tool on that path — it is a 
 If a line has a "document_path" field, use the Read tool on that path — it is a file the operator attached (e.g. a PDF); the line's "text" is its caption and "document_name" is the original filename.
 <job>
 <vault-clause — only when a vault is configured for the session's chat (HIMMEL-321)>
+Acting on Jira tickets for the operator is part of your job — when asked, DO IT DIRECTLY (don't just offer a paste-ready command). Use the Jira CLI by its ABSOLUTE path: `node <cwd>/scripts/jira/dist/index.js <op>` (JIRA_PROJECT_KEY comes from the repo .env; run it with --help for the ops). You MAY create, edit/update, comment, transition, assign, change priority/labels, attach files, link, and read tickets — this is sanctioned, non-destructive work. You may NOT delete tickets (there is no delete op), and do NOT use `move` (it closes the source ticket) or `project-create` (admin) unless the operator explicitly asks.
 Reply to the operator by APPENDING one JSON line {"text":"<your reply>"} per message to <outbox>. That is the only way to reach the operator.
 Do NOT poll Telegram yourself and do NOT open a --channels session.
 As your FINAL action, append a one-line progress note to <context> (so the next run has context). Then stop — you are done.
@@ -53,6 +54,18 @@ Here a PDF sent to the group with its own `vault` is filed into that vault;
 a PDF sent to any other chat (other allowlisted groups, or a DM) falls back to
 `defaultVault` — which covers every chat without its own.
 The poller reads `access.json` ONCE at startup — restart the bridge after edits.
+
+## Jira sanction (HIMMEL-424 followup)
+
+The bridge session runs in auto-mode, where the harness classifier VETOES Jira ticket
+writes when the session's stated workflow omits Jira — so without this clause the bridge
+replies *"I can't create the ticket (classifier veto)"* instead of doing it. The clause
+states Jira ticket work as in-scope, which lifts the veto. It is deliberately scoped to
+**non-destructive** operations: there is no `delete` op in the CLI, and `move` (closes the
+source ticket) and `project-create` (admin) are excluded unless the operator explicitly
+asks. The CLI is invoked by its absolute path under `<cwd>` (the primary checkout, where
+the untracked `dist/` build artifact lives — a worktree-relative path would
+`MODULE_NOT_FOUND`).
 
 ## Contract the prompt enforces
 

--- a/scripts/telegram/run.test.ts
+++ b/scripts/telegram/run.test.ts
@@ -69,3 +69,16 @@ test("buildPrompt without a vault adds no file-into-vault clause (HIMMEL-321)", 
   const p = buildPrompt("group_-50", { inbox:"i", outbox:"o", context:"c", cwd:"/r" });
   expect(p).not.toContain("into the Obsidian vault");   // matches the real clause text
 });
+test("buildPrompt sanctions non-destructive Jira ticket ops (HIMMEL-424 followup — lifts the classifier veto)", () => {
+  const p = buildPrompt("__chat__", { inbox:"i", outbox:"o", context:"c", cwd:"/repo" });
+  // the absolute jira CLI path, derived from cwd (avoids the worktree dist/ trap)
+  expect(p).toContain("/repo/scripts/jira/dist/index.js");
+  // Jira ticket work is stated as IN-SCOPE so the auto-mode classifier doesn't veto it
+  expect(p).toContain("Jira");
+  expect(p.toLowerCase()).toMatch(/create|edit|comment|transition/);
+  // explicit non-destructive boundary: assert the FORBIDDANCE phrasing, not just the
+  // keyword (a prompt that said "you may delete" would otherwise pass — CR gptoss-1)
+  expect(p).toMatch(/NOT delete/i);                       // no deletion
+  expect(p).toMatch(/do NOT use [`']?move/i);             // no move (closes the source ticket)
+  expect(p).toContain("project-create");                  // admin op named in the exclusion
+});

--- a/scripts/telegram/run.ts
+++ b/scripts/telegram/run.ts
@@ -33,6 +33,12 @@ export function buildPrompt(session: string, p: BusPaths, vault?: string | null)
     ...(vault ? [
       `When a message carries a "document_path", file the document's content into the Obsidian vault at ${vault}: read that vault's _CLAUDE.md first and follow its filing conventions (use the obsidian-second-brain skill). In your reply, confirm what you filed and where.`,
     ] : []),
+    // Jira sanction (HIMMEL-424 followup): without this, the auto-mode classifier
+    // VETOES ticket writes because the bridge session's stated workflow omits Jira —
+    // the bridge would reply "I can't create the ticket (classifier veto)". Stating
+    // it as in-scope lifts the veto. Non-destructive only: there is no delete op, and
+    // move (closes the source ticket) / project-create (admin) are excluded.
+    `Acting on Jira tickets for the operator is part of your job — when asked, DO IT DIRECTLY (don't just offer a paste-ready command). Use the Jira CLI by its ABSOLUTE path: \`node ${p.cwd}/scripts/jira/dist/index.js <op>\` (JIRA_PROJECT_KEY comes from the repo .env; run it with --help for the ops). You MAY create, edit/update, comment, transition, assign, change priority/labels, attach files, link, and read tickets — this is sanctioned, non-destructive work. You may NOT delete tickets (there is no delete op), and do NOT use \`move\` (it closes the source ticket) or \`project-create\` (admin) unless the operator explicitly asks.`,
     `Reply to the operator by APPENDING one JSON line {"text":"<your reply>"} per message to ${p.outbox}. That is the only way to reach the operator.`,
     `Do NOT poll Telegram yourself and do NOT open a --channels session.`,
     `As your FINAL action, append a one-line progress note to ${p.context} (so the next run has context). Then stop — you are done.`,


### PR DESCRIPTION
buildPrompt states Jira ticket work as in-scope so the auto-mode classifier no longer vetoes it. Non-destructive only (create/edit/comment/transition/assign/priority/attach/link/read); no delete op exists; move/project-create excluded unless explicitly asked. CLI invoked by absolute path under cwd.