### PR TITLE
feat(mcp): [HIMMEL-719] tiered lean MCP profiles (strict-mcp-config generator)

### DIFF
--- a/.claude/mcp-profiles/.gitignore
+++ b/.claude/mcp-profiles/.gitignore
@@ -1,0 +1,3 @@
+# Generated per-machine profiles carry real absolute paths + env (incl. secrets).
+# Never commit them — regenerate with: node scripts/mcp/build-mcp-profiles.mjs
+local.*.json

--- a/.claude/mcp-profiles/README.md
+++ b/.claude/mcp-profiles/README.md
@@ -1,0 +1,84 @@
+# MCP fleet lean profiles (HIMMEL-719)
+
+Every Claude Code session spawns the **full** MCP fleet at startup — per-session,
+not shared. Measured baseline: ~6 node procs/session (chrome-devtools + context7 +
+playwright, ×2 each) that multiply across the operator's 8–11 concurrent sessions
+(~69 node / 5.6 GB at peak). Lazy per-server spawn is **not supported** by Claude
+Code today (7+ upstream requests, none shipped). The one **verified** lever:
+
+> `claude --strict-mcp-config --mcp-config <file>` loads **only** the servers named
+> in `<file>` — ignoring `~/.claude.json` and every enabled plugin's MCP server.
+
+These profiles are minimal `--mcp-config` files, one per lane. A coding/armed
+session launches with `minimal` (just tokensave) instead of the whole fleet;
+browser/vault/research work launches with the matching profile. Zero capability
+loss — the servers are still one flag away, per session.
+
+## Generate (per machine)
+
+```powershell
+node scripts/mcp/build-mcp-profiles.mjs          # writes local.<name>.json
+node scripts/mcp/build-mcp-profiles.mjs --list   # show profile → servers
+```
+
+The generator reads your live `~/.claude.json` for the real (absolute-path,
+secret-bearing) server specs and writes `local.<name>.json` here. **Those are
+gitignored** — they carry your `OBSIDIAN_API_KEY` and `C:\Users\…` paths, which
+must never hit git. Only the generator + `profiles.json` manifest + this README
+are committed.
+
+## Launch a lean session
+
+```powershell
+claude --strict-mcp-config --mcp-config .claude/mcp-profiles/local.minimal.json
+```
+
+| Profile | Servers | Use for |
+|---|---|---|
+| `minimal` | tokensave | Default coding / armed / overnight sessions |
+| `research` | tokensave, context7 (remote HTTP) | Library-docs / API work |
+| `browser` | tokensave, playwright, chrome-devtools | Browser automation / web debug |
+| `vault` | tokensave, obsidian-vault | luna / salus vault sessions |
+| `secrets` | tokensave, onepassword | Sessions that need 1Password |
+
+Edit `profiles.json` to add/rebalance a profile, then re-run the generator.
+
+### "Auto-invocation" — lane → profile
+
+Claude Code has no mid-session server bring-up (`claude mcp add` only persists for
+the *next* session). So "auto-invocation" = the launcher picks the profile from the
+task lane: overnight-shift / armed-resume for a browser ticket launches with
+`browser`, a luna ticket with `vault`, everything else with `minimal`. Wiring the
+lane→profile default into the arm/overnight launchers is the Phase-2 follow-up.
+
+## Optional: lean the DEFAULT session too (operator-review-gated)
+
+Profiles make *opt-in* lean launches. To also shrink the fleet a bare `claude`
+(no flags) spawns, trim the always-on config. This changes **every** future
+session, so it is left for you to review + apply — not done automatically:
+
+```powershell
+# 1. Drop rarely-needed always-on stdio servers from ~/.claude.json mcpServers.
+#    Re-add recipe is just the reverse — keep this block to restore:
+#      headroom     -> until HIMMEL-622 adopts it
+#      onepassword  -> now reachable via the `secrets` profile on demand
+# 2. context7: disable the npx plugin, rely on the remote endpoint (research profile):
+#      claude plugin disable context7
+# 3. gh-CLI-first: github MCP is redundant with the gh CLI (block-backend-tier enforces):
+#      claude plugin disable github
+# 4. Browser via the `browser` profile on demand:
+#      claude plugin disable chrome-devtools-mcp playwright
+#    NOTE: disabling chrome-devtools-mcp also disables its skills until a himmel fork.
+```
+
+Each step is reversible (`claude plugin enable <name>` / restore the `~/.claude.json`
+block). Verify after: open a fresh session, confirm the expected tools still resolve
+(directly or via a profile launch) — nothing lost its ability to run, just its
+*automatic* per-session spawn.
+
+## Tier model (fleet-map lives in `docs/tooling-catalog.md`)
+
+T0 always-on (tokensave) · T1 shared HTTP singleton (context7 remote, atlassian,
+huggingface, vercel — 0 local procs) · T2 profile-scoped (browser, vault, secrets)
+· T3 env-gated opt-in (telegram-himmel, luna-correlate — HIMMEL-591, done) · TX
+CLI-first (jira over atlassian, gh over github, firecrawl).

