### PR TITLE
feat(codex): soft-check claude in adopt + sanitize external-plugin hooks.json

### DIFF
--- a/docs/internals/harness-compat.md
+++ b/docs/internals/harness-compat.md
@@ -273,11 +273,15 @@ node scripts/agents-md/generate.mjs --check
 ### 3. Plugins / marketplace — works
 
 `config.toml` registers the himmel marketplace + `handover@himmel`,
-`obsidian-triage@himmel`, `telegram-himmel@himmel` (enabled). The only known
-issue is benign: 4 **external** plugins' `hooks.json` carry a top-level
-`description` key that Codex's strict parser rejects ("unknown field
+`obsidian-triage@himmel`, `telegram-himmel@himmel` (enabled). A few **external**
+plugins' `hooks.json` (warp, hookify, ralph-loop, security-guidance) carry a
+top-level `description` key that Codex's strict parser rejects ("unknown field
 description") — Codex skips just those hooks and runs normally. No himmel-owned
-plugin ships that shape. **Accept** (operator decision 2026-06-20).
+plugin ships that shape. **Sanitize** (supersedes the 2026-06-20 "accept",
+operator decision 2026-06-30, HIMMEL-651): `scripts/codex/sanitize-plugin-hooks.{sh,ps1}`
+strips the top-level `description` from every `hooks.json` under
+`~/.codex/plugins/cache/` (idempotent; re-run after a plugin update re-adds the
+field). `install-himmel-codex.{sh,ps1}` runs it automatically as its final phase.
 
 ### 4. Skills / slash commands
 

--- a/docs/setup/codex.md
+++ b/docs/setup/codex.md
@@ -38,9 +38,14 @@ Codex loads marketplaces + `@himmel` plugins from `config.toml`. The himmel
 marketplace and the `himmel-ops` plugin (stuck-playbook / minerva / vm /
 himmel-doctor skills **and** the plugin-delivered security hooks) are enabled
 there (HIMMEL-597). Verify your `~/.codex/config.toml` registers the himmel
-marketplace and enables `himmel-ops@himmel`. The non-`description` plugin
-`hooks.json` shape is accepted by Codex's strict parser; a few external plugins'
-top-level `description` key is skipped harmlessly (see harness-compat.md §3).
+marketplace and enables `himmel-ops@himmel`. A few external plugins (warp,
+hookify, ralph-loop, security-guidance) ship a top-level `description` in their
+`hooks.json` that Codex's strict parser rejects ("unknown field description") and
+skips with a boot warning. `install-himmel-codex.{sh,ps1}` strips it automatically
+as its final phase via `scripts/codex/sanitize-plugin-hooks.{sh,ps1}` (HIMMEL-651);
+re-run that script standalone after a `codex` plugin update re-adds the field
+(`bash scripts/codex/sanitize-plugin-hooks.sh`, or the `.ps1` twin). See
+harness-compat.md §3.
 
 ## 4. Hooks — the PreToolUse guardrails
 

--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -49,6 +49,12 @@ $LunaTargetSet = $PSBoundParameters.ContainsKey('LunaTarget')
 $ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
 $HimmelRoot  = (Resolve-Path (Join-Path $ScriptDir '..')).Path
 
+# Default-to-available, mirroring adopt.sh's `${CLAUDE_AVAILABLE:-1}` (HIMMEL-600).
+# Require-Tools flips this to $false when `claude` is absent; initializing it here
+# keeps the flag an explicit boolean (never $null) so Install-Plugins' read is
+# unambiguous and strict-mode-safe.
+$script:ClaudeAvailable = $true
+
 # Shared wire helpers (PreToolUse trio + SessionStart) -- one implementation for
 # adopt.ps1 and setup.ps1 (HIMMEL install/uninstall symmetry).
 . (Join-Path $ScriptDir 'lib/wire-pretooluse-hooks.ps1')
