### PR TITLE
fix(hooks): [HIMMEL-733] lane-aware auto-arm-on-cap + codex worktree ACL normalizer

### DIFF
--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -167,6 +167,12 @@ Installed via `extraKnownMarketplaces` in `settings.json`.
 **What:** The OpenAI codex companion plugin — the codex CLI runtime, the `codex:codex-rescue` / `codex:setup` skills, and the `codex-companion.mjs` script under `$HOME/.claude/plugins/cache/openai-codex/codex/<version>/` (the version segment drifts on plugin update — glob-resolve it, never hardcode).
 
 **ADOPTED (HIMMEL-694):** the companion's `adversarial-review` mode is integrated into `/pr-check` step 3.1 as an ADDITIONAL pre-merge cross-model pass of the paid/pair tier — **availability-gated** (it consumes the operator's OpenAI usage bank, so absence of codex ⇒ silently skipped with a one-line note, never an error; also skipped under `CR_PROFILE=none`). Its `[codex-adv-N]` findings are blocking candidates merged into the same adjudication flow as the free critic panel (VERDICT lines + step-4.5 ledger `--model codex-adv`). Runbook: `.claude/commands/pr-check.md` step 3.1.
+**Windows ACL hardening (HIMMEL-733):** aged Codex worktrees can lose inherited
+sandbox ACEs on child directories. Before an unattended Codex dispatch into an
+existing worktree, run `pwsh -NoProfile -File scripts\codex\normalize-worktree-acl.ps1 <worktree>`
+(or the `scripts/codex/normalize-worktree-acl.sh` wrapper from Git Bash). The
+helper refuses paths outside `.claude/worktrees/<name>` and resets only each
+top-level child directory, never the worktree root.
 
 ### himmel (local directory marketplace)
 

--- a/scripts/codex/normalize-worktree-acl.ps1
+++ b/scripts/codex/normalize-worktree-acl.ps1
@@ -1,0 +1,67 @@
+<#
+.SYNOPSIS
+Normalize inherited ACLs for a Codex worktree's top-level child directories.
+
+.DESCRIPTION
+Windows-only helper for aged Codex worktrees whose subdirectories missed the
+sandbox SID inheritance granted at the worktree root. Given a path under a
+.claude\worktrees\<name> segment, this script runs:
+
+  icacls <child-directory> /reset /T /C /Q
+
+for each top-level child directory. It deliberately never resets the worktree
+root, because the root carries the explicit Codex sandbox SID ACE that must
+survive. If no Codex dispatch chokepoint is available, run manually before an
+unattended Codex lane dispatch:
+
+  pwsh -NoProfile -File scripts\codex\normalize-worktree-acl.ps1 <worktree>
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true, Position = 0)]
+  [string]$WorktreePath,
+
+  [Parameter()]
+  [string]$IcaclsPath = 'icacls'
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+function Write-Err([string]$Message) {
+  [Console]::Error.WriteLine("normalize-worktree-acl: $Message")
+}
+
+try {
+  $root = (Resolve-Path -LiteralPath $WorktreePath).ProviderPath
+} catch {
+  Write-Err "path not found: $WorktreePath"
+  exit 2
+}
+
+$fullRoot = [System.IO.Path]::GetFullPath($root)
+$normalized = $fullRoot -replace '/', '\'
+$parts = @($normalized -split '\\+')
+$underWorktree = $false
+for ($i = 0; $i -lt ($parts.Count - 2); $i++) {
+  if (($parts[$i] -ieq '.claude') -and ($parts[$i + 1] -ieq 'worktrees') -and ($parts[$i + 2] -ne '')) {
+    $underWorktree = $true
+    break
+  }
+}
+if (-not $underWorktree) {
+  Write-Err "refusing to reset ACLs outside a .claude\worktrees\<name> path: $fullRoot"
+  exit 2
+}
+
+$children = @(Get-ChildItem -LiteralPath $fullRoot -Directory -Force)
+$failed = $false
+foreach ($child in $children) {
+  & $IcaclsPath $child.FullName '/reset' '/T' '/C' '/Q'
+  if ($LASTEXITCODE -ne 0) {
+    $failed = $true
+  }
+}
+
+if ($failed) { exit 1 }
+exit 0

