### PR TITLE
feat(cr): [HIMMEL-727] adopter-safe registry — universal defaults + operator-local overlay + opt-in provider routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ logs/gemini/
 .agents/skills/source-command-*/
 # himmel-contributor marker (opt-in; enables doc-guard gate) — never commit it
 .himmel-dev
+# per-operator CR registry overlay (account quota state) — never commit (HIMMEL-727)
+scripts/cr/critics.local.json

--- a/docs/hermes-runbook.md
+++ b/docs/hermes-runbook.md
@@ -356,7 +356,7 @@ Add one alias per tier you want reachable. Claude-tier parity map:
 | sonnet | `qwen-plus` |
 | opus | `qwen3-max` / `qwen3.7-max` |
 | thinking / fable | `qwq-plus` / `qwen3-235b-a22b-thinking` |
-| CR critic | anchor row in `scripts/cr/critics.json` (2026-07-09: `qwen3.7-max`; `qwen3-coder-plus`/`qwen-plus` exhausted) |
+| CR critic | anchor row in `scripts/cr/critics.json` (per-account quota state — e.g. exhausted models swapped out — lives in the gitignored `scripts/cr/critics.local.json` overlay, HIMMEL-727) |
 
 ### Validate THROUGH hermes
 
@@ -374,9 +374,12 @@ one-shot auto-detect on `-m` re-overrides a profile's provider.
 ### Consumers
 
 The CR panel's free critic is anchored via this lane to the model in
-`scripts/cr/critics.json`'s anchor row (HIMMEL-725 introduced the lane;
-HIMMEL-838 swapped the anchor to `qwen3.7-max` after the 2026-07-09
-exhaustion). Free-quota exhaustion is why a quota guard is tracked
+the registry's anchor row (HIMMEL-725 introduced the lane). The shipped
+`scripts/cr/critics.json` carries UNIVERSAL defaults; when YOUR account's
+free quotas exhaust, record the swap in the gitignored
+`scripts/cr/critics.local.json` overlay (auto-picked-up, HIMMEL-727) —
+do not edit the shipped registry for account state (HIMMEL-838 did, reverted).
+Free-quota exhaustion is why a quota guard is tracked
 separately — it needs a dynamic API pull (console screenshots are not
 automatable).
 

--- a/scripts/cr/critic-first-pass.sh
+++ b/scripts/cr/critic-first-pass.sh
@@ -39,6 +39,7 @@ EOF
 }
 
 model=""
+provider=""
 slug=""
 pf=""
 artifact_mode=0
