### PR TITLE
fix(luna-template): stop pre-commit rewriting vault .md + autosync retry on auto-fixer

### DIFF
--- a/templates/luna-second-brain/.pre-commit-config.yaml
+++ b/templates/luna-second-brain/.pre-commit-config.yaml
@@ -8,8 +8,14 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
+      # Vault notes are user prose, not code — pre-commit must VALIDATE them
+      # (gitleaks/check-*) but never REWRITE them. trailing-whitespace would
+      # strip Markdown hard-line-breaks (two trailing spaces), and the churn
+      # from either fixer aborts the unattended autosync commit. So skip `.md`.
       - id: trailing-whitespace
+        exclude: '\.md$'
       - id: end-of-file-fixer
+        exclude: '\.md$'
       - id: check-yaml
       - id: check-json
 

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.1.0",
-  "upgraded_at": "2026-06-19T00:00:00Z"
+  "version": "0.2.0",
+  "upgraded_at": "2026-06-21T00:00:00Z"
 }

--- a/templates/luna-second-brain/scripts/test-vault-git.ps1
+++ b/templates/luna-second-brain/scripts/test-vault-git.ps1
@@ -100,6 +100,39 @@ try {
         Assert 'clone autosync: exit 0' ($LASTEXITCODE -eq 0)
         Assert 'clone autosync recreated .single-writer' (Test-Path (Join-Path $V '.single-writer'))
         Assert 'clone autosync commit landed past unborn HEAD' (([int]((git -C $V rev-list --count HEAD).Trim())) -gt ([int]$eBase))
+
+        # Phase G (HIMMEL-501) — auto-fixer resilience.
+        # A churny .md note (hard-break = 2 trailing spaces, no final newline):
+        # pre-commit must NOT rewrite it, so the commit isn't aborted.
+        $gBase = (git -C $V rev-list --count HEAD).Trim()
+        $mdPath = Join-Path $V '00-Inbox\md-fixer.md'
+        Set-Content -NoNewline -Path $mdPath -Value "first line  `nsecond line"
+        $mdOrig = Get-Content -Raw $mdPath
+        Push-Location $V; & pwsh -NoProfile -File $autosync *> $null; Pop-Location
+        Assert 'G1 autosync with churny .md: exit 0 (not blocked)' ($LASTEXITCODE -eq 0)
+        Assert 'G2 autosync commit landed' (([int]((git -C $V rev-list --count HEAD).Trim())) -gt ([int]$gBase))
+        Assert 'G3 .md left UNMODIFIED by pre-commit' ((Get-Content -Raw $mdPath) -eq $mdOrig)
+
+        # A NON-.md file a fixer DOES rewrite still lands (re-stage + retry).
+        $g2Base = (git -C $V rev-list --count HEAD).Trim()
+        Set-Content -NoNewline -Path (Join-Path $V '00-Inbox\data.txt') -Value "data with trailing space   `n"
+        Push-Location $V; & pwsh -NoProfile -File $autosync *> $null; Pop-Location
+        Assert 'G4 autosync recovers from fixer-modified non-.md: exit 0' ($LASTEXITCODE -eq 0)
+        Assert 'G5 retry committed after fixer ran' (([int]((git -C $V rev-list --count HEAD).Trim())) -gt ([int]$g2Base))
+        Assert 'G6 data.txt landed in committed tree' ([bool]((git -C $V ls-tree -r HEAD --name-only) -match 'data\.txt'))
+        Assert 'G7 fixer-retry result pushed to remote' (((git -C $bare rev-parse main).Trim()) -eq ((git -C $V rev-parse HEAD).Trim()))
+
+        # The retry must NOT weaken the egress guard: a NON-.md file with BOTH a
+        # fixer defect (trailing whitespace) AND a planted secret stays blocked
+        # through the re-stage pass — nothing committed, nothing pushed.
+        $g8Local = (git -C $V rev-parse HEAD).Trim()
+        $g8Bare = (git -C $bare rev-parse main).Trim()
+        $akp = 'AKIA'; $aks = '1234567890ABCDEF'
+        Set-Content -Path (Join-Path $V '30-Resources\leak.txt') -Value "leaky data   `naws_key = ""$akp$aks"""
+        Push-Location $V; & pwsh -NoProfile -File $autosync *> $null; Pop-Location
+        Assert 'G8 fixer-defect + secret (non-.md): blocked through retry (non-zero)' ($LASTEXITCODE -ne 0)
+        Assert 'G9 local HEAD unchanged (retry did not commit the secret)' (((git -C $V rev-parse HEAD).Trim()) -eq $g8Local)
+        Assert 'G10 bare remote unchanged (nothing pushed)' (((git -C $bare rev-parse main).Trim()) -eq $g8Bare)
     }
 }
 finally {

--- a/templates/luna-second-brain/scripts/test-vault-git.sh
+++ b/templates/luna-second-brain/scripts/test-vault-git.sh
@@ -234,6 +234,61 @@ else
       "$(yn "$([ "$(git_in "$VF" rev-parse HEAD)" != "$f_local_before" ] && echo 0 || echo 1)")"
     assert_eq "F3 remote unchanged (push refused, nothing leaked)" "$seed_before" "$(git_in "$SEED" rev-parse HEAD)"
   fi
+
+  # =========================================================================
+  # Phase G — auto-fixer resilience (HIMMEL-501: "autosync blocked so much").
+  # G1-G3: a churny .md note (Markdown hard-break = two trailing spaces, no
+  #        final newline) is committed UNMODIFIED — pre-commit no longer
+  #        rewrites prose, so the unattended commit isn't aborted and the
+  #        note's line breaks survive.
+  # G4-G7: a NON-.md file a fixer DOES rewrite still lands — the first commit
+  #        aborts when the hook modifies it, and autosync re-stages + retries
+  #        instead of skipping the push.
+  # =========================================================================
+  VG="$TMP/fixer"
+  make_vault "$VG"
+  run_setup "$VG"
+  if [ -f "$VG/.git/hooks/pre-commit" ]; then
+    BARE_G="$TMP/fixer-bare.git"
+    git init --bare -b main "$BARE_G" >/dev/null 2>&1
+    (cd "$VG" && git remote add origin "$BARE_G")
+    g_base=$(git_in "$VG" rev-list --count HEAD)
+
+    printf 'first line  \nsecond line' >"$VG/00-Inbox/md-fixer.md" # 2 trailing spaces + NO final newline
+    cp "$VG/00-Inbox/md-fixer.md" "$TMP/md-fixer.orig"
+    (cd "$VG" && LUNA_VAULT_AUTOSYNC=1 bash "$VG/scripts/vault-autosync.sh") >/dev/null 2>&1
+    assert_ok "G1 autosync with a churny .md note: exit 0 (not blocked)" "$?"
+    assert_eq "G2 autosync commit landed" "yes" \
+      "$(yn "$([ "$(git_in "$VG" rev-list --count HEAD)" -gt "$g_base" ] && echo 0 || echo 1)")"
+    cmp -s "$VG/00-Inbox/md-fixer.md" "$TMP/md-fixer.orig"
+    assert_ok "G3 .md left UNMODIFIED by pre-commit (hard-breaks + no-final-newline preserved)" "$?"
+
+    g2_base=$(git_in "$VG" rev-list --count HEAD)
+    printf 'data with trailing space   \n' >"$VG/00-Inbox/data.txt" # non-.md → a fixer WILL rewrite it
+    (cd "$VG" && LUNA_VAULT_AUTOSYNC=1 bash "$VG/scripts/vault-autosync.sh") >/dev/null 2>&1
+    assert_ok "G4 autosync recovers from a fixer-modified non-.md file: exit 0" "$?"
+    assert_eq "G5 retry committed after the fixer ran (HEAD advanced)" "yes" \
+      "$(yn "$([ "$(git_in "$VG" rev-list --count HEAD)" -gt "$g2_base" ] && echo 0 || echo 1)")"
+    assert_eq "G6 data.txt landed in the committed tree" "1" \
+      "$(git_in "$VG" ls-tree -r HEAD --name-only | grep -c 'data\.txt' || true)"
+    git_in "$BARE_G" rev-parse --verify main >/dev/null 2>&1
+    assert_ok "G7 fixer-retry result pushed to remote" "$?"
+
+    # G8-G10: the retry must NOT weaken the egress guard. A NON-.md file with
+    # BOTH a fixer defect (trailing whitespace) AND a planted secret: pass 1
+    # aborts, the re-stage pass re-runs gitleaks on the same secret, and the
+    # commit stays blocked — nothing committed, nothing pushed. (Key assembled
+    # at runtime so this test's source stays clean.)
+    g8_local_before=$(git_in "$VG" rev-parse HEAD)
+    g8_bare_before=$(git_in "$BARE_G" rev-parse main)
+    _akp="AKIA"
+    _aks="1234567890ABCDEF"
+    printf 'leaky data   \naws_key = "%s%s"\n' "$_akp" "$_aks" >"$VG/30-Resources/leak.txt"
+    (cd "$VG" && LUNA_VAULT_AUTOSYNC=1 bash "$VG/scripts/vault-autosync.sh") >/dev/null 2>&1
+    assert_nz "G8 fixer-defect + secret (non-.md): autosync blocked through the retry" "$?"
+    assert_eq "G9 local HEAD unchanged (retry did not commit the secret)" "$g8_local_before" "$(git_in "$VG" rev-parse HEAD)"
+    assert_eq "G10 bare remote unchanged (nothing pushed)" "$g8_bare_before" "$(git_in "$BARE_G" rev-parse main)"
+  fi
 fi
 
 echo ""

--- a/templates/luna-second-brain/scripts/vault-autosync.ps1
+++ b/templates/luna-second-brain/scripts/vault-autosync.ps1
@@ -64,17 +64,29 @@ if ($LASTEXITCODE -ne 0) {
 # Commit THROUGH pre-commit (NEVER --no-verify): the gitleaks/secret hooks are
 # the egress guard. A blocked commit exits non-zero, and the push below is gated
 # on this success, so nothing leaves.
+#
+# A pre-commit AUTO-FIXER (e.g. end-of-file-fixer on a stray non-.md file) may
+# modify a staged file, which aborts the commit and leaves the tree dirty — at a
+# glance indistinguishable from a real block. So retry ONCE: re-stage and commit
+# again. A genuine gitleaks/secret rejection survives both passes (gitleaks never
+# auto-fixes, so the second commit fails too) and still aborts the push.
 git commit -q -m "chore: vault autosync"
 if ($LASTEXITCODE -ne 0) {
-    # Distinguish a benign "nothing left to commit" (a pre-commit auto-fixer may
-    # have re-cleaned the tree) from a real block — a gitleaks/secret rejection
-    # or a hook that modified files leaves the tree dirty.
     if ([string]::IsNullOrWhiteSpace(((git status --porcelain) -join ''))) {
         Log "nothing to commit after hooks ran — no-op."
         exit 0
     }
-    Log "commit BLOCKED by pre-commit (secret detected, or a hook modified files) — NOT pushing."
-    exit 1
+    # A hook auto-fixed files — re-stage and retry once.
+    git add -A
+    git commit -q -m "chore: vault autosync"
+    if ($LASTEXITCODE -ne 0) {
+        if ([string]::IsNullOrWhiteSpace(((git status --porcelain) -join ''))) {
+            Log "nothing to commit after retry — no-op."
+            exit 0
+        }
+        Log "commit BLOCKED by pre-commit (secret detected, or a hook keeps modifying files) — NOT pushing."
+        exit 1
+    }
 }
 Log "committed."
 

--- a/templates/luna-second-brain/scripts/vault-autosync.sh
+++ b/templates/luna-second-brain/scripts/vault-autosync.sh
@@ -66,17 +66,29 @@ fi
 # Commit THROUGH pre-commit (NEVER --no-verify): the gitleaks/secret hooks are
 # the egress guard. A blocked commit (e.g. an API key slipped in) exits non-zero
 # here, and because the push below is gated on this success, nothing leaves.
-if ! git commit -q -m "chore: vault autosync"; then
-  # Distinguish a benign "nothing left to commit" (a pre-commit auto-fixer such
-  # as trailing-whitespace may have re-cleaned the tree) from a real block — a
-  # gitleaks/secret rejection or a hook that modified files leaves the tree
-  # dirty. Clean tree → no-op exit 0; dirty → something blocked → exit 1.
+#
+# A pre-commit AUTO-FIXER (e.g. end-of-file-fixer on a stray non-.md file) may
+# modify a staged file, which aborts the commit and leaves the tree dirty — at a
+# glance indistinguishable from a real block. So retry ONCE: re-stage the fixer's
+# changes and commit again. A genuine gitleaks/secret rejection survives both
+# passes (gitleaks never auto-fixes, so the second commit fails too) and still
+# aborts the push — the egress guard is fully preserved.
+_commit() { git commit -q -m "chore: vault autosync"; }
+if ! _commit; then
   if [ -z "$(git status --porcelain)" ]; then
     log "nothing to commit after hooks ran — no-op."
     exit 0
   fi
-  log "commit BLOCKED by pre-commit (secret detected, or a hook modified files) — NOT pushing." >&2
-  exit 1
+  # A hook auto-fixed files — re-stage and retry once.
+  git add -A
+  if ! _commit; then
+    if [ -z "$(git status --porcelain)" ]; then
+      log "nothing to commit after retry — no-op."
+      exit 0
+    fi
+    log "commit BLOCKED by pre-commit (secret detected, or a hook keeps modifying files) — NOT pushing." >&2
+    exit 1
+  fi
 fi
 log "committed."
 


### PR DESCRIPTION
## What & why

The luna-second-brain template's pre-commit + autosync had two coupled defects:

- **Resilience:** `vault-autosync.sh`/`.ps1` aborted the push whenever a pre-commit auto-fixer (`trailing-whitespace`/`end-of-file-fixer`) modified a staged file — i.e. on nearly every note save — because there was no re-stage/retry.
- **Correctness:** `trailing-whitespace` rewrote `.md` with no markdown guard, silently stripping Markdown hard-line-breaks (two trailing spaces) from notes.

## Fix

1. `.pre-commit-config.yaml`: `exclude: '\.md$'` on `trailing-whitespace` + `end-of-file-fixer` — pre-commit validates notes (gitleaks/check-* still scan `.md`) but never rewrites prose.
2. `vault-autosync.sh` + `.ps1`: a single re-stage-and-retry pass. A real gitleaks secret block survives both passes and still aborts the push — the egress guard is fully preserved.
3. `.vault-template.json`: `0.1.0 → 0.2.0`.

## Tests (Phase G, both `.sh` + `.ps1`, green on Windows)

- A churny `.md` note (hard-break + no final newline) is committed **unmodified**.
- A non-`.md` file a fixer rewrites still lands + pushes (retry recovers).
- A non-`.md` file with **both a fixer defect AND a planted key** stays blocked through the retry (HEAD + remote unchanged) — proves the retry doesn't weaken the egress guard.
