### PR TITLE
feat(codex): [HIMMEL-607] low-urgency .agents/skills wrappers + cavecrew dispatch note

### DIFF
--- a/.agents/skills/cavecrew/SKILL.md
+++ b/.agents/skills/cavecrew/SKILL.md
@@ -80,3 +80,12 @@ Skip investigator. Hand exact path:line to `cavecrew-builder` directly.
 ## Auto-clarity (inherited)
 
 Subagents drop caveman → normal English for security warnings, irreversible-action confirmations, and any output where fragment ambiguity could be misread. Resume caveman after.
+
+## Dispatch syntax (harness-specific)
+
+The WHEN-to-use guidance above is harness-neutral; the **dispatch mechanism is
+not**. The cavecrew presets (`cavecrew-investigator`/`-builder`/`-reviewer`) are
+defined as **Claude Agent types** (caveman plugin `agents/`):
+
+- **Under Claude Code:** dispatch via the Agent tool, e.g. `subagent_type: "caveman:cavecrew-investigator"` (send 2-3 in one message to run them in parallel).
+- **Under Codex (or another harness):** there is no Claude Agent tool — use the harness-native subagent surface (Codex `.codex/agents/*.toml`). If the cavecrew presets are not registered there, either invoke the equivalent harness-native subagent or run the work inline. Do **not** assume `subagent_type: "caveman:…"` resolves outside Claude.

--- a/.agents/skills/cr-scores/SKILL.md
+++ b/.agents/skills/cr-scores/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: cr-scores
+description: Print the per-critic agreed/availability scorecard and surface drop advice. Use when the user asks for CR critic scores or runs /cr-scores.
+---
+
+# cr-scores
+
+When the user asks for the critic scorecard, run:
+
+    bash scripts/cr/cr-scores.sh [--window N]
+
+`--window N` narrows to the last N PRs (default 20). Summarise the all-time +
+windowed per-model table (total findings, agreed %, disproved %, conflict count,
+unaddressed count, availability %) and surface any "consider dropping" lines
+verbatim. If the ledger is empty, report "no critic scores recorded yet" and stop.
+See `.claude/commands/cr-scores.md`.

--- a/.agents/skills/luna-backfill/SKILL.md
+++ b/.agents/skills/luna-backfill/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: luna-backfill
+description: Backfill old Claude session transcripts into the luna vault as structured session notes. TOKEN-INTENSIVE — recommend --dry-run first. Use when the user asks to backfill sessions into luna or runs /luna-backfill.
+---
+
+# luna-backfill
+
+When the user asks to backfill session transcripts into luna, run:
+
+    bash scripts/luna/backfill-sessions.sh [--all | --project <path>] [--reheal | --recrystallize [--limit N]] [--dry-run] [--include-orphaned] [--only <glob>] [--exclude <glob>] [--projects-dir <dir>] [--state-file <path>] [--vault-registry <path>] [--luna-vault-path <dir>]
+
+**TOKEN-INTENSIVE** — seeds many session notes at once; a follow-up pipeline pass
+over them can cost significant tokens. **Run `--dry-run` first** to see the count;
+do large backfills in batches. Notes are written CREATE-only (idempotent). Default
+scope = current project; `--all` routes each session to its own repo's vault. See
+`.claude/commands/luna-backfill.md`.

--- a/.agents/skills/pipeline-cadence/SKILL.md
+++ b/.agents/skills/pipeline-cadence/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: pipeline-cadence
+description: Arm/inspect/remove the recurring luna clip-pipeline cadence (daily harvest+triage, weekly synthesize+archive, monthly health) via schtasks/cron. Dedup-guarded. Use when the user asks to arm/check/disarm the clip-pipeline cadence or runs /pipeline-cadence.
+---
+
+# pipeline-cadence
+
+When the user asks to arm/inspect/remove the clip-pipeline cadence, run:
+
+    bash scripts/luna/pipeline-cadence.sh arm|status|disarm [--harvest-time HH:MM] [--synth-day DAY] [--synth-time HH:MM] [--health-day N] [--health-time HH:MM] [--vault PATH] [--force] [--dry-run]
+
+Registers the luna clip-pipeline's recurring runs with the OS scheduler
+(Windows `schtasks` / POSIX crontab), following the `arm-resume.sh` precedent
+(direct scheduler invoke, dedup guard `# HIMMEL-Pipeline-*`, runner indirection).
+Each run launches a bounded interactive claude session (`claude … < /dev/null`,
+NOT `--print` — stays on Max quota). This shells the SANCTIONED cadence path —
+never hand-roll `schtasks`/`cron`. See `.claude/commands/pipeline-cadence.md`.

