### PR TITLE
feat(overnight): standing operator actions in the morning report

### DIFF
--- a/docs/handover/overnight-mode.md
+++ b/docs/handover/overnight-mode.md
@@ -104,6 +104,16 @@ batched into a single entry point. Work the decisions block first, then
 review PRs in report order (`/pr-check`). Merging stays human — only the
 review *surface* is batched.
 
+**Standing operator actions (HIMMEL-450).** The report is *regenerated* every
+run, so a one-off note elsewhere won't resurface. Durable manual actions —
+especially **single-session-only** ones (e.g. a history rewrite) — go in
+`<handover-root>/operator-actions.md`; `morning-report.sh` appends them verbatim
+as a `## Standing operator actions` section to *every* report until you delete
+them. Use plain bullets (not headings — they'd compete with the report's H2s);
+absent or blank ⇒ no section. The run-end command relies on the default path
+(`<dirname report>/operator-actions.md`) — no `--actions` flag needed. With no
+overnight run, just read the file directly; it's plain markdown.
+
 ## Budget (informational)
 
 - **Subagent dispatches:** ~50-60 per overnight run. Per phase 3, impl is ~3 subagents per task (implementer + 2 reviewers); a 16-task plan = ~48 just for impl. Add ~6-12 for phase 5 heavy CR over 1-2 rounds, plus fix-batch dispatches (5-10).

--- a/scripts/overnight/morning-report.sh
+++ b/scripts/overnight/morning-report.sh
@@ -43,11 +43,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 ROWS_FILE=""
 OUT_FILE=""
+ACTIONS_FILE=""
 DRY_RUN=0
 
 usage() {
     cat <<'EOF'
-Usage: morning-report.sh [--rows FILE] [--out PATH] [--dry-run]
+Usage: morning-report.sh [--rows FILE] [--out PATH] [--actions FILE] [--dry-run]
 
 Reads one TSV row per dispatched ticket (stdin by default):
 
@@ -63,6 +64,11 @@ Optional:
                 <handover-root>/overnight-report-YYYY-MM-DD.md, resolved
                 via handover_root_ensure (scripts/lib/handover-path.sh).
                 A broken HANDOVER_DIR fails closed (exit 2) — no fallback.
+  --actions FILE  Standing operator actions appended verbatim as a
+                "## Standing operator actions" section. Default:
+                <dirname OUT_FILE>/operator-actions.md. A durable list that
+                survives every regeneration (one-off notes elsewhere do not
+                resurface in a regenerated report). Skipped when absent/blank.
   --dry-run     Print the report to stdout; touch no files.
 
 Environment overrides:
@@ -78,6 +84,9 @@ while [ $# -gt 0 ]; do
         --out)
             [ -n "${2:-}" ] || { echo "ERR morning-report: --out requires a PATH" >&2; exit 1; }
             OUT_FILE="$2"; shift 2 ;;
+        --actions)
+            [ -n "${2:-}" ] || { echo "ERR morning-report: --actions requires a FILE" >&2; exit 1; }
+            ACTIONS_FILE="$2"; shift 2 ;;
         --dry-run) DRY_RUN=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *)         echo "ERR morning-report: unknown arg: $1" >&2; usage >&2; exit 1 ;;
@@ -164,6 +173,18 @@ if [ -z "$OUT_FILE" ]; then
     fi
 fi
 
+# Resolve standing operator actions. Default sits next to the report so it
+# follows the same handover-root resolution. Read verbatim (markdown), strip
+# CRs (CRLF-edited files on Windows), and treat whitespace-only as absent.
+if [ -z "$ACTIONS_FILE" ]; then
+    ACTIONS_FILE="$(dirname "$OUT_FILE")/operator-actions.md"
+fi
+actions_body=""
+if [ -f "$ACTIONS_FILE" ]; then
+    actions_body=$(tr -d '\r' < "$ACTIONS_FILE")
+    printf '%s' "$actions_body" | grep -q '[^[:space:]]' || actions_body=""
+fi
+
 # Order rows decisions-first --------------------------------------------
 # Decorate (has-decision rank, status rank, input order) → sort → strip.
 
