### PR TITLE
feat(initiative): shared leg grammar + resolver + gate profiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,9 +188,11 @@ himmel enforces structurally, not by prose: **6 PreToolUse hooks**
 `.pre-commit-config.yaml`; pre-push incl. `check-platforms-tested`), a
 `UserPromptSubmit` hook (`improve-on-submit.sh`,
 default OFF), a `SessionStart` hook (`inject-initiative.sh` — opt-in
-`HIMMEL_INITIATIVE` drive-to-ship directive: `1`/`all` for the full chain or a
-comma-separated subset of `prcheck,pr,ticket,handover`, default OFF, advisory
-only; HIMMEL-425), and shared **guardrail predicates** (`scripts/guardrails/lib.sh`).
+`HIMMEL_INITIATIVE` drive-to-ship directive over the shared leg grammar
+(`scripts/lib/initiative-legs.sh`, HIMMEL-443): `1`/`all` or a comma-subset of
+`plan,execute,prcheck,pr,ticket,merge,public,handover`; `HIMMEL_OVERNIGHT`
+selects the overnight profile reading `HIMMEL_INITIATIVE_OVERNIGHT`; default OFF,
+advisory only; HIMMEL-425), and shared **guardrail predicates** (`scripts/guardrails/lib.sh`).
 Hook bypass = session env var set in the LAUNCHING shell (e.g.
 `EDIT_ON_MAIN_OK=1 claude`); a per-call prefix does NOT work. Per-repo opt-out:
 a local gitignored `.single-writer` at a repo root allows on-main edits there

--- a/scripts/hooks/inject-initiative.sh
+++ b/scripts/hooks/inject-initiative.sh
@@ -1,28 +1,36 @@
 #!/usr/bin/env bash
-# inject-initiative.sh — SessionStart hook for opt-in initiative mode (HIMMEL-425).
+# inject-initiative.sh — SessionStart hook for opt-in initiative mode
+# (HIMMEL-425; leg grammar + profiles HIMMEL-443).
 #
-# Gated by the HIMMEL_INITIATIVE env var (must be set in the shell that
-# LAUNCHED Claude — bypass convention per scripts/hooks/CLAUDE.md; a per-call
-# prefix does NOT reach the hook process). When active, the session is given a
-# scoped "drive to ship" directive so a normal session proactively runs the
-# /pr-check → open PR → transition ticket → handover sequence at natural
-# completion points, without the operator saying "ship it" each time.
+# Gated by an initiative env var (must be set in the shell that LAUNCHED Claude
+# — bypass convention per scripts/hooks/CLAUDE.md; a per-call prefix does NOT
+# reach the hook process). When active, the session is given a scoped "drive to
+# ship" directive so a normal session proactively advances the work through its
+# active legs at natural completion points, without the operator saying "ship
+# it" each time.
 #
-# Per-part control (mirrors CRITIC_PANEL_TIERS): the value is either a master
-# switch (1/true/on/yes/all → all four parts) or a comma-separated subset of
-# the canonical parts `prcheck,pr,ticket,handover`. Parsing is
-# case-insensitive and whitespace-tolerant; unknown tokens are ignored; steps
-# always render in canonical order regardless of input order. The directive
-# echoes the recognized tokens (`Active steps: …`) so a typo is visible.
+# Leg grammar (single source of truth: scripts/lib/initiative-legs.sh). The
+# value is either a master switch (1/true/on/yes/all) or a comma-separated
+# subset of the 8-leg vocabulary
+# `plan,execute,prcheck,pr,ticket,merge,public,handover` (`plan` is a reserved
+# token with no behavior yet). Parsing is case-insensitive, whitespace-tolerant,
+# deduped; unknown tokens are ignored; steps always render in canonical order.
+# The directive echoes the recognized tokens (`Active steps: …`) so a typo is
+# visible.
+#
+# Profiles (selected by HIMMEL_OVERNIGHT):
+#   - interactive (default): var = HIMMEL_INITIATIVE,           `all` = prcheck,pr,ticket,handover
+#   - overnight (selector):  var = HIMMEL_INITIATIVE_OVERNIGHT, `all` = execute,prcheck,pr,ticket,merge,handover
 #
 # Default: OFF. Exit silently when the env is unset, falsy, or resolves to no
