### PR TITLE
fix(omniroute): cr-deferred sweep F6-F9 — dup-key lint parity, seed exit-4, header refs

### DIFF
--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -407,7 +407,9 @@ never pass as "nothing enabled found"), any entry is enabled, any unknown
 key appears inside `compression` (a renamed engine can't sneak in;
 `optimization` = SQLite tuning, excluded), or the free-lane switch
 `autoRoutingEnabled` is not explicitly `false`. Exit codes: 0 PASS / 1
-findings / 2 usage-or-unparseable.
+findings / 2 usage / unreadable / unparseable input (mirrors the script
+header; covers wrong arg count, an unreadable file, invalid JSON, and a
+non-object JSON root).
 
 **Status:** the router deploy itself (HIMMEL-666 Task 2) is operator-gated
 (per-token lane decision) — these artifacts are built-and-tested ahead of it;

--- a/scripts/claude-routed
+++ b/scripts/claude-routed
@@ -3,7 +3,10 @@
 # HIMMEL-654 WS2 (child HIMMEL-666). bash 3.2-safe. Copy-and-edit of scripts/claude-glm
 # (WS1 extensibility seam): ONLY the backend block differs — loopback router base URL
 # + an OmniRoute-issued client key. Everything else (guard, config-dir seeding, arg
-# handling, exit codes) is behaviour-identical. Spec: himmel/specs/design/ws1-claude-glm-wrapper.md
+# handling, exit codes) is behaviour-identical. Specs: WS1 wrapper
+# himmel/specs/design/ws1-claude-glm-wrapper.md (the wrapper this edits); WS2 routed
+# design himmel/specs/design/ws2-router-omniroute-pilot.md + plan
+# himmel/specs/plan/ws2-router-omniroute-pilot.md (routed-specific rationale).
 # shellcheck disable=SC1091  # load-dotenv.sh path issue
 set -u
 

--- a/scripts/claude-routed.ps1
+++ b/scripts/claude-routed.ps1
@@ -8,7 +8,9 @@
   3 = egress refusal, 4 = failed seed). A guard config (phi-roots / egress-denylist)
   that exists but is not a readable regular file also fails CLOSED with the bash-parity
   message ("guard config <path> exists but is not a readable file — failing closed.")
-  and exit 3. Spec: himmel/specs/design/ws1-claude-glm-wrapper.md
+  and exit 3. Specs: WS1 wrapper himmel/specs/design/ws1-claude-glm-wrapper.md (the
+  wrapper this edits); WS2 routed design himmel/specs/design/ws2-router-omniroute-pilot.md
+  + plan himmel/specs/plan/ws2-router-omniroute-pilot.md (routed-specific rationale).
 
   Flags LEAD, then everything else passes to `claude` verbatim - mirrors the
   bash flags-lead rule. This is deliberately a PLAIN script with NO declared
@@ -187,22 +189,28 @@ function Copy-SeedConfig {
       exit 4
     }
   }
