### PR TITLE
fix(codex): MCP-fleet orphan reaper + companion liveness probe

### DIFF
--- a/scripts/codex/companion-liveness.sh
+++ b/scripts/codex/companion-liveness.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# companion-liveness.sh (HIMMEL-741) - flag stuck codex-companion jobs.
+#
+# WHY: the codex-companion background task-worker can die silently, leaving its
+# job pinned at "queued"/"running" in the per-workspace job registry forever;
+# any dispatcher polling `codex-companion status` then waits for a job whose
+# runner is already dead. This probe reads the registry for a workspace and
+# reports active jobs older than a threshold whose recorded runner pid is dead
+# (or was never a separate process), so the stall is visible instead of silent.
+#
+# GROUNDING (verified on this machine + codex-companion 1.0.5 source):
+#   State dir (lib/state.mjs resolveStateDir):
+#     $CLAUDE_PLUGIN_DATA/state/<slug>-<sha256(realpath(workspace))[:16]>/
+#     slug = basename(workspace) with [^A-Za-z0-9._-]+ -> '-'. Fallback state
+#     root when CLAUDE_PLUGIN_DATA is unset: <os.tmpdir>/codex-companion.
+#     On this box: ~/.claude/plugins/data/codex-openai-codex/state/
+#       himmel-380d03577bfc6dc9/state.json
+#   state.json shape (lib/state.mjs): { version, config, jobs: [ {
+#       id, kind, kindLabel, title, workspaceRoot, jobClass, status,
+#       createdAt, updatedAt, startedAt, completedAt, pid, logFile, ... } ] }
+#   status in queued|running|completed|failed|cancelled; ACTIVE = queued|running
+#     (codex-companion.mjs isActiveJobStatus). A backgrounded worker records its
+#     detached pid (enqueueBackgroundTask: pid = child.pid); a foreground job
+#     records pid=null (runs inside the parent, no separate runner).
+#   Example real record (completed): pid=null, status="completed",
+#     updatedAt="2026-07-07T10:14:16.500Z".
+#
+# RESOLUTION ORDER (first hit wins):
+#   CODEX_STATE_DIR   - a single <slug>-<hash> dir (used verbatim; test seam).
+#   CODEX_STATE_ROOT  - the 'state' dir that CONTAINS the <slug>-<hash> dirs.
+#   CLAUDE_PLUGIN_DATA/state
+#   ~/.claude/plugins/data/codex-openai-codex/state   (this machine's default)
+# Workspace = $1 or $PWD; its slug selects <state-root>/<slug>-* dirs.
+# Threshold = CODEX_STUCK_THRESHOLD_SECS (default 1800 = 30m).
+#
+#   scripts/codex/companion-liveness.sh [workspace-dir]
+# Exit codes (mirrors scripts/codex/startup-health.sh contract):
+#   0 = healthy (no stuck jobs)   1 = findings (stuck jobs)   2 = cannot read
+set -euo pipefail
+
+THRESHOLD="${CODEX_STUCK_THRESHOLD_SECS:-1800}"
+WORKSPACE="${1:-$PWD}"
+
+NODE_BIN=""
+for c in node node.exe; do
+  if command -v "$c" >/dev/null 2>&1; then NODE_BIN="$c"; break; fi
+done
+if [ -z "$NODE_BIN" ]; then
+  echo "cannot-read: node not found on PATH (needed to parse the JSON registry)." >&2
+  exit 2
+fi
+
+# --- platform + pid liveness (mirror arm-resume.sh _pid_alive) ---------------
+case "${OSTYPE:-$(uname -s 2>/dev/null || echo unknown)}" in
+  msys*|cygwin*|win32*|MINGW*|MSYS*) PLATFORM=windows ;;
+  linux*|Linux*)                     PLATFORM=linux ;;
+  darwin*|Darwin*)                   PLATFORM=macos ;;
+  *)                                 PLATFORM=unknown ;;
+esac
+
+_pid_alive() {
+  local pid="$1"
+  [ -n "$pid" ] || return 1
+  case "$PLATFORM" in
+    windows)
+      local out rc
+      out=$(MSYS_NO_PATHCONV=1 tasklist /FI "PID eq $pid" 2>&1); rc=$?
+      case "$out" in
+        *"No tasks"*) return 1 ;;
+        *"$pid"*)     [ "$rc" -eq 0 ] && return 0 ;;
+      esac
+      return 1
+      ;;
+    *)
+      kill -0 "$pid" 2>/dev/null
+      ;;
+  esac
+}
+
+# --- resolve the state dir(s) for this workspace -----------------------------
+STATE_DIRS=()
+if [ -n "${CODEX_STATE_DIR:-}" ]; then
+  STATE_DIRS=("$CODEX_STATE_DIR")
+else
+  # Candidate roots, mirroring lib/state.mjs: CLAUDE_PLUGIN_DATA/state when the
+  # harness sets it, else os.tmpdir()/codex-companion (the companion's REAL
+  # fallback). The plugins/data path is kept as a candidate because in-session
+  # runs get CLAUDE_PLUGIN_DATA pointed there. All existing roots are scanned -
+  # a probe checking only one can falsely report healthy.
+  STATE_ROOTS=()
+  if [ -n "${CODEX_STATE_ROOT:-}" ]; then
+    STATE_ROOTS=("$CODEX_STATE_ROOT")
+  else
+    [ -n "${CLAUDE_PLUGIN_DATA:-}" ] && STATE_ROOTS+=("$CLAUDE_PLUGIN_DATA/state")
+    STATE_ROOTS+=("$HOME/.claude/plugins/data/codex-openai-codex/state")
+    STATE_ROOTS+=("${TMPDIR:-${TEMP:-/tmp}}/codex-companion")
+  fi
+  # slug = basename(workspace), sanitized exactly like lib/state.mjs.
+  base="$(basename "$WORKSPACE")"
+  slug="$(printf '%s' "$base" | sed 's/[^A-Za-z0-9._-][^A-Za-z0-9._-]*/-/g; s/^-*//; s/-*$//')"
+  [ -n "$slug" ] || slug="workspace"
+  found_root=0
+  for r in "${STATE_ROOTS[@]}"; do
+    [ -d "$r" ] || continue
+    found_root=1
+    for d in "$r/$slug"-*; do
+      [ -d "$d" ] && STATE_DIRS+=("$d")
+    done
+  done
+  if [ "$found_root" -eq 0 ]; then
+    echo "healthy: no codex-companion state root (checked: ${STATE_ROOTS[*]}) (no jobs to check)."
+    exit 0
+  fi
+fi
+
+if [ "${#STATE_DIRS[@]}" -eq 0 ]; then
+  echo "healthy: no codex-companion state dir for workspace '$WORKSPACE' (no jobs to check)."
+  exit 0
+fi
+
+# --- emit active jobs from each state.json via node --------------------------
+# node prints TAB-separated: status  pid  ageSecs  id  title  (one active job
+# per line). Exits 3 if the file is present but unparseable (-> cannot-read).
+extract_active() {
+  local statefile="$1"
+  # shellcheck disable=SC2016  # the single-quoted body is JS for node, not bash.
+  "$NODE_BIN" -e '
+    const fs = require("fs");
+    const f = process.argv[1];
+    let raw;
+    try { raw = fs.readFileSync(f, "utf8"); } catch { process.exit(0); }
+    let o;
+    try { o = JSON.parse(raw); } catch { process.exit(3); }
+    const jobs = Array.isArray(o.jobs) ? o.jobs : [];
+    const now = Date.now();
+    for (const j of jobs) {
+      const st = j.status;
+      if (st !== "queued" && st !== "running") continue;
+      const ts = Date.parse(j.updatedAt || j.startedAt || j.createdAt || "");
+      const age = Number.isFinite(ts) ? Math.max(0, Math.round((now - ts) / 1000)) : -1;
+      // "-" sentinel for a null pid: TAB is whitespace-IFS in bash `read`, so an
+      // empty interior field would collapse and shift every later column.
+      const pid = (j.pid === null || j.pid === undefined) ? "-" : String(j.pid);
+      const title = String(j.title || "").replace(/[\t\r\n]+/g, " ").slice(0, 60);
+      process.stdout.write([st, pid, age, j.id || "?", title].join("\t") + "\n");
+    }
+  ' "$statefile"
+}
+
+findings=0
+checked_files=0
+
+for dir in "${STATE_DIRS[@]}"; do
+  statefile="$dir/state.json"
+  [ -f "$statefile" ] || continue
+  checked_files=$((checked_files + 1))
+
+  active_out="$(extract_active "$statefile")" || {
+    rc=$?
+    if [ "$rc" -eq 3 ]; then
+      echo "cannot-read: $statefile is not valid JSON." >&2
+      exit 2
+    fi
+    echo "cannot-read: failed to read $statefile (node rc=$rc)." >&2
+    exit 2
+  }
+
+  [ -n "$active_out" ] || continue
+
+  while IFS=$'\t' read -r status pid age id title; do
+    [ -n "${status:-}" ] || continue
+    [ "$pid" = "-" ] && pid=""   # decode the null-pid sentinel
+    # A job is STUCK when it is old enough AND has no live runner. A live pid
+    # means the worker is still doing the job (not stuck), regardless of age.
+    if [ "$age" -ge 0 ] && [ "$age" -lt "$THRESHOLD" ]; then
+      continue   # too fresh to call stuck
+    fi
+    if [ -n "$pid" ] && _pid_alive "$pid"; then
+      continue   # runner alive -> working, not stuck
+    fi
+    runner="dead pid $pid"
+    [ -n "$pid" ] || runner="no runner pid (foreground/never-detached)"
+    if [ "$findings" -eq 0 ]; then
+      echo "STUCK codex-companion job(s) - active but no live runner:"
+    fi
+    findings=$((findings + 1))
+    printf '  %-9s age=%ss  %s  [%s]  %s\n' "$status" "$age" "$id" "$runner" "$title"
+  done <<EOF
+$active_out
+EOF
+done
+
+if [ "$checked_files" -eq 0 ]; then
+  echo "healthy: no state.json under the resolved state dir(s) (no jobs to check)."
+  exit 0
+fi
+
+if [ "$findings" -gt 0 ]; then
+  echo "$findings stuck job(s) found (threshold ${THRESHOLD}s)."
+  exit 1
+fi
+
+echo "healthy: no stuck codex-companion jobs (threshold ${THRESHOLD}s)."
+exit 0