-# recognized part — behaviour then is byte-identical to a session without the
+# recognized leg — behaviour then is byte-identical to a session without the
 # directive.
 #
 # This is ADVISORY injected context, not a permission change: it cannot widen
 # what the hooks allow. The safety rails still HARD-block (check-cr-marker-on-
 # pr-create gates gh pr create; the persistence classifier vetoes reactive
-# --amend and settings.json self-edits; merge stays an operator action).
+# --amend and settings.json self-edits; the `merge` leg is advisory — branch
+# protection still applies; the exfil classifier still blocks public push).
 #
 # Hook contract (SessionStart):
 #   - Reads the SessionStart JSON payload from stdin (we don't consume fields).
@@ -53,35 +61,28 @@ else
     cat >/dev/null 2>&1 || true
 fi
 
-# --- Parse HIMMEL_INITIATIVE into the set of active chain parts -------------
-# The value is either a whole-string master switch or a comma-separated subset
-# of the four canonical parts (mirrors CRITIC_PANEL_TIERS). Normalize once:
-# lowercase + strip all whitespace so "PR, ticket" == "pr,ticket". Bash 3.2-safe.
-_norm=$(printf '%s' "${HIMMEL_INITIATIVE:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+# --- Resolve the active legs via the shared resolver (HIMMEL-443) -----------
+# The leg grammar lives in ONE place: scripts/lib/initiative-legs.sh. We pass
+# the relevant env vars as named arguments (the resolver never reads ambient
+# env) and get back the normalized, canonical-ordered, deduped active leg set.
+# Profile is selected by HIMMEL_OVERNIGHT: truthy → read HIMMEL_INITIATIVE_OVERNIGHT
+# (overnight `all` = 6 legs), else HIMMEL_INITIATIVE (interactive `all` = legacy 4).
+# shellcheck source=/dev/null
+. "$(dirname "${BASH_SOURCE[0]}")/../lib/initiative-legs.sh"
 
-# Resolve the active parts (canonical order is fixed by the loop below, not by
-# input order). `active` is a space-separated list drawn from the canonical set.
-case "$_norm" in
-    ""|0|false|off|no)
-        exit 0
-        ;;
-    1|true|on|yes|all)
-        active="prcheck pr ticket handover"
-        ;;
-    *)
-        # Comma subset: keep only canonical tokens (membership test against the
-        # input dedups, drops empty/trailing fields, and ignores unknowns).
-        active=""
-        for _tok in prcheck pr ticket handover; do
-            case ",$_norm," in
-                *,"$_tok",*) active="$active $_tok" ;;
-            esac
-        done
-        active="${active# }"
-        # A non-empty value that resolved to nothing (all-unknown / typo) is off.
-        [ -n "$active" ] || exit 0
-        ;;
-esac
+active=$(resolve_legs "${HIMMEL_INITIATIVE:-}" "${HIMMEL_INITIATIVE_OVERNIGHT:-}" "${HIMMEL_OVERNIGHT:-}")
+# Off when nothing resolved (unset / falsy / all-unknown subset).
+[ -n "$active" ] || exit 0
+
+# Profile-dependent labels (which var the operator set; shown in the directive).
+if _il_truthy "${HIMMEL_OVERNIGHT:-}"; then
+    _var="HIMMEL_INITIATIVE_OVERNIGHT"; _profile="overnight"
+else
+    _var="HIMMEL_INITIATIVE"; _profile="interactive"
+fi
+
+# Membership test against the active leg set.
+has_leg() { case " $active " in *" $1 "*) return 0;; *) return 1;; esac; }
 
 # CSV of recognized tokens for the in-session echo (typo visibility).
 _steps_csv=$(printf '%s' "$active" | tr ' ' ',')
@@ -90,10 +91,7 @@ _steps_csv=$(printf '%s' "$active" | tr ' ' ',')
 # Invariant prose stays in quoted heredocs (it contains backticks that an
 # unquoted heredoc would try to command-substitute). Only the numbered step
 # list is built dynamically, so it renumbers to the active subset.
