### PR TITLE
feat(statusline): Task 4.1 - wiring switch to the hud renderer

### DIFF
--- a/docs/internals/harness-compat.md
+++ b/docs/internals/harness-compat.md
@@ -338,7 +338,7 @@ and hook wiring live here, not in `.claude/`.
 
 ### 7. Status context — statusLine is Claude-only (HIMMEL-554)
 
-Claude's `statusLine.command` is wired through `scripts/where-are-we/statusline.sh`;
+Claude's `statusLine.command` is wired to the hud node renderer `marketplace/plugins/claude-hud/dist/index.js` (HIMMEL-718), with the bash bar `scripts/where-are-we/statusline.sh` retained as the rollback fallback;
 Codex has no equivalent visual statusline surface. The Codex port should inject
 the same advisory context through a Codex-native context path (likely
 SessionStart/UserPromptSubmit additional context), not by porting the rendered

--- a/docs/setup/settings-template.json
+++ b/docs/setup/settings-template.json
@@ -67,7 +67,10 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bash \"<himmel-path>/scripts/where-are-we/statusline.sh\""
+    "command": "node \"<himmel-path>/marketplace/plugins/claude-hud/dist/index.js\""
+  },
+  "env": {
+    "CLAUDE_HUD_ALLOW_EXTRA_CMD": "1"
   },
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true,

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -307,7 +307,7 @@ idempotent `scripts/lib/register-auto-arm-hook.sh`. Tests:
 ## claude-statusline (vendored, HIMMEL-331)
 
 **Vendored in himmel:** `scripts/statusline/` (`bin/statusline.sh`, `test/`, `LICENSE`, `README.md`, provenance in `VENDORED.md`).
-**Config:** `~/.claude/settings.json` → `statusLine.command` (machine-setup points it at the himmel wrapper `<himmel-path>/scripts/where-are-we/statusline.sh`, which composes this vendored `bin/statusline.sh` + a where-are-we line — active handover + epic progression, HIMMEL-538; the segment is default-ON since HIMMEL-556 — opt out with an explicit falsy `HIMMEL_WHERE_ARE_WE` (`0|false|off|no`); no external clone).
+**Config:** `~/.claude/settings.json` → `statusLine.command` now points at the hud node renderer (`node "<himmel-path>/marketplace/plugins/claude-hud/dist/index.js"`, wired by `scripts/lib/wire-statusline.sh`; env gate `CLAUDE_HUD_ALLOW_EXTRA_CMD=1`; hud config dropped at `~/.claude/plugins/claude-hud/config.json`). The bash wrapper `<himmel-path>/scripts/where-are-we/statusline.sh` is retained as the rollback fallback that `scripts/lib/unwire-statusline.sh` can repoint to; it composes this vendored `bin/statusline.sh` + a where-are-we line — active handover + epic progression, HIMMEL-538; the segment is default-ON since HIMMEL-556 — opt out with an explicit falsy `HIMMEL_WHERE_ARE_WE` (`0|false|off|no`); no external clone.
 **What:** Bash script receiving Claude Code session JSON via stdin, outputs formatted status bar.
 
 Displays: model, context %, git branch, rate-limit bars (current/weekly/extra), cache TTL countdown, per-session and all-sessions cache read/write/hit/savings.

--- a/scripts/himmel-update.sh
+++ b/scripts/himmel-update.sh
@@ -225,6 +225,60 @@ report_guardrail_block() {
     return 0
 }
 
+
+# ─── statusLine hud migration (HIMMEL-718) ──────────────────────────────────
+# Existing installs wired to the bash bar need one best-effort re-wire after the
+# repo update. Fresh installs already get the hud renderer from setup/adopt.
+rewire_statusline() {
+    local settings="${CLAUDE_USER_SETTINGS:-$HOME/.claude/settings.json}"
+    local match_re='marketplace/plugins/claude-hud/dist/index[.]js|scripts/(statusline/bin/statusline|where-are-we/statusline)[.]sh'
+    local cur lib="$ROOT/scripts/lib/wire-statusline.sh"
+
+    echo ""
+    echo "==> statusLine re-wire (hud migration, HIMMEL-718)"
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "    skip: jq not on PATH (cannot inspect statusLine)."
+        return 0
+    fi
+    if [ ! -f "$settings" ]; then
+        echo "    skip: settings file not found ($settings)."
+        return 0
+    fi
+    if ! jq -e . "$settings" >/dev/null 2>&1; then
+        echo "    skip: settings file is not valid JSON ($settings)."
+        return 0
+    fi
+
+    cur=$(jq -r '.statusLine.command? // ""' "$settings" 2>/dev/null || printf '')
+    # A user who never wired or deliberately unwired must not be re-wired by an
+    # update; only an EXISTING himmel wiring migrates.
+    if ! printf '%s' "$cur" | grep -Eq "$match_re"; then
+        echo "    skip: statusLine not himmel-wired — leaving it alone."
+        return 0
+    fi
+    if [ ! -f "$lib" ]; then
+        echo "    skip: wire-statusline.sh not found ($lib)."
+        return 0
+    fi
+    # The hud renderer is `node …/dist/index.js` — migrating a WORKING bash bar
+    # on a node-less machine would trade it for a silently broken statusLine.
+    # Skip (keeping the bash bar, the stated fallback) instead.
+    if ! command -v node >/dev/null 2>&1; then
+        echo "    skip: node not on PATH — leaving the bash statusLine bar in place."
+        return 0
+    fi
+
+    # shellcheck source=lib/wire-statusline.sh
+    # shellcheck disable=SC1090,SC1091
+    if ! . "$lib"; then
+        echo "    warn: could not load wire-statusline.sh (non-fatal)." >&2
+        return 0
+    fi
+    if ! wire_statusline "$settings" "$ROOT"; then
+        echo "    warn: statusLine re-wire failed (non-fatal) — run bash scripts/lib/wire-statusline.sh manually if needed." >&2
+    fi
+    return 0
+}
 # Test seam: source with HIMMEL_UPDATE_LIB=1 to load the functions above without
 # running any update mode (lets test-himmel-update-hermes.sh call update_hermes
 # directly with HERMES_HOME fixtures — no network, no repo mutation).
@@ -298,16 +352,21 @@ fi
 #    repo — see update_hermes). Best-effort; skips cleanly when hermes is absent.
 update_hermes apply
 
