### PR TITLE
fix(hermes): [HIMMEL-737] installer syncs model_aliases root->profile

### DIFF
--- a/scripts/hermes/assets/sync_model_aliases.py
+++ b/scripts/hermes/assets/sync_model_aliases.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""sync_model_aliases.py — sync the top-level `model_aliases:` block from a
+hermes root config.yaml into a profile config.yaml. Stdlib only (no PyYAML)
+so it runs under any python.
+
+hermes's one-shot dispatch path loads the PROFILE config, not the root
+config. The root config carries the `model_aliases:` block (qwen aliases +
+openrouter fallback target); a profile cloned before those aliases existed
+never picks up new/changed aliases on its own — a bare `-m qwen-plus` then
+falls through to catalog detection and breaks (HIMMEL-737). This keeps the
+profile's block synced to the root's on every install/refresh.
+
+Behavior:
+  - locate the top-level `model_aliases:` block in the root config (the line
+    starting `model_aliases:` at column 0 through the last following line
+    that is indented or blank, stopping before the next top-level key).
+  - if absent: print `SKIP <root>: no model_aliases block` and exit 0,
+    leaving the profile untouched.
+  - profile lacks the block: append the root's block verbatim at EOF.
+  - profile has the block: MERGE, not wholesale replace (codex CR —
+    profiles are user-editable and the installer advertises non-destructive
+    refresh). Root aliases win for every key present in root; alias keys
+    that exist ONLY in the profile are preserved — their whole sub-block is
+    appended after the root entries, in stable profile order — and reported
+    on one line (`preserved profile-only aliases: x, y`). Within the block
+    an alias key line is exactly-2-space indented, first char not
+    space/#/-, terminated by the LAST colon at end-of-line or before an
+    inline value — so slash keys, plain colon-bearing keys (`a/b:free`) and
+    quoted keys all round-trip; one layer of surrounding quotes is stripped
+    for the root-vs-profile name comparison. A sub-block runs until the
+    next alias key or block end (column-0 comments travel with the
+    sub-block they follow). FAIL CLOSED: a non-blank, non-comment
+    2-space-indented line that is not a recognizable alias key and has no
+    sub-block to attach to aborts the merge — `ERR: cannot merge
+    model_aliases in <path>: unrecognized entry '<line>'` + exit 2, profile
+    untouched — silent drop is the one forbidden outcome (codex CR).
+  - the rest of the profile content is preserved line-for-line (a rewrite
+    normalizes line endings to LF: text-mode read + newline="\n" write).
+    Idempotent — re-running produces no change. Writes are atomic (codex
+    CR): a temp file in the target's directory, then os.replace(), so a
+    failed write can never truncate the live profile config.
+
+Usage: sync_model_aliases.py <root_config.yaml> <profile_config.yaml>
+Exit 0 on success/skip, exit 2 on bad usage / unreadable or unwritable files.
+"""
+
+import os
+import re
+import sys
+import tempfile
+
+# an alias key inside the model_aliases block: exactly-2-space indent, first
+# char not space/#/- (deeper nesting, comments and list items excluded). The
+# terminating colon is the LAST colon at end-of-line or before an inline
+# value, so plain colon-bearing keys round-trip (`  a/b:free:` -> `a/b:free`)
+# and quoted keys are captured whole (codex CR round 3 — the narrow
+# [A-Za-z0-9_.-]+ matcher silently attached such keys to the previous entry).
+ALIAS_KEY_RE = re.compile(r"^  (?![\s#-])(.+):(?:\s.*)?$")
+
+
+def _key_name(raw):
+    """Comparison name for an alias key: one layer of surrounding quotes
+    stripped — applied identically to root and profile keys so the
+    root-vs-profile set comparison stays consistent."""
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in "\"'":
+        return raw[1:-1]
+    return raw
+
+
+def _find_block(lines, key):
+    """Return the [start, end) line-index range of the top-level `<key>:`
+    block, or None if the key has no top-level occurrence. A column-0
+    full-line comment does NOT terminate the block (in YAML it is not a new
+    top-level key — treating it as one truncated the copied aliases, codex
+    CR); comments adjacent to the block therefore travel with it."""
+    start = None
+    for i, ln in enumerate(lines):
+        if ln.startswith(key + ":") and not ln[:1].isspace():
+            start = i
+            break
+    if start is None:
+        return None
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        ln = lines[j]
+        if ln.strip() and not ln[:1].isspace() and not ln.lstrip().startswith("#"):
+            end = j
+            break
+    return start, end
+
+
+def _split_aliases(body):
+    """Split a model_aliases block body (the lines AFTER the header line)
+    into an ordered list of (name, [lines]) sub-blocks. A sub-block runs
+    from its alias key line to the next alias key line or block end, so
+    comments/blank lines travel with the sub-block they follow. Lines
+    before the first alias key are returned separately as the preamble.
+    FAIL CLOSED (codex CR round 3): a non-blank, non-comment line at
+    exactly-2-space indent that is not a recognizable alias key and has no
+    current sub-block to attach to raises ValueError(line) — silently
+    dropping a user-edited entry is the one forbidden outcome."""
+    preamble, entries = [], []
+    cur_name, cur_lines = None, []
+    for ln in body:
+        m = ALIAS_KEY_RE.match(ln)
+        if m:
+            if cur_name is not None:
+                entries.append((cur_name, cur_lines))
+            cur_name, cur_lines = _key_name(m.group(1)), [ln]
+        elif cur_name is None:
+            stripped = ln.strip()
+            if (ln.startswith("  ") and not ln[2:3].isspace()
+                    and stripped and not stripped.startswith("#")):
+                raise ValueError(ln.rstrip("\n"))
+            preamble.append(ln)
+        else:
+            cur_lines.append(ln)
+    if cur_name is not None:
+        entries.append((cur_name, cur_lines))
+    return preamble, entries
+
+
+def _write_atomic(path, lines):
+    """Write lines to path atomically: temp file in the same directory,
+    then os.replace() — a failed write never truncates the live config
+    (codex CR). Raises OSError to the caller on either step."""
+    d = os.path.dirname(os.path.abspath(path))
+    tmp = tempfile.NamedTemporaryFile("w", encoding="utf-8", newline="\n",
+                                      dir=d, delete=False)
+    try:
+        with tmp:
+            tmp.writelines(lines)
+        os.replace(tmp.name, path)
+    except OSError:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+        raise
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    root_path, profile_path = sys.argv[1], sys.argv[2]
+
+    try:
+        with open(root_path, "r", encoding="utf-8") as f:
+            root_lines = f.readlines()
+    except OSError as e:
+        print(f"ERR: cannot read {root_path}: {e}", file=sys.stderr)
+        return 2
+
+    span = _find_block(root_lines, "model_aliases")
+    if span is None:
+        print(f"SKIP {root_path}: no model_aliases block")
+        return 0
+    r_start, r_end = span
+    block = root_lines[r_start:r_end]
+    if block and not block[-1].endswith("\n"):
+        block[-1] += "\n"
+
+    try:
+        with open(profile_path, "r", encoding="utf-8") as f:
+            profile_lines = f.readlines()
+    except OSError as e:
+        print(f"ERR: cannot read {profile_path}: {e}", file=sys.stderr)
+        return 2
+
+    p_span = _find_block(profile_lines, "model_aliases")
+    preserved_names = []
+    if p_span is None:
+        if profile_lines and not profile_lines[-1].endswith("\n"):
+            profile_lines[-1] += "\n"
+        new = profile_lines + block
+        action = "appended"
+    else:
+        p_start, p_end = p_span
+        # merge: root block verbatim (root wins for keys present in root),
+        # then any profile-only alias sub-blocks, in stable profile order
+        try:
+            _, root_entries = _split_aliases(block[1:])
+        except ValueError as e:
+            print(f"ERR: cannot merge model_aliases in {root_path}: "
+                  f"unrecognized entry '{e.args[0]}'", file=sys.stderr)
+            return 2
+        try:
+            _, prof_entries = _split_aliases(profile_lines[p_start + 1:p_end])
+        except ValueError as e:
+            print(f"ERR: cannot merge model_aliases in {profile_path}: "
+                  f"unrecognized entry '{e.args[0]}'", file=sys.stderr)
+            return 2
+        root_names = {name for name, _ in root_entries}
+        merged = list(block)
+        for name, sub in prof_entries:
+            if name not in root_names:
+                preserved_names.append(name)
+                merged.extend(sub)
+        if merged and not merged[-1].endswith("\n"):
+            merged[-1] += "\n"
+        if profile_lines[p_start:p_end] == merged:
+            print(f"OK {profile_path}: model_aliases already in sync")
+            return 0
+        new = profile_lines[:p_start] + merged + profile_lines[p_end:]
+        action = "merged" if preserved_names else "replaced"
+
+    try:
+        _write_atomic(profile_path, new)
+    except OSError as e:
+        print(f"ERR: cannot write {profile_path}: {e}", file=sys.stderr)
+        return 2
+    if preserved_names:
+        print("preserved profile-only aliases: " + ", ".join(preserved_names))
+    print(f"{action} model_aliases block in {profile_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hermes/install-himmel-profile.ps1
+++ b/scripts/hermes/install-himmel-profile.ps1
@@ -25,8 +25,9 @@ $AssetDir = Join-Path $PSScriptRoot "assets"
 $SoulAsset = Join-Path $AssetDir "himmel-agent.SOUL.md"
 $GuardAsset = Join-Path $AssetDir "parity_guard.py"
 $Wire = Join-Path $AssetDir "wire_parity_guard.py"
+$Sync = Join-Path $AssetDir "sync_model_aliases.py"
 
-foreach ($f in @($SoulAsset, $GuardAsset, $Wire)) {
+foreach ($f in @($SoulAsset, $GuardAsset, $Wire, $Sync)) {
   if (-not (Test-Path $f)) { throw "missing asset: $f" }
 }
 
@@ -89,10 +90,19 @@ if (-not (Test-Path $HaDir)) { throw "$Profile_ profile dir missing after create
 Copy-Item $SoulAsset $HaSoul -Force
 Write-Host "installed   : $HaSoul"
 
-# 4. wire himmel_agent's pre_tool_call hook -> parity_guard (full set)
+# 4. sync the root config's model_aliases block onto himmel_agent (HIMMEL-737):
+#    the one-shot dispatch path loads the PROFILE config, not the root config,
+#    so a profile cloned before the aliases existed never picks them up on
+#    its own - keep it synced on every create/refresh.
+& $Py $Sync (Join-Path $HomeDir "config.yaml") $HaConfig
+# $ErrorActionPreference=Stop does NOT trap native exit codes - check
+# explicitly so a failed sync cannot end in "OK: provisioned" (CR finding).
+if ($LASTEXITCODE -ne 0) { throw "sync_model_aliases.py failed (exit $LASTEXITCODE) syncing model_aliases into $HaConfig" }
+
+# 5. wire himmel_agent's pre_tool_call hook -> parity_guard (full set)
 & $Py $Wire set $HaConfig $GuardDest $Py
 
-# 5. universal guard (HIMMEL-744): ensure parity_guard on EVERY other profile.
+# 6. universal guard (HIMMEL-744): ensure parity_guard on EVERY other profile.
 #    Default (no flag) = the `default` profile + all others. -ParityGuard <csv>
 #    narrows to named profiles; all is the explicit form of the default. ensure
 #    is non-clobbering: swaps a luna_vault_guard, adds the guard where none

--- a/scripts/hermes/install-himmel-profile.sh
+++ b/scripts/hermes/install-himmel-profile.sh
@@ -35,8 +35,9 @@ ASSETS="$SCRIPT_DIR/assets"
 SOUL_ASSET="$ASSETS/himmel-agent.SOUL.md"
 GUARD_ASSET="$ASSETS/parity_guard.py"
 WIRE="$ASSETS/wire_parity_guard.py"
+SYNC="$ASSETS/sync_model_aliases.py"
 
-for f in "$SOUL_ASSET" "$GUARD_ASSET" "$WIRE"; do
+for f in "$SOUL_ASSET" "$GUARD_ASSET" "$WIRE" "$SYNC"; do
   [ -f "$f" ] || { echo "ERR: missing asset: $f" >&2; exit 1; }
 done
 
@@ -101,10 +102,16 @@ fi
 cp "$SOUL_ASSET" "$HA_SOUL"
 echo "installed   : $HA_SOUL"
 
-# 4. wire himmel_agent's pre_tool_call hook -> parity_guard (full set)
+# 4. sync the root config's model_aliases block onto himmel_agent (HIMMEL-737):
+#    the one-shot dispatch path loads the PROFILE config, not the root config,
+#    so a profile cloned before the aliases existed never picks them up on
+#    its own - keep it synced on every create/refresh.
+"$PYBIN" "$SYNC" "$HOME_DIR/config.yaml" "$HA_CONFIG"
+
+# 5. wire himmel_agent's pre_tool_call hook -> parity_guard (full set)
 "$PYBIN" "$WIRE" set "$HA_CONFIG" "$GUARD_DEST" "$PYBIN"
 
-# 5. universal guard (HIMMEL-744): ensure parity_guard on EVERY other profile.
+# 6. universal guard (HIMMEL-744): ensure parity_guard on EVERY other profile.
 #    Default (no flag) = the `default` profile + all others. --parity-guard=<csv>
 #    narrows to named profiles; =all is the explicit form of the default. ensure
 #    is non-clobbering: swaps a luna_vault_guard, adds the guard where none

--- a/scripts/hermes/test-install-himmel-profile.sh
+++ b/scripts/hermes/test-install-himmel-profile.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALLER="$SCRIPT_DIR/install-himmel-profile.sh"
+SYNC_SCRIPT="$SCRIPT_DIR/assets/sync_model_aliases.py"
 
 PYBIN="$(command -v python3 || command -v python)" || {
   echo "SKIP: no python available" >&2; exit 0; }
@@ -130,6 +131,227 @@ assert_contains "$HOME_DIR/profiles/research/config.yaml" "logger.py" "unrelated
 # legacy luna_vault_guard swapped in place
 assert_contains "$HOME_DIR/profiles/legacy/config.yaml" "parity_guard.py" "legacy profile swapped to parity"
 assert_absent   "$HOME_DIR/profiles/legacy/config.yaml" "luna_vault_guard.py" "legacy luna_vault_guard removed"
+
+echo "== model_aliases sync (HIMMEL-737): sync_model_aliases.py direct =="
+MA_TMP="$TMP/model_aliases"
+mkdir -p "$MA_TMP"
+
+# (a) root has model_aliases, profile lacks it -> appended
+cat > "$MA_TMP/root_with.yaml" <<'EOF'
+model:
+  default: gpt-5.5
+model_aliases:
+  qwen-plus:
+    model: qwen-plus
+    provider: alibaba-coding-plan
+EOF
+cat > "$MA_TMP/profile_none.yaml" <<'EOF'
+model:
+  default: gpt-5.5
+hooks: {}
+EOF
+"$PYBIN" "$SYNC_SCRIPT" "$MA_TMP/root_with.yaml" "$MA_TMP/profile_none.yaml" >/dev/null
+assert_contains "$MA_TMP/profile_none.yaml" "model_aliases:" "(a) block appended when profile lacks it"
+assert_contains "$MA_TMP/profile_none.yaml" "qwen-plus" "(a) alias content copied"
+
+# (b) profile has a stale model_aliases block -> replaced by root's
+cat > "$MA_TMP/profile_stale.yaml" <<'EOF'
+model:
+  default: gpt-5.5
+model_aliases:
+  qwen-plus:
+    model: STALE-VALUE
+hooks: {}
+EOF
+"$PYBIN" "$SYNC_SCRIPT" "$MA_TMP/root_with.yaml" "$MA_TMP/profile_stale.yaml" >/dev/null
+assert_absent   "$MA_TMP/profile_stale.yaml" "STALE-VALUE" "(b) stale alias value replaced"
+assert_contains "$MA_TMP/profile_stale.yaml" "alibaba-coding-plan" "(b) root's alias content now present"
+assert_contains "$MA_TMP/profile_stale.yaml" "hooks: {}" "(b) rest of profile preserved"
+
+# (c) root lacks model_aliases -> SKIP printed, profile untouched
+cat > "$MA_TMP/root_without.yaml" <<'EOF'
+model:
+  default: gpt-5.5
+EOF
+cat > "$MA_TMP/profile_c.yaml" <<'EOF'
+model:
+  default: gpt-5.5
+hooks: {}
+EOF
+cp "$MA_TMP/profile_c.yaml" "$MA_TMP/profile_c.before"
+out="$("$PYBIN" "$SYNC_SCRIPT" "$MA_TMP/root_without.yaml" "$MA_TMP/profile_c.yaml")"
+case "$out" in
+  SKIP*"no model_aliases block") pass "(c) SKIP printed when root lacks model_aliases" ;;
+  *) fail "(c) SKIP not printed (got: $out)" ;;
+esac
+if diff -q "$MA_TMP/profile_c.before" "$MA_TMP/profile_c.yaml" >/dev/null; then
+  pass "(c) profile untouched when root lacks model_aliases"
+else
+  fail "(c) profile was modified despite root lacking model_aliases"
+fi
+
+# (d) idempotence: re-running on an already-synced profile changes nothing
+cp "$MA_TMP/profile_none.yaml" "$MA_TMP/profile_none.once"
+"$PYBIN" "$SYNC_SCRIPT" "$MA_TMP/root_with.yaml" "$MA_TMP/profile_none.yaml" >/dev/null
+if diff -q "$MA_TMP/profile_none.once" "$MA_TMP/profile_none.yaml" >/dev/null; then
+  pass "(d) idempotent re-run produces identical profile"
+else
+  fail "(d) re-run changed an already-synced profile"
+fi
+
+# (g) column-0 full-line comment INSIDE the block does not truncate the copy
+cat > "$MA_TMP/root_comment.yaml" <<'EOF'
+model_aliases:
+  qwen-plus:
+    provider: alibaba-coding-plan
+# CR tier below
+  qwen3-coder-plus:
+    provider: alibaba-coding-plan
+security:
+  level: high
+EOF
+cat > "$MA_TMP/profile_g.yaml" <<'EOF'
+model:
+  default: gpt-5.5
+EOF
+"$PYBIN" "$SYNC_SCRIPT" "$MA_TMP/root_comment.yaml" "$MA_TMP/profile_g.yaml" >/dev/null
+assert_contains "$MA_TMP/profile_g.yaml" "qwen3-coder-plus" "(g) alias after column-0 comment synced (not truncated)"
+assert_absent   "$MA_TMP/profile_g.yaml" "security:" "(g) next top-level key still terminates the block"
+
+# (e) root block at literal EOF with NO trailing newline -> replace stays well-formed
+#     (guards the newline-pad branches; without them writelines glues lines)
+printf 'model:\n  default: gpt-5.5\nmodel_aliases:\n  qwen-plus:\n    provider: alibaba-coding-plan' > "$MA_TMP/root_noeol.yaml"
+cat > "$MA_TMP/profile_e.yaml" <<'EOF'
+model_aliases:
+  qwen-plus:
+    provider: STALE
+hooks: {}
+EOF
+"$PYBIN" "$SYNC_SCRIPT" "$MA_TMP/root_noeol.yaml" "$MA_TMP/profile_e.yaml" >/dev/null
+assert_contains "$MA_TMP/profile_e.yaml" "alibaba-coding-plan" "(e) no-eol root block synced"
+if grep -q "alibaba-coding-planhooks" "$MA_TMP/profile_e.yaml"; then
+  fail "(e) lines glued: newline pad on the root block regressed"
+else
+  pass "(e) block boundary intact after no-eol root sync"
+fi
+
+# (f) profile with NO trailing newline + no model_aliases -> append stays well-formed
+printf 'model:\n  default: gpt-5.5\nhooks: {}' > "$MA_TMP/profile_f.yaml"
+"$PYBIN" "$SYNC_SCRIPT" "$MA_TMP/root_with.yaml" "$MA_TMP/profile_f.yaml" >/dev/null
+assert_contains "$MA_TMP/profile_f.yaml" "model_aliases:" "(f) block appended to no-eol profile"
+if grep -q "hooks: {}model_aliases" "$MA_TMP/profile_f.yaml"; then
+  fail "(f) lines glued: newline pad on the profile tail regressed"
+else
+  pass "(f) append boundary intact on no-eol profile"
+fi
+
+# (h) profile has root aliases (stale) + a profile-only alias -> merge:
+#     root values refreshed, profile-only alias preserved, preserved-line printed
+cat > "$MA_TMP/profile_h.yaml" <<'EOF'
+model:
+  default: gpt-5.5
+model_aliases:
+  qwen-plus:
+    model: STALE-VALUE
+  my-local:
+    model: my-local-model
+    provider: custom
+hooks: {}
+EOF
+out="$("$PYBIN" "$SYNC_SCRIPT" "$MA_TMP/root_with.yaml" "$MA_TMP/profile_h.yaml")"
+assert_absent   "$MA_TMP/profile_h.yaml" "STALE-VALUE" "(h) root-shared alias value refreshed"
+assert_contains "$MA_TMP/profile_h.yaml" "alibaba-coding-plan" "(h) root's alias content now present"
+assert_contains "$MA_TMP/profile_h.yaml" "my-local:" "(h) profile-only alias preserved"
+assert_contains "$MA_TMP/profile_h.yaml" "provider: custom" "(h) profile-only sub-block intact"
+case "$out" in
+  *"preserved profile-only aliases: my-local"*) pass "(h) preserved-line printed" ;;
+  *) fail "(h) preserved-line missing (got: $out)" ;;
+esac
+
+# (i) idempotence of the MERGED result: second run byte-identical
+cp "$MA_TMP/profile_h.yaml" "$MA_TMP/profile_h.once"
+"$PYBIN" "$SYNC_SCRIPT" "$MA_TMP/root_with.yaml" "$MA_TMP/profile_h.yaml" >/dev/null
+if diff -q "$MA_TMP/profile_h.once" "$MA_TMP/profile_h.yaml" >/dev/null; then
+  pass "(i) merged result idempotent (second run byte-identical)"
+else
+  fail "(i) re-run changed an already-merged profile"
+fi
+
+# (j) merge ordering: root keys first, then preserved profile-only keys
+r_ln="$(grep -n '^  qwen-plus:' "$MA_TMP/profile_h.yaml" | head -1 | cut -d: -f1)"
+p_ln="$(grep -n '^  my-local:' "$MA_TMP/profile_h.yaml" | head -1 | cut -d: -f1)"
+if [ -n "$r_ln" ] && [ -n "$p_ln" ] && [ "$r_ln" -lt "$p_ln" ]; then
+  pass "(j) root keys precede preserved profile-only keys"
+else
+  fail "(j) merge ordering wrong (root at line ${r_ln:-?}, profile-only at line ${p_ln:-?})"
+fi
+
+# (k) profile-only alias with a slash+colon key (openrouter-style) survives a merge
+#     (codex CR round 3: the narrow key matcher attached it to the previous entry)
+cat > "$MA_TMP/profile_k.yaml" <<'EOF'
+model:
+  default: gpt-5.5
+model_aliases:
+  qwen-plus:
+    model: STALE-VALUE
+  qwen/qwen3-next-80b-a3b-instruct:free:
+    provider: openrouter
+hooks: {}
+EOF
+out="$("$PYBIN" "$SYNC_SCRIPT" "$MA_TMP/root_with.yaml" "$MA_TMP/profile_k.yaml")"
+assert_contains "$MA_TMP/profile_k.yaml" "qwen/qwen3-next-80b-a3b-instruct:free:" "(k) slash+colon profile-only key preserved"
+assert_contains "$MA_TMP/profile_k.yaml" "provider: openrouter" "(k) its sub-block intact"
+assert_absent   "$MA_TMP/profile_k.yaml" "STALE-VALUE" "(k) root-shared key still refreshed"
+case "$out" in
+  *"preserved profile-only aliases: qwen/qwen3-next-80b-a3b-instruct:free"*) pass "(k) preserved-line names the colon-bearing key" ;;
+  *) fail "(k) preserved-line wrong (got: $out)" ;;
+esac
+
+# (l) profile-only QUOTED key preserved through a merge
+cat > "$MA_TMP/profile_l.yaml" <<'EOF'
+model_aliases:
+  qwen-plus:
+    model: STALE-VALUE
+  "my:alias":
+    provider: custom
+hooks: {}
+EOF
+"$PYBIN" "$SYNC_SCRIPT" "$MA_TMP/root_with.yaml" "$MA_TMP/profile_l.yaml" >/dev/null
+assert_contains "$MA_TMP/profile_l.yaml" '"my:alias":' "(l) quoted profile-only key preserved"
+assert_contains "$MA_TMP/profile_l.yaml" "provider: custom" "(l) quoted key sub-block intact"
+
+# (m) unparseable 2-space line with no sub-block to attach to -> fail closed:
+#     exit 2, ERR on stderr, profile byte-identical (never silently dropped)
+cat > "$MA_TMP/profile_m.yaml" <<'EOF'
+model_aliases:
+  not a parseable entry
+  qwen-plus:
+    model: STALE-VALUE
+hooks: {}
+EOF
+cp "$MA_TMP/profile_m.yaml" "$MA_TMP/profile_m.before"
+rc=0
+"$PYBIN" "$SYNC_SCRIPT" "$MA_TMP/root_with.yaml" "$MA_TMP/profile_m.yaml" >/dev/null 2>"$MA_TMP/m.err" || rc=$?
+if [ "$rc" = "2" ]; then pass "(m) unparseable entry fails closed (exit 2)"; else fail "(m) expected exit 2, got $rc"; fi
+assert_contains "$MA_TMP/m.err" "unrecognized entry" "(m) ERR names the unrecognized entry"
+if diff -q "$MA_TMP/profile_m.before" "$MA_TMP/profile_m.yaml" >/dev/null; then
+  pass "(m) profile untouched on fail-closed"
+else
+  fail "(m) profile modified despite fail-closed"
+fi
+
+echo "== scenario G: model_aliases synced onto pre-existing himmel_agent (refresh path, HIMMEL-737) =="
+rm -rf "$HOME_DIR/profiles"; mkdir -p "$HOME_DIR/profiles"
+seed_default empty
+# root config carries model_aliases (drift case: added to root after himmel_agent was cloned)
+printf 'model_aliases:\n  qwen-plus:\n    model: qwen-plus\n    provider: alibaba-coding-plan\n' >> "$HOME_DIR/config.yaml"
+# pre-existing himmel_agent WITHOUT model_aliases (simulates a profile cloned before the block existed)
+mkdir -p "$HOME_DIR/profiles/himmel_agent"
+printf 'model:\n  default: gpt-5.5\nhooks: {}\n' > "$HOME_DIR/profiles/himmel_agent/config.yaml"
+run >/dev/null
+assert_contains "$HOME_DIR/profiles/himmel_agent/config.yaml" "model_aliases:" "(G) refresh path syncs model_aliases onto existing himmel_agent"
+assert_contains "$HOME_DIR/profiles/himmel_agent/config.yaml" "alibaba-coding-plan" "(G) synced alias content matches root"
+assert_contains "$HOME_DIR/profiles/himmel_agent/config.yaml" "parity_guard.py" "(G) hook still wired after alias sync"
 
 echo ""
 if [ "$fails" -eq 0 ]; then echo "ALL PASS"; else echo "$fails FAILED" >&2; exit 1; fi


### PR DESCRIPTION
Code-only propagation. stdlib sync_model_aliases.py: MERGE root-wins + profile-only keys preserved + fail-closed on unparseable keys; atomic write; ps1 LASTEXITCODE throw.