### PR TITLE
fix: statusline pricing + where-are-we To-Do digest flood

### DIFF
--- a/scripts/statusline/VENDORED.md
+++ b/scripts/statusline/VENDORED.md
@@ -6,15 +6,18 @@ external repo or hand-editing global `~/.claude/settings.json`.
 
 - **Source fork:** `yotamleo/claude-statusline` (origin)
 - **Upstream:** `nilbuild/claude-statusline` (`Kamran Ahmed`, MIT — see `LICENSE`)
-- **Vendored at commit:** `dd68f9b` (`fix(cache): incremental all-sessions scan + hide stale cache tier`)
+- **Vendored at commit:** `9423572` (`test(cache): assert mythos/glm/gpt-5 write_overhead=0 boundary`)
 - **himmel cache-metrics patch:** `docs/patches/2026-05-16-cache-statusline.md`
 
 > **Local divergence pending re-vendor (HIMMEL-617):** `bin/statusline.sh` here
-> carries the `HIMMEL_STATUSLINE_PERIOD` bottom-row period knob (week/month/all),
-> which is **not yet in the fork**. This vendored copy is the deployed artifact,
-> so the feature ships; but it MUST be mirrored to `yotamleo/claude-statusline`
-> and the "Vendored at commit" SHA above bumped to the resulting fork commit on
-> the next fork push. (The local-hash drift guard is a separate follow-up.)
+> still carries the `HIMMEL_STATUSLINE_PERIOD` bottom-row period knob
+> (week/month/all), which is **not yet in the fork** — the fork push
+> (through `9423572`) mirrored only the `get_model_savings_rate` per-model
+> pricing fix + its test coverage (HIMMEL-679).
+> This vendored copy is the deployed artifact, so both features ship; the period
+> knob MUST still be mirrored to `yotamleo/claude-statusline` and the "Vendored
+> at commit" SHA above bumped on the next fork push. (The local-hash drift guard
+> is a separate follow-up.)
 
 ## What's here
 

--- a/scripts/statusline/bin/statusline.sh
+++ b/scripts/statusline/bin/statusline.sh
@@ -481,10 +481,18 @@ format_tokens() {
 get_model_savings_rate() {
     local model_id="${1:-claude-sonnet}"
     local input_price cache_read_price cache_write_price
+    # Rates per 1M tokens. Cache convention: read = 0.1x input, write = 2x
+    # input (1h TTL; 5m write = 1.25x). Cache rows derived from the standard
+    # prompt-caching multipliers. Case ORDER matters: higher-priced /
+    # more-specific globs must precede glm/gpt/default so they win.
     case "$model_id" in
-        claude-opus*)   input_price=15.00; cache_read_price=1.50;  cache_write_price=30.00 ;;
-        claude-haiku*)  input_price=0.80;  cache_read_price=0.08;  cache_write_price=1.60  ;;
-        claude-sonnet*) input_price=3.00;  cache_read_price=0.30;  cache_write_price=6.00  ;;
+        claude-fable*)  input_price=10.00; cache_read_price=1.00;  cache_write_price=20.00 ;; # 1h; 5m=12.50
+        claude-mythos*) input_price=10.00; cache_read_price=1.00;  cache_write_price=20.00 ;; # 1h; 5m=12.50
+        claude-opus*)   input_price=5.00;  cache_read_price=0.50;  cache_write_price=10.00 ;; # 1h; 5m=6.25
+        claude-haiku*)  input_price=1.00;  cache_read_price=0.10;  cache_write_price=2.00  ;; # 1h; 5m=1.25
+        claude-sonnet*) input_price=3.00;  cache_read_price=0.30;  cache_write_price=6.00  ;; # 1h; 5m=3.75
+        glm-*)          input_price=1.40;  cache_read_price=0.26;  cache_write_price=1.40  ;; # z.ai promo: free cache-write, write_overhead 0
+        gpt-5*)         input_price=5.00;  cache_read_price=0.50;  cache_write_price=5.00  ;; # gpt-5.5 standard tier: no write premium, write_overhead 0
         *)              input_price=3.00;  cache_read_price=0.30;  cache_write_price=6.00  ;;
     esac
     read_savings_rate=$(awk  -v i="$input_price" -v r="$cache_read_price"  'BEGIN{printf "%.8f",(i-r)/1000000}')

--- a/scripts/statusline/test/test_cache.sh
+++ b/scripts/statusline/test/test_cache.sh
@@ -77,12 +77,33 @@ assert_eq "sonnet read_savings_rate"   "$read_savings_rate"   "0.00000270"
 assert_eq "sonnet write_overhead_rate" "$write_overhead_rate" "0.00000300"
 
 get_model_savings_rate "claude-opus-4-7"
