### PR TITLE
feat(setup): [HIMMEL-469] install/uninstall symmetry + user-scope universal hooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,11 @@
 #      environment, NOT this file. These must be EXPORTED in the shell that
 #      launches `claude`, or set in ~/.claude/settings.json "env" {} (Claude Code
 #      injects that block into every session). A value sitting ONLY in this .env
-#      is never seen -- e.g. the SessionStart hook that reads HIMMEL_INITIATIVE
-#      does not load .env. (Exception: HANDOVER_DIR and USER_SLUG are bridged
-#      from .env into the env by scripts/lib/load-dotenv.sh, so those two also
-#      work from here.)
+#      is never seen by most of them. (Exceptions, bridged from .env by
+#      scripts/lib/load-dotenv.sh: HANDOVER_DIR and USER_SLUG always; and the
+#      SessionStart inject-initiative hook reads HIMMEL_INITIATIVE /
+#      HIMMEL_OVERNIGHT / HIMMEL_INITIATIVE_OVERNIGHT from the himmel clone's
+#      .env when they are not already exported -- HIMMEL-460.)
 #
 # setup.sh / adopt.sh AUTO-SET HIMMEL_REPO for you (it is the himmel clone path,
 # which the installer knows) into ~/.claude/settings.json. Run setup/adopt with
