### PR TITLE
fix(lanes): [HIMMEL-827] claude-routed.ps1 stale-sentinel guard parity + T17c

### DIFF
--- a/scripts/claude-routed.ps1
+++ b/scripts/claude-routed.ps1
@@ -174,7 +174,23 @@ function Copy-SeedConfig {
   # Without the up-front delete a failed -Reseed would exit 4 yet leave a stale
   # sentinel, and the next plain launch would proceed with the half-populated tree.
   $src = Join-Path $HomeDir '.claude'
-  Remove-Item -LiteralPath (Join-Path $ConfigDir '.seeded') -Force -ErrorAction SilentlyContinue
+  # The up-front delete is part of that exit-4 contract, so a REAL removal failure
+  # must NOT be swallowed (HIMMEL-820 CR: codex-adv [high] + silent-failure-hunter
+  # convergence). A blanket -ErrorAction SilentlyContinue hid a locked/ACL-denied
+  # .seeded: the reseed then threw later and exited 4, but the OLD sentinel survived
+  # next to a half-seeded tree, and a plain relaunch (whose staleness check tracks
+  # only settings + plugin manifests, not the copied subtrees) read it as "seeded"
+  # and launched on the corrupt tree. Guard the missing-file case (Test-Path — first
+  # seed has no sentinel) and exit 4 on a genuine removal failure, BEFORE any copy.
+  $sentinel = Join-Path $ConfigDir '.seeded'
+  if (Test-Path -LiteralPath $sentinel) {
+    try {
+      Remove-Item -LiteralPath $sentinel -Force -ErrorAction Stop
+    } catch {
+      [Console]::Error.WriteLine("claude-routed: FAILED to clear stale .seeded sentinel ($($_.Exception.Message)). Refusing to reseed while a stale sentinel remains. Fix the cause and re-run (or rm -rf ~/.claude-routed).")
+      exit 4
+    }
+  }
   New-Item -ItemType Directory -Force -Path (Join-Path $ConfigDir 'plugins') | Out-Null
   $settings = Join-Path $src 'settings.json'
   if (Test-Path -LiteralPath $settings) {

--- a/scripts/test-claude-routed.ps1
+++ b/scripts/test-claude-routed.ps1
@@ -323,6 +323,26 @@ try {
   if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\.seeded')) { Fail 'sentinel written despite seed Copy-Item failure' } else { Pass 'no sentinel on seed Copy-Item failure' }
   if (FileHas $OutTxt 'FAILED to seed config dir') { Pass 'copy failure emits the failed-seed message' } else { Fail 'copy failure did not emit the failed-seed message' }
 
+  # --- T17c (HIMMEL-827, parity with glm T17c from HIMMEL-820 CR: codex-adv [high]
+  # + silent-failure-hunter): a stale .seeded that cannot be removed on reseed exits
+  # 4 with the clear-sentinel message BEFORE any copy work, and the sentinel is left
+  # intact (never silently swallowed) — so the seeder never proceeds leaving the old
+  # sentinel next to a half-seeded tree. Fixture: seed once, then exclusively lock
+  # the sentinel. ---
+  New-Sandbox; $script:KEY = 'omni-test-123'  # gitleaks:allow
+  Assert-Exit (Invoke-Launcher) 0 'seed before sentinel-lock'   # writes .seeded
+  Remove-Item -LiteralPath $ChildEnv -Force -ErrorAction SilentlyContinue  # so the non-launch assert below is meaningful
+  $sentinel = Join-Path $FAKEHOME '.claude-routed\.seeded'
+  $slock = [System.IO.File]::Open($sentinel, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+  try {
+    Assert-Exit (Invoke-Launcher -LArgs @('-Reseed')) 4 'unremovable stale sentinel exits 4 on reseed'
+  } finally {
+    $slock.Dispose()
+  }
+  if (FileHas $OutTxt 'FAILED to clear stale .seeded sentinel') { Pass 'stale-sentinel failure emits the clear-sentinel message' } else { Fail 'no clear-sentinel message on unremovable stale sentinel' }
+  if (Test-Path -LiteralPath $sentinel) { Pass 'stale sentinel left intact (not silently removed)' } else { Fail 'stale sentinel vanished despite lock' }
+  if (Test-Path -LiteralPath $ChildEnv) { Fail 'claude launched despite unremovable stale sentinel' } else { Pass 'claude not launched on unremovable stale sentinel' }
+
   # --- T18 (guard I7): phi-roots that is a DIRECTORY (not a readable regular file)
   # fails CLOSED with exit 3, never silently allows egress, never launches claude.
   # PS twin of bash T17 — proves the PS guard maps the not-a-leaf case to the


### PR DESCRIPTION
## What & why

Parity follow-up from the HIMMEL-820 CR. `claude-routed.ps1`'s `Copy-SeedConfig` cleared the stale `.seeded` sentinel with a blanket `Remove-Item -ErrorAction SilentlyContinue` — **byte-identical** to the pre-fix `claude-glm.ps1` line. A REAL removal failure (locked / ACL-denied `.seeded`) was silently swallowed: a later caught seed failure exits 4 while the OLD sentinel survives next to a half-seeded tree, and a plain relaunch (`Test-ConfigSeedStale` tracks only settings + plugin manifests, not the copied subtrees) reads it as "seeded" and launches on the corrupt tree — defeating the exit-4 seed contract.

HIMMEL-820 fixed this in `claude-glm.ps1` (commit `79a751bd`, private #1049 / public #317). This PR ports the identical guard to `claude-routed.ps1`, restoring glm↔routed behavioral parity. `claude-routed.ps1` already carried the function-level seed wrap (CR-F9 #830), so unlike glm it needed no body-wrap change — this port is scoped to just the sentinel guard.

## Changes

1. **Guarded stale-sentinel removal** (`scripts/claude-routed.ps1`) — `Test-Path` (missing = first seed, no-op) + `try { Remove-Item -ErrorAction Stop } catch { exit 4 }` with a distinct `claude-routed: FAILED to clear stale .seeded sentinel` message, **before** any copy work.
2. **T17c regression test** (`scripts/test-claude-routed.ps1`) — twin of glm's: seed once, exclusively lock `.seeded`, `-Reseed` → exit 4 + the clear-sentinel message + sentinel left intact + claude not launched.

## Contract-boundary decision (827)

The pre-copy `New-Item ...plugins` + `$src` run OUTSIDE the exit-4 try in both launchers (raw exit 1 on an obstructed path). **KEPT as-is** — matches the documented launcher-header contract ("any OTHER failure fails CLOSED via exit 1"), and `New-Item -Force` also creates `$ConfigDir` for the sanitizer so it cannot simply move inside the seed-body try. Same decision the glm reference (HIMMEL-820) reached on its identical [medium]. Not chasing the codex-adversarial next-line-outside-try convergence on a documented, pre-existing line.

## Tests

`test-claude-routed.ps1` + `test-claude-glm.ps1` — **ALL PASS** (pwsh 7, Windows). T17c verified a genuine regression test: against the pre-fix script it FAILS on the message assertion (the later New-Item-sentinel throw still exits 4, so only the distinguishing clear-sentinel message discriminates the fix).

## Code review

Critic panel (codex ok → 0 Critical / 0 Important; qwen3coder flaky-drop) + codex adversarial pass + 4 pr-review-toolkit reviewers (code-reviewer, pr-test-analyzer, silent-failure-hunter, comment-analyzer). **Final: 0 Critical / 0 Important.**

Codex adversarial raised one `[codex-adv-1]` **[medium]**: a TOCTOU race — `Test-Path` then `Remove-Item -ErrorAction Stop` is non-atomic, so a concurrent reseed sharing the config dir could remove the sentinel first → the other process gets ItemNotFound → spurious exit 4. Adjudicated **agreed** (2 reviewers) but unanimously real-but-low: fail-loud/fail-safe (no corruption, recovery = relaunch), applies identically to glm, and fixing it in routed alone would re-break parity. **Deferred to HIMMEL-828** (harden both launchers together: TOCTOU race + the deeper `Test-ConfigSeedStale`-subtree-tracking root cause).

## Follow-up

- **HIMMEL-828** — TOCTOU sentinel-race hardening + `Test-ConfigSeedStale` subtree tracking, both launchers together.

Attestation trailers (`Platforms tested: windows`, `Security reviewed: manual`) are in the first commit of the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
