### PR TITLE
feat(fleet-control): Phase 1 observability - unified fleet aggregator + read-only page

### DIFF
--- a/scripts/fleet-control/aggregator/armed.ts
+++ b/scripts/fleet-control/aggregator/armed.ts
@@ -1,0 +1,27 @@
+import type { Worker } from "./types";
+
+// arm-resume.sh exposes scheduler query logic only as internal shell functions;
+// Phase 1 therefore accepts a helper-produced JSONL stream via this env seam and
+// never hand-rolls raw schtasks/crontab parsing in fleet-control.
+export function readArmedSlots(jsonl = process.env.FLEET_CONTROL_ARMED_SLOTS_JSONL ?? ""): Worker[] {
+  return jsonl.split(/\r?\n/).filter((l) => l.trim() !== "").map((line): Worker => {
+    // A malformed slot line becomes a visible degraded row - never a throw
+    // (which would 500 the fleet) and never a silent drop.
+    let row: Record<string, unknown>;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (typeof parsed !== "object" || parsed === null) throw new Error("not an object");
+      row = parsed as Record<string, unknown>;
+    } catch {
+      return { lane: "armed", name: "unparseable armed slot", status: "failed", artifacts: [] };
+    }
+    const handover = String(row.handover ?? row.handoverPath ?? "");
+    return {
+      lane: "armed",
+      name: String(row.name ?? row.task ?? "armed-slot"),
+      status: "armed",
+      artifacts: handover ? [handover] : [],
+      title: row.time ? `armed for ${row.time}` : undefined,
+    };
+  });
+}

--- a/scripts/fleet-control/aggregator/codex.ts
+++ b/scripts/fleet-control/aggregator/codex.ts
@@ -1,0 +1,77 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { isPidAlive } from "./liveness";
+import type { Worker, WorkerStatus } from "./types";
+
+function readJson(path: string): Record<string, unknown> | undefined {
+  try {
+    const v: unknown = JSON.parse(readFileSync(path, "utf8"));
+    return typeof v === "object" && v !== null ? (v as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Fail-closed status mapping at the codex boundary: only known companion statuses
+// pass through to an honest WorkerStatus; anything unexpected renders "failed"
+// rather than leaking a raw string the UI can't reason about.
+const CODEX_STATUS: Record<string, WorkerStatus> = {
+  queued: "queued",
+  running: "running",
+  completed: "done",
+  failed: "failed",
+  cancelled: "failed",
+};
+
+export function readCodexJobs(pluginDataRoot: string): Worker[] {
+  // The serve entry may pass either a plugin-data root (companion writes state
+  // under <root>/state) or a bare state root (the tmpdir fallback IS the state
+  // root). Prefer <root>/state when it exists, else treat the arg as the root.
+  const withState = join(pluginDataRoot, "state");
+  const stateRoot = existsSync(withState) ? withState : pluginDataRoot;
+  if (!existsSync(stateRoot)) return [];
+  const workers: Worker[] = [];
+  for (const dir of readdirSync(stateRoot, { withFileTypes: true })) {
+    if (!dir.isDirectory()) continue;
+    const stateFile = join(stateRoot, dir.name, "state.json");
+    const stateExists = existsSync(stateFile);
+    const state = stateExists ? readJson(stateFile) : undefined;
+    if (!state) {
+      // Present-but-unparseable state.json = a job registry we can't read: show
+      // it degraded (visible) instead of dropping it. Missing file = no jobs.
+      if (stateExists) {
+        workers.push({ lane: "codex", name: "<corrupt state>", status: "failed", artifacts: [stateFile], error: "unreadable state.json" });
+      }
+      continue;
+    }
+    if (state.jobs !== undefined && !Array.isArray(state.jobs)) {
+      workers.push({ lane: "codex", name: "<corrupt state>", status: "failed", artifacts: [stateFile], error: "state.jobs is not an array" });
+      continue;
+    }
+    const jobs: unknown[] = Array.isArray(state.jobs) ? state.jobs : [];
+    for (const raw of jobs) {
+      if (typeof raw !== "object" || raw === null) continue;
+      const job = raw as Record<string, unknown>;
+      const rawStatus = typeof job.status === "string" ? job.status : "";
+      const mapped: WorkerStatus = CODEX_STATUS[rawStatus] ?? "failed";
+      const active = rawStatus === "queued" || rawStatus === "running";
+      const pid = typeof job.pid === "number" ? job.pid : null;
+      // Liveness only DOWNGRADES an active job whose RECORDED pid is gone.
+      // pid=null is a legitimate shape (foreground jobs run inside the parent;
+      // queued jobs have not spawned) per companion-liveness.sh — those keep
+      // their mapped status rather than being mislabeled "dead".
+      const status: WorkerStatus = active && pid !== null && !isPidAlive(pid) ? "dead" : mapped;
+      const logFile = typeof job.logFile === "string" ? job.logFile : undefined;
+      workers.push({
+        lane: "codex",
+        name: String(job.id ?? job.title ?? "codex-job"),
+        title: typeof job.title === "string" ? job.title : undefined,
+        status,
+        pid,
+        sessionDir: typeof job.workspaceRoot === "string" ? job.workspaceRoot : undefined,
+        artifacts: [stateFile, ...(logFile ? [logFile] : [])],
+      });
+    }
+  }
+  return workers;
+}

--- a/scripts/fleet-control/aggregator/escalations.ts
+++ b/scripts/fleet-control/aggregator/escalations.ts
@@ -1,0 +1,56 @@
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type Escalation = { escalation_id: string; sessionDir: string; capability: string; step: string | number; ts: string; shape: "read" | "write"; raw: Record<string, unknown> };
+
+export function escalationId(e: { sessionDir: string; step: string | number; capability: string; ts: string }): string {
+  return createHash("sha256").update([e.sessionDir, String(e.step), e.capability, e.ts].join("\0")).digest("hex").slice(0, 12);
+}
+
+export function capabilityShape(capability: string): "read" | "write" {
+  const parts = capability.split(".");
+  const verb = parts[parts.length - 1]?.toLowerCase() ?? "";
+  if (capability === "net.fetch" || verb === "read" || verb === "get" || verb === "list" || verb === "fetch") return "read";
+  if (verb === "write" || verb === "delete" || verb === "exec" || verb === "mutate" || verb === "push" || verb === "post") return "write";
+  return "write";
+}
+
+export type EscalationsResult = { escalations: Escalation[]; parseErrors: number };
+
+// A dropped (malformed) escalation line = an invisible blocked worker. Skip the
+// bad line but COUNT it, so the incompleteness is surfaced rather than hidden.
+function jsonl(path: string, onParseError: () => void): Record<string, unknown>[] {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8").split(/\r?\n/).filter((l) => l.trim() !== "").flatMap((l) => {
+    try {
+      const parsed: unknown = JSON.parse(l);
+      return typeof parsed === "object" && parsed !== null ? [parsed as Record<string, unknown>] : [];
+    } catch {
+      onParseError();
+      return [];
+    }
+  });
+}
+
+export function readEscalations(bridgeRoot: string): EscalationsResult {
+  const root = join(bridgeRoot, "glm-sessions");
+  if (!existsSync(root)) return { escalations: [], parseErrors: 0 };
+  const out: Escalation[] = [];
+  let parseErrors = 0;
+  const bump = () => { parseErrors++; };
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const sessionDir = join(root, entry.name);
+    const closed = new Set(jsonl(join(sessionDir, "grants.jsonl"), bump).map((r) => r.escalation_id).filter(Boolean));
+    for (const row of jsonl(join(sessionDir, "outbox.jsonl"), bump)) {
+      if (row.type !== "escalation" || typeof row.capability !== "string") continue;
+      const step = (typeof row.step === "string" || typeof row.step === "number") ? row.step : "";
+      const ts = String(row.ts ?? "");
+      const escalation_id = escalationId({ sessionDir, step, capability: row.capability, ts });
+      if (closed.has(escalation_id)) continue;
+      out.push({ escalation_id, sessionDir, capability: row.capability, step, ts, shape: capabilityShape(row.capability), raw: row });
+    }
+  }
+  return { escalations: out, parseErrors };
+}

