### PR TITLE
feat(handover): [HIMMEL-416] F2 P2+P3 — bug tracker, resume surfacing, dashboard + lessons

### DIFF
--- a/marketplace/plugins/handover/README.md
+++ b/marketplace/plugins/handover/README.md
@@ -50,6 +50,9 @@ though the himmel repo also wires explicit `/handover *` commands.
 | `new-standalone <name>` | Create a standalone (optional Jira Story). |
 | `update-status` | Regenerate `status.md` + `roadmap.md` + `tech-debt.md` from filesystem state. Run after any mutation. |
 | `handover-resume #N` | Resume a tracked item — surface its brief, decisions, and stop-point. Read-only (no worktree gate). |
+| `/handover bug <add\|fix\|status>` | Quick-add / update a bug in the active item's `bugs.md` (status + FAILED/WORKED fixes-tried). The circular-debugging breaker. |
+| `/handover bugs [--open]` | Cross-item dashboard of every tracked bug (item / id / status / symptom / #fixes + totals). Read-only. |
+| `/handover lessons` | Proposal-only sweep: recurring resolved-bug symptoms + CR findings as lesson candidates. Writes nothing. |
 | `end-session [id]` | Consolidate session work into a `next-session-N.md` snapshot for the named item. |
 | `/handover bucket <id> <bucket>` | Move an item between source buckets (HIMMEL-307). |
 | `/handover priority <id> <priority>` | Set an item's priority. |

--- a/marketplace/plugins/handover/skills/handover/SKILL.md
+++ b/marketplace/plugins/handover/skills/handover/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handover
-description: Use when the user says "new epic", "new task", "new standalone", "end session", "update status", "handover", "handover-resume #N", "handover init", "handover register", "handover repos", or asks to create/track work items in the handover system. Also use when wrapping up a session or resuming tracked work. Triggers on phrases like "wrap up", "session done", "start epic", "add task to #N", "handover-resume", "resume session", "register handover for <repo>".
+description: Use when the user says "new epic", "new task", "new standalone", "end session", "update status", "handover", "handover-resume #N", "handover bug", "log a bug", "track a bug", "fix didn't work", "handover bugs", "bug dashboard", "handover lessons", "lessons sweep", "handover init", "handover register", "handover repos", or asks to create/track work items in the handover system. Also use when wrapping up a session or resuming tracked work. Triggers on phrases like "wrap up", "session done", "start epic", "add task to #N", "handover-resume", "resume session", "register handover for <repo>".
 ---
 
 # Handover System
@@ -237,7 +237,7 @@ Regenerates `<state-root>/status.md` + `roadmap.md` + `tech-debt.md` from filesy
 2. List `<state-root>/{,<bucket>/}epics/<form>-*/` → read each `master-plan.md` for Status, Task Index, frontmatter (bucket, priority, severity, jira, pending_jira_link).
 3. List `<state-root>/{,<bucket>/}epics/*/tasks/<form>-*/` → read each `brief.md`.
 4. List `<state-root>/{,<bucket>/}standalones/<form>-*/` → read each `brief.md`.
-5. Count open bugs across all `bugs.md` files; count blocked items.
+5. Count open bugs across all `bugs.md` files (an open bug = a `### BUG-<n>` heading whose inline `<!-- status: ... -->` is `open` or `fixing`; legacy table-format files have no such headings → count 0); count blocked items.
 6. **Regenerate three auto-files in one pass:**
 
    a. `<state-root>/status.md` — summary table with new columns Bucket and Priority:
@@ -304,6 +304,45 @@ The skill produces `<state-root>/tech-debt.md` on every `update-status` call. Al
 
 Items with `pending_jira_link: true` are listed under their dedicated section, not the stale tiers, regardless of age.
 
+### `/handover bug <add|fix|status>`
+
+Quick-add / update a bug in the **active item's** `bugs.md` (resolved from the
+current branch's ticket via `scripts/handover/resolve-active-item.sh` — C1; if it
+exits non-zero, tell the user there's no active handover item and stop). Backed by
+`scripts/handover/bug.sh`. Run by absolute path from the repo root.
+
+- `add "<symptom>"` → `bug.sh add --bugs <item>/bugs.md --symptom "<symptom>"`. Echoes the new `BUG-<n>` id.
+- `fix <BUG-n> <FAILED|WORKED> "<note>"` → `bug.sh fix --bugs <item>/bugs.md --id <BUG-n> --outcome <FAILED|WORKED> --note "<note>"`. Records a fix attempt under `Fixes tried:`.
+- `status <BUG-n> <open|fixing|resolved|wontfix>` → `bug.sh status --bugs <item>/bugs.md --id <BUG-n> --to <status>`.
+
+Resolve `<item>` once: `item="$(bash scripts/handover/resolve-active-item.sh)"` (exit 3 → no active item → skip with a one-line note). The bug id is per-item sequential and stable.
+
+### `/handover bugs [--open]`
+
+Cross-item **dashboard** of every tracked bug (read-only). Renders a markdown
+table (Item / Bug / Status / Symptom / #Fixes) across all `bugs.md` under the
+handover root, with totals. `--open` restricts to `open`/`fixing`. Backed by
+`scripts/handover/bugs-dashboard.sh`; run by absolute path from the repo root:
+
+```
+bash scripts/handover/bugs-dashboard.sh [--open]
+```
+
+No active-item resolve needed — it aggregates the whole root. Prints
+`_No bugs tracked._` when clean (`_No open bugs tracked._` under `--open`).
+
+### `/handover lessons`
+
+Proposal-only **lessons sweep** (read-only, writes nothing). Surfaces symptoms
+of `resolved`/`wontfix` bugs and CR-finding titles that recur across ≥2 items
+as lesson **candidates**, followed by a full digest. The operator promotes
+what's worth keeping — there is no auto-write to the vault or `CLAUDE.md`.
+Backed by `scripts/handover/lessons-sweep.sh`:
+
+```
+bash scripts/handover/lessons-sweep.sh
+```
+
 ### `handover-resume #N`
 
 Resolves any ID and outputs the cold-start prompt to resume work in a new session. Read-only.
@@ -322,6 +361,7 @@ Resolves any ID and outputs the cold-start prompt to resume work in a new sessio
 5. List `next-session-*.md` in target dir. Find highest-numbered file.
 6. **If session file exists:** read in full, locate the `## Cold-Start Prompt` heading, print every line **after** the heading up to the next `## ` heading or EOF (exclude the heading line itself, trim leading/trailing blank lines). Print under header `Cold-start prompt for #N (repo: <name>):`.
 7. **No session file:** fallback — print `context.md` (epic) or `brief.md` (task/standalone), prefixed `No session file yet for #N in <repo-name>. Showing context:`.
+7.5. **Surface open bugs + latest CR findings (C5).** Run `bash scripts/handover/resume-context.sh --item <resolved-item-dir>` (the dir found in step 3). If it prints anything, append it to the output under a blank line — so the resuming session sees open bugs (with FAILED/WORKED fixes-tried, to avoid re-trying a failed fix) and the most recent CR-findings block before continuing. Prints nothing for an item with no open bugs and no CR findings — leave the output clean.
 8. **Stale nudge** — if `<state-root>/tech-debt.md` has any entries under `## Lingering` or `## Zombie`, append the top 3 to the printed output:
 
    ```
@@ -635,6 +675,10 @@ Registry (machine-global, not per-repo):
 ## Capturing Human Feedback
 
 When user gives feedback on work during chat, capture it to the relevant `reviewer-notes.md` under `## Human Feedback`. Proactively — don't wait to be asked. Resolves under the **target repo** of the work being reviewed.
+
+## Capturing Bug Fixes
+
+When a fix is attempted during debugging and **fails**, append it to the active item's bug before moving on — proactively, don't wait to be asked: `/handover bug fix <BUG-n> FAILED "<what you tried + why it failed>"` (or `bug add "<symptom>"` first if the bug isn't tracked yet). When a fix works, record `WORKED` and set status `resolved`. This `Fixes tried` FAILED/WORKED ledger is the circular-debugging breaker — it stops a later session (or a post-compaction you) from re-trying a fix that already failed. Resolves under the **target repo** of the work being debugged (same resolver as Human Feedback).
 
 ## References (load on demand)
 

--- a/marketplace/plugins/handover/templates/epic-bugs.md
+++ b/marketplace/plugins/handover/templates/epic-bugs.md
@@ -3,5 +3,8 @@ template_version: 2
 ---
 # Bug Log — #N <Epic Name>
 
-| Bug | Description | Status | Task | Session | Notes |
-|-----|-------------|--------|------|---------|-------|
+<!-- One "### BUG-<n> — <symptom>" entry per bug, each carrying an inline status
+     marker (open | fixing | resolved | wontfix) on its heading and a "Fixes
+     tried:" list that records every attempt as FAILED or WORKED — the
+     circular-debug breaker — plus Resolution and CR-link fields. Entries are
+     added and updated via /handover bug (scripts/handover/bug.sh), not by hand. -->

--- a/marketplace/plugins/handover/templates/standalone-bugs.md
+++ b/marketplace/plugins/handover/templates/standalone-bugs.md
@@ -3,5 +3,8 @@ template_version: 2
 ---
 # Bug Log — Standalone #N <Name>
 
-| Bug | Description | Status | Notes |
-|-----|-------------|--------|-------|
+<!-- One "### BUG-<n> — <symptom>" entry per bug, each carrying an inline status
+     marker (open | fixing | resolved | wontfix) on its heading and a "Fixes
+     tried:" list that records every attempt as FAILED or WORKED — the
+     circular-debug breaker — plus Resolution and CR-link fields. Entries are
+     added and updated via /handover bug (scripts/handover/bug.sh), not by hand. -->

--- a/marketplace/plugins/handover/templates/task-bugs.md
+++ b/marketplace/plugins/handover/templates/task-bugs.md
@@ -3,5 +3,8 @@ template_version: 2
 ---
 # Bug Log — Task #N <Name>
 
-| Bug | Description | Status | Session | Notes |
-|-----|-------------|--------|---------|-------|
+<!-- One "### BUG-<n> — <symptom>" entry per bug, each carrying an inline status
+     marker (open | fixing | resolved | wontfix) on its heading and a "Fixes
+     tried:" list that records every attempt as FAILED or WORKED — the
+     circular-debug breaker — plus Resolution and CR-link fields. Entries are
+     added and updated via /handover bug (scripts/handover/bug.sh), not by hand. -->

--- a/scripts/handover/bug.sh
+++ b/scripts/handover/bug.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# scripts/handover/bug.sh — per-item bug tracker over one bugs.md
+# (HIMMEL-416 F2 / C3). Subcommands: add | fix | status | list.
+# Bug ids are per-item sequential (BUG-1, BUG-2, …), stable within the item.
+set -uo pipefail
+
+sub="${1:-}"; [ $# -gt 0 ] && shift
+bugs="" symptom="" id="" outcome="" note="" to="" only_open="" porcelain=""
+while [ $# -gt 0 ]; do case "$1" in
+  --bugs) bugs="$2"; shift 2;; --symptom) symptom="$2"; shift 2;;
+  --id) id="$2"; shift 2;; --outcome) outcome="$2"; shift 2;;
+  --note) note="$2"; shift 2;; --to) to="$2"; shift 2;;
+  --open) only_open=1; shift;; --porcelain) porcelain=1; shift;;
+  *) echo "bug.sh: unknown arg $1" >&2; exit 2;;
+esac; done
+[ -n "$bugs" ] || { echo "bug.sh: --bugs required" >&2; exit 2; }
+
+seed_if_missing(){
+  [ -f "$bugs" ] && return 0
+  local d; d="$(dirname "$bugs")"
+  [ -d "$d" ] || { echo "bug.sh: item dir not found ($d)" >&2; exit 2; }
+  printf '%s\n' '---' 'template_version: 2' '---' '# Bug Log' '' > "$bugs" || { echo "bug.sh: failed to seed $bugs" >&2; exit 2; }
+}
+
+next_id(){
+  local n
+  n="$(grep -oE '^### BUG-[0-9]+ ' "$bugs" 2>/dev/null | grep -oE '[0-9]+' | sort -n | tail -n1)"
+  [ -n "$n" ] && echo $((n+1)) || echo 1
+}
+
+case "$sub" in
+  add)
+    [ -n "$symptom" ] || { echo "bug.sh add: --symptom required" >&2; exit 2; }
+    seed_if_missing
+    n="$(next_id)"
+    {
+      printf '\n### BUG-%s — %s <!-- status: open -->\n' "$n" "$symptom"
+      printf -- '- **Symptom:** %s\n' "$symptom"
+      printf -- '- **Fixes tried:**\n'
+      printf -- '- **Resolution:** —\n'
+      printf -- '- **CR link:** —\n'
+    } >> "$bugs" || { echo "bug.sh add: write failed" >&2; exit 2; }
+    echo "BUG-$n"
+    ;;
+  fix)
+    [ -n "$id" ] || { echo "bug.sh fix: --id required" >&2; exit 2; }
+    case "$outcome" in FAILED|WORKED) :;; *) echo "bug.sh fix: --outcome must be FAILED|WORKED" >&2; exit 2;; esac
+    [ -f "$bugs" ] || { echo "bug.sh fix: $bugs not found" >&2; exit 3; }
+    n="${id#BUG-}"
+    grep -qE "^### BUG-${n} — " "$bugs" || { echo "bug.sh fix: $id not found" >&2; exit 3; }
+    tmpf="$(mktemp "${bugs}.bug.XXXXXX")" || { echo "bug.sh fix: cannot create temp" >&2; exit 2; }
+    trap 'rm -f "$tmpf"' EXIT
+    # Insert the outcome bullet right after the target bug's "Fixes tried:" line.
+    # `inbug` is on only between the target heading and the next "### " heading.
+    if ! (awk -v n="$n" -v line="  - ${note} → ${outcome}" '
+      /^### BUG-/ { inbug = ($0 ~ ("^### BUG-" n " — ")) }
+      { print }
+      inbug && /^- \*\*Fixes tried:\*\*/ { print line }
+    ' "$bugs" > "$tmpf" && mv "$tmpf" "$bugs"); then
+      echo "bug.sh fix: write failed" >&2; exit 2
+    fi
+    trap - EXIT
+    ;;
+  status)
+    [ -n "$id" ] || { echo "bug.sh status: --id required" >&2; exit 2; }
+    case "$to" in open|fixing|resolved|wontfix) :;; *) echo "bug.sh status: --to must be open|fixing|resolved|wontfix" >&2; exit 2;; esac
+    [ -f "$bugs" ] || { echo "bug.sh status: $bugs not found" >&2; exit 3; }
+    n="${id#BUG-}"
+    grep -qE "^### BUG-${n} — " "$bugs" || { echo "bug.sh status: $id not found" >&2; exit 3; }
+    tmpf="$(mktemp "${bugs}.bug.XXXXXX")" || { echo "bug.sh status: cannot create temp" >&2; exit 2; }
+    trap 'rm -f "$tmpf"' EXIT
+    if ! (awk -v n="$n" -v to="$to" '
+      $0 ~ ("^### BUG-" n " — ") { sub(/<!-- status: [a-z]+ -->/, "<!-- status: " to " -->") }
+      { print }
+    ' "$bugs" > "$tmpf" && mv "$tmpf" "$bugs"); then
+      echo "bug.sh status: write failed" >&2; exit 2
+    fi
+    trap - EXIT
+    ;;
+  list)
+    [ -f "$bugs" ] || exit 0
+    awk -v only_open="$only_open" -v porc="$porcelain" '
+      function flush(   show, i, s) {
+        if (cur_n == "") return
+        show = (only_open=="") || (cur_st=="open") || (cur_st=="fixing")
+        if (show) {
+          if (porc != "") {
+            s=cur_sym; gsub(/\t/, " ", s)   # tabs would break the porcelain field contract
+            printf "BUG-%s\t%s\t%s\t%s\n", cur_n, cur_st, cur_nf, s
+          }
+          else {
+            printf "BUG-%s [%s] %s\n", cur_n, cur_st, cur_sym
+            for (i = 0; i < nf; i++) print fixbuf[i]
+          }
+        }
+        cur_n=""; cur_nf=0; nf=0; infixes=0
+      }
+      /^### BUG-[0-9]+ — / {
+        flush()
+        cur_nf=0
+        line=$0
+        cur_n=line;  sub(/^### BUG-/,"",cur_n);   sub(/ — .*/,"",cur_n)
+        cur_st="open"   # default for a legacy/hand-edited heading missing the status comment
+        if (line ~ /<!-- status: [a-z]+ -->/) { cur_st=line; sub(/.*<!-- status: /,"",cur_st); sub(/ -->.*/,"",cur_st) }
+        cur_sym=line; sub(/^### BUG-[0-9]+ — /,"",cur_sym); sub(/ <!-- status:.*/,"",cur_sym)
+        next
+      }
+      /^- \*\*Fixes tried:\*\*/ { infixes=1; next }
+      /^### / { infixes=0 }
+      infixes && /^  - / {
+        cur_nf++
+        f=$0; sub(/^  - /,"  ",f); fixbuf[nf++]=f
+      }
+      END { flush() }
+    ' "$bugs"
+    ;;
+  *) echo "bug.sh: unknown subcommand '$sub'" >&2; exit 2;;
+esac

