### PR TITLE
feat(minerva): execute-leg auto-handoff (the execute seam)

### DIFF
--- a/marketplace/plugins/himmel-ops/scripts/legs.sh
+++ b/marketplace/plugins/himmel-ops/scripts/legs.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# legs.sh — TRANSPORT ONLY (HIMMEL-444). Locates the himmel checkout and
+# re-execs the single-source leg resolver (scripts/lib/initiative-legs.sh), so
+# the leg `case` lives in exactly one place. This wrapper holds ZERO leg logic.
+#
+# minerva (a plugin) cannot relative-path to the himmel checkout when installed
+# outside it, so we resolve the repo by, in order: $HIMMEL_REPO override → the
+# git toplevel of the current dir (himmel-dev sessions run with cwd in the
+# checkout) → the git toplevel of this wrapper's own dir (plugin loaded from the
+# repo's marketplace/). If none yields the resolver, fail open (empty, exit 0) —
+# minerva then keeps its prose hand-off, never erroring on a missing resolver.
+set -u
+
+_find_repo() {
+  local cand
+  if [ -n "${HIMMEL_REPO:-}" ] && [ -f "${HIMMEL_REPO}/scripts/lib/initiative-legs.sh" ]; then
+    printf '%s' "$HIMMEL_REPO"; return 0
+  fi
+  cand="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [ -n "$cand" ] && [ -f "$cand/scripts/lib/initiative-legs.sh" ]; then
+    printf '%s' "$cand"; return 0
+  fi
+  cand="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [ -n "$cand" ] && [ -f "$cand/scripts/lib/initiative-legs.sh" ]; then
+    printf '%s' "$cand"; return 0
+  fi
+  return 1
+}
+
+repo="$(_find_repo)" || { printf ''; exit 0; }   # fail-open: no reachable resolver
+# shellcheck source=/dev/null
+. "$repo/scripts/lib/initiative-legs.sh"
+resolve_legs "${HIMMEL_INITIATIVE:-}" "${HIMMEL_INITIATIVE_OVERNIGHT:-}" "${HIMMEL_OVERNIGHT:-}"

--- a/marketplace/plugins/himmel-ops/scripts/test-legs.sh
+++ b/marketplace/plugins/himmel-ops/scripts/test-legs.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+# test-legs.sh — transport wrapper for the shared leg resolver (HIMMEL-444).
+# legs.sh holds ZERO leg logic; it locates the himmel checkout and re-execs
+# scripts/lib/initiative-legs.sh so the leg `case` lives in exactly one place.
+set -u
+here="$(cd "$(dirname "$0")" && pwd)"
+repo="$(cd "$here/../../../.." && pwd)"   # himmel checkout root (4 up from .../himmel-ops/scripts)
+fails=0
+check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+
+# execute leg active → surfaces in the wrapper output (via HIMMEL_REPO anchor).
+out="$(HIMMEL_REPO="$repo" HIMMEL_INITIATIVE='prcheck,execute' bash "$here/legs.sh")"
+case " $out " in *" execute "*) echo "ok - execute surfaced";; *) echo "FAIL: execute missing [$out]"; fails=$((fails+1));; esac
+
+# execute leg absent → not in output.
+out="$(HIMMEL_REPO="$repo" HIMMEL_INITIATIVE='prcheck' bash "$here/legs.sh")"
+case " $out " in *" execute "*) echo "FAIL: execute leaked [$out]"; fails=$((fails+1));; *) echo "ok - execute absent";; esac
+
+# no anchor + cwd inside the himmel checkout → resolves via git toplevel of cwd.
+out="$(cd "$repo" && env -u HIMMEL_REPO HIMMEL_INITIATIVE='execute' bash "$here/legs.sh")"
+case " $out " in *" execute "*) echo "ok - resolves via cwd git-toplevel";; *) echo "FAIL: cwd resolution [$out]"; fails=$((fails+1));; esac
+
+# fail-open: wrapper copied OUTSIDE any himmel checkout + no anchor → empty, exit 0.
+td="$(mktemp -d)"; cp "$here/legs.sh" "$td/legs.sh"
+out="$(cd "$td" && env -u HIMMEL_REPO HIMMEL_INITIATIVE='execute' bash "$td/legs.sh")"; rc=$?
+{ [ -z "$out" ] && [ "$rc" = 0 ]; } && echo "ok - fail-open with no reachable resolver" || { echo "FAIL: not fail-open [$out] rc=$rc"; fails=$((fails+1)); }
+rm -rf "$td"
+
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/marketplace/plugins/himmel-ops/skills/minerva/SKILL.md
+++ b/marketplace/plugins/himmel-ops/skills/minerva/SKILL.md
@@ -83,8 +83,22 @@ if `autonomous`, proceed.
 
 ## Terminal
 
-You now hold a critic-hardened, approved implementation plan. minerva STOPS
-here — it does not start implementation. Offer the hand-off:
+You now hold a critic-hardened, approved implementation plan. What happens next
+depends on the **`execute` leg** of the initiative grammar (HIMMEL-444). Read the
+active legs (transport wrapper → the shared resolver; fail-open):
 
-> Plan ready. Execute with `superpowers:subagent-driven-development`
-> (recommended) or `superpowers:executing-plans`?
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/legs.sh"
+```
+
+- If mode is `autonomous` (Stage 0) **AND** the output contains `execute`: do NOT
+  stop — **invoke `superpowers:subagent-driven-development`** on the hardened plan
+  to implement it task-by-task. This is the execute-seam auto-handoff that makes
+  the loop continuous. (You remain the parent: own synthesis across the subagents.)
+- Otherwise (interactive mode, or `execute` not active): minerva STOPS here — it
+  does not start implementation. Offer the hand-off:
+
+  > Plan ready. Execute with `superpowers:subagent-driven-development`
+  > (recommended) or `superpowers:executing-plans`?
+
+Interactive mode never auto-executes (a human is present to choose).


### PR DESCRIPTION
minerva Terminal reads active legs via a transport wrapper (himmel-ops/scripts/legs.sh) and, when autonomous AND execute leg active, invokes superpowers:subagent-driven-development instead of the prose hand-off. Wrapper test 4/4.