### PR TITLE
feat(quota-gauge): alibaba free-tier grants + live probe touchpoint (qwen piggyback)

### DIFF
--- a/scripts/hermes/invoke.sh
+++ b/scripts/hermes/invoke.sh
@@ -188,10 +188,31 @@ main()
 '
 }
 
+# HIMMEL-729 wiring chunk B — best-effort Alibaba quota-gauge probe piggybacked
+# on a qwen* dispatch. Fire-and-forget: backgrounded, all output to /dev/null,
+# NEVER blocks or fails the dispatch (it cannot reach the dispatch rc). The
+# runner self-throttles (60s freshness marker) and skips silently when the
+# Alibaba env vars are unset. Invoke-only — no always-on surface. The shell edit
+# stays minimal; the logic lives in the TS runner (scripts/telegram/alibaba-probe-once.ts).
+alibaba_quota_piggyback() {
+    [ -n "$model" ] || return 0
+    case "$model" in
+        [Qq][Ww][Ee][Nn]*) : ;;  # qwen* (qwen-plus, qwen3-coder-plus, …) — case-insensitive
+        *) return 0 ;;
+    esac
+    command -v bun >/dev/null 2>&1 || return 0
+    local runner="$SCRIPT_DIR/../telegram/alibaba-probe-once.ts"
+    [ -f "$runner" ] || return 0
+    ( bun "$runner" >/dev/null 2>&1 || true ) &   # detached; never affects the dispatch
+    disown 2>/dev/null || true
+}
+
 if [ -n "$log" ]; then
     run_hermes 2>&1 | tee "$log"
-    exit "${PIPESTATUS[0]}"
+    rc="${PIPESTATUS[0]}"
 else
     run_hermes
-    exit $?
+    rc=$?
 fi
+alibaba_quota_piggyback   # best-effort, fire-and-forget, never touches rc
+exit "$rc"

