### PR TITLE
fix(hooks): full-body detach jira-nudge-on-end (SessionEnd "Hook cancelled")

### DIFF
--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -549,9 +549,18 @@ lives in `scripts/lib/jira-breadcrumb.sh`.
 Suppressed when the `ticket` initiative leg is active (`HIMMEL_INITIATIVE`
 includes `ticket`) — that leg already injects the same reminder at SessionStart,
 so this is the second advisory surface for when the leg is OFF, not a structural
-backstop. Nudge surface: stdout + a Telegram relay when configured
-(`TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID`, or the `JIRA_NUDGE_RELAY_CMD`
-override) — the only operator-reaching channel for an unattended session.
+backstop. The whole detection body runs **full-body detached** (HIMMEL-661,
+same `__himmel_detached` re-exec pattern as `refresh-where-are-we-on-end.sh`):
+the parent parks the SessionEnd payload in a temp file and returns in ~0.1s,
+so in practice it no longer loses the teardown race ("Hook cancelled") — even
+the gate-off path previously cost ~1.7s of process spawns on Windows Git Bash.
+Nudge surface: the Telegram relay when configured (`TELEGRAM_BOT_TOKEN` +
+`TELEGRAM_CHAT_ID`, or the `JIRA_NUDGE_RELAY_CMD` override) — the only
+operator-reaching channel for an unattended session; the stdout print survives
+only for direct child-mode invocation (`bash jira-nudge-on-end.sh
+__himmel_detached <payload-file>` — tests or a manual debug run reproducing
+that contract; a plain manual invocation goes through the detaching parent and
+produces no stdout).
 Paired hermetic suite: `scripts/hooks/test-jira-nudge-on-end.sh`.
 
 ## Claude PostToolUse Hooks

--- a/scripts/hooks/jira-nudge-on-end.sh
+++ b/scripts/hooks/jira-nudge-on-end.sh
@@ -18,12 +18,25 @@
 #   7. NO jira-mutation breadcrumb exists with epoch >= session start
 #      (scripts/jira/src/breadcrumb.ts drops these on every mutating verb).
 #
-# Nudge surface: stdout (transcript) + relay via the Telegram bridge when
-# configured (the only operator-reaching channel unattended). Best-effort.
+# Nudge surface: the Telegram relay when configured (the only operator-reaching
+# channel unattended). The stdout print survives only for direct CHILD-MODE
+# invocation — `bash jira-nudge-on-end.sh __himmel_detached <payload-file>`
+# (tests, or a manual debug run reproducing that contract); a plain manual
+# invocation goes through the detaching parent and produces no stdout, since in
+# production the whole body runs full-body DETACHED (HIMMEL-661, see below).
+# Best-effort. NOTE: since HIMMEL-661 the hook depends on lib/detach.sh to do
+# anything at all (pre-661 a missing detach.sh only degraded the relay).
 #
 # Wiring: himmel-ops plugin hooks.json SessionEnd (exec-if-exists), default OFF.
-# Test seams (used only by test-jira-nudge-on-end.sh):
-#   JIRA_NUDGE_RELAY_CMD   override the relay command (default Telegram curl)
+# Test seams:
+#   JIRA_NUDGE_RELAY_CMD    override the relay command (default Telegram curl);
+#                           used by test-jira-nudge-on-end.sh AND
+#                           test-codex-stop-hooks.sh.
+#   JIRA_NUDGE_TEST_DELAY   (test-jira-nudge-on-end.sh only) sleep N seconds at
+#                           the START of the detached child body. Proves the
+#                           full-body detach keeps the PARENT fast: a regression
+#                           that un-detaches the body would make this delay
+#                           block teardown.
 
 # This hook runs under bash on every platform (no .ps1 twin), so do NOT add a
 # msys/cygwin guard — that would silence the nudge on Windows/Git-Bash.
@@ -38,9 +51,52 @@ set +e
 set -u 2>/dev/null || true
 trap 'exit 0' EXIT
 
