### PR TITLE
chore(setup): [HIMMEL-453] self-document env.example + HIMMEL_REPO default-by-install

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,72 +1,122 @@
-# Operator slug (HIMMEL-145). Used in handover bucket paths
-# (<state-root>/<USER_SLUG>/...), registry.json, scratch dirs.
-# Resolution order in scripts/lib/user-slug.sh:
-#   1. $USER_SLUG (this var)
-#   2. git config user.name, slugified
-#   3. fail-loud with a hint
+# himmel environment configuration.  Copy to .env (setup.sh / adopt.sh do this
+# for you):  cp .env.example .env
+#
+# TWO kinds of variable live here, and they reach code DIFFERENTLY -- getting
+# this wrong is the classic "I set it in .env but nothing happened" tax:
+#
+#   1. TOOL-LOADED  -- a himmel CLI reads this .env file itself, so a value here
+#      is enough; no shell export needed. The Jira/Confluence CLI (scripts/jira)
+#      and the Bitbucket CLI (scripts/bitbucket) load their keys straight from
+#      the repo-root .env.
+#
+#   2. PROCESS-ENV  -- hooks, shell scripts, and skill tools read the LIVE
+#      environment, NOT this file. These must be EXPORTED in the shell that
+#      launches `claude`, or set in ~/.claude/settings.json "env" {} (Claude Code
+#      injects that block into every session). A value sitting ONLY in this .env
+#      is never seen -- e.g. the SessionStart hook that reads HIMMEL_INITIATIVE
+#      does not load .env. (Exception: HANDOVER_DIR and USER_SLUG are bridged
+#      from .env into the env by scripts/lib/load-dotenv.sh, so those two also
+#      work from here.)
+#
+# setup.sh / adopt.sh AUTO-SET HIMMEL_REPO for you (it is the himmel clone path,
+# which the installer knows) into ~/.claude/settings.json. Run setup/adopt with
+# --fill-env (PowerShell: -FillEnv) to be PROMPTED for the uncommented values
+# below instead of hand-editing this file; press Enter at a prompt to skip a var
+# and keep its current value. Commented (#) lines are opt-in -- uncomment first.
+
+# === SECTION: TOOL-LOADED ===  a himmel CLI reads .env directly; no export needed
+
+# Operator slug (HIMMEL-145). Handover bucket paths (<state-root>/<USER_SLUG>/...),
+# registry.json, scratch dirs. Resolution (scripts/lib/user-slug.sh): $USER_SLUG
+# -> git config user.name slugified -> fail-loud. Also bridged from .env into the
+# live env by scripts/lib/load-dotenv.sh.
 USER_SLUG=your-slug
 
-# Handover state root (HIMMEL-335). Where the handover system reads/writes
-# epics, tasks, standalones, and session snapshots. Two modes:
-#   - Unset (Mode A, default): inline at <this-repo>/handovers/.
-#   - Set   (Mode B): an external directory, typically a separate state repo
-#     so handover commits don't land on your feature branches.
-# Resolved by scripts/lib/handover-path.sh; loaded from this file by
-# scripts/lib/load-dotenv.sh when the launching shell didn't export it.
-# Run `/handover-setup` to be prompted for the path and have it written here.
-# HANDOVER_DIR=/c/path/to/your/handover-repo/handovers
-
-# Luna vault root for end-session-wiki capture (global default). The SessionEnd
-# hook writes a note per session into <vault>/sessions/. Unset → ~/Documents/luna.
-# A per-repo `.claude/end-session-wiki.json` "vault_path" overrides this for that
-# repo. See docs/luna/end-session-wiki.md ("Choosing the target vault").
-# LUNA_VAULT_PATH=/c/path/to/your/obsidian-vault
-
-JIRA_BASE_URL=https://<your-site>.atlassian.net
-JIRA_EMAIL=<your-email@example.com>
-JIRA_API_TOKEN=your_api_token_here
-# Example value — replace with YOUR Jira project key (e.g. ACME).
-JIRA_PROJECT_KEY=HIMMEL
+# --- Jira / Confluence CLI (scripts/jira) -- reads these straight from .env ---
+JIRA_BASE_URL=https://<your-site>.atlassian.net   # your Atlassian site URL
+JIRA_EMAIL=<your-email@example.com>               # Atlassian account email
+JIRA_API_TOKEN=your_api_token_here                # id.atlassian.com/manage-profile/security/api-tokens
+# Example value -- replace with YOUR Jira project key (e.g. ACME).
+JIRA_PROJECT_KEY=HIMMEL                            # default project for jira ops
+JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian cloud id (REST / MCP)
 # Optional: extra projects whose metadata /jira-init caches (comma-list).
-# Defaults to JIRA_PROJECT_KEY alone.
-# JIRA_PROJECTS=ACME,BETA
-JIRA_CLOUD_ID=<your-cloud-id>
+# Defaults to JIRA_PROJECT_KEY alone. himmel itself tracks HIMMEL + LUNA.
+# JIRA_PROJECTS=HIMMEL,LUNA
 # Optional: default Agile board id for `jira sprints` (HIMMEL-437). When set,
 # `sprints` needs no --board in the common single-board case.
 # JIRA_BOARD_ID=123
-# Optional: separate Atlassian creds for the `confluence` CLI (HIMMEL-437).
+# Legacy: no active code reader as of 2026-06-20 -- kept for back-compat only.
+# ORGANIZATION_ID=your_org_id_here
+
+# --- Bitbucket Cloud CLI (scripts/bitbucket) -- only for a Bitbucket forge ---
+# Reads repo-root .env or environment. Unset on a GitHub repo (never invoked).
+# BITBUCKET_EMAIL=<your-email@example.com>
+# BITBUCKET_API_TOKEN=your_bitbucket_api_token_here
+
+# --- Confluence CLI (scripts/jira/dist/confluence.js) -- optional (HIMMEL-437) ---
 # A scoped Jira API token 401s against Confluence (/wiki); set these to a
-# Confluence-capable (scopeless/full-account) token. Unset -> confluence CLI
+# Confluence-capable (scopeless/full-account) token. Unset -> the confluence CLI
 # falls back to JIRA_EMAIL/JIRA_API_TOKEN.
 # CONFLUENCE_EMAIL=<your-email@example.com>
 # CONFLUENCE_API_TOKEN=your_confluence_api_token_here
-ORGANIZATION_ID=your_org_id_here
 
-# VirtualBox VMs — see docs/setup/vms.md
-ubuntu_vm_user=your_ubuntu_vm_username
-ubuntu_vm_pass=your_ubuntu_vm_password
+# === SECTION: PROCESS-ENV ===  read from the LIVE env -- EXPORT these (shell or
+#     ~/.claude/settings.json "env" {}); a value ONLY in .env is NOT read, except
+#     the two load-dotenv-bridged vars noted below.
 
