### PR TITLE
fix(lanes): [HIMMEL-828] harden lane seed/reseed path — TOCTOU race + full staleness/deletion mirroring

### DIFF
--- a/scripts/claude-glm
+++ b/scripts/claude-glm
@@ -136,14 +136,24 @@ seed_config_dir() {
     # steering the lane — same rationale as the subtree re-mirror below.
     rm -f "$CONFIG_DIR/settings.json" || seed_fail "remove stale settings.json"
   fi
+  # Leaf files mirror deletion too (HIMMEL-828/819): CLAUDE.md literally steers the lane,
+  # so a deleted source must not leave a stale copy behind — same rationale as settings.
   for f in CLAUDE.md RTK.md; do
-    [ -f "$SRC/$f" ] && { cp "$SRC/$f" "$CONFIG_DIR/$f" || seed_fail "copy $f"; }
+    if [ -f "$SRC/$f" ]; then
+      cp "$SRC/$f" "$CONFIG_DIR/$f" || seed_fail "copy $f"
+    else
+      rm -f "$CONFIG_DIR/$f" || seed_fail "remove stale $f"
+    fi
   done
-  # Clean re-mirror: rm the destination subtree BEFORE copying so a --reseed
-  # drops files deleted from the source and BSD cp -R does not nest a second
-  # copy inside the existing dir (commands/commands). No-op on the first seed.
+  # Clean re-mirror + deletion mirror (HIMMEL-828/819): rm the destination subtree FIRST
+  # — drops files deleted from the source, avoids BSD cp -R nesting (commands/commands),
+  # AND mirrors a whole-subtree deletion so a removed command/hook does not linger
+  # steering the cloud lane ("a deleted source must not leave a stale copy steering the
+  # lane") — then copy only when the source still exists. No-op on the first seed; rm -rf
+  # on an absent dest is a safe no-op. Symmetric with the settings/manifest mirror.
   for d in commands skills hooks agents; do
-    [ -d "$SRC/$d" ] && { rm -rf "${CONFIG_DIR:?}/$d" || seed_fail "clear $d before reseed"; cp -R "$SRC/$d" "$CONFIG_DIR/" || seed_fail "copy $d"; }
+    rm -rf "${CONFIG_DIR:?}/$d" || seed_fail "clear stale $d"
+    [ -d "$SRC/$d" ] && { cp -R "$SRC/$d" "$CONFIG_DIR/" || seed_fail "copy $d"; }
   done
   for p in installed_plugins.json known_marketplaces.json; do
     if [ -f "$SRC/plugins/$p" ]; then
@@ -152,13 +162,16 @@ seed_config_dir() {
       rm -f "$CONFIG_DIR/plugins/$p" || seed_fail "remove stale plugins/$p"
     fi
   done
-  [ -d "$SRC/plugins/marketplaces" ] && { rm -rf "${CONFIG_DIR:?}/plugins/marketplaces" || seed_fail "clear plugins/marketplaces before reseed"; cp -R "$SRC/plugins/marketplaces" "$CONFIG_DIR/plugins/" || seed_fail "copy plugins/marketplaces"; }
+  rm -rf "${CONFIG_DIR:?}/plugins/marketplaces" || seed_fail "clear stale plugins/marketplaces"
+  [ -d "$SRC/plugins/marketplaces" ] && { cp -R "$SRC/plugins/marketplaces" "$CONFIG_DIR/plugins/" || seed_fail "copy plugins/marketplaces"; }
   # claude-hud DISPLAY config — seed the single config.json only; the three cache
   # dirs under plugins/claude-hud/ (config-cache/context-cache/transcript-cache) are
-  # runtime state, never seeded. Source-absent → skip (mirrors the [ -f ] guards above).
+  # runtime state, never seeded. Source-absent → mirror the deletion (HIMMEL-828/819).
   if [ -f "$SRC/plugins/claude-hud/config.json" ]; then
     mkdir -p "$CONFIG_DIR/plugins/claude-hud" || seed_fail "create $CONFIG_DIR/plugins/claude-hud"
     cp "$SRC/plugins/claude-hud/config.json" "$CONFIG_DIR/plugins/claude-hud/config.json" || seed_fail "copy plugins/claude-hud/config.json"
+  else
+    rm -f "$CONFIG_DIR/plugins/claude-hud/config.json" || seed_fail "remove stale plugins/claude-hud/config.json"
   fi
   : > "$CONFIG_DIR/.seeded" || seed_fail "write the .seeded sentinel"
 }
@@ -166,18 +179,34 @@ seed_config_dir() {
 # Staleness-aware reseed (HIMMEL-819): a once-only seed strands lane workers on
 # whatever plugin/settings profile existed at first launch — the operator's lean
 # enabledPlugins profile never reaches the lane, so every worker pays duplicated
-# plugin context + duplicate MCP invocations. Track the three config sources that
-# change out-of-band (newer than the sentinel, OR deleted while a lane copy
-# remains); commands/skills/hooks/agents drift still needs --reseed.
+# plugin context + duplicate MCP invocations. Track every allowlisted leaf source
+# (settings, CLAUDE.md, RTK.md, the two plugin manifests, claude-hud config — newer
+# than the sentinel OR deleted while a lane copy remains) AND the copied subtrees
+# (HIMMEL-828 Part B — a half-seeded/externally-removed subtree, a top-level
+# command/skill add/remove, or a deleted source, self-heals on plain launch); a deep
+# in-file subtree edit still needs --reseed (directory mtime granularity).
 # Opt-out: CLAUDE_LANE_AUTO_RESEED=0 restores the once-only seed (first seed +
 # explicit --reseed only) — the escape hatch if auto-reseed ever blocks a
 # launch in your setup (e.g. seed re-runs surfacing a broken node).
 config_seed_stale() { # rc=0 when any tracked source is newer than the sentinel, or gone but still mirrored
   [ "${CLAUDE_LANE_AUTO_RESEED:-1}" = "0" ] && return 1
-  for s in settings.json plugins/installed_plugins.json plugins/known_marketplaces.json; do
+  for s in settings.json CLAUDE.md RTK.md plugins/installed_plugins.json plugins/known_marketplaces.json plugins/claude-hud/config.json; do
     if [ -f "${HOME}/.claude/$s" ]; then
       if [ "${HOME}/.claude/$s" -nt "$CONFIG_DIR/.seeded" ]; then return 0; fi
     elif [ -f "$CONFIG_DIR/$s" ]; then
+      return 0  # source deleted but lane copy remains — reseed mirrors the removal
+    fi
+  done
+  # HIMMEL-828 Part B — also track the copied subtrees, fully symmetric with the
+  # settings/manifest loop above. Per subtree: SOURCE present but DEST missing = a
+  # half-seed → reseed; SOURCE newer than the sentinel = top-level drift → reseed;
+  # SOURCE absent but DEST present = a deleted source whose lane copy lingers → reseed
+  # (the seeder mirrors the deletion, so this fires once then clears — no churn).
+  for d in commands skills hooks agents plugins/marketplaces; do
+    if [ -d "${HOME}/.claude/$d" ]; then
+      [ -d "$CONFIG_DIR/$d" ] || return 0
+      if [ "${HOME}/.claude/$d" -nt "$CONFIG_DIR/.seeded" ]; then return 0; fi
+    elif [ -d "$CONFIG_DIR/$d" ]; then
       return 0  # source deleted but lane copy remains — reseed mirrors the removal
     fi
   done

--- a/scripts/claude-glm.ps1
+++ b/scripts/claude-glm.ps1
@@ -163,18 +163,22 @@ function Copy-SeedConfig {
   # must NOT be swallowed (HIMMEL-820 CR: codex-adv [high] + silent-failure-hunter
   # convergence). A blanket -ErrorAction SilentlyContinue hid a locked/ACL-denied
   # .seeded: the reseed then threw later and exited 4, but the OLD sentinel survived
-  # next to a half-seeded tree, and a plain relaunch (whose staleness check tracks
-  # only settings + plugin manifests, not the copied subtrees) read it as "seeded"
-  # and launched on the corrupt tree. Guard the missing-file case (Test-Path — first
-  # seed has no sentinel) and exit 4 on a genuine removal failure, BEFORE any copy.
+  # next to a half-seeded tree, and a plain relaunch read it as "seeded" and launched
+  # on the corrupt tree.
+  # HIMMEL-828 Part A — race-free, mirroring bash `rm -f`: do NOT Test-Path-then-Remove
+  # (a concurrent reseed sharing this config dir can delete the sentinel in that window,
+  # so Remove-Item throws ItemNotFound even though sentinel-ABSENT is the desired end
+  # state → a spurious exit 4). Attempt the removal unconditionally and treat a
+  # missing-file (ItemNotFoundException) as success (goal reached); only a genuine
+  # lock/ACL failure (the file is still there) exits 4.
   $sentinel = Join-Path $ConfigDir '.seeded'
-  if (Test-Path -LiteralPath $sentinel) {
-    try {
-      Remove-Item -LiteralPath $sentinel -Force -ErrorAction Stop
-    } catch {
-      [Console]::Error.WriteLine("claude-glm: FAILED to clear stale .seeded sentinel ($($_.Exception.Message)). Refusing to reseed while a stale sentinel remains. Fix the cause and re-run (or rm -rf ~/.claude-glm).")
-      exit 4
-    }
+  try {
+    Remove-Item -LiteralPath $sentinel -Force -ErrorAction Stop
+  } catch [System.Management.Automation.ItemNotFoundException] {
+    # already absent (first seed, or a concurrent reseed beat us to it) — goal reached.
+  } catch {
+    [Console]::Error.WriteLine("claude-glm: FAILED to clear stale .seeded sentinel ($($_.Exception.Message)). Refusing to reseed while a stale sentinel remains. Fix the cause and re-run (or rm -rf ~/.claude-glm).")
+    exit 4
   }
   New-Item -ItemType Directory -Force -Path (Join-Path $ConfigDir 'plugins') | Out-Null
   $settings = Join-Path $src 'settings.json'
@@ -212,22 +216,26 @@ function Copy-SeedConfig {
       $dst = Join-Path $ConfigDir 'settings.json'
       if (Test-Path -LiteralPath $dst) { Remove-Item -LiteralPath $dst -Force }
     }
+    # Leaf files mirror deletion too (HIMMEL-828/819): CLAUDE.md literally steers the
+    # lane, so a deleted source must not leave a stale copy behind — same as settings.
     foreach ($f in 'CLAUDE.md', 'RTK.md') {
       $p = Join-Path $src $f
-      if (Test-Path -LiteralPath $p) { Copy-Item -LiteralPath $p -Destination (Join-Path $ConfigDir $f) -Force }
+      $dp = Join-Path $ConfigDir $f
+      if (Test-Path -LiteralPath $p) { Copy-Item -LiteralPath $p -Destination $dp -Force }
+      elseif (Test-Path -LiteralPath $dp) { Remove-Item -LiteralPath $dp -Force }
     }
-    # Clean re-mirror: remove the destination subtree BEFORE copying so a -Reseed
-    # drops files deleted from the source instead of leaving them stale. No-op on
-    # the first seed. (Parity with the bash twin's rm -rf-then-copy.) A REAL removal
-    # failure (locked file, ACL denial) terminates under Stop and is caught below —
-    # same "no sentinel on any failure" contract.
+    # Clean re-mirror + deletion mirror (HIMMEL-828/819): remove the destination subtree
+    # FIRST — this both drops files deleted from the source AND mirrors a whole-subtree
+    # deletion (a removed command/hook/skill must not linger steering the cloud lane:
+    # "a deleted source must not leave a stale copy steering the lane") — then copy only
+    # when the source still exists. No-op on the first seed. A REAL removal failure
+    # (locked file, ACL denial) terminates under Stop and is caught below — same "no
+    # sentinel on any failure" contract. Symmetric with the settings/manifest mirror.
     foreach ($d in 'commands', 'skills', 'hooks', 'agents') {
+      $dst = Join-Path $ConfigDir $d
+      if (Test-Path -LiteralPath $dst) { Remove-Item -LiteralPath $dst -Recurse -Force }
       $p = Join-Path $src $d
-      if (Test-Path -LiteralPath $p -PathType Container) {
-        $dst = Join-Path $ConfigDir $d
-        if (Test-Path -LiteralPath $dst) { Remove-Item -LiteralPath $dst -Recurse -Force }
-        Copy-Item -LiteralPath $p -Destination $ConfigDir -Recurse -Force
-      }
+      if (Test-Path -LiteralPath $p -PathType Container) { Copy-Item -LiteralPath $p -Destination $ConfigDir -Recurse -Force }
     }
     foreach ($p in 'installed_plugins.json', 'known_marketplaces.json') {
       $sp = Join-Path $src (Join-Path 'plugins' $p)
@@ -235,18 +243,20 @@ function Copy-SeedConfig {
       if (Test-Path -LiteralPath $sp) { Copy-Item -LiteralPath $sp -Destination $dp -Force }
       elseif (Test-Path -LiteralPath $dp) { Remove-Item -LiteralPath $dp -Force }
     }
+    $mdst = Join-Path $ConfigDir (Join-Path 'plugins' 'marketplaces')
+    if (Test-Path -LiteralPath $mdst) { Remove-Item -LiteralPath $mdst -Recurse -Force }
     $mp = Join-Path $src (Join-Path 'plugins' 'marketplaces')
-    if (Test-Path -LiteralPath $mp -PathType Container) {
-      $mdst = Join-Path $ConfigDir (Join-Path 'plugins' 'marketplaces')
-      if (Test-Path -LiteralPath $mdst) { Remove-Item -LiteralPath $mdst -Recurse -Force }
-      Copy-Item -LiteralPath $mp -Destination (Join-Path $ConfigDir 'plugins') -Recurse -Force
-    }
+    if (Test-Path -LiteralPath $mp -PathType Container) { Copy-Item -LiteralPath $mp -Destination (Join-Path $ConfigDir 'plugins') -Recurse -Force }
     # claude-hud DISPLAY config — seed the single config.json only; the cache dirs
-    # under plugins/claude-hud/ are runtime state, never seeded. Source-absent → skip.
+    # under plugins/claude-hud/ are runtime state, never seeded. Source-absent → mirror
+    # the deletion (HIMMEL-828/819).
     $hudCfg = Join-Path $src (Join-Path 'plugins' (Join-Path 'claude-hud' 'config.json'))
+    $hudDst = Join-Path $ConfigDir (Join-Path 'plugins' (Join-Path 'claude-hud' 'config.json'))
     if (Test-Path -LiteralPath $hudCfg) {
       New-Item -ItemType Directory -Force -Path (Join-Path $ConfigDir (Join-Path 'plugins' 'claude-hud')) | Out-Null
-      Copy-Item -LiteralPath $hudCfg -Destination (Join-Path $ConfigDir (Join-Path 'plugins' (Join-Path 'claude-hud' 'config.json'))) -Force
+      Copy-Item -LiteralPath $hudCfg -Destination $hudDst -Force
+    } elseif (Test-Path -LiteralPath $hudDst) {
+      Remove-Item -LiteralPath $hudDst -Force
     }
     # sentinel LAST: only a fully-populated seed reads as "seeded"
     New-Item -ItemType File -Force -Path (Join-Path $ConfigDir '.seeded') | Out-Null
@@ -259,9 +269,12 @@ function Copy-SeedConfig {
 # Staleness-aware reseed (HIMMEL-819): a once-only seed strands lane workers on
 # whatever plugin/settings profile existed at first launch — the operator's lean
 # enabledPlugins profile never reaches the lane, so every worker pays duplicated
-# plugin context + duplicate MCP invocations. Track the three config sources that
-# change out-of-band (newer than the sentinel, OR deleted while a lane copy
-# remains); commands/skills/hooks/agents drift still needs -Reseed.
+# plugin context + duplicate MCP invocations. Track every allowlisted leaf source
+# (settings, CLAUDE.md, RTK.md, the two plugin manifests, claude-hud config — newer
+# than the sentinel OR deleted while a lane copy remains) AND the copied subtrees
+# (HIMMEL-828 Part B — a half-seeded/externally-removed subtree, a command/skill
+# added/removed at the top level, or a deleted source, self-heals on plain launch); a
+# deep in-file edit inside a subtree still needs -Reseed (directory mtime granularity).
 # Opt-out: CLAUDE_LANE_AUTO_RESEED=0 restores the once-only seed (first seed +
 # explicit -Reseed only) — the escape hatch if auto-reseed ever blocks a
 # launch in your setup (e.g. seed re-runs surfacing a broken node).
@@ -276,12 +289,28 @@ function Test-ConfigSeedStale {
     if (-not (Test-Path -LiteralPath $sentinel)) { return $false }
     $sentinelTime = (Get-Item -LiteralPath $sentinel).LastWriteTimeUtc
     $src = Join-Path $HomeDir '.claude'
-    foreach ($rel in @('settings.json', (Join-Path 'plugins' 'installed_plugins.json'), (Join-Path 'plugins' 'known_marketplaces.json'))) {
+    foreach ($rel in @('settings.json', 'CLAUDE.md', 'RTK.md', (Join-Path 'plugins' 'installed_plugins.json'), (Join-Path 'plugins' 'known_marketplaces.json'), (Join-Path 'plugins' (Join-Path 'claude-hud' 'config.json')))) {
       $s = Join-Path $src $rel
       $d = Join-Path $ConfigDir $rel
       if (Test-Path -LiteralPath $s) {
         if ((Get-Item -LiteralPath $s).LastWriteTimeUtc -gt $sentinelTime) { return $true }
       } elseif (Test-Path -LiteralPath $d) {
+        return $true  # source deleted but lane copy remains — reseed mirrors the removal
+      }
+    }
+    # HIMMEL-828 Part B — also track the copied subtrees, fully symmetric with the
+    # settings/manifest loop above, so a half-seeded OR a source-deleted subtree
+    # self-heals on a plain launch. Per subtree: SOURCE present but DEST missing = a
+    # half-seed → reseed; SOURCE newer than the sentinel = top-level drift → reseed;
+    # SOURCE absent but DEST present = a deleted source whose lane copy lingers → reseed
+    # (the seeder mirrors the deletion, so this fires once then clears — no churn).
+    foreach ($rel in @('commands', 'skills', 'hooks', 'agents', (Join-Path 'plugins' 'marketplaces'))) {
+      $s = Join-Path $src $rel
+      $d = Join-Path $ConfigDir $rel
+      if (Test-Path -LiteralPath $s -PathType Container) {
+        if (-not (Test-Path -LiteralPath $d -PathType Container)) { return $true }
+        if ((Get-Item -LiteralPath $s).LastWriteTimeUtc -gt $sentinelTime) { return $true }
+      } elseif (Test-Path -LiteralPath $d -PathType Container) {
         return $true  # source deleted but lane copy remains — reseed mirrors the removal
       }
     }

--- a/scripts/claude-routed
+++ b/scripts/claude-routed
@@ -151,10 +151,24 @@ seed_config_dir() {
     # steering the lane — same rationale as the subtree re-mirror below.
     rm -f "$CONFIG_DIR/settings.json" || seed_fail "remove stale settings.json"
   fi
+  # Leaf files mirror deletion too (HIMMEL-828/819): CLAUDE.md literally steers the lane,
+  # so a deleted source must not leave a stale copy behind — same rationale as settings.
   for f in CLAUDE.md RTK.md; do
-    [ -f "$SRC/$f" ] && { cp "$SRC/$f" "$CONFIG_DIR/$f" || seed_fail "copy $f"; }
+    if [ -f "$SRC/$f" ]; then
+      cp "$SRC/$f" "$CONFIG_DIR/$f" || seed_fail "copy $f"
+    else
+      rm -f "$CONFIG_DIR/$f" || seed_fail "remove stale $f"
+    fi
   done
+  # Clean re-mirror + deletion mirror (HIMMEL-828/819, parity with the claude-glm twin):
+  # rm the destination subtree FIRST — drops files deleted from the source, avoids BSD
+  # cp -R nesting (commands/commands), AND mirrors a whole-subtree deletion so a removed
+  # command/hook does not linger steering the routed lane ("a deleted source must not
+  # leave a stale copy steering the lane") — then copy only when the source still exists.
+  # No-op on the first seed; rm -rf on an absent dest is a safe no-op. Symmetric with the
+  # settings/manifest mirror.
   for d in commands skills hooks agents; do
+    rm -rf "${CONFIG_DIR:?}/$d" || seed_fail "clear stale $d"
     [ -d "$SRC/$d" ] && { cp -R "$SRC/$d" "$CONFIG_DIR/" || seed_fail "copy $d"; }
   done
   for p in installed_plugins.json known_marketplaces.json; do
@@ -164,13 +178,16 @@ seed_config_dir() {
       rm -f "$CONFIG_DIR/plugins/$p" || seed_fail "remove stale plugins/$p"
     fi
   done
+  rm -rf "${CONFIG_DIR:?}/plugins/marketplaces" || seed_fail "clear stale plugins/marketplaces"
   [ -d "$SRC/plugins/marketplaces" ] && { cp -R "$SRC/plugins/marketplaces" "$CONFIG_DIR/plugins/" || seed_fail "copy plugins/marketplaces"; }
   # claude-hud DISPLAY config — seed the single config.json only; the three cache
   # dirs under plugins/claude-hud/ (config-cache/context-cache/transcript-cache) are
-  # runtime state, never seeded. Source-absent → skip (mirrors the [ -f ] guards above).
+  # runtime state, never seeded. Source-absent → mirror the deletion (HIMMEL-828/819).
   if [ -f "$SRC/plugins/claude-hud/config.json" ]; then
     mkdir -p "$CONFIG_DIR/plugins/claude-hud" || seed_fail "create $CONFIG_DIR/plugins/claude-hud"
     cp "$SRC/plugins/claude-hud/config.json" "$CONFIG_DIR/plugins/claude-hud/config.json" || seed_fail "copy plugins/claude-hud/config.json"
+  else
+    rm -f "$CONFIG_DIR/plugins/claude-hud/config.json" || seed_fail "remove stale plugins/claude-hud/config.json"
   fi
   : > "$CONFIG_DIR/.seeded" || seed_fail "write the .seeded sentinel"
 }
@@ -178,18 +195,34 @@ seed_config_dir() {
 # Staleness-aware reseed (HIMMEL-819): a once-only seed strands lane workers on
 # whatever plugin/settings profile existed at first launch — the operator's lean
 # enabledPlugins profile never reaches the lane, so every worker pays duplicated
-# plugin context + duplicate MCP invocations. Track the three config sources that
-# change out-of-band (newer than the sentinel, OR deleted while a lane copy
-# remains); commands/skills/hooks/agents drift still needs --reseed.
+# plugin context + duplicate MCP invocations. Track every allowlisted leaf source
+# (settings, CLAUDE.md, RTK.md, the two plugin manifests, claude-hud config — newer
+# than the sentinel OR deleted while a lane copy remains) AND the copied subtrees
+# (HIMMEL-828 Part B — a half-seeded/externally-removed subtree, a top-level
+# command/skill add/remove, or a deleted source, self-heals on plain launch); a deep
+# in-file subtree edit still needs --reseed (directory mtime granularity).
 # Opt-out: CLAUDE_LANE_AUTO_RESEED=0 restores the once-only seed (first seed +
 # explicit --reseed only) — the escape hatch if auto-reseed ever blocks a
 # launch in your setup (e.g. seed re-runs surfacing a broken node).
 config_seed_stale() { # rc=0 when any tracked source is newer than the sentinel, or gone but still mirrored
   [ "${CLAUDE_LANE_AUTO_RESEED:-1}" = "0" ] && return 1
-  for s in settings.json plugins/installed_plugins.json plugins/known_marketplaces.json; do
+  for s in settings.json CLAUDE.md RTK.md plugins/installed_plugins.json plugins/known_marketplaces.json plugins/claude-hud/config.json; do
     if [ -f "${HOME}/.claude/$s" ]; then
       if [ "${HOME}/.claude/$s" -nt "$CONFIG_DIR/.seeded" ]; then return 0; fi
     elif [ -f "$CONFIG_DIR/$s" ]; then
+      return 0  # source deleted but lane copy remains — reseed mirrors the removal
+    fi
+  done
+  # HIMMEL-828 Part B — also track the copied subtrees, fully symmetric with the
+  # settings/manifest loop above. Per subtree: SOURCE present but DEST missing = a
+  # half-seed → reseed; SOURCE newer than the sentinel = top-level drift → reseed;
+  # SOURCE absent but DEST present = a deleted source whose lane copy lingers → reseed
+  # (the seeder mirrors the deletion, so this fires once then clears — no churn).
+  for d in commands skills hooks agents plugins/marketplaces; do
+    if [ -d "${HOME}/.claude/$d" ]; then
+      [ -d "$CONFIG_DIR/$d" ] || return 0
+      if [ "${HOME}/.claude/$d" -nt "$CONFIG_DIR/.seeded" ]; then return 0; fi
+    elif [ -d "$CONFIG_DIR/$d" ]; then
       return 0  # source deleted but lane copy remains — reseed mirrors the removal
     fi
   done

--- a/scripts/claude-routed.ps1
+++ b/scripts/claude-routed.ps1
@@ -178,18 +178,22 @@ function Copy-SeedConfig {
   # must NOT be swallowed (HIMMEL-820 CR: codex-adv [high] + silent-failure-hunter
   # convergence). A blanket -ErrorAction SilentlyContinue hid a locked/ACL-denied
   # .seeded: the reseed then threw later and exited 4, but the OLD sentinel survived
-  # next to a half-seeded tree, and a plain relaunch (whose staleness check tracks
-  # only settings + plugin manifests, not the copied subtrees) read it as "seeded"
-  # and launched on the corrupt tree. Guard the missing-file case (Test-Path — first
-  # seed has no sentinel) and exit 4 on a genuine removal failure, BEFORE any copy.
+  # next to a half-seeded tree, and a plain relaunch read it as "seeded" and launched
+  # on the corrupt tree.
+  # HIMMEL-828 Part A — race-free, mirroring bash `rm -f`: do NOT Test-Path-then-Remove
+  # (a concurrent reseed sharing this config dir can delete the sentinel in that window,
+  # so Remove-Item throws ItemNotFound even though sentinel-ABSENT is the desired end
+  # state → a spurious exit 4). Attempt the removal unconditionally and treat a
+  # missing-file (ItemNotFoundException) as success (goal reached); only a genuine
+  # lock/ACL failure (the file is still there) exits 4.
   $sentinel = Join-Path $ConfigDir '.seeded'
-  if (Test-Path -LiteralPath $sentinel) {
-    try {
-      Remove-Item -LiteralPath $sentinel -Force -ErrorAction Stop
-    } catch {
-      [Console]::Error.WriteLine("claude-routed: FAILED to clear stale .seeded sentinel ($($_.Exception.Message)). Refusing to reseed while a stale sentinel remains. Fix the cause and re-run (or rm -rf ~/.claude-routed).")
-      exit 4
-    }
+  try {
+    Remove-Item -LiteralPath $sentinel -Force -ErrorAction Stop
+  } catch [System.Management.Automation.ItemNotFoundException] {
+    # already absent (first seed, or a concurrent reseed beat us to it) — goal reached.
+  } catch {
+    [Console]::Error.WriteLine("claude-routed: FAILED to clear stale .seeded sentinel ($($_.Exception.Message)). Refusing to reseed while a stale sentinel remains. Fix the cause and re-run (or rm -rf ~/.claude-routed).")
+    exit 4
   }
   New-Item -ItemType Directory -Force -Path (Join-Path $ConfigDir 'plugins') | Out-Null
   $settings = Join-Path $src 'settings.json'
@@ -219,11 +223,24 @@ function Copy-SeedConfig {
       $dst = Join-Path $ConfigDir 'settings.json'
       if (Test-Path -LiteralPath $dst) { Remove-Item -LiteralPath $dst -Force }
     }
+    # Leaf files mirror deletion too (HIMMEL-828/819): CLAUDE.md literally steers the
+    # lane, so a deleted source must not leave a stale copy behind — same as settings.
     foreach ($f in 'CLAUDE.md', 'RTK.md') {
       $p = Join-Path $src $f
-      if (Test-Path -LiteralPath $p) { Copy-Item -LiteralPath $p -Destination (Join-Path $ConfigDir $f) -Force }
+      $dp = Join-Path $ConfigDir $f
+      if (Test-Path -LiteralPath $p) { Copy-Item -LiteralPath $p -Destination $dp -Force }
+      elseif (Test-Path -LiteralPath $dp) { Remove-Item -LiteralPath $dp -Force }
     }
+    # Clean re-mirror + deletion mirror (HIMMEL-828/819, parity with the claude-glm twin):
+    # remove the destination subtree FIRST — this both drops files deleted from the source
+    # AND mirrors a whole-subtree deletion (a removed command/hook/skill must not linger
+    # steering the routed lane: "a deleted source must not leave a stale copy steering the
+    # lane") — then copy only when the source still exists. No-op on the first seed. A REAL
+    # removal failure (locked file, ACL denial) terminates under Stop and is caught below —
+    # same "no sentinel on any failure". Symmetric with the settings/manifest mirror.
     foreach ($d in 'commands', 'skills', 'hooks', 'agents') {
+      $dst = Join-Path $ConfigDir $d
+      if (Test-Path -LiteralPath $dst) { Remove-Item -LiteralPath $dst -Recurse -Force }
       $p = Join-Path $src $d
       if (Test-Path -LiteralPath $p -PathType Container) { Copy-Item -LiteralPath $p -Destination $ConfigDir -Recurse -Force }
     }
@@ -233,14 +250,20 @@ function Copy-SeedConfig {
       if (Test-Path -LiteralPath $sp) { Copy-Item -LiteralPath $sp -Destination $dp -Force }
       elseif (Test-Path -LiteralPath $dp) { Remove-Item -LiteralPath $dp -Force }
     }
+    $mdst = Join-Path $ConfigDir (Join-Path 'plugins' 'marketplaces')
+    if (Test-Path -LiteralPath $mdst) { Remove-Item -LiteralPath $mdst -Recurse -Force }
     $mp = Join-Path $src (Join-Path 'plugins' 'marketplaces')
     if (Test-Path -LiteralPath $mp -PathType Container) { Copy-Item -LiteralPath $mp -Destination (Join-Path $ConfigDir 'plugins') -Recurse -Force }
     # claude-hud DISPLAY config — seed the single config.json only; the cache dirs
-    # under plugins/claude-hud/ are runtime state, never seeded. Source-absent → skip.
+    # under plugins/claude-hud/ are runtime state, never seeded. Source-absent → mirror
+    # the deletion (HIMMEL-828/819).
     $hudCfg = Join-Path $src (Join-Path 'plugins' (Join-Path 'claude-hud' 'config.json'))
+    $hudDst = Join-Path $ConfigDir (Join-Path 'plugins' (Join-Path 'claude-hud' 'config.json'))
     if (Test-Path -LiteralPath $hudCfg) {
       New-Item -ItemType Directory -Force -Path (Join-Path $ConfigDir (Join-Path 'plugins' 'claude-hud')) | Out-Null
-      Copy-Item -LiteralPath $hudCfg -Destination (Join-Path $ConfigDir (Join-Path 'plugins' (Join-Path 'claude-hud' 'config.json'))) -Force
+      Copy-Item -LiteralPath $hudCfg -Destination $hudDst -Force
+    } elseif (Test-Path -LiteralPath $hudDst) {
+      Remove-Item -LiteralPath $hudDst -Force
     }
     # sentinel LAST: only a fully-populated seed reads as "seeded"
     New-Item -ItemType File -Force -Path (Join-Path $ConfigDir '.seeded') | Out-Null
@@ -253,9 +276,12 @@ function Copy-SeedConfig {
 # Staleness-aware reseed (HIMMEL-819): a once-only seed strands lane workers on
 # whatever plugin/settings profile existed at first launch — the operator's lean
 # enabledPlugins profile never reaches the lane, so every worker pays duplicated
-# plugin context + duplicate MCP invocations. Track the three config sources that
-# change out-of-band (newer than the sentinel, OR deleted while a lane copy
-# remains); commands/skills/hooks/agents drift still needs -Reseed.
+# plugin context + duplicate MCP invocations. Track every allowlisted leaf source
+# (settings, CLAUDE.md, RTK.md, the two plugin manifests, claude-hud config — newer
+# than the sentinel OR deleted while a lane copy remains) AND the copied subtrees
+# (HIMMEL-828 Part B — a half-seeded/externally-removed subtree, a command/skill
+# added/removed at the top level, or a deleted source, self-heals on plain launch); a
+# deep in-file edit inside a subtree still needs -Reseed (directory mtime granularity).
 # Opt-out: CLAUDE_LANE_AUTO_RESEED=0 restores the once-only seed (first seed +
 # explicit -Reseed only) — the escape hatch if auto-reseed ever blocks a
 # launch in your setup (e.g. seed re-runs surfacing a broken node).
@@ -270,12 +296,28 @@ function Test-ConfigSeedStale {
     if (-not (Test-Path -LiteralPath $sentinel)) { return $false }
     $sentinelTime = (Get-Item -LiteralPath $sentinel).LastWriteTimeUtc
     $src = Join-Path $HomeDir '.claude'
-    foreach ($rel in @('settings.json', (Join-Path 'plugins' 'installed_plugins.json'), (Join-Path 'plugins' 'known_marketplaces.json'))) {
+    foreach ($rel in @('settings.json', 'CLAUDE.md', 'RTK.md', (Join-Path 'plugins' 'installed_plugins.json'), (Join-Path 'plugins' 'known_marketplaces.json'), (Join-Path 'plugins' (Join-Path 'claude-hud' 'config.json')))) {
       $s = Join-Path $src $rel
       $d = Join-Path $ConfigDir $rel
       if (Test-Path -LiteralPath $s) {
         if ((Get-Item -LiteralPath $s).LastWriteTimeUtc -gt $sentinelTime) { return $true }
       } elseif (Test-Path -LiteralPath $d) {
+        return $true  # source deleted but lane copy remains — reseed mirrors the removal
+      }
+    }
+    # HIMMEL-828 Part B — also track the copied subtrees, fully symmetric with the
+    # settings/manifest loop above, so a half-seeded OR a source-deleted subtree
+    # self-heals on a plain launch. Per subtree: SOURCE present but DEST missing = a
+    # half-seed → reseed; SOURCE newer than the sentinel = top-level drift → reseed;
+    # SOURCE absent but DEST present = a deleted source whose lane copy lingers → reseed
+    # (the seeder mirrors the deletion, so this fires once then clears — no churn).
+    foreach ($rel in @('commands', 'skills', 'hooks', 'agents', (Join-Path 'plugins' 'marketplaces'))) {
+      $s = Join-Path $src $rel
+      $d = Join-Path $ConfigDir $rel
+      if (Test-Path -LiteralPath $s -PathType Container) {
+        if (-not (Test-Path -LiteralPath $d -PathType Container)) { return $true }
+        if ((Get-Item -LiteralPath $s).LastWriteTimeUtc -gt $sentinelTime) { return $true }
+      } elseif (Test-Path -LiteralPath $d -PathType Container) {
         return $true  # source deleted but lane copy remains — reseed mirrors the removal
       }
     }

--- a/scripts/test-claude-glm.ps1
+++ b/scripts/test-claude-glm.ps1
@@ -170,8 +170,11 @@ try {
   if (FileHas (Join-Path $FAKEHOME '.claude-glm\settings.json') 'lean-profile-v2') { Pass 'stale seed refreshed on plain launch' } else { Fail 'stale seed not refreshed on plain launch' }
 
   # --- T7c: fresh sentinel -> plain launch does NOT reseed (no churn) ---
+  # (HIMMEL-828 Part B: the subtree sources are set old here too, so the widened
+  # staleness check keeps its no-churn guarantee when nothing has drifted.)
   '{"local":"tamper-survives"}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude-glm\settings.json') -NoNewline
-  foreach ($srcRel in @('.claude\settings.json', '.claude\plugins\installed_plugins.json', '.claude\plugins\known_marketplaces.json')) {
+  foreach ($srcRel in @('.claude\settings.json', '.claude\plugins\installed_plugins.json', '.claude\plugins\known_marketplaces.json',
+                        '.claude\commands', '.claude\skills', '.claude\hooks', '.claude\agents', '.claude\plugins\marketplaces')) {
     $p = Join-Path $FAKEHOME $srcRel
     if (Test-Path -LiteralPath $p) { (Get-Item -LiteralPath $p).LastWriteTimeUtc = [datetime]'2020-01-01' }
   }
@@ -399,6 +402,90 @@ try {
   if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\plugins\marketplaces\stale.json')) { Fail 'stale marketplaces file survived reseed' } else { Pass 'stale marketplaces file dropped on reseed' }
   if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\plugins\marketplaces\marketplaces')) { Fail 'nested marketplaces dir after reseed' } else { Pass 'no nested marketplaces dir after reseed' }
   if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\plugins\marketplaces\keep.json')) { Pass 'kept marketplaces file survived reseed' } else { Fail 'kept marketplaces file lost after reseed' }
+
+  # --- T22 (HIMMEL-828 Part A): the up-front sentinel removal is race-free like bash
+  # `rm -f` — a reseed whose sentinel is ABSENT at removal time (a concurrent reseed
+  # sharing the config dir removed it in the window the old Test-Path-then-Remove left
+  # open) must NOT spuriously exit 4. Deterministic stand-in for that race: seed once,
+  # delete the sentinel out from under the seeder, then -Reseed; Remove-Item hits
+  # ItemNotFound, which the typed catch treats as goal-reached, so the reseed completes
+  # (exit 0) and rewrites the sentinel. Guards a regression that drops/narrows the typed
+  # catch so ItemNotFound falls through to the general catch -> exit 4. Twin: T17c pins
+  # the opposite (a REAL lock failure still exits 4). ---
+  New-Sandbox; $script:KEY = 'zai-test-123'  # gitleaks:allow
+  Assert-Exit (Invoke-Launcher) 0 'seed before absent-sentinel reseed'   # writes .seeded
+  Remove-Item -LiteralPath (Join-Path $FAKEHOME '.claude-glm\.seeded') -Force  # vanish, as a concurrent reseed would
+  Assert-Exit (Invoke-Launcher -LArgs @('-Reseed')) 0 'reseed with an absent sentinel does not spuriously exit 4'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\.seeded')) { Pass 'sentinel rewritten after absent-sentinel reseed' } else { Fail 'sentinel not rewritten after absent-sentinel reseed' }
+
+  # --- T23 (HIMMEL-828 Part B): a half-seeded tree self-heals on a plain launch — the
+  # sentinel is present but a copied subtree is missing (an interrupted reseed or an
+  # external removal), which the pre-828 settings+manifest staleness check missed.
+  # Fixture: seed a sandbox with a commands subtree, delete the DEST subtree while
+  # leaving a FRESH sentinel + old sources; a plain launch must detect the source-
+  # present/dest-missing mismatch and reseed, restoring the subtree. FAILS on pre-828
+  # code (fresh sentinel + old tracked files => not stale => no reseed). ---
+  New-Sandbox; $script:KEY = 'zai-test-123'  # gitleaks:allow
+  New-Item -ItemType Directory -Force -Path (Join-Path $FAKEHOME '.claude\commands') | Out-Null
+  Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\commands\keep.md') -Value 'a'
+  Assert-Exit (Invoke-Launcher) 0 'seed before half-seed simulation'
+  Remove-Item -LiteralPath (Join-Path $FAKEHOME '.claude-glm\commands') -Recurse -Force  # dest subtree vanishes
+  foreach ($srcRel in @('.claude\settings.json', '.claude\plugins\installed_plugins.json', '.claude\plugins\known_marketplaces.json', '.claude\commands')) {
+    $p = Join-Path $FAKEHOME $srcRel
+    if (Test-Path -LiteralPath $p) { (Get-Item -LiteralPath $p).LastWriteTimeUtc = [datetime]'2020-01-01' }
+  }
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude-glm\.seeded')).LastWriteTimeUtc = [datetime]::UtcNow
+  Assert-Exit (Invoke-Launcher) 0 'half-seeded tree triggers reseed on plain launch'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\commands\keep.md')) { Pass 'missing subtree restored by self-heal reseed' } else { Fail 'missing subtree NOT restored (half-seed not detected)' }
+
+  # --- T24 (HIMMEL-828 Part B): a top-level add inside a source subtree (source dir
+  # mtime newer than the sentinel) auto-reseeds without -Reseed — pre-828 this drift
+  # needed an explicit -Reseed. Fixture: seed, set a fresh-ish sentinel + OLD settings/
+  # manifests (so only the subtree can be the trigger), add a new command to the source
+  # (bumping its dir mtime past the sentinel), confirm a plain launch mirrors it. ---
+  New-Sandbox; $script:KEY = 'zai-test-123'  # gitleaks:allow
+  New-Item -ItemType Directory -Force -Path (Join-Path $FAKEHOME '.claude\commands') | Out-Null
+  Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\commands\one.md') -Value 'a'
+  Assert-Exit (Invoke-Launcher) 0 'seed before subtree drift'
+  foreach ($srcRel in @('.claude\settings.json', '.claude\plugins\installed_plugins.json', '.claude\plugins\known_marketplaces.json')) {
+    $p = Join-Path $FAKEHOME $srcRel
+    if (Test-Path -LiteralPath $p) { (Get-Item -LiteralPath $p).LastWriteTimeUtc = [datetime]'2020-01-01' }
+  }
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude-glm\.seeded')).LastWriteTimeUtc = [datetime]'2020-06-01'
+  Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\commands\two.md') -Value 'b'  # new source command
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude\commands')).LastWriteTimeUtc = [datetime]::UtcNow
+  Assert-Exit (Invoke-Launcher) 0 'source subtree drift auto-reseeds on plain launch'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\commands\two.md')) { Pass 'new source command mirrored by subtree-drift reseed' } else { Fail 'new source command NOT mirrored (subtree drift not detected)' }
+
+  # --- T25 (HIMMEL-828/819, codex-adv [high]): DELETION MIRRORING — a deleted SOURCE
+  # subtree is removed from the lane on a plain launch (a removed command/hook must not
+  # linger steering the cloud lane), fully symmetric with settings/manifest deletion
+  # mirroring, AND it does NOT churn forever (the seeder clears the dest, so the predicate
+  # stops firing). Fixture: seed with a commands subtree, delete the SOURCE; launch 2
+  # mirrors the removal; launch 3 is stable (a lane tamper survives = no reseed). ---
+  New-Sandbox; $script:KEY = 'zai-test-123'  # gitleaks:allow
+  New-Item -ItemType Directory -Force -Path (Join-Path $FAKEHOME '.claude\commands') | Out-Null
+  Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\commands\keep.md') -Value 'a'
+  Assert-Exit (Invoke-Launcher) 0 'seed before source-subtree deletion'
+  Remove-Item -LiteralPath (Join-Path $FAKEHOME '.claude\commands') -Recurse -Force  # SOURCE subtree deleted
+  Assert-Exit (Invoke-Launcher) 0 'source-deleted subtree triggers a mirror reseed'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\commands')) { Fail 'stale lane subtree survived source deletion' } else { Pass 'stale lane subtree removed (deletion mirrored)' }
+  '{"local":"tamper-stable"}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude-glm\settings.json') -NoNewline
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude\settings.json')).LastWriteTimeUtc = [datetime]'2020-01-01'
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude-glm\.seeded')).LastWriteTimeUtc = [datetime]::UtcNow
+  Assert-Exit (Invoke-Launcher) 0 'no further churn after deletion mirrored'
+  if (FileHas (Join-Path $FAKEHOME '.claude-glm\settings.json') 'tamper-stable') { Pass 'stable after mirror (no churn)' } else { Fail 'churns after deletion mirrored' }
+
+  # --- T26 (HIMMEL-828/819, codex-adv [high]): LEAF-FILE deletion mirroring — a deleted
+  # source CLAUDE.md (which literally steers the lane) is removed from the lane on a plain
+  # launch, not just subtrees/manifests. Every allowlisted leaf now mirrors deletion. ---
+  New-Sandbox; $script:KEY = 'zai-test-123'  # gitleaks:allow
+  'steer' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\CLAUDE.md') -NoNewline
+  Assert-Exit (Invoke-Launcher) 0 'seed before CLAUDE.md deletion'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\CLAUDE.md')) { Pass 'CLAUDE.md seeded' } else { Fail 'CLAUDE.md not seeded' }
+  Remove-Item -LiteralPath (Join-Path $FAKEHOME '.claude\CLAUDE.md') -Force  # SOURCE deleted
+  Assert-Exit (Invoke-Launcher) 0 'deleted source CLAUDE.md triggers a mirror reseed'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\CLAUDE.md')) { Fail 'stale CLAUDE.md survived source deletion' } else { Pass 'stale CLAUDE.md removed (leaf deletion mirrored)' }
 
   Write-Host ''
   if ($script:fails -eq 0) { Write-Host 'ALL PASS' } else { Write-Host "$($script:fails) failure(s)" -ForegroundColor Red; exit 1 }

--- a/scripts/test-claude-glm.sh
+++ b/scripts/test-claude-glm.sh
@@ -120,9 +120,11 @@ t "stale seed auto-refreshes" 0
 grep -q "lean-profile-v2" "$FAKEHOME/.claude-glm/settings.json" || { echo "FAIL: stale seed not refreshed on plain launch"; FAILS=$((FAILS+1)); }
 
 # --- T7c: fresh sentinel -> plain launch does NOT reseed (no churn) — sources
-# older than the sentinel leave the config dir untouched.
+# older than the sentinel leave the config dir untouched. (HIMMEL-828 Part B: the
+# subtree sources are aged too, so the widened check keeps its no-churn guarantee.)
 printf '{"local":"tamper-survives"}' > "$FAKEHOME/.claude-glm/settings.json"
-touch -t 202001010000 "$FAKEHOME/.claude/settings.json" "$FAKEHOME/.claude/plugins/installed_plugins.json" 2>/dev/null
+touch -t 202001010000 "$FAKEHOME/.claude/settings.json" "$FAKEHOME/.claude/plugins/installed_plugins.json" \
+  "$FAKEHOME/.claude/commands" "$FAKEHOME/.claude/plugins/marketplaces" 2>/dev/null
 touch "$FAKEHOME/.claude-glm/.seeded"
 t "fresh sentinel skips reseed" 0
 grep -q "tamper-survives" "$FAKEHOME/.claude-glm/settings.json" || { echo "FAIL: fresh sentinel still reseeded"; FAILS=$((FAILS+1)); }
@@ -326,5 +328,66 @@ t "reseed re-mirrors marketplaces" 0 --reseed
 [ ! -f "$FAKEHOME/.claude-glm/plugins/marketplaces/stale.json" ] || { echo "FAIL: stale marketplaces file survived reseed"; FAILS=$((FAILS+1)); }
 [ ! -d "$FAKEHOME/.claude-glm/plugins/marketplaces/marketplaces" ] || { echo "FAIL: nested marketplaces/marketplaces after reseed"; FAILS=$((FAILS+1)); }
 [ -f "$FAKEHOME/.claude-glm/plugins/marketplaces/keep.json" ] || { echo "FAIL: kept marketplaces file lost after reseed"; FAILS=$((FAILS+1)); }
+
+# --- T24 (HIMMEL-828 Part B): a half-seeded tree self-heals on a plain launch — the
+# sentinel is present but a copied subtree is missing (interrupted reseed / external
+# removal), which the pre-828 settings+manifest check missed. Fixture: seed with a
+# commands subtree, delete the DEST subtree while leaving a FRESH sentinel + old
+# sources; a plain launch detects the source-present/dest-missing mismatch and reseeds.
+# FAILS on pre-828 code (fresh sentinel + old tracked files => not stale => no reseed).
+setup; KEY="zai-test-123"
+mkdir -p "$FAKEHOME/.claude/commands"
+printf 'a' > "$FAKEHOME/.claude/commands/keep.md"
+t "seed before half-seed simulation" 0
+rm -rf "$FAKEHOME/.claude-glm/commands"   # dest subtree vanishes
+touch -t 202001010000 "$FAKEHOME/.claude/settings.json" "$FAKEHOME/.claude/commands" 2>/dev/null
+touch "$FAKEHOME/.claude-glm/.seeded"     # fresh sentinel
+t "half-seeded tree triggers reseed on plain launch" 0
+[ -f "$FAKEHOME/.claude-glm/commands/keep.md" ] || { echo "FAIL: missing subtree NOT restored (half-seed not detected)"; FAILS=$((FAILS+1)); }
+
+# --- T25 (HIMMEL-828 Part B): a top-level add inside a source subtree (source dir
+# mtime newer than the sentinel) auto-reseeds without --reseed — pre-828 this drift
+# needed an explicit --reseed. Fixture: seed, age settings so only the subtree can be
+# the trigger, set a fresh-ish sentinel, add a new command (bumping the source commands
+# dir mtime past the sentinel), confirm a plain launch mirrors it into the lane copy.
+setup; KEY="zai-test-123"
+mkdir -p "$FAKEHOME/.claude/commands"
+printf 'a' > "$FAKEHOME/.claude/commands/one.md"
+t "seed before subtree drift" 0
+touch -t 202001010000 "$FAKEHOME/.claude/settings.json" 2>/dev/null
+touch -t 202006010000 "$FAKEHOME/.claude-glm/.seeded"
+printf 'b' > "$FAKEHOME/.claude/commands/two.md"   # new source command bumps the commands dir mtime to now
+t "source subtree drift auto-reseeds on plain launch" 0
+[ -f "$FAKEHOME/.claude-glm/commands/two.md" ] || { echo "FAIL: new source command NOT mirrored (subtree drift not detected)"; FAILS=$((FAILS+1)); }
+
+# --- T26 (HIMMEL-828/819, codex-adv [high]): DELETION MIRRORING — a deleted SOURCE
+# subtree is removed from the lane on a plain launch (a removed command/hook must not
+# linger steering the cloud lane), symmetric with settings/manifest deletion mirroring,
+# AND it does NOT churn forever (the seeder clears the dest, so the predicate stops
+# firing). Fixture: seed with a commands subtree, delete the SOURCE; launch 2 mirrors
+# the removal; launch 3 is stable (a lane tamper survives = no reseed).
+setup; KEY="zai-test-123"
+mkdir -p "$FAKEHOME/.claude/commands"
+printf 'a' > "$FAKEHOME/.claude/commands/keep.md"
+t "seed before source-subtree deletion" 0
+rm -rf "$FAKEHOME/.claude/commands"   # SOURCE subtree deleted
+t "source-deleted subtree triggers a mirror reseed" 0
+[ ! -d "$FAKEHOME/.claude-glm/commands" ] || { echo "FAIL: stale lane subtree survived source deletion"; FAILS=$((FAILS+1)); }
+printf '{"local":"tamper-stable"}' > "$FAKEHOME/.claude-glm/settings.json"
+touch -t 202001010000 "$FAKEHOME/.claude/settings.json" 2>/dev/null
+touch "$FAKEHOME/.claude-glm/.seeded"
+t "no further churn after deletion mirrored" 0
+grep -q "tamper-stable" "$FAKEHOME/.claude-glm/settings.json" || { echo "FAIL: churns after deletion mirrored (tamper lost)"; FAILS=$((FAILS+1)); }
+
+# --- T27 (HIMMEL-828/819, codex-adv [high]): LEAF-FILE deletion mirroring — a deleted
+# source CLAUDE.md (which literally steers the lane) is removed from the lane on a plain
+# launch, not just subtrees/manifests. Every allowlisted leaf now mirrors deletion.
+setup; KEY="zai-test-123"
+printf 'steer' > "$FAKEHOME/.claude/CLAUDE.md"
+t "seed before CLAUDE.md deletion" 0
+[ -f "$FAKEHOME/.claude-glm/CLAUDE.md" ] || { echo "FAIL: CLAUDE.md not seeded"; FAILS=$((FAILS+1)); }
+rm -f "$FAKEHOME/.claude/CLAUDE.md"   # SOURCE deleted
+t "deleted source CLAUDE.md triggers a mirror reseed" 0
+[ ! -f "$FAKEHOME/.claude-glm/CLAUDE.md" ] || { echo "FAIL: stale CLAUDE.md survived source deletion"; FAILS=$((FAILS+1)); }
 
 echo; [ "$FAILS" -eq 0 ] && echo "ALL PASS" || { echo "$FAILS failure(s)"; exit 1; }

--- a/scripts/test-claude-routed.ps1
+++ b/scripts/test-claude-routed.ps1
@@ -176,8 +176,11 @@ try {
   if (FileHas (Join-Path $FAKEHOME '.claude-routed\settings.json') 'lean-profile-v2') { Pass 'stale seed refreshed on plain launch' } else { Fail 'stale seed not refreshed on plain launch' }
 
   # --- T7c: fresh sentinel -> plain launch does NOT reseed (no churn) ---
+  # (HIMMEL-828 Part B: the subtree sources are set old here too, so the widened
+  # staleness check keeps its no-churn guarantee when nothing has drifted.)
   '{"local":"tamper-survives"}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude-routed\settings.json') -NoNewline
-  foreach ($srcRel in @('.claude\settings.json', '.claude\plugins\installed_plugins.json', '.claude\plugins\known_marketplaces.json')) {
+  foreach ($srcRel in @('.claude\settings.json', '.claude\plugins\installed_plugins.json', '.claude\plugins\known_marketplaces.json',
+                        '.claude\commands', '.claude\skills', '.claude\hooks', '.claude\agents', '.claude\plugins\marketplaces')) {
     $p = Join-Path $FAKEHOME $srcRel
     if (Test-Path -LiteralPath $p) { (Get-Item -LiteralPath $p).LastWriteTimeUtc = [datetime]'2020-01-01' }
   }
@@ -352,6 +355,111 @@ try {
   Assert-Exit (Invoke-Launcher) 3 'phi-roots as directory fails closed'
   if (Test-Path -LiteralPath $ChildEnv) { Fail 'claude launched despite unreadable phi-roots' } else { Pass 'claude not launched on unreadable phi-roots' }
   if (FileHas $OutTxt 'failing closed') { Pass 'phi-roots dir emits the failing-closed message' } else { Fail 'no failing-closed message on phi-roots dir' }
+
+  # --- T19 (HIMMEL-828 Part A): the up-front sentinel removal is race-free like bash
+  # `rm -f` — a reseed whose sentinel is ABSENT at removal time (a concurrent reseed
+  # sharing the config dir removed it in the window the old Test-Path-then-Remove left
+  # open) must NOT spuriously exit 4. Deterministic stand-in for that race: seed once,
+  # delete the sentinel out from under the seeder, then -Reseed; Remove-Item hits
+  # ItemNotFound, which the typed catch treats as goal-reached, so the reseed completes
+  # (exit 0) and rewrites the sentinel. Guards a regression that drops/narrows the typed
+  # catch so ItemNotFound falls through to the general catch -> exit 4. Twin: T17c pins
+  # the opposite (a REAL lock failure still exits 4). ---
+  New-Sandbox; $script:KEY = 'omni-test-123'  # gitleaks:allow
+  Assert-Exit (Invoke-Launcher) 0 'seed before absent-sentinel reseed'   # writes .seeded
+  Remove-Item -LiteralPath (Join-Path $FAKEHOME '.claude-routed\.seeded') -Force  # vanish, as a concurrent reseed would
+  Assert-Exit (Invoke-Launcher -LArgs @('-Reseed')) 0 'reseed with an absent sentinel does not spuriously exit 4'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\.seeded')) { Pass 'sentinel rewritten after absent-sentinel reseed' } else { Fail 'sentinel not rewritten after absent-sentinel reseed' }
+
+  # --- T20 (HIMMEL-828 Part B): a half-seeded tree self-heals on a plain launch — the
+  # sentinel is present but a copied subtree is missing (an interrupted reseed or an
+  # external removal), which the pre-828 settings+manifest staleness check missed.
+  # Fixture: seed a sandbox with a commands subtree, delete the DEST subtree while
+  # leaving a FRESH sentinel + old sources; a plain launch must detect the source-
+  # present/dest-missing mismatch and reseed, restoring the subtree. FAILS on pre-828
+  # code (fresh sentinel + old tracked files => not stale => no reseed). ---
+  New-Sandbox; $script:KEY = 'omni-test-123'  # gitleaks:allow
+  New-Item -ItemType Directory -Force -Path (Join-Path $FAKEHOME '.claude\commands') | Out-Null
+  Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\commands\keep.md') -Value 'a'
+  Assert-Exit (Invoke-Launcher) 0 'seed before half-seed simulation'
+  Remove-Item -LiteralPath (Join-Path $FAKEHOME '.claude-routed\commands') -Recurse -Force  # dest subtree vanishes
+  foreach ($srcRel in @('.claude\settings.json', '.claude\plugins\installed_plugins.json', '.claude\plugins\known_marketplaces.json', '.claude\commands')) {
+    $p = Join-Path $FAKEHOME $srcRel
+    if (Test-Path -LiteralPath $p) { (Get-Item -LiteralPath $p).LastWriteTimeUtc = [datetime]'2020-01-01' }
+  }
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude-routed\.seeded')).LastWriteTimeUtc = [datetime]::UtcNow
+  Assert-Exit (Invoke-Launcher) 0 'half-seeded tree triggers reseed on plain launch'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\commands\keep.md')) { Pass 'missing subtree restored by self-heal reseed' } else { Fail 'missing subtree NOT restored (half-seed not detected)' }
+
+  # --- T21 (HIMMEL-828 Part B): a top-level add inside a source subtree (source dir
+  # mtime newer than the sentinel) auto-reseeds without -Reseed — pre-828 this drift
+  # needed an explicit -Reseed. Fixture: seed, set a fresh-ish sentinel + OLD settings/
+  # manifests (so only the subtree can be the trigger), add a new command to the source
+  # (bumping its dir mtime past the sentinel), confirm a plain launch mirrors it. ---
+  New-Sandbox; $script:KEY = 'omni-test-123'  # gitleaks:allow
+  New-Item -ItemType Directory -Force -Path (Join-Path $FAKEHOME '.claude\commands') | Out-Null
+  Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\commands\one.md') -Value 'a'
+  Assert-Exit (Invoke-Launcher) 0 'seed before subtree drift'
+  foreach ($srcRel in @('.claude\settings.json', '.claude\plugins\installed_plugins.json', '.claude\plugins\known_marketplaces.json')) {
+    $p = Join-Path $FAKEHOME $srcRel
+    if (Test-Path -LiteralPath $p) { (Get-Item -LiteralPath $p).LastWriteTimeUtc = [datetime]'2020-01-01' }
+  }
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude-routed\.seeded')).LastWriteTimeUtc = [datetime]'2020-06-01'
+  Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\commands\two.md') -Value 'b'  # new source command
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude\commands')).LastWriteTimeUtc = [datetime]::UtcNow
+  Assert-Exit (Invoke-Launcher) 0 'source subtree drift auto-reseeds on plain launch'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\commands\two.md')) { Pass 'new source command mirrored by subtree-drift reseed' } else { Fail 'new source command NOT mirrored (subtree drift not detected)' }
+
+  # --- T22 (HIMMEL-828, codex-adv [high]): reseed CLEAN re-mirrors seeded subtrees —
+  # a file left stale in the dest (deleted from the source) is DROPPED, no nested copy
+  # appears, kept files survive. Twin of glm T21; covers the routed clean-remirror fix
+  # (routed previously merged into the existing dest and left source-deleted files
+  # active). Exercises both the commands loop and the separate plugins/marketplaces
+  # statement in Copy-SeedConfig. ---
+  New-Sandbox; $script:KEY = 'omni-test-123'  # gitleaks:allow
+  New-Item -ItemType Directory -Force -Path (Join-Path $FAKEHOME '.claude\commands') | Out-Null
+  Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\commands\keep.md') -Value 'a'
+  New-Item -ItemType Directory -Force -Path (Join-Path $FAKEHOME '.claude\plugins\marketplaces') | Out-Null
+  Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\plugins\marketplaces\keep.json') -Value 'a'
+  Assert-Exit (Invoke-Launcher) 0 'seed before re-mirror'
+  Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude-routed\commands\stale.md') -Value 'stale'
+  Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude-routed\plugins\marketplaces\stale.json') -Value 'stale'
+  Assert-Exit (Invoke-Launcher -LArgs @('-Reseed')) 0 'reseed re-mirrors subtrees'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\commands\stale.md')) { Fail 'stale commands file survived reseed' } else { Pass 'stale commands file dropped on reseed' }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\commands\commands')) { Fail 'nested commands\commands after reseed' } else { Pass 'no nested commands dir after reseed' }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\commands\keep.md')) { Pass 'kept commands file survived reseed' } else { Fail 'kept commands file lost after reseed' }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\plugins\marketplaces\stale.json')) { Fail 'stale marketplaces file survived reseed' } else { Pass 'stale marketplaces file dropped on reseed' }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\plugins\marketplaces\marketplaces')) { Fail 'nested marketplaces dir after reseed' } else { Pass 'no nested marketplaces dir after reseed' }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\plugins\marketplaces\keep.json')) { Pass 'kept marketplaces file survived reseed' } else { Fail 'kept marketplaces file lost after reseed' }
+
+  # --- T23 (HIMMEL-828/819, codex-adv [high]): DELETION MIRRORING — a deleted SOURCE
+  # subtree is removed from the lane on a plain launch (a removed command/hook must not
+  # linger steering the routed lane), symmetric with settings/manifest deletion mirroring,
+  # AND it does NOT churn forever. Twin of glm T25. Fixture: seed with a commands subtree,
+  # delete the SOURCE; launch 2 mirrors the removal; launch 3 is stable (tamper survives). ---
+  New-Sandbox; $script:KEY = 'omni-test-123'  # gitleaks:allow
+  New-Item -ItemType Directory -Force -Path (Join-Path $FAKEHOME '.claude\commands') | Out-Null
+  Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\commands\keep.md') -Value 'a'
+  Assert-Exit (Invoke-Launcher) 0 'seed before source-subtree deletion'
+  Remove-Item -LiteralPath (Join-Path $FAKEHOME '.claude\commands') -Recurse -Force  # SOURCE subtree deleted
+  Assert-Exit (Invoke-Launcher) 0 'source-deleted subtree triggers a mirror reseed'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\commands')) { Fail 'stale lane subtree survived source deletion' } else { Pass 'stale lane subtree removed (deletion mirrored)' }
+  '{"local":"tamper-stable"}' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude-routed\settings.json') -NoNewline
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude\settings.json')).LastWriteTimeUtc = [datetime]'2020-01-01'
+  (Get-Item -LiteralPath (Join-Path $FAKEHOME '.claude-routed\.seeded')).LastWriteTimeUtc = [datetime]::UtcNow
+  Assert-Exit (Invoke-Launcher) 0 'no further churn after deletion mirrored'
+  if (FileHas (Join-Path $FAKEHOME '.claude-routed\settings.json') 'tamper-stable') { Pass 'stable after mirror (no churn)' } else { Fail 'churns after deletion mirrored' }
+
+  # --- T24 (HIMMEL-828/819, codex-adv [high]): LEAF-FILE deletion mirroring — a deleted
+  # source CLAUDE.md (which literally steers the lane) is removed from the lane on a plain
+  # launch, not just subtrees/manifests. Twin of glm T26. ---
+  New-Sandbox; $script:KEY = 'omni-test-123'  # gitleaks:allow
+  'steer' | Set-Content -LiteralPath (Join-Path $FAKEHOME '.claude\CLAUDE.md') -NoNewline
+  Assert-Exit (Invoke-Launcher) 0 'seed before CLAUDE.md deletion'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\CLAUDE.md')) { Pass 'CLAUDE.md seeded' } else { Fail 'CLAUDE.md not seeded' }
+  Remove-Item -LiteralPath (Join-Path $FAKEHOME '.claude\CLAUDE.md') -Force  # SOURCE deleted
+  Assert-Exit (Invoke-Launcher) 0 'deleted source CLAUDE.md triggers a mirror reseed'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\CLAUDE.md')) { Fail 'stale CLAUDE.md survived source deletion' } else { Pass 'stale CLAUDE.md removed (leaf deletion mirrored)' }
 
   Write-Host ''
   if ($script:fails -eq 0) { Write-Host 'ALL PASS' } else { Write-Host "$($script:fails) failure(s)" -ForegroundColor Red; exit 1 }

--- a/scripts/test-claude-routed.sh
+++ b/scripts/test-claude-routed.sh
@@ -127,9 +127,11 @@ t "stale seed auto-refreshes" 0
 grep -q "lean-profile-v2" "$FAKEHOME/.claude-routed/settings.json" || { echo "FAIL: stale seed not refreshed on plain launch"; FAILS=$((FAILS+1)); }
 
 # --- T7c: fresh sentinel -> plain launch does NOT reseed (no churn) — sources
-# older than the sentinel leave the config dir untouched.
+# older than the sentinel leave the config dir untouched. (HIMMEL-828 Part B: the
+# subtree sources are aged too, so the widened check keeps its no-churn guarantee.)
 printf '{"local":"tamper-survives"}' > "$FAKEHOME/.claude-routed/settings.json"
-touch -t 202001010000 "$FAKEHOME/.claude/settings.json" "$FAKEHOME/.claude/plugins/installed_plugins.json" 2>/dev/null
+touch -t 202001010000 "$FAKEHOME/.claude/settings.json" "$FAKEHOME/.claude/plugins/installed_plugins.json" \
+  "$FAKEHOME/.claude/commands" "$FAKEHOME/.claude/plugins/marketplaces" 2>/dev/null
 touch "$FAKEHOME/.claude-routed/.seeded"
 t "fresh sentinel skips reseed" 0
 grep -q "tamper-survives" "$FAKEHOME/.claude-routed/settings.json" || { echo "FAIL: fresh sentinel still reseeded"; FAILS=$((FAILS+1)); }
@@ -282,5 +284,94 @@ setup; KEY="omni-test-123"
 mkdir -p "$FAKEHOME/.config/claude-glm"
 printf '/some/unrelated/root\r\n\r\n' > "$FAKEHOME/.config/claude-glm/egress-denylist"
 t "blank CRLF guard line does not over-refuse clean cwd" 0
+
+# --- T21 (HIMMEL-828 Part B): a half-seeded tree self-heals on a plain launch — the
+# sentinel is present but a copied subtree is missing (interrupted reseed / external
+# removal), which the pre-828 settings+manifest check missed. Fixture: seed with a
+# commands subtree, delete the DEST subtree while leaving a FRESH sentinel + old
+# sources; a plain launch detects the source-present/dest-missing mismatch and reseeds.
+# FAILS on pre-828 code (fresh sentinel + old tracked files => not stale => no reseed).
+setup; KEY="omni-test-123"
+mkdir -p "$FAKEHOME/.claude/commands"
+printf 'a' > "$FAKEHOME/.claude/commands/keep.md"
+t "seed before half-seed simulation" 0
+rm -rf "$FAKEHOME/.claude-routed/commands"   # dest subtree vanishes
+touch -t 202001010000 "$FAKEHOME/.claude/settings.json" "$FAKEHOME/.claude/commands" 2>/dev/null
+touch "$FAKEHOME/.claude-routed/.seeded"     # fresh sentinel
+t "half-seeded tree triggers reseed on plain launch" 0
+[ -f "$FAKEHOME/.claude-routed/commands/keep.md" ] || { echo "FAIL: missing subtree NOT restored (half-seed not detected)"; FAILS=$((FAILS+1)); }
+
+# --- T22 (HIMMEL-828 Part B): a top-level add inside a source subtree (source dir
+# mtime newer than the sentinel) auto-reseeds without --reseed — pre-828 this drift
+# needed an explicit --reseed. Fixture: seed, age settings so only the subtree can be
+# the trigger, set a fresh-ish sentinel, add a new command (bumping the source commands
+# dir mtime past the sentinel), confirm a plain launch mirrors it into the lane copy.
+setup; KEY="omni-test-123"
+mkdir -p "$FAKEHOME/.claude/commands"
+printf 'a' > "$FAKEHOME/.claude/commands/one.md"
+t "seed before subtree drift" 0
+touch -t 202001010000 "$FAKEHOME/.claude/settings.json" 2>/dev/null
+touch -t 202006010000 "$FAKEHOME/.claude-routed/.seeded"
+printf 'b' > "$FAKEHOME/.claude/commands/two.md"   # new source command bumps the commands dir mtime to now
+t "source subtree drift auto-reseeds on plain launch" 0
+[ -f "$FAKEHOME/.claude-routed/commands/two.md" ] || { echo "FAIL: new source command NOT mirrored (subtree drift not detected)"; FAILS=$((FAILS+1)); }
+
+# --- T23 (HIMMEL-828, codex-adv [high]): --reseed CLEAN re-mirrors seeded subtrees —
+# a file left stale in the dest (deleted from the source) is DROPPED, and cp -R does
+# not nest a second copy (commands/commands on BSD cp). Twin of glm T22; covers the
+# routed clean-remirror fix (routed previously left source-deleted files active).
+setup; KEY="omni-test-123"
+mkdir -p "$FAKEHOME/.claude/commands"
+printf 'a' > "$FAKEHOME/.claude/commands/keep.md"
+t "seed before re-mirror" 0
+[ -f "$FAKEHOME/.claude-routed/commands/keep.md" ] || { echo "FAIL: commands not seeded"; FAILS=$((FAILS+1)); }
+printf 'stale' > "$FAKEHOME/.claude-routed/commands/stale.md"   # never in source
+t "reseed re-mirrors subtree" 0 --reseed
+[ ! -f "$FAKEHOME/.claude-routed/commands/stale.md" ] || { echo "FAIL: stale file survived reseed"; FAILS=$((FAILS+1)); }
+[ ! -d "$FAKEHOME/.claude-routed/commands/commands" ] || { echo "FAIL: nested commands/commands after reseed"; FAILS=$((FAILS+1)); }
+[ -f "$FAKEHOME/.claude-routed/commands/keep.md" ] || { echo "FAIL: kept file lost after reseed"; FAILS=$((FAILS+1)); }
+
+# --- T24 (HIMMEL-828, codex-adv [high]): --reseed CLEAN re-mirrors plugins/marketplaces
+# too — a SEPARATE statement from the commands/skills/hooks/agents loop, so T23 does not
+# cover it. Twin of glm T23.
+setup; KEY="omni-test-123"
+mkdir -p "$FAKEHOME/.claude/plugins/marketplaces"
+printf 'a' > "$FAKEHOME/.claude/plugins/marketplaces/keep.json"
+t "seed marketplaces before re-mirror" 0
+[ -f "$FAKEHOME/.claude-routed/plugins/marketplaces/keep.json" ] || { echo "FAIL: marketplaces not seeded"; FAILS=$((FAILS+1)); }
+printf 'stale' > "$FAKEHOME/.claude-routed/plugins/marketplaces/stale.json"   # never in source
+t "reseed re-mirrors marketplaces" 0 --reseed
+[ ! -f "$FAKEHOME/.claude-routed/plugins/marketplaces/stale.json" ] || { echo "FAIL: stale marketplaces file survived reseed"; FAILS=$((FAILS+1)); }
+[ ! -d "$FAKEHOME/.claude-routed/plugins/marketplaces/marketplaces" ] || { echo "FAIL: nested marketplaces/marketplaces after reseed"; FAILS=$((FAILS+1)); }
+[ -f "$FAKEHOME/.claude-routed/plugins/marketplaces/keep.json" ] || { echo "FAIL: kept marketplaces file lost after reseed"; FAILS=$((FAILS+1)); }
+
+# --- T25 (HIMMEL-828/819, codex-adv [high]): DELETION MIRRORING — a deleted SOURCE
+# subtree is removed from the lane on a plain launch (a removed command/hook must not
+# linger steering the routed lane), symmetric with settings/manifest deletion mirroring,
+# AND it does NOT churn forever. Twin of glm T26. Fixture: seed with a commands subtree,
+# delete the SOURCE; launch 2 mirrors the removal; launch 3 is stable (tamper survives).
+setup; KEY="omni-test-123"
+mkdir -p "$FAKEHOME/.claude/commands"
+printf 'a' > "$FAKEHOME/.claude/commands/keep.md"
+t "seed before source-subtree deletion" 0
+rm -rf "$FAKEHOME/.claude/commands"   # SOURCE subtree deleted
+t "source-deleted subtree triggers a mirror reseed" 0
+[ ! -d "$FAKEHOME/.claude-routed/commands" ] || { echo "FAIL: stale lane subtree survived source deletion"; FAILS=$((FAILS+1)); }
+printf '{"local":"tamper-stable"}' > "$FAKEHOME/.claude-routed/settings.json"
+touch -t 202001010000 "$FAKEHOME/.claude/settings.json" 2>/dev/null
+touch "$FAKEHOME/.claude-routed/.seeded"
+t "no further churn after deletion mirrored" 0
+grep -q "tamper-stable" "$FAKEHOME/.claude-routed/settings.json" || { echo "FAIL: churns after deletion mirrored (tamper lost)"; FAILS=$((FAILS+1)); }
+
+# --- T26 (HIMMEL-828/819, codex-adv [high]): LEAF-FILE deletion mirroring — a deleted
+# source CLAUDE.md (which literally steers the lane) is removed from the lane on a plain
+# launch, not just subtrees/manifests. Twin of glm T27.
+setup; KEY="omni-test-123"
+printf 'steer' > "$FAKEHOME/.claude/CLAUDE.md"
+t "seed before CLAUDE.md deletion" 0
+[ -f "$FAKEHOME/.claude-routed/CLAUDE.md" ] || { echo "FAIL: CLAUDE.md not seeded"; FAILS=$((FAILS+1)); }
+rm -f "$FAKEHOME/.claude/CLAUDE.md"   # SOURCE deleted
+t "deleted source CLAUDE.md triggers a mirror reseed" 0
+[ ! -f "$FAKEHOME/.claude-routed/CLAUDE.md" ] || { echo "FAIL: stale CLAUDE.md survived source deletion"; FAILS=$((FAILS+1)); }
 
 echo; [ "$FAILS" -eq 0 ] && echo "ALL PASS" || { echo "$FAILS failure(s)"; exit 1; }


### PR DESCRIPTION
Propagated from private HIMMEL-828. Hardens the GLM + routed lane launchers' config seed/reseed path: Part A fixes a PowerShell TOCTOU sentinel-remove race; Part B makes the lane a faithful self-healing mirror of every allowlisted source (settings/CLAUDE.md/RTK.md/manifests/claude-hud/subtrees) incl. deletion mirroring. Concurrent-seed locking deferred to HIMMEL-830. All four test suites green; shellcheck clean.