### PR TITLE
fix(cr): exhaustion-signature precision - bare AccessDenied never triggers critic fallback

### DIFF
--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -281,6 +281,10 @@ Steps:
        # Critical/Important panel findings → "<finding-id>\t<severity>\t<symptom>" (one per line, REAL tabs).
        # (write each [<slug>-N] Critical/Important finding from the step-3 aggregate here)
        # panel-availability lines → "<slug>\tok|unavailable" (strip any trailing " (rc=N)").
+       # Same normalization as step 4.5 (HIMMEL-729): fallback(<model>) → ok (the
+       # critic responded via its fallback — a vanished finding may resolve);
+       # a fallback-failed line accompanies an unavailable line for the same
+       # slug — write only the unavailable.
        # (write each $panel_avail_lines entry here)
        bash scripts/handover/append-cr-bugs.sh --bugs "$item_dir/bugs.md" --findings "$cr_find" --avail "$cr_avail"
        rm -f "$cr_find" "$cr_avail"

--- a/scripts/cr/critic-panel.sh
+++ b/scripts/cr/critic-panel.sh
@@ -198,7 +198,15 @@ agg_sug=""
 # timeout is never mistaken for exhaustion.
 # ---------------------------------------------------------------------------
 _is_quota_exhaustion() {
-    _qe_sig='exceeded.*quota|quota.*exhaust|AccessDenied|Arrearage|Throttling\.User|allocated quota'
+    # Bare AccessDenied is NOT exhaustion (codex adversarial CR on HIMMEL-729):
+    # e.g. Alibaba's AccessDenied.Unpurchased means "service not activated" and
+    # a plain AccessDenied is an auth/permission failure — falling back on those
+    # would mask a dead primary lane as a healthy critic. AccessDenied counts
+    # only when PAIRED with an exhaustion/quota/arrearage phrase.
+    # NOTE: plain .* is correct here — grep matches line-by-line, so .* can
+    # never cross a newline; [^\n] in POSIX ERE would wrongly mean "any char
+    # except backslash or the letter n" (codex CR round 2).
+    _qe_sig='exceeded.*quota|quota.*exhaust|Arrearage|Throttling\.User|allocated quota|AccessDenied.*(quota|exhaust|arrear)|(quota|exhaust|arrear).*AccessDenied'
     if [ -n "$1" ] && [ -f "$1" ] && grep -qiE "$_qe_sig" "$1"; then
         return 0
     fi

--- a/scripts/cr/test-critic-panel-fallback.sh
+++ b/scripts/cr/test-critic-panel-fallback.sh
@@ -98,6 +98,12 @@ if [ "\$model" = "$PRI" ]; then
         generic)
             printf 'connection refused\\n' >&2
             exit 1 ;;
+        accessdenied)
+            printf 'AccessDenied.Unpurchased: the Model Studio service has not been activated\\n' >&2
+            exit 1 ;;
+        accessdenied-paired)
+            printf 'AccessDenied due to quota limits reached for this model\\n' >&2
+            exit 1 ;;
         timeout)
             exit 124 ;;
     esac
@@ -197,6 +203,35 @@ check_contains "4: no-fallback row -> plain unavailable on exhaustion" "$stderr4
 check_not_contains "4: NO WARN line" "$stderr4" "WARN critic-panel"
 check "4: fallback model NEVER invoked when row has no fallback_model" \
     "$(grep -cF -- "$FB" "$tmp/cap4")" "0"
+
+# ===========================================================================
+# Case 5: GENERIC AccessDenied (auth/permission, e.g. Alibaba
+# AccessDenied.Unpurchased = service not activated) -> NO fallback (codex
+# adversarial CR on HIMMEL-729): falling back would mask a dead primary lane
+# as a healthy critic. AccessDenied counts only when PAIRED with an
+# exhaustion/quota/arrearage phrase.
+# ===========================================================================
+run_case accessdenied "$JSON" "$tmp/out5" "$tmp/err5" "$tmp/cap5"
+stderr5="$(cat "$tmp/err5")"
+check_contains "5: generic AccessDenied -> plain unavailable" "$stderr5" \
+    "panel-availability: qwen3coder unavailable (rc=1)"
+check_not_contains "5: NO WARN line" "$stderr5" "WARN critic-panel"
+check_not_contains "5: NO fallback token" "$stderr5" "fallback("
+check "5: fallback model NEVER invoked on bare AccessDenied" \
+    "$(grep -cF -- "$FB" "$tmp/cap5")" "0"
+
+# ===========================================================================
+# Case 6: AccessDenied PAIRED with a quota phrase -> fallback DOES fire
+# (positive coverage for the paired-AccessDenied signature branches; the
+# message matches only the AccessDenied.*(quota|...) pair, none of the
+# standalone phrases).
+# ===========================================================================
+run_case accessdenied-paired "$JSON" "$tmp/out6" "$tmp/err6" "$tmp/cap6"
+stderr6="$(cat "$tmp/err6")"
+check_contains "6: paired AccessDenied+quota -> WARN + fallback" "$stderr6" \
+    "WARN critic-panel: qwen3coder quota-exhausted - fell back to $FB (openrouter)"
+check "6: fallback invoked exactly once on paired AccessDenied" \
+    "$(grep -cF -- "$FB" "$tmp/cap6")" "1"
 
 if [ "$fails" -eq 0 ]; then
     echo "ALL PASS"


### PR DESCRIPTION
Generic AccessDenied (auth/permission) no longer masquerades as quota exhaustion in the critic fallback path; AccessDenied requires a paired quota/exhaust/arrearage phrase (line-safe ERE). pr-check cr_avail prose normalizes fallback() -> ok in step 4.7 like 4.5. Regression cases 5+6.