### PR TITLE
feat(hooks): [HIMMEL-647] block raw scheduler-arms of claude that bypass arm-resume.sh

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -158,6 +158,15 @@
         ]
       },
       {
+        "matcher": "Bash|PowerShell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/scripts/hooks/block-rogue-claude-schedule.sh"
+          }
+        ]
+      },
+      {
         "matcher": "mcp__plugin_atlassian_atlassian__.*",
         "hooks": [
           {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,8 +223,10 @@ Autonomous end-to-end execution of a well-scoped ticket: see
 
 ## ENFORCEMENT (runs automatically)
 
-himmel enforces structurally, not by prose: **8 PreToolUse hooks**
+himmel enforces structurally, not by prose: **9 PreToolUse hooks**
 (`auto-approve-safe-bash`, `block-edit-on-main`, `block-read-secrets`,
+`block-rogue-claude-schedule` — blocks raw scheduler-arms of claude that bypass
+arm-resume.sh (System32-cwd trap, HIMMEL-647),
 `block-backend-tier` — registry-driven MCP guard, replaces `block-mcp-when-plugin-exists`,
 `auto-arm-on-cap`, `check-cr-marker-on-pr-create`, and `block-docker-privesc` —
 root-equivalent docker/podman mount+privilege guard, HIMMEL-441, shipped via the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,8 +185,10 @@ Autonomous end-to-end execution of a well-scoped ticket: see
 
 ## ENFORCEMENT (runs automatically)
 
-himmel enforces structurally, not by prose: **8 PreToolUse hooks**
+himmel enforces structurally, not by prose: **9 PreToolUse hooks**
 (`auto-approve-safe-bash`, `block-edit-on-main`, `block-read-secrets`,
+`block-rogue-claude-schedule` — blocks raw scheduler-arms of claude that bypass
+arm-resume.sh (System32-cwd trap, HIMMEL-647),
 `block-backend-tier` — registry-driven MCP guard, replaces `block-mcp-when-plugin-exists`,
 `auto-arm-on-cap`, `check-cr-marker-on-pr-create`, and `block-docker-privesc` —
 root-equivalent docker/podman mount+privilege guard, HIMMEL-441, shipped via the

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -106,9 +106,9 @@ the env var.
 
 ## Claude PreToolUse Hooks
 
-Six hooks wired in `.claude/settings.json` fire BEFORE Claude executes
-tool calls. Five BLOCK risky operations; one (`auto-approve-safe-bash`)
-GRANTS permission for safe ones so they don't hang. A seventh and eighth
+Seven hooks wired in `.claude/settings.json` fire BEFORE Claude executes
+tool calls. Six BLOCK risky operations; one (`auto-approve-safe-bash`)
+GRANTS permission for safe ones so they don't hang. An eighth and ninth
 block hook, `block-docker-privesc.sh` (HIMMEL-441) and
 `block-merged-pr-commit.sh` (HIMMEL-512), are shipped via the **himmel-ops
 plugin `hooks.json`** rather than `.claude/settings.json` (so they can be
@@ -211,6 +211,34 @@ print or grep the contents of a secret file (`.env`, `.env.*`,
 print file contents to stdout (`awk '{print}' .env`, `sed s/X/Y/ .env`).
 Prefer asking the operator to echo specific values via the `!` prefix
 instead of bypassing.
+
+### `block-rogue-claude-schedule.sh` — raw scheduler-arm guard (HIMMEL-647)
+
+Fires on Bash/PowerShell. Refuses a tool call that registers an OS scheduler
+job which launches claude **without** routing through the sanctioned arming
+tools (`arm-resume.sh`, `pipeline-cadence.sh`, `schedule-resume.sh`). Blocks
+when the command BOTH (a) registers a job — `schtasks /create`,
+`Register-ScheduledTask`/`Register-ScheduledJob`, a `crontab` write, or
+`at <timespec>` — AND (b)
+launches the claude executable (`claude.exe`/`.cmd`/`.ps1`, a `/claude` or
+`\claude` binary path, or a bare `claude "<prompt>"`). Bypass:
+`ROGUE_SCHEDULE_OK=1`.
+
+Why: a hand-rolled `schtasks /create … /tr <bat>` whose `.bat` is just
+`"claude.exe" "load <handover> …"` (no `cd /d`, no Start In) fires with the
+scheduler's default cwd `C:\Windows\System32`, so the relaunch runs OUTSIDE the
+repo — a stray `~/.claude/projects/C--Windows-System32` project gets registered,
+`block-edit-on-main` can't find `.git`, relative handover paths break, and the
+autonomous run is wasted. `arm-resume.sh` already emits the
+`cd /d "$RESUME_CWD" || exit /b 1` guard, pre-trusts the cwd (HIMMEL-386),
+dedups and self-cleans; this guard forces scheduled claude relaunches back
+through it.
+
+**Known limitation (accepted):** only catches a rogue arm that writes the
+launcher AND registers it in ONE tool call (the HIMMEL-647 incident shape). A
+split across two calls — write the `.bat` in call 1, `schtasks /create
+/tr that.bat` in call 2 — carries no `claude` token on the register call and
+is not caught. Targets the accidental shape, not a determined bypass.
 
 ### `block-docker-privesc.sh` — root-equivalent container guard (HIMMEL-441)
 

--- a/scripts/hooks/block-rogue-claude-schedule.sh
+++ b/scripts/hooks/block-rogue-claude-schedule.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash/PowerShell.
+#
+# Blocks a tool call that registers an OS scheduler job which launches claude
+# WITHOUT routing through the sanctioned arming tools — the exact shape that bit
+# us in HIMMEL-647: a session hand-rolled
+#     schtasks /create /tn HIMMEL-Arm-640-detector /tr <temp.bat> /sc ONCE ...
+# where the .bat was just `"claude.exe" "load <handover> overnight mode"` — no
+# `cd /d`, no Start In. schtasks fires a task with its DEFAULT cwd
+# `C:\Windows\System32`, so claude relaunched from System32: a stray
+# ~/.claude/projects/C--Windows-System32 project got registered, block-edit-on-
+# main couldn't find .git, and relative handover paths broke. Two autonomous
+# runs were wasted and had to be restarted by hand.
+#
+# The fix is to force scheduled claude relaunches back through the tools that
+# already do it right:
+#   - scripts/handover/arm-resume.sh   (emits `cd /d "$RESUME_CWD" || exit /b 1`,
+#                                       pre-trusts the cwd HIMMEL-386, dedups,
+#                                       names tasks HIMMEL-Resume-*, self-cleans)
+#   - scripts/luna/pipeline-cadence.sh (same cwd + trust handling for the
+#                                       recurring clip-pipeline cadence)
+#   - scripts/handover/schedule-resume.sh (prints the command for review)
+#
+# Detection model (single tool-call command text, case-insensitive):
+#   BLOCK when the command BOTH
+#     (a) registers a scheduler job — `schtasks /create`,
+#         `Register-ScheduledTask`/`Register-ScheduledJob`, a `crontab` write,
+#         or `at <time>`, AND
+#     (b) launches the claude EXECUTABLE (claude.exe/.cmd/.ps1, a `/claude`
+#         or `\claude` binary path, or a bare `claude "<prompt>"` at command
+#         position) — but NOT a mere `.claude/` directory reference,
+#   UNLESS the command routes through a sanctioned arming script (allow).
+#
+# Known limitation (consciously accepted — like block-read-secrets, this guard
+# targets the accidental shape, not a determined bypass): if the rogue arm is
+# SPLIT across two tool calls (write the .bat in call 1, `schtasks /create
+# /tr that.bat` in call 2), call 2 carries no `claude` token and is not caught.
+# The HIMMEL-647 incident did both in ONE PowerShell call, which IS caught.
+#
+# Hook input arrives on stdin as JSON. Exit codes:
+#   0 — allow (default)
+#   2 — block; stderr is shown to Claude and the user
+#
+# Bypass: set ROGUE_SCHEDULE_OK=1 in the shell that launched Claude Code
+# (Claude cannot inject env vars into hooks). Session-sticky; restart to
+# re-enable. Or comment the hook in .claude/settings.json.
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "block-rogue-claude-schedule: jq not on PATH — refusing to evaluate; install jq or comment the hook in .claude/settings.json" >&2
+    exit 2
+fi
+
+input=$(cat)
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)
+
+case "$tool" in
+    Bash|PowerShell) ;;
+    *) exit 0 ;;
+esac
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+[ -z "$cmd" ] && exit 0
+
+# Lower-case once so every match below is plain (case-insensitive) without
+# per-grep -i. All tokens we match (schtasks, register-scheduledtask, crontab,
+# at, claude.exe, arm-resume.sh) are ASCII. ALSO flatten newlines/CRs to spaces:
+# grep is line-oriented, so on a multi-line command an `^`-anchored arm (the `at`
+# command-position check) would match the start of ANY line — a benign multi-line
+# `git commit -m "...claude...<newline>at 0430..."` would false-block. Flattening
+# makes `^`/`$` mean true start/end of the whole command and keeps unrelated
+# tokens on different lines from jointly tripping the AND-gate.
+cmd_lc=$(printf '%s' "$cmd" | tr '[:upper:]' '[:lower:]' | tr '\n\r' '  ')
+
+# Allow short-circuit: the command routes through a sanctioned arming tool,
+# which already handles cwd + workspace-trust + dedup. (arm-resume.sh runs its
+# OWN schtasks/at/crontab in a CHILD process the hook never sees, so this only
+# guards against a future caller that mentions both in one tool command.)
+if printf '%s' "$cmd_lc" | grep -qE 'arm-resume\.sh|pipeline-cadence\.sh|schedule-resume\.sh'; then
+    exit 0
+fi
+
+# (a) Does the command register a scheduler job?
+is_scheduler_create() {
+    local c="$1"
+    # schtasks /create — both tokens present (order-independent in the command).
+    if printf '%s' "$c" | grep -q 'schtasks' && printf '%s' "$c" | grep -q '/create'; then
+        return 0
+    fi
+    if printf '%s' "$c" | grep -qE 'register-scheduled(task|job)'; then return 0; fi
+    # crontab as a command (write or install); `crontab -l` reads — harmless
+    # here because (b) launches_claude won't be true for a pure read.
+    if printf '%s' "$c" | grep -qE '(^|[[:space:];|&(])crontab([[:space:]]|$)'; then return 0; fi
+    # POSIX `at <timespec>` / `at -t|-f|...`. The `at` must sit at a command
+    # position (line start or right after a ; & | ( separator, modulo spaces) so
+    # prose like `git commit -m "... claude at 0430"` — where `at` follows a word
+    # — is not mistaken for the scheduler.
+    if printf '%s' "$c" | grep -qE '([;&|(]|^)[[:space:]]*at[[:space:]]+(-[a-z]|now|noon|midnight|[0-9])'; then return 0; fi
+    return 1
+}
+
+# (b) Does the command launch the claude EXECUTABLE (not just a .claude/ path)?
+launches_claude() {
+    local c="$1"
+    # claude.exe / claude.cmd / claude.ps1
+    if printf '%s' "$c" | grep -qE 'claude\.(exe|cmd|ps1)'; then return 0; fi
+    # a /claude or \claude binary PATH — the slash/backslash must sit IMMEDIATELY
+    # before `claude`, so `~/.claude/...` (a `.` precedes claude) never matches.
+    if printf '%s' "$c" | grep -qE '[/\]claude([[:space:]"'\''`]|$)'; then return 0; fi
+    # a bare `claude "<prompt>"` at a command position OR right after a quote
+    # (e.g. a schtasks /tr "claude ..." value).
+    if printf '%s' "$c" | grep -qE '(^|[[:space:];|&("'\''])claude[[:space:]"'\'']'; then return 0; fi
+    return 1
+}
+
+if is_scheduler_create "$cmd_lc" && launches_claude "$cmd_lc"; then
+    [ "${ROGUE_SCHEDULE_OK:-0}" = "1" ] && exit 0
+    {
+        echo "⛔ block-rogue-claude-schedule: refusing a raw scheduler-arm of claude."
+        echo "    A hand-rolled schtasks/crontab/at job that launches claude fires with"
+        echo "    its DEFAULT cwd (C:\\Windows\\System32 on Windows), so the relaunch runs"
+        echo "    OUTSIDE the repo — wasting the run and registering a stray System32"
+        echo "    project (HIMMEL-647)."
+        echo ""
+        echo "    Use the sanctioned tool, which sets cwd, pre-trusts it, dedups and"
+        echo "    self-cleans:"
+        echo "        bash scripts/handover/arm-resume.sh --time <HH:MM|smart|auto> \\"
+        echo "             --handover <path> [--worktree <type/slug>]"
+        echo "    or, for the recurring clip-pipeline cadence:"
+        echo "        bash scripts/luna/pipeline-cadence.sh arm"
+        echo ""
+        echo "    To bypass intentionally, set ROGUE_SCHEDULE_OK=1 in the shell that"
+        echo "    launched Claude Code (env vars can't be injected per-call):"
+        echo "        ROGUE_SCHEDULE_OK=1 claude"
+        echo "    Session-sticky. Restart without it to re-enable the guard."
+    } >&2
+    exit 2
+fi
+
+exit 0

--- a/scripts/hooks/test-block-rogue-claude-schedule.sh
+++ b/scripts/hooks/test-block-rogue-claude-schedule.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/hooks/block-rogue-claude-schedule.sh (HIMMEL-647).
+#
+# Usage: bash scripts/hooks/test-block-rogue-claude-schedule.sh
+#
+# Exit codes:
+#   0 — all cases passed
+#   1 — at least one case failed
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/block-rogue-claude-schedule.sh"
+[ -x "$HOOK" ] || chmod +x "$HOOK"
+
+FAILED=0
+
+run_case() {
+    local input="$1"
+    local env_assign="${2:-}"
+    if [ -n "$env_assign" ]; then
+        printf '%s' "$input" | env "$env_assign" bash "$HOOK" >/dev/null 2>&1
+    else
+        printf '%s' "$input" | bash "$HOOK" >/dev/null 2>&1
+    fi
+    echo "$?"
+}
+
+assert_rc() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS $label (rc=$actual)"
+    else
+        echo "FAIL $label — expected rc=$expected, got rc=$actual"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+j_bash()  { printf '{"tool_name":"Bash","tool_input":{"command":%s}}'  "$(printf '%s' "$1" | jq -Rs .)"; }
+j_pwsh()  { printf '{"tool_name":"PowerShell","tool_input":{"command":%s}}' "$(printf '%s' "$1" | jq -Rs .)"; }
+
+# The actual HIMMEL-647 incident: a single PowerShell call that wrote a claude
+# launcher .bat AND registered it with schtasks /create — no cd, fires from
+# System32. (Literal PowerShell text — the $claude is intentionally unexpanded.)
+# shellcheck disable=SC2016
+INCIDENT='$claude = "C:\Users\yotam\.local\bin\claude.exe"
+Set-Content -Path $bat640 -Value "`"$claude`" `"load /c/.../next-session.md overnight mode`"" -Encoding ASCII
+schtasks /create /tn "HIMMEL-Arm-640-detector" /tr "$bat640" /sc ONCE /st 04:30 /f'
+
+# --- BLOCK cases (expect rc=2) ---
+assert_rc "HIMMEL-647 incident (PowerShell)"      2 "$(run_case "$(j_pwsh "$INCIDENT")")"
+assert_rc "schtasks /create /tr claude.exe"       2 "$(run_case "$(j_bash 'schtasks /create /tn X /tr "C:\\Users\\u\\.local\\bin\\claude.exe load h" /sc ONCE /st 04:30 /f')")"
+assert_rc "schtasks /create bareword claude"      2 "$(run_case "$(j_bash 'schtasks /create /tn X /tr "claude \"load h\"" /sc ONCE /st 09:00 /f')")"
+assert_rc "Register-ScheduledTask claude.exe"     2 "$(run_case "$(j_pwsh 'Register-ScheduledTask -TaskName X -Action (New-ScheduledTaskAction -Execute "claude.exe" -Argument "load h")')")"
+assert_rc "Register-ScheduledJob claude.exe"      2 "$(run_case "$(j_pwsh 'Register-ScheduledJob -Name X -ScriptBlock { claude.exe "load h" }')")"
+assert_rc "schtasks /create /tr claude.cmd"       2 "$(run_case "$(j_bash 'schtasks /create /tn X /tr "C:\\Users\\u\\.local\\bin\\claude.cmd load h" /sc ONCE /st 09:00 /f')")"
+assert_rc "crontab install claude"                2 "$(run_case "$(j_bash 'echo "30 4 * * * /home/u/.local/bin/claude \"load h\"" | crontab -')")"
+assert_rc "at now claude"                         2 "$(run_case "$(j_bash 'echo "claude \"load h\"" | at now + 1 hour')")"
+
+# --- ALLOW cases (expect rc=0) ---
+assert_rc "sanctioned arm-resume.sh"              0 "$(run_case "$(j_bash 'bash scripts/handover/arm-resume.sh --time 04:30 --handover /c/h/next-session.md')")"
+assert_rc "sanctioned pipeline-cadence arm"       0 "$(run_case "$(j_bash 'bash scripts/luna/pipeline-cadence.sh arm --harvest-time 02:00')")"
+assert_rc "schtasks /query (read, no create)"     0 "$(run_case "$(j_bash 'schtasks /query /tn HIMMEL-Pipeline-Harvest /fo LIST')")"
+assert_rc "schtasks /create non-claude task"      0 "$(run_case "$(j_bash 'schtasks /create /tn Backup /tr "robocopy C:\\a C:\\b" /sc DAILY /st 01:00 /f')")"
+assert_rc "crontab -l (read)"                     0 "$(run_case "$(j_bash 'crontab -l')")"
+assert_rc "plain claude launch (not scheduled)"   0 "$(run_case "$(j_bash 'claude "do a thing"')")"
+assert_rc "cat ~/.claude/settings.json"           0 "$(run_case "$(j_bash 'cat ~/.claude/settings.json')")"
+assert_rc "git commit msg mentioning claude+at"   0 "$(run_case "$(j_bash 'git commit -m "fire claude at 0430"')")"
+# Multi-line prose must NOT false-block: grep is line-oriented, so an `at 0430`
+# at the START of a body line + `claude` on another line previously tripped the
+# `^`-anchored at-arm. cmd_lc flattens newlines so `^` means true start-of-cmd.
+assert_rc "multi-line commit claude+at (prose)"   0 "$(run_case "$(j_bash "$(printf 'git commit -m "fix claude bug\nat 0430 it still failed"')")")"
+# scheduler-create whose only claude token is a .claude/ DIRECTORY (a backup
+# task), not the executable → ALLOW (predicate (b) discriminates exe vs dir).
+assert_rc "schtasks /create backup of .claude"    0 "$(run_case "$(j_bash 'schtasks /create /tn Backup /tr "robocopy C:\\Users\\u\\.claude C:\\backup" /sc DAILY /st 01:00 /f')")"
+assert_rc "sanctioned schedule-resume.sh"         0 "$(run_case "$(j_bash 'bash scripts/handover/schedule-resume.sh --time 04:30 --handover /c/h.md')")"
+assert_rc "non-Bash/PS tool ignored"              0 "$(run_case '{"tool_name":"Read","tool_input":{"file_path":"x"}}')"
+
+# --- Escape hatch (expect rc=0 even on an otherwise-blocked command) ---
+assert_rc "incident + ROGUE_SCHEDULE_OK=1"        0 "$(run_case "$(j_pwsh "$INCIDENT")" "ROGUE_SCHEDULE_OK=1")"
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "FAILED: $FAILED case(s)"
+    exit 1
+fi
+echo "All block-rogue-claude-schedule cases passed."
+exit 0


### PR DESCRIPTION
New PreToolUse hook `block-rogue-claude-schedule.sh` (matcher `Bash|PowerShell`)
hard-blocks a scheduler-registration (`schtasks /create`,
`Register-ScheduledTask`/`Register-ScheduledJob`, a `crontab` write, or `at <time>`)
that launches the claude executable, unless it routes through the sanctioned
arming tools (`arm-resume.sh` / `pipeline-cadence.sh` / `schedule-resume.sh`),
which set the working directory, pre-trust it, dedup and self-clean. Without this,
a hand-rolled scheduler arm fires claude from its default cwd `C:\Windows\System32`
and the relaunch runs outside the repo.

Escape hatch: `ROGUE_SCHEDULE_OK=1` (launching-shell env var). Fail-closed on
missing `jq`. 21-case smoke test; wired in `.claude/settings.json`; documented in
`docs/internals/enforcement.md`.

Known limitation (accepted): only catches a rogue arm that writes the launcher
and registers it in one tool call; a split across two calls is not caught.