-cat <<'EOF'
-<system-reminder>
-HIMMEL_INITIATIVE is active for this Claude Code session.
-EOF
+printf '<system-reminder>\n%s is active for this Claude Code session (%s profile).\n' "$_var" "$_profile"
 printf 'Active steps: %s\n' "$_steps_csv"
 cat <<'EOF'
 
@@ -105,11 +103,16 @@ EOF
 _n=0
 # shellcheck disable=SC2016 # backticks in the format strings are literal directive prose, not expansions
 for _tok in $active; do
+    # `plan` is a reserved vocabulary token (no behavior yet) — consumes no number.
+    [ "$_tok" = plan ] && continue
     _n=$((_n + 1))
     case "$_tok" in
+        execute)  printf '%d. When a critic-hardened plan exists, hand it to execution: invoke `superpowers:subagent-driven-development` (recommended) to implement it task-by-task. (Advisory — it does not relax any rail.)\n' "$_n" ;;
         prcheck)  printf '%d. Run `/pr-check` and loop — fix every finding, re-run — until CR is clean.\n' "$_n" ;;
         pr)       printf '%d. When CR is clean, open or refresh the PR.\n' "$_n" ;;
         ticket)   printf '%d. Transition the Jira ticket to the appropriate status.\n' "$_n" ;;
+        merge)    printf '%d. When CR is clean and the PR is open, squash-merge to PRIVATE main via `scripts/handover/pr-merge.sh` (plain-first; defer to the operator on real branch protection; never `--admin`). Advisory — branch protection still applies.\n' "$_n" ;;
+        public)   printf '%d. After merge, run the public-propagation helper in PREP mode only: stage the public branch + patch and STOP. DO NOT push — the operator ships. The exfil classifier hard-blocks unattended public push regardless.\n' "$_n" ;;
         handover) printf '%d. Write the handover.\n' "$_n" ;;
     esac
 done
@@ -119,17 +122,22 @@ cat <<'EOF'
 Scope and limits:
 - Fire only at completion points, NOT on every small edit. Don't interrupt
   mid-task.
-- Do NOT merge — merge stays an operator action.
+EOF
+# The unconditional no-merge guard is dropped only when the `merge` leg is
+# explicitly active (then the merge step above carries the gate); every other
+# configuration keeps merge an operator action.
+has_leg merge || printf -- '- Do NOT merge — merge stays an operator action.\n'
+cat <<'EOF'
 - This directive does NOT relax any safety rail. The CR-marker hook still
   HARD-blocks `gh pr create` until a clean /pr-check; attestation trailers must
   be in the FIRST commit; reactive `git commit --amend` and self-editing
   `.claude/settings.json` to widen rules are still HARD-vetoed.
-
-To disable for the rest of the session, unset HIMMEL_INITIATIVE in the
-launching shell + restart claude (env vars don't propagate into a running
-session). For per-part control, set HIMMEL_INITIATIVE to a comma-separated
-subset of: prcheck, pr, ticket, handover (e.g. HIMMEL_INITIATIVE=prcheck,pr).
-</system-reminder>
 EOF
+printf '\nTo disable for the rest of the session, unset %s in the\n' "$_var"
+printf 'launching shell + restart claude (env vars do not propagate into a running\n'
+printf 'session). For per-part control, set %s to a comma-separated\n' "$_var"
+printf 'subset of: execute, prcheck, pr, ticket, merge, public, handover\n'
+printf '(e.g. %s=prcheck,pr).\n' "$_var"
+printf '</system-reminder>\n'
 
 exit 0

--- a/scripts/hooks/test-inject-initiative.sh
+++ b/scripts/hooks/test-inject-initiative.sh
@@ -220,6 +220,37 @@ out=$(printf '{}' | HIMMEL_INITIATIVE=pr,pr, bash "$hook")
 assert_has   "pr step present"       "open or refresh the PR"   "$out"
 assert_lacks "no second numbered step" "2\."                    "$out"
 
