### PR TITLE
fix(ci): portable mapfile + public-aware C10 doctor test

### DIFF
--- a/scripts/handover/flush.sh
+++ b/scripts/handover/flush.sh
@@ -128,7 +128,9 @@ if [ "$forge_usable" -eq 0 ] && [ "$NO_PR_OPEN" -eq 0 ]; then
 fi
 
 # Collect local handover/* branches. Sorted for deterministic output.
-mapfile -t branches < <($GIT_CMD -C "$handover_repo" for-each-ref --format='%(refname:short)' 'refs/heads/handover/' 2>/dev/null | sort)
+# bash 3.2-safe (macOS): no mapfile.
+branches=()
+while IFS= read -r _line; do branches+=("$_line"); done < <($GIT_CMD -C "$handover_repo" for-each-ref --format='%(refname:short)' 'refs/heads/handover/' 2>/dev/null | sort)
 
 if [ ${#branches[@]} -eq 0 ]; then
     echo "flush: no local handover/* branches — nothing to do."

--- a/scripts/handover/generate-morning-briefing.sh
+++ b/scripts/handover/generate-morning-briefing.sh
@@ -191,7 +191,9 @@ fi
 commit_count=$(printf '%s\n' "$commits_raw" | grep -c . || true)
 
 # Extract HIMMEL-N / LUNA-N ticket keys from commit messages.
-mapfile -t ticket_keys < <(printf '%s\n' "$commits_raw" \
+# bash 3.2-safe (macOS): no mapfile.
+ticket_keys=()
+while IFS= read -r _line; do ticket_keys+=("$_line"); done < <(printf '%s\n' "$commits_raw" \
     | grep -oE '[A-Z][A-Z0-9]+-[0-9]+' \
     | sort -u)
 

--- a/scripts/hooks/CLAUDE.md
+++ b/scripts/hooks/CLAUDE.md
@@ -7,9 +7,9 @@ is how to safely edit a hook.
 ## Editing conventions
 - Most hooks have a paired smoke test `test-<name>.sh` (the suite is the
   spec). **Update it when you change such a hook; add one for new hooks.**
-- **bash 3.2-compatible by default** (macOS ships 3.2). Only reach for bash
-  4 features (`mapfile`/associative arrays) when necessary — 8 scripts do,
-  the rest must stay 3.2-safe.
+- **bash 3.2-compatible by default** (macOS ships 3.2). Avoid bash 4 features
+  (`mapfile` — use a `while IFS= read -r` loop; associative arrays). All hooks
+  here are 3.2-safe.
 - Hooks fail-closed (non-zero exit blocks the action). Preserve that.
   Exception: `auto-arm-on-cap.sh` is a WATCHDOG, deliberately fail-open
   (it must never block tool calls on its own bugs) — do not "fix" it

--- a/scripts/hooks/check-lockfile-integrity.sh
+++ b/scripts/hooks/check-lockfile-integrity.sh
@@ -10,7 +10,9 @@
 set -euo pipefail
 
 # Scoped to scripts/ so we don't recurse into nested worktrees under .claude/.
-mapfile -t pkgs < <(find scripts -maxdepth 3 -name package.json -not -path '*/node_modules/*')
+# bash 3.2-safe (macOS): no mapfile.
+pkgs=()
+while IFS= read -r _line; do pkgs+=("$_line"); done < <(find scripts -maxdepth 3 -name package.json -not -path '*/node_modules/*')
 
 if [ ${#pkgs[@]} -eq 0 ]; then
     echo "→ lockfile-integrity: no npm/bun projects under scripts/, skipping"

--- a/scripts/hooks/check-mcp-plugin-refs.sh
+++ b/scripts/hooks/check-mcp-plugin-refs.sh
@@ -50,7 +50,8 @@ is_exempt() {
 # always_run usage also works.
 files=("$@")
 if [ "${#files[@]}" -eq 0 ]; then
-    mapfile -t files < <(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
+    # bash 3.2-safe (macOS): no mapfile.
+    while IFS= read -r _line; do files+=("$_line"); done < <(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
 fi
 [ "${#files[@]}" -eq 0 ] && exit 0
 

--- a/scripts/hooks/check-no-headless-claude.sh
+++ b/scripts/hooks/check-no-headless-claude.sh
@@ -89,7 +89,8 @@ has_optin_marker() {
 # hook also works when invoked standalone.
 files=("$@")
 if [ "${#files[@]}" -eq 0 ]; then
-    mapfile -t files < <(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
+    # bash 3.2-safe (macOS): no mapfile.
+    while IFS= read -r _line; do files+=("$_line"); done < <(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
 fi
 [ "${#files[@]}" -eq 0 ] && exit 0
 

--- a/scripts/hooks/check-no-headless-gemini.sh
+++ b/scripts/hooks/check-no-headless-gemini.sh
@@ -83,7 +83,8 @@ has_optin_marker() {
 # hook also works when invoked standalone.
 files=("$@")
 if [ "${#files[@]}" -eq 0 ]; then
-    mapfile -t files < <(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
+    # bash 3.2-safe (macOS): no mapfile.
+    while IFS= read -r _line; do files+=("$_line"); done < <(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
 fi
 [ "${#files[@]}" -eq 0 ] && exit 0
 

--- a/scripts/hooks/check-npm-audit-signatures.sh
+++ b/scripts/hooks/check-npm-audit-signatures.sh
@@ -5,7 +5,9 @@
 set -euo pipefail
 
 # Scoped to scripts/ so we don't recurse into nested worktrees under .claude/.
-mapfile -t pkgs < <(find scripts -maxdepth 3 -name package.json -not -path '*/node_modules/*')
+# bash 3.2-safe (macOS): no mapfile.
+pkgs=()
+while IFS= read -r _line; do pkgs+=("$_line"); done < <(find scripts -maxdepth 3 -name package.json -not -path '*/node_modules/*')
 
 if [ ${#pkgs[@]} -eq 0 ]; then
     echo "→ npm audit signatures: no package.json found under scripts/ — nothing to verify"

--- a/scripts/hooks/check-npm-audit.sh
+++ b/scripts/hooks/check-npm-audit.sh
@@ -11,10 +11,10 @@ if ! pkgs_raw=$(git ls-files '*package.json' ':(exclude)*/node_modules/*'); then
     echo "ERROR: 'git ls-files' failed — cannot enumerate packages to audit." >&2
     exit 1
 fi
+pkgs=()
 if [ -n "$pkgs_raw" ]; then
-    mapfile -t pkgs <<<"$pkgs_raw"
-else
-    pkgs=()
+    # bash 3.2-safe (macOS): no mapfile.
+    while IFS= read -r _line; do pkgs+=("$_line"); done <<<"$pkgs_raw"
 fi
 
 if [ ${#pkgs[@]} -eq 0 ]; then

--- a/scripts/hooks/check-npm-licenses.sh
+++ b/scripts/hooks/check-npm-licenses.sh
@@ -16,10 +16,10 @@ if ! pkgs_raw=$(git ls-files '*package.json' ':(exclude)*/node_modules/*'); then
     echo "ERROR: 'git ls-files' failed — cannot enumerate packages to license-check." >&2
     exit 1
 fi
+pkgs=()
 if [ -n "$pkgs_raw" ]; then
-    mapfile -t pkgs <<<"$pkgs_raw"
-else
-    pkgs=()
+    # bash 3.2-safe (macOS): no mapfile.
+    while IFS= read -r _line; do pkgs+=("$_line"); done <<<"$pkgs_raw"
 fi
 
 if [ ${#pkgs[@]} -eq 0 ]; then

--- a/scripts/hooks/check-uv-lock.sh
+++ b/scripts/hooks/check-uv-lock.sh
@@ -6,7 +6,9 @@
 # Soft-fail when `uv` is missing so contributors who don't touch Python aren't blocked.
 set -euo pipefail
 
-mapfile -t projects < <(find . -maxdepth 4 -name pyproject.toml \
+# bash 3.2-safe (macOS): no mapfile.
+projects=()
+while IFS= read -r _line; do projects+=("$_line"); done < <(find . -maxdepth 4 -name pyproject.toml \
     -not -path '*/.venv/*' \
     -not -path '*/node_modules/*' \
     -not -path '*/.claude/*')

--- a/scripts/luna/sweep-himmel.sh
+++ b/scripts/luna/sweep-himmel.sh
@@ -245,11 +245,12 @@ EOF
         echo "_No merged PRs in this window._"
         echo ""
     else
-        # Use mapfile to avoid `jq | while read` subshell — silent jq
-        # failures inside a pipe-fed while loop would leave the script
-        # rc=0 with partial output. mapfile keeps the loop in the parent
-        # shell so `set -e` actually fires on per-line jq failure.
-        mapfile -t PR_LINES < <(printf '%s' "$PR_JSON" | jq -r '.[] | @json')
+        # Read via process substitution (not `jq | while read`) so the loop
+        # runs in the PARENT shell — a pipe-fed while loop would swallow silent
+        # jq failures and leave the script rc=0 with partial output. bash
+        # 3.2-safe (macOS): no mapfile.
+        PR_LINES=()
+        while IFS= read -r _line; do PR_LINES+=("$_line"); done < <(printf '%s' "$PR_JSON" | jq -r '.[] | @json')
         for pr_line in "${PR_LINES[@]}"; do
             pr_number=$(echo "$pr_line" | jq -r '.number')
             pr_title=$(echo "$pr_line" | jq -r '.title')

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -100,14 +100,14 @@ if [ "${#_missing[@]}" -gt 0 ]; then
   _missing=("${_still[@]}")
 fi
 
-# Bash version: 8 scripts use mapfile (bash 4+). Warn on bash 3.x rather
-# than fail-hard — those scripts will error at invocation time with a
-# clear "mapfile: command not found", and the foundational ones (e.g.
-# Claude PreToolUse hooks) are all bash 3.2-compatible.
+# Bash version: a few non-foundational scripts use bash 4+ features (associative
+# arrays via `declare -A`, e.g. scripts/skill-index/build-skill-index.sh). Warn on
+# bash 3.x rather than fail-hard — the foundational ones (e.g. Claude PreToolUse
+# hooks) are all bash 3.2-compatible.
 _bash_major=$(bash -c 'echo "${BASH_VERSION:0:1}"' 2>/dev/null || echo "?")
 if [ "$_bash_major" != "?" ] && [ "$_bash_major" -lt 4 ] 2>/dev/null; then
   echo "  WARN bash $BASH_VERSION detected (system default on macOS is 3.2)." >&2
-  echo "       Foundational scripts work; 8 hooks under scripts/hooks/check-* + scripts/luna/sweep-himmel.sh use mapfile (bash 4+)." >&2
+  echo "       Foundational scripts work; a few non-foundational scripts use bash 4+ features (associative arrays)." >&2
   echo "       Fix: brew install bash  (then ensure /opt/homebrew/bin or /usr/local/bin is on PATH)." >&2
 fi
 

--- a/scripts/test-himmel-doctor.sh
+++ b/scripts/test-himmel-doctor.sh
@@ -401,6 +401,14 @@ out="$(HIMMEL_PUBLIC_CLONE="$t/none" DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json
 if printf '%s' "$out" | grep -q 'OK   C10-propagation' && [ "$rc" -eq 0 ]; then pass "C10 -> OK (skip, no clone)"; else fail "C10 -> rc=$rc; $(printf '%s' "$out" | grep C10)"; fi
 rm -rf "$t"
 
+# Public/adopter clones lack the private-only mirror tooling
+# (scripts/propagate-public.sh + scripts/lib/propagation-drift.sh), so the doctor's
+# C10 check short-circuits to a clean "skipped (no private mirror tooling)" OK
+# BEFORE it ever consults HIMMEL_PRIV_ROOT (see check_c10() in himmel-doctor.sh). On such a
+# checkout the seeded-drift / unreadable-refs fixtures can never surface a WARN —
+# so the assertion is gated on whether this checkout actually carries the tooling.
+if [ -f "$REPO_ROOT/scripts/propagate-public.sh" ] && [ -f "$REPO_ROOT/scripts/lib/propagation-drift.sh" ]; then C10_TOOLING=1; else C10_TOOLING=0; fi
+
 echo "== C10: seeded drift fixture -> WARN C10-propagation =="
 t="$(mktemp -d)"; mkdir -p "$t/claude"; write_settings "$t/claude" "$WRAPPER"
 ps="$t/ps"; mkdir -p "$ps/scripts"; printf 'stub\n' > "$ps/scripts/propagate-public.sh"; printf 'new doc\n' > "$ps/onlypriv.md"
@@ -410,7 +418,11 @@ mk10 "$us" "$t/us.git" "$t/uc"
 out="$(HIMMEL_PRIV_ROOT="$t/pc" HIMMEL_PUBLIC_CLONE="$t/uc" HIMMEL_PUBLIC_REMOTE="us.git" \
     DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" \
     bash "$DOC" --no-color 2>&1)"
-if printf '%s' "$out" | grep -q 'WARN C10-propagation' && printf '%s' "$out" | grep -q 'onlypriv.md'; then pass "C10 -> WARN (seeded drift, MISSING flagged)"; else fail "C10 -> $(printf '%s' "$out" | grep -A6 C10)"; fi
+if [ "$C10_TOOLING" -eq 1 ]; then
+    if printf '%s' "$out" | grep -q 'WARN C10-propagation' && printf '%s' "$out" | grep -q 'onlypriv.md'; then pass "C10 -> WARN (seeded drift, MISSING flagged)"; else fail "C10 -> $(printf '%s' "$out" | grep -A6 C10)"; fi
+else
+    if printf '%s' "$out" | grep -q 'OK   C10-propagation' && printf '%s' "$out" | grep -q 'skipped (no private mirror tooling)'; then pass "C10 -> skip (public checkout, no mirror tooling)"; else fail "C10 -> $(printf '%s' "$out" | grep -A6 C10)"; fi
+fi
 rm -rf "$t"
 
 echo "== C10: unreadable origin/main -> WARN (stale/unreadable refs, not false-clean) =="
@@ -426,7 +438,11 @@ mk10 "$us" "$t/us.git" "$t/uc"
 out="$(HIMMEL_PRIV_ROOT="$ps" HIMMEL_PUBLIC_CLONE="$t/uc" HIMMEL_PUBLIC_REMOTE="us.git" \
     DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" \
     bash "$DOC" --no-color 2>&1)"
-if printf '%s' "$out" | grep -q 'WARN C10-propagation' && ! printf '%s' "$out" | grep -q 'OK   C10-propagation'; then pass "C10 -> WARN (unreadable refs, not false-clean)"; else fail "C10 unreadable -> $(printf '%s' "$out" | grep -A4 C10)"; fi
+if [ "$C10_TOOLING" -eq 1 ]; then
+    if printf '%s' "$out" | grep -q 'WARN C10-propagation' && ! printf '%s' "$out" | grep -q 'OK   C10-propagation'; then pass "C10 -> WARN (unreadable refs, not false-clean)"; else fail "C10 unreadable -> $(printf '%s' "$out" | grep -A4 C10)"; fi
+else
+    if printf '%s' "$out" | grep -q 'OK   C10-propagation' && printf '%s' "$out" | grep -q 'skipped (no private mirror tooling)'; then pass "C10 -> skip (public checkout, no mirror tooling)"; else fail "C10 unreadable -> $(printf '%s' "$out" | grep -A4 C10)"; fi
+fi
 rm -rf "$t"
 
 rm -rf "$FAKEROOT"


### PR DESCRIPTION
Fixes the public shell-unit CI reds: C10 doctor sub-tests now assert the clean skip when the checkout lacks private mirror tooling (design intent, no guard weakened), and all bash-4-only mapfile/readarray uses are replaced with bash-3.2-safe while-read loops for the macOS leg.