### PR TITLE
feat(hooks): [HIMMEL-754] deterministic destructive-command floor across Claude + Codex lanes

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -24,6 +24,7 @@
       {
         "matcher": "Bash|PowerShell",
         "hooks": [
+          { "type": "command", "command": ".codex/run-hook.cmd --sandbox block-destructive-commands.sh" },
           { "type": "command", "command": ".codex/run-hook.cmd --sandbox block-docker-privesc.sh" },
           { "type": "command", "command": ".codex/run-hook.cmd --sandbox block-merged-pr-commit.sh" },
           { "type": "command", "command": ".codex/run-hook.cmd --sandbox block-terminal-write-fence.sh" },

--- a/scripts/hooks/block-destructive-commands.sh
+++ b/scripts/hooks/block-destructive-commands.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash/PowerShell.
+#
+# Deterministic destructive-command floor shared by Claude and Codex lanes
+# (HIMMEL-754). Ports the TERMINAL_DESTRUCTIVE command classes from
+# scripts/hermes/assets/parity_guard.py: catastrophic/shared-machine/
+# irreversible terminal shapes only. Routine git/gh/mv/cp, non-recursive rm,
+# curl without remote-exec pipe, and normal git status/commit/push are allowed.
+#
+# Hook input arrives on stdin as JSON. Exit codes:
+#   0 - allow
+#   2 - block; stderr is shown to the model/user
+#
+# Bypass: set DESTRUCTIVE_OK=1 in the shell that launched the agent. Session-
+# sticky; restart without it to re-enable the guard.
+set -euo pipefail
+
+# Security hook: any unexpected top-level failure must deny, not fail open as a
+# plain rc=1 hook error.
+# shellcheck disable=SC2154 # rc is assigned inside the trap string.
+trap 'rc=$?; if [ "$rc" != 0 ] && [ "$rc" != 2 ]; then exit 2; fi' EXIT
+
+if [ "${DESTRUCTIVE_OK:-0}" = "1" ]; then
+    exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "block-destructive-commands: jq not on PATH - refusing to evaluate; install jq" >&2
+    exit 2
+fi
+
+input=$(cat)
+if ! printf '%s' "$input" | jq -e . >/dev/null 2>&1; then
+    echo "block-destructive-commands: malformed/truncated JSON on stdin - failing closed" >&2
+    exit 2
+fi
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)
+case "$tool" in
+    Bash|PowerShell|"") ;;
+    *) exit 0 ;;
+esac
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // .tool_input.cmd // empty' 2>/dev/null || true)
+[ -z "$cmd" ] && exit 0
+
+# parity_guard.norm() lower-cases before applying TERMINAL_DESTRUCTIVE. Newlines
+# separate shell commands, so preserve them as semicolon boundaries.
+cmd_lc=$(printf '%s' "$cmd" | LC_ALL=C tr '[:upper:]' '[:lower:]' | LC_ALL=C tr '\n\r' ';;')
+
+contains() {
+    printf '%s' "$cmd_lc" | grep -Eq "$1"
+}
+
+deny() {
+    echo "block-destructive-commands: destructive command refused ($1)" >&2
+    exit 2
+}
+
+# Binary boundary helpers are inlined in the patterns below. Every binary atom
+# that parity_guard names tolerates an optional .exe suffix for the Windows lane.
+# Bare-name atoms (format/schtasks/taskkill/shutdown/icacls classes) anchor to
+# COMMAND POSITION - start of command or right after a separator, tolerating
+# whitespace and env-var assignment prefixes - so the bare word inside an
+# argument (git log --pretty=format:, grep -rn format src/) does not match.
+# Mirrors parity_guard.py's _CMDPOS idiom for the external-write fence.
+CMDPOS='(^|[|;&(`])[[:space:]]*([[:alnum:]_]+=[^[:space:]|;&]*[[:space:]]+)*'
+if contains '(^|[^[:alnum:]_.-])rm(\.exe)?([^[:alnum:]_.-][^|;&]*)?[[:space:]]-[[:alnum:]_]*r'; then
+    deny "recursive rm"
+fi
+if contains '(^|[^[:alnum:]_.-])rm(\.exe)?([^[:alnum:]_.-]|$)[^|;&]*--recursive([^[:alnum:]_-]|$)'; then
+    deny "recursive rm"
+fi
+if contains '(^|[^[:alnum:]_.-])(del|erase|rd|rmdir)(\.exe)?([^[:alnum:]_.-]|$)[^|;&]*/s'; then
+    deny "recursive Windows delete"
+fi
+# mkfs keeps no trailing boundary (parity: \bmkfs) so mkfs.ext4 still matches.
+if contains "${CMDPOS}"'((format|diskpart|bcdedit)(\.exe)?([^[:alnum:]_.-]|$)|mkfs)'; then
+    deny "disk/boot mutation"
+fi
+if contains '(^|[^[:alnum:]_.-])cipher(\.exe)?[[:space:]]+/w'; then
+    deny "disk wipe"
+fi
+if contains "${CMDPOS}"'schtasks(\.exe)?([^[:alnum:]_.-]|$)'; then
+    deny "scheduled-task mutation"
+fi
+if contains "${CMDPOS}"'(taskkill|stop-process|pskill)(\.exe)?([^[:alnum:]_.-]|$)'; then
+    deny "process termination"
+fi
+if contains '(^|[^[:alnum:]_.-])kill(\.exe)?[[:space:]]+-9'; then
+    deny "process termination"
+fi
+if contains "${CMDPOS}"'(shutdown|reboot|logoff)(\.exe)?([^[:alnum:]_.-]|$)'; then
+    deny "system shutdown"
+fi
+if contains '(^|[^[:alnum:]_.-])reg(\.exe)?[[:space:]]+(add|delete)([[:space:]]|$)'; then
+    deny "registry mutation"
+fi
+if contains "${CMDPOS}"'(icacls|takeown)(\.exe)?([^[:alnum:]_.-]|$)'; then
+    deny "permission mutation"
+fi
+if contains '(^|[^[:alnum:]_.-])git(\.exe)?[[:space:]]+push([^|;&]*)(--force|--force-with-lease|[[:space:]]-f([^[:alnum:]_-]|$))'; then
+    deny "force push"
+fi
+if contains '(^|[^[:alnum:]_.-])git(\.exe)?[[:space:]]+reset[[:space:]]+--hard([^[:alnum:]_-]|$)'; then
+    deny "git reset --hard"
+fi
+if contains '(^|[^[:alnum:]_.-])git(\.exe)?[[:space:]]+clean[[:space:]]+-[[:alnum:]_]*f'; then
+    deny "git clean -f"
+fi
+if contains '(^|[^[:alnum:]_.-])git(\.exe)?[[:space:]]+filter-branch([^[:alnum:]_-]|$)'; then
+    deny "git filter-branch"
+fi
+if contains '(^|[^[:alnum:]_.-])curl(\.exe)?[^|;&]*\|[[:space:]]*(ba)?sh(\.exe)?([^[:alnum:]_.-]|$)'; then
+    deny "remote exec pipe"
+fi
+if contains '(^|[^[:alnum:]_.-])wget(\.exe)?[^|;&]*\|[[:space:]]*(ba)?sh(\.exe)?([^[:alnum:]_.-]|$)'; then
+    deny "remote exec pipe"
+fi
+
+exit 0