--- a/scripts/codex/normalize-worktree-acl.sh
+++ b/scripts/codex/normalize-worktree-acl.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# normalize-worktree-acl.sh - Windows-only wrapper for normalize-worktree-acl.ps1.
+# Non-Windows platforms do not have the Codex Windows sandbox ACL failure mode, so
+# this wrapper exits 0 without side effects there.
+set -u
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+    MINGW*|MSYS*|CYGWIN*) ;;
+    *) exit 0 ;;
+esac
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: normalize-worktree-acl.sh <worktree-path>" >&2
+    exit 2
+fi
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+ps1="$script_dir/normalize-worktree-acl.ps1"
+
+if command -v pwsh >/dev/null 2>&1; then
+    exec pwsh -NoProfile -ExecutionPolicy Bypass -File "$ps1" "$1"
+fi
+if command -v powershell.exe >/dev/null 2>&1; then
+    exec powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$ps1" "$1"
+fi
+
+echo "normalize-worktree-acl.sh: PowerShell not found" >&2
+exit 1

--- a/scripts/codex/test-normalize-worktree-acl.ps1
+++ b/scripts/codex/test-normalize-worktree-acl.ps1
@@ -1,0 +1,61 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Helper = Join-Path $ScriptDir 'normalize-worktree-acl.ps1'
+$Tmp = Join-Path ([System.IO.Path]::GetTempPath()) ('himmel-acl-test-' + [Guid]::NewGuid().ToString('N').Substring(0, 8))
+$Pass = 0
+$Fail = 0
+
+function Pass([string]$Name) { Write-Host "  PASS  $Name"; $script:Pass++ }
+function Fail([string]$Name, [string]$Detail = '') { Write-Host "  FAIL  $Name $Detail"; $script:Fail++ }
+function Check([string]$Name, [bool]$Ok, [string]$Detail = '') { if ($Ok) { Pass $Name } else { Fail $Name $Detail } }
+
+function Run-Helper([string]$Path, [string]$Icacls) {
+  $out = & pwsh -NoProfile -ExecutionPolicy Bypass -File $Helper $Path -IcaclsPath $Icacls 2>&1
+  [pscustomobject]@{ Code = $LASTEXITCODE; Output = ($out | Out-String) }
+}
+
+try {
+  New-Item -ItemType Directory -Path $Tmp -Force | Out-Null
+  $primary = Join-Path $Tmp 'primary-checkout'
+  New-Item -ItemType Directory -Path $primary -Force | Out-Null
+
+  $log = Join-Path $Tmp 'icacls.log'
+  $fake = Join-Path $Tmp 'fake-icacls.ps1'
+  @"
+`$ErrorActionPreference = 'Stop'
+Add-Content -LiteralPath '$log' -Value (`$args -join '|')
+exit 0
+"@ | Set-Content -NoNewline -Path $fake
+
+  Write-Host 'Test 1: primary checkout path is refused before icacls runs'
+  $r = Run-Helper $primary $fake
+  Check 'primary checkout exits 2' ($r.Code -eq 2) "rc=$($r.Code) out=$($r.Output)"
+  Check 'primary checkout refusal mentions .claude\worktrees' ($r.Output -like '*.claude\worktrees*') $r.Output
+  Check 'primary checkout did not invoke icacls' (-not (Test-Path -LiteralPath $log))
+
+  Write-Host 'Test 2: fake worktree invokes icacls once per top-level child directory'
+  $wt = Join-Path $Tmp '.claude\worktrees\fix+acl'
+  $childA = Join-Path $wt 'scripts'
+  $childB = Join-Path $wt 'docs'
+  $nested = Join-Path $childA 'nested'
+  New-Item -ItemType Directory -Path $nested -Force | Out-Null
+  New-Item -ItemType Directory -Path $childB -Force | Out-Null
+  Set-Content -NoNewline -Path (Join-Path $wt 'README.md') -Value 'not a directory'
+  Remove-Item -LiteralPath $log -ErrorAction SilentlyContinue
+
+  $r = Run-Helper $wt $fake
+  Check 'worktree exits 0' ($r.Code -eq 0) "rc=$($r.Code) out=$($r.Output)"
+  $calls = @(Get-Content -LiteralPath $log)
+  Check 'two top-level directory calls' ($calls.Count -eq 2) ($calls -join '; ')
+  Check 'scripts child reset with expected args' ($calls -contains "$childA|/reset|/T|/C|/Q") ($calls -join '; ')
+  Check 'docs child reset with expected args' ($calls -contains "$childB|/reset|/T|/C|/Q") ($calls -join '; ')
+  Check 'root itself is never reset' (-not ($calls -contains "$wt|/reset|/T|/C|/Q")) ($calls -join '; ')
+  Check 'nested dir is not a separate top-level call' (-not ($calls -contains "$nested|/reset|/T|/C|/Q")) ($calls -join '; ')
+
+  Write-Host "Results: $Pass passed, $Fail failed"
+  if ($Fail -ne 0) { exit 1 }
+} finally {
+  Remove-Item -LiteralPath $Tmp -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/hooks/auto-arm-on-cap.sh
+++ b/scripts/hooks/auto-arm-on-cap.sh
@@ -47,8 +47,9 @@
 #         block while arm-resume's HIMMEL-Resume-* dedup keeps the
 #         scheduler at one job.
 #   4. arm-resume rc=3 (a HIMMEL-Resume-* job already exists) counts as
-#      success — the goal (a queued resume) is already met. Any other
-#      arm failure surfaces (exit 1 — non-blocking, stderr shown) and
+#      success — the goal (a queued resume) is already met; the hook notes
+#      that and allows the tool call. Any other arm failure surfaces
+#      (exit 1 — non-blocking, stderr shown) and
 #      retries next interval; after $AUTO_ARM_MAX_ARM_FAILURES
 #      consecutive failures it escalates to the one-shot exit-2 block
 #      anyway, telling the model the safety net is torn and to arm
@@ -66,10 +67,12 @@
 # Output / exit semantics (NON-STANDARD for this directory — this is a
 # WATCHDOG, not a guard; see scripts/hooks/CLAUDE.md "fail-closed"
 # convention, which this hook deliberately inverts):
-#   - exit 0 → allow; quiet. Absence-of-signal paths ONLY (disabled,
+#   - exit 0 → allow. Quiet for absence-of-signal paths (disabled,
 #              throttled, no/unreadable cache, stale cache below the
 #              escalation bound, below threshold, already fired this
 #              window / already escalated this wedge by THIS session).
+#              Non-Claude lane pass-through and arm-resume dedup emit a
+#              one-line stderr note.
 #   - exit 1 → allow; stderr surfaces to the user. Watchdog-MALFUNCTION
 #              paths (cannot write state, python3 missing/crashed,
 #              snapshot unwritable everywhere, arm-resume missing or
@@ -79,8 +82,8 @@
 #              marker, so "already escalated" may be suppressing a
 #              sibling's wind-down notice — that skip stays visible.
 #   - exit 2 → block this one tool call; stderr fed to the model
-#              (resume armed / already armed / arm UNFIXABLE — write a
-#              handover now). One-shot per session, keyed by cap window
+#              (resume armed / arm UNFIXABLE — write a handover now).
+#              One-shot per session, keyed by cap window
 #              (threshold trip) or wedge mtime (stale escalation).
 #
 # Env knobs (all optional):
@@ -103,6 +106,28 @@ warn() { echo "auto-arm-on-cap: $*" >&2; }
 
 [ "${AUTO_ARM_DISABLE:-0}" = "1" ] && exit 0
 
+non_claude_lane=""
+case "${ANTHROPIC_BASE_URL:-}" in
+    *api.z.ai*) non_claude_lane="ANTHROPIC_BASE_URL=api.z.ai" ;;
+esac
+if [ -z "$non_claude_lane" ] && [ -n "${HERMES_ENGINE:-}" ]; then
+    non_claude_lane="HERMES_ENGINE set"
+fi
+if [ -z "$non_claude_lane" ] && [ -n "${CODEX_ADAPTER:-}" ]; then
+    non_claude_lane="CODEX_ADAPTER set"
+fi
+# NOTE: CODEX_COMPANION_SESSION_ID is deliberately NOT a lane signal — the
+# codex-companion PLUGIN exports it into every Claude session where it is
+# installed (observed live in a plain Fable session), so keying on it would
+# silently disable this watchdog machine-wide. CODEX_THREAD_ID is only set
+# inside a real codex runtime.
+if [ -z "$non_claude_lane" ] && [ -n "${CODEX_THREAD_ID:-}" ]; then
+    non_claude_lane="CODEX_THREAD_ID set"
+fi
+if [ -n "$non_claude_lane" ]; then
+    warn "non-Claude lane detected ($non_claude_lane); passing through"
+    exit 0
+fi
 hook_dir=$(cd "$(dirname "$0")" && pwd)
 project_dir="${CLAUDE_PROJECT_DIR:-}"
 
