### PR TITLE
fix(hooks): [HIMMEL-636] full-body-detach SessionEnd hooks so the preamble can't trip 'Hook cancelled'

### DIFF
--- a/scripts/hooks/jira-nudge-on-end.sh
+++ b/scripts/hooks/jira-nudge-on-end.sh
@@ -28,11 +28,12 @@
 # This hook runs under bash on every platform (no .ps1 twin), so do NOT add a
 # msys/cygwin guard — that would silence the nudge on Windows/Git-Bash.
 
-# Error isolation: do NOT use `set -e`/`pipefail` + an ERR trap — the sourced
-# parse_session_transcript() returns non-zero on a content-free transcript (its
-# last `&&` short-circuits), which an ERR trap would mistake for a fatal error.
-# Instead run with set +e and force a clean exit via the EXIT trap (a SessionEnd
-# advisory hook must NEVER block teardown, regardless of how it got here).
+# Error isolation: do NOT use `set -e`/`pipefail` + an ERR trap — the many
+# best-effort probes below (jq pipelines, `git log`, the `|| exit 0`
+# short-circuits) routinely return non-zero on a content-free transcript or a
+# missing tool, which an ERR trap would mistake for a fatal error. Instead run
+# with set +e and force a clean exit via the EXIT trap (a SessionEnd advisory
+# hook must NEVER block teardown, regardless of how it got here).
 set +e
 set -u 2>/dev/null || true
 trap 'exit 0' EXIT
@@ -89,9 +90,17 @@ if [ -r "$HOOK_LIB/initiative-legs.sh" ]; then
 fi
 
 # --- Session-start epoch from the transcript's first timestamp --------------
-# shellcheck source=/dev/null
-. "$HOOK_LIB/session-transcript.sh"
-parse_session_transcript "$TRANSCRIPT_PATH"
+# Only the FIRST timestamp is needed. Extract it directly rather than via
+# parse_session_transcript(), which runs FOUR full-file jq scans
+# (FIRST_TS/LAST_TS/LAST_ASSISTANT/COMMANDS) — three of which this hook never
+# uses. On a long transcript those synchronous scans are what race Claude Code's
+# SessionEnd teardown ("Hook cancelled"); the single-scan path keeps detection
+# cheap so the nudge stays SYNCHRONOUS (its stdout/transcript surface survives)
+# without a full-body detach. HIMMEL-636.
+FIRST_TS=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -r "$TRANSCRIPT_PATH" ]; then
+    FIRST_TS="$(jq -r 'select(.timestamp) | .timestamp' "$TRANSCRIPT_PATH" 2>/dev/null | head -n1)"
+fi
 [ -n "${FIRST_TS:-}" ] || exit 0
 START_EPOCH="$(date -u -d "$FIRST_TS" +%s 2>/dev/null || echo "")"
 if [ -z "$START_EPOCH" ]; then

--- a/scripts/hooks/refresh-where-are-we-on-end.sh
+++ b/scripts/hooks/refresh-where-are-we-on-end.sh
@@ -27,14 +27,42 @@
 # Test seams (used only by test-refresh-where-are-we-on-end.sh):
 #   WHERE_ARE_WE_STATE_DIR            override the state dir (default $root/.where-are-we)
 #   HIMMEL_WHERE_ARE_WE_COLLECT_CMD   override the refresh command (default node collect.mjs)
+#   HIMMEL_WHERE_ARE_WE_TEST_DELAY    sleep N seconds at the START of the detached
+#                                     child body. Proves the full-body detach keeps
+#                                     the PARENT fast: a regression that un-detaches
+#                                     the body would make this delay block teardown,
+#                                     failing the fast-return assertion (Case 5).
 
 set -euo pipefail
 
 # Always exit clean; never block session teardown on our own bug.
 trap 'exit 0' ERR
 
-# Drain stdin (SessionEnd pipes a JSON payload) so the contract doesn't break.
-if [ -t 0 ]; then :; else cat >/dev/null 2>&1 || true; fi
+# --- Full-body detach (HIMMEL-636) ------------------------------------------
+# Re-exec ourselves DETACHED and return 0 instantly so the synchronous preamble
+# below (git rev-parse, .env load, node resolution) runs in the detached child
+# and can never race Claude Code's SessionEnd teardown timer — the residual
+# "Hook cancelled" that HIMMEL-623/635 left behind by detaching only the collect
+# sub-step while the preamble still ran in the foreground. The child writes only
+# files (ledger + freshness marker), so deferring it loses no operator-visible
+# surface; HIMMEL-576 proved such a child survives the hook's process-group
+# teardown.
+if [ "${1:-}" != "__himmel_detached" ]; then
+    # Drain stdin (SessionEnd pipes a JSON payload) so the contract doesn't break.
+    if [ -t 0 ]; then :; else cat >/dev/null 2>&1 || true; fi
+    # shellcheck source=/dev/null
+    . "$(dirname "${BASH_SOURCE[0]}")/../lib/detach.sh"
+    detach_run bash "$0" __himmel_detached
+    exit 0
+fi
+
+# === Detached child: the real refresh (parent already returned 0) ===========
+
+# Test-only preamble-latency seam (see header). if-guarded, not `&& sleep`, so an
+# unset value can't trip `set -e` + the ERR trap into a premature exit 0.
+if [ -n "${HIMMEL_WHERE_ARE_WE_TEST_DELAY:-}" ]; then
+    sleep "$HIMMEL_WHERE_ARE_WE_TEST_DELAY"
+fi
 
 # --- Resolve the himmel root (never trust CWD) ------------------------------
 _wa_root="${HIMMEL_REPO:-}"