+# --- himmel harness ---
+# Path to your himmel checkout. The leg resolver + minerva transport anchor to it
+# (marketplace/plugins/himmel-ops/scripts/legs.sh). setup.sh / adopt.sh AUTO-SET
+# this into ~/.claude/settings.json; legs.sh also falls back to the default
+# install path ($HOME/Documents/github/himmel). Set it explicitly only for a
+# non-default clone location.  EXPORT -- not read from .env.
+# HIMMEL_REPO=/c/path/to/your/himmel
+# Drive-to-ship initiative legs (HIMMEL-425/443). Default OFF. `1`/`all` enables
+# the full interactive profile, or a comma-subset of:
+#   plan,execute,prcheck,pr,ticket,merge,public,handover     EXPORT -- not read from .env.
+# HIMMEL_INITIATIVE=prcheck,pr,ticket,handover
+# Overnight profile (HIMMEL-443): when HIMMEL_OVERNIGHT is truthy the resolver
+# reads HIMMEL_INITIATIVE_OVERNIGHT instead, and `all` widens to 6 legs.
+# HIMMEL_OVERNIGHT=1
+# HIMMEL_INITIATIVE_OVERNIGHT=all
+
+# --- handover + vault ---
+# Handover state root (HIMMEL-335). Unset (Mode A) = inline <repo>/handovers/.
+# Set (Mode B) = external dir / state repo so handover commits don't land on
+# feature branches. Resolved by scripts/lib/handover-path.sh; ALSO bridged from
+# this .env by scripts/lib/load-dotenv.sh when the shell didn't export it. Run
+# /handover-setup to be prompted.
+# HANDOVER_DIR=/c/path/to/your/handover-repo/handovers
+# Luna vault root for end-session-wiki capture (global default). The SessionEnd
+# hook writes a note per session into <vault>/sessions/. Unset -> ~/Documents/luna.
+# A per-repo .claude/end-session-wiki.json "vault_path" overrides this for that
+# repo. NOT bridged -- a value in .env is ignored; EXPORT it. See
+# docs/luna/end-session-wiki.md ("Choosing the target vault").
+# LUNA_VAULT_PATH=/c/path/to/your/obsidian-vault
+
+# --- Research / AI skill keys (read from the LIVE env by the skills' tools) ---
+PERPLEXITY_API_KEY=     # Perplexity Sonar -- /research, /research-deep, harvest
+XAI_API_KEY=            # xAI Grok -- /x-read, /x-pulse, /youtube
+GEMINI_API_KEY=         # Gemini -- scripts/gemini/invoke.sh (gemini-subagent)
+
+# --- VirtualBox VMs (optional) -- see docs/setup/vms.md ---
+# ubuntu_vm_user=your_ubuntu_vm_username
+# ubuntu_vm_pass=your_ubuntu_vm_password
 # windows_vm_user=your_windows_vm_username
 # windows_vm_pass=your_windows_vm_password
 
-# --- Research / AI skill keys ---
-# Perplexity Sonar — /research, /research-deep, clipper-pipeline harvest
-PERPLEXITY_API_KEY=
-# xAI Grok — /x-read, /x-pulse, /youtube
-XAI_API_KEY=
-# Gemini — scripts/gemini/invoke.sh (gemini-subagent)
-GEMINI_API_KEY=
+# === SECTION: EXTERNAL-TOOLS ===  key lives in the tool's OWN .env -- listed
+#     here as operator inventory only; setting it in THIS file does nothing.
 
 # --- hermes junior tier (HIMMEL-272) ---
-# Live copies belong in %LOCALAPPDATA%/hermes/.env (hermes reads its own
-# .env, not this file) — listed here as the operator key inventory.
-# Provider routes: NIM nemotron (default), OpenRouter, gemini-flash,
-# DeepSeek, Ollama local (no key needed).
+# Live copies belong in %LOCALAPPDATA%/hermes/.env (hermes reads its own .env,
+# not this file). Provider routes: NIM nemotron (default), OpenRouter,
+# gemini-flash, DeepSeek, Ollama local (no key needed).
 # NVIDIA_API_KEY=
 # OPENROUTER_API_KEY=
 # GOOGLE_API_KEY=
 # DEEPSEEK_API_KEY=
-# OLLAMA_API_KEY=          # Ollama Cloud only — local ollama needs no key
+# OLLAMA_API_KEY=          # Ollama Cloud only -- local ollama needs no key
 
 # --- Telegram bridge ---
 # TELEGRAM_BOT_TOKEN lives in ~/.claude/channels/telegram/.env (NOT here);

--- a/marketplace/plugins/himmel-ops/scripts/legs.sh
+++ b/marketplace/plugins/himmel-ops/scripts/legs.sh
@@ -4,11 +4,14 @@
 # the leg `case` lives in exactly one place. This wrapper holds ZERO leg logic.
 #
 # minerva (a plugin) cannot relative-path to the himmel checkout when installed
-# outside it, so we resolve the repo by, in order: $HIMMEL_REPO override → the
+# outside it, so we resolve the repo by, in order: $HIMMEL_REPO override -> the
 # git toplevel of the current dir (himmel-dev sessions run with cwd in the
-# checkout) → the git toplevel of this wrapper's own dir (plugin loaded from the
-# repo's marketplace/). If none yields the resolver, fail open (empty, exit 0) —
-# minerva then keeps its prose hand-off, never erroring on a missing resolver.
+# checkout) -> the git toplevel of this wrapper's own dir (plugin loaded from the
+# repo's marketplace/) -> the canonical default install path
+# ($HOME/Documents/github/himmel, HIMMEL-453: we control the himmel install, so
+# it sits at a known path, resolving even outside any git checkout). If none
+# yields the resolver, fail open (empty, exit 0) -- minerva then keeps its prose
+# hand-off, never erroring on a missing resolver.
 set -u
 
 _find_repo() {
@@ -22,6 +25,10 @@ _find_repo() {
   fi
   cand="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || true)"
   if [ -n "$cand" ] && [ -f "$cand/scripts/lib/initiative-legs.sh" ]; then
+    printf '%s' "$cand"; return 0
+  fi
+  cand="$HOME/Documents/github/himmel"      # canonical default install (HIMMEL-453)
+  if [ -f "$cand/scripts/lib/initiative-legs.sh" ]; then
     printf '%s' "$cand"; return 0
   fi
   return 1

--- a/marketplace/plugins/himmel-ops/scripts/test-legs.sh
+++ b/marketplace/plugins/himmel-ops/scripts/test-legs.sh
@@ -21,10 +21,24 @@ case " $out " in *" execute "*) echo "FAIL: execute leaked [$out]"; fails=$((fai
 out="$(cd "$repo" && env -u HIMMEL_REPO HIMMEL_INITIATIVE='execute' bash "$here/legs.sh")"
 case " $out " in *" execute "*) echo "ok - resolves via cwd git-toplevel";; *) echo "FAIL: cwd resolution [$out]"; fails=$((fails+1));; esac
 
-# fail-open: wrapper copied OUTSIDE any himmel checkout + no anchor → empty, exit 0.
+# fail-open: wrapper copied OUTSIDE any himmel checkout + no anchor + no checkout
+# at the default install path -> empty, exit 0. HOME="$td" defeats the HIMMEL-453
+# default-path candidate ($HOME/Documents/github/himmel) so it cannot resolve to
+# the real machine checkout.
 td="$(mktemp -d)"; cp "$here/legs.sh" "$td/legs.sh"
-out="$(cd "$td" && env -u HIMMEL_REPO HIMMEL_INITIATIVE='execute' bash "$td/legs.sh")"; rc=$?
+out="$(cd "$td" && env -u HIMMEL_REPO HOME="$td" HIMMEL_INITIATIVE='execute' bash "$td/legs.sh")"; rc=$?
 { [ -z "$out" ] && [ "$rc" = 0 ]; } && echo "ok - fail-open with no reachable resolver" || { echo "FAIL: not fail-open [$out] rc=$rc"; fails=$((fails+1)); }
 rm -rf "$td"
+
+# default-install fallback (HIMMEL-453): no anchor, cwd OUTSIDE any checkout, but
+# a himmel checkout exists at $HOME/Documents/github/himmel -> resolves via the
+# 4th candidate. Same cwd/BASH_SOURCE setup as the fail-open case above (a non-git
+# mktemp dir, so candidates 2+3 fail); only HOME differs, isolating candidate 4.
+th="$(mktemp -d)"; mkdir -p "$th/Documents/github/himmel/scripts/lib"
+cp "$repo/scripts/lib/initiative-legs.sh" "$th/Documents/github/himmel/scripts/lib/initiative-legs.sh"
+td2="$(mktemp -d)"; cp "$here/legs.sh" "$td2/legs.sh"
+out="$(cd "$td2" && env -u HIMMEL_REPO HOME="$th" HIMMEL_INITIATIVE='execute' bash "$td2/legs.sh")"
+case " $out " in *" execute "*) echo "ok - resolves via default install path";; *) echo "FAIL: default-path resolution [$out]"; fails=$((fails+1));; esac
+rm -rf "$th" "$td2"
 
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -23,6 +23,8 @@
 #                     -Profile luna. Default: current directory.
 #   -LunaTarget PATH  Vault dir when -Profile all. Default: ~/Documents/luna.
 #   -DryRun           Print actions instead of doing them.
