### PR TITLE
feat(graphify): [HIMMEL-829] graphmap-cadence.sh — separate scheduler for refresh-graph-map (Option B)

### DIFF
--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -691,8 +691,20 @@ view into the vault — the bridge between the derived graph and the KB.
   `bash scripts/graphify/refresh-graph-map.sh --name luna --corpus-root <vault> --maps-dir <vault>/60-Maps --title "Graphify Luna Vault Map" --slug graphify-luna-map --corpus-tag luna`.
   Model: the derived graph.json + full report stay repo-local (gitignored,
   regenerable); only the curated MOC is committed to the vault, so each refresh
-  shows the map's drift as a small git diff. Consolidation into the unified
-  `pipeline-cadence` runner is the open follow-up (HIMMEL-825).
+  shows the map's drift as a small git diff.
+- `scripts/luna/graphmap-cadence.sh` — the scheduler that arms this refresh
+  (HIMMEL-829, follow-up to HIMMEL-825). A SEPARATE OS-scheduler sibling of
+  `pipeline-cadence.sh` (deliberately not a pipeline-cadence leg — that runner's
+  invariant is "every task = a claude session", and a graph refresh is a
+  deterministic script, no claude). `arm`/`status`/`disarm` register two daily
+  tasks — `HIMMEL-GraphMap-Luna` (default 13:00 local) and `HIMMEL-GraphMap-Himmel`
+  (13:20, staggered) — each firing `refresh-graph-map.sh` for its corpus off-peak
+  (13:00–13:20 local lands off-peak-UTC across common EU/US zones; DeepSeek peak =
+  UTC 1-4 + 6-10 = 2x). schtasks (Windows, StartWhenAvailable XML) / crontab
+  (POSIX); dedup-guarded; hermetic test `test-graphmap-cadence.sh`. Arming is an
+  operator flip (daily DeepSeek spend), not auto-armed:
+  `bash scripts/luna/graphmap-cadence.sh arm` (`--luna-time` / `--himmel-time` /
+  `--vault` / `--force` / `--dry-run`).
 
 ---
 

