### PR TITLE
fix: [HIMMEL-548/549] fresh-macOS adopter install failures (bun bootstrap + claude-obsidian HTTPS)

### DIFF
--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -452,6 +452,29 @@ bash Himmel/scripts/machine-setup/install-plugins.sh --scope project
 The plugins carry their own slash commands + skills — that's all you need to use
 them.
 
+### Troubleshooting: `Host key verification failed` on plugin install (HIMMEL-549)
+
+Every `@himmel` plugin installs from the **local** marketplace clone except
+`claude-obsidian`, which is sourced from a separate GitHub repo and is the only
+one Claude Code must `git clone` over the network. himmel's manifest now points
+it at an explicit **HTTPS** url so a fresh machine clones over HTTPS (no SSH
+host key needed). If you still hit:
+
+```
+Failed to clone repository: ... No ED25519 host key is known for github.com
+and you have requested strict checking. Host key verification failed.
+```
+
+your git is rewriting HTTPS → SSH (a `url."git@github.com:".insteadOf
+"https://github.com/"` in `~/.gitconfig`), so the clone resolves over SSH on a
+box with no `github.com` entry in `~/.ssh/known_hosts`. Pre-seed the host key
+once, then retry the install:
+
+```bash
+ssh-keyscan github.com >> ~/.ssh/known_hosts
+claude plugin install claude-obsidian@himmel --scope user
+```
+
 ### Remove / move between scopes
 
 - **Remove (user scope):** `/plugin uninstall <name>@himmel`.