@@ -53,6 +54,9 @@ while [ $# -gt 0 ]; do
         --model)
             [ $# -ge 2 ] || { echo "critic-first-pass.sh: --model requires a value" >&2; exit 2; }
             model="$2"; shift 2 ;;
+        --provider)
+            [ $# -ge 2 ] || { echo "critic-first-pass.sh: --provider requires a value" >&2; exit 2; }
+            provider="$2"; shift 2 ;;
         --slug)
             [ $# -ge 2 ] || { echo "critic-first-pass.sh: --slug requires a value" >&2; exit 2; }
             slug="$2"; shift 2 ;;
@@ -356,10 +360,21 @@ fi
 # invoke.sh flags. `none`/empty → omit --profile (hermes default profile). An
 # array would hit the bash-3.2 `set -u` empty-array expansion bug, so branch instead.
 _cfp_invoke() {
+    # --provider threads the registry row's provider to hermes (HIMMEL-727) so
+    # model ids newer than hermes' catalog can't silently fall to its default
+    # provider. Branching (not arrays) for the same bash-3.2 reason as --profile.
     if [ -n "$_crit_profile" ] && [ "$_crit_profile" != "none" ]; then
-        bash "$INVOKE" --model "$model" --profile "$_crit_profile" --prompt-file "$pf"
+        if [ -n "$provider" ]; then
+            bash "$INVOKE" --model "$model" --provider "$provider" --profile "$_crit_profile" --prompt-file "$pf"
+        else
+            bash "$INVOKE" --model "$model" --profile "$_crit_profile" --prompt-file "$pf"
+        fi
     else
-        bash "$INVOKE" --model "$model" --prompt-file "$pf"
+        if [ -n "$provider" ]; then
+            bash "$INVOKE" --model "$model" --provider "$provider" --prompt-file "$pf"
+        else
+            bash "$INVOKE" --model "$model" --prompt-file "$pf"
+        fi
     fi
 }
 

--- a/scripts/cr/critic-panel.sh
+++ b/scripts/cr/critic-panel.sh
@@ -29,7 +29,18 @@ export LC_ALL
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CFP="${CRITIC_FIRST_PASS:-$SCRIPT_DIR/critic-first-pass.sh}"
-REG="${CRITICS_JSON:-$SCRIPT_DIR/critics.json}"
+# Registry resolution (HIMMEL-727 operator-vs-universal split): CRITICS_JSON env
+# (tests/CI) > critics.local.json (gitignored per-operator overlay — carries
+# ACCOUNT state like exhausted free quotas / upgraded models, so the shipped
+# registry stays adopter-neutral) > critics.json (universal defaults).
+if [ -n "${CRITICS_JSON:-}" ]; then
+    REG="$CRITICS_JSON"
+elif [ -f "$SCRIPT_DIR/critics.local.json" ]; then
+    REG="$SCRIPT_DIR/critics.local.json"
+    echo "critic-panel.sh: using operator-local registry critics.local.json" >&2
+else
+    REG="$SCRIPT_DIR/critics.json"
+fi
 INVOKE="${CRITIC_INVOKE:-$SCRIPT_DIR/../hermes/invoke.sh}"
 
 # Effective tier resolution (HIMMEL-558). CR_PROFILE is AUTHORITATIVE when set —
@@ -50,7 +61,7 @@ else
 fi
 
 ANCHOR_SLUG="qwen3coder"
-ANCHOR_MODEL="qwen3.7-max"
+ANCHOR_MODEL="qwen3-coder-plus"
 
 # Per-member timeout: validate CRITIC_TIMEOUT_SECS (Bash 3.2 safe via expr).
 CRITIC_TIMEOUT_SECS="${CRITIC_TIMEOUT_SECS:-240}"
@@ -103,7 +114,7 @@ if [ "$CHECK_MODE" = "1" ]; then
     const j = JSON.parse(fs.readFileSync(reg, "utf8"));
     const p = (j.panel || []).filter(r => r.slug && r.model);
     if (!p.length) throw new Error("no rows");
-    process.stdout.write(p.map(r => r.slug + "\t" + r.model + "\t" + (r.tier || "")).join("\n"));
+    process.stdout.write(p.map(r => r.slug + "\t" + r.model + "\t" + (r.tier || "") + "\t" + (r.route_provider || "-")).join("\n"));
   } catch (e) {
     process.exit(7);
   }
@@ -111,7 +122,7 @@ if [ "$CHECK_MODE" = "1" ]; then
 
     if [ -z "${check_rows:-}" ]; then
         echo "critic-panel.sh: registry $REG missing/invalid/empty — anchor-only ($ANCHOR_SLUG)" >&2
-        check_rows="${ANCHOR_SLUG}	${ANCHOR_MODEL}	free"
+        check_rows="${ANCHOR_SLUG}	${ANCHOR_MODEL}	free	-"
     fi
 
     check_prompt="$(mktemp -t critic-panel-check.XXXXXX)"
@@ -119,13 +130,14 @@ if [ "$CHECK_MODE" = "1" ]; then
     printf '%s' 'Reply with exactly: ok' > "$check_prompt"
 
     check_failed="0"
-    while IFS="	" read -r slug model tier; do
+    while IFS="	" read -r slug model tier row_provider; do
         [ -n "$slug" ] || continue
