### PR TITLE
feat(codex): startup-health detector - surface degraded codex starts

### DIFF
--- a/scripts/codex/startup-health.ps1
+++ b/scripts/codex/startup-health.ps1
@@ -1,0 +1,122 @@
+<#
+.SYNOPSIS
+  Surface a DEGRADED Codex CLI startup (HIMMEL-747) — twin of startup-health.sh.
+
+.DESCRIPTION
+  When himmel routes work to the Codex lane, a codex session can start degraded
+  in ways that leave the lane LOOKING healthy: skills/plugin prompts silently
+  truncated, lifecycle hooks silently ignored, or an oversized _where-are-we
+  context injection. This read-only detector inspects the MOST-RECENT codex
+  session's own logs and reports each signal it finds. See the .sh twin's header
+  for the full grounding in the real ~/.codex log formats.
+
+  Output: one `WARN <signal>: <detail>` line per finding.
+  Exit:   0 = healthy   1 = finding(s)   2 = cannot read codex logs.
+  Env:    CODEX_HOME (default ~/.codex)
+          WHERE_ARE_WE_BUDGET_BYTES (default 8192)
+
+  NON-FATAL by contract: callers treat any failure as "no signal".
+#>
+[CmdletBinding(PositionalBinding=$false)]
+param()
+$ErrorActionPreference = 'Stop'
+
+# Read a file that may be held open by a live codex process (Windows locks it):
+# open with FileShare ReadWrite, and return $null on any failure (non-fatal).
+function Read-SharedBytes([string]$path) {
+  try {
+    $fs = [System.IO.File]::Open($path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {
+      $ms = New-Object System.IO.MemoryStream
+      $fs.CopyTo($ms)
+      return $ms.ToArray()
+    } finally { $fs.Dispose() }
+  } catch { return $null }
+}
+
+$codexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $HOME '.codex' }
+$budget    = if ($env:WHERE_ARE_WE_BUDGET_BYTES) { [int]$env:WHERE_ARE_WE_BUDGET_BYTES } else { 8192 }
+$logdb     = Join-Path $codexHome 'logs_2.sqlite'
+$sessions  = Join-Path $codexHome 'sessions'
+
+if (-not (Test-Path -LiteralPath $logdb) -and -not (Test-Path -LiteralPath $sessions)) {
+  [Console]::Error.WriteLine("startup-health: no codex logs under $codexHome (logs_2.sqlite / sessions absent)")
+  exit 2
+}
+
+$findings = 0
+function Emit([string]$signal, [string]$detail) {
+  Write-Output "WARN ${signal}: ${detail}"
+  $script:findings++
+}
+
+# Newest rollout session (lexical sort of ISO-timestamp-prefixed filenames).
+$newest = $null
+if (Test-Path -LiteralPath $sessions) {
+  $newest = Get-ChildItem -LiteralPath $sessions -Recurse -Filter 'rollout-*.jsonl' -File -ErrorAction SilentlyContinue |
+            Sort-Object Name | Select-Object -Last 1
+}
+$tid = $null
+if ($newest) {
+  $m = [regex]::Match($newest.Name, '-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$')
+  if ($m.Success) { $tid = $m.Groups[1].Value }
+}
+
+# --- (a) skill/plugin prompt truncation + (b) lifecycle hook failure -----------
+# logs_2.sqlite stores TEXT inline as UTF-8; extract printable runs (>=20 chars),
+# keep those carrying the current session thread_id, count the WARN markers.
+if ((Test-Path -LiteralPath $logdb) -and $tid) {
+  $bytes = Read-SharedBytes $logdb
+  # Latin1 = 1:1 byte->char, so [\x20-\x7E]{20,} isolates printable runs verbatim.
+  $text  = if ($bytes) { [System.Text.Encoding]::GetEncoding('ISO-8859-1').GetString($bytes) } else { '' }
+  $hookHits = 0; $skillHits = 0
+  foreach ($run in [regex]::Matches($text, '[\x20-\x7E]{20,}')) {
+    $r = $run.Value
+    if ($r -notmatch [regex]::Escape($tid)) { continue }
+    if ($r -match 'ignoring hooks') { $hookHits++ }
+    if ($r -match 'ignoring interface\.defaultPrompt|prompt must be at most|maximum of [0-9]+ prompts') { $skillHits++ }
+  }
+  if ($hookHits -gt 0) {
+    Emit 'hook-failure' "codex ignored a lifecycle hooks block in the current session (codex_core_plugins::manifest 'ignoring hooks') — SessionStart/UserPromptSubmit/Stop hooks may not be running"
+  }
+  if ($skillHits -gt 0) {
+    Emit 'skill-truncation' "codex truncated $skillHits skill/plugin prompt field(s) in the current session (codex_core_plugins::manifest 'defaultPrompt ... at most N chars / maximum of N prompts') — skill content silently dropped"
+  }
+}
+
+# --- (c) oversized _where-are-we context injection -----------------------------
+if ($newest) {
+  $maxBytes = 0
+  # Recurse every JSON string leaf; track the largest that carries the header.
+  function Walk($node) {
+    if ($null -eq $node) { return }
+    if ($node -is [string]) {
+      if ($node -like '*# Where are we*') {
+        $b = [System.Text.Encoding]::UTF8.GetByteCount($node)
+        if ($b -gt $script:maxBytes) { $script:maxBytes = $b }
+      }
+      return
+    }
+    if ($node -is [System.Collections.IEnumerable] -and $node -isnot [string]) {
+      foreach ($item in $node) { Walk $item }
+      return
+    }
+    if ($node -is [psobject] -and $node.PSObject.Properties) {
+      foreach ($p in $node.PSObject.Properties) { Walk $p.Value }
+    }
+  }
+  $script:maxBytes = 0
+  $jb = Read-SharedBytes $newest.FullName
+  $jtext = if ($jb) { [System.Text.Encoding]::UTF8.GetString($jb) } else { '' }
+  foreach ($line in ($jtext -split "`n")) {
+    if ([string]::IsNullOrWhiteSpace($line)) { continue }
+    try { $obj = $line | ConvertFrom-Json } catch { continue }
+    Walk $obj
+  }
+  if ($script:maxBytes -gt $budget) {
+    Emit 'where-are-we-oversized' "the _where-are-we context injected into the most recent codex session is $($script:maxBytes) bytes (budget $budget)"
+  }
+}
+
+if ($findings -gt 0) { exit 1 }
+exit 0