-# Drain stdin (SessionEnd pipes a JSON payload).
-PAYLOAD=""
-if [ -t 0 ]; then :; else PAYLOAD="$(cat 2>/dev/null || true)"; fi
+# --- Full-body detach (HIMMEL-661, extends the HIMMEL-636 pattern) -----------
+# Re-exec ourselves DETACHED with the SessionEnd payload parked in a temp file,
+# and return 0 instantly. Even the gate-off fast path costs ~1.7s of process
+# spawns on Windows Git Bash (payload jq, git rev-parse, dotenv) — all BEFORE
+# the gate check — which loses the race against Claude Code's SessionEnd
+# teardown: the recurring "Hook cancelled" that HIMMEL-635 (relay detach) and
+# HIMMEL-636 (single-scan transcript parse) shaved but did not eliminate. The
+# sibling refresh-where-are-we-on-end.sh returns in ~0.1s with this same
+# full-body detach and no longer errors. The stdout nudge surface this hook
+# previously stayed synchronous to preserve was already unreliable (a cancelled
+# hook loses stdout AND relay); after this change the (already-detached) relay
+# is the operator-reaching surface, and stdout survives for direct child-mode
+# invocation only.
+if [ "${1:-}" != "__himmel_detached" ]; then
+    # Drain stdin (SessionEnd pipes a JSON payload) so the contract doesn't break.
+    PAYLOAD=""
+    if [ -t 0 ]; then :; else PAYLOAD="$(cat 2>/dev/null || true)"; fi
+    [ -n "$PAYLOAD" ] || exit 0
+    _tmp="$(mktemp "${TMPDIR:-/tmp}/jira-nudge-payload.XXXXXX" 2>/dev/null)" || exit 0
+    printf '%s' "$PAYLOAD" > "$_tmp" 2>/dev/null || { rm -f "$_tmp"; exit 0; }
+    # Guarded source: unlike the pre-661 flow (where a missing detach.sh only
+    # degraded the relay), the parent now depends on it for the hook to do
+    # ANYTHING — so on failure, clean up our own temp file instead of leaking
+    # one per session with no child to delete it.
+    _dlib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/detach.sh"
+    if [ -r "$_dlib" ]; then
+        # shellcheck source=/dev/null
+        . "$_dlib"
+        detach_run bash "${BASH_SOURCE[0]}" __himmel_detached "$_tmp"
+    else
+        rm -f "$_tmp"
+    fi
+    exit 0
+fi
+
+# === Detached child: detection + nudge (parent already returned 0) ===========
+
+# Test-only child-latency seam (see header). if-guarded so an unset value is a
+# clean no-op.
+if [ -n "${JIRA_NUDGE_TEST_DELAY:-}" ]; then
+    sleep "$JIRA_NUDGE_TEST_DELAY"
+fi
+
+# Recover the payload the parent parked; delete it whatever happens next.
+PAYLOAD="$(cat "${2:-}" 2>/dev/null || true)"
+rm -f "${2:-}" 2>/dev/null || true
 
 # Need jq + git to decide anything; absent → fail-safe (no nudge).
 command -v jq  >/dev/null 2>&1 || exit 0
@@ -93,10 +149,9 @@ fi
 # Only the FIRST timestamp is needed. Extract it directly rather than via
 # parse_session_transcript(), which runs FOUR full-file jq scans
 # (FIRST_TS/LAST_TS/LAST_ASSISTANT/COMMANDS) — three of which this hook never
-# uses. On a long transcript those synchronous scans are what race Claude Code's
-# SessionEnd teardown ("Hook cancelled"); the single-scan path keeps detection
-# cheap so the nudge stays SYNCHRONOUS (its stdout/transcript surface survives)
-# without a full-body detach. HIMMEL-636.
+# uses (HIMMEL-636). We now run detached (HIMMEL-661) so teardown no longer
+# races this scan, but keep the single-scan path — the detached child should
+# still be cheap on a long transcript.
 FIRST_TS=""
 if [ -n "$TRANSCRIPT_PATH" ] && [ -r "$TRANSCRIPT_PATH" ]; then
     FIRST_TS="$(jq -r 'select(.timestamp) | .timestamp' "$TRANSCRIPT_PATH" 2>/dev/null | head -n1)"

