### PR TITLE
feat(hooks): [HIMMEL-440] block-read-secrets recurse into bash -c / sh -c bodies

### DIFF
--- a/scripts/hooks/block-read-secrets.sh
+++ b/scripts/hooks/block-read-secrets.sh
@@ -34,8 +34,19 @@
 #
 # Known limitations (consciously accepted — gate targets accidental leaks,
 # not a determined attacker):
-#   * `bash -c 'cat .env'` — the quoted body is one shell token; we never
-#     see `cat` and `.env` as separate tokens after metachar splitting.
+#   * `bash -c 'cat .env'` IS now caught (HIMMEL-440): when the clause command
+#     resolves to a shell interpreter (bash/sh/zsh/dash/ksh/ash), the matcher
+#     recurses into the `-c '<body>'` and re-runs the reader+secret check on the
+#     body's first statement (the body is real shell, so this is FP-free —
+#     unlike node -e / python -c non-shell bodies). Remaining `-c` gaps:
+#     variable bodies `bash -c "$CMD"` (variable indirection, below), process
+#     substitution `bash <(echo 'cat .env')`, and exotic flag interleavings
+#     where `-c` follows a non-flag operand. (Multi-statement bodies like
+#     `bash -c 'echo hi; cat .env'` already block via the later clause.) A
+#     secret passed as a POSITIONAL into the body (`bash -c 'cat "$1"' _ .env`)
+#     reaches the reader via `$1` — the same accepted variable-indirection gap
+#     below, not a literal arg. Scanning stops at the body's closing quote, so a
+#     trailing positional after a NON-secret body read is not over-blocked.
 #   * `git show HEAD:.env`, `git cat-file -p HEAD:.env` — git not in
 #     reader list (would false-positive on most git commands).
 #   * Cross-command exfil: `cp .env /tmp/x; cat /tmp/x` — cp is write-only,
@@ -113,6 +124,17 @@ is_reader_cmd() {
         xxd|od|hexdump|strings|base64|file)    return 0 ;;
         # PowerShell readers (Bash matcher may still see these via pwsh -c).
         Get-Content|gc|Select-String|sls|type) return 0 ;;
+    esac
+    return 1
+}
+
+is_interp_cmd() {
+    # Shell interpreters whose `-c '<body>'` body IS shell — so re-running the
+    # matcher on the body is correct and FP-free (HIMMEL-440). Deliberately
+    # EXCLUDES node/python/etc.: their `-e`/`-c` bodies are NOT shell, and
+    # scanning them is exactly what caused the HIMMEL-436 false positives.
+    case "$1" in
+        bash|sh|zsh|dash|ksh|ash) return 0 ;;
     esac
     return 1
 }
@@ -199,6 +221,15 @@ case "$tool" in
             secret_after=0
             inplace=0
             prev=""
+            # HIMMEL-440 recursion state (interpreter `-c` body re-resolution):
+            interp=0          # cmdtok resolved to a shell interpreter
+            found_c=0         # a -c / -*c flag has been seen
+            rec_cmd=""        # the recursed command (body's first token)
+            rec_reader=0
+            rec_secret=0
+            rec_inplace=0
+            bodyq=""          # the -c body's outer quote char (' or "), if any
+            bodyclosed=0      # past the body's closing quote → tokens are $0/$1…
             # shellcheck disable=SC2086 # intentional word split for tokenisation
             for tok in $clause; do
                 # Redirect-from-secret: authoritative for `<`-redirects and
@@ -219,18 +250,83 @@ case "$tool" in
                     esac
                     cmdtok="$tok"
                     if is_reader_cmd "$cmdtok"; then reader=1; fi
+                    if is_interp_cmd "$cmdtok"; then interp=1; fi
                     prev="$tok"
                     continue
                 fi
                 # Past the command token: scan its arguments.
                 if is_inplace_token "$tok"; then inplace=1; fi
                 if is_secret_path "$tok";   then secret_after=1; fi
