### PR TITLE
fix(telegram): GLM-lane CR salvage batch - guard order, log-append isolation, fail-closed salus stat, comment anchors

### DIFF
--- a/docs/glm-offload.md
+++ b/docs/glm-offload.md
@@ -382,6 +382,14 @@ below (`gh pr create/merge/edit/review/comment/ready`, `gh api`, `gh repo`,
 aliases), and all `mcp__*` tools EXCEPT the qmd KB carve-out.
 Off-lane sessions exit immediately.
 
+**Why blanket-block the network CLIs** (mirror of the deny-hook header): a
+read-vs-write split would mean parsing each CLI's write flags (`curl -X POST`,
+`wget --post-data`, `iwr -Method`), and that flag parsing is fragile once the
+command is lowercased and reshaped by the hook — so a verb-list deny is the
+fail-closed choice, not a flag-position heuristic. v1 GLM chores are repo-local
+anyway, which is why `bun`/`npm` dependency fetch stays allowed (it is
+dependency fetch, not an external write).
+
 **Allowed on-lane (operator policy 2026-07-03 — audited-action carve-out):**
 the **Jira CLI** (`node scripts/jira/dist/index.js …` or bare `jira`) — writes
 are audited in Jira history and recoverable, so GLM workers may update status,

--- a/scripts/claude-glm
+++ b/scripts/claude-glm
@@ -28,6 +28,8 @@ if [ -z "${ZAI_API_KEY-}" ] && [ -f "$HERE/lib/load-dotenv.sh" ]; then
   # load_dotenv leaves surrounding quotes literal (the shared lib does not strip
   # them); drop ONE matching surrounding quote pair so a `.env` value written as
   # ZAI_API_KEY="…" doesn't send the quotes to the API. bash 3.2-safe.
+  # Anchor name: "surrounding-quote-strip" - referenced by name (not line
+  # numbers) from scripts/telegram/glm-env.ts's twin strip.
   case "${ZAI_API_KEY-}" in
     \"*\") ZAI_API_KEY="${ZAI_API_KEY#\"}"; ZAI_API_KEY="${ZAI_API_KEY%\"}" ;;
     \'*\') ZAI_API_KEY="${ZAI_API_KEY#\'}"; ZAI_API_KEY="${ZAI_API_KEY%\'}" ;;

--- a/scripts/telegram/glm-env.ts
+++ b/scripts/telegram/glm-env.ts
@@ -17,7 +17,7 @@ function parseZaiKeyFromEnv(envFile: string): string | undefined {
     const m = raw.match(/^\s*(?:export\s+)?ZAI_API_KEY\s*=\s*(.*)\s*$/);
     if (!m) continue;
     let v = m[1].trim();
-    // one matching surrounding quote pair stripped — parity with claude-glm:26-29
+    // one matching surrounding quote pair stripped — parity with claude-glm's "surrounding-quote-strip" case block (named anchor, not line numbers)
     if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
     return v || undefined;
   }

--- a/scripts/telegram/glm-guard.test.ts
+++ b/scripts/telegram/glm-guard.test.ts
@@ -95,3 +95,28 @@ test("guard config read THROW fails closed (catch branch — e.g. permission-den
     mock.restore();
   }
 });
+
+test(".salus stat THROW fails closed, not open (#850 — e.g. permission-denied)", () => {
+  // Do NOT create .salus: the mock makes statSync throw EACCES (not ENOENT) for
+  // it. existsSync-based code returns false → passes (fail-OPEN); the statSync
+  // fix distinguishes non-ENOENT errors and fails CLOSED, matching the list checks.
+  const salus = join(work, ".salus");
+  mock.module("node:fs", () => ({
+    ...realFsSnapshot,
+    statSync: (p: any, ...rest: any[]) => {
+      if (typeof p === "string" && p === salus) {
+        const err: NodeJS.ErrnoException = new Error("EACCES: permission denied");
+        err.code = "EACCES";
+        throw err;
+      }
+      return realFsSnapshot.statSync(p, ...rest);
+    },
+  }));
+  try {
+    const r = checkGlmGuards(work, cfg);
+    expect(r.ok).toBe(false);
+    expect((r as any).reason).toMatch(/failing closed/);
+  } finally {
+    mock.restore();
+  }
+});

--- a/scripts/telegram/glm-guard.ts
+++ b/scripts/telegram/glm-guard.ts
@@ -31,8 +31,18 @@ function pathUnderAny(target: string, listFile: string): "hit" | "miss" | "unrea
 }
 
 export function checkGlmGuards(cwd: string, cfgDir: string = join(homedir(), ".config", "claude-glm")): GuardResult {
-  if (existsSync(join(cwd, ".salus")))
+  // .salus root marker (#850): existsSync fails OPEN (returns false on a stat
+  // error like EACCES/EIO), which would let an unreadable .salus slip through as
+  // "not PHI". statSync distinguishes a real ENOENT (absent) from any other stat
+  // error, failing CLOSED — matching the pathUnderAny list checks' posture below.
+  try {
+    statSync(join(cwd, ".salus"));
     return { ok: false, reason: `glm-guard: REFUSED — ${cwd} is PHI-marked (.salus). No override exists.` };
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException | undefined)?.code;
+    if (code !== "ENOENT")
+      return { ok: false, reason: `glm-guard: .salus at ${cwd} is not a readable stat target (stat code ${code ?? "?"}) — failing closed.` };
+  }
   for (const [file, label] of [["phi-roots", "PHI-marked (phi-roots)"], ["egress-denylist", "on the egress denylist"]] as const) {
     const rc = pathUnderAny(cwd, join(cfgDir, file));
     if (rc === "unreadable")

--- a/scripts/telegram/spawn-glm.test.ts
+++ b/scripts/telegram/spawn-glm.test.ts
@@ -122,6 +122,17 @@ test("window preflight runs BEFORE git worktree add — a refusal leaves no orph
   expect(preIdx).toBeLessThan(wtIdx);
 });
 
