### PR TITLE
fix(agents-md): [HIMMEL-806] cover 2026-07-08 lane-table phrasings in debrand (3 Fable leaks)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,9 +143,9 @@ nothing. Route by lane. The Claude tiers are always present; their
 | Lane | Best for | Effort / notes |
 |---|---|---|
 | Haiku | bulk mechanical (never delegates further) | low |
-| Sonnet 5 | scoped research; **implementor candidate** (operator 2026-07-08: token-normalized pricing makes it competitive for well-specified impl — compare per task vs Fable-low) | medium default; scale up by task length |
+| Sonnet 5 | scoped research; **implementor candidate** (operator 2026-07-08: token-normalized pricing makes it competitive for well-specified impl — compare per task vs top-model-low) | medium default; scale up by task length |
 | Opus 4.8 | multi-step reasoning; **default parent/orchestrator** | xhigh default for orchestration; scale DOWN (high/medium) for lighter parenting or scoped impl |
-| Fable 5 | judgment, taste — hardest calls; escalation target | scale to the item (operator 2026-07-08, un-capped): medium default; **high for substantial judgment work — not just the hardest**; xhigh for the hardest |
+| top model | judgment, taste — hardest calls; escalation target | scale to the item (operator 2026-07-08, un-capped): medium default; **high for substantial judgment work — not just the hardest**; xhigh for the hardest |
 
 Beyond the Claude tiers the fleet includes machine-specific impl/critic/
 bulk lanes (paid/optional — they exist only where the operator configured
@@ -167,7 +167,7 @@ Raise *effort* before raising model tier — on Claude, Fable-5 `low` ≈ prior-
 `xhigh`, and the same shift applies down-tier. Effort is a PER-DISPATCH
 lever: use the full scale per item, don't flatten to one default.
 (Temperature is Claude-API-only — DEFERRED for now; rides HIMMEL-774.)
-Fable stays CONSERVED (limited release) — the spread optimizes
+The top model stays CONSERVED (limited release) — the spread optimizes
 Sonnet/Opus/impl lanes. Full per-lane calibration (web pricing +
 benchmark index analysis) = HIMMEL-774, later phase.
 Invariants (not model-tuned): spawn-depth limit **2** (kept on

--- a/scripts/agents-md/debrand.json
+++ b/scripts/agents-md/debrand.json
@@ -35,9 +35,9 @@
     "note": "HIMMEL-559: the effort calibration is a Claude-family fact (false for GPT) — attribute it instead of asserting it about the reading model. Embedded newline matches CLAUDE.md's wrap, same caveat as above."
   },
   {
-    "from": "| Fable 5 | judgment, taste — the ~10% hardest calls; escalation target |",
-    "to": "| top model | judgment, taste — the ~10% hardest calls; escalation target |",
-    "note": "HIMMEL-688 lane table row — neutral tier language for non-Claude drivers; table rows never wrap so the full-cell match is stable."
+    "from": "| Fable 5 | judgment, taste — hardest calls; escalation target |",
+    "to": "| top model | judgment, taste — hardest calls; escalation target |",
+    "note": "HIMMEL-688 lane table row — neutral tier language for non-Claude drivers; table rows never wrap so the full-cell match is stable. Re-matched after the 2026-07-08 effort-calibration rewording dropped 'the ~10%' (HIMMEL-806)."
   },
   {
     "from": "spawns a Fable child",
@@ -48,5 +48,15 @@
     "from": "Fable-as-parent",
     "to": "Top-model-as-parent",
     "note": "HIMMEL-688 escalation prose — same neutralization."
+  },
+  {
+    "from": "compare per task vs Fable-low",
+    "to": "compare per task vs top-model-low",
+    "note": "HIMMEL-806: Sonnet-row pricing comparison added 2026-07-08 — neutral tier language; full-phrase so it never matches the attributed calibration line."
+  },
+  {
+    "from": "Fable stays CONSERVED (limited release)",
+    "to": "The top model stays CONSERVED (limited release)",
+    "note": "HIMMEL-806: conservation note added 2026-07-08 — sentence-initial, single line, so the full-phrase match is stable."
   }
 ]


### PR DESCRIPTION
Fixes the shell-unit red on every CI run since 2026-07-08: three lane-table Fable phrasings were uncovered by debrand.json, so generated AGENTS.md leaked Fable text and test-generate.sh's leak check failed. Re-matches the dormant table-row rule, adds two full-phrase rules, regenerates AGENTS.md. Verified in this worktree: 30 passed, 0 failed.