--- a/scripts/codex/startup-health.sh
+++ b/scripts/codex/startup-health.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# startup-health.sh (HIMMEL-747) — surface a DEGRADED Codex CLI startup.
+#
+# When himmel routes work to the Codex lane, a codex session can start degraded
+# in ways that leave the lane LOOKING healthy to the orchestrator: skills/plugin
+# prompts silently truncated, lifecycle hooks silently ignored, or an oversized
+# _where-are-we context injection. This read-only detector inspects the
+# MOST-RECENT codex session's own logs and reports each signal it finds.
+#
+# GROUNDING (real ~/.codex on the author's Win11 box, 2026-07-07):
+#  - Codex writes a tracing DB at $CODEX_HOME/logs_2.sqlite (table `logs`; cols
+#    level / target / feedback_log_body). Startup + plugin-load warnings live
+#    THERE, not in the per-session rollout .jsonl (whose event_msg payloads are
+#    only token_count / agent_message / task_* — no warning event type). The
+#    relevant rows are level=WARN, target=codex_core_plugins::manifest, and are
+#    re-emitted per-turn INSIDE the session_loop span, so the session thread_id
+#    is embedded in the message text. Verified example bodies:
+#      * hook-failure     "...load_plugins_from_layer_stack: ignoring hooks:
+#                          expected a string, string array, object, or object
+#                          array; found object"
+#      * skill-truncation "ignoring interface.defaultPrompt: maximum of 3 prompts
+#                          is supported path=...\.codex-plugin/plugin.json"  and
+#                          "ignoring interface.defaultPrompt[0]: prompt must be at
+#                          most 128 characters path=..."
+#  - The _where-are-we injection is a rollout-jsonl string value that begins
+#    "<system-reminder>\n_where-are-we ...\n\n# Where are we\n..." (a healthy one
+#    is ~4 KiB; e.g. rollout-2026-07-07T11-56-16-...jsonl was 4138 bytes).
+#
+# logs_2.sqlite is read WITHOUT a sqlite dependency (mirroring the read-the-bytes
+# approach of scripts/telegram/quota-gauge-codex.ts): sqlite stores TEXT inline
+# as UTF-8, so printable-run extraction (grep -aoE) + a thread_id filter scopes
+# matches to the MOST-RECENT session. That scoping matters: the DB is append-only,
+# so a since-FIXED misconfig's stale rows persist forever; filtering by the newest
+# session's thread_id means a fixed config stops firing on the next launch.
+#
+# Output: one `WARN <signal>: <detail>` line per finding, on stdout.
+# Exit:   0 = healthy (no findings)   1 = finding(s)   2 = cannot read codex logs.
+# Env:    CODEX_HOME (default ~/.codex)
+#         WHERE_ARE_WE_BUDGET_BYTES (default 8192 — ~2x a normal ~4 KiB injection)
+#
+# NON-FATAL by contract: callers (himmel-doctor, scripts/lanes) must treat any
+# failure as "no signal". Internal errors degrade to a clean exit, never a crash.
+set -uo pipefail
+
+case "${1:-}" in
+  -h|--help) sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  "") ;;
+  *) echo "startup-health: unknown argument: $1" >&2; exit 2 ;;
+esac
+
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+BUDGET="${WHERE_ARE_WE_BUDGET_BYTES:-8192}"
+LOGDB="$CODEX_HOME/logs_2.sqlite"
+SESSIONS="$CODEX_HOME/sessions"
+
+# cannot-read: no codex logs at all under CODEX_HOME.
+if [ ! -f "$LOGDB" ] && [ ! -d "$SESSIONS" ]; then
+  echo "startup-health: no codex logs under $CODEX_HOME (logs_2.sqlite / sessions absent)" >&2
+  exit 2
+fi
+
+findings=0
+emit() { printf 'WARN %s: %s\n' "$1" "$2"; findings=$((findings + 1)); }
+
+# Newest rollout session. Rollout filenames are ISO-timestamp-prefixed
+# (rollout-2026-07-07T11-56-16-<uuid>.jsonl), so a lexical sort is chronological
+# — no GNU-only `find -printf` / stat (keeps this portable to macOS find).
+newest_jsonl=""
+if [ -d "$SESSIONS" ]; then
+  newest_jsonl="$(find "$SESSIONS" -name 'rollout-*.jsonl' -type f 2>/dev/null | sort | tail -1)"
+fi
+tid=""
+if [ -n "$newest_jsonl" ]; then
+  tid="$(basename "$newest_jsonl" | sed -nE 's/.*-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/\1/p')"
+fi
+
+# --- (a) skill/plugin prompt truncation  +  (b) lifecycle hook failure ----------
+# Both live in logs_2.sqlite and both re-emit with the session thread_id embedded,
+# so scope by $tid to the current session (avoids stale, since-fixed rows).
+if [ -f "$LOGDB" ] && [ -n "$tid" ]; then
+  runs="$(LC_ALL=C grep -aoE '[[:print:]]{20,}' "$LOGDB" 2>/dev/null | grep -F "$tid" 2>/dev/null || true)"
+  hook_hits="$(printf '%s\n' "$runs" | grep -c 'ignoring hooks' 2>/dev/null || true)"
+  skill_hits="$(printf '%s\n' "$runs" | grep -cE 'ignoring interface\.defaultPrompt|prompt must be at most|maximum of [0-9]+ prompts' 2>/dev/null || true)"
+  hook_hits="${hook_hits//[^0-9]/}";  hook_hits="${hook_hits:-0}"
+  skill_hits="${skill_hits//[^0-9]/}"; skill_hits="${skill_hits:-0}"
+  [ "$hook_hits" -gt 0 ] && emit hook-failure \
+    "codex ignored a lifecycle hooks block in the current session (codex_core_plugins::manifest 'ignoring hooks') — SessionStart/UserPromptSubmit/Stop hooks may not be running"
+  [ "$skill_hits" -gt 0 ] && emit skill-truncation \
+    "codex truncated $skill_hits skill/plugin prompt field(s) in the current session (codex_core_plugins::manifest 'defaultPrompt ... at most N chars / maximum of N prompts') — skill content silently dropped"
+fi
+
+# --- (c) oversized _where-are-we context injection ------------------------------
+# The injected block is a rollout-jsonl string value carrying the "# Where are we"
+# header; flag when the largest such value exceeds the byte budget. jq is a hard
+# dependency of the codex hook adapter's environment; if it is somehow absent we
+# skip this signal rather than fail.
+if [ -n "$newest_jsonl" ] && command -v jq >/dev/null 2>&1; then
+  waw_bytes="$(jq -rn '[inputs | .. | strings | select(test("# Where are we")) | utf8bytelength] | max // 0' "$newest_jsonl" 2>/dev/null || echo 0)"
+  waw_bytes="${waw_bytes//[^0-9]/}"; waw_bytes="${waw_bytes:-0}"
+  if [ "$waw_bytes" -gt "$BUDGET" ]; then
+    emit where-are-we-oversized \
+      "the _where-are-we context injected into the most recent codex session is ${waw_bytes} bytes (budget ${BUDGET})"
+  fi
+fi
+
+[ "$findings" -gt 0 ] && exit 1
+exit 0