@@ -71,11 +77,18 @@ $PortableFiles = @(
 
 function Require-Tools {
     $missing = @()
-    foreach ($t in @('git', 'jq', 'python3', 'claude')) {
+    # git/jq/python3 are the harness-agnostic core deps — hard-required.
+    foreach ($t in @('git', 'jq', 'python3')) {
         if (-not (Get-Command $t -ErrorAction SilentlyContinue)) { $missing += $t }
     }
     if ($missing.Count -gt 0) {
         Write-Error "missing required tools: $($missing -join ', ') (see $HimmelRoot\docs\setup\new-machine.md)"
+    }
+    # `claude` is SOFT (HIMMEL-600): only the plugin-install step needs the CLI;
+    # a Codex-only (or any non-Claude) adopter still gets the harness-agnostic core.
+    if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
+        $script:ClaudeAvailable = $false
+        Write-Warning "'claude' not found — installing the harness-agnostic core only; skipping the Claude plugin-install step (Codex-only adopter is fine)."
     }
 }
 
@@ -92,6 +105,10 @@ function Copy-Portable {
 }
 
 function Install-Plugins {
+    if ($script:ClaudeAvailable -eq $false) {
+        Write-Host "──── Skipping plugin install ('claude' not found — non-Claude adopter) ────"
+        return
+    }
     Write-Host "──── Installing plugins (-Scope $Scope) ────"
     $pluginArgs = @('-Scope', $Scope)
     if ($DryRun) { $pluginArgs += '-DryRun' }

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -41,6 +41,7 @@ HIMMEL_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 # Shared wire helpers (the PreToolUse trio + SessionStart) — one implementation
 # for adopt.sh and setup.sh (HIMMEL install/uninstall symmetry).
 # shellcheck source=scripts/lib/wire-pretooluse-hooks.sh
+# shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/wire-pretooluse-hooks.sh"
 
 # ── Defaults ─────────────────────────────────────────────────────────────────
@@ -88,13 +89,22 @@ PORTABLE_FILES=(
 
 require_tools() {
   local missing=() t
-  for t in bash git jq python3 claude; do
+  # bash/git/jq/python3 are the harness-agnostic core deps — hard-required.
+  for t in bash git jq python3; do
     command -v "$t" >/dev/null 2>&1 || missing+=("$t")
   done
   if [[ ${#missing[@]} -gt 0 ]]; then
     echo "ERROR: missing required tools: ${missing[*]}" >&2
     echo "  see $HIMMEL_ROOT/docs/setup/new-machine.md (Required environment)" >&2
     exit 1
+  fi
+  # `claude` is SOFT (HIMMEL-600): the portable core + git gates are
+  # harness-agnostic, and only the Claude plugin-install step needs the CLI. A
+  # Codex-only (or any non-Claude) adopter still gets the core — don't reject it.
+  if ! command -v claude >/dev/null 2>&1; then
+    CLAUDE_AVAILABLE=0
+    echo "WARN: 'claude' not found — installing the harness-agnostic core only;" >&2
+    echo "      skipping the Claude plugin-install step (Codex-only adopter is fine)." >&2
   fi
 }
 
@@ -110,6 +120,10 @@ copy_portable() {
 }
 
 install_plugins() {
+  if [[ "${CLAUDE_AVAILABLE:-1}" -eq 0 ]]; then
+    echo "──── Skipping plugin install ('claude' not found — non-Claude adopter) ────"
+    return 0
+  fi
   echo "──── Installing plugins (--scope $SCOPE) ────"
   local args=(--scope "$SCOPE")
   [[ $DRY_RUN -eq 1 ]] && args+=(--dry-run)

--- a/scripts/codex/README.md
+++ b/scripts/codex/README.md
@@ -27,8 +27,17 @@ line endings). It is **idempotent** and **non-destructive**:
    himmel-doctor / himmel-update skills + the himmel-ops hooks to Codex
    (the HIMMEL-597 target).
 
-It only ever *adds*; it never removes or disables a plugin, and a re-run on a
-provisioned machine is a no-op.
+3. **Sanitizes external-plugin `hooks.json`** as a final phase (HIMMEL-651): a
+   few external plugins (warp, hookify, ralph-loop, security-guidance) ship a
+   top-level `description` that Codex's strict parser rejects ("unknown field
+   description"), skipping those hooks with a boot warning. The installer strips
+   it via `sanitize-plugin-hooks.{sh,ps1}` (idempotent; non-fatal). himmel-owned
+   plugins never ship that shape.
+
+For plugin enablement it only ever *adds* — it never removes or disables a
+plugin, and a re-run on a provisioned machine is a no-op. (The sanitize phase
+edits external-plugin cache files in place, removing only the offending
+`description` key.)
 
 ## Usage
 
@@ -46,6 +55,18 @@ pwsh -NoProfile -File scripts\codex\install-himmel-codex.ps1 -All
 
 Env override: `CODEX_BIN` (path to the `codex` CLI). After a change, restart
 Codex so the plugins load; new project hooks are trust-hashed on first use.
+
+Run the hooks sanitizer standalone (e.g. after a `codex` plugin update re-adds a
+`description`) — env override `CODEX_HOME` (default `~/.codex`):
+
+```sh
+bash scripts/codex/sanitize-plugin-hooks.sh              # strip in place
+bash scripts/codex/sanitize-plugin-hooks.sh --dry-run    # report, change nothing
+```
+
+```powershell
+pwsh -NoProfile -File scripts\codex\sanitize-plugin-hooks.ps1 -DryRun
+```
 
 ## Skill loading caveat
 

--- a/scripts/codex/install-himmel-codex.ps1
+++ b/scripts/codex/install-himmel-codex.ps1
@@ -108,6 +108,20 @@ foreach ($p in $PluginSet) {
   }
 }
 
+# --- 3. sanitize external-plugin hooks.json (HIMMEL-651) ---
+# Codex's strict plugin-hooks parser rejects a top-level `description` key that
+# several external plugins ship in their hooks.json ("unknown field
+# description") and skips those hooks at boot. Strip it so codex boots clean.
+# Idempotent + non-fatal (cosmetic cleanup must never fail the install).
+Write-Host ""
+Write-Host "--- 3. sanitize external-plugin hooks.json (codex strict-parser workaround) ---"
+$sanitizer = Join-Path $PSScriptRoot "sanitize-plugin-hooks.ps1"
+try {
+  if ($DryRun) { & $sanitizer -DryRun } else { & $sanitizer }
+} catch {
+  Write-Warning "sanitize step failed (non-fatal): $($_.Exception.Message)"
+}
+
 Write-Host ""
 if ($DryRun) {
   Write-Host "DRY-RUN: $changed change(s) would be made. Re-run without -DryRun to apply."

--- a/scripts/codex/install-himmel-codex.sh
+++ b/scripts/codex/install-himmel-codex.sh
@@ -102,6 +102,19 @@ for p in $PLUGINS; do
   fi
 done
 
+# --- 3. sanitize external-plugin hooks.json (HIMMEL-651) ---------------------
+# Codex's strict plugin-hooks parser rejects a top-level `description` key that
+# several external plugins ship in their hooks.json ("unknown field
+# description") and skips those hooks at boot. Strip it so `codex` boots clean.
+# Idempotent + non-fatal (cosmetic cleanup must never fail the install).
+echo ""
+echo "--- 3. sanitize external-plugin hooks.json (codex strict-parser workaround) ---"
+if [ "$DRY_RUN" = "1" ]; then
+  bash "$SCRIPT_DIR/sanitize-plugin-hooks.sh" --dry-run || echo "WARN: sanitize step failed (non-fatal)" >&2
+else
+  bash "$SCRIPT_DIR/sanitize-plugin-hooks.sh" || echo "WARN: sanitize step failed (non-fatal)" >&2
+fi
+
 echo ""
 if [ "$DRY_RUN" = "1" ]; then
   echo "DRY-RUN: $changed change(s) would be made. Re-run without --dry-run to apply."

--- a/scripts/codex/sanitize-plugin-hooks.ps1
+++ b/scripts/codex/sanitize-plugin-hooks.ps1
@@ -1,0 +1,74 @@
+<#
+.SYNOPSIS
+  Strip the top-level `description` key from external-plugin hooks.json under the
+  Codex plugin cache (HIMMEL-651) — twin of sanitize-plugin-hooks.sh.
+
+.DESCRIPTION
+  Codex's strict plugin-hooks parser rejects a top-level `description`
+  ("unknown field description") and skips those hooks at boot. himmel-owned
+  plugins don't ship that shape; this clears the boot-time noise from external
+  plugins (warp, hookify, ralph-loop, security-guidance, ...).
+
+  Idempotent + re-runnable: re-run after a `codex` plugin update re-adds the
+  field. Only the `description` key is removed; the `hooks` block is preserved.
+
+    sanitize-plugin-hooks.ps1            # strip in place, report
+    sanitize-plugin-hooks.ps1 -DryRun    # report what WOULD change, mutate nothing
+
+  Env overrides: CODEX_HOME (default ~/.codex).
+#>
+[CmdletBinding(PositionalBinding=$false)]
+param(
+  [switch]$DryRun
+)
+$ErrorActionPreference = 'Stop'
+
+$codexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $HOME '.codex' }
+$cache     = Join-Path $codexHome 'plugins/cache'
+
+if (-not (Test-Path -LiteralPath $cache)) {
+  Write-Host "OK: no Codex plugin cache at $cache (nothing to sanitize)."
+  exit 0
+}
+
+$scanned  = 0
+$stripped = 0
+# `foreach` (statement, not ForEach-Object) runs in THIS scope so the counters
+# persist across iterations.
+foreach ($item in (Get-ChildItem -LiteralPath $cache -Recurse -Filter hooks.json -File)) {
+  $scanned++
+  $file = $item.FullName
+  try {
+    $json = Get-Content -LiteralPath $file -Raw | ConvertFrom-Json
+  } catch {
+    Write-Warning "SKIP (parse): $file - $($_.Exception.Message)"
+    continue
+  }
+  if ($json.PSObject.Properties.Name -contains 'description') {
+    if ($DryRun) {
+      Write-Host "WOULD STRIP : $file"
+    } else {
+      $json.PSObject.Properties.Remove('description')
+      $text = ($json | ConvertTo-Json -Depth 100)
+      # Write to a sibling temp then atomic Move-Item, mirroring the .sh twin's
+      # temp+mv (an interrupted write never corrupts the cache file). UTF8Encoding
+      # ($false) is BOM-free AND works on Windows PowerShell 5.1 (where the
+      # `-Encoding utf8NoBOM` token does NOT exist); a BOM would itself trip
+      # Codex's strict parser.
+      $tmp = Join-Path $item.DirectoryName ('.hooks.json.' + [guid]::NewGuid().ToString('N').Substring(0,8))
+      [System.IO.File]::WriteAllText($tmp, $text, (New-Object System.Text.UTF8Encoding($false)))
+      Move-Item -LiteralPath $tmp -Destination $file -Force
+      Write-Host "STRIPPED    : $file"
+    }
+    $stripped++
+  }
+}
+
+Write-Host ""
+if ($DryRun) {
+  Write-Host "DRY-RUN: $stripped of $scanned hooks.json would be sanitized."
+} elseif ($stripped -eq 0) {
+  Write-Host "OK: nothing to sanitize ($scanned hooks.json already clean)."
+} else {
+  Write-Host "OK: sanitized $stripped of $scanned hooks.json. Restart Codex to clear the warnings."
+}

--- a/scripts/codex/sanitize-plugin-hooks.sh
+++ b/scripts/codex/sanitize-plugin-hooks.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# sanitize-plugin-hooks.sh (HIMMEL-651)
+#
+# Strip the top-level `description` key from external-plugin `hooks.json` files
+# under the Codex plugin cache. Codex's strict plugin-hooks parser rejects a
+# top-level `description` ("unknown field description") and skips those hooks at
+# boot. himmel-owned plugins don't ship that shape; this clears the boot-time
+# noise from external plugins (warp, hookify, ralph-loop, security-guidance, …).
+#
+# Idempotent + re-runnable: re-run after a `codex` plugin update re-adds the
+# field. Only the `description` key is removed; the `hooks` block is preserved.
+#
+#   sanitize-plugin-hooks.sh            # strip in place, report
+#   sanitize-plugin-hooks.sh --dry-run  # report what WOULD change, mutate nothing
+#
+# Env overrides: CODEX_HOME (default ~/.codex).
+set -euo pipefail
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help) sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "ERR: unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || { echo "ERR: jq required" >&2; exit 1; }
+
+CACHE="${CODEX_HOME:-$HOME/.codex}/plugins/cache"
+if [ ! -d "$CACHE" ]; then
+  echo "OK: no Codex plugin cache at $CACHE (nothing to sanitize)."
+  exit 0
+fi
+
+scanned=0
+stripped=0
+while IFS= read -r f; do
+  scanned=$((scanned + 1))
+  # `has("description")` -> true only when the top-level key is present. A parse
+  # error (malformed JSON) exits non-zero too; those land in the elif below.
+  if jq -e 'has("description")' "$f" >/dev/null 2>&1; then
+    if [ "$DRY_RUN" = "1" ]; then
+      echo "WOULD STRIP : $f"
+    else
+      # Temp beside the target so the replace is an atomic same-filesystem
+      # rename (a $TMPDIR temp could be a cross-fs, non-atomic copy).
+      tmp="$(mktemp "$(dirname "$f")/.hooks.json.XXXXXX")"
+      # `has("description")` already proved this file parses, so a del failure
+      # here is an I/O error (disk full / unwritable), never a parse error —
+      # keep jq's stderr visible and label it as a write failure.
+      if jq 'del(.description)' "$f" > "$tmp"; then
+        mv "$tmp" "$f"
+        echo "STRIPPED    : $f"
+      else
+        rm -f "$tmp"
+        echo "SKIP (write failed): $f" >&2
+        continue
+      fi
+    fi
+    stripped=$((stripped + 1))
+  elif ! jq empty "$f" >/dev/null 2>&1; then
+    # Unparseable JSON: left untouched (correct), but tell the operator so a
+    # "why didn't this plugin's hooks load" hunt has a signal.
+    echo "SKIP (unparseable): $f" >&2
+  fi
+done < <(find "$CACHE" -name hooks.json 2>/dev/null)
+
+echo ""
+if [ "$DRY_RUN" = "1" ]; then
+  echo "DRY-RUN: $stripped of $scanned hooks.json would be sanitized."
+elif [ "$stripped" -eq 0 ]; then
+  echo "OK: nothing to sanitize ($scanned hooks.json already clean)."
+else
+  echo "OK: sanitized $stripped of $scanned hooks.json. Restart Codex to clear the warnings."
+fi

--- a/scripts/codex/test-install-himmel-codex.ps1
+++ b/scripts/codex/test-install-himmel-codex.ps1
@@ -62,12 +62,17 @@ exit 0
     if (-not $codexBin) { $codexBin = $Stub }
     $env:CODEX_BIN = $codexBin
     $env:CODEX_STUB_STATE = $state
+    # CODEX_HOME -> an empty temp dir so the wired sanitize-plugin-hooks step
+    # (HIMMEL-651) finds no plugin cache and no-ops, keeping the test hermetic
+    # (never touches the real ~/.codex cache).
+    $env:CODEX_HOME = Join-Path $TMP "codex-home"
     try {
       $out = & pwsh -NoProfile -File $Installer @iargs 2>&1 | Out-String
       $code = $LASTEXITCODE
     } finally {
       Remove-Item Env:CODEX_BIN -ErrorAction SilentlyContinue
       Remove-Item Env:CODEX_STUB_STATE -ErrorAction SilentlyContinue
+      Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue
     }
     return @{ Out = $out; Code = $code }
   }

--- a/scripts/codex/test-install-himmel-codex.sh
+++ b/scripts/codex/test-install-himmel-codex.sh
@@ -69,7 +69,10 @@ mk_state() {  # $1 = state dir; seeds empty marketplaces + plugins + calls
 
 run() {  # state-dir, then installer args
   local s="$1"; shift
-  CODEX_BIN="$STUB" CODEX_STUB_STATE="$s" bash "$INSTALLER" "$@"
+  # CODEX_HOME -> an empty temp dir so the wired sanitize-plugin-hooks step
+  # (HIMMEL-651) finds no plugin cache and no-ops, keeping the test hermetic
+  # (never touches the real ~/.codex cache).
+  CODEX_BIN="$STUB" CODEX_STUB_STATE="$s" CODEX_HOME="$TMP/codex-home" bash "$INSTALLER" "$@"
 }
 
 DEFAULT_SET="himmel-ops handover obsidian-triage telegram-himmel"

--- a/scripts/codex/test-sanitize-plugin-hooks.ps1
+++ b/scripts/codex/test-sanitize-plugin-hooks.ps1
@@ -1,0 +1,120 @@
+<#
+.SYNOPSIS
+  Hermetic tests for sanitize-plugin-hooks.ps1 (HIMMEL-651) — PowerShell twin of
+  test-sanitize-plugin-hooks.sh.
+
+.DESCRIPTION
+  A temp CODEX_HOME holds fixture plugin-cache hooks.json files (one WITH a
+  top-level `description` + a DEEPLY-nested hooks block, one already clean, one
+  malformed). Asserts the sanitizer strips only `description`, preserves the
+  nested `hooks` block (guards the `ConvertTo-Json -Depth` choice), honours
+  -DryRun, is idempotent, leaves clean/malformed files untouched, aggregates the
+  count over multiple files, and exits 0 when there is no cache dir. Never
+  touches the real ~/.codex.
+#>
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Sanitizer = Join-Path $ScriptDir 'sanitize-plugin-hooks.ps1'
+
+$fails = 0
+function Pass($m) { Write-Host "  ok: $m" }
+function Fail($m) { Write-Warning "  FAIL: $m"; $script:fails++ }
+
+$TMP = Join-Path ([System.IO.Path]::GetTempPath()) ("san-ps-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+$cache = Join-Path $TMP '.codex/plugins/cache'
+New-Item -ItemType Directory -Force -Path (Join-Path $cache 'ext-desc/hooks')  | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $cache 'ext-desc2/hooks') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $cache 'ext-clean/hooks') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $cache 'ext-bad/hooks')   | Out-Null
+
+$descFile  = Join-Path $cache 'ext-desc/hooks/hooks.json'
+$desc2File = Join-Path $cache 'ext-desc2/hooks/hooks.json'
+$cleanFile = Join-Path $cache 'ext-clean/hooks/hooks.json'
+$badFile   = Join-Path $cache 'ext-bad/hooks/hooks.json'
+
+# WITH top-level description + a deeply-nested hooks block (exercises -Depth).
+@'
+{
+  "description": "External plugin - rejected by Codex",
+  "hooks": {
+    "SessionStart": [
+      { "matcher": "startup", "hooks": [ { "type": "command", "command": "echo hi", "meta": { "a": { "b": { "c": "deep" } } } } ] }
+    ]
+  }
+}
+'@ | Set-Content -LiteralPath $descFile -Encoding utf8NoBOM
+
+# A SECOND file with description (exercises multi-file aggregation).
+@'
+{ "description": "another external", "hooks": { "Stop": [ { "hooks": [ { "type": "command", "command": "echo two" } ] } ] } }
+'@ | Set-Content -LiteralPath $desc2File -Encoding utf8NoBOM
+
+# Already clean (no top-level description).
+@'
+{ "hooks": { "Stop": [ { "hooks": [ { "type": "command", "command": "echo bye" } ] } ] } }
+'@ | Set-Content -LiteralPath $cleanFile -Encoding utf8NoBOM
+
+# Malformed JSON — must be left untouched, never crash the run.
+'{ not valid json' | Set-Content -LiteralPath $badFile -Encoding utf8NoBOM
+$badBefore = Get-Content -LiteralPath $badFile -Raw
+
+function Has-Description($path) {
+  $j = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+  return ($j.PSObject.Properties.Name -contains 'description')
+}
+
+$env:CODEX_HOME = Join-Path $TMP '.codex'
+try {
+  # --- 1. dry-run reports but mutates nothing ---
+  # 6>&1 merges the Information stream (Write-Host) into output so Out-String
+  # captures the human-facing report lines.
+  $out = (& $Sanitizer -DryRun 6>&1 | Out-String)
+  if ($out -match 'WOULD STRIP') { Pass 'dry-run flags a strippable file' } else { Fail 'dry-run did not flag any file' }
+  if ($out -match 'DRY-RUN: 2 of 4') { Pass 'dry-run count = 2 of 4' } else { Fail "dry-run count wrong (want 2 of 4): $out" }
+  if (Has-Description $descFile) { Pass 'dry-run left description in place' } else { Fail 'dry-run MUTATED ext-desc' }
+
+  # --- 2. real run strips description, preserves nested hooks ---
+  $out = (& $Sanitizer 6>&1 | Out-String)
+  if ($out -match 'STRIPPED') { Pass 'real run strips' } else { Fail 'real run stripped nothing' }
+  if (Has-Description $descFile) { Fail 'description NOT removed from ext-desc' } else { Pass 'description removed from ext-desc' }
+  if (Has-Description $desc2File) { Fail 'description NOT removed from ext-desc2' } else { Pass 'description removed from ext-desc2' }
+
+  $j = Get-Content -LiteralPath $descFile -Raw | ConvertFrom-Json
+  if ($j.hooks.SessionStart[0].hooks[0].command -eq 'echo hi') { Pass 'hooks block preserved' } else { Fail 'hooks block damaged' }
+  # deep nesting survived the ConvertTo-Json -Depth round-trip.
+  if ($j.hooks.SessionStart[0].hooks[0].meta.a.b.c -eq 'deep') { Pass 'deeply-nested value preserved (-Depth ok)' } else { Fail 'deep nesting truncated' }
+
+  # multi-file aggregation summary.
+  if ($out -match 'sanitized 2 of 4') { Pass 'real-run summary = sanitized 2 of 4' } else { Fail "real-run summary wrong: $out" }
+
+  # clean file untouched.
+  $jc = Get-Content -LiteralPath $cleanFile -Raw | ConvertFrom-Json
+  if ($jc.hooks.Stop[0].hooks[0].command -eq 'echo bye') { Pass 'clean file left intact' } else { Fail 'clean file changed' }
+
+  # malformed file untouched byte-for-byte.
+  if ((Get-Content -LiteralPath $badFile -Raw) -eq $badBefore) { Pass 'malformed file left untouched' } else { Fail 'malformed file was mutated' }
+
+  # --- 3. idempotent re-run ---
+  $out = (& $Sanitizer 6>&1 | Out-String)
+  if ($out -match 'nothing to sanitize') { Pass 'idempotent re-run' } else { Fail "re-run not idempotent: $out" }
+}
+finally {
+  Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue
+}
+
+# --- 4. no cache dir -> graceful exit 0 ---
+$env:CODEX_HOME = Join-Path $TMP 'empty/.codex'
+try {
+  $out = (& $Sanitizer 6>&1 | Out-String)
+  if ($LASTEXITCODE -eq 0) { Pass 'no-cache exits 0' } else { Fail "no-cache exit $LASTEXITCODE (want 0)" }
+  if ($out -match 'no Codex plugin cache') { Pass 'no-cache message present' } else { Fail 'no-cache message missing' }
+}
+finally {
+  Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue
+}
+
+Remove-Item -Recurse -Force $TMP -ErrorAction SilentlyContinue
+
+Write-Host ""
+if ($fails -eq 0) { Write-Host "PASS" } else { Write-Host "FAIL ($fails)"; exit 1 }

--- a/scripts/codex/test-sanitize-plugin-hooks.sh
+++ b/scripts/codex/test-sanitize-plugin-hooks.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Hermetic tests for sanitize-plugin-hooks.sh (HIMMEL-651).
+# No real Codex install needed: a temp CODEX_HOME holds fixture plugin-cache
+# hooks.json files (one WITH a top-level `description`, one already clean, one
+# malformed). Asserts the sanitizer strips only the `description` key, preserves
+# the `hooks` block, honours --dry-run, is idempotent, leaves clean/malformed
+# files untouched, and exits 0 when there is no cache dir.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SANITIZER="$SCRIPT_DIR/sanitize-plugin-hooks.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq required" >&2; exit 1; }
+
+fails=0
+pass() { echo "  ok: $1"; }
+fail() { echo "  FAIL: $1" >&2; fails=$((fails + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- fixtures ----------------------------------------------------------------
+CACHE="$TMP/.codex/plugins/cache"
+mkdir -p "$CACHE/ext-desc/hooks" "$CACHE/ext-desc2/hooks" "$CACHE/ext-clean/hooks" "$CACHE/ext-bad/hooks"
+
+# WITH top-level description + a hooks block (the offending shape).
+cat > "$CACHE/ext-desc/hooks/hooks.json" <<'JSON'
+{
+  "description": "External plugin - rejected by Codex",
+  "hooks": {
+    "SessionStart": [
+      { "matcher": "startup", "hooks": [ { "type": "command", "command": "echo hi" } ] }
+    ]
+  }
+}
+JSON
+
+# A SECOND file with description (exercises multi-file count aggregation).
+cat > "$CACHE/ext-desc2/hooks/hooks.json" <<'JSON'
+{
+  "description": "another external",
+  "hooks": { "Stop": [ { "hooks": [ { "type": "command", "command": "echo two" } ] } ] }
+}
+JSON
+
+# Already clean (no top-level description).
+cat > "$CACHE/ext-clean/hooks/hooks.json" <<'JSON'
+{
+  "hooks": {
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "echo bye" } ] }
+    ]
+  }
+}
+JSON
+
+# Malformed JSON — must be left untouched, never crash the run.
+printf '%s' '{ not valid json' > "$CACHE/ext-bad/hooks/hooks.json"
+bad_before="$(cat "$CACHE/ext-bad/hooks/hooks.json")"
+
+# --- 1. dry-run reports but mutates nothing -----------------------------------
+out="$(CODEX_HOME="$TMP/.codex" bash "$SANITIZER" --dry-run 2>&1)"
+echo "$out" | grep -q "WOULD STRIP : .*ext-desc/" || fail "dry-run did not flag ext-desc"
+echo "$out" | grep -q "WOULD STRIP : .*ext-desc2/" || fail "dry-run did not flag ext-desc2"
+echo "$out" | grep -q "DRY-RUN: 2 of 4" || fail "dry-run count wrong (want 2 of 4): $out"
+echo "$out" | grep -q "SKIP (unparseable): .*ext-bad" || fail "dry-run did not report ext-bad as unparseable"
+if jq -e 'has("description")' "$CACHE/ext-desc/hooks/hooks.json" >/dev/null 2>&1; then
+  pass "dry-run left description in place"
+else
+  fail "dry-run MUTATED ext-desc"
+fi
+
+# --- 2. real run strips description, preserves hooks --------------------------
+out="$(CODEX_HOME="$TMP/.codex" bash "$SANITIZER" 2>&1)"
+echo "$out" | grep -q "STRIPPED    : .*ext-desc/" || fail "real run did not strip ext-desc"
+echo "$out" | grep -q "STRIPPED    : .*ext-desc2/" || fail "real run did not strip ext-desc2"
+echo "$out" | grep -q "OK: sanitized 2 of 4" || fail "real-run summary wrong (want 2 of 4): $out"
+if jq -e 'has("description")' "$CACHE/ext-desc/hooks/hooks.json" >/dev/null 2>&1; then
+  fail "description NOT removed from ext-desc"
+else
+  pass "description removed from ext-desc"
+fi
+if jq -e 'has("description")' "$CACHE/ext-desc2/hooks/hooks.json" >/dev/null 2>&1; then
+  fail "description NOT removed from ext-desc2"
+else
+  pass "description removed from ext-desc2"
+fi
+# hooks block intact (command survives).
+got="$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$CACHE/ext-desc/hooks/hooks.json" 2>/dev/null)"
+if [ "$got" = "echo hi" ]; then pass "hooks block preserved after strip"; else fail "hooks block damaged (got '$got')"; fi
+
+# clean file untouched (still parses, still has its command).
+got="$(jq -r '.hooks.Stop[0].hooks[0].command' "$CACHE/ext-clean/hooks/hooks.json" 2>/dev/null)"
+if [ "$got" = "echo bye" ]; then pass "clean file left intact"; else fail "clean file changed (got '$got')"; fi
+
+# malformed file untouched byte-for-byte.
+if [ "$(cat "$CACHE/ext-bad/hooks/hooks.json")" = "$bad_before" ]; then
+  pass "malformed file left untouched"
+else
+  fail "malformed file was mutated"
+fi
+
+# --- 3. idempotent re-run -----------------------------------------------------
+out="$(CODEX_HOME="$TMP/.codex" bash "$SANITIZER" 2>&1)"
+echo "$out" | grep -q "OK: nothing to sanitize" || fail "re-run not idempotent: $out"
+
+# --- 4. no cache dir -> graceful exit 0 ---------------------------------------
+empty="$TMP/empty-home"
+mkdir -p "$empty"
+rc=0
+out="$(CODEX_HOME="$empty/.codex" bash "$SANITIZER" 2>&1)" || rc=$?
+if [ "$rc" -eq 0 ]; then pass "no-cache exits 0"; else fail "no-cache exit $rc (want 0)"; fi
+echo "$out" | grep -q "no Codex plugin cache" || fail "no-cache message missing"
+
+# --- 5. unknown arg rejected (exit 2) -----------------------------------------
+rc=0
+CODEX_HOME="$TMP/.codex" bash "$SANITIZER" --bogus >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 2 ]; then pass "unknown arg rejected (exit 2)"; else fail "unknown arg exit $rc (want 2)"; fi
+
+echo ""
+if [ "$fails" -eq 0 ]; then echo "PASS"; else echo "FAIL ($fails)"; exit 1; fi


### PR DESCRIPTION
Codex-harness parity (two changes):

**adopt soft-checks `claude`** — `scripts/adopt.{sh,ps1}` no longer hard-require
the `claude` CLI. Core deps (bash/git/jq/python3) stay required; a missing
`claude` only warns and skips the Claude plugin-install step, so a Codex-only (or
any non-Claude) adopter still gets the harness-agnostic core.

**sanitize external-plugin hooks.json** — `scripts/codex/sanitize-plugin-hooks.{sh,ps1}`
strips the top-level `description` key that several external plugins ship in their
`hooks.json` (Codex's strict parser rejects it as `unknown field description` and
skips those hooks). Idempotent, atomic, preserves the `hooks` block; wired as a
non-fatal final phase into `install-himmel-codex.{sh,ps1}`. New hermetic tests for
both twins; docs updated (harness-compat §3, docs/setup/codex.md, scripts/codex/README.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