--- a/scripts/hooks/test-codex-stop-hooks.sh
+++ b/scripts/hooks/test-codex-stop-hooks.sh
@@ -31,10 +31,11 @@
 #      through run-hook.cmd and exits 0 emitting NO hookSpecificOutput on stdout
 #      (proves the Stop branch is taken, not the additionalContext wrap, and that an
 #      advisory hook never blocks teardown).
-#   3) BEHAVIORAL positive (jira-nudge gate ON, hermetic temp git repo) - the nudge
-#      reaches the adapter's STDERR as advisory and is NOT on stdout / NOT a
-#      hookSpecificOutput JSON. Directly validates the Stop-branch design (vs the
-#      vacuous gated-off "no JSON").
+#   3) BEHAVIORAL positive (jira-nudge gate ON, hermetic temp git repo) - since
+#      HIMMEL-661 the hook full-body-detaches, so the adapter surfaces NO nudge
+#      text on stdout or stderr; this case polls a stubbed relay-command log for
+#      the ticket and separately asserts stdout stays empty (nothing reaches the
+#      Codex Stop decision parser).
 #   4) EXIT-2 protection (adapter direct, temp CLAUDE_PROJECT_DIR fixture) - a Stop
 #      hook that exits 2 emitting hookSpecificOutput-looking stdout still yields
 #      adapter exit 0 with NO hookSpecificOutput on stdout (locks in that Stop never
@@ -139,9 +140,13 @@ for h in $STOP_HOOKS; do
   if ! grep -q 'hookSpecificOutput' "$out" 2>/dev/null; then ok "$h smoke: no hookSpecificOutput on stdout"; else bad "$h smoke: stdout leaked hookSpecificOutput ($(cat "$out"))"; fi
 done
 
-# == 3) Behavioral positive: jira-nudge gate ON -> nudge on STDERR, not stdout ==
+# == 3) Behavioral positive: jira-nudge gate ON -> detached relay fires ==
 # Hermetic temp git repo with a commit referencing TESTKEY-1 inside the session
 # window (transcript first-timestamp = far past), no breadcrumb, relay stubbed.
