### PR TITLE
fix(lanes)+test(guardrails)+docs(handover): lane config auto-reseed, nested-handover fence pin, state-in-vault default

### DIFF
--- a/docs/internals/handover-system.md
+++ b/docs/internals/handover-system.md
@@ -165,10 +165,20 @@ shell scripts use when they only know about one root:
   Post-HIMMEL-124 this resolves to a near-empty `himmel/handovers/`
   (just the README stub). Useful only for himmel-scoped legacy code.
 - **Mode B — external**: `HANDOVER_DIR` set → that path. **Recommended
-  default** post-HIMMEL-124:
+  default** post-HIMMEL-343: a `handovers/` folder **inside your
+  luna-style vault** — state becomes part of the knowledge base
+  (wikilinkable, qmd-indexed, graphify-able) with no extra repo to sync:
+  ```bash
+  export HANDOVER_DIR="$HOME/Documents/<your-vault>/handovers"
+  ```
+  A dedicated external state repo remains fully supported (the resolver
+  is root-agnostic):
   ```bash
   export HANDOVER_DIR="$HOME/Documents/github/<state-repo>/handovers"
   ```
+  **Pick ONE root.** Running both (state duplicated across a vault and a
+  state repo) is unsupported — two writable roots drift and the resolver
+  reads only `HANDOVER_DIR`.
 
 Consumed by `scripts/handover/auto-commit.sh`,
 `scripts/handover/arm-resume.sh`, `setup.sh`'s step 6, and

--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -134,6 +134,7 @@ documented at the top of [`.env.example`](../../.env.example):
 | `HIMMEL_REPO` | Path to your himmel checkout. | **Auto-set** by setup/adopt into `settings.json`; set explicitly only for a non-default clone path. |
 | `HANDOVER_DIR` | Handover state root (Mode B — external state repo). | Run `/handover-setup`. Bridged from `.env`. Unset = inline `<repo>/handovers/`. |
 | `LUNA_VAULT_PATH` | Luna vault root for end-session capture. | Your Obsidian vault path. **Not** bridged — export it. Unset → `~/Documents/luna`. |
+| `CLAUDE_LANE_AUTO_RESEED` | Optional opt-out for the lane launchers' config auto-refresh (HIMMEL-819). By default `claude-glm`/`claude-routed` re-seed their isolated config dir when your `~/.claude` settings or plugin registry changed, so lane workers pick up plugin-profile changes automatically. Set `0` to restore the once-only seed (first launch + explicit `--reseed`) if the auto-refresh ever blocks a launch in your setup. | Leave unset (default on). **Not** bridged from `.env` — set it in the launching shell. Only relevant if you use the offload lanes. |
 | `HIMMEL_INITIATIVE` | Drive-to-ship legs (opt-in, default OFF). | Uncomment one line in `.env` (leg grammar documented inline in `.env.example`); read from `.env` by the SessionStart hook. |
 | `PERPLEXITY_API_KEY` | Perplexity Sonar — `/research`, `/research-deep`. | Perplexity API settings. Optional (blank = feature off). |
 | `XAI_API_KEY` | xAI Grok — `/x-read`, `/x-pulse`, `/youtube`. | xAI API console. Optional. |

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -347,7 +347,16 @@ env from `settings.json`-injected env — don't put the key in `settings.json`
 (that hands it to every session); use per-launch shell env or the repo `.env`.
 
 **Isolated config dir (`$HOME/.claude-glm`):** seeded from `~/.claude` on first
-launch (or `--reseed`/`-Reseed`) by an allowlist copy — `settings.json`
+launch (or `--reseed`/`-Reseed`), and **auto-refreshed** (HIMMEL-819) on any
+plain launch when `~/.claude/settings.json`, `plugins/installed_plugins.json`,
+or `plugins/known_marketplaces.json` is newer than the `.seeded` sentinel — or
+deleted while a lane copy remains (true mirror for those three files) — so
+plugin-profile changes (e.g. disabling plugins to slim worker context) reach
+lane workers without a manual `--reseed`. `commands`/`skills`/`hooks`/`agents`
+drift still needs an explicit `--reseed`. **Optional:** set
+`CLAUDE_LANE_AUTO_RESEED=0` in the launching shell to restore the once-only
+seed if auto-reseed ever blocks a launch in your setup (e.g. a settings change
+re-running the seed against a broken `node`). The seed is an allowlist copy — `settings.json`
 (sanitized via node: the `model` key + every `env.ANTHROPIC_*` stripped so they
 don't fight the launcher's env), `CLAUDE.md`, `RTK.md`,
 `commands`/`skills`/`hooks`/`agents`, and the plugin registry

