### PR TITLE
feat(codex): [HIMMEL-599] port SessionEnd hooks to Codex Stop event

### DIFF
--- a/.codex/codex-hook-adapter.sh
+++ b/.codex/codex-hook-adapter.sh
@@ -103,6 +103,24 @@ case "$ev" in
     [ -n "$cbody" ] && emit_context "$cbody" "$ev"
     exit 0
     ;;
+  Stop)
+    # SessionEnd-class hooks (HIMMEL-599): refresh-where-are-we-on-end,
+    # jira-nudge-on-end, end-session-wiki. Unlike SessionStart/UserPromptSubmit,
+    # Codex's stop.command.output schema has NO additionalContext / hookSpecificOutput
+    # — only a continue/decision/systemMessage gate. himmel's SessionEnd hooks are
+    # ADVISORY + side-effecting (refresh the ledger / write the session note / nudge
+    # via Telegram) and must NEVER block teardown. So run the hook for its side
+    # effects and route any stdout+stderr to OUR stderr as advisory — NOT to Codex's
+    # Stop *decision* parser (raw advisory text there is mis-parsed), and NOT through
+    # the generic exit-2 path (which would emit a hookSpecificOutput shape Stop's
+    # strict deny_unknown_fields schema rejects). Always exit 0. Under Codex,
+    # jira-nudge's operator surface is its Telegram relay, not this stdout. $(...)
+    # strips trailing newlines; drop a stray CR (Windows). Empty body = no-op.
+    cbody="$( printf '%s' "$input" | bash "$script" 2>&1 )"
+    cbody="${cbody%$'\r'}"
+    [ -n "$cbody" ] && printf '%s\n' "$cbody" >&2
+    exit 0
+    ;;
 esac
 
 # Run the guardrail with the hook JSON on stdin. Capture its STDERR into a var
@@ -121,8 +139,8 @@ reason="${captured%EXIT:*}"
 reason="${reason%$'\n'}"; reason="${reason%$'\r'}"   # drop the guardrail's trailing CR/LF
 
 if [ "$code" = "2" ]; then
-  # ev parsed above; SessionStart/UserPromptSubmit already returned, so this only
-  # sees PreToolUse/PermissionRequest (→ deny) and PostToolUse/unknown (→ context).
+  # ev parsed above; SessionStart/UserPromptSubmit/Stop already returned, so this
+  # only sees PreToolUse/PermissionRequest (→ deny) and PostToolUse/unknown (→ context).
   case "$ev" in
     PreToolUse|PermissionRequest)
       # Block: translate to Codex's JSON deny. hookEventName mirrors the inbound event.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -64,6 +64,15 @@
           { "type": "command", "command": ".codex/run-hook.cmd --sandbox improve-on-submit.sh" }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": ".codex/run-hook.cmd --sandbox refresh-where-are-we-on-end.sh", "timeout": 15 },
+          { "type": "command", "command": ".codex/run-hook.cmd --sandbox jira-nudge-on-end.sh", "timeout": 15 },
+          { "type": "command", "command": ".codex/run-hook.cmd --sandbox end-session-wiki.sh", "timeout": 30 }
+        ]
+      }
     ]
   }
 }

--- a/docs/internals/harness-compat.md
+++ b/docs/internals/harness-compat.md
@@ -200,9 +200,43 @@ derives the root from its own location. The non-security plugin SessionStart
 hooks (`inject-where-are-we` / `inject-doc-freshness`) shared the same
 root-resolution bug; **HIMMEL-596** mirrors them (plus `inject-initiative`) into
 `.codex/hooks.json` SessionStart with the exit-0 `additionalContext` wrap above
