### PR TITLE
docs: update/upgrade + uninstall lifecycle + llms.txt front door

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Map of the `docs/` tree. New here? Start at **[getting-started.md](getting-start
 
 - [setup/new-machine.md](setup/new-machine.md) — fresh-machine setup: required tools + per-platform (Linux / macOS / Windows Git Bash) install.
 - [setup/use-on-your-project.md](setup/use-on-your-project.md) — adopt the portable core (hooks + worktree workflow) in an existing repo.
+- [setup/updating.md](setup/updating.md) — update the harness (`/himmel-update`) and upgrade luna vaults (`/luna-upgrade`); also points to the symmetric `scripts/uninstall.sh` teardown.
 - [setup/global-claude-md.md](setup/global-claude-md.md) — Claude Code global config (`~/.claude/`).
 - [setup/vms.md](setup/vms.md) — VM-based dev machines for cross-platform testing.
 - [setup/claude-squad.md](setup/claude-squad.md) — optional `claude-squad` (cs) install.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,7 +113,8 @@ himmel needs almost nothing to start:
 
 - **`USER_SLUG`** — your kebab-case handle (e.g. `jane-doe`). If you skip it,
   himmel derives it from your `git config user.name`. That's it for the core.
-- **Everything else is optional.** luna (the companion vault), Telegram, hermes,
+- **Everything else is optional.** luna (the companion vault), Telegram,
+  [hermes](hermes-runbook.md) (himmel's free-inference junior-tier model lane),
   and Jira are all opt-in — the harness runs fully without any of them. Add Jira
   later by filling `JIRA_*` in `.env` (see the
   [env table](../README.md#quickstart)); the local CLI needs only four values
@@ -268,6 +269,8 @@ guard is yours to lift:
 | Run unattended overnight | [handover/overnight-mode.md](handover/overnight-mode.md) |
 | Adopt the core in another repo | [setup/use-on-your-project.md](setup/use-on-your-project.md) |
 | Full machine setup + gotchas | [setup/new-machine.md](setup/new-machine.md) |
+| Update the harness + upgrade the vault | [setup/updating.md](setup/updating.md) |
+| Uninstall / offboard himmel | [`scripts/uninstall.sh`](../scripts/uninstall.sh) (see [updating.md](setup/updating.md#uninstalling--offboarding)) |
 
 Working as an LLM in this repo? Start from [`llms.txt`](../llms.txt) — the
 machine-readable map.

--- a/docs/setup/updating.md
+++ b/docs/setup/updating.md
@@ -105,6 +105,29 @@ Plain `git pull` works too if you don't need the marketplace re-sync.
 - **Plugins / slash commands / skills**: loaded at session start — **restart**
   any running Claude session to pick them up.
 
+## Uninstalling / offboarding
+
+The inverse of setup is [`scripts/uninstall.sh`](../../scripts/uninstall.sh)
+(`scripts\uninstall.ps1` on Windows) — a symmetric six-step teardown of what
+`setup.sh`/`adopt` onboard: stops the Telegram bridge, removes its pairing +
+bridge state, deletes the `HIMMEL-Resume-*` scheduled jobs, uninstalls the
+Claude plugins + marketplaces, uninstalls the repo's git hooks, and unwires the
+user-scope `~/.claude/settings.json` keys himmel added. It is destructive and
+fail-closed (a non-interactive run aborts without `--yes`); preview any run with
+`--dry-run`, and skip individual steps with `--skip-plugins` / `--skip-hooks` /
+`--skip-tasks` / `--skip-settings`.
+
+```bash
+bash scripts/uninstall.sh --dry-run    # preview; nothing is executed
+bash scripts/uninstall.sh --yes        # actually offboard
+```
+
+It deliberately leaves the himmel clone, your `.env`, worktrees, handover state
+outside the bridge root, and non-himmel `settings.json` keys untouched. **hermes
+is not torn down** — it installs outside the repo (`%LOCALAPPDATA%\hermes` /
+`$HERMES_HOME`); stop its gateway and remove that directory by hand if you are
+decommissioning it (see the [hermes runbook](../hermes-runbook.md)).
+
 ## Notes
 
 - **On a feature branch?** A pull lands updates on the default branch; merge or

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,23 @@
 
 > A harness for running Claude Code as a managed, orchestrated, PR-gated, overnight-capable agent. himmel makes an agent's behaviour *structurally* safe and repeatable — hooks + gates + guardrails enforce the workflow at the tool-call layer rather than relying on the model to remember prose. Memory is Camp 2: durable, hand-editable markdown (the handover system + the companion luna vault) that compounds across sessions — no vector DB. Targets solo-operator / small-team work at Tier 3-4 Claude Code maturity (orchestrated + 24/7 autonomous).
 
-If you are an LLM working in this repo, read CLAUDE.md first — it is the authoritative rule set and is loaded into every session. The links below are the canonical docs; each owns its topic, so prefer reading the linked file over re-deriving from code.
+If you are an LLM **working inside** this repo, read CLAUDE.md first — it is the authoritative rule set and is loaded into every session. If you were just **pointed at this repo** to set it up, start with the next section. Either way the links below are the canonical docs; each owns its topic, so prefer reading the linked file over re-deriving from code.
+
+## If you were just pointed at this repo (install / doctor)
+
+himmel is a harness *for* [Claude Code](https://claude.com/claude-code) — install that first (`curl -fsSL https://claude.ai/install.sh | bash`, or `irm https://claude.ai/install.ps1 | iex` on Windows). Prereqs for everything below: `git`, `bash` 3.2+ (Git Bash on Windows), `node`, `npm`, `bun`, `python3`, `jq` (`gh` optional); the setup/adopt scripts verify them and fail fast. The three things people ask for first — each is idempotent, non-destructive, and narrates what it does:
+
+1. **Add himmel to an existing repo** (most common) — the portable core: hooks + guardrails + worktree workflow + marketplace plugins/skills.
+   ```bash
+   git clone https://github.com/yotamleo/himmel
+   bash himmel/scripts/adopt.sh --profile core --scope project --target /path/to/your/repo
+   # Windows:  pwsh himmel\scripts\adopt.ps1 -Profile core -Scope project -Target C:\path\to\repo
+   ```
+   Full adopter guide + à-la-carte parts: [docs/setup/use-on-your-project.md](docs/setup/use-on-your-project.md).
+2. **Run / develop himmel standalone** — `git clone https://github.com/yotamleo/himmel && cd himmel && bash scripts/setup.sh` (Windows: `powershell -File scripts\setup.ps1`). Verifies tools, installs the git hooks, builds the Jira CLI, registers the qmd index, writes a ready `.env`. Walkthrough: [docs/getting-started.md](docs/getting-started.md).
+3. **Diagnose an install that already exists** — run the `himmel-ops:himmel-doctor` skill (`/himmel-doctor`): a read-only, severity-grouped health report for the field problems that bite himmel installs (SessionStart `node: command not found`, a shadowed claude-obsidian plugin, a dirty single-writer luna vault, a repo missing from the handover registry, PATH-fragile MCP servers, un-pruned merged-PR worktrees). `--fix` heals the node wiring; everything else points you at the right command.
+
+Lifecycle after install: update with the `himmel-ops:himmel-update` skill (`/himmel-update` — `git pull` + marketplace re-sync; `autoUpdate` does NOT deliver himmel), upgrade a luna vault with `/luna-upgrade`, and offboard with `scripts/uninstall.sh`. All three: [docs/setup/updating.md](docs/setup/updating.md).
 
 ## Start here
 
@@ -27,12 +43,14 @@ If you are an LLM working in this repo, read CLAUDE.md first — it is the autho
 - [docs/internals/jira-plugin.md](docs/internals/jira-plugin.md): the local Jira CLI (`scripts/jira/`) — preferred over the Atlassian MCP server — and the op↔MCP mapping.
 - [plugins/himmel-gh/README.md](plugins/himmel-gh/README.md): forge-agnostic git ops — the worktree→PR→merge loop, PR review threads, and luna-ingest route to `gh` on GitHub or the himmel Bitbucket CLI ([scripts/bitbucket/README.md](scripts/bitbucket/README.md)) on Bitbucket Cloud, chosen per-repo from `origin`.
 - [docs/operator-conventions.md](docs/operator-conventions.md): durable operator working-habits (Jira CLI invocation, CR/merge habits).
+- [docs/hermes-runbook.md](docs/hermes-runbook.md): hermes — himmel's opt-in free-inference junior tier for chore-shaped work. Config lives OUTSIDE the repo (`%LOCALAPPDATA%\hermes` / `$HERMES_HOME`), so it is part of himmel even when absent from a checkout; refreshed by `/himmel-update`.
 - [docs/tooling-catalog.md](docs/tooling-catalog.md): every tool/script/plugin in active use.
 
 ## Setup
 
 - [docs/setup/new-machine.md](docs/setup/new-machine.md): fresh-machine setup — required environment + per-platform (Linux / macOS / Windows Git Bash) install; the user-vs-project hook-scope model (§4b) and the symmetric `uninstall.sh` teardown.
 - [docs/setup/use-on-your-project.md](docs/setup/use-on-your-project.md): adopting the portable core (hooks + worktree workflow) in another repo.
+- [docs/setup/updating.md](docs/setup/updating.md): the update/upgrade lifecycle — `/himmel-update` (harness git pull + marketplace re-sync, incl. the hermes editable-checkout refresh), `/luna-upgrade` (vault template), why a plain `git pull` is required, and the symmetric `scripts/uninstall.sh` offboarding.
 
 ## Optional
 


### PR DESCRIPTION
Surfaces the update/upgrade -> uninstall lifecycle in getting-started + docs index, adds an Uninstalling/offboarding section to updating.md, makes hermes discoverable, and turns llms.txt into a self-sufficient install/doctor front door. Docs-only. (himmel HIMMEL-529)