### PR TITLE
feat(codex): [HIMMEL-596] fire advisory SessionStart hooks under Codex

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -17,6 +17,15 @@ full compat matrix.
   `$CLAUDE_PROJECT_DIR`, which Codex leaves unset for plugin hooks — so they
   silently no-op under Codex unless mirrored here, where `run-hook.cmd` derives
   the repo root from its own location.
+  Also wires the three advisory **SessionStart** hooks `inject-initiative.sh`,
+  `inject-where-are-we.sh`, `inject-doc-freshness.sh` (HIMMEL-596) for the same
+  root-resolution reason. These are advisory (always exit 0) and emit their
+  `<system-reminder>` on stdout, so `codex-hook-adapter.sh` wraps a
+  SessionStart/UserPromptSubmit hook's output into the
+  `hookSpecificOutput.additionalContext` JSON channel (raw stdout is not a
+  reliable Codex context channel). The wrap is gated on the **event**, not the
+  exit code (any exit code → additionalContext; these events have no deny path).
+  Adding hooks re-trust-hashes `.codex/hooks.json` on the next Codex session.
 - **`run-hook.cmd`** — a **polyglot** wrapper (cmd.exe batch on Windows, bash on
   Unix) that fixes the three reasons the old hand-ported `.codex/hooks.json` did
   **not** block on Windows under Codex:
@@ -62,6 +71,10 @@ exit code propagated, an **exit-2 block translated to a JSON `deny`** (stderr �
 reason), and fail-closed JSON denies for wrapper/adapter precondition failures.
 The Windows test also covers Git Bash startup failure before adapter execution,
 plus explicit `--sandbox` and diagnostic `--no-sandbox` modes.
+- `scripts/hooks/test-codex-sessionstart-hooks.sh` — asserts the three advisory
+  SessionStart hooks (HIMMEL-596) are wired through `run-hook.cmd --sandbox`, the
+  strict schema holds, and `inject-initiative` fires end-to-end through the
+  adapter as `additionalContext` JSON (gate ON) / no-op (gate OFF).
 
 ## Setup modes
 - **Sandboxed project hooks (recommended):** use the tracked `.codex/hooks.json`

--- a/.codex/codex-hook-adapter.sh
+++ b/.codex/codex-hook-adapter.sh
@@ -79,6 +79,32 @@ script="$proj/scripts/hooks/$name"
 
 input="$(cat)"
 
+# Inbound lifecycle event, parsed once. SessionStart / UserPromptSubmit are
+# advisory CONTEXT events with no permission gate. Under Codex a hook feeds the
+# model via `hookSpecificOutput.additionalContext`, NOT raw stdout — that JSON
+# channel is exactly why HIMMEL-565 added emit_context. So for these two events
+# the guardrail's output (stdout for an exit-0 advisory hook like
+# inject-initiative / inject-where-are-we / inject-doc-freshness; stderr for a
+# defensive exit-2) is captured and re-emitted through emit_context; empty output
+# → nothing injected, exit 0. This is what makes himmel's advisory SessionStart /
+# UserPromptSubmit hooks actually FIRE under Codex (HIMMEL-596) instead of being
+# wired-but-inert. PreToolUse / PermissionRequest / PostToolUse keep the
+# stdout-passthrough contract below (auto-approve emits its JSON decision on
+# stdout — it MUST pass through verbatim, so it must NOT be wrapped).
+ev="$(printf '%s' "$input" | jq -r '.hook_event_name // "PreToolUse"' 2>/dev/null || echo PreToolUse)"
+case "$ev" in
+  SessionStart|UserPromptSubmit)
+    # Combine stdout+stderr (an advisory context message has no separate channels
+    # to preserve) and run the guardrail exactly once. $(...) strips trailing
+    # newlines; also drop a stray CR (Windows). emit_context exits 0; an empty
+    # body is an advisory no-op (exit 0) — these hooks never block session start.
+    cbody="$( printf '%s' "$input" | bash "$script" 2>&1 )"
+    cbody="${cbody%$'\r'}"
+    [ -n "$cbody" ] && emit_context "$cbody" "$ev"
+    exit 0
+    ;;
+esac
+
 # Run the guardrail with the hook JSON on stdin. Capture its STDERR into a var
 # while its STDOUT (e.g. an auto-approve decision) passes straight through to the
 # real stdout (fd 3). No temp files: Codex runs hooks inside the tool sandbox
