### PR TITLE
feat(pr-check): CR->bug-tracker bridge

### DIFF
--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -238,6 +238,24 @@ Steps:
 
    Like 4.5, this is **deduped** — `append-cr-findings.sh` skips a `(head, <slug>-N)` already present, so re-running `/pr-check` on the same HEAD adds nothing. Errors are best-effort: a missing `reviewer-notes.md` or unwritable state repo logs to stderr and does NOT block steps 5/6.
 
+4.7. **CR→bug-tracker lifecycle (HIMMEL-446) — runs alongside 4.5/4.6; best-effort, graceful skip when there is no active handover item.** Where 4.6 writes a flat human-readable trail, 4.7 gives Critical/Important findings a tracked **open→resolved lifecycle** in the item's `bugs.md`, closing the CR-ledger / bug-tracker / handover triangle.
+
+   **Names its own inputs — do NOT assume 4.6's shell vars persist** (each `pr-check.md` ```bash``` fence runs independently). Re-resolve the item dir, then write two temp files and call the bridge:
+   ```bash
+   if item_dir=$(bash scripts/handover/resolve-active-item.sh --branch "$branch" 2>/dev/null); then
+       cr_find=$(mktemp -t cr-bugs-find.XXXXXX); cr_avail=$(mktemp -t cr-bugs-avail.XXXXXX)
+       # Critical/Important panel findings → "<finding-id>\t<severity>\t<symptom>" (one per line, REAL tabs).
+       # (write each [<slug>-N] Critical/Important finding from the step-3 aggregate here)
+       # panel-availability lines → "<slug>\tok|unavailable" (strip any trailing " (rc=N)").
+       # (write each $panel_avail_lines entry here)
+       bash scripts/handover/append-cr-bugs.sh --bugs "$item_dir/bugs.md" --findings "$cr_find" --avail "$cr_avail"
+       rm -f "$cr_find" "$cr_avail"
+   else
+       echo "4.7: no active handover item for $branch — CR-bug lifecycle skipped" >&2
+   fi
+   ```
+   The bridge is idempotent (dedups by finding-id), reopens a `resolved` bug whose finding reappears (regression), and resolves a vanished finding ONLY when its critic was `panel-availability: ok` that HEAD (a flaky critic drop-out must not falsely resolve a still-open bug). Best-effort — it always exits 0 and never blocks steps 5/6.
+
 5. If both `N == 0`:
    - Delete `$marker` (`rm -f "$marker"`).
    - Report: `CR clean — marker cleared for $branch (HEAD=$head). Safe to gh pr create.`

