### PR TITLE
fix(hooks): end-session-wiki BSD date +%s%3N no longer crashes success path (#202)

### DIFF
--- a/scripts/hooks/end-session-wiki.sh
+++ b/scripts/hooks/end-session-wiki.sh
@@ -439,7 +439,17 @@ HTTP_CODE="$(curl -sk -o /dev/null -w '%{http_code}' \
     --data-binary "$MARKDOWN" \
     "$ENDPOINT" 2>/dev/null || echo "000")"
 END_MS="$(date +%s%3N 2>/dev/null || echo 0)"
-ELAPSED=$((END_MS - START_MS))
+# `%3N` (nanoseconds) is a GNU extension. On macOS/BSD date it is NOT an error
+# (exit 0, so the `|| echo 0` guard never fires) — it yields a non-numeric
+# string like `17514160003N`. Under `set +e` the failed `$(( ))` leaves ELAPSED
+# UNSET, and the later `${ELAPSED}` reference in the success-path log line then
+# tripped `set -u` ("unbound variable"), aborting the hook before its success
+# log + crystallizer spawn. So only compute the (cosmetic) elapsed ms when both
+# stamps are pure integers; otherwise report 0. (GH#202 — sibling of GH#192.)
+case "${START_MS}:${END_MS}" in
+    *[!0-9:]*) ELAPSED=0 ;;
+    *) ELAPSED=$((END_MS - START_MS)) ;;
+esac
 
 if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ] && [ "$HTTP_CODE" != "204" ]; then
     # REST PUT failed (e.g. Obsidian not running) — fall back to on-disk write.

--- a/scripts/hooks/test-end-session-wiki.sh
+++ b/scripts/hooks/test-end-session-wiki.sh
@@ -298,6 +298,59 @@ sleep 0.5
 if [ ! -s "$MARK" ]; then pass "crystallize:false suppresses the spawn"; else fail "crystallize:false still spawned the crystallizer"; fi
 rm -rf "$SB"
 
+# --- Case 10: BSD/macOS `date +%s%3N` must not crash the REST-success path (GH#202)
+# `%N` is a GNU extension. On BSD date, `+%s%3N` is NOT an error (exit 0, so the
+# hook's `|| echo 0` guard never fires) — it yields a non-numeric string like
+# `17514160003N`. Under `set +e` the failed `$((END_MS - START_MS))` leaves
+# ELAPSED UNSET; the success-path log line `wrote ... (${ELAPSED}ms)` then
+# referenced it under `set -u` -> "unbound variable" -> the hook aborted BEFORE
+# its success log + crystallizer spawn (HIMMEL-576). Note delivered by the PUT,
+# but crystallization silently never fired on macOS. On a GNU box `%3N` works,
+# so reaching this needs a `date` shim emitting the BSD-shaped value for `%3N`
+# (real date otherwise) — the GNU-host technique from test-compute-duration.sh
+# (HIMMEL-653/GH#192) — plus a `curl` shim forcing HTTP 200 so the REST-success
+# branch (the only ELAPSED reader) is actually exercised.
+SB="$(make_sandbox)"
+SHIMDIR="$SB/bin"; mkdir -p "$SHIMDIR"
+REAL_DATE="$(command -v date)"
+cat > "$SHIMDIR/date" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+    *%3N*) printf '%sN\n' "\$('$REAL_DATE' +%s)"; exit 0 ;;
+esac
+exec '$REAL_DATE' "\$@"
+EOF
+chmod +x "$SHIMDIR/date"
+# Stub curl to report HTTP 200 for the vault PUT (the hook's only curl call),
+# so the hook takes the success path that reads ELAPSED.
+cat > "$SHIMDIR/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '200'
+EOF
+chmod +x "$SHIMDIR/curl"
+MARK="$SB/marker.txt"
+payload=$(printf '{"transcript_path":"%s","cwd":"%s","session_id":"t","reason":"other"}' "$SB/transcript.jsonl" "$SB/proj")
+RC="$(printf '%s' "$payload" | env OSTYPE="linux-gnu" OS="" PATH="$SHIMDIR:$PATH" \
+        LUNA_VAULT_PATH="$SB/vault" OBSIDIAN_API_KEY="dummy-key" \
+        STUB_MODE="success" CRYSTALLIZE_MARKER="$MARK" CRYSTALLIZE_PID_DIR="$SB/pids" \
+        CLAUDE_PROJECT_DIR="$SB/proj" bash "$HOOK"; echo $?)"
+if [ "$RC" = "0" ]; then pass "GH#202: BSD-shaped %3N — hook still exits 0"; else fail "GH#202: exit was $RC, expected 0"; fi
+if grep -q 'wrote ' "$SB/proj/.claude/end-session-wiki.log" 2>/dev/null \
+   && ! grep -q 'unbound variable\|FAILED' "$SB/proj/.claude/end-session-wiki.log" 2>/dev/null; then
+    pass "GH#202: REST-success log line survives a non-numeric %3N (no unbound-var crash)"
+else
+    fail "GH#202: non-numeric %3N crashed the success path before the 'wrote' log"
+fi
+# The crystallizer spawn is line 457 — reached only if line 456's ELAPSED
+# reference didn't abort. Poll for the marker the same way as Case 8.
+i=0; while [ ! -s "$MARK" ] && [ "$i" -lt 30 ]; do sleep 0.1; i=$((i + 1)); done
+if [ -s "$MARK" ]; then
+    pass "GH#202: crystallizer still spawns after a non-numeric %3N"
+else
+    fail "GH#202: %3N crash pre-empted the crystallizer spawn"
+fi
+rm -rf "$SB"
+
 if [ "$FAILED" -eq 0 ]; then
     echo "ALL PASS"
     exit 0


### PR DESCRIPTION
Fixes #202.

`scripts/hooks/end-session-wiki.sh` timed the vault PUT with `date +%s%3N` for a cosmetic `wrote X (Nms)` log line. `%N` is a GNU extension. On macOS/BSD `date`, `+%s%3N` is not an error (exit 0, so the `|| echo 0` guard never fires) — it yields a non-numeric string like `17514160003N`.

Under the hook's `set +e`, the failed `ELAPSED=$((END_MS - START_MS))` leaves `ELAPSED` unset; the success-path log line `wrote ... (${ELAPSED}ms)` then references it under `set -u` (`unbound variable`), aborting the hook before its success log and its crystallizer spawn. The note is delivered by the PUT, but crystallization silently never fires on macOS.

**Fix:** compute the elapsed ms only when both stamps are pure integers; otherwise report `0`. `ELAPSED` is always assigned → no unbound crash. bash 3.2-safe `case` glob; GNU/Linux/Windows behaviour unchanged. Same class as #192.

**Tests:** new Case 10 in `test-end-session-wiki.sh` shims `date` (BSD-shaped `%3N`) and `curl` (force HTTP 200) to exercise the REST-success branch. Verified it fails on the pre-fix code and passes after. Full suite passes; shellcheck clean.
