### PR TITLE
fix(guardrails): [HIMMEL-778] graphify-fence MSYS normalization + staged-copy corpus declaration

### DIFF
--- a/docs/internals/egress-matrix.md
+++ b/docs/internals/egress-matrix.md
@@ -33,6 +33,32 @@ already use: `.salus` root markers and the
 plus vault/state roots from env or config — never hardcoded absolute paths.
 The matrix defines *policy*; membership resolution stays with the guards.
 
+## Staged-copy corpus declaration (`.graphify-corpus`, HIMMEL-778)
+
+The 621/622 plan runs extraction on scratchpad **copies** of corpus content,
+never live vaults — but a copy classifies as nothing, so an undeclared copy is
+denied unconditionally. A `.graphify-corpus` marker file at or above the target
+declares the copy's **origin** corpus: its first line, trimmed, must be one of
+`salus` · `luna-personal` · `luna-clippings` · `handover-state` · `himmel-code`
+(anything else, or an unreadable marker, is a fail-closed **deny**). Precedence
+is strict: `.salus`/PHI roots and the real luna/handover/himmel roots BOTH beat
+the marker (a marker inside a real vault can never relax classification); the
+marker is consulted **only** for otherwise-unclassifiable paths. Because a copy
+is origin-blind, mis-declaration is possible and accepted — the load-bearing PHI
+guard stays `parity_guard` / the file-tool fence, not this command-text guard.
+As a backstop, any marker-derived invocation **always** appends a ledger line
+on every allow-family verdict (`allow` / `allow+log` / `conditional` — a deny
+already blocks the egress), carrying `"declared":true`, even on a plain `allow`
+cell, so a mis-declared marker cannot also dodge the audit trail. The marker is
+consulted **only when a luna root is configured** (`LUNA_VAULT` /
+`LUNA_VAULT_PATH` non-empty): the real-root-beats-marker guarantee depends on
+the fence seeing the real roots, so with no luna root the marker is inert and
+staged copies stay unclassifiable → deny. `graphify-fence.sh` also normalizes
+MSYS-form paths (`/c/…` → `c:/…`) for its **lexical** root comparisons (the
+filesystem marker walks use the original path form) so Windows Git-Bash
+candidates and the Bash tool's always-MSYS `$PWD` match the drive-lettered
+corpus roots.
+
 ## Consumers
 
 | Surface | What it reads |

--- a/scripts/guardrails/graphify-fence.sh
+++ b/scripts/guardrails/graphify-fence.sh
@@ -77,6 +77,35 @@
 # outright as not statically fenceable), a backslash-escaped `\graphify`, and a
 # position-0 path-like token (classified, not swallowed as the subcommand).
 #
+# NOW HANDLED (HIMMEL-778):
+#   - MSYS drive-path normalization: `_normalize` translates a leading MSYS-form
+#     `/c/...` (or bare `/c`) into drive-lettered `c:/...` so an MSYS candidate
+#     and the Bash tool's always-MSYS $PWD match the drive-lettered corpus roots
+#     (git prints `C:/...`). Before this, even `graphify --version` in the himmel
+#     checkout was denied via the unclassifiable-cwd fallback.
+#   - Staged-copy corpus declaration: a `.graphify-corpus` marker file at or above
+#     an otherwise-unclassifiable target path declares the ORIGIN corpus of the
+#     staged scratchpad COPIES the 621/622 plan runs extraction on (a copy
+#     classifies as nothing without it). First line trimmed = one of
+#     salus|luna-personal|luna-clippings|handover-state|himmel-code; anything else
+#     (empty, unknown) or an unreadable marker DENIES. Precedence: (1) `.salus`/PHI
+#     roots beat it, (2) the real luna/handover/himmel roots beat it (a marker
+#     inside a real vault can NOT relax classification), (3) it is consulted ONLY
+#     for otherwise-unclassifiable paths, (4) no marker -> the pre-existing
+#     unclassifiable DENY. An invocation in which ANY classified token was
+#     marker-derived (invocation-wide, not only the rank-winning token, so
+#     argument ordering cannot suppress the audit) ALWAYS appends a ledger line
+#     on every ALLOW-family verdict (allow / allow+log / conditional - a deny
+#     already blocks the egress), even on a plain `allow` cell, so a
+#     mis-declared marker cannot also dodge the audit trail. The marker is
+#     consulted ONLY when a luna root is configured (LUNA_VAULT/LUNA_VAULT_PATH
+#     non-empty): precedence rule (2) depends on the fence SEEING the real
+#     roots, so an unconfigured luna root makes the marker INERT
+#     (unclassifiable -> deny, the pre-marker behavior). Residual: a
+#     configured-luna machine with an UNCONFIGURED handover root could still
+#     have handover content relabeled by a planted marker - accepted (work
+#     artifacts, lower sensitivity than vault content; always-ledgered).
+#
 # Accepted static-analysis limitations (the load-bearing PHI guard is the
 # file-tool fence parity_guard, not this command-text guard):
 #   (a) quoted-separator mis-split - a path with embedded spaces, or a quoted
