### PR TITLE
fix(codex): [HIMMEL-565] PostToolUse exit-2 -> additionalContext

### DIFF
--- a/.codex/codex-hook-adapter.sh
+++ b/.codex/codex-hook-adapter.sh
@@ -37,6 +37,34 @@ emit_deny() {
   exit 0
 }
 
+# emit_context <reason> <event> — print Codex's non-blocking additionalContext
+# JSON on stdout and exit 0 (HIMMEL-565). Used for guardrail exit 2 on lifecycle
+# events that have NO permission gate (PostToolUse, SessionStart, UserPromptSubmit).
+# Their `*.command.output` schema (openai/codex generated schemas) carries
+# `hookSpecificOutput.additionalContext` — appended to the model's context — not a
+# permissionDecision. (The fixture proves the adapter emits this shape; a live
+# Codex runtime probe of the auto-arm path is still pending — see harness-compat.md.)
+# A PostToolUse auto-arm (auto-arm-on-subagent-cap.sh) exits 2 AFTER its side
+# effects ran, so the message belongs in additionalContext — emitting a PreToolUse
+# deny here is the wrong lifecycle event AND a bogus permission gate for a tool
+# that already ran.
+emit_context() {
+  local r="$1" ev="$2"
+  # Normalise to a known additionalContext-carrying event; default to PostToolUse
+  # (the only non-permission event himmel wires a blocking/exit-2 guardrail on —
+  # the SessionStart/UserPromptSubmit hooks in .codex/hooks.json are advisory). An
+  # unrecognised inbound event would otherwise yield an invalid `hookEventName`
+  # const that Codex's strict parser rejects, dropping the message.
+  case "$ev" in PostToolUse|SessionStart|UserPromptSubmit) ;; *) ev="PostToolUse" ;; esac
+  # No jq-less fallback: reaching here means the exit-2 dispatcher already parsed
+  # the inbound event with jq, so jq is present (a jq-less run resolves ev to
+  # PreToolUse → emit_deny, never here). emit_deny keeps its fallback because its
+  # precondition callers run before any jq use.
+  jq -cn --arg ev "$ev" --arg r "$r" \
+    '{hookSpecificOutput:{hookEventName:$ev,additionalContext:$r}}'
+  exit 0
+}
+
 name="${1:-}"
 [ -n "$name" ] || emit_deny "codex-hook-adapter: missing script name — fail closed"
 # run-hook.cmd's cmd.exe branch exports CLAUDE_PROJECT_DIR with backslashes;
@@ -67,9 +95,18 @@ reason="${captured%EXIT:*}"
 reason="${reason%$'\n'}"; reason="${reason%$'\r'}"   # drop the guardrail's trailing CR/LF
 
 if [ "$code" = "2" ]; then
-  # Block: translate to Codex's JSON deny. hookEventName mirrors the inbound event.
   ev="$(printf '%s' "$input" | jq -r '.hook_event_name // "PreToolUse"' 2>/dev/null || echo PreToolUse)"
-  emit_deny "$reason" "$ev"
+  case "$ev" in
+    PreToolUse|PermissionRequest)
+      # Block: translate to Codex's JSON deny. hookEventName mirrors the inbound event.
+      emit_deny "$reason" "$ev"
+      ;;
+    *)
+      # Non-permission lifecycle event (PostToolUse, SessionStart, UserPromptSubmit):
+      # surface the guardrail's message as additionalContext, never a permission deny.
+      emit_context "$reason" "$ev"
+      ;;
+  esac
 fi
 
 # Non-block: surface the guardrail's stderr (advisory) and propagate its code.