--- a/scripts/handover/bugs-dashboard.sh
+++ b/scripts/handover/bugs-dashboard.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# scripts/handover/bugs-dashboard.sh — cross-item aggregate bug dashboard
+# (HIMMEL-416 F2 / C4). Read-only: walks every item's bugs.md under the
+# handover root and renders a markdown table + totals. Reuses bug.sh as the
+# single bugs.md parser (list --porcelain). Rows sorted by item path (groups
+# epics/ before standalones/); per-item bugs stay in id order.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
+. "$HERE/../lib/handover-path.sh" || { echo "bugs-dashboard.sh: cannot source handover-path.sh" >&2; exit 2; }
+
+only_open="" root_override=""
+while [ $# -gt 0 ]; do case "$1" in
+  --open) only_open=1; shift;;
+  --all) only_open=""; shift;;
+  --root) root_override="$2"; shift 2;;
+  *) echo "bugs-dashboard.sh: unknown arg $1" >&2; exit 2;;
+esac; done
+
+root="${root_override:-$(handover_root)}" || { echo "bugs-dashboard.sh: handover root unresolved" >&2; exit 2; }
+[ -d "$root" ] || { echo "bugs-dashboard.sh: handover root not found ($root)" >&2; exit 2; }
+
+total=0 open=0 rows=""
+while IFS= read -r bf; do
+  [ -n "$bf" ] || continue
+  item="$(dirname "$bf")"; label="${item#"$root"}"; label="${label#/}"
+  # No 2>/dev/null on the bug.sh subcall or find below: bug.sh already self-guards
+  # a missing file (exit 0, no output), so the only thing a redirect would hide is a
+  # genuine parser/permission failure — which must surface, not read as "no bugs".
+  while IFS="$(printf '\t')" read -r id st nf sym; do
+    [ -n "$id" ] || continue
+    total=$((total+1))
+    case "$st" in open|fixing) open=$((open+1));; esac
+    sym="${sym//|/\\|}"
+    rows="${rows}| ${label} | ${id} | ${st} | ${sym} | ${nf} |
+"
+  done < <(bash "$HERE/bug.sh" list --porcelain ${only_open:+--open} --bugs "$bf")
+done < <(find "$root" -type f -name bugs.md | LC_ALL=C sort)
+
+if [ "$total" -eq 0 ]; then
+  printf '_No %sbugs tracked._\n' "${only_open:+open }"
+  exit 0
+fi
+printf '| Item | Bug | Status | Symptom | Fixes |\n'
+printf '|------|-----|--------|---------|-------|\n'
+printf '%s' "$rows"
+printf '\n**Totals:** %d bug(s), %d open/fixing.\n' "$total" "$open"

