### PR TITLE
feat(minerva): [HIMMEL-429] Skill-tool hook injects critic on any brainstorm/plan trigger (Piece 2)

### DIFF
--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -325,6 +325,31 @@ Spec: `scripts/hooks/test-auto-arm-on-cap.sh` (paired smoke suite).
    twice per tool call — harmless (the throttle marker is shared, so
    the second invocation is a single stat() no-op).
 
+### `inject-minerva-critic.sh` — plugin PreToolUse(Skill) critic injector (HIMMEL-429)
+
+The one PreToolUse hook NOT wired in `.claude/settings.json` (so it is not
+counted in the "six hooks" above): it ships in the **himmel-ops plugin**
+(`marketplace/plugins/himmel-ops/hooks/hooks.json`, `matcher: "Skill"`), so any
+himmel-ops install gets it — himmel sessions and external installs alike — with
+no repo wiring.
+
+Closes the no-`/minerva` bypass. When `superpowers:brainstorming` or
+`superpowers:writing-plans` is invoked by ANY path (auto-trigger, direct
+`/skill`, sub-skill handoff) without going through `/minerva`, it injects a
+scoped `additionalContext` directive so the model still runs the matching
+minerva adversarial critic loop (spec-critic / plan-critic; `himmel-ops:minerva`
+Stage 2 / Stage 4 charters). The invoked skill name is read at `tool_input.skill`
+(field path confirmed by the HIMMEL-429 spike); per the CC hooks reference a
+PreToolUse `additionalContext` is wrapped in a system reminder and inserted next
+to the tool result, where the model reads it on the next request.
+
+ADVISORY context, not a permission change — it cannot widen what any hook
+allows. **FAIL-OPEN** (unlike the block-* hooks): it only ever exits 0 with
+either the injection envelope or empty stdout, so it never blocks a Skill call
+on its own error (a PreToolUse exit 2 would block the tool). Kill switch:
+`MINERVA_HOOK_DISABLE=1` in the launching shell (bypass convention as above).
+Paired smoke test: `hooks/test-inject-minerva-critic.sh`.
+
 ## Claude SessionStart Hooks
 
 Wired in the `SessionStart` array of `.claude/settings.json`; fires once when a

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -201,6 +201,14 @@ Installed via `extraKnownMarketplaces` in `settings.json`.
 **Offline factors:** `kp` (GFZ Potsdam, CC BY 4.0), `lunar_phase` (astronomical formula, zero network), `daylight` (bbox-centroid latitude, zero network). Location factors (`pressure`, `pollen`, `aq`) via Open-Meteo, opt-in via `LUNA_REGION_BBOX`.
 **Plugin path:** `marketplace/plugins/luna-correlate/`
 
+#### himmel-ops (`himmel-ops@himmel`)
+
+**What:** Harness-meta operational skills for himmel.
+**Skills:** `himmel-ops:stuck-playbook` (load-on-trigger guardrail-recovery playbook, HIMMEL-211), `himmel-ops:minerva` (brainstorm→critic→spec→critic→plan pipeline with adversarial critic loops, HIMMEL-428).
+**Command:** `/minerva` — runs the minerva pipeline.
+**Hook:** `hooks/hooks.json` wires a PreToolUse(`matcher: "Skill"`) hook `inject-minerva-critic.sh` (HIMMEL-429) — injects the minerva critic loop when `superpowers:brainstorming`/`writing-plans` fires without `/minerva`. Advisory, fail-open; kill switch `MINERVA_HOOK_DISABLE=1`.
+**Plugin path:** `marketplace/plugins/himmel-ops/`
+
 ---
 
 ## Hooks

--- a/marketplace/plugins/himmel-ops/README.md
+++ b/marketplace/plugins/himmel-ops/README.md
@@ -95,6 +95,13 @@ Otherwise it reports `interactive` and minerva pauses for the operator after eac
 critic-cleaned artifact.
 
 **Distribution:** ships in this plugin (skill + command + helper), so it installs