@@ -62,21 +63,30 @@ JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian cloud id (REST / 
 
 # === SECTION: PROCESS-ENV ===  read from the LIVE env -- EXPORT these (shell or
 #     ~/.claude/settings.json "env" {}); a value ONLY in .env is NOT read, except
-#     the two load-dotenv-bridged vars noted below.
+#     the load-dotenv-bridged vars (HANDOVER_DIR, USER_SLUG, and the
+#     HIMMEL_INITIATIVE* set) noted below.
 
 # --- himmel harness ---
 # Path to your himmel checkout. The leg resolver + minerva transport anchor to it
 # (marketplace/plugins/himmel-ops/scripts/legs.sh). setup.sh / adopt.sh AUTO-SET
 # this into ~/.claude/settings.json; legs.sh also falls back to the default
 # install path ($HOME/Documents/github/himmel). Set it explicitly only for a
-# non-default clone location.  EXPORT -- not read from .env.
+# non-default clone location.  Read from the live env / settings.json (setup
+# auto-sets it); NOT from this .env.
 # HIMMEL_REPO=/c/path/to/your/himmel
-# Drive-to-ship initiative legs (HIMMEL-425/443). Default OFF. `1`/`all` enables
-# the full interactive profile, or a comma-subset of:
-#   plan,execute,prcheck,pr,ticket,merge,public,handover     EXPORT -- not read from .env.
+# Drive-to-ship initiative legs (HIMMEL-425/443/460). Default OFF -- opt-in, so
+# keep it COMMENTED unless you want every Claude session on this MACHINE to drive
+# to ship (the hook is user-scope-wired by setup/adopt and always reads THIS
+# clone's .env, regardless of which directory the session was launched from).
+# `1`/`all` enables the full interactive profile, or a comma-subset of:
+#   plan,execute,prcheck,pr,ticket,merge,public,handover
+# READ FROM .env by the SessionStart inject-initiative hook (HIMMEL-460); a value
+# exported in the launching shell or set in settings.json "env" overrides it.
+# Uncomment ONE line to enable (the only edit needed):
 # HIMMEL_INITIATIVE=prcheck,pr,ticket,handover
 # Overnight profile (HIMMEL-443): when HIMMEL_OVERNIGHT is truthy the resolver
-# reads HIMMEL_INITIATIVE_OVERNIGHT instead, and `all` widens to 6 legs.
+# reads HIMMEL_INITIATIVE_OVERNIGHT instead, and `all` widens to 6 legs. Both are
+# also read from .env by the hook.
 # HIMMEL_OVERNIGHT=1
 # HIMMEL_INITIATIVE_OVERNIGHT=all
 

--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -169,7 +169,12 @@ cd himmel
 bash scripts/setup.sh
 ```
 
-`scripts/setup.sh` handles: pre-commit install, Jira CLI build, `.env` from `.env.example`.
+`scripts/setup.sh` handles: pre-commit install, Jira CLI build, `.env` from
+`.env.example`, plugin install, and wiring the statusline + `env.HIMMEL_REPO` +
+the **UNIVERSAL hooks** into `~/.claude/settings.json` (user scope — see §4b).
+A missing required tool (git/jq/python3) is auto-fetched via the platform
+package manager when possible, else setup fails loud with the manual command
+(HIMMEL-460).
 
 To **update** an existing checkout later, run `/himmel-update` (or `bash scripts/himmel-update.sh`):
 `git pull` is what delivers himmel updates — marketplace `autoUpdate` does not.
@@ -203,6 +208,43 @@ touch ~/Documents/luna/.single-writer ~/Documents/luna-medic/.single-writer ~/Do
 
 This lets those repos opt out of the on-main edit block locally without the marker
 ever being committed.
+
+### 4b. Hook scope: user vs project (HIMMEL-460)
+
+himmel's hooks split into two scopes. `scripts/setup.sh` (and `adopt --scope
+user`) wires the **UNIVERSAL** set into your **user-scope** `~/.claude/settings.json`
+so they apply to *every* Claude session, in any directory — not just inside the
+himmel clone:
+
+- **UNIVERSAL (user scope):** `auto-approve-safe-bash`, `block-edit-on-main`,
+  `block-read-secrets` (PreToolUse) + `inject-initiative` (SessionStart). Without
+  user-scope wiring, a session launched outside the repo has no auto-approve (so
+  the allow-listed Jira CLI gets denied) and no leg-injector (so `HIMMEL_INITIATIVE`
+  never fires).
+- **HIMMEL-DEV-ONLY (project scope):** `check-cr-marker-on-pr-create`,
+  `block-backend-tier`, `auto-arm-on-cap`, `check-update-available`, … — they only
+  make sense while working inside the himmel repo, so they stay in the repo's
+  committed `.claude/settings.json` and are **not** user-wired.
+
+The hooks reference **this clone's absolute path** and dedup by hook *basename*, so
+re-running setup after moving the clone repairs the wiring instead of double-wiring.
+A fresh contributor who clones himmel still gets the safety hooks from the committed
+project `.claude/settings.json` even before running setup.
+
+**Duplication is benign.** Inside the himmel repo the UNIVERSAL hooks are wired at
+both scopes and fire twice — that is idempotent (two auto-approve passes = the same
+allow; two block passes = the same block), so setup stays silent about it in-repo.
+For *another* adopted project that also carries a project-scope copy, setup prints
+an advisory listing the dupes + the `unwire-pretooluse-hooks --scope project
+--target <repo>` command to collapse them (never automatic).
+
+`HIMMEL_INITIATIVE` and the overnight pair are read from the himmel clone's `.env`
+by the SessionStart hook (a value exported in the launching shell or set in
+settings.json `env` still wins); they ship **commented** in `.env.example`, so the
+opt-in default-OFF is preserved — uncomment one line to enable.
+
+`scripts/uninstall.sh` step `[6/6]` is the symmetric teardown — it removes exactly
+what setup/adopt wired (preserving your non-himmel keys); `--skip-settings` keeps it.
 
 ---
 
@@ -464,10 +506,14 @@ does NOT revoke the bot token; revoke via @BotFather when decommissioning,
 (3) remove `HIMMEL-Resume-*` scheduled jobs + the `HimmelTelegramBridge`
 logon task, (4) uninstall the settings-template plugins + marketplaces via
 `scripts/machine-setup/uninstall-plugins.{sh,ps1}` (**user-scope — affects
-every repo on the machine**), (5) `pre-commit uninstall` ×3 hook types.
-Partial offboard via `--keep-telegram-state` / `--skip-plugins` /
-`--skip-tasks` / `--skip-hooks` (PS: `-KeepTelegramState` etc.). Not
-touched: `~/.claude/settings.json`, the himmel clone + `.env`, handover
+every repo on the machine**), (5) `pre-commit uninstall` ×3 hook types,
+(6) unwire `~/.claude/settings.json` — remove the statusLine, `env.HIMMEL_REPO`,
+`env.LUNA_VAULT_PATH`, and the UNIVERSAL hooks that setup/adopt wired (each
+helper removes ONLY its own key/stanza; non-himmel keys — your own hooks, MCP
+config, the rtk guard — are preserved; HIMMEL-460). Partial offboard via
+`--keep-telegram-state` / `--skip-plugins` / `--skip-tasks` / `--skip-hooks` /
+`--skip-settings` (PS: `-KeepTelegramState` etc.). Not touched: the himmel
+clone + `.env`, your non-himmel `~/.claude/settings.json` keys, handover
 state outside the bridge root.
 
 ---

--- a/docs/setup/vms.md
+++ b/docs/setup/vms.md
@@ -4,6 +4,26 @@ Local VMs for testing and automation. Credentials stored in `.env` — see `.env
 
 To provision a fresh Ubuntu VM run: `python scripts/machine-setup/ubuntu-vm-setup.py`
 
+## Dependency split — test-harness vs user-runtime (HIMMEL-469)
+
+Two **different** dependency sets; do not conflate them:
+
+| Set | Who needs it | Deps | Installed by |
+|-----|--------------|------|--------------|
+| **Test harness** | throwaway test VMs + CI runners (to *run* himmel's bash suites) | `bash git jq` | `scripts/machine-setup/test-bootstrap.sh` |
+| **User runtime** | himmel adopters (to *use* himmel) | `bash git node npm bun python3 jq gh mktemp` (+ `claude`) | `scripts/setup.sh` `[0/10]` (R6 `ensure-tools` auto-installs git/jq/python3, flags the rest) |
+
+A bare test VM only needs `test-bootstrap.sh` to run the suites — it does **not**
+need the full user runtime. `bash scripts/machine-setup/test-bootstrap.sh`
+(`--check` to report only, `--no-sudo` if already root).
+
+**Provision test VMs / CI with NOPASSWD sudo** (or run as root) so `test-bootstrap`
+and the R6 `ensure-tools` apt path run non-interactively — a password-prompted
+`sudo` over a non-TTY ssh fails with `A terminal is required to authenticate`.
+The host-driven validator `scripts/test-install-symmetry-vm.sh [user@host] [port]
+[identity]` GAP-skips the git-dependent suites when git is absent rather than
+failing, so it stays green on a not-yet-bootstrapped box.
+
 ---
 
 ## Ubuntu VM

--- a/llms.txt
+++ b/llms.txt
@@ -31,7 +31,7 @@ If you are an LLM working in this repo, read CLAUDE.md first — it is the autho
 
 ## Setup
 
-- [docs/setup/new-machine.md](docs/setup/new-machine.md): fresh-machine setup — required environment + per-platform (Linux / macOS / Windows Git Bash) install.
+- [docs/setup/new-machine.md](docs/setup/new-machine.md): fresh-machine setup — required environment + per-platform (Linux / macOS / Windows Git Bash) install; the user-vs-project hook-scope model (§4b) and the symmetric `uninstall.sh` teardown.
 - [docs/setup/use-on-your-project.md](docs/setup/use-on-your-project.md): adopting the portable core (hooks + worktree workflow) in another repo.
 
 ## Optional

--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -48,6 +48,11 @@ $LunaTargetSet = $PSBoundParameters.ContainsKey('LunaTarget')
 
 $ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
 $HimmelRoot  = (Resolve-Path (Join-Path $ScriptDir '..')).Path
+
+# Shared wire helpers (PreToolUse trio + SessionStart) -- one implementation for
+# adopt.ps1 and setup.ps1 (HIMMEL install/uninstall symmetry).
+. (Join-Path $ScriptDir 'lib/wire-pretooluse-hooks.ps1')
+
 if (-not $Target)     { $Target     = (Get-Location).Path }
 if (-not $LunaTarget) { $LunaTarget = Join-Path $HOME 'Documents\luna' }
 
@@ -84,50 +89,6 @@ function Copy-Portable {
         Copy-Item -Force $src $dst
         Write-Host "  $f"
     }
-}
-
-# Merge the three PreToolUse hook stanzas into a settings.json, idempotently.
-# The hook path is FORWARD-SLASHED and QUOTED: an unquoted Windows backslash path
-# (`bash C:\Users\...\X.sh`) collapses when the hook command is parsed by a shell
-# (`\U`->`U`), so the hook silently never fires. Dedup is by hook
-# BASENAME with REPLACE semantics — a re-run repairs a bad install, never dups.
-function Wire-Settings([string]$SettingsPath, [string]$Prefix) {
-    $pfx = $Prefix.Replace('\', '/')   # forward-slash any backslashes in the prefix
-    $desired = @(
-        [pscustomobject]@{ matcher = 'Bash'; hooks = @([pscustomobject]@{ type = 'command'; command = "bash `"$pfx/scripts/hooks/auto-approve-safe-bash.sh`"" }) },
-        [pscustomobject]@{ matcher = 'Edit|Write|MultiEdit|NotebookEdit'; hooks = @([pscustomobject]@{ type = 'command'; command = "bash `"$pfx/scripts/hooks/block-edit-on-main.sh`"" }) },
-        [pscustomobject]@{ matcher = 'Bash|PowerShell|Read|Grep'; hooks = @([pscustomobject]@{ type = 'command'; command = "bash `"$pfx/scripts/hooks/block-read-secrets.sh`"" }) }
-    )
-    if ($DryRun) { Write-Host "DRY: merge 3 PreToolUse hook stanzas into $SettingsPath (prefix: $Prefix)"; return }
-    New-Item -ItemType Directory -Force (Split-Path $SettingsPath) | Out-Null
-
-    if (Test-Path $SettingsPath) {
-        $cfg = Get-Content $SettingsPath -Raw | ConvertFrom-Json
-    } else {
-        $cfg = [pscustomobject]@{}
-    }
-    if (-not $cfg.PSObject.Properties['hooks']) {
-        $cfg | Add-Member -NotePropertyName hooks -NotePropertyValue ([pscustomobject]@{})
-    }
-    if (-not $cfg.hooks.PSObject.Properties['PreToolUse']) {
-        $cfg.hooks | Add-Member -NotePropertyName PreToolUse -NotePropertyValue @()
-    }
-    # Drop only the himmel hook OBJECTS (not whole stanzas), keep stanzas that
-    # still have hooks, then append the fresh stanzas. Hook-object granularity
-    # preserves a non-himmel hook (rtk-hook-guard / operator's own) co-located in
-    # the SAME hooks[] array as a himmel hook (basename REPLACE, not append).
-    $himmelRe = 'scripts/hooks/(auto-approve-safe-bash|block-edit-on-main|block-read-secrets)\.sh'
-    $kept = @()
-    foreach ($st in @($cfg.hooks.PreToolUse)) {
-        $keepHooks = @($st.hooks | Where-Object { $_.command -notmatch $himmelRe })
-        if ($keepHooks.Count -gt 0) {
-            $st.hooks = $keepHooks
-            $kept += $st
-        }
-    }
-    $cfg.hooks.PreToolUse = @($kept + $desired)
-    $cfg | ConvertTo-Json -Depth 12 | Set-Content $SettingsPath -Encoding utf8
-    Write-Host "  wired PreToolUse hooks → $SettingsPath"
 }
 
 function Install-Plugins {
@@ -235,10 +196,15 @@ function Do-Core {
     Require-Tools
     if ($Scope -eq 'project') {
         Copy-Portable
-        Wire-Settings (Join-Path $Target '.claude\settings.json') '$CLAUDE_PROJECT_DIR'
+        Set-PretooluseHooks -SettingsPath (Join-Path $Target '.claude\settings.json') -Prefix '$CLAUDE_PROJECT_DIR' -DryRun:$DryRun
         Write-Host "  worktree commands: bash $Target/scripts/worktree.sh feat/slug"
     } else {
-        Wire-Settings (Join-Path $HOME '.claude\settings.json') $HimmelRoot
+        # user scope: wire the full UNIVERSAL set -- the PreToolUse trio AND the
+        # SessionStart leg-injector -- so a session launched anywhere gets the legs
+        # (parity with setup.ps1 / R3).
+        $userSettings = Join-Path $HOME '.claude\settings.json'
+        Set-PretooluseHooks -SettingsPath $userSettings -Prefix $HimmelRoot -DryRun:$DryRun
+        Set-SessionStartHook -SettingsPath $userSettings -Prefix $HimmelRoot -HookBasename 'inject-initiative.sh' -DryRun:$DryRun
         Write-Host "  worktree commands run from the himmel clone: bash $HimmelRoot/scripts/worktree.sh feat/slug"
     }
     Install-Plugins

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -38,6 +38,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 HIMMEL_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 
+# Shared wire helpers (the PreToolUse trio + SessionStart) — one implementation
+# for adopt.sh and setup.sh (HIMMEL install/uninstall symmetry).
+# shellcheck source=scripts/lib/wire-pretooluse-hooks.sh
+. "$SCRIPT_DIR/lib/wire-pretooluse-hooks.sh"
+
 # ── Defaults ─────────────────────────────────────────────────────────────────
 PROFILE="core"
 SCOPE="project"
@@ -102,54 +107,6 @@ copy_portable() {
     run chmod +x "$TARGET/$f"
     echo "  $f"
   done
-}
-
-# Merge the three PreToolUse hook stanzas into a settings.json, idempotently.
-# $1 = settings.json path, $2 = command path prefix (literal, e.g.
-# '$CLAUDE_PROJECT_DIR' for project scope or the himmel abs path for user scope).
-# The hook path is FORWARD-SLASHED and QUOTED in the command: an unquoted Windows
-# backslash path (`bash C:\Users\...\X.sh`) collapses when the hook command is
-# parsed by a shell (`\U`->`U`), so the hook silently never fires.
-# Dedup is by hook BASENAME with REPLACE semantics: re-running adopt overwrites a
-# previously-wired (incl. broken backslash) himmel hook rather than appending a
-# duplicate — so a re-run repairs a bad install and never double-wires.
-wire_settings() {
-  local settings="$1" prefix="$2"
-  # shellcheck disable=SC1003  # '\' is a literal backslash to replace, not a quote escape
-  local pfx="${prefix//'\'//}"   # forward-slash any backslashes in the prefix
-  local desired
-  desired=$(cat <<JSON
-[
-  {"matcher":"Bash","hooks":[{"type":"command","command":"bash \"${pfx}/scripts/hooks/auto-approve-safe-bash.sh\""}]},
-  {"matcher":"Edit|Write|MultiEdit|NotebookEdit","hooks":[{"type":"command","command":"bash \"${pfx}/scripts/hooks/block-edit-on-main.sh\""}]},
-  {"matcher":"Bash|PowerShell|Read|Grep","hooks":[{"type":"command","command":"bash \"${pfx}/scripts/hooks/block-read-secrets.sh\""}]}
-]
-JSON
-)
-  if [[ $DRY_RUN -eq 1 ]]; then
-    echo "DRY: merge 3 PreToolUse hook stanzas into $settings (prefix: $prefix)"
-    return
-  fi
-  mkdir -p "$(dirname "$settings")"
-  local base="{}"
-  [[ -f "$settings" ]] && base=$(cat "$settings")
-  # Drop only the himmel hook OBJECTS (not whole stanzas) from each existing
-  # PreToolUse entry, then drop any stanza left empty, then append the fresh
-  # stanzas. Hook-object granularity preserves a non-himmel hook (rtk-hook-guard,
-  # the operator's own) even when it is co-located in the SAME hooks[] array as a
-  # himmel hook — a stanza-level filter would take it down with the himmel one.
-  printf '%s' "$base" | jq --argjson add "$desired" '
-    .hooks = (.hooks // {})
-    | .hooks.PreToolUse = (
-        ((.hooks.PreToolUse // [])
-          | map(.hooks = ((.hooks // [])
-              | map(select((.command // "")
-                    | test("scripts/hooks/(auto-approve-safe-bash|block-edit-on-main|block-read-secrets)[.]sh") | not))))
-          | map(select((.hooks | length) > 0)))
-        + $add
-      )
-  ' > "$settings.adopt.tmp" && mv "$settings.adopt.tmp" "$settings"
-  echo "  wired PreToolUse hooks → $settings"
 }
 
 install_plugins() {
@@ -239,11 +196,14 @@ do_core() {
     copy_portable
     # Literal $CLAUDE_PROJECT_DIR — Claude Code expands it at hook-fire time.
     # shellcheck disable=SC2016
-    wire_settings "$TARGET/.claude/settings.json" '$CLAUDE_PROJECT_DIR'
+    wire_pretooluse_hooks "$TARGET/.claude/settings.json" '$CLAUDE_PROJECT_DIR' "$DRY_RUN"
     echo "  worktree commands: bash $TARGET/scripts/worktree.sh feat/slug"
   else
-    # user scope: reference this himmel clone, don't copy per-repo.
-    wire_settings "$HOME/.claude/settings.json" "$HIMMEL_ROOT"
+    # user scope: reference this himmel clone, don't copy per-repo. Wire the full
+    # UNIVERSAL set — the PreToolUse trio AND the SessionStart leg-injector — so a
+    # session launched anywhere gets the legs (parity with setup.sh / R3).
+    wire_pretooluse_hooks "$HOME/.claude/settings.json" "$HIMMEL_ROOT" "$DRY_RUN"
+    wire_sessionstart_hook "$HOME/.claude/settings.json" "$HIMMEL_ROOT" "inject-initiative.sh" "$DRY_RUN"
     echo "  worktree commands run from the himmel clone: bash $HIMMEL_ROOT/scripts/worktree.sh feat/slug"
   fi
   install_plugins

--- a/scripts/hooks/inject-initiative.sh
+++ b/scripts/hooks/inject-initiative.sh
@@ -61,6 +61,24 @@ else
     cat >/dev/null 2>&1 || true
 fi
 
+# --- Source the himmel clone's .env for the initiative vars (R1, HIMMEL-460) -
+# The hook reads HIMMEL_INITIATIVE* from the process env, but a session launched
+# from a shell that never exported them (and without a settings.json `env` block)
+# would see no legs. Populate them from the himmel clone's .env — but ONLY for
+# vars not already set (process env / settings.json env still wins; load_dotenv is
+# non-clobbering). Resolve the himmel root EXPLICITLY (HIMMEL_REPO, else the git
+# toplevel of THIS hook script) and never trust the CWD: a session launched inside
+# a DIFFERENT git repo must not read that repo's .env. Fail-open on any miss.
+_ii_root="${HIMMEL_REPO:-}"
+if [ -z "$_ii_root" ]; then
+    _ii_root=$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel 2>/dev/null) || _ii_root=""
+fi
+if [ -n "$_ii_root" ] && [ -f "$_ii_root/.env" ]; then
+    # shellcheck source=/dev/null
+    . "$(dirname "${BASH_SOURCE[0]}")/../lib/load-dotenv.sh"
+    load_dotenv --root "$_ii_root" HIMMEL_INITIATIVE HIMMEL_OVERNIGHT HIMMEL_INITIATIVE_OVERNIGHT || true
+fi
+
 # --- Resolve the active legs via the shared resolver (HIMMEL-443) -----------
 # The leg grammar lives in ONE place: scripts/lib/initiative-legs.sh. We pass
 # the relevant env vars as named arguments (the resolver never reads ambient

--- a/scripts/hooks/test-inject-initiative.sh
+++ b/scripts/hooks/test-inject-initiative.sh
@@ -34,6 +34,15 @@ fi
 pass=0
 fail=0
 
+# Hermetic isolation (HIMMEL-460): the hook now sources the himmel clone's .env
+# for HIMMEL_INITIATIVE*. Point HIMMEL_REPO at an EMPTY temp dir so the existing
+# process-env cases are unaffected by whatever .env exists on the test machine.
+# The SC3 cases below override HIMMEL_REPO per-case to a fixture with a real .env.
+TMPII=$(mktemp -d)
+trap 'rm -rf "$TMPII"' EXIT
+mkdir -p "$TMPII/noenv"
+export HIMMEL_REPO="$TMPII/noenv"
+
 assert_pass() {
     pass=$((pass + 1))
     echo "  PASS: $1"
@@ -250,6 +259,41 @@ echo "Test 21: 'plan,prcheck' → plan emits no step, prcheck numbered first"
 out=$(printf '{}' | HIMMEL_INITIATIVE=plan,prcheck bash "$hook")
 assert_has   "prcheck numbered first (plan consumes no number)" "1\. Run" "$out"
 assert_lacks "no second numbered step from plan"               "2\."     "$out"
+
+# ---------- SC3 (HIMMEL-460): legs sourced from the himmel clone's .env --------
+# Fixture himmel root with an .env that activates a subset.
+FIX="$TMPII/himmel"; mkdir -p "$FIX"
+printf 'HIMMEL_INITIATIVE=prcheck,pr\n' > "$FIX/.env"
+
+# 22. env var UNSET → legs come from .env.
+echo "Test 22: HIMMEL_INITIATIVE unset → legs resolved from the himmel .env"
+out=$(unset HIMMEL_INITIATIVE; printf '{}' | HIMMEL_REPO="$FIX" bash "$hook")
+assert_has "active from .env (prcheck)" "fix every finding"      "$out"
+assert_has "active from .env (pr)"      "open or refresh the PR" "$out"
+assert_has "active-steps echoes .env subset" "Active steps: prcheck,pr" "$out"
+
+# 23. process env OVERRIDES .env (non-clobber: live value wins).
+echo "Test 23: process env overrides the .env value"
+out=$(printf '{}' | HIMMEL_REPO="$FIX" HIMMEL_INITIATIVE=handover bash "$hook")
+assert_has   "process-env handover wins" "Write the handover"    "$out"
+assert_lacks " .env prcheck suppressed"  "fix every finding"     "$out"
+
+# 24. CWD-safety: launched inside a DIFFERENT git repo with a decoy .env, the
+# himmel .env (HIMMEL_REPO) is used — the decoy repo's .env is NEVER read.
+echo "Test 24: a sibling repo's .env is not read (CWD-safety)"
+DECOY="$TMPII/decoy"; mkdir -p "$DECOY"; git -C "$DECOY" init --quiet
+printf 'HIMMEL_INITIATIVE=ticket\n' > "$DECOY/.env"
+out=$(cd "$DECOY" && unset HIMMEL_INITIATIVE; printf '{}' | HIMMEL_REPO="$FIX" bash "$hook")
+assert_has   "himmel .env subset used"   "fix every finding"          "$out"
+assert_lacks "decoy .env subset ignored" "Transition the Jira ticket" "$out"
+
+# 25. fail-open: HIMMEL_REPO points at a dir with no .env, env unset → OFF, exit 0.
+echo "Test 25: no .env at the resolved root → fail-open OFF"
+out=$(unset HIMMEL_INITIATIVE; printf '{}' | HIMMEL_REPO="$TMPII/noenv" bash "$hook"; echo "rc=$?")
+assert_has  "fail-open exits 0" "rc=0" "$out"
+# stdout should be only the rc marker (no directive).
+body=$(unset HIMMEL_INITIATIVE; printf '{}' | HIMMEL_REPO="$TMPII/noenv" bash "$hook")
+if [ -z "$body" ]; then assert_pass "no directive when no .env + env unset"; else assert_fail "expected OFF, got: $body"; fi
 
 echo
 echo "RESULTS: $pass passed, $fail failed"

--- a/scripts/lib/detect-hook-dup.ps1
+++ b/scripts/lib/detect-hook-dup.ps1
@@ -1,0 +1,49 @@
+# detect-hook-dup.ps1 -- PowerShell counterpart of detect-hook-dup.sh (R4,
+# HIMMEL-460). ADVISORY warning (always rc 0) when a himmel UNIVERSAL hook is
+# wired at BOTH user and a project's settings.json. Suppressed in-repo. Uses jq
+# for parity (no-ops without it).
+#
+#   pwsh -File detect-hook-dup.ps1 -UserSettings <p> -ProjectSettings <p> -HimmelRoot <p>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$UserSettings,
+    [Parameter(Mandatory = $true)][string]$ProjectSettings,
+    [Parameter(Mandatory = $true)][string]$HimmelRoot
+)
+
+$Universal = @('auto-approve-safe-bash', 'block-edit-on-main', 'block-read-secrets', 'inject-initiative')
+
+function _DhdNorm([string]$p) { ($p -replace '\\', '/').TrimEnd('/') }
+
+function _DhdHasHook([string]$settings, [string]$base) {
+    if (-not (Test-Path $settings)) { return $false }
+    if (-not (Get-Command jq -ErrorAction SilentlyContinue)) { return $false }
+    Get-Content $settings -Raw | jq -e . > $null 2>&1
+    if ($LASTEXITCODE -ne 0) { return $false }
+    $pat = "scripts/hooks/$base[.]sh"
+    Get-Content $settings -Raw | jq -e --arg pat $pat 'any(.. | (.command? // empty) | strings; test($pat))' > $null 2>&1
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Invoke-DetectHookDup {
+    param([string]$UserSettings, [string]$ProjectSettings, [string]$HimmelRoot)
+    if ((_DhdNorm $ProjectSettings) -eq (_DhdNorm (Join-Path $HimmelRoot '.claude/settings.json'))) {
+        return  # in-repo: himmel devs are expected to have both
+    }
+    $dups = @()
+    foreach ($b in $Universal) {
+        if ((_DhdHasHook $UserSettings $b) -and (_DhdHasHook $ProjectSettings $b)) { $dups += $b }
+    }
+    if ($dups.Count -gt 0) {
+        $projRepo = Split-Path (Split-Path $ProjectSettings)
+        Write-Host "  NOTE: these himmel UNIVERSAL hooks are wired at BOTH user and project scope (they fire twice):" -ForegroundColor Yellow
+        foreach ($b in $dups) { Write-Host "    - $b" -ForegroundColor Yellow }
+        Write-Host "  The double-fire is benign + idempotent. To remove the redundant project copy, run:" -ForegroundColor Yellow
+        Write-Host "    bash $HimmelRoot/scripts/lib/unwire-pretooluse-hooks.sh --scope project --target $projRepo" -ForegroundColor Yellow
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Invoke-DetectHookDup -UserSettings $UserSettings -ProjectSettings $ProjectSettings -HimmelRoot $HimmelRoot
+}

--- a/scripts/lib/detect-hook-dup.sh
+++ b/scripts/lib/detect-hook-dup.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# detect-hook-dup.sh -- ADVISORY warning when a himmel UNIVERSAL hook is wired at
+# BOTH user scope AND a project's settings.json, so it fires twice (R4,
+# HIMMEL-460). The double-fire is benign + idempotent (SC11: two auto-approve
+# passes = same allow; two block passes = same block), so this is advisory (always
+# rc 0), never an error.
+#
+# SUPPRESSED when the project IS the himmel repo itself: its devs are EXPECTED to
+# carry the committed project-scope hooks AND the user-scope wiring -- nagging them
+# every setup run would be noise. Warn only for OTHER adopted projects.
+#
+# Usage:
+#   bash detect-hook-dup.sh <user-settings> <project-settings> <himmel-root>
+#
+# Prints the remediation (`unwire-pretooluse-hooks --scope project --target`) the
+# operator runs IF they accept the advice. Requires jq (no-ops without it).
+set -uo pipefail
+
+_DHD_UNIVERSAL="auto-approve-safe-bash block-edit-on-main block-read-secrets inject-initiative"
+
+# Forward-slash + strip a trailing slash so the in-repo self-compare is robust to
+# backslash paths (Windows) without needing realpath on a maybe-absent file.
+_dhd_norm() { local s="${1//\\//}"; printf '%s' "${s%/}"; }
+
+# Echo "yes" when <settings> wires a hook whose command path contains
+# scripts/hooks/<basename>.sh anywhere (PreToolUse stanza or SessionStart array).
+_dhd_has_hook() {
+  local settings="$1" base="$2" pat
+  [ -f "$settings" ] || { echo no; return; }
+  command -v jq >/dev/null 2>&1 || { echo no; return; }
+  jq -e . "$settings" >/dev/null 2>&1 || { echo no; return; }
+  pat="scripts/hooks/${base}[.]sh"
+  if jq -e --arg pat "$pat" 'any(.. | (.command? // empty) | strings; test($pat))' "$settings" >/dev/null 2>&1; then
+    echo yes
+  else
+    echo no
+  fi
+}
+
+detect_hook_dup() {
+  local user="$1" project="$2" himmel="$3"
+  # In-repo suppression: project settings IS himmel's own settings.json.
+  if [ "$(_dhd_norm "$project")" = "$(_dhd_norm "$himmel/.claude/settings.json")" ]; then
+    return 0
+  fi
+  local dups="" b
+  for b in $_DHD_UNIVERSAL; do
+    if [ "$(_dhd_has_hook "$user" "$b")" = yes ] && [ "$(_dhd_has_hook "$project" "$b")" = yes ]; then
+      dups="$dups $b"
+    fi
+  done
+  if [ -n "$dups" ]; then
+    echo "  NOTE: these himmel UNIVERSAL hooks are wired at BOTH user and project scope (they fire twice):" >&2
+    for b in $dups; do echo "    - $b" >&2; done
+    echo "  The double-fire is benign + idempotent. To remove the redundant project copy, run:" >&2
+    echo "    bash $himmel/scripts/lib/unwire-pretooluse-hooks.sh --scope project --target $(dirname "$(dirname "$project")")" >&2
+  fi
+  return 0
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  [ "$#" -eq 3 ] || { echo "usage: detect-hook-dup.sh <user-settings> <project-settings> <himmel-root>" >&2; exit 2; }
+  detect_hook_dup "$1" "$2" "$3"
+fi

--- a/scripts/lib/load-dotenv.sh
+++ b/scripts/lib/load-dotenv.sh
@@ -9,12 +9,19 @@
 #
 # Usage — source this file, then:
 #   load_dotenv [KEY ...]
-# With no args, loads the default keys: HANDOVER_DIR USER_SLUG.
+#   load_dotenv --root <dir> [KEY ...]
+# With no keys, loads the default keys: HANDOVER_DIR USER_SLUG.
 #
 # The .env path is resolved like the Jira CLI: the parent of
 # `git rev-parse --git-common-dir`, so from inside a git worktree it still
 # finds the PRIMARY checkout's .env (the gitignored .env is not copied into
 # worktrees). Falls back to two levels up from this script if git is absent.
+#
+# `--root <dir>` (HIMMEL-460): load <dir>/.env and BYPASS the CWD-based
+# `_load_dotenv_root` resolution entirely (no `git rev-parse` against the
+# process CWD). The caller has already resolved the correct root — used by the
+# SessionStart inject-initiative hook so a session launched inside an UNRELATED
+# git repo never reads THAT repo's .env.
 #
 # Safety: never `source`s the file (no arbitrary code execution). Extracts
 # only the requested `KEY=` lines; skips comments, blanks, and lines without
@@ -39,11 +46,16 @@ _load_dotenv_root() {
 }
 
 load_dotenv() {
+    local root=""
+    if [ "${1:-}" = "--root" ]; then
+        root="$2"; shift 2
+    fi
     local keys=("$@")
     [ "${#keys[@]}" -eq 0 ] && keys=(HANDOVER_DIR USER_SLUG)
 
-    local root envfile
-    root=$(_load_dotenv_root) || return 0
+    local envfile
+    # An explicit --root bypasses CWD git resolution (never trust the CWD repo).
+    [ -n "$root" ] || { root=$(_load_dotenv_root) || return 0; }
     envfile="$root/.env"
     [ -f "$envfile" ] || return 0
 

--- a/scripts/lib/test-detect-hook-dup.ps1
+++ b/scripts/lib/test-detect-hook-dup.ps1
@@ -1,0 +1,51 @@
+# test-detect-hook-dup.ps1 -- committed PS test for detect-hook-dup.ps1 (SC5).
+# Warns iff a UNIVERSAL hook is wired at BOTH user + a NON-himmel project; silent
+# in-repo and when nothing is shared. (SC11's benign-double-fire uses the bash
+# hooks and lives in test-detect-hook-dup.sh.) Run: pwsh -File test-detect-hook-dup.ps1
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$det = Join-Path $here 'detect-hook-dup.ps1'
+$fails = 0
+function Check($name, $got, $want) {
+    if ("$got" -eq "$want") { Write-Host "ok - $name" }
+    else { Write-Host "FAIL - ${name}: [$got]!=[$want]"; $script:fails++ }
+}
+
+$td = Join-Path ([System.IO.Path]::GetTempPath()) ("dhd-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force $td | Out-Null
+$user = Join-Path $td 'user.json'
+'{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"bash /user/scripts/hooks/auto-approve-safe-bash.sh"}]}],"SessionStart":[{"hooks":[{"type":"command","command":"bash /user/scripts/hooks/inject-initiative.sh"}]}]}}' | Set-Content $user -Encoding utf8
+
+# SC5a: non-himmel project sharing a UNIVERSAL hook → warning.
+New-Item -ItemType Directory -Force (Join-Path $td 'proj/.claude') | Out-Null
+$proj = Join-Path $td 'proj/.claude/settings.json'
+'{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"bash /proj/scripts/hooks/auto-approve-safe-bash.sh"}]}]}}' | Set-Content $proj -Encoding utf8
+$out = & pwsh -NoProfile -File $det -UserSettings $user -ProjectSettings $proj -HimmelRoot '/opt/himmel' 2>&1 | Out-String
+Check 'SC5 warns on non-himmel dup' ($out -match 'BOTH user and project scope') $true
+Check 'SC5 lists the dup hook'      ($out -match 'auto-approve-safe-bash') $true
+
+# SC5b: in-repo (project == himmel's own settings) → silent.
+$himmel = Join-Path $td 'himmel'
+New-Item -ItemType Directory -Force (Join-Path $himmel '.claude') | Out-Null
+$himmelSettings = Join-Path $himmel '.claude/settings.json'
+Copy-Item $user $himmelSettings
+$out = & pwsh -NoProfile -File $det -UserSettings $user -ProjectSettings $himmelSettings -HimmelRoot $himmel 2>&1 | Out-String
+Check 'SC5 silent in-repo' ($out -match 'BOTH user and project') $false
+
+# SC5c: project shares nothing → silent.
+New-Item -ItemType Directory -Force (Join-Path $td 'proj2/.claude') | Out-Null
+$proj2 = Join-Path $td 'proj2/.claude/settings.json'
+'{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"bash /p2/scripts/hooks/other.sh"}]}]}}' | Set-Content $proj2 -Encoding utf8
+$out = & pwsh -NoProfile -File $det -UserSettings $user -ProjectSettings $proj2 -HimmelRoot '/opt/himmel' 2>&1 | Out-String
+Check 'SC5 silent when no shared hook' ($out -match 'BOTH user and project') $false
+
+# SC5d: SessionStart inject-initiative dup detected.
+New-Item -ItemType Directory -Force (Join-Path $td 'proj3/.claude') | Out-Null
+$proj3 = Join-Path $td 'proj3/.claude/settings.json'
+'{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"bash /p3/scripts/hooks/inject-initiative.sh"}]}]}}' | Set-Content $proj3 -Encoding utf8
+$out = & pwsh -NoProfile -File $det -UserSettings $user -ProjectSettings $proj3 -HimmelRoot '/opt/himmel' 2>&1 | Out-String
+Check 'SC5 detects SessionStart dup' ($out -match 'inject-initiative') $true
+
+Remove-Item -Recurse -Force $td
+if ($fails -eq 0) { Write-Host 'ALL PASS' } else { Write-Host "$fails FAILED"; exit 1 }

--- a/scripts/lib/test-detect-hook-dup.sh
+++ b/scripts/lib/test-detect-hook-dup.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+# test-detect-hook-dup.sh -- hermetic tests for detect-hook-dup.sh.
+# SC5:  warns iff a UNIVERSAL hook is wired at BOTH user + a NON-himmel project;
+#       stays SILENT in-repo (project == himmel's own settings.json).
+# SC11: the double-fire is benign -- a representative allow-case (auto-approve) and
+#       block-case (block-read-secrets) each yield the SAME decision when the hook
+#       runs twice on identical input (so wiring it at both scopes is harmless).
+set -u
+here="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+det="$here/detect-hook-dup.sh"
+fails=0
+check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+td="$(mktemp -d)"
+
+UJSON='{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"bash /user/scripts/hooks/auto-approve-safe-bash.sh"}]}],"SessionStart":[{"hooks":[{"type":"command","command":"bash /user/scripts/hooks/inject-initiative.sh"}]}]}}'
+user="$td/user.json"; printf '%s' "$UJSON" > "$user"
+
+# ── SC5a: non-himmel project sharing a UNIVERSAL hook → warning lists it ─────
+mkdir -p "$td/proj/.claude"
+printf '%s' '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"bash /proj/scripts/hooks/auto-approve-safe-bash.sh"}]}]}}' > "$td/proj/.claude/settings.json"
+out=$(bash "$det" "$user" "$td/proj/.claude/settings.json" "/opt/himmel" 2>&1)
+printf '%s' "$out" | grep -q "wired at BOTH user and project scope" && check "SC5 warns on non-himmel dup" yes yes || check "SC5 warns on non-himmel dup" no yes
+printf '%s' "$out" | grep -q "auto-approve-safe-bash" && check "SC5 lists the dup hook" yes yes || check "SC5 lists the dup hook" no yes
+printf '%s' "$out" | grep -q "unwire-pretooluse-hooks.sh --scope project --target $td/proj" && check "SC5 prints remediation target" yes yes || check "SC5 remediation" no yes
+
+# ── SC5b: in-repo (project == himmel's own settings) → SILENT ───────────────
+out=$(bash "$det" "$user" "$repo_root/.claude/settings.json" "$repo_root" 2>&1)
+check "SC5 silent in-repo" "$(printf '%s' "$out" | grep -c 'BOTH user and project')" "0"
+
+# ── SC5c: project does NOT share any UNIVERSAL hook → SILENT ────────────────
+mkdir -p "$td/proj2/.claude"
+printf '%s' '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"bash /proj2/scripts/hooks/some-other-hook.sh"}]}]}}' > "$td/proj2/.claude/settings.json"
+out=$(bash "$det" "$user" "$td/proj2/.claude/settings.json" "/opt/himmel" 2>&1)
+check "SC5 silent when no shared hook" "$(printf '%s' "$out" | grep -c 'BOTH user and project')" "0"
+
+# ── SC5d: SessionStart inject-initiative dup is also detected ───────────────
+mkdir -p "$td/proj3/.claude"
+printf '%s' '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"bash /proj3/scripts/hooks/inject-initiative.sh"}]}]}}' > "$td/proj3/.claude/settings.json"
+out=$(bash "$det" "$user" "$td/proj3/.claude/settings.json" "/opt/himmel" 2>&1)
+printf '%s' "$out" | grep -q "inject-initiative" && check "SC5 detects SessionStart dup" yes yes || check "SC5 detects SessionStart dup" no yes
+
+# ── SC11: benign double-fire — same hook, same input, twice → same decision ─
+aa="$repo_root/scripts/hooks/auto-approve-safe-bash.sh"
+brs="$repo_root/scripts/hooks/block-read-secrets.sh"
+
+# allow-case (auto-approve a safe read): identical stdout both passes.
+ALLOW_IN='{"tool_name":"Bash","tool_input":{"command":"cat notes.txt"}}'
+o1=$(printf '%s' "$ALLOW_IN" | bash "$aa" 2>/dev/null); r1=$?
+o2=$(printf '%s' "$ALLOW_IN" | bash "$aa" 2>/dev/null); r2=$?
+check "SC11 allow-case rc stable"   "$r1" "$r2"
+check "SC11 allow-case output stable" "$o1" "$o2"
+printf '%s' "$o1" | grep -q '"permissionDecision"[: ]*"allow"' && check "SC11 allow-case actually allows" yes yes || check "SC11 allow-case actually allows" no yes
+
+# block-case (read a .env secret): identical exit (block=2) both passes.
+BLOCK_IN='{"tool_name":"Read","tool_input":{"file_path":"/somewhere/.env"}}'
+printf '%s' "$BLOCK_IN" | bash "$brs" >/dev/null 2>&1; b1=$?
+printf '%s' "$BLOCK_IN" | bash "$brs" >/dev/null 2>&1; b2=$?
+check "SC11 block-case rc stable" "$b1" "$b2"
+check "SC11 block-case actually blocks (exit 2)" "$b1" "2"
+
+rm -rf "$td"
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/lib/test-load-dotenv.sh
+++ b/scripts/lib/test-load-dotenv.sh
@@ -86,6 +86,30 @@ mkdir -p "$NONGIT"
 out=$( cd "$NONGIT" && unset HANDOVER_DIR && load_dotenv HANDOVER_DIR; rc=$?; printf '%s|%s' "${HANDOVER_DIR:-<unset>}" "$rc" )
 assert_eq "T10 git-absent fallback clean no-op" "<unset>|0" "$out"
 
+# ── --root mode (HIMMEL-460): explicit root, CWD git resolution bypassed ─────
+ROOTDIR="$TMP/explicit-root"
+mkdir -p "$ROOTDIR"
+printf 'HIMMEL_INITIATIVE=prcheck,pr\n' > "$ROOTDIR/.env"
+
+# T11: --root loads <dir>/.env regardless of CWD.
+got=$( cd "$NONGIT" && unset HIMMEL_INITIATIVE && load_dotenv --root "$ROOTDIR" HIMMEL_INITIATIVE && printf '%s' "${HIMMEL_INITIATIVE:-<unset>}" )
+assert_eq "T11 --root loads its .env" "prcheck,pr" "$got"
+
+# T12: --root NEVER reads the CWD repo's .env (the CWD-safety guarantee). Launch
+# from inside a DECOY git repo whose .env sets a different value; --root must win.
+DECOY="$TMP/decoy"; mkdir -p "$DECOY"; git -C "$DECOY" init --quiet
+printf 'HIMMEL_INITIATIVE=DECOY_VALUE\n' > "$DECOY/.env"
+got=$( cd "$DECOY" && unset HIMMEL_INITIATIVE && load_dotenv --root "$ROOTDIR" HIMMEL_INITIATIVE && printf '%s' "$HIMMEL_INITIATIVE" )
+assert_eq "T12 --root ignores CWD repo .env" "prcheck,pr" "$got"
+
+# T13: --root is still non-clobbering (process env wins).
+got=$( cd "$NONGIT" && export HIMMEL_INITIATIVE=live && load_dotenv --root "$ROOTDIR" HIMMEL_INITIATIVE && printf '%s' "$HIMMEL_INITIATIVE" )
+assert_eq "T13 --root non-clobbering" "live" "$got"
+
+# T14: --root pointing at a dir with no .env → clean no-op, rc=0.
+out=$( cd "$NONGIT" && unset HIMMEL_INITIATIVE && load_dotenv --root "$NONGIT" HIMMEL_INITIATIVE; rc=$?; printf '%s|%s' "${HIMMEL_INITIATIVE:-<unset>}" "$rc" )
+assert_eq "T14 --root no .env no-op" "<unset>|0" "$out"
+
 echo
 if [ "$FAILED" -eq 0 ]; then
     echo "All load-dotenv tests passed."

--- a/scripts/lib/test-setup-wire.sh
+++ b/scripts/lib/test-setup-wire.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+# test-setup-wire.sh -- hermetic test for the wiring sequence setup.sh's [9/10]
+# performs (R3, HIMMEL-460): statusline + HIMMEL_REPO + the UNIVERSAL hooks
+# (PreToolUse trio + SessionStart inject-initiative) at user scope.
+#   SC1: after wiring, the user settings.json has the UNIVERSAL hooks at abs path
+#        AND a pre-existing rtk-hook-guard entry is preserved.
+#   SC8: running the sequence TWICE (with a changed clone path the 2nd time) leaves
+#        exactly one of each UNIVERSAL stanza (basename dedup survives a path move).
+set -u
+here="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+fails=0
+check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+
+# shellcheck source=wire-statusline.sh
+# shellcheck disable=SC1091
+. "$here/wire-statusline.sh"
+# shellcheck source=wire-himmel-repo.sh
+# shellcheck disable=SC1091
+. "$here/wire-himmel-repo.sh"
+# shellcheck source=wire-pretooluse-hooks.sh
+# shellcheck disable=SC1091
+. "$here/wire-pretooluse-hooks.sh"
+
+# The exact [9/10] sequence against <settings> referencing himmel root <prefix>.
+wire_all() {
+  local settings="$1" prefix="$2"
+  wire_statusline "$settings" "$prefix" >/dev/null
+  wire_himmel_repo "$settings" "$prefix" >/dev/null
+  wire_pretooluse_hooks "$settings" "$prefix" 0 >/dev/null
+  wire_sessionstart_hook "$settings" "$prefix" "inject-initiative.sh" 0 >/dev/null
+}
+
+td="$(mktemp -d)"
+s="$td/settings.json"
+# Pre-existing rtk-hook-guard in the Bash stanza + a custom SessionStart sibling.
+printf '%s' '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"bash /opt/rtk-hook-guard.sh"}]}],"SessionStart":[{"hooks":[{"type":"command","command":"bash /x/scripts/hooks/check-update-available.sh"}]}]}}' > "$s"
+
+wire_all "$s" "C:/Users/op/himmel"
+
+# SC1: UNIVERSAL hooks present at the abs path.
+check "auto-approve wired"   "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("auto-approve-safe-bash"))] | length' "$s")" "1"
+check "block-edit wired"     "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("block-edit-on-main"))] | length' "$s")" "1"
+check "block-read wired"     "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("block-read-secrets"))] | length' "$s")" "1"
+check "inject-initiative wired" "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("inject-initiative"))] | length' "$s")" "1"
+check "abs path used"        "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("C:/Users/op/himmel/scripts/hooks/auto-approve"))] | length' "$s")" "1"
+# SC1: pre-existing non-himmel entries preserved.
+check "rtk guard preserved"  "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("rtk-hook-guard"))] | length' "$s")" "1"
+check "SessionStart sibling preserved" "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("check-update-available"))] | length' "$s")" "1"
+# SC1: statusline + HIMMEL_REPO set.
+check "statusLine set"  "$(jq -r '.statusLine.type' "$s")" "command"
+check "HIMMEL_REPO set" "$(jq -r '.env.HIMMEL_REPO' "$s")" "C:/Users/op/himmel"
+
+# SC8: re-run with a CHANGED clone path → exactly one of each (basename dedup).
+wire_all "$s" "C:/Users/op/himmel-moved"
+check "SC8 PreToolUse trio count" "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("scripts/hooks/(auto-approve-safe-bash|block-edit-on-main|block-read-secrets)"))] | length' "$s")" "3"
+check "SC8 inject single"         "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("inject-initiative"))] | length' "$s")" "1"
+check "SC8 new path applied"      "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("himmel-moved/scripts/hooks/auto-approve"))] | length' "$s")" "1"
+check "SC8 rtk still single"      "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("rtk-hook-guard"))] | length' "$s")" "1"
+
+# SC2: the GOAL behaviour — with the auto-approve hook user-wired, an OUT-OF-REPO
+# session's Bash call to the abs-path Jira CLI is auto-approved. The hook decides
+# from the command TEXT, so run it from a non-himmel CWD and assert "allow". This
+# is the always-running hermetic counterpart to the VM script's SC2.
+aa="$repo_root/scripts/hooks/auto-approve-safe-bash.sh"
+outdir="$td/somewhere-else"; mkdir -p "$outdir"
+sc2_in="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"node $repo_root/scripts/jira/dist/index.js transition HIMMEL-1 Done\"}}"
+sc2_out=$(cd "$outdir" && printf '%s' "$sc2_in" | bash "$aa" 2>/dev/null)
+printf '%s' "$sc2_out" | grep -q '"permissionDecision"[: ]*"allow"' \
+  && check "SC2 out-of-repo jira call auto-approved" yes yes \
+  || check "SC2 out-of-repo jira call auto-approved" "no: $sc2_out" yes
+
+rm -rf "$td"
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/lib/test-unwire-pretooluse-hooks.ps1
+++ b/scripts/lib/test-unwire-pretooluse-hooks.ps1
@@ -1,0 +1,87 @@
+# test-unwire-pretooluse-hooks.ps1 -- committed PS test for unwire-pretooluse-hooks.ps1.
+# Covers: removes the UNIVERSAL trio + inject-initiative; SC12 sibling survives;
+# HIMMEL-DEV-ONLY hooks survive; idempotent; absent -> no-op; invalid JSON refused;
+# -Scope project -Target. Run: pwsh -File test-unwire-pretooluse-hooks.ps1
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$unwire = Join-Path $here 'unwire-pretooluse-hooks.ps1'
+. $unwire
+$fails = 0
+function Check($name, $got, $want) {
+    if ("$got" -eq "$want") { Write-Host "ok - $name" }
+    else { Write-Host "FAIL - ${name}: [$got]!=[$want]"; $script:fails++ }
+}
+function JqVal($file, $expr) { Get-Content $file -Raw | jq -r $expr }
+
+$td = Join-Path ([System.IO.Path]::GetTempPath()) ("unwireph-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force $td | Out-Null
+
+$fixture = '{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher":"Bash","hooks":[
+        {"type":"command","command":"bash C:/h/scripts/hooks/auto-approve-safe-bash.sh"},
+        {"type":"command","command":"bash /opt/rtk-hook-guard.sh"}
+      ]},
+      {"matcher":"Edit|Write|MultiEdit|NotebookEdit","hooks":[{"type":"command","command":"bash C:/h/scripts/hooks/block-edit-on-main.sh"}]},
+      {"matcher":"Bash|PowerShell|Read|Grep","hooks":[{"type":"command","command":"bash C:/h/scripts/hooks/block-read-secrets.sh"}]},
+      {"matcher":"*","hooks":[{"type":"command","command":"bash C:/h/scripts/hooks/auto-arm-on-cap.sh"}]}
+    ],
+    "SessionStart": [
+      {"hooks":[
+        {"type":"command","command":"bash C:/h/scripts/hooks/check-update-available.sh"},
+        {"type":"command","command":"bash C:/h/scripts/hooks/inject-initiative.sh"}
+      ]}
+    ]
+  }
+}'
+
+# 1. removes the trio, keeps rtk guard + dev-only auto-arm.
+$s1 = Join-Path $td 's1.json'; $fixture | Set-Content $s1 -Encoding utf8
+Remove-PretooluseHooks -SettingsPath $s1 | Out-Null
+Check 'trio removed (auto-approve)' (JqVal $s1 '[.hooks.PreToolUse[].hooks[].command | select(test("auto-approve-safe-bash"))] | length') '0'
+Check 'rtk guard survives'          (JqVal $s1 '[.hooks.PreToolUse[].hooks[].command | select(test("rtk-hook-guard"))] | length') '1'
+Check 'dev-only auto-arm survives'  (JqVal $s1 '[.hooks.PreToolUse[].hooks[].command | select(test("auto-arm-on-cap"))] | length') '1'
+
+# 2. SC12: inject-initiative spliced, check-update-available survives.
+Check 'inject-initiative removed' (JqVal $s1 '[.hooks.SessionStart[].hooks[].command | select(test("inject-initiative"))] | length') '0'
+Check 'SC12 sibling survives'     (JqVal $s1 '[.hooks.SessionStart[].hooks[].command | select(test("check-update-available"))] | length') '1'
+
+# 3. SessionStart stanza pruned when it ONLY held inject-initiative.
+$s3 = Join-Path $td 's3.json'
+'{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"bash C:/h/scripts/hooks/inject-initiative.sh"}]}]}}' | Set-Content $s3 -Encoding utf8
+Remove-PretooluseHooks -SettingsPath $s3 | Out-Null
+Check 'empty SessionStart pruned' (JqVal $s3 '.hooks.SessionStart | length') '0'
+
+# 4. idempotent re-run -> identical bytes.
+$b1 = Get-Content $s1 -Raw
+Remove-PretooluseHooks -SettingsPath $s1 | Out-Null
+Check 'idempotent re-run' (Get-Content $s1 -Raw) $b1
+
+# 5. absent -> no-op, not created.
+$s5 = Join-Path $td 'missing.json'
+Remove-PretooluseHooks -SettingsPath $s5 | Out-Null
+Check 'absent -> not created' (Test-Path $s5) $false
+
+# 6. invalid JSON -> throws, file unchanged.
+$s6 = Join-Path $td 's6.json'; 'nope {' | Set-Content $s6 -Encoding utf8
+$threw = $false
+try { Remove-PretooluseHooks -SettingsPath $s6 | Out-Null } catch { $threw = $true }
+if ($threw) { Write-Host 'ok - refuses invalid JSON' } else { Write-Host 'FAIL: invalid JSON not refused'; $fails++ }
+Check 'invalid file unchanged' ((Get-Content $s6 -Raw).Trim()) 'nope {'
+
+# 7. -Scope project -Target resolves <repo>/.claude/settings.json.
+$proj = Join-Path $td 'proj'; New-Item -ItemType Directory -Force (Join-Path $proj '.claude') | Out-Null
+$fixture | Set-Content (Join-Path $proj '.claude/settings.json') -Encoding utf8
+& pwsh -NoProfile -File $unwire -Scope project -Target $proj | Out-Null
+Check 'project-scope trio gone' (JqVal (Join-Path $proj '.claude/settings.json') '[.hooks.PreToolUse[].hooks[].command | select(test("auto-approve-safe-bash"))] | length') '0'
+Check 'project-scope dev hook kept' (JqVal (Join-Path $proj '.claude/settings.json') '[.hooks.PreToolUse[].hooks[].command | select(test("auto-arm-on-cap"))] | length') '1'
+
+# 8. -DryRun mutates nothing.
+$s8 = Join-Path $td 's8.json'; $fixture | Set-Content $s8 -Encoding utf8; $b8 = Get-Content $s8 -Raw
+Remove-PretooluseHooks -SettingsPath $s8 -DryRun | Out-Null
+Check 'dry-run no mutation' (Get-Content $s8 -Raw) $b8
+
+Remove-Item -Recurse -Force $td
+if ($fails -eq 0) { Write-Host 'ALL PASS' } else { Write-Host "$fails FAILED"; exit 1 }

--- a/scripts/lib/test-unwire-pretooluse-hooks.sh
+++ b/scripts/lib/test-unwire-pretooluse-hooks.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+# test-unwire-pretooluse-hooks.sh -- hermetic tests for unwire-pretooluse-hooks.sh.
+# Covers: removes only the UNIVERSAL himmel stanzas; SC12 (a SessionStart sibling
+# like check-update-available survives); HIMMEL-DEV-ONLY PreToolUse hooks survive;
+# idempotent; absent -> no-op; invalid JSON refused; --scope project --target.
+set -u
+here="$(cd "$(dirname "$0")" && pwd)"
+unwire="$here/unwire-pretooluse-hooks.sh"
+fails=0
+check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+
+td="$(mktemp -d)"
+
+# Build a realistic settings.json: UNIVERSAL trio + a HIMMEL-DEV-ONLY PreToolUse
+# (auto-arm) + a rtk guard co-located, and SessionStart with inject-initiative
+# beside check-update-available (the SC12 sibling).
+mk() {
+  printf '%s' '{
+    "hooks": {
+      "PreToolUse": [
+        {"matcher":"Bash","hooks":[
+          {"type":"command","command":"bash C:/h/scripts/hooks/auto-approve-safe-bash.sh"},
+          {"type":"command","command":"bash /opt/rtk-hook-guard.sh"}
+        ]},
+        {"matcher":"Edit|Write|MultiEdit|NotebookEdit","hooks":[{"type":"command","command":"bash C:/h/scripts/hooks/block-edit-on-main.sh"}]},
+        {"matcher":"Bash|PowerShell|Read|Grep","hooks":[{"type":"command","command":"bash C:/h/scripts/hooks/block-read-secrets.sh"}]},
+        {"matcher":"*","hooks":[{"type":"command","command":"bash C:/h/scripts/hooks/auto-arm-on-cap.sh"}]}
+      ],
+      "SessionStart": [
+        {"hooks":[
+          {"type":"command","command":"bash C:/h/scripts/hooks/check-update-available.sh"},
+          {"type":"command","command":"bash C:/h/scripts/hooks/inject-initiative.sh"}
+        ]}
+      ]
+    }
+  }' > "$1"
+}
+
+# 1. removes the UNIVERSAL trio, keeps rtk guard + the dev-only auto-arm hook.
+s1="$td/s1.json"; mk "$s1"
+bash "$unwire" "$s1" >/dev/null
+check "trio removed (auto-approve)" "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("auto-approve-safe-bash"))] | length' "$s1")" "0"
+check "trio removed (block-edit)"   "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("block-edit-on-main"))] | length' "$s1")" "0"
+check "trio removed (block-read)"   "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("block-read-secrets"))] | length' "$s1")" "0"
+check "rtk guard survives"          "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("rtk-hook-guard"))] | length' "$s1")" "1"
+check "dev-only auto-arm survives"  "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("auto-arm-on-cap"))] | length' "$s1")" "1"
+
+# 2. SC12: inject-initiative spliced out, check-update-available sibling survives.
+check "inject-initiative removed"   "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("inject-initiative"))] | length' "$s1")" "0"
+check "SC12 sibling survives"       "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("check-update-available"))] | length' "$s1")" "1"
+check "SessionStart stanza kept"    "$(jq '.hooks.SessionStart | length' "$s1")" "1"
+
+# 3. SessionStart stanza pruned when it ONLY held inject-initiative.
+s3="$td/s3.json"
+printf '%s' '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"bash C:/h/scripts/hooks/inject-initiative.sh"}]}]}}' > "$s3"
+bash "$unwire" "$s3" >/dev/null
+check "empty SessionStart stanza pruned" "$(jq '.hooks.SessionStart | length' "$s3")" "0"
+
+# 4. idempotent: second run no-ops, identical bytes.
+b1="$(cat "$s1")"
+bash "$unwire" "$s1" >/dev/null
+check "idempotent re-run" "$(cat "$s1")" "$b1"
+
+# 5. absent file -> no-op, rc 0.
+s5="$td/missing.json"
+bash "$unwire" "$s5" >/dev/null 2>&1
+check "absent -> rc 0" "$?" "0"
+check "absent -> not created" "$([ -f "$s5" ] && echo yes || echo no)" "no"
+
+# 6. invalid JSON -> refused, file unchanged.
+s6="$td/s6.json"; printf '%s' 'nope {' > "$s6"
+if bash "$unwire" "$s6" >/dev/null 2>&1; then echo "FAIL: invalid JSON not refused"; fails=$((fails+1)); else echo "ok - refuses invalid JSON"; fi
+check "invalid file unchanged" "$(cat "$s6")" "nope {"
+
+# 7. --scope project --target resolves <repo>/.claude/settings.json and unwires it.
+proj="$td/proj"; mkdir -p "$proj/.claude"
+mk "$proj/.claude/settings.json"
+bash "$unwire" --scope project --target "$proj" >/dev/null
+check "project-scope unwire (trio gone)" "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("auto-approve-safe-bash"))] | length' "$proj/.claude/settings.json")" "0"
+check "project-scope dev hook kept"      "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("auto-arm-on-cap"))] | length' "$proj/.claude/settings.json")" "1"
+
+# 8. --dry-run mutates nothing.
+s8="$td/s8.json"; mk "$s8"; b8="$(cat "$s8")"
+bash "$unwire" "$s8" 1 >/dev/null
+check "dry-run no mutation" "$(cat "$s8")" "$b8"
+
+rm -rf "$td"
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/lib/test-unwire-singlekey.ps1
+++ b/scripts/lib/test-unwire-singlekey.ps1
@@ -1,0 +1,92 @@
+# test-unwire-singlekey.ps1 -- committed PS test for the single-key unwire helpers
+# (unwire-statusline.ps1, unwire-himmel-repo.ps1, unwire-luna-vault.ps1; SC6).
+# Plus a .sh/.ps1 byte-parity assertion (both libs normalize through `jq --indent 2`,
+# so identical input must yield identical output). Run:
+#   pwsh -File test-unwire-singlekey.ps1
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $here 'unwire-statusline.ps1')
+. (Join-Path $here 'unwire-himmel-repo.ps1')
+. (Join-Path $here 'unwire-luna-vault.ps1')
+$fails = 0
+function Check($name, $got, $want) {
+    if ("$got" -eq "$want") { Write-Host "ok - $name" }
+    else { Write-Host "FAIL - ${name}: [$got]!=[$want]"; $script:fails++ }
+}
+function JqVal($file, $expr) { Get-Content $file -Raw | jq -r $expr }
+
+$td = Join-Path ([System.IO.Path]::GetTempPath()) ("unwiresk-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force $td | Out-Null
+
+# 1. statusline: removes himmel statusLine, preserves siblings.
+$s = Join-Path $td 'sl1.json'
+'{"statusLine":{"type":"command","command":"bash \"C:/h/scripts/statusline/bin/statusline.sh\""},"env":{"X":"1"}}' | Set-Content $s -Encoding utf8
+Remove-Statusline -SettingsPath $s | Out-Null
+Check 'statusLine removed'      (JqVal $s 'has("statusLine")') 'false'
+Check 'statusLine sibling kept' (JqVal $s '.env.X') '1'
+
+# 2. non-himmel statusLine left untouched.
+$s = Join-Path $td 'sl2.json'
+'{"statusLine":{"type":"command","command":"bash /opt/my-own-statusline.sh"}}' | Set-Content $s -Encoding utf8
+Remove-Statusline -SettingsPath $s | Out-Null
+Check 'custom statusLine preserved' (JqVal $s '.statusLine.command') 'bash /opt/my-own-statusline.sh'
+
+# 3. himmel-repo: removes key, preserves siblings.
+$s = Join-Path $td 'hr1.json'
+'{"env":{"HIMMEL_REPO":"C:/h","HIMMEL_INITIATIVE":"all"}}' | Set-Content $s -Encoding utf8
+Remove-HimmelRepo -SettingsPath $s | Out-Null
+Check 'HIMMEL_REPO removed'    (JqVal $s '.env.HIMMEL_REPO // "ABSENT"') 'ABSENT'
+Check 'HIMMEL_INITIATIVE kept' (JqVal $s '.env.HIMMEL_INITIATIVE') 'all'
+
+# 4. himmel-repo: env pruned when empty.
+$s = Join-Path $td 'hr2.json'
+'{"statusLine":{"x":1},"env":{"HIMMEL_REPO":"C:/h"}}' | Set-Content $s -Encoding utf8
+Remove-HimmelRepo -SettingsPath $s | Out-Null
+Check 'empty env pruned' (JqVal $s 'has("env")') 'false'
+
+# 5. luna-vault: removes key, preserves siblings.
+$s = Join-Path $td 'lv1.json'
+'{"env":{"LUNA_VAULT_PATH":"C:/v","HIMMEL_REPO":"C:/h"}}' | Set-Content $s -Encoding utf8
+Remove-LunaVault -SettingsPath $s | Out-Null
+Check 'LUNA_VAULT_PATH removed' (JqVal $s '.env.LUNA_VAULT_PATH // "ABSENT"') 'ABSENT'
+Check 'HIMMEL_REPO kept'        (JqVal $s '.env.HIMMEL_REPO') 'C:/h'
+
+# 6. shared invariants: absent file -> no-op; invalid JSON refused.
+$missing = Join-Path $td 'missing.json'
+Remove-HimmelRepo -SettingsPath $missing | Out-Null
+Check 'absent -> not created' (Test-Path $missing) $false
+$bad = Join-Path $td 'bad.json'; 'nope {' | Set-Content $bad -Encoding utf8
+$threw = $false
+try { Remove-LunaVault -SettingsPath $bad | Out-Null } catch { $threw = $true }
+if ($threw) { Write-Host 'ok - refuses invalid JSON' } else { Write-Host 'FAIL: invalid JSON not refused'; $fails++ }
+
+# 7. .sh/.ps1 byte-parity (skip if Git Bash unavailable -- never the System32 WSL stub).
+$gitBash = "C:\Program Files\Git\bin\bash.exe"
+if (-not (Test-Path $gitBash)) {
+    $bc = Get-Command bash -ErrorAction SilentlyContinue
+    if ($bc -and $bc.Source -notmatch 'System32') { $gitBash = $bc.Source } else { $gitBash = $null }
+}
+if ($gitBash) {
+    $pairs = @(
+        @{ ps = { param($p) Remove-HimmelRepo -SettingsPath $p }; sh = 'unwire-himmel-repo.sh'; json = '{"env":{"HIMMEL_REPO":"C:/h","HIMMEL_INITIATIVE":"all"}}' },
+        @{ ps = { param($p) Remove-LunaVault -SettingsPath $p };  sh = 'unwire-luna-vault.sh';  json = '{"env":{"LUNA_VAULT_PATH":"C:/v","K":"1"}}' },
+        @{ ps = { param($p) Remove-Statusline -SettingsPath $p }; sh = 'unwire-statusline.sh';  json = '{"statusLine":{"type":"command","command":"bash \"C:/h/scripts/statusline/bin/statusline.sh\""},"env":{"X":"1"}}' }
+    )
+    foreach ($pair in $pairs) {
+        $pf = Join-Path $td ("par-ps-" + $pair.sh + ".json")
+        $sf = Join-Path $td ("par-sh-" + $pair.sh + ".json")
+        $pair.json | Set-Content $pf -Encoding utf8
+        $pair.json | Set-Content $sf -Encoding utf8
+        & $pair.ps $pf | Out-Null
+        & $gitBash (Join-Path $here $pair.sh).Replace('\','/') $sf.Replace('\','/') | Out-Null
+        $pOut = (Get-Content $pf -Raw).Replace("`r`n","`n").TrimEnd("`n")
+        $sOut = (Get-Content $sf -Raw).Replace("`r`n","`n").TrimEnd("`n")
+        Check ("parity " + $pair.sh) $pOut $sOut
+    }
+} else {
+    Write-Host 'skip - .sh/.ps1 parity (Git Bash not found)'
+}
+
+Remove-Item -Recurse -Force $td
+if ($fails -eq 0) { Write-Host 'ALL PASS' } else { Write-Host "$fails FAILED"; exit 1 }

--- a/scripts/lib/test-unwire-singlekey.sh
+++ b/scripts/lib/test-unwire-singlekey.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+# test-unwire-singlekey.sh -- hermetic tests for the single-key unwire helpers
+# (unwire-statusline.sh, unwire-himmel-repo.sh, unwire-luna-vault.sh; SC6). Each:
+# removes only its key/stanza, preserves siblings, idempotent, absent -> no-op,
+# refuses invalid JSON. statusLine removal is conditional (himmel binary only).
+set -u
+here="$(cd "$(dirname "$0")" && pwd)"
+sl="$here/unwire-statusline.sh"
+hr="$here/unwire-himmel-repo.sh"
+lv="$here/unwire-luna-vault.sh"
+fails=0
+check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+td="$(mktemp -d)"
+
+# ── unwire-statusline ───────────────────────────────────────────────────────
+# 1. removes himmel statusLine, preserves siblings.
+s="$td/sl1.json"
+printf '%s' '{"statusLine":{"type":"command","command":"bash \"C:/h/scripts/statusline/bin/statusline.sh\""},"env":{"X":"1"}}' > "$s"
+bash "$sl" "$s" >/dev/null
+check "statusLine removed"      "$(jq -r 'has("statusLine")' "$s")" "false"
+check "statusLine sibling kept" "$(jq -r '.env.X' "$s")" "1"
+# 2. a NON-himmel custom statusLine is left untouched.
+s="$td/sl2.json"
+printf '%s' '{"statusLine":{"type":"command","command":"bash /opt/my-own-statusline.sh"}}' > "$s"
+bash "$sl" "$s" >/dev/null
+check "custom statusLine preserved" "$(jq -r '.statusLine.command' "$s")" "bash /opt/my-own-statusline.sh"
+
+# ── unwire-himmel-repo ──────────────────────────────────────────────────────
+# 3. removes HIMMEL_REPO, preserves sibling env keys.
+s="$td/hr1.json"
+printf '%s' '{"env":{"HIMMEL_REPO":"C:/h","HIMMEL_INITIATIVE":"all"}}' > "$s"
+bash "$hr" "$s" >/dev/null
+check "HIMMEL_REPO removed"     "$(jq -r '.env.HIMMEL_REPO // "ABSENT"' "$s")" "ABSENT"
+check "HIMMEL_INITIATIVE kept"  "$(jq -r '.env.HIMMEL_INITIATIVE' "$s")" "all"
+# 4. env pruned when it becomes empty.
+s="$td/hr2.json"
+printf '%s' '{"statusLine":{"x":1},"env":{"HIMMEL_REPO":"C:/h"}}' > "$s"
+bash "$hr" "$s" >/dev/null
+check "empty env pruned"        "$(jq -r 'has("env")' "$s")" "false"
+check "non-env sibling kept"    "$(jq -r '.statusLine.x' "$s")" "1"
+
+# ── unwire-luna-vault ───────────────────────────────────────────────────────
+# 5. removes LUNA_VAULT_PATH, preserves sibling env keys.
+s="$td/lv1.json"
+printf '%s' '{"env":{"LUNA_VAULT_PATH":"C:/v","HIMMEL_REPO":"C:/h"}}' > "$s"
+bash "$lv" "$s" >/dev/null
+check "LUNA_VAULT_PATH removed"  "$(jq -r '.env.LUNA_VAULT_PATH // "ABSENT"' "$s")" "ABSENT"
+check "HIMMEL_REPO kept"         "$(jq -r '.env.HIMMEL_REPO' "$s")" "C:/h"
+
+# ── shared invariants for all three ─────────────────────────────────────────
+for h in "$sl" "$hr" "$lv"; do
+  n="$(basename "$h")"
+  # absent file -> rc 0, not created.
+  m="$td/missing-$n.json"
+  bash "$h" "$m" >/dev/null 2>&1; check "$n absent -> rc0" "$?" "0"
+  check "$n absent -> not created" "$([ -f "$m" ] && echo yes || echo no)" "no"
+  # absent key -> content semantically unchanged (jq reformats, like the wire twins).
+  k="$td/nokey-$n.json"; printf '%s' '{"permissions":{"allow":[]}}' > "$k"; kb="$(jq -S . "$k")"
+  bash "$h" "$k" >/dev/null; check "$n absent-key idempotent" "$(jq -S . "$k")" "$kb"
+  # invalid JSON -> refused, unchanged.
+  v="$td/bad-$n.json"; printf '%s' 'nope {' > "$v"
+  if bash "$h" "$v" >/dev/null 2>&1; then echo "FAIL: $n didn't refuse invalid JSON"; fails=$((fails+1)); else echo "ok - $n refuses invalid JSON"; fi
+  check "$n invalid unchanged" "$(cat "$v")" "nope {"
+done
+
+# ── idempotent re-run (statusline example) ──────────────────────────────────
+s="$td/idem.json"
+printf '%s' '{"statusLine":{"type":"command","command":"bash \"C:/h/scripts/statusline/bin/statusline.sh\""},"env":{"HIMMEL_REPO":"C:/h"}}' > "$s"
+bash "$sl" "$s" >/dev/null; ba="$(cat "$s")"; bash "$sl" "$s" >/dev/null
+check "statusline idempotent" "$(cat "$s")" "$ba"
+
+rm -rf "$td"
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/lib/test-wire-pretooluse-hooks.ps1
+++ b/scripts/lib/test-wire-pretooluse-hooks.ps1
@@ -1,0 +1,85 @@
+# test-wire-pretooluse-hooks.ps1 -- committed PS test for wire-pretooluse-hooks.ps1.
+# Covers: PreToolUse trio wired + forward-slashed/quoted; dedup-by-basename across
+# a clone-path change (SC8); rtk guard preserved; SessionStart shared-array merge +
+# sibling survival; idempotent; invalid JSON refused. Run:
+#   pwsh -File test-wire-pretooluse-hooks.ps1
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$wire = Join-Path $here 'wire-pretooluse-hooks.ps1'
+. $wire
+$fails = 0
+function Check($name, $got, $want) {
+    if ("$got" -eq "$want") { Write-Host "ok - $name" }
+    else { Write-Host "FAIL - ${name}: [$got]!=[$want]"; $script:fails++ }
+}
+function JqVal($file, $expr) { Get-Content $file -Raw | jq -r $expr }
+
+$td = Join-Path ([System.IO.Path]::GetTempPath()) ("wireph-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force $td | Out-Null
+
+# 1. missing file -> 3 stanzas, forward-slashed + quoted.
+$s1 = Join-Path $td 's1.json'
+Set-PretooluseHooks -SettingsPath $s1 -Prefix 'C:/himmel' | Out-Null
+Check '3 PreToolUse stanzas'     (JqVal $s1 '.hooks.PreToolUse | length') '3'
+Check 'auto-approve quoted path' (JqVal $s1 '.hooks.PreToolUse[0].hooks[0].command') 'bash "C:/himmel/scripts/hooks/auto-approve-safe-bash.sh"'
+
+# 2. backslash prefix -> forward-slashed.
+$s2 = Join-Path $td 's2.json'
+Set-PretooluseHooks -SettingsPath $s2 -Prefix 'C:\Users\me\himmel' | Out-Null
+Check 'backslash forward-slashed' (JqVal $s2 '.hooks.PreToolUse[1].hooks[0].command') 'bash "C:/Users/me/himmel/scripts/hooks/block-edit-on-main.sh"'
+
+# 3. SC8: clone-path change -> still exactly 3, new path.
+$s3 = Join-Path $td 's3.json'
+Set-PretooluseHooks -SettingsPath $s3 -Prefix 'C:/old/himmel' | Out-Null
+Set-PretooluseHooks -SettingsPath $s3 -Prefix 'C:/new/himmel' | Out-Null
+Check 'clone-path change: still 3'  (JqVal $s3 '.hooks.PreToolUse | length') '3'
+Check 'clone-path change: new path' (JqVal $s3 '.hooks.PreToolUse[0].hooks[0].command') 'bash "C:/new/himmel/scripts/hooks/auto-approve-safe-bash.sh"'
+
+# 4. rtk guard co-located in the Bash stanza survives; himmel object replaced.
+$s4 = Join-Path $td 's4.json'
+'{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"bash /opt/rtk-hook-guard.sh"},{"type":"command","command":"bash /old/scripts/hooks/auto-approve-safe-bash.sh"}]}]}}' | Set-Content $s4 -Encoding utf8
+Set-PretooluseHooks -SettingsPath $s4 -Prefix 'C:/himmel' | Out-Null
+Check 'rtk guard survives' (JqVal $s4 '[.hooks.PreToolUse[].hooks[].command | select(test("rtk-hook-guard"))] | length') '1'
+Check 'himmel object no-dup' (JqVal $s4 '[.hooks.PreToolUse[].hooks[].command | select(test("auto-approve-safe-bash"))] | length') '1'
+
+# 5. SessionStart shared-array merge: inject-initiative beside a sibling.
+$s5 = Join-Path $td 's5.json'
+'{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"bash /x/scripts/hooks/check-update-available.sh"}]}]}}' | Set-Content $s5 -Encoding utf8
+Set-SessionStartHook -SettingsPath $s5 -Prefix 'C:/himmel' -HookBasename 'inject-initiative.sh' | Out-Null
+Check 'SessionStart stanza count' (JqVal $s5 '.hooks.SessionStart | length') '1'
+Check 'sibling check-update kept' (JqVal $s5 '[.hooks.SessionStart[].hooks[].command | select(test("check-update-available"))] | length') '1'
+Check 'inject-initiative added'   (JqVal $s5 '[.hooks.SessionStart[].hooks[].command | select(test("inject-initiative"))] | length') '1'
+
+# 6. SessionStart dedup across changed clone path -> single object, new path.
+Set-SessionStartHook -SettingsPath $s5 -Prefix 'C:/moved/himmel' -HookBasename 'inject-initiative.sh' | Out-Null
+Check 'inject-initiative dedup'    (JqVal $s5 '[.hooks.SessionStart[].hooks[].command | select(test("inject-initiative"))] | length') '1'
+
+# 7. idempotent PreToolUse re-run -> identical bytes.
+$s7 = Join-Path $td 's7.json'
+Set-PretooluseHooks -SettingsPath $s7 -Prefix 'C:/himmel' | Out-Null
+$b7 = Get-Content $s7 -Raw
+Set-PretooluseHooks -SettingsPath $s7 -Prefix 'C:/himmel' | Out-Null
+Check 'PreToolUse idempotent' (Get-Content $s7 -Raw) $b7
+
+# 7c. whitespace-only existing file -> treated as {} (not refused), 3 stanzas.
+$s7c = Join-Path $td 's7c.json'
+"   `n" | Set-Content $s7c -Encoding utf8
+Set-PretooluseHooks -SettingsPath $s7c -Prefix 'C:/himmel' | Out-Null
+Check 'whitespace file -> 3 stanzas' (JqVal $s7c '.hooks.PreToolUse | length') '3'
+
+# 7d. BOM-less output: the written file must NOT start with a UTF-8 BOM (EF BB BF).
+$bytes = [System.IO.File]::ReadAllBytes($s7c)
+$hasBom = ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF)
+Check 'no UTF-8 BOM written' $hasBom $false
+
+# 8. invalid JSON -> throws (caught), file unchanged.
+$s8 = Join-Path $td 's8.json'
+'nope {' | Set-Content $s8 -Encoding utf8
+$threw = $false
+try { Set-PretooluseHooks -SettingsPath $s8 -Prefix 'C:/himmel' | Out-Null } catch { $threw = $true }
+if ($threw) { Write-Host 'ok - refuses invalid JSON' } else { Write-Host 'FAIL: invalid JSON not refused'; $fails++ }
+Check 'invalid file unchanged' ((Get-Content $s8 -Raw).Trim()) 'nope {'
+
+Remove-Item -Recurse -Force $td
+if ($fails -eq 0) { Write-Host 'ALL PASS' } else { Write-Host "$fails FAILED"; exit 1 }

--- a/scripts/lib/test-wire-pretooluse-hooks.sh
+++ b/scripts/lib/test-wire-pretooluse-hooks.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015,SC1090
+# test-wire-pretooluse-hooks.sh -- hermetic tests for wire-pretooluse-hooks.sh.
+# Covers: PreToolUse trio wired; dedup-by-basename across a clone-path change
+# (SC8 -> no double-wire); rtk-hook-guard / non-himmel hook preserved; SessionStart
+# shared-array merge; idempotent re-run.
+set -u
+here="$(cd "$(dirname "$0")" && pwd)"
+wire="$here/wire-pretooluse-hooks.sh"
+fails=0
+check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+
+td="$(mktemp -d)"
+
+# 1. missing file -> creates the 3 PreToolUse stanzas, forward-slashed + quoted.
+s1="$td/s1.json"
+bash "$wire" "$s1" "C:/himmel" >/dev/null
+check "3 PreToolUse stanzas"      "$(jq '.hooks.PreToolUse | length' "$s1")" "3"
+check "auto-approve quoted path"  "$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$s1")" 'bash "C:/himmel/scripts/hooks/auto-approve-safe-bash.sh"'
+
+# 2. backslash prefix -> forward-slashed in the command.
+s2="$td/s2.json"
+bash "$wire" "$s2" 'C:\Users\me\himmel' >/dev/null
+check "backslash forward-slashed" "$(jq -r '.hooks.PreToolUse[1].hooks[0].command' "$s2")" 'bash "C:/Users/me/himmel/scripts/hooks/block-edit-on-main.sh"'
+
+# 3. SC8 dedup-by-basename across a CLONE-PATH change -> still exactly 3, new path.
+s3="$td/s3.json"
+bash "$wire" "$s3" "C:/old/himmel" >/dev/null
+bash "$wire" "$s3" "C:/new/himmel" >/dev/null
+check "clone-path change: still 3"   "$(jq '.hooks.PreToolUse | length' "$s3")" "3"
+check "clone-path change: new path"  "$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$s3")" 'bash "C:/new/himmel/scripts/hooks/auto-approve-safe-bash.sh"'
+
+# 4. rtk-hook-guard / non-himmel hook in the SAME Bash stanza is preserved.
+s4="$td/s4.json"
+printf '%s' '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"bash /opt/rtk-hook-guard.sh"},{"type":"command","command":"bash /old/scripts/hooks/auto-approve-safe-bash.sh"}]}]}}' > "$s4"
+bash "$wire" "$s4" "C:/himmel" >/dev/null
+check "rtk guard survives" "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("rtk-hook-guard"))] | length' "$s4")" "1"
+check "himmel object replaced (no dup)" "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("auto-approve-safe-bash"))] | length' "$s4")" "1"
+
+# 5. SessionStart shared-array merge: inject-initiative co-resides with a sibling.
+s5="$td/s5.json"
+printf '%s' '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"bash /x/scripts/hooks/check-update-available.sh"}]}]}}' > "$s5"
+# SessionStart wiring is a function call (direct-invoke only does PreToolUse):
+( . "$wire"; wire_sessionstart_hook "$s5" "C:/himmel" "inject-initiative.sh" 0 >/dev/null )
+check "SessionStart stanza count" "$(jq '.hooks.SessionStart | length' "$s5")" "1"
+check "sibling check-update kept"  "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("check-update-available"))] | length' "$s5")" "1"
+check "inject-initiative added"    "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("inject-initiative"))] | length' "$s5")" "1"
+
+# 6. SessionStart idempotent across re-run with changed clone path -> single object.
+( . "$wire"; wire_sessionstart_hook "$s5" "C:/moved/himmel" "inject-initiative.sh" 0 >/dev/null )
+check "inject-initiative dedup"    "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("inject-initiative"))] | length' "$s5")" "1"
+check "inject-initiative new path" "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("inject-initiative"))][0]' "$s5")" 'bash "C:/moved/himmel/scripts/hooks/inject-initiative.sh"'
+
+# 7. SessionStart with no prior stanza -> creates a standalone one.
+s7="$td/s7.json"
+( . "$wire"; wire_sessionstart_hook "$s7" "C:/himmel" "inject-initiative.sh" 0 >/dev/null )
+check "standalone SessionStart created" "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("inject-initiative"))] | length' "$s7")" "1"
+
+# 7b. --sessionstart CLI dispatch (the subprocess path setup.sh uses) wires it.
+s7b="$td/s7b.json"
+bash "$wire" --sessionstart "$s7b" "C:/himmel" "inject-initiative.sh" >/dev/null
+check "--sessionstart CLI wires inject" "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("inject-initiative"))] | length' "$s7b")" "1"
+
+# 8. PreToolUse idempotent re-run (same path) -> identical bytes.
+s8="$td/s8.json"
+bash "$wire" "$s8" "C:/himmel" >/dev/null
+b8="$(cat "$s8")"
+bash "$wire" "$s8" "C:/himmel" >/dev/null
+check "PreToolUse idempotent" "$(cat "$s8")" "$b8"
+
+# 8b. whitespace-only existing file -> treated as {} (not refused), 3 stanzas.
+s8b="$td/s8b.json"; printf '   \n' > "$s8b"
+bash "$wire" "$s8b" "C:/himmel" >/dev/null
+check "whitespace file -> 3 stanzas" "$(jq '.hooks.PreToolUse | length' "$s8b")" "3"
+# 8c. whitespace-only file -> SessionStart wires cleanly too.
+s8c="$td/s8c.json"; printf '\t\n ' > "$s8c"
+( . "$wire"; wire_sessionstart_hook "$s8c" "C:/himmel" "inject-initiative.sh" 0 >/dev/null )
+check "whitespace file -> SessionStart inject" "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("inject-initiative"))] | length' "$s8c")" "1"
+
+# 9. invalid JSON -> refused, file unchanged.
+s9="$td/s9.json"
+printf '%s' 'nope {' > "$s9"
+if bash "$wire" "$s9" "C:/himmel" >/dev/null 2>&1; then
+  echo "FAIL: invalid JSON not refused"; fails=$((fails+1))
+else
+  echo "ok - refuses invalid JSON"
+fi
+check "invalid file unchanged" "$(cat "$s9")" "nope {"
+
+rm -rf "$td"
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/lib/unwire-himmel-repo.ps1
+++ b/scripts/lib/unwire-himmel-repo.ps1
@@ -1,0 +1,31 @@
+# unwire-himmel-repo.ps1 -- PowerShell counterpart of unwire-himmel-repo.sh.
+# Removes env.HIMMEL_REPO from a Claude Code settings.json; all other env keys are
+# preserved; an env object left empty is pruned. Shells out to jq for byte-parity.
+#
+#   Remove-HimmelRepo -SettingsPath <path>
+# Direct:  pwsh -File unwire-himmel-repo.ps1 -SettingsPath <path>
+
+[CmdletBinding()]
+param([string]$SettingsPath)
+
+function Remove-HimmelRepo {
+    param([Parameter(Mandatory = $true)][string]$SettingsPath)
+    if (-not (Get-Command jq -ErrorAction SilentlyContinue)) { throw "unwire-himmel-repo: jq required" }
+    if (-not (Test-Path $SettingsPath)) { return }
+    $raw = Get-Content $SettingsPath -Raw
+    if ([string]::IsNullOrWhiteSpace($raw)) { return }
+    $raw | jq -e . > $null 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "unwire-himmel-repo: $SettingsPath is not valid JSON -- refusing to modify" }
+    $filter = 'del(.env.HIMMEL_REPO) | if (has("env") and (.env == {})) then del(.env) else . end'
+    $out = $raw | jq --indent 2 $filter
+    if ($LASTEXITCODE -ne 0) { throw "unwire-himmel-repo: jq transform failed" }
+    $tmp = "$SettingsPath.unwirehr.tmp"
+    # UTF-8 without BOM (HIMMEL-365/408): Set-Content -Encoding utf8 BOMs on PS 5.1.
+    [System.IO.File]::WriteAllText($tmp, ($out -join "`n") + "`n")
+    Move-Item -Path $tmp -Destination $SettingsPath -Force
+    Write-Host "  removed env.HIMMEL_REPO (if present) -> $SettingsPath"
+}
+
+if ($SettingsPath) {
+    try { Remove-HimmelRepo -SettingsPath $SettingsPath } catch { Write-Error $_; exit 1 }
+}

--- a/scripts/lib/unwire-himmel-repo.sh
+++ b/scripts/lib/unwire-himmel-repo.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# unwire-himmel-repo.sh -- remove env.HIMMEL_REPO from a Claude Code settings.json
+# (the inverse of wire-himmel-repo.sh; HIMMEL install/uninstall symmetry). All
+# other env keys (HIMMEL_INITIATIVE, LUNA_VAULT_PATH, ...) are preserved; an env
+# object left empty is pruned.
+#
+# Usage:
+#   bash unwire-himmel-repo.sh <settings-json-path>
+#
+# Idempotent (absent key / absent file -> no-op), atomic (temp file + mv),
+# refuses invalid JSON, preserves all sibling keys. Requires jq. Source it to
+# call unwire_himmel_repo directly, or invoke via bash.
+set -euo pipefail
+
+unwire_himmel_repo() {
+  local settings="$1"
+  command -v jq >/dev/null 2>&1 || { echo "unwire-himmel-repo: jq required" >&2; return 1; }
+  [ -f "$settings" ] || return 0
+  local base
+  base=$(cat "$settings")
+  [ -z "$(printf '%s' "$base" | tr -d '[:space:]')" ] && return 0
+  if ! printf '%s' "$base" | jq -e . >/dev/null 2>&1; then
+    echo "unwire-himmel-repo: $settings is not valid JSON -- refusing to modify" >&2
+    return 1
+  fi
+  printf '%s' "$base" | jq '
+    del(.env.HIMMEL_REPO)
+    | if (has("env") and (.env == {})) then del(.env) else . end
+  ' > "$settings.unwirehr.tmp" && mv "$settings.unwirehr.tmp" "$settings"
+  echo "  removed env.HIMMEL_REPO (if present) -> $settings"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  [ "$#" -eq 1 ] || { echo "usage: unwire-himmel-repo.sh <settings-json-path>" >&2; exit 2; }
+  unwire_himmel_repo "$1"
+fi

--- a/scripts/lib/unwire-luna-vault.ps1
+++ b/scripts/lib/unwire-luna-vault.ps1
@@ -1,0 +1,31 @@
+# unwire-luna-vault.ps1 -- PowerShell counterpart of unwire-luna-vault.sh.
+# Removes env.LUNA_VAULT_PATH from a Claude Code settings.json; all other env keys
+# are preserved; an env object left empty is pruned. Shells out to jq for byte-parity.
+#
+#   Remove-LunaVault -SettingsPath <path>
+# Direct:  pwsh -File unwire-luna-vault.ps1 -SettingsPath <path>
+
+[CmdletBinding()]
+param([string]$SettingsPath)
+
+function Remove-LunaVault {
+    param([Parameter(Mandatory = $true)][string]$SettingsPath)
+    if (-not (Get-Command jq -ErrorAction SilentlyContinue)) { throw "unwire-luna-vault: jq required" }
+    if (-not (Test-Path $SettingsPath)) { return }
+    $raw = Get-Content $SettingsPath -Raw
+    if ([string]::IsNullOrWhiteSpace($raw)) { return }
+    $raw | jq -e . > $null 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "unwire-luna-vault: $SettingsPath is not valid JSON -- refusing to modify" }
+    $filter = 'del(.env.LUNA_VAULT_PATH) | if (has("env") and (.env == {})) then del(.env) else . end'
+    $out = $raw | jq --indent 2 $filter
+    if ($LASTEXITCODE -ne 0) { throw "unwire-luna-vault: jq transform failed" }
+    $tmp = "$SettingsPath.unwirelv.tmp"
+    # UTF-8 without BOM (HIMMEL-365/408): Set-Content -Encoding utf8 BOMs on PS 5.1.
+    [System.IO.File]::WriteAllText($tmp, ($out -join "`n") + "`n")
+    Move-Item -Path $tmp -Destination $SettingsPath -Force
+    Write-Host "  removed env.LUNA_VAULT_PATH (if present) -> $SettingsPath"
+}
+
+if ($SettingsPath) {
+    try { Remove-LunaVault -SettingsPath $SettingsPath } catch { Write-Error $_; exit 1 }
+}

--- a/scripts/lib/unwire-luna-vault.sh
+++ b/scripts/lib/unwire-luna-vault.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# unwire-luna-vault.sh -- remove env.LUNA_VAULT_PATH from a Claude Code
+# settings.json (the inverse of wire-luna-vault.sh; HIMMEL install/uninstall
+# symmetry). Written by `adopt --profile luna/all`, so this matters for
+# luna-scaffolded installs. All other env keys are preserved; an env object left
+# empty is pruned.
+#
+# Usage:
+#   bash unwire-luna-vault.sh <settings-json-path>
+#
+# Idempotent (absent key / absent file -> no-op), atomic (temp file + mv),
+# refuses invalid JSON, preserves all sibling keys. Requires jq. Source it to
+# call unwire_luna_vault directly, or invoke via bash.
+set -euo pipefail
+
+unwire_luna_vault() {
+  local settings="$1"
+  command -v jq >/dev/null 2>&1 || { echo "unwire-luna-vault: jq required" >&2; return 1; }
+  [ -f "$settings" ] || return 0
+  local base
+  base=$(cat "$settings")
+  [ -z "$(printf '%s' "$base" | tr -d '[:space:]')" ] && return 0
+  if ! printf '%s' "$base" | jq -e . >/dev/null 2>&1; then
+    echo "unwire-luna-vault: $settings is not valid JSON -- refusing to modify" >&2
+    return 1
+  fi
+  printf '%s' "$base" | jq '
+    del(.env.LUNA_VAULT_PATH)
+    | if (has("env") and (.env == {})) then del(.env) else . end
+  ' > "$settings.unwirelv.tmp" && mv "$settings.unwirelv.tmp" "$settings"
+  echo "  removed env.LUNA_VAULT_PATH (if present) -> $settings"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  [ "$#" -eq 1 ] || { echo "usage: unwire-luna-vault.sh <settings-json-path>" >&2; exit 2; }
+  unwire_luna_vault "$1"
+fi

--- a/scripts/lib/unwire-pretooluse-hooks.ps1
+++ b/scripts/lib/unwire-pretooluse-hooks.ps1
@@ -1,0 +1,82 @@
+# unwire-pretooluse-hooks.ps1 -- PowerShell counterpart of unwire-pretooluse-hooks.sh.
+# Removes himmel's UNIVERSAL hooks (PreToolUse trio + SessionStart inject-initiative)
+# from a Claude Code settings.json by BASENAME, preserving every non-himmel hook and
+# the HIMMEL-DEV-ONLY hooks. Shells out to jq for byte-parity with the bash twin.
+#
+#   Remove-PretooluseHooks -SettingsPath <path> [-DryRun]
+#
+# Usage (direct):
+#   pwsh -File unwire-pretooluse-hooks.ps1 -SettingsPath <path> [-DryRun]
+#   pwsh -File unwire-pretooluse-hooks.ps1 -Scope project -Target <repo> [-DryRun]
+#
+# Idempotent (absent -> no-op), atomic (temp + move), refuses invalid JSON,
+# preserves siblings (SC12: a SessionStart sibling like check-update-available.sh
+# survives). Requires jq.
+
+[CmdletBinding()]
+param(
+    [string]$SettingsPath,
+    [string]$Scope,
+    [string]$Target,
+    [switch]$DryRun
+)
+
+$script:UnwirePrePat = 'scripts/hooks/(auto-approve-safe-bash|block-edit-on-main|block-read-secrets)[.]sh'
+$script:UnwireSsPat  = 'scripts/hooks/inject-initiative[.]sh'
+
+function Remove-PretooluseHooks {
+    param(
+        [Parameter(Mandatory = $true)] [string]$SettingsPath,
+        [switch]$DryRun
+    )
+    if (-not (Get-Command jq -ErrorAction SilentlyContinue)) { throw "unwire-pretooluse-hooks: jq required" }
+    if (-not (Test-Path $SettingsPath)) {
+        if ($DryRun) { Write-Host "DRY: $SettingsPath absent -> no-op" }
+        return
+    }
+    $raw = Get-Content $SettingsPath -Raw
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        if ($DryRun) { Write-Host "DRY: $SettingsPath empty -> no-op" }
+        return
+    }
+    $raw | jq -e . > $null 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "unwire-pretooluse-hooks: $SettingsPath is not valid JSON -- refusing to modify" }
+    if ($DryRun) {
+        Write-Host "DRY: remove UNIVERSAL himmel hooks (PreToolUse trio + SessionStart inject-initiative) from $SettingsPath"
+        return
+    }
+    $filter = @'
+if (.hooks // {} | has("PreToolUse")) then
+  .hooks.PreToolUse = ((.hooks.PreToolUse)
+    | map(.hooks = ((.hooks // []) | map(select((.command // "") | test($pre) | not))))
+    | map(select((.hooks | length) > 0)))
+else . end
+| if (.hooks // {} | has("SessionStart")) then
+    .hooks.SessionStart = ((.hooks.SessionStart)
+      | map(.hooks = ((.hooks // []) | map(select((.command // "") | test($ss) | not))))
+      | map(select((.hooks | length) > 0)))
+  else . end
+'@
+    $out = $raw | jq --indent 2 --arg pre $script:UnwirePrePat --arg ss $script:UnwireSsPat $filter
+    if ($LASTEXITCODE -ne 0) { throw "unwire-pretooluse-hooks: jq transform failed" }
+    $tmp = "$SettingsPath.unwirehooks.tmp"
+    # UTF-8 without BOM (see wire-pretooluse-hooks.ps1) -- never BOM-corrupt the
+    # operator's real settings.json on the teardown path.
+    [System.IO.File]::WriteAllText($tmp, ($out -join "`n") + "`n")
+    Move-Item -Path $tmp -Destination $SettingsPath -Force
+    Write-Host "  removed UNIVERSAL himmel hooks -> $SettingsPath"
+}
+
+# Direct invocation. Dot-sourcing with no args just defines the function.
+if ($Scope -eq 'project') {
+    if (-not $Target) { Write-Error "unwire-pretooluse-hooks: -Scope project requires -Target <repo>"; exit 2 }
+    $SettingsPath = Join-Path $Target '.claude/settings.json'
+}
+if ($SettingsPath) {
+    try {
+        Remove-PretooluseHooks -SettingsPath $SettingsPath -DryRun:$DryRun
+    } catch {
+        Write-Error $_
+        exit 1
+    }
+}

--- a/scripts/lib/unwire-pretooluse-hooks.sh
+++ b/scripts/lib/unwire-pretooluse-hooks.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# unwire-pretooluse-hooks.sh -- remove himmel's UNIVERSAL hooks from a Claude Code
+# settings.json (the inverse of wire-pretooluse-hooks.sh). Used by:
+#   - uninstall.sh [6/6] to tear down user-scope wiring (install/uninstall symmetry),
+#   - R4 duplication remediation: `--scope project --target <repo>` removes the
+#     redundant project-scope copy when a project ALSO has user-scope wiring.
+#
+# Removes ONLY the UNIVERSAL himmel hooks (by BASENAME) -- preserving every
+# non-himmel hook and the HIMMEL-DEV-ONLY hooks (check-cr-marker, block-backend-tier,
+# auto-arm, check-update-available, ...):
+#   PreToolUse: auto-approve-safe-bash, block-edit-on-main, block-read-secrets
+#               (drop the hook object; prune a stanza only when it becomes empty)
+#   SessionStart: inject-initiative (splice out the hook OBJECT; prune the wrapper
+#                 stanza ONLY if its hooks[] becomes empty -- never delete a
+#                 sibling like check-update-available.sh, SC12)
+#
+# Usage:
+#   bash unwire-pretooluse-hooks.sh <settings-json-path> [<dry_run>]
+#   bash unwire-pretooluse-hooks.sh --scope project --target <repo> [--dry-run]
+#
+# Idempotent (absent -> no-op), atomic (temp file + mv), refuses invalid JSON,
+# preserves siblings. Requires jq. Source it to call unwire_pretooluse_hooks
+# directly, or invoke via bash.
+set -euo pipefail
+
+# Regexes (extended) matching the UNIVERSAL hook commands by basename path.
+_UNWIRE_PRE_PAT='scripts/hooks/(auto-approve-safe-bash|block-edit-on-main|block-read-secrets)[.]sh'
+_UNWIRE_SS_PAT='scripts/hooks/inject-initiative[.]sh'
+
+unwire_pretooluse_hooks() {
+  local settings="$1" dry_run="${2:-0}"
+  command -v jq >/dev/null 2>&1 || { echo "unwire-pretooluse-hooks: jq required" >&2; return 1; }
+  if [ ! -f "$settings" ]; then
+    [ "$dry_run" -eq 1 ] && echo "DRY: $settings absent -> no-op"
+    return 0
+  fi
+  local base
+  base=$(cat "$settings")
+  if [ -z "$(printf '%s' "$base" | tr -d '[:space:]')" ]; then
+    [ "$dry_run" -eq 1 ] && echo "DRY: $settings empty -> no-op"
+    return 0
+  fi
+  if ! printf '%s' "$base" | jq -e . >/dev/null 2>&1; then
+    echo "unwire-pretooluse-hooks: $settings is not valid JSON -- refusing to modify" >&2
+    return 1
+  fi
+  if [ "$dry_run" -eq 1 ]; then
+    echo "DRY: remove UNIVERSAL himmel hooks (PreToolUse trio + SessionStart inject-initiative) from $settings"
+    return 0
+  fi
+  printf '%s' "$base" | jq --arg pre "$_UNWIRE_PRE_PAT" --arg ss "$_UNWIRE_SS_PAT" '
+    if (.hooks // {} | has("PreToolUse")) then
+      .hooks.PreToolUse = ((.hooks.PreToolUse)
+        | map(.hooks = ((.hooks // []) | map(select((.command // "") | test($pre) | not))))
+        | map(select((.hooks | length) > 0)))
+    else . end
+    | if (.hooks // {} | has("SessionStart")) then
+        .hooks.SessionStart = ((.hooks.SessionStart)
+          | map(.hooks = ((.hooks // []) | map(select((.command // "") | test($ss) | not))))
+          | map(select((.hooks | length) > 0)))
+      else . end
+  ' > "$settings.unwirehooks.tmp" && mv "$settings.unwirehooks.tmp" "$settings"
+  echo "  removed UNIVERSAL himmel hooks -> $settings"
+}
+
+# Allow both `source` and direct invocation (incl. --scope project --target).
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  _settings=""; _scope=""; _target=""; _dry=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --scope)   _scope="$2"; shift 2 ;;
+      --target)  _target="$2"; shift 2 ;;
+      --dry-run) _dry=1; shift ;;
+      -h|--help) echo "usage: unwire-pretooluse-hooks.sh <settings> [<dry_run>] | --scope project --target <repo> [--dry-run]" >&2; exit 0 ;;
+      *)         if [ -z "$_settings" ]; then _settings="$1"; else _dry="$1"; fi; shift ;;
+    esac
+  done
+  if [ "$_scope" = "project" ]; then
+    [ -n "$_target" ] || { echo "unwire-pretooluse-hooks: --scope project requires --target <repo>" >&2; exit 2; }
+    _settings="$_target/.claude/settings.json"
+  fi
+  [ -n "$_settings" ] || { echo "usage: unwire-pretooluse-hooks.sh <settings> [<dry_run>] | --scope project --target <repo> [--dry-run]" >&2; exit 2; }
+  unwire_pretooluse_hooks "$_settings" "$_dry"
+fi

--- a/scripts/lib/unwire-statusline.ps1
+++ b/scripts/lib/unwire-statusline.ps1
@@ -1,0 +1,32 @@
+# unwire-statusline.ps1 -- PowerShell counterpart of unwire-statusline.sh.
+# Removes .statusLine from a Claude Code settings.json ONLY when it points at the
+# himmel statusline binary (a user's own statusLine is left untouched). Shells out
+# to jq for byte-parity with the bash twin.
+#
+#   Remove-Statusline -SettingsPath <path>
+# Direct:  pwsh -File unwire-statusline.ps1 -SettingsPath <path>
+
+[CmdletBinding()]
+param([string]$SettingsPath)
+
+function Remove-Statusline {
+    param([Parameter(Mandatory = $true)][string]$SettingsPath)
+    if (-not (Get-Command jq -ErrorAction SilentlyContinue)) { throw "unwire-statusline: jq required" }
+    if (-not (Test-Path $SettingsPath)) { return }
+    $raw = Get-Content $SettingsPath -Raw
+    if ([string]::IsNullOrWhiteSpace($raw)) { return }
+    $raw | jq -e . > $null 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "unwire-statusline: $SettingsPath is not valid JSON -- refusing to modify" }
+    $filter = 'if ((.statusLine.command? // "") | test("scripts/statusline/bin/statusline[.]sh")) then del(.statusLine) else . end'
+    $out = $raw | jq --indent 2 $filter
+    if ($LASTEXITCODE -ne 0) { throw "unwire-statusline: jq transform failed" }
+    $tmp = "$SettingsPath.unwiresl.tmp"
+    # UTF-8 without BOM (HIMMEL-365/408): Set-Content -Encoding utf8 BOMs on PS 5.1.
+    [System.IO.File]::WriteAllText($tmp, ($out -join "`n") + "`n")
+    Move-Item -Path $tmp -Destination $SettingsPath -Force
+    Write-Host "  removed himmel statusLine (if present) -> $SettingsPath"
+}
+
+if ($SettingsPath) {
+    try { Remove-Statusline -SettingsPath $SettingsPath } catch { Write-Error $_; exit 1 }
+}

--- a/scripts/lib/unwire-statusline.sh
+++ b/scripts/lib/unwire-statusline.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# unwire-statusline.sh -- remove the himmel statusLine from a Claude Code
+# settings.json (the inverse of wire-statusline.sh; HIMMEL install/uninstall
+# symmetry). Removes .statusLine ONLY when it points at the himmel statusline
+# binary -- a user's own custom statusLine is left untouched.
+#
+# Usage:
+#   bash unwire-statusline.sh <settings-json-path>
+#
+# Idempotent (absent key / absent file -> no-op), atomic (temp file + mv),
+# refuses invalid JSON, preserves all sibling keys. Requires jq. Source it to
+# call unwire_statusline directly, or invoke via bash.
+set -euo pipefail
+
+unwire_statusline() {
+  local settings="$1"
+  command -v jq >/dev/null 2>&1 || { echo "unwire-statusline: jq required" >&2; return 1; }
+  [ -f "$settings" ] || return 0
+  local base
+  base=$(cat "$settings")
+  [ -z "$(printf '%s' "$base" | tr -d '[:space:]')" ] && return 0
+  if ! printf '%s' "$base" | jq -e . >/dev/null 2>&1; then
+    echo "unwire-statusline: $settings is not valid JSON -- refusing to modify" >&2
+    return 1
+  fi
+  printf '%s' "$base" | jq '
+    if ((.statusLine.command? // "") | test("scripts/statusline/bin/statusline[.]sh"))
+    then del(.statusLine) else . end
+  ' > "$settings.unwiresl.tmp" && mv "$settings.unwiresl.tmp" "$settings"
+  echo "  removed himmel statusLine (if present) -> $settings"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  [ "$#" -eq 1 ] || { echo "usage: unwire-statusline.sh <settings-json-path>" >&2; exit 2; }
+  unwire_statusline "$1"
+fi

--- a/scripts/lib/wire-pretooluse-hooks.ps1
+++ b/scripts/lib/wire-pretooluse-hooks.ps1
@@ -1,0 +1,123 @@
+# wire-pretooluse-hooks.ps1 -- PowerShell counterpart of wire-pretooluse-hooks.sh.
+# Merges himmel's UNIVERSAL hooks into a Claude Code settings.json idempotently.
+# Shells out to jq for the JSON transform so output is byte-identical to the bash
+# twin (jq is a required tool; the bash lib + wire-himmel-repo.ps1 already rely on
+# it). Two functions:
+#   Set-PretooluseHooks  -SettingsPath <path> -Prefix <prefix> [-DryRun]
+#   Set-SessionStartHook -SettingsPath <path> -Prefix <prefix> -HookBasename <name> [-DryRun]
+#
+# Dedup is by hook BASENAME with REPLACE semantics (a re-run repairs a bad/moved
+# install, never double-wires). Forward-slashes + quotes the hook path so a
+# Windows backslash path does not collapse when the hook command is parsed.
+#
+# Dot-source to get the functions, or invoke directly:
+#   pwsh -File wire-pretooluse-hooks.ps1 -SettingsPath <path> -Prefix <prefix> [-DryRun]
+
+[CmdletBinding()]
+param(
+    [string]$SettingsPath,
+    [string]$Prefix,
+    [switch]$DryRun
+)
+
+function Read-SettingsBase {
+    param([Parameter(Mandatory = $true)][string]$SettingsPath, [string]$Who)
+    if (Test-Path $SettingsPath) {
+        $raw = Get-Content $SettingsPath -Raw
+        if ([string]::IsNullOrWhiteSpace($raw)) { return '{}' }
+        $raw | jq -e . > $null 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "$Who`: $SettingsPath is not valid JSON -- refusing to overwrite"
+        }
+        return $raw
+    }
+    $dir = Split-Path $SettingsPath
+    if ($dir) { New-Item -ItemType Directory -Force $dir | Out-Null }
+    return '{}'
+}
+
+function Write-SettingsAtomic {
+    param([Parameter(Mandatory = $true)][string]$SettingsPath, [Parameter(Mandatory = $true)][string]$Json)
+    $tmp = "$SettingsPath.wirehooks.tmp"
+    # UTF-8 *without* BOM, version-independent: `Set-Content -Encoding utf8` emits
+    # a BOM under Windows PowerShell 5.1, which has broken settings.json consumers
+    # before (HIMMEL-365/408). WriteAllText(string,string) is BOM-less on all hosts.
+    [System.IO.File]::WriteAllText($tmp, $Json + "`n")
+    Move-Item -Path $tmp -Destination $SettingsPath -Force
+}
+
+function Set-PretooluseHooks {
+    param(
+        [Parameter(Mandatory = $true)] [string]$SettingsPath,
+        [Parameter(Mandatory = $true)] [string]$Prefix,
+        [switch]$DryRun
+    )
+    if (-not (Get-Command jq -ErrorAction SilentlyContinue)) { throw "wire-pretooluse-hooks: jq required" }
+    $pfx = $Prefix.Replace('\', '/')
+    $desired = @"
+[
+  {"matcher":"Bash","hooks":[{"type":"command","command":"bash \"$pfx/scripts/hooks/auto-approve-safe-bash.sh\""}]},
+  {"matcher":"Edit|Write|MultiEdit|NotebookEdit","hooks":[{"type":"command","command":"bash \"$pfx/scripts/hooks/block-edit-on-main.sh\""}]},
+  {"matcher":"Bash|PowerShell|Read|Grep","hooks":[{"type":"command","command":"bash \"$pfx/scripts/hooks/block-read-secrets.sh\""}]}
+]
+"@
+    if ($DryRun) { Write-Host "DRY: merge 3 PreToolUse hook stanzas into $SettingsPath (prefix: $Prefix)"; return }
+    $base = Read-SettingsBase -SettingsPath $SettingsPath -Who 'wire-pretooluse-hooks'
+    $filter = @'
+.hooks = (.hooks // {})
+| .hooks.PreToolUse = (
+    ((.hooks.PreToolUse // [])
+      | map(.hooks = ((.hooks // [])
+          | map(select((.command // "")
+                | test("scripts/hooks/(auto-approve-safe-bash|block-edit-on-main|block-read-secrets)[.]sh") | not))))
+      | map(select((.hooks | length) > 0)))
+    + $add
+  )
+'@
+    $out = $base | jq --indent 2 --argjson add $desired $filter
+    if ($LASTEXITCODE -ne 0) { throw "wire-pretooluse-hooks: jq transform failed" }
+    Write-SettingsAtomic -SettingsPath $SettingsPath -Json ($out -join "`n")
+    Write-Host "  wired PreToolUse hooks -> $SettingsPath"
+}
+
+function Set-SessionStartHook {
+    param(
+        [Parameter(Mandatory = $true)] [string]$SettingsPath,
+        [Parameter(Mandatory = $true)] [string]$Prefix,
+        [Parameter(Mandatory = $true)] [string]$HookBasename,
+        [switch]$DryRun
+    )
+    if (-not (Get-Command jq -ErrorAction SilentlyContinue)) { throw "wire-pretooluse-hooks: jq required" }
+    $pfx = $Prefix.Replace('\', '/')
+    $cmd = "bash `"$pfx/scripts/hooks/$HookBasename`""
+    $basepat = "scripts/hooks/" + ($HookBasename -replace '\.', '[.]')
+    if ($DryRun) { Write-Host "DRY: merge SessionStart hook $HookBasename into $SettingsPath (prefix: $Prefix)"; return }
+    $base = Read-SettingsBase -SettingsPath $SettingsPath -Who 'wire-pretooluse-hooks'
+    $filter = @'
+.hooks = (.hooks // {})
+| .hooks.SessionStart = ((.hooks.SessionStart // [])
+    | map(.hooks = ((.hooks // [])
+        | map(select((.command // "") | test($basepat) | not))))
+    | map(select((.hooks | length) > 0)))
+| (.hooks.SessionStart | map(has("matcher") | not) | index(true)) as $idx
+| if $idx == null
+  then .hooks.SessionStart += [{"hooks":[{"type":"command","command":$cmd}]}]
+  else .hooks.SessionStart[$idx].hooks += [{"type":"command","command":$cmd}]
+  end
+'@
+    $out = $base | jq --indent 2 --arg cmd $cmd --arg basepat $basepat $filter
+    if ($LASTEXITCODE -ne 0) { throw "wire-pretooluse-hooks: jq transform failed" }
+    Write-SettingsAtomic -SettingsPath $SettingsPath -Json ($out -join "`n")
+    Write-Host "  wired SessionStart $HookBasename -> $SettingsPath"
+}
+
+# Direct invocation (SettingsPath + Prefix supplied) wires the PreToolUse trio.
+# Dot-sourcing with no args just defines the functions.
+if ($SettingsPath -and $Prefix) {
+    try {
+        Set-PretooluseHooks -SettingsPath $SettingsPath -Prefix $Prefix -DryRun:$DryRun
+    } catch {
+        Write-Error $_
+        exit 1
+    }
+}

--- a/scripts/lib/wire-pretooluse-hooks.sh
+++ b/scripts/lib/wire-pretooluse-hooks.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# wire-pretooluse-hooks.sh -- merge himmel's UNIVERSAL hooks into a Claude Code
+# settings.json idempotently (HIMMEL install/uninstall symmetry). Extracted from
+# adopt.sh's wire_settings so setup.sh and adopt.sh share ONE implementation.
+#
+# Two functions:
+#   wire_pretooluse_hooks <settings> <prefix> [<dry_run>]
+#       Wire the PreToolUse trio (auto-approve-safe-bash, block-edit-on-main,
+#       block-read-secrets), each as its own matcher stanza.
+#   wire_sessionstart_hook <settings> <prefix> <hook-basename> [<dry_run>]
+#       Wire ONE SessionStart hook object (e.g. inject-initiative.sh) into the
+#       shared SessionStart hooks[] array.
+#
+# $prefix = command path prefix (literal, e.g. '$CLAUDE_PROJECT_DIR' for project
+# scope or the himmel abs path for user scope). The hook path is FORWARD-SLASHED
+# and QUOTED in the command: an unquoted Windows backslash path
+# (`bash C:\Users\...\X.sh`) collapses when the hook command is parsed by a shell
+# (`\U`->`U`), so the hook silently never fires.
+#
+# Dedup is by hook BASENAME with REPLACE semantics: re-running overwrites a
+# previously-wired (incl. broken backslash, or moved-clone) himmel hook rather
+# than appending a duplicate -- so a re-run repairs a bad install and never
+# double-wires, even when the clone path changed (SC8).
+#
+# Reads NO script globals (the dry-run flag is an explicit param). Requires jq.
+# Source it to call the functions directly, or invoke via bash (the BASH_SOURCE
+# guard below dispatches `wire-pretooluse-hooks.sh <settings> <prefix>`).
+set -euo pipefail
+
+wire_pretooluse_hooks() {
+  local settings="$1" prefix="$2" dry_run="${3:-0}"
+  command -v jq >/dev/null 2>&1 || { echo "wire-pretooluse-hooks: jq required" >&2; return 1; }
+  # shellcheck disable=SC1003  # '\' is a literal backslash to replace, not a quote escape
+  local pfx="${prefix//'\'//}"   # forward-slash any backslashes in the prefix
+  local desired
+  desired=$(cat <<JSON
+[
+  {"matcher":"Bash","hooks":[{"type":"command","command":"bash \"${pfx}/scripts/hooks/auto-approve-safe-bash.sh\""}]},
+  {"matcher":"Edit|Write|MultiEdit|NotebookEdit","hooks":[{"type":"command","command":"bash \"${pfx}/scripts/hooks/block-edit-on-main.sh\""}]},
+  {"matcher":"Bash|PowerShell|Read|Grep","hooks":[{"type":"command","command":"bash \"${pfx}/scripts/hooks/block-read-secrets.sh\""}]}
+]
+JSON
+)
+  if [[ "$dry_run" -eq 1 ]]; then
+    echo "DRY: merge 3 PreToolUse hook stanzas into $settings (prefix: $prefix)"
+    return
+  fi
+  mkdir -p "$(dirname "$settings")"
+  local base="{}"
+  [[ -f "$settings" ]] && base=$(cat "$settings")
+  if [ -n "$(printf '%s' "$base" | tr -d '[:space:]')" ] && ! printf '%s' "$base" | jq -e . >/dev/null 2>&1; then
+    echo "wire-pretooluse-hooks: $settings is not valid JSON -- refusing to overwrite" >&2
+    return 1
+  fi
+  [ -z "$(printf '%s' "$base" | tr -d '[:space:]')" ] && base="{}"
+  # Drop only the himmel hook OBJECTS (not whole stanzas) from each existing
+  # PreToolUse entry, then drop any stanza left empty, then append the fresh
+  # stanzas. Hook-object granularity preserves a non-himmel hook (rtk-hook-guard,
+  # the operator's own) even when it is co-located in the SAME hooks[] array as a
+  # himmel hook -- a stanza-level filter would take it down with the himmel one.
+  printf '%s' "$base" | jq --argjson add "$desired" '
+    .hooks = (.hooks // {})
+    | .hooks.PreToolUse = (
+        ((.hooks.PreToolUse // [])
+          | map(.hooks = ((.hooks // [])
+              | map(select((.command // "")
+                    | test("scripts/hooks/(auto-approve-safe-bash|block-edit-on-main|block-read-secrets)[.]sh") | not))))
+          | map(select((.hooks | length) > 0)))
+        + $add
+      )
+  ' > "$settings.wirehooks.tmp" && mv "$settings.wirehooks.tmp" "$settings"
+  echo "  wired PreToolUse hooks -> $settings"
+}
+
+# Wire ONE SessionStart hook object (by basename) into the shared
+# .hooks.SessionStart[].hooks[] array. SessionStart hooks co-reside under a single
+# matcher-less stanza (in himmel's project settings inject-initiative.sh sits
+# beside check-update-available.sh), so we operate at the hook-OBJECT level:
+# strip any existing object whose command basename matches (REPLACE), then append
+# a fresh one into the first matcher-less stanza, or create a standalone stanza if
+# none exists. Dedup-by-basename keeps a moved clone from double-wiring (SC8).
+wire_sessionstart_hook() {
+  local settings="$1" prefix="$2" basename="$3" dry_run="${4:-0}"
+  command -v jq >/dev/null 2>&1 || { echo "wire-pretooluse-hooks: jq required" >&2; return 1; }
+  # shellcheck disable=SC1003
+  local pfx="${prefix//'\'//}"
+  local cmd="bash \"${pfx}/scripts/hooks/${basename}\""
+  local basepat="scripts/hooks/${basename//./[.]}"
+  if [[ "$dry_run" -eq 1 ]]; then
+    echo "DRY: merge SessionStart hook $basename into $settings (prefix: $prefix)"
+    return
+  fi
+  mkdir -p "$(dirname "$settings")"
+  local base="{}"
+  [[ -f "$settings" ]] && base=$(cat "$settings")
+  if [ -n "$(printf '%s' "$base" | tr -d '[:space:]')" ] && ! printf '%s' "$base" | jq -e . >/dev/null 2>&1; then
+    echo "wire-pretooluse-hooks: $settings is not valid JSON -- refusing to overwrite" >&2
+    return 1
+  fi
+  [ -z "$(printf '%s' "$base" | tr -d '[:space:]')" ] && base="{}"
+  printf '%s' "$base" | jq --arg cmd "$cmd" --arg basepat "$basepat" '
+    .hooks = (.hooks // {})
+    | .hooks.SessionStart = ((.hooks.SessionStart // [])
+        | map(.hooks = ((.hooks // [])
+            | map(select((.command // "") | test($basepat) | not))))
+        | map(select((.hooks | length) > 0)))
+    | (.hooks.SessionStart | map(has("matcher") | not) | index(true)) as $idx
+    | if $idx == null
+      then .hooks.SessionStart += [{"hooks":[{"type":"command","command":$cmd}]}]
+      else .hooks.SessionStart[$idx].hooks += [{"type":"command","command":$cmd}]
+      end
+  ' > "$settings.wirehooks.tmp" && mv "$settings.wirehooks.tmp" "$settings"
+  echo "  wired SessionStart $basename -> $settings"
+}
+
+# Allow both `source wire-pretooluse-hooks.sh` (to call the functions directly,
+# e.g. from adopt.sh which is already `set -euo pipefail`) and direct invocation.
+# Callers that DON'T want this lib's `set -euo pipefail` to leak into their shell
+# (e.g. setup.sh, which runs `set -e` only) invoke it as a subprocess:
+#   bash wire-pretooluse-hooks.sh <settings> <prefix> [<dry>]            # PreToolUse trio
+#   bash wire-pretooluse-hooks.sh --sessionstart <settings> <prefix> <basename> [<dry>]
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  if [ "${1:-}" = "--sessionstart" ]; then
+    shift
+    if [ "$#" -lt 3 ]; then
+      echo "usage: wire-pretooluse-hooks.sh --sessionstart <settings> <prefix> <hook-basename> [<dry_run>]" >&2
+      exit 2
+    fi
+    wire_sessionstart_hook "$1" "$2" "$3" "${4:-0}"
+  else
+    if [ "$#" -lt 2 ]; then
+      echo "usage: wire-pretooluse-hooks.sh <settings-json-path> <command-prefix> [<dry_run>]" >&2
+      exit 2
+    fi
+    wire_pretooluse_hooks "$1" "$2" "${3:-0}"
+  fi
+fi

--- a/scripts/machine-setup/test-bootstrap.sh
+++ b/scripts/machine-setup/test-bootstrap.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# test-bootstrap.sh -- install the MINIMAL deps to RUN himmel's bash test suites
+# on a fresh Debian/Ubuntu box: a throwaway test VM or a CI runner (HIMMEL-469).
+#
+# This is the TEST-HARNESS dependency set, deliberately SEPARATE from
+# scripts/setup.sh's user-facing RUNTIME set ([0/10]: bash git node npm bun
+# python3 jq gh mktemp + claude). Running the committed hermetic suites needs only:
+#   bash  (always present)   git  (test-load-dotenv, test-inject-initiative)   jq
+# node/npm/bun/python3/gh are NOT needed to run the suites -- they're runtime deps
+# a real himmel USER installs, not test-harness deps.
+#
+# Idempotent: already-present tools are skipped. On a GitHub Actions ubuntu runner
+# git+jq are preinstalled, so this is a no-op there. Uses `sudo apt-get` unless
+# already root or --no-sudo is passed.
+#
+# Usage:
+#   bash scripts/machine-setup/test-bootstrap.sh            # install missing test deps
+#   bash scripts/machine-setup/test-bootstrap.sh --check    # report only, install nothing
+#   bash scripts/machine-setup/test-bootstrap.sh --no-sudo  # don't prefix apt-get with sudo
+set -euo pipefail
+
+# The test-harness dependency set (NOT the user runtime set).
+TEST_DEPS="git jq"
+
+CHECK=0
+NO_SUDO=0
+for arg in "$@"; do
+  case "$arg" in
+    --check)   CHECK=1 ;;
+    --no-sudo) NO_SUDO=1 ;;
+    -h|--help) sed -n '2,/^set -e/p' "$0" | sed 's/^# \{0,1\}//' | sed '$d'; exit 0 ;;
+    *) echo "test-bootstrap: unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+missing=""
+for t in $TEST_DEPS; do
+  command -v "$t" >/dev/null 2>&1 || missing="$missing $t"
+done
+missing="${missing# }"
+
+if [ -z "$missing" ]; then
+  echo "test-bootstrap: all test deps present ($TEST_DEPS)."
+  exit 0
+fi
+
+if [ "$CHECK" -eq 1 ]; then
+  echo "test-bootstrap: MISSING test deps: $missing"
+  exit 1
+fi
+
+# Resolve the install command. Only apt-get is supported (the test VMs + the CI
+# runner are Debian/Ubuntu); other platforms get a loud manual hint.
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "test-bootstrap: apt-get not found -- install manually: $missing" >&2
+  exit 1
+fi
+
+sudo_pfx="sudo"
+if [ "$NO_SUDO" -eq 1 ] || [ "$(id -u 2>/dev/null || echo 0)" = "0" ]; then
+  sudo_pfx=""
+fi
+
+echo "test-bootstrap: installing test deps:$missing"
+# shellcheck disable=SC2086  # $missing intentionally word-splits into package args
+$sudo_pfx apt-get update -qq
+# shellcheck disable=SC2086
+$sudo_pfx apt-get install -y $missing
+
+# Verify.
+still=""
+for t in $missing; do
+  command -v "$t" >/dev/null 2>&1 || still="$still $t"
+done
+if [ -n "$still" ]; then
+  echo "test-bootstrap: STILL missing after install:$still" >&2
+  exit 1
+fi
+echo "test-bootstrap: test deps ready ($TEST_DEPS)."

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -18,8 +18,9 @@ param(
     [switch]$FillEnv
 )
 
-$RepoRoot = git rev-parse --show-toplevel
-Set-Location $RepoRoot
+# $RepoRoot is resolved AFTER the [0/10] preflight (R6, HIMMEL-460): the preflight
+# may auto-install git, so `git rev-parse` must not run before it.
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 # Surface Ctrl-C / pipeline failures rather than letting the script
 # continue past a broken step. Mirrors `trap ... INT TERM` in setup.sh.
@@ -51,6 +52,39 @@ foreach ($tool in @('git', 'node', 'npm', 'bun', 'python', 'jq', 'gh', 'bash')) 
         $missing += $tool
     }
 }
+
+# R6 (HIMMEL-460): best-effort FETCH of the auto-installable missing tools
+# (git/jq/python) via winget -> scoop -> choco BEFORE failing. The rest keep the
+# flag-loud fallback below. Mirrors setup.sh's ensure-tools step.
+if ($missing.Count -gt 0) {
+    $wingetIds = @{ 'git' = 'Git.Git'; 'jq' = 'jqlang.jq'; 'python' = 'Python.Python.3.12' }
+    $installer = $null
+    if (Get-Command winget -ErrorAction SilentlyContinue) { $installer = 'winget' }
+    elseif (Get-Command scoop -ErrorAction SilentlyContinue) { $installer = 'scoop' }
+    elseif (Get-Command choco -ErrorAction SilentlyContinue) { $installer = 'choco' }
+    if ($installer) {
+        Write-Host "  Missing: $($missing -join ', ') — attempting auto-install via $installer..."
+        foreach ($tool in $missing) {
+            if (-not $wingetIds.ContainsKey($tool)) {
+                Write-Host "    no known $installer package for '$tool' — install it manually." -ForegroundColor Yellow
+                continue
+            }
+            try {
+                switch ($installer) {
+                    'winget' { winget install --id $wingetIds[$tool] --silent --accept-source-agreements --accept-package-agreements | Out-Null }
+                    'scoop'  { scoop install $tool | Out-Null }
+                    'choco'  { choco install $tool -y | Out-Null }
+                }
+            } catch {
+                Write-Host "    $installer install '$tool' failed — install it manually." -ForegroundColor Yellow
+            }
+        }
+        $missing = @($missing | Where-Object { -not (Get-Command $_ -ErrorAction SilentlyContinue) })
+    } else {
+        Write-Host "  No supported installer (winget/scoop/choco) found — cannot auto-install." -ForegroundColor Yellow
+    }
+}
+
 if ($missing.Count -gt 0) {
     Write-Error "missing required tools: $($missing -join ', ')"
     Write-Host "  Install hints (see docs/setup/new-machine.md for full per-platform table):" -ForegroundColor Yellow
@@ -61,6 +95,11 @@ if ($missing.Count -gt 0) {
 }
 Write-Host "  All foundational tools present."
 Write-Host ""
+
+# --- repo root (relocated past the preflight — R6, HIMMEL-460) ---
+# git is now guaranteed present; safe to resolve the checkout root.
+$RepoRoot = git rev-parse --show-toplevel
+Set-Location $RepoRoot
 
 # --- Claude Code CLI (the runtime himmel harnesses) — soft check ---
 # Soft, not hard-fail: setup configures the repo and never invokes claude, so a
@@ -332,7 +371,7 @@ Write-Host ""
 # --- statusline + HIMMEL_REPO (HIMMEL-359 / HIMMEL-453) ---
 # Wire the himmel statusline AND env.HIMMEL_REPO into ~/.claude/settings.json via
 # the shared helpers. Both write settings.json, need no claude binary, idempotent.
-Write-Host "[9/10] Wiring statusline + HIMMEL_REPO (user scope)..."
+Write-Host "[9/10] Wiring statusline + HIMMEL_REPO + UNIVERSAL hooks (user scope)..."
 $settingsJson = Join-Path $HOME ".claude\settings.json"
 $savedEAP = $ErrorActionPreference
 try {
@@ -347,6 +386,14 @@ try {
     if ($LASTEXITCODE -ne 0) {
         Write-Host "  WARNING: wire-himmel-repo failed; setup continues." -ForegroundColor Yellow
     }
+    # R3 (HIMMEL-460): wire the UNIVERSAL hooks (PreToolUse trio + SessionStart
+    # inject-initiative) at USER scope so a session launched anywhere gets them.
+    . (Join-Path $RepoRoot "scripts\lib\wire-pretooluse-hooks.ps1")
+    try { Set-PretooluseHooks -SettingsPath $settingsJson -Prefix $RepoRoot } catch { Write-Host "  WARNING: wire-pretooluse-hooks failed; setup continues." -ForegroundColor Yellow }
+    try { Set-SessionStartHook -SettingsPath $settingsJson -Prefix $RepoRoot -HookBasename 'inject-initiative.sh' } catch { Write-Host "  WARNING: wire SessionStart inject-initiative failed; setup continues." -ForegroundColor Yellow }
+    # R4 (HIMMEL-460): advise on user/project hook duplication (silent in-repo).
+    & pwsh -NoProfile -File (Join-Path $RepoRoot "scripts\lib\detect-hook-dup.ps1") `
+        -UserSettings $settingsJson -ProjectSettings (Join-Path $RepoRoot ".claude\settings.json") -HimmelRoot $RepoRoot
 } finally {
     $ErrorActionPreference = $savedEAP
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,12 +9,11 @@ set -e
 # WARNING then continue to the success footer, fooling the operator.
 trap 'echo "setup interrupted by signal" >&2; exit 130' INT TERM
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-cd "$REPO_ROOT"
-
-# shellcheck source=lib/qmd-bin.sh
-# shellcheck disable=SC1091
-. "$REPO_ROOT/scripts/lib/qmd-bin.sh"
+# REPO_ROOT is resolved AFTER the [0/10] preflight (R6, HIMMEL-460): the
+# preflight may auto-install git, so `git rev-parse --show-toplevel` must not run
+# before it. Until then, resolve THIS script's own dir (no git needed) so the
+# preflight can source its sibling helper.
+SETUP_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 # --- arg parse (HIMMEL-151) ---
 # Optional flags only. Unknown args land in setup_extra_args for now —
@@ -74,6 +73,24 @@ for _tool in bash git node npm bun python3 jq gh mktemp; do
   fi
 done
 
+# R6 (HIMMEL-460): best-effort FETCH of the auto-installable missing tools
+# (git/jq/python3) via the platform package manager BEFORE failing — the operator
+# asked "setup should fetch it". The rest keep the flag-loud fallback below. This
+# runs before the relocated `git rev-parse`, so a fresh box missing git is
+# repaired here instead of dying on a cryptic git error.
+if [ "${#_missing[@]}" -gt 0 ]; then
+  echo "  Missing: ${_missing[*]} — attempting auto-install of the installable ones..."
+  # Subprocess (not sourced): ensure-tools.sh runs `set -uo pipefail`, which would
+  # otherwise leak into this `set -e`-only script. It installs system-wide; we
+  # re-check `command -v` below to see what truly remains.
+  bash "$SETUP_DIR/setup/ensure-tools.sh" "${_missing[@]}" || true
+  _still=()
+  for _tool in "${_missing[@]}"; do
+    command -v "$_tool" >/dev/null 2>&1 || _still+=("$_tool")
+  done
+  _missing=("${_still[@]}")
+fi
+
 # Bash version: 8 scripts use mapfile (bash 4+). Warn on bash 3.x rather
 # than fail-hard — those scripts will error at invocation time with a
 # clear "mapfile: command not found", and the foundational ones (e.g.
@@ -105,6 +122,16 @@ if [ "${#_missing[@]}" -gt 0 ]; then
 fi
 echo "  All foundational tools present."
 echo ""
+
+# --- repo root (relocated past the preflight — R6, HIMMEL-460) ---
+# git is now guaranteed present (preflight verified / auto-installed it), so it is
+# safe to resolve the checkout root. A non-zero here means setup.sh was run from
+# outside a git checkout — fail loud rather than letting downstream paths break.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+# shellcheck source=lib/qmd-bin.sh
+# shellcheck disable=SC1091
+. "$REPO_ROOT/scripts/lib/qmd-bin.sh"
 
 # --- Claude Code CLI (the runtime himmel harnesses) — soft check ---
 # Not a hard requirement of setup itself (the steps below configure the repo and
@@ -333,12 +360,29 @@ echo ""
 # the shared helpers. Both write settings.json, need no claude binary, idempotent.
 # HIMMEL_REPO default-by-install: the installer knows the clone path, so the leg
 # resolver + minerva anchor get it without a manual export.
-echo "[9/10] Wiring statusline + HIMMEL_REPO (user scope)..."
-if ! bash "$REPO_ROOT/scripts/lib/wire-statusline.sh" "$HOME/.claude/settings.json" "$REPO_ROOT"; then
+echo "[9/10] Wiring statusline + HIMMEL_REPO + UNIVERSAL hooks (user scope)..."
+_user_settings="$HOME/.claude/settings.json"
+if ! bash "$REPO_ROOT/scripts/lib/wire-statusline.sh" "$_user_settings" "$REPO_ROOT"; then
   echo "  WARNING: wire-statusline failed; setup continues." >&2
 fi
-if ! bash "$REPO_ROOT/scripts/lib/wire-himmel-repo.sh" "$HOME/.claude/settings.json" "$REPO_ROOT"; then
+if ! bash "$REPO_ROOT/scripts/lib/wire-himmel-repo.sh" "$_user_settings" "$REPO_ROOT"; then
   echo "  WARNING: wire-himmel-repo failed; setup continues." >&2
+fi
+# R3 (HIMMEL-460): wire the UNIVERSAL hooks at USER scope so a session launched
+# ANYWHERE (not just inside this repo) gets the portable safety + auto-approve
+# trio AND the SessionStart leg-injector. Referenced by THIS clone's abs path;
+# basename-dedup keeps a re-run from double-wiring. The HIMMEL-DEV-ONLY hooks
+# (check-cr-marker, backend-tier, auto-arm, check-update-available) stay project
+# scope — they only make sense inside the himmel repo. Invoked as a SUBPROCESS
+# (not sourced) so the lib's `set -euo pipefail` does not leak into this script's
+# `set -e`-only shell.
+bash "$REPO_ROOT/scripts/lib/wire-pretooluse-hooks.sh" "$_user_settings" "$REPO_ROOT" \
+  || echo "  WARNING: wire-pretooluse-hooks failed; setup continues." >&2
+bash "$REPO_ROOT/scripts/lib/wire-pretooluse-hooks.sh" --sessionstart "$_user_settings" "$REPO_ROOT" "inject-initiative.sh" \
+  || echo "  WARNING: wire SessionStart inject-initiative failed; setup continues." >&2
+# R4 (HIMMEL-460): advise on user/project hook duplication (silent in-repo).
+if ! bash "$REPO_ROOT/scripts/lib/detect-hook-dup.sh" "$_user_settings" "$REPO_ROOT/.claude/settings.json" "$REPO_ROOT"; then
+  : # detect-hook-dup is advisory-only; never fail setup on it.
 fi
 echo ""
 

--- a/scripts/setup/ensure-tools.sh
+++ b/scripts/setup/ensure-tools.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# ensure-tools.sh -- best-effort install of missing REQUIRED tools via the
+# platform package manager (R6, HIMMEL-460). setup.sh's [0/10] preflight calls
+# this so a missing git (etc.) is FETCHED, not just flagged. The fallback is
+# always honest: on an unknown platform, no package manager, no root/sudo, or a
+# failed install, the tool simply stays missing and the CALLER fails loud with
+# the manual hint -- ensure_tools never claims success it didn't achieve.
+#
+# Only tools with a known package name are attempted (git, jq, python3). Tools
+# that need a bespoke installer (node, bun, gh) are left to the caller's hint.
+#
+# Usage:  source ensure-tools.sh; ensure_tools git jq ...   (re-check after).
+#         bash ensure-tools.sh git jq ...                   (direct).
+set -uo pipefail
+
+# tool -> package name. Identity for the ones we handle; an empty result means
+# "not auto-installable here" (caller keeps its manual hint).
+_ensure_pkg_for() {
+  case "$1" in
+    git)     echo git ;;
+    jq)      echo jq ;;
+    python3) echo python3 ;;
+    *)       echo "" ;;
+  esac
+}
+
+# Echo the first supported package manager on PATH, or "" (rc 1) if none.
+_ensure_detect_pm() {
+  if command -v apt-get >/dev/null 2>&1; then echo apt-get; return 0; fi
+  if command -v dnf     >/dev/null 2>&1; then echo dnf;     return 0; fi
+  if command -v brew    >/dev/null 2>&1; then echo brew;    return 0; fi
+  echo ""; return 1
+}
+
+# Echo the sudo prefix needed for apt/dnf: "" when root, "sudo" when a sudo
+# binary exists, "__NOSUDO__" (rc 1) when neither (caller skips that tool).
+_ensure_sudo_prefix() {
+  if [ "$(id -u 2>/dev/null || echo 0)" = "0" ]; then echo ""; return 0; fi
+  if command -v sudo >/dev/null 2>&1; then echo "sudo"; return 0; fi
+  echo "__NOSUDO__"; return 1
+}
+
+# ensure_tools <tool>... -- attempt to install the auto-installable missing ones.
+# Always returns 0; the caller re-checks `command -v` to see what truly remains.
+ensure_tools() {
+  [ "$#" -gt 0 ] || return 0
+  local pm t pkg sudo_pfx
+  if ! pm=$(_ensure_detect_pm); then
+    echo "  ensure-tools: no supported package manager (apt-get/dnf/brew) found -- cannot auto-install; install manually." >&2
+    return 0
+  fi
+  for t in "$@"; do
+    command -v "$t" >/dev/null 2>&1 && continue
+    pkg=$(_ensure_pkg_for "$t")
+    if [ -z "$pkg" ]; then
+      echo "  ensure-tools: no known $pm package for '$t' -- install it manually." >&2
+      continue
+    fi
+    if [ "$pm" = brew ]; then
+      echo "  ensure-tools: installing '$t' via brew..."
+      brew install "$pkg" >/dev/null 2>&1 || echo "  ensure-tools: 'brew install $pkg' failed -- install '$t' manually." >&2
+      continue
+    fi
+    # apt-get / dnf need root.
+    if ! sudo_pfx=$(_ensure_sudo_prefix); then
+      echo "  ensure-tools: '$t' needs $pm but no root/sudo available -- install it manually." >&2
+      continue
+    fi
+    echo "  ensure-tools: installing '$t' via $pm..."
+    if [ "$pm" = apt-get ]; then
+      $sudo_pfx apt-get update >/dev/null 2>&1 || true
+      $sudo_pfx apt-get install -y "$pkg" >/dev/null 2>&1 \
+        || echo "  ensure-tools: 'apt-get install $pkg' failed -- install '$t' manually." >&2
+    else
+      $sudo_pfx dnf install -y "$pkg" >/dev/null 2>&1 \
+        || echo "  ensure-tools: 'dnf install $pkg' failed -- install '$t' manually." >&2
+    fi
+  done
+  return 0
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  ensure_tools "$@"
+fi

--- a/scripts/setup/test-setup-preflight.sh
+++ b/scripts/setup/test-setup-preflight.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+# test-setup-preflight.sh -- hermetic tests for the R6 preflight (HIMMEL-460):
+# ensure-tools.sh auto-install branches (SC7) + the setup.sh ordering invariant
+# (git rev-parse for REPO_ROOT must run AFTER the [0/10] preflight, since the
+# preflight may auto-install git).
+set -u
+here="$(cd "$(dirname "$0")" && pwd)"
+ensure="$here/ensure-tools.sh"
+setup_sh="$(cd "$here/.." && pwd)/setup.sh"
+fails=0
+check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+has(){ printf '%s' "$2" | grep -q "$1" && echo yes || echo no; }
+
+# shellcheck source=ensure-tools.sh
+# shellcheck disable=SC1091
+. "$ensure"
+
+td="$(mktemp -d)"
+
+# ── SC7 branch 1: unknown platform (no apt/dnf/brew on PATH) → fail-loud, no-op.
+out=$( PATH="$td/empty-nonexistent" ensure_tools git 2>&1 )
+check "SC7 unknown-platform message" "$(has 'no supported package manager' "$out")" "yes"
+
+# ── SC7 branch 2: install SUCCEEDS — a stub apt-get that "installs" git.
+stub="$td/ok-bin"; mkdir -p "$stub"
+cat > "$stub/apt-get" <<EOF
+#!/usr/bin/env bash
+# fake apt-get: 'install -y <pkg>' drops a stub <pkg> into this bin dir.
+if [ "\$1" = install ]; then
+  shift; while [ "\$1" = "-y" ]; do shift; done
+  for pkg in "\$@"; do printf '#!/usr/bin/env bash\necho stub-\$pkg\n' > "$stub/\$pkg"; chmod +x "$stub/\$pkg"; done
+fi
+exit 0
+EOF
+printf '#!/usr/bin/env bash\nexec "$@"\n' > "$stub/sudo"   # pass-through sudo
+chmod +x "$stub/apt-get" "$stub/sudo"
+out=$( PATH="$stub:$PATH" ensure_tools git 2>&1 )
+present=$( PATH="$stub:$PATH" command -v git >/dev/null 2>&1 && echo yes || echo no )
+check "SC7 install-succeeds installs git" "$present" "yes"
+
+# ── SC7 branch 3a: install FAILS (apt-get returns non-zero) → fail-loud, no-op.
+# Minimal PATH (only the fail-stub) so a known-package tool (git) is genuinely
+# absent and the install path is actually exercised. `id` is absent here too, so
+# the helper treats the run as root (sudo not needed) — fine for this branch.
+fbin="$td/fail-bin"; mkdir -p "$fbin"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$fbin/apt-get"
+chmod +x "$fbin/apt-get"
+out=$( PATH="$fbin" ensure_tools git 2>&1 )
+check "SC7 install-fails message" "$(has "'apt-get install git' failed" "$out")" "yes"
+
+# ── SC7 branch 3b: no root/sudo (apt-get present, sudo absent, non-root).
+# Runs on Linux AND Windows (HIMMEL-469). Key insight: in the no-sudo path
+# ensure_tools only `command -v`s apt-get (never executes it) and only EXECUTES
+# `id` — so a self-contained PATH needs just a stub apt-get (existence only) + a
+# real `id` copy, with NO sudo. That makes `command -v sudo` fail even on a Linux
+# host where /usr/bin/sudo exists, exercising the branch cross-platform. (An
+# earlier version put /usr/bin:/bin on PATH, which on Linux ships a real sudo, so
+# the branch silently never fired — caught on the Ubuntu VM.)
+nbin="$td/nosudo-bin"; mkdir -p "$nbin"
+: > "$nbin/apt-get"; chmod +x "$nbin/apt-get"   # present for `command -v`; never executed here
+# Fake `id` with an ABSOLUTE /bin/sh shebang: /bin/sh exists at a fixed path on
+# both Linux and Git Bash, so it runs even with PATH restricted to $nbin (unlike
+# `#!/usr/bin/env bash`, which needs bash ON PATH, or a copied id.exe, which needs
+# msys DLLs on Windows). Reports non-root so the sudo check is reached.
+printf '#!/bin/sh\necho 1000\n' > "$nbin/id"; chmod +x "$nbin/id"
+out=$( PATH="$nbin" ensure_tools git 2>&1 )
+check "SC7 no-sudo message" "$(has 'no root/sudo' "$out")" "yes"
+
+# ── SC7 ordering invariant: REPO_ROOT git rev-parse runs AFTER the preflight.
+# Line number of the [0/10] preflight banner vs the REPO_ROOT assignment.
+pf_line=$(grep -n '\[0/10\] Verifying foundational tools' "$setup_sh" | head -1 | cut -d: -f1)
+# shellcheck disable=SC2016  # literal grep pattern -- no shell expansion wanted
+rr_line=$(grep -n 'REPO_ROOT="\$(git rev-parse --show-toplevel)"' "$setup_sh" | head -1 | cut -d: -f1)
+if [ -n "$pf_line" ] && [ -n "$rr_line" ] && [ "$rr_line" -gt "$pf_line" ]; then
+  echo "ok - SC7 REPO_ROOT git rev-parse is after the [0/10] preflight (line $rr_line > $pf_line)"
+else
+  echo "FAIL - SC7 ordering: pf=$pf_line rr=$rr_line"; fails=$((fails+1))
+fi
+
+rm -rf "$td"
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/test-e2e-symmetry.sh
+++ b/scripts/test-e2e-symmetry.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+# test-e2e-symmetry.sh -- END-TO-END install -> uninstall roundtrip for the
+# settings.json wiring (HIMMEL-469). Unlike the hermetic unit suites (which test
+# one helper in isolation), this drives the REAL setup `[9/10]` wire sequence and
+# the REAL `uninstall.sh [6/6]` against a sandbox settings.json, then asserts the
+# round trip leaves it byte-clean of himmel wiring while preserving the operator's
+# own keys.
+#
+# jq-only (no git / node / bun) -- runs on a bare test VM and in CI, not just on a
+# full himmel install. This is the foundation the VM harness uses for uninstall
+# (and, later, upgrade) e2e coverage.
+#
+# Usage: bash scripts/test-e2e-symmetry.sh
+set -u
+here="$(cd "$(dirname "$0")" && pwd)"   # <repo>/scripts
+repo_root="$(cd "$here/.." && pwd)"
+lib="$repo_root/scripts/lib"
+fails=0
+check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+
+command -v jq >/dev/null 2>&1 || { echo "test-e2e-symmetry: jq required" >&2; exit 2; }
+
+td="$(mktemp -d)"
+trap 'rm -rf "$td"' EXIT
+HIMMEL_FAKE="C:/fake/himmel"             # stand-in clone path (string only)
+SETTINGS="$td/home/.claude/settings.json"
+mkdir -p "$(dirname "$SETTINGS")"
+
+# Seed a realistic pre-existing settings.json: the operator's OWN rtk guard +
+# a custom MCP allow that MUST survive the whole round trip.
+cat > "$SETTINGS" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher":"Bash","hooks":[{"type":"command","command":"bash /opt/rtk-hook-guard.sh"}]}
+    ]
+  },
+  "permissions": {"allow":["mcp__obsidian-vault__obsidian_simple_search"]}
+}
+JSON
+
+echo "==== PHASE INSTALL (the setup [9/10] wire sequence) ===="
+# Exactly what setup.sh [9/10] runs, by subprocess (no set -e leak).
+bash "$lib/wire-statusline.sh"        "$SETTINGS" "$HIMMEL_FAKE" >/dev/null
+bash "$lib/wire-himmel-repo.sh"       "$SETTINGS" "$HIMMEL_FAKE" >/dev/null
+bash "$lib/wire-pretooluse-hooks.sh"  "$SETTINGS" "$HIMMEL_FAKE" >/dev/null
+bash "$lib/wire-pretooluse-hooks.sh"  --sessionstart "$SETTINGS" "$HIMMEL_FAKE" "inject-initiative.sh" >/dev/null
+
+check "install: 3 PreToolUse himmel hooks present" \
+  "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("scripts/hooks/(auto-approve-safe-bash|block-edit-on-main|block-read-secrets)"))] | length' "$SETTINGS")" "3"
+check "install: SessionStart inject-initiative present" \
+  "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("inject-initiative"))] | length' "$SETTINGS")" "1"
+check "install: statusLine wired"    "$(jq -r '.statusLine.type' "$SETTINGS")" "command"
+check "install: env.HIMMEL_REPO set" "$(jq -r '.env.HIMMEL_REPO' "$SETTINGS")" "C:/fake/himmel"
+check "install: rtk guard preserved" "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("rtk-hook-guard"))] | length' "$SETTINGS")" "1"
+check "install: MCP allow preserved" "$(jq -r '.permissions.allow[0]' "$SETTINGS")" "mcp__obsidian-vault__obsidian_simple_search"
+
+echo "==== PHASE UNINSTALL (the real uninstall.sh [6/6]) ===="
+# Drive the REAL uninstall.sh with the settings target redirected to the sandbox,
+# everything else skipped + non-interactive. Telegram/bridge point at empty temp
+# dirs so steps 1-2 no-op.
+out=$(HIMMEL_USER_SETTINGS="$SETTINGS" TELEGRAM_CHANNEL_DIR="$td/none" BRIDGE_ROOT="$td/noneb" \
+  bash "$repo_root/scripts/uninstall.sh" --yes --keep-telegram-state --skip-tasks --skip-plugins --skip-hooks </dev/null 2>&1) || true
+
+printf '%s\n' "$out" | grep -q '\[6/6\] Unwiring' && check "uninstall: [6/6] ran" yes yes || check "uninstall: [6/6] ran" no yes
+check "uninstall: PreToolUse himmel hooks gone" \
+  "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("scripts/hooks/(auto-approve-safe-bash|block-edit-on-main|block-read-secrets)"))] | length' "$SETTINGS")" "0"
+check "uninstall: SessionStart inject-initiative gone" \
+  "$(jq -r '[.hooks.SessionStart[]?.hooks[]?.command // empty | select(test("inject-initiative"))] | length' "$SETTINGS")" "0"
+check "uninstall: statusLine removed"      "$(jq -r 'has("statusLine")' "$SETTINGS")" "false"
+check "uninstall: env.HIMMEL_REPO removed"  "$(jq -r '.env.HIMMEL_REPO // "ABSENT"' "$SETTINGS")" "ABSENT"
+check "uninstall: rtk guard SURVIVED"       "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("rtk-hook-guard"))] | length' "$SETTINGS")" "1"
+check "uninstall: MCP allow SURVIVED"       "$(jq -r '.permissions.allow[0]' "$SETTINGS")" "mcp__obsidian-vault__obsidian_simple_search"
+
+echo "==== ROUNDTRIP INVARIANT ===="
+# After install->uninstall, the only himmel-managed keys are gone and the
+# operator's seed survives: assert no himmel hook command remains anywhere.
+check "roundtrip: zero himmel hook commands remain" \
+  "$(jq -r '[.. | .command? // empty | strings | select(test("/scripts/hooks/(auto-approve-safe-bash|block-edit-on-main|block-read-secrets|inject-initiative)"))] | length' "$SETTINGS")" "0"
+
+[ "$fails" -eq 0 ] && echo "E2E ALL PASS" || { echo "$fails E2E FAILED"; exit 1; }

--- a/scripts/test-install-symmetry-vm.sh
+++ b/scripts/test-install-symmetry-vm.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# test-install-symmetry-vm.sh -- host-driven VM validation for the install/
+# uninstall symmetry initiative (R8, HIMMEL-460). Copies THIS worktree to an
+# Ubuntu VM over ssh and runs the hermetic bash suites + the real out-of-repo
+# auto-approve check (SC2) on real Linux.
+#
+# EXITS 0 iff SC1/SC2/SC3/SC5/SC6/SC7 all pass on the VM. Tools that setup should
+# provide but the VM lacks are emitted to stderr as `GAP:` lines; a GAP fails the
+# run only when the missing tool is in setup's hard-required set (that is the R6
+# bug the initiative guards against), else it warns.
+#
+# Usage:
+#   bash scripts/test-install-symmetry-vm.sh [user@host] [port] [identity]
+#   defaults: localhost 2222 $HOME/.ssh/id_ed25519
+#
+# Exit codes: 0 = all assertions passed; 1 = an assertion failed; 3 = the VM was
+# unreachable (key auth) -- not a code failure, re-run when the VM is provisioned.
+set -uo pipefail
+
+HOSTSPEC="${1:-localhost}"
+PORT="${2:-2222}"
+IDENT="${3:-$HOME/.ssh/id_ed25519}"
+SSH_OPTS="-p $PORT -i $IDENT -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new"
+REPO="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+REMOTE_DIR="/tmp/himmel-symmetry-vm"
+
+# Intentional: $SSH_OPTS word-splits into flags (SC2086) and the remote command
+# expands host-side before transport (SC2029 -- we WANT host vars like REMOTE_DIR
+# substituted before the VM runs the body).
+# shellcheck disable=SC2086,SC2029
+ssh_vm() { ssh $SSH_OPTS "$HOSTSPEC" "$@"; }
+
+echo "==> VM validation: $HOSTSPEC:$PORT (worktree: $REPO)"
+
+# 0. connectivity (fail soft with rc 3 -- VM not ready is not a code defect).
+if ! ssh_vm 'echo connected' >/dev/null 2>&1; then
+  echo "ERROR: cannot ssh to $HOSTSPEC:$PORT with key $IDENT (publickey rejected)." >&2
+  echo "  The VM is not reachable by this session -- run this script once the VM" >&2
+  echo "  is provisioned (the agent's pubkey in the VM's authorized_keys)." >&2
+  exit 3
+fi
+
+# 1. stage the branch (rsync when both sides have it, else scp -r the scripts tree).
+echo "[stage] copying worktree to $REMOTE_DIR ..."
+ssh_vm "rm -rf $REMOTE_DIR && mkdir -p $REMOTE_DIR"
+if command -v rsync >/dev/null 2>&1 && ssh_vm 'command -v rsync >/dev/null 2>&1'; then
+  rsync -az -e "ssh $SSH_OPTS" --exclude '.git' --exclude 'node_modules' --exclude 'dist' \
+    "$REPO/scripts" "$REPO/.env.example" "$HOSTSPEC:$REMOTE_DIR/"
+else
+  # shellcheck disable=SC2086
+  scp -P $PORT -i "$IDENT" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -r \
+    "$REPO/scripts" "$HOSTSPEC:$REMOTE_DIR/"
+  # shellcheck disable=SC2086
+  scp -P $PORT -i "$IDENT" -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+    "$REPO/.env.example" "$HOSTSPEC:$REMOTE_DIR/" 2>/dev/null || true
+fi
+
+# 2. run the assertions on the VM. The remote body is self-contained: it runs the
+#    hermetic suites that map to each SC, the real out-of-repo auto-approve (SC2),
+#    a setup.sh syntax+arg-parse smoke, and the GAP scan. It echoes a final
+#    RESULT: line and exits non-zero on any failure.
+ssh_vm "REMOTE_DIR=$REMOTE_DIR bash -s" <<'REMOTE'
+set -uo pipefail
+DIR="$REMOTE_DIR"
+fails=0
+run_suite() {
+  local label="$1" script="$2"
+  if [ ! -f "$DIR/$script" ]; then echo "MISS  $label ($script not staged)"; fails=$((fails+1)); return; fi
+  # Run from the staged repo root: some suites (test-inject-initiative) resolve
+  # their repo via a CWD-relative `git rev-parse --show-toplevel`.
+  if ( cd "$DIR" && bash "$script" ) >"/tmp/vm-$(basename "$script").log" 2>&1; then
+    echo "PASS  $label"
+  else
+    echo "FAIL  $label -- see /tmp/vm-$(basename "$script").log"; fails=$((fails+1))
+    tail -5 "/tmp/vm-$(basename "$script").log" | sed 's/^/      /'
+  fi
+}
+
+echo "---- VM: $(uname -srm) ----"
+
+# Bootstrap the TEST-HARNESS deps (bash/git/jq) -- separate from the user runtime
+# set (HIMMEL-469). Best-effort: on a NOPASSWD test VM / CI runner this installs
+# git+jq; on a password-sudo box it fails loud and the git-dependent suites are
+# reported as GAPs below (the non-git suites still run).
+if [ -f "$DIR/scripts/machine-setup/test-bootstrap.sh" ]; then
+  bash "$DIR/scripts/machine-setup/test-bootstrap.sh" 2>&1 | sed 's/^/  /' || echo "  test-bootstrap: could not install all test deps (non-fatal; see GAP scan)"
+fi
+
+# The staged tree is a plain scp copy (no .git). test-inject-initiative resolves
+# its repo root via `git rev-parse --show-toplevel`, so make the staging dir a git
+# repo (a real clone would already be one). Guarded on git presence.
+if command -v git >/dev/null 2>&1 && [ ! -d "$DIR/.git" ]; then
+  ( cd "$DIR" && git init -q . && git config user.email t@e.co && git config user.name t ) 2>/dev/null \
+    && echo "  [stage] git-initialised $DIR (test-inject-initiative needs a git toplevel)"
+fi
+
+# SC1/SC8 (setup wires the UNIVERSAL hooks; basename dedup survives a path move).
+run_suite "SC1/SC8 setup-wire"        scripts/lib/test-setup-wire.sh
+# SC3 (inject-initiative resolves legs from the himmel .env; CWD-safety).
+# These two need `git` (git-toplevel resolution + decoy-repo fixtures). On a
+# bare VM without git they're GAP-skipped (a test-dep provisioning gap, not a
+# code failure); CI / a NOPASSWD VM has git via test-bootstrap, so they run.
+if command -v git >/dev/null 2>&1; then
+  run_suite "SC3 inject-initiative"   scripts/hooks/test-inject-initiative.sh
+  run_suite "SC3 load-dotenv --root"  scripts/lib/test-load-dotenv.sh
+else
+  echo "GAP:  git missing -- SC3 inject-initiative + load-dotenv suites SKIPPED (test-dep; run test-bootstrap.sh)" >&2
+fi
+# SC5/SC11 (dup detection advisory; benign double-fire).
+run_suite "SC5/SC11 detect-hook-dup"  scripts/lib/test-detect-hook-dup.sh
+# SC6 (uninstall [6/6] + unwire helpers).
+run_suite "SC6 uninstall"             scripts/test-uninstall.sh
+run_suite "SC6 unwire-pretooluse"     scripts/lib/test-unwire-pretooluse-hooks.sh
+run_suite "SC6 unwire-singlekey"      scripts/lib/test-unwire-singlekey.sh
+# SC7 (preflight ordering + ensure-tools branches).
+run_suite "SC7 setup-preflight"       scripts/setup/test-setup-preflight.sh
+# wire lib sanity.
+run_suite "wire-pretooluse"           scripts/lib/test-wire-pretooluse-hooks.sh
+# E2E install -> uninstall roundtrip (drives the REAL setup-wire sequence + the
+# REAL uninstall.sh [6/6] against a sandbox settings.json; jq-only, no git).
+run_suite "E2E install->uninstall"    scripts/test-e2e-symmetry.sh
+
+# SC2 (the real Goal): an out-of-repo Bash call to the abs-path Jira CLI is
+# auto-approved by the user-scope hook. Run from /tmp (outside the repo) and feed
+# the hook the exact payload Claude Code would.
+echo "---- SC2: out-of-repo auto-approve ----"
+AA="$DIR/scripts/hooks/auto-approve-safe-bash.sh"
+SC2_IN="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"node $DIR/scripts/jira/dist/index.js transition HIMMEL-1 Done\"}}"
+if command -v jq >/dev/null 2>&1; then
+  sc2_out=$(cd /tmp && printf '%s' "$SC2_IN" | bash "$AA" 2>/dev/null)
+  if printf '%s' "$sc2_out" | grep -q '"permissionDecision"[: ]*"allow"'; then
+    echo "PASS  SC2 out-of-repo jira call auto-approved"
+  else
+    echo "FAIL  SC2 out-of-repo jira call NOT auto-approved: $sc2_out"; fails=$((fails+1))
+  fi
+else
+  echo "GAP:  jq missing on VM -- SC2 (and the hooks) need jq; setup must provide it" >&2
+  fails=$((fails+1))   # jq is hard-required
+fi
+
+# setup.sh smoke: syntax + arg-parse path (exercises the relocated SETUP_DIR top
+# without the heavy full install).
+echo "---- setup.sh smoke ----"
+if bash -n "$DIR/scripts/setup.sh" && bash "$DIR/scripts/setup.sh" --help >/dev/null 2>&1; then
+  echo "PASS  setup.sh syntax + --help"
+else
+  echo "FAIL  setup.sh syntax/--help"; fails=$((fails+1))
+fi
+
+# GAP scan: tools setup's [0/10] treats as hard-required.
+echo "---- GAP scan (hard-required tools) ----"
+for t in bash git node npm bun python3 jq gh mktemp; do
+  command -v "$t" >/dev/null 2>&1 || echo "GAP:  hard-required '$t' missing on VM (setup [0/10] would auto-install/flag it)" >&2
+done
+
+echo "RESULT: $fails failure(s)"
+[ "$fails" -eq 0 ]
+REMOTE
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+  echo "==> VM validation PASSED"
+else
+  echo "==> VM validation FAILED (rc=$rc)" >&2
+fi
+exit "$rc"

--- a/scripts/test-uninstall.ps1
+++ b/scripts/test-uninstall.ps1
@@ -55,6 +55,13 @@ New-Item -ItemType Directory -Force $Tmp | Out-Null
 
 $SavedChannelDir = $env:TELEGRAM_CHANNEL_DIR
 $SavedBridgeRoot = $env:BRIDGE_ROOT
+$SavedUserSettings = $env:HIMMEL_USER_SETTINGS
+
+# Redirect the [6/6] settings-unwire target away from the operator's REAL
+# ~/.claude/settings.json for the whole suite (HIMMEL-460). SC6 cases re-seed it.
+$UserSettingsFile = Join-Path $Tmp 'user-settings.json'
+$env:HIMMEL_USER_SETTINGS = $UserSettingsFile
+Set-Content -Path $UserSettingsFile -Value '{}'
 
 function New-State {
     $script:Channel = Join-Path $Tmp 'channels\telegram'
@@ -328,9 +335,77 @@ function Unregister-ScheduledTask {
         Write-Host 'FAIL access.json gone despite open handle'; $script:Failed++
     }
     }
+
+    # ── SC6 (HIMMEL-460): [6/6] settings unwire ─────────────────────────────
+    $SeedSettings = {
+        @'
+{
+  "statusLine": {"type":"command","command":"bash \"C:/h/scripts/statusline/bin/statusline.sh\""},
+  "env": {"HIMMEL_REPO":"C:/h","LUNA_VAULT_PATH":"C:/v","KEEP_ME":"1"},
+  "hooks": {
+    "PreToolUse": [
+      {"matcher":"Bash","hooks":[
+        {"type":"command","command":"bash C:/h/scripts/hooks/auto-approve-safe-bash.sh"},
+        {"type":"command","command":"bash /opt/rtk-hook-guard.sh"}
+      ]},
+      {"matcher":"*","hooks":[{"type":"command","command":"bash C:/h/scripts/hooks/auto-arm-on-cap.sh"}]}
+    ],
+    "SessionStart": [
+      {"hooks":[
+        {"type":"command","command":"bash C:/h/scripts/hooks/check-update-available.sh"},
+        {"type":"command","command":"bash C:/h/scripts/hooks/inject-initiative.sh"}
+      ]}
+    ]
+  },
+  "permissions": {"allow":["mcp__obsidian-vault__obsidian_simple_search"]}
+}
+'@ | Set-Content -Path $UserSettingsFile -Encoding utf8
+    }
+    function JqU($expr) { Get-Content $UserSettingsFile -Raw | jq -r $expr }
+
+    # 11. [6/6] clears the wiring, preserves non-himmel keys.
+    New-State
+    $env:TELEGRAM_CHANNEL_DIR = Join-Path $Tmp 'n1'
+    $env:BRIDGE_ROOT = Join-Path $Tmp 'n1b'
+    & $SeedSettings
+    $out = Invoke-Uninstall @('-Yes', '-SkipTasks', '-SkipPlugins', '-SkipHooks')
+    Assert-Rc '[6/6] run exits 0' 0 $script:Rc
+    Assert-Has '[6/6] banner present' '[6/6] Unwiring' $out
+    Assert-Rc 'statusLine removed'      'null' (JqU '.statusLine // "null"')
+    Assert-Rc 'HIMMEL_REPO removed'     'null' (JqU '.env.HIMMEL_REPO // "null"')
+    Assert-Rc 'LUNA_VAULT_PATH removed' 'null' (JqU '.env.LUNA_VAULT_PATH // "null"')
+    Assert-Rc 'non-himmel env kept'     '1'    (JqU '.env.KEEP_ME')
+    Assert-Rc 'UNIVERSAL hook removed'  '0'    (JqU '[.hooks.PreToolUse[].hooks[].command|select(test("auto-approve-safe-bash"))]|length')
+    Assert-Rc 'rtk guard preserved'     '1'    (JqU '[.hooks.PreToolUse[].hooks[].command|select(test("rtk-hook-guard"))]|length')
+    Assert-Rc 'dev-only hook preserved' '1'    (JqU '[.hooks.PreToolUse[].hooks[].command|select(test("auto-arm-on-cap"))]|length')
+    Assert-Rc 'inject-initiative removed' '0'  (JqU '[.hooks.SessionStart[].hooks[].command|select(test("inject-initiative"))]|length')
+    Assert-Rc 'SessionStart sibling kept' '1'  (JqU '[.hooks.SessionStart[].hooks[].command|select(test("check-update-available"))]|length')
+
+    # 12. -SkipSettings keeps the wiring intact.
+    New-State
+    $env:TELEGRAM_CHANNEL_DIR = Join-Path $Tmp 'n2'
+    $env:BRIDGE_ROOT = Join-Path $Tmp 'n2b'
+    & $SeedSettings
+    $before = Get-Content $UserSettingsFile -Raw
+    $out = Invoke-Uninstall @('-Yes', '-SkipSettings', '-SkipTasks', '-SkipPlugins', '-SkipHooks')
+    Assert-Rc '-SkipSettings run exits 0' 0 $script:Rc
+    Assert-Has '-SkipSettings honored' 'kept (-SkipSettings)' $out
+    Assert-Rc '-SkipSettings leaves file unchanged' $before (Get-Content $UserSettingsFile -Raw)
+
+    # 13. -DryRun does not mutate the settings file.
+    New-State
+    $env:TELEGRAM_CHANNEL_DIR = Join-Path $Tmp 'n3'
+    $env:BRIDGE_ROOT = Join-Path $Tmp 'n3b'
+    & $SeedSettings
+    $before = Get-Content $UserSettingsFile -Raw
+    $out = Invoke-Uninstall @('-DryRun', '-SkipTasks', '-SkipPlugins', '-SkipHooks')
+    Assert-Rc 'dry-run [6/6] exits 0' 0 $script:Rc
+    Assert-Has 'dry-run prints [6/6] DRY' 'DRY: unwire statusLine' $out
+    Assert-Rc 'dry-run leaves settings unchanged' $before (Get-Content $UserSettingsFile -Raw)
 } finally {
     $env:TELEGRAM_CHANNEL_DIR = $SavedChannelDir
     $env:BRIDGE_ROOT = $SavedBridgeRoot
+    $env:HIMMEL_USER_SETTINGS = $SavedUserSettings
     Remove-Item -Recurse -Force $Tmp -ErrorAction SilentlyContinue
 }
 

--- a/scripts/test-uninstall.sh
+++ b/scripts/test-uninstall.sh
@@ -55,6 +55,12 @@ FAILED=0
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
+# Redirect the [6/6] settings-unwire target away from the operator's REAL
+# ~/.claude/settings.json for the whole suite (HIMMEL-460). The dedicated SC6
+# cases re-seed this file per-test; the others simply never touch the real one.
+export HIMMEL_USER_SETTINGS="$TMP/user-settings.json"
+printf '{}\n' > "$HIMMEL_USER_SETTINGS"
+
 mk_state() {
     CHANNEL="$TMP/channels/telegram"
     BRIDGE="$TMP/bridge"
@@ -403,6 +409,69 @@ else
         echo "FAIL state removed though bridge could not be stopped"; FAILED=$((FAILED + 1))
     fi
 fi
+
+# ── SC6 (HIMMEL-460): [6/6] settings unwire ─────────────────────────────────
+# Seed a settings.json carrying everything setup/adopt wire PLUS non-himmel keys
+# that MUST survive (rtk guard, a custom statusLine sibling, an MCP allow).
+seed_settings() {
+  cat > "$HIMMEL_USER_SETTINGS" <<'JSON'
+{
+  "statusLine": {"type":"command","command":"bash \"C:/h/scripts/statusline/bin/statusline.sh\""},
+  "env": {"HIMMEL_REPO":"C:/h","LUNA_VAULT_PATH":"C:/v","KEEP_ME":"1"},
+  "hooks": {
+    "PreToolUse": [
+      {"matcher":"Bash","hooks":[
+        {"type":"command","command":"bash C:/h/scripts/hooks/auto-approve-safe-bash.sh"},
+        {"type":"command","command":"bash /opt/rtk-hook-guard.sh"}
+      ]},
+      {"matcher":"*","hooks":[{"type":"command","command":"bash C:/h/scripts/hooks/auto-arm-on-cap.sh"}]}
+    ],
+    "SessionStart": [
+      {"hooks":[
+        {"type":"command","command":"bash C:/h/scripts/hooks/check-update-available.sh"},
+        {"type":"command","command":"bash C:/h/scripts/hooks/inject-initiative.sh"}
+      ]}
+    ]
+  },
+  "permissions": {"allow":["mcp__obsidian-vault__obsidian_simple_search"]}
+}
+JSON
+}
+
+# 13. [6/6] clears the wiring, preserves non-himmel keys.
+seed_settings
+out=$(TELEGRAM_CHANNEL_DIR="$TMP/none1" BRIDGE_ROOT="$TMP/none1b" \
+    bash "$CLI" --yes --skip-tasks --skip-plugins --skip-hooks </dev/null 2>&1); rc=$?
+assert_rc "[6/6] run exits 0" 0 "$rc"
+assert_has "[6/6] banner present" "[6/6] Unwiring" "$out"
+assert_rc "statusLine removed"      "null"   "$(jq -r '.statusLine // "null"' "$HIMMEL_USER_SETTINGS")"
+assert_rc "HIMMEL_REPO removed"     "null"   "$(jq -r '.env.HIMMEL_REPO // "null"' "$HIMMEL_USER_SETTINGS")"
+assert_rc "LUNA_VAULT_PATH removed" "null"   "$(jq -r '.env.LUNA_VAULT_PATH // "null"' "$HIMMEL_USER_SETTINGS")"
+assert_rc "non-himmel env kept"     "1"      "$(jq -r '.env.KEEP_ME' "$HIMMEL_USER_SETTINGS")"
+assert_rc "UNIVERSAL hook removed"  "0"      "$(jq -r '[.hooks.PreToolUse[].hooks[].command|select(test("auto-approve-safe-bash"))]|length' "$HIMMEL_USER_SETTINGS")"
+assert_rc "rtk guard preserved"     "1"      "$(jq -r '[.hooks.PreToolUse[].hooks[].command|select(test("rtk-hook-guard"))]|length' "$HIMMEL_USER_SETTINGS")"
+assert_rc "dev-only hook preserved" "1"      "$(jq -r '[.hooks.PreToolUse[].hooks[].command|select(test("auto-arm-on-cap"))]|length' "$HIMMEL_USER_SETTINGS")"
+assert_rc "inject-initiative removed" "0"    "$(jq -r '[.hooks.SessionStart[].hooks[].command|select(test("inject-initiative"))]|length' "$HIMMEL_USER_SETTINGS")"
+assert_rc "SessionStart sibling kept" "1"    "$(jq -r '[.hooks.SessionStart[].hooks[].command|select(test("check-update-available"))]|length' "$HIMMEL_USER_SETTINGS")"
+assert_rc "MCP allow preserved"     "mcp__obsidian-vault__obsidian_simple_search" "$(jq -r '.permissions.allow[0]' "$HIMMEL_USER_SETTINGS")"
+
+# 14. --skip-settings keeps the wiring intact.
+seed_settings
+before=$(cat "$HIMMEL_USER_SETTINGS")
+out=$(TELEGRAM_CHANNEL_DIR="$TMP/none2" BRIDGE_ROOT="$TMP/none2b" \
+    bash "$CLI" --yes --skip-settings --skip-tasks --skip-plugins --skip-hooks </dev/null 2>&1); rc=$?
+assert_rc "--skip-settings run exits 0" 0 "$rc"
+assert_has "--skip-settings honored" "kept (--skip-settings)" "$out"
+assert_rc "--skip-settings leaves file unchanged" "$before" "$(cat "$HIMMEL_USER_SETTINGS")"
+
+# 15. --dry-run does not mutate the settings file.
+seed_settings
+before=$(cat "$HIMMEL_USER_SETTINGS")
+out=$(TELEGRAM_CHANNEL_DIR="$TMP/none3" BRIDGE_ROOT="$TMP/none3b" \
+    bash "$CLI" --dry-run --skip-tasks --skip-plugins --skip-hooks </dev/null 2>&1); rc=$?
+assert_rc "dry-run [6/6] exits 0" 0 "$rc"
+assert_has "dry-run prints [6/6] DRY" "DRY: unwire statusLine" "$out"
+assert_rc "dry-run leaves settings unchanged" "$before" "$(cat "$HIMMEL_USER_SETTINGS")"
 
 echo ""
 if [ "$FAILED" -eq 0 ]; then

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -2,11 +2,13 @@
 # PowerShell counterpart of uninstall.sh. Symmetric teardown of what
 # setup.ps1 + install-plugins.ps1 onboard:
 #
-#   [1/5] stop the telegram bun bridge      (bun supervisor.ts --kill)
-#   [2/5] remove telegram pairing + bridge state
-#   [3/5] remove HIMMEL-Resume-* scheduled tasks + HimmelTelegramBridge
-#   [4/5] uninstall Claude plugins + marketplaces (uninstall-plugins.ps1)
-#   [5/5] uninstall git hooks (pre-commit/pre-push/commit-msg)
+#   [1/6] stop the telegram bun bridge      (bun supervisor.ts --kill)
+#   [2/6] remove telegram pairing + bridge state
+#   [3/6] remove HIMMEL-Resume-* scheduled tasks + HimmelTelegramBridge
+#   [4/6] uninstall Claude plugins + marketplaces (uninstall-plugins.ps1)
+#   [5/6] uninstall git hooks (pre-commit/pre-push/commit-msg)
+#   [6/6] unwire ~/.claude/settings.json (statusLine, env.HIMMEL_REPO,
+#         env.LUNA_VAULT_PATH, the UNIVERSAL hooks — what setup.ps1/adopt wired)
 #
 # Destructive. Fail-closed: without -Yes an interactive run prompts; a
 # non-interactive run aborts (rc=2). -DryRun prints actions only.
@@ -14,6 +16,7 @@
 # Usage:
 #   pwsh -File scripts/uninstall.ps1 [-DryRun] [-Yes]
 #        [-KeepTelegramState] [-SkipPlugins] [-SkipTasks] [-SkipHooks]
+#        [-SkipSettings]
 #
 # Env overrides (tests): $env:TELEGRAM_CHANNEL_DIR, $env:BRIDGE_ROOT
 
@@ -24,7 +27,8 @@ param(
     [switch]$KeepTelegramState,
     [switch]$SkipPlugins,
     [switch]$SkipTasks,
-    [switch]$SkipHooks
+    [switch]$SkipHooks,
+    [switch]$SkipSettings
 )
 
 $RepoRoot = Resolve-Path (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) '..')
@@ -33,6 +37,9 @@ $ChannelDir = if ($env:TELEGRAM_CHANNEL_DIR) { $env:TELEGRAM_CHANNEL_DIR }
               else { Join-Path $HOME '.claude\channels\telegram' }
 $BridgeRoot = if ($env:BRIDGE_ROOT) { $env:BRIDGE_ROOT }
               else { Join-Path $HOME '.claude\handover\bridge' }
+# Test override so the [6/6] settings-unwire targets a temp file, not the real one.
+$UserSettings = if ($env:HIMMEL_USER_SETTINGS) { $env:HIMMEL_USER_SETTINGS }
+                else { Join-Path $HOME '.claude\settings.json' }
 
 # Locale-independent existence check for an exact scheduled-task name.
 # Returns $true if the task exists, $false if absent. Throws only on
@@ -71,6 +78,12 @@ if (-not $SkipHooks) {
 } else {
     Write-Host "  5. keep git hooks (-SkipHooks)"
 }
+if (-not $SkipSettings) {
+    Write-Host "  6. unwire ~/.claude/settings.json (statusLine, HIMMEL_REPO,"
+    Write-Host "     LUNA_VAULT_PATH, UNIVERSAL hooks -- non-himmel keys untouched)"
+} else {
+    Write-Host "  6. keep ~/.claude/settings.json wiring (-SkipSettings)"
+}
 Write-Host ""
 
 if ($DryRun) {
@@ -87,12 +100,12 @@ if ($DryRun) {
 }
 Write-Host ""
 
-# --- [1/5] stop the bridge ---------------------------------------------------
+# --- [1/6] stop the bridge ---------------------------------------------------
 # $BridgeMaybeRunning gates step 2: removing state while a supervisor may
 # still be live would be recreated by it, and its open handles make the
 # Remove-Item fail partway on Windows.
 $BridgeMaybeRunning = $false
-Write-Host "[1/5] Stopping telegram bridge..."
+Write-Host "[1/6] Stopping telegram bridge..."
 $PidFile = Join-Path $BridgeRoot 'supervisor.pid'
 if (-not (Test-Path $PidFile)) {
     Write-Host "  no supervisor.pid under $BridgeRoot -- bridge not running, skipping."
@@ -123,8 +136,8 @@ if (-not (Test-Path $PidFile)) {
 }
 Write-Host ""
 
-# --- [2/5] remove telegram pairing + bridge state ------------------------------
-Write-Host "[2/5] Removing telegram pairing + bridge state..."
+# --- [2/6] remove telegram pairing + bridge state ------------------------------
+Write-Host "[2/6] Removing telegram pairing + bridge state..."
 if ($KeepTelegramState) {
     Write-Host "  kept (-KeepTelegramState)."
 } elseif ($BridgeMaybeRunning) {
@@ -174,8 +187,8 @@ if ($KeepTelegramState) {
 }
 Write-Host ""
 
-# --- [3/5] remove scheduled tasks ----------------------------------------------
-Write-Host "[3/5] Removing scheduled tasks (HIMMEL-Resume-*, HimmelTelegramBridge)..."
+# --- [3/6] remove scheduled tasks ----------------------------------------------
+Write-Host "[3/6] Removing scheduled tasks (HIMMEL-Resume-*, HimmelTelegramBridge)..."
 if ($SkipTasks) {
     Write-Host "  kept (-SkipTasks)."
 } else {
@@ -243,8 +256,8 @@ if ($SkipTasks) {
 }
 Write-Host ""
 
-# --- [4/5] uninstall plugins + marketplaces -------------------------------------
-Write-Host "[4/5] Uninstalling Claude plugins + marketplaces..."
+# --- [4/6] uninstall plugins + marketplaces -------------------------------------
+Write-Host "[4/6] Uninstalling Claude plugins + marketplaces..."
 if ($SkipPlugins) {
     Write-Host "  kept (-SkipPlugins)."
 } elseif (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
@@ -259,9 +272,9 @@ if ($SkipPlugins) {
 }
 Write-Host ""
 
-# --- [5/5] uninstall git hooks ----------------------------------------------------
+# --- [5/6] uninstall git hooks ----------------------------------------------------
 # Mirror of setup.ps1 step 2 (which installs via python -m pre_commit).
-Write-Host "[5/5] Uninstalling git hooks (this repo)..."
+Write-Host "[5/6] Uninstalling git hooks (this repo)..."
 if ($SkipHooks) {
     Write-Host "  kept (-SkipHooks)."
 } elseif (-not (Get-Command python -ErrorAction SilentlyContinue)) {
@@ -287,9 +300,37 @@ if ($SkipHooks) {
 }
 Write-Host ""
 
+# --- [6/6] unwire user-scope settings.json (HIMMEL-460) ----------------------
+# Symmetric inverse of setup.ps1 [9/10] + adopt -Scope user: remove the
+# statusLine, env.HIMMEL_REPO, env.LUNA_VAULT_PATH, and the UNIVERSAL hooks.
+# Each helper removes ONLY its own key/stanza (refuses invalid JSON, preserves
+# every non-himmel key). The single-key helpers have no dry-run flag, so -DryRun
+# is gated here; unwire-pretooluse-hooks has its own switch.
+Write-Host "[6/6] Unwiring ~/.claude/settings.json (statusLine, HIMMEL_REPO, LUNA_VAULT_PATH, hooks)..."
+if ($SkipSettings) {
+    Write-Host "  kept (-SkipSettings)."
+} elseif (-not (Test-Path $UserSettings)) {
+    Write-Host "  no $UserSettings -- nothing to unwire."
+} elseif ($DryRun) {
+    Write-Host "DRY: unwire statusLine (himmel), env.HIMMEL_REPO, env.LUNA_VAULT_PATH from $UserSettings"
+    & pwsh -NoProfile -File (Join-Path $RepoRoot 'scripts\lib\unwire-pretooluse-hooks.ps1') -SettingsPath $UserSettings -DryRun
+} else {
+    foreach ($u in @('unwire-statusline', 'unwire-himmel-repo', 'unwire-luna-vault')) {
+        & pwsh -NoProfile -File (Join-Path $RepoRoot "scripts\lib\$u.ps1") -SettingsPath $UserSettings
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  WARN: $u reported a problem; setup-state may remain." -ForegroundColor Yellow
+        }
+    }
+    & pwsh -NoProfile -File (Join-Path $RepoRoot 'scripts\lib\unwire-pretooluse-hooks.ps1') -SettingsPath $UserSettings
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  WARN: unwire-pretooluse-hooks reported a problem." -ForegroundColor Yellow
+    }
+}
+Write-Host ""
+
 Write-Host "Uninstall complete."
 Write-Host ""
 Write-Host "NOT touched (by design):"
-Write-Host "  - ~/.claude/settings.json (hooks/MCP config -- prune manually if wanted)"
+Write-Host "  - ~/.claude/settings.json non-himmel keys (MCP config, your own hooks, rtk guard)"
 Write-Host "  - the himmel clone itself, .env, and worktrees"
 Write-Host "  - ~/.claude/handover/registry.json + handover state outside the bridge root"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -2,14 +2,16 @@
 # uninstall.sh — offboard the himmel operator surface (HIMMEL-227).
 # Symmetric teardown of what setup.sh + install-plugins.sh onboard:
 #
-#   [1/5] stop the telegram bun bridge      (bun supervisor.ts --kill)
-#   [2/5] remove telegram pairing + bridge state
+#   [1/6] stop the telegram bun bridge      (bun supervisor.ts --kill)
+#   [2/6] remove telegram pairing + bridge state
 #         (channel dir incl. access.json + bot-token .env; bridge root)
-#   [3/5] remove HIMMEL-Resume-* scheduled jobs (+ HimmelTelegramBridge
+#   [3/6] remove HIMMEL-Resume-* scheduled jobs (+ HimmelTelegramBridge
 #         logon task on Windows)
-#   [4/5] uninstall Claude plugins + marketplaces
+#   [4/6] uninstall Claude plugins + marketplaces
 #         (machine-setup/uninstall-plugins.sh — user-scope, affects all repos)
-#   [5/5] uninstall git hooks (pre-commit/pre-push/commit-msg)
+#   [5/6] uninstall git hooks (pre-commit/pre-push/commit-msg)
+#   [6/6] unwire ~/.claude/settings.json (statusLine, env.HIMMEL_REPO,
+#         env.LUNA_VAULT_PATH, the UNIVERSAL hooks — what setup.sh/adopt wired)
 #
 # Destructive. Fail-closed: without --yes an interactive run prompts; a
 # non-interactive run aborts (rc=2). --dry-run prints every action without
@@ -18,6 +20,7 @@
 # Usage:
 #   bash scripts/uninstall.sh [--dry-run] [--yes]
 #        [--keep-telegram-state] [--skip-plugins] [--skip-tasks] [--skip-hooks]
+#        [--skip-settings]
 #
 # Flags:
 #   --dry-run              Print actions instead of running them.
@@ -27,11 +30,14 @@
 #   --skip-plugins         Keep Claude plugins + marketplaces installed.
 #   --skip-tasks           Keep HIMMEL-Resume-* / HimmelTelegramBridge jobs.
 #   --skip-hooks           Keep the repo's pre-commit git hooks.
+#   --skip-settings        Keep the user-scope ~/.claude/settings.json wiring
+#                          (statusLine, HIMMEL_REPO, LUNA_VAULT_PATH, hooks).
 #
 # Env overrides (tests):
 #   TELEGRAM_CHANNEL_DIR — default $HOME/.claude/channels/telegram
 #   BRIDGE_ROOT          — default $HOME/.claude/handover/bridge
 #                          (same var the bridge's bus.ts honors)
+#   HIMMEL_USER_SETTINGS — default $HOME/.claude/settings.json (the [6/6] target)
 #
 # Exit codes: 0 = done (per-step problems are WARNs); 2 = aborted
 # (no confirmation) or bad flag.
@@ -45,6 +51,7 @@ KEEP_TELEGRAM_STATE=0
 SKIP_PLUGINS=0
 SKIP_TASKS=0
 SKIP_HOOKS=0
+SKIP_SETTINGS=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run)             DRY_RUN=1 ;;
@@ -53,6 +60,7 @@ while [ $# -gt 0 ]; do
     --skip-plugins)        SKIP_PLUGINS=1 ;;
     --skip-tasks)          SKIP_TASKS=1 ;;
     --skip-hooks)          SKIP_HOOKS=1 ;;
+    --skip-settings)       SKIP_SETTINGS=1 ;;
     -h|--help)
       sed -n '2,/^set -u/p' "$0" | sed 's/^# \{0,1\}//' | head -n -1
       exit 0
@@ -64,6 +72,9 @@ done
 
 CHANNEL_DIR="${TELEGRAM_CHANNEL_DIR:-$HOME/.claude/channels/telegram}"
 BRIDGE_ROOT="${BRIDGE_ROOT:-$HOME/.claude/handover/bridge}"
+# Test override (HIMMEL_USER_SETTINGS) so the [6/6] settings-unwire can target a
+# temp file instead of the operator's real ~/.claude/settings.json.
+USER_SETTINGS="${HIMMEL_USER_SETTINGS:-$HOME/.claude/settings.json}"
 
 run() {
   if [ "$DRY_RUN" -eq 1 ]; then
@@ -111,6 +122,12 @@ if [ "$SKIP_HOOKS" -eq 0 ]; then
 else
   echo "  5. keep git hooks (--skip-hooks)"
 fi
+if [ "$SKIP_SETTINGS" -eq 0 ]; then
+  echo "  6. unwire ~/.claude/settings.json (statusLine, HIMMEL_REPO,"
+  echo "     LUNA_VAULT_PATH, UNIVERSAL hooks — non-himmel keys untouched)"
+else
+  echo "  6. keep ~/.claude/settings.json wiring (--skip-settings)"
+fi
 echo ""
 
 if [ "$DRY_RUN" -eq 1 ]; then
@@ -131,7 +148,7 @@ elif [ "$YES" -ne 1 ]; then
 fi
 echo ""
 
-# --- [1/5] stop the bridge -------------------------------------------------
+# --- [1/6] stop the bridge -------------------------------------------------
 # Uses the documented cross-platform lever (supervisor.pid under the bridge
 # root; see docs/internals/telegram-bridge.md). BRIDGE_ROOT is passed through
 # so a non-default root kills the matching bridge, not another one.
@@ -139,7 +156,7 @@ echo ""
 # still be live would be recreated by it (and on Windows, locked files make
 # the removal fail partway).
 bridge_maybe_running=0
-echo "[1/5] Stopping telegram bridge..."
+echo "[1/6] Stopping telegram bridge..."
 if [ ! -f "$BRIDGE_ROOT/supervisor.pid" ]; then
   echo "  no supervisor.pid under $BRIDGE_ROOT — bridge not running, skipping."
 elif ! command -v bun >/dev/null 2>&1; then
@@ -164,8 +181,8 @@ else
 fi
 echo ""
 
-# --- [2/5] remove telegram pairing + bridge state ----------------------------
-echo "[2/5] Removing telegram pairing + bridge state..."
+# --- [2/6] remove telegram pairing + bridge state ----------------------------
+echo "[2/6] Removing telegram pairing + bridge state..."
 if [ "$KEEP_TELEGRAM_STATE" -eq 1 ]; then
   echo "  kept (--keep-telegram-state)."
 elif [ "$bridge_maybe_running" -eq 1 ]; then
@@ -195,10 +212,10 @@ else
 fi
 echo ""
 
-# --- [3/5] remove scheduled jobs ---------------------------------------------
+# --- [3/6] remove scheduled jobs ---------------------------------------------
 # Mirrors scripts/handover/arm-resume.sh job discovery: schtasks task names
 # on Windows; at-job body marker / crontab line marker on Linux/macOS.
-echo "[3/5] Removing scheduled jobs (HIMMEL-Resume-*, HimmelTelegramBridge)..."
+echo "[3/6] Removing scheduled jobs (HIMMEL-Resume-*, HimmelTelegramBridge)..."
 if [ "$SKIP_TASKS" -eq 1 ]; then
   echo "  kept (--skip-tasks)."
 elif command -v schtasks >/dev/null 2>&1; then
@@ -306,8 +323,8 @@ EOF
 fi
 echo ""
 
-# --- [4/5] uninstall plugins + marketplaces ----------------------------------
-echo "[4/5] Uninstalling Claude plugins + marketplaces..."
+# --- [4/6] uninstall plugins + marketplaces ----------------------------------
+echo "[4/6] Uninstalling Claude plugins + marketplaces..."
 if [ "$SKIP_PLUGINS" -eq 1 ]; then
   echo "  kept (--skip-plugins)."
 elif ! command -v claude >/dev/null 2>&1; then
@@ -321,9 +338,9 @@ else
 fi
 echo ""
 
-# --- [5/5] uninstall git hooks -------------------------------------------------
+# --- [5/6] uninstall git hooks -------------------------------------------------
 # Mirror of setup-hooks.sh / setup.sh step 2.
-echo "[5/5] Uninstalling git hooks (this repo)..."
+echo "[5/6] Uninstalling git hooks (this repo)..."
 if [ "$SKIP_HOOKS" -eq 1 ]; then
   echo "  kept (--skip-hooks)."
 elif ! command -v pre-commit >/dev/null 2>&1; then
@@ -344,9 +361,38 @@ else
 fi
 echo ""
 
+# --- [6/6] unwire user-scope settings.json (HIMMEL-460) ----------------------
+# Symmetric inverse of setup.sh [9/10] + adopt --scope user: remove the
+# statusLine, env.HIMMEL_REPO, env.LUNA_VAULT_PATH, and the UNIVERSAL hooks that
+# himmel wired into ~/.claude/settings.json. Each helper removes ONLY its own
+# key/stanza (refuses invalid JSON, preserves every non-himmel key: rtk guard,
+# the operator's own hooks, MCP config). --dry-run flows through to each.
+echo "[6/6] Unwiring ~/.claude/settings.json (statusLine, HIMMEL_REPO, LUNA_VAULT_PATH, hooks)..."
+_user_settings="$USER_SETTINGS"
+if [ "$SKIP_SETTINGS" -eq 1 ]; then
+  echo "  kept (--skip-settings)."
+elif [ ! -f "$_user_settings" ]; then
+  echo "  no $_user_settings — nothing to unwire."
+elif [ "$DRY_RUN" -eq 1 ]; then
+  # The single-key unwire helpers have no dry-run flag, so gate at this level to
+  # keep --dry-run a true no-op (SC6). unwire-pretooluse-hooks has its own flag.
+  echo "DRY: unwire statusLine (himmel), env.HIMMEL_REPO, env.LUNA_VAULT_PATH from $_user_settings"
+  bash "$REPO_ROOT/scripts/lib/unwire-pretooluse-hooks.sh" "$_user_settings" 1 \
+    || echo "  WARN: unwire-pretooluse-hooks dry-run reported a problem." >&2
+else
+  for _unwire in unwire-statusline unwire-himmel-repo unwire-luna-vault; do
+    if ! bash "$REPO_ROOT/scripts/lib/$_unwire.sh" "$_user_settings"; then
+      echo "  WARN: $_unwire reported a problem; setup-state may remain." >&2
+    fi
+  done
+  bash "$REPO_ROOT/scripts/lib/unwire-pretooluse-hooks.sh" "$_user_settings" \
+    || echo "  WARN: unwire-pretooluse-hooks reported a problem." >&2
+fi
+echo ""
+
 echo "Uninstall complete."
 echo ""
 echo "NOT touched (by design):"
-echo "  - ~/.claude/settings.json (hooks/MCP config — prune manually if wanted)"
+echo "  - ~/.claude/settings.json non-himmel keys (MCP config, your own hooks, rtk guard)"
 echo "  - the himmel clone itself, .env, and worktrees"
 echo "  - ~/.claude/handover/registry.json + handover state outside the bridge root"


### PR DESCRIPTION
Wire the UNIVERSAL hooks (PreToolUse trio + SessionStart inject-initiative) at user scope from setup/adopt; symmetric uninstall [6/6]; inject-initiative sources .env (CWD-safe); R6 preflight auto-install; full e2e harness (test-bootstrap + install/uninstall roundtrip). VM-validated on Ubuntu 26.04 + Windows.