### PR TITLE
feat(hermes): [HIMMEL-654] dispatch-trusted.sh — named escape hatch for the external-writes opt-in

### DIFF
--- a/scripts/hermes/dispatch-trusted.sh
+++ b/scripts/hermes/dispatch-trusted.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# scripts/hermes/dispatch-trusted.sh — TRUSTED-engine hermes dispatch with the
+# external-writes opt-in (HERMES_EXTERNAL_WRITES_OK=1) set INSIDE the wrapper.
+#
+# WHY (HIMMEL-654 session-8, operator-directed): a hermes WORKER writing repo
+# files needs the fence opt-in in its launch env, but an inline
+# `HERMES_EXTERNAL_WRITES_OK=1 bash invoke.sh …` is denied by the auto-mode
+# classifier as an unnamed safety-bypass flag. This wrapper is the NAMED
+# escape hatch: the operator authorizes it ONCE with a specific standing
+# allow-rule, after which agents dispatch trusted hermes workers unattended.
+#
+#   Operator setup (one-time; agents cannot self-add rules):
+#     .claude/settings.json → permissions.allow:
+#       "Bash(bash scripts/hermes/dispatch-trusted.sh:*)"
+#
+# SAFETY: this wrapper does NOT relax the fence. parity_guard's
+# _external_writes_allowed() stays fail-closed — an untrusted engine
+# (z.ai / GLM) is refused REGARDLESS of the env var; the opt-in only takes
+# effect on a trusted (codex-class) engine. Defaults to the himmel_agent
+# profile (senior trusted tier) unless the caller passes --profile.
+#
+# Usage: identical to invoke.sh (see scripts/hermes/invoke.sh):
+#   dispatch-trusted.sh [--model <m>] [--profile <p>] [--toolsets <list>]
+#                       [--prompt-file <path>] [--log <path>] [<prompt>|-]
+#
+# Environment:
+#   HERMES_INVOKE   Override the invoke.sh path (tests inject a stub).
+#
+# Bash 3.2 safe (macOS / Git Bash on Windows).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INVOKE="${HERMES_INVOKE:-$SCRIPT_DIR/invoke.sh}"
+
+if [ ! -f "$INVOKE" ]; then
+    echo "dispatch-trusted.sh: invoke chokepoint not found: $INVOKE" >&2
+    exit 2
+fi
+
+# Default to the trusted senior profile unless the caller chose one.
+have_profile=0
+for a in "$@"; do
+    case "$a" in --profile|--profile=*) have_profile=1 ;; esac
+done
+
+if [ "$have_profile" -eq 1 ]; then
+    HERMES_EXTERNAL_WRITES_OK=1 exec bash "$INVOKE" "$@"
+fi
+HERMES_EXTERNAL_WRITES_OK=1 exec bash "$INVOKE" --profile himmel_agent "$@"

--- a/scripts/hermes/test-dispatch-trusted.sh
+++ b/scripts/hermes/test-dispatch-trusted.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Tests for scripts/hermes/dispatch-trusted.sh (HIMMEL-654 escape hatch).
+# Stubs invoke.sh via HERMES_INVOKE; asserts env opt-in + profile defaulting.
+set -uo pipefail
+
+WRAP="$(cd "$(dirname "$0")" && pwd)/dispatch-trusted.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+FAILED=0
+
+check() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then echo "PASS $label"
+    else echo "FAIL $label — expected [$expected], got [$actual]"; FAILED=$((FAILED+1)); fi
+}
+check_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    case "$haystack" in *"$needle"*) echo "PASS $label" ;;
+        *) echo "FAIL $label — missing: $needle | got: $haystack"; FAILED=$((FAILED+1)) ;; esac
+}
+
+# Stub invoke: record env + argv, exit 0.
+STUB="$TMP/invoke-stub.sh"
+cat > "$STUB" <<EOS
+#!/usr/bin/env bash
+printf '%s\n' "WRITES_OK=\${HERMES_EXTERNAL_WRITES_OK:-unset}" > "$TMP/env.out"
+printf '%s\n' "\$@" > "$TMP/args.out"
+exit 0
+EOS
+chmod +x "$STUB"
+
+# T1: opt-in env var reaches the invoke child.
+HERMES_INVOKE="$STUB" bash "$WRAP" "PONG" >/dev/null 2>&1
+check "T1 wrapper exits 0" 0 $?
+check "T1 HERMES_EXTERNAL_WRITES_OK=1 in child env" "WRITES_OK=1" "$(cat "$TMP/env.out")"
+
+# T2: default profile injected when caller passes none.
+check_contains "T2 default --profile himmel_agent injected" "--profile
+himmel_agent" "$(cat "$TMP/args.out")"
+
+# T3: explicit --profile passes through, NOT duplicated.
+HERMES_INVOKE="$STUB" bash "$WRAP" --profile free_junior "PONG" >/dev/null 2>&1
+profile_count=$(grep -c -- "--profile" "$TMP/args.out")
+check "T3 explicit profile not duplicated" "1" "$profile_count"
+check_contains "T3 explicit profile preserved" "free_junior" "$(cat "$TMP/args.out")"
+
+# T4: missing invoke chokepoint -> rc 2, clean error.
+err=$(HERMES_INVOKE="$TMP/nope.sh" bash "$WRAP" "PONG" 2>&1); rc=$?
+check "T4 missing invoke exits 2" 2 "$rc"
+check_contains "T4 names the missing path" "invoke chokepoint not found" "$err"
+
+if [ "$FAILED" -gt 0 ]; then echo "---"; echo "FAIL $FAILED case(s)"; exit 1; fi
+echo "---"; echo "PASS all cases"; exit 0


### PR DESCRIPTION
Propagation of private #963 (squash f0e3e21f). Named wrapper carrying HERMES_EXTERNAL_WRITES_OK=1; operator authorizes once via a specific allow-rule; parity_guard fence unrelaxed. Platforms tested: windows, gitbash / Security reviewed: manual