-(live Codex firing pending a probe). The SessionEnd half
-(`refresh-where-are-we-on-end`) is still pending — leg HIMMEL-599 (SessionEnd →
-Codex `Stop`).
+(live Codex firing pending a probe).
+
+**SessionEnd → Codex `Stop` (HIMMEL-596 follow-up, HIMMEL-599).** himmel's three
+SessionEnd hooks — `refresh-where-are-we-on-end` + `jira-nudge-on-end` (himmel-ops
+plugin) and `end-session-wiki` (user-scope settings-template) — are now wired into
+a `.codex/hooks.json` **`Stop`** key via `run-hook.cmd --sandbox`, the same
+root-resolution fix. Stop is a real Codex event (one of 10); its **input** schema
+(`stop.command.input`) carries `cwd` + `transcript_path` (both consumed by the
+hooks; it has no `reason` field — `last_assistant_message`/`stop_hook_active`
+instead — but `end-session-wiki` reads `.reason // "other"` harmlessly). Unlike
+SessionStart, the Stop **output** schema (`stop.command.output`) has **no
+`additionalContext` / `hookSpecificOutput`** — only a `continue`/`decision`/
+`systemMessage` gate. So the adapter does NOT wrap Stop output as
+`additionalContext`; it has a dedicated **`Stop` branch** that runs the hook for
+its side effects, routes any output to the adapter's stderr as advisory (never to
+Codex's Stop *decision* parser, and never through the generic exit-2 path that
+would emit a `hookSpecificOutput` shape Stop's strict `deny_unknown_fields` schema
+rejects), and always exits 0 — a SessionEnd advisory hook must never block
+teardown. `jira-nudge`'s operator-reaching surface under Codex is its Telegram
+relay, not stdout. Covered by the no-token fixture
+`scripts/hooks/test-codex-stop-hooks.sh` (static wiring + behavioral, incl. a
+gate-ON nudge case and the exit-2-protection case).
+
+**Caveats (do not overclaim).** (1) `end-session-wiki.sh` self-guards out on
+`msys*/cygwin*/Windows_NT` (its `.ps1` twin is the Windows-Claude path, and
+`run-hook.cmd` is bash-only), so under Codex on **Windows it captures nothing** —
+only `refresh-where-are-we-on-end` + `jira-nudge-on-end` (no platform guard) fire
+there (2/3). end-session-wiki capture works on **Linux/macOS/VM Codex**. (2) Even
+where it fires, its config path (`$CLAUDE_PROJECT_DIR/.claude/end-session-wiki.json`)
+may be Codex-blind (the Codex setup writes elsewhere), so it can capture to a
+default/possibly-wrong vault rather than the configured one (separate gap). (3)
+Side effects need a `workspace-write` sandbox (Codex suppresses hook writes under
+`-s read-only`). (4) `end-session-wiki` runs synchronously (transcript scan + a
+`curl` with no `-m` timeout) and can block teardown to its `timeout: 30`. (5)
+Whether Codex fires `Stop` on `codex exec` exit (vs only interactive) is unprobed.
+A **live Codex `Stop` probe** is the follow-up (same posture as 565/596; the
+fixture is the gate now).
 
 ### 2. Instruction file — CLAUDE.md is invisible; AGENTS.md must carry the rules
 