@@ -491,22 +516,19 @@ PY
     arm_rc=$?
     set -e
     case "$arm_rc" in
-        0|3)
-            # 0 = armed; 3 = a HIMMEL-Resume job already exists — goal
-            # met either way (same dedup contract as the threshold trip).
+        0)
             armed_word="SAFETY RESUME ARMED at ${slot_hhmm}"
-            [ "$arm_rc" = "3" ] && armed_word="a resume is ALREADY armed (dedup)"
             if ! : > "$stale_marker" 2>/dev/null; then
                 # One-shot marker unpersistable (e.g. STATE_DIR went
                 # read-only — in which case the throttle marker and the
                 # counter are failing right alongside it, so EVERY tool
                 # call lands here). An exit-2 block now would repeat on
                 # every call while claiming "this block fires once" —
-                # actively false. The arm itself succeeded/deduped, so
-                # degrade to a loud non-blocking warn (exit 1): visible
-                # every check, but never a block loop. The counter is
-                # left in place on purpose — the next check re-warns
-                # instead of going quiet.
+                # actively false. The arm itself succeeded, so degrade
+                # to a loud non-blocking warn (exit 1): visible every
+                # check, but never a block loop. The counter is left in
+                # place on purpose — the next check re-warns instead of
+                # going quiet.
                 warn "STATUSLINE WEDGED and ${armed_word} (${slot_source}), but the one-shot marker $stale_marker is UNWRITABLE — cannot persist block-dedup state, so the exit-2 block is downgraded to this repeating warning. Snapshot: $snapshot. Write a full handover NOW and wind down."
                 exit 1
             fi
