### PR TITLE
fix(mcp): [HIMMEL-639] wrap bun MCP servers through a runtime resolver (#121 C6)

### DIFF
--- a/marketplace/plugins/luna-correlate/.mcp.json
+++ b/marketplace/plugins/luna-correlate/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "luna-correlate": {
-      "command": "bun",
-      "args": ["run", "--cwd", "${CLAUDE_PLUGIN_ROOT}", "--shell=bun", "--silent", "start"]
+      "command": "bash",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/run-bun.sh", "run", "--cwd", "${CLAUDE_PLUGIN_ROOT}", "--shell=bun", "--silent", "start"]
     }
   }
 }

--- a/marketplace/plugins/luna-correlate/run-bun.sh
+++ b/marketplace/plugins/luna-correlate/run-bun.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# run-bun.sh — runtime bun launcher for this plugin's MCP server. Resolves an
+# absolute `bun` at spawn time and execs it, so the server starts even on a
+# PATH-less GUI launch (macOS dock / Windows shortcut) where a bare `bun`
+# command silently fails to start and the server's tools vanish with no error
+# (issue #121 C6). Mirrors the himmel C1/P4 wrapper model
+# (scripts/lib/run-node.sh, run-pwsh.sh).
+#
+# Shipped PER-PLUGIN (not in the himmel repo's scripts/lib) on purpose: a
+# .mcp.json installed to the plugin cache can only anchor on
+# ${CLAUDE_PLUGIN_ROOT} and cannot reach the himmel checkout. Wired from
+# .mcp.json as: command "bash", args ["${CLAUDE_PLUGIN_ROOT}/run-bun.sh", …].
+# A trailing-token `bash` is not PATH-fragile (it is in the base GUI PATH on
+# every platform), so /himmel-doctor C6 no longer flags the server.
+#
+# FAIL-CLOSED: unlike the fail-open hook wrappers, an MCP server that cannot
+# find its interpreter genuinely cannot run — so on a missing bun we write ONE
+# breadcrumb and exit 127, surfacing the server as failed-to-start (honest)
+# rather than pretending success. bash 3.2-safe.
+#
+# Test seam (scripts/lib/test-run-bun.sh): RESOLVE_BUN_PROBE_DIRS — a
+# colon-separated dir list that REPLACES the built-in candidates (PATH first).
+set -u
+
+_resolve_bun() {
+    # 1) PATH — the common case (and what a terminal launch sees).
+    if command -v bun >/dev/null 2>&1; then command -v bun; return 0; fi
+
+    # 2) Well-known absolute locations. `~/.bun/bin` is bun's default install on
+    #    every platform incl. Windows (Git Bash $HOME), so it covers the GUI-PATH
+    #    case there too. (No `$LOCALAPPDATA` candidate: its `C:\…` colon is eaten
+    #    by the `IFS=:` split below, so it could never match anyway.)
+    local dirs d save_ifs="$IFS"
+    if [ "${RESOLVE_BUN_PROBE_DIRS+set}" = set ]; then
+        dirs="$RESOLVE_BUN_PROBE_DIRS"
+    else
+        dirs="${BUN_INSTALL:-${HOME:-}/.bun}/bin:${HOME:-}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin"
+    fi
+    IFS=:
+    for d in $dirs; do
+        [ -n "$d" ] || continue
+        if [ -x "$d/bun" ]; then printf '%s\n' "$d/bun"; IFS="$save_ifs"; return 0; fi
+        if [ -x "$d/bun.exe" ]; then printf '%s\n' "$d/bun.exe"; IFS="$save_ifs"; return 0; fi
+    done
+    IFS="$save_ifs"
+    return 1
+}
+
+_bun="$(_resolve_bun)" || _bun=""
+if [ -n "$_bun" ]; then
+    exec "$_bun" "$@"
+fi
+
+# No bun: fail-closed with a breadcrumb for /himmel-doctor C6 / a curious operator.
+_log_dir="${CLAUDE_DIR:-${HOME:-.}/.claude}"
+mkdir -p "$_log_dir" 2>/dev/null || true
+printf '%s bun not found; MCP server not started: %s\n' "$(date '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || echo '?')" "$*" \
+    >> "$_log_dir/himmel-bun.log" 2>/dev/null || true
+exit 127

--- a/marketplace/plugins/telegram-himmel/.mcp.json
+++ b/marketplace/plugins/telegram-himmel/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "telegram": {
-      "command": "bun",
-      "args": ["run", "--cwd", "${CLAUDE_PLUGIN_ROOT}", "--shell=bun", "--silent", "start"]
+      "command": "bash",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/run-bun.sh", "run", "--cwd", "${CLAUDE_PLUGIN_ROOT}", "--shell=bun", "--silent", "start"]
     }
   }
 }

