### PR TITLE
fix(codex): wire plugin security guards into .codex/hooks.json

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -11,12 +11,19 @@ full compat matrix.
   Kept to the strict schema (only a top-level `hooks` key — Codex's parser uses
   `deny_unknown_fields`, so an extra key like `description`/`_comment` would make
   it skip the hooks).
+  Includes `block-docker-privesc.sh` + `block-merged-pr-commit.sh` (HIMMEL-589):
+  these two SECURITY guards ship via the `himmel-ops` plugin `hooks.json` using
+  `$CLAUDE_PROJECT_DIR`, which Codex leaves unset for plugin hooks — so they
+  silently no-op under Codex unless mirrored here, where `run-hook.cmd` derives
+  the repo root from its own location.
 - **`run-hook.cmd`** — a **polyglot** wrapper (cmd.exe batch on Windows, bash on
   Unix) that fixes the three reasons the old hand-ported `.codex/hooks.json` did
   **not** block on Windows under Codex:
-  1. **No `CLAUDE_PROJECT_DIR`.** Codex injects it only for *plugin* hooks, not
-     *project* hooks. The wrapper derives the repo root from its **own** location
-     (`.codex/..`) and exports `CLAUDE_PROJECT_DIR` for the guardrail scripts.
+  1. **No `CLAUDE_PROJECT_DIR`.** Codex injects no `CLAUDE_PROJECT_DIR` for
+     project hooks (plugin hooks get `CLAUDE_PLUGIN_ROOT`, not
+     `CLAUDE_PROJECT_DIR`). The wrapper derives the repo root from its **own**
+     location (`.codex/..`) and exports `CLAUDE_PROJECT_DIR` for the guardrail
+     scripts.
   2. **Bare `bash` → WSL stub.** Via `cmd.exe`, bare `bash` resolves to
      `C:\Windows\System32\bash.exe` (the WSL stub — can't read `C:\`, exit 127).
      The wrapper finds **Git Bash** explicitly (`Program Files\Git`), and the

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -21,6 +21,13 @@
         ]
       },
       {
+        "matcher": "Bash|PowerShell",
+        "hooks": [
+          { "type": "command", "command": ".codex/run-hook.cmd block-docker-privesc.sh" },
+          { "type": "command", "command": ".codex/run-hook.cmd block-merged-pr-commit.sh" }
+        ]
+      },
+      {
         "matcher": "mcp__plugin_atlassian_atlassian__.*",
         "hooks": [
           { "type": "command", "command": ".codex/run-hook.cmd block-backend-tier.sh" }

--- a/docs/internals/harness-compat.md
+++ b/docs/internals/harness-compat.md
@@ -128,6 +128,17 @@ bugs but **not** the exit-2-vs-JSON one — the adapter translation is required
 regardless of delivery mechanism. Project-file delivery + adapter was chosen as
 the smaller change.
 
+The converse bit himmel later (HIMMEL-589): two SECURITY guards that *do* ship
+via the `himmel-ops` plugin `hooks.json` — `block-docker-privesc.sh` (HIMMEL-441)
+and `block-merged-pr-commit.sh` (HIMMEL-512) — resolve their script via
+`$CLAUDE_PROJECT_DIR`, which Codex injects for **neither** plugin nor project
+hooks (plugin hooks get `CLAUDE_PLUGIN_ROOT` instead — see §1), so under Codex
+the wrapper's `[ -f "$h" ]` was false and the guards silently no-op'd
+(root-equivalent docker mounts + merged-PR commits went unguarded). Fix: mirror both into `.codex/hooks.json` via `run-hook.cmd`, which
+derives the root from its own location. The non-security plugin hooks
+(`inject-where-are-we` / `refresh-where-are-we-on-end`) share the same
+root-resolution bug and stay broken under Codex pending HIMMEL-554.
+
 ### 2. Instruction file — CLAUDE.md is invisible; AGENTS.md must carry the rules
 
 **Codex does not read `CLAUDE.md`.** It reads `AGENTS.md`, checking

--- a/scripts/hooks/test-codex-plugin-security-hooks.ps1
+++ b/scripts/hooks/test-codex-plugin-security-hooks.ps1
@@ -1,0 +1,75 @@
+# Regression test (HIMMEL-589) — WINDOWS (cmd.exe) branch. The Unix/bash branch
+# is covered by the .sh twin (which also exercises merged-pr end-to-end).
+#
+# Asserts the two plugin-delivered SECURITY guards are wired into
+# .codex/hooks.json and FIRE under the Codex plugin-hook env on Windows, where
+# Codex sets CLAUDE_PLUGIN_ROOT but NOT CLAUDE_PROJECT_DIR. run-hook.cmd's
+# cmd.exe branch derives the repo root from its own location, so the guard runs
+# even with CLAUDE_PROJECT_DIR unset.
+#
+# block-docker-privesc is self-contained (no git/forge), so it is the Windows
+# behavioral anchor here. block-merged-pr-commit's logic runs inside Git Bash
+# once dispatched; the cmd.exe->bash handoff is proven generically by
+# test-codex-run-hook.ps1, and its firing is asserted by the .sh twin.
+
+$ErrorActionPreference = 'Continue'
+$HOOKS     = $PSScriptRoot
+$REPO_ROOT = (Resolve-Path (Join-Path $HOOKS '..' | Join-Path -ChildPath '..')).Path
+$HOOKS_JSON = Join-Path $REPO_ROOT '.codex\hooks.json'
+
+$script:failures = 0
+function Check([string]$name, [bool]$cond) {
+    if ($cond) { Write-Host "  ok   $name" } else { Write-Host "  FAIL $name"; $script:failures++ }
+}
+
+if (-not (Test-Path -LiteralPath $HOOKS_JSON)) { Write-Host ".codex/hooks.json not found: $HOOKS_JSON"; exit 1 }
+
+$cfg = Get-Content -Raw -LiteralPath $HOOKS_JSON | ConvertFrom-Json
+$pre = @($cfg.hooks.PreToolUse)
+
+function Wired-Block([string]$guard) {
+    foreach ($b in $pre) {
+        foreach ($h in @($b.hooks)) {
+            if ($h.command -like "*$guard*") { return $b }
+        }
+    }
+    return $null
+}
+
+# ── 1) Static wiring ────────────────────────────────────────────────────────
+foreach ($g in @('block-docker-privesc.sh', 'block-merged-pr-commit.sh')) {
+    $b = Wired-Block $g
+    Check "$g wired into .codex/hooks.json" ($null -ne $b)
+    if ($null -ne $b) {
+        $cmds = (@($b.hooks) | ForEach-Object { $_.command }) -join ' '
+        Check "$g routed through run-hook.cmd" ($cmds -like '*run-hook.cmd*')
+        Check "$g matches both Bash and PowerShell" (($b.matcher -like '*Bash*') -and ($b.matcher -like '*PowerShell*'))
+    }
+}
+
+# ── 2) Behavioral: docker-privesc fires through the cmd.exe branch ──────────
+$oldProj = $env:CLAUDE_PROJECT_DIR
+$oldPlugin = $env:CLAUDE_PLUGIN_ROOT
+Remove-Item Env:\CLAUDE_PROJECT_DIR -ErrorAction SilentlyContinue
+$env:CLAUDE_PLUGIN_ROOT = 'C:\nonexistent\codex\plugin-root'
+try {
+    $privesc = '{"tool_name":"Bash","tool_input":{"command":"docker run --rm -v /etc:/host-etc:rw ubuntu:22.04 cat /host-etc/shadow"}}'
+    $benign  = '{"tool_name":"Bash","tool_input":{"command":"echo hello"}}'
+
+    Push-Location $REPO_ROOT
+    $dout = ($privesc | & cmd.exe /c '.codex\run-hook.cmd' --sandbox block-docker-privesc.sh 2>&1 | Out-String)
+    Pop-Location
+    Check "docker-privesc: root-equiv mount denied (CLAUDE_PROJECT_DIR unset)" ($dout -match '"permissionDecision":"deny"')
+
+    Push-Location $REPO_ROOT
+    $bout = ($benign | & cmd.exe /c '.codex\run-hook.cmd' --sandbox block-docker-privesc.sh 2>&1 | Out-String)
+    Pop-Location
+    Check "docker-privesc: benign command allowed" ($bout -notmatch '"permissionDecision":"deny"')
+}
+finally {
+    if ($null -eq $oldProj) { Remove-Item Env:\CLAUDE_PROJECT_DIR -ErrorAction SilentlyContinue } else { $env:CLAUDE_PROJECT_DIR = $oldProj }
+    if ($null -eq $oldPlugin) { Remove-Item Env:\CLAUDE_PLUGIN_ROOT -ErrorAction SilentlyContinue } else { $env:CLAUDE_PLUGIN_ROOT = $oldPlugin }
+}
+
+if ($script:failures -eq 0) { Write-Host 'OK: all cases passed'; exit 0 }
+else { Write-Host "FAIL: $($script:failures) case(s) failed"; exit 1 }

--- a/scripts/hooks/test-codex-plugin-security-hooks.sh
+++ b/scripts/hooks/test-codex-plugin-security-hooks.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Regression test (HIMMEL-589): the two plugin-delivered SECURITY guards
+# (block-docker-privesc.sh, block-merged-pr-commit.sh) must FIRE under Codex.
+#
+# Background. Both guards ship via the himmel-ops plugin hooks.json with a
+# wrapper `h="$CLAUDE_PROJECT_DIR/scripts/hooks/<guard>.sh"; [ -f "$h" ] && exec
+# bash "$h"`. Codex injects CLAUDE_PLUGIN_ROOT for plugin hooks but NOT
+# CLAUDE_PROJECT_DIR, so under Codex `$h` resolves empty, `[ -f "$h" ]` is false,
+# and the guard SILENTLY NO-OPS (root-equivalent docker mounts + merged-PR
+# commits go unguarded). Fix: wire both into .codex/hooks.json via
+# run-hook.cmd --sandbox (the wrapper derives the repo root from its OWN
+# location, harness-agnostically), like the other already-wired security hooks.
+#
+# This suite asserts, for BOTH guards:
+#   1) they are wired into .codex/hooks.json through run-hook.cmd, under a
+#      Bash-inclusive matcher (static — RED before the fix);
+#   2) invoking that wired command with the Codex plugin-hook env simulated
+#      (CLAUDE_PROJECT_DIR UNSET, CLAUDE_PLUGIN_ROOT set) actually FIRES the
+#      guard end-to-end — a privesc / merged-PR-commit input yields Codex's
+#      JSON deny, while a benign input does not (behavioral).
+#
+# Hermetic: docker/podman are never invoked (the guard only inspects the
+# command string); the forge is stubbed (GH_CMD), so no network. bash 3.2-safe.
+#
+# The Windows (cmd.exe) branch of run-hook.cmd is covered by the .ps1 twin.
+set -uo pipefail
+
+HOOKS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HOOKS_DIR/../.." && pwd)"
+HOOKS_JSON="$REPO_ROOT/.codex/hooks.json"
+BOGUS_PLUGIN="/nonexistent/codex/plugin-root"
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf '  FAIL %s\n' "$1"; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq not on PATH — required for this test" >&2; exit 1
+fi
+[ -f "$HOOKS_JSON" ] || { echo ".codex/hooks.json not found: $HOOKS_JSON" >&2; exit 1; }
+
+# Extract the (first) PreToolUse hook command wiring a given guard filename.
+wired_cmd() {
+  jq -r --arg g "$1" \
+    '.hooks.PreToolUse[]?.hooks[]?.command // empty | select(contains($g))' \
+    "$HOOKS_JSON" 2>/dev/null | head -1
+}
+# Extract the matcher of the PreToolUse block containing that guard.
+wired_matcher() {
+  jq -r --arg g "$1" \
+    '.hooks.PreToolUse[]? | select(([.hooks[]?.command // ""] | join(" ")) | contains($g)) | .matcher' \
+    "$HOOKS_JSON" 2>/dev/null | head -1
+}
+
+# Run a guard via its WIRED .codex/hooks.json command, simulating the Codex
+# plugin-hook env (CLAUDE_PROJECT_DIR unset, CLAUDE_PLUGIN_ROOT set). Extra
+# args are passed as env overrides (e.g. FORGE=github GH_CMD=...). Prints the
+# command's stdout (Codex decision JSON, when blocked).
+run_codex_hook() {
+  local guard="$1" json="$2"; shift 2
+  local cmd; cmd="$(wired_cmd "$guard")"
+  if [ -z "$cmd" ]; then printf '__NOT_WIRED__'; return; fi
+  # shellcheck disable=SC2086
+  ( cd "$REPO_ROOT" && printf '%s' "$json" \
+      | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_ROOT="$BOGUS_PLUGIN" "$@" \
+        bash $cmd 2>/dev/null )
+}
+
+assert_deny() {
+  local label="$1" out="$2"
+  case "$out" in
+    *'"permissionDecision":"deny"'*) ok "$label";;
+    *) bad "$label (out=${out:-<empty>})";;
+  esac
+}
+assert_no_deny() {
+  local label="$1" out="$2"
+  case "$out" in
+    *'"permissionDecision":"deny"'*) bad "$label (unexpected deny: $out)";;
+    *) ok "$label";;
+  esac
+}
+
+# ── 1) Static wiring: both guards routed through run-hook.cmd, Bash matcher ──
+for g in block-docker-privesc.sh block-merged-pr-commit.sh; do
+  c="$(wired_cmd "$g")"
+  if [ -n "$c" ]; then ok "$g wired into .codex/hooks.json"; else bad "$g wired into .codex/hooks.json"; fi
+  case "$c" in *run-hook.cmd*) ok "$g routed through run-hook.cmd";; *) bad "$g routed through run-hook.cmd (got: ${c:-<none>})";; esac
+  m="$(wired_matcher "$g")"
+  case "$m" in
+    *Bash*PowerShell*|*PowerShell*Bash*) ok "$g matches both Bash and PowerShell";;
+    *) bad "$g matches both Bash and PowerShell (got: ${m:-<none>})";;
+  esac
+done
+
+# ── 2a) block-docker-privesc fires under the Codex env ──────────────────────
+PRIVESC='{"tool_name":"Bash","tool_input":{"command":"docker run --rm -v /etc:/host-etc:rw ubuntu:22.04 cat /host-etc/shadow"}}'
+BENIGN='{"tool_name":"Bash","tool_input":{"command":"echo hello"}}'
+assert_deny    "docker-privesc: root-equiv mount denied (CLAUDE_PROJECT_DIR unset)" \
+               "$(run_codex_hook block-docker-privesc.sh "$PRIVESC")"
+assert_no_deny "docker-privesc: benign command allowed" \
+               "$(run_codex_hook block-docker-privesc.sh "$BENIGN")"
+
+# ── 2b) block-merged-pr-commit fires under the Codex env ────────────────────
+SANDBOX="$(mktemp -d)"; trap 'rm -rf "$SANDBOX"' EXIT
+STUB="$SANDBOX/gh-merged"
+cat > "$STUB" <<'EOF'
+#!/usr/bin/env bash
+echo "1"
+EOF
+chmod +x "$STUB"
+STUB_CLEAN="$SANDBOX/gh-clean"
+cat > "$STUB_CLEAN" <<'EOF'
+#!/usr/bin/env bash
+echo "0"
+EOF
+chmod +x "$STUB_CLEAN"
+
+mkrepo() {
+  local path="$1" branch="$2"
+  mkdir -p "$path"
+  git -C "$path" init -q
+  git -C "$path" symbolic-ref HEAD "refs/heads/$branch"
+  git -C "$path" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+}
+TESTREPO="$SANDBOX/repo"
+mkrepo "$TESTREPO" "feat/codex-589"
+
+# JSON payload with the repo as cwd (the guard targets the repo via cwd, not
+# CLAUDE_PROJECT_DIR — so this is unaffected by it being unset).
+repo_esc="$(printf '%s' "$TESTREPO" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+COMMIT_JSON="$(printf '{"tool_name":"Bash","tool_input":{"command":"git commit -m x"},"cwd":"%s"}' "$repo_esc")"
+
+assert_deny    "merged-pr: commit onto merged branch denied (CLAUDE_PROJECT_DIR unset)" \
+               "$(run_codex_hook block-merged-pr-commit.sh "$COMMIT_JSON" FORGE=github GH_CMD="$STUB")"
+assert_no_deny "merged-pr: commit onto un-merged branch allowed" \
+               "$(run_codex_hook block-merged-pr-commit.sh "$COMMIT_JSON" FORGE=github GH_CMD="$STUB_CLEAN")"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Two himmel-ops plugin security guards (block-docker-privesc, block-merged-pr-commit) silently no-op'd under Codex because Codex doesn't set CLAUDE_PROJECT_DIR for plugin hooks. Mirrored both into .codex/hooks.json via run-hook.cmd; added hermetic regression tests (test-codex-plugin-security-hooks.{sh,ps1}).