### PR TITLE
fix(ci-orch): [HIMMEL-714] reporter dead-letter + error classification + workflow-scoped observe

### DIFF
--- a/scripts/ci-orchestrator/src/adapters/private-gha-hosted.ts
+++ b/scripts/ci-orchestrator/src/adapters/private-gha-hosted.ts
@@ -29,12 +29,23 @@ export function makePrivateGhaHostedAdapter(opts: PrivateGhaHostedOptions): Lane
       return { up: code === 0, inFlight: 0, cap };
     },
     async dispatch(job: JobAttrs): Promise<{ runId: string }> {
-      // 1. Observe an existing native run for this head SHA + job, if any.
+      // 1. Observe an existing native run for this head SHA + THIS workflow, if
+      //    any. Scoping to the workflow (HIMMEL-714) matters: a repo with >1
+      //    workflow can have several runs at the same head SHA, and observing the
+      //    wrong one attributes a sibling workflow's conclusion to this job. We
+      //    scope server-side with `--workflow <file>` rather than a jq
+      //    `.workflowName==<job.workflow>` filter because job.workflow is the
+      //    workflow FILE basename (e.g. "ci") while the JSON `workflowName` is the
+      //    display name (e.g. "CI") — they don't match, so a jq name filter would
+      //    drop every run and break the observe path. `--workflow` accepts the
+      //    file name and filters to exactly this adapter's workflow.
       const existing = await opts.exec("gh", [
         "run",
         "list",
         "--repo",
         opts.repo,
+        "--workflow",
+        workflow,
         "--json",
         "databaseId,headSha,workflowName,status",
         "--jq",

--- a/scripts/ci-orchestrator/src/cli.ts
+++ b/scripts/ci-orchestrator/src/cli.ts
@@ -30,6 +30,14 @@ export async function runCli(argv: string[], io: CliIo): Promise<number> {
     }
     case "tick":
     case "daemon":
+      // WIRING NOTE (HIMMEL-714): when the production tick is assembled here, the
+      // reporter (makeReporter, reporter.ts) MUST be constructed ONCE and reused
+      // across passes — its backoff/dead-letter state is in-memory in the reporter
+      // closure, so a per-tick reporter silently resets the counters and defeats
+      // both. For `daemon`, build the reporter OUTSIDE the tickFn passed to
+      // runDaemon. The tick returns TickReport.deadLettered (required verdicts the
+      // reporter gave up on) — surface it (log/alert), don't discard it, or a
+      // wedged required check is invisible.
       io.err(
         `ci-orchestrator ${cmd}: requires production lane + discovery wiring ` +
           `(HIMMEL_CI_* env + registered adapters). See docs/internals/ci-orchestrator.md. ` +

--- a/scripts/ci-orchestrator/src/reporter.ts
+++ b/scripts/ci-orchestrator/src/reporter.ts
@@ -7,31 +7,82 @@
 // a fork verdict can never masquerade as a private required check BY
 // CONSTRUCTION (no verbal contract needed). Compute never waits on GitHub: when
 // the status writer throws the verdict is kept `verdict-known, status-unposted`
-// and re-attempted on the next scheduler pass (OQ3). V1 BOUNDARY: every throw is
-// treated as transient (retry) and there is no attempt cap / backoff / dead-letter
-// yet — a PERMANENT error (bad sha, auth, 4xx) would re-attempt every pass until
-// the job is otherwise resolved. Error classification + bounded backoff + a
-// dead-letter are a tracked follow-up (HIMMEL-502 P3 hardening), not wired here.
+// and re-attempted on a later scheduler pass (OQ3).
+//
+// HIMMEL-714 (P3 hardening) wires the error classification + bounded backoff +
+// dead-letter the P3 V1 boundary deferred:
+//   - classifyGhError: a PERMANENT gh error (4xx — bad sha, auth, not-found) can
+//     never be fixed by retrying, so it dead-letters immediately and is surfaced
+//     rather than re-attempted every pass forever. TRANSIENT (5xx / network /
+//     429 rate-limit / unknown shape) retries with bounded exponential backoff.
+//   - dead-letter after `maxAttempts` transient failures so a poison verdict
+//     cannot wedge the scheduler re-attempting a required check indefinitely.
+// The attempt/backoff/dead-letter state is IN-MEMORY in the reporter closure
+// (never the append-only ledger — the single ledger writer is the VM daemon).
+// INVARIANT: the caller MUST construct the reporter ONCE and reuse the instance
+// across passes (the scheduler injects it as a persistent dep) — a per-pass
+// reporter would reset the counters and defeat backoff + dead-letter.
 import { type JobAttrs, type JobState } from "./ledger.js";
 
 // Injected GitHub status writer. The real caller passes a `gh api ...` shell-out;
-// tests pass a spy. Throwing signals GitHub-unreachable (→ status-unposted).
+// tests pass a spy. Throwing signals a failed post; the thrown error MAY carry a
+// numeric `status`/`httpStatus` (HTTP status) or an explicit `permanent` boolean
+// so the reporter can tell a retryable outage from a permanent 4xx.
 export type GhStatusFn = (args: {
   sha: string;
   conclusion: string;
   context: string;
 }) => Promise<void>;
 
-export type PostResult = { posted: boolean };
+export type PostResult = { posted: boolean; deadLettered?: boolean };
 
 export type Reporter = {
   // Post ONE verdict to job.headSha. Returns {posted:false} (never throws) when
-  // GitHub is unreachable so the scheduler can keep the verdict and retry.
+  // the post fails and is still retryable; {posted:false, deadLettered:true} when
+  // the job is dead-lettered (permanent error or attempt cap reached).
   postVerdict(job: JobAttrs, conclusion: string, gh: GhStatusFn): Promise<PostResult>;
-  // Drain the backlog: post every verdict-known, required, still-unposted job.
-  // Returns the jobIds successfully posted this pass.
-  retryUnposted(state: Map<string, JobState>, gh: GhStatusFn): Promise<{ posted: string[] }>;
+  // Drain the backlog: post every verdict-known, required, still-unposted job
+  // that is neither dead-lettered nor in backoff. Returns the jobIds posted this
+  // pass and the jobIds that are dead-lettered (surfaced so a wedged required
+  // check is visible instead of silently retried forever).
+  retryUnposted(state: Map<string, JobState>, gh: GhStatusFn): Promise<{ posted: string[]; deadLettered: string[] }>;
 };
+
+export type ReporterOptions = {
+  now?: () => number; // injected clock (epoch ms); default Date.now
+  maxAttempts?: number; // dead-letter after this many transient failures; default 5
+  baseBackoffMs?: number; // first-retry backoff; default 1000
+  maxBackoffMs?: number; // backoff ceiling; default 5 min
+};
+
+export type ErrorClass = "transient" | "permanent";
+
+function extractStatus(err: unknown): number | undefined {
+  if (err && typeof err === "object") {
+    const o = err as Record<string, unknown>;
+    if (typeof o.status === "number") return o.status;
+    if (typeof o.httpStatus === "number") return o.httpStatus;
+  }
+  return undefined;
+}
+
+// Classify a failed-post error. PERMANENT = a 4xx the retry can never fix (bad
+// sha 404/422, auth 401/403) — dead-letter + surface, don't wedge the pass.
+// TRANSIENT = 5xx / network / 429 rate-limit / unknown shape — retry with
+// backoff. Unknown shape defaults to TRANSIENT (fail-open to the prior behaviour:
+// keep the verdict and retry rather than silently drop it).
+export function classifyGhError(err: unknown): ErrorClass {
+  if (err && typeof err === "object") {
+    const p = (err as Record<string, unknown>).permanent;
+    if (p === true) return "permanent";
+    if (p === false) return "transient";
+  }
+  const status = extractStatus(err);
+  if (status === undefined) return "transient";
+  if (status === 429) return "transient"; // rate-limited — back off, then retry
+  if (status >= 400 && status < 500) return "permanent";
+  return "transient"; // 5xx and anything else
+}
 
 // The Checks context string for a job — stable per (workflow, job, os) so the
 // posted status maps 1:1 to a required-check name.
@@ -39,26 +90,62 @@ export function checkContext(job: JobAttrs): string {
   return `ci-orch/${job.workflow}:${job.job} (${job.os})`;
 }
 
-export function makeReporter(): Reporter {
+type AttemptRec = { attempts: number; nextRetryAt: number; deadLettered: boolean };
+
+export function makeReporter(opts: ReporterOptions = {}): Reporter {
+  const now = opts.now ?? Date.now;
+  const maxAttempts = opts.maxAttempts ?? 5;
+  const baseBackoffMs = opts.baseBackoffMs ?? 1000;
+  const maxBackoffMs = opts.maxBackoffMs ?? 5 * 60_000;
+  // In-memory per-job attempt state. Persists for the reporter's lifetime (the
+  // scheduler reuses one instance across passes — see INVARIANT above).
+  const attempts = new Map<string, AttemptRec>();
+
+  function backoffMs(attempt: number): number {
+    return Math.min(baseBackoffMs * 2 ** (attempt - 1), maxBackoffMs);
+  }
+
   async function postVerdict(job: JobAttrs, conclusion: string, gh: GhStatusFn): Promise<PostResult> {
+    const rec = attempts.get(job.id);
+    if (rec?.deadLettered) return { posted: false, deadLettered: true };
+    if (rec && rec.nextRetryAt > now()) return { posted: false }; // still in backoff — don't hit gh
     try {
       await gh({ sha: job.headSha, conclusion, context: checkContext(job) });
+      attempts.delete(job.id); // recovered — clear the failure history
       return { posted: true };
-    } catch {
-      // GitHub unreachable — keep the verdict, retry later (OQ3). Never throw.
+    } catch (err) {
+      const cur = rec ?? { attempts: 0, nextRetryAt: 0, deadLettered: false };
+      if (classifyGhError(err) === "permanent") {
+        cur.deadLettered = true;
+        attempts.set(job.id, cur);
+        return { posted: false, deadLettered: true };
+      }
+      cur.attempts += 1;
+      if (cur.attempts >= maxAttempts) {
+        cur.deadLettered = true;
+        attempts.set(job.id, cur);
+        return { posted: false, deadLettered: true };
+      }
+      cur.nextRetryAt = now() + backoffMs(cur.attempts);
+      attempts.set(job.id, cur);
       return { posted: false };
     }
   }
 
-  async function retryUnposted(state: Map<string, JobState>, gh: GhStatusFn): Promise<{ posted: string[] }> {
+  async function retryUnposted(
+    state: Map<string, JobState>,
+    gh: GhStatusFn,
+  ): Promise<{ posted: string[]; deadLettered: string[] }> {
     const posted: string[] = [];
+    const deadLettered: string[] = [];
     for (const js of state.values()) {
       if (js.status !== "verdict-known") continue;
       if (!js.attrs.required || js.statusPosted) continue;
       const res = await postVerdict(js.attrs, js.conclusion ?? "failure", gh);
       if (res.posted) posted.push(js.attrs.id);
+      else if (res.deadLettered) deadLettered.push(js.attrs.id);
     }
-    return { posted };
+    return { posted, deadLettered };
   }
 
   return { postVerdict, retryUnposted };

--- a/scripts/ci-orchestrator/src/scheduler.ts
+++ b/scripts/ci-orchestrator/src/scheduler.ts
@@ -43,6 +43,7 @@ export type TickReport = {
   deferred: string[];
   verdicts: { jobId: string; conclusion: string }[];
   posted: string[];
+  deadLettered: string[]; // required verdicts the reporter gave up on (permanent error / attempt cap) — surfaced, not silently retried forever (HIMMEL-714)
 };
 
 export type SchedulerDeps = {
@@ -88,7 +89,7 @@ export async function tick(deps: SchedulerDeps): Promise<TickReport> {
   const daemon = deps.daemonId ?? "vm";
   const ttl = deps.leaseTtlMs ?? 15 * 60_000;
   const byName = new Map<LaneName, LaneAdapter>(deps.adapters.map((a) => [a.name, a]));
-  const report: TickReport = { submitted: [], reused: [], dispatched: [], deferred: [], verdicts: [], posted: [] };
+  const report: TickReport = { submitted: [], reused: [], dispatched: [], deferred: [], verdicts: [], posted: [], deadLettered: [] };
 
   // 1. Discover + plan submission (doc-only skip + dedup). Only genuinely new
   //    jobs are submitted (a job already in the ledger is not re-submitted).
@@ -184,7 +185,11 @@ export async function tick(deps: SchedulerDeps): Promise<TickReport> {
   }
 
   // 6. Drain any still-unposted backlog (prior ticks where GitHub was down).
-  await deps.reporter.retryUnposted(readState(env, path), deps.gh);
+  //    Dead-lettered required verdicts (permanent error / attempt cap) are
+  //    surfaced in the report so a wedged required check is visible rather than
+  //    retried forever (HIMMEL-714).
+  const drain = await deps.reporter.retryUnposted(readState(env, path), deps.gh);
+  report.deadLettered = drain.deadLettered;
 
   return report;
 }

--- a/scripts/ci-orchestrator/tests/adapters-private-gha.test.ts
+++ b/scripts/ci-orchestrator/tests/adapters-private-gha.test.ts
@@ -57,6 +57,25 @@ describe("private-gha-hosted (dispatched, sparing)", () => {
     expect(r.runId).toBe("555");
   });
 
+  test("scopes the observe-run query to the job's workflow file (no sibling mis-attribution, HIMMEL-714)", async () => {
+    const listCalls: string[][] = [];
+    const exec: ExecFn = async (_file, args) => {
+      if (args.includes("list")) {
+        listCalls.push(args);
+        return { stdout: "777\n", stderr: "", code: 0 };
+      }
+      throw new Error("workflow_dispatch must not be called when a run is observed");
+    };
+    const a = makePrivateGhaHostedAdapter({ exec, repo: "o/r", workflowFile: "ci.yml" });
+    const r = await a.dispatch(job());
+    expect(r.runId).toBe("777");
+    // the run-list query is scoped server-side to the workflow FILE, not just the SHA
+    const args = listCalls[0];
+    const wIdx = args.indexOf("--workflow");
+    expect(wIdx).toBeGreaterThanOrEqual(0);
+    expect(args[wIdx + 1]).toBe("ci.yml");
+  });
+
   test("no native run → issues a workflow_dispatch (win/mac pre-merge path)", async () => {
     const calls: string[][] = [];
     const exec: ExecFn = async (_file, args) => {

--- a/scripts/ci-orchestrator/tests/reporter.test.ts
+++ b/scripts/ci-orchestrator/tests/reporter.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi } from "vitest";
-import { makeReporter, checkContext, type GhStatusFn } from "../src/reporter.js";
+import { makeReporter, checkContext, classifyGhError, type GhStatusFn } from "../src/reporter.js";
 import { reduce, type CiEvent, type JobAttrs } from "../src/ledger.js";
 
 const T0 = "2026-07-05T00:00:00Z";
@@ -62,5 +62,114 @@ describe("reporter.retryUnposted", () => {
     const out = await makeReporter().retryUnposted(state, gh);
     expect(out.posted).toEqual([]);
     expect(gh).not.toHaveBeenCalled();
+  });
+});
+
+// HIMMEL-714 — error classification + bounded backoff + dead-letter.
+describe("classifyGhError", () => {
+  test("4xx (except 429) is permanent; 5xx / 429 / unknown-shape is transient", () => {
+    expect(classifyGhError(Object.assign(new Error(), { status: 404 }))).toBe("permanent");
+    expect(classifyGhError(Object.assign(new Error(), { status: 403 }))).toBe("permanent");
+    expect(classifyGhError(Object.assign(new Error(), { httpStatus: 422 }))).toBe("permanent");
+    expect(classifyGhError(Object.assign(new Error(), { status: 429 }))).toBe("transient"); // rate-limit retries
+    expect(classifyGhError(Object.assign(new Error(), { status: 503 }))).toBe("transient");
+    expect(classifyGhError(new Error("network down, no status"))).toBe("transient");
+    expect(classifyGhError(Object.assign(new Error(), { permanent: true }))).toBe("permanent");
+    expect(classifyGhError(Object.assign(new Error(), { status: 404, permanent: false }))).toBe("transient");
+  });
+});
+
+describe("reporter dead-letter + backoff (HIMMEL-714)", () => {
+  test("a permanent (4xx) error dead-letters immediately and never retries gh", async () => {
+    const gh = vi.fn<GhStatusFn>(async () => {
+      throw Object.assign(new Error("not found"), { status: 404 });
+    });
+    const r = makeReporter({ now: () => 0 });
+    const res = await r.postVerdict(job(), "failure", gh);
+    expect(res.posted).toBe(false);
+    expect(res.deadLettered).toBe(true);
+    expect(gh).toHaveBeenCalledTimes(1);
+    // dead-lettered → subsequent calls short-circuit without hitting gh
+    await r.postVerdict(job(), "failure", gh);
+    expect(gh).toHaveBeenCalledTimes(1);
+  });
+
+  test("transient failures dead-letter after maxAttempts, then stop hitting gh", async () => {
+    const gh = vi.fn<GhStatusFn>(async () => {
+      throw new Error("network down"); // no status → transient
+    });
+    const r = makeReporter({ now: () => 0, baseBackoffMs: 0, maxAttempts: 3 });
+    const j = job();
+    expect((await r.postVerdict(j, "failure", gh)).deadLettered).toBeUndefined(); // attempt 1
+    expect((await r.postVerdict(j, "failure", gh)).deadLettered).toBeUndefined(); // attempt 2
+    expect((await r.postVerdict(j, "failure", gh)).deadLettered).toBe(true); // attempt 3 → cap
+    expect(gh).toHaveBeenCalledTimes(3);
+    await r.postVerdict(j, "failure", gh); // dead-lettered — no further gh
+    expect(gh).toHaveBeenCalledTimes(3);
+  });
+
+  test("bounded backoff: an in-window retry does not hit gh; retries again once backoff elapses", async () => {
+    let t = 1000;
+    const failing = vi.fn<GhStatusFn>(async () => {
+      throw new Error("outage");
+    });
+    const r = makeReporter({ now: () => t, baseBackoffMs: 1000, maxAttempts: 10 });
+    const j = job();
+    expect((await r.postVerdict(j, "success", failing)).posted).toBe(false); // attempt 1 → nextRetryAt = 2000
+    expect(failing).toHaveBeenCalledTimes(1);
+    await r.postVerdict(j, "success", failing); // still t=1000 < 2000 → in backoff, no gh
+    expect(failing).toHaveBeenCalledTimes(1);
+    t = 2000; // backoff elapsed
+    const recovered = vi.fn<GhStatusFn>(async () => {});
+    expect((await r.postVerdict(j, "success", recovered)).posted).toBe(true);
+    expect(recovered).toHaveBeenCalledTimes(1);
+  });
+
+  test("a successful post clears prior failure state (fresh attempt budget after recovery)", async () => {
+    let fail = true;
+    const gh = vi.fn<GhStatusFn>(async () => {
+      if (fail) throw new Error("down");
+    });
+    const r = makeReporter({ now: () => 0, baseBackoffMs: 0, maxAttempts: 2 });
+    const j = job();
+    await r.postVerdict(j, "failure", gh); // attempt 1 (attempts=1)
+    fail = false;
+    expect((await r.postVerdict(j, "failure", gh)).posted).toBe(true); // recovers → clears
+    fail = true;
+    const res = await r.postVerdict(j, "failure", gh); // fresh attempt 1, NOT immediately dead-lettered
+    expect(res.deadLettered).toBeUndefined();
+  });
+
+  test("per-job attempt state is isolated — one job dead-lettering does not affect another", async () => {
+    // The in-memory attempt map is keyed by job.id; a poison verdict on job A must
+    // not consume job B's attempt budget or dead-letter it.
+    const poison = job({ id: "poison", job: "scan-a" });
+    const healthy = job({ id: "healthy", job: "scan-b" });
+    const gh = vi.fn<GhStatusFn>(async (arg) => {
+      if (arg.context === checkContext(poison)) {
+        throw Object.assign(new Error("bad sha"), { status: 422 }); // A: permanent
+      }
+      // B (scan-b): succeeds
+    });
+    const r = makeReporter({ now: () => 0 });
+    const a = await r.postVerdict(poison, "failure", gh);
+    const b = await r.postVerdict(healthy, "success", gh);
+    expect(a.deadLettered).toBe(true);
+    expect(b.posted).toBe(true);
+    expect(b.deadLettered).toBeUndefined();
+  });
+
+  test("retryUnposted surfaces dead-lettered jobs (poison verdict is visible, not silently retried)", async () => {
+    const J = job({ id: "poison" });
+    const state = reduce([
+      { t: "submit", ts: T0, job: J },
+      { t: "verdict", ts: T0, jobId: J.id, conclusion: "failure" },
+    ]);
+    const gh: GhStatusFn = async () => {
+      throw Object.assign(new Error("bad sha"), { status: 422 });
+    };
+    const out = await makeReporter({ now: () => 0 }).retryUnposted(state, gh);
+    expect(out.posted).toEqual([]);
+    expect(out.deadLettered).toEqual(["poison"]);
   });
 });

--- a/scripts/ci-orchestrator/tests/scheduler.test.ts
+++ b/scripts/ci-orchestrator/tests/scheduler.test.ts
@@ -51,7 +51,7 @@ function spyReporter(): Reporter & {
 } {
   return {
     postVerdict: vi.fn(async () => ({ posted: true })),
-    retryUnposted: vi.fn(async () => ({ posted: [] })),
+    retryUnposted: vi.fn(async () => ({ posted: [], deadLettered: [] })),
   };
 }
 


### PR DESCRIPTION
## HIMMEL-714 — P3 hardening of the ci-orchestrator required-check reporter

Wires the error-classification + bounded-backoff + dead-letter that the P3 V1 boundary deferred. Two correctness fixes, kept surgical.

### `reporter.ts` — `classifyGhError` + in-memory backoff/dead-letter state machine
- A **PERMANENT** gh error (4xx — bad sha 404/422, auth 401/403) dead-letters immediately and is surfaced, rather than re-attempted every scheduler pass forever (a poison verdict could otherwise wedge a required check).
- **TRANSIENT** (5xx / network / 429 rate-limit / unknown shape) retries with bounded exponential backoff (`base·2^(n-1)`, capped), dead-lettering after `maxAttempts`.
- Unknown error shape **fails open to transient** (preserves the prior keep-and-retry behaviour rather than silently dropping a verdict).
- Attempt/backoff/dead-letter state is **in-memory in the reporter closure** (never the append-only ledger). **INVARIANT:** the reporter must be constructed once and reused across passes; a per-pass reporter resets the counters and defeats backoff + dead-letter.
- Scheduler surfaces dead-letters via new `TickReport.deadLettered`.

### `adapters/private-gha-hosted.ts` — workflow-scoped observe lookup
The observe-run lookup is scoped to the job's workflow via `gh run list --workflow <file>` so a sibling workflow's run at the same head SHA isn't mis-attributed. Scoped server-side with `--workflow` (which takes the workflow *file* name) rather than a jq `.workflowName==` filter, because `job.workflow` is the file basename (`"ci"`) while the JSON `workflowName` is the display name (`"CI"`) — a name-equality filter would match nothing.

### Tests
Full ci-orchestrator suite green. New coverage: classification (permanent vs transient + explicit override), immediate dead-letter, cap dead-letter, bounded backoff (in-window skip + post-elapse retry), recovery-clears-state, `retryUnposted` dead-letter surfacing, per-job state isolation, and adapter workflow-scoping.

### Follow-ups (production-wiring, out of this P3 logic-hardening scope)
- Consume `TickReport.deadLettered` in the daemon loop (log/alert).
- A `gh` wrapper that parses HTTP status onto the thrown error so a permanent 4xx dead-letters immediately (rather than after the transient cap).
- A durable dead-letter ledger event so the state survives a daemon restart.