+# Since HIMMEL-661 the hook full-body-detaches: the adapter surfaces NO nudge
+# text (parent returns ~0.1s, child stdout goes to /dev/null) — the operator
+# surface is the relay, so this case polls for the stubbed relay's marker
+# written by the detached child.
 NUDGE_REPO="$TMP_ROOT/nudgerepo"
 mkdir -p "$NUDGE_REPO"
 (
@@ -163,16 +168,31 @@ if [ -z "$nudge_cmd" ]; then
 else
   nout="$TMP_ROOT/nudge.out"; nerr="$TMP_ROOT/nudge.err"
   # HIMMEL_INITIATIVE stripped (else the `ticket` leg would suppress the nudge);
-  # gate ON; JIRA_PROJECT_KEY injected (temp repo has no .env); relay -> `true`.
+  # gate ON; JIRA_PROJECT_KEY injected (temp repo has no .env); relay -> a stub
+  # that appends its argument to a log (the detached child's only observable).
   # HOME=$TMP_ROOT so the no-mutation breadcrumb check reads a temp store, never the
   # real ~/.claude/jira-breadcrumbs (a stale machine-global file could otherwise
   # suppress the nudge and false-FAIL this case).
+  NUDGE_RELAY_LOG="$TMP_ROOT/nudge-relay.log"
+  NUDGE_RELAY="$TMP_ROOT/nudge-relay"
+  cat > "$NUDGE_RELAY" <<RELAYEOF
+#!/usr/bin/env bash
+printf '%s\n' "\$1" >> "$NUDGE_RELAY_LOG"
+RELAYEOF
+  chmod +x "$NUDGE_RELAY"
   # shellcheck disable=SC2086 # $ENV_CLEAN flags + $nudge_cmd are intentional splits
   ( cd "$REPO_ROOT" && printf '%s' "$NUDGE_PAYLOAD" \
-      | env $ENV_CLEAN HOME="$TMP_ROOT" HIMMEL_JIRA_NUDGE=1 JIRA_PROJECT_KEY=TESTKEY JIRA_NUDGE_RELAY_CMD=true \
+      | env $ENV_CLEAN HOME="$TMP_ROOT" HIMMEL_JIRA_NUDGE=1 JIRA_PROJECT_KEY=TESTKEY JIRA_NUDGE_RELAY_CMD="$NUDGE_RELAY" \
         bash $nudge_cmd >"$nout" 2>"$nerr" ); rc=$?
   if [ "$rc" -eq 0 ]; then ok "jira-nudge positive: adapter exit 0"; else bad "jira-nudge positive: adapter exit 0 (got rc=$rc)"; fi
-  if grep -q 'TESTKEY-1' "$nerr" 2>/dev/null; then ok "jira-nudge positive: nudge surfaced on adapter STDERR (advisory)"; else bad "jira-nudge positive: nudge expected on stderr (stderr: $(cat "$nerr" 2>/dev/null); stdout: $(cat "$nout" 2>/dev/null))"; fi
+  # The detached child runs the full detection (~1-2s of spawns) before firing
+  # the relay — poll for the marker rather than asserting adapter output.
+  _w=0; while [ ! -f "$NUDGE_RELAY_LOG" ] && [ "$_w" -lt 10 ]; do sleep 1; _w=$((_w + 1)); done
+  if grep -q 'TESTKEY-1' "$NUDGE_RELAY_LOG" 2>/dev/null; then
+    ok "jira-nudge positive: detached child fired the relay with the ticket"
+  else
+    bad "jira-nudge positive: detached relay expected (log: $(cat "$NUDGE_RELAY_LOG" 2>/dev/null); stderr: $(cat "$nerr" 2>/dev/null))"
+  fi
   if [ ! -s "$nout" ]; then
     ok "jira-nudge positive: stdout fully empty (nothing reaches Codex Stop decision parser)"
   else

--- a/scripts/hooks/test-jira-nudge-on-end.sh
+++ b/scripts/hooks/test-jira-nudge-on-end.sh
@@ -94,17 +94,23 @@ build_case() {
 }
 
 # ---- run helper ------------------------------------------------------------
-# run_hook <gate> <initiative> → echoes stdout; sets RUN_RC
+# run_hook <gate> <initiative> → echoes stdout
+# Drives the hook in CHILD MODE (`__himmel_detached <payload-file>`) — the
+# production parent full-body-detaches (HIMMEL-661) and its stdout goes to
+# /dev/null, so the detection matrix asserts on the child's direct stdout.
+# The parent path itself is covered by the fast-return + relay cases below.
 run_hook() {
     local gate="$1" initiative="$2"
     rm -f "$RELAY_LOG"
-    local out
-    out="$(printf '%s' "$CASE_PAYLOAD" | env -u JIRA_PROJECT_KEY \
+    local pf out
+    pf="$(mktemp "$ROOT_TMP/payload.XXXXXX")"
+    printf '%s' "$CASE_PAYLOAD" > "$pf"
+    out="$(env -u JIRA_PROJECT_KEY \
         -u HIMMEL_INITIATIVE -u HIMMEL_INITIATIVE_OVERNIGHT -u HIMMEL_OVERNIGHT \
         HOME="$CASE_HOME" USERPROFILE="$CASE_HOME" PATH="$STUB_DIR:$PATH" \
         HIMMEL_JIRA_NUDGE="$gate" HIMMEL_INITIATIVE="$initiative" \
         JIRA_NUDGE_RELAY_CMD="$RELAY_CMD" \
-        bash "$HOOK" 2>/dev/null)"
+        bash "$HOOK" __himmel_detached "$pf" 2>/dev/null)"
     printf '%s' "$out"
 }
 