@@ -521,6 +543,15 @@ PY
                 echo "near the cap. This block fires once per session; your next tool call will proceed."
             } >&2
             exit 2
+            ;;
+        3)
+            if ! : > "$stale_marker" 2>/dev/null; then
+                warn "STATUSLINE WEDGED and a resume is ALREADY armed (dedup), but the one-shot marker $stale_marker is UNWRITABLE. Snapshot: $snapshot."
+                exit 1
+            fi
+            rm -f "$stale_count_file" 2>/dev/null || true
+            warn "STATUSLINE WEDGED and a resume is ALREADY armed (dedup); allowing tool call. Snapshot: $snapshot."
+            exit 0
             ;;
         *)
             # Surfaced, non-blocking; the counter stays >= STALE_MIN_CHECKS
@@ -770,21 +801,23 @@ arm_rc=$?
 set -e
 
 case "$arm_rc" in
-    0|3)
-        # 0 = armed; 3 = a HIMMEL-Resume job already exists — goal met
-        # either way (dedup with operator/supervisor arms is by design).
+    0)
         touch "$fired_marker" 2>/dev/null || true
         rm -f "$failcount_file" 2>/dev/null || true
-        armed_word="RESUME ARMED (--time smart)"
-        [ "$arm_rc" = "3" ] && armed_word="a resume is ALREADY armed (dedup)"
         {
-            echo "auto-arm-on-cap: usage ${util}% >= ${THRESHOLD}% on ${window} — ${armed_word}."
+            echo "auto-arm-on-cap: usage ${util}% >= ${THRESHOLD}% on ${window} — RESUME ARMED (--time smart)."
             echo "Status snapshot: $snapshot"
             echo "ACTION REQUIRED: write a full handover NOW (it will be picked up on resume),"
             echo "finish or park the in-flight step, then wind down. This block fires once;"
             echo "your next tool call will proceed."
         } >&2
         exit 2