--- a/scripts/codex/test-startup-health.ps1
+++ b/scripts/codex/test-startup-health.ps1
@@ -1,0 +1,92 @@
+<#
+.SYNOPSIS
+  Hermetic tests for startup-health.ps1 (HIMMEL-747) — twin of test-startup-health.sh.
+.DESCRIPTION
+  Builds a temp CODEX_HOME per case (synthetic rollout .jsonl naming the session
+  thread_id + a synthetic logs_2.sqlite text file carrying the real WARN message
+  shapes) and asserts: healthy -> 0; hook-failure -> 1; skill-truncation -> 1;
+  a marker under an OLD thread_id does NOT fire (session scoping); oversized
+  _where-are-we -> 1; missing CODEX_HOME -> 2.
+#>
+[CmdletBinding()]
+param()
+$ErrorActionPreference = 'Stop'
+
+$DET  = Join-Path $PSScriptRoot 'startup-health.ps1'
+$TMP  = Join-Path ([System.IO.Path]::GetTempPath()) ("sh-test-" + [guid]::NewGuid().ToString('N').Substring(0,8))
+$NEW  = '019f3c01-afbf-7ef3-a689-c5be6d9afde0'
+$OLD  = '019f0000-0000-7000-8000-000000000000'
+$fails = 0
+function Pass($m) { Write-Host "  ok: $m" }
+function Fail($m) { [Console]::Error.WriteLine("  FAIL: $m"); $script:fails++ }
+
+function New-Home([string]$name, [string]$tid, [string]$waw) {
+  $h = Join-Path $TMP $name
+  $d = Join-Path $h 'sessions/2026/07/07'
+  New-Item -ItemType Directory -Force -Path $d | Out-Null
+  $f = Join-Path $d "rollout-2026-07-07T11-56-16-$tid.jsonl"
+  '{"type":"event_msg","payload":{"type":"token_count"}}' | Set-Content -LiteralPath $f -Encoding utf8
+  $rec = [pscustomobject]@{ type = 'response_item'; payload = [pscustomobject]@{ type = 'message'; content = @([pscustomobject]@{ type = 'text'; text = $waw }) } }
+  ($rec | ConvertTo-Json -Depth 20 -Compress) | Add-Content -LiteralPath $f -Encoding utf8
+  return $h
+}
+function Set-Db([string]$homeDir, [string]$line) { $line | Set-Content -LiteralPath (Join-Path $homeDir 'logs_2.sqlite') -Encoding utf8 }
+function Run([string]$homeDir, [hashtable]$envx = @{}) {
+  $env:CODEX_HOME = $homeDir
+  $env:WHERE_ARE_WE_BUDGET_BYTES = $(if ($envx.ContainsKey('budget')) { $envx.budget } else { $null })
+  $out = & pwsh -NoProfile -File $DET 2>&1
+  $rc = $LASTEXITCODE
+  $env:CODEX_HOME = $null; $env:WHERE_ARE_WE_BUDGET_BYTES = $null
+  return @{ rc = $rc; out = ($out -join "`n") }
+}
+
+$small = "<system-reminder>`n# Where are we`nsmall"
+$hookLine  = "WARN codex_core_plugins::manifest session_loop{thread_id=__TID__}:x: load_plugins_from_layer_stack: ignoring hooks: found object"
+$skillLine = "WARN codex_core_plugins::manifest session_loop{thread_id=__TID__}:built_tools: ignoring interface.defaultPrompt[0]: prompt must be at most 128 characters path=X"
+
+try {
+  # 1. healthy
+  $h = New-Home 'healthy' $NEW $small
+  Set-Db $h "INFO codex_core_skills::service session_loop{thread_id=$NEW}: skills cache cleared padding"
+  $r = Run $h
+  if ($r.rc -eq 0 -and [string]::IsNullOrWhiteSpace($r.out)) { Pass 'healthy -> exit 0, no findings' } else { Fail "healthy rc=$($r.rc) out=$($r.out)" }
+
+  # 2. hook-failure
+  $h = New-Home 'hook' $NEW $small
+  Set-Db $h ($hookLine -replace '__TID__', $NEW)
+  $r = Run $h
+  if ($r.rc -eq 1 -and $r.out -match '^WARN hook-failure:') { Pass 'hook-failure -> exit 1' } else { Fail "hook rc=$($r.rc) out=$($r.out)" }
+
+  # 3. skill-truncation
+  $h = New-Home 'skill' $NEW $small
+  Set-Db $h (($skillLine -replace '__TID__', $NEW))
+  $r = Run $h
+  if ($r.rc -eq 1 -and $r.out -match 'WARN skill-truncation:') { Pass 'skill-truncation -> exit 1' } else { Fail "skill rc=$($r.rc) out=$($r.out)" }
+
+  # 4. session scoping: marker only under OLD tid
+  $h = New-Home 'scope' $NEW $small
+  $od = Join-Path $h 'sessions/2026/07/01'; New-Item -ItemType Directory -Force -Path $od | Out-Null
+  '{}' | Set-Content -LiteralPath (Join-Path $od "rollout-2026-07-01T00-00-00-$OLD.jsonl") -Encoding utf8
+  Set-Db $h ($hookLine -replace '__TID__', $OLD)
+  $r = Run $h
+  if ($r.rc -eq 0) { Pass 'stale-only markers (old tid) -> exit 0 (scoped out)' } else { Fail "scope rc=$($r.rc) out=$($r.out)" }
+
+  # 5. oversized where-are-we
+  $big = "<system-reminder>`n# Where are we`n" + ('x' * 400)
+  $h = New-Home 'big' $NEW $big
+  Set-Db $h "INFO x session_loop{thread_id=$NEW}: noise padding line here"
+  $r = Run $h @{ budget = '200' }
+  if ($r.rc -eq 1 -and $r.out -match 'WARN where-are-we-oversized:') { Pass 'oversized where-are-we -> exit 1' } else { Fail "oversized rc=$($r.rc) out=$($r.out)" }
+  $r = Run $h @{ budget = '100000' }
+  if ($r.rc -eq 0) { Pass 'big block under generous budget -> exit 0' } else { Fail "budget-gate rc=$($r.rc)" }
+
+  # 6. missing CODEX_HOME -> 2
+  $r = Run (Join-Path $TMP 'nope/.codex')
+  if ($r.rc -eq 2) { Pass 'missing CODEX_HOME -> exit 2' } else { Fail "missing rc=$($r.rc)" }
+}
+finally {
+  Remove-Item -Recurse -Force $TMP -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+if ($fails -eq 0) { Write-Host 'PASS' } else { Write-Host "FAIL ($fails)"; exit 1 }

--- a/scripts/codex/test-startup-health.sh
+++ b/scripts/codex/test-startup-health.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Hermetic tests for startup-health.sh (HIMMEL-747).
+# No real Codex install: each case builds a temp CODEX_HOME with a synthetic
+# rollout .jsonl (names the session thread_id) + a synthetic logs_2.sqlite. The
+# detector reads logs_2.sqlite by printable-run byte extraction (grep -aoE), NOT
+# via a sqlite driver, so a plain text file carrying the real WARN message shapes
+# is a faithful fixture. Asserts: healthy -> 0; each signal detected -> 1 + its
+# WARN line; a marker under an OLD (non-current) thread_id does NOT fire (session
+# scoping); oversized _where-are-we -> 1; missing CODEX_HOME -> 2; bad arg -> 2.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DETECT="$SCRIPT_DIR/startup-health.sh"
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq required" >&2; exit 1; }
+
+fails=0
+pass() { echo "  ok: $1"; }
+fail() { echo "  FAIL: $1" >&2; fails=$((fails + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+NEW_TID="019f3c01-afbf-7ef3-a689-c5be6d9afde0"
+OLD_TID="019f0000-0000-7000-8000-000000000000"
+
+# make_home <name> <tid> <waw_text> -> echoes the CODEX_HOME path (no logs_2.sqlite yet)
+make_home() {
+  local home="$TMP/$1" tid="$2" waw="$3"
+  local dir="$home/sessions/2026/07/07"
+  mkdir -p "$dir"
+  # Rollout filename ends in the thread_id; lexical sort picks the newest.
+  local f="$dir/rollout-2026-07-07T11-56-16-$tid.jsonl"
+  # A token_count line (noise) + the where-are-we injection line.
+  printf '%s\n' '{"type":"event_msg","payload":{"type":"token_count"}}' > "$f"
+  jq -cn --arg t "$waw" '{type:"response_item",payload:{type:"message",content:[{type:"text",text:$t}]}}' >> "$f"
+  echo "$home"
+}
+
+# A real-shape WARN row body (level+target+span+message on one printable line).
+db_hook_row()  { printf 'WARN codex_core_plugins::manifest session_loop{thread_id=%s}:submission_dispatch{}:turn: load_plugins_from_layer_stack: ignoring hooks: expected a string, string array, object, or object array; found object\n' "$1"; }
+db_skill_row() { printf 'WARN codex_core_plugins::manifest session_loop{thread_id=%s}:built_tools: ignoring interface.defaultPrompt[0]: prompt must be at most 128 characters path=X/.codex-plugin/plugin.json\n' "$1"; }
+db_noise_row() { printf 'INFO codex_core_skills::service session_loop{thread_id=%s}: skills cache cleared (0 entries)\n' "$1"; }
+
+SMALL_WAW="<system-reminder>
+_where-are-we
+
+# Where are we
+
+## In flight
+(none)"
+
+# check_rc <want> <got> <msg>  /  want_line <needle> <text> <msg>
+check_rc()   { if [ "$2" -eq "$1" ]; then pass "$3"; else fail "$3 (got exit $2)"; fi; }
+want_line()  { if printf '%s\n' "$2" | grep -q "$1"; then pass "$3"; else fail "$3 (out: $2)"; fi; }
+
+# --- 1. healthy: current session, no warn rows, small where-are-we -> exit 0 ----
+H="$(make_home healthy "$NEW_TID" "$SMALL_WAW")"
+db_noise_row "$NEW_TID" > "$H/logs_2.sqlite"
+rc=0; out="$(CODEX_HOME="$H" bash "$DETECT" 2>&1)" || rc=$?
+check_rc 0 "$rc" "healthy -> exit 0"
+if [ -z "$out" ]; then pass "healthy -> no findings printed"; else fail "healthy printed: $out"; fi
+
+# --- 2. hook-failure detected (scoped to current tid) -> exit 1 -----------------
+H="$(make_home hookfail "$NEW_TID" "$SMALL_WAW")"
+{ db_noise_row "$NEW_TID"; db_hook_row "$NEW_TID"; } > "$H/logs_2.sqlite"
+rc=0; out="$(CODEX_HOME="$H" bash "$DETECT" 2>&1)" || rc=$?
+check_rc 1 "$rc" "hook-failure -> exit 1"
+want_line '^WARN hook-failure:' "$out" "hook-failure WARN line present"
+
+# --- 3. skill-truncation detected -> exit 1 ------------------------------------
+H="$(make_home skilltrunc "$NEW_TID" "$SMALL_WAW")"
+{ db_skill_row "$NEW_TID"; db_skill_row "$NEW_TID"; } > "$H/logs_2.sqlite"
+rc=0; out="$(CODEX_HOME="$H" bash "$DETECT" 2>&1)" || rc=$?
+check_rc 1 "$rc" "skill-truncation -> exit 1"
+want_line '^WARN skill-truncation:.*2 skill' "$out" "skill-truncation counts 2"
+
+# --- 4. session scoping: marker under an OLD tid must NOT fire -> exit 0 --------
+# Newest session is NEW_TID (healthy); the DB carries hook+skill rows but only for
+# the OLD tid (a since-fixed misconfig whose stale rows persist append-only).
+H="$(make_home scoping "$NEW_TID" "$SMALL_WAW")"
+# add an older session file so the dir has two; NEW_TID sorts later (newest).
+mkdir -p "$H/sessions/2026/07/01"
+printf '%s\n' '{"type":"event_msg","payload":{"type":"token_count"}}' > "$H/sessions/2026/07/01/rollout-2026-07-01T00-00-00-$OLD_TID.jsonl"
+{ db_hook_row "$OLD_TID"; db_skill_row "$OLD_TID"; } > "$H/logs_2.sqlite"
+rc=0; out="$(CODEX_HOME="$H" bash "$DETECT" 2>&1)" || rc=$?
+check_rc 0 "$rc" "stale-only markers (old tid) -> exit 0 (scoped out)"
+
+# --- 5. oversized _where-are-we -> exit 1 --------------------------------------
+BIG_WAW="<system-reminder>
+# Where are we
+$(printf 'x%.0s' $(seq 1 400))"
+H="$(make_home bigwaw "$NEW_TID" "$BIG_WAW")"
+db_noise_row "$NEW_TID" > "$H/logs_2.sqlite"
+rc=0; out="$(CODEX_HOME="$H" WHERE_ARE_WE_BUDGET_BYTES=200 bash "$DETECT" 2>&1)" || rc=$?
+check_rc 1 "$rc" "oversized where-are-we -> exit 1"
+want_line '^WARN where-are-we-oversized:' "$out" "where-are-we-oversized line present"
+# same big block stays healthy under a generous budget (proves it is the size, not presence)
+rc=0; out="$(CODEX_HOME="$H" WHERE_ARE_WE_BUDGET_BYTES=100000 bash "$DETECT" 2>&1)" || rc=$?
+check_rc 0 "$rc" "big block under generous budget -> exit 0"
+
+# --- 6. missing CODEX_HOME -> exit 2 -------------------------------------------
+rc=0; out="$(CODEX_HOME="$TMP/nope/.codex" bash "$DETECT" 2>&1)" || rc=$?
+check_rc 2 "$rc" "missing CODEX_HOME -> exit 2"
+
+# --- 7. unknown arg -> exit 2 --------------------------------------------------
+rc=0; CODEX_HOME="$H" bash "$DETECT" --bogus >/dev/null 2>&1 || rc=$?
+check_rc 2 "$rc" "unknown arg -> exit 2"
+
+echo ""
+if [ "$fails" -eq 0 ]; then echo "PASS"; else echo "FAIL ($fails)"; exit 1; fi

--- a/scripts/himmel-doctor.sh
+++ b/scripts/himmel-doctor.sh
@@ -454,6 +454,35 @@ check_c11() {
     esac
 }
 
+# --- C12: codex startup health (read-only advisory, HIMMEL-747) -----------------
+# Surfaces a DEGRADED codex CLI startup (skills silently truncated / lifecycle
+# hooks silently ignored / oversized _where-are-we injection) so a codex
+# delegation lane that LOOKS healthy but starts degraded becomes visible. Runs
+# scripts/codex/startup-health.sh, which reads only the most-recent codex session
+# logs under CODEX_HOME. Skips cleanly when codex is absent (detector rc=2).
+# NON-fatal (WARN at most, never FAIL): a broken detector must never fail doctor.
+check_c12() {
+    local detector="$REPO_ROOT/scripts/codex/startup-health.sh"
+    if [ ! -f "$detector" ]; then
+        emit OK C12-codex "codex startup-health detector not present (skipped)"
+        return
+    fi
+    local out rc
+    out="$(bash "$detector" 2>/dev/null)"; rc=$?
+    case "$rc" in
+        0) emit OK C12-codex "codex startup healthy (no skill-truncation / hook-failure / oversized where-are-we in the last session)" ;;
+        2) emit OK C12-codex "no codex logs under CODEX_HOME (codex lane not in use here — skipped)" ;;
+        1)
+            local n; n="$(printf '%s\n' "$out" | grep -c '^WARN ')"
+            emit WARN C12-codex \
+                "codex started DEGRADED -- $n startup finding(s) in the most recent session (a routed codex lane looks healthy but is not)" \
+                "restart codex after fixing (skills: scripts/codex/sanitize-plugin-hooks.sh; hooks: check .codex/hooks.json shape). Detail: scripts/codex/startup-health.sh"
+            printf '%s\n' "$out" | sed 's/^WARN /       · /'
+            ;;
+        *) emit WARN C12-codex "codex startup-health detector exited rc=$rc (unexpected)" "inspect scripts/codex/startup-health.sh" ;;
+    esac
+}
+
 # --- issue filing ---------------------------------------------------------------
 resolve_issue_repo() {
     [ -n "$REPO_FLAG" ] && { printf '%s\n' "$REPO_FLAG"; return 0; }
@@ -505,6 +534,7 @@ check_c8
 check_c9
 check_c10
 check_c11
+check_c12
 echo
 printf 'Summary: %s%d FAIL%s  %s%d WARN%s  %s%d INFO%s\n' "$C_RED" "$n_fail" "$C_0" "$C_YEL" "$n_warn" "$C_0" "$C_DIM" "$n_info" "$C_0"
 

--- a/scripts/lanes/resolve.mjs
+++ b/scripts/lanes/resolve.mjs
@@ -90,12 +90,50 @@ function renderText(lanes) {
     '\n\nNote: codex(paid) reflects CR_PROFILE=paid (opt-in preference, not a funded-bank guarantee).\n';
 }
 
+// HIMMEL-747 — turn the codex startup-health detector's exit code + WARN lines
+// into a /lanes annotation. PURE (unit-tested): only rc=1 (findings) annotates;
+// rc=0 (healthy), rc=2 (no codex), or a spawn failure (rc<0) render nothing, so
+// a degraded codex delegation lane stops looking healthy without ever breaking
+// the lane listing.
+export function formatCodexHealth(rc, stdout) {
+  if (rc !== 1) return '';
+  const lines = String(stdout).split(/\r?\n/).filter((l) => l.startsWith('WARN '));
+  if (lines.length === 0) return '';
+  return `\ncodex lane health: DEGRADED — ${lines.length} startup finding(s) (a routed codex lane looks healthy but is not; run scripts/codex/startup-health.sh):\n` +
+    lines.map((l) => '  - ' + l.replace(/^WARN /, '')).join('\n') + '\n';
+}
+
+// Impure companion (real machine, untested by design, mirrors buildCtx). Spawns
+// the bash detector non-fatally: findings make execFileSync throw with e.status=1
+// and the WARN lines on e.stdout; a missing bash / missing script returns rc<0
+// so formatCodexHealth renders nothing. Git-Bash is resolved explicitly on
+// Windows (a bare `bash` is the WSL stub) — matching scripts/hooks tests.
+function runCodexHealth(repoRoot, env) {
+  const script = join(repoRoot, 'scripts', 'codex', 'startup-health.sh');
+  if (!existsSync(script)) return { rc: -1, out: '' };
+  let bash = '/bin/bash';
+  if (process.platform === 'win32') {
+    const cands = [env.GUARDRAIL_BASH, 'C:/Program Files/Git/bin/bash.exe', 'C:/Program Files/Git/usr/bin/bash.exe'].filter(Boolean);
+    bash = cands.find((b) => existsSync(b)) || 'bash';
+  }
+  try {
+    const out = execFileSync(bash, [script], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 20000 });
+    return { rc: 0, out };
+  } catch (e) {
+    if (e && typeof e.status === 'number') return { rc: e.status, out: e.stdout ? String(e.stdout) : '' };
+    return { rc: -1, out: '' };
+  }
+}
+
 // --- CLI (no --check here; the drift guard is Task 6's check.mjs + bash hook) ---
 const mode = process.argv[2];
 if (process.argv[1]?.endsWith('resolve.mjs')) {
   const registry = loadRegistry();
   const lanes = resolveLanes(registry, buildCtx(REPO_ROOT, process.env));
   if (mode === '--json') process.stdout.write(JSON.stringify(lanes, null, 2) + '\n');
-  else                   process.stdout.write(renderText(lanes));
+  else {
+    const { rc, out } = runCodexHealth(REPO_ROOT, process.env);
+    process.stdout.write(renderText(lanes) + formatCodexHealth(rc, out));
+  }
   process.exit(0);
 }

