### PR TITLE
fix(lanes): [HIMMEL-780] free-bank lane probes installed->path + buildCtx lockstep guard

### DIFF
--- a/scripts/lanes/lanes.json
+++ b/scripts/lanes/lanes.json
@@ -14,18 +14,18 @@
     { "id": "codex",  "label": "codex (paid, via hermes)", "class": "critic", "bestFor": "CR escalation, second opinions (CR_PROFILE=paid)", "effort": "consumes OpenAI bank",
       "probe": { "kind": "crprofile", "token": "paid" } },
     { "id": "copilot-cli", "label": "GitHub Copilot CLI (free tier)", "class": "bulk", "bestFor": "free chores / second opinions — 2,000 completions/mo bank; AUTO model only (Haiku 4.5 / GPT-5 mini class, NO per-dispatch model selection); operator ran /allow-all; worker-spawn-matrix row UNVERIFIED (guard coverage + skills-load pending eval)", "effort": "small tasks only — model tier is mini-class",
-      "probe": { "kind": "installed", "tool": "copilot" } },
+      "probe": { "kind": "path", "cli": "copilot" } },
     { "id": "hermes-oneshot", "label": "hermes one-shot (scripts/hermes/dispatch-trusted.sh)", "class": "impl", "bestFor": "trusted-engine impl/build dispatch — multi-provider chokepoint (default gpt-5.5 codex; --model selects e.g. qwen3-coder-plus); parity_guard fences writes; LIVE-PROVEN spawn path (worker-spawn matrix)", "effort": "no internal timeout — caller wraps; toolsets opt-in via --toolsets",
       "probe": { "kind": "installed", "tool": "hermes" } },
     { "id": "codex-exec", "label": "codex CLI sandbox (scripts/codex/dispatch-codex-exec.sh)", "class": "impl", "bestFor": "offloaded impl in a git worktree via the codex CLI sandbox - dispatch ONLY via bash scripts/codex/dispatch-codex-exec.sh --worktree <wt> <args> (the chokepoint ENFORCES the HIMMEL-741 invariants: ACL preflight fail-closed, gpt-5.5 pin - codex-variant names 400 on ChatGPT auth, --background refused - upstream silent death; pair long runs with scripts/codex/companion-liveness.sh)", "effort": "well-scoped chunks; job registry is per-workspace",
       "probe": { "kind": "path", "cli": "codex" } },
     { "id": "antigravity-cli", "label": "Antigravity CLI (Google AI Plus)", "class": "bulk", "bestFor": "free-bank chores/second opinions — roster per 2026-07-08 research: Gemini 3.5 Flash / 3.1 Pro + Claude Sonnet/Opus 4.6 + GPT-OSS 120B (AI-Plus subset + quota shape TO VERIFY at eval, HIMMEL-772); headless agy -p; EGRESS: gemini-family cells are matrix-DENIED for vault corpora (himmel-code only); parity/guards UNVERIFIED — permission flags only, NO hook surface (wrapper-level guards required)", "effort": "simple tasks; --output-format drift seen on Windows builds",
-      "probe": { "kind": "installed", "tool": "agy" } },
+      "probe": { "kind": "path", "cli": "agy" } },
     { "id": "ollama-local", "label": "ollama (local models)", "class": "bulk", "bestFor": "zero-egress local inference (qwen2.5-coder:7b pulled) — the ONLY salus-eligible backend (per-run opt-in) and the graphify zero-egress fallback; zero-egress PIN: OLLAMA_NO_CLOUD=1 (boot-verifiable) + bare model names (cloud is opt-in via the -cloud suffix); slow, small tasks", "effort": "free, local wall-clock",
-      "probe": { "kind": "installed", "tool": "ollama" } },
+      "probe": { "kind": "path", "cli": "ollama" } },
     { "id": "openrouter-free", "label": "OpenRouter free models", "class": "bulk", "bestFor": "free-tier model pool — probe web for current uptime/availability before routing; simple tasks only; rate-limited; parity/guards UNVERIFIED pending eval", "effort": "availability varies by model/day",
       "probe": { "kind": "env", "name": "OPENROUTER_API_KEY" } },
     { "id": "ollama-cloud", "label": "Ollama Cloud (free tier, ollama.com)", "class": "bulk", "bestFor": "hosted open models on the free bank (verified 2026-07-08: 5h session limits + weekly limits, 1 concurrent cloud model, larger models Pro-only) — NOT the local lane: content EGRESSES to ollama.com, an UNDECLARED provider in the egress matrix -> vault corpora default-DENY (himmel-code only) until the operator declares a cell; parity/guards UNVERIFIED pending eval", "effort": "simple tasks; free-bank caps",
-      "probe": { "kind": "installed", "tool": "ollama" } }
+      "probe": { "kind": "path", "cli": "ollama" } }
   ]
 }