+        ;;
+    3)
+        touch "$fired_marker" 2>/dev/null || true
+        rm -f "$failcount_file" 2>/dev/null || true
+        warn "usage ${util}% >= ${THRESHOLD}% on ${window} — a resume is ALREADY armed (dedup); allowing tool call. Status snapshot: $snapshot"
+        exit 0
         ;;
     *)
         # Arm failed. Surface it (exit 1 — non-blocking but visible),

--- a/scripts/hooks/test-auto-arm-on-cap.sh
+++ b/scripts/hooks/test-auto-arm-on-cap.sh
@@ -8,6 +8,11 @@ set -u -o pipefail
 HOOK="$(cd "$(dirname "$0")" && pwd)/auto-arm-on-cap.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
+# Hermetic lane env (HIMMEL-733): the hook now passes through on non-Claude
+# lane signals. Strip any such signal inherited from the RUNNING session
+# (e.g. a z.ai shell or a codex runtime) so baseline tests exercise the
+# Claude-lane paths; Test 1b re-sets them explicitly per case.
+unset ANTHROPIC_BASE_URL HERMES_ENGINE CODEX_ADAPTER CODEX_THREAD_ID
 # Isolate the quota-gauge ledger so threshold-trip tests never pollute the
 # operator's real ~/.himmel/quota-gauge.jsonl (HIMMEL-687).
 export HIMMEL_QUOTA_GAUGE_LEDGER="$TMP/quota-gauge.jsonl"
@@ -101,6 +106,26 @@ AUTO_ARM_DISABLE=1 AUTO_ARM_STATE_DIR="$S" AUTO_ARM_CACHE="$C" \
     bash "$HOOK" </dev/null >/dev/null 2>&1
 assert_rc "disabled hook exits 0" 0 $?
 assert_file "disabled hook touches no throttle marker" absent "$S/auto-arm-last-check"
+
+echo "Test 1b: non-Claude lanes pass through before cache/throttle/arm work"
+for spec in \
+    "z.ai env:ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic" \
+    "hermes env:HERMES_ENGINE=codex" \
+    "codex adapter:CODEX_ADAPTER=1"
+do
+    desc=$(printf '%s' "$spec" | cut -d: -f1)
+    assignment=$(printf '%s' "$spec" | cut -d: -f2-)
+    S="$TMP/s1b-$(printf '%s' "$desc" | tr ' .' '--')"; mkdir -p "$S"
+    C="$TMP/c1b-$(printf '%s' "$desc" | tr ' .' '--').json"; write_cache "$C" 99 99
+    rm -f "$ARM_LOG" "$STDERR_LOG"
+    env "$assignment" AUTO_ARM_STATE_DIR="$S" AUTO_ARM_CACHE="$C" \
+        AUTO_ARM_BIN="$ARM_STUB" ARM_LOG_PATH="$ARM_LOG" HANDOVER_DIR="$HANDOVER_TEST_DIR" \
+        CLAUDE_PROJECT_DIR="" bash "$HOOK" </dev/null >/dev/null 2>"$STDERR_LOG"
+    assert_rc "$desc pass-through exits 0" 0 $?
+    assert_file "$desc pass-through does not touch throttle marker" absent "$S/auto-arm-last-check"
+    assert_file "$desc pass-through does not arm" absent "$ARM_LOG"
+    assert_grep "$desc pass-through emits lane note" "non-Claude lane" "$STDERR_LOG"
+done
 
 echo "Test 2: below threshold — no arm, throttle marker touched"
 S="$TMP/s2"; mkdir -p "$S"
