### PR TITLE
feat(hermes): land update leg on public + venv pip self-heal

### DIFF
--- a/docs/hermes-runbook.md
+++ b/docs/hermes-runbook.md
@@ -17,6 +17,19 @@ repo) so a machine rebuild can reproduce it.
 - Hermes reads its OWN `.env` (`%LOCALAPPDATA%\hermes\.env`) — shell
   env and himmel's repo-root `.env` are irrelevant to it.
 
+## Keeping it updated (HIMMEL-426)
+
+`hermes-agent` is an **editable git checkout** (`pip install -e`) of
+`NousResearch/hermes-agent` living at `<install-root>/hermes-agent`, so a
+himmel `git pull` never updates it. `/himmel-update` (and `/himmel-update-all`)
+now pulls that checkout and re-runs the editable install as one of its steps;
+`/himmel-update --check` reports whether a hermes update is available without
+applying it. The step resolves the install root from `HERMES_HOME` (else
+`%LOCALAPPDATA%\hermes`) and operates on its `hermes-agent/` subdir; it skips
+cleanly and never fails the himmel update when hermes isn't installed. After an
+update, **restart the hermes gateway** (`hermes gateway restart`, when no
+session is running) to pick up changes.
+
 ## Provider routes (wired 2026-06-12, HIMMEL-278)
 
 Routing policy per the ticket: free routes first, fail-open down the
@@ -35,15 +48,20 @@ providers: {}
 fallback_providers:
 - provider: openrouter
   model: nvidia/nemotron-3-ultra-550b-a55b:free
-- provider: gemini
-  model: gemini-flash-latest
 ```
+
+> **2026-06-19 — gemini route removed.** The AI Studio API project behind
+> `GEMINI_API_KEY`/`GOOGLE_API_KEY` was suspended by Google (Gemini API ToS /
+> Prohibited Use Policy). The `gemini`/`gemini-flash-latest` fallback was
+> dropped from the live config; chain is now NIM primary → OpenRouter only.
+> Re-add only with a fresh, working Gemini API key (paid project — the free
+> tier is unavailable in the EEA).
 
 | # | Route | Provider name | Model | Key (env name in hermes `.env`) | Why this position |
 |---|-------|---------------|-------|--------------------------------|-------------------|
 | 1 (primary) | NVIDIA NIM | `nvidia` (built-in; aliases `nim`, `nemotron`) | `nvidia/nemotron-3-ultra-550b-a55b` | `NVIDIA_API_KEY` | Free NIM credits; current Nemotron Ultra flagship. NIM model ids ARE vendor-prefixed — `hermes doctor`'s "vendor-prefixed slug" warning is a false-positive heuristic here. |
 | 2 | OpenRouter | `openrouter` (built-in) | `nvidia/nemotron-3-ultra-550b-a55b:free` | `OPENROUTER_API_KEY` | Same model via a different aggregator — NIM quota/outage fallback keeps behavior comparable. |
-| 3 | Gemini API | `gemini` (built-in; reads `GOOGLE_API_KEY` or `GEMINI_API_KEY`) | `gemini-flash-latest` (rolling alias) | `GOOGLE_API_KEY` | Key exists but is scarce (already showed a 429 in `hermes auth list`) — deliberately last. |
+| ~~3~~ | ~~Gemini API~~ | `gemini` (built-in; reads `GOOGLE_API_KEY` or `GEMINI_API_KEY`) | `gemini-flash-latest` (rolling alias) | `GOOGLE_API_KEY` | **REMOVED 2026-06-19** — AI Studio project suspended (see note above). Was deliberately last (scarce key, 429s). |
 
 Not wired, with reasons (recorded so a rebuild doesn't "fix" them):
 
@@ -55,7 +73,7 @@ Not wired, with reasons (recorded so a rebuild doesn't "fix" them):
 - **gemini-cli / OAuth routes** — VOIDED by operator (HIMMEL-277);
   do not re-add.
 
-`providers: {}` stays empty on purpose: all three routes are built-in
+`providers: {}` stays empty on purpose: both routes are built-in
 provider names, so endpoint + key-env resolution comes from hermes's
 internal registry; a `providers:` entry is only needed for custom
 endpoints or per-provider timeout overrides.
@@ -68,9 +86,9 @@ user message.
 ## Verify after a rebuild (zero inference cost)
 
 ```
