### PR TITLE
fix(obsidian-triage): resolve telegram digest chat + reply target from composite msg ids

### DIFF
--- a/marketplace/plugins/obsidian-triage/tests/test-synthesize-telegram-digest.sh
+++ b/marketplace/plugins/obsidian-triage/tests/test-synthesize-telegram-digest.sh
@@ -80,7 +80,7 @@ mkvault() {
 }
 
 # ── Vault A: two telegram-origin clips on one concept → 1 stub, 1 digest ──────
-A="$(mktemp -d)"; trap 'rm -rf "$A" "$B" "$C"' EXIT
+A="$(mktemp -d)"; trap 'rm -rf "$A" "$B" "$C" "$E"' EXIT
 mkvault "$A"
 tg_clip "$A" tg1.md "Alice R" "https://alpha.com/x"  "agent-loops" 555 11
 tg_clip "$A" tg2.md "Bob W"   "https://beta.org/y"   "agent-loops" 555 12
@@ -135,7 +135,47 @@ node "$TOOL" "$C" --apply --no-telegram-digest >/dev/null 2>&1
 if [ -f "$DIGEST_C" ]; then f=present; else f=absent; fi
 assert "no digest written under --no-telegram-digest" "absent" "$f"
 
-echo "Test 5: structural — synthesize-stubs runbook documents the digest send"
+# ── Vault E: real-bridge COMPOSITE telegram_msg_id, NO separate chat_id ──────
+# Some bridges file chat+message into one composite id. The digest must derive
+# the chat + numeric reply target from it end-to-end — no telegram_chat_id, no
+# backfill (the pre-LUNA-91 clips still work).
+E="$(mktemp -d)"
+mkvault "$E"
+comp_clip() { # name author url tag composite_msg_id
+    cat > "$E/Clippings/_evidence/$1" <<EOF
+---
+title: "comp $1"
+author: $2
+source: $3
+harvest_url_canonical: $3
+type: article
+processed: true
+triaged_at: 2026-06-28
+evidence_kind:
+  - concepts
+clipped_via: telegram
+telegram_sender: "1087968824"
+telegram_msg_id: "$5"
+tags:
+  - $4
+---
+clip $1
+EOF
+}
+comp_clip e1.md "Gina P" "https://one.com/x" "voice-ui" "telegram-tg-group_-1003985279697-1782605997"
+comp_clip e2.md "Hal R"  "https://two.org/y" "voice-ui" "tg-group_-1003985279697-1782605414-7"
+DIGEST_E="$E/.synthesize-stubs.telegram-digest.json"
+
+echo "Test 5: composite telegram_msg_id (no chat_id) → digest with derived chat + numeric reply_to"
+node "$TOOL" "$E" --apply >/dev/null 2>&1
+if [ -f "$DIGEST_E" ]; then f=yes; else f=no; fi
+assert "digest written from composite-id telegram clips" "yes" "$f"
+chat_e=$(node -e 'const j=require(process.argv[1]); console.log(j.replies[0].chat_id)' "$DIGEST_E" 2>/dev/null)
+assert "chat derived from the composite id" "-1003985279697" "$chat_e"
+reply_e=$(node -e 'const j=require(process.argv[1]); console.log(j.replies[0].reply_to)' "$DIGEST_E" 2>/dev/null)
+assert "reply_to is the numeric message id (most recent)" "1782605997" "$reply_e"
+
+echo "Test 6: structural — synthesize-stubs runbook documents the digest send"
 if grep -qF 'telegram-digest.json' "$PLUGIN_DIR/commands/synthesize-stubs.md"; then f=yes; else f=no; fi
 assert "synthesize-stubs.md documents the telegram digest reply step" "yes" "$f"
 

--- a/marketplace/plugins/obsidian-triage/tests/test-telegram-digest.mjs
+++ b/marketplace/plugins/obsidian-triage/tests/test-telegram-digest.mjs
@@ -12,7 +12,7 @@
  *   - suppress (migration backfill) → no messages.
  *   - reply threads under the most recent contributing message id.
  */