-# 4. Report any himmel-marketplace plugins not installed from @himmel — the
+# 4. Re-wire existing himmel statusLine installs to the hud renderer. Fresh
+#    installs already get hud via setup/adopt; update previously had the rollout
+#    gap for users still wired to the bash bar. Advisory; never fails the update.
+rewire_statusline
+
+# 5. Report any himmel-marketplace plugins not installed from @himmel — the
 #    marketplace re-sync above can't surface these (it only touches plugins that
 #    are already installed). Advisory; never fails the update.
 report_plugin_gap
 
-# 5. Nudge if an armed pipeline-cadence is firing pre-change (stale) runners
+# 6. Nudge if an armed pipeline-cadence is firing pre-change (stale) runners
 #    that this pull's code won't regenerate on its own (HIMMEL-588). Advisory.
 report_cadence_stale
 
-# 6. Check the himmel-owned guardrail-mode block for baked-path drift (HIMMEL-709).
+# 7. Check the himmel-owned guardrail-mode block for baked-path drift (HIMMEL-709).
 #    Advisory; never mutates ~/.claude/settings.json.
 report_guardrail_block
 

--- a/scripts/lib/test-setup-wire.sh
+++ b/scripts/lib/test-setup-wire.sh
@@ -48,9 +48,12 @@ check "abs path used"        "$(jq -r '[.hooks.PreToolUse[].hooks[].command | se
 # SC1: pre-existing non-himmel entries preserved.
 check "rtk guard preserved"  "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("rtk-hook-guard"))] | length' "$s")" "1"
 check "SessionStart sibling preserved" "$(jq -r '[.hooks.SessionStart[].hooks[].command | select(test("check-update-available"))] | length' "$s")" "1"
-# SC1: statusline + HIMMEL_REPO set.
+# SC1: statusline + HIMMEL_REPO set. The hud extra-cmd gate (wired by
+# wire_statusline) coexists with env.HIMMEL_REPO (wired by wire_himmel_repo),
+# proving the two env merges are non-destructive across the [9/10] sequence.
 check "statusLine set"  "$(jq -r '.statusLine.type' "$s")" "command"
 check "HIMMEL_REPO set" "$(jq -r '.env.HIMMEL_REPO' "$s")" "C:/Users/op/himmel"
+check "extra-cmd gate set" "$(jq -r '.env.CLAUDE_HUD_ALLOW_EXTRA_CMD' "$s")" "1"
 
 # SC8: re-run with a CHANGED clone path → exactly one of each (basename dedup).
 wire_all "$s" "C:/Users/op/himmel-moved"

--- a/scripts/lib/test-unwire-singlekey.ps1
+++ b/scripts/lib/test-unwire-singlekey.ps1
@@ -26,11 +26,27 @@ Remove-Statusline -SettingsPath $s | Out-Null
 Check 'statusLine removed'      (JqVal $s 'has("statusLine")') 'false'
 Check 'statusLine sibling kept' (JqVal $s '.env.X') '1'
 
-# 2. non-himmel statusLine left untouched.
+# 1c. removes the NEW hud renderer command too (HIMMEL-718) -- single-arg = REMOVE.
+$s = Join-Path $td 'sl1c.json'
+'{"statusLine":{"type":"command","command":"node \"C:/h/marketplace/plugins/claude-hud/dist/index.js\""},"env":{"CLAUDE_HUD_ALLOW_EXTRA_CMD":"1"}}' | Set-Content $s -Encoding utf8
+Remove-Statusline -SettingsPath $s | Out-Null
+Check 'hud statusLine removed' (JqVal $s 'has("statusLine")') 'false'
+
+# 1d. WITH -HimmelPath -> REPOINT to the bash-bar fallback (HIMMEL-718 rollback);
+#     the extra-cmd gate is left in place.
+$s = Join-Path $td 'sl1d.json'
+'{"statusLine":{"type":"command","command":"node \"C:/h/marketplace/plugins/claude-hud/dist/index.js\""},"env":{"CLAUDE_HUD_ALLOW_EXTRA_CMD":"1"}}' | Set-Content $s -Encoding utf8
+Remove-Statusline -SettingsPath $s -HimmelPath 'C:/h' | Out-Null
+Check 'repointed to bash bar' (JqVal $s '.statusLine.command') 'bash "C:/h/scripts/where-are-we/statusline.sh"'
+Check 'repoint keeps gate'    (JqVal $s '.env.CLAUDE_HUD_ALLOW_EXTRA_CMD') '1'
+
+# 2. non-himmel statusLine left untouched (both remove and repoint modes).
 $s = Join-Path $td 'sl2.json'
 '{"statusLine":{"type":"command","command":"bash /opt/my-own-statusline.sh"}}' | Set-Content $s -Encoding utf8
 Remove-Statusline -SettingsPath $s | Out-Null
 Check 'custom statusLine preserved' (JqVal $s '.statusLine.command') 'bash /opt/my-own-statusline.sh'
+Remove-Statusline -SettingsPath $s -HimmelPath 'C:/h' | Out-Null
+Check 'custom statusLine preserved (repoint mode)' (JqVal $s '.statusLine.command') 'bash /opt/my-own-statusline.sh'
 
 # 3. himmel-repo: removes key, preserves siblings.
 $s = Join-Path $td 'hr1.json'

--- a/scripts/lib/test-unwire-singlekey.sh
+++ b/scripts/lib/test-unwire-singlekey.sh
@@ -25,11 +25,32 @@ s="$td/sl1b.json"
 printf '%s' '{"statusLine":{"type":"command","command":"bash \"C:/h/scripts/where-are-we/statusline.sh\""},"env":{"X":"1"}}' > "$s"
 bash "$sl" "$s" >/dev/null
 check "wrapper statusLine removed" "$(jq -r 'has("statusLine")' "$s")" "false"
