### PR TITLE
fix(adopt): install all @himmel plugins + per-profile getting-started commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,13 @@ repos:
         always_run: true
         pass_filenames: false
 
+      - id: template-himmel-plugins
+        name: settings-template enables every vendored @himmel plugin
+        entry: bash scripts/hooks/check-template-himmel-plugins.sh
+        language: system
+        always_run: true
+        pass_filenames: false
+
       - id: merged-branch-check
         name: Merged branch check
         language: system

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,16 +34,40 @@ there.
 [Claude Code](https://claude.com/claude-code) CLI on your `PATH`. `gh` is
 optional — only the worktree-prune step uses it.
 
+Clone once, then run the one-shot adopt for the profile you want:
+
 ```bash
 git clone https://github.com/yotamleo/Himmel
+```
+
+**`core`** — the harness (hooks + guardrails + worktree commands + marketplace
+plugins/skills) wired into your repo. *Most people start here.*
+
+```bash
 bash Himmel/scripts/adopt.sh --profile core --scope project --target /path/to/your/repo
 # Windows:  pwsh Himmel\scripts\adopt.ps1 -Profile core -Scope project -Target C:\path\to\repo
 ```
 
-`--profile core` brings the harness; `--scope project` wires it into your repo
-(commit the result and anyone who clones it gets it). Profiles
-(`core` / `luna` / `all`), `--scope user`, remove/move, and the à-la-carte parts
-are all in [use-on-your-project.md](setup/use-on-your-project.md).
+**`luna`** — the luna second-brain vault scaffold only (no harness). `--target`
+is the vault directory.
+
+```bash
+bash Himmel/scripts/adopt.sh --profile luna --target ~/Documents/luna
+# Windows:  pwsh Himmel\scripts\adopt.ps1 -Profile luna -Target $HOME\Documents\luna
+```
+
+**`all`** — `core` + `luna`. The harness lands in `--target`; the vault in
+`--luna-target` (default `~/Documents/luna`).
+
+```bash
+bash Himmel/scripts/adopt.sh --profile all --scope project --target /path/to/your/repo --luna-target ~/Documents/luna
+# Windows:  pwsh Himmel\scripts\adopt.ps1 -Profile all -Scope project -Target C:\path\to\repo -LunaTarget $HOME\Documents\luna
+```
+
+`--scope project` wires it into your repo (commit the result and anyone who
+clones it gets it); `--scope user` enables it for you in every project on this
+machine. `--scope user`, remove/move, and the à-la-carte parts are all in
+[use-on-your-project.md](setup/use-on-your-project.md).
 
 ### B. Run / develop himmel itself standalone
 

--- a/docs/setup/settings-template.json
+++ b/docs/setup/settings-template.json
@@ -89,7 +89,12 @@
     "qmd@qmd": true,
     "caveman@caveman": true,
     "claude-obsidian@claude-obsidian-marketplace": true,
-    "handover@himmel": true
+    "handover@himmel": true,
+    "luna-correlate@himmel": true,
+    "himmel-ops@himmel": true,
+    "obsidian-triage@himmel": true,
+    "pr-review-toolkit-himmel@himmel": true,
+    "telegram-himmel@himmel": true
   },
   "extraKnownMarketplaces": {
     "obsidian-skills": {

--- a/scripts/hooks/check-template-himmel-plugins.sh
+++ b/scripts/hooks/check-template-himmel-plugins.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Drift guard: every locally-vendored @himmel marketplace plugin
+# (marketplace/.claude-plugin/marketplace.json entries with a local "./…"
+# string source) MUST be enabled in docs/setup/settings-template.json as
+# "<name>@himmel": true. That template is the SINGLE list install-plugins.sh
+# (and adopt.sh, at every scope and for both core/all profiles) installs from.
+# A plugin added to the marketplace but not the template is silently never
+# installed by adopt — and install-plugins' post-install verify only checks the
+# template's own list, so it falsely reports success. This is exactly how 5
+# himmel plugins shipped uninstallable-by-adopt for one drift.
+# Externally-sourced plugins (object "source", e.g. claude-obsidian served from
+# its own marketplace) are curated separately and exempt.
+# Fail-closed on detected drift; skips (exit 0) only when jq or an input file
+# is unavailable. Inputs env-overridable for testing. bash 3.2-safe.
+set -euo pipefail
+
+MARKET_JSON="${HIMMEL_MARKETPLACE_JSON:-marketplace/.claude-plugin/marketplace.json}"
+TEMPLATE_JSON="${HIMMEL_SETTINGS_TEMPLATE:-docs/setup/settings-template.json}"
+
+command -v jq >/dev/null 2>&1 || { echo "template-plugins-check: jq not on PATH — skipping"; exit 0; }
+[ -f "$MARKET_JSON" ]   || { echo "template-plugins-check: $MARKET_JSON missing — skipping"; exit 0; }
+[ -f "$TEMPLATE_JSON" ] || { echo "template-plugins-check: $TEMPLATE_JSON missing — skipping"; exit 0; }
+
+# Locally-vendored himmel plugins = entries whose source is a string ("./…").
+# tr -d '\r': jq emits CRLF on Windows; a trailing \r corrupts the key match.
+local_plugins="$(jq -r '.plugins[] | select((.source|type)=="string") | .name' "$MARKET_JSON" | tr -d '\r')"
+
+missing=""
+while IFS= read -r name; do
+  [ -z "$name" ] && continue
+  if [ "$(jq -r --arg k "$name@himmel" '(.enabledPlugins[$k] // false)' "$TEMPLATE_JSON" | tr -d '\r')" != "true" ]; then
+    missing="$missing  $name@himmel
+"
+  fi
+done <<EOF
+$local_plugins
+EOF
+
+if [ -n "$missing" ]; then
+  echo "ERR template-plugins-check: @himmel plugins missing from $TEMPLATE_JSON enabledPlugins:" >&2
+  printf '%s' "$missing" >&2
+  echo "    These ship in the himmel marketplace but adopt.sh/install-plugins.sh will never install them." >&2
+  echo "    Add each as \"<name>@himmel\": true to enabledPlugins (or, if intentionally excluded," >&2
+  echo "    give it an object source in marketplace.json so it is curated separately)." >&2
+  exit 1
+fi
+
+echo "template-plugins-check: all locally-vendored @himmel plugins present in settings-template.json"

--- a/scripts/hooks/test-check-template-himmel-plugins.sh
+++ b/scripts/hooks/test-check-template-himmel-plugins.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Smoke test for check-template-himmel-plugins.sh. Drives the guard with
+# fixture marketplace.json + settings-template.json via its env-override seams.
+set -euo pipefail
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$HERE/check-template-himmel-plugins.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# A locally-vendored plugin (handover, obsidian-triage) plus an externally
+# sourced one (claude-obsidian, object source) that must be EXEMPT.
+cat > "$tmp/market.json" <<'JSON'
+{"name":"himmel","plugins":[
+  {"name":"handover","source":"./plugins/handover"},
+  {"name":"obsidian-triage","source":"./plugins/obsidian-triage"},
+  {"name":"claude-obsidian","source":{"source":"github","repo":"x/y"}}
+]}
+JSON
+
+run_guard() { HIMMEL_MARKETPLACE_JSON="$tmp/market.json" HIMMEL_SETTINGS_TEMPLATE="$1" bash "$GUARD"; }
+
+# Case 1: template missing obsidian-triage@himmel → expect FAIL (exit 1).
+printf '{"enabledPlugins":{"handover@himmel":true}}' > "$tmp/tmpl.json"
+if run_guard "$tmp/tmpl.json" >/dev/null 2>&1; then
+  echo "FAIL: guard passed despite missing obsidian-triage@himmel"; exit 1
+fi
+echo "ok: drift detected"
+
+# Case 2: all locally-vendored present, claude-obsidian exempt → expect PASS.
+printf '{"enabledPlugins":{"handover@himmel":true,"obsidian-triage@himmel":true}}' > "$tmp/tmpl.json"
+if ! run_guard "$tmp/tmpl.json" >/dev/null 2>&1; then
+  echo "FAIL: guard failed on a complete template"; exit 1
+fi
+echo "ok: complete template passes"
+
+# Case 3: missing input file → fail-OPEN skip (exit 0). Pins the deliberate
+# skip contract: the always_run hook must not start blocking commits in a
+# partial checkout where an input is absent.
+if ! run_guard "$tmp/does-not-exist.json" >/dev/null 2>&1; then
+  echo "FAIL: guard did not skip (exit 0) on a missing template file"; exit 1
+fi
+echo "ok: missing input skips"
+
+echo "PASS: check-template-himmel-plugins smoke test"


### PR DESCRIPTION
Public propagation of private #616. Fixes adopt installing only handover@himmel of himmel's 7 plugins (root: settings-template.json enabledPlugins); adds the 5 missing plugins + a fail-closed drift guard; per-profile copy-paste install commands in getting-started.md.