@@ -96,6 +125,20 @@
 #       parsed with POSIX word-splitting; a PowerShell-only quoting/escaping
 #       form can mis-parse. Mis-parses land safe-direction (a mis-split path-like
 #       token is unclassifiable -> DENY, not a silent allow).
+#   (d) MSYS translation is unconditional (no OS sniff) and applies to the
+#       LEXICAL comparison form only: on Linux a genuine `/x/...` single-letter
+#       -rooted path translates to `x:/...` on BOTH sides of a root comparison
+#       (candidate and configured root normalize identically), so root matching
+#       still works; a translated candidate against a non-single-letter POSIX
+#       root simply fails to match -> DENY. Filesystem stat-walks (.salus /
+#       .graphify-corpus markers) deliberately use the ORIGINAL untranslated
+#       path (see classify()), so a PHI marker on a real POSIX `/x/...` root is
+#       still found.
+#   (e) `.graphify-corpus` is origin-BLIND: a scratchpad copy carries no proof of
+#       where it came from, so a marker mis-declaration is possible and accepted.
+#       The load-bearing PHI guard is parity_guard / the file-tool fence, not this
+#       command-text guard; the always-on ledger line (`"declared":true`) keeps a
+#       mis-declaration auditable even when the matrix verdict is a plain allow.
 set -uo pipefail
 set -f  # no pathname expansion when we word-split the command / a path
 
