### PR TITLE
fix(hooks): inject-initiative double-fire dedup + checkGlmGuards pin un-stale

### DIFF
--- a/scripts/hooks/inject-initiative.sh
+++ b/scripts/hooks/inject-initiative.sh
@@ -33,9 +33,26 @@
 # protection still applies; the exfil classifier still blocks public push).
 #
 # Hook contract (SessionStart):
-#   - Reads the SessionStart JSON payload from stdin (we don't consume fields).
+#   - Reads the SessionStart JSON payload from stdin. Only session_id is
+#     consumed (per-session-start dedup below, HIMMEL-813); no other field
+#     is read.
 #   - Exit 0 with stdout → stdout is injected as additional context.
 #   - Non-zero exit → would surface an error; we never block, only ever exit 0.
+#
+# Double-fire dedup (HIMMEL-813): this script is wired at BOTH user scope
+# (~/.claude/settings.json) and project scope (.claude/settings.json), so a
+# single SessionStart event fires it twice within seconds, doubling the
+# directive. Dedup is keyed on session_id with a ~60s FRESHNESS WINDOW, not a
+# once-per-session-id-ever marker: a resume/clear later in the SAME
+# session_id fires SessionStart again, and compaction may have dropped the
+# directive from context by then, so that later fire must still re-inject. A
+# marker younger than the window means "this is the duplicate of the two
+# near-simultaneous registrations for the same session-start event" (stay
+# silent); a marker older than the window means "this is a later, distinct
+# session-start event" (refresh + re-inject). See the marker/mkdir block
+# below for the atomicity + timestamp-freshness mechanics. Missing or
+# unparseable session_id skips dedup entirely and always injects (fail-open
+# — this hook must never suppress its own output on its own bugs).
 #
 # Wiring (in .claude/settings.json):
 #   {
@@ -54,11 +71,13 @@ set -euo pipefail
 trap 'exit 0' ERR
 
 # Drain stdin so the hook contract doesn't break the runtime if it pipes a
-# payload. We don't currently need the JSON body.
+# payload. Captured (not merely discarded) so session_id can be pulled out
+# below for the per-session-start dedup marker (HIMMEL-813).
+_ii_payload=""
 if [ -t 0 ]; then
     :
 else
-    cat >/dev/null 2>&1 || true
+    _ii_payload=$(cat 2>/dev/null) || true
 fi
 
 # --- Source the himmel clone's .env for the initiative vars (R1, HIMMEL-460) -
@@ -91,6 +110,77 @@ fi
 active=$(resolve_legs "${HIMMEL_INITIATIVE:-}" "${HIMMEL_INITIATIVE_OVERNIGHT:-}" "${HIMMEL_OVERNIGHT:-}")
 # Off when nothing resolved (unset / falsy / all-unknown subset).
 [ -n "$active" ] || exit 0
