### PR TITLE
feat(guardrails): owned data-egress matrix (corpus x provider x purpose)

### DIFF
--- a/docs/internals/egress-matrix.md
+++ b/docs/internals/egress-matrix.md
@@ -1,0 +1,70 @@
+# Data-egress matrix (HIMMEL-766)
+
+**Source of truth: [`scripts/guardrails/egress-matrix.json`](../../scripts/guardrails/egress-matrix.json).**
+One owned corpus × provider × purpose policy that every egress-enforcing
+surface reads, replacing per-tool hard-coded policy. It exists because four
+ad-hoc egress decisions (ollama-only → DeepSeek override → GLM-Clippings
+exception → Alibaba embeddings) accumulated across four documents with no
+single owner, producing a live contradiction (the HIMMEL-621/622 fence as
+specced denied Alibaba for luna content; HIMMEL-765 sends luna content to
+Alibaba for embeddings).
+
+## Semantics
+
+- **Evaluation:** first-match-wins over `rules`, `*` wildcards, then
+  `default` (which is `deny` — fail-closed).
+- **Verdicts:** `allow` · `allow+log` (must append a ledger line) ·
+  `conditional` (allow only while the rule's `condition` holds) · `deny` ·
+  `pending-operator` (**evaluates as deny**; a named operator decision flips
+  the cell via a one-line PR on the JSON).
+- **Reference implementation:** the `evaluate()` function in
+  [`scripts/guardrails/test-egress-matrix.mjs`](../../scripts/guardrails/test-egress-matrix.mjs)
+  — consumers in other languages copy those semantics.
+- **Load-bearing nuance:** embedding, rerank, and vision-embedding send FULL
+  content (text or images) to the provider. An "embedding lane" is content
+  egress, not metadata egress, and is gated accordingly.
+
+## Corpus resolution (shared primitives, not new ones)
+
+Corpus membership resolves through the SAME primitives the live guards
+already use: `.salus` root markers and the
+`~/.config/claude-glm/{phi-roots,egress-denylist}` list files
+(`scripts/telegram/glm-guard.ts`, `scripts/hermes/assets/parity_guard.py`),
+plus vault/state roots from env or config — never hardcoded absolute paths.
+The matrix defines *policy*; membership resolution stays with the guards.
+
+## Consumers
+
+| Surface | What it reads |
+|---|---|
+| `graphify-fence.sh` (HIMMEL-621/622 Phase G-F, to be built) | maps graphify `--backend` → provider, target path → corpus, purpose = `extraction` |
+| `parity_guard.py` PHI/egress fence (HIMMEL-695) | the `salus` row (hard deny) — already enforced; the matrix documents the policy it implements |
+| `glm-guard.ts` | same `salus`/denylist row |
+| HIMMEL-765 embedding/rerank pilot client | the `alibaba` × `embedding`/`rerank`/`vision-embedding` cells (all five currently `pending-operator` = deny) |
+
+## Invariants (enforced by the test)
+
+- `default` is `deny`; salus × any-cloud × anything is a **hard** deny with
+  no recordable override; google-gemini is denied everywhere (keys stay
+  unset); `pending-operator` cells evaluate as deny; the DeepSeek override
+  covers **extraction only**; no bulk pipelines over handover-state.
+- Run: `node scripts/guardrails/test-egress-matrix.mjs`.
+
+## Changing the matrix
+
+Every change is a PR through the normal CR flow — the matrix is
+enforcement-path configuration. In particular the planned self-evolving
+loop (HIMMEL-767 family) is structurally denied writes here: a widened cell
+must always be a human-merged diff. Flipping a `pending-operator` cell:
+change its `verdict` (typically to `allow+log`), delete `decision_needed`,
+note the operator decision + date in `why`, update the test's expectations,
+and cite the ratifying ticket in the commit.
+
+## Open operator decisions carried in the matrix
+
+- **HIMMEL-765 (Alibaba embedding/rerank):** five `pending-operator` cells
+  — `luna-clippings` × embedding/rerank/vision-embedding (recommended first
+  pilot corpus: clipped public web content, lowest sensitivity) and
+  `luna-personal` × embedding/rerank (the contradiction cell from the
+  2026-07-08 Fable design review; personal-content egress to a new provider
+  is an operator call). Until flipped, the 765 pilot is gated.

--- a/scripts/guardrails/egress-matrix.json
+++ b/scripts/guardrails/egress-matrix.json
@@ -1,0 +1,146 @@
+{
+  "version": 1,
+  "jira": "HIMMEL-766",
+  "updated": "2026-07-08",
+  "doc": "docs/internals/egress-matrix.md",
+  "semantics": {
+    "evaluation": "first-match-wins over `rules`, then `default`. '*' matches any value.",
+    "verdicts": {
+      "allow": "permitted, no ledger requirement",
+      "allow+log": "permitted; the executing tool MUST append a ledger line (JSONL: ts, corpus, provider, purpose, path, tool)",
+      "conditional": "permitted ONLY when the rule's `condition` holds; otherwise treat as deny",
+      "pending-operator": "evaluates as DENY. A named operator decision is required to flip this cell; flipping it is a one-line PR on this file",
+      "deny": "refused; enforcing guards fail closed"
+    },
+    "note": "embedding, rerank, and vision-embedding send FULL content (text or images) to the provider — they are content egress, not metadata egress."
+  },
+  "corpora": {
+    "salus": "any path under a `.salus`-marked root, or under a root listed in ~/.config/claude-glm/phi-roots or ~/.config/claude-glm/egress-denylist (the shared glm-guard.ts / parity_guard.py primitives)",
+    "luna-personal": "the luna vault root EXCLUDING Clippings/ (journals, maps, sessions, notes)",
+    "luna-clippings": "<luna-root>/Clippings/ (clipped public web content)",
+    "handover-state": "the handover state repo root (HANDOVER_DIR; work artifacts, specs, session notes)",
+    "himmel-code": "himmel checkout(s), worktrees, and the public mirror (code + docs; public-propagated)"
+  },
+  "providers": {
+    "local-ollama": { "region": "local", "note": "zero egress; includes qmd local GGUF embeddings" },
+    "anthropic": { "region": "US", "note": "the operating harness itself (Claude sessions natively read the vaults); recording status quo, not a widening" },
+    "openai-codex": { "region": "US", "note": "codex via hermes, paid usage bank" },
+    "deepseek": { "region": "CN", "note": "operator-accepted 2026-07-05 for luna extraction (speed override)" },
+    "zai-glm": { "region": "CN", "note": "GLM Coding Plan impl lanes" },
+    "alibaba": { "region": "CN-account, ap-southeast-1 endpoint", "note": "qwen text lanes + free-quota modality bank (HIMMEL-729/765)" },
+    "google-gemini": { "region": "US", "note": "DE-LISTED; keys deliberately unset" }
+  },
+  "purposes": ["extraction", "embedding", "rerank", "inference", "vision-embedding"],
+  "rules": [
+    {
+      "corpus": "salus", "provider": "local-ollama", "purpose": "*",
+      "verdict": "conditional",
+      "condition": "per-run explicit opt-in flag (621/622 spec §4.1: even local salus extraction needs a per-run opt-in)",
+      "why": "PHI stays on-machine; opt-in prevents accidental bulk runs"
+    },
+    {
+      "corpus": "salus", "provider": "*", "purpose": "*",
+      "verdict": "deny", "hard": true,
+      "why": "PHI never leaves the machine. No override exists; no operator decision can be recorded here that flips this row"
+    },
+    {
+      "corpus": "*", "provider": "google-gemini", "purpose": "*",
+      "verdict": "deny", "hard": true,
+      "why": "gemini de-listed; GEMINI/GOOGLE keys stay unset (621/622 P.7)"
+    },
+    {
+      "corpus": "himmel-code", "provider": "*", "purpose": "*",
+      "verdict": "allow",
+      "why": "public-propagated code/docs; impl lanes (codex/GLM/alibaba) are ratified consumers. Caveat rides the lane guards: debrand content-not-name; secrets are excluded by block-read-secrets, not by this matrix"
+    },
+    {
+      "corpus": "handover-state", "provider": "local-ollama", "purpose": "*",
+      "verdict": "allow", "why": "zero egress"
+    },
+    {
+      "corpus": "handover-state", "provider": "anthropic", "purpose": "*",
+      "verdict": "allow", "why": "operating substrate (sessions read/write handovers natively)"
+    },
+    {
+      "corpus": "handover-state", "provider": "openai-codex", "purpose": "inference",
+      "verdict": "conditional",
+      "condition": "brief-scoped: task briefs/excerpts through the guarded dispatch chokepoints only — never bulk corpus runs",
+      "why": "worker briefs necessarily carry handover-derived context; the chokepoint audit is the ledger"
+    },
+    {
+      "corpus": "handover-state", "provider": "zai-glm", "purpose": "inference",
+      "verdict": "conditional",
+      "condition": "brief-scoped: task briefs/excerpts through the guarded dispatch chokepoints only — never bulk corpus runs",
+      "why": "same as openai-codex row"
+    },
+    {
+      "corpus": "handover-state", "provider": "alibaba", "purpose": "inference",
+      "verdict": "conditional",
+      "condition": "brief-scoped: task briefs/excerpts through the guarded dispatch chokepoints only — never bulk corpus runs",
+      "why": "same as openai-codex row"
+    },
+    {
+      "corpus": "luna-clippings", "provider": "local-ollama", "purpose": "*",
+      "verdict": "allow", "why": "zero egress"
+    },
+    {
+      "corpus": "luna-clippings", "provider": "anthropic", "purpose": "*",
+      "verdict": "allow", "why": "operating substrate"
+    },
+    {
+      "corpus": "luna-clippings", "provider": "deepseek", "purpose": "extraction",
+      "verdict": "allow+log",
+      "why": "subsumed by the operator DeepSeek override (2026-07-05) which covers the more-sensitive luna-personal corpus"
+    },
+    {
+      "corpus": "luna-clippings", "provider": "zai-glm", "purpose": "extraction",
+      "verdict": "conditional",
+      "condition": "only if the 621/622 G2.3 local-quality ladder forces it AND the operator provisions ZAI_API_KEY for it (spec §4.2 exception; never mid-run)",
+      "why": "pre-existing narrow exception for clipped public content"
+    },
+    {
+      "corpus": "luna-clippings", "provider": "alibaba", "purpose": "embedding",
+      "verdict": "pending-operator",
+      "decision_needed": "HIMMEL-765 pilot: ratify Alibaba embedding egress for Clippings (recommended FIRST pilot corpus — clipped public web content, lowest sensitivity)",
+      "why": "filed as valuable (765) but the egress widening was never explicitly ratified; default deny until flipped"
+    },
+    {
+      "corpus": "luna-clippings", "provider": "alibaba", "purpose": "rerank",
+      "verdict": "pending-operator",
+      "decision_needed": "same HIMMEL-765 decision as the embedding cell",
+      "why": "rerank sends query + candidate documents — same content egress class"
+    },
+    {
+      "corpus": "luna-clippings", "provider": "alibaba", "purpose": "vision-embedding",
+      "verdict": "pending-operator",
+      "decision_needed": "same HIMMEL-765 decision (tongyi-embedding-vision; vault image search)",
+      "why": "images from clips are content egress too"
+    },
+    {
+      "corpus": "luna-personal", "provider": "local-ollama", "purpose": "*",
+      "verdict": "allow", "why": "zero egress; the salus-grade fallback backend"
+    },
+    {
+      "corpus": "luna-personal", "provider": "anthropic", "purpose": "*",
+      "verdict": "allow", "why": "operating substrate (Claude sessions read the vault natively every day)"
+    },
+    {
+      "corpus": "luna-personal", "provider": "deepseek", "purpose": "extraction",
+      "verdict": "allow+log",
+      "why": "operator override 2026-07-05 (speed): luna non-Clippings graphify extraction on DeepSeek, single model, ledgered per run"
+    },
+    {
+      "corpus": "luna-personal", "provider": "alibaba", "purpose": "embedding",
+      "verdict": "pending-operator",
+      "decision_needed": "HIMMEL-765: ratify Alibaba embedding egress for PERSONAL luna content (journals/notes/sessions). This is THE contradiction cell from the Fable 2026-07-08 review — the 621/622 fence as specced denies it; 765 as filed needs it",
+      "why": "personal-content egress to a new provider is an operator call, not an agent default; deny until ratified"
+    },
+    {
+      "corpus": "luna-personal", "provider": "alibaba", "purpose": "rerank",
+      "verdict": "pending-operator",
+      "decision_needed": "same HIMMEL-765 decision as the embedding cell",
+      "why": "same content egress class"
+    }
+  ],
+  "default": "deny"
+}

--- a/scripts/guardrails/test-egress-matrix.mjs
+++ b/scripts/guardrails/test-egress-matrix.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// test-egress-matrix.mjs — invariant checks for scripts/guardrails/egress-matrix.json
+// (HIMMEL-766). Run: node scripts/guardrails/test-egress-matrix.mjs
+//
+// evaluate() below is also the REFERENCE semantics for consumers
+// (graphify-fence.sh, parity_guard.py, the HIMMEL-765 pilot client):
+// first-match-wins over `rules`, '*' wildcards, then `default`;
+// `conditional` is allow-only-under-condition; `pending-operator` IS a deny.
+// Consumers MUST treat `conditional` as deny unless they positively verify
+// the rule's prose `condition` — "anything not deny" is NOT allow.
+// An unrecognized verdict string normalizes to deny (fail-closed).
+// `allow+log` collapses to effective "allow" but rule.verdict retains
+// "allow+log": consumers MUST honor its ledger obligation (a JSONL line per
+// run — see semantics.verdicts in the JSON), not just the allow.
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const matrixPath = join(dirname(fileURLToPath(import.meta.url)), "egress-matrix.json");
+const m = JSON.parse(readFileSync(matrixPath, "utf8"));
+
+function evaluate(corpus, provider, purpose) {
+  for (const r of m.rules) {
+    const hit =
+      (r.corpus === "*" || r.corpus === corpus) &&
+      (r.provider === "*" || r.provider === provider) &&
+      (r.purpose === "*" || r.purpose === purpose);
+    if (!hit) continue;
+    const effective =
+      r.verdict === "allow" ? "allow" :
+      r.verdict === "allow+log" ? "allow" :
+      r.verdict === "conditional" ? "conditional" :
+      "deny"; // deny, pending-operator, and any UNKNOWN verdict all fail closed
+    return { effective, rule: r };
+  }
+  // m.default is asserted to be "deny" below; treated as already-effective.
+  return { effective: m.default, rule: null };
+}
+
+let failures = 0;
+function assert(cond, msg) {
+  if (!cond) { failures++; console.error(`FAIL: ${msg}`); }
+}
+
+const corpora = Object.keys(m.corpora);
+const providers = Object.keys(m.providers);
+const purposes = m.purposes;
+
+// 1. Structure
+assert(m.default === "deny", "default must be deny (fail-closed)");
+assert(Array.isArray(m.rules) && m.rules.length > 0, "rules present");
+
+// 2. Every rule references declared corpora/providers/purposes (or '*')
+for (const [i, r] of m.rules.entries()) {
+  assert(r.corpus === "*" || corpora.includes(r.corpus), `rule[${i}] unknown corpus ${r.corpus}`);
+  assert(r.provider === "*" || providers.includes(r.provider), `rule[${i}] unknown provider ${r.provider}`);
+  assert(r.purpose === "*" || purposes.includes(r.purpose), `rule[${i}] unknown purpose ${r.purpose}`);
+  assert(["allow", "allow+log", "conditional", "deny", "pending-operator"].includes(r.verdict),
+    `rule[${i}] unknown verdict ${r.verdict}`);
+  if (r.verdict === "conditional") assert(typeof r.condition === "string" && r.condition.length > 0,
+    `rule[${i}] conditional without condition`);
+  if (r.verdict === "pending-operator") assert(typeof r.decision_needed === "string",
+    `rule[${i}] pending-operator without decision_needed`);
+}
+
+// 3. salus: every CLOUD provider x every purpose = hard deny; local-ollama = conditional
+for (const p of providers) {
+  for (const u of purposes) {
+    const { effective, rule } = evaluate("salus", p, u);
+    if (p === "local-ollama") {
+      assert(effective === "conditional", `salus x ${p} x ${u} must be conditional (per-run opt-in), got ${effective}`);
+    } else {
+      assert(effective === "deny", `salus x ${p} x ${u} must be deny, got ${effective}`);
+      assert(rule && rule.hard === true, `salus x ${p} x ${u} deny must be hard`);
+    }
+  }
+}
+
+// 4. google-gemini denied everywhere, via the HARD rule (pins rule existence,
+//    not just the outcome — mirrors the salus pattern)
+for (const c of corpora) for (const u of purposes) {
+  const { effective, rule } = evaluate(c, "google-gemini", u);
+  assert(effective === "deny", `gemini must be denied for ${c} x ${u}`);
+  assert(rule && rule.hard === true, `gemini deny for ${c} x ${u} must come from the hard rule`);
+}
+
+// 5. EVERY pending-operator cell evaluates as deny — programmatic enumeration,
+//    so a future pending cell shadowed by an earlier allow rule fails loudly
+// NOTE: the count below is a deletion tripwire. Ratifying a 765 cell
+// (pending-operator -> allow+log) legitimately LOWERS it — update the
+// expected count consciously in the same PR that flips the cell.
+const pendingRules = m.rules.filter(r => r.verdict === "pending-operator");
+assert(pendingRules.length >= 5, "expected the five 765 gate cells to be pending-operator (update consciously when ratifying a cell)");
+for (const r of pendingRules) {
+  const { effective, rule } = evaluate(r.corpus, r.provider, r.purpose);
+  assert(effective === "deny" && rule?.verdict === "pending-operator",
+    `pending cell ${r.corpus} x ${r.provider} x ${r.purpose} must evaluate deny via its own pending-operator rule (shadowed by an earlier rule?), got ${effective}/${rule?.verdict}`);
+}
+
+// 5b. Fail-closed for UNDECLARED inputs — the exact shape a resolver bug
+//     produces (a path that fails to classify into a known corpus)
+assert(evaluate("mystery-corpus", "mystery-provider", "mystery-purpose").effective === "deny",
+  "fully unknown triple must fall through to default deny");
+assert(evaluate("luna-personal", "brand-new-provider", "inference").effective === "deny",
+  "unknown provider on a non-wildcard corpus must deny");
+assert(evaluate("luna-personal", "deepseek", "unknown-purpose").effective === "deny",
+  "unknown purpose must deny");
+assert(evaluate("mystery-corpus", "google-gemini", "inference").effective === "deny",
+  "unknown corpus x gemini must deny");
+
+// 5d. EVERY conditional rule's own triple evaluates as "conditional" —
+//     programmatic, so a typo'd conditional->allow on the CN brief-egress
+//     cells (or a shadowing earlier rule) fails loudly
+const conditionalRules = m.rules.filter(r => r.verdict === "conditional");
+assert(conditionalRules.length >= 5, "expected the salus opt-in + 3 handover brief-scoped + clippings-GLM cells");
+for (const r of conditionalRules) {
+  const probe = {
+    corpus: r.corpus === "*" ? corpora[0] : r.corpus,
+    provider: r.provider === "*" ? "local-ollama" : r.provider,
+    purpose: r.purpose === "*" ? purposes[0] : r.purpose,
+  };
+  const { effective, rule } = evaluate(probe.corpus, probe.provider, probe.purpose);
+  assert(effective === "conditional" && rule?.verdict === "conditional" && rule.condition === r.condition,
+    `conditional cell ${probe.corpus} x ${probe.provider} x ${probe.purpose} must evaluate conditional via its own rule, got ${effective}/${rule?.verdict}`);
+}
+
+// 5c. Pin the ONE deliberate wildcard widening surface so it stays a conscious,
+//     visible test change: himmel-code allows ANY declared-or-new provider
+//     (public-propagated code; gemini already excluded by the earlier hard rule)
+assert(evaluate("himmel-code", "brand-new-provider", "inference").effective === "allow",
+  "himmel-code x * x * is the deliberate allow-all (change this test consciously if narrowing)");
+
+// 6. Ratified allows stay allowed (regression guard both directions)
+assert(evaluate("luna-personal", "deepseek", "extraction").effective === "allow",
+  "luna-personal x deepseek x extraction is the ratified operator override (allow+log)");
+assert(evaluate("himmel-code", "openai-codex", "inference").effective === "allow",
+  "himmel-code x codex impl lane must stay allowed");
+assert(evaluate("luna-personal", "zai-glm", "inference").effective === "deny",
+  "luna-personal x zai-glm must fall through to default deny");
+assert(evaluate("luna-personal", "deepseek", "embedding").effective === "deny",
+  "DeepSeek override covers extraction ONLY — embedding must deny");
+assert(evaluate("handover-state", "openai-codex", "embedding").effective === "deny",
+  "no bulk pipelines over handover-state");
+
+if (failures > 0) {
+  console.error(`egress-matrix: ${failures} invariant failure(s)`);
+  process.exit(1);
+}
+console.log("egress-matrix: all invariants pass");


### PR DESCRIPTION
One owned egress policy (scripts/guardrails/egress-matrix.json) that egress-enforcing surfaces read instead of hard-coding per-tool rules. First-match-wins, wildcards, fail-closed default deny; sensitive-vault rows are hard denies; provider-widening cells ship as pending-operator (= deny) so widening is always an explicit one-line human flip. node scripts/guardrails/test-egress-matrix.mjs = invariant suite + reference evaluate() semantics.

Propagated from private #985.

🤖 Generated with [Claude Code](https://claude.com/claude-code)