### PR TITLE
fix(machine-setup): [HIMMEL-802] PS 5.1 native-exit-code checks — Invoke-Fatal section + per-call Invoke-NonFatal

### DIFF
--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -128,10 +128,15 @@ function Install-Plugins {
         # project scope writes to the CWD's .claude/settings.json — run from
         # $Target so plugins land in the adopted repo, not the himmel clone.
         Push-Location $Target
-        try { & pwsh -NoProfile -File $ip @pluginArgs } finally { Pop-Location }
+        try {
+            & pwsh -NoProfile -File $ip @pluginArgs
+            $pluginRc = $LASTEXITCODE
+        } finally { Pop-Location }
     } else {
         & pwsh -NoProfile -File $ip @pluginArgs
+        $pluginRc = $LASTEXITCODE
     }
+    if ($pluginRc -ne 0) { throw "install-plugins failed (exit $pluginRc)" }
 }
 
 # statusLine — part of the core harness (HIMMEL-359). Wired into the

--- a/scripts/codex/install-himmel-codex.ps1
+++ b/scripts/codex/install-himmel-codex.ps1
@@ -83,7 +83,11 @@ if ($mkPresent) {
   Write-Host "UNCHANGED   : marketplace '$Marketplace' already registered"
 } else {
   if ($DryRun) { Write-Host "WOULD ADD   : marketplace '$Marketplace' -> $MarketPath" }
-  else { & $Codex plugin marketplace add $MarketPath | Out-Null; Write-Host "CHANGED     : registered marketplace '$Marketplace' -> $MarketPath" }
+  else {
+    & $Codex plugin marketplace add $MarketPath | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "plugin marketplace add failed (exit $LASTEXITCODE) for $MarketPath" }
+    Write-Host "CHANGED     : registered marketplace '$Marketplace' -> $MarketPath"
+  }
   $changed++
 }
 
@@ -103,7 +107,11 @@ foreach ($p in $PluginSet) {
     Write-Host "UNCHANGED   : $sel (installed, enabled)"
   } else {
     if ($DryRun) { Write-Host "WOULD ADD   : $sel" }
-    else { & $Codex plugin add $sel | Out-Null; Write-Host "CHANGED     : enabled $sel" }
+    else {
+      & $Codex plugin add $sel | Out-Null
+      if ($LASTEXITCODE -ne 0) { throw "plugin add failed (exit $LASTEXITCODE) for $sel" }
+      Write-Host "CHANGED     : enabled $sel"
+    }
     $changed++
   }
 }
@@ -118,6 +126,7 @@ Write-Host "--- 3. sanitize external-plugin hooks.json (codex strict-parser work
 $sanitizer = Join-Path $PSScriptRoot "sanitize-plugin-hooks.ps1"
 try {
   if ($DryRun) { & $sanitizer -DryRun } else { & $sanitizer }
+  if ($LASTEXITCODE -ne 0) { throw "sanitize step failed (exit $LASTEXITCODE)" }
 } catch {
   Write-Warning "sanitize step failed (non-fatal): $($_.Exception.Message)"
 }

--- a/scripts/codex/test-install-himmel-codex.ps1
+++ b/scripts/codex/test-install-himmel-codex.ps1
@@ -35,14 +35,22 @@ if ($a[0] -eq "plugin" -and $a[1] -eq "marketplace" -and $a[2] -eq "list") {
   if (Test-Path $mf) { Get-Content $mf | ForEach-Object { if ($_) { "{0}  /fake/{1}" -f $_, $_ } } }
   exit 0
 }
-if ($a[0] -eq "plugin" -and $a[1] -eq "marketplace" -and $a[2] -eq "add") { Log "marketplace add $($a[3])"; exit 0 }
+if ($a[0] -eq "plugin" -and $a[1] -eq "marketplace" -and $a[2] -eq "add") {
+  Log "marketplace add $($a[3])"
+  if ($env:CODEX_STUB_FAIL_MARKETPLACE_ADD -eq "1") { exit 11 }
+  exit 0
+}
 if ($a[0] -eq "plugin" -and $a[1] -eq "list") {
   "PLUGIN                                   STATUS              VERSION  PATH"
   $pf = Join-Path $S "plugins.txt"
   if (Test-Path $pf) { Get-Content $pf | ForEach-Object { if ($_) { $p = $_ -split "`t"; "{0}  {1}  local  /fake/{2}" -f $p[0], $p[1], $p[0] } } }
   exit 0
 }
