### PR TITLE
fix(omniroute): cr-deferred sweep F1-F5

### DIFF
--- a/scripts/omniroute-config-lint.ps1
+++ b/scripts/omniroute-config-lint.ps1
@@ -18,6 +18,9 @@
 
   Usage: omniroute-config-lint.ps1 <config.json>
   Exit:  0 = PASS, 1 = one or more FAILs, 2 = usage / unreadable / unparseable input.
+  (The bash twin additionally exits 4 if its node runtime is absent — it delegates
+  JSON parsing to node; PS parses natively via ConvertFrom-Json and has no node
+  dependency, so it cannot hit that path.)
 
   JSON parsing uses ConvertFrom-Json natively (twin uses node); presence is probed
   via PSObject.Properties so an OMITTED key is distinguished from a disabled one.
@@ -162,6 +165,9 @@ else {
   Assert-False 'compression.cache.semanticCacheEnabled' (Get-Leaf $cache 'semanticCacheEnabled')
   Assert-False 'compression.cache.promptCacheEnabled' (Get-Leaf $cache 'promptCacheEnabled')
 
+  # KEEP IN SYNC with the twin allowlist in scripts/omniroute-config-lint.sh
+  # (var known) — the recognized-key set must match, or one twin flags a key the
+  # other silently accepts (a renamed/new engine sneaking past only one twin).
   $known = @('enabled', 'defaultMode', 'autoTriggerMode', 'rtkConfig', 'cavemanConfig', 'cavemanOutputMode', 'ultra', 'contextEditing', 'languageConfig', 'mcpDescriptionCompressionEnabled', 'mcpAccessibilityConfig', 'engines', 'aggressive', 'stackedPipeline', 'cache', 'optimization')
   foreach ($pr in $comp.PSObject.Properties) {
     if ($known -notcontains $pr.Name) {
@@ -180,7 +186,10 @@ elseif (-not (($ar.value -is [bool]) -and ($ar.value -eq $false))) {
 }
 
 if ($script:fails.Count -gt 0) {
-  foreach ($f in $script:fails) { Write-Output $f }
+  # FAIL diagnostics go to stderr; the PASS confirmation stays on stdout so a
+  # passing lint emits exactly one stdout line (testable / pipeable), while a
+  # failing one writes nothing to stdout. Exit code is unchanged (1).
+  foreach ($f in $script:fails) { [Console]::Error.WriteLine($f) }
   exit 1
 }
 Write-Output "PASS: omniroute compression stack disabled ($($script:asserted) keys asserted)"

--- a/scripts/omniroute-config-lint.sh
+++ b/scripts/omniroute-config-lint.sh
@@ -14,7 +14,9 @@
 # prompt optimization) and is ignored.
 #
 # Usage: omniroute-config-lint.sh <config.json>
-# Exit:  0 = PASS, 1 = one or more FAILs, 2 = usage / unreadable / unparseable input.
+# Exit:  0 = PASS, 1 = one or more FAILs, 2 = usage / unreadable / unparseable input,
+#         4 = node runtime missing (JSON parsing is delegated to node; matches the
+#         claude-routed twins' node-missing=4 convention).
 #
 # JSON parsing is delegated to node (a himmel dependency — same precedent as
 # scripts/claude-glm sanitize_settings). bash 3.2-safe.
@@ -137,6 +139,9 @@ if (!has(doc, "compression")) {
   assertFalse("compression.cache.semanticCacheEnabled", leaf(cache, "semanticCacheEnabled"));
   assertFalse("compression.cache.promptCacheEnabled", leaf(cache, "promptCacheEnabled"));
 
+  // KEEP IN SYNC with the twin allowlist in scripts/omniroute-config-lint.ps1
+  // ($known) — the recognized-key set must match, or one twin flags a key the
+  // other silently accepts (a renamed/new engine sneaking past only one twin).
   var known = { enabled: 1, defaultMode: 1, autoTriggerMode: 1, rtkConfig: 1, cavemanConfig: 1, cavemanOutputMode: 1, ultra: 1, contextEditing: 1, languageConfig: 1, mcpDescriptionCompressionEnabled: 1, mcpAccessibilityConfig: 1, engines: 1, aggressive: 1, stackedPipeline: 1, cache: 1, optimization: 1 };
   var ck = Object.keys(comp);
   for (var k = 0; k < ck.length; k++) {
@@ -152,7 +157,10 @@ if (!has(doc, "autoRoutingEnabled")) {
 }
 
 if (fails.length) {
-  for (var f = 0; f < fails.length; f++) process.stdout.write(fails[f] + "\n");
+  // FAIL diagnostics go to stderr; the PASS confirmation stays on stdout so a
+  // passing lint emits exactly one stdout line (testable / pipeable), while a
+  // failing one writes nothing to stdout. Exit code is unchanged (1).
+  for (var f = 0; f < fails.length; f++) process.stderr.write(fails[f] + "\n");
   process.exit(1);
 }
 process.stdout.write("PASS: omniroute compression stack disabled (" + asserted + " keys asserted)\n");
@@ -160,4 +168,11 @@ process.exit(0);
 NODE
 )
 
+# Preflight: JSON parsing is delegated to node, so a missing node would otherwise
+# surface as a generic "node: command not found" (exit 127). Catch it up front with
+# a clear message + exit 4, matching the claude-routed twins' node-missing=4 contract.
+if ! command -v node >/dev/null 2>&1; then
+  echo "omniroute-config-lint: node is required (JSON parsing is delegated to node) but was not found on PATH." >&2
+  exit 4
+fi
 exec node -e "$LINT_JS" "$1"

--- a/scripts/test-omniroute-config-lint.ps1
+++ b/scripts/test-omniroute-config-lint.ps1
@@ -116,6 +116,13 @@ try {
   Assert-Exit (Invoke-Lint @($f)) 1 'non-empty stackedPipeline fails'
   Have 'FAIL: compression.stackedPipeline expected an empty array, got 1 entry'
 
+  # --- T9b: stackedPipeline with TWO entries -> FAIL using the PLURAL "entries"
+  # branch (the length>1 arm of the entry/ies ternary; T9 only covers the 1-entry
+  # "entry" arm). CR F1: this branch was untested on both twins. ---
+  $f = Join-Path $TMP 'stack2.json'; New-Config $f { param($c) $c.compression.stackedPipeline = @([ordered]@{ name = 'x' }, [ordered]@{ name = 'y' }) }
+  Assert-Exit (Invoke-Lint @($f)) 1 'two-entry stackedPipeline fails (plural)'
+  Have 'FAIL: compression.stackedPipeline expected an empty array, got 2 entries'
+
   # --- T10: wrong string value on defaultMode -> FAIL ---
   $f = Join-Path $TMP 'mode.json'; New-Config $f { param($c) $c.compression.defaultMode = 'aggressive' }
   Assert-Exit (Invoke-Lint @($f)) 1 'wrong defaultMode fails'
@@ -143,6 +150,34 @@ try {
   Have 'FAIL: compression.ultra.enabled expected false, got true'
   Have 'FAIL: autoRoutingEnabled expected false, got <absent>'
 
+  # --- T13b..T13f: defensive structural FAIL branches (CR F2). Each exercises a
+  # guard the happy path never hits, so a future fail-open simplification is caught.
+  # These mirror the bash twin case-for-case (keep both twins' matrices in sync). ---
+  # engines MISSING
+  $f = Join-Path $TMP 'noeng.json'; New-Config $f { param($c) $c.compression.Remove('engines') }
+  Assert-Exit (Invoke-Lint @($f)) 1 'engines missing fails'
+  Have 'FAIL: compression.engines missing (expected an object with every entry disabled)'
+
+  # engines present but NOT an object
+  $f = Join-Path $TMP 'engnonobj.json'; New-Config $f { param($c) $c.compression.engines = $true }
+  Assert-Exit (Invoke-Lint @($f)) 1 'engines non-object fails'
+  Have 'FAIL: compression.engines expected an object, got true'
+
+  # aggressive.toolStrategies MISSING
+  $f = Join-Path $TMP 'nots.json'; New-Config $f { param($c) $c.compression.aggressive.Remove('toolStrategies') }
+  Assert-Exit (Invoke-Lint @($f)) 1 'toolStrategies missing fails'
+  Have 'FAIL: compression.aggressive.toolStrategies missing (expected an object with every entry disabled)'
+
+  # aggressive.toolStrategies entry that is a STRING (not bool, not object) -> else branch
+  $f = Join-Path $TMP 'tsstr.json'; New-Config $f { param($c) $c.compression.aggressive.toolStrategies = [ordered]@{ weird = 'somestring' } }
+  Assert-Exit (Invoke-Lint @($f)) 1 'toolStrategies string entry fails'
+  Have 'FAIL: compression.aggressive.toolStrategies.weird expected disabled, got somestring'
+
+  # stackedPipeline MISSING
+  $f = Join-Path $TMP 'nosp.json'; New-Config $f { param($c) $c.compression.Remove('stackedPipeline') }
+  Assert-Exit (Invoke-Lint @($f)) 1 'stackedPipeline missing fails'
+  Have 'FAIL: compression.stackedPipeline missing (expected an empty array)'
+
   # --- T14: missing/unreadable file -> exit 2 ---
   Assert-Exit (Invoke-Lint @((Join-Path $TMP 'does-not-exist.json'))) 2 'missing file exits 2'
 
@@ -159,6 +194,23 @@ try {
 
   # --- T18: usage (two args) -> exit 2 ---
   Assert-Exit (Invoke-Lint @('a', 'b')) 2 'two-args usage exits 2'
+
+  # --- T19: FAIL diagnostics route to STDERR (not stdout); PASS stays on stdout.
+  # CR F5: locks the routing contract so a future regression that re-merges FAIL to
+  # stdout is caught. (The cases above capture 2>&1, so they pass either way.) ---
+  $rf = Join-Path $TMP 'rfail.json'; New-Config $rf { param($c) $c.compression.ultra.enabled = $true }
+  $RoutOut = Join-Path $TMP 'rout-stdout.txt'; $RoutErr = Join-Path $TMP 'rout-stderr.txt'
+  & pwsh -NoProfile -File $Lint $rf 2>$RoutErr | Out-File -LiteralPath $RoutOut -Encoding utf8
+  if ($LASTEXITCODE -eq 1) { Pass 'routing case exit 1' } else { Fail "routing case exit $LASTEXITCODE, want 1" }
+  if (FileHas $RoutErr 'FAIL: compression.ultra.enabled expected false, got true') { Pass 'FAIL on stderr' } else { Fail 'FAIL not on stderr' }
+  if (FileHas $RoutOut 'FAIL:') { Fail 'FAIL leaked to stdout' } else { Pass 'no FAIL on stdout' }
+  # PASS on stdout, nothing on stderr
+  $cf = Join-Path $TMP 'rcompliant.json'; New-Config $cf $null
+  & pwsh -NoProfile -File $Lint $cf 2>$RoutErr | Out-File -LiteralPath $RoutOut -Encoding utf8
+  if ($LASTEXITCODE -eq 0) { Pass 'compliant routing exit 0' } else { Fail "compliant routing exit $LASTEXITCODE, want 0" }
+  if (FileHas $RoutOut $PassLine) { Pass 'PASS on stdout' } else { Fail 'PASS not on stdout' }
+  $errRaw = if (Test-Path -LiteralPath $RoutErr) { (Get-Content -LiteralPath $RoutErr -Raw) } else { '' }
+  if ([string]::IsNullOrWhiteSpace($errRaw)) { Pass 'PASS case stderr empty' } else { Fail 'PASS case wrote to stderr' }
 
   Write-Host ''
   if ($script:fails -eq 0) { Write-Host 'ALL PASS' } else { Write-Host "$($script:fails) failure(s)" -ForegroundColor Red; exit 1 }

--- a/scripts/test-omniroute-config-lint.sh
+++ b/scripts/test-omniroute-config-lint.sh
@@ -92,6 +92,13 @@ mkcfg "$WORK/stack.json" 'c.compression.stackedPipeline=[{name:"x"}];'
 t "non-empty stackedPipeline fails" 1 "$WORK/stack.json"
 have "FAIL: compression.stackedPipeline expected an empty array, got 1 entry"
 
+# --- T9b: stackedPipeline with TWO entries -> FAIL using the PLURAL "entries"
+# branch (the length>1 arm of the entry/ies ternary; T9 only covers the 1-entry
+# "entry" arm). CR F1: this branch was untested on both twins. ---
+mkcfg "$WORK/stack2.json" 'c.compression.stackedPipeline=[{name:"x"},{name:"y"}];'
+t "two-entry stackedPipeline fails (plural)" 1 "$WORK/stack2.json"
+have "FAIL: compression.stackedPipeline expected an empty array, got 2 entries"
+
 # --- T10: wrong string value on defaultMode -> FAIL ---
 mkcfg "$WORK/mode.json" 'c.compression.defaultMode="aggressive";'
 t "wrong defaultMode fails" 1 "$WORK/mode.json"
@@ -119,6 +126,37 @@ t "reports all failures" 1 "$WORK/multi.json"
 have "FAIL: compression.ultra.enabled expected false, got true"
 have "FAIL: autoRoutingEnabled expected false, got <absent>"
 
+# --- T13b..T13f: defensive structural FAIL branches (CR F2). Each exercises a
+# guard the happy path never hits, so a future fail-open simplification is caught.
+# These mirror the .ps1 twin case-for-case (keep both twins' matrices in sync). ---
+# engines MISSING -> the structural guard fires (not the per-entry loop)
+mkcfg "$WORK/noeng.json" 'delete c.compression.engines;'
+t "engines missing fails" 1 "$WORK/noeng.json"
+have "FAIL: compression.engines missing (expected an object with every entry disabled)"
+
+# engines present but NOT an object -> the guard before the per-entry loop
+mkcfg "$WORK/engnonobj.json" 'c.compression.engines=true;'
+t "engines non-object fails" 1 "$WORK/engnonobj.json"
+have "FAIL: compression.engines expected an object, got true"
+
+# aggressive.toolStrategies MISSING -> the summarizer assert still passes; only
+# the toolStrategies structural guard fires
+mkcfg "$WORK/nots.json" 'delete c.compression.aggressive.toolStrategies;'
+t "toolStrategies missing fails" 1 "$WORK/nots.json"
+have "FAIL: compression.aggressive.toolStrategies missing (expected an object with every entry disabled)"
+
+# aggressive.toolStrategies entry that is a STRING (not bool, not object) -> the
+# `else` disabled-expected branch (T11/T11b cover only the object + bare-bool arms)
+mkcfg "$WORK/tsstr.json" 'c.compression.aggressive.toolStrategies={weird:"somestring"};'
+t "toolStrategies string entry fails" 1 "$WORK/tsstr.json"
+have "FAIL: compression.aggressive.toolStrategies.weird expected disabled, got somestring"
+
+# stackedPipeline MISSING -> the absent-key structural arm (T9/T9b cover
+# present-but-non-empty)
+mkcfg "$WORK/nosp.json" 'delete c.compression.stackedPipeline;'
+t "stackedPipeline missing fails" 1 "$WORK/nosp.json"
+have "FAIL: compression.stackedPipeline missing (expected an empty array)"
+
 # --- T14: missing/unreadable file -> exit 2 ---
 t "missing file exits 2" 2 "$WORK/does-not-exist.json"
 
@@ -137,5 +175,36 @@ bash "$LINT" >"$OUT" 2>&1; got=$?
 # --- T18: usage (two args) -> exit 2 ---
 bash "$LINT" a b >"$OUT" 2>&1; got=$?
 [ "$got" -eq 2 ] && echo "ok: two-args usage exits 2" || { echo "FAIL: two-args usage (exit $got, want 2)"; cat "$OUT"; FAILS=$((FAILS+1)); }
+
+# --- T19: FAIL diagnostics route to STDERR (not stdout); PASS stays on stdout.
+# CR F5: locks the routing contract so a future regression that re-merges FAIL to
+# stdout is caught. (The cases above capture 2>&1, so they pass either way.) ---
+mkcfg "$WORK/rfail.json" 'c.compression.ultra.enabled=true;'
+ROUT_OUT="$WORK/rout-stdout.txt"; ROUT_ERR="$WORK/rout-stderr.txt"
+bash "$LINT" "$WORK/rfail.json" >"$ROUT_OUT" 2>"$ROUT_ERR"; grc=$?
+if [ "$grc" -ne 1 ]; then echo "FAIL: routing case wrong exit ($grc, want 1)"; FAILS=$((FAILS+1)); else echo "ok: routing case exit 1"; fi
+{ grep -qF "FAIL: compression.ultra.enabled expected false, got true" "$ROUT_ERR" && echo "ok: FAIL line on stderr"; } || { echo "FAIL: FAIL line not on stderr"; FAILS=$((FAILS+1)); }
+if grep -qF "FAIL:" "$ROUT_OUT"; then echo "FAIL: FAIL line leaked to stdout"; FAILS=$((FAILS+1)); else echo "ok: no FAIL line on stdout"; fi
+# PASS on stdout, nothing on stderr
+bash "$LINT" "$WORK/compliant.json" >"$ROUT_OUT" 2>"$ROUT_ERR"; prc=$?
+if [ "$prc" -ne 0 ]; then echo "FAIL: compliant routing case wrong exit ($prc, want 0)"; FAILS=$((FAILS+1)); else echo "ok: compliant routing exit 0"; fi
+{ grep -qF "$PASS_LINE" "$ROUT_OUT" && echo "ok: PASS on stdout"; } || { echo "FAIL: PASS not on stdout"; FAILS=$((FAILS+1)); }
+if [ -s "$ROUT_ERR" ]; then echo "FAIL: PASS case wrote to stderr"; cat "$ROUT_ERR"; FAILS=$((FAILS+1)); else echo "ok: PASS case stderr empty"; fi
+
+# --- T20: node runtime ABSENT from PATH -> exit 4 with a clear stderr message
+# (CR F3 red-path). JSON parsing is delegated to node, so a missing node must fail
+# closed on the node-missing=4 contract (matching the claude-routed twins), not a
+# generic "node: command not found" (127). Uses the proven empty-PATH pattern from
+# scripts/hooks/test-block-glm-external-writes.sh run_case_no_jq: absolute bash +
+# an empty PATH dir so `command -v node` fails. (Isolating a coreutils-only PATH is
+# itself PATH-fragile on Windows/msys — cat needs its colocated DLLs — but the exit-4
+# preflight fires before the LINT_JS heredoc's cat output matters, so the benign
+# "cat: command not found" noise is ignored; we assert only the node-missing line.) ---
+BASH_ABS="$(command -v bash)"
+NONODE_PATH="$WORK/nonode-path"; mkdir -p "$NONODE_PATH"
+NODE_ERR="$WORK/nonode-stderr.txt"
+PATH="$NONODE_PATH" "$BASH_ABS" "$LINT" "$WORK/compliant.json" >"$OUT" 2>"$NODE_ERR"; nrc=$?
+if [ "$nrc" -ne 4 ]; then echo "FAIL: node-missing case wrong exit ($nrc, want 4)"; cat "$NODE_ERR"; FAILS=$((FAILS+1)); else echo "ok: node-missing exits 4"; fi
+{ grep -qF "omniroute-config-lint: node is required" "$NODE_ERR" && echo "ok: node-missing message on stderr"; } || { echo "FAIL: node-missing message not on stderr"; cat "$NODE_ERR"; FAILS=$((FAILS+1)); }
 
 echo; [ "$FAILS" -eq 0 ] && echo "ALL PASS" || { echo "$FAILS failure(s)"; exit 1; }


### PR DESCRIPTION
Propagation of private #861 (squash 8119a9b4): omniroute config-lint + launcher cr-deferred fixes — stackedPipeline plural + defensive-branch test coverage on both twins, node-missing preflight (exit 4) + red-path case, cross-twin allowlist sync notes, FAIL diagnostics to stderr. Leak scan clean.