### PR TITLE
chore: proper AGENTS.md (CLAUDE.md pointer) + gitignore codex artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ logs/gemini/
 # Mode A (no HANDOVER_DIR) regenerates plans under docs/superpowers/plans/ —
 # keep those local, never re-track the folder into the public repo.
 /docs/superpowers/
+# Codex auto-generated artifacts (deferred until codex is wired up — HIMMEL-427).
+# AGENTS.md itself IS tracked (thin pointer to CLAUDE.md); only codex's local
+# runtime config + its auto-generated slash-command→skill mirrors are ignored.
+.codex/
+.agents/skills/source-command-*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+This repository's rules, repo map, and workflows live in
+**[CLAUDE.md](CLAUDE.md)** — the single source of truth for every coding
+agent that works here (Claude Code, Codex, and any other tool that reads
+`AGENTS.md`).
+
+This file is intentionally a thin pointer, not a copy, so the two can never
+drift. **Read [CLAUDE.md](CLAUDE.md) first.**
+
+> Codex-specific compatibility — whether himmel's PreToolUse hooks and
+> pre-commit/pre-push gates actually fire under Codex — is tracked in
+> HIMMEL-427. Until that audit lands, treat himmel's structural guardrails as
+> Claude-Code-validated only.


### PR DESCRIPTION
Thin AGENTS.md pointer to CLAUDE.md (no drift) + gitignore codex runtime artifacts (.codex/, .agents/skills/source-command-*/).