-system-wide and works in any repo, with no `superpowers` fork. A deferred
-companion (HIMMEL-429) adds a Skill-tool hook so the critic also fires when
-brainstorming/writing-plans is triggered without `/minerva`.
+system-wide and works in any repo, with no `superpowers` fork.
+
+**Skill-tool hook (HIMMEL-429).** A `PreToolUse` hook (`hooks/hooks.json`,
+`matcher: "Skill"`) closes the no-`/minerva` bypass: when
+`superpowers:brainstorming` or `superpowers:writing-plans` is invoked by ANY
+path without going through `/minerva`, the hook injects a scoped directive so the
+critic loop still fires (spec-critic after brainstorming, plan-critic after
+writing-plans). It is advisory context, not a permission change, and is
+**fail-open** — it never blocks a Skill call. Disable it with
+`MINERVA_HOOK_DISABLE=1` in the shell that launched Claude Code.

--- a/marketplace/plugins/himmel-ops/hooks/hooks.json
+++ b/marketplace/plugins/himmel-ops/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/inject-minerva-critic.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/marketplace/plugins/himmel-ops/hooks/inject-minerva-critic.sh
+++ b/marketplace/plugins/himmel-ops/hooks/inject-minerva-critic.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# inject-minerva-critic.sh — PreToolUse(Skill) hook (HIMMEL-429).
+#
+# Closes the no-/minerva bypass: when superpowers:brainstorming or
+# superpowers:writing-plans is invoked by ANY path (auto-trigger, direct
+# /skill, or a sub-skill handoff) WITHOUT going through /minerva, inject a
+# scoped directive so the model still runs the matching minerva adversarial
+# critic loop (himmel-ops:minerva). This is ADVISORY context, not a permission
+# change — it cannot widen what any hook allows.
+#
+# Spike findings (HIMMEL-429 Task 1, all confirmed):
+#   Q1 matcher:"Skill" is valid for PreToolUse.                        (docs)
+#   Q2 the invoked skill name is at tool_input.skill.   (session-transcript)
+#   Q3 PreToolUse additionalContext reaches the model — "wrapped in a
+#      system reminder, inserted next to the tool result, read on the next
+#      model request".                                                  (docs)
+#   Q4 a plugin hooks/hooks.json fires the same as repo settings.json.  (docs)
+# => shipped via the himmel-ops plugin hooks.json for system-wide reach.
+#
+# Context injector → FAIL-OPEN: never block a Skill call on our own error.
+# (PreToolUse exit code 2 would BLOCK the tool; we only ever exit 0 with
+# either an injection envelope or empty stdout.)
+#
+# Kill switch: MINERVA_HOOK_DISABLE=1 (set in the launching shell) disables it.
+#
+# Hook contract (PreToolUse): reads the tool-call JSON on stdin; exit 0 with a
+# {"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":...}}
+# envelope on stdout to inject context, or exit 0 with empty stdout for no-op.
+#
+# Wiring: marketplace/plugins/himmel-ops/hooks/hooks.json (PreToolUse,
+# matcher "Skill"). bash 3.2-safe.
+
+set -uo pipefail
+trap 'exit 0' ERR
+
+[ "${MINERVA_HOOK_DISABLE:-0}" = "1" ] && exit 0
+
+# Slurp the FULL payload. Sibling PreToolUse hooks use `cat` (block-edit-on-
+# main.sh, auto-approve-safe-bash.sh); `read -r` reads only the first line and
+# would silently no-op on a multi-line / pretty-printed JSON body. Guard the
+# interactive no-stdin case so a hand-run never hangs on cat.
+[ -t 0 ] && exit 0
+payload=$(cat 2>/dev/null || true)
+[ -z "$payload" ] && exit 0
+
+# Extract the invoked skill name: grep the "skill" value (the only such key in a
+# Skill tool_input; canonical path tool_input.skill, confirmed by the spike). On
+# a multi-line payload sed still matches the line that bears the key.
+skill=$(printf '%s' "$payload" | sed -n 's/.*"skill"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+inject() {
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"%s"}}\n' "$1"
+}
+
+case "$skill" in
+  *brainstorming*)
+    inject "minerva (HIMMEL-428): after this brainstorming writes the spec, do NOT auto-handoff to writing-plans — run the minerva SPEC-CRITIC loop first (himmel-ops:minerva, Stage 2 charter), then proceed."
+    ;;
+  *writing-plans*)
+    inject "minerva (HIMMEL-428): after this plan is written, run the minerva PLAN-CRITIC loop (himmel-ops:minerva, Stage 4 charter) before implementation."
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+exit 0