-hermes fallback list   # chain resolves: nvidia primary + 2 fallbacks
+hermes fallback list   # chain resolves: nvidia primary + 1 fallback
 hermes auth list       # one credential per provider, sourced from env
-hermes doctor          # API Connectivity: ✓ OpenRouter ✓ NVIDIA NIM ✓ gemini
+hermes doctor          # API Connectivity: ✓ OpenRouter ✓ NVIDIA NIM
 ```
 
 Then one paid-nothing smoke: `hermes --cli -z "Reply with exactly: OK"`
@@ -78,5 +96,23 @@ Then one paid-nothing smoke: `hermes --cli -z "Reply with exactly: OK"`
 start — restart it (`hermes gateway restart`, when no session is
 running) to pick up route changes.
 
-Wiring verified 2026-06-12: all three connectivity probes green;
+## Recover a broken venv pip ("No module named pip")
+
+uv-created venvs (the default hermes install uses `uv venv`) ship **without
+pip**, so the editable refresh — and any manual `pip install -e .` — fails
+with `No module named pip`. `/himmel-update` now bootstraps pip
+automatically (`ensurepip`) before the refresh; to repair by hand (older
+checkout, or the gateway is misbehaving after a pull):
+
+```
+# <venv-py> = …/hermes/hermes-agent/venv/Scripts/python.exe  (Windows)
+#             …/hermes/hermes-agent/venv/bin/python           (macOS/Linux)
+"<venv-py>" -m ensurepip --upgrade      # restore pip into the venv
+cd …/hermes/hermes-agent
+"<venv-py>" -m pip install -e .          # editable reinstall (picks up pulled code)
+hermes gateway restart                   # restart the gateway to load the changes
+```
+
+Wiring verified 2026-06-12: all connectivity probes green (3 routes at the
+time; gemini route removed 2026-06-19 — see note above, now 2);
 config backup at `config.yaml.bak.20260612_overnight`.

--- a/docs/setup/updating.md
+++ b/docs/setup/updating.md
@@ -88,3 +88,8 @@ Plain `git pull` works too if you don't need the marketplace re-sync.
   pinned `@himmel` source **operator-present, in a fresh session**:
   `bash scripts/machine-setup/migrate-plugin-to-himmel.sh --apply <name@market> …`
   (it mutates `settings.json` via `claude plugin`, so it is an operator step).
+  Run it from a shell where the `claude` CLI is on `PATH` — on Windows that is
+  PowerShell, **not** a bare Git Bash (which exits `ERROR: claude CLI required
+  on PATH`). The external marketplace can silently re-appear later (its
+  `autoUpdate` re-adds it), so re-run the migrate whenever `--plugins-check`
+  flags the shadow again.

--- a/scripts/himmel-update.sh
+++ b/scripts/himmel-update.sh
@@ -102,6 +102,86 @@ EOF
     return 0
 }
 
+# ─── hermes junior-tier update (HIMMEL-426) ──────────────────────────────────
+# Hermes (NousResearch/hermes-agent) is an EDITABLE install from a local git
+# checkout (default %LOCALAPPDATA%/hermes/hermes-agent), NOT a himmel plugin and
+# NOT in this repo — so `git pull` of this checkout never updates it. This step
+# pulls that checkout and refreshes the editable install. Operator-personal +
+# à-la-carte: absent on most machines, so it skips cleanly and is always
+# best-effort (never fails the himmel update). HERMES_HOME (install root) /
+# HERMES_PY (venv python) override the defaults; HERMES_PY mirrors
+# scripts/hermes/invoke.sh resolution.
+update_hermes() {
+    local mode="$1"   # check | apply
+    # HERMES_HOME is the hermes install ROOT (the runbook + operator env set it
+    # to %LOCALAPPDATA%\hermes) — config + venv + the editable git checkout, the
+    # last living in the hermes-agent/ subdir. So the checkout we pull is
+    # $root/hermes-agent. Default root: %LOCALAPPDATA%\hermes. We also tolerate
+    # HERMES_HOME pointing straight at the checkout (… /.git) for robustness.
+    local root="${HERMES_HOME:-}"
+    [ -n "$root" ] || root="${LOCALAPPDATA:-$HOME/AppData/Local}/hermes"
+    local src="$root/hermes-agent"
+    [ -d "$src/.git" ] || { [ -d "$root/.git" ] && src="$root"; }
+
+    echo ""
+    echo "==> hermes junior-tier update"
+    if [ ! -d "$src/.git" ]; then
+        echo "    skip: hermes not installed as a git checkout ($src) — see docs/hermes-runbook.md."
+        return 0
+    fi
+    if ! git -C "$src" remote get-url origin 2>/dev/null | grep -q "NousResearch/hermes-agent"; then
+        echo "    skip: $src is not a NousResearch/hermes-agent checkout — leaving it alone."
+        return 0
+    fi
+
+    if [ "$mode" = "check" ]; then
+        if ! git -C "$src" fetch -q origin 2>/dev/null; then
+            echo "    skip: could not reach origin (offline?)."
+            return 0
+        fi
+        local here there
+        here=$(git -C "$src" rev-parse @ 2>/dev/null || echo "?")
+        there=$(git -C "$src" rev-parse '@{u}' 2>/dev/null || echo "")
+        if [ -n "$there" ] && [ "$here" != "$there" ]; then
+            echo "    update available — run /himmel-update (no --check) to pull + reinstall."
+        else
+            echo "    hermes is current."
+        fi
+        return 0
+    fi
+
+    # apply
+    if ! git -C "$src" pull --ff-only; then
+        echo "    warn: hermes git pull was not fast-forward (local edits / diverged?) — resolve in $src." >&2
+        return 0
+    fi
+    local py="${HERMES_PY:-}"
+    if [ -z "$py" ]; then
+        if   [ -x "$src/venv/Scripts/python.exe" ]; then py="$src/venv/Scripts/python.exe"
+        elif [ -x "$src/venv/bin/python" ];        then py="$src/venv/bin/python"
+        fi
+    fi
+    if [ -n "$py" ] && [ -x "$py" ]; then
+        # uv-created venvs ship WITHOUT pip (uv venv default), so a plain
+        # `$py -m pip install` fails with "No module named pip". Bootstrap pip
+        # via stdlib ensurepip first — best-effort, harmless if pip is present.
+        "$py" -m pip --version >/dev/null 2>&1 \
+            || "$py" -m ensurepip --upgrade >/dev/null 2>&1 \
+            || echo "    warn: could not bootstrap pip in the hermes venv (ensurepip failed) — see docs/hermes-runbook.md." >&2
+        echo "    refreshing editable install (deps may have changed)…"
+        "$py" -m pip install -e "$src" --quiet \
+            || echo "    warn: pip editable refresh failed (non-fatal) — see docs/hermes-runbook.md (recover a broken venv pip) if hermes misbehaves." >&2
+    else
+        echo "    note: hermes venv python not found — code pulled, but run 'pip install -e .' in the venv if pyproject changed."
+    fi
+    return 0
+}
+
+# Test seam: source with HIMMEL_UPDATE_LIB=1 to load the functions above without
+# running any update mode (lets test-himmel-update-hermes.sh call update_hermes
+# directly with HERMES_HOME fixtures — no network, no repo mutation).
+[ "${HIMMEL_UPDATE_LIB:-}" = "1" ] && return 0
+
 # ─── --plugins-check mode ────────────────────────────────────────────────────
 # Just the plugin install-state report; no git, no network. Exit 0 always.
 if [ "${1:-}" = "--plugins-check" ]; then
@@ -135,6 +215,7 @@ if [ "${1:-}" = "--check" ] || [ "${1:-}" = "--dry-run" ]; then
         echo "status:   $behind commit(s) behind — run /himmel-update (or bash scripts/himmel-update.sh) to pull."
     fi
     report_plugin_gap
+    update_hermes check
     exit 0
 fi
 
@@ -162,7 +243,11 @@ else
     echo "update: claude CLI not on PATH — skipping marketplace re-sync." >&2
 fi
 
-# 3. Report any himmel-marketplace plugins not installed from @himmel — the
+# 3. Update the hermes junior tier (separate editable git checkout outside this
+#    repo — see update_hermes). Best-effort; skips cleanly when hermes is absent.
+update_hermes apply
+
+# 4. Report any himmel-marketplace plugins not installed from @himmel — the
 #    marketplace re-sync above can't surface these (it only touches plugins that
 #    are already installed). Advisory; never fails the update.
 report_plugin_gap
@@ -173,4 +258,6 @@ cat <<'EOF'
     - Hooks are live immediately (PreToolUse/etc. re-read from disk per call).
     - Plugins / slash commands / skills load at session start — RESTART any
       running Claude session to pick them up.
+    - hermes (if installed) was pulled + reinstalled; restart its gateway to
+      pick up changes (docs/hermes-runbook.md).
 EOF

--- a/scripts/test-himmel-update-hermes.sh
+++ b/scripts/test-himmel-update-hermes.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Smoke test for update_hermes() in himmel-update.sh (HIMMEL-426). Sources the
+# script via its HIMMEL_UPDATE_LIB seam so the function runs in isolation with
+# HERMES_HOME fixtures — no network, no repo mutation.
+set -uo pipefail
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+HIMMEL_UPDATE_LIB=1 . "$HERE/himmel-update.sh"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+fail=0
+
+check() {  # <description> <expected-substring> <actual-output>
+  if printf '%s' "$3" | grep -Eq "$2"; then
+    echo "ok: $1"
+  else
+    echo "FAIL: $1"; echo "  expected /$2/ in:"; printf '%s\n' "$3" | sed 's/^/    /'
+    fail=1
+  fi
+}
+
+# HERMES_HOME is the install ROOT; the git checkout is its hermes-agent/ subdir.
+
+# Case 1: install root with no hermes-agent checkout → "not installed" skip.
+out=$(HERMES_HOME="$tmp/nope" update_hermes check 2>&1)
+check "absent hermes skips" "skip: hermes not installed as a git checkout" "$out"
+
+# Case 2: hermes-agent/ checkout with a foreign remote → "not a … checkout" skip
+# (returns before any fetch/pull, so this stays offline).
+git init -q "$tmp/other/hermes-agent"
+git -C "$tmp/other/hermes-agent" remote add origin https://github.com/x/y.git
+out=$(HERMES_HOME="$tmp/other" update_hermes apply 2>&1)
+check "foreign checkout skips" "is not a NousResearch/hermes-agent checkout" "$out"
+
+# Case 3: NousResearch hermes-agent/ checkout, check mode, fetch unreachable →
+# graceful handling (offline / current / update-available), never crash/push.
+git init -q "$tmp/install/hermes-agent"
+git -C "$tmp/install/hermes-agent" remote add origin https://github.com/NousResearch/hermes-agent.git
+out=$(HERMES_HOME="$tmp/install" update_hermes check 2>&1)
+check "nous checkout check handled" "could not reach origin|hermes is current|update available" "$out"
+
+# Case 4: HERMES_HOME pointing STRAIGHT at the checkout (…/.git present) is
+# tolerated — same NousResearch handling.
+git init -q "$tmp/direct"
+git -C "$tmp/direct" remote add origin https://github.com/NousResearch/hermes-agent.git
+out=$(HERMES_HOME="$tmp/direct" update_hermes check 2>&1)
+check "direct checkout tolerated" "could not reach origin|hermes is current|update available" "$out"
+
+if [ "$fail" -eq 0 ]; then
+  echo "PASS: himmel-update hermes smoke test"
+else
+  echo "FAILED"; exit 1
+fi


### PR DESCRIPTION
Propagates the hermes junior-tier update leg (HIMMEL-426) to public — it
had never been shipped here — plus the venv-pip self-heal, the 2026-06-19
gemini-route removal in the runbook (HIMMEL-277), and a claude-obsidian
migrate PATH note.

Private parity merged as himmel-private#627. CR clean (free critic panel,
0 Critical / 0 Important). Leak scan clean (telegram-token + denylist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
