### PR TITLE
feat(guardrails): structural graphify data-egress fence (matrix-driven, fail-closed)

### DIFF
--- a/docs/internals/egress-matrix.md
+++ b/docs/internals/egress-matrix.md
@@ -37,7 +37,7 @@ The matrix defines *policy*; membership resolution stays with the guards.
 
 | Surface | What it reads |
 |---|---|
-| `graphify-fence.sh` (HIMMEL-621/622 Phase G-F, to be built) | maps graphify `--backend` → provider, target path → corpus, purpose = `extraction` |
+| `scripts/guardrails/graphify-fence.sh` (HIMMEL-621 Phase G-F) | maps graphify `--backend` → provider, target path → corpus, purpose = `extraction`; verdict via `scripts/guardrails/egress-matrix-eval.mjs` (the reference semantics as a CLI); wired as the narrow `block-graphify-egress` PreToolUse hook |
 | `parity_guard.py` PHI/egress fence (HIMMEL-695) | the `salus` row (hard deny) — already enforced; the matrix documents the policy it implements |
 | `glm-guard.ts` | same `salus`/denylist row |
 | HIMMEL-765 embedding/rerank pilot client | the `alibaba` × `embedding`/`rerank`/`vision-embedding` cells (all five currently `pending-operator` = deny) |

--- a/marketplace/plugins/himmel-ops/hooks/hooks.json
+++ b/marketplace/plugins/himmel-ops/hooks/hooks.json
@@ -36,6 +36,15 @@
             "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/block-glm-external-writes.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Bash|PowerShell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/block-graphify-egress.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; fi'"
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/scripts/guardrails/egress-matrix-eval.mjs
+++ b/scripts/guardrails/egress-matrix-eval.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// egress-matrix-eval.mjs - CLI wrapper over the egress-matrix reference
+// semantics (HIMMEL-766) for shell consumers (graphify-fence.sh, HIMMEL-621/622).
+//
+// Reuses the SAME first-match-wins evaluation as the reference evaluate() in
+// test-egress-matrix.mjs: iterate `rules`, '*' wildcards, then `default`.
+// Unlike that helper (which collapses allow+log -> allow for its invariant
+// asserts), THIS wrapper PRESERVES the distinction the fence needs:
+//   allow       -> permitted, no ledger
+//   allow+log   -> permitted, ledger obligation
+//   conditional -> permitted ONLY if the caller verifies the rule condition
+//   deny        -> refused (pending-operator and any UNKNOWN verdict fail closed)
+// No rule match returns `default` (asserted "deny" by the matrix test).
+//
+// Usage: node egress-matrix-eval.mjs <corpus> <provider> <purpose>
+// Prints ONE line to stdout: "<verdict>\t<note>". Exit 0 on a clean
+// evaluation, 2 on bad args / unreadable matrix (caller fails closed).
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const [corpus, provider, purpose] = process.argv.slice(2);
+if (!corpus || !provider || !purpose) {
+  process.stderr.write("egress-matrix-eval: need <corpus> <provider> <purpose>\n");
+  process.exit(2);
+}
+
+let m;
+try {
+  const matrixPath = join(dirname(fileURLToPath(import.meta.url)), "egress-matrix.json");
+  m = JSON.parse(readFileSync(matrixPath, "utf8"));
+} catch (e) {
+  process.stderr.write(`egress-matrix-eval: cannot read matrix: ${e?.message ?? e}\n`);
+  process.exit(2);
+}
+
+function evaluate(c, p, u) {
+  for (const r of m.rules) {
+    const hit =
+      (r.corpus === "*" || r.corpus === c) &&
+      (r.provider === "*" || r.provider === p) &&
+      (r.purpose === "*" || r.purpose === u);
+    if (!hit) continue;
+    const verdict =
+      r.verdict === "allow" ? "allow" :
+      r.verdict === "allow+log" ? "allow+log" :
+      r.verdict === "conditional" ? "conditional" :
+      "deny"; // deny, pending-operator, and any UNKNOWN verdict fail closed
+    return { verdict, note: r.why || r.condition || "" };
+  }
+  // m.default is asserted "deny" by test-egress-matrix.mjs; treated as effective.
+  return { verdict: m.default, note: "default (no rule matched)" };
+}
+
+const { verdict, note } = evaluate(corpus, provider, purpose);
+process.stdout.write(`${verdict}\t${note}\n`);

