### PR TITLE
fix(adopt): wire qmd end-to-end in adopt flow + un-crash canonical install

### DIFF
--- a/docs/internals/environment-gotchas.md
+++ b/docs/internals/environment-gotchas.md
@@ -100,6 +100,20 @@ reason to use `/xml` at all is that `schtasks /create` has no flag for
 `StartWhenAvailable` (run a missed scheduled start when next available) — the only
 CLI route to that setting is `/create /xml`.
 
+## macOS: qmd's `ggml_metal_library_init_from_source` error is benign noise
+
+On macOS (Apple Silicon), every `qmd embed` / `qmd vsearch` prints
+`[node-llama-cpp] ggml_metal_library_init_from_source: error compiling source`
+even though GPU embedding **succeeds** (verified on an M5: 423 chunks / 144
+docs embedded in 28s right after that line). It reads like a hard failure to
+a fresh adopter; it is not — treat it as benign unless the embed itself
+errors or hangs. For genuine Metal problems, the underlying
+node-llama-cpp/ggml backend exposes a `GGML_METAL_NO_RESIDENCY` residency
+knob (per the issue-#276 report; macOS-native layer). Reported on the
+fresh-machine adopt run in public issue #276 (G6, HIMMEL-752); the message
+is emitted by qmd's upstream node-llama-cpp, so himmel documents it rather
+than suppressing stderr (a blanket filter would hide real errors).
+
 ## Anthropic output content-filter trips on policy text and minified blobs
 
 The 400 "Output blocked by content filtering policy" error scans the model's

--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -55,6 +55,10 @@ $HimmelRoot  = (Resolve-Path (Join-Path $ScriptDir '..')).Path
 # unambiguous and strict-mode-safe.
 $script:ClaudeAvailable = $true
 
+# Same pattern for `bun` (HIMMEL-752 G2): Require-Tools flips this to $false when
+# `bun` is absent; Wire-QmdCore consults it to skip qmd cleanly.
+$script:BunAvailable = $true
+
 # Shared wire helpers (PreToolUse trio + SessionStart) -- one implementation for
 # adopt.ps1 and setup.ps1 (HIMMEL install/uninstall symmetry).
 . (Join-Path $ScriptDir 'lib/wire-pretooluse-hooks.ps1')
@@ -89,6 +93,13 @@ function Require-Tools {
     if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
         $script:ClaudeAvailable = $false
         Write-Warning "'claude' not found — installing the harness-agnostic core only; skipping the Claude plugin-install step (Codex-only adopter is fine)."
+    }
+    # `bun` is SOFT (HIMMEL-752 G2): only the qmd wiring needs it; the
+    # harness-agnostic core + git gates run without it. Warn with the install
+    # hint; Wire-QmdCore consults $script:BunAvailable and skips qmd cleanly.
+    if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
+        $script:BunAvailable = $false
+        Write-Warning "'bun' not found — qmd search will be skipped; install: https://bun.sh (runs handover armed-resume, qmd search, the Telegram bridge, obsidian-triage tools)"
     }
 }
 
@@ -209,6 +220,176 @@ function FillEnv-Core {
     }
 }
 