--- a/llms.txt
+++ b/llms.txt
@@ -58,5 +58,6 @@ Lifecycle after install: update with the `himmel-ops:himmel-update` skill (`/him
 
 ## Optional
 
+- [docs/glm-offload.md](docs/glm-offload.md) + [docs/tooling-catalog.md](docs/tooling-catalog.md#claude-glm-scriptsclaude-glm-ps1-twin-himmel-665): the optional `claude-glm`/`claude-routed` flat-rate offload lanes. Their isolated config dirs auto-refresh from `~/.claude` when your settings/plugin profile changes (HIMMEL-819); set `CLAUDE_LANE_AUTO_RESEED=0` to opt out — the lanes and the auto-reseed are both optional and nothing blocks a plain `claude` setup without them.
 - [docs/tool-adoption/rubric.md](docs/tool-adoption/rubric.md): the decision method every community-tool evaluation runs through (goal/KPI, trust tiers, ADOPT/PILOT/REJECT).
 - [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md): dependency-license attribution (audited clean, fully permissive; MIT root license).

--- a/marketplace/plugins/handover/commands/handover-setup.md
+++ b/marketplace/plugins/handover/commands/handover-setup.md
@@ -41,22 +41,31 @@ If `$1` (the `handover-dir` argument) was provided, treat it as the operator's
 explicit Mode-B path and skip the prompt. Otherwise ask via `AskUserQuestion`:
 
 > **Where should handover state live?**
-> - **Inline (this repo)** — state under `<repo-root>/handovers/`. Simplest; no
->   `.env` change. Best for a single-repo setup. (Mode A)
+> - **Inside your vault (Recommended)** — a `handovers/` folder in your
+>   luna-style Obsidian vault. State joins the knowledge base (wikilinkable,
+>   searchable, graphify-able) and rides the vault's own git. (Mode B)
 > - **External state repo** — a separate directory (typically a dedicated repo)
 >   so handover commits never land on your feature branches. You'll enter the
 >   path. (Mode B)
+> - **Inline (this repo)** — state under `<repo-root>/handovers/`. Simplest; no
+>   `.env` change. Best for a single-repo setup. (Mode A)
 
-For the **External** choice, get the absolute path (the user types it via the
-"Other" option or a follow-up). Expect a path ending in `/handovers` inside a
-git repo, e.g. `/c/Users/<you>/Documents/github/<your-state-repo>/handovers`.
+Pick ONE location — duplicated mode (state in both a vault and a state repo) is
+unsupported; the resolver reads a single `HANDOVER_DIR` root.
+
+For the **vault** or **external** choice, get the absolute path (the user types
+it via the "Other" option or a follow-up). Expect a path ending in `/handovers`
+inside a git repo — e.g. `/c/Users/<you>/Documents/<your-vault>/handovers`
+(vault) or `/c/Users/<you>/Documents/github/<your-state-repo>/handovers`
+(state repo).
 
 ### 4. Persist the choice
 
 - **Inline (Mode A):** nothing to write — `HANDOVER_DIR` stays unset and the
   resolver (`scripts/lib/handover-path.sh`) defaults to `<repo-root>/handovers`.
   Continue to step 5 with `<state-root-host>` = `<repo-root>`.
-- **External (Mode B):** if the chosen directory does not exist yet, ask whether
+- **Vault or external (Mode B — both persist identically):** if the chosen
+  directory does not exist yet, ask whether
   to create it (`mkdir -p`) — do not write a `HANDOVER_DIR` that points at a
   missing path. Then run the idempotent writer (this never echoes secret values,
   so it passes the secrets guard):
@@ -89,8 +98,9 @@ specs in the skill's `references/init-register.md`.
 
 ### 6. Confirm
 
-Print a one-line summary: the mode (inline/external), the resolved `<state-root>`,
-and the registered repo name. Suggest the next step: `/handover new-epic <name>`.
+Print a one-line summary: the mode (inline / vault / external), the resolved
+`<state-root>`, and the registered repo name. Suggest the next step:
+`/handover new-epic <name>`.
 
 ### Notes
 

--- a/scripts/claude-glm
+++ b/scripts/claude-glm
@@ -131,6 +131,10 @@ seed_config_dir() {
   if [ -f "$SRC/settings.json" ]; then
     sanitize_settings "$SRC/settings.json" "$CONFIG_DIR/settings.json" \
       || seed_fail "sanitize settings.json (node missing/broken?)"
+  else
+    # True mirror (HIMMEL-819): a deleted source must not leave a stale copy
+    # steering the lane — same rationale as the subtree re-mirror below.
+    rm -f "$CONFIG_DIR/settings.json" || seed_fail "remove stale settings.json"
   fi
   for f in CLAUDE.md RTK.md; do
     [ -f "$SRC/$f" ] && { cp "$SRC/$f" "$CONFIG_DIR/$f" || seed_fail "copy $f"; }
@@ -142,7 +146,11 @@ seed_config_dir() {
     [ -d "$SRC/$d" ] && { rm -rf "${CONFIG_DIR:?}/$d" || seed_fail "clear $d before reseed"; cp -R "$SRC/$d" "$CONFIG_DIR/" || seed_fail "copy $d"; }
   done
   for p in installed_plugins.json known_marketplaces.json; do
-    [ -f "$SRC/plugins/$p" ] && { cp "$SRC/plugins/$p" "$CONFIG_DIR/plugins/$p" || seed_fail "copy plugins/$p"; }
+    if [ -f "$SRC/plugins/$p" ]; then
+      cp "$SRC/plugins/$p" "$CONFIG_DIR/plugins/$p" || seed_fail "copy plugins/$p"
+    else
+      rm -f "$CONFIG_DIR/plugins/$p" || seed_fail "remove stale plugins/$p"
+    fi
   done
   [ -d "$SRC/plugins/marketplaces" ] && { rm -rf "${CONFIG_DIR:?}/plugins/marketplaces" || seed_fail "clear plugins/marketplaces before reseed"; cp -R "$SRC/plugins/marketplaces" "$CONFIG_DIR/plugins/" || seed_fail "copy plugins/marketplaces"; }
   # claude-hud DISPLAY config — seed the single config.json only; the three cache
@@ -155,7 +163,28 @@ seed_config_dir() {
   : > "$CONFIG_DIR/.seeded" || seed_fail "write the .seeded sentinel"
 }
 
-if [ ! -f "$CONFIG_DIR/.seeded" ] || [ "$RESEED" -eq 1 ]; then
+# Staleness-aware reseed (HIMMEL-819): a once-only seed strands lane workers on
+# whatever plugin/settings profile existed at first launch — the operator's lean
+# enabledPlugins profile never reaches the lane, so every worker pays duplicated
+# plugin context + duplicate MCP invocations. Track the three config sources that
+# change out-of-band (newer than the sentinel, OR deleted while a lane copy
+# remains); commands/skills/hooks/agents drift still needs --reseed.
+# Opt-out: CLAUDE_LANE_AUTO_RESEED=0 restores the once-only seed (first seed +
+# explicit --reseed only) — the escape hatch if auto-reseed ever blocks a
+# launch in your setup (e.g. seed re-runs surfacing a broken node).
+config_seed_stale() { # rc=0 when any tracked source is newer than the sentinel, or gone but still mirrored
+  [ "${CLAUDE_LANE_AUTO_RESEED:-1}" = "0" ] && return 1
+  for s in settings.json plugins/installed_plugins.json plugins/known_marketplaces.json; do
+    if [ -f "${HOME}/.claude/$s" ]; then
+      if [ "${HOME}/.claude/$s" -nt "$CONFIG_DIR/.seeded" ]; then return 0; fi
+    elif [ -f "$CONFIG_DIR/$s" ]; then
+      return 0  # source deleted but lane copy remains — reseed mirrors the removal
+    fi
+  done
+  return 1
+}
+
+if [ ! -f "$CONFIG_DIR/.seeded" ] || [ "$RESEED" -eq 1 ] || config_seed_stale; then
   seed_config_dir
 fi
 

--- a/scripts/claude-glm.ps1
+++ b/scripts/claude-glm.ps1
@@ -178,6 +178,11 @@ function Copy-SeedConfig {
       [Console]::Error.WriteLine('claude-glm: FAILED to sanitize settings.json (node missing/broken?). Refusing to launch with an unseeded config dir. Fix the cause and re-run (or rm -rf ~/.claude-glm).')
       exit 4
     }
+  } else {
+    # True mirror (HIMMEL-819): a deleted source must not leave a stale copy
+    # steering the lane — same rationale as the subtree re-mirror below.
+    $dst = Join-Path $ConfigDir 'settings.json'
+    if (Test-Path -LiteralPath $dst) { Remove-Item -LiteralPath $dst -Force }
   }
   foreach ($f in 'CLAUDE.md', 'RTK.md') {
     $p = Join-Path $src $f
@@ -199,7 +204,9 @@ function Copy-SeedConfig {
   }
   foreach ($p in 'installed_plugins.json', 'known_marketplaces.json') {
     $sp = Join-Path $src (Join-Path 'plugins' $p)
-    if (Test-Path -LiteralPath $sp) { Copy-Item -LiteralPath $sp -Destination (Join-Path $ConfigDir (Join-Path 'plugins' $p)) -Force }
+    $dp = Join-Path $ConfigDir (Join-Path 'plugins' $p)
+    if (Test-Path -LiteralPath $sp) { Copy-Item -LiteralPath $sp -Destination $dp -Force }
+    elseif (Test-Path -LiteralPath $dp) { Remove-Item -LiteralPath $dp -Force }
   }
   $mp = Join-Path $src (Join-Path 'plugins' 'marketplaces')
   if (Test-Path -LiteralPath $mp -PathType Container) {
@@ -228,7 +235,42 @@ function Copy-SeedConfig {
   New-Item -ItemType File -Force -Path (Join-Path $ConfigDir '.seeded') | Out-Null
 }
 
-if ((-not (Test-Path -LiteralPath (Join-Path $ConfigDir '.seeded'))) -or $Reseed) {
+# Staleness-aware reseed (HIMMEL-819): a once-only seed strands lane workers on
+# whatever plugin/settings profile existed at first launch — the operator's lean
+# enabledPlugins profile never reaches the lane, so every worker pays duplicated
+# plugin context + duplicate MCP invocations. Track the three config sources that
+# change out-of-band (newer than the sentinel, OR deleted while a lane copy
+# remains); commands/skills/hooks/agents drift still needs -Reseed.
+# Opt-out: CLAUDE_LANE_AUTO_RESEED=0 restores the once-only seed (first seed +
+# explicit -Reseed only) — the escape hatch if auto-reseed ever blocks a
+# launch in your setup (e.g. seed re-runs surfacing a broken node).
+function Test-ConfigSeedStale {
+  if ($env:CLAUDE_LANE_AUTO_RESEED -eq '0') { return $false }
+  # try/catch: the predicate must never block a launch. A TOCTOU race (file
+  # deleted between Test-Path and Get-Item under ErrorActionPreference=Stop)
+  # reads as not-stale — worst case a slightly stale config, never an abort.
+  # (The bash twin's [ -f ] && [ -nt ] is race-safe by construction.)
+  try {
+    $sentinel = Join-Path $ConfigDir '.seeded'
+    if (-not (Test-Path -LiteralPath $sentinel)) { return $false }
+    $sentinelTime = (Get-Item -LiteralPath $sentinel).LastWriteTimeUtc
+    $src = Join-Path $HomeDir '.claude'
+    foreach ($rel in @('settings.json', (Join-Path 'plugins' 'installed_plugins.json'), (Join-Path 'plugins' 'known_marketplaces.json'))) {
+      $s = Join-Path $src $rel
+      $d = Join-Path $ConfigDir $rel
+      if (Test-Path -LiteralPath $s) {
+        if ((Get-Item -LiteralPath $s).LastWriteTimeUtc -gt $sentinelTime) { return $true }
+      } elseif (Test-Path -LiteralPath $d) {
+        return $true  # source deleted but lane copy remains — reseed mirrors the removal
+      }
+    }
+    return $false
+  } catch {
+    return $false
+  }
+}
+
+if ((-not (Test-Path -LiteralPath (Join-Path $ConfigDir '.seeded'))) -or $Reseed -or (Test-ConfigSeedStale)) {
   Copy-SeedConfig
 }
 

--- a/scripts/claude-routed
+++ b/scripts/claude-routed
@@ -146,6 +146,10 @@ seed_config_dir() {
   if [ -f "$SRC/settings.json" ]; then
     sanitize_settings "$SRC/settings.json" "$CONFIG_DIR/settings.json" \
       || seed_fail "sanitize settings.json (node missing/broken?)"
+  else
+    # True mirror (HIMMEL-819): a deleted source must not leave a stale copy
+    # steering the lane — same rationale as the subtree re-mirror below.
+    rm -f "$CONFIG_DIR/settings.json" || seed_fail "remove stale settings.json"
   fi
   for f in CLAUDE.md RTK.md; do
     [ -f "$SRC/$f" ] && { cp "$SRC/$f" "$CONFIG_DIR/$f" || seed_fail "copy $f"; }
@@ -154,7 +158,11 @@ seed_config_dir() {
     [ -d "$SRC/$d" ] && { cp -R "$SRC/$d" "$CONFIG_DIR/" || seed_fail "copy $d"; }
   done
   for p in installed_plugins.json known_marketplaces.json; do
-    [ -f "$SRC/plugins/$p" ] && { cp "$SRC/plugins/$p" "$CONFIG_DIR/plugins/$p" || seed_fail "copy plugins/$p"; }
+    if [ -f "$SRC/plugins/$p" ]; then
+      cp "$SRC/plugins/$p" "$CONFIG_DIR/plugins/$p" || seed_fail "copy plugins/$p"
+    else
+      rm -f "$CONFIG_DIR/plugins/$p" || seed_fail "remove stale plugins/$p"
+    fi
   done
   [ -d "$SRC/plugins/marketplaces" ] && { cp -R "$SRC/plugins/marketplaces" "$CONFIG_DIR/plugins/" || seed_fail "copy plugins/marketplaces"; }
   # claude-hud DISPLAY config — seed the single config.json only; the three cache
@@ -167,7 +175,28 @@ seed_config_dir() {
   : > "$CONFIG_DIR/.seeded" || seed_fail "write the .seeded sentinel"
 }
 
-if [ ! -f "$CONFIG_DIR/.seeded" ] || [ "$RESEED" -eq 1 ]; then
+# Staleness-aware reseed (HIMMEL-819): a once-only seed strands lane workers on
+# whatever plugin/settings profile existed at first launch — the operator's lean
+# enabledPlugins profile never reaches the lane, so every worker pays duplicated
+# plugin context + duplicate MCP invocations. Track the three config sources that
+# change out-of-band (newer than the sentinel, OR deleted while a lane copy
+# remains); commands/skills/hooks/agents drift still needs --reseed.
+# Opt-out: CLAUDE_LANE_AUTO_RESEED=0 restores the once-only seed (first seed +
+# explicit --reseed only) — the escape hatch if auto-reseed ever blocks a
+# launch in your setup (e.g. seed re-runs surfacing a broken node).
+config_seed_stale() { # rc=0 when any tracked source is newer than the sentinel, or gone but still mirrored
+  [ "${CLAUDE_LANE_AUTO_RESEED:-1}" = "0" ] && return 1
+  for s in settings.json plugins/installed_plugins.json plugins/known_marketplaces.json; do
+    if [ -f "${HOME}/.claude/$s" ]; then
+      if [ "${HOME}/.claude/$s" -nt "$CONFIG_DIR/.seeded" ]; then return 0; fi
+    elif [ -f "$CONFIG_DIR/$s" ]; then
+      return 0  # source deleted but lane copy remains — reseed mirrors the removal
+    fi
+  done
+  return 1
+}
+
+if [ ! -f "$CONFIG_DIR/.seeded" ] || [ "$RESEED" -eq 1 ] || config_seed_stale; then
   seed_config_dir
 fi
 

--- a/scripts/claude-routed.ps1
+++ b/scripts/claude-routed.ps1
@@ -196,6 +196,13 @@ function Copy-SeedConfig {
   }
   # Parity with the bash twin's seed_fail=4 — any seed failure must exit 4, not raw 1 (CR F9, #830).
   try {
+    if (-not (Test-Path -LiteralPath $settings)) {
+      # True mirror (HIMMEL-819): a deleted source must not leave a stale copy
+      # steering the lane — same rationale as the subtree re-mirror below.
+      # Inside the CR-F9 try so a removal failure exits 4, not raw 1.
+      $dst = Join-Path $ConfigDir 'settings.json'
+      if (Test-Path -LiteralPath $dst) { Remove-Item -LiteralPath $dst -Force }
+    }
     foreach ($f in 'CLAUDE.md', 'RTK.md') {
       $p = Join-Path $src $f
       if (Test-Path -LiteralPath $p) { Copy-Item -LiteralPath $p -Destination (Join-Path $ConfigDir $f) -Force }
@@ -206,7 +213,9 @@ function Copy-SeedConfig {
     }
     foreach ($p in 'installed_plugins.json', 'known_marketplaces.json') {
       $sp = Join-Path $src (Join-Path 'plugins' $p)
-      if (Test-Path -LiteralPath $sp) { Copy-Item -LiteralPath $sp -Destination (Join-Path $ConfigDir (Join-Path 'plugins' $p)) -Force }
+      $dp = Join-Path $ConfigDir (Join-Path 'plugins' $p)
+      if (Test-Path -LiteralPath $sp) { Copy-Item -LiteralPath $sp -Destination $dp -Force }
+      elseif (Test-Path -LiteralPath $dp) { Remove-Item -LiteralPath $dp -Force }
     }
     $mp = Join-Path $src (Join-Path 'plugins' 'marketplaces')
     if (Test-Path -LiteralPath $mp -PathType Container) { Copy-Item -LiteralPath $mp -Destination (Join-Path $ConfigDir 'plugins') -Recurse -Force }
@@ -225,7 +234,42 @@ function Copy-SeedConfig {
   }
 }
 
-if ((-not (Test-Path -LiteralPath (Join-Path $ConfigDir '.seeded'))) -or $Reseed) {
+# Staleness-aware reseed (HIMMEL-819): a once-only seed strands lane workers on
+# whatever plugin/settings profile existed at first launch — the operator's lean
+# enabledPlugins profile never reaches the lane, so every worker pays duplicated
+# plugin context + duplicate MCP invocations. Track the three config sources that
+# change out-of-band (newer than the sentinel, OR deleted while a lane copy
+# remains); commands/skills/hooks/agents drift still needs -Reseed.
+# Opt-out: CLAUDE_LANE_AUTO_RESEED=0 restores the once-only seed (first seed +
+# explicit -Reseed only) — the escape hatch if auto-reseed ever blocks a
+# launch in your setup (e.g. seed re-runs surfacing a broken node).
+function Test-ConfigSeedStale {
+  if ($env:CLAUDE_LANE_AUTO_RESEED -eq '0') { return $false }
+  # try/catch: the predicate must never block a launch. A TOCTOU race (file
+  # deleted between Test-Path and Get-Item under ErrorActionPreference=Stop)
+  # reads as not-stale — worst case a slightly stale config, never an abort.
+  # (The bash twin's [ -f ] && [ -nt ] is race-safe by construction.)
+  try {
+    $sentinel = Join-Path $ConfigDir '.seeded'
+    if (-not (Test-Path -LiteralPath $sentinel)) { return $false }
+    $sentinelTime = (Get-Item -LiteralPath $sentinel).LastWriteTimeUtc
+    $src = Join-Path $HomeDir '.claude'
+    foreach ($rel in @('settings.json', (Join-Path 'plugins' 'installed_plugins.json'), (Join-Path 'plugins' 'known_marketplaces.json'))) {
+      $s = Join-Path $src $rel
+      $d = Join-Path $ConfigDir $rel
+      if (Test-Path -LiteralPath $s) {
+        if ((Get-Item -LiteralPath $s).LastWriteTimeUtc -gt $sentinelTime) { return $true }
+      } elseif (Test-Path -LiteralPath $d) {
+        return $true  # source deleted but lane copy remains — reseed mirrors the removal
+      }
+    }
+    return $false
+  } catch {
+    return $false
+  }
+}
+
+if ((-not (Test-Path -LiteralPath (Join-Path $ConfigDir '.seeded'))) -or $Reseed -or (Test-ConfigSeedStale)) {
   Copy-SeedConfig
 }
 

--- a/scripts/guardrails/egress-matrix.json
+++ b/scripts/guardrails/egress-matrix.json
@@ -18,7 +18,7 @@
     "salus": "any path under a `.salus`-marked root, or under a root listed in ~/.config/claude-glm/phi-roots or ~/.config/claude-glm/egress-denylist (the shared glm-guard.ts / parity_guard.py primitives)",
     "luna-personal": "the luna vault root EXCLUDING Clippings/ (journals, maps, sessions, notes)",
     "luna-clippings": "<luna-root>/Clippings/ (clipped public web content)",
-    "handover-state": "the handover state repo root (HANDOVER_DIR; work artifacts, specs, session notes)",
+    "handover-state": "the handover state repo root (HANDOVER_DIR; work artifacts, specs, session notes). Kept for Mode-B EXTERNAL state repos after the HIMMEL-343 fold: a HANDOVER_DIR nested INSIDE a vault classifies as that vault's corpus instead (fence precedence checks vault roots first — more restrictive; pinned by test, HIMMEL-817)",
     "himmel-code": "himmel checkout(s), worktrees, and the public mirror (code + docs; public-propagated)"
   },
   "providers": {

--- a/scripts/guardrails/test-graphify-fence.sh
+++ b/scripts/guardrails/test-graphify-fence.sh
@@ -357,6 +357,22 @@ else
     fail "ledger content conditional: got $(cat "$LEDGER" 2>/dev/null)"
 fi
 
+# nested handover root (HIMMEL-817, post-HIMMEL-343 fold): HANDOVER_DIR INSIDE
+# the vault -> the path classifies as the VAULT corpus (luna-personal, rank 4),
+# NOT handover-state (rank 2) — vault roots are checked first, so a fold-style
+# setup tightens classification and the handover-state row keeps serving only
+# Mode-B external state repos. deepseek extraction verdict stays allow+log.
+mkdir -p "$LUNA/handovers/op"
+: > "$LUNA/handovers/op/next-session-1.md"
+rm -f "$LEDGER"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$HIMMEL" && env $CLEAN_ENV HANDOVER_DIR="$LUNA/handovers" "$BASH_BIN" "$FENCE" "graphify update $LUNA/handovers/op/next-session-1.md --backend deepseek" ) >/dev/null 2>&1
+if grep -q '"verdict":"allow+log"' "$LEDGER" 2>/dev/null && grep -q '"corpus":"luna-personal"' "$LEDGER" 2>/dev/null; then
+    pass "nested HANDOVER_DIR inside vault classifies as luna-personal (allow+log)"
+else
+    fail "nested handover root: got $(cat "$LEDGER" 2>/dev/null)"
+fi
+
 echo "== egress-matrix-eval.mjs unit =="
 
 # pending-operator cell -> verdict deny

--- a/scripts/test-claude-glm.ps1
+++ b/scripts/test-claude-glm.ps1
@@ -162,6 +162,56 @@ try {
   if (FileHas (Join-Path $FAKEHOME '.claude-glm\CLAUDE.md') 'updated') { Pass 'reseed refreshed CLAUDE.md' } else { Fail 'reseed did not refresh' }
   if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\history.jsonl')) { Fail 'denied file seeded' } else { Pass 'denied file not seeded' }
 
+  # --- T7b: stale seed auto-refreshes on plain launch (HIMMEL-819) — source
+  # settings.json newer than the sentinel triggers a reseed without -Reseed. ---
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude-glm\.seeded')).LastWriteTimeUtc = [datetime]'2020-01-01'
+  '{"env":{"HIMMEL_INITIATIVE":"1"},"marker":"lean-profile-v2"}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\settings.json') -NoNewline
+  Assert-Exit (Invoke-Launcher) 0 'stale seed auto-refreshes'
+  if (FileHas (Join-Path $FAKEHOME '.claude-glm\settings.json') 'lean-profile-v2') { Pass 'stale seed refreshed on plain launch' } else { Fail 'stale seed not refreshed on plain launch' }
+
+  # --- T7c: fresh sentinel -> plain launch does NOT reseed (no churn) ---
+  '{"local":"tamper-survives"}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude-glm\settings.json') -NoNewline
+  foreach ($srcRel in @('.claude\settings.json', '.claude\plugins\installed_plugins.json', '.claude\plugins\known_marketplaces.json')) {
+    $p = Join-Path $FAKEHOME $srcRel
+    if (Test-Path -LiteralPath $p) { (Get-Item -LiteralPath $p).LastWriteTimeUtc = [datetime]'2020-01-01' }
+  }
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude-glm\.seeded')).LastWriteTimeUtc = [datetime]::UtcNow
+  Assert-Exit (Invoke-Launcher) 0 'fresh sentinel skips reseed'
+  if (FileHas (Join-Path $FAKEHOME '.claude-glm\settings.json') 'tamper-survives') { Pass 'fresh sentinel skipped reseed' } else { Fail 'fresh sentinel still reseeded' }
+
+  # --- T7d: deleted source triggers reseed and the lane copy is removed (true mirror) ---
+  Remove-Item -LiteralPath (Join-Path $FAKEHOME '.claude\settings.json') -Force
+  Assert-Exit (Invoke-Launcher) 0 'deleted source triggers reseed'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\settings.json')) { Fail 'stale settings copy survived source deletion' } else { Pass 'stale settings copy removed on source deletion' }
+
+  # --- T7e: CLAUDE_LANE_AUTO_RESEED=0 opt-out — stale state left alone on plain launch ---
+  '{"env":{"HIMMEL_INITIATIVE":"1"},"marker":"optout-should-not-land"}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\settings.json') -NoNewline
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude-glm\.seeded')).LastWriteTimeUtc = [datetime]'2020-01-01'
+  $env:CLAUDE_LANE_AUTO_RESEED = '0'
+  Assert-Exit (Invoke-Launcher) 0 'opt-out skips auto-reseed'
+  Remove-Item Env:CLAUDE_LANE_AUTO_RESEED
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\settings.json')) { Fail 'opt-out still auto-reseeded' } else { Pass 'opt-out skipped auto-reseed' }
+  # restore a sane seeded state for the tests below
+  Assert-Exit (Invoke-Launcher -LArgs @('-Reseed')) 0 'restore reseed'
+
+  # --- T7f: plugin-manifest sources participate in staleness AND deletion mirroring ---
+  New-Item -ItemType Directory -Force -Path (Join-Path $FAKEHOME '.claude\plugins') | Out-Null
+  '{"m":1}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\plugins\installed_plugins.json') -NoNewline
+  '{"k":1}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\plugins\known_marketplaces.json') -NoNewline
+  Assert-Exit (Invoke-Launcher) 0 'manifest newer triggers reseed'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\plugins\installed_plugins.json')) { Pass 'installed_plugins reseeded on manifest change' } else { Fail 'installed_plugins not reseeded on manifest change' }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\plugins\known_marketplaces.json')) { Pass 'known_marketplaces reseeded on manifest change' } else { Fail 'known_marketplaces not reseeded on manifest change' }
+  Remove-Item -LiteralPath (Join-Path $FAKEHOME '.claude\plugins\known_marketplaces.json') -Force
+  Assert-Exit (Invoke-Launcher) 0 'deleted manifest mirrors removal'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\plugins\known_marketplaces.json')) { Fail 'stale known_marketplaces copy survived source deletion' } else { Pass 'known_marketplaces copy removed on source deletion' }
+
+  # --- T7g: explicit -Reseed still seeds while the opt-out is set ---
+  '{"local":"tamper2"}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude-glm\settings.json') -NoNewline
+  $env:CLAUDE_LANE_AUTO_RESEED = '0'
+  Assert-Exit (Invoke-Launcher -LArgs @('-Reseed')) 0 'explicit reseed wins over opt-out'
+  Remove-Item Env:CLAUDE_LANE_AUTO_RESEED
+  if (FileHas (Join-Path $FAKEHOME '.claude-glm\settings.json') 'tamper2') { Fail '-Reseed under opt-out did not reseed' } else { Pass '-Reseed wins over opt-out' }
+
   # --- T8: .salus marker -> refuse exit 3, --force does NOT override ---
   New-Sandbox; $script:KEY = 'zai-test-123'  # gitleaks:allow
   New-Item -ItemType File -Force -Path (Join-Path $WORK '.salus') | Out-Null

--- a/scripts/test-claude-glm.sh
+++ b/scripts/test-claude-glm.sh
@@ -112,6 +112,58 @@ t "reseed" 0 --reseed
 grep -q updated "$FAKEHOME/.claude-glm/CLAUDE.md" || { echo "FAIL: reseed did not refresh"; FAILS=$((FAILS+1)); }
 [ ! -f "$FAKEHOME/.claude-glm/history.jsonl" ] || { echo "FAIL: denied file seeded"; FAILS=$((FAILS+1)); }
 
+# --- T7b: stale seed auto-refreshes on plain launch (HIMMEL-819) — source
+# settings.json newer than the sentinel triggers a reseed without --reseed.
+touch -t 202001010000 "$FAKEHOME/.claude-glm/.seeded"
+printf '{"env":{"HIMMEL_INITIATIVE":"1"},"marker":"lean-profile-v2"}' > "$FAKEHOME/.claude/settings.json"
+t "stale seed auto-refreshes" 0
+grep -q "lean-profile-v2" "$FAKEHOME/.claude-glm/settings.json" || { echo "FAIL: stale seed not refreshed on plain launch"; FAILS=$((FAILS+1)); }
+
+# --- T7c: fresh sentinel -> plain launch does NOT reseed (no churn) — sources
+# older than the sentinel leave the config dir untouched.
+printf '{"local":"tamper-survives"}' > "$FAKEHOME/.claude-glm/settings.json"
+touch -t 202001010000 "$FAKEHOME/.claude/settings.json" "$FAKEHOME/.claude/plugins/installed_plugins.json" 2>/dev/null
+touch "$FAKEHOME/.claude-glm/.seeded"
+t "fresh sentinel skips reseed" 0
+grep -q "tamper-survives" "$FAKEHOME/.claude-glm/settings.json" || { echo "FAIL: fresh sentinel still reseeded"; FAILS=$((FAILS+1)); }
+
+# --- T7d: deleted source triggers reseed and the lane copy is removed (true
+# mirror — a stale settings copy must not keep steering the lane).
+rm -f "$FAKEHOME/.claude/settings.json"
+t "deleted source triggers reseed" 0
+[ ! -f "$FAKEHOME/.claude-glm/settings.json" ] || { echo "FAIL: stale settings copy survived source deletion"; FAILS=$((FAILS+1)); }
+
+# --- T7e: CLAUDE_LANE_AUTO_RESEED=0 opt-out — stale state is left alone on
+# plain launch (only first seed / --reseed run the seed).
+printf '{"env":{"HIMMEL_INITIATIVE":"1"},"marker":"optout-should-not-land"}' > "$FAKEHOME/.claude/settings.json"
+touch -t 202001010000 "$FAKEHOME/.claude-glm/.seeded"
+export CLAUDE_LANE_AUTO_RESEED=0
+t "opt-out skips auto-reseed" 0
+unset CLAUDE_LANE_AUTO_RESEED
+[ ! -f "$FAKEHOME/.claude-glm/settings.json" ] || { echo "FAIL: opt-out still auto-reseeded"; FAILS=$((FAILS+1)); }
+# restore a sane settings source + fresh sentinel for the tests below
+printf '{"env":{"HIMMEL_INITIATIVE":"1"}}' > "$FAKEHOME/.claude/settings.json"
+t "restore reseed" 0 --reseed
+
+# --- T7f: plugin-manifest sources participate in staleness AND deletion
+# mirroring (2nd/3rd tracked file — not just settings.json).
+printf '{"m":1}' > "$FAKEHOME/.claude/plugins/installed_plugins.json"
+printf '{"k":1}' > "$FAKEHOME/.claude/plugins/known_marketplaces.json"
+t "manifest newer triggers reseed" 0
+[ -f "$FAKEHOME/.claude-glm/plugins/installed_plugins.json" ] || { echo "FAIL: installed_plugins not reseeded on manifest change"; FAILS=$((FAILS+1)); }
+[ -f "$FAKEHOME/.claude-glm/plugins/known_marketplaces.json" ] || { echo "FAIL: known_marketplaces not reseeded on manifest change"; FAILS=$((FAILS+1)); }
+rm -f "$FAKEHOME/.claude/plugins/known_marketplaces.json"
+t "deleted manifest mirrors removal" 0
+[ ! -f "$FAKEHOME/.claude-glm/plugins/known_marketplaces.json" ] || { echo "FAIL: stale known_marketplaces copy survived source deletion"; FAILS=$((FAILS+1)); }
+
+# --- T7g: explicit --reseed still seeds while the opt-out is set (the escape
+# hatch does not disable the manual path).
+printf '{"local":"tamper2"}' > "$FAKEHOME/.claude-glm/settings.json"
+export CLAUDE_LANE_AUTO_RESEED=0
+t "explicit reseed wins over opt-out" 0 --reseed
+unset CLAUDE_LANE_AUTO_RESEED
+grep -q "tamper2" "$FAKEHOME/.claude-glm/settings.json" && { echo "FAIL: --reseed under opt-out did not reseed"; FAILS=$((FAILS+1)); }
+
 # --- T8: .salus marker -> refuse exit 3, --force does NOT override
 setup; KEY="zai-test-123"; touch "$WORK/.salus"
 t "salus refuses" 3

--- a/scripts/test-claude-routed.ps1
+++ b/scripts/test-claude-routed.ps1
@@ -168,6 +168,56 @@ try {
   if (FileHas (Join-Path $FAKEHOME '.claude-routed\CLAUDE.md') 'updated') { Pass 'reseed refreshed CLAUDE.md' } else { Fail 'reseed did not refresh' }
   if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\history.jsonl')) { Fail 'denied file seeded' } else { Pass 'denied file not seeded' }
 
+  # --- T7b: stale seed auto-refreshes on plain launch (HIMMEL-819) — source
+  # settings.json newer than the sentinel triggers a reseed without -Reseed. ---
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude-routed\.seeded')).LastWriteTimeUtc = [datetime]'2020-01-01'
+  '{"env":{"HIMMEL_INITIATIVE":"1"},"marker":"lean-profile-v2"}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\settings.json') -NoNewline
+  Assert-Exit (Invoke-Launcher) 0 'stale seed auto-refreshes'
+  if (FileHas (Join-Path $FAKEHOME '.claude-routed\settings.json') 'lean-profile-v2') { Pass 'stale seed refreshed on plain launch' } else { Fail 'stale seed not refreshed on plain launch' }
+
+  # --- T7c: fresh sentinel -> plain launch does NOT reseed (no churn) ---
+  '{"local":"tamper-survives"}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude-routed\settings.json') -NoNewline
+  foreach ($srcRel in @('.claude\settings.json', '.claude\plugins\installed_plugins.json', '.claude\plugins\known_marketplaces.json')) {
+    $p = Join-Path $FAKEHOME $srcRel
+    if (Test-Path -LiteralPath $p) { (Get-Item -LiteralPath $p).LastWriteTimeUtc = [datetime]'2020-01-01' }
+  }
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude-routed\.seeded')).LastWriteTimeUtc = [datetime]::UtcNow
+  Assert-Exit (Invoke-Launcher) 0 'fresh sentinel skips reseed'
+  if (FileHas (Join-Path $FAKEHOME '.claude-routed\settings.json') 'tamper-survives') { Pass 'fresh sentinel skipped reseed' } else { Fail 'fresh sentinel still reseeded' }
+
+  # --- T7d: deleted source triggers reseed and the lane copy is removed (true mirror) ---
+  Remove-Item -LiteralPath (Join-Path $FAKEHOME '.claude\settings.json') -Force
+  Assert-Exit (Invoke-Launcher) 0 'deleted source triggers reseed'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\settings.json')) { Fail 'stale settings copy survived source deletion' } else { Pass 'stale settings copy removed on source deletion' }
+
+  # --- T7e: CLAUDE_LANE_AUTO_RESEED=0 opt-out — stale state left alone on plain launch ---
+  '{"env":{"HIMMEL_INITIATIVE":"1"},"marker":"optout-should-not-land"}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\settings.json') -NoNewline
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude-routed\.seeded')).LastWriteTimeUtc = [datetime]'2020-01-01'
+  $env:CLAUDE_LANE_AUTO_RESEED = '0'
+  Assert-Exit (Invoke-Launcher) 0 'opt-out skips auto-reseed'
+  Remove-Item Env:CLAUDE_LANE_AUTO_RESEED
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\settings.json')) { Fail 'opt-out still auto-reseeded' } else { Pass 'opt-out skipped auto-reseed' }
+  # restore a sane seeded state for the tests below
+  Assert-Exit (Invoke-Launcher -LArgs @('-Reseed')) 0 'restore reseed'
+
+  # --- T7f: plugin-manifest sources participate in staleness AND deletion mirroring ---
+  New-Item -ItemType Directory -Force -Path (Join-Path $FAKEHOME '.claude\plugins') | Out-Null
+  '{"m":1}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\plugins\installed_plugins.json') -NoNewline
+  '{"k":1}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\plugins\known_marketplaces.json') -NoNewline
+  Assert-Exit (Invoke-Launcher) 0 'manifest newer triggers reseed'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\plugins\installed_plugins.json')) { Pass 'installed_plugins reseeded on manifest change' } else { Fail 'installed_plugins not reseeded on manifest change' }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\plugins\known_marketplaces.json')) { Pass 'known_marketplaces reseeded on manifest change' } else { Fail 'known_marketplaces not reseeded on manifest change' }
+  Remove-Item -LiteralPath (Join-Path $FAKEHOME '.claude\plugins\known_marketplaces.json') -Force
+  Assert-Exit (Invoke-Launcher) 0 'deleted manifest mirrors removal'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\plugins\known_marketplaces.json')) { Fail 'stale known_marketplaces copy survived source deletion' } else { Pass 'known_marketplaces copy removed on source deletion' }
+
+  # --- T7g: explicit -Reseed still seeds while the opt-out is set ---
+  '{"local":"tamper2"}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude-routed\settings.json') -NoNewline
+  $env:CLAUDE_LANE_AUTO_RESEED = '0'
+  Assert-Exit (Invoke-Launcher -LArgs @('-Reseed')) 0 'explicit reseed wins over opt-out'
+  Remove-Item Env:CLAUDE_LANE_AUTO_RESEED
+  if (FileHas (Join-Path $FAKEHOME '.claude-routed\settings.json') 'tamper2') { Fail '-Reseed under opt-out did not reseed' } else { Pass '-Reseed wins over opt-out' }
+
   # --- T8: .salus marker -> refuse exit 3, -Force does NOT override (guard survives
   # the variant — the mandated red path) ---
   New-Sandbox; $script:KEY = 'omni-test-123'  # gitleaks:allow

--- a/scripts/test-claude-routed.sh
+++ b/scripts/test-claude-routed.sh
@@ -119,6 +119,58 @@ t "reseed" 0 --reseed
 grep -q updated "$FAKEHOME/.claude-routed/CLAUDE.md" || { echo "FAIL: reseed did not refresh"; FAILS=$((FAILS+1)); }
 [ ! -f "$FAKEHOME/.claude-routed/history.jsonl" ] || { echo "FAIL: denied file seeded"; FAILS=$((FAILS+1)); }
 
+# --- T7b: stale seed auto-refreshes on plain launch (HIMMEL-819) — source
+# settings.json newer than the sentinel triggers a reseed without --reseed.
+touch -t 202001010000 "$FAKEHOME/.claude-routed/.seeded"
+printf '{"env":{"HIMMEL_INITIATIVE":"1"},"marker":"lean-profile-v2"}' > "$FAKEHOME/.claude/settings.json"
+t "stale seed auto-refreshes" 0
+grep -q "lean-profile-v2" "$FAKEHOME/.claude-routed/settings.json" || { echo "FAIL: stale seed not refreshed on plain launch"; FAILS=$((FAILS+1)); }
+
+# --- T7c: fresh sentinel -> plain launch does NOT reseed (no churn) — sources
+# older than the sentinel leave the config dir untouched.
+printf '{"local":"tamper-survives"}' > "$FAKEHOME/.claude-routed/settings.json"
+touch -t 202001010000 "$FAKEHOME/.claude/settings.json" "$FAKEHOME/.claude/plugins/installed_plugins.json" 2>/dev/null
+touch "$FAKEHOME/.claude-routed/.seeded"
+t "fresh sentinel skips reseed" 0
+grep -q "tamper-survives" "$FAKEHOME/.claude-routed/settings.json" || { echo "FAIL: fresh sentinel still reseeded"; FAILS=$((FAILS+1)); }
+
+# --- T7d: deleted source triggers reseed and the lane copy is removed (true
+# mirror — a stale settings copy must not keep steering the lane).
+rm -f "$FAKEHOME/.claude/settings.json"
+t "deleted source triggers reseed" 0
+[ ! -f "$FAKEHOME/.claude-routed/settings.json" ] || { echo "FAIL: stale settings copy survived source deletion"; FAILS=$((FAILS+1)); }
+
+# --- T7e: CLAUDE_LANE_AUTO_RESEED=0 opt-out — stale state is left alone on
+# plain launch (only first seed / --reseed run the seed).
+printf '{"env":{"HIMMEL_INITIATIVE":"1"},"marker":"optout-should-not-land"}' > "$FAKEHOME/.claude/settings.json"
+touch -t 202001010000 "$FAKEHOME/.claude-routed/.seeded"
+export CLAUDE_LANE_AUTO_RESEED=0
+t "opt-out skips auto-reseed" 0
+unset CLAUDE_LANE_AUTO_RESEED
+[ ! -f "$FAKEHOME/.claude-routed/settings.json" ] || { echo "FAIL: opt-out still auto-reseeded"; FAILS=$((FAILS+1)); }
+# restore a sane settings source + fresh sentinel for the tests below
+printf '{"env":{"HIMMEL_INITIATIVE":"1"}}' > "$FAKEHOME/.claude/settings.json"
+t "restore reseed" 0 --reseed
+
+# --- T7f: plugin-manifest sources participate in staleness AND deletion
+# mirroring (2nd/3rd tracked file — not just settings.json).
+printf '{"m":1}' > "$FAKEHOME/.claude/plugins/installed_plugins.json"
+printf '{"k":1}' > "$FAKEHOME/.claude/plugins/known_marketplaces.json"
+t "manifest newer triggers reseed" 0
+[ -f "$FAKEHOME/.claude-routed/plugins/installed_plugins.json" ] || { echo "FAIL: installed_plugins not reseeded on manifest change"; FAILS=$((FAILS+1)); }
+[ -f "$FAKEHOME/.claude-routed/plugins/known_marketplaces.json" ] || { echo "FAIL: known_marketplaces not reseeded on manifest change"; FAILS=$((FAILS+1)); }
+rm -f "$FAKEHOME/.claude/plugins/known_marketplaces.json"
+t "deleted manifest mirrors removal" 0
+[ ! -f "$FAKEHOME/.claude-routed/plugins/known_marketplaces.json" ] || { echo "FAIL: stale known_marketplaces copy survived source deletion"; FAILS=$((FAILS+1)); }
+
+# --- T7g: explicit --reseed still seeds while the opt-out is set (the escape
+# hatch does not disable the manual path).
+printf '{"local":"tamper2"}' > "$FAKEHOME/.claude-routed/settings.json"
+export CLAUDE_LANE_AUTO_RESEED=0
+t "explicit reseed wins over opt-out" 0 --reseed
+unset CLAUDE_LANE_AUTO_RESEED
+grep -q "tamper2" "$FAKEHOME/.claude-routed/settings.json" && { echo "FAIL: --reseed under opt-out did not reseed"; FAILS=$((FAILS+1)); }
+
 # --- T8: .salus marker -> refuse exit 3, --force does NOT override (guard survives
 # the variant — the mandated red path)
 setup; KEY="omni-test-123"; touch "$WORK/.salus"


### PR DESCRIPTION
Propagation batch (private #1044 + #1045 + #1046):

- **Lane config auto-reseed (HIMMEL-819):** claude-glm/claude-routed (+ .ps1 twins) re-seed their isolated config dir when ~/.claude settings or the plugin registry changed (or a tracked source was deleted — true mirror), so plugin-profile changes reach lane workers automatically. Optional: CLAUDE_LANE_AUTO_RESEED=0 restores the once-only seed. Docs: tooling-catalog, new-machine env table, llms.txt. Tests T7b–T7g in all four suites.
- **Fence pin (HIMMEL-817):** a HANDOVER_DIR nested inside a vault classifies as the vault corpus (more restrictive); handover-state row stays for external state repos.
- **Docs (HIMMEL-818):** recommended handover default = state inside a luna-style vault; external state repo still supported; pick one root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)