### PR TITLE
feat(setup): [HIMMEL-842] adopter preflight — toolchain checks, standalone entry point + jira-CLI build in adopt

### DIFF
--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -56,6 +56,7 @@ Complete checklist for getting a new machine to full working state.
 | `schtasks` | Built-in. Used by `scripts/handover/arm-resume.sh` for cron-armed Claude relaunches. **Always invoke under `MSYS_NO_PATHCONV=1`** (per HIMMEL-125) to prevent Git Bash from mangling `/flag` args into Windows paths. |
 | `MSYS_NO_PATHCONV` awareness | Documented in CLAUDE.md handover section. |
 | WSL or PowerShell-only is **NOT sufficient** — most operator-facing tooling needs bash. WSL works but adds an indirection layer; native Git Bash is the tested path. |
+| WSL2 / Docker resource caps | If WSL or Docker Desktop is installed, cap them before multi-agent runs. Start with `%UserProfile%\.wslconfig` `memory=16GB`, `processors=8`, `swap=4GB` on a 48 GB / 32-logical-core class host, then tune after measuring. Docker gets separate Desktop/per-container caps. See [environment gotchas](../internals/environment-gotchas.md#windows-wsl--docker-resource-budget). |
 
 ### Scripts requiring bash 4+
 
@@ -245,7 +246,7 @@ result to exactly one guard entry. Safe to run multiple times.
 ## 4. himmel Repo
 
 ```bash
-git clone https://github.com/yotamleo/Himmel.git
+git clone https://github.com/yotamleo/himmel.git
 cd himmel
 bash scripts/setup.sh
 ```
@@ -256,6 +257,18 @@ the **UNIVERSAL hooks** into `~/.claude/settings.json` (user scope — see §4b)
 A missing required tool (git/jq/python3) is auto-fetched via the platform
 package manager when possible, else setup fails loud with the manual command
 (HIMMEL-460).
+
+> **Build artifacts are gitignored — build them after cloning (HIMMEL-842).**
+> `scripts/jira/dist/index.js` and `scripts/bitbucket/dist/index.js` are TypeScript
+> build outputs, NOT tracked. A fresh clone has no `dist/`, so a direct
+> `node scripts/jira/dist/index.js list` dies with `MODULE_NOT_FOUND`. `bash scripts/setup.sh`
+> builds them (step `[3/10]`, Jira + Bitbucket CLIs). If you skip setup, build by hand:
+> ```bash
+> cd scripts/jira && npm install && npm run build && cd ../..   # or: bun install && bun run build
+> node scripts/jira/dist/index.js list                          # verify
+> # same shape for the Bitbucket CLI: cd scripts/bitbucket && npm install && npm run build
+> ```
+> (Needs Node 18+ with npm, OR bun — see [§1](#1-required-environment-himmel-123).)
 
 To **update** an existing checkout later, run `/himmel-update` (or `bash scripts/himmel-update.sh`):
 `git pull` is what delivers himmel updates — marketplace `autoUpdate` does not.
@@ -390,6 +403,48 @@ For **whole-subtree** coverage (any launch cwd under the root refused), also
 list the absolute PHI roots one-per-line in `~/.config/claude-glm/phi-roots` —
 same PHI-tier refusal, but subtree-wide.
 
+### 4e. qmd search bootstrap (optional — HIMMEL-842)
+
+> **Skip** if you don't use qmd semantic search over the himmel docs + luna vault. Optional; the harness runs without it.
+
+qmd is a local markdown search engine (BM25 + vector + rerank). himmel's fork
+runs it as a **shared HTTP daemon** (`localhost:8181`, HIMMEL-592) auto-brought-up
+by the `qmd` plugin's SessionStart hook, so every session shares one read-only
+index. The standalone CLI is installed via **bun** (project rule: bun, never npm).
+`bash scripts/setup.sh` step `[4/10]` + `adopt.sh`'s `wire_qmd_core` already
+register the `himmel` collection and best-effort `qmd pull`; this section is the
+**manual bootstrap** if you skipped those or want the luna vault indexed too.
+
+```bash
+# 1. Install the qmd CLI (bun global). bun itself: see §1 foundational table.
+bun add -g @tobilu/qmd@latest
+
+# 2. Pull the embedding + rerank models. WARNING: ~2.1 GB download — Ctrl-C-safe
+#    (re-run resumes); run once. Semantic search needs these.
+qmd pull
+
+# 3. Register collections (idempotent; skip ones you don't have).
+qmd collection add /path/to/himmel          --name himmel
+qmd collection add ~/Documents/luna         --name luna     # your luna vault
+
+# 4. Index + embed. `qmd update` ingests new/changed docs (fast); `qmd embed`
+#    builds the vector embeddings — CPU-intensive on a big vault (the luna vault
+#    can take tens of minutes on first embed; subsequent runs are incremental).
+qmd update
+qmd embed
+
+# Verify
+qmd collection list
+qmd status                    # collections + doc counts (index registered)
+```
+
+Notes:
+- The qmd Claude plugin ships a path stub in `~/.claude/plugins/cache/qmd/qmd/<v>/bin/qmd`
+  that references an unbuilt `dist/`; `scripts/lib/fix-qmd-stub.sh` (run by setup +
+  adopt) rewrites it to locate the bun-global install so plain `qmd` works everywhere.
+- Stop the shared daemon: `qmd mcp stop`. The index is sqlite+WAL read per query, so
+  docs added by `qmd update` are live immediately — no daemon restart needed.
+
 ---
 
 ## 5. Luna Vault
@@ -466,7 +521,7 @@ git clone https://github.com/eugeniughelbur/obsidian-second-brain ~/.claude/plug
 
 # 2. himmel marketplace (carries handover + obsidian-triage + claude-obsidian)
 # inside Claude Code:
-#   /plugin marketplace add yotamleo/Himmel
+#   /plugin marketplace add yotamleo/himmel
 #   /plugin install handover
 #
 #   # Optional — Web Clipper triage stack (skip if §5a was skipped)
@@ -499,7 +554,7 @@ The setup scripts let you pick: `scripts/machine-setup/install-plugins.{sh,ps1}`
 // <repo>/.claude/settings.json
 {
   "extraKnownMarketplaces": {
-    "himmel": { "source": { "source": "github", "repo": "yotamleo/Himmel" } }
+    "himmel": { "source": { "source": "github", "repo": "yotamleo/himmel" } }
   },
   "enabledPlugins": {
     "obsidian-triage@himmel": true
@@ -517,7 +572,7 @@ choosing the scope per command — copy-paste instead:
 
 ```bash
 # Register the marketplace (once; the GitHub slug is case-insensitive)
-claude plugin marketplace add yotamleo/Himmel
+claude plugin marketplace add yotamleo/himmel
 
 # Install plugins — --scope user (default, every project) or
 # --scope project (this repo's .claude/settings.json, shared on clone)
@@ -535,8 +590,8 @@ Or install the entire manifest (the himmel plugins plus the official ones it
 builds on) in one shot from a clone, at a chosen scope:
 
 ```bash
-git clone https://github.com/yotamleo/Himmel
-bash Himmel/scripts/machine-setup/install-plugins.sh --scope project
+git clone https://github.com/yotamleo/himmel
+bash himmel/scripts/machine-setup/install-plugins.sh --scope project
 ```
 
 The plugins carry their own slash commands + skills — that's all you need to use

--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -63,6 +63,12 @@ $script:BunAvailable = $true
 # adopt.ps1 and setup.ps1 (HIMMEL install/uninstall symmetry).
 . (Join-Path $ScriptDir 'lib/wire-pretooluse-hooks.ps1')
 
+# Adopter preflight checks (HIMMEL-842). Provides the shared WARN-not-fail
+# checks (uv/pipx, npm-less-node, jira-dist) consumed by Require-Tools below.
+# The standalone scripts/preflight-adopter.ps1 runner dot-sources the same lib,
+# so the two entry points report identically and can't drift (operator answer Q4).
+. (Join-Path $ScriptDir 'lib/preflight-adopter.ps1')
+
 if (-not $Target)     { $Target     = (Get-Location).Path }
 if (-not $LunaTarget) { $LunaTarget = Join-Path $HOME 'Documents\luna' }
 
@@ -100,6 +106,21 @@ function Require-Tools {
     if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
         $script:BunAvailable = $false
         Write-Warning "'bun' not found — qmd search will be skipped; install: https://bun.sh (runs handover armed-resume, qmd search, the Telegram bridge, obsidian-triage tools)"
+    }
+    # HIMMEL-842 adopter preflight: the shared advisory checks (uv/pipx,
+    # npm-less-node, jira-dist) live in scripts/lib/preflight-adopter.ps1 and are
+    # also run by the standalone scripts/preflight-adopter.ps1 runner. Each
+    # returns $false (after Write-Warning) when its gap is present. The
+    # npm-less-node case escalates to a HARD fail below when there is no JS
+    # package manager at all (npm AND bun both absent): adopt is about to build
+    # dist/ artifacts (Build-JiraCli) and cannot proceed without one. When bun is
+    # present it covers every himmel JS build, so the shared warning stays
+    # advisory and adopt proceeds.
+    $npmGap = -not (Test-PreflightNpmInvocable)
+    Test-PreflightUvPipx | Out-Null
+    Test-PreflightJiraDist | Out-Null
+    if ($npmGap -and ($script:BunAvailable -eq $false)) {
+        Write-Error "'node' found but 'npm' is missing (Ubuntu's nodejs ships without npm) and 'bun' is absent -- no JS package manager. Install bun (works for all himmel builds): https://bun.sh OR Node + npm via NodeSource: https://github.com/nodesource/distributions"
     }
 }
 
@@ -395,6 +416,73 @@ function Wire-QmdCoreInner {
     }
 }
 
+# Build-JiraCli -- build scripts/jira/dist/index.js (HIMMEL-842 gap 3). dist/ is
+# a gitignored build artifact, so a fresh clone bootstrapped via adopt.ps1 hits
+# MODULE_NOT_FOUND without this (CLAUDE.md's "worktrees lack dist/" warning is
+# scoped too narrowly -- a fresh PRIMARY clone via adopt.ps1 hits the identical
+# failure). Ports scripts/setup.sh step [3/10]'s build block, gated on
+# npm-or-bun presence (bun covers the Ubuntu node-without-npm case), and
+# WARN-not-fail: a build failure warns with the manual command and returns --
+# matches Wire-QmdCore's contract so a broken build never aborts an adopt.
+# Unlike setup.sh, NO `npm link`: adopted repos invoke the clone's dist/index.js
+# directly (`node $HimmelRoot\scripts\jira\dist\index.js`), so a global symlink
+# isn't needed. Honors -DryRun.
+function Build-JiraCli {
+    $jiraDir = Join-Path $HimmelRoot 'scripts\jira'
+    # fix-batch F3: skip only when BOTH halves are present — a stale dist/
+    # without node_modules/ (gitignored, so a dist/ leftover from a prior
+    # build can outlive a node_modules/ wipe) previously passed as "already
+    # built" then failed at runtime. Mirrors setup.ps1's invariant (checks both).
+    if ((Test-Path (Join-Path $jiraDir 'node_modules')) -and (Test-Path (Join-Path $jiraDir 'dist\index.js'))) {
+        Write-Host "  jira CLI dist already built — skipping"
+        return
+    }
+    $pm = $null
+    if (Get-Command npm -ErrorAction SilentlyContinue) { $pm = 'npm' }
+    elseif (Get-Command bun -ErrorAction SilentlyContinue) { $pm = 'bun' }
+    if (-not $pm) {
+        Write-Host "  jira CLI: skipping build (no npm or bun — install one to build dist/)." -ForegroundColor Yellow
+        Write-Host "  Manual: (cd scripts/jira && npm install && npm run build)" -ForegroundColor Yellow
+        return
+    }
+    Write-Host "──── Building jira CLI (scripts/jira/dist) ────"
+    if ($DryRun) { Write-Host "DRY: (cd scripts/jira && $pm install && $pm run build)"; return }
+    # WARN-not-fail under EAP='Stop' + PSNativeCommandUseErrorActionPreference:
+    # decouple native exit from EAP so a build failure WARNs instead of throwing
+    # (mirrors Wire-QmdCore's native-EAP guard). npm takes --silent (matches
+    # setup.sh); bun has no --silent flag, so the invocation branches on $pm.
+    $savedNativeEAP = $null
+    if (Test-Path variable:PSNativeCommandUseErrorActionPreference) {
+        $savedNativeEAP = $PSNativeCommandUseErrorActionPreference
+    }
+    $global:PSNativeCommandUseErrorActionPreference = $false
+    $savedEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $buildRc = 0
+    try {
+        Push-Location $jiraDir
+        if ($pm -eq 'npm') {
+            & npm install --silent
+            $rc1 = $LASTEXITCODE
+            if ($rc1 -eq 0) { & npm run build --silent; $buildRc = $LASTEXITCODE } else { $buildRc = $rc1 }
+        } else {
+            & bun install
+            $rc1 = $LASTEXITCODE
+            if ($rc1 -eq 0) { & bun run build; $buildRc = $LASTEXITCODE } else { $buildRc = $rc1 }
+        }
+    } finally {
+        Pop-Location
+        $ErrorActionPreference = $savedEAP
+        if ($null -ne $savedNativeEAP) { $global:PSNativeCommandUseErrorActionPreference = $savedNativeEAP }
+    }
+    if ($buildRc -eq 0) {
+        Write-Host "  jira CLI built. Invoke: node $HimmelRoot\scripts\jira\dist\index.js --help"
+    } else {
+        Write-Host "  WARNING: jira CLI build failed (exit $buildRc) — continuing (the preflight flagged this too)." -ForegroundColor Yellow
+        Write-Host "  Manual: (cd scripts/jira && $pm install && $pm run build)" -ForegroundColor Yellow
+    }
+}
+
 function Do-Core {
     Require-Tools
     if ($Scope -eq 'project') {
@@ -411,6 +499,7 @@ function Do-Core {
         Write-Host "  worktree commands run from the himmel clone: bash $HimmelRoot/scripts/worktree.sh feat/slug"
     }
     Install-Plugins
+    Build-JiraCli
     Wire-QmdCore
     Wire-StatuslineCore
     Wire-HimmelRepoCore

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -51,6 +51,14 @@ HIMMEL_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/qmd-bin.sh"
 
+# Adopter preflight checks (HIMMEL-842). Provides the shared WARN-not-fail
+# checks (uv/pipx, npm-less-node, jira-dist) consumed by require_tools() below.
+# The standalone scripts/preflight-adopter.sh runner sources the same lib, so the
+# two entry points report identically and can't drift (operator answer Q4).
+# shellcheck source=scripts/lib/preflight-adopter.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/preflight-adopter.sh"
+
 # ── Defaults ─────────────────────────────────────────────────────────────────
 PROFILE="core"
 SCOPE="project"
@@ -120,6 +128,25 @@ require_tools() {
     BUN_AVAILABLE=0
     echo "WARN: 'bun' not found — qmd search will be skipped;" >&2
     echo "      install: https://bun.sh (runs handover armed-resume, qmd search, the Telegram bridge, obsidian-triage tools)" >&2
+  fi
+  # HIMMEL-842 adopter preflight: the shared advisory checks (uv/pipx,
+  # npm-less-node, jira-dist) live in scripts/lib/preflight-adopter.sh and are
+  # also run by the standalone scripts/preflight-adopter.sh runner. Each returns
+  # 1 (after WARNing) when its gap is present; the `||` capture keeps a non-zero
+  # return from aborting under set -e. The npm-less-node case escalates to a
+  # HARD fail below when there is no JS package manager at all (npm AND bun both
+  # absent): adopt is about to build dist/ artifacts (build_jira_cli) and cannot
+  # proceed without one. When bun is present it covers every himmel JS build, so
+  # the shared WARN stays advisory and adopt proceeds.
+  local npm_gap=0
+  preflight_check_uv_pipx       || true
+  preflight_check_npm_invocable || npm_gap=1
+  preflight_check_jira_dist     || true
+  if [[ "$npm_gap" -eq 1 && "${BUN_AVAILABLE:-1}" -eq 0 ]]; then
+    echo "ERROR: 'node' found but 'npm' is missing (Ubuntu's nodejs ships without npm) and 'bun' is absent — no JS package manager." >&2
+    echo "  Install bun (works for all himmel builds): https://bun.sh" >&2
+    echo "  OR Node + npm via NodeSource: https://github.com/nodesource/distributions" >&2
+    exit 1
   fi
 }
 
@@ -267,6 +294,60 @@ wire_qmd_core() {
   fi
 }
 
+# build_jira_cli — build scripts/jira/dist/index.js (HIMMEL-842 gap 3). dist/ is
+# a gitignored build artifact, so a fresh clone bootstrapped via adopt.sh hits
+# MODULE_NOT_FOUND without this (CLAUDE.md's "worktrees lack dist/" warning is
+# scoped too narrowly — a fresh PRIMARY clone via adopt.sh hits the identical
+# failure). Ports scripts/setup.sh step [3/10]'s build block, gated on
+# npm-or-bun presence (bun covers the Ubuntu node-without-npm case), and
+# WARN-not-fail: a build failure warns with the manual command and returns 0 —
+# matches wire_qmd_core's contract so a broken build never aborts an adopt.
+# Unlike setup.sh, NO `npm link`: adopted repos invoke the clone's dist/index.js
+# directly (`node $HIMMEL_ROOT/scripts/jira/dist/index.js`), so a global symlink
+# isn't needed. Honors --dry-run.
+build_jira_cli() {
+  local jira_dir="$HIMMEL_ROOT/scripts/jira"
+  # fix-batch F3: skip only when BOTH halves are present — a stale dist/
+  # without node_modules/ (gitignored, so a dist/ leftover from a prior build
+  # can outlive a node_modules/ wipe) previously passed as "already built"
+  # then failed at runtime. Mirrors setup.sh's invariant (checks both).
+  if [[ -d "$jira_dir/node_modules" && -f "$jira_dir/dist/index.js" ]]; then
+    echo "  jira CLI dist already built — skipping"
+    return 0
+  fi
+  local pm=""
+  if command -v npm >/dev/null 2>&1; then
+    pm=npm
+  elif command -v bun >/dev/null 2>&1; then
+    pm=bun
+  fi
+  if [[ -z "$pm" ]]; then
+    echo "  jira CLI: skipping build (no npm or bun — install one to build dist/)." >&2
+    echo "  Manual: (cd scripts/jira && npm install && npm run build)" >&2
+    return 0
+  fi
+  echo "──── Building jira CLI (scripts/jira/dist) ────"
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "DRY: (cd scripts/jira && $pm install && $pm run build)"
+    return 0
+  fi
+  # npm takes --silent (matches setup.sh step [3/10]); bun has no --silent flag,
+  # so branch the invocation rather than pass an unknown flag.
+  local ok=1
+  if [[ "$pm" == "npm" ]]; then
+    ( cd "$jira_dir" && npm install --silent && npm run build --silent ) || ok=0
+  else
+    ( cd "$jira_dir" && bun install && bun run build ) || ok=0
+  fi
+  if [[ $ok -eq 1 ]]; then
+    echo "  jira CLI built. Invoke: node $HIMMEL_ROOT/scripts/jira/dist/index.js --help"
+  else
+    echo "  WARNING: jira CLI build failed — continuing (the preflight flagged this too)." >&2
+    echo "  Manual: (cd scripts/jira && $pm install && $pm run build)" >&2
+    # WARN-not-fail: return 0 so a broken build never aborts adopt.
+  fi
+}
+
 do_core() {
   require_tools
   if [[ "$SCOPE" == "project" ]]; then
@@ -284,6 +365,7 @@ do_core() {
     echo "  worktree commands run from the himmel clone: bash $HIMMEL_ROOT/scripts/worktree.sh feat/slug"
   fi
   install_plugins
+  build_jira_cli
   wire_qmd_core
   wire_statusline_core
   wire_himmel_repo_core

--- a/scripts/lib/preflight-adopter.ps1
+++ b/scripts/lib/preflight-adopter.ps1
@@ -1,0 +1,87 @@
+# preflight-adopter.ps1 — shared adopter preflight checks (HIMMEL-842 fix-batch).
+#
+# Dot-sourced (not executed) by both scripts/adopt.ps1 (auto-invoked from
+# Require-Tools) and scripts/preflight-adopter.ps1 (the standalone check-only
+# runner an adopter can run BEFORE committing to adopt.ps1 — operator answer Q4:
+# "BOTH standalone check-only AND auto-invoked"). Counterpart of
+# scripts/lib/preflight-adopter.sh; keep both in lockstep.
+#
+# FUNCTIONS ONLY — dot-sourcing this file has NO side effects (no variables are
+# set, nothing runs at source time). Each Test-* check returns $true when the
+# environment is clean and $false when its gap is detected (after Write-Warning).
+# WARN-not-fail in the sense that a check never throws/exits — the caller decides
+# severity. adopt.ps1 escalates the npm-less-node $false into a hard fail when
+# there is no JS package manager at all; the standalone runner just counts. The
+# detection is not duplicated between the two entry points; only the severity
+# policy differs.
+#
+# Checks (each closes a HIMMEL-842 gap from the preflight design spec):
+#   Test-PreflightUvPipx        — uv OR pipx present (gap 1: pre-commit install)
+#   Test-PreflightNpmInvocable  — npm invocable when node is (gap 2: npm-less
+#                                 distro node)
+#   Test-PreflightJiraDist      — scripts/jira/dist/index.js + node_modules
+#                                 both built (gap 3)
+#
+# $HimmelRoot must be set by the caller before calling Test-PreflightJiraDist —
+# an unset/empty $HimmelRoot WARNs and returns $false (caller bug) rather than
+# silently passing.
+
+# uv OR pipx must be present so the luna-vault setup can install pre-commit
+# (PEP 668 blocks raw pip). Neither himmel's adopt.ps1 nor ensure-tools.sh
+# auto-installs uv today, so surface the gap + the same astral.sh command used
+# ad hoc in 3 other places. Returns $false (advisory) on the gap.
+function Test-PreflightUvPipx {
+    if ((-not (Get-Command uv -ErrorAction SilentlyContinue)) -and (-not (Get-Command pipx -ErrorAction SilentlyContinue))) {
+        Write-Warning "neither 'uv' nor 'pipx' found — the luna-vault setup's pre-commit install will fail. Install uv: curl -LsSf https://astral.sh/uv/install.sh | sh"
+        return $false
+    }
+    return $true
+}
+
+# Ubuntu's distro 'nodejs' ships WITHOUT npm. node-without-npm breaks the
+# plugin-install workflow, the lockfile/audit pre-commit gates, and a bare node
+# with no package manager can't build dist/ artifacts. Returns $false (advisory)
+# when node is present but npm is not — bun covers every himmel JS build, so this
+# is advisory here; adopt.ps1 escalates to a hard fail only when there is no JS
+# package manager AT ALL (npm AND bun both absent).
+function Test-PreflightNpmInvocable {
+    if ((Get-Command node -ErrorAction SilentlyContinue) -and (-not (Get-Command npm -ErrorAction SilentlyContinue))) {
+        Write-Warning "'node' found but 'npm' is missing (Ubuntu's nodejs ships without npm). Install Node + npm via NodeSource: https://github.com/nodesource/distributions OR use bun: https://bun.sh (covers all himmel JS builds; required for qmd/handover)"
+        return $false
+    }
+    return $true
+}
+
+# scripts/jira/dist/index.js AND scripts/jira/node_modules are gitignored
+# build artifacts — a fresh clone bootstrapped via adopt.ps1 hits
+# MODULE_NOT_FOUND without dist/ (CLAUDE.md's "worktrees lack dist/" warning is
+# scoped too narrowly; a fresh PRIMARY clone via adopt.ps1 hits the identical
+# failure), and a STALE dist/ without node_modules/ passes as "already built"
+# then fails at runtime (fix-batch F3: setup.ps1's invariant checks BOTH, so
+# this check now does too — naming which half is missing). Returns $false
+# (advisory) when either is absent. Also returns $false (fix-batch F2) when
+# $HimmelRoot is unset/empty — a caller bug, not a silent pass. adopt.ps1's
+# Build-JiraCli builds both; this check only surfaces the gap so a standalone
+# preflight run flags it up front.
+function Test-PreflightJiraDist {
+    if (-not $HimmelRoot) {
+        Write-Warning "HIMMEL_ROOT not set — jira-dist check skipped (caller bug)"
+        return $false
+    }
+    $jiraDir = Join-Path $HimmelRoot 'scripts\jira'
+    $hasNodeModules = Test-Path (Join-Path $jiraDir 'node_modules')
+    $hasDist = Test-Path (Join-Path $jiraDir 'dist\index.js')
+    $gap = $null
+    if ((-not $hasNodeModules) -and (-not $hasDist)) {
+        $gap = "scripts/jira/node_modules and scripts/jira/dist/index.js not built"
+    } elseif (-not $hasNodeModules) {
+        $gap = "scripts/jira/node_modules not installed"
+    } elseif (-not $hasDist) {
+        $gap = "scripts/jira/dist/index.js not built"
+    }
+    if ($gap) {
+        Write-Warning "$gap (gitignored build artifact) — the Jira CLI won't run until it is. Build it: (cd scripts/jira && npm install && npm run build)   [adopt.ps1 builds this automatically via Build-JiraCli]"
+        return $false
+    }
+    return $true
+}

--- a/scripts/lib/preflight-adopter.sh
+++ b/scripts/lib/preflight-adopter.sh
@@ -1,0 +1,92 @@
+# shellcheck shell=bash
+# preflight-adopter.sh — shared adopter preflight checks (HIMMEL-842 fix-batch).
+#
+# Sourced (not executed) by both scripts/adopt.sh (auto-invoked from
+# require_tools) and scripts/preflight-adopter.sh (the standalone check-only
+# runner an adopter can run BEFORE committing to adopt.sh — operator answer Q4:
+# "BOTH standalone check-only AND auto-invoked"). Mirrors the existing
+# scripts/lib/qmd-bin.sh / wire-*.sh pattern: small, single-purpose, sourced by
+# multiple entry points so the check logic lives in exactly one place.
+#
+# FUNCTIONS ONLY — sourcing this file has NO side effects (no globals, nothing
+# runs at source time). Callers invoke the preflight_check_* functions, each of
+# which returns 0 when the environment is clean and 1 when its gap is detected
+# (after printing a WARN line to stderr). WARN-not-fail in the sense that a check
+# never exits the process — the caller decides severity. adopt.sh escalates the
+# npm-less-node return into a hard fail when there is no JS package manager at
+# all; the standalone runner just counts. The detection is not duplicated between
+# the two entry points; only the severity policy differs.
+#
+# Checks (each closes a HIMMEL-842 gap from the preflight design spec):
+#   preflight_check_uv_pipx       — uv OR pipx present (gap 1: pre-commit install)
+#   preflight_check_npm_invocable — npm invocable when node is (gap 2: npm-less
+#                                   distro node)
+#   preflight_check_jira_dist     — scripts/jira/dist/index.js + node_modules
+#                                   both built (gap 3)
+#
+# $HIMMEL_ROOT must be set by the caller before calling the jira-dist check —
+# an unset/empty $HIMMEL_ROOT WARNs and returns 1 (caller bug) rather than
+# silently passing.
+
+# Internal: print a WARN line to stderr.
+preflight_warn() {
+  printf 'WARN: %s\n' "$*" >&2
+}
+
+# uv OR pipx must be present so the luna-vault setup can install pre-commit
+# (PEP 668 blocks raw pip). Neither himmel's adopt.sh nor ensure-tools.sh
+# auto-installs uv today, so surface the gap + the same astral.sh command used
+# ad hoc in 3 other places. Returns 1 (advisory) on the gap.
+preflight_check_uv_pipx() {
+  if ! command -v uv >/dev/null 2>&1 && ! command -v pipx >/dev/null 2>&1; then
+    preflight_warn "neither 'uv' nor 'pipx' found — the luna-vault setup's pre-commit install will fail. Install uv: curl -LsSf https://astral.sh/uv/install.sh | sh"
+    return 1
+  fi
+  return 0
+}
+
+# Ubuntu's distro 'nodejs' ships WITHOUT npm. node-without-npm breaks the
+# plugin-install workflow, the lockfile/audit pre-commit gates, and a bare node
+# with no package manager can't build dist/ artifacts. Returns 1 (advisory) when
+# node is present but npm is not — bun covers every himmel JS build, so this is
+# advisory here; adopt.sh escalates to a hard fail only when there is no JS
+# package manager AT ALL (npm AND bun both absent).
+preflight_check_npm_invocable() {
+  if command -v node >/dev/null 2>&1 && ! command -v npm >/dev/null 2>&1; then
+    preflight_warn "'node' found but 'npm' is missing (Ubuntu's nodejs ships without npm). Install Node + npm via NodeSource: https://github.com/nodesource/distributions OR use bun: https://bun.sh (covers all himmel JS builds; required for qmd/handover)"
+    return 1
+  fi
+  return 0
+}
+
+# scripts/jira/dist/index.js AND scripts/jira/node_modules are gitignored
+# build artifacts — a fresh clone bootstrapped via adopt.sh hits
+# MODULE_NOT_FOUND without dist/ (CLAUDE.md's "worktrees lack dist/" warning is
+# scoped too narrowly; a fresh PRIMARY clone via adopt.sh hits the identical
+# failure), and a STALE dist/ without node_modules/ passes as "already built"
+# then fails at runtime (fix-batch F3: setup.sh's invariant checks BOTH, so
+# this check now does too — naming which half is missing). Returns 1
+# (advisory) when either is absent. Also returns 1 (fix-batch F2) when
+# $HIMMEL_ROOT is unset/empty — a caller bug, not a silent pass. adopt.sh's
+# build_jira_cli() builds both; this check only surfaces the gap so a
+# standalone preflight run flags it up front.
+preflight_check_jira_dist() {
+  if [ -z "${HIMMEL_ROOT:-}" ]; then
+    preflight_warn "HIMMEL_ROOT not set — jira-dist check skipped (caller bug)"
+    return 1
+  fi
+  local jira_dir="$HIMMEL_ROOT/scripts/jira"
+  local gap=""
+  if [ ! -d "$jira_dir/node_modules" ] && [ ! -f "$jira_dir/dist/index.js" ]; then
+    gap="scripts/jira/node_modules and scripts/jira/dist/index.js not built"
+  elif [ ! -d "$jira_dir/node_modules" ]; then
+    gap="scripts/jira/node_modules not installed"
+  elif [ ! -f "$jira_dir/dist/index.js" ]; then
+    gap="scripts/jira/dist/index.js not built"
+  fi
+  if [ -n "$gap" ]; then
+    preflight_warn "$gap (gitignored build artifact) — the Jira CLI won't run until it is. Build it: (cd scripts/jira && npm install && npm run build)   [adopt.sh builds this automatically via build_jira_cli]"
+    return 1
+  fi
+  return 0
+}

--- a/scripts/preflight-adopter.ps1
+++ b/scripts/preflight-adopter.ps1
@@ -1,0 +1,62 @@
+# preflight-adopter.ps1 — standalone check-only adopter preflight (HIMMEL-842
+# fix-batch). An adopter can run this BEFORE committing to adopt.ps1 to surface
+# the common fresh-machine gaps (uv/pipx, npm-less distro node, unbuilt
+# scripts/jira/dist) in one pass, instead of discovering them one abort at a
+# time across three downstream scripts. Counterpart of preflight-adopter.sh;
+# keep both in lockstep.
+#
+# Dot-sources scripts/lib/preflight-adopter.ps1 — the SAME shared checks adopt.ps1
+# calls — so the two entry points can never drift (operator answer Q4: "BOTH
+# standalone check-only AND auto-invoked").
+#
+# Advisory-first, matching adopt.ps1's WARN-not-fail culture: prints WARN lines
+# and ALWAYS exits 0 unless -Strict is passed (then any WARN exits 1, for use in
+# CI / a verification pass where "does this reach zero warnings" is the thing
+# being measured). No fixes are applied — adopt.ps1 does the building; this only
+# reports.
+#
+# Usage:
+#   pwsh preflight-adopter.ps1 [-Strict] [-Help]
+
+[CmdletBinding()]
+param(
+    [switch]$Strict,
+    [Alias('h')]
+    [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+# -h/-Help parity with preflight-adopter.sh's --help: dump this script's own
+# leading comment header (stripped of the "# " prefix) and exit 0.
+if ($Help) {
+    foreach ($line in (Get-Content -LiteralPath $PSCommandPath)) {
+        if ($line -notmatch '^#') { break }
+        Write-Host ($line -replace '^# ?', '')
+    }
+    exit 0
+}
+
+$ScriptDir  = Split-Path -Parent $MyInvocation.MyCommand.Path
+$HimmelRoot = (Resolve-Path (Join-Path $ScriptDir '..')).Path
+
+. (Join-Path $ScriptDir 'lib\preflight-adopter.ps1')
+
+Write-Host "==> himmel adopter preflight (check-only)"
+
+# Run each shared check, counting how many WARN. adopt.ps1 calls these same
+# functions, so the two entry points can never drift.
+$warns = 0
+if (-not (Test-PreflightUvPipx))       { $warns++ }
+if (-not (Test-PreflightNpmInvocable)) { $warns++ }
+if (-not (Test-PreflightJiraDist))     { $warns++ }
+
+if ($warns -gt 0) {
+    Write-Host "──── $warns warning(s). adopt.ps1 will warn on these too."
+    Write-Host "──── Re-run with -Strict to exit non-zero on any warning."
+} else {
+    Write-Host "──── preflight clean (0 warnings)."
+}
+
+if ($Strict -and ($warns -gt 0)) { exit 1 }
+exit 0

--- a/scripts/preflight-adopter.sh
+++ b/scripts/preflight-adopter.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# preflight-adopter.sh — standalone check-only adopter preflight (HIMMEL-842
+# fix-batch). An adopter can run this BEFORE committing to adopt.sh to surface
+# the common fresh-machine gaps (uv/pipx, npm-less distro node, unbuilt
+# scripts/jira/dist) in one pass, instead of discovering them one `set -e`
+# abort at a time across three downstream scripts.
+#
+# Sources scripts/lib/preflight-adopter.sh — the SAME shared checks adopt.sh
+# calls — so the two entry points can never drift (operator answer Q4: "BOTH
+# standalone check-only AND auto-invoked").
+#
+# Advisory-first, matching adopt.sh's WARN-not-fail culture: prints WARN lines
+# and ALWAYS exits 0 unless --strict is passed (then any WARN exits 1, for use
+# in CI / a verification pass where "does this reach zero warnings" is the thing
+# being measured). No fixes are applied — adopt.sh does the building; this only
+# reports.
+#
+# Usage:
+#   bash scripts/preflight-adopter.sh [--strict]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# Exported: the sourced lib's preflight_check_jira_dist reads $HIMMEL_ROOT.
+HIMMEL_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+export HIMMEL_ROOT
+
+STRICT=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --strict) STRICT=1; shift ;;
+    -h|--help)
+      sed -n '2,/^set -e/p' "$0" | sed 's/^# \{0,1\}//' | sed '$d'
+      exit 0
+      ;;
+    *) echo "ERROR: unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+# shellcheck source=lib/preflight-adopter.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/preflight-adopter.sh"
+
+echo "==> himmel adopter preflight (check-only)"
+
+# Run each shared check, counting how many WARN. The `||` capture keeps a
+# non-zero return (gap detected) from aborting under set -e and lets every check
+# run so all gaps surface in one pass. adopt.sh calls these same functions, so
+# the two entry points can never drift.
+warns=0
+preflight_check_uv_pipx       || warns=$((warns + 1))
+preflight_check_npm_invocable || warns=$((warns + 1))
+preflight_check_jira_dist     || warns=$((warns + 1))
+
+if [ "$warns" -gt 0 ]; then
+  echo "──── $warns warning(s). adopt.sh will warn on these too."
+  echo "──── Re-run with --strict to exit non-zero on any warning."
+else
+  echo "──── preflight clean (0 warnings)."
+fi
+
+if [ "$STRICT" -eq 1 ] && [ "$warns" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/test-adopt.ps1
+++ b/scripts/test-adopt.ps1
@@ -13,6 +13,26 @@ function Fail($m) { Write-Host "  FAIL: $m" -ForegroundColor Red; $script:fails+
 
 $TMP = Join-Path ([System.IO.Path]::GetTempPath()) ("himmel-adopt-native-test-" + [System.Guid]::NewGuid().ToString("N").Substring(0,8))
 New-Item -ItemType Directory -Force -Path $TMP | Out-Null
+
+# HIMMEL-842 CR round-2 (F1): scripts/jira/dist + scripts/jira/node_modules are
+# gitignored build artifacts that MAY already exist in this checkout (a primary
+# checkout that ran adopt.ps1/setup.ps1 before). Build-JiraCli's "already
+# built" skip fires the instant either is present, which would make scenarios
+# E-J below assert on the WRONG branch. Move any existing dist/node_modules
+# aside for the whole suite; sentinel-tracked, restored unconditionally in the
+# outer finally (mirrors the old scenario-H-only pattern, now suite-wide).
+$RealJiraDist = Join-Path $ScriptDir 'jira\dist'
+$RealJiraNodeModules = Join-Path $ScriptDir 'jira\node_modules'
+$DistBackup = $null
+$NodeModulesBackup = $null
+if (Test-Path $RealJiraDist) {
+    $DistBackup = Join-Path $TMP 'dist-backup'
+    Move-Item -Path $RealJiraDist -Destination $DistBackup
+}
+if (Test-Path $RealJiraNodeModules) {
+    $NodeModulesBackup = Join-Path $TMP 'node_modules-backup'
+    Move-Item -Path $RealJiraNodeModules -Destination $NodeModulesBackup
+}
 try {
   $StubDir = Join-Path $TMP "bin"
   $Target = Join-Path $TMP "target"
@@ -78,7 +98,260 @@ exit /b 0
   if ($outB -match "install-plugins failed" -and $outB -match "exit \d+") { Pass "user-scope error names install-plugins step + exit code" } else { Fail "user-scope error message missing install-plugins step/exit-code detail (got: $outB)" }
 
   Write-Host ""
+  Write-Host "== scenario C: node-without-npm + no JS package manager (HIMMEL-842) -> Require-Tools fails upfront =="
+  # Separate stub dir so this does not perturb scenarios A/B (which must reach
+  # Install-Plugins). Same hard-required stubs (git/jq/python3 + claude soft) PLUS
+  # node.cmd, but NO npm.cmd and NO bun. The scrubbed PATH (stub + System32 +
+  # SystemRoot) keeps real node/npm/bun off PATH, so the broken distro-node state
+  # (node present, npm absent, bun absent) is reproduced hermetically.
+  $StubDirC = Join-Path $TMP "binC"
+  $TargetC  = Join-Path $TMP "targetC"
+  New-Item -ItemType Directory -Force -Path $StubDirC,$TargetC | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $TargetC '.claude') | Out-Null
+  Set-Content -Path (Join-Path $TargetC '.claude\settings.json') -Value '{}'
+  foreach ($name in @("git","python3","claude","node")) {
+    Set-Content -Path (Join-Path $StubDirC "$name.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  }
+  Set-Content -Path (Join-Path $StubDirC "jq.cmd") -Encoding ASCII -Value "@echo off`r`necho {}`r`nexit /b 0`r`n"
+
+  $env:Path = "$StubDirC;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $outC = & $realPwsh -NoProfile -NonInteractive -File $Installer -Profile core -Scope project -Target $TargetC 2>&1 | Out-String
+    $codeC = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+  }
+
+  if ($codeC -ne 0) { Pass "node-without-npm + no bun exits non-zero" } else { Fail "node-without-npm + no bun should exit non-zero" }
+  if (($outC -match "npm") -and ($outC -match "bun.sh") -and ($outC -match "(?i)nodesource")) { Pass "error names npm + bun.sh + NodeSource install hints" } else { Fail "error missing npm/bun.sh/nodesource hint (got: $outC)" }
+
+  Write-Host ""
+  Write-Host "== scenario D: node-without-npm + bun present (HIMMEL-842) -> soft warn only, adopt proceeds =="
+  # bun covers every himmel JS build, so this must NOT hard-fail (mirror of
+  # test-adopt.sh scenario 13). -DryRun keeps the run side-effect-free and lets
+  # Require-Tools' escalation logic be exercised without a working pwsh child
+  # stub for Install-Plugins/Wire-StatuslineCore/Wire-HimmelRepoCore (claude
+  # omitted -> Install-Plugins skips; -DryRun -> the rest short-circuit before
+  # any child pwsh call).
+  $StubDirD = Join-Path $TMP "binD"
+  $TargetD  = Join-Path $TMP "targetD"
+  New-Item -ItemType Directory -Force -Path $StubDirD,$TargetD | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $TargetD '.claude') | Out-Null
+  Set-Content -Path (Join-Path $TargetD '.claude\settings.json') -Value '{}'
+  foreach ($name in @("git","python3","node","bun")) {
+    Set-Content -Path (Join-Path $StubDirD "$name.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  }
+  Set-Content -Path (Join-Path $StubDirD "jq.cmd") -Encoding ASCII -Value "@echo off`r`necho {}`r`nexit /b 0`r`n"
+
+  $env:Path = "$StubDirD;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $outD = & $realPwsh -NoProfile -NonInteractive -File $Installer -Profile core -Scope project -Target $TargetD -DryRun 2>&1 | Out-String
+    $codeD = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+  }
+
+  if ($codeD -eq 0) { Pass "node-without-npm + bun present proceeds (rc=0)" } else { Fail "node-without-npm + bun present should proceed, got rc=$codeD" }
+  if ($outD -match "npm") { Pass "soft-warn mentions npm" } else { Fail "missing npm soft-warn (got: $outD)" }
+  if ($outD -match "no JS package manager") { Fail "must NOT hard-fail when bun present (saw hard-fail message)" } else { Pass "no hard-fail message when bun present" }
+
+  Write-Host ""
+  Write-Host "== scenario E: Build-JiraCli success path (stub npm exit 0) (HIMMEL-842 gap 3) =="
+  # No -DryRun: exercises the real build branch. `claude` omitted so
+  # Install-Plugins skips (ClaudeAvailable=$false); Wire-StatuslineCore /
+  # Wire-HimmelRepoCore still shell out to a pwsh child unconditionally, so a
+  # pwsh.cmd stub that exits 0 is required. dist/index.js is not actually
+  # created by the npm stub -- the assertion is on the reported outcome.
+  $StubDirE = Join-Path $TMP "binE"
+  $TargetE  = Join-Path $TMP "targetE"
+  New-Item -ItemType Directory -Force -Path $StubDirE,$TargetE | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $TargetE '.claude') | Out-Null
+  Set-Content -Path (Join-Path $TargetE '.claude\settings.json') -Value '{}'
+  foreach ($name in @("git","python3")) {
+    Set-Content -Path (Join-Path $StubDirE "$name.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  }
+  Set-Content -Path (Join-Path $StubDirE "jq.cmd")   -Encoding ASCII -Value "@echo off`r`necho {}`r`nexit /b 0`r`n"
+  Set-Content -Path (Join-Path $StubDirE "pwsh.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  Set-Content -Path (Join-Path $StubDirE "npm.cmd")  -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+
+  $env:Path = "$StubDirE;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $outE = & $realPwsh -NoProfile -NonInteractive -File $Installer -Profile core -Scope project -Target $TargetE 2>&1 | Out-String
+    $codeE = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+  }
+
+  if ($codeE -eq 0) { Pass "Build-JiraCli success path: adopt exits 0" } else { Fail "Build-JiraCli success path should exit 0, got rc=$codeE" }
+  if ($outE -match "Building jira CLI") { Pass "Build-JiraCli prints the build header" } else { Fail "missing 'Building jira CLI' header (got: $outE)" }
+  if ($outE -match "jira CLI built") { Pass "Build-JiraCli reports built" } else { Fail "missing 'jira CLI built' success message (got: $outE)" }
+  if ($outE -match "jira CLI build failed") { Fail "success path must not print a build-failed warning" } else { Pass "success path prints no build-failed warning" }
+
+  Write-Host ""
+  Write-Host "== scenario F: Build-JiraCli WARN-not-fail (stub npm exit 1) (HIMMEL-842 gap 3) =="
+  # A failing build must WARN with the manual command and adopt must still
+  # exit 0 -- matches Wire-QmdCore's contract; a broken jira build never
+  # aborts adopt.
+  $StubDirF = Join-Path $TMP "binF"
+  $TargetF  = Join-Path $TMP "targetF"
+  New-Item -ItemType Directory -Force -Path $StubDirF,$TargetF | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $TargetF '.claude') | Out-Null
+  Set-Content -Path (Join-Path $TargetF '.claude\settings.json') -Value '{}'
+  foreach ($name in @("git","python3")) {
+    Set-Content -Path (Join-Path $StubDirF "$name.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  }
+  Set-Content -Path (Join-Path $StubDirF "jq.cmd")   -Encoding ASCII -Value "@echo off`r`necho {}`r`nexit /b 0`r`n"
+  Set-Content -Path (Join-Path $StubDirF "pwsh.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  Set-Content -Path (Join-Path $StubDirF "npm.cmd")  -Encoding ASCII -Value "@echo off`r`nexit /b 1`r`n"
+
+  $env:Path = "$StubDirF;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $outF = & $realPwsh -NoProfile -NonInteractive -File $Installer -Profile core -Scope project -Target $TargetF 2>&1 | Out-String
+    $codeF = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+  }
+
+  if ($codeF -eq 0) { Pass "Build-JiraCli WARN-not-fail: adopt exits 0 on a build failure" } else { Fail "Build-JiraCli WARN-not-fail should exit 0, got rc=$codeF" }
+  if ($outF -match "WARNING.*jira CLI build failed") { Pass "Build-JiraCli prints the build-failed WARNING" } else { Fail "missing build-failed WARNING (got: $outF)" }
+  if ($outF -match [regex]::Escape("npm install") -and $outF -match [regex]::Escape("npm run build")) { Pass "WARNING includes the manual command" } else { Fail "missing manual command in WARNING (got: $outF)" }
+
+  Write-Host ""
+  Write-Host "== scenario G: Build-JiraCli skip when no JS package manager (HIMMEL-842 gap 3) =="
+  # npm AND bun both absent -> Build-JiraCli skips with the manual command and
+  # never attempts a build. Real run (no -DryRun) exercises the skip branch,
+  # not the DRY branch.
+  $StubDirG = Join-Path $TMP "binG"
+  $TargetG  = Join-Path $TMP "targetG"
+  New-Item -ItemType Directory -Force -Path $StubDirG,$TargetG | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $TargetG '.claude') | Out-Null
+  Set-Content -Path (Join-Path $TargetG '.claude\settings.json') -Value '{}'
+  foreach ($name in @("git","python3")) {
+    Set-Content -Path (Join-Path $StubDirG "$name.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  }
+  Set-Content -Path (Join-Path $StubDirG "jq.cmd")   -Encoding ASCII -Value "@echo off`r`necho {}`r`nexit /b 0`r`n"
+  Set-Content -Path (Join-Path $StubDirG "pwsh.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+
+  $env:Path = "$StubDirG;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $outG = & $realPwsh -NoProfile -NonInteractive -File $Installer -Profile core -Scope project -Target $TargetG 2>&1 | Out-String
+    $codeG = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+  }
+
+  if ($codeG -eq 0) { Pass "Build-JiraCli skip path: adopt exits 0" } else { Fail "Build-JiraCli skip path should exit 0, got rc=$codeG" }
+  if ($outG -match [regex]::Escape("jira CLI: skipping build (no npm or bun")) { Pass "Build-JiraCli prints the no-pm skip note" } else { Fail "missing no-pm skip note (got: $outG)" }
+  if ($outG -match "Building jira CLI") { Fail "no-pm path must NOT attempt a build (saw build header)" } else { Pass "no-pm path attempts no build" }
+
+  Write-Host ""
+  Write-Host "== scenario H: Build-JiraCli idempotent when dist AND node_modules already built (HIMMEL-842 gap 3, F3: skip requires BOTH) =="
+  # The suite-wide move-aside above guarantees scripts/jira/dist and
+  # scripts/jira/node_modules are both absent entering this scenario; create
+  # both so Build-JiraCli's "already built" branch fires. Removed right after
+  # (dist/ and node_modules/ are gitignored, so this never pollutes git); the
+  # outer finally restores the real ones unconditionally regardless.
+  New-Item -ItemType Directory -Force -Path $RealJiraDist | Out-Null
+  New-Item -ItemType File -Force -Path (Join-Path $RealJiraDist 'index.js') | Out-Null
+  New-Item -ItemType Directory -Force -Path $RealJiraNodeModules | Out-Null
+  $StubDirH = Join-Path $TMP "binH"
+  $TargetH  = Join-Path $TMP "targetH"
+  New-Item -ItemType Directory -Force -Path $StubDirH,$TargetH | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $TargetH '.claude') | Out-Null
+  Set-Content -Path (Join-Path $TargetH '.claude\settings.json') -Value '{}'
+  foreach ($name in @("git","python3")) {
+    Set-Content -Path (Join-Path $StubDirH "$name.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  }
+  Set-Content -Path (Join-Path $StubDirH "jq.cmd")   -Encoding ASCII -Value "@echo off`r`necho {}`r`nexit /b 0`r`n"
+  Set-Content -Path (Join-Path $StubDirH "pwsh.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+
+  $env:Path = "$StubDirH;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $outH = & $realPwsh -NoProfile -NonInteractive -File $Installer -Profile core -Scope project -Target $TargetH 2>&1 | Out-String
+    $codeH = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+    Remove-Item -Recurse -Force $RealJiraDist -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $RealJiraNodeModules -ErrorAction SilentlyContinue
+  }
+
+  if ($codeH -eq 0) { Pass "Build-JiraCli idempotent path: adopt exits 0" } else { Fail "Build-JiraCli idempotent path should exit 0, got rc=$codeH" }
+  if ($outH -match [regex]::Escape("jira CLI dist already built")) { Pass "Build-JiraCli prints the already-built skip" } else { Fail "missing 'already built' skip (got: $outH)" }
+  if ($outH -match "Building jira CLI") { Fail "already-built path must NOT attempt a build" } else { Pass "already-built path attempts no build" }
+
+  Write-Host ""
+  Write-Host "== scenario I: Build-JiraCli builds when dist present but node_modules ABSENT (HIMMEL-842 gap 3, F3) =="
+  # A stale dist/ without node_modules/ previously passed as "already built"
+  # then failed at runtime -- F3 requires BOTH halves present to skip.
+  New-Item -ItemType Directory -Force -Path $RealJiraDist | Out-Null
+  New-Item -ItemType File -Force -Path (Join-Path $RealJiraDist 'index.js') | Out-Null
+  # node_modules stays absent (suite-wide baseline).
+  $StubDirI = Join-Path $TMP "binI"
+  $TargetI  = Join-Path $TMP "targetI"
+  New-Item -ItemType Directory -Force -Path $StubDirI,$TargetI | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $TargetI '.claude') | Out-Null
+  Set-Content -Path (Join-Path $TargetI '.claude\settings.json') -Value '{}'
+  foreach ($name in @("git","python3")) {
+    Set-Content -Path (Join-Path $StubDirI "$name.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  }
+  Set-Content -Path (Join-Path $StubDirI "jq.cmd")   -Encoding ASCII -Value "@echo off`r`necho {}`r`nexit /b 0`r`n"
+  Set-Content -Path (Join-Path $StubDirI "pwsh.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  Set-Content -Path (Join-Path $StubDirI "npm.cmd")  -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+
+  $env:Path = "$StubDirI;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $outI = & $realPwsh -NoProfile -NonInteractive -File $Installer -Profile core -Scope project -Target $TargetI 2>&1 | Out-String
+    $codeI = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+    Remove-Item -Recurse -Force $RealJiraDist -ErrorAction SilentlyContinue
+  }
+
+  if ($codeI -eq 0) { Pass "dist-present/node_modules-absent: adopt exits 0" } else { Fail "dist-present/node_modules-absent should exit 0, got rc=$codeI" }
+  if ($outI -match "Building jira CLI") { Pass "Build-JiraCli builds (does not skip) when node_modules absent" } else { Fail "missing build header -- should NOT skip (got: $outI)" }
+  if ($outI -match [regex]::Escape("jira CLI dist already built")) { Fail "must NOT take the already-built skip branch" } else { Pass "no already-built skip message" }
+
+  Write-Host ""
+  Write-Host "== scenario J: Build-JiraCli bun branch, REAL invocation (HIMMEL-842 gap 3, F5) =="
+  # npm absent, bun stubbed; assert the bun install/build lines actually ran
+  # (success path is enough per F5). No -DryRun -- the bun branch was
+  # previously only exercised via -DryRun (scenario D).
+  $StubDirJ = Join-Path $TMP "binJ"
+  $TargetJ  = Join-Path $TMP "targetJ"
+  New-Item -ItemType Directory -Force -Path $StubDirJ,$TargetJ | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $TargetJ '.claude') | Out-Null
+  Set-Content -Path (Join-Path $TargetJ '.claude\settings.json') -Value '{}'
+  foreach ($name in @("git","python3")) {
+    Set-Content -Path (Join-Path $StubDirJ "$name.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  }
+  Set-Content -Path (Join-Path $StubDirJ "jq.cmd")   -Encoding ASCII -Value "@echo off`r`necho {}`r`nexit /b 0`r`n"
+  Set-Content -Path (Join-Path $StubDirJ "pwsh.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  Set-Content -Path (Join-Path $StubDirJ "bun.cmd")  -Encoding ASCII -Value @"
+@echo off
+if "%1"=="install" echo BUN_INSTALL_STUB_RAN& exit /b 0
+if "%1%2"=="runbuild" echo BUN_BUILD_STUB_RAN& exit /b 0
+exit /b 0
+"@
+
+  $env:Path = "$StubDirJ;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $outJ = & $realPwsh -NoProfile -NonInteractive -File $Installer -Profile core -Scope project -Target $TargetJ 2>&1 | Out-String
+    $codeJ = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+  }
+
+  if ($codeJ -eq 0) { Pass "Build-JiraCli bun real-invocation: adopt exits 0" } else { Fail "Build-JiraCli bun real-invocation should exit 0, got rc=$codeJ" }
+  if ($outJ -match "BUN_INSTALL_STUB_RAN") { Pass "bun install ran" } else { Fail "bun install did not run (got: $outJ)" }
+  if ($outJ -match "BUN_BUILD_STUB_RAN") { Pass "bun run build ran" } else { Fail "bun run build did not run (got: $outJ)" }
+  if ($outJ -match "jira CLI built") { Pass "Build-JiraCli reports built" } else { Fail "missing success message (got: $outJ)" }
+
+  Write-Host ""
   if ($script:fails -eq 0) { Write-Host "ALL PASS" } else { Write-Host "$($script:fails) FAILED" -ForegroundColor Red; exit 1 }
 } finally {
+  Remove-Item -Recurse -Force $RealJiraDist -ErrorAction SilentlyContinue
+  Remove-Item -Recurse -Force $RealJiraNodeModules -ErrorAction SilentlyContinue
+  if ($DistBackup) { Move-Item -Path $DistBackup -Destination $RealJiraDist }
+  if ($NodeModulesBackup) { Move-Item -Path $NodeModulesBackup -Destination $RealJiraNodeModules }
   Remove-Item $TMP -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/scripts/test-adopt.sh
+++ b/scripts/test-adopt.sh
@@ -33,7 +33,34 @@ fail() { echo "FAIL: $1" >&2; exit 1; }
 norm() { jq -rn --arg v "$1" '$v'; }
 
 work=$(mktemp -d)
-trap 'rm -rf "$work"' EXIT
+
+# HIMMEL-842 CR round-2 (F1): scripts/jira/dist + scripts/jira/node_modules are
+# gitignored build artifacts that MAY already exist in this checkout (a primary
+# checkout that has run adopt.sh/setup.sh before). build_jira_cli's "already
+# built" skip fires the instant either is present, which would make scenarios
+# 14-19 below assert on the WRONG branch. Move any existing dist/node_modules
+# aside for the whole suite and restore unconditionally on exit — mirrors the
+# real_jira_dist/dist_backup + trap cleanup EXIT pattern in
+# scripts/test-preflight-adopter.sh.
+real_jira_dist="$repo_root/scripts/jira/dist"
+real_jira_node_modules="$repo_root/scripts/jira/node_modules"
+dist_backup=""
+node_modules_backup=""
+if [ -e "$real_jira_dist" ]; then
+  dist_backup="$work/dist-backup"
+  mv "$real_jira_dist" "$dist_backup"
+fi
+if [ -e "$real_jira_node_modules" ]; then
+  node_modules_backup="$work/node_modules-backup"
+  mv "$real_jira_node_modules" "$node_modules_backup"
+fi
+cleanup() {
+  rm -rf "$real_jira_dist" "$real_jira_node_modules"
+  if [ -n "$dist_backup" ]; then mv "$dist_backup" "$real_jira_dist"; fi
+  if [ -n "$node_modules_backup" ]; then mv "$node_modules_backup" "$real_jira_node_modules"; fi
+  rm -rf "$work"
+}
+trap cleanup EXIT
 
 # Stub claude so adopt's install-plugins step is a no-op. `plugin list` must echo
 # the enabled plugin specs so install-plugins.sh's presence-verify (HIMMEL-361)
@@ -54,10 +81,17 @@ chmod +x "$work/bin/claude"
 # mutation), a real `qmd pull` (~2.1 GB), or a real collection registration on
 # a dev box that has the toolchain installed. Tests 10/11 re-add their own
 # stubbed bun on top of this scrubbed base to exercise the qmd path.
+#
+# HIMMEL-842: ALSO scrub `npm` dirs (node + npm share a bin dir, so this drops
+# real node too). With npm AND bun both absent suite-wide, build_jira_cli takes
+# its "no npm or bun — skipping build" branch, so NO test fires a real
+# `npm install` in scripts/jira (network + repo mutation). Tests 14/15 re-add a
+# stubbed npm on top of this scrubbed base to exercise the build path; 12/13
+# re-add a stubbed node (and 13 a stubbed bun) for the npm-less-node preflight.
 qmd_free_path=""
 _save_ifs="$IFS"; IFS=':'
 for _d in $PATH; do
-  { [ -x "$_d/qmd" ] || [ -x "$_d/bun" ]; } && continue
+  { [ -x "$_d/qmd" ] || [ -x "$_d/bun" ] || [ -x "$_d/npm" ]; } && continue
   qmd_free_path="${qmd_free_path:+$qmd_free_path:}$_d"
 done
 IFS="$_save_ifs"
@@ -237,7 +271,10 @@ printf '%s' "$out" | grep -q 'DRY: qmd_install'      || fail "dry-run missing qm
 printf '%s' "$out" | grep -q 'DRY: qmd pull'         || fail "dry-run missing qmd pull DRY line"
 printf '%s' "$out" | grep -q 'DRY: qmd_register_collection .* himmel$' || fail "dry-run missing himmel register DRY line"
 printf '%s' "$out" | grep -q 'DRY: qmd_register_collection .* luna$'   || fail "dry-run missing luna register DRY line"
-echo "ok: dry-run emits all qmd step DRY lines (core G1/G3/G4 + luna G5)"
+# HIMMEL-842 gap 3: build_jira_cli runs after install_plugins; with npm scrubbed
+# suite-wide and bun stubbed present, it picks bun and emits its DRY build line.
+printf '%s' "$out" | grep -q 'DRY:.*(cd scripts/jira && bun install && bun run build)' || fail "dry-run missing build_jira_cli DRY line"
+echo "ok: dry-run emits all qmd step DRY lines (core G1/G3/G4 + luna G5) + build_jira_cli"
 
 # ── 11. HIMMEL-752 qmd WARN-not-fail: a failing qmd install never aborts adopt
 # bun present (stubbed to exit 1) + has_qmd=false (scrubbed PATH, fake HOME) ->
@@ -258,5 +295,170 @@ set -e
 printf '%s' "$out" | grep -q 'Installing qmd via bun' || fail "qmd_install not invoked (call order)"
 printf '%s' "$out" | grep -Eq 'WARNING.*qmd install failed' || fail "missing qmd install WARNING (WARN-not-fail)"
 echo "ok: qmd install failure WARNs and adopt continues (WARN-not-fail, rc=0)"
+
+# ── 12. HIMMEL-842 gap 2: node-without-npm + no JS package manager -> HARD fail ──
+# Stub node on PATH but provide NO npm; bun is already absent suite-wide, so the
+# node-without-npm check finds no JS package manager and adopt must exit non-zero
+# with the bun.sh + NodeSource install hints. npm dirs are scrubbed from the
+# suite-wide bun/qmd-scrubbed PATH (node + npm usually share a bin dir, so dropping
+# the npm dir also drops real node — the stub node re-adds node deterministically).
+nbin="$work/nbin"; mkdir -p "$nbin"
+cat > "$nbin/node" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$nbin/node"
+npm_free_path=""
+_save_ifs="$IFS"; IFS=':'
+for _d in $qmd_free_path; do
+  [ -x "$_d/npm" ] && continue
+  npm_free_path="${npm_free_path:+$npm_free_path:}$_d"
+done
+IFS="$_save_ifs"
+ntarget="$work/ntarget"; nhome="$work/nhome"; mkdir -p "$ntarget" "$nhome"
+set +e
+out=$(PATH="$nbin:$work/bin:$npm_free_path" HOME="$nhome" bash "$adopt" \
+      --profile core --scope project --target "$ntarget" 2>&1); rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "node-without-npm + no bun should exit non-zero (got $rc)"
+printf '%s' "$out" | grep -q 'npm' || fail "node-without-npm msg missing 'npm'"
+printf '%s' "$out" | grep -q 'bun.sh' || fail "node-without-npm msg missing bun.sh hint"
+printf '%s' "$out" | grep -qi 'nodesource' || fail "node-without-npm msg missing nodesource hint"
+echo "ok: node-without-npm + no JS package manager -> hard fail (rc=$rc) + install hints"
+
+# ── 13. HIMMEL-842 gap 2: node-without-npm WITH bun -> soft warn, adopt proceeds ─
+# bun covers every himmel JS build, so node-without-npm is only a SOFT warn when
+# bun is present (no hard fail). --dry-run keeps the run side-effect-free.
+nbin2="$work/nbin2"; mkdir -p "$nbin2"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$nbin2/node"; chmod +x "$nbin2/node"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$nbin2/bun";  chmod +x "$nbin2/bun"
+ntarget2="$work/ntarget2"; nhome2="$work/nhome2"; mkdir -p "$ntarget2" "$nhome2"
+set +e
+out=$(PATH="$nbin2:$work/bin:$npm_free_path" HOME="$nhome2" bash "$adopt" \
+      --profile core --scope project --target "$ntarget2" --dry-run 2>&1); rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "node-without-npm + bun should proceed (got $rc)"
+printf '%s' "$out" | grep -q 'npm' || fail "node-without-npm+bun missing soft warn"
+if printf '%s' "$out" | grep -q 'no JS package manager'; then
+  fail "node-without-npm+bun must NOT hard-fail (saw hard-fail message)"
+fi
+echo "ok: node-without-npm + bun present -> soft warn, adopt proceeds (rc=0)"
+
+# ── 14. HIMMEL-842 gap 3: build_jira_cli success path (stub npm exit 0) ───────
+# npm scrubbed suite-wide; re-add a stub npm (exit 0) so build_jira_cli picks npm,
+# the (cd scripts/jira && npm install && npm run build) subshell "succeeds", and
+# adopt reports the build + continues. dist/index.js is not actually created by
+# the stub — the assertion is on the reported outcome, not the artifact.
+bjbin="$work/bjbin"; mkdir -p "$bjbin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$bjbin/npm"; chmod +x "$bjbin/npm"
+bjhome="$work/bjhome"; mkdir -p "$bjhome"
+set +e
+out=$(PATH="$bjbin:$work/bin:$qmd_free_path" HOME="$bjhome" bash "$adopt" \
+      --profile core --scope user --target "$work/ign-bj" 2>&1); rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "build_jira_cli success path: adopt should exit 0 (got $rc)"
+printf '%s' "$out" | grep -q 'Building jira CLI' || fail "build_jira_cli: missing 'Building jira CLI' header"
+printf '%s' "$out" | grep -q 'jira CLI built'    || fail "build_jira_cli: missing success message"
+if printf '%s' "$out" | grep -q 'jira CLI build failed'; then
+  fail "build_jira_cli: success path must not print a build-failed warning"
+fi
+echo "ok: build_jira_cli success path (stub npm) reports built, adopt exits 0"
+
+# ── 15. HIMMEL-842 gap 3: build_jira_cli WARN-not-fail (stub npm exit 1) ──────
+# A failing build must WARN with the manual command and return 0 — matches
+# wire_qmd_core's contract; a broken jira build never aborts adopt.
+bfbin="$work/bfbin"; mkdir -p "$bfbin"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$bfbin/npm"; chmod +x "$bfbin/npm"
+bfhome="$work/bfhome"; mkdir -p "$bfhome"
+set +e
+out=$(PATH="$bfbin:$work/bin:$qmd_free_path" HOME="$bfhome" bash "$adopt" \
+      --profile core --scope user --target "$work/ign-bf" 2>&1); rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "build_jira_cli WARN-not-fail: adopt must exit 0 on a build failure (got $rc)"
+printf '%s' "$out" | grep -Eq 'WARNING.*jira CLI build failed' || fail "build_jira_cli: missing build-failed WARNING"
+printf '%s' "$out" | grep -q 'npm install && npm run build'     || fail "build_jira_cli: missing manual command in WARNING"
+echo "ok: build_jira_cli failure WARNs with manual command, adopt continues (rc=0)"
+
+# ── 16. HIMMEL-842 gap 3: build_jira_cli skip when no JS package manager ──────
+# npm AND bun both absent (the scrubbed suite base) -> build_jira_cli skips with
+# the manual command and never attempts a build. A real run, not --dry-run, so
+# the skip branch (not the DRY branch) is exercised.
+skhome="$work/skhome"; mkdir -p "$skhome"
+set +e
+out=$(PATH="$work/bin:$qmd_free_path" HOME="$skhome" bash "$adopt" \
+      --profile core --scope user --target "$work/ign-sk" 2>&1); rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "build_jira_cli skip path: adopt should exit 0 (got $rc)"
+printf '%s' "$out" | grep -q 'jira CLI: skipping build (no npm or bun' || fail "build_jira_cli: missing no-pm skip note"
+if printf '%s' "$out" | grep -q 'Building jira CLI'; then
+  fail "build_jira_cli: no-pm path must NOT attempt a build (saw build header)"
+fi
+echo "ok: build_jira_cli skips (no npm/bun) with manual command, no build attempted"
+
+# ── 17. HIMMEL-842 gap 3: build_jira_cli idempotent when dist AND node_modules
+# already built (F3: the skip now requires BOTH halves present) ─────────────
+# The suite-wide move-aside at the top guarantees scripts/jira/dist and
+# scripts/jira/node_modules are both absent entering this scenario; create
+# both so build_jira_cli's "already built" branch fires. Removed right after
+# (dist/ and node_modules/ are gitignored, so this never pollutes git); the
+# suite-wide trap restores the real ones unconditionally regardless.
+mkdir -p "$real_jira_dist"; : > "$real_jira_dist/index.js"
+mkdir -p "$real_jira_node_modules"
+bjhome2="$work/bjhome2"; mkdir -p "$bjhome2"
+set +e
+out=$(PATH="$bjbin:$work/bin:$qmd_free_path" HOME="$bjhome2" bash "$adopt" \
+      --profile core --scope user --target "$work/ign-bj2" 2>&1); rc=$?
+set -e
+rm -rf "$real_jira_dist" "$real_jira_node_modules"
+[ "$rc" -eq 0 ] || fail "build_jira_cli idempotent path: adopt should exit 0 (got $rc)"
+printf '%s' "$out" | grep -q 'jira CLI dist already built' || fail "build_jira_cli: missing 'already built' skip"
+if printf '%s' "$out" | grep -q 'Building jira CLI'; then
+  fail "build_jira_cli: already-built path must NOT attempt a build"
+fi
+echo "ok: build_jira_cli idempotent when dist/index.js + node_modules already present (skips build)"
+
+# ── 18. HIMMEL-842 gap 3 (F3): dist present but node_modules ABSENT -> build
+# must NOT skip ────────────────────────────────────────────────────────────
+# A stale dist/ without node_modules/ previously passed as "already built"
+# then failed at runtime — F3's fix requires BOTH halves present to skip.
+mkdir -p "$real_jira_dist"; : > "$real_jira_dist/index.js"
+# node_modules stays absent (suite-wide baseline).
+bjhome3="$work/bjhome3"; mkdir -p "$bjhome3"
+set +e
+out=$(PATH="$bjbin:$work/bin:$qmd_free_path" HOME="$bjhome3" bash "$adopt" \
+      --profile core --scope user --target "$work/ign-bj3" 2>&1); rc=$?
+set -e
+rm -rf "$real_jira_dist"
+[ "$rc" -eq 0 ] || fail "dist-present/node_modules-absent: adopt should exit 0 (got $rc)"
+printf '%s' "$out" | grep -q 'Building jira CLI' || fail "dist-present/node_modules-absent: build_jira_cli should NOT skip (missing build header)"
+if printf '%s' "$out" | grep -q 'jira CLI dist already built'; then
+  fail "dist-present/node_modules-absent: must NOT take the already-built skip branch"
+fi
+echo "ok: build_jira_cli builds when dist present but node_modules absent (F3 invariant)"
+
+# ── 19. HIMMEL-842 gap 3 (F5): build_jira_cli bun branch, REAL invocation ────
+# npm absent (suite-wide scrub), bun stubbed; assert the bun install/build
+# lines actually ran (success path is enough per F5) — the bun branch was
+# previously only exercised via --dry-run (scenario 10).
+bubin="$work/bubin"; mkdir -p "$bubin"
+cat > "$bubin/bun" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  install) echo "BUN_INSTALL_STUB_RAN" ;;
+  run) [ "$2" = "build" ] && echo "BUN_BUILD_STUB_RAN" ;;
+esac
+exit 0
+STUB
+chmod +x "$bubin/bun"
+buhome="$work/buhome"; mkdir -p "$buhome"
+set +e
+out=$(PATH="$bubin:$work/bin:$qmd_free_path" HOME="$buhome" bash "$adopt" \
+      --profile core --scope user --target "$work/ign-bu" 2>&1); rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "build_jira_cli bun real-invocation: adopt should exit 0 (got $rc)"
+printf '%s' "$out" | grep -q 'BUN_INSTALL_STUB_RAN' || fail "build_jira_cli bun real-invocation: bun install did not run"
+printf '%s' "$out" | grep -q 'BUN_BUILD_STUB_RAN'   || fail "build_jira_cli bun real-invocation: bun run build did not run"
+printf '%s' "$out" | grep -q 'jira CLI built' || fail "build_jira_cli bun real-invocation: missing success message"
+echo "ok: build_jira_cli bun branch real-invocation runs install + build (F5)"
 
 echo "PASS"

--- a/scripts/test-preflight-adopter.ps1
+++ b/scripts/test-preflight-adopter.ps1
@@ -1,0 +1,238 @@
+<#
+  test-preflight-adopter.ps1 — smoke tests for the standalone check-only
+  adopter preflight PS1 twin (HIMMEL-842 CR round-2, F4):
+  scripts/preflight-adopter.ps1 + its shared lib scripts/lib/preflight-adopter.ps1.
+
+  Mirrors scripts/test-preflight-adopter.sh's scenarios. Hermetic full-PATH-
+  replacement style like test-adopt.ps1 scenarios C-H: each scenario points
+  $env:Path at a throwaway stub dir + System32 + SystemRoot only (no real
+  uv/pipx/node/npm/bun can leak in), invokes a REAL pwsh child process, and
+  asserts on $LASTEXITCODE + captured output.
+
+  scripts/jira/dist + scripts/jira/node_modules in THIS worktree (gitignored
+  build artifacts Test-PreflightJiraDist reads via $HimmelRoot, which
+  preflight-adopter.ps1 derives from its own script path == this repo) are
+  moved aside at suite start so every scenario starts from a known "absent"
+  baseline, then restored unconditionally in the outer finally.
+
+  Covers:
+    1. standalone, fully clean env -> "0 warnings", exit 0.
+    2. standalone, pipx present (uv absent) -> clean, exit 0 (F6).
+    3. standalone, uv+pipx both absent -> WARN, exit 0 (non-strict default).
+    4. standalone, node present + npm absent -> WARN, exit 0 (non-strict).
+    5. standalone, jira dist+node_modules absent -> WARN, exit 0 (non-strict).
+    6. -Strict with a WARN present -> exit 1.
+    7. -Strict with a fully clean env -> exit 0.
+    8. structural: adopt.ps1's Require-Tools reuses the shared lib functions
+       (dot-sources scripts/lib/preflight-adopter.ps1, calls each Test-Preflight*
+       function) instead of duplicating the check/warn-text logic.
+    9. F2: Test-PreflightJiraDist WARNs + returns $false when $HimmelRoot unset.
+#>
+$ErrorActionPreference = "Stop"
+$ScriptDir = $PSScriptRoot
+$Preflight = Join-Path $ScriptDir "preflight-adopter.ps1"
+$Lib       = Join-Path $ScriptDir "lib\preflight-adopter.ps1"
+$AdoptPs1  = Join-Path $ScriptDir "adopt.ps1"
+
+$script:fails = 0
+function Pass($m) { Write-Host "  ok: $m" }
+function Fail($m) { Write-Host "  FAIL: $m" -ForegroundColor Red; $script:fails++ }
+
+if (-not (Test-Path $Preflight)) { Write-Host "FAIL: $Preflight not found" -ForegroundColor Red; exit 1 }
+if (-not (Test-Path $Lib))       { Write-Host "FAIL: $Lib not found" -ForegroundColor Red; exit 1 }
+
+$TMP = Join-Path ([System.IO.Path]::GetTempPath()) ("himmel-preflight-test-" + [System.Guid]::NewGuid().ToString("N").Substring(0,8))
+New-Item -ItemType Directory -Force -Path $TMP | Out-Null
+
+# scripts/jira/dist + scripts/jira/node_modules are gitignored build artifacts
+# in THIS worktree — move any existing ones aside so every scenario below
+# starts from a known "absent" baseline. Restored unconditionally in the
+# outer finally, alongside the scratch dir.
+$RealJiraDist        = Join-Path $ScriptDir 'jira\dist'
+$RealJiraNodeModules = Join-Path $ScriptDir 'jira\node_modules'
+$DistBackup = $null
+$NodeModulesBackup = $null
+if (Test-Path $RealJiraDist) {
+    $DistBackup = Join-Path $TMP 'dist-backup'
+    Move-Item -Path $RealJiraDist -Destination $DistBackup
+}
+if (Test-Path $RealJiraNodeModules) {
+    $NodeModulesBackup = Join-Path $TMP 'node_modules-backup'
+    Move-Item -Path $RealJiraNodeModules -Destination $NodeModulesBackup
+}
+
+$realPwsh = (Get-Command pwsh -CommandType Application).Source
+$oldPath = $env:Path
+
+try {
+  # ── 1. standalone, fully clean env -> "0 warnings", exit 0 ─────────────────
+  $StubDir1 = Join-Path $TMP "bin1"
+  New-Item -ItemType Directory -Force -Path $StubDir1 | Out-Null
+  Set-Content -Path (Join-Path $StubDir1 "uv.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  New-Item -ItemType Directory -Force -Path $RealJiraDist | Out-Null
+  New-Item -ItemType File -Force -Path (Join-Path $RealJiraDist 'index.js') | Out-Null
+  New-Item -ItemType Directory -Force -Path $RealJiraNodeModules | Out-Null
+
+  $env:Path = "$StubDir1;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $out1 = & $realPwsh -NoProfile -NonInteractive -File $Preflight 2>&1 | Out-String
+    $code1 = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+    Remove-Item -Recurse -Force $RealJiraDist -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $RealJiraNodeModules -ErrorAction SilentlyContinue
+  }
+  if ($code1 -eq 0) { Pass "clean env exits 0" } else { Fail "clean env should exit 0, got rc=$code1" }
+  if ($out1 -match "0 warnings") { Pass "clean env reports 0 warnings" } else { Fail "clean env missing '0 warnings' (got: $out1)" }
+  if ($out1 -cmatch "WARNING:") { Fail "clean env has an unexpected WARNING (got: $out1)" } else { Pass "clean env has no WARNING" }
+
+  # ── 2. pipx present (uv absent) -> clean, exit 0 (F6: uv OR pipx) ──────────
+  $StubDir2 = Join-Path $TMP "bin2"
+  New-Item -ItemType Directory -Force -Path $StubDir2 | Out-Null
+  Set-Content -Path (Join-Path $StubDir2 "pipx.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  New-Item -ItemType Directory -Force -Path $RealJiraDist | Out-Null
+  New-Item -ItemType File -Force -Path (Join-Path $RealJiraDist 'index.js') | Out-Null
+  New-Item -ItemType Directory -Force -Path $RealJiraNodeModules | Out-Null
+
+  $env:Path = "$StubDir2;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $out2 = & $realPwsh -NoProfile -NonInteractive -File $Preflight 2>&1 | Out-String
+    $code2 = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+    Remove-Item -Recurse -Force $RealJiraDist -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $RealJiraNodeModules -ErrorAction SilentlyContinue
+  }
+  if ($code2 -eq 0) { Pass "pipx-only exits 0" } else { Fail "pipx-only should exit 0, got rc=$code2" }
+  if ($out2 -match "0 warnings") { Pass "pipx-only reports 0 warnings" } else { Fail "pipx-only missing '0 warnings' (got: $out2)" }
+  if ($out2 -cmatch "WARNING:") { Fail "pipx-only has an unexpected WARNING (got: $out2)" } else { Pass "pipx-only has no WARNING" }
+
+  # ── 3. uv+pipx both absent -> WARN, exit 0 (non-strict default) ────────────
+  $StubDir3 = Join-Path $TMP "bin3"
+  New-Item -ItemType Directory -Force -Path $StubDir3 | Out-Null
+  New-Item -ItemType Directory -Force -Path $RealJiraDist | Out-Null
+  New-Item -ItemType File -Force -Path (Join-Path $RealJiraDist 'index.js') | Out-Null
+  New-Item -ItemType Directory -Force -Path $RealJiraNodeModules | Out-Null
+
+  $env:Path = "$StubDir3;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $out3 = & $realPwsh -NoProfile -NonInteractive -File $Preflight 2>&1 | Out-String
+    $code3 = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+    Remove-Item -Recurse -Force $RealJiraDist -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $RealJiraNodeModules -ErrorAction SilentlyContinue
+  }
+  if ($code3 -eq 0) { Pass "uv/pipx gap: non-strict exits 0" } else { Fail "uv/pipx gap should exit 0, got rc=$code3" }
+  if ($out3 -match [regex]::Escape("neither 'uv' nor 'pipx' found")) { Pass "uv/pipx gap WARN text present" } else { Fail "missing uv/pipx WARN text (got: $out3)" }
+  if ($out3 -match "warning\(s\)") { Pass "uv/pipx gap warning-count summary present" } else { Fail "missing warning-count summary (got: $out3)" }
+
+  # ── 4. node present + npm absent -> WARN, exit 0 (non-strict) ──────────────
+  $StubDir4 = Join-Path $TMP "bin4"
+  New-Item -ItemType Directory -Force -Path $StubDir4 | Out-Null
+  Set-Content -Path (Join-Path $StubDir4 "uv.cmd")   -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  Set-Content -Path (Join-Path $StubDir4 "node.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  New-Item -ItemType Directory -Force -Path $RealJiraDist | Out-Null
+  New-Item -ItemType File -Force -Path (Join-Path $RealJiraDist 'index.js') | Out-Null
+  New-Item -ItemType Directory -Force -Path $RealJiraNodeModules | Out-Null
+
+  $env:Path = "$StubDir4;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $out4 = & $realPwsh -NoProfile -NonInteractive -File $Preflight 2>&1 | Out-String
+    $code4 = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+    Remove-Item -Recurse -Force $RealJiraDist -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $RealJiraNodeModules -ErrorAction SilentlyContinue
+  }
+  if ($code4 -eq 0) { Pass "node-without-npm: non-strict exits 0" } else { Fail "node-without-npm should exit 0, got rc=$code4" }
+  if ($out4 -match [regex]::Escape("'node' found but 'npm' is missing")) { Pass "node-without-npm WARN text present" } else { Fail "missing node-without-npm WARN text (got: $out4)" }
+
+  # ── 5. jira dist+node_modules absent -> WARN, exit 0 (non-strict) ──────────
+  $StubDir5 = Join-Path $TMP "bin5"
+  New-Item -ItemType Directory -Force -Path $StubDir5 | Out-Null
+  Set-Content -Path (Join-Path $StubDir5 "uv.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  # $RealJiraDist / $RealJiraNodeModules stay absent (moved-aside baseline).
+
+  $env:Path = "$StubDir5;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $out5 = & $realPwsh -NoProfile -NonInteractive -File $Preflight 2>&1 | Out-String
+    $code5 = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+  }
+  if ($code5 -eq 0) { Pass "jira-dist gap: non-strict exits 0" } else { Fail "jira-dist gap should exit 0, got rc=$code5" }
+  if ($out5 -match [regex]::Escape("scripts/jira/dist/index.js not built")) { Pass "jira-dist gap WARN text present" } else { Fail "missing jira-dist WARN text (got: $out5)" }
+
+  # ── 6. -Strict with a WARN present -> exit 1 ────────────────────────────────
+  # $RealJiraDist/node_modules absent -> the jira-dist gap alone trips -Strict.
+  $StubDir6 = Join-Path $TMP "bin6"
+  New-Item -ItemType Directory -Force -Path $StubDir6 | Out-Null
+  Set-Content -Path (Join-Path $StubDir6 "uv.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+
+  $env:Path = "$StubDir6;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $out6 = & $realPwsh -NoProfile -NonInteractive -File $Preflight -Strict 2>&1 | Out-String
+    $code6 = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+  }
+  if ($code6 -eq 1) { Pass "-Strict with a WARN present exits 1" } else { Fail "-Strict with a WARN present should exit 1, got rc=$code6" }
+
+  # ── 7. -Strict with a fully clean env -> exit 0 ─────────────────────────────
+  $StubDir7 = Join-Path $TMP "bin7"
+  New-Item -ItemType Directory -Force -Path $StubDir7 | Out-Null
+  Set-Content -Path (Join-Path $StubDir7 "uv.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  New-Item -ItemType Directory -Force -Path $RealJiraDist | Out-Null
+  New-Item -ItemType File -Force -Path (Join-Path $RealJiraDist 'index.js') | Out-Null
+  New-Item -ItemType Directory -Force -Path $RealJiraNodeModules | Out-Null
+
+  $env:Path = "$StubDir7;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $out7 = & $realPwsh -NoProfile -NonInteractive -File $Preflight -Strict 2>&1 | Out-String
+    $code7 = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+    Remove-Item -Recurse -Force $RealJiraDist -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $RealJiraNodeModules -ErrorAction SilentlyContinue
+  }
+  if ($code7 -eq 0) { Pass "-Strict with a clean env exits 0" } else { Fail "-Strict with a clean env should exit 0, got rc=$code7" }
+  if ($out7 -match "0 warnings") { Pass "-Strict clean env reports 0 warnings" } else { Fail "-Strict clean env missing '0 warnings' (got: $out7)" }
+
+  # ── 8. structural: adopt.ps1's Require-Tools reuses the shared lib ─────────
+  # (no duplicated logic, per the HIMMEL-842 spec) instead of re-implementing
+  # the check/warn-text logic inline.
+  $adoptSrc = Get-Content -Raw -LiteralPath $AdoptPs1
+  if ($adoptSrc -notmatch [regex]::Escape('lib/preflight-adopter.ps1') -and $adoptSrc -notmatch [regex]::Escape('lib\preflight-adopter.ps1')) {
+    Fail "structural: adopt.ps1 does not dot-source scripts/lib/preflight-adopter.ps1"
+  } else {
+    Pass "structural: adopt.ps1 dot-sources scripts/lib/preflight-adopter.ps1"
+  }
+  foreach ($fn in @('Test-PreflightUvPipx','Test-PreflightNpmInvocable','Test-PreflightJiraDist')) {
+    if ($adoptSrc -match [regex]::Escape($fn)) { Pass "structural: adopt.ps1's Require-Tools calls $fn" } else { Fail "structural: adopt.ps1's Require-Tools does not call $fn (shared lib function)" }
+  }
+  # The shared warn text must live in the lib, not be re-typed into adopt.ps1 —
+  # a duplicate would let the two entry points drift (the spec's stated risk).
+  if ($adoptSrc -match [regex]::Escape("neither 'uv' nor 'pipx' found")) {
+    Fail "structural: adopt.ps1 duplicates the uv/pipx warn text instead of reusing the shared lib"
+  } else {
+    Pass "structural: adopt.ps1 does not duplicate the uv/pipx warn text"
+  }
+
+  # ── 9. F2: Test-PreflightJiraDist WARNs + returns $false when $HimmelRoot
+  # unset — a caller bug must surface, not silently pass. Dot-source the lib
+  # in-process (not via the standalone runner, which always sets $HimmelRoot)
+  # with $HimmelRoot left undefined.
+  $out9 = & $realPwsh -NoProfile -NonInteractive -Command "`$ErrorActionPreference='Stop'; . '$Lib'; `$r = Test-PreflightJiraDist; Write-Host `"result=`$r`"" 2>&1 | Out-String
+  if ($out9 -match "HIMMEL_ROOT not set") { Pass "F2: HIMMEL_ROOT-unset WARN text present" } else { Fail "F2: missing HIMMEL_ROOT-unset WARN text (got: $out9)" }
+  if ($out9 -match "result=False") { Pass "F2: Test-PreflightJiraDist returns `$false when `$HimmelRoot unset" } else { Fail "F2: expected result=False (got: $out9)" }
+
+  Write-Host ""
+  if ($script:fails -eq 0) { Write-Host "PASS" } else { Write-Host "$($script:fails) FAILED" -ForegroundColor Red; exit 1 }
+} finally {
+  Remove-Item -Recurse -Force $RealJiraDist -ErrorAction SilentlyContinue
+  Remove-Item -Recurse -Force $RealJiraNodeModules -ErrorAction SilentlyContinue
+  if ($DistBackup) { Move-Item -Path $DistBackup -Destination $RealJiraDist }
+  if ($NodeModulesBackup) { Move-Item -Path $NodeModulesBackup -Destination $RealJiraNodeModules }
+  Remove-Item $TMP -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/test-preflight-adopter.sh
+++ b/scripts/test-preflight-adopter.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# test-preflight-adopter.sh — smoke tests for the standalone check-only adopter
+# preflight (HIMMEL-842 fix-batch): scripts/preflight-adopter.sh + its shared
+# lib scripts/lib/preflight-adopter.sh.
+#
+# Self-contained: scrubs uv/pipx/node/npm/bun off PATH and re-adds stubs per
+# scenario so nothing here depends on (or mutates) the real dev machine's
+# toolchain. scripts/jira/dist/index.js AND scripts/jira/node_modules in THIS
+# worktree are temporarily moved aside (if present) so every scenario starts
+# from a known "absent" baseline, then restored on exit — never left mutated.
+#
+# Covers:
+#   1. standalone, fully clean env -> "0 warnings", exit 0.
+#   2. standalone, pipx present (uv absent) -> clean, exit 0 (F6).
+#   3. standalone, uv+pipx both absent -> WARN, exit 0 (non-strict default).
+#   4. standalone, node present + npm absent -> WARN, exit 0 (non-strict).
+#   5. standalone, jira dist+node_modules absent -> WARN, exit 0 (non-strict).
+#   6. --strict with a WARN present -> exit 1.
+#   7. --strict with a fully clean env -> exit 0.
+#   8. structural: adopt.sh's require_tools() reuses the shared lib functions
+#      (sources scripts/lib/preflight-adopter.sh, calls each preflight_check_*
+#      function) instead of duplicating the check/warn-text logic.
+#   9. F2: preflight_check_jira_dist WARNs + returns 1 when HIMMEL_ROOT unset.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+preflight="$repo_root/scripts/preflight-adopter.sh"
+lib="$repo_root/scripts/lib/preflight-adopter.sh"
+adopt="$repo_root/scripts/adopt.sh"
+[ -f "$preflight" ] || { echo "FAIL: $preflight not found" >&2; exit 1; }
+[ -f "$lib" ]       || { echo "FAIL: $lib not found" >&2; exit 1; }
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+work=$(mktemp -d)
+
+# scripts/jira/dist + scripts/jira/node_modules are gitignored build artifacts
+# in THIS worktree — move any existing ones aside so every scenario below
+# starts from a known "absent" baseline (preflight_check_jira_dist reads
+# $HIMMEL_ROOT, which the standalone runner derives from its own path == this
+# repo, and F3 now checks both halves). Restored unconditionally on exit,
+# alongside the scratch dir.
+real_jira_dist="$repo_root/scripts/jira/dist"
+real_jira_node_modules="$repo_root/scripts/jira/node_modules"
+dist_backup=""
+node_modules_backup=""
+if [ -e "$real_jira_dist" ]; then
+  dist_backup="$work/dist-backup"
+  mv "$real_jira_dist" "$dist_backup"
+fi
+if [ -e "$real_jira_node_modules" ]; then
+  node_modules_backup="$work/node_modules-backup"
+  mv "$real_jira_node_modules" "$node_modules_backup"
+fi
+cleanup() {
+  rm -rf "$real_jira_dist" "$real_jira_node_modules"
+  if [ -n "$dist_backup" ]; then mv "$dist_backup" "$real_jira_dist"; fi
+  if [ -n "$node_modules_backup" ]; then mv "$node_modules_backup" "$real_jira_node_modules"; fi
+  rm -rf "$work"
+}
+trap cleanup EXIT
+
+# Hermeticity: scrub every dir carrying a real uv/pipx/node/npm/bun off PATH so
+# no scenario below can observe (or be confused by) the real dev machine's
+# toolchain. Scenarios re-add their own stubs on top of this scrubbed base.
+scrub_path=""
+_save_ifs="$IFS"; IFS=':'
+for _d in $PATH; do
+  { [ -x "$_d/uv" ] || [ -x "$_d/pipx" ] || [ -x "$_d/node" ] || [ -x "$_d/npm" ] || [ -x "$_d/bun" ]; } && continue
+  scrub_path="${scrub_path:+$scrub_path:}$_d"
+done
+IFS="$_save_ifs"
+
+# ── 1. standalone, fully clean env -> "0 warnings", exit 0 ───────────────────
+c1bin="$work/c1bin"; mkdir -p "$c1bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$c1bin/uv"; chmod +x "$c1bin/uv"
+mkdir -p "$real_jira_dist"; : > "$real_jira_dist/index.js"
+mkdir -p "$real_jira_node_modules"
+out=$(PATH="$c1bin:$scrub_path" bash "$preflight" 2>&1); rc=$?
+rm -rf "$real_jira_dist" "$real_jira_node_modules"
+[ "$rc" -eq 0 ] || fail "clean env: expected exit 0, got $rc"
+printf '%s' "$out" | grep -q '0 warnings' || fail "clean env: missing '0 warnings' summary (got: $out)"
+if printf '%s' "$out" | grep -q 'WARN:'; then fail "clean env: unexpected WARN line (got: $out)"; fi
+echo "ok: standalone clean env reports 0 warnings, exit 0"
+
+# ── 2. pipx present (uv absent) -> clean, exit 0 (F6: the check is uv OR pipx) ─
+c2bin="$work/c2bin"; mkdir -p "$c2bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$c2bin/pipx"; chmod +x "$c2bin/pipx"
+mkdir -p "$real_jira_dist"; : > "$real_jira_dist/index.js"
+mkdir -p "$real_jira_node_modules"
+out=$(PATH="$c2bin:$scrub_path" bash "$preflight" 2>&1); rc=$?
+rm -rf "$real_jira_dist" "$real_jira_node_modules"
+[ "$rc" -eq 0 ] || fail "pipx-only: expected exit 0, got $rc"
+printf '%s' "$out" | grep -q '0 warnings' || fail "pipx-only: missing '0 warnings' summary (got: $out)"
+if printf '%s' "$out" | grep -q 'WARN:'; then fail "pipx-only: unexpected WARN line (got: $out)"; fi
+echo "ok: pipx present (uv absent) reports 0 warnings, exit 0"
+
+# ── 3. uv+pipx both absent -> WARN, exit 0 (non-strict default) ──────────────
+mkdir -p "$real_jira_dist"; : > "$real_jira_dist/index.js"
+mkdir -p "$real_jira_node_modules"
+out=$(PATH="$scrub_path" bash "$preflight" 2>&1); rc=$?
+rm -rf "$real_jira_dist" "$real_jira_node_modules"
+[ "$rc" -eq 0 ] || fail "uv/pipx gap: non-strict should exit 0, got $rc"
+printf '%s' "$out" | grep -q "neither 'uv' nor 'pipx' found" || fail "uv/pipx gap: missing WARN text (got: $out)"
+printf '%s' "$out" | grep -q 'warning(s)' || fail "uv/pipx gap: missing warning-count summary (got: $out)"
+echo "ok: uv+pipx absent WARNs and exits 0 (non-strict)"
+
+# ── 4. node present + npm absent -> WARN, exit 0 (non-strict) ────────────────
+c4bin="$work/c4bin"; mkdir -p "$c4bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$c4bin/uv";   chmod +x "$c4bin/uv"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$c4bin/node"; chmod +x "$c4bin/node"
+mkdir -p "$real_jira_dist"; : > "$real_jira_dist/index.js"
+mkdir -p "$real_jira_node_modules"
+out=$(PATH="$c4bin:$scrub_path" bash "$preflight" 2>&1); rc=$?
+rm -rf "$real_jira_dist" "$real_jira_node_modules"
+[ "$rc" -eq 0 ] || fail "node-without-npm: non-strict should exit 0, got $rc"
+printf '%s' "$out" | grep -q "'node' found but 'npm' is missing" || fail "node-without-npm: missing WARN text (got: $out)"
+echo "ok: node-without-npm WARNs and exits 0 (non-strict)"
+
+# ── 5. jira dist+node_modules absent -> WARN, exit 0 (non-strict) ────────────
+c5bin="$work/c5bin"; mkdir -p "$c5bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$c5bin/uv"; chmod +x "$c5bin/uv"
+# real_jira_dist / real_jira_node_modules stay absent (moved-aside baseline).
+out=$(PATH="$c5bin:$scrub_path" bash "$preflight" 2>&1); rc=$?
+[ "$rc" -eq 0 ] || fail "jira-dist gap: non-strict should exit 0, got $rc"
+printf '%s' "$out" | grep -q 'scripts/jira/dist/index.js not built' || fail "jira-dist gap: missing WARN text (got: $out)"
+echo "ok: jira dist+node_modules absent WARNs and exits 0 (non-strict)"
+
+# ── 6. --strict with a WARN present -> exit 1 ─────────────────────────────────
+# real_jira_dist/node_modules absent -> the jira-dist gap alone trips --strict.
+c6bin="$work/c6bin"; mkdir -p "$c6bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$c6bin/uv"; chmod +x "$c6bin/uv"
+set +e
+out=$(PATH="$c6bin:$scrub_path" bash "$preflight" --strict 2>&1); rc=$?
+set -e
+[ "$rc" -eq 1 ] || fail "--strict with a WARN present should exit 1, got $rc"
+printf '%s' "$out" | grep -q 'Re-run with --strict' || true  # informational only when warns==0; not asserted here
+echo "ok: --strict exits 1 when any WARN is present"
+
+# ── 7. --strict with a fully clean env -> exit 0 ──────────────────────────────
+c7bin="$work/c7bin"; mkdir -p "$c7bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$c7bin/uv"; chmod +x "$c7bin/uv"
+mkdir -p "$real_jira_dist"; : > "$real_jira_dist/index.js"
+mkdir -p "$real_jira_node_modules"
+out=$(PATH="$c7bin:$scrub_path" bash "$preflight" --strict 2>&1); rc=$?
+rm -rf "$real_jira_dist" "$real_jira_node_modules"
+[ "$rc" -eq 0 ] || fail "--strict with a clean env should exit 0, got $rc"
+printf '%s' "$out" | grep -q '0 warnings' || fail "--strict clean env: missing '0 warnings' summary (got: $out)"
+echo "ok: --strict exits 0 on a fully clean env"
+
+# ── 8. structural: adopt.sh's require_tools() reuses the shared lib ──────────
+# (no duplicated logic, per the HIMMEL-842 spec) instead of re-implementing
+# the check/warn-text logic inline.
+grep -q 'lib/preflight-adopter\.sh' "$adopt" \
+  || fail "structural: adopt.sh does not source scripts/lib/preflight-adopter.sh"
+for fn in preflight_check_uv_pipx preflight_check_npm_invocable preflight_check_jira_dist; do
+  grep -q "$fn" "$adopt" \
+    || fail "structural: adopt.sh's require_tools() does not call $fn (shared lib function)"
+done
+# The shared warn text must live in the lib, not be re-typed into adopt.sh —
+# a duplicate would let the two entry points drift (the spec's stated risk).
+if grep -q "neither 'uv' nor 'pipx' found" "$adopt"; then
+  fail "structural: adopt.sh duplicates the uv/pipx warn text instead of reusing the shared lib"
+fi
+echo "ok: adopt.sh's require_tools() calls the shared preflight-adopter.sh lib functions (no duplicated logic)"
+
+# ── 9. F2: preflight_check_jira_dist WARNs + returns 1 when HIMMEL_ROOT unset ─
+# A caller bug (forgetting to set $HIMMEL_ROOT before calling the check) must
+# surface, not silently pass. Source the lib directly (not via the standalone
+# runner, which always sets HIMMEL_ROOT) in a subshell with it unset.
+out=$(bash -c 'unset HIMMEL_ROOT; source "'"$lib"'"; preflight_check_jira_dist; echo "rc=$?"' 2>&1)
+printf '%s' "$out" | grep -q 'HIMMEL_ROOT not set' || fail "F2: missing HIMMEL_ROOT-unset WARN text (got: $out)"
+printf '%s' "$out" | grep -q 'rc=1' || fail "F2: preflight_check_jira_dist should return 1 when HIMMEL_ROOT unset (got: $out)"
+echo "ok: preflight_check_jira_dist WARNs + returns 1 when HIMMEL_ROOT is unset (F2)"
+
+echo "PASS"

--- a/templates/luna-second-brain/scripts/setup.sh
+++ b/templates/luna-second-brain/scripts/setup.sh
@@ -86,6 +86,20 @@ if [ "${#_missing[@]}" -gt 0 ]; then
   exit 1
 fi
 echo "  All foundational tools present."
+
+# HIMMEL-842 gap 1: pre-commit (installed at [3/6]) needs uv OR pipx on a PEP 668
+# distro (Ubuntu 24.04+ / most 2025+ distros block raw system pip). Fail UPFRONT
+# here with the install command instead of hard-stopping mid-run at [3/6]. A
+# pre-commit already on PATH needs neither, so this mirrors [3/6]'s exact failure
+# condition (pre-commit absent AND uv absent AND pipx absent).
+if ! command -v pre-commit >/dev/null 2>&1 \
+  && ! command -v uv >/dev/null 2>&1 \
+  && ! command -v pipx >/dev/null 2>&1; then
+  echo "ERROR: need uv or pipx to install pre-commit (PEP 668 blocks raw pip on most 2025+ distros)." >&2
+  echo "  Install uv: curl -LsSf https://astral.sh/uv/install.sh | sh" >&2
+  exit 1
+fi
+echo "  uv/pipx available for pre-commit install."
 echo ""
 
 # --- [2/6] USER_SLUG resolution ---


### PR DESCRIPTION
## Summary

Closes the four HIMMEL-842 adopter-preflight gaps (fresh-install toolchain + untracked-build-artifact failures the operator walked through live on the VM):

1. **uv/pipx hard stop** — upfront check in the shared preflight lib + the luna template's setup.sh gains the same upfront gate (mirrors its own step [3/6] failure condition).
2. **npm-less node** — explicit `npm`-invocable check (distinct from `node`), soft-warn when `bun` covers it, hard-fail only when NO JS package manager exists.
3. **jira `dist/` absent on fresh adopt** — new `build_jira_cli()`/`Build-JiraCli` in `adopt.sh`/`adopt.ps1` `do_core()` (ports setup.sh step [3/10]), WARN-not-fail, gated on npm-or-bun; skip requires **both** `node_modules/` AND `dist/index.js` (setup.sh's invariant — a stale dist alone no longer reads as built).
4. **qmd stub/pull expectations** — documented in `docs/setup/new-machine.md` (the HIMMEL-163 stub trap + ~2.1 GB pull + CPU-embed time; empirically re-confirmed by the win2 H1 session's qmd rider).

Per the operator's answered Q4: preflight ships as **both** a standalone check-only entry point (`scripts/preflight-adopter.sh`/`.ps1`, WARN lines, exit 0 unless `--strict`) **and** auto-invoked from `adopt.sh`'s `require_tools()` — one shared functions-only lib (`scripts/lib/preflight-adopter.sh`/`.ps1`), no duplicated check logic (structurally tested).

## CR trail (3 rounds)

- Reconcile review vs the answered spec (Sonnet): 2 Importants → fix-batch 1 (`7b84876a`): standalone entry point + build_jira_cli.
- Round 2 (panel clean + codex adversarial + 3 reviewers): 4 Importants + 2 medium → fix-batch 2 (`780a16c3`): node_modules+dist skip invariant (both twins + preflight check), hermetic dist/node_modules move-aside in the build-path tests, HIMMEL_ROOT-unset WARN (no silent success), full PS standalone-runner test suite (F4), real bun-branch invocation tests (F5), dead `preflight_adopter_run_all` dropped, `-h`/pipx-only parity.
- Round 3: panel clean (0/0/0).

## Tests

`test-adopt.sh` 19 scenarios / `test-adopt.ps1` A-J / `test-preflight-adopter.sh` 9 scenarios / `test-preflight-adopter.ps1` 22 assertions — all green; shellcheck clean. (Known pre-existing quirk: `test-adopt.ps1` under a PS5.1 *outer* host has an unrelated NativeCommandError — reproduces on the unmodified file; the gate command `pwsh` is green.)

## Provenance

GLM worker (cbe1d34c) + GLM fix-batch (timed out at 80%) completed by Sonnet (7b84876a), round-2 batch by Sonnet (780a16c3); parent-reviewed (Fable s29). Spec: vm-adopter-preflight-839-842-816 (839/816 halves explicitly out of scope — 816 sequenced next, touches the same new-machine.md).
