### PR TITLE
feat(hooks): GLM-lane external-write deny hook (classifier substitute)

### DIFF
--- a/docs/glm-offload.md
+++ b/docs/glm-offload.md
@@ -50,6 +50,9 @@ grafts the GLM lane onto that path via a standalone CLI
 1. **Spawn** — from the main session (or any shell), run the CLI (below). It
    creates a fresh git worktree + `glm/<slug>` branch, guard-checks the
    worktree cwd, and starts an unattended GLM-lane worker on your task.
+   Before relying on the deny-hook, confirm it is LIVE: `bash
+   scripts/himmel-update.sh --plugins-check` reports the installed plugin has
+   the entry, AND the parent checkout has pulled the merge (see Hardening).
 2. **Inspect** — via files, no interaction with the worker. While running:
    `meta.json` status + the worker-appended `outbox.jsonl` / `context.md`.
    After exit: those plus `run.log` (stdout/stderr tail, post-exit only —
@@ -124,7 +127,7 @@ know these paths, they are minted at spawn time:
 ```
 You are an unattended GLM-lane worker session (himmel offload spike).
 Work ONLY inside your current directory (a dedicated git worktree). Commit your work on the branch <branch> which is already checked out.
-HARD RULES: never push, never open a PR, never write to Jira or any external tracker — a validating session reviews your branch and owns all external writes.
+HARD RULES: never push, never open a PR — a validating session reviews your branch and owns the git/PR surface. Jira updates (status, comments, followup tickets) ARE allowed via node scripts/jira/dist/index.js (audited + recoverable).
 Report progress by APPENDING one JSON line {"text":"<note>"} per update to <sessionDir>/outbox.jsonl. That is the only channel to the operator.
 THE TASK: <task>
 As your FINAL action, append a one-line summary of what you did to <sessionDir>/context.md, then stop.
@@ -162,8 +165,9 @@ with it the normal `gh pr create` path — fails loudly. This blocks
 - A `bypassPermissions` worker could push via an explicit URL or unset the
   config, and it inherits the operator's git credentials via the shared
   `~/.claude`.
-- Jira and other external writes are **prompt-forbidden only** (the worker
-  contract above), not mechanically blocked.
+- Other external writes are **prompt-forbidden only** (the worker contract
+  above), not mechanically blocked. (Jira is now operator-*allowed* on-lane —
+  audited + recoverable; see the Hardening section.)
 
 **The load-bearing control is the CR gate.** No GLM-produced branch is
 pushed or merged except by the validating session after the CR loop. The
@@ -181,6 +185,102 @@ himmel tree itself is listed in `~/.config/claude-glm/{phi-roots,egress-denylist
 They ship now (fail-closed, no `--force` on this path) because the vault
 follow-up is the next step and investigation blocker (b) mandates them on any
 env-only spawn path — do not weight them as a live v1 safety control.
+
+## Hardening: the deny-hook (HIMMEL-654 harden-first, HIMMEL-675)
+
+`scripts/hooks/block-glm-external-writes.sh` adds a deterministic in-session
+layer — the classifier substitute the GLM lane otherwise lacks (third-party
+lanes have no auto-mode classifier, and `bypassPermissions` removes the prompt
+layer). It fires on `Bash|PowerShell|mcp__.*`, detects the lane by
+`ANTHROPIC_BASE_URL` containing `api.z.ai`, and on-lane hard-blocks `git push`,
+remote-URL rewrites, the entire `gh` CLI, network CLIs
+(`curl`/`wget`/`Invoke-WebRequest`/`Invoke-RestMethod`, plus the `iwr`/`irm`
+aliases), and all `mcp__*` tools EXCEPT the qmd KB carve-out.
+Off-lane sessions exit immediately.
+
+**Allowed on-lane (operator policy 2026-07-03 — audited-action carve-out):**
+the **Jira CLI** (`node scripts/jira/dist/index.js …` or bare `jira`) — writes
+are audited in Jira history and recoverable, so GLM workers may update status,
+add comments, and file followup tickets; and **qmd KB reads**
+(`mcp__plugin_qmd_qmd__*`). Atlassian MCP stays blocked (Jira routing is
+CLI-first — `block-backend-tier` enforces that in every session), and the
+obsidian-vault MCP stays blocked (vault offload is the v2 follow-up).
+
+**The guard stack is now three layers:**
+
+1. **deny-hook** (this hook) — deterministic, in-session, blocks the write
+   shapes above before they run.
+2. **poisoned pushurl tripwire** — the worktree-scoped invalid `pushurl` that
+   fails a default-path `git push`.
+3. **parent-session CR gate** — no GLM branch is pushed/merged except by the
+   validating session after the CR loop.
+
+The deny-hook is an accidental-shape guard (like `block-read-secrets`), NOT a
+containment wall. **Layers 2 and 3 (tripwire + CR gate) remain the load-bearing
+backstops**; the hook is the added deterministic in-session layer, not a
+replacement for them.
+
+**When the hook is actually LIVE — BOTH conditions must hold** (merging the PR
+is not enough):
+
+1. The **installed** plugin has the new entry — that happens only after
+   `/himmel-update` (marketplace re-sync). Verify with
+   `bash scripts/himmel-update.sh --plugins-check`.
+2. The checkout that `spawn-glm` runs from contains the merged script — workers
+   `git worktree add` from the **parent checkout's HEAD** (not "main"), so the
+   operator's checkout must have pulled the merge.
+
+Until BOTH hold, the lane is unhardened and the low-blast-radius "chores only"
+restriction stays.
+
+**Interactive `claude-glm` caveat:** the hook covers `claude-glm` sessions only
+when the cwd is a himmel checkout AND its separate seeded `CLAUDE_CONFIG_DIR`
+(`~/.claude-glm`) has been re-seeded post-merge (`claude-glm --reseed` —
+`/himmel-update` does not refresh it). With a vault cwd the `[ -f ]` plugin
+wrapper no-ops. spawn-glm workers (himmel worktrees, shared `~/.claude`) are the
+covered target.
+
+**Bypass:** `GLM_EXTERNAL_WRITES_OK=1` set in the shell that spawns the worker
+(session-sticky; a per-call prefix does not reach the hook).
+
+**Known limitations** (tripwire + CR-gate backstopped): a wrapper that displaces
+the command from command position is missed — env-prefixed `FOO=1 git push`,
+`sudo`/`xargs`/`timeout` wrappers, the dashed `git-push` form, and the
+`=`-joined global-flag form `git --git-dir=/x push`; malformed or empty tool
+JSON is allowed through (parity with sibling hooks — Claude Code emits valid
+JSON); and in-process network is invisible to a command-text hook — bun/node
+`fetch`, INCLUDING `bun`-invoking the Telegram bridge send path
+(`scripts/telegram/telegram-api.ts` sendMessage, a real external write).
+
+## Peak-hours & quota windows (lane scheduling, HIMMEL-654 decision #4)
+
+Time-aware routing facts for the three worker lanes, researched 2026-07-03
+(vault-first + official docs; verify the time-boxed items before relying on
+them past their dates).
+
+| Lane | Quota model | Window / reset | Peak / degraded hours | Best offload hours | Confidence |
+|---|---|---|---|---|---|
+| **GLM** (z.ai Coding Plan) | Prompts per **5-hour rolling cycle** (Pro ≈ 400/5h; Lite ≈ 80; Max ≈ 1600) — NOT a daily bank. Advanced models burn quota by a **time-of-day multiplier**. | 5h cycle starts at first prompt. | **14:00–18:00 UTC+8** (= 08:00–12:00 Berlin summer) → **3× quota burn**. Documented effect is COST, not latency. | Outside the peak window; under the off-peak **1× promo (through Sept 2026, then 2×)** it is the cheapest bulk lane in the fleet. | Multiplier: official. Latency-at-peak: unconfirmed. |
+| **Claude** (Anthropic Max) | **5-hour rolling window + weekly (`seven_day`) cap**, usage-metered; Opus drains faster. | 5h window from first message; weekly is the harder ceiling. Live counters: `api.anthropic.com/api/oauth/usage` (cached `/tmp/claude/statusline-usage-cache.json`). | **No clock-based peak** — degradation is depletion-based. | Route by counter (`five_hour`/`seven_day` utilization), not clock; arm-resume handles reset boundaries. | High (official mechanics). |
+| **Codex** (OpenAI) | Two windows: primary **300 min** + secondary **10080 min (weekly)** — the weekly is the real cap. Separate OpenAI bank (independent of Claude quota). | Rolling windows that fully reset. Local pull: grep `~/.codex/logs_2.sqlite*` for `"secondary"`/`used_percent` (freshest in `-wal`). | **No published clock peak**; OpenAI throttles dynamically under aggregate load. | Route by the weekly `used_percent` counter; primary overflow lane when Claude's weekly cap is spent. | Windows: high. Reset anchor detail: community-sourced. |
+
+Routing rules:
+
+1. **GLM bulk/mechanical chores → off-peak** (avoid 14:00–18:00 UTC+8). The
+   3× peak multiplier drains the 5h cycle ~1.5× faster than off-peak 2× — and
+   the promo makes off-peak 1×, so schedule big fanout jobs there.
+2. **GLM peak is a cost penalty, not a wall** — small urgent GLM jobs are fine
+   at peak; only defer bulk work.
+3. **Claude and Codex have no clock to schedule against** — treat
+   "peak/degraded" as "depletion counter is high" and route by the live
+   counters above.
+4. **Overflow order when Claude's weekly cap is spent:** Codex first for
+   judgment-capable work (independent bank); GLM off-peak for bulk/mechanical
+   (capacity lane, not a behavioral equal — keep judgment-heavy work off GLM).
+5. **All three 5h windows anchor at first prompt** — start a bulk GLM run
+   early enough to finish before the peak window opens, or after it closes.
+6. **The GLM peak is z.ai-fixed at UTC+8** — it does not track local DST;
+   re-derive the local mapping at DST switches.
 
 ## Acceptance runs (2026-07-03, session 9 — both PASS)
 

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -298,6 +298,50 @@ live only after `/himmel-update` (marketplace re-sync) + a fresh session.
 Paired artifacts: `scripts/lib/branch-shipped.sh` (predicate),
 `scripts/hooks/test-block-merged-pr-commit.sh` (smoke suite).
 
+### `block-glm-external-writes.sh` — GLM-lane external-write deny (HIMMEL-654)
+
+Fires on `Bash|PowerShell|mcp__.*`. The deterministic classifier substitute for
+third-party offload lanes, which have no auto-mode classifier and usually run
+`--permission-mode bypassPermissions` (GLM workers via `spawn-glm.ts`,
+`claude-glm` sessions). Detects the lane by `ANTHROPIC_BASE_URL` containing
+`api.z.ai` (set by `glm-env.ts` `buildGlmEnv` / the `scripts/claude-glm{,.ps1}`
+launchers, inherited by hook processes); off-lane sessions exit 0 on the first
+env check — near-zero overhead, before the jq check.
+
+On-lane it hard-blocks: `git push`, remote-URL rewrites (`git remote set-url`,
+`git config …url` — keeps the poisoned-pushurl tripwire un-poisonable), the
+entire `gh` CLI (PR/issue/API writes are parent-session actions), network CLIs
+(`curl`/`wget`/`Invoke-WebRequest`/`Invoke-RestMethod`/`iwr`/`irm`), and all
+`mcp__*` tools except the qmd carve-out below (v1 chores are repo-local; a
+blanket deny beats a write-verb list). `git commit`/`add`/`status`/`diff` and
+`bun`/`npm install` stay allowed.
+
+**Allowed on-lane (operator policy 2026-07-03 — audited-action carve-out):** the
+**Jira CLI** (`scripts/jira/` path or a bare `jira`) — writes are audited in
+Jira history and recoverable, so GLM workers may update status/comments and file
+followup tickets; and **qmd KB reads** (`mcp__plugin_qmd_qmd__*`, allowed before
+the blanket `mcp__*` deny). Atlassian MCP stays blocked — Jira routing is
+CLI-first (`block-backend-tier` enforces that in every session).
+
+**Fail-CLOSED:** missing `jq` on the GLM lane blocks (parity with
+`block-rogue-claude-schedule`). Command-position matching (start, or after
+`; & | (` — not space/quote) keeps commit-message prose mentioning "git push"
+from false-blocking. **Bypass:** `GLM_EXTERNAL_WRITES_OK=1` set in the shell
+that spawns the worker (session-sticky).
+
+Known limitations (accidental-shape guard, backstopped by the poisoned pushurl
+tripwire + the parent CR gate — the two load-bearing controls): a wrapper that
+displaces the command from command position is missed (env-prefixed
+`FOO=1 git push`, `sudo`/`xargs`/`timeout`, the dashed `git-push`), and
+in-process network is invisible (bun/node `fetch`, including the bun-invoked
+telegram bridge send path).
+
+**Delivery:** shipped via the **himmel-ops plugin `hooks.json`** (same
+exec-if-exists `$CLAUDE_PROJECT_DIR` pattern as `block-docker-privesc`); live
+only after `/himmel-update` (marketplace re-sync) + a fresh session, AND the
+checkout workers branch from having pulled the merge. Spec:
+`scripts/hooks/test-block-glm-external-writes.sh`.
+
 ### `block-backend-tier.sh` — service-agnostic backend-routing guard (HIMMEL-400)
 
 Fires on `mcp__plugin_atlassian_atlassian__*` tool calls (and any other

--- a/marketplace/plugins/himmel-ops/hooks/hooks.json
+++ b/marketplace/plugins/himmel-ops/hooks/hooks.json
@@ -27,6 +27,15 @@
             "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/block-merged-pr-commit.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Bash|PowerShell|mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/block-glm-external-writes.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; fi'"
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/scripts/hooks/block-glm-external-writes.sh
+++ b/scripts/hooks/block-glm-external-writes.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash/PowerShell/mcp__* — GLM-lane external-write deny.
+#
+# WHY (HIMMEL-654 session-9 tail, operator decision #1 — "harden BEFORE
+# scaling the offload"): GLM workers (scripts/telegram/spawn-glm.ts) and
+# claude-glm sessions run claude against api.z.ai, usually with
+# --permission-mode bypassPermissions. Third-party lanes have NO auto-mode
+# classifier and bypassPermissions removes the prompt layer, so the only
+# control between a mis-prompted worker and an external write is the
+# poisoned worktree pushurl — a tripwire, not a wall. This hook is the
+# deterministic classifier SUBSTITUTE: on the GLM lane, hard-block
+# push / PR / external-write shapes.
+#
+# Lane detection: ANTHROPIC_BASE_URL contains api.z.ai (set by
+# scripts/telegram/glm-env.ts buildGlmEnv and the scripts/claude-glm{,.ps1}
+# launcher family; inherited by hook processes). Non-GLM sessions exit 0 on
+# the first case below — near-zero overhead, before the jq availability check.
+#
+# Blocked on-lane:
+#   - ALL mcp__* tools EXCEPT the qmd KB carve-out (v1 chores are repo-local;
+#     blanket beats a verb list; qmd KB reads are operator-allowed, see below)
+#   - git push; git remote set-url; git config …url (tripwire un-poisoning)
+#   - the ENTIRE gh CLI (PR/issue/api writes are parent-session actions)
+#   - network CLIs: curl/wget/Invoke-WebRequest/Invoke-RestMethod/iwr/irm
+#     (write-flag parsing is fragile post-lowercasing; chores are repo-local;
+#     bun/npm installs remain allowed — dependency fetch, not external write)
+#
+# Allowed on-lane (operator policy 2026-07-03 — audited-action carve-out):
+#   - the Jira CLI (scripts/jira/ path, or bare `jira`): writes are audited in
+#     Jira history + recoverable, so GLM workers may update status/comments and
+#     file followup tickets. Atlassian MCP stays blocked (mcp__* below) — Jira
+#     routing is CLI-first (block-backend-tier enforces that in every session).
+#   - the qmd KB (mcp__plugin_qmd_qmd__* tools): read-only knowledge-base access.
+#
+# Known limitations (accidental-shape guard, like block-read-secrets):
+#   - any wrapper displacing the command from command position is missed:
+#     env-prefixed `FOO=1 git push`, sudo/xargs/timeout wrappers, `git-push`,
+#     and the `=`-joined global-flag form `git --git-dir=/x push` (missed too)
+#   - in-process network is invisible to a command-text hook — bun/node
+#     fetch, including bun-invoking the telegram bridge send path
+#   - malformed/empty tool JSON -> allow (parity with sibling hooks; Claude
+#     Code emits valid JSON)
+#   All backstopped by the poisoned pushurl tripwire + the parent CR gate —
+#   those two remain the load-bearing controls; this hook is the in-session
+#   deterministic layer.
+#
+# Exit codes: 0 allow; 2 block (stderr shown to the worker).
+# Bypass: GLM_EXTERNAL_WRITES_OK=1 in the env of the shell that spawns the
+# worker (spawn-glm caller / claude-glm launcher). Session-sticky.
+set -euo pipefail
+
+case "${ANTHROPIC_BASE_URL:-}" in
+    *api.z.ai*) ;;
+    *) exit 0 ;;
+esac
+
+[ "${GLM_EXTERNAL_WRITES_OK:-0}" = "1" ] && exit 0
+
+# On-lane, a TOP-LEVEL errexit abort must BLOCK (exit 2), never slip through
+# as a non-blocking exit 1 (only exit 2 denies in Claude Code). Scope honesty:
+# the trap cannot see failures inside `if at_cmd ...` condition contexts
+# (errexit-exempt; a grep crashing on a fixed pattern is the only such shape —
+# ~impossible in practice), and the malformed-JSON path deliberately stays
+# fail-OPEN above per sibling-hook parity — this clamp covers everything else.
+# shellcheck disable=SC2154  # rc is assigned by rc=$? inside the same trap string
+trap 'rc=$?; if [ "$rc" != 0 ] && [ "$rc" != 2 ]; then exit 2; fi' EXIT
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "block-glm-external-writes: jq not on PATH — refusing to evaluate on the GLM lane; install jq" >&2
+    exit 2
+fi
+
+input=$(cat)
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)
+
+deny() {
+    {
+        echo "⛔ block-glm-external-writes: $1"
+        echo "    This session runs on the GLM lane (ANTHROPIC_BASE_URL=api.z.ai), which has"
+        echo "    no auto-mode classifier — external writes are hard-blocked (HIMMEL-654)."
+        echo "    Deliver results as a committed branch diff + your session outbox summary;"
+        echo "    the parent Claude session / operator pushes and opens PRs."
+        echo "    Operator bypass: GLM_EXTERNAL_WRITES_OK=1 in the spawning shell."
+    } >&2
+    exit 2
+}
+
+case "$tool" in
+    mcp__plugin_qmd_qmd__*) exit 0 ;; # KB search/read — operator-allowed (audited-lane policy 2026-07-03)
+    mcp__*) deny "MCP tool '$tool' is blocked on the GLM lane." ;;
+    Bash|PowerShell) ;;
+    *) exit 0 ;;
+esac
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+[ -z "$cmd" ] && exit 0
+
+# Lower-case + flatten newlines (same rationale as block-rogue-claude-schedule:
+# line-oriented grep + multi-line commands otherwise let ^ match any line).
+cmd_lc=$(printf '%s' "$cmd" | LC_ALL=C tr '[:upper:]' '[:lower:]' | LC_ALL=C tr '\n\r' '  ')
+
+# Command-position matcher: start-of-command or right after ; & | ( —
+# deliberately NOT space/quote, so prose inside a commit message ("… git push
+# …") does not false-block. Env-prefixed `FOO=1 git push` is therefore missed:
+# accepted limitation, tripwire-backstopped (see header).
+at_cmd() { printf '%s' "$cmd_lc" | grep -qE "(^|[;&|(])[[:space:]]*($1)"; }
+
+# git push — subcommand position; tolerate intervening short/long flags with
+# one optional argument each (git -C <path> push, git -c k=v push).
+if at_cmd 'git([[:space:]]+-[a-z-]+([[:space:]]+[^[:space:];&|]+)?)*[[:space:]]+push([[:space:]]|$)'; then
+    deny "git push is blocked on the GLM lane (commit locally; the parent session pushes)."
+fi
+# tripwire un-poisoning: remote set-url, or git config touching any *url key.
+# Flag-tolerant subcommand-position shape (same as the push arm) — NOT the
+# greedy `git[^;&|]*` form, which gobbles quoted prose and false-blocks
+# commit messages mentioning "remote set-url" / "config url" (critic F2).
+# `git config --get remote.origin.url` (a read) still blocks: accepted
+# overmatch, pinned by test — allowing --get would miss `--local` writes.
+if at_cmd 'git([[:space:]]+-[a-z-]+([[:space:]]+[^[:space:];&|]+)?)*[[:space:]]+remote[[:space:]]+set-url' || at_cmd 'git([[:space:]]+-[a-z-]+([[:space:]]+[^[:space:];&|]+)?)*[[:space:]]+config([[:space:]]+-[a-z-]+)*[[:space:]]+[^[:space:];&|]*url'; then
+    deny "rewriting git remote/push URLs is blocked on the GLM lane (the pushurl tripwire stays poisoned)."
+fi
+if at_cmd 'gh([[:space:]]|$)'; then
+    deny "the gh CLI is blocked on the GLM lane (PR/issue/API actions belong to the parent session)."
+fi
+if at_cmd '(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm)([[:space:]]|$)'; then
+    deny "network CLIs are blocked on the GLM lane (chores are repo-local)."
+fi
+
+exit 0