-# 2. a NON-himmel custom statusLine is left untouched.
+# 1c. removes the NEW hud renderer command too (marketplace/.../claude-hud/dist/index.js;
+#     HIMMEL-718) -- single-arg = REMOVE, so uninstall clears a hud-wired statusLine.
+s="$td/sl1c.json"
+printf '%s' '{"statusLine":{"type":"command","command":"node \"C:/h/marketplace/plugins/claude-hud/dist/index.js\""},"env":{"CLAUDE_HUD_ALLOW_EXTRA_CMD":"1"}}' > "$s"
+bash "$sl" "$s" >/dev/null
+check "hud statusLine removed" "$(jq -r 'has("statusLine")' "$s")" "false"
+# 1d. WITH a himmel path -> REPOINT to the bash-bar fallback (HIMMEL-718 migration
+#     rollback); the extra-cmd gate is deliberately left in place.
+s="$td/sl1d.json"
+printf '%s' '{"statusLine":{"type":"command","command":"node \"C:/h/marketplace/plugins/claude-hud/dist/index.js\""},"env":{"CLAUDE_HUD_ALLOW_EXTRA_CMD":"1"}}' > "$s"
+bash "$sl" "$s" "C:/h" >/dev/null
+check "repointed to bash bar" "$(jq -r '.statusLine.command' "$s")" 'bash "C:/h/scripts/where-are-we/statusline.sh"'
+check "repoint keeps type"    "$(jq -r '.statusLine.type' "$s")" "command"
+check "repoint keeps gate"    "$(jq -r '.env.CLAUDE_HUD_ALLOW_EXTRA_CMD' "$s")" "1"
+# 1e. backslash himmel path normalized on repoint.
+s="$td/sl1e.json"
+printf '%s' '{"statusLine":{"type":"command","command":"node \"C:/h/marketplace/plugins/claude-hud/dist/index.js\""}}' > "$s"
+bash "$sl" "$s" 'C:\h' >/dev/null
+check "repoint backslash normalized" "$(jq -r '.statusLine.command' "$s")" 'bash "C:/h/scripts/where-are-we/statusline.sh"'
+# 2. a NON-himmel custom statusLine is left untouched (both remove and repoint modes).
 s="$td/sl2.json"
 printf '%s' '{"statusLine":{"type":"command","command":"bash /opt/my-own-statusline.sh"}}' > "$s"
 bash "$sl" "$s" >/dev/null
 check "custom statusLine preserved" "$(jq -r '.statusLine.command' "$s")" "bash /opt/my-own-statusline.sh"
+bash "$sl" "$s" "C:/h" >/dev/null
+check "custom statusLine preserved (repoint mode)" "$(jq -r '.statusLine.command' "$s")" "bash /opt/my-own-statusline.sh"
 
 # ── unwire-himmel-repo ──────────────────────────────────────────────────────
 # 3. removes HIMMEL_REPO, preserves sibling env keys.

--- a/scripts/lib/test-wire-statusline.ps1
+++ b/scripts/lib/test-wire-statusline.ps1
@@ -1,10 +1,13 @@
-# Hermetic test for wire-statusline.ps1 (HIMMEL-359). Temp dir only, no network.
-# Mirrors test-wire-statusline.sh so the bash/PowerShell twins stay in parity —
-# in particular case 5 pins the invalid-JSON exit code (the bug the CR caught:
-# Write-Error+return exited 0, masking the refusal from -File callers).
+# Hermetic test for wire-statusline.ps1 (HIMMEL-359 / HIMMEL-718). Temp dir only,
+# no network. Mirrors test-wire-statusline.sh so the bash/PowerShell twins stay in
+# parity -- HIMMEL-718 Task 4.1 switched the command to the hud renderer (node),
+# added the .env extra-cmd gate, and drops the hud config. Case 5 pins the
+# invalid-JSON exit code (the bug the CR caught: Write-Error+return exited 0,
+# masking the refusal from -File callers).
 $ErrorActionPreference = 'Stop'
 $here   = Split-Path -Parent $MyInvocation.MyCommand.Path
 $helper = Join-Path $here 'wire-statusline.ps1'