--- a/scripts/codex/reap-mcp-fleet.ps1
+++ b/scripts/codex/reap-mcp-fleet.ps1
@@ -1,0 +1,181 @@
+# reap-mcp-fleet.ps1 (HIMMEL-741) - report/reap ORPHANED Codex MCP-fleet processes.
+#
+# WHY: the Codex app-server (`codex.exe app-server`, launched via
+# app-server-broker.mjs) spawns a fleet of ~5-6 MCP server processes per job
+# (node_repl.exe, `uvx mcp-obsidian`, `bun ... --cwd <codex plugin cache> start`
+# and their `bun server.ts` grandchildren) and does NOT reap them when the job
+# ends. Repeated jobs pile up dozens of leaked node/bun/uvx processes on this
+# Windows box. This tool surfaces (default) or terminates (--kill) ONLY the
+# fleet processes whose Codex app-server ancestor is GONE - never a fleet with a
+# live app-server (that fleet is legitimately in use).
+#
+# GROUNDING (verified on this machine, 2026-07-07):
+#   Live topology, one app-server subtree (`Get-CimInstance Win32_Process`):
+#     codex.exe app-server (pid 51184)               <- SUPERVISOR
+#       |- node_repl.exe   ...\OpenAI\Codex\runtimes\cua_node\...\node_repl.exe
+#       |- uvx.exe         "...\uvx.exe" mcp-obsidian
+#       |- bun.exe         run --cwd C:/Users/.../.codex/plugins/cache/himmel/luna-correlate/... start
+#       |    \- bun.exe    server.ts        (grandchild, no codex marker of its own)
+#       \- bun.exe         run --cwd C:/Users/.../.codex/plugins/cache/himmel/telegram-himmel/... start
+#   The broker that owns the app-server:
+#     node ...\.claude\plugins\cache\openai-codex\codex\1.0.5\scripts\app-server-broker.mjs serve ...
+#   Multiple app-servers (51184 / 28748 / 61016 / desktop-app 66900) each carry
+#   their own fleet -> that duplication IS the flood.
+#
+# FINGERPRINT (deliberately conservative - "when unsure, exclude"):
+#   codex-owned  = own CommandLine references a codex-only path
+#                  (OpenAI\Codex\runtimes  OR  \.codex\plugins\cache\)  OR  Name=node_repl.exe.
+#                  These survive their parent's death (own cmdline still proves lineage).
+#   supervisor   = Name codex.exe/Codex.exe (app-server + desktop app)  OR  app-server-broker.mjs.
+#   A process is ORPHANED when it is codex-owned (or a descendant of a codex-owned
+#   process still in the table) AND walking its ParentProcessId chain reaches a
+#   dead/absent ancestor WITHOUT passing a LIVE supervisor.
+#   Bare `uvx mcp-obsidian` / `bun server.ts` whose whole codex parent chain has
+#   already vanished are NOT reaped (no codex marker to prove lineage) - the SAFE
+#   under-reap direction, mirroring restart-bridge.ps1's server.ts handling.
+#
+# USAGE:
+#   pwsh -NoProfile -File scripts/codex/reap-mcp-fleet.ps1            # report-only (default)
+#   pwsh -NoProfile -File scripts/codex/reap-mcp-fleet.ps1 -Kill     # terminate the orphans
+# Exit codes: 0 = ran (report or kill); 1 = usage/enumeration error.
+
+[CmdletBinding()]
+param(
+  [switch]$Kill,
+  # Dot-source seam for the hermetic test: define the functions, then return
+  # WITHOUT scanning the live process table.
+  [switch]$AsLibrary
+)
+
+# --- pure predicates + filter (fed a records array; unit-tested directly) ----
+
+function Test-CodexOwned {
+  param([Parameter(Mandatory)]$Proc)
+  if ($Proc.Name -and ($Proc.Name -ieq 'node_repl.exe')) { return $true }
+  $cl = [string]$Proc.CommandLine
+  if (-not $cl) { return $false }
+  return ($cl -match 'OpenAI[\\/]+Codex[\\/]+runtimes') -or ($cl -match '[\\/]+\.codex[\\/]+plugins[\\/]+cache[\\/]+')
+}
+
+function Test-FleetSupervisor {
+  param([Parameter(Mandatory)]$Proc)
+  if ($Proc.Name -and ($Proc.Name -ieq 'codex.exe')) { return $true }
+  $cl = [string]$Proc.CommandLine
+  if ($cl -and ($cl -match 'app-server-broker\.mjs')) { return $true }
+  return $false
+}
+
+# Walk the ParentProcessId chain over the supplied (live) record set.
+# Returns a hashtable: HasLiveSupervisor (bool), UnderCodex (bool - an ancestor
+# is codex-owned), DeadAncestorPid (first parent pid absent from the table, or $null).
+function Resolve-Ancestry {
+  param([Parameter(Mandatory)]$Proc, [Parameter(Mandatory)][hashtable]$ByPid)
+  $hasSup = $false; $underCodex = $false; $deadPid = $null
+  $seen = @{}
+  $cur = $Proc.ParentProcessId
+  $depth = 0
+  while ($null -ne $cur -and $cur -ne 0 -and $depth -lt 64) {
+    $depth++
+    if ($seen.ContainsKey([string]$cur)) { break }   # pid-reuse cycle guard
+    $seen[[string]$cur] = $true
+    if (-not $ByPid.ContainsKey([string]$cur)) { $deadPid = $cur; break }  # ancestor gone
+    $anc = $ByPid[[string]$cur]
+    if (Test-FleetSupervisor -Proc $anc) { $hasSup = $true; break }
+    if (Test-CodexOwned -Proc $anc)      { $underCodex = $true }
+    $cur = $anc.ParentProcessId
+  }
+  return @{ HasLiveSupervisor = $hasSup; UnderCodex = $underCodex; DeadAncestorPid = $deadPid }
+}
+
+# Pure orphan filter. $Procs = array of records exposing ProcessId,
+# ParentProcessId, Name, CommandLine (CreationDate optional). Returns the orphan
+# records annotated with a DeadAncestorPid note.
+function Get-OrphanFleet {
+  param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs)
+  $byPid = @{}
+  foreach ($p in $Procs) { if ($null -ne $p.ProcessId) { $byPid[[string]$p.ProcessId] = $p } }
+  $out = New-Object System.Collections.ArrayList
+  foreach ($p in $Procs) {
+    $isCodex = Test-CodexOwned -Proc $p
+    # A supervisor (the app-server / broker) is NEVER a reap target.
+    if (Test-FleetSupervisor -Proc $p) { continue }
+    $anc = Resolve-Ancestry -Proc $p -ByPid $byPid
+    $fleetRelated = $isCodex -or $anc.UnderCodex
+    # Orphan requires EVIDENCE of a broken chain (a dead/absent ancestor pid),
+    # not merely the absence of a recognized supervisor: a codex-owned process
+    # whose fully-live chain roots at PID 0 or an unrecognized supervisor
+    # variant must never be reaped (conservative under-reap).
+    if ($fleetRelated -and -not $anc.HasLiveSupervisor -and $null -ne $anc.DeadAncestorPid) {
+      $p | Add-Member -NotePropertyName DeadAncestorPid -NotePropertyValue $anc.DeadAncestorPid -Force
+      [void]$out.Add($p)
+    }
+  }
+  return $out.ToArray()
+}
+
+if ($AsLibrary) { return }
+
+# --- production path: enumerate the live table, report, optionally kill -------
+
+$ErrorActionPreference = 'Stop'
+
+try {
+  $records = @(Get-CimInstance Win32_Process -ErrorAction Stop |
+    ForEach-Object {
+      [pscustomobject]@{
+        ProcessId       = [int]$_.ProcessId
+        ParentProcessId = [int]$_.ParentProcessId
+        Name            = [string]$_.Name
+        CommandLine     = [string]$_.CommandLine
+        CreationDate    = $_.CreationDate
+      }
+    })
+} catch {
+  Write-Error "[reap-mcp-fleet] could not enumerate processes: $_"
+  exit 1
+}
+
+$orphans = @(Get-OrphanFleet -Procs $records)
+
+if ($orphans.Count -eq 0) {
+  Write-Host "[reap-mcp-fleet] no orphaned Codex MCP-fleet processes found."
+  exit 0
+}
+
+$now = Get-Date
+$rows = $orphans | ForEach-Object {
+  $ageStr = '?'
+  if ($_.CreationDate -is [datetime]) {
+    $mins = [int]([math]::Round(($now - $_.CreationDate).TotalMinutes))
+    $ageStr = "${mins}m"
+  }
+  $snip = if ($_.CommandLine) { $_.CommandLine.Substring(0, [Math]::Min(80, $_.CommandLine.Length)) } else { '' }
+  [pscustomobject]@{
+    PID          = $_.ProcessId
+    Name         = $_.Name
+    Age          = $ageStr
+    DeadAncestor = $_.DeadAncestorPid
+    Cmdline      = $snip
+  }
+}
+
+Write-Host ("[reap-mcp-fleet] {0} orphaned Codex MCP-fleet process(es):" -f $orphans.Count)
+$rows | Format-Table -AutoSize | Out-String -Width 200 | Write-Host
+
+if (-not $Kill) {
+  Write-Host "[reap-mcp-fleet] report-only (default). Re-run with -Kill to terminate the above."
+  exit 0
+}
+
+$killed = 0
+foreach ($o in $orphans) {
+  try {
+    Stop-Process -Id $o.ProcessId -Force -ErrorAction Stop
+    Write-Host "[reap-mcp-fleet] killed pid $($o.ProcessId) ($($o.Name))"
+    $killed++
+  } catch {
+    Write-Warning "[reap-mcp-fleet] could not kill pid $($o.ProcessId): $_"
+  }
+}
+Write-Host ("[reap-mcp-fleet] terminated {0}/{1} orphan(s)." -f $killed, $orphans.Count)
+exit 0