--- a/scripts/handover/lessons-sweep.sh
+++ b/scripts/handover/lessons-sweep.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# scripts/handover/lessons-sweep.sh — proposal-only lessons sweep
+# (HIMMEL-416 F2 / C6). Read-only: collects resolved/wontfix bug symptoms and
+# CR-finding titles across every handover item, flags text recurring across
+# >=2 items as lesson CANDIDATES, then prints a digest. Writes nothing — the
+# operator promotes what's worth keeping (no auto-write to vault / CLAUDE.md).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
+. "$HERE/../lib/handover-path.sh" || { echo "lessons-sweep.sh: cannot source handover-path.sh" >&2; exit 2; }
+
+root_override=""
+while [ $# -gt 0 ]; do case "$1" in
+  --root) root_override="$2"; shift 2;;
+  *) echo "lessons-sweep.sh: unknown arg $1" >&2; exit 2;;
+esac; done
+root="${root_override:-$(handover_root)}" || { echo "lessons-sweep.sh: handover root unresolved" >&2; exit 2; }
+[ -d "$root" ] || { echo "lessons-sweep.sh: handover root not found ($root)" >&2; exit 2; }
+
+TAB="$(printf '\t')"
+# norm: lowercase + whitespace-collapse — the recurrence key.
+norm(){ printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//'; }
+
+digest=""   # pre-formatted "- bug · …" / "- cr · …" lines
+pairs=""    # "<item><TAB><key><TAB><display>" rows for recurrence detection
+
+# Resolved/wontfix bug symptoms (via bug.sh — the single bugs.md parser).
+# No 2>/dev/null on the subcalls/find: a genuine parser or permission failure must
+# surface on stderr rather than read as "no lessons" (bug.sh self-guards missing files).
+while IFS= read -r bf; do
+  [ -n "$bf" ] || continue
+  item="${bf%/bugs.md}"; label="${item#"$root"}"; label="${label#/}"
+  while IFS="$TAB" read -r id st nf sym; do
+    [ -n "$id" ] || continue
+    case "$st" in resolved|wontfix) :;; *) continue;; esac
+    : "$nf"   # nfixes unused here; symptom is the recurrence signal
+    key="$(norm "$sym")"
+    digest="${digest}- bug · ${label} · ${id} · ${sym}
+"
+    pairs="${pairs}${label}${TAB}${key}${TAB}${sym}
+"
+  done < <(bash "$HERE/bug.sh" list --porcelain --bugs "$bf")
+done < <(find "$root" -type f -name bugs.md | LC_ALL=C sort)
+
+# CR-finding titles: bullet "… — <title> (<verdict>) <!-- cr:… -->" under "## CR Findings".
+while IFS= read -r nf2; do
+  [ -n "$nf2" ] || continue
+  item="${nf2%/reviewer-notes.md}"; label="${item#"$root"}"; label="${label#/}"
+  while IFS= read -r title; do
+    [ -n "$title" ] || continue
+    key="$(norm "$title")"
+    digest="${digest}- cr · ${label} · ${title}
+"
+    pairs="${pairs}${label}${TAB}${key}${TAB}${title}
+"
+  done < <(awk '
+    /^## CR Findings[[:space:]]*$/ { incr=1; next }
+    incr && /^## / && !/^### / { incr=0 }
+    incr && /^- / {
+      t=$0
+      sep=" — "; ix=index(t, sep); if (ix > 0) t=substr(t, ix+length(sep))  # content after the FIRST " — "
+      sub(/ \([^)]*\)[[:space:]]*<!--.*$/,"",t)    # drop " (verdict) <!-- … -->"
+      print t
+    }
+  ' "$nf2")
+done < <(find "$root" -type f -name reviewer-notes.md | LC_ALL=C sort)
+
+# Recurring: a norm-key appearing in >=2 DISTINCT items.
+recurring="$(printf '%s' "$pairs" | awk -F"$TAB" '
+  NF>=3 {
+    key=$2
+    if (!(key SUBSEP $1 in seen)) { seen[key SUBSEP $1]=1; items[key]=items[key] (items[key]?", ":"") $1; cnt[key]++ }
+    if (!(key in disp)) disp[key]=$3
+  }
+  END { for (k in cnt) if (cnt[k] >= 2) printf "- %s  (in: %s)\n", disp[k], items[k] }
+' | LC_ALL=C sort)"
+
+if [ -n "$recurring" ]; then
+  printf '## Recurring (lesson candidates)\n%s\n\n' "$recurring"
+fi
+printf '## Digest\n'
+if [ -z "$digest" ]; then
+  printf '_No resolved bugs or CR findings yet._\n'
+else
+  printf '%s' "$digest"
+fi