@@ -189,6 +232,17 @@ _abs() {
 _normalize() {
     local p="$1"
     p="${p//\\//}"   # backslashes -> forward slashes (Windows paths)
+    # MSYS drive-path form -> drive-lettered form: `/c/Users` -> `c:/Users`,
+    # bare `/c` -> `c:/`. Corpus roots resolve drive-lettered (git prints
+    # `C:/...`) and the Bash tool's $PWD is always MSYS-form on Windows, so an
+    # untranslated MSYS candidate never matches a root. Unconditional (no OS
+    # sniff): on Linux a genuine `/x/...` path is translated then simply fails
+    # to match POSIX roots -> deny, the same fail-closed outcome as today
+    # (accepted limitation, see header). bash 3.2-safe substring ops.
+    case "$p" in
+        /[A-Za-z]/*) p="${p:1:1}:/${p:3}" ;;
+        /[A-Za-z])   p="${p:1:1}:/" ;;
+    esac
     local prefix=""
     case "$p" in
         [A-Za-z]:/*) prefix="${p%%:*}:"; p="${p#[A-Za-z]:}" ;;
@@ -232,6 +286,46 @@ _salus_marked() {
     return 1
 }
 
+# _graphify_corpus_marker <abs-path> -> ancestor-walk (exactly like _salus_marked:
+# from the path, or its parent dir if not a directory, up to filesystem root)
+# for a `.graphify-corpus` marker that declares the ORIGIN corpus of a staged
+# scratchpad copy (621/622 mandates extraction runs on copies, never live
+# vaults; a copy classifies as nothing without this). First marker found wins.
+# Echoes ONE of:
+#   ""                                      no marker found
+#   "declared<TAB><corpus>"                 first line is a valid corpus name
+#   "__marker_unreadable__<TAB><markerpath>" marker exists but is not a readable regular file
+#   "__marker_bad__<TAB><markerpath><TAB><content>" empty / unknown first line
+_graphify_corpus_marker() {
+    local d="$1" prev="" mk line
+    [ -d "$d" ] || d="${d%/*}"
+    while [ -n "$d" ] && [ "$d" != "$prev" ]; do
+        mk="$d/.graphify-corpus"
+        if [ -e "$mk" ]; then
+            if ! { [ -f "$mk" ] && [ -r "$mk" ]; }; then
+                printf '__marker_unreadable__\t%s' "$mk"; return
+            fi
+            # `read` exits non-zero on a final line lacking a trailing newline
+            # but still populates the variable - do NOT clear it on failure (a
+            # `printf 'luna-personal' >` marker is valid). Pre-clear instead.
+            line=""
+            IFS= read -r line < "$mk" || :
+            line="${line%$'\r'}"
+            line="${line#"${line%%[![:space:]]*}"}"   # trim leading whitespace
+            line="${line%"${line##*[![:space:]]}"}"   # trim trailing whitespace
+            case "$line" in
+                salus|luna-personal|luna-clippings|handover-state|himmel-code)
+                    printf 'declared\t%s' "$line" ;;
+                *)  printf '__marker_bad__\t%s\t%s' "$mk" "$line" ;;
+            esac
+            return
+        fi
+        prev="$d"
+        d="${d%/*}"
+    done
+    return 0
+}
+
 # _under_any_list <abs-path> <listfile> -> echoes hit | miss | unreadable.
 _under_any_list() {
     local p="$1" listfile="$2" root
@@ -248,9 +342,17 @@ _under_any_list() {
 
 # classify <target-path> -> echoes corpus, "__unreadable__", or "" (unclassifiable).
 classify() {
-    local ap name rc
-    ap="$(_normalize "$(_abs "$1")")"
-    if _salus_marked "$ap"; then echo salus; return; fi
+    local apfs ap name rc mk
+    # Two forms of the same path: apfs = the ORIGINAL absolute form, used for
+    # every FILESYSTEM check (.salus / .graphify-corpus ancestor stat-walks -
+    # on a POSIX box a real `/c/...` path only exists in this form; the
+    # drive-translated `c:/...` string would stat nothing and silently skip a
+    # PHI marker). ap = the lexically normalized form, used for STRING root
+    # comparison only (_under_root/_under_any_list normalize both sides, so
+    # the comparison stays consistent).
+    apfs="$(_abs "$1")"
+    ap="$(_normalize "$apfs")"
+    if _salus_marked "$apfs"; then echo salus; return; fi
     for name in phi-roots egress-denylist; do
         rc="$(_under_any_list "$ap" "$PHI_CONFIG_DIR/$name")"
         if [ "$rc" = unreadable ]; then echo "__unreadable__"; return; fi
@@ -266,6 +368,27 @@ classify() {
     fi
     if [ -n "$HANDOVER_ROOT" ] && _under_root "$ap" "$HANDOVER_ROOT"; then echo handover-state; return; fi
     if [ -n "$HIMMEL_ROOT" ] && _under_root "$ap" "$HIMMEL_ROOT"; then echo himmel-code; return; fi
+    # LAST RESORT ONLY (precedence: .salus/PHI beat everything above; the real
+    # luna/handover/himmel roots beat this - a marker inside a CONFIGURED vault
+    # can NOT relax classification). Consult a `.graphify-corpus` staging marker
+    # so a scratchpad COPY can declare its origin corpus. Marker-derived hits
+    # carry an `@declared` suffix (callers strip it, but always ledger the
+    # invocation).
+    # GATED on a configured luna root (silent-failure CR round): the real-root-
+    # beats-marker guarantee for the most sensitive non-PHI corpus depends on
+    # LUNA_VAULT/LUNA_VAULT_PATH being set - with it EMPTY the luna branch above
+    # is skipped and a marker planted inside the (invisible) vault could relax
+    # luna content to an allow corpus. No luna root -> the marker is INERT and
+    # the path stays unclassifiable -> deny (exact pre-marker behavior).
+    # (.salus/PHI-root protection above is env-independent and unaffected.)
+    if [ -n "$LUNA_ROOT" ]; then
+        mk="$(_graphify_corpus_marker "$apfs")"
+        case "$mk" in
+            declared$'\t'*)          echo "${mk#declared$'\t'}@declared"; return ;;
+            __marker_unreadable__*)  echo "$mk"; return ;;
+            __marker_bad__*)         echo "$mk"; return ;;
+        esac
+    fi
     echo ""
 }
 
@@ -347,24 +470,33 @@ _json_escape() {
     printf '%s' "$s"
 }
 
-# ledger_append <path> <corpus> <backend> <provider> <verdict> -> 0 on a durable
-# write, 1 on any failure (unwritable dir / file). Callers DENY on failure: an
-# allow+log verdict without its ledger line is not allowed.
+# ledger_append <path> <corpus> <backend> <provider> <verdict> [declared] -> 0 on
+# a durable write, 1 on any failure (unwritable dir / file). Callers DENY on
+# failure: an allow+log verdict without its ledger line is not allowed. When the
+# optional 6th arg is "1" (ANY token in the invocation classified via a
+# `.graphify-corpus` marker - invocation-wide, not just the winning token) an
+# extra `"declared":true` field is emitted so a mis-declared marker cannot dodge
+# audit.
 ledger_append() {
-    local dir ts ep
+    local dir ts ep decl=""
+    [ "${6:-}" = 1 ] && decl=',"declared":true'
     dir="$(dirname "$LEDGER")"
     mkdir -p "$dir" || return 1
     ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%s)"
     ep="$(_json_escape "$1")"
-    printf '{"ts":"%s","path":"%s","corpus":"%s","backend":"%s","provider":"%s","verdict":"%s","tool":"graphify"}\n' \
-        "$ts" "$ep" "$2" "$3" "$4" "$5" >> "$LEDGER" || return 1
+    printf '{"ts":"%s","path":"%s","corpus":"%s","backend":"%s","provider":"%s","verdict":"%s","tool":"graphify"%s}\n' \
+        "$ts" "$ep" "$2" "$3" "$4" "$5" "$decl" >> "$LEDGER" || return 1
     return 0
 }
 
-# apply_verdict <corpus> <target> <backend-raw> -> return 0 (allow, ledger
-# written where required) or DENY (exit 2).
+# apply_verdict <corpus> <target> <backend-raw> [declared] -> return 0 (allow,
+# ledger written where required) or DENY (exit 2). When <declared> is 1 ANY
+# classified token in the invocation came from a `.graphify-corpus` marker
+# (invocation-wide - not only the rank-winning token, so argument ordering
+# cannot suppress the audit): ALWAYS ledger the run, even on a plain `allow`
+# cell (a mis-declared marker must not also dodge audit).
 apply_verdict() {
-    local corpus="$1" target="$2" backend_raw="$3"
+    local corpus="$1" target="$2" backend_raw="$3" declared="${4:-0}"
     local backend_effective provider verdict everr eout emsg optvar optval
 
     if [ -z "$backend_raw" ]; then
@@ -397,10 +529,14 @@ apply_verdict() {
 
     case "$verdict" in
         allow)
+            if [ "$declared" = 1 ]; then
+                ledger_append "$target" "$corpus" "$backend_effective" "$provider" "allow" 1 \
+                    || deny "declared-corpus audit requires the ledger line (ledger unwritable): $corpus x $provider"
+            fi
             return 0
             ;;
         allow+log)
-            ledger_append "$target" "$corpus" "$backend_effective" "$provider" "allow+log" \
+            ledger_append "$target" "$corpus" "$backend_effective" "$provider" "allow+log" "$declared" \
                 || deny "allow+log requires the ledger line (ledger unwritable): $corpus x $provider"
             return 0
             ;;
@@ -411,8 +547,8 @@ apply_verdict() {
                 *) deny "$corpus x $provider x extraction is conditional with no known opt-in (fail-closed)" ;;
             esac
             if [ "$optval" = "1" ]; then
-                ledger_append "$target" "$corpus" "$backend_effective" "$provider" "conditional" \
-                    || deny "allow+log requires the ledger line (ledger unwritable): $corpus x $provider"
+                ledger_append "$target" "$corpus" "$backend_effective" "$provider" "conditional" "$declared" \
+                    || deny "conditional requires the ledger line (ledger unwritable): $corpus x $provider"
                 return 0
             fi
             deny "$corpus x $provider x extraction requires opt-in $optvar=1 (matrix conditional cell)"
@@ -423,13 +559,29 @@ apply_verdict() {
     esac
 }
 
+# _deny_on_classify_sentinel <classify-output> - DENY (exit 2) for any fail-closed
+# sentinel classify can echo. MUST be called from the main shell body, never in a
+# $(...) subshell (deny's exit would only leave the subshell otherwise).
+_deny_on_classify_sentinel() {
+    local rest mkpath mkcontent
+    case "$1" in
+        __unreadable__)
+            deny "a PHI root list under $PHI_CONFIG_DIR exists but is not readable (fail-closed)" ;;
+        __marker_unreadable__$'\t'*)
+            deny ".graphify-corpus marker ${1#__marker_unreadable__$'\t'} exists but is not a readable regular file (fail-closed)" ;;
+        __marker_bad__$'\t'*)
+            rest="${1#__marker_bad__$'\t'}"; mkpath="${rest%%$'\t'*}"; mkcontent="${rest#*$'\t'}"
+            deny ".graphify-corpus marker $mkpath declares an invalid corpus: '$mkcontent' (must be salus|luna-personal|luna-clippings|handover-state|himmel-code)" ;;
+    esac
+}
+
 # evaluate_invocation <arg-tokens...> - args are the tokens AFTER the graphify
 # command word. Skips the subcommand, classifies path-like tokens
 # (most-restrictive-wins), applies the CWD fallback, then applies the verdict.
 evaluate_invocation() {
     local have_sub=0 subcmd="" want_backend=0 backend=""
-    local unclassifiable=0 best_rank=-1 best_corpus="" best_target=""
-    local tok st c r skip_redir_target=0
+    local unclassifiable=0 best_rank=-1 best_corpus="" best_target="" any_declared=0
+    local tok st c r declared skip_redir_target=0
 
     for tok in "$@"; do
         if [ "$skip_redir_target" = 1 ]; then skip_redir_target=0; continue; fi
@@ -468,9 +620,12 @@ evaluate_invocation() {
         [ -n "$st" ] || continue
         is_path_like "$st" || continue          # non-path arg (node name, question, model)
         c="$(classify "$st")"
-        if [ "$c" = "__unreadable__" ]; then
-            deny "a PHI root list under $PHI_CONFIG_DIR exists but is not readable (fail-closed)"
-        fi
+        _deny_on_classify_sentinel "$c"
+        # The declared bit is INVOCATION-WIDE: ANY marker-derived token forces
+        # the always-ledger audit, regardless of whether it wins the rank
+        # comparison (else a real-root token of equal/higher rank listed first
+        # would suppress the ledger line - argument ordering must not dodge audit).
+        case "$c" in *@declared) c="${c%@declared}"; any_declared=1 ;; esac
         if [ -n "$c" ]; then
             r="$(_rank "$c")"
             if [ "$r" -gt "$best_rank" ]; then
@@ -488,17 +643,17 @@ evaluate_invocation() {
     fi
 
     if [ -n "$best_corpus" ]; then
-        apply_verdict "$best_corpus" "$best_target" "$backend"
+        apply_verdict "$best_corpus" "$best_target" "$backend" "$any_declared"
         return
     fi
 
     # No classified path-like token -> the corpus is the one around the CWD.
     c="$(classify "$PWD")"
-    if [ "$c" = "__unreadable__" ]; then
-        deny "a PHI root list under $PHI_CONFIG_DIR exists but is not readable (fail-closed)"
-    fi
+    _deny_on_classify_sentinel "$c"
+    declared=0
+    case "$c" in *@declared) c="${c%@declared}"; declared=1 ;; esac
     [ -n "$c" ] || deny "unclassifiable cwd for graphify '$subcmd' (no classifiable path arg): $PWD"
-    apply_verdict "$c" "$PWD" "$backend"
+    apply_verdict "$c" "$PWD" "$backend" "$declared"
 }
 
 # classify_clause <clause-tokens...> - resolve the command-position token of one

--- a/scripts/guardrails/test-graphify-fence.sh
+++ b/scripts/guardrails/test-graphify-fence.sh
@@ -379,6 +379,173 @@ run_fence allow no "$HIMMEL" "redirect: standalone > target skipped -> allow" \
 run_fence deny no "$HIMMEL" "redirect: 2>/dev/null on salus target still denies" \
     "graphify update $SALUS/notes/patient.md --backend glm 2>/dev/null"
 
+echo "== HIMMEL-778: MSYS drive-path normalization =="
+
+# (M1) MSYS-form path under the himmel root -> himmel-code allow. PURE LEXICAL
+# (drive-lettered root + /c/... candidate) so it genuinely exercises the
+# translation on ANY OS - no real /c dir needed.
+run_fence allow no "$HIMMEL" "MSYS /c/... under himmel root -> himmel-code allow" \
+    "graphify update /c/fake/himmel/doc.md --backend deepseek" GRAPHIFY_HIMMEL_ROOT="C:/fake/himmel"
+
+# (M2) MSYS-form path under the luna root -> luna-personal (allow+log + ledger).
+run_fence allow yes "$HIMMEL" "MSYS /c/... under luna root -> luna-personal allow+ledger" \
+    "graphify update /c/fake/luna/journal.md --backend deepseek" LUNA_VAULT_PATH="C:/fake/luna"
+
+# (M3) THE --version regression: no path arg -> cwd fallback. The himmel root is
+# supplied drive-lettered (as git prints it); the fence must still classify the
+# cwd as himmel-code. drive_form() below yields a genuine drive-lettered/MSYS
+# mismatch on Windows Git Bash (where $PWD is /c/...) and degrades to a plain
+# match under a POSIX /tmp fixture root (still green).
+drive_form() {  # /c/Users/x -> C:/Users/x ; POSIX /tmp/x unchanged
+    local L
+    case "$1" in
+        /[A-Za-z]/*) L=$(printf '%s' "$1" | cut -c2 | tr '[:lower:]' '[:upper:]'); printf '%s:/%s' "$L" "${1#/?/}" ;;
+        /[A-Za-z])   L=$(printf '%s' "$1" | cut -c2 | tr '[:lower:]' '[:upper:]'); printf '%s:/' "$L" ;;
+        *)           printf '%s' "$1" ;;
+    esac
+}
+ROOT_DRIVE=$( cd "$HIMMEL" && drive_form "$PWD" )
+run_fence allow no "$HIMMEL/scripts" "MSYS --version cwd-in-himmel (drive-lettered root) -> allow" \
+    "graphify --version" GRAPHIFY_HIMMEL_ROOT="$ROOT_DRIVE"
+
+echo "== HIMMEL-778: .graphify-corpus staged-copy declaration =="
+
+STAGED="$WS/staged";        mkdir -p "$STAGED";        : > "$STAGED/copy.md";  printf 'luna-personal\n' > "$STAGED/.graphify-corpus"
+STAGED_SALUS="$WS/stgsalus"; mkdir -p "$STAGED_SALUS"; : > "$STAGED_SALUS/copy.md"; printf 'salus\n'        > "$STAGED_SALUS/.graphify-corpus"
+STAGED_BAD="$WS/stgbad";     mkdir -p "$STAGED_BAD";   : > "$STAGED_BAD/copy.md";   printf 'banana\n'       > "$STAGED_BAD/.graphify-corpus"
+STAGED_NONE="$WS/stgnone";   mkdir -p "$STAGED_NONE";  : > "$STAGED_NONE/copy.md"
+STAGED_HIM="$WS/stghim";     mkdir -p "$STAGED_HIM";   : > "$STAGED_HIM/copy.md";   printf 'himmel-code\n'  > "$STAGED_HIM/.graphify-corpus"
+
+# (S1) staged copy declares luna-personal + deepseek -> allow+log + ledger
+run_fence allow yes "$HIMMEL" "staged marker luna-personal + deepseek -> allow+ledger" \
+    "graphify update $STAGED/copy.md --backend deepseek"
+
+# (S2) staged copy declares salus + deepseek -> hard salus deny
+run_fence deny no "$HIMMEL" "staged marker salus + deepseek -> deny (hard salus row)" \
+    "graphify update $STAGED_SALUS/copy.md --backend deepseek"
+
+# (S3) staged marker with invalid content -> deny
+run_fence deny no "$HIMMEL" "staged marker invalid content -> deny" \
+    "graphify update $STAGED_BAD/copy.md --backend deepseek"
+
+# (S4) staged dir with NO marker -> deny (existing unclassifiable behavior held)
+run_fence deny no "$HIMMEL" "staged dir no marker -> deny (unclassifiable)" \
+    "graphify update $STAGED_NONE/copy.md --backend deepseek"
+
+# (S5) marker INSIDE the real luna root claiming himmel-code -> luna-personal wins
+# (real root beats the marker; classification NOT relaxed; no declared field).
+rm -f "$LEDGER"
+printf 'himmel-code\n' > "$LUNA/.graphify-corpus"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$HIMMEL" && env $CLEAN_ENV "$BASH_BIN" "$FENCE" "graphify update $LUNA/journal-2026.md --backend deepseek" ) >/dev/null 2>&1; rc_s5=$?
+rm -f "$LUNA/.graphify-corpus"
+if [ "$rc_s5" -eq 0 ] && grep -q '"corpus":"luna-personal"' "$LEDGER" 2>/dev/null && ! grep -q '"declared":true' "$LEDGER" 2>/dev/null; then
+    pass "marker in REAL luna claiming himmel-code -> luna-personal (real root wins)"
+else
+    fail "marker-in-real-luna: rc=$rc_s5 ledger=$(cat "$LEDGER" 2>/dev/null)"
+fi
+
+# (S6) declared himmel-code marker + ollama (matrix verdict is PLAIN allow) ->
+# ledger line IS written and carries "declared":true (audit cannot be dodged).
+rm -f "$LEDGER"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$HIMMEL" && env $CLEAN_ENV "$BASH_BIN" "$FENCE" "graphify update $STAGED_HIM/copy.md --backend ollama" ) >/dev/null 2>&1; rc_s6=$?
+if [ "$rc_s6" -eq 0 ] && grep -q '"declared":true' "$LEDGER" 2>/dev/null && grep -q '"corpus":"himmel-code"' "$LEDGER" 2>/dev/null; then
+    pass "declared himmel-code marker + ollama (plain allow) -> ledger w/ declared:true"
+else
+    fail "declared-audit: rc=$rc_s6 ledger=$(cat "$LEDGER" 2>/dev/null)"
+fi
+
+# (S7) marker file present but UNREADABLE -> deny (fail-closed). Skip gracefully
+# where chmod cannot drop read (admin on Windows, root on Linux).
+STAGED_UR="$WS/stgunread"; mkdir -p "$STAGED_UR"; : > "$STAGED_UR/copy.md"; printf 'luna-personal\n' > "$STAGED_UR/.graphify-corpus"
+chmod 000 "$STAGED_UR/.graphify-corpus" 2>/dev/null || true
+if [ -r "$STAGED_UR/.graphify-corpus" ]; then
+    printf '  SKIP  unreadable .graphify-corpus marker (chmod could not drop read perm here)\n'
+else
+    run_fence deny no "$HIMMEL" "unreadable .graphify-corpus marker -> deny (fail-closed)" \
+        "graphify update $STAGED_UR/copy.md --backend deepseek"
+fi
+chmod 644 "$STAGED_UR/.graphify-corpus" 2>/dev/null || true
+
+# (S8) marker WITHOUT a trailing newline is still valid (CR codex-1: `read`
+# exits non-zero on EOF-without-newline but populates the variable; the old
+# `|| line=""` cleared it -> false deny on a `printf 'x' >` marker).
+STAGED_NONL="$WS/stgnonl"; mkdir -p "$STAGED_NONL"; : > "$STAGED_NONL/copy.md"; printf 'luna-personal' > "$STAGED_NONL/.graphify-corpus"
+run_fence allow yes "$HIMMEL" "staged marker with NO trailing newline -> still classifies (allow+ledger)" \
+    "graphify update $STAGED_NONL/copy.md --backend deepseek"
+
+# (S10) UNCONFIGURED luna root -> the marker is INERT (silent-failure CR round:
+# without a visible luna root the real-root-beats-marker precedence cannot be
+# enforced, so a valid marker must NOT classify; pre-marker deny behavior).
+run_fence deny no "$HIMMEL" "no luna root configured -> valid marker is inert (deny)" \
+    "graphify update $STAGED/copy.md --backend deepseek" LUNA_VAULT_PATH=
+
+# (S6b) declared marker + PLAIN-allow cell (himmel-code x ollama) + UNWRITABLE
+# ledger -> DENY (pr-test-analyzer: the always-ledger audit on a plain allow is
+# its own branch in apply_verdict; dropping its `|| deny` must not pass green).
+run_fence deny no "$HIMMEL" "declared + plain allow + unwritable ledger -> deny (audit required)" \
+    "graphify update $STAGED_HIM/copy.md --backend ollama" GRAPHIFY_LEDGER="$WS/ledblocker/led.jsonl"
+
+# (S9) filesystem walks use the ORIGINAL path form: an MSYS-form (/c/...)
+# target must still find its .graphify-corpus marker (the stat-walk runs on
+# the untranslated path; only root COMPARISON uses the drive-translated form).
+# Windows-only shape - needs cygpath to produce a real MSYS form of $STAGED.
+if command -v cygpath >/dev/null 2>&1; then
+    # cygpath -u round-trips mounted paths (/tmp stays /tmp), so build the raw
+    # /x/... form by hand from the drive-lettered mixed form: C:/foo -> /c/foo.
+    STAGED_MIXED="$(cygpath -m "$STAGED" 2>/dev/null || true)"
+    case "$STAGED_MIXED" in
+        [A-Za-z]:/*)
+            _drv="$(printf '%s' "${STAGED_MIXED%%:*}" | tr '[:upper:]' '[:lower:]')"
+            STAGED_MSYS="/${_drv}${STAGED_MIXED#?:}"
+            run_fence allow yes "$HIMMEL" "MSYS-form staged path still finds its marker (walk on original form)" \
+                "graphify update $STAGED_MSYS/copy.md --backend deepseek"
+            ;;
+        *) printf '  SKIP  MSYS-form marker walk (no drive-lettered form here)\n' ;;
+    esac
+else
+    printf '  SKIP  MSYS-form marker walk (no cygpath on this platform)\n'
+fi
+
+echo "== HIMMEL-778 CR: declared bit is INVOCATION-WIDE (ordering cannot suppress audit) =="
+
+# (D1) real himmel-code path FIRST, then a staged himmel-code-declared path
+# (same rank 1): the marker token loses the strictly-greater rank comparison,
+# but the ledger line with declared:true MUST still be written (the
+# ordering-bypass case the CR found).
+rm -f "$LEDGER"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$HIMMEL" && env $CLEAN_ENV "$BASH_BIN" "$FENCE" "graphify merge-graphs $HIMMEL/scripts/thing.sh $STAGED_HIM/copy.md --backend ollama" ) >/dev/null 2>&1; rc_d1=$?
+if [ "$rc_d1" -eq 0 ] && grep -q '"declared":true' "$LEDGER" 2>/dev/null; then
+    pass "real himmel FIRST + staged himmel marker -> allow + declared ledger (order bypass closed)"
+else
+    fail "ordering-bypass D1: rc=$rc_d1 ledger=$(cat "$LEDGER" 2>/dev/null)"
+fi
+
+# (D2) same two paths in REVERSE order -> same outcome (order-independence).
+rm -f "$LEDGER"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$HIMMEL" && env $CLEAN_ENV "$BASH_BIN" "$FENCE" "graphify merge-graphs $STAGED_HIM/copy.md $HIMMEL/scripts/thing.sh --backend ollama" ) >/dev/null 2>&1; rc_d2=$?
+if [ "$rc_d2" -eq 0 ] && grep -q '"declared":true' "$LEDGER" 2>/dev/null; then
+    pass "staged himmel marker FIRST + real himmel -> allow + declared ledger (order-independent)"
+else
+    fail "ordering-bypass D2: rc=$rc_d2 ledger=$(cat "$LEDGER" 2>/dev/null)"
+fi
+
+# (D3) staged luna-personal-declared path + real himmel-code path in ONE
+# invocation -> most-restrictive still wins (luna-personal x deepseek ->
+# allow+log) AND declared:true is present.
+rm -f "$LEDGER"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$HIMMEL" && env $CLEAN_ENV "$BASH_BIN" "$FENCE" "graphify merge-graphs $HIMMEL/scripts/thing.sh $STAGED/copy.md --backend deepseek" ) >/dev/null 2>&1; rc_d3=$?
+if [ "$rc_d3" -eq 0 ] && grep -q '"corpus":"luna-personal"' "$LEDGER" 2>/dev/null \
+    && grep -q '"verdict":"allow+log"' "$LEDGER" 2>/dev/null && grep -q '"declared":true' "$LEDGER" 2>/dev/null; then
+    pass "staged luna-personal + real himmel -> most-restrictive wins + declared ledger"
+else
+    fail "mixed-corpus D3: rc=$rc_d3 ledger=$(cat "$LEDGER" 2>/dev/null)"
+fi
+
 if [ "$failures" -eq 0 ]; then
     echo "OK: all cases passed"
     exit 0


### PR DESCRIPTION
Public propagation of himmel-private #998 (single squash ac42887d). Two fence defects blocked all graphify extraction on Windows: MSYS /c/ paths never classified, and staged scratchpad copies had no corpus-declaration mechanism. Adds lexical drive translation (filesystem walks keep the original path form), the .graphify-corpus staging marker (strict allowlist, salus/PHI + real roots take precedence, always-ledgered with declared:true, gated on a configured luna root), and 16 new hermetic tests. 3 cross-model CR rounds + 4-reviewer matrix; suite green; shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)