+$repoRoot = (Resolve-Path (Join-Path $here '..\..')).Path.Replace('\', '/')
 $tmp    = Join-Path ([IO.Path]::GetTempPath()) ("twsl-" + [guid]::NewGuid())
 New-Item -ItemType Directory -Force $tmp | Out-Null
 $script:fail = 0
@@ -17,16 +20,18 @@ function Wire([string]$path, [string]$himmel) {
     return $LASTEXITCODE
 }
 
-# 1 fresh file + backslash path normalized
+# 1 fresh file + backslash path normalized + extra-cmd gate
 Wire "$tmp\s1.json" 'C:\fake\himmel' | Out-Null
 $s1 = Get-Content "$tmp\s1.json" -Raw | ConvertFrom-Json
-Check ($s1.statusLine.command -eq 'bash "C:/fake/himmel/scripts/where-are-we/statusline.sh"') "1 fresh+backslash-normalized"
+Check ($s1.statusLine.command -eq 'node "C:/fake/himmel/marketplace/plugins/claude-hud/dist/index.js"') "1 fresh+backslash-normalized"
+Check ($s1.env.CLAUDE_HUD_ALLOW_EXTRA_CMD -eq '1') "1b extra-cmd gate set"
 
-# 2 existing keys preserved
-'{"theme":"dark"}' | Set-Content "$tmp\s2.json"
+# 2 existing keys preserved incl. pre-existing .env keys (non-destructive merge)
+'{"theme":"dark","env":{"CR_PROFILE":"paid"}}' | Set-Content "$tmp\s2.json"
 Wire "$tmp\s2.json" 'C:\fake\himmel' | Out-Null
 $s2 = Get-Content "$tmp\s2.json" -Raw | ConvertFrom-Json
 Check ($s2.theme -eq 'dark' -and $s2.statusLine.type -eq 'command') "2 existing keys preserved"
+Check ($s2.env.CR_PROFILE -eq 'paid' -and $s2.env.CLAUDE_HUD_ALLOW_EXTRA_CMD -eq '1') "2b env merged non-destructively"
 
 # 3 idempotent
 Wire "$tmp\s3.json" 'C:\fake\himmel' | Out-Null
@@ -45,6 +50,20 @@ Check ($s4.statusLine.type -eq 'command') "4 empty file handled"
 $rc = Wire "$tmp\s5.json" 'C:\fake\himmel'
 Check ($rc -ne 0) "5a invalid json exits non-zero"
 Check ((Get-Content "$tmp\s5.json" -Raw).Trim() -eq '{not valid') "5b invalid json not clobbered"
+
+# 6 hud config dropped next to settings.json with <himmel-path> SUBSTITUTED.
+# Uses the REAL himmel clone so the source himmel-config.json exists.
+$sdir = Join-Path $tmp 'cfgdrop'
+Wire (Join-Path $sdir 'settings.json') $repoRoot | Out-Null
+$dropped = Join-Path $sdir 'plugins/claude-hud/config.json'
+Check (Test-Path $dropped) "6a hud config dropped"
+if (Test-Path $dropped) {
+    $body = Get-Content $dropped -Raw
+    Check (-not ($body -match '<himmel-path>')) "6b placeholder substituted"
+    Check ($body.Contains($repoRoot)) "6c real himmel path substituted"
+    $sj = Get-Content (Join-Path $sdir 'settings.json') -Raw | ConvertFrom-Json
+    Check ($sj.statusLine.command -eq "node `"$repoRoot/marketplace/plugins/claude-hud/dist/index.js`"") "6d command node w/ real path"
+}
 
 Get-ChildItem $tmp -Recurse | Remove-Item -Force -Recurse
 Remove-Item $tmp -Force

--- a/scripts/lib/test-wire-statusline.sh
+++ b/scripts/lib/test-wire-statusline.sh
@@ -1,23 +1,29 @@
 #!/usr/bin/env bash
-# Hermetic test for wire-statusline.sh (HIMMEL-359). No network, temp dir only.
+# Hermetic test for wire-statusline.sh (HIMMEL-359 / HIMMEL-718). No network,
+# temp dir only. HIMMEL-718 Task 4.1 switched the command to the hud renderer
+# (node) + added the .env extra-cmd gate + the dropped hud config.
 set -euo pipefail
 HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 HELPER="$HERE/wire-statusline.sh"
+REPO_ROOT="$(cd -- "$HERE/../.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
-# 1. fresh file gets a valid statusLine
+# 1. fresh file gets a valid hud statusLine + the extra-cmd gate.
 bash "$HELPER" "$TMP/s1.json" "/c/Users/me/himmel" >/dev/null
 [ "$(jq -r .statusLine.type "$TMP/s1.json")" = "command" ] || fail "fresh type"
-[ "$(jq -r .statusLine.command "$TMP/s1.json")" = 'bash "/c/Users/me/himmel/scripts/where-are-we/statusline.sh"' ] || fail "fresh command"
+[ "$(jq -r .statusLine.command "$TMP/s1.json")" = 'node "/c/Users/me/himmel/marketplace/plugins/claude-hud/dist/index.js"' ] || fail "fresh command"
+[ "$(jq -r .env.CLAUDE_HUD_ALLOW_EXTRA_CMD "$TMP/s1.json")" = "1" ] || fail "extra-cmd gate set"
 echo "ok 1 fresh file"
 
-# 2. existing keys preserved
-echo '{"theme":"dark","hooks":{"PreToolUse":[1]}}' > "$TMP/s2.json"
+# 2. existing keys preserved, incl. pre-existing .env keys (non-destructive merge)
+echo '{"theme":"dark","hooks":{"PreToolUse":[1]},"env":{"CR_PROFILE":"paid"}}' > "$TMP/s2.json"
 bash "$HELPER" "$TMP/s2.json" "/c/Users/me/himmel" >/dev/null
 [ "$(jq -r .theme "$TMP/s2.json")" = "dark" ] || fail "theme preserved"
 [ "$(jq -r '.hooks.PreToolUse[0]' "$TMP/s2.json")" = "1" ] || fail "hooks preserved"
+[ "$(jq -r .env.CR_PROFILE "$TMP/s2.json")" = "paid" ] || fail "pre-existing env key preserved"
+[ "$(jq -r .env.CLAUDE_HUD_ALLOW_EXTRA_CMD "$TMP/s2.json")" = "1" ] || fail "extra-cmd gate merged"
 [ "$(jq -r .statusLine.type "$TMP/s2.json")" = "command" ] || fail "statusLine added"
 echo "ok 2 existing keys preserved"
 
@@ -30,7 +36,7 @@ echo "ok 3 idempotent"
 
 # 4. backslash himmel path normalized to forward slashes
 bash "$HELPER" "$TMP/s4.json" 'C:\Users\me\himmel' >/dev/null
-[ "$(jq -r .statusLine.command "$TMP/s4.json")" = 'bash "C:/Users/me/himmel/scripts/where-are-we/statusline.sh"' ] || fail "backslash normalize"
+[ "$(jq -r .statusLine.command "$TMP/s4.json")" = 'node "C:/Users/me/himmel/marketplace/plugins/claude-hud/dist/index.js"' ] || fail "backslash normalize"
 echo "ok 4 backslash normalized"
 
 # 5. overwrites a stale statusLine (authoritative)
@@ -63,5 +69,23 @@ echo "ok 8 whitespace-only handled"
 bash "$HELPER" "$TMP/nested/deep/s9.json" "/c/Users/me/himmel" >/dev/null
 [ "$(jq -r .statusLine.type "$TMP/nested/deep/s9.json")" = "command" ] || fail "nested dir not created"
 echo "ok 9 nested parent dir created"
+
+# 10. hud config dropped next to settings.json with <himmel-path> SUBSTITUTED.
+# Uses the REAL himmel clone so the source himmel-config.json exists.
+sdir="$TMP/cfgdrop"
+bash "$HELPER" "$sdir/settings.json" "$REPO_ROOT" >/dev/null
+dropped="$sdir/plugins/claude-hud/config.json"
+[ -f "$dropped" ] || fail "hud config not dropped"
+jq -e . "$dropped" >/dev/null 2>&1 || fail "dropped config not valid JSON"
+grep -q '<himmel-path>' "$dropped" && fail "placeholder <himmel-path> left in dropped config"
+grep -qF "$REPO_ROOT" "$dropped" || fail "real himmel path not substituted into dropped config"
+[ "$(jq -r .statusLine.command "$sdir/settings.json")" = "node \"$REPO_ROOT/marketplace/plugins/claude-hud/dist/index.js\"" ] || fail "command not node w/ real path"
+echo "ok 10 hud config dropped + substituted"
+
+# 11. config drop is idempotent too (deterministic)
+B="$(cat "$dropped")"
+bash "$HELPER" "$sdir/settings.json" "$REPO_ROOT" >/dev/null
+[ "$B" = "$(cat "$dropped")" ] || fail "config drop not idempotent"
+echo "ok 11 config drop idempotent"
 
 echo "ALL PASS"

--- a/scripts/lib/unwire-statusline.ps1
+++ b/scripts/lib/unwire-statusline.ps1
@@ -1,34 +1,54 @@
 # unwire-statusline.ps1 -- PowerShell counterpart of unwire-statusline.sh.
-# Removes .statusLine from a Claude Code settings.json ONLY when it points at the
-# himmel statusline binary (a user's own statusLine is left untouched). Shells out
-# to jq for byte-parity with the bash twin.
+# Rolls back .statusLine in a Claude Code settings.json ONLY when it points at a
+# himmel statusLine -- the hud renderer (marketplace/plugins/claude-hud/dist/index.js;
+# HIMMEL-718), the where-are-we wrapper (HIMMEL-538), or the older vendored bar.
+# A user's own statusLine is left untouched. Shells out to jq for byte-parity
+# with the bash twin.
 #
-#   Remove-Statusline -SettingsPath <path>
-# Direct:  pwsh -File unwire-statusline.ps1 -SettingsPath <path>
+#   Remove-Statusline -SettingsPath <path> [-HimmelPath <path>]
+# Direct:  pwsh -File unwire-statusline.ps1 -SettingsPath <path> [-HimmelPath <path>]
+#
+# With -HimmelPath -> REPOINT .statusLine.command to the bash-bar fallback
+#   (HIMMEL-718 migration rollback). Without it -> REMOVE .statusLine (uninstall).
 
 [CmdletBinding()]
-param([string]$SettingsPath)
+param([string]$SettingsPath, [string]$HimmelPath)
 
 function Remove-Statusline {
-    param([Parameter(Mandatory = $true)][string]$SettingsPath)
+    param(
+        [Parameter(Mandatory = $true)][string]$SettingsPath,
+        [string]$HimmelPath
+    )
     if (-not (Get-Command jq -ErrorAction SilentlyContinue)) { throw "unwire-statusline: jq required" }
     if (-not (Test-Path $SettingsPath)) { return }
     $raw = Get-Content $SettingsPath -Raw
     if ([string]::IsNullOrWhiteSpace($raw)) { return }
     $raw | jq -e . > $null 2>&1
     if ($LASTEXITCODE -ne 0) { throw "unwire-statusline: $SettingsPath is not valid JSON -- refusing to modify" }
-    # Match either the himmel wrapper (scripts/where-are-we/statusline.sh,
-    # HIMMEL-538) or the older vendored path — both are the himmel statusLine.
-    $filter = 'if ((.statusLine.command? // "") | test("scripts/(statusline/bin/statusline|where-are-we/statusline)[.]sh")) then del(.statusLine) else . end'
-    $out = $raw | jq --indent 2 $filter
+    # Matches the himmel statusLine in any of its shapes; a user's own custom
+    # statusLine matches none and is left alone.
+    $matchRe = 'marketplace/plugins/claude-hud/dist/index[.]js|scripts/(statusline/bin/statusline|where-are-we/statusline)[.]sh'
+    if ($HimmelPath) {
+        $himmelFwd = $HimmelPath.Replace('\', '/')
+        $cmd = "bash `"$himmelFwd/scripts/where-are-we/statusline.sh`""
+        $filter = 'if ((.statusLine.command? // "") | test($re)) then .statusLine.command = $cmd else . end'
+        $out = $raw | jq --indent 2 --arg re $matchRe --arg cmd $cmd $filter
+    } else {
+        $filter = 'if ((.statusLine.command? // "") | test($re)) then del(.statusLine) else . end'
+        $out = $raw | jq --indent 2 --arg re $matchRe $filter
+    }
     if ($LASTEXITCODE -ne 0) { throw "unwire-statusline: jq transform failed" }
     $tmp = "$SettingsPath.unwiresl.tmp"
     # UTF-8 without BOM (HIMMEL-365/408): Set-Content -Encoding utf8 BOMs on PS 5.1.
     [System.IO.File]::WriteAllText($tmp, ($out -join "`n") + "`n")
     Move-Item -Path $tmp -Destination $SettingsPath -Force
-    Write-Host "  removed himmel statusLine (if present) -> $SettingsPath"
+    if ($HimmelPath) {
+        Write-Host "  repointed himmel statusLine to bash-bar fallback (if present) -> $SettingsPath"
+    } else {
+        Write-Host "  removed himmel statusLine (if present) -> $SettingsPath"
+    }
 }
 
 if ($SettingsPath) {
-    try { Remove-Statusline -SettingsPath $SettingsPath } catch { Write-Error $_; exit 1 }
+    try { Remove-Statusline -SettingsPath $SettingsPath -HimmelPath $HimmelPath } catch { Write-Error $_; exit 1 }
 }

--- a/scripts/lib/unwire-statusline.sh
+++ b/scripts/lib/unwire-statusline.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
-# unwire-statusline.sh -- remove the himmel statusLine from a Claude Code
+# unwire-statusline.sh -- roll back the himmel statusLine in a Claude Code
 # settings.json (the inverse of wire-statusline.sh; HIMMEL install/uninstall
-# symmetry). Removes .statusLine ONLY when it points at the himmel statusline
-# binary -- a user's own custom statusLine is left untouched.
+# symmetry). Acts ONLY when .statusLine points at a himmel statusLine -- the hud
+# renderer (marketplace/plugins/claude-hud/dist/index.js; HIMMEL-718), the
+# where-are-we wrapper (HIMMEL-538), or the older vendored bar -- a user's own
+# custom statusLine is left untouched.
 #
 # Usage:
-#   bash unwire-statusline.sh <settings-json-path>
+#   bash unwire-statusline.sh <settings-json-path> [himmel-path]
+#
+# With a himmel path -> REPOINT .statusLine.command to the bash-bar fallback
+#   (bash "<himmel>/scripts/where-are-we/statusline.sh"; the HIMMEL-718 migration
+#   rollback -- the .env.CLAUDE_HUD_ALLOW_EXTRA_CMD gate is left in place, being
+#   harmless when the bash bar renders).
+# Without a himmel path -> REMOVE .statusLine entirely (the uninstall path).
 #
 # Idempotent (absent key / absent file -> no-op), atomic (temp file + mv),
 # refuses invalid JSON, preserves all sibling keys. Requires jq. Source it to
@@ -13,7 +21,7 @@
 set -euo pipefail
 
 unwire_statusline() {
-  local settings="$1"
+  local settings="$1" himmel="${2:-}"
   command -v jq >/dev/null 2>&1 || { echo "unwire-statusline: jq required" >&2; return 1; }
   [ -f "$settings" ] || return 0
   local base
@@ -23,18 +31,31 @@ unwire_statusline() {
     echo "unwire-statusline: $settings is not valid JSON -- refusing to modify" >&2
     return 1
   fi
-  # Match either the himmel wrapper (scripts/where-are-we/statusline.sh,
-  # HIMMEL-538) or the older vendored path (scripts/statusline/bin/statusline.sh,
-  # for sessions wired before the wrapper landed) — both are "the himmel
-  # statusLine". A user's own custom statusLine matches neither and is left alone.
-  printf '%s' "$base" | jq '
-    if ((.statusLine.command? // "") | test("scripts/(statusline/bin/statusline|where-are-we/statusline)[.]sh"))
-    then del(.statusLine) else . end
-  ' > "$settings.unwiresl.tmp" && mv "$settings.unwiresl.tmp" "$settings"
-  echo "  removed himmel statusLine (if present) -> $settings"
+  # Matches the himmel statusLine in any of its shapes; a user's own custom
+  # statusLine matches none and is left alone.
+  local match_re='marketplace/plugins/claude-hud/dist/index[.]js|scripts/(statusline/bin/statusline|where-are-we/statusline)[.]sh'
+  if [ -n "$himmel" ]; then
+    local himmel_fwd="${himmel//\\//}"
+    local cmd="bash \"${himmel_fwd}/scripts/where-are-we/statusline.sh\""
+    printf '%s' "$base" | jq --arg re "$match_re" --arg cmd "$cmd" '
+      if ((.statusLine.command? // "") | test($re))
+      then .statusLine.command = $cmd else . end
+    ' > "$settings.unwiresl.tmp" || { rm -f "$settings.unwiresl.tmp"; return 1; }
+    mv "$settings.unwiresl.tmp" "$settings" || return 1
+    echo "  repointed himmel statusLine to bash-bar fallback (if present) -> $settings"
+  else
+    printf '%s' "$base" | jq --arg re "$match_re" '
+      if ((.statusLine.command? // "") | test($re))
+      then del(.statusLine) else . end
+    ' > "$settings.unwiresl.tmp" || { rm -f "$settings.unwiresl.tmp"; return 1; }
+    mv "$settings.unwiresl.tmp" "$settings" || return 1
+    echo "  removed himmel statusLine (if present) -> $settings"
+  fi
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
-  [ "$#" -eq 1 ] || { echo "usage: unwire-statusline.sh <settings-json-path>" >&2; exit 2; }
-  unwire_statusline "$1"
+  if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    echo "usage: unwire-statusline.sh <settings-json-path> [himmel-path]" >&2; exit 2
+  fi
+  unwire_statusline "$1" "${2:-}"
 fi

--- a/scripts/lib/wire-statusline.ps1
+++ b/scripts/lib/wire-statusline.ps1
@@ -6,10 +6,13 @@
 # Dot-source to get Set-HimmelStatusLine, or invoke directly:
 #   pwsh -File wire-statusline.ps1 -SettingsPath <path> -HimmelPath <path>
 #
-# Sets .statusLine = { type: "command",
-#   command: 'bash "<himmel>/scripts/where-are-we/statusline.sh"' }
-# (the himmel wrapper composes the VENDORED scripts/statusline/bin/statusline.sh
-#  with the where-are-we segment — active handover + epic progression; HIMMEL-538)
+# Does THREE things (HIMMEL-718 Task 4.1 — the wiring switch to the forked
+# claude-hud renderer; the vendored bash bar is RETAINED as fallback):
+#   1. .statusLine = { type: "command",
+#        command: 'node "<himmel>/marketplace/plugins/claude-hud/dist/index.js"' }
+#   2. .env.CLAUDE_HUD_ALLOW_EXTRA_CMD = "1"  (merged, other env keys preserved)
+#   3. Drops the hud config (himmel-config.json with <himmel-path> substituted)
+#      to <settings-dir>/plugins/claude-hud/config.json.
 # Idempotent, atomic (temp + move), non-destructive (other keys preserved;
 # file + parent dir created if absent). Normalizes JSON through `jq --indent 2`
 # when jq is on PATH (matches win11.ps1's Write-SettingsJson), else falls back
@@ -27,9 +30,12 @@ function Set-HimmelStatusLine {
         [Parameter(Mandatory = $true)] [string]$HimmelPath
     )
 
-    # Forward-slash the himmel path so the `bash "..."` command is valid.
+    # Forward-slash the himmel path so the `node "..."` command is valid.
     $himmelFwd = $HimmelPath.Replace('\', '/')
-    $cmd = "bash `"$himmelFwd/scripts/where-are-we/statusline.sh`""
+    $cmd = "node `"$himmelFwd/marketplace/plugins/claude-hud/dist/index.js`""
+
+    $settingsDir = Split-Path $SettingsPath -Parent
+    if (-not $settingsDir) { $settingsDir = '.' }
 
     if (Test-Path $SettingsPath) {
         $raw = Get-Content $SettingsPath -Raw
@@ -49,18 +55,26 @@ function Set-HimmelStatusLine {
             }
         }
     } else {
-        # Split-Path returns '' for a bare filename with no directory — guard so
-        # New-Item is not handed an empty path.
-        $dir = Split-Path $SettingsPath
-        if ($dir) { New-Item -ItemType Directory -Force $dir | Out-Null }
+        New-Item -ItemType Directory -Force $settingsDir | Out-Null
         $cfg = [pscustomobject]@{}
     }
 
+    # (1) statusLine → hud renderer.
     $statusLine = [pscustomobject]@{ type = 'command'; command = $cmd }
     if ($cfg.PSObject.Properties['statusLine']) {
         $cfg.statusLine = $statusLine
     } else {
         $cfg | Add-Member -NotePropertyName statusLine -NotePropertyValue $statusLine -Force
+    }
+
+    # (2) Merge the extra-cmd gate into .env, preserving every other env key.
+    if (-not $cfg.PSObject.Properties['env']) {
+        $cfg | Add-Member -NotePropertyName env -NotePropertyValue ([pscustomobject]@{}) -Force
+    }
+    if ($cfg.env.PSObject.Properties['CLAUDE_HUD_ALLOW_EXTRA_CMD']) {
+        $cfg.env.CLAUDE_HUD_ALLOW_EXTRA_CMD = '1'
+    } else {
+        $cfg.env | Add-Member -NotePropertyName CLAUDE_HUD_ALLOW_EXTRA_CMD -NotePropertyValue '1' -Force
     }
 
     $json = $cfg | ConvertTo-Json -Depth 20
@@ -70,6 +84,21 @@ function Set-HimmelStatusLine {
     }
     Set-Content -Path "$SettingsPath.new" -Value $json -Encoding utf8
     Move-Item -Path "$SettingsPath.new" -Destination $SettingsPath -Force
+
+    # (3) Drop the hud config next to settings.json, substituting this clone's
+    # path for the <himmel-path> placeholder. Guarded on the source existing so
+    # tests wiring against a synthetic himmel path stay a pure statusLine/env op.
+    $hudSrc = "$himmelFwd/marketplace/plugins/claude-hud/config/himmel-config.json"
+    if (Test-Path $hudSrc) {
+        $hudDir = Join-Path $settingsDir 'plugins/claude-hud'
+        New-Item -ItemType Directory -Force $hudDir | Out-Null
+        $hudCfg = (Get-Content $hudSrc -Raw).Replace('<himmel-path>', $himmelFwd).Replace("`r`n", "`n")
+        $hudPath = Join-Path $hudDir 'config.json'
+        $hudTmp = "$hudPath.tmp"
+        # UTF-8 without BOM; single trailing LF (matches the bash twin's printf).
+        [System.IO.File]::WriteAllText($hudTmp, $hudCfg.TrimEnd("`n") + "`n")
+        Move-Item -Path $hudTmp -Destination $hudPath -Force
+    }
     Write-Host "  wired statusLine → $SettingsPath"
 }
 

--- a/scripts/lib/wire-statusline.sh
+++ b/scripts/lib/wire-statusline.sh
@@ -7,28 +7,34 @@
 # Usage:
 #   bash wire-statusline.sh <settings-json-path> <himmel-path>
 #
-# Sets:
-#   .statusLine = { type: "command",
-#                   command: "bash \"<himmel>/scripts/where-are-we/statusline.sh\"" }
-# The himmel wrapper composes the VENDORED scripts/statusline/bin/statusline.sh
-# with the where-are-we segment (active handover + epic progression; HIMMEL-538).
+# Does THREE things (HIMMEL-718 Task 4.1 — the wiring switch to the forked
+# claude-hud renderer; the vendored bash bar is RETAINED as fallback):
+#   1. .statusLine = { type: "command",
+#                      command: "node \"<himmel>/marketplace/plugins/claude-hud/dist/index.js\"" }
+#   2. .env.CLAUDE_HUD_ALLOW_EXTRA_CMD = "1"  (merged, preserving other env keys)
+#      — activates hud's customLineCommand extra-cmd gate.
+#   3. Drops the hud config: reads
+#      marketplace/plugins/claude-hud/config/himmel-config.json from the himmel
+#      clone, substitutes every <himmel-path> with this clone's path, and writes
+#      it to <settings-dir>/plugins/claude-hud/config.json (the config-path
+#      ${CLAUDE_CONFIG_DIR:-~/.claude}/plugins/claude-hud/config.json).
 #
-# Idempotent (re-setting the same value is a no-op), atomic (temp file + mv),
-# and non-destructive (all other keys preserved; file + parent dir created if
-# absent). Requires jq. The statusline binary is referenced by absolute path —
-# it is vendored in the himmel clone, never copied per-repo.
+# Idempotent (re-running yields the same result), atomic (temp file + mv), and
+# non-destructive (all other keys / all other env keys preserved; file + parent
+# dir created if absent). Requires jq. Paths are forward-slashed.
 set -euo pipefail
 
 wire_statusline() {
   local settings="$1" himmel="$2"
   command -v jq >/dev/null 2>&1 || { echo "wire-statusline: jq required" >&2; return 1; }
 
-  # Forward-slash the himmel path so the `bash "..."` command is valid even
+  # Forward-slash the himmel path so the `node "..."` command is valid even
   # when a caller passes a Windows backslash path (Git Bash tolerates /c/... ).
   local himmel_fwd="${himmel//\\//}"
-  local cmd="bash \"${himmel_fwd}/scripts/where-are-we/statusline.sh\""
+  local cmd="node \"${himmel_fwd}/marketplace/plugins/claude-hud/dist/index.js\""
 
-  mkdir -p "$(dirname "$settings")"
+  local settings_dir; settings_dir="$(dirname "$settings")"
+  mkdir -p "$settings_dir"
   local base="{}"
   if [ -s "$settings" ]; then
     base=$(cat "$settings")
@@ -42,9 +48,30 @@ wire_statusline() {
     fi
   fi
 
+  # (1) statusLine → hud renderer, (2) merge the extra-cmd gate into .env
+  # (creating .env if absent, preserving every other env key). Fail LOUD on a
+  # failed transform/write: a bare `… && mv` swallows the failure when the
+  # caller runs us in an `if !` / errexit-exempt context and would report a
+  # successful wire that never happened.
   printf '%s' "$base" | jq --arg cmd "$cmd" \
-    '.statusLine = { type: "command", command: $cmd }' \
-    > "$settings.statusline.tmp" && mv "$settings.statusline.tmp" "$settings"
+    '.statusLine = { type: "command", command: $cmd }
+     | .env.CLAUDE_HUD_ALLOW_EXTRA_CMD = "1"' \
+    > "$settings.statusline.tmp" || { rm -f "$settings.statusline.tmp"; return 1; }
+  mv "$settings.statusline.tmp" "$settings" || return 1
+
+  # (3) Drop the hud config next to settings.json, substituting this clone's
+  # path for the <himmel-path> placeholder. Guarded on the source existing so
+  # tests wiring against a synthetic himmel path stay a pure statusLine/env op.
+  local hud_src="${himmel_fwd}/marketplace/plugins/claude-hud/config/himmel-config.json"
+  if [ -f "$hud_src" ]; then
+    local hud_dir="$settings_dir/plugins/claude-hud"
+    mkdir -p "$hud_dir"
+    local hud_cfg; hud_cfg="$(cat "$hud_src")"
+    hud_cfg="${hud_cfg//<himmel-path>/$himmel_fwd}"
+    printf '%s\n' "$hud_cfg" > "$hud_dir/config.json.tmp" \
+      || { rm -f "$hud_dir/config.json.tmp"; return 1; }
+    mv "$hud_dir/config.json.tmp" "$hud_dir/config.json" || return 1
+  fi
   echo "  wired statusLine → $settings"
 }
 

--- a/scripts/test-himmel-update.sh
+++ b/scripts/test-himmel-update.sh
@@ -38,6 +38,14 @@ assert_contains() {
         assert_fail "$desc — expected pattern '$pattern', got: $actual"
     fi
 }
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        assert_pass "$desc"
+    else
+        assert_fail "$desc — expected '$expected', got '$actual'"
+    fi
+}
 
 _repo_counter=0
 
@@ -91,6 +99,7 @@ make_repo_behind() {
     mkdir -p "$clone/scripts/guardrails" "$clone/scripts/lib"
     cp "$src_scripts/guardrails/lib.sh"      "$clone/scripts/guardrails/lib.sh"
     cp "$src_scripts/lib/cadence-format.sh"  "$clone/scripts/lib/cadence-format.sh"
+    cp "$src_scripts/lib/resolve-hermes-py.sh" "$clone/scripts/lib/resolve-hermes-py.sh"
     CHECKOUT_DIR="$clone"
 }
 
@@ -140,6 +149,111 @@ out=$(HIMMEL_MARKETPLACE_JSON="$PFIX/marketplace.json" \
       HIMMEL_INSTALLED_PLUGINS_JSON="$PFIX/installed-all.json" \
       bash "$CHECKOUT_DIR/scripts/himmel-update.sh" --plugins-check 2>&1) || true
 assert_contains "all-installed: clean message" "all 3 @himmel plugins installed" "$out"
+
+# ─── rewire_statusline ───────────────────────────────────────────────────────
+echo "Test 5: rewire_statusline → migrates only existing himmel statusLine wiring"
+REAL_ROOT="$(cd "$(dirname "$SCRIPT")/.." && pwd)"
+REAL_ROOT_FWD="${REAL_ROOT//\\//}"
+EXPECTED_HUD_CMD="node \"$REAL_ROOT_FWD/marketplace/plugins/claude-hud/dist/index.js\""
+
+run_rewire_statusline() {
+    local p="$1"
+    (
+        set -euo pipefail
+        # shellcheck disable=SC1090
+        HIMMEL_UPDATE_LIB=1 . "$SCRIPT"
+        CLAUDE_USER_SETTINGS="$p" rewire_statusline
+    )
+}
+
+# Case a: old bash bar wiring is migrated to the hud renderer, preserving env
+# siblings and top-level settings.
+printf '%s' '{"statusLine":{"type":"command","command":"bash \"C:/old/himmel/scripts/where-are-we/statusline.sh\""},"env":{"KEEP":"1"},"theme":"dark"}' > "$TMP/sl-old.json"
+if run_rewire_statusline "$TMP/sl-old.json" >/dev/null 2>&1; then
+    assert_pass "rewire old bash bar: rc 0"
+else
+    assert_fail "rewire old bash bar: rc non-zero"
+fi
+assert_eq "rewire old bash bar: hud command" "$EXPECTED_HUD_CMD" "$(jq -r '.statusLine.command' "$TMP/sl-old.json")"
+assert_eq "rewire old bash bar: hud env gate" "1" "$(jq -r '.env.CLAUDE_HUD_ALLOW_EXTRA_CMD' "$TMP/sl-old.json")"
+assert_eq "rewire old bash bar: preserves env sibling" "1" "$(jq -r '.env.KEEP' "$TMP/sl-old.json")"
+assert_eq "rewire old bash bar: preserves theme" "dark" "$(jq -r '.theme' "$TMP/sl-old.json")"
+
+# Case a2: the OLD VENDORED path (pre-HIMMEL-538 installs) also migrates.
+printf '%s' '{"statusLine":{"type":"command","command":"bash \"C:/old/himmel/scripts/statusline/bin/statusline.sh\""}}' > "$TMP/sl-vendored.json"
+if run_rewire_statusline "$TMP/sl-vendored.json" >/dev/null 2>&1; then
+    assert_pass "rewire old vendored bar: rc 0"
+else
+    assert_fail "rewire old vendored bar: rc non-zero"
+fi
+assert_eq "rewire old vendored bar: hud command" "$EXPECTED_HUD_CMD" "$(jq -r '.statusLine.command' "$TMP/sl-vendored.json")"
+
+# Case b: custom statusLine is byte-unchanged.
+printf '%s' '{"statusLine":{"type":"command","command":"bash /opt/mine.sh"}}' > "$TMP/sl-custom.json"
+cp "$TMP/sl-custom.json" "$TMP/sl-custom.before"
+if run_rewire_statusline "$TMP/sl-custom.json" >/dev/null 2>&1; then
+    assert_pass "rewire custom statusLine: rc 0"
+else
+    assert_fail "rewire custom statusLine: rc non-zero"
+fi
+if cmp -s "$TMP/sl-custom.before" "$TMP/sl-custom.json"; then
+    assert_pass "rewire custom statusLine: unchanged"
+else
+    assert_fail "rewire custom statusLine: changed unexpectedly"
+fi
+
+# Case c: no statusLine key is unchanged.
+printf '%s' '{"theme":"dark"}' > "$TMP/sl-none.json"
+cp "$TMP/sl-none.json" "$TMP/sl-none.before"
+if run_rewire_statusline "$TMP/sl-none.json" >/dev/null 2>&1; then
+    assert_pass "rewire no statusLine: rc 0"
+else
+    assert_fail "rewire no statusLine: rc non-zero"
+fi
+if cmp -s "$TMP/sl-none.before" "$TMP/sl-none.json"; then
+    assert_pass "rewire no statusLine: unchanged"
+else
+    assert_fail "rewire no statusLine: changed unexpectedly"
+fi
+
+# Case d: absent settings path is a no-create no-op.
+if run_rewire_statusline "$TMP/sl-missing.json" >/dev/null 2>&1; then
+    assert_pass "rewire absent settings: rc 0"
+else
+    assert_fail "rewire absent settings: rc non-zero"
+fi
+if [ ! -e "$TMP/sl-missing.json" ]; then
+    assert_pass "rewire absent settings: file not created"
+else
+    assert_fail "rewire absent settings: file created unexpectedly"
+fi
+
+# Case e: invalid JSON is unchanged and non-fatal.
+printf '%s' '{"statusLine":' > "$TMP/sl-invalid.json"
+cp "$TMP/sl-invalid.json" "$TMP/sl-invalid.before"
+if run_rewire_statusline "$TMP/sl-invalid.json" >/dev/null 2>&1; then
+    assert_pass "rewire invalid JSON: rc 0"
+else
+    assert_fail "rewire invalid JSON: rc non-zero"
+fi
+if cmp -s "$TMP/sl-invalid.before" "$TMP/sl-invalid.json"; then
+    assert_pass "rewire invalid JSON: unchanged"
+else
+    assert_fail "rewire invalid JSON: changed unexpectedly"
+fi
+
+# Case f: idempotent — a second run leaves the migrated file identical.
+cp "$TMP/sl-old.json" "$TMP/sl-old.once"
+if run_rewire_statusline "$TMP/sl-old.json" >/dev/null 2>&1; then
+    assert_pass "rewire idempotent second run: rc 0"
+else
+    assert_fail "rewire idempotent second run: rc non-zero"
+fi
+if cmp -s "$TMP/sl-old.once" "$TMP/sl-old.json"; then
+    assert_pass "rewire idempotent second run: unchanged"
+else
+    assert_fail "rewire idempotent second run: changed unexpectedly"
+fi
 
 # ─── Summary ─────────────────────────────────────────────────────────────────
 echo


### PR DESCRIPTION
Propagation of the statusline HUD-renderer wiring switch (private #940): wire/unwire scripts switch settings statusLine to the claude-hud renderer, himmel-update gains the wiring phase, tests included.