--- a/scripts/handover/resume-context.sh
+++ b/scripts/handover/resume-context.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# scripts/handover/resume-context.sh — resume panel for one handover item:
+# open bugs (avoid re-trying failed fixes) + the latest CR-findings block
+# (HIMMEL-416 F2 / C5). Read-only; prints nothing for a clean item.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+item=""
+while [ $# -gt 0 ]; do case "$1" in
+  --item) item="$2"; shift 2;;
+  *) echo "resume-context.sh: unknown arg $1" >&2; exit 2;;
+esac; done
+[ -n "$item" ] || { echo "resume-context.sh: --item required" >&2; exit 2; }
+
+# Open bugs (only if any).
+bugs="$item/bugs.md"
+if [ -f "$bugs" ]; then
+  open_out="$(bash "$HERE/bug.sh" list --bugs "$bugs" --open)" || echo "resume-context.sh: bug.sh list failed, open bugs unavailable" >&2
+  if [ -n "$open_out" ]; then
+    printf '### Open bugs (avoid re-trying failed fixes)\n%s\n\n' "$open_out"
+  fi
+fi
+
+# Latest CR-findings block: the LAST "### " header under "## CR Findings" and
+# its bullets (append-cr-findings.sh appends newest blocks at EOF). awk resets
+# `blk` on each "### " so only the final block survives to END.
+notes="$item/reviewer-notes.md"
+if [ -f "$notes" ] && grep -qE '^## CR Findings[[:space:]]*$' "$notes"; then
+  cr="$(awk '
+    /^## CR Findings[[:space:]]*$/ { incr=1; next }
+    incr && /^## / && !/^### / { incr=0 }                # left the section
+    incr && /^### / { blk=$0 ORS; next }                 # new block -> reset
+    incr { blk=blk $0 ORS }
+    END { printf "%s", blk }
+  ' "$notes")"
+  if [ -n "$cr" ]; then
+    printf '### Latest CR findings\n%s\n' "$cr"
+  fi
+fi