--- a/scripts/luna/graphmap-cadence.sh
+++ b/scripts/luna/graphmap-cadence.sh
@@ -1,0 +1,998 @@
+#!/usr/bin/env bash
+# graphmap-cadence.sh — arm/status/disarm the recurring graphify curated-map
+# cadence (HIMMEL-829, Option B).
+#
+# WHY: graphify graphs are point-in-time snapshots that drift as the corpus
+# changes. scripts/graphify/refresh-graph-map.sh (HIMMEL-825) is the schedulable
+# RUNNER that does a fence-safe incremental refresh + republishes a curated MOC
+# for ONE corpus. What was missing is the scheduler/arm layer. This is that
+# layer: a SEPARATE OS-scheduler cadence (Option B) that fires
+# refresh-graph-map.sh per corpus, daily, off-peak — bounding graph drift with a
+# cheap incremental (`graphify --update` re-extracts only changed files) instead
+# of an expensive full re-sync.
+#
+# DESIGN DIFFERENCE from the sibling pipeline-cadence.sh: pipeline-cadence fires
+# interactive `claude "<prompt>" < NUL` bounded sessions (each pipeline task = a
+# claude session, wired with a --settings auto-approve fragment). THIS scheduler
+# fires a DETERMINISTIC SCRIPT directly — `bash <himmel>/scripts/graphify/
+# refresh-graph-map.sh <args>` — so it has NO claude, NO NUL-stdin, NO settings
+# fragment, NO auto-approve hook, and NO claude-billing concern (HIMMEL-128 does
+# not apply). That keeps pipeline-cadence's "every task = a claude session"
+# invariant clean, and makes this scheduler strictly simpler than its sibling.
+#
+# FENCE SAFETY: refresh-graph-map.sh never extracts on a live vault — it copies
+# the corpus to a PID-owned scratchpad, carries the `.graphify-corpus` marker,
+# and only publishes the curated MOC back into the vault's 60-Maps/. That
+# discipline lives in the runner; this scheduler just fires it.
+#
+# OPERATOR FLIP: arming this cadence commits to a daily DeepSeek extraction run
+# per corpus (real, if small, recurring API spend). It never auto-arms — `arm`
+# registers tasks only when explicitly invoked, so the operator decides.
+#
+# Two daily tasks are registered:
+#   HIMMEL-GraphMap-Luna    daily (default 13:00 local)
+#       bash <himmel>/scripts/graphify/refresh-graph-map.sh --name luna ...
+#   HIMMEL-GraphMap-Himmel  daily (default 13:20 local)
+#       bash <himmel>/scripts/graphify/refresh-graph-map.sh --name himmel ...
+#
+# WHY 13:00 / 13:20 LOCAL (and staggered 20 min apart): DeepSeek off-peak is
+# defined in UTC (peak UTC 1-4 + 6-10 charges ~2x). 13:00-13:20 LOCAL lands in
+# the off-peak-UTC valley across the common European/US operator zones, and
+# refresh-graph-map.sh ALSO emits its own UTC-peak-window advisory at fire time
+# as a backstop if the local->UTC mapping ever lands inside a peak window. The
+# 20-minute stagger keeps the two DeepSeek extraction jobs from running
+# simultaneously (avoids concurrent-run rate/cost spikes).
+#
+# Usage:
+#   bash scripts/luna/graphmap-cadence.sh arm [--luna-time HH:MM]
+#       [--himmel-time HH:MM] [--vault PATH] [--force] [--dry-run]
+#   bash scripts/luna/graphmap-cadence.sh status
+#   bash scripts/luna/graphmap-cadence.sh disarm
+#
+# Test seams (used by test-graphmap-cadence.sh):
+#   GRAPHMAP_SCHTASKS  — command invoked instead of `schtasks` (Windows)
+#   GRAPHMAP_CRONTAB   — command invoked instead of `crontab` (POSIX)
+#   GRAPHMAP_BAT_DIR   — where the persistent runners (.bat/.sh) live
+#
+# Exit codes (mirrors pipeline-cadence.sh):
+#   0  done (armed / status printed / disarmed / dry-run)
+#   1  usage / input error
+#   2  env unusable (no schtasks/crontab; unknown platform; runner missing;
+#      query tool errored)
+#   3  dedup block — HIMMEL-GraphMap-* task(s) already armed; use --force
+#   4  scheduler invocation failed (/create, /delete, crontab rewrite,
+#      path conversion)
+set -euo pipefail
+
+TASK_PREFIX="HIMMEL-GraphMap-"
+TASK_LUNA="${TASK_PREFIX}Luna"
+TASK_HIMMEL="${TASK_PREFIX}Himmel"
+SCHTASKS_BIN="${GRAPHMAP_SCHTASKS:-schtasks}"
+CRONTAB_BIN="${GRAPHMAP_CRONTAB:-crontab}"
+
+# Cross-platform user-home resolution (mirrors pipeline-cadence's
+# resolve_user_home, HIMMEL-645). On Windows Git-Bash $HOME can be the MSYS home
+# (/home/<user>) while Claude Code's config (~/.claude) lives under the Windows
+# user profile, so prefer USERPROFILE via cygpath BEFORE $HOME. POSIX hosts have
+# USERPROFILE unset and fall straight through to $HOME. /tmp is the last-resort
+# floor when both are unset.
+resolve_user_home() {
+    if [ -n "${USERPROFILE:-}" ] && command -v cygpath >/dev/null 2>&1; then
+        cygpath -u "$USERPROFILE" 2>/dev/null || printf '%s' "$USERPROFILE"
+    else
+        printf '%s' "${HOME:-${USERPROFILE:-/tmp}}"
+    fi
+}
+
+# Persistent runner home (.bat on Windows, .sh on POSIX) — NOT mktemp: these
+# tasks recur daily and %TEMP% / /tmp are subject to cleanup sweeps that would
+# silently kill the cadence (same rationale as pipeline-cadence's BAT_DIR).
+BAT_DIR="${GRAPHMAP_BAT_DIR:-$(resolve_user_home)/.claude/graphmap-cadence}"
+
+# Resolve the himmel root from this script's own location (scripts/luna/..),
+# so the runner fires the shipped refresh-graph-map.sh by absolute path.
+HIMMEL_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)"
+REFRESH_SCRIPT="$HIMMEL_ROOT/scripts/graphify/refresh-graph-map.sh"
+
+# Runner-format version stamp (HIMMEL-588): emit_bat / emit_runner stamp
+# CADENCE_RUNNER_FORMAT_VERSION into every runner so a stale-format armed cadence
+# is detectable. Reused from the shared lib (same as pipeline-cadence).
+# shellcheck source=../lib/cadence-format.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/../lib/cadence-format.sh"
+
+# Off-peak defaults (see the header for the 13:00 / 13:20 local rationale).
+LUNA_TIME="13:00"
+HIMMEL_TIME="13:20"
+
+# Default vault resolution (cross-platform; mirrors pipeline-cadence). Honors
+# LUNA_VAULT_PATH first, else <home>/Documents/luna. Explicit --vault overrides.
+default_vault() {
+    if [ -n "${LUNA_VAULT_PATH:-}" ]; then
+        printf '%s' "$LUNA_VAULT_PATH"
+        return
+    fi
+    printf '%s/Documents/luna' "$(resolve_user_home)"
+}
+VAULT="$(default_vault)"
+FORCE=0
+DRY_RUN=0
+
+# Fixed per-corpus map identity (titles/slugs/tags). ASCII-only: the .bat is
+# parsed by cmd.exe under the OEM codepage where UTF-8 punctuation mojibakes.
+LUNA_TITLE="Graphify Luna Map"
+LUNA_SLUG="graphify-luna-map"
+LUNA_TAG="luna"
+HIMMEL_TITLE="Graphify Himmel Map"
+HIMMEL_SLUG="graphify-himmel-map"
+HIMMEL_TAG="himmel"
+BACKEND="deepseek"
+
+usage() {
+    cat <<'EOF'
+Usage: graphmap-cadence.sh <arm|status|disarm> [flags]
+
+Arm the OS scheduler with the recurring graphify curated-map cadence
+(HIMMEL-829): a daily fence-safe incremental refresh + curated-MOC
+republish for the luna and himmel corpora, fired as a DETERMINISTIC
+script (bash refresh-graph-map.sh ...) — NO claude session.
+
+Subcommands:
+  arm      Register both daily tasks. Dedup-guarded: refuses (rc=3) if
+           any HIMMEL-GraphMap-* task already exists; --force replaces.
+  status   Show which cadence tasks are armed (+ next run time).
+  disarm   Remove both tasks (idempotent; rc=0 if nothing was armed).
+
+Flags (arm only, except --dry-run):
+  --luna-time <HH:MM>    Daily luna-map time, 24h local   (default 13:00)
+  --himmel-time <HH:MM>  Daily himmel-map time, 24h local (default 13:20;
+                         staggered 20min after luna so the two DeepSeek
+                         extraction jobs don't run at once)
+  --vault <PATH>         Luna vault root (default: $LUNA_VAULT_PATH if set,
+                         else <user-profile>/Documents/luna). The vault's
+                         60-Maps/ is where the curated MOCs are published.
+  --force                Replace existing HIMMEL-GraphMap-* tasks
+  --dry-run              Print what would happen, touch nothing
+                         (honored by arm AND disarm)
+
+WHY 13:00 / 13:20 local: DeepSeek off-peak is defined in UTC (peak UTC
+1-4 + 6-10 = ~2x). 13:00-13:20 local lands off-peak-UTC across common
+European/US zones; refresh-graph-map.sh also emits its own UTC-peak
+advisory at fire time as a backstop.
+EOF
+}
+
+SUBCMD="${1:-}"
+if [ -z "$SUBCMD" ]; then
+    echo "ERR graphmap-cadence: subcommand required (arm|status|disarm)" >&2
+    usage >&2
+    exit 1
+fi
+shift
+case "$SUBCMD" in
+    arm|status|disarm) ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+        echo "ERR graphmap-cadence: unknown subcommand: $SUBCMD" >&2
+        usage >&2
+        exit 1
+        ;;
+esac
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --luna-time)     LUNA_TIME="${2:-}"; shift 2 ;;
+        --luna-time=*)   LUNA_TIME="${1#--luna-time=}"; shift ;;
+        --himmel-time)   HIMMEL_TIME="${2:-}"; shift 2 ;;
+        --himmel-time=*) HIMMEL_TIME="${1#--himmel-time=}"; shift ;;
+        --vault)         VAULT="${2:-}"; shift 2 ;;
+        --vault=*)       VAULT="${1#--vault=}"; shift ;;
+        --force)         FORCE=1; shift ;;
+        --dry-run)       DRY_RUN=1; shift ;;
+        -h|--help)       usage; exit 0 ;;
+        *)
+            echo "ERR graphmap-cadence: unknown arg: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Platform detect (same matrix as pipeline-cadence.sh).
+case "${OSTYPE:-$(uname -s 2>/dev/null || echo unknown)}" in
+    msys*|cygwin*|win32*|MINGW*) PLATFORM=windows ;;
+    linux*|Linux*)               PLATFORM=linux ;;
+    darwin*|Darwin*)             PLATFORM=macos ;;
+    *)                           PLATFORM=unknown ;;
+esac
+case "$PLATFORM" in
+    windows)
+        command -v "$SCHTASKS_BIN" >/dev/null 2>&1 || {
+            echo "ERR graphmap-cadence: '$SCHTASKS_BIN' not on PATH (required on Windows)" >&2
+            exit 2
+        }
+        ;;
+    linux|macos)
+        command -v "$CRONTAB_BIN" >/dev/null 2>&1 || {
+            echo "ERR graphmap-cadence: '$CRONTAB_BIN' not on PATH (required on $PLATFORM)" >&2
+            exit 2
+        }
+        ;;
+    *)
+        echo "ERR graphmap-cadence: unsupported platform (OSTYPE=${OSTYPE:-})" >&2
+        echo "    Supported: Windows (schtasks), Linux/macOS (crontab)" >&2
+        exit 2
+        ;;
+esac
+
+# MSYS_NO_PATHCONV=1 per call: without it gitbash mangles /query, /create etc.
+# into Windows-rooted paths before schtasks sees them.
+run_schtasks() { MSYS_NO_PATHCONV=1 "$SCHTASKS_BIN" "$@"; }
+
+# Escape CMD metacharacters for values interpolated into the .bat (same order as
+# pipeline-cadence's cmd_escape) so a path containing legal-but-hostile chars
+# (% & ^ are valid in Windows dirnames) can't inject commands at fire time.
+cmd_escape() {
+    local s="$1"
+    s="${s//\"/\\\"}"
+    s="${s//%/%%}"
+    s="${s//^/^^}"
+    s="${s//&/^&}"
+    s="${s//</^<}"
+    s="${s//>/^>}"
+    s="${s//|/^|}"
+    printf '%s' "$s"
+}
+
+# Dedup listing: every scheduled task named HIMMEL-GraphMap-*. Fail-CLOSED if
+# the query tool itself errors (mirrors pipeline-cadence list_existing).
+list_existing() {
+    local err_file out rc
+    err_file=$(mktemp -t graphmap-cadence.err.XXXXXX)
+    set +e
+    out=$(run_schtasks /query /fo CSV /nh 2>"$err_file")
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+        # Fail-CLOSED: any nonzero rc is fatal UNLESS it matches the one trusted
+        # empty-scheduler signature — rc=1 with EMPTY stderr (schtasks returns
+        # rc=1 on a completely empty scheduler; real errors carry stderr).
+        if [ "$rc" -ne 1 ] || [ -s "$err_file" ]; then
+            echo "ERR graphmap-cadence: schtasks /query failed (rc=$rc) — refusing to treat as empty scheduler:" >&2
+            cat "$err_file" >&2
+            rm -f "$err_file"
+            exit 2
+        fi
+    fi
+    rm -f "$err_file"
+    # shellcheck disable=SC1003  # strips both quote and the literal backslash schtasks prefixes task names with
+    printf '%s\n' "$out" \
+        | grep -o '"\\\?HIMMEL-GraphMap-[^"]*"' 2>/dev/null \
+        | tr -d '"\\' \
+        | sort -u || true
+}
+
+delete_task() {
+    local name="$1" err_file
+    err_file=$(mktemp -t graphmap-cadence.err.XXXXXX)
+    if run_schtasks /delete /tn "$name" /f >/dev/null 2>"$err_file"; then
+        rm -f "$err_file"
+        echo "graphmap-cadence: deleted scheduled task: $name"
+    else
+        echo "ERR graphmap-cadence: schtasks /delete $name failed:" >&2
+        cat "$err_file" >&2
+        rm -f "$err_file"
+        exit 4
+    fi
+}
+
+# Known not-found stderr signatures for `/query /tn <name>` (mirrors
+# pipeline-cadence). Real schtasks always emits one of these on a missing task,
+# so rc=1 WITHOUT a match (silent rc=1 included) is a real query failure.
+NOT_FOUND_RE='The system cannot find the file specified|The specified task name .* does not exist'
+
+# query_one <name>: rc 0 = armed (QUERY_OUT set), rc 1 = trusted not-found,
+# rc 2 = query failed (stderr already printed).
+QUERY_OUT=""
+query_one() {
+    local name="$1" rc err_file
+    err_file=$(mktemp -t graphmap-cadence.err.XXXXXX)
+    set +e
+    QUERY_OUT=$(run_schtasks /query /tn "$name" /fo LIST 2>"$err_file")
+    rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+        rm -f "$err_file"
+        return 0
+    fi
+    if [ "$rc" -eq 1 ] && grep -qiE "$NOT_FOUND_RE" "$err_file"; then
+        rm -f "$err_file"
+        return 1
+    fi
+    echo "ERR graphmap-cadence: schtasks /query /tn $name failed (rc=$rc) — refusing to treat as 'not armed':" >&2
+    cat "$err_file" >&2
+    echo "    If this is a localized 'task does not exist' message, the task may simply" >&2
+    echo "    not be armed. Verify / remove manually:" >&2
+    echo "        schtasks /query /tn $name" >&2
+    echo "        schtasks /delete /tn $name /f" >&2
+    rm -f "$err_file"
+    return 2
+}
+
+task_summary() {
+    case "$1" in
+        "$TASK_LUNA")   printf ' -> refresh-graph-map luna (daily)' ;;
+        "$TASK_HIMMEL") printf ' -> refresh-graph-map himmel (daily)' ;;
+    esac
+}
+
+status_one() {
+    local name="$1" next qrc=0
+    query_one "$name" || qrc=$?
+    case "$qrc" in
+        0)
+            next=$(printf '%s\n' "$QUERY_OUT" | grep -i 'Next Run Time' | head -1 \
+                | sed 's/^[^:]*:[[:space:]]*//' || true)
+            echo "ARMED      $name${next:+ (next run: $next)}$(task_summary "$name")"
+            ;;
+        1)  echo "not armed  $name$(task_summary "$name")" ;;
+        *)
+            echo "QUERY ERR  $name (see stderr above)"
+            return 2
+            ;;
+    esac
+}
+
+# Surface fire-time evidence: each runner writes its output to a .log next to the
+# runner (rotated per fire), so "armed but never succeeding" is visible here.
+status_log() {
+    local log="$1" mtime last
+    if [ -f "$log" ]; then
+        mtime=$(date -r "$log" '+%Y-%m-%d %H:%M' 2>/dev/null \
+            || stat -f '%Sm' -t '%Y-%m-%d %H:%M' "$log" 2>/dev/null \
+            || echo '?')
+        last=$(tail -n 1 "$log" 2>/dev/null | tr -d '\r' || true)
+        echo "  run log    $log (last write: $mtime)"
+        if [ -n "$last" ]; then
+            echo "             last line: $last"
+        fi
+    elif [ -f "$log.prev" ]; then
+        echo "  run log    $log (rotated — see .log.prev; no run since last rotation)"
+    else
+        echo "  run log    $log (absent — task has not fired yet)"
+    fi
+    if [ -f "$log.prev" ]; then
+        mtime=$(date -r "$log.prev" '+%Y-%m-%d %H:%M' 2>/dev/null || echo '?')
+        last=$(tail -n 1 "$log.prev" 2>/dev/null | tr -d '\r' || true)
+        echo "  prev log   $log.prev (last write: $mtime)"
+        if [ -n "$last" ]; then
+            echo "             last line: $last"
+        fi
+    fi
+}
+
+cmd_status() {
+    local status_rc=0
+    echo "graphmap-cadence status:"
+    status_one "$TASK_LUNA" || status_rc=2
+    status_log "$BAT_DIR/graphmap-luna.log"
+    status_one "$TASK_HIMMEL" || status_rc=2
+    status_log "$BAT_DIR/graphmap-himmel.log"
+    return "$status_rc"
+}
+
+cmd_disarm() {
+    local name found=0 qrc
+    for name in "$TASK_LUNA" "$TASK_HIMMEL"; do
+        qrc=0
+        query_one "$name" || qrc=$?
+        case "$qrc" in
+            0)
+                found=1
+                if [ "$DRY_RUN" -eq 1 ]; then
+                    echo "DRY graphmap-cadence: would delete $name"
+                else
+                    delete_task "$name"
+                fi
+                ;;
+            1)  : ;;
+            *)  exit 2 ;;
+        esac
+    done
+    if [ "$DRY_RUN" -eq 0 ]; then
+        rm -f "$BAT_DIR/graphmap-luna.bat" "$BAT_DIR/graphmap-himmel.bat"
+    fi
+    if [ "$found" -eq 0 ]; then
+        echo "graphmap-cadence: nothing armed — disarm is a no-op"
+    elif [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRY graphmap-cadence: no changes made"
+    else
+        echo "graphmap-cadence: cadence disarmed"
+    fi
+}
+
+# Build the argv the .bat hands to bash: the refresh-graph-map.sh path + its
+# flags. All interpolated path values are already cmd-escaped by the caller;
+# name/slug/tag/backend are fixed ASCII literals.
+bat_payload() {
+    local script_esc="$1" name="$2" corpus_esc="$3" maps_esc="$4" title="$5" slug="$6" tag="$7"
+    printf '"%s" --name %s --corpus-root "%s" --maps-dir "%s" --title "%s" --slug %s --backend %s --corpus-tag %s' \
+        "$script_esc" "$name" "$corpus_esc" "$maps_esc" "$title" "$slug" "$BACKEND" "$tag"
+}
+
+# Emit the .bat body for one cadence task: stamp the format version, rotate the
+# run log (one prior run kept as .log.prev), stamp the fire time, cd into the
+# himmel root (a failing cd aborts + is logged, instead of firing from the wrong
+# CWD), then fire bash + refresh-graph-map.sh with its stdout+stderr captured to
+# the rotating log. NO claude, NO stdin redirect: the runner IS the payload.
+emit_bat() {
+    local himmel_win_esc="$1" bash_win="$2" payload="$3" log_win_esc="$4"
+    printf 'rem %s %s\r\n' "$CADENCE_FORMAT_MARKER" "$CADENCE_RUNNER_FORMAT_VERSION"
+    printf 'if exist "%s" move /y "%s" "%s.prev" > NUL 2>&1\r\n' "$log_win_esc" "$log_win_esc" "$log_win_esc"
+    printf 'echo [fired %%DATE%% %%TIME%%] >> "%s" 2>&1\r\n' "$log_win_esc"
+    printf 'cd /d "%s" >> "%s" 2>&1 || exit /b 1\r\n' "$himmel_win_esc" "$log_win_esc"
+    printf '%s >> "%s" 2>&1\r\n' "$payload" "$log_win_esc"
+}
+
+# --- schtasks task XML (StartWhenAvailable) --------------------------------
+#
+# schtasks /create has no flag for StartWhenAvailable ("run as soon as possible
+# after a missed scheduled start"), so a daily 13:00 run is SILENTLY SKIPPED if
+# the machine was off/asleep at 13:00. The only CLI route is `schtasks /create
+# /xml`; we keep the per-task .bat as the Exec Command and wrap it in XML that
+# carries StartWhenAvailable=true (same approach as pipeline-cadence, HIMMEL-362).
+
+# Escape the three XML-significant characters for element-body text (the Exec
+# <Command> path — a BAT_DIR path may legally contain `&`). `&` first so the `&`
+# in the &lt;/&gt; entities isn't re-escaped. sed (not bash ${//}) for a
+# version-independent literal-ampersand replacement.
+xml_escape() {
+    printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
+schedule_daily_xml() {
+    printf '      <ScheduleByDay>\n        <DaysInterval>1</DaysInterval>\n      </ScheduleByDay>'
+}
+
+# Emit one task XML: a CalendarTrigger at the given local time, daily schedule,
+# StartWhenAvailable=true, and the .bat runner as the Exec Command. StartBoundary
+# date is a fixed past sentinel — the schedule fragment (not the date) governs
+# firing. Declared UTF-16 (what schtasks /create /xml expects) but the bytes are
+# plain ASCII — keep it ASCII-only (a non-ASCII byte would need a real UTF-16LE
+# +BOM file; declaring UTF-8 is rejected on Win11).
+emit_task_xml() {
+    local command_raw="$1" start_time="$2" schedule_xml="$3" command
+    command=$(xml_escape "$command_raw")
+    cat <<XML
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>himmel graphmap-cadence (HIMMEL-829)</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <CalendarTrigger>
+      <StartBoundary>2020-01-01T${start_time}:00</StartBoundary>
+      <Enabled>true</Enabled>
+${schedule_xml}
+    </CalendarTrigger>
+  </Triggers>
+  <Settings>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <Enabled>true</Enabled>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>${command}</Command>
+    </Exec>
+  </Actions>
+</Task>
+XML
+}
+
+# Create one task from an XML definition (so StartWhenAvailable applies). Mirrors
+# pipeline-cadence's schtasks_create_xml: self-contained error handling, returns
+# the schtasks rc so callers keep the failure/rollback flow.
+schtasks_create_xml() {
+    local name="$1" schedule_xml="$2" start_time="$3" bat_win="$4" err_file="$5"
+    local xml_file xml_win rc
+    if ! xml_file=$(mktemp -t graphmap-cadence.xml.XXXXXX 2>"$err_file"); then
+        return 1
+    fi
+    emit_task_xml "$bat_win" "$start_time" "$schedule_xml" > "$xml_file"
+    if ! xml_win=$(cygpath -w "$xml_file" 2>"$err_file"); then
+        rm -f "$xml_file"
+        return 1
+    fi
+    set +e
+    run_schtasks /create /tn "$name" /xml "$xml_win" /f 2>"$err_file"
+    rc=$?
+    set -e
+    rm -f "$xml_file"
+    return "$rc"
+}
+
+# Input validation shared by the schtasks and cron arm paths.
+validate_arm_inputs() {
+    if ! [[ "$LUNA_TIME" =~ ^([01][0-9]|2[0-3]):[0-5][0-9]$ ]]; then
+        echo "ERR graphmap-cadence: --luna-time must be HH:MM (24h), got: $LUNA_TIME" >&2
+        exit 1
+    fi
+    if ! [[ "$HIMMEL_TIME" =~ ^([01][0-9]|2[0-3]):[0-5][0-9]$ ]]; then
+        echo "ERR graphmap-cadence: --himmel-time must be HH:MM (24h), got: $HIMMEL_TIME" >&2
+        exit 1
+    fi
+    if [ ! -d "$VAULT" ]; then
+        echo "ERR graphmap-cadence: --vault is not a directory: $VAULT" >&2
+        exit 1
+    fi
+    if [ ! -f "$REFRESH_SCRIPT" ]; then
+        echo "ERR graphmap-cadence: refresh-graph-map.sh not found at $REFRESH_SCRIPT" >&2
+        exit 2
+    fi
+}
+
+cmd_arm() {
+    validate_arm_inputs
+
+    # Resolve bash to an absolute Windows path so the .bat invokes the Git-Bash
+    # interpreter directly — NOT the bare `bash` that resolves to the WSL
+    # System32 stub in a fresh cmd.exe.
+    local bash_posix bash_win
+    if ! bash_posix=$(command -v bash 2>/dev/null); then
+        echo "ERR graphmap-cadence: 'bash' not on PATH at arm time" >&2
+        exit 2
+    fi
+    command -v cygpath >/dev/null 2>&1 || {
+        echo "ERR graphmap-cadence: cygpath not on PATH; cannot convert paths for schtasks" >&2
+        exit 2
+    }
+    if ! bash_win=$(cygpath -w "$bash_posix" 2>&1); then
+        echo "ERR graphmap-cadence: cygpath -w failed for bash path: $bash_win" >&2
+        exit 4
+    fi
+
+    # bash consumes these paths (POSIX/mixed C:/ form via cygpath -m, which
+    # Git-Bash reads); the himmel cd target is a Windows path.
+    local script_mixed vault_mixed maps_mixed himmel_mixed himmel_win
+    if ! script_mixed=$(cygpath -m "$REFRESH_SCRIPT" 2>&1); then
+        echo "ERR graphmap-cadence: cygpath -m failed for refresh script: $script_mixed" >&2
+        exit 4
+    fi
+    if ! vault_mixed=$(cygpath -m "$VAULT" 2>&1); then
+        echo "ERR graphmap-cadence: cygpath -m failed for vault path: $vault_mixed" >&2
+        exit 4
+    fi
+    if ! maps_mixed=$(cygpath -m "$VAULT/60-Maps" 2>&1); then
+        echo "ERR graphmap-cadence: cygpath -m failed for maps dir: $maps_mixed" >&2
+        exit 4
+    fi
+    if ! himmel_mixed=$(cygpath -m "$HIMMEL_ROOT" 2>&1); then
+        echo "ERR graphmap-cadence: cygpath -m failed for himmel root: $himmel_mixed" >&2
+        exit 4
+    fi
+    if ! himmel_win=$(cygpath -w "$HIMMEL_ROOT" 2>&1); then
+        echo "ERR graphmap-cadence: cygpath -w failed for himmel root: $himmel_win" >&2
+        exit 4
+    fi
+
+    # Dedup guard — never double-register the cadence.
+    local existing
+    existing=$(list_existing)
+    if [ -n "$existing" ]; then
+        if [ "$FORCE" -eq 1 ]; then
+            echo "graphmap-cadence: --force set; replacing existing task(s):" >&2
+            local marker
+            while IFS= read -r marker; do
+                [ -z "$marker" ] && continue
+                echo "  $marker" >&2
+                if [ "$DRY_RUN" -eq 0 ]; then
+                    delete_task "$marker"
+                else
+                    echo "DRY graphmap-cadence: would delete $marker"
+                fi
+            done <<< "$existing"
+        else
+            {
+                echo "ERR graphmap-cadence: HIMMEL-GraphMap-* task(s) already armed:"
+                printf '%s\n' "$existing" | sed 's/^/    /'
+                echo ""
+                echo "Dedup safeguard — re-run with --force to replace, or inspect with:"
+                echo "    bash scripts/luna/graphmap-cadence.sh status"
+            } >&2
+            exit 3
+        fi
+    fi
+
+    # cmd-escape the path values interpolated into each .bat payload.
+    local script_esc vault_esc maps_esc himmel_esc himmel_win_esc
+    script_esc=$(cmd_escape "$script_mixed")
+    vault_esc=$(cmd_escape "$vault_mixed")
+    maps_esc=$(cmd_escape "$maps_mixed")
+    himmel_esc=$(cmd_escape "$himmel_mixed")
+    himmel_win_esc=$(cmd_escape "$himmel_win")
+
+    # Per-corpus payloads. NOTE the asymmetric --corpus-root: the luna map
+    # extracts the VAULT ($vault_esc); the himmel map extracts the HIMMEL REPO
+    # ($himmel_esc, so its derived graphify-out stays repo-local + gitignored) —
+    # but BOTH publish their curated MOC into the luna vault's 60-Maps ($maps_esc).
+    # The luna vault is the single home for every map; the cross-corpus mix here
+    # is intentional, not a copy-paste bug (HIMMEL-829 wiring decision).
+    local payload_luna payload_himmel
+    payload_luna=$(bat_payload "$script_esc" luna "$vault_esc" "$maps_esc" "$LUNA_TITLE" "$LUNA_SLUG" "$LUNA_TAG")
+    payload_himmel=$(bat_payload "$script_esc" himmel "$himmel_esc" "$maps_esc" "$HIMMEL_TITLE" "$HIMMEL_SLUG" "$HIMMEL_TAG")
+    # Both .bats get the bash exe prepended; assemble the full exec line.
+    payload_luna="\"$bash_win\" $payload_luna"
+    payload_himmel="\"$bash_win\" $payload_himmel"
+
+    local bat_luna="$BAT_DIR/graphmap-luna.bat"
+    local bat_himmel="$BAT_DIR/graphmap-himmel.bat"
+
+    # Fire-time run logs live next to the .bats (cmd-escaped for the `>>` target).
+    local bat_dir_win log_luna_esc log_himmel_esc
+    if ! bat_dir_win=$(cygpath -w "$BAT_DIR" 2>&1); then
+        echo "ERR graphmap-cadence: cygpath -w failed for bat dir: $bat_dir_win" >&2
+        exit 4
+    fi
+    log_luna_esc=$(cmd_escape "$bat_dir_win\\graphmap-luna.log")
+    log_himmel_esc=$(cmd_escape "$bat_dir_win\\graphmap-himmel.log")
+
+    # The .bat runner is the task's Exec Command. cygpath -w is a pure string
+    # transform (the .bat need not exist yet), so resolve the win paths before
+    # the dry-run preview too.
+    local bat_luna_win bat_himmel_win
+    if ! bat_luna_win=$(cygpath -w "$bat_luna" 2>&1); then
+        echo "ERR graphmap-cadence: cygpath -w failed: $bat_luna_win" >&2
+        exit 4
+    fi
+    if ! bat_himmel_win=$(cygpath -w "$bat_himmel" 2>&1); then
+        echo "ERR graphmap-cadence: cygpath -w failed: $bat_himmel_win" >&2
+        exit 4
+    fi
+
+    local sched
+    sched=$(schedule_daily_xml)
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRY graphmap-cadence: would write $bat_luna:"
+        emit_bat "$himmel_win_esc" "$bash_win" "$payload_luna" "$log_luna_esc" | sed 's/^/    /'
+        echo "DRY graphmap-cadence: would write $bat_himmel:"
+        emit_bat "$himmel_win_esc" "$bash_win" "$payload_himmel" "$log_himmel_esc" | sed 's/^/    /'
+        echo "DRY graphmap-cadence: would schtasks /create /tn $TASK_LUNA /xml <daily $LUNA_TIME, StartWhenAvailable=true> /f"
+        emit_task_xml "$bat_luna_win" "$LUNA_TIME" "$sched" | sed 's/^/    /'
+        echo "DRY graphmap-cadence: would schtasks /create /tn $TASK_HIMMEL /xml <daily $HIMMEL_TIME, StartWhenAvailable=true> /f"
+        emit_task_xml "$bat_himmel_win" "$HIMMEL_TIME" "$sched" | sed 's/^/    /'
+        echo "graphmap-cadence: dry-run complete (no changes made)"
+        return 0
+    fi
+
+    mkdir -p "$BAT_DIR"
+    emit_bat "$himmel_win_esc" "$bash_win" "$payload_luna" "$log_luna_esc" > "$bat_luna"
+    emit_bat "$himmel_win_esc" "$bash_win" "$payload_himmel" "$log_himmel_esc" > "$bat_himmel"
+
+    local err_file
+    err_file=$(mktemp -t graphmap-cadence.err.XXXXXX)
+    if ! schtasks_create_xml "$TASK_LUNA" "$sched" "$LUNA_TIME" "$bat_luna_win" "$err_file"; then
+        echo "ERR graphmap-cadence: schtasks /create $TASK_LUNA failed:" >&2
+        cat "$err_file" >&2
+        rm -f "$err_file"
+        exit 4
+    fi
+    if [ -s "$err_file" ]; then cat "$err_file" >&2; fi
+    if ! schtasks_create_xml "$TASK_HIMMEL" "$sched" "$HIMMEL_TIME" "$bat_himmel_win" "$err_file"; then
+        echo "ERR graphmap-cadence: schtasks /create $TASK_HIMMEL failed:" >&2
+        cat "$err_file" >&2
+        rm -f "$err_file"
+        # Roll back the luna task that DID register so status/dedup stay truthful.
+        if ! run_schtasks /delete /tn "$TASK_LUNA" /f >/dev/null 2>&1; then
+            echo "WARN: rollback of $TASK_LUNA failed — run disarm" >&2
+        fi
+        exit 4
+    fi
+    if [ -s "$err_file" ]; then cat "$err_file" >&2; fi
+    rm -f "$err_file"
+
+    cat <<EOF
+
+================================================================
+  GRAPHMAP CADENCE ARMED (HIMMEL-829)
+  $TASK_LUNA    daily $LUNA_TIME   -> refresh-graph-map luna
+  $TASK_HIMMEL  daily $HIMMEL_TIME   -> refresh-graph-map himmel
+  Vault: $VAULT   (maps -> 60-Maps/)
+  Himmel: $HIMMEL_ROOT
+  Runner .bats: $BAT_DIR
+
+  Each task fires bash + refresh-graph-map.sh directly (no claude
+  session). StartWhenAvailable=true: a run missed because the PC was
+  off/asleep fires when the PC is next on. Arming = daily DeepSeek
+  extraction spend; disarm anytime with:
+      bash scripts/luna/graphmap-cadence.sh disarm
+================================================================
+EOF
+}
+
+# --- POSIX (cron) implementation -------------------------------------------
+#
+# Same arm/status/disarm contract as the schtasks path, against the user
+# crontab. Both cadence entries live in ONE crontab rewrite (snapshot -> filter
+# -> append -> install), so there is no half-armed state to roll back. Runner
+# .sh files mirror the .bat runners: log rotation, fire stamp, cd-into-himmel,
+# then bash + refresh-graph-map.sh.
+
+CRON_RUNNER_LUNA="$BAT_DIR/graphmap-luna.sh"
+CRON_RUNNER_HIMMEL="$BAT_DIR/graphmap-himmel.sh"
+
+# Shell-quote a value for a cron command line (mirrors pipeline-cadence
+# cron_escape): printf %q survives the /bin/sh re-parse; the extra % -> \% pass
+# is cron(5) syntax. Control characters are rejected (rc=2).
+cron_escape() {
+    if printf '%s' "$1" | grep -qP '[[:cntrl:]]' 2>/dev/null \
+       || printf '%s' "$1" | LC_ALL=C grep -q $'[\x01-\x1f\x7f]'; then
+        echo "ERR graphmap-cadence: cron_escape: argument contains control characters — rejected" >&2
+        return 2
+    fi
+    local s
+    s=$(printf '%q' "$1")
+    printf '%s' "${s//%/\\%}"
+}
+
+# Read the current crontab into CRON_TAB. Fail-CLOSED like list_existing.
+CRON_TAB=""
+cron_read() {
+    local err_file rc
+    err_file=$(mktemp -t graphmap-cadence.err.XXXXXX)
+    set +e
+    CRON_TAB=$(LC_ALL=C "$CRONTAB_BIN" -l 2>"$err_file")
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+        if [ "$rc" -eq 1 ] && { [ ! -s "$err_file" ] || grep -qi 'no crontab' "$err_file"; }; then
+            CRON_TAB=""
+        else
+            echo "ERR graphmap-cadence: crontab -l failed (rc=$rc) — refusing to treat as empty crontab:" >&2
+            cat "$err_file" >&2
+            echo "    Non-vixie crons (busybox, Solaris) phrase 'no crontab yet' differently;" >&2
+            echo "    if that is what tripped this, install an empty crontab to unblock:" >&2
+            echo "        crontab - </dev/null" >&2
+            rm -f "$err_file"
+            exit 2
+        fi
+    fi
+    rm -f "$err_file"
+}
+
+# Install a new crontab from the given file. Returns 4 on failure; the rejected
+# tab is kept for forensics.
+cron_install() {
+    local tab_file="$1" err_file
+    err_file=$(mktemp -t graphmap-cadence.err.XXXXXX)
+    if ! "$CRONTAB_BIN" - < "$tab_file" 2>"$err_file"; then
+        echo "ERR graphmap-cadence: crontab install failed:" >&2
+        cat "$err_file" >&2
+        rm -f "$err_file"
+        echo "    rejected crontab left at: $tab_file" >&2
+        return 4
+    fi
+    rm -f "$err_file" "$tab_file"
+}
+
+# Marker-tagged cadence lines in the current CRON_TAB (empty if none).
+cron_existing() {
+    printf '%s\n' "$CRON_TAB" | grep -F "$TASK_PREFIX" || true
+}
+
+# Build the argv the runner .sh hands to /bin/sh: bash + refresh-graph-map.sh +
+# flags. bash/script/corpus/maps/title arrive pre-quoted (printf %q);
+# name/slug/tag/backend are fixed ASCII literals.
+cron_payload() {
+    local q_bash="$1" q_script="$2" name="$3" q_corpus="$4" q_maps="$5" q_title="$6" slug="$7" tag="$8"
+    printf '%s %s --name %s --corpus-root %s --maps-dir %s --title %s --slug %s --backend %s --corpus-tag %s' \
+        "$q_bash" "$q_script" "$name" "$q_corpus" "$q_maps" "$q_title" "$slug" "$BACKEND" "$tag"
+}
+
+# Emit the runner .sh body for one cadence task: stamp the format version,
+# rotate the run log, stamp the fire time, cd into the himmel root, then fire the
+# payload with output captured to the log. Optional PATH prepend for nvm-managed
+# node (refresh-graph-map.sh calls node) under cron's minimal PATH.
+# shellcheck disable=SC2016  # single-quoted $log/$(date)/_rc are emitted literally for the runner's own /bin/sh
+emit_runner() {
+    local name="$1" payload="$2" q_log="$3" q_himmel="$4" q_node_dir="${5:-}"
+    printf '#!/bin/sh\n'
+    printf '# %s runner — generated by graphmap-cadence.sh arm (HIMMEL-829)\n' "$name"
+    printf '# %s %s\n' "$CADENCE_FORMAT_MARKER" "$CADENCE_RUNNER_FORMAT_VERSION"
+    if [ -n "$q_node_dir" ]; then
+        printf 'export PATH=%s:$PATH\n' "$q_node_dir"
+    fi
+    printf 'log=%s\n' "$q_log"
+    printf 'if [ -f "$log" ]; then\n'
+    printf '    mv -f "$log" "$log.prev" || echo "[rotation failed: mv $log -> $log.prev]" >> "$log" 2>&1\n'
+    printf 'fi\n'
+    printf '{\n'
+    printf '    echo "[fired $(date '\''+%%Y-%%m-%%d %%H:%%M:%%S'\'')]"\n'
+    printf '    cd %s || exit 1\n' "$q_himmel"
+    printf '    _rc=0; %s || _rc=$?\n' "$payload"
+    printf '    echo "[exit rc=$_rc]"\n'
+    printf '} >> "$log" 2>&1\n'
+}
+
+cron_status() {
+    cron_read
+    echo "graphmap-cadence status:"
+    local name log entry sched
+    for name in "$TASK_LUNA" "$TASK_HIMMEL"; do
+        case "$name" in
+            "$TASK_LUNA") log="$BAT_DIR/graphmap-luna.log" ;;
+            *)            log="$BAT_DIR/graphmap-himmel.log" ;;
+        esac
+        entry=$(printf '%s\n' "$CRON_TAB" | grep -F "# $name" | head -1 || true)
+        if [ -n "$entry" ]; then
+            sched=$(printf '%s' "$entry" | awk '{print $1, $2, $3, $4, $5}')
+            echo "ARMED      $name (cron: $sched)$(task_summary "$name")"
+        else
+            echo "not armed  $name$(task_summary "$name")"
+        fi
+        status_log "$log"
+    done
+}
+
+cron_disarm() {
+    cron_read
+    local existing
+    existing=$(cron_existing)
+    if [ -z "$existing" ]; then
+        if [ "$DRY_RUN" -eq 0 ]; then
+            rm -f "$CRON_RUNNER_LUNA" "$CRON_RUNNER_HIMMEL"
+        fi
+        echo "graphmap-cadence: nothing armed — disarm is a no-op"
+        return 0
+    fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+        local line
+        while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            echo "DRY graphmap-cadence: would remove crontab entry: $line"
+        done <<< "$existing"
+        echo "DRY graphmap-cadence: no changes made"
+        return 0
+    fi
+    local newtab
+    newtab=$(mktemp -t graphmap-cadence.cron.XXXXXX)
+    printf '%s\n' "$CRON_TAB" | grep -vF "$TASK_PREFIX" > "$newtab" || true
+    # Install must succeed BEFORE the runners are removed — a failed install
+    # leaves the entries live and they must keep pointing at existing runners.
+    cron_install "$newtab" || exit 4
+    rm -f "$CRON_RUNNER_LUNA" "$CRON_RUNNER_HIMMEL"
+    echo "graphmap-cadence: cadence disarmed"
+}
+
+cron_arm() {
+    validate_arm_inputs
+
+    # Resolve bash to an absolute path so the runner doesn't depend on cron's
+    # minimal PATH. Capture node's directory so the runner can prepend it (nvm
+    # node won't be in cron's PATH; refresh-graph-map.sh needs node).
+    local bash_bin node_dir node_bin
+    if ! bash_bin=$(command -v bash 2>/dev/null); then
+        echo "ERR graphmap-cadence: 'bash' not on PATH at arm time" >&2
+        exit 2
+    fi
+    node_dir=""
+    if node_bin=$(command -v node 2>/dev/null); then
+        node_dir=$(dirname "$node_bin")
+    fi
+
+    # Dedup guard — never double-register the cadence.
+    cron_read
+    local existing
+    existing=$(cron_existing)
+    if [ -n "$existing" ]; then
+        if [ "$FORCE" -eq 1 ]; then
+            echo "graphmap-cadence: --force set; replacing existing cadence entries:" >&2
+            local line
+            while IFS= read -r line; do
+                [ -z "$line" ] && continue
+                if [ "$DRY_RUN" -eq 0 ]; then
+                    echo "  $line" >&2
+                else
+                    echo "DRY graphmap-cadence: would remove crontab entry: $line"
+                fi
+            done <<< "$existing"
+        else
+            {
+                echo "ERR graphmap-cadence: HIMMEL-GraphMap-* crontab entries already armed:"
+                printf '%s\n' "$existing" | sed 's/^/    /'
+                echo ""
+                echo "Dedup safeguard — re-run with --force to replace, or inspect with:"
+                echo "    bash scripts/luna/graphmap-cadence.sh status"
+            } >&2
+            exit 3
+        fi
+    fi
+
+    local q_bash q_script q_node_dir q_vault q_himmel q_maps q_luna_title q_himmel_title q_log_luna q_log_himmel
+    q_bash=$(printf '%q' "$bash_bin")
+    q_script=$(printf '%q' "$REFRESH_SCRIPT")
+    q_node_dir=$([ -n "$node_dir" ] && printf '%q' "$node_dir" || printf '')
+    q_vault=$(printf '%q' "$VAULT")
+    q_himmel=$(printf '%q' "$HIMMEL_ROOT")
+    q_maps=$(printf '%q' "$VAULT/60-Maps")
+    q_luna_title=$(printf '%q' "$LUNA_TITLE")
+    q_himmel_title=$(printf '%q' "$HIMMEL_TITLE")
+    q_log_luna=$(printf '%q' "$BAT_DIR/graphmap-luna.log")
+    q_log_himmel=$(printf '%q' "$BAT_DIR/graphmap-himmel.log")
+
+    local payload_luna payload_himmel
+    payload_luna=$(cron_payload "$q_bash" "$q_script" luna "$q_vault" "$q_maps" "$q_luna_title" "$LUNA_SLUG" "$LUNA_TAG")
+    payload_himmel=$(cron_payload "$q_bash" "$q_script" himmel "$q_himmel" "$q_maps" "$q_himmel_title" "$HIMMEL_SLUG" "$HIMMEL_TAG")
+
+    local luna_hh luna_mm himmel_hh himmel_mm
+    luna_hh="${LUNA_TIME%:*}"; luna_mm="${LUNA_TIME#*:}"
+    himmel_hh="${HIMMEL_TIME%:*}"; himmel_mm="${HIMMEL_TIME#*:}"
+    local q_runner_luna q_runner_himmel
+    q_runner_luna=$(cron_escape "$CRON_RUNNER_LUNA")
+    q_runner_himmel=$(cron_escape "$CRON_RUNNER_HIMMEL")
+    local entry_luna entry_himmel
+    entry_luna="$luna_mm $luna_hh * * * $q_runner_luna # $TASK_LUNA"
+    entry_himmel="$himmel_mm $himmel_hh * * * $q_runner_himmel # $TASK_HIMMEL"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRY graphmap-cadence: would write $CRON_RUNNER_LUNA:"
+        emit_runner "$TASK_LUNA" "$payload_luna" "$q_log_luna" "$q_himmel" "$q_node_dir" | sed 's/^/    /'
+        echo "DRY graphmap-cadence: would write $CRON_RUNNER_HIMMEL:"
+        emit_runner "$TASK_HIMMEL" "$payload_himmel" "$q_log_himmel" "$q_himmel" "$q_node_dir" | sed 's/^/    /'
+        echo "DRY graphmap-cadence: would add crontab entries:"
+        echo "    $entry_luna"
+        echo "    $entry_himmel"
+        echo "graphmap-cadence: dry-run complete (no changes made)"
+        return 0
+    fi
+
+    mkdir -p "$BAT_DIR"
+    # Stage the runners at temp paths and promote (mv) them only after the
+    # crontab install succeeds: writing them in place first would let a failed
+    # install (exit 4) leave the OLD crontab live while the runner files already
+    # carry the NEW config — a silent half-state under --force re-arm.
+    local tmp_luna="$CRON_RUNNER_LUNA.tmp.$$" tmp_himmel="$CRON_RUNNER_HIMMEL.tmp.$$"
+    emit_runner "$TASK_LUNA" "$payload_luna" "$q_log_luna" "$q_himmel" "$q_node_dir" > "$tmp_luna"
+    emit_runner "$TASK_HIMMEL" "$payload_himmel" "$q_log_himmel" "$q_himmel" "$q_node_dir" > "$tmp_himmel"
+    chmod +x "$tmp_luna" "$tmp_himmel"
+
+    # Single atomic rewrite: everything that isn't ours, then both entries.
+    local newtab
+    newtab=$(mktemp -t graphmap-cadence.cron.XXXXXX)
+    {
+        if [ -n "$CRON_TAB" ]; then
+            printf '%s\n' "$CRON_TAB" | grep -vF "$TASK_PREFIX" || true
+        fi
+        printf '%s\n' "$entry_luna" "$entry_himmel"
+    } > "$newtab"
+    if ! cron_install "$newtab"; then
+        rm -f "$tmp_luna" "$tmp_himmel"
+        echo "    existing runner files left untouched" >&2
+        exit 4
+    fi
+    mv -f "$tmp_luna" "$CRON_RUNNER_LUNA"
+    mv -f "$tmp_himmel" "$CRON_RUNNER_HIMMEL"
+
+    cat <<EOF
+
+================================================================
+  GRAPHMAP CADENCE ARMED (HIMMEL-829, cron)
+  $TASK_LUNA    daily $LUNA_TIME   -> refresh-graph-map luna
+  $TASK_HIMMEL  daily $HIMMEL_TIME   -> refresh-graph-map himmel
+  Vault: $VAULT   (maps -> 60-Maps/)
+  Himmel: $HIMMEL_ROOT
+  Runner .sh: $BAT_DIR
+
+  Each task fires bash + refresh-graph-map.sh directly (no claude
+  session). Arming = daily DeepSeek extraction spend; disarm anytime:
+      bash scripts/luna/graphmap-cadence.sh disarm
+================================================================
+EOF
+}
+
+case "$SUBCMD" in
+    arm)    if [ "$PLATFORM" = "windows" ]; then cmd_arm;    else cron_arm;    fi ;;
+    status) if [ "$PLATFORM" = "windows" ]; then cmd_status; else cron_status; fi ;;
+    disarm) if [ "$PLATFORM" = "windows" ]; then cmd_disarm; else cron_disarm; fi ;;
+esac