+
+# --- Per-session-start dedup (HIMMEL-813) -----------------------------------
+# Only reached once we know we're about to inject (the OFF path above already
+# exited silently, so there is nothing to dedup there). Extraction mirrors
+# the jq-first / grep -oP-fallback convention used elsewhere in this dir
+# (scripts/hooks/block-cheap-lane-pr-without-verdict.sh's extract_command).
+_ii_extract_session_id() {
+    local input="$1"
+    if command -v jq >/dev/null 2>&1; then
+        jq -r '.session_id // empty' <<<"$input" 2>/dev/null
+        return
+    fi
+    echo "$input" | grep -oP '"session_id"\s*:\s*"(\\.|[^"\\])*"' \
+        | head -1 \
+        | sed -E 's/^"session_id"\s*:\s*"(.*)"$/\1/' \
+        | sed 's/\\"/"/g'
+}
+
+_ii_sid=$(_ii_extract_session_id "$_ii_payload" || true)
+# Sanitize to a safe path component (session_id is normally a UUID; belt for
+# any stray path-hostile characters reaching the marker directory name).
+_ii_sid_safe=$(printf '%s' "$_ii_sid" | tr -c 'A-Za-z0-9._-' '-')
+
+if [ -n "$_ii_sid_safe" ]; then
+    _ii_window=60
+    _ii_now=$(date +%s)
+    _ii_marker_dir="${TMPDIR:-/tmp}/himmel-inject-initiative-${_ii_sid_safe}"
+    _ii_ts_file="$_ii_marker_dir/ts"
+
+    if mkdir "$_ii_marker_dir" 2>/dev/null; then
+        # Won the mkdir race: first of the (likely two) near-simultaneous
+        # firings for this session-start event. Stamp and proceed to inject.
+        printf '%s\n' "$_ii_now" >"$_ii_ts_file" 2>/dev/null || true
+    else
+        # Lost the mkdir race (or this is a later, distinct fire): read the
+        # existing timestamp numerically — never stat -c/-f (GNU/BSD differ).
+        _ii_ts=$(head -1 "$_ii_ts_file" 2>/dev/null || true)
+        case "$_ii_ts" in
+            ''|*[!0-9]*)
+                # Timestamp missing or unparseable. Two different causes:
+                # (1) this read raced the winner's write - resolves in <1s;
+                # (2) an orphaned/corrupted marker (winner killed pre-write,
+                #     temp-cleaner swept the file but not the dir). Case (2)
+                #     must NOT go silent - it would suppress the directive
+                #     for this session_id forever. Retry once, then fail OPEN.
+                sleep 1
+                _ii_ts=$(head -1 "$_ii_ts_file" 2>/dev/null || true)
+                ;;
+        esac
+        case "$_ii_ts" in
+            ''|*[!0-9]*)
+                # Still unreadable after the retry: orphaned/corrupted marker.
+                # Fail OPEN - refresh the stamp and fall through to inject.
+                # Worst case is one extra inject, which this dedup exists to
+                # reduce, never to buy permanent silence on our own bugs.
+                printf '%s\n' "$_ii_now" >"$_ii_ts_file" 2>/dev/null || true
+                ;;
+            *)
+                _ii_age=$(( _ii_now - _ii_ts ))
+                if [ "$_ii_age" -ge 0 ] && [ "$_ii_age" -lt "$_ii_window" ]; then
+                    exit 0  # duplicate fire of the same session-start event — silent
+                fi
+                # Stale marker: a later, distinct session-start event
+                # (resume/clear) for the same session_id. Refresh the stamp
+                # and fall through to re-inject — compaction may have dropped
+                # the directive since.
+                printf '%s\n' "$_ii_now" >"$_ii_ts_file" 2>/dev/null || true
+                ;;
+        esac
+    fi
+fi
 
 # Profile-dependent labels (which var the operator set; shown in the directive).
 if _il_truthy "${HIMMEL_OVERNIGHT:-}"; then

--- a/scripts/hooks/test-glm-subagent-path.sh
+++ b/scripts/hooks/test-glm-subagent-path.sh
@@ -65,7 +65,11 @@ if grep -qxF 'name: glm-subagent' "$REPO_ROOT/$AGENT"; then assert "(a) agent na
 # checkGlmGuards is CALLED before executeRun is CALLED. Pull the call-site line
 # numbers via parameter expansion (no head|cut pipe under pipefail -> no SIGPIPE
 # on the grep-early-exit path).
-guard_match=$(grep -m1 -n 'checkGlmGuards(plan' "$REPO_ROOT/$SPAWN_GLM" 2>/dev/null || true)
+# Match the assignment call-site shape ('= checkGlmGuards(') rather than a
+# specific argument: HIMMEL-800's runSharedDispatch refactor renamed the arg
+# (plan.worktree -> worktree) and the old 'checkGlmGuards(plan' pin broke on
+# public CI while the guard-before-run invariant itself still held.
+guard_match=$(grep -m1 -n '= checkGlmGuards(' "$REPO_ROOT/$SPAWN_GLM" 2>/dev/null || true)
 run_match=$(grep -m1 -n 'await executeRun(' "$REPO_ROOT/$SPAWN_GLM" 2>/dev/null || true)
 guard_line=${guard_match%%:*}
 run_line=${run_match%%:*}

--- a/scripts/hooks/test-inject-initiative.sh
+++ b/scripts/hooks/test-inject-initiative.sh
@@ -43,6 +43,12 @@ trap 'rm -rf "$TMPII"' EXIT
 mkdir -p "$TMPII/noenv"
 export HIMMEL_REPO="$TMPII/noenv"
 
