### PR TITLE
fix(telegram): genericize operator paths in spawn-glm test/comment

### DIFF
--- a/scripts/telegram/spawn-glm.test.ts
+++ b/scripts/telegram/spawn-glm.test.ts
@@ -32,15 +32,15 @@ test("worker prompt embeds minted session paths + contract", () => {
 });
 
 test("transcript dir derives from escaped cwd, not slug", () => {
-  const d = transcriptDirFor("C:\\Users\\yotam\\Documents\\github\\himmel\\.claude\\worktrees\\glm+a");
+  const d = transcriptDirFor("C:\\Users\\alice\\Documents\\github\\himmel\\.claude\\worktrees\\glm+a");
   expect(d).toBe(join(homedir(), ".claude", "projects",
-    "C--Users-yotam-Documents-github-himmel--claude-worktrees-glm-a"));
+    "C--Users-alice-Documents-github-himmel--claude-worktrees-glm-a"));
 });
 
 test("transcript dir escapes EVERY non-alphanumeric (underscore too — matches real CC dirs)", () => {
-  // ground truth on this machine: ...\my_notes → ...-my-notes
-  const d = transcriptDirFor("C:\\Users\\yotam\\Documents\\github\\my_notes");
-  expect(d).toBe(join(homedir(), ".claude", "projects", "C--Users-yotam-Documents-github-my-notes"));
+  // ground truth from real CC project dirs: ...\my_docs → ...-my-docs
+  const d = transcriptDirFor("C:\\Users\\alice\\Documents\\github\\my_docs");
+  expect(d).toBe(join(homedir(), ".claude", "projects", "C--Users-alice-Documents-github-my-docs"));
 });
 
 test("pushurl poison makes bare git push fail in the worktree", () => {

--- a/scripts/telegram/spawn-glm.ts
+++ b/scripts/telegram/spawn-glm.ts
@@ -17,7 +17,7 @@ export function glmSessionRoot(): string {
 
 // Claude Code keys transcript dirs by the ESCAPED CWD — EVERY non-alphanumeric
 // char → "-" (ground truth: real project dirs escape "_" and "." too, e.g.
-// my_notes → my-notes). Not keyed by any name/slug.
+// my_docs → my-docs). Not keyed by any name/slug.
 export function transcriptDirFor(cwd: string): string {
   return join(homedir(), ".claude", "projects", resolve(cwd).replace(/[^a-zA-Z0-9]/g, "-"));
 }


### PR DESCRIPTION
Propagation of private #855 (squash eb33dcd1): genericize operator-local paths in spawn-glm test fixtures + one comment.

- `spawn-glm.test.ts`: transcript-dir tests now use a synthetic `C:\Users\alice\...` path; the underscore ground-truth test flips `my_notes` → `my_docs` (cosmetic, intended — supersedes the manual #216 scrub which kept the real username).
- `spawn-glm.ts`: comment example `my_notes → my-notes` → `my_docs → my-docs`.

Applied as a wholesale overwrite of the two files from private main (the #216 manual scrub diverged, so the patch context didn't apply). Leak scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