--- a/scripts/handover/append-cr-bugs.sh
+++ b/scripts/handover/append-cr-bugs.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# scripts/handover/append-cr-bugs.sh — CR->bug-tracker bridge (HIMMEL-446).
+#
+# Bridges /pr-check panel findings into the active item's bugs.md so the CR
+# fix-loop has an open->resolved lifecycle (the F1 ledger is machine telemetry;
+# reviewer-notes.md is the human trail; THIS gives findings tracked state).
+#
+# Inputs (files, NOT shell vars — /pr-check fences run independently, so 4.7
+# re-resolves its own item dir and writes temp files rather than leaning on 4.6):
+#   --bugs <path>        the active item's bugs.md (bug.sh target)
+#   --findings <path>    Critical/Important findings: "<finding-id>\t<severity>\t<symptom>" per line
+#   --avail <path>       panel availability: "<slug>\tok|unavailable" per line
+#
+# Per finding: open (new) / reopen (matched bug is resolved = regression) / skip
+# (matched bug already open|fixing). Per open bug whose finding-id is ABSENT this
+# run: resolve ONLY if its critic slug is `ok` in --avail (a flaky critic drop
+# must not falsely resolve a still-open bug — the F-D guard). The critic slug is
+# the finding-id with its trailing -<integer> stripped (gptoss-3 -> gptoss);
+# critic slugs never end in -<digits> (pr-check.md registry contract).
+#
+# Best-effort: all errors to stderr, ALWAYS exit 0 — never block the /pr-check gate.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; BUG="$HERE/bug.sh"
+TAB="$(printf '\t')"
+
+bugs="" findings="" avail=""
+while [ $# -gt 0 ]; do case "$1" in
+  --bugs) bugs="$2"; shift 2;; --findings) findings="$2"; shift 2;;
+  --avail) avail="$2"; shift 2;;
+  *) echo "append-cr-bugs: unknown arg $1" >&2; exit 0;;
+esac; done
+{ [ -n "$bugs" ] && [ -f "$findings" ]; } || { echo "append-cr-bugs: need --bugs + an existing --findings file" >&2; exit 0; }
+
+slug_of(){ printf '%s' "${1%-*}"; }   # gptoss-3 -> gptoss
+
+# avail_ok <slug> → rc 0 if the slug is marked `ok` in the availability file.
+avail_ok(){
+  [ -n "$avail" ] && [ -f "$avail" ] || return 1
+  awk -F'\t' -v s="$1" '$1==s && $2=="ok"{f=1} END{exit !f}' "$avail"
+}
+
+# 1) Open / reopen each current finding.
+present=""
+while IFS="$(printf '\t')" read -r fid sev sym || [ -n "$fid" ]; do
+  [ -n "$fid" ] || continue
+  present="$present $fid"
+  match="$(bash "$BUG" find --bugs "$bugs" --finding-id "$fid" 2>/dev/null || true)"
+  if [ -z "$match" ]; then
+    bash "$BUG" add --bugs "$bugs" --symptom "${sym:-$fid ($sev)}" --finding-id "$fid" >/dev/null 2>&1 || true
+  else
+    bn="${match%%"$TAB"*}"; st="${match#*"$TAB"}"
+    [ "$st" = "resolved" ] && { bash "$BUG" status --bugs "$bugs" --id "$bn" --to open >/dev/null 2>&1 || true; }
+  fi
+done < "$findings"
+
+# 2) Resolve open bugs whose finding-id is ABSENT this run AND whose critic is available.
+[ -f "$bugs" ] || exit 0
+# Real finding-ids are ASCII <slug>-<int>; the placeholder bullet value is a
+# non-ASCII em-dash, so this ASCII class naturally excludes it (and keeps this
+# source file ASCII-only — a literal em-dash breaks shellcheck output on Windows).
+{ grep -oE '^- \*\*CR finding:\*\* [A-Za-z0-9._-]+$' "$bugs" 2>/dev/null || true; } | awk '{print $NF}' | sort -u | while read -r fid; do
+  [ -n "$fid" ] || continue
+  case " $present " in *" $fid "*) continue;; esac        # still present -> leave
+  m="$(bash "$BUG" find --bugs "$bugs" --finding-id "$fid" 2>/dev/null || true)"
+  [ -n "$m" ] || continue
+  bn="${m%%"$TAB"*}"; st="${m#*"$TAB"}"
+  { [ "$st" = "open" ] || [ "$st" = "fixing" ]; } || continue
+  if avail_ok "$(slug_of "$fid")"; then
+    bash "$BUG" status --bugs "$bugs" --id "$bn" --to resolved >/dev/null 2>&1 || true
+  fi                                                       # critic unavailable → leave open (F-D)
+done
+
+exit 0

--- a/scripts/handover/bug.sh
+++ b/scripts/handover/bug.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
 # scripts/handover/bug.sh — per-item bug tracker over one bugs.md
-# (HIMMEL-416 F2 / C3). Subcommands: add | fix | status | list.
+# (HIMMEL-416 F2 / C3). Subcommands: add | fix | status | list | find.
 # Bug ids are per-item sequential (BUG-1, BUG-2, …), stable within the item.