--- a/scripts/hooks/test-codex-run-hook.ps1
+++ b/scripts/hooks/test-codex-run-hook.ps1
@@ -93,13 +93,15 @@ try {
 
     # 2e) Unknown/garbage inbound event on exit-2 normalises to PostToolUse — never
     #     echoes the raw event string into the hookEventName const, never a deny.
+    #     Use a clearly-bogus event name: `Stop` is now a first-class adapter branch
+    #     (HIMMEL-599), so it is no longer "unknown".
     Push-Location $T
-    $unkout = ('{"hook_event_name":"Stop"}' | & cmd.exe /c '.codex\run-hook.cmd' blocker.sh 2>&1 | Out-String)
+    $unkout = ('{"hook_event_name":"BogusEvent"}' | & cmd.exe /c '.codex\run-hook.cmd' blocker.sh 2>&1 | Out-String)
     $unkrc = $LASTEXITCODE
     Pop-Location
     Check "unknown-event exit-2 -> wrapper exits 0" ($unkrc -eq 0)
     Check "unknown-event exit-2 -> normalised to PostToolUse" ($unkout -match '"hookEventName":"PostToolUse"')
-    Check "unknown-event exit-2 -> must NOT echo the raw event string" ($unkout -notmatch '"Stop"')
+    Check "unknown-event exit-2 -> must NOT echo the raw event string" ($unkout -notmatch '"BogusEvent"')
     Check "unknown-event exit-2 -> must NOT emit a permission decision" ($unkout -notmatch 'permissionDecision')
 
     # 3) FAIL-CLOSED paths: a bare exit 2 fails OPEN under Codex, so precondition

--- a/scripts/hooks/test-codex-run-hook.sh
+++ b/scripts/hooks/test-codex-run-hook.sh
@@ -130,15 +130,16 @@ esac
 # 2e) Unknown/garbage inbound event on exit-2 is NORMALISED to PostToolUse — it
 #     must NOT echo the attacker-controllable event string into the hookEventName
 #     const (Codex's strict parser would reject it, dropping the message), and
-#     must NOT become a permission deny.
-unkout="$(printf '{"hook_event_name":"Stop"}\n' | bash "$T/.codex/run-hook.cmd" blocker.sh)"; unkrc=$?
+#     must NOT become a permission deny. Use a clearly-bogus event name: `Stop` is
+#     now a first-class adapter branch (HIMMEL-599), so it is no longer "unknown".
+unkout="$(printf '{"hook_event_name":"BogusEvent"}\n' | bash "$T/.codex/run-hook.cmd" blocker.sh)"; unkrc=$?
 if [ "$unkrc" -eq 0 ]; then ok "unknown-event exit-2 -> wrapper exits 0"; else bad "unknown-event exit-2 -> wrapper exits 0 (got $unkrc)"; fi
 case "$unkout" in
   *'"hookEventName":"PostToolUse"'*) ok "unknown-event exit-2 -> normalised to PostToolUse";;
   *) bad "unknown-event exit-2 -> normalised to PostToolUse ($unkout)";;
 esac
 case "$unkout" in
-  *'"Stop"'*) bad "unknown-event exit-2 -> must NOT echo the raw event string ($unkout)";;
+  *'"BogusEvent"'*) bad "unknown-event exit-2 -> must NOT echo the raw event string ($unkout)";;
   *) ok "unknown-event exit-2 -> raw event string not echoed";;
 esac
 case "$unkout" in