--- a/marketplace/.claude-plugin/marketplace.json
+++ b/marketplace/.claude-plugin/marketplace.json
@@ -78,11 +78,11 @@
     {
       "name": "claude-obsidian",
       "source": {
-        "source": "github",
-        "repo": "yotamleo/claude-obsidian",
+        "source": "url",
+        "url": "https://github.com/yotamleo/claude-obsidian.git",
         "ref": "v1.9.2-himmel.1"
       },
-      "description": "[yotamleo fork — vendor + attribution only, no upstream PR] Claude + Obsidian knowledge companion. Wiki query, save, ingest, lint, autoresearch. Companion to obsidian-triage — its wiki-query skill optionally powers the Phase 4 Related Notes link-graph traversal. Pinned to an immutable tag per himmel supply-chain policy (a bare commit SHA is NOT installable — `claude plugin install` clones via `git clone --branch <ref>`, which only resolves branch/tag names; see marketplace/plugins/obsidian-triage/README.md § Pin update workflow). Fork tracks upstream AgriciDaniel/claude-obsidian (v1.9.2 base) with the unsupported prompt-type SessionStart/PostCompact hooks removed. Original: AgriciDaniel/claude-obsidian.",
+      "description": "[yotamleo fork — vendor + attribution only, no upstream PR] Claude + Obsidian knowledge companion. Wiki query, save, ingest, lint, autoresearch. Companion to obsidian-triage — its wiki-query skill optionally powers the Phase 4 Related Notes link-graph traversal. Sourced via an explicit HTTPS git url (NOT the `github` shorthand, which clones over SSH and fails host-key verification on a fresh machine with no github.com in ~/.ssh/known_hosts — HIMMEL-549). Pinned to an immutable tag per himmel supply-chain policy (a bare commit SHA is NOT installable — `claude plugin install` clones via `git clone --branch <ref>`, which only resolves branch/tag names; see marketplace/plugins/obsidian-triage/README.md § Pin update workflow). Fork tracks upstream AgriciDaniel/claude-obsidian (v1.9.2 base) with the unsupported prompt-type SessionStart/PostCompact hooks removed. Original: AgriciDaniel/claude-obsidian.",
       "author": {
         "name": "AgriciDaniel",
         "url": "https://github.com/AgriciDaniel"

--- a/scripts/check-plugin-drift.sh
+++ b/scripts/check-plugin-drift.sh
@@ -4,8 +4,9 @@
 # forks + pinned plugins current with upstream?" (HIMMEL-322).
 #
 # Two plugin classes are checked, each against its TRUE upstream via `gh api`:
-#   1. Pinned remotes — any plugin in marketplace.json whose source is
-#      {github, repo, ref}. Two sub-cases:
+#   1. Pinned remotes — any plugin in marketplace.json whose source is a git
+#      remote with a ref: {github, repo, ref} or {url, url, ref} (the explicit
+#      HTTPS url form claude-obsidian uses after HIMMEL-549). Two sub-cases:
 #        a. Plain pin (no override): drift = the pinned `ref` (a 40-hex SHA) !=
 #           the marketplace repo's default-branch HEAD. (kepano/obsidian.)
 #        b. Fork-with-upstream override (scripts/plugin-upstreams.json): the
@@ -62,11 +63,22 @@ m = json.load(open(sys.argv[1]))
 ups = {}
 if os.path.exists(sys.argv[2]):
     ups = json.load(open(sys.argv[2]))   # malformed -> raises -> class UNCHECKED
+def repo_of(s):
+    # github source carries owner/repo directly; the explicit-https url source
+    # (claude-obsidian after HIMMEL-549) encodes it in the url. repo is only used
+    # for the plain-pin HEAD compare + message text — fork overrides ignore it.
+    if s.get("source") == "github":
+        return s.get("repo", "")
+    u = s.get("url", "")
+    if "github.com/" in u:
+        r = u.split("github.com/", 1)[1].rstrip("/")
+        return r[:-4] if r.endswith(".git") else r
+    return ""
 for p in m.get("plugins", []):
     s = p.get("source")
-    if isinstance(s, dict) and s.get("source") == "github" and s.get("ref"):
+    if isinstance(s, dict) and s.get("source") in ("github", "url") and s.get("ref"):
         o = ups.get(p["name"]) or {}
-        print("|".join([p["name"], s["repo"], s["ref"],
+        print("|".join([p["name"], repo_of(s), s["ref"],
                         o.get("upstream_repo", ""), o.get("track", ""), o.get("synced_base", "")]))
 PY
 )"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -84,6 +84,15 @@ if [ "${#_missing[@]}" -gt 0 ]; then
   # otherwise leak into this `set -e`-only script. It installs system-wide; we
   # re-check `command -v` below to see what truly remains.
   bash "$SETUP_DIR/setup/ensure-tools.sh" "${_missing[@]}" || true
+  # bun's official installer (ensure-tools.sh) drops the binary in ~/.bun/bin,
+  # which isn't on PATH in this process yet — add it so the re-check below and the
+  # rest of setup find the freshly-installed bun, and hint the operator to persist
+  # it for future shells (HIMMEL-548).
+  if [ -x "$HOME/.bun/bin/bun" ] && ! command -v bun >/dev/null 2>&1; then
+    PATH="$HOME/.bun/bin:$PATH"; export PATH
+    echo "  bun installed to ~/.bun/bin — add it to PATH permanently:"
+    echo "    echo 'export PATH=\"\$HOME/.bun/bin:\$PATH\"' >> ~/.zshrc   # or ~/.bashrc"
+  fi
   _still=()
   for _tool in "${_missing[@]}"; do
     command -v "$_tool" >/dev/null 2>&1 || _still+=("$_tool")

--- a/scripts/setup/ensure-tools.sh
+++ b/scripts/setup/ensure-tools.sh
@@ -6,8 +6,10 @@
 # failed install, the tool simply stays missing and the CALLER fails loud with
 # the manual hint -- ensure_tools never claims success it didn't achieve.
 #
-# Only tools with a known package name are attempted (git, jq, python3). Tools
-# that need a bespoke installer (node, bun, gh) are left to the caller's hint.
+# Tools with a known package name are attempted via the package manager (git,
+# jq, python3). bun has no homebrew-core/apt/dnf package, so it is bootstrapped
+# via its official installer (HIMMEL-548). Tools that still need a bespoke
+# installer (node, gh) are left to the caller's hint.
 #
 # Usage:  source ensure-tools.sh; ensure_tools git jq ...   (re-check after).
 #         bash ensure-tools.sh git jq ...                   (direct).
@@ -32,6 +34,28 @@ _ensure_detect_pm() {
   echo ""; return 1
 }
 
+# bun bootstrap -- bun is not in homebrew-core / apt / dnf, so the official
+# installer is the portable path (mac + linux, no tap). It lands the binary in
+# $HOME/.bun/bin, which is NOT on PATH in this subprocess -- the CALLER (setup.sh)
+# adds ~/.bun/bin to PATH and re-checks. The installer source is captured first
+# (then piped to bash) so a curl failure is detected directly rather than masked
+# by `bash` succeeding on empty stdin. Honest fallback: if curl is absent or the
+# fetch fails, bun stays missing and the caller fails loud with the manual hint.
+_ensure_install_bun() {
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "  ensure-tools: 'bun' needs curl to bootstrap (curl not found) -- install bun manually: https://bun.sh" >&2
+    return 1
+  fi
+  echo "  ensure-tools: installing 'bun' via the official installer (https://bun.sh/install)..."
+  local installer
+  installer=$(curl -fsSL https://bun.sh/install 2>/dev/null) || installer=""
+  if [ -n "$installer" ] && printf '%s' "$installer" | bash >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "  ensure-tools: bun official installer failed -- install bun manually: https://bun.sh" >&2
+  return 1
+}
+
 # Echo the sudo prefix needed for apt/dnf: "" when root, "sudo" when a sudo
 # binary exists, "__NOSUDO__" (rc 1) when neither (caller skips that tool).
 _ensure_sudo_prefix() {
@@ -45,12 +69,19 @@ _ensure_sudo_prefix() {
 ensure_tools() {
   [ "$#" -gt 0 ] || return 0
   local pm t pkg sudo_pfx
-  if ! pm=$(_ensure_detect_pm); then
-    echo "  ensure-tools: no supported package manager (apt-get/dnf/brew) found -- cannot auto-install; install manually." >&2
-    return 0
-  fi
+  pm=$(_ensure_detect_pm) || pm=""   # bun needs no pm; others fall through below
   for t in "$@"; do
     command -v "$t" >/dev/null 2>&1 && continue
+    # bun: no system package -- bootstrap via its official installer (mac + linux),
+    # independent of any package manager.
+    if [ "$t" = bun ]; then
+      _ensure_install_bun
+      continue
+    fi
+    if [ -z "$pm" ]; then
+      echo "  ensure-tools: no supported package manager (apt-get/dnf/brew) found -- cannot auto-install '$t'; install it manually." >&2
+      continue
+    fi
     pkg=$(_ensure_pkg_for "$t")
     if [ -z "$pkg" ]; then
       echo "  ensure-tools: no known $pm package for '$t' -- install it manually." >&2

--- a/scripts/setup/test-setup-preflight.sh
+++ b/scripts/setup/test-setup-preflight.sh
@@ -67,6 +67,59 @@ printf '#!/bin/sh\necho 1000\n' > "$nbin/id"; chmod +x "$nbin/id"
 out=$( PATH="$nbin" ensure_tools git 2>&1 )
 check "SC7 no-sudo message" "$(has 'no root/sudo' "$out")" "yes"
 
+# ── HIMMEL-548 bun branch 1: official installer SUCCEEDS (mocked, no real curl).
+# bun has no homebrew-core/apt/dnf package, so it is bootstrapped via its official
+# installer (`curl -fsSL https://bun.sh/install` piped to bash), which lands the
+# binary in $HOME/.bun/bin. A stub curl emits a tiny installer script on stdout;
+# HOME is a temp dir so the install is hermetic. The install/fail branches call the
+# helper directly (calling `ensure_tools bun` would short-circuit on any ambient
+# bun already on the tester's PATH); the no-curl case below covers the routing.
+bbin="$td/bun-ok"; mkdir -p "$bbin"
+cat > "$bbin/curl" <<'EOF'
+#!/usr/bin/env bash
+# fake bun installer source: emit a script that drops bun into $HOME/.bun/bin.
+cat <<'INSTALLER'
+mkdir -p "$HOME/.bun/bin"
+printf '#!/usr/bin/env bash\necho stub-bun\n' > "$HOME/.bun/bin/bun"
+chmod +x "$HOME/.bun/bin/bun"
+INSTALLER
+EOF
+chmod +x "$bbin/curl"
+bhome="$td/bun-ok-home"; mkdir -p "$bhome"
+out=$( HOME="$bhome" PATH="$bbin:$PATH" _ensure_install_bun 2>&1 )
+present=$( [ -x "$bhome/.bun/bin/bun" ] && echo yes || echo no )
+check "bun official-installer drops bun in ~/.bun/bin" "$present" "yes"
+
+# ── HIMMEL-548 bun branch 2: installer FAILS (curl returns non-zero) → fail-loud,
+# no bun, honest manual hint.
+fbun="$td/bun-fail"; mkdir -p "$fbun"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$fbun/curl"; chmod +x "$fbun/curl"
+fhome="$td/bun-fail-home"; mkdir -p "$fhome"
+out=$( HOME="$fhome" PATH="$fbun:$PATH" _ensure_install_bun 2>&1 )
+check "bun installer-fails leaves no bun" "$( [ -x "$fhome/.bun/bin/bun" ] && echo yes || echo no )" "no"
+check "bun installer-fails manual hint" "$(has 'install bun manually' "$out")" "yes"
+
+# ── HIMMEL-548 bun branch 2b: curl SUCCEEDS but the installer BODY fails (network
+# OK, install script errors) — the more realistic production failure. A stub curl
+# emits a non-empty installer that exits non-zero when piped to bash → fail-loud,
+# no bun, same honest manual hint as the curl-fails path.
+xbun="$td/bun-installerfail"; mkdir -p "$xbun"
+printf '#!/usr/bin/env bash\necho exit 1\n' > "$xbun/curl"; chmod +x "$xbun/curl"
+xhome="$td/bun-installerfail-home"; mkdir -p "$xhome"
+out=$( HOME="$xhome" PATH="$xbun:$PATH" _ensure_install_bun 2>&1 )
+check "bun installer-body-fails leaves no bun" "$( [ -x "$xhome/.bun/bin/bun" ] && echo yes || echo no )" "no"
+check "bun installer-body-fails manual hint" "$(has 'install bun manually' "$out")" "yes"
+
+# ── HIMMEL-548 bun branch 3: routed through ensure_tools, curl absent → fail-loud
+# manual hint (no crash). Empty PATH guarantees no ambient bun short-circuits it.
+out=$( HOME="$td/bun-nocurl-home" PATH="$td/empty-nonexistent" ensure_tools bun 2>&1 )
+check "bun no-curl manual hint" "$(has 'needs curl' "$out")" "yes"
+
+# ── HIMMEL-548 setup.sh: ~/.bun/bin is added to PATH after ensure-tools so the
+# re-check + downstream see a freshly-installed bun, and a persist-PATH hint is
+# printed. Assert the wiring exists in setup.sh.
+check "setup.sh adds ~/.bun/bin to PATH" "$(has 'HOME/.bun/bin' "$(cat "$setup_sh")")" "yes"
+
 # ── SC7 ordering invariant: REPO_ROOT git rev-parse runs AFTER the preflight.
 # Line number of the [0/10] preflight banner vs the REPO_ROOT assignment.
 pf_line=$(grep -n '\[0/10\] Verifying foundational tools' "$setup_sh" | head -1 | cut -d: -f1)

--- a/scripts/test-check-plugin-drift.sh
+++ b/scripts/test-check-plugin-drift.sh
@@ -13,15 +13,17 @@ bad() { echo "FAIL - $1" >&2; fails=$((fails + 1)); }
 # 1. Syntax.
 if bash -n "$SCRIPT"; then ok "syntax (bash -n)"; else bad "syntax"; fi
 
-# 2. The marketplace.json parser yields the github-pinned remotes (>=1; expect
-#    claude-obsidian — obsidian/kepano was dropped, it installs from its own
-#    marketplace, HIMMEL-435). Mirrors the script's own parser.
+# 2. The marketplace.json parser yields the git-remote pinned remotes (>=1; expect
+#    claude-obsidian — sourced via an explicit HTTPS url since HIMMEL-549, so the
+#    parser must accept both the {github,repo} and {url,url} shapes; obsidian/kepano
+#    was dropped, it installs from its own marketplace, HIMMEL-435). Mirrors the
+#    script's own parser.
 pins="$(python3 - "$MJSON" <<'PY' | tr -d '\r'
 import json, sys
 m = json.load(open(sys.argv[1]))
 for p in m.get("plugins", []):
     s = p.get("source")
-    if isinstance(s, dict) and s.get("source") == "github" and s.get("ref"):
+    if isinstance(s, dict) and s.get("source") in ("github", "url") and s.get("ref"):
         print(p["name"])
 PY
 )"
@@ -55,11 +57,19 @@ if [ -f "$UPS" ]; then
 import json, os, sys
 m = json.load(open(sys.argv[1]))
 ups = json.load(open(sys.argv[2])) if os.path.exists(sys.argv[2]) else {}
+def repo_of(s):
+    if s.get("source") == "github":
+        return s.get("repo", "")
+    u = s.get("url", "")
+    if "github.com/" in u:
+        r = u.split("github.com/", 1)[1].rstrip("/")
+        return r[:-4] if r.endswith(".git") else r
+    return ""
 for p in m.get("plugins", []):
     s = p.get("source")
-    if isinstance(s, dict) and s.get("source") == "github" and s.get("ref"):
+    if isinstance(s, dict) and s.get("source") in ("github", "url") and s.get("ref"):
         o = ups.get(p["name"]) or {}
-        print("|".join([p["name"], s["repo"], s["ref"],
+        print("|".join([p["name"], repo_of(s), s["ref"],
                         o.get("upstream_repo", ""), o.get("track", ""), o.get("synced_base", "")]))
 PY
 )"


### PR DESCRIPTION
## Summary

Fixes two fresh-macOS adopter install failures.

### HIMMEL-548 — bun not auto-installable on macOS (blocked setup.sh)
ensure-tools.sh now bootstraps bun via its official installer (curl -fsSL https://bun.sh/install captured then piped to bash; honest-fallback preserved), and setup.sh adds ~/.bun/bin to PATH + prints a persist hint. bun has no homebrew-core/apt/dnf package, so the [0/10] preflight used to abort. +5 hermetic mocked-installer tests.

### HIMMEL-549 — claude-obsidian clone failed on fresh mac (SSH host-key)
Switched the marketplace source from the github shorthand (clones over SSH → host-key failure on a fresh mac) to the explicit-HTTPS url type, keeping the immutable-tag pin. Adds an ssh-keyscan troubleshooting note for the residual user-side https→ssh rewrite case, and teaches the upstream-drift checker the url source shape.

## Tests
+5 hermetic bun cases + drift-parser tests for the url shape. All green; bash -n + shellcheck clean; marketplace.json validates.

## Platforms
Platforms tested: windows (Git Bash, hermetic). Fixes target macOS; logic is bash 3.2-safe. A live mac smoke is recommended before relying on it in production.
