### PR TITLE
test(telegram): backfill missing HIMMEL-578 test block + genericize vault name

### DIFF
--- a/scripts/telegram/run.test.ts
+++ b/scripts/telegram/run.test.ts
@@ -65,14 +65,21 @@ test("buildPrompt tells the run to Read a document_path attachment (HIMMEL-321)"
   expect(p).toContain("Read");
 });
 test("buildPrompt with a vault adds a file-into-vault clause (HIMMEL-321)", () => {
-  const p = buildPrompt("group_-50", { inbox:"i", outbox:"o", context:"c", cwd:"/r" }, "/luna-medic");
-  expect(p).toContain("/luna-medic");
+  const p = buildPrompt("group_-50", { inbox:"i", outbox:"o", context:"c", cwd:"/r" }, "/medic-vault");
+  expect(p).toContain("/medic-vault");
   expect(p).toContain("document_path");
   expect(p).toContain("_CLAUDE.md");
 });
 test("buildPrompt without a vault adds no file-into-vault clause (HIMMEL-321)", () => {
   const p = buildPrompt("group_-50", { inbox:"i", outbox:"o", context:"c", cwd:"/r" });
   expect(p).not.toContain("into the Obsidian vault");   // matches the real clause text
+});
+// --- HIMMEL-578: per-chat vault cwd + scoped bypass + image filing ---
+test("buildRunArgs injects --permission-mode before the prompt when set; omits it otherwise", () => {
+  const a = buildRunArgs("do it", "bypassPermissions");
+  expect(a.cmd).toEqual(["claude", "--model", DEFAULT_MODEL, "--permission-mode", "bypassPermissions", "do it"]);
+  const b = buildRunArgs("do it");
+  expect(b.cmd).toEqual(["claude", "--model", DEFAULT_MODEL, "do it"]); // no --permission-mode when unset (still model-pinned)
 });
 // --- HIMMEL-671: bounded runs must pin an explicit --model (never inherit the
 // user default, which is currently Fable) ---
@@ -109,6 +116,23 @@ test("buildRunArgs falls back to the default when TELEGRAM_CLAUDE_MODEL is blank
 test("the baked-in default model is non-Fable (HIMMEL-671 — the whole point)", () => {
   expect(DEFAULT_MODEL.toLowerCase()).not.toContain("fable");
   expect(DEFAULT_MODEL.length).toBeGreaterThan(0);
+});
+test("buildPrompt reports the SPAWN cwd (sessionCwd) but keeps the Jira path on repoCwd (cwd) — HIMMEL-578 decoupling", () => {
+  const p = buildPrompt("__chat__", { inbox:"i", outbox:"o", context:"c", cwd:"/himmel", sessionCwd:"/vault" });
+  expect(p).toContain("running in /vault");               // session runs in the vault cwd
+  expect(p).toContain("/himmel/scripts/jira/dist/index.js"); // jira path stays anchored on repoCwd
+  expect(p).not.toContain("/vault/scripts/jira");         // never the vault for jira
+});
+test("buildPrompt falls back to cwd for 'running in' when sessionCwd is absent (back-compat)", () => {
+  const p = buildPrompt("__chat__", { inbox:"i", outbox:"o", context:"c", cwd:"/repo" });
+  expect(p).toContain("running in /repo");
+});
+test("buildPrompt vault clause files an image_path (not just document_path) and prefers a vault medic skill (HIMMEL-578)", () => {
+  const p = buildPrompt("group_-50", { inbox:"i", outbox:"o", context:"c", cwd:"/r", sessionCwd:"/medic-vault" }, "/medic-vault");
+  expect(p).toContain("image_path");
+  expect(p).toMatch(/FILE that attachment/i);             // images are FILED, not just read
+  expect(p).toMatch(/medic.*skill/i);                     // prefer the vault-local medic skill
+  expect(p).toContain("/medic-vault");
 });
 test("buildPrompt sanctions non-destructive Jira ticket ops (HIMMEL-424 followup — lifts the classifier veto)", () => {
   const p = buildPrompt("__chat__", { inbox:"i", outbox:"o", context:"c", cwd:"/repo" });


### PR DESCRIPTION
Backfills the 5 HIMMEL-578 tests missing from the mirror's run.test.ts (their hunk context-mismatched on every propagation) and genericizes the example vault path to /medic-vault file-wide (incl. the two older HIMMEL-321 lines). File is now a deterministic transform of the source, so future propagations apply cleanly. Leak scan clean; 19 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)