--- a/scripts/hooks/test-block-destructive-commands.sh
+++ b/scripts/hooks/test-block-destructive-commands.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/hooks/block-destructive-commands.sh.
+#
+# Usage: bash scripts/hooks/test-block-destructive-commands.sh
+#
+# Exit codes:
+#   0 - all cases passed
+#   1 - at least one case failed
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/block-destructive-commands.sh"
+[ -x "$HOOK" ] || chmod +x "$HOOK" 2>/dev/null || true
+
+FAILED=0
+
+run_case() {
+    local input="$1"
+    local env_assign="${2:-}"
+    if [ -n "$env_assign" ]; then
+        printf '%s' "$input" | env "$env_assign" bash "$HOOK" >/dev/null 2>&1
+    else
+        printf '%s' "$input" | bash "$HOOK" >/dev/null 2>&1
+    fi
+    echo "$?"
+}
+
+assert_rc() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS $label (rc=$actual)"
+    else
+        echo "FAIL $label - expected rc=$expected, got rc=$actual"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+j_bash() { printf '{"tool_name":"Bash","tool_input":{"command":%s}}' "$(printf '%s' "$1" | jq -Rs .)"; }
+j_pwsh() { printf '{"tool_name":"PowerShell","tool_input":{"command":%s}}' "$(printf '%s' "$1" | jq -Rs .)"; }
+
+# --- BLOCK cases (expect rc=2) ---
+assert_rc "rm -rf /tmp/x"              2 "$(run_case "$(j_bash 'rm -rf /tmp/x')")"
+assert_rc "rm -fr x"                   2 "$(run_case "$(j_bash 'rm -fr x')")"
+assert_rc "rm.exe -rf x"               2 "$(run_case "$(j_bash 'rm.exe -rf x')")"
+assert_rc "git reset --hard"           2 "$(run_case "$(j_bash 'git reset --hard')")"
+assert_rc "git.exe reset --hard"       2 "$(run_case "$(j_bash 'git.exe reset --hard')")"
+assert_rc "git clean -fx"              2 "$(run_case "$(j_bash 'git clean -fx')")"
+assert_rc "git filter-branch"          2 "$(run_case "$(j_bash 'git filter-branch --tree-filter true')")"
+assert_rc "curl pipe sh"               2 "$(run_case "$(j_bash 'curl http://x | sh')")"
+assert_rc "curl.exe pipe bash"         2 "$(run_case "$(j_bash 'curl.exe http://x | bash')")"
+assert_rc "wget pipe bash"             2 "$(run_case "$(j_bash 'wget -qO- x | bash')")"
+assert_rc "wget.exe pipe sh"           2 "$(run_case "$(j_bash 'wget.exe -qO- x | sh')")"
+assert_rc "schtasks create"            2 "$(run_case "$(j_bash 'schtasks /create /tn x /tr y')")"
+assert_rc "schtasks.exe create"        2 "$(run_case "$(j_bash 'schtasks.exe /create /tn x /tr y')")"
+assert_rc "del /s /q x"                2 "$(run_case "$(j_bash 'del /s /q x')")"
+assert_rc "PowerShell shutdown.exe"    2 "$(run_case "$(j_pwsh 'shutdown.exe /s /t 0')")"
+assert_rc "format c:"                  2 "$(run_case "$(j_bash 'format c:')")"
+assert_rc "shutdown /s now"            2 "$(run_case "$(j_bash 'shutdown /s now')")"
+assert_rc "x; shutdown -r"             2 "$(run_case "$(j_bash 'x; shutdown -r')")"
+assert_rc "foo && reboot"              2 "$(run_case "$(j_bash 'foo && reboot')")"
+assert_rc "mkfs.ext4 /dev/sda"         2 "$(run_case "$(j_bash 'mkfs.ext4 /dev/sda')")"
+assert_rc "FOO=1 shutdown -r"          2 "$(run_case "$(j_bash 'FOO=1 shutdown -r')")"
+# shellcheck disable=SC2016  # literal backtick payload is the point of this case
+assert_rc "backtick format subst"      2 "$(run_case "$(j_bash 'echo `format c:`')")"
+
+# --- ALLOW cases (expect rc=0) ---
+assert_rc "rmtemp.sh -r foo"           0 "$(run_case "$(j_bash 'rmtemp.sh -r foo')")"
+assert_rc "rmdir -r foo"               0 "$(run_case "$(j_bash 'rmdir -r foo')")"
+assert_rc "rm x.txt"                   0 "$(run_case "$(j_bash 'rm x.txt')")"
+assert_rc "git status"                 0 "$(run_case "$(j_bash 'git status')")"
+assert_rc "git commit -m x"            0 "$(run_case "$(j_bash 'git commit -m x')")"
+assert_rc "git push"                   0 "$(run_case "$(j_bash 'git push')")"
+assert_rc "mv a b"                     0 "$(run_case "$(j_bash 'mv a b')")"
+assert_rc "cp a b"                     0 "$(run_case "$(j_bash 'cp a b')")"
+assert_rc "gh pr view 1"               0 "$(run_case "$(j_bash 'gh pr view 1')")"
+assert_rc "curl without pipe"          0 "$(run_case "$(j_bash 'curl http://x -o f')")"
+assert_rc "git log --pretty=format:"   0 "$(run_case "$(j_bash 'git log --pretty=format:%H -n 5')")"
+assert_rc "git log quoted format"      0 "$(run_case "$(j_bash 'git log --pretty="format:%h %s"')")"
+assert_rc "grep -rn format src/"       0 "$(run_case "$(j_bash 'grep -rn format src/')")"
+assert_rc "rg format scripts/"         0 "$(run_case "$(j_bash 'rg "format" scripts/')")"
+assert_rc "commit msg mentions reboot" 0 "$(run_case "$(j_bash 'git commit -m "fix reboot loop"')")"
+assert_rc "non-terminal tool"          0 "$(run_case '{"tool_name":"Read","tool_input":{"file_path":"README.md"}}')"
+assert_rc "empty payload"              0 "$(run_case '{}')"
+
+# --- MALFORMED JSON case (expect rc=2, fail closed) ---
+assert_rc "truncated JSON + rm -rf" 2 "$(run_case '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/x"')"
+
+# --- BYPASS case ---
+assert_rc "DESTRUCTIVE_OK bypass"       0 "$(run_case "$(j_bash 'rm -rf /tmp/x')" "DESTRUCTIVE_OK=1")"
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+    echo "All cases passed."
+    exit 0
+else
+    echo "$FAILED case(s) failed."
+    exit 1
+fi

