### PR TITLE
fix(guardrails): [HIMMEL-808] lesson-write-fence _abs path-classification bypasses (POSIX backslash + drive-relative)

### DIFF
--- a/scripts/guardrails/lesson-write-fence.sh
+++ b/scripts/guardrails/lesson-write-fence.sh
@@ -347,15 +347,30 @@ _strip_wrap() {
 _abs() {
     local p; p="$(_strip_wrap "$1")"
     local base="${2:-$PWD}"
+    # Backslashes -> forward slashes BEFORE the absolute/relative split
+    # (HIMMEL-808): on POSIX a backslash-form target ('\tmp\x' or 'C:\x')
+    # matches neither /* nor [A-Za-z]:* below, gets anchored to cwd, and
+    # normalizes to a non-enforcement path -> allow. Windows-payload parity
+    # on every host; fail-closed for the rare POSIX filename containing a
+    # literal backslash (_normalize already collapses them the same way).
+    p="${p//\\//}"
     # shellcheck disable=SC2088 # the "~/" is a literal case-pattern, not an expansion
     case "$p" in
         "~")   p="$HOME" ;;
         "~/"*) p="$HOME/${p#\~/}" ;;
     esac
     case "$p" in
-        /*)         : ;;             # POSIX absolute
-        [A-Za-z]:*) : ;;             # Windows drive-absolute (C:/...)
-        *)          p="$base/$p" ;;  # relative -> anchor to base
+        /*)          : ;;             # POSIX absolute
+        [A-Za-z]:/*) : ;;             # Windows drive-ROOTED absolute (C:/...)
+        [A-Za-z]:*)  p="$base/${p#?:}" ;;
+                     # Windows drive-RELATIVE (C:foo = foo relative to the
+                     # cwd on drive C). Codex-adv HIMMEL-808: the old
+                     # [A-Za-z]:* arm classified this absolute, and
+                     # _normalize mangled it into a synthetic non-repo path
+                     # -> allow. Anchor to the payload cwd instead — exact
+                     # when cwd is on that drive (the attack shape), and a
+                     # fail-closed lexical approximation otherwise.
+        *)           p="$base/$p" ;;  # relative -> anchor to base
     esac
     printf '%s' "$p"
 }

--- a/scripts/guardrails/test-lesson-write-fence.sh
+++ b/scripts/guardrails/test-lesson-write-fence.sh
@@ -251,6 +251,15 @@ BACKSLASH_TARGET="$REPO/scripts/hooks/y.sh"
 BACKSLASH_TARGET="${BACKSLASH_TARGET//\//\\}"
 run_hook deny "11: backslash form -> deny" "$(write_json "$BACKSLASH_TARGET" "$REPO")" 1
 
+# Drive-RELATIVE Windows form (codex-adv HIMMEL-808): C:scripts\hooks\y.sh
+# with repo cwd means <repo>/scripts/hooks/y.sh on Windows — must deny on
+# every host (the old [A-Za-z]:* arm classified it absolute and _normalize
+# mangled it into a synthetic non-repo path -> allow).
+run_hook deny "11: drive-relative backslash form -> deny" \
+    "$(write_json 'C:scripts\hooks\y.sh' "$REPO")" 1
+run_hook deny "11: drive-relative slash form -> deny" \
+    "$(write_json 'C:scripts/hooks/y.sh' "$REPO")" 1
+
 run_hook deny "11: mixed case final component -> deny" \
     "$(write_json "$REPO/scripts/guardrails/X.SH" "$REPO")" 1
 


### PR DESCRIPTION
Fixes the last shell-unit red: backslash-form absolute paths on POSIX and drive-relative Windows forms (C:foo) were misclassified in _abs and escaped the fence. Normalize backslashes before the absolute/relative split; only drive-rooted [A-Za-z]:/* counts as absolute; drive-relative anchors to the payload cwd. 2 regression cases; suite verified green on ubuntu in this exact worktree.