### PR TITLE
feat(HIMMEL-533): Codex driver-command skills

### DIFF
--- a/.agents/skills/clean-garden/SKILL.md
+++ b/.agents/skills/clean-garden/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: clean-garden
+description: Prune merged-PR worktrees AND create a new one in one shot. Use when the user asks to run /clean_garden or prune-and-create a worktree.
+---
+
+# clean-garden
+
+When the user asks to prune-and-create, run:
+
+    bash scripts/clean-garden.sh <branch-name> [--no-prune] [--prune-only] [--no-install] [--dry-run]
+
+`<branch-name>` is `type/slug`. Summarize prunes, then the created worktree path.

--- a/.agents/skills/clean/SKILL.md
+++ b/.agents/skills/clean/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: clean
+description: Prune merged-PR worktrees (no create). Use when the user asks to clean worktrees or run /clean.
+---
+
+# clean
+
+When the user asks to prune merged worktrees, run:
+
+    bash scripts/clean-garden.sh --prune-only
+
+Summarize which worktrees were pruned and which were kept (and why). This only
+prunes worktrees whose PR is merged; it never creates.

--- a/.agents/skills/guardrail-sim/SKILL.md
+++ b/.agents/skills/guardrail-sim/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: guardrail-sim
+description: Pre-flight guardrail simulator — flags/rewrites predictable himmel guardrail collisions in planned bash commands before they stall a run. Use when the user asks to simulate guardrails or run /guardrail-sim.
+---
+
+# guardrail-sim
+
+When the user wants to pre-flight planned bash commands, feed them on stdin:
+
+    printf '%s\n' "cmd1" "cmd2" | bash scripts/guardrails/preflight-sim.sh
+
+Report each flagged command, the predicted collision, and the suggested rewrite.

--- a/.agents/skills/pr-check/SKILL.md
+++ b/.agents/skills/pr-check/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: pr-check
+description: Panel-only CR gate for Codex — runs the shell critic panel over the branch diff and clears the CR marker only when the panel is clean. Use when the user asks to run /pr-check or clear the CR gate under Codex.
+---
+
+# pr-check (Codex panel-only subset)
+
+This is the Codex subset of himmel's `/pr-check`: the cross-model **shell critic
+panel** plus CR-marker handling. It does NOT dispatch the Claude
+`pr-review-toolkit` reviewer agents, and there is NO per-finding verdict /
+adjudication step. (Codex native `/review` integration is a post-HIMMEL-527
+follow-up.)
+
+## 1. Locate the marker
+
+    branch=$(git branch --show-current)
+    gitdir=$(git rev-parse --git-common-dir)
+    marker="$gitdir/cr-pending/$branch"
+
+If `$marker` is absent, report `no pending CR for $branch — nothing to do` and stop.
+
+## 2. Lane check (HIMMEL-303)
+
+    lane=$(awk -F' [|] ' '{print $3; exit}' "$marker" 2>/dev/null)
+
+If `lane = docs-audit`: the code-critic panel is the wrong charter — **retain**
+the marker and tell the operator to run the Claude `/pr-check` for docs lanes.
+Stop. Only `lane = full` or empty proceeds.
+
+## 3. Run the panel over the diff
+
+    db=$(. scripts/guardrails/lib.sh 2>/dev/null && default_branch || echo main)
+    diff_rc=0; diff_out=$(git diff "$db...HEAD") || diff_rc=$?
+    if [ "$diff_rc" -ne 0 ] || [ -z "$diff_out" ]; then
+        echo "diff unavailable/empty — marker retained"; exit 0
+    fi
+    panel_rc=0
+    panel_out=$(printf '%s\n' "$diff_out" | CRITIC_PANEL_TIERS="${CR_PROFILE:-free}" bash scripts/cr/critic-panel.sh) || panel_rc=$?
+
+`CR_PROFILE` (if the operator set it) passes through as `CRITIC_PANEL_TIERS`;
+default is the free fast panel.
+
+## 4. Gate decision
+
+- If `panel_rc != 0` (the panel header reports `0/N critics responded` →
+  unavailable): **retain** the marker, report `panel unavailable — marker
+  retained`, and point the operator at the `SKIP_CR=1` emergency bypass. Stop.
+- Else parse the panel stdout. The header line is
+  `# Critic Panel Review (M/N critics responded)` and the count lines are
+  `## Critical Issues (C found)` / `## Important Issues (I found)`.
+  - If `C = 0` AND `I = 0`: **clear** the marker — `rm -f "$marker"` — and report
+    `CR clean — marker cleared (M/N critics responded)`, reading `M/N` from the
+    header line. A clean clear only requires ≥1 critic to have responded; surface
+    `M/N` so the operator sees coverage.
+  - Otherwise: **retain** the marker and report the Critical/Important findings
+    verbatim for the operator to fix and re-run.

--- a/.agents/skills/shell-lint/SKILL.md
+++ b/.agents/skills/shell-lint/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: shell-lint
+description: Pre-emptive advisory shell lint (shellcheck + BOM + errexit-leak) on staged shell before commit. Use when the user asks to lint shell or run /shell-lint.
+---
+
+# shell-lint
+
+When the user asks to lint shell, run:
+
+    bash scripts/lint/shell-lint.sh --staged
+
+To lint specific files instead of the staged set, pass paths:
+`bash scripts/lint/shell-lint.sh <file...>`. Report each finding with its
+file:line and the fix; if clean, say so.

