### PR TITLE
fix(luna): cross-platform BAT_DIR runner home for pipeline-cadence

### DIFF
--- a/scripts/luna/pipeline-cadence.sh
+++ b/scripts/luna/pipeline-cadence.sh
@@ -73,11 +73,28 @@ TASK_SYNTH="${TASK_PREFIX}Synthesize"
 TASK_HEALTH="${TASK_PREFIX}Health"
 SCHTASKS_BIN="${PIPELINE_SCHTASKS:-schtasks}"
 CRONTAB_BIN="${PIPELINE_CRONTAB:-crontab}"
+
+# Cross-platform user-home resolution (HIMMEL-645, generalized from
+# HIMMEL-642's default_vault). On Windows Git-Bash $HOME can be the MSYS home
+# (/home/<user>) while Claude Code's config (~/.claude) and the luna vault live
+# under the Windows user profile, so prefer USERPROFILE via cygpath BEFORE
+# $HOME. POSIX hosts have USERPROFILE unset and fall straight through to $HOME,
+# unchanged. /tmp is the last-resort floor when both are unset.
+resolve_user_home() {
+    if [ -n "${USERPROFILE:-}" ] && command -v cygpath >/dev/null 2>&1; then
+        cygpath -u "$USERPROFILE" 2>/dev/null || printf '%s' "$USERPROFILE"
+    else
+        printf '%s' "${HOME:-${USERPROFILE:-/tmp}}"
+    fi
+}
+
 # Persistent runner home (.bat on Windows, .sh on POSIX) — NOT mktemp
 # like arm-resume's one-shot task: these tasks recur indefinitely, and
 # %TEMP% / /tmp are subject to cleanup sweeps that would silently kill
-# the cadence.
-BAT_DIR="${PIPELINE_BAT_DIR:-$HOME/.claude/pipeline-cadence}"
+# the cadence. Default home resolved cross-platform (HIMMEL-645): the bare
+# $HOME default put the runners under the MSYS home on Windows Git-Bash,
+# where Claude Code does not read its config.
+BAT_DIR="${PIPELINE_BAT_DIR:-$(resolve_user_home)/.claude/pipeline-cadence}"
 
 # HIMMEL-575: a `claude --settings` fragment that wires himmel's
 # auto-approve-safe-bash PreToolUse hook by ABSOLUTE path. The cadence fires in
@@ -110,24 +127,15 @@ HEALTH_TIME="04:00"
 # Default vault resolution (cross-platform; HIMMEL-642). Honors
 # LUNA_VAULT_PATH first — the vault path adopt.sh persists into
 # .claude/settings.json (HIMMEL-458) and himmel-doctor probes first — so an
-# adopted setup needs no --vault. Otherwise fall back to <home>/Documents/luna.
-# On Windows Git-Bash $HOME can be the MSYS home (/home/<user>) while the luna
-# vault lives under the Windows user profile, so resolve USERPROFILE via cygpath
-# BEFORE $HOME (the bare "$HOME/Documents/luna" default failed closed there).
-# POSIX hosts have USERPROFILE unset and fall straight through to $HOME,
-# unchanged. Explicit --vault always overrides (parsed below).
+# adopted setup needs no --vault. Otherwise fall back to <home>/Documents/luna
+# via the shared cross-platform home resolver (HIMMEL-645). Explicit --vault
+# always overrides (parsed below).
 default_vault() {
     if [ -n "${LUNA_VAULT_PATH:-}" ]; then
         printf '%s' "$LUNA_VAULT_PATH"
         return
     fi
-    local home
-    if [ -n "${USERPROFILE:-}" ] && command -v cygpath >/dev/null 2>&1; then
-        home="$(cygpath -u "$USERPROFILE" 2>/dev/null || printf '%s' "$USERPROFILE")"
-    else
-        home="${HOME:-${USERPROFILE:-/tmp}}"
-    fi
-    printf '%s/Documents/luna' "$home"
+    printf '%s/Documents/luna' "$(resolve_user_home)"
 }
 VAULT="$(default_vault)"
 FORCE=0

