### PR TITLE
docs(readme): clarify qmd embeds files→pointers, not extracted facts (Camp 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ Mem0, no RAG over embeddings of extracted facts). himmel does run a local search
 index ([qmd](https://www.npmjs.com/package/@tobilu/qmd) — BM25 + vectors) *over*
 the same markdown, but that index is a derived, drop-and-rebuild view that points
 you back at the real file; the files remain the single source of truth, never
-replaced by the index.
+replaced by the index. The line is *what gets embedded and returned*, not whether
+embeddings are used: qmd embeds the files and returns a pointer to the source,
+whereas a Camp 1 backend embeds extracted facts and returns the fact in the
+file's place.
 
 The reasoning: for a single operator, the operator *is* the source of truth and
 can read and edit the substrate by hand. Camp 1 backends (extract → embed →


### PR DESCRIPTION
Small clarification to the README Camp-2 memory-architecture section: the "no RAG over embeddings" claim is only precise with its "of extracted facts" qualifier, since qmd does use vector embeddings. Adds one sentence making the real dividing line explicit — *what gets embedded and returned* (files→pointer vs extracted-fact→replacement), not whether embeddings are used. Docs-only (4 lines). Private parent: yotamleo/himmel-private#683.