--- a/scripts/telegram/alibaba-probe-once.test.ts
+++ b/scripts/telegram/alibaba-probe-once.test.ts
@@ -1,0 +1,219 @@
+// scripts/telegram/alibaba-probe-once.test.ts
+// HIMMEL-729 wiring chunk B — runner tests. Hermetic: NO live HTTP, NO real fs.
+// runProbe's fetch / append / marker / log are all injected spies. Credentials
+// in these tests are FAKE ("test-ak"/"test-sk") — never real secret material.
+import { expect, test } from "bun:test";
+import {
+  MIN_PROBE_GAP_S, markerPath, shouldProbe, basicAuthHeader, buildPromQueryUrl,
+  runProbe, parseDotenv,
+} from "./alibaba-probe-once";
+import type { FetchResult, ProbeOutcome } from "./alibaba-probe-once";
+import type { QuotaGaugeRecord } from "./quota-gauge";
+import { writeFileSync, unlinkSync } from "node:fs";
+
+const NOW_MS = Date.parse("2026-07-04T12:00:00Z");
+
+// Realistic Prometheus model_usage instant-query: qwen3-coder-plus total_tokens
+// across two apikey_id series (sums to 600000) + qwen-plus (250000).
+const REAL_PROM = JSON.stringify({
+  status: "success",
+  data: {
+    result: [
+      { metric: { model: "qwen3-coder-plus", usage_type: "total_tokens", apikey_id: "k1" }, value: [1782800000, "500000"] },
+      { metric: { model: "qwen3-coder-plus", usage_type: "input_tokens", apikey_id: "k1" }, value: [1782800000, "300000"] },
+      { metric: { model: "qwen3-coder-plus", usage_type: "total_tokens", apikey_id: "k2" }, value: [1782800000, "100000"] },
+      { metric: { model: "qwen-plus", usage_type: "total_tokens", apikey_id: "k1" }, value: [1782800000, "250000"] },
+    ],
+  },
+});
+
+// Full env with the 3 Alibaba vars (FAKE creds). Tests spread overrides over it.
+const BASE_ENV: Record<string, string | undefined> = {
+  ALIBABA_QUOTA_PROM_URL: "https://prom.example/api/v1/query",
+  ALIBABA_QUOTA_AK: "test-ak",
+  ALIBABA_QUOTA_SK: "test-sk",
+};
+
+test("MIN_PROBE_GAP_S is 60", () => {
+  expect(MIN_PROBE_GAP_S).toBe(60);
+});
+
+test("markerPath: default alongside the ledger; HIMMEL_ALIBABA_PROBE_MARKER override wins", () => {
+  // node:path.join is platform-native (backslashes on Windows); normalize for assertion.
+  const norm = (p: string): string => p.replace(/\\/g, "/");
+  expect(norm(markerPath({ HOME: "/tmp/fake-home" }))).toBe("/tmp/fake-home/.himmel/alibaba-probe-lastrun");
+  const override = markerPath({ HOME: "/tmp/fake-home", HIMMEL_ALIBABA_PROBE_MARKER: "/tmp/marker" });
+  expect(override).toBe("/tmp/marker");   // override returned verbatim (no join)
+});
+
+test("shouldProbe: null -> true; within gap -> false; >= gap -> true", () => {
+  expect(shouldProbe(null, NOW_MS)).toBe(true);
+  expect(shouldProbe(NOW_MS - 5_000, NOW_MS)).toBe(false);              // 5s ago
+  expect(shouldProbe(NOW_MS - (MIN_PROBE_GAP_S * 1000), NOW_MS)).toBe(true);   // exactly 60s
+  expect(shouldProbe(NOW_MS - (MIN_PROBE_GAP_S * 1000 + 1), NOW_MS)).toBe(true); // >60s
+  expect(shouldProbe(NOW_MS - 59_000, NOW_MS)).toBe(false);            // 59s ago
+});
+
+test("basicAuthHeader: 'Basic <base64(AK:SK)>' — decodes back to the pair (FAKE creds)", () => {
+  const h = basicAuthHeader("test-ak", "test-sk");
+  expect(h.startsWith("Basic ")).toBe(true);
+  const b64 = h.slice("Basic ".length);
+  expect(Buffer.from(b64, "base64").toString()).toBe("test-ak:test-sk");
+});
+
+test("buildPromQueryUrl: appends ?query=model_usage; uses & when a query string is present", () => {
+  expect(buildPromQueryUrl("https://prom.example/api/v1/query")).toBe("https://prom.example/api/v1/query?query=model_usage");
+  expect(buildPromQueryUrl("https://prom.example/api/v1/query?timeout=30s")).toBe("https://prom.example/api/v1/query?timeout=30s&query=model_usage");
+});
+
+test("parseDotenv: reads KEY=VAL; strips one surrounding quote pair; skips blanks/comments", () => {
+  // parseDotenv reads a real file path; write a tiny fixture to a temp file.
+  const tmp = `${import.meta.dir}/.alibaba-probe-fixture.env`;
+  writeFileSync(tmp, [
+    '# comment',
+    'export ALIBABA_QUOTA_AK="real-ak"',
+    "ALIBABA_QUOTA_SK='real-sk'",
+    "ALIBABA_QUOTA_PROM_URL=https://prom.example/api",
+    "BLANK=",
+    "NOTHING_HERE",
+  ].join("\n"));
+  try {
+    const out = parseDotenv(tmp);
+    expect(out.ALIBABA_QUOTA_AK).toBe("real-ak");
+    expect(out.ALIBABA_QUOTA_SK).toBe("real-sk");
+    expect(out.ALIBABA_QUOTA_PROM_URL).toBe("https://prom.example/api");
+    expect(out.BLANK).toBeUndefined();          // blank value dropped
+    expect(out.NOTHING_HERE).toBeUndefined();   // no `=` -> not a var line
+  } finally { unlinkSync(tmp); }
+});
+
+// ── runProbe (all side effects injected) ─────────────────────────────────────
+test("runProbe skip-noenv: any missing var -> skip-noenv, silent, no fetch/append/marker", async () => {
+  let fetched = 0, appended = 0, committed = 0, logged = 0;
+  const outcome = await runProbe({
+    env: { ...BASE_ENV, ALIBABA_QUOTA_SK: undefined },   // SK missing
+    nowMs: NOW_MS, markerMs: null,
+    fetchJson: async () => { fetched++; return { status: "ok", body: REAL_PROM }; },
+    append: () => { appended++; },
+    commitMarker: () => { committed++; },
+    log: () => { logged++; },
+  });
+  expect(outcome).toBe("skip-noenv");
+  expect([fetched, appended, committed, logged]).toEqual([0, 0, 0, 0]);
+});
+
+test("runProbe skip-fresh: within the gap -> skip-fresh, silent, no fetch/append/marker", async () => {
+  let fetched = 0, appended = 0, committed = 0, logged = 0;
+  const outcome = await runProbe({
+    env: BASE_ENV,
+    nowMs: NOW_MS, markerMs: NOW_MS - 5_000,   // 5s ago — too fresh
+    fetchJson: async () => { fetched++; return { status: "ok", body: REAL_PROM }; },
+    append: () => { appended++; },
+    commitMarker: () => { committed++; },
+    log: () => { logged++; },
+  });
+  expect(outcome).toBe("skip-fresh");
+  expect([fetched, appended, committed, logged]).toEqual([0, 0, 0, 0]);
+});
+
+test("runProbe skip-429: HTTP 429 -> backoff; marker committed; NO append; one stderr line", async () => {
+  let fetched = 0, appended = 0, committed = 0, logged = 0;
+  const outcome = await runProbe({
+    env: BASE_ENV, nowMs: NOW_MS, markerMs: null,
+    fetchJson: async () => { fetched++; return { status: "rate_limited" }; },
+    append: () => { appended++; },
+    commitMarker: () => { committed++; },
+    log: () => { logged++; },
+  });
+  expect(outcome).toBe("skip-429");
+  expect([fetched, committed, logged]).toEqual([1, 1, 1]);
+  expect(appended).toBe(0);
+});
+
+test("runProbe skip-error: transport error / non-2xx -> skip-error; marker committed; one stderr line", async () => {
+  // (a) explicit error result (non-2xx mapped by the transport)
+  let appended = 0, committed = 0, logged = 0;
+  let o1 = await runProbe({
+    env: BASE_ENV, nowMs: NOW_MS, markerMs: null,
+    fetchJson: async () => ({ status: "error", message: "HTTP 502" }),
+    append: () => { appended++; },
+    commitMarker: () => { committed++; },
+    log: () => { logged++; },
+  });
+  expect(o1).toBe("skip-error");
+  // (b) thrown fetch -> same skip-error path
+  let o2 = await runProbe({
+    env: BASE_ENV, nowMs: NOW_MS, markerMs: null,
+    fetchJson: async () => { throw new Error("ENETUNREACH"); },
+    append: () => { appended++; },
+    commitMarker: () => { committed++; },
+    log: () => { logged++; },
+  });
+  expect(o2).toBe("skip-error");
+  expect([appended, committed, logged]).toEqual([0, 2, 2]);   // marker+log each attempt; never appended
+});
+
+test("runProbe appended (ok): default grants applied -> derived used_pct; marker committed; no stderr", async () => {
+  const rows: QuotaGaugeRecord[] = [];
+  let committed = 0, logged = 0;
+  const outcome = await runProbe({
+    env: BASE_ENV, nowMs: NOW_MS, markerMs: null,
+    fetchJson: async () => ({ status: "ok", body: REAL_PROM }),
+    append: (r) => rows.push(r),
+    commitMarker: () => { committed++; },
+    log: () => { logged++; },
+  });
+  expect(outcome).toBe("appended");
+  expect(committed).toBe(1);
+  expect(logged).toBe(0);                          // success is silent
+  expect(rows.length).toBe(2);                     // qwen3-coder-plus + qwen-plus
+  const coder = rows.find((r) => r.tier === "qwen3-coder-plus")!;
+  expect(coder.used_pct).toBe(60);                 // round(100*600000/1_000_000) via free-tier default
+  expect(coder.source).toBe("alibaba-prometheus");
+});
+
+test("runProbe appended (ok): ALIBABA_QUOTA_GRANTS override flows through resolveGrants", async () => {
+  const rows: QuotaGaugeRecord[] = [];
+  const outcome = await runProbe({
+    env: { ...BASE_ENV, ALIBABA_QUOTA_GRANTS: '{"qwen-plus": 500000}' }, // qwen-plus overridden to 500k
+    nowMs: NOW_MS, markerMs: null,
+    fetchJson: async () => ({ status: "ok", body: REAL_PROM }),
+    append: (r) => rows.push(r),
+  });
+  expect(outcome).toBe("appended");
+  const plus = rows.find((r) => r.tier === "qwen-plus")!;
+  expect(plus.used_pct).toBe(50);                  // round(100*250000/500000) — override beat the 1M default
+  const coder = rows.find((r) => r.tier === "qwen3-coder-plus")!;
+  expect(coder.used_pct).toBe(60);                 // default still applies to the non-overridden model
+});
+
+test("runProbe appended (ok, garbled body): ONE invisible row + one stderr line", async () => {
+  const rows: QuotaGaugeRecord[] = [];
+  let logged = 0;
+  const outcome = await runProbe({
+    env: BASE_ENV, nowMs: NOW_MS, markerMs: null,
+    fetchJson: async () => ({ status: "ok", body: "not json{" }),
+    append: (r) => rows.push(r),
+    log: () => { logged++; },
+  });
+  expect(outcome).toBe("appended");
+  expect(rows.length).toBe(1);
+  expect(rows[0].source).toBe("invisible");
+  expect(rows[0].used_pct).toBeNull();
+  expect(logged).toBe(1);
+});
+
+test("runProbe: exhausted-but-distinct outcomes (compile-time coverage of the union)", () => {
+  // Belt-and-braces: the four skip outcomes + appended are the whole ProbeOutcome
+  // union; this pins the spelling the runner's callers/observers depend on.
+  const all: ProbeOutcome[] = ["appended", "skip-noenv", "skip-fresh", "skip-429", "skip-error"];
+  expect(new Set(all).size).toBe(all.length);
+});
+
+// FetchResult union pin (guards against a silent shape drift in the transport).
+test("FetchResult shapes are spellable", () => {
+  const a: FetchResult = { status: "ok", body: "{}" };
+  const b: FetchResult = { status: "rate_limited" };
+  const c: FetchResult = { status: "error", message: "x" };
+  expect([a.status, b.status, c.status]).toEqual(["ok", "rate_limited", "error"]);
+});