--- a/marketplace/plugins/telegram-himmel/run-bun.sh
+++ b/marketplace/plugins/telegram-himmel/run-bun.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# run-bun.sh — runtime bun launcher for this plugin's MCP server. Resolves an
+# absolute `bun` at spawn time and execs it, so the server starts even on a
+# PATH-less GUI launch (macOS dock / Windows shortcut) where a bare `bun`
+# command silently fails to start and the server's tools vanish with no error
+# (issue #121 C6). Mirrors the himmel C1/P4 wrapper model
+# (scripts/lib/run-node.sh, run-pwsh.sh).
+#
+# Shipped PER-PLUGIN (not in the himmel repo's scripts/lib) on purpose: a
+# .mcp.json installed to the plugin cache can only anchor on
+# ${CLAUDE_PLUGIN_ROOT} and cannot reach the himmel checkout. Wired from
+# .mcp.json as: command "bash", args ["${CLAUDE_PLUGIN_ROOT}/run-bun.sh", …].
+# A trailing-token `bash` is not PATH-fragile (it is in the base GUI PATH on
+# every platform), so /himmel-doctor C6 no longer flags the server.
+#
+# FAIL-CLOSED: unlike the fail-open hook wrappers, an MCP server that cannot
+# find its interpreter genuinely cannot run — so on a missing bun we write ONE
+# breadcrumb and exit 127, surfacing the server as failed-to-start (honest)
+# rather than pretending success. bash 3.2-safe.
+#
+# Test seam (scripts/lib/test-run-bun.sh): RESOLVE_BUN_PROBE_DIRS — a
+# colon-separated dir list that REPLACES the built-in candidates (PATH first).
+set -u
+
+_resolve_bun() {
+    # 1) PATH — the common case (and what a terminal launch sees).
+    if command -v bun >/dev/null 2>&1; then command -v bun; return 0; fi
+
+    # 2) Well-known absolute locations. `~/.bun/bin` is bun's default install on
+    #    every platform incl. Windows (Git Bash $HOME), so it covers the GUI-PATH
+    #    case there too. (No `$LOCALAPPDATA` candidate: its `C:\…` colon is eaten
+    #    by the `IFS=:` split below, so it could never match anyway.)
+    local dirs d save_ifs="$IFS"
+    if [ "${RESOLVE_BUN_PROBE_DIRS+set}" = set ]; then
+        dirs="$RESOLVE_BUN_PROBE_DIRS"
+    else
+        dirs="${BUN_INSTALL:-${HOME:-}/.bun}/bin:${HOME:-}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin"
+    fi
+    IFS=:
+    for d in $dirs; do
+        [ -n "$d" ] || continue
+        if [ -x "$d/bun" ]; then printf '%s\n' "$d/bun"; IFS="$save_ifs"; return 0; fi
+        if [ -x "$d/bun.exe" ]; then printf '%s\n' "$d/bun.exe"; IFS="$save_ifs"; return 0; fi
+    done
+    IFS="$save_ifs"
+    return 1
+}
+
+_bun="$(_resolve_bun)" || _bun=""
+if [ -n "$_bun" ]; then
+    exec "$_bun" "$@"
+fi
+
+# No bun: fail-closed with a breadcrumb for /himmel-doctor C6 / a curious operator.
+_log_dir="${CLAUDE_DIR:-${HOME:-.}/.claude}"
+mkdir -p "$_log_dir" 2>/dev/null || true
+printf '%s bun not found; MCP server not started: %s\n' "$(date '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || echo '?')" "$*" \
+    >> "$_log_dir/himmel-bun.log" 2>/dev/null || true
+exit 127

