### PR TITLE
fix(lanes): [HIMMEL-830] serialize concurrent same-lane reseeds — per-config mkdir lock, all four launcher twins

### DIFF
--- a/scripts/claude-glm
+++ b/scripts/claude-glm
@@ -213,8 +213,76 @@ config_seed_stale() { # rc=0 when any tracked source is newer than the sentinel,
   return 1
 }
 
+# Concurrency lock (HIMMEL-830): serialize concurrent same-lane reseeds so two
+# launches of THIS lane cannot interleave seed_config_dir's rm/cp sequence into a
+# torn config dir (the .seeded sentinel guards FAILED seeds, not CONCURRENT ones).
+# The lock is a DIRECTORY sibling of CONFIG_DIR (NOT under it, so the seeder's own
+# rm -rf sweeps can never delete it); mkdir is atomic on every platform incl. Git
+# Bash. The dir is kept EMPTY so the rmdir release is atomic and steal-safe.
+LOCK="$CONFIG_DIR.seed-lock"
+SEED_LOCK_TIMEOUT="${CLAUDE_LANE_SEED_LOCK_TIMEOUT:-60}"   # seconds to wait before giving up
+SEED_LOCK_STALE="${CLAUDE_LANE_SEED_LOCK_STALE:-120}"      # seconds after which a held lock is presumed abandoned
+
+seed_lock_is_stale() { # rc=0 when LOCK exists and its mtime is older than SEED_LOCK_STALE seconds
+  [ -d "$LOCK" ] || return 1
+  # GNU stat form first (Linux + Git Bash), BSD form fallback (macOS).
+  lock_mt="$(stat -c %Y "$LOCK" 2>/dev/null || stat -f %m "$LOCK" 2>/dev/null)"
+  [ -n "$lock_mt" ] || return 1
+  [ "$(( $(date +%s) - lock_mt ))" -ge "$SEED_LOCK_STALE" ]
+}
+
+seed_with_lock() {
+  # Acquire (mkdir), poll on contention, steal a stale holder, or time out (exit 4).
+  seed_lock_ticks=0
+  seed_lock_max=$(( SEED_LOCK_TIMEOUT * 2 ))   # two 0.5s polls per second
+  while ! mkdir_err="$(mkdir "$LOCK" 2>&1)"; do
+    # SINGLE-WINNER stale steal via atomic same-dir rename: only ONE waiter's mv
+    # succeeds (the path is gone for every loser, whose mv simply fails), and the
+    # winner's FRESH replacement lock can never be renamed away by a queued loser
+    # (a fresh lock is never stale). A plain rmdir steal is a TOCTOU double-acquire:
+    # two waiters both judge the dead lock stale, one rmdirs+re-acquires, the
+    # other's queued rmdir then deletes the winner's fresh EMPTY lock, both seed
+    # concurrently -- the torn config this lock exists to prevent. The renamed dir
+    # is removed best-effort; if it was non-empty (invariant violation) the orphan
+    # is harmless -- it is not the lock path. Accepted residual: a LIVE seeder
+    # holding the lock past SEED_LOCK_STALE gets stolen -- but seeds are sub-second
+    # copies, so a hold that long means a dead/hung holder in practice.
+    if seed_lock_is_stale && mv "$LOCK" "$LOCK.stale.$$" 2>/dev/null; then
+      rmdir "$LOCK.stale.$$" 2>/dev/null || true   # orphaned .stale dir is harmless (not the lock path)
+      continue
+    fi
+    if [ "$seed_lock_ticks" -ge "$seed_lock_max" ]; then
+      echo "claude-glm: timed out after ${SEED_LOCK_TIMEOUT}s waiting for the config-dir seed lock ($LOCK). If no other claude-glm launch of this lane is seeding, remove that dir, or tune CLAUDE_LANE_SEED_LOCK_TIMEOUT / CLAUDE_LANE_SEED_LOCK_STALE; last mkdir error: $mkdir_err" >&2
+      exit 4
+    fi
+    sleep 0.5
+    seed_lock_ticks=$(( seed_lock_ticks + 1 ))
+  done
+  # Release the lock on ANY exit while held (covers seed_fail's exit 4 path). This
+  # trap release stays best-effort SILENT -- the exit path already carries its own
+  # error. Accepted residual: an untrapped SIGINT/SIGTERM while holding leaks the
+  # lock until the stale steal (~SEED_LOCK_STALE s) -- deliberate; adding INT/TERM
+  # traps would change the launcher's existing signal semantics.
+  trap 'rmdir "$LOCK" 2>/dev/null' EXIT
+  # Double-checked recheck UNDER the lock: the OUTER if was a cheap pre-check that
+  # raced other launches; a concurrent winner may have just seeded while we waited,
+  # so re-evaluate the same condition and skip a redundant reseed. RESEED=1 forces a
+  # reseed regardless (explicit operator intent), but still under the lock.
+  # Residual (accepted): a READER launch that judged the sentinel fresh a moment
+  # before the winner removed it can still exec claude against a mid-seed dir -- the
+  # window shrinks from the full seed duration to one stat. Full reader-writer
+  # exclusion would need an atomic dir swap Windows cannot give; out of scope.
+  if [ "$RESEED" -eq 1 ] || [ ! -f "$CONFIG_DIR/.seeded" ] || config_seed_stale; then
+    seed_config_dir
+  fi
+  trap - EXIT
+  # Explicit release warns on failure (a non-empty/busy lock is an invariant
+  # violation worth surfacing) but stays NON-FATAL: the seed itself succeeded.
+  rmdir "$LOCK" 2>/dev/null || echo "claude-glm: WARNING - failed to release seed lock $LOCK (not empty or busy); it self-heals via stale steal after ${SEED_LOCK_STALE}s but concurrent launches wait/time out until then." >&2
+}
+
 if [ ! -f "$CONFIG_DIR/.seeded" ] || [ "$RESEED" -eq 1 ] || config_seed_stale; then
-  seed_config_dir
+  seed_with_lock
 fi
 
 # Peak window 14:00-18:00 UTC+8 == 06:00-10:00 UTC (unverified for the

--- a/scripts/claude-glm.ps1
+++ b/scripts/claude-glm.ps1
@@ -320,8 +320,96 @@ function Test-ConfigSeedStale {
   }
 }
 