@@ -245,7 +270,7 @@ AUTO_ARM_STATE_DIR="$S" AUTO_ARM_CACHE="$C" \
     AUTO_ARM_BIN="$ARM_STUB" ARM_LOG_PATH="$ARM_LOG" ARM_STUB_RC=3 \
     HANDOVER_DIR="$HANDOVER_TEST_DIR" CLAUDE_PROJECT_DIR="" \
     bash "$HOOK" </dev/null >/dev/null 2>"$STDERR_LOG"
-assert_rc "already-armed run exits 2 (still tells the model)" 2 $?
+assert_rc "already-armed run exits 0 (armed, no block)" 0 $?
 assert_grep "dedup message says ALREADY armed" "ALREADY armed" "$STDERR_LOG"
 fired=$(count_glob "$S" 'auto-arm-fired-*')
 if [ "$fired" = "1" ]; then
@@ -456,7 +481,7 @@ AUTO_ARM_STATE_DIR="$S" AUTO_ARM_CACHE="$C" AUTO_ARM_STALE_MIN_CHECKS=1 \
     AUTO_ARM_BIN="$ARM_STUB" ARM_LOG_PATH="$ARM_LOG" ARM_STUB_RC=3 \
     HANDOVER_DIR="$HANDOVER_TEST_DIR" CLAUDE_PROJECT_DIR="" \
     bash "$HOOK" </dev/null >/dev/null 2>"$STDERR_LOG"
-assert_rc "already-armed safety escalation exits 2" 2 $?
+assert_rc "already-armed safety escalation exits 0 (armed, no block)" 0 $?
 assert_grep "dedup message says ALREADY armed" "ALREADY armed" "$STDERR_LOG"
 stale_markers=$(count_glob "$S" 'auto-arm-stale-escalated-*')
 if [ "$stale_markers" = "1" ]; then
@@ -527,10 +552,12 @@ rm -f "$S/auto-arm-last-check"
 run_hook_sid "$S" "$C" "session-alpha-0001"
 assert_rc "session A re-check — one-shot held (exit 0)" 0 $?
 rm -f "$S/auto-arm-last-check" "$ARM_LOG"
-# Session B under the same frozen mtime: must get its OWN block; the arm
-# itself dedups at the scheduler (rc=3 = already armed counts as success).
+# Session B under the same frozen mtime: the arm dedups at the scheduler
+# (rc=3 = already armed). HIMMEL-733: dedup counts as ARMED — B is notified
+# on stderr but NOT blocked (the safety net already exists).
 run_hook_sid "$S" "$C" "session-beta-0002" 3
-assert_rc "session B under the same wedge blocks too (exit 2)" 2 $?
+assert_rc "session B under the same wedge allowed (dedup = armed, exit 0)" 0 $?
+assert_grep "session B dedup note says ALREADY armed" "ALREADY armed" "$STDERR_LOG"
 assert_grep "session B told a resume is ALREADY armed (scheduler dedup)" "ALREADY armed" "$STDERR_LOG"
 stale_markers=$(count_glob "$S" 'auto-arm-stale-escalated-*')
 if [ "$stale_markers" = "2" ]; then


### PR DESCRIPTION
Propagation of private #959 (squash bfc8c789). auto-arm-on-cap passes through on non-Claude lanes + treats arm-resume dedup as armed; new codex worktree ACL normalizer (ps1 + sh wrapper). 174/174 + 9/9 tests, shellcheck clean, panel CR clean.