### PR TITLE
feat(hooks): [HIMMEL-507] block feature-branch edits in the primary checkout

### DIFF
--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -164,15 +164,25 @@ Spec: `scripts/hooks/test-auto-approve-safe-bash.sh`.
 
 ### `block-edit-on-main.sh` — pre-edit guard
 
-Fires on Edit/Write/MultiEdit/NotebookEdit. Refuses any edit targeting
-the primary worktree while HEAD == main. Paths are canonicalised via
-`realpath -m` first, so `..` traversal and symlink tricks cannot
-bypass. `handovers/**` is exempt. Bypass: `EDIT_ON_MAIN_OK=1`. Per-repo opt-out:
-place a local `.single-writer` file at the repo root (gitignored via global
-excludes — never committed, so clones stay protected by default); the hook
-allows all on-main edits in that repo and skips the block entirely. Anchored
-to the edited file's repo (`repo_real`), so a marker in a parent repo cannot
-leak the opt-out onto a nested repo.
+Fires on Edit/Write/MultiEdit/NotebookEdit. Refuses any edit targeting the
+**primary checkout** of a repo — forcing all feature work into a worktree.
+Two block cases: (1) the repo is on `main`/`master` (the original case), and
+(2) **HIMMEL-507** — the repo is on a feature branch but the edit lands in the
+primary checkout rather than a linked worktree. The structural signal for
+"primary checkout vs worktree" is the `.git` entry: a normal checkout has a
+`.git` **directory**, a linked worktree (and a submodule) has a `.git`
+**file**. So an edit inside a `.claude/worktrees/…` linked worktree on a
+feature branch is always allowed — that is where feature work belongs — while
+the *same* feature branch checked out in the primary tree is blocked. This
+closes the gap where an autonomous session did feature work on a PR branch in
+the primary checkout instead of isolating it in a worktree. Paths are
+canonicalised via `realpath -m` first, so `..` traversal and symlink tricks
+cannot bypass. `handovers/**` is exempt. Bypass: `EDIT_ON_MAIN_OK=1` (covers
+both block cases). Per-repo opt-out: place a local `.single-writer` file at the
+repo root (gitignored via global excludes — never committed, so clones stay
+protected by default); the hook then allows edits in that repo (both cases) and
+skips the block entirely. Anchored to the edited file's repo (`repo_real`), so
+a marker in a parent repo cannot leak the opt-out onto a nested repo.
 
 Dependencies: `jq` plus either GNU `realpath -m` (Linux native; Git
 Bash on Windows includes it) or `python3` (macOS default — uses

--- a/scripts/hooks/block-edit-on-main.sh
+++ b/scripts/hooks/block-edit-on-main.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 # PreToolUse hook for Edit/Write/MultiEdit/NotebookEdit.
 #
-# Blocks edits whose target FILE lives in a git repo that is currently on
-# main/master, forcing all feature work into a worktree per CLAUDE.md ("All
-# feature work in git worktrees. Never commit directly to main.").
+# Blocks edits whose target FILE lives in the PRIMARY checkout of a git repo,
+# forcing all feature work into a worktree per CLAUDE.md ("All feature work in
+# git worktrees. Never commit directly to main."). Two block cases:
+#   - the repo is on main/master (the original case), OR
+#   - the repo is on a feature branch but is the PRIMARY checkout, NOT a linked
+#     worktree (HIMMEL-507 — closes the gap where feature work happened on a
+#     branch checked out in the primary tree instead of an isolated worktree).
+# A linked worktree carries its own `.git` FILE (vs the primary checkout's
+# `.git` DIRECTORY); edits inside one are always allowed — that is the intended
+# place for feature work.
 #
 # The repo is resolved from the EDITED FILE's path (walking up its own ancestors
 # for a `.git`), NOT from CLAUDE_PROJECT_DIR / the launch dir. That way it still
@@ -176,10 +183,11 @@ case "$file_real" in
 esac
 
 # No explicit `.claude/worktrees/` skip is needed: a git worktree carries its
-# own `.git` file, so the walk above resolves repo_real to the worktree dir
-# (checked out on a feature branch) and the branch check below ALLOWS the edit
-# via rc=1. The old launch-dir-anchored worktrees skip was itself part of the
-# Himmel#45 mis-anchoring.
+# own `.git` FILE, so the walk above resolves repo_real to the worktree dir,
+# and the branch check below ALLOWS the edit at the `.git`-is-not-a-directory
+# test (a feature branch in the PRIMARY checkout, whose `.git` is a directory,
+# is blocked instead — HIMMEL-507). The old launch-dir-anchored worktrees skip
+# was itself part of the Himmel#45 mis-anchoring.
 
 # Check the branch of the FILE's repo. rc=2 (branch unreadable — e.g. a repo
 # with a corrupt/removed HEAD) fails CLOSED to match this script's security
@@ -190,17 +198,38 @@ esac
 # error: No stderr output" (HIMMEL-392).
 branch_rc=0
 is_on_main "$repo_real" || branch_rc=$?
+
+# Map the branch state to a block reason — or allow. The hook's job is to force
+# ALL feature work into a worktree (header), so an edit in the PRIMARY checkout
+# is blocked whether the branch is main OR a feature branch; only a linked
+# worktree (its own `.git` is a FILE, not a directory) is allowed (HIMMEL-507).
+#   rc=1 + repo_real/.git is a FILE → linked worktree / submodule → ALLOW
+#   rc=1 + repo_real/.git is a DIR  → feature branch in the PRIMARY checkout → BLOCK
+#   rc=0                            → main/master → BLOCK
+#   rc>=2                           → branch unreadable → fail CLOSED
+block_reason=""
 if [ "$branch_rc" -eq 1 ]; then
-    exit 0
-fi
-if [ "$branch_rc" -ne 0 ]; then
+    # A linked worktree (and a submodule) carries a `.git` FILE; the primary
+    # checkout a `.git` DIRECTORY. Feature work belongs in a worktree, so the
+    # worktree case is the only feature-branch path that ALLOWS the edit.
+    if [ ! -d "$repo_real/.git" ]; then
+        exit 0
+    fi
+    block_reason="primary-feature"
+elif [ "$branch_rc" -ne 0 ]; then
     echo "block-edit-on-main: is_on_main returned rc=$branch_rc (cannot determine branch for '$repo_real') - refusing to evaluate" >&2
     exit 2
+else
+    block_reason="main"
 fi
 
-# Branch is main. Honour bypass BEFORE printing the block message so the
-# operator does not see a misleading "refusing" warning when the edit will
-# actually succeed.
+# Both block reasons are "feature work in the PRIMARY checkout" (on main, or on
+# a feature branch). Honour the shared opt-outs BEFORE printing a block message
+# so the operator never sees a misleading "refusing" warning for an edit that
+# will actually succeed.
+#
+# EDIT_ON_MAIN_OK=1 — session bypass (set in the LAUNCHING shell; a per-edit
+# prefix cannot reach the hook process).
 if [ "${EDIT_ON_MAIN_OK:-0}" = "1" ]; then
     exit 0
 fi
@@ -218,6 +247,29 @@ fi
 # and anyone able to create the marker could just touch it directly).
 if [ -f "$repo_real/.single-writer" ]; then
     exit 0
+fi
+
+if [ "$block_reason" = "primary-feature" ]; then
+    cat >&2 <<EOF
+⛔ block-edit-on-main: refusing to edit \`$file_path\` — its repo is the PRIMARY
+checkout on a feature branch. Feature work must be isolated in a worktree per
+CLAUDE.md, not done on a branch checked out in the primary tree (HIMMEL-507).
+(file: $file_real — repo: $repo_real)
+
+Move the work into a worktree (a linked worktree carries its own \`.git\` file,
+so edits there are allowed):
+
+    /clean_garden feat/<scope>          # prune merged worktrees + create new
+    cd .claude/worktrees/feat+<scope>   # switch in the existing shell
+
+Bypass / single-writer opt-out behave the same as the on-main case:
+
+    EDIT_ON_MAIN_OK=1 claude            # session bypass (set in the launching shell)
+    touch "$repo_real/.single-writer"   # local, gitignored single-writer opt-in
+
+Or temporarily comment out the hook stanza in .claude/settings.json.
+EOF
+    exit 2
 fi
 
 cat >&2 <<EOF

--- a/scripts/hooks/test-block-edit-on-main.sh
+++ b/scripts/hooks/test-block-edit-on-main.sh
@@ -98,8 +98,16 @@ rm -f "$SANDBOX/brokenrepo/.git/HEAD"
 # T1: file in a repo on main → BLOCK
 assert_rc "T1 main-repo edit blocks" 2 "$(rc_of "$SANDBOX/mainrepo/src/foo.js")"
 
-# T2: file in a repo on a feature branch → ALLOW
-assert_rc "T2 feature-repo edit allows" 0 "$(rc_of "$SANDBOX/featrepo/foo.js")"
+# T2: feature branch in the PRIMARY checkout (its `.git` is a directory) → BLOCK
+# (HIMMEL-507: feature work belongs in a worktree, not a branch checked out in
+# the primary tree). T2b asserts the message names the feature-branch case,
+# distinct from the on-main message.
+assert_rc "T2 feature branch in primary checkout blocks (HIMMEL-507)" 2 "$(rc_of "$SANDBOX/featrepo/foo.js")"
+t2err=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$SANDBOX/featrepo/foo.js\"}}" | bash "$HOOK" 2>&1 >/dev/null)
+case "$t2err" in
+    *"on a feature branch"*) echo "PASS T2b primary-feature block message" ;;
+    *) echo "FAIL T2b primary-feature block message — got: $t2err"; FAILED=$((FAILED + 1)) ;;
+esac
 
 # T3 (Himmel#45 regression): nested repo on main, launched from the OUTER repo
 # (on a feature branch). The hook must read the NESTED repo's branch → BLOCK,
@@ -108,11 +116,19 @@ assert_rc "T2 feature-repo edit allows" 0 "$(rc_of "$SANDBOX/featrepo/foo.js")"
 assert_rc "T3 nested-on-main under outer-feature blocks (Himmel#45)" 2 \
     "$(rc_of "$SANDBOX/outer/sc/nested/src/foo.js" CLAUDE_PROJECT_DIR="$SANDBOX/outer")"
 
-# T3b (inverse): nested repo on a FEATURE branch inside an outer repo on MAIN —
-# must ALLOW. Guards against a regression that re-anchors to a parent/outer repo
-# instead of the launch dir specifically (which would wrongly BLOCK this edit).
-assert_rc "T3b nested-on-feature under outer-main allows" 0 \
+# T3b (inverse): nested repo on a FEATURE branch (a PRIMARY checkout) inside an
+# outer repo on MAIN. Post-HIMMEL-507 BOTH branches block, so the rc alone no
+# longer proves anchoring — assert the MESSAGE is the primary-feature one. If
+# the hook wrongly re-anchored to the outer (main) repo it would print the
+# on-main message instead, so this still guards the Himmel#45 anchoring.
+assert_rc "T3b nested-on-feature in primary blocks (HIMMEL-507)" 2 \
     "$(rc_of "$SANDBOX/outer2/sc/nested/src/foo.js" CLAUDE_PROJECT_DIR="$SANDBOX/outer2")"
+t3berr=$(printf '%s' "{\"tool_input\":{\"file_path\":\"$SANDBOX/outer2/sc/nested/src/foo.js\"}}" \
+    | env CLAUDE_PROJECT_DIR="$SANDBOX/outer2" bash "$HOOK" 2>&1 >/dev/null)
+case "$t3berr" in
+    *"on a feature branch"*) echo "PASS T3b message proves nested-repo anchoring (not outer-main)" ;;
+    *) echo "FAIL T3b anchoring message — got: $t3berr"; FAILED=$((FAILED + 1)) ;;
+esac
 
 # T3c (sibling): launched in a feature-branch repo, editing a file in an
 # UNRELATED repo on main → BLOCK. Proves the launch dir is ignored even with no
@@ -127,8 +143,10 @@ else
     echo "SKIP T4 (SANDBOX inside a repo)"
 fi
 
-# T5: file inside a real git worktree (feature branch) → ALLOW (the worktree's
-# own `.git` file is found by the walk; branch check allows via rc=1).
+# T5: file inside a real git worktree (feature branch) → ALLOW. The worktree's
+# own `.git` is a FILE (not a directory), so the HIMMEL-507 primary-checkout
+# block does not apply — a linked worktree is exactly where feature work belongs.
+# This is the case T2 (feature branch in the PRIMARY checkout) contrasts with.
 assert_rc "T5 worktree (feature branch) edit allows" 0 \
     "$(rc_of "$SANDBOX/wtrepo/.claude/worktrees/feat+x/src/foo.js")"
 
@@ -139,9 +157,14 @@ assert_rc "T6 handover doc on main allows" 0 "$(rc_of "$SANDBOX/mainrepo/handove
 # (the `.git` walk skips the missing dirs and finds the repo root).
 assert_rc "T7 new file in new subdir on main blocks" 2 "$(rc_of "$SANDBOX/mainrepo/new/deep/foo.js")"
 
-# T7b: same shape but in a FEATURE repo → ALLOW (the walk doesn't over-shoot to a
-# parent; it stops at the feature repo's own .git).
-assert_rc "T7b new file in new subdir on feature allows" 0 "$(rc_of "$SANDBOX/featrepo/new/deep/foo.js")"
+# T7b: same shape but in a FEATURE repo (primary checkout) → BLOCK post-HIMMEL-507
+# (the walk stops at the feature repo's own `.git` directory → primary-feature block;
+# it does not over-shoot to a parent). T7c: the SAME new-subdir shape inside a linked
+# worktree → ALLOW (worktree `.git` is a file), confirming the walk + the file/dir
+# distinction both work for a not-yet-existing target.
+assert_rc "T7b new file in new subdir on feature-primary blocks (HIMMEL-507)" 2 "$(rc_of "$SANDBOX/featrepo/new/deep/foo.js")"
+assert_rc "T7c new file in new subdir inside a worktree allows" 0 \
+    "$(rc_of "$SANDBOX/wtrepo/.claude/worktrees/feat+x/new/deep/foo.js")"
 
 # T8: bypass on a main repo → ALLOW, and T8b: with zero stderr.
 assert_rc "T8 bypass allows" 0 "$(rc_of "$SANDBOX/mainrepo/src/foo.js" EDIT_ON_MAIN_OK=1)"
@@ -193,12 +216,14 @@ else
 fi
 
 # --- Cross-canonicaliser coverage: force the python3 canon branch end-to-end
-# (main → block, feature → allow). Skip if python3 not on the runner.
+# (main → block; worktree → allow). The allow path uses the worktree (not a
+# feature-branch primary checkout, which now blocks per HIMMEL-507) so python
+# canon still exercises a real ALLOW. Skip if python3 not on the runner.
 if command -v python3 >/dev/null 2>&1; then
     assert_rc "T15 python3 canon — main blocks" 2 \
         "$(rc_of "$SANDBOX/mainrepo/src/foo.js" CANON_FORCE=python3)"
-    assert_rc "T15b python3 canon — feature allows" 0 \
-        "$(rc_of "$SANDBOX/featrepo/foo.js" CANON_FORCE=python3)"
+    assert_rc "T15b python3 canon — worktree allows" 0 \
+        "$(rc_of "$SANDBOX/wtrepo/.claude/worktrees/feat+x/src/foo.js" CANON_FORCE=python3)"
 else
     echo "SKIP T15 (no python3 on PATH)"
 fi
@@ -305,15 +330,14 @@ mkdir -p "$SANDBOX/swdir/src"
 assert_rc "T24 dir-shaped marker on main blocks (fail-closed)" 2 \
     "$(rc_of "$SANDBOX/swdir/src/foo.md")"
 
-# T25: .single-writer present + FEATURE branch → ALLOW via normal branch path.
-# Confirms the marker does not interfere with the feature-branch path: a
-# marked repo on a feature branch is still allowed through the normal rc=1
-# is_on_main path (the marker check is never reached). Paired with T2 (no
-# marker, feature branch → allow) and T20 (marker, main → allow), this
-# documents the marker is orthogonal to the branch check.
+# T25: .single-writer present + FEATURE branch in the PRIMARY checkout → ALLOW
+# via the marker opt-out. Post-HIMMEL-507 this case would otherwise BLOCK (a
+# feature branch in the primary tree), so this proves the .single-writer opt-out
+# covers the new primary-feature block path too, not just on-main. Paired with
+# T21 (no marker, would-block → block) and T20 (marker, main → allow).
 mkrepo "$SANDBOX/swfeat" feat/x
 touch "$SANDBOX/swfeat/.single-writer"
-assert_rc "T25 marker present on feature branch allows (normal branch path)" 0 \
+assert_rc "T25 marker present on feature-branch primary allows (opt-out covers HIMMEL-507)" 0 \
     "$(rc_of "$SANDBOX/swfeat/foo.md")"
 
 # T26: EDIT_ON_MAIN_OK=1 + marker present on main → ALLOW via env bypass.
@@ -322,6 +346,13 @@ assert_rc "T25 marker present on feature branch allows (normal branch path)" 0 \
 # regardless of marker". Reuses swrepo (has marker, on main).
 assert_rc "T26 EDIT_ON_MAIN_OK=1 + marker present allows (env bypass wins)" 0 \
     "$(rc_of "$SANDBOX/swrepo/src/foo.md" EDIT_ON_MAIN_OK=1)"
+
+# T27 (HIMMEL-507): EDIT_ON_MAIN_OK=1 bypasses the feature-branch-in-primary
+# block too (no marker present) — confirms the env bypass covers the new block
+# path, mirroring T23 (bypass on main with no marker). featrepo is a primary
+# checkout on a feature branch with no .single-writer.
+assert_rc "T27 EDIT_ON_MAIN_OK=1 allows feature branch in primary (HIMMEL-507)" 0 \
+    "$(rc_of "$SANDBOX/featrepo/foo.js" EDIT_ON_MAIN_OK=1)"
 
 # Clean up the worktree registration before removing the sandbox (avoids a
 # dangling `git worktree` admin record under SANDBOX/wtrepo).


### PR DESCRIPTION
## HIMMEL-507 — block feature-branch edits in the primary checkout

`block-edit-on-main`'s job is *"forcing all feature work into a worktree"*, but it only blocked the **main/master** case — a feature branch checked out in the **primary tree** slipped through.

**Change:** at the feature-branch path, distinguish the **primary checkout** (`.git` is a **directory**) from a **linked worktree / submodule** (`.git` is a **file**). Block the primary case with a worktree-directing message; keep linked-worktree edits allowed. Same `EDIT_ON_MAIN_OK` + `.single-writer` opt-outs; `handovers/**` exempt; Himmel#45 file-anchored resolution unchanged.

**Tests:** flipped the primary-checkout feature-branch cases to BLOCK + asserted the new message, kept linked-worktree edits ALLOW, added opt-out coverage. Full suite green + shellcheck clean on Windows.

CR clean (pr-review-toolkit-himmel:code-reviewer, no Critical/Important). Known low-sev limitation: a `git init --separate-git-dir` primary checkout has a `.git` *file* so the feature-branch guard wouldn't catch it (on-main block unaffected; `check-worktree-isolation.sh` backstops at commit time).

Platforms tested: windows · Security reviewed: pr-review-toolkit