--- a/.claude/mcp-profiles/profiles.json
+++ b/.claude/mcp-profiles/profiles.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "HIMMEL-719 — which servers each --strict-mcp-config profile includes. Keys resolve from ~/.claude.json mcpServers or the generator's PLUGIN_SERVERS map. Edit then re-run: node scripts/mcp/build-mcp-profiles.mjs",
+  "profiles": {
+    "minimal": ["tokensave"],
+    "research": ["tokensave", "context7-remote"],
+    "browser": ["tokensave", "playwright", "chrome-devtools"],
+    "vault": ["tokensave", "obsidian-vault"],
+    "secrets": ["tokensave", "onepassword"]
+  }
+}

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -522,6 +522,35 @@ Specs saved to: `docs/superpowers/specs/YYYY-MM-DD-feature.md`
 
 ---
 
+## MCP fleet — tiered lean profiles (`scripts/mcp/build-mcp-profiles.mjs`, HIMMEL-719)
+
+**What:** Every session spawns the full MCP fleet at startup (per-session, not
+shared) — ~6 node procs/session that multiply across concurrent sessions. Lazy
+per-server spawn is unsupported upstream. The verified lever: `claude
+--strict-mcp-config --mcp-config <file>` loads **only** the servers named in
+`<file>`, ignoring `~/.claude.json` and enabled plugins.
+
+**Generator:** `node scripts/mcp/build-mcp-profiles.mjs` reads the machine's live
+`~/.claude.json` and emits `.claude/mcp-profiles/local.<name>.json` (gitignored —
+they carry absolute paths + secrets). Committed = the generator, the
+`profiles.json` manifest, and `.claude/mcp-profiles/README.md`. `--list` prints the
+profile→server map.
+
+**Fleet-map / tier admission** — every MCP admission names its tier:
+
+| Tier | Meaning | Members |
+|---|---|---|
+| T0 always-on | single pinned binary, used most sessions | tokensave |
+| T1 shared HTTP | remote/daemon singleton, 0–1 local procs total | context7 (remote), atlassian, huggingface, vercel |
+| T2 profile-scoped | in a `--mcp-config` profile, launched per lane | playwright, chrome-devtools, obsidian-vault, onepassword |
+| T3 env-gated | default-OFF `mcp-gate.sh`, activated by launch env var (HIMMEL-591) | telegram-himmel, luna-correlate |
+| TX CLI-first | no server; a CLI + skill (enforced by `block-backend-tier`) | jira (over atlassian), gh (over github), firecrawl |
+
+Launch recipes, lane→profile mapping, and the operator-review-gated default-fleet
+trim: `.claude/mcp-profiles/README.md`.
+
+---
+
 ## jq
 
 **What:** JSON processor. Used in `statusline.sh` for parsing session JSON and transcript JSONL files.

