### PR TITLE
fix(luna-vitals): sleep semantics + degraded-stage contract (HIMMEL-785/792/793)

### DIFF
--- a/docs/luna/google-health-connector-setup.md
+++ b/docs/luna/google-health-connector-setup.md
@@ -214,7 +214,7 @@ HR-zone config, nutrition-log multi-nutrient arrays) are excluded from the serie
 | **Activity** | `steps`, `distance_km`, `active_energy_kcal`, `active_minutes` | Sub-daily intervals, summed per day |
 | | `active_zone_minutes`, `sedentary_minutes`, `altitude_gain_km` | Sub-daily intervals, summed per day |
 | | `swim_strokes`, `exercise_minutes` | Rare / device-dependent |
-| **Sleep** | `sleep_hours` (time in bed), `sleep_asleep_hours` (non-AWAKE stages) | Longest session per date |
+| **Sleep** | `sleep_hours` (non-AWAKE stages, hours asleep), `sleep_in_bed_hours` (time in bed) | Longest session per date; `sleep_hours` emitted only when asleep hours round to > 0 (see [connectors/SCHEMA.md](../../scripts/luna-vitals/connectors/SCHEMA.md) for the authoritative emission semantics) |
 | **Nutrition** | `hydration_ml` | Log entries, summed per day |
 | **Scaffolded (gated)** | `calories_in_hr_zone_kcal`, `floors`, `total_calories_kcal` | Skipped at runtime; dailyRollUp shape unverified |
 

--- a/scripts/luna-vitals/cli.ts
+++ b/scripts/luna-vitals/cli.ts
@@ -3,6 +3,9 @@ import { mergeRows } from "./src/merge";
 import { writeSeries } from "./src/writeSeries";
 import { readArtifact, writeArtifact, type ExtractedRow, type ReviewArtifact } from "./src/types";
 