+
+                # HIMMEL-440: when the command is a shell interpreter, recurse
+                # into its `-c '<body>'`. The body is real shell, so re-running
+                # the reader+secret check on it is correct (and FP-free, unlike
+                # node -e / python -c non-shell bodies). Only the FIRST
+                # statement of the body needs this — any `;`/`|`/`&`-separated
+                # later statements are already their own clauses.
+                if [ "$interp" = "1" ]; then
+                    if [ -z "$rec_cmd" ]; then
+                        if [ "$found_c" = "0" ]; then
+                            # Hunt for -c: skip interpreter flags; a -c or a
+                            # combined trailing-c bundle (-lc, -ic, -xc) arms
+                            # the next operand as the recursed command. A
+                            # non-flag operand BEFORE any -c (`bash run.sh`)
+                            # means this isn't a -c invocation → abort recursion.
+                            case "$tok" in
+                                --*)    : ;;
+                                -c|-*c) found_c=1 ;;
+                                -*)     : ;;
+                                *)      interp=0 ;;
+                            esac
+                        else
+                            # -c seen; the first non-flag operand is the body's
+                            # command. Note the body's outer quote char so we can
+                            # stop scanning at its close (everything after is
+                            # $0/$1… positionals the body does not read). Strip
+                            # ONE leading quote glued on by the quote-naive
+                            # tokeniser (`'cat` → `cat`); bash-3.2-safe.
+                            case "$tok" in
+                                -*) : ;;
+                                *)
+                                    case "$tok" in
+                                        \'*) bodyq="'" ;;
+                                        \"*) bodyq='"' ;;
+                                    esac
+                                    rtok="${tok#\'}"; rtok="${rtok#\"}"
+                                    rec_cmd="$rtok"
+                                    if is_reader_cmd "$rec_cmd"; then rec_reader=1; fi
+                                    # Unquoted single-word body (`bash -c cat .env`)
+                                    # has no args of its own — the rest are
+                                    # positionals. Mark the body already closed.
+                                    [ -z "$bodyq" ] && bodyclosed=1
+                                    ;;
+                            esac
+                        fi
+                    elif [ "$bodyclosed" = "0" ]; then
+                        # Inside the body: scan ITS args. is_secret_path already
+                        # strips one trailing quote (`.env'` → `.env`).
+                        if is_inplace_token "$tok"; then rec_inplace=1; fi
+                        if is_secret_path "$tok";   then rec_secret=1; fi
+                        # A token bearing the body's closing quote ends the body;
+                        # subsequent tokens are positionals (`bash -c 'cat x' .env`
+                        # — the `.env` is $0, never read). Quote-naive: matches the
+                        # outer quote only (escaped/nested quotes are accepted gaps).
+                        case "$tok" in
+                            *\') [ "$bodyq" = "'" ] && bodyclosed=1 ;;
+                            *\") [ "$bodyq" = '"' ] && bodyclosed=1 ;;
+                        esac
+                    fi
+                fi
                 prev="$tok"
             done
             # A clause leaks only when its COMMAND is a reader and a secret
             # follows as an arg. In-place sed/awk rewrites (carved per-clause,
             # so a global `-i` can't mask a separate read clause) don't leak.
             if [ "$reader" = "1" ] && [ "$secret_after" = "1" ] && [ "$inplace" = "0" ]; then
+                block=1
+            fi
+            # HIMMEL-440: the recursed interpreter `-c` body leaked a secret.
+            if [ "$rec_reader" = "1" ] && [ "$rec_secret" = "1" ] && [ "$rec_inplace" = "0" ]; then
                 block=1
             fi
         done <<EOF