--- a/scripts/guardrails/graphify-fence.sh
+++ b/scripts/guardrails/graphify-fence.sh
@@ -1,0 +1,681 @@
+#!/usr/bin/env bash
+# scripts/guardrails/graphify-fence.sh - structural data-egress fence for
+# `graphify` invocations (HIMMEL-621/622 Phase G-F).
+#
+# Invoked with ONE arg: the shell command string. It acts ONLY when that
+# command invokes `graphify` in COMMAND POSITION; a bare mention (a grep/echo
+# argument, a substring of a path) exits 0 (not its job). For a real graphify
+# invocation it:
+#   1. splits the command into clauses (on ;  |  &&  ||  &  newline) and, for
+#      each clause whose command-position token is graphify, parses the REAL
+#      subcommand grammar `graphify <subcommand> <path...> [--backend=x]`:
+#      the subcommand token is skipped (never classified) UNLESS the first
+#      positional is itself path-like (then it IS classified, not swallowed as a
+#      subcommand word); EVERY subsequent bare (non-flag) path-like token is
+#      normalized + classified against the corpus roots; MOST-RESTRICTIVE-WINS
+#      across all classified tokens (salus > luna-personal > luna-clippings >
+#      handover-state > himmel-code). ANY subcommand carrying a path-like token
+#      that does NOT classify -> DENY (fail closed); the extraction-subcommand
+#      list is now defense-in-depth commentary, not the gate. If the invocation
+#      has NO path-like token (e.g. `query "question"`) the CWD corpus is
+#      classified instead (the graph in cwd derives from the corpus around it).
+#   2. resolves the backend -> provider. When `--backend` is ABSENT the fence
+#      cannot see which provider graphify's own cloud-key auto-detect will pick,
+#      so it DENIES unless the effective corpus is himmel-code (which defaults to
+#      local-ollama and is allowed); every other corpus demands explicit
+#      --backend.
+#   3. evaluates scripts/guardrails/egress-matrix.json at purpose="extraction"
+#      via egress-matrix-eval.mjs (single source of first-match-wins semantics).
+#   4. allow -> continue; allow+log / allowed-conditional -> append a JSONL
+#      ledger line to ~/.claude/graphify-egress.jsonl (a failed append DENIES -
+#      allow+log requires the ledger line); deny -> print a one-line reason
+#      naming the matrix cell and exit 2. ANY denied clause denies overall.
+#
+# FAIL CLOSED throughout: an unparseable command-position invocation, an
+# unclassifiable path-like token, an unclassifiable cwd, an unreadable PHI root
+# list, a missing node, an unwritable ledger, a no-backend non-himmel corpus,
+# graphify deferred through xargs/find -exec, or any non-allow verdict all DENY.
+# An EXIT trap converts any abnormal exit (anything other than 0 or 2) into a
+# fail-closed exit 2.
+#
+# Opt-in env vars (the two `conditional` matrix cells graphify can reach at
+# purpose=extraction; set in the launching shell, not per-call):
+#   GRAPHIFY_SALUS_LOCAL_OK=1     - allow salus corpus x local-ollama (per-run
+#                                   opt-in; PHI stays on-machine but even local
+#                                   salus extraction needs an explicit opt-in).
+#   GRAPHIFY_CLIPPINGS_GLM_OK=1   - allow luna-clippings corpus x zai-glm
+#                                   (the pre-existing narrow clipped-public-web
+#                                   content exception).
+# Neither flag can flip a hard-deny cell (salus x any cloud, gemini anywhere).
+#
+# Backend -> provider map (backend name is lower-cased first):
+#   ollama          -> local-ollama, UNLESS OLLAMA_HOST points off-box
+#                      (not localhost/127.0.0.1/[::1], with or without port) ->
+#                      undeclared `ollama` (falls to matrix default deny)
+#   deepseek        -> deepseek
+#   openai          -> deepseek ONLY when OPENAI_BASE_URL or DEEPSEEK_BASE_URL
+#                      points at api.deepseek.com; otherwise the undeclared
+#                      `openai` (falls to matrix default deny)
+#   glm | zai       -> zai-glm
+#   gemini | google -> google-gemini
+#   anything else   -> the literal backend string (undeclared -> default deny)
+#
+# Test overrides (mirror parity_guard's CLAUDE_GLM_CONFIG_DIR posture; let the
+# hermetic suite point at a temp tree without touching real state):
+#   CLAUDE_GLM_CONFIG_DIR  - PHI root-list dir (default ~/.config/claude-glm)
+#   LUNA_VAULT / LUNA_VAULT_PATH - luna vault root
+#   HANDOVER_DIR           - handover state root (via handover-path.sh)
+#   GRAPHIFY_HIMMEL_ROOT   - himmel checkout root (default: git toplevel here)
+#   GRAPHIFY_LEDGER        - ledger path (default ~/.claude/graphify-egress.jsonl)
+#
+# Exit codes: 0 = allow (ledger written where the matched cell requires it);
+# 2 = deny (stderr carries the reason).
+#
+# NOW HANDLED (closed in the HIMMEL-621 hardening round, no longer limitations):
+# command-position wrappers (exec/nohup/timeout/sudo/env -i/stdbuf/nice/time/
+# command/builtin, chained), graphify reached via xargs / find -exec (DENIED
+# outright as not statically fenceable), a backslash-escaped `\graphify`, and a
+# position-0 path-like token (classified, not swallowed as the subcommand).
+#
+# Accepted static-analysis limitations (the load-bearing PHI guard is the
+# file-tool fence parity_guard, not this command-text guard):
+#   (a) quoted-separator mis-split - a path with embedded spaces, or a quoted
+#       `;`/`|`/`&`, is word-split naively, so a truncated token can still land
+#       under a corpus root. Two structural margins keep this safe-direction:
+#       corpus classification is PREFIX-ANCHORED (a fragment classifies only if
+#       it still normalizes UNDER a corpus root), and most-restrictive-wins plus
+#       the unconditional unclassifiable-path-like DENY bias every ambiguous
+#       split toward deny. Residual: a truncated fragment that happens to
+#       normalize under an ALLOW corpus root (himmel-code) - a mis-classify that
+#       loosens, though the salus corpus is `.salus`-marker + PHI-root anchored
+#       so a partial salus path stays PHI as long as the fragment reaches a
+#       marked ancestor.
+#   (b) `$GRAPHIFY update ...` - variable indirection of the binary itself is
+#       out of static reach and is NOT fenced.
+#   (c) PowerShell - the hook routes PowerShell commands here too, but they are
+#       parsed with POSIX word-splitting; a PowerShell-only quoting/escaping
+#       form can mis-parse. Mis-parses land safe-direction (a mis-split path-like
+#       token is unclassifiable -> DENY, not a silent allow).
+set -uo pipefail
+set -f  # no pathname expansion when we word-split the command / a path
+
+# Arm the fail-closed EXIT trap BEFORE any $HOME (or other) expansion so an
+# unbound-var abort under `set -u` becomes a clean deny (exit 2) rather than a
+# non-blocking rc=1 the hook would let through.
+# shellcheck disable=SC2329,SC2317 # invoked indirectly via `trap ... EXIT`
+_on_exit() {
+    local rc=$?
+    case "$rc" in
+        0|2) exit "$rc" ;;
+        *)   echo "graphify-fence: DENY abnormal exit (rc=$rc); fail-closed" >&2; exit 2 ;;
+    esac
+}
+trap _on_exit EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EVAL_HELPER="$SCRIPT_DIR/egress-matrix-eval.mjs"
+
+CMD="${1:-}"
+
+PHI_CONFIG_DIR="${CLAUDE_GLM_CONFIG_DIR:-$HOME/.config/claude-glm}"
+LEDGER="${GRAPHIFY_LEDGER:-$HOME/.claude/graphify-egress.jsonl}"
+LUNA_ROOT="${LUNA_VAULT:-${LUNA_VAULT_PATH:-}}"
+
+HANDOVER_ROOT=""
+HANDOVER_LIB="$SCRIPT_DIR/../lib/handover-path.sh"
+if [ -f "$HANDOVER_LIB" ]; then
+    # shellcheck source=../lib/handover-path.sh
+    # shellcheck disable=SC1091
+    . "$HANDOVER_LIB"
+    HANDOVER_ROOT="$(handover_root 2>/dev/null || true)"
+fi
+
+HIMMEL_ROOT="${GRAPHIFY_HIMMEL_ROOT:-$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)}"
+
+# Extraction-shaped subcommands (defense-in-depth commentary, NOT the gate as of
+# HIMMEL-621): update label cluster-only add merge-graphs merge-driver path.
+# ANY subcommand carrying an unclassifiable path-like token now DENIES.
+
+deny() { # <reason>
+    echo "graphify-fence: DENY $1" >&2
+    exit 2
+}
+
+# --- path helpers (pure bash, bash 3.2-safe) --------------------------------
+
+_lc() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# _strip_wrap <token> -> strip one layer of surrounding quotes/backticks (the
+# tokeniser is quote-naive; a path token may arrive as `"path` or `path"`).
+_strip_wrap() {
+    local p="$1"
+    p="${p%\"}"; p="${p#\"}"
+    p="${p%\'}"; p="${p#\'}"
+    p="${p%\`}"; p="${p#\`}"
+    printf '%s' "$p"
+}
+
+# _strip_cmd <token> -> aggressive strip for COMMAND-POSITION identification:
+# remove every quote / backtick / `$` / `(` / `)` / backslash so a wrapped,
+# command-substituted, or backslash-escaped binary (`"graphify`, `\graphify`,
+# `$(which graphify)`, backtick form) is compared on its bare name.
+_strip_cmd() {
+    local t="$1"
+    t="${t//\"/}"; t="${t//\'/}"; t="${t//\`/}"
+    t="${t//\$/}"; t="${t//(/}";  t="${t//)/}"
+    t="${t//\\/}"
+    printf '%s' "$t"
+}
+
+# _abs <path> -> absolute path (expanduser + anchor a relative path to PWD).
+_abs() {
+    local p; p="$(_strip_wrap "$1")"
+    # shellcheck disable=SC2088 # the "~/" is a literal case-pattern, not an expansion
+    case "$p" in
+        "~")   p="$HOME" ;;
+        "~/"*) p="$HOME/${p#\~/}" ;;
+    esac
+    case "$p" in
+        /*)         : ;;             # POSIX absolute
+        [A-Za-z]:*) : ;;             # Windows drive-absolute (C:/...)
+        *)          p="$PWD/$p" ;;   # relative -> anchor to cwd
+    esac
+    printf '%s' "$p"
+}
+
+# _normalize <abs-path> -> lexically normalized, forward-slashed (collapse
+# `.` / `..` segments so a `Clippings/../../salus` traversal cannot mis-match a
+# corpus by raw string prefix). Lexical only - no symlink resolution.
+_normalize() {
+    local p="$1"
+    p="${p//\\//}"   # backslashes -> forward slashes (Windows paths)
+    local prefix=""
+    case "$p" in
+        [A-Za-z]:/*) prefix="${p%%:*}:"; p="${p#[A-Za-z]:}" ;;
+    esac
+    local seg result="" oldIFS="$IFS"
+    IFS='/'
+    # shellcheck disable=SC2086 # intentional split on '/'
+    set -- $p
+    IFS="$oldIFS"
+    for seg in "$@"; do
+        case "$seg" in
+            ''|.) : ;;
+            ..)   result="${result%/*}" ;;
+            *)    result="$result/$seg" ;;
+        esac
+    done
+    printf '%s%s' "$prefix" "${result:-/}"
+}
+
+# _under_root <path> <root> -> 0 if path == root or a descendant of root.
+_under_root() {
+    local p r
+    p="$(_lc "$(_normalize "$1")")"
+    r="$(_lc "$(_normalize "$2")")"
+    [ -n "$r" ] || return 1
+    r="${r%/}"
+    case "$p/" in "$r/"*) return 0 ;; esac
+    return 1
+}
+
+# _salus_marked <abs-path> -> 0 if a `.salus` marker sits at the path or any
+# ancestor directory (a path anywhere inside a PHI vault is PHI).
+_salus_marked() {
+    local d="$1" prev=""
+    [ -d "$d" ] || d="${d%/*}"
+    while [ -n "$d" ] && [ "$d" != "$prev" ]; do
+        if [ -e "$d/.salus" ]; then return 0; fi
+        prev="$d"
+        d="${d%/*}"
+    done
+    return 1
+}
+
+# _under_any_list <abs-path> <listfile> -> echoes hit | miss | unreadable.
+_under_any_list() {
+    local p="$1" listfile="$2" root
+    [ -e "$listfile" ] || { echo miss; return; }
+    { [ -f "$listfile" ] && [ -r "$listfile" ]; } || { echo unreadable; return; }
+    while IFS= read -r root || [ -n "$root" ]; do
+        root="${root%$'\r'}"
+        root="${root%/}"; root="${root%\\}"
+        [ -n "$root" ] || continue
+        if _under_root "$p" "$root"; then echo hit; return; fi
+    done < "$listfile"
+    echo miss
+}
+
+# classify <target-path> -> echoes corpus, "__unreadable__", or "" (unclassifiable).
+classify() {
+    local ap name rc
+    ap="$(_normalize "$(_abs "$1")")"
+    if _salus_marked "$ap"; then echo salus; return; fi
+    for name in phi-roots egress-denylist; do
+        rc="$(_under_any_list "$ap" "$PHI_CONFIG_DIR/$name")"
+        if [ "$rc" = unreadable ]; then echo "__unreadable__"; return; fi
+        if [ "$rc" = hit ]; then echo salus; return; fi
+    done
+    if [ -n "$LUNA_ROOT" ] && _under_root "$ap" "$LUNA_ROOT"; then
+        if _under_root "$ap" "$LUNA_ROOT/Clippings"; then
+            echo luna-clippings
+        else
+            echo luna-personal
+        fi
+        return
+    fi
+    if [ -n "$HANDOVER_ROOT" ] && _under_root "$ap" "$HANDOVER_ROOT"; then echo handover-state; return; fi
+    if [ -n "$HIMMEL_ROOT" ] && _under_root "$ap" "$HIMMEL_ROOT"; then echo himmel-code; return; fi
+    echo ""
+}
+
+# _rank <corpus> -> restrictiveness rank (higher = more restrictive).
+_rank() {
+    case "$1" in
+        salus)          echo 5 ;;
+        luna-personal)  echo 4 ;;
+        luna-clippings) echo 3 ;;
+        handover-state) echo 2 ;;
+        himmel-code)    echo 1 ;;
+        *)              echo 0 ;;
+    esac
+}
+
+# is_path_like <stripped-token> -> 0 if the token looks like a filesystem path
+# (NOT a URL, which is remote content pulled IN, not a corpus path).
+is_path_like() {
+    local t="$1"
+    case "$t" in
+        *://*) return 1 ;;                       # scheme://host - a URL, not a path
+    esac
+    case "$t" in
+        */*|*\\*)     return 0 ;;              # any slash (covers ~/foo too)
+        "."|"..")     return 0 ;;
+        [A-Za-z]:*)   return 0 ;;
+        *.md|*.markdown|*.json|*.txt|*.py|*.js|*.ts|*.sh|*.html|*.htm|*.csv|*.yaml|*.yml|*.toml|*.rs|*.go|*.java|*.rb|*.c|*.h|*.cpp)
+                      return 0 ;;
+    esac
+    return 1
+}
+
+# NO-BACKEND policy (HIMMEL-621): when `--backend` is absent the fence cannot
+# see which provider graphify's own cloud-key auto-detect will select (the key
+# list DEEPSEEK_API_KEY/ZAI_API_KEY/DASHSCOPE_API_KEY/OPENAI_API_KEY/... is
+# graphify-internal). So the rule is corpus-based, not key-sniffing: no-backend
+# is allowed ONLY for the himmel-code corpus (defaults to local-ollama); every
+# other corpus DENIES and demands an explicit --backend. See apply_verdict.
+
+# _ollama_local -> 0 if OLLAMA_HOST is unset or points at the local box.
+_ollama_local() {
+    local h="${OLLAMA_HOST:-}"
+    [ -n "$h" ] || return 0
+    h="$(_lc "$h")"
+    h="${h#http://}"; h="${h#https://}"
+    case "$h" in
+        localhost|localhost:*|127.0.0.1|127.0.0.1:*|'[::1]'|'[::1]:'*|::1|::1:*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# map_provider <backend(lowercased)> -> echoes provider (may be undeclared literal).
+map_provider() {
+    local b="$1" hit=0
+    case "$b" in
+        ollama)
+            if _ollama_local; then echo local-ollama; else echo ollama; fi
+            ;;
+        deepseek)      echo deepseek ;;
+        openai)
+            case "${OPENAI_BASE_URL:-}"   in *api.deepseek.com*) hit=1 ;; esac
+            case "${DEEPSEEK_BASE_URL:-}" in *api.deepseek.com*) hit=1 ;; esac
+            if [ "$hit" = 1 ]; then echo deepseek; else echo openai; fi
+            ;;
+        glm|zai)       echo zai-glm ;;
+        gemini|google) echo google-gemini ;;
+        *)             echo "$b" ;;
+    esac
+}
+
+# _json_escape <string> -> JSON-safe (backslash, quote, and control chars).
+_json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+# ledger_append <path> <corpus> <backend> <provider> <verdict> -> 0 on a durable
+# write, 1 on any failure (unwritable dir / file). Callers DENY on failure: an
+# allow+log verdict without its ledger line is not allowed.
+ledger_append() {
+    local dir ts ep
+    dir="$(dirname "$LEDGER")"
+    mkdir -p "$dir" || return 1
+    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%s)"
+    ep="$(_json_escape "$1")"
+    printf '{"ts":"%s","path":"%s","corpus":"%s","backend":"%s","provider":"%s","verdict":"%s","tool":"graphify"}\n' \
+        "$ts" "$ep" "$2" "$3" "$4" "$5" >> "$LEDGER" || return 1
+    return 0
+}
+
+# apply_verdict <corpus> <target> <backend-raw> -> return 0 (allow, ledger
+# written where required) or DENY (exit 2).
+apply_verdict() {
+    local corpus="$1" target="$2" backend_raw="$3"
+    local backend_effective provider verdict everr eout emsg optvar optval
+
+    if [ -z "$backend_raw" ]; then
+        if [ "$corpus" != "himmel-code" ]; then
+            deny "pass --backend explicitly (graphify auto-detects cloud keys; the fence cannot see which) [corpus=$corpus]"
+        fi
+        backend_effective="ollama"
+    else
+        backend_effective="$(_lc "$(_strip_wrap "$backend_raw")")"
+    fi
+    provider="$(map_provider "$backend_effective")"
+
+    command -v node >/dev/null 2>&1 || deny "node not found; cannot evaluate the egress matrix (fail-closed)"
+
+    everr="$(mktemp 2>/dev/null || echo "")"
+    if [ -n "$everr" ]; then
+        if eout="$(node "$EVAL_HELPER" "$corpus" "$provider" extraction 2>"$everr")"; then
+            :
+        else
+            emsg="$(tr '\n' ' ' < "$everr" 2>/dev/null)"
+            rm -f "$everr"
+            deny "egress matrix eval failed for $corpus x $provider x extraction: $emsg (fail-closed)"
+        fi
+        rm -f "$everr"
+    else
+        eout="$(node "$EVAL_HELPER" "$corpus" "$provider" extraction 2>&1)" \
+            || deny "egress matrix eval failed for $corpus x $provider x extraction: $eout (fail-closed)"
+    fi
+    verdict="${eout%%$'\t'*}"
+
+    case "$verdict" in
+        allow)
+            return 0
+            ;;
+        allow+log)
+            ledger_append "$target" "$corpus" "$backend_effective" "$provider" "allow+log" \
+                || deny "allow+log requires the ledger line (ledger unwritable): $corpus x $provider"
+            return 0
+            ;;
+        conditional)
+            case "$corpus/$provider" in
+                salus/local-ollama)     optvar="GRAPHIFY_SALUS_LOCAL_OK";   optval="${GRAPHIFY_SALUS_LOCAL_OK:-}" ;;
+                luna-clippings/zai-glm) optvar="GRAPHIFY_CLIPPINGS_GLM_OK"; optval="${GRAPHIFY_CLIPPINGS_GLM_OK:-}" ;;
+                *) deny "$corpus x $provider x extraction is conditional with no known opt-in (fail-closed)" ;;
+            esac
+            if [ "$optval" = "1" ]; then
+                ledger_append "$target" "$corpus" "$backend_effective" "$provider" "conditional" \
+                    || deny "allow+log requires the ledger line (ledger unwritable): $corpus x $provider"
+                return 0
+            fi
+            deny "$corpus x $provider x extraction requires opt-in $optvar=1 (matrix conditional cell)"
+            ;;
+        *)
+            deny "$corpus x $provider x extraction -> $verdict (egress matrix)"
+            ;;
+    esac
+}
+
+# evaluate_invocation <arg-tokens...> - args are the tokens AFTER the graphify
+# command word. Skips the subcommand, classifies path-like tokens
+# (most-restrictive-wins), applies the CWD fallback, then applies the verdict.
+evaluate_invocation() {
+    local have_sub=0 subcmd="" want_backend=0 backend=""
+    local unclassifiable=0 best_rank=-1 best_corpus="" best_target=""
+    local tok st c r skip_redir_target=0
+
+    for tok in "$@"; do
+        if [ "$skip_redir_target" = 1 ]; then skip_redir_target=0; continue; fi
+        case "$tok" in
+            '>'|'>>'|'<'|[0-9]'>')
+                # Standalone redirection: the NEXT token is its filename
+                # target, not a graphify arg - skip both.
+                skip_redir_target=1; continue ;;
+            '>'*|'<'*|[0-9]'>'*)
+                # Attached redirection ('>/tmp/out', '2>/dev/null', '>>log')
+                # carries its own target: skip, do not classify (previously
+                # read as an unclassifiable path -> false deny).
+                # ('&>' can't occur: '&' is a clause splitter.)
+                continue ;;
+        esac
+        if [ "$want_backend" = 1 ]; then backend="$tok"; want_backend=0; continue; fi
+        case "$tok" in
+            --backend)   want_backend=1; continue ;;
+            --backend=*) backend="${tok#--backend=}"; continue ;;
+        esac
+        case "$tok" in
+            -*) continue ;;                    # other flag
+        esac
+        if [ "$have_sub" = 0 ]; then
+            st="$(_strip_wrap "$tok")"
+            # Position-0 path (HIMMEL-621): if the first positional is itself
+            # path-like it is a target, NOT a subcommand word - classify it
+            # (fall through) instead of swallowing it. Otherwise it is the
+            # subcommand token: record + skip (never classified).
+            if ! is_path_like "$st"; then
+                subcmd="$(_lc "$st")"; have_sub=1; continue
+            fi
+            have_sub=1
+        fi
+        st="$(_strip_wrap "$tok")"
+        [ -n "$st" ] || continue
+        is_path_like "$st" || continue          # non-path arg (node name, question, model)
+        c="$(classify "$st")"
+        if [ "$c" = "__unreadable__" ]; then
+            deny "a PHI root list under $PHI_CONFIG_DIR exists but is not readable (fail-closed)"
+        fi
+        if [ -n "$c" ]; then
+            r="$(_rank "$c")"
+            if [ "$r" -gt "$best_rank" ]; then
+                best_rank="$r"; best_corpus="$c"; best_target="$st"
+            fi
+        else
+            # Unconditional (HIMMEL-621): an unclassifiable path-like token
+            # denies for ANY subcommand, not only the extraction-shaped ones.
+            unclassifiable=1
+        fi
+    done
+
+    if [ "$unclassifiable" = 1 ]; then
+        deny "unclassifiable path in graphify '$subcmd' invocation (fail-closed): $CMD"
+    fi
+
+    if [ -n "$best_corpus" ]; then
+        apply_verdict "$best_corpus" "$best_target" "$backend"
+        return
+    fi
+
+    # No classified path-like token -> the corpus is the one around the CWD.
+    c="$(classify "$PWD")"
+    if [ "$c" = "__unreadable__" ]; then
+        deny "a PHI root list under $PHI_CONFIG_DIR exists but is not readable (fail-closed)"
+    fi
+    [ -n "$c" ] || deny "unclassifiable cwd for graphify '$subcmd' (no classifiable path arg): $PWD"
+    apply_verdict "$c" "$PWD" "$backend"
+}
+
+# classify_clause <clause-tokens...> - resolve the command-position token of one
+# clause; if it is graphify (bare, wrapped, substituted, or reached via
+# bash -c/sh -c), dispatch its args to evaluate_invocation. A non-command-position
+# mention is a no-op (return without evaluating).
+classify_clause() {
+    local n=$# i=0 raw s j k found fs inner seen_exec
+    local -a toks args
+    toks=("$@")
+
+    # Skip leading env-var assignments (X=y) and command wrappers (HIMMEL-621),
+    # so a wrapper set placed before graphify - exec / nohup / timeout 600 /
+    # sudo / env -i / stdbuf -oL / ... - does not hide the invocation from the
+    # command-position walk. Wrappers may chain (`sudo nohup timeout 600 ...`).
+    while [ "$i" -lt "$n" ]; do
+        raw="${toks[$i]}"; s="$(_strip_cmd "$raw")"
+        case "$s" in
+            [A-Za-z_]*=*)
+                i=$((i+1)); continue ;;                    # leading VAR=val assignment
+            command|exec|builtin|nohup|time|nice)
+                i=$((i+1)); continue ;;                    # transparent wrapper (no args to consume)
+            env)
+                i=$((i+1))                                 # env [-i|-|-u VAR|X=y]... CMD
+                while [ "$i" -lt "$n" ]; do
+                    case "$(_strip_cmd "${toks[$i]}")" in
+                        -u|--unset)   i=$((i+2)) ;;        # flag + VAR value
+                        [A-Za-z_]*=*) i=$((i+1)) ;;        # env-local assignment
+                        -*)           i=$((i+1)) ;;        # -i / - / --ignore-environment / ...
+                        *)            break ;;
+                    esac
+                done
+                continue ;;
+            timeout)
+                i=$((i+1))                                 # timeout [flags] DURATION CMD
+                while [ "$i" -lt "$n" ]; do
+                    case "$(_strip_cmd "${toks[$i]}")" in
+                        -k|-s|--kill-after|--signal) i=$((i+2)) ;;  # flag + value
+                        -*)                          i=$((i+1)) ;;  # -v / --preserve-status / =-form
+                        *)                           break ;;
+                    esac
+                done
+                [ "$i" -lt "$n" ] && i=$((i+1))            # consume the DURATION positional
+                continue ;;
+            stdbuf)
+                i=$((i+1))                                 # stdbuf [-i|-o|-e MODE]... CMD
+                while [ "$i" -lt "$n" ]; do
+                    case "$(_strip_cmd "${toks[$i]}")" in
+                        -i|-o|-e) i=$((i+2)) ;;            # bare short opt + separate MODE value
+                        -*)       i=$((i+1)) ;;            # -oL combined / other flag
+                        *)        break ;;
+                    esac
+                done
+                continue ;;
+            sudo)
+                i=$((i+1))                                 # sudo [flags] CMD
+                while [ "$i" -lt "$n" ]; do
+                    case "$(_strip_cmd "${toks[$i]}")" in
+                        -u|-g|-U|-p|-C|-r|-t|-h) i=$((i+2)) ;;       # flag + value
+                        --)                      i=$((i+1)); break ;;  # end of sudo options
+                        [A-Za-z_]*=*)            i=$((i+1)) ;;        # sudo-local VAR=val
+                        -*)                      i=$((i+1)) ;;        # -n / -E / -H / -i / -s / ...
+                        *)                       break ;;
+                    esac
+                done
+                continue ;;
+        esac
+        break
+    done
+    [ "$i" -lt "$n" ] || return 0
+
+    raw="${toks[$i]}"; s="$(_strip_cmd "$raw")"
+
+    # xargs / find -exec (HIMMEL-621): graphify reached as a DEFERRED target of
+    # xargs or find -exec/-execdir is not statically fenceable (the real arg
+    # list is materialised at runtime). Fail closed - DENY outright rather than
+    # attempt to parse the deferred invocation. A bare mention that is NOT the
+    # deferred command (`find . -name graphify`) is left alone.
+    case "$s" in
+        xargs|*/xargs)
+            j=$((i+1))
+            while [ "$j" -lt "$n" ]; do
+                case "$(_strip_cmd "${toks[$j]}")" in
+                    graphify|*/graphify)
+                        deny "graphify via xargs/find -exec is not statically fenceable; invoke graphify directly" ;;
+                esac
+                j=$((j+1))
+            done
+            return 0
+            ;;
+        find|*/find)
+            j=$((i+1)); seen_exec=0
+            while [ "$j" -lt "$n" ]; do
+                case "$(_strip_cmd "${toks[$j]}")" in
+                    -exec|-execdir) seen_exec=1 ;;
+                    graphify|*/graphify)
+                        [ "$seen_exec" = 1 ] && \
+                            deny "graphify via xargs/find -exec is not statically fenceable; invoke graphify directly" ;;
+                esac
+                j=$((j+1))
+            done
+            return 0
+            ;;
+    esac
+
+    # bash -c / sh -c: unwrap the inner command string and re-resolve it.
+    case "$s" in
+        bash|sh|*/bash|*/sh)
+            j=$((i+1))
+            while [ "$j" -lt "$n" ]; do
+                fs="$(_strip_cmd "${toks[$j]}")"
+                case "$fs" in
+                    -c)
+                        j=$((j+1)); inner=""
+                        while [ "$j" -lt "$n" ]; do inner="$inner ${toks[$j]}"; j=$((j+1)); done
+                        inner="$(_strip_cmd "$inner")"
+                        # shellcheck disable=SC2086 # intentional re-split of the unwrapped command
+                        set -- $inner
+                        classify_clause ${1+"$@"}
+                        return
+                        ;;
+                    -*) j=$((j+1)); continue ;;
+                    *)  break ;;
+                esac
+            done
+            return 0
+            ;;
+    esac
+
+    # Command substitution in command position: $(which graphify) / `which graphify`.
+    # shellcheck disable=SC2016 # literal `$(` / backtick case-patterns, not expansions
+    case "$raw" in
+        '$('*|'`'*)
+            k="$i"; found=0
+            while [ "$k" -lt "$n" ]; do
+                case "$(_strip_cmd "${toks[$k]}")" in graphify|*/graphify) found=1 ;; esac
+                case "${toks[$k]}" in *')'|*'`') k=$((k+1)); break ;; esac
+                k=$((k+1))
+            done
+            if [ "$found" = 1 ]; then
+                args=()
+                while [ "$k" -lt "$n" ]; do args+=("${toks[$k]}"); k=$((k+1)); done
+                evaluate_invocation ${args[@]+"${args[@]}"}
+            fi
+            return 0
+            ;;
+    esac
+
+    # Plain command position.
+    case "$s" in
+        graphify|*/graphify)
+            args=()
+            j=$((i+1))
+            while [ "$j" -lt "$n" ]; do args+=("${toks[$j]}"); j=$((j+1)); done
+            evaluate_invocation ${args[@]+"${args[@]}"}
+            ;;
+    esac
+    return 0
+}
+
+# --- main: split into clauses, evaluate every graphify command-position clause -
+# Separators ;  |  &  (and && / ||, which collapse) and newlines become clause
+# boundaries. Any denied clause exits 2 immediately; reaching the end = allow.
+# Over-splitting here is safe: corpus classification is prefix-anchored, so a
+# fragment produced by an aggressive split classifies only if it still lands
+# under a corpus root; anything ambiguous falls to the unclassifiable DENY.
+tmp="$CMD"
+tmp="${tmp//;/$'\n'}"
+tmp="${tmp//|/$'\n'}"
+tmp="${tmp//&/$'\n'}"
+
+while IFS= read -r clause || [ -n "$clause" ]; do
+    [ -n "$clause" ] || continue
+    # shellcheck disable=SC2086 # intentional word split for tokenisation
+    set -- $clause
+    [ "$#" -gt 0 ] || continue
+    classify_clause "$@"
+done <<< "$tmp"
+
+exit 0

