### PR TITLE
chore(deps): bump env-paths 3->4 in himmel-run (dependabot #134)

### DIFF
--- a/scripts/himmel-run/package-lock.json
+++ b/scripts/himmel-run/package-lock.json
@@ -10,14 +10,14 @@
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",
-        "env-paths": "^3.0.0",
+        "env-paths": "^4.0.0",
         "proper-lockfile": "^4.1.2"
       },
       "bin": {
         "himmel-run": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^22.0.0",
+        "@types/node": "^26.0.0",
         "@types/proper-lockfile": "^4.1.4",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9"
@@ -419,13 +419,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/proper-lockfile": {
@@ -605,12 +605,15 @@
       }
     },
     "node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-4.0.0.tgz",
+      "integrity": "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==",
       "license": "MIT",
+      "dependencies": {
+        "is-safe-filename": "^0.1.0"
+      },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -681,6 +684,18 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/is-safe-filename": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-safe-filename/-/is-safe-filename-0.1.1.tgz",
+      "integrity": "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1209,9 +1224,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/scripts/himmel-run/package.json
+++ b/scripts/himmel-run/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "commander": "^15.0.0",
-    "env-paths": "^3.0.0",
+    "env-paths": "^4.0.0",
     "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {

--- a/scripts/himmel-run/tests/paths.test.ts
+++ b/scripts/himmel-run/tests/paths.test.ts
@@ -1,10 +1,24 @@
 import { describe, it, expect } from 'vitest';
+import { isAbsolute } from 'node:path';
+import { platform } from 'node:os';
 import { cacheRoot, tagDir, indexDir, logPath, errPath, repoContextPath } from '../src/paths.js';
 
 describe('paths', () => {
   it('cacheRoot returns himmel-cli under OS cache dir', () => {
     const root = cacheRoot();
     expect(root).toMatch(/himmel-cli$/);
+  });
+
+  it('cacheRoot is absolute and (win32) has the Cache suffix stripped', () => {
+    const root = cacheRoot();
+    expect(isAbsolute(root)).toBe(true);
+    if (platform() === 'win32') {
+      // env-paths appends \Cache to the app dir on Windows; paths.ts strips it
+      // via dirname() so the root ends in \himmel-cli, NOT \himmel-cli\Cache.
+      // Positively pin the stripped layout — guards against an env-paths layout
+      // change (the regression surface of the v3->v4 bump, HIMMEL-547).
+      expect(root).toMatch(/[\\/]himmel-cli$/);
+    }
   });
 
   it('tagDir nests <root>/<tag>', () => {


### PR DESCRIPTION
Bumps env-paths ^3.0.0 -> ^4.0.0 in scripts/himmel-run. v4's only breaking change is Node >= 20 (CI runs Node 22). Still ESM, no API change; cacheRoot() resolves identically. Strengthened tests/paths.test.ts with absolute + win32 stripped-layout invariants. Adds one transitive dep is-safe-filename. Matches private (himmel-private#702). Commander left at public's ^15.0.0.