### PR TITLE
feat(luna): [HIMMEL-832] fold-chat-history — provider chat-history importer (ChatGPT export -> luna chats/)

### DIFF
--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -637,7 +637,7 @@ Shell scripts that run as pre-commit / pre-push gates (wired in `.pre-commit-con
 
 ## Luna Scripts (`scripts/luna/`)
 
-Shell scripts for luna vault maintenance and session import. Operator-invoked
+Scripts for luna vault maintenance and session import. Operator-invoked
 on demand; nothing here runs automatically.
 
 - `scripts/luna/backfill-sessions.sh` — Render historical Claude session
@@ -661,6 +661,7 @@ on demand; nothing here runs automatically.
   `backfill-sessions.sh --reheal`/`--recrystallize`. Fail-open (no `claude` / over the concurrency
   cap → leaves the mechanical note untouched). Detail:
   `docs/luna/end-session-wiki.md` → Crystallization.
+- `scripts/luna/fold-chat-history.py` — Fold an exported provider chat history (ChatGPT now; Gemini rides HIMMEL-391) into the luna vault as `chats/gpt/` notes (provider id maps to a vault subdir, e.g. `chatgpt` → `gpt`) + gitignored assets; create-only idempotent, `--dry-run` first (HIMMEL-832).
 
 ---
 

--- a/scripts/luna/fold-chat-history.py
+++ b/scripts/luna/fold-chat-history.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""fold-chat-history — fold an exported provider chat history into the luna vault.
+
+HIMMEL-832. Provider 1: ChatGPT export (conversations-*.json + .dat assets).
+Zero-LLM: parses + renders markdown notes; enrichment is HIMMEL-833.
+
+Usage:
+  python scripts/luna/fold-chat-history.py --provider chatgpt \
+      --export <export-dir> --vault <vault-dir> [--dry-run]
+"""
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):  # Windows cp1252 trap
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+# provider-id -> vault subdir under chats/ (spec: stated once)
+PROVIDER_DIRS = {"chatgpt": "gpt"}
+
+RENDER_ROLES = ("user", "assistant")
+SKIP_CONTENT_TYPES = ("thoughts", "reasoning_recap")
+AUDIO_POINTER_TYPES = ("audio_asset_pointer",
+                       "real_time_user_audio_video_asset_pointer")
+
+# Segment = ("text", body) | ("image", file_id) | ("audio", file_id)
+Segment = tuple
+
+
+@dataclass
+class Turn:
+    role: str
+    segments: list
+
+
+@dataclass
+class Conversation:
+    id: str
+    title: str
+    created: datetime
+    updated: "datetime | None"
+    model: "str | None"
+    turns: "list[Turn]"
+
+
+def _normalize_pointer(pointer):
+    """'sediment://file_X' / 'file-service://file-X' -> bare file id."""
+    return pointer.split("://", 1)[-1]
+
+
+def _segments_from_content(content):
+    """Typed segments from a message content dict (or None to skip)."""
+    ctype = content.get("content_type")
+    if ctype in SKIP_CONTENT_TYPES:
+        return None
+    segments = []
+    for part in content.get("parts") or []:
+        if isinstance(part, str):
+            if part.strip():
+                segments.append(("text", part.strip()))
+        elif isinstance(part, dict):
+            ptype = part.get("content_type")
+            if ptype == "audio_transcription":
+                text = (part.get("text") or "").strip()
+                if text:
+                    segments.append(("text", text))
+            elif ptype == "image_asset_pointer":
+                pointer = part.get("asset_pointer") or ""
+                if pointer:
+                    segments.append(("image", _normalize_pointer(pointer)))
+            elif ptype in AUDIO_POINTER_TYPES:
+                pointer = part.get("asset_pointer") or ""
+                segments.append(("audio", _normalize_pointer(pointer)))
+    return segments
+
+
+def _linearize(raw):
+    """Main-thread nodes: current_node -> parent chain, reversed."""
+    mapping = raw.get("mapping") or {}
+    nodes = []
+    seen = set()
+    nid = raw.get("current_node")
+    while nid and nid in mapping and nid not in seen:
+        seen.add(nid)
+        nodes.append(mapping[nid])
+        nid = mapping[nid].get("parent")
+    nodes.reverse()
+    return nodes
+
+
+def parse_conversation(raw):
+    """Raw export conversation dict -> Conversation, or None if 0 turns."""
+    if not isinstance(raw, dict):
+        return None
+    ct = raw.get("create_time")
+    if ct is None:
+        return None
+    turns = []
+    for node in _linearize(raw):
+        message = node.get("message")
+        if not message:
+            continue
+        if (message.get("author") or {}).get("role") not in RENDER_ROLES:
+            continue
+        if (message.get("metadata") or {}).get("is_visually_hidden_from_conversation"):
+            continue
+        segments = _segments_from_content(message.get("content") or {})
+        if segments:
+            turns.append(Turn(message["author"]["role"], segments))
+    if not turns:
+        return None
+    updated = raw.get("update_time")
+    cid = raw.get("conversation_id") or ""
+    if not cid or not _SAFE_CONV_ID.fullmatch(cid):
+        # full-record hash: only byte-identical records share an id, and
+        # deduping those is correct; reruns stay idempotent
+        seed = json.dumps(raw, sort_keys=True, ensure_ascii=False)
+        cid = "synthetic-" + hashlib.sha1(seed.encode("utf-8")).hexdigest()[:16]
+    model = raw.get("default_model_slug")
+    if model and not isinstance(model, str):
+        model = None
+    if model and not _SAFE_MODEL.fullmatch(model):
+        model = None
+    return Conversation(
+        id=cid,
+        title=(raw.get("title") or "").strip() or "untitled",
+        created=datetime.fromtimestamp(ct),
+        updated=datetime.fromtimestamp(updated) if updated else None,
+        model=model,
+        turns=turns,
+    )
+
+
+def parse_chatgpt(export_dir):
+    """All renderable Conversations from conversations-*.json (sorted)."""
+    export_dir = Path(export_dir)
+    conversations = []
+    for jf in sorted(export_dir.glob("conversations-*.json")):
+        for raw in json.loads(jf.read_text(encoding="utf-8")):
+            conv = parse_conversation(raw)
+            if conv:
+                conversations.append(conv)
+    return conversations
+
+
+# Windows-unsafe + Obsidian-link-breaking chars, stripped from slugs
+_SLUG_STRIP = re.compile(r'[<>:"/\\|?*#^\[\]]')
+_ROLE_HEADINGS = {"user": "## 🧑 User", "assistant": "## 🤖 Assistant"}
+
+
+def slugify(title):
+    slug = _SLUG_STRIP.sub("", title)
+    slug = re.sub(r"\s+", "-", slug.strip())
+    slug = re.sub(r"-{2,}", "-", slug).strip("-")
+    return slug[:60].rstrip("-") or "untitled"
+
+
+def note_filename(conv, taken):
+    """'YYYY-MM-DD-<slug>.md', collision -> '-<id[:8]>', then '-<n>'. Adds result to taken."""
+    base = f"{conv.created:%Y-%m-%d}-{slugify(conv.title)}"
+    id8 = conv.id[:8]
+    candidates = [f"{base}.md"]
+    if id8:
+        candidates.append(f"{base}-{id8}.md")
+    for name in candidates:
+        if name not in taken:
+            taken.add(name)
+            return name
+    stem = f"{base}-{id8}" if id8 else base
+    n = 2
+    while True:
+        name = f"{stem}-{n}.md"
+        if name not in taken:
+            taken.add(name)
+            return name
+        n += 1
+
+
+def _render_segment(segment, assets_dir_rel, available):
+    kind, value = segment
+    if kind == "text":
+        return value
+    if kind == "image":
+        if value in available:
+            return f"![[{assets_dir_rel}/{available[value]}]]"
+        return f"[image: {value} — not in export archive]"
+    return "[audio: not in export archive]"
+
+
+def render_note(conv, assets_dir_rel, available):
+    lines = [
+        "---",
+        "type: chat-import",
+        "source: chatgpt",
+        f"conversation_id: {conv.id}",
+        f"created: {conv.created:%Y-%m-%d}",
+    ]
+    if conv.updated:
+        lines.append(f"updated: {conv.updated:%Y-%m-%d}")
+    if conv.model:
+        lines.append(f"model: {conv.model}")
+    lines += [
+        f"messages: {len(conv.turns)}",
+        "tags: [chat-import, gpt]",
+        "enriched: false",
+        "---",
+        "",
+        f"# {conv.title}",
+    ]
+    for turn in conv.turns:
+        lines += ["", _ROLE_HEADINGS[turn.role], ""]
+        lines.append("\n\n".join(
+            _render_segment(s, assets_dir_rel, available) for s in turn.segments))
+    return "\n".join(lines) + "\n"
+
+
+_MAGIC_EXTS = ((b"\x89PNG", "png"), (b"\xff\xd8\xff", "jpg"))
+
+
+def referenced_image_ids(convs):
+    seen, ordered = set(), []
+    for conv in convs:
+        for turn in conv.turns:
+            for kind, value in turn.segments:
+                if kind == "image" and value not in seen:
+                    seen.add(value)
+                    ordered.append(value)
+    return ordered
+
+
+def asset_ext(export_dir, file_id):
+    """Extension (no dot): export's own name map first, magic-byte fallback."""
+    names_file = export_dir / "conversation_asset_file_names.json"
+    if names_file.exists():
+        names = json.loads(names_file.read_text(encoding="utf-8"))
+        original = names.get(f"{file_id}.dat", "")
+        if "." in original:
+            ext = original.rsplit(".", 1)[1].lower()
+            if _SAFE_EXT.fullmatch(ext):
+                return ext
+    dat = export_dir / f"{file_id}.dat"
+    if dat.exists():
+        with dat.open("rb") as fh:
+            head = fh.read(8)
+        for magic, ext in _MAGIC_EXTS:
+            if head.startswith(magic):
+                return ext
+    return None
+
+
+# file_id comes from export data (asset_pointer) and is interpolated into
+# src/dest paths below — reject anything but a bare filename-safe token
+# (blocks path traversal via a crafted "sediment://../../evil" pointer).
+_SAFE_ASSET_ID = re.compile(r"[A-Za-z0-9_-]+\Z")
+
+# extension from the name map must also be safe (1-8 lowercase alphanumeric)
+# to prevent smuggled path separators (e.g., "photo.png/../../evil" -> "png/../../evil")
+_SAFE_EXT = re.compile(r"[a-z0-9]{1,8}\Z")
+
+# conversation_id must be safe for YAML frontmatter and filenames
+# (blocks newlines, colons, and other problematic chars that corrupt YAML)
+_SAFE_CONV_ID = re.compile(r"[A-Za-z0-9_-]{1,64}\Z")
+
+# model slug must be safe for YAML frontmatter
+# (blocks newlines, colons, and other problematic chars)
+_SAFE_MODEL = re.compile(r"[A-Za-z0-9._-]{1,64}\Z")
+
+
+def copy_assets(convs, export_dir, assets_dir, dry_run):
+    """Copy referenced image assets. -> (available, copied, skipped, missing, unrecognized)."""
+    export_dir = Path(export_dir)
+    available, copied, skipped, missing, unrecognized = {}, 0, 0, 0, 0
+    for file_id in referenced_image_ids(convs):
+        if not _SAFE_ASSET_ID.match(file_id):
+            missing += 1
+            continue
+        src = export_dir / f"{file_id}.dat"
+        if not src.exists():
+            missing += 1
+            continue
+        ext = asset_ext(export_dir, file_id)
+        if not ext:
+            unrecognized += 1
+            continue
+        final = f"{file_id}.{ext}"
+        dest = assets_dir / final
+        available[file_id] = final
+        if dest.exists():
+            skipped += 1
+            continue
+        if not dry_run:
+            assets_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(src, dest)
+        copied += 1
+    return available, copied, skipped, missing, unrecognized
+
+
+_FRONTMATTER_ID = re.compile(r"^conversation_id:\s*(.+?)\s*$", re.MULTILINE)
+_GITIGNORE_RULE = "chats/*/_assets/"
+
+
+@dataclass
+class Report:
+    notes_created: int = 0
+    notes_skipped_existing: int = 0
+    convs_skipped_empty: int = 0
+    assets_copied: int = 0
+    assets_skipped_existing: int = 0
+    assets_missing: int = 0
+    assets_unrecognized: int = 0
+    audio_placeholders: int = 0
+    dry_run: bool = False
+
+    def lines(self):
+        mode = "DRY-RUN — would have: " if self.dry_run else ""
+        return [
+            f"{mode}notes created: {self.notes_created}",
+            f"notes skipped (already imported): {self.notes_skipped_existing}",
+            f"conversations skipped (empty): {self.convs_skipped_empty}",
+            f"assets copied: {self.assets_copied}",
+            f"assets skipped (already present): {self.assets_skipped_existing}",
+            f"assets missing from export: {self.assets_missing}",
+            f"assets present but unrecognized format (left in export): {self.assets_unrecognized}",
+            f"audio placeholders (named voice audio, not in export): {self.audio_placeholders}",
+        ]
+
+
+def existing_conversation_ids(provider_dir):
+    ids = set()
+    if provider_dir.is_dir():
+        for note in provider_dir.rglob("*.md"):
+            try:
+                text = note.read_text(encoding="utf-8")[:2000]
+            except (OSError, UnicodeDecodeError):
+                continue
+            match = _FRONTMATTER_ID.search(text)
+            if match:
+                ids.add(match.group(1))
+    return ids
+
+
+def ensure_gitignore(vault_dir, dry_run):
+    gitignore = vault_dir / ".gitignore"
+    content = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+    if _GITIGNORE_RULE in content.splitlines():
+        return False
+    if not dry_run:
+        joiner = "" if (not content or content.endswith("\n")) else "\n"
+        gitignore.write_text(content + joiner + _GITIGNORE_RULE + "\n",
+                             encoding="utf-8")
+    return True
+
+
+def _note_meta(note_path):
+    """(created, title, messages) for the index, from a note on disk."""
+    text = note_path.read_text(encoding="utf-8")
+    created = re.search(r"^created:\s*(\S+)", text, re.MULTILINE)
+    messages = re.search(r"^messages:\s*(\d+)", text, re.MULTILINE)
+    title = re.search(r"^# (.+)$", text, re.MULTILINE)
+    return (created.group(1) if created else "",
+            title.group(1) if title else note_path.stem,
+            messages.group(1) if messages else "?")
+
+
+def write_index(chats_dir, dry_run):
+    lines = ["# Chat-history imports", "",
+             "Machine-generated by fold-chat-history (HIMMEL-832). "
+             "Regenerated every run — do not hand-edit.", ""]
+    for provider_dir in sorted(p for p in chats_dir.iterdir()
+                               if p.is_dir() and not p.name.startswith("_")):
+        rows = []
+        for note in provider_dir.rglob("*.md"):
+            try:
+                created, title, messages = _note_meta(note)
+            except (OSError, UnicodeDecodeError):
+                continue
+            link = note.relative_to(chats_dir.parent).with_suffix("").as_posix()
+            rows.append((created, f"| {created} | [[{link}\\|{title}]] | {messages} |"))
+        lines += [f"## {provider_dir.name}", "",
+                  f"{len(rows)} conversations.", "",
+                  "| date | conversation | msgs |", "|---|---|---|"]
+        lines += [row for _, row in sorted(rows, reverse=True)]
+        lines.append("")
+    if not dry_run:
+        (chats_dir / "_index.md").write_text("\n".join(lines) + "\n",
+                                             encoding="utf-8")
+
+
+def fold(provider, export_dir, vault_dir, dry_run):
+    export_dir, vault_dir = Path(export_dir), Path(vault_dir)
+    provider_dir = vault_dir / "chats" / PROVIDER_DIRS[provider]
+    assets_dir = provider_dir / "_assets"
+    assets_dir_rel = f"chats/{PROVIDER_DIRS[provider]}/_assets"
+
+    all_raw_count = 0
+    conversations = []
+    for jf in sorted(export_dir.glob("conversations-*.json")):
+        for raw in json.loads(jf.read_text(encoding="utf-8")):
+            all_raw_count += 1
+            conv = parse_conversation(raw)
+            if conv:
+                conversations.append(conv)
+
+    report = Report(dry_run=dry_run)
+    report.convs_skipped_empty = all_raw_count - len(conversations)
+
+    known = existing_conversation_ids(provider_dir)
+    new_convs = []
+    for conv in conversations:
+        if conv.id in known:
+            report.notes_skipped_existing += 1
+        else:
+            new_convs.append(conv)
+            known.add(conv.id)
+
+    available, copied, skipped, missing, unrecognized = copy_assets(
+        conversations, export_dir, assets_dir, dry_run)
+    report.assets_copied = copied
+    report.assets_skipped_existing = skipped
+    report.assets_missing = missing
+    report.assets_unrecognized = unrecognized
+    # named audio ids only — user-side real_time parts carry no top-level
+    # asset_pointer and emit ("audio", ""); they still render placeholders
+    report.audio_placeholders = len({value
+                                     for conv in conversations
+                                     for turn in conv.turns
+                                     for kind, value in turn.segments
+                                     if kind == "audio" and value})
+
+    taken = {p.name for p in provider_dir.rglob("*.md")} if provider_dir.is_dir() else set()
+    for conv in new_convs:
+        name = note_filename(conv, taken)
+        month_dir = provider_dir / f"{conv.created:%Y-%m}"
+        if not dry_run:
+            month_dir.mkdir(parents=True, exist_ok=True)
+            (month_dir / name).write_text(
+                render_note(conv, assets_dir_rel, available), encoding="utf-8")
+        report.notes_created += 1
+
+    try:
+        ensure_gitignore(vault_dir, dry_run)
+        if not dry_run and provider_dir.is_dir():
+            write_index(vault_dir / "chats", dry_run)
+    except Exception as e:
+        print(f"warning: index/gitignore update failed: {e}", file=sys.stderr)
+    return report
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Fold an exported provider chat history into the luna vault "
+                    "(HIMMEL-832; create-only, idempotent).")
+    parser.add_argument("--provider", required=True,
+                        choices=sorted(PROVIDER_DIRS))
+    parser.add_argument("--export", required=True, metavar="DIR",
+                        help="export root (holds conversations-*.json)")
+    parser.add_argument("--vault", required=True, metavar="DIR",
+                        help="luna vault root")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="report what would happen; write nothing")
+    args = parser.parse_args(argv)
+
+    export_dir, vault_dir = Path(args.export), Path(args.vault)
+    if not export_dir.is_dir():
+        print(f"error: export dir not found: {export_dir}", file=sys.stderr)
+        return 1
+    if not vault_dir.is_dir():
+        print(f"error: vault dir not found: {vault_dir}", file=sys.stderr)
+        return 1
+
+    report = fold(args.provider, export_dir, vault_dir, args.dry_run)
+    for line in report.lines():
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/luna/test-fold-chat-history.py
+++ b/scripts/luna/test-fold-chat-history.py
@@ -1,0 +1,676 @@
+#!/usr/bin/env python3
+"""Hermetic tests for fold-chat-history (stdlib unittest).
+
+Run: python scripts/luna/test-fold-chat-history.py
+"""
+import importlib.util
+import json
+import re
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+_MOD_PATH = Path(__file__).resolve().parent / "fold-chat-history.py"
+_spec = importlib.util.spec_from_file_location("fold_chat_history", _MOD_PATH)
+fch = importlib.util.module_from_spec(_spec)
+sys.modules["fold_chat_history"] = fch
+_spec.loader.exec_module(fch)
+
+
+# ---------- fixture builders ----------
+
+def chain(*msgs, conv_id="conv-1", title="Test chat", create_time=1755500000.0,
+          update_time=None, model="gpt-5"):
+    """Build a raw conversation dict whose mapping is a linear chain of msgs.
+
+    Each msg: dict(role=..., ctype=..., parts=[...], hidden=False).
+    Returns the raw conversation dict (as in conversations-*.json).
+    """
+    mapping = {"root": {"id": "root", "message": None, "parent": None, "children": []}}
+    prev = "root"
+    for i, m in enumerate(msgs):
+        nid = f"n{i}"
+        message = None
+        if m is not None:
+            message = {
+                "author": {"role": m["role"]},
+                "content": {"content_type": m.get("ctype", "text"),
+                            "parts": m.get("parts", [])},
+                "metadata": ({"is_visually_hidden_from_conversation": True}
+                             if m.get("hidden") else {}),
+            }
+        mapping[nid] = {"id": nid, "message": message, "parent": prev, "children": []}
+        mapping[prev]["children"].append(nid)
+        prev = nid
+    return {
+        "conversation_id": conv_id,
+        "title": title,
+        "create_time": create_time,
+        "update_time": update_time,
+        "default_model_slug": model,
+        "mapping": mapping,
+        "current_node": prev,
+    }
+
+
+def u(text):
+    return {"role": "user", "parts": [text]}
+
+
+def a(text):
+    return {"role": "assistant", "parts": [text]}
+
+
+class TestParseConversation(unittest.TestCase):
+    def test_linear_text_chain(self):
+        conv = fch.parse_conversation(chain(u("hi"), a("hello"), u("bye"), a("cya")))
+        self.assertEqual(conv.id, "conv-1")
+        self.assertEqual(conv.title, "Test chat")
+        self.assertEqual([t.role for t in conv.turns],
+                         ["user", "assistant", "user", "assistant"])
+        self.assertEqual(conv.turns[0].segments, [("text", "hi")])
+        self.assertEqual(conv.model, "gpt-5")
+
+    def test_edit_branch_dropped(self):
+        # main thread = current_node parent chain; abandoned sibling not rendered
+        raw = chain(u("keep-q"), a("keep-a"))
+        # graft an abandoned branch off root
+        raw["mapping"]["orphan"] = {
+            "id": "orphan",
+            "message": {"author": {"role": "assistant"},
+                        "content": {"content_type": "text", "parts": ["ABANDONED"]},
+                        "metadata": {}},
+            "parent": "root", "children": [],
+        }
+        raw["mapping"]["root"]["children"].append("orphan")
+        conv = fch.parse_conversation(raw)
+        flat = json.dumps([t.segments for t in conv.turns])
+        self.assertNotIn("ABANDONED", flat)
+        self.assertEqual(len(conv.turns), 2)
+
+    def test_skips_system_tool_hidden_thoughts_recap_empty(self):
+        raw = chain(
+            {"role": "system", "parts": ["sys"]},
+            u("real question"),
+            {"role": "assistant", "ctype": "thoughts", "parts": ["thinking..."]},
+            {"role": "assistant", "ctype": "reasoning_recap", "parts": ["recap"]},
+            {"role": "tool", "parts": ["tool out"]},
+            {"role": "assistant", "parts": ["real answer"]},
+            {"role": "user", "parts": [""]},          # empty text -> skipped
+            {"role": "user", "parts": ["hidden"], "hidden": True},
+        )
+        conv = fch.parse_conversation(raw)
+        self.assertEqual([t.role for t in conv.turns], ["user", "assistant"])
+        self.assertEqual(conv.turns[1].segments, [("text", "real answer")])
+
+    def test_zero_renderable_returns_none(self):
+        raw = chain({"role": "system", "parts": ["only system"]})
+        self.assertIsNone(fch.parse_conversation(raw))
+
+    def test_created_from_create_time(self):
+        conv = fch.parse_conversation(chain(u("x"), create_time=1755500000.0))
+        self.assertEqual(conv.created.year, 2025)
+        self.assertIsNone(conv.updated)
+
+    def test_null_create_time_returns_none(self):
+        raw = chain(u("x"), a("y"))
+        raw["create_time"] = None
+        self.assertIsNone(fch.parse_conversation(raw))
+
+    def test_missing_create_time_returns_none(self):
+        raw = chain(u("x"), a("y"))
+        del raw["create_time"]
+        self.assertIsNone(fch.parse_conversation(raw))
+
+    def test_non_dict_raw_returns_none(self):
+        self.assertIsNone(fch.parse_conversation(None))
+        self.assertIsNone(fch.parse_conversation("junk"))
+
+    def test_null_author_skipped_not_raised(self):
+        raw = chain(u("keep"), a("also-keep"))
+        raw["mapping"]["n0"]["message"]["author"] = None  # explicit JSON null
+        conv = fch.parse_conversation(raw)
+        self.assertIsNotNone(conv)
+        self.assertEqual([t.role for t in conv.turns], ["assistant"])
+
+    def test_null_metadata_not_raised(self):
+        raw = chain(u("hi"), a("hello"))
+        raw["mapping"]["n0"]["message"]["metadata"] = None  # explicit JSON null
+        conv = fch.parse_conversation(raw)
+        self.assertIsNotNone(conv)
+        self.assertEqual([t.role for t in conv.turns], ["user", "assistant"])
+
+    def test_cyclic_parent_chain_returns_fast(self):
+        raw = chain(u("a"), a("b"))
+        # corrupt mapping into a 2-node cycle (n0 <-> n1) with no path to root
+        raw["mapping"]["n0"]["parent"] = "n1"
+        conv = fch.parse_conversation(raw)  # must return, not hang
+        self.assertIsNotNone(conv)
+
+
+class TestParseChatgpt(unittest.TestCase):
+    def test_reads_all_conversation_files_sorted(self):
+        with tempfile.TemporaryDirectory() as td:
+            ed = Path(td)
+            (ed / "conversations-000.json").write_text(
+                json.dumps([chain(u("a"), conv_id="c1")]), encoding="utf-8")
+            (ed / "conversations-001.json").write_text(
+                json.dumps([chain(u("b"), conv_id="c2"),
+                            chain({"role": "system", "parts": ["x"]}, conv_id="c3")]),
+                encoding="utf-8")
+            convs = fch.parse_chatgpt(ed)
+            self.assertEqual([c.id for c in convs], ["c1", "c2"])
+
+
+class TestMultimodalSegments(unittest.TestCase):
+    def test_image_pointer_both_schemes(self):
+        raw = chain({"role": "user", "ctype": "multimodal_text", "parts": [
+            {"content_type": "image_asset_pointer",
+             "asset_pointer": "sediment://file_0001"},
+            "what is this?",
+            {"content_type": "image_asset_pointer",
+             "asset_pointer": "file-service://file-ABC"},
+        ]})
+        conv = fch.parse_conversation(raw)
+        self.assertEqual(conv.turns[0].segments, [
+            ("image", "file_0001"),
+            ("text", "what is this?"),
+            ("image", "file-ABC"),
+        ])
+
+    def test_voice_chat_transcription_renders(self):
+        # spec round-2: voice chats are NOT empty — transcription is the body
+        # real export shape: user-side real_time parts have NO top-level
+        # asset_pointer (it is nested under part["audio_asset_pointer"]) ->
+        # segment value is "" but the placeholder must still render
+        raw = chain(
+            {"role": "user", "ctype": "multimodal_text", "parts": [
+                {"content_type": "real_time_user_audio_video_asset_pointer",
+                 "audio_asset_pointer":
+                     {"asset_pointer": "sediment://file_wav1"}},
+                {"content_type": "audio_transcription",
+                 "text": "how long to cook frozen chicken"},
+            ]},
+            {"role": "assistant", "ctype": "multimodal_text", "parts": [
+                {"content_type": "audio_transcription", "text": "about 25 minutes"},
+                {"content_type": "audio_asset_pointer",
+                 "asset_pointer": "sediment://file_wav2"},
+            ]},
+        )
+        conv = fch.parse_conversation(raw)
+        self.assertIsNotNone(conv)
+        self.assertEqual(conv.turns[0].segments, [
+            ("audio", ""),
+            ("text", "how long to cook frozen chicken"),
+        ])
+        self.assertEqual(conv.turns[1].segments, [
+            ("text", "about 25 minutes"),
+            ("audio", "file_wav2"),
+        ])
+
+    def test_unknown_dict_part_ignored(self):
+        raw = chain({"role": "user", "ctype": "multimodal_text", "parts": [
+            {"content_type": "some_future_type", "data": "x"},
+            "still works",
+        ]})
+        conv = fch.parse_conversation(raw)
+        self.assertEqual(conv.turns[0].segments, [("text", "still works")])
+
+
+class TestSlugAndRender(unittest.TestCase):
+    def test_slugify_hebrew_kept_windows_unsafe_stripped(self):
+        self.assertEqual(fch.slugify("הגדרת מידע: רשמי?"), "הגדרת-מידע-רשמי")
+        self.assertEqual(fch.slugify('a<b>c:"d/e\\f|g?h*i'), "abcdefghi")
+        self.assertEqual(fch.slugify("[[link]] #tag ^block"), "link-tag-block")
+        self.assertEqual(fch.slugify("   "), "untitled")
+        self.assertLessEqual(len(fch.slugify("x" * 200)), 60)
+
+    def test_note_filename_collision_same_month(self):
+        taken = set()
+        c1 = fch.parse_conversation(chain(u("a"), conv_id="aaaa1111-x",
+                                          title="New chat",
+                                          create_time=1755500000.0))
+        c2 = fch.parse_conversation(chain(u("b"), conv_id="bbbb2222-y",
+                                          title="New chat",
+                                          create_time=1755500000.0))
+        f1 = fch.note_filename(c1, taken)
+        f2 = fch.note_filename(c2, taken)
+        self.assertNotEqual(f1, f2)
+        self.assertIn("bbbb2222", f2)
+
+    def test_render_note_frontmatter_and_turns(self):
+        conv = fch.parse_conversation(chain(
+            u("שאלה בעברית"), a("answer"),
+            conv_id="cid-1", title="My chat", model="gpt-5",
+            create_time=1755500000.0, update_time=1755600000.0))
+        text = fch.render_note(conv, "chats/gpt/_assets", {})
+        self.assertTrue(text.startswith("---\n"))
+        self.assertIn("type: chat-import", text)
+        self.assertIn("source: chatgpt", text)
+        self.assertIn("conversation_id: cid-1", text)
+        self.assertIn("model: gpt-5", text)
+        self.assertIn("messages: 2", text)
+        self.assertIn("tags: [chat-import, gpt]", text)
+        self.assertIn("enriched: false", text)
+        self.assertIn("# My chat", text)
+        self.assertIn("## 🧑 User\n\nשאלה בעברית", text)
+        self.assertIn("## 🤖 Assistant\n\nanswer", text)
+
+    def test_render_note_assets_and_placeholders(self):
+        raw = chain({"role": "user", "ctype": "multimodal_text", "parts": [
+            {"content_type": "image_asset_pointer",
+             "asset_pointer": "sediment://file_here"},
+            {"content_type": "image_asset_pointer",
+             "asset_pointer": "sediment://file_gone"},
+            {"content_type": "audio_asset_pointer",
+             "asset_pointer": "sediment://file_wav"},
+            "caption",
+        ]})
+        conv = fch.parse_conversation(raw)
+        text = fch.render_note(conv, "chats/gpt/_assets",
+                               {"file_here": "file_here.png"})
+        self.assertIn("![[chats/gpt/_assets/file_here.png]]", text)
+        self.assertIn("[image: file_gone — not in export archive]", text)
+        self.assertIn("[audio: not in export archive]", text)
+        self.assertNotIn("file_gone.dat", text)
+
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+JPEG_MAGIC = b"\xff\xd8\xff\xe0" + b"\x00" * 8
+
+
+class TestAssets(unittest.TestCase):
+    def _export(self, td):
+        ed = Path(td)
+        (ed / "file-MAPPED.dat").write_bytes(JPEG_MAGIC)
+        (ed / "file_sniffed.dat").write_bytes(PNG_MAGIC)
+        (ed / "file_mystery.dat").write_bytes(b"\x00unknown\x00" * 4)
+        (ed / "conversation_asset_file_names.json").write_text(
+            json.dumps({"file-MAPPED.dat": "photo 1.jpg"}), encoding="utf-8")
+        return ed
+
+    def _convs(self):
+        raw = chain({"role": "user", "ctype": "multimodal_text", "parts": [
+            {"content_type": "image_asset_pointer",
+             "asset_pointer": "file-service://file-MAPPED"},
+            {"content_type": "image_asset_pointer",
+             "asset_pointer": "sediment://file_sniffed"},
+            {"content_type": "image_asset_pointer",
+             "asset_pointer": "sediment://file_mystery"},
+            {"content_type": "image_asset_pointer",
+             "asset_pointer": "sediment://file_absent"},
+            {"content_type": "image_asset_pointer",
+             "asset_pointer": "file-service://file-MAPPED"},  # dup -> once
+        ]})
+        return [fch.parse_conversation(raw)]
+
+    def test_referenced_ids_unique_ordered(self):
+        self.assertEqual(fch.referenced_image_ids(self._convs()),
+                         ["file-MAPPED", "file_sniffed", "file_mystery",
+                          "file_absent"])
+
+    def test_copy_assets(self):
+        with tempfile.TemporaryDirectory() as td:
+            ed = self._export(td)
+            assets = Path(td) / "vault-assets"
+            available, copied, skipped, missing, unrecognized = fch.copy_assets(
+                self._convs(), ed, assets, dry_run=False)
+            # mapped name wins; sniff fallback works; mystery -> unrecognized, absent -> missing
+            self.assertEqual(available, {"file-MAPPED": "file-MAPPED.jpg",
+                                         "file_sniffed": "file_sniffed.png"})
+            self.assertEqual((copied, skipped, missing, unrecognized), (2, 0, 1, 1))
+            self.assertTrue((assets / "file-MAPPED.jpg").exists())
+            # idempotent second run: 0 copied, 2 skipped-existing
+            available2, copied2, skipped2, missing2, unrecognized2 = fch.copy_assets(
+                self._convs(), ed, assets, dry_run=False)
+            self.assertEqual(available2, available)
+            self.assertEqual((copied2, skipped2, missing2, unrecognized2), (0, 2, 1, 1))
+
+    def test_copy_assets_dry_run_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as td:
+            ed = self._export(td)
+            assets = Path(td) / "vault-assets"
+            available, copied, skipped, missing, unrecognized = fch.copy_assets(
+                self._convs(), ed, assets, dry_run=True)
+            self.assertEqual(copied, 2)
+            self.assertFalse(assets.exists())
+
+    def test_copy_assets_junk_extension_in_map_falls_back_to_sniff(self):
+        # HIMMEL-832: a .dat file with PNG magic whose map entry has junk
+        # (e.g. "x.png/../../evil") should sniff the magic and return "png",
+        # not the crafted string
+        with tempfile.TemporaryDirectory() as td:
+            ed = Path(td) / "export"
+            ed.mkdir()
+            # .dat file with PNG magic
+            (ed / "file_junk.dat").write_bytes(PNG_MAGIC)
+            # map entry with path separator in the extension
+            (ed / "conversation_asset_file_names.json").write_text(
+                json.dumps({"file_junk.dat": "x.png/../../evil"}), encoding="utf-8")
+            assets = Path(td) / "vault-assets"
+            raw = chain({"role": "user", "ctype": "multimodal_text", "parts": [
+                {"content_type": "image_asset_pointer",
+                 "asset_pointer": "sediment://file_junk"},
+            ]})
+            convs = [fch.parse_conversation(raw)]
+            available, copied, skipped, missing, unrecognized = fch.copy_assets(
+                convs, ed, assets, dry_run=False)
+            # should copy as file_junk.png, not file_junk.png/../../evil
+            self.assertEqual(available, {"file_junk": "file_junk.png"})
+            self.assertEqual((copied, skipped, missing, unrecognized), (1, 0, 0, 0))
+            # verify only the safe file exists
+            self.assertTrue((assets / "file_junk.png").exists())
+            self.assertFalse((Path(td) / "evil").exists())
+
+    def test_copy_assets_unsafe_id_rejected(self):
+        # a crafted asset_pointer with path-traversal segments must never be
+        # interpolated into a filesystem path — counted as missing (renders
+        # the existing "not in export archive" placeholder)
+        with tempfile.TemporaryDirectory() as td:
+            ed = Path(td) / "export"
+            ed.mkdir()
+            assets = Path(td) / "vault-assets"
+            raw = chain({"role": "user", "ctype": "multimodal_text", "parts": [
+                {"content_type": "image_asset_pointer",
+                 "asset_pointer": "sediment://../../evil"},
+            ]})
+            convs = [fch.parse_conversation(raw)]
+            available, copied, skipped, missing, unrecognized = fch.copy_assets(
+                convs, ed, assets, dry_run=False)
+            self.assertEqual(available, {})
+            self.assertEqual((copied, skipped, missing, unrecognized), (0, 0, 1, 0))
+            self.assertFalse(assets.exists())
+            self.assertFalse((Path(td) / "evil").exists())
+            self.assertFalse((Path(td).parent / "evil").exists())
+            text = fch.render_note(convs[0], "chats/gpt/_assets", available)
+            self.assertIn("not in export archive", text)
+
+
+class TestFold(unittest.TestCase):
+    def _make_export(self, td, convs=None):
+        ed = Path(td) / "export"
+        ed.mkdir()
+        (ed / "file-IMG.dat").write_bytes(JPEG_MAGIC)
+        (ed / "conversation_asset_file_names.json").write_text(
+            json.dumps({"file-IMG.dat": "pic.jpg"}), encoding="utf-8")
+        if convs is None:
+            convs = [
+                chain(u("שאלה"), a("תשובה"), conv_id="c-heb",
+                      title="שיחה בעברית", create_time=1755500000.0),
+                chain({"role": "user", "ctype": "multimodal_text", "parts": [
+                           {"content_type": "image_asset_pointer",
+                            "asset_pointer": "file-service://file-IMG"},
+                           {"content_type": "audio_asset_pointer",
+                            "asset_pointer": "sediment://file_voice"},
+                           {"content_type":
+                                "real_time_user_audio_video_asset_pointer",
+                            "audio_asset_pointer":
+                                {"asset_pointer": "sediment://file_rt"}},
+                           "look"]},
+                      a("nice"), conv_id="c-img", title="Pic chat",
+                      create_time=1758200000.0),
+                chain({"role": "system", "parts": ["x"]}, conv_id="c-empty",
+                      title="Empty", create_time=1758200000.0),
+            ]
+        (ed / "conversations-000.json").write_text(
+            json.dumps(convs), encoding="utf-8")
+        return ed
+
+    def test_fold_end_to_end_and_idempotent(self):
+        with tempfile.TemporaryDirectory() as td:
+            ed = self._make_export(td)
+            vault = Path(td) / "vault"
+            vault.mkdir()
+            report = fch.fold("chatgpt", ed, vault, dry_run=False)
+            self.assertEqual(report.notes_created, 2)
+            self.assertEqual(report.convs_skipped_empty, 1)
+            self.assertEqual(report.assets_copied, 1)
+            # named-only count: the empty-pointer real_time part renders a
+            # placeholder but does NOT increment the counter
+            self.assertEqual(report.audio_placeholders, 1)
+            gpt = vault / "chats" / "gpt"
+            # derive expected dates via the SAME local-time conversion the
+            # module uses — hard-coding the day would be timezone-fragile
+            d1 = datetime.fromtimestamp(1755500000.0)
+            d2 = datetime.fromtimestamp(1758200000.0)
+            heb_name = f"{d1:%Y-%m-%d}-שיחה-בעברית.md"
+            pic_name = f"{d2:%Y-%m-%d}-Pic-chat.md"
+            notes = sorted(p.name for p in gpt.rglob("*.md"))
+            self.assertEqual(notes, sorted([heb_name, pic_name]))
+            self.assertTrue((gpt / f"{d1:%Y-%m}" / heb_name).exists())
+            self.assertTrue((gpt / "_assets" / "file-IMG.jpg").exists())
+            index = (vault / "chats" / "_index.md").read_text(encoding="utf-8")
+            self.assertIn("שיחה בעברית", index)
+            gi = (vault / ".gitignore").read_text(encoding="utf-8")
+            self.assertIn("chats/*/_assets/", gi)
+            # second run: nothing new
+            report2 = fch.fold("chatgpt", ed, vault, dry_run=False)
+            self.assertEqual(report2.notes_created, 0)
+            self.assertEqual(report2.notes_skipped_existing, 2)
+            self.assertEqual(report2.assets_copied, 0)
+            self.assertEqual(report2.assets_skipped_existing, 1)
+            # gitignore rule not duplicated
+            gi2 = (vault / ".gitignore").read_text(encoding="utf-8")
+            self.assertEqual(gi2.count("chats/*/_assets/"), 1)
+
+    def test_fold_dry_run_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as td:
+            ed = self._make_export(td)
+            vault = Path(td) / "vault"
+            vault.mkdir()
+            report = fch.fold("chatgpt", ed, vault, dry_run=True)
+            self.assertEqual(report.notes_created, 2)
+            self.assertEqual(report.assets_copied, 1)
+            self.assertEqual(list(vault.iterdir()), [])
+
+    def test_fold_same_title_same_time_no_id_no_overwrite(self):
+        # three conversations, same title + create_time, conversation_id absent
+        # but different mapping sizes -> different synthetic ids, each creates
+        # a distinct note via the filename collision loop
+        with tempfile.TemporaryDirectory() as td:
+            ed = Path(td) / "export"
+            ed.mkdir()
+            # vary message count so mapping sizes differ: 1, 2, 3 messages
+            convs = [
+                chain(u("q0"), title="Same title",
+                      create_time=1755500000.0, conv_id=None),
+                chain(u("q1"), a("a1"), title="Same title",
+                      create_time=1755500000.0, conv_id=None),
+                chain(u("q2"), a("a2"), u("q2b"), title="Same title",
+                      create_time=1755500000.0, conv_id=None),
+            ]
+            (ed / "conversations-000.json").write_text(
+                json.dumps(convs), encoding="utf-8")
+            vault = Path(td) / "vault"
+            vault.mkdir()
+            report = fch.fold("chatgpt", ed, vault, dry_run=False)
+            self.assertEqual(report.notes_created, 3)
+            notes = list((vault / "chats" / "gpt").rglob("*.md"))
+            self.assertEqual(len(notes), 3)
+
+    def test_fold_same_title_same_time_same_size_different_content_no_collision(self):
+        # HIMMEL-832: two conversations with identical title + create_time +
+        # message count but DIFFERENT text must NOT collide (old seed bug:
+        # title|create_time|mapping-size would collide; full-record hash fixes)
+        with tempfile.TemporaryDirectory() as td:
+            ed = Path(td) / "export"
+            ed.mkdir()
+            # Both have 1 user message (2-node mapping: root + n0), but different content
+            convs = [
+                chain(u("aaa"), title="Same title",
+                      create_time=1755500000.0, conv_id=None),
+                chain(u("bbb"), title="Same title",
+                      create_time=1755500000.0, conv_id=None),
+            ]
+            (ed / "conversations-000.json").write_text(
+                json.dumps(convs), encoding="utf-8")
+            vault = Path(td) / "vault"
+            vault.mkdir()
+            report = fch.fold("chatgpt", ed, vault, dry_run=False)
+            # without the fix, these would collide into 1 note; with fix, 2 distinct notes
+            self.assertEqual(report.notes_created, 2)
+            notes = list((vault / "chats" / "gpt").rglob("*.md"))
+            self.assertEqual(len(notes), 2)
+            # verify they have different ids
+            ids = []
+            for note in sorted(notes):
+                text = note.read_text(encoding="utf-8")
+                match = re.search(r"^conversation_id:\s*(.+?)$", text, re.MULTILINE)
+                if match:
+                    ids.append(match.group(1))
+            self.assertEqual(len(ids), 2)
+            self.assertNotEqual(ids[0], ids[1], "distinct conversations should have distinct ids")
+
+    def test_fold_missing_conversation_id_idempotent_with_synthetic_id(self):
+        # conversation with missing conversation_id -> synthetic id generated
+        # from title, create_time, mapping size. Reruns are idempotent.
+        with tempfile.TemporaryDirectory() as td:
+            ed = Path(td) / "export"
+            ed.mkdir()
+            raw = chain(u("hello"), a("hi"), title="Test", create_time=1755500000.0)
+            del raw["conversation_id"]  # simulate missing id in export
+            (ed / "conversations-000.json").write_text(
+                json.dumps([raw]), encoding="utf-8")
+            vault = Path(td) / "vault"
+            vault.mkdir()
+            # first run
+            report1 = fch.fold("chatgpt", ed, vault, dry_run=False)
+            self.assertEqual(report1.notes_created, 1)
+            self.assertEqual(report1.notes_skipped_existing, 0)
+            # verify synthetic id is in frontmatter
+            notes = list((vault / "chats" / "gpt").rglob("*.md"))
+            self.assertEqual(len(notes), 1)
+            note_text = notes[0].read_text(encoding="utf-8")
+            self.assertIn("conversation_id: synthetic-", note_text)
+            # second run: idempotent (no duplicates)
+            report2 = fch.fold("chatgpt", ed, vault, dry_run=False)
+            self.assertEqual(report2.notes_created, 0)
+            self.assertEqual(report2.notes_skipped_existing, 1)
+            self.assertEqual(len(list((vault / "chats" / "gpt").rglob("*.md"))), 1)
+
+    def test_fold_non_dict_conversation_entries_skipped(self):
+        with tempfile.TemporaryDirectory() as td:
+            ed = Path(td) / "export"
+            ed.mkdir()
+            valid = chain(u("hi"), a("hello"), conv_id="c-valid")
+            (ed / "conversations-000.json").write_text(
+                json.dumps([None, "junk", valid]), encoding="utf-8")
+            vault = Path(td) / "vault"
+            vault.mkdir()
+            report = fch.fold("chatgpt", ed, vault, dry_run=False)
+            self.assertEqual(report.notes_created, 1)
+            self.assertEqual(report.convs_skipped_empty, 2)
+
+    def test_fold_intra_run_duplicate_conversation_ids_deduped(self):
+        # Fix 1: one export file containing the SAME conversation dict twice
+        # -> fold reports notes_created 1, notes_skipped_existing 1 (second
+        # occurrence counted as intra-run duplicate via known set)
+        with tempfile.TemporaryDirectory() as td:
+            same_conv = chain(u("hello"), a("hi"), conv_id="c-dup",
+                            title="Duplicate test", create_time=1755500000.0)
+            # include the same conversation dict twice
+            ed = self._make_export(td, convs=[same_conv, same_conv])
+            vault = Path(td) / "vault"
+            vault.mkdir()
+            report = fch.fold("chatgpt", ed, vault, dry_run=False)
+            # first run: should create 1, skip 0 (intra-run dedup)
+            self.assertEqual(report.notes_created, 1)
+            self.assertEqual(report.notes_skipped_existing, 1)
+            notes = list((vault / "chats" / "gpt").rglob("*.md"))
+            self.assertEqual(len(notes), 1)
+
+    def test_fold_unsafe_conversation_id_sanitized_to_synthetic(self):
+        # Fix 2: conversation with newline/colon in conversation_id gets
+        # redirected to synthetic-id path; fold twice stays idempotent
+        with tempfile.TemporaryDirectory() as td:
+            unsafe_conv = chain(u("test"), title="Evil ID test",
+                              create_time=1755500000.0,
+                              conv_id="evil\nout: injected")
+            ed = self._make_export(td, convs=[unsafe_conv])
+            vault = Path(td) / "vault"
+            vault.mkdir()
+            report1 = fch.fold("chatgpt", ed, vault, dry_run=False)
+            self.assertEqual(report1.notes_created, 1)
+            # verify unsafe id was replaced with synthetic
+            notes = list((vault / "chats" / "gpt").rglob("*.md"))
+            self.assertEqual(len(notes), 1)
+            note_text = notes[0].read_text(encoding="utf-8")
+            self.assertIn("conversation_id: synthetic-", note_text)
+            self.assertNotIn("evil\nout:", note_text)
+            # second run: idempotent (0 created, 1 skipped)
+            report2 = fch.fold("chatgpt", ed, vault, dry_run=False)
+            self.assertEqual(report2.notes_created, 0)
+            self.assertEqual(report2.notes_skipped_existing, 1)
+
+    def test_fold_unsafe_model_slug_omitted_from_frontmatter(self):
+        # Fix 3: conversation with newline/colon in model slug ->
+        # parsed model is None, renders NO model: line in frontmatter
+        with tempfile.TemporaryDirectory() as td:
+            unsafe_conv = chain(u("test"), title="Evil Model test",
+                              create_time=1755500000.0,
+                              model="gpt\nevil: x")
+            ed = self._make_export(td, convs=[unsafe_conv])
+            vault = Path(td) / "vault"
+            vault.mkdir()
+            report = fch.fold("chatgpt", ed, vault, dry_run=False)
+            self.assertEqual(report.notes_created, 1)
+            notes = list((vault / "chats" / "gpt").rglob("*.md"))
+            self.assertEqual(len(notes), 1)
+            note_text = notes[0].read_text(encoding="utf-8")
+            # model line should be absent, no injection
+            self.assertNotIn("model:", note_text)
+            self.assertNotIn("evil: x", note_text)
+            self.assertNotIn("evil:\n", note_text)
+
+    def test_fold_survives_unreadable_existing_note(self):
+        with tempfile.TemporaryDirectory() as td:
+            ed = self._make_export(td)
+            vault = Path(td) / "vault"
+            vault.mkdir()
+            report1 = fch.fold("chatgpt", ed, vault, dry_run=False)
+            self.assertEqual(report1.notes_created, 2)
+            # drop a non-UTF-8 .md file into the provider dir between folds
+            gpt = vault / "chats" / "gpt"
+            (gpt / "corrupt.md").write_bytes(b"\xff\xfe garbage")
+            report2 = fch.fold("chatgpt", ed, vault, dry_run=False)
+            self.assertEqual(report2.notes_created, 0)
+            self.assertEqual(report2.notes_skipped_existing, 2)
+            for line in report2.lines():
+                self.assertIsInstance(line, str)
+
+
+class TestCli(unittest.TestCase):
+    def test_main_dry_run_prints_report(self):
+        with tempfile.TemporaryDirectory() as td:
+            ed = Path(td) / "export"
+            ed.mkdir()
+            (ed / "conversations-000.json").write_text(
+                json.dumps([chain(u("q"), a("a"), conv_id="c1")]),
+                encoding="utf-8")
+            vault = Path(td) / "vault"
+            vault.mkdir()
+            import contextlib, io
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = fch.main(["--provider", "chatgpt", "--export", str(ed),
+                               "--vault", str(vault), "--dry-run"])
+            self.assertEqual(rc, 0)
+            self.assertIn("notes created: 1", buf.getvalue())
+            self.assertEqual(list(vault.iterdir()), [])
+
+    def test_main_rejects_unknown_provider(self):
+        with self.assertRaises(SystemExit):
+            fch.main(["--provider", "gemini", "--export", "x", "--vault", "y"])
+
+    def test_main_rejects_missing_export_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            rc = fch.main(["--provider", "chatgpt",
+                           "--export", str(Path(td) / "nope"),
+                           "--vault", td])
+            self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Propagation of the private HIMMEL-832 change: `fold-chat-history` — a
zero-LLM, provider-pluggable chat-history importer (ChatGPT export → luna
vault `chats/`).

- `scripts/luna/fold-chat-history.py`: parses `conversations-*.json`,
  linearizes the `current_node` main thread, writes month-bucketed notes +
  referenced image assets + a regenerated `chats/_index.md`.
- Create-only idempotent; dry-run mode; voice chats via `audio_transcription`.
- All export-derived values reaching the filesystem/frontmatter are
  allow-listed; hardened through 6 cross-model CR rounds.
- `scripts/luna/test-fold-chat-history.py`: 37 hermetic tests.

## CR trail

Full CR completed on the private PR (#1057, merged): spec/plan critic rounds,
per-task SDD reviews, final whole-branch review, 6 codex panel rounds to
clean + adjudicator GATE: CLEAR. Deferred follow-ups: HIMMEL-833, HIMMEL-391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
