### PR TITLE
feat(codex): [HIMMEL-597] user-global installer to enable himmel plugins under Codex

### DIFF
--- a/docs/internals/harness-compat.md
+++ b/docs/internals/harness-compat.md
@@ -220,10 +220,20 @@ critic panel (`scripts/cr/critic-panel.sh`) and clears the CR marker only when
 the panel reports 0 Critical + 0 Important (retains on findings, panel
 unavailable, or a `docs-audit` lane). It does **not** dispatch the Claude
 `pr-review-toolkit` reviewer agents. Codex native `/review` participation is a
-post-HIMMEL-527 follow-up (shared `cr-context.sh` assembler). Tier-A skills
-(minerva, handover, obsidian-triage wrappers, himmel-update, stuck-playbook,
-vm) already load natively — verified live (`stuck-playbook` triggered under
-Codex).
+post-HIMMEL-527 follow-up (shared `cr-context.sh` assembler).
+
+Tier-A skills split by **delivery mechanism**: the enabled himmel plugins
+(`handover@himmel`, `obsidian-triage@himmel`, `telegram-himmel@himmel`) carry
+their own skills/commands. The **himmel-ops** skills (minerva, stuck-playbook,
+vm, himmel-doctor, himmel-update) require `himmel-ops@himmel` enabled in
+user-global `~/.codex/config.toml` — provisioned **reproducibly** by
+`scripts/codex/install-himmel-codex.{sh,ps1}` (HIMMEL-597; the codex-CLI half of
+the install split, twin of the hermes `scripts/hermes/install-himmel-profile.*`).
+The installer drives the `codex` CLI (`codex plugin marketplace add` /
+`codex plugin add`), idempotent + non-destructive. Independent of plugin-skill
+loading, the **verified** Codex skill-discovery path is project-local
+`.agents/skills/<name>/SKILL.md` (HIMMEL-533); guaranteed wrappers for the
+minerva/stuck-playbook/vm cluster are tracked in HIMMEL-604/607.
 
 ### 5. Subagents
 

