### PR TITLE
fix(telegram): scrub test

### DIFF
--- a/docs/telegram-bridge.md
+++ b/docs/telegram-bridge.md
@@ -54,7 +54,7 @@ TELEGRAM_OWN_POLLER=1 claude "telegram bridge owner — standby" --dangerously-l
 ```
 
 Confirm: the session prints `Listening for channel messages from:
-plugin:telegram-himmel@himmel`. DM `@overlord_luna_bot` from the allowlisted
+plugin:telegram-himmel@himmel`. DM your bot (`@<your-bot-username>`) from the allowlisted
 account → the message appears in the session as a `<channel …>` block; reply
 flows back to Telegram.
 

--- a/scripts/telegram/README.md
+++ b/scripts/telegram/README.md
@@ -120,7 +120,7 @@ dropped) OR the chat is allowlisted: its chat_id is a key in `groups` in
 `~/.claude/channels/telegram/access.json`:
 
 ```json
-"groups": { "-5072730283": {} }
+"groups": { "-1009999999": {} }
 ```
 
 A non-empty per-group `allowFrom` (the fork's GroupPolicy shape) restricts
@@ -162,11 +162,10 @@ message lands in `~/.claude/handover/bridge/inbound.jsonl` with its `chat_id`.
 The poller reads access.json ONCE at startup — restart the bridge after every
 allowlist edit.
 
-**Verified live (2026-06-10, HIMMEL-238 acceptance):** group `-5072730283`
-(AI TODO) — plain message ingested, bounded run replied INTO the group, DM
-untouched; channel `-1004267040815` — first post surfaced its id via the
-gated-out log, allowlisted + restarted, posts then processed with replies
-into the channel. Both ids live in the operator's access.json.
+**Verified live (2026-06-10, HIMMEL-238 acceptance):** an allowlisted group
+— plain message ingested, bounded run replied INTO the group, DM untouched;
+an allowlisted channel — first post surfaced its id via the gated-out log,
+allowlisted + restarted, posts then processed with replies into the channel.
 
 **Consolidation pattern:** Telegram channels don't contain groups — to funnel
 many sources through one allowlisted chat, forward/post their content INTO a
@@ -263,7 +262,7 @@ $env:WHISPER_INTEGRATION_TEST = "1"; bun test scripts/telegram/transcribe-integr
 | `install-logon-task.ps1` | register/remove/report the `HimmelTelegramBridge` reboot-persistence task |
 | `run-prompt.md` | the prompt contract handed to each bounded run |
 
-Bot: `@overlord_luna_bot`. Token: `~/.claude/channels/telegram/.env`
+Bot: `@<your-bot-username>`. Token: `~/.claude/channels/telegram/.env`
 (`TELEGRAM_BOT_TOKEN=`). Logs + pidfile: `~/.claude/channels/telegram/`.
 Bus (sessions, inbound.jsonl, offset): `~/.claude/handover/bridge/`
 (`BRIDGE_ROOT` to override).

--- a/scripts/telegram/gate.test.ts
+++ b/scripts/telegram/gate.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { isAllowed, isGroupAllowed, vaultForChat } from "./gate";
 
 // Real access.json shape (~/.claude/channels/telegram/access.json):
-//   { "dmPolicy": "allowlist", "allowFrom": ["7282416230"], "groups": {}, "pending": {} }
+//   { "dmPolicy": "allowlist", "allowFrom": ["1000000001"], "groups": {}, "pending": {} }
 // The fork's gate() compares String(from.id) against allowFrom (string array).
 
 test("allows listed sender, rejects others", () => {
@@ -32,20 +32,20 @@ test("fails closed on malformed allowlist", () => {
 // allows the chat. Covers groups (-…) and channels (-100…) alike.
 
 test("isGroupAllowed: allows a chat_id present in groups, rejects others", () => {
-  const access = { allowFrom: ["1"], groups: { "-5072730283": {} } };
-  expect(isGroupAllowed(access, -5072730283)).toBe(true);
-  expect(isGroupAllowed(access, "-5072730283")).toBe(true);
+  const access = { allowFrom: ["1"], groups: { "-1009999999": {} } };
+  expect(isGroupAllowed(access, -1009999999)).toBe(true);
+  expect(isGroupAllowed(access, "-1009999999")).toBe(true);
   expect(isGroupAllowed(access, -999)).toBe(false);
-  expect(isGroupAllowed(access, 7282416230)).toBe(false);   // DM id not in groups
+  expect(isGroupAllowed(access, 1000000001)).toBe(false);   // DM id not in groups
 });
 
 test("isGroupAllowed: fails closed on missing/empty/malformed groups", () => {
-  expect(isGroupAllowed({}, -5072730283)).toBe(false);
-  expect(isGroupAllowed({ groups: {} }, -5072730283)).toBe(false);
-  expect(isGroupAllowed({ groups: ["-5072730283"] } as any, -5072730283)).toBe(false);
-  expect(isGroupAllowed({ groups: "-5072730283" } as any, -5072730283)).toBe(false);
-  expect(isGroupAllowed(null as any, -5072730283)).toBe(false);
-  expect(isGroupAllowed(undefined as any, -5072730283)).toBe(false);
+  expect(isGroupAllowed({}, -1009999999)).toBe(false);
+  expect(isGroupAllowed({ groups: {} }, -1009999999)).toBe(false);
+  expect(isGroupAllowed({ groups: ["-1009999999"] } as any, -1009999999)).toBe(false);
+  expect(isGroupAllowed({ groups: "-1009999999" } as any, -1009999999)).toBe(false);
+  expect(isGroupAllowed(null as any, -1009999999)).toBe(false);
+  expect(isGroupAllowed(undefined as any, -1009999999)).toBe(false);
 });
 
 test("isGroupAllowed: a non-empty per-group allowFrom restricts senders (fork GroupPolicy)", () => {
@@ -82,7 +82,7 @@ test("vaultForChat: a group without its own vault falls back to defaultVault", (
 test("vaultForChat: an unknown chat still gets defaultVault (covers DMs too)", () => {
   const access = { defaultVault: "/luna", groups: { "-50": {} } };
   expect(vaultForChat(access, -999)).toBe("/luna");
-  expect(vaultForChat(access, 7282416230)).toBe("/luna");
+  expect(vaultForChat(access, 1000000001)).toBe("/luna");
 });
 
 test("vaultForChat: null when no vault and no default (fails closed → file nothing)", () => {

--- a/scripts/telegram/poller.test.ts
+++ b/scripts/telegram/poller.test.ts
@@ -425,10 +425,10 @@ test("chat routes to __chat__ session", async () => {
 
 test("group chat routes to its own group_<chat_id> session with meta.chat_id = the group", async () => {
   const r = root(); const ran: string[] = [];
-  await handleInbound(r, { from:1, chat_id:-5072730283, text:"hello group" }, async (s:string)=>{ran.push(s);});
-  expect(ran).toEqual(["group_-5072730283"]);
-  const m = await readMeta(r, "group_-5072730283");
-  expect(m?.chat_id).toBe(-5072730283);
+  await handleInbound(r, { from:1, chat_id:-1009999999, text:"hello group" }, async (s:string)=>{ran.push(s);});
+  expect(ran).toEqual(["group_-1009999999"]);
+  const m = await readMeta(r, "group_-1009999999");
+  expect(m?.chat_id).toBe(-1009999999);
 });
 
 test("ticket session chat_id is pinned by its creator; a group followup does not re-route it", async () => {


### PR DESCRIPTION
Removes test from the bridge docs and tests; placeholders, tests 122/0. No token was ever committed.