+# --- config-dir seed concurrency lock (HIMMEL-830) ---------------------------
+# Serialize concurrent same-lane reseeds so two launches of THIS lane cannot
+# interleave Copy-SeedConfig's remove/copy sequence into a torn config dir (the
+# .seeded sentinel guards FAILED seeds, not CONCURRENT ones). The lock is a
+# DIRECTORY sibling of $ConfigDir (NOT under it, so the seeder's own recursive
+# removes can never delete it); New-Item -ItemType Directory is atomic and throws
+# if it already exists. The dir is kept EMPTY so the release remove is atomic and
+# steal-safe. Env names + defaults + rc=4 mirror the bash twin exactly.
+$Lock            = "$ConfigDir.seed-lock"
+$SeedLockTimeout = if ($env:CLAUDE_LANE_SEED_LOCK_TIMEOUT) { [int]$env:CLAUDE_LANE_SEED_LOCK_TIMEOUT } else { 60 }   # seconds to wait
+$SeedLockStale   = if ($env:CLAUDE_LANE_SEED_LOCK_STALE) { [int]$env:CLAUDE_LANE_SEED_LOCK_STALE } else { 120 }     # seconds before a held lock is presumed abandoned
+
+function Test-SeedLockStale {
+  # $true when $Lock exists and its mtime is older than $SeedLockStale seconds.
+  if (-not (Test-Path -LiteralPath $Lock -PathType Container)) { return $false }
+  try {
+    $age = ([DateTime]::UtcNow - (Get-Item -LiteralPath $Lock).LastWriteTimeUtc).TotalSeconds
+    return ($age -ge $SeedLockStale)
+  } catch { return $false }
+}
+
+function Invoke-SeedWithLock {
+  # Acquire (New-Item dir), poll on contention, steal a stale holder, or time out (exit 4).
+  $ticks = 0
+  $maxTicks = $SeedLockTimeout * 2   # two 500ms polls per second
+  $lastAcquireErr = ''
+  while ($true) {
+    try {
+      New-Item -ItemType Directory -Path $Lock -ErrorAction Stop | Out-Null
+      break   # acquired
+    } catch {
+      $lastAcquireErr = $_.Exception.Message
+      # SINGLE-WINNER stale steal via atomic same-dir rename: only ONE waiter's
+      # Rename-Item succeeds (the path is gone for every loser, whose rename simply
+      # throws), and the winner's FRESH replacement lock can never be renamed away
+      # by a queued loser (a fresh lock is never stale). A plain remove steal is a
+      # TOCTOU double-acquire: two waiters both judge the dead lock stale, one
+      # removes+re-acquires, the other's queued remove then deletes the winner's
+      # fresh EMPTY lock, both seed concurrently -- the torn config this lock
+      # exists to prevent. The renamed dir is removed best-effort with the
+      # empty-only [IO.Directory]::Delete (rmdir parity; no -Recurse vaporizing);
+      # if it was non-empty (invariant violation) the orphan is harmless -- it is
+      # not the lock path. Accepted residual: a LIVE seeder holding the lock past
+      # $SeedLockStale gets stolen -- but seeds are sub-second copies, so a hold
+      # that long means a dead/hung holder in practice.
+      if (Test-SeedLockStale) {
+        try {
+          Rename-Item -LiteralPath $Lock -NewName ((Split-Path -Leaf $Lock) + ".stale.$PID") -ErrorAction Stop
+          try { [System.IO.Directory]::Delete("$Lock.stale.$PID") } catch { }   # orphaned .stale dir is harmless (not the lock path)
+          continue
+        } catch {
+          # not the steal winner -- fall through to poll
+        }
+      }
+      if ($ticks -ge $maxTicks) {
+        [Console]::Error.WriteLine("claude-glm: timed out after ${SeedLockTimeout}s waiting for the config-dir seed lock ($Lock). If no other claude-glm launch of this lane is seeding, remove that dir, or tune CLAUDE_LANE_SEED_LOCK_TIMEOUT / CLAUDE_LANE_SEED_LOCK_STALE; last acquire error: $lastAcquireErr")
+        exit 4
+      }
+      Start-Sleep -Milliseconds 500
+      $ticks++
+    }
+  }
+  # Release in finally so a seed failure (Copy-SeedConfig's exit 4) still frees the
+  # lock -- PowerShell runs finally blocks even when a called function calls exit.
+  # Accepted residual: an untrapped Ctrl+C / process kill while holding leaks the
+  # lock until the stale steal (~$SeedLockStale s) -- deliberate; adding signal
+  # handling would change the launcher's existing semantics.
+  try {
+    # Double-checked recheck UNDER the lock: the OUTER if was a cheap pre-check that
+    # raced other launches; a concurrent winner may have just seeded while we waited,
+    # so re-evaluate and skip a redundant reseed. -Reseed forces a reseed regardless
+    # (explicit operator intent), but still under the lock.
+    # Residual (accepted): a READER launch that judged the sentinel fresh a moment
+    # before the winner removed it can still launch claude against a mid-seed dir --
+    # the window shrinks from the full seed duration to one stat. Full reader-writer
+    # exclusion would need an atomic dir swap Windows cannot give; out of scope.
+    if ($Reseed -or (-not (Test-Path -LiteralPath (Join-Path $ConfigDir '.seeded'))) -or (Test-ConfigSeedStale)) {
+      Copy-SeedConfig
+    }
+  } finally {
+    # Empty-only release ([IO.Directory]::Delete = rmdir parity, never -Recurse:
+    # recursing would silently vaporize evidence of an invariant violation). A
+    # failure warns (worth surfacing) but stays NON-FATAL: the seed itself succeeded.
+    try { [System.IO.Directory]::Delete($Lock) }
+    catch { [Console]::Error.WriteLine("claude-glm: WARNING - failed to release seed lock $Lock (not empty or busy); it self-heals via stale steal after ${SeedLockStale}s but concurrent launches wait/time out until then.") }
+  }
+}
+
 if ((-not (Test-Path -LiteralPath (Join-Path $ConfigDir '.seeded'))) -or $Reseed -or (Test-ConfigSeedStale)) {
-  Copy-SeedConfig
+  Invoke-SeedWithLock
 }
 
 # --- off-peak annotation -----------------------------------------------------

--- a/scripts/claude-routed
+++ b/scripts/claude-routed
@@ -229,8 +229,76 @@ config_seed_stale() { # rc=0 when any tracked source is newer than the sentinel,
   return 1
 }
 