+# Isolate the HIMMEL-813 dedup markers (${TMPDIR:-/tmp}/himmel-inject-initiative-*)
+# inside this test's own scratch dir so runs never collide with a real session's
+# markers (or each other, across re-runs) and get swept by the trap above.
+export TMPDIR="$TMPII/markers"
+mkdir -p "$TMPDIR"
+
 assert_pass() {
     pass=$((pass + 1))
     echo "  PASS: $1"
@@ -332,6 +338,79 @@ assert_has "preamble present in overnight profile" "seed your native tasklist" "
 
 # OFF-guard: tests 1/4/7/25 already assert empty stdout when unset/falsy, which
 # is the structural proof the preamble cannot leak outside the active block.
+
+# ---------- HIMMEL-813: per-session-start dedup (double-fire fix) -----------
+# The hook is wired at BOTH user scope and project scope, so a single
+# SessionStart event fires it twice within seconds. Dedup is keyed on
+# session_id with a freshness window (NOT once-per-session-id-ever), because a
+# resume/clear later in the SAME session_id must still re-inject (compaction
+# may have dropped the directive by then).
+
+# ---------- 29. Second invocation within the window, same session_id -> silent
+echo "Test 29: same session_id within the freshness window -> second call silent"
+sid29="sid-dedup-$$-a"
+out1=$(printf '{"session_id":"%s"}' "$sid29" | HIMMEL_INITIATIVE=1 bash "$hook")
+assert_has "first call injects" "HIMMEL_INITIATIVE is active" "$out1"
+out2=$(printf '{"session_id":"%s"}' "$sid29" | HIMMEL_INITIATIVE=1 bash "$hook")
+if [ -z "$out2" ]; then
+    assert_pass "second call within window stays silent"
+else
+    assert_fail "second call should be silent, got: $out2"
+fi
+printf '{"session_id":"%s"}' "$sid29" | HIMMEL_INITIATIVE=1 bash "$hook" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    assert_pass "second call still exits 0"
+else
+    assert_fail "second call should exit 0, got rc=$rc"
+fi
+
+# ---------- 30. A different session_id injects independently -----------------
+echo "Test 30: a different session_id injects independently"
+sid30="sid-dedup-$$-b"
+out=$(printf '{"session_id":"%s"}' "$sid30" | HIMMEL_INITIATIVE=1 bash "$hook")
+assert_has "different session_id injects" "HIMMEL_INITIATIVE is active" "$out"
+
+# ---------- 31. Stale marker (backdated timestamp) re-injects ----------------
+echo "Test 31: a stale marker (backdated past the window) re-injects"
+sid31="sid-dedup-$$-c"
+marker_dir="$TMPDIR/himmel-inject-initiative-${sid31}"
+mkdir -p "$marker_dir"
+printf '%s\n' "$(($(date +%s) - 3600))" >"$marker_dir/ts"
+out=$(printf '{"session_id":"%s"}' "$sid31" | HIMMEL_INITIATIVE=1 bash "$hook")
+assert_has "stale marker re-injects" "HIMMEL_INITIATIVE is active" "$out"
+
+# ---------- 32. Missing session_id skips dedup entirely (fail-open) ---------
+echo "Test 32: missing session_id injects on every call (fail-open)"
+out1=$(printf '{}' | HIMMEL_INITIATIVE=1 bash "$hook")
+out2=$(printf '{}' | HIMMEL_INITIATIVE=1 bash "$hook")
+assert_has "first call (no session_id) injects"  "HIMMEL_INITIATIVE is active" "$out1"
+assert_has "second call (no session_id) injects" "HIMMEL_INITIATIVE is active" "$out2"
+
+# ---------- 33. Orphaned marker (dir exists, ts missing) still injects -------
+# CR round 1: a marker dir whose ts file is gone (winner killed pre-write, or
+# a temp-cleaner swept the file but not the dir) must NOT permanently silence
+# the directive for that session_id. After a one-shot retry the hook fails
+# OPEN: refreshes the stamp and injects.
+echo "Test 33: orphaned marker (no ts file) fails open and injects"
+sid33="sid-dedup-$$-d"
+marker_dir="$TMPDIR/himmel-inject-initiative-${sid33}"
+mkdir -p "$marker_dir"
+rm -f "$marker_dir/ts"
+out=$(printf '{"session_id":"%s"}' "$sid33" | HIMMEL_INITIATIVE=1 bash "$hook")
+assert_has "orphaned marker injects (fail-open)" "HIMMEL_INITIATIVE is active" "$out"
+if [ -s "$marker_dir/ts" ]; then
+    assert_pass "orphaned marker got a refreshed ts stamp"
+else
+    assert_fail "orphaned marker ts file was not refreshed"
+fi
+# ...and the refreshed stamp makes the NEXT call a normal fresh duplicate.
+out=$(printf '{"session_id":"%s"}' "$sid33" | HIMMEL_INITIATIVE=1 bash "$hook")
+if [ -z "$out" ]; then
+    assert_pass "call after the refresh dedups normally"
+else
+    assert_fail "call after the refresh should be silent, got: $out"
+fi
 
 echo
 echo "RESULTS: $pass passed, $fail failed"


### PR DESCRIPTION
Two private squashes: (1) HIMMEL-813 — the SessionStart hook fires at both user and project scope, injecting the initiative directive twice per session; now deduped per session_id with a 60s freshness window (mkdir-atomic marker, numeric epoch compare, fail-open on missing session_id AND on orphaned markers — CR-found, reproduced, test-pinned; 96/96, shellcheck clean). (2) HIMMEL-800 follow-up — the test-glm-subagent-path.sh wiring pin grepped the pre-refactor call shape and turned public CI red on the previous batch; now matches the assignment call-site shape with the line-order invariant unchanged. Leak scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)