### PR TITLE
feat(codex): [HIMMEL-427] himmel guardrails fire+block under Codex

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,64 @@
+# `.codex/` — himmel guardrails under Codex (HIMMEL-427)
+
+Wires himmel's PreToolUse / PostToolUse / SessionStart / UserPromptSubmit
+guardrails so they fire when himmel runs under **Codex** (which implements a
+Claude-compatible hook engine). See `docs/internals/harness-compat.md` for the
+full compat matrix.
+
+## Files
+- **`hooks.json`** — the project hook config (Codex recognises a project
+  `.codex/hooks.json` layer). Every command invokes `run-hook.cmd <script.sh>`.
+  Kept to the strict schema (only a top-level `hooks` key — Codex's parser uses
+  `deny_unknown_fields`, so an extra key like `description`/`_comment` would make
+  it skip the hooks).
+- **`run-hook.cmd`** — a **polyglot** wrapper (cmd.exe batch on Windows, bash on
+  Unix) that fixes the three reasons the old hand-ported `.codex/hooks.json` did
+  **not** block on Windows under Codex:
+  1. **No `CLAUDE_PROJECT_DIR`.** Codex injects it only for *plugin* hooks, not
+     *project* hooks. The wrapper derives the repo root from its **own** location
+     (`.codex/..`) and exports `CLAUDE_PROJECT_DIR` for the guardrail scripts.
+  2. **Bare `bash` → WSL stub.** Via `cmd.exe`, bare `bash` resolves to
+     `C:\Windows\System32\bash.exe` (the WSL stub — can't read `C:\`, exit 127).
+     The wrapper finds **Git Bash** explicitly (`Program Files\Git`), and the
+     PATH fallback skips any `\System32\` bash.
+  3. **Exit 2 ≠ block under Codex.** himmel guardrails block by exiting 2 (Claude
+     convention), but Codex blocks a tool call only on a JSON
+     `permissionDecision:"deny"` on stdout — it ignores exit 2 (the tool would
+     proceed). The wrapper delegates to `codex-hook-adapter.sh` (below) to bridge
+     this.
+  After finding Git Bash, the wrapper execs the adapter and propagates its exit
+  code (`exit /b %ERRORLEVEL%` at top level — a bare `exit /b` inside a cmd
+  `if (...)` block returns 0, not the child's code). If **no Git Bash** is found
+  the wrapper **fails CLOSED** by emitting a JSON `deny` on stdout (an `exit 2`
+  would fail *open* under Codex) with a loud reason — Git Bash is a hard
+  dependency, so a missing-bash env is surfaced, never silently run unprotected.
+- **`codex-hook-adapter.sh`** — the exit-code→JSON-decision bridge. Runs the
+  named guardrail with the hook JSON on **stdin** (inherited untouched) and, when
+  it exits 2 (block), re-emits the block as Codex's JSON
+  `permissionDecision:"deny"` with the guardrail's stderr as the reason, exiting
+  0. All other outcomes pass through (stdout decisions forwarded, exit code
+  propagated). This keeps the guardrails single-sourced: they run verbatim under
+  Claude Code, which never invokes the adapter.
+
+## Tests
+- `scripts/hooks/test-codex-run-hook.sh` — the Unix (bash) branch.
+- `scripts/hooks/test-codex-run-hook.ps1` — the Windows (cmd.exe) branch.
+Both assert: `CLAUDE_PROJECT_DIR` derived+exported, stdin forwarded, a non-block
+exit code propagated, an **exit-2 block translated to a JSON `deny`** (stderr →
+reason), missing-name → rc 2.
+
+## Live-verified (codex-cli 0.141.0, Windows, HIMMEL-427)
+Confirmed against a real `codex exec` run: `.codex/hooks.json` parses (no
+`deny_unknown_fields` rejection), the guardrails **fire and block** —
+`block-read-secrets` denies a secret read (`PreToolUse Blocked`), and a benign
+command is allowed. The exit-2→`deny` translation in `codex-hook-adapter.sh` is
+what makes the block land (Codex ignores exit 2). Caveats observed live:
+- Codex runs hooks **inside the tool sandbox**; a `read-only` sandbox suppresses
+  their side effects, so the interactive default (`workspace-write`) or wider is
+  needed for them to act.
+- Run from a git **worktree**, Codex loads project hooks from the **main
+  checkout** (the worktree's `.git` is a file) — trust/edit hooks there.
+- New project hooks are trust-hashed on first use; interactive Codex prompts to
+  trust them once (non-interactive `codex exec` needs
+  `--dangerously-bypass-hook-trust`).
+See `docs/internals/harness-compat.md` §"Codex deep-dive → Hooks" for detail.

--- a/.codex/codex-hook-adapter.sh
+++ b/.codex/codex-hook-adapter.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Codex hook adapter (HIMMEL-427). Bridges himmel's exit-code block convention to
+# Codex's JSON decision convention.
+#
+# himmel guardrails signal a BLOCK by exiting 2 (Claude Code's convention: exit 2
+# = deny, stderr shown to the model). Codex's hook engine does NOT act on exit 2
+# — it blocks a tool call ONLY when a hook prints a JSON
+#   {"hookSpecificOutput":{"hookEventName":"<ev>","permissionDecision":"deny",...}}
+# on stdout. A guardrail (or this adapter) that merely exits 2/non-zero is
+# reported by Codex as a failed (non-blocking) hook and the tool call PROCEEDS.
+# (Verified against codex-cli 0.141.0: `exit 2` -> "PreToolUse Failed", command
+# runs; deny-JSON -> "PreToolUse Blocked".)
+#
+# CONSEQUENCE: every path that must block has to speak the deny JSON, not an exit
+# code. So the adapter translates a guardrail's exit-2 block into the JSON deny,
+# AND fails CLOSED (same JSON deny) on its OWN precondition errors (missing script
+# name, unset CLAUDE_PROJECT_DIR, missing guardrail file) — a bare `exit 2` there
+# would fail OPEN under Codex. Every other guardrail outcome passes through
+# unchanged, so the guardrails stay single-sourced and keep working verbatim under
+# Claude Code (which never invokes this adapter — only .codex/hooks.json does).
+set -u
+
+# emit_deny <reason> [event] — print Codex's JSON deny on stdout and exit 0 (fail
+# closed). `event` is whitelisted to the block-capable events; anything else (or
+# absent) defaults to PreToolUse, the event all himmel blockers use.
+emit_deny() {
+  local r="$1" ev="${2:-PreToolUse}"
+  case "$ev" in PreToolUse|PermissionRequest) ;; *) ev="PreToolUse" ;; esac
+  if command -v jq >/dev/null 2>&1; then
+    jq -cn --arg ev "$ev" --arg r "$r" \
+      '{hookSpecificOutput:{hookEventName:$ev,permissionDecision:"deny",permissionDecisionReason:$r}}'
+  else
+    # jq is a hard dependency of the guardrails; this path is only reached if jq
+    # vanished mid-run. Emit a minimal static deny (no untrusted interpolation).
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"blocked fail-closed (jq unavailable to format reason)"}}\n'
+  fi
+  exit 0
+}
+
+name="${1:-}"
+[ -n "$name" ] || emit_deny "codex-hook-adapter: missing script name — fail closed"
+# run-hook.cmd's cmd.exe branch exports CLAUDE_PROJECT_DIR with backslashes;
+# normalise a copy to forward slashes so the guardrail path resolves under Git
+# Bash. The bash branch already exports a forward-slash path (no-op here).
+[ -n "${CLAUDE_PROJECT_DIR:-}" ] || emit_deny "codex-hook-adapter: CLAUDE_PROJECT_DIR unset — fail closed"
+proj="${CLAUDE_PROJECT_DIR//\\//}"
+script="$proj/scripts/hooks/$name"
+# A missing guardrail (typo in hooks.json, or referenced before it's ported) must
+# fail CLOSED, not silently let the tool through.
+[ -f "$script" ] || emit_deny "codex-hook-adapter: guardrail '$name' not found at $script — fail closed"
+
+input="$(cat)"
+
+# Run the guardrail with the hook JSON on stdin. Capture its STDERR into a var
+# while its STDOUT (e.g. an auto-approve decision) passes straight through to the
+# real stdout (fd 3). No temp files: Codex runs hooks inside the tool sandbox
+# where $TMPDIR/`/tmp` may be unwritable. The trailing EXIT: marker carries the
+# guardrail's real exit code (PIPESTATUS[1]) out of the command substitution; it
+# is a separate command in the { …; …; } group so it ALWAYS runs (code is never
+# empty), and being appended last it survives a guardrail stderr that itself
+# contains "EXIT:" (the greedy ## / shortest % both resolve to the final marker).
+exec 3>&1
+captured="$( { printf '%s' "$input" | bash "$script" 2>&1 1>&3; printf 'EXIT:%s' "${PIPESTATUS[1]}"; } )"
+exec 3>&-
+code="${captured##*EXIT:}"
+reason="${captured%EXIT:*}"
+reason="${reason%$'\n'}"; reason="${reason%$'\r'}"   # drop the guardrail's trailing CR/LF
+
+if [ "$code" = "2" ]; then
+  # Block: translate to Codex's JSON deny. hookEventName mirrors the inbound event.
+  ev="$(printf '%s' "$input" | jq -r '.hook_event_name // "PreToolUse"' 2>/dev/null || echo PreToolUse)"
+  emit_deny "$reason" "$ev"
+fi
+
+# Non-block: surface the guardrail's stderr (advisory) and propagate its code.
+[ -n "$reason" ] && printf '%s' "$reason" >&2
+exit "${code:-0}"

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,59 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": ".codex/run-hook.cmd auto-approve-safe-bash.sh" },
+          { "type": "command", "command": ".codex/run-hook.cmd check-cr-marker-on-pr-create.sh" }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          { "type": "command", "command": ".codex/run-hook.cmd block-edit-on-main.sh" }
+        ]
+      },
+      {
+        "matcher": "Bash|PowerShell|Read|Grep",
+        "hooks": [
+          { "type": "command", "command": ".codex/run-hook.cmd block-read-secrets.sh" }
+        ]
+      },
+      {
+        "matcher": "mcp__plugin_atlassian_atlassian__.*",
+        "hooks": [
+          { "type": "command", "command": ".codex/run-hook.cmd block-backend-tier.sh" }
+        ]
+      },
+      {
+        "matcher": ".*",
+        "hooks": [
+          { "type": "command", "command": ".codex/run-hook.cmd auto-arm-on-cap.sh" }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          { "type": "command", "command": ".codex/run-hook.cmd auto-arm-on-subagent-cap.sh" }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": ".codex/run-hook.cmd check-update-available.sh", "timeout": 15 }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": ".codex/run-hook.cmd improve-on-submit.sh" }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/run-hook.cmd
+++ b/.codex/run-hook.cmd
@@ -1,0 +1,58 @@
+: << 'CMDBLOCK'
+@echo off
+REM himmel Codex hook wrapper (HIMMEL-427). Polyglot: cmd.exe runs the batch
+REM part on Windows; bash interprets the part after CMDBLOCK on Unix (`:` is a
+REM no-op and `<< 'CMDBLOCK'` swallows the batch lines as a heredoc).
+REM
+REM Fixes the reasons himmel's PreToolUse guardrails don't fire/block under Codex:
+REM   (1) Codex injects NO CLAUDE_PROJECT_DIR for *project* hooks -> derive the
+REM       repo root from this wrapper's own location (.codex\.. ) and export it.
+REM   (2) bare `bash` via cmd.exe hits the WSL System32\bash.exe stub (can't read
+REM       C:\, exit 127) -> find Git Bash explicitly; skip any System32 bash.
+REM   (3) himmel guardrails BLOCK by exiting 2 (Claude convention); Codex ignores
+REM       exit 2 and blocks only on a JSON permissionDecision:"deny" on stdout ->
+REM       both branches delegate to codex-hook-adapter.sh, which runs the guardrail
+REM       and translates an exit-2 block into the JSON deny Codex understands.
+REM
+REM The adapter exits 0 after emitting a deny (the block now lives in its stdout
+REM JSON, not the exit code), so propagating its code with `exit /b %ERRORLEVEL%`
+REM at TOP LEVEL is still correct (a bare `exit /b` inside an if-(...) block
+REM returns 0, not the child's code). Guardrails read the hook JSON from STDIN
+REM (inherited); the wrapper forwards no positional args to them.
+REM
+REM Usage (from .codex/hooks.json): run-hook.cmd <script-name.sh>
+REM Missing script name -> fail CLOSED with a JSON deny on stdout (exit /b 2 would
+REM fail OPEN under Codex), mirroring the no-Git-Bash branch below.
+if "%~1"=="" (
+  echo {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"run-hook.cmd: missing script name - fail closed"}}
+  exit /b 0
+)
+set "HOOK_DIR=%~dp0"
+for %%I in ("%HOOK_DIR%..") do set "CLAUDE_PROJECT_DIR=%%~fI"
+set "ADAPTER=%CLAUDE_PROJECT_DIR%\.codex\codex-hook-adapter.sh"
+set "BASH="
+if exist "C:\Program Files\Git\bin\bash.exe" set "BASH=C:\Program Files\Git\bin\bash.exe"
+if not defined BASH if exist "C:\Program Files (x86)\Git\bin\bash.exe" set "BASH=C:\Program Files (x86)\Git\bin\bash.exe"
+if not defined BASH for /f "delims=" %%B in ('where bash 2^>nul') do echo %%B| find /i "\System32\" >nul || if not defined BASH set "BASH=%%B"
+REM No Git Bash -> FAIL CLOSED. himmel guardrails are fail-closed and Git Bash is a
+REM hard dependency; a missing-bash env is misconfigured and must be surfaced
+REM loudly, never silently run unprotected. Emit Codex's JSON deny on stdout (exit
+REM 2 would fail OPEN under Codex), and exit 0 so the deny decision is honored.
+if not defined BASH (
+  echo {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"run-hook.cmd: no Git Bash found (install Git for Windows); blocking %~1 fail-closed"}}
+  exit /b 0
+)
+"%BASH%" "%ADAPTER%" "%~1"
+exit /b %ERRORLEVEL%
+CMDBLOCK
+
+# --- Unix (bash) ------------------------------------------------------------
+# `:`/heredoc above hid the batch lines from bash; resolve + run the adapter,
+# which runs the guardrail and translates an exit-2 block into Codex's JSON deny.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLAUDE_PROJECT_DIR="$(cd "$HOOK_DIR/.." && pwd)"
+export CLAUDE_PROJECT_DIR
+# Guardrails read the hook JSON from stdin (inherited); no positional args
+# forwarded. A missing script name is handled by the adapter (fail-closed JSON
+# deny), so it is passed straight through rather than gated with a bare exit 2.
+exec bash "$CLAUDE_PROJECT_DIR/.codex/codex-hook-adapter.sh" "${1:-}"

--- a/.gitignore
+++ b/.gitignore
@@ -41,10 +41,15 @@ logs/gemini/
 # Mode A (no HANDOVER_DIR) regenerates plans under docs/superpowers/plans/ —
 # keep those local, never re-track the folder into the public repo.
 /docs/superpowers/
-# Codex auto-generated artifacts (deferred until codex is wired up — HIMMEL-427).
-# AGENTS.md itself IS tracked (thin pointer to CLAUDE.md); only codex's local
-# runtime config + its auto-generated slash-command→skill mirrors are ignored.
-.codex/
+# Codex artifacts (HIMMEL-427: codex IS now wired). The guardrail wiring is
+# TRACKED (hooks.json + the run-hook.cmd polyglot + its README); codex's local
+# runtime config, sessions, and auto-generated slash-command→skill mirrors stay
+# ignored. (AGENTS.md itself is tracked separately.)
+.codex/*
+!.codex/hooks.json
+!.codex/run-hook.cmd
+!.codex/codex-hook-adapter.sh
+!.codex/README.md
 .agents/skills/source-command-*/
 # himmel-contributor marker (opt-in; enables doc-guard gate) — never commit it
 .himmel-dev

--- a/docs/internals/harness-compat.md
+++ b/docs/internals/harness-compat.md
@@ -23,7 +23,7 @@ to **other coding harnesses** — Codex first — so an operator can decide what
 
 | Surface | Claude Code | Codex | Cursor | Copilot CLI | Gemini CLI |
 |---|---|---|---|---|---|
-| **PreToolUse guardrail hooks** | native | ✅ Claude-compatible engine (`ClaudeHooksEngine`); same stdin/decision contract | ✅ `.cursor/hooks.json`; events **camelCase** (`preToolUse`, `beforeShellExecution`); **fails OPEN** unless `failClosed:true` | ✅ `.github/hooks/*.json`; camel/Pascal; **fails CLOSED**; ⚠️ headless `-p` disables repo hooks unless `GITHUB_COPILOT_PROMPT_MODE_REPO_HOOKS=true` | ✅ `.gemini/settings.json` `hooks`; events **PascalCase** (`BeforeTool`); stdin JSON |
+| **PreToolUse guardrail hooks** | native | ✅ Claude-compatible engine (`ClaudeHooksEngine`); same stdin schema, but blocks via JSON `permissionDecision:"deny"` **not exit 2** — himmel bridges via `.codex/run-hook.cmd`→`codex-hook-adapter.sh` (HIMMEL-427, live-verified) | ✅ `.cursor/hooks.json`; events **camelCase** (`preToolUse`, `beforeShellExecution`); **fails OPEN** unless `failClosed:true` | ✅ `.github/hooks/*.json`; camel/Pascal; **fails CLOSED**; ⚠️ headless `-p` disables repo hooks unless `GITHUB_COPILOT_PROMPT_MODE_REPO_HOOKS=true` | ✅ `.gemini/settings.json` `hooks`; events **PascalCase** (`BeforeTool`); stdin JSON |
 | **pre-commit / pre-push git gates** | ✅ | ✅ harness-independent (git runs them) | ✅ | ✅ | ✅ |
 | **Plugins / marketplace** | native | ✅ marketplaces + `@himmel` plugins load (`config.toml`) | ✅ marketplace exists (`.cursor-plugin/plugin.json`) — *corrects "no marketplace"* | ✅ `marketplace.json` registries (`copilot plugin marketplace add`) | ✅ "extensions" gallery (`gemini-extension.json`) |
 | **Skills** | native | ✅ native skill loading | ✅ `SKILL.md`; reads `.cursor/skills` **+ `.claude/skills` + `.codex/skills`** | ✅ `SKILL.md`; reads `.github/skills` **+ `.claude/skills`** | ✅ `SKILL.md` (gemini-native); `.gemini/skills/` |
@@ -61,7 +61,7 @@ leave them low-priority until there's demand.
 
 ## Codex deep-dive
 
-### 1. Hooks — Claude-compatible, with a Windows wiring bug
+### 1. Hooks — Claude-compatible; Windows wiring + block-decision fixed (HIMMEL-427)
 
 Codex implements a hook engine literally named `ClaudeHooksEngine`. The
 PreToolUse contract mirrors Claude Code's:
@@ -83,26 +83,50 @@ PreToolUse contract mirrors Claude Code's:
   inject a project-dir var for project hooks — `cwd` arrives via stdin JSON.
 - **execution:** commands run via `cmd.exe` (Windows) / `/bin/sh` (Unix).
 
-**The bug.** himmel's (untracked) repo `.codex/hooks.json` was hand-ported from
-`.claude/settings.json` and uses `bash $CLAUDE_PROJECT_DIR/scripts/hooks/…`. Two
-failure modes on Windows under Codex:
-1. `$CLAUDE_PROJECT_DIR` is **unset** for project hooks → the path resolves to
-   `/scripts/hooks/…` (broken).
-2. Bare `bash` via `cmd.exe` hits the **WSL `System32\bash.exe` stub trap** →
-   can't read `C:/`, exit 127.
+**The bugs (3 — the third found only by live verification).** himmel's original
+hand-ported `.codex/hooks.json` used `bash $CLAUDE_PROJECT_DIR/scripts/hooks/…`,
+which fails on Windows under Codex because (1) `$CLAUDE_PROJECT_DIR` is **unset**
+for project hooks → path resolves to `/scripts/hooks/…`; and (2) bare `bash` via
+`cmd.exe` hits the **WSL `System32\bash.exe` stub trap** (can't read `C:/`, exit
+127). A live `codex exec` run (codex-cli **0.141.0**, 2026-06-21) surfaced a
+third, deeper one: (3) himmel guardrails signal a block by **exiting 2** (Claude
+convention), but **Codex does not act on exit 2** — it blocks a tool call ONLY
+on a JSON `{"hookSpecificOutput":{"permissionDecision":"deny",…}}` on stdout. A
+guardrail that merely exits 2 is reported as a *failed (non-blocking)* hook and
+**the tool call proceeds**. So even with the path bugs fixed, the guardrails
+would *fire but never block*.
 
-So himmel's PreToolUse guardrails almost certainly **do not fire** under Codex
-today, despite being registered.
+**The fix (HIMMEL-427, shipped + live-verified).** Tracked `.codex/hooks.json`
+routes every hook through a polyglot wrapper `.codex/run-hook.cmd` (cmd.exe on
+Windows / bash on Unix) that derives + exports `CLAUDE_PROJECT_DIR` from its own
+location and finds Git Bash explicitly (skipping the System32 stub). The wrapper
+delegates to `.codex/codex-hook-adapter.sh`, which runs the guardrail and, on
+exit 2, re-emits the block as Codex's JSON `permissionDecision:"deny"` (the
+guardrail's stderr → reason) and exits 0; all other outcomes pass through. The
+guardrails stay single-sourced — they keep working verbatim under Claude Code,
+which never invokes the adapter (only `.codex/hooks.json` does). Verified live
+against codex-cli 0.141.0: a secret read (`block-read-secrets`) is **Blocked**;
+a benign command is allowed. Unit-tested both polyglot branches +
+exit-2→deny translation (`scripts/hooks/test-codex-run-hook.{sh,ps1}`).
 
-**Fix paths** (HIMMEL-427 follow-on):
-- **Preferred — plugin delivery.** Ship the guardrails through the `himmel-ops`
-  plugin (it already ships a `hooks.json`). Codex injects `CLAUDE_PLUGIN_ROOT`
-  for plugin hooks, so `${CLAUDE_PLUGIN_ROOT}/…` resolves. Add a
-  `hooks-codex.json` variant if the Claude/Codex shapes ever diverge (superpowers
-  ships one).
-- **Or — harden the project file.** Mirror superpowers' `run-hook.cmd` polyglot
-  (finds Git Bash explicitly; avoids the WSL stub) and derive the project dir
-  from stdin `cwd` instead of `$CLAUDE_PROJECT_DIR`.
+**Live-verification caveats (codex-cli 0.141.0, Windows):**
+- Codex runs each hook **inside the tool's sandbox**. Under `-s read-only` the
+  hooks' side effects are suppressed; a writable sandbox (the interactive
+  default `workspace-write`) is needed for them to act. The adapter writes **no
+  temp files** for this reason.
+- Run from a git **worktree**, Codex resolves the project root to the **main
+  checkout** (the worktree's `.git` is a file, not a dir) and loads *its*
+  `.codex/hooks.json` — so the live hook config is the main checkout's, not the
+  worktree's. Edit/trust hooks in the primary checkout.
+- New project hooks are **trust-hashed on first use**; non-interactive
+  `codex exec` needs `--dangerously-bypass-hook-trust` to run not-yet-trusted
+  hooks (interactive Codex prompts to trust them once).
+
+**Alternative considered — plugin delivery.** Shipping via the `himmel-ops`
+plugin (Codex injects `CLAUDE_PLUGIN_ROOT` for plugin hooks) would fix the *path*
+bugs but **not** the exit-2-vs-JSON one — the adapter translation is required
+regardless of delivery mechanism. Project-file delivery + adapter was chosen as
+the smaller change.
 
 ### 2. Instruction file — CLAUDE.md is invisible; AGENTS.md must carry the rules
 

--- a/scripts/hooks/test-codex-run-hook.ps1
+++ b/scripts/hooks/test-codex-run-hook.ps1
@@ -1,0 +1,79 @@
+# Unit test for .codex/run-hook.cmd + .codex/codex-hook-adapter.sh — the Codex
+# hook wrapper + decision adapter (HIMMEL-427). Tests the WINDOWS (cmd.exe)
+# branch of the polyglot on its native interpreter (cmd.exe via PowerShell). The
+# Unix/bash branch is covered by the .sh twin. Mirrors the .sh assertions:
+# CLAUDE_PROJECT_DIR derived+exported, stdin forwarded, a non-block exit code
+# PROPAGATES, and an exit-2 block is translated to Codex's JSON deny on stdout.
+
+$ErrorActionPreference = 'Continue'
+$HOOKS   = $PSScriptRoot
+$WRAPPER = Join-Path $HOOKS '..' | Join-Path -ChildPath '..' | Join-Path -ChildPath '.codex' | Join-Path -ChildPath 'run-hook.cmd'
+$ADAPTER = Join-Path $HOOKS '..' | Join-Path -ChildPath '..' | Join-Path -ChildPath '.codex' | Join-Path -ChildPath 'codex-hook-adapter.sh'
+
+$script:failures = 0
+function Check([string]$name, [bool]$cond) {
+    if ($cond) { Write-Host "  ok   $name" } else { Write-Host "  FAIL $name"; $script:failures++ }
+}
+
+if (-not (Test-Path -LiteralPath $WRAPPER)) { Write-Host "wrapper not found: $WRAPPER"; exit 1 }
+if (-not (Test-Path -LiteralPath $ADAPTER)) { Write-Host "adapter not found: $ADAPTER"; exit 1 }
+
+$T = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Path (Join-Path $T '.codex') -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $T 'scripts\hooks') -Force | Out-Null
+Copy-Item -LiteralPath $WRAPPER -Destination (Join-Path $T '.codex\run-hook.cmd')
+Copy-Item -LiteralPath $ADAPTER -Destination (Join-Path $T '.codex\codex-hook-adapter.sh')
+# Guardrails (LF-only so Git Bash runs them cleanly).
+$dummy = "read -r line || true`necho `"PROJDIR=[`$CLAUDE_PROJECT_DIR]`"`necho `"STDIN=[`$line]`"`nexit 7`n"
+[System.IO.File]::WriteAllText((Join-Path $T 'scripts\hooks\dummy.sh'), $dummy)
+$blocker = "read -r line || true`necho `"blocking-reason-xyz`" >&2`nexit 2`n"
+[System.IO.File]::WriteAllText((Join-Path $T 'scripts\hooks\blocker.sh'), $blocker)
+
+try {
+    # 1) ALLOW path: non-block exit code propagates; env + stdin forwarded.
+    Push-Location $T
+    $out = ('fromstdin' | & cmd.exe /c '.codex\run-hook.cmd' dummy.sh 2>&1 | Out-String)
+    $rc = $LASTEXITCODE
+    Pop-Location
+
+    Check "non-block exit code propagates (rc=7)" ($rc -eq 7)
+    $expected = (Resolve-Path -LiteralPath $T).Path
+    Check "CLAUDE_PROJECT_DIR derived from wrapper location + exported" ($out -match [regex]::Escape("PROJDIR=[$expected]"))
+    # Match the prefix only — PowerShell pipes CRLF, so `read -r` may keep a
+    # trailing \r inside the brackets; stdin forwarding is what we're asserting.
+    Check "stdin forwarded to the guardrail" ($out -match 'STDIN=\[fromstdin')
+
+    # 2) BLOCK path: exit 2 -> Codex JSON deny on stdout, wrapper exits 0. Use a
+    #    DISTINCT inbound event so the hookEventName mirror is load-bearing and the
+    #    non-PreToolUse path is covered.
+    Push-Location $T
+    $bout = ('{"hook_event_name":"PermissionRequest"}' | & cmd.exe /c '.codex\run-hook.cmd' blocker.sh 2>&1 | Out-String)
+    $brc = $LASTEXITCODE
+    Pop-Location
+
+    Check "block -> wrapper exits 0 (decision is in stdout JSON)" ($brc -eq 0)
+    Check "block -> emits permissionDecision deny" ($bout -match '"permissionDecision":"deny"')
+    Check "block -> guardrail stderr becomes the deny reason" ($bout -match 'blocking-reason-xyz')
+    Check "block -> hookEventName mirrors the inbound event" ($bout -match '"hookEventName":"PermissionRequest"')
+
+    # 3) FAIL-CLOSED paths: a bare exit 2 fails OPEN under Codex, so precondition
+    #    errors must emit a JSON deny (rc 0) instead.
+    # 3a) Missing script name -> fail-closed deny (rc 0).
+    Push-Location $T
+    $nout = ('' | & cmd.exe /c '.codex\run-hook.cmd' 2>&1 | Out-String)
+    $rc2 = $LASTEXITCODE
+    Pop-Location
+    Check "missing script name -> fail-closed deny (rc 0)" (($rc2 -eq 0) -and ($nout -match '"permissionDecision":"deny"'))
+    # 3b) Referenced guardrail file does not exist -> fail-closed deny (rc 0).
+    Push-Location $T
+    $gout = ('{}' | & cmd.exe /c '.codex\run-hook.cmd' nonexistent-guardrail.sh 2>&1 | Out-String)
+    $rc3 = $LASTEXITCODE
+    Pop-Location
+    Check "missing guardrail file -> fail-closed deny (rc 0)" (($rc3 -eq 0) -and ($gout -match '"permissionDecision":"deny"'))
+}
+finally {
+    Remove-Item -Recurse -Force -LiteralPath $T -ErrorAction SilentlyContinue
+}
+
+if ($script:failures -eq 0) { Write-Host 'OK: all cases passed'; exit 0 }
+else { Write-Host "FAIL: $($script:failures) case(s) failed"; exit 1 }

--- a/scripts/hooks/test-codex-run-hook.sh
+++ b/scripts/hooks/test-codex-run-hook.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Unit test for .codex/run-hook.cmd + .codex/codex-hook-adapter.sh — the Codex
+# hook wrapper + decision adapter (HIMMEL-427). Tests the UNIX (bash) branch of
+# the polyglot. The Windows (cmd.exe) branch is tested by the .ps1 twin.
+#
+# Sets up an ISOLATED temp tree (<T>/.codex/{run-hook.cmd,codex-hook-adapter.sh}
+# + <T>/scripts/hooks/...) so the test proves the wrapper derives the repo root
+# from its OWN location, independent of the real repo.
+set -uo pipefail
+HOOKS="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER="$HOOKS/../../.codex/run-hook.cmd"
+ADAPTER="$HOOKS/../../.codex/codex-hook-adapter.sh"
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf '  FAIL %s\n' "$1"; }
+
+[ -f "$WRAPPER" ] || { echo "wrapper not found: $WRAPPER" >&2; exit 1; }
+[ -f "$ADAPTER" ] || { echo "adapter not found: $ADAPTER" >&2; exit 1; }
+
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+mkdir -p "$T/.codex" "$T/scripts/hooks"
+cp "$WRAPPER" "$T/.codex/run-hook.cmd"
+cp "$ADAPTER" "$T/.codex/codex-hook-adapter.sh"
+# Canonical temp root (bash resolves symlinks via cd+pwd, mktemp may not).
+TC="$(cd "$T" && pwd)"
+
+# 1) ALLOW path: a guardrail that exits non-2 passes through unchanged — stdout,
+#    a distinctive exit code, CLAUDE_PROJECT_DIR export, and stdin forwarding.
+cat > "$T/scripts/hooks/dummy.sh" <<'EOF'
+read -r line || true
+echo "PROJDIR=[$CLAUDE_PROJECT_DIR]"
+echo "STDIN=[$line]"
+exit 7
+EOF
+out="$(printf 'fromstdin\n' | bash "$T/.codex/run-hook.cmd" dummy.sh)"; rc=$?
+if [ "$rc" -eq 7 ]; then ok "non-block exit code propagates (rc=7)"; else bad "non-block exit code propagates (rc=$rc, want 7)"; fi
+case "$out" in
+  *"PROJDIR=[$TC]"*) ok "CLAUDE_PROJECT_DIR derived from wrapper location + exported";;
+  *) bad "CLAUDE_PROJECT_DIR derived ($out)";;
+esac
+case "$out" in
+  *"STDIN=[fromstdin]"*) ok "stdin forwarded to the guardrail";;
+  *) bad "stdin forwarded ($out)";;
+esac
+
+# 2) BLOCK path: a guardrail that exits 2 is translated to Codex's JSON deny on
+#    stdout (stderr -> reason) and the wrapper exits 0 (the block lives in the
+#    JSON, not the exit code — Codex ignores exit 2). Use a DISTINCT inbound event
+#    (PermissionRequest, not the PreToolUse default) so the hookEventName mirror
+#    is load-bearing AND the non-PreToolUse path is covered.
+cat > "$T/scripts/hooks/blocker.sh" <<'EOF'
+read -r line || true
+echo "blocking-reason-xyz" >&2
+exit 2
+EOF
+bout="$(printf '{"hook_event_name":"PermissionRequest"}\n' | bash "$T/.codex/run-hook.cmd" blocker.sh)"; brc=$?
+if [ "$brc" -eq 0 ]; then ok "block -> wrapper exits 0 (decision is in stdout JSON)"; else bad "block -> wrapper exits 0 (got $brc)"; fi
+case "$bout" in
+  *'"permissionDecision":"deny"'*) ok "block -> emits permissionDecision deny";;
+  *) bad "block -> emits permissionDecision deny ($bout)";;
+esac
+case "$bout" in
+  *"blocking-reason-xyz"*) ok "block -> guardrail stderr becomes the deny reason";;
+  *) bad "block -> guardrail stderr becomes the deny reason ($bout)";;
+esac
+case "$bout" in
+  *'"hookEventName":"PermissionRequest"'*) ok "block -> hookEventName mirrors the inbound event";;
+  *) bad "block -> hookEventName mirrors the inbound event ($bout)";;
+esac
+
+# 3) FAIL-CLOSED paths: under Codex a bare exit 2 fails OPEN, so the adapter must
+#    emit a JSON deny (exit 0) on its own precondition errors, not just on a
+#    guardrail block.
+# 3a) Missing script name -> fail closed (deny, rc 0), not a non-blocking error.
+nout="$(printf '' | bash "$T/.codex/run-hook.cmd" 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$nout" | grep -q '"permissionDecision":"deny"'; then
+  ok "missing script name -> fail-closed deny (rc 0)"
+else bad "missing script name -> fail-closed deny (rc=$rc, out=$nout)"; fi
+# 3b) Referenced guardrail file does not exist -> fail closed (deny, rc 0).
+gout="$(printf '{}' | bash "$T/.codex/run-hook.cmd" nonexistent-guardrail.sh 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$gout" | grep -q '"permissionDecision":"deny"'; then
+  ok "missing guardrail file -> fail-closed deny (rc 0)"
+else bad "missing guardrail file -> fail-closed deny (rc=$rc, out=$gout)"; fi
+# 3c) Adapter invoked with CLAUDE_PROJECT_DIR unset -> fail closed (deny, rc 0).
+#     (The wrapper always exports it; this locks the adapter's own guard.)
+uout="$(printf '{}' | env -u CLAUDE_PROJECT_DIR bash "$T/.codex/codex-hook-adapter.sh" somehook.sh 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$uout" | grep -q '"permissionDecision":"deny"'; then
+  ok "unset CLAUDE_PROJECT_DIR -> fail-closed deny (rc 0)"
+else bad "unset CLAUDE_PROJECT_DIR -> fail-closed deny (rc=$rc, out=$uout)"; fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Makes himmel PreToolUse guardrails block under Codex. Codex ignores exit 2 and blocks only on JSON permissionDecision:deny — adds .codex/hooks.json + run-hook.cmd polyglot + codex-hook-adapter.sh (exit-2 to JSON-deny). Verified live vs codex-cli 0.141.0; tests 10/10 bash + 9/9 pwsh.