--- a/scripts/hooks/test-codex-stop-hooks.sh
+++ b/scripts/hooks/test-codex-stop-hooks.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Regression test (HIMMEL-599): himmel's SessionEnd hooks must FIRE under Codex
+# via the Stop lifecycle event.
+#
+# Background. himmel has three SessionEnd hooks: refresh-where-are-we-on-end +
+# jira-nudge-on-end (himmel-ops plugin hooks.json, exec-if-exists via
+# $CLAUDE_PROJECT_DIR) and end-session-wiki (user-scope settings-template via
+# run-pwsh.sh + the .sh twin). Under Codex none of them ran: .codex/hooks.json had
+# no Stop key, and the plugin wrapper's $CLAUDE_PROJECT_DIR is unset under Codex
+# (the same no-op class HIMMEL-596 fixed for SessionStart). Fix: wire all three
+# into .codex/hooks.json Stop via run-hook.cmd --sandbox.
+#
+# Stop is SIDE-EFFECTING, not context-injecting. The authoritative Codex
+# stop.command.output schema carries NO additionalContext / hookSpecificOutput
+# (only continue/decision[block]/reason/stopReason/suppressOutput/systemMessage).
+# So the adapter must NOT wrap a Stop hook's output as additionalContext, and it
+# must NOT feed the hook's stdout to Codex's Stop *decision* parser (raw advisory
+# text there is mis-parsed; the generic exit-2 path would emit a hookSpecificOutput
+# shape Stop's strict deny_unknown_fields schema rejects). codex-hook-adapter.sh
+# therefore has a dedicated Stop branch: run the hook for its side effects, route
+# any output to the adapter's stderr as advisory, always exit 0 (a SessionEnd
+# advisory hook never blocks teardown). jira-nudge's operator-reaching surface
+# under Codex is its Telegram relay, not stdout.
+#
+# This suite asserts:
+#   1) STATIC WIRING - each of the 3 SessionEnd hooks is wired into
+#      .codex/hooks.json Stop through run-hook.cmd --sandbox; no raw
+#      $CLAUDE_PROJECT_DIR/bare-bash path remains; the file parses and carries ONLY
+#      a top-level `hooks` key (Codex deny_unknown_fields strict schema).
+#   2) BEHAVIORAL smoke (Codex env simulated, gates OFF) - each wired Stop hook runs
+#      through run-hook.cmd and exits 0 emitting NO hookSpecificOutput on stdout
+#      (proves the Stop branch is taken, not the additionalContext wrap, and that an
+#      advisory hook never blocks teardown).
+#   3) BEHAVIORAL positive (jira-nudge gate ON, hermetic temp git repo) - the nudge
+#      reaches the adapter's STDERR as advisory and is NOT on stdout / NOT a
+#      hookSpecificOutput JSON. Directly validates the Stop-branch design (vs the
+#      vacuous gated-off "no JSON").
+#   4) EXIT-2 protection (adapter direct, temp CLAUDE_PROJECT_DIR fixture) - a Stop
+#      hook that exits 2 emitting hookSpecificOutput-looking stdout still yields
+#      adapter exit 0 with NO hookSpecificOutput on stdout (locks in that Stop never
+#      reaches the generic exit-2 branch -> no Stop-schema-invalid output).
+#
+# Hermetic: gate vars are set EXPLICITLY =0 (the plugin hooks load_dotenv their
+# gate from the clone's .env non-clobbering, so merely unsetting would load ON on a
+# dogfooding machine and the test would go LIVE). Ambient HIMMEL_* profile vars are
+# stripped and HOME is pointed at a temp dir (so no HOME-rooted lookup -- vault
+# resolution, jira breadcrumb store -- ever touches real machine state). No network,
+# no real Telegram (relay stubbed). bash 3.2-safe. The run-hook.cmd cmd.exe branch is
+# covered by the existing .ps1 twin (test-codex-run-hook.ps1).
+#
+# Coverage note: end-session-wiki.sh self-guards out on msys*/cygwin*/Windows_NT
+# (its .ps1 is the Windows-Claude path; run-hook.cmd is bash-only), so on a Windows
+# Git-Bash runner its section-2 smoke is a trivial exit-0 -- its Stop routing is
+# exercised end-to-end only on POSIX. The adapter Stop branch itself is fully
+# covered cross-platform by sections 3 (nudge) + 4 (stub).
+set -uo pipefail
+
+HOOKS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HOOKS_DIR/../.." && pwd)"
+HOOKS_JSON="$REPO_ROOT/.codex/hooks.json"
+ADAPTER="$REPO_ROOT/.codex/codex-hook-adapter.sh"
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf '  FAIL %s\n' "$1"; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq not on PATH - required for this test" >&2; exit 1
+fi
+command -v git >/dev/null 2>&1 || { echo "git not on PATH - required for this test" >&2; exit 1; }
+[ -f "$HOOKS_JSON" ] || { echo ".codex/hooks.json not found: $HOOKS_JSON" >&2; exit 1; }
+[ -f "$ADAPTER" ]    || { echo "adapter not found: $ADAPTER" >&2; exit 1; }
+
+TMP_ROOT="$(mktemp -d 2>/dev/null || mktemp -d -t himmel599)"
+trap 'rm -rf "$TMP_ROOT" 2>/dev/null || true' EXIT
+
+# Extract the (first) Stop hook command wiring a given hook filename.
+wired_cmd() {
+  jq -r --arg h "$1" \
+    '.hooks.Stop[]?.hooks[]?.command // empty | select(contains($h))' \
+    "$HOOKS_JSON" 2>/dev/null | head -1
+}
+
+# A minimal Codex Stop input payload. $1 = cwd, $2 = transcript_path (empty -> null).
+stop_payload() {
+  if [ -n "${2:-}" ]; then
+    jq -cn --arg cwd "$1" --arg tp "$2" \
+      '{hook_event_name:"Stop",cwd:$cwd,transcript_path:$tp,session_id:"t",turn_id:"t",model:"m",permission_mode:"default",last_assistant_message:null,stop_hook_active:false}'
+  else
+    jq -cn --arg cwd "$1" \
+      '{hook_event_name:"Stop",cwd:$cwd,transcript_path:null,session_id:"t",turn_id:"t",model:"m",permission_mode:"default",last_assistant_message:null,stop_hook_active:false}'
+  fi
+}
+
+# Strip ambient profile/initiative vars so a launching shell that has them ON
+# (overnight/initiative sessions, dogfooded gates) can't flip a hook live and turn
+# a gated-OFF assertion into a false red. Gate vars are then set explicitly per case.
+ENV_CLEAN="-u CLAUDE_PROJECT_DIR -u HIMMEL_OVERNIGHT -u HIMMEL_INITIATIVE_OVERNIGHT -u HIMMEL_INITIATIVE -u HIMMEL_WHERE_ARE_WE -u HIMMEL_JIRA_NUDGE"
+
+STOP_HOOKS="refresh-where-are-we-on-end.sh jira-nudge-on-end.sh end-session-wiki.sh"
+
+# == 1) Static wiring ========================================================
+for h in $STOP_HOOKS; do
+  c="$(wired_cmd "$h")"
+  if [ -n "$c" ]; then ok "$h wired into .codex/hooks.json Stop"; else bad "$h wired into .codex/hooks.json Stop"; fi
+  case "$c" in *run-hook.cmd*) ok "$h routed through run-hook.cmd";; *) bad "$h routed through run-hook.cmd (got: ${c:-<none>})";; esac
+  case "$c" in *--sandbox*) ok "$h uses --sandbox mode";; *) bad "$h uses --sandbox mode (got: ${c:-<none>})";; esac
+done
+
+# No raw $CLAUDE_PROJECT_DIR / bare-bash path may remain in any Stop command (that
+# under-Codex no-op bug is exactly what this ticket fixes).
+raw="$(jq -r '.hooks.Stop[]?.hooks[]?.command // empty | select(contains("CLAUDE_PROJECT_DIR"))' "$HOOKS_JSON" 2>/dev/null)"
+if [ -z "$raw" ]; then ok "no raw \$CLAUDE_PROJECT_DIR path in any Stop command"; else bad "raw \$CLAUDE_PROJECT_DIR path present: $raw"; fi
+
+# Strict schema: file parses, and the ONLY top-level key is `hooks`.
+if jq -e . "$HOOKS_JSON" >/dev/null 2>&1; then ok ".codex/hooks.json is valid JSON"; else bad ".codex/hooks.json is valid JSON"; fi
+if jq -e 'keys == ["hooks"]' "$HOOKS_JSON" >/dev/null 2>&1; then
+  ok "strict schema: only top-level 'hooks' key"
+else
+  bad "strict schema: only top-level 'hooks' key (got: $(jq -rc 'keys' "$HOOKS_JSON" 2>/dev/null))"
+fi
+
+# == 2) Behavioral smoke: each Stop hook runs, exit 0, no hookSpecificOutput ==
+# Gates set EXPLICITLY =0 (see ENV_CLEAN note). CLAUDE_PROJECT_DIR unset -> proves
+# run-hook.cmd re-derives the repo root under Codex. cwd = REPO_ROOT (a real dir, so
+# jira-nudge's `[ -d cwd ]` precondition holds before it exits at the gate).
+SMOKE_PAYLOAD="$(stop_payload "$REPO_ROOT" "")"
+for h in $STOP_HOOKS; do
+  cmd="$(wired_cmd "$h")"
+  if [ -z "$cmd" ]; then bad "$h smoke: not wired (cannot run)"; continue; fi
+  out="$TMP_ROOT/smoke-$h.out"
+  # shellcheck disable=SC2086 # $ENV_CLEAN flags + $cmd are intentional splits
+  # HOME=$TMP_ROOT keeps any HOME-rooted lookup (vault resolution, breadcrumb store)
+  # off the real machine -- tests must never touch real data.
+  ( cd "$REPO_ROOT" && printf '%s' "$SMOKE_PAYLOAD" \
+      | env $ENV_CLEAN HOME="$TMP_ROOT" HIMMEL_WHERE_ARE_WE=0 HIMMEL_JIRA_NUDGE=0 CLAUDE_END_SESSION_WIKI=0 \
+        bash $cmd >"$out" 2>/dev/null ); rc=$?
+  if [ "$rc" -eq 0 ]; then ok "$h smoke: exit 0 (advisory, never blocks teardown)"; else bad "$h smoke: exit 0 (got rc=$rc)"; fi
+  if ! grep -q 'hookSpecificOutput' "$out" 2>/dev/null; then ok "$h smoke: no hookSpecificOutput on stdout"; else bad "$h smoke: stdout leaked hookSpecificOutput ($(cat "$out"))"; fi
+done
+
+# == 3) Behavioral positive: jira-nudge gate ON -> nudge on STDERR, not stdout ==
+# Hermetic temp git repo with a commit referencing TESTKEY-1 inside the session
+# window (transcript first-timestamp = far past), no breadcrumb, relay stubbed.
+NUDGE_REPO="$TMP_ROOT/nudgerepo"
+mkdir -p "$NUDGE_REPO"
+(
+  cd "$NUDGE_REPO" || exit 1
+  git init -q
+  git config user.email "t@example.com"
+  git config user.name  "t"
+  git config commit.gpgsign false
+  echo x > f.txt
+  git add f.txt
+  git commit -q -m "feat: TESTKEY-1 work"
+) >/dev/null 2>&1
+NUDGE_TS="$TMP_ROOT/transcript.jsonl"
+printf '%s\n' '{"timestamp":"2020-01-01T00:00:00Z"}' > "$NUDGE_TS"
+NUDGE_PAYLOAD="$(stop_payload "$NUDGE_REPO" "$NUDGE_TS")"
+nudge_cmd="$(wired_cmd jira-nudge-on-end.sh)"
+if [ -z "$nudge_cmd" ]; then
+  bad "jira-nudge positive: not wired (cannot run)"
+else
+  nout="$TMP_ROOT/nudge.out"; nerr="$TMP_ROOT/nudge.err"
+  # HIMMEL_INITIATIVE stripped (else the `ticket` leg would suppress the nudge);
+  # gate ON; JIRA_PROJECT_KEY injected (temp repo has no .env); relay -> `true`.
+  # HOME=$TMP_ROOT so the no-mutation breadcrumb check reads a temp store, never the
+  # real ~/.claude/jira-breadcrumbs (a stale machine-global file could otherwise
+  # suppress the nudge and false-FAIL this case).
+  # shellcheck disable=SC2086 # $ENV_CLEAN flags + $nudge_cmd are intentional splits
+  ( cd "$REPO_ROOT" && printf '%s' "$NUDGE_PAYLOAD" \
+      | env $ENV_CLEAN HOME="$TMP_ROOT" HIMMEL_JIRA_NUDGE=1 JIRA_PROJECT_KEY=TESTKEY JIRA_NUDGE_RELAY_CMD=true \
+        bash $nudge_cmd >"$nout" 2>"$nerr" ); rc=$?
+  if [ "$rc" -eq 0 ]; then ok "jira-nudge positive: adapter exit 0"; else bad "jira-nudge positive: adapter exit 0 (got rc=$rc)"; fi
+  if grep -q 'TESTKEY-1' "$nerr" 2>/dev/null; then ok "jira-nudge positive: nudge surfaced on adapter STDERR (advisory)"; else bad "jira-nudge positive: nudge expected on stderr (stderr: $(cat "$nerr" 2>/dev/null); stdout: $(cat "$nout" 2>/dev/null))"; fi
+  if [ ! -s "$nout" ]; then
+    ok "jira-nudge positive: stdout fully empty (nothing reaches Codex Stop decision parser)"
+  else
+    bad "jira-nudge positive: stdout not empty - leaked to Codex decision parser ($(cat "$nout" 2>/dev/null))"
+  fi
+fi
+
+# == 4) Exit-2 protection: adapter direct, stub hook exits 2 with JSON stdout ==
+# Proves the Stop branch swallows stdout (-> stderr) and exits 0 regardless, so a
+# Stop hook can never emit the generic exit-2 hookSpecificOutput shape that Stop's
+# strict output schema forbids.
+FIX="$TMP_ROOT/fixture"
+mkdir -p "$FIX/scripts/hooks"
+# The stub emits on BOTH stdout and stderr so this also exercises the Stop branch's
+# 2>&1 channel-merge: both must land on the adapter's stderr (advisory), never stdout.
+cat > "$FIX/scripts/hooks/stub-exit2.sh" <<'STUB'
+#!/usr/bin/env bash
+cat >/dev/null
+printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"x"}}\n'
+printf 'STUB-STDOUT\n'
+printf 'STUB-STDERR\n' >&2
+exit 2
+STUB
+chmod +x "$FIX/scripts/hooks/stub-exit2.sh" 2>/dev/null || true
+e2out="$TMP_ROOT/exit2.out"; e2err="$TMP_ROOT/exit2.err"
+printf '%s' "$(stop_payload "$FIX" "")" \
+  | env CLAUDE_PROJECT_DIR="$FIX" HOME="$TMP_ROOT" bash "$ADAPTER" stub-exit2.sh >"$e2out" 2>"$e2err"; rc=$?
+if [ "$rc" -eq 0 ]; then ok "exit-2 stub: adapter exit 0 (Stop never blocks)"; else bad "exit-2 stub: adapter exit 0 (got rc=$rc)"; fi
+if [ ! -s "$e2out" ]; then ok "exit-2 stub: stdout fully empty (no forbidden hookSpecificOutput; Stop bypasses generic exit-2 branch)"; else bad "exit-2 stub: stdout not empty ($(cat "$e2out"))"; fi
+if grep -q 'STUB-STDOUT' "$e2err" 2>/dev/null && grep -q 'STUB-STDERR' "$e2err" 2>/dev/null; then ok "exit-2 stub: hook stdout AND stderr both routed to adapter stderr (2>&1 merge, advisory)"; else bad "exit-2 stub: hook stdout+stderr not both on adapter stderr (stderr: $(cat "$e2err" 2>/dev/null))"; fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Port himmel's **SessionEnd** hooks to Codex's `Stop` lifecycle event. Before this,
`.codex/hooks.json` had no `Stop` key, so under Codex none of the three SessionEnd
hooks fired — session capture, the where-are-we ledger refresh, and the jira nudge
all silently no-op'd (the same class the SessionStart port fixed).