--- a/scripts/hooks/check-mcp-plugin-refs.sh
+++ b/scripts/hooks/check-mcp-plugin-refs.sh
@@ -41,6 +41,7 @@ is_exempt() {
         scripts/hooks/test-block-backend-tier.sh) return 0 ;;
         scripts/hooks/check-mcp-plugin-refs.sh) return 0 ;;
         scripts/hooks/test-check-mcp-plugin-refs.sh) return 0 ;;
+        scripts/hooks/test-block-glm-external-writes.sh) return 0 ;;
         *) return 1 ;;
     esac
 }

--- a/scripts/hooks/test-block-glm-external-writes.sh
+++ b/scripts/hooks/test-block-glm-external-writes.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/hooks/block-glm-external-writes.sh (HIMMEL-654 GLM
+# lane hardening — deterministic classifier substitute).
+#
+# Usage: bash scripts/hooks/test-block-glm-external-writes.sh
+# Exit codes: 0 — all cases passed; 1 — at least one failed
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/block-glm-external-writes.sh"
+[ -x "$HOOK" ] || chmod +x "$HOOK"
+
+FAILED=0
+CASES=0
+GLM_URL="https://api.z.ai/api/anthropic"
+BASH_ABS=$(command -v bash)
+EMPTY_PATH=$(mktemp -d)
+
+# run_case <json> [VAR=val ...] — extra args become env assignments.
+run_case() {
+    local input="$1"; shift
+    printf '%s' "$input" | env -u ANTHROPIC_BASE_URL -u GLM_EXTERNAL_WRITES_OK "$@" bash "$HOOK" >/dev/null 2>&1
+    echo "$?"
+}
+
+assert_rc() {
+    local label="$1" expected="$2" actual="$3"
+    CASES=$((CASES + 1))
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS $label (rc=$actual)"
+    else
+        echo "FAIL $label — expected rc=$expected, got rc=$actual"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+j_bash() { printf '{"tool_name":"Bash","tool_input":{"command":%s}}' "$(printf '%s' "$1" | jq -Rs .)"; }
+j_pwsh() { printf '{"tool_name":"PowerShell","tool_input":{"command":%s}}' "$(printf '%s' "$1" | jq -Rs .)"; }
+
+# jq-missing runner: empty PATH hides jq from the hook, but bash is invoked by
+# absolute path so the script still runs and must fail closed at the jq check.
+run_case_no_jq() {
+    printf '%s' "$1" | env -u ANTHROPIC_BASE_URL "ANTHROPIC_BASE_URL=$GLM_URL" PATH="$EMPTY_PATH" "$BASH_ABS" "$HOOK" >/dev/null 2>&1
+    echo "$?"
+}
+
+# --- OFF-LANE: everything allowed (expect rc=0) ---
+assert_rc "off-lane git push"            0 "$(run_case "$(j_bash 'git push origin main')")"
+assert_rc "off-lane gh pr create"        0 "$(run_case "$(j_bash 'gh pr create --title x')")"
+assert_rc "off-lane mcp tool"            0 "$(run_case '{"tool_name":"mcp__plugin_github_github__merge_pull_request","tool_input":{}}')"
+assert_rc "anthropic-url non-glm"        0 "$(run_case "$(j_bash 'git push')" "ANTHROPIC_BASE_URL=https://api.anthropic.com")"
+
+# --- ON-LANE BLOCK cases (expect rc=2) ---
+assert_rc "glm git push"                 2 "$(run_case "$(j_bash 'git push origin feat/x')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm git push after &&"        2 "$(run_case "$(j_bash 'bun test && git push')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm git -C path push"         2 "$(run_case "$(j_bash 'git -C /tmp/wt push')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+# shellcheck disable=SC2016  # literal $(git push) is the command text under test, not for expansion
+assert_rc "glm git push in subshell"     2 "$(run_case "$(j_bash 'echo $(git push 2>&1)')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh pr create"             2 "$(run_case "$(j_bash 'gh pr create --fill')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh pr view (reads too)"   2 "$(run_case "$(j_bash 'gh pr view 855')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm IWR uppercase alias"      2 "$(run_case "$(j_pwsh 'IWR https://example.com')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm push after pipe"          2 "$(run_case "$(j_bash 'git status | git push')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm remote set-url"           2 "$(run_case "$(j_bash 'git remote set-url --push origin git@github.com:u/r.git')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm config pushurl"           2 "$(run_case "$(j_bash 'git config remote.origin.pushurl git@github.com:u/r.git')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm config --local pushurl"   2 "$(run_case "$(j_bash 'git config --local remote.origin.pushurl git@github.com:u/r.git')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm config --get url (pinned overmatch)" 2 "$(run_case "$(j_bash 'git config --get remote.origin.url')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh at end of command"     2 "$(run_case "$(j_bash 'cd /tmp && gh')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm iwr (PS alias)"           2 "$(run_case "$(j_pwsh 'iwr https://example.com')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm curl"                     2 "$(run_case "$(j_bash 'curl -X POST https://api.example.com -d x=1')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm wget"                     2 "$(run_case "$(j_bash 'wget https://example.com/f.tar.gz')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm Invoke-RestMethod"        2 "$(run_case "$(j_pwsh 'Invoke-RestMethod -Uri https://api.example.com -Method Post')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp github write"         2 "$(run_case '{"tool_name":"mcp__plugin_github_github__merge_pull_request","tool_input":{}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp atlassian (CLI-first, still blocked)" 2 "$(run_case '{"tool_name":"mcp__plugin_atlassian_atlassian__createJiraIssue","tool_input":{}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+
+# --- ON-LANE ALLOW cases (expect rc=0) ---
+assert_rc "glm git commit"               0 "$(run_case "$(j_bash 'git commit -m "docs: fix typos"')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm commit msg says git push" 0 "$(run_case "$(j_bash 'git commit -m "explain when to git push"')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm git add/status/diff"      0 "$(run_case "$(j_bash 'git add -u && git status && git diff --stat')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm bun test"                 0 "$(run_case "$(j_bash 'bun test scripts/telegram')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm bun install"              0 "$(run_case "$(j_bash 'bun install')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm prose mentions gh"        0 "$(run_case "$(j_bash 'git commit -m "docs: gh usage notes"')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm jirafish not jira"        0 "$(run_case "$(j_bash 'echo jirafish')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm jira prose in commit msg" 0 "$(run_case "$(j_bash 'git commit -m "docs: fix scripts/jira/index"')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+# Jira CLI is operator-allowed on-lane (audited + recoverable, policy 2026-07-03).
+assert_rc "glm jira CLI path (allowed)"  0 "$(run_case "$(j_bash 'node scripts/jira/dist/index.js transition HIMMEL-1 Done')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm bare jira (allowed)"      0 "$(run_case "$(j_bash 'jira list')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm jira direct path (allowed)" 0 "$(run_case "$(j_bash './scripts/jira/dist/index.js list')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+# qmd KB reads are operator-allowed on-lane (carve-out before the blanket mcp deny).
+assert_rc "glm mcp qmd read (allowed)"   0 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm Read tool ignored"        0 "$(run_case '{"tool_name":"Read","tool_input":{"file_path":"x"}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm empty command"            0 "$(run_case '{"tool_name":"Bash","tool_input":{}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm multi-line prose push"    0 "$(run_case "$(j_bash "$(printf 'git commit -m "notes\nabout git push etiquette"')")" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm prose remote set-url"     0 "$(run_case "$(j_bash 'git commit -m "docs: note the remote set-url tripwire"')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm prose config url"         0 "$(run_case "$(j_bash 'git commit -m "docs: update config url notes"')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm env-prefix push (pinned limitation)" 0 "$(run_case "$(j_bash 'FOO=1 git push')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+
+# --- Edge cases: jq availability + malformed input ---
+assert_rc "glm jq missing fails closed"  2 "$(run_case_no_jq "$(j_bash 'git status')")"
+assert_rc "glm malformed JSON allows (documented)" 0 "$(run_case '{not json' "ANTHROPIC_BASE_URL=$GLM_URL")"
+
+# --- Escape hatch (expect rc=0 on an otherwise-blocked command) ---
+assert_rc "bypass GLM_EXTERNAL_WRITES_OK" 0 "$(run_case "$(j_bash 'git push')" "ANTHROPIC_BASE_URL=$GLM_URL" "GLM_EXTERNAL_WRITES_OK=1")"
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "$FAILED case(s) FAILED"
+    exit 1
+fi
+
+# Total-count guard: every assert_rc increments CASES; a drift here means a case
+# was silently dropped (or an early exit skipped the tail) even though nothing
+# FAILED. Update EXPECTED_CASES deliberately when adding/removing a case.
+EXPECTED_CASES=44
+if [ "$CASES" -ne "$EXPECTED_CASES" ]; then
+    echo "CASE-COUNT MISMATCH — ran $CASES, expected $EXPECTED_CASES"
+    exit 1
+fi
+echo "all cases passed ($CASES/$EXPECTED_CASES)"
+exit 0

--- a/scripts/telegram/spawn-glm.ts
+++ b/scripts/telegram/spawn-glm.ts
@@ -28,7 +28,7 @@ export function composeWorkerPrompt(task: string, sessionDir: string, branch: st
   return [
     `You are an unattended GLM-lane worker session (himmel offload spike).`,
     `Work ONLY inside your current directory (a dedicated git worktree). Commit your work on the branch ${branch} which is already checked out.`,
-    `HARD RULES: never push, never open a PR, never write to Jira or any external tracker — a validating session reviews your branch and owns all external writes.`,
+    `HARD RULES: never push, never open a PR — a validating session reviews your branch and owns the git/PR surface. Jira updates (status, comments, followup tickets) ARE allowed via node scripts/jira/dist/index.js (audited + recoverable).`,
     `Report progress by APPENDING one JSON line {"text":"<note>"} per update to ${outbox}. That is the only channel to the operator.`,
     `THE TASK: ${task}`,
     `As your FINAL action, append a one-line summary of what you did to ${context}, then stop.`,


### PR DESCRIPTION
Propagation of private #856 (squash 3e087927): GLM-lane external-write deny hook.

- `scripts/hooks/block-glm-external-writes.sh` + 44-case smoke test: deterministic PreToolUse guard for GLM-lane sessions (`ANTHROPIC_BASE_URL` ~ api.z.ai) — blocks git push / remote-URL rewrites / gh CLI / network CLIs / mcp__* (qmd KB carve-out); Jira CLI allowed (audited-action policy). Fail-closed on missing jq + errexit clamp; prose-safe command-position matching.
- himmel-ops plugin `hooks.json` delivery entry; `docs/internals/enforcement.md` + `docs/glm-offload.md` (hardening + peak-hours sections); mcp-refs test exemption; spawn-glm worker-prompt policy line.

Applied clean onto the #217-aligned base. Leak scan clean (full 7-file staged delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