-assert_eq "opus read_savings_rate"     "$read_savings_rate"   "0.00001350"
-assert_eq "opus write_overhead_rate"   "$write_overhead_rate" "0.00001500"
+assert_eq "opus read_savings_rate"     "$read_savings_rate"   "0.00000450"
+assert_eq "opus write_overhead_rate"   "$write_overhead_rate" "0.00000500"
 
 get_model_savings_rate "claude-haiku-4-5"
-assert_eq "haiku read_savings_rate"    "$read_savings_rate"   "0.00000072"
-assert_eq "haiku write_overhead_rate"  "$write_overhead_rate" "0.00000080"
+assert_eq "haiku read_savings_rate"    "$read_savings_rate"   "0.00000090"
+assert_eq "haiku write_overhead_rate"  "$write_overhead_rate" "0.00000100"
+
+# Fable red-path: must NOT fall through to the sonnet default (0.00000270).
+# (10 - 1) / 1e6 = 0.00000900 read; (20 - 10) / 1e6 = 0.00001000 write.
+get_model_savings_rate "claude-fable-5"
+assert_eq "fable read_savings_rate"    "$read_savings_rate"   "0.00000900"
+assert_eq "fable write_overhead_rate"  "$write_overhead_rate" "0.00001000"
+
+# Mythos shares fable's rates; assert the branch is not a silent fallthrough.
+get_model_savings_rate "claude-mythos-5"
+assert_eq "mythos read_savings_rate"   "$read_savings_rate"   "0.00000900"
+assert_eq "mythos write_overhead_rate" "$write_overhead_rate" "0.00001000"
+
+# glm-* / gpt-5*: cache_write == input, so write_overhead must be exactly 0
+# (z.ai free-write / no-write-premium boundary). Guard the zero-diff case.
+get_model_savings_rate "glm-4.6"
+assert_eq "glm read_savings_rate"      "$read_savings_rate"   "0.00000114"
+assert_eq "glm write_overhead_rate"    "$write_overhead_rate" "0.00000000"
+
+get_model_savings_rate "gpt-5.5"
+assert_eq "gpt5 read_savings_rate"     "$read_savings_rate"   "0.00000450"
+assert_eq "gpt5 write_overhead_rate"   "$write_overhead_rate" "0.00000000"
 
 get_model_savings_rate "unknown-model"
 assert_eq "fallback read_savings_rate" "$read_savings_rate"   "0.00000270"

--- a/scripts/where-are-we/collect.mjs
+++ b/scripts/where-are-we/collect.mjs
@@ -15,8 +15,9 @@ import { UsageError } from './lib/errors.mjs';
 const TICKET_KEY_RE = /^[A-Z][A-Z0-9]+-\d+$/;
 
 // Explicit page size for the live working set. The jira CLI defaults to
-// --limit 25; In-Progress + To-Do are well under this but the default is a trap
-// (HIMMEL-567), so we pin a high ceiling rather than rely on it.
+// --limit 25; the project-wide In-Progress set is well under this but the
+// default is a trap (HIMMEL-567), so we pin a high ceiling rather than rely on
+// it.
 const JIRA_LIMIT = '200';
 
 // ---------------------------------------------------------------------------
@@ -37,20 +38,27 @@ const _jiraCli = join(_repoRoot, 'scripts', 'jira', 'dist', 'index.js');
 // default of 25 rows — with hundreds of historical Done tickets matching, the
 // page filled before any In-Progress row, so live work never reached the ledger
 // (HIMMEL-567). Instead:
-//   - In-Progress + To-Do are read project-wide with an explicit high --limit
-//     (the HIMMEL working set, always small);
-//   - every ACTIVE key is re-read by key across ALL statuses. This serves two
+//   - In-Progress is read project-wide with an explicit high --limit (the HIMMEL
+//     live working set, always small);
+//   - every ACTIVE key is re-read by key across ALL statuses. This serves three
 //     ends: (a) a HIMMEL ticket still self-clears on its Done transition (fold
 //     treats 'done' as terminal) without re-reading the unbounded Done history;
 //     (b) a cross-project LUNA *harness* ticket (one with a himmel footprint —
 //     open PR / locked worktree) shows its real status even though it never
