### PR TITLE
feat: Jira CLI completeness + Confluence support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,15 @@ JIRA_PROJECT_KEY=HIMMEL
 # Defaults to JIRA_PROJECT_KEY alone.
 # JIRA_PROJECTS=ACME,BETA
 JIRA_CLOUD_ID=<your-cloud-id>
+# Optional: default Agile board id for `jira sprints` (HIMMEL-437). When set,
+# `sprints` needs no --board in the common single-board case.
+# JIRA_BOARD_ID=123
+# Optional: separate Atlassian creds for the `confluence` CLI (HIMMEL-437).
+# A scoped Jira API token 401s against Confluence (/wiki); set these to a
+# Confluence-capable (scopeless/full-account) token. Unset -> confluence CLI
+# falls back to JIRA_EMAIL/JIRA_API_TOKEN.
+# CONFLUENCE_EMAIL=<your-email@example.com>
+# CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 ORGANIZATION_ID=your_org_id_here
 
 # VirtualBox VMs — see docs/setup/vms.md

--- a/docs/internals/jira-plugin.md
+++ b/docs/internals/jira-plugin.md
@@ -39,10 +39,15 @@ For Jira ops in this repo, default to the local CLI at
 | Move        | `... move HIMMEL-N --to-project LUNA [--type Story] [--dry-run]` (HIMMEL-197 — close source + create target + copy comments) | (none — Jira Cloud REST API has no direct project-change endpoint) |
 | Projects    | `... projects` / `... project-create ...`                                   | `getVisibleJiraProjects` / no equivalent for create              |
 | Link        | `... link HIMMEL-A HIMMEL-B --type Relates` (HIMMEL-210; case-insensitive type, validated against the live type list) | `createIssueLink` (+ `getIssueLinkTypes` for the type list) |
+| Assign      | `... assign HIMMEL-N <email\|accountId>` (`-`/`unassigned` clears, `auto` = default assignee; email → accountId via `/user/search`) (HIMMEL-437) | `editJiraIssue` (assignee field) |
+| Attachments | `... attachments HIMMEL-N` (list) / `... download HIMMEL-N [id] [--all] [--out dir]` (HIMMEL-437) | (none — MCP has no attachment download) |
+| Worklog     | `... worklog add HIMMEL-N --time 1h [--comment ...]` / `... worklog list HIMMEL-N` (HIMMEL-437) | `addWorklogToJiraIssue` (no list) |
+| Watchers    | `... watch HIMMEL-N [user]` / `... unwatch HIMMEL-N [user]` / `... watchers HIMMEL-N` (HIMMEL-437) | (none) |
+| Sprint      | `... boards` / `... sprints [--board N]` / `... sprint HIMMEL-N <sprintId\|backlog>` (Agile API `/rest/agile/1.0`; `JIRA_BOARD_ID` default) (HIMMEL-437) | (none — MCP has no Agile-board ops) |
 
 **Use MCP only when the plugin lacks the operation** (custom-field
-discovery, account-ID lookup via `lookupJiraAccountId`, Confluence
-operations — there is no Confluence plugin yet). The MCP block in
+discovery, account-ID lookup via `lookupJiraAccountId`). Confluence now has
+a sibling CLI (see below) — prefer it over the Confluence MCP tools. The MCP block in
 `block-backend-tier.sh` derives its blocked-set by introspecting
 the CLI's verbs (`node …/index.js --list-commands`) against a small
 verb→MCP-method map (HIMMEL-231) — an MCP method is refused iff its mapped
@@ -65,3 +70,38 @@ scripts/jira/dist/index.js list` works with an empty shell environment.
 A `JIRA_PROJECT_KEY` *unset in your shell* is irrelevant and is **not**
 the cause of a `projectKey()` error; check the repo-root `.env` instead.
 Only pass `--project FOO` for a one-off call against a different project.
+
+## Confluence CLI (HIMMEL-437)
+
+A sibling binary `scripts/jira/dist/confluence.js` (same package, same
+`.env` auth) covers routine Confluence ops. It is registered as the
+`confluence` service in `scripts/backends.json` (same Atlassian MCP prefix
+as jira, `chain: [cli, api, mcp]`), so `block-backend-tier.sh` hard-blocks
+the equivalent Confluence MCP tools — the routing hook evaluates BOTH
+atlassian-prefixed services and blocks on whichever has the mapped verb
+(Jira/Confluence method suffixes are disjoint).
+
+**API surface:** Confluence Cloud REST **v2** (`/wiki/api/v2`) is the
+default; two ops have no v2 equivalent and stay on **v1**
+(`/wiki/rest/api`): **CQL search** and **attachment upload**.
+
+**Auth (HIMMEL-437):** a *scoped* Jira API token returns `401` against
+Confluence (`/wiki`) — same gotcha as the bitbucket CLI. The confluence CLI
+uses `CONFLUENCE_EMAIL` / `CONFLUENCE_API_TOKEN` when **both** are set
+(point them at a Confluence-capable, i.e. scopeless/full-account, Atlassian
+token); otherwise it falls back to `JIRA_EMAIL` / `JIRA_API_TOKEN` (which
+works only if that token covers Confluence too).
+
+| Op            | Plugin (`node scripts/jira/dist/confluence.js …`)                    | MCP                                  |
+|---------------|----------------------------------------------------------------------|--------------------------------------|
+| Get page      | `page get <id>` (renders body ADF→text)                              | `getConfluencePage`                  |
+| Create page   | `page create --space KEY --title ... --body-file f [--parent id]`    | `createConfluencePage`               |
+| Update page   | `page update <id> [--title ...] [--body-file f]` (auto version-bump) | `updateConfluencePage`               |
+| Delete page   | `page delete <id>`                                                    | (none)                               |
+| Search        | `search --cql "..." [--limit N]` (v1)                                | `searchConfluenceUsingCql`           |
+| Spaces        | `spaces [--limit N]`                                                  | `getConfluenceSpaces`                |
+| Comments      | `comments <pageId>` (list) / `comment <pageId> "text" [--body-file f]` (add footer)  | `getConfluencePageFooterComments` / `createConfluenceFooterComment` |
+| Attachments   | `attachments <pageId>` (list) / `attach <pageId> file...` (upload, v1) / `download <pageId> [id] [--all] [--out dir]` | (none) |
+
+The verb↔MCP-method rows above mirror `_CONFLUENCE_VERB_METHOD_MAP` in
+`block-backend-tier.sh` — keep them in sync.

--- a/scripts/backends.json
+++ b/scripts/backends.json
@@ -5,6 +5,12 @@
     "cli": "scripts/jira/dist/index.js",
     "chain": ["cli", "api", "mcp"]
   },
+  "confluence": {
+    "enabled": true,
+    "mcp_prefix": "mcp__plugin_atlassian_atlassian__",
+    "cli": "scripts/jira/dist/confluence.js",
+    "chain": ["cli", "api", "mcp"]
+  },
   "bitbucket": {
     "enabled": true,
     "mcp_prefix": null,

--- a/scripts/hooks/block-backend-tier.sh
+++ b/scripts/hooks/block-backend-tier.sh
@@ -29,8 +29,8 @@
 #
 # Bypass env vars (set in the shell that LAUNCHED Claude Code):
 #   MCP_ALL_OK=1              — global; bypasses every service.
-#   MCP_JIRA_OK=1             — Jira only (backward-compat alias for MCP_JIRA_OK).
-#   MCP_<SERVICE_UPPER>_OK=1  — per-service (e.g. MCP_GITHUB_OK=1).
+#   MCP_JIRA_OK=1             — Jira only (legacy name; still honoured).
+#   MCP_<SERVICE_UPPER>_OK=1  — per-service (e.g. MCP_GITHUB_OK=1, MCP_CONFLUENCE_OK=1).
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
@@ -39,6 +39,7 @@ set -euo pipefail
 # chain is colon-separated tiers (cli:api:mcp or mcp:cli:api etc.)
 # ---------------------------------------------------------------------------
 _DEFAULTS="jira|true|mcp__plugin_atlassian_atlassian__|scripts/jira/dist/index.js|cli:api:mcp
+confluence|true|mcp__plugin_atlassian_atlassian__|scripts/jira/dist/confluence.js|cli:api:mcp
 bitbucket|true||scripts/bitbucket/dist/index.js|cli:api:mcp
 github|true||gh|cli:api:mcp"
 
@@ -57,6 +58,22 @@ _JIRA_VERB_METHOD_MAP=$(printf '%s\n' \
     "link	createIssueLink")
 
 # ---------------------------------------------------------------------------
+# Confluence verb->MCP-method map. Verb strings match `confluence.js
+# --list-commands` EXACTLY (page verbs are space-joined: "page get").
+# Jira and Confluence method-name SUFFIXES are disjoint (*Jira* vs
+# *Confluence*), so at most one service maps any given MCP suffix — the
+# multi-service loop below can never double-attribute.
+# ---------------------------------------------------------------------------
+_CONFLUENCE_VERB_METHOD_MAP=$(printf '%s\n' \
+    "page get	getConfluencePage" \
+    "page create	createConfluencePage" \
+    "page update	updateConfluencePage" \
+    "search	searchConfluenceUsingCql" \
+    "spaces	getConfluenceSpaces" \
+    "comments	getConfluencePageFooterComments" \
+    "comment	createConfluenceFooterComment")
+
+# ---------------------------------------------------------------------------
 # Replacement hint per verb, keyed by service and verb.
 # Format: <service>:<verb> → human-readable replacement command.
 # ---------------------------------------------------------------------------
@@ -72,6 +89,15 @@ replacement_for() {
         jira:projects)   echo 'node scripts/jira/dist/index.js projects' ;;
         jira:link)       echo 'node scripts/jira/dist/index.js link HIMMEL-A HIMMEL-B --type Relates' ;;
         jira:*)          echo 'node scripts/jira/dist/index.js --help' ;;
+        # Confluence — note the page verbs carry an internal space in the arm key.
+        "confluence:page get")    echo 'node scripts/jira/dist/confluence.js page get <id>' ;;
+        "confluence:page create") echo 'node scripts/jira/dist/confluence.js page create --space <KEY> --title "..." --body-file <f>' ;;
+        "confluence:page update") echo 'node scripts/jira/dist/confluence.js page update <id> --body-file <f>' ;;
+        confluence:search)        echo 'node scripts/jira/dist/confluence.js search --cql "<cql>"' ;;
+        confluence:spaces)        echo 'node scripts/jira/dist/confluence.js spaces' ;;
+        confluence:comments)      echo 'node scripts/jira/dist/confluence.js comments <pageId>' ;;
+        confluence:comment)       echo 'node scripts/jira/dist/confluence.js comment <pageId> "<text>"' ;;
+        confluence:*)             echo 'node scripts/jira/dist/confluence.js --help' ;;
         *)               echo "${service} CLI --help" ;;
     esac
 }
