### PR TITLE
fix: npm-licenses gate skips bun-managed packages + document jira-mutation breadcrumbs

### DIFF
--- a/docs/internals/jira-plugin.md
+++ b/docs/internals/jira-plugin.md
@@ -105,3 +105,22 @@ works only if that token covers Confluence too).
 
 The verb↔MCP-method rows above mirror `_CONFLUENCE_VERB_METHOD_MAP` in
 `block-backend-tier.sh` — keep them in sync.
+
+## Mutation breadcrumbs (HIMMEL-618)
+
+Every ticket-workflow mutating verb (`transition`, `comment`, `create`, `move`,
+`edit`, `assign`, `worklog`, `link`, `sprint`) writes a breadcrumb file under
+`~/.claude/jira-breadcrumbs/` immediately after its request **resolves** — not
+gated on the command's exit code, so a mutation that landed before a later
+non-fatal failure (e.g. an attachment upload) still leaves a breadcrumb.
+
+The file is keyed by **repo + branch**, not session id: the standalone CLI
+process (spawned via the Bash tool) never receives the Claude `session_id`, so
+the writer (`scripts/jira/src/breadcrumb.ts`) and the SessionEnd hook reader
+(`scripts/lib/jira-breadcrumb.sh` ← `scripts/hooks/jira-nudge-on-end.sh`) agree
+on a `repo-key` (basename of `git remote get-url origin`, `.git` stripped —
+stable across worktrees) and let the hook match on `epoch >= session-start`.
+The path + token sanitization (`[^A-Za-z0-9._-]` → `-`) MUST stay byte-identical
+between the TS writer and the bash reader. The nudge hook consumes these to
+decide whether a ticket-scoped session already synced Jira (advisory, default
+OFF).

--- a/scripts/hooks/check-npm-licenses.sh
+++ b/scripts/hooks/check-npm-licenses.sh
@@ -30,6 +30,19 @@ fi
 fail=0
 for pkg in "${pkgs[@]}"; do
     dir=$(dirname "$pkg")
+    # HIMMEL-523: skip bun-managed packages. A package with a bun lockfile
+    # (bun.lock / bun.lockb) and NO package-lock.json is bun-managed (e.g.
+    # scripts/luna-vitals — only a @types/bun devDep). For such a package
+    # `npm install --omit=dev` installs nothing and `license-checker --production`
+    # then errors "No packages found in this path", failing this always-run gate
+    # on EVERY push (forcing SKIP=npm-licenses, which disables the check for ALL
+    # packages). bun packages carry no npm production deps to license-check here
+    # and are covered by the bun-suites CI; skip them. A package that ALSO has a
+    # package-lock.json is treated as npm-managed (not skipped).
+    if { [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; } && [ ! -f "$dir/package-lock.json" ]; then
+        echo "→ license-checker: $dir is bun-managed (bun lockfile, no package-lock.json) — skipping npm license check (bun deps covered by bun-suites)"
+        continue
+    fi
     # Self-install prod deps when node_modules is missing (e.g. fresh worktree).
     # --ignore-scripts is critical: never execute third-party postinstall scripts in a pre-push gate.
     if [ ! -d "$dir/node_modules" ]; then

--- a/scripts/hooks/test-check-npm-licenses.sh
+++ b/scripts/hooks/test-check-npm-licenses.sh
@@ -15,6 +15,8 @@
 # Usage: bash scripts/hooks/test-check-npm-licenses.sh
 set -uo pipefail
 
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-npm-licenses.sh"
+
 FAILED=0
 
 assert_eq() {
@@ -110,6 +112,32 @@ if printf '%s\n' "$new_out" | grep -q 'node_modules'; then
 else
     echo "PASS node_modules package.json excluded from enumeration"
 fi
+
+# Case 5: HIMMEL-523 — a bun-managed package (bun.lock, no package-lock.json) is
+# SKIPPED by the gate, so a repo whose only package is bun-managed passes (rc 0)
+# instead of erroring "No packages found in this path". Runs the REAL script
+# against a throwaway repo; the skip happens before any npm/npx call (no network).
+BUN_REPO=$(mktemp -d)
+(
+    cd "$BUN_REPO" || exit 1
+    git init -q -b main
+    git config user.email t@t
+    git config user.name t
+    mkdir -p scripts/luna-vitals
+    echo '{"name":"luna-vitals","devDependencies":{"@types/bun":"latest"}}' > scripts/luna-vitals/package.json
+    : > scripts/luna-vitals/bun.lock   # bun lockfile, no package-lock.json
+    git add -A
+    git -c commit.gpgsign=false commit -q -m "bun-only package"
+)
+bun_out=$( cd "$BUN_REPO" && bash "$SCRIPT" 2>&1 ); bun_rc=$?
+if [ "$bun_rc" -eq 0 ] && printf '%s' "$bun_out" | grep -qi "bun-managed"; then
+    echo "PASS bun-managed package skipped — gate passes (rc 0), no 'No packages found'"
+else
+    echo "FAIL bun-managed skip: rc=$bun_rc"
+    echo "     out: $bun_out"
+    FAILED=$((FAILED + 1))
+fi
+rm -rf "$BUN_REPO"
 
 echo ""
 if [ "$FAILED" -eq 0 ]; then


### PR DESCRIPTION
Code-only propagation of two private merges: (1) the npm-licenses pre-push gate now skips bun-managed packages (no spurious 'No packages found' failures on bun-only dirs); (2) new docs section documenting the jira-mutation breadcrumb mechanism consumed by the SessionEnd nudge hook.