+# Concurrency lock (HIMMEL-830): serialize concurrent same-lane reseeds so two
+# launches of THIS lane cannot interleave seed_config_dir's rm/cp sequence into a
+# torn config dir (the .seeded sentinel guards FAILED seeds, not CONCURRENT ones).
+# The lock is a DIRECTORY sibling of CONFIG_DIR (NOT under it, so the seeder's own
+# rm -rf sweeps can never delete it); mkdir is atomic on every platform incl. Git
+# Bash. The dir is kept EMPTY so the rmdir release is atomic and steal-safe.
+LOCK="$CONFIG_DIR.seed-lock"
+SEED_LOCK_TIMEOUT="${CLAUDE_LANE_SEED_LOCK_TIMEOUT:-60}"   # seconds to wait before giving up
+SEED_LOCK_STALE="${CLAUDE_LANE_SEED_LOCK_STALE:-120}"      # seconds after which a held lock is presumed abandoned
+
+seed_lock_is_stale() { # rc=0 when LOCK exists and its mtime is older than SEED_LOCK_STALE seconds
+  [ -d "$LOCK" ] || return 1
+  # GNU stat form first (Linux + Git Bash), BSD form fallback (macOS).
+  lock_mt="$(stat -c %Y "$LOCK" 2>/dev/null || stat -f %m "$LOCK" 2>/dev/null)"
+  [ -n "$lock_mt" ] || return 1
+  [ "$(( $(date +%s) - lock_mt ))" -ge "$SEED_LOCK_STALE" ]
+}
+
+seed_with_lock() {
+  # Acquire (mkdir), poll on contention, steal a stale holder, or time out (exit 4).
+  seed_lock_ticks=0
+  seed_lock_max=$(( SEED_LOCK_TIMEOUT * 2 ))   # two 0.5s polls per second
+  while ! mkdir_err="$(mkdir "$LOCK" 2>&1)"; do
+    # SINGLE-WINNER stale steal via atomic same-dir rename: only ONE waiter's mv
+    # succeeds (the path is gone for every loser, whose mv simply fails), and the
+    # winner's FRESH replacement lock can never be renamed away by a queued loser
+    # (a fresh lock is never stale). A plain rmdir steal is a TOCTOU double-acquire:
+    # two waiters both judge the dead lock stale, one rmdirs+re-acquires, the
+    # other's queued rmdir then deletes the winner's fresh EMPTY lock, both seed
+    # concurrently -- the torn config this lock exists to prevent. The renamed dir
+    # is removed best-effort; if it was non-empty (invariant violation) the orphan
+    # is harmless -- it is not the lock path. Accepted residual: a LIVE seeder
+    # holding the lock past SEED_LOCK_STALE gets stolen -- but seeds are sub-second
+    # copies, so a hold that long means a dead/hung holder in practice.
+    if seed_lock_is_stale && mv "$LOCK" "$LOCK.stale.$$" 2>/dev/null; then
+      rmdir "$LOCK.stale.$$" 2>/dev/null || true   # orphaned .stale dir is harmless (not the lock path)
+      continue
+    fi
+    if [ "$seed_lock_ticks" -ge "$seed_lock_max" ]; then
+      echo "claude-routed: timed out after ${SEED_LOCK_TIMEOUT}s waiting for the config-dir seed lock ($LOCK). If no other claude-routed launch of this lane is seeding, remove that dir, or tune CLAUDE_LANE_SEED_LOCK_TIMEOUT / CLAUDE_LANE_SEED_LOCK_STALE; last mkdir error: $mkdir_err" >&2
+      exit 4
+    fi
+    sleep 0.5
+    seed_lock_ticks=$(( seed_lock_ticks + 1 ))
+  done
+  # Release the lock on ANY exit while held (covers seed_fail's exit 4 path). This
+  # trap release stays best-effort SILENT -- the exit path already carries its own
+  # error. Accepted residual: an untrapped SIGINT/SIGTERM while holding leaks the
+  # lock until the stale steal (~SEED_LOCK_STALE s) -- deliberate; adding INT/TERM
+  # traps would change the launcher's existing signal semantics.
+  trap 'rmdir "$LOCK" 2>/dev/null' EXIT
+  # Double-checked recheck UNDER the lock: the OUTER if was a cheap pre-check that
+  # raced other launches; a concurrent winner may have just seeded while we waited,
+  # so re-evaluate the same condition and skip a redundant reseed. RESEED=1 forces a
+  # reseed regardless (explicit operator intent), but still under the lock.
+  # Residual (accepted): a READER launch that judged the sentinel fresh a moment
+  # before the winner removed it can still exec claude against a mid-seed dir -- the
+  # window shrinks from the full seed duration to one stat. Full reader-writer
+  # exclusion would need an atomic dir swap Windows cannot give; out of scope.
+  if [ "$RESEED" -eq 1 ] || [ ! -f "$CONFIG_DIR/.seeded" ] || config_seed_stale; then
+    seed_config_dir
+  fi
+  trap - EXIT
+  # Explicit release warns on failure (a non-empty/busy lock is an invariant
+  # violation worth surfacing) but stays NON-FATAL: the seed itself succeeded.
+  rmdir "$LOCK" 2>/dev/null || echo "claude-routed: WARNING - failed to release seed lock $LOCK (not empty or busy); it self-heals via stale steal after ${SEED_LOCK_STALE}s but concurrent launches wait/time out until then." >&2
+}
+
 if [ ! -f "$CONFIG_DIR/.seeded" ] || [ "$RESEED" -eq 1 ] || config_seed_stale; then
-  seed_config_dir
+  seed_with_lock
 fi
 
 # Peak window 14:00-18:00 UTC+8 == 06:00-10:00 UTC (unverified for the

--- a/scripts/claude-routed.ps1
+++ b/scripts/claude-routed.ps1
@@ -327,8 +327,96 @@ function Test-ConfigSeedStale {
   }
 }
 