--- a/scripts/codex/reap-mcp-fleet.sh
+++ b/scripts/codex/reap-mcp-fleet.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# reap-mcp-fleet.sh (HIMMEL-741) - thin twin of reap-mcp-fleet.ps1.
+#
+# The Codex MCP-fleet flood is a Windows-process-tree problem (Win32_Process
+# ancestry walk). The real logic lives in the .ps1; on Windows this forwards to
+# pwsh, on every other platform it is a no-op (nothing to reap - Codex on
+# mac/Linux reaps its own children). Kept only to satisfy the .ps1/.sh twin
+# convention and give a stable cross-platform entrypoint.
+#
+#   scripts/codex/reap-mcp-fleet.sh          # report-only (default)
+#   scripts/codex/reap-mcp-fleet.sh --kill   # forwards -Kill to the .ps1
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PS1="$SCRIPT_DIR/reap-mcp-fleet.ps1"
+
+case "${OSTYPE:-$(uname -s 2>/dev/null || echo unknown)}" in
+  msys*|cygwin*|win32*|MINGW*|MSYS*) ;;
+  *)
+    echo "[reap-mcp-fleet] non-Windows platform - the Codex MCP-fleet flood is Windows-only; nothing to do."
+    exit 0
+    ;;
+esac
+
+PWSH_BIN=""
+for c in pwsh pwsh.exe powershell.exe; do
+  if command -v "$c" >/dev/null 2>&1; then PWSH_BIN="$c"; break; fi
+done
+if [ -z "$PWSH_BIN" ]; then
+  echo "ERR: pwsh not found on PATH - run scripts/codex/reap-mcp-fleet.ps1 directly." >&2
+  exit 1
+fi
+
+PS_ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --kill) PS_ARGS+=("-Kill") ;;
+    -h|--help) sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "ERR: unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+# Guard the empty-array expansion (bash 3.2 + set -u treats "${a[@]}" on an
+# empty array as an unbound variable).
+exec "$PWSH_BIN" -NoProfile -ExecutionPolicy Bypass -File "$PS1" ${PS_ARGS[@]+"${PS_ARGS[@]}"}