--- a/docs/internals/harness-compat.md
+++ b/docs/internals/harness-compat.md
@@ -107,16 +107,35 @@ with Codex deny JSON if Git Bash is present but unusable in the hook sandbox. Th
 wrapper delegates to `.codex/codex-hook-adapter.sh`, which runs the guardrail and,
 for PreToolUse/PermissionRequest exit 2, re-emits the block as Codex's JSON
 `permissionDecision:"deny"` (the guardrail's stderr → reason) and exits 0.
-Non-exit-2 outcomes pass through. For other events, exit 2 currently falls back
-to a bogus PreToolUse deny. PostToolUse auto-arm uses exit 2 after arming, so
-that event remains an explicit adapter follow-up. The
-guardrails stay single-sourced — they keep working verbatim under Claude Code,
-which never invokes the adapter (only `.codex/hooks.json` does). Verified live
-against codex-cli 0.141.0: a secret read (`block-read-secrets`) is **Blocked**;
-a benign command is allowed. Unit-tested both polyglot branches, exit-2→deny
-translation, explicit sandbox/no-sandbox mode parsing, and Windows
+Non-exit-2 outcomes pass through.
+
+**Lifecycle exit-2 contract (HIMMEL-565).** Exit 2 on a **non-permission**
+lifecycle event (PostToolUse, SessionStart, UserPromptSubmit) does NOT translate
+to a permission deny — those events have no permission gate, and their
+`*.command.output` schema (per the openai/codex *generated* schemas) carries
+`hookSpecificOutput.additionalContext` (which Codex appends to the model's
+context), not a `permissionDecision`. **Verification scope:** the schema shape is
+confirmed against those generated schemas and the fixture proves the *adapter*
+emits it; a live Codex runtime probe of the auto-arm path (does Codex honour
+additionalContext on PostToolUse end-to-end) is still pending. The adapter's
+`emit_context` re-emits such an exit 2 as `additionalContext` with the inbound
+`hookEventName` (unrecognised events normalise to PostToolUse so the
+`hookEventName` const stays valid), exit 0. This is what
+`auto-arm-on-subagent-cap.sh` (the lone PostToolUse guardrail) needs: it arms a resume + writes a snapshot during
+execution, then exits 2 only to feed its "write a handover now" message to the
+model — previously the adapter mistranslated that to a **bogus PreToolUse deny**
+(wrong event, and a permission gate for a tool that already ran).
+
+The guardrails stay single-sourced — they keep working verbatim under Claude
+Code, which never invokes the adapter (only `.codex/hooks.json` does). Verified
+live against codex-cli 0.141.0: a secret read (`block-read-secrets`) is
+**Blocked**; a benign command is allowed. Unit-tested both polyglot branches,
+exit-2→deny translation, **exit-2→additionalContext for PostToolUse/SessionStart
+(HIMMEL-565)**, explicit sandbox/no-sandbox mode parsing, and Windows
 Git-Bash-startup fail-closed handling
-(`scripts/hooks/test-codex-run-hook.{sh,ps1}`).
+(`scripts/hooks/test-codex-run-hook.{sh,ps1}`). Live Codex lifecycle probes of
+the auto-arm path remain a follow-up; the no-token fixture is the gate that has
+now passed.
 
 **Setup options / live-verification caveats (codex-cli 0.141.0, Windows):**
 - **Sandboxed project hooks are the supported setup.** The tracked
@@ -250,8 +269,10 @@ that working matrix.
   Reuse ledgers; do not emulate Claude's visual statusline.
 - **Hook confidence:** file an owner ticket for no-token fixture coverage of
   individual guardrails and lifecycle events before any live Codex probe. The
-  first lifecycle case should resolve PostToolUse auto-arm's exit-2 contract
-  without emitting a bogus PreToolUse deny.
+  first lifecycle case — PostToolUse auto-arm's exit-2 contract — is **resolved
+  (HIMMEL-565)**: exit 2 on non-permission events now emits `additionalContext`,
+  not a bogus PreToolUse deny (see §1). Live auto-arm lifecycle probe still
+  pending.
 - **Install/update confidence:** file an owner ticket for disposable VM or
   temp-config checks covering setup, update, hook trust, and uninstall before
   live harness probes.

--- a/scripts/hooks/test-codex-run-hook.ps1
+++ b/scripts/hooks/test-codex-run-hook.ps1
@@ -68,6 +68,40 @@ try {
     Check "block -> guardrail stderr becomes the deny reason" ($bout -match 'blocking-reason-xyz')
     Check "block -> hookEventName mirrors the inbound event" ($bout -match '"hookEventName":"PermissionRequest"')
 
+    # 2b) NON-PERMISSION lifecycle exit-2 (HIMMEL-565): a guardrail that exits 2 on
+    #     a non-permission event (PostToolUse auto-arm success) must surface its
+    #     message via additionalContext, NOT a bogus PreToolUse permission deny.
+    Push-Location $T
+    $pout = ('{"hook_event_name":"PostToolUse"}' | & cmd.exe /c '.codex\run-hook.cmd' blocker.sh 2>&1 | Out-String)
+    $prc = $LASTEXITCODE
+    Pop-Location
+    Check "PostToolUse exit-2 -> wrapper exits 0 (signal is in stdout JSON)" ($prc -eq 0)
+    Check "PostToolUse exit-2 -> hookEventName mirrors PostToolUse" ($pout -match '"hookEventName":"PostToolUse"')
+    Check "PostToolUse exit-2 -> surfaces additionalContext" ($pout -match '"additionalContext"')
+    Check "PostToolUse exit-2 -> must NOT emit a permission decision" ($pout -notmatch 'permissionDecision')
+    Check "PostToolUse exit-2 -> guardrail stderr becomes the additionalContext reason" ($pout -match 'blocking-reason-xyz')
+
+    # 2c) Coherence: SessionStart exit-2 follows the same non-permission contract.
+    Push-Location $T
+    $ssout = ('{"hook_event_name":"SessionStart"}' | & cmd.exe /c '.codex\run-hook.cmd' blocker.sh 2>&1 | Out-String)
+    $ssrc = $LASTEXITCODE
+    Pop-Location
+    Check "SessionStart exit-2 -> wrapper exits 0" ($ssrc -eq 0)
+    Check "SessionStart exit-2 -> hookEventName mirrors SessionStart" ($ssout -match '"hookEventName":"SessionStart"')
+    Check "SessionStart exit-2 -> surfaces additionalContext" ($ssout -match '"additionalContext"')
+    Check "SessionStart exit-2 -> must NOT emit a permission decision" ($ssout -notmatch 'permissionDecision')
+
+    # 2e) Unknown/garbage inbound event on exit-2 normalises to PostToolUse — never
+    #     echoes the raw event string into the hookEventName const, never a deny.
+    Push-Location $T
+    $unkout = ('{"hook_event_name":"Stop"}' | & cmd.exe /c '.codex\run-hook.cmd' blocker.sh 2>&1 | Out-String)
+    $unkrc = $LASTEXITCODE
+    Pop-Location
+    Check "unknown-event exit-2 -> wrapper exits 0" ($unkrc -eq 0)
+    Check "unknown-event exit-2 -> normalised to PostToolUse" ($unkout -match '"hookEventName":"PostToolUse"')
+    Check "unknown-event exit-2 -> must NOT echo the raw event string" ($unkout -notmatch '"Stop"')
+    Check "unknown-event exit-2 -> must NOT emit a permission decision" ($unkout -notmatch 'permissionDecision')
+
     # 3) FAIL-CLOSED paths: a bare exit 2 fails OPEN under Codex, so precondition
     #    errors must emit a JSON deny (rc 0) instead.
     # 3a) Missing script name -> fail-closed deny (rc 0).

--- a/scripts/hooks/test-codex-run-hook.sh
+++ b/scripts/hooks/test-codex-run-hook.sh
@@ -78,6 +78,74 @@ case "$bout" in
   *) bad "block -> hookEventName mirrors the inbound event ($bout)";;
 esac
 
+# 2b) NON-PERMISSION lifecycle exit-2 (HIMMEL-565): a guardrail that exits 2 on a
+#     non-permission event (PostToolUse auto-arm success, SessionStart,
+#     UserPromptSubmit) must surface its message via additionalContext — NOT a
+#     bogus PreToolUse permission deny. Those events have no permission gate; the
+#     guardrail's side effects (e.g. arm + snapshot) already ran during execution,
+#     so exit 2 only needs to feed the advisory message to the model.
+pout="$(printf '{"hook_event_name":"PostToolUse"}\n' | bash "$T/.codex/run-hook.cmd" blocker.sh)"; prc=$?
+if [ "$prc" -eq 0 ]; then ok "PostToolUse exit-2 -> wrapper exits 0 (signal is in stdout JSON)"; else bad "PostToolUse exit-2 -> wrapper exits 0 (got $prc)"; fi
+case "$pout" in
+  *'"hookEventName":"PostToolUse"'*) ok "PostToolUse exit-2 -> hookEventName mirrors PostToolUse";;
+  *) bad "PostToolUse exit-2 -> hookEventName mirrors PostToolUse ($pout)";;
+esac
+case "$pout" in
+  *'"additionalContext"'*) ok "PostToolUse exit-2 -> surfaces additionalContext";;
+  *) bad "PostToolUse exit-2 -> surfaces additionalContext ($pout)";;
+esac
+case "$pout" in
+  *permissionDecision*) bad "PostToolUse exit-2 -> must NOT emit a permission decision ($pout)";;
+  *) ok "PostToolUse exit-2 -> no bogus permissionDecision";;
+esac
+case "$pout" in
+  *"blocking-reason-xyz"*) ok "PostToolUse exit-2 -> guardrail stderr becomes the additionalContext reason";;
+  *) bad "PostToolUse exit-2 -> guardrail stderr becomes the additionalContext reason ($pout)";;
+esac
+
+# 2c) Coherence: SessionStart exit-2 follows the same non-permission contract,
+#     incl. the additionalContext channel carrying the guardrail's reason.
+ssout="$(printf '{"hook_event_name":"SessionStart"}\n' | bash "$T/.codex/run-hook.cmd" blocker.sh)"; ssrc=$?
+if [ "$ssrc" -eq 0 ]; then ok "SessionStart exit-2 -> wrapper exits 0"; else bad "SessionStart exit-2 -> wrapper exits 0 (got $ssrc)"; fi
+case "$ssout" in
+  *'"hookEventName":"SessionStart"'*) ok "SessionStart exit-2 -> hookEventName mirrors SessionStart";;
+  *) bad "SessionStart exit-2 -> hookEventName mirrors SessionStart ($ssout)";;
+esac
+case "$ssout" in
+  *'"additionalContext"'*"blocking-reason-xyz"*) ok "SessionStart exit-2 -> guardrail stderr becomes the additionalContext reason";;
+  *) bad "SessionStart exit-2 -> guardrail stderr becomes the additionalContext reason ($ssout)";;
+esac
+case "$ssout" in
+  *permissionDecision*) bad "SessionStart exit-2 -> must NOT emit a permission decision ($ssout)";;
+  *) ok "SessionStart exit-2 -> no bogus permissionDecision";;
+esac
+
+# 2d) Coherence: UserPromptSubmit exit-2 mirrors its own event (3rd whitelist arm).
+upout="$(printf '{"hook_event_name":"UserPromptSubmit"}\n' | bash "$T/.codex/run-hook.cmd" blocker.sh)"
+case "$upout" in
+  *'"hookEventName":"UserPromptSubmit"'*) ok "UserPromptSubmit exit-2 -> hookEventName mirrors UserPromptSubmit";;
+  *) bad "UserPromptSubmit exit-2 -> hookEventName mirrors UserPromptSubmit ($upout)";;
+esac
+
+# 2e) Unknown/garbage inbound event on exit-2 is NORMALISED to PostToolUse — it
+#     must NOT echo the attacker-controllable event string into the hookEventName
+#     const (Codex's strict parser would reject it, dropping the message), and
+#     must NOT become a permission deny.
+unkout="$(printf '{"hook_event_name":"Stop"}\n' | bash "$T/.codex/run-hook.cmd" blocker.sh)"; unkrc=$?
+if [ "$unkrc" -eq 0 ]; then ok "unknown-event exit-2 -> wrapper exits 0"; else bad "unknown-event exit-2 -> wrapper exits 0 (got $unkrc)"; fi
+case "$unkout" in
+  *'"hookEventName":"PostToolUse"'*) ok "unknown-event exit-2 -> normalised to PostToolUse";;
+  *) bad "unknown-event exit-2 -> normalised to PostToolUse ($unkout)";;
+esac
+case "$unkout" in
+  *'"Stop"'*) bad "unknown-event exit-2 -> must NOT echo the raw event string ($unkout)";;
+  *) ok "unknown-event exit-2 -> raw event string not echoed";;
+esac
+case "$unkout" in
+  *permissionDecision*) bad "unknown-event exit-2 -> must NOT emit a permission decision ($unkout)";;
+  *) ok "unknown-event exit-2 -> no bogus permissionDecision";;
+esac
+
 # 3) FAIL-CLOSED paths: under Codex a bare exit 2 fails OPEN, so the adapter must
 #    emit a JSON deny (exit 0) on its own precondition errors, not just on a
 #    guardrail block.


### PR DESCRIPTION
Codex lifecycle adapter: exit-2 on non-permission events (PostToolUse/SessionStart/UserPromptSubmit) now emits hookSpecificOutput.additionalContext instead of a bogus PreToolUse permission deny. PreToolUse/PermissionRequest keep the deny path. Adds deterministic no-token fixture coverage in test-codex-run-hook.{sh,ps1}.