+# --- config-dir seed concurrency lock (HIMMEL-830) ---------------------------
+# Serialize concurrent same-lane reseeds so two launches of THIS lane cannot
+# interleave Copy-SeedConfig's remove/copy sequence into a torn config dir (the
+# .seeded sentinel guards FAILED seeds, not CONCURRENT ones). The lock is a
+# DIRECTORY sibling of $ConfigDir (NOT under it, so the seeder's own recursive
+# removes can never delete it); New-Item -ItemType Directory is atomic and throws
+# if it already exists. The dir is kept EMPTY so the release remove is atomic and
+# steal-safe. Env names + defaults + rc=4 mirror the bash twin exactly.
+$Lock            = "$ConfigDir.seed-lock"
+$SeedLockTimeout = if ($env:CLAUDE_LANE_SEED_LOCK_TIMEOUT) { [int]$env:CLAUDE_LANE_SEED_LOCK_TIMEOUT } else { 60 }   # seconds to wait
+$SeedLockStale   = if ($env:CLAUDE_LANE_SEED_LOCK_STALE) { [int]$env:CLAUDE_LANE_SEED_LOCK_STALE } else { 120 }     # seconds before a held lock is presumed abandoned
+
+function Test-SeedLockStale {
+  # $true when $Lock exists and its mtime is older than $SeedLockStale seconds.
+  if (-not (Test-Path -LiteralPath $Lock -PathType Container)) { return $false }
+  try {
+    $age = ([DateTime]::UtcNow - (Get-Item -LiteralPath $Lock).LastWriteTimeUtc).TotalSeconds
+    return ($age -ge $SeedLockStale)
+  } catch { return $false }
+}
+
+function Invoke-SeedWithLock {
+  # Acquire (New-Item dir), poll on contention, steal a stale holder, or time out (exit 4).
+  $ticks = 0
+  $maxTicks = $SeedLockTimeout * 2   # two 500ms polls per second
+  $lastAcquireErr = ''
+  while ($true) {
+    try {
+      New-Item -ItemType Directory -Path $Lock -ErrorAction Stop | Out-Null
+      break   # acquired
+    } catch {
+      $lastAcquireErr = $_.Exception.Message
+      # SINGLE-WINNER stale steal via atomic same-dir rename: only ONE waiter's
+      # Rename-Item succeeds (the path is gone for every loser, whose rename simply
+      # throws), and the winner's FRESH replacement lock can never be renamed away
+      # by a queued loser (a fresh lock is never stale). A plain remove steal is a
+      # TOCTOU double-acquire: two waiters both judge the dead lock stale, one
+      # removes+re-acquires, the other's queued remove then deletes the winner's
+      # fresh EMPTY lock, both seed concurrently -- the torn config this lock
+      # exists to prevent. The renamed dir is removed best-effort with the
+      # empty-only [IO.Directory]::Delete (rmdir parity; no -Recurse vaporizing);
+      # if it was non-empty (invariant violation) the orphan is harmless -- it is
+      # not the lock path. Accepted residual: a LIVE seeder holding the lock past
+      # $SeedLockStale gets stolen -- but seeds are sub-second copies, so a hold
+      # that long means a dead/hung holder in practice.
+      if (Test-SeedLockStale) {
+        try {
+          Rename-Item -LiteralPath $Lock -NewName ((Split-Path -Leaf $Lock) + ".stale.$PID") -ErrorAction Stop
+          try { [System.IO.Directory]::Delete("$Lock.stale.$PID") } catch { }   # orphaned .stale dir is harmless (not the lock path)
+          continue
+        } catch {
+          # not the steal winner -- fall through to poll
+        }
+      }
+      if ($ticks -ge $maxTicks) {
+        [Console]::Error.WriteLine("claude-routed: timed out after ${SeedLockTimeout}s waiting for the config-dir seed lock ($Lock). If no other claude-routed launch of this lane is seeding, remove that dir, or tune CLAUDE_LANE_SEED_LOCK_TIMEOUT / CLAUDE_LANE_SEED_LOCK_STALE; last acquire error: $lastAcquireErr")
+        exit 4
+      }
+      Start-Sleep -Milliseconds 500
+      $ticks++
+    }
+  }
+  # Release in finally so a seed failure (Copy-SeedConfig's exit 4) still frees the
+  # lock -- PowerShell runs finally blocks even when a called function calls exit.
+  # Accepted residual: an untrapped Ctrl+C / process kill while holding leaks the
+  # lock until the stale steal (~$SeedLockStale s) -- deliberate; adding signal
+  # handling would change the launcher's existing semantics.
+  try {
+    # Double-checked recheck UNDER the lock: the OUTER if was a cheap pre-check that
+    # raced other launches; a concurrent winner may have just seeded while we waited,
+    # so re-evaluate and skip a redundant reseed. -Reseed forces a reseed regardless
+    # (explicit operator intent), but still under the lock.
+    # Residual (accepted): a READER launch that judged the sentinel fresh a moment
+    # before the winner removed it can still launch claude against a mid-seed dir --
+    # the window shrinks from the full seed duration to one stat. Full reader-writer
+    # exclusion would need an atomic dir swap Windows cannot give; out of scope.
+    if ($Reseed -or (-not (Test-Path -LiteralPath (Join-Path $ConfigDir '.seeded'))) -or (Test-ConfigSeedStale)) {
+      Copy-SeedConfig
+    }
+  } finally {
+    # Empty-only release ([IO.Directory]::Delete = rmdir parity, never -Recurse:
+    # recursing would silently vaporize evidence of an invariant violation). A
+    # failure warns (worth surfacing) but stays NON-FATAL: the seed itself succeeded.
+    try { [System.IO.Directory]::Delete($Lock) }
+    catch { [Console]::Error.WriteLine("claude-routed: WARNING - failed to release seed lock $Lock (not empty or busy); it self-heals via stale steal after ${SeedLockStale}s but concurrent launches wait/time out until then.") }
+  }
+}
+
 if ((-not (Test-Path -LiteralPath (Join-Path $ConfigDir '.seeded'))) -or $Reseed -or (Test-ConfigSeedStale)) {
-  Copy-SeedConfig
+  Invoke-SeedWithLock
 }
 
 # --- off-peak annotation -----------------------------------------------------