--- a/scripts/fleet-control/aggregator/fleet.ts
+++ b/scripts/fleet-control/aggregator/fleet.ts
@@ -1,0 +1,66 @@
+import { join } from "node:path";
+import { readGlmWorkers } from "./glm";
+import { readCodexJobs } from "./codex";
+import { readHermes, type HermesCoverage } from "./hermes";
+import { readArmedSlots } from "./armed";
+import { readFeeds, type Feeds } from "./ledger";
+import type { Worker } from "./types";
+
+// HIMMEL-760 seam: the deterministic zero-token scheduler will be the first
+// non-human consumer of this API as a fleet-control CLIENT/principal - never a
+// second dispatch authority. Phase-1 read surfaces (GET /fleet) are designed
+// with a programmatic consumer in mind (stable JSON contract, no HTML-only state).
+export type FleetRoots = { bridgeRoot: string; stateRoot: string; pluginDataRoot: string };
+type Lane = "glm" | "codex" | "hermes" | "armed";
+export type FleetDoc = { lanes: Record<Lane, Worker[]>; feeds: Feeds; coverage: HermesCoverage; generatedAt: string };
+
+function errMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+// Per-lane error isolation: a throwing reader must NOT 500 the whole document.
+// It degrades to a single synthetic "failed" worker carrying the error while the
+// other lanes render normally (truthful state: degrade visibly, never drop silently).
+function safeLane(lane: Lane, read: () => Worker[]): Worker[] {
+  try {
+    return read();
+  } catch (e) {
+    return [{ lane, name: "<reader error>", status: "failed", artifacts: [], error: errMessage(e) }];
+  }
+}
+
+export function buildFleet(roots: FleetRoots): FleetDoc {
+  let hermesWorkers: Worker[];
+  let coverage: HermesCoverage;
+  try {
+    const hermes = readHermes(roots.stateRoot);
+    hermesWorkers = hermes.workers;
+    coverage = hermes.coverage;
+  } catch (e) {
+    hermesWorkers = [{ lane: "hermes", name: "<reader error>", status: "failed", artifacts: [], error: errMessage(e) }];
+    coverage = { hermesNativeChildren: "blind", note: `coverage unavailable: ${errMessage(e)}` };
+  }
+
+  let feeds: Feeds;
+  try {
+    feeds = readFeeds({
+      ledgerPath: join(roots.stateRoot, "where-are-we.jsonl"),
+      quotaPath: join(roots.stateRoot, "quota-gauge.jsonl"),
+      posturePath: join(roots.stateRoot, "posture-734.jsonl"),
+    });
+  } catch (e) {
+    feeds = { ledger: [], quota: [], posture: null, parseErrors: 0, error: errMessage(e) };
+  }
+
+  return {
+    lanes: {
+      glm: safeLane("glm", () => readGlmWorkers(roots.bridgeRoot)),
+      codex: safeLane("codex", () => readCodexJobs(roots.pluginDataRoot)),
+      hermes: hermesWorkers,
+      armed: safeLane("armed", () => readArmedSlots()),
+    },
+    feeds,
+    coverage,
+    generatedAt: new Date().toISOString(),
+  };
+}

