### PR TITLE
fix(where-are-we): [HIMMEL-567] surface In-Progress tickets (jira --limit 25 truncation)

### DIFF
--- a/scripts/where-are-we/collect.mjs
+++ b/scripts/where-are-we/collect.mjs
@@ -4,7 +4,19 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, join } from 'node:path';
 import { jiraRecords, prRecords, gitRecords } from './lib/collect.mjs';
 import { appendRecords } from './lib/append.mjs';
+import { readRecords } from './lib/ledger.mjs';
+import { fold, inFlight } from './lib/fold.mjs';
 import { UsageError } from './lib/errors.mjs';
+
+// Well-formed Jira ticket key, e.g. HIMMEL-567 / LUNA-44. Used both to filter
+// the active-key set passed into the Done self-clear query (no JQL injection)
+// and to keep PR keys (#7) out of it.
+const TICKET_KEY_RE = /^[A-Z][A-Z0-9]+-\d+$/;
+
+// Explicit page size for the live working set. The jira CLI defaults to
+// --limit 25; In-Progress + To-Do are well under this but the default is a trap
+// (HIMMEL-567), so we pin a high ceiling rather than rely on it.
+const JIRA_LIMIT = '200';
 
 // ---------------------------------------------------------------------------
 // Live readers (impure — each degrades gracefully to [] / '' on failure)
@@ -16,29 +28,59 @@ import { UsageError } from './lib/errors.mjs';
 const _repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const _jiraCli = join(_repoRoot, 'scripts', 'jira', 'dist', 'index.js');
 