@@ -171,56 +177,136 @@ build_case "$PAST" "feat/HIMMEL-123" "did work" 0 0
 OUT="$(run_hook 1 "")"
 assert_no_nudge "unresolved-key suppresses" "$OUT"
 
-# 8b. Relay is DETACHED + FIRED (HIMMEL-635): drive the real Telegram path (no
-#     JIRA_NUDGE_RELAY_CMD seam) with a `curl` stub that DROPS A MARKER then
-#     sleeps past the hook budget. The hook must return FAST (proving detach) AND
-#     the marker must land (proving the relay was actually launched — the hook's
-#     `trap exit 0` returns 0 on every path, so timing alone can't tell "detached"
-#     from "never fired"). Skipped where GNU coreutils `timeout` is absent (stock
-#     macOS); the detach primitive's setsid+disown branches are covered portably
-#     by scripts/lib/test-detach.sh, so this case only proves the hook WIRES it.
+# 8b. PARENT MODE end-to-end (HIMMEL-635 + HIMMEL-661): drive the production
+#     entry path (piped payload, no child-mode args) through the real Telegram
+#     branch (no JIRA_NUDGE_RELAY_CMD seam) with a `curl` stub that DROPS A
+#     MARKER then sleeps past the hook budget. The parent must return FAST
+#     (proving the full-body detach) AND the marker must land (proving the
+#     detached child ran the whole detection body and launched the relay — the
+#     hook's `trap exit 0` returns 0 on every path, so timing alone can't tell
+#     "detached" from "never fired"). Skipped where GNU coreutils `timeout` is
+#     absent (stock macOS); the detach primitive's setsid+disown branches are
+#     covered portably by scripts/lib/test-detach.sh.
 if command -v timeout >/dev/null 2>&1; then
     build_case "$PAST" "feat/HIMMEL-123" "did work" 1 0
     CURL_MARK="$ROOT_TMP/curl-fired"
-    rm -f "$CURL_MARK"
-    # Unquoted heredoc so $CURL_MARK bakes into the stub; the surrounding quotes
-    # stay literal (only $CURL_MARK expands).
+    CURL_ARGS="$ROOT_TMP/curl-args"
+    rm -f "$CURL_MARK" "$CURL_ARGS"
+    # Unquoted heredoc so $CURL_MARK/$CURL_ARGS bake into the stub; the
+    # surrounding quotes stay literal. Args are recorded BEFORE the marker so
+    # a present marker implies complete args.
     cat > "$STUB_DIR/curl" <<CURLEOF
 #!/usr/bin/env bash
+printf '%s\n' "\$@" > "$CURL_ARGS"
 : > "$CURL_MARK"
 sleep 12
 CURLEOF
     chmod +x "$STUB_DIR/curl"
+    # Isolated TMPDIR so the parent's OWN mktemp'd payload file is observable:
+    # after the relay fires, the dir must be empty again (child deleted it) —
+    # the end-to-end proof of the production temp-file lifecycle.
+    TMPDIR_8B="$ROOT_TMP/tmpdir-8b"
+    mkdir -p "$TMPDIR_8B"
     _t0=$(date +%s)
     printf '%s' "$CASE_PAYLOAD" | timeout 15 env -u JIRA_PROJECT_KEY \
         -u HIMMEL_INITIATIVE -u HIMMEL_INITIATIVE_OVERNIGHT -u HIMMEL_OVERNIGHT \
         HOME="$CASE_HOME" USERPROFILE="$CASE_HOME" PATH="$STUB_DIR:$PATH" \
+        TMPDIR="$TMPDIR_8B" \
         HIMMEL_JIRA_NUDGE=1 TELEGRAM_BOT_TOKEN=t TELEGRAM_CHAT_ID=c \
         bash "$HOOK" >/dev/null 2>&1
     _rc=$?
     _elapsed=$(( $(date +%s) - _t0 ))