--- a/scripts/test-claude-glm.ps1
+++ b/scripts/test-claude-glm.ps1
@@ -487,6 +487,55 @@ try {
   Assert-Exit (Invoke-Launcher) 0 'deleted source CLAUDE.md triggers a mirror reseed'
   if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\CLAUDE.md')) { Fail 'stale CLAUDE.md survived source deletion' } else { Pass 'stale CLAUDE.md removed (leaf deletion mirrored)' }
 
+  # --- T27 (HIMMEL-830): a FRESH held seed lock makes a launch that needs seeding
+  # time out with exit 4, a message naming the lock path, and the held lock LEFT
+  # intact (we must not delete a fresh holder's lock on timeout). Lock is a SIBLING
+  # of the config dir. TIMEOUT=1 keeps the deterministic wait ~1s. ---
+  New-Sandbox; $script:KEY = 'zai-test-123'  # gitleaks:allow
+  New-Item -ItemType Directory -Force -Path (Join-Path $FAKEHOME '.claude-glm.seed-lock') | Out-Null
+  $env:CLAUDE_LANE_SEED_LOCK_TIMEOUT = '1'
+  Assert-Exit (Invoke-Launcher) 4 'held fresh seed lock times out (exit 4)'
+  Remove-Item Env:CLAUDE_LANE_SEED_LOCK_TIMEOUT
+  if (FileHas $OutTxt '.claude-glm.seed-lock') { Pass 'timeout message names the lock path' } else { Fail 'timeout message does not name the lock path' }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm.seed-lock')) { Pass 'fresh held lock left intact on timeout' } else { Fail 'fresh held lock removed on timeout' }
+
+  # --- T28 (HIMMEL-830): a STALE held lock (mtime far in the past) is stolen, the
+  # seed proceeds, the launch exits 0, and the lock is released (no residue). ---
+  New-Sandbox; $script:KEY = 'zai-test-123'  # gitleaks:allow
+  $lockDir = Join-Path $FAKEHOME '.claude-glm.seed-lock'
+  New-Item -ItemType Directory -Force -Path $lockDir | Out-Null
+  (Get-Item -LiteralPath $lockDir).LastWriteTimeUtc = [datetime]'2020-01-01'   # older than the 120s default stale window
+  Assert-Exit (Invoke-Launcher) 0 'stale seed lock is stolen and seed proceeds'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\.seeded')) { Pass 'seed completed after stealing stale lock' } else { Fail 'seed did not complete after stealing stale lock' }
+  if (Test-Path -LiteralPath $lockDir) { Fail 'stale lock not released after seed' } else { Pass 'stale lock released after seed' }
+
+  # --- T29 (HIMMEL-830, best-effort concurrency smoke): two simultaneous first-launch
+  # seeders of the same lane both exit 0, leave a consistent config (sentinel present),
+  # and leave no lock residue. The lock serializes them; the loser's recheck skips. This
+  # also exercises the double-checked recheck path (the second acquirer finds a fresh
+  # sentinel and skips). NOTE (deviation): the dedicated canary recheck-skip test lives
+  # in the two bash suites only; here the concurrency smoke covers the recheck path. ---
+  New-Sandbox; $script:KEY = 'zai-test-123'  # gitleaks:allow
+  $env:ZAI_API_KEY            = $script:KEY
+  $env:USERPROFILE            = $FAKEHOME
+  $env:CLAUDE_GLM_DOTENV_ROOT = $WORK
+  $env:MOCK_ENV_OUT           = $ChildEnv
+  $env:MOCK_ARGV_OUT          = $ArgvOut
+  $env:PATH = $BIN + [IO.Path]::PathSeparator + $OrigEnv['PATH']
+  $pa = Start-Process pwsh -ArgumentList @('-NoProfile', '-File', $Launcher) -WorkingDirectory $WORK -PassThru
+  $pb = Start-Process pwsh -ArgumentList @('-NoProfile', '-File', $Launcher) -WorkingDirectory $WORK -PassThru
+  $pa.WaitForExit(); $pb.WaitForExit()
+  if ($pa.ExitCode -eq 0 -and $pb.ExitCode -eq 0) { Pass 'both concurrent launches exit 0' } else { Fail "concurrent launches exit A=$($pa.ExitCode) B=$($pb.ExitCode)" }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\.seeded')) { Pass 'concurrent seed left a sentinel' } else { Fail 'concurrent seed left no sentinel' }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm.seed-lock')) { Fail 'concurrent launch left lock residue' } else { Pass 'no lock residue after concurrent launches' }
+
+  # DEVIATION (HIMMEL-830 CR r1): the bash suites' release-failure test (intruder file
+  # planted inside the held lock -> non-fatal WARNING, lock left intact) is bash-only.
+  # The honest construction needs a slow-but-SUCCEEDING node shim, and a node.cmd batch
+  # shim cannot receive the launcher's multi-line `-e <script>` argument (cmd mangles
+  # embedded newlines); the .ps1-shim precedence workaround is fragile. The release
+  # code path itself is shared and covered by the bash twins.
+
   Write-Host ''
   if ($script:fails -eq 0) { Write-Host 'ALL PASS' } else { Write-Host "$($script:fails) failure(s)" -ForegroundColor Red; exit 1 }
 }

--- a/scripts/test-claude-glm.sh
+++ b/scripts/test-claude-glm.sh
@@ -390,4 +390,84 @@ rm -f "$FAKEHOME/.claude/CLAUDE.md"   # SOURCE deleted
 t "deleted source CLAUDE.md triggers a mirror reseed" 0
 [ ! -f "$FAKEHOME/.claude-glm/CLAUDE.md" ] || { echo "FAIL: stale CLAUDE.md survived source deletion"; FAILS=$((FAILS+1)); }
 
