### PR TITLE
docs: salus as the public example name (genericize personal vault/repo names)

### DIFF
--- a/.claude/commands/end-session-wiki-setup.md
+++ b/.claude/commands/end-session-wiki-setup.md
@@ -22,7 +22,7 @@ Run this from the **code repo** whose sessions you want captured. Be idempotent 
    - **GLOBAL (every repo)** — your default vault for all repos via `LUNA_VAULT_PATH`. Go to step 2c.
 
 2a. **By name.**
-   - Ask for the **vault name** (e.g. `luna-medic`). Validate: 1–64 chars, `[A-Za-z0-9._-]`, must start alphanumeric, no `/` or `..`. Reject otherwise.
+   - Ask for the **vault name** (e.g. `salus`). Validate: 1–64 chars, `[A-Za-z0-9._-]`, must start alphanumeric, no `/` or `..`. Reject otherwise.
    - Resolve the name to a path: if `~/Documents/<name>/.obsidian/` exists, that's the convention target — **no registry entry needed**. Otherwise ask for the absolute vault path (or `~/`-prefixed) and write the mapping into `~/.claude/luna-vaults.json`, preserving existing entries:
      `jq '.vaults = ((.vaults // {}) + {($n): $p})' --arg n "<name>" --arg p "<path>"` (create the file as `{ "vaults": { "<name>": "<path>" } }` if absent). The path should contain an `.obsidian/` marker.
    - Merge `"vault": "<name>"` into this repo's `.claude/end-session-wiki.json`, preserving existing keys: `jq '. + {vault: $n}' --arg n "<name>"`. Create as `{ "vault": "<name>" }` if absent.

--- a/docs/commands-catalog.md
+++ b/docs/commands-catalog.md
@@ -114,7 +114,7 @@ slash alias exists).
 | stuck-playbook (himmel-ops) | Load-on-trigger guardrail-recovery escape-hatches — fires on a denial/friction symptom (auto-mode Bash/Jira write denied, hung permission prompt, missing attestation trailer). Surfaces escape-hatches kept out of the always-on root CLAUDE.md (HIMMEL-211). |
 | vm (himmel-ops) | Lean-invoke VM lifecycle + e2e runbook — front door to the central VM-control SDK (`scripts/lib/vmsdk.py`); covers up/down/snapshot/restore/baseline/clone/provision/e2e verbs, the engine pass + skill pass probes, and the `sync_repo`/`install_plugin`/`drive_claude` SDK primitives (HIMMEL-491/493). |
 | vault-lint (obsidian-triage) | Filesystem-only, report-only vault health lint — a single deterministic Python pass that converges on large PARA vaults (orphans, broken wikilinks, audit). Vault-agnostic. |
-| luna-vitals-extract (obsidian-triage) | Backfill luna-medic health series for one vault time-bucket (HIMMEL-355) — extracts (date, metric, value) tuples via the luna-vitals CLI + an LLM prose pass, writing one per-bucket review artifact. Single-writer; never writes 50-Vitals/ directly. |
+| luna-vitals-extract (obsidian-triage) | Backfill salus health series for one vault time-bucket (HIMMEL-355) — extracts (date, metric, value) tuples via the luna-vitals CLI + an LLM prose pass, writing one per-bucket review artifact. Single-writer; never writes 50-Vitals/ directly. |
 
 ## Utility
 

