### PR TITLE
fix(guardrails): [HIMMEL-809] graphify-fence _abs drive-relative + backslash-form bypass (HIMMEL-808 port)

### DIFF
--- a/scripts/guardrails/graphify-fence.sh
+++ b/scripts/guardrails/graphify-fence.sh
@@ -213,15 +213,30 @@ _strip_cmd() {
 # _abs <path> -> absolute path (expanduser + anchor a relative path to PWD).
 _abs() {
     local p; p="$(_strip_wrap "$1")"
+    # Backslashes -> forward slashes BEFORE the absolute/relative split
+    # (HIMMEL-808): on POSIX a backslash-form target ('\tmp\x' or 'C:\x')
+    # matches neither /* nor [A-Za-z]:* below, gets anchored to cwd, and
+    # normalizes to a non-corpus path -> allow. Windows-payload parity on
+    # every host; fail-closed for the rare POSIX filename containing a
+    # literal backslash (_normalize already collapses them the same way).
+    p="${p//\\//}"
     # shellcheck disable=SC2088 # the "~/" is a literal case-pattern, not an expansion
     case "$p" in
         "~")   p="$HOME" ;;
         "~/"*) p="$HOME/${p#\~/}" ;;
     esac
     case "$p" in
-        /*)         : ;;             # POSIX absolute
-        [A-Za-z]:*) : ;;             # Windows drive-absolute (C:/...)
-        *)          p="$PWD/$p" ;;   # relative -> anchor to cwd
+        /*)          : ;;             # POSIX absolute
+        [A-Za-z]:/*) : ;;             # Windows drive-ROOTED absolute (C:/...)
+        [A-Za-z]:*)  p="$PWD/${p#?:}" ;;
+                     # Windows drive-RELATIVE (C:foo = foo relative to the
+                     # cwd on drive C). HIMMEL-808: the old [A-Za-z]:* arm
+                     # classified this absolute, and _normalize mangled it
+                     # into a synthetic non-corpus path. Anchor to the
+                     # current cwd instead - exact when cwd is on that drive
+                     # (the attack shape), and a fail-closed lexical
+                     # approximation otherwise.
+        *)           p="$PWD/$p" ;;   # relative -> anchor to cwd
     esac
     printf '%s' "$p"
 }

--- a/scripts/guardrails/test-graphify-fence.sh
+++ b/scripts/guardrails/test-graphify-fence.sh
@@ -424,6 +424,14 @@ ROOT_DRIVE=$( cd "$HIMMEL" && drive_form "$PWD" )
 run_fence allow no "$HIMMEL/scripts" "MSYS --version cwd-in-himmel (drive-lettered root) -> allow" \
     "graphify --version" GRAPHIFY_HIMMEL_ROOT="$ROOT_DRIVE"
 
+BACKSLASH_SALUS="$SALUS/notes/patient.md"
+BACKSLASH_SALUS="${BACKSLASH_SALUS//\//\\}"
+run_fence deny no "$HIMMEL" "backslash-form absolute salus path -> deny" \
+    "graphify update $BACKSLASH_SALUS --backend deepseek"
+
+run_fence allow no "$HIMMEL" "drive-relative C:scripts/thing.sh anchors to cwd -> allow" \
+    "graphify update C:scripts/thing.sh --backend deepseek"
+
 echo "== HIMMEL-778: .graphify-corpus staged-copy declaration =="
 
 STAGED="$WS/staged";        mkdir -p "$STAGED";        : > "$STAGED/copy.md";  printf 'luna-personal\n' > "$STAGED/.graphify-corpus"


### PR DESCRIPTION
Propagated from private (squash bc3a8feb, PR #1068 there). Ports the HIMMEL-808 lesson-write-fence _abs fixes into graphify-fence.sh (backslash normalization; only drive:/ is absolute; drive-relative anchors to payload cwd). Two regression cases. CR: clean private /pr-check gate before merge; public branch byte-verified identical.