-function readJira() {
-  try {
-    // 'Done' is intentional: terminal tickets must be read so a Done transition
-    // self-clears the ticket from the in-flight view (fold drops terminal items).
-    // Do NOT drop Done — that would leave stale in-progress entries forever.
-    const out = execFileSync(process.execPath, [_jiraCli, 'list', '--status', 'To Do,In Progress,Done'], { encoding: 'utf8' });
-    const rows = [];
-    for (const line of out.split('\n')) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      const cols = trimmed.split('\t');
-      // columns: KEY\tTYPE\tSTATUS\tTITLE
-      if (cols.length < 3) continue;
-      const key = cols[0].trim();
-      const status = cols[2].trim();
-      if (!key || !status || key === 'KEY') continue; // skip header if any
-      rows.push({ key, status });
-    }
-    return rows;
-  } catch (err) {
-    console.error('[where-are-we] jira reader unavailable:', err.message);
-    return [];
+// Build the jira CLI arg-lists for one collection pass. Pure + exported so the
+// query shapes (per-status, explicit --limit, scoped Done) are unit-testable
+// without shelling out.
+//
+// The old single `--status 'To Do,In Progress,Done'` query truncated at the CLI
+// default of 25 rows — with hundreds of historical Done tickets matching, the
+// page filled before any In-Progress row, so live work never reached the ledger
+// (HIMMEL-567). Instead:
+//   - In-Progress + To-Do are read on their own with an explicit high --limit
+//     (the real in-flight working set, always small);
+//   - Done is read ONLY for keys already tracked in-flight, so a Done transition
+//     still self-clears (fold treats 'done' as terminal) without re-reading the
+//     entire unbounded Done history each pass.
+export function jiraQueries(activeKeys = []) {
+  const queries = [
+    ['list', '--status', 'In Progress', '--limit', JIRA_LIMIT],
+    ['list', '--status', 'To Do', '--limit', JIRA_LIMIT],
+  ];
+  const safeKeys = activeKeys.filter((k) => TICKET_KEY_RE.test(k));
+  if (safeKeys.length) {
+    queries.push(['list', '--jql', `status = Done AND key in (${safeKeys.join(',')})`]);
   }
+  return queries;
+}
+
+function parseJiraRows(out) {
+  const rows = [];
+  for (const line of out.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const cols = trimmed.split('\t');
+    // columns: KEY\tTYPE\tSTATUS\tTITLE
+    if (cols.length < 3) continue;
+    const key = cols[0].trim();
+    const status = cols[2].trim();
+    if (!key || !status || key === 'KEY') continue; // skip header if any
+    rows.push({ key, status });
+  }
+  return rows;
+}
+
+function readJira(activeKeys = []) {
+  const rows = [];
+  for (const args of jiraQueries(activeKeys)) {
+    try {
+      const out = execFileSync(process.execPath, [_jiraCli, ...args], { encoding: 'utf8' });
+      rows.push(...parseJiraRows(out));
+    } catch (err) {
+      // One failed query degrades to skipping it — partial data beats none.
+      console.error('[where-are-we] jira reader unavailable:', err.message);
+    }
+  }
+  return rows;
 }
 
 function readPRs() {
@@ -64,11 +106,26 @@ function readWorktrees() {
 // collectAll — wiring (exported for testing with injected readers)
 // ---------------------------------------------------------------------------
 
-export function collectAll(now, readers = { readJira, readPRs, readWorktrees }) {
-  const jira = jiraRecords(readers.readJira(), now);
+export function collectAll(now, readers = { readJira, readPRs, readWorktrees }, activeKeys = []) {
+  const jira = jiraRecords(readers.readJira(activeKeys), now);
   const prs = prRecords(readers.readPRs(), now);
   const git = gitRecords(readers.readWorktrees(), now);
   return [...jira, ...prs, ...git];
+}
+
+// Non-terminal ticket keys currently in the ledger — the set whose Done
+// transitions we must re-read so they self-clear. Fail-open: an unreadable or
+// malformed ledger yields no keys (skip the Done read, never throw the collect).
+function activeTicketKeys(ledgerPath) {
+  let records;
+  try {
+    records = readRecords(ledgerPath);
+  } catch {
+    return [];
+  }
+  return inFlight(fold(records))
+    .filter((it) => it.kind === 'ticket' && TICKET_KEY_RE.test(it.key))
+    .map((it) => it.key);
 }
 
 // ---------------------------------------------------------------------------
@@ -90,7 +147,8 @@ export function main(argv, { readers } = {}) {
   const now = a.now ?? new Date().toISOString();
   const effectiveReaders = readers ?? { readJira, readPRs, readWorktrees };
 
-  const records = collectAll(now, effectiveReaders);
+  const activeKeys = activeTicketKeys(a.ledger);
+  const records = collectAll(now, effectiveReaders, activeKeys);
   const r = appendRecords(a.ledger, records);
   const summary = `appended=${r.appended} dropped=${r.dropped}`;
   if (r.dropped > 0) {

--- a/scripts/where-are-we/tests/collect.jira-limit.test.mjs
+++ b/scripts/where-are-we/tests/collect.jira-limit.test.mjs
@@ -1,0 +1,68 @@
+// scripts/where-are-we/tests/collect.jira-limit.test.mjs
+// HIMMEL-567: the collector queried `jira list --status 'To Do,In Progress,Done'`
+// with no --limit. The CLI defaults to --limit 25, and with Done in the filter
+// (hundreds of historical tickets) the 25-row page filled with To-Do rows — live
+// In-Progress tickets never entered the ledger ("In flight: none" while work was
+// in progress). These tests pin the fix: per-status queries with an explicit high
+// limit, plus a Done read scoped to the active in-flight keys (for self-clear).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { jiraQueries, main } from '../collect.mjs';
+
+const statusOf = (q) => q[q.indexOf('--status') + 1];
+const isStatusQuery = (q) => q.includes('--status');
+const isDoneQuery = (q) => q.some((a) => typeof a === 'string' && a.startsWith('status = Done'));
+
+test('jiraQueries: pulls In Progress and To Do as separate queries (no combined comma filter)', () => {
+  const statuses = jiraQueries([]).filter(isStatusQuery).map(statusOf);
+  assert.ok(statuses.includes('In Progress'), 'must query In Progress on its own');
+  assert.ok(statuses.includes('To Do'), 'must query To Do on its own');
+  assert.ok(!statuses.some((s) => s.includes(',')), 'must NOT use a combined comma status filter (the truncation source)');
+});
+
+test('jiraQueries: every status query carries an explicit --limit above the CLI default of 25', () => {
+  for (const q of jiraQueries([]).filter(isStatusQuery)) {
+    const li = q.indexOf('--limit');
+    assert.ok(li !== -1, 'each status query must pass --limit');
+    assert.ok(Number(q[li + 1]) > 25, 'limit must exceed the CLI default of 25');
+  }
+});
+
+test('jiraQueries: no Done query when nothing is in flight', () => {
+  assert.ok(!jiraQueries([]).some(isDoneQuery), 'empty active set → no Done query');
+});
+
+test('jiraQueries: Done self-clear is scoped to the active in-flight keys only', () => {
+  const done = jiraQueries(['HIMMEL-1', 'HIMMEL-2']).find(isDoneQuery);
+  assert.ok(done, 'active keys → a Done-by-keys query');
+  const jql = done[done.indexOf('--jql') + 1];
+  assert.match(jql, /key in \(HIMMEL-1,HIMMEL-2\)/);
+});
+
+test('jiraQueries: sanitizes keys so a malformed entry cannot inject JQL', () => {
+  const done = jiraQueries(['HIMMEL-1', 'HIMMEL-1) OR status != Done --', 'evil']).find(isDoneQuery);
+  const jql = done[done.indexOf('--jql') + 1];
+  assert.match(jql, /key in \(HIMMEL-1\)$/, 'only well-formed ticket keys survive');
+});
+
+test('main: derives active in-flight ticket keys from the ledger and scopes the Done read to them', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'waw-jira-limit-'));
+  const ledger = join(dir, 'ledger.jsonl');
+  writeFileSync(ledger, [
+    JSON.stringify({ ts: '2026-01-01T00:00:00Z', source: 'jira', key: 'HIMMEL-1', kind: 'ticket', status: 'in-progress' }),
+    JSON.stringify({ ts: '2026-01-01T00:00:00Z', source: 'jira', key: 'HIMMEL-2', kind: 'ticket', status: 'done' }),
+    JSON.stringify({ ts: '2026-01-01T00:00:00Z', source: 'pr', key: '#7', kind: 'pr', status: 'open', branch: 'feat/x' }),
+  ].join('\n') + '\n');
+
+  let captured = null;
+  const readers = {
+    readJira: (activeKeys) => { captured = activeKeys; return []; },
+    readPRs: () => [],
+    readWorktrees: () => '',
+  };
+  main(['--ledger', ledger, '--now', '2026-02-01T00:00:00Z'], { readers });
+  assert.deepEqual(captured, ['HIMMEL-1'], 'only the non-terminal ticket key is passed for the Done self-clear read');
+});


### PR DESCRIPTION
Split the combined To-Do/In-Progress/Done jira read (capped at --limit 25, dropping live In-Progress rows) into per-status reads with explicit --limit + a Done read scoped to in-flight keys for self-clear. 6 new tests; verified on Windows.