### PR TITLE
fix(luna): rules parity + --limit guard

### DIFF
--- a/scripts/luna/backfill-sessions.sh
+++ b/scripts/luna/backfill-sessions.sh
@@ -145,7 +145,7 @@ while [ $# -gt 0 ]; do
             shift ;;
         --limit)
             shift
-            case "$1" in [0-9]*) RECRYS_LIMIT="$1" ;; *) printf 'backfill: --limit needs a number\n' >&2; exit 1 ;; esac
+            case "${1:-}" in [0-9]*) RECRYS_LIMIT="$1" ;; *) printf 'backfill: --limit needs a number\n' >&2; exit 1 ;; esac
             shift ;;
         --state-file)
             shift; STATE_FILE="$1"; shift ;;

--- a/scripts/luna/crystallize-note.ps1
+++ b/scripts/luna/crystallize-note.ps1
@@ -105,9 +105,14 @@ your file tools, then stop.
 
     # Operator rules/context injection: append a readable rules file's content as
     # a clearly delimited block. Unreadable / missing / empty -> append nothing.
+    # Trim whitespace before the emptiness check to ensure parity with bash
+    # (bash `$(cat)` strips trailing newline, but PS Get-Content -Raw keeps it;
+    # both must skip on whitespace-only files).
     if ($rulesFile -and (Test-Path -LiteralPath $rulesFile)) {
         $rulesContent = (Get-Content -LiteralPath $rulesFile -Raw)
-        if ($rulesContent) {
+        # Null-safe whitespace check: Get-Content -Raw returns $null on a
+        # zero-byte file, so .Trim() would throw and abort the run.
+        if (-not [string]::IsNullOrWhiteSpace($rulesContent)) {
             $prompt = $prompt + @"
 
 Additionally apply these operator rules when synthesizing:

--- a/scripts/luna/crystallize-note.sh
+++ b/scripts/luna/crystallize-note.sh
@@ -163,10 +163,14 @@ fi
 
 # Operator rules/context injection: when a readable rules file was supplied,
 # append its content as a clearly delimited block. Unreadable / missing / empty
-# -> append nothing (fail-open).
+# -> append nothing (fail-open). Trim whitespace before the emptiness guard to
+# ensure parity with PowerShell (Get-Content -Raw keeps trailing newline, but
+# bash `$(cat)` strips it; both must skip on whitespace-only files).
 if [ -n "$RULES_FILE" ] && [ -r "$RULES_FILE" ]; then
     _rules_content="$(cat "$RULES_FILE" 2>/dev/null)"
-    if [ -n "$_rules_content" ]; then
+    # Trim whitespace (spaces, tabs, newlines) before the emptiness check
+    _rules_trimmed="${_rules_content//[$'\t\r\n ']/}"
+    if [ -n "$_rules_trimmed" ]; then
         PROMPT="$PROMPT
 
 Additionally apply these operator rules when synthesizing:

--- a/scripts/luna/test-backfill-sessions.sh
+++ b/scripts/luna/test-backfill-sessions.sh
@@ -1635,6 +1635,14 @@ out32b=$(bash "$BACKFILL" --reheal --rules 2>&1) || rc32b=$?
 if [ "$rc32b" -eq 1 ]; then pass "rules(guard): trailing --rules exits 1"; else fail "rules(guard): wrong exit $rc32b (want 1)" "$out32b"; fi
 assert_contains "rules(guard): explicit needs-a-value message" "--rules needs a value" "$out32b"
 
+# Trailing --limit with no value (HIMMEL-842): the guard must fail fast with a
+# clean message, not a raw set -u "$1: unbound variable" abort. Uses the same
+# safe expansion shape (${1:-}) as the --rules arm.
+rc32c=0
+out32c=$(bash "$BACKFILL" --recrystallize --limit 2>&1) || rc32c=$?
+if [ "$rc32c" -eq 1 ]; then pass "limit(guard): trailing --limit exits 1"; else fail "limit(guard): wrong exit $rc32c (want 1)" "$out32c"; fi
+assert_contains "limit(guard): explicit needs-a-number message" "--limit needs a number" "$out32c"
+
 # ============================================================================
 # Case 33: multi-vault --all already-in-vault dedup (#790) — two repos route to
 #          two DIFFERENT vaults (mirror Case 17), each vault already holds a live

--- a/scripts/luna/test-crystallize-note.ps1
+++ b/scripts/luna/test-crystallize-note.ps1
@@ -323,15 +323,37 @@ $note = Join-Path $SB 'note.md'; $tr = Join-Path $SB 't.jsonl'
 $rules = Join-Path $SB 'empty-rules.txt'; $argvd = Join-Path $SB 'argv.txt'
 Write-Note $note; Set-Content -LiteralPath $tr -Value '{}'
 [System.IO.File]::WriteAllText($rules, '')
-$env:STUB_MODE = 'success'; $env:CRYSTALLIZE_PID_DIR = (Join-Path $SB 'pids')
+$env:CRYSTALLIZE_CLAUDE_BIN = $STUB; $env:STUB_MODE = 'success'; $env:CRYSTALLIZE_PID_DIR = (Join-Path $SB 'pids')
 $env:CRYSTALLIZE_ARGV_DUMP = $argvd; $env:CRYSTALLIZE_RULES_FILE = $rules
 Run-Crys $note $tr
 Remove-Item Env:\CRYSTALLIZE_ARGV_DUMP -ErrorAction SilentlyContinue
 Remove-Item Env:\CRYSTALLIZE_RULES_FILE -ErrorAction SilentlyContinue
 $nc = Get-Content -LiteralPath $note -Raw
+if ($nc -match '(?m)^crystallized: true$') { Pass 'rules(empty): run still proceeds normally with zero-byte rules file' } else { Fail 'rules(empty): run did not proceed' }
 $avRaw = Get-Content -LiteralPath $argvd -Raw
-if ($avRaw -notmatch 'begin operator rules') { Pass 'rules(empty): no operator-rules block for a zero-byte rules file' } else { Fail 'rules(empty): rules block wrongly present for empty file' }
-if ($nc -match '(?m)^crystallized: true$') { Pass 'rules(empty): run still proceeds normally' } else { Fail 'rules(empty): run did not proceed' }
+if ($avRaw -notmatch 'begin operator rules') { Pass 'rules(empty): no operator-rules block for a zero-byte rules file' } else { Fail 'rules(empty): rules block wrongly present for zero-byte file' }
+Remove-Item -LiteralPath $SB -Recurse -Force
+
+# --- Case 16: whitespace-only rules file — parity test (bash vs ps1 divergence) --
+# HIMMEL-841: bash `$(cat file)` strips trailing newline; PS `Get-Content -Raw`
+# keeps it. A file with ONLY a newline must NOT append a rules block in BOTH.
+$SB = Join-Path ([System.IO.Path]::GetTempPath()) ("cnt-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $SB -Force | Out-Null
+$note = Join-Path $SB 'note.md'; $tr = Join-Path $SB 't.jsonl'
+$rules = Join-Path $SB 'ws-only-rules.txt'; $argvd = Join-Path $SB 'argv.txt'
+Write-Note $note; Set-Content -LiteralPath $tr -Value '{}'
+[System.IO.File]::WriteAllText($rules, "`n")
+$env:CRYSTALLIZE_CLAUDE_BIN = $STUB; $env:STUB_MODE = 'success'; $env:CRYSTALLIZE_PID_DIR = (Join-Path $SB 'pids')
+$env:CRYSTALLIZE_ARGV_DUMP = $argvd; $env:CRYSTALLIZE_RULES_FILE = $rules
+Run-Crys $note $tr
+Remove-Item Env:\CRYSTALLIZE_ARGV_DUMP -ErrorAction SilentlyContinue
+Remove-Item Env:\CRYSTALLIZE_RULES_FILE -ErrorAction SilentlyContinue
+$nc = Get-Content -LiteralPath $note -Raw
+if ($nc -match '(?m)^crystallized: true$') { Pass 'rules(ws-only): run still proceeds normally with whitespace-only rules file' } else { Fail 'rules(ws-only): run did not proceed' }
+# The load-bearing parity assertion (HIMMEL-841): the block must be ABSENT —
+# without it this case stays green even if the trim guard is reverted.
+$avRaw = Get-Content -LiteralPath $argvd -Raw
+if ($avRaw -notmatch 'begin operator rules') { Pass 'rules(ws-only): no operator-rules block for whitespace-only file (parity with bash)' } else { Fail 'rules(ws-only): rules block wrongly present for whitespace-only file' }
 Remove-Item -LiteralPath $SB -Recurse -Force
 
 if ($script:fails -eq 0) { 'ALL PASS'; exit 0 } else { "$($script:fails) FAILED"; exit 1 }

--- a/scripts/luna/test-crystallize-note.sh
+++ b/scripts/luna/test-crystallize-note.sh
@@ -334,6 +334,21 @@ if ! grep -qF 'begin operator rules' "$ARGVD" 2>/dev/null; then pass "rules(empt
 if grep -q '^crystallized: true$' "$NOTE"; then pass "rules(empty): run still proceeds normally"; else fail "rules(empty): run did not proceed"; fi
 rm -rf "$SB"
 
+# --- Case R9: whitespace-only rules file — parity test (bash vs ps1 divergence) --
+# HIMMEL-841: bash `$(cat file)` strips trailing newline; PS `Get-Content -Raw`
+# keeps it. A file with ONLY a newline must NOT append a rules block in BOTH.
+# This tests the trimmed check for parity.
+SB="$(mktemp -d)"
+NOTE="$SB/note.md"; TR="$SB/t.jsonl"; RULES="$SB/ws-only-rules.txt"; ARGVD="$SB/argv.txt"
+write_note "$NOTE"; printf '{}\n' > "$TR"
+printf '\n' > "$RULES"
+env CRYSTALLIZE_CLAUDE_BIN="$STUB" STUB_MODE=success \
+    CRYSTALLIZE_PID_DIR="$SB/pids" CRYSTALLIZE_ARGV_DUMP="$ARGVD" \
+    CRYSTALLIZE_RULES_FILE="$RULES" bash "$CRYS" "$NOTE" "$TR"
+if ! grep -qF 'begin operator rules' "$ARGVD" 2>/dev/null; then pass "rules(ws-only): no operator-rules block for whitespace-only file (parity with ps1)"; else fail "rules(ws-only): rules block wrongly present for whitespace-only file"; fi
+if grep -q '^crystallized: true$' "$NOTE"; then pass "rules(ws-only): run still proceeds normally"; else fail "rules(ws-only): run did not proceed"; fi
+rm -rf "$SB"
+
 # --- Case 9: real-claude smoke (OPT-IN: CRYSTALLIZE_REAL_CLAUDE=1) --------------
 # The whole point of HIMMEL-590 is that the STUB hides the real-claude no-op.
 # This case runs the genuine `claude` across the himmel-cwd -> vault-note boundary


### PR DESCRIPTION
Propagation of private #862 (squash e882c432): crystallize-note twins skip whitespace-only rules files identically (null-safe on PS) + backfill-sessions --limit trailing-flag friendly error; load-bearing block-absence test assertions on both PS cases. Leak scan clean.