+#   -FillEnv          Interactively fill the himmel clone's .env (creates it from
+#                     .env.example if absent). Needs Git Bash. Enter to skip a var.
 #
 # Idempotent: re-running adds nothing already present.
 
@@ -34,7 +36,8 @@ param(
     [string]$Scope = 'project',
     [string]$Target,
     [string]$LunaTarget,
-    [switch]$DryRun
+    [switch]$DryRun,
+    [switch]$FillEnv
 )
 
 $ErrorActionPreference = 'Stop'
@@ -145,6 +148,55 @@ function Wire-StatuslineCore {
     if ($LASTEXITCODE -ne 0) { throw "wire-statusline failed (exit $LASTEXITCODE)" }
 }
 
+# env.HIMMEL_REPO — default-by-install (HIMMEL-453). Sibling of
+# Wire-StatuslineCore: write THIS himmel clone's path into the scope-appropriate
+# settings.json so the leg resolver + minerva anchor get it without a manual set.
+function Wire-HimmelRepoCore {
+    $settings = if ($Scope -eq 'project') {
+        Join-Path $Target '.claude\settings.json'
+    } else {
+        Join-Path $HOME '.claude\settings.json'
+    }
+    if ($DryRun) {
+        Write-Host "DRY: wire env.HIMMEL_REPO → $settings (himmel: $HimmelRoot)"
+        return
+    }
+    $whr = Join-Path $HimmelRoot 'scripts\lib\wire-himmel-repo.ps1'
+    & pwsh -NoProfile -File $whr -SettingsPath $settings -HimmelPath $HimmelRoot
+    if ($LASTEXITCODE -ne 0) { throw "wire-himmel-repo failed (exit $LASTEXITCODE)" }
+}
+
+# -FillEnv (HIMMEL-453): fill the himmel clone's .env via the bash fill-env.sh.
+# Targets $HimmelRoot\.env for BOTH scopes (adopt copies hooks, never the Jira
+# CLI, so an adopted repo always uses the clone's CLI reading $HimmelRoot\.env).
+# Resolve GIT Bash explicitly -- a bare `bash` often resolves to the System32 WSL
+# stub, which cannot read C:/... paths. Require-Tools does not verify bash.
+function FillEnv-Core {
+    if ($DryRun) { Write-Host "DRY: fill $HimmelRoot\.env"; return }
+    $gitBash = "C:\Program Files\Git\bin\bash.exe"
+    if (-not (Test-Path $gitBash)) {
+        $bc = Get-Command bash -ErrorAction SilentlyContinue
+        $gitBash = if ($bc -and $bc.Source -notmatch 'System32') { $bc.Source } else { $null }
+    }
+    if (-not $gitBash) {
+        Write-Host "  -FillEnv skipped: Git Bash not found (edit .env by hand)." -ForegroundColor Yellow
+        return
+    }
+    $envF = Join-Path $HimmelRoot '.env'
+    $exF  = Join-Path $HimmelRoot '.env.example'
+    if ((-not (Test-Path $envF)) -and (Test-Path $exF)) { Copy-Item $exF $envF }
+    if (-not (Test-Path $envF)) { return }
+    $fe = (Join-Path $HimmelRoot 'scripts/setup/fill-env.sh').Replace('\', '/')
+    $savedEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        & $gitBash $fe $envF.Replace('\', '/') $exF.Replace('\', '/')
+        if ($LASTEXITCODE -ne 0) { Write-Host "  WARNING: fill-env failed; continuing." -ForegroundColor Yellow }
+    } finally {
+        $ErrorActionPreference = $savedEAP
+    }
+}
+
 function Do-Core {
     Require-Tools
     if ($Scope -eq 'project') {
@@ -157,6 +209,8 @@ function Do-Core {
     }
     Install-Plugins
     Wire-StatuslineCore
+    Wire-HimmelRepoCore
+    if ($FillEnv) { FillEnv-Core }
     Write-Host "  (optional) pre-commit gates: see $HimmelRoot\docs\setup\use-on-your-project.md"
 }
 

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -29,6 +29,8 @@
 #                       `--profile luna`. Default: current directory.
 #   --luna-target PATH  Vault dir when `--profile all`. Default: ~/Documents/luna.
 #   --dry-run           Print actions instead of doing them.
+#   --fill-env          Interactively fill the himmel clone's .env (creates it
+#                       from .env.example if absent). Enter to skip a var.
 #
 # Idempotent: re-running adds nothing already present.
 set -euo pipefail
@@ -42,6 +44,7 @@ SCOPE="project"
 TARGET="$PWD"
 LUNA_TARGET=""
 DRY_RUN=0
+FILL_ENV=0
 
 # ── Parse args ───────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -51,6 +54,7 @@ while [[ $# -gt 0 ]]; do
     --target)       TARGET="$2"; shift 2 ;;
     --luna-target)  LUNA_TARGET="$2"; shift 2 ;;
     --dry-run)      DRY_RUN=1; shift ;;
+    --fill-env)     FILL_ENV=1; shift ;;
     -h|--help)      sed -n '2,/^set -e/p' "$0" | sed 's/^# \{0,1\}//' | sed '$d'; exit 0 ;;
     *) echo "ERROR: unknown flag: $1" >&2; exit 2 ;;
   esac