--- a/docs/luna/end-session-wiki.md
+++ b/docs/luna/end-session-wiki.md
@@ -153,7 +153,7 @@ Fields:
 | `crystallize` | bool | `true` | `false` → never spawn the LLM crystallizer; the mechanical note is the final note. See [Crystallization](#crystallization-llm-upgrade). |
 | `crystallize_model` | string | _(absent)_ | Pin the crystallizer to a specific model (e.g. `"claude-haiku-4-5-20251001"`). Absent → the crystallizer's default model. |
 | `vault_path` | string | `""` | Absolute path (a leading `~/` is expanded) to the Obsidian vault this repo's sessions are captured into. Empty → fall back to `vault`, then `LUNA_VAULT_PATH` env, then the default. See [Choosing the target vault](#choosing-the-target-vault) below. |
-| `vault` | string | _(absent)_ | Vault **name** (not a path) — e.g. `"luna-medic"`. Distributable/safe to commit; resolved to a path per-machine (registry, then the `~/Documents/<name>` convention). An invalid or unresolvable name **skips** the capture rather than misrouting it. See [Choosing the target vault](#choosing-the-target-vault). |
+| `vault` | string | _(absent)_ | Vault **name** (not a path) — e.g. `"salus"`. Distributable/safe to commit; resolved to a path per-machine (registry, then the `~/Documents/<name>` convention). An invalid or unresolvable name **skips** the capture rather than misrouting it. See [Choosing the target vault](#choosing-the-target-vault). |
 
 Missing file → defaults applied (`enabled: true`, `dry_run: false`, `min_duration_seconds: 60`); `vault_path`/`vault` absent.
 
@@ -179,13 +179,13 @@ Your vault almost certainly does not live where the operator's does, and you may
 
 ```json
 // .claude/end-session-wiki.json — distributable: route by vault NAME (safe to commit)
-{ "vault": "luna-medic" }
+{ "vault": "salus" }
 ```
 
 ```json
 // ~/.claude/luna-vaults.json — per-machine name→path map (optional;
 // only needed for vaults that don't live at ~/Documents/<name>)
-{ "vaults": { "luna-medic": "~/Documents/luna-medic" } }
+{ "vaults": { "salus": "~/Documents/salus" } }
 ```
 
 ```bash
@@ -219,7 +219,7 @@ The hook files each note but does not maintain an index, so a fresh capture is a
 
 ```bash
 bash scripts/sessions-reindex.sh                       # default ~/Documents/luna
-bash scripts/sessions-reindex.sh --vault ~/Documents/luna-medic
+bash scripts/sessions-reindex.sh --vault ~/Documents/salus
 ```
 
 It regenerates `<vault>/sessions/_index.md` (links every session note → no orphans) and creates a `sessions/<repo>.md` hub for each repo that doesn't already resolve `[[<repo>]]` somewhere in the vault. Lean-invoke: run on demand after a batch of captures (or wire it into the clip-pipeline cadence).

--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -246,7 +246,7 @@ pre-commit run --all-files
 
 ### 4a. Optional — single-writer opt-out (HIMMEL-404)
 
-For personal repos that commit straight to main (luna, luna-medic, yotam_docs),
+For personal repos that commit straight to main (e.g. `luna`, `salus`, your docs/state repo),
 opt them out of the `block-edit-on-main` hook by dropping a local `.single-writer`
 marker at each repo's root. The marker is gitignored (via global excludes) so it
 never propagates to a clone — a checkout without it stays protected.
@@ -257,7 +257,7 @@ never propagates to a clone — a checkout without it stays protected.
 EX="$(git config --global core.excludesfile)"
 [ -z "$EX" ] && EX="$HOME/.config/git/ignore" && mkdir -p "$(dirname "$EX")" && git config --global core.excludesfile "$EX"
 grep -qxF ".single-writer" "$EX" 2>/dev/null || printf '.single-writer\n' >> "$EX"
-touch ~/Documents/luna/.single-writer ~/Documents/luna-medic/.single-writer ~/Documents/github/yotam_docs/.single-writer
+touch ~/Documents/luna/.single-writer ~/Documents/salus/.single-writer ~/Documents/github/work-notes/.single-writer
 ```
 
 This lets those repos opt out of the on-main edit block locally without the marker

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -196,7 +196,7 @@ Installed via `extraKnownMarketplaces` in `settings.json`.
 
 **What:** Offline health-factor correlation MCP. Correlates personal health series (sleep, HRV, resting HR) against public environmental factors (geomagnetic Kp, lunar phase, daylight hours) and a gated country-level grid fetcher for location factors (barometric pressure, pollen, PM2.5 air quality). Boundary B+C: only `factors.cache` touches the network; all joins and computations are offline. Outputs are candidate signals only — never a diagnosis, never causation.
 
-**M3 operator-facing tool:** `signals.dashboard` — lag-swept (±3 days default), best-lag-per-pair, Benjamini-Hochberg FDR-controlled (q=0.1) analysis over device series × factors. Writes `dashboard.md` + `dashboard.json` to `LUNA_SIGNALS_DIR` (must be set; luna-medic `60-Signals/` by convention).
+**M3 operator-facing tool:** `signals.dashboard` — lag-swept (±3 days default), best-lag-per-pair, Benjamini-Hochberg FDR-controlled (q=0.1) analysis over device series × factors. Writes `dashboard.md` + `dashboard.json` to `LUNA_SIGNALS_DIR` (must be set; a salus vault's `60-Signals/` by convention).
 
 **MCP tools:** `factors.cache` (network, gated), `series.load`, `correlate`, `signals.report`, `signals.dashboard` (all offline).
 **Offline factors:** `kp` (GFZ Potsdam, CC BY 4.0), `lunar_phase` (astronomical formula, zero network), `daylight` (bbox-centroid latitude, zero network). Location factors (`pressure`, `pollen`, `aq`) via Open-Meteo, opt-in via `LUNA_REGION_BBOX`.


### PR DESCRIPTION
Replace personal `luna-medic` / `yotam_docs` example names with `salus` (the public medical-vault profile name) + generic placeholders across the public docs (end-session-wiki, end-session-wiki-setup, new-machine, commands-catalog, tooling-catalog). Fork URLs, LICENSE, and real ticket links unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)