### PR TITLE
fix(codex): debrand Fable identity/quota/effort claims in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,12 +137,12 @@ working while it runs; intervene only if one goes off track or is
 missing context. Tier by job: **Haiku** = bulk mechanical work;
 **Sonnet** = most implementation, research, synthesis; **Opus** =
 reasoning-heavy subagent phases (deep review, plan drafts, tradeoff
-analysis); the **Fable main thread** orchestrates and owns final
+analysis); the **main thread** orchestrates and owns final
 judgment + synthesis across everything it spawned. **Every dispatch
-names an explicit model** — an unnamed dispatch inherits the Fable
-main loop and burns the time-limited Fable quota on work a cheaper
+names an explicit model** — an unnamed dispatch inherits the main
+loop and burns the time-limited top-tier quota on work a cheaper
 tier handles.
-Raise *effort* before raising model tier — Fable-5 `low` ≈ prior-gen
+Raise *effort* before raising model tier — on Claude, Fable-5 `low` ≈ prior-gen
 `xhigh`, and the same shift applies down-tier.
 Invariants (not model-tuned; survive the HIMMEL-282 revert): spawn-depth
 limit **2** (nesting is now platform-supported to ~depth 5, staged and

--- a/scripts/agents-md/debrand.json
+++ b/scripts/agents-md/debrand.json
@@ -13,5 +13,25 @@
     "from": "the Bash tool",
     "to": "your shell-execution mechanism",
     "note": "Full-phrase tool reference -> behavioral text."
+  },
+  {
+    "from": "the **Fable main thread**",
+    "to": "the **main thread**",
+    "note": "HIMMEL-559: identity claim — a Codex/GPT session must not read itself as the Fable main thread. Fable mentions in FABLE-WINDOW provenance comments stay (documentary, not identity)."
+  },
+  {
+    "from": "inherits the Fable\nmain loop",
+    "to": "inherits the main\nloop",
+    "note": "HIMMEL-559: spans CLAUDE.md's hard wrap — the embedded newline is load-bearing; if CLAUDE.md rewraps this phrase the entry stops matching and the debrand test's leak check catches it."
+  },
+  {
+    "from": "the time-limited Fable quota",
+    "to": "the time-limited top-tier quota",
+    "note": "HIMMEL-559: quota claim — neutral tier language; every harness has some premium-tier budget the rule protects."
+  },
+  {
+    "from": "Fable-5 `low` ≈ prior-gen\n`xhigh`",
+    "to": "on Claude, Fable-5 `low` ≈ prior-gen\n`xhigh`",
+    "note": "HIMMEL-559: the effort calibration is a Claude-family fact (false for GPT) — attribute it instead of asserting it about the reading model. Embedded newline matches CLAUDE.md's wrap, same caveat as above."
   }
 ]

--- a/scripts/agents-md/test-generate.sh
+++ b/scripts/agents-md/test-generate.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Tests for generate.mjs — the CLAUDE.md -> AGENTS.md generator (HIMMEL-471).
-# Bash 3.2-safe. Uses temp fixtures + env path overrides; never touches the
-# repo's real CLAUDE.md / AGENTS.md.
+# Bash 3.2-safe. Uses temp fixtures + env path overrides; never WRITES the
+# repo's real CLAUDE.md / AGENTS.md. One deliberate exception to fixture
+# hermeticity: section 9b READS the real CLAUDE.md as a rewrap-drift guard
+# (HIMMEL-559), so an unrelated CLAUDE.md edit can legitimately fail it.
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GEN="$SCRIPT_DIR/generate.mjs"
@@ -104,6 +106,97 @@ run 0 "idempotency write #1" -- --write
 cp "$TGT" "$TMP/first"
 run 0 "idempotency write #2" -- --write
 if cmp -s "$TMP/first" "$TGT"; then ok "two writes are byte-identical"; else bad "two writes are byte-identical"; fi