--- a/scripts/lib/test-run-bun.sh
+++ b/scripts/lib/test-run-bun.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Smoke test for the per-plugin MCP bun launchers (marketplace/plugins/*/run-bun.sh,
+# HIMMEL-639). Mirrors scripts/lib/test-run-node.sh. Runs every assertion against
+# BOTH shipped copies so the two stay byte-identical and neither regresses.
+# Usage: bash scripts/lib/test-run-bun.sh
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+W1="$REPO_ROOT/marketplace/plugins/luna-correlate/run-bun.sh"
+W2="$REPO_ROOT/marketplace/plugins/telegram-himmel/run-bun.sh"
+
+failures=0
+pass() { printf '  PASS  %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures+1)); }
+
+UTILS_DIR="$(dirname "$(command -v sort)")"
+
+# A fake bun: route on the first arg so we can exercise args/stdin/exit.
+make_fake_bun() {
+    local dir="$1"; mkdir -p "$dir"
+    cat > "$dir/bun" <<'EOF'
+#!/bin/sh
+case "$1" in
+  echo-args) shift; printf 'args:%s\n' "$*" ;;
+  echo-stdin) cat ;;
+  exit42) exit 42 ;;
+  *) printf 'ran:%s\n' "$1" ;;
+esac
+EOF
+    chmod +x "$dir/bun"
+}
+
+for RUN in "$W1" "$W2"; do
+    [ -f "$RUN" ] || { fail "$RUN not found"; continue; }
+    label="${RUN#"$REPO_ROOT"/marketplace/plugins/}"; label="${label%/run-bun.sh}"
+    echo "== $label: args pass through + stdout =="
+    tmp="$(mktemp -d)"; make_fake_bun "$tmp/bin"
+    out="$(PATH="$UTILS_DIR" RESOLVE_BUN_PROBE_DIRS="$tmp/bin" bash "$RUN" echo-args A B)"
+    if [ "$out" = "args:A B" ]; then pass "args -> '$out'"; else fail "args -> '$out'"; fi
+    rm -rf "$tmp"
+
+    echo "== $label: exit code propagates =="
+    tmp="$(mktemp -d)"; make_fake_bun "$tmp/bin"
+    PATH="$UTILS_DIR" RESOLVE_BUN_PROBE_DIRS="$tmp/bin" bash "$RUN" exit42 >/dev/null 2>&1
+    rc=$?
+    if [ "$rc" -eq 42 ]; then pass "exit -> 42"; else fail "exit -> $rc (want 42)"; fi
+    rm -rf "$tmp"
+
+    echo "== $label: stdin reaches the child (stdio MCP) =="
+    tmp="$(mktemp -d)"; make_fake_bun "$tmp/bin"
+    out="$(printf 'PAYLOAD-123' | PATH="$UTILS_DIR" RESOLVE_BUN_PROBE_DIRS="$tmp/bin" bash "$RUN" echo-stdin)"
+    if [ "$out" = "PAYLOAD-123" ]; then pass "stdin -> '$out'"; else fail "stdin -> '$out'"; fi
+    rm -rf "$tmp"
+
+    echo "== $label: no bun -> fail-closed (exit 127, silent, one log line) =="
+    tmp="$(mktemp -d)"; cdir="$tmp/claude"
+    out="$(PATH="$UTILS_DIR" RESOLVE_BUN_PROBE_DIRS="" CLAUDE_DIR="$cdir" bash "$RUN" run start 2>"$tmp/err.txt")"
+    rc=$?
+    err="$(cat "$tmp/err.txt")"
+    logc=0; [ -f "$cdir/himmel-bun.log" ] && logc="$(wc -l < "$cdir/himmel-bun.log" | tr -d ' ')"
+    if [ "$rc" -eq 127 ] && [ -z "$out" ] && [ -z "$err" ] && [ "$logc" = "1" ]; then
+        pass "no-bun -> rc127, silent, 1 log line"
+    else
+        fail "no-bun -> rc=$rc out='$out' err='$err' logc=$logc"
+    fi
+    rm -rf "$tmp"
+done
+
+echo "== both wrappers are byte-identical (no drift) =="
+if cmp -s "$W1" "$W2"; then pass "luna-correlate/run-bun.sh == telegram-himmel/run-bun.sh"; else fail "wrappers diverged"; fi
+
+echo "== each .mcp.json routes through its wrapper (no bare bun) =="
+for p in luna-correlate telegram-himmel; do
+    mcp="$REPO_ROOT/marketplace/plugins/$p/.mcp.json"
+    cmd="$(jq -r '(.mcpServers // {}) | to_entries[0].value.command' "$mcp" 2>/dev/null)"
+    a0="$(jq -r '(.mcpServers // {}) | to_entries[0].value.args[0]' "$mcp" 2>/dev/null)"
+    # shellcheck disable=SC2016  # literal ${CLAUDE_PLUGIN_ROOT} must NOT expand here
+    if [ "$cmd" = "bash" ] && [ "$a0" = '${CLAUDE_PLUGIN_ROOT}/run-bun.sh' ]; then
+        pass "$p .mcp.json wired through run-bun.sh"
+    else
+        fail "$p .mcp.json command='$cmd' args[0]='$a0' (want bash + \${CLAUDE_PLUGIN_ROOT}/run-bun.sh)"
+    fi
+done
+
+echo
+if [ "$failures" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$failures FAILURE(S)"; exit 1; fi


### PR DESCRIPTION
Closes the remaining C6 gap in #121 — PATH-fragile bun MCP servers (luna-correlate, telegram) now resolve bun at spawn time via a per-plugin run-bun.sh wrapper, so they start on a PATH-less GUI launch. Mirrors the C1/P4 wrapper model. Fixes #121 (C6).