--- a/scripts/handover/test-bug.sh
+++ b/scripts/handover/test-bug.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; B="$HERE/bug.sh"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+fails=0; check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+F="$tmp/bugs.md"
+seed(){ printf '%s\n' '---' 'template_version: 2' '---' '# Bug Log — Task #1 Demo' '' > "$F"; }
+
+# add: first bug -> BUG-1, status open, body skeleton present, id echoed.
+seed
+id1="$(bash "$B" add --bugs "$F" --symptom "race on resume")"
+check "add: echoes BUG-1"       "$id1" "BUG-1"
+check "add: heading present"     "$(grep -c '^### BUG-1 — race on resume <!-- status: open -->' "$F")" "1"
+check "add: symptom field"       "$(grep -c '^- \*\*Symptom:\*\* race on resume' "$F")" "1"
+check "add: fixes-tried field"   "$(grep -c '^- \*\*Fixes tried:\*\*' "$F")" "1"
+
+# add: second bug -> BUG-2 (sequential).
+id2="$(bash "$B" add --bugs "$F" --symptom "dup CR entry")"
+check "add: echoes BUG-2"        "$id2" "BUG-2"
+check "add: two headings"        "$(grep -c '^### BUG-' "$F")" "2"
+
+# seq must use max+1, not count: removing the lower id still yields max+1.
+# (simulate by adding a high id by hand, then add -> next = high+1)
+printf '%s\n' '### BUG-9 — manual <!-- status: open -->' >> "$F"
+id3="$(bash "$B" add --bugs "$F" --symptom "after gap")"
+check "add: next = max+1 (BUG-10)" "$id3" "BUG-10"
+
+# seed-if-missing: item dir exists, bugs.md absent -> create + add.
+mkdir -p "$tmp/item"; G="$tmp/item/bugs.md"
+idg="$(bash "$B" add --bugs "$G" --symptom "fresh")"
+check "seed: file created"       "$( [ -f "$G" ] && echo yes )" "yes"
+check "seed: BUG-1 echoed"       "$idg" "BUG-1"
+check "seed: has title"          "$(grep -c '^# Bug Log' "$G")" "1"
+
+# missing parent dir -> exit 2, no stray file.
+bash "$B" add --bugs "$tmp/nodir/bugs.md" --symptom x 2>/dev/null
+check "missing parent -> rc 2"   "$?" "2"
+check "no stray file"            "$( [ -e "$tmp/nodir/bugs.md" ] && echo bad || echo ok )" "ok"
+
+# fix: append a FAILED then a WORKED outcome under the right bug.
+seed
+bash "$B" add --bugs "$F" --symptom "alpha" >/dev/null   # BUG-1
+bash "$B" add --bugs "$F" --symptom "beta"  >/dev/null   # BUG-2
+bash "$B" fix --bugs "$F" --id BUG-2 --outcome FAILED --note "bumped timeout"
+bash "$B" fix --bugs "$F" --id BUG-2 --outcome WORKED --note "added mutex"
+check "fix: FAILED line present"  "$(grep -c -- '- bumped timeout → FAILED' "$F")" "1"
+check "fix: WORKED line present"  "$(grep -c -- '- added mutex → WORKED' "$F")" "1"
+
+# fix lands under BUG-2, not BUG-1: the WORKED line is after the BUG-2 heading.
+ln_b2=$(grep -n '^### BUG-2 — ' "$F" | head -1 | cut -d: -f1)
+ln_fx=$(grep -n -- '- added mutex → WORKED' "$F" | head -1 | cut -d: -f1)
+check "fix: under correct bug"   "$( [ "$ln_fx" -gt "$ln_b2" ] && echo yes )" "yes"
+
+# anchor: BUG-1 must NOT match BUG-12 (prefix-collision guard).
+printf '%s\n' '### BUG-12 — twelfth <!-- status: open -->' '- **Fixes tried:**' >> "$F"
+bash "$B" fix --bugs "$F" --id BUG-1 --outcome FAILED --note "only one"
+ln_b12=$(grep -n '^### BUG-12 — ' "$F" | head -1 | cut -d: -f1)
+ln_one=$(grep -n -- '- only one → FAILED' "$F" | head -1 | cut -d: -f1)
+check "fix: BUG-1 not under BUG-12" "$( [ "$ln_one" -lt "$ln_b12" ] && echo yes )" "yes"
+
+# unknown id -> rc 3 (graceful).
+bash "$B" fix --bugs "$F" --id BUG-99 --outcome FAILED --note nope 2>/dev/null
+check "fix: unknown id -> rc 3"   "$?" "3"
+
+# bad outcome -> rc 2.
+bash "$B" fix --bugs "$F" --id BUG-1 --outcome MAYBE --note x 2>/dev/null
+check "fix: bad outcome -> rc 2"  "$?" "2"
+
+# status: flip BUG-1 open -> resolved without touching BUG-2.
+seed
+bash "$B" add --bugs "$F" --symptom "gamma" >/dev/null   # BUG-1
+bash "$B" add --bugs "$F" --symptom "delta" >/dev/null   # BUG-2
+bash "$B" status --bugs "$F" --id BUG-1 --to resolved
+check "status: BUG-1 resolved"   "$(grep -c '^### BUG-1 — gamma <!-- status: resolved -->' "$F")" "1"
+check "status: BUG-2 untouched"  "$(grep -c '^### BUG-2 — delta <!-- status: open -->' "$F")" "1"
+
+# anchor guard: BUG-1 status change must not hit BUG-12.
+printf '%s\n' '### BUG-12 — twelfth <!-- status: open -->' >> "$F"
+bash "$B" status --bugs "$F" --id BUG-1 --to fixing
+check "status: BUG-12 untouched" "$(grep -c '^### BUG-12 — twelfth <!-- status: open -->' "$F")" "1"
+
+# unknown id -> rc 3; bad target -> rc 2.
+bash "$B" status --bugs "$F" --id BUG-77 --to open 2>/dev/null
+check "status: unknown id -> rc 3" "$?" "3"
+bash "$B" status --bugs "$F" --id BUG-1 --to nope 2>/dev/null
+check "status: bad --to -> rc 2"   "$?" "2"
+
+# list: open-only shows open+fixing, hides resolved; includes fixes-tried.
+seed
+bash "$B" add --bugs "$F" --symptom "open one"  >/dev/null   # BUG-1
+bash "$B" add --bugs "$F" --symptom "done one"  >/dev/null   # BUG-2
+bash "$B" fix --bugs "$F" --id BUG-1 --outcome FAILED --note "tried X"
+bash "$B" status --bugs "$F" --id BUG-2 --to resolved
+out="$(bash "$B" list --bugs "$F" --open)"
+check "list --open: shows BUG-1"     "$(printf '%s' "$out" | grep -c 'BUG-1 \[open\] open one')" "1"
+check "list --open: hides BUG-2"     "$(printf '%s' "$out" | grep -c 'BUG-2')" "0"
+check "list --open: shows fix line"  "$(printf '%s' "$out" | grep -c 'tried X → FAILED')" "1"
+
+# list (no filter) shows all including resolved.
+all="$(bash "$B" list --bugs "$F")"
+check "list all: shows BUG-2"         "$(printf '%s' "$all" | grep -c 'BUG-2 \[resolved\] done one')" "1"
+
+# missing file -> empty, rc 0.
+out2="$(bash "$B" list --bugs "$tmp/none.md" 2>/dev/null)"; rc=$?
+check "list missing -> rc 0"         "$rc" "0"
+check "list missing -> empty"        "$out2" ""
+
+# status: wontfix is a valid target.
+seed
+bash "$B" add --bugs "$F" --symptom "wf bug" >/dev/null   # BUG-1
+bash "$B" status --bugs "$F" --id BUG-1 --to wontfix
+check "status: wontfix accepted" "$(grep -c '^### BUG-1 — wf bug <!-- status: wontfix -->' "$F")" "1"
+
+# list --open: a fixing-status bug is shown (open OR fixing).
+seed
+bash "$B" add --bugs "$F" --symptom "fix me" >/dev/null   # BUG-1
+bash "$B" status --bugs "$F" --id BUG-1 --to fixing
+out_fx="$(bash "$B" list --bugs "$F" --open)"
+check "list --open: shows fixing bug" "$(printf '%s' "$out_fx" | grep -c 'BUG-1 \[fixing\] fix me')" "1"
+
+# list --porcelain: tab-delimited id/status/nfixes/symptom; nfixes counts fixes.
+seed
+bash "$B" add --bugs "$F" --symptom "porc one" >/dev/null            # BUG-1
+bash "$B" add --bugs "$F" --symptom "porc two" >/dev/null            # BUG-2
+bash "$B" fix --bugs "$F" --id BUG-1 --outcome FAILED --note "a" >/dev/null
+bash "$B" fix --bugs "$F" --id BUG-1 --outcome WORKED --note "b" >/dev/null
+bash "$B" status --bugs "$F" --id BUG-2 --to resolved
+pall="$(bash "$B" list --porcelain --bugs "$F")"
+check "porc: BUG-1 row" "$(printf '%s' "$pall" | grep -c $'^BUG-1\topen\t2\tporc one$')" "1"
+check "porc: BUG-2 row" "$(printf '%s' "$pall" | grep -c $'^BUG-2\tresolved\t0\tporc two$')" "1"
+popen="$(bash "$B" list --porcelain --open --bugs "$F")"
+check "porc --open: keeps BUG-1" "$(printf '%s' "$popen" | grep -c $'^BUG-1\t')" "1"
+check "porc --open: drops BUG-2" "$(printf '%s' "$popen" | grep -c $'^BUG-2\t')" "0"
+
+# porc: a single zero-fix bug emits nfixes=0 (not an empty field that would
+# collapse under IFS=tab in a consumer's read loop).
+seed
+bash "$B" add --bugs "$F" --symptom "no fixes" >/dev/null              # BUG-1, 0 fixes
+psingle="$(bash "$B" list --porcelain --bugs "$F")"
+check "porc: zero-fix nfixes=0" "$(printf '%s' "$psingle" | grep -c $'^BUG-1\topen\t0\tno fixes$')" "1"
+
+# porc: a heading missing the status comment (legacy/hand-edited) defaults to open,
+# so it surfaces in --open rather than rendering a garbage status / silently vanishing.
+printf '%s\n' '---' 'template_version: 2' '---' '# Bug Log' '' '### BUG-1 — legacy no status' > "$F"
+pleg="$(bash "$B" list --porcelain --bugs "$F")"
+check "porc: no-status -> open"        "$(printf '%s' "$pleg" | grep -c $'^BUG-1\topen\t0\tlegacy no status$')" "1"
+plegopen="$(bash "$B" list --porcelain --open --bugs "$F")"
+check "porc --open: no-status surfaces" "$(printf '%s' "$plegopen" | grep -c $'^BUG-1\t')" "1"
+
+# porc: a literal tab in a symptom is sanitized to a space so the 4-field contract holds.
+seed
+bash "$B" add --bugs "$F" --symptom "$(printf 'tab\there')" >/dev/null   # BUG-1
+ptab="$(bash "$B" list --porcelain --bugs "$F")"
+check "porc: tab field count = 4" "$(printf '%s' "$ptab" | awk -F'\t' 'NR==1{print NF}')" "4"
+check "porc: tab sanitized"       "$(printf '%s' "$ptab" | grep -c $'^BUG-1\topen\t0\ttab here$')" "1"
+
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/handover/test-bugs-dashboard.sh
+++ b/scripts/handover/test-bugs-dashboard.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; D="$HERE/bugs-dashboard.sh"; B="$HERE/bug.sh"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+fails=0; check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+
+root="$tmp/state"
+mkdir -p "$root/epics/HIMMEL-1-alpha" "$root/standalones/HIMMEL-2-beta"
+ba="$root/epics/HIMMEL-1-alpha/bugs.md"; bb="$root/standalones/HIMMEL-2-beta/bugs.md"
+bash "$B" add --bugs "$ba" --symptom "alpha race" >/dev/null            # BUG-1 open
+bash "$B" fix --bugs "$ba" --id BUG-1 --outcome FAILED --note "x" >/dev/null
+bash "$B" add --bugs "$bb" --symptom "beta leak" >/dev/null             # BUG-1 open
+bash "$B" status --bugs "$bb" --id BUG-1 --to resolved
+
+out="$(bash "$D" --root "$root")"
+check "table header"   "$(printf '%s' "$out" | grep -c '^| Item | Bug | Status | Symptom | Fixes |')" "1"
+check "alpha row"      "$(printf '%s' "$out" | grep -c '| epics/HIMMEL-1-alpha | BUG-1 | open | alpha race | 1 |')" "1"
+check "beta row"       "$(printf '%s' "$out" | grep -c '| standalones/HIMMEL-2-beta | BUG-1 | resolved | beta leak | 0 |')" "1"
+check "totals all"     "$(printf '%s' "$out" | grep -c '\*\*Totals:\*\* 2 bug(s), 1 open/fixing\.')" "1"
+
+# sort: alpha (epics/) sorts before beta (standalones/)
+la=$(printf '%s' "$out" | grep -n 'alpha race' | head -1 | cut -d: -f1)
+lb=$(printf '%s' "$out" | grep -n 'beta leak'  | head -1 | cut -d: -f1)
+check "epics sorts first" "$( [ "$la" -lt "$lb" ] && echo yes )" "yes"
+
+# --open: only open/fixing rows, totals reflect filtered set
+oout="$(bash "$D" --open --root "$root")"
+check "open: keeps alpha" "$(printf '%s' "$oout" | grep -c 'alpha race')" "1"
+check "open: drops beta"  "$(printf '%s' "$oout" | grep -c 'beta leak')" "0"
+
+# symptom with a pipe is escaped so the table stays valid
+mkdir -p "$root/standalones/HIMMEL-3-pipe"
+bash "$B" add --bugs "$root/standalones/HIMMEL-3-pipe/bugs.md" --symptom 'a | b' >/dev/null
+pout="$(bash "$D" --root "$root")"
+check "pipe escaped" "$(printf '%s' "$pout" | grep -cF 'a \| b')" "1"
+
+# multiple bugs in one item: both rows render in id order; --open filters within the
+# item and the totals reflect the filtered set.
+root4="$tmp/multi"; mkdir -p "$root4/epics/HIMMEL-7-multi"
+m="$root4/epics/HIMMEL-7-multi/bugs.md"
+bash "$B" add --bugs "$m" --symptom "first open" >/dev/null     # BUG-1 open
+bash "$B" add --bugs "$m" --symptom "second done" >/dev/null    # BUG-2
+bash "$B" status --bugs "$m" --id BUG-2 --to resolved
+mout="$(bash "$D" --root "$root4")"
+check "multi: BUG-1 row" "$(printf '%s' "$mout" | grep -c '| epics/HIMMEL-7-multi | BUG-1 | open | first open | 0 |')" "1"
+check "multi: BUG-2 row" "$(printf '%s' "$mout" | grep -c '| epics/HIMMEL-7-multi | BUG-2 | resolved | second done | 0 |')" "1"
+ml1=$(printf '%s' "$mout" | grep -n 'first open'  | head -1 | cut -d: -f1)
+ml2=$(printf '%s' "$mout" | grep -n 'second done' | head -1 | cut -d: -f1)
+check "multi: id order"  "$( [ "$ml1" -lt "$ml2" ] && echo yes )" "yes"
+check "multi: totals"    "$(printf '%s' "$mout" | grep -c '\*\*Totals:\*\* 2 bug(s), 1 open/fixing\.')" "1"
+mopen="$(bash "$D" --open --root "$root4")"
+check "multi --open: keeps BUG-1" "$(printf '%s' "$mopen" | grep -c 'BUG-1')" "1"
+check "multi --open: drops BUG-2" "$(printf '%s' "$mopen" | grep -c 'BUG-2')" "0"
+check "multi --open: totals"      "$(printf '%s' "$mopen" | grep -c '\*\*Totals:\*\* 1 bug(s), 1 open/fixing\.')" "1"
+
+# empty root -> friendly message, rc 0
+empty="$tmp/empty"; mkdir -p "$empty"
+eout="$(bash "$D" --root "$empty")"; erc=$?
+check "empty rc 0"   "$erc" "0"
+check "empty message" "$(printf '%s' "$eout" | grep -c '_No bugs tracked._')" "1"
+
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/handover/test-lessons-sweep.sh
+++ b/scripts/handover/test-lessons-sweep.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; L="$HERE/lessons-sweep.sh"; B="$HERE/bug.sh"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+fails=0; check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+
+root="$tmp/state"
+mkdir -p "$root/epics/HIMMEL-1-a" "$root/standalones/HIMMEL-2-b"
+a="$root/epics/HIMMEL-1-a"; b="$root/standalones/HIMMEL-2-b"
+# Same resolved symptom in two items -> recurring candidate.
+bash "$B" add --bugs "$a/bugs.md" --symptom "flaky timeout" >/dev/null
+bash "$B" status --bugs "$a/bugs.md" --id BUG-1 --to resolved
+bash "$B" add --bugs "$b/bugs.md" --symptom "flaky timeout" >/dev/null
+bash "$B" status --bugs "$b/bugs.md" --id BUG-1 --to resolved
+# A non-recurring wontfix bug.
+bash "$B" add --bugs "$a/bugs.md" --symptom "unique glitch" >/dev/null   # BUG-2
+bash "$B" status --bugs "$a/bugs.md" --id BUG-2 --to wontfix
+# An open bug must NOT appear (only resolved/wontfix are lessons).
+bash "$B" add --bugs "$b/bugs.md" --symptom "still open" >/dev/null      # BUG-2 open
+# A CR finding in item a.
+printf '%s\n' '## CR Findings' '### 2026-06-20 — HEAD abc (PR 1)' \
+  '- 🟠 Important [k-1] f.sh:9 — unquoted var in trap (real) <!-- cr:abc:k-1 -->' > "$a/reviewer-notes.md"
+
+out="$(bash "$L" --root "$root")"
+check "recurring section present" "$(printf '%s' "$out" | grep -c '## Recurring (lesson candidates)')" "1"
+check "recurring catches shared"  "$(printf '%s' "$out" | grep -c '^- flaky timeout  (in: ')" "1"
+check "recurring lists both items" "$(printf '%s' "$out" | grep -c 'epics/HIMMEL-1-a, standalones/HIMMEL-2-b')" "1"
+check "digest section present"    "$(printf '%s' "$out" | grep -c '## Digest')" "1"
+check "digest lists wontfix bug"  "$(printf '%s' "$out" | grep -c 'unique glitch')" "1"
+check "digest lists CR title"     "$(printf '%s' "$out" | grep -c 'unquoted var in trap')" "1"
+check "open bug excluded"         "$(printf '%s' "$out" | grep -c 'still open')" "0"
+
+# No recurrence -> no Recurring section, still a digest, rc 0.
+root2="$tmp/s2"; mkdir -p "$root2/standalones/HIMMEL-9-z"
+bash "$B" add --bugs "$root2/standalones/HIMMEL-9-z/bugs.md" --symptom "lonely" >/dev/null
+bash "$B" status --bugs "$root2/standalones/HIMMEL-9-z/bugs.md" --id BUG-1 --to resolved
+out2="$(bash "$L" --root "$root2")"; rc=$?
+check "no-recur rc 0"          "$rc" "0"
+check "no-recur omits section" "$(printf '%s' "$out2" | grep -c '## Recurring')" "0"
+check "no-recur has digest"    "$(printf '%s' "$out2" | grep -c 'lonely')" "1"
+
+# norm(): case + whitespace differences still recur (keystone of recurrence detection).
+rootn="$tmp/norm"; mkdir -p "$rootn/epics/HIMMEL-1-a" "$rootn/standalones/HIMMEL-2-b"
+bash "$B" add --bugs "$rootn/epics/HIMMEL-1-a/bugs.md" --symptom "Flaky   Timeout" >/dev/null
+bash "$B" status --bugs "$rootn/epics/HIMMEL-1-a/bugs.md" --id BUG-1 --to resolved
+bash "$B" add --bugs "$rootn/standalones/HIMMEL-2-b/bugs.md" --symptom "flaky timeout" >/dev/null
+bash "$B" status --bugs "$rootn/standalones/HIMMEL-2-b/bugs.md" --id BUG-1 --to resolved
+nout="$(bash "$L" --root "$rootn")"
+check "norm: case/ws recurs" "$(printf '%s' "$nout" | grep -c '## Recurring (lesson candidates)')" "1"
+
+# negative twin: symptoms differing after normalization do NOT recur.
+rootnn="$tmp/nonorm"; mkdir -p "$rootnn/epics/HIMMEL-1-a" "$rootnn/standalones/HIMMEL-2-b"
+bash "$B" add --bugs "$rootnn/epics/HIMMEL-1-a/bugs.md" --symptom "timeout A" >/dev/null
+bash "$B" status --bugs "$rootnn/epics/HIMMEL-1-a/bugs.md" --id BUG-1 --to resolved
+bash "$B" add --bugs "$rootnn/standalones/HIMMEL-2-b/bugs.md" --symptom "timeout B" >/dev/null
+bash "$B" status --bugs "$rootnn/standalones/HIMMEL-2-b/bugs.md" --id BUG-1 --to resolved
+nnout="$(bash "$L" --root "$rootnn")"
+check "norm: distinct no recur" "$(printf '%s' "$nnout" | grep -c '## Recurring')" "0"
+
+# CR title containing an inner " — " keeps the FULL title (split on the FIRST sep).
+rootd="$tmp/dash"; mkdir -p "$rootd/epics/HIMMEL-1-a"
+printf '%s\n' '## CR Findings' '### 2026-06-20 — HEAD abc (PR 1)' \
+  '- 🟠 Important [k-1] f.sh:9 — title — with inner dash (real) <!-- cr:abc:k-1 -->' > "$rootd/epics/HIMMEL-1-a/reviewer-notes.md"
+dout="$(bash "$L" --root "$rootd")"
+check "cr title keeps inner dash" "$(printf '%s' "$dout" | grep -c 'title — with inner dash')" "1"
+
+# reviewer-notes.md present but with NO "## CR Findings" section -> no cr digest lines, rc 0.
+rootc="$tmp/nocr"; mkdir -p "$rootc/epics/HIMMEL-1-a"
+printf '%s\n' '# Reviewer Notes' '' '## Human Feedback' '' 'some prose' > "$rootc/epics/HIMMEL-1-a/reviewer-notes.md"
+cout="$(bash "$L" --root "$rootc")"; crc=$?
+check "no-cr rc 0"               "$crc" "0"
+check "no-cr: no cr digest lines" "$(printf '%s' "$cout" | grep -c '^- cr · ')" "0"
+
+# Empty root -> digest placeholder, rc 0.
+root3="$tmp/s3"; mkdir -p "$root3"
+out3="$(bash "$L" --root "$root3")"; rc3=$?
+check "empty rc 0"        "$rc3" "0"
+check "empty placeholder" "$(printf '%s' "$out3" | grep -c '_No resolved bugs or CR findings yet._')" "1"
+
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/handover/test-resume-context.sh
+++ b/scripts/handover/test-resume-context.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; R="$HERE/resume-context.sh"; B="$HERE/bug.sh"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+fails=0; check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+
+item="$tmp/it"; mkdir -p "$item"
+# one open bug w/ a failed fix
+bash "$B" add --bugs "$item/bugs.md" --symptom "leaks fd" >/dev/null
+bash "$B" fix --bugs "$item/bugs.md" --id BUG-1 --outcome FAILED --note "closed in finally"
+# two CR-findings blocks (older then newer) in reviewer-notes.md
+printf '%s\n' '# Reviewer Notes' '' '## CR Findings' '' \
+  '### 2026-06-18 — HEAD aaa' '- 🔵 Suggestion [s-1] x.ts:1 — old (agreed)' '' \
+  '### 2026-06-20 — HEAD bbb (PR 99)' '- 🔴 Critical [c-1] y.ts:2 — new (agreed)' > "$item/reviewer-notes.md"
+
+out="$(bash "$R" --item "$item")"
+check "panel: open-bugs header"   "$(printf '%s' "$out" | grep -c 'Open bugs')" "1"
+check "panel: bug line"           "$(printf '%s' "$out" | grep -c 'BUG-1 \[open\] leaks fd')" "1"
+check "panel: failed fix shown"   "$(printf '%s' "$out" | grep -c 'closed in finally → FAILED')" "1"
+check "panel: CR header"          "$(printf '%s' "$out" | grep -c 'Latest CR findings')" "1"
+check "panel: newest CR block"    "$(printf '%s' "$out" | grep -c 'HEAD bbb (PR 99)')" "1"
+check "panel: newest CR bullet"   "$(printf '%s' "$out" | grep -c 'c-1\] y.ts:2 — new')" "1"
+check "panel: old CR block hidden" "$(printf '%s' "$out" | grep -c 'HEAD aaa')" "0"
+
+# clean item (no bugs, no CR) -> empty output, rc 0.
+clean="$tmp/clean"; mkdir -p "$clean"
+out2="$(bash "$R" --item "$clean")"; rc=$?
+check "clean item -> rc 0"        "$rc" "0"
+check "clean item -> empty"       "$out2" ""
+
+# bugs-only item: open-bugs section present, no CR section.
+bonly="$tmp/bonly"; mkdir -p "$bonly"
+bash "$B" add --bugs "$bonly/bugs.md" --symptom "only a bug" >/dev/null
+out_b="$(bash "$R" --item "$bonly")"
+check "bugs-only: open-bugs header"  "$(printf '%s' "$out_b" | grep -c 'Open bugs')" "1"
+check "bugs-only: no CR header"      "$(printf '%s' "$out_b" | grep -c 'Latest CR findings')" "0"
+
+# CR-only item: CR section present, no open-bugs section.
+cronly="$tmp/cronly"; mkdir -p "$cronly"
+printf '%s\n' '# Reviewer Notes' '' '## CR Findings' '' '### 2026-06-20 — HEAD zzz' '- 🔴 Critical [c-9] z.ts:1 — only cr (agreed)' > "$cronly/reviewer-notes.md"
+out_c="$(bash "$R" --item "$cronly")"
+check "cr-only: CR header"           "$(printf '%s' "$out_c" | grep -c 'Latest CR findings')" "1"
+check "cr-only: no open-bugs header" "$(printf '%s' "$out_c" | grep -c 'Open bugs')" "0"
+
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
## F2 P2 + P3 — handover bug/CR ledger (HIMMEL-416)

