### PR TITLE
feat(codex): [HIMMEL-604] .agents/skills wrappers for the handover-flow cluster

### DIFF
--- a/.agents/skills/context-hop/SKILL.md
+++ b/.agents/skills/context-hop/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: context-hop
+description: Mid-session jump to a fresh claude session when the context window approaches the soft budget. Sibling of handover-arm-resume. Use when the user asks to context-hop or run /context-hop.
+---
+
+# context-hop
+
+When the user asks to context-hop, run:
+
+    bash scripts/handover/hop.sh [--message "what to pick up"] [--delay <minutes>] [--print] [--dry-run] [--force]
+
+Writes a point-in-time snapshot to the handover root, then schedules a relaunch
+via `arm-resume.sh` (default, ~2 min delay) or prints the command (`--print`).
+Use when nearing ~75-80% of the context window to `/exit` and pick up cleanly.
+This shells the SANCTIONED hop path (inherits the arm-resume dedup + cd-into-repo
+contract). See `.claude/commands/context-hop.md` for snapshot shape + exit codes.

--- a/.agents/skills/handover-arm-resume/SKILL.md
+++ b/.agents/skills/handover-arm-resume/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: handover-arm-resume
+description: Arm the OS scheduler to relaunch claude at a given time with a given handover. Dedup-guarded. Use when the user asks to arm a resume / schedule a relaunch or run /handover-arm-resume.
+---
+
+# handover-arm-resume
+
+When the user asks to arm a scheduled resume, run:
+
+    bash scripts/handover/arm-resume.sh --time <HH:MM|smart|auto> --handover <path> [--force] [--dry-run]
+
+`--time smart` (prefer) reads the usage cache and picks the throughput-maximizing
+slot; `auto` waits for the next cap reset; `HH:MM` is explicit local time.
+Dedup-guarded: refuses (rc=3) if a `HIMMEL-Resume-*` job exists (use `--force` to
+replace). This shells the SANCTIONED arm path — never hand-roll `schtasks`/`at`
+(blocked by block-rogue-claude-schedule). See
+`.claude/commands/handover-arm-resume.md` for the time sentinels + exit codes.

--- a/.agents/skills/handover-commit/SKILL.md
+++ b/.agents/skills/handover-commit/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: handover-commit
+description: Auto-commit *.md changes in the handover root (Mode B / external HANDOVER_DIR only). Use when the user asks to commit handover state or run /handover-commit.
+---
+
+# handover-commit
+
+When the user asks to commit handover state, run:
+
+    bash scripts/handover/auto-commit.sh <message> [--push] [--dry-run]
+
+`<message>` is the commit message (positional); trailing `--push` / `--dry-run`
+are flags, not part of the message. Mode B only — refuses (rc=3) on Mode A
+(inline `<repo>/handovers/`). Check the mode first with `handover-link` if unsure.
+See `.claude/commands/handover-commit.md` for exit codes + the explicit
+`--message` form.

--- a/.agents/skills/handover-flush/SKILL.md
+++ b/.agents/skills/handover-flush/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: handover-flush
+description: Session-end consolidation sweep across handover/* branches — push unpushed, open missing PRs, report merged. Use when the user asks to flush handover branches or run /handover-flush.
+---
+
+# handover-flush
+
+When the user asks to flush handover branches, run:
+
+    bash scripts/handover/flush.sh [--dry-run] [--cleanup] [--no-pr-open]
+
+Walks every local `handover/*` branch in the resolved handover repo and
+reconciles each against origin (push unpushed, open missing PRs, report merged;
+`--cleanup` deletes branches that landed on main). Best-effort — exits 0 even on
+per-branch errors. Report the per-branch status table. See
+`.claude/commands/handover-flush.md` for detail.

--- a/.agents/skills/handover-link/SKILL.md
+++ b/.agents/skills/handover-link/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: handover-link
+description: Report or check where Claude reads/writes handover state (inline ./handovers or external $HANDOVER_DIR). Use when the user asks where handover state lives or runs /handover-link.
+---
+
+# handover-link
+
+When the user asks where handover state lives (or to check the link), run:
+
+    bash scripts/handover-link.sh [status|doctor]
+
+Default verb is `status` (print resolved root + mode A-inline/B-external).
+`doctor` exits non-zero on misconfiguration (CI/pre-push use). Note this script
+is top-level (`scripts/handover-link.sh`), not under `scripts/handover/`. See
+`.claude/commands/handover-link.md` for the mode A/B detail.

--- a/.agents/skills/handover-pr-merge/SKILL.md
+++ b/.agents/skills/handover-pr-merge/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: handover-pr-merge
+description: Squash-merge the PR for the current handover/<TICKET>-<slug> branch. Plain merge (no --admin by default). Use when the user asks to merge the handover PR or run /handover-pr-merge.
+---
+
+# handover-pr-merge
+
+When the user asks to merge the handover PR, run:
+
+    bash scripts/handover/pr-merge.sh [--dry-run]
+
+Fires a plain `gh pr merge <N> --squash --delete-branch` for the open PR on the
+current handover branch — no `--admin` (that fallback needs explicit
+`GH_ADMIN_MERGE_OK=1`; the script never silently escalates). Refuses (rc=3) if
+HEAD is not on a `handover/*` branch. Run from the worktree of the handover repo.
+Run after `handover-flush` or at session-end. See
+`.claude/commands/handover-pr-merge.md` for env vars + exit codes.

--- a/.agents/skills/handover-pr-open/SKILL.md
+++ b/.agents/skills/handover-pr-open/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: handover-pr-open
+description: Open or update the PR for the current handover/<TICKET>-<slug> branch. Idempotent. Use when the user asks to open/refresh the handover PR or run /handover-pr-open.
+---
+
+# handover-pr-open
+
+When the user asks to open or update the handover PR, run:
+
+    bash scripts/handover/pr-open.sh [--dry-run] [--base <branch>]
+
+Opens a new PR or updates the existing one for the current handover branch
+(idempotent). Refuses (rc=3) if HEAD is not on a `handover/*` branch. Run from
+the worktree of the handover repo (not himmel root). See
+`.claude/commands/handover-pr-open.md` for env vars (`HANDOVER_PR_AUTO`,
+`HANDOVER_PR_BASE`, `GH_CMD`) + exit codes.


### PR DESCRIPTION
## HIMMEL-604 — .agents/skills wrappers for the handover-flow cluster

Leg 6 of the Phase-1 Codex-parity chain.

Extends the HIMMEL-533 wrapper pattern to the daily-loop handover commands so
they're runnable under Codex. Seven thin tracked `.agents/skills/<name>/SKILL.md`
files, each shelling the same harness-neutral script Claude's `.claude/commands/*.md`
use — no new shell logic, no new scripts, no `.ps1` twins, Claude commands untouched:

- `handover-commit` → `scripts/handover/auto-commit.sh`
- `handover-flush` → `scripts/handover/flush.sh`
- `handover-arm-resume` → `scripts/handover/arm-resume.sh`
- `context-hop` → `scripts/handover/hop.sh`
- `handover-link` → `scripts/handover-link.sh` (top-level, by design)
- `handover-pr-open` → `scripts/handover/pr-open.sh`
- `handover-pr-merge` → `scripts/handover/pr-merge.sh`

Bodies use literal placeholder arg-hints (no `$ARGUMENTS` — that's a Claude
slash-command mechanism, absent under Codex skills). `arm-resume`/`context-hop`
shell the sanctioned arm path, so raw `schtasks`/`at` arms stay guarded. Tracked
(not under the gitignored `.agents/skills/source-command-*/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