-    # The detached curl writes its marker asynchronously — wait briefly for it.
-    _w=0; while [ ! -f "$CURL_MARK" ] && [ "$_w" -lt 5 ]; do sleep 1; _w=$((_w + 1)); done
+    # The detached child runs the FULL detection chain before firing curl —
+    # allow 10s (matches test-codex-stop-hooks.sh §3; 5s flaked risk on
+    # loaded CI runners).
+    _w=0; while [ ! -f "$CURL_MARK" ] && [ "$_w" -lt 10 ]; do sleep 1; _w=$((_w + 1)); done
     rm -f "$STUB_DIR/curl"
     if [ "$_rc" -eq 0 ] && [ "$_elapsed" -lt 10 ] && [ -f "$CURL_MARK" ]; then
         pass "relay detached + fired (returns fast AND curl was launched)"
     else
         fail "relay detached + fired (rc=$_rc elapsed=${_elapsed}s marker=$([ -f "$CURL_MARK" ] && echo Y || echo N))"
     fi
-    rm -f "$CURL_MARK"
+    # Payload integrity across the parent->temp-file->child roundtrip: the
+    # relayed message must carry the detected ticket, not just fire at all.
+    if grep -q 'HIMMEL-123' "$CURL_ARGS" 2>/dev/null; then
+        pass "relayed message carries the ticket (payload survived the temp-file roundtrip)"
+    else
+        fail "relayed message carries the ticket (args: $(cat "$CURL_ARGS" 2>/dev/null))"
+    fi
+    # Production temp-file lifecycle: the parent's own mktemp'd payload file
+    # must be gone once the child has fired the relay (child deletes it before
+    # detection). A leak here means the parent->child handoff regressed.
+    if [ -z "$(ls -A "$TMPDIR_8B" 2>/dev/null)" ]; then
+        pass "parent's payload temp file cleaned up end-to-end"
+    else
+        fail "parent's payload temp file cleaned up end-to-end (left: $(ls -A "$TMPDIR_8B"))"
+    fi
+    rm -f "$CURL_MARK" "$CURL_ARGS"
 else
     echo "SKIP relay-detached (no GNU coreutils timeout on this runner)"
 fi
 
 # 8c. Relay configured for NEITHER channel (no seam, no TELEGRAM_*) — the default
-#     production posture. The hook must still emit the stdout nudge and exit 0.
+#     production posture. Child mode must still emit the stdout nudge (direct-
+#     invocation contract), exit 0, and DELETE the payload temp file it was
+#     handed (temp hygiene — the parent never cleans up after the child).
 build_case "$PAST" "feat/HIMMEL-123" "did work" 1 0