--- a/.agents/skills/pr-triage/SKILL.md
+++ b/.agents/skills/pr-triage/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: pr-triage
+description: Lightweight 4-step PR triage gate (steipete) — decide if a PR is even worth a deep multi-agent CR before running pr-check. Use when the user asks to triage a PR or runs /pr-triage.
+---
+
+# pr-triage
+
+A lightweight first-pass gate (~10s of reasoning) run BEFORE the heavy `pr-check`.
+The question is "is this PR even worth a deep review?" — not "is it correct?".
+There is no script: this is a reasoning procedure. Given a PR number/URL (default
+the current branch's PR):
+
+0. **Pull the PR:** `gh pr view <PR> --json title,body,files,additions,deletions`
+   and `gh pr diff <PR>`. Read the diff + linked ticket.
+1. **Is the issue clear?** If the *problem* is fuzzy, stop — push back for a
+   problem statement (no review fixes an unclear goal).
+2. **Is this the best fix?** Is it the simplest approach that solves the stated
+   problem? A "yes, but" here is the highest-leverage redirect.
+3. **Tradeoffs / usually rewrite.** Name the tradeoffs; often rewrite the PR
+   rather than nitpick the diff.
+
+**Verdict** (one line): `PROCEED` (issue clear + fix sound → run `pr-check`) /
+`REDIRECT` (approach wrong or issue unclear → comment, skip CR) / `REWRITE` (fix
+the direction first, then re-triage). See `.claude/commands/pr-triage.md`.

--- a/.agents/skills/quiet-run/SKILL.md
+++ b/.agents/skills/quiet-run/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: quiet-run
+description: Run a noisy command quietly — one OK/ERR line + log path. Use when the user asks to run something quietly or runs /quiet-run.
+---
+
+# quiet-run
+
+When the user asks to run a verbose command quietly, run:
+
+    bash scripts/quiet-run.sh <label> -- <command...>
+
+Wraps any verbose command so it doesn't spam the session — prints one line with
+exit status, duration, and log path (`/tmp/quiet-run-<label>-<ts>-<pid>.log`).
+`<label>` is a short slug for log naming; everything after `--` is the command.
+Grep the log if more detail is needed. See `.claude/commands/quiet-run.md`.

--- a/.agents/skills/retitle/SKILL.md
+++ b/.agents/skills/retitle/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: retitle
+description: Infer a himmel-canonical session name (TICKET-ID + meaningful name) from the current branch and print a ready-to-paste built-in /rename line. Use when the user asks to retitle/rename the session or runs /retitle.
+---
+
+# retitle
+
+When the user asks to retitle the session, run:
+
+    bash scripts/retitle.sh [TICKET-ID ...]
+
+Computes `<TICKET-ID[/TICKET-ID...]> <meaningful name>` from the current git
+branch and prints a ready-to-paste line for the harness's **built-in** `/rename`
+(the agent cannot set the session name itself). Pass extra ticket IDs for a
+multi-ticket session. Print the line; the user applies it with the built-in
+rename. See `.claude/commands/retitle.md`.

--- a/.agents/skills/skill-find/SKILL.md
+++ b/.agents/skills/skill-find/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: skill-find
+description: Embedding-indexed lookup over installed skills/commands/agents — eliminates wrong-namespace mistakes. Use when the user asks which skill/command/agent fits an intent, or runs /skill-find.
+---
+
+# skill-find
+
+When the user asks which skill/command/agent fits an intent, find the
+best match via qmd's hybrid BM25 + vector search over the `skills` collection.
+
+1. **Ensure the index exists.** If `$SKILL_INDEX_DIR` (default
+   `$HOME/.claude/skill-index`) is empty, build + ingest it:
+
+       bash scripts/skill-index/build-skill-index.sh
+       bash -c 'source scripts/lib/qmd-bin.sh; qmd_cmd ingest --collection skills "$HOME/.claude/skill-index"'
+
+   Always go through the `scripts/lib/qmd-bin.sh` resolver — bare `qmd` resolves
+   to the broken plugin-cache stub. Re-run both after plugin install/uninstall.
+
+2. **Query** with the intent text (substitute it for `<intent>`):
+
+       bash -c 'source scripts/lib/qmd-bin.sh; qmd_cmd query --collection skills --intent "<intent>" --lex "<intent>" --vec "<intent>" --limit 5'
+
+3. **Report** the top matches: `<qualified-name>` (e.g. `pr-review-toolkit:code-reviewer`),
+   `<kind>` (command|agent|skill), `<plugin>` (or `local`). See `.claude/commands/skill-find.md`.


### PR DESCRIPTION
## HIMMEL-607 — low-urgency .agents/skills wrappers + cavecrew dispatch note

Final leg of the Phase-1 Codex-parity chain. Completes the 533/604/607
`.agents/skills` wrapper set.

Seven thin tracked `.agents/skills/<name>/SKILL.md` wrappers shelling the same
harness-neutral scripts Claude's `.claude/commands/*.md` use — no new logic, no
new scripts, no `.ps1` twins, Claude commands untouched:

- `cr-scores` → `scripts/cr/cr-scores.sh`
- `retitle` → `scripts/retitle.sh`
- `quiet-run` → `scripts/quiet-run.sh`
- `pipeline-cadence` → `scripts/luna/pipeline-cadence.sh`
- `luna-backfill` → `scripts/luna/backfill-sessions.sh`
- `skill-find` → `scripts/skill-index/build-skill-index.sh` + qmd query (via `scripts/lib/qmd-bin.sh`)
- `pr-triage` → *(no script — prose 4-step gate)*

Plus a harness-specific dispatch note on the existing `cavecrew` wrapper: the
WHEN-to-use guidance is harness-neutral, but the dispatch mechanism is not
(Claude Agent tool vs Codex `.codex/agents`).

Bodies use literal placeholder arg-hints (no `$ARGUMENTS`). `pipeline-cadence`
shells the sanctioned cadence path. Tracked (not under the gitignored
`.agents/skills/source-command-*/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