-import { buildPromotionDigest, basenameLink, renderDigestText } from "../tools/lib/telegram-digest.mjs";
+import { buildPromotionDigest, basenameLink, renderDigestText, parseTelegramRef } from "../tools/lib/telegram-digest.mjs";
 
 let pass = 0, fail = 0;
 function assert(desc, expected, actual) {
@@ -73,9 +73,38 @@ const twoChats = [
 ];
 assert("two originating chats → two messages (one each)", 2, buildPromotionDigest(twoChats).length);
 
-// A telegram clip missing chat_id can't be targeted → excluded.
+// A telegram clip with a bare numeric msg id and no chat_id can't be targeted.
 const noChat = [{ subject: "[[A]]", clip: { clipped_via: "telegram", telegram_msg_id: "9" } }];
-assert("telegram clip without chat_id → no message", 0, buildPromotionDigest(noChat).length);
+assert("telegram clip without chat_id (bare numeric msg id) → no message", 0, buildPromotionDigest(noChat).length);
+
+// ── Composite bridge id form (real vault shape): telegram-tg-group_<chat>-<msg>[-<drop>]
+// Some bridges file the chat+message_id into a single composite telegram_msg_id.
+// The digest must derive both the chat AND a NUMERIC reply target from it, with
+// no separate telegram_chat_id and no vault backfill.
+const single = "telegram-tg-group_-1003985279697-1782605997"; // single message
+const drop   = "tg-group_-1003985279697-1782605414-7";        // one drop of a multi-link msg
+
+assert("parseTelegramRef derives chat + numeric msg from a composite id",
+  { chatId: "-1003985279697", replyTo: "1782605997" }, parseTelegramRef({ telegram_msg_id: single }));
+assert("parseTelegramRef strips the multi-drop suffix to the real message id",
+  { chatId: "-1003985279697", replyTo: "1782605414" }, parseTelegramRef({ telegram_msg_id: drop }));
+assert("parseTelegramRef prefers an explicit telegram_chat_id over the embedded one",
+  { chatId: "777", replyTo: "1782605997" }, parseTelegramRef({ telegram_chat_id: "777", telegram_msg_id: single }));
+
+// A composite-id clip with NO separate chat_id still yields one digest, chat +
+// reply_to recovered from the id (the 7 pre-LUNA-91 clips work, zero backfill).
+const composite = [{ subject: "[[30-Resources/Concepts/Voicebox]]", clip: { clipped_via: "telegram", telegram_msg_id: single } }];
+const dComp = buildPromotionDigest(composite);
+assert("composite-id clip (no separate chat_id) → one message", 1, dComp.length);
+assert("composite digest targets the embedded chat", "-1003985279697", dComp[0].chat_id);
+assert("composite digest threads under the embedded numeric message id", "1782605997", dComp[0].reply_to);
+
+// reply_to is OPTIONAL: a clean chat_id but an unparseable msg id → still sends,
+// just unthreaded (reply_to null), never a bogus non-numeric reply target.
+const unthreaded = [{ subject: "[[A]]", clip: { clipped_via: "telegram", telegram_chat_id: "555", telegram_msg_id: "weird-id" } }];
+const dUnthreaded = buildPromotionDigest(unthreaded);
+assert("unparseable msg id with chat_id → one message", 1, dUnthreaded.length);
+assert("unparseable msg id → reply_to null (send unthreaded, not a bogus id)", null, dUnthreaded[0].reply_to);
 
 // Helpers.
 assert("basenameLink strips the path", "[[Context-Windows]]", basenameLink("[[30-Resources/Concepts/Context-Windows]]"));

--- a/marketplace/plugins/obsidian-triage/tools/lib/telegram-digest.mjs
+++ b/marketplace/plugins/obsidian-triage/tools/lib/telegram-digest.mjs
@@ -22,15 +22,46 @@ export function basenameLink(link) {
   return `[[${base}]]`;
 }
 
-/** reply_to target for a chat: the numerically-largest (most recent) msg id when
- *  all are numeric, else the first seen — deterministic either way. */
-export function pickReplyTo(msgIds) {
-  const ids = (msgIds || []).map((s) => String(s)).filter(Boolean);
-  if (!ids.length) return null;
-  if (ids.every((s) => /^\d+$/.test(s))) {
-    return ids.reduce((a, b) => (BigInt(b) > BigInt(a) ? b : a));
+/**
+ * Composite telegram id form some bridges file under, e.g.
+ * `telegram-tg-group_-1003985279697-1782605997` (single) or
+ * `tg-group_-1003985279697-1782605414-7` (one drop of a multi-link message):
+ * `…_<chat_id>-<message_id>[-<drop>]`, chat possibly negative (supergroup).
+ * Captures group 1 = chat_id, group 2 = the numeric Telegram message_id.
+ */
+const COMPOSITE_REF_RE = /_(-?\d+)-(\d+)(?:-\d+)?$/;
+
+/**
+ * Resolve a clip's chat id + a NUMERIC reply target from its telegram fields,
+ * tolerant of both the clean shape (separate `telegram_chat_id`, numeric
+ * `telegram_msg_id`) and a composite `telegram_msg_id` that embeds both. The
+ * digest never reaches into the vault — this derives from what the clip already
+ * carries, so composite-id clips work for replies with no backfill.
+ * @returns {{chatId:string|null, replyTo:string|null}} replyTo is null when no
+ *          numeric message id is recoverable (→ send the reply unthreaded).
+ */
+export function parseTelegramRef(clip) {
+  const c = clip || {};
+  const rawMsg = c.telegram_msg_id != null ? String(c.telegram_msg_id) : "";
+  let chatId = (c.telegram_chat_id != null && String(c.telegram_chat_id) !== "")
+    ? String(c.telegram_chat_id) : null;
+  let replyTo = /^\d+$/.test(rawMsg) ? rawMsg : null;
+  if (!chatId || !replyTo) {
+    const m = rawMsg.match(COMPOSITE_REF_RE);
+    if (m) {
+      if (!chatId) chatId = m[1];
+      if (!replyTo) replyTo = m[2];
+    }
   }
-  return ids[0];
+  return { chatId, replyTo };
+}
+
+/** reply_to target for a chat: the numerically-largest (most recent) message id
+ *  among the resolved numeric targets, or null (→ unthreaded) when none. */
+export function pickReplyTo(replyTargets) {
+  const ids = (replyTargets || []).map((s) => String(s)).filter((s) => /^\d+$/.test(s));
+  if (!ids.length) return null;
+  return ids.reduce((a, b) => (BigInt(b) > BigInt(a) ? b : a));
 }
 
 /** "📌 Saved → now a subject: [[X]]" / "… now subjects: [[X]], [[Y]]". */
@@ -47,28 +78,32 @@ export function renderDigestText(subjectLinks) {
  *                telegram_chat_id?:string}}>} promotions — one entry per
  *        (subject, contributing-clip) newly promoted in THIS run.
  * @param {{suppress?:boolean}} [opts] — suppress=true (migration backfill) → [].
+ * Chat id + reply target are resolved via parseTelegramRef, so clips whose
+ * bridge filed a composite `telegram_msg_id` (chat embedded, no separate
+ * `telegram_chat_id`) still produce a correctly-targeted reply with no backfill.
+ *
  * @returns {Array<{chat_id:string, reply_to:string|null, text:string}>} at most
- *          one digest per originating telegram chat. Empty when there are no
- *          telegram-origin promotions or when suppressed. Distinct subjects only
- *          (a subject promoted from two telegram clips is listed once).
+ *          one digest per originating telegram chat. reply_to is null when no
+ *          numeric message id is recoverable (→ send unthreaded). Empty when
+ *          there are no telegram-origin promotions or when suppressed. Distinct
+ *          subjects only (a subject promoted from two telegram clips is once).
  */
 export function buildPromotionDigest(promotions, opts = {}) {
   if (opts.suppress) return [];
-  const byChat = new Map(); // chat_id -> { subjects:[], seen:Set, msgIds:[] }
+  const byChat = new Map(); // chat_id -> { subjects:[], seen:Set, replyTos:[] }
   for (const p of promotions || []) {
     const c = p && p.clip;
-    if (!c || c.clipped_via !== "telegram") continue;
-    const chatId = c.telegram_chat_id;
-    const msgId = c.telegram_msg_id;
-    if (!chatId || !msgId || !p.subject) continue;
-    let g = byChat.get(String(chatId));
-    if (!g) { g = { subjects: [], seen: new Set(), msgIds: [] }; byChat.set(String(chatId), g); }
+    if (!c || c.clipped_via !== "telegram" || !p.subject) continue;
+    const { chatId, replyTo } = parseTelegramRef(c);
+    if (!chatId) continue; // no chat to target → can't reply
+    let g = byChat.get(chatId);
+    if (!g) { g = { subjects: [], seen: new Set(), replyTos: [] }; byChat.set(chatId, g); }
     if (!g.seen.has(p.subject)) { g.seen.add(p.subject); g.subjects.push(p.subject); }
-    g.msgIds.push(String(msgId));
+    if (replyTo) g.replyTos.push(replyTo);
   }
   const digests = [];
   for (const [chatId, g] of byChat) {
-    digests.push({ chat_id: chatId, reply_to: pickReplyTo(g.msgIds), text: renderDigestText(g.subjects) });
+    digests.push({ chat_id: chatId, reply_to: pickReplyTo(g.replyTos), text: renderDigestText(g.subjects) });
   }
   return digests;
 }


### PR DESCRIPTION
Derive chat id + numeric reply target from clean OR composite telegram_msg_id, so composite-id captures route promotion replies correctly with no backfill.