### PR TITLE
fix(codex): [HIMMEL-840] registry-driven reap for codex-exec MCP-server fleets + at-source EXIT-trap reap

### DIFF
--- a/scripts/codex/README.md
+++ b/scripts/codex/README.md
@@ -132,6 +132,55 @@ help in that case):
 bash scripts/lib/shared-branch-lock.sh release <worktree-or-repo-dir> <branch>
 ```
 
+### Job registry + MCP-fleet reap (HIMMEL-840)
+
+The codex-exec **CLI sandbox** (this dispatcher) leaks its own MCP-server
+fleet - plain `npx <mcp-server>` under `cmd.exe` wrappers - that
+`reap-mcp-fleet.ps1`'s HIMMEL-741 fingerprint cannot see: those processes
+carry no codex path marker of their own once the `codex.exe` supervisor is
+gone, so they are structurally invisible to that app-server-only
+fingerprint. The dispatcher closes the gap itself instead of relying on a
+periodic sweep:
+
+1. It never `exec`s codex (in either the default or `--shared-branch` path)
+   - it runs codex as a **child**, so its pid is known immediately. Backgrounding
+   a child in a non-interactive script redirects its stdin to `/dev/null` by
+   default, so the child is launched with an explicit `<&0` to inherit the
+   dispatcher's own stdin (a caller that pipes context to `codex exec` would
+   otherwise silently see it dropped).
+2. Right after the child starts, it writes a **job registry** entry under
+   `CODEX_JOBS_DIR` (default `$HOME/.himmel/state/codex-exec-jobs/`), one
+   file per job (`<epoch>-<codexpid>.json`: `codex_pid`, `dispatch_pid`,
+   `worktree`, `started_at`).
+3. On EXIT (composed with the shared-branch lock-release trap), it calls
+   `reap-mcp-fleet.sh --root-pid <codex-child-pid> --started-at <epoch> --kill`
+   to terminate any still-live descendants of that pid - the leftover MCP
+   fleet, if any - then removes the registry entry.
+
+If the dispatcher itself is killed before its own EXIT trap can run (e.g.
+SIGKILL), the registry entry survives as evidence of the leak.
+`reap-mcp-fleet.{sh,ps1}`'s default (no-args) **report mode** additionally
+scans `CODEX_JOBS_DIR` for entries whose `codex_pid` is dead and reports
+their remaining descendants (`-Kill`/`--kill` reaps them and removes the
+entry); it also prints a summary line (jobs live/dead, dead-job fleet count,
+app-server orphan count, and an observability-only count of MCP-shaped
+processes with a dead direct parent that carry no lineage evidence at all -
+counted, never reaped). `-RootPid`/`--root-pid` is a general primitive (not
+codex-exec-specific): report/reap every live descendant of one given
+(possibly dead) root pid, with a `CreationDate`/start-time pid-reuse guard.
+On Windows the `.sh` forwards to the `.ps1` (`Get-CimInstance Win32_Process`
+is the authoritative source there); on mac/Linux the `.sh` walks `ps -eo
+pid,ppid[,etimes]` directly - real logic, not a thin shim, since the
+dispatcher's own EXIT trap needs this primitive on every platform it runs on.
+
+Tests: `scripts/codex/test-reap-mcp-fleet.{sh,ps1}` (pure descendant-walk
+fixtures, incl. a codex-exec sandbox fleet alongside a live-claude MCP fleet
+in the same table to assert the latter is spared); `test-dispatch-codex-exec.sh`
+asserts the registry file appears during the run and is gone after, and that
+the reap primitive is invoked with the codex **child's** pid (env overrides
+`CODEX_JOBS_DIR` / `CODEX_REAP_HELPER` inject a tmpdir and a stub - no real
+process table or `$HOME` state is touched).
+
 ## Skill loading caveat
 
 Enabling `himmel-ops` makes its **hooks** fire under Codex (e.g.

--- a/scripts/codex/dispatch-codex-exec.sh
+++ b/scripts/codex/dispatch-codex-exec.sh
@@ -28,6 +28,17 @@
 #      lock helper's own release verb (see scripts/codex/README.md).
 #      Default posture (no --shared-branch) is unchanged: own worktree, own
 #      throwaway branch, no lock.
+#   6. Job registry + descendant reap (HIMMEL-840): the codex-exec CLI sandbox
+#      leaks its own MCP-server fleet (npx/node children under cmd.exe
+#      wrappers) that the HIMMEL-741 app-server fingerprint cannot see (no
+#      codex path marker survives on those processes once codex.exe is gone).
+#      This wrapper now ALWAYS runs codex as a child (never exec's it, in
+#      either path - exec would drop the trap below), records the child pid
+#      under CODEX_JOBS_DIR right after it starts, and on EXIT reaps the
+#      child's still-live descendants via reap-mcp-fleet.{sh,ps1} before
+#      removing the registry entry. A stale registry entry (dispatcher killed
+#      before its own EXIT trap ran) is still visible to reap-mcp-fleet's
+#      registry-driven maintenance mode.
 #
 # Usage:
 #   dispatch-codex-exec.sh --worktree <path> [--shared-branch <branch>] [codex exec args...]
@@ -36,6 +47,9 @@
 #   CODEX_BIN            Override the codex CLI (tests inject a stub).
 #   CODEX_ACL_NORMALIZE  Override the preflight script path (tests).
 #   SBL_HELPER           Override the shared-branch-lock.sh path (tests).
+#   CODEX_JOBS_DIR        Override the job registry dir (tests; default
+#                         $HOME/.himmel/state/codex-exec-jobs).
+#   CODEX_REAP_HELPER     Override the reap-mcp-fleet.sh path (tests).
 #
 # Bash 3.2 safe (macOS / Git Bash on Windows).
 set -uo pipefail
@@ -44,13 +58,49 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NORMALIZE="${CODEX_ACL_NORMALIZE:-$SCRIPT_DIR/normalize-worktree-acl.sh}"
 CODEX="${CODEX_BIN:-codex}"
 LOCK_HELPER="${SBL_HELPER:-$SCRIPT_DIR/../lib/shared-branch-lock.sh}"
+JOBS_DIR="${CODEX_JOBS_DIR:-$HOME/.himmel/state/codex-exec-jobs}"
+REAP_HELPER="${CODEX_REAP_HELPER:-$SCRIPT_DIR/reap-mcp-fleet.sh}"
 
 usage() {
     echo "usage: dispatch-codex-exec.sh --worktree <path> [--shared-branch <branch>] [codex exec args...]" >&2
     exit 2
 }
 
+# codex-adv-style minimal JSON string escaping (backslash, quote) - mirrors
+# shared-branch-lock.sh's _sbl_json_escape. Worktree paths on Windows carry
+# backslashes that must not break the registry file's JSON.
+_json_escape() {
+    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+# Invariant 6 state, initialized up front (set -u safe) and read by the
+# single composed EXIT trap below regardless of which early-exit path fires.
+# WORKTREE/SHARED_BRANCH are declared here too (ahead of their normal parsing
+# spot below) so the trap never trips set -u on an early usage() exit.
 WORKTREE=""
+SHARED_BRANCH=""
+LOCK_ACQUIRED=""
+CODEX_CHILD_PID=""
+JOB_FILE=""
+STARTED_AT=""
+
+# Single composed EXIT trap (HIMMEL-800 lock-release + HIMMEL-840 fleet-reap).
+# Registered once, up front, so every early-exit path (usage errors, deny-
+# listed flags, preflight failure) also runs it - each branch below is a
+# no-op until its guard var is actually set, so nothing fires for a dispatch
+# that never reached codex.
+# shellcheck disable=SC2329,SC2317 # invoked indirectly via `trap ... EXIT`
+_dispatch_cleanup() {
+    if [ -n "$SHARED_BRANCH" ] && [ -n "$LOCK_ACQUIRED" ]; then
+        bash "$LOCK_HELPER" release "$WORKTREE" "$SHARED_BRANCH"
+    fi
+    if [ -n "$CODEX_CHILD_PID" ]; then
+        bash "$REAP_HELPER" --root-pid "$CODEX_CHILD_PID" --started-at "$STARTED_AT" --kill || true
+        [ -n "$JOB_FILE" ] && rm -f "$JOB_FILE" 2>/dev/null
+    fi
+}
+trap _dispatch_cleanup EXIT
+
 if [ "${1:-}" = "--worktree" ]; then
     [ -n "${2:-}" ] || usage
     WORKTREE="$2"
@@ -59,7 +109,6 @@ fi
 [ -n "$WORKTREE" ] || usage
 [ -d "$WORKTREE" ] || { echo "dispatch-codex-exec.sh: worktree not found: $WORKTREE" >&2; exit 2; }
 
-SHARED_BRANCH=""
 if [ "${1:-}" = "--shared-branch" ]; then
     [ -n "${2:-}" ] || usage
     SHARED_BRANCH="$2"
@@ -163,10 +212,11 @@ if ! bash "$NORMALIZE" "$WORKTREE"; then
 fi
 
 # Invariant 5 (HIMMEL-800): acquire the single-writer lock now that the gate
-# and the ACL preflight both passed. The EXIT trap releases on every CATCHABLE
-# exit from here on (codex CLI missing, worktree vanishing, codex nonzero exit)
-# - a leaked lock is worse than a redundant release call. A SIGKILL/hard-kill
-# is NOT catchable, so a crash there can still leak the lock; recover it
+# and the ACL preflight both passed. The composed EXIT trap (registered up
+# front) releases on every CATCHABLE exit from here on (codex CLI missing,
+# worktree vanishing, codex nonzero exit) once LOCK_ACQUIRED is set - a
+# leaked lock is worse than a redundant release call. A SIGKILL/hard-kill is
+# NOT catchable, so a crash there can still leak the lock; recover it
 # manually with the helper's release verb (see scripts/codex/README.md).
 if [ -n "$SHARED_BRANCH" ]; then
     bash "$LOCK_HELPER" acquire "$WORKTREE" "$SHARED_BRANCH" codex-exec
@@ -183,8 +233,11 @@ if [ -n "$SHARED_BRANCH" ]; then
         fi
         exit 4
     fi
-    # shellcheck disable=SC2064  # intentional early expansion: capture WORKTREE/SHARED_BRANCH now, not at trap-fire time
-    trap "bash \"$LOCK_HELPER\" release \"$WORKTREE\" \"$SHARED_BRANCH\"" EXIT
+    # Do NOT register a new trap here - the composed _dispatch_cleanup trap is
+    # already active (registered up front); setting LOCK_ACQUIRED is enough
+    # to arm its lock-release branch. This also keeps a lock held by another
+    # writer (the rc-4 path above) untouched by our own trap.
+    LOCK_ACQUIRED=1
 fi
 
 # The codex CLI must resolve before the tail exec (a bare bash "not found"
@@ -214,16 +267,31 @@ fi
 if [ "$have_sandbox" -eq 0 ]; then
     pin_args="$pin_args --sandbox workspace-write"
 fi
-# Invariant 5 (HIMMEL-800): the shared-branch path must NOT exec codex -
-# exec replaces this process image, which would drop the EXIT trap above and
-# leak the lock. Run codex as a child, capture its rc, exit with that rc (the
-# trap fires on this exit and releases the lock). The flag-less path keeps
-# the original exec tail byte-identical.
-if [ -n "$SHARED_BRANCH" ]; then
-    # shellcheck disable=SC2086  # pin_args is a fixed, space-safe flag list built above
-    "$CODEX" exec $pin_args "$@"
-    CODEX_RC=$?
-    exit "$CODEX_RC"
-fi
+# Invariants 5+6 (HIMMEL-800/840): NEVER exec codex in either path - exec
+# replaces this process image, which would drop the composed EXIT trap above
+# (losing both the shared-branch lock release and the fleet reap). Run codex
+# as a background child so its pid is known immediately, register the job
+# registry entry, then wait for it and propagate its exit code.
+# <&0 (CR fix): backgrounding a child in a non-interactive script redirects
+# its stdin to /dev/null by default - a silent regression vs the old `exec`
+# tail for any caller that PIPES context to codex exec. Explicitly wire the
+# caller's own stdin through to the backgrounded child.
+STARTED_AT="$(date +%s)"
 # shellcheck disable=SC2086  # pin_args is a fixed, space-safe flag list built above
-exec "$CODEX" exec $pin_args "$@"
+"$CODEX" exec $pin_args "$@" <&0 &
+CODEX_CHILD_PID=$!
+
+# Job registry (HIMMEL-840): one file per job so a leaked fleet (dispatcher
+# killed before its own EXIT trap ran) is still visible to reap-mcp-fleet's
+# registry-driven maintenance mode. Best-effort: a write failure here does
+# not abort the dispatch - the at-source reap below still works off
+# CODEX_CHILD_PID/STARTED_AT regardless of whether the registry file exists.
+mkdir -p "$JOBS_DIR" 2>/dev/null
+JOB_FILE="$JOBS_DIR/${STARTED_AT}-${CODEX_CHILD_PID}.json"
+printf '{"codex_pid":%s,"dispatch_pid":%s,"worktree":"%s","started_at":%s}\n' \
+    "$CODEX_CHILD_PID" "$$" "$(_json_escape "$WORKTREE")" "$STARTED_AT" \
+    > "$JOB_FILE" 2>/dev/null
+
+wait "$CODEX_CHILD_PID"
+CODEX_RC=$?
+exit "$CODEX_RC"

--- a/scripts/codex/reap-mcp-fleet.ps1
+++ b/scripts/codex/reap-mcp-fleet.ps1
@@ -9,6 +9,34 @@
 # fleet processes whose Codex app-server ancestor is GONE - never a fleet with a
 # live app-server (that fleet is legitimately in use).
 #
+# HIMMEL-840 EXTENSION: the codex-exec CLI sandbox (a DIFFERENT lane than the
+# app-server above, dispatched via dispatch-codex-exec.sh) leaks its own MCP
+# fleet - plain `npx <mcp-server>` under `cmd.exe` wrappers with NO codex path
+# marker of their own once the `codex.exe` supervisor is gone, structurally
+# invisible to the Test-CodexOwned fingerprint above. Two new primitives close
+# that gap:
+#   -RootPid <pid> [-StartedAt <epoch>] [-Kill] - report/reap every LIVE
+#     descendant of a given (possibly dead) root pid, walking ParentProcessId
+#     links down from RootPid over the current table (the dispatcher's own
+#     EXIT trap calls this with its codex child's pid right after that child
+#     exits - anything still alive under it is, by construction, a leak).
+#     -StartedAt guards pid-reuse: a would-be descendant whose own
+#     CreationDate predates the job start is excluded (it belongs to whatever
+#     unrelated process now holds that pid, not our job).
+#   Registry-driven maintenance (default mode, no -RootPid): in addition to
+#     the app-server orphan scan above, reads the job registry dispatch-
+#     codex-exec.sh writes (CODEX_JOBS_DIR, default
+#     ~/.himmel/state/codex-exec-jobs/*.json) and, for every entry whose
+#     codex_pid is dead (the dispatcher's own EXIT-trap reap never ran, or
+#     died before it could - e.g. a SIGKILL), reports (default) / reaps
+#     (-Kill) its descendants the same way, removing the entry under -Kill.
+#     Also prints a summary line (registered jobs live/dead, dead-job fleet
+#     count, app-server orphan count) plus an OBSERVABILITY-ONLY count of
+#     MCP-shaped processes with a dead direct parent that carry no codex
+#     lineage evidence at all (unregistered/historic leaks) - counted, never
+#     killed (no marker to prove they are ours; the conservative "when unsure,
+#     exclude" rule from the app-server fingerprint applies here too).
+#
 # GROUNDING (verified on this machine, 2026-07-07):
 #   Live topology, one app-server subtree (`Get-CimInstance Win32_Process`):
 #     codex.exe app-server (pid 51184)               <- SUPERVISOR
@@ -35,13 +63,19 @@
 #   under-reap direction, mirroring restart-bridge.ps1's server.ts handling.
 #
 # USAGE:
-#   pwsh -NoProfile -File scripts/codex/reap-mcp-fleet.ps1            # report-only (default)
-#   pwsh -NoProfile -File scripts/codex/reap-mcp-fleet.ps1 -Kill     # terminate the orphans
+#   pwsh -NoProfile -File scripts/codex/reap-mcp-fleet.ps1            # report-only (default; app-server scan + registry maintenance)
+#   pwsh -NoProfile -File scripts/codex/reap-mcp-fleet.ps1 -Kill     # terminate the orphans + dead-job registry fleets
+#   pwsh -NoProfile -File scripts/codex/reap-mcp-fleet.ps1 -RootPid <pid> [-StartedAt <epoch>] [-Kill]
+#                                                                     # HIMMEL-840: report/reap descendants of one root pid
 # Exit codes: 0 = ran (report or kill); 1 = usage/enumeration error.
 
 [CmdletBinding()]
 param(
   [switch]$Kill,
+  # HIMMEL-840: single-root descendant-reap primitive (dispatch-codex-exec.sh's
+  # own EXIT trap). 0 = not provided (a real pid is never 0) -> default mode.
+  [int]$RootPid = 0,
+  [string]$StartedAt = '',
   # Dot-source seam for the hermetic test: define the functions, then return
   # WITHOUT scanning the live process table.
   [switch]$AsLibrary
@@ -113,6 +147,68 @@ function Get-OrphanFleet {
   return $out.ToArray()
 }
 
+# Get-DescendantPids (HIMMEL-840) - pure descendant walk. Returns every LIVE
+# pid in $Procs reachable from $RootPid by following ParentProcessId links
+# DOWNWARD (children, grandchildren, ...). $RootPid itself need not be present
+# in $Procs (it is typically already dead - that is why we are reaping) - a
+# direct child still records the dead root's pid as its own ParentProcessId,
+# which is all the walk needs to find it. $StartedAtEpoch, when given, guards
+# pid-reuse: a candidate descendant whose own CreationDate predates the job
+# start is excluded (and its subtree is NOT traversed - conservative
+# under-reap, mirrors Get-OrphanFleet's stance).
+function Get-DescendantPids {
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [Parameter(Mandatory)][int]$RootPid,
+    [Nullable[long]]$StartedAtEpoch = $null
+  )
+  $byParent = @{}
+  foreach ($p in $Procs) {
+    $key = [string]$p.ParentProcessId
+    if (-not $byParent.ContainsKey($key)) { $byParent[$key] = New-Object System.Collections.ArrayList }
+    [void]$byParent[$key].Add($p)
+  }
+  $result = New-Object System.Collections.ArrayList
+  $queue = New-Object System.Collections.Generic.Queue[int]
+  $queue.Enqueue($RootPid)
+  $visited = @{}
+  $depth = 0
+  while ($queue.Count -gt 0 -and $depth -lt 4096) {
+    $depth++
+    $cur = $queue.Dequeue()
+    $curKey = [string]$cur
+    if ($visited.ContainsKey($curKey)) { continue }   # pid-reuse cycle guard
+    $visited[$curKey] = $true
+    if (-not $byParent.ContainsKey($curKey)) { continue }
+    foreach ($child in $byParent[$curKey]) {
+      if ($null -ne $StartedAtEpoch -and $child.CreationDate -is [datetime]) {
+        $childEpoch = [long][DateTimeOffset]::new($child.CreationDate.ToUniversalTime()).ToUnixTimeSeconds()
+        if ($childEpoch -lt $StartedAtEpoch) { continue }  # predates the job - not ours (pid-reuse guard)
+      }
+      [void]$result.Add([int]$child.ProcessId)
+      $queue.Enqueue([int]$child.ProcessId)
+    }
+  }
+  return $result.ToArray()
+}
+
+# Test-McpShaped (HIMMEL-840, observability-only) - a coarse "looks like an
+# MCP-server-launching process" predicate used ONLY for the report-mode
+# visibility count of unregistered/historic dead-parent leaks (point 4). It is
+# deliberately looser than Test-CodexOwned (no path-marker requirement) and
+# MUST NEVER drive a kill decision - it has no lineage evidence, just a name/
+# cmdline shape shared by legitimate live-Claude MCP servers too.
+function Test-McpShaped {
+  param([Parameter(Mandatory)]$Proc)
+  if (-not $Proc.Name) { return $false }
+  if ($Proc.Name -in @('node.exe', 'bun.exe', 'uvx.exe', 'npx.exe')) { return $true }
+  if ($Proc.Name -ieq 'cmd.exe') {
+    $cl = [string]$Proc.CommandLine
+    return ($cl -match 'npx(\.cmd)?\s')
+  }
+  return $false
+}
+
 if ($AsLibrary) { return }
 
 # --- production path: enumerate the live table, report, optionally kill -------
@@ -135,47 +231,149 @@ try {
   exit 1
 }
 
+# --- HIMMEL-840: -RootPid mode - report/reap descendants of ONE root pid ----
+# (the dispatcher's own EXIT trap, called with its codex child's pid).
+if ($RootPid -gt 0) {
+  # Entry-point safety parity with the registry-scan path below (which skips a
+  # job whose codex_pid is still present in the table): a caller-supplied root
+  # pid that is itself still alive must abort, not walk descendants - a live
+  # root's own fleet is legitimately in use, not a leak.
+  $byPidRoot = @{}
+  foreach ($p in $records) { $byPidRoot[[string]$p.ProcessId] = $p }
+  if ($byPidRoot.ContainsKey([string]$RootPid)) {
+    Write-Host "[reap-mcp-fleet] pid $RootPid is still alive - skipping descendant walk (only reap descendants of a dead root)."
+    exit 0
+  }
+  $startedEpoch = $null
+  if ($StartedAt) {
+    $parsed = 0L
+    if ([long]::TryParse($StartedAt, [ref]$parsed)) { $startedEpoch = $parsed }
+  }
+  $descendants = @(Get-DescendantPids -Procs $records -RootPid $RootPid -StartedAtEpoch $startedEpoch)
+  if ($descendants.Count -eq 0) {
+    Write-Host "[reap-mcp-fleet] no live descendants of pid $RootPid."
+    exit 0
+  }
+  Write-Host ("[reap-mcp-fleet] {0} descendant process(es) of pid {1}:" -f $descendants.Count, $RootPid)
+  foreach ($d in $descendants) {
+    $nm = if ($byPidRoot.ContainsKey([string]$d)) { $byPidRoot[[string]$d].Name } else { '?' }
+    Write-Host "  pid $d ($nm)"
+  }
+  if (-not $Kill) {
+    Write-Host "[reap-mcp-fleet] report-only (default). Re-run with -Kill to terminate the above."
+    exit 0
+  }
+  $killedRoot = 0
+  foreach ($d in $descendants) {
+    try {
+      Stop-Process -Id $d -Force -ErrorAction Stop
+      $killedRoot++
+    } catch {
+      Write-Warning "[reap-mcp-fleet] could not kill pid $d`: $_"
+    }
+  }
+  Write-Host ("[reap-mcp-fleet] terminated {0}/{1} descendant(s) of pid {2}." -f $killedRoot, $descendants.Count, $RootPid)
+  exit 0
+}
+
+# --- default mode: app-server orphan scan + registry-driven maintenance -----
+
 $orphans = @(Get-OrphanFleet -Procs $records)
 
 if ($orphans.Count -eq 0) {
   Write-Host "[reap-mcp-fleet] no orphaned Codex MCP-fleet processes found."
-  exit 0
-}
-
-$now = Get-Date
-$rows = $orphans | ForEach-Object {
-  $ageStr = '?'
-  if ($_.CreationDate -is [datetime]) {
-    $mins = [int]([math]::Round(($now - $_.CreationDate).TotalMinutes))
-    $ageStr = "${mins}m"
+} else {
+  $now = Get-Date
+  $rows = $orphans | ForEach-Object {
+    $ageStr = '?'
+    if ($_.CreationDate -is [datetime]) {
+      $mins = [int]([math]::Round(($now - $_.CreationDate).TotalMinutes))
+      $ageStr = "${mins}m"
+    }
+    $snip = if ($_.CommandLine) { $_.CommandLine.Substring(0, [Math]::Min(80, $_.CommandLine.Length)) } else { '' }
+    [pscustomobject]@{
+      PID          = $_.ProcessId
+      Name         = $_.Name
+      Age          = $ageStr
+      DeadAncestor = $_.DeadAncestorPid
+      Cmdline      = $snip
+    }
   }
-  $snip = if ($_.CommandLine) { $_.CommandLine.Substring(0, [Math]::Min(80, $_.CommandLine.Length)) } else { '' }
-  [pscustomobject]@{
-    PID          = $_.ProcessId
-    Name         = $_.Name
-    Age          = $ageStr
-    DeadAncestor = $_.DeadAncestorPid
-    Cmdline      = $snip
+
+  Write-Host ("[reap-mcp-fleet] {0} orphaned Codex MCP-fleet process(es):" -f $orphans.Count)
+  $rows | Format-Table -AutoSize | Out-String -Width 200 | Write-Host
+
+  if (-not $Kill) {
+    Write-Host "[reap-mcp-fleet] report-only (default). Re-run with -Kill to terminate the above."
+  } else {
+    $killed = 0
+    foreach ($o in $orphans) {
+      try {
+        Stop-Process -Id $o.ProcessId -Force -ErrorAction Stop
+        Write-Host "[reap-mcp-fleet] killed pid $($o.ProcessId) ($($o.Name))"
+        $killed++
+      } catch {
+        Write-Warning "[reap-mcp-fleet] could not kill pid $($o.ProcessId): $_"
+      }
+    }
+    Write-Host ("[reap-mcp-fleet] terminated {0}/{1} orphan(s)." -f $killed, $orphans.Count)
   }
 }
 
-Write-Host ("[reap-mcp-fleet] {0} orphaned Codex MCP-fleet process(es):" -f $orphans.Count)
-$rows | Format-Table -AutoSize | Out-String -Width 200 | Write-Host
-
-if (-not $Kill) {
-  Write-Host "[reap-mcp-fleet] report-only (default). Re-run with -Kill to terminate the above."
-  exit 0
+# --- HIMMEL-840: registry-driven maintenance (visibility surface, point 4) --
+# Every job dispatch-codex-exec.sh registered under CODEX_JOBS_DIR whose
+# codex_pid is now dead is a leak the dispatcher's own EXIT-trap reap never
+# cleaned up (killed before it could run). Report (default) or reap (-Kill)
+# its remaining descendants the same way -RootPid does, and drop the entry
+# under -Kill (a report-only pass must not mutate state).
+$jobsDir = if ($env:CODEX_JOBS_DIR) { $env:CODEX_JOBS_DIR } else { Join-Path $env:USERPROFILE '.himmel\state\codex-exec-jobs' }
+$jobFiles = @()
+if (Test-Path -LiteralPath $jobsDir) {
+  $jobFiles = @(Get-ChildItem -LiteralPath $jobsDir -Filter '*.json' -File -ErrorAction SilentlyContinue)
 }
+$byPidAll = @{}
+foreach ($p in $records) { $byPidAll[[string]$p.ProcessId] = $p }
 
-$killed = 0
-foreach ($o in $orphans) {
-  try {
-    Stop-Process -Id $o.ProcessId -Force -ErrorAction Stop
-    Write-Host "[reap-mcp-fleet] killed pid $($o.ProcessId) ($($o.Name))"
-    $killed++
-  } catch {
-    Write-Warning "[reap-mcp-fleet] could not kill pid $($o.ProcessId): $_"
+$liveJobs = 0
+$deadJobs = 0
+$deadFleetTotal = 0
+foreach ($jf in $jobFiles) {
+  $job = $null
+  try { $job = Get-Content -Raw -LiteralPath $jf.FullName | ConvertFrom-Json } catch { continue }
+  if (-not $job.codex_pid) { continue }
+  $jobPid = [int]$job.codex_pid
+  $jobStarted = $null
+  if ($job.started_at) {
+    $parsedStarted = 0L
+    if ([long]::TryParse([string]$job.started_at, [ref]$parsedStarted)) { $jobStarted = $parsedStarted }
+  }
+  if ($byPidAll.ContainsKey([string]$jobPid)) { $liveJobs++; continue }
+  $deadJobs++
+  $desc = @(Get-DescendantPids -Procs $records -RootPid $jobPid -StartedAtEpoch $jobStarted)
+  $deadFleetTotal += $desc.Count
+  if ($desc.Count -gt 0) {
+    Write-Host ("[reap-mcp-fleet] registry job {0} (codex pid {1}, dead): {2} descendant fleet process(es)" -f $jf.Name, $jobPid, $desc.Count)
+  }
+  if ($Kill) {
+    foreach ($d in $desc) {
+      try { Stop-Process -Id $d -Force -ErrorAction Stop } catch { Write-Warning "[reap-mcp-fleet] could not kill pid $d`: $_" }
+    }
+    Remove-Item -LiteralPath $jf.FullName -Force -ErrorAction SilentlyContinue
   }
 }
-Write-Host ("[reap-mcp-fleet] terminated {0}/{1} orphan(s)." -f $killed, $orphans.Count)
+
+# Observability-only: MCP-shaped processes with a dead DIRECT parent that
+# carry no codex lineage evidence at all (unregistered/historic leaks - a job
+# that predates this registry, or a fleet that lost its own marker). Counted
+# for visibility; NEVER reaped (no evidence they are ours - conservative
+# under-reap).
+$unregisteredDeadParent = 0
+foreach ($p in $records) {
+  if (-not (Test-McpShaped -Proc $p)) { continue }
+  if (-not $byPidAll.ContainsKey([string]$p.ParentProcessId)) { $unregisteredDeadParent++ }
+}
+
+Write-Host ("[reap-mcp-fleet] registry: {0} job(s) live, {1} job(s) dead ({2} descendant fleet proc(s)); app-server orphans: {3}; unregistered dead-parent MCP-shaped proc(s): {4} (report-only, never reaped)" `
+  -f $liveJobs, $deadJobs, $deadFleetTotal, $orphans.Count, $unregisteredDeadParent)
+
 exit 0

--- a/scripts/codex/reap-mcp-fleet.sh
+++ b/scripts/codex/reap-mcp-fleet.sh
@@ -1,45 +1,239 @@
 #!/usr/bin/env bash
-# reap-mcp-fleet.sh (HIMMEL-741) - thin twin of reap-mcp-fleet.ps1.
+# reap-mcp-fleet.sh (HIMMEL-741; HIMMEL-840 descendant-reap primitive) -
+# cross-platform twin of reap-mcp-fleet.ps1.
 #
-# The Codex MCP-fleet flood is a Windows-process-tree problem (Win32_Process
-# ancestry walk). The real logic lives in the .ps1; on Windows this forwards to
-# pwsh, on every other platform it is a no-op (nothing to reap - Codex on
-# mac/Linux reaps its own children). Kept only to satisfy the .ps1/.sh twin
-# convention and give a stable cross-platform entrypoint.
+# The app-server-fleet FINGERPRINT (Win32_Process ancestry walk with codex
+# path markers) is a Windows-only concern - the default (no-args) mode's
+# orphan scan forwards entirely to the .ps1 on Windows; on other platforms
+# Codex reaps its own app-server children, so that scan is skipped there.
 #
-#   scripts/codex/reap-mcp-fleet.sh          # report-only (default)
-#   scripts/codex/reap-mcp-fleet.sh --kill   # forwards -Kill to the .ps1
-set -euo pipefail
+# The HIMMEL-840 descendant-reap PRIMITIVE (--root-pid) is NOT Windows-only:
+# dispatch-codex-exec.sh's own EXIT trap calls it on every platform right
+# after its codex child exits. On Windows this still forwards to the .ps1
+# (Win32_Process + CreationDate is the authoritative source there); on
+# mac/Linux this file carries a REAL implementation (`ps -eo pid,ppid[,etimes]`
+# + a pure BFS walk, mirroring Get-DescendantPids in the .ps1) - not a thin
+# pwsh shim. The registry-driven maintenance scan (default mode) is likewise
+# real on every platform (it is just `ps` + the job registry).
+#
+# USAGE:
+#   scripts/codex/reap-mcp-fleet.sh                                    # report-only (default)
+#   scripts/codex/reap-mcp-fleet.sh --kill                             # reap the above
+#   scripts/codex/reap-mcp-fleet.sh --root-pid <pid> [--started-at <epoch>] [--kill]
+#                                                                       # HIMMEL-840: report/reap descendants of one root pid
+#
+# ENVIRONMENT:
+#   CODEX_JOBS_DIR   Override the job registry dir (tests; default
+#                    $HOME/.himmel/state/codex-exec-jobs).
+#
+# Bash 3.2 safe. Sourcing this file (instead of executing it) defines the
+# pure functions below WITHOUT running production code - the hermetic test
+# seam (mirrors reap-mcp-fleet.ps1's -AsLibrary and shared-branch-lock.sh's
+# own sourcing guard).
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PS1="$SCRIPT_DIR/reap-mcp-fleet.ps1"
+JOBS_DIR="${CODEX_JOBS_DIR:-$HOME/.himmel/state/codex-exec-jobs}"
 
-case "${OSTYPE:-$(uname -s 2>/dev/null || echo unknown)}" in
-  msys*|cygwin*|win32*|MINGW*|MSYS*) ;;
-  *)
-    echo "[reap-mcp-fleet] non-Windows platform - the Codex MCP-fleet flood is Windows-only; nothing to do."
-    exit 0
-    ;;
-esac
+_reap_platform() {
+    case "${OSTYPE:-$(uname -s 2>/dev/null || echo unknown)}" in
+        msys*|cygwin*|win32*|MINGW*|MSYS*) echo windows ;;
+        *) echo other ;;
+    esac
+}
 
-PWSH_BIN=""
-for c in pwsh pwsh.exe powershell.exe; do
-  if command -v "$c" >/dev/null 2>&1; then PWSH_BIN="$c"; break; fi
-done
-if [ -z "$PWSH_BIN" ]; then
-  echo "ERR: pwsh not found on PATH - run scripts/codex/reap-mcp-fleet.ps1 directly." >&2
-  exit 1
+# --- pure descendant walk (bash 3.2-safe; the hermetic test calls this
+# directly via the sourcing seam) ---------------------------------------
+# _reap_descendants <table> <root-pid> [<started-at-epoch>]
+# <table>: one line per process, "<pid> <ppid> <start-epoch-or-dash>"
+# (space-separated). Prints one descendant pid per line (BFS discovery
+# order). $root_pid need not appear in <table> (it is typically already
+# dead - that is why we are reaping); a direct child still records the dead
+# root's pid as its own ppid, which is all the walk needs. <started-at>,
+# when given, guards pid-reuse: a candidate whose own start predates the job
+# is excluded and its subtree is NOT traversed (conservative under-reap).
+_reap_descendants() {
+    _rd_table="$1"
+    _rd_root="$2"
+    _rd_started="${3:-}"
+    _rd_frontier="$_rd_root"
+    _rd_seen=" $_rd_root "
+    _rd_depth=0
+    while [ -n "$_rd_frontier" ] && [ "$_rd_depth" -lt 64 ]; do
+        _rd_depth=$((_rd_depth + 1))
+        _rd_next=""
+        for _rd_parent in $_rd_frontier; do
+            # <<EOF (not `| while read`) - a piped while-loop runs in a
+            # subshell in bash, which would lose _rd_seen/_rd_next mutations
+            # once the loop ends.
+            while read -r _rd_pid _rd_ppid _rd_start; do
+                [ -z "$_rd_pid" ] && continue
+                [ "$_rd_ppid" = "$_rd_parent" ] || continue
+                case "$_rd_seen" in *" $_rd_pid "*) continue ;; esac
+                if [ -n "$_rd_started" ] && [ -n "$_rd_start" ] && [ "$_rd_start" != "-" ]; then
+                    if [ "$_rd_start" -lt "$_rd_started" ] 2>/dev/null; then
+                        continue   # predates the job - not ours (pid-reuse guard)
+                    fi
+                fi
+                _rd_seen="$_rd_seen$_rd_pid "
+                _rd_next="$_rd_next $_rd_pid"
+                printf '%s\n' "$_rd_pid"
+            done <<EOF
+$_rd_table
+EOF
+        done
+        _rd_frontier="$_rd_next"
+    done
+}
+
+# _reap_ps_table - print the live "<pid> <ppid> <start-epoch-or-dash>" table
+# from the real process list (non-Windows production path only; not used by
+# the hermetic test, which feeds _reap_descendants a fixture directly).
+_reap_ps_table() {
+    _rpt_now="$(date +%s)"
+    if _rpt_raw="$(ps -eo pid,ppid,etimes 2>/dev/null)" && [ -n "$_rpt_raw" ]; then
+        printf '%s\n' "$_rpt_raw" | awk -v now="$_rpt_now" '$1+0==$1 && $2+0==$2 {print $1, $2, (now-$3)}'
+        return 0
+    fi
+    # BSD/macOS ps has no `etimes` keyword - degrade to pid/ppid only. The
+    # pid-reuse guard becomes a no-op on this platform (best-effort, not
+    # load-bearing for the walk's own correctness).
+    ps -eo pid,ppid 2>/dev/null | awk '$1+0==$1 && $2+0==$2 {print $1, $2, "-"}'
+}
+
+# _reap_registry_scan - non-Windows twin of the .ps1's registry-driven
+# maintenance block (visibility surface, HIMMEL-840 point 4). Reads
+# $JOBS_DIR/*.json (node -e, mirroring companion-liveness.sh's own JSON-
+# parsing convention) and, for each entry whose codex_pid is dead, reports
+# (default) / reaps (--kill) its descendants, dropping the entry under
+# --kill only (a report-only pass must not mutate state). Reads $_kill (set
+# by _reap_main).
+_reap_registry_scan() {
+    if [ ! -d "$JOBS_DIR" ]; then
+        echo "[reap-mcp-fleet] registry: 0 job(s) (no job registry dir: $JOBS_DIR)."
+        return 0
+    fi
+    _rrs_node=""
+    for c in node node.exe; do
+        if command -v "$c" >/dev/null 2>&1; then _rrs_node="$c"; break; fi
+    done
+    if [ -z "$_rrs_node" ]; then
+        echo "[reap-mcp-fleet] registry: cannot scan (node not found on PATH)." >&2
+        return 0
+    fi
+    _rrs_table="$(_reap_ps_table)"
+    _rrs_live=0
+    _rrs_dead=0
+    _rrs_fleet_total=0
+    for _rrs_jf in "$JOBS_DIR"/*.json; do
+        [ -f "$_rrs_jf" ] || continue
+        _rrs_line="$("$_rrs_node" -e '
+            const fs = require("fs");
+            let o;
+            try { o = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); } catch { process.exit(0); }
+            if (!o.codex_pid) process.exit(0);
+            process.stdout.write(String(o.codex_pid) + "\t" + String(o.started_at || ""));
+        ' "$_rrs_jf" 2>/dev/null)"
+        [ -n "$_rrs_line" ] || continue
+        _rrs_pid="${_rrs_line%%$'\t'*}"
+        _rrs_started="${_rrs_line#*$'\t'}"
+        if printf '%s\n' "$_rrs_table" | awk -v p="$_rrs_pid" '$1==p{f=1} END{exit !f}'; then
+            _rrs_live=$((_rrs_live + 1))
+            continue
+        fi
+        _rrs_dead=$((_rrs_dead + 1))
+        _rrs_desc="$(_reap_descendants "$_rrs_table" "$_rrs_pid" "$_rrs_started")"
+        if [ -n "$_rrs_desc" ]; then
+            _rrs_dcount=$(printf '%s\n' "$_rrs_desc" | grep -c .)
+            _rrs_fleet_total=$((_rrs_fleet_total + _rrs_dcount))
+            echo "[reap-mcp-fleet] registry job $(basename "$_rrs_jf") (codex pid $_rrs_pid, dead): $_rrs_dcount descendant fleet process(es)"
+            if [ "$_kill" -eq 1 ]; then
+                printf '%s\n' "$_rrs_desc" | while read -r _rrs_d; do
+                    if [ -n "$_rrs_d" ]; then kill -9 "$_rrs_d" 2>/dev/null || true; fi
+                done
+            fi
+        fi
+        [ "$_kill" -eq 1 ] && rm -f "$_rrs_jf"
+    done
+    echo "[reap-mcp-fleet] registry: $_rrs_live job(s) live, $_rrs_dead job(s) dead ($_rrs_fleet_total descendant fleet proc(s))."
+}
+
+_reap_main() {
+    _platform="$(_reap_platform)"
+
+    _kill=0
+    _root_pid=""
+    _started_at=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --kill) _kill=1; shift ;;
+            --root-pid) [ $# -ge 2 ] || { echo "reap-mcp-fleet: missing value for $1" >&2; return 1; }; _root_pid="$2"; shift 2 ;;
+            --root-pid=*) _root_pid="${1#--root-pid=}"; shift ;;
+            --started-at) [ $# -ge 2 ] || { echo "reap-mcp-fleet: missing value for $1" >&2; return 1; }; _started_at="$2"; shift 2 ;;
+            --started-at=*) _started_at="${1#--started-at=}"; shift ;;
+            -h|--help) sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'; return 0 ;;
+            *) echo "ERR: unknown argument: $1" >&2; return 1 ;;
+        esac
+    done
+
+    if [ "$_platform" = "windows" ]; then
+        _pwsh_bin=""
+        for c in pwsh pwsh.exe powershell.exe; do
+            if command -v "$c" >/dev/null 2>&1; then _pwsh_bin="$c"; break; fi
+        done
+        if [ -z "$_pwsh_bin" ]; then
+            echo "ERR: pwsh not found on PATH - run scripts/codex/reap-mcp-fleet.ps1 directly." >&2
+            return 1
+        fi
+        _ps_args=()
+        [ -n "$_root_pid" ] && _ps_args+=("-RootPid" "$_root_pid")
+        [ -n "$_started_at" ] && _ps_args+=("-StartedAt" "$_started_at")
+        [ "$_kill" -eq 1 ] && _ps_args+=("-Kill")
+        "$_pwsh_bin" -NoProfile -ExecutionPolicy Bypass -File "$PS1" ${_ps_args[@]+"${_ps_args[@]}"}
+        return $?
+    fi
+
+    # --- non-Windows: real descendant-reap + registry scan (no app-server
+    # fingerprint - that fingerprint is Win32_Process-specific).
+    if [ -n "$_root_pid" ]; then
+        _table="$(_reap_ps_table)"
+        # Entry-point safety parity with the registry-scan path (which skips a
+        # job whose codex_pid is still present in the table): a caller-supplied
+        # root pid that is itself still alive must abort, not walk descendants -
+        # a live root's own fleet is legitimately in use, not a leak.
+        if printf '%s\n' "$_table" | awk -v p="$_root_pid" '$1==p{f=1} END{exit !f}'; then
+            echo "[reap-mcp-fleet] pid $_root_pid is still alive - skipping descendant walk (only reap descendants of a dead root)."
+            return 0
+        fi
+        _descendants="$(_reap_descendants "$_table" "$_root_pid" "$_started_at")"
+        if [ -z "$_descendants" ]; then
+            echo "[reap-mcp-fleet] no live descendants of pid $_root_pid."
+            return 0
+        fi
+        _count="$(printf '%s\n' "$_descendants" | grep -c .)"
+        echo "[reap-mcp-fleet] $_count descendant process(es) of pid $_root_pid:"
+        printf '%s\n' "$_descendants" | while read -r _d; do
+            [ -n "$_d" ] && echo "  pid $_d"
+        done
+        if [ "$_kill" -ne 1 ]; then
+            echo "[reap-mcp-fleet] report-only (default). Re-run with --kill to terminate the above."
+            return 0
+        fi
+        printf '%s\n' "$_descendants" | while read -r _d; do
+            if [ -n "$_d" ]; then kill -9 "$_d" 2>/dev/null || true; fi
+        done
+        echo "[reap-mcp-fleet] terminated descendant(s) of pid $_root_pid."
+        return 0
+    fi
+
+    echo "[reap-mcp-fleet] non-Windows platform - the app-server MCP-fleet fingerprint is Windows-only; running the registry-driven job scan only."
+    _reap_registry_scan
+}
+
+# Sourcing guard (bash 3.2-safe form of "is this file executed, not
+# sourced"), mirroring shared-branch-lock.sh's own _sbl_main guard.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+    _reap_main "$@"
+    exit $?
 fi
-
-PS_ARGS=()
-for arg in "$@"; do
-  case "$arg" in
-    --kill) PS_ARGS+=("-Kill") ;;
-    -h|--help) sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
-    *) echo "ERR: unknown argument: $arg" >&2; exit 1 ;;
-  esac
-done
-
-# Guard the empty-array expansion (bash 3.2 + set -u treats "${a[@]}" on an
-# empty array as an unbound variable).
-exec "$PWSH_BIN" -NoProfile -ExecutionPolicy Bypass -File "$PS1" ${PS_ARGS[@]+"${PS_ARGS[@]}"}

--- a/scripts/codex/test-dispatch-codex-exec.sh
+++ b/scripts/codex/test-dispatch-codex-exec.sh
@@ -23,6 +23,8 @@ trap 'rm -rf "$TMP"' EXIT
 WT="$TMP/.claude/worktrees/wt"
 mkdir -p "$WT"
 LOG="$TMP/calls.log"
+JOBS_DIR="$TMP/jobs-dir"
+mkdir -p "$JOBS_DIR"
 
 # codex stub: records invocation order, argv, and cwd; exits 0.
 CODEX_STUB="$TMP/codex-stub"
@@ -46,9 +48,23 @@ EOF
 chmod +x "$NORM_STUB"
 echo 0 > "$TMP/norm.rc"
 
+# reap-mcp-fleet stub (HIMMEL-840): records invocation + argv, exits 0 - no
+# real process table or pwsh is touched. Injected into every run_dispatch
+# call below so a codex stub that actually runs (rc-0 or nonzero-rc paths)
+# never shells out to the real reap-mcp-fleet.sh/.ps1.
+REAP_STUB="$TMP/reap-stub.sh"
+cat > "$REAP_STUB" <<EOF
+#!/usr/bin/env bash
+echo "reap" >> "$LOG"
+printf '%s\n' "\$*" > "$TMP/reap.args"
+exit 0
+EOF
+chmod +x "$REAP_STUB"
+
 run_dispatch() {  # run_dispatch <args...> ; sets $RC and $OUT
   set +e
   OUT="$(CODEX_BIN="$CODEX_STUB" CODEX_ACL_NORMALIZE="$NORM_STUB" SBL_HELPER="$LOCK_LIB" \
+      CODEX_JOBS_DIR="$JOBS_DIR" CODEX_REAP_HELPER="$REAP_STUB" \
       bash "$DISPATCH" "$@" 2>&1)"
   RC=$?
   set -e
@@ -338,6 +354,48 @@ printf '%s\n' "\$*" > "$TMP/codex.args"
 pwd > "$TMP/codex.cwd"
 exit 0
 EOF
+
+# --- 15: job registry (HIMMEL-840) - created during the run, removed after; --
+# the composed EXIT trap invokes the reap primitive with the codex CHILD's
+# own pid (never the dispatcher's own $$); rc propagation unchanged with the
+# new always-a-child flow. A dedicated slow stub records its own pid and
+# snapshots $CODEX_JOBS_DIR mid-run (the parent's registry write is racing
+# the child's start, so the child sleeps briefly first).
+: > "$LOG"; echo 0 > "$TMP/norm.rc"
+rm -f "$TMP/jobs-during.txt" "$TMP/codex.pid" "$TMP/reap.args"
+SLOW_CODEX_STUB="$TMP/codex-slow-stub"
+cat > "$SLOW_CODEX_STUB" <<EOF
+#!/usr/bin/env bash
+echo "codex" >> "$LOG"
+echo \$\$ > "$TMP/codex.pid"
+sleep 0.3
+ls "\$CODEX_JOBS_DIR" 2>/dev/null > "$TMP/jobs-during.txt"
+exit 0
+EOF
+chmod +x "$SLOW_CODEX_STUB"
+set +e
+OUT="$(CODEX_BIN="$SLOW_CODEX_STUB" CODEX_ACL_NORMALIZE="$NORM_STUB" SBL_HELPER="$LOCK_LIB" \
+    CODEX_JOBS_DIR="$JOBS_DIR" CODEX_REAP_HELPER="$REAP_STUB" \
+    bash "$DISPATCH" --worktree "$WT" do-it 2>&1)"
+RC=$?
+set -e
+assert_rc 0 "registry-test dispatch exits 0" "registry rc=$RC out=$OUT"
+case "$(cat "$TMP/jobs-during.txt" 2>/dev/null)" in
+  *.json) pass "job registry file present during the run" ;;
+  *) fail "job registry file missing during run: $(cat "$TMP/jobs-during.txt" 2>/dev/null)" ;;
+esac
+if [ -z "$(ls -A "$JOBS_DIR" 2>/dev/null)" ]; then
+  pass "job registry file removed after the run (EXIT trap cleanup)"
+else
+  fail "job registry file(s) left behind: $(ls "$JOBS_DIR")"
+fi
+CODEX_CHILD_PID_SEEN="$(cat "$TMP/codex.pid" 2>/dev/null)"
+case "$(cat "$TMP/reap.args" 2>/dev/null)" in
+  "--root-pid $CODEX_CHILD_PID_SEEN --started-at "*" --kill")
+    pass "reap primitive invoked with the codex child's own pid" ;;
+  *)
+    fail "reap.args: $(cat "$TMP/reap.args" 2>/dev/null) (expected root-pid=$CODEX_CHILD_PID_SEEN)" ;;
+esac
 
 echo
 if [ "$fails" -ne 0 ]; then

--- a/scripts/codex/test-reap-mcp-fleet.ps1
+++ b/scripts/codex/test-reap-mcp-fleet.ps1
@@ -89,6 +89,85 @@ Check 'codex.exe is a supervisor'  (Test-FleetSupervisor -Proc (Rec 1 0 'codex.e
 Check 'broker.mjs is a supervisor' (Test-FleetSupervisor -Proc (Rec 1 0 'node.exe' $BROKER))
 Check 'playwright node NOT a supervisor' (-not (Test-FleetSupervisor -Proc (Rec 1 0 'node.exe' '"node" @playwright/mcp/cli.js')))
 
+# --- HIMMEL-840: Get-DescendantPids (codex-exec CLI sandbox fleet) -----------
+# The codex-exec CLI sandbox spawns npx/node MCP servers under a cmd.exe
+# wrapper with NO codex path marker of their own once codex.exe is gone -
+# structurally invisible to Test-CodexOwned/Get-OrphanFleet above. The ONLY
+# way to identify them is the descendant-of-a-registered-root-pid walk this
+# primitive performs (dispatch-codex-exec.sh registers the codex child's pid
+# right after launch and calls this on its own EXIT).
+Write-Host "Test 6: codex-exec CLI sandbox fleet (dead registered root) reaped via descendant walk; a live-claude MCP fleet (same table, same process shapes) is spared"
+$sandboxProcs = @(
+  # dead codex-exec CLI root (pid 500) - ALREADY GONE from the table (simulates
+  # 'codex_pid dead': dispatch-codex-exec.sh's own child already exited).
+  (Rec 501 500 'cmd.exe'  'cmd.exe /c npx @upstash/context7-mcp')          # direct child of dead root -> descendant
+  (Rec 502 501 'node.exe' 'node C:\...\npx-cli.js @upstash/context7-mcp')  # grandchild, no codex marker -> descendant
+  (Rec 503 502 'node.exe' 'node mcp-server.js')                            # great-grandchild -> descendant
+
+  # live-claude session's OWN MCP servers - siblings under a DIFFERENT, LIVE
+  # parent (pid 700), same process shapes (cmd.exe/npx, node) as the sandbox
+  # fleet above. They must be spared because they are not descendants of 500,
+  # not because they look different.
+  (Rec 700 1   'node.exe' 'node claude cli')                               # live claude parent
+  (Rec 701 700 'node.exe' 'node qmd-mcp-server.js')                        # live sibling MCP
+  (Rec 702 700 'cmd.exe'  'cmd.exe /c npx @some/other-mcp')                # live sibling MCP, same shape as 501
+)
+$descPids = @(Get-DescendantPids -Procs $sandboxProcs -RootPid 500)
+$gotDescPids = @($descPids | Sort-Object)
+Check 'sandbox fleet {501,502,503} found via descendant walk' (($gotDescPids -join ',') -eq '501,502,503') "got=$($gotDescPids -join ',')"
+Check 'live-claude MCP 701 spared (not a descendant of 500)' (-not ($gotDescPids -contains 701))
+Check 'live-claude MCP 702 spared (same process shape as 501, still not a descendant)' (-not ($gotDescPids -contains 702))
+Check 'dead root pid 500 itself is not returned (only its descendants)' (-not ($gotDescPids -contains 500))
+
+Write-Host "Test 7: StartedAt >= CreationDate pid-reuse guard"
+$now = Get-Date
+$reused = @(
+  (Rec 511 510 'cmd.exe' 'cmd.exe /c npx old-unrelated-mcp')  # created well before our job started
+)
+$reused[0] | Add-Member -NotePropertyName CreationDate -NotePropertyValue ($now.AddMinutes(-60)) -Force
+$jobStartedEpoch = [long][DateTimeOffset]::new($now.ToUniversalTime()).ToUnixTimeSeconds()
+$descGuarded = @(Get-DescendantPids -Procs $reused -RootPid 510 -StartedAtEpoch $jobStartedEpoch)
+Check 'guard excludes a descendant that predates StartedAt (pid-reuse)' ($descGuarded.Count -eq 0) "got count=$($descGuarded.Count)"
+$descUnguarded = @(Get-DescendantPids -Procs $reused -RootPid 510)
+Check 'without StartedAt the same descendant IS found' ($descUnguarded.Count -eq 1 -and $descUnguarded[0] -eq 511)
+
+Write-Host "Test 8: empty/absent-root inputs do not throw"
+$emptyDesc = @(Get-DescendantPids -Procs @() -RootPid 999)
+Check 'empty proc table -> 0 descendants' ($emptyDesc.Count -eq 0)
+$noChildren = @(Get-DescendantPids -Procs $sandboxProcs -RootPid 999999)
+Check 'root pid with no children in the table -> 0 descendants' ($noChildren.Count -eq 0)
+
+Write-Host "Test 9: malformed argv - missing value for -RootPid/-StartedAt fails fast (no hang)"
+# The .sh twin's option-parsing loop had a `shift 2` no-op bug (HIMMEL-840
+# Fix 2) that spun forever on a missing value; PowerShell's own typed-param
+# binding already fails fast on this, but the coverage closes the parity gap
+# on both twins. Invokes the real script as a genuine subprocess (never the
+# dot-sourced -AsLibrary functions) so a regression would show up as an
+# actual hang, not just an in-process exception. Stdin is redirected from an
+# empty file so a would-be interactive prompt gets immediate EOF instead of
+# blocking.
+function Test-FailsFast([string[]]$ExtraArgs, [string]$Name) {
+  $inFile = [System.IO.Path]::GetTempFileName()
+  $outFile = [System.IO.Path]::GetTempFileName()
+  $errFile = [System.IO.Path]::GetTempFileName()
+  try {
+    $psArgs = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $Helper) + $ExtraArgs
+    $proc = Start-Process -FilePath (Get-Process -Id $PID).Path -ArgumentList $psArgs `
+      -NoNewWindow -PassThru -RedirectStandardInput $inFile -RedirectStandardOutput $outFile -RedirectStandardError $errFile
+    $finished = $proc.WaitForExit(10000)
+    if (-not $finished) {
+      try { $proc.Kill() } catch {}
+      Fail $Name 'timed out after 10s (hang)'
+    } else {
+      Check $Name ($proc.ExitCode -ne 0) "exit=$($proc.ExitCode)"
+    }
+  } finally {
+    Remove-Item -Path $inFile, $outFile, $errFile -Force -ErrorAction SilentlyContinue
+  }
+}
+Test-FailsFast @('-RootPid') 'missing -RootPid value fails fast (no hang)'
+Test-FailsFast @('-RootPid', '123', '-StartedAt') 'missing -StartedAt value fails fast (no hang)'
+
 Write-Host "Results: $Pass passed, $Fail failed"
 if ($Fail -ne 0) { exit 1 }
 exit 0

--- a/scripts/codex/test-reap-mcp-fleet.sh
+++ b/scripts/codex/test-reap-mcp-fleet.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Hermetic tests for the cross-platform descendant-walk logic added to
+# reap-mcp-fleet.sh by HIMMEL-840 (_reap_descendants - the bash twin of
+# reap-mcp-fleet.ps1's Get-DescendantPids, unit-tested in
+# test-reap-mcp-fleet.ps1). No real process table is touched: this file
+# sources reap-mcp-fleet.sh (the sourcing guard skips production code, only
+# defining functions - same seam shared-branch-lock.sh uses) and feeds
+# _reap_descendants a synthetic proc-table fixture.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+fails=0
+pass() { echo "  ok: $1"; }
+fail() { echo "  FAIL: $1" >&2; fails=$((fails + 1)); }
+
+# shellcheck source=scripts/codex/reap-mcp-fleet.sh
+. "$SCRIPT_DIR/reap-mcp-fleet.sh"
+
+# --- Test 1: codex-exec CLI sandbox fleet (dead registered root) found via --
+# the descendant walk; a live-claude MCP fleet (same table, same process
+# shapes) is spared because it is not a descendant of the dead root.
+TABLE_SANDBOX="500 1 100
+501 500 110
+502 501 111
+503 502 112
+700 1 50
+701 700 200
+702 700 201"
+# pid 500 (the dead codex-exec root) is deliberately ABSENT from the table -
+# only its still-live descendants (501/502/503) appear, exactly like the
+# real incident: codex.exe already exited, its MCP-fleet children did not.
+
+got="$(_reap_descendants "$TABLE_SANDBOX" 500 | sort -n | tr '\n' ',')"
+want="501,502,503,"
+if [ "$got" = "$want" ]; then
+  pass "sandbox fleet {501,502,503} found via descendant walk (got=$got)"
+else
+  fail "sandbox fleet mismatch: got=$got want=$want"
+fi
+
+case ",$got" in
+  *",701,"*) fail "live-claude MCP 701 wrongly reaped (not a descendant of 500)" ;;
+  *) pass "live-claude MCP 701 spared" ;;
+esac
+case ",$got" in
+  *",702,"*) fail "live-claude MCP 702 wrongly reaped (same process shape as 501, still not a descendant)" ;;
+  *) pass "live-claude MCP 702 spared" ;;
+esac
+case ",$got" in
+  *",500,"*) fail "dead root pid 500 itself must not be returned (only its descendants)" ;;
+  *) pass "dead root pid 500 itself not returned" ;;
+esac
+
+# --- Test 2: pid-reuse guard (started-at >= table's start-epoch column) -----
+TABLE_REUSE="510 1 100
+511 510 50"
+# pid 511's own start-epoch (50) predates the job's started-at (200) - it
+# belongs to whatever unrelated process reused pid 510's slot, not our job.
+guarded="$(_reap_descendants "$TABLE_REUSE" 510 200 | tr '\n' ',')"
+if [ -z "$guarded" ]; then
+  pass "pid-reuse guard excludes a descendant that predates started-at"
+else
+  fail "pid-reuse guard did not exclude: $guarded"
+fi
+unguarded="$(_reap_descendants "$TABLE_REUSE" 510 | tr '\n' ',')"
+if [ "$unguarded" = "511," ]; then
+  pass "without started-at the same descendant IS found"
+else
+  fail "unguarded walk mismatch: got=$unguarded want=511,"
+fi
+
+# --- Test 3: empty/absent-root inputs do not error -------------------------
+empty_out="$(_reap_descendants "" 999 || true)"
+if [ -z "$empty_out" ]; then
+  pass "empty proc table -> no descendants"
+else
+  fail "empty proc table produced output: $empty_out"
+fi
+none_out="$(_reap_descendants "$TABLE_SANDBOX" 999999 || true)"
+if [ -z "$none_out" ]; then
+  pass "root pid with no children in the table -> no descendants"
+else
+  fail "no-children root produced output: $none_out"
+fi
+
+# --- Test 4: malformed argv - missing option value fails fast, no hang ------
+# (HIMMEL-840 Fix 2: `shift 2` under `set -u` without `-e` was a no-op when
+# only one arg remained, spinning the option-parsing `while` loop forever -
+# confirmed rc=124 under `timeout` before the fix. Invokes the real script as
+# a subprocess, wrapped in `timeout`, so a regression here would show up as
+# rc=124 rather than hanging the whole test run.)
+out="$(timeout 5 bash "$SCRIPT_DIR/reap-mcp-fleet.sh" --root-pid 2>&1)"
+rc=$?
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 124 ]; then
+  pass "missing --root-pid value fails fast (rc=$rc, not a hang)"
+else
+  fail "missing --root-pid value: rc=$rc (want nonzero and not 124) out=$out"
+fi
+case "$out" in
+  *"missing value for --root-pid"*) pass "missing --root-pid value names the flag" ;;
+  *) fail "missing --root-pid value message: $out" ;;
+esac
+
+out="$(timeout 5 bash "$SCRIPT_DIR/reap-mcp-fleet.sh" --root-pid 123 --started-at 2>&1)"
+rc=$?
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 124 ]; then
+  pass "missing --started-at value fails fast (rc=$rc, not a hang)"
+else
+  fail "missing --started-at value: rc=$rc (want nonzero and not 124) out=$out"
+fi
+case "$out" in
+  *"missing value for --started-at"*) pass "missing --started-at value names the flag" ;;
+  *) fail "missing --started-at value message: $out" ;;
+esac
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "FAILED: $fails test(s)"
+  exit 1
+fi
+echo "ALL PASS"