-if ($a[0] -eq "plugin" -and $a[1] -eq "add")    { Log "plugin add $($a[2])"; exit 0 }
+if ($a[0] -eq "plugin" -and $a[1] -eq "add")    {
+  Log "plugin add $($a[2])"
+  if ($env:CODEX_STUB_FAIL_PLUGIN_ADD -eq "1") { exit 13 }
+  exit 0
+}
 if ($a[0] -eq "plugin" -and $a[1] -eq "remove") { Log "plugin remove $($a[2])"; exit 0 }
 exit 0
 '@
@@ -167,6 +175,21 @@ exit 0
   Set-Content (Join-Path $S "marketplaces.txt") "himmel-extra"
   Invoke-Installer $S @("-Plugins","himmel-ops") | Out-Null
   Assert-LogHas (Join-Path $S "calls.log") "marketplace add" "registers 'himmel' when only 'himmel-extra' present (no substring false-match)"
+  Write-Host "== scenario K: marketplace add fails (mutation) -> exits non-zero, names the step + exit code =="
+  $S = New-State "K"
+  Set-Content (Join-Path $S "marketplaces.txt") "openai-bundled"
+  $env:CODEX_STUB_FAIL_MARKETPLACE_ADD = "1"
+  try { $r = Invoke-Installer $S @("-Plugins","himmel-ops") } finally { Remove-Item Env:CODEX_STUB_FAIL_MARKETPLACE_ADD -ErrorAction SilentlyContinue }
+  if ($r.Code -ne 0) { Pass "failed marketplace add exits non-zero" } else { Fail "failed marketplace add should exit non-zero" }
+  if ($r.Out -match "plugin marketplace add failed" -and $r.Out -match "exit 11") { Pass "error names marketplace-add step + exit code" } else { Fail "error message missing marketplace-add step/exit-code detail (got: $($r.Out))" }
+
+  Write-Host "== scenario L: plugin add fails (mutation) -> exits non-zero, names the step + exit code =="
+  $S = New-State "L"
+  Set-Content (Join-Path $S "marketplaces.txt") "himmel"
+  $env:CODEX_STUB_FAIL_PLUGIN_ADD = "1"
+  try { $r = Invoke-Installer $S @("-Plugins","himmel-ops") } finally { Remove-Item Env:CODEX_STUB_FAIL_PLUGIN_ADD -ErrorAction SilentlyContinue }
+  if ($r.Code -ne 0) { Pass "failed plugin add exits non-zero" } else { Fail "failed plugin add should exit non-zero" }
+  if ($r.Out -match "plugin add failed" -and $r.Out -match "exit 13") { Pass "error names plugin-add step + exit code" } else { Fail "error message missing plugin-add step/exit-code detail (got: $($r.Out))" }
 
   Write-Host ""
   if ($script:fails -eq 0) { Write-Host "ALL PASS" } else { Write-Host "$($script:fails) FAILED" -ForegroundColor Red; exit 1 }

