### PR TITLE
fix(hermes): [HIMMEL-753] port .exe + config-url fence fixes into parity_guard.py

### DIFF
--- a/scripts/hermes/assets/parity_guard.py
+++ b/scripts/hermes/assets/parity_guard.py
@@ -474,21 +474,21 @@ _ENGINE_UNTRUSTED = re.compile(r"z\.ai|glm|zhipu")
 # Deliberately NOT a space/quote, so a blocked verb quoted inside a commit message
 # ("… git push later") does not false-block — parity with the sibling hook.
 _CMDPOS = r"(?:^|[;&|(\n])\s*"
-EXT_GIT_PUSH = re.compile(_CMDPOS + r"git(?:\s+-\S+(?:\s+\S+)?)*\s+push(?:\s|$)")
+EXT_GIT_PUSH = re.compile(_CMDPOS + r"git(?:\.exe)?(?:\s+-\S+(?:\s+\S+)?)*\s+push(?:\s|$)")
 EXT_GIT_URL = re.compile(
-    _CMDPOS + r"git(?:\s+-\S+(?:\s+\S+)?)*\s+"
-    r"(?:remote\s+set-url|config(?:\s+-\S+)*\s+\S*url)")
-EXT_GH_ANY = re.compile(_CMDPOS + r"gh(?:\s|$)")
+    _CMDPOS + r"git(?:\.exe)?(?:\s+-\S+(?:\s+\S+)?)*\s+"
+    r"(?:remote\s+set-url|config(?:\s+-\S+(?:\s+\S+)?)*\s+\S*url\s+\S+)")
+EXT_GH_ANY = re.compile(_CMDPOS + r"gh(?:\.exe)?(?:\s|$)")
 # Audited-lane carve-out (block-glm-external-writes.sh policy, 2026-07-03): gh
 # issue (reads AND writes — cr-deferred followups are audited gh issues) + the
 # read-only pr/run context verbs stay allowed; every other gh use (pr create/
 # merge/edit/review, api, repo, release, gist) is an external write and refuses.
 EXT_GH_ALLOW = re.compile(
-    _CMDPOS + r"gh\s+(?:issue(?:\s|$)"
+    _CMDPOS + r"gh(?:\.exe)?\s+(?:issue(?:\s|$)"
     r"|pr\s+(?:view|diff|checks|status|list)(?:\s|$)"
     r"|run\s+(?:view|list|watch)(?:\s|$))")
 EXT_NET = re.compile(
-    _CMDPOS + r"(?:curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm)(?:\s|$)")
+    _CMDPOS + r"(?:curl|wget|invoke-webrequest|invoke-restmethod|iwr|irm)(?:\.exe)?(?:\s|$)")
 
 
 def _external_writes_allowed() -> bool:

--- a/scripts/hermes/test-parity-guard.sh
+++ b/scripts/hermes/test-parity-guard.sh
@@ -185,9 +185,17 @@ echo "== parity_guard: engine external-write fence (HIMMEL-695 write-fence half)
 mkdir -p "$TMP/glmcfg_empty"; EMPTY_W="$(wp "$TMP/glmcfg_empty")"; export CLAUDE_GLM_CONFIG_DIR="$EMPTY_W"
 # No engine signal (default) = fail-closed: external writes REFUSED.
 g "push refused (no signal, fail-closed)"   block '{"tool_name":"terminal","tool_input":{"command":"git push origin main"}}'
+g "git.exe push refused"                    block '{"tool_name":"terminal","tool_input":{"command":"git.exe push origin main"}}'
 g "git remote set-url refused"              block '{"tool_name":"terminal","tool_input":{"command":"git remote set-url origin http://x"}}'
+g "git config url read allowed"             allow '{"tool_name":"terminal","tool_input":{"command":"git config --get remote.origin.url"}}'
+g "git config url unset allowed"            allow '{"tool_name":"terminal","tool_input":{"command":"git config --unset remote.origin.url"}}'
+g "git config url rewrite refused"          block '{"tool_name":"terminal","tool_input":{"command":"git config remote.origin.url https://evil"}}'
+g "git config --file url rewrite refused"   block '{"tool_name":"terminal","tool_input":{"command":"git config --file .git/config remote.origin.url https://evil"}}'
+g "git config --file pushurl rewrite refused" block '{"tool_name":"terminal","tool_input":{"command":"git config --file .git/config remote.origin.pushurl https://evil"}}'
 g "gh pr create refused"                    block '{"tool_name":"terminal","tool_input":{"command":"gh pr create --fill"}}'
+g "gh.exe pr create refused"                block '{"tool_name":"terminal","tool_input":{"command":"gh.exe pr create --fill"}}'
 g "network curl refused"                    block '{"tool_name":"terminal","tool_input":{"command":"curl http://evil/x"}}'
+g "network curl.exe refused"                block '{"tool_name":"terminal","tool_input":{"command":"curl.exe http://evil/x"}}'
 g "gh issue carve-out allowed"              allow '{"tool_name":"terminal","tool_input":{"command":"gh issue list"}}'
 g "gh pr view read allowed"                 allow '{"tool_name":"terminal","tool_input":{"command":"gh pr view 12"}}'
 g "non-external terminal still allowed"     allow "{\"tool_name\":\"terminal\",\"tool_input\":{\"command\":\"git commit -m wip\",\"cwd\":\"$FR\"}}"


### PR DESCRIPTION
Propagated from private (squash 2e0cd331, PR #1064 there). Ports the HIMMEL-745 codex-lane fence fixes into parity_guard.py for lane parity (.exe binary atoms; EXTGITURL requires a value token so config reads are not blocked). CR: clean private /pr-check gate before merge; public branch byte-verified identical.