### PR TITLE
test(glm): cr-deferred test-only sweep

### DIFF
--- a/scripts/telegram/glm-env.test.ts
+++ b/scripts/telegram/glm-env.test.ts
@@ -79,3 +79,37 @@ test("formatConflict renders the file:key strings the print/refusal sites emit",
   expect(formatConflict({ file: "/a", kind: "env", key: "ANTHROPIC_MODEL" })).toBe("/a: env.ANTHROPIC_MODEL");
   expect(formatConflict({ file: "/a", kind: "unparseable" })).toBe("/a: unparseable");
 });
+
+// --- .env precedence when sources COEXIST (CR finding F3). Existing tests prove
+// each source in isolation; these pin the ordering readZaiKey promises:
+// process.env > repo(worktree) .env > main-checkout .env.
+
+test("precedence: process.env beats repo .env when both present", () => {
+  process.env.ZAI_API_KEY = "from-process-env";
+  writeFileSync(join(root, ".env"), "ZAI_API_KEY=from-repo-env\n"); // gitleaks:allow
+  expect(buildGlmEnv(root).ANTHROPIC_AUTH_TOKEN).toBe("from-process-env");
+});
+
+test("precedence: worktree .env beats main-checkout .env fallback when both present", () => {
+  const repo = mkdtempSync(join(tmpdir(), "glmmain2-"));
+  const sh = (args: string[], cwd: string) => {
+    const r = Bun.spawnSync(args, { cwd, stdout: "pipe", stderr: "pipe" });
+    if (r.exitCode !== 0) throw new Error(`${args.join(" ")} failed: ${r.stderr.toString()}`);
+  };
+  try {
+    sh(["git", "init"], repo);
+    sh(["git", "config", "user.email", "t@t.t"], repo);
+    sh(["git", "config", "user.name", "t"], repo);
+    writeFileSync(join(repo, ".env"), "ZAI_API_KEY=from-main-checkout\n"); // gitleaks:allow
+    writeFileSync(join(repo, "f.txt"), "x");
+    sh(["git", "add", "f.txt"], repo); // .env stays out of the commit (mirrors gitignore)
+    sh(["git", "commit", "-m", "init"], repo);
+    const wt = join(repo, "wt");
+    sh(["git", "worktree", "add", wt], repo);
+    // worktree's OWN .env present → must win over the main-checkout fallback
+    writeFileSync(join(wt, ".env"), "ZAI_API_KEY=from-worktree\n"); // gitleaks:allow
+    expect(buildGlmEnv(wt).ANTHROPIC_AUTH_TOKEN).toBe("from-worktree");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/scripts/telegram/glm-guard.test.ts
+++ b/scripts/telegram/glm-guard.test.ts
@@ -1,6 +1,15 @@
 // scripts/telegram/glm-guard.test.ts
-import { afterEach, beforeEach, expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import * as realFs from "node:fs";
+
+// Plain-object snapshot of the REAL fs, captured at module load (before any
+// mock runs). ESM namespace props are live bindings, but spreading copies the
+// current function REFERENCES into a fresh object whose props won't follow a
+// later mock — so the surgical readFileSync mock below can pass through to real
+// for every path except the one under test, and cannot starve other test files
+// (bun runs them concurrently in one process; a global throw leaked once).
+const realFsSnapshot = { ...realFs };
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { checkGlmGuards } from "./glm-guard";
@@ -57,4 +66,32 @@ test("guard config as DIRECTORY fails closed", () => {
 test("sibling prefix does not false-positive", () => {
   writeFileSync(join(cfg, "egress-denylist"), work + "-sibling\n");
   expect(checkGlmGuards(work, cfg).ok).toBe(true);
+});
+
+// --- pathUnderAny catch branch (CR finding F2). The `!statSync().isFile()`
+// branch is covered by the DIRECTORY test above; the TRY/CATCH (statSync or
+// readFileSync THROW — e.g. permission-denied at read time) is not. Force the
+// throw with a SURGICAL module mock (readFileSync throws ONLY for this listFile,
+// passes through to real for every other path) and assert fail-closed. Without
+// the mock this config would be a HIT (PHI-marked refuse), so the "failing
+// closed" wording proves the catch fired rather than the happy isFile path.
+// Kept LAST; mock.restore() in finally restores the registry.
+
+test("guard config read THROW fails closed (catch branch — e.g. permission-denied)", () => {
+  const listFile = join(cfg, "phi-roots");
+  writeFileSync(listFile, work + "\n"); // exists; sans mock this is a HIT (REFUSED — PHI-marked)
+  mock.module("node:fs", () => ({
+    ...realFsSnapshot,
+    readFileSync: (p: any, ...rest: any[]) => {
+      if (typeof p === "string" && p === listFile) throw new Error("EACCES: permission denied");
+      return realFsSnapshot.readFileSync(p, ...rest);
+    },
+  }));
+  try {
+    const r = checkGlmGuards(work, cfg);
+    expect(r.ok).toBe(false);
+    expect((r as any).reason).toMatch(/failing closed/);
+  } finally {
+    mock.restore();
+  }
 });

--- a/scripts/telegram/spawn-glm.test.ts
+++ b/scripts/telegram/spawn-glm.test.ts
@@ -193,3 +193,51 @@ test("executeRun: a capped result writes status:capped (F4 wiring)", async () =>
     expect(meta.pid).toBe(99);
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
+
+// --- poisonPushUrl scope (CR finding F1: tripwire must be worktree-scoped, not
+// repo-global). The poison sets remote.origin.pushurl via `--worktree`, which
+// only lands in the worktree's private config when extensions.worktreeConfig is
+// on. This pins that scope: a SIBLING worktree (shares the repo's origin config)
+// and the repo-global config itself must both stay clean.
+
+test("pushurl poison is worktree-scoped, not repo-global (sibling worktree still pushes; repo-global pushurl unset)", () => {
+  const repo = mkdtempSync(join(tmpdir(), "glmgit-"));
+  const run = (args: string[], cwd: string) => Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+  run(["init", "-b", "main"], repo);
+  run(["-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "seed"], repo);
+  run(["remote", "add", "origin", repo], repo); // self-remote: a real push would land in-repo
+  const wtPoison = join(repo, "wtp");
+  const wtSibling = join(repo, "wts");
+  run(["worktree", "add", wtPoison, "-b", "glm/p"], repo);
+  run(["worktree", "add", wtSibling, "-b", "glm/s"], repo);
+  poisonPushUrl(repo, wtPoison);
+  // anchor: the poisoned worktree's push fails on the POISON
+  const pushPoison = run(["push", "origin", "HEAD"], wtPoison);
+  expect(pushPoison.exitCode).not.toBe(0);
+  expect(pushPoison.stderr.toString()).toContain("DISABLED-glm-quarantine");
+  // sibling worktree shares the repo's origin url (its own worktree config is
+  // empty) → its push is UNAFFECTED. If the poison had leaked repo-global, this
+  // sibling push --dry-run would hit DISABLED-glm-quarantine and fail.
+  const drySibling = run(["push", "--dry-run", "origin", "HEAD"], wtSibling);
+  expect(drySibling.exitCode).toBe(0);
+  // direct repo-global proof: remote.origin.pushurl was never written to the
+  // shared .git/config (git config --get exits 1 when the key is unset).
+  const cfgGlobal = run(["config", "--get", "remote.origin.pushurl"], repo);
+  expect(cfgGlobal.exitCode).not.toBe(0);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+// --- planSpawn refusal when ONE settings file mixes model + env.ANTHROPIC_*
+// (CR finding F4: the combination is untested — assert the env conflict still
+// refuses and is not masked by the co-located model downgrade).
+
+test("planSpawn refuses when ONE settings file mixes model + env.ANTHROPIC_* (env conflict not masked by co-located model)", () => {
+  const r = planSpawn("/repo", undefined, okDeps({ settingsConflicts: () => [
+    { file: "/home/t/.claude/settings.json", kind: "model" },
+    { file: "/home/t/.claude/settings.json", kind: "env", key: "ANTHROPIC_MODEL" },
+  ] }));
+  expect(r.ok).toBe(false);
+  expect((r as any).reason).toContain("settings conflicts");
+  // the env refusal is surfaced (not swallowed by the model→warning downgrade)
+  expect((r as any).reason).toContain("/home/t/.claude/settings.json: env.ANTHROPIC_MODEL");
+});


### PR DESCRIPTION
Propagation of private #860 (squash d69ec6a2): 4 test-only additions to the spawn-glm/glm-guard/glm-env suites (tripwire worktree-scope pin, guard catch-branch fail-closed, .env precedence pair, mixed model+env refusal). Leak scan clean.