--- a/scripts/machine-setup/test-win11-native-exits.ps1
+++ b/scripts/machine-setup/test-win11-native-exits.ps1
@@ -1,0 +1,38 @@
+<#
+  Focused helper test for machine-setup/win11.ps1 (HIMMEL-802). win11.ps1 is
+  administrator-gated and mutates the machine, so this extracts only its
+  Invoke-NonFatal helper and verifies a failed native command inside the block
+  is recorded as a non-fatal failure. try/catch alone does not catch that case.
+#>
+$ErrorActionPreference = "Stop"
+$ScriptDir = $PSScriptRoot
+$Source = Join-Path $ScriptDir "win11.ps1"
+
+$script:fails = 0
+function Pass($m) { Write-Host "  ok: $m" }
+function Fail($m) { Write-Host "  FAIL: $m" -ForegroundColor Red; $script:fails++ }
+
+$TMP = Join-Path ([System.IO.Path]::GetTempPath()) ("himmel-win11-native-test-" + [System.Guid]::NewGuid().ToString("N").Substring(0,8))
+New-Item -ItemType Directory -Force -Path $TMP | Out-Null
+try {
+  $raw = Get-Content -LiteralPath $Source -Raw
+  $start = $raw.IndexOf("function Invoke-NonFatal")
+  $end = $raw.IndexOf("function Write-SettingsJson")
+  if ($start -lt 0 -or $end -le $start) { throw "could not extract Invoke-NonFatal from $Source" }
+  Invoke-Expression $raw.Substring($start, $end - $start)
+
+  $failNative = Join-Path $TMP "fail-native.ps1"
+  Set-Content -Path $failNative -Encoding UTF8 -Value 'exit 29'
+  $Script:Step = 7
+  $Script:Failures = @()
+
+  Write-Host "== scenario A: native failure inside Invoke-NonFatal block is recorded =="
+  Invoke-NonFatal "stub native failure" { & $failNative }
+  if ($Script:Failures.Count -eq 1) { Pass "native failure recorded as non-fatal failure" } else { Fail "native failure should be recorded exactly once, got $($Script:Failures.Count)" }
+  if ($Script:Failures -match "stub native failure") { Pass "failure names the failed step" } else { Fail "failure did not name the failed step" }
+
+  Write-Host ""
+  if ($script:fails -eq 0) { Write-Host "ALL PASS" } else { Write-Host "$($script:fails) FAILED" -ForegroundColor Red; exit 1 }
+} finally {
+  Remove-Item $TMP -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/machine-setup/win11.ps1
+++ b/scripts/machine-setup/win11.ps1
@@ -25,12 +25,35 @@ function Write-Step($msg) {
     Write-Host "══════════════════════════════════════════════"
 }
 
+# Invoke-NonFatal: runs $block, logging + recording (never throwing out of this
+# function) on failure. LASTEXITCODE caveat: only the LAST native call inside
+# $block is checked automatically here — native commands don't raise PS
+# exceptions, so if $block runs MULTIPLE native calls, an earlier failure is
+# masked when a later native call in the same block resets $LASTEXITCODE to 0
+# on success. Blocks with more than one native call MUST add an explicit
+# `if ($LASTEXITCODE -ne 0) { throw ... }` check after EACH native call inside
+# the block (see the "Luna vault setup" / "obsidian-second-brain" blocks below
+# for the pattern) — do not rely on this function's own trailing check for them.
 function Invoke-NonFatal([string]$label, [scriptblock]$block) {
-    try { & $block }
+    try {
+        $global:LASTEXITCODE = 0
+        & $block
+        if ($LASTEXITCODE -ne 0) { throw "$label failed (exit $LASTEXITCODE)" }
+    }
     catch {
         Write-Host "  WARNING: $label failed — continuing"
         $Script:Failures += "Step $($Script:Step): $label"
     }
+}
+
+# Invoke-Fatal: runs $block and throws (aborting the script, $ErrorActionPreference
+# = 'Stop') if the LAST native call inside it left a nonzero $LASTEXITCODE. Same
+# one-check-per-block caveat as Invoke-NonFatal above — wrap ONE native call per
+# invocation (as done throughout the fatal steps below) to get a check per call.
+function Invoke-Fatal([string]$label, [scriptblock]$block) {
+    $global:LASTEXITCODE = 0
+    & $block
+    if ($LASTEXITCODE -ne 0) { throw "$label failed (exit $LASTEXITCODE)" }
 }
 
 function Write-SettingsJson([string]$Path, $Settings) {
@@ -52,18 +75,18 @@ function Write-SettingsJson([string]$Path, $Settings) {
 
 # ── Fatal steps (1–6) ───────────────────────────────────────────────────────
 Write-Step "Update package manager"
-winget upgrade --all --silent --accept-source-agreements --accept-package-agreements
+Invoke-Fatal "winget upgrade --all" { winget upgrade --all --silent --accept-source-agreements --accept-package-agreements }
 
 Write-Step "Install core tools: git, Node LTS, Python, jq, shellcheck, gitleaks"
 # shellcheck + gitleaks are referenced directly by .pre-commit-config.yaml hooks;
 # pre-commit downloads its own binaries inside the hook framework, but local
 # direct invocation (manual lint runs, smoke tests) needs them on PATH.
-winget install --id Git.Git -e --silent --accept-source-agreements --accept-package-agreements
-winget install --id OpenJS.NodeJS.LTS -e --silent --accept-source-agreements --accept-package-agreements
-winget install --id Python.Python.3 -e --silent --accept-source-agreements --accept-package-agreements
-winget install --id jqlang.jq -e --silent --accept-source-agreements --accept-package-agreements
-winget install --id koalaman.shellcheck -e --silent --accept-source-agreements --accept-package-agreements
-winget install --id Gitleaks.Gitleaks -e --silent --accept-source-agreements --accept-package-agreements
+Invoke-Fatal "winget install Git.Git" { winget install --id Git.Git -e --silent --accept-source-agreements --accept-package-agreements }
+Invoke-Fatal "winget install OpenJS.NodeJS.LTS" { winget install --id OpenJS.NodeJS.LTS -e --silent --accept-source-agreements --accept-package-agreements }
+Invoke-Fatal "winget install Python.Python.3" { winget install --id Python.Python.3 -e --silent --accept-source-agreements --accept-package-agreements }
+Invoke-Fatal "winget install jqlang.jq" { winget install --id jqlang.jq -e --silent --accept-source-agreements --accept-package-agreements }
+Invoke-Fatal "winget install koalaman.shellcheck" { winget install --id koalaman.shellcheck -e --silent --accept-source-agreements --accept-package-agreements }
+Invoke-Fatal "winget install Gitleaks.Gitleaks" { winget install --id Gitleaks.Gitleaks -e --silent --accept-source-agreements --accept-package-agreements }
 
 # Refresh PATH for current session after winget installs
 $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" +
@@ -71,7 +94,7 @@ $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";
 
 Write-Step "Install nvm-windows + Node from .nvmrc"
 if (-not (Get-Command nvm.exe -ErrorAction SilentlyContinue)) {
-    winget install --id CoreyButler.NVMforWindows -e --silent --accept-package-agreements --accept-source-agreements
+    Invoke-Fatal "winget install CoreyButler.NVMforWindows" { winget install --id CoreyButler.NVMforWindows -e --silent --accept-package-agreements --accept-source-agreements }
     # winget updates the registry PATH but the current process needs a refresh
     $machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
     $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
@@ -83,8 +106,8 @@ if (-not (Get-Command nvm.exe -ErrorAction SilentlyContinue)) {
     }
 }
 $NodeVersion = (Get-Content (Join-Path $RepoRoot '.nvmrc')).Trim()
-nvm install $NodeVersion
-nvm use $NodeVersion
+Invoke-Fatal "nvm install $NodeVersion" { nvm install $NodeVersion }
+Invoke-Fatal "nvm use $NodeVersion" { nvm use $NodeVersion }
 $Actual = (node --version) -replace '^v(\d+).*', '$1'
 $Expect = $NodeVersion -replace '^v?(\d+).*', '$1'
 if ($Actual -ne $Expect) {
@@ -98,12 +121,12 @@ irm https://astral.sh/uv/install.ps1 | iex
 # Refresh PATH so uv is available
 $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" +
             [System.Environment]::GetEnvironmentVariable("PATH", "User")
-uv --version
+Invoke-Fatal "uv --version" { uv --version }
 
 Write-Step "Install Claude Code CLI (native installer — no npm dependency)"
 Invoke-RestMethod "https://claude.ai/install.ps1" | Invoke-Expression
 $env:Path = "$env:LOCALAPPDATA\Programs\ClaudeCode;$env:Path"
-claude --version
+Invoke-Fatal "claude --version" { claude --version }
 
 Write-Step "Install RTK"
 $RtkTag = (Invoke-RestMethod "https://api.github.com/repos/rtk-ai/rtk/releases/latest").tag_name
@@ -124,13 +147,13 @@ if ($PathParts -notcontains $RtkInstallDir) {
 }
 $env:PATH = "$env:PATH;$RtkInstallDir"
 
-rtk init -g
-rtk --version
+Invoke-Fatal "rtk init -g" { rtk init -g }
+Invoke-Fatal "rtk --version" { rtk --version }
 
 Write-Step "Clone himmel + run repo setup"
 $HimmelParent = Split-Path $HimmelPath -Parent
 New-Item -ItemType Directory -Force $HimmelParent | Out-Null
-git clone https://github.com/yotamleo/himmel.git $HimmelPath
+Invoke-Fatal "git clone himmel" { git clone https://github.com/yotamleo/himmel.git $HimmelPath }
 Push-Location $HimmelPath
 
 # HIMMEL-105: gate the clone for core.hooksPath misconfiguration BEFORE
@@ -142,17 +165,17 @@ if ($LASTEXITCODE -ne 0) {
     throw "check-hookspath.ps1 failed (exit $LASTEXITCODE) — refusing to run setup.ps1 on a misconfigured clone."
 }
 
-.\scripts\setup.ps1
+Invoke-Fatal "scripts/setup.ps1" { .\scripts\setup.ps1 }
 Pop-Location
 
 Write-Step "Build scripts/jira/dist + scripts/himmel-run/dist"
 Push-Location (Join-Path $HimmelPath 'scripts/jira')
-npm ci
-npm run build
+Invoke-Fatal "npm ci (scripts/jira)" { npm ci }
+Invoke-Fatal "npm run build (scripts/jira)" { npm run build }
 Pop-Location
 Push-Location (Join-Path $HimmelPath 'scripts/himmel-run')
-npm ci
-npm run build
+Invoke-Fatal "npm ci (scripts/himmel-run)" { npm ci }
+Invoke-Fatal "npm run build (scripts/himmel-run)" { npm run build }
 Pop-Location
 
 Write-Step "Add himmel-run to user PATH"
@@ -181,10 +204,12 @@ Invoke-NonFatal "obsidian-second-brain plugin" {
     New-Item -ItemType Directory -Force $PluginsDir | Out-Null
     git clone https://github.com/eugeniughelbur/obsidian-second-brain.git `
         "$PluginsDir\obsidian-second-brain"
+    if ($LASTEXITCODE -ne 0) { throw "git clone obsidian-second-brain failed (exit $LASTEXITCODE)" }
     $GitBash = "C:\Program Files\Git\bin\bash.exe"
     Push-Location "$PluginsDir\obsidian-second-brain"
     try {
         & $GitBash -c "./install.sh"
+        if ($LASTEXITCODE -ne 0) { throw "install.sh failed (exit $LASTEXITCODE)" }
     } finally {
         Pop-Location
     }
@@ -264,13 +289,17 @@ Invoke-NonFatal "Luna vault setup" {
         Write-Host '  luna vault already present - skipping clone'
     } else {
         git clone $LunaRemote $LunaVaultPath
+        if ($LASTEXITCODE -ne 0) { throw "git clone luna vault failed (exit $LASTEXITCODE)" }
     }
 
     Push-Location $LunaVaultPath
     try {
         uv tool install pre-commit
+        if ($LASTEXITCODE -ne 0) { throw "uv tool install pre-commit failed (exit $LASTEXITCODE)" }
         pre-commit install
+        if ($LASTEXITCODE -ne 0) { throw "pre-commit install failed (exit $LASTEXITCODE)" }
         pre-commit install --hook-type pre-push
+        if ($LASTEXITCODE -ne 0) { throw "pre-commit install --hook-type pre-push failed (exit $LASTEXITCODE)" }
     } finally {
         Pop-Location
     }

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -195,8 +195,11 @@ if ($LASTEXITCODE -ne 0) {
 
 Write-Host "[2/10] Installing git hooks (pre-commit, pre-push, commit-msg)..."
 python -m pre_commit install
+if ($LASTEXITCODE -ne 0) { throw "pre_commit install failed (exit $LASTEXITCODE)" }
 python -m pre_commit install --hook-type pre-push
+if ($LASTEXITCODE -ne 0) { throw "pre_commit install --hook-type pre-push failed (exit $LASTEXITCODE)" }
 python -m pre_commit install --hook-type commit-msg
+if ($LASTEXITCODE -ne 0) { throw "pre_commit install --hook-type commit-msg failed (exit $LASTEXITCODE)" }
 
 Write-Host "[3/10] Installing Jira CLI..."
 if (Get-Command node -ErrorAction SilentlyContinue) {
@@ -206,8 +209,11 @@ if (Get-Command node -ErrorAction SilentlyContinue) {
     } else {
         Push-Location "$RepoRoot\scripts\jira"
         npm install --silent
+        if ($LASTEXITCODE -ne 0) { throw "npm install failed (exit $LASTEXITCODE) in scripts\jira" }
         npm run build --silent
+        if ($LASTEXITCODE -ne 0) { throw "npm run build failed (exit $LASTEXITCODE) in scripts\jira" }
         npm link
+        if ($LASTEXITCODE -ne 0) { throw "npm link failed (exit $LASTEXITCODE) in scripts\jira" }
         Pop-Location
         Write-Host "  jira CLI installed. Run: jira --help"
     }
@@ -572,6 +578,7 @@ if ($installCs) {
             # Step 8: version probe.
             try {
                 & (Join-Path $binDir "cs.exe") version | ForEach-Object { Write-Host "  $_" }
+                if ($LASTEXITCODE -ne 0) { throw "cs.exe version failed (exit $LASTEXITCODE)" }
             } catch {
                 Write-Host "  Step 8 (cs.exe version probe) failed." -ForegroundColor Yellow
                 throw

--- a/scripts/test-adopt.ps1
+++ b/scripts/test-adopt.ps1
@@ -1,0 +1,84 @@
+<#
+  Hermetic native-exit test for adopt.ps1 (HIMMEL-802). The child run uses
+  stub tools on PATH; the stub pwsh fails only the install-plugins.ps1 child
+  call so the test proves adopt.ps1 itself checks that native exit code.
+#>
+$ErrorActionPreference = "Stop"
+$ScriptDir = $PSScriptRoot
+$Installer = Join-Path $ScriptDir "adopt.ps1"
+
+$script:fails = 0
+function Pass($m) { Write-Host "  ok: $m" }
+function Fail($m) { Write-Host "  FAIL: $m" -ForegroundColor Red; $script:fails++ }
+
+$TMP = Join-Path ([System.IO.Path]::GetTempPath()) ("himmel-adopt-native-test-" + [System.Guid]::NewGuid().ToString("N").Substring(0,8))
+New-Item -ItemType Directory -Force -Path $TMP | Out-Null
+try {
+  $StubDir = Join-Path $TMP "bin"
+  $Target = Join-Path $TMP "target"
+  New-Item -ItemType Directory -Force -Path $StubDir,$Target | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $Target '.claude') | Out-Null
+  Set-Content -Path (Join-Path $Target '.claude\settings.json') -Value '{}'
+  $Log = Join-Path $TMP "calls.log"
+  Set-Content -Path $Log -Value "" -NoNewline
+
+  foreach ($name in @("git","python3","claude")) {
+    Set-Content -Path (Join-Path $StubDir "$name.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  }
+  Set-Content -Path (Join-Path $StubDir "jq.cmd") -Encoding ASCII -Value "@echo off`r`necho {}`r`nexit /b 0`r`n"
+  Set-Content -Path (Join-Path $StubDir "pwsh.cmd") -Encoding ASCII -Value @"
+@echo off
+echo %*>> "%ADOPT_STUB_LOG%"
+echo %* | findstr /i "install-plugins.ps1" >nul
+if %errorlevel%==0 exit /b 23
+exit /b 0
+"@
+
+  $realPwsh = (Get-Command pwsh -CommandType Application).Source
+  $oldPath = $env:Path
+  $oldLog = $env:ADOPT_STUB_LOG
+  $env:Path = "$StubDir;$env:SystemRoot\System32;$env:SystemRoot"
+  $env:ADOPT_STUB_LOG = $Log
+  try {
+    $out = & $realPwsh -NoProfile -NonInteractive -File $Installer -Profile core -Scope project -Target $Target 2>&1 | Out-String
+    $code = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+    if ($null -eq $oldLog) { Remove-Item Env:ADOPT_STUB_LOG -ErrorAction SilentlyContinue } else { $env:ADOPT_STUB_LOG = $oldLog }
+  }
+
+  Write-Host "== scenario A: install-plugins child fails (mutation) -> exits non-zero, names the step + exit code =="
+  if ($code -ne 0) { Pass "failed install-plugins exits non-zero" } else { Fail "failed install-plugins should exit non-zero" }
+  if ($out -match "install-plugins failed" -and $out -match "exit \d+") { Pass "error names install-plugins step + exit code" } else { Fail "error message missing install-plugins step/exit-code detail (got: $out)" }
+
+  Write-Host ""
+  Write-Host "== scenario B: -Scope user (no Push-Location branch in Install-Plugins) hits the same check =="
+  # -Scope user reads/writes `$HOME\.claude\settings.json` (adopt.ps1 line ~408)
+  # instead of -Target's `.claude\settings.json` — redirect the child process's
+  # HOME to a sandboxed fake profile so this test never touches the real
+  # operator ~/.claude/settings.json.
+  $UserHome = Join-Path $TMP "userhome"
+  New-Item -ItemType Directory -Force -Path (Join-Path $UserHome '.claude') | Out-Null
+  Set-Content -Path (Join-Path $UserHome '.claude\settings.json') -Value '{}'
+
+  $oldUserProfile = $env:USERPROFILE
+  $env:Path = "$StubDir;$env:SystemRoot\System32;$env:SystemRoot"
+  $env:ADOPT_STUB_LOG = $Log
+  $env:USERPROFILE = $UserHome
+  try {
+    $outB = & $realPwsh -NoProfile -NonInteractive -File $Installer -Profile core -Scope user 2>&1 | Out-String
+    $codeB = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+    $env:USERPROFILE = $oldUserProfile
+    if ($null -eq $oldLog) { Remove-Item Env:ADOPT_STUB_LOG -ErrorAction SilentlyContinue } else { $env:ADOPT_STUB_LOG = $oldLog }
+  }
+
+  if ($codeB -ne 0) { Pass "user-scope failed install-plugins exits non-zero" } else { Fail "user-scope failed install-plugins should exit non-zero" }
+  if ($outB -match "install-plugins failed" -and $outB -match "exit \d+") { Pass "user-scope error names install-plugins step + exit code" } else { Fail "user-scope error message missing install-plugins step/exit-code detail (got: $outB)" }
+
+  Write-Host ""
+  if ($script:fails -eq 0) { Write-Host "ALL PASS" } else { Write-Host "$($script:fails) FAILED" -ForegroundColor Red; exit 1 }
+} finally {
+  Remove-Item $TMP -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/test-setup.ps1
+++ b/scripts/test-setup.ps1
@@ -1,0 +1,75 @@
+<#
+  Hermetic native-exit test for setup.ps1 (HIMMEL-802). The child run resolves
+  a fake repo root through stub git and uses stub native tools. The python stub
+  fails only the pre_commit install mutation so setup.ps1 must stop there with
+  the native exit code instead of drifting into later setup steps.
+#>
+$ErrorActionPreference = "Stop"
+$ScriptDir = $PSScriptRoot
+$Installer = Join-Path $ScriptDir "setup.ps1"
+
+$script:fails = 0
+function Pass($m) { Write-Host "  ok: $m" }
+function Fail($m) { Write-Host "  FAIL: $m" -ForegroundColor Red; $script:fails++ }
+
+$TMP = Join-Path ([System.IO.Path]::GetTempPath()) ("himmel-setup-native-test-" + [System.Guid]::NewGuid().ToString("N").Substring(0,8))
+New-Item -ItemType Directory -Force -Path $TMP | Out-Null
+try {
+  $StubDir = Join-Path $TMP "bin"
+  $FakeRoot = Join-Path $TMP "repo"
+  $FakeHome = Join-Path $TMP "home"
+  New-Item -ItemType Directory -Force -Path $StubDir,$FakeRoot,$FakeHome | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $FakeRoot "scripts\jira") | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $FakeRoot "scripts\lib") | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $FakeRoot "scripts\setup") | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $FakeRoot "scripts\machine-setup") | Out-Null
+  Set-Content -Path (Join-Path $FakeRoot ".env.example") -Value "JIRA_API_TOKEN=`n"
+  Set-Content -Path (Join-Path $FakeRoot "scripts\lib\fix-qmd-stub.sh") -Encoding ASCII -Value "#!/usr/bin/env bash`nexit 0`n"
+  Set-Content -Path (Join-Path $FakeRoot "scripts\handover-link.sh") -Encoding ASCII -Value "#!/usr/bin/env bash`nexit 0`n"
+
+  foreach ($name in @("node","npm","bun","jq","gh","bash","claude","pwsh")) {
+    Set-Content -Path (Join-Path $StubDir "$name.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  }
+  Set-Content -Path (Join-Path $StubDir "git.cmd") -Encoding ASCII -Value @"
+@echo off
+echo %* | findstr /i "rev-parse" >nul
+if %errorlevel%==0 (
+  echo %SETUP_FAKE_ROOT%
+  exit /b 0
+)
+exit /b 0
+"@
+  Set-Content -Path (Join-Path $StubDir "python.cmd") -Encoding ASCII -Value @"
+@echo off
+if "%1"=="-m" if "%2"=="pre_commit" if "%3"=="install" exit /b 17
+exit /b 0
+"@
+
+  $realPwsh = (Get-Command pwsh -CommandType Application).Source
+  $oldPath = $env:Path
+  $oldRoot = $env:SETUP_FAKE_ROOT
+  $oldHome = $env:HOME
+  $oldUserProfile = $env:USERPROFILE
+  $env:Path = "$StubDir;$env:SystemRoot\System32;$env:SystemRoot"
+  $env:SETUP_FAKE_ROOT = $FakeRoot
+  $env:HOME = $FakeHome
+  $env:USERPROFILE = $FakeHome
+  try {
+    $out = & $realPwsh -NoProfile -NonInteractive -File $Installer 2>&1 | Out-String
+    $code = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+    if ($null -eq $oldRoot) { Remove-Item Env:SETUP_FAKE_ROOT -ErrorAction SilentlyContinue } else { $env:SETUP_FAKE_ROOT = $oldRoot }
+    if ($null -eq $oldHome) { Remove-Item Env:HOME -ErrorAction SilentlyContinue } else { $env:HOME = $oldHome }
+    if ($null -eq $oldUserProfile) { Remove-Item Env:USERPROFILE -ErrorAction SilentlyContinue } else { $env:USERPROFILE = $oldUserProfile }
+  }
+
+  Write-Host "== scenario A: pre_commit hook install fails (mutation) -> exits non-zero, names the step + exit code =="
+  if ($code -ne 0) { Pass "failed pre_commit install exits non-zero" } else { Fail "failed pre_commit install should exit non-zero" }
+  if ($out -match "pre_commit install failed" -and $out -match "exit 17") { Pass "error names pre_commit install step + exit code" } else { Fail "error message missing pre_commit install step/exit-code detail (got: $out)" }
+
+  Write-Host ""
+  if ($script:fails -eq 0) { Write-Host "ALL PASS" } else { Write-Host "$($script:fails) FAILED" -ForegroundColor Red; exit 1 }
+} finally {
+  Remove-Item $TMP -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary

Machine-setup PowerShell scripts now fail properly on native-command exits (HIMMEL-802). Target is Windows PowerShell 5.1, where `$ErrorActionPreference` does NOT catch native exit codes — only explicit `$LASTEXITCODE` checks do.

- `Invoke-Fatal` helper wraps every native call in win11.ps1's fatal section (21 call sites: winget, nvm, uv, claude, rtk, git clone, setup.ps1, npm ci/build); resets `$global:LASTEXITCODE` before each block so cmdlet-only blocks can't false-throw on a stale code.
- `Invoke-NonFatal` multi-statement blocks check `$LASTEXITCODE` after EACH native call (luna-clone and obsidian-plugin blocks) instead of only the last; limitation documented in the helper's doc comment.
- `test-adopt.ps1` scenario B covers the `-Scope user` path with `USERPROFILE` sandboxed to a temp dir (never touches the real `~/.claude/settings.json`).

## CR trail

- Round 1 review: 0 Critical / 2 Important (fatal-section unchecked native calls; last-call-only Invoke-NonFatal checks) — both fixed in 250842c3. Panel suggestions qwen3coder-1/2 were reviewer-REFUTED and left untouched.
- Verify round (Opus code-reviewer, fresh context): **SHIP — 0 Critical / 0 Important.** `$LASTEXITCODE` reset semantics empirically confirmed (no false throw after a prior native failure); fatal-section coverage audited call-by-call with no stragglers (the three unwrapped reads are value-checked or cmdlet-pipelines with immediate Invoke-Fatal probes); per-call throws confirmed to convert to the non-fatal WARNING path; the `git insteadOf` control-flow traced to `$LASTEXITCODE=0` on all branches.
- Parse-clean on all changed .ps1; `test-win11-native-exits.ps1` + `test-adopt.ps1` scenarios A+B ALL PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
