### PR TITLE
fix(doctor): C13-plugin-hooks resolve check + T17b seed-copy red-path test

### DIFF
--- a/scripts/himmel-doctor.sh
+++ b/scripts/himmel-doctor.sh
@@ -483,6 +483,45 @@ check_c12() {
     esac
 }
 
+# --- C13: himmel-ops plugin hooks resolve in this checkout ----------------------
+# The plugin-delivered hooks.json deliberately guards project-local hooks with
+# `[ -f "$h" ] && exec ...` so external/adopter repos fail open.  That also makes
+# a missing/moved himmel hook script silent in a himmel checkout.  Doctor surfaces
+# that drift without changing hook runtime semantics.
+check_c13() {
+    local hooks_files=() hooks_json f
+    if [ -n "${DOCTOR_HIMMEL_OPS_HOOKS_JSON:-}" ]; then
+        hooks_files=("$DOCTOR_HIMMEL_OPS_HOOKS_JSON")
+    else
+        for f in "$REPO_ROOT/marketplace/plugins/himmel-ops/hooks/hooks.json" \
+                 "$CLAUDE_DIR_R"/plugins/cache/himmel/himmel-ops/*/hooks/hooks.json \
+                 "$CLAUDE_DIR_R"/plugins/repos/*/himmel-ops/hooks/hooks.json; do
+            [ -f "$f" ] && hooks_files+=("$f")
+        done
+    fi
+    if [ "${#hooks_files[@]}" -eq 0 ]; then
+        emit INFO C13-plugin-hooks "himmel-ops hooks.json not found (skipped)" "run /himmel-update or verify the himmel-ops plugin install"
+        return
+    fi
+    local missing="" cmd rel target
+    for hooks_json in "${hooks_files[@]}"; do
+        while IFS= read -r cmd; do
+            [ -n "$cmd" ] || continue
+            rel="$(printf '%s\n' "$cmd" | sed -n 's#.*CLAUDE_PROJECT_DIR/\([^"]*\)".*#\1#p')"
+            [ -n "$rel" ] || continue
+            target="$REPO_ROOT/$rel"
+            [ -f "$target" ] || missing="$missing $rel"
+        done <<EOF_CMDS
+$(jq -r '(.hooks // {}) | to_entries[] | .value[]? | .hooks[]? | .command // empty | select(contains("CLAUDE_PROJECT_DIR/"))' "$hooks_json" 2>/dev/null)
+EOF_CMDS
+    done
+    if [ -n "$missing" ]; then
+        emit WARN C13-plugin-hooks "himmel-ops hooks.json references missing checkout hook(s):$missing - guarded [ -f ] wrappers will silently no-op" "run /himmel-update or restore the missing script(s), then re-run"
+    else
+        emit OK C13-plugin-hooks "himmel-ops plugin hooks resolve in this checkout"
+    fi
+}
+
 # --- issue filing ---------------------------------------------------------------
 resolve_issue_repo() {
     [ -n "$REPO_FLAG" ] && { printf '%s\n' "$REPO_FLAG"; return 0; }
@@ -535,6 +574,7 @@ check_c9
 check_c10
 check_c11
 check_c12
+check_c13
 echo
 printf 'Summary: %s%d FAIL%s  %s%d WARN%s  %s%d INFO%s\n' "$C_RED" "$n_fail" "$C_0" "$C_YEL" "$n_warn" "$C_0" "$C_DIM" "$n_info" "$C_0"
 

--- a/scripts/test-claude-routed.ps1
+++ b/scripts/test-claude-routed.ps1
@@ -257,6 +257,22 @@ try {
   if (Test-Path -LiteralPath $ChildEnv) { Fail 'claude launched despite missing node' } else { Pass 'claude not launched when node missing' }
   if (FileHas $OutTxt 'FAILED to sanitize settings.json') { Pass 'node-missing emits the failed-seed message' } else { Fail 'node-missing did not emit the failed-seed message' }
 
+  # --- T17b: a Copy-Item failure inside the allowlisted seed copy block maps to
+  # exit 4 (the "failed seed" contract), never a raw exit 1, and never launches
+  # claude. Fixture: the child launcher cannot read an exclusively locked source. ---
+  New-Sandbox; $script:KEY = 'omni-test-123'  # gitleaks:allow
+  $lockedSeed = Join-Path $FAKEHOME '.claude\CLAUDE.md'
+  'locked' | Set-Content -LiteralPath $lockedSeed -NoNewline
+  $lock = [System.IO.File]::Open($lockedSeed, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+  try {
+    Assert-Exit (Invoke-Launcher) 4 'seed Copy-Item failure exits 4'
+  } finally {
+    $lock.Dispose()
+  }
+  if (Test-Path -LiteralPath $ChildEnv) { Fail 'claude launched despite seed Copy-Item failure' } else { Pass 'claude not launched on seed Copy-Item failure' }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\.seeded')) { Fail 'sentinel written despite seed Copy-Item failure' } else { Pass 'no sentinel on seed Copy-Item failure' }
+  if (FileHas $OutTxt 'FAILED to seed config dir') { Pass 'copy failure emits the failed-seed message' } else { Fail 'copy failure did not emit the failed-seed message' }
+
   # --- T18 (guard I7): phi-roots that is a DIRECTORY (not a readable regular file)
   # fails CLOSED with exit 3, never silently allows egress, never launches claude.
   # PS twin of bash T17 — proves the PS guard maps the not-a-leaf case to the

--- a/scripts/test-himmel-doctor.sh
+++ b/scripts/test-himmel-doctor.sh
@@ -445,6 +445,22 @@ else
 fi
 rm -rf "$t"
 
+echo "== C13: himmel-ops hooks.json target missing -> WARN C13-plugin-hooks =="
+t="$(mktemp -d)"; mkdir -p "$t/claude" "$t/plugin-hooks"; write_settings "$t/claude" "$WRAPPER"
+cat > "$t/plugin-hooks/hooks.json" <<'EOF'
+{ "hooks": { "PreToolUse": [ { "matcher": "Bash", "hooks": [ { "type": "command", "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/no-such-hook.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; fi'" } ] } ] } } }
+EOF
+out="$(DOCTOR_HIMMEL_OPS_HOOKS_JSON="$t/plugin-hooks/hooks.json" DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" \
+    CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"
+if printf '%s' "$out" | grep -q 'WARN C13-plugin-hooks' && printf '%s' "$out" | grep -q 'scripts/hooks/no-such-hook.sh'; then pass "C13 -> WARN (missing hook target)"; else fail "C13 -> $(printf '%s' "$out" | grep C13)"; fi
+rm -rf "$t"
+
+echo "== C13: shipped himmel-ops hooks.json targets exist -> OK C13-plugin-hooks =="
+t="$(mktemp -d)"; mkdir -p "$t/claude"; write_settings "$t/claude" "$WRAPPER"
+out="$(DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"
+if printf '%s' "$out" | grep -q 'OK   C13-plugin-hooks'; then pass "C13 -> OK (shipped hook targets exist)"; else fail "C13 -> $(printf '%s' "$out" | grep C13)"; fi
+rm -rf "$t"
+
 rm -rf "$FAKEROOT"
 echo
 if [ "$failures" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$failures FAILURE(S)"; exit 1; fi


### PR DESCRIPTION
Propagation of private #976: himmel-doctor C13 check that plugin hooks.json commands resolve in the checkout (guarded [ -f ] wrappers can no longer silently no-op), plus the T17b Copy-SeedConfig red-path test and doctor-harness cases.