### PR TITLE
fix(codex): terminal write-fence guard + through-adapter e2e proofs

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -24,7 +24,8 @@
         "matcher": "Bash|PowerShell",
         "hooks": [
           { "type": "command", "command": ".codex/run-hook.cmd --sandbox block-docker-privesc.sh" },
-          { "type": "command", "command": ".codex/run-hook.cmd --sandbox block-merged-pr-commit.sh" }
+          { "type": "command", "command": ".codex/run-hook.cmd --sandbox block-merged-pr-commit.sh" },
+          { "type": "command", "command": ".codex/run-hook.cmd --sandbox block-terminal-write-fence.sh" }
         ]
       },
       {

--- a/docs/internals/lane-parity.md
+++ b/docs/internals/lane-parity.md
@@ -96,7 +96,7 @@ confirmed HIMMEL-695 landed it (see the conformance notes below).
 | main-claude | auto-mode classifier |
 | glm-spawn | `tested:scripts/hooks/test-block-glm-external-writes.sh` |
 | glm-launcher | `tested:scripts/hooks/test-block-glm-external-writes.sh` |
-| codex-direct | adapter path -- `.codex/hooks.json` reaches the native block-* hooks |
+| codex-direct | `tested:scripts/hooks/test-block-terminal-write-fence.sh` -- the terminal write/push/network fence (codex-lane classifier substitute, HIMMEL-745), e2e-proved through the adapter (`scripts/hooks/test-codex-adapter-e2e.sh`). The Edit/Write patch path is fenced by `block-edit-on-main.sh` via the adapter. |
 | hermes-main (DEFAULT; engines codex-5.5 + GLM) | `parity_guard` push/PR fence -- `tested:scripts/hermes/test-parity-guard.sh` (HIMMEL-695 write-fence; the CC hook does NOT fire under hermes, parity_guard is the sole fence). The four OTHER deny-guards were ported into parity_guard by Task 6 / HIMMEL-731 (all now `present`). |
 | hermes-junior | n/a -- read-only tier (`luna_vault_guard`) |
 | gemini / copilot / cursor | `deferred` |
@@ -191,12 +191,12 @@ deny-guards plus the write-fence are now PRESENT under hermes.
 | deny-guard | glm-spawn | glm-launcher | codex-direct | hermes-main (codex-5.5 + GLM) | hermes-junior |
 |---|---|---|---|---|---|
 | block-edit-on-main | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-codex-run-hook.sh` `tested:scripts/hooks/test-block-edit-on-main.sh` | `tested:scripts/hermes/test-parity-guard.sh` | `GAP` |
-| block-read-secrets | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-codex-run-hook.sh` `tested:scripts/hooks/test-block-read-secrets.sh` `GAP` | `tested:scripts/hermes/test-parity-guard.sh` | `GAP` |
+| block-read-secrets | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-codex-run-hook.sh` `tested:scripts/hooks/test-block-read-secrets.sh` `tested:scripts/hooks/test-codex-adapter-e2e.sh` | `tested:scripts/hermes/test-parity-guard.sh` | `GAP` |
 | block-backend-tier | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-codex-run-hook.sh` `tested:scripts/hooks/test-block-backend-tier.sh` | `tested:scripts/hermes/test-parity-guard.sh` | `GAP` |
 | block-docker-privesc | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-codex-run-hook.sh` `tested:scripts/hooks/test-block-docker-privesc.sh` | `tested:scripts/hermes/test-parity-guard.sh` | `GAP` |
 | block-rogue-claude-schedule | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-codex-run-hook.sh` `tested:scripts/hooks/test-block-rogue-claude-schedule.sh` | `tested:scripts/hermes/test-parity-guard.sh` | `GAP` |
 | block-merged-pr-commit | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-codex-run-hook.sh` `tested:scripts/hooks/test-block-merged-pr-commit.sh` | `tested:scripts/hermes/test-parity-guard.sh` | `GAP` |
-| write-authority / external-write-fence (cross-lane dimension, NOT a CC PreToolUse hook) | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `GAP` | `tested:scripts/hermes/test-parity-guard.sh` | `GAP` |
+| write-authority / external-write-fence (cross-lane dimension, NOT a CC PreToolUse hook) | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-block-glm-external-writes.sh` | `tested:scripts/hooks/test-block-terminal-write-fence.sh` `tested:scripts/hooks/test-codex-adapter-e2e.sh` | `tested:scripts/hermes/test-parity-guard.sh` | `GAP` |
 
 <!-- END guard-lane-conformance -->
 
@@ -214,11 +214,24 @@ Notes on the cells:
   `tested:scripts/hooks/test-codex-run-hook.sh` (the `.codex/hooks.json`
   adapter's exit-2 to `deny` translation, HIMMEL-427) PLUS the NATIVE
   `tested:scripts/hooks/test-block-<guard>.sh` the adapter reaches (all six
-  native fixtures exist). The `block-read-secrets` cell additionally carries
-  `GAP`: a true codex through-adapter END-TO-END secret-read fixture is wanted
-  and does not exist, so T6 is proven by the PAIR, not by a (non-existent)
-  codex-specific fixture. The write-authority cell is `GAP` for the same
-  reason -- there is no codex through-adapter external-write e2e proof.
+  native fixtures exist). HIMMEL-745 closed the two remaining codex-direct
+  GAPs with a through-adapter END-TO-END fixture,
+  `scripts/hooks/test-codex-adapter-e2e.sh`: it drives
+  `.codex/codex-hook-adapter.sh` against the REAL guardrails
+  (`CLAUDE_PROJECT_DIR` = the checkout) and asserts the JSON `deny` lands for a
+  secret-read (through `block-read-secrets.sh`) AND an external-write (through
+  the new `block-terminal-write-fence.sh`), so the `block-read-secrets` cell no
+  longer carries a `GAP`. The write-authority cell is now `tested` too: a live
+  probe on this ticket came back SPLIT -- `.codex/hooks.json` wired
+  `block-edit-on-main.sh` only on the Edit|Write matcher, so the PATCH path was
+  denied but the TERMINAL path (a pwsh/bash command that writes a file, pushes,
+  or hits the network) succeeded, and codex has NO auto-mode classifier to
+  catch it (HIMMEL-748 deterministic-guards-only). `block-terminal-write-fence.sh`
+  is the codex-lane classifier substitute for that terminal surface
+  (external-write class fail-closed behind `CODEX_EXTERNAL_WRITES_OK`; a
+  write-on-main class honouring `.single-writer`), unit-tested by
+  `scripts/hooks/test-block-terminal-write-fence.sh` and e2e-proved through the
+  adapter. The codex-direct column is now `tested`-green.
 - **hermes-main (DEFAULT; both engines codex-5.5 + GLM).** himmel's CC
   PreToolUse hooks do NOT load under hermes, so `parity_guard.py` is the sole
   fence; both engines are exercised by

--- a/scripts/hooks/block-terminal-write-fence.sh
+++ b/scripts/hooks/block-terminal-write-fence.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash/PowerShell — codex-lane terminal write-fence.
+#
+# WHY (HIMMEL-745): the codex-direct lane runs himmel's deny-guards through the
+# .codex/hooks.json adapter, but block-edit-on-main.sh is wired ONLY on the
+# Edit|Write|MultiEdit matcher — so the PATCH path (Edit/Write tools) is fenced
+# while the TERMINAL path (a shell command that writes a file, pushes, or hits
+# the network) is not. On the Claude lane the auto-mode classifier + the
+# GLM-lane block-glm-external-writes.sh cover that terminal surface; codex has
+# NO classifier layer (HIMMEL-748 ratified deterministic-guards-only for codex),
+# so this hook is the codex-lane classifier SUBSTITUTE for the terminal write
+# surface. It is the behavioural port of hermes's parity_guard.py
+# (terminal_external_write_reason + the terminal branch of _edit_on_main_reason)
+# into the Claude hook convention, wired ONLY in .codex/hooks.json.
+#
+# Two classes, both scoped to a tool_input.command (Bash/PowerShell payloads):
+#
+#   (a) EXTERNAL-WRITE — plain/force git push; git remote-URL rewrite
+#       (remote set-url / config ...url); gh PR-mutations (create/merge/close/
+#       edit/review/comment/api/…) with a read carve-out (gh issue *, gh pr
+#       view/diff/checks/status/list, gh run view/list/watch); and network CLIs
+#       (curl/wget/iwr/irm/Invoke-WebRequest/Invoke-RestMethod). FAIL-CLOSED:
+#       denied UNLESS the named opt-in CODEX_EXTERNAL_WRITES_OK=1 is set (mirrors
+#       HERMES_EXTERNAL_WRITES_OK / GLM_EXTERNAL_WRITES_OK semantics).
+#
+#   (b) WRITE-ON-MAIN — a write-shaped terminal command (redirect > / >>, tee,
+#       Set-Content/Out-File/Add-Content, sed -i, cp/mv/rm on a path, git commit)
+#       whose effective repo (tool_input.cwd if present, else process cwd) is
+#       checked out on its DEFAULT branch (main/master) is refused, UNLESS the
+#       repo root carries a .single-writer marker (same opt-out as
+#       block-edit-on-main.sh). A feature/worker-branch cwd is ALLOWED — normal
+#       worktree work is never blocked. Conservative on false positives: a
+#       command that is not confidently write-shaped is ALLOWED (the charter is
+#       the known write shapes, not a general sandbox).
+#
+# Known limitations (accidental-shape guard, like block-glm-external-writes /
+# block-read-secrets): a write verb displaced from command position (env-prefix
+# `FOO=1 git push`, sudo/xargs/timeout wrappers, hyphenated aliases) is missed
+# (under-block); command-text scanning shares those wrapper/quoting gaps. A
+# `.exe` suffix on the Windows lane (`git.exe push`, `curl.exe`) IS handled.
+#
+# Exit codes: 0 allow; 2 block (stderr shown to the model). Bash 3.2-safe.
+set -euo pipefail
+
+# On a security-relevant hook a TOP-LEVEL errexit abort must BLOCK (exit 2),
+# never slip through as a non-blocking exit 1 (only exit 2 denies under Claude
+# Code, and the codex adapter only translates exit 2 -> JSON deny). Mirrors
+# block-glm-external-writes.sh's clamp. The malformed-JSON path below stays
+# fail-OPEN (sibling-hook parity — Claude Code / codex emit valid JSON).
+# shellcheck disable=SC2154  # rc is assigned by rc=$? inside the same trap string
+trap 'rc=$?; if [ "$rc" != 0 ] && [ "$rc" != 2 ]; then exit 2; fi' EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "block-terminal-write-fence: jq not on PATH — refusing to evaluate; install jq" >&2
+    exit 2
+fi
+
+# lib.sh drives the on-main branch read (is_on_main). Class (b) is skipped if it
+# cannot be sourced (fail-OPEN for the hygiene class), but class (a) — the
+# security-critical external-write fence — still runs.
+LIB_OK=1
+# shellcheck source=../guardrails/lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../guardrails/lib.sh" 2>/dev/null || LIB_OK=0
+
+input=$(cat)
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)
+case "$tool" in
+    Bash|PowerShell|"") ;;   # "" = tolerate a payload with no tool_name
+    *) exit 0 ;;
+esac
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+[ -z "$cmd" ] && exit 0
+
+# Lower-case + flatten newlines TO ';' (a newline separates commands like ';';
+# flattening to spaces would UNDER-block a two-line "gh pr view 1\ngh pr merge 1"
+# by reading it as one command). Keeps command boundaries visible to the
+# (^|[;&|(]) anchor. Mirrors block-glm-external-writes.sh.
+cmd_lc=$(printf '%s' "$cmd" | LC_ALL=C tr '[:upper:]' '[:lower:]' | LC_ALL=C tr '\n\r' ';;')
+
+# Command-position occurrence counter (start-of-command or right after ; & | ( —
+# deliberately NOT space/quote, so a blocked verb quoted in a message does not
+# false-block). grep -c counts LINES; cmd_lc is one line, so count PER-MATCH via
+# grep -oE | wc -l. grep exits 1 on zero matches; `|| true` keeps errexit calm.
+count_cmd() {
+    local n
+    n=$(printf '%s' "$cmd_lc" | grep -oE "(^|[;&|(])[[:space:]]*($1)" | wc -l) || true
+    printf '%s' "$((n))"
+}
+
+# ------------------------------------------------------------------ class (a)
+# External-write fence (port of parity_guard.terminal_external_write_reason /
+# block-glm-external-writes.sh shapes). FAIL-CLOSED unless the operator opts in.
+if [ "${CODEX_EXTERNAL_WRITES_OK:-0}" != "1" ]; then
+    deny_ext() {
+        {
+            echo "⛔ block-terminal-write-fence: $1"
+            echo "    The codex-direct lane has no auto-mode classifier, so external-write"
+            echo "    shapes are hard-blocked (HIMMEL-745). Commit locally and deliver a"
+            echo "    branch diff; the operator / trusted lane pushes and opens PRs."
+            echo "    Opt-in: set CODEX_EXTERNAL_WRITES_OK=1 in the launching shell."
+        } >&2
+        exit 2
+    }
+
+    # `git(\.exe)?` etc: a Windows lane invokes git.exe/curl.exe/gh.exe — the
+    # bare-name anchor would miss those (CR codex-1), so tolerate an optional
+    # `.exe`. Flag atom is `-[^[:space:];&|]+` (spec parity: parity_guard uses
+    # `-\S+`) so an attached-value long flag like `--git-dir=/x` before `push`
+    # cannot break the anchor (CR under-block).
+    gp_shape='git(\.exe)?([[:space:]]+-[^[:space:];&|]+([[:space:]]+[^[:space:];&|]+)?)*[[:space:]]+push([[:space:]]|$)'
+    # config-url branch requires a VALUE token after the url key, so a read
+    # (`git config --get remote.origin.url`, no trailing value) is NOT blocked
+    # (CR codex-2); only a `config …url <newvalue>` rewrite matches.
+    # config-subcommand flags carry the same optional-VALUE tolerance as the
+    # git-level flags (`--file <path>` before the url key), else a value-taking
+    # config flag breaks the anchor and lets a url rewrite slip through (CR).
+    gu_shape='(git(\.exe)?([[:space:]]+-[^[:space:];&|]+([[:space:]]+[^[:space:];&|]+)?)*[[:space:]]+remote[[:space:]]+set-url|git(\.exe)?([[:space:]]+-[^[:space:];&|]+([[:space:]]+[^[:space:];&|]+)?)*[[:space:]]+config([[:space:]]+-[^[:space:];&|]+([[:space:]]+[^[:space:];&|]+)?)*[[:space:]]+[^[:space:];&|]*url[[:space:]]+[^[:space:];&|])'
+    gh_shape='gh(\.exe)?([[:space:]]|$)'
+    gh_allow='gh(\.exe)?[[:space:]]+(issue([[:space:]]|$)|pr[[:space:]]+(view|diff|checks|status|list)([[:space:]]|$)|run[[:space:]]+(view|list|watch)([[:space:]]|$))'
+    net_shape='(curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm)(\.exe)?([[:space:]]|$)'
+
+    if [ "$(count_cmd "$gp_shape")" -gt 0 ]; then
+        deny_ext "git push is refused (external-write class)."
+    fi
+    if [ "$(count_cmd "$gu_shape")" -gt 0 ]; then
+        deny_ext "rewriting a git remote / push URL is refused (external-write class)."
+    fi
+    if [ "$(count_cmd "$gh_shape")" -gt "$(count_cmd "$gh_allow")" ]; then
+        deny_ext "gh is limited (external-write class): issue ops + pr/run reads only; PR mutations belong to the operator / trusted lane."
+    fi
+    if [ "$(count_cmd "$net_shape")" -gt 0 ]; then
+        deny_ext "network CLIs are refused (external-write class); chores are repo-local."
+    fi
+fi
+
+# ------------------------------------------------------------------ class (b)
+# Write-on-main lock (port of the terminal branch of parity_guard's
+# _edit_on_main_reason). Only fires when the command is CONFIDENTLY write-shaped
+# AND the effective repo is on its default branch AND no .single-writer opt-out.
+
+# True (rc 0) iff at least one redirect / tee target is a REAL file (not
+# /dev/null and not a temp path). $TMP-redirects and > /dev/null are NOT writes
+# worth fencing (per the charter's precision list).
+is_temp_or_devnull() {
+    # The '$tmp'* / '%temp%'* branches keep the $ / % literal on purpose (they
+    # match an unexpanded env-var temp ref in the payload text), so SC2016 is
+    # expected — a directive can only sit in front of the whole `case`.
+    # shellcheck disable=SC2016
+    case "$1" in
+        /dev/null|/dev/null/*) return 0 ;;
+        /tmp|/tmp/*|*/tmp/*|*/temp/*) return 0 ;;
+        *appdata/local/temp*) return 0 ;;
+        '$tmp'*|'$temp'*|'%temp%'*|'%tmp%'*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+redirect_real_target() {
+    local c="$1" chunk tok
+    # Redirect targets: >>? then the following token. `2>&1` / `>&2` yield no
+    # target token (the char after > is & / a digit-then-&, excluded), so they
+    # are not treated as file writes.
+    while IFS= read -r chunk; do
+        [ -z "$chunk" ] && continue
+        tok=$(printf '%s' "$chunk" | sed -E 's/^>>?[[:space:]]*//')
+        [ -z "$tok" ] && continue
+        is_temp_or_devnull "$tok" || return 0
+    done < <(printf '%s' "$c" | grep -oE '>>?[[:space:]]*[^[:space:];&|<>()]+' || true)
+    # tee targets: `tee [-a] <file>` (also matches `| tee file`).
+    while IFS= read -r chunk; do
+        [ -z "$chunk" ] && continue
+        tok=$(printf '%s' "$chunk" | sed -E 's/^tee[[:space:]]+(-a[[:space:]]+)?//')
+        [ -z "$tok" ] && continue
+        is_temp_or_devnull "$tok" || return 0
+    done < <(printf '%s' "$c" | grep -oE 'tee[[:space:]]+(-a[[:space:]]+)?[^[:space:];&|<>()]+' || true)
+    return 1
+}
+
+write_shaped() {
+    local c="$1"
+    # git commit at command position (flag-tolerant; `commit` as the verb so
+    # commit-graph / commit-tree do not match). `git(\.exe)?` catches the
+    # Windows-lane git.exe form (CR parity with class (a)).
+    printf '%s' "$c" | grep -qE '(^|[;&|(])[[:space:]]*git(\.exe)?([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]]+)?)*[[:space:]]+commit([[:space:]]|$)' && return 0
+    # sed -i (in-place edit).
+    printf '%s' "$c" | grep -qE '(^|[;&|(])[[:space:]]*sed[[:space:]]+[^;&|]*-i' && return 0
+    # PowerShell file writers at command position (not matched inside quoted /
+    # logged text like `echo set-content …` — CR false-positive fix).
+    printf '%s' "$c" | grep -qE '(^|[;&|(])[[:space:]]*(set-content|out-file|add-content)([[:space:]]|$)' && return 0
+    # cp / mv / rm targeting a path (at command position).
+    printf '%s' "$c" | grep -qE '(^|[;&|(])[[:space:]]*(cp|mv|rm)[[:space:]]+[^[:space:]]' && return 0
+    # redirect / tee to a real (non-devnull, non-temp) file.
+    redirect_real_target "$c" && return 0
+    return 1
+}
+
+if [ "$LIB_OK" = 1 ] && command -v git >/dev/null 2>&1 && write_shaped "$cmd_lc"; then
+    # Effective repo dir: tool payload cwd, else the hook process cwd.
+    cwd=$(printf '%s' "$input" | jq -r '.tool_input.cwd // .cwd // empty' 2>/dev/null || true)
+    [ -z "$cwd" ] && cwd="$PWD"
+
+    branch_rc=0
+    is_on_main "$cwd" || branch_rc=$?
+    # rc 0 = on default branch -> candidate for the lock; rc 1 (feature branch /
+    # detached) or rc 2 (branch unreadable) -> ALLOW (fail-open on the hygiene
+    # class so normal worktree work is never blocked).
+    if [ "$branch_rc" -eq 0 ]; then
+        repo_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)
+        # .single-writer opt-out (mirrors block-edit-on-main.sh): a repo that
+        # commits straight to main by design (personal vaults / state repos).
+        if [ -z "$repo_root" ] || [ ! -f "$repo_root/.single-writer" ]; then
+            {
+                echo "⛔ block-terminal-write-fence: refusing a write-shaped terminal command —"
+                echo "    the effective repo is checked out on its default branch (main/master)."
+                echo "    (command: $cmd)"
+                echo "    (cwd: $cwd)"
+                echo ""
+                echo "    Feature work belongs in a worktree per CLAUDE.md, not on the primary"
+                echo "    main checkout (write-on-main class, HIMMEL-745). To proceed:"
+                echo "      - run the command from a type/slug worktree, or"
+                echo "      - touch \"$repo_root/.single-writer\" if this repo commits to main by design."
+            } >&2
+            exit 2
+        fi
+    fi
+fi
+
+exit 0