--- a/scripts/lanes/tests/resolve.test.mjs
+++ b/scripts/lanes/tests/resolve.test.mjs
@@ -1,10 +1,11 @@
 // scripts/lanes/tests/resolve.test.mjs
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { resolveLanes, formatCodexHealth } from '../resolve.mjs';
+import { resolveLanes, formatCodexHealth, buildCtx } from '../resolve.mjs';
 
 const REG = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'lanes.json'), 'utf8'));
 const ctx = (o = {}) => ({ env: o.env ?? {}, pathHas: (c) => (o.paths ?? []).includes(c), installed: o.installed ?? {} });
@@ -35,6 +36,38 @@ test('codex-exec lane keys off the codex CLI on PATH (HIMMEL-781)', () => {
 test('hermes-critics lane keys off the resolved install', () => {
   assert.ok(resolveLanes(REG, ctx({ installed: { hermes: true } })).some((l) => l.id === 'hermes-critics'));
   assert.ok(!resolveLanes(REG, ctx()).some((l) => l.id === 'hermes-critics'));
+});
+// HIMMEL-780 — these four rows used probe kind "installed" with tools buildCtx
+// never populates, so they could NEVER resolve; they key off PATH now.
+test('free-bank CLI lanes (copilot/agy/ollama) resolve via PATH (HIMMEL-780)', () => {
+  const onPath = resolveLanes(REG, ctx({ paths: ['copilot', 'agy', 'ollama'] })).map((l) => l.id);
+  for (const id of ['copilot-cli', 'antigravity-cli', 'ollama-local', 'ollama-cloud']) {
+    assert.ok(onPath.includes(id), `${id} should resolve with its CLI on PATH`);
+    assert.ok(!resolveLanes(REG, ctx()).some((l) => l.id === id), `${id} should not resolve on a bare machine`);
+  }
+});
+test('buildCtx pathHas does real PATH/PATHEXT lookup (HIMMEL-780 follow-through)', () => {
+  const bin = mkdtempSync(join(tmpdir(), 'lanes-bin-'));
+  writeFileSync(join(bin, 'copilot.cmd'), '@echo off\n');
+  writeFileSync(join(bin, 'agy'), '#!/bin/sh\n');
+  const repo = mkdtempSync(join(tmpdir(), 'lanes-repo-'));
+  const { pathHas } = buildCtx(repo, { PATH: bin, PATHEXT: '.COM;.EXE;.BAT;.CMD' });
+  if (process.platform === 'win32') {
+    assert.equal(pathHas('copilot'), true, 'PATHEXT .cmd shim should resolve on Windows');
+    assert.equal(pathHas('agy'), false, 'bare extensionless file is not executable on Windows');
+  } else {
+    assert.equal(pathHas('agy'), true, 'bare name should resolve on POSIX');
+    assert.equal(pathHas('copilot'), false, 'POSIX matches the bare name only, not .cmd');
+  }
+  assert.equal(pathHas('missing-cli'), false);
+});
+test('every "installed" probe names a tool buildCtx actually populates (HIMMEL-780 lockstep guard)', () => {
+  const populated = Object.keys(buildCtx(mkdtempSync(join(tmpdir(), 'lanes-ctx-')), {}).installed);
+  for (const l of REG.lanes) {
+    if (l.probe?.kind !== 'installed') continue;
+    assert.ok(populated.includes(l.probe.tool),
+      `${l.id}: probe tool "${l.probe.tool}" is not populated by buildCtx (${populated.join(', ')}) — it can never resolve; use kind "path" or extend buildCtx`);
+  }
 });
 test('registry is valid JSON with the required per-lane keys', () => {
   for (const l of REG.lanes) for (const k of ['id', 'label', 'class', 'probe']) assert.ok(k in l, `${l.id ?? '?'} missing ${k}`);


### PR DESCRIPTION
Code-only propagation. Four free-bank lane rows declared probe kind 'installed' with tools buildCtx never populates - could never resolve in /lanes. Switched to the PATHEXT-aware 'path' probe; lockstep test + first real PATH/PATHEXT coverage of pathHasFactory.