### PR TITLE
fix(adopt): create parent dir before luna vault scaffold

### DIFF
--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -165,6 +165,8 @@ function Do-Luna([string]$Dest) {
     if ((Test-Path $Dest) -and -not $DryRun) {
         Write-Host "  $Dest already exists — skipping copy (re-run the vault's own setup to update)"
     } elseif (-not $DryRun) {
+        $parent = Split-Path $Dest
+        if ($parent) { New-Item -ItemType Directory -Force $parent | Out-Null }
         Copy-Item -Recurse -Force (Join-Path $HimmelRoot 'templates\luna-second-brain') $Dest
     } else {
         Write-Host "DRY: copy templates\luna-second-brain → $Dest"

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -187,6 +187,7 @@ do_luna() {
   if [[ -e "$dest" && $DRY_RUN -ne 1 ]]; then
     echo "  $dest already exists — skipping copy (re-run the vault's own setup to update)"
   else
+    run mkdir -p "$(dirname "$dest")"
     run cp -r "$HIMMEL_ROOT/templates/luna-second-brain" "$dest"
   fi
   echo "  next: cd \"$dest\" && bash scripts/setup.sh   (idempotent; prints the plugin-install commands)"


### PR DESCRIPTION
Scaffolding the luna vault to a path whose parent did not exist failed with a cryptic error; create the parent first, matching copy_portable. PowerShell guards the empty Split-Path (bare relative target) case for lockstep parity with bash dirname.