--- a/scripts/hooks/test-block-terminal-write-fence.sh
+++ b/scripts/hooks/test-block-terminal-write-fence.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Unit test for scripts/hooks/block-terminal-write-fence.sh (HIMMEL-745) — the
+# codex-lane terminal write-fence. Exit 0 = allow, exit 2 = block.
+#
+# Hermetic: a temp HOME + isolated git config, temp git fixtures built with
+# `git init` + `symbolic-ref` (no commits / identity needed), and EXPLICIT cwd
+# in every write-on-main payload so the assertion never depends on the suite's
+# own process cwd (the #975 lesson). No network — the external-write cases are
+# classified by command text alone.
+set -uo pipefail
+
+HOOKS="$(cd "$(dirname "$0")" && pwd)"
+GUARD="$HOOKS/block-terminal-write-fence.sh"
+[ -f "$GUARD" ] || { echo "guard not found: $GUARD" >&2; exit 1; }
+command -v git >/dev/null 2>&1 || { echo "SKIP: git not on PATH"; exit 0; }
+command -v jq  >/dev/null 2>&1 || { echo "SKIP: jq not on PATH"; exit 0; }
+
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+# Isolate git from the real user/system config so branch reads are deterministic.
+export HOME="$T"
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL="$T/.gitconfig"
+# The guard must never inherit the opt-in from the suite env.
+unset CODEX_EXTERNAL_WRITES_OK 2>/dev/null || true
+
+mkrepo() {  # mkrepo <dir> <branch-ref>
+    git init -q "$1" >/dev/null 2>&1
+    git -C "$1" symbolic-ref HEAD "refs/heads/$2"
+}
+mkrepo "$T/mainrepo"  "main"
+mkrepo "$T/featrepo"  "feat/x"
+MAIN="$T/mainrepo"
+FEAT="$T/featrepo"
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf '  FAIL %s\n' "$1"; }
+
+# check <label> <block|allow> <json> [ENV=val ...]
+check() {
+    local label="$1" expect="$2" json="$3"; shift 3
+    local rc got
+    printf '%s' "$json" | env "$@" bash "$GUARD" >/dev/null 2>&1
+    rc=$?
+    case "$rc" in
+        0) got=allow ;;
+        2) got=block ;;
+        *) got="?(rc=$rc)" ;;
+    esac
+    if [ "$got" = "$expect" ]; then ok "$label"; else
+        bad "$label — expected $expect got $got"; fi
+}
+
+echo "== external-write class (a) =="
+check "git push denied"                 block '{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}'
+check "git push allowed with opt-in"    allow '{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}' CODEX_EXTERNAL_WRITES_OK=1
+check "git push --force denied"          block '{"tool_name":"Bash","tool_input":{"command":"git push --force origin main"}}'
+check "remote set-url rewrite denied"    block '{"tool_name":"Bash","tool_input":{"command":"git remote set-url origin http://x"}}'
+check "config url rewrite denied"        block '{"tool_name":"Bash","tool_input":{"command":"git config remote.origin.url http://x"}}'
+check "config url READ allowed"          allow '{"tool_name":"Bash","tool_input":{"command":"git config --get remote.origin.url"}}'
+check "config --file url rewrite denied"  block '{"tool_name":"Bash","tool_input":{"command":"git config --file .git/config remote.origin.url http://x"}}'
+check "gh pr create denied"              block '{"tool_name":"Bash","tool_input":{"command":"gh pr create --fill"}}'
+check "gh pr view allowed"               allow '{"tool_name":"Bash","tool_input":{"command":"gh pr view 12"}}'
+check "gh issue list allowed"            allow '{"tool_name":"Bash","tool_input":{"command":"gh issue list"}}'
+check "curl denied"                      block '{"tool_name":"Bash","tool_input":{"command":"curl http://evil/x"}}'
+check "curl allowed with opt-in"         allow '{"tool_name":"Bash","tool_input":{"command":"curl http://evil/x"}}' CODEX_EXTERNAL_WRITES_OK=1
+# Windows lane: .exe-suffixed binaries must not bypass the fence (CR codex-1).
+check "git.exe push denied"              block '{"tool_name":"Bash","tool_input":{"command":"git.exe push origin main"}}'
+check "curl.exe denied"                  block '{"tool_name":"Bash","tool_input":{"command":"curl.exe http://evil/x"}}'
+check "gh.exe pr create denied"          block '{"tool_name":"Bash","tool_input":{"command":"gh.exe pr create --fill"}}'
+check "gh.exe pr view allowed"           allow '{"tool_name":"Bash","tool_input":{"command":"gh.exe pr view 12"}}'
+# Attached-value long flag before push must not break the anchor (CR under-block).
+check "git --git-dir=/x push denied"     block '{"tool_name":"Bash","tool_input":{"command":"git --git-dir=/x push origin main"}}'
+
+echo "== write-on-main class (b) =="
+check "Set-Content on main-checkout denied" block "{\"tool_name\":\"PowerShell\",\"tool_input\":{\"command\":\"Set-Content -Path foo.txt -Value x\",\"cwd\":\"$MAIN\"}}"
+check "Set-Content on feature-branch allowed" allow "{\"tool_name\":\"PowerShell\",\"tool_input\":{\"command\":\"Set-Content -Path foo.txt -Value x\",\"cwd\":\"$FEAT\"}}"
+# git.exe commit on main must be caught too (CR .exe parity for class b).
+check "git.exe commit on main denied"    block "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git.exe commit -m x\",\"cwd\":\"$MAIN\"}}"
+# A write-verb only inside quoted/logged text must NOT be flagged on main
+# (CR false-positive: command-position anchor on the PS writers).
+check "echo mentioning set-content on main allowed" allow "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo see Set-Content docs\",\"cwd\":\"$MAIN\"}}"
+check "git commit on main denied"        block "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m wip\",\"cwd\":\"$MAIN\"}}"
+check "git commit on feature allowed"    allow "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m wip\",\"cwd\":\"$FEAT\"}}"
+check "redirect to real file on main denied" block "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo hi > out.txt\",\"cwd\":\"$MAIN\"}}"
+# $TMP is a literal token in the payload the guard must treat as a temp path.
+# shellcheck disable=SC2016
+check "redirect into \$TMP allowed" allow '{"tool_name":"Bash","tool_input":{"command":"echo hi > $TMP/scratch.txt","cwd":"'"$MAIN"'"}}'
+check "redirect to /dev/null allowed" allow "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo hi > /dev/null 2>&1\",\"cwd\":\"$MAIN\"}}"
+check "git status on main allowed"       allow "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git status\",\"cwd\":\"$MAIN\"}}"
+check "cat read on main allowed"         allow "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cat foo.txt\",\"cwd\":\"$MAIN\"}}"
+
+# .single-writer opt-out: the same on-main write is now allowed.
+: > "$MAIN/.single-writer"
+check "Set-Content on main with .single-writer allowed" allow "{\"tool_name\":\"PowerShell\",\"tool_input\":{\"command\":\"Set-Content -Path foo.txt -Value x\",\"cwd\":\"$MAIN\"}}"
+
+echo "== non-command payloads =="
+check "no command -> allow"              allow '{"tool_name":"Bash","tool_input":{}}'
+check "non-terminal tool -> allow"       allow '{"tool_name":"Read","tool_input":{"file_path":"/x/README.md"}}'
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/hooks/test-codex-adapter-e2e.sh
+++ b/scripts/hooks/test-codex-adapter-e2e.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Through-adapter e2e for the codex-direct lane (HIMMEL-745 acceptance). Drives
+# .codex/codex-hook-adapter.sh END-TO-END: stdin = a codex-shaped PreToolUse
+# JSON, CLAUDE_PROJECT_DIR pointed at THIS checkout so the adapter runs the REAL
+# guardrails under scripts/hooks/. Asserts the exit-2 block is translated into
+# Codex's JSON `permissionDecision:"deny"` for BOTH:
+#   (a) a secret-read payload through block-read-secrets.sh, and
+#   (b) an external-write payload through block-terminal-write-fence.sh
+#       (the guard this ticket adds).
+# Plus an ALLOW passthrough (a benign command through the new guard must NOT
+# emit a deny). Companion to scripts/hooks/test-codex-run-hook.sh, which proves
+# the wrapper+adapter mechanics on a synthetic guardrail; this proves the real
+# guardrails deny through the adapter. Hermetic: no network, no fixtures needed
+# (both deny cases classify by the payload alone).
+set -uo pipefail
+
+HOOKS="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HOOKS/../.." && pwd)"
+ADAPTER="$REPO/.codex/codex-hook-adapter.sh"
+[ -f "$ADAPTER" ] || { echo "adapter not found: $ADAPTER" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not on PATH"; exit 0; }
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf '  FAIL %s\n' "$1"; }
+
+# The adapter must never see the external-write opt-in from the suite env.
+unset CODEX_EXTERNAL_WRITES_OK 2>/dev/null || true
+
+# run <guardrail.sh> <json> -> echoes adapter stdout; exit code in $rc
+run() {
+    local script="$1" json="$2"
+    CLAUDE_PROJECT_DIR="$REPO" bash "$ADAPTER" "$script" <<EOF
+$json
+EOF
+}
+
+echo "== (a) secret-read through block-read-secrets.sh =="
+out="$(run block-read-secrets.sh '{"hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"/x/.env"}}')"; rc=$?
+if [ "$rc" -eq 0 ]; then ok "adapter exits 0 (decision is in the JSON)"; else bad "adapter exits 0 (got $rc)"; fi
+case "$out" in
+  *'"permissionDecision":"deny"'*) ok "secret read -> JSON deny";;
+  *) bad "secret read -> JSON deny ($out)";;
+esac
+case "$out" in
+  *'"hookEventName":"PreToolUse"'*) ok "secret read -> hookEventName PreToolUse";;
+  *) bad "secret read -> hookEventName PreToolUse ($out)";;
+esac
+
+echo "== (b) external-write through block-terminal-write-fence.sh =="
+out="$(run block-terminal-write-fence.sh '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git push origin main"}}')"; rc=$?
+if [ "$rc" -eq 0 ]; then ok "adapter exits 0 (decision is in the JSON)"; else bad "adapter exits 0 (got $rc)"; fi
+case "$out" in
+  *'"permissionDecision":"deny"'*) ok "git push -> JSON deny";;
+  *) bad "git push -> JSON deny ($out)";;
+esac
+case "$out" in
+  *"external-write"*) ok "git push -> reason names the external-write class";;
+  *) bad "git push -> reason names the external-write class ($out)";;
+esac
+
+echo "== (b') benign command through block-terminal-write-fence.sh -> ALLOW =="
+out="$(run block-terminal-write-fence.sh '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git status"}}')"; rc=$?
+if [ "$rc" -eq 0 ]; then ok "benign command -> adapter exits 0"; else bad "benign command -> adapter exits 0 (got $rc)"; fi
+case "$out" in
+  *permissionDecision*) bad "benign command -> must NOT emit a deny ($out)";;
+  *) ok "benign command -> no permissionDecision (passthrough allow)";;
+esac
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
The codex lane fenced the patch path (Edit/Write) but not the terminal path — a shell command that writes a file, pushes, or hits the network went through, and codex has no auto-mode classifier to catch it. Adds scripts/hooks/block-terminal-write-fence.sh (a behavioral port of the hermes parity_guard terminal fence: external-write class fail-closed behind CODEX_EXTERNAL_WRITES_OK, write-on-main hygiene class honoring .single-writer; .exe-suffixed Windows binaries handled), wired into .codex/hooks.json. Through-adapter e2e tests assert the JSON deny for a secret-read and an external-write end to end; lane-parity.md codex-direct is now tested-green. Suite 31/0, adapter e2e 8/0, conformance + parity canary green.