--- a/scripts/hooks/test-block-read-secrets.sh
+++ b/scripts/hooks/test-block-read-secrets.sh
@@ -115,6 +115,36 @@ assert_rc "Bash nice cat .env"               2 "$(run_case "$(j_bash 'nice cat .
 # separate `cat .env` clause (today's global carve-out wrongly ALLOWs this).
 assert_rc "Bash sed -i foo; cat .env"        2 "$(run_case "$(j_bash 'sed -i s/a/b/ foo.txt; cat .env')")"
 
+# --- HIMMEL-440: recurse into bash -c / sh -c bodies ---
+# An interpreter `-c '<reader> <secret>'` body IS shell, so re-running the
+# matcher on it is correct (unlike node -e / python -c non-shell bodies, which
+# is why HIMMEL-436 must NOT re-open). New BLOCK: the secret-read is the
+# first/only statement of the -c body.
+assert_rc "Bash bash -c 'cat .env'"          2 "$(run_case "$(j_bash "bash -c 'cat .env'")")"
+assert_rc "Bash sh -c \"cat .env\""          2 "$(run_case "$(j_bash 'sh -c "cat .env"')")"
+assert_rc "Bash bash -lc 'cat .env'"         2 "$(run_case "$(j_bash "bash -lc 'cat .env'")")"
+assert_rc "Bash env bash -c 'cat .env'"      2 "$(run_case "$(j_bash "env bash -c 'cat .env'")")"
+assert_rc "Bash zsh -c 'grep X .env'"        2 "$(run_case "$(j_bash "zsh -c 'grep X .env'")")"
+# Regression (already green via the <-redirect path, must stay green).
+assert_rc "Bash bash -c 'read x <.env'"      2 "$(run_case "$(j_bash "bash -c 'read x <.env'")")"
+# PRESERVED ALLOW: -c body with no secret-read, and no -c at all.
+assert_rc "Bash bash -c 'echo hi'"           0 "$(run_case "$(j_bash "bash -c 'echo hi'")")"
+assert_rc "Bash sh -c 'ls -la'"              0 "$(run_case "$(j_bash "sh -c 'ls -la'")")"
+assert_rc "Bash bash run.sh (no -c)"         0 "$(run_case "$(j_bash 'bash run.sh')")"
+assert_rc "Bash bash script.sh .env (no -c)" 0 "$(run_case "$(j_bash 'bash script.sh .env')")"
+# More interpreters + flag-shape coverage of the -c hunt state machine.
+assert_rc "Bash dash -c 'cat .env'"          2 "$(run_case "$(j_bash "dash -c 'cat .env'")")"
+assert_rc "Bash bash -x -c 'cat .env'"       2 "$(run_case "$(j_bash "bash -x -c 'cat .env'")")"
+assert_rc "Bash bash --norc -c 'cat .env'"   2 "$(run_case "$(j_bash "bash --norc -c 'cat .env'")")"
+# Multi-statement body blocks via the LATER clause (design's load-bearing claim).
+assert_rc "Bash bash -c 'echo hi; cat .env'" 2 "$(run_case "$(j_bash "bash -c 'echo hi; cat .env'")")"
+# In-place carve-out propagates into the -c body (recursive twin of sed -i).
+assert_rc "Bash bash -c 'sed -i s/a/b/ .env'" 0 "$(run_case "$(j_bash "bash -c 'sed -i s/a/b/ .env'")")"
+# No FP on a trailing positional ($0) after a quoted body that reads a NON-secret
+# (the body reads config.json; .env is the unused $0, never read) — body-quote
+# boundary tracking stops the recursed-arg scan at the body's closing quote.
+assert_rc "Bash bash -c 'cat config.json' .env" 0 "$(run_case "$(j_bash "bash -c 'cat config.json' .env")")"
+
 # --- BYPASS case (expect rc=0 with READ_SECRETS_OK=1) ---
 assert_rc "Bypass cat .env"                0 "$(run_case "$(j_bash 'cat .env')" "READ_SECRETS_OK=1")"
 assert_rc "Bypass Read .env"               0 "$(run_case "$(j_read '/proj/.env')" "READ_SECRETS_OK=1")"


### PR DESCRIPTION
Close a documented false-negative: `bash -c 'cat .env'` (and sh/zsh/dash/ksh/ash `-c` bodies) slipped through because the quoted body was one token in command position. Adds a second classification on the resolved interpreter command → recurse into the `-c` body and re-run the reader+secret check on its first statement. Interpreters only (not node -e / python -c) so no HIMMEL-436 false-positive re-opens; body-quote boundary tracking avoids over-blocking a trailing positional. Suite green, shellcheck clean, bash 3.2-safe. (Private: himmel-private#629.)