-//     appears in the HIMMEL-project status lists (HIMMEL-573). LUNA vault/content
-//     tickets carry no footprint, so they never become active keys and never
-//     enter the report.
+//     appears in the HIMMEL-project status lists (HIMMEL-573); (c) a To-Do ticket
+//     surfaces ONLY when it carries a real footprint (an open PR / a locked
+//     worktree / a prior-pass ledger breadcrumb seeds it into activeKeys).
+//     LUNA vault/content tickets carry no footprint, so they never become active
+//     keys and never enter the report.
+//
+// The blanket `--status 'To Do'` read was DROPPED (HIMMEL-679): reading every
+// backlog ticket project-wide folded the entire To-Do backlog (~188 keys) into
+// "Other in-flight" and drowned the real live work. HIMMEL-567's actual goal —
+// not truncating In-Progress — is preserved: that bug was the combined query
+// filling the page with Done rows, not the To-Do read itself.
 export function jiraQueries(activeKeys = []) {
   const queries = [
     ['list', '--status', 'In Progress', '--limit', JIRA_LIMIT],
-    ['list', '--status', 'To Do', '--limit', JIRA_LIMIT],
   ];
   const safeKeys = activeKeys.filter((k) => TICKET_KEY_RE.test(k));
   if (safeKeys.length) {

--- a/scripts/where-are-we/tests/collect.jira-limit.test.mjs
+++ b/scripts/where-are-we/tests/collect.jira-limit.test.mjs
@@ -3,11 +3,16 @@
 // with no --limit. The CLI defaults to --limit 25, and with Done in the filter
 // (hundreds of historical tickets) the 25-row page filled with To-Do rows — live
 // In-Progress tickets never entered the ledger ("In flight: none" while work was
-// in progress). These tests pin the fix: per-status queries with an explicit high
-// limit, plus a Done read scoped to the active in-flight keys (for self-clear).
+// in progress). These tests pin the fix: an In-Progress project-wide read with an
+// explicit high limit, plus an all-status by-key read scoped to the active
+// in-flight keys (for self-clear + footprint-bearing To-Do surfacing).
+//
+// HIMMEL-679: the blanket `--status 'To Do'` read was DROPPED — it folded the
+// whole backlog into "Other in-flight". A To-Do ticket now surfaces only via the
+// by-key read (an open PR / a ledger breadcrumb seeds it into activeKeys).
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { jiraQueries, main } from '../collect.mjs';
@@ -16,11 +21,15 @@ const statusOf = (q) => q[q.indexOf('--status') + 1];
 const isStatusQuery = (q) => q.includes('--status');
 const isKeyQuery = (q) => q.some((a) => typeof a === 'string' && a.startsWith('key in ('));
 
-test('jiraQueries: pulls In Progress and To Do as separate queries (no combined comma filter)', () => {
+test('jiraQueries: reads In Progress project-wide (no combined comma filter)', () => {
   const statuses = jiraQueries([]).filter(isStatusQuery).map(statusOf);
   assert.ok(statuses.includes('In Progress'), 'must query In Progress on its own');
-  assert.ok(statuses.includes('To Do'), 'must query To Do on its own');
   assert.ok(!statuses.some((s) => s.includes(',')), 'must NOT use a combined comma status filter (the truncation source)');
+});
+
+test('jiraQueries: does NOT issue a blanket To-Do status read (HIMMEL-679 flood fix)', () => {
+  const statuses = jiraQueries([]).filter(isStatusQuery).map(statusOf);
+  assert.ok(!statuses.includes('To Do'), 'the whole-backlog To-Do read is dropped; To-Do surfaces only by footprint key');
 });
 
 test('jiraQueries: every status query carries an explicit --limit above the CLI default of 25', () => {
@@ -65,4 +74,28 @@ test('main: derives active in-flight ticket keys from the ledger and scopes the 
   };
   main(['--ledger', ledger, '--now', '2026-02-01T00:00:00Z'], { readers });
   assert.deepEqual(captured, ['HIMMEL-1'], 'only the non-terminal ticket key is passed for the by-key status read');
+});
+
+test('main: a footprint-bearing To-Do ticket surfaces as a to-do record via the by-key read (end-to-end, no blanket To-Do read)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'waw-jira-todo-'));
+  const ledger = join(dir, 'ledger.jsonl');
+  // Prior-pass breadcrumb: HIMMEL-9 was in-progress, so it is a non-terminal
+  // ledger key and activeTicketKeys seeds it into the by-key read.
+  writeFileSync(ledger,
+    JSON.stringify({ ts: '2026-01-01T00:00:00Z', source: 'jira', key: 'HIMMEL-9', kind: 'ticket', status: 'in-progress' }) + '\n');
+
+  const readers = {
+    // The by-key read now reports HIMMEL-9 as To Do (it moved back to the
+    // backlog). Without the blanket To-Do read, the footprint key is the ONLY
+    // path that carries it — assert it still lands in the ledger as to-do.
+    readJira: (activeKeys) =>
+      activeKeys.includes('HIMMEL-9') ? [{ key: 'HIMMEL-9', status: 'To Do' }] : [],
+    readPRs: () => [],
+    readWorktrees: () => '',
+  };
+  main(['--ledger', ledger, '--now', '2026-02-01T00:00:00Z'], { readers });
+
+  const records = readFileSync(ledger, 'utf8').trim().split('\n').map((l) => JSON.parse(l));
+  const latest = records.filter((r) => r.key === 'HIMMEL-9').at(-1);
+  assert.equal(latest.status, 'to-do', 'the footprint To-Do ticket is recorded (normalized) via the by-key read');
 });


### PR DESCRIPTION
Corrects statusline per-model net-savings pricing and drops the blanket To-Do read that flooded the where-are-we digest. Tests included.