### PR TITLE
feat(cr): [HIMMEL-846] OpenRouter free-tier watcher — catalog snapshot diff + pinned-model probe feeding critics.local.json suggestions

### DIFF
--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -790,6 +790,26 @@ Shell scripts that implement `/pr-check` sub-steps. Called by the `/pr-check` co
 - `scripts/cr/cr-scores.sh` — generates a per-critic correctness scorecard from the ledger; surfaced via `/cr-scores`. Adds an estimated-token Usage section (per-model + cumulative) when the ledger holds `usage` records.
 - `scripts/cr/pr-check-external.sh` — **Claude-free CR runner** (HIMMEL-750): reviews a branch with NO Claude session so review still runs when the Claude quota bank is maxed. `--branch <b> [--session-dir <dir>] [--base <ref>]`; fetches, diffs `origin/<base>...<branch>`, pipes to `critic-panel.sh` with `CR_PROFILE=free,paid` forced (so the paid codex critic reviews; `CR_PROFILE=none` refused). Fail-CLOSED gate: panel non-zero exit, unparseable Critical/Important counts, an ABSENT codex critic, or any Critical/Important finding all FAIL. On clean it writes `external_cr_verdict: pass (sha=…; critics=…)` into the spawn-glm session `meta.json` (distinct from `d1_verdict`) and prints a PR-body snippet; does NOT touch the CR marker. Test: `scripts/cr/test-pr-check-external.sh` (hermetic; fake git repo + stubbed panel via `CRITIC_PANEL_CMD`). See [`docs/glm-offload.md`](glm-offload.md) "Claude-down ship flow".
 
+## OpenRouter free-tier watcher (`scripts/openrouter/free-watch.sh`, HIMMEL-846)
+
+Lean-invoke (no hook/daemon) watcher for free-model CHURN on OpenRouter —
+the risk under the free-only policy (the $20 top-up is NEVER spent; it only
+unlocks the 1000 free-req/day tier; panels pin `:free` ids exclusively).
+Fetches the public catalog (no auth), keeps the `:free` subset, snapshots to
+`~/.himmel/openrouter-free-catalog.json`, diffs vs the last run
+(new/delisted free models), checks every OpenRouter model pinned in the CR
+registry (overlay `critics.local.json` > shipped `critics.json`) for
+delisting / deranked endpoints (any `status < 0`; all-deranked and
+partial-derank are distinct flags) / uptime drops
+(`uptime_last_30m < OPENROUTER_UPTIME_MIN`, default 90, validated numeric
+at startup), and prints
+`SUGGEST` lines for better code-capable `:free` candidates (bigger context
+than the pinned max). Suggestions only — never edits any registry file.
+Flags for hermetic testing: `--catalog-file`, `--endpoints-dir`,
+`--state-dir`, `--registry`, `--no-probe`. Test:
+`scripts/openrouter/test-free-watch.sh`. Pattern-parity with
+`alibaba-probe-once` (HIMMEL-729); relates HIMMEL-737 rotation.
+
 ## GLM ship lane (`scripts/glm/`, HIMMEL-750)
 
 - `scripts/glm/ship-branch.sh` — pushes a reviewed `glm/*` branch FROM the trusted main checkout (the GLM worker stays fully quarantined — `poisonPushUrl` + the no-push prompt + the deny hook are unchanged). `ship-branch.sh <branch> [--session-dir <dir>] [--allow-any-branch]`; refuses to run from a `.claude/worktrees/` path, requires an `origin` remote, and is authorized only by `external_cr_verdict:pass` (written by `pr-check-external.sh`) whose reviewed SHA must equal the current branch tip (closes the post-panel-commit TOCTOU). Runs `git push -u origin <branch>` with the real pre-push gates (NO `--no-verify`), then clears the CR marker only when its SHA matches the pushed SHA. Never opens a PR, never merges — prints the exact `gh pr create` for the operator. Test: `scripts/glm/test-ship-branch.sh` (hermetic; temp bare-repo origin). See [`docs/glm-offload.md`](glm-offload.md) "Claude-down ship flow".