--- a/.agents/skills/worktree/SKILL.md
+++ b/.agents/skills/worktree/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: worktree
+description: Create a git worktree under .claude/worktrees/ for a type/slug branch (feat|fix|chore|docs|refactor|test). Use when the user asks to make a worktree or run /worktree.
+---
+
+# worktree
+
+When the user asks to create a worktree, run:
+
+    bash scripts/worktree.sh <branch-name> [--no-install] [--verbose] [--dry-run]
+
+Branch must be `type/slug` (type ∈ feat|fix|chore|docs|refactor|test). After the
+OK line, report the printed worktree path so the operator can `cd` in. For
+prune+create use `clean-garden`; for prune-only use `clean`.

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -62,3 +62,13 @@ what makes the block land (Codex ignores exit 2). Caveats observed live:
   trust them once (non-interactive `codex exec` needs
   `--dangerously-bypass-hook-trust`).
 See `docs/internals/harness-compat.md` §"Codex deep-dive → Hooks" for detail.
+
+## codex-cli 0.142.0 note (HIMMEL-533)
+Once the project hooks are **already trusted** (persisted from a prior
+interactive trust, or this checkout's hooks already hashed), plain
+`codex exec "<prompt>"` runs **without** `--dangerously-bypass-hook-trust` — the
+flag is only the first-run / still-untrusted non-interactive path. (The flag
+still exists in 0.142.0; this README's live-verified block above is 0.141.0.)
+Skill discovery: Codex reads **project-local `.agents/skills/<name>/SKILL.md`**
+from the run cwd — live-verified under 0.142.0 (HIMMEL-533 ships the himmel
+driver skills there).

--- a/docs/internals/harness-compat.md
+++ b/docs/internals/harness-compat.md
@@ -158,6 +158,24 @@ Skills load natively under Codex. himmel's project-local **slash commands**
 (`.claude/commands/*.md`) do **not** auto-load — Codex has its own
 slash-command surface. **Accept / port selectively** (TBD per command).
 
+**Codex skill-discovery root = project-local `.agents/skills/<name>/SKILL.md`**
+(HIMMEL-533, live-verified codex-cli 0.142.0: a project-local probe skill
+loaded + ran from the worktree). The `.gitignore` ignores only
+`.agents/skills/source-command-*/` (the external-installer mirror that trips
+`clean-garden`); hand-authored `.agents/skills/<name>/` is tracked.
+
+**HIMMEL-533 delivered** the high-value "driver" commands as thin **tracked**
+`.agents/skills/` wrappers that shell the same harness-neutral `scripts/` the
+Claude commands use (no logic duplication; Claude `.claude/commands/*.md`
+untouched): `worktree`, `clean`, `clean-garden`, `shell-lint`, `guardrail-sim`,
+and `pr-check`. `pr-check` is the **panel-only** subset — it runs the pure-shell
+critic panel (`scripts/cr/critic-panel.sh`) and clears the CR marker only when
+the panel reports 0 Critical + 0 Important (retains on findings, panel
+unavailable, or a `docs-audit` lane). It does **not** dispatch the Claude
+`pr-review-toolkit` reviewer agents. Codex native `/review` participation is a
+post-HIMMEL-527 follow-up. Tier-A skills already load natively (verified live —
+`stuck-playbook` triggered under Codex).
+
 ### 5. Subagents
 
 Codex uses `.codex/agents/*.toml` (`name`, `description`,
@@ -235,7 +253,8 @@ follow-up subtask (priority: with Codex).
 | Hooks → Cursor (`.cursor/hooks.json`, fail-open) | **Port** (priority 2) | HIMMEL-487 |
 | Hooks → Copilot / Gemini | **Port, SOFT-DEFER** (no free usage) | HIMMEL-489 |
 | Skills / subagents (Cursor, Copilot) | **Accept** — read `.claude/*` directly | — |
-| CR reviewer skill for Codex | **Port/adopt** — codex `SKILL.md` or brooks-lint | HIMMEL-488 |
+| Driver commands → Codex skills | **Ported (delivered)** — thin tracked `.agents/skills/` wrappers (worktree/clean/clean-garden/shell-lint/guardrail-sim/pr-check) shelling existing `scripts/`; live-verified under codex-cli 0.142.0 | HIMMEL-533 |
+| CR reviewer skill for Codex | **Ported (panel-only)** — Codex `pr-check` skill runs the shell panel + clears the CR marker on clean; native `/review` participation deferred post-HIMMEL-527 | HIMMEL-533 |
 | Marketplace (all) | **Accept** — each has one | — |
 
 ## Prompt anatomy — why rules must be *adapted*, not copied


### PR DESCRIPTION
Thin tracked .agents/skills/ wrappers (worktree/clean/clean-garden/shell-lint/guardrail-sim/pr-check) shelling existing scripts so the worktree->CR->handover driver loop runs under Codex. pr-check is panel-only. Live-verified codex-cli 0.142.0.