### PR TITLE
feat(scripts): keys-only .env <-> 1Password Environment parity checker

### DIFF
--- a/scripts/op-env-parity.mjs
+++ b/scripts/op-env-parity.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+// op-env-parity — compare himmel/.env KEY NAMES against the variable names of a
+// 1Password Environment, and report drift (keys present in one but not the other).
+//
+// KEYS ONLY. This tool never reads, prints, compares, or otherwise handles secret
+// VALUES. From .env it captures only the token left of the first `=`; the
+// Environment side is supplied as a list of variable NAMES.
+//
+// Why the Environment names come from a file/stdin rather than a live read:
+// 1Password Environments are exposed only through the desktop app and the
+// `onepassword` MCP server (a Labs experiment) — the `op` CLI has no
+// environments-variable reader. So a Claude session dumps the Environment's
+// variable names via the MCP `list_variables` tool (names only) into a manifest,
+// and this checker diffs .env against that manifest. Refresh the manifest the
+// same way when it drifts.
+//
+// Usage:
+//   node scripts/op-env-parity.mjs --list-env-keys [--env <path>]
+//       Print the .env key names (one per line, sorted). Names only.
+//
+//   node scripts/op-env-parity.mjs --op-keys <path|-> [--env <path>]
+//       Compare .env keys against the Environment key list (JSON array of
+//       strings, or newline-separated names; `-` reads stdin). Prints a drift
+//       report and exits non-zero if there is any drift.
+//
+// Exit codes: 0 = in sync / list mode, 1 = drift found, 2 = usage/IO error.
+
+import { readFileSync } from 'node:fs';
+
+/** Split a line into whitespace-separated tokens, respecting single/double quotes so a
+ * quoted value with spaces (FOO="a b") stays one token. Used only to locate NAME= starts;
+ * values themselves are never returned to the caller. */
+function tokenizeLine(line) {
+  const tokens = [];
+  let cur = '';
+  let quote = null;
+  let hasContent = false;
+  for (const c of line) {
+    if (quote) {
+      cur += c;
+      if (c === quote) quote = null;
+    } else if (c === '"' || c === "'") {
+      quote = c;
+      cur += c;
+      hasContent = true;
+    } else if (/\s/.test(c)) {
+      if (hasContent) {
+        tokens.push(cur);
+        cur = '';
+        hasContent = false;
+      }
+    } else {
+      cur += c;
+      hasContent = true;
+    }
+  }
+  if (hasContent) tokens.push(cur);
+  return tokens;
+}
+
+/** Extract sorted, de-duplicated env-var KEY names from .env text. Values are never captured.
+ * Multiple assignments on one physical line (e.g. `HIMMEL_WHERE_ARE_WE=1 USER_SLUG=exampleuser`)
+ * are each captured — matching how a shell and 1Password's importer treat them. A bare
+ * leading `export` token has no `=` and is skipped naturally. */
+export function parseEnvKeys(text) {
+  const keys = new Set();
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trimStart();
+    if (line === '' || line.startsWith('#')) continue;
+    for (const token of tokenizeLine(line)) {
+      // A token that starts with `#` begins an inline comment (whitespace-delimited,
+      // outside quotes) — stop, so `FOO=bar # NOTE=x` does not mint a phantom NOTE key.
+      // `#` inside a quoted value (FOO="a # b") or with no leading space (FOO=a#b) stays
+      // part of that single token and is captured as its name.
+      if (token.startsWith('#')) break;
+      // Capture group 1 = the name; everything from `=` onward (the value) is ignored.
+      const m = token.match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+      if (m) keys.add(m[1]);
+    }
+  }
+  return [...keys].sort();
+}
+
+/** Parse an Environment key list: JSON array of strings, or newline-separated names. */
+export function parseOpKeys(text) {
+  const trimmed = text.trim();
+  let names;
+  if (trimmed.startsWith('[')) {
+    const parsed = JSON.parse(trimmed);
+    if (!Array.isArray(parsed)) throw new Error('op-keys JSON must be an array of strings');
+    names = parsed;
+  } else {
+    names = trimmed.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  }
+  const keys = new Set();
+  for (const n of names) {
+    if (typeof n !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(n)) {
+      throw new Error(`invalid variable name in op-keys: ${JSON.stringify(n)}`);
+    }
+    keys.add(n);
+  }
+  return [...keys].sort();
+}
+
+/** Diff two key-name lists. Returns names missing from each side. */
+export function diffKeys(envKeys, opKeys) {
+  const envSet = new Set(envKeys);
+  const opSet = new Set(opKeys);
+  return {
+    missingInOp: envKeys.filter((k) => !opSet.has(k)).sort(), // in .env, absent from Environment
+    missingInEnv: opKeys.filter((k) => !envSet.has(k)).sort(), // in Environment, absent from .env
+  };
+}
+
+/** Build the human-readable drift report. `renamed` is not detected directly — a rename
+ * surfaces as one entry in each list; the report says so. Pure: takes counts + diff. */
+export function formatReport(envKeys, opKeys, diff) {
+  const lines = [];
+  lines.push(`.env keys:         ${envKeys.length}`);
+  lines.push(`Environment keys:  ${opKeys.length}`);
+  const inSync = diff.missingInOp.length === 0 && diff.missingInEnv.length === 0;
+  if (inSync) {
+    lines.push('');
+    lines.push('OK — key sets are identical.');
+    return lines.join('\n');
+  }
+  if (diff.missingInOp.length) {
+    lines.push('');
+    lines.push(`In .env but NOT in Environment (${diff.missingInOp.length}):`);
+    for (const k of diff.missingInOp) lines.push(`  - ${k}`);
+  }
+  if (diff.missingInEnv.length) {
+    lines.push('');
+    lines.push(`In Environment but NOT in .env (${diff.missingInEnv.length}):`);
+    for (const k of diff.missingInEnv) lines.push(`  + ${k}`);
+  }
+  if (diff.missingInOp.length && diff.missingInEnv.length) {
+    lines.push('');
+    lines.push('Note: a renamed key appears as one `-` (old name) and one `+` (new name).');
+  }
+  return lines.join('\n');
+}
+
+function parseArgs(argv) {
+  const opts = { env: '.env', opKeys: null, listEnvKeys: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--env') opts.env = argv[++i];
+    else if (a === '--op-keys') opts.opKeys = argv[++i];
+    else if (a === '--list-env-keys') opts.listEnvKeys = true;
+    else if (a === '-h' || a === '--help') opts.help = true;
+    else throw new Error(`unknown argument: ${a}`);
+  }
+  return opts;
+}
+
+const HELP = `op-env-parity — compare .env key NAMES against a 1Password Environment's variable names (keys only, never values)
+
+  node scripts/op-env-parity.mjs --list-env-keys [--env <path>]
+  node scripts/op-env-parity.mjs --op-keys <path|-> [--env <path>]
+
+Refresh the Environment key list with a Claude session:
+  mcp__onepassword__list_variables → save "variableNames" as a JSON array.`;
+
+function main() {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (e) {
+    process.stderr.write(`${e.message}\n\n${HELP}\n`);
+    process.exit(2);
+  }
+  if (opts.help) {
+    process.stdout.write(`${HELP}\n`);
+    return;
+  }
+
+  let envText;
+  try {
+    envText = readFileSync(opts.env, 'utf8');
+  } catch (e) {
+    process.stderr.write(`cannot read env file ${opts.env}: ${e.message}\n`);
+    process.exit(2);
+  }
+  const envKeys = parseEnvKeys(envText);
+
+  if (opts.listEnvKeys) {
+    process.stdout.write(envKeys.join('\n') + (envKeys.length ? '\n' : ''));
+    return;
+  }
+
+  if (!opts.opKeys) {
+    process.stderr.write(`missing --op-keys (or use --list-env-keys)\n\n${HELP}\n`);
+    process.exit(2);
+  }
+
+  let opText;
+  try {
+    opText = opts.opKeys === '-' ? readFileSync(0, 'utf8') : readFileSync(opts.opKeys, 'utf8');
+  } catch (e) {
+    process.stderr.write(`cannot read op-keys ${opts.opKeys}: ${e.message}\n`);
+    process.exit(2);
+  }
+  let opKeys;
+  try {
+    opKeys = parseOpKeys(opText);
+  } catch (e) {
+    process.stderr.write(`bad op-keys: ${e.message}\n`);
+    process.exit(2);
+  }
+
+  const diff = diffKeys(envKeys, opKeys);
+  process.stdout.write(formatReport(envKeys, opKeys, diff) + '\n');
+  const drift = diff.missingInOp.length > 0 || diff.missingInEnv.length > 0;
+  process.exit(drift ? 1 : 0);
+}
+
+// Run main only when invoked directly (not when imported by the test).
+if (process.argv[1]?.endsWith('op-env-parity.mjs')) {
+  main();
+}