--- a/scripts/codex/test-companion-liveness.sh
+++ b/scripts/codex/test-companion-liveness.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Hermetic tests for companion-liveness.sh (HIMMEL-741).
+# No real Codex install: temp state dirs hold fixture state.json files shaped
+# exactly like lib/state.mjs (queued/running jobs with real+dead pids, empty,
+# missing, corrupt). Asserts the exit-code contract: 0 healthy / 1 findings /
+# 2 cannot-read.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROBE="$SCRIPT_DIR/companion-liveness.sh"
+
+command -v node >/dev/null 2>&1 || command -v node.exe >/dev/null 2>&1 || {
+  echo "FAIL: node required" >&2; exit 1; }
+
+fails=0
+pass() { echo "  ok: $1"; }
+fail() { echo "  FAIL: $1" >&2; fails=$((fails + 1)); }
+assert_rc() {  # assert_rc <expected> <ok-name> <fail-detail>
+  if [ "$RC" -eq "$1" ]; then pass "$2"; else fail "$3"; fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+export CODEX_STUCK_THRESHOLD_SECS=60
+
+NOW_ISO="$(node -e 'process.stdout.write(new Date().toISOString())' 2>/dev/null \
+        || node.exe -e 'process.stdout.write(new Date().toISOString())')"
+STALE_ISO='2020-01-01T00:00:00.000Z'
+
+# A definitely-live pid the script's _pid_alive will confirm on THIS platform.
+case "${OSTYPE:-$(uname -s 2>/dev/null || echo unknown)}" in
+  msys*|cygwin*|win32*|MINGW*|MSYS*)
+    # MSYS $$ does not map to a Windows pid; use System (pid 4), always alive.
+    LIVE_PID="$(MSYS_NO_PATHCONV=1 tasklist /FO CSV /NH 2>/dev/null | sed -n '2p' | sed 's/^"[^"]*","\([0-9]*\)".*/\1/')"
+    [ -n "$LIVE_PID" ] || LIVE_PID=4
+    ;;
+  *) LIVE_PID="$$" ;;
+esac
+DEAD_PID=999999   # nothing this high should be live in a test run
+
+# --- fixture helpers ---------------------------------------------------------
+# make_state <dir> <status> <pid-json> <updatedAt>
+make_state() {
+  local dir="$1" status="$2" pidjson="$3" ts="$4"
+  mkdir -p "$dir"
+  cat > "$dir/state.json" <<JSON
+{
+  "version": 1,
+  "config": { "stopReviewGate": false },
+  "jobs": [
+    {
+      "id": "task-fixture-01",
+      "kind": "task",
+      "kindLabel": "rescue",
+      "title": "Fixture Codex Task",
+      "workspaceRoot": "C:/tmp/ws",
+      "jobClass": "task",
+      "status": "$status",
+      "createdAt": "$ts",
+      "updatedAt": "$ts",
+      "startedAt": "$ts",
+      "pid": $pidjson,
+      "logFile": "$dir/task-fixture-01.log"
+    }
+  ]
+}
+JSON
+}
+
+run_probe() {  # run_probe <state-dir> ; sets $RC and $OUT
+  set +e
+  OUT="$(CODEX_STATE_DIR="$1" bash "$PROBE" 2>&1)"
+  RC=$?
+  set -e
+}
+
+# --- 1: queued + stale + null pid -> STUCK (exit 1) --------------------------
+D="$TMP/queued-stale"; make_state "$D" 'queued' 'null' "$STALE_ISO"
+run_probe "$D"
+assert_rc 1 "queued-stale null-pid exits 1" "queued-stale rc=$RC out=$OUT"
+case "$OUT" in *"STUCK"*"task-fixture-01"*) pass "queued-stale names the job";; *) fail "queued-stale output: $OUT";; esac
+
+# --- 2: queued + fresh -> healthy (exit 0) -----------------------------------
+D="$TMP/queued-fresh"; make_state "$D" 'queued' 'null' "$NOW_ISO"
+run_probe "$D"
+assert_rc 0 "queued-fresh exits 0" "queued-fresh rc=$RC out=$OUT"
+
+# --- 3: running + stale + LIVE pid -> healthy (runner alive) ------------------
+D="$TMP/running-live"; make_state "$D" 'running' "$LIVE_PID" "$STALE_ISO"
+run_probe "$D"
+assert_rc 0 "running-with-live-pid exits 0" "running-live rc=$RC out=$OUT (LIVE_PID=$LIVE_PID)"
+
+# --- 4: running + stale + DEAD pid -> STUCK (exit 1) -------------------------
+D="$TMP/running-dead"; make_state "$D" 'running' "$DEAD_PID" "$STALE_ISO"
+run_probe "$D"
+assert_rc 1 "running-with-dead-pid exits 1" "running-dead rc=$RC out=$OUT"
+
+# --- 5: empty jobs array -> healthy (exit 0) ---------------------------------
+D="$TMP/empty"; mkdir -p "$D"
+printf '%s\n' '{ "version": 1, "config": {}, "jobs": [] }' > "$D/state.json"
+run_probe "$D"
+assert_rc 0 "empty jobs exits 0" "empty rc=$RC out=$OUT"
+
+# --- 6: missing state.json -> healthy (exit 0) -------------------------------
+D="$TMP/missing"; mkdir -p "$D"
+run_probe "$D"
+assert_rc 0 "missing state.json exits 0" "missing rc=$RC out=$OUT"
+
+# --- 7: corrupt JSON -> cannot-read (exit 2) ---------------------------------
+D="$TMP/corrupt"; mkdir -p "$D"
+printf '%s\n' '{ this is : not json' > "$D/state.json"
+run_probe "$D"
+assert_rc 2 "corrupt json exits 2" "corrupt rc=$RC out=$OUT"
+
+# --- 8: slug resolution via CODEX_STATE_ROOT + workspace ---------------------
+ROOT="$TMP/root"; WS="$TMP/ws-himmel/my.repo"
+mkdir -p "$WS"
+# slug of basename 'my.repo' is 'my.repo' (dots/dashes preserved).
+make_state "$ROOT/my.repo-deadbeefdeadbeef" 'queued' 'null' "$STALE_ISO"
+set +e
+OUT="$(CODEX_STATE_ROOT="$ROOT" bash "$PROBE" "$WS" 2>&1)"; RC=$?
+set -e
+assert_rc 1 "slug-matched state dir found via workspace (exit 1)" "slug-match rc=$RC out=$OUT"
+
+# --- 9: nonexistent state root -> healthy (exit 0) ---------------------------
+set +e
+OUT="$(CODEX_STATE_ROOT="$TMP/does-not-exist" bash "$PROBE" "$TMP/ws-himmel/my.repo" 2>&1)"; RC=$?
+set -e
+assert_rc 0 "nonexistent state root exits 0" "no-root rc=$RC out=$OUT"
+
+# --- 10: tmpdir fallback root (CLAUDE_PLUGIN_DATA unset) is scanned ----------
+# lib/state.mjs falls back to os.tmpdir()/codex-companion when the harness does
+# not set CLAUDE_PLUGIN_DATA; a stuck job there must be found, not false-healthy.
+FAKE_TMP="$TMP/fake-tmpdir"; FAKE_HOME="$TMP/fake-home"
+mkdir -p "$FAKE_TMP" "$FAKE_HOME"
+make_state "$FAKE_TMP/codex-companion/my.repo-cafebabecafebabe" 'queued' 'null' "$STALE_ISO"
+set +e
+OUT="$(env -u CODEX_STATE_ROOT -u CLAUDE_PLUGIN_DATA TMPDIR="$FAKE_TMP" HOME="$FAKE_HOME" \
+    CODEX_STUCK_THRESHOLD_SECS=60 bash "$PROBE" "$TMP/ws-himmel/my.repo" 2>&1)"; RC=$?
+set -e
+assert_rc 1 "tmpdir fallback root scanned (stuck job found, exit 1)" "tmpdir-fallback rc=$RC out=$OUT"
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "FAILED: $fails test(s)"; exit 1
+fi
+echo "ALL PASS"