+# --- T28 (HIMMEL-830): a FRESH held seed lock makes a launch that needs seeding
+# time out with exit 4, a message naming the lock path, and the held lock LEFT
+# intact (we must not delete a fresh holder's lock on timeout). Lock is a SIBLING
+# of the config dir. TIMEOUT=1 keeps the deterministic wait ~1s.
+setup; KEY="zai-test-123"
+mkdir -p "$FAKEHOME/.claude-glm.seed-lock"        # fresh-mtime held lock, held by nobody
+export CLAUDE_LANE_SEED_LOCK_TIMEOUT=1
+t "held fresh seed lock times out (exit 4)" 4
+unset CLAUDE_LANE_SEED_LOCK_TIMEOUT
+grep -qF ".claude-glm.seed-lock" "$WORK/out.txt" || { echo "FAIL: timeout message does not name the lock path"; FAILS=$((FAILS+1)); }
+[ -d "$FAKEHOME/.claude-glm.seed-lock" ] || { echo "FAIL: fresh held lock removed on timeout"; FAILS=$((FAILS+1)); }
+
+# --- T29 (HIMMEL-830): a STALE held lock (mtime far in the past) is stolen, the
+# seed proceeds, the launch exits 0, and the lock is released (no residue).
+setup; KEY="zai-test-123"
+mkdir -p "$FAKEHOME/.claude-glm.seed-lock"
+touch -t 202001010000 "$FAKEHOME/.claude-glm.seed-lock"   # older than the 120s default stale window
+t "stale seed lock is stolen and seed proceeds" 0
+[ -f "$FAKEHOME/.claude-glm/.seeded" ] || { echo "FAIL: seed did not complete after stealing stale lock"; FAILS=$((FAILS+1)); }
+[ ! -d "$FAKEHOME/.claude-glm.seed-lock" ] || { echo "FAIL: stale lock not released after seed"; FAILS=$((FAILS+1)); }
+
+# --- T30 (HIMMEL-830): the double-checked recheck UNDER the lock skips a redundant
+# reseed when a concurrent winner already seeded while we waited. Deterministic by
+# construction (no timing reliance): a background holder writes the sentinel THEN
+# releases the lock, so by the moment our launcher can acquire, the recheck condition
+# is already FALSE. A dest-only canary that a reseed's rm -rf would drop must SURVIVE.
+setup; KEY="zai-test-123"
+mkdir -p "$FAKEHOME/.claude/commands"
+printf 'real' > "$FAKEHOME/.claude/commands/real.md"
+t "seed before recheck-skip simulation" 0
+printf 'canary' > "$FAKEHOME/.claude-glm/commands/canary.md"   # dest-only; a reseed would drop it
+rm -f "$FAKEHOME/.claude-glm/.seeded"                          # make the OUTER pre-check fire (sentinel missing)
+find "$FAKEHOME/.claude" -exec touch -t 202001010000 {} + 2>/dev/null   # age ALL sources so a fresh sentinel reads not-stale
+mkdir -p "$FAKEHOME/.claude-glm.seed-lock"                     # a "winner" is holding the lock
+( sleep 1; : > "$FAKEHOME/.claude-glm/.seeded"; rmdir "$FAKEHOME/.claude-glm.seed-lock" ) &   # winner finishes its seed then releases
+winpid=$!
+t "recheck under lock skips redundant reseed" 0
+wait "$winpid" 2>/dev/null
+[ -f "$FAKEHOME/.claude-glm/commands/canary.md" ] || { echo "FAIL: recheck did not skip -- canary dropped by a redundant reseed"; FAILS=$((FAILS+1)); }
+[ ! -d "$FAKEHOME/.claude-glm.seed-lock" ] || { echo "FAIL: lock residue after recheck-skip launch"; FAILS=$((FAILS+1)); }
+
+# --- T31 (HIMMEL-830, best-effort concurrency smoke): two simultaneous first-launch
+# seeders of the same lane both exit 0, leave a consistent config (sentinel present),
+# and leave no lock residue. The lock serializes them; the loser's recheck skips.
+setup; KEY="zai-test-123"
+( cd "$WORK" && HOME="$FAKEHOME" PATH="$BIN:$PATH" ZAI_API_KEY="$KEY" CLAUDE_GLM_DOTENV_ROOT="$WORK" \
+    bash "$LAUNCHER" >"$WORK/out-a.txt" 2>&1 ) &
+cpid=$!
+( cd "$WORK" && HOME="$FAKEHOME" PATH="$BIN:$PATH" ZAI_API_KEY="$KEY" CLAUDE_GLM_DOTENV_ROOT="$WORK" \
+    bash "$LAUNCHER" >"$WORK/out-b.txt" 2>&1 )
+brc=$?
+wait "$cpid"; arc=$?
+[ "$arc" -eq 0 ] || { echo "FAIL: concurrent launch A exit $arc"; cat "$WORK/out-a.txt"; FAILS=$((FAILS+1)); }
+[ "$brc" -eq 0 ] || { echo "FAIL: concurrent launch B exit $brc"; cat "$WORK/out-b.txt"; FAILS=$((FAILS+1)); }
+[ -f "$FAKEHOME/.claude-glm/.seeded" ] || { echo "FAIL: concurrent seed left no sentinel"; FAILS=$((FAILS+1)); }
+[ ! -d "$FAKEHOME/.claude-glm.seed-lock" ] || { echo "FAIL: concurrent launch left lock residue"; FAILS=$((FAILS+1)); }
+
+# --- T32 (HIMMEL-830 CR r1): a lock that cannot be released (a file appeared inside
+# it while the seeder held it) is NON-FATAL -- the launch still exits 0 and a WARNING
+# names the lock; the non-empty lock is LEFT for the stale steal to self-heal (its
+# contents are evidence, never vaporized). Honest construction: a slow node shim (the
+# sanitize step) keeps the seeder holding the lock ~1s while a background subshell
+# plants an intruder file the moment the lock dir appears.
+setup; KEY="zai-test-123"
+cat > "$BIN/node" <<'NODESHIM'
+#!/usr/bin/env bash
+# slow "sanitize": argv is -e <script> <src> <dest>; plain copy is fine here (this
+# test asserts lock-release behaviour, not sanitization).
+sleep 1
+cp "$3" "$4"
+NODESHIM
+chmod +x "$BIN/node"
+( while [ ! -d "$FAKEHOME/.claude-glm.seed-lock" ]; do sleep 0.05; done
+  touch "$FAKEHOME/.claude-glm.seed-lock/intruder" ) &
+plpid=$!
+t "release failure is non-fatal (exit 0)" 0
+wait "$plpid" 2>/dev/null
+grep -q "WARNING - failed to release seed lock" "$WORK/out.txt" || { echo "FAIL: no release-failure warning emitted"; FAILS=$((FAILS+1)); }
+[ -d "$FAKEHOME/.claude-glm.seed-lock" ] || { echo "FAIL: non-empty lock unexpectedly removed on release"; FAILS=$((FAILS+1)); }
+
 echo; [ "$FAILS" -eq 0 ] && echo "ALL PASS" || { echo "$FAILS failure(s)"; exit 1; }