--- a/scripts/telegram/alibaba-probe-once.ts
+++ b/scripts/telegram/alibaba-probe-once.ts
@@ -1,0 +1,203 @@
+// scripts/telegram/alibaba-probe-once.ts
+// HIMMEL-729 wiring chunk B — the deferred LIVE touchpoint for the Alibaba
+// quota-gauge probe (companion to the PURE quota-gauge-alibaba.ts module shipped
+// in PR #950/#951). Invoke-only and PIGGYBACKED on a qwen* dispatch from
+// scripts/hermes/invoke.sh: NO always-on surface (no hook, no daemon, no cron,
+// no poll loop). The probe runs at most ONCE per invocation and self-throttles.
+//
+// Flow: read ALIBABA_QUOTA_{AK,SK,PROM_URL} (process.env -> repo .env ->
+// main-checkout .env); SKIP SILENTLY (rc 0) when any is missing. A freshness
+// marker enforces a MIN 60s gap between probes (stale-skip is rc 0). Query the
+// Prometheus instant endpoint (HTTP Basic base64(AK:SK), `query=model_usage`);
+// on HTTP 429 record a backoff and skip (no in-line retry); on success feed
+// parseModelUsage + resolveGrants + buildAlibabaRows and append every row to the
+// quota-gauge ledger. NEVER prints secret values; the credential pair lives only
+// in the Authorization header passed to the fetch.
+//
+// All I/O (fetch, marker read/write, append) is injected into runProbe so the
+// core is unit-testable with NO network and NO real fs. The thin main() wires
+// the real fetch + fs + appendQuotaGauge and is the only thing that runs live.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  alibabaEnv, alibabaEnvReady, parseModelUsage, resolveGrants, buildAlibabaRows,
+} from "./quota-gauge-alibaba";
+import { appendQuotaGauge, ledgerPath } from "./quota-gauge";
+import type { QuotaGaugeRecord } from "./quota-gauge";
+
+export const MIN_PROBE_GAP_S = 60;
+
+// Freshness-marker path: alongside the ledger (<HOME>/.himmel/alibaba-probe-
+// lastrun), overridable via HIMMEL_ALIBABA_PROBE_MARKER for tests. Reads HOME
+// from the injectable env (via ledgerPath) so it never touches the real home in
+// a hermetic test.
+export function markerPath(env: Record<string, string | undefined> = process.env): string {
+  const override = env.HIMMEL_ALIBABA_PROBE_MARKER;
+  if (override && override.trim()) return override;
+  return join(dirname(ledgerPath(env)), "alibaba-probe-lastrun");
+}
+
+// True iff enough time has elapsed since the last probe attempt. `lastProbeMs`
+// null (no prior attempt) -> always probe. Pure.
+export function shouldProbe(lastProbeMs: number | null, nowMs: number, gapS: number = MIN_PROBE_GAP_S): boolean {
+  if (lastProbeMs === null) return true;
+  return nowMs - lastProbeMs >= gapS * 1000;
+}
+
+// HTTP Basic header for the Prometheus endpoint. base64(AK:SK). NEVER logged.
+export function basicAuthHeader(accessKey: string, accessSecret: string): string {
+  return "Basic " + Buffer.from(`${accessKey}:${accessSecret}`).toString("base64");
+}
+
+// Append the instant-query expression to the configured Prometheus URL. Adds
+// `?query=model_usage` (or `&query=model_usage` when the URL already carries a
+// query string). Pure.
+export function buildPromQueryUrl(promUrl: string): string {
+  const base = promUrl.trim();
+  const sep = base.includes("?") ? "&" : "?";
+  return `${base}${sep}query=model_usage`;
+}
+
+// One fetch outcome. `ok` carries the raw body (string or parsed object —
+// parseModelUsage accepts both); `rate_limited` is HTTP 429; `error` is any
+// other failure (network, non-2xx, throw). The injected fetch maps errors to
+// this shape so runProbe never sees a throw from the transport.
+export type FetchResult =
+  | { status: "ok"; body: unknown }
+  | { status: "rate_limited" }
+  | { status: "error"; message: string };
+
+export type ProbeOutcome = "appended" | "skip-noenv" | "skip-fresh" | "skip-429" | "skip-error";
+
+// Core probe. Every side effect is injected:
+//   - markerMs    : last probe-attempt time (read by the caller), or null.
+//   - fetchJson   : the Prometheus fetch (transport-mapped to FetchResult).
+//   - append      : ledger append (one QuotaGaugeRecord).
+//   - commitMarker: write the attempt time (called once a real fetch is about to
+//                   happen, so a 429 / error also throttles for the gap).
+//   - log         : stderr sink (default console.error); silent on noenv/fresh.
+// Returns the outcome; never throws. The caller exits 0 regardless (best-effort).
+export async function runProbe(opts: {
+  env: Record<string, string | undefined>;
+  nowMs: number;
+  markerMs: number | null;
+  gapS?: number;
+  fetchJson: (url: string, authHeader: string) => Promise<FetchResult>;
+  append: (row: QuotaGaugeRecord) => void;
+  commitMarker?: () => void;
+  log?: (msg: string) => void;
+}): Promise<ProbeOutcome> {
+  const aenv = alibabaEnv(opts.env);
+  if (!alibabaEnvReady(aenv)) return "skip-noenv";          // silent — unconfigured
+  if (!shouldProbe(opts.markerMs, opts.nowMs, opts.gapS)) return "skip-fresh"; // silent — throttled
+  const log = opts.log ?? ((m: string) => console.error(m));
+  opts.commitMarker?.();                                     // mark the attempt (throttle holds even on 429/error)
+
+  let res: FetchResult;
+  try {
+    res = await opts.fetchJson(buildPromQueryUrl(aenv.promUrl!), basicAuthHeader(aenv.accessKey!, aenv.accessSecret!));
+  } catch (e) {
+    res = { status: "error", message: e instanceof Error ? e.message : String(e) };
+  }
+
+  if (res.status === "rate_limited") {
+    log("alibaba-probe-once: HTTP 429 from Prometheus — backing off (skipping this probe)");
+    return "skip-429";
+  }
+  if (res.status === "error") {
+    log(`alibaba-probe-once: probe failed (${res.message}) — skipping`);
+    return "skip-error";
+  }
+
+  const usage = parseModelUsage(res.body);
+  if (usage === null) log("alibaba-probe-once: prometheus response unreadable or no total_tokens series — recording an invisible alibaba row");
+  const grants = resolveGrants(usage, opts.env);
+  for (const row of buildAlibabaRows(usage, grants, opts.nowMs)) opts.append(row);
+  return "appended";
+}
+
+// ── .env cascade (parity with glm-env.ts:readZaiKey + mainCheckoutRoot) ───────
+// process.env wins; then the worktree/repo .env; then the main-checkout .env
+// (a worktree's .env is gitignored/absent — the real one lives in the main
+// checkout, resolved via `git rev-parse --git-common-dir`). NOT imported from
+// glm-env.ts to keep this runner self-contained and avoid its spawn-glm deps.
+export function parseDotenv(envFile: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!existsSync(envFile)) return out;
+  for (const raw of readFileSync(envFile, "utf8").split(/\r?\n/)) {
+    const m = raw.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/);
+    if (!m) continue;
+    let v = m[2].trim();
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+    if (v) out[m[1]] = v;
+  }
+  return out;
+}
+
+export function mainCheckoutRoot(repoRoot: string): string | undefined {
+  try {
+    const r = Bun.spawnSync(["git", "-C", repoRoot, "rev-parse", "--path-format=absolute", "--git-common-dir"], { stdout: "pipe", stderr: "pipe" });
+    if (r.exitCode !== 0) return undefined;
+    const commonDir = r.stdout.toString().trim();
+    if (!commonDir) return undefined;
+    const parent = dirname(commonDir);
+    return resolve(parent) !== resolve(repoRoot) ? parent : undefined;
+  } catch { return undefined; }
+}
+
+export function loadAlibabaEnv(repoRoot: string): Record<string, string | undefined> {
+  const merged: Record<string, string | undefined> = {};
+  const mainRoot = mainCheckoutRoot(repoRoot);
+  if (mainRoot) Object.assign(merged, parseDotenv(join(mainRoot, ".env")));   // lowest precedence
+  Object.assign(merged, parseDotenv(join(repoRoot, ".env")));
+  for (const [k, v] of Object.entries(process.env)) if (v !== undefined) merged[k] = v; // process.env wins
+  return merged;
+}
+
+// ── real I/O (main-only; never exercised by tests) ────────────────────────────
+function readMarkerMs(path: string): number | null {
+  if (!existsSync(path)) return null;
+  const raw = readFileSync(path, "utf8").trim();
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+function writeMarkerMs(path: string, nowMs: number): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(path, String(nowMs), "utf8");
+}
+
+async function realFetchJson(url: string, authHeader: string): Promise<FetchResult> {
+  try {
+    const resp = await fetch(url, { headers: { Authorization: authHeader } });
+    if (resp.status === 429) return { status: "rate_limited" };
+    if (!resp.ok) return { status: "error", message: `HTTP ${resp.status}` };
+    return { status: "ok", body: await resp.text() };
+  } catch (e) {
+    return { status: "error", message: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+async function main(): Promise<void> {
+  const env = loadAlibabaEnv(REPO_ROOT);
+  const nowMs = Date.now();
+  const mPath = markerPath(env);
+  await runProbe({
+    env,
+    nowMs,
+    markerMs: readMarkerMs(mPath),
+    fetchJson: realFetchJson,
+    append: (row) => appendQuotaGauge(row, ledgerPath(env)),
+    commitMarker: () => writeMarkerMs(mPath, nowMs),
+  });
+  // rc 0 always — best-effort piggyback; never fails the dispatch.
+}
+
+if (import.meta.main) {
+  main().catch((e) => { console.error(`alibaba-probe-once: fatal: ${e instanceof Error ? e.message : String(e)}`); });
+}

--- a/scripts/telegram/quota-gauge-alibaba.test.ts
+++ b/scripts/telegram/quota-gauge-alibaba.test.ts
@@ -10,6 +10,10 @@ import {
   parseModelUsage,
   buildAlibabaRows,
   alibabaProbeAppend,
+  DEFAULT_FREE_TIER_GRANT_TOKENS,
+  isUnitQuotaModel,
+  parseGrantsOverride,
+  resolveGrants,
 } from "./quota-gauge-alibaba";
 import type { QuotaGaugeRecord } from "./quota-gauge";
 
@@ -169,4 +173,89 @@ test("latent empty usage[] -> ONE invisible row, never a silent zero-row append"
   expect(rows.length).toBe(1);
   expect(rows[0].source).toBe("invisible");
   expect(rows[0].used_pct).toBeNull();
+});
+
+// ── HIMMEL-729 wiring chunk A: free-tier grants resolution ───────────────────
+test("DEFAULT_FREE_TIER_GRANT_TOKENS is the documented 1,000,000", () => {
+  expect(DEFAULT_FREE_TIER_GRANT_TOKENS).toBe(1_000_000);
+});
+
+test("isUnitQuotaModel: wan* only (case-insensitive); qwen/glm/deepseek are not", () => {
+  expect(isUnitQuotaModel("wan2.2-t2v")).toBe(true);
+  expect(isUnitQuotaModel("WAN2.2-i2v")).toBe(true);
+  expect(isUnitQuotaModel("qwen-plus")).toBe(false);
+  expect(isUnitQuotaModel("qwen3-coder-plus")).toBe(false);
+  expect(isUnitQuotaModel("glm-5.2")).toBe(false);
+  expect(isUnitQuotaModel("deepseek-v3.2")).toBe(false);
+  expect(isUnitQuotaModel("kimi-k2.7-code")).toBe(false);
+});
+
+test("parseGrantsOverride: absent/blank -> {} (defaults apply later)", () => {
+  expect(parseGrantsOverride({})).toEqual({});
+  expect(parseGrantsOverride({ ALIBABA_QUOTA_GRANTS: "   " })).toEqual({});
+});
+
+test("parseGrantsOverride: valid object -> map; non-positive/non-finite values dropped", () => {
+  expect(parseGrantsOverride({ ALIBABA_QUOTA_GRANTS: '{"qwen-plus": 500000}' })).toEqual({ "qwen-plus": 500000 });
+  const mixed = parseGrantsOverride({ ALIBABA_QUOTA_GRANTS: '{"a": 100, "b": 0, "c": -5, "d": "x", "e": 200}' });
+  expect(mixed).toEqual({ a: 100, e: 200 });   // b/c non-positive, d non-numeric -> dropped
+});
+
+test("parseGrantsOverride: malformed JSON -> warn to stderr + {} (fall back to defaults)", () => {
+  let stderrCount = 0;
+  const origErr = console.error;
+  console.error = () => { stderrCount++; };
+  try {
+    expect(parseGrantsOverride({ ALIBABA_QUOTA_GRANTS: "not json{" })).toEqual({});
+    expect(parseGrantsOverride({ ALIBABA_QUOTA_GRANTS: "[1,2,3]" })).toEqual({});      // non-object body
+    expect(parseGrantsOverride({ ALIBABA_QUOTA_GRANTS: '"a string"' })).toEqual({});   // non-object body
+    expect(parseGrantsOverride({ ALIBABA_QUOTA_GRANTS: "42" })).toEqual({});            // non-object body
+  } finally { console.error = origErr; }
+  expect(stderrCount).toBe(4);   // one warning per malformed/non-object parse
+});
+
+test("resolveGrants: missing ALIBABA_QUOTA_GRANTS -> blanket 1M default on every reported token model", () => {
+  const usage = parseModelUsage(REAL_PROM)!;   // qwen3-coder-plus + qwen-plus
+  const grants = resolveGrants(usage, {});
+  expect(grants).toEqual({ "qwen3-coder-plus": 1_000_000, "qwen-plus": 1_000_000 });
+});
+
+test("resolveGrants: override REPLACES the default per model key (others still default)", () => {
+  const usage = parseModelUsage(REAL_PROM)!;
+  const grants = resolveGrants(usage, { ALIBABA_QUOTA_GRANTS: '{"qwen-plus": 500000}' });
+  expect(grants).toEqual({ "qwen-plus": 500000, "qwen3-coder-plus": 1_000_000 });
+});
+
+test("resolveGrants: wan* model gets NO token default (used_pct stays null downstream)", () => {
+  const usage = [{ model: "wan2.2-t2v", totalTokens: 30 }, { model: "qwen-plus", totalTokens: 250000 }];
+  const grants = resolveGrants(usage, {});
+  expect(grants).toEqual({ "qwen-plus": 1_000_000 });   // wan2.2-t2v absent — never fabricated
+  const rows = buildAlibabaRows(usage, grants, NOW_MS);
+  const wan = rows.find((r) => r.tier === "wan2.2-t2v")!;
+  expect(wan.used_pct).toBeNull();
+  expect(wan.note).toBe("consumed=30 (no grant configured - used_pct unknowable)");
+});
+
+test("resolveGrants: an override ON a wan* model applies (operator supplies the token figure)", () => {
+  const usage = [{ model: "wan2.2-t2v", totalTokens: 100000 }];
+  const grants = resolveGrants(usage, { ALIBABA_QUOTA_GRANTS: '{"wan2.2-t2v": 1000000}' });
+  expect(grants).toEqual({ "wan2.2-t2v": 1_000_000 });
+  const rows = buildAlibabaRows(usage, grants, NOW_MS);
+  expect(rows[0].used_pct).toBe(10);
+});
+
+test("resolveGrants: usage null (probe unreadable) -> only overrides knowable, no blind default", () => {
+  const grants = resolveGrants(null, { ALIBABA_QUOTA_GRANTS: '{"qwen-plus": 500000}' });
+  expect(grants).toEqual({ "qwen-plus": 500000 });   // no fabricated defaults without a reported model
+});
+
+test("resolveGrants + buildAlibabaRows: default makes a previously-unknowable model derivable", () => {
+  // Same input as the shipped "missing grant -> null" test, but grants now resolved
+  // with the free-tier default: qwen3-coder-plus is NO LONGER unknowable.
+  const usage = parseModelUsage(REAL_PROM)!;
+  const grants = resolveGrants(usage, {});   // defaults only
+  const rows = buildAlibabaRows(usage, grants, NOW_MS);
+  const coder = rows.find((r) => r.tier === "qwen3-coder-plus")!;
+  expect(coder.used_pct).toBe(60);                       // round(100*600000/1_000_000)
+  expect(coder.note).toBe("consumed=600000/1000000");
 });

--- a/scripts/telegram/quota-gauge-alibaba.ts
+++ b/scripts/telegram/quota-gauge-alibaba.ts
@@ -40,6 +40,71 @@ export function alibabaEnv(env: Record<string, string | undefined> = process.env
   };
 }
 
+// ── HIMMEL-729 wiring chunk A: free-tier grants resolution ───────────────────
+// Every TOKEN-quota model on the account carries exactly this free-tier grant.
+// Source: operator-verified from the live Model Studio console, 2026-07-06,
+// cross-checked with https://www.alibabacloud.com/help/en/model-studio/new-free-quota
+// — ~89 token models (~70M total pool): qwen* families PLUS glm-5.1/glm-5.2,
+// deepseek-v3.2/v4-*, kimi-k2.7-code, qwq/qvq. Most grants expire 2026-10-03;
+// qwen-plus and qwen-turbo expire 2026-08-04. Quota is SHARED between the account
+// and its RAM users; Singapore region; Stop-on-Exhaust is enabled (hard stop, no
+// overage). Applied ONLY as a default to a reported token model with no operator
+// override — never to wan* (unit-quota video models). Never fabricated: a grant
+// figure is emitted only for a model that is either defaulted or overridden.
+export const DEFAULT_FREE_TIER_GRANT_TOKENS = 1_000_000;
+
+// wan* (e.g. wan2.2-t2v) are UNIT-quota video models: their grant is measured in
+// calls (~50), not tokens, so the token default never applies. used_pct for one
+// stays null unless an operator override supplies a token figure for it.
+export function isUnitQuotaModel(model: string): boolean {
+  return /^wan/i.test(model);
+}
+
+// Read the operator override `ALIBABA_QUOTA_GRANTS` (JSON `{"<model>": <tokens>}`).
+// Malformed JSON (or a non-object body) -> ONE stderr warning + empty map (fall
+// back to defaults). Absent/blank -> empty map. A non-positive / non-finite
+// value for a key is dropped. Returns the override map ONLY; the per-model
+// default is applied in resolveGrants. Injectable env (alibabaEnv-style).
+export function parseGrantsOverride(env: Record<string, string | undefined> = process.env): AlibabaGrants {
+  const raw = env.ALIBABA_QUOTA_GRANTS;
+  if (!raw || !raw.trim()) return {};
+  let obj: unknown;
+  try { obj = JSON.parse(raw); } catch {
+    console.error("quota-gauge-alibaba: ALIBABA_QUOTA_GRANTS is not valid JSON — ignoring override, using defaults");
+    return {};
+  }
+  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+    console.error("quota-gauge-alibaba: ALIBABA_QUOTA_GRANTS is not a JSON object — ignoring override, using defaults");
+    return {};
+  }
+  const out: AlibabaGrants = {};
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    const n = Number(v);
+    if (Number.isFinite(n) && n > 0) out[k] = n;   // override REPLACES the default per model key
+  }
+  return out;
+}
+
+// Resolve the per-model grant map for the models the probe actually reported. An
+// operator override REPLACES the default for that model key; otherwise every
+// non-wan* token model gets DEFAULT_FREE_TIER_GRANT_TOKENS; wan* models get no
+// entry (used_pct stays null unless overridden). `usage` null (probe unreadable)
+// -> only overrides are knowable, so the default is NOT applied blindly. Pure +
+// injectable; the runner calls this AFTER parseModelUsage so the default lands on
+// reported models only, and buildAlibabaRows (unchanged) receives a fully
+// resolved map — keeping its never-fabricate rule intact for any model neither
+// defaulted nor overridden.
+export function resolveGrants(usage: ModelUsage[] | null, env: Record<string, string | undefined> = process.env): AlibabaGrants {
+  const grants: AlibabaGrants = { ...parseGrantsOverride(env) };
+  if (usage === null) return grants;
+  for (const { model } of usage) {
+    if (model in grants) continue;          // override wins (already a positive finite number)
+    if (isUnitQuotaModel(model)) continue;  // wan*: unit-quota, no token default
+    grants[model] = DEFAULT_FREE_TIER_GRANT_TOKENS;
+  }
+  return grants;
+}
+
 // Parse a Prometheus HTTP API instant-query response into per-model consumed
 // totals. Accepts either a raw JSON string (parsed here) or an already-parsed
 // object (so the deferred wiring may use resp.text() OR resp.json()). Keeps


### PR DESCRIPTION
Grants resolution (1M-per-token-model default + ALIBABA_QUOTA_GRANTS override, wan* unit-quota excluded) + the deferred live touchpoint: throttled hermetic probe runner (60s marker, 429 backoff, rc-0 best-effort) piggybacked fire-and-forget on qwen* dispatches in invoke.sh. 368 tests green. Mirrors private #954.