### PR TITLE
chore(deps): dependabot sync — CI actions (checkout v7 / setup-node v6) + @types/node ^26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
   secret-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: bash scripts/ci/check-no-secrets.sh
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # --severity=warning makes the gate deterministic across shellcheck
       # versions: SC2329 (note-level, "function never invoked") is the only
       # check newer shellchecks add over the pre-commit-pinned 0.10.x, and it
@@ -36,8 +36,8 @@ jobs:
       matrix:
         pkg: [jira, bitbucket, himmel-run]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - run: npm ci
@@ -48,12 +48,12 @@ jobs:
   bun-suites:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
       - run: cd scripts/luna-vitals && bun install --frozen-lockfile && bun test
 
   shell-unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: bash scripts/ci/run-shell-tests.sh

--- a/scripts/bitbucket/package.json
+++ b/scripts/bitbucket/package.json
@@ -19,7 +19,7 @@
     "commander": "^15.0.0"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^26.0.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   }

--- a/scripts/himmel-run/package.json
+++ b/scripts/himmel-run/package.json
@@ -20,7 +20,7 @@
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^26.0.0",
     "@types/proper-lockfile": "^4.1.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"

--- a/scripts/jira/package.json
+++ b/scripts/jira/package.json
@@ -20,7 +20,7 @@
     "commander": "^15.0.0"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^26.0.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   }


### PR DESCRIPTION
Consolidates open dependabot PRs: actions/checkout v4->v7 (#131), actions/setup-node v4->v6 (#130), and @types/node ->^26 in scripts/{jira,bitbucket,himmel-run} (#132/#133/#135). Matches the private mirror end-state (private merged as himmel-private#701). env-paths (#134) held out — ESM-breaking runtime bump, separate pass.