### PR TITLE
feat(himmel-ops): /himmel-doctor diagnostic + runtime node-resolver fix

### DIFF
--- a/docs/commands-catalog.md
+++ b/docs/commands-catalog.md
@@ -114,5 +114,6 @@ slash alias exists).
 | Command | What it does |
 |---|---|
 | /quiet-run | Run a noisy command quietly — one OK/ERR line + log path |
+| /himmel-doctor (himmel-ops) | Diagnose common harness health problems (node/caveman SessionStart wiring, shadowed claude-obsidian, dirty single-writer luna vault, bitbucket-vs-gh, handover-registry gaps, PATH-fragile bare-interpreter MCP servers); severity-grouped report; `--fix` heals the node wiring; `--file-issue` files ONE consolidated public GitHub issue. |
 | /himmel-update | Update this himmel checkout (harness) — git pull + marketplace re-sync. autoUpdate does NOT deliver himmel updates. |
 | /himmel-update-all | Update BOTH the himmel harness (/himmel-update) and the luna vault (/luna-upgrade) in one shot; `--check` dry-runs both. |

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -240,6 +240,28 @@ node ~/.claude/hooks/caveman-activate.js
 ```
 On every new session: writes `~/.claude/.caveman-active` flag, emits the full caveman ruleset as hidden session context. Ensures mode is active from turn 1.
 
+**Node resolution (macOS/Linux):** a GUI-launched session has no `node` on PATH,
+so this hook is wired through `scripts/lib/run-node.sh` (a runtime launcher that
+resolves node every call via `scripts/lib/resolve-node.sh` — PATH → homebrew →
+newest nvm/fnm → Windows install dir, `sort -V` so never a stale EOL node — and
+fail-opens silently if none, instead of erroring every session). `ubuntu.sh` and
+`scripts/lib/wire-caveman-node.sh` (the idempotent heal helper, also used by
+`/himmel-doctor --fix`) install the wrapper form; win11.ps1 keeps the stable
+absolute Windows path. See `/himmel-doctor` (C1).
+
+---
+
+## himmel-doctor (`scripts/himmel-doctor.sh`)
+
+The `/himmel-doctor` diagnostic. Read-only except `--fix`. Checks: C1 node/caveman
+SessionStart wiring (+ `--fix` heal), C2 shadowed claude-obsidian, C3 dirty
+single-writer luna vault, C4 Bitbucket-remote-where-`gh`-fails, C5 repo not in the
+handover registry, C6 PATH-fragile bare-interpreter MCP servers (uvx/bun — same
+GUI-launch failure class as the node hook). Prints a severity-grouped report (FAIL/WARN/INFO); `--file-issue
+[--repo owner/name]` files ONE deduped consolidated public GitHub issue (resolves
+the repo from `--repo` → `$HIMMEL_DOCTOR_ISSUE_REPO` → github origin). Exit 1 on any
+FAIL. Tests: `scripts/test-himmel-doctor.sh`, `scripts/lib/test-{resolve,run,wire-caveman}-node.sh`.
+
 ---
 
 ## claude-statusline (vendored, HIMMEL-331)

--- a/marketplace/plugins/himmel-ops/commands/himmel-doctor.md
+++ b/marketplace/plugins/himmel-ops/commands/himmel-doctor.md
@@ -1,0 +1,50 @@
+---
+description: Diagnose common himmel-harness health problems (node/caveman SessionStart wiring, shadowed claude-obsidian, dirty single-writer luna vault, bitbucket-vs-gh, handover-registry gaps, PATH-fragile bare-interpreter MCP servers), print a severity-grouped report, optionally heal the node wiring (--fix) and file ONE consolidated GitHub issue.
+---
+
+Run `himmel-doctor` to surface the field problems that bite himmel installs —
+chiefly the macOS/Linux **`node: command not found` at SessionStart** (a caveman
+hook wired at a node path that a PATH-less GUI launch / a node upgrade made
+unresolvable), a **shadowed claude-obsidian** (prompt-type-hook error after
+autoUpdate shadows the himmel pin), a **dirty single-writer luna vault** (e.g.
+after `/luna-upgrade`, which writes but never commits), a **Bitbucket repo** where
+`/commit-push-pr`'s hardcoded `gh` can't open a PR, and a **repo not in the
+handover registry** (so `handover-resume` finds nothing).
+
+It also flags **PATH-fragile MCP servers** (C6) — servers wired as a bare
+interpreter (`uvx mcp-obsidian`, `bun …`) that a PATH-less macOS GUI launch can't
+find, so the server and all its tools silently fail to start (same root cause as
+the node hook).
+
+It is read-only EXCEPT `--fix`, which heals the C1 node wiring by rewriting the
+caveman hooks in the **user-scope** `~/.claude/settings.json` (outside any repo —
+the on-main / repo-settings self-mod guards do not apply) to route through the
+runtime node wrapper `scripts/lib/run-node.sh`. On Windows `--fix` is a no-op (the
+`C:\Program Files\nodejs` path is stable; win11.ps1 owns it).
+
+This command runs from **any directory** — resolve the himmel checkout the same
+way `/himmel-update` does, then run the doctor:
+
+```bash
+# Resolve the himmel checkout: $HIMMEL_REPO -> git toplevel -> canonical -> error.
+REPO="${HIMMEL_REPO:-}"
+[ -n "$REPO" ] && [ -f "$REPO/scripts/himmel-doctor.sh" ] || REPO="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$REPO" ] || [ ! -f "$REPO/scripts/himmel-doctor.sh" ]; then
+  for c in "$HOME/Documents/github/himmel" "$HOME/Documents/github/Himmel" "$HOME/github/himmel" "$HOME/github/Himmel"; do
+    [ -f "$c/scripts/himmel-doctor.sh" ] && { REPO="$c"; break; }
+  done
+fi
+[ -f "$REPO/scripts/himmel-doctor.sh" ] || { echo "ERR: cannot locate himmel checkout — set HIMMEL_REPO" >&2; exit 1; }
+
+bash "$REPO/scripts/himmel-doctor.sh"                       # report only
+bash "$REPO/scripts/himmel-doctor.sh" --fix                 # also heal the node (C1) wiring
+bash "$REPO/scripts/himmel-doctor.sh" --file-issue --repo owner/name   # file ONE consolidated public GitHub issue
+```
+
+Drive the operator interaction yourself: run the report; if there are FAIL/WARN
+findings, summarize them, then ASK the operator whether to (a) heal the node
+wiring (`--fix`) and/or (b) file a consolidated GitHub issue. Only on a yes re-run
+with `--fix` / `--file-issue --repo <public-repo>`. The issue repo resolves from
+`--repo` → `$HIMMEL_DOCTOR_ISSUE_REPO` → the github `origin` slug; for the
+operator's himmel, that public mirror is `yotamleo/Himmel`. Exit code is 1 if any
+FAIL finding is present (0 otherwise), so a `--fix` re-run that clears C1 returns 0.

--- a/marketplace/plugins/obsidian-triage/skills/luna-upgrade/SKILL.md
+++ b/marketplace/plugins/obsidian-triage/skills/luna-upgrade/SKILL.md
@@ -142,6 +142,30 @@ Report the engine's outcome, preserving its loud signals:
 Do NOT attempt to resolve a conflict or re-run automatically — the
 content-preserving contract is the engine's; your job is to surface its result.
 
+## Step 7 — Offer to commit (single-writer vaults only)
+
+`upgrade.sh` writes template files but never commits — and the vault's
+`vault-autosync.sh` is opt-in (default OFF) and wired to no trigger, so a fresh
+upgrade leaves a dirty working tree that silently never lands (the "N uncommitted
+changes after /luna-upgrade" surprise). On a **successful apply (exit 0)**, close
+that gap:
+
+```bash
+# only if the vault commits straight to main by design AND has pending changes
+[ -f "$VAULT/.single-writer" ] && [ -n "$(git -C "$VAULT" status --porcelain)" ] && echo offer
+```
+
+If both hold, OFFER to commit (operator confirms — do not auto-commit):
+
+```bash
+git -C "$VAULT" add -A && git -C "$VAULT" commit -m "chore: luna vault upgrade → template vX.Y.Z"
+```
+
+If the vault is not single-writer (no `.single-writer`), do NOT offer — those
+vaults gate vault writes through a PR lane; just tell the operator the upgrade
+left uncommitted changes to review. (`/himmel-doctor` C3 is the standing backstop
+that flags a dirty single-writer vault later.)
+
 ## Exit codes (from the engine)
 
 - `0` — applied (or dry-run completed, or already current).

--- a/scripts/himmel-doctor.sh
+++ b/scripts/himmel-doctor.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# himmel-doctor.sh — diagnose common himmel-harness health problems, print a
+# severity-grouped report with remediation, and (on request) file ONE
+# consolidated GitHub issue. Read-only except `--fix` (heals C1 node wiring).
+#
+#   bash himmel-doctor.sh [--fix] [--file-issue] [--repo owner/name] [--no-color]
+#
+# Exit 0 unless a FAIL finding is present (then 1) — so `--fix` re-checks are
+# scriptable. WARN/INFO never fail the exit. See the /himmel-doctor command md.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/scripts/himmel-doctor.sh" ] || REPO_ROOT="${HIMMEL_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)}"
+# shellcheck source=/dev/null
+. "$REPO_ROOT/scripts/lib/resolve-node.sh"
+
+CLAUDE_DIR_R="${CLAUDE_DIR:-${HOME:-}/.claude}"
+SETTINGS="$CLAUDE_DIR_R/settings.json"
+REGISTRY="$CLAUDE_DIR_R/handover/registry.json"
+
+# --- args ---
+DO_FIX=0; DO_FILE=0; REPO_FLAG=""; USE_COLOR=1
+[ -t 1 ] || USE_COLOR=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --fix) DO_FIX=1 ;;
+        --file-issue) DO_FILE=1 ;;
+        --repo) shift; REPO_FLAG="${1:-}" ;;
+        --no-color) USE_COLOR=0 ;;
+        -h|--help) sed -n '2,9p' "${BASH_SOURCE[0]}"; exit 0 ;;
+        *) echo "himmel-doctor: unknown arg '$1'" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ "$USE_COLOR" = 1 ]; then C_RED=$'\033[31m'; C_YEL=$'\033[33m'; C_GRN=$'\033[32m'; C_DIM=$'\033[2m'; C_0=$'\033[0m'
+else C_RED=""; C_YEL=""; C_GRN=""; C_DIM=""; C_0=""; fi
+
+n_fail=0; n_warn=0; n_info=0
+BODY="$(mktemp)"
+trap 'rm -f "$BODY"' EXIT
+printf '## himmel-doctor findings (%s)\n\n' "$(uname -s 2>/dev/null || echo ?)" >> "$BODY"
+
+# emit <SEV> <id> <msg> <remedy>
+emit() {
+    local sev="$1" id="$2" msg="$3" remedy="${4:-}" col=""
+    case "$sev" in
+        FAIL) col="$C_RED"; n_fail=$((n_fail+1)) ;;
+        WARN) col="$C_YEL"; n_warn=$((n_warn+1)) ;;
+        INFO) col="$C_DIM"; n_info=$((n_info+1)) ;;
+        OK)   col="$C_GRN" ;;
+    esac
+    printf '%s%-4s%s %s: %s\n' "$col" "$sev" "$C_0" "$id" "$msg"
+    [ -n "$remedy" ] && printf '       %s→ %s%s\n' "$C_DIM" "$remedy" "$C_0"
+    if [ "$sev" != OK ]; then printf -- '- **%s** %s: %s\n  - → %s\n' "$sev" "$id" "$msg" "$remedy" >> "$BODY"; fi
+}
+
+is_windows() { case "$(uname -s 2>/dev/null || echo x)" in MINGW*|MSYS*|CYGWIN*) return 0 ;; *) return 1 ;; esac; }
+
+# --- C1: node / caveman SessionStart wiring -------------------------------------
+classify_caveman_cmd() {
+    # echoes: ok-wrapper | ok-bin | fail-dangling | fail-missing | warn-bare
+    local cmd="$1" bin bin_unix
+    case "$cmd" in
+        *run-node.sh*) echo ok-wrapper; return ;;
+        *'<node-path>'*) echo fail-dangling; return ;;
+    esac
+    bin="$(printf '%s' "$cmd" | sed -E 's/^"([^"]*)".*/\1/; t; s/^([^ ]+).*/\1/')"
+    bin_unix="$(printf '%s' "$bin" | sed 's#\\#/#g')"
+    if [ "$bin" = node ] || [ "$bin" = node.exe ]; then
+        if command -v node >/dev/null 2>&1; then echo ok-bin; else echo warn-bare; fi
+        return
+    fi
+    if [ -x "$bin_unix" ]; then echo ok-bin; else echo fail-missing; fi
+}
+
+check_c1() {
+    if [ ! -f "$SETTINGS" ]; then
+        emit INFO C1-node "no ~/.claude/settings.json — node hook wiring not checked" "run himmel setup if this is a himmel machine"
+        return
+    fi
+    local cmds worst="ok" has_wrapper=0 line cl
+    cmds="$(jq -r '[.hooks.SessionStart[]?.hooks[]?, .hooks.UserPromptSubmit[]?.hooks[]?] | .[]? | .command? // empty | select(test("caveman-(activate|mode-tracker)\\.js"))' "$SETTINGS" 2>/dev/null || true)"
+    if [ -z "$cmds" ]; then
+        if resolve_node >/dev/null 2>&1; then emit OK C1-node "node resolvable; no caveman node hooks wired"; else emit WARN C1-node "no node found on this machine" "install Node.js"; fi
+        return
+    fi
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        cl="$(classify_caveman_cmd "$line")"
+        case "$cl" in
+            ok-wrapper) has_wrapper=1 ;;
+            fail-dangling|fail-missing) worst="fail" ;;
+            warn-bare) [ "$worst" = fail ] || worst="warn" ;;
+        esac
+    done <<EOF
+$cmds
+EOF
+    # A wrapper-form command resolves node at runtime — but if NO node exists
+    # anywhere, the wrapper silently no-ops (fail-open). C1 is the only surface
+    # for that, so flag it (R4/P5).
+    if [ "$worst" = ok ] && [ "$has_wrapper" = 1 ] && ! resolve_node >/dev/null 2>&1; then
+        emit FAIL C1-node "no node found anywhere — the caveman runtime wrapper will silently skip every session" "install Node.js (or fix PATH/nvm); then re-run"
+        return
+    fi
+    case "$worst" in
+        fail)
+            if is_windows; then
+                emit FAIL C1-node "caveman SessionStart hook points at a missing node — session-start error every launch" "re-run himmel setup / win11.ps1 to re-resolve the node path"
+            else
+                emit FAIL C1-node "caveman SessionStart hook points at a dangling/missing node (the 'node: command not found' error)" "himmel-doctor --fix"
+            fi ;;
+        warn) emit WARN C1-node "caveman hook uses a bare 'node' (works only if node is on the GUI launch PATH)" "himmel-doctor --fix" ;;
+        *)    emit OK C1-node "caveman node hooks resolve to a working node" ;;
+    esac
+}
+
+fix_c1() {
+    if is_windows; then
+        printf '%sWindows: node path is stable — nothing to wire (win11.ps1 owns Windows).%s\n' "$C_DIM" "$C_0"
+        return 0
+    fi
+    [ -f "$SETTINGS" ] || { echo "no settings.json to fix"; return 0; }
+    bash "$REPO_ROOT/scripts/lib/wire-caveman-node.sh" "$SETTINGS" "$REPO_ROOT" "$CLAUDE_DIR_R"
+    echo "  re-checking C1 after --fix:"
+    check_c1
+}
+
+# --- C2: claude-obsidian shadow (prompt-type-hook risk) -------------------------
+check_c2() {
+    local shadow=""
+    for d in "$CLAUDE_DIR_R"/plugins/cache/claude-obsidian-marketplace \
+             "$CLAUDE_DIR_R"/plugins/marketplaces/claude-obsidian-marketplace \
+             "$CLAUDE_DIR_R"/plugins/repos/*/claude-obsidian-marketplace; do
+        [ -e "$d" ] && { shadow="$d"; break; }
+    done
+    if [ -n "$shadow" ]; then
+        emit WARN C2-obsidian "claude-obsidian served from a non-@himmel marketplace — autoUpdate can shadow the himmel pin (prompt-type-hook error risk)" "scripts/machine-setup/migrate-plugin-to-himmel.sh --apply claude-obsidian@claude-obsidian-marketplace, then restart"
+    else
+        emit OK C2-obsidian "no shadowing claude-obsidian marketplace detected"
+    fi
+}
+
+# --- C3: dirty single-writer luna vault (won't autosync) ------------------------
+check_c3() {
+    local v=""
+    for c in "${LUNA_VAULT_PATH:-}" "${HOME:-}/Documents/luna" "${HOME:-}/luna"; do
+        [ -n "$c" ] && [ -d "$c/.git" ] && { v="$c"; break; }
+    done
+    [ -n "$v" ] || { emit OK C3-luna "no local luna vault found (skipped)"; return; }
+    if [ ! -f "$v/.single-writer" ]; then emit OK C3-luna "luna vault present, not single-writer (skipped)"; return; fi
+    if [ -n "$(git -C "$v" status --porcelain 2>/dev/null)" ]; then
+        emit WARN C3-luna "luna vault ($v) has uncommitted changes — single-writer vaults are NOT auto-committed (e.g. after /luna-upgrade)" "commit it: git -C '$v' add -A && git -C '$v' commit -m 'chore: vault update'"
+    else
+        emit OK C3-luna "luna vault clean"
+    fi
+}
+
+# --- C4: bitbucket remote where gh-based flows fail -----------------------------
+check_c4() {
+    local url; url="$(git remote get-url origin 2>/dev/null || true)"
+    case "$url" in
+        *bitbucket.org*)
+            emit INFO C4-forge "this repo's origin is Bitbucket — /commit-push-pr hardcodes 'gh pr create' and will not open a PR here" "use the handover forge seam (scripts/handover/pr-open.sh → scripts/bitbucket/ CLI)" ;;
+        *) : ;;
+    esac
+}
+
+# --- C5: cwd repo not registered for handover-resume ----------------------------
+check_c5() {
+    local top; top="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    [ -n "$top" ] || return
+    [ -f "$REGISTRY" ] || { emit INFO C5-handover "no handover registry yet" "/handover-setup to enable handover-resume"; return; }
+    # Case-insensitive (Windows registry stores lowercased paths) + accept a
+    # registered path that is a PARENT of $top (so a worktree under the main
+    # checkout still counts as registered).
+    local match; match="$(jq -r --arg p "$top" '
+        ($p | ascii_downcase) as $pl
+        | [.. | .path? // empty] | map(ascii_downcase)
+        | map(. as $rp | select($rp == $pl or ($pl | startswith($rp + "/")))) | length' "$REGISTRY" 2>/dev/null || echo 0)"
+    if [ "${match:-0}" = 0 ]; then
+        emit INFO C5-handover "this repo is not in the handover registry — /handover handover-resume won't find handovers written here" "/handover register"
+    fi
+}
+
+# --- C6: PATH-fragile bare-interpreter MCP servers ------------------------------
+# Same failure class as C1 node: a macOS GUI launch has a minimal PATH, so an MCP
+# server wired as a bare interpreter name (uvx/bun/deno/python/pwsh) silently fails
+# to start and all its tools vanish. Scans user settings + the himmel plugins.
+check_c6() {
+    local fragile="" name c
+    _scan_mcp() { # $1 = json file with .mcpServers
+        [ -f "$1" ] || return
+        while IFS="$(printf '\t')" read -r name c; do
+            [ -n "$c" ] || continue
+            case "$c" in */*) continue ;; esac
+            case "$c" in uvx|uv|bun|node|deno|python|python3|pwsh) fragile="$fragile ${name}(${c})" ;; esac
+        done <<EOF
+$(jq -r '(.mcpServers // {}) | to_entries[] | "\(.key)\t\(.value.command)"' "$1" 2>/dev/null)
+EOF
+    }
+    _scan_mcp "$SETTINGS"
+    local glob="${DOCTOR_MCP_PLUGINS_GLOB:-$REPO_ROOT/marketplace/plugins/*/.mcp.json}"
+    for mcp in $glob; do _scan_mcp "$mcp"; done
+    if [ -n "$fragile" ]; then
+        emit WARN C6-mcp "MCP server(s) wired as a bare interpreter a PATH-less GUI launch often lacks:$fragile — the server + its tools silently fail to start on macOS app launch" "expose the interpreter's bin dir on the launch PATH, or wire an absolute command"
+    else
+        emit OK C6-mcp "no PATH-fragile bare-interpreter MCP servers"
+    fi
+}
+
+# --- issue filing ---------------------------------------------------------------
+resolve_issue_repo() {
+    [ -n "$REPO_FLAG" ] && { printf '%s\n' "$REPO_FLAG"; return 0; }
+    [ -n "${HIMMEL_DOCTOR_ISSUE_REPO:-}" ] && { printf '%s\n' "$HIMMEL_DOCTOR_ISSUE_REPO"; return 0; }
+    local url; url="$(git remote get-url origin 2>/dev/null || true)"
+    case "$url" in
+        *github.com[:/]*) printf '%s\n' "$url" | sed -E 's#.*github\.com[:/]([^/]+/[^/]+)#\1#; s#\.git$##'; return 0 ;;
+    esac
+    return 1
+}
+
+file_issue() {
+    local title repo existing
+    title="[himmel-doctor] $((n_fail+n_warn+n_info)) finding(s) on $(uname -s 2>/dev/null || echo ?)"
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "  gh not found — report saved at: $BODY"
+        echo "  manual: gh issue create --repo <owner/name> --title '$title' --body-file '$BODY'"
+        cp "$BODY" "$CLAUDE_DIR_R/himmel-doctor-report.md" 2>/dev/null && echo "  (also copied to $CLAUDE_DIR_R/himmel-doctor-report.md)"
+        return 0
+    fi
+    if ! repo="$(resolve_issue_repo)"; then
+        echo "  cannot resolve a public repo — pass --repo owner/name or set HIMMEL_DOCTOR_ISSUE_REPO"
+        return 0
+    fi
+    existing="$(gh issue list --repo "$repo" --state open --search 'in:title himmel-doctor' --json title,url 2>/dev/null | jq -r '.[] | select(.title|startswith("[himmel-doctor]")) | .url' | head -1 || true)"
+    if [ -n "$existing" ]; then
+        echo "  an open himmel-doctor issue already exists: $existing (skipping create — comment there instead)"
+        return 0
+    fi
+    if ! gh issue create --repo "$repo" --title "$title" --body-file "$BODY"; then
+        # Don't lose the report when filing fails (auth/network) — the EXIT trap rm's $BODY.
+        cp "$BODY" "$CLAUDE_DIR_R/himmel-doctor-report.md" 2>/dev/null \
+            && echo "  issue filing failed — report saved at $CLAUDE_DIR_R/himmel-doctor-report.md" >&2
+        return 0
+    fi
+}
+
+# --- run ------------------------------------------------------------------------
+echo "himmel-doctor — $(uname -s 2>/dev/null || echo ?) — checkout: $REPO_ROOT"
+echo
+if [ "$DO_FIX" = 1 ]; then fix_c1; else check_c1; fi
+check_c2
+check_c3
+check_c4
+check_c5
+check_c6
+echo
+printf 'Summary: %s%d FAIL%s  %s%d WARN%s  %s%d INFO%s\n' "$C_RED" "$n_fail" "$C_0" "$C_YEL" "$n_warn" "$C_0" "$C_DIM" "$n_info" "$C_0"
+
+if [ "$DO_FILE" = 1 ] && [ $((n_fail+n_warn+n_info)) -gt 0 ]; then
+    echo; echo "Filing a consolidated GitHub issue:"; file_issue
+elif [ $((n_fail+n_warn)) -gt 0 ] && [ -t 1 ]; then
+    echo; printf 'File a consolidated GitHub issue? [y/N] '; read -r ans
+    case "$ans" in y|Y|yes) file_issue ;; *) echo "  (skipped — re-run with --file-issue to file)";; esac
+fi
+
+[ "$n_fail" -eq 0 ]

--- a/scripts/lib/resolve-node.sh
+++ b/scripts/lib/resolve-node.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# resolve-node.sh — locate an absolute `node` binary at RUNTIME, cross-platform.
+#
+# WHY: GUI-launched Claude Code (macOS app, Windows) starts hooks in a shell with
+# a minimal PATH that often lacks node — so a SessionStart hook wired as a bare
+# `node …` (or a setup-time-substituted absolute path that a later `winget`/nvm/
+# homebrew upgrade moved) fails every session. Resolving at runtime, every call,
+# survives node upgrades and a PATH-less launch. See `run-node.sh` (the wrapper
+# the caveman hooks route through) and `scripts/himmel-doctor.sh` C1.
+#
+# Source this file, then call `resolve_node`:
+#   node="$(resolve_node)" || { echo "no node"; exit 1; }
+# Prints the absolute path on stdout + returns 0 on success; returns 1 + empty
+# stdout if no node is found. bash 3.2-safe (no mapfile / associative arrays).
+#
+# Test seams (used only by scripts/lib/test-resolve-node.sh):
+#   RESOLVE_NODE_PROBE_DIRS  colon-separated dir list that REPLACES the built-in
+#                            absolute-location candidates (PATH is still tried first).
+#   RESOLVE_NODE_NVM_ROOT    override the nvm versions root (default ~/.nvm/versions/node).
+
+resolve_node() {
+    # 1) PATH — the common case (and what setup-time invocations see).
+    if command -v node >/dev/null 2>&1; then
+        command -v node
+        return 0
+    fi
+
+    # 2) Well-known absolute locations (macOS homebrew, Linux, Windows). The
+    #    test seam replaces this list wholesale so cases stay hermetic.
+    local dirs
+    if [ "${RESOLVE_NODE_PROBE_DIRS+set}" = set ]; then
+        dirs="$RESOLVE_NODE_PROBE_DIRS"
+    else
+        dirs="/opt/homebrew/bin:/usr/local/bin:/usr/bin:${HOME:-}/.local/bin:/c/Program Files/nodejs:${LOCALAPPDATA:-}/nodejs"
+    fi
+    local d save_ifs="$IFS"
+    IFS=:
+    for d in $dirs; do
+        [ -n "$d" ] || continue
+        if [ -x "$d/node" ]; then printf '%s\n' "$d/node"; IFS="$save_ifs"; return 0; fi
+        if [ -x "$d/node.exe" ]; then printf '%s\n' "$d/node.exe"; IFS="$save_ifs"; return 0; fi
+    done
+    IFS="$save_ifs"
+
+    # 3) nvm — newest installed version. sort -V (NOT lexical: "v8" > "v20"
+    #    lexically would pick an EOL node that can't run modern ESM).
+    local nvm_root="${RESOLVE_NODE_NVM_ROOT:-${HOME:-}/.nvm/versions/node}"
+    if [ -d "$nvm_root" ]; then
+        # printf-on-glob (not `ls`) so SC2012 stays quiet; a non-matching glob
+        # stays literal and fails the -x test below, so no false hit.
+        local newest
+        newest="$(printf '%s\n' "$nvm_root"/*/bin/node | sort -V | tail -1)"
+        if [ -n "$newest" ] && [ -x "$newest" ]; then printf '%s\n' "$newest"; return 0; fi
+    fi
+
+    # 4) fnm — newest installed version (its layout: <dir>/node-versions/*/installation/bin/node).
+    local fnm_root="${FNM_DIR:-${HOME:-}/.local/share/fnm}"
+    if [ -d "$fnm_root/node-versions" ]; then
+        local fnm_newest
+        fnm_newest="$(printf '%s\n' "$fnm_root"/node-versions/*/installation/bin/node | sort -V | tail -1)"
+        if [ -n "$fnm_newest" ] && [ -x "$fnm_newest" ]; then printf '%s\n' "$fnm_newest"; return 0; fi
+    fi
+
+    return 1
+}

--- a/scripts/lib/run-node.sh
+++ b/scripts/lib/run-node.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# run-node.sh — runtime node launcher for hook commands. Resolves node every
+# call (surviving PATH-less GUI launches + node upgrades) and execs it.
+#
+#   bash run-node.sh <script.js> [args...]
+#
+# The caveman SessionStart/UserPromptSubmit hooks route through this instead of a
+# bare `node` or a setup-time-frozen absolute path (see resolve-node.sh WHY).
+#
+# FAIL-OPEN: if no node is found, write ONE breadcrumb line to
+# ${CLAUDE_DIR:-$HOME/.claude}/himmel-node.log and exit 0 with NOTHING on
+# stdout/stderr — converting the old per-session "node: command not found" hook
+# error (which Claude Code surfaces) into actual silence. `/himmel-doctor` C1 is
+# what surfaces a genuinely-missing node.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/resolve-node.sh"
+
+_node="$(resolve_node)" || _node=""
+if [ -n "$_node" ]; then
+    exec "$_node" "$@"
+fi
+
+# No node: silent fail-open + a breadcrumb for the doctor / a curious operator.
+_log_dir="${CLAUDE_DIR:-${HOME:-.}/.claude}"
+mkdir -p "$_log_dir" 2>/dev/null || true
+printf '%s node not found; skipped: %s\n' "$(date '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || echo '?')" "$*" \
+    >> "$_log_dir/himmel-node.log" 2>/dev/null || true
+exit 0

--- a/scripts/lib/test-resolve-node.sh
+++ b/scripts/lib/test-resolve-node.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/lib/resolve-node.sh.
+# Usage: bash scripts/lib/test-resolve-node.sh
+# Exit 0 if all cases pass, 1 otherwise.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+LIB="$REPO_ROOT/scripts/lib/resolve-node.sh"
+
+[ -f "$LIB" ] || { echo "FAIL: $LIB not found"; exit 1; }
+# shellcheck source=/dev/null
+. "$LIB"
+
+failures=0
+pass() { printf '  PASS  %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures+1)); }
+
+# A realistic "node not on PATH" still has coreutils (/usr/bin). Use the dir
+# that actually holds sort/ls so resolve_node's nvm/fnm pipeline works, while
+# node stays absent from it. (Setting PATH=/nonexistent would also strip sort.)
+UTILS_DIR="$(dirname "$(command -v sort)")"
+
+# A fake node binary (executable, content irrelevant — resolve_node only checks -x).
+make_fake_node() {
+    # $1 = dir, $2 = optional basename (default node)
+    local dir="$1" name="${2:-node}"
+    mkdir -p "$dir"
+    printf '#!/bin/sh\necho fake\n' > "$dir/$name"
+    chmod +x "$dir/$name"
+}
+
+echo "== resolve_node: real node on PATH =="
+# This box may or may not have node on PATH; only assert when it does.
+if command -v node >/dev/null 2>&1; then
+    out="$(resolve_node)"; rc=$?
+    if [ "$rc" -eq 0 ] && [ -n "$out" ]; then pass "PATH node -> '$out' rc0"; else fail "PATH node -> rc=$rc out='$out'"; fi
+else
+    pass "PATH node -> (skipped: no node on PATH here)"
+fi
+
+echo "== resolve_node: found in an injected probe dir (PATH cleared) =="
+tmp="$(mktemp -d)"; make_fake_node "$tmp/bin"
+out="$(PATH="$UTILS_DIR" RESOLVE_NODE_PROBE_DIRS="$tmp/bin" RESOLVE_NODE_NVM_ROOT="$tmp/none" FNM_DIR="$tmp/none" resolve_node)"; rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "$tmp/bin/node" ]; then pass "probe dir -> '$out'"; else fail "probe dir -> rc=$rc out='$out' (want $tmp/bin/node)"; fi
+rm -rf "$tmp"
+
+echo "== resolve_node: node.exe variant in probe dir =="
+tmp="$(mktemp -d)"; make_fake_node "$tmp/bin" "node.exe"
+out="$(PATH="$UTILS_DIR" RESOLVE_NODE_PROBE_DIRS="$tmp/bin" RESOLVE_NODE_NVM_ROOT="$tmp/none" FNM_DIR="$tmp/none" resolve_node)"; rc=$?
+# On Git Bash, `[ -x node ]` already resolves node.exe, so resolve_node may print
+# either basename; both are valid working paths. On macOS/Linux only node.exe exists.
+if [ "$rc" -eq 0 ] && { [ "$out" = "$tmp/bin/node.exe" ] || [ "$out" = "$tmp/bin/node" ]; }; then pass "node.exe -> '$out'"; else fail "node.exe -> rc=$rc out='$out'"; fi
+rm -rf "$tmp"
+
+echo "== resolve_node: no node anywhere -> rc1, empty =="
+tmp="$(mktemp -d)"
+out="$(PATH="$UTILS_DIR" RESOLVE_NODE_PROBE_DIRS="" RESOLVE_NODE_NVM_ROOT="$tmp/none" FNM_DIR="$tmp/none" resolve_node)"; rc=$?
+if [ "$rc" -eq 1 ] && [ -z "$out" ]; then pass "no node -> rc1 empty"; else fail "no node -> rc=$rc out='$out'"; fi
+rm -rf "$tmp"
+
+echo "== resolve_node: nvm picks newest (sort -V, not lexical) =="
+tmp="$(mktemp -d)"; nvm="$tmp/nvm"
+make_fake_node "$nvm/v8.9.0/bin"
+make_fake_node "$nvm/v20.5.0/bin"
+make_fake_node "$nvm/v18.0.0/bin"
+out="$(PATH="$UTILS_DIR" RESOLVE_NODE_PROBE_DIRS="" RESOLVE_NODE_NVM_ROOT="$nvm" FNM_DIR="$tmp/none" resolve_node)"; rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "$nvm/v20.5.0/bin/node" ]; then pass "nvm newest -> '$out'"; else fail "nvm newest -> rc=$rc out='$out' (want v20.5.0; lexical bug would give v8.9.0)"; fi
+rm -rf "$tmp"
+
+echo
+if [ "$failures" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$failures FAILURE(S)"; exit 1; fi

--- a/scripts/lib/test-run-node.sh
+++ b/scripts/lib/test-run-node.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/lib/run-node.sh.
+# Usage: bash scripts/lib/test-run-node.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+RUN="$REPO_ROOT/scripts/lib/run-node.sh"
+[ -f "$RUN" ] || { echo "FAIL: $RUN not found"; exit 1; }
+
+failures=0
+pass() { printf '  PASS  %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures+1)); }
+
+UTILS_DIR="$(dirname "$(command -v sort)")"
+
+# A fake node: $1 is the "script" path (we route on its basename), rest are args.
+make_fake_node() {
+    local dir="$1"; mkdir -p "$dir"
+    cat > "$dir/node" <<'EOF'
+#!/bin/sh
+case "$1" in
+  *echo-args*) shift; printf 'args:%s\n' "$*" ;;
+  *echo-stdin*) cat ;;
+  *exit42*) exit 42 ;;
+  *) printf 'ran:%s\n' "$1" ;;
+esac
+EOF
+    chmod +x "$dir/node"
+}
+
+echo "== run-node: args pass through + stdout =="
+tmp="$(mktemp -d)"; make_fake_node "$tmp/bin"
+out="$(PATH="$UTILS_DIR" RESOLVE_NODE_PROBE_DIRS="$tmp/bin" RESOLVE_NODE_NVM_ROOT="$tmp/none" FNM_DIR="$tmp/none" bash "$RUN" "$tmp/echo-args.js" A B)"
+if [ "$out" = "args:A B" ]; then pass "args -> '$out'"; else fail "args -> '$out'"; fi
+rm -rf "$tmp"
+
+echo "== run-node: exit code propagates =="
+tmp="$(mktemp -d)"; make_fake_node "$tmp/bin"
+PATH="$UTILS_DIR" RESOLVE_NODE_PROBE_DIRS="$tmp/bin" RESOLVE_NODE_NVM_ROOT="$tmp/none" FNM_DIR="$tmp/none" bash "$RUN" "$tmp/exit42.js" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 42 ]; then pass "exit -> 42"; else fail "exit -> $rc (want 42)"; fi
+rm -rf "$tmp"
+
+echo "== run-node: stdin reaches the child =="
+tmp="$(mktemp -d)"; make_fake_node "$tmp/bin"
+out="$(printf 'PAYLOAD-123' | PATH="$UTILS_DIR" RESOLVE_NODE_PROBE_DIRS="$tmp/bin" RESOLVE_NODE_NVM_ROOT="$tmp/none" FNM_DIR="$tmp/none" bash "$RUN" "$tmp/echo-stdin.js")"
+if [ "$out" = "PAYLOAD-123" ]; then pass "stdin -> '$out'"; else fail "stdin -> '$out'"; fi
+rm -rf "$tmp"
+
+echo "== run-node: no node -> silent, exit 0, one log line =="
+tmp="$(mktemp -d)"; cdir="$tmp/claude"
+out="$(PATH="$UTILS_DIR" RESOLVE_NODE_PROBE_DIRS="" RESOLVE_NODE_NVM_ROOT="$tmp/none" FNM_DIR="$tmp/none" CLAUDE_DIR="$cdir" bash "$RUN" "$tmp/caveman-activate.js" 2>"$tmp/err.txt")"
+rc=$?
+err="$(cat "$tmp/err.txt")"
+logc=0; [ -f "$cdir/himmel-node.log" ] && logc="$(wc -l < "$cdir/himmel-node.log" | tr -d ' ')"
+if [ "$rc" -eq 0 ] && [ -z "$out" ] && [ -z "$err" ] && [ "$logc" = "1" ]; then
+    pass "no-node -> rc0, silent, 1 log line"
+else
+    fail "no-node -> rc=$rc out='$out' err='$err' logc=$logc"
+fi
+rm -rf "$tmp"
+
+echo
+if [ "$failures" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$failures FAILURE(S)"; exit 1; fi

--- a/scripts/lib/test-wire-caveman-node.sh
+++ b/scripts/lib/test-wire-caveman-node.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/lib/wire-caveman-node.sh.
+# Usage: bash scripts/lib/test-wire-caveman-node.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WIRE="$REPO_ROOT/scripts/lib/wire-caveman-node.sh"
+[ -f "$WIRE" ] || { echo "FAIL: $WIRE not found"; exit 1; }
+
+failures=0
+pass() { printf '  PASS  %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures+1)); }
+
+# Opaque non-slash tokens for the himmel/claude args: the rewrite interpolates
+# them verbatim, and avoiding leading slashes sidesteps Git Bash POSIX->Windows
+# arg conversion (which would mangle /fake/... but must stay ON for the real
+# settings-file path that native jq opens).
+HP="HIMMELROOT"; CD="CLAUDEDIR"
+WANT_SS='bash "HIMMELROOT/scripts/lib/run-node.sh" "CLAUDEDIR/hooks/caveman-activate.js"'
+WANT_UPS='bash "HIMMELROOT/scripts/lib/run-node.sh" "CLAUDEDIR/hooks/caveman-mode-tracker.js"'
+
+# Fake a non-Windows uname so the rewrite runs on this MINGW box.
+FAKEBIN="$(mktemp -d)/bin"; mkdir -p "$FAKEBIN"
+printf '#!/bin/sh\necho Linux\n' > "$FAKEBIN/uname"; chmod +x "$FAKEBIN/uname"
+# MSYS_NO_PATHCONV=1: stop Git Bash rewriting the fake /fake/... args into
+# Windows paths (a Git-Bash-only arg-conversion; real Linux/macOS never mangle).
+run_wire() { PATH="$FAKEBIN:$PATH" bash "$WIRE" "$1" "$HP" "$CD"; }
+
+# $1 = caveman SessionStart command, $2 = caveman UserPromptSubmit command
+write_settings() {
+    cat > "$3" <<EOF
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [
+        { "type": "command", "command": $1 },
+        { "type": "command", "command": "bash \"<himmel-path>/scripts/hooks/check-update-available.sh\"", "timeout": 15 }
+      ] }
+    ],
+    "UserPromptSubmit": [
+      { "hooks": [ { "type": "command", "command": $2 } ] }
+    ]
+  }
+}
+EOF
+}
+
+echo "== dangling <node-path> -> wrapper form, sibling preserved =="
+s="$(mktemp)"
+write_settings '"\"<node-path>\" \"<claude-dir>/hooks/caveman-activate.js\""' '"\"<node-path>\" \"<claude-dir>/hooks/caveman-mode-tracker.js\""' "$s"
+run_wire "$s"
+got_ss="$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$s")"
+got_ups="$(jq -r '.hooks.UserPromptSubmit[0].hooks[0].command' "$s")"
+sib="$(jq -r '.hooks.SessionStart[0].hooks[1].command' "$s")"
+if [ "$got_ss" = "$WANT_SS" ]; then pass "SessionStart rewritten"; else fail "SessionStart -> '$got_ss'"; fi
+if [ "$got_ups" = "$WANT_UPS" ]; then pass "UserPromptSubmit rewritten"; else fail "UserPromptSubmit -> '$got_ups'"; fi
+case "$sib" in *check-update-available.sh*) pass "sibling preserved" ;; *) fail "sibling clobbered -> '$sib'" ;; esac
+if jq -e . "$s" >/dev/null 2>&1; then pass "valid JSON"; else fail "invalid JSON"; fi
+
+echo "== idempotent (2nd run byte-identical) =="
+cp "$s" "$s.before"; run_wire "$s"
+if cmp -s "$s" "$s.before"; then pass "idempotent"; else fail "not idempotent"; fi
+rm -f "$s" "$s.before"
+
+echo "== bare-node variant converges =="
+s="$(mktemp)"
+write_settings '"node \"/old/path/hooks/caveman-activate.js\""' '"node \"/old/path/hooks/caveman-mode-tracker.js\""' "$s"
+run_wire "$s"
+got_ss="$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$s")"
+if [ "$got_ss" = "$WANT_SS" ]; then pass "bare-node -> wrapper"; else fail "bare-node -> '$got_ss'"; fi
+rm -f "$s"
+
+# (already-wrapped convergence is covered by the idempotent case above.)
+
+rm -rf "$(dirname "$FAKEBIN")"
+echo
+if [ "$failures" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$failures FAILURE(S)"; exit 1; fi

--- a/scripts/lib/wire-caveman-node.sh
+++ b/scripts/lib/wire-caveman-node.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# wire-caveman-node.sh — rewrite the caveman SessionStart/UserPromptSubmit hook
+# commands in a settings.json to route through the runtime node wrapper
+# (scripts/lib/run-node.sh) instead of a bare `node` / a dangling `<node-path>` /
+# a setup-time-frozen absolute path. Heals existing macOS/Linux installs and is
+# the shared wiring used by ubuntu.sh on fresh installs.
+#
+#   bash wire-caveman-node.sh <settings.json> [himmel_path] [claude_dir]
+#
+# Defaults: himmel_path = $HIMMEL_REPO or this script's repo root;
+#           claude_dir  = ${CLAUDE_DIR:-$HOME/.claude}.
+# Idempotent (re-running is a byte-for-byte no-op). Matches caveman hooks by the
+# script basename in the command string, so it converges from any prior form and
+# leaves sibling hooks (check-update-available.sh, …) untouched.
+#
+# Windows: refuses (no-op). win11.ps1 owns Windows wiring and the
+# C:\Program Files\nodejs path is stable across winget in-place updates.
+set -uo pipefail
+
+SETTINGS="${1:-}"
+if [ -z "$SETTINGS" ] || [ ! -f "$SETTINGS" ]; then
+    echo "wire-caveman-node: usage: wire-caveman-node.sh <settings.json> [himmel_path] [claude_dir]" >&2
+    exit 2
+fi
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+    MINGW*|MSYS*|CYGWIN*)
+        echo "wire-caveman-node: Windows detected — node path is stable, nothing to wire (win11.ps1 owns this)." >&2
+        exit 0 ;;
+esac
+
+_self_root="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+HIMMEL_PATH="${2:-${HIMMEL_REPO:-$_self_root}}"
+CLAUDE_DIR_RESOLVED="${3:-${CLAUDE_DIR:-${HOME:-}/.claude}}"
+
+command -v jq >/dev/null 2>&1 || { echo "wire-caveman-node: jq is required" >&2; exit 1; }
+
+# Count caveman hook commands so a direct (standalone) invocation gets a clear
+# signal instead of a silent no-op when nothing matched.
+n_caveman="$(jq '[.hooks.SessionStart[]?.hooks[]?, .hooks.UserPromptSubmit[]?.hooks[]?]
+    | map(.command? // "") | map(select(test("caveman-(activate|mode-tracker)\\.js"))) | length' "$SETTINGS" 2>/dev/null || echo 0)"
+
+tmp="$(mktemp)" || { echo "wire-caveman-node: mktemp failed" >&2; exit 1; }
+if jq \
+    --arg hp "$HIMMEL_PATH" \
+    --arg cd "$CLAUDE_DIR_RESOLVED" '
+  def rw:
+    if ((.command? // "") | test("caveman-(activate|mode-tracker)\\.js"))
+    then .command = ("bash \"" + $hp + "/scripts/lib/run-node.sh\" \"" + $cd
+        + "/hooks/" + ((.command | capture("(?<b>caveman-(activate|mode-tracker)\\.js)")).b) + "\"")
+    else . end;
+  def rwgroups: map(.hooks = ((.hooks // []) | map(rw)));
+  if (.hooks | type) == "object"
+  then .hooks.SessionStart = ((.hooks.SessionStart // []) | rwgroups)
+     | .hooks.UserPromptSubmit = ((.hooks.UserPromptSubmit // []) | rwgroups)
+  else . end
+' "$SETTINGS" > "$tmp"; then
+    if [ -s "$tmp" ] && jq -e . "$tmp" >/dev/null 2>&1; then
+        mv "$tmp" "$SETTINGS"
+        if [ "${n_caveman:-0}" = 0 ]; then
+            echo "wire-caveman-node: no caveman hook commands found to wire (no-op)" >&2
+        else
+            echo "wire-caveman-node: normalized $n_caveman caveman hook command(s) to the runtime wrapper" >&2
+        fi
+    else
+        rm -f "$tmp"; echo "wire-caveman-node: refusing to write empty/invalid JSON" >&2; exit 1
+    fi
+else
+    rm -f "$tmp"; echo "wire-caveman-node: jq transform failed" >&2; exit 1
+fi

--- a/scripts/machine-setup/ubuntu.sh
+++ b/scripts/machine-setup/ubuntu.sh
@@ -372,9 +372,11 @@ step "Patch ~/.claude/settings.json"
       # HIMMEL-264: resolve <himmel-path> placeholders the template carries
       # (the PreToolUse rtk-hook-guard entry) so a freshly written
       # settings.json never holds a dangling <himmel-path>. Scope note:
-      # ONLY <himmel-path> — the caveman <node-path>/<claude-dir>
-      # placeholders are not resolved on Ubuntu (caveman hook wiring is
-      # Windows-only, via win11.ps1).
+      # ONLY <himmel-path> here — the caveman <node-path>/<claude-dir>
+      # placeholders are rewritten to the runtime node wrapper
+      # (scripts/lib/run-node.sh) by wire-caveman-node.sh below, so a GUI-launched
+      # macOS/Linux session resolves node at hook time instead of failing on a
+      # PATH-less launch / a moved node (the /himmel-doctor node-resolver fix).
       | walk(if type == "string" then gsub("<himmel-path>"; $hp) else . end)' \
       "$TEMPLATE")
 
@@ -393,9 +395,14 @@ step "Patch ~/.claude/settings.json"
       # statusLine via the shared helper (HIMMEL-359) — runs after the merge so
       # it is authoritative and refreshes any stale path on idempotent re-runs.
       bash "$HIMMEL_PATH/scripts/lib/wire-statusline.sh" "$SETTINGS" "$HIMMEL_PATH"
+      # Route the caveman node hooks through the runtime wrapper (resolve node at
+      # hook time, not setup time) — heals the macOS/Linux "node: command not
+      # found" SessionStart error and survives node upgrades.
+      bash "$HIMMEL_PATH/scripts/lib/wire-caveman-node.sh" "$SETTINGS" "$HIMMEL_PATH" "$CLAUDE_DIR"
     else
       write_settings_json "$PATCH" "$SETTINGS"
       bash "$HIMMEL_PATH/scripts/lib/wire-statusline.sh" "$SETTINGS" "$HIMMEL_PATH"
+      bash "$HIMMEL_PATH/scripts/lib/wire-caveman-node.sh" "$SETTINGS" "$HIMMEL_PATH" "$CLAUDE_DIR"
     fi
   fi
 } || fail_nonfatal "patch settings.json"

--- a/scripts/test-himmel-doctor.sh
+++ b/scripts/test-himmel-doctor.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/himmel-doctor.sh (hermetic — temp CLAUDE_DIR/HOME).
+# Usage: bash scripts/test-himmel-doctor.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DOC="$REPO_ROOT/scripts/himmel-doctor.sh"
+[ -f "$DOC" ] || { echo "FAIL: $DOC not found"; exit 1; }
+
+# Hermeticity: never let an inherited LUNA_VAULT_PATH point C3 at the operator's
+# real vault (HOME is redirected per-case, but C3 probes $LUNA_VAULT_PATH first).
+export LUNA_VAULT_PATH=""
+
+failures=0
+pass() { printf '  PASS  %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures+1)); }
+
+# PATH that has every tool the doctor/scripts need EXCEPT node and gh (so the
+# no-node and gh-absent branches are exercisable). node lives in its own dir.
+tool_dirs() {
+    local t d; for t in git jq sort sed cat date mktemp dirname uname wc tr head cp rm mv chmod; do
+        d="$(command -v "$t" 2>/dev/null)" && dirname "$d"
+    done | sort -u | tr '\n' ':'
+}
+TOOLS_PATH="$(tool_dirs)"
+
+# fake uname=Linux (to exercise the non-Windows --fix path on this MINGW box)
+FAKEROOT="$(mktemp -d)"; FAKEBIN="$FAKEROOT/bin"; mkdir -p "$FAKEBIN"
+printf '#!/bin/sh\necho Linux\n' > "$FAKEBIN/uname"; chmod +x "$FAKEBIN/uname"
+
+# A fake node so "node resolvable" cases are deterministic regardless of whether
+# the host actually has node (a node-less Linux box would otherwise FAIL them).
+FAKENODE="$FAKEROOT/nodebin"; mkdir -p "$FAKENODE"
+printf '#!/bin/sh\necho v20\n' > "$FAKENODE/node"; chmod +x "$FAKENODE/node"
+
+# A curated PATH with the tools the doctor needs but WITHOUT gh — for the
+# gh-absent case. On Linux gh shares /usr/bin with coreutils, so excluding a dir
+# won't drop it; symlink only the needed tools instead.
+NOGH="$FAKEROOT/nogh"; mkdir -p "$NOGH"
+for _tool in bash sh git jq sort tail sed cat date mktemp mkdir dirname uname wc tr head cp rm mv chmod grep basename; do
+    _p="$(command -v "$_tool" 2>/dev/null)" && ln -sf "$_p" "$NOGH/$_tool" 2>/dev/null
+done
+
+# $1=claude dir, $2=JSON-encoded caveman SessionStart command
+write_settings() {
+    mkdir -p "$1"
+    cat > "$1/settings.json" <<EOF
+{ "hooks": {
+  "SessionStart": [ { "hooks": [ { "type": "command", "command": $2 } ] } ],
+  "UserPromptSubmit": [] } }
+EOF
+}
+DANGLING='"\"<node-path>\" \"<claude-dir>/hooks/caveman-activate.js\""'
+WRAPPER='"bash \"/x/scripts/lib/run-node.sh\" \"/y/hooks/caveman-activate.js\""'
+
+make_gh() { # $1=dir, $2=create|exists
+    mkdir -p "$1"
+    if [ "$2" = exists ]; then LIST='echo "[{\"title\":\"[himmel-doctor] old\",\"url\":\"http://x/1\"}]"'; else LIST='echo "[]"'; fi
+    cat > "$1/gh" <<EOF
+#!/bin/sh
+case "\$1 \$2" in
+  "issue list") $LIST ;;
+  "issue create") echo "CREATE \$4" ;;
+esac
+EOF
+    chmod +x "$1/gh"
+}
+
+echo "== clean (wrapper-form, node resolvable) -> exit 0, C1 OK =="
+t="$(mktemp -d)"; write_settings "$t/claude" "$WRAPPER"
+out="$(RESOLVE_NODE_PROBE_DIRS="$FAKENODE" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q 'OK   C1-node'; then pass "clean -> rc0, C1 OK"; else fail "clean -> rc=$rc; $(printf '%s' "$out" | grep C1-node)"; fi
+rm -rf "$t"
+
+echo "== dangling <node-path> -> C1 FAIL, exit 1 =="
+t="$(mktemp -d)"; write_settings "$t/claude" "$DANGLING"
+out="$(CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"; rc=$?
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q 'FAIL C1-node'; then pass "dangling -> rc1, C1 FAIL"; else fail "dangling -> rc=$rc; $(printf '%s' "$out" | grep C1-node)"; fi
+rm -rf "$t"
+
+echo "== --fix heals dangling (faked Linux uname) -> C1 OK =="
+t="$(mktemp -d)"; write_settings "$t/claude" "$DANGLING"
+out="$(RESOLVE_NODE_PROBE_DIRS="$FAKENODE" PATH="$FAKEBIN:$PATH" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --fix --no-color 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q 'OK   C1-node'; then pass "--fix -> healed, rc0"; else fail "--fix -> rc=$rc; $out"; fi
+# confirm the settings file now points at the wrapper
+if grep -q 'run-node.sh' "$t/claude/settings.json"; then pass "--fix wrote wrapper form"; else fail "--fix did not write wrapper"; fi
+rm -rf "$t"
+
+echo "== wrapper-form but NO node anywhere -> C1 FAIL (R4/P5) =="
+t="$(mktemp -d)"; write_settings "$t/claude" "$WRAPPER"
+out="$(PATH="$TOOLS_PATH" RESOLVE_NODE_PROBE_DIRS="" RESOLVE_NODE_NVM_ROOT="$t/none" FNM_DIR="$t/none" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"; rc=$?
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q 'FAIL C1-node'; then pass "wrapper+no-node -> rc1 FAIL"; else fail "wrapper+no-node -> rc=$rc; $(printf '%s' "$out" | grep C1-node)"; fi
+rm -rf "$t"
+
+echo "== --file-issue with gh stub -> creates with resolved repo =="
+t="$(mktemp -d)"; write_settings "$t/claude" "$DANGLING"; make_gh "$t/gh" create
+out="$(PATH="$t/gh:$PATH" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --file-issue --repo me/repo --no-color 2>&1)"
+if printf '%s' "$out" | grep -q 'CREATE me/repo'; then pass "file-issue -> created"; else fail "file-issue -> $(printf '%s' "$out" | tail -3)"; fi
+rm -rf "$t"
+
+echo "== --file-issue dedup (existing open issue) -> skip create =="
+t="$(mktemp -d)"; write_settings "$t/claude" "$DANGLING"; make_gh "$t/gh" exists
+out="$(PATH="$t/gh:$PATH" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --file-issue --repo me/repo --no-color 2>&1)"
+if printf '%s' "$out" | grep -q 'already exists' && ! printf '%s' "$out" | grep -q 'CREATE'; then pass "dedup -> skipped"; else fail "dedup -> $(printf '%s' "$out" | tail -3)"; fi
+rm -rf "$t"
+
+echo "== --file-issue with gh ABSENT -> graceful, no crash =="
+# Only run where the curated symlink PATH genuinely works (Linux) — Windows
+# Git Bash symlinks to .exe tools don't execute, so skip there cleanly.
+if PATH="$NOGH" bash -c 'git --version >/dev/null 2>&1 && jq --version >/dev/null 2>&1 && ! command -v gh >/dev/null 2>&1' 2>/dev/null; then
+    t="$(mktemp -d)"; write_settings "$t/claude" "$DANGLING"
+    out="$(PATH="$NOGH" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --file-issue --repo me/repo --no-color 2>&1)"; rc=$?
+    if printf '%s' "$out" | grep -q 'gh not found' && { [ "$rc" -eq 0 ] || [ "$rc" -eq 1 ]; }; then pass "gh-absent -> graceful (rc=$rc)"; else fail "gh-absent -> rc=$rc; $(printf '%s' "$out" | tail -3)"; fi
+    rm -rf "$t"
+else
+    pass "gh-absent -> (skipped: could not build a gh-less PATH on this host)"
+fi
+
+echo "== bare 'node' caveman cmd + node off PATH -> C1 WARN =="
+t="$(mktemp -d)"; write_settings "$t/claude" '"node \"X/hooks/caveman-activate.js\""'
+out="$(PATH="$TOOLS_PATH" RESOLVE_NODE_PROBE_DIRS="" RESOLVE_NODE_NVM_ROOT="$t/none" FNM_DIR="$t/none" DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"
+if printf '%s' "$out" | grep -q 'WARN C1-node'; then pass "bare-node -> C1 WARN"; else fail "bare-node -> $(printf '%s' "$out" | grep C1-node)"; fi
+rm -rf "$t"
+
+echo "== C2: shadowed claude-obsidian marketplace -> WARN =="
+t="$(mktemp -d)"; mkdir -p "$t/claude/plugins/cache/claude-obsidian-marketplace"; write_settings "$t/claude" "$WRAPPER"
+out="$(DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"
+if printf '%s' "$out" | grep -q 'WARN C2-obsidian'; then pass "C2 -> WARN (shadow)"; else fail "C2 -> $(printf '%s' "$out" | grep C2)"; fi
+rm -rf "$t"
+
+echo "== C3: dirty single-writer luna vault -> WARN =="
+t="$(mktemp -d)"; mkdir -p "$t/claude"; v="$t/home/Documents/luna"; mkdir -p "$v"
+git -C "$v" init -q 2>/dev/null; git -C "$v" config user.email t@t; git -C "$v" config user.name t
+: > "$v/.single-writer"; echo dirty > "$v/note.md"
+write_settings "$t/claude" "$WRAPPER"
+out="$(DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"
+if printf '%s' "$out" | grep -q 'WARN C3-luna'; then pass "C3 -> WARN (dirty single-writer)"; else fail "C3 -> $(printf '%s' "$out" | grep C3)"; fi
+rm -rf "$t"
+
+echo "== C6: bare-interpreter MCP server -> WARN =="
+t="$(mktemp -d)"; mkdir -p "$t/claude"
+cat > "$t/claude/settings.json" <<'EOF'
+{ "mcpServers": { "obsidian-vault": { "command": "uvx", "args": ["mcp-obsidian"] } }, "hooks": {} }
+EOF
+out="$(DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"
+if printf '%s' "$out" | grep -q 'WARN C6-mcp' && printf '%s' "$out" | grep -q 'obsidian-vault(uvx)'; then pass "C6 -> WARN (uvx)"; else fail "C6 -> $(printf '%s' "$out" | grep C6)"; fi
+rm -rf "$t"
+
+echo "== C6: absolute-command MCP server -> OK =="
+t="$(mktemp -d)"; mkdir -p "$t/claude"
+cat > "$t/claude/settings.json" <<'EOF'
+{ "mcpServers": { "x": { "command": "/usr/local/bin/foo" } }, "hooks": {} }
+EOF
+out="$(DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"
+if printf '%s' "$out" | grep -q 'OK   C6-mcp'; then pass "C6 -> OK (absolute)"; else fail "C6 -> $(printf '%s' "$out" | grep C6)"; fi
+rm -rf "$t"
+
+rm -rf "$FAKEROOT"
+echo
+if [ "$failures" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$failures FAILURE(S)"; exit 1; fi


### PR DESCRIPTION
Diagnose harness health problems + fix the macOS/Linux node:command-not-found SessionStart failure via a runtime node-resolver wrapper. 6 checks (C1-C6), --fix heals, --file-issue files one GitHub issue. Tested on Windows + Ubuntu.