-OUT="$(printf '%s' "$CASE_PAYLOAD" | env -u JIRA_PROJECT_KEY \
+PF_8C="$(mktemp "$ROOT_TMP/payload.XXXXXX")"
+printf '%s' "$CASE_PAYLOAD" > "$PF_8C"
+OUT="$(env -u JIRA_PROJECT_KEY \
     -u HIMMEL_INITIATIVE -u HIMMEL_INITIATIVE_OVERNIGHT -u HIMMEL_OVERNIGHT \
     -u JIRA_NUDGE_RELAY_CMD -u TELEGRAM_BOT_TOKEN -u TELEGRAM_CHAT_ID \
     HOME="$CASE_HOME" USERPROFILE="$CASE_HOME" PATH="$STUB_DIR:$PATH" \
-    HIMMEL_JIRA_NUDGE=1 bash "$HOOK" 2>/dev/null)"
-assert_nudge "neither-channel still nudges stdout" "$OUT"
+    HIMMEL_JIRA_NUDGE=1 bash "$HOOK" __himmel_detached "$PF_8C" 2>/dev/null)"
+assert_nudge "neither-channel still nudges stdout (child mode)" "$OUT"
+if [ ! -f "$PF_8C" ]; then pass "child deletes its payload temp file"; else fail "child deletes its payload temp file"; fi
+
+# 8d. Full-body detach keeps the PARENT fast (HIMMEL-661). The discriminating
+#     test: inject latency at the START of the child body (JIRA_NUDGE_TEST_DELAY)
+#     — BEFORE the gate check — so a regression that un-detaches the body would
+#     block the parent for 12s and fail the fast-return assertion. Gate is OFF
+#     here on purpose: even the gate-off path must not run in the foreground.
+#     Skipped where GNU coreutils `timeout` is absent (stock macOS).
+if command -v timeout >/dev/null 2>&1; then
+    build_case "$PAST" "feat/HIMMEL-123" "did work" 1 0
+    _t0=$(date +%s)
+    printf '%s' "$CASE_PAYLOAD" | timeout 15 env -u JIRA_PROJECT_KEY \
+        -u HIMMEL_INITIATIVE -u HIMMEL_INITIATIVE_OVERNIGHT -u HIMMEL_OVERNIGHT \
+        HOME="$CASE_HOME" USERPROFILE="$CASE_HOME" PATH="$STUB_DIR:$PATH" \
+        HIMMEL_JIRA_NUDGE=0 JIRA_NUDGE_TEST_DELAY=12 \
+        bash "$HOOK" >/dev/null 2>&1
+    _rc=$?
+    _elapsed=$(( $(date +%s) - _t0 ))
+    if [ "$_rc" -eq 0 ] && [ "$_elapsed" -lt 10 ]; then
+        pass "full-body detach: parent returns fast despite slow child (${_elapsed}s)"
+    else
+        fail "full-body detach: parent returns fast despite slow child (rc=$_rc elapsed=${_elapsed}s)"
+    fi
+else
+    echo "SKIP parent-fast (no GNU coreutils timeout on this runner)"
+fi
+
+# 8e. Parent with EMPTY stdin exits 0 and spawns NOTHING — the no-payload guard
+#     keeps a payload-less teardown spawn-free. TMPDIR is pointed at an empty
+#     dir and JIRA_NUDGE_TEST_DELAY holds any (wrongly) spawned child asleep
+#     BEFORE it can read+delete its payload file, so a regression of the
+#     `[ -n "$PAYLOAD" ]` guard leaves the parked temp file visible here.
+build_case "$PAST" "feat/HIMMEL-123" "did work" 1 0
+EMPTY_TMPDIR="$ROOT_TMP/empty-tmpdir"
+mkdir -p "$EMPTY_TMPDIR"
+printf '' | env -u JIRA_PROJECT_KEY \
+    -u HIMMEL_INITIATIVE -u HIMMEL_INITIATIVE_OVERNIGHT -u HIMMEL_OVERNIGHT \
+    HOME="$CASE_HOME" USERPROFILE="$CASE_HOME" PATH="$STUB_DIR:$PATH" \
+    TMPDIR="$EMPTY_TMPDIR" HIMMEL_JIRA_NUDGE=1 JIRA_NUDGE_TEST_DELAY=12 \
+    JIRA_NUDGE_RELAY_CMD="$RELAY_CMD" \
+    bash "$HOOK" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ]; then pass "empty-payload parent exits 0"; else fail "empty-payload parent exits 0 (rc=$rc)"; fi
+if [ -z "$(ls -A "$EMPTY_TMPDIR" 2>/dev/null)" ]; then
+    pass "empty-payload parent parks no temp file (no child spawned)"
+else
+    fail "empty-payload parent parks no temp file (found: $(ls -A "$EMPTY_TMPDIR"))"
+fi
 
 # 9. Tripwire: the jira CLI (node) was never invoked across all cases.
 if [ -f "$TRIPWIRE" ]; then fail "jira CLI never invoked"; else pass "jira CLI never invoked"; fi


### PR DESCRIPTION
Propagated from the private repo (CR-clean there: free panel + 4 reviewer agents). SessionEnd hook now full-body-detaches (parent returns ~0.165s, was ~1.7s even gate-off), eliminating the recurring teardown-race 'Hook cancelled'. Guarded detach.sh source; payload-integrity/temp-lifecycle/empty-payload tests. 21/21 + 24/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)