@@ -81,7 +107,8 @@ replacement_for() {
 # ---------------------------------------------------------------------------
 verb_method_map_for() {
     case "$1" in
-        jira) printf '%s\n' "$_JIRA_VERB_METHOD_MAP" ;;
+        jira)       printf '%s\n' "$_JIRA_VERB_METHOD_MAP" ;;
+        confluence) printf '%s\n' "$_CONFLUENCE_VERB_METHOD_MAP" ;;
         *)    : ;;  # no map → nothing matches → allow
     esac
 }
@@ -184,147 +211,10 @@ else
     services_list=$(printf '%s\n' "$_DEFAULTS")
 fi
 
-# Iterate services
-matched_service=""
-matched_chain=""
-matched_cli=""
-matched_prefix=""
-
-while IFS='|' read -r svc_name svc_enabled svc_mcp_prefix svc_cli svc_chain; do
-    # Strip \r from values — jq on Windows may produce CRLF output.
-    svc_name="${svc_name//$'\r'/}"
-    svc_enabled="${svc_enabled//$'\r'/}"
-    svc_mcp_prefix="${svc_mcp_prefix//$'\r'/}"
-    svc_cli="${svc_cli//$'\r'/}"
-    svc_chain="${svc_chain//$'\r'/}"
-
-    [ -z "$svc_name" ] && continue
-
-    # Skip disabled services
-    [ "$svc_enabled" = "false" ] && continue
-
-    # Skip services with no MCP prefix (no Atlassian-style MCP namespace → nothing to match)
-    [ -z "$svc_mcp_prefix" ] && continue
-
-    # Does the tool_name start with this service's prefix?
-    case "$tool_name" in
-        "${svc_mcp_prefix}"*)
-            matched_service="$svc_name"
-            matched_prefix="$svc_mcp_prefix"
-            matched_chain="$svc_chain"
-            matched_cli="$svc_cli"
-            break
-            ;;
-    esac
-done <<EOF
-$services_list
-EOF
-
-# No prefix matched → allow
-[ -z "$matched_service" ] && exit 0
-
-# Per-service bypass (MCP_<SERVICE_UPPER>_OK=1)
-# Also honour legacy MCP_JIRA_OK=1 for the jira service.
-svc_upper=$(printf '%s' "$matched_service" | tr '[:lower:]' '[:upper:]')
-bypass_var="MCP_${svc_upper}_OK"
-# Use indirect lookup that is bash 3.2-safe.
-# Security: eval is used to build a variable name from svc_upper.  Before
-# eval, we validate that svc_upper contains ONLY [A-Z0-9_] — if it holds
-# any other character (possible if a registry file has an adversarial key)
-# we skip the bypass (no eval, no expansion, no injection).  The explicit
-# case arms below cover the known services without any eval.
-bypass_val=""
-case "$bypass_var" in
-    MCP_JIRA_OK)      bypass_val="${MCP_JIRA_OK:-0}" ;;
-    MCP_BITBUCKET_OK) bypass_val="${MCP_BITBUCKET_OK:-0}" ;;
-    MCP_GITHUB_OK)    bypass_val="${MCP_GITHUB_OK:-0}" ;;
-    # Generic fallback for services added via the registry.
-    # eval is safe ONLY when bypass_var contains [A-Z0-9_]+ (validated below).
-    *)
-        case "$svc_upper" in
-            *[!A-Z0-9_]*)
-                # Service name contains unsafe characters — skip bypass, no eval.
-                ;;
-            *)
-                eval "bypass_val=\"\${${bypass_var}:-0}\""
-                ;;
-        esac
-        ;;
-esac
-[ "$bypass_val" = "1" ] && exit 0
-
 # ---------------------------------------------------------------------------
