### PR TITLE
chore(luna): ignore /.worktrees/ in vault template gitignore

### DIFF
--- a/templates/luna-second-brain/.gitignore
+++ b/templates/luna-second-brain/.gitignore
@@ -29,6 +29,7 @@ __pycache__/
 
 # Claude worktrees
 /.claude/worktrees/
+/.worktrees/
 /.claude/settings.local.json
 
 # Single-writer opt-in marker. A per-clone, gitignored file that designates


### PR DESCRIPTION
Adds `/.worktrees/` to `templates/luna-second-brain/.gitignore`. Vault autosync's `git add -A` was recapturing root `.worktrees/` git-worktree dirs as phantom submodule gitlinks; the leading-slash ignore stops it. Auto-propagates to existing vaults via /luna-upgrade (`.gitignore` classified `overwrite` in upgrade.sh). Private: yotamleo/himmel-private#637 / HIMMEL-460.