### PR TITLE
feat(hooks): gh carve-out on the GLM lane + himmel-ops 0.4.0 delivery bump

### DIFF
--- a/docs/glm-offload.md
+++ b/docs/glm-offload.md
@@ -193,7 +193,9 @@ layer — the classifier substitute the GLM lane otherwise lacks (third-party
 lanes have no auto-mode classifier, and `bypassPermissions` removes the prompt
 layer). It fires on `Bash|PowerShell|mcp__.*`, detects the lane by
 `ANTHROPIC_BASE_URL` containing `api.z.ai`, and on-lane hard-blocks `git push`,
-remote-URL rewrites, the entire `gh` CLI, network CLIs
+remote-URL rewrites, the `gh` CLI EXCEPT the issue-ops + pr/run-reads carve-out
+below (`gh pr create/merge/edit/review/comment/ready`, `gh api`, `gh repo`,
+`gh release`, `gh gist`, … stay blocked), network CLIs
 (`curl`/`wget`/`Invoke-WebRequest`/`Invoke-RestMethod`, plus the `iwr`/`irm`
 aliases), and all `mcp__*` tools EXCEPT the qmd KB carve-out.
 Off-lane sessions exit immediately.
@@ -201,8 +203,14 @@ Off-lane sessions exit immediately.
 **Allowed on-lane (operator policy 2026-07-03 — audited-action carve-out):**
 the **Jira CLI** (`node scripts/jira/dist/index.js …` or bare `jira`) — writes
 are audited in Jira history and recoverable, so GLM workers may update status,
-add comments, and file followup tickets; and **qmd KB reads**
-(`mcp__plugin_qmd_qmd__*`). Atlassian MCP stays blocked (Jira routing is
+add comments, and file followup tickets; **qmd KB reads**
+(`mcp__plugin_qmd_qmd__*`); and (HIMMEL-675) **`gh issue <anything>`** — the
+full issue surface, reads AND writes, because cr-deferred followups are gh
+issues (audited in GitHub + recoverable) — plus read-only **PR/CI context**
+(`gh pr view|diff|checks|status|list`, `gh run view|list|watch`). The gh
+carve-out is compound-smuggle-safe: the hook counts command-position gh
+occurrences vs allowed ones, so `gh pr view 1 && gh pr merge 1` still denies
+(total 2 > allowed 1). Atlassian MCP stays blocked (Jira routing is
 CLI-first — `block-backend-tier` enforces that in every session), and the
 obsidian-vault MCP stays blocked (vault offload is the v2 follow-up).
 
@@ -229,6 +237,16 @@ is not enough):
 2. The checkout that `spawn-glm` runs from contains the merged script — workers
    `git worktree add` from the **parent checkout's HEAD** (not "main"), so the
    operator's checkout must have pulled the merge.
+
+**A hooks.json change ships live only with a plugin VERSION BUMP.** The
+installed-plugin cache is **version-keyed**
+(`~/.claude/plugins/cache/…/himmel-ops/<version>/`), so a same-version
+`hooks.json` edit is invisible to `/himmel-update`'s re-sync — the cache never
+refreshes and the new/changed hook never reaches workers. #856 added a
+`hooks.json` entry without bumping `himmel-ops`'s `version`, which is exactly
+why the deny-hook did not go live until the HIMMEL-675 `0.4.0` bump. Bump the
+plugin `version` in `.claude-plugin/plugin.json` whenever you change its
+`hooks.json`.
 
 Until BOTH hold, the lane is unhardened and the low-blast-radius "chores only"
 restriction stays.

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -310,7 +310,9 @@ env check — near-zero overhead, before the jq check.
 
 On-lane it hard-blocks: `git push`, remote-URL rewrites (`git remote set-url`,
 `git config …url` — keeps the poisoned-pushurl tripwire un-poisonable), the