--- a/scripts/op-env-parity.test.mjs
+++ b/scripts/op-env-parity.test.mjs
@@ -1,0 +1,198 @@
+// Tests for op-env-parity. Hermetic: inline fixtures, no real .env, no secrets, no network.
+// Run: node --test scripts/op-env-parity.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseEnvKeys, parseOpKeys, diffKeys, formatReport } from './op-env-parity.mjs';
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'op-env-parity.mjs');
+
+/** Run the CLI in a subprocess. Hermetic: caller supplies temp file paths. */
+function runCli(args, { input } = {}) {
+  const res = spawnSync(process.execPath, [SCRIPT, ...args], { input, encoding: 'utf8' });
+  return { code: res.status, stdout: res.stdout, stderr: res.stderr };
+}
+
+/** Make a throwaway temp dir with named files; returns { dir, path(name) } and auto-cleanup via t.after. */
+function tmpFiles(t, files) {
+  const dir = mkdtempSync(join(tmpdir(), 'op-env-parity-test-'));
+  for (const [name, content] of Object.entries(files)) writeFileSync(join(dir, name), content);
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  return { dir, path: (name) => join(dir, name) };
+}
+
+test('parseEnvKeys: basic one-per-line assignments', () => {
+  const keys = parseEnvKeys('JIRA_EMAIL=a@b.com\nJIRA_API_TOKEN=xyz\n');
+  assert.deepEqual(keys, ['JIRA_API_TOKEN', 'JIRA_EMAIL']); // sorted
+});
+
+test('parseEnvKeys: TWO assignments on one physical line (the reported bug)', () => {
+  // HIMMEL_WHERE_ARE_WE=1 USER_SLUG=exampleuser on a single line must yield BOTH keys.
+  const keys = parseEnvKeys('HIMMEL_WHERE_ARE_WE=1 USER_SLUG=exampleuser\n');
+  assert.deepEqual(keys, ['HIMMEL_WHERE_ARE_WE', 'USER_SLUG']);
+});
+
+test('parseEnvKeys: three assignments on one line', () => {
+  const keys = parseEnvKeys('A=1 B=2 C=3');
+  assert.deepEqual(keys, ['A', 'B', 'C']);
+});
+
+test('parseEnvKeys: skips blank lines and comments', () => {
+  const keys = parseEnvKeys('\n# a comment\n   # indented comment\nFOO=bar\n');
+  assert.deepEqual(keys, ['FOO']);
+});
+
+test('parseEnvKeys: handles a leading export', () => {
+  const keys = parseEnvKeys('export FOO=bar\nexport BAZ=qux QUX=1');
+  assert.deepEqual(keys, ['BAZ', 'FOO', 'QUX']);
+});
+
+test('parseEnvKeys: quoted value with spaces stays one token; trailing assignment still captured', () => {
+  const keys = parseEnvKeys('MSG="hello world" NEXT=2');
+  assert.deepEqual(keys, ['MSG', 'NEXT']);
+});
+
+test('parseEnvKeys: de-duplicates repeated key names', () => {
+  const keys = parseEnvKeys('FOO=1\nFOO=2');
+  assert.deepEqual(keys, ['FOO']);
+});
+
+test('parseEnvKeys: never leaks a value into the output', () => {
+  const keys = parseEnvKeys('SECRET_TOKEN=sk-supersecret-abc123 OTHER=plainvalue');
+  assert.deepEqual(keys, ['OTHER', 'SECRET_TOKEN']);
+  for (const k of keys) {
+    assert.ok(!k.includes('supersecret'), 'value substring leaked into a key');
+    assert.ok(!k.includes('plainvalue'), 'value substring leaked into a key');
+  }
+});
+
+test('parseOpKeys: JSON array form', () => {
+  assert.deepEqual(parseOpKeys('["B","A","A"]'), ['A', 'B']); // sorted + deduped
+});
+
+test('parseOpKeys: newline-separated form', () => {
+  assert.deepEqual(parseOpKeys('B\nA\n\n  C  \n'), ['A', 'B', 'C']);
+});
+
+test('parseOpKeys: rejects an invalid variable name', () => {
+  assert.throws(() => parseOpKeys('["OK","not a name"]'), /invalid variable name/);
+});
+
+test('diffKeys: reports each side of the drift', () => {
+  const diff = diffKeys(['A', 'B', 'PERPLEXITY_API_KEY'], ['A', 'B', 'USER_SLUG']);
+  assert.deepEqual(diff.missingInOp, ['PERPLEXITY_API_KEY']); // in .env, absent from Environment
+  assert.deepEqual(diff.missingInEnv, ['USER_SLUG']); // in Environment, absent from .env
+});
+
+test('diffKeys: identical sets produce no drift', () => {
+  const diff = diffKeys(['A', 'B'], ['B', 'A']);
+  assert.deepEqual(diff.missingInOp, []);
+  assert.deepEqual(diff.missingInEnv, []);
+});
+
+test('formatReport: in-sync message', () => {
+  const env = ['A', 'B'];
+  const op = ['A', 'B'];
+  const report = formatReport(env, op, diffKeys(env, op));
+  assert.match(report, /OK — key sets are identical\./);
+});
+
+test('formatReport: drift lists both sides and the rename note', () => {
+  const env = ['A', 'PERPLEXITY_API_KEY'];
+  const op = ['A', 'USER_SLUG'];
+  const report = formatReport(env, op, diffKeys(env, op));
+  assert.match(report, /NOT in Environment/);
+  assert.match(report, /- PERPLEXITY_API_KEY/);
+  assert.match(report, /NOT in \.env/);
+  assert.match(report, /\+ USER_SLUG/);
+  assert.match(report, /renamed key appears as one/);
+});
+
+test('formatReport: one-sided drift omits the rename note', () => {
+  const env = ['A', 'EXTRA'];
+  const op = ['A'];
+  const report = formatReport(env, op, diffKeys(env, op));
+  assert.match(report, /NOT in Environment/);
+  assert.doesNotMatch(report, /renamed key appears as one/);
+});
+
+// --- inline-comment handling (a `# ...` inline comment must not mint a phantom key) ---
+
+test('parseEnvKeys: inline comment after an assignment is not a key', () => {
+  assert.deepEqual(parseEnvKeys('FOO=bar # NOTE=x'), ['FOO']);
+});
+
+test('parseEnvKeys: a # with no leading space stays part of the value token', () => {
+  assert.deepEqual(parseEnvKeys('FOO=bar#baz'), ['FOO']); // one token, name FOO
+});
+
+test('parseEnvKeys: a # inside a quoted value does not start a comment', () => {
+  assert.deepEqual(parseEnvKeys('MSG="a # b" NEXT=2'), ['MSG', 'NEXT']);
+});
+
+test('parseEnvKeys: an unquoted spaced value word (no =) never becomes a key', () => {
+  assert.deepEqual(parseEnvKeys('TOKEN=abc secretword'), ['TOKEN']);
+});
+
+// --- CLI layer: exit-code contract (0 in-sync/list, 1 drift, 2 usage/IO) and I/O paths ---
+
+test('CLI: identical key sets exit 0', (t) => {
+  const f = tmpFiles(t, { '.env': 'A=1\nB=2\n', 'op.json': '["A","B"]' });
+  const r = runCli(['--env', f.path('.env'), '--op-keys', f.path('op.json')]);
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /identical/);
+});
+
+test('CLI: drift exits 1 and names the missing key', (t) => {
+  const f = tmpFiles(t, { '.env': 'A=1\nB=2\n', 'op.json': '["A"]' });
+  const r = runCli(['--env', f.path('.env'), '--op-keys', f.path('op.json')]);
+  assert.equal(r.code, 1);
+  assert.match(r.stdout, /NOT in Environment/);
+  assert.match(r.stdout, /- B/);
+});
+
+test('CLI: unreadable env file exits 2', (t) => {
+  const f = tmpFiles(t, { 'op.json': '["A"]' });
+  const r = runCli(['--env', f.path('does-not-exist.env'), '--op-keys', f.path('op.json')]);
+  assert.equal(r.code, 2);
+  assert.match(r.stderr, /cannot read env file/);
+});
+
+test('CLI: unknown argument exits 2', (t) => {
+  const f = tmpFiles(t, { '.env': 'A=1\n' });
+  const r = runCli(['--env', f.path('.env'), '--bogus']);
+  assert.equal(r.code, 2);
+  assert.match(r.stderr, /unknown argument/);
+});
+
+test('CLI: missing --op-keys (compare mode) exits 2', (t) => {
+  const f = tmpFiles(t, { '.env': 'A=1\n' });
+  const r = runCli(['--env', f.path('.env')]);
+  assert.equal(r.code, 2);
+  assert.match(r.stderr, /missing --op-keys/);
+});
+
+test('CLI: --list-env-keys prints sorted names and exits 0', (t) => {
+  const f = tmpFiles(t, { '.env': 'B_KEY=2\nA_KEY=1\n' });
+  const r = runCli(['--list-env-keys', '--env', f.path('.env')]);
+  assert.equal(r.code, 0);
+  assert.equal(r.stdout, 'A_KEY\nB_KEY\n');
+});
+
+test('CLI: --op-keys from stdin (-) works and reports drift', (t) => {
+  const f = tmpFiles(t, { '.env': 'A=1\nB=2\n' });
+  const r = runCli(['--env', f.path('.env'), '--op-keys', '-'], { input: '["A"]' });
+  assert.equal(r.code, 1);
+  assert.match(r.stdout, /- B/);
+});
+
+test('CLI: malformed JSON op-keys exits 2', (t) => {
+  const f = tmpFiles(t, { '.env': 'A=1\n', 'op.json': '["A"' }); // unterminated array
+  const r = runCli(['--env', f.path('.env'), '--op-keys', f.path('op.json')]);
+  assert.equal(r.code, 2);
+  assert.match(r.stderr, /bad op-keys/);
+});


### PR DESCRIPTION
Adds a keys-only parity checker (`scripts/op-env-parity.mjs` + tests) that
compares the key **names** in a `.env` file against the variable names of a
1Password Environment and reports drift.

- **Keys only** — never reads, prints, or compares secret values (from `.env`
  it captures only the token left of `=`; the Environment side is a supplied
  name list).
- Parser handles multiple space-separated `KEY=val` assignments on one physical
  line, is quote-aware, and drops inline comments.
- 28 hermetic `node:test` cases — no real `.env`, no secrets, no network.

Run: `node scripts/op-env-parity.mjs --op-keys <names.json>` (exit 1 on drift).