+# `--finding-id` (HIMMEL-446) tags a bug with the CR finding-id that raised it,
+# so the CR->bug bridge can dedup/reopen/resolve by that id (`find` queries it).
 set -uo pipefail
 
 sub="${1:-}"; [ $# -gt 0 ] && shift
-bugs="" symptom="" id="" outcome="" note="" to="" only_open="" porcelain=""
+bugs="" symptom="" id="" outcome="" note="" to="" only_open="" porcelain="" finding_id=""
 while [ $# -gt 0 ]; do case "$1" in
   --bugs) bugs="$2"; shift 2;; --symptom) symptom="$2"; shift 2;;
   --id) id="$2"; shift 2;; --outcome) outcome="$2"; shift 2;;
   --note) note="$2"; shift 2;; --to) to="$2"; shift 2;;
+  --finding-id) finding_id="$2"; shift 2;;
   --open) only_open=1; shift;; --porcelain) porcelain=1; shift;;
   *) echo "bug.sh: unknown arg $1" >&2; exit 2;;
 esac; done
@@ -40,6 +43,7 @@ case "$sub" in
       printf -- '- **Fixes tried:**\n'
       printf -- '- **Resolution:** —\n'
       printf -- '- **CR link:** —\n'
+      printf -- '- **CR finding:** %s\n' "${finding_id:-—}"
     } >> "$bugs" || { echo "bug.sh add: write failed" >&2; exit 2; }
     echo "BUG-$n"
     ;;
@@ -113,6 +117,24 @@ case "$sub" in
         f=$0; sub(/^  - /,"  ",f); fixbuf[nf++]=f
       }
       END { flush() }
+    ' "$bugs"
+    ;;
+  find)
+    # Query by CR finding-id → echo "BUG-N<TAB>status" for the FIRST bug whose
+    # `**CR finding:**` bullet matches (finding-ids are unique per bugs.md by the
+    # bridge's contract). Empty output if none. The em-dash placeholder is never
+    # matchable (bridge always passes a real id). status comes from the bug's
+    # heading comment, same source `list` uses.
+    [ -n "$finding_id" ] || { echo "bug.sh find: --finding-id required" >&2; exit 2; }
+    [ "$finding_id" = "—" ] && exit 0
+    [ -f "$bugs" ] || exit 0
+    awk -v want="$finding_id" '
+      /^### BUG-[0-9]+ — / {
+        id=$0; sub(/^### BUG-/,"",id); sub(/ — .*/,"",id)
+        st="open"
+        if ($0 ~ /<!-- status: [a-z]+ -->/) { st=$0; sub(/.*<!-- status: /,"",st); sub(/ -->.*/,"",st) }
+      }
+      $0 ~ ("^- \\*\\*CR finding:\\*\\* " want "$") { printf "BUG-%s\t%s\n", id, st; exit }
     ' "$bugs"
     ;;
   *) echo "bug.sh: unknown subcommand '$sub'" >&2; exit 2;;