Propagates the private F2 P2 (#610) + P3 (#612) work to the public harness — **code-only** (no private state).

### P2 (C3 + C5)
- **`/handover bug <add|fix|status>`** (`scripts/handover/bug.sh`) — per-item bug tracker: heading-per-bug with an inline `<!-- status: open|fixing|resolved|wontfix -->` marker and a `Fixes tried:` FAILED/WORKED ledger (the circular-debugging breaker).
- **resume surfacing** (`scripts/handover/resume-context.sh`) — `handover-resume` now shows the active item's open bugs + their fixes-tried + the latest `## CR Findings` block, so a resuming session avoids re-trying a failed fix.

### P3 (C4 + C6)
- **`/handover bugs [--open]`** (`scripts/handover/bugs-dashboard.sh`) — cross-item read-only dashboard: a markdown table (Item / Bug / Status / Symptom / #Fixes) + totals across the whole handover root.
- **`/handover lessons`** (`scripts/handover/lessons-sweep.sh`) — proposal-only sweep (writes nothing): resolved/wontfix symptoms + CR-finding titles recurring across ≥2 items as lesson candidates, then a digest.
- **`bug.sh list --porcelain`** — tab-delimited bug list, the single `bugs.md` parser both new scripts reuse.

SKILL.md + README + bug templates wired.

### Review
Reviewed privately: 6-reviewer heavy CR + fresh-context verifier + cross-model critic panel, all clean (key catch: a `2>/dev/null` that made a broken parser read as "no bugs"). All test suites green (`test-bug.sh`, `test-resume-context.sh`, `test-bugs-dashboard.sh`, `test-lessons-sweep.sh`), shellcheck clean, on Windows Git-Bash — re-verified in this public worktree before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