### PR DESCRIPTION
## Summary

Registry-driven reaper for codex-exec-leaked MCP-server fleets + at-source EXIT-trap reap in the dispatcher (HIMMEL-840, operator priority — the codex-exec fleet leak hung the box at 102 node procs in session 26).

- `scripts/codex/reap-mcp-fleet.sh` + `.ps1` twin — registry-driven: each dispatch registers root pid + started-at; the reaper walks descendants of DEAD roots only. Safety guards on every entry path: root-still-alive → skip (registry-scan AND direct `--root-pid`/`-RootPid` paths, both twins), whole-second started-at identity check (PID-reuse defense), qmd/claude-parented servers spared.
- `dispatch-codex-exec.sh` — at-source EXIT-trap reap + registry entry; backgrounded codex child explicitly inherits caller stdin via `<&0` (documented in README).
- Option parsing fails fast on missing `--root-pid`/`--started-at` values instead of infinite-looping under `set -u` without `-e`.
- Hermetic proc-table fixture suites for both twins incl. malformed-argv fail-fast cases; dispatch suite covers registry + trap-reap.

## CR trail

- Round 1 (fresh-context reviewer, execution-verified): 0 Critical / 3 Important — backgrounded-child stdin `/dev/null` regression, missing-value infinite loop (repro rc=124), direct-pid path missing the root-still-alive guard. All three fixed + regression-tested.
- Verify round (Opus code-reviewer, fresh context): **SHIP — 0 Critical / 0 Important.** All four entry points' guards walked individually; started-at truncation bias verified conservative (under-reap direction) in both twins; `<&0` semantics checked for the no-stdin caller case; sh↔ps1 parity confirmed.
- Suites at commit time: sh reap ALL PASS, dispatch ALL PASS, ps1 25/25, shellcheck clean.

Note: this branch was rebuilt onto current main from the s27 worktree state (the earlier branch pointer never had the commits; work was staged-only — recovered via patch, all suites re-run in the fresh worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