--- a/scripts/openrouter/free-watch.sh
+++ b/scripts/openrouter/free-watch.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# free-watch.sh - OpenRouter free-tier watcher (HIMMEL-846).
+#
+# Operator policy (2026-07-09, twice-confirmed): the $20 top-up is NEVER spent;
+# it only unlocks the 1000 free-req/day tier. Panels/fallbacks pin ':free'
+# model ids EXCLUSIVELY. The risk this watcher covers is free-model CHURN
+# (delisting, provider/uptime changes), not the daily cap.
+#
+# Lean-invoke (no hook, no daemon): run it on demand. It
+#   1. fetches the public catalog (GET /api/v1/models, no auth) and keeps the
+#      ':free' subset,
+#   2. parses the OpenRouter pins out of the CR registry (overlay
+#      critics.local.json wins over shipped critics.json),
+#   3. snapshots the ':free' subset to the state dir and diffs vs the previous
+#      run (new / delisted free models),
+#   4. checks every pin - non-free policy violation, delisted pin, deranked
+#      endpoints (any status < 0; all-deranked vs partial), uptime drop,
+#   5. prints SUGGEST lines for better code-capable ':free' candidates.
+# It never edits any registry file - suggestions only. Suggested ids are
+# structurally ':free'-only (non-free ids are filtered before any suggestion).
+#
+# Usage: free-watch.sh [--catalog-file f] [--endpoints-dir d] [--state-dir d]
+#                      [--registry f] [--no-probe]
+#   --catalog-file f   read the catalog JSON from f instead of the network
+#   --endpoints-dir d  read per-model endpoint JSON fixtures from d instead of
+#                      the network (filename: model id with / and : -> _)
+#   --state-dir d      snapshot dir (default $HOME/.himmel)
+#   --registry f       registry to read pins from (default: overlay > shipped)
+#   --no-probe         skip only the per-pin endpoints probe (policy +
+#                      delisted-pin checks and the catalog diff still run)
+# Env: OPENROUTER_UPTIME_MIN  uptime-drop threshold percent (default 90)
+# Exit: 0 = ran (flags/suggestions are advisory); 1 = fetch/parse/dep error.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+API_BASE="https://openrouter.ai/api/v1"
+UPTIME_MIN="${OPENROUTER_UPTIME_MIN:-90}"
+# Validate once at startup: a bad value would otherwise crash jq --argjson
+# mid-loop, silently skipping the remaining pin health checks (false-healthy).
+# Must be a valid JSON number for --argjson: digits with at most one INNER dot
+# (".5", "5.", "." are invalid JSON and would still crash jq).
+case "$UPTIME_MIN" in
+  ''|*[!0-9.]*|*.*.*|.*|*.) echo "free-watch: OPENROUTER_UPTIME_MIN must be numeric, got '$UPTIME_MIN'" >&2; exit 1 ;;
+esac
+
+CATALOG_FILE="" ENDPOINTS_DIR="" STATE_DIR="${HOME}/.himmel" REGISTRY="" NO_PROBE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    # Value-taking flags check $# first: with set -u a bare "$2" on a missing
+    # value would crash unbound instead of printing the friendly error.
+    --catalog-file|--endpoints-dir|--state-dir|--registry)
+      [ $# -ge 2 ] || { echo "free-watch: $1 requires a value" >&2; exit 1; }
+      case "$1" in
+        --catalog-file)  CATALOG_FILE="$2" ;;
+        --endpoints-dir) ENDPOINTS_DIR="$2" ;;
+        --state-dir)     STATE_DIR="$2" ;;
+        --registry)      REGISTRY="$2" ;;
+      esac
+      shift 2 ;;
+    --no-probe) NO_PROBE=1; shift ;;
+    *) echo "free-watch: unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || { echo "free-watch: jq is required" >&2; exit 1; }
+
+# Registry resolution mirrors critic-panel.sh (HIMMEL-727) in full:
+# --registry flag > CRITICS_JSON env > overlay critics.local.json > shipped.
+# Without the env tier the watcher could report health for a different
+# registry than the one the panel actually runs.
+if [ -z "$REGISTRY" ]; then
+  if [ -n "${CRITICS_JSON:-}" ]; then
+    REGISTRY="$CRITICS_JSON"
+  elif [ -f "$REPO_ROOT/scripts/cr/critics.local.json" ]; then
+    REGISTRY="$REPO_ROOT/scripts/cr/critics.local.json"
+  else
+    REGISTRY="$REPO_ROOT/scripts/cr/critics.json"
+  fi
+fi
+[ -f "$REGISTRY" ] || { echo "free-watch: registry not found: $REGISTRY" >&2; exit 1; }
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# ---- 1. catalog ------------------------------------------------------------
+CATALOG="$TMP_DIR/catalog.json"
+if [ -n "$CATALOG_FILE" ]; then
+  cp "$CATALOG_FILE" "$CATALOG" \
+    || { echo "free-watch: catalog file not readable: $CATALOG_FILE" >&2; exit 1; }
+else
+  curl -sf --max-time 30 "$API_BASE/models" -o "$CATALOG" \
+    || { echo "free-watch: catalog fetch failed" >&2; exit 1; }
+fi
+# ':free'-only subset, sorted by id. This filter is the free-only policy guard:
+# nothing outside it is ever diffed or suggested (a non-':free' registry pin is
+# separately FLAGGED as a policy violation below, not filtered silently).
+FREE="$TMP_DIR/free.json"
+jq '[.data[] | select(.id | endswith(":free"))
+     | {id, name, context_length}] | sort_by(.id)' "$CATALOG" > "$FREE" \
+  || { echo "free-watch: catalog JSON unreadable" >&2; exit 1; }
+# NB: Windows jq emits CRLF; every text-producing jq below strips \r.
+FREE_COUNT="$(jq 'length' "$FREE" | tr -d '\r')"
+echo "free-watch: catalog has $FREE_COUNT ':free' models"
+
+# ---- 2. pinned models from the registry -------------------------------------
+# Parsed BEFORE the snapshot is replaced so a malformed registry aborts the run
+# without losing the previous snapshot (the churn diff survives a retry).
+# Mirrors critic-panel.sh fallback semantics: "fallback_models" array OR legacy
+# "fallback_model" string, on EVERY row - a non-OpenRouter primary can carry an
+# OpenRouter fallback (the HIMMEL-729 quota-exhaustion path). OpenRouter ids
+# are the author/slug form; on non-openrouter rows only those count.
+jq -r '.panel[] as $r
+       | [$r.model, ($r.fallback_models[]?), ($r.fallback_model // empty)]
+       | if $r.provider == "openrouter" then . else map(select(contains("/"))) end
+       | .[]' "$REGISTRY" \
+  | tr -d '\r' | sort -u > "$TMP_DIR/pins" \
+  || { echo "free-watch: registry unreadable: $REGISTRY" >&2; exit 1; }
+
+# ---- 3. snapshot diff --------------------------------------------------------
+mkdir -p "$STATE_DIR"
+SNAP="$STATE_DIR/openrouter-free-catalog.json"
+# A corrupt previous snapshot (killed prior run, manual edit) degrades to a
+# first run instead of aborting - it would otherwise wedge EVERY later run
+# until a human deletes the state file.
+if [ -f "$SNAP" ] && ! jq -e 'type == "array"' "$SNAP" >/dev/null 2>&1; then
+  echo "free-watch: previous snapshot unreadable ($SNAP) - treating as first run" >&2
+  rm -f "$SNAP"
+fi
+if [ -f "$SNAP" ]; then
+  jq -r '.[].id' "$SNAP" | tr -d '\r' > "$TMP_DIR/old.ids"
+  jq -r '.[].id' "$FREE" | tr -d '\r' > "$TMP_DIR/new.ids"
+  # LC_ALL=C: comm must collate the way jq's sort_by(.id) sorted (codepoint).
+  LC_ALL=C comm -13 "$TMP_DIR/old.ids" "$TMP_DIR/new.ids" > "$TMP_DIR/added"
+  LC_ALL=C comm -23 "$TMP_DIR/old.ids" "$TMP_DIR/new.ids" > "$TMP_DIR/removed"
+  while IFS= read -r id; do
+    [ -n "$id" ] && echo "FLAG new-free-model: $id"
+  done < "$TMP_DIR/added"
+  while IFS= read -r id; do
+    [ -n "$id" ] && echo "FLAG delisted-free-model: $id"
+  done < "$TMP_DIR/removed"
+else
+  echo "free-watch: first run - snapshot created, no diff"
+fi
+# Atomic replace: an interrupted copy must not corrupt the previous snapshot.
+# The explicit guard matters: a failing non-final command in an && list is
+# exempt from set -e, so an unguarded cp failure would report success ("done")
+# while the snapshot silently never updates.
+if ! cp "$FREE" "$SNAP.tmp" || ! mv -f "$SNAP.tmp" "$SNAP"; then
+  echo "free-watch: snapshot write failed ($SNAP)" >&2; exit 1
+fi
+
+# ---- 4. pinned-model checks --------------------------------------------------
+probe_endpoints() { # $1 = model id; prints endpoints JSON to stdout, or fails
+  if [ -n "$ENDPOINTS_DIR" ]; then
+    local fixture
+    fixture="$ENDPOINTS_DIR/$(echo "$1" | tr '/:' '__').json"
+    [ -f "$fixture" ] && cat "$fixture"
+  else
+    curl -sf --max-time 30 "$API_BASE/models/$1/endpoints"
+  fi
+}
+
+while IFS= read -r pin; do
+  [ -n "$pin" ] || continue
+  case "$pin" in
+    *:free) : ;;
+    *) echo "FLAG non-free-pin: $pin (violates free-only policy - replace with a :free id)"; continue ;;
+  esac
+  if ! jq -e --arg id "$pin" 'any(.[]; .id == $id)' "$FREE" >/dev/null; then
+    echo "FLAG delisted-pin: $pin (pinned in $(basename "$REGISTRY") but absent from the ':free' catalog)"
+    continue
+  fi
+  [ "$NO_PROBE" -eq 1 ] && continue
+  EP="$TMP_DIR/ep.json"
+  if ! probe_endpoints "$pin" > "$EP" || ! jq -e '.data.endpoints' "$EP" >/dev/null 2>&1; then
+    echo "FLAG probe-failed: $pin (endpoints API unreachable or unreadable)"
+    continue
+  fi
+  # status < 0 means OpenRouter deranked/disabled the endpoint; uptime_last_30m
+  # is null for some free providers (observed live 2026-07-10) - null is OK.
+  if ! jq -e '.data.endpoints | length > 0' "$EP" >/dev/null; then
+    echo "FLAG no-endpoints: $pin (zero live endpoints)"
+    continue
+  fi
+  neg="$(jq -r '[.data.endpoints[] | select((.status // 0) < 0)] | length' "$EP" | tr -d '\r')"
+  tot="$(jq -r '.data.endpoints | length' "$EP" | tr -d '\r')"
+  if [ "$neg" -gt 0 ]; then
+    if [ "$neg" -eq "$tot" ]; then
+      echo "FLAG deranked-pin: $pin (all $tot endpoint(s) status < 0)"
+    else
+      # Partial derank = lost provider redundancy; surface before it worsens.
+      echo "FLAG deranked-pin-partial: $pin ($neg of $tot endpoint(s) status < 0)"
+    fi
+  fi
+  low="$(jq -r --argjson min "$UPTIME_MIN" \
+    '[.data.endpoints[] | select(.uptime_last_30m != null and .uptime_last_30m < $min)] | length' "$EP" | tr -d '\r')"
+  if [ "$low" -gt 0 ]; then
+    echo "FLAG uptime-drop: $pin ($low endpoint(s) under ${UPTIME_MIN}% uptime_last_30m)"
+  fi
+done < "$TMP_DIR/pins"
+
+# ---- 5. better-candidate suggestions ----------------------------------------
+# Code-capable heuristic: id or name mentions code/coder. A candidate beats the
+# pins when its context_length exceeds every pinned model's. Suggestions only -
+# the operator edits critics.local.json (qwenor row) manually.
+PINS_JSON="$(jq -R -s 'split("\n") | map(select(length > 0))' "$TMP_DIR/pins" | tr -d '\r')"
+MAX_PIN_CTX="$(jq -r --argjson pins "$PINS_JSON" \
+  '[.[] | select(.id as $i | $pins | index($i)) | .context_length] | max // 0' "$FREE" | tr -d '\r')"
+jq -r --argjson maxctx "$MAX_PIN_CTX" '
+  .[] | select((.id + " " + (.name // "")) | test("(^|[-/_ ])cod(e|er)([-/_ :]|$)"; "i"))
+      | select(.context_length > $maxctx)
+      | "SUGGEST qwenor-candidate: \(.id) (ctx \(.context_length) beats pinned max \($maxctx)) - consider critics.local.json"
+' "$FREE" | tr -d '\r'
+
+echo "free-watch: done (snapshot: $SNAP)"

--- a/scripts/openrouter/test-free-watch.sh
+++ b/scripts/openrouter/test-free-watch.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# Hermetic suite for scripts/openrouter/free-watch.sh (HIMMEL-846).
+# No network: catalog + endpoints come from fixtures; state dir is a temp dir.
+# The suite is the spec: free-only filter, snapshot diff, pin flags, suggestions.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUT="$DIR/free-watch.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail=0
+expect() { # $1=label $2=haystack-file $3=needle
+  grep -qF "$3" "$2" || { echo "FAIL $1: missing '$3'"; fail=1; }
+}
+refute() { # $1=label $2=haystack-file $3=needle
+  if grep -qF "$3" "$2"; then echo "FAIL $1: unexpected '$3'"; fail=1; fi
+}
+
+mk_catalog() { # $1=outfile, rest = "id ctx name" triples via stdin
+  local rows="[]"
+  while read -r id ctx name; do
+    [ -n "$id" ] || continue
+    rows="$(jq --arg id "$id" --argjson ctx "$ctx" --arg name "$name" \
+      '. + [{id: $id, name: $name, context_length: $ctx}]' <<<"$rows")"
+  done
+  jq -n --argjson d "$rows" '{data: $d}' > "$1"
+}
+
+# Registry fixture: one openrouter row (pin + fallback) + a non-openrouter row.
+cat > "$TMP/registry.json" <<'EOF'
+{"panel":[
+  {"slug":"qwenor","model":"qwen/qwen3-coder:free","provider":"openrouter","tier":"free",
+   "fallback_models":["qwen/qwen3-next-80b-a3b-instruct:free"]},
+  {"slug":"codex","model":"gpt-5.5","provider":"openai-codex","tier":"paid"}
+]}
+EOF
+
+# Endpoints fixtures (filename: id with / and : -> _).
+EPD="$TMP/endpoints"; mkdir -p "$EPD"
+cat > "$EPD/qwen_qwen3-coder_free.json" <<'EOF'
+{"data":{"endpoints":[{"name":"Venice","status":0,"uptime_last_30m":null}]}}
+EOF
+cat > "$EPD/qwen_qwen3-next-80b-a3b-instruct_free.json" <<'EOF'
+{"data":{"endpoints":[{"name":"Venice","status":0,"uptime_last_30m":99.2}]}}
+EOF
+
+mk_catalog "$TMP/catalog1.json" <<'EOF'
+qwen/qwen3-coder:free 262000 Qwen3 Coder (free)
+qwen/qwen3-next-80b-a3b-instruct:free 262144 Qwen3 Next (free)
+openai/gpt-5.5 400000 GPT-5.5 paid coder
+EOF
+
+run() { # $1=catalog $2=extra-args... ; output -> $TMP/out
+  local cat="$1"; shift
+  bash "$SUT" --catalog-file "$cat" --endpoints-dir "$EPD" \
+    --state-dir "$TMP/state" --registry "$TMP/registry.json" "$@" \
+    > "$TMP/out" 2>&1 || { echo "FAIL: run rc=$? for $cat"; fail=1; }
+}
+
+# T1 first run: paid ids filtered out of the catalog count; snapshot created;
+# healthy pins produce no flags; no suggestion (nothing beats pinned ctx).
+run "$TMP/catalog1.json"
+expect T1-count   "$TMP/out" "catalog has 2 ':free' models"
+expect T1-first   "$TMP/out" "first run - snapshot created"
+refute T1-noflag  "$TMP/out" "FLAG"
+refute T1-nosug   "$TMP/out" "SUGGEST"
+refute T1-nopaid  "$TMP/out" "gpt-5.5"
+[ -f "$TMP/state/openrouter-free-catalog.json" ] || { echo "FAIL T1: no snapshot"; fail=1; }
+
+# T2 second run, catalog changed: pinned fallback delisted; a new bigger-ctx
+# code model appears -> new-model flag + delisted flags + suggestion (:free only).
+mk_catalog "$TMP/catalog2.json" <<'EOF'
+qwen/qwen3-coder:free 262000 Qwen3 Coder (free)
+cohere/north-mini-code:free 512000 North Mini Code (free)
+EOF
+run "$TMP/catalog2.json"
+expect T2-new     "$TMP/out" "FLAG new-free-model: cohere/north-mini-code:free"
+expect T2-gone    "$TMP/out" "FLAG delisted-free-model: qwen/qwen3-next-80b-a3b-instruct:free"
+expect T2-pin     "$TMP/out" "FLAG delisted-pin: qwen/qwen3-next-80b-a3b-instruct:free"
+expect T2-suggest "$TMP/out" "SUGGEST qwenor-candidate: cohere/north-mini-code:free"
+
+# T3 deranked + uptime-drop: both endpoint degradations flagged.
+cat > "$EPD/qwen_qwen3-coder_free.json" <<'EOF'
+{"data":{"endpoints":[{"name":"Venice","status":-3,"uptime_last_30m":42.5}]}}
+EOF
+run "$TMP/catalog2.json"
+expect T3-derank  "$TMP/out" "FLAG deranked-pin: qwen/qwen3-coder:free"
+expect T3-uptime  "$TMP/out" "FLAG uptime-drop: qwen/qwen3-coder:free"
+
+# T4 missing endpoints fixture = probe failure flag (not a crash).
+rm "$EPD/qwen_qwen3-coder_free.json"
+run "$TMP/catalog2.json"
+expect T4-probe   "$TMP/out" "FLAG probe-failed: qwen/qwen3-coder:free"
+
+# T5 non-free pin violates policy -> flagged, never probed/suggested as-is.
+cat > "$TMP/registry.json" <<'EOF'
+{"panel":[{"slug":"qwenor","model":"qwen/qwen3-coder-plus","provider":"openrouter","tier":"free"}]}
+EOF
+run "$TMP/catalog2.json"
+expect T5-policy  "$TMP/out" "FLAG non-free-pin: qwen/qwen3-coder-plus"
+
+# T6 --no-probe skips endpoint checks but keeps catalog diff + policy checks.
+cat > "$TMP/registry.json" <<'EOF'
+{"panel":[{"slug":"qwenor","model":"qwen/qwen3-coder:free","provider":"openrouter","tier":"free"}]}
+EOF
+run "$TMP/catalog2.json" --no-probe
+refute T6-noprobe "$TMP/out" "FLAG probe-failed"
+
+# T7 unreadable catalog -> rc 1.
+echo "not json" > "$TMP/bad.json"
+if bash "$SUT" --catalog-file "$TMP/bad.json" --state-dir "$TMP/state" \
+     --registry "$TMP/registry.json" >/dev/null 2>&1; then
+  echo "FAIL T7: bad catalog should rc 1"; fail=1
+fi
+
+# T8 malformed registry -> rc 1 AND the previous snapshot survives (the churn
+# diff is not lost by a failed run - codex-adv finding, ordering regression).
+cp "$TMP/state/openrouter-free-catalog.json" "$TMP/snap-before.json"
+echo "not json" > "$TMP/badreg.json"
+if bash "$SUT" --catalog-file "$TMP/catalog1.json" --state-dir "$TMP/state" \
+     --registry "$TMP/badreg.json" >/dev/null 2>&1; then
+  echo "FAIL T8: bad registry should rc 1"; fail=1
+fi
+if ! diff -q "$TMP/snap-before.json" "$TMP/state/openrouter-free-catalog.json" >/dev/null; then
+  echo "FAIL T8: snapshot was replaced despite registry parse failure"; fail=1
+fi
+
+# T8.5 partial derank: one endpoint down, one healthy -> partial flag (codex-adv
+# round-2 finding: redundancy loss must not read as healthy).
+cat > "$TMP/registry.json" <<'EOF'
+{"panel":[{"slug":"qwenor","model":"qwen/qwen3-coder:free","provider":"openrouter","tier":"free"}]}
+EOF
+cat > "$EPD/qwen_qwen3-coder_free.json" <<'EOF'
+{"data":{"endpoints":[{"name":"A","status":-1,"uptime_last_30m":null},{"name":"B","status":0,"uptime_last_30m":99.0}]}}
+EOF
+run "$TMP/catalog2.json"
+expect T85-partial "$TMP/out" "FLAG deranked-pin-partial: qwen/qwen3-coder:free (1 of 2"
+refute T85-notall  "$TMP/out" "FLAG deranked-pin: qwen/qwen3-coder:free (all"
+
+# T9 OpenRouter fallback on a NON-openrouter row (legacy singular
+# fallback_model) is still watched - critic-panel fallback-semantics parity
+# (HIMMEL-729 exhaustion path); the alibaba primary (no /) is NOT policy-flagged.
+cat > "$TMP/registry.json" <<'EOF'
+{"panel":[{"slug":"qwen3coder","model":"qwen3-coder-plus","provider":"alibaba-coding-plan","tier":"free",
+  "fallback_model":"qwen/qwen3-next-80b-a3b-instruct:free"}]}
+EOF
+run "$TMP/catalog2.json" --no-probe
+expect T9-fbpin   "$TMP/out" "FLAG delisted-pin: qwen/qwen3-next-80b-a3b-instruct:free"
+refute T9-primary "$TMP/out" "FLAG non-free-pin: qwen3-coder-plus"
+
+# T10 corrupted previous snapshot degrades to first-run (rc 0, snapshot healed)
+# instead of wedging every later run (silent-failure-hunter Critical 1).
+cat > "$TMP/registry.json" <<'EOF'
+{"panel":[{"slug":"qwenor","model":"qwen/qwen3-coder:free","provider":"openrouter","tier":"free"}]}
+EOF
+cat > "$EPD/qwen_qwen3-coder_free.json" <<'EOF'
+{"data":{"endpoints":[{"name":"Venice","status":0,"uptime_last_30m":null}]}}
+EOF
+echo "not json" > "$TMP/state/openrouter-free-catalog.json"
+run "$TMP/catalog2.json"
+expect T10-degrade "$TMP/out" "previous snapshot unreadable"
+expect T10-first   "$TMP/out" "first run - snapshot created"
+jq -e 'type == "array"' "$TMP/state/openrouter-free-catalog.json" >/dev/null 2>&1 \
+  || { echo "FAIL T10: snapshot not healed"; fail=1; }
+
+# T11 non-numeric OPENROUTER_UPTIME_MIN -> friendly rc 1 at startup, not a
+# mid-loop jq crash that skips pin checks (silent-failure-hunter Critical 2).
+if OPENROUTER_UPTIME_MIN=abc bash "$SUT" --catalog-file "$TMP/catalog2.json" \
+     --state-dir "$TMP/state" --registry "$TMP/registry.json" > "$TMP/out" 2>&1; then
+  echo "FAIL T11: non-numeric uptime min should rc 1"; fail=1
+fi
+expect T11-msg "$TMP/out" "OPENROUTER_UPTIME_MIN must be numeric"
+
+# T12 threshold override honored: 42.5% uptime flags at the default 90 but not
+# at 30 (also covers the pr-test-analyzer env-override gap).
+cat > "$EPD/qwen_qwen3-coder_free.json" <<'EOF'
+{"data":{"endpoints":[{"name":"Venice","status":0,"uptime_last_30m":42.5}]}}
+EOF
+run "$TMP/catalog2.json"
+expect T12-default "$TMP/out" "FLAG uptime-drop: qwen/qwen3-coder:free"
+OPENROUTER_UPTIME_MIN=30 bash "$SUT" --catalog-file "$TMP/catalog2.json" \
+  --endpoints-dir "$EPD" --state-dir "$TMP/state" --registry "$TMP/registry.json" \
+  > "$TMP/out" 2>&1 || { echo "FAIL T12: rc"; fail=1; }
+refute T12-lower "$TMP/out" "FLAG uptime-drop"
+
+# T13 zero live endpoints -> its own flag (pr-test-analyzer gap 1).
+cat > "$EPD/qwen_qwen3-coder_free.json" <<'EOF'
+{"data":{"endpoints":[]}}
+EOF
+run "$TMP/catalog2.json"
+expect T13-none "$TMP/out" "FLAG no-endpoints: qwen/qwen3-coder:free"
+
+# T14 suggestion heuristic: a bigger-context NON-code model is never suggested,
+# and substring hits like "Unicode" don't count (code-reviewer + test-analyzer).
+mk_catalog "$TMP/catalog3.json" <<'EOF'
+qwen/qwen3-coder:free 262000 Qwen3 Coder (free)
+acme/big-general:free 999999 Acme General (free)
+acme/unicode-9b:free 999999 Unicode 9B (free)
+EOF
+cat > "$EPD/qwen_qwen3-coder_free.json" <<'EOF'
+{"data":{"endpoints":[{"name":"Venice","status":0,"uptime_last_30m":null}]}}
+EOF
+run "$TMP/catalog3.json"
+refute T14-nonsug "$TMP/out" "SUGGEST qwenor-candidate: acme/big-general:free"
+refute T14-substr "$TMP/out" "SUGGEST qwenor-candidate: acme/unicode-9b:free"
+
+# T15 registry path that does not exist -> friendly rc 1 (distinct from T8's
+# exists-but-malformed path).
+if bash "$SUT" --catalog-file "$TMP/catalog2.json" --state-dir "$TMP/state" \
+     --registry "$TMP/nope.json" > "$TMP/out" 2>&1; then
+  echo "FAIL T15: missing registry should rc 1"; fail=1
+fi
+expect T15-msg "$TMP/out" "registry not found"
+
+# T16 CRITICS_JSON env tier: with no --registry, the env-named registry is
+# scanned (critic-panel.sh precedence parity - codex-adv round-3 finding).
+cat > "$TMP/envreg.json" <<'EOF'
+{"panel":[{"slug":"qwenor","model":"qwen/gone-model:free","provider":"openrouter","tier":"free"}]}
+EOF
+CRITICS_JSON="$TMP/envreg.json" bash "$SUT" --catalog-file "$TMP/catalog2.json" \
+  --endpoints-dir "$EPD" --state-dir "$TMP/state" --no-probe \
+  > "$TMP/out" 2>&1 || { echo "FAIL T16: rc"; fail=1; }
+expect T16-env "$TMP/out" "FLAG delisted-pin: qwen/gone-model:free"
+
+# T17 dot-edge uptime values are invalid JSON numbers -> rejected at startup.
+for v in . .5 5.; do
+  if OPENROUTER_UPTIME_MIN="$v" bash "$SUT" --catalog-file "$TMP/catalog2.json" \
+       --state-dir "$TMP/state" --registry "$TMP/registry.json" > "$TMP/out" 2>&1; then
+    echo "FAIL T17: OPENROUTER_UPTIME_MIN='$v' should rc 1"; fail=1
+  fi
+  expect "T17-$v" "$TMP/out" "OPENROUTER_UPTIME_MIN must be numeric"
+done
+
+# T18 value-taking flag with no value -> friendly rc 1, not a set -u crash.
+if bash "$SUT" --registry > "$TMP/out" 2>&1; then
+  echo "FAIL T18: --registry with no value should rc 1"; fail=1
+fi
+expect T18-msg "$TMP/out" "requires a value"
+
+[ "$fail" -eq 0 ] && echo "PASS test-free-watch" || exit 1


### PR DESCRIPTION
Propagated from private (squash bd9b799a, PR #1077 there). Lean-invoke ':free'-only OpenRouter churn watcher feeding critics.local.json suggestions; 21-case hermetic suite; 5 CR rounds clean. Public branch byte-verified identical to the private squash.