@@ -95,7 +121,8 @@ reason="${captured%EXIT:*}"
 reason="${reason%$'\n'}"; reason="${reason%$'\r'}"   # drop the guardrail's trailing CR/LF
 
 if [ "$code" = "2" ]; then
-  ev="$(printf '%s' "$input" | jq -r '.hook_event_name // "PreToolUse"' 2>/dev/null || echo PreToolUse)"
+  # ev parsed above; SessionStart/UserPromptSubmit already returned, so this only
+  # sees PreToolUse/PermissionRequest (→ deny) and PostToolUse/unknown (→ context).
   case "$ev" in
     PreToolUse|PermissionRequest)
       # Block: translate to Codex's JSON deny. hookEventName mirrors the inbound event.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -51,7 +51,10 @@
     "SessionStart": [
       {
         "hooks": [
-          { "type": "command", "command": ".codex/run-hook.cmd --sandbox check-update-available.sh", "timeout": 15 }
+          { "type": "command", "command": ".codex/run-hook.cmd --sandbox check-update-available.sh", "timeout": 15 },
+          { "type": "command", "command": ".codex/run-hook.cmd --sandbox inject-initiative.sh", "timeout": 10 },
+          { "type": "command", "command": ".codex/run-hook.cmd --sandbox inject-where-are-we.sh", "timeout": 15 },
+          { "type": "command", "command": ".codex/run-hook.cmd --sandbox inject-doc-freshness.sh", "timeout": 10 }
         ]
       }
     ],

--- a/docs/internals/harness-compat.md
+++ b/docs/internals/harness-compat.md
@@ -126,6 +126,34 @@ execution, then exits 2 only to feed its "write a handover now" message to the
 model — previously the adapter mistranslated that to a **bogus PreToolUse deny**
 (wrong event, and a permission gate for a tool that already ran).
 
+**Advisory SessionStart/UserPromptSubmit wiring (HIMMEL-596).** Three advisory
+SessionStart hooks (`inject-initiative`, `inject-where-are-we`,
+`inject-doc-freshness`) are wired into `.codex/hooks.json` SessionStart via
+`run-hook.cmd --sandbox`, alongside `check-update-available`. Because these hooks
+deliver their `<system-reminder>` on **stdout at exit 0** (not exit 2), the
+adapter now wraps such a hook's output into the SAME
+`hookSpecificOutput.additionalContext` JSON channel. The wrap is **gated on the
+event** (`hook_event_name ∈ {SessionStart, UserPromptSubmit}`), NOT on the exit
+code: it captures the combined output and always exits 0 (exit-0 stdout AND a
+defensive exit-2's stderr both funnel to additionalContext — there is no deny
+path for these no-permission-gate events). Event-gating means it never touches
+the PreToolUse stdout-decision passthrough (auto-approve's JSON `allow` must pass
+verbatim). Raw stdout is NOT a reliable Codex context channel (the JSON
+`additionalContext` field is — same reasoning as the 565 exit-2 path), so the
+wrap is correct-by-construction whether or not Codex also honours raw stdout.
+**Verification scope:** the fixture
+(`scripts/hooks/test-codex-sessionstart-hooks.sh`) proves the adapter emits the
+`additionalContext` JSON end-to-end through `run-hook.cmd`; a **live Codex
+SessionStart probe** (does Codex inject that additionalContext into the model at
+session start?) remains pending — the same open follow-up as the 565 PostToolUse
+probe, and it also retroactively covers the pre-existing `check-update-available`
+wiring. Two operational notes: (a) adding hooks changes the trusted set, so the
+next Codex session re-trust-hashes `.codex/hooks.json` (non-interactive
+`codex exec` needs `--dangerously-bypass-hook-trust` until trusted); (b)
+`inject-where-are-we`'s detached background ledger refresh likely won't survive
+Codex's hook sandbox, so under Codex the synchronous render still fires but the
+ledger may not refresh (known limitation; the render is the load-bearing half).
+
 The guardrails stay single-sourced — they keep working verbatim under Claude
 Code, which never invokes the adapter (only `.codex/hooks.json` does). Verified
 live against codex-cli 0.141.0: a secret read (`block-read-secrets`) is