+# ---------- 17. execute leg renders an execution-handoff step (HIMMEL-443) ----
+echo "Test 17: 'prcheck,execute' renders the execute handoff"
+out=$(printf '{}' | HIMMEL_INITIATIVE=prcheck,execute bash "$hook")
+assert_has "execute step present" "subagent-driven-development" "$out"
+
+# ---------- 18. merge leg renders a merge step + drops the no-merge line ------
+echo "Test 18: 'prcheck,merge' points at pr-merge.sh, guards --admin, no no-merge line"
+out=$(printf '{}' | HIMMEL_INITIATIVE=prcheck,merge bash "$hook")
+assert_has   "merge step names pr-merge.sh" "pr-merge.sh"       "$out"
+assert_has   "merge step guards --admin"    "never .*--admin"   "$out"
+assert_lacks "no-merge line dropped when merge active" "Do NOT merge" "$out"
+
+# ---------- 19. public leg renders a PREP-ONLY step --------------------------
+echo "Test 19: 'merge,public' renders a prep-only public step (stops before push)"
+out=$(printf '{}' | HIMMEL_INITIATIVE=merge,public bash "$hook")
+assert_has "public step is prep-only" "PREP"                    "$out"
+assert_has "public step says do not push" "DO NOT push"         "$out"
+
+# ---------- 20. overnight profile: selector reads the overnight var ----------
+echo "Test 20: HIMMEL_OVERNIGHT=1 + HIMMEL_INITIATIVE_OVERNIGHT=all → 6-leg set"
+out=$(printf '{}' | HIMMEL_OVERNIGHT=1 HIMMEL_INITIATIVE_OVERNIGHT=all bash "$hook")
+assert_has "overnight has execute" "subagent-driven-development" "$out"
+assert_has "overnight has merge"   "pr-merge.sh"                  "$out"
+assert_has "overnight header names the overnight var" "HIMMEL_INITIATIVE_OVERNIGHT is active" "$out"
+
+# ---------- 21. plan token reserved → no plan-specific prose -----------------
+echo "Test 21: 'plan,prcheck' → plan emits no step, prcheck numbered first"
+out=$(printf '{}' | HIMMEL_INITIATIVE=plan,prcheck bash "$hook")
+assert_has   "prcheck numbered first (plan consumes no number)" "1\. Run" "$out"
+assert_lacks "no second numbered step from plan"               "2\."     "$out"
+
 echo
 echo "RESULTS: $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1

--- a/scripts/lib/initiative-legs.sh
+++ b/scripts/lib/initiative-legs.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# scripts/lib/initiative-legs.sh — pure leg resolver (HIMMEL-443).
+#
+# Single source of truth for the harness-autonomy "leg grammar". Maps the
+# relevant env values (passed as NAMED ARGUMENTS, never ambient reads, so the
+# same function is callable from the SessionStart hook AND from minerva's
+# plugin-side transport wrapper) to a normalized, canonical-ordered, deduped
+# active leg set.
+#
+# Profiles:
+#   - interactive (default):        var = HIMMEL_INITIATIVE,           all = 4 legacy legs
+#   - overnight (selector truthy):  var = HIMMEL_INITIATIVE_OVERNIGHT, all = 6 legs
+#
+# `plan` is a reserved vocabulary token (recognized, no behavior yet).
+#
+# Usage: resolve_legs <initiative_val> <overnight_val> <overnight_selector>
+# Echoes the active legs space-separated in canonical order, or empty string.
+
+# Canonical vocabulary order — every emitted set is filtered through this.
+_IL_VOCAB="plan execute prcheck pr ticket merge public handover"
+_IL_INTERACTIVE_ALL="prcheck pr ticket handover"
+_IL_OVERNIGHT_ALL="execute prcheck pr ticket merge handover"
+
+# _il_norm <value> → lowercased, whitespace-stripped
+_il_norm() { printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]'; }
+
+# _il_truthy <value> → rc 0 if truthy (selector test)
+_il_truthy() {
+  case "$(_il_norm "${1:-}")" in
+    ''|0|false|off|no) return 1;;
+    *) return 0;;
+  esac
+}
+
+# _il_filter <wanted=",tok,tok,"> → echo VOCAB ∩ wanted in canonical order
+_il_filter() {
+  local wanted="$1" out="" t
+  for t in $_IL_VOCAB; do
+    case "$wanted" in *",$t,"*) out="${out:+$out }$t";; esac
+  done
+  printf '%s' "$out"
+}
+
+# resolve_legs <initiative_val> <overnight_val> <overnight_selector>
+resolve_legs() {
+  local init_val="${1:-}" over_val="${2:-}" selector="${3:-}"
+  local base all_set norm
+  if _il_truthy "$selector"; then
+    base="$over_val"; all_set="$_IL_OVERNIGHT_ALL"
+  else
+    base="$init_val"; all_set="$_IL_INTERACTIVE_ALL"
+  fi
+  norm="$(_il_norm "$base")"
+  case "$norm" in
+    ''|0|false|off|no) return 0;;                       # empty set
+    1|true|on|yes|all) printf '%s' "$all_set"; return 0;;
+  esac
+  _il_filter ",$norm,"                                  # comma-subset (canonical, deduped)
+}