--- a/scripts/test-claude-routed.ps1
+++ b/scripts/test-claude-routed.ps1
@@ -461,6 +461,56 @@ try {
   Assert-Exit (Invoke-Launcher) 0 'deleted source CLAUDE.md triggers a mirror reseed'
   if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\CLAUDE.md')) { Fail 'stale CLAUDE.md survived source deletion' } else { Pass 'stale CLAUDE.md removed (leaf deletion mirrored)' }
 
+  # --- T25 (HIMMEL-830): a FRESH held seed lock makes a launch that needs seeding
+  # time out with exit 4, a message naming the lock path, and the held lock LEFT
+  # intact (we must not delete a fresh holder's lock on timeout). Lock is a SIBLING
+  # of the config dir. TIMEOUT=1 keeps the deterministic wait ~1s. ---
+  New-Sandbox; $script:KEY = 'omni-test-123'  # gitleaks:allow
+  New-Item -ItemType Directory -Force -Path (Join-Path $FAKEHOME '.claude-routed.seed-lock') | Out-Null
+  $env:CLAUDE_LANE_SEED_LOCK_TIMEOUT = '1'
+  Assert-Exit (Invoke-Launcher) 4 'held fresh seed lock times out (exit 4)'
+  Remove-Item Env:CLAUDE_LANE_SEED_LOCK_TIMEOUT
+  if (FileHas $OutTxt '.claude-routed.seed-lock') { Pass 'timeout message names the lock path' } else { Fail 'timeout message does not name the lock path' }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed.seed-lock')) { Pass 'fresh held lock left intact on timeout' } else { Fail 'fresh held lock removed on timeout' }
+
+  # --- T26 (HIMMEL-830): a STALE held lock (mtime far in the past) is stolen, the
+  # seed proceeds, the launch exits 0, and the lock is released (no residue). ---
+  New-Sandbox; $script:KEY = 'omni-test-123'  # gitleaks:allow
+  $lockDir = Join-Path $FAKEHOME '.claude-routed.seed-lock'
+  New-Item -ItemType Directory -Force -Path $lockDir | Out-Null
+  (Get-Item -LiteralPath $lockDir).LastWriteTimeUtc = [datetime]'2020-01-01'   # older than the 120s default stale window
+  Assert-Exit (Invoke-Launcher) 0 'stale seed lock is stolen and seed proceeds'
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\.seeded')) { Pass 'seed completed after stealing stale lock' } else { Fail 'seed did not complete after stealing stale lock' }
+  if (Test-Path -LiteralPath $lockDir) { Fail 'stale lock not released after seed' } else { Pass 'stale lock released after seed' }
+
+  # --- T27 (HIMMEL-830, best-effort concurrency smoke): two simultaneous first-launch
+  # seeders of the same lane both exit 0, leave a consistent config (sentinel present),
+  # and leave no lock residue. The lock serializes them; the loser's recheck skips. This
+  # also exercises the double-checked recheck path (the second acquirer finds a fresh
+  # sentinel and skips). NOTE (deviation): the dedicated canary recheck-skip test lives
+  # in the two bash suites only; here the concurrency smoke covers the recheck path. ---
+  New-Sandbox; $script:KEY = 'omni-test-123'  # gitleaks:allow
+  $env:OMNIROUTE_API_KEY         = $script:KEY
+  $env:USERPROFILE               = $FAKEHOME
+  $env:CLAUDE_ROUTED_DOTENV_ROOT = $WORK
+  $env:MOCK_ENV_OUT              = $ChildEnv
+  $env:MOCK_ARGV_OUT             = $ArgvOut
+  Remove-Item Env:OMNIROUTE_PORT -ErrorAction SilentlyContinue
+  $env:PATH = $BIN + [IO.Path]::PathSeparator + $OrigEnv['PATH']
+  $pa = Start-Process pwsh -ArgumentList @('-NoProfile', '-File', $Launcher) -WorkingDirectory $WORK -PassThru
+  $pb = Start-Process pwsh -ArgumentList @('-NoProfile', '-File', $Launcher) -WorkingDirectory $WORK -PassThru
+  $pa.WaitForExit(); $pb.WaitForExit()
+  if ($pa.ExitCode -eq 0 -and $pb.ExitCode -eq 0) { Pass 'both concurrent launches exit 0' } else { Fail "concurrent launches exit A=$($pa.ExitCode) B=$($pb.ExitCode)" }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\.seeded')) { Pass 'concurrent seed left a sentinel' } else { Fail 'concurrent seed left no sentinel' }
+  if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed.seed-lock')) { Fail 'concurrent launch left lock residue' } else { Pass 'no lock residue after concurrent launches' }
+
+  # DEVIATION (HIMMEL-830 CR r1): the bash suites' release-failure test (intruder file
+  # planted inside the held lock -> non-fatal WARNING, lock left intact) is bash-only.
+  # The honest construction needs a slow-but-SUCCEEDING node shim, and a node.cmd batch
+  # shim cannot receive the launcher's multi-line `-e <script>` argument (cmd mangles
+  # embedded newlines); the .ps1-shim precedence workaround is fragile. The release
+  # code path itself is shared and covered by the bash twins.
+
   Write-Host ''
   if ($script:fails -eq 0) { Write-Host 'ALL PASS' } else { Write-Host "$($script:fails) failure(s)" -ForegroundColor Red; exit 1 }
 }

--- a/scripts/test-claude-routed.sh
+++ b/scripts/test-claude-routed.sh
@@ -374,4 +374,86 @@ rm -f "$FAKEHOME/.claude/CLAUDE.md"   # SOURCE deleted
 t "deleted source CLAUDE.md triggers a mirror reseed" 0
 [ ! -f "$FAKEHOME/.claude-routed/CLAUDE.md" ] || { echo "FAIL: stale CLAUDE.md survived source deletion"; FAILS=$((FAILS+1)); }
 
