### PR TITLE
feat(luna): backfill --recrystallize (crystallize content-bearing uncrystallized notes)

### DIFF
--- a/.claude/commands/luna-backfill.md
+++ b/.claude/commands/luna-backfill.md
@@ -1,6 +1,6 @@
 ---
 description: Backfill old Claude session transcripts into the luna vault as structured session notes. TOKEN-INTENSIVE — warns before running and recommends --dry-run first.
-argument-hint: [--all | --project <path>] [--reheal] [--dry-run] [--include-orphaned] [--only <glob>] [--exclude <glob>] [--projects-dir <dir>] [--state-file <path>] [--vault-registry <path>] [--luna-vault-path <dir>]
+argument-hint: [--all | --project <path>] [--reheal | --recrystallize [--limit N]] [--dry-run] [--include-orphaned] [--only <glob>] [--exclude <glob>] [--projects-dir <dir>] [--state-file <path>] [--vault-registry <path>] [--luna-vault-path <dir>]
 ---
 
 > **TOKEN-USAGE WARNING:** Backfill seeds many session notes into the vault at
@@ -48,7 +48,10 @@ by a multi-vault test (two repos → two vaults, no cross-contamination).
 --include-orphaned       Also import sessions whose cwd no longer exists on disk
 --only <glob>            Only process projects matching glob (repo path)
 --exclude <glob>         Exclude projects matching glob (repo path)
---reheal                 Recover existing husk notes in the vault (see below)
+--reheal                 Recover existing HUSK notes in the vault (see below)
+--recrystallize          Crystallize ANY uncrystallized note with a content-bearing
+                         transcript (not just husks) — see below
+--limit <N>              Cap real crystallizations per --recrystallize run (0 = unbounded)
 --projects-dir <dir>     Override transcripts root (default: ~/.claude/projects) — testing
 --state-file <path>      Override ledger path (default: ~/.claude/luna-backfill-state.json)
 --vault-registry <path>  Override vault registry (default: ~/.claude/luna-vaults.json)
@@ -71,13 +74,17 @@ by a multi-vault test (two repos → two vaults, no cross-contamination).
    ```
 4. **Crystallize (quality pass)** — backfill writes **mechanical** notes
    (`crystallized: false`): a slugged Summary from the transcript, no LLM
-   synthesis. Only the live `end-session-wiki` hook and `--reheal` run the LLM
-   crystallizer. Backfill deliberately does **not** auto-crystallize each note
+   synthesis. Backfill deliberately does **not** auto-crystallize each note
    (a bulk `--all` import would fan out an unbounded number of billed `claude`
-   runs); instead it prints a nudge and you run the one explicit,
-   concurrency-capped, idempotent quality pass over what just landed:
+   runs); instead it prints a nudge and you run the explicit, concurrency-capped,
+   idempotent pass over what just landed. A backfilled prose-session note is
+   **content-bearing** (not a husk), so **`--recrystallize`** is the mode that
+   crystallizes it — `--reheal` is husk-only and would skip it. **Dry-run first**
+   to see the count (one real `claude` run per note); `--limit` bounds a batch:
    ```bash