+        [ "$row_provider" = "-" ] && row_provider=""
         if [ "$tier" = "paid" ] && [ "$CHECK_ALL_TIERS" != "1" ]; then
             echo "row $slug: skipped (paid)"
             continue
         fi
-        "$INVOKE" --model "$model" --prompt-file "$check_prompt" >/dev/null 2>&1
+        "$INVOKE" --model "$model" --provider "$row_provider" --prompt-file "$check_prompt" >/dev/null 2>&1
         rc=$?
         if [ "$rc" -eq 0 ]; then
             echo "row $slug: ok"
@@ -216,12 +228,20 @@ rows="$(REG="$REG" TIER_FILTER="$TIER_FILTER" node -e '
     // Field 4 = the fallback CHAIN (HIMMEL-737): the ordered "fallback_models"
     // array, comma-joined; a legacy "fallback_model" string is a 1-element chain
     // for back-compat; "-" when empty. Model names never contain a comma or tab.
+    // Field 5 = ROUTE_PROVIDER (HIMMEL-727): OPT-IN per row. When set, threaded
+    // to hermes as an explicit --provider so a model id newer than the hermes
+    // internal catalog cannot fall to its default provider. Deliberately a
+    // SEPARATE key from the descriptive "provider" metadata: blanket-threading
+    // provider broke alias-routed rows (explicit --provider bypasses the hermes
+    // alias base_url -> 401 on the alibaba lane). Primary dispatch only —
+    // fallback-chain members stay name-routed (hermes aliases, possibly
+    // cross-provider).
     process.stdout.write(p.map(r => {
       let chain = Array.isArray(r.fallback_models) ? r.fallback_models
                 : (r.fallback_model ? [r.fallback_model] : []);
       chain = chain.filter(m => typeof m === "string" && m.length);
       const fb = chain.length ? chain.join(",") : "-";
-      return r.slug + "\t" + r.model + "\t" + (r.perspective || "-") + "\t" + fb;
+      return r.slug + "\t" + r.model + "\t" + (r.perspective || "-") + "\t" + fb + "\t" + (r.route_provider || "-");
     }).join("\n"));
   } catch (e) {
     process.exit(7);
@@ -482,29 +502,31 @@ if [ "$CRITIC_PARALLEL" = "0" ]; then
     _seq_out="$(mktemp -t critic-panel-seq.XXXXXX)"
     _seq_err="$(mktemp -t critic-panel-seq-err.XXXXXX)"
 
-    while IFS="	" read -r slug model perspective fallback_chain; do
+    while IFS="	" read -r slug model perspective fallback_chain row_provider; do
         [ -n "$slug" ] || continue
         # Map the "-" empty-field placeholder back to "" (see the registry
         # emission above — plain empty fields collapse under tab-IFS).
         [ "$perspective" = "-" ] && perspective=""
         [ "$fallback_chain" = "-" ] && fallback_chain=""
+        [ "$row_provider" = "-" ] && row_provider=""
         total=$((total + 1))
 
-        # Run this member (with per-member timeout if available)
+        # Run this member (with per-member timeout if available). --provider ""
+        # is a no-op in critic-first-pass.sh, so it is passed unconditionally.
         if [ -n "$perspective" ]; then
             if [ -n "$_TIMEOUT_BIN" ]; then
-                "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" --model "$model" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$_seq_out" 2>"$_seq_err"
+                "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$_seq_out" 2>"$_seq_err"
                 rc=$?
             else
-                bash "$CFP" --model "$model" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$_seq_out" 2>"$_seq_err"
+                bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$_seq_out" 2>"$_seq_err"
                 rc=$?
             fi
         else
             if [ -n "$_TIMEOUT_BIN" ]; then
-                "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" --model "$model" --slug "$slug" < "$tmp" > "$_seq_out" 2>"$_seq_err"
+                "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" < "$tmp" > "$_seq_out" 2>"$_seq_err"
                 rc=$?
             else
-                bash "$CFP" --model "$model" --slug "$slug" < "$tmp" > "$_seq_out" 2>"$_seq_err"
+                bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" < "$tmp" > "$_seq_out" 2>"$_seq_err"
                 rc=$?
             fi
         fi
@@ -523,12 +545,13 @@ else
 
     # Launch each member indexed by position i (i=0,1,2,...)
     i=0
-    while IFS="	" read -r slug model perspective fallback_chain; do
+    while IFS="	" read -r slug model perspective fallback_chain row_provider; do
         [ -n "$slug" ] || continue
         # Map the "-" empty-field placeholder back to "" (see the registry
         # emission above — plain empty fields collapse under tab-IFS).
         [ "$perspective" = "-" ] && perspective=""
         [ "$fallback_chain" = "-" ] && fallback_chain=""
+        [ "$row_provider" = "-" ] && row_provider=""
         total=$((total + 1))
         # Write slug and model so the result loop can recover them
         printf '%s' "$slug"  > "$outdir/$i.slug"
@@ -540,18 +563,18 @@ else
         (
             if [ -n "$perspective" ]; then
                 if [ -n "$_TIMEOUT_BIN" ]; then
-                    "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" --model "$model" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
+                    "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
                     echo $? > "$outdir/$i.rc"
                 else
-                    bash "$CFP" --model "$model" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
+                    bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
                     echo $? > "$outdir/$i.rc"
                 fi
             else
                 if [ -n "$_TIMEOUT_BIN" ]; then
-                    "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" --model "$model" --slug "$slug" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
+                    "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
                     echo $? > "$outdir/$i.rc"
                 else
-                    bash "$CFP" --model "$model" --slug "$slug" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
+                    bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
                     echo $? > "$outdir/$i.rc"
                 fi
             fi

--- a/scripts/cr/critics.json
+++ b/scripts/cr/critics.json
@@ -1,8 +1,8 @@
 {
   "_compliance": "panel/router lanes must terminate per-token keys only; the Z.ai Coding-Plan subscription (and any subscription lane) is launcher-only (ToS restricts it to officially supported tools) — never behind a panel or router.",
   "panel": [
-    { "slug": "qwen3coder", "model": "qwen3.7-max", "provider": "alibaba-coding-plan", "tier": "free", "fallback_models": ["qwen3-max", "qwq-plus", "qwen-flash"], "_exhausted_2026-07-09": ["qwen3-coder-plus", "qwen-plus"] },
-    { "slug": "qwenor",     "model": "qwen/qwen3-next-80b-a3b-instruct:free", "provider": "openrouter", "tier": "free" },
+    { "slug": "qwen3coder", "model": "qwen3-coder-plus", "provider": "alibaba-coding-plan", "tier": "free", "fallback_models": ["qwen-plus", "qwen3.7-max", "qwen3-max", "qwq-plus", "qwen-flash"] },
+    { "slug": "qwenor",     "model": "qwen/qwen3-next-80b-a3b-instruct:free", "provider": "openrouter", "route_provider": "openrouter", "tier": "free" },
     { "slug": "codex",      "model": "gpt-5.5",                             "provider": "openai-codex", "tier": "paid" }
   ]
 }

--- a/scripts/cr/test-critic-panel.sh
+++ b/scripts/cr/test-critic-panel.sh
@@ -449,6 +449,39 @@ check "P3: merged stdout keeps pr-check bullet contract" "$(printf '%s\n' "$out_
 : > "$CAPTURE_FILE"
 printf '%s' "$DIFF" | CRITICS_JSON="$PLAIN_JSON" CRITIC_FIRST_PASS="$CAPTURE_STUB" bash "$PANEL" >/dev/null 2>&1
 check "P2: row without perspective omits flag" "$(grep -c -- '--perspective-file' "$CAPTURE_FILE")" "0"
+
+# Test PV: OPT-IN route_provider threaded to first-pass as --provider
+# (HIMMEL-727) so model ids newer than hermes' catalog can't fall to its
+# default provider. The descriptive "provider" metadata key alone must NOT
+# thread (blanket --provider broke alias-routed rows: 401 on alibaba).
+PROV_JSON="$tmp/critics-provider.json"
+printf '%s' '{"panel":[{"slug":"routed","model":"fake/newid:free","provider":"openrouter","route_provider":"openrouter","tier":"free"}]}' > "$PROV_JSON"
+: > "$CAPTURE_FILE"
+printf '%s' "$DIFF" | CRITICS_JSON="$PROV_JSON" CRITIC_FIRST_PASS="$CAPTURE_STUB" bash "$PANEL" >/dev/null 2>&1
+check "PV1: --provider openrouter passed to first-pass" "$(grep -c -- '--provider openrouter' "$CAPTURE_FILE")" "1"
+PROVMETA_JSON="$tmp/critics-provider-meta.json"
+printf '%s' '{"panel":[{"slug":"meta","model":"fake/meta","provider":"openrouter","tier":"free"}]}' > "$PROVMETA_JSON"
+: > "$CAPTURE_FILE"
+printf '%s' "$DIFF" | CRITICS_JSON="$PROVMETA_JSON" CRITIC_FIRST_PASS="$CAPTURE_STUB" bash "$PANEL" >/dev/null 2>&1
+check "PV2: provider metadata alone does NOT thread --provider <name>" "$(grep -c -- '--provider openrouter' "$CAPTURE_FILE")" "0"
+
+# Test O: operator-local registry overlay (HIMMEL-727). critics.local.json next
+# to the panel wins over critics.json; CRITICS_JSON env wins over both. Run a
+# COPY of the panel from a tmp dir so the repo tree is never polluted with a
+# local overlay file (concurrent sessions share this checkout).
+mkdir -p "$tmp/panelcopy"
+cp "$PANEL" "$tmp/panelcopy/critic-panel.sh"
+printf '%s' '{"panel":[{"slug":"repodefault","model":"fake/repo","provider":"test","tier":"free"}]}' > "$tmp/panelcopy/critics.json"
+printf '%s' '{"panel":[{"slug":"localoverlay","model":"fake/local","provider":"test","tier":"free"}]}' > "$tmp/panelcopy/critics.local.json"
+stderr_l="$(printf '%s' "$DIFF" | CRITIC_FIRST_PASS="$CAPTURE_STUB" bash "$tmp/panelcopy/critic-panel.sh" 2>&1 >/dev/null)"
+check "O1: local overlay used when present" "$(printf '%s\n' "$stderr_l" | grep -cF 'panel-availability: localoverlay')" "1"
+check "O1: local overlay announced on stderr" "$(printf '%s\n' "$stderr_l" | grep -cF 'critics.local.json')" "1"
+stderr_l2="$(printf '%s' "$DIFF" | CRITICS_JSON="$tmp/panelcopy/critics.json" CRITIC_FIRST_PASS="$CAPTURE_STUB" bash "$tmp/panelcopy/critic-panel.sh" 2>&1 >/dev/null)"
+check "O2: CRITICS_JSON env wins over local overlay" "$(printf '%s\n' "$stderr_l2" | grep -cF 'panel-availability: repodefault')" "1"
+rm -f "$tmp/panelcopy/critics.local.json"
+stderr_l3="$(printf '%s' "$DIFF" | CRITIC_FIRST_PASS="$CAPTURE_STUB" bash "$tmp/panelcopy/critic-panel.sh" 2>&1 >/dev/null)"
+check "O3: no overlay -> repo registry" "$(printf '%s\n' "$stderr_l3" | grep -cF 'panel-availability: repodefault')" "1"
+
 if [ "$fails" -eq 0 ]; then
     echo "ALL PASS"
 else

--- a/scripts/hermes/invoke.sh
+++ b/scripts/hermes/invoke.sh
@@ -47,6 +47,11 @@ Usage: invoke.sh [--model <name>] [--profile <name>] [--toolsets <list>]
   <prompt>           Prompt text. If `-` or omitted (and no --prompt-file),
                      read from stdin.
   --model <name>     Model override (hermes -m). Default: hermes config default.
+  --provider <name>  Provider override (hermes --provider). Needed when the
+                     model id is newer than hermes' internal catalog — without
+                     it hermes silently routes unknown ids to its DEFAULT
+                     provider (observed: an OpenRouter :free id landing on
+                     codex, HIMMEL-727). Omit to keep hermes' own routing.
   --profile <name>   Run under this hermes profile (hermes -p), i.e. its SOUL +
                      config (e.g. himmel_agent = senior main-tier reviewer). Fail-
                      open: if the profile does not exist, warn and use the default
@@ -65,6 +70,7 @@ EOF
 }
 
 model=""
+provider=""
 profile=""
 toolsets="todo"
 prompt_file=""
@@ -77,6 +83,9 @@ while [ $# -gt 0 ]; do
         --model)
             [ $# -ge 2 ] || { echo "invoke.sh: --model requires a value" >&2; exit 2; }
             model="$2"; shift 2 ;;
+        --provider)
+            [ $# -ge 2 ] || { echo "invoke.sh: --provider requires a value" >&2; exit 2; }
+            provider="$2"; shift 2 ;;
         --profile)
             [ $# -ge 2 ] || { echo "invoke.sh: --profile requires a value" >&2; exit 2; }
             profile="$2"; shift 2 ;;
@@ -166,19 +175,22 @@ if [ -n "$profile" ]; then
 fi
 
 run_hermes() {
-    HERMES_PROMPT_FILE="$pf_native" HERMES_ONESHOT_MODEL="$model" HERMES_ONESHOT_PROFILE="$profile_arg" HERMES_ONESHOT_TOOLSETS="$toolsets" \
+    HERMES_PROMPT_FILE="$pf_native" HERMES_ONESHOT_MODEL="$model" HERMES_ONESHOT_PROVIDER="$provider" HERMES_ONESHOT_PROFILE="$profile_arg" HERMES_ONESHOT_TOOLSETS="$toolsets" \
     "$py" -c '
 import os, sys, io
 with io.open(os.environ["HERMES_PROMPT_FILE"], encoding="utf-8") as fh:
     prompt = fh.read()
 argv = ["hermes", "--cli"]
 model = os.environ.get("HERMES_ONESHOT_MODEL", "")
+provider = os.environ.get("HERMES_ONESHOT_PROVIDER", "")
 profile = os.environ.get("HERMES_ONESHOT_PROFILE", "")
 toolsets = os.environ.get("HERMES_ONESHOT_TOOLSETS", "")
 if profile:
     argv += ["-p", profile]
 if model:
     argv += ["-m", model]
+if provider:
+    argv += ["--provider", provider]
 if toolsets:
     argv += ["-t", toolsets]
 argv += ["-z", prompt]


### PR DESCRIPTION
## Summary
Propagated from private (squash d0afa2ec, PR #1069 there). Corrects HIMMEL-838's semantics slip (account quota state baked into shipped config):

- `critics.json` restored to UNIVERSAL defaults (anchor qwen3-coder-plus, full Alibaba ladder, qwenor=next-80b:free)
- NEW gitignored `scripts/cr/critics.local.json` overlay for per-operator account state; resolution: `CRITICS_JSON` env > overlay > shipped
- NEW opt-in `route_provider` row key threaded panel→cfp→invoke.sh as hermes `--provider` — fixes model ids newer than the hermes catalog silently falling to its default provider. Opt-in because live A/B showed blanket threading 401s alias-routed rows.
- Runbook documents overlay semantics; dated account snapshots removed.

## Test plan
- [x] 72 assertions across all CR suites + test-invoke.sh; shellcheck clean
- [x] Live A/B: `--provider` on alias-routed row = 401, name-routed = PONG (drove the opt-in design)
- [x] Live panel dogfood: universal chain multi-hop worked; CR 0C/0I

🤖 Generated with [Claude Code](https://claude.com/claude-code)