+# --- T27 (HIMMEL-830): a FRESH held seed lock makes a launch that needs seeding
+# time out with exit 4, a message naming the lock path, and the held lock LEFT
+# intact (we must not delete a fresh holder's lock on timeout). Lock is a SIBLING
+# of the config dir. TIMEOUT=1 keeps the deterministic wait ~1s.
+setup; KEY="omni-test-123"
+mkdir -p "$FAKEHOME/.claude-routed.seed-lock"        # fresh-mtime held lock, held by nobody
+export CLAUDE_LANE_SEED_LOCK_TIMEOUT=1
+t "held fresh seed lock times out (exit 4)" 4
+unset CLAUDE_LANE_SEED_LOCK_TIMEOUT
+grep -qF ".claude-routed.seed-lock" "$WORK/out.txt" || { echo "FAIL: timeout message does not name the lock path"; FAILS=$((FAILS+1)); }
+[ -d "$FAKEHOME/.claude-routed.seed-lock" ] || { echo "FAIL: fresh held lock removed on timeout"; FAILS=$((FAILS+1)); }
+
+# --- T28 (HIMMEL-830): a STALE held lock (mtime far in the past) is stolen, the
+# seed proceeds, the launch exits 0, and the lock is released (no residue).
+setup; KEY="omni-test-123"
+mkdir -p "$FAKEHOME/.claude-routed.seed-lock"
+touch -t 202001010000 "$FAKEHOME/.claude-routed.seed-lock"   # older than the 120s default stale window
+t "stale seed lock is stolen and seed proceeds" 0
+[ -f "$FAKEHOME/.claude-routed/.seeded" ] || { echo "FAIL: seed did not complete after stealing stale lock"; FAILS=$((FAILS+1)); }
+[ ! -d "$FAKEHOME/.claude-routed.seed-lock" ] || { echo "FAIL: stale lock not released after seed"; FAILS=$((FAILS+1)); }
+
+# --- T29 (HIMMEL-830): the double-checked recheck UNDER the lock skips a redundant
+# reseed when a concurrent winner already seeded while we waited. Deterministic by
+# construction (no timing reliance): a background holder writes the sentinel THEN
+# releases the lock, so by the moment our launcher can acquire, the recheck condition
+# is already FALSE. A dest-only canary that a reseed's rm -rf would drop must SURVIVE.
+setup; KEY="omni-test-123"
+mkdir -p "$FAKEHOME/.claude/commands"
+printf 'real' > "$FAKEHOME/.claude/commands/real.md"
+t "seed before recheck-skip simulation" 0
+printf 'canary' > "$FAKEHOME/.claude-routed/commands/canary.md"   # dest-only; a reseed would drop it
+rm -f "$FAKEHOME/.claude-routed/.seeded"                          # make the OUTER pre-check fire (sentinel missing)
+find "$FAKEHOME/.claude" -exec touch -t 202001010000 {} + 2>/dev/null   # age ALL sources so a fresh sentinel reads not-stale
+mkdir -p "$FAKEHOME/.claude-routed.seed-lock"                     # a "winner" is holding the lock
+( sleep 1; : > "$FAKEHOME/.claude-routed/.seeded"; rmdir "$FAKEHOME/.claude-routed.seed-lock" ) &   # winner finishes its seed then releases
+winpid=$!
+t "recheck under lock skips redundant reseed" 0
+wait "$winpid" 2>/dev/null
+[ -f "$FAKEHOME/.claude-routed/commands/canary.md" ] || { echo "FAIL: recheck did not skip -- canary dropped by a redundant reseed"; FAILS=$((FAILS+1)); }
+[ ! -d "$FAKEHOME/.claude-routed.seed-lock" ] || { echo "FAIL: lock residue after recheck-skip launch"; FAILS=$((FAILS+1)); }
+
+# --- T30 (HIMMEL-830, best-effort concurrency smoke): two simultaneous first-launch
+# seeders of the same lane both exit 0, leave a consistent config (sentinel present),
+# and leave no lock residue. The lock serializes them; the loser's recheck skips.
+setup; KEY="omni-test-123"
+( cd "$WORK" && HOME="$FAKEHOME" PATH="$BIN:$PATH" OMNIROUTE_API_KEY="$KEY" \
+    CLAUDE_ROUTED_DOTENV_ROOT="$WORK" OMNIROUTE_PORT="${PORT-}" \
+    bash "$LAUNCHER" >"$WORK/out-a.txt" 2>&1 ) &
+cpid=$!
+( cd "$WORK" && HOME="$FAKEHOME" PATH="$BIN:$PATH" OMNIROUTE_API_KEY="$KEY" \
+    CLAUDE_ROUTED_DOTENV_ROOT="$WORK" OMNIROUTE_PORT="${PORT-}" \
+    bash "$LAUNCHER" >"$WORK/out-b.txt" 2>&1 )
+brc=$?
+wait "$cpid"; arc=$?
+[ "$arc" -eq 0 ] || { echo "FAIL: concurrent launch A exit $arc"; cat "$WORK/out-a.txt"; FAILS=$((FAILS+1)); }
+[ "$brc" -eq 0 ] || { echo "FAIL: concurrent launch B exit $brc"; cat "$WORK/out-b.txt"; FAILS=$((FAILS+1)); }
+[ -f "$FAKEHOME/.claude-routed/.seeded" ] || { echo "FAIL: concurrent seed left no sentinel"; FAILS=$((FAILS+1)); }
+[ ! -d "$FAKEHOME/.claude-routed.seed-lock" ] || { echo "FAIL: concurrent launch left lock residue"; FAILS=$((FAILS+1)); }
+
+# --- T31 (HIMMEL-830 CR r1): a lock that cannot be released (a file appeared inside
+# it while the seeder held it) is NON-FATAL -- the launch still exits 0 and a WARNING
+# names the lock; the non-empty lock is LEFT for the stale steal to self-heal (its
+# contents are evidence, never vaporized). Honest construction: a slow node shim (the
+# sanitize step) keeps the seeder holding the lock ~1s while a background subshell
+# plants an intruder file the moment the lock dir appears.
+setup; KEY="omni-test-123"
+cat > "$BIN/node" <<'NODESHIM'
+#!/usr/bin/env bash
+# slow "sanitize": argv is -e <script> <src> <dest>; plain copy is fine here (this
+# test asserts lock-release behaviour, not sanitization).
+sleep 1
+cp "$3" "$4"
+NODESHIM
+chmod +x "$BIN/node"
+( while [ ! -d "$FAKEHOME/.claude-routed.seed-lock" ]; do sleep 0.05; done
+  touch "$FAKEHOME/.claude-routed.seed-lock/intruder" ) &
+plpid=$!
+t "release failure is non-fatal (exit 0)" 0
+wait "$plpid" 2>/dev/null
+grep -q "WARNING - failed to release seed lock" "$WORK/out.txt" || { echo "FAIL: no release-failure warning emitted"; FAILS=$((FAILS+1)); }
+[ -d "$FAKEHOME/.claude-routed.seed-lock" ] || { echo "FAIL: non-empty lock unexpectedly removed on release"; FAILS=$((FAILS+1)); }
+
 echo; [ "$FAILS" -eq 0 ] && echo "ALL PASS" || { echo "$FAILS failure(s)"; exit 1; }


### PR DESCRIPTION
## Summary

Serialize concurrent same-lane reseeds with a per-config mkdir lock, in all four launcher twins (`scripts/claude-glm`, `scripts/claude-routed`, `scripts/claude-glm.ps1`, `scripts/claude-routed.ps1`) — HIMMEL-830, epic HIMMEL-654.

Two sessions launching the same lane concurrently could both detect a stale/missing seed and both reseed, racing each other's writes. Acquisition is `mkdir` (atomic on all supported platforms); release via EXIT trap (sh) / `finally` (ps1); bounded wait with exit 4 on timeout.

## CR trail

- Round 1 (Opus code-reviewer + silent-failure hunter; panel qwen-only clean): 1 REAL Important — stale-steal TOCTOU double-acquire (the loser's `rmdir` could delete the winner's FRESH lock → both seed) + diagnosability gaps (silent release failure, undiagnosed mkdir errors, ps1 `-Recurse` divergence).
- Fix commit 124112f4: single-winner steal via mv-rename (rename atomicity guarantees exactly one winner; the loser's cleanup can only ever touch its own `.stale.$$` target), release/acquire warnings, `-Recurse` drop, release-failure test (T32), SIGINT-residual doc note. All 4 suites pass, shellcheck clean, sh/ps1 parity verified.
- Verify round (Opus code-reviewer, fresh context): **SHIP — 0 Critical / 0 Important.** Race walked end-to-end (two-waiter steal, late-arrival gap, non-empty-lock self-heal, MSYS/Windows rename portability); sh↔ps1 semantic parity confirmed byte-identical modulo lane name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