@@ -168,9 +196,13 @@ and `block-merged-pr-commit.sh` (HIMMEL-512) — resolve their script via
 hooks (plugin hooks get `CLAUDE_PLUGIN_ROOT` instead — see §1), so under Codex
 the wrapper's `[ -f "$h" ]` was false and the guards silently no-op'd
 (root-equivalent docker mounts + merged-PR commits went unguarded). Fix: mirror both into `.codex/hooks.json` via `run-hook.cmd`, which
-derives the root from its own location. The non-security plugin hooks
-(`inject-where-are-we` / `refresh-where-are-we-on-end`) share the same
-root-resolution bug and stay broken under Codex pending HIMMEL-554.
+derives the root from its own location. The non-security plugin SessionStart
+hooks (`inject-where-are-we` / `inject-doc-freshness`) shared the same
+root-resolution bug; **HIMMEL-596** mirrors them (plus `inject-initiative`) into
+`.codex/hooks.json` SessionStart with the exit-0 `additionalContext` wrap above
+(live Codex firing pending a probe). The SessionEnd half
+(`refresh-where-are-we-on-end`) is still pending — leg HIMMEL-599 (SessionEnd →
+Codex `Stop`).
 
 ### 2. Instruction file — CLAUDE.md is invisible; AGENTS.md must carry the rules
 