+test("GLM guard check runs BEFORE git worktree add — a refusal leaves no orphan (wiring pin, #848)", () => {
+  const src = readFileSync("scripts/telegram/spawn-glm.ts", "utf8");
+  const guardIdx = src.indexOf("checkGlmGuards(");
+  const wtIdx = src.indexOf('"worktree", "add"');
+  const poisonIdx = src.indexOf("poisonPushUrl(absCwd");
+  expect(guardIdx).toBeGreaterThan(-1);
+  expect(wtIdx).toBeGreaterThan(-1);
+  expect(guardIdx).toBeLessThan(wtIdx);
+  expect(guardIdx).toBeLessThan(poisonIdx);
+});
+
 test("transcript dir derives from escaped cwd, not slug", () => {
   const d = transcriptDirFor("C:\\Users\\alice\\Documents\\github\\himmel\\.claude\\worktrees\\glm+a");
   expect(d).toBe(join(homedir(), ".claude", "projects",
@@ -317,6 +328,21 @@ test("executeRun: a plain failed run (no prompt-too-long tail) has NO failure_cl
     const meta = JSON.parse(readFileSync(metaPath, "utf8"));
     expect(meta.status).toBe("failed");
     expect(meta.failure_class).toBeUndefined();
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("executeRun: a run.log append failure does NOT flip a successful run to failed (#849)", async () => {
+  const { dir, metaPath, runningMeta } = seedRunningMeta();
+  try {
+    // Force the cosmetic run.log append to throw (EISDIR) by making run.log a
+    // directory. The append is isolated from the terminal-state write, so a
+    // successful run (code 0) must stay "done", not throw into the outer catch.
+    mkdirSync(join(dir, "run.log"));
+    const ok = (async () => ({ code: 0, capped: false, blocked: false, timedOut: false, pid: 5, tail: "done tail" })) as any;
+    const { code } = await executeRun({ runSession: ok, prompt: "p", worktree: "/wt", sessionDir: dir, metaPath, runningMeta });
+    expect(code).toBe(0);
+    const meta = JSON.parse(readFileSync(metaPath, "utf8"));
+    expect(meta.status).toBe("done");
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 

--- a/scripts/telegram/spawn-glm.ts
+++ b/scripts/telegram/spawn-glm.ts
@@ -223,7 +223,14 @@ export async function executeRun(deps: {
 }): Promise<{ code: number }> {
   try {
     const res = await deps.runSession(deps.prompt, deps.worktree, deps.permMode, "glm");
-    if (res.tail !== undefined) appendFileSync(join(deps.sessionDir, "run.log"), res.tail);
+    // run.log append is COSMETIC persistence (the debug tail). Isolate it (#849):
+    // an I/O failure here (EACCES/EISDIR/ENOSPC) must NOT throw into the outer
+    // catch — that writes status:failed + rethrows, flipping a successful run to
+    // failed. The final-meta write below is the load-bearing terminal-state record.
+    if (res.tail !== undefined) {
+      try { appendFileSync(join(deps.sessionDir, "run.log"), res.tail); }
+      catch (e) { console.error(`spawn-glm: run.log append failed (non-fatal): ${String((e as any)?.message ?? e)}`); }
+    }
     const fm = finalMeta(res.code, res.pid, res.capped, res.blocked, res.timedOut);
     writeFileSync(deps.metaPath, JSON.stringify({ ...deps.runningMeta, ...fm }, null, 2));
     // HIMMEL-740: an honest failure_class for the submit-reject. ONLY on a bare
@@ -337,12 +344,16 @@ async function main(): Promise<void> {
   const pre = preflightWindowCheck({ briefChars: briefText.length, overheadChars, windowTokens });
   if (!pre.ok) { console.error(pre.reason); process.exit(2); }
 
+  // GLM guard (spec D2) BEFORE any worktree/branch mutation (#848): a refusal
+  // must leave NO orphan worktree/branch/poisoned-pushurl behind. The
+  // path-under-list checks resolve plan.worktree as a string, so a PHI- or
+  // egress-denied dispatch path refuses here, pre-creation.
+  const guard = checkGlmGuards(plan.worktree);
+  if (!guard.ok) { console.error(guard.reason); process.exit(3); }
+
   const g = (args: string[]) => { const r = Bun.spawnSync(["git", "-C", absCwd, ...args], { stdout: "pipe", stderr: "pipe" }); if (r.exitCode !== 0) throw new Error(`git ${args[0]} failed: ${r.stderr.toString()}`); };
   g(["worktree", "add", plan.worktree, "-b", plan.branch]);
   poisonPushUrl(absCwd, plan.worktree);
-
-  const guard = checkGlmGuards(plan.worktree);
-  if (!guard.ok) { console.error(guard.reason); process.exit(3); }
 
   mkdirSync(sessionDir, { recursive: true });
   // GLM_SESSION_DIR (spec D5): the deny hook (running inside the worker child)


### PR DESCRIPTION
Propagation of private #978: five CR-deferred GLM-lane fixes - guard-before-mutation ordering in spawn-glm (orphan-free refusal), run.log append isolation, fail-closed .salus stat in glm-guard, named comment anchors, network-CLI blocklist rationale. Each behavioral fix pinned by a regression test; suite green (383 pass).