--- a/scripts/mcp/build-mcp-profiles.mjs
+++ b/scripts/mcp/build-mcp-profiles.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// build-mcp-profiles.mjs — HIMMEL-719 MCP fleet tiered management.
+//
+// Emits per-lane MINIMAL `--strict-mcp-config` profiles so a session/subagent
+// launches with only the servers it needs instead of the full per-session fleet
+// (~6 node procs × N sessions). The verified lever: `--strict-mcp-config
+// --mcp-config <file>` loads ONLY the servers named in <file>, ignoring
+// ~/.claude.json and every enabled plugin's MCP server.
+//
+// Committed = this generator + profiles.json manifest + README (all path- and
+// secret-free). Generated = .claude/mcp-profiles/local.<name>.json, which carry
+// the machine's real absolute paths + env (incl. secrets) and are gitignored.
+// This is why the profiles are generated, not committed: it keeps the operator's
+// OBSIDIAN_API_KEY and C:\Users\... paths out of git while staying runnable.
+//
+// Usage:  node scripts/mcp/build-mcp-profiles.mjs [--list]
+// Cross-platform: pure node, no shell — no .ps1 twin needed.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const outDir = path.join(repoRoot, ".claude", "mcp-profiles");
+const manifestPath = path.join(outDir, "profiles.json");
+const claudeJson = path.join(os.homedir(), ".claude.json");
+
+// Portable plugin-server specs (npx-based, no absolute path). Kept here rather
+// than read from plugin caches so the generated browser/research profiles work
+// even after the plugins are disabled (which is the whole point). context7-remote
+// is the HTTP endpoint form — zero local procs, N sessions share one singleton.
+const PLUGIN_SERVERS = {
+  playwright: { type: "stdio", command: "npx", args: ["@playwright/mcp@latest"] },
+  "chrome-devtools": { type: "stdio", command: "npx", args: ["chrome-devtools-mcp@latest"] },
+  "context7-remote": { type: "http", url: "https://mcp.context7.com/mcp" },
+};
+
+function die(msg) {
+  console.error(`build-mcp-profiles: ${msg}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(manifestPath)) die(`manifest not found: ${manifestPath}`);
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+if (process.argv.includes("--list")) {
+  for (const [name, keys] of Object.entries(manifest.profiles)) {
+    console.log(`${name.padEnd(10)} ${keys.join(", ")}`);
+  }
+  process.exit(0);
+}
+
+if (!fs.existsSync(claudeJson)) die(`~/.claude.json not found — cannot resolve machine server specs`);
+const globalServers = (JSON.parse(fs.readFileSync(claudeJson, "utf8")).mcpServers) || {};
+
+fs.mkdirSync(outDir, { recursive: true });
+
+// Fail loudly on any unresolved server: under --strict-mcp-config a silently
+// missing server = that capability just gone, so a typo in profiles.json must
+// not produce a "successful" but broken profile. We still write every complete
+// profile, never an empty one, and exit non-zero if anything was unresolved.
+let written = 0;
+const problems = [];
+for (const [name, keys] of Object.entries(manifest.profiles)) {
+  const mcpServers = {};
+  for (const key of keys) {
+    const spec = globalServers[key] ?? PLUGIN_SERVERS[key];
+    if (!spec) { problems.push(`${name}: unresolved server "${key}"`); continue; }
+    // context7-remote is written under the plain "context7" name so tools resolve normally.
+    mcpServers[key === "context7-remote" ? "context7" : key] = spec;
+  }
+  if (Object.keys(mcpServers).length === 0) {
+    problems.push(`${name}: no servers resolved — profile not written`);
+    continue;
+  }
+  const dest = path.join(outDir, `local.${name}.json`);
+  fs.writeFileSync(dest, JSON.stringify({ mcpServers }, null, 2) + "\n");
+  console.log(`  wrote ${path.relative(repoRoot, dest)} (${Object.keys(mcpServers).length} server(s))`);
+  written++;
+}
+console.log(`build-mcp-profiles: ${written} profile(s) generated in ${path.relative(repoRoot, outDir)}/`);
+console.log(`launch a lean session:  claude --strict-mcp-config --mcp-config .claude/mcp-profiles/local.minimal.json`);
+if (problems.length) {
+  console.error(`build-mcp-profiles: FAILED — unresolved server(s) (fix profiles.json keys or install the server):`);
+  for (const p of problems) console.error(`  - ${p}`);
+  process.exit(1);
+}


### PR DESCRIPTION
Per-lane --strict-mcp-config profiles + cross-platform generator. See .claude/mcp-profiles/README.md.