--- a/scripts/hooks/test-codex-adapter-e2e.sh
+++ b/scripts/hooks/test-codex-adapter-e2e.sh
@@ -67,5 +67,17 @@ case "$out" in
   *) ok "benign command -> no permissionDecision (passthrough allow)";;
 esac
 
+echo "== (c) destructive command through block-destructive-commands.sh =="
+out="$(run block-destructive-commands.sh '{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/x"}}')"; rc=$?
+if [ "$rc" -eq 0 ]; then ok "adapter exits 0 for destructive deny"; else bad "adapter exits 0 for destructive deny (got $rc)"; fi
+case "$out" in
+  *'"permissionDecision":"deny"'*) ok "rm -rf -> JSON deny";;
+  *) bad "rm -rf -> JSON deny ($out)";;
+esac
+case "$out" in
+  *"block-destructive-commands"*) ok "rm -rf -> reason names destructive guard";;
+  *) bad "rm -rf -> reason names destructive guard ($out)";;
+esac
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Deterministic destructive-command floor shared across Claude + Codex lanes (HIMMEL-754, epic HIMMEL-654) — a PreToolUse-shaped port of the hermes `parity_guard.py` destructive floor, so every lane denies the same terminal-destructive classes.

- `scripts/hooks/block-destructive-commands.sh` (new): denies recursive rm and Windows del/rd forms, disk/boot mutation, git reset --hard / clean -f / filter-branch / force-push, curl|wget piped to a shell, schtasks/process-kill/shutdown/registry/ACL mutation classes; exit 2; `DESTRUCTIVE_OK=1` session-env bypass mirrors the other guards.
- Fail-CLOSED everywhere: upfront `jq -e` validity pass (malformed stdin → exit 2), jq-absent → exit 2, EXIT trap converts unexpected rc to 2.
- Wiring: `.claude/settings.json` PreToolUse (Bash|PowerShell) + `.codex/hooks.json` sandbox entry (adapter exit-2 → JSON deny).
- 41-case red/green suite + codex-adapter e2e (11/11).

## CR trail

- Round 1 (execution-verified): 1 Critical — malformed JSON failed OPEN (`|| true`-guarded extractions never tripped the trap) — fixed + red-tested; 1 Important — missing right word-boundary over-blocked `rmtemp.sh -r` / `rmdir -r` — fixed + green-tested.
- Verify round (Opus code-reviewer, fresh context): 0 Critical / 1 Important — bare-name atoms (format/reboot/… classes) fired mid-argument, denying `git log --pretty=format:%H`, `grep -rn format`, `git commit -m "fix reboot loop"` (all empirically verified rc=2). Fixed in round 2 via `_CMDPOS`-style command-position anchoring (+ backtick-subst separator added in parent review); 6 new red + 5 new green tests.
- Known shared SPEC weaknesses (bare `/s` path-prefix, quoted-flag `rm "-rf"`, `${IFS}`/continuation bypass, and porting the command-position anchoring back to `parity_guard.py`) are tracked in HIMMEL-851 — joint lockstep fix, deliberately out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