-  foreach ($f in 'CLAUDE.md', 'RTK.md') {
-    $p = Join-Path $src $f
-    if (Test-Path -LiteralPath $p) { Copy-Item -LiteralPath $p -Destination (Join-Path $ConfigDir $f) -Force }
+  # Parity with the bash twin's seed_fail=4 — any seed failure must exit 4, not raw 1 (CR F9, #830).
+  try {
+    foreach ($f in 'CLAUDE.md', 'RTK.md') {
+      $p = Join-Path $src $f
+      if (Test-Path -LiteralPath $p) { Copy-Item -LiteralPath $p -Destination (Join-Path $ConfigDir $f) -Force }
+    }
+    foreach ($d in 'commands', 'skills', 'hooks', 'agents') {
+      $p = Join-Path $src $d
+      if (Test-Path -LiteralPath $p -PathType Container) { Copy-Item -LiteralPath $p -Destination $ConfigDir -Recurse -Force }
+    }
+    foreach ($p in 'installed_plugins.json', 'known_marketplaces.json') {
+      $sp = Join-Path $src (Join-Path 'plugins' $p)
+      if (Test-Path -LiteralPath $sp) { Copy-Item -LiteralPath $sp -Destination (Join-Path $ConfigDir (Join-Path 'plugins' $p)) -Force }
+    }
+    $mp = Join-Path $src (Join-Path 'plugins' 'marketplaces')
+    if (Test-Path -LiteralPath $mp -PathType Container) { Copy-Item -LiteralPath $mp -Destination (Join-Path $ConfigDir 'plugins') -Recurse -Force }
+    # sentinel LAST: only a fully-populated seed reads as "seeded"
+    New-Item -ItemType File -Force -Path (Join-Path $ConfigDir '.seeded') | Out-Null
+  } catch {
+    [Console]::Error.WriteLine("claude-routed: FAILED to seed config dir ($($_.Exception.Message)). Refusing to launch with a half-seeded config dir. Fix the cause and re-run (or rm -rf ~/.claude-routed).")
+    exit 4
   }
-  foreach ($d in 'commands', 'skills', 'hooks', 'agents') {
-    $p = Join-Path $src $d
-    if (Test-Path -LiteralPath $p -PathType Container) { Copy-Item -LiteralPath $p -Destination $ConfigDir -Recurse -Force }
-  }
-  foreach ($p in 'installed_plugins.json', 'known_marketplaces.json') {
-    $sp = Join-Path $src (Join-Path 'plugins' $p)
-    if (Test-Path -LiteralPath $sp) { Copy-Item -LiteralPath $sp -Destination (Join-Path $ConfigDir (Join-Path 'plugins' $p)) -Force }
-  }
-  $mp = Join-Path $src (Join-Path 'plugins' 'marketplaces')
-  if (Test-Path -LiteralPath $mp -PathType Container) { Copy-Item -LiteralPath $mp -Destination (Join-Path $ConfigDir 'plugins') -Recurse -Force }
-  # sentinel LAST: only a fully-populated seed reads as "seeded"
-  New-Item -ItemType File -Force -Path (Join-Path $ConfigDir '.seeded') | Out-Null
 }
 
 if ((-not (Test-Path -LiteralPath (Join-Path $ConfigDir '.seeded'))) -or $Reseed) {

--- a/scripts/omniroute-config-lint.ps1
+++ b/scripts/omniroute-config-lint.ps1
@@ -78,6 +78,79 @@ function Assert-Off([string]$path, $leaf) {
   if (-not (($v -is [string]) -and ($v -eq 'off'))) { Add-Fail "$path expected off, got $(Get-Show $v)" }
 }
 
+function Find-DuplicateKeys {
+  # Pre-parse duplicate-key scan (CR F6, #836). ConvertFrom-Json collapses duplicate
+  # keys to the LAST value silently (same as node JSON.parse), so a duplicate-key
+  # config is ambiguous: the "real" value is engine-defined, not author-defined. For a
+  # positive-assertion lint that must PROVABLY catch enabled engines, trusting
+  # last-wins is a hole (one day both engines could keep FIRST and pass a config that
+  # still contains an enabled=true). Scan the raw text for a key that appears twice
+  # within the SAME object and FAIL closed on any, before the (now-ambiguous)
+  # engine-key assertions run. Operates on already-validated JSON, so braces/quotes
+  # are balanced and string values' internal {/}/:/, can't trip it. Twin of the
+  # bash/node scan in scripts/omniroute-config-lint.sh — same message lines + exit 1
+  # so both platforms produce the SAME outcome (parity) for EXACT-case duplicates
+  # (T21/T22 scope). Case-VARIANT sibling keys never reach this scan: ConvertFrom-
+  # Json rejects them ("keys with different casing") → exit 2 fail-closed, while the
+  # node twin accepts them (distinct keys, exit 0) — an engine divergence pinned by
+  # T23. Keys compare as RAW escaped text — a unicode-escaped key
+  # (backslash-u0061) and its literal twin ("a") read as different keys
+  # (shared symmetric blind spot, adversarial-only input).
+  param([string]$Raw)
+  $dups = [System.Collections.Generic.List[string]]::new()
+  # Ordinal (case-SENSITIVE) key-sets: JSON keys are case-sensitive and the node
+  # twin's Object.create(null) compares case-sensitively — a default @{} hashtable
+  # is case-INSENSITIVE and would flag {"enabled":…,"Enabled":…} as a duplicate on
+  # Windows only, breaking the cross-platform-identical outcome this scan exists
+  # to guarantee (CR round-2 finding).
+  $stack = [System.Collections.Generic.Stack[System.Collections.Generic.HashSet[string]]]::new()   # per-object key-sets; top = innermost object
+  $chars = $Raw.ToCharArray()
+  $i = 0; $n = $chars.Length
+  while ($i -lt $n) {
+    $ch = $chars[$i]
+    if ($ch -eq ' ' -or $ch -eq "`t" -or $ch -eq "`r" -or $ch -eq "`n") { $i++; continue }
+    if ($ch -eq '{') { $stack.Push([System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)); $i++; continue }
+    if ($ch -eq '}') { if ($stack.Count -gt 0) { [void]$stack.Pop() }; $i++; continue }
+    if ($ch -eq '[' -or $ch -eq ']' -or $ch -eq ':' -or $ch -eq ',') { $i++; continue }
+    if ($ch -eq '"') {
+      $i++   # opening quote; readStr returns the key, advancing past the close quote
+      $sb = [System.Text.StringBuilder]::new()
+      while ($i -lt $n) {
+        $c = $chars[$i]
+        if ($c -eq '\') { [void]$sb.Append($chars[$i + 1]); $i += 2; continue }
+        if ($c -eq '"') { $i++; break }
+        [void]$sb.Append($c); $i++
+      }
+      $key = $sb.ToString()
+      $j = $i   # peek next non-ws to tell a key from a string value
+      while ($j -lt $n) {
+        $cj = $chars[$j]
+        if ($cj -ne ' ' -and $cj -ne "`t" -and $cj -ne "`r" -and $cj -ne "`n") { break }
+        $j++
+      }
+      if ($j -lt $n -and $chars[$j] -eq ':') {
+        if ($stack.Count -gt 0) {
+          $top = $stack.Peek()
+          if (-not $top.Add($key)) { $dups.Add($key) }   # HashSet.Add: $false = already present
+        }
+      }
+      continue
+    }
+    $i++   # number/true/false/null chars — none are structural
+  }
+  return ,$dups
+}
+
+# CR F6 (#836): reject a duplicate-key config as ambiguous BEFORE the engine-key
+# assertions run (see Find-DuplicateKeys). Runs after all helpers are defined and
+# after the root-object check; short-circuits with exit 1 + a per-dup FAIL line on
+# stderr — same lines + exit as the bash twin (parity).
+$dupKeys = Find-DuplicateKeys -Raw $raw
+if ($dupKeys.Count -gt 0) {
+  foreach ($k in $dupKeys) { [Console]::Error.WriteLine("FAIL: duplicate JSON key `"$k`"") }
+  exit 1
+}
+
 $compLeaf = Get-Leaf $doc 'compression'
 if (-not $compLeaf.present) {
   Add-Fail 'compression object is missing (expected present with every engine disabled)'

--- a/scripts/omniroute-config-lint.sh
+++ b/scripts/omniroute-config-lint.sh
@@ -42,6 +42,60 @@ if (doc === null || typeof doc !== "object" || Array.isArray(doc)) {
   process.exit(2);
 }
 
+// Pre-parse duplicate-key scan (CR F6, #836). JSON.parse collapses duplicate keys
+// to the LAST value SILENTLY (and PS ConvertFrom-Json does the same) — so a config
+// with a duplicate key is ambiguous: the "real" value is engine-defined, not
+// author-defined. For a positive-assertion lint that must PROVABLY catch enabled
+// engines, trusting last-wins is a hole (one day both engines could keep FIRST and
+// pass a config that still contains an enabled=true). Scan the raw text for a key
+// that appears twice within the SAME object and FAIL closed on any, before the
+// (now-ambiguous) engine-key assertions run. Operates on already-validated JSON, so
+// braces/quotes are balanced and string values' internal {/}/:/, can't trip it.
+// SCOPE (CR round 2): the cross-platform parity guarantee covers EXACT-case
+// duplicates (T21/T22). Case-VARIANT sibling keys are an engine divergence pinned
+// by T23: this twin accepts them (distinct keys, exit 0); ConvertFrom-Json rejects
+// them pre-scan (.ps1 exits 2, fail-closed). Keys compare as RAW escaped text —
+// a unicode-escaped key (backslash-u0061) and its literal twin ("a") read as
+// different keys (shared symmetric blind spot, adversarial-only input).
+(function scanDupKeys(raw) {
+  var i = 0, n = raw.length;
+  var stack = [];                         // per-object key-sets; top = innermost object
+  var dups = [];
+  function readStr() {                    // assumes raw[i] == '"'; returns key, advances past close quote
+    i++;                                  // opening quote
+    var s = "";
+    while (i < n) {
+      var c = raw.charAt(i);
+      if (c === "\\") { s += raw.charAt(i + 1); i += 2; continue; }
+      if (c === "\"") { i++; return s; }
+      s += c; i++;
+    }
+    return s;                             // unterminated (valid JSON can't reach here)
+  }
+  while (i < n) {
+    var ch = raw.charAt(i);
+    if (ch === " " || ch === "\t" || ch === "\r" || ch === "\n") { i++; continue; }
+    if (ch === "{") { stack.push(Object.create(null)); i++; continue; }
+    if (ch === "}") { if (stack.length) stack.pop(); i++; continue; }
+    if (ch === "[" || ch === "]" || ch === ":" || ch === ",") { i++; continue; }
+    if (ch === "\"") {
+      var key = readStr();
+      var j = i;                           // peek next non-ws to tell key from string value
+      while (j < n) { var cj = raw.charAt(j); if (cj !== " " && cj !== "\t" && cj !== "\r" && cj !== "\n") break; j++; }
+      if (j < n && raw.charAt(j) === ":") {
+        var top = stack.length ? stack[stack.length - 1] : null;
+        if (top) { if (top[key]) dups.push(key); else top[key] = 1; }
+      }
+      continue;
+    }
+    i++;                                  // number/true/false/null chars — none are structural
+  }
+  if (dups.length) {
+    for (var d = 0; d < dups.length; d++) process.stderr.write("FAIL: duplicate JSON key \"" + dups[d] + "\"\n");
+    process.exit(1);
+  }
+})(raw);
+
 var fails = [];
 var asserted = 0;
 function fail(m) { fails.push("FAIL: " + m); }

--- a/scripts/test-omniroute-config-lint.ps1
+++ b/scripts/test-omniroute-config-lint.ps1
@@ -212,6 +212,54 @@ try {
   $errRaw = if (Test-Path -LiteralPath $RoutErr) { (Get-Content -LiteralPath $RoutErr -Raw) } else { '' }
   if ([string]::IsNullOrWhiteSpace($errRaw)) { Pass 'PASS case stderr empty' } else { Fail 'PASS case wrote to stderr' }
 
+  # --- T21 (CR F6, #836): a DUPLICATE JSON key makes the config ambiguous. Both
+  # engines (PS ConvertFrom-Json, node JSON.parse) silently keep the LAST value, so a
+  # duplicate-key config could lint differently per platform if an engine ever kept
+  # FIRST. The lint now rejects duplicate keys explicitly (pre-parse scan) on BOTH
+  # twins, so the outcome is deterministic and cross-platform identical. This case
+  # injects a duplicate autoRoutingEnabled whose LAST value is `false` (compliant) —
+  # WITHOUT detection the lint would PASS (exit 0), so the exit-1 + dup message here
+  # PROVES detection fired, not coincidental keep-last catching a non-compliant last
+  # value. The .sh twin asserts the IDENTICAL outcome + message (parity). ---
+  $f = Join-Path $TMP 'dupkey.json'
+  $baseRaw = '{"autoRoutingEnabled":false,"compression":{"enabled":false,"defaultMode":"off","autoTriggerMode":"off","rtkConfig":{"enabled":false},"cavemanConfig":{"enabled":false},"cavemanOutputMode":{"enabled":false},"ultra":{"enabled":false},"contextEditing":{"enabled":false},"languageConfig":{"enabled":false},"mcpDescriptionCompressionEnabled":false,"mcpAccessibilityConfig":{"enabled":false},"engines":{},"aggressive":{"summarizerEnabled":false,"toolStrategies":{}},"stackedPipeline":[],"cache":{"semanticCacheEnabled":false,"promptCacheEnabled":false}}}'
+  $dupRaw = $baseRaw -replace [regex]::Escape('{"autoRoutingEnabled":false,'), '{"autoRoutingEnabled":true,"autoRoutingEnabled":false,'
+  $dupRaw | Set-Content -LiteralPath $f -NoNewline
+  Assert-Exit (Invoke-Lint @($f)) 1 'duplicate-key config rejected (exit 1, both twins)'
+  Have 'FAIL: duplicate JSON key "autoRoutingEnabled"'
+
+  # --- T22 (CR F6, #836 — CR round 2): NESTED duplicate key. The engine keys this
+  # lint exists to catch live in nested objects (rtkConfig.enabled etc.), and the
+  # scanner's per-object stack is what distinguishes a real nested dup from the
+  # many legitimate same-name "enabled" keys across DIFFERENT objects (the
+  # compliant PASS case already guards that direction). A dup INSIDE one nested
+  # object must flag — catches any future "flatten/scan-root-only" regression the
+  # top-level T21 case would miss. LAST value compliant (false) for the same
+  # detection-proof reasoning as T21. The .sh twin asserts the IDENTICAL
+  # outcome + message (parity). ---
+  $f2 = Join-Path $TMP 'nesteddupkey.json'
+  $nestedRaw = $baseRaw -replace [regex]::Escape('"rtkConfig":{"enabled":false}'), '"rtkConfig":{"enabled":true,"enabled":false}'
+  if ($nestedRaw -eq $baseRaw) { Fail 'T22 fixture injection did not match BASE' }
+  $nestedRaw | Set-Content -LiteralPath $f2 -NoNewline
+  Assert-Exit (Invoke-Lint @($f2)) 1 'nested duplicate-key config rejected (exit 1, both twins)'
+  Have 'FAIL: duplicate JSON key "enabled"'
+
+  # --- T23 (CR F6, #836 — CR round 2): CASE-VARIANT sibling keys — a DOCUMENTED
+  # ENGINE DIVERGENCE, deliberately pinned per twin (not parity). ConvertFrom-Json
+  # REJECTS keys differing only in case ("keys with different casing") BEFORE the
+  # dup scan runs → this twin exits 2 (invalid JSON, fail-closed — the safe
+  # direction). node's JSON.parse accepts them as two distinct keys → the .sh twin
+  # PASSes exit 0. The exact-dup parity guarantee (T21/T22) is scoped to exact-case
+  # duplicates; this case pins each twin's actual behavior so neither drifts
+  # silently. (The scanner's Ordinal HashSet keeps its own comparison
+  # case-sensitive like node's, should the parse gate ever start admitting
+  # case-variant keys, e.g. -AsHashtable.) ---
+  $f3 = Join-Path $TMP 'casevariantkey.json'
+  $caseRaw = $baseRaw -replace [regex]::Escape('"rtkConfig":{"enabled":false}'), '"rtkConfig":{"enabled":false,"Enabled":false}'
+  if ($caseRaw -eq $baseRaw) { Fail 'T23 fixture injection did not match BASE' }
+  $caseRaw | Set-Content -LiteralPath $f3 -NoNewline
+  Assert-Exit (Invoke-Lint @($f3)) 2 'case-variant sibling keys rejected by ConvertFrom-Json (exit 2; .sh twin exits 0 — documented divergence)'
+
   Write-Host ''
   if ($script:fails -eq 0) { Write-Host 'ALL PASS' } else { Write-Host "$($script:fails) failure(s)" -ForegroundColor Red; exit 1 }
 }

--- a/scripts/test-omniroute-config-lint.sh
+++ b/scripts/test-omniroute-config-lint.sh
@@ -207,4 +207,45 @@ PATH="$NONODE_PATH" "$BASH_ABS" "$LINT" "$WORK/compliant.json" >"$OUT" 2>"$NODE_
 if [ "$nrc" -ne 4 ]; then echo "FAIL: node-missing case wrong exit ($nrc, want 4)"; cat "$NODE_ERR"; FAILS=$((FAILS+1)); else echo "ok: node-missing exits 4"; fi
 { grep -qF "omniroute-config-lint: node is required" "$NODE_ERR" && echo "ok: node-missing message on stderr"; } || { echo "FAIL: node-missing message not on stderr"; cat "$NODE_ERR"; FAILS=$((FAILS+1)); }
 
+# --- T21 (CR F6, #836): a DUPLICATE JSON key makes the config ambiguous. Both
+# engines (node JSON.parse, PS ConvertFrom-Json) silently keep the LAST value, so a
+# duplicate-key config could lint differently per platform if an engine ever kept
+# FIRST. The lint now rejects duplicate keys explicitly (pre-parse scan) on BOTH
+# twins, so the outcome is deterministic and cross-platform identical. This case
+# injects a duplicate autoRoutingEnabled whose LAST value is `false` (compliant) —
+# WITHOUT detection the lint would PASS (exit 0), so the exit-1 + dup message here
+# PROVES detection fired, not coincidental keep-last catching a non-compliant last
+# value. The .ps1 twin asserts the IDENTICAL outcome + message (parity). ---
+DUP_JSON="$WORK/dupkey.json"
+BASE="$BASE_JSON" node -e 'const fs=require("fs"); const d=process.env.BASE.replace("{\"autoRoutingEnabled\":false,", "{\"autoRoutingEnabled\":true,\"autoRoutingEnabled\":false,"); fs.writeFileSync(process.argv[1], d);' "$DUP_JSON"
+t "duplicate-key config rejected (exit 1, both twins)" 1 "$DUP_JSON"
+have 'FAIL: duplicate JSON key "autoRoutingEnabled"'
+
+# --- T22 (CR F6, #836 — CR round 2): NESTED duplicate key. The engine keys this
+# lint exists to catch live in nested objects (rtkConfig.enabled etc.), and the
+# scanner's per-object stack is what distinguishes a real nested dup from the
+# many legitimate same-name "enabled" keys across DIFFERENT objects (which T1's
+# compliant PASS already guards). A dup INSIDE one nested object must flag —
+# this catches any future "flatten/scan-root-only" regression that T21's
+# top-level case would miss. LAST value compliant (false) for the same
+# detection-proof reasoning as T21. The .ps1 twin asserts the IDENTICAL
+# outcome + message (parity). ---
+NESTED_DUP_JSON="$WORK/nesteddupkey.json"
+BASE="$BASE_JSON" node -e 'const fs=require("fs"); const d=process.env.BASE.replace("\"rtkConfig\":{\"enabled\":false}", "\"rtkConfig\":{\"enabled\":true,\"enabled\":false}"); if (d===process.env.BASE) { console.error("T22 fixture injection did not match BASE"); process.exit(1); } fs.writeFileSync(process.argv[1], d);' "$NESTED_DUP_JSON"
+t "nested duplicate-key config rejected (exit 1, both twins)" 1 "$NESTED_DUP_JSON"
+have 'FAIL: duplicate JSON key "enabled"'
+
+# --- T23 (CR F6, #836 — CR round 2): CASE-VARIANT sibling keys — a DOCUMENTED
+# ENGINE DIVERGENCE, deliberately pinned per twin (not parity). JSON keys are
+# case-sensitive: node's JSON.parse accepts {"enabled":…,"Enabled":…} as two
+# distinct keys → the scan (case-sensitive) sees no dup → this twin PASSes exit 0.
+# PowerShell's ConvertFrom-Json REJECTS keys differing only in case ("keys with
+# different casing") BEFORE the scan runs → the .ps1 twin exits 2 (invalid JSON,
+# fail-closed — the safe direction). The exact-dup parity guarantee (T21/T22) is
+# scoped to exact-case duplicates; this case pins each twin's actual behavior so
+# neither drifts silently. ---
+CASE_JSON="$WORK/casevariantkey.json"
+BASE="$BASE_JSON" node -e 'const fs=require("fs"); const d=process.env.BASE.replace("\"rtkConfig\":{\"enabled\":false}", "\"rtkConfig\":{\"enabled\":false,\"Enabled\":false}"); if (d===process.env.BASE) { console.error("T23 fixture injection did not match BASE"); process.exit(1); } fs.writeFileSync(process.argv[1], d);' "$CASE_JSON"
+t "case-variant sibling keys accepted by node, no dup flag (exit 0; .ps1 twin exits 2 — documented divergence)" 0 "$CASE_JSON"
+
 echo; [ "$FAILS" -eq 0 ] && echo "ALL PASS" || { echo "$FAILS failure(s)"; exit 1; }


### PR DESCRIPTION
Propagation of private #863 (squash ce732240), code-only. Pre-parse duplicate-key detection in both omniroute-config-lint twins (ordinal case-sensitive comparer; T21 top-level, T22 nested, T23 pins the documented node-vs-ConvertFrom-Json case-variant engine divergence); Copy-SeedConfig maps any seed throw to exit 4 (bash-twin parity, sentinel-last preserved); claude-routed headers cite the WS2 spec twins; tooling-catalog exit-2 phrasing aligned. All twin suites green + shellcheck clean (windows, gitbash).