@@ -210,6 +231,11 @@ EOF
         printf "| %s | `%s` | %s | %s | %s |\n", $1, $2, pr, $4, $5
     }'
 )
+
+# Append standing operator actions verbatim (durable — survives regeneration).
+if [ -n "$actions_body" ]; then
+    report="$report"$'\n\n'"## Standing operator actions"$'\n\n'"$actions_body"
+fi
 
 # Write / print ----------------------------------------------------------
 

--- a/scripts/overnight/test-morning-report.sh
+++ b/scripts/overnight/test-morning-report.sh
@@ -304,6 +304,58 @@ else
     pass "no CR chars leak into the report"
 fi
 
+# Test 18: standing operator actions appended from --actions -------------
+
+echo "TEST: standing operator actions appended (verbatim, after tickets)"
+printf '%s\n' $'HIMMEL-380\tfeat/HIMMEL-380-x\thttps://example.com/pr/12\tdone\tShipped' > "$ROWS"
+acts="$TMP_ROOT/operator-actions.md"
+printf '🔴 SINGLE-SESSION-ONLY:\n- Run the leak history rewrite.\n' > "$acts"
+report=$(HANDOVER_DIR="$hroot" bash "$SCRIPT" --rows "$ROWS" --actions "$acts" --dry-run)
+assert_contains "standing-actions heading" "## Standing operator actions" "$report"
+assert_contains "standing-actions content" "Run the leak history rewrite." "$report"
+assert_before "tickets before standing actions" "## Tickets" "## Standing operator actions" "$report"
+
+# Test 19: blank/whitespace-only actions file -> no section --------------
+
+echo "TEST: blank actions file -> no standing-actions section"
+printf '   \n\n' > "$acts"
+report=$(HANDOVER_DIR="$hroot" bash "$SCRIPT" --rows "$ROWS" --actions "$acts" --dry-run)
+if printf '%s' "$report" | grep -qF "## Standing operator actions"; then
+    fail "blank actions file produced a section"
+else
+    pass "blank actions file -> no section"
+fi
+
+# Test 20: --actions missing value -> exit 1 ----------------------------
+
+echo "TEST: --actions missing value rejected"
+rc=0
+out=$(bash "$SCRIPT" --actions 2>&1 </dev/null) || rc=$?
+case "$rc" in
+    1) pass "exit 1 on --actions as last arg" ;;
+    *) fail "expected rc=1, got $rc" "$out" ;;
+esac
+assert_contains "--actions diagnostic" "--actions requires a FILE" "$out"
+
+# Test 21: default actions path resolves next to OUT_FILE ----------------
+
+echo "TEST: default actions path = <dirname OUT_FILE>/operator-actions.md"
+out_dir="$TMP_ROOT/acts-default"
+mkdir -p "$out_dir"
+printf '%s\n' $'HIMMEL-381\tfeat/HIMMEL-381-y\thttps://example.com/pr/13\tdone\tShipped' > "$ROWS"
+printf -- '- Default-path standing action.\n' > "$out_dir/operator-actions.md"
+report=$(bash "$SCRIPT" --rows "$ROWS" --out "$out_dir/report.md" --dry-run)
+assert_contains "default actions path picked up" "Default-path standing action." "$report"
+
+# Test 22: actions body is appended VERBATIM (not pipe-escaped) ----------
+# Locks the verbatim contract so a future "let's escape it" refactor breaks here.
+
+echo "TEST: actions body appended verbatim (markdown/pipes un-escaped)"
+printf -- '- Action with a | pipe and **bold**.\n' > "$acts"
+printf '%s\n' $'HIMMEL-382\tfeat/HIMMEL-382-z\thttps://example.com/pr/14\tdone\tShipped' > "$ROWS"
+report=$(HANDOVER_DIR="$hroot" bash "$SCRIPT" --rows "$ROWS" --actions "$acts" --dry-run)
+assert_contains "actions body verbatim (pipe un-escaped)" "Action with a | pipe and **bold**." "$report"
+
 # Summary --------------------------------------------------------------
 
 echo


### PR DESCRIPTION
Durable <handover-root>/operator-actions.md appended to every regenerated morning report. 54/54 tests.