### PR TITLE
feat: [HIMMEL-640] propagation-drift detector — public-facing C10 doctor + seed wiring

### DIFF
--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -259,7 +259,10 @@ single-writer luna vault, C4 Bitbucket-remote-where-`gh`-fails, C5 repo not in t
 handover registry, C6 PATH-fragile bare-interpreter MCP servers (uvx/bun — same
 GUI-launch failure class as the node hook), C7 lingering merged-PR worktrees, C8
 stale pipeline-cadence runners, C9 auto-arm scheduler backend (HIMMEL-594 — reads
-`scripts/lib/scheduler-backend.sh`; never sudos). Prints a severity-grouped report (FAIL/WARN/INFO); `--file-issue
+`scripts/lib/scheduler-backend.sh`; never sudos), C10 private→public propagation
+drift (HIMMEL-640 — read-only advisory; surfaces MISSING/DRIFT/REVERSE-LEAK
+between the private mirror and the public clone; skips cleanly on adopter clones).
+Prints a severity-grouped report (FAIL/WARN/INFO); `--file-issue
 [--repo owner/name]` files ONE deduped consolidated public GitHub issue (resolves
 the repo from `--repo` → `$HIMMEL_DOCTOR_ISSUE_REPO` → github origin). Exit 1 on any
 FAIL. Tests: `scripts/test-himmel-doctor.sh`, `scripts/lib/test-{resolve,run,wire-caveman}-node.sh`.

--- a/marketplace/plugins/himmel-ops/commands/himmel-doctor.md
+++ b/marketplace/plugins/himmel-ops/commands/himmel-doctor.md
@@ -25,6 +25,19 @@ was never pruned).  C7 only emits findings and points to `/clean` (which dry-run
 first); it never deletes or modifies anything.  On forge outage (rc 2) it emits a
 single INFO "skipped" rather than a false WARN.
 
+It also runs a **private→public propagation-drift check** (C10, read-only) — for
+the maintainer's private mirror it compares the private repo against the public
+clone by git blob SHA and surfaces what never propagated: MISSING (public-eligible
+files absent from public), DRIFT (present-but-stale), and REVERSE-LEAK (a path present
+in public but absent from private — typically a leaked `PRIVATE_PATHS` file). It folds
+out the deliberate divergence axes — slug/clone-dir casing + the genericization map,
+plus the public-maintained files (LICENSE/README/.github) excluded on both sides — so
+genuine gaps stand out, and tags genericization-sensitive files `*-needs-review`. C10
+is advisory only (never `--fix`, never propagates) and points at `propagate-public.sh`;
+on a public/adopter clone the private tooling is absent so it prints `skipped` and stays
+OK. A WARN ("stale/unreadable refs") means the compare couldn't fetch fresh `origin/main`
+— a 0-finding result there is not a clean bill of health.
+
 It is read-only EXCEPT `--fix`, which heals the C1 node wiring by rewriting the
 caveman hooks in the **user-scope** `~/.claude/settings.json` (outside any repo —
 the on-main / repo-settings self-mod guards do not apply) to route through the

--- a/scripts/himmel-doctor.sh
+++ b/scripts/himmel-doctor.sh
@@ -362,6 +362,58 @@ check_c9() {
     esac
 }
 
+# --- C10: private→public propagation drift (read-only advisory) -----------------
+# Sources the drift detector (Component A) and surfaces MISSING/DRIFT/REVERSE-LEAK
+# between the private mirror and the public clone. Private-only tooling: on a
+# public/adopter clone propagate-public.sh + propagation-drift.sh are absent →
+# skipped, OK. NON-fatal (WARN never FAILs), no --fix — like C7. The detector's
+# own cwd/clone/fetch guards make a non-private or clone-less run skip cleanly.
+check_c10() {
+    local drift_lib="$REPO_ROOT/scripts/lib/propagation-drift.sh"
+    if [ ! -f "$REPO_ROOT/scripts/propagate-public.sh" ] || [ ! -f "$drift_lib" ]; then
+        emit OK C10-propagation "skipped (no private mirror tooling)"
+        return
+    fi
+    # shellcheck source=scripts/lib/public-clone-paths.sh
+    # shellcheck disable=SC1091
+    . "$REPO_ROOT/scripts/lib/public-clone-paths.sh"
+    # shellcheck source=scripts/lib/propagation-drift.sh
+    # shellcheck disable=SC1091
+    . "$drift_lib"
+    local out; out="$(propagation_drift 2>/dev/null)"
+    case "$out" in
+        *"propagation-drift: skipped"*)
+            emit OK C10-propagation "$(printf '%s\n' "$out" | sed -n 's/^propagation-drift: //p' | head -1)"
+            return ;;
+    esac
+    local total; total="$(printf '%s\n' "$out" | grep -c '^DRIFT-BUCKET ' || true)"
+    # A WARN line (fetch failed → stale/local refs, or unreadable/empty origin/main)
+    # means the comparison did NOT run against fresh trees — a "0 buckets" result
+    # there is NOT a clean bill of health, so surface it as WARN, never OK.
+    local warned; warned="$(printf '%s\n' "$out" | grep -c '^propagation-drift: WARN' || true)"
+    if [ "${total:-0}" -eq 0 ] && [ "${warned:-0}" -gt 0 ]; then
+        emit WARN C10-propagation \
+            "drift comparison ran against stale/unreadable refs — cannot assert clean" \
+            "re-run with network access (fetch origin/main on both private + public clone)"
+        printf '%s\n' "$out" | grep '^propagation-drift: WARN' | sed 's/^propagation-drift: /       /'
+        return
+    fi
+    if [ "${total:-0}" -eq 0 ]; then
+        emit OK C10-propagation "no private→public propagation drift"
+        return
+    fi
+    emit WARN C10-propagation \
+        "$total private→public propagation-drift finding(s) — public mirror behind/diverged" \
+        "review + propagate: scripts/propagate-public.sh prep/new (genericize MISSING-needs-review by hand)"
+    # Surface any fetch/unreadable WARN too — if drift was found AGAINST stale refs
+    # the counts may be inaccurate, and the operator must know the compare wasn't fresh.
+    printf '%s\n' "$out" | grep '^propagation-drift: WARN' | sed 's/^propagation-drift: /       /'
+    # One-screen breakdown: per-bucket counts + up to 5 example paths.
+    printf '%s\n' "$out" | sed -n '/propagation-drift summary/,$p' | grep -v 'summary (private' | sed 's/^/       /'
+    printf '       examples:\n'
+    printf '%s\n' "$out" | grep '^DRIFT-BUCKET ' | head -5 | sed 's/^DRIFT-BUCKET /       · /'
+}
+
 # --- issue filing ---------------------------------------------------------------
 resolve_issue_repo() {
     [ -n "$REPO_FLAG" ] && { printf '%s\n' "$REPO_FLAG"; return 0; }
@@ -411,6 +463,7 @@ check_c6
 check_c7
 check_c8
 check_c9
+check_c10
 echo
 printf 'Summary: %s%d FAIL%s  %s%d WARN%s  %s%d INFO%s\n' "$C_RED" "$n_fail" "$C_0" "$C_YEL" "$n_warn" "$C_0" "$C_DIM" "$n_info" "$C_0"
 

--- a/scripts/machine-setup/macos.sh
+++ b/scripts/machine-setup/macos.sh
@@ -23,7 +23,7 @@ HIMMEL_PATH="${HIMMEL_PATH:-$(cd "$(dirname "$0")/../.." && pwd)}"
 CLAUDE_DIR="${CLAUDE_DIR:-$HOME/.claude}"
 SETTINGS="$CLAUDE_DIR/settings.json"
 
-TOTAL_STEPS=4
+TOTAL_STEPS=5
 STEP=0
 FAILURES=()
 step() {
@@ -88,6 +88,14 @@ step "Report scheduler-backend status"
     echo "  scheduler backend status: $(scheduler_backend_status) ($(scheduler_backend_os))"
   fi
 } || fail_nonfatal "report scheduler-backend status"
+
+step "Seed operator leak denylist (private tooling — skipped if absent)"
+{
+  # Private-only helper (in PRIVATE_PATHS): present on the operator's mirror,
+  # absent on adopter clones → guarded skip. Idempotent.
+  SEEDER="$HIMMEL_PATH/scripts/lib/seed-leak-denylist.sh"
+  if [ -f "$SEEDER" ]; then bash "$SEEDER"; else echo "  skipped: $SEEDER not present (public/adopter clone)"; fi
+} || fail_nonfatal "seed leak denylist"
 
 echo ""
 echo "════════════════════════════════════════"

--- a/scripts/machine-setup/ubuntu.sh
+++ b/scripts/machine-setup/ubuntu.sh
@@ -30,7 +30,7 @@ mkdir -p "$HOME/.local/bin"
 export PATH="$HOME/.local/bin:$PATH"
 
 # ── Progress ────────────────────────────────────────────────────────────────
-TOTAL_STEPS=19
+TOTAL_STEPS=20
 STEP=0
 FAILURES=()
 
@@ -558,6 +558,18 @@ step "Swap rtk hook for rtk-hook-guard wrapper (HIMMEL-241)"
     fi
   fi
 } || fail_nonfatal "swap rtk hook for guard"
+
+step "Seed operator leak denylist (private tooling — skipped if absent)"
+{
+  # Private-only helper (in PRIVATE_PATHS): present on the operator's mirror,
+  # absent on adopter clones → guarded skip. Idempotent.
+  SEEDER="$HIMMEL_PATH/scripts/lib/seed-leak-denylist.sh"
+  if [[ -f "$SEEDER" ]]; then
+    bash "$SEEDER"
+  else
+    echo "  skipped: $SEEDER not present (public/adopter clone)"
+  fi
+} || fail_nonfatal "seed leak denylist"
 
 step "Install Obsidian + open vault"
 {

--- a/scripts/machine-setup/win11.ps1
+++ b/scripts/machine-setup/win11.ps1
@@ -13,7 +13,7 @@ $ClaudeDir      = "$env:USERPROFILE\.claude"
 $RepoRoot       = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 
 # ── Progress ────────────────────────────────────────────────────────────────
-$TotalSteps = 18
+$TotalSteps = 19
 $Script:Step = 0
 $Script:Failures = @()
 
@@ -619,6 +619,22 @@ Invoke-NonFatal "swap rtk hook for guard" {
 
     Write-SettingsJson $SettingsFile $settings
     Write-Host "  Swapped $swapped 'rtk hook claude' entry(s) -> bash $GuardPath"
+}
+
+Write-Step "Seed operator leak denylist (private tooling — skipped if absent)"
+Invoke-NonFatal "seed leak denylist" {
+    # Single bash helper (no PS twin → no lockstep drift); run via Git Bash so it
+    # writes to the SAME ~/.claude path the bash leak-scan reads. Private-only (in
+    # PRIVATE_PATHS): present on the operator mirror, absent on adopter clones →
+    # guarded skip. Idempotent.
+    $GitBash = "C:\Program Files\Git\bin\bash.exe"
+    $SeederWin = "$HimmelPath\scripts\lib\seed-leak-denylist.sh"
+    if (Test-Path $SeederWin) {
+        $SeederUnix = $SeederWin.Replace('\', '/')
+        & $GitBash -c "bash '$SeederUnix'"
+    } else {
+        Write-Host "  skipped: $SeederWin not present (public/adopter clone)"
+    }
 }
 
 Write-Step "Install Obsidian + open vault"

--- a/scripts/test-himmel-doctor.sh
+++ b/scripts/test-himmel-doctor.sh
@@ -385,6 +385,50 @@ if printf '%s' "$out" | grep -q 'WARN C9-scheduler'; then pass "C9 macos warn"; 
 if printf '%s' "$out" | grep -q 'apt install'; then fail "C9 macos wrongly suggests apt"; else pass "C9 macos no apt advice"; fi
 rm -rf "$t"
 
+# ── C10: private→public propagation drift (HIMMEL-640) ────────────────────────
+# mk10 <seed> <bare> <clone> — commit seed contents on main, bare-clone, work-clone.
+mk10() {
+    git -C "$1" init -q; git -C "$1" config user.email t@t; git -C "$1" config user.name t
+    git -C "$1" config core.autocrlf false
+    git -C "$1" add -A; git -C "$1" commit -qm x; git -C "$1" branch -M main
+    git clone -q --bare "$1" "$2"; git clone -q "$2" "$3"
+}
+
+echo "== C10: no public clone -> OK C10-propagation (skip-clean) =="
+t="$(mktemp -d)"; mkdir -p "$t/claude"; write_settings "$t/claude" "$WRAPPER"
+out="$(HIMMEL_PUBLIC_CLONE="$t/none" DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" \
+    CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"; rc=$?
+if printf '%s' "$out" | grep -q 'OK   C10-propagation' && [ "$rc" -eq 0 ]; then pass "C10 -> OK (skip, no clone)"; else fail "C10 -> rc=$rc; $(printf '%s' "$out" | grep C10)"; fi
+rm -rf "$t"
+
+echo "== C10: seeded drift fixture -> WARN C10-propagation =="
+t="$(mktemp -d)"; mkdir -p "$t/claude"; write_settings "$t/claude" "$WRAPPER"
+ps="$t/ps"; mkdir -p "$ps/scripts"; printf 'stub\n' > "$ps/scripts/propagate-public.sh"; printf 'new doc\n' > "$ps/onlypriv.md"
+us="$t/us"; mkdir -p "$us"; printf 'base\n' > "$us/base.md"
+mk10 "$ps" "$t/ps.git" "$t/pc"
+mk10 "$us" "$t/us.git" "$t/uc"
+out="$(HIMMEL_PRIV_ROOT="$t/pc" HIMMEL_PUBLIC_CLONE="$t/uc" HIMMEL_PUBLIC_REMOTE="us.git" \
+    DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" \
+    bash "$DOC" --no-color 2>&1)"
+if printf '%s' "$out" | grep -q 'WARN C10-propagation' && printf '%s' "$out" | grep -q 'onlypriv.md'; then pass "C10 -> WARN (seeded drift, MISSING flagged)"; else fail "C10 -> $(printf '%s' "$out" | grep -A6 C10)"; fi
+rm -rf "$t"
+
+echo "== C10: unreadable origin/main -> WARN (stale/unreadable refs, not false-clean) =="
+t="$(mktemp -d)"; mkdir -p "$t/claude"; write_settings "$t/claude" "$WRAPPER"
+# priv has the marker but its default branch is NOT 'main' -> ls-tree origin/main
+# is empty -> detector WARNs -> C10 must surface WARN, never OK "no drift".
+ps="$t/ps"; mkdir -p "$ps/scripts"; printf 'stub\n' > "$ps/scripts/propagate-public.sh"
+git -C "$ps" init -q; git -C "$ps" config user.email t@t; git -C "$ps" config user.name t
+git -C "$ps" config core.autocrlf false
+git -C "$ps" add -A; git -C "$ps" commit -qm x; git -C "$ps" branch -M notmain
+us="$t/us"; mkdir -p "$us"; printf 'base\n' > "$us/base.md"
+mk10 "$us" "$t/us.git" "$t/uc"
+out="$(HIMMEL_PRIV_ROOT="$ps" HIMMEL_PUBLIC_CLONE="$t/uc" HIMMEL_PUBLIC_REMOTE="us.git" \
+    DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" \
+    bash "$DOC" --no-color 2>&1)"
+if printf '%s' "$out" | grep -q 'WARN C10-propagation' && ! printf '%s' "$out" | grep -q 'OK   C10-propagation'; then pass "C10 -> WARN (unreadable refs, not false-clean)"; else fail "C10 unreadable -> $(printf '%s' "$out" | grep -A4 C10)"; fi
+rm -rf "$t"
+
 rm -rf "$FAKEROOT"
 echo
 if [ "$failures" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$failures FAILURE(S)"; exit 1; fi


### PR DESCRIPTION
Code-only public propagation of HIMMEL-640. The C10 himmel-doctor check + machine-setup leak-denylist seed wiring (ubuntu/macos/win11) degrade gracefully on adopter clones; the token-bearing detector libs stay private by design (PRIVATE_PATHS).