-# Determine if chain ranks cli ABOVE mcp (hard-block applies)
-# ---------------------------------------------------------------------------
-# Strip \r from matched_chain — jq on Windows may emit CRLF line endings,
-# producing e.g. "cli:api:mcp\r" which breaks the case arm matching "mcp".
-matched_chain="${matched_chain//$'\r'/}"
-cli_above_mcp=0
-seen_cli=0
-IFS=':' read -ra chain_tiers <<< "$matched_chain"
-for tier in "${chain_tiers[@]}"; do
-    # Strip any residual whitespace from tier name (defensive)
-    tier="${tier//[$' \t\r\n']/}"
-    case "$tier" in
-        cli) seen_cli=1 ;;
-        mcp)
-            # If we've already seen cli before hitting mcp, cli is ranked higher
-            [ "$seen_cli" -eq 1 ] && cli_above_mcp=1
-            ;;
-    esac
-done
-
-# If mcp is ranked at or above cli, no hard block for this service
-[ "$cli_above_mcp" -eq 0 ] && exit 0
-
-# Check if api advisory tier is present in the chain
-api_in_chain=0
-for tier in "${chain_tiers[@]}"; do
-    tier="${tier//[$' \t\r\n']/}"
-    [ "$tier" = "api" ] && api_in_chain=1
-done
-
-# ---------------------------------------------------------------------------
-# Extract MCP method suffix and reverse-map to CLI verb
-# ---------------------------------------------------------------------------
-suffix="${tool_name#"${matched_prefix}"}"
-
-verb_method_map=$(verb_method_map_for "$matched_service")
-if [ -z "$verb_method_map" ]; then
-    # No verb map for this service → no known equivalent → allow
-    exit 0
-fi
-
-verb=""
-while IFS="$(printf '\t')" read -r map_verb map_method; do
-    [ -z "$map_method" ] && continue
-    if [ "$map_method" = "$suffix" ]; then
-        verb="$map_verb"
-        break
-    fi
-done <<EOF
-$verb_method_map
-EOF
-
-# Unmapped MCP method → no plugin equivalent → allow
-[ -z "$verb" ] && exit 0
-
-# ---------------------------------------------------------------------------
-# Introspect the CLI's actual verbs (fail OPEN on any introspection failure)
-# ---------------------------------------------------------------------------
-# Resolve CLI path: relative paths resolved from repo_root; absolute pass-through.
-cli_bin="$matched_cli"
-case "$cli_bin" in
-    /*) : ;;  # absolute — keep as-is
-    *)  cli_bin="$repo_root/$cli_bin" ;;
-esac
-
-# Allow test seam: JIRA_CLI overrides the jira service CLI path (backward compat).
-if [ "$matched_service" = "jira" ] && [ -n "${JIRA_CLI:-}" ]; then
-    cli_bin="$JIRA_CLI"
-fi
-
 # node-based CLI (*.js) → invoke via node; others invoke directly.
+# Defined once at top level (used by evaluate_service).
+# ---------------------------------------------------------------------------
 invoke_cli() {
     local bin="$1"
     case "$bin" in
@@ -343,71 +233,184 @@ invoke_cli() {
     esac
 }
 
-if [ ! -f "$cli_bin" ] && ! command -v "$cli_bin" >/dev/null 2>&1; then
-    exit 0
-fi
+# ---------------------------------------------------------------------------
+# evaluate_service <name> <chain> <cli> <prefix>
+#   Evaluate ONE prefix-matching service. Returns:
+#     2 — block (refusal already printed to stderr)
+#     0 — no block for this service (caller should try the next match)
+#   Reads globals: tool_name, repo_root, env bypass vars, JIRA_CLI/CONFLUENCE_CLI.
+#   Every "no block" path returns 0 (NOT exit) so the multi-service loop below
+#   can keep going; only a genuine block returns 2. Call it from an `if`
+#   condition so `set -e` is suspended for its dynamic extent (a `return 2`
+#   must not abort the script prematurely).
+# ---------------------------------------------------------------------------
+evaluate_service() {
+    local matched_service="$1" matched_chain="$2" matched_cli="$3" matched_prefix="$4"
+    local svc_upper bypass_var bypass_val
+    local cli_above_mcp seen_cli api_in_chain tier chain_tiers
+    local suffix verb_method_map verb map_verb map_method
+    local cli_bin commands line verb_present
+    local replacement bypass_var_alias api_advisory bypass_launch
 
-commands=$(invoke_cli "$cli_bin") || exit 0
-[ -z "$commands" ] && exit 0
+    # Per-service bypass (MCP_<SERVICE_UPPER>_OK=1); legacy MCP_JIRA_OK honoured.
+    # Security: eval builds a var name from svc_upper only after validating it
+    # is [A-Z0-9_]+ (adversarial registry keys → no eval, no injection).
+    svc_upper=$(printf '%s' "$matched_service" | tr '[:lower:]' '[:upper:]')
+    bypass_var="MCP_${svc_upper}_OK"
+    bypass_val=""
+    case "$bypass_var" in
+        MCP_JIRA_OK)      bypass_val="${MCP_JIRA_OK:-0}" ;;
+        MCP_BITBUCKET_OK) bypass_val="${MCP_BITBUCKET_OK:-0}" ;;
+        MCP_GITHUB_OK)    bypass_val="${MCP_GITHUB_OK:-0}" ;;
+        *)
+            case "$svc_upper" in
+                *[!A-Z0-9_]*) ;;  # unsafe chars — skip bypass, no eval
+                *) eval "bypass_val=\"\${${bypass_var}:-0}\"" ;;
+            esac
+            ;;
+    esac
+    [ "$bypass_val" = "1" ] && return 0
 
-# Block iff the mapped verb is present — exact whole-line match.
-verb_present=0
-while IFS= read -r line; do
-    line="${line//[$' \t\r\n']/}"
-    if [ "$line" = "$verb" ]; then
-        verb_present=1
-        break
+    # Determine if chain ranks cli ABOVE mcp (hard-block applies).
+    matched_chain="${matched_chain//$'\r'/}"
+    cli_above_mcp=0
+    seen_cli=0
+    IFS=':' read -ra chain_tiers <<< "$matched_chain"
+    for tier in "${chain_tiers[@]}"; do
+        tier="${tier//[$' \t\r\n']/}"
+        case "$tier" in
+            cli) seen_cli=1 ;;
+            mcp) [ "$seen_cli" -eq 1 ] && cli_above_mcp=1 ;;
+        esac
+    done
+    # mcp ranked at or above cli → no hard block for this service.
+    [ "$cli_above_mcp" -eq 0 ] && return 0
+
+    api_in_chain=0
+    for tier in "${chain_tiers[@]}"; do
+        tier="${tier//[$' \t\r\n']/}"
+        [ "$tier" = "api" ] && api_in_chain=1
+    done
+
+    # Extract MCP method suffix and reverse-map to a CLI verb.
+    suffix="${tool_name#"${matched_prefix}"}"
+    verb_method_map=$(verb_method_map_for "$matched_service")
+    [ -z "$verb_method_map" ] && return 0  # no map → no known equivalent → allow
+    verb=""
+    while IFS="$(printf '\t')" read -r map_verb map_method; do
+        [ -z "$map_method" ] && continue
+        if [ "$map_method" = "$suffix" ]; then
+            verb="$map_verb"
+            break
+        fi
+    done <<EOF
+$verb_method_map
+EOF
+    [ -z "$verb" ] && return 0  # unmapped MCP method → allow
+
+    # Introspect the CLI's actual verbs (fail OPEN on any introspection failure).
+    cli_bin="$matched_cli"
+    case "$cli_bin" in
+        /*) : ;;  # absolute — keep as-is
+        *)  cli_bin="$repo_root/$cli_bin" ;;
+    esac
+    # Test seams: JIRA_CLI / CONFLUENCE_CLI override the resolved CLI path.
+    if [ "$matched_service" = "jira" ] && [ -n "${JIRA_CLI:-}" ]; then
+        cli_bin="$JIRA_CLI"
     fi
-done <<EOF
+    if [ "$matched_service" = "confluence" ] && [ -n "${CONFLUENCE_CLI:-}" ]; then
+        cli_bin="$CONFLUENCE_CLI"
+    fi
+
+    if [ ! -f "$cli_bin" ] && ! command -v "$cli_bin" >/dev/null 2>&1; then
+        return 0
+    fi
+    commands=$(invoke_cli "$cli_bin") || return 0
+    [ -z "$commands" ] && return 0
+
+    # Block iff the mapped verb is present — exact whole-line match. Strip only
+    # CR/LF/TAB (NOT internal spaces) from both the verb and each introspected
+    # line, so multi-word verbs like "page get" survive. Jira verbs have no
+    # internal spaces, so this is a no-op for them.
+    verb="${verb//[$'\t\r\n']/}"
+    verb_present=0
+    while IFS= read -r line; do
+        line="${line//[$'\t\r\n']/}"
+        if [ "$line" = "$verb" ]; then
+            verb_present=1
+            break
+        fi
+    done <<EOF
 $commands
 EOF
+    [ "$verb_present" -eq 1 ] || return 0
 
-[ "$verb_present" -eq 1 ] || exit 0
-
-# ---------------------------------------------------------------------------
-# Build refusal message and block (exit 2)
-# ---------------------------------------------------------------------------
-replacement=$(replacement_for "$matched_service" "$verb")
-
-# Determine bypass var names for the message.
-# bypass_var (MCP_${svc_upper}_OK) is already set above and is used for the
-# copy-pasteable command example.  For jira, the legacy alias MCP_JIRA_OK is
-# the same value (svc_upper=JIRA), so no alias note is needed.
-# bypass_var_alias holds an optional parenthetical alias note (non-empty only
-# when the service has a well-known alternative name).
-bypass_var_alias=""
-# Currently no service has a *different* alias var; the old jira display was
-# "MCP_JIRA_OK (or MCP_JIRA_OK)" which was redundant and garbled.  Leave the
-# slot here for future services that genuinely need one.
-
-api_advisory=""
-if [ "$api_in_chain" -eq 1 ]; then
-    api_advisory="
+    # Build refusal message and block (return 2).
+    replacement=$(replacement_for "$matched_service" "$verb")
+    bypass_var_alias=""
+    api_advisory=""
+    if [ "$api_in_chain" -eq 1 ]; then
+        api_advisory="
 For ops the CLI lacks, prefer raw REST (curl/WebFetch) before falling back to MCP.
 "
-fi
+    fi
+    bypass_launch="${bypass_var}=1 claude"
+    {
+        printf 'block-backend-tier: refusing MCP call "%s".\n\n' "$tool_name"
+        printf '%s plugin has an equivalent — use it instead:\n\n' "$matched_service"
+        printf '    %s\n' "$replacement"
+        if [ -n "$api_advisory" ]; then
+            printf '\n%s\n' "$api_advisory"
+        fi
+        printf '\nWhy: the plugin is one shell call with --help schema, far fewer tokens than\n'
+        printf 'the MCP schema fetch + response, and dogfoods code we ship. Routing is\n'
+        printf 'governed by scripts/backends.json (chain: %s, cli ranked above mcp).\n\n' "$matched_chain"
+        if [ -n "$bypass_var_alias" ]; then
+            printf 'Bypass for a genuine carve-out: set %s=1 (or %s=1)\n' "$bypass_var" "$bypass_var_alias"
+        else
+            printf 'Bypass for a genuine carve-out: set %s=1\n' "$bypass_var"
+        fi
+        printf 'in the shell that launched Claude Code. Per-call prefix does not work;\n'
+        printf 'the bypass lasts the session. Restart without the var to re-enable.\n\n'
+        printf '    %s\n\n' "$bypass_launch"
+        printf 'Or temporarily comment the hook stanza in .claude/settings.json.\n'
+    } >&2
+    return 2
+}
 
-# Use printf to avoid unquoted heredoc expansion of untrusted tool_name content.
-# All user-data variables are passed as %s arguments, not embedded in a format string.
-bypass_launch="${bypass_var}=1 claude"
-{
-    printf 'block-backend-tier: refusing MCP call "%s".\n\n' "$tool_name"
-    printf '%s plugin has an equivalent — use it instead:\n\n' "$matched_service"
-    printf '    %s\n' "$replacement"
-    if [ -n "$api_advisory" ]; then
-        printf '\n%s\n' "$api_advisory"
-    fi
-    printf '\nWhy: the plugin is one shell call with --help schema, far fewer tokens than\n'
-    printf 'the MCP schema fetch + response, and dogfoods code we ship. Routing is\n'
-    printf 'governed by scripts/backends.json (chain: %s, cli ranked above mcp).\n\n' "$matched_chain"
-    if [ -n "$bypass_var_alias" ]; then
-        printf 'Bypass for a genuine carve-out: set %s=1 (or %s=1)\n' "$bypass_var" "$bypass_var_alias"
+# ---------------------------------------------------------------------------
+# Evaluate EVERY service whose mcp_prefix matches tool_name (no break-on-first:
+# jira + confluence share the Atlassian prefix). Block on the first matching
+# service whose mapped verb its CLI has; otherwise continue. Jira/Confluence
+# method suffixes are disjoint, so at most one service maps a given suffix.
+# ---------------------------------------------------------------------------
+while IFS='|' read -r svc_name svc_enabled svc_mcp_prefix svc_cli svc_chain; do
+    # Strip \r — jq on Windows may produce CRLF output.
+    svc_name="${svc_name//$'\r'/}"
+    svc_enabled="${svc_enabled//$'\r'/}"
+    svc_mcp_prefix="${svc_mcp_prefix//$'\r'/}"
+    svc_cli="${svc_cli//$'\r'/}"
+    svc_chain="${svc_chain//$'\r'/}"
+
+    [ -z "$svc_name" ] && continue
+    [ "$svc_enabled" = "false" ] && continue
+    [ -z "$svc_mcp_prefix" ] && continue
+
+    # Skip services whose prefix does not match this tool_name.
+    case "$tool_name" in
+        "${svc_mcp_prefix}"*) ;;
+        *) continue ;;
+    esac
+
+    if evaluate_service "$svc_name" "$svc_chain" "$svc_cli" "$svc_mcp_prefix"; then
+        : # returned 0 → no block for this service, try the next match
     else
-        printf 'Bypass for a genuine carve-out: set %s=1\n' "$bypass_var"
+        rc=$?
+        [ "$rc" -eq 2 ] && exit 2
     fi
-    printf 'in the shell that launched Claude Code. Per-call prefix does not work;\n'
-    printf 'the bypass lasts the session. Restart without the var to re-enable.\n\n'
-    printf '    %s\n\n' "$bypass_launch"
-    printf 'Or temporarily comment the hook stanza in .claude/settings.json.\n'
-} >&2
-exit 2
+done <<EOF
+$services_list
+EOF
+
+# No matching service blocked → allow
+exit 0

--- a/scripts/hooks/test-block-backend-tier.sh
+++ b/scripts/hooks/test-block-backend-tier.sh
@@ -67,6 +67,17 @@ STUB_EMPTY="$TMPDIR_TEST/cli-empty.js"
 STUB_TRANS_ONLY="$TMPDIR_TEST/cli-transitions-only.js"
 make_stub "$STUB_TRANS_ONLY" get transitions
 
+# Confluence CLI stub (HIMMEL-437). Page verbs are MULTI-WORD ("page get") and
+# MUST be passed quoted so make_stub emits them as single lines — this is what
+# exercises the introspection strip fix (CR/LF/TAB stripped, internal space kept).
+STUB_CONF="$TMPDIR_TEST/cli-confluence.js"
+make_stub "$STUB_CONF" "page get" "page create" "page update" "page delete" \
+    search spaces comments comment attachments attach download
+
+# Reduced confluence stub: no 'page get', no 'search' → those routes fail open.
+STUB_CONF_REDUCED="$TMPDIR_TEST/cli-confluence-reduced.js"
+make_stub "$STUB_CONF_REDUCED" spaces comments
+
 # --- Registry fixture helpers -----------------------------------------------
 # write_registry <path> <json> — write a fixture backends.json.
 write_registry() {
@@ -127,12 +138,13 @@ run_case() {
     local input="$1"
     local cli="${2:-$STUB_FULL}"
     local extra_env="${3:-}"
-    # Build env: always set JIRA_CLI for backward compat seam.
-    local cmd_env="JIRA_CLI=$cli"
+    local conf="${4:-$STUB_CONF}"
+    # Build env: set both CLI seams so routing is deterministic regardless of
+    # whether a built dist/confluence.js exists at the resolved repo root.
     if [ -n "$extra_env" ]; then
-        printf '%s' "$input" | env "$cmd_env" "$extra_env" bash "$HOOK" >/dev/null 2>&1
+        printf '%s' "$input" | env "JIRA_CLI=$cli" "CONFLUENCE_CLI=$conf" "$extra_env" bash "$HOOK" >/dev/null 2>&1
     else
-        printf '%s' "$input" | env "$cmd_env" bash "$HOOK" >/dev/null 2>&1
+        printf '%s' "$input" | env "JIRA_CLI=$cli" "CONFLUENCE_CLI=$conf" bash "$HOOK" >/dev/null 2>&1
     fi
     echo "$?"
 }
@@ -159,9 +171,9 @@ assert_rc() {
 }
 
 assert_stderr_contains() {
-    local label="$1" input="$2" needle="$3" cli="${4:-$STUB_FULL}"
+    local label="$1" input="$2" needle="$3" cli="${4:-$STUB_FULL}" conf="${5:-$STUB_CONF}"
     local out
-    out=$(printf '%s' "$input" | env "JIRA_CLI=$cli" bash "$HOOK" 2>&1 >/dev/null || true)
+    out=$(printf '%s' "$input" | env "JIRA_CLI=$cli" "CONFLUENCE_CLI=$conf" bash "$HOOK" 2>&1 >/dev/null || true)
     case "$out" in
         *"$needle"*) echo "PASS $label" ;;
         *)
@@ -220,14 +232,15 @@ assert_stderr_contains "stderr names 'link' verb" \
     '{"tool_name":"mcp__plugin_atlassian_atlassian__createIssueLink","tool_input":{}}' \
     'jira/dist/index.js link'
 
-# --- Allowed Atlassian tools (no verb in the map → no plugin equivalent) ---
+# --- Allowed Atlassian tools (no verb in EITHER map → no plugin equivalent) ---
+# NOTE: the Confluence page/search/spaces/comment methods are NO LONGER here —
+# they now route to the confluence CLI (see the Confluence section below).
 for tool in lookupJiraAccountId getJiraIssueTypeMetaWithFields \
             getJiraProjectIssueTypesMetadata getIssueLinkTypes \
             addWorklogToJiraIssue atlassianUserInfo \
             getAccessibleAtlassianResources fetch search \
             getJiraIssueRemoteIssueLinks \
-            getConfluencePage createConfluencePage updateConfluencePage \
-            getConfluenceSpaces searchConfluenceUsingCql; do
+            getConfluencePageInlineComments createConfluenceInlineComment; do
     rc=$(run_case "{\"tool_name\":\"mcp__plugin_atlassian_atlassian__${tool}\",\"tool_input\":{}}")
     assert_rc "allow $tool" 0 "$rc"
 done
@@ -372,6 +385,92 @@ case "$out_no_api" in
         echo "PASS chain without api tier: api advisory absent from stderr"
         ;;
 esac
+
+# ============================================================================
+# 3. CONFLUENCE ROUTING (HIMMEL-437) — two services share the Atlassian prefix
+# ============================================================================
+
+echo ""
+echo "=== Confluence routing (HIMMEL-437) ==="
+
+# The confluence SERVICE must be in the active registry for it to be evaluated.
+# A repo backends.json (resolved via CLAUDE_PROJECT_DIR) may predate this change,
+# so force the CODE DEFAULTS path (which includes confluence) via a missing
+# BACKENDS_REGISTRY — identical to the "absent registry" jira case above — and
+# point both CLI seams at the stubs.
+# run a confluence case through forced code-defaults; $1=input, $2=confluence stub.
+run_case_conf() {
+    local input="$1" conf="${2:-$STUB_CONF}"
+    printf '%s' "$input" \
+        | env "BACKENDS_REGISTRY=$REG_MISSING" "JIRA_CLI=$STUB_FULL" "CONFLUENCE_CLI=$conf" bash "$HOOK" >/dev/null 2>&1
+    echo "$?"
+}
+
+# Registry FILE that includes BOTH atlassian services (mirrors the real
+# scripts/backends.json after HIMMEL-437). Exercises the registry-file path —
+# the one that actually runs in production — not just the code-defaults path.
+REG_ATLASSIAN_BOTH="$TMPDIR_TEST/reg-atlassian-both.json"
+write_registry "$REG_ATLASSIAN_BOTH" "{
+  \"jira\": {
+    \"enabled\": true,
+    \"mcp_prefix\": \"mcp__plugin_atlassian_atlassian__\",
+    \"cli\": \"${STUB_FULL}\",
+    \"chain\": [\"cli\", \"api\", \"mcp\"]
+  },
+  \"confluence\": {
+    \"enabled\": true,
+    \"mcp_prefix\": \"mcp__plugin_atlassian_atlassian__\",
+    \"cli\": \"${STUB_CONF}\",
+    \"chain\": [\"cli\", \"api\", \"mcp\"]
+  }
+}"
+
+# Block each Confluence MCP method whose mapped verb the confluence CLI has.
+# getConfluencePage → "page get" exercises the multi-word strip fix (Step 5).
+for tool in getConfluencePage createConfluencePage updateConfluencePage \
+            searchConfluenceUsingCql getConfluenceSpaces \
+            getConfluencePageFooterComments createConfluenceFooterComment; do
+    rc=$(run_case_conf "{\"tool_name\":\"mcp__plugin_atlassian_atlassian__${tool}\",\"tool_input\":{}}")
+    assert_rc "block $tool (confluence verb present)" 2 "$rc"
+done
+
+# Multi-word verb survives whitespace strip: getConfluencePage → "page get".
+out=$(printf '%s' '{"tool_name":"mcp__plugin_atlassian_atlassian__getConfluencePage","tool_input":{}}' \
+    | env "BACKENDS_REGISTRY=$REG_MISSING" "JIRA_CLI=$STUB_FULL" "CONFLUENCE_CLI=$STUB_CONF" bash "$HOOK" 2>&1 >/dev/null || true)
+case "$out" in
+    *"confluence.js page get"*) echo "PASS stderr names confluence 'page get' verb" ;;
+    *) echo "FAIL stderr names confluence 'page get' verb"; echo "--- got ---"; echo "$out"; echo "-----------"; FAILED=$((FAILED + 1)) ;;
+esac
+
+# Allow when the confluence CLI lacks the mapped verb (reduced stub: no 'page get').
+rc=$(run_case_conf '{"tool_name":"mcp__plugin_atlassian_atlassian__getConfluencePage","tool_input":{}}' "$STUB_CONF_REDUCED")
+assert_rc "allow getConfluencePage when confluence CLI lacks 'page get'" 0 "$rc"
+
+# Jira call is still routed to the jira CLI and NOT shadowed by the confluence arm.
+out=$(printf '%s' '{"tool_name":"mcp__plugin_atlassian_atlassian__getJiraIssue","tool_input":{}}' \
+    | env "BACKENDS_REGISTRY=$REG_MISSING" "JIRA_CLI=$STUB_FULL" "CONFLUENCE_CLI=$STUB_CONF" bash "$HOOK" 2>&1 >/dev/null || true)
+case "$out" in
+    *"jira/dist/index.js get"*) echo "PASS jira call names jira CLI (not confluence)" ;;
+    *) echo "FAIL jira call names jira CLI (not confluence)"; echo "--- got ---"; echo "$out"; echo "-----------"; FAILED=$((FAILED + 1)) ;;
+esac
+
+# Per-service bypass for confluence (generic MCP_<SERVICE>_OK eval path).
+rc=$(printf '%s' '{"tool_name":"mcp__plugin_atlassian_atlassian__getConfluencePage","tool_input":{}}' \
+    | env "BACKENDS_REGISTRY=$REG_MISSING" "CONFLUENCE_CLI=$STUB_CONF" MCP_CONFLUENCE_OK=1 bash "$HOOK" >/dev/null 2>&1; echo "$?")
+assert_rc "MCP_CONFLUENCE_OK=1 per-service bypass" 0 "$rc"
+
+# REGISTRY-FILE path (production): drive a Confluence call through a registry
+# that includes the confluence service — this is the path that runs when
+# scripts/backends.json exists. Guards against the backends.json entry being
+# dropped (the code-defaults cases above would still pass without it).
+rc=$(printf '%s' '{"tool_name":"mcp__plugin_atlassian_atlassian__getConfluencePage","tool_input":{}}' \
+    | env "BACKENDS_REGISTRY=$REG_ATLASSIAN_BOTH" bash "$HOOK" >/dev/null 2>&1; echo "$?")
+assert_rc "registry-file path: block getConfluencePage (confluence service in registry)" 2 "$rc"
+
+# The jira service in the SAME shared-prefix registry still blocks (loop covers both).
+rc=$(printf '%s' '{"tool_name":"mcp__plugin_atlassian_atlassian__getJiraIssue","tool_input":{}}' \
+    | env "BACKENDS_REGISTRY=$REG_ATLASSIAN_BOTH" bash "$HOOK" >/dev/null 2>&1; echo "$?")
+assert_rc "registry-file path: block getJiraIssue (jira not shadowed by confluence)" 2 "$rc"
 
 # ============================================================================
 # Summary

--- a/scripts/jira/CLAUDE.md
+++ b/scripts/jira/CLAUDE.md
@@ -8,6 +8,10 @@ restated here.
 The Jira CLI itself (`jira-cli`). Run from repo root as
 `node scripts/jira/dist/index.js <op>`. ESM (`"type": "module"`),
 arg-parsing via `commander`. One file per op in `src/commands/`.
+A second binary ships from the same package: the **Confluence CLI**
+(`node scripts/jira/dist/confluence.js <op>`, entry `src/confluence.ts`,
+ops under `src/commands/confluence/`) — shares `client.ts` auth + ADF
+helpers (HIMMEL-437).
 
 ## Editing conventions
 - **`dist/` is gitignored — not committed.** After editing `src/`, run

--- a/scripts/jira/package.json
+++ b/scripts/jira/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "type": "module",
   "bin": {
-    "jira": "./dist/index.js"
+    "jira": "./dist/index.js",
+    "confluence": "./dist/confluence.js"
   },
   "scripts": {
     "build": "tsc",

--- a/scripts/jira/src/client.test.ts
+++ b/scripts/jira/src/client.test.ts
@@ -157,3 +157,71 @@ describe('baseUrl', () => {
     expect(message).not.toMatch(/yotamleo/);
   });
 });
+
+describe('requestAt base composition (HIMMEL-437)', () => {
+  const origBase = process.env.JIRA_BASE_URL;
+  afterEach(() => {
+    if (origBase === undefined) delete process.env.JIRA_BASE_URL; else process.env.JIRA_BASE_URL = origBase;
+    vi.restoreAllMocks();
+  });
+
+  it('prefixes the apiBase + path onto baseUrl for each named helper', async () => {
+    process.env.JIRA_BASE_URL = 'https://x.example';
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, text: async () => '{}' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { agileRequest, confluenceV2, confluenceV1 } = await import('./client.js');
+    await agileRequest('GET', '/board');
+    await confluenceV2('GET', '/pages/1');
+    await confluenceV1('GET', '/search');
+    expect(fetchMock.mock.calls[0][0]).toBe('https://x.example/rest/agile/1.0/board');
+    expect(fetchMock.mock.calls[1][0]).toBe('https://x.example/wiki/api/v2/pages/1');
+    expect(fetchMock.mock.calls[2][0]).toBe('https://x.example/wiki/rest/api/search');
+  });
+});
+
+describe('confluenceAuthHeader (HIMMEL-437)', () => {
+  const keys = ['JIRA_EMAIL', 'JIRA_API_TOKEN', 'CONFLUENCE_EMAIL', 'CONFLUENCE_API_TOKEN'];
+  const orig: Record<string, string | undefined> = {};
+  for (const k of keys) orig[k] = process.env[k];
+  afterEach(() => {
+    for (const k of keys) {
+      if (orig[k] === undefined) delete process.env[k]; else process.env[k] = orig[k];
+    }
+  });
+
+  it('uses CONFLUENCE_* creds when both are set', async () => {
+    process.env.JIRA_EMAIL = 'j@x'; process.env.JIRA_API_TOKEN = 'jtok';
+    process.env.CONFLUENCE_EMAIL = 'c@x'; process.env.CONFLUENCE_API_TOKEN = 'ctok';
+    const { confluenceAuthHeader } = await import('./client.js');
+    expect(confluenceAuthHeader()).toBe(`Basic ${Buffer.from('c@x:ctok').toString('base64')}`);
+  });
+
+  it('falls back to JIRA_* creds when CONFLUENCE_* is not fully set', async () => {
+    process.env.JIRA_EMAIL = 'j@x'; process.env.JIRA_API_TOKEN = 'jtok';
+    delete process.env.CONFLUENCE_EMAIL; delete process.env.CONFLUENCE_API_TOKEN;
+    const { confluenceAuthHeader, authHeader } = await import('./client.js');
+    expect(confluenceAuthHeader()).toBe(authHeader());
+  });
+});
+
+describe('resolveAccountId (HIMMEL-437)', () => {
+  const origBase = process.env.JIRA_BASE_URL;
+  afterEach(() => {
+    if (origBase === undefined) delete process.env.JIRA_BASE_URL; else process.env.JIRA_BASE_URL = origBase;
+    vi.restoreAllMocks();
+  });
+
+  it('returns the input unchanged when it has no @ (accountId passthrough)', async () => {
+    const { resolveAccountId } = await import('./client.js');
+    expect(await resolveAccountId('5b10ac8d82e05b22cc7d4ef5')).toBe('5b10ac8d82e05b22cc7d4ef5');
+  });
+
+  it('looks up an email and returns the first accountId', async () => {
+    process.env.JIRA_BASE_URL = 'https://x.example';
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, text: async () => '[{"accountId":"abc"}]' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { resolveAccountId } = await import('./client.js');
+    expect(await resolveAccountId('a@b.com')).toBe('abc');
+    expect(decodeURIComponent(String(fetchMock.mock.calls[0][0]))).toContain('/user/search?query=a@b.com');
+  });
+});

--- a/scripts/jira/src/client.ts
+++ b/scripts/jira/src/client.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, dirname } from 'node:path';
 
 function repoRoot(): string {
@@ -50,6 +50,9 @@ export function normalizeEnv(): void {
     'JIRA_API_TOKEN',
     'JIRA_PROJECT_KEY',
     'JIRA_SEVERITY_FIELD',
+    'JIRA_BOARD_ID',
+    'CONFLUENCE_EMAIL',
+    'CONFLUENCE_API_TOKEN',
   ]) {
     const raw = process.env[key];
     if (raw === undefined) continue;
@@ -98,22 +101,41 @@ export const projectKey = (): string => {
 export const severityField = (): string | undefined =>
   process.env.JIRA_SEVERITY_FIELD || undefined;
 
+export const boardId = (): string | undefined =>
+  process.env.JIRA_BOARD_ID || undefined;
+
 export function authHeader(): string {
   const email = process.env.JIRA_EMAIL ?? '';
   const token = process.env.JIRA_API_TOKEN ?? '';
   return `Basic ${Buffer.from(`${email}:${token}`).toString('base64')}`;
 }
 
-export async function request<T>(
+// Confluence often needs its OWN Atlassian token: a *scoped* Jira API token
+// 401s against /wiki (Confluence), same as the bitbucket CLI needs a separate
+// scoped token. Use CONFLUENCE_EMAIL/CONFLUENCE_API_TOKEN when BOTH are set;
+// otherwise fall back to the Jira creds (works when JIRA_API_TOKEN is a
+// scopeless/full-account token covering both products).
+export function confluenceAuthHeader(): string {
+  const email = process.env.CONFLUENCE_EMAIL;
+  const token = process.env.CONFLUENCE_API_TOKEN;
+  if (email && token) {
+    return `Basic ${Buffer.from(`${email}:${token}`).toString('base64')}`;
+  }
+  return authHeader();
+}
+
+export async function requestAt<T>(
+  apiBase: string,
   method: string,
   path: string,
   body?: unknown,
+  auth: string = authHeader(),
 ): Promise<T> {
-  const url = `${baseUrl()}/rest/api/3${path}`;
+  const url = `${baseUrl()}${apiBase}${path}`;
   const res = await fetch(url, {
     method,
     headers: {
-      Authorization: authHeader(),
+      Authorization: auth,
       'Content-Type': 'application/json',
       Accept: 'application/json',
     },
@@ -127,22 +149,32 @@ export async function request<T>(
   return (text.trim() ? JSON.parse(text) : {}) as T;
 }
 
-export async function uploadAttachment(
-  issueKey: string,
+export const request = <T>(method: string, path: string, body?: unknown) =>
+  requestAt<T>('/rest/api/3', method, path, body);
+export const agileRequest = <T>(method: string, path: string, body?: unknown) =>
+  requestAt<T>('/rest/agile/1.0', method, path, body);
+export const confluenceV2 = <T>(method: string, path: string, body?: unknown) =>
+  requestAt<T>('/wiki/api/v2', method, path, body, confluenceAuthHeader());
+export const confluenceV1 = <T>(method: string, path: string, body?: unknown) =>
+  requestAt<T>('/wiki/rest/api', method, path, body, confluenceAuthHeader());
+
+export async function uploadMultipart(
+  url: string,
   filePath: string,
+  field = 'file',
+  auth: string = authHeader(),
 ): Promise<unknown> {
   if (!existsSync(filePath)) {
     throw new Error(`attachment not found: ${filePath}`);
   }
   const data = readFileSync(filePath);
   const fd = new FormData();
-  fd.append('file', new Blob([data]), basename(filePath));
+  fd.append(field, new Blob([data]), basename(filePath));
 
-  const url = `${baseUrl()}/rest/api/3/issue/${issueKey}/attachments`;
   const res = await fetch(url, {
     method: 'POST',
     headers: {
-      Authorization: authHeader(),
+      Authorization: auth,
       'X-Atlassian-Token': 'no-check',
       // intentionally NO Content-Type — fetch must set multipart boundary
     },
@@ -154,4 +186,43 @@ export async function uploadAttachment(
   }
   const text = await res.text();
   return text.trim() ? JSON.parse(text) : {};
+}
+
+// Back-compat wrapper: Jira issue attachment upload composes its own URL.
+export function uploadAttachment(issueKey: string, filePath: string): Promise<unknown> {
+  return uploadMultipart(
+    `${baseUrl()}/rest/api/3/issue/${issueKey}/attachments`,
+    filePath,
+  );
+}
+
+export async function downloadTo(fullUrl: string, outPath: string, auth: string = authHeader()): Promise<number> {
+  const res = await fetch(fullUrl, { headers: { Authorization: auth } });
+  if (!res.ok) {
+    const text = (await res.text()).slice(0, 500);
+    throw new Error(`HTTP ${res.status}: ${text}`);
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  writeFileSync(outPath, buf);
+  return buf.length;
+}
+
+// Jira accountIds are 24-hex or "<provider>:<uuid>"; an '@' means it's an email.
+export async function resolveAccountId(emailOrId: string): Promise<string> {
+  if (!emailOrId.includes('@')) return emailOrId;
+  const users = await request<Array<{ accountId: string }>>(
+    'GET',
+    `/user/search?query=${encodeURIComponent(emailOrId)}`,
+  );
+  if (!users.length) throw new Error(`no Jira user found for "${emailOrId}"`);
+  return users[0].accountId;
+}
+
+export async function resolveSpaceId(spaceKey: string): Promise<string> {
+  const r = await confluenceV2<{ results: Array<{ id: string }> }>(
+    'GET',
+    `/spaces?keys=${encodeURIComponent(spaceKey)}`,
+  );
+  if (!r.results?.length) throw new Error(`no Confluence space with key "${spaceKey}"`);
+  return r.results[0].id;
 }

--- a/scripts/jira/src/commands/assign.test.ts
+++ b/scripts/jira/src/commands/assign.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildAssignBody } from './assign.js';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('assign', () => {
+  it('clears the assignee for "-"/"unassigned"/"none"', async () => {
+    for (const u of ['-', 'unassigned', 'none']) {
+      expect(await buildAssignBody(u)).toEqual({ accountId: null });
+    }
+  });
+  it('uses default assignee for "auto"/"-1"', async () => {
+    for (const u of ['auto', '-1']) {
+      expect(await buildAssignBody(u)).toEqual({ accountId: '-1' });
+    }
+  });
+  it('passes a raw accountId through', async () => {
+    expect(await buildAssignBody('5b10ac8d82e05b22cc7d4ef5')).toEqual({
+      accountId: '5b10ac8d82e05b22cc7d4ef5',
+    });
+  });
+  it('resolves an email to an accountId', async () => {
+    process.env.JIRA_BASE_URL = 'https://x.example';
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true, status: 200, text: async () => '[{"accountId":"abc"}]',
+    })));
+    expect(await buildAssignBody('a@b.com')).toEqual({ accountId: 'abc' });
+  });
+});

--- a/scripts/jira/src/commands/assign.ts
+++ b/scripts/jira/src/commands/assign.ts
@@ -1,0 +1,20 @@
+import type { Command } from 'commander';
+import { request, resolveAccountId } from '../client.js';
+
+export async function buildAssignBody(user: string): Promise<{ accountId: string | null }> {
+  const u = user.trim().toLowerCase();
+  if (u === '-' || u === 'unassigned' || u === 'none') return { accountId: null };
+  if (u === 'auto' || u === '-1') return { accountId: '-1' };
+  return { accountId: await resolveAccountId(user) };
+}
+
+export function registerAssign(program: Command): void {
+  program
+    .command('assign <key> <user>')
+    .description('Set the assignee (email or accountId; "-"/"unassigned" clears, "auto" = default)')
+    .action(async (key: string, user: string) => {
+      const body = await buildAssignBody(user);
+      await request('PUT', `/issue/${key}/assignee`, body);
+      console.log(`${key} assigned to ${body.accountId ?? '(unassigned)'}`);
+    });
+}

--- a/scripts/jira/src/commands/attachments.test.ts
+++ b/scripts/jira/src/commands/attachments.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { pickAttachments } from './attachments.js';
+
+const issue = { fields: { attachment: [
+  { id: '1', filename: 'a.png' },
+  { id: '2', filename: 'b.pdf' },
+] } };
+
+describe('download selection', () => {
+  it('selects one by id', () => {
+    expect(pickAttachments(issue, '2', false)).toEqual([{ id: '2', filename: 'b.pdf' }]);
+  });
+  it('selects all with --all', () => {
+    expect(pickAttachments(issue, undefined, true)).toHaveLength(2);
+  });
+  it('throws when id not found', () => {
+    expect(() => pickAttachments(issue, '9', false)).toThrow(/no attachment/i);
+  });
+  it('throws on duplicate filenames in --all', () => {
+    const dup = { fields: { attachment: [
+      { id: '1', filename: 'x' }, { id: '2', filename: 'x' },
+    ] } };
+    expect(() => pickAttachments(dup, undefined, true)).toThrow(/duplicate filename/i);
+  });
+});

--- a/scripts/jira/src/commands/attachments.ts
+++ b/scripts/jira/src/commands/attachments.ts
@@ -1,0 +1,57 @@
+import { join, basename } from 'node:path';
+import type { Command } from 'commander';
+import { request, downloadTo, baseUrl } from '../client.js';
+
+interface Attachment { id: string; filename: string; size?: number; author?: { displayName: string }; created?: string; }
+interface IssueAttachments { fields: { attachment?: Attachment[] } }
+
+export function pickAttachments(
+  issue: IssueAttachments,
+  idArg: string | undefined,
+  all: boolean,
+): Attachment[] {
+  const list = issue.fields.attachment ?? [];
+  if (all) {
+    const names = new Set<string>();
+    for (const a of list) {
+      if (names.has(a.filename)) throw new Error(`duplicate filename "${a.filename}" — cannot --all into one dir`);
+      names.add(a.filename);
+    }
+    return list;
+  }
+  if (!idArg) throw new Error('download requires an attachment id or --all');
+  const hit = list.find((a) => a.id === idArg);
+  if (!hit) throw new Error(`no attachment with id ${idArg} on the issue`);
+  return [hit];
+}
+
+export function registerAttachments(program: Command): void {
+  program
+    .command('attachments <key>')
+    .description('List attachments on an issue')
+    .action(async (key: string) => {
+      const issue = await request<IssueAttachments>('GET', `/issue/${key}?fields=attachment`);
+      const list = issue.fields.attachment ?? [];
+      if (!list.length) { console.log(`${key}: no attachments`); return; }
+      for (const a of list) {
+        console.log(`${a.id}\t${a.filename}\t${a.size ?? '?'}b\t${a.author?.displayName ?? ''}`);
+      }
+    });
+
+  program
+    .command('download <key> [attachmentId]')
+    .description('Download one attachment (by id) or --all from an issue')
+    .option('--all', 'Download every attachment')
+    .option('--out <dir>', 'Output directory (default cwd)', '.')
+    .action(async (key: string, attachmentId: string | undefined, opts: { all?: boolean; out: string }) => {
+      const issue = await request<IssueAttachments>('GET', `/issue/${key}?fields=attachment`);
+      const picked = pickAttachments(issue, attachmentId, Boolean(opts.all));
+      for (const a of picked) {
+        // basename() the server-supplied filename so a malicious/odd name
+        // (e.g. containing ../) cannot write outside --out.
+        const out = join(opts.out, basename(a.filename));
+        const n = await downloadTo(`${baseUrl()}/rest/api/3/attachment/content/${a.id}`, out);
+        console.log(`${out} (${n}b)`);
+      }
+    });
+}

--- a/scripts/jira/src/commands/confluence/attachments.test.ts
+++ b/scripts/jira/src/commands/confluence/attachments.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { pickPageAttachments } from './attachments.js';
+
+const list = [
+  { id: 'att1', title: 'a.png', downloadLink: '/download/att/1' },
+  { id: 'att2', title: 'b.pdf', downloadLink: '/download/att/2' },
+];
+
+describe('confluence attachment selection', () => {
+  it('selects one by id', () => {
+    expect(pickPageAttachments(list, 'att2', false)).toEqual([list[1]]);
+  });
+  it('selects all with --all', () => {
+    expect(pickPageAttachments(list, undefined, true)).toHaveLength(2);
+  });
+  it('throws on a missing id', () => {
+    expect(() => pickPageAttachments(list, 'nope', false)).toThrow(/no attachment/i);
+  });
+  it('throws on duplicate titles in --all', () => {
+    const dup = [{ id: '1', title: 'x', downloadLink: '/a' }, { id: '2', title: 'x', downloadLink: '/b' }];
+    expect(() => pickPageAttachments(dup, undefined, true)).toThrow(/duplicate filename/i);
+  });
+});

--- a/scripts/jira/src/commands/confluence/attachments.ts
+++ b/scripts/jira/src/commands/confluence/attachments.ts
@@ -1,0 +1,52 @@
+import { join, basename } from 'node:path';
+import type { Command } from 'commander';
+import { confluenceV2, uploadMultipart, downloadTo, baseUrl, confluenceAuthHeader } from '../../client.js';
+
+interface PageAttachment { id: string; title: string; downloadLink: string }
+
+export function pickPageAttachments(list: PageAttachment[], idArg: string | undefined, all: boolean): PageAttachment[] {
+  if (all) {
+    const names = new Set<string>();
+    for (const a of list) {
+      if (names.has(a.title)) throw new Error(`duplicate filename "${a.title}" — cannot --all into one dir`);
+      names.add(a.title);
+    }
+    return list;
+  }
+  if (!idArg) throw new Error('download requires an attachment id or --all');
+  const hit = list.find((a) => a.id === idArg);
+  if (!hit) throw new Error(`no attachment with id ${idArg} on the page`);
+  return [hit];
+}
+
+export function registerAttachments(program: Command): void {
+  program.command('attachments <pageId>')
+    .description('List attachments on a page')
+    .action(async (pageId: string) => {
+      const r = await confluenceV2<{ results: PageAttachment[] }>('GET', `/pages/${pageId}/attachments`);
+      for (const a of r.results ?? []) console.log(`${a.id}\t${a.title}`);
+    });
+  program.command('attach <pageId> <paths...>')
+    .description('Upload file(s) as page attachments')
+    .action(async (pageId: string, paths: string[]) => {
+      // v1 multipart upload — caller composes the full URL (no v2 upload endpoint).
+      const url = `${baseUrl()}/wiki/rest/api/content/${pageId}/child/attachment`;
+      let n = 0;
+      for (const p of paths) { await uploadMultipart(url, p, 'file', confluenceAuthHeader()); n++; }
+      console.log(`Attached ${n} file(s) to page ${pageId}`);
+    });
+  program.command('download <pageId> [attachmentId]')
+    .description('Download one page attachment (by id) or --all')
+    .option('--all', 'Download every attachment')
+    .option('--out <dir>', 'Output directory (default cwd)', '.')
+    .action(async (pageId: string, attachmentId: string | undefined, opts: { all?: boolean; out: string }) => {
+      const r = await confluenceV2<{ results: PageAttachment[] }>('GET', `/pages/${pageId}/attachments`);
+      const picked = pickPageAttachments(r.results ?? [], attachmentId, Boolean(opts.all));
+      for (const a of picked) {
+        // basename() guards against a server-supplied title escaping --out.
+        const out = join(opts.out, basename(a.title));
+        const n = await downloadTo(`${baseUrl()}${a.downloadLink}`, out, confluenceAuthHeader()); // downloadLink is /wiki/...-rooted
+        console.log(`${out} (${n}b)`);
+      }
+    });
+}

--- a/scripts/jira/src/commands/confluence/comment.test.ts
+++ b/scripts/jira/src/commands/confluence/comment.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { buildCommentBody } from './comment.js';
+
+const adf = { type: 'doc', version: 1, content: [] };
+
+describe('confluence comment', () => {
+  it('puts pageId at top level alongside the body', () => {
+    expect(buildCommentBody('123', adf)).toEqual({
+      pageId: '123',
+      body: { representation: 'atlas_doc_format', value: JSON.stringify(adf) },
+    });
+  });
+});

--- a/scripts/jira/src/commands/confluence/comment.ts
+++ b/scripts/jira/src/commands/confluence/comment.ts
@@ -1,0 +1,37 @@
+import type { Command } from 'commander';
+import { confluenceV2 } from '../../client.js';
+import { markdownToAdf } from '../../adf.js';
+import { readBodyFile } from '../body-file.js';
+import { adfToPlainText } from '../../adf-render.js';
+
+type Adf = ReturnType<typeof markdownToAdf>;
+
+export function buildCommentBody(pageId: string, adf: Adf): Record<string, unknown> {
+  return { pageId, body: { representation: 'atlas_doc_format', value: JSON.stringify(adf) } };
+}
+
+interface CommentV2 { id: string; body?: { atlas_doc_format?: { value: string } } }
+
+export function registerComment(program: Command): void {
+  program.command('comments <pageId>')
+    .description('List footer comments on a page')
+    .action(async (pageId: string) => {
+      const r = await confluenceV2<{ results: CommentV2[] }>(
+        'GET', `/pages/${pageId}/footer-comments?body-format=atlas_doc_format`);
+      for (const c of r.results ?? []) {
+        const raw = c.body?.atlas_doc_format?.value;
+        console.log(`--- ${c.id} ---`);
+        if (raw) console.log(adfToPlainText(JSON.parse(raw)));
+      }
+    });
+  program.command('comment <pageId> [text]')
+    .description('Add a footer comment to a page (markdown)')
+    .option('--body-file <path>', 'Markdown comment file (overrides [text])')
+    .action(async (pageId: string, text: string | undefined, opts: { bodyFile?: string }) => {
+      const md = opts.bodyFile ? readBodyFile(opts.bodyFile, '--body-file') : text;
+      if (md === undefined) { console.error('comment requires [text] or --body-file'); process.exit(1); }
+      const r = await confluenceV2<{ id: string }>('POST', '/footer-comments',
+        buildCommentBody(pageId, markdownToAdf(md)));
+      console.log(`Added comment ${r.id} to page ${pageId}`);
+    });
+}

--- a/scripts/jira/src/commands/confluence/page-get.test.ts
+++ b/scripts/jira/src/commands/confluence/page-get.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { pageGetPath } from './page-get.js';
+
+describe('page get', () => {
+  it('requests the atlas_doc_format body by id', () => {
+    expect(pageGetPath('123')).toBe('/pages/123?body-format=atlas_doc_format');
+  });
+});

--- a/scripts/jira/src/commands/confluence/page-get.ts
+++ b/scripts/jira/src/commands/confluence/page-get.ts
@@ -1,0 +1,26 @@
+import type { Command } from 'commander';
+import { confluenceV2 } from '../../client.js';
+import { adfToPlainText } from '../../adf-render.js';
+
+export function pageGetPath(id: string): string {
+  return `/pages/${id}?body-format=atlas_doc_format`;
+}
+
+interface PageV2 {
+  id: string; title: string; spaceId: string;
+  version?: { number: number };
+  body?: { atlas_doc_format?: { value: string } };
+  _links?: { webui?: string };
+}
+
+export function registerPageGet(page: Command): void {
+  page.command('get <id>')
+    .description('Get a Confluence page (renders body as text)')
+    .action(async (id: string) => {
+      const p = await confluenceV2<PageV2>('GET', pageGetPath(id));
+      console.log(`# ${p.title}`);
+      console.log(`id=${p.id} space=${p.spaceId} version=${p.version?.number ?? '?'}`);
+      const raw = p.body?.atlas_doc_format?.value;
+      if (raw) console.log('\n' + adfToPlainText(JSON.parse(raw)));
+    });
+}

--- a/scripts/jira/src/commands/confluence/page-write.test.ts
+++ b/scripts/jira/src/commands/confluence/page-write.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { buildCreateBody, buildUpdateBody } from './page-write.js';
+
+const adf = { type: 'doc', version: 1, content: [] };
+
+describe('confluence page write', () => {
+  it('builds a create body with atlas_doc_format', () => {
+    const b = buildCreateBody({ spaceId: '99', title: 'T', adf });
+    expect(b).toMatchObject({
+      spaceId: '99', status: 'current', title: 'T',
+      body: { representation: 'atlas_doc_format', value: JSON.stringify(adf) },
+    });
+  });
+  it('includes parentId when given', () => {
+    expect(buildCreateBody({ spaceId: '99', title: 'T', adf, parentId: '5' }).parentId).toBe('5');
+  });
+  it('bumps the version on update', () => {
+    const b = buildUpdateBody({ id: '1', currentVersion: 4, title: 'T', adf });
+    expect(b).toMatchObject({ id: '1', status: 'current', title: 'T', version: { number: 5 } });
+  });
+  it('omits the body on a title-only update (no adf)', () => {
+    const b = buildUpdateBody({ id: '1', currentVersion: 4, title: 'T' });
+    expect(b).not.toHaveProperty('body');
+    expect(b).toMatchObject({ id: '1', title: 'T', version: { number: 5 } });
+  });
+});

--- a/scripts/jira/src/commands/confluence/page-write.ts
+++ b/scripts/jira/src/commands/confluence/page-write.ts
@@ -1,0 +1,68 @@
+import type { Command } from 'commander';
+import { confluenceV2, resolveSpaceId } from '../../client.js';
+import { markdownToAdf } from '../../adf.js';
+import { readBodyFile } from '../body-file.js';
+
+type Adf = ReturnType<typeof markdownToAdf>;
+
+export function buildCreateBody(p: { spaceId: string; title: string; adf: Adf; parentId?: string }): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    spaceId: p.spaceId, status: 'current', title: p.title,
+    body: { representation: 'atlas_doc_format', value: JSON.stringify(p.adf) },
+  };
+  if (p.parentId) body.parentId = p.parentId;
+  return body;
+}
+
+export function buildUpdateBody(p: { id: string; currentVersion: number; title: string; adf?: Adf }): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    id: p.id, status: 'current', title: p.title, version: { number: p.currentVersion + 1 },
+  };
+  if (p.adf) body.body = { representation: 'atlas_doc_format', value: JSON.stringify(p.adf) };
+  return body;
+}
+
+interface PageMeta { title: string; version?: { number: number } }
+
+export function registerPageWrite(page: Command): void {
+  page.command('create')
+    .description('Create a Confluence page (body from markdown file)')
+    .requiredOption('--space <key>', 'Space key')
+    .requiredOption('--title <t>', 'Page title')
+    .requiredOption('--body-file <path>', 'Markdown body file (converted to ADF)')
+    .option('--parent <id>', 'Parent page id')
+    .action(async (opts: { space: string; title: string; bodyFile: string; parent?: string }) => {
+      const spaceId = await resolveSpaceId(opts.space);
+      const adf = markdownToAdf(readBodyFile(opts.bodyFile, '--body-file'));
+      const r = await confluenceV2<{ id: string }>('POST', '/pages',
+        buildCreateBody({ spaceId, title: opts.title, adf, parentId: opts.parent }));
+      console.log(`Created page ${r.id}`);
+    });
+  page.command('update <id>')
+    .description('Update a Confluence page (auto version-bump)')
+    .option('--title <t>', 'New title (defaults to existing)')
+    .option('--body-file <path>', 'New markdown body file')
+    .action(async (id: string, opts: { title?: string; bodyFile?: string }) => {
+      if (opts.title === undefined && opts.bodyFile === undefined) {
+        console.error('page update requires --title and/or --body-file');
+        process.exit(1);
+      }
+      const cur = await confluenceV2<PageMeta>('GET', `/pages/${id}`);
+      // Don't fabricate a version: a wrong number → opaque 409. Fail clearly.
+      const currentVersion = cur.version?.number;
+      if (currentVersion === undefined) {
+        throw new Error(`could not determine current version of page ${id}`);
+      }
+      const adf = opts.bodyFile ? markdownToAdf(readBodyFile(opts.bodyFile, '--body-file')) : undefined;
+      await confluenceV2('PUT', `/pages/${id}`, buildUpdateBody({
+        id, currentVersion, title: opts.title ?? cur.title, adf,
+      }));
+      console.log(`Updated page ${id}`);
+    });
+  page.command('delete <id>')
+    .description('Delete (trash) a Confluence page')
+    .action(async (id: string) => {
+      await confluenceV2('DELETE', `/pages/${id}`);
+      console.log(`Deleted page ${id}`);
+    });
+}

--- a/scripts/jira/src/commands/confluence/search.test.ts
+++ b/scripts/jira/src/commands/confluence/search.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { searchPath } from './search.js';
+
+describe('confluence search', () => {
+  it('builds the v1 CQL search path with encoded cql + limit', () => {
+    expect(searchPath('type=page AND text~"x"', 10)).toBe(
+      '/search?cql=type%3Dpage%20AND%20text~%22x%22&limit=10',
+    );
+  });
+});

--- a/scripts/jira/src/commands/confluence/search.ts
+++ b/scripts/jira/src/commands/confluence/search.ts
@@ -1,0 +1,28 @@
+import type { Command } from 'commander';
+import { confluenceV1, confluenceV2 } from '../../client.js';
+
+export function searchPath(cql: string, limit: number): string {
+  return `/search?cql=${encodeURIComponent(cql)}&limit=${limit}`;
+}
+
+export function registerSearch(program: Command): void {
+  program.command('search')
+    .description('Search Confluence with CQL')
+    .requiredOption('--cql <cql>', 'CQL query, e.g. \'type=page AND text~"foo"\'')
+    .option('--limit <n>', 'Max results', '25')
+    .action(async (opts: { cql: string; limit: string }) => {
+      const r = await confluenceV1<{ results: Array<{ content?: { id: string; title: string; type: string } }> }>(
+        'GET', searchPath(opts.cql, Number(opts.limit)));
+      for (const hit of r.results ?? []) {
+        if (hit.content) console.log(`${hit.content.id}\t${hit.content.type}\t${hit.content.title}`);
+      }
+    });
+  program.command('spaces')
+    .description('List Confluence spaces')
+    .option('--limit <n>', 'Max results', '25')
+    .action(async (opts: { limit: string }) => {
+      const r = await confluenceV2<{ results: Array<{ id: string; key: string; name: string }> }>(
+        'GET', `/spaces?limit=${Number(opts.limit)}`);
+      for (const s of r.results ?? []) console.log(`${s.id}\t${s.key}\t${s.name}`);
+    });
+}

--- a/scripts/jira/src/commands/sprint.test.ts
+++ b/scripts/jira/src/commands/sprint.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { sprintTarget, resolveBoard } from './sprint.js';
+
+afterEach(() => { delete process.env.JIRA_BOARD_ID; });
+
+describe('sprint helpers', () => {
+  it('parses a backlog target', () => {
+    expect(sprintTarget('backlog')).toEqual({ backlog: true });
+  });
+  it('parses a numeric sprint id', () => {
+    expect(sprintTarget('42')).toEqual({ backlog: false, sprintId: '42' });
+  });
+  it('resolveBoard prefers --board', () => {
+    expect(resolveBoard('5')).toBe('5');
+  });
+  it('resolveBoard falls back to JIRA_BOARD_ID', () => {
+    process.env.JIRA_BOARD_ID = '7';
+    expect(resolveBoard(undefined)).toBe('7');
+  });
+  it('resolveBoard throws when neither set', () => {
+    expect(() => resolveBoard(undefined)).toThrow(/board/i);
+  });
+});

--- a/scripts/jira/src/commands/sprint.ts
+++ b/scripts/jira/src/commands/sprint.ts
@@ -1,0 +1,44 @@
+import type { Command } from 'commander';
+import { agileRequest, boardId } from '../client.js';
+
+export function resolveBoard(optBoard?: string): string {
+  const b = optBoard ?? boardId();
+  if (!b) throw new Error('sprints needs --board <id> or the JIRA_BOARD_ID env var');
+  return b;
+}
+
+export function sprintTarget(target: string): { backlog: boolean; sprintId?: string } {
+  if (target.trim().toLowerCase() === 'backlog') return { backlog: true };
+  return { backlog: false, sprintId: target };
+}
+
+export function registerSprint(program: Command): void {
+  program.command('boards')
+    .description('List Agile boards (id, name, type)')
+    .action(async () => {
+      const r = await agileRequest<{ values: Array<{ id: number; name: string; type: string }> }>(
+        'GET', '/board');
+      for (const b of r.values ?? []) console.log(`${b.id}\t${b.type}\t${b.name}`);
+    });
+  program.command('sprints')
+    .description('List sprints for a board')
+    .option('--board <id>', 'Board id (default: JIRA_BOARD_ID)')
+    .action(async (opts: { board?: string }) => {
+      const board = resolveBoard(opts.board);
+      const r = await agileRequest<{ values: Array<{ id: number; name: string; state: string }> }>(
+        'GET', `/board/${board}/sprint`);
+      for (const s of r.values ?? []) console.log(`${s.id}\t${s.state}\t${s.name}`);
+    });
+  program.command('sprint <key> <target>')
+    .description('Move an issue to a sprint id, or to the backlog')
+    .action(async (key: string, target: string) => {
+      const t = sprintTarget(target);
+      if (t.backlog) {
+        await agileRequest('POST', '/backlog/issue', { issues: [key] });
+        console.log(`${key} moved to backlog`);
+      } else {
+        await agileRequest('POST', `/sprint/${t.sprintId}/issue`, { issues: [key] });
+        console.log(`${key} moved to sprint ${t.sprintId}`);
+      }
+    });
+}

--- a/scripts/jira/src/commands/watchers.test.ts
+++ b/scripts/jira/src/commands/watchers.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { watcherDeletePath } from './watchers.js';
+
+describe('watchers', () => {
+  it('builds the DELETE path with an encoded accountId', () => {
+    expect(watcherDeletePath('HIMMEL-1', 'abc:1/2')).toBe(
+      '/issue/HIMMEL-1/watchers?accountId=abc%3A1%2F2',
+    );
+  });
+});

--- a/scripts/jira/src/commands/watchers.ts
+++ b/scripts/jira/src/commands/watchers.ts
@@ -1,0 +1,35 @@
+import type { Command } from 'commander';
+import { request, resolveAccountId } from '../client.js';
+
+export function watcherDeletePath(key: string, accountId: string): string {
+  return `/issue/${key}/watchers?accountId=${encodeURIComponent(accountId)}`;
+}
+
+async function selfAccountId(): Promise<string> {
+  const me = await request<{ accountId: string }>('GET', '/myself');
+  return me.accountId;
+}
+
+export function registerWatchers(program: Command): void {
+  program.command('watch <key> [user]')
+    .description('Add a watcher (default: yourself)')
+    .action(async (key: string, user?: string) => {
+      const accountId = user ? await resolveAccountId(user) : await selfAccountId();
+      await request('POST', `/issue/${key}/watchers`, accountId);
+      console.log(`Watching ${key} as ${accountId}`);
+    });
+  program.command('unwatch <key> [user]')
+    .description('Remove a watcher (default: yourself)')
+    .action(async (key: string, user?: string) => {
+      const accountId = user ? await resolveAccountId(user) : await selfAccountId();
+      await request('DELETE', watcherDeletePath(key, accountId));
+      console.log(`Unwatched ${key} for ${accountId}`);
+    });
+  program.command('watchers <key>')
+    .description('List watchers on an issue')
+    .action(async (key: string) => {
+      const r = await request<{ watchers: Array<{ accountId: string; displayName: string }> }>(
+        'GET', `/issue/${key}/watchers`);
+      for (const w of r.watchers ?? []) console.log(`${w.accountId}\t${w.displayName}`);
+    });
+}

--- a/scripts/jira/src/commands/worklog.test.ts
+++ b/scripts/jira/src/commands/worklog.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { buildWorklogBody } from './worklog.js';
+
+describe('worklog', () => {
+  it('requires time spent', () => {
+    expect(() => buildWorklogBody({ time: '' })).toThrow(/time/i);
+  });
+  it('builds a timeSpent-only body', () => {
+    expect(buildWorklogBody({ time: '1h 30m' })).toEqual({ timeSpent: '1h 30m' });
+  });
+  it('adds an ADF comment when given', () => {
+    const b = buildWorklogBody({ time: '2h', comment: 'work' });
+    expect(b.timeSpent).toBe('2h');
+    expect((b.comment as { type: string }).type).toBe('doc');
+  });
+  it('passes started through', () => {
+    const b = buildWorklogBody({ time: '1h', started: '2026-06-20T10:00:00.000+0000' });
+    expect(b.started).toBe('2026-06-20T10:00:00.000+0000');
+  });
+});

--- a/scripts/jira/src/commands/worklog.ts
+++ b/scripts/jira/src/commands/worklog.ts
@@ -1,0 +1,34 @@
+import type { Command } from 'commander';
+import { request } from '../client.js';
+import { markdownToAdf } from '../adf.js';
+
+export function buildWorklogBody(opts: { time: string; comment?: string; started?: string }): Record<string, unknown> {
+  if (!opts.time || !opts.time.trim()) throw new Error('worklog add requires --time (e.g. "1h 30m")');
+  const body: Record<string, unknown> = { timeSpent: opts.time };
+  if (opts.comment !== undefined) body.comment = markdownToAdf(opts.comment);
+  if (opts.started !== undefined) body.started = opts.started;
+  return body;
+}
+
+interface Worklog { id: string; timeSpent: string; author?: { displayName: string }; started?: string }
+
+export function registerWorklog(program: Command): void {
+  const wl = program.command('worklog').description('Worklog operations');
+  wl.command('add <key>')
+    .description('Log work on an issue')
+    .requiredOption('--time <t>', 'Time spent, Jira format (e.g. "1h 30m")')
+    .option('--comment <c>', 'Worklog comment (markdown)')
+    .option('--started <iso>', 'Start time, Jira ISO (e.g. 2026-06-20T10:00:00.000+0000)')
+    .action(async (key: string, opts: { time: string; comment?: string; started?: string }) => {
+      await request('POST', `/issue/${key}/worklog`, buildWorklogBody(opts));
+      console.log(`Logged ${opts.time} on ${key}`);
+    });
+  wl.command('list <key>')
+    .description('List worklog entries on an issue')
+    .action(async (key: string) => {
+      const r = await request<{ worklogs: Worklog[] }>('GET', `/issue/${key}/worklog`);
+      for (const w of r.worklogs ?? []) {
+        console.log(`${w.id}\t${w.timeSpent}\t${w.author?.displayName ?? ''}\t${w.started ?? ''}`);
+      }
+    });
+}

--- a/scripts/jira/src/confluence.ts
+++ b/scripts/jira/src/confluence.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { registerPageGet } from './commands/confluence/page-get.js';
+import { registerPageWrite } from './commands/confluence/page-write.js';
+import { registerSearch } from './commands/confluence/search.js';
+import { registerComment } from './commands/confluence/comment.js';
+import { registerAttachments } from './commands/confluence/attachments.js';
+
+const program = new Command();
+program.name('confluence').version('1.0.0').description('Confluence CLI for himmel project');
+
+const page = program.command('page').description('Page operations');
+registerPageGet(page);
+registerPageWrite(page);
+
+registerSearch(program);
+registerComment(program);
+registerAttachments(program);
+
+// Machine-readable command introspection (mirrors index.ts). Emits one verb
+// path per line so block-backend-tier.sh can map Confluence MCP methods to CLI
+// verbs. Top-level verbs emit bare (search, spaces, …); page verbs emit
+// space-joined (page get, …). The routing hook's _CONFLUENCE_VERB_METHOD_MAP
+// must use these exact strings.
+if (process.argv.includes('--list-commands')) {
+  const walk = (cmd: Command, prefix: string): void => {
+    for (const c of cmd.commands) {
+      if (c.name() === 'help') continue; // commander auto-adds help — don't emit it
+      const name = `${prefix}${c.name()}`;
+      if (c.commands.length) walk(c, `${name} `);
+      else console.log(name);
+    }
+  };
+  walk(program, '');
+  process.exit(0);
+}
+
+program.parseAsync(process.argv).catch((err: Error) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/scripts/jira/src/index.ts
+++ b/scripts/jira/src/index.ts
@@ -12,6 +12,11 @@ import { registerMove } from './commands/move.js';
 import { registerProjects } from './commands/projects.js';
 import { registerProjectCreate } from './commands/project-create.js';
 import { registerLink } from './commands/link.js';
+import { registerAssign } from './commands/assign.js';
+import { registerAttachments } from './commands/attachments.js';
+import { registerWorklog } from './commands/worklog.js';
+import { registerWatchers } from './commands/watchers.js';
+import { registerSprint } from './commands/sprint.js';
 
 const program = new Command();
 
@@ -32,6 +37,11 @@ registerMove(program);
 registerProjects(program);
 registerProjectCreate(program);
 registerLink(program);
+registerAssign(program);
+registerAttachments(program);
+registerWorklog(program);
+registerWatchers(program);
+registerSprint(program);
 
 // HIMMEL-159: expose the CLI verbs over the Model Context Protocol on stdio.
 // The MCP SDK is heavy, so import it lazily inside the action — keeping it out


### PR DESCRIPTION
New Jira verbs (assign/attachments+download/worklog/watch+watchers/boards+sprints+sprint) and a sibling confluence CLI (page CRUD/search/spaces/comments/attachments, v2-primary). Routing hook extended for the shared Atlassian prefix. Mirror of private HIMMEL-437.