### PR TITLE
fix(luna-vitals): Google Health pull - pageSize + fail-closed early-stop pagination

### DIFF
--- a/scripts/luna-vitals/connectors/fetch/dataType.test.ts
+++ b/scripts/luna-vitals/connectors/fetch/dataType.test.ts
@@ -126,6 +126,439 @@ describe('fetchDataPoints', () => {
   });
 });
 
+// ── early-stop pagination ────────────────────────────────────────────────────
+
+describe('fetchDataPoints early-stop', () => {
+  const byDate = (p: any) => p.date as string | undefined;
+  const stop = (windowFrom: string) => ({ windowFrom, pointDate: byDate });
+
+  test('pageSize=1000 is sent on every page', async () => {
+    const { impl, calls } = makePagedFetch([
+      { dataPoints: [{ date: '2026-07-08' }], nextPageToken: 'p2' },
+      { dataPoints: [{ date: '2026-07-07' }] },
+    ]);
+
+    await fetchDataPoints(
+      { dataTypeId: 'steps', accessToken: 'tok', baseUrl: 'https://fake.api/v4' },
+      impl,
+    );
+
+    expect(calls[0].url).toContain('pageSize=1000');
+    expect(calls[1].url).toContain('pageSize=1000');
+  });
+
+  test('descending pages: arms when oldest clears the slacked threshold, breaks on the confirming page', async () => {
+    const { impl, calls } = makePagedFetch([
+      // page 1: newest-first, oldest (07-04) below windowFrom 07-07 minus the
+      // 2-day slack (< 07-05) → ARM
+      { dataPoints: [{ date: '2026-07-08' }, { date: '2026-07-04' }], nextPageToken: 'p2' },
+      // page 2: ordered, boundary-consistent, fully below threshold → CONFIRM + break
+      { dataPoints: [{ date: '2026-07-03' }, { date: '2026-07-02' }], nextPageToken: 'p3' },
+      // never reached
+      { dataPoints: [{ date: '2026-07-01' }], nextPageToken: 'p4' },
+    ]);
+
+    const result = await fetchDataPoints(
+      {
+        dataTypeId: 'heart-rate',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(2); // stopped despite page 2's nextPageToken
+    expect(result).toHaveLength(4); // both fetched pages collected
+  });
+
+  test('descending pages still inside the window: keeps paging', async () => {
+    const { impl, calls } = makePagedFetch([
+      { dataPoints: [{ date: '2026-07-08' }, { date: '2026-07-07' }], nextPageToken: 'p2' },
+      { dataPoints: [{ date: '2026-07-06' }, { date: '2026-07-05' }] },
+    ]);
+
+    const result = await fetchDataPoints(
+      {
+        dataTypeId: 'heart-rate',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(result).toHaveLength(4);
+  });
+
+  test('pages inside the 2-day offset-jitter slack keep paging (no stop near the window edge)', async () => {
+    const { impl, calls } = makePagedFetch([
+      // Everything below windowFrom (07-07) but NOT below the slacked
+      // threshold (07-05): offset jitter could still hide in-window points,
+      // so no arm — full paging.
+      { dataPoints: [{ date: '2026-07-08' }, { date: '2026-07-06' }], nextPageToken: 'p2' },
+      { dataPoints: [{ date: '2026-07-06' }, { date: '2026-07-05' }], nextPageToken: 'p3' },
+      { dataPoints: [{ date: '2026-07-05' }] },
+    ]);
+
+    const result = await fetchDataPoints(
+      {
+        dataTypeId: 'heart-rate',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(3);
+    expect(result).toHaveLength(5);
+  });
+
+  test('oldest point exactly equal to windowFrom does not arm (boundary day is in-window)', async () => {
+    const { impl, calls } = makePagedFetch([
+      { dataPoints: [{ date: '2026-07-08' }, { date: '2026-07-07' }], nextPageToken: 'p2' },
+      { dataPoints: [{ date: '2026-07-06' }, { date: '2026-07-05' }], nextPageToken: 'p3' },
+      { dataPoints: [{ date: '2026-07-04' }] },
+    ]);
+
+    const result = await fetchDataPoints(
+      {
+        dataTypeId: 'heart-rate',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    // page 1 oldest == windowFrom → no arm; page 2 arms; page 3 confirms via
+    // natural end (no nextPageToken).
+    expect(calls).toHaveLength(3);
+    expect(result).toHaveLength(5);
+  });
+
+  test('ascending page order disables early-stop for the whole fetch (order guard)', async () => {
+    const { impl, calls } = makePagedFetch([
+      // ascending: violates newest-first — early-stop permanently distrusted
+      { dataPoints: [{ date: '2026-07-01' }, { date: '2026-07-02' }], nextPageToken: 'p2' },
+      { dataPoints: [{ date: '2026-07-03' }, { date: '2026-07-08' }] },
+    ]);
+
+    const result = await fetchDataPoints(
+      {
+        dataTypeId: 'steps',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(result).toHaveLength(4);
+  });
+
+  test('mixed-order page never arms even when endpoints look descending', async () => {
+    const { impl, calls } = makePagedFetch([
+      // endpoints descend (07-08 >= 07-01) but the middle breaks monotonicity
+      {
+        dataPoints: [{ date: '2026-07-08' }, { date: '2026-07-01' }, { date: '2026-07-05' }, { date: '2026-07-01' }],
+        nextPageToken: 'p2',
+      },
+      { dataPoints: [{ date: '2026-07-07' }] },
+    ]);
+
+    const result = await fetchDataPoints(
+      {
+        dataTypeId: 'heart-rate',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(2); // must NOT stop on the mixed page
+    expect(result).toHaveLength(5);
+  });
+
+  test('cross-page boundary violation fails closed to full paging', async () => {
+    const { impl, calls } = makePagedFetch([
+      // page 1 arms (oldest 07-04 < 07-07)…
+      { dataPoints: [{ date: '2026-07-05' }, { date: '2026-07-04' }], nextPageToken: 'p2' },
+      // …but page 2's newest (07-08) exceeds page 1's oldest — global order
+      // broken → distrust, keep paging (page 2 holds in-window 07-07!)
+      { dataPoints: [{ date: '2026-07-08' }, { date: '2026-07-07' }], nextPageToken: 'p3' },
+      { dataPoints: [{ date: '2026-07-03' }] },
+    ]);
+
+    const result = await fetchDataPoints(
+      {
+        dataTypeId: 'heart-rate',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(3); // all pages fetched — no data dropped
+    expect(result).toHaveLength(5);
+  });
+
+  test('tie-only pre-window pages never arm — no strict decrease means no direction evidence', async () => {
+    const { impl, calls } = makePagedFetch([
+      // Two full pages of ONE repeated old date: non-increasing and
+      // boundary-consistent, but direction-neutral — on an ascending feed
+      // these could precede in-window data. Must NOT arm/confirm.
+      { dataPoints: [{ date: '2026-07-05' }, { date: '2026-07-05' }], nextPageToken: 'p2' },
+      { dataPoints: [{ date: '2026-07-05' }, { date: '2026-07-05' }], nextPageToken: 'p3' },
+      // ascending feed reveals in-window data later (boundary violation here)
+      { dataPoints: [{ date: '2026-07-08' }, { date: '2026-07-07' }], nextPageToken: 'p4' },
+      { dataPoints: [{ date: '2026-06-30' }] },
+    ]);
+
+    const result = await fetchDataPoints(
+      {
+        dataTypeId: 'heart-rate',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(4); // all pages fetched — the 07-07/07-08 rows survive
+    expect(result).toHaveLength(7);
+  });
+
+  test('strict cross-page decrease proves direction — ties alone within pages can then arm', async () => {
+    const { impl, calls } = makePagedFetch([
+      // page 1: tie-only (no proof yet, no arm)
+      { dataPoints: [{ date: '2026-07-05' }, { date: '2026-07-05' }], nextPageToken: 'p2' },
+      // page 2: newest 07-04 < page 1's oldest 07-05 — STRICT cross-page
+      // decrease proves descending; page is pre-window → arm
+      { dataPoints: [{ date: '2026-07-04' }, { date: '2026-07-04' }], nextPageToken: 'p3' },
+      // page 3: confirm → break
+      { dataPoints: [{ date: '2026-07-03' }, { date: '2026-07-03' }], nextPageToken: 'p4' },
+      // never reached
+      { dataPoints: [{ date: '2026-07-02' }], nextPageToken: 'p5' },
+    ]);
+
+    const result = await fetchDataPoints(
+      {
+        dataTypeId: 'heart-rate',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(3);
+    expect(result).toHaveLength(6);
+  });
+
+  test('tied adjacent dates count as non-increasing (arm + confirm still fire)', async () => {
+    const { impl, calls } = makePagedFetch([
+      { dataPoints: [{ date: '2026-07-08' }, { date: '2026-07-08' }, { date: '2026-07-04' }], nextPageToken: 'p2' },
+      { dataPoints: [{ date: '2026-07-03' }, { date: '2026-07-03' }], nextPageToken: 'p3' },
+      { dataPoints: [{ date: '2026-07-02' }] },
+    ]);
+
+    const result = await fetchDataPoints(
+      {
+        dataTypeId: 'heart-rate',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(2); // page 2 confirms the stop
+    expect(result).toHaveLength(5);
+  });
+
+  test('single-point page never CONFIRMS a stop — armed state persists to the next 2-point page', async () => {
+    const { impl, calls } = makePagedFetch([
+      // page 1 arms (oldest 07-04 clears the slacked threshold 07-05)
+      { dataPoints: [{ date: '2026-07-08' }, { date: '2026-07-04' }], nextPageToken: 'p2' },
+      // page 2: single below-threshold point — direction-blind, must NOT confirm
+      { dataPoints: [{ date: '2026-07-03' }], nextPageToken: 'p3' },
+      // page 3: 2-point verified below-threshold page — NOW the stop confirms
+      { dataPoints: [{ date: '2026-07-02' }, { date: '2026-07-01' }], nextPageToken: 'p4' },
+      // never reached
+      { dataPoints: [{ date: '2026-06-30' }], nextPageToken: 'p5' },
+    ]);
+
+    const result = await fetchDataPoints(
+      {
+        dataTypeId: 'heart-rate',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(3); // p2 (single) fetched, p3 confirms, p4 never
+    expect(result).toHaveLength(5);
+  });
+
+  test('disorder revealed after a single-point page still fails closed (no data dropped)', async () => {
+    const { impl, calls } = makePagedFetch([
+      // page 1 arms (oldest 07-04 clears the slacked threshold 07-05)
+      { dataPoints: [{ date: '2026-07-08' }, { date: '2026-07-04' }], nextPageToken: 'p2' },
+      // page 2: single old point — stays armed, does not confirm
+      { dataPoints: [{ date: '2026-07-03' }], nextPageToken: 'p3' },
+      // page 3: newest 07-07 exceeds page 2's oldest (07-03) — boundary
+      // violation reveals IN-WINDOW data → distrust, full paging
+      { dataPoints: [{ date: '2026-07-07' }, { date: '2026-07-01' }], nextPageToken: 'p4' },
+      { dataPoints: [{ date: '2026-06-30' }] },
+    ]);
+
+    const result = await fetchDataPoints(
+      {
+        dataTypeId: 'heart-rate',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(4); // all pages fetched — the 07-07 row survives
+    expect(result).toHaveLength(6);
+  });
+
+  test('single-point page never arms (cannot establish ordering direction)', async () => {
+    const { impl, calls } = makePagedFetch([
+      { dataPoints: [{ date: '2026-07-01' }], nextPageToken: 'p2' },
+      { dataPoints: [{ date: '2026-06-30' }] },
+    ]);
+
+    const result = await fetchDataPoints(
+      {
+        dataTypeId: 'steps',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(2); // lone pre-window point must not stop paging
+    expect(result).toHaveLength(2);
+  });
+
+  test('page with one unparseable date among parseable ones: keeps paging', async () => {
+    const { impl, calls } = makePagedFetch([
+      { dataPoints: [{ date: '2026-07-06' }, { bogus: true }, { date: '2026-07-05' }], nextPageToken: 'p2' },
+      { dataPoints: [{ date: '2026-07-04' }] },
+    ]);
+
+    await fetchDataPoints(
+      {
+        dataTypeId: 'steps',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(2); // unverifiable page → no early-stop
+  });
+
+  test('fully unparseable page: keeps paging (no early-stop)', async () => {
+    const { impl, calls } = makePagedFetch([
+      { dataPoints: [{ bogus: true }, { bogus: true }], nextPageToken: 'p2' },
+      { dataPoints: [{ date: '2026-07-08' }] },
+    ]);
+
+    await fetchDataPoints(
+      {
+        dataTypeId: 'steps',
+        accessToken: 'tok',
+        baseUrl: 'https://fake.api/v4',
+        earlyStop: stop('2026-07-07'),
+      },
+      impl,
+    );
+
+    expect(calls).toHaveLength(2);
+  });
+
+  test('no earlyStop: legacy full paging (backward compatible)', async () => {
+    const { impl, calls } = makePagedFetch([
+      { dataPoints: [{ date: '2026-07-08' }, { date: '2026-07-06' }], nextPageToken: 'p2' },
+      { dataPoints: [{ date: '2026-07-05' }] },
+    ]);
+
+    const result = await fetchDataPoints(
+      { dataTypeId: 'steps', accessToken: 'tok', baseUrl: 'https://fake.api/v4' },
+      impl,
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(result).toHaveLength(3);
+  });
+
+  test('GOOGLE_HEALTH_PAGE_CAP env override raises the cap', async () => {
+    const prev = process.env.GOOGLE_HEALTH_PAGE_CAP;
+    process.env.GOOGLE_HEALTH_PAGE_CAP = '3';
+    try {
+      let caught: unknown;
+      let pages = 0;
+      const countingInfinite = async (_url: string, _init?: RequestInit) => {
+        pages++;
+        return {
+          ok: true as const,
+          status: 200,
+          json: async () => ({ dataPoints: [], nextPageToken: 'more' }),
+        };
+      };
+      try {
+        await fetchDataPoints(
+          { dataTypeId: 'steps', accessToken: 'tok', baseUrl: 'https://fake.api/v4' },
+          countingInfinite,
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toContain('(3)');
+      expect(pages).toBe(3);
+    } finally {
+      if (prev === undefined) delete process.env.GOOGLE_HEALTH_PAGE_CAP;
+      else process.env.GOOGLE_HEALTH_PAGE_CAP = prev;
+    }
+  });
+
+  test('invalid GOOGLE_HEALTH_PAGE_CAP falls back to the default cap (100)', async () => {
+    const prev = process.env.GOOGLE_HEALTH_PAGE_CAP;
+    process.env.GOOGLE_HEALTH_PAGE_CAP = 'abc';
+    try {
+      let caught: unknown;
+      try {
+        await fetchDataPoints(
+          { dataTypeId: 'steps', accessToken: 'tok', baseUrl: 'https://fake.api/v4' },
+          makeInfiniteFetch(),
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toContain('(100)');
+    } finally {
+      if (prev === undefined) delete process.env.GOOGLE_HEALTH_PAGE_CAP;
+      else process.env.GOOGLE_HEALTH_PAGE_CAP = prev;
+    }
+  });
+});
 // ── filterByDateWindow ───────────────────────────────────────────────────────
 
 describe('filterByDateWindow', () => {

--- a/scripts/luna-vitals/connectors/fetch/dataType.ts
+++ b/scripts/luna-vitals/connectors/fetch/dataType.ts
@@ -1,5 +1,30 @@
 const BASE_URL = 'https://health.googleapis.com/v4';
+// Default 100; GOOGLE_HEALTH_PAGE_CAP overrides for full-history backfills.
 const PAGE_CAP = 100;
+// API default is 50; 1000 is the verified maximum (probed live 2026-07-08).
+const PAGE_SIZE = 1000;
+
+function pageCap(): number {
+  const env = Number(process.env.GOOGLE_HEALTH_PAGE_CAP);
+  return Number.isFinite(env) && env > 0 ? env : PAGE_CAP;
+}
+
+/** Extract the civil date (YYYY-MM-DD) of one raw dataPoint; undefined if unparseable. */
+export type PointDate = (point: unknown) => string | undefined;
+
+// Early-stop slack in days. pointDate yields LOCAL civil dates while the
+// API's (observed) newest-first order is presumably keyed on raw timestamps;
+// mixed UTC offsets can skew local dates vs raw order by up to ~26h
+// (-12h..+14h). Stopping only once pages are this many days BEFORE the
+// window start makes offset jitter unable to hide an in-window point.
+const EARLY_STOP_SLACK_DAYS = 2;
+
+/** ISO date (YYYY-MM-DD) minus N days, in pure UTC date math. */
+function isoMinusDays(iso: string, days: number): string {
+  const d = new Date(Date.parse(`${iso}T00:00:00Z`) - days * 86_400_000);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+}
 
 type FetchLike = (
   url: string,
@@ -12,6 +37,12 @@ export async function fetchDataPoints(
     method?: 'list' | 'dailyRollUp';
     accessToken: string;
     baseUrl?: string;
+    /**
+     * Enables early-stop paging (see fetchList). windowFrom is the window
+     * start (YYYY-MM-DD); pointDate extracts one point's civil date. They are
+     * one object because neither means anything without the other.
+     */
+    earlyStop?: { windowFrom: string; pointDate: PointDate };
   },
   fetchImpl: FetchLike = fetch as unknown as FetchLike,
 ): Promise<any[]> {
@@ -20,18 +51,81 @@ export async function fetchDataPoints(
   if (args.method === 'dailyRollUp') {
     return fetchDailyRollUp(args.dataTypeId, args.accessToken, base, fetchImpl);
   }
-  return fetchList(args.dataTypeId, args.accessToken, base, fetchImpl);
+  return fetchList(args, base, fetchImpl);
 }
 
+/**
+ * Scan one page: verify every point has a parseable date and the page is
+ * non-increasing (newest-first). On success, newest/oldest are the page's
+ * first/last dates.
+ */
+function scanDescending(
+  points: unknown[],
+  pointDate: PointDate,
+): { ok: boolean; newest?: string; oldest?: string; strictDecrease?: boolean } {
+  let prev: string | undefined;
+  let newest: string | undefined;
+  let strictDecrease = false;
+  for (const p of points) {
+    const d = pointDate(p);
+    if (!d || (prev !== undefined && d > prev)) return { ok: false };
+    if (prev !== undefined && d < prev) strictDecrease = true;
+    if (newest === undefined) newest = d;
+    prev = d;
+  }
+  return { ok: true, newest, oldest: prev, strictDecrease };
+}
+
+/**
+ * Page through a list dataType.
+ *
+ * Early stop: the API returns points newest-first (verified live 2026-07-08).
+ * Once pages fall entirely before earlyStop.windowFrom, later pages are older
+ * still — stop paging. The ordering is a live observation, NOT a documented
+ * contract, and a false stop silently drops in-window data, so every
+ * detectable violation fails closed to full paging:
+ *   - every point on a page must have a parseable date and the page must be
+ *     non-increasing, or early-stop is disabled for the rest of this fetch;
+ *   - each page's newest date must not exceed the previous page's oldest
+ *     (cross-page boundary), or early-stop is disabled likewise;
+ *   - a stop only ARMS when a verified page (>= 2 points) ends before
+ *     windowFrom minus a 2-day offset-jitter slack (local civil dates can
+ *     skew ~26h against the presumed raw-timestamp page order); the actual
+ *     break requires the NEXT page to confirm — also verified-ordered,
+ *     boundary-consistent, and fully below the slacked threshold;
+ *   - tied dates are direction-neutral: arming additionally requires one
+ *     STRICT date decrease seen in or across pages (directionProven).
+ * Undetectable disorder (in-window data hidden beyond two verified-ordered,
+ * pre-window pages) would defeat any client short of full-history paging,
+ * which is the structural failure this early-stop exists to fix (HIMMEL-771).
+ */
 async function fetchList(
-  dataTypeId: string,
-  accessToken: string,
+  args: {
+    dataTypeId: string;
+    accessToken: string;
+    earlyStop?: { windowFrom: string; pointDate: PointDate };
+  },
   base: string,
   fetchImpl: FetchLike,
 ): Promise<any[]> {
+  const { dataTypeId, accessToken, earlyStop } = args;
   const allPoints: any[] = [];
   let pageToken: string | undefined;
   let pages = 0;
+  const cap = pageCap();
+
+  let orderTrusted = true; // false = a violation was seen; early-stop disabled
+  let stopArmed = false; // previous page ended pre-window; this page must confirm
+  let prevPageOldest: string | undefined;
+  // Stop threshold: windowFrom minus the offset-jitter slack (see above).
+  const stopBefore = earlyStop
+    ? isoMinusDays(earlyStop.windowFrom, EARLY_STOP_SLACK_DAYS)
+    : '';
+  // Tied dates are non-increasing but direction-NEUTRAL: pages of one repeated
+  // date would pass every monotonic/boundary check even on an ascending feed.
+  // A stop may only arm after at least one STRICT decrease has proven the
+  // feed's direction (within a page, or strictly across a page boundary).
+  let directionProven = false;
 
   const headers = {
     Authorization: `Bearer ${accessToken}`,
@@ -39,13 +133,14 @@ async function fetchList(
   };
 
   while (true) {
-    if (pages >= PAGE_CAP) {
+    if (pages >= cap) {
       throw new Error(
-        `fetchDataPoints: page cap (${PAGE_CAP}) hit for dataTypeId "${dataTypeId}" — possible infinite pagination`,
+        `fetchDataPoints: page cap (${cap}) hit for dataTypeId "${dataTypeId}" — possible infinite pagination`,
       );
     }
 
     const url = new URL(`${base}/users/me/dataTypes/${dataTypeId}/dataPoints`);
+    url.searchParams.set('pageSize', String(PAGE_SIZE));
     if (pageToken) {
       url.searchParams.set('pageToken', pageToken);
     }
@@ -58,9 +153,46 @@ async function fetchList(
     }
 
     const data = (await resp.json()) as { dataPoints?: any[]; nextPageToken?: string };
-    allPoints.push(...(data.dataPoints ?? []));
+    const pagePoints = data.dataPoints ?? [];
+    allPoints.push(...pagePoints);
 
     if (!data.nextPageToken) break;
+
+    if (earlyStop && orderTrusted && pagePoints.length > 0) {
+      const scan = scanDescending(pagePoints, earlyStop.pointDate);
+      const boundaryOk =
+        scan.ok && (prevPageOldest === undefined || scan.newest! <= prevPageOldest);
+
+      if (!scan.ok || !boundaryOk) {
+        // Detected disorder — fail closed: no early-stop for this fetch.
+        orderTrusted = false;
+        stopArmed = false;
+      } else {
+        if (
+          scan.strictDecrease ||
+          (prevPageOldest !== undefined && scan.newest! < prevPageOldest)
+        ) {
+          directionProven = true;
+        }
+        if (pagePoints.length >= 2) {
+          // Only a page with >= 2 points can carry ordering evidence — the
+          // same threshold for arming AND confirming.
+          if (stopArmed && scan.newest! < stopBefore) {
+            // Look-ahead confirmation: this page is verified-ordered,
+            // boundary-consistent, and entirely below the slacked threshold.
+            break;
+          }
+          prevPageOldest = scan.oldest;
+          stopArmed = directionProven && scan.oldest! < stopBefore;
+        } else {
+          // Single-point page: boundary-consistent but direction-blind — it
+          // neither confirms a stop nor re-arms; keep the prior armed state
+          // and keep paging until a two-point page settles it.
+          prevPageOldest = scan.oldest;
+        }
+      }
+    }
+
     pageToken = data.nextPageToken;
   }
 

--- a/scripts/luna-vitals/connectors/google-health.test.ts
+++ b/scripts/luna-vitals/connectors/google-health.test.ts
@@ -182,6 +182,78 @@ describe('pull', () => {
     await expect(writeArtifact(tmpPath, artifact)).resolves.toBeUndefined();
   });
 
+  test('earlyStop wiring: heart-rate pages bounded to 2 fetches (arm + confirm)', async () => {
+    // A heart-rate endpoint that would page FOREVER without early-stop: every
+    // response carries a nextPageToken and serves 2 descending, pre-window
+    // sample points (all dates in May 2026, before the pull's from=2026-06-01).
+    // If windowFrom + pointDate did NOT thread through pull() to the fetch layer,
+    // this would page until the cap and throw. With early-stop it stops after the
+    // arming page + the confirming page = exactly 2 calls.
+    const state = { heartRateCalls: 0 };
+
+    // pageNum (1-based) → 2 descending heart-rate points, each page older than the last.
+    // Page 1: 2026-05-28, 2026-05-27; page 2: 2026-05-26, 2026-05-25; … — all
+    // below the slacked stop threshold (from=2026-06-01 minus 2-day slack = 05-30),
+    // so page 1 arms and page 2 confirms.
+    function heartRatePage(pageNum: number): unknown[] {
+      const baseMs = Date.UTC(2026, 4, 28); // 2026-05-28
+      const idx0 = (pageNum - 1) * 2;
+      return [0, 1].map((k) => {
+        const d = new Date(baseMs - (idx0 + k) * 86_400_000);
+        const y = d.getUTCFullYear();
+        const m = d.getUTCMonth() + 1;
+        const day = d.getUTCDate();
+        return {
+          dataSource: { recordingMethod: 'UNKNOWN', platform: 'HEALTH_CONNECT' },
+          heartRate: {
+            sampleTime: {
+              physicalTime: `${y}-${String(m).padStart(2, '0')}-${String(day).padStart(2, '0')}T12:00:00Z`,
+              utcOffset: '0s',
+              civilTime: { date: { year: y, month: m, day }, time: { hours: 12, minutes: 0 } },
+            },
+            beatsPerMinute: String(60 + k),
+            metadata: {},
+          },
+        };
+      });
+    }
+
+    const earlyStopFetch = async (url: string, _init?: RequestInit): Promise<FakeResponse> => {
+      if (url.includes('oauth2.googleapis.com/token')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ access_token: 't', token_type: 'Bearer' }),
+        };
+      }
+      const match = url.match(/\/dataTypes\/([^/?]+)\/dataPoints/);
+      if (match && match[1] === 'heart-rate') {
+        state.heartRateCalls++;
+        const page = state.heartRateCalls;
+        // nextPageToken on EVERY response → infinite without early-stop.
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ dataPoints: heartRatePage(page), nextPageToken: `p${page + 1}` }),
+        };
+      }
+      // Every other dataType: single empty page (no token → stops immediately).
+      return { ok: true, status: 200, json: async () => ({ dataPoints: [] }) };
+    };
+
+    const artifact = await pull({
+      from: '2026-06-01',
+      to: '2026-06-30',
+      cfg: FAKE_CFG,
+      fetchImpl: earlyStopFetch as unknown as typeof fetch,
+    });
+
+    // (a) completes — did not throw the page-cap error.
+    expect(artifact.bucket).toBe('2026-06-01..2026-06-30');
+    // (b) bounded: arming page + confirming page = exactly 2 heart-rate fetches.
+    expect(state.heartRateCalls).toBe(2);
+  });
+
   test('reconsent: invalid_grant token response rejects with ReconsentNeededError (exitCode 75)', async () => {
     const fetchImpl = asFetch(
       makeFakeFetch({ ok: false, status: 400, body: { error: 'invalid_grant' } }),

--- a/scripts/luna-vitals/connectors/google-health.ts
+++ b/scripts/luna-vitals/connectors/google-health.ts
@@ -5,7 +5,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { MAPPINGS } from './map/table';
-import { extractRows } from './map/shape';
+import { extractRows, pointDate } from './map/shape';
 import { aggregateRows, deriveRestingHeartRate, deriveSleep } from './map/derive';
 import {
   getAccessToken,
@@ -67,11 +67,23 @@ export async function pull(opts: {
     );
   }
 
-  // 3. Fetch each dataType once.
+  // 3. Fetch each dataType once. earlyStop bounds the paging to the window
+  // (the API returns newest-first; without this, every pull pages the ENTIRE
+  // per-type history and raw sample feeds blow the page cap).
   const fetched = new Map<string, unknown[]>();
   for (const dataTypeId of uniqueDataTypeIds) {
+    const mapping = MAPPINGS.find(
+      (m) => m.dataTypeId === dataTypeId && m.method !== 'dailyRollUp',
+    );
     const points = await fetchDataPoints(
-      { dataTypeId, accessToken, baseUrl: opts.baseUrl },
+      {
+        dataTypeId,
+        accessToken,
+        baseUrl: opts.baseUrl,
+        earlyStop: mapping
+          ? { windowFrom: opts.from, pointDate: (p: unknown) => pointDate(mapping, p) }
+          : undefined,
+      },
       fetchFn,
     );
     fetched.set(dataTypeId, points);

--- a/scripts/luna-vitals/connectors/map/shape.test.ts
+++ b/scripts/luna-vitals/connectors/map/shape.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { join } from 'path';
-import { extractRows } from './shape';
+import { extractRows, pointDate } from './shape';
 import { MAPPINGS } from './table';
 
 const FIXTURES_DIR = join(import.meta.dir, '../__fixtures__');
@@ -216,5 +216,34 @@ describe('extractRows — R4 deferred (returns [])', () => {
     const floorsMapping = findByTypeId('floors');
     // dataPoints content is irrelevant — short-circuits on method check.
     expect(extractRows(floorsMapping, { dataPoints: [{}] })).toEqual([]);
+  });
+});
+
+// ── pointDate (single-point civil date; used by fetch early-stop) ─────────────
+
+describe('pointDate', () => {
+  test('daily category: dailyRestingHeartRate.date → "2024-09-16"', async () => {
+    const fixture = await loadFixture('daily-resting-heart-rate');
+    const mapping = findByTypeId('daily-resting-heart-rate');
+    expect(pointDate(mapping, fixture.dataPoints![0])).toBe('2024-09-16');
+  });
+
+  test('sample category: weight.sampleTime.civilTime.date → "2026-06-21"', async () => {
+    const fixture = await loadFixture('weight');
+    const mapping = findByTypeId('weight');
+    expect(pointDate(mapping, fixture.dataPoints![0])).toBe('2026-06-21');
+  });
+
+  test('interval category: steps endTime + endUtcOffset → "2026-06-28"', async () => {
+    const fixture = await loadFixture('steps');
+    const mapping = findByTypeId('steps');
+    // No civilEndTime on the fixture — falls back to endTime "2026-06-28T09:00:00Z"
+    // + "7200s" → local 11:00 → 2026-06-28.
+    expect(pointDate(mapping, fixture.dataPoints![0])).toBe('2026-06-28');
+  });
+
+  test('malformed point (no field object) → undefined', () => {
+    // {} has no metric-object key → getFieldKey returns undefined → pointDate undefined.
+    expect(pointDate(findByTypeId('weight'), {})).toBeUndefined();
   });
 });

--- a/scripts/luna-vitals/connectors/map/shape.ts
+++ b/scripts/luna-vitals/connectors/map/shape.ts
@@ -73,6 +73,18 @@ function extractDate(mapping: Mapping, fieldObj: unknown): string | undefined {
   return computeLocalDate(interval.endTime as string, interval.endUtcOffset as string);
 }
 
+/**
+ * Extract the civil date (YYYY-MM-DD) of ONE raw dataPoint, or undefined if
+ * the point lacks the expected shape. Used by the fetch layer's early-stop
+ * pagination guard (which needs point dates before extractRows runs).
+ */
+export function pointDate(mapping: Mapping, dp: unknown): string | undefined {
+  const point = dp as Record<string, unknown>;
+  const fieldKey = getFieldKey(point);
+  if (!fieldKey) return undefined;
+  return extractDate(mapping, point[fieldKey]);
+}
+
 /** Traverse a dot-path into an object (e.g. "amountConsumed.milliliters"). */
 function getByPath(obj: unknown, path: string): unknown {
   return path.split('.').reduce<unknown>((cur, key) => (cur as any)?.[key], obj);


### PR DESCRIPTION
Every pull failed on the page cap: no pageSize (API default 50) + full per-type history paged before the client-side date filter. Fix: pageSize=1000 + fail-closed early-stop bounded to the pull window (whole-page monotonicity, cross-page boundary contract, arm/confirm handshake, strict-decrease direction proof, 2-day offset-jitter slack), GOOGLE_HEALTH_PAGE_CAP override for backfills. 134 tests.