--- a/scripts/fleet-control/aggregator/glm.ts
+++ b/scripts/fleet-control/aggregator/glm.ts
@@ -1,0 +1,75 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Worker, WorkerStatus } from "./types";
+
+function readJson(path: string): Record<string, unknown> | undefined {
+  try {
+    const v: unknown = JSON.parse(readFileSync(path, "utf8"));
+    return typeof v === "object" && v !== null ? (v as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Fail-closed status mapping at the glm boundary (mirrors CODEX_STATUS in
+// codex.ts): only known spawn-glm meta statuses pass through; anything
+// unexpected renders "failed" instead of leaking a raw string.
+const GLM_STATUS: Record<string, WorkerStatus> = {
+  running: "running",
+  done: "done",
+  failed: "failed",
+  capped: "capped",
+  blocked: "blocked",
+  timeout: "timeout",
+};
+
+function glmStatus(raw: unknown): WorkerStatus {
+  if (typeof raw !== "string") return "running"; // running meta may predate the status write
+  return GLM_STATUS[raw] ?? "failed";
+}
+
+function lastJsonLine(path: string): unknown | undefined {
+  if (!existsSync(path)) return undefined;
+  const lines = readFileSync(path, "utf8").split(/\r?\n/).filter((l) => l.trim() !== "");
+  if (lines.length === 0) return undefined;
+  try { return JSON.parse(lines[lines.length - 1]); } catch { return { parseError: true, raw: lines[lines.length - 1] }; }
+}
+
+export function readGlmWorkers(bridgeRoot: string): Worker[] {
+  const root = join(bridgeRoot, "glm-sessions");
+  if (!existsSync(root)) return [];
+  const workers: Worker[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const sessionDir = join(root, entry.name);
+    const metaPath = join(sessionDir, "meta.json");
+    const metaExists = existsSync(metaPath);
+    const meta = metaExists ? readJson(metaPath) : undefined;
+    if (!meta) {
+      // meta.json present but unparseable/unreadable -> a worker existed here,
+      // so render it degraded rather than dropping it. Missing meta entirely =
+      // no worker was ever recorded, so skip silently.
+      if (metaExists) {
+        workers.push({ lane: "glm", name: entry.name, status: "failed", artifacts: [metaPath], error: "unreadable meta.json" });
+      }
+      continue;
+    }
+    const outboxPath = join(sessionDir, "outbox.jsonl");
+    const grantsPath = join(sessionDir, "grants.jsonl");
+    const artifacts = [metaPath];
+    if (existsSync(outboxPath)) artifacts.push(outboxPath);
+    if (existsSync(grantsPath)) artifacts.push(grantsPath);
+    workers.push({
+      lane: "glm",
+      name: String(meta.name ?? meta.task_name ?? entry.name),
+      status: glmStatus(meta.status),
+      branch: typeof meta.branch === "string" ? meta.branch : undefined,
+      sessionDir,
+      artifacts,
+      lastOutboxLine: lastJsonLine(outboxPath),
+      hasGrants: existsSync(grantsPath),
+      pid: typeof meta.pid === "number" ? meta.pid : undefined,
+    });
+  }
+  return workers;
+}

--- a/scripts/fleet-control/aggregator/hermes.ts
+++ b/scripts/fleet-control/aggregator/hermes.ts
@@ -1,0 +1,28 @@
+import { existsSync, readdirSync } from "node:fs";
+import { join, basename } from "node:path";
+import type { Worker } from "./types";
+
+export type HermesCoverage = { hermesNativeChildren: "blind"; note: string };
+
+export function readHermes(stateRoot: string): { workers: Worker[]; coverage: HermesCoverage } {
+  // stateRoot is already the fleet-control root (serve passes <bridge>/fleet-control),
+  // so logs live at <stateRoot>/logs - joining "fleet-control" again would double-nest.
+  const logs = join(stateRoot, "logs");
+  const workers: Worker[] = [];
+  if (existsSync(logs)) {
+    for (const entry of readdirSync(logs, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.startsWith("hermes-") || !entry.name.endsWith(".log")) continue;
+      const name = basename(entry.name, ".log").replace(/^hermes-/, "");
+      // A log's mere existence does not prove completion; status is "unknown"
+      // because we cannot derive it from the file alone.
+      workers.push({ lane: "hermes", name, status: "unknown", artifacts: [join(logs, entry.name)] });
+    }
+  }
+  return {
+    workers,
+    coverage: {
+      hermesNativeChildren: "blind",
+      note: "Hermes-native delegate_task children do not create durable fleet-control artifacts; only pane-dispatched one-shot logs are visible here.",
+    },
+  };
+}

--- a/scripts/fleet-control/aggregator/ledger.ts
+++ b/scripts/fleet-control/aggregator/ledger.ts
@@ -1,0 +1,42 @@
+import { existsSync, readFileSync } from "node:fs";
+
+export type FeedPaths = { ledgerPath?: string; quotaPath?: string; posturePath?: string };
+export type Feeds = { ledger: unknown[]; quota: unknown[]; posture: unknown | null; parseErrors: number; error: string | null };
+
+// Append-only feeds legitimately have a partial final line mid-write, so a bad
+// line is SKIPPED (good lines kept) and counted - never a throw that drops the
+// whole feed. The skipped count surfaces the incompleteness instead of hiding it.
+function readJsonl(path: string | undefined, onError: (msg: string) => void): { rows: unknown[]; parseErrors: number } {
+  if (!path || !existsSync(path)) return { rows: [], parseErrors: 0 };
+  let parseErrors = 0;
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch (e) {
+    onError(e instanceof Error ? e.message : String(e));
+    return { rows: [], parseErrors: 0 };
+  }
+  const rows = text.split(/\r?\n/).filter((l) => l.trim() !== "").flatMap((l) => {
+    try { return [JSON.parse(l)]; } catch { parseErrors++; return []; }
+  });
+  return { rows, parseErrors };
+}
+
+export function readFeeds(paths: FeedPaths = {}): Feeds {
+  let parseErrors = 0;
+  const errors: string[] = [];
+  const onError = (msg: string) => errors.push(msg);
+
+  const ledger = readJsonl(paths.ledgerPath, onError);
+  const quota = readJsonl(paths.quotaPath, onError);
+  const posture = readJsonl(paths.posturePath, onError);
+  parseErrors += ledger.parseErrors + quota.parseErrors + posture.parseErrors;
+
+  return {
+    ledger: ledger.rows,
+    quota: quota.rows,
+    posture: posture.rows[posture.rows.length - 1] ?? null,
+    parseErrors,
+    error: errors.length ? errors.join("; ") : null,
+  };
+}

--- a/scripts/fleet-control/aggregator/liveness.ts
+++ b/scripts/fleet-control/aggregator/liveness.ts
@@ -1,0 +1,21 @@
+// LIMITATION - PID recycling: this probe only ever DOWNGRADES an active job from
+// running -> dead. The OS can reassign a dead job's pid to an unrelated process,
+// in which case that recycled pid answers "alive" and masks the dead job as
+// running until the next state write corrects the record. We accept this: the
+// alternative (treating recycled pids as dead) would false-kill live jobs.
+export function isPidAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  if (process.platform === "win32") {
+    try {
+      const r = Bun.spawnSync(["tasklist", "/FI", `PID eq ${pid}`], { stdout: "pipe", stderr: "pipe", env: { ...process.env, MSYS_NO_PATHCONV: "1" } });
+      const out = r.stdout.toString();
+      return r.exitCode === 0 && out.includes(String(pid)) && !out.includes("No tasks");
+    } catch (e) {
+      // A persistent tasklist spawn failure would silently mark EVERY job dead;
+      // surface it so the operator can see liveness is degraded, not truthful.
+      console.error(`fleet-control: tasklist liveness probe failed for pid ${pid}: ${e instanceof Error ? e.message : String(e)}`);
+      return false;
+    }
+  }
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}

--- a/scripts/fleet-control/aggregator/types.ts
+++ b/scripts/fleet-control/aggregator/types.ts
@@ -1,0 +1,15 @@
+export type WorkerStatus = "running" | "done" | "failed" | "dead" | "capped" | "blocked" | "timeout" | "armed" | "queued" | "unknown";
+
+export type Worker = {
+  lane: "glm" | "codex" | "hermes" | "armed";
+  name: string;
+  status: WorkerStatus;
+  branch?: string;
+  sessionDir?: string;
+  artifacts: string[];
+  lastOutboxLine?: unknown;
+  hasGrants?: boolean;
+  pid?: number | null;
+  title?: string;
+  error?: string;
+};

--- a/scripts/fleet-control/public/app.js
+++ b/scripts/fleet-control/public/app.js
@@ -1,0 +1,64 @@
+async function json(path) {
+  const res = await fetch(path);
+  if (!res.ok) throw new Error(`${path} returned ${res.status}`);
+  return res.json();
+}
+
+function cell(text) {
+  const td = document.createElement("td");
+  td.textContent = text == null ? "" : String(text);
+  return td;
+}
+
+function renderFleet(doc) {
+  const body = document.querySelector("#fleet-table tbody");
+  body.replaceChildren();
+  const head = document.createElement("tr");
+  for (const h of ["lane", "worker", "status", "branch", "last line", "artifacts"]) head.appendChild(cell(h));
+  body.appendChild(head);
+  for (const [lane, workers] of Object.entries(doc.lanes || {})) {
+    for (const w of workers) {
+      const tr = document.createElement("tr");
+      tr.append(cell(lane), cell(w.name), cell(w.status), cell(w.branch), cell(w.lastOutboxLine ? JSON.stringify(w.lastOutboxLine) : ""), cell((w.artifacts || []).join("\n")));
+      body.appendChild(tr);
+    }
+  }
+  document.querySelector("#gauges").textContent = JSON.stringify(doc.feeds || {}, null, 2);
+}
+
+function renderEscalations(rows, parseErrors) {
+  const body = document.querySelector("#escalations-table tbody");
+  body.replaceChildren();
+  const note = document.querySelector("#escalation-parse-errors");
+  if (note) note.textContent = parseErrors > 0 ? `${parseErrors} unparsed escalation record(s) — grant view may be incomplete` : "";
+  const head = document.createElement("tr");
+  for (const h of ["id", "shape", "capability", "step", "actions"]) head.appendChild(cell(h));
+  body.appendChild(head);
+  for (const e of rows) {
+    const tr = document.createElement("tr");
+    tr.append(cell(e.escalation_id), cell(e.shape), cell(e.capability), cell(e.step));
+    const td = document.createElement("td");
+    const grant = document.createElement("button"); grant.textContent = "grant"; grant.disabled = true;
+    const refuse = document.createElement("button"); refuse.textContent = "refuse"; refuse.disabled = true;
+    td.append(grant, " ", refuse); tr.appendChild(td); body.appendChild(tr);
+  }
+}
+
+async function refetch() {
+  const [fleet, escalations] = await Promise.all([json("/fleet"), json("/escalations")]);
+  renderFleet(fleet);
+  renderEscalations((escalations && escalations.escalations) || [], (escalations && escalations.parseErrors) || 0);
+}
+
+refetch().catch((e) => { document.querySelector("#gauges").textContent = String(e); });
+if (typeof EventSource !== "undefined") {
+  const events = new EventSource("/events");
+  events.addEventListener("refetch", () => refetch().catch(console.error));
+  events.addEventListener("degraded", (ev) => {
+    let reason = "live updates unavailable";
+    try { reason = (JSON.parse(ev.data) || {}).reason || reason; } catch (_) { /* keep default */ }
+    const banner = document.querySelector("#stale-banner");
+    banner.textContent = "Live updates unavailable - view may be stale: " + reason;
+    banner.style.display = "block";
+  });
+}

--- a/scripts/fleet-control/public/index.html
+++ b/scripts/fleet-control/public/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>himmel fleet-control</title>
+  <style>
+    body { font-family: ui-sans-serif, system-ui, sans-serif; margin: 2rem; background: #0f1115; color: #e6edf3; }
+    table { border-collapse: collapse; width: 100%; margin: 1rem 0 2rem; }
+    th, td { border-bottom: 1px solid #30363d; padding: .5rem; text-align: left; vertical-align: top; }
+    code { color: #9cdcfe; }
+    .muted { color: #8b949e; }
+    button[disabled] { opacity: .45; }
+    #stale-banner { display: none; margin: 1rem 0; padding: .5rem .75rem; border-radius: 4px; background: #4d1f00; color: #ffd7a8; }
+  </style>
+</head>
+<body>
+  <h1>Fleet Control</h1>
+  <div id="stale-banner"></div>
+  <p class="muted">Read-only Phase 1 pane. Dispatch and adjudication controls remain disabled until Phase 2.</p>
+  <section><h2>Fleet</h2><table id="fleet-table"><tbody></tbody></table></section>
+  <section><h2>Escalations</h2><div id="escalation-parse-errors"></div><table id="escalations-table"><tbody></tbody></table></section>
+  <section><h2>Gauges</h2><pre id="gauges">loading...</pre></section>
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/scripts/fleet-control/server.ts
+++ b/scripts/fleet-control/server.ts
@@ -1,0 +1,147 @@
+import { existsSync, readFileSync, watch } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildFleet, type FleetRoots } from "./aggregator/fleet";
+import { readEscalations } from "./aggregator/escalations";
+
+// Complete against the process-env provider keys documented in .env.example
+// (plus the Claude/OpenAI/z.ai keys the fleet itself may run under). The page is
+// read-only localhost, but the served process must never expose a live key.
+export const PROVIDER_KEY_NAMES = [
+  "ZAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "XAI_API_KEY",
+  "PERPLEXITY_API_KEY",
+  "DASHSCOPE_API_KEY",
+  "NVIDIA_API_KEY",
+  "OPENROUTER_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "OLLAMA_API_KEY",
+  "TELEGRAM_BOT_TOKEN",
+  "JIRA_API_TOKEN",
+  "BITBUCKET_API_TOKEN",
+  "CONFLUENCE_API_TOKEN",
+] as const;
+
+export function scrubProviderKeys(env: Record<string, string | undefined>): void {
+  for (const k of PROVIDER_KEY_NAMES) delete env[k];
+}
+
+// Resolve where codex-companion writes its job state, mirroring the fallback
+// chain in scripts/codex/companion-liveness.sh (first hit wins):
+//   $CLAUDE_PLUGIN_DATA -> ~/.claude/plugins/data/codex-openai-codex -> <tmpdir>/codex-companion
+// readCodexJobs treats the arg as a plugin-data root (<root>/state) or, when no
+// /state subdir exists (the tmpdir case), as the bare state root.
+export function resolveCodexStateRoot(env: Record<string, string | undefined> = process.env): string {
+  if (env.CLAUDE_PLUGIN_DATA) return env.CLAUDE_PLUGIN_DATA;
+  const home = env.HOME ?? env.USERPROFILE;
+  if (home) {
+    const p = join(home, ".claude", "plugins", "data", "codex-openai-codex");
+    if (existsSync(p)) return p;
+  }
+  return join(tmpdir(), "codex-companion");
+}
+
+export type ServerOpts = { port?: number; stateRoot: string; bridgeRoot?: string; pluginDataRoot?: string; env?: Record<string, string | undefined> };
+
+function rootsFor(opts: ServerOpts): FleetRoots {
+  return { bridgeRoot: opts.bridgeRoot ?? opts.stateRoot, stateRoot: opts.stateRoot, pluginDataRoot: opts.pluginDataRoot ?? join(opts.stateRoot, "codex-plugin-data") };
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), { headers: { "content-type": "application/json" } });
+}
+
+function staticResponse(path: string, contentType: string): Response {
+  return new Response(readFileSync(path), { headers: { "content-type": contentType } });
+}
+
+export function eventsResponse(watchRoots: string | string[], watchFactory: typeof watch = watch): Response {
+  // Watch every distinct root (fleet-control state dir AND the bridge root,
+  // where glm-sessions/ lives) so all lane changes ping a refetch. A root
+  // nested inside an already-watched recursive root is skipped as redundant.
+  const requested = (Array.isArray(watchRoots) ? watchRoots : [watchRoots]).filter(Boolean);
+  const isUnder = (child: string, parent: string) => child.startsWith(parent + "/") || child.startsWith(parent + "\\");
+  const roots = requested.filter((r, i) =>
+    requested.indexOf(r) === i && !requested.some((other) => other !== r && isUnder(r, other)));
+  const watchers: ReturnType<typeof watch>[] = [];
+  let closed = false;
+  const closeAll = () => { closed = true; for (const w of watchers) w.close(); };
+  const enc = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      const emit = () => {
+        if (closed) return;
+        try {
+          controller.enqueue(enc.encode("event: refetch\ndata: {}\n\n"));
+        } catch {
+          // The consumer went away between the fs event and the enqueue: stop
+          // emitting and release the watchers instead of throwing on a dead stream.
+          closeAll();
+        }
+      };
+      const degrade = (reason: string) => {
+        if (closed) return;
+        try { controller.enqueue(enc.encode(`event: degraded\ndata: ${JSON.stringify({ reason })}\n\n`)); } catch { /* stream already gone */ }
+      };
+      emit();
+      let watching = 0;
+      for (const root of roots) {
+        try {
+          if (existsSync(root)) {
+            watchers.push(watchFactory(root, { recursive: true }, emit));
+            watching++;
+          }
+        } catch (e) {
+          degrade(`fs.watch unavailable for ${root}: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
+      if (watching === 0) degrade("no watchable roots; live updates unavailable");
+    },
+    // WHATWG Streams: start()'s return value is NOT a teardown hook - teardown on
+    // consumer cancel belongs here, so the watchers are always released.
+    cancel() {
+      closeAll();
+    },
+  });
+  return new Response(stream, { headers: { "content-type": "text/event-stream", "cache-control": "no-cache" } });
+}
+
+export function startServer(opts: ServerOpts): { server: import("bun").Server; port: number } {
+  scrubProviderKeys(opts.env ?? process.env);
+  const publicRoot = join(import.meta.dir, "public");
+  const roots = rootsFor(opts);
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: opts.port ?? 7350,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/fleet") return jsonResponse(buildFleet(roots));
+      if (url.pathname === "/escalations") return jsonResponse(readEscalations(roots.bridgeRoot));
+      if (url.pathname === "/events") return eventsResponse([opts.stateRoot, roots.bridgeRoot]);
+      if (url.pathname === "/") return staticResponse(join(publicRoot, "index.html"), "text/html; charset=utf-8");
+      if (url.pathname === "/app.js") return staticResponse(join(publicRoot, "app.js"), "application/javascript; charset=utf-8");
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return { server, port: server.port };
+}
+
+export function resolveServeRoots(env: Record<string, string | undefined> = process.env): { stateRoot: string; bridgeRoot: string } {
+  // glm-sessions/ lives under the BRIDGE root; fleet-control state is its
+  // child dir. Deriving bridgeRoot from stateRoot's default parent (or the
+  // explicit envs) keeps the GLM/escalation readers pointed at the right tree.
+  const bridgeRoot = env.FLEET_CONTROL_BRIDGE_ROOT ?? env.BRIDGE_ROOT ?? join(env.HOME ?? process.cwd(), ".claude", "handover", "bridge");
+  const stateRoot = env.FLEET_CONTROL_STATE_ROOT ?? join(bridgeRoot, "fleet-control");
+  return { stateRoot, bridgeRoot };
+}
+
+if (import.meta.main && process.argv[2] === "serve") {
+  const { stateRoot, bridgeRoot } = resolveServeRoots();
+  const { port } = startServer({ port: Number(process.env.FLEET_CONTROL_PORT ?? 7350), stateRoot, bridgeRoot, pluginDataRoot: resolveCodexStateRoot() });
+  console.log(`fleet-control listening on http://127.0.0.1:${port}`);
+}

--- a/scripts/fleet-control/tests/armed.test.ts
+++ b/scripts/fleet-control/tests/armed.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test";
+import { readArmedSlots } from "../aggregator/armed";
+
+test("malformed armed-slot lines render a degraded row, never throw or drop (finding 2)", () => {
+  const good = JSON.stringify({ name: "good-slot", handover: "/tmp/h.md", time: "01:00" });
+  const slots = readArmedSlots(`${good}\n{not json\n`);
+  expect(slots).toHaveLength(2);
+  expect(slots[0]).toMatchObject({ lane: "armed", name: "good-slot", status: "armed" });
+  expect(slots[1]).toMatchObject({ lane: "armed", name: "unparseable armed slot", status: "failed" });
+});
+
+test("readArmedSlots parses injected arm-resume helper JSONL without touching scheduler", () => {
+  const old = process.env.FLEET_CONTROL_ARMED_SLOTS_JSONL;
+  process.env.FLEET_CONTROL_ARMED_SLOTS_JSONL = JSON.stringify({ name: "HIMMEL-Resume-demo", handover: "/tmp/next.md", time: "12:34" });
+  try {
+    const slots = readArmedSlots();
+    expect(slots).toHaveLength(1);
+    expect(slots[0]).toMatchObject({ lane: "armed", name: "HIMMEL-Resume-demo", status: "armed" });
+    expect(slots[0].artifacts).toContain("/tmp/next.md");
+  } finally {
+    if (old === undefined) delete process.env.FLEET_CONTROL_ARMED_SLOTS_JSONL;
+    else process.env.FLEET_CONTROL_ARMED_SLOTS_JSONL = old;
+  }
+});

--- a/scripts/fleet-control/tests/codex.test.ts
+++ b/scripts/fleet-control/tests/codex.test.ts
@@ -1,0 +1,75 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readCodexJobs } from "../aggregator/codex";
+
+function root() { return mkdtempSync(join(tmpdir(), "fleet-codex-")); }
+
+test("readCodexJobs reads companion state and marks dead recorded pids", () => {
+  const pluginData = root();
+  const stateDir = join(pluginData, "state", "himmel-abc123");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(join(stateDir, "state.json"), JSON.stringify({ jobs: [
+    { id: "live", title: "Live job", status: "running", pid: process.pid, workspaceRoot: "/repo", updatedAt: new Date().toISOString() },
+    { id: "dead", title: "Dead job", status: "running", pid: 999999, workspaceRoot: "/repo", updatedAt: new Date().toISOString() },
+  ] }));
+
+  const jobs = readCodexJobs(pluginData);
+  expect(jobs.find((j) => j.name === "live")?.status).toBe("running");
+  expect(jobs.find((j) => j.name === "dead")?.status).toBe("dead");
+  expect(jobs.find((j) => j.name === "dead")?.artifacts).toContain(join(stateDir, "state.json"));
+});
+
+test("queued job with a live pid renders 'queued'; unknown status fails closed (finding 10)", () => {
+  const pluginData = root();
+  const stateDir = join(pluginData, "state", "himmel-status");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(join(stateDir, "state.json"), JSON.stringify({ jobs: [
+    { id: "q", status: "queued", pid: process.pid, workspaceRoot: "/repo" },
+    { id: "weird", status: "banana", pid: process.pid, workspaceRoot: "/repo" },
+  ] }));
+
+  const jobs = readCodexJobs(pluginData);
+  expect(jobs.find((j) => j.name === "q")?.status).toBe("queued");
+  expect(jobs.find((j) => j.name === "weird")?.status).toBe("failed");
+});
+
+test("active jobs with pid=null keep their mapped status (foreground/queued shape, not dead)", () => {
+  const pluginData = root();
+  const stateDir = join(pluginData, "state", "himmel-nullpid");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(join(stateDir, "state.json"), JSON.stringify({ jobs: [
+    { id: "fg", title: "Foreground job", status: "running", pid: null, workspaceRoot: "/repo" },
+    { id: "q0", title: "Not yet spawned", status: "queued", workspaceRoot: "/repo" },
+  ] }));
+
+  const jobs = readCodexJobs(pluginData);
+  expect(jobs.find((j) => j.name === "fg")?.status).toBe("running");
+  expect(jobs.find((j) => j.name === "q0")?.status).toBe("queued");
+});
+
+test("unparseable state.json renders one degraded row; missing file yields nothing (finding 5)", () => {
+  const pluginData = root();
+  const corrupt = join(pluginData, "state", "himmel-corrupt");
+  mkdirSync(corrupt, { recursive: true });
+  writeFileSync(join(corrupt, "state.json"), "{not json");
+  const empty = join(pluginData, "state", "himmel-empty");
+  mkdirSync(empty, { recursive: true }); // no state.json at all
+
+  const jobs = readCodexJobs(pluginData);
+  expect(jobs).toHaveLength(1);
+  expect(jobs[0]).toMatchObject({ lane: "codex", name: "<corrupt state>", status: "failed" });
+  expect(jobs[0].artifacts).toContain(join(corrupt, "state.json"));
+});
+
+test("state.jobs present but not an array renders a degraded row (finding 5)", () => {
+  const pluginData = root();
+  const stateDir = join(pluginData, "state", "himmel-badjobs");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(join(stateDir, "state.json"), JSON.stringify({ jobs: { not: "an array" } }));
+
+  const jobs = readCodexJobs(pluginData);
+  expect(jobs).toHaveLength(1);
+  expect(jobs[0]).toMatchObject({ lane: "codex", name: "<corrupt state>", status: "failed" });
+});

--- a/scripts/fleet-control/tests/escalations.test.ts
+++ b/scripts/fleet-control/tests/escalations.test.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { capabilityShape, escalationId, readEscalations } from "../aggregator/escalations";
+import { startServer } from "../server";
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "fleet-esc-"));
+  const s = join(root, "glm-sessions", "demo");
+  mkdirSync(s, { recursive: true });
+  const granted = { type: "escalation", capability: "net.fetch", step: 3, ts: "2026-07-07T00:00:00Z" };
+  const open = { type: "escalation", capability: "fs.write", step: "ship", ts: "2026-07-07T00:01:00Z" };
+  const id = escalationId({ sessionDir: s, step: granted.step, capability: granted.capability, ts: granted.ts });
+  writeFileSync(join(s, "outbox.jsonl"), `${JSON.stringify(granted)}\n${JSON.stringify(open)}\n`);
+  writeFileSync(join(s, "grants.jsonl"), `${JSON.stringify({ escalation_id: id, capability: "net.fetch" })}\n`);
+  return { root, id };
+}
+
+test("escalationId is deterministic first-12-hex of sha256 over the tuple", () => {
+  const a = escalationId({ sessionDir: "/s", step: 3, capability: "net.fetch", ts: "2026-07-07T00:00:00Z" });
+  const b = escalationId({ sessionDir: "/s", step: 3, capability: "net.fetch", ts: "2026-07-07T00:00:00Z" });
+  expect(a).toBe(b);
+  expect(a).toMatch(/^[0-9a-f]{12}$/);
+});
+
+test("adjudicated escalations drop out and open escalations remain", () => {
+  const { root, id } = fixture();
+  const { escalations: open } = readEscalations(root);
+  expect(open.find((e) => e.escalation_id === id)).toBeUndefined();
+  expect(open.some((e) => e.capability === "fs.write" && e.shape === "write")).toBe(true);
+});
+
+test("malformed escalation lines are skipped but counted as parseErrors (finding 13)", () => {
+  const root = mkdtempSync(join(tmpdir(), "fleet-esc-bad-"));
+  const s = join(root, "glm-sessions", "demo");
+  mkdirSync(s, { recursive: true });
+  const good = { type: "escalation", capability: "fs.write", step: 1, ts: "2026-07-07T00:00:00Z" };
+  writeFileSync(join(s, "outbox.jsonl"), `${JSON.stringify(good)}\n{not json\n`);
+
+  const { escalations, parseErrors } = readEscalations(root);
+  expect(escalations.some((e) => e.capability === "fs.write")).toBe(true);
+  expect(parseErrors).toBe(1);
+});
+
+test("capabilityShape maps per the charter taxonomy", () => {
+  expect(capabilityShape("net.fetch")).toBe("read");
+  expect(capabilityShape("fs.read")).toBe("read");
+  expect(capabilityShape("gh.list")).toBe("read");
+  expect(capabilityShape("fs.write")).toBe("write");
+  expect(capabilityShape("tool.delete")).toBe("write");
+  expect(capabilityShape("mystery.cap")).toBe("write");
+});
+
+test("GET /escalations returns open escalations", async () => {
+  const { root } = fixture();
+  const { server, port } = startServer({ port: 0, stateRoot: root, bridgeRoot: root });
+  try {
+    const body = await (await fetch(`http://127.0.0.1:${port}/escalations`)).json();
+    expect(body.escalations.some((e: any) => e.capability === "fs.write")).toBe(true);
+    expect(typeof body.parseErrors).toBe("number");
+  } finally { server.stop(); }
+});

--- a/scripts/fleet-control/tests/fleet.test.ts
+++ b/scripts/fleet-control/tests/fleet.test.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startServer } from "../server";
+import { buildFleet } from "../aggregator/fleet";
+
+function makeRoot() {
+  const root = mkdtempSync(join(tmpdir(), "fleet-doc-"));
+  const glm = join(root, "glm-sessions", "demo");
+  mkdirSync(glm, { recursive: true });
+  writeFileSync(join(glm, "meta.json"), JSON.stringify({ task_name: "demo", branch: "glm/demo", status: "running" }));
+  const codex = join(root, "codex-plugin-data", "state", "himmel-abc");
+  mkdirSync(codex, { recursive: true });
+  writeFileSync(join(codex, "state.json"), JSON.stringify({ jobs: [{ id: "dead", status: "running", pid: 999999 }] }));
+  const logs = join(root, "logs");
+  mkdirSync(logs, { recursive: true });
+  writeFileSync(join(logs, "hermes-foo.log"), "ok\n");
+  writeFileSync(join(root, "quota-gauge.jsonl"), '{"lane":"glm"}\n');
+  return root;
+}
+
+test("GET /fleet returns unified lanes, feeds, and coverage", async () => {
+  const root = makeRoot();
+  process.env.FLEET_CONTROL_ARMED_SLOTS_JSONL = JSON.stringify({ name: "armed", handover: "/h.md" });
+  const { server, port } = startServer({ port: 0, stateRoot: root, bridgeRoot: root, pluginDataRoot: join(root, "codex-plugin-data") });
+  try {
+    const doc = await (await fetch(`http://127.0.0.1:${port}/fleet`)).json();
+    expect(doc.lanes.glm[0].branch).toBe("glm/demo");
+    expect(doc.lanes.codex[0].status).toBe("dead");
+    expect(doc.lanes.hermes[0].name).toBe("foo");
+    expect(doc.lanes.armed[0].status).toBe("armed");
+    expect(doc.feeds.quota).toHaveLength(1);
+    expect(doc.coverage.hermesNativeChildren).toBe("blind");
+  } finally {
+    delete process.env.FLEET_CONTROL_ARMED_SLOTS_JSONL;
+    server.stop();
+  }
+});
+
+test("fleet builder remains passive: no interval polling loop", () => {
+  const source = readFileSync(join(import.meta.dir, "..", "aggregator", "fleet.ts"), "utf8");
+  expect(source).not.toContain("setInterval");
+  const root = makeRoot();
+  const doc = buildFleet({ bridgeRoot: root, stateRoot: root, pluginDataRoot: join(root, "codex-plugin-data") });
+  expect(doc.generatedAt).toMatch(/T/);
+});
+
+test("one throwing lane degrades to a failed marker while other lanes render (finding 1)", () => {
+  const root = mkdtempSync(join(tmpdir(), "fleet-degrade-"));
+  // glm-sessions as a FILE makes readdirSync throw (ENOTDIR) -> lane must isolate.
+  writeFileSync(join(root, "glm-sessions"), "not a dir");
+  const logs = join(root, "logs");
+  mkdirSync(logs, { recursive: true });
+  writeFileSync(join(logs, "hermes-ok.log"), "ok\n");
+
+  const doc = buildFleet({ bridgeRoot: root, stateRoot: root, pluginDataRoot: join(root, "codex-plugin-data") });
+  expect(doc.lanes.glm).toHaveLength(1);
+  expect(doc.lanes.glm[0].status).toBe("failed");
+  expect(doc.lanes.glm[0].name).toBe("<reader error>");
+  expect(typeof doc.lanes.glm[0].error).toBe("string");
+  expect(doc.lanes.hermes[0].name).toBe("ok"); // other lane rendered normally
+});
+
+test("GET /fleet returns 200 with other lanes populated when one lane throws (finding 1)", async () => {
+  const root = mkdtempSync(join(tmpdir(), "fleet-degrade-http-"));
+  writeFileSync(join(root, "glm-sessions"), "not a dir");
+  const logs = join(root, "logs");
+  mkdirSync(logs, { recursive: true });
+  writeFileSync(join(logs, "hermes-ok.log"), "ok\n");
+  const { server, port } = startServer({ port: 0, stateRoot: root, bridgeRoot: root, pluginDataRoot: join(root, "codex-plugin-data") });
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/fleet`);
+    expect(res.status).toBe(200);
+    const doc = await res.json();
+    expect(doc.lanes.glm[0].status).toBe("failed");
+    expect(doc.lanes.hermes[0].name).toBe("ok");
+  } finally {
+    server.stop();
+  }
+});

--- a/scripts/fleet-control/tests/glm.test.ts
+++ b/scripts/fleet-control/tests/glm.test.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readGlmWorkers } from "../aggregator/glm";
+
+function fixtureRoot() {
+  return mkdtempSync(join(tmpdir(), "fleet-glm-"));
+}
+
+test("readGlmWorkers reads meta, artifacts, last outbox line, and grants presence", () => {
+  const root = fixtureRoot();
+  const sessionDir = join(root, "glm-sessions", "demo");
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(join(sessionDir, "meta.json"), JSON.stringify({ name: "demo", branch: "glm/demo", status: "running", sessionDir }));
+  writeFileSync(join(sessionDir, "outbox.jsonl"), '{"text":"first"}\n{"type":"escalation","capability":"net.fetch"}\n');
+  writeFileSync(join(sessionDir, "grants.jsonl"), "");
+
+  const workers = readGlmWorkers(root);
+  expect(workers).toHaveLength(1);
+  expect(workers[0]).toMatchObject({ lane: "glm", name: "demo", status: "running", branch: "glm/demo", sessionDir, hasGrants: true });
+  expect(workers[0].lastOutboxLine).toEqual({ type: "escalation", capability: "net.fetch" });
+  expect(workers[0].artifacts).toContain(join(sessionDir, "meta.json"));
+  expect(workers[0].artifacts).toContain(join(sessionDir, "outbox.jsonl"));
+});
+
+test("readGlmWorkers tolerates missing outbox", () => {
+  const root = fixtureRoot();
+  const sessionDir = join(root, "glm-sessions", "no-outbox");
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(join(sessionDir, "meta.json"), JSON.stringify({ task_name: "no-outbox", status: "done" }));
+
+  const [worker] = readGlmWorkers(root);
+  expect(worker.lastOutboxLine).toBeUndefined();
+  expect(worker.hasGrants).toBe(false);
+});
+
+test("session with unparseable meta.json renders a degraded worker (finding 4)", () => {
+  const root = fixtureRoot();
+  const sessionDir = join(root, "glm-sessions", "corrupt");
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(join(sessionDir, "meta.json"), "{not valid json");
+
+  const workers = readGlmWorkers(root);
+  expect(workers).toHaveLength(1);
+  expect(workers[0]).toMatchObject({ lane: "glm", name: "corrupt", status: "failed" });
+  expect(workers[0].artifacts).toContain(join(sessionDir, "meta.json"));
+});
+
+test("session with no meta.json is skipped entirely (finding 4)", () => {
+  const root = fixtureRoot();
+  const sessionDir = join(root, "glm-sessions", "no-meta");
+  mkdirSync(sessionDir, { recursive: true });
+
+  expect(readGlmWorkers(root)).toHaveLength(0);
+});
+
+test("unknown meta.status fails closed to 'failed' at the glm boundary", () => {
+  const bridgeRoot = mkdtempSync(join(tmpdir(), "fleet-glm-"));
+  const sessionDir = join(bridgeRoot, "glm-sessions", "glm-weird-1");
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(join(sessionDir, "meta.json"), JSON.stringify({ name: "weird", status: "exploded" }));
+  const workers = readGlmWorkers(bridgeRoot);
+  expect(workers.find((w) => w.name === "weird")?.status).toBe("failed");
+});

--- a/scripts/fleet-control/tests/hermes.test.ts
+++ b/scripts/fleet-control/tests/hermes.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readHermes } from "../aggregator/hermes";
+
+test("readHermes lists pane-dispatched one-shot logs and states native-child blind spot", () => {
+  const stateRoot = mkdtempSync(join(tmpdir(), "fleet-hermes-"));
+  const logs = join(stateRoot, "logs");
+  mkdirSync(logs, { recursive: true });
+  writeFileSync(join(logs, "hermes-foo.log"), "hello\n");
+
+  const got = readHermes(stateRoot);
+  expect(got.workers).toHaveLength(1);
+  expect(got.workers[0]).toMatchObject({ lane: "hermes", name: "foo", status: "unknown" });
+  expect(got.workers[0].artifacts).toContain(join(logs, "hermes-foo.log"));
+  expect(got.coverage.hermesNativeChildren).toBe("blind");
+  expect(got.coverage.note.length).toBeGreaterThan(0);
+});

--- a/scripts/fleet-control/tests/ledger.test.ts
+++ b/scripts/fleet-control/tests/ledger.test.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readFeeds } from "../aggregator/ledger";
+
+test("readFeeds parses ledger and quota JSONL as render-only feeds with posture reserved", () => {
+  const root = mkdtempSync(join(tmpdir(), "fleet-ledger-"));
+  const ledgerPath = join(root, "where-are-we.jsonl");
+  const quotaPath = join(root, "quota-gauge.jsonl");
+  writeFileSync(ledgerPath, '{"event":"a"}\n{"event":"b"}\n');
+  writeFileSync(quotaPath, '{"lane":"glm","used_pct":80}\n');
+
+  const feeds = readFeeds({ ledgerPath, quotaPath });
+  expect(feeds.ledger).toEqual([{ event: "a" }, { event: "b" }]);
+  expect(feeds.quota).toEqual([{ lane: "glm", used_pct: 80 }]);
+  expect(feeds.posture).toBeNull();
+  expect(feeds.parseErrors).toBe(0);
+  expect(feeds.error).toBeNull();
+});
+
+test("partial trailing line is skipped, good lines kept, and counted as parseErrors (finding 3)", () => {
+  const root = mkdtempSync(join(tmpdir(), "fleet-ledger-partial-"));
+  const ledgerPath = join(root, "where-are-we.jsonl");
+  // append-only feed caught mid-write: a valid line then a partial trailing line.
+  writeFileSync(ledgerPath, '{"event":"a"}\n{"event":"b"}\n{"event":"part');
+
+  const feeds = readFeeds({ ledgerPath });
+  expect(feeds.ledger).toEqual([{ event: "a" }, { event: "b" }]);
+  expect(feeds.parseErrors).toBe(1);
+});

--- a/scripts/fleet-control/tests/page.test.ts
+++ b/scripts/fleet-control/tests/page.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startServer } from "../server";
+
+test("serves static fleet-control page and app js", async () => {
+  const stateRoot = mkdtempSync(join(tmpdir(), "fleet-page-"));
+  const { server, port } = startServer({ port: 0, stateRoot });
+  try {
+    const html = await fetch(`http://127.0.0.1:${port}/`);
+    expect(html.headers.get("content-type")).toContain("text/html");
+    expect(await html.text()).toContain('id="fleet-table"');
+
+    const js = await fetch(`http://127.0.0.1:${port}/app.js`);
+    expect(js.headers.get("content-type")).toContain("application/javascript");
+  } finally { server.stop(); }
+});

--- a/scripts/fleet-control/tests/server.test.ts
+++ b/scripts/fleet-control/tests/server.test.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scrubProviderKeys, PROVIDER_KEY_NAMES, startServer, eventsResponse, resolveCodexStateRoot, resolveServeRoots } from "../server";
+
+test("scrubProviderKeys removes every known provider key from the env map", () => {
+  const env: Record<string, string> = { ZAI_API_KEY: "x", PATH: "/usr/bin", ANTHROPIC_API_KEY: "y" };
+  scrubProviderKeys(env);
+  for (const k of PROVIDER_KEY_NAMES) expect(env[k]).toBeUndefined();
+  expect(env.PATH).toBe("/usr/bin");
+});
+
+test("scrub removes each newly-covered provider key including xai/perplexity/dashscope/nvidia/openrouter/deepseek (finding 7)", () => {
+  const env: Record<string, string | undefined> = {};
+  for (const k of PROVIDER_KEY_NAMES) env[k] = "secret";
+  env.PATH = "/usr/bin";
+  scrubProviderKeys(env);
+  for (const k of PROVIDER_KEY_NAMES) expect(env[k]).toBeUndefined();
+  for (const k of ["XAI_API_KEY", "PERPLEXITY_API_KEY", "DASHSCOPE_API_KEY", "NVIDIA_API_KEY", "OPENROUTER_API_KEY", "DEEPSEEK_API_KEY"]) {
+    expect(PROVIDER_KEY_NAMES).toContain(k as any);
+  }
+  expect(env.PATH).toBe("/usr/bin");
+});
+
+test("startServer scrubs an injected env, leaving process.env untouched (hermetic)", () => {
+  const env: Record<string, string | undefined> = { ZAI_API_KEY: "leak", PATH: "/usr/bin" };
+  const { server } = startServer({ port: 0, stateRoot: "/tmp/fc-test", env });
+  expect(env.ZAI_API_KEY).toBeUndefined();
+  server.stop();
+});
+
+test("server binds loopback only", () => {
+  const { server } = startServer({ port: 0, stateRoot: "/tmp/fc-test" });
+  expect(server.hostname).toBe("127.0.0.1");
+  server.stop();
+});
+
+test("server ignores injected host override", () => {
+  const { server } = startServer({ port: 0, stateRoot: "/tmp/fc-test", hostname: "0.0.0.0" } as any);
+  expect(server.hostname).toBe("127.0.0.1");
+  server.stop();
+});
+
+test("events stream teardown closes the fs watcher on cancel (finding 6)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "fleet-events-"));
+  let closed = false;
+  const fakeWatcher = { close: () => { closed = true; } } as any;
+  const factory = (() => fakeWatcher) as any;
+  const res = eventsResponse(dir, factory);
+  const reader = res.body!.getReader();
+  await reader.read(); // ensure start() has run and the watcher is attached
+  await reader.cancel();
+  expect(closed).toBe(true);
+});
+
+test("missing state root emits a degraded SSE event so the page can show a stale banner (finding 12)", async () => {
+  const res = eventsResponse(join(tmpdir(), `does-not-exist-${Date.now()}`));
+  const reader = res.body!.getReader();
+  const dec = new TextDecoder();
+  let acc = "";
+  for (let i = 0; i < 2; i++) {
+    const { value } = await reader.read();
+    if (value) acc += dec.decode(value);
+  }
+  await reader.cancel();
+  expect(acc).toContain("event: degraded");
+});
+
+test("resolveCodexStateRoot precedence: CLAUDE_PLUGIN_DATA > plugins dir > tmpdir (finding 8)", () => {
+  const home = mkdtempSync(join(tmpdir(), "fleet-home-"));
+  expect(resolveCodexStateRoot({ CLAUDE_PLUGIN_DATA: "/x/plugindata", HOME: home })).toBe("/x/plugindata");
+
+  const pluginsDir = join(home, ".claude", "plugins", "data", "codex-openai-codex");
+  mkdirSync(pluginsDir, { recursive: true });
+  expect(resolveCodexStateRoot({ HOME: home })).toBe(pluginsDir);
+
+  const bareHome = mkdtempSync(join(tmpdir(), "fleet-barehome-"));
+  expect(resolveCodexStateRoot({ HOME: bareHome })).toBe(join(tmpdir(), "codex-companion"));
+});
+
+test("passivity: no setInterval in server.ts or any aggregator source (broadened)", () => {
+  const files = [join(import.meta.dir, "..", "server.ts")];
+  const aggDir = join(import.meta.dir, "..", "aggregator");
+  for (const f of readdirSync(aggDir)) if (f.endsWith(".ts")) files.push(join(aggDir, f));
+  for (const f of files) expect(readFileSync(f, "utf8")).not.toContain("setInterval");
+});
+
+test("resolveServeRoots derives bridgeRoot as the PARENT of the fleet-control state dir", () => {
+  const r = resolveServeRoots({ BRIDGE_ROOT: "/bridge" });
+  expect(r.bridgeRoot).toBe("/bridge");
+  expect(r.stateRoot.replaceAll("\\", "/")).toBe("/bridge/fleet-control");
+  const o = resolveServeRoots({ FLEET_CONTROL_BRIDGE_ROOT: "/b2", FLEET_CONTROL_STATE_ROOT: "/elsewhere/fc" });
+  expect(o.bridgeRoot).toBe("/b2");
+  expect(o.stateRoot).toBe("/elsewhere/fc");
+});
+
+test("eventsResponse watches every distinct root and dedupes nested ones", () => {
+  const bridge = mkdtempSync(join(tmpdir(), "fleet-events-bridge-"));
+  const state = join(bridge, "fleet-control");
+  mkdirSync(state, { recursive: true });
+  const watched: string[] = [];
+  const factory = ((path: string) => { watched.push(String(path)); return { close() {} }; }) as never;
+  // state nested under bridge -> bridge alone suffices (one watcher)
+  eventsResponse([state, bridge], factory);
+  expect(watched.length).toBe(1);
+  // two unrelated roots -> two watchers
+  const other = mkdtempSync(join(tmpdir(), "fleet-events-other-"));
+  watched.length = 0;
+  eventsResponse([other, bridge], factory);
+  expect(watched.length).toBe(2);
+});


### PR DESCRIPTION
Read-only fleet observability service (scripts/fleet-control/): unified GET /fleet document over worker lanes (liveness-checked, per-lane error isolation, truthful-degrade doctrine), GET /escalations with deterministic escalation ids + grants join (fail-closed capability shapes), static page + fs-watch SSE (no polling), loopback-only bind + startup key scrub. 36 hermetic tests.

Propagated from private #987.

🤖 Generated with [Claude Code](https://claude.com/claude-code)