@@ -163,6 +167,38 @@ wire_statusline_core() {
   bash "$HIMMEL_ROOT/scripts/lib/wire-statusline.sh" "$settings" "$HIMMEL_ROOT"
 }
 
+# env.HIMMEL_REPO — default-by-install (HIMMEL-453). Sibling of
+# wire_statusline_core: write THIS himmel clone's path into the scope-appropriate
+# settings.json so the leg resolver + minerva anchor get it without a manual set.
+wire_himmel_repo_core() {
+  local settings
+  if [[ "$SCOPE" == "project" ]]; then
+    settings="$TARGET/.claude/settings.json"
+  else
+    settings="$HOME/.claude/settings.json"
+  fi
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "DRY: wire env.HIMMEL_REPO → $settings (himmel: $HIMMEL_ROOT)"
+    return
+  fi
+  bash "$HIMMEL_ROOT/scripts/lib/wire-himmel-repo.sh" "$settings" "$HIMMEL_ROOT"
+}
+
+# --fill-env (HIMMEL-453): fill the himmel clone's .env. We target
+# $HIMMEL_ROOT/.env (NOT $TARGET/.env) for BOTH scopes because adopt copies only
+# portable hooks — never the Jira CLI — so an adopted repo always invokes
+# `node $HIMMEL_ROOT/scripts/jira/...`, whose repoRoot() reads $HIMMEL_ROOT/.env.
+fill_env_core() {
+  [[ $DRY_RUN -eq 1 ]] && { echo "DRY: fill $HIMMEL_ROOT/.env"; return; }
+  if [[ ! -f "$HIMMEL_ROOT/.env" ]] && [[ -f "$HIMMEL_ROOT/.env.example" ]]; then
+    cp "$HIMMEL_ROOT/.env.example" "$HIMMEL_ROOT/.env"
+  fi
+  if [[ -f "$HIMMEL_ROOT/.env" ]]; then
+    bash "$HIMMEL_ROOT/scripts/setup/fill-env.sh" "$HIMMEL_ROOT/.env" "$HIMMEL_ROOT/.env.example" \
+      || echo "  WARNING: fill-env failed; continuing." >&2
+  fi
+}
+
 do_core() {
   require_tools
   if [[ "$SCOPE" == "project" ]]; then
@@ -178,6 +214,8 @@ do_core() {
   fi
   install_plugins
   wire_statusline_core
+  wire_himmel_repo_core
+  [[ $FILL_ENV -eq 1 ]] && fill_env_core
   echo "  (optional) pre-commit gates: see $HIMMEL_ROOT/docs/setup/use-on-your-project.md (Pre-commit hooks)"
 }
 

--- a/scripts/lib/test-wire-himmel-repo.ps1
+++ b/scripts/lib/test-wire-himmel-repo.ps1
@@ -1,0 +1,71 @@
+# test-wire-himmel-repo.ps1 -- committed PS test for wire-himmel-repo.ps1
+# (HIMMEL-453). The .env merge is genuinely new logic vs the statusline twin's
+# single-object set, and clobbering a sibling key (e.g. HIMMEL_INITIATIVE) is the
+# highest-risk failure on the operator's primary platform -- so it gets a real
+# assertion, not parity-by-inspection. Run: pwsh -File test-wire-himmel-repo.ps1
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$wire = Join-Path $here 'wire-himmel-repo.ps1'
+$fails = 0
+function Check($name, $got, $want) {
+    if ($got -eq $want) { Write-Host "ok - $name" }
+    else { Write-Host "FAIL - ${name}: [$got]!=[$want]"; $script:fails++ }
+}
+
+$td = Join-Path ([System.IO.Path]::GetTempPath()) ("wirehr-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force $td | Out-Null
+
+# 1. existing sibling env key preserved + HIMMEL_REPO added.
+$s1 = Join-Path $td 's1.json'
+'{"statusLine":{"type":"command"},"env":{"HIMMEL_INITIATIVE":"all"}}' | Set-Content $s1 -Encoding utf8
+& pwsh -NoProfile -File $wire -SettingsPath $s1 -HimmelPath 'C:/himmel' | Out-Null
+$c1 = Get-Content $s1 -Raw | ConvertFrom-Json
+Check 'sibling env key preserved' $c1.env.HIMMEL_INITIATIVE 'all'
+Check 'top-level key preserved'   $c1.statusLine.type 'command'
+Check 'HIMMEL_REPO added'         $c1.env.HIMMEL_REPO 'C:/himmel'
+
+# 2. missing file -> created with env.HIMMEL_REPO.
+$s2 = Join-Path $td 's2.json'
+& pwsh -NoProfile -File $wire -SettingsPath $s2 -HimmelPath 'C:/himmel' | Out-Null
+$c2 = Get-Content $s2 -Raw | ConvertFrom-Json
+Check 'create on missing file' $c2.env.HIMMEL_REPO 'C:/himmel'
+
+# 3. backslash -> forward-slashed.
+$s3 = Join-Path $td 's3.json'
+& pwsh -NoProfile -File $wire -SettingsPath $s3 -HimmelPath 'C:\Users\me\himmel' | Out-Null
+$c3 = Get-Content $s3 -Raw | ConvertFrom-Json
+Check 'backslash forward-slashed' $c3.env.HIMMEL_REPO 'C:/Users/me/himmel'
+
+# 4. invalid JSON -> exit 1, file unchanged.
+$s4 = Join-Path $td 's4.json'
+'not json {' | Set-Content $s4 -Encoding utf8
+& pwsh -NoProfile -File $wire -SettingsPath $s4 -HimmelPath 'C:/himmel' 2>$null | Out-Null
+if ($LASTEXITCODE -eq 0) { Write-Host 'FAIL: invalid JSON not refused'; $fails++ }
+else { Write-Host 'ok - refuses invalid JSON' }
+Check 'invalid file unchanged' ((Get-Content $s4 -Raw).Trim()) 'not json {'
+
+# 5. replace an EXISTING HIMMEL_REPO value (the update arm of the PS branch).
+$s5 = Join-Path $td 's5.json'
+'{"env":{"HIMMEL_REPO":"C:/old","KEEP":"x"}}' | Set-Content $s5 -Encoding utf8
+& pwsh -NoProfile -File $wire -SettingsPath $s5 -HimmelPath 'C:/new' | Out-Null
+$c5 = Get-Content $s5 -Raw | ConvertFrom-Json
+Check 'replaces existing value' $c5.env.HIMMEL_REPO 'C:/new'
+Check 'replace keeps sibling'   $c5.env.KEEP 'x'
+
+# 6. idempotent -> second run identical bytes (PS serializer path).
+$s6 = Join-Path $td 's6.json'
+& pwsh -NoProfile -File $wire -SettingsPath $s6 -HimmelPath 'C:/himmel' | Out-Null
+$h6a = Get-Content $s6 -Raw
+& pwsh -NoProfile -File $wire -SettingsPath $s6 -HimmelPath 'C:/himmel' | Out-Null
+Check 'idempotent re-run' (Get-Content $s6 -Raw) $h6a
+
+# 7. whitespace-only file -> treated as {}, not refused.
+$s7 = Join-Path $td 's7.json'
+"   `n" | Set-Content $s7 -Encoding utf8
+& pwsh -NoProfile -File $wire -SettingsPath $s7 -HimmelPath 'C:/himmel' | Out-Null
+$c7 = Get-Content $s7 -Raw | ConvertFrom-Json
+Check 'whitespace file -> created' $c7.env.HIMMEL_REPO 'C:/himmel'
+
+Remove-Item -Recurse -Force $td
+if ($fails -eq 0) { Write-Host 'ALL PASS' } else { Write-Host "$fails FAILED"; exit 1 }

--- a/scripts/lib/test-wire-himmel-repo.sh
+++ b/scripts/lib/test-wire-himmel-repo.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+# test-wire-himmel-repo.sh -- hermetic tests for wire-himmel-repo.sh (HIMMEL-453).
+# Verifies the settings.json .env.HIMMEL_REPO merge: create, preserve siblings,
+# forward-slash, refuse invalid JSON, idempotent.
+set -u
+# Fixture values use a Windows-style path (C:/himmel) -- exactly what
+# `git rev-parse --show-toplevel` yields on the operator's primary platform, and
+# unaffected by Git-Bash's leading-slash->drive path translation. A bare
+# /x/himmel would be mangled to X:/himmel by MSYS before the callee sees it.
+here="$(cd "$(dirname "$0")" && pwd)"
+wire="$here/wire-himmel-repo.sh"
+fails=0
+check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+
+td="$(mktemp -d)"
+
+# 1. missing file -> creates {"env":{"HIMMEL_REPO":"C:/himmel"}}.
+s1="$td/s1.json"
+bash "$wire" "$s1" "C:/himmel" >/dev/null
+check "create on missing file" "$(jq -r '.env.HIMMEL_REPO' "$s1")" "C:/himmel"
+
+# 2. existing siblings preserved (other env key + a top-level key).
+s2="$td/s2.json"
+printf '%s' '{"statusLine":{"type":"command"},"env":{"HIMMEL_INITIATIVE":"all"}}' > "$s2"
+bash "$wire" "$s2" "C:/himmel" >/dev/null
+check "sibling env key preserved" "$(jq -r '.env.HIMMEL_INITIATIVE' "$s2")" "all"
+check "top-level key preserved"   "$(jq -r '.statusLine.type' "$s2")" "command"
+check "HIMMEL_REPO added"         "$(jq -r '.env.HIMMEL_REPO' "$s2")" "C:/himmel"
+
+# 3. backslash path arg -> stored forward-slashed.
+s3="$td/s3.json"
+bash "$wire" "$s3" 'C:\Users\me\himmel' >/dev/null
+check "backslash forward-slashed" "$(jq -r '.env.HIMMEL_REPO' "$s3")" "C:/Users/me/himmel"
+
+# 4. invalid JSON -> rc != 0, file unchanged.
+s4="$td/s4.json"
+printf '%s' 'not json {' > "$s4"
+if bash "$wire" "$s4" "C:/himmel" >/dev/null 2>&1; then
+  echo "FAIL: invalid JSON not refused"; fails=$((fails+1))
+else
+  echo "ok - refuses invalid JSON"
+fi
+check "invalid file unchanged" "$(cat "$s4")" "not json {"
+
+# 5. idempotent -> second run identical bytes.
+s5="$td/s5.json"
+bash "$wire" "$s5" "C:/himmel" >/dev/null
+h5a="$(cat "$s5")"
+bash "$wire" "$s5" "C:/himmel" >/dev/null
+check "idempotent re-run" "$(cat "$s5")" "$h5a"
+
+# 6. replace an EXISTING HIMMEL_REPO value (the update arm, not add).
+s6="$td/s6.json"
+printf '%s' '{"env":{"HIMMEL_REPO":"C:/old","KEEP":"x"}}' > "$s6"
+bash "$wire" "$s6" "C:/new" >/dev/null
+check "replaces existing value" "$(jq -r '.env.HIMMEL_REPO' "$s6")" "C:/new"
+check "replace keeps sibling"   "$(jq -r '.env.KEEP' "$s6")" "x"
+
+# 7. empty / whitespace-only file -> treated as {}, not refused as invalid JSON.
+s7="$td/s7.json"
+printf '   \n' > "$s7"
+bash "$wire" "$s7" "C:/himmel" >/dev/null
+check "whitespace file -> created" "$(jq -r '.env.HIMMEL_REPO' "$s7")" "C:/himmel"
+
+rm -rf "$td"
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/lib/wire-himmel-repo.ps1
+++ b/scripts/lib/wire-himmel-repo.ps1
@@ -1,0 +1,80 @@
+# wire-himmel-repo.ps1 -- PowerShell counterpart of wire-himmel-repo.sh
+# (HIMMEL-453). Sets .env.HIMMEL_REPO in a Claude Code settings.json to the
+# himmel clone path. Sibling of wire-statusline.ps1 -- same shape, but it MERGES
+# into the existing .env object (preserving HIMMEL_INITIATIVE and any other env
+# keys) instead of replacing a single top-level object.
+#
+# Dot-source to get Set-HimmelRepo, or invoke directly:
+#   pwsh -File wire-himmel-repo.ps1 -SettingsPath <path> -HimmelPath <path>
+#
+# Idempotent, atomic (temp + move), non-destructive (other keys preserved; file
+# + parent dir created if absent). Normalizes JSON through `jq --indent 2` when
+# jq is on PATH (matches the statusline twin), else falls back to ConvertTo-Json.
+
+[CmdletBinding()]
+param(
+    [string]$SettingsPath,
+    [string]$HimmelPath
+)
+
+function Set-HimmelRepo {
+    param(
+        [Parameter(Mandatory = $true)] [string]$SettingsPath,
+        [Parameter(Mandatory = $true)] [string]$HimmelPath
+    )
+
+    # Forward-slash so the stored value is a valid Git-Bash path even when a
+    # caller passes a Windows backslash path.
+    $repoFwd = $HimmelPath.Replace('\', '/')
+
+    if (Test-Path $SettingsPath) {
+        $raw = Get-Content $SettingsPath -Raw
+        if ([string]::IsNullOrWhiteSpace($raw)) {
+            $cfg = [pscustomobject]@{}
+        } else {
+            try {
+                $cfg = $raw | ConvertFrom-Json
+            } catch {
+                # Throw (not Write-Error+return): the entry point converts this to
+                # `exit 1` so `-File` callers see a non-zero code, matching the
+                # bash twin's `return 1`.
+                throw "wire-himmel-repo: $SettingsPath is not valid JSON -- refusing to overwrite"
+            }
+        }
+    } else {
+        $dir = Split-Path $SettingsPath
+        if ($dir) { New-Item -ItemType Directory -Force $dir | Out-Null }
+        $cfg = [pscustomobject]@{}
+    }
+
+    # Ensure an .env object exists, then set/replace only the HIMMEL_REPO member
+    # (all sibling env keys preserved).
+    if (-not $cfg.PSObject.Properties['env'] -or $null -eq $cfg.env) {
+        $cfg | Add-Member -NotePropertyName env -NotePropertyValue ([pscustomobject]@{}) -Force
+    }
+    if ($cfg.env.PSObject.Properties['HIMMEL_REPO']) {
+        $cfg.env.HIMMEL_REPO = $repoFwd
+    } else {
+        $cfg.env | Add-Member -NotePropertyName HIMMEL_REPO -NotePropertyValue $repoFwd -Force
+    }
+
+    $json = $cfg | ConvertTo-Json -Depth 20
+    if (Get-Command jq -ErrorAction SilentlyContinue) {
+        $normalized = $json | jq --indent 2 .
+        if ($LASTEXITCODE -eq 0 -and $normalized) { $json = $normalized -join "`n" }
+    }
+    Set-Content -Path "$SettingsPath.new" -Value $json -Encoding utf8
+    Move-Item -Path "$SettingsPath.new" -Destination $SettingsPath -Force
+    Write-Host "  set env.HIMMEL_REPO -> $SettingsPath"
+}
+
+# Direct invocation (both args supplied) runs the function. Dot-sourcing with no
+# args just defines it.
+if ($SettingsPath -and $HimmelPath) {
+    try {
+        Set-HimmelRepo -SettingsPath $SettingsPath -HimmelPath $HimmelPath
+    } catch {
+        Write-Error $_
+        exit 1
+    }
+}

--- a/scripts/lib/wire-himmel-repo.sh
+++ b/scripts/lib/wire-himmel-repo.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# wire-himmel-repo.sh -- set env.HIMMEL_REPO in a Claude Code settings.json to
+# the himmel clone path (HIMMEL-453). The leg resolver + minerva transport anchor
+# to HIMMEL_REPO (marketplace/plugins/himmel-ops/scripts/legs.sh); setup.sh and
+# adopt.sh call this so it is set without a manual export. Sibling of
+# wire-statusline.sh -- same shape, different key.
+#
+# Usage:
+#   bash wire-himmel-repo.sh <settings-json-path> <himmel-path>
+#
+# Sets:
+#   .env.HIMMEL_REPO = "<himmel-path forward-slashed>"   (all other .env keys
+#   preserved -- HIMMEL_INITIATIVE etc. are never clobbered).
+#
+# Idempotent (re-setting the same value is a no-op), atomic (temp file + mv),
+# non-destructive (other keys preserved; file + parent dir created if absent).
+# Requires jq. Invoked via bash, never sourced.
+set -euo pipefail
+
+wire_himmel_repo() {
+  local settings="$1" himmel="$2"
+  command -v jq >/dev/null 2>&1 || { echo "wire-himmel-repo: jq required" >&2; return 1; }
+
+  # Forward-slash the himmel path so the stored value is a valid Git-Bash path
+  # even when a caller passes a Windows backslash path.
+  local himmel_fwd="${himmel//\\//}"
+
+  mkdir -p "$(dirname "$settings")"
+  local base="{}"
+  if [ -s "$settings" ]; then
+    base=$(cat "$settings")
+    # An empty / whitespace-only file -> treat as {} (jq would choke on it).
+    # A non-empty but INVALID file -> refuse, rather than clobber data.
+    if [ -z "$(printf '%s' "$base" | tr -d '[:space:]')" ]; then
+      base="{}"
+    elif ! printf '%s' "$base" | jq -e . >/dev/null 2>&1; then
+      echo "wire-himmel-repo: $settings is not valid JSON -- refusing to overwrite" >&2
+      return 1
+    fi
+  fi
+
+  printf '%s' "$base" | jq --arg repo "$himmel_fwd" \
+    '.env = ((.env // {}) + { HIMMEL_REPO: $repo })' \
+    > "$settings.himmelrepo.tmp" && mv "$settings.himmelrepo.tmp" "$settings"
+  echo "  set env.HIMMEL_REPO -> $settings"
+}
+
+# Allow both `source wire-himmel-repo.sh` (to call wire_himmel_repo directly) and
+# direct invocation `bash wire-himmel-repo.sh <settings> <himmel>`.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  if [ "$#" -ne 2 ]; then
+    echo "usage: wire-himmel-repo.sh <settings-json-path> <himmel-path>" >&2
+    exit 2
+  fi
+  wire_himmel_repo "$1" "$2"
+fi

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -7,11 +7,15 @@
 # -WithJira : require Jira configuration — abort if JIRA_PROJECT_KEY is
 #             unset. Without the switch the check downgrades to a skip
 #             notice (HIMMEL-285).
+# -FillEnv  : after creating .env, interactively prompt for each must-set value
+#             (Enter to skip). Non-interactive shells no-op. Shells out to the
+#             bash fill-env.sh (Git Bash verified in [0/10]). (HIMMEL-453)
 
 [CmdletBinding()]
 param(
     [switch]$WithCs,
-    [switch]$WithJira
+    [switch]$WithJira,
+    [switch]$FillEnv
 )
 
 $RepoRoot = git rev-parse --show-toplevel
@@ -195,6 +199,34 @@ if (-not (Test-Path ".env")) {
 } else {
     Write-Host "  .env already exists -- skipping"
 }
+# -FillEnv (HIMMEL-453): prompt for the must-set values via the bash fill-env.sh
+# (one implementation). Default-off; non-interactive shells no-op inside
+# fill-env.sh. Resolve GIT Bash explicitly -- a bare `bash` on Windows often
+# resolves to the System32 WSL stub, which cannot read C:/... paths.
+if ($FillEnv -and (Test-Path ".env")) {
+    $gitBash = "C:\Program Files\Git\bin\bash.exe"
+    if (-not (Test-Path $gitBash)) {
+        $bc = Get-Command bash -ErrorAction SilentlyContinue
+        $gitBash = if ($bc -and $bc.Source -notmatch 'System32') { $bc.Source } else { $null }
+    }
+    if (-not $gitBash) {
+        Write-Host "  -FillEnv skipped: Git Bash not found (edit .env by hand)." -ForegroundColor Yellow
+    } else {
+        $fe   = (Join-Path $RepoRoot "scripts/setup/fill-env.sh").Replace('\', '/')
+        $envF = (Join-Path $RepoRoot ".env").Replace('\', '/')
+        $exF  = (Join-Path $RepoRoot ".env.example").Replace('\', '/')
+        $savedEAP = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = 'Continue'
+            & $gitBash $fe $envF $exF
+            if ($LASTEXITCODE -ne 0) { Write-Host "  WARNING: fill-env failed; continuing." -ForegroundColor Yellow }
+        } finally {
+            $ErrorActionPreference = $savedEAP
+        }
+    }
+} elseif (Test-Path ".env") {
+    Write-Host "  (re-run with -FillEnv to be prompted for .env values)"
+}
 
 # --- handover root ---
 # Reports where Claude will read/write handover state (per HIMMEL-118
@@ -297,18 +329,23 @@ if (Get-Command claude -ErrorAction SilentlyContinue) {
 }
 Write-Host ""
 
-# --- statusline (HIMMEL-359) ---
-# Wire the himmel statusline into ~/.claude/settings.json via the shared helper.
-# Independent of the plugin step (writes settings.json, needs no claude binary);
-# idempotent.
-Write-Host "[9/10] Wiring statusline (user scope)..."
+# --- statusline + HIMMEL_REPO (HIMMEL-359 / HIMMEL-453) ---
+# Wire the himmel statusline AND env.HIMMEL_REPO into ~/.claude/settings.json via
+# the shared helpers. Both write settings.json, need no claude binary, idempotent.
+Write-Host "[9/10] Wiring statusline + HIMMEL_REPO (user scope)..."
+$settingsJson = Join-Path $HOME ".claude\settings.json"
 $savedEAP = $ErrorActionPreference
 try {
     $ErrorActionPreference = 'Continue'
     & pwsh -NoProfile -File (Join-Path $RepoRoot "scripts\lib\wire-statusline.ps1") `
-        -SettingsPath (Join-Path $HOME ".claude\settings.json") -HimmelPath $RepoRoot
+        -SettingsPath $settingsJson -HimmelPath $RepoRoot
     if ($LASTEXITCODE -ne 0) {
         Write-Host "  WARNING: wire-statusline failed; setup continues." -ForegroundColor Yellow
+    }
+    & pwsh -NoProfile -File (Join-Path $RepoRoot "scripts\lib\wire-himmel-repo.ps1") `
+        -SettingsPath $settingsJson -HimmelPath $RepoRoot
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  WARNING: wire-himmel-repo failed; setup continues." -ForegroundColor Yellow
     }
 } finally {
     $ErrorActionPreference = $savedEAP

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -21,14 +21,16 @@ cd "$REPO_ROOT"
 # no flag uses them yet, but reserve the pattern.
 WITH_CS=0
 WITH_JIRA=0
+FILL_ENV=0
 setup_extra_args=()
 while [ $# -gt 0 ]; do
   case "$1" in
     --with-cs) WITH_CS=1 ;;
     --with-jira) WITH_JIRA=1 ;;
+    --fill-env) FILL_ENV=1 ;;
     --help|-h)
       cat <<'USAGE'
-Usage: bash scripts/setup.sh [--with-cs] [--with-jira]
+Usage: bash scripts/setup.sh [--with-cs] [--with-jira] [--fill-env]
 
 Optional flags:
   --with-cs    Install claude-squad (cs) at the end of setup.
@@ -37,6 +39,9 @@ Optional flags:
   --with-jira  Require Jira configuration: abort setup if JIRA_PROJECT_KEY
                is unset. Without the flag the check downgrades to a skip
                notice and Jira-dependent next-steps are omitted.
+  --fill-env   After creating .env, interactively prompt for each must-set
+               value (Enter to skip / keep current). Non-interactive shells
+               no-op. Without the flag, .env keeps the .env.example placeholders.
 USAGE
       exit 0
       ;;
@@ -262,6 +267,14 @@ if [ ! -f ".env" ]; then
 else
   echo "  .env already exists -- skipping"
 fi
+# --fill-env (HIMMEL-453): prompt for the must-set values now. Default-off keeps
+# unattended runs unchanged; non-interactive shells no-op inside fill-env.sh.
+if [ "$FILL_ENV" = "1" ] && [ -f ".env" ]; then
+  bash "$REPO_ROOT/scripts/setup/fill-env.sh" "$REPO_ROOT/.env" "$REPO_ROOT/.env.example" \
+    || echo "  WARNING: fill-env failed; continuing." >&2
+elif [ -f ".env" ]; then
+  echo "  (re-run with --fill-env to be prompted for .env values)"
+fi
 
 # --- handover root ---
 # Reports where Claude will read/write handover state (per HIMMEL-118
@@ -315,13 +328,17 @@ else
 fi
 echo ""
 
-# --- statusline (HIMMEL-359) ---
-# Wire the himmel statusline into ~/.claude/settings.json via the shared helper.
-# Independent of the plugin step (writes settings.json, needs no claude binary);
-# idempotent.
-echo "[9/10] Wiring statusline (user scope)..."
+# --- statusline + HIMMEL_REPO (HIMMEL-359 / HIMMEL-453) ---
+# Wire the himmel statusline AND env.HIMMEL_REPO into ~/.claude/settings.json via
+# the shared helpers. Both write settings.json, need no claude binary, idempotent.
+# HIMMEL_REPO default-by-install: the installer knows the clone path, so the leg
+# resolver + minerva anchor get it without a manual export.
+echo "[9/10] Wiring statusline + HIMMEL_REPO (user scope)..."
 if ! bash "$REPO_ROOT/scripts/lib/wire-statusline.sh" "$HOME/.claude/settings.json" "$REPO_ROOT"; then
   echo "  WARNING: wire-statusline failed; setup continues." >&2
+fi
+if ! bash "$REPO_ROOT/scripts/lib/wire-himmel-repo.sh" "$HOME/.claude/settings.json" "$REPO_ROOT"; then
+  echo "  WARNING: wire-himmel-repo failed; setup continues." >&2
 fi
 echo ""
 

--- a/scripts/setup/fill-env.sh
+++ b/scripts/setup/fill-env.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# fill-env.sh -- interactive fill of the must-set .env values (HIMMEL-453).
+# Prompts for each UNCOMMENTED `KEY=` line in .env.example (the must-set vars;
+# commented lines are opt-in -- uncomment first) and writes the answer into .env.
+# Press Enter at any prompt to SKIP that var (keep its current value).
+# Non-interactive stdin -> no-op with a notice.
+#
+# Opt-in: only runs when setup.sh/adopt.sh are passed --fill-env / -FillEnv.
+# bash-only (the PS installers shell out to it) so there is ONE implementation
+# operating on a plain-text file.
+#
+# Source-safe: defines functions on `source`, runs fill_env only on direct
+# invocation. NO top-level `set -e` (it would alter a sourcing caller's shell).
+#   bash fill-env.sh <env-file> [example-file]
+
+# Strip trailing CR + surrounding whitespace (CRLF-safe; mirrors
+# scripts/lib/load-dotenv.sh::_load_dotenv_trim). Pure (stdout only).
+_fe_trim() {
+  local s="$1"
+  s="${s%$'\r'}"
+  s="${s#"${s%%[![:space:]]*}"}"   # ltrim
+  s="${s%"${s##*[![:space:]]}"}"   # rtrim
+  printf '%s' "$s"
+}
+
+# dotenv_get <file> <key> -- value of the first uncommented `KEY=` line, trimmed
+# (CR-stripped); empty if absent.
+dotenv_get() {
+  local file="$1" key="$2" line
+  [ -f "$file" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"
+    case "$line" in "$key="*) _fe_trim "${line#*=}"; return 0 ;; esac
+  done < "$file"
+}
+
+# dotenv_set <file> <key> <value> -- replace the FIRST uncommented `KEY=` line in
+# place (CRLF on that line tolerated); append `KEY=value` if absent. Idempotent.
+dotenv_set() {
+  local file="$1" key="$2" val="$3" tmp
+  if [ -f "$file" ] && grep -qE "^${key}=" "$file"; then
+    tmp="$(mktemp)"
+    # Pass key/value via ENVIRON, NOT `awk -v` -- `-v` escape-processes the value
+    # (a backslash or \n in a Windows path would silently corrupt the .env).
+    # ENVIRON[] values are taken literally. Replace the FIRST `KEY=` line.
+    FE_K="$key" FE_V="$val" awk '
+      !done && index($0, ENVIRON["FE_K"] "=") == 1 { print ENVIRON["FE_K"] "=" ENVIRON["FE_V"]; done=1; next }
+      { print }
+    ' "$file" > "$tmp" && mv "$tmp" "$file"
+  else
+    # Ensure the file ends in a newline before appending -- a final line with no
+    # trailing \n would otherwise fuse with the new KEY=value.
+    if [ -s "$file" ] && [ -n "$(tail -c1 "$file")" ]; then printf '\n' >> "$file"; fi
+    printf '%s=%s\n' "$key" "$val" >> "$file"
+  fi
+}
+
+# fillable_keys <example-file> -- names of every UNCOMMENTED `KEY=` line, in file
+# order (whole file; no section logic). CR-tolerant.
+fillable_keys() {
+  local file="$1" line
+  [ -f "$file" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"
+    case "$line" in
+      [A-Za-z_]*=*) printf '%s\n' "${line%%=*}" ;;
+    esac
+  done < "$file"
+}
+
+# fill_env <env-file> [example-file] -- interactive prompt loop.
+fill_env() {
+  local envfile="$1" example="${2:-}" key cur ans
+  [ -n "$envfile" ] || { echo "fill-env: usage: fill_env <env-file> [example-file]" >&2; return 2; }
+  [ -f "$envfile" ] || { echo "fill-env: $envfile not found" >&2; return 1; }
+  [ -n "$example" ] || example="$(dirname "$envfile")/.env.example"
+  [ -f "$example" ] || { echo "fill-env: $example not found" >&2; return 1; }
+  if [ ! -t 0 ]; then
+    echo "fill-env: non-interactive shell -- skipping (.env left as-is)." >&2
+    return 0
+  fi
+  echo "Fill .env values (press Enter to skip / keep current):"
+  while IFS= read -r key; do
+    cur="$(dotenv_get "$envfile" "$key")"
+    printf '  %s [%s]: ' "$key" "$cur"
+    IFS= read -r ans || ans=""
+    if [ -n "$ans" ]; then
+      dotenv_set "$envfile" "$key" "$ans" || echo "  WARNING: could not write $key" >&2
+    fi
+  done < <(fillable_keys "$example")
+  echo "  done."
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  fill_env "$@"
+fi

--- a/scripts/setup/test-fill-env.sh
+++ b/scripts/setup/test-fill-env.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+# test-fill-env.sh -- hermetic tests for fill-env.sh pure helpers (HIMMEL-453).
+# dotenv_get/set (incl. CRLF), fillable_keys (fixture-based, NOT pinned to the
+# live .env.example), and the non-interactive fill_env no-op.
+set -u
+here="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
+. "$here/fill-env.sh"
+fails=0
+check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+
+td="$(mktemp -d)"
+
+# dotenv_set replaces existing key (first match only).
+f1="$td/f1.env"
+printf 'A=1\nKEY=old\nB=2\nKEY=dup\n' > "$f1"
+dotenv_set "$f1" KEY new
+check "set replaces first match" "$(dotenv_get "$f1" KEY)" "new"
+check "set leaves later dup"     "$(grep -c '^KEY=dup' "$f1")" "1"
+check "set preserves siblings"   "$(dotenv_get "$f1" B)" "2"
+
+# dotenv_set appends an absent key.
+f2="$td/f2.env"
+printf 'A=1\n' > "$f2"
+dotenv_set "$f2" NEWKEY hello
+check "set appends absent key" "$(dotenv_get "$f2" NEWKEY)" "hello"
+
+# dotenv_set preserves a backslash-bearing value (awk ENVIRON, not -v escaping).
+f2b="$td/f2b.env"
+printf 'KEY=old\n' > "$f2b"
+dotenv_set "$f2b" KEY 'C:\Users\me\himmel'
+check "set keeps backslashes" "$(dotenv_get "$f2b" KEY)" 'C:\Users\me\himmel'
+
+# dotenv_set appends safely onto a file with NO trailing newline (no fusing).
+f2c="$td/f2c.env"
+printf 'FOO=old' > "$f2c"   # deliberately no trailing \n
+dotenv_set "$f2c" BAR new
+check "no-trailing-newline: FOO intact" "$(dotenv_get "$f2c" FOO)" "old"
+check "no-trailing-newline: BAR added"  "$(dotenv_get "$f2c" BAR)" "new"
+
+# Value containing '=' (e.g. a base64-padded token) round-trips intact.
+f2d="$td/f2d.env"
+printf 'TOK=old\n' > "$f2d"
+dotenv_set "$f2d" TOK 'a=b=c=='
+check "value with = round-trips" "$(dotenv_get "$f2d" TOK)" 'a=b=c=='
+
+# CRLF: a KEY=old\r line -> get returns clean value, set replaces cleanly.
+f3="$td/f3.env"
+printf 'A=1\r\nKEY=old\r\n' > "$f3"
+check "get strips CR" "$(dotenv_get "$f3" KEY)" "old"
+dotenv_set "$f3" KEY fresh
+check "set on CRLF line" "$(dotenv_get "$f3" KEY)" "fresh"
+
+# fillable_keys against a FIXTURE (commented + uncommented + blank + no-`=`).
+f4="$td/example.env"
+{
+  printf '# a comment\n'
+  printf 'USER_SLUG=your-slug\n'
+  printf '# COMMENTED_KEY=skipme\n'
+  printf '\n'
+  printf 'JIRA_API_TOKEN=tok\n'
+  printf 'not a kv line\n'
+  printf '  # indented comment\n'
+  printf 'ubuntu_vm_user=u\n'
+} > "$f4"
+got="$(fillable_keys "$f4" | tr '\n' ',')"
+check "fillable_keys = uncommented only" "$got" "USER_SLUG,JIRA_API_TOKEN,ubuntu_vm_user,"
+
+# fillable_keys smoke run against the real .env.example (no assert, just rc 0).
+if fillable_keys "$here/../../.env.example" >/dev/null 2>&1; then
+  echo "ok - fillable_keys smoke on real .env.example"
+else
+  echo "FAIL: fillable_keys errored on real .env.example"; fails=$((fails+1))
+fi
+
+# fill_env non-interactive (stdin not a TTY) -> rc 0, file unchanged.
+f5="$td/f5.env"
+printf 'JIRA_API_TOKEN=keepme\n' > "$f5"
+before="$(cat "$f5")"
+fill_env "$f5" "$f4" </dev/null >/dev/null 2>&1; rc=$?
+check "fill_env non-interactive rc 0" "$rc" "0"
+check "fill_env non-interactive no-op" "$(cat "$f5")" "$before"
+
+rm -rf "$td"
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
Self-document .env.example (TOOL-LOADED vs PROCESS-ENV vs EXTERNAL, verified classification); HIMMEL_REPO default-by-install via wire-himmel-repo.{sh,ps1} + legs.sh fallback; opt-in --fill-env/-FillEnv interactive fill. Tests: legs 5, wire 11x2, fill-env 15. Propagated from private #636.