--- a/scripts/hooks/test-refresh-where-are-we-on-end.sh
+++ b/scripts/hooks/test-refresh-where-are-we-on-end.sh
@@ -29,6 +29,9 @@ HIMMEL_REPO="$REPO_ROOT" WHERE_ARE_WE_STATE_DIR="$state1" \
     HIMMEL_WHERE_ARE_WE="" \
     HIMMEL_WHERE_ARE_WE_COLLECT_CMD="touch '$sentinel1'" \
     bash "$HOOK" </dev/null >/dev/null 2>&1; rc1=$?
+# Gate now runs in the detached child (HIMMEL-636) — give it time to (not) fire
+# before asserting the refresh stayed off; a regressed gate would touch by now.
+sleep 0.5
 if [ "$rc1" = 0 ] && [ ! -e "$sentinel1" ]; then
     pass "OFF -> no refresh, exit 0"
 else
@@ -61,6 +64,7 @@ HIMMEL_REPO="$REPO_ROOT" WHERE_ARE_WE_STATE_DIR="$state2b" \
     HIMMEL_WHERE_ARE_WE=false \
     HIMMEL_WHERE_ARE_WE_COLLECT_CMD="touch '$sentinel2b'" \
     bash "$HOOK" </dev/null >/dev/null 2>&1; rc2b=$?
+sleep 0.5   # gate runs in the detached child now — barrier before the negative check
 if [ "$rc2b" = 0 ] && [ ! -e "$sentinel2b" ]; then
     pass "OFF via 'false' grammar -> no refresh, exit 0"
 else
@@ -90,6 +94,39 @@ if [ "$rc4" = 0 ]; then
     pass "broken root -> fail-open exit 0"
 else
     fail "broken root -> expected exit 0, got rc=$rc4"
+fi
+
+# --- Case 5: full-body detach keeps the PARENT fast (HIMMEL-636) -------------
+# The discriminating test: inject latency into the PREAMBLE (HIMMEL_WHERE_ARE_WE_TEST_DELAY
+# sleeps at the start of the child body) — NOT into the collect, which was already
+# detached pre-HIMMEL-636 (so a slow COLLECT_CMD would pass on the OLD code too).
+# With the full-body detach the preamble runs in the detached child, so the parent
+# returns immediately; a regression that un-detached the body would run this 12s
+# delay in the FOREGROUND and blow the <10s assertion. Then confirm the child still
+# completes async (sentinel + marker) AFTER the delay. Skipped where GNU coreutils
+# `timeout` is absent (stock macOS); the detach primitive is covered portably by
+# scripts/lib/test-detach.sh.
+if command -v timeout >/dev/null 2>&1; then
+    state5="$TMP/s5"; mkdir -p "$state5"
+    sentinel5="$TMP/sentinel5"
+    _t0=$(date +%s)
+    timeout 20 env HIMMEL_REPO="$REPO_ROOT" WHERE_ARE_WE_STATE_DIR="$state5" \
+        HIMMEL_WHERE_ARE_WE=1 \
+        HIMMEL_WHERE_ARE_WE_TEST_DELAY=12 \
+        HIMMEL_WHERE_ARE_WE_COLLECT_CMD="touch '$sentinel5'" \
+        bash "$HOOK" </dev/null >/dev/null 2>&1; rc5=$?
+    _elapsed=$(( $(date +%s) - _t0 ))
+    # Wait out the 12s preamble delay, then confirm the child completed.
+    i=0; while { [ ! -e "$sentinel5" ] || [ ! -e "$state5/.refreshed-at" ]; } && [ "$i" -lt 250 ]; do sleep 0.1; i=$((i + 1)); done
+    if [ "$rc5" = 0 ] && [ "$_elapsed" -lt 10 ] && [ -e "$sentinel5" ] && [ -e "$state5/.refreshed-at" ]; then
+        pass "slow PREAMBLE -> parent returns fast AND child completes async"
+    else
+        sv=no; [ -e "$sentinel5" ] && sv=yes
+        mv=no; [ -e "$state5/.refreshed-at" ] && mv=yes
+        fail "slow preamble -> rc=$rc5 elapsed=${_elapsed}s sentinel=$sv marker=$mv"
+    fi
+else
+    echo "SKIP slow-preamble-fast-return (no GNU coreutils timeout on this runner)"
 fi
 
 echo "---"

--- a/scripts/lib/detach.sh
+++ b/scripts/lib/detach.sh
@@ -25,6 +25,13 @@
 #      hanging; stdout/stderr to /dev/null so the child never holds the hook's
 #      output pipe open.
 #
+# CONSTRAINT (HIMMEL-636): detached SessionEnd work must be self-contained host
+# tooling (node/git/curl). It must NOT depend on headless `claude` print/--bg
+# modes — those bill to a separate, volatile bucket (HIMMEL-128) and a detached
+# failure is silent. If a SessionEnd step ever needs an LLM (e.g. the HIMMEL-576
+# crystallizer), migrate it to an ARMED-session model (a scheduled INTERACTIVE
+# `claude` via the arm-resume scheduler), not a fire-and-forget child here.
+#
 # bash 3.2-safe (`disown` is a 3.2 builtin; it is guarded so a non-bash sh that
 # happens to source this still degrades to a plain background job).
 # DETACH_NO_SETSID=1 forces the no-setsid fallback even where setsid exists — a


### PR DESCRIPTION
Full-body-detach refresh-where-are-we-on-end.sh and trim jira-nudge-on-end.sh detection so the synchronous preamble can't race Claude Code's SessionEnd teardown timer. Builds on the #749/#754 work-completion detaches.