### PR TITLE
fix(plugins): make claude-obsidian @himmel-installable (tag pin) + track true upstream

### DIFF
--- a/marketplace/.claude-plugin/marketplace.json
+++ b/marketplace/.claude-plugin/marketplace.json
@@ -80,9 +80,9 @@
       "source": {
         "source": "github",
         "repo": "yotamleo/claude-obsidian",
-        "ref": "f102ee61bf5c00f78bb0af134501bc3020cdf66e"
+        "ref": "v1.9.2-himmel.1"
       },
-      "description": "[yotamleo fork — vendor + attribution only, no upstream PR] Claude + Obsidian knowledge companion. Wiki query, save, ingest, lint, autoresearch. Companion to obsidian-triage — its wiki-query skill optionally powers the Phase 4 Related Notes link-graph traversal. Pinned to a commit SHA per himmel supply-chain policy (see marketplace/plugins/obsidian-triage/README.md § Pin update workflow). Original: AgriciDaniel/claude-obsidian.",
+      "description": "[yotamleo fork — vendor + attribution only, no upstream PR] Claude + Obsidian knowledge companion. Wiki query, save, ingest, lint, autoresearch. Companion to obsidian-triage — its wiki-query skill optionally powers the Phase 4 Related Notes link-graph traversal. Pinned to an immutable tag per himmel supply-chain policy (a bare commit SHA is NOT installable — `claude plugin install` clones via `git clone --branch <ref>`, which only resolves branch/tag names; see marketplace/plugins/obsidian-triage/README.md § Pin update workflow). Fork tracks upstream AgriciDaniel/claude-obsidian (v1.9.2 base) with the unsupported prompt-type SessionStart/PostCompact hooks removed. Original: AgriciDaniel/claude-obsidian.",
       "author": {
         "name": "AgriciDaniel",
         "url": "https://github.com/AgriciDaniel"

--- a/marketplace/plugins/CLAUDE.md
+++ b/marketplace/plugins/CLAUDE.md
@@ -9,8 +9,10 @@ needs (`commands/`, `skills/`, `agents/`, `tools/`). Local plugins (sourced
 from this subtree): `handover`, `obsidian-triage`, `pr-review-toolkit-himmel`,
 `telegram-himmel`, `himmel-ops`, `luna-correlate`. The marketplace also
 declares two **github-pinned** vendored plugins that do NOT live here —
-`claude-obsidian` and `obsidian` (SHA-pinned upstream sources; see their
-entries in `marketplace/.claude-plugin/marketplace.json`).
+`claude-obsidian` and `obsidian` (pinned upstream sources — `claude-obsidian`
+by immutable **tag** since a bare SHA is not installable, `obsidian` by SHA;
+see their entries in `marketplace/.claude-plugin/marketplace.json` and the Pin
+update workflow in `obsidian-triage/README.md`).
 
 ## Conventions
 - **Plugin specs belong in `<plugin>/README.md`** (luna-docs tier-1,

--- a/marketplace/plugins/obsidian-triage/README.md
+++ b/marketplace/plugins/obsidian-triage/README.md
@@ -122,14 +122,21 @@ Tracked in the operator's private handover repo (LUNA-3 next-session notes). Cal
 
 ## Pin update workflow
 
-External plugins (`obsidian`, `claude-obsidian`) are pinned to commit SHAs in himmel's `marketplace/.claude-plugin/marketplace.json`. To bump:
+External plugins (`obsidian`, `claude-obsidian`) are pinned in himmel's `marketplace/.claude-plugin/marketplace.json`. The `ref` MUST be an **immutable tag**, never a bare commit SHA: `claude plugin install` clones the source with `git clone --branch <ref>`, and `--branch` only resolves branch/tag *names* — a 40-hex SHA (even one that is the tip of `main`) fails with `fatal: Remote branch <sha> not found`. A branch name would install but moves, breaking reproducibility. So: **tag, not SHA, not branch.** This keeps the same hygiene posture as `npm-audit-signatures` / `pip-hashes` / `lockfile-integrity` — no moving refs in production marketplace entries — while staying installable.
 
-1. Verify the upstream commit is what you expect: `gh api repos/<owner>/<repo>/commits/main --jq .sha`
-2. Update the `ref` field in `marketplace.json` (deliberate PR, same gate as a dep bump).
-3. PR description should include a one-line note on what changed upstream and why we're picking it up now.
+### Bumping a vendored fork (`claude-obsidian`)
 
-This is the same hygiene posture as `npm-audit-signatures`, `pip-hashes`, `lockfile-integrity` — no moving-`main` refs in production marketplace entries.
+`claude-obsidian` is pinned to the `yotamleo/claude-obsidian` vendor fork (not upstream `AgriciDaniel/claude-obsidian`), carrying a small himmel twist (the unsupported prompt-type SessionStart/PostCompact hooks removed — Claude Code's SessionStart accepts `command`/`mcp_tool` only). To pick up a new upstream release:
 
-### Vendor-fork SHA immutability (LUNA-4)
+1. Sync the fork: merge the new upstream release tag into `yotamleo/claude-obsidian` `main`, reapplying the hook twist + attribution on any `hooks.json`/`README.md` conflict.
+2. Tag the synced commit `vX.Y.Z-himmel.N` (upstream base version + himmel patch level — upstream's own `vX.Y.Z` tag lives on a different commit, so the suffix avoids ambiguity) and push the tag.
+3. In **one himmel PR**: bump `marketplace.json` `ref` → the new tag, AND bump `synced_base` in [`scripts/plugin-upstreams.json`](../../../scripts/plugin-upstreams.json) → the new upstream `vX.Y.Z`.
+4. PR description: one line on what changed upstream and why we're picking it up now.
 
-`claude-obsidian` is pinned to the `yotamleo/claude-obsidian` vendor fork, not the upstream `AgriciDaniel/claude-obsidian`. SHAs on an operator-controlled fork are not implicitly immutable — to keep the pinned SHA reachable, branch protection on `yotamleo/claude-obsidian` `main` enforces `allow_force_pushes: false` + `allow_deletions: false` + `enforce_admins: true`. Any future fork-side change (e.g. a new attribution banner update) goes through PR + new commit, never a force-push over a pinned SHA.
+### Drift detection (track the TRUE upstream)
+
+Because the marketplace `repo` for a fork points at OUR fork, a naive pin-vs-HEAD check would only ever catch fork-vs-pin drift — never the real signal, the original upstream advancing. `scripts/plugin-upstreams.json` declares each fork's true upstream so `scripts/check-plugin-drift.sh` compares the upstream's latest **version tag** (highest semver — not the GitHub Releases API, which would silently miss a tag-only or prerelease version) against `synced_base` and reports BEHIND when upstream ships a newer version. Run `bash scripts/check-plugin-drift.sh` on demand (or on a cadence) to know when a re-sync is due. Direct (non-fork) SHA pins like `obsidian` → `kepano/obsidian-skills` need no override; note kepano publishes no tags, which is why `obsidian` is served from its own marketplace rather than installed from `@himmel`.
+
+### Fork tag immutability (LUNA-4)
+
+Tags on an operator-controlled fork are not implicitly immutable — to keep a pinned tag reachable and unmovable, branch protection on `yotamleo/claude-obsidian` enforces `allow_force_pushes: false` + `allow_deletions: false` + `enforce_admins: true`. Any future fork-side change goes through PR + a new commit + a new `-himmel.N` tag, never a force-push or a moved tag over a pinned ref.

--- a/scripts/check-plugin-drift.sh
+++ b/scripts/check-plugin-drift.sh
@@ -4,9 +4,19 @@
 # forks + pinned plugins current with upstream?" (HIMMEL-322).
 #
 # Two plugin classes are checked, each against its TRUE upstream via `gh api`:
-#   1. SHA-pinned remotes — any plugin in marketplace.json whose source is
-#      {github, repo, ref}. Drift = the pinned `ref` != the upstream repo's
-#      default-branch HEAD. (claude-obsidian, kepano/obsidian, + any future pin.)
+#   1. Pinned remotes — any plugin in marketplace.json whose source is
+#      {github, repo, ref}. Two sub-cases:
+#        a. Plain pin (no override): drift = the pinned `ref` (a 40-hex SHA) !=
+#           the marketplace repo's default-branch HEAD. (kepano/obsidian.)
+#        b. Fork-with-upstream override (scripts/plugin-upstreams.json): the
+#           marketplace `repo` is OUR fork, so a HEAD compare would only catch
+#           fork-vs-pin drift, never the real signal. The override names the TRUE
+#           upstream and `track:release` compares its latest VERSION TAG (highest
+#           semver, not the GitHub Releases API which omits tag-only/prereleases)
+#           against our recorded `synced_base`. Drift = upstream tagged a newer
+#           version than the one our fork is merged to. (claude-obsidian -> AgriciDaniel.)
+#           This sub-case also makes tag-name refs (e.g. v1.9.2-himmel.1) work —
+#           we never compare a tag name to a SHA.
 #   2. Vendored forks — any marketplace/plugins/<p>/UPSTREAM_PIN that carries the
 #      generic fields `upstream_repo` / `upstream_path` / `upstream_sha256`. Drift
 #      = the recorded sha256 != the sha256 of that upstream file fetched now.
@@ -25,7 +35,9 @@
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-MJSON="$ROOT/marketplace/.claude-plugin/marketplace.json"
+# Paths are env-overridable so the test harness can point at fixtures.
+MJSON="${DRIFT_MJSON:-$ROOT/marketplace/.claude-plugin/marketplace.json}"
+UPSTREAMS="${DRIFT_UPSTREAMS:-$ROOT/scripts/plugin-upstreams.json}"  # per-plugin true-upstream overrides (may be absent)
 
 if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
   echo "drift-check: gh CLI not available/authenticated — skipping (fail-open)."
@@ -35,29 +47,90 @@ fi
 drift=0
 incomplete=0
 
-echo "== SHA-pinned remotes (pin vs upstream default-branch HEAD) =="
+echo "== pinned remotes (SHA-pin vs HEAD; fork → true-upstream release) =="
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "  ? python3 not available — cannot parse marketplace.json; SHA-pin class UNCHECKED."
+  echo "  ? python3 not available — cannot parse marketplace.json; pinned-remote class UNCHECKED."
   incomplete=1
 else
   # Capture the parser output + its exit status separately, so a python3 crash
   # (the Windows Store stub can wedge) is treated as UNCHECKED, never as "0 pins".
-  pins_out="$(python3 - "$MJSON" <<'PY' 2>/dev/null | tr -d '\r'
-import json, sys
+  # Each line: name|repo|ref|upstream_repo|track|synced_base (last three empty
+  # unless scripts/plugin-upstreams.json declares a true-upstream override).
+  pins_out="$(python3 - "$MJSON" "$UPSTREAMS" <<'PY' 2>/dev/null | tr -d '\r'
+import json, os, sys
 m = json.load(open(sys.argv[1]))
+ups = {}
+if os.path.exists(sys.argv[2]):
+    ups = json.load(open(sys.argv[2]))   # malformed -> raises -> class UNCHECKED
 for p in m.get("plugins", []):
     s = p.get("source")
     if isinstance(s, dict) and s.get("source") == "github" and s.get("ref"):
-        print(f"{p['name']}|{s['repo']}|{s['ref']}")
+        o = ups.get(p["name"]) or {}
+        print("|".join([p["name"], s["repo"], s["ref"],
+                        o.get("upstream_repo", ""), o.get("track", ""), o.get("synced_base", "")]))
 PY
 )"
   pins_rc=$?  # pipefail makes this the pipeline's status (= python3's, if it failed)
   if [ "$pins_rc" -ne 0 ]; then
-    echo "  ? marketplace.json parse failed (python3 error) — SHA-pin class UNCHECKED."
+    echo "  ? marketplace.json / plugin-upstreams.json parse failed (python3 error) — pinned-remote class UNCHECKED."
     incomplete=1
   else
-    while IFS='|' read -r name repo ref; do
+    while IFS='|' read -r name repo ref up_repo up_track up_base; do
       [ -n "$name" ] || continue
+      # Sub-case (b): fork with a true-upstream override. The marketplace `repo`
+      # is OUR fork; check the named upstream's latest STABLE version TAG against
+      # synced_base. We use the highest stable semver tag (sort -V), NOT the
+      # GitHub Releases API: releases/latest silently omits tag-only releases,
+      # which would read as CURRENT while upstream had actually moved — exactly
+      # the false-negative this script's header forbids. Prereleases are excluded
+      # below (a stale same-version prerelease would otherwise read as BEHIND).
+      if [ -n "$up_repo" ]; then
+        if [ "$up_track" != "release" ]; then
+          echo "  $name: ? upstream override has unknown track='$up_track' — UNCHECKED"
+          incomplete=1
+          continue
+        fi
+        # A malformed override (missing synced_base) must be UNCHECKED, never a
+        # comparison — else a real upstream tag != "" reads as a phantom BEHIND.
+        if [ -z "$up_base" ]; then
+          echo "  $name: ? upstream override missing synced_base — UNCHECKED (fix scripts/plugin-upstreams.json)"
+          incomplete=1
+          continue
+        fi
+        # Capture raw tags first and gate on gh's EXIT STATUS (a pipe would mask
+        # it behind sort/tail). per_page=100 so the newest tag is in the page.
+        tags_raw="$(gh api "repos/$up_repo/tags?per_page=100" --jq '.[].name' 2>/dev/null)"; api_rc=$?
+        if [ "$api_rc" -ne 0 ] || [ -z "$tags_raw" ]; then
+          echo "  $name: ? true upstream unreachable ($up_repo tags) — UNCHECKED"
+          incomplete=1
+          continue
+        fi
+        # Consider STABLE version tags only (vMAJOR.MINOR[.PATCH], no -suffix).
+        # synced_base is a stable release; including prereleases would let a stale
+        # same-version prerelease (e.g. v1.9.2-alpha, which `sort -V` ranks AFTER
+        # v1.9.2) be picked as "latest" and read as a phantom BEHIND against a
+        # current base. A real new stable release still trips the BEHIND path.
+        latest="$(printf '%s\n' "$tags_raw" | grep -E '^v?[0-9]+\.[0-9]+(\.[0-9]+)?$' | sort -V | tail -1)"
+        if [ -z "$latest" ]; then
+          echo "  $name: ? no stable version tags found on $up_repo — UNCHECKED"
+          incomplete=1
+          continue
+        fi
+        if [ "$latest" = "$up_base" ]; then
+          echo "  $name: CURRENT  (fork tracks $up_repo @ $up_base; pin $ref)"
+        else
+          echo "  $name: BEHIND   ($up_repo latest tag $latest; fork synced to $up_base — re-sync fork, bump synced_base + fork tag, then bump marketplace ref)"
+          drift=1
+        fi
+        continue
+      fi
+      # Sub-case (a): plain pin — ref must be a 40-hex SHA to compare against HEAD.
+      # A non-SHA ref (tag/branch) with no override can't be compared meaningfully.
+      if ! printf '%s' "$ref" | grep -qE '^[0-9a-f]{40}$'; then
+        echo "  $name: ? non-SHA ref '$ref' with no upstream override — UNCHECKED (declare it in scripts/plugin-upstreams.json)"
+        incomplete=1
+        continue
+      fi
       head="$(gh api "repos/$repo/commits/HEAD" --jq '.sha' 2>/dev/null)"; api_rc=$?
       # Gate on gh's EXIT STATUS, not stdout emptiness: gh api prints a non-empty
       # error body to stdout on HTTP 4xx/5xx. Also require a 40-hex sha so any

--- a/scripts/plugin-upstreams.json
+++ b/scripts/plugin-upstreams.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Per-plugin TRUE-upstream overrides for scripts/check-plugin-drift.sh. A himmel fork's marketplace.json `repo` points at OUR fork, so the drift guard would otherwise only catch fork-vs-pin drift, never the real signal: the original upstream advancing. Each entry here makes the guard track that true upstream instead. `track:release` compares the upstream's latest version TAG (highest semver via `sort -V` — not the GitHub Releases API, which omits tag-only/prerelease versions) against `synced_base` (the upstream version our fork is currently merged to). On a fork re-sync, bump `synced_base` here in the same PR. Keyed by plugin name (matches marketplace.json).",
+  "claude-obsidian": {
+    "upstream_repo": "AgriciDaniel/claude-obsidian",
+    "track": "release",
+    "synced_base": "v1.9.2"
+  }
+}

--- a/scripts/test-check-plugin-drift.sh
+++ b/scripts/test-check-plugin-drift.sh
@@ -36,6 +36,51 @@ for pin in "$ROOT"/marketplace/plugins/*/UPSTREAM_PIN; do
   done
 done
 
+# 3b. The true-upstream override sidecar is well-formed and routes through the
+#     parser deterministically (no network). claude-obsidian is a fork whose
+#     marketplace `repo` is OURS, so it MUST carry an override or the guard would
+#     only ever check fork-vs-pin.
+UPS="$ROOT/scripts/plugin-upstreams.json"
+if [ -f "$UPS" ]; then
+  ok "plugin-upstreams.json present"
+  if python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$UPS" >/dev/null 2>&1; then
+    ok "plugin-upstreams.json is valid JSON"
+  else
+    bad "plugin-upstreams.json is not valid JSON"
+  fi
+  # The augmented parser (same shape the script uses) must emit a 6-field line for
+  # claude-obsidian with field 4 = the TRUE upstream.
+  line="$(python3 - "$MJSON" "$UPS" <<'PY' 2>/dev/null | tr -d '\r' | grep '^claude-obsidian|'
+import json, os, sys
+m = json.load(open(sys.argv[1]))
+ups = json.load(open(sys.argv[2])) if os.path.exists(sys.argv[2]) else {}
+for p in m.get("plugins", []):
+    s = p.get("source")
+    if isinstance(s, dict) and s.get("source") == "github" and s.get("ref"):
+        o = ups.get(p["name"]) or {}
+        print("|".join([p["name"], s["repo"], s["ref"],
+                        o.get("upstream_repo", ""), o.get("track", ""), o.get("synced_base", "")]))
+PY
+)"
+  up_repo_field="$(printf '%s' "$line" | cut -d'|' -f4)"
+  up_track_field="$(printf '%s' "$line" | cut -d'|' -f5)"
+  up_base_field="$(printf '%s' "$line" | cut -d'|' -f6)"
+  if [ "$up_repo_field" = "AgriciDaniel/claude-obsidian" ]; then ok "override routes claude-obsidian to true upstream"; else bad "claude-obsidian override upstream_repo wrong: '$up_repo_field'"; fi
+  if [ "$up_track_field" = "release" ]; then ok "claude-obsidian override track=release"; else bad "claude-obsidian track wrong: '$up_track_field'"; fi
+  if [ -n "$up_base_field" ]; then ok "claude-obsidian override has synced_base ($up_base_field)"; else bad "claude-obsidian override missing synced_base"; fi
+else
+  bad "plugin-upstreams.json missing — claude-obsidian (a fork) would be checked against itself"
+fi
+
+# 3c. Stable-tag selection (mirrors the script's `latest` computation): a stale
+#     same-version prerelease must NOT be picked as latest over the stable tag
+#     (would be a phantom BEHIND), and a genuinely-newer stable IS picked.
+TAG_RE='^v?[0-9]+\.[0-9]+(\.[0-9]+)?$'
+pick() { printf '%s\n' "$1" | grep -E "$TAG_RE" | sort -V | tail -1; }
+if [ "$(pick "$(printf 'v1.9.1\nv1.9.2\nv1.9.2-alpha\nv1.8.1\n')")" = "v1.9.2" ]; then ok "stable-tag select: prerelease of current version ignored"; else bad "prerelease leaked into latest"; fi
+if [ "$(pick "$(printf 'v1.9.2\nv1.9.3\n')")" = "v1.9.3" ]; then ok "stable-tag select: newer stable wins"; else bad "newer stable not selected"; fi
+if [ -z "$(pick "$(printf 'v1.9.2-alpha\nv1.9.3-rc1\n')")" ]; then ok "stable-tag select: all-prerelease -> empty (drives the UNCHECKED path)"; else bad "all-prerelease should select nothing, got '$(pick "$(printf 'v1.9.2-alpha\nv1.9.3-rc1\n')")'"; fi
+
 # 4. End-to-end: the script runs to completion with a sane exit code —
 #    0 (all current / fail-open), 2 (drift), or 3 (incomplete). Anything else
 #    (1, 127, crash) fails.
@@ -44,10 +89,17 @@ case "$rc" in
   0|2|3) ok "end-to-end run exits $rc (expected 0, 2, or 3)" ;;
   *)     bad "end-to-end run exited $rc; output: $out" ;;
 esac
-# When gh ran (not the fail-open path), both section headers must appear.
+# When gh ran (not the fail-open path), both section headers must appear, and the
+# claude-obsidian line must reference its TRUE upstream (AgriciDaniel), proving the
+# override routed the check away from our fork repo.
 if ! printf '%s' "$out" | grep -q "fail-open"; then
-  if printf '%s' "$out" | grep -q "SHA-pinned remotes"; then ok "output has SHA-pinned section"; else bad "no SHA-pinned section"; fi
+  if printf '%s' "$out" | grep -q "pinned remotes"; then ok "output has pinned-remotes section"; else bad "no pinned-remotes section"; fi
   if printf '%s' "$out" | grep -q "vendored forks"; then ok "output has vendored-forks section"; else bad "no vendored-forks section"; fi
+  if printf '%s' "$out" | grep "claude-obsidian" | grep -q "AgriciDaniel/claude-obsidian"; then
+    ok "claude-obsidian drift tracks true upstream (AgriciDaniel), not the fork"
+  else
+    bad "claude-obsidian line does not reference true upstream AgriciDaniel; output: $(printf '%s' "$out" | grep claude-obsidian)"
+  fi
 else
   ok "gh unavailable — fail-open path taken (sections skipped, expected)"
 fi
@@ -61,11 +113,38 @@ else
   bad "fail-open broken: rc=$fo_rc out=$fo_out"
 fi
 
-# Note (deliberately NOT covered by this smoke layer): the exit-2 DRIFT verdict
-# and the exit-3 INCOMPLETE path require an actually-drifted / unreachable
-# upstream (non-deterministic) or an injectable-gh fixture harness — out of scope
-# for a network-tool smoke test. The CRLF-strip is exercised implicitly on this
-# Windows checkout (python3 emits CRLF; check #2 + the real run both depend on it).
+# 6. Override-branch UNCHECKED paths via fixtures (DRIFT_MJSON/DRIFT_UPSTREAMS).
+#    Both checks fire BEFORE any gh call, but the script's top-level fail-open gate
+#    means the pin loop only runs when gh is present — so gate this on the real run
+#    not having taken the fail-open path.
+if ! printf '%s' "$out" | grep -q "fail-open"; then
+  fix_m="$(mktemp)"; fix_u="$(mktemp)"
+  cat >"$fix_m" <<'JSON'
+{"plugins":[
+ {"name":"fix-missing-base","source":{"source":"github","repo":"yotamleo/x","ref":"v1"}},
+ {"name":"fix-bad-track","source":{"source":"github","repo":"yotamleo/y","ref":"v1"}}
+]}
+JSON
+  cat >"$fix_u" <<'JSON'
+{
+ "fix-missing-base":{"upstream_repo":"AgriciDaniel/claude-obsidian","track":"release"},
+ "fix-bad-track":{"upstream_repo":"AgriciDaniel/claude-obsidian","track":"bogus"}
+}
+JSON
+  fx_out="$(DRIFT_MJSON="$fix_m" DRIFT_UPSTREAMS="$fix_u" bash "$SCRIPT" 2>&1)"; fx_rc=$?
+  rm -f "$fix_m" "$fix_u"
+  if printf '%s' "$fx_out" | grep "fix-missing-base" | grep -q "missing synced_base"; then ok "missing synced_base -> UNCHECKED (not a phantom BEHIND)"; else bad "missing synced_base not UNCHECKED; out: $(printf '%s' "$fx_out" | grep fix-missing-base)"; fi
+  if printf '%s' "$fx_out" | grep "fix-bad-track" | grep -q "unknown track"; then ok "unknown track -> UNCHECKED"; else bad "bad track not UNCHECKED; out: $(printf '%s' "$fx_out" | grep fix-bad-track)"; fi
+  if [ "$fx_rc" -eq 3 ] || [ "$fx_rc" -eq 2 ]; then ok "fixture run signals incomplete/drift (rc=$fx_rc, never a false all-clear)"; else bad "fixture run rc=$fx_rc; expected 3 (incomplete) — UNCHECKED must not read as exit 0"; fi
+else
+  ok "gh unavailable — override-branch fixture checks skipped (consistent with fail-open)"
+fi
+
+# Note (deliberately NOT covered by this smoke layer): the exit-2 DRIFT verdict on
+# a REAL upstream advance is non-deterministic (depends on upstream releasing); the
+# fixture above covers the UNCHECKED override paths deterministically. The CRLF-strip
+# is exercised implicitly on this Windows checkout (python3 emits CRLF; check #2 +
+# the real run both depend on it).
 
 echo ""
 if [ "$fails" -ne 0 ]; then echo "$fails check(s) failed."; exit 1; fi


### PR DESCRIPTION
## What & why

`claude plugin install` clones via `git clone --branch <ref>`, which only resolves branch/tag names - a bare commit SHA fails (`fatal: Remote branch <sha> not found`). So the SHA-pinned claude-obsidian plugin could not be installed.

## Changes

- Pin -> immutable tag `v1.9.2-himmel.1` (fork synced to upstream AgriciDaniel v1.9.2; unsupported prompt-type SessionStart/PostCompact hooks removed).
- Drift guard tracks the true upstream via new `scripts/plugin-upstreams.json`: compares the upstream's highest stable version tag against `synced_base` (not the Releases API). Missing `synced_base`/unknown `track` -> UNCHECKED, never a phantom BEHIND.
- Pin-update-workflow doc rewritten (tag-not-SHA); tests + fixtures (25 checks).

Platforms tested: windows
Security reviewed: pr-review-toolkit
