### PR TITLE
docs(luna): document auto-memory to vault compounding + capture map

### DIFF
--- a/docs/luna/compounding.md
+++ b/docs/luna/compounding.md
@@ -6,6 +6,17 @@ feeds the next stage. This document describes the loop, what each stage
 adds, the recommended cadence, and how to seed the vault with historical
 sessions.
 
+There are **two complementary compounding loops**, and they feed different
+kinds of knowledge into the same vault:
+
+1. **The clips / session-capture loop** (most of this document) — turns raw
+   session output and inbox clips into triaged, synthesized vault content.
+2. **The auto-memory → vault loop** ([below](#a-second-loop-auto-memory--vault))
+   — periodically distils Claude Code's own per-project *auto-memory* (the
+   always-loaded `MEMORY.md` index plus its topic files) into searchable vault
+   reference notes, so durable learnings survive while the always-loaded index
+   stays lean.
+
 ## The loop
 
 ```
@@ -97,6 +108,78 @@ Recommended steps:
 
 Full flag reference: [`/luna-backfill`](../../.claude/commands/luna-backfill.md)
 (or type `/luna-backfill --help` in a Claude Code session).
+
+## A second loop: auto-memory → vault
+
+Claude Code keeps a per-project **auto-memory** store
+(`~/.claude/projects/<project-slug>/memory/`): a `MEMORY.md` index that is
+loaded into context *every session*, plus one topic file per remembered fact.
+It grows by itself — each session that learns something durable (a gotcha, a
+preference, a project decision) appends an entry. That is exactly what makes it
+valuable *and* what eventually makes it a liability: an index that is paid for
+on every single turn cannot grow without bound. Left alone it bloats past its
+size budget, and once it is too long it stops being read — by you and by Claude.
+
+The fix is the same compounding move the clips loop makes, pointed at a
+different source. **Periodically distil the auto-memory into the vault:**
+
+1. **Mine** each topic file for the *durable* learning it carries — the
+   reusable gotcha or decision — as distinct from ephemeral status (PR numbers,
+   "merged", ticket state, dates). Status is already recoverable from your issue
+   tracker, git history, and the session captures in `sessions/`.
+2. **Land** that learning in a vault reference note under `30-Resources/`
+   (grouped by theme — environment traps, harness gotchas, operator
+   conventions, …) so it becomes [qmd](../tooling-catalog.md)-searchable
+   substrate rather than always-loaded weight.
+3. **Slim** the `MEMORY.md` index: drop the now-compounded entry, or collapse it
+   to a one-line pointer (`… → vault [[note-name]]`). Keep every topic file until
+   you have re-indexed and confirmed the moved content is findable, then delete it.
+
+The ordering matters: **land the knowledge in the vault before trimming the
+index**, and re-index (`qmd update` + `qmd embed`) and spot-check findability
+before deleting any source file. Done in that order the move is zero-loss — the
+learning is now searchable substrate, and the always-loaded index shrinks back
+under budget.
+
+This is a manual, operator-cadenced pass (run it when `MEMORY.md` approaches its
+size limit), not an automatic hook — it requires judgement about what is durable
+versus disposable. It is one of several capture paths, mapped next.
+
+## What reaches the vault — automatic vs manual
+
+A new user reading "Stage 1 — Capture (automatic)" above can assume *everything*
+ends up in the vault. It does not. The automatic capture writes a session
+**summary** on a graceful exit — it does **not** capture the mid-session
+*findings, decisions, and learnings* themselves. Those reach the vault only when
+you **explicitly invoke a capture skill**. Knowing which paths are automatic,
+which are scheduled, and which are manual is the difference between a vault that
+quietly compounds and one with silent gaps.
+
+| Tier | What it captures | Entry point |
+|------|------------------|-------------|
+| **Automatic** | Session **summary** (decisions/commands/follow-ups) on graceful `SessionEnd` — enabled by default (HIMMEL-469) | `end-session-wiki` hook — no action required |
+| **Semi-automatic** (scheduled) | Inbox clips → triaged + synthesized notes; periodic vault health | `/pipeline-cadence arm` schedules `/harvest-clips`→`/triage-clips` (daily), `/synthesize-clips`→`/archive-clips` (weekly), `/obsidian-health` (monthly). Generic `/schedule` + `/loop` drive any recurring pass. |
+| **Manual** (you invoke it) | The mid-session findings/sources the automatic path misses | see list below |
+
+**Manual capture — what you must invoke explicitly:**
+
+- **A conversation's findings/decisions** → the vault's obsidian-second-brain
+  capture skills: `/obsidian-save` (everything worth keeping from the chat),
+  `/obsidian-log` (a dev/work session), `/obsidian-capture` (a quick idea). This
+  is the path the "automatic" summary does **not** cover.
+- **A repo / issue / PR URL** → `/luna-ingest <url>` (obsidian-triage) — fetches,
+  classifies, and files a structured note under `30-Resources/Tech/`.
+- **A Telegram message / URL / forward** → `/telegram-clip` files it into
+  `Clippings/` for the harvest pipeline to pick up.
+- **Open-web research** → the obsidian-second-brain research toolkit
+  (`/research`, `/research-deep`); grounded research → `/notebooklm`.
+- **Historical Claude Code sessions** (pre-vault) → `/luna-backfill`.
+- **Claude Code's own auto-memory** → the distil pass in
+  [the section above](#a-second-loop-auto-memory--vault).
+
+The automatic and scheduled tiers keep the raw corpus flowing in on their own;
+the manual tier is where you decide what is worth keeping — and it is the only
+tier that captures the substance of a working session, not just its summary.
 
 ## What the loop gives you over time
 


### PR DESCRIPTION
Adds a second compounding loop (distil Claude Code auto-memory into vault reference notes) and a three-tier automatic/semi-automatic/manual capture map to docs/luna/compounding.md.