### PR TITLE
chore(deps): [HIMMEL-553] regenerate luna-correlate bun.lock to match…

### DIFF
--- a/marketplace/plugins/luna-correlate/bun.lock
+++ b/marketplace/plugins/luna-correlate/bun.lock
@@ -9,7 +9,7 @@
       },
       "devDependencies": {
         "bun-types": "^1.3.14",
-        "typescript": "^5",
+        "typescript": "^6",
       },
     },
   },
@@ -188,7 +188,7 @@
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 


### PR DESCRIPTION
… package.json (typescript ^6)

The committed package.json declares typescript ^6 but this lockfile still pinned ^5/5.9.3, so a fresh 'bun install' rewrote it and adopters saw a spurious bun.lock diff. Regenerated with bun 1.3.14 -> typescript 6.0.3, matching package.json and the private surface.