## How

- **`.codex/hooks.json`** — new `Stop` key wiring all three SessionEnd hooks via
  `run-hook.cmd --sandbox` (mirrors the SessionStart shape; no `matcher`; strict
  top-level-`hooks`-only schema preserved).
- **`.codex/codex-hook-adapter.sh`** — a dedicated `Stop` branch. Codex's
  `stop.command.output` schema has **no `additionalContext` / `hookSpecificOutput`**
  (only `continue`/`decision`/`systemMessage`), so Stop is NOT wrapped as
  additionalContext. The branch runs the hook for its side effects, routes any
  output to the adapter's stderr as advisory (never to Codex's Stop *decision*
  parser, never via the generic exit-2 path that would emit a `hookSpecificOutput`
  shape Stop's strict `deny_unknown_fields` rejects), and always exits 0 — a
  SessionEnd advisory hook never blocks teardown.
- **`scripts/hooks/test-codex-stop-hooks.sh`** (new) — static wiring + behavioral
  (gated-off smoke, a hermetic gate-ON nudge case, an exit-2 stub case).
- **`scripts/hooks/test-codex-run-hook.{sh,ps1}`** — `Stop` is now first-class, so
  the unknown-event-normalization case uses a clearly-bogus event name.
- **`docs/internals/harness-compat.md` §1** — documents the wiring + caveats
  (end-session-wiki self-guards on Windows; config-path blind spot;
  workspace-write requirement; no-curl-timeout; live Stop probe pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
