### PR TITLE
feat(luna-template): honor .single-writer opt-out in vault guardrails

### DIFF
--- a/templates/luna-second-brain/scripts/guardrails/lib.sh
+++ b/templates/luna-second-brain/scripts/guardrails/lib.sh
@@ -89,3 +89,19 @@ is_dirty() {
     out=$(git -C "$dir" status --porcelain 2>/dev/null) || return 2
     [ -n "$out" ]
 }
+
+# is_single_writer_repo [DIR]
+# True iff the repo containing DIR (default PWD) has a local `.single-writer`
+# marker file at its top level. The marker is a gitignored, per-clone opt-in
+# that designates a repo as committing/pushing straight to main by design
+# (personal vaults / state repos). Mirrors himmel's block-edit-on-main.sh: a
+# clone without the marker stays protected by worktree-isolation.
+# `[ -f ]` is true for a regular file or a symlink resolving to one, false for
+# a directory / missing / broken symlink — so an ambiguous marker does NOT
+# grant the opt-out (fail-closed). Returns 2 if the repo root cannot be found.
+is_single_writer_repo() {
+    local dir="${1:-.}"
+    local top
+    top=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null) || return 2
+    [ -f "$top/.single-writer" ]
+}

--- a/templates/luna-second-brain/scripts/hooks/check-push-target.sh
+++ b/templates/luna-second-brain/scripts/hooks/check-push-target.sh
@@ -8,6 +8,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/../guardrails/lib.sh"
 
+# Single-writer opt-in: a repo with a local `.single-writer` marker pushes
+# main directly by design (personal vaults / state repos). Mirrors the
+# worktree-isolation pre-commit gate / block-edit-on-main.sh.
+if is_single_writer_repo; then
+    exit 0
+fi
+
 while read -r _local_ref _local_sha remote_ref _remote_sha; do
     if is_main_ref "$remote_ref"; then
         echo "ERROR: Direct push to 'main' is not allowed."

--- a/templates/luna-second-brain/scripts/hooks/check-worktree-isolation.sh
+++ b/templates/luna-second-brain/scripts/hooks/check-worktree-isolation.sh
@@ -19,6 +19,15 @@ if ! git rev-parse --verify -q HEAD >/dev/null 2>&1; then
     exit 0
 fi
 
+# Single-writer opt-in: a repo with a local `.single-writer` marker at its
+# root commits straight to main by design (personal vaults / state repos);
+# the worktree-forcing block does not apply. Mirrors block-edit-on-main.sh.
+# On internal error the predicate returns false (fail-closed) and we fall
+# through to the normal is_on_main check below.
+if is_single_writer_repo; then
+    exit 0
+fi
+
 is_on_main
 rc=$?
 case "$rc" in


### PR DESCRIPTION
Mirrors himmel block-edit-on-main .single-writer opt-out into the luna-second-brain scaffold's worktree-isolation (pre-commit) + no-push-to-main (pre-push) gates. Single-operator vaults commit/push to main natively; clones without the marker stay protected (fail-closed). Platforms tested: windows. Security reviewed: manual.