--- a/scripts/luna/test-pipeline-cadence.sh
+++ b/scripts/luna/test-pipeline-cadence.sh
@@ -179,7 +179,9 @@ assert_not_contains "xml_escape leaves no bare ampersand" "a & b" "$xesc"
 # hit (vault resolved to /home/<user>/Documents/luna, not the real profile).
 # ============================================================================
 echo "TEST: default_vault resolves the cross-platform default vault"
-DV_SRC="$(sed -n '/^default_vault()/,/^}/p' "$SCRIPT")"
+# default_vault delegates the home part to resolve_user_home (HIMMEL-645), so
+# extract BOTH functions for the standalone call.
+DV_SRC="$(sed -n '/^resolve_user_home()/,/^}/p' "$SCRIPT"; sed -n '/^default_vault()/,/^}/p' "$SCRIPT")"
 run_dv() { env "$@" bash -c "$DV_SRC"$'\n'"default_vault"; }
 
 # USERPROFILE set too, so this proves LUNA_VAULT_PATH wins even when the
@@ -219,6 +221,32 @@ if command -v cygpath >/dev/null 2>&1; then
     assert_not_contains "default_vault does NOT use the MSYS \$HOME on Windows" "/home/msysuser" "$dv_c"
 else
     echo "  SKIP: default_vault Windows-profile case (cygpath absent — POSIX host)"
+fi
+
+# ============================================================================
+# resolve_user_home unit (HIMMEL-645) — the shared home resolver that ALSO
+# backs the BAT_DIR default ($(resolve_user_home)/.claude/pipeline-cadence).
+# Pins the same cross-platform contract directly on the helper so a BAT_DIR
+# regression (runners landing under the MSYS home on Windows) is caught even
+# though BAT_DIR itself is computed at script load.
+# ============================================================================
+echo "TEST: resolve_user_home resolves the cross-platform user home"
+RUH_SRC="$(sed -n '/^resolve_user_home()/,/^}/p' "$SCRIPT")"
+run_ruh() { env "$@" bash -c "$RUH_SRC"$'\n'"resolve_user_home"; }
+
+ruh_posix=$(run_ruh -u USERPROFILE HOME="/posix/home")
+assert_contains "resolve_user_home POSIX shape is \$HOME" "/posix/home" "$ruh_posix"
+assert_not_contains "resolve_user_home returns home only (no Documents append)" "Documents" "$ruh_posix"
+
+ruh_floor=$(run_ruh -u USERPROFILE -u HOME)
+assert_contains "resolve_user_home floor is /tmp when HOME+USERPROFILE unset" "/tmp" "$ruh_floor"
+
+if command -v cygpath >/dev/null 2>&1; then
+    ruh_win=$(run_ruh USERPROFILE='C:\Users\testuser' HOME="/home/msysuser")
+    assert_contains "resolve_user_home prefers Windows profile over MSYS \$HOME" "$(cygpath -u 'C:\Users\testuser')" "$ruh_win"
+    assert_not_contains "resolve_user_home does NOT use the MSYS \$HOME on Windows" "/home/msysuser" "$ruh_win"
+else
+    echo "  SKIP: resolve_user_home Windows-profile case (cygpath absent — POSIX host)"
 fi
 
 # ============================================================================


### PR DESCRIPTION
BAT_DIR defaulted to "$HOME/.claude/pipeline-cadence" — the same MSYS-$HOME
trap as the --vault default. On Windows Git-Bash $HOME can be the MSYS home,
so a default-armed cadence wrote its runners under the MSYS tree instead of
the Windows profile where Claude Code reads its config. Extract a shared
resolve_user_home() helper (USERPROFILE via cygpath before $HOME) and use it
for both BAT_DIR and the vault default. PIPELINE_BAT_DIR override and explicit
--vault still honored; POSIX unchanged.

Platforms tested: windows
Security reviewed: manual