--- a/scripts/codex/test-reap-mcp-fleet.ps1
+++ b/scripts/codex/test-reap-mcp-fleet.ps1
@@ -1,0 +1,94 @@
+# Hermetic tests for reap-mcp-fleet.ps1 (HIMMEL-741).
+# Get-CimInstance is NOT mocked: the .ps1 exposes a pure filter, Get-OrphanFleet,
+# that takes a synthetic process-records array. We dot-source the script with
+# -AsLibrary (defines functions, skips the live scan) and assert the orphan set
+# for a hand-built topology that mirrors the real machine grounding.
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Helper = Join-Path $ScriptDir 'reap-mcp-fleet.ps1'
+$Pass = 0
+$Fail = 0
+function Pass([string]$Name) { Write-Host "  PASS  $Name"; $script:Pass++ }
+function Fail([string]$Name, [string]$Detail = '') { Write-Host "  FAIL  $Name $Detail"; $script:Fail++ }
+function Check([string]$Name, [bool]$Ok, [string]$Detail = '') { if ($Ok) { Pass $Name } else { Fail $Name $Detail } }
+
+# Load the functions without running the production scan.
+. $Helper -AsLibrary
+
+function Rec($procId, $parentId, $name, $cl) {
+  [pscustomobject]@{ ProcessId = $procId; ParentProcessId = $parentId; Name = $name; CommandLine = $cl }
+}
+
+# Fixture command lines derive from the running user's profile dir (no literal
+# home paths in source — the propagation leak scan fail-closes on them). The
+# reaper's ownership predicates match username-independent fragments
+# (OpenAI\Codex\runtimes, .codex\plugins\cache), so any profile root works.
+$UserHome = $env:USERPROFILE
+$UserHomeFwd = $UserHome -replace '\\', '/'
+$CODEX_RUNTIME = "$UserHome\AppData\Local\OpenAI\Codex\runtimes\cua_node\1b23c930\bin\node_repl.exe"
+$BUN_LUNA = "run --cwd $UserHomeFwd/.codex/plugins/cache/himmel/luna-correlate/0.2.0 --shell=bun --silent start"
+$BROKER   = "node $UserHome\.claude\plugins\cache\openai-codex\codex\1.0.5\scripts\app-server-broker.mjs serve"
+
+# --- topology ----------------------------------------------------------------
+$procs = @(
+  # LIVE fleet under a live app-server (which the live broker owns).
+  (Rec 90  1   'node.exe'      $BROKER)                                   # broker (supervisor, live)
+  (Rec 100 90  'codex.exe'     'codex.exe app-server')                    # app-server (supervisor, live)
+  (Rec 101 100 'node_repl.exe' $CODEX_RUNTIME)                            # live fleet child -> NOT orphan
+  (Rec 102 100 'uvx.exe'       "`"$UserHomeFwd/.local/bin/uvx.exe`" mcp-obsidian") # live fleet child -> NOT orphan
+
+  # ORPHANED fleet: app-server pid 200 is DEAD (absent from the table).
+  (Rec 201 200 'node_repl.exe' $CODEX_RUNTIME)                            # codex-owned, parent gone -> ORPHAN
+  (Rec 202 200 'bun.exe'       "bun $BUN_LUNA")                           # codex-owned, parent gone -> ORPHAN
+  (Rec 203 202 'bun.exe'       'bun server.ts')                           # under codex 202 -> ORPHAN
+
+  # Non-codex MCP servers (Claude-launched) must be untouched.
+  (Rec 301 1   'node.exe'      'node claude cli')                         # not a supervisor by our narrow def
+  (Rec 300 301 'node.exe'      '"node" @playwright/mcp/cli.js')           # not codex-owned -> NOT orphan
+
+  # Safe under-reap: bun server.ts whose codex launcher parent (211) is ALSO gone.
+  (Rec 210 211 'bun.exe'       'bun server.ts')                           # no marker, parent gone -> NOT orphan
+
+  # Kill-safety: codex-owned proc with a FULLY-LIVE chain rooting at PID 0 and
+  # no recognized supervisor in it (e.g. launched under an unrecognized
+  # supervisor variant). No dead link -> NOT orphan, never reaped.
+  (Rec 401 0   'pwsh.exe'      'pwsh -NoProfile -File dev-driver.ps1')    # live non-supervisor root
+  (Rec 400 401 'node.exe'      $CODEX_RUNTIME)                            # codex-owned, live chain -> NOT orphan
+)
+
+$orphans = @(Get-OrphanFleet -Procs $procs)
+$got = @($orphans | ForEach-Object { $_.ProcessId } | Sort-Object)
+$want = @(201, 202, 203)
+
+Write-Host "Test 1: exact orphan set = dead-app-server fleet + its server.ts descendant"
+Check 'orphan set is {201,202,203}' (($got -join ',') -eq ($want -join ',')) "got=$($got -join ',')"
+
+Write-Host "Test 2: live fleet + supervisors + non-codex + under-reap are all excluded"
+Check 'live node_repl 101 excluded'      (-not ($got -contains 101))
+Check 'live uvx 102 excluded'            (-not ($got -contains 102))
+Check 'app-server 100 never reaped'      (-not ($got -contains 100))
+Check 'broker 90 never reaped'           (-not ($got -contains 90))
+Check 'non-codex playwright 300 excluded' (-not ($got -contains 300))
+Check 'orphan-parent server.ts 210 excluded (safe under-reap)' (-not ($got -contains 210))
+
+Write-Host "Test 3: DeadAncestorPid annotation points at the vanished app-server"
+$o201 = $orphans | Where-Object { $_.ProcessId -eq 201 }
+Check 'node_repl 201 dead ancestor = 200' ($o201.DeadAncestorPid -eq 200) "got=$($o201.DeadAncestorPid)"
+
+Write-Host "Test 4: empty input yields no orphans (no throw)"
+$empty = @(Get-OrphanFleet -Procs @())
+Check 'empty input -> 0 orphans' ($empty.Count -eq 0)
+
+Write-Host "Test 5: predicates classify the grounded fingerprints"
+Check 'node_repl is codex-owned'   (Test-CodexOwned -Proc (Rec 1 0 'node_repl.exe' $CODEX_RUNTIME))
+Check '.codex plugin cache bun is codex-owned' (Test-CodexOwned -Proc (Rec 1 0 'bun.exe' "bun $BUN_LUNA"))
+Check 'bare uvx mcp-obsidian NOT codex-owned'  (-not (Test-CodexOwned -Proc (Rec 1 0 'uvx.exe' 'uvx mcp-obsidian')))
+Check 'codex.exe is a supervisor'  (Test-FleetSupervisor -Proc (Rec 1 0 'codex.exe' 'codex.exe app-server'))
+Check 'broker.mjs is a supervisor' (Test-FleetSupervisor -Proc (Rec 1 0 'node.exe' $BROKER))
+Check 'playwright node NOT a supervisor' (-not (Test-FleetSupervisor -Proc (Rec 1 0 'node.exe' '"node" @playwright/mcp/cli.js')))
+
+Write-Host "Results: $Pass passed, $Fail failed"
+if ($Fail -ne 0) { exit 1 }
+exit 0


### PR DESCRIPTION
Propagation of private #973 + #974: reap-mcp-fleet (report-only default, -Kill opt-in, dead-ancestor-link required), companion-liveness probe across all state roots, hermetic tests with USERPROFILE-derived fixtures.