+# --- qmd resolver + helpers (HIMMEL-752; mirror of scripts/lib/qmd-bin.sh) ---
+# pwsh cannot source bash, so the resolver + install/register/pull logic is
+# duplicated inline (parity with setup.ps1's qmd block). UPDATE qmd-bin.sh +
+# setup.ps1 + adopt.ps1 together; scripts/lib/test-qmd-bin.sh is the canonical
+# behavior spec. Honors $env:BUN_INSTALL for relocated bun roots.
+$QmdBunRoot = if ($env:BUN_INSTALL) { $env:BUN_INSTALL } else { Join-Path $HOME '.bun' }
+$QmdBunJs = Join-Path $QmdBunRoot 'install\global\node_modules\@tobilu\qmd\dist\cli\qmd.js'
+# G3 (HIMMEL-752): NO --ignore-scripts - it blocked better-sqlite3's native
+# build (prebuild-install || node-gyp rebuild --release) and crashed qmd on
+# platforms with no prebuilt binary (fresh macOS arm64 / new node major).
+$QmdInstallHint = 'bun add -g @tobilu/qmd@latest'
+
+function Invoke-Qmd {
+    param([Parameter(ValueFromRemainingArguments=$true)] [string[]] $QmdArgs)
+    if ((Test-Path $script:QmdBunJs) -and (Get-Command bun -ErrorAction SilentlyContinue)) {
+        & bun $script:QmdBunJs @QmdArgs
+    } elseif (Get-Command qmd -ErrorAction SilentlyContinue) {
+        & qmd @QmdArgs
+    } else {
+        $global:LASTEXITCODE = 127
+    }
+}
+
+function Test-Qmd {
+    if ((Test-Path $script:QmdBunJs) -and (Get-Command bun -ErrorAction SilentlyContinue)) {
+        return $true
+    }
+    return [bool](Get-Command qmd -ErrorAction SilentlyContinue)
+}
+
+# Mirror of qmd_install(): run the hint, verify --version, heal a missing
+# better-sqlite3 native build, return an honest int rc. All native output is
+# redirected away so the return value stays a clean int (Write-Host writes to
+# the host stream, not the pipeline).
+function Install-Qmd {
+    Write-Host "Installing qmd via bun..."
+    Invoke-Expression $script:QmdInstallHint *> $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  bun add failed (exit $LASTEXITCODE) - qmd not installed." -ForegroundColor Yellow
+        return $LASTEXITCODE
+    }
+    # Verify the binary runs - a broken better-sqlite3 native build dies here
+    # even though the package is present.
+    Invoke-Qmd --version *> $null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  qmd installed and verified."
+        return 0
+    }
+    # Heal: rebuild better-sqlite3 in place, then re-verify (HIMMEL-752).
+    $bsqlite = Join-Path $script:QmdBunRoot 'install\global\node_modules\better-sqlite3'
+    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+        # A missing npm would raise a terminating CommandNotFoundException under
+        # EAP='Stop' and abort adopt - check first, WARN, honest rc (CR fix).
+        Write-Host "  WARNING: npm not found - cannot rebuild better-sqlite3." -ForegroundColor Yellow
+        return 1
+    }
+    if (Test-Path $bsqlite) {
+        Write-Host "  qmd present but --version failed - rebuilding better-sqlite3 native module..."
+        Push-Location $bsqlite
+        try { npm run build-release *> $null } finally { Pop-Location }
+        if ($LASTEXITCODE -eq 0) {
+            Invoke-Qmd --version *> $null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "  qmd verified after native rebuild."
+                return 0
+            }
+            Write-Host "  WARNING: native rebuild ran but qmd --version still fails (exit $LASTEXITCODE)." -ForegroundColor Yellow
+        } else {
+            Write-Host "  WARNING: better-sqlite3 native build failed (need a compiler toolchain?)." -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "  WARNING: better-sqlite3 not found at $bsqlite - cannot heal." -ForegroundColor Yellow
+    }
+    return 1
+}
+
+# Mirror of qmd_register_collection(): idempotent + WARN-not-fail, returns an
+# honest int rc (0 on a clean add or an already-registered skip).
+function Register-QmdCollection([string]$Path, [string]$Name) {
+    $listOut = Invoke-Qmd collection list 2>&1
+    $listRc = $LASTEXITCODE
+    if ($listRc -ne 0) {
+        Write-Host "  WARNING: qmd collection list failed (rc=$listRc) - skipping '$Name' registration." -ForegroundColor Yellow
+        $listOut | ForEach-Object { Write-Host "    $_" -ForegroundColor Yellow }
+        return $listRc
+    }
+    if ($listOut -match "^$Name\b") {
+        Write-Host "  Collection '$Name' already registered - skipping."
+        return 0
+    }
+    Invoke-Qmd collection add $Path --name $Name | Out-Null
+    $addRc = $LASTEXITCODE
+    if ($addRc -ne 0) {
+        Write-Host "  WARNING: qmd collection add '$Name' failed (rc=$addRc) - continuing." -ForegroundColor Yellow
+        if ($addRc -eq 127) {
+            Write-Host "  (rc=127 means the resolver could not find qmd - install: $script:QmdInstallHint)" -ForegroundColor Yellow
+        }
+        return $addRc
+    }
+    return 0
+}
+
+# Mirror of wire_qmd_core(): fix the broken plugin stub, install the qmd CLI if
+# missing, pull the embedding/rerank models, and register the himmel clone.
+# Best-effort throughout; never throws (qmd is optional - a failure WARNs).
+function Wire-QmdCore {
+    if ($script:BunAvailable -eq $false) {
+        Write-Host "---- Skipping qmd wiring (bun not found) ----"
+        Write-Host "  Install bun to enable qmd search: https://bun.sh"
+        return
+    }
+    Write-Host "---- Wiring qmd search ----"
+    # WARN-not-fail structural guarantee (CR fix): on PS configs where
+    # $PSNativeCommandUseErrorActionPreference=$true (documented 7.4+ default),
+    # a nonzero native exit under EAP='Stop' throws BEFORE the $LASTEXITCODE
+    # warn-checks below can run - a broken qmd/bun would then abort adopt.
+    # Disable that coupling for the qmd block only; restore in finally.
+    $savedNativeEAP = $null
+    if (Test-Path variable:PSNativeCommandUseErrorActionPreference) {
+        $savedNativeEAP = $PSNativeCommandUseErrorActionPreference
+    }
+    $global:PSNativeCommandUseErrorActionPreference = $false
+    try {
+    Wire-QmdCoreInner
+    } finally {
+        if ($null -ne $savedNativeEAP) { $global:PSNativeCommandUseErrorActionPreference = $savedNativeEAP }
+    }
+}
+
+function Wire-QmdCoreInner {
+    # G1: neutralize the broken plugin-cache stub. WARN-not-fail.
+    if ($DryRun) {
+        Write-Host "DRY: bash $HimmelRoot/scripts/lib/fix-qmd-stub.sh"
+    } else {
+        $savedEAP = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = 'Continue'
+            & bash "$HimmelRoot/scripts/lib/fix-qmd-stub.sh"
+            if ($LASTEXITCODE -ne 0) { Write-Host "  WARNING: fix-qmd-stub failed (rc=$LASTEXITCODE) - continuing." -ForegroundColor Yellow }
+        } finally {
+            $ErrorActionPreference = $savedEAP
+        }
+    }
+    # Install the qmd CLI if missing. Install-Qmd verifies + heals (HIMMEL-752 G3).
+    if ($DryRun) {
+        if (-not (Test-Qmd)) { Write-Host "DRY: Install-Qmd" }
+    } elseif (-not (Test-Qmd)) {
+        $installRc = Install-Qmd
+        if ($installRc -ne 0) { Write-Host "  WARNING: qmd install failed (rc=$installRc) - continuing without qmd." -ForegroundColor Yellow }
+    }
+    # G4: pull models (~2.1 GB). Size caveat FIRST so the operator can Ctrl-C
+    # before the download, then best-effort pull.
+    if ($DryRun) {
+        Write-Host "DRY: qmd pull (downloads ~2.1 GB of embedding/rerank models)"
+    } elseif (Test-Qmd) {
+        Write-Host "  Pulling qmd models (downloads ~2.1 GB of embedding/rerank models)..."
+        Invoke-Qmd pull
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  WARNING: qmd pull failed - semantic search needs the models." -ForegroundColor Yellow
+            Write-Host "  Pull manually: qmd pull" -ForegroundColor Yellow
+        }
+    }
+    # Register the himmel clone.
+    if ($DryRun) {
+        Write-Host "DRY: Register-QmdCollection $HimmelRoot himmel"
+    } elseif (Test-Qmd) {
+        Register-QmdCollection $HimmelRoot himmel | Out-Null
+    }
+}
+
 function Do-Core {
     Require-Tools
     if ($Scope -eq 'project') {
@@ -225,6 +406,7 @@ function Do-Core {
         Write-Host "  worktree commands run from the himmel clone: bash $HimmelRoot/scripts/worktree.sh feat/slug"
     }
     Install-Plugins
+    Wire-QmdCore
     Wire-StatuslineCore
     Wire-HimmelRepoCore
     if ($FillEnv) { FillEnv-Core }
@@ -245,6 +427,29 @@ function Do-Luna([string]$Dest) {
     # Persist the vault path UNCONDITIONALLY — a re-run over an existing scaffold
     # must still wire a previously-unwired install (HIMMEL-458).
     Wire-LunaVaultPath $Dest
+    # G5 (HIMMEL-752): register the scaffolded vault as a qmd collection so it
+    # is queryable immediately. Skip + note when qmd/bun unavailable; WARN-not-fail.
+    # For -Profile all, Do-Core (-> Wire-QmdCore) has already installed qmd; for
+    # -Profile luna alone it may be absent, in which case Test-Qmd skips cleanly.
+    if ($script:BunAvailable -eq $false) {
+        Write-Host "  qmd: skipping luna collection registration (bun not found)"
+    } elseif ($DryRun) {
+        Write-Host "DRY: Register-QmdCollection $Dest luna"
+    } elseif (Test-Qmd) {
+        # Same native-EAP decoupling as Wire-QmdCore (WARN-not-fail, CR fix).
+        $savedNativeEAP = $null
+        if (Test-Path variable:PSNativeCommandUseErrorActionPreference) {
+            $savedNativeEAP = $PSNativeCommandUseErrorActionPreference
+        }
+        $global:PSNativeCommandUseErrorActionPreference = $false
+        try {
+            Register-QmdCollection $Dest luna | Out-Null
+        } finally {
+            if ($null -ne $savedNativeEAP) { $global:PSNativeCommandUseErrorActionPreference = $savedNativeEAP }
+        }
+    } else {
+        Write-Host "  qmd: skipping luna collection registration (qmd not installed)"
+    }
     Write-Host "  next: cd `"$Dest`"; bash scripts/setup.sh   (idempotent; prints the plugin-install commands)"
 }
 

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -44,6 +44,13 @@ HIMMEL_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/wire-pretooluse-hooks.sh"
 
+# qmd resolver + install/register helpers (HIMMEL-752 qmd wiring). Provides
+# has_qmd / qmd_cmd / qmd_install / qmd_register_collection, consumed by
+# wire_qmd_core() and do_luna().
+# shellcheck source=scripts/lib/qmd-bin.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/qmd-bin.sh"
+
 # ── Defaults ─────────────────────────────────────────────────────────────────
 PROFILE="core"
 SCOPE="project"
@@ -105,6 +112,14 @@ require_tools() {
     CLAUDE_AVAILABLE=0
     echo "WARN: 'claude' not found — installing the harness-agnostic core only;" >&2
     echo "      skipping the Claude plugin-install step (Codex-only adopter is fine)." >&2
+  fi
+  # `bun` is SOFT (HIMMEL-752 G2): qmd search is the only do_core step that
+  # needs it, and the harness-agnostic core + git gates run without it. Warn with the
+  # install hint; wire_qmd_core consults BUN_AVAILABLE and skips qmd cleanly.
+  if ! command -v bun >/dev/null 2>&1; then
+    BUN_AVAILABLE=0
+    echo "WARN: 'bun' not found — qmd search will be skipped;" >&2
+    echo "      install: https://bun.sh (runs handover armed-resume, qmd search, the Telegram bridge, obsidian-triage tools)" >&2
   fi
 }
 
@@ -204,6 +219,54 @@ fill_env_core() {
   fi
 }
 
+# wire_qmd_core — wire the qmd search stack end-to-end (HIMMEL-752 G1/G3/G4):
+# fix the broken plugin-cache stub, install the qmd CLI if missing (qmd_install
+# verifies the binary and heals a missing better-sqlite3 native build), pull the
+# embedding/rerank models, and register the himmel clone as a collection.
+# Best-effort throughout: every failure WARNs and returns 0 so a missing or
+# broken qmd never aborts an adopt. Called from do_core() after install_plugins
+# (the qmd Claude plugin lands there; this makes the qmd CLI + models work).
+# Honors --dry-run (DRY: lines) and the BUN_AVAILABLE soft-check flag.
+wire_qmd_core() {
+  if [[ "${BUN_AVAILABLE:-1}" -eq 0 ]]; then
+    echo "──── Skipping qmd wiring (bun not found) ────"
+    echo "  Install bun to enable qmd search: https://bun.sh"
+    return 0
+  fi
+  echo "──── Wiring qmd search ────"
+  # G1: neutralize the broken qmd plugin-cache stub so plain `qmd` works inside
+  # Claude's Bash tool too (HIMMEL-163). WARN-not-fail.
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "DRY: bash $HIMMEL_ROOT/scripts/lib/fix-qmd-stub.sh"
+  else
+    bash "$HIMMEL_ROOT/scripts/lib/fix-qmd-stub.sh" \
+      || echo "  WARNING: fix-qmd-stub failed — continuing." >&2
+  fi
+  # Install the qmd CLI if missing. qmd_install verifies + heals (HIMMEL-752 G3).
+  if [[ $DRY_RUN -eq 1 ]]; then
+    has_qmd || echo "DRY: qmd_install"
+  elif ! has_qmd; then
+    qmd_install || echo "  WARNING: qmd install failed — continuing without qmd." >&2
+  fi
+  # G4: pull the embedding/rerank models. Size caveat FIRST so the operator can
+  # Ctrl-C before the ~2.1 GB download, then best-effort pull (never abort adopt).
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "DRY: qmd pull (downloads ~2.1 GB of embedding/rerank models)"
+  elif has_qmd; then
+    echo "  Pulling qmd models (downloads ~2.1 GB of embedding/rerank models)..."
+    if ! qmd_cmd pull; then
+      echo "  WARNING: qmd pull failed — semantic search needs the models." >&2
+      echo "  Pull manually: qmd pull" >&2
+    fi
+  fi
+  # Register the himmel clone itself as a collection.
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "DRY: qmd_register_collection $HIMMEL_ROOT himmel"
+  elif has_qmd; then
+    qmd_register_collection "$HIMMEL_ROOT" himmel || true
+  fi
+}
+
 do_core() {
   require_tools
   if [[ "$SCOPE" == "project" ]]; then
@@ -221,6 +284,7 @@ do_core() {
     echo "  worktree commands run from the himmel clone: bash $HIMMEL_ROOT/scripts/worktree.sh feat/slug"
   fi
   install_plugins
+  wire_qmd_core
   wire_statusline_core
   wire_himmel_repo_core
   [[ $FILL_ENV -eq 1 ]] && fill_env_core
@@ -239,6 +303,19 @@ do_luna() {
   # Persist the vault path UNCONDITIONALLY — a re-run over an existing scaffold
   # (skipped copy above) must still wire a previously-unwired install (HIMMEL-458).
   wire_luna_vault_path "$dest"
+  # G5 (HIMMEL-752): register the scaffolded vault as a qmd collection so it is
+  # queryable immediately. Skip + note when qmd/bun unavailable; WARN-not-fail.
+  # For --profile all, do_core (→ wire_qmd_core) has already installed qmd; for
+  # --profile luna alone it may be absent, in which case has_qmd skips cleanly.
+  if [[ "${BUN_AVAILABLE:-1}" -eq 0 ]]; then
+    echo "  qmd: skipping luna collection registration (bun not found)"
+  elif [[ $DRY_RUN -eq 1 ]]; then
+    echo "DRY: qmd_register_collection $dest luna"
+  elif has_qmd; then
+    qmd_register_collection "$dest" luna || true
+  else
+    echo "  qmd: skipping luna collection registration (qmd not installed)"
+  fi
   echo "  next: cd \"$dest\" && bash scripts/setup.sh   (idempotent; prints the plugin-install commands)"
 }
 

--- a/scripts/lib/fix-qmd-stub.sh
+++ b/scripts/lib/fix-qmd-stub.sh
@@ -161,7 +161,7 @@ if [ "$BUN_QMD_NO_BUN" -eq 1 ]; then
 else
   echo "qmd: not found (plugin dist missing; no bun global install; nothing else on PATH)." >&2
 fi
-echo "Install: bun add -g @tobilu/qmd@latest --ignore-scripts" >&2
+echo "Install: bun add -g @tobilu/qmd@latest" >&2
 exit 127
 STUB
   then

--- a/scripts/lib/qmd-bin.sh
+++ b/scripts/lib/qmd-bin.sh
@@ -19,11 +19,103 @@
 #
 # Project rule: qmd is installed via bun, never npm. Bash callers get
 # the install hint via qmd_install_hint() (single source of truth for
-# bash); the pwsh mirror in scripts/setup.ps1 hardcodes the same
-# string and must be updated in lockstep.
+# bash); qmd_install() runs that hint, verifies the binary actually
+# works, and heals a missing better-sqlite3 native build (HIMMEL-752:
+# the old --ignore-scripts hint blocked better-sqlite3's native build
+# and crashed qmd on platforms without a prebuilt binary, so the hint
+# no longer carries it). qmd_register_collection() is the shared
+# idempotent collection-registration helper used by setup.sh + adopt.sh.
+# The pwsh mirrors in scripts/setup.ps1 + scripts/adopt.ps1, and the
+# bash stub-error hint line in scripts/lib/fix-qmd-stub.sh, hardcode
+# the same string and must be updated in lockstep.
 
 qmd_install_hint() {
-  echo 'bun add -g @tobilu/qmd@latest --ignore-scripts'
+  echo 'bun add -g @tobilu/qmd@latest'
+}
+
+# Install qmd via the canonical hint, then verify the binary actually
+# runs. Returns an honest rc: 0 ONLY when `qmd_cmd --version` succeeds.
+# HIMMEL-752: the old `--ignore-scripts` hint blocked better-sqlite3's
+# native build (its install script is `prebuild-install || node-gyp
+# rebuild --release`), so on machines with no prebuilt binary (fresh
+# macOS arm64 / new node major) every qmd command died with "Could not
+# locate the bindings file". The hint now runs the full install; if the
+# postinstall was skipped (bun does this for untrusted packages) or a
+# prebuild is missing, fall back to a node-gyp build-release inside the
+# better-sqlite3 dir, then re-verify. WARN-not-fail by contract: the
+# rc is honest, callers (adopt.sh, ubuntu.sh) decide whether
+# a qmd failure aborts. Every external command is under an `if` guard so
+# a caller's `set -e` cannot abort mid-install before the rc is returned.
+qmd_install() {
+  local bun_root _bsqlite
+  echo "Installing qmd via bun..."
+  # Run the canonical hint command (single source of truth; a trusted
+  # hardcoded literal, so eval is safe here - never feed it untrusted input).
+  if ! eval "$(qmd_install_hint)"; then
+    echo "  bun add failed - qmd not installed." >&2
+    return 1
+  fi
+  # Verify the binary actually runs. has_qmd is presence-only by design,
+  # so probe --version directly: a broken better-sqlite3 native build
+  # (missing bindings file) dies here even though the package is present.
+  if qmd_cmd --version >/dev/null 2>&1; then
+    echo "  qmd installed and verified."
+    return 0
+  fi
+  # Heal: bun may skip the postinstall for untrusted packages, and the
+  # better-sqlite3 prebuild may be missing on a new platform. Build the
+  # native module in place, then re-verify (HIMMEL-752).
+  bun_root="${BUN_INSTALL:-$HOME/.bun}"
+  _bsqlite="$bun_root/install/global/node_modules/better-sqlite3"
+  if [ -d "$_bsqlite" ]; then
+    echo "  qmd present but --version failed - rebuilding better-sqlite3 native module..."
+    if (cd "$_bsqlite" && npm run build-release) >/dev/null 2>&1; then
+      if qmd_cmd --version >/dev/null 2>&1; then
+        echo "  qmd verified after native rebuild."
+        return 0
+      fi
+      echo "  WARNING: native rebuild ran but qmd --version still fails." >&2
+    else
+      echo "  WARNING: better-sqlite3 native build failed (need a compiler toolchain?)." >&2
+    fi
+  else
+    echo "  WARNING: better-sqlite3 not found at $_bsqlite - cannot heal." >&2
+  fi
+  return 1
+}
+
+# Register a directory as a qmd collection. Idempotent: skips when
+# <name> is already listed. WARN-not-fail: a list/add error prints a
+# WARNING (with the indented payload on a list failure, and the rc=127
+# resolver hint on an add-127) and returns the nonzero rc, but the
+# CALLER decides whether to abort (setup.sh wraps with `|| true`;
+# adopt.sh treats qmd as best-effort). $1 = path, $2 = name.
+qmd_register_collection() {
+  local path="$1" name="$2" list_out list_rc add_rc
+  list_out=$(qmd_cmd collection list 2>&1)
+  list_rc=$?
+  if [ "$list_rc" -ne 0 ]; then
+    echo "  WARNING: qmd collection list failed (rc=$list_rc) - skipping '$name' registration." >&2
+    # shellcheck disable=SC2001
+    # Per-line indent - parameter expansion doesn't replicate sed's per-line anchor cleanly.
+    echo "$list_out" | sed 's/^/    /' >&2
+    return "$list_rc"
+  fi
+  # Idempotency check: skip when <name> is already a registered collection.
+  if echo "$list_out" | grep -q "^${name}\b"; then
+    echo "  Collection '$name' already registered - skipping."
+    return 0
+  fi
+  qmd_cmd collection add "$path" --name "$name"
+  add_rc=$?
+  if [ "$add_rc" -ne 0 ]; then
+    echo "  WARNING: qmd collection add '$name' failed (rc=$add_rc) - continuing." >&2
+    if [ "$add_rc" -eq 127 ]; then
+      echo "  (rc=127 means scripts/lib/qmd-bin.sh resolver could not find qmd - install: $(qmd_install_hint))" >&2
+    fi
+    return "$add_rc"
+  fi
+  return 0
 }
 
 # Resolve bun-direct qmd.js path. Respects BUN_INSTALL (bun's own override)

--- a/scripts/lib/test-qmd-bin.sh
+++ b/scripts/lib/test-qmd-bin.sh
@@ -109,8 +109,10 @@ rc=0
 HOME="$tmpdir" PATH="$tmpdir/bin:$PATH" BUN_INSTALL="$tmpdir/custom-bun" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_cmd --version' >/dev/null 2>&1 || rc=$?
 assert "wrapped command rc=42 propagates" test "$rc" -eq 42
 
-echo "[test-qmd-bin] qmd_install_hint contains --ignore-scripts"
-assert "hint preserves --ignore-scripts flag" grep -q -- '--ignore-scripts' <<<"$(qmd_install_hint)"
+echo "[test-qmd-bin] qmd_install_hint drops --ignore-scripts (HIMMEL-752 G3)"
+# shellcheck disable=SC2016
+# Single quotes intentional - $1 expands inside the spawned bash -c subshell.
+assert "hint does NOT contain --ignore-scripts" bash -c '! grep -q -- "--ignore-scripts" <<<"$1"' _ "$(qmd_install_hint)"
 
 echo "[test-qmd-bin] has_qmd is presence-only (does not invoke binary)"
 # Make the bun-js path point at a broken/empty script that would error on run.
@@ -120,11 +122,128 @@ rc=0
 HOME="$tmpdir" PATH="$tmpdir/bin:$PATH" BUN_INSTALL="$tmpdir/broken-bun" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; has_qmd' || rc=$?
 assert "has_qmd=true even when bun-js is broken (presence only)" test "$rc" -eq 0
 
+echo "[test-qmd-bin] qmd_install() happy / heal / honest-fail (HIMMEL-752 G3)"
+# Hermetic stub env: a fake `bun` (tells 'add' apart from a qmd run by $1),
+# a fake `npm` (drops a heal marker), a fake qmd.js so qmd_cmd resolves via bun,
+# and a better-sqlite3 dir for the heal path. Lives under $tmpdir so the EXIT
+# trap cleans it. Stubs read behavior from env vars so one env covers all paths.
+id2="$tmpdir/install"
+mkdir -p "$id2/bin" "$id2/.bun/install/global/node_modules/@tobilu/qmd/dist/cli" \
+         "$id2/.bun/install/global/node_modules/better-sqlite3"
+: > "$id2/.bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
+cat > "$id2/bin/bun" <<'STUB'
+#!/usr/bin/env bash
+# 'bun add ...' = install; anything else = a qmd run dispatch (bun <qmd.js> ...).
+if [ "$1" = "add" ]; then exit "${STUB_BUN_ADD_RC:-0}"; fi
+if [ -f "${HEAL_MARKER:-}" ]; then exit 0; fi
+exit "${STUB_BUN_VER_RC:-0}"
+STUB
+chmod +x "$id2/bin/bun"
+cat > "$id2/bin/npm" <<'STUB'
+#!/usr/bin/env bash
+# Simulate the native build: STUB_NPM_RC=1 = build fails (no heal marker);
+# default = success (drop the heal marker).
+if [ "${STUB_NPM_RC:-0}" -ne 0 ]; then exit "${STUB_NPM_RC}"; fi
+: > "${HEAL_MARKER:?}"
+exit 0
+STUB
+chmod +x "$id2/bin/npm"
+heal_marker="$id2/.healed"
+qmd_install_rc() {
+  HOME="$id2" BUN_INSTALL="$id2/.bun" HEAL_MARKER="$heal_marker" \
+    PATH="$id2/bin:$PATH" \
+    STUB_BUN_ADD_RC="${STUB_BUN_ADD_RC:-0}" STUB_BUN_VER_RC="${STUB_BUN_VER_RC:-0}" \
+    STUB_NPM_RC="${STUB_NPM_RC:-0}" \
+    bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install >/dev/null 2>&1; echo $?'
+}
+# happy: install ok + verify ok -> rc 0.
+STUB_BUN_ADD_RC=0; STUB_BUN_VER_RC=0; rm -f "$heal_marker"
+assert "qmd_install happy path returns 0" test "$(qmd_install_rc)" -eq 0
+# honest-fail: bun add fails -> rc nonzero, verify never reached.
+STUB_BUN_ADD_RC=1; STUB_BUN_VER_RC=0; rm -f "$heal_marker"
+assert "qmd_install honest-fail returns nonzero" test "$(qmd_install_rc)" -ne 0
+# heal: install ok, verify fails, npm rebuild heals, re-verify ok -> rc 0.
+STUB_BUN_ADD_RC=0; STUB_BUN_VER_RC=1; STUB_NPM_RC=0; rm -f "$heal_marker"
+assert "qmd_install heal path returns 0" test "$(qmd_install_rc)" -eq 0
+assert "qmd_install heal path ran npm rebuild" test -f "$heal_marker"
+# heal-FAIL: install ok, verify fails, npm rebuild FAILS -> honest rc nonzero
+# (the core HIMMEL-752 honest-rc contract: 0 only when qmd verifiably works).
+STUB_BUN_ADD_RC=0; STUB_BUN_VER_RC=1; STUB_NPM_RC=1; rm -f "$heal_marker"
+assert "qmd_install heal-fail returns nonzero (honest rc)" test "$(qmd_install_rc)" -ne 0
+assert "qmd_install heal-fail left no heal marker" test ! -f "$heal_marker"
+STUB_NPM_RC=0
+
+echo "[test-qmd-bin] qmd_register_collection() add / idempotent-skip / warn (HIMMEL-752)"
+# Hermetic stub env: a fake `qmd` on PATH (no bun-qmd.js, no bun -> qmd_cmd
+# falls to the PATH qmd). Stubs read behavior from env vars.
+id3="$tmpdir/register"
+mkdir -p "$id3/bin"
+add_log="$id3/add-calls"
+cat > "$id3/bin/qmd" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "collection" ] && [ "$2" = "list" ]; then
+  [ -n "${STUB_LIST_FAIL:-}" ] && { echo "boom" >&2; exit 2; }
+  printf '%s\n' "${STUB_LIST:-}"
+  exit 0
+fi
+if [ "$1" = "collection" ] && [ "$2" = "add" ]; then
+  printf 'collection %s\n' "$*" >> "${ADD_LOG:?}"
+  exit "${STUB_ADD_RC:-0}"
+fi
+exit 0
+STUB
+chmod +x "$id3/bin/qmd"
+reg_rc() { # $1 = path, $2 = name; echoes the register rc on stdout.
+  HOME="$id3" ADD_LOG="$add_log" PATH="$id3/bin:$PATH" \
+    STUB_LIST="${STUB_LIST:-}" STUB_LIST_FAIL="${STUB_LIST_FAIL:-}" \
+    STUB_ADD_RC="${STUB_ADD_RC:-0}" \
+    bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_register_collection "'"$1"'" "'"$2"'"' >/dev/null 2>&1; echo $?
+}
+reg_err() { # like reg_rc but echoes the captured STDERR (for message asserts).
+  # shellcheck disable=SC2069
+  # 2>&1 >/dev/null is deliberate: stderr goes to the CAPTURED stdout while the
+  # original stdout is discarded (we assert on the WARNING text, stderr-only).
+  HOME="$id3" ADD_LOG="$add_log" PATH="$id3/bin:$PATH" \
+    STUB_LIST="${STUB_LIST:-}" STUB_LIST_FAIL="${STUB_LIST_FAIL:-}" \
+    STUB_ADD_RC="${STUB_ADD_RC:-0}" \
+    bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_register_collection "'"$1"'" "'"$2"'"' 2>&1 >/dev/null || true
+}
+# add: list empty, name absent -> add called, rc 0.
+STUB_LIST=""; STUB_LIST_FAIL=""; : > "$add_log"
+assert "register add path returns 0" test "$(reg_rc /repo himmel)" -eq 0
+assert "register add path called qmd collection add" grep -q 'collection add' "$add_log"
+# idempotent skip: list contains himmel -> skip, add NOT called, rc 0.
+STUB_LIST="himmel"; STUB_LIST_FAIL=""; : > "$add_log"
+assert "register idempotent-skip returns 0" test "$(reg_rc /repo himmel)" -eq 0
+assert "register idempotent-skip did NOT call add" test ! -s "$add_log"
+# warn on list failure -> rc nonzero, add NOT called.
+STUB_LIST="x"; STUB_LIST_FAIL=1; : > "$add_log"
+assert "register warn-on-list-fail returns nonzero" test "$(reg_rc /repo himmel)" -ne 0
+assert "register warn-on-list-fail did NOT call add" test ! -s "$add_log"
+# idempotency must not false-match a prefix-only name (luna vs lunabot).
+STUB_LIST="lunabot"; STUB_LIST_FAIL=""; : > "$add_log"
+assert "register no prefix false-match (luna vs lunabot)" test "$(reg_rc /vault luna)" -eq 0
+assert "register luna added despite lunabot in list" grep -q 'collection add' "$add_log"
+# add-FAILURE: list ok, add exits nonzero -> WARN + honest rc passthrough.
+STUB_LIST=""; STUB_LIST_FAIL=""; STUB_ADD_RC=3; : > "$add_log"
+assert "register add-failure returns the add rc" test "$(reg_rc /repo himmel)" -eq 3
+err_out=$(reg_err /repo himmel)
+assert "register add-failure WARNs" grep -q 'WARNING: qmd collection add' <<<"$err_out"
+# add rc=127 (resolver could not find qmd) -> the install-hint diagnostic fires.
+STUB_LIST=""; STUB_LIST_FAIL=""; STUB_ADD_RC=127; : > "$add_log"
+assert "register add-127 returns 127" test "$(reg_rc /repo himmel)" -eq 127
+err_out=$(reg_err /repo himmel)
+assert "register add-127 prints the resolver install hint" grep -q 'rc=127 means' <<<"$err_out"
+STUB_ADD_RC=0
+
 echo "[test-qmd-bin] consumer integration — scripts/setup.sh uses helpers"
 # Guard against accidental reintroduction of plain `qmd` in consumers.
 repo_root="$(cd "$SCRIPT_DIR/../.." && pwd)"
 assert "setup.sh sources qmd-bin.sh" grep -q 'lib/qmd-bin.sh' "$repo_root/scripts/setup.sh"
-assert "setup.sh calls qmd_cmd" grep -q 'qmd_cmd ' "$repo_root/scripts/setup.sh"
+# setup.sh [4/10] was refactored to call qmd_register_collection (HIMMEL-752),
+# which wraps qmd_cmd - either helper counts as "uses the resolver, not bare qmd".
+assert "setup.sh calls a qmd-bin.sh helper (qmd_cmd/qmd_register_collection)" \
+  grep -qE 'qmd_cmd |qmd_register_collection ' "$repo_root/scripts/setup.sh"
 assert "ubuntu.sh sources qmd-bin.sh" grep -q 'lib/qmd-bin.sh' "$repo_root/scripts/machine-setup/ubuntu.sh"
 assert "ubuntu.sh calls qmd_cmd" grep -q 'qmd_cmd ' "$repo_root/scripts/machine-setup/ubuntu.sh"
 

--- a/scripts/machine-setup/ubuntu.sh
+++ b/scripts/machine-setup/ubuntu.sh
@@ -239,8 +239,9 @@ step "Install qmd CLI + register himmel/luna collections"
 {
   # Project rule: qmd installs via bun, not npm. The qmd Claude plugin ships
   # a path stub that breaks plain `qmd` on Windows; scripts/lib/qmd-bin.sh
-  # picks the working invoker. --ignore-scripts skips the better-sqlite3
-  # native build (prebuilt binary works).
+  # picks the working invoker. qmd_install runs the full install + verifies
+  # the binary + heals a missing native build (HIMMEL-752: --ignore-scripts
+  # crashed qmd on platforms without a better-sqlite3 prebuilt binary).
   # shellcheck source=../lib/qmd-bin.sh
   # shellcheck disable=SC1091
   . "$HIMMEL_PATH/scripts/lib/qmd-bin.sh"
@@ -259,11 +260,13 @@ step "Install qmd CLI + register himmel/luna collections"
 
   if ! has_qmd; then
     if command -v bun >/dev/null 2>&1; then
+      # qmd_install runs the canonical hint (no --ignore-scripts), verifies
+      # the binary, and heals a missing better-sqlite3 native build (HIMMEL-752).
       # Capture rc *before* the `if`: `if ! cmd; then $?` is 0, not cmd's rc.
-      bun add -g @tobilu/qmd@latest --ignore-scripts
-      _bun_rc=$?
-      if [ "$_bun_rc" -ne 0 ]; then
-        echo "  ERROR: bun add -g @tobilu/qmd failed (rc=$_bun_rc)." >&2
+      qmd_install
+      _qmd_install_rc=$?
+      if [ "$_qmd_install_rc" -ne 0 ]; then
+        echo "  ERROR: qmd install failed (rc=$_qmd_install_rc)." >&2
         echo "  Check network / registry; skipping collection registration." >&2
         _qmd_step_ok=0
       fi
@@ -317,7 +320,7 @@ step "Install qmd CLI + register himmel/luna collections"
   # Compute final rc. The bare test is the group's last command, so its
   # rc determines whether `|| fail_nonfatal` fires.
   _qmd_step_final=$_qmd_step_ok
-  unset _qmd_list_out _qmd_list_rc _bun_rc _qmd_version_rc _qmd_add_rc _qmd_step_ok
+  unset _qmd_list_out _qmd_list_rc _qmd_install_rc _qmd_version_rc _qmd_add_rc _qmd_step_ok
   [ "$_qmd_step_final" -eq 1 ]
 } || fail_nonfatal "qmd setup"
 

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -224,7 +224,10 @@ if (Get-Command node -ErrorAction SilentlyContinue) {
 # Honors $env:BUN_INSTALL for relocated bun roots, matching the bash lib.
 $QmdBunRoot = if ($env:BUN_INSTALL) { $env:BUN_INSTALL } else { Join-Path $HOME '.bun' }
 $QmdBunJs = Join-Path $QmdBunRoot 'install\global\node_modules\@tobilu\qmd\dist\cli\qmd.js'
-$QmdInstallHint = 'bun add -g @tobilu/qmd@latest --ignore-scripts'
+# HIMMEL-752 G3: NO --ignore-scripts. It blocked better-sqlite3's native
+# build (prebuild-install || node-gyp rebuild --release), crashing qmd on
+# machines with no prebuilt binary (fresh macOS arm64 / new node major).
+$QmdInstallHint = 'bun add -g @tobilu/qmd@latest'
 
 function Invoke-Qmd {
     param([Parameter(ValueFromRemainingArguments=$true)] [string[]] $QmdArgs)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -263,30 +263,11 @@ echo "[4/10] Registering qmd collection 'himmel'..."
 # absent, already patched, or upstream has shipped a fixed stub.
 bash "$REPO_ROOT/scripts/lib/fix-qmd-stub.sh" || echo "  WARNING: fix-qmd-stub failed — continuing." >&2
 if has_qmd; then
-  # Capture rc from `list` separately. Piping through grep would mask
-  # a `list` failure (DB corruption, schema mismatch) as "no match".
-  _qmd_list_out=$(qmd_cmd collection list 2>&1)
-  _qmd_list_rc=$?
-  if [ "$_qmd_list_rc" -ne 0 ]; then
-    echo "  WARNING: qmd collection list failed (rc=$_qmd_list_rc) — skipping registration." >&2
-    # shellcheck disable=SC2001
-    # Per-line indent — parameter expansion doesn't replicate sed's per-line anchor cleanly.
-    echo "$_qmd_list_out" | sed 's/^/    /' >&2
-  elif echo "$_qmd_list_out" | grep -q '^himmel\b'; then
-    echo "  Collection 'himmel' already registered — skipping."
-  else
-    # Capture rc *before* the `if`: `if ! cmd; then $?` evaluates to 0
-    # (the negated-test exit), not cmd's actual rc.
-    qmd_cmd collection add "$REPO_ROOT" --name himmel
-    _qmd_add_rc=$?
-    if [ "$_qmd_add_rc" -ne 0 ]; then
-      echo "  WARNING: qmd collection add failed (rc=$_qmd_add_rc) — continuing." >&2
-      if [ "$_qmd_add_rc" -eq 127 ]; then
-        echo "  (rc=127 means scripts/lib/qmd-bin.sh resolver could not find qmd — install: $(qmd_install_hint))" >&2
-      fi
-    fi
-  fi
-  unset _qmd_list_out _qmd_list_rc _qmd_add_rc
+  # qmd_register_collection: idempotent + WARN-not-fail with the same
+  # messages/semantics the inline logic had (HIMMEL-752). `|| true` keeps
+  # this script's `set -e` from aborting on a best-effort qmd failure
+  # (a list/add error already WARNed inside the helper).
+  qmd_register_collection "$REPO_ROOT" himmel || true
 else
   echo "  qmd not available — skipping. Install: $(qmd_install_hint)"
 fi

--- a/scripts/test-adopt.sh
+++ b/scripts/test-adopt.sh
@@ -47,7 +47,21 @@ fi
 exit 0
 STUB
 chmod +x "$work/bin/claude"
-export PATH="$work/bin:$PATH"
+
+# Hermeticity (HIMMEL-752 CR): scrub every dir carrying a real `qmd` OR `bun`
+# from the suite-wide PATH. With bun absent, wire_qmd_core takes its documented
+# clean-skip branch, so NO test can fire a real fix-qmd-stub (~/.claude
+# mutation), a real `qmd pull` (~2.1 GB), or a real collection registration on
+# a dev box that has the toolchain installed. Tests 10/11 re-add their own
+# stubbed bun on top of this scrubbed base to exercise the qmd path.
+qmd_free_path=""
+_save_ifs="$IFS"; IFS=':'
+for _d in $PATH; do
+  { [ -x "$_d/qmd" ] || [ -x "$_d/bun" ]; } && continue
+  qmd_free_path="${qmd_free_path:+$qmd_free_path:}$_d"
+done
+IFS="$_save_ifs"
+export PATH="$work/bin:$qmd_free_path"
 
 # ── 5. invalid args (run first — validated before any tool preflight) ────────
 set +e
@@ -62,8 +76,11 @@ set -e
 echo "ok: invalid --profile / --scope rejected (exit 2)"
 
 # ── 1. core/project ──────────────────────────────────────────────────────────
+# Fake HOME on every non-user-scope run too (belt-and-braces with the PATH
+# scrub): nothing in the suite may read or write the real ~/.claude.
+base_home="$work/home-base"; mkdir -p "$base_home"
 proj="$work/proj"; mkdir -p "$proj"
-bash "$adopt" --profile core --scope project --target "$proj" >/dev/null
+HOME="$base_home" bash "$adopt" --profile core --scope project --target "$proj" >/dev/null
 for f in scripts/hooks/block-edit-on-main.sh scripts/guardrails/lib.sh scripts/worktree.sh; do
   [ -f "$proj/$f" ] || fail "core/project did not copy $f"
 done
@@ -76,14 +93,14 @@ echo "ok: core/project copies portable files + wires 3 \$CLAUDE_PROJECT_DIR hook
 
 # idempotency
 cp "$s" "$work/before.json"
-bash "$adopt" --profile core --scope project --target "$proj" >/dev/null
+HOME="$base_home" bash "$adopt" --profile core --scope project --target "$proj" >/dev/null
 diff -q "$work/before.json" "$s" >/dev/null || fail "core/project not idempotent"
 echo "ok: core/project idempotent on re-run"
 
 # ── 2. merge preserves existing settings ─────────────────────────────────────
 proj2="$work/proj2"; mkdir -p "$proj2/.claude"
 printf '%s' '{"permissions":{"allow":["Bash(ls)"]},"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"bash /pre/existing.sh"}]}]}}' > "$proj2/.claude/settings.json"
-bash "$adopt" --profile core --scope project --target "$proj2" >/dev/null
+HOME="$base_home" bash "$adopt" --profile core --scope project --target "$proj2" >/dev/null
 [ "$(jq -r '.permissions.allow[0]' "$proj2/.claude/settings.json")" = "Bash(ls)" ] || fail "merge dropped existing permissions"
 [ "$(jq '.hooks.PreToolUse | length' "$proj2/.claude/settings.json")" = "4" ] || fail "merge expected 4 PreToolUse hooks (1 existing + 3)"
 echo "ok: merge preserves existing keys + hooks"
@@ -106,7 +123,7 @@ echo "ok: core/user wires ~/.claude to himmel abs path, copies no scripts"
 
 # ── 4. luna scaffold ─────────────────────────────────────────────────────────
 vault="$work/vault"
-bash "$adopt" --profile luna --target "$vault" >/dev/null
+HOME="$base_home" bash "$adopt" --profile luna --target "$vault" >/dev/null
 [ -f "$vault/README.md" ] || fail "luna profile did not scaffold the vault (README.md missing)"
 # F1 (HIMMEL-458): project scope wires LUNA_VAULT_PATH into $TARGET/.claude.
 lv=$(jq -r '.env.LUNA_VAULT_PATH' "$vault/.claude/settings.json" 2>/dev/null)
@@ -115,7 +132,7 @@ echo "ok: luna scaffolds the vault + persists LUNA_VAULT_PATH (project scope)"
 
 # ── 6. all — core→--target, vault→--luna-target (no leak) ────────────────────
 allrepo="$work/allrepo"; allvault="$work/allvault"; mkdir -p "$allrepo"
-bash "$adopt" --profile all --scope project --target "$allrepo" --luna-target "$allvault" >/dev/null
+HOME="$base_home" bash "$adopt" --profile all --scope project --target "$allrepo" --luna-target "$allvault" >/dev/null
 [ -f "$allrepo/scripts/worktree.sh" ] || fail "all: core did not land in --target"
 [ -f "$allvault/README.md" ] || fail "all: vault did not land in --luna-target"
 [ ! -f "$allrepo/README.md" ] || fail "all: vault scaffold leaked into the core --target"
@@ -195,5 +212,51 @@ jq -e '.hooks.PreToolUse[].hooks[].command | select(test("rtk-hook-guard"))' "$s
 [ "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(test("auto-approve-safe-bash"))] | length' "$s9b")" = "1" ] \
   || fail "hookpath(nested): expected exactly one auto-approve after re-wire"
 echo "ok: co-located non-himmel hook survives re-wire (hook-object granularity)"
+
+# ── 10. HIMMEL-752 qmd wiring: --dry-run emits the qmd step DRY lines ───────
+# Force has_qmd=false deterministically: fake HOME (no ~/.bun/.../qmd.js) on the
+# suite-wide qmd/bun-scrubbed PATH (computed at the top), so wire_qmd_core
+# reaches its install/register steps even on a dev box that has a real qmd
+# installed. bun is stubbed (exit 0) so require_tools leaves BUN_AVAILABLE at
+# its default (1). --dry-run is side-effect-free (the wire helpers honor the
+# dry flag).
+qbin="$work/qbin"; mkdir -p "$qbin"
+cat > "$qbin/bun" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$qbin/bun"
+qhome="$work/qhome"; mkdir -p "$qhome"
+set +e
+out=$(PATH="$qbin:$work/bin:$qmd_free_path" HOME="$qhome" bash "$adopt" \
+      --profile all --scope user --target "$work/ign-q" --luna-target "$work/qvault" --dry-run 2>&1); rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "dry-run adopt exited rc=$rc (expected 0)"
+printf '%s' "$out" | grep -q 'DRY:.*fix-qmd-stub'    || fail "dry-run missing fix-qmd-stub DRY line"
+printf '%s' "$out" | grep -q 'DRY: qmd_install'      || fail "dry-run missing qmd_install DRY line"
+printf '%s' "$out" | grep -q 'DRY: qmd pull'         || fail "dry-run missing qmd pull DRY line"
+printf '%s' "$out" | grep -q 'DRY: qmd_register_collection .* himmel$' || fail "dry-run missing himmel register DRY line"
+printf '%s' "$out" | grep -q 'DRY: qmd_register_collection .* luna$'   || fail "dry-run missing luna register DRY line"
+echo "ok: dry-run emits all qmd step DRY lines (core G1/G3/G4 + luna G5)"
+
+# ── 11. HIMMEL-752 qmd WARN-not-fail: a failing qmd install never aborts adopt
+# bun present (stubbed to exit 1) + has_qmd=false (scrubbed PATH, fake HOME) ->
+# qmd_install is invoked and fails -> wire_qmd_core WARNs, but adopt still exits
+# 0 (qmd is best-effort). Fake HOME keeps settings writes isolated.
+fbin="$work/fbin"; mkdir -p "$fbin"
+cat > "$fbin/bun" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "$fbin/bun"
+fhome="$work/fhome"; mkdir -p "$fhome"
+set +e
+out=$(PATH="$fbin:$work/bin:$qmd_free_path" HOME="$fhome" bash "$adopt" \
+      --profile core --scope user --target "$work/ign-f" 2>&1); rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "adopt must exit 0 when qmd install fails (WARN-not-fail), got rc=$rc"
+printf '%s' "$out" | grep -q 'Installing qmd via bun' || fail "qmd_install not invoked (call order)"
+printf '%s' "$out" | grep -Eq 'WARNING.*qmd install failed' || fail "missing qmd install WARNING (WARN-not-fail)"
+echo "ok: qmd install failure WARNs and adopt continues (WARN-not-fail, rc=0)"
 
 echo "PASS"


### PR DESCRIPTION
Closes #276 — all six gaps (G1–G6) from the fresh-machine report.

- **G3 (blocker):** the canonical install hint drops `--ignore-scripts` (it blocked better-sqlite3's native build → crashing qmd on platforms with no prebuilt binary). New `qmd_install()` in `scripts/lib/qmd-bin.sh`: install → verify `qmd --version` → heal via better-sqlite3 `npm run build-release` → re-verify → honest rc. All mirror locations updated in lockstep (`setup.ps1`, `adopt.ps1`, `fix-qmd-stub.sh`, `ubuntu.sh`).
- **G1:** `adopt.sh` now wires qmd end-to-end via `wire_qmd_core()` (stub-fix → install-if-missing → model pull → register the himmel clone), WARN-not-fail (a broken/missing qmd never aborts adopt), `--dry-run` honored.
- **G2:** `require_tools()` soft-checks `bun` with an actionable hint.
- **G4:** `qmd pull` runs with the ~2.1 GB caveat printed first; on failure the manual command is surfaced.
- **G5:** shared idempotent `qmd_register_collection()`; the scaffolded luna vault is registered as a collection (and `setup.sh [4/10]` now uses the same helper).
- **G6:** `docs/internals/environment-gotchas.md` documents the benign darwin `ggml_metal_library_init_from_source` noise (GPU embedding succeeds despite it).
- `adopt.ps1` mirrors everything for Windows.

Tests: hermetic suites `test-qmd-bin.sh` (38 cases — install happy/heal/heal-fail/honest-fail, register add/skip/list-fail/add-127) + `test-adopt.sh` (dry-run step lines + WARN-not-fail continuation); shellcheck clean; ps1 parse-clean. Reviewed via the multi-model CR panel + 4-reviewer matrix over two rounds.

Thanks @Goomal for the exceptionally precise fresh-machine report — the checklist made this directly actionable.