+// Scopes the parse/self-report default metric set only — NOT an allowlist.
+// Derived connector metrics (e.g. sleep_in_bed_hours) land via writeSeries
+// regardless of what's listed here.
 const DEFAULT_METRICS = ["migraine", "skin_flare", "sleep_hours", "hrv_ms", "rhr_bpm"];
 
 function flag(args: string[], name: string): string | undefined {

--- a/scripts/luna-vitals/connectors/README.md
+++ b/scripts/luna-vitals/connectors/README.md
@@ -10,7 +10,7 @@ does nothing without `GOOGLE_HEALTH_*` set in `.env` and a cadence armed.
 ## Layout
 - `map/table.ts` — `MAPPINGS`: which API dataType → which series (the source of truth for coverage).
 - `map/shape.ts` — per-dataPoint extraction (daily / sample / interval date + value, unit/string coercion).
-- `map/derive.ts` — day aggregation + derived `rhr_bpm` (raw-HR percentile) + `sleep_hours`/`sleep_asleep_hours`.
+- `map/derive.ts` — day aggregation + derived `rhr_bpm` (raw-HR percentile) + `sleep_hours`/`sleep_in_bed_hours`.
 - `auth/oauth.ts` — refresh→access token, `auth-url`/`exchange`, `RECONSENT_EXIT=75`.
 - `fetch/dataType.ts` — paged list (+ gated `dailyRollUp`) + client-side date filter.
 - `google-health.ts` — CLI: `pull` / `auth-url` / `auth-exchange`.

--- a/scripts/luna-vitals/connectors/SCHEMA.md
+++ b/scripts/luna-vitals/connectors/SCHEMA.md
@@ -35,7 +35,31 @@ Three categories by date source; values often JSON **strings** → coerce.
 | swim-lengths-data | swimLengthsData | strokeCount (STRING) | strokes | sum | rare |
 | exercise | exercise | (interval end−start as minutes) | min | sum | also has exerciseType, metricsSummary; emit exercise_minutes |
 | hydration-log | hydrationLog | amountConsumed.milliliters | ml | sum | |
-| sleep | sleep | (interval; stages[]) | hours | main session | emit sleep_hours (in-bed) + sleep_asleep_hours (Σ non-AWAKE) |
+| sleep | sleep | (interval; stages[]) | hours | main session | emit sleep_hours (Σ non-AWAKE, only if the rounded value is >0) + sleep_in_bed_hours (in-bed) |
+
+### Migration note (HIMMEL-785)
+Prior to HIMMEL-785 the connector emitted `sleep_hours` = time-in-bed (what is now
+`sleep_in_bed_hours`). `writeSeries` only overlays emitted rows onto the existing
+on-disk CSV, so `sleep_hours.csv` values written by pre-HIMMEL-785 artifacts are
+**not** auto-reconciled — any vault that ever landed old connector artifacts verbatim
+must one-time repair that series (the operator vault was repaired in salus commit `a1c9456`).
+
+### Degraded stage data (HIMMEL-793)
+If any non-AWAKE stage in the main sleep session has an unparseable start/end timestamp
+(`Date.parse` → NaN), the session's stage data is treated as DEGRADED for that date:
+`sleep_hours` is omitted entirely (the remaining valid stages would under-count sleep),
+`sleep_in_bed_hours` is still emitted (derived from the session interval, not the stages),
+and a `[google-health]` stderr warning is printed. Invalid AWAKE stages never enter the
+asleep sum, so they do not trigger the degraded path.
+
+Known limitations (tracked in HIMMEL-794): the warning is **stderr-only** — the review
+artifact carries no warnings field, so a degraded date looks identical to a genuinely
+stage-less classic session in the artifact JSON, and `writeSeries` leaves any previously
+written `sleep_hours` value for that date untouched (metrics absent from artifact rows
+are never rewritten). Adjacent silent skips predating HIMMEL-793: a session with no
+`civilEndTime` and no `endUtcOffset`, or an unparseable session interval, is dropped
+entirely without a warning; a non-array `stages` field is coerced to `[]` (treated as
+classic stage-less).
 
 ## Derived
 - `rhr_bpm` ← heart-rate raw samples: per civil day, take a low estimator

--- a/scripts/luna-vitals/connectors/google-health.test.ts
+++ b/scripts/luna-vitals/connectors/google-health.test.ts
@@ -91,9 +91,9 @@ describe('pull', () => {
 
     // heart-rate → 5th-percentile derivation → rhr_bpm
     expect(metrics.has('rhr_bpm')).toBe(true);
-    // sleep → both time-in-bed and asleep duration
+    // sleep → both asleep duration and time-in-bed
     expect(metrics.has('sleep_hours')).toBe(true);
-    expect(metrics.has('sleep_asleep_hours')).toBe(true);
+    expect(metrics.has('sleep_in_bed_hours')).toBe(true);
     // daily-oxygen-saturation → daily_spo2_pct
     expect(metrics.has('daily_spo2_pct')).toBe(true);
     // steps fixture

--- a/scripts/luna-vitals/connectors/google-health.ts
+++ b/scripts/luna-vitals/connectors/google-health.ts
@@ -99,7 +99,7 @@ export async function pull(opts: {
       // derive: 5th-percentile per day → rhr_bpm
       allRows.push(...deriveRestingHeartRate(response));
     } else if (dataTypeId === 'sleep') {
-      // derive: longest session per date → sleep_hours + sleep_asleep_hours
+      // derive: longest session per date → sleep_hours + sleep_in_bed_hours
       allRows.push(...deriveSleep(response));
     } else {
       // Standard path: for each mapping on this dataTypeId, extract + aggregate.

--- a/scripts/luna-vitals/connectors/map/derive.test.ts
+++ b/scripts/luna-vitals/connectors/map/derive.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, spyOn } from 'bun:test';
 import { join } from 'path';
 import { aggregateRows, deriveRestingHeartRate, deriveSleep } from './derive';
 import { extractRows } from './shape';
@@ -262,31 +262,33 @@ describe('deriveRestingHeartRate', () => {
 // ── deriveSleep ───────────────────────────────────────────────────────────────
 
 describe('deriveSleep', () => {
-  test('2026-06-28: main session 8h31m (sleep_hours=8.5); nap excluded from main value', async () => {
+  test('2026-06-28: main session 8h31m (sleep_in_bed_hours=8.5); nap excluded from main value', async () => {
     // Fixture: session 1 (01:24Z–09:55Z = 511 min = main) + session 2 nap (14:00Z–14:40Z = 40 min).
     // Both end on 2026-06-28 local (UTC+2). Main = session 1 (511 > 40).
     const fixture = await loadFixture('sleep');
     const rows = deriveSleep(fixture);
 
-    const hoursRow = rows.find((r) => r.metric === 'sleep_hours' && r.date === '2026-06-28');
-    expect(hoursRow).toBeDefined();
+    const inBedRow = rows.find(
+      (r) => r.metric === 'sleep_in_bed_hours' && r.date === '2026-06-28',
+    );
+    expect(inBedRow).toBeDefined();
     // 511 min / 60 = 8.5167 → 8.5 (NOT 8.5 + 0.7 from nap)
-    expect(hoursRow!.value).toBe(8.5);
+    expect(inBedRow!.value).toBe(8.5);
   });
 
-  test('2026-06-28: sleep_asleep_hours < sleep_hours (main session has AWAKE segment)', async () => {
+  test('2026-06-28: sleep_hours (asleep) < sleep_in_bed_hours (main session has AWAKE segment)', async () => {
     // Main session (01:24Z–09:55Z) starts with 20 min AWAKE stage.
     // Non-AWAKE stages sum: 86+55+50+95+45+55+105 = 491 min = 8.183→ 8.2 h
     const fixture = await loadFixture('sleep');
     const rows = deriveSleep(fixture);
 
-    const hoursRow = rows.find((r) => r.metric === 'sleep_hours' && r.date === '2026-06-28')!;
-    const asleepRow = rows.find(
-      (r) => r.metric === 'sleep_asleep_hours' && r.date === '2026-06-28',
-    );
+    const inBedRow = rows.find(
+      (r) => r.metric === 'sleep_in_bed_hours' && r.date === '2026-06-28',
+    )!;
+    const asleepRow = rows.find((r) => r.metric === 'sleep_hours' && r.date === '2026-06-28');
     expect(asleepRow).toBeDefined();
     expect(asleepRow!.value).toBe(8.2);
-    expect(asleepRow!.value).toBeLessThan(hoursRow.value);
+    expect(asleepRow!.value).toBeLessThan(inBedRow.value);
   });
 
   test('midnight-cross session → date = 2026-06-27 (local end date, not start date)', async () => {
@@ -295,9 +297,11 @@ describe('deriveSleep', () => {
     const fixture = await loadFixture('sleep');
     const rows = deriveSleep(fixture);
 
-    const hoursRow = rows.find((r) => r.metric === 'sleep_hours' && r.date === '2026-06-27');
-    expect(hoursRow).toBeDefined();
-    expect(hoursRow!.value).toBe(7.0);
+    const inBedRow = rows.find(
+      (r) => r.metric === 'sleep_in_bed_hours' && r.date === '2026-06-27',
+    );
+    expect(inBedRow).toBeDefined();
+    expect(inBedRow!.value).toBe(7.0);
     // Start date (2026-06-26) must NOT appear in output.
     expect(rows.some((r) => r.date === '2026-06-26')).toBe(false);
   });
@@ -306,15 +310,203 @@ describe('deriveSleep', () => {
     const fixture = await loadFixture('sleep');
     const rows = deriveSleep(fixture);
 
-    // fixture has sessions on 2026-06-27 and 2026-06-28 → 4 rows total (2 per date)
+    // fixture has sessions on 2026-06-27 and 2026-06-28, both stage-backed → 4 rows total (2 per date)
     expect(rows.length).toBe(4);
     for (const row of rows) {
-      expect(row.metric).toMatch(/^sleep_(hours|asleep_hours)$/);
+      expect(row.metric).toMatch(/^sleep_(hours|in_bed_hours)$/);
       expect(row.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
       expect(typeof row.value).toBe('number');
       expect(Number.isFinite(row.value)).toBe(true);
       expect(row.source).toMatch(/^google-health:sleep:/);
     }
+  });
+
+  test('classic session (no stages) → sleep_in_bed_hours only, no sleep_hours row', () => {
+    // Fitbit classic-era sync: interval present, stages array absent/empty.
+    const fixture = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'IOS' },
+          sleep: {
+            interval: {
+              startTime: '2018-03-01T23:00:00Z',
+              startUtcOffset: '0s',
+              endTime: '2018-03-02T07:00:00Z',
+              endUtcOffset: '0s',
+            },
+          },
+        },
+      ],
+    };
+    const rows = deriveSleep(fixture);
+
+    expect(rows.length).toBe(1);
+    expect(rows[0].metric).toBe('sleep_in_bed_hours');
+    expect(rows[0].value).toBe(8.0);
+    expect(rows.some((r) => r.metric === 'sleep_hours')).toBe(false);
+  });
+
+  test('stages session → emits both sleep_hours (asleep) and sleep_in_bed_hours (span)', () => {
+    const fixture = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-01T22:00:00Z',
+              startUtcOffset: '0s',
+              endTime: '2026-01-02T06:00:00Z',
+              endUtcOffset: '0s',
+            },
+            stages: [
+              {
+                startTime: '2026-01-01T22:00:00Z',
+                endTime: '2026-01-01T22:30:00Z',
+                type: 'AWAKE',
+              },
+              {
+                startTime: '2026-01-01T22:30:00Z',
+                endTime: '2026-01-02T06:00:00Z',
+                type: 'LIGHT',
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const rows = deriveSleep(fixture);
+
+    expect(rows.length).toBe(2);
+    const inBedRow = rows.find((r) => r.metric === 'sleep_in_bed_hours')!;
+    const asleepRow = rows.find((r) => r.metric === 'sleep_hours')!;
+    expect(inBedRow.value).toBe(8.0); // full 22:00–06:00 span
+    expect(asleepRow.value).toBe(7.5); // AWAKE 30min excluded
+  });
+
+  test('all-AWAKE stages session → sleep_in_bed_hours only, no sleep_hours row (asleep sum is 0)', () => {
+    // Stages array is PRESENT (unlike the classic-session case above) but every
+    // stage is AWAKE, so the non-AWAKE sum is 0 — distinguishes "stages absent"
+    // from "stages present but zero asleep".
+    const fixture = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-01T22:00:00Z',
+              startUtcOffset: '0s',
+              endTime: '2026-01-02T06:00:00Z',
+              endUtcOffset: '0s',
+            },
+            stages: [
+              {
+                startTime: '2026-01-01T22:00:00Z',
+                endTime: '2026-01-02T06:00:00Z',
+                type: 'AWAKE',
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const rows = deriveSleep(fixture);
+
+    expect(rows.length).toBe(1);
+    expect(rows[0].metric).toBe('sleep_in_bed_hours');
+    expect(rows[0].value).toBe(8.0);
+    expect(rows.some((r) => r.metric === 'sleep_hours')).toBe(false);
+  });
+
+  test('malformed non-AWAKE stage timestamps → degraded: sleep_in_bed_hours only, no sleep_hours row', () => {
+    // One valid 4h LIGHT stage + one DEEP stage with unparseable timestamps. The
+    // malformed non-AWAKE stage marks the session's stage data DEGRADED: even though
+    // the valid LIGHT stage would sum to 4h, sleep_hours is omitted entirely (it would
+    // under-count sleep). sleep_in_bed_hours (session span) is unaffected; a stderr
+    // warning is printed.
+    const fixture = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-01T22:00:00Z',
+              startUtcOffset: '0s',
+              endTime: '2026-01-02T06:00:00Z',
+              endUtcOffset: '0s',
+            },
+            stages: [
+              {
+                startTime: '2026-01-01T22:00:00Z',
+                endTime: '2026-01-02T02:00:00Z',
+                type: 'LIGHT',
+              },
+              {
+                startTime: 'not-a-timestamp',
+                endTime: 'also-garbage',
+                type: 'DEEP',
+              },
+            ],
+          },
+        },
+      ],
+    };
+    // The stderr warning is part of the degraded contract (it is the only
+    // operator-visible signal today — see SCHEMA.md / HIMMEL-794). Assert while
+    // the spy is live — mockRestore() clears the recorded calls.
+    const errSpy = spyOn(console, 'error');
+    try {
+      const rows = deriveSleep(fixture);
+
+      expect(rows.length).toBe(1);
+      expect(rows[0].metric).toBe('sleep_in_bed_hours');
+      expect(rows[0].value).toBe(8.0);
+      expect(rows.some((r) => r.metric === 'sleep_hours')).toBe(false);
+      expect(errSpy).toHaveBeenCalledWith(
+        '[google-health] sleep 2026-01-02: malformed stage timestamps - sleep_hours omitted (degraded stage data)',
+      );
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  test('malformed AWAKE stage timestamps do NOT degrade (AWAKE never enters the sum) → both rows', () => {
+    // A valid non-AWAKE (LIGHT) stage plus a garbage-timestamp AWAKE stage: the AWAKE
+    // stage is skipped before its timestamps are parsed, so the malformed AWAKE
+    // timestamps do not trigger the degraded path and both rows are emitted.
+    const fixture = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-01T22:00:00Z',
+              startUtcOffset: '0s',
+              endTime: '2026-01-02T06:00:00Z',
+              endUtcOffset: '0s',
+            },
+            stages: [
+              {
+                startTime: 'garbage',
+                endTime: 'garbage',
+                type: 'AWAKE',
+              },
+              {
+                startTime: '2026-01-01T22:00:00Z',
+                endTime: '2026-01-02T06:00:00Z',
+                type: 'LIGHT',
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const rows = deriveSleep(fixture);
+
+    expect(rows.length).toBe(2);
+    const inBedRow = rows.find((r) => r.metric === 'sleep_in_bed_hours')!;
+    const asleepRow = rows.find((r) => r.metric === 'sleep_hours')!;
+    expect(inBedRow.value).toBe(8.0);
+    expect(asleepRow.value).toBe(8.0); // full 8h LIGHT span, garbage AWAKE ignored
   });
 
   test('empty dataPoints → []', () => {

--- a/scripts/luna-vitals/connectors/map/derive.ts
+++ b/scripts/luna-vitals/connectors/map/derive.ts
@@ -3,7 +3,7 @@
  *
  * aggregateRows: collapse multi-point same-day ExtractedRows into one row/date.
  * deriveRestingHeartRate: compute rhr_bpm from raw heart-rate samples (5th pctile/day).
- * deriveSleep: extract sleep_hours + sleep_asleep_hours from sleep dataPoints.
+ * deriveSleep: extract sleep_hours + sleep_in_bed_hours from sleep dataPoints.
  */
 import type { Mapping } from './table';
 import { type ExtractedRow, validateRow } from '../../src/types';
@@ -223,7 +223,7 @@ type SleepSession = {
 };
 
 /**
- * Derive sleep_hours and sleep_asleep_hours from sleep dataPoints.
+ * Derive sleep_hours and sleep_in_bed_hours from sleep dataPoints.
  *
  * Session date: local calendar date of the interval's END.
  *   Prefer interval.civilEndTime.date; fall back to endTime + endUtcOffset.
@@ -235,12 +235,24 @@ type SleepSession = {
  *   the main-session values — they represent separate rest periods and stacking
  *   them would overstate a single night's time-in-bed.
  *
- * Emits TWO rows per date:
- *   sleep_hours       — main session (end − start) in hours, 1 decimal (time in bed).
- *   sleep_asleep_hours — sum of non-AWAKE stage durations in the main session, 1 decimal.
+ * Emits UP TO TWO rows per date:
+ *   sleep_hours        — sum of non-AWAKE stage durations in the main session, 1 decimal
+ *                         (hours actually asleep). Emitted ONLY when > 0 AND the session's
+ *                         stage data is not degraded (see below) — a stage-less session
+ *                         (classic-era Fitbit sync, no stage breakdown) has no asleep figure
+ *                         to report, so no row is emitted rather than a misleading 0.
+ *   sleep_in_bed_hours — main session (end − start) in hours, 1 decimal (time in bed).
+ *                         Always emitted for a valid session.
+ *
+ *   DEGRADED stage data: if ANY non-AWAKE stage in the main session has an unparseable
+ *   start/end timestamp (Date.parse → NaN), the session is treated as DEGRADED for that
+ *   date — sleep_hours is omitted regardless of what the remaining valid stages sum to
+ *   (they would under-count sleep), while sleep_in_bed_hours is still emitted (derived
+ *   from the session interval, not the stages) and a stderr warning is printed. Invalid
+ *   AWAKE stages never enter the sum, so they do NOT trigger the degraded path.
  *
  * Source: 'google-health:sleep:<platform>'.
- * Both rows pass validateRow before being returned.
+ * Each emitted row passes validateRow before being returned.
  */
 export function deriveSleep(response: { dataPoints?: unknown[] }): ExtractedRow[] {
   const sessions: SleepSession[] = [];
@@ -292,33 +304,52 @@ export function deriveSleep(response: { dataPoints?: unknown[] }): ExtractedRow[
   for (const [date, main] of byDate) {
     const source = `google-health:sleep:${main.platform}`;
 
-    // sleep_hours: total time-in-bed, 1 decimal.
-    const sleepHours = Math.round((main.durationMs / 3_600_000) * 10) / 10;
+    // sleep_in_bed_hours: total time-in-bed, 1 decimal.
+    const inBedHours = Math.round((main.durationMs / 3_600_000) * 10) / 10;
 
-    // sleep_asleep_hours: sum non-AWAKE stage durations, 1 decimal.
+    // sleep_hours: sum non-AWAKE stage durations, 1 decimal (hours actually asleep).
+    // A non-AWAKE stage with an unparseable start/end timestamp marks the session's
+    // stage data as DEGRADED — the remaining valid stages would under-count sleep, so
+    // sleep_hours is omitted below (sleep_in_bed_hours is derived from the session
+    // interval and is unaffected). Invalid AWAKE stages never enter the sum, so they
+    // do not trigger the degraded path.
     let asleepMs = 0;
+    let degraded = false;
     for (const stage of main.stages) {
       if (stage.type === 'AWAKE') continue;
       const sMs = Date.parse(stage.startTime);
       const eMs = Date.parse(stage.endTime);
       if (Number.isFinite(sMs) && Number.isFinite(eMs)) {
         asleepMs += eMs - sMs;
+      } else {
+        degraded = true;
       }
     }
-    const sleepAsleepHours = Math.round((asleepMs / 3_600_000) * 10) / 10;
+    const sleepHours = Math.round((asleepMs / 3_600_000) * 10) / 10;
 
-    const rowHours: ExtractedRow = { metric: 'sleep_hours', date, value: sleepHours, source };
-    const rowAsleep: ExtractedRow = {
-      metric: 'sleep_asleep_hours',
+    const rowInBed: ExtractedRow = {
+      metric: 'sleep_in_bed_hours',
       date,
-      value: sleepAsleepHours,
+      value: inBedHours,
       source,
     };
+    validateRow(rowInBed);
+    rows.push(rowInBed);
 
-    validateRow(rowHours);
-    validateRow(rowAsleep);
-
-    rows.push(rowHours, rowAsleep);
+    if (degraded) {
+      // Malformed non-AWAKE stage timestamps: the remaining valid stages would
+      // under-count sleep, so omit the sleep_hours row rather than emit a misleading
+      // figure. sleep_in_bed_hours above is unaffected (derived from the interval).
+      console.error(
+        `[google-health] sleep ${date}: malformed stage timestamps - sleep_hours omitted (degraded stage data)`,
+      );
+    } else if (sleepHours > 0) {
+      // Stage-less sessions (classic-era Fitbit) yield sleepHours === 0 — skip rather
+      // than emit a misleading 0-hours-asleep row.
+      const rowAsleep: ExtractedRow = { metric: 'sleep_hours', date, value: sleepHours, source };
+      validateRow(rowAsleep);
+      rows.push(rowAsleep);
+    }
   }
 
   return rows;

--- a/scripts/luna-vitals/connectors/map/shape.test.ts
+++ b/scripts/luna-vitals/connectors/map/shape.test.ts
@@ -207,9 +207,9 @@ describe('extractRows — R4 deferred (returns [])', () => {
     expect(extractRows(findByMetric('sleep_hours'), fixture)).toEqual([]);
   });
 
-  test('sleep_asleep_hours mapping → [] (stage summation handled in R4)', async () => {
+  test('sleep_in_bed_hours mapping → [] (main-session selection handled in R4)', async () => {
     const fixture = await loadFixture('sleep');
-    expect(extractRows(findByMetric('sleep_asleep_hours'), fixture)).toEqual([]);
+    expect(extractRows(findByMetric('sleep_in_bed_hours'), fixture)).toEqual([]);
   });
 
   test('dailyRollUp method mapping (floors) → []', () => {

--- a/scripts/luna-vitals/connectors/map/shape.ts
+++ b/scripts/luna-vitals/connectors/map/shape.ts
@@ -126,7 +126,7 @@ function extractValue(mapping: Mapping, fieldObj: unknown): number | undefined {
  *
  * Mappings R3 cannot resolve per-point (handled in R4):
  *   - aggregate === 'derive'   → rhr_bpm (5th-percentile of raw HR samples)
- *   - dataTypeId === 'sleep'   → sleep_hours / sleep_asleep_hours (main-session selection)
+ *   - dataTypeId === 'sleep'   → sleep_hours / sleep_in_bed_hours (main-session selection)
  *   - method === 'dailyRollUp' → rollup shape TBD; requires a different fetch method
  */
 export function extractRows(

--- a/scripts/luna-vitals/connectors/map/table.test.ts
+++ b/scripts/luna-vitals/connectors/map/table.test.ts
@@ -64,13 +64,13 @@ describe('MAPPINGS table', () => {
     expect(entry?.dataTypeId).toBe('heart-rate');
   });
 
-  test('includes sleep_hours and sleep_asleep_hours (both from sleep dataTypeId)', () => {
+  test('includes sleep_hours and sleep_in_bed_hours (both from sleep dataTypeId)', () => {
     const sleepHours = MAPPINGS.find(m => m.metric === 'sleep_hours');
-    const sleepAsleep = MAPPINGS.find(m => m.metric === 'sleep_asleep_hours');
+    const sleepInBed = MAPPINGS.find(m => m.metric === 'sleep_in_bed_hours');
     expect(sleepHours).toBeDefined();
-    expect(sleepAsleep).toBeDefined();
+    expect(sleepInBed).toBeDefined();
     expect(sleepHours?.dataTypeId).toBe('sleep');
-    expect(sleepAsleep?.dataTypeId).toBe('sleep');
+    expect(sleepInBed?.dataTypeId).toBe('sleep');
   });
 
   test('list-method entries with a matching fixture file have that file accessible', () => {

--- a/scripts/luna-vitals/connectors/map/table.ts
+++ b/scripts/luna-vitals/connectors/map/table.ts
@@ -222,7 +222,7 @@ export const MAPPINGS: Mapping[] = [
     aggregate: 'sum',
     note: 'Dot path into nested amountConsumed object.',
   },
-  // sleep → two entries (in-bed duration + asleep duration)
+  // sleep → two entries (asleep duration + in-bed duration)
   {
     dataTypeId: 'sleep',
     metric: 'sleep_hours',
@@ -230,16 +230,16 @@ export const MAPPINGS: Mapping[] = [
     valuePath: '',
     unit: 'hours',
     aggregate: 'duration',
-    note: 'Total time-in-bed: main-session (longest) interval (end − start) per local date. Two entries for sleep dataTypeId; see also sleep_asleep_hours.',
+    note: 'Total asleep time: sum of non-AWAKE stage durations in the main sleep session. Only emitted when > 0 (stage-less sessions have no asleep figure). Two entries for sleep dataTypeId; see also sleep_in_bed_hours.',
   },
   {
     dataTypeId: 'sleep',
-    metric: 'sleep_asleep_hours',
+    metric: 'sleep_in_bed_hours',
     category: 'interval',
     valuePath: '',
     unit: 'hours',
     aggregate: 'duration',
-    note: 'Total asleep time: sum of non-AWAKE stage durations in the main sleep session. Second entry for sleep dataTypeId.',
+    note: 'Total time-in-bed: main-session (longest) interval (end − start) per local date. Always emitted for a valid session. Second entry for sleep dataTypeId.',
   },
 
   // ── Rollup-only (dailyRollUp method; shape TBD) ──────────────────────────────

--- a/scripts/luna-vitals/templates/_series.md
+++ b/scripts/luna-vitals/templates/_series.md
@@ -4,8 +4,8 @@
 |---|---|---|---|
 | migraine | 0–3 | headache/migraine severity that day | self-report (vault backfill HIMMEL-355) |
 | skin_flare | 0–3 | atopic-dermatitis flare severity | self-report |
-| sleep_hours | hours | sleep duration | device export / self-report |
-| sleep_asleep_hours | hours | total asleep time within main sleep session | device export (Google Health API, HIMMEL-609) |
+| sleep_hours | hours | hours asleep (sum of non-AWAKE stages within main sleep session) | device export / self-report |
+| sleep_in_bed_hours | hours | total time-in-bed within main sleep session | device export (Google Health API, HIMMEL-609) |
 | hrv_ms | ms | heart-rate variability | device export |
 | daily_hrv_ms | ms | historical daily HRV RMSSD aggregate (Fitbit daily aggregate; live data uses hrv_ms) | device export (Google Health API, HIMMEL-609) |
 | rhr_bpm | bpm | resting heart rate | device export |

--- a/scripts/luna-vitals/tests/writeSeries.test.ts
+++ b/scripts/luna-vitals/tests/writeSeries.test.ts
@@ -58,6 +58,18 @@ test("an empty artifact (rows: []) writes nothing and returns []", async () => {
   expect(res).toEqual([]);
 });
 
+test("preserves existing sleep_hours row when a stage-less date emits no sleep_hours (HIMMEL-785)", async () => {
+  const dir = tmp();
+  await Bun.write(join(dir, "sleep_hours.csv"), "date,value\n2024-06-14,7.5\n");
+  const a: ReviewArtifact = {
+    bucket: "x", conflicts: [],
+    rows: [{ metric: "sleep_in_bed_hours", date: "2024-06-14", value: 8.0, source: "s" }],
+  };
+  await writeSeries(a, dir);
+  expect(await Bun.file(join(dir, "sleep_hours.csv")).text()).toBe("date,value\n2024-06-14,7.5\n");
+  expect(await Bun.file(join(dir, "sleep_in_bed_hours.csv")).text()).toBe("date,value\n2024-06-14,8\n");
+});
+
 test("skips malformed rows in an existing CSV (no NaN / misaligned values seeded)", async () => {
   const dir = tmp();
   // bad rows: missing value, extra column, non-numeric value — none must survive


### PR DESCRIPTION
Propagates the sleep-semantics fix (sleep_hours = stage-derived asleep, >0 only; time-in-bed -> new sleep_in_bed_hours; sleep_asleep_hours removed), the cr-deferred follow-ups (DEFAULT_METRICS comment, NaN-stage test, SCHEMA cross-pointer), and the degraded-stage contract (malformed non-AWAKE stage timestamps -> sleep_hours omitted + stderr warning). 140/140 tests green in the propagation worktree; all 14 files byte-verified identical to private main.