+
+# ---- 9. Fable debrand (HIMMEL-559) ----------------------------------------
+# a) fixture: identity / quota / effort-calibration claims are neutralized.
+# The fixture reproduces the two wrap points that matter — the embedded
+# newlines in the 'Fable main loop' and 'Fable-5' entries are part of the
+# contract (the rest of the fixture is condensed, not a verbatim copy).
+FAB="$TMP/fable.md"; TGTFAB="$TMP/AGENTS-fable.md"
+cat > "$FAB" <<'EOF'
+# Fixture Rules
+
+analysis); the **Fable main thread** orchestrates and owns final
+judgment + synthesis. **Every dispatch names an explicit model** — an
+unnamed dispatch inherits the Fable
+main loop and burns the time-limited Fable quota on work a cheaper
+tier handles.
+Raise *effort* before raising model tier — Fable-5 `low` ≈ prior-gen
+`xhigh`, and the same shift applies down-tier.
+EOF
+SAVED_SRC="$SRC"; SAVED_TGT="$TGT"; SRC="$FAB"; TGT="$TGTFAB"
+run 0 "fable fixture write succeeds" -- --write
+if grep -q 'the \*\*main thread\*\* orchestrates' "$TGT" && ! grep -q 'Fable main thread' "$TGT"; then
+  ok "identity claim neutralized (main thread)"
+else bad "identity claim neutralized (main thread)"; fi
+if grep -q 'time-limited top-tier quota' "$TGT" && ! grep -q 'Fable quota' "$TGT"; then
+  ok "quota claim neutralized"
+else bad "quota claim neutralized"; fi
+if grep -q 'inherits the main$' "$TGT"; then
+  ok "wrap-spanning 'Fable main loop' entry matched across the newline"
+else bad "wrap-spanning 'Fable main loop' entry matched across the newline"; fi
+if grep -q 'on Claude, Fable-5' "$TGT"; then
+  ok "effort calibration attributed to Claude"
+else bad "effort calibration attributed to Claude"; fi
+SRC="$SAVED_SRC"; TGT="$SAVED_TGT"
+
+# b) real-CLAUDE.md leak check: after generation, no identity-claiming Fable
+# text may survive outside HTML comments (FABLE-WINDOW provenance comments are
+# documentary and allowed). This is the guard that catches a CLAUDE.md rewrap
+# silently breaking the newline-embedded debrand entries. Reads the repo's
+# real CLAUDE.md; writes only to a temp target.
+strip_html_comments() {   # <in> <out>
+  # Two-pass on purpose: a bare sed RANGE ('/<!--/,/-->/d') treats a
+  # SINGLE-LINE '<!-- ... -->' as an unterminated range START (addr2 is only
+  # tested from the NEXT line) and deletes everything to the next '-->' or
+  # EOF — the preamble's single-line comments would swallow the whole body
+  # and make the leak check vacuously pass. So: drop inline comment spans
+  # first, then range-drop the remaining true multi-line blocks.
+  sed 's/<!--.*-->//g' "$1" | sed '/<!--/,/-->/d' > "$2"
+}
+REAL_SRC="$SCRIPT_DIR/../../CLAUDE.md"; TGTREAL="$TMP/AGENTS-real.md"
+if [ -f "$REAL_SRC" ]; then
+  SAVED_SRC="$SRC"; SAVED_TGT="$TGT"; SRC="$REAL_SRC"; TGT="$TGTREAL"
+  run 0 "real-CLAUDE.md write succeeds" -- --write
+  stripped="$TMP/real-stripped.md"
+  strip_html_comments "$TGTREAL" "$stripped"
+  # Guard the guard: the strip must not have eaten the body (a regression back
+  # to the vacuous strip would silently green-light every leak).
+  if grep -q 'Subagent policy' "$stripped"; then
+    ok "comment-strip preserves the body (leak check is non-vacuous)"
+  else bad "comment-strip preserves the body (leak check is non-vacuous)"; fi
+  # A leak = ANY 'Fable' text outside comments except the explicitly attributed
+  # calibration phrase. Strip the allowed phrase FIRST, then any residual
+  # 'Fable' is a leak — line-position-independent, so it catches wrap-split
+  # fragments (e.g. '**Fable' / 'main thread**' after a rewrap breaks an
+  # entry) and future unattributed Fable-5 mentions alike.
+  leaks="$(sed 's/on Claude, Fable-5//g' "$stripped" | grep -n 'Fable' || true)"
+  if [ -z "$leaks" ]; then
+    ok "no Fable text outside comments except attributed calibration (real CLAUDE.md)"
+  else bad "no Fable text outside comments except attributed calibration (real CLAUDE.md): $leaks"; fi
+  SRC="$SAVED_SRC"; TGT="$SAVED_TGT"
+fi
+
+# c) RED PATH: prove the leak check actually fires when a rewrap breaks an
+# entry. Re-wrap 'the **Fable main thread**' across a line boundary — entry 4
+# (no embedded newline) stops matching and the leaked fragments span two lines,
+# which the old line-based patterns ('the Fable|Fable main|Fable quota') could
+# NOT see. The strip-then-residual check must still flag it.
+BROKEN="$TMP/fable-rewrap.md"; TGTBROKEN="$TMP/AGENTS-broken.md"
+cat > "$BROKEN" <<'EOF'
+# Fixture Rules
+
+analysis); the **Fable
+main thread** orchestrates and owns final judgment.
+EOF
+SAVED_SRC="$SRC"; SAVED_TGT="$TGT"; SRC="$BROKEN"; TGT="$TGTBROKEN"
+run 0 "rewrap red-path fixture write succeeds" -- --write
+broken_stripped="$TMP/broken-stripped.md"
+strip_html_comments "$TGTBROKEN" "$broken_stripped"
+if sed 's/on Claude, Fable-5//g' "$broken_stripped" | grep -q 'Fable'; then
+  ok "leak check fires on a rewrap-broken entry (red path)"
+else bad "leak check fires on a rewrap-broken entry (red path)"; fi
+SRC="$SAVED_SRC"; TGT="$SAVED_TGT"
 
 # ---- summary --------------------------------------------------------------
 printf '\n%d passed, %d failed\n' "$pass" "$fail"


### PR DESCRIPTION
Propagated from the private repo (CR-clean there: free cross-model panel + 3 reviewer agents). The generated AGENTS.md no longer tells a non-Claude session it is 'the Fable main thread' with a 'Fable quota'; the Claude-only effort calibration is attributed instead of asserted about the reader. Test section 9 adds fixture substitution checks, a real-CLAUDE.md leak check (two-pass HTML-comment strip + non-vacuousness guard), and a red-path rewrap case. 30/30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)