--- a/marketplace/plugins/himmel-ops/hooks/test-inject-minerva-critic.sh
+++ b/marketplace/plugins/himmel-ops/hooks/test-inject-minerva-critic.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# test-inject-minerva-critic.sh — smoke test for the PreToolUse(Skill) minerva
+# critic-injection hook (HIMMEL-429). The suite is the spec.
+#
+# Field path (.skill) confirmed by the HIMMEL-429 spike: Claude Code records the
+# Skill tool's input as {"tool_name":"Skill","tool_input":{"skill":"<name>"}}.
+set -uo pipefail
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/inject-minerva-critic.sh"
+fail=0
+emit() { printf '%s' "$1" | bash "$SCRIPT"; }
+
+# brainstorming → inject spec-critic directive
+out=$(emit '{"tool_name":"Skill","tool_input":{"skill":"superpowers:brainstorming"}}')
+case "$out" in *spec-critic*|*minerva*) ;; *) echo "FAIL: brainstorming not injected (got '$out')"; fail=1;; esac
+
+# writing-plans → inject plan-critic directive
+out=$(emit '{"tool_name":"Skill","tool_input":{"skill":"superpowers:writing-plans"}}')
+case "$out" in *plan-critic*|*minerva*) ;; *) echo "FAIL: writing-plans not injected (got '$out')"; fail=1;; esac
+
+# the injected JSON must be a well-formed PreToolUse hookSpecificOutput
+out=$(emit '{"tool_name":"Skill","tool_input":{"skill":"superpowers:brainstorming"}}')
+case "$out" in *'"hookEventName":"PreToolUse"'*'"additionalContext"'*) ;; *) echo "FAIL: malformed injection envelope (got '$out')"; fail=1;; esac
+
+# unrelated skill → no injection (empty stdout)
+out=$(emit '{"tool_name":"Skill","tool_input":{"skill":"superpowers:using-superpowers"}}')
+[ -z "$out" ] || { echo "FAIL: unrelated skill injected (got '$out')"; fail=1; }
+
+# minerva's own skill → no injection (the operator already ran the pipeline)
+out=$(emit '{"tool_name":"Skill","tool_input":{"skill":"himmel-ops:minerva"}}')
+[ -z "$out" ] || { echo "FAIL: minerva self-skill injected (got '$out')"; fail=1; }
+
+# kill switch
+out=$(MINERVA_HOOK_DISABLE=1 emit '{"tool_name":"Skill","tool_input":{"skill":"superpowers:brainstorming"}}')
+[ -z "$out" ] || { echo "FAIL: kill switch ignored (got '$out')"; fail=1; }
+
+# no payload → quiet exit 0
+out=$(printf '' | bash "$SCRIPT"); [ -z "$out" ] || { echo "FAIL: empty payload injected (got '$out')"; fail=1; }
+
+# non-Skill tool → no injection (defensive; matcher should prevent this anyway)
+out=$(emit '{"tool_name":"Bash","tool_input":{"command":"echo brainstorming"}}')
+[ -z "$out" ] || { echo "FAIL: non-Skill tool injected (got '$out')"; fail=1; }
+
+# multi-line / pretty-printed payload still injects (must not assume single-line stdin)
+out=$(printf '{\n  "tool_name": "Skill",\n  "tool_input": { "skill": "superpowers:brainstorming" }\n}' | bash "$SCRIPT")
+case "$out" in *minerva*) ;; *) echo "FAIL: multi-line payload not injected (got '$out')"; fail=1;; esac
+
+# trigger word only in an arg value (not the skill field) → no injection
+out=$(emit '{"tool_name":"Skill","tool_input":{"skill":"obsidian-save","args":"brainstorming notes"}}')
+[ -z "$out" ] || { echo "FAIL: arg-value substring injected (got '$out')"; fail=1; }
+
+# Skill tool, well-formed JSON, but no skill key → no-op
+out=$(emit '{"tool_name":"Skill","tool_input":{}}')
+[ -z "$out" ] || { echo "FAIL: missing skill key injected (got '$out')"; fail=1; }
+
+[ "$fail" = "0" ] && echo "ALL PASS"; exit "$fail"


### PR DESCRIPTION
minerva Piece 2 — plugin PreToolUse(Skill) critic-injection hook; fail-open; kill switch MINERVA_HOOK_DISABLE=1