--- a/scripts/luna/test-graphmap-cadence.sh
+++ b/scripts/luna/test-graphmap-cadence.sh
@@ -1,0 +1,760 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/luna/graphmap-cadence.sh (HIMMEL-829, Option B).
+#
+# Two daily cadence tasks are armed: HIMMEL-GraphMap-Luna (daily 13:00 ->
+# refresh-graph-map.sh --name luna ...) and HIMMEL-GraphMap-Himmel (daily
+# 13:20 -> refresh-graph-map.sh --name himmel ...). Unlike pipeline-cadence
+# these runners fire a DETERMINISTIC script (bash refresh-graph-map.sh ...),
+# NOT a claude session — so there is no --settings fragment, no NUL stdin, no
+# auto-approve hook to assert.
+#
+# Strategy (hermetic — mirrors test-pipeline-cadence.sh): replace the
+# scheduler with a fake — schtasks via the GRAPHMAP_SCHTASKS seam (records
+# /create XML + simulates /query and /delete from a state dir), crontab via
+# the GRAPHMAP_CRONTAB seam (a state-file crontab supporting -l and - install);
+# point GRAPHMAP_BAT_DIR at a temp dir so the runners (.bat/.sh) are
+# inspectable; put a fake `bash` first on PATH so arm resolves the stub, never
+# the real interpreter. HOME/USERPROFILE point at the temp dir so nothing
+# touches the real user profile. The cron suite runs on EVERY platform (the
+# POSIX path is forced with an OSTYPE override); the schtasks suite stays
+# Windows-only (cmd_arm needs cygpath).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/graphmap-cadence.sh"
+
+PASS=0
+FAIL=0
+TMP_ROOT=""
+
+# shellcheck disable=SC2329,SC2317
+cleanup() {
+    if [ -n "$TMP_ROOT" ] && [ -d "$TMP_ROOT" ]; then
+        rm -rf "$TMP_ROOT" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; if [ $# -ge 2 ]; then printf '    %s\n' "$2"; fi; FAIL=$((FAIL+1)); }
+assert_contains() {
+    local name="$1" needle="$2" haystack="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then pass "$name"; else fail "$name" "missing: $needle"; fi
+}
+assert_not_contains() {
+    local name="$1" needle="$2" haystack="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then fail "$name" "unexpected: $needle"; else pass "$name"; fi
+}
+assert_rc() {
+    local name="$1" want="$2" got="$3"
+    if [ "$got" = "$want" ]; then pass "$name"; else fail "$name" "expected rc=$want, got rc=$got"; fi
+}
+summary() {
+    echo
+    echo "===================================="
+    echo "test summary: $PASS passed, $FAIL failed"
+    echo "===================================="
+    [ "$FAIL" -gt 0 ] && exit 1 || exit 0
+}
+
+TMP_ROOT=$(mktemp -d)
+if command -v cygpath >/dev/null 2>&1; then TMP_ROOT=$(cygpath -m "$TMP_ROOT"); fi
+
+# Shared fixtures ------------------------------------------------------------
+
+# Fake bash on PATH (arm resolves it via `command -v bash`). A no-op stub is
+# enough — the tests assert runner TEXT, they never fire the runner.
+mkdir -p "$TMP_ROOT/bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP_ROOT/bin/bash"
+chmod +x "$TMP_ROOT/bin/bash"
+
+# Hermeticity: point HOME/USERPROFILE at the temp dir so a stray BAT_DIR default
+# (should the seam ever be dropped) can't land under the real user profile.
+export HOME="$TMP_ROOT/home"
+mkdir -p "$HOME"
+
+VAULT="$TMP_ROOT/vault"
+mkdir -p "$VAULT"
+
+# The himmel root the runners cd into is this script's ../.. (same resolution
+# graphmap-cadence.sh uses for HIMMEL_ROOT).
+HIMMEL_ROOT_EXP="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# A claude-session runner (the sibling pipeline-cadence) would carry these
+# markers; a deterministic refresh-graph-map runner must carry NONE of them.
+# (Can't grep the bare word "claude" — the worktree path contains ".claude".)
+
+# ============================================================================
+# xml_escape unit — the one non-trivial string transform. Pure + platform-
+# agnostic, so it runs on EVERY platform: extract the function and call it.
+# ============================================================================
+echo "TEST: xml_escape escapes & < > with & ordered first"
+xesc=$( { sed -n '/^xml_escape()/,/^}/p' "$SCRIPT"; echo "xml_escape 'a & b < c > d'"; } | bash )
+assert_contains "xml_escape produces well-formed entities (& first)" "a &amp; b &lt; c &gt; d" "$xesc"
+assert_not_contains "xml_escape leaves no bare ampersand" "a & b" "$xesc"
+
+# ============================================================================
+# default_vault / resolve_user_home units — cross-platform default resolution.
+# Pure (env + cygpath only), so they run on EVERY platform.
+# ============================================================================
+echo "TEST: default_vault resolves the cross-platform default vault"
+DV_SRC="$(sed -n '/^resolve_user_home()/,/^}/p' "$SCRIPT"; sed -n '/^default_vault()/,/^}/p' "$SCRIPT")"
+run_dv() { env "$@" bash -c "$DV_SRC"$'\n'"default_vault"; }
+
+dv_a=$(run_dv LUNA_VAULT_PATH="/some/explicit/vault" USERPROFILE='C:\Users\x')
+assert_contains "default_vault honors LUNA_VAULT_PATH" "/some/explicit/vault" "$dv_a"
+assert_not_contains "LUNA_VAULT_PATH used verbatim (no Documents/luna append)" "Documents/luna" "$dv_a"
+
+dv_b=$(run_dv -u LUNA_VAULT_PATH -u USERPROFILE HOME="/posix/home")
+assert_contains "default_vault POSIX shape is \$HOME/Documents/luna" "/posix/home/Documents/luna" "$dv_b"
+
+# ============================================================================
+# POSIX (cron) suite. Runs on EVERY platform: the cron code path is forced via
+# an OSTYPE override + the GRAPHMAP_CRONTAB seam.
+# ============================================================================
+
+CSTATE="$TMP_ROOT/cron-state"
+mkdir -p "$CSTATE"
+
+# Fake crontab: persists the installed tab at $CSTATE/crontab. Mimics real
+# crontab signatures: -l with no tab prints "no crontab for <user>" + rc=1;
+# `crontab -` installs from stdin. Failure seam: $CSTATE/fail-write.
+FAKE_CRONTAB="$TMP_ROOT/crontab-fake.sh"
+cat >"$FAKE_CRONTAB" <<FAKE
+#!/usr/bin/env bash
+CSTATE="$CSTATE"
+FAKE
+cat >>"$FAKE_CRONTAB" <<'FAKE'
+case "${1:-}" in
+    -l)
+        if [ -e "$CSTATE/fail-list" ]; then
+            echo "crontab: must be privileged to use -l" >&2
+            exit 1
+        fi
+        if [ -f "$CSTATE/crontab" ]; then
+            cat "$CSTATE/crontab"
+        else
+            echo "no crontab for fakeuser" >&2
+            exit 1
+        fi
+        ;;
+    -)
+        if [ -e "$CSTATE/fail-write" ]; then
+            echo "crontab: error writing new crontab" >&2
+            exit 1
+        fi
+        cat > "$CSTATE/crontab"
+        ;;
+    *)
+        echo "crontab-fake: unsupported argv: $*" >&2
+        exit 64
+        ;;
+esac
+FAKE
+chmod +x "$FAKE_CRONTAB"
+
+CRON_DIR="$TMP_ROOT/cron-runners"
+
+run_cron() {
+    env OSTYPE=linux-gnu GRAPHMAP_CRONTAB="$FAKE_CRONTAB" \
+        GRAPHMAP_BAT_DIR="$CRON_DIR" PATH="$TMP_ROOT/bin:$PATH" bash "$SCRIPT" "$@"
+}
+
+# Test C1: status with no crontab installed ----------------------------------
+
+echo "TEST: cron status with no crontab installed"
+out=$(run_cron status)
+assert_contains "cron luna not armed"   "not armed  HIMMEL-GraphMap-Luna"   "$out"
+assert_contains "cron himmel not armed" "not armed  HIMMEL-GraphMap-Himmel" "$out"
+
+# Test C12: shared validation wired into the cron path -----------------------
+
+echo "TEST: cron arm rejects invalid input (shared validation)"
+rc=0; out=$(run_cron arm --vault "$VAULT" --luna-time 24:61 2>&1) || rc=$?
+assert_rc "cron bad --luna-time -> rc 1" 1 "$rc"
+rc=0; out=$(run_cron arm --vault "$VAULT" --himmel-time 25:00 2>&1) || rc=$?
+assert_rc "cron bad --himmel-time -> rc 1" 1 "$rc"
+rc=0; out=$(run_cron arm --vault "$TMP_ROOT/does-not-exist" 2>&1) || rc=$?
+assert_rc "cron missing vault dir -> rc 1" 1 "$rc"
+
+# Test C2: arm --dry-run touches nothing --------------------------------------
+
+echo "TEST: cron arm --dry-run prints plan, installs nothing"
+out=$(run_cron arm --vault "$VAULT" --dry-run)
+assert_contains "dry-run daily luna entry"   "00 13 * * *" "$out"
+assert_contains "dry-run daily himmel entry" "20 13 * * *" "$out"
+assert_contains "dry-run luna marker"   "# HIMMEL-GraphMap-Luna"   "$out"
+assert_contains "dry-run himmel marker" "# HIMMEL-GraphMap-Himmel" "$out"
+assert_contains "dry-run fires refresh-graph-map.sh" "refresh-graph-map.sh" "$out"
+assert_contains "dry-run luna payload names the corpus" "--name luna" "$out"
+assert_contains "dry-run himmel payload names the corpus" "--name himmel" "$out"
+if [ ! -f "$CSTATE/crontab" ]; then
+    pass "dry-run installed no crontab"
+else
+    fail "dry-run installed a crontab" "$(cat "$CSTATE/crontab")"
+fi
+if [ ! -d "$CRON_DIR" ]; then
+    pass "dry-run wrote no runner .sh"
+else
+    fail "dry-run wrote runners" "$(ls "$CRON_DIR")"
+fi
+
+# Test C3: arm installs marker-tagged entries, preserves unrelated lines ------
+
+echo "TEST: cron arm installs entries with defaults, preserves unrelated lines"
+printf '5 5 * * * /usr/bin/true # keep-me\n' > "$CSTATE/crontab"
+out=$(run_cron arm --vault "$VAULT")
+assert_contains "cron arm banner" "GRAPHMAP CADENCE ARMED" "$out"
+tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
+assert_contains "daily luna entry 13:00"   "00 13 * * *" "$tab"
+assert_contains "daily himmel entry 13:20" "20 13 * * *" "$tab"
+assert_contains "luna entry marker-tagged"   "# HIMMEL-GraphMap-Luna"   "$tab"
+assert_contains "himmel entry marker-tagged" "# HIMMEL-GraphMap-Himmel" "$tab"
+assert_contains "luna entry fires the runner"   "graphmap-luna.sh"   "$tab"
+assert_contains "himmel entry fires the runner" "graphmap-himmel.sh" "$tab"
+assert_contains "unrelated entry preserved" "keep-me" "$tab"
+if [ -x "$CRON_DIR/graphmap-luna.sh" ] && [ -x "$CRON_DIR/graphmap-himmel.sh" ]; then
+    pass "runner .sh files written + executable"
+else
+    fail "runner .sh files missing or not executable" "$(ls -l "$CRON_DIR" 2>/dev/null || true)"
+fi
+
+# Test C4: runner .sh fires refresh-graph-map.sh with the right payload -------
+
+echo "TEST: runner .sh fires bash refresh-graph-map.sh (deterministic, no claude)"
+luna_sh=$(cat "$CRON_DIR/graphmap-luna.sh" 2>/dev/null || echo MISSING)
+himmel_sh=$(cat "$CRON_DIR/graphmap-himmel.sh" 2>/dev/null || echo MISSING)
+# The sh runner embeds paths/title via printf %q (backslash-escapes spaces);
+# strip the escapes before multi-word asserts.
+luna_sh_plain=${luna_sh//\\/}
+himmel_sh_plain=${himmel_sh//\\/}
+assert_contains "luna runner stamps the format version (HIMMEL-588)"   "# himmel-cadence-runner-format: 1" "$luna_sh"
+assert_contains "himmel runner stamps the format version (HIMMEL-588)" "# himmel-cadence-runner-format: 1" "$himmel_sh"
+assert_contains "luna runner fires refresh-graph-map.sh"   "refresh-graph-map.sh" "$luna_sh_plain"
+assert_contains "luna runner names the luna corpus"        "--name luna"          "$luna_sh"
+assert_contains "luna runner sets the luna slug"           "--slug graphify-luna-map" "$luna_sh"
+assert_contains "luna runner sets the luna corpus-tag"     "--corpus-tag luna"    "$luna_sh"
+assert_contains "luna runner uses the deepseek backend"    "--backend deepseek"   "$luna_sh"
+assert_contains "luna runner sets the luna title"          "Graphify Luna Map"    "$luna_sh_plain"
+assert_contains "luna runner publishes into 60-Maps"       "60-Maps"              "$luna_sh_plain"
+# Strong corpus-root asserts (HIMMEL-829 CR, pr-test-analyzer): the luna map
+# extracts the VAULT, the himmel map extracts the HIMMEL REPO — deliberately
+# different roots. Match the --corpus-root TOKEN (not a bare $VAULT, which also
+# appears in --maps-dir) so a payload arg-swap that makes the himmel map extract
+# the vault (or vice-versa) fails here instead of shipping a wrong/empty graph.
+assert_contains "luna runner corpus-root is the vault"     "--corpus-root $VAULT"           "$luna_sh_plain"
+assert_contains "himmel runner names the himmel corpus"    "--name himmel"        "$himmel_sh"
+assert_contains "himmel runner sets the himmel slug"       "--slug graphify-himmel-map" "$himmel_sh"
+assert_contains "himmel runner sets the himmel corpus-tag" "--corpus-tag himmel"  "$himmel_sh"
+assert_contains "himmel runner uses the deepseek backend"  "--backend deepseek"   "$himmel_sh"
+assert_contains "himmel runner corpus-root is the himmel repo" "--corpus-root $HIMMEL_ROOT_EXP" "$himmel_sh_plain"
+assert_contains "himmel runner sets the himmel title"      "Graphify Himmel Map"  "$himmel_sh_plain"
+assert_contains "luna runner cds into himmel root" "cd $HIMMEL_ROOT_EXP" "$luna_sh_plain"
+# shellcheck disable=SC2016  # literal $log needles — the runner expands them at fire time
+assert_contains "luna runner rotates the log" 'mv -f "$log" "$log.prev"' "$luna_sh"
+assert_contains "luna runner stamps every fire" '[fired' "$luna_sh"
+# shellcheck disable=SC2016
+assert_contains "luna runner captures output to log" '>> "$log" 2>&1' "$luna_sh"
+for what in luna himmel; do
+    body=$(eval "printf '%s' \"\$${what}_sh\"")
+    assert_not_contains "$what runner has no --settings (not a claude session)" "--settings" "$body"
+    assert_not_contains "$what runner has no bounded-claude stdin marker" "< /dev/null" "$body"
+done
+
+# Test C5: status after arm ----------------------------------------------------
+
+echo "TEST: cron status reflects armed entries"
+out=$(run_cron status)
+assert_contains "cron luna armed"   "ARMED      HIMMEL-GraphMap-Luna"   "$out"
+assert_contains "cron himmel armed" "ARMED      HIMMEL-GraphMap-Himmel" "$out"
+assert_contains "cron status surfaces run log state" "run log" "$out"
+
+# Test C6: re-arm without --force -> dedup block -------------------------------
+
+echo "TEST: cron re-arm without --force blocked (rc 3)"
+rc=0; out=$(run_cron arm --vault "$VAULT" 2>&1) || rc=$?
+assert_rc "cron dedup block rc 3" 3 "$rc"
+assert_contains "cron dedup message names existing entries" "HIMMEL-GraphMap-Himmel" "$out"
+if [ "$(grep -c 'HIMMEL-GraphMap-' "$CSTATE/crontab")" -eq 2 ]; then
+    pass "no duplicate entries after blocked re-arm"
+else
+    fail "entry count changed on blocked re-arm" "$(cat "$CSTATE/crontab")"
+fi
+
+# Test C7: re-arm --force with overrides ----------------------------------------
+
+echo "TEST: cron re-arm --force applies flag overrides"
+out=$(run_cron arm --vault "$VAULT" --force --luna-time 01:15 --himmel-time 02:30 2>&1)
+tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
+assert_contains "cron daily luna override"   "15 01 * * *" "$tab"
+assert_contains "cron daily himmel override" "30 02 * * *" "$tab"
+assert_contains "unrelated entry survives --force re-arm" "keep-me" "$tab"
+if [ "$(grep -c 'HIMMEL-GraphMap-' "$CSTATE/crontab")" -eq 2 ]; then
+    pass "still exactly two entries after --force re-arm"
+else
+    fail "duplicate entries after --force re-arm" "$(cat "$CSTATE/crontab")"
+fi
+
+# Test C14: dry-run disarm with armed entries prints DRY tail, touches nothing --
+
+echo "TEST: cron dry-run disarm prints DRY tail, touches nothing"
+out=$(run_cron disarm --dry-run)
+assert_contains "cron dry disarm lists removals" "would remove crontab entry" "$out"
+assert_contains "cron dry disarm closing summary" "no changes made" "$out"
+if [ "$(grep -c 'HIMMEL-GraphMap-' "$CSTATE/crontab")" -eq 2 ]; then
+    pass "dry-run disarm removed no entries"
+else
+    fail "dry-run disarm changed crontab state" "$(cat "$CSTATE/crontab")"
+fi
+if [ -f "$CRON_DIR/graphmap-luna.sh" ] && [ -f "$CRON_DIR/graphmap-himmel.sh" ]; then
+    pass "dry-run disarm kept the runner .sh files"
+else
+    fail "dry-run disarm deleted runner .sh files"
+fi
+
+# Test C8: disarm + idempotent second disarm ------------------------------------
+
+echo "TEST: cron disarm removes entries + runners, keeps unrelated lines"
+out=$(run_cron disarm)
+assert_contains "cron disarm reports" "cadence disarmed" "$out"
+tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
+assert_not_contains "cadence entries removed" "HIMMEL-GraphMap-" "$tab"
+assert_contains "unrelated entry survives disarm" "keep-me" "$tab"
+if [ ! -f "$CRON_DIR/graphmap-luna.sh" ] && [ ! -f "$CRON_DIR/graphmap-himmel.sh" ]; then
+    pass "runner .sh files removed"
+else
+    fail "runner .sh files left after disarm"
+fi
+rc=0; out=$(run_cron disarm) || rc=$?
+assert_rc "cron second disarm rc 0" 0 "$rc"
+assert_contains "cron second disarm is a no-op" "no-op" "$out"
+
+# Test C9: failing crontab -l is fail-CLOSED -------------------------------------
+
+echo "TEST: cron arm/status/disarm with failing crontab -l exit 2"
+touch "$CSTATE/fail-list"
+rc=0; out=$(run_cron arm --vault "$VAULT" 2>&1) || rc=$?
+assert_rc "cron fail-closed arm rc 2" 2 "$rc"
+assert_contains "cron arm failure surfaces stderr" "must be privileged" "$out"
+rc=0; out=$(run_cron status 2>&1) || rc=$?
+assert_rc "cron fail-closed status rc 2" 2 "$rc"
+rm -f "$CSTATE/fail-list"
+out=$(run_cron arm --vault "$VAULT")
+touch "$CSTATE/fail-list"
+rc=0; out=$(run_cron disarm 2>&1) || rc=$?
+assert_rc "cron fail-closed disarm rc 2" 2 "$rc"
+assert_not_contains "no false no-op on failing crontab -l" "no-op" "$out"
+if [ -f "$CRON_DIR/graphmap-luna.sh" ] && [ -f "$CRON_DIR/graphmap-himmel.sh" ]; then
+    pass "runner .sh files NOT deleted on crontab -l failure"
+else
+    fail "runner .sh files deleted despite crontab -l failure"
+fi
+rm -f "$CSTATE/fail-list"
+run_cron disarm >/dev/null
+
+# Test C10: crontab install failure -> rc 4 ---------------------------------------
+
+echo "TEST: cron arm with failing crontab install exits 4"
+touch "$CSTATE/fail-write"
+rc=0; out=$(run_cron arm --vault "$VAULT" 2>&1) || rc=$?
+assert_rc "cron install failure rc 4" 4 "$rc"
+assert_contains "cron install failure surfaces stderr" "error writing new crontab" "$out"
+if ! grep -q 'HIMMEL-GraphMap-' "$CSTATE/crontab" 2>/dev/null; then
+    pass "no cadence entries installed on write failure"
+else
+    fail "cadence entries installed despite write failure" "$(cat "$CSTATE/crontab")"
+fi
+if [ ! -f "$CRON_DIR/graphmap-luna.sh" ] && [ ! -f "$CRON_DIR/graphmap-himmel.sh" ]; then
+    pass "no runner promoted to its final path on write failure"
+else
+    fail "runner files left despite write failure" "$(ls "$CRON_DIR" 2>/dev/null || true)"
+fi
+if ! compgen -G "$CRON_DIR/*.tmp.*" >/dev/null; then
+    pass "no staged .tmp runner litter on write failure"
+else
+    fail "staged .tmp runner litter left" "$(ls "$CRON_DIR")"
+fi
+rm -f "$CSTATE/fail-write"
+run_cron disarm >/dev/null
+
+# Test C10b: --force re-arm with failing install leaves NO half-state ------------
+
+echo "TEST: cron --force re-arm with failing install keeps old runners + entries"
+out=$(run_cron arm --vault "$VAULT")
+VAULT2="$TMP_ROOT/vault2"
+mkdir -p "$VAULT2"
+touch "$CSTATE/fail-write"
+rc=0; out=$(run_cron arm --vault "$VAULT2" --force 2>&1) || rc=$?
+assert_rc "cron force re-arm install failure rc 4" 4 "$rc"
+luna_sh=$(cat "$CRON_DIR/graphmap-luna.sh" 2>/dev/null || echo MISSING)
+assert_contains "old runner still points at the old vault" "$VAULT" "${luna_sh//\\/}"
+assert_not_contains "no new-config runner promoted" "vault2" "$luna_sh"
+if ! compgen -G "$CRON_DIR/*.tmp.*" >/dev/null; then
+    pass "no staged .tmp runner litter after failed --force re-arm"
+else
+    fail "staged .tmp runner litter left" "$(ls "$CRON_DIR")"
+fi
+if [ "$(grep -c 'HIMMEL-GraphMap-' "$CSTATE/crontab")" -eq 2 ]; then
+    pass "old entries still armed after failed --force re-arm"
+else
+    fail "entry count changed on failed --force re-arm" "$(cat "$CSTATE/crontab")"
+fi
+rm -f "$CSTATE/fail-write"
+run_cron disarm >/dev/null
+
+# Test C10c: disarm with failing install keeps entries + runners -----------------
+
+echo "TEST: cron disarm with failing crontab install exits 4, keeps entries + runners"
+out=$(run_cron arm --vault "$VAULT")
+touch "$CSTATE/fail-write"
+rc=0; out=$(run_cron disarm 2>&1) || rc=$?
+assert_rc "cron disarm install failure rc 4" 4 "$rc"
+assert_contains "disarm install failure surfaces stderr" "error writing new crontab" "$out"
+if [ "$(grep -c 'HIMMEL-GraphMap-' "$CSTATE/crontab")" -eq 2 ]; then
+    pass "entries still in crontab after failed disarm install"
+else
+    fail "entries lost despite failed disarm install" "$(cat "$CSTATE/crontab")"
+fi
+if [ -f "$CRON_DIR/graphmap-luna.sh" ] && [ -f "$CRON_DIR/graphmap-himmel.sh" ]; then
+    pass "runner .sh files NOT deleted on failed disarm install"
+else
+    fail "runner .sh files deleted despite failed disarm install"
+fi
+rm -f "$CSTATE/fail-write"
+run_cron disarm >/dev/null
+
+# Test C11: hostile-but-legal vault dirname + runner dir can't inject -------------
+
+echo "TEST: cron entries + runner escape hostile vault/runner paths"
+EVIL_VAULT="$TMP_ROOT/va&ult \$X y"
+EVIL_DIR="$TMP_ROOT/cr%on rnr"
+mkdir -p "$EVIL_VAULT"
+out=$(env OSTYPE=linux-gnu GRAPHMAP_CRONTAB="$FAKE_CRONTAB" \
+    GRAPHMAP_BAT_DIR="$EVIL_DIR" PATH="$TMP_ROOT/bin:$PATH" bash "$SCRIPT" arm --vault "$EVIL_VAULT")
+luna_sh=$(cat "$EVIL_DIR/graphmap-luna.sh" 2>/dev/null || echo MISSING)
+assert_contains "ampersand %q-escaped in runner" 'va\&ult' "$luna_sh"
+# shellcheck disable=SC2016  # literal \$X needle — asserting the %q escape itself
+assert_contains "dollar %q-escaped in runner" '\$X' "$luna_sh"
+tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
+assert_contains "percent cron-escaped in entry (\\%)" 'cr\%on' "$tab"
+assert_contains "space %q-escaped in entry" 'cr\%on\ rnr' "$tab"
+env OSTYPE=linux-gnu GRAPHMAP_CRONTAB="$FAKE_CRONTAB" \
+    GRAPHMAP_BAT_DIR="$EVIL_DIR" PATH="$TMP_ROOT/bin:$PATH" bash "$SCRIPT" disarm >/dev/null
+
+# Test C13: unknown platform exits 2 ----------------------------------------------
+
+echo "TEST: unknown platform (OSTYPE=beos) exits 2"
+rc=0; out=$(env OSTYPE=beos bash "$SCRIPT" status 2>&1) || rc=$?
+assert_rc "unknown platform rc 2" 2 "$rc"
+assert_contains "unknown platform message" "unsupported platform" "$out"
+
+# ============================================================================
+# schtasks suite — Windows-only (cmd_arm needs cygpath; the cron suite above
+# already exercised the POSIX path on this platform).
+# ============================================================================
+
+case "${OSTYPE:-$(uname -s 2>/dev/null || echo unknown)}" in
+    msys*|cygwin*|win32*|MINGW*) : ;;
+    *)
+        echo "SKIP: schtasks suite (Windows-only — needs cygpath/schtasks shapes)"
+        summary
+        ;;
+esac
+
+# schtasks fixtures ----------------------------------------------------------
+
+STATE="$TMP_ROOT/state"
+mkdir -p "$STATE/tasks"
+
+# Fake schtasks: persists tasks as files under $STATE/tasks/<name> (content =
+# the created XML, for assertions). Mirrors test-pipeline-cadence's fake.
+FAKE_SCHTASKS="$TMP_ROOT/schtasks-fake.sh"
+cat >"$FAKE_SCHTASKS" <<FAKE
+#!/usr/bin/env bash
+STATE="$STATE"
+FAKE
+cat >>"$FAKE_SCHTASKS" <<'FAKE'
+tn=""; mode=""; xmlpath=""
+args=("$@")
+i=0
+while [ $i -lt ${#args[@]} ]; do
+    case "${args[$i]}" in
+        /create|/delete|/query) mode="${args[$i]}" ;;
+        /tn) i=$((i+1)); tn="${args[$i]}" ;;
+        /xml) i=$((i+1)); xmlpath="${args[$i]}" ;;
+    esac
+    i=$((i+1))
+done
+case "$mode" in
+    /create)
+        if [ -e "$STATE/fail-create-$tn" ]; then
+            echo "ERROR: Access is denied." >&2
+            exit 1
+        fi
+        if [ -n "$xmlpath" ]; then
+            xml_posix=$(cygpath -u "$xmlpath" 2>/dev/null || echo "$xmlpath")
+            cat "$xml_posix" > "$STATE/tasks/$tn"
+        else
+            printf '%s\n' "$*" > "$STATE/tasks/$tn"
+        fi
+        echo "SUCCESS: The scheduled task \"$tn\" has successfully been created."
+        ;;
+    /delete)
+        if [ -f "$STATE/tasks/$tn" ]; then rm -f "$STATE/tasks/$tn"; exit 0; else exit 1; fi
+        ;;
+    /query)
+        if [ -e "$STATE/fail-query" ]; then
+            echo "ERROR: Access is denied." >&2
+            exit 1
+        fi
+        if [ -n "$tn" ]; then
+            if [ -f "$STATE/tasks/$tn" ]; then
+                printf 'TaskName:      \\%s\nNext Run Time: 7/10/2026 1:00:00 PM\n' "$tn"
+                exit 0
+            fi
+            echo "ERROR: The system cannot find the file specified." >&2
+            exit 1
+        fi
+        found=0
+        for f in "$STATE/tasks"/*; do
+            [ -e "$f" ] || continue
+            found=1
+            printf '"\\%s","7/10/2026 1:00:00 PM","Ready"\n' "$(basename "$f")"
+        done
+        [ "$found" -eq 1 ] || exit 1
+        ;;
+    *) exit 1 ;;
+esac
+FAKE
+chmod +x "$FAKE_SCHTASKS"
+
+BAT_DIR="$TMP_ROOT/bats"
+
+run_gc() {
+    PIPELINE_UNUSED="" GRAPHMAP_SCHTASKS="$FAKE_SCHTASKS" GRAPHMAP_BAT_DIR="$BAT_DIR" \
+        PATH="$TMP_ROOT/bin:$PATH" bash "$SCRIPT" "$@"
+}
+
+# Test 1: usage errors ------------------------------------------------------
+
+echo "TEST: missing / unknown subcommand rejected"
+rc=0; out=$(run_gc 2>&1) || rc=$?
+assert_rc "no subcommand -> rc 1" 1 "$rc"
+rc=0; out=$(run_gc frobnicate 2>&1) || rc=$?
+assert_rc "unknown subcommand -> rc 1" 1 "$rc"
+
+# Test 2: input validation --------------------------------------------------
+
+echo "TEST: invalid inputs rejected"
+rc=0; out=$(run_gc arm --vault "$VAULT" --luna-time 9:00 2>&1) || rc=$?
+assert_rc "bad --luna-time (no leading zero) -> rc 1" 1 "$rc"
+rc=0; out=$(run_gc arm --vault "$VAULT" --himmel-time 25:00 2>&1) || rc=$?
+assert_rc "bad --himmel-time -> rc 1" 1 "$rc"
+rc=0; out=$(run_gc arm --vault "$TMP_ROOT/does-not-exist" 2>&1) || rc=$?
+assert_rc "missing vault dir -> rc 1" 1 "$rc"
+
+# Test 3: status on empty scheduler ----------------------------------------
+
+echo "TEST: status with nothing armed"
+out=$(run_gc status)
+assert_contains "luna not armed"   "not armed  HIMMEL-GraphMap-Luna"   "$out"
+assert_contains "himmel not armed" "not armed  HIMMEL-GraphMap-Himmel" "$out"
+
+# Test 4: arm --dry-run touches nothing -------------------------------------
+
+echo "TEST: arm --dry-run prints plan, registers nothing"
+out=$(run_gc arm --vault "$VAULT" --dry-run)
+assert_contains "dry-run luna create"   "/tn HIMMEL-GraphMap-Luna /xml" "$out"
+assert_contains "dry-run himmel create" "/tn HIMMEL-GraphMap-Himmel /xml" "$out"
+assert_contains "dry-run XML has StartWhenAvailable" "<StartWhenAvailable>true</StartWhenAvailable>" "$out"
+assert_contains "dry-run XML daily schedule" "<ScheduleByDay>" "$out"
+assert_contains "dry-run luna time" "T13:00:00" "$out"
+assert_contains "dry-run himmel time" "T13:20:00" "$out"
+assert_contains "dry-run fires refresh-graph-map.sh" "refresh-graph-map.sh" "$out"
+if [ -z "$(ls -A "$STATE/tasks" 2>/dev/null)" ]; then
+    pass "dry-run registered no tasks"
+else
+    fail "dry-run registered tasks" "$(ls "$STATE/tasks")"
+fi
+if [ ! -d "$BAT_DIR" ]; then
+    pass "dry-run wrote no .bat files"
+else
+    fail "dry-run wrote .bat files" "$(ls "$BAT_DIR")"
+fi
+
+# Test 5: arm registers both tasks with operator-decision defaults ----------
+
+echo "TEST: arm registers daily luna 13:00 + daily himmel 13:20"
+out=$(run_gc arm --vault "$VAULT")
+assert_contains "arm banner" "GRAPHMAP CADENCE ARMED" "$out"
+luna_args=$(cat "$STATE/tasks/HIMMEL-GraphMap-Luna" 2>/dev/null || echo MISSING)
+himmel_args=$(cat "$STATE/tasks/HIMMEL-GraphMap-Himmel" 2>/dev/null || echo MISSING)
+assert_contains "luna daily schedule (XML)"   "<ScheduleByDay>" "$luna_args"
+assert_contains "luna time (XML)"             "T13:00:00"       "$luna_args"
+assert_contains "himmel daily schedule (XML)" "<ScheduleByDay>" "$himmel_args"
+assert_contains "himmel time (XML)"           "T13:20:00"       "$himmel_args"
+assert_contains "luna XML StartWhenAvailable"   "<StartWhenAvailable>true</StartWhenAvailable>" "$luna_args"
+assert_contains "himmel XML StartWhenAvailable" "<StartWhenAvailable>true</StartWhenAvailable>" "$himmel_args"
+assert_contains "luna Exec points at runner bat"   "graphmap-luna.bat"   "$luna_args"
+assert_contains "himmel Exec points at runner bat" "graphmap-himmel.bat" "$himmel_args"
+
+# Test 6: .bat runners fire refresh-graph-map.sh (deterministic, no claude) ---
+
+echo "TEST: .bat runners fire bash refresh-graph-map.sh with the right payload"
+luna_bat=$(cat "$BAT_DIR/graphmap-luna.bat" 2>/dev/null || echo MISSING)
+himmel_bat=$(cat "$BAT_DIR/graphmap-himmel.bat" 2>/dev/null || echo MISSING)
+assert_contains "luna bat stamps the format version (HIMMEL-588)"   "rem himmel-cadence-runner-format: 1" "$luna_bat"
+assert_contains "himmel bat stamps the format version (HIMMEL-588)" "rem himmel-cadence-runner-format: 1" "$himmel_bat"
+assert_contains "luna bat cds into himmel root" 'cd /d "' "$luna_bat"
+assert_contains "luna bat fires refresh-graph-map.sh" "refresh-graph-map.sh" "$luna_bat"
+assert_contains "luna bat names the luna corpus"      "--name luna"          "$luna_bat"
+assert_contains "luna bat sets the luna slug"         "--slug graphify-luna-map" "$luna_bat"
+assert_contains "luna bat sets the luna corpus-tag"   "--corpus-tag luna"    "$luna_bat"
+assert_contains "luna bat uses the deepseek backend"  "--backend deepseek"   "$luna_bat"
+assert_contains "luna bat sets the luna title"        "Graphify Luna Map"    "$luna_bat"
+assert_contains "luna bat publishes into 60-Maps"     "60-Maps"              "$luna_bat"
+assert_contains "luna bat appends run log" 'graphmap-luna.log" 2>&1' "$luna_bat"
+assert_contains "luna bat rotates the log before firing" 'move /y' "$luna_bat"
+assert_contains "luna bat stamps every fire" 'echo [fired %DATE% %TIME%]' "$luna_bat"
+assert_contains "himmel bat names the himmel corpus"    "--name himmel"        "$himmel_bat"
+assert_contains "himmel bat sets the himmel slug"       "--slug graphify-himmel-map" "$himmel_bat"
+assert_contains "himmel bat sets the himmel corpus-tag" "--corpus-tag himmel"  "$himmel_bat"
+assert_contains "himmel bat uses the deepseek backend"  "--backend deepseek"   "$himmel_bat"
+# Strong per-corpus-root asserts on the Windows path too (bat_payload is a
+# SEPARATE builder from the cron cron_payload, so the cron suite's exact asserts
+# don't guard a Windows-only swap). VAULT is already mixed-form here, so it
+# matches the cygpath -m'd corpus-root the .bat carries. The luna bat's
+# corpus-root IS the vault; the himmel bat's corpus-root is NOT (it's the himmel
+# repo) — so a swap that makes the himmel map extract the vault fails here.
+assert_contains     "luna bat corpus-root is the vault"       "--corpus-root \"$VAULT\"" "$luna_bat"
+assert_not_contains "himmel bat corpus-root is not the vault" "--corpus-root \"$VAULT\"" "$himmel_bat"
+assert_contains     "himmel bat carries a corpus-root"        "--corpus-root"            "$himmel_bat"
+assert_contains "himmel bat sets the himmel title"      "Graphify Himmel Map"  "$himmel_bat"
+assert_contains "himmel bat appends run log" 'graphmap-himmel.log" 2>&1' "$himmel_bat"
+for what in luna himmel; do
+    body=$(eval "printf '%s' \"\$${what}_bat\"")
+    assert_not_contains "$what bat has no --settings (not a claude session)" "--settings" "$body"
+    assert_not_contains "$what bat has no bounded-claude stdin marker" "< NUL" "$body"
+done
+
+# Test 7: status after arm ---------------------------------------------------
+
+echo "TEST: status reflects armed tasks"
+out=$(run_gc status)
+assert_contains "luna armed"   "ARMED      HIMMEL-GraphMap-Luna"   "$out"
+assert_contains "himmel armed" "ARMED      HIMMEL-GraphMap-Himmel" "$out"
+assert_contains "status surfaces run log state" "run log" "$out"
+
+# Test 8: re-arm without --force -> dedup block ------------------------------
+
+echo "TEST: re-arm without --force blocked (rc 3)"
+rc=0; out=$(run_gc arm --vault "$VAULT" 2>&1) || rc=$?
+assert_rc "dedup block rc 3" 3 "$rc"
+assert_contains "dedup message names existing tasks" "HIMMEL-GraphMap-Himmel" "$out"
+if [ "$(find "$STATE/tasks" -mindepth 1 | wc -l)" -eq 2 ]; then
+    pass "no duplicate tasks after blocked re-arm"
+else
+    fail "task count changed on blocked re-arm" "$(ls "$STATE/tasks")"
+fi
+
+# Test 9: re-arm --force with overrides --------------------------------------
+
+echo "TEST: re-arm --force applies flag overrides"
+out=$(run_gc arm --vault "$VAULT" --force --luna-time 01:15 --himmel-time 05:00 2>&1)
+luna_args=$(cat "$STATE/tasks/HIMMEL-GraphMap-Luna" 2>/dev/null || echo MISSING)
+himmel_args=$(cat "$STATE/tasks/HIMMEL-GraphMap-Himmel" 2>/dev/null || echo MISSING)
+assert_contains "luna override (XML time)"   "T01:15:00" "$luna_args"
+assert_contains "himmel override (XML time)" "T05:00:00" "$himmel_args"
+if [ "$(find "$STATE/tasks" -mindepth 1 | wc -l)" -eq 2 ]; then
+    pass "still exactly two tasks after --force re-arm"
+else
+    fail "duplicate tasks after --force re-arm" "$(ls "$STATE/tasks")"
+fi
+
+# Test 10: disarm + idempotent second disarm ---------------------------------
+
+echo "TEST: disarm removes tasks + runners; second disarm is a no-op"
+out=$(run_gc disarm)
+assert_contains "disarm reports" "cadence disarmed" "$out"
+if [ -z "$(ls -A "$STATE/tasks" 2>/dev/null)" ]; then
+    pass "all tasks removed"
+else
+    fail "tasks left after disarm" "$(ls "$STATE/tasks")"
+fi
+if [ ! -f "$BAT_DIR/graphmap-luna.bat" ] && [ ! -f "$BAT_DIR/graphmap-himmel.bat" ]; then
+    pass ".bat runners removed"
+else
+    fail ".bat runners left after disarm"
+fi
+rc=0; out=$(run_gc disarm) || rc=$?
+assert_rc "second disarm rc 0" 0 "$rc"
+assert_contains "second disarm is a no-op" "no-op" "$out"
+
+# Test 11: cmd_escape — hostile-but-legal vault dirname can't inject ----------
+
+echo "TEST: vault path with CMD metachars is escaped in the .bat"
+EVIL_VAULT="$TMP_ROOT/va&ult %X%^Y"
+mkdir -p "$EVIL_VAULT"
+out=$(run_gc arm --vault "$EVIL_VAULT")
+luna_bat=$(cat "$BAT_DIR/graphmap-luna.bat" 2>/dev/null || echo MISSING)
+assert_contains "percent doubled (%% in bat)" '%%X%%' "$luna_bat"
+assert_contains "ampersand careted (^& in bat)" '^&' "$luna_bat"
+assert_contains "caret doubled (^^ in bat)" '^^' "$luna_bat"
+run_gc disarm >/dev/null
+
+# Test 12: half-arm rollback when the SECOND /create fails --------------------
+
+echo "TEST: himmel /create failure rolls back the luna task (rc 4)"
+touch "$STATE/fail-create-HIMMEL-GraphMap-Himmel"
+rc=0; out=$(run_gc arm --vault "$VAULT" 2>&1) || rc=$?
+assert_rc "half-arm fails rc 4" 4 "$rc"
+assert_contains "failure names the himmel create" "HIMMEL-GraphMap-Himmel failed" "$out"
+if [ -z "$(ls -A "$STATE/tasks" 2>/dev/null)" ]; then
+    pass "no task state left after rollback"
+else
+    fail "task state left after rollback" "$(ls "$STATE/tasks")"
+fi
+rm -f "$STATE/fail-create-HIMMEL-GraphMap-Himmel"
+
+# Test 13: dedup listing failure is fail-CLOSED ------------------------------
+
+echo "TEST: arm with failing /query listing exits 2 (fail-closed dedup)"
+touch "$STATE/fail-query"
+rc=0; out=$(run_gc arm --vault "$VAULT" 2>&1) || rc=$?
+assert_rc "fail-closed dedup rc 2" 2 "$rc"
+assert_contains "dedup failure surfaces stderr" "Access is denied" "$out"
+if [ -z "$(ls -A "$STATE/tasks" 2>/dev/null)" ]; then
+    pass "nothing registered when dedup listing failed"
+else
+    fail "tasks registered despite failed dedup listing" "$(ls "$STATE/tasks")"
+fi
+rm -f "$STATE/fail-query"
+
+# Test 14: disarm under query failure must not no-op or delete runners --------
+
+echo "TEST: disarm with failing /query exits nonzero, keeps the .bats"
+out=$(run_gc arm --vault "$VAULT")
+touch "$STATE/fail-query"
+rc=0; out=$(run_gc disarm 2>&1) || rc=$?
+assert_rc "disarm query failure rc 2" 2 "$rc"
+assert_not_contains "no false no-op on query failure" "no-op" "$out"
+assert_contains "query failure prints manual delete escape hatch" "schtasks /delete /tn" "$out"
+if [ -f "$BAT_DIR/graphmap-luna.bat" ] && [ -f "$BAT_DIR/graphmap-himmel.bat" ]; then
+    pass ".bat runners NOT deleted on query failure"
+else
+    fail ".bat runners deleted despite query failure"
+fi
+rm -f "$STATE/fail-query"
+run_gc disarm >/dev/null
+
+# Test 15: status propagates query errors as rc=2 ----------------------------
+
+echo "TEST: status with failing /query exits 2"
+out=$(run_gc arm --vault "$VAULT")
+touch "$STATE/fail-query"
+rc=0; out=$(run_gc status 2>&1) || rc=$?
+assert_rc "status query failure rc 2" 2 "$rc"
+assert_contains "status prints QUERY ERR" "QUERY ERR" "$out"
+rm -f "$STATE/fail-query"
+run_gc disarm >/dev/null
+
+summary


### PR DESCRIPTION
## What & why

Follow-up to HIMMEL-825/826 (both In Public via #1047). #1047 shipped the schedulable RUNNER (`scripts/graphify/refresh-graph-map.sh`) but not the scheduler/arm layer; `docs/tooling-catalog.md` flagged the cadence as the open follow-up. Operator picked **Option B**: a SEPARATE OS-scheduler, not a `pipeline-cadence` leg — pipeline-cadence's invariant is "every task = a claude session", and a graph refresh is a DETERMINISTIC script (no claude, no `--settings`, no NUL stdin, no billing concern). Keeping them separate keeps that invariant clean.

## Changes

- **`scripts/luna/graphmap-cadence.sh`** (new) — `arm`/`status`/`disarm` sibling of `pipeline-cadence.sh`. Two daily tasks (prefix `HIMMEL-GraphMap-`): **Luna** (default 13:00 local) + **Himmel** (13:20, staggered 20min so the two DeepSeek extraction jobs don't run at once). Each runner fires `bash <himmel>/scripts/graphify/refresh-graph-map.sh --name <corpus> …` directly. schtasks (Windows, StartWhenAvailable XML so a slept-through 13:00 still fires) / crontab (POSIX, marker-tagged). Mirrors pipeline-cadence's dedup guard (rc=3; `--force` replaces), fail-closed reads, dry-run, cadence-format version stamp, exit contract (0/1/2/3/4), and test seams (`GRAPHMAP_SCHTASKS`/`GRAPHMAP_CRONTAB`/`GRAPHMAP_BAT_DIR`). Off-peak rationale documented in-header (13:00–13:20 local ≈ off-peak-UTC across common EU/US zones; DeepSeek peak = UTC 1-4 + 6-10 = 2x; refresh-graph-map.sh also emits its own UTC-peak advisory at fire time as a backstop).
- **`scripts/luna/test-graphmap-cadence.sh`** (new) — hermetic (stubs scheduler via env seams, HOME redirected). **178 assertions**; exercises BOTH the POSIX/cron and Windows/schtasks paths (correct per-corpus payloads incl. strong `--corpus-root` guards, StartWhenAvailable, dedup rc=3, `--force`, dry-run, idempotent disarm, fail-closed reads, rollback, and a guard that the runners are NOT claude-shaped). ALL PASS; shellcheck clean.
- **`docs/tooling-catalog.md`** — document graphmap-cadence.sh; retire the now-stale "consolidation into pipeline-cadence is the open follow-up" line.

## Wiring decision (documented, non-blocking)

`refresh-graph-map.sh` writes derived `graphify-out` to `$CORPUS_ROOT/graphify-out` (no override). The himmel cadence therefore lands its derived `graph.json` in `himmel/graphify-out` (gitignored, regenerable) while the **tracked** curated MOC single-homes in `luna/60-Maps` via `--maps-dir`. If the operator needs himmel's derived `graph.json` itself consolidated under `luna/graphify-out/himmel` (s21 ecosystem-global substrate), that needs a small `--out-dir` seam in refresh-graph-map.sh — noted on HIMMEL-829, not built by default.

## NOT auto-armed — operator flip

Arming the cadence = daily DeepSeek spend, so it is an operator decision, not auto-armed by this PR. To arm:
```
bash scripts/luna/graphmap-cadence.sh arm            # defaults: Luna 13:00, Himmel 13:20 local
bash scripts/luna/graphmap-cadence.sh status
bash scripts/luna/graphmap-cadence.sh disarm
```
Flags: `--luna-time HH:MM`, `--himmel-time HH:MM`, `--vault PATH`, `--force`, `--dry-run`.

## Code review

Critic panel (codex) + codex adversarial pass + 4 pr-review-toolkit reviewers (code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer). **Final: 0 Critical / 0 Important.**

Both codex blocking candidates adjudicated **DISPROVED** (2 reviewers each): **[codex-1]** (Critical, "UTF-16 declared but ASCII bytes → schtasks rejects") — byte-identical to the shipped-and-working pipeline-cadence.sh, and codex's proposed `encoding="UTF-8"` is actively REJECTED on Win11 (verified in the sibling's comment); **[codex-2]** (Important, "POSIX runner exits 0 masking failure") — a parity pattern with the shipped sibling; the rc IS surfaced via the log's `[exit rc=N]` line + `status`, and cron doesn't act on the exit code. Fixing either in graphmap alone would diverge the siblings.

Reviewer-surfaced Importants fixed in the CR-round-1 commit: strong per-corpus `--corpus-root` test guards on both platforms (a payload arg-swap making the himmel map extract the vault now fails — verified by swap-testing each platform); documented the intentional asymmetric wiring at the payload site; fixed a comment. Minor deferred test nits (schtasks disarm-dry-run branch, status next-run parsing, force+dry-combined) noted, not blocking.

Attestation trailers (`Platforms tested: windows`, `Security reviewed: manual`) are in the first commit of the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