--- a/scripts/guardrails/test-graphify-fence.sh
+++ b/scripts/guardrails/test-graphify-fence.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+# Hermetic smoke test for scripts/guardrails/graphify-fence.sh, the narrow hook
+# scripts/hooks/block-graphify-egress.sh, and the egress-matrix-eval.mjs helper
+# (HIMMEL-621/622 Phase G-F). Builds a temp HOME + fixture vault/handover/himmel
+# roots + fake PHI config lists, invokes the fence against REAL graphify-grammar
+# command strings (`graphify <subcommand> <path> [--backend=x]`), and asserts the
+# matrix verdict plus the fail-closed behaviour confirmed by the CR live probes.
+#
+# Hermeticity (CR round-2): run_fence scrubs every env var that could leak from
+# the developer's shell (GRAPHIFY_*_OK, OPENAI_BASE_URL, DEEPSEEK_BASE_URL,
+# LUNA_VAULT, OLLAMA_HOST, and all ten cloud provider keys) so a real key set in
+# the outer environment cannot flip a fixture verdict.
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+FENCE="$REPO_ROOT/scripts/guardrails/graphify-fence.sh"
+HOOK="$REPO_ROOT/scripts/hooks/block-graphify-egress.sh"
+EVAL_HELPER="$REPO_ROOT/scripts/guardrails/egress-matrix-eval.mjs"
+
+for f in "$FENCE" "$HOOK" "$EVAL_HELPER"; do
+    if [ ! -f "$f" ]; then echo "FAIL: $f not found"; exit 1; fi
+done
+
+BASH_BIN="$(command -v bash)"
+
+failures=0
+pass() { printf '  PASS  %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures+1)); }
+
+# --- fixture workspace ------------------------------------------------------
+WS="$(mktemp -d)"
+trap 'rm -rf "$WS"' EXIT
+
+export HOME="$WS/home"; mkdir -p "$HOME/.claude"
+LUNA="$WS/luna";        mkdir -p "$LUNA/Clippings"
+SALUS="$WS/salusvault"; mkdir -p "$SALUS/notes"; : > "$SALUS/.salus"
+HANDDIR="$WS/handover"; mkdir -p "$HANDDIR"
+HIMMEL="$WS/himmelco";  mkdir -p "$HIMMEL/scripts"
+PHI="$WS/phicfg";       mkdir -p "$PHI"
+PHI_BADROOTS="$WS/phicfg2"; mkdir -p "$PHI_BADROOTS/phi-roots"   # phi-roots is a DIR -> unreadable
+DENYROOT="$WS/secretvault"; mkdir -p "$DENYROOT/x"
+NOWHERE="$WS/nowhere";  mkdir -p "$NOWHERE"
+
+# an egress-denylist root (path-list membership -> salus corpus)
+printf '%s\n' "$DENYROOT" > "$PHI/egress-denylist"
+
+export LUNA_VAULT_PATH="$LUNA"
+export HANDOVER_DIR="$HANDDIR"
+export CLAUDE_GLM_CONFIG_DIR="$PHI"
+export GRAPHIFY_HIMMEL_ROOT="$HIMMEL"
+LEDGER="$HOME/.claude/graphify-egress.jsonl"
+
+# make fixture target files
+: > "$LUNA/journal-2026.md"
+: > "$LUNA/Clippings/clip.md"
+: > "$SALUS/notes/patient.md"
+: > "$HIMMEL/scripts/thing.sh"
+: > "$DENYROOT/x/leak.md"
+: > "$NOWHERE/loose.md"
+
+# env vars scrubbed on every fence call so the outer shell cannot leak state in.
+CLEAN_ENV="-u GRAPHIFY_SALUS_LOCAL_OK -u GRAPHIFY_CLIPPINGS_GLM_OK -u GRAPHIFY_LEDGER \
+-u OPENAI_BASE_URL -u DEEPSEEK_BASE_URL -u LUNA_VAULT -u OLLAMA_HOST \
+-u DEEPSEEK_API_KEY -u ZAI_API_KEY -u DASHSCOPE_API_KEY -u OPENAI_API_KEY \
+-u ANTHROPIC_API_KEY -u GEMINI_API_KEY -u GOOGLE_API_KEY -u XAI_API_KEY \
+-u OPENROUTER_API_KEY -u NVIDIA_API_KEY"
+
+# run_fence <expect: allow|deny> <expect-ledger: yes|no> <cwd> <name> <cmd> [VAR=val ...]
+# Extra trailing args are per-call `VAR=val` env assignments (override CLEAN_ENV).
+run_fence() {
+    local expect="$1" expect_ledger="$2" cwd="$3" name="$4" cmd="$5"; shift 5
+    rm -f "$LEDGER"
+    local out rc
+    # shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+    out=$( cd "$cwd" && env $CLEAN_ENV "$@" "$BASH_BIN" "$FENCE" "$cmd" 2>&1 ); rc=$?
+    local ledger_lines=0
+    [ -f "$LEDGER" ] && ledger_lines=$(wc -l < "$LEDGER" | tr -d ' ')
+
+    local ok=1
+    if [ "$expect" = allow ]; then
+        [ "$rc" -eq 0 ] || ok=0
+    else
+        [ "$rc" -eq 2 ] || ok=0
+    fi
+    if [ "$expect_ledger" = yes ]; then
+        [ "$ledger_lines" -ge 1 ] || ok=0
+    else
+        [ "$ledger_lines" -eq 0 ] || ok=0
+    fi
+    if [ "$ok" = 1 ]; then
+        pass "$name"
+    else
+        fail "$name (rc=$rc ledger=$ledger_lines) out=$out"
+    fi
+}
+
+echo "== corpus x provider cells (real grammar) =="
+
+# salus + GLM -> hard deny
+run_fence deny no "$HIMMEL" "salus x glm -> deny" \
+    "graphify update $SALUS/notes/patient.md --backend glm"
+
+# salus + ollama WITHOUT opt-in -> deny (conditional cell, flag unset)
+run_fence deny no "$HIMMEL" "salus x ollama no-optin -> deny" \
+    "graphify update $SALUS/notes/patient.md --backend ollama"
+
+# salus + ollama WITH GRAPHIFY_SALUS_LOCAL_OK=1 -> allow + ledger
+run_fence allow yes "$HIMMEL" "salus x ollama opt-in -> allow+ledger" \
+    "graphify update $SALUS/notes/patient.md --backend ollama" GRAPHIFY_SALUS_LOCAL_OK=1
+
+# luna journal (non-Clippings) + GLM -> deny (default deny)
+run_fence deny no "$HIMMEL" "luna-personal x glm -> deny" \
+    "graphify update $LUNA/journal-2026.md --backend glm"
+
+# luna Clippings + GLM WITHOUT opt-in -> deny (conditional cell)
+run_fence deny no "$HIMMEL" "clippings x glm no-optin -> deny" \
+    "graphify update $LUNA/Clippings/clip.md --backend glm"
+
+# luna Clippings + GLM WITH GRAPHIFY_CLIPPINGS_GLM_OK=1 -> allow + ledger
+run_fence allow yes "$HIMMEL" "clippings x glm opt-in -> allow+ledger" \
+    "graphify update $LUNA/Clippings/clip.md --backend glm" GRAPHIFY_CLIPPINGS_GLM_OK=1
+
+# luna personal + deepseek -> allow+log + ledger
+run_fence allow yes "$HIMMEL" "luna-personal x deepseek -> allow+ledger" \
+    "graphify update $LUNA/journal-2026.md --backend deepseek"
+
+# luna personal + openai backend WITH deepseek base url -> allow + ledger
+run_fence allow yes "$HIMMEL" "luna-personal x openai(deepseek-baseurl) -> allow+ledger" \
+    "graphify update $LUNA/journal-2026.md --backend openai" OPENAI_BASE_URL=https://api.deepseek.com/v1
+
+# luna personal + openai WITHOUT deepseek base url -> deny (undeclared provider)
+run_fence deny no "$HIMMEL" "luna-personal x openai(no-baseurl) -> deny" \
+    "graphify update $LUNA/journal-2026.md --backend openai"
+
+# himmel path + declared provider -> allow (no ledger)
+run_fence allow no "$HIMMEL" "himmel-code x deepseek -> allow (no ledger)" \
+    "graphify update $HIMMEL/scripts/thing.sh --backend deepseek"
+
+# egress-denylist root membership -> salus corpus -> deny
+run_fence deny no "$HIMMEL" "denylist-root x deepseek -> salus deny" \
+    "graphify update $DENYROOT/x/leak.md --backend deepseek"
+
+# gemini backend anywhere -> hard deny
+run_fence deny no "$HIMMEL" "himmel x gemini -> hard deny" \
+    "graphify update $HIMMEL/scripts/thing.sh --backend gemini"
+
+echo "== C1: subcommand grammar + cwd-in-himmel reproduction =="
+
+# (1) THE C1 REPRODUCTION: cwd INSIDE the himmel checkout, salus path arg. Old
+# parser took `update` as the target (classified himmel-code via cwd) -> allow.
+# New parser skips the subcommand, classifies the salus path -> deny.
+run_fence deny no "$HIMMEL/scripts" "C1: update salus path w/ cwd-in-himmel -> deny" \
+    "graphify update $SALUS/notes/patient.md --backend=deepseek"
+
+# (15) multi-path merge-graphs: himmel + salus -> most-restrictive salus -> deny
+run_fence deny no "$HIMMEL" "merge-graphs himmel+salus -> most-restrictive deny" \
+    "graphify merge-graphs $HIMMEL/graphify-out/graph.json $SALUS/graphify-out/graph.json --backend deepseek"
+
+# unclassifiable path-like token in an extraction subcommand -> deny
+run_fence deny no "$HIMMEL" "unclassifiable path (extraction) -> deny" \
+    "graphify update $NOWHERE/loose.md --backend deepseek"
+
+# graphify present but no path arg at all + himmel cwd + no cloud key -> cwd class -> allow
+run_fence allow no "$HIMMEL/scripts" "no-path update, cwd-himmel, no key -> allow" \
+    "graphify update --force"
+
+echo "== chained + command-position (fail-open fixes) =="
+
+# (2) chained: first clause allows (himmel), second denies (salus) -> deny overall
+run_fence deny no "$HIMMEL" "chained safe;salus -> deny overall" \
+    "graphify update $HIMMEL/scripts/thing.sh --backend deepseek ; graphify update $SALUS/notes/patient.md --backend glm"
+
+# (3) bash -c wrapped salus invocation -> deny
+run_fence deny no "$HIMMEL" "bash -c salus -> deny" \
+    "bash -c \"graphify update $SALUS/notes/patient.md --backend glm\""
+
+# (4) command-substitution binary `\$(which graphify)` salus -> deny
+run_fence deny no "$HIMMEL" "\$(which graphify) salus -> deny" \
+    "\$(which graphify) update $SALUS/notes/patient.md --backend glm"
+
+# (5) mention negatives -> allow rc 0 (NOT a command-position invocation)
+run_fence allow no "$HIMMEL" "mention: grep graphify -> allow" \
+    "grep graphify $HIMMEL/scripts/thing.sh"
+run_fence allow no "$HIMMEL" "mention: echo graphify -> allow" \
+    "echo \"graphify is cool\""
+
+echo "== HIMMEL-621: command-position wrapper skip =="
+
+# (W1) exec wrapper before graphify -> salus still fenced -> deny
+run_fence deny no "$HIMMEL" "exec graphify salus -> deny" \
+    "exec graphify update $SALUS/notes/patient.md --backend glm"
+
+# (W2) nohup wrapper -> deny
+run_fence deny no "$HIMMEL" "nohup graphify salus -> deny" \
+    "nohup graphify update $SALUS/notes/patient.md --backend glm"
+
+# (W3) timeout with duration arg -> deny
+run_fence deny no "$HIMMEL" "timeout 600 graphify salus -> deny" \
+    "timeout 600 graphify update $SALUS/notes/patient.md --backend glm"
+
+# (W3b) timeout with leading -k 5 flag + duration -> deny
+run_fence deny no "$HIMMEL" "timeout -k 5 600 graphify salus -> deny" \
+    "timeout -k 5 600 graphify update $SALUS/notes/patient.md --backend glm"
+
+# (W4) env -i (options form) -> deny (env -i graphify previously bypassed)
+run_fence deny no "$HIMMEL" "env -i graphify salus -> deny" \
+    "env -i graphify update $SALUS/notes/patient.md --backend glm"
+
+# (W5) sudo wrapper -> deny
+run_fence deny no "$HIMMEL" "sudo graphify salus -> deny" \
+    "sudo graphify update $SALUS/notes/patient.md --backend glm"
+
+# (W6) chained wrappers sudo nohup timeout -> deny
+run_fence deny no "$HIMMEL" "sudo nohup timeout 600 graphify salus -> deny" \
+    "sudo nohup timeout 600 graphify update $SALUS/notes/patient.md --backend glm"
+
+# (W7) BACKSLASH: \graphify seen after _strip_cmd -> deny
+run_fence deny no "$HIMMEL" "backslash \\graphify salus -> deny" \
+    "\graphify update $SALUS/notes/patient.md --backend glm"
+
+echo "== HIMMEL-621: xargs / find -exec fail-closed deny =="
+
+# (X1) graphify as xargs command -> deny outright (not statically fenceable)
+run_fence deny no "$HIMMEL" "xargs graphify -> deny" \
+    "echo $SALUS/notes/patient.md | xargs graphify update --backend glm"
+
+# (X2) graphify as find -exec target -> deny outright
+run_fence deny no "$HIMMEL" "find -exec graphify -> deny" \
+    "find . -name \"*.md\" -exec graphify update {} --backend glm ;"
+
+# (X3) NEGATIVE: `find . -name graphify` is a mention, not an -exec invocation -> allow
+run_fence allow no "$HIMMEL" "find -name graphify (mention) -> allow" \
+    "find . -name graphify"
+
+echo "== HIMMEL-621: position-0 path + unconditional unclassifiable-deny =="
+
+# (P1) POSITION-0 PATH: first positional is a salus path (no subcommand) -> classified -> deny
+run_fence deny no "$HIMMEL" "position-0 salus path (no subcmd) -> deny" \
+    "graphify $SALUS/notes/patient.md --backend glm"
+
+# (U1) unclassifiable path under a NON-extraction subcommand (export) -> deny
+run_fence deny no "$HIMMEL" "export unclassifiable path -> deny" \
+    "graphify export $NOWHERE/x.md --backend glm"
+
+# (U2) query (non-extraction) with a classifiable himmel path AND an unclassifiable path -> deny
+run_fence deny no "$HIMMEL" "query himmel + unclassifiable path -> deny" \
+    "graphify query $HIMMEL/scripts/thing.sh $NOWHERE/loose.md --backend glm"
+
+echo "== fail-closed infra (ledger / trap / node / phi-roots) =="
+
+# (6) unwritable ledger on an allow+log cell -> deny + no partial ledger line.
+# GRAPHIFY_LEDGER parent is a regular file so mkdir -p fails.
+: > "$WS/ledblocker"
+run_fence deny no "$HIMMEL" "unwritable ledger allow+log -> deny, no partial line" \
+    "graphify update $LUNA/journal-2026.md --backend deepseek" GRAPHIFY_LEDGER="$WS/ledblocker/led.jsonl"
+
+# (7) abnormal-exit trap: HOME unset -> $HOME expansion aborts under set -u -> trap -> rc 2
+out=$( cd "$HIMMEL" && env -u HOME -u CLAUDE_GLM_CONFIG_DIR "$BASH_BIN" "$FENCE" "graphify update $HIMMEL/scripts/thing.sh --backend deepseek" 2>&1 ); rc=$?
+if [ "$rc" -eq 2 ]; then pass "trap: HOME unset -> rc 2"; else fail "trap: HOME unset expected rc=2 got rc=$rc out=$out"; fi
+
+# (8) node absent (PATH stripped to /usr/bin, which has coreutils but not node) -> rc 2
+run_fence deny no "$HIMMEL" "node absent -> rc 2 (fail-closed)" \
+    "graphify update $HIMMEL/scripts/thing.sh --backend deepseek" PATH=/usr/bin
+
+# (9) unreadable phi-roots (a directory sits at the phi-roots path) -> rc 2
+run_fence deny no "$HIMMEL" "unreadable phi-roots -> rc 2" \
+    "graphify update $HIMMEL/scripts/thing.sh --backend deepseek" CLAUDE_GLM_CONFIG_DIR="$PHI_BADROOTS"
+
+echo "== normalization + backend-detect + provider mapping =="
+
+# (10a) .. traversal escaping into salus -> deny
+run_fence deny no "$LUNA" ".. traversal Clippings/../../salus -> deny" \
+    "graphify update Clippings/../../salusvault/notes/patient.md --backend deepseek"
+
+# (10b) .. traversal escaping Clippings into luna-personal -> deny even with clippings opt-in
+run_fence deny no "$LUNA" ".. traversal out of Clippings -> deny (opt-in cannot save it)" \
+    "graphify update Clippings/../journal-2026.md --backend glm" GRAPHIFY_CLIPPINGS_GLM_OK=1
+
+# (11) uppercase --backend GLM is lower-cased -> zai-glm -> luna-personal deny
+run_fence deny no "$HIMMEL" "uppercase --backend GLM -> deny" \
+    "graphify update $LUNA/journal-2026.md --backend GLM"
+
+# (12a) no --backend + himmel path -> local-ollama -> allow (corpus rule, HIMMEL-621)
+run_fence allow no "$HIMMEL" "no-backend himmel -> allow (local-ollama)" \
+    "graphify update $HIMMEL/scripts/thing.sh"
+
+# (12b) no --backend + luna path -> deny REGARDLESS of env keys (cloud key set here)
+run_fence deny no "$HIMMEL" "no-backend luna (w/ cloud key) -> deny (corpus rule)" \
+    "graphify update $LUNA/journal-2026.md" DEEPSEEK_API_KEY=sk-test
+
+# (12c) no --backend + himmel path + cloud key -> allow (key no longer flips the verdict)
+run_fence allow no "$HIMMEL" "no-backend himmel + cloud key -> allow (key irrelevant now)" \
+    "graphify update $HIMMEL/scripts/thing.sh" DEEPSEEK_API_KEY=sk-test
+
+# (13) OLLAMA_HOST off-box + --backend ollama + luna path -> undeclared provider deny
+run_fence deny no "$HIMMEL" "OLLAMA_HOST remote + ollama -> deny" \
+    "graphify update $LUNA/journal-2026.md --backend ollama" OLLAMA_HOST=remote:11434
+
+echo "== query (no path arg -> cwd classification) =="
+
+# (14a) query with cwd in himmel + no cloud key -> cwd himmel-code x local-ollama -> allow
+run_fence allow no "$HIMMEL/scripts" "query cwd-himmel no-key -> allow" \
+    "graphify query \"where is the entrypoint\""
+
+# (14b) query with cwd in luna-personal + --backend glm -> luna-personal x zai-glm -> deny
+run_fence deny no "$LUNA" "query cwd-luna glm -> deny" \
+    "graphify query \"what is in my journal\" --backend glm"
+
+echo "== hook-level: parse + delegation + malformed-json fallback =="
+
+# non-graphify Bash command -> hook exits 0 instantly
+out=$(printf '%s' '{"tool_name":"Bash","tool_input":{"command":"echo hello world"}}' | "$BASH_BIN" "$HOOK" 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then pass "hook: non-graphify -> exit 0"; else fail "hook: non-graphify expected rc=0 got rc=$rc out=$out"; fi
+
+# non-Bash tool -> hook exits 0
+out=$(printf '%s' '{"tool_name":"Read","tool_input":{"file_path":"/x"}}' | "$BASH_BIN" "$HOOK" 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then pass "hook: non-Bash tool -> exit 0"; else fail "hook: non-Bash expected rc=0 got rc=$rc out=$out"; fi
+
+# graphify salus deny delegated through the hook -> rc 2
+rm -f "$LEDGER"
+payload=$(printf '{"tool_name":"Bash","tool_input":{"command":"graphify update %s --backend glm"}}' "$SALUS/notes/patient.md")
+out=$(printf '%s' "$payload" | env HOME="$HOME" LUNA_VAULT_PATH="$LUNA" HANDOVER_DIR="$HANDDIR" CLAUDE_GLM_CONFIG_DIR="$PHI" GRAPHIFY_HIMMEL_ROOT="$HIMMEL" "$BASH_BIN" "$HOOK" 2>&1); rc=$?
+if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qi "DENY"; then pass "hook: graphify salus -> delegated deny rc=2"; else fail "hook: expected rc=2 + DENY got rc=$rc out=$out"; fi
+
+# graphify allow (himmel) delegated through the hook -> rc 0
+payload=$(printf '{"tool_name":"Bash","tool_input":{"command":"graphify update %s --backend deepseek"}}' "$HIMMEL/scripts/thing.sh")
+out=$(printf '%s' "$payload" | env HOME="$HOME" LUNA_VAULT_PATH="$LUNA" HANDOVER_DIR="$HANDDIR" CLAUDE_GLM_CONFIG_DIR="$PHI" GRAPHIFY_HIMMEL_ROOT="$HIMMEL" "$BASH_BIN" "$HOOK" 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then pass "hook: graphify himmel -> delegated allow rc=0"; else fail "hook: expected rc=0 got rc=$rc out=$out"; fi
+
+# (16) malformed hook JSON that mentions a graphify command + jq present -> deny
+out=$(printf '%s' '{"tool_name":"Bash","tool_input":{"command":"graphify update /x --backend glm"' | env HOME="$HOME" "$BASH_BIN" "$HOOK" 2>&1); rc=$?
+if [ "$rc" -eq 2 ]; then pass "hook: malformed JSON + graphify -> deny rc=2"; else fail "hook: malformed JSON expected rc=2 got rc=$rc out=$out"; fi
+
+# malformed hook JSON WITHOUT graphify -> allow (never block unrelated on bad payload)
+out=$(printf '%s' '{"tool_name":"Bash","tool_input":{"command":"echo hi"' | env HOME="$HOME" "$BASH_BIN" "$HOOK" 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then pass "hook: malformed JSON no-graphify -> allow rc=0"; else fail "hook: malformed no-graphify expected rc=0 got rc=$rc out=$out"; fi
+
+echo "== ledger line CONTENT (verdict + corpus fields) =="
+
+# allow+log: luna-personal x deepseek -> ledger line carries verdict + corpus
+rm -f "$LEDGER"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$HIMMEL" && env $CLEAN_ENV "$BASH_BIN" "$FENCE" "graphify update $LUNA/journal-2026.md --backend deepseek" ) >/dev/null 2>&1
+if grep -q '"verdict":"allow+log"' "$LEDGER" 2>/dev/null && grep -q '"corpus":"luna-personal"' "$LEDGER" 2>/dev/null; then
+    pass "ledger content: allow+log verdict + luna-personal corpus"
+else
+    fail "ledger content allow+log: got $(cat "$LEDGER" 2>/dev/null)"
+fi
+
+# conditional: clippings x glm opt-in -> ledger line carries conditional + luna-clippings
+rm -f "$LEDGER"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$HIMMEL" && env $CLEAN_ENV GRAPHIFY_CLIPPINGS_GLM_OK=1 "$BASH_BIN" "$FENCE" "graphify update $LUNA/Clippings/clip.md --backend glm" ) >/dev/null 2>&1
+if grep -q '"verdict":"conditional"' "$LEDGER" 2>/dev/null && grep -q '"corpus":"luna-clippings"' "$LEDGER" 2>/dev/null; then
+    pass "ledger content: conditional verdict + luna-clippings corpus"
+else
+    fail "ledger content conditional: got $(cat "$LEDGER" 2>/dev/null)"
+fi
+
+echo "== egress-matrix-eval.mjs unit =="
+
+# pending-operator cell -> verdict deny
+v=$(node "$EVAL_HELPER" luna-clippings alibaba embedding 2>/dev/null | cut -f1)
+if [ "$v" = deny ]; then pass "eval: pending-operator -> deny"; else fail "eval: pending-operator expected deny got '$v'"; fi
+
+# no rule match -> default (deny)
+v=$(node "$EVAL_HELPER" no-such-corpus no-such-provider extraction 2>/dev/null | cut -f1)
+if [ "$v" = deny ]; then pass "eval: default -> deny"; else fail "eval: default expected deny got '$v'"; fi
+
+# bad args -> exit 2
+node "$EVAL_HELPER" onlyone >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ]; then pass "eval: bad args -> exit 2"; else fail "eval: bad args expected exit 2 got rc=$rc"; fi
+
+# --- redirection tokens are I/O plumbing, never classified (final round) ---
+run_fence allow no "$HIMMEL" "redirect: attached >/tmp/out -> not classified, allow" \
+    "graphify update $HIMMEL/doc.md --backend deepseek >/tmp/redir-out.log"
+run_fence allow no "$HIMMEL" "redirect: standalone > target skipped -> allow" \
+    "graphify update $HIMMEL/doc.md --backend deepseek > /tmp/redir-out.log"
+run_fence deny no "$HIMMEL" "redirect: 2>/dev/null on salus target still denies" \
+    "graphify update $SALUS/notes/patient.md --backend glm 2>/dev/null"
+
+if [ "$failures" -eq 0 ]; then
+    echo "OK: all cases passed"
+    exit 0
+else
+    echo "FAIL: $failures case(s) failed"
+    exit 1
+fi

--- a/scripts/hooks/block-graphify-egress.sh
+++ b/scripts/hooks/block-graphify-egress.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# PreToolUse hook (Bash|PowerShell) - NARROW data-egress fence for `graphify`
+# (HIMMEL-621/622 Phase G-F). Fast-exits 0 for every command that is not a
+# graphify invocation; for a graphify command it delegates the corpus x
+# provider x purpose decision to scripts/guardrails/graphify-fence.sh and
+# propagates its verdict (fence exit 2 = deny, surfaced to Claude via stderr).
+#
+# Hook I/O contract (mirrors block-read-secrets.sh): input is JSON on stdin.
+#   exit 0 - allow (default)
+#   exit 2 - block; stderr is shown to Claude and the user
+#
+# The egress policy + all fail-closed logic live in the fence; this hook only
+# does the stdin parse + the word-boundary graphify gate.
+set -uo pipefail
+
+# Raw-substring fallback for input we cannot structurally parse (jq missing, or
+# malformed JSON). Stay NARROW: fail closed only when the payload mentions
+# graphify; otherwise allow (never block unrelated Bash on an unparseable input).
+_raw_decide() {
+    case "$1" in
+        *graphify*)
+            echo "block-graphify-egress: unparseable tool input mentions graphify; refusing (fail-closed). Install jq / fix the payload or comment the hook." >&2
+            exit 2
+            ;;
+        *) exit 0 ;;
+    esac
+}
+
+input=$(cat)
+
+if ! command -v jq >/dev/null 2>&1; then
+    _raw_decide "$input"
+fi
+
+# jq present but the JSON is malformed -> same raw-substring fallback (a graphify
+# mention in an unparseable payload fails closed rather than sailing through).
+if ! printf '%s' "$input" | jq empty >/dev/null 2>&1; then
+    _raw_decide "$input"
+fi
+
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)
+case "$tool" in
+    Bash|PowerShell) ;;
+    *) exit 0 ;;
+esac
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+[ -n "$cmd" ] || exit 0
+
+# Word-boundary `graphify` match (a path-invoked `.../graphify` still matches;
+# `mygraphify` / `graphifyx` do not). Pad so leading/trailing boundaries work.
+case " $cmd " in
+    *[!A-Za-z0-9_]graphify[!A-Za-z0-9_]*) ;;
+    *) exit 0 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FENCE="$SCRIPT_DIR/../guardrails/graphify-fence.sh"
+[ -f "$FENCE" ] || exit 0   # fence not installed -> do not block
+
+exec bash "$FENCE" "$cmd"


### PR DESCRIPTION
Narrow PreToolUse fence: parses real graphify invocations (wrapper skip, chained clauses, command-position matching), classifies every path token most-restrictive-wins on the shared guard primitives, and delegates verdicts to the owned egress matrix (no policy of its own). Fail-closed on every error path (EXIT trap, ledger-failure deny, unclassifiable deny, no-backend deny outside repo code). 62 hermetic tests; documented accepted limitations in the header.

Propagated from private #988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)