--- a/scripts/hooks/test-codex-sessionstart-hooks.sh
+++ b/scripts/hooks/test-codex-sessionstart-hooks.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Regression test (HIMMEL-596): the three ADVISORY SessionStart hooks
+# (inject-initiative, inject-where-are-we, inject-doc-freshness) must FIRE under
+# Codex.
+#
+# Background. inject-initiative ships via .claude/settings.json; inject-where-are-we
+# + inject-doc-freshness ship via the himmel-ops plugin hooks.json with a wrapper
+# `h="$CLAUDE_PROJECT_DIR/scripts/hooks/<h>.sh"; [ -f "$h" ] && exec bash "$h"`.
+# Codex injects CLAUDE_PLUGIN_ROOT for plugin hooks but NOT CLAUDE_PROJECT_DIR
+# (and nothing for project hooks), so under Codex `$h` resolves empty,
+# `[ -f "$h" ]` is false, and the hook SILENTLY NO-OPS — initiative / overnight
+# mode, the where-are-we ledger, and the doc-freshness nudge never fire. Fix:
+# wire all three into .codex/hooks.json SessionStart via run-hook.cmd --sandbox
+# (the wrapper derives the repo root from its OWN location, harness-agnostically),
+# exactly like check-update-available (the existing advisory SessionStart hook)
+# and the HIMMEL-589 security guards.
+#
+# This suite asserts:
+#   1) STATIC WIRING — each of the 3 hooks (+ retained check-update-available) is
+#      wired into .codex/hooks.json SessionStart through run-hook.cmd; no raw
+#      $CLAUDE_PROJECT_DIR/bare-bash path remains; the file parses and carries
+#      ONLY a top-level `hooks` key (Codex's deny_unknown_fields strict schema).
+#   2) BEHAVIORAL (advisory passthrough, end-to-end) — running the WIRED
+#      inject-initiative command through run-hook.cmd (bash branch) with the Codex
+#      env simulated (CLAUDE_PROJECT_DIR UNSET) emits its <system-reminder> on
+#      STDOUT and exits 0 when the gate is ON, and emits nothing (exit 0) when the
+#      gate is OFF. inject-initiative is pure local env+prose (no node/network),
+#      so this is hermetic and proves a real advisory SessionStart hook fires
+#      through the adapter under Codex.
+#   3) SMOKE — inject-where-are-we + inject-doc-freshness run through their wired
+#      command without crashing the wrapper (rc 0), tolerating empty output (their
+#      full inject behavior is covered by their own test-inject-*.sh under Claude).
+#
+# Hermetic: no network, no .env required (process env wins via load_dotenv's
+# non-clobber). The Windows cmd.exe branch of run-hook.cmd is covered by the
+# existing .ps1 twin (test-codex-run-hook.ps1). bash 3.2-safe.
+set -uo pipefail
+
+HOOKS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HOOKS_DIR/../.." && pwd)"
+HOOKS_JSON="$REPO_ROOT/.codex/hooks.json"
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf '  FAIL %s\n' "$1"; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq not on PATH — required for this test" >&2; exit 1
+fi
+[ -f "$HOOKS_JSON" ] || { echo ".codex/hooks.json not found: $HOOKS_JSON" >&2; exit 1; }
+
+# Extract the (first) SessionStart hook command wiring a given hook filename.
+wired_cmd() {
+  jq -r --arg h "$1" \
+    '.hooks.SessionStart[]?.hooks[]?.command // empty | select(contains($h))' \
+    "$HOOKS_JSON" 2>/dev/null | head -1
+}
+
+# Run a hook via its WIRED .codex/hooks.json command, simulating the Codex env
+# (CLAUDE_PROJECT_DIR UNSET — run-hook.cmd must re-derive + export it). Extra args
+# are env overrides (e.g. HIMMEL_INITIATIVE=all). Feeds an empty SessionStart
+# payload on stdin. Prints the command's stdout.
+#
+# Hermeticity: also strip the overnight-profile vars so an ambient
+# HIMMEL_OVERNIGHT in the launching shell can't flip inject-initiative's
+# resolve_legs onto HIMMEL_INITIATIVE_OVERNIGHT and turn the gate-ON case into a
+# false red (the .env load is non-clobbering, so this guards only process-env
+# leakage). CR: pr-test-analyzer HIMMEL-596.
+HOOK_ENV_CLEAN="-u CLAUDE_PROJECT_DIR -u HIMMEL_OVERNIGHT -u HIMMEL_INITIATIVE_OVERNIGHT"
+run_codex_hook() {
+  local hook="$1"; shift
+  local cmd; cmd="$(wired_cmd "$hook")"
+  if [ -z "$cmd" ]; then printf '__NOT_WIRED__'; return; fi
+  # shellcheck disable=SC2086 # $HOOK_ENV_CLEAN flags + $cmd are intentional splits
+  ( cd "$REPO_ROOT" && printf '{"hook_event_name":"SessionStart"}' \
+      | env $HOOK_ENV_CLEAN "$@" bash $cmd 2>/dev/null )
+}
+
+# ── 1) Static wiring: all advisory SessionStart hooks routed via run-hook.cmd ──
+for h in inject-initiative.sh inject-where-are-we.sh inject-doc-freshness.sh check-update-available.sh; do
+  c="$(wired_cmd "$h")"
+  if [ -n "$c" ]; then ok "$h wired into .codex/hooks.json SessionStart"; else bad "$h wired into .codex/hooks.json SessionStart"; fi
+  case "$c" in *run-hook.cmd*) ok "$h routed through run-hook.cmd";; *) bad "$h routed through run-hook.cmd (got: ${c:-<none>})";; esac
+  case "$c" in *--sandbox*) ok "$h uses --sandbox mode";; *) bad "$h uses --sandbox mode (got: ${c:-<none>})";; esac
+done
+
+# No raw $CLAUDE_PROJECT_DIR / bare-bash path may remain in any SessionStart cmd
+# (that is exactly the under-Codex no-op bug this ticket fixes).
+raw="$(jq -r '.hooks.SessionStart[]?.hooks[]?.command // empty | select(contains("CLAUDE_PROJECT_DIR"))' "$HOOKS_JSON" 2>/dev/null)"
+if [ -z "$raw" ]; then ok "no raw \$CLAUDE_PROJECT_DIR path in any SessionStart command"; else bad "raw \$CLAUDE_PROJECT_DIR path present: $raw"; fi
+
+# Strict schema: file parses, and the ONLY top-level key is `hooks`
+# (Codex's deny_unknown_fields rejects any extra top-level key).
+if jq -e . "$HOOKS_JSON" >/dev/null 2>&1; then ok ".codex/hooks.json is valid JSON"; else bad ".codex/hooks.json is valid JSON"; fi
+# Assert the ONLY top-level key is `hooks` directly in jq (no string munging — a
+# trailing CR on Windows Git Bash would defeat a shell `=` compare).
+if jq -e 'keys == ["hooks"]' "$HOOKS_JSON" >/dev/null 2>&1; then
+  ok "strict schema: only top-level 'hooks' key"
+else
+  bad "strict schema: only top-level 'hooks' key (got: $(jq -rc 'keys' "$HOOKS_JSON" 2>/dev/null))"
+fi
+
+# ── 2) Behavioral: inject-initiative FIRES through the adapter under Codex ────
+# The boundary that matters is NOT "run-hook.cmd emits stdout" (the security
+# guards already prove passthrough) but "Codex receives the directive as
+# context". Under Codex that channel is hookSpecificOutput.additionalContext, so
+# the adapter wraps an advisory SessionStart hook's exit-0 output into that JSON
+# (HIMMEL-596). Gate ON: HIMMEL_INITIATIVE=all → resolve_legs yields a non-empty
+# interactive set → the directive is emitted as additionalContext JSON, exit 0.
+# CLAUDE_PROJECT_DIR is UNSET, so this also proves run-hook.cmd re-derives the
+# repo root under Codex.
+on_out="$(run_codex_hook inject-initiative.sh HIMMEL_INITIATIVE=all)"
+if printf '%s' "$on_out" | jq -e '.hookSpecificOutput.hookEventName == "SessionStart"' >/dev/null 2>&1; then
+  ok "inject-initiative: gate ON → emitted as SessionStart additionalContext JSON"
+else
+  bad "inject-initiative: gate ON → SessionStart additionalContext JSON (got: ${on_out:-<empty>})"
+fi
+if printf '%s' "$on_out" | jq -e '.hookSpecificOutput.additionalContext | contains("is active")' >/dev/null 2>&1; then
+  ok "inject-initiative: gate ON → additionalContext carries the directive"
+else
+  bad "inject-initiative: gate ON → additionalContext carries the directive (got: ${on_out:-<empty>})"
+fi
+
+# Gate OFF: HIMMEL_INITIATIVE=off → empty set → no output, exit 0.
+off_out="$(run_codex_hook inject-initiative.sh HIMMEL_INITIATIVE=off)"
+if [ -z "$off_out" ]; then ok "inject-initiative: gate OFF → no output"; else bad "inject-initiative: gate OFF → no output (got: $off_out)"; fi
+off_cmd="$(wired_cmd inject-initiative.sh)"
+# shellcheck disable=SC2086 # $HOOK_ENV_CLEAN flags + $off_cmd are intentional splits
+( cd "$REPO_ROOT" && printf '{"hook_event_name":"SessionStart"}' | env $HOOK_ENV_CLEAN HIMMEL_INITIATIVE=off bash $off_cmd >/dev/null 2>&1 ); off_rc=$?
+if [ "$off_rc" -eq 0 ]; then ok "inject-initiative: gate OFF → exit 0 (advisory, never blocks)"; else bad "inject-initiative: gate OFF → exit 0 (got rc=$off_rc)"; fi
+
+# ── 3) Smoke: the node/git advisory hooks run through the wrapper, rc 0 ──────
+# They may legitimately emit nothing on a bare runner (gated off / no node / no
+# origin-main ref); the contract under test is "advisory → never crashes the
+# wrapper, exit 0". Full inject behavior is covered by their own test-inject-*.sh.
+for h in inject-where-are-we.sh inject-doc-freshness.sh; do
+  h_cmd="$(wired_cmd "$h")"
+  # shellcheck disable=SC2086 # $HOOK_ENV_CLEAN flags + $h_cmd are intentional splits
+  ( cd "$REPO_ROOT" && printf '{"hook_event_name":"SessionStart"}' | env $HOOK_ENV_CLEAN bash $h_cmd >/dev/null 2>&1 ); rc=$?
+  if [ "$rc" -eq 0 ]; then ok "$h: runs through run-hook.cmd, exit 0 (advisory)"; else bad "$h: runs through run-hook.cmd, exit 0 (got rc=$rc)"; fi
+done
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Wire inject-initiative/inject-where-are-we/inject-doc-freshness into .codex/hooks.json via run-hook.cmd; adapter wraps exit-0 SessionStart/UserPromptSubmit output into hookSpecificOutput.additionalContext (event-gated).