-entire `gh` CLI (PR/issue/API writes are parent-session actions), network CLIs
+`gh` CLI EXCEPT the issue-ops + pr/run-reads carve-out below (`gh pr
+create/merge/edit/review/comment/ready`, `gh api`, `gh repo`, … stay blocked —
+parent-session actions), network CLIs
 (`curl`/`wget`/`Invoke-WebRequest`/`Invoke-RestMethod`/`iwr`/`irm`), and all
 `mcp__*` tools except the qmd carve-out below (v1 chores are repo-local; a
 blanket deny beats a write-verb list). `git commit`/`add`/`status`/`diff` and
@@ -319,9 +321,16 @@ blanket deny beats a write-verb list). `git commit`/`add`/`status`/`diff` and
 **Allowed on-lane (operator policy 2026-07-03 — audited-action carve-out):** the
 **Jira CLI** (`scripts/jira/` path or a bare `jira`) — writes are audited in
 Jira history and recoverable, so GLM workers may update status/comments and file
-followup tickets; and **qmd KB reads** (`mcp__plugin_qmd_qmd__*`, allowed before
-the blanket `mcp__*` deny). Atlassian MCP stays blocked — Jira routing is
-CLI-first (`block-backend-tier` enforces that in every session).
+followup tickets; **qmd KB reads** (`mcp__plugin_qmd_qmd__*`, allowed before
+the blanket `mcp__*` deny); and (HIMMEL-675) **`gh issue <anything>`** (full
+issue surface, reads AND writes — cr-deferred followups are gh issues, audited +
+recoverable) plus read-only **PR/CI context** (`gh pr view|diff|checks|status|
+list`, `gh run view|list|watch`). The gh carve-out counts command-position gh
+occurrences vs allowed ones, so a compound smuggling a denied gh past an allowed
+one (`gh pr view 1 && gh pr merge 1`) still denies (total > allowed) — it shares
+the command-position wrapper gap with the other arms. Atlassian MCP stays
+blocked — Jira routing is CLI-first (`block-backend-tier` enforces that in every
+session).
 
 **Fail-CLOSED:** missing `jq` on the GLM lane blocks (parity with
 `block-rogue-claude-schedule`). Command-position matching (start, or after

--- a/marketplace/plugins/himmel-ops/.claude-plugin/plugin.json
+++ b/marketplace/plugins/himmel-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "himmel-ops",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Harness-meta operational skills for himmel. Load-on-trigger guardrail-recovery playbook (stuck-playbook) that surfaces escape-hatches when an auto-mode write is denied, a Bash command falls through to the classifier, a permission prompt hangs, or a pre-push gate fails — so operational/troubleshooting rules stay out of the always-on root CLAUDE.md (HIMMEL-211). Plus the minerva pipeline skill (/minerva): brainstorm→critic→spec→critic→plan with adversarial critic loops between stages (HIMMEL-428); and memory-compound (/memory-compound): lean-invoke compaction of the per-project auto-memory into qmd-searchable luna/himmel reference notes with a findability gate (HIMMEL-569).",
   "author": {
     "name": "yotamleo"

--- a/scripts/hooks/block-glm-external-writes.sh
+++ b/scripts/hooks/block-glm-external-writes.sh
@@ -20,7 +20,9 @@
 #   - ALL mcp__* tools EXCEPT the qmd KB carve-out (v1 chores are repo-local;
 #     blanket beats a verb list; qmd KB reads are operator-allowed, see below)
 #   - git push; git remote set-url; git config …url (tripwire un-poisoning)
-#   - the ENTIRE gh CLI (PR/issue/api writes are parent-session actions)
+#   - the gh CLI EXCEPT the carve-out below — pr create/merge/edit/review/
+#     comment/ready, api, repo, release, gist, … stay blocked (parent-session
+#     actions)
 #   - network CLIs: curl/wget/Invoke-WebRequest/Invoke-RestMethod/iwr/irm
 #     (write-flag parsing is fragile post-lowercasing; chores are repo-local;
 #     bun/npm installs remain allowed — dependency fetch, not external write)
@@ -31,6 +33,10 @@
 #     file followup tickets. Atlassian MCP stays blocked (mcp__* below) — Jira
 #     routing is CLI-first (block-backend-tier enforces that in every session).
 #   - the qmd KB (mcp__plugin_qmd_qmd__* tools): read-only knowledge-base access.
+#   - gh issue <anything> (full issue surface — reads AND writes; cr-deferred
+#     followups are gh issues, audited in GitHub + recoverable), plus read-only
+#     PR/CI context: `gh pr view|diff|checks|status|list`, `gh run
+#     view|list|watch`. Every other gh use stays blocked (counting arm below).
 #
 # Known limitations (accidental-shape guard, like block-read-secrets):
 #   - any wrapper displacing the command from command position is missed:
@@ -40,6 +46,18 @@
 #     fetch, including bun-invoking the telegram bridge send path
 #   - malformed/empty tool JSON -> allow (parity with sibling hooks; Claude
 #     Code emits valid JSON)
+#   - the gh carve-out counts command-position gh occurrences (total vs
+#     allowed) and shares the wrapper gap above — a wrapper-displaced gh is
+#     invisible to BOTH counts, so it is neither blocked nor credited as allowed
+#   Accepted OVER-blocks (fail-closed direction, all test-pinned):
+#   - newlines flatten to ';', so quoted prose whose LINE starts with a
+#     blocked verb ("…\ngit push later") blocks; mid-line prose stays allowed
+#   - an allowed `gh issue …` whose quoted body contains `;`/`|` followed by
+#     another gh token ("--body 'step 1; gh pr merge later'") blocks (the
+#     body token inflates the total count)
+#   - global flags BEFORE a gh subcommand displace it from the allow anchor:
+#     `gh -R o/r issue list` blocks; write flags AFTER the subcommand
+#     (`gh issue list -R o/r`) — allowed
 #   All backstopped by the poisoned pushurl tripwire + the parent CR gate —
 #   those two remain the load-bearing controls; this hook is the in-session
 #   deterministic layer.
@@ -95,15 +113,31 @@ esac
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 [ -z "$cmd" ] && exit 0
 
-# Lower-case + flatten newlines (same rationale as block-rogue-claude-schedule:
-# line-oriented grep + multi-line commands otherwise let ^ match any line).
-cmd_lc=$(printf '%s' "$cmd" | LC_ALL=C tr '[:upper:]' '[:lower:]' | LC_ALL=C tr '\n\r' '  ')
+# Lower-case + flatten newlines TO ';' — a newline separates commands exactly
+# like ';' does, so flattening to spaces (the sibling hooks' shape) UNDER-blocks:
+# a two-line "gh pr view 1\ngh pr merge 1" would read as one command and the
+# merge would slip through as an "argument". Flattening to ';' keeps command
+# boundaries visible to the (^|[;&|(]) anchor. Cost (accepted, fail-closed): a
+# quoted commit-message LINE that STARTS with a blocked verb ("…\ngit push
+# later") now over-blocks — pinned by test; mid-line prose stays allowed.
+cmd_lc=$(printf '%s' "$cmd" | LC_ALL=C tr '[:upper:]' '[:lower:]' | LC_ALL=C tr '\n\r' ';;')
 
 # Command-position matcher: start-of-command or right after ; & | ( —
 # deliberately NOT space/quote, so prose inside a commit message ("… git push
 # …") does not false-block. Env-prefixed `FOO=1 git push` is therefore missed:
 # accepted limitation, tripwire-backstopped (see header).
 at_cmd() { printf '%s' "$cmd_lc" | grep -qE "(^|[;&|(])[[:space:]]*($1)"; }
+
+# Occurrence counter (same command-position wrapper as at_cmd). grep -c counts
+# LINES, and cmd_lc is flattened to one line, so -c undercounts a compound with
+# two command-position matches — count PER-MATCH via grep -oE | wc -l instead.
+# grep exits 1 on zero matches; `|| true` keeps that from tripping errexit
+# inside the assignment's command substitution. $(( )) strips wc's whitespace.
+count_cmd() {
+    local n
+    n=$(printf '%s' "$cmd_lc" | grep -oE "(^|[;&|(])[[:space:]]*($1)" | wc -l) || true
+    printf '%s' "$((n))"
+}
 
 # git push — subcommand position; tolerate intervening short/long flags with
 # one optional argument each (git -C <path> push, git -c k=v push).
@@ -119,8 +153,16 @@ fi
 if at_cmd 'git([[:space:]]+-[a-z-]+([[:space:]]+[^[:space:];&|]+)?)*[[:space:]]+remote[[:space:]]+set-url' || at_cmd 'git([[:space:]]+-[a-z-]+([[:space:]]+[^[:space:];&|]+)?)*[[:space:]]+config([[:space:]]+-[a-z-]+)*[[:space:]]+[^[:space:];&|]*url'; then
     deny "rewriting git remote/push URLs is blocked on the GLM lane (the pushurl tripwire stays poisoned)."
 fi
-if at_cmd 'gh([[:space:]]|$)'; then
-    deny "the gh CLI is blocked on the GLM lane (PR/issue/API actions belong to the parent session)."
+# gh carve-out (operator policy 2026-07-03, HIMMEL-675): allow `gh issue`
+# (full surface — cr-deferred followups are gh issues, audited + recoverable)
+# and read-only PR/CI context (`gh pr view|diff|checks|status|list`, `gh run
+# view|list|watch`); deny every other gh. Count command-position gh occurrences
+# vs allowed ones — a compound smuggling a denied gh past an allowed one
+# (`gh pr view 1 && gh pr merge 1`) has total > allowed → deny.
+gh_total=$(count_cmd 'gh([[:space:]]|$)')
+gh_allowed=$(count_cmd 'gh[[:space:]]+(issue([[:space:]]|$)|pr[[:space:]]+(view|diff|checks|status|list)([[:space:]]|$)|run[[:space:]]+(view|list|watch)([[:space:]]|$))')
+if [ "$gh_total" -gt "$gh_allowed" ]; then
+    deny "gh is limited on the GLM lane: issue ops + pr/run reads; PR mutations belong to the parent session."
 fi
 if at_cmd '(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm)([[:space:]]|$)'; then
     deny "network CLIs are blocked on the GLM lane (chores are repo-local)."

--- a/scripts/hooks/test-block-glm-external-writes.sh
+++ b/scripts/hooks/test-block-glm-external-writes.sh
@@ -55,8 +55,14 @@ assert_rc "glm git push after &&"        2 "$(run_case "$(j_bash 'bun test && gi
 assert_rc "glm git -C path push"         2 "$(run_case "$(j_bash 'git -C /tmp/wt push')" "ANTHROPIC_BASE_URL=$GLM_URL")"
 # shellcheck disable=SC2016  # literal $(git push) is the command text under test, not for expansion
 assert_rc "glm git push in subshell"     2 "$(run_case "$(j_bash 'echo $(git push 2>&1)')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+# gh carve-out (HIMMEL-675): issue ops + pr/run READS allow; everything else denies.
 assert_rc "glm gh pr create"             2 "$(run_case "$(j_bash 'gh pr create --fill')" "ANTHROPIC_BASE_URL=$GLM_URL")"
-assert_rc "glm gh pr view (reads too)"   2 "$(run_case "$(j_bash 'gh pr view 855')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh pr merge"              2 "$(run_case "$(j_bash 'gh pr merge 856 --squash')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh pr comment"           2 "$(run_case "$(j_bash 'gh pr comment 856 --body x')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh api"                   2 "$(run_case "$(j_bash 'gh api repos/o/r/issues -f title=x')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh repo delete"           2 "$(run_case "$(j_bash 'gh repo delete o/r')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm bare gh"                  2 "$(run_case "$(j_bash 'gh')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh compound smuggle"      2 "$(run_case "$(j_bash 'gh pr view 1 && gh pr merge 1')" "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm IWR uppercase alias"      2 "$(run_case "$(j_pwsh 'IWR https://example.com')" "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm push after pipe"          2 "$(run_case "$(j_bash 'git status | git push')" "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm remote set-url"           2 "$(run_case "$(j_bash 'git remote set-url --push origin git@github.com:u/r.git')" "ANTHROPIC_BASE_URL=$GLM_URL")"
@@ -84,11 +90,28 @@ assert_rc "glm jira prose in commit msg" 0 "$(run_case "$(j_bash 'git commit -m 
 assert_rc "glm jira CLI path (allowed)"  0 "$(run_case "$(j_bash 'node scripts/jira/dist/index.js transition HIMMEL-1 Done')" "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm bare jira (allowed)"      0 "$(run_case "$(j_bash 'jira list')" "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm jira direct path (allowed)" 0 "$(run_case "$(j_bash './scripts/jira/dist/index.js list')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+# gh issue ops + pr/run reads are operator-allowed on-lane (HIMMEL-675 carve-out).
+assert_rc "glm gh issue list (allowed)"    0 "$(run_case "$(j_bash 'gh issue list')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh issue create (allowed)"  0 "$(run_case "$(j_bash 'gh issue create --title x --body y')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh issue comment (allowed)" 0 "$(run_case "$(j_bash 'gh issue comment 858 --body done')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh issue close (allowed)"   0 "$(run_case "$(j_bash 'gh issue close 858')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh pr view (allowed)"       0 "$(run_case "$(j_bash 'gh pr view 856')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh pr diff (allowed)"       0 "$(run_case "$(j_bash 'gh pr diff 856')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh pr checks (allowed)"     0 "$(run_case "$(j_bash 'gh pr checks 856')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh pr list (allowed)"       0 "$(run_case "$(j_bash 'gh pr list')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh run list (allowed)"      0 "$(run_case "$(j_bash 'gh run list')" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm gh run watch (allowed)"     0 "$(run_case "$(j_bash 'gh run watch 123')" "ANTHROPIC_BASE_URL=$GLM_URL")"
 # qmd KB reads are operator-allowed on-lane (carve-out before the blanket mcp deny).
 assert_rc "glm mcp qmd read (allowed)"   0 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm Read tool ignored"        0 "$(run_case '{"tool_name":"Read","tool_input":{"file_path":"x"}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm empty command"            0 "$(run_case '{"tool_name":"Bash","tool_input":{}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm multi-line prose push"    0 "$(run_case "$(j_bash "$(printf 'git commit -m "notes\nabout git push etiquette"')")" "ANTHROPIC_BASE_URL=$GLM_URL")"
+# Newlines are command separators (flattened to ';'): a second-line mutation
+# must NOT slip through as an "argument" of the first line.
+assert_rc "glm newline gh smuggle"       2 "$(run_case "$(j_bash "$(printf 'gh pr view 1\ngh pr merge 1')")" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm newline git push"         2 "$(run_case "$(j_bash "$(printf 'echo hi\ngit push')")" "ANTHROPIC_BASE_URL=$GLM_URL")"
+# Pinned over-block: quoted prose whose LINE STARTS with a blocked verb.
+assert_rc "glm prose line-start push (pinned overmatch)" 2 "$(run_case "$(j_bash "$(printf 'git commit -m "notes\ngit push later"')")" "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm prose remote set-url"     0 "$(run_case "$(j_bash 'git commit -m "docs: note the remote set-url tripwire"')" "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm prose config url"         0 "$(run_case "$(j_bash 'git commit -m "docs: update config url notes"')" "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm env-prefix push (pinned limitation)" 0 "$(run_case "$(j_bash 'FOO=1 git push')" "ANTHROPIC_BASE_URL=$GLM_URL")"
@@ -108,7 +131,7 @@ fi
 # Total-count guard: every assert_rc increments CASES; a drift here means a case
 # was silently dropped (or an early exit skipped the tail) even though nothing
 # FAILED. Update EXPECTED_CASES deliberately when adding/removing a case.
-EXPECTED_CASES=44
+EXPECTED_CASES=62
 if [ "$CASES" -ne "$EXPECTED_CASES" ]; then
     echo "CASE-COUNT MISMATCH — ran $CASES, expected $EXPECTED_CASES"
     exit 1


### PR DESCRIPTION
Propagation of private #859 (squash 33e25ef7): GLM-lane gh allowlist (issue ops + pr/run reads, compound- and newline-smuggle-safe occurrence counting) + himmel-ops 0.4.0 version bump (version-keyed plugin cache delivery fix). 62-case suite. Leak scan clean.