--- a/scripts/handover/test-append-cr-bugs.sh
+++ b/scripts/handover/test-append-cr-bugs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+# test-append-cr-bugs.sh — CR->bug bridge (HIMMEL-446 / Task 5).
+# Verifies: open Critical/Important findings as tracked bugs (deduped by
+# finding-id), reopen on regression, and resolve a vanished finding ONLY when
+# the raising critic was panel-available that run (the F-D guard).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; S="$HERE/append-cr-bugs.sh"; BUG="$HERE/bug.sh"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+F="$tmp/bugs.md"; fails=0
+check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+porc(){ bash "$BUG" list --bugs "$F" --porcelain 2>/dev/null; }
+nopen(){ porc | grep -c "$(printf '\topen\t')"; }
+nres(){ porc | grep -c "$(printf '\tresolved\t')"; }
+
+# Fixtures use REAL tabs: \t lives in the printf FORMAT string (interpreted),
+# never inside a %s arg (where it would stay literal backslash-t).
+# Round 1: two findings (Critical + Important) → two open bugs carrying finding-id.
+printf 'gptoss-1\tCritical\trace on resume\nkimi-2\tImportant\tnull deref\n' > "$tmp/find1"
+printf 'gptoss\tok\nkimi\tok\n' > "$tmp/avail1"
+bash "$S" --bugs "$F" --findings "$tmp/find1" --avail "$tmp/avail1"
+check "r1: two bugs opened" "$(nopen)" "2"
+
+# Round 1 re-run, same findings → idempotent (still two, no dupes).
+bash "$S" --bugs "$F" --findings "$tmp/find1" --avail "$tmp/avail1"
+check "r1b: still two headings" "$(grep -c '^### BUG-' "$F")" "2"
+
+# Round 2: kimi-2 gone, kimi available → its bug resolves; gptoss-1 stays open.
+printf 'gptoss-1\tCritical\trace on resume\n' > "$tmp/find2"
+printf 'gptoss\tok\nkimi\tok\n' > "$tmp/avail2"
+bash "$S" --bugs "$F" --findings "$tmp/find2" --avail "$tmp/avail2"
+check "r2: one resolved"    "$(nres)" "1"
+check "r2: one still open"  "$(nopen)" "1"
+
+# Round 2b guard (F-D): gptoss-1 gone BUT gptoss unavailable → bug stays open.
+: > "$tmp/find3"
+printf 'gptoss\tunavailable\nkimi\tok\n' > "$tmp/avail3"
+bash "$S" --bugs "$F" --findings "$tmp/find3" --avail "$tmp/avail3"
+check "r2b: open bug NOT resolved (critic down)" "$(nopen)" "1"
+
+# Regression reopen: resolve gptoss-1 by hand, then re-feed it → reopens.
+bash "$BUG" status --bugs "$F" --id "$(bash "$BUG" find --bugs "$F" --finding-id gptoss-1 | cut -f1)" --to resolved >/dev/null
+bash "$S" --bugs "$F" --findings "$tmp/find1" --avail "$tmp/avail1"
+check "reopen: regression reopens bug" "$(nopen)" "2"
+
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/handover/test-bug.sh
+++ b/scripts/handover/test-bug.sh
@@ -155,4 +155,19 @@ ptab="$(bash "$B" list --porcelain --bugs "$F")"
 check "porc: tab field count = 4" "$(printf '%s' "$ptab" | awk -F'\t' 'NR==1{print NF}')" "4"
 check "porc: tab sanitized"       "$(printf '%s' "$ptab" | grep -c $'^BUG-1\topen\t0\ttab here$')" "1"
 
+# --finding-id (HIMMEL-446): stored on its own body bullet, queryable with
+# status via `find`, drives the CR->bug bridge dedup/reopen/resolve logic.
+seed
+b1="$(bash "$B" add --bugs "$F" --symptom "panel race" --finding-id "gptoss-3")"
+check "finding-id: bullet rendered"   "$(grep -c -- '^- \*\*CR finding:\*\* gptoss-3$' "$F")" "1"
+check "find: returns BUG-N<TAB>open"  "$(bash "$B" find --bugs "$F" --finding-id "gptoss-3")" "$(printf '%s\topen' "$b1")"
+check "find: missing id is empty"     "$(bash "$B" find --bugs "$F" --finding-id "nope")" ""
+# add without --finding-id still works and renders the placeholder em-dash.
+bash "$B" add --bugs "$F" --symptom "no finding id" >/dev/null
+check "add: no finding-id -> em-dash" "$(grep -c -- '^- \*\*CR finding:\*\* —$' "$F")" "1"
+check "find: skips em-dash placeholder" "$(bash "$B" find --bugs "$F" --finding-id "—")" ""
+# status reflected in find output (drives reopen-vs-skip in the bridge).
+bash "$B" status --bugs "$F" --id "$b1" --to resolved >/dev/null
+check "find: status tracks resolve"   "$(bash "$B" find --bugs "$F" --finding-id "gptoss-3")" "$(printf '%s\tresolved' "$b1")"
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
bug.sh --finding-id + status-aware find; append-cr-bugs.sh opens Critical/Important findings as tracked bugs (deduped, reopen-on-regression, availability-guarded resolve); /pr-check step 4.7 wires it. Tests green.