--- a/scripts/lib/test-initiative-legs.sh
+++ b/scripts/lib/test-initiative-legs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015  # `A && B || C` reporting pattern is intentional here
+# test-initiative-legs.sh — unit test for scripts/lib/initiative-legs.sh
+# (HIMMEL-443). Verifies the pure leg resolver: named-arg inputs → normalized,
+# canonical-ordered, deduped active leg set, across interactive + overnight
+# profiles, subsets, falsy values, case/space tolerance, and selector precedence.
+set -u
+here="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
+. "$here/initiative-legs.sh"
+fail=0
+check() { # desc expected actual
+  if [ "$2" = "$3" ]; then printf 'ok   - %s\n' "$1"
+  else printf 'FAIL - %s\n     expected [%s] got [%s]\n' "$1" "$2" "$3"; fail=1; fi
+}
+
+# interactive profile (selector empty → read arg1)
+check "interactive all → legacy 4"      "prcheck pr ticket handover" "$(resolve_legs all '' '')"
+check "interactive 1 → legacy 4"        "prcheck pr ticket handover" "$(resolve_legs 1 '' '')"
+check "interactive falsy 0 → empty"     ""                            "$(resolve_legs 0 '' '')"
+check "interactive empty → empty"       ""                            "$(resolve_legs '' '' '')"
+check "interactive off → empty"         ""                            "$(resolve_legs off '' '')"
+check "interactive subset+order"        "prcheck pr merge"            "$(resolve_legs 'merge,prcheck,pr' '' '')"
+check "interactive unknown ignored"     "pr ticket"                   "$(resolve_legs 'pr,bogus,ticket' '' '')"
+check "interactive case+space"          "prcheck handover"            "$(resolve_legs '  Handover , PRCHECK ' '' '')"
+check "interactive dedup"               "pr"                          "$(resolve_legs 'pr,pr' '' '')"
+check "interactive plan token kept"     "plan prcheck"                "$(resolve_legs 'plan,prcheck' '' '')"
+
+# overnight profile (selector truthy → read arg2, ignore arg1)
+check "overnight all → 6 legs"          "execute prcheck pr ticket merge handover" "$(resolve_legs '' all 1)"
+check "overnight bare 1 → 6 legs"       "execute prcheck pr ticket merge handover" "$(resolve_legs '' 1 1)"
+check "overnight subset"                "execute merge"               "$(resolve_legs '' 'merge,execute' 1)"
+check "selector wins over initiative"   "execute"                     "$(resolve_legs all execute 1)"
+check "overnight falsy → empty"         ""                            "$(resolve_legs '' 0 1)"
+
+[ "$fail" = 0 ] && echo "ALL PASS" || { echo "FAILURES"; exit 1; }


### PR DESCRIPTION
Pure leg resolver (scripts/lib/initiative-legs.sh, 8-leg vocab + interactive/overnight profiles) + inject-initiative.sh rewired onto it with execute/merge/public leg prose. Backward-compatible. Tests 15/15 + 69/69.