--- a/scripts/lanes/tests/resolve.test.mjs
+++ b/scripts/lanes/tests/resolve.test.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { resolveLanes } from '../resolve.mjs';
+import { resolveLanes, formatCodexHealth } from '../resolve.mjs';
 
 const REG = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'lanes.json'), 'utf8'));
 const ctx = (o = {}) => ({ env: o.env ?? {}, pathHas: (c) => (o.paths ?? []).includes(c), installed: o.installed ?? {} });
@@ -38,4 +38,24 @@ test('registry is valid JSON with the required per-lane keys', () => {
 test('malformed/empty registry → [] (the ?? [] guard, no throw)', () => {
   assert.deepEqual(resolveLanes({}, ctx()), []);
   assert.deepEqual(resolveLanes({ lanes: [] }, ctx()), []);
+});
+
+// HIMMEL-747 — codex startup-health annotation for /lanes.
+test('formatCodexHealth: healthy (rc 0) / no-codex (rc 2) / spawn-fail (rc -1) render nothing', () => {
+  assert.equal(formatCodexHealth(0, ''), '');
+  assert.equal(formatCodexHealth(2, ''), '');
+  assert.equal(formatCodexHealth(-1, ''), '');
+});
+test('formatCodexHealth: findings (rc 1) annotate with each WARN line, count, and the fix pointer', () => {
+  const out = 'WARN hook-failure: codex ignored a hooks block\nWARN skill-truncation: codex truncated 3 prompts\n';
+  const s = formatCodexHealth(1, out);
+  assert.match(s, /codex lane health: DEGRADED/);
+  assert.match(s, /2 startup finding\(s\)/);
+  assert.match(s, /scripts\/codex\/startup-health\.sh/);
+  assert.match(s, /- hook-failure: codex ignored a hooks block/);
+  assert.match(s, /- skill-truncation: codex truncated 3 prompts/);
+  assert.ok(!/WARN /.test(s), 'strips the WARN prefix in the rendered list');
+});
+test('formatCodexHealth: rc 1 but no WARN lines (defensive) → nothing', () => {
+  assert.equal(formatCodexHealth(1, 'unexpected noise\n'), '');
 });


### PR DESCRIPTION
Propagation of private #972: codex startup-health detector (logs sqlite printable-run reader, newest-thread-scoped), himmel-doctor C12-codex check, and /lanes availability annotation. Tests for sh + ps1 twins included.