### PR TITLE
chore(hooks): [HIMMEL-648] sync public settings.json hook wiring to private parity

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -171,7 +171,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash $CLAUDE_PROJECT_DIR/scripts/hooks/block-mcp-when-plugin-exists.sh"
+            "command": "bash $CLAUDE_PROJECT_DIR/scripts/hooks/block-backend-tier.sh"
           }
         ]
       },
@@ -202,6 +202,22 @@
           {
             "type": "command",
             "command": "bash $CLAUDE_PROJECT_DIR/scripts/hooks/improve-on-submit.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/scripts/hooks/check-update-available.sh",
+            "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/scripts/hooks/inject-initiative.sh",
+            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
Public `.claude/settings.json` had drifted behind private on three hook wirings.
The hook scripts were all already present in the public repo — this is a
wiring-only sync so the next `git pull` connects them.

- `block-mcp-when-plugin-exists.sh` → **`block-backend-tier.sh`** — public was
  running the superseded MCP-routing guard; CLAUDE.md already documents the
  registry-driven replacement.
- **SessionStart** → `check-update-available.sh` (update-available nudge).
- **SessionStart** → `inject-initiative.sh` (opt-in `HIMMEL_INITIATIVE`,
  default-OFF, no operator-personal data; already documented in public CLAUDE.md).

`settings.json` is now byte-identical to the private tree. Verified no other
settings/permissions/env drift, and the himmel-ops plugin `hooks.json` was
already in parity.