### PR TITLE
feat(where-are-we): flip statusline ledger segment default to ON (opt-out)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,9 @@ JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian tenant cloud id (
 # Default OFF (adopters see no change). Set `1` to enable; READ FROM .env by the
 # SessionStart inject-where-are-we hook (ships via the himmel-ops plugin, live
 # after /himmel-update + a fresh session). Same falsy grammar as HIMMEL_INITIATIVE.
+# NOTE (HIMMEL-556): this same var also gates the STATUS-LINE segment, which is
+# default-ON — set an explicit falsy value (0|false|off|no) to opt the status-line
+# segment out. The SessionStart inject above stays opt-in (default OFF) regardless.
 # HIMMEL_WHERE_ARE_WE=1
 # Staleness threshold in hours before a background ledger refresh is triggered
 # (default 6). The refresh is async/detached — it never blocks session start.

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -267,7 +267,7 @@ FAIL. Tests: `scripts/test-himmel-doctor.sh`, `scripts/lib/test-{resolve,run,wir
 ## claude-statusline (vendored, HIMMEL-331)
 
 **Vendored in himmel:** `scripts/statusline/` (`bin/statusline.sh`, `test/`, `LICENSE`, `README.md`, provenance in `VENDORED.md`).
-**Config:** `~/.claude/settings.json` → `statusLine.command` (machine-setup points it at the himmel wrapper `<himmel-path>/scripts/where-are-we/statusline.sh`, which composes this vendored `bin/statusline.sh` + a where-are-we line — active handover + epic progression, HIMMEL-538, opt-in `HIMMEL_WHERE_ARE_WE`; no external clone).
+**Config:** `~/.claude/settings.json` → `statusLine.command` (machine-setup points it at the himmel wrapper `<himmel-path>/scripts/where-are-we/statusline.sh`, which composes this vendored `bin/statusline.sh` + a where-are-we line — active handover + epic progression, HIMMEL-538; the segment is default-ON since HIMMEL-556 — opt out with an explicit falsy `HIMMEL_WHERE_ARE_WE` (`0|false|off|no`); no external clone).
 **What:** Bash script receiving Claude Code session JSON via stdin, outputs formatted status bar.
 
 Displays: model, context %, git branch, rate-limit bars (current/weekly/extra), cache TTL countdown, per-session and all-sessions cache read/write/hit/savings.

--- a/scripts/where-are-we/statusline-segment.sh
+++ b/scripts/where-are-we/statusline-segment.sh
@@ -15,8 +15,9 @@
 #                   cache fires a DETACHED, lock-gated refresh (statusline-rollup.sh).
 #
 # FAIL-OPEN everywhere: any error omits only its own part; never errors/hangs.
-# Gated by HIMMEL_WHERE_ARE_WE (default OFF) — defense-in-depth (the wrapper also
-# gates) so the segment is testable in isolation.
+# Gated by HIMMEL_WHERE_ARE_WE (default ON, HIMMEL-556 — opt-out on an explicit
+# 0|false|off|no) — defense-in-depth (the wrapper also gates) so the segment is
+# testable in isolation.
 #
 # Test seams: --branch / --cwd ; HANDOVER_DIR (breadcrumb root, existing) ;
 #   --ledger (provision.mjs ledger path) ; HIMMEL_WHERE_ARE_WE_ROLLUP_DIR
@@ -40,13 +41,15 @@ input=""
 if [ ! -t 0 ]; then input="$(cat 2>/dev/null || true)"; fi
 
 # --- Gate -------------------------------------------------------------------
-_truthy() {
+# Default ON (HIMMEL-556): enabled unless HIMMEL_WHERE_ARE_WE is an explicit
+# opt-out (0|false|off|no). Unset / empty / any other value → enabled.
+_enabled() {
     case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
-        ""|0|false|off|no) return 1 ;;
+        0|false|off|no) return 1 ;;
         *) return 0 ;;
     esac
 }
-_truthy "${HIMMEL_WHERE_ARE_WE:-}" || exit 0
+_enabled "${HIMMEL_WHERE_ARE_WE:-}" || exit 0
 
 SD="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SD/../.." && pwd)"

--- a/scripts/where-are-we/statusline.sh
+++ b/scripts/where-are-we/statusline.sh
@@ -5,7 +5,9 @@
 # with ONE where-are-we line (statusline-segment.sh), gated by HIMMEL_WHERE_ARE_WE.
 #
 # Not a parallel status line: it runs the exact vendored script for the base bar
-# and only appends a line. Gate OFF (default) → adds ZERO bytes beyond the base.
+# and only appends a line. Gate default ON (HIMMEL-556, opt-out): an explicit
+# falsy HIMMEL_WHERE_ARE_WE (0|false|off|no) suppresses the segment → adds ZERO
+# bytes beyond the base; unset/empty → segment renders.
 #
 # Fail-open: a missing/erroring base or segment never errors the bar. The segment
 # is `timeout`-bounded (it does one node spawn) so a hung child degrades to
@@ -30,14 +32,16 @@ base="$(printf '%s' "$input" | bash "$BASE" 2>/dev/null || true)"
 base="${base%$'\n'}"
 printf '%s' "$base"
 
-_truthy() {
+# Default ON (HIMMEL-556): enabled unless HIMMEL_WHERE_ARE_WE is an explicit
+# opt-out (0|false|off|no). Unset / empty / any other value → enabled.
+_enabled() {
     case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
-        ""|0|false|off|no) return 1 ;;
+        0|false|off|no) return 1 ;;
         *) return 0 ;;
     esac
 }
 
-if _truthy "${HIMMEL_WHERE_ARE_WE:-}"; then
+if _enabled "${HIMMEL_WHERE_ARE_WE:-}"; then
     # Bound the segment with GNU `timeout` or macOS coreutils `gtimeout`. If
     # neither exists the segment still self-bounds its one node spawn (C1), so
     # the unguarded fallback is safe.

--- a/scripts/where-are-we/test-statusline-segment.sh
+++ b/scripts/where-are-we/test-statusline-segment.sh
@@ -37,9 +37,23 @@ printf '%s\n' '{"foo":1}' > "$ROLLDIR_BADSHAPE/where-are-we-rollup-HIMMEL-538.js
 run() { HIMMEL_WHERE_ARE_WE=1 HANDOVER_DIR="$HROOT" HIMMEL_WHERE_ARE_WE_ROLLUP_DIR="$ROLLDIR_COLD" \
         bash "$SUT" "$@" </dev/null 2>/dev/null; }
 
-# --- Case 1: off-gate → empty -----------------------------------------------
-o="$(HIMMEL_WHERE_ARE_WE="" HANDOVER_DIR="$HROOT" bash "$SUT" --branch feat/HIMMEL-538-x </dev/null 2>/dev/null)"
-if [ -z "$o" ]; then pass "off-gate -> empty"; else fail "off-gate -> '$o'"; fi
+# --- Case 1: explicit opt-out → empty ---------------------------------------
+# (HIMMEL-556: default is now ON, so only an explicit falsy value suppresses.)
+for off in 0 false off no FALSE Off " no "; do
+    o="$(HIMMEL_WHERE_ARE_WE="$off" HANDOVER_DIR="$HROOT" bash "$SUT" --branch feat/HIMMEL-538-x </dev/null 2>/dev/null)"
+    if [ -z "$o" ]; then pass "opt-out '$off' -> empty"; else fail "opt-out '$off' -> '$o'"; fi
+done
+
+# --- Case 1b: default ON (unset/empty) on a ticket branch → renders ----------
+for on in "" "  "; do
+    o="$(HIMMEL_WHERE_ARE_WE="$on" HANDOVER_DIR="$HROOT" HIMMEL_WHERE_ARE_WE_ROLLUP_DIR="$ROLLDIR_COLD" \
+         bash "$SUT" --branch feat/HIMMEL-538-x --ledger "$TMP/none.jsonl" </dev/null 2>/dev/null)"
+    if printf '%s' "$o" | grep -qF '⎇ HIMMEL-538'; then
+        pass "default ON (HIMMEL_WHERE_ARE_WE='$on') -> ticket renders"
+    else
+        fail "default ON ('$on') -> '$o'"
+    fi
+done
 
 # --- Case 2: main branch → empty (no key) -----------------------------------
 o="$(run --branch main)"
@@ -210,16 +224,29 @@ else
 fi
 
 # --- Case 17: stdin .cwd + git branch detection (production input route) -----
-# Feed JSON with .cwd = this worktree (on feat/himmel-538-status-line); no
-# --branch seam, so the segment must resolve the branch via git.
+# Feed JSON with .cwd = this worktree; no --branch seam, so the segment must
+# resolve the branch via git. Derive the EXPECTED key from the worktree's actual
+# branch (the same branchToKey rule the SUT applies) rather than hardcoding one
+# ticket — so the case is correct on whatever branch the test runs from.
 WT="$(cd "$DIR/../.." && pwd)"
-o="$(printf '%s' '{"cwd":"'"$WT"'"}' | HIMMEL_WHERE_ARE_WE=1 HANDOVER_DIR="$HROOT2" \
-     HIMMEL_WHERE_ARE_WE_ROLLUP_DIR="$ROLLDIR_COLD" HIMMEL_WHERE_ARE_WE_ROLLUP_CMD="true" \
-     bash "$SUT" --ledger "$TMP/none.jsonl" 2>/dev/null)"
-if printf '%s' "$o" | grep -qF '⎇ HIMMEL-538'; then
-    pass "stdin .cwd + git branch detection -> ticket shown"
+wt_branch="$(git -C "$WT" symbolic-ref --short HEAD 2>/dev/null || true)"
+# Mirror the SUT's branchToKey exactly: a key is only extracted when the branch
+# has a `type/` prefix (case "$branch" in */*) in statusline-segment.sh).
+exp_key=""
+case "$wt_branch" in
+    */*) exp_key="$(printf '%s' "${wt_branch#*/}" | sed -n 's/^\([A-Za-z][A-Za-z]*-[0-9][0-9]*\).*/\1/p' | tr '[:lower:]' '[:upper:]')" ;;
+esac
+if [ -n "$exp_key" ]; then
+    o="$(printf '%s' '{"cwd":"'"$WT"'"}' | HIMMEL_WHERE_ARE_WE=1 HANDOVER_DIR="$HROOT2" \
+         HIMMEL_WHERE_ARE_WE_ROLLUP_DIR="$ROLLDIR_COLD" HIMMEL_WHERE_ARE_WE_ROLLUP_CMD="true" \
+         bash "$SUT" --ledger "$TMP/none.jsonl" 2>/dev/null)"
+    if printf '%s' "$o" | grep -qF "⎇ $exp_key"; then
+        pass "stdin .cwd + git branch detection -> ticket shown ($exp_key)"
+    else
+        fail "stdin .cwd path -> '$o' (expected ⎇ $exp_key)"
+    fi
 else
-    fail "stdin .cwd path -> '$o'"
+    pass "stdin .cwd + git branch detection -> SKIPPED (branch '$wt_branch' has no ticket key)"
 fi
 
 echo "---"

--- a/scripts/where-are-we/test-statusline-wrapper.sh
+++ b/scripts/where-are-we/test-statusline-wrapper.sh
@@ -42,15 +42,29 @@ printf '%s\n' '#!/usr/bin/env bash' "cat >/dev/null 2>&1 || true" "printf 'BASE_
 
 INPUT='{"cwd":"/tmp","model":{"display_name":"x"}}'
 
-# --- Case 1: gate OFF → wrapper output == base output, ZERO bytes added -----
+# --- Case 1: explicit opt-out → wrapper output == base, ZERO bytes added -----
+# (HIMMEL-556: default is now ON, so suppression requires an explicit falsy value.)
 want="$(printf '%s' "$INPUT" | bash "$BASE")"
-got="$(HIMMEL_WHERE_ARE_WE="" HIMMEL_STATUSLINE_BASE="$BASE" HIMMEL_STATUSLINE_SEGMENT="$SEG_OK" \
-       bash "$SUT" <<<"$INPUT" 2>/dev/null)"
-if [ "$got" = "$want" ]; then
-    pass "gate OFF -> wrapper adds zero bytes (== base)"
-else
-    fail "gate OFF -> got '$got' want '$want'"
-fi
+for off in 0 false off no FALSE Off " no "; do
+    got="$(HIMMEL_WHERE_ARE_WE="$off" HIMMEL_STATUSLINE_BASE="$BASE" HIMMEL_STATUSLINE_SEGMENT="$SEG_OK" \
+           bash "$SUT" <<<"$INPUT" 2>/dev/null)"
+    if [ "$got" = "$want" ]; then
+        pass "opt-out '$off' -> wrapper adds zero bytes (== base)"
+    else
+        fail "opt-out '$off' -> got '$got' want '$want'"
+    fi
+done
+
+# --- Case 1b: default ON (unset/empty) → segment renders --------------------
+for on in "" "  "; do
+    got="$(HIMMEL_WHERE_ARE_WE="$on" HIMMEL_STATUSLINE_BASE="$BASE" HIMMEL_STATUSLINE_SEGMENT="$SEG_OK" \
+           bash "$SUT" <<<"$INPUT" 2>/dev/null)"
+    if [ "$got" = "$(printf 'BASE_L1\nBASE_L2\nWAW_LINE')" ]; then
+        pass "default ON (HIMMEL_WHERE_ARE_WE='$on') -> segment renders"
+    else
+        fail "default ON ('$on') -> got '$got'"
+    fi
+done
 
 # --- Case 2: gate ON + segment line → base + \n + line ----------------------
 got="$(HIMMEL_WHERE_ARE_WE=1 HIMMEL_STATUSLINE_BASE="$BASE" HIMMEL_STATUSLINE_SEGMENT="$SEG_OK" \


### PR DESCRIPTION
Flip the where-are-we status-line segment gate from default-OFF (opt-in) to default-ON (opt-out) on HIMMEL_WHERE_ARE_WE. The segment renders unless an explicit falsy value (0|false|off|no) suppresses it. The shared SessionStart inject hook keeps its own gate and stays opt-in. Tests cover the inverted semantics; both suites green.