--- a/scripts/codex/README.md
+++ b/scripts/codex/README.md
@@ -1,0 +1,76 @@
+# `scripts/codex/` — provision himmel under the Codex CLI (HIMMEL-597)
+
+User-global install for the **Codex** side of himmel, the twin of the hermes
+profile installer. The split:
+
+| Side | Installer | Manages |
+|------|-----------|---------|
+| hermes (CR/model orchestrator) | `scripts/hermes/install-himmel-profile.{sh,ps1}` | the `himmel_agent` hermes profile |
+| **codex CLI (harness/plugins)** | `scripts/codex/install-himmel-codex.{sh,ps1}` | himmel plugin enablement in `~/.codex/config.toml` |
+
+`~/.codex/config.toml` is user-global and not repo-tracked, so — like the hermes
+profile and like the Claude `~/.claude/settings.json` wiring in `setup.sh` — it
+needs an installer rather than a hand edit. This is that installer.
+
+## What it does
+
+Drives the `codex` CLI (`codex plugin marketplace add` / `codex plugin add`) —
+it **never hand-edits `config.toml`**, so Codex owns every config write (plugin
+trust hashes, `[mcp_servers.*]` secrets, `\\?\` long-path marketplace sources,
+line endings). It is **idempotent** and **non-destructive**:
+
+1. Registers the `himmel` marketplace (`<repo>/marketplace`) if not already
+   registered.
+2. Enables the himmel plugin set if not already `installed, enabled`. Default
+   set (all `@himmel`): `himmel-ops handover obsidian-triage telegram-himmel`.
+   `himmel-ops` is the one that delivers the minerva / stuck-playbook / vm /
+   himmel-doctor / himmel-update skills + the himmel-ops hooks to Codex
+   (the HIMMEL-597 target).
+
+It only ever *adds*; it never removes or disables a plugin, and a re-run on a
+provisioned machine is a no-op.
+
+## Usage
+
+```sh
+bash scripts/codex/install-himmel-codex.sh              # marketplace + default plugin set
+bash scripts/codex/install-himmel-codex.sh --all        # also luna-correlate + pr-review-toolkit-himmel
+bash scripts/codex/install-himmel-codex.sh --plugins=himmel-ops,handover
+bash scripts/codex/install-himmel-codex.sh --dry-run    # report intended changes, change nothing
+```
+
+```powershell
+pwsh -NoProfile -File scripts\codex\install-himmel-codex.ps1 -DryRun
+pwsh -NoProfile -File scripts\codex\install-himmel-codex.ps1 -All
+```
+
+Env override: `CODEX_BIN` (path to the `codex` CLI). After a change, restart
+Codex so the plugins load; new project hooks are trust-hashed on first use.
+
+## Skill loading caveat
+
+Enabling `himmel-ops` makes its **hooks** fire under Codex (e.g.
+`inject-minerva-critic` via `${CLAUDE_PLUGIN_ROOT}` — fail-open, exit-0-only).
+Whether an enabled plugin's **skills** auto-load under Codex vs only via
+project-local `.agents/skills/<name>/` wrappers is delivery-dependent; the
+**verified** skill-discovery path is `.agents/skills/` (HIMMEL-533). Guaranteed
+wrappers for the minerva/stuck-playbook/vm cluster are tracked in
+HIMMEL-604/607. See `docs/internals/harness-compat.md` §4.
+
+## Scope
+
+This installer is run-on-demand (like the hermes profile installer), separate
+from the Claude `setup.sh` `[N/10]` flow. Wiring it into the broader setup /
+`/himmel-update` flow is **HIMMEL-605** ("user-scope guardrail wiring for Codex").
+
+## Tests
+
+- `scripts/codex/test-install-himmel-codex.sh` — hermetic; stubs the `codex` CLI
+  via `CODEX_BIN`, asserts marketplace-register-when-absent, per-plugin enable,
+  idempotency, `--dry-run`, missing-CLI exit, non-destructiveness, `--plugins`.
+  Auto-discovered by `scripts/ci/run-shell-tests.sh`.
+- `scripts/codex/test-install-himmel-codex.ps1` — the Windows twin.
+
+> Not to be confused with the project-local Codex **guardrail** wiring in the
+> repo's `.codex/` dir (hooks adapter, HIMMEL-427/565). That fires guardrails
+> *under* Codex; this provisions the user-global plugin set.

--- a/scripts/codex/install-himmel-codex.ps1
+++ b/scripts/codex/install-himmel-codex.ps1
@@ -1,0 +1,120 @@
+<#
+.SYNOPSIS
+  Provision himmel under the Codex CLI (HIMMEL-597) — the codex-CLI half of the
+  install split, twin of scripts/codex/install-himmel-codex.sh.
+
+.DESCRIPTION
+  Manages user-global plugin state in ~/.codex/config.toml the SAME way
+  scripts/hermes/install-himmel-profile.ps1 provisions the hermes side:
+    hermes side : scripts/hermes/install-himmel-profile.{sh,ps1}  (CR/model profile)
+    codex side  : scripts/codex/install-himmel-codex.{sh,ps1}     (this file)
+
+  Drives the `codex` CLI (codex plugin marketplace add / codex plugin add) — never
+  hand-edits config.toml — so Codex owns all config writes (trust hashes, MCP
+  secrets, long-path marketplace sources). NON-DESTRUCTIVE + idempotent: registers
+  the himmel marketplace only when absent and enables the himmel plugin set; never
+  removes or disables anything; re-runs are no-ops.
+
+  Default plugin set (all @himmel): himmel-ops handover obsidian-triage telegram-himmel.
+  -All also enables luna-correlate + pr-review-toolkit-himmel.
+  -Plugins <csv> overrides the set. -DryRun reports intended changes, mutates nothing.
+  Env overrides: CODEX_BIN (codex CLI path).
+#>
+# PositionalBinding=$false + a remaining-args catch so a bash-style flag
+# (e.g. --dry-run) or a stray bareword is REJECTED rather than silently bound to
+# -Plugins — which would otherwise flip a dry-run into a live mutation and a
+# garbage `plugin add --dry-run@himmel`. Mirrors the .sh `*) exit 2` arm.
+[CmdletBinding(PositionalBinding=$false)]
+param(
+  [switch]$DryRun,
+  [switch]$All,
+  [string]$Plugins = "",
+  [Parameter(ValueFromRemainingArguments=$true)]
+  [string[]]$Rest
+)
+
+$ErrorActionPreference = "Stop"
+if ($Rest -and $Rest.Count -gt 0) {
+  Write-Error "unknown argument(s): $($Rest -join ' ') (use -DryRun / -All / -Plugins <csv>)"
+  exit 2
+}
+$Marketplace = "himmel"   # the himmel marketplace name (marketplace/.claude-plugin/marketplace.json)
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$MarketPath = Join-Path $RepoRoot "marketplace"
+
+# --- resolve the codex CLI ---
+$Codex = $null
+if ($env:CODEX_BIN) {
+  if (Test-Path $env:CODEX_BIN) { $Codex = $env:CODEX_BIN }
+  else { Write-Error "codex CLI not found (CODEX_BIN set to non-existent path)"; exit 1 }
+} elseif (Get-Command codex -ErrorAction SilentlyContinue) {
+  $Codex = (Get-Command codex).Source
+}
+if (-not $Codex) { Write-Error "codex CLI not found (set CODEX_BIN, or install Codex)"; exit 1 }
+
+if (-not (Test-Path $MarketPath)) { Write-Error "himmel marketplace dir not found at $MarketPath"; exit 1 }
+
+# --- resolve the plugin set ---
+if ($Plugins) {
+  $PluginSet = @($Plugins -split "," | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+} else {
+  $PluginSet = @("himmel-ops","handover","obsidian-triage","telegram-himmel")
+  if ($All) { $PluginSet += @("luna-correlate","pr-review-toolkit-himmel") }
+}
+
+Write-Host "codex CLI   : $Codex"
+Write-Host "marketplace : $Marketplace ($MarketPath)"
+if ($DryRun) { Write-Host "mode        : DRY-RUN (no changes will be made)" }
+
+$changed = 0
+
+# helper: first whitespace-delimited token of a line (Trim first so a leading-
+# whitespace line yields its real first token, matching awk's $1 in the .sh twin)
+function First-Token([string]$line) { ($line.Trim() -split "\s+", 2)[0] }
+
+# --- 1. register the himmel marketplace if absent ---
+$mkList = (& $Codex plugin marketplace list 2>$null) | Out-String
+$mkPresent = $false
+foreach ($line in ($mkList -split "`r?`n")) {
+  if ((First-Token $line) -eq $Marketplace) { $mkPresent = $true; break }
+}
+if ($mkPresent) {
+  Write-Host "UNCHANGED   : marketplace '$Marketplace' already registered"
+} else {
+  if ($DryRun) { Write-Host "WOULD ADD   : marketplace '$Marketplace' -> $MarketPath" }
+  else { & $Codex plugin marketplace add $MarketPath | Out-Null; Write-Host "CHANGED     : registered marketplace '$Marketplace' -> $MarketPath" }
+  $changed++
+}
+
+# --- 2. enable each plugin in the set if not already installed+enabled ---
+# `codex plugin list` groups rows per-marketplace; each plugin row's first column
+# is the FULL selector `name@marketplace` (verified live: `himmel-ops@himmel`),
+# status column reads "installed, enabled". Match the exact selector AND enabled.
+$plList = (& $Codex plugin list 2>$null) | Out-String
+$plLines = $plList -split "`r?`n"
+foreach ($p in $PluginSet) {
+  $sel = "$p@$Marketplace"
+  $enabled = $false
+  foreach ($line in $plLines) {
+    if (((First-Token $line) -eq $sel) -and ($line -match "installed, enabled")) { $enabled = $true; break }
+  }
+  if ($enabled) {
+    Write-Host "UNCHANGED   : $sel (installed, enabled)"
+  } else {
+    if ($DryRun) { Write-Host "WOULD ADD   : $sel" }
+    else { & $Codex plugin add $sel | Out-Null; Write-Host "CHANGED     : enabled $sel" }
+    $changed++
+  }
+}
+
+Write-Host ""
+if ($DryRun) {
+  Write-Host "DRY-RUN: $changed change(s) would be made. Re-run without -DryRun to apply."
+} elseif ($changed -eq 0) {
+  Write-Host "OK: himmel already provisioned under Codex (nothing to do)."
+} else {
+  Write-Host "OK: himmel provisioned under Codex ($changed change(s))."
+  Write-Host "    Restart Codex so the newly-enabled plugins load; new project hooks are"
+  Write-Host "    trust-hashed on first use (interactive Codex prompts once)."
+}

--- a/scripts/codex/install-himmel-codex.sh
+++ b/scripts/codex/install-himmel-codex.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# install-himmel-codex.sh (HIMMEL-597)
+#
+# Provision himmel under the Codex CLI by managing user-global plugin state in
+# ~/.codex/config.toml the SAME way scripts/hermes/install-himmel-profile.sh
+# provisions the hermes side. This is the codex-CLI half of the split:
+#   hermes side : scripts/hermes/install-himmel-profile.{sh,ps1}  (CR/model profile)
+#   codex side  : scripts/codex/install-himmel-codex.{sh,ps1}     (this file)
+#
+# It drives the `codex` CLI (codex plugin marketplace add / codex plugin add) —
+# never hand-edits config.toml — so Codex owns all config writes (trust hashes,
+# MCP secrets, long-path marketplace sources). NON-DESTRUCTIVE + idempotent: it
+# only registers the himmel marketplace when absent and enables the himmel plugin
+# set; it never removes or disables anything, and re-runs are no-ops.
+#
+#   install-himmel-codex.sh                 # register marketplace + enable default set
+#   install-himmel-codex.sh --all           # also enable luna-correlate + pr-review-toolkit-himmel
+#   install-himmel-codex.sh --plugins=himmel-ops,handover
+#   install-himmel-codex.sh --dry-run       # report intended changes, mutate nothing
+#
+# Default plugin set (all @himmel): himmel-ops handover obsidian-triage telegram-himmel.
+# Env overrides: CODEX_BIN (codex CLI path).
+set -euo pipefail
+
+MARKET="himmel"   # the himmel marketplace name (per marketplace/.claude-plugin/marketplace.json)
+DRY_RUN=0
+ALL=0
+PLUGINS_OVERRIDE=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)        DRY_RUN=1 ;;
+    --all)            ALL=1 ;;
+    --plugins=*)      PLUGINS_OVERRIDE="${arg#*=}" ;;
+    -h|--help)        sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "ERR: unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MARKET_PATH="$REPO_ROOT/marketplace"
+
+# --- resolve the codex CLI ---------------------------------------------------
+resolve_codex() {
+  if [ -n "${CODEX_BIN:-}" ]; then
+    [ -x "$CODEX_BIN" ] && { echo "$CODEX_BIN"; return 0; }
+    return 1   # explicitly overridden but unusable -> hard error (no silent PATH fallback)
+  fi
+  command -v codex 2>/dev/null && return 0
+  return 1
+}
+CODEX="$(resolve_codex)" || { echo "ERR: codex CLI not found (set CODEX_BIN, or install Codex)" >&2; exit 1; }
+
+[ -d "$MARKET_PATH" ] || { echo "ERR: himmel marketplace dir not found at $MARKET_PATH" >&2; exit 1; }
+
+# --- resolve the plugin set --------------------------------------------------
+if [ -n "$PLUGINS_OVERRIDE" ]; then
+  PLUGINS="$(printf '%s' "$PLUGINS_OVERRIDE" | tr ',' ' ')"
+else
+  PLUGINS="himmel-ops handover obsidian-triage telegram-himmel"
+  [ "$ALL" = "1" ] && PLUGINS="$PLUGINS luna-correlate pr-review-toolkit-himmel"
+fi
+
+echo "codex CLI   : $CODEX"
+echo "marketplace : $MARKET ($MARKET_PATH)"
+[ "$DRY_RUN" = "1" ] && echo "mode        : DRY-RUN (no changes will be made)"
+
+changed=0
+
+# --- 1. register the himmel marketplace if absent ----------------------------
+if "$CODEX" plugin marketplace list 2>/dev/null | awk -v n="$MARKET" '$1==n{f=1} END{exit f?0:1}'; then
+  echo "UNCHANGED   : marketplace '$MARKET' already registered"
+else
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "WOULD ADD   : marketplace '$MARKET' -> $MARKET_PATH"
+  else
+    "$CODEX" plugin marketplace add "$MARKET_PATH" >/dev/null
+    echo "CHANGED     : registered marketplace '$MARKET' -> $MARKET_PATH"
+  fi
+  changed=$((changed + 1))
+fi
+
+# --- 2. enable each plugin in the set if not already installed+enabled --------
+# `codex plugin list` groups rows per-marketplace; each plugin row's first column
+# is the FULL selector `name@marketplace` (verified live: `himmel-ops@himmel`),
+# and the status column reads "installed, enabled". Match the exact selector
+# (so a same-named plugin in another marketplace can't false-match) AND enabled.
+plugin_list="$("$CODEX" plugin list 2>/dev/null || true)"
+for p in $PLUGINS; do
+  sel="$p@$MARKET"
+  if printf '%s\n' "$plugin_list" | awk -v s="$sel" '$1==s && index($0,"installed, enabled"){f=1} END{exit f?0:1}'; then
+    echo "UNCHANGED   : $sel (installed, enabled)"
+  else
+    if [ "$DRY_RUN" = "1" ]; then
+      echo "WOULD ADD   : $sel"
+    else
+      "$CODEX" plugin add "$sel" >/dev/null
+      echo "CHANGED     : enabled $sel"
+    fi
+    changed=$((changed + 1))
+  fi
+done
+
+echo ""
+if [ "$DRY_RUN" = "1" ]; then
+  echo "DRY-RUN: $changed change(s) would be made. Re-run without --dry-run to apply."
+elif [ "$changed" -eq 0 ]; then
+  echo "OK: himmel already provisioned under Codex (nothing to do)."
+else
+  echo "OK: himmel provisioned under Codex ($changed change(s))."
+  echo "    Restart Codex so the newly-enabled plugins load; new project hooks are"
+  echo "    trust-hashed on first use (interactive Codex prompts once)."
+fi

--- a/scripts/codex/test-install-himmel-codex.ps1
+++ b/scripts/codex/test-install-himmel-codex.ps1
@@ -1,0 +1,171 @@
+<#
+  Hermetic tests for install-himmel-codex.ps1 (HIMMEL-597) — Windows twin of
+  test-install-himmel-codex.sh. A stub `codex` CLI (codex-stub.ps1) simulates
+  `plugin marketplace list/add` + `plugin list/add`, driven by test-controlled
+  state files, logging every mutating call. The installer runs in a child pwsh
+  so a scenario's `exit 1` cannot terminate this harness.
+#>
+$ErrorActionPreference = "Stop"
+$ScriptDir = $PSScriptRoot
+$Installer = Join-Path $ScriptDir "install-himmel-codex.ps1"
+
+$script:fails = 0
+function Pass($m) { Write-Host "  ok: $m" }
+function Fail($m) { Write-Host "  FAIL: $m" -ForegroundColor Red; $script:fails++ }
+function Assert-LogHas($log,$needle,$msg)   { if ((Test-Path $log) -and (Select-String -SimpleMatch -Quiet -Pattern $needle -Path $log)) { Pass $msg } else { Fail "$msg (missing '$needle')" } }
+function Assert-LogLacks($log,$needle,$msg) { if ((Test-Path $log) -and (Select-String -SimpleMatch -Quiet -Pattern $needle -Path $log)) { Fail "$msg (unexpected '$needle')" } else { Pass $msg } }
+function Assert-Count($log,$needle,$want,$msg) {
+  $n = 0
+  if (Test-Path $log) { $n = (Select-String -SimpleMatch -Pattern $needle -Path $log | Measure-Object).Count }
+  if ($n -eq $want) { Pass $msg } else { Fail "$msg (count '$needle' = $n, want $want)" }
+}
+
+$TMP = Join-Path ([System.IO.Path]::GetTempPath()) ("himmel-codex-test-" + [System.Guid]::NewGuid().ToString("N").Substring(0,8))
+New-Item -ItemType Directory -Force -Path $TMP | Out-Null
+try {
+  # --- stub codex CLI ---
+  $Stub = Join-Path $TMP "codex-stub.ps1"
+  Set-Content -Path $Stub -Encoding UTF8 -Value @'
+$S = $env:CODEX_STUB_STATE
+$a = $args
+function Log($m) { Add-Content -Path (Join-Path $S "calls.log") -Value $m }
+if ($a[0] -eq "plugin" -and $a[1] -eq "marketplace" -and $a[2] -eq "list") {
+  "MARKETPLACE                  ROOT"
+  $mf = Join-Path $S "marketplaces.txt"
+  if (Test-Path $mf) { Get-Content $mf | ForEach-Object { if ($_) { "{0}  /fake/{1}" -f $_, $_ } } }
+  exit 0
+}
+if ($a[0] -eq "plugin" -and $a[1] -eq "marketplace" -and $a[2] -eq "add") { Log "marketplace add $($a[3])"; exit 0 }
+if ($a[0] -eq "plugin" -and $a[1] -eq "list") {
+  "PLUGIN                                   STATUS              VERSION  PATH"
+  $pf = Join-Path $S "plugins.txt"
+  if (Test-Path $pf) { Get-Content $pf | ForEach-Object { if ($_) { $p = $_ -split "`t"; "{0}  {1}  local  /fake/{2}" -f $p[0], $p[1], $p[0] } } }
+  exit 0
+}
+if ($a[0] -eq "plugin" -and $a[1] -eq "add")    { Log "plugin add $($a[2])"; exit 0 }
+if ($a[0] -eq "plugin" -and $a[1] -eq "remove") { Log "plugin remove $($a[2])"; exit 0 }
+exit 0
+'@
+
+  function New-State($name) {
+    $s = Join-Path $TMP $name
+    if (Test-Path $s) { Remove-Item $s -Recurse -Force }
+    New-Item -ItemType Directory -Force -Path $s | Out-Null
+    Set-Content -Path (Join-Path $s "marketplaces.txt") -Value "" -NoNewline
+    Set-Content -Path (Join-Path $s "plugins.txt") -Value "" -NoNewline
+    Set-Content -Path (Join-Path $s "calls.log") -Value "" -NoNewline
+    return $s
+  }
+
+  # run installer in a CHILD pwsh; returns @{ Out=<string>; Code=<int> }
+  function Invoke-Installer($state, [string[]]$iargs, [string]$codexBin) {
+    if (-not $codexBin) { $codexBin = $Stub }
+    $env:CODEX_BIN = $codexBin
+    $env:CODEX_STUB_STATE = $state
+    try {
+      $out = & pwsh -NoProfile -File $Installer @iargs 2>&1 | Out-String
+      $code = $LASTEXITCODE
+    } finally {
+      Remove-Item Env:CODEX_BIN -ErrorAction SilentlyContinue
+      Remove-Item Env:CODEX_STUB_STATE -ErrorAction SilentlyContinue
+    }
+    return @{ Out = $out; Code = $code }
+  }
+
+  $DefaultSet = @("himmel-ops","handover","obsidian-triage","telegram-himmel")
+
+  Write-Host "== scenario A: fresh machine (no himmel marketplace, no plugins) =="
+  $S = New-State "A"
+  Set-Content (Join-Path $S "marketplaces.txt") "openai-bundled"
+  Set-Content (Join-Path $S "plugins.txt") "browser@openai-bundled`tinstalled, enabled"
+  Invoke-Installer $S @() | Out-Null
+  $log = Join-Path $S "calls.log"
+  Assert-LogHas  $log "marketplace add" "registers himmel marketplace when absent"
+  Assert-Count   $log "plugin add" 4 "adds all 4 default plugins"
+  foreach ($p in $DefaultSet) { Assert-LogHas $log "plugin add $p@himmel" "adds $p" }
+
+  Write-Host "== scenario B: idempotent (marketplace present, all installed+enabled) =="
+  $S = New-State "B"
+  Set-Content (Join-Path $S "marketplaces.txt") "openai-bundled`r`nhimmel"
+  ($DefaultSet | ForEach-Object { "$_@himmel`tinstalled, enabled" }) -join "`r`n" | Set-Content (Join-Path $S "plugins.txt")
+  Invoke-Installer $S @() | Out-Null
+  $log = Join-Path $S "calls.log"
+  Assert-LogLacks $log "marketplace add" "no re-register when himmel marketplace present"
+  Assert-LogLacks $log "plugin add" "no re-add when all targets enabled (idempotent)"
+
+  Write-Host "== scenario C: one target not installed (others enabled) =="
+  $S = New-State "C"
+  Set-Content (Join-Path $S "marketplaces.txt") "himmel"
+  @("himmel-ops@himmel`tnot installed",
+    "handover@himmel`tinstalled, enabled",
+    "obsidian-triage@himmel`tinstalled, enabled",
+    "telegram-himmel@himmel`tinstalled, enabled") -join "`r`n" | Set-Content (Join-Path $S "plugins.txt")
+  Invoke-Installer $S @() | Out-Null
+  $log = Join-Path $S "calls.log"
+  Assert-Count   $log "plugin add" 1 "adds exactly the one missing plugin"
+  Assert-LogHas  $log "plugin add himmel-ops@himmel" "adds the not-installed himmel-ops"
+  Assert-LogLacks $log "plugin add handover@himmel" "leaves already-enabled handover untouched"
+
+  Write-Host "== scenario D: -DryRun reports but does not mutate =="
+  $S = New-State "D"
+  Set-Content (Join-Path $S "marketplaces.txt") "openai-bundled"
+  $r = Invoke-Installer $S @("-DryRun")
+  $log = Join-Path $S "calls.log"
+  Assert-LogLacks $log "marketplace add" "-DryRun issues no marketplace add"
+  Assert-LogLacks $log "plugin add" "-DryRun issues no plugin add"
+  if ($r.Out -match "(?i)would|dry") { Pass "-DryRun reports intended changes" } else { Fail "-DryRun gave no change report" }
+
+  Write-Host "== scenario E: codex CLI missing -> exit 1, no calls =="
+  $S = New-State "E"
+  $r = Invoke-Installer $S @() (Join-Path $TMP "nope-not-a-codex")
+  if ($r.Code -eq 1) { Pass "missing codex CLI exits 1" } else { Fail "missing codex CLI exit=$($r.Code) (want 1)" }
+  Assert-LogLacks (Join-Path $S "calls.log") "add" "no calls when codex CLI missing"
+
+  Write-Host "== scenario F: non-destructive (never removes/disables) =="
+  $S = New-State "F"
+  Set-Content (Join-Path $S "marketplaces.txt") "himmel"
+  Set-Content (Join-Path $S "plugins.txt") "himmel-ops@himmel`tnot installed"
+  Invoke-Installer $S @() | Out-Null
+  $log = Join-Path $S "calls.log"
+  Assert-LogLacks $log "remove" "never calls plugin/marketplace remove"
+  Assert-LogLacks $log "--disable" "never disables a plugin"
+
+  Write-Host "== scenario G: -Plugins override =="
+  $S = New-State "G"
+  Set-Content (Join-Path $S "marketplaces.txt") "himmel"
+  $r = Invoke-Installer $S @("-Plugins","himmel-ops")
+  $log = Join-Path $S "calls.log"
+  Assert-Count   $log "plugin add" 1 "-Plugins restricts the set to one"
+  Assert-LogHas  $log "plugin add himmel-ops@himmel" "-Plugins adds the named plugin"
+
+  Write-Host "== scenario H: bash-style / unknown arg -> rejected, no mutation =="
+  $S = New-State "H"
+  Set-Content (Join-Path $S "marketplaces.txt") "himmel"
+  # a bash-style --dry-run must NOT silently bind to -Plugins and mutate
+  $r = Invoke-Installer $S @("--dry-run")
+  if ($r.Code -ne 0) { Pass "bash-style --dry-run rejected (exit non-zero)" } else { Fail "--dry-run should be rejected by the .ps1, not bound to -Plugins" }
+  Assert-LogLacks (Join-Path $S "calls.log") "add" "no mutation on rejected arg"
+  # a stray bareword is likewise rejected
+  $S2 = New-State "H2"; Set-Content (Join-Path $S2 "marketplaces.txt") "himmel"
+  $r2 = Invoke-Installer $S2 @("himmel-ops")
+  if ($r2.Code -ne 0) { Pass "stray bareword rejected (exit non-zero)" } else { Fail "stray bareword should be rejected" }
+
+  Write-Host "== scenario I: @marketplace discrimination (same plugin name, different marketplace) =="
+  $S = New-State "I"
+  Set-Content (Join-Path $S "marketplaces.txt") "himmel`r`nopenai-bundled"
+  Set-Content (Join-Path $S "plugins.txt") "himmel-ops@openai-bundled`tinstalled, enabled"
+  Invoke-Installer $S @("-Plugins","himmel-ops") | Out-Null
+  Assert-LogHas (Join-Path $S "calls.log") "plugin add himmel-ops@himmel" "still adds himmel-ops@himmel despite same name in another marketplace"
+
+  Write-Host "== scenario J: marketplace name exact-match (near-miss must not satisfy) =="
+  $S = New-State "J"
+  Set-Content (Join-Path $S "marketplaces.txt") "himmel-extra"
+  Invoke-Installer $S @("-Plugins","himmel-ops") | Out-Null
+  Assert-LogHas (Join-Path $S "calls.log") "marketplace add" "registers 'himmel' when only 'himmel-extra' present (no substring false-match)"
+
+  Write-Host ""
+  if ($script:fails -eq 0) { Write-Host "ALL PASS" } else { Write-Host "$($script:fails) FAILED" -ForegroundColor Red; exit 1 }
+}
+finally {
+  Remove-Item $TMP -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/codex/test-install-himmel-codex.sh
+++ b/scripts/codex/test-install-himmel-codex.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Hermetic tests for install-himmel-codex.sh (HIMMEL-597).
+# No real Codex install needed: a stub `codex` CLI simulates
+# `plugin marketplace list/add` and `plugin list/add`, driven by test-controlled
+# state files, and records every mutating call to a log. Asserts the installer is
+# idempotent (no re-add when already installed+enabled), registers the himmel
+# marketplace when absent, adds only the missing plugins, honours --dry-run, and
+# is non-destructive (never removes/disables anything).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="$SCRIPT_DIR/install-himmel-codex.sh"
+
+fails=0
+pass() { echo "  ok: $1"; }
+fail() { echo "  FAIL: $1" >&2; fails=$((fails + 1)); }
+# `-e "$2"` so a pattern beginning with '-' (e.g. "--disable") is not parsed as a grep option.
+assert_log_has()  { if grep -qF -e "$2" "$1"; then pass "$3"; else fail "$3 (missing '$2' in call-log)"; fi; }
+assert_log_lacks(){ if grep -qF -e "$2" "$1"; then fail "$3 (unexpected '$2' in call-log)"; else pass "$3"; fi; }
+assert_count()    { local n; n="$(grep -cF -e "$2" "$1" || true)"; if [ "$n" = "$3" ]; then pass "$4"; else fail "$4 (count '$2' = $n, want $3)"; fi; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- stub `codex` CLI --------------------------------------------------------
+# State dir ($CODEX_STUB_STATE):
+#   marketplaces.txt : one marketplace NAME per line (drives `marketplace list`)
+#   plugins.txt      : "name@marketplace<TAB>STATUS" per line (drives `plugin list`)
+#   calls.log        : every mutating invocation, appended by the stub
+STUB="$TMP/codex-stub.sh"
+cat > "$STUB" <<'STUB_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+S="${CODEX_STUB_STATE:?CODEX_STUB_STATE unset}"
+log() { echo "$*" >> "$S/calls.log"; }
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "marketplace" ] && [ "${3:-}" = "list" ]; then
+  echo "MARKETPLACE                  ROOT"
+  if [ -f "$S/marketplaces.txt" ]; then
+    while IFS= read -r m; do [ -n "$m" ] && printf '%-28s %s\n' "$m" "/fake/$m"; done < "$S/marketplaces.txt"
+  fi
+  exit 0
+fi
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "marketplace" ] && [ "${3:-}" = "add" ]; then
+  log "marketplace add ${4:-}"; exit 0
+fi
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "list" ]; then
+  echo "PLUGIN                                   STATUS              VERSION  PATH"
+  if [ -f "$S/plugins.txt" ]; then
+    while IFS="$(printf '\t')" read -r sel status; do
+      [ -n "$sel" ] && printf '%-40s %-19s local     /fake/%s\n' "$sel" "$status" "$sel"
+    done < "$S/plugins.txt"
+  fi
+  exit 0
+fi
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "add" ]; then
+  log "plugin add ${3:-}"; exit 0
+fi
+if [ "${1:-}" = "plugin" ] && [ "${2:-}" = "remove" ]; then
+  log "plugin remove ${3:-}"; exit 0
+fi
+exit 0
+STUB_EOF
+chmod +x "$STUB"
+
+mk_state() {  # $1 = state dir; seeds empty marketplaces + plugins + calls
+  local s="$1"; rm -rf "$s"; mkdir -p "$s"
+  : > "$s/marketplaces.txt"; : > "$s/plugins.txt"; : > "$s/calls.log"
+}
+
+run() {  # state-dir, then installer args
+  local s="$1"; shift
+  CODEX_BIN="$STUB" CODEX_STUB_STATE="$s" bash "$INSTALLER" "$@"
+}
+
+DEFAULT_SET="himmel-ops handover obsidian-triage telegram-himmel"
+
+echo "== scenario A: fresh machine (no himmel marketplace, no plugins) =="
+S="$TMP/A"; mk_state "$S"
+# only foreign marketplaces/plugins present
+printf 'openai-bundled\n' > "$S/marketplaces.txt"
+printf 'browser@openai-bundled\tinstalled, enabled\n' > "$S/plugins.txt"
+run "$S" >/dev/null
+assert_log_has  "$S/calls.log" "marketplace add"           "registers himmel marketplace when absent"
+assert_count    "$S/calls.log" "plugin add"              "4" "adds all 4 default plugins"
+for p in $DEFAULT_SET; do assert_log_has "$S/calls.log" "plugin add $p@himmel" "adds $p"; done
+
+echo "== scenario B: idempotent (marketplace present, all targets installed+enabled) =="
+S="$TMP/B"; mk_state "$S"
+printf 'openai-bundled\nhimmel\n' > "$S/marketplaces.txt"
+{ for p in $DEFAULT_SET; do printf '%s@himmel\tinstalled, enabled\n' "$p"; done; } > "$S/plugins.txt"
+run "$S" >/dev/null
+assert_log_lacks "$S/calls.log" "marketplace add" "no re-register when himmel marketplace present"
+assert_log_lacks "$S/calls.log" "plugin add"      "no re-add when all targets enabled (idempotent)"
+
+echo "== scenario C: one target not installed (others enabled) =="
+S="$TMP/C"; mk_state "$S"
+printf 'himmel\n' > "$S/marketplaces.txt"
+{ printf 'himmel-ops@himmel\tnot installed\n';
+  printf 'handover@himmel\tinstalled, enabled\n';
+  printf 'obsidian-triage@himmel\tinstalled, enabled\n';
+  printf 'telegram-himmel@himmel\tinstalled, enabled\n'; } > "$S/plugins.txt"
+run "$S" >/dev/null
+assert_count    "$S/calls.log" "plugin add" "1" "adds exactly the one missing plugin"
+assert_log_has  "$S/calls.log" "plugin add himmel-ops@himmel" "adds the not-installed himmel-ops"
+assert_log_lacks "$S/calls.log" "plugin add handover@himmel"  "leaves already-enabled handover untouched"
+
+echo "== scenario D: --dry-run reports but does not mutate =="
+S="$TMP/D"; mk_state "$S"
+printf 'openai-bundled\n' > "$S/marketplaces.txt"; : > "$S/plugins.txt"
+out="$(run "$S" --dry-run)"
+assert_log_lacks "$S/calls.log" "marketplace add" "--dry-run issues no marketplace add"
+assert_log_lacks "$S/calls.log" "plugin add"      "--dry-run issues no plugin add"
+if printf '%s' "$out" | grep -qiE 'would|dry'; then pass "--dry-run reports intended changes"; else fail "--dry-run gave no change report"; fi
+
+echo "== scenario E: codex CLI missing -> exit 1, no calls =="
+S="$TMP/E"; mk_state "$S"
+rc=0; CODEX_BIN="$TMP/nope-not-a-codex" CODEX_STUB_STATE="$S" bash "$INSTALLER" >/dev/null 2>&1 || rc=$?
+if [ "$rc" = "1" ]; then pass "missing codex CLI exits 1"; else fail "missing codex CLI exit=$rc (want 1)"; fi
+assert_log_lacks "$S/calls.log" "add" "no calls when codex CLI missing"
+
+echo "== scenario F: non-destructive (never removes/disables) =="
+S="$TMP/F"; mk_state "$S"
+printf 'himmel\n' > "$S/marketplaces.txt"
+printf 'himmel-ops@himmel\tnot installed\n' > "$S/plugins.txt"
+run "$S" >/dev/null
+assert_log_lacks "$S/calls.log" "remove"    "never calls plugin/marketplace remove"
+assert_log_lacks "$S/calls.log" "--disable" "never disables a plugin"
+
+echo "== scenario G: --plugins override =="
+S="$TMP/G"; mk_state "$S"
+printf 'himmel\n' > "$S/marketplaces.txt"; : > "$S/plugins.txt"
+run "$S" --plugins=himmel-ops >/dev/null
+assert_count   "$S/calls.log" "plugin add" "1" "--plugins restricts the set to one"
+assert_log_has "$S/calls.log" "plugin add himmel-ops@himmel" "--plugins adds the named plugin"
+
+echo "== scenario H: unknown argument -> exit 2, no calls =="
+S="$TMP/H"; mk_state "$S"
+printf 'himmel\n' > "$S/marketplaces.txt"
+rc=0; run "$S" --bogus >/dev/null 2>&1 || rc=$?
+if [ "$rc" = "2" ]; then pass "unknown arg exits 2"; else fail "unknown arg exit=$rc (want 2)"; fi
+assert_log_lacks "$S/calls.log" "add" "no calls on unknown arg"
+
+echo "== scenario I: @marketplace discrimination (same plugin name, different marketplace) =="
+S="$TMP/I"; mk_state "$S"
+printf 'himmel\nopenai-bundled\n' > "$S/marketplaces.txt"
+# himmel-ops is installed+enabled under ANOTHER marketplace; the himmel one is absent.
+printf 'himmel-ops@openai-bundled\tinstalled, enabled\n' > "$S/plugins.txt"
+run "$S" --plugins=himmel-ops >/dev/null
+assert_log_has "$S/calls.log" "plugin add himmel-ops@himmel" "still adds himmel-ops@himmel despite same name in another marketplace"
+
+echo "== scenario J: marketplace name exact-match (near-miss must not satisfy) =="
+S="$TMP/J"; mk_state "$S"
+printf 'himmel-extra\n' > "$S/marketplaces.txt"   # 'himmel' absent; only a substring-y near-miss present
+: > "$S/plugins.txt"
+run "$S" --plugins=himmel-ops >/dev/null
+assert_log_has "$S/calls.log" "marketplace add" "registers 'himmel' when only 'himmel-extra' present (no substring false-match)"
+
+echo ""
+if [ "$fails" -eq 0 ]; then echo "ALL PASS"; else echo "$fails FAILED" >&2; exit 1; fi


### PR DESCRIPTION
Codex-CLI half of the himmel install split (twin of the hermes profile installer). Drives the codex CLI (plugin marketplace add / plugin add) to register the himmel marketplace and enable the himmel plugin set (himmel-ops handover obsidian-triage telegram-himmel) idempotently + non-destructively, so user-global ~/.codex/config.toml is provisioned reproducibly. Hermetic tests stub the codex CLI on both .sh and .ps1. harness-compat §4 reconciled.