-   bash scripts/luna/backfill-sessions.sh --reheal   # add the same scope flags
+   bash scripts/luna/backfill-sessions.sh --recrystallize --dry-run   # count
+   bash scripts/luna/backfill-sessions.sh --recrystallize --limit 25  # apply a batch
+   # (add the same --all / --luna-vault-path / --vault-registry scope you used)
    ```
 
 ## Opt-out + skip rules
@@ -131,6 +138,35 @@ bash scripts/luna/backfill-sessions.sh --reheal --luna-vault-path ~/Documents/lu
 ```
 
 Background: [`docs/luna/end-session-wiki.md` → Crystallization](../../docs/luna/end-session-wiki.md#crystallization-llm-upgrade).
+
+## Recrystallize mode (`--recrystallize`)
+
+`--reheal` only recovers **husks** (`crystallized != true` **AND**
+`_Transcript unavailable._` **AND** Files Touched `_None._`). But the common
+uncrystallized note is **content-bearing, not a husk** — e.g. a backfilled
+prose-session note, or a live note left `crystallized: false` by an earlier
+crystallizer bug. `--reheal` *skips* those (`non-husk-skip`).
+
+`--recrystallize` closes that gap: it crystallizes **any** note with
+`crystallized != true` that has a **recoverable (content-bearing) transcript**,
+husk or not. It is **LLM-only** — with no `claude` it skips (a mechanical
+re-render can't crystallize). Idempotent (already-`true` notes are skipped), and
+it honours the same `--dry-run` + vault-targeting flags.
+
+Because it is **one real `claude` run per note**, always **dry-run first** to see
+the count, then bound a batch with `--limit <N>` (remaining notes recover on a
+later run):
+
+```bash
+# Preview: how many uncrystallized content-notes would crystallize?
+bash scripts/luna/backfill-sessions.sh --recrystallize --dry-run --luna-vault-path ~/Documents/luna
+# Apply a bounded batch (e.g. 25 at a time):
+bash scripts/luna/backfill-sessions.sh --recrystallize --limit 25 --luna-vault-path ~/Documents/luna
+```
+
+> **Sequencing:** run `--recrystallize` to fully crystallize the session corpus
+> **before** a memory-compound pass (HIMMEL-564), so compounding works over real
+> distilled notes rather than mechanical ones.
 
 ## First-run note (live-capture overlap)
 

--- a/scripts/luna/backfill-sessions.sh
+++ b/scripts/luna/backfill-sessions.sh
@@ -30,6 +30,21 @@
 #                          transcript) are left as-is. Idempotent. Honours
 #                          --dry-run and --vault-registry/--luna-vault-path.
 #
+# Recrystallize mode (HIMMEL-620):
+#   --recrystallize        Like --reheal, but the broader predicate: crystallize
+#                          ANY note with crystallized != true that has a
+#                          recoverable (content-bearing) transcript — NOT just
+#                          husks. Covers content-bearing-but-uncrystallized notes
+#                          that --reheal skips (an F1-affected live note, or a
+#                          backfilled prose-session note). LLM-only (no claude ->
+#                          skip; a mechanical re-render does not crystallize).
+#                          Idempotent; honours --dry-run + the vault flags.
+#   --limit <N>            Cap real crystallizations per run (token-cost guard;
+#                          0 = unbounded). --dry-run reports the FULL count so you
+#                          can size batches. Remaining notes recover on a later run.
+#                          RUN --recrystallize --dry-run FIRST to see the scale —
+#                          it is one real `claude` run per note.
+#
 # bash 3.2-safe; shellcheck-clean; cross-platform (Windows Git Bash / macOS / Linux).
 
 set -uo pipefail
@@ -55,6 +70,8 @@ SCOPE_ALL=false
 ONLY_GLOB=""
 EXCLUDE_GLOB=""
 REHEAL=false
+RECRYSTALLIZE=false
+RECRYS_LIMIT=0
 
 # Home resolution (cross-platform)
 if [ -n "${HOME:-}" ]; then
@@ -97,6 +114,12 @@ while [ $# -gt 0 ]; do
             DRY_RUN=true; shift ;;
         --reheal)
             REHEAL=true; shift ;;
+        --recrystallize)
+            RECRYSTALLIZE=true; shift ;;
+        --limit)
+            shift
+            case "$1" in [0-9]*) RECRYS_LIMIT="$1" ;; *) printf 'backfill: --limit needs a number\n' >&2; exit 1 ;; esac
+            shift ;;
         --state-file)
             shift; STATE_FILE="$1"; shift ;;
         --vault-registry)
@@ -539,6 +562,8 @@ _process_one() {
 CNT_REHEAL=0
 CNT_REHEAL_INERT=0
 CNT_REHEAL_SKIP=0
+CNT_RECRYS=0
+CNT_RECRYS_SKIP=0
 
 # Read a frontmatter field's value from a note (between the first two `---`
 # lines). Echoes the value (may be empty); nothing if the key is absent.
@@ -700,6 +725,61 @@ _reheal_one() { # <note>
     fi
 }
 
+# ===========================================================================
+# Recrystallize mode (HIMMEL-620) — crystallize ANY note with crystallized != true
+# that has a recoverable (content-bearing) transcript, NOT just husks. --reheal is
+# husk-only (crystallized!=true AND "_Transcript unavailable._" AND Files None), so
+# it SKIPS content-bearing-but-uncrystallized notes — which is the common shape of
+# both an F1-affected live note and a backfilled prose-session note. This mode
+# closes that gap. Crystallization needs the LLM (a mechanical re-render stays
+# crystallized:false), so a missing `claude` skips rather than degrades.
+# ===========================================================================
+_recrystallize_one() { # <note>
+    local note="$1"
+    # Already crystallized -> nothing to do (idempotent).
+    if grep -q '^crystallized: true$' "$note" 2>/dev/null; then
+        CNT_RECRYS_SKIP=$((CNT_RECRYS_SKIP + 1))
+        return 0
+    fi
+    local sid jl
+    sid="$(_note_fm session_id "$note")"
+    jl="$(_find_transcript "$sid")"
+    if [ -z "$jl" ]; then
+        CNT_RECRYS_SKIP=$((CNT_RECRYS_SKIP + 1))   # transcript gone — can't crystallize
+        return 0
+    fi
+    parse_session_transcript "$jl"
+    # shellcheck disable=SC2153  # global set by the sourced lib
+    if [ "${HAS_CONTENT:-0}" -eq 0 ]; then
+        CNT_RECRYS_SKIP=$((CNT_RECRYS_SKIP + 1))   # no salvageable content to distil
+        return 0
+    fi
+    if ! _claude_available; then
+        CNT_RECRYS_SKIP=$((CNT_RECRYS_SKIP + 1))   # recrystallize is LLM-only
+        return 0
+    fi
+    # Dry-run reports the FULL recoverable count (limit not applied) so the operator
+    # can size --limit batches against the real token cost.
+    if [ "$DRY_RUN" = "true" ]; then
+        CNT_RECRYS=$((CNT_RECRYS + 1))
+        return 0
+    fi
+    # --limit caps real crystallizations (token-cost guard); remaining are skipped
+    # and recoverable on a later run (idempotent).
+    if [ "$RECRYS_LIMIT" -gt 0 ] && [ "$CNT_RECRYS" -ge "$RECRYS_LIMIT" ]; then
+        CNT_RECRYS_SKIP=$((CNT_RECRYS_SKIP + 1))
+        return 0
+    fi
+    # Synchronous (not detached): batch op, one note at a time; crystallize-note.sh
+    # is idempotent + fail-open. Count crystallized only when the flag actually flips.
+    bash "$SCRIPT_DIR/crystallize-note.sh" "$note" "$jl" || true
+    if grep -q '^crystallized: true$' "$note" 2>/dev/null; then
+        CNT_RECRYS=$((CNT_RECRYS + 1))
+    else
+        CNT_RECRYS_SKIP=$((CNT_RECRYS_SKIP + 1))   # cap/race/error — left for a later run
+    fi
+}
+
 # Enumerate husk-candidate notes (all sessions/**/*.md) into TMP_JSONL_LIST.
 _run_reheal() {
     local vault_root
@@ -711,10 +791,17 @@ _run_reheal() {
     # shellcheck disable=SC2088
     case "$vault_root" in "~/"*) vault_root="$_HOME/${vault_root#\~/}" ;; esac
 
+    local mode="reheal"
+    [ "$RECRYSTALLIZE" = "true" ] && mode="recrystallize"
+
     local sessions_dir="$vault_root/sessions"
     if [ ! -d "$sessions_dir" ]; then
-        printf 'backfill: reheal: no sessions/ under %s\n' "$vault_root" >&2
-        printf 'reheal: healed=0 inert=0 non-husk-skip=0\n'
+        printf 'backfill: %s: no sessions/ under %s\n' "$mode" "$vault_root" >&2
+        if [ "$mode" = "recrystallize" ]; then
+            printf 'recrystallize: crystallized=0 skipped=0\n'
+        else
+            printf 'reheal: healed=0 inert=0 non-husk-skip=0\n'
+        fi
         return 0
     fi
 
@@ -722,14 +809,24 @@ _run_reheal() {
     find "$sessions_dir" -type f -name '*.md' 2>/dev/null > "$TMP_JSONL_LIST"
     while IFS= read -r note; do
         [ -n "$note" ] || continue
-        _reheal_one "$note"
+        if [ "$mode" = "recrystallize" ]; then
+            _recrystallize_one "$note"
+        else
+            _reheal_one "$note"
+        fi
     done < "$TMP_JSONL_LIST"
 
-    printf 'reheal: healed=%d inert=%d non-husk-skip=%d\n' \
-        "$CNT_REHEAL" "$CNT_REHEAL_INERT" "$CNT_REHEAL_SKIP"
+    if [ "$mode" = "recrystallize" ]; then
+        printf 'recrystallize: crystallized=%d skipped=%d' "$CNT_RECRYS" "$CNT_RECRYS_SKIP"
+        [ "$RECRYS_LIMIT" -gt 0 ] && printf ' (--limit %d)' "$RECRYS_LIMIT"
+        printf '\n'
+    else
+        printf 'reheal: healed=%d inert=%d non-husk-skip=%d\n' \
+            "$CNT_REHEAL" "$CNT_REHEAL_INERT" "$CNT_REHEAL_SKIP"
+    fi
 }
 
-if [ "$REHEAL" = "true" ]; then
+if [ "$REHEAL" = "true" ] || [ "$RECRYSTALLIZE" = "true" ]; then
     _run_reheal
     exit 0
 fi
@@ -750,15 +847,19 @@ done < "$TMP_JSONL_LIST"
 printf 'backfill: new=%d already-in-ledger=%d opt-out-skip=%d orphaned-skip=%d under-min=%d husk-skip=%d\n' \
     "$CNT_NEW" "$CNT_LEDGER" "$CNT_OPTOUT" "$CNT_ORPHANED" "$CNT_UNDERMIN" "$CNT_HUSK"
 
-# Crystallization nudge (HIMMEL-590 F3): plain backfill writes MECHANICAL notes
-# (crystallized: false) — only the live end-session hook and `--reheal` run the
-# LLM crystallizer. Auto-spawning it per imported note during a bulk `--all`
-# import would fan out an unbounded number of billed `claude` runs, so backfill
-# deliberately does NOT; instead it points the operator at the one explicit,
-# concurrency-capped, idempotent quality pass. Printed only when notes landed.
+# Crystallization nudge (HIMMEL-590 F3 / HIMMEL-620): plain backfill writes
+# MECHANICAL notes (crystallized: false) — only the live end-session hook and the
+# crystallize passes run the LLM crystallizer. Auto-spawning it per imported note
+# during a bulk `--all` import would fan out an unbounded number of billed
+# `claude` runs, so backfill deliberately does NOT; instead it points the operator
+# at the explicit, concurrency-capped, idempotent pass. A backfilled prose-session
+# note is content-bearing (NOT a husk), so `--recrystallize` (not `--reheal`,
+# which is husk-only) is the mode that crystallizes it. Printed only when notes
+# landed.
 if [ "$DRY_RUN" != "true" ] && [ "$CNT_NEW" -gt 0 ]; then
     printf '\nbackfill: %d new note(s) are mechanical (crystallized: false).\n' "$CNT_NEW"
-    printf 'backfill: run the LLM crystallizer over them with:\n'
-    printf '    bash scripts/luna/backfill-sessions.sh --reheal\n'
+    printf 'backfill: preview the crystallize cost, then run it (one real claude run per note):\n'
+    printf '    bash scripts/luna/backfill-sessions.sh --recrystallize --dry-run   # count\n'
+    printf '    bash scripts/luna/backfill-sessions.sh --recrystallize [--limit N] # apply\n'
     printf 'backfill: (add the same --all / --luna-vault-path / --vault-registry scope you used here).\n'
 fi

--- a/scripts/luna/test-backfill-sessions.sh
+++ b/scripts/luna/test-backfill-sessions.sh
@@ -189,7 +189,7 @@ else
 fi
 
 # F3 (HIMMEL-590): a real import prints the --reheal crystallization nudge.
-assert_contains "F3: real import prints the --reheal nudge" "--reheal" "$out1"
+assert_contains "F3: real import prints the --recrystallize nudge" "--recrystallize" "$out1"
 # The imported note is mechanical (crystallized: false) until reheal runs.
 if grep -q '^crystallized: false$' "$NOTE" 2>/dev/null; then
     pass "F3: imported note is mechanical (crystallized: false)"
@@ -648,6 +648,62 @@ _None._
 EOF
 }
 
+# A CONTENT-bearing crystallized:false note (HIMMEL-620): real Raw Conversation
+# (NOT "_Transcript unavailable._"), so it is NOT a husk — --reheal skips it,
+# --recrystallize crystallizes it. This is the shape of an F1-affected live note
+# and a backfilled prose-session note.
+write_content_note() {
+    local path="$1" sid="$2"
+    mkdir -p "$(dirname "$path")"
+    cat > "$path" <<EOF
+---
+date: 2026-06-20T00:00:00Z
+type: session
+repo: testrepo
+branch:
+worktree: /tmp/testrepo
+duration_minutes: 5
+files_touched: 0
+tags:
+  - session
+  - autocapture
+ai-first: true
+session_id: ${sid}
+source: live
+crystallized: false
+crystallized_at:
+---
+
+Auto-captured session.
+
+## Summary
+
+Did some real work here (mechanical first line).
+
+## Decisions
+
+_None._
+
+## Files Touched
+
+_None._
+
+## Commands
+
+\`\`\`bash
+\`\`\`
+
+## Follow-ups
+
+_None._
+
+## Raw Conversation
+
+> [!note]- Raw conversation
+> Real assistant prose turn — this note is NOT a husk.
+EOF
+}
+
 # Drop a transcript fixture into a projects dir as <session_id>.jsonl so reheal
 # can locate it (the project slug is irrelevant — reheal globs */<sid>.jsonl).
 seed_named_transcript() {
@@ -1040,6 +1096,85 @@ if [ -n "$NOTE_B" ] && grep -q "repo: $(basename "$REPO_B")" "$NOTE_B" 2>/dev/nu
 else
     fail "multi-vault: vaultB note has wrong repo identity" "$out17"
 fi
+
+# ============================================================================
+# Case 18: --recrystallize crystallizes a CONTENT-bearing note that --reheal
+#          SKIPS (HIMMEL-620). The note is crystallized:false with a real Raw
+#          Conversation (not a husk). --reheal must skip it (non-husk-skip);
+#          --recrystallize must crystallize it (crystallized:true).
+# ============================================================================
+echo ""
+echo "Case 18: --recrystallize crystallizes a content-note that --reheal skips"
+
+SB="$TMP_ROOT/case18"
+VAULT18="$SB/vault"
+PROJ_ROOT18="$SB/projects"
+STATE18="$SB/state.json"
+NOTE18="$VAULT18/sessions/2026/06/2026-06-20-0000-testrepo.md"
+mkdir -p "$VAULT18" "$PROJ_ROOT18"
+write_content_note "$NOTE18" "recrys-sess-001"
+seed_named_transcript "$PROJ_ROOT18" "recrys-sess-001" "$TRANSCRIPT_FIXTURES/normal.jsonl"
+
+# 18a: --reheal SKIPS it (proves the gap — it's not a husk).
+out18r=$(env CRYSTALLIZE_CLAUDE_BIN="$CLAUDE_STUB" STUB_MODE=success \
+    CRYSTALLIZE_PID_DIR="$SB/pids" \
+    bash "$BACKFILL" --reheal \
+    --projects-dir "$PROJ_ROOT18" --luna-vault-path "$VAULT18" \
+    --state-file "$STATE18" --vault-registry /dev/null 2>&1)
+assert_contains "recrys: --reheal skips the content-note (non-husk)" "non-husk-skip=1" "$out18r"
+if grep -q '^crystallized: false$' "$NOTE18"; then pass "recrys: --reheal left it crystallized:false"; else fail "recrys: --reheal wrongly changed it" "$out18r"; fi
+
+# 18b: --recrystallize crystallizes it.
+out18=$(env CRYSTALLIZE_CLAUDE_BIN="$CLAUDE_STUB" STUB_MODE=success \
+    CRYSTALLIZE_PID_DIR="$SB/pids" CRYSTALLIZE_NOW="2026-06-29T00:00:00Z" \
+    bash "$BACKFILL" --recrystallize \
+    --projects-dir "$PROJ_ROOT18" --luna-vault-path "$VAULT18" \
+    --state-file "$STATE18" --vault-registry /dev/null 2>&1)
+assert_contains "recrys: --recrystallize reports crystallized=1" "crystallized=1" "$out18"
+if grep -q '^crystallized: true$' "$NOTE18"; then pass "recrys: content-note crystallized:true"; else fail "recrys: content-note not crystallized" "$out18"; fi
+
+# 18c: idempotent — re-run skips the now-crystallized note.
+out18b=$(env CRYSTALLIZE_CLAUDE_BIN="$CLAUDE_STUB" STUB_MODE=success \
+    CRYSTALLIZE_PID_DIR="$SB/pids" \
+    bash "$BACKFILL" --recrystallize \
+    --projects-dir "$PROJ_ROOT18" --luna-vault-path "$VAULT18" \
+    --state-file "$STATE18" --vault-registry /dev/null 2>&1)
+assert_contains "recrys: idempotent re-run crystallizes nothing" "crystallized=0" "$out18b"
+
+# ============================================================================
+# Case 19: --recrystallize --dry-run counts but writes nothing; --limit caps.
+# ============================================================================
+echo ""
+echo "Case 19: --recrystallize --dry-run (no write) + --limit caps real runs"
+
+SB="$TMP_ROOT/case19"
+VAULT19="$SB/vault"
+PROJ_ROOT19="$SB/projects"
+STATE19="$SB/state.json"
+N19A="$VAULT19/sessions/2026/06/2026-06-20-0000-a.md"
+N19B="$VAULT19/sessions/2026/06/2026-06-20-0001-b.md"
+mkdir -p "$VAULT19" "$PROJ_ROOT19"
+write_content_note "$N19A" "recrys-a"; seed_named_transcript "$PROJ_ROOT19" "recrys-a" "$TRANSCRIPT_FIXTURES/normal.jsonl"
+write_content_note "$N19B" "recrys-b"; seed_named_transcript "$PROJ_ROOT19" "recrys-b" "$TRANSCRIPT_FIXTURES/normal.jsonl"
+
+# dry-run: counts both, writes nothing.
+SHA19A="$(_file_sha256 "$N19A")"
+out19d=$(env CRYSTALLIZE_CLAUDE_BIN="$CLAUDE_STUB" STUB_MODE=success CRYSTALLIZE_PID_DIR="$SB/pids" \
+    bash "$BACKFILL" --recrystallize --dry-run \
+    --projects-dir "$PROJ_ROOT19" --luna-vault-path "$VAULT19" \
+    --state-file "$STATE19" --vault-registry /dev/null 2>&1)
+assert_contains "recrys(dry): both content-notes counted" "crystallized=2" "$out19d"
+if [ "$SHA19A" = "$(_file_sha256 "$N19A")" ]; then pass "recrys(dry): note byte-unchanged"; else fail "recrys(dry): --dry-run mutated a note" "$out19d"; fi
+
+# --limit 1: only one crystallized this run.
+out19l=$(env CRYSTALLIZE_CLAUDE_BIN="$CLAUDE_STUB" STUB_MODE=success \
+    CRYSTALLIZE_PID_DIR="$SB/pids" CRYSTALLIZE_NOW="2026-06-29T00:00:00Z" \
+    bash "$BACKFILL" --recrystallize --limit 1 \
+    --projects-dir "$PROJ_ROOT19" --luna-vault-path "$VAULT19" \
+    --state-file "$STATE19" --vault-registry /dev/null 2>&1)
+assert_contains "recrys(limit): --limit 1 crystallizes exactly one" "crystallized=1" "$out19l"
+_cryst_count=$(grep -l '^crystallized: true$' "$N19A" "$N19B" 2>/dev/null | wc -l | tr -d ' ')
+if [ "$_cryst_count" = "1" ]; then pass "recrys(limit): exactly one note crystallized on disk"; else fail "recrys(limit): $_cryst_count crystallized (expected 1)" "$out19l"; fi
 
 # ============================================================================
 # Summary


### PR DESCRIPTION
--reheal only recovers husks; content-bearing-but-uncrystallized notes (backfilled prose sessions, or notes left crystallized:false by an earlier crystallizer bug) were skipped. --recrystallize crystallizes any crystallized!=true note with a content-bearing transcript; LLM-only; --limit N caps token cost; dry-run reports the full count. The backfill nudge now points at --recrystallize. 73 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)