### PR TITLE
feat(cr): [HIMMEL-838] fresh Alibaba anchor + parallel OpenRouter free member; drop exhausted models

### DIFF
--- a/docs/hermes-runbook.md
+++ b/docs/hermes-runbook.md
@@ -181,8 +181,9 @@ free model with write/git/PR control.
 
 Himmel ships one tuned free-tier identity as an **opt-in asset**:
 [`scripts/hermes/assets/free-tier.SOUL.md`](../scripts/hermes/assets/free-tier.SOUL.md).
-It is tuned for the open-model free anchor (live: `qwen3-coder-plus`, read at
-build time from `scripts/cr/critics.json`) — rigid JSON / format-obedience
+It is tuned for the open-model free anchor (read live from
+`scripts/cr/critics.json` — the anchor model drifts as free quotas
+exhaust; do not hardcode it here) — rigid JSON / format-obedience
 scaffolding, a declared `Context budget:` line, and fewer hedges. Open models
 drift from the output contract and over-report, so the free SOUL compensates
 where the premium GPT-anatomy prompt would instead rely on contradiction
@@ -355,7 +356,7 @@ Add one alias per tier you want reachable. Claude-tier parity map:
 | sonnet | `qwen-plus` |
 | opus | `qwen3-max` / `qwen3.7-max` |
 | thinking / fable | `qwq-plus` / `qwen3-235b-a22b-thinking` |
-| CR critic | `qwen3-coder-plus` |
+| CR critic | anchor row in `scripts/cr/critics.json` (2026-07-09: `qwen3.7-max`; `qwen3-coder-plus`/`qwen-plus` exhausted) |
 
 ### Validate THROUGH hermes
 
@@ -372,8 +373,10 @@ one-shot auto-detect on `-m` re-overrides a profile's provider.
 
 ### Consumers
 
-The CR panel's free critic is anchored to `qwen3-coder-plus` via this lane
-(HIMMEL-725). Free-quota exhaustion is why a quota guard is tracked
+The CR panel's free critic is anchored via this lane to the model in
+`scripts/cr/critics.json`'s anchor row (HIMMEL-725 introduced the lane;
+HIMMEL-838 swapped the anchor to `qwen3.7-max` after the 2026-07-09
+exhaustion). Free-quota exhaustion is why a quota guard is tracked
 separately — it needs a dynamic API pull (console screenshots are not
 automatable).
 

--- a/scripts/cr/critic-panel.sh
+++ b/scripts/cr/critic-panel.sh
@@ -50,7 +50,7 @@ else
 fi
 
 ANCHOR_SLUG="qwen3coder"
-ANCHOR_MODEL="qwen3-coder-plus"
+ANCHOR_MODEL="qwen3.7-max"
 
 # Per-member timeout: validate CRITIC_TIMEOUT_SECS (Bash 3.2 safe via expr).
 CRITIC_TIMEOUT_SECS="${CRITIC_TIMEOUT_SECS:-240}"

--- a/scripts/cr/critics.json
+++ b/scripts/cr/critics.json
@@ -1,7 +1,8 @@
 {
   "_compliance": "panel/router lanes must terminate per-token keys only; the Z.ai Coding-Plan subscription (and any subscription lane) is launcher-only (ToS restricts it to officially supported tools) — never behind a panel or router.",
   "panel": [
-    { "slug": "qwen3coder", "model": "qwen3-coder-plus", "provider": "alibaba-coding-plan", "tier": "free", "fallback_models": ["qwen-plus", "qwen/qwen3-next-80b-a3b-instruct:free"] },
+    { "slug": "qwen3coder", "model": "qwen3.7-max", "provider": "alibaba-coding-plan", "tier": "free", "fallback_models": ["qwen3-max", "qwq-plus", "qwen-flash"], "_exhausted_2026-07-09": ["qwen3-coder-plus", "qwen-plus"] },
+    { "slug": "qwenor",     "model": "qwen/qwen3-next-80b-a3b-instruct:free", "provider": "openrouter", "tier": "free" },
     { "slug": "codex",      "model": "gpt-5.5",                             "provider": "openai-codex", "tier": "paid" }
   ]
 }

--- a/scripts/cr/testdata/stub-cfp.py
+++ b/scripts/cr/testdata/stub-cfp.py
@@ -20,7 +20,7 @@ sys.stdin.read()
 # for the merge/renumber/tier tests); the new string is the current ANCHOR_MODEL
 # that the anchor-fallback tests (E, I2) feed through this stub to prove the
 # anchor MODEL ran. Keep both so a future ANCHOR_MODEL bump only touches this line.
-if model in ("qwen/qwen3-coder-480b-a35b-instruct", "qwen/qwen3.6-35b-a3b", "qwen3-coder-plus"):
+if model in ("qwen/qwen3-coder-480b-a35b-instruct", "qwen/qwen3.6-35b-a3b", "qwen3-coder-plus", "qwen3.7-max"):
     print("# qwen3coder First-Pass Review")
     print("")
     print("## Critical Issues (1 found)")


### PR DESCRIPTION
Propagated from private (squash 7619d00b, PR #1055 there). Anchor swap after the 2026-07-09 free-quota exhaustion + OpenRouter free as a parallel panel member. All CR suites pass; chain dogfooded live during its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)