### PR TITLE
feat(guardrails): [HIMMEL-869] fleet-wide upstream drift guard — registry-driven coverage for all carried upstreams

### DIFF
--- a/scripts/check-plugin-drift.sh
+++ b/scripts/check-plugin-drift.sh
@@ -22,6 +22,42 @@
 #      generic fields `upstream_repo` / `upstream_path` / `upstream_sha256`. Drift
 #      = the recorded sha256 != the sha256 of that upstream file fetched now.
 #      (telegram-himmel, pr-review-toolkit-himmel.)
+#   3. Carried upstreams (HIMMEL-869) — the rest of the fleet that the two
+#      classes above don't reach. A data-driven registry
+#      (scripts/upstreams.json, DRIFT_REGISTRY-overridable) enumerates each with a
+#      detection `kind`:
+#        a. commit_head — compare a local commit to the tracked repo's default
+#           HEAD. mode `pin` takes the commit from `pinned_commit` (full or short
+#           SHA; short is resolved via gh) — for vendored copies that are NOT a
+#           git checkout of upstream (claude-hud, claude-statusline). mode
+#           `checkout` takes it from a local git checkout at `checkout_path`
+#           (env-expanded cross-platform) — for editable/installed checkouts
+#           (hermes-agent). Drift = the tracked repo advanced past our commit.
+#        b. tag_release — compare a local version to the tracked repo's latest
+#           STABLE version tag (highest semver via sort -V, prereleases excluded —
+#           same discipline as the claude-obsidian fork override). mode `base`
+#           takes the version from `synced_base`; mode `probe` runs
+#           `version_command` and extracts the version via `version_regex` — for
+#           installed binaries/CLIs (rtk, twitter-cli).
+#      Installed marketplaces (caveman, obsidian-skills, openai-codex,
+#      claude-video, claude-plugins-official, …) are NOT listed in the registry:
+#      they are discovered dynamically from ~/.claude/plugins/known_marketplaces.json
+#      (DRIFT_KNOWN_MARKETPLACES-overridable) so the guard auto-covers any future
+#      marketplace install, each checked as commit_head/checkout vs its source repo.
+#      `tier` (A=proactive / B=reactive, from the HIMMEL-850 audit) is printed in
+#      the verdict so a reader can tell expected churn (Tier B usually reads BEHIND
+#      by design) from a genuinely stale pin. An absent checkout / uninstalled
+#      tool / unreachable upstream is UNCHECKED, never drift.
+#
+# Additive-only-delta audit (true forks: claude-obsidian, telegram-himmel,
+# pr-review-toolkit-himmel, qmd) is a MANUAL step — verifying that each fork's
+# diff vs its synced base is the expected whitelisted delta and nothing else is a
+# per-fork judgment this script does not automate (the deltas differ per fork and
+# are reviewed in their own tickets). One-liner per fork, runnable when gh is up:
+#   claude-obsidian:    gh api 'repos/AgriciDaniel/claude-obsidian/compare/v1.9.2...yotamleo:claude-obsidian:v1.9.2-himmel.1'
+#   telegram-himmel:    diff the fork's server.ts vs the UPSTREAM_PIN sha256 base
+#   pr-review-tk-himmel: diff the fork's agents/code-reviewer.md vs the UPSTREAM_PIN base
+#   qmd:                gh api 'repos/tobi/qmd/compare/<base>...yotamleo:qmd:<fork-head>'  (base = last synced tag)
 #
 # Exit codes (a cadence keys its alert on these):
 #   0  every plugin verified CURRENT, OR gh is absent/unauthenticated (fail-open
@@ -208,6 +244,288 @@ for pin in "$ROOT"/marketplace/plugins/*/UPSTREAM_PIN; do
     drift=1
   fi
 done
+
+echo ""
+echo "== carried upstreams (registry + installed marketplaces; HIMMEL-869) =="
+# scripts/upstreams.json enumerates the fleet the two classes above don't reach
+# (claude-hud, claude-statusline, hermes-agent, rtk, twitter-cli); installed
+# marketplaces are discovered from known_marketplaces.json. Both paths are
+# env-overridable so the test harness can point at fixtures / a stubbed gh.
+REGISTRY="${DRIFT_REGISTRY:-$ROOT/scripts/upstreams.json}"
+KNOWN_MKTS="${DRIFT_KNOWN_MARKETPLACES:-$HOME/.claude/plugins/known_marketplaces.json}"
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "  ? python3 not available — cannot parse the upstream registry / known marketplaces; carried-upstreams class UNCHECKED."
+  incomplete=1
+else
+  # Emit one line per carried upstream: name<US>kind<US>repo<US>mode<US>v1<US>v2<US>tier,
+  # <US> = ASCII unit separator (\x1f), NOT `|` — a probe entry's version_regex
+  # can itself contain `|` (regex alternation), which would silently misalign a
+  # pipe-delimited protocol. v1/v2 are kind/mode-specific (see header). A
+  # malformed JSON file raises -> the pipeline exits non-zero -> class UNCHECKED;
+  # a missing/empty file emits nothing (clean).
+  reg_out="$(python3 - "$REGISTRY" "$KNOWN_MKTS" <<'PY' 2>/dev/null | tr -d '\r'
+import json, os, re, sys
+reg_path, mkt_path = sys.argv[1], sys.argv[2]
+
+def expand(p):
+    # Cross-platform env expansion ($VAR / ${VAR} / %VAR%) so the same registry
+    # entry resolves on Git Bash python AND Windows python, then forward-slash
+    # the result so `git -C <path>` is portable.
+    if not p:
+        return p
+    def rep(m):
+        return os.environ.get(m.group(1) or m.group(2), '')
+    p = re.sub(r'\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)', rep, p)
+    p = re.sub(r'%([A-Za-z_][A-Za-z0-9_]*)%', lambda m: os.environ.get(m.group(1), ''), p)
+    return os.path.expanduser(p).replace('\\', '/')
+
+def line(name, kind, repo, mode, v1, v2, tier):
+    # \x1f (ASCII unit separator), not '|': version_regex (v2, probe mode) can
+    # legitimately contain '|' for regex alternation, which would misalign a
+    # pipe-delimited record.
+    print('\x1f'.join([name, kind, repo, mode, v1 or '', v2 or '', tier or '']))
+
+if os.path.exists(reg_path) and os.path.getsize(reg_path) > 0:
+    d = json.load(open(reg_path))   # malformed -> raises -> class UNCHECKED
+    for e in d.get('entries', []):
+        kind = e.get('kind', '')
+        mode = e.get('mode', '')
+        repo = e.get('tracked_repo', '')
+        tier = e.get('tier', '')
+        if kind == 'commit_head' and mode == 'pin':
+            line(e['name'], 'commit_head', repo, 'pin', e.get('pinned_commit', ''), '', tier)
+        elif kind == 'commit_head' and mode == 'checkout':
+            line(e['name'], 'commit_head', repo, 'checkout', expand(e.get('checkout_path', '')), '', tier)
+        elif kind == 'tag_release' and mode == 'base':
+            line(e['name'], 'tag_release', repo, 'base', e.get('synced_base', ''), '', tier)
+        elif kind == 'tag_release' and mode == 'probe':
+            line(e['name'], 'tag_release', repo, 'probe', e.get('version_command', ''), e.get('version_regex', ''), tier)
+        else:
+            # Unrecognized kind/mode: pass it through verbatim so the bash
+            # dispatch reports the REAL kind/mode (e.g. a known kind with a bad
+            # mode reads as "commit_head mode '<mode>' unknown", not a generic
+            # "unknown kind"). Empty kind -> 'unknown' for a stable message.
+            line(e.get('name', '?'), kind or 'unknown', repo, mode, '', '', tier)
+
+if os.path.exists(mkt_path) and os.path.getsize(mkt_path) > 0:
+    km = json.load(open(mkt_path))   # malformed -> raises -> class UNCHECKED
+    for mname, info in km.items():
+        src = info.get('source', {}) or {}
+        if src.get('source') == 'github' and src.get('repo'):
+            tier = 'mkt-auto' if info.get('autoUpdate') else 'mkt-manual'
+            loc = info.get('installLocation', '')
+            if not loc:
+                # Older/foreign known_marketplaces.json shape without
+                # installLocation: an empty path would otherwise flow into the
+                # checkout-missing branch below and print as "checkout not
+                # present on this machine ()" — reads like a real absent
+                # checkout instead of a shape gap. Flag it explicitly instead.
+                line('mkt:' + mname, 'commit_head', src['repo'], 'no-install-location', '', '', tier)
+            else:
+                line('mkt:' + mname, 'commit_head', src['repo'], 'checkout',
+                     expand(loc), '', tier)
+PY
+)"
+  reg_rc=$?
+  if [ "$reg_rc" -ne 0 ]; then
+    echo "  ? upstreams.json / known_marketplaces.json parse failed (python3 error) — carried-upstreams class UNCHECKED."
+    incomplete=1
+  else
+    while IFS=$'\x1f' read -r name kind repo mode v1 v2 tier; do
+      [ -n "$name" ] || continue
+      tier_note=""
+      if [ -n "$tier" ]; then tier_note="  [$tier]"; fi
+      case "$kind" in
+        commit_head)
+          # Resolve the LOCAL commit: a pinned SHA, or the HEAD of a checkout.
+          if [ "$mode" = "pin" ]; then
+            local_ref="$v1"
+            if [ -z "$local_ref" ]; then
+              echo "  $name: ? entry missing pinned_commit — UNCHECKED (fix scripts/upstreams.json)"
+              incomplete=1; continue
+            fi
+          elif [ "$mode" = "checkout" ]; then
+            path="$v1"
+            if [ -z "$path" ] || [ ! -d "$path" ]; then
+              echo "  $name: ? checkout not present on this machine ($path) — UNCHECKED"
+              incomplete=1; continue
+            fi
+            if ! git -C "$path" rev-parse --git-dir >/dev/null 2>&1; then
+              echo "  $name: ? checkout is not a git repo ($path) — UNCHECKED"
+              incomplete=1; continue
+            fi
+            local_ref="$(git -C "$path" rev-parse HEAD 2>/dev/null)"
+            if [ -z "$local_ref" ]; then
+              echo "  $name: ? could not read HEAD of checkout ($path) — UNCHECKED"
+              incomplete=1; continue
+            fi
+          elif [ "$mode" = "no-install-location" ]; then
+            # Older/foreign known_marketplaces.json entry shape: github-sourced
+            # but no installLocation field to check out. Skip with a named,
+            # explicit UNCHECKED note — never let an empty path fall through to
+            # the checkout branch above (that would print "()" and read like a
+            # real absent checkout instead of a metadata-shape gap).
+            echo "  $name: ? marketplace entry lacks installLocation (older/foreign metadata shape) — UNCHECKED${tier_note}"
+            incomplete=1; continue
+          else
+            echo "  $name: ? commit_head mode '$mode' unknown — UNCHECKED (fix scripts/upstreams.json)"
+            incomplete=1; continue
+          fi
+          # Normalize the local ref to a full 40-hex SHA (short SHA -> gh resolves).
+          if printf '%s' "$local_ref" | grep -qE '^[0-9a-f]{40}$'; then
+            local_sha="$local_ref"
+          else
+            local_sha="$(gh api "repos/$repo/commits/$local_ref" --jq '.sha' 2>/dev/null)"; api_rc=$?
+            if [ "$api_rc" -ne 0 ] || ! printf '%s' "$local_sha" | grep -qE '^[0-9a-f]{40}$'; then
+              echo "  $name: ? cannot resolve local ref '$local_ref' on $repo — UNCHECKED"
+              incomplete=1; continue
+            fi
+          fi
+          head="$(gh api "repos/$repo/commits/HEAD" --jq '.sha' 2>/dev/null)"; api_rc=$?
+          if [ "$api_rc" -ne 0 ] || ! printf '%s' "$head" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "  $name: ? upstream unreachable ($repo) — UNCHECKED"
+            incomplete=1; continue
+          fi
+          if [ "$local_sha" = "$head" ]; then
+            echo "  $name: CURRENT  ($repo @ ${local_sha:0:7})${tier_note}"
+          else
+            delta="$(gh api "repos/$repo/compare/$local_sha...$head" --jq '.ahead_by' 2>/dev/null)"
+            echo "  $name: BEHIND   ($repo upstream is ${delta:-?} commit(s) ahead — ${local_sha:0:7} -> ${head:0:7})${tier_note}"
+            drift=1
+          fi
+          ;;
+        tag_release)
+          # Resolve the LOCAL version: a recorded synced_base, or a probed one.
+          if [ "$mode" = "base" ]; then
+            local_ver="$v1"
+            if [ -z "$local_ver" ]; then
+              echo "  $name: ? entry missing synced_base — UNCHECKED (fix scripts/upstreams.json)"
+              incomplete=1; continue
+            fi
+          elif [ "$mode" = "probe" ]; then
+            cmd_str="$v1"; rx="$v2"
+            if [ -z "$cmd_str" ] || [ -z "$rx" ]; then
+              echo "  $name: ? probe entry missing version_command/version_regex — UNCHECKED (fix scripts/upstreams.json)"
+              incomplete=1; continue
+            fi
+            # version_command is simple space-separated tokens; split into an array.
+            read -r -a cmd_arr <<< "$cmd_str"
+            if ! command -v "${cmd_arr[0]}" >/dev/null 2>&1; then
+              echo "  $name: ? tool '${cmd_arr[0]}' not installed — UNCHECKED${tier_note}"
+              incomplete=1; continue
+            fi
+            # A --version that exits non-zero after printing the version (e.g.
+            # twitter-cli) is fine: we extract the version from combined output.
+            if command -v timeout >/dev/null 2>&1; then
+              probe_out="$(timeout 10 "${cmd_arr[@]}" 2>&1)"; probe_rc=$?
+              # rc=124 is `timeout`'s own kill signal; 137 (128+9) shows up if
+              # the probe was SIGKILLed some other way. Either means the probe
+              # never finished — route to UNCHECKED, never parse the partial
+              # output (a probe that prints a version line and THEN hangs
+              # would otherwise parse as CURRENT/BEHIND on truncated output).
+              if [ "$probe_rc" -eq 124 ] || [ "$probe_rc" -eq 137 ]; then
+                echo "  $name: ? probe timed out (10s) — UNCHECKED${tier_note}"
+                incomplete=1; continue
+              fi
+            else
+              # No `timeout` on PATH (uncommon but not guaranteed — a stripped
+              # PATH, an odd distro): fall back to a portable bash-native
+              # watchdog so a hanging probe can never wedge the whole run.
+              # Plain background job + sleep-then-kill — no `wait -n` (absent
+              # on bash 3.2 / older Git-Bash), so this stays portable.
+              echo "  $name: note — 'timeout' unavailable, using bash-native watchdog fallback (10s budget)${tier_note}"
+              probe_tmp="$(mktemp)"
+              # Best-effort GROUP cleanup: with `setsid` the probe becomes its
+              # own process-group leader, so `kill -9 -- -$probe_pid` (negative
+              # pid = the whole group) also reaps any children it spawned.
+              # Without setsid (not every box has coreutils/util-linux) we fall
+              # back to killing the direct pid plus any direct children found
+              # via `ps -ef` ppid matching — NOT full-group semantics
+              # (grandchildren can survive), but probes here are short-lived
+              # `--version`-style calls, so the residual leak is small. Real
+              # process-group semantics need the `timeout` path above (coreutils).
+              if command -v setsid >/dev/null 2>&1; then
+                setsid "${cmd_arr[@]}" >"$probe_tmp" 2>&1 &
+                probe_pid=$!
+                probe_grouped=1
+              else
+                "${cmd_arr[@]}" >"$probe_tmp" 2>&1 &
+                probe_pid=$!
+                probe_grouped=0
+              fi
+              (
+                sleep 10
+                if [ "$probe_grouped" -eq 1 ]; then
+                  kill -9 -- -"$probe_pid" 2>/dev/null
+                else
+                  kill -9 "$probe_pid" 2>/dev/null
+                  if command -v ps >/dev/null 2>&1; then
+                    ps -ef 2>/dev/null | awk -v ppid="$probe_pid" '$3==ppid{print $2}' \
+                      | while IFS= read -r cpid; do kill -9 "$cpid" 2>/dev/null; done
+                  fi
+                fi
+              ) &
+              watchdog_pid=$!
+              wait "$probe_pid" 2>/dev/null
+              probe_status=$?
+              # Probe finished (or was killed) — the watchdog's sleep is no
+              # longer needed either way; reap it so it doesn't linger. Cleanup
+              # above is best-effort only — it must never change probe_status
+              # or the UNCHECKED verdict path below.
+              kill "$watchdog_pid" 2>/dev/null
+              wait "$watchdog_pid" 2>/dev/null
+              if [ "$probe_status" -ge 128 ]; then
+                rm -f "$probe_tmp"
+                echo "  $name: ? probe timed out (10s watchdog) — UNCHECKED${tier_note}"
+                incomplete=1; continue
+              fi
+              probe_out="$(cat "$probe_tmp" 2>/dev/null)"
+              rm -f "$probe_tmp"
+            fi
+            local_ver="$(printf '%s' "$probe_out" | grep -oE "$rx" | head -1)"
+            if [ -z "$local_ver" ]; then
+              echo "  $name: ? could not parse version from '${cmd_arr[0]}' output — UNCHECKED${tier_note}"
+              incomplete=1; continue
+            fi
+          else
+            echo "  $name: ? tag_release mode '$mode' unknown — UNCHECKED (fix scripts/upstreams.json)"
+            incomplete=1; continue
+          fi
+          tags_raw="$(gh api "repos/$repo/tags?per_page=100" --jq '.[].name' 2>/dev/null)"; api_rc=$?
+          if [ "$api_rc" -ne 0 ] || [ -z "$tags_raw" ]; then
+            echo "  $name: ? true upstream unreachable ($repo tags) — UNCHECKED"
+            incomplete=1; continue
+          fi
+          latest="$(printf '%s\n' "$tags_raw" | grep -E '^v?[0-9]+\.[0-9]+(\.[0-9]+)?$' | sort -V | tail -1)"
+          if [ -z "$latest" ]; then
+            echo "  $name: ? no stable version tags found on $repo — UNCHECKED"
+            incomplete=1; continue
+          fi
+          # Normalize leading 'v' on both sides before comparing.
+          norm_local="${local_ver#v}"
+          norm_latest="${latest#v}"
+          if [ "$norm_local" = "$norm_latest" ]; then
+            echo "  $name: CURRENT  (installed $norm_local = $repo latest tag)${tier_note}"
+          else
+            hi="$(printf '%s\n%s\n' "$norm_local" "$norm_latest" | sort -V | tail -1)"
+            if [ "$hi" = "$norm_local" ]; then
+              # Installed is newer than the latest STABLE tag (e.g. a prerelease or
+              # locally-built version): not behind upstream's stable line.
+              echo "  $name: CURRENT  (installed $norm_local >= $repo latest stable $norm_latest)${tier_note}"
+            else
+              echo "  $name: BEHIND   ($repo latest tag $latest; installed $local_ver — upgrade)${tier_note}"
+              drift=1
+            fi
+          fi
+          ;;
+        *)
+          echo "  $name: ? unknown kind '$kind' (mode '$mode') — UNCHECKED (fix scripts/upstreams.json)"
+          incomplete=1
+          ;;
+      esac
+    done <<< "$reg_out"
+  fi
+fi
 
 echo ""
 if [ "$drift" -ne 0 ]; then

--- a/scripts/test-check-plugin-drift.sh
+++ b/scripts/test-check-plugin-drift.sh
@@ -142,7 +142,10 @@ JSON
  "fix-bad-track":{"upstream_repo":"AgriciDaniel/claude-obsidian","track":"bogus"}
 }
 JSON
-  fx_out="$(DRIFT_MJSON="$fix_m" DRIFT_UPSTREAMS="$fix_u" bash "$SCRIPT" 2>&1)"; fx_rc=$?
+  # Stub the carried-upstreams registry + marketplaces (HIMMEL-869) to /dev/null so
+  # this override-branch fixture run stays hermetic + deterministic (no real
+  # carried-upstream checks firing alongside the fixture under test).
+  fx_out="$(DRIFT_MJSON="$fix_m" DRIFT_UPSTREAMS="$fix_u" DRIFT_REGISTRY=/dev/null DRIFT_KNOWN_MARKETPLACES=/dev/null bash "$SCRIPT" 2>&1)"; fx_rc=$?
   rm -f "$fix_m" "$fix_u"
   if printf '%s' "$fx_out" | grep "fix-missing-base" | grep -q "missing synced_base"; then ok "missing synced_base -> UNCHECKED (not a phantom BEHIND)"; else bad "missing synced_base not UNCHECKED; out: $(printf '%s' "$fx_out" | grep fix-missing-base)"; fi
   if printf '%s' "$fx_out" | grep "fix-bad-track" | grep -q "unknown track"; then ok "unknown track -> UNCHECKED"; else bad "bad track not UNCHECKED; out: $(printf '%s' "$fx_out" | grep fix-bad-track)"; fi
@@ -156,6 +159,275 @@ fi
 # fixture above covers the UNCHECKED override paths deterministically. The CRLF-strip
 # is exercised implicitly on this Windows checkout (python3 emits CRLF; check #2 +
 # the real run both depend on it).
+
+# 7. Carried-upstreams registry (HIMMEL-869): fully hermetic — a stubbed `gh` on
+#    PATH serves canned SHAs/tags from a state dir, a fixture upstreams.json +
+#    fixture known_marketplaces.json cover every kind/mode + the UNCHECKED shapes,
+#    and a throwaway git checkout backs the commit_head/checkout + marketplace
+#    paths. NO network. Exercises: commit_head pin (full SHA CURRENT / short-SHA
+#    resolve BEHIND / checkout CURRENT / checkout-missing UNCHECKED / unknown-mode
+#    UNCHECKED), tag_release base (CURRENT / BEHIND) + probe (CURRENT / BEHIND /
+#    installed-ahead CURRENT), marketplace discovery from known_marketplaces.json
+#    (github-sourced checked, directory-sourced skipped), unknown-kind UNCHECKED,
+#    malformed-registry UNCHECKED, empty-registry clean.
+W7="$(mktemp -d)"; mkdir -p "$W7/bin"
+# Stub gh: dispatches on the api path, serves per-repo heads/tags/resolves from
+# $GHSTATE so one stub covers every repo in the fixture.
+cat > "$W7/bin/gh" <<'GH'
+#!/usr/bin/env bash
+a="$*"
+[ "$1" = auth ] && [ "$2" = status ] && exit 0
+repo=$(printf '%s\n' "$a" | sed -n 's|.*repos/\([^/ ]*/[^/ ]*\)/.*|\1|p')
+case "$a" in
+  *"/compare/"*) printf '%s\n' "${FAKE_AHEAD:-5}"; exit 0 ;;
+  *"/tags"*)
+    grep -E "^${repo}=" "$GHSTATE/tags" 2>/dev/null | head -1 | cut -d= -f2- | tr ',' '\n'
+    exit 0 ;;
+  *"commits/HEAD"*)
+    grep -E "^${repo}=" "$GHSTATE/heads" 2>/dev/null | head -1 | cut -d= -f2
+    exit 0 ;;
+  *commits/*)
+    ref=$(printf '%s\n' "$a" | sed -n 's|.*/commits/\([^ ]*\).*|\1|p')
+    hit=$(grep -E "^${repo}:${ref}=" "$GHSTATE/resolves" 2>/dev/null | head -1 | cut -d= -f2)
+    if [ -n "$hit" ]; then printf '%s\n' "$hit"; else
+      grep -E "^${repo}=" "$GHSTATE/heads" 2>/dev/null | head -1 | cut -d= -f2
+    fi
+    exit 0 ;;
+esac
+exit 0
+GH
+chmod +x "$W7/bin/gh"
+mk_repo() {  # mk_repo <name> -> echoes the new git checkout dir (1 commit)
+  d="$W7/ck_$1"; mkdir -p "$d"; git -C "$d" init -q
+  printf 'x\n' >"$d/f"
+  git -C "$d" -c user.email=t@t -c user.name=t add f
+  git -C "$d" -c user.email=t@t -c user.name=t commit -qm "init $1"
+  printf '%s' "$d"
+}
+CK1="$(mk_repo ok)"; CK1_HEAD="$(git -C "$CK1" rev-parse HEAD)"
+CK2="$(mk_repo mkt)"; CK2_HEAD="$(git -C "$CK2" rev-parse HEAD)"
+mkdir -p "$W7/state"
+: >"$W7/state/resolves"
+cat >"$W7/state/heads" <<HEADS
+owner/pin-full=aaaabbbbccccdddd000011112222333344445555
+owner/pin-short=1111222233334444555566667777888899990000
+owner/checkout-repo=${CK1_HEAD}
+owner/mkt-fixt=${CK2_HEAD}
+HEADS
+cat >"$W7/state/resolves" <<RESOLVES
+owner/pin-short:Short0a=9999888877776666555544443333222211110000
+RESOLVES
+cat >"$W7/state/tags" <<TAGS
+owner/ver-current=v1.0.0,v1.2.3,v1.2.3-rc1
+owner/ver-behind=v0.9.0,v2.0.0,v2.0.0-beta
+owner/ver-ahead=v0.1.0,v0.2.0
+owner/base-cur=v1.0.0,v1.2.3,v1.2.3-rc1
+owner/base-behind=v1.0.0,v2.0.0
+TAGS
+MISSING="$W7/does_not_exist_dir"
+cat >"$W7/upstreams.json" <<JSON
+{"entries":[
+ {"name":"pin-full","kind":"commit_head","mode":"pin","tracked_repo":"owner/pin-full","pinned_commit":"aaaabbbbccccdddd000011112222333344445555","tier":"A"},
+ {"name":"pin-short","kind":"commit_head","mode":"pin","tracked_repo":"owner/pin-short","pinned_commit":"Short0a","tier":"A"},
+ {"name":"checkout-ok","kind":"commit_head","mode":"checkout","tracked_repo":"owner/checkout-repo","checkout_path":"$CK1","tier":"B"},
+ {"name":"checkout-missing","kind":"commit_head","mode":"checkout","tracked_repo":"owner/x","checkout_path":"$MISSING","tier":"B"},
+ {"name":"base-cur","kind":"tag_release","mode":"base","tracked_repo":"owner/base-cur","synced_base":"v1.2.3","tier":"A"},
+ {"name":"base-behind","kind":"tag_release","mode":"base","tracked_repo":"owner/base-behind","synced_base":"v1.0.0","tier":"A"},
+ {"name":"probe-cur","kind":"tag_release","mode":"probe","tracked_repo":"owner/ver-current","version_command":"printf 1.2.3","version_regex":"[0-9]+[.][0-9]+[.][0-9]+[0-9A-Za-z.-]*","tier":"A"},
+ {"name":"probe-behind","kind":"tag_release","mode":"probe","tracked_repo":"owner/ver-behind","version_command":"printf 1.2.3","version_regex":"[0-9]+[.][0-9]+[.][0-9]+[0-9A-Za-z.-]*","tier":"A"},
+ {"name":"probe-ahead","kind":"tag_release","mode":"probe","tracked_repo":"owner/ver-ahead","version_command":"printf 1.5.0","version_regex":"[0-9]+[.][0-9]+[.][0-9]+[0-9A-Za-z.-]*","tier":"A"},
+ {"name":"probe-pipe-regex","kind":"tag_release","mode":"probe","tracked_repo":"owner/ver-current","version_command":"printf 1.2.3","version_regex":"[0-9]+[.][0-9]+[.][0-9]+|nomatchxyz","tier":"A"},
+ {"name":"weird-kind","kind":"bogus","mode":"x","tracked_repo":"owner/x"},
+ {"name":"weird-mode","kind":"commit_head","mode":"bogus","tracked_repo":"owner/x"}
+]}
+JSON
+cat >"$W7/km.json" <<KJSON
+{
+ "fixt-mkt":{"source":{"source":"github","repo":"owner/mkt-fixt"},"installLocation":"$CK2","autoUpdate":true},
+ "dir-src":{"source":{"source":"directory","path":"/whatever"},"installLocation":"/whatever"}
+}
+KJSON
+empty_mjson="$W7/empty_mjson.json"
+printf '{"plugins":[]}' >"$empty_mjson"
+printf '{}' >"$W7/empty_ups.json"
+GHSTATE="$W7/state" PATH="$W7/bin:$PATH" \
+  DRIFT_REGISTRY="$W7/upstreams.json" DRIFT_KNOWN_MARKETPLACES="$W7/km.json" \
+  DRIFT_MJSON="$empty_mjson" DRIFT_UPSTREAMS="$W7/empty_ups.json" \
+  bash "$SCRIPT" >"$W7/out.txt" 2>&1; rc7=$?
+sec7="$(sed -n '/carried upstreams/,$p' "$W7/out.txt")"
+# 7a. commit_head paths.
+if printf '%s' "$sec7" | grep -q '^  pin-full: CURRENT'; then ok "commit_head pin full-SHA -> CURRENT"; else bad "commit_head pin-full not CURRENT; $(printf '%s' "$sec7" | grep pin-full)"; fi
+if printf '%s' "$sec7" | grep -q '^  pin-short: BEHIND'; then ok "commit_head pin short-SHA resolved -> BEHIND"; else bad "commit_head pin-short not BEHIND; $(printf '%s' "$sec7" | grep pin-short)"; fi
+if printf '%s' "$sec7" | grep -q '^  checkout-ok: CURRENT'; then ok "commit_head checkout present -> CURRENT"; else bad "checkout-ok not CURRENT; $(printf '%s' "$sec7" | grep checkout-ok)"; fi
+if printf '%s' "$sec7" | grep 'checkout-missing' | grep -q 'UNCHECKED'; then ok "commit_head checkout absent -> UNCHECKED"; else bad "checkout-missing not UNCHECKED"; fi
+if printf '%s' "$sec7" | grep 'weird-mode' | grep -q "mode 'bogus' unknown"; then ok "commit_head unknown mode -> UNCHECKED"; else bad "weird-mode not flagged"; fi
+# 7b. tag_release paths.
+if printf '%s' "$sec7" | grep -q '^  base-cur: CURRENT'; then ok "tag_release base synced -> CURRENT"; else bad "base-cur not CURRENT"; fi
+if printf '%s' "$sec7" | grep -q '^  base-behind: BEHIND'; then ok "tag_release base stale -> BEHIND"; else bad "base-behind not BEHIND"; fi
+if printf '%s' "$sec7" | grep -q '^  probe-cur: CURRENT'; then ok "tag_release probe synced -> CURRENT"; else bad "probe-cur not CURRENT"; fi
+if printf '%s' "$sec7" | grep -q '^  probe-behind: BEHIND'; then ok "tag_release probe stale -> BEHIND"; else bad "probe-behind not BEHIND"; fi
+if printf '%s' "$sec7" | grep 'probe-ahead' | grep -q 'CURRENT'; then ok "tag_release probe installed-ahead -> CURRENT (not a phantom BEHIND)"; else bad "probe-ahead not CURRENT; $(printf '%s' "$sec7" | grep probe-ahead)"; fi
+# 7b-extra (HIMMEL-869 CR fix): a version_regex containing a literal '|'
+# (regex alternation) must round-trip through the emitter/consumer protocol
+# intact. Under a pipe-delimited protocol this record's own fields would
+# misalign (v2/version_regex truncates at the first '|', the remainder spills
+# into tier) — assert the verdict line is well-formed: CURRENT, with tier
+# exactly "[A]" and no leaked regex remainder.
+if printf '%s' "$sec7" | grep '^  probe-pipe-regex: CURRENT' | grep -q '\[A\]$'; then
+  ok "tag_release probe: version_regex containing '|' parses into correct fields (well-formed CURRENT line, tier intact)"
+else
+  bad "probe-pipe-regex line malformed (delimiter/field misalignment?); $(printf '%s' "$sec7" | grep probe-pipe-regex)"
+fi
+if printf '%s' "$sec7" | grep 'probe-pipe-regex' | grep -q 'nomatchxyz'; then
+  bad "probe-pipe-regex line leaked regex remainder into tier/verdict — field misalignment"
+else
+  ok "probe-pipe-regex line does not leak regex remainder (fields correctly delimited)"
+fi
+# 7c. marketplace discovery.
+if printf '%s' "$sec7" | grep -q '^  mkt:fixt-mkt: CURRENT'; then ok "marketplace github-sourced checkout -> CURRENT"; else bad "mkt:fixt-mkt not CURRENT; $(printf '%s' "$sec7" | grep 'mkt:')"; fi
+if printf '%s' "$sec7" | grep -q 'mkt:dir-src'; then bad "directory-sourced marketplace should be skipped (not checked)"; else ok "directory-sourced marketplace correctly skipped"; fi
+# 7d. unknown kind + exit code (drift from pin-short/base-behind/probe-behind => 2).
+if printf '%s' "$sec7" | grep 'weird-kind' | grep -q "unknown kind 'bogus'"; then ok "unknown kind -> UNCHECKED"; else bad "weird-kind not flagged"; fi
+if [ "$rc7" -eq 2 ]; then ok "carried-upstreams drift run exits 2 (drift, precedence over incomplete)"; else bad "carried-upstreams drift run rc=$rc7; expected 2"; fi
+# 7e. malformed registry -> class UNCHECKED (never a false all-clear).
+printf '{not valid json' >"$W7/bad.json"
+bad_out="$(GHSTATE="$W7/state" PATH="$W7/bin:$PATH" DRIFT_REGISTRY="$W7/bad.json" DRIFT_KNOWN_MARKETPLACES=/dev/null DRIFT_MJSON="$empty_mjson" DRIFT_UPSTREAMS="$W7/empty_ups.json" bash "$SCRIPT" 2>&1)"; bad_rc=$?
+if printf '%s' "$bad_out" | grep -q 'carried-upstreams class UNCHECKED'; then ok "malformed registry -> class UNCHECKED"; else bad "malformed registry not UNCHECKED; $bad_out"; fi
+if [ "$bad_rc" -eq 3 ]; then ok "malformed registry run exits 3 (incomplete, not a false 0)"; else bad "malformed registry rc=$bad_rc; expected 3"; fi
+# 7f. empty/missing registry -> no entries (clean, not UNCHECKED). (Overall exit
+#     code is not asserted: the vendored-forks section still globs the REAL
+#     UPSTREAM_PINs and reads UNCHECKED under the stub, which is orthogonal to
+#     the empty-registry property under test — that the carried-upstreams section
+#     emits no spurious entries.)
+empty_out="$(GHSTATE="$W7/state" PATH="$W7/bin:$PATH" DRIFT_REGISTRY=/dev/null DRIFT_KNOWN_MARKETPLACES=/dev/null DRIFT_MJSON="$empty_mjson" DRIFT_UPSTREAMS="$W7/empty_ups.json" bash "$SCRIPT" 2>&1)"
+if printf '%s' "$empty_out" | grep -q 'carried upstreams' && ! printf '%s' "$empty_out" | sed -n '/carried upstreams/,$p' | grep -Eq '^  [a-z].*: (CURRENT|BEHIND|UNCHECKED|unknown)'; then
+  ok "empty registry -> carried-upstreams section header only (no spurious entries/UNCHECKED)"
+else
+  bad "empty registry emitted entries or parse error; $(printf '%s' "$empty_out" | sed -n '/carried upstreams/,$p')"
+fi
+rm -rf "$W7"
+
+# 8. Probe watchdog fallback (HIMMEL-869 CR fix 1): when `timeout` is absent
+#    from PATH, a hanging version_command must not wedge the run — the
+#    bash-native watchdog fallback bounds it to the same 10s budget, and a
+#    killed probe reads UNCHECKED (never CURRENT/BEHIND). PATH is rebuilt from
+#    symlinks to every /usr/bin entry EXCEPT timeout (Windows also ships
+#    system32/timeout.exe, so merely reordering PATH can't hide it — the
+#    masked dir must be the only source of these tools) plus /mingw64/bin
+#    (git) and the python3 dir, so the fallback branch is the one genuinely
+#    exercised, not the `timeout`-present branch.
+W8="$(mktemp -d)"; mkdir -p "$W8/notimeout" "$W8/bin"
+for f in /usr/bin/*; do
+  b="$(basename "$f")"
+  case "$b" in
+    timeout|timeout.exe) continue ;;
+  esac
+  ln -s "$f" "$W8/notimeout/$b" 2>/dev/null
+done
+cat > "$W8/bin/gh" <<'GH'
+#!/usr/bin/env bash
+[ "$1" = auth ] && [ "$2" = status ] && exit 0
+exit 0
+GH
+chmod +x "$W8/bin/gh"
+cat > "$W8/bin/hangprobe" <<'HANG'
+#!/usr/bin/env bash
+sleep 60
+HANG
+chmod +x "$W8/bin/hangprobe"
+cat > "$W8/upstreams.json" <<'JSON'
+{"entries":[
+ {"name":"hang-tool","kind":"tag_release","mode":"probe","tracked_repo":"owner/hang","version_command":"hangprobe","version_regex":"[0-9]+","tier":"A"}
+]}
+JSON
+printf '{"plugins":[]}' >"$W8/empty_mjson.json"
+printf '{}' >"$W8/empty_ups.json"
+NOTIMEOUT_PATH="$W8/bin:$W8/notimeout:/mingw64/bin:$HOME/.local/bin"
+if PATH="$NOTIMEOUT_PATH" command -v timeout >/dev/null 2>&1; then
+  bad "PATH-mask setup failed — 'timeout' still resolvable, fallback branch not actually exercised"
+else
+  ok "PATH-mask: 'timeout' unresolvable in the rebuilt PATH"
+fi
+w8_start=$(date +%s)
+w8_out="$(PATH="$NOTIMEOUT_PATH" DRIFT_REGISTRY="$W8/upstreams.json" DRIFT_KNOWN_MARKETPLACES=/dev/null DRIFT_MJSON="$W8/empty_mjson.json" DRIFT_UPSTREAMS="$W8/empty_ups.json" bash "$SCRIPT" 2>&1)"; w8_rc=$?
+w8_elapsed=$(( $(date +%s) - w8_start ))
+if [ "$w8_elapsed" -lt 20 ]; then ok "hanging probe watchdog: run completed in ${w8_elapsed}s (<20s)"; else bad "hanging probe watchdog: run took ${w8_elapsed}s (>=20s) — watchdog did not bound it"; fi
+if printf '%s' "$w8_out" | grep -q "watchdog fallback"; then ok "hanging probe: fallback-watchdog note emitted"; else bad "hanging probe: no fallback-watchdog note; out: $w8_out"; fi
+if printf '%s' "$w8_out" | grep 'hang-tool' | grep -q 'probe timed out'; then ok "hanging probe: entry reads 'probe timed out' UNCHECKED"; else bad "hanging probe: no timeout note; $(printf '%s' "$w8_out" | grep hang-tool)"; fi
+if printf '%s' "$w8_out" | grep -qE '^  hang-tool: (CURRENT|BEHIND)'; then bad "hanging probe: entry read CURRENT/BEHIND instead of UNCHECKED"; else ok "hanging probe: entry never read CURRENT/BEHIND"; fi
+if [ "$w8_rc" -eq 3 ]; then ok "hanging probe run exits 3 (incomplete)"; else bad "hanging probe run rc=$w8_rc; expected 3"; fi
+rm -rf "$W8"
+
+# 9. Marketplace entry lacking installLocation (HIMMEL-869 CR fix 3): older/
+#    foreign known_marketplaces.json shapes must skip with a named per-entry
+#    UNCHECKED note, never fall through to the checkout-missing branch with an
+#    empty path (which would read as "checkout not present on this machine ()"
+#    — indistinguishable from a real absent checkout).
+W9="$(mktemp -d)"; mkdir -p "$W9/bin"
+cat > "$W9/bin/gh" <<'GH'
+#!/usr/bin/env bash
+[ "$1" = auth ] && [ "$2" = status ] && exit 0
+exit 0
+GH
+chmod +x "$W9/bin/gh"
+cat > "$W9/km.json" <<'KJSON'
+{"no-install-loc-marketplace":{"source":{"source":"github","repo":"owner/no-loc"}}}
+KJSON
+printf '{"plugins":[]}' >"$W9/empty_mjson.json"
+printf '{}' >"$W9/empty_ups.json"
+w9_out="$(PATH="$W9/bin:$PATH" DRIFT_REGISTRY=/dev/null DRIFT_KNOWN_MARKETPLACES="$W9/km.json" DRIFT_MJSON="$W9/empty_mjson.json" DRIFT_UPSTREAMS="$W9/empty_ups.json" bash "$SCRIPT" 2>&1)"; w9_rc=$?
+if printf '%s' "$w9_out" | grep 'mkt:no-install-loc-marketplace' | grep -q 'lacks installLocation'; then
+  ok "marketplace entry without installLocation -> named per-entry UNCHECKED skip"
+else
+  bad "missing-installLocation marketplace entry not flagged; $(printf '%s' "$w9_out" | grep 'no-install-loc-marketplace')"
+fi
+if printf '%s' "$w9_out" | grep 'mkt:no-install-loc-marketplace' | grep -q 'checkout not present'; then
+  bad "missing-installLocation entry fell through to the empty-path checkout-missing branch"
+else
+  ok "missing-installLocation entry did not fall through to checkout-missing"
+fi
+if [ "$w9_rc" -eq 3 ]; then ok "missing-installLocation-only run exits 3 (incomplete)"; else bad "missing-installLocation run rc=$w9_rc; expected 3"; fi
+rm -rf "$W9"
+
+# 10. Probe timeout path (HIMMEL-869 CR round-3): with `timeout` AVAILABLE on
+#     PATH (the normal/common case — no PATH masking here, unlike test 8's
+#     fallback exercise), a probe that prints a version line and THEN hangs
+#     must be killed by `timeout` (rc=124) and read UNCHECKED, never parsed
+#     from its partial (pre-hang) output as CURRENT/BEHIND.
+W10="$(mktemp -d)"; mkdir -p "$W10/bin"
+cat > "$W10/bin/gh" <<'GH'
+#!/usr/bin/env bash
+[ "$1" = auth ] && [ "$2" = status ] && exit 0
+exit 0
+GH
+chmod +x "$W10/bin/gh"
+cat > "$W10/bin/timedprobe" <<'HANG'
+#!/usr/bin/env bash
+echo "v1.2.3"
+sleep 60
+HANG
+chmod +x "$W10/bin/timedprobe"
+cat > "$W10/upstreams.json" <<'JSON'
+{"entries":[
+ {"name":"timedprobe-tool","kind":"tag_release","mode":"probe","tracked_repo":"owner/timed","version_command":"timedprobe","version_regex":"[0-9]+\\.[0-9]+\\.[0-9]+","tier":"A"}
+]}
+JSON
+printf '{"plugins":[]}' >"$W10/empty_mjson.json"
+printf '{}' >"$W10/empty_ups.json"
+TIMEOUT_PATH="$W10/bin:$PATH"
+if PATH="$TIMEOUT_PATH" command -v timeout >/dev/null 2>&1; then
+  ok "timeout-available setup: 'timeout' resolvable on PATH"
+else
+  bad "timeout-available setup failed — 'timeout' not resolvable, timeout branch not actually exercised"
+fi
+w10_start=$(date +%s)
+w10_out="$(PATH="$TIMEOUT_PATH" DRIFT_REGISTRY="$W10/upstreams.json" DRIFT_KNOWN_MARKETPLACES=/dev/null DRIFT_MJSON="$W10/empty_mjson.json" DRIFT_UPSTREAMS="$W10/empty_ups.json" bash "$SCRIPT" 2>&1)"; w10_rc=$?
+w10_elapsed=$(( $(date +%s) - w10_start ))
+if [ "$w10_elapsed" -lt 20 ]; then ok "timeout-path hanging probe: run completed in ${w10_elapsed}s (<20s)"; else bad "timeout-path hanging probe: run took ${w10_elapsed}s (>=20s) — 'timeout' did not bound it"; fi
+if printf '%s' "$w10_out" | grep 'timedprobe-tool' | grep -q 'probe timed out (10s)'; then ok "timeout-path hanging probe: entry reads 'probe timed out (10s)' UNCHECKED"; else bad "timeout-path hanging probe: no timeout note; $(printf '%s' "$w10_out" | grep timedprobe-tool)"; fi
+if printf '%s' "$w10_out" | grep -qE '^  timedprobe-tool: (CURRENT|BEHIND)'; then bad "timeout-path hanging probe: entry read CURRENT/BEHIND instead of UNCHECKED (partial pre-hang output was parsed)"; else ok "timeout-path hanging probe: entry never read CURRENT/BEHIND"; fi
+if [ "$w10_rc" -eq 3 ]; then ok "timeout-path hanging probe run exits 3 (incomplete)"; else bad "timeout-path hanging probe run rc=$w10_rc; expected 3"; fi
+rm -rf "$W10"
 
 echo ""
 if [ "$fails" -ne 0 ]; then echo "$fails check(s) failed."; exit 1; fi

--- a/scripts/upstreams.json
+++ b/scripts/upstreams.json
@@ -1,0 +1,52 @@
+{
+  "_comment": "Fleet-wide registry of carried upstreams for scripts/check-plugin-drift.sh (HIMMEL-869). Covers the upstreams NOT already reached by the two existing checks (marketplace.json pinned remotes incl. the claude-obsidian fork override in plugin-upstreams.json; vendored forks with a marketplace/plugins/<p>/UPSTREAM_PIN). Each entry names a TRUE upstream and how to detect that it has advanced past what himmel carries, so the goal state 'always sync + additive' (fork deltas stay strictly additive on a current upstream base) is observable. Two detection kinds, each a discriminated union on `kind`: (1) commit_head — compare a local commit to the tracked repo's default-branch HEAD. `mode: pin` takes the commit from `pinned_commit` (full or short SHA; short is resolved via gh). `mode: checkout` takes it from a local git checkout at `checkout_path` ($VAR/${VAR} expanded cross-platform by the script's python emitter; absent checkout -> UNCHECKED, never drift). Use `pin` for vendored copies (the dir is NOT a git checkout of upstream — claude-hud, claude-statusline) and `checkout` for editable/installed git checkouts (hermes-agent). (2) tag_release — compare a local version to the tracked repo's latest STABLE version tag (highest semver via sort -V, prereleases excluded — same discipline as the claude-obsidian fork override). `mode: base` takes the version from `synced_base` (a recorded literal). `mode: probe` runs `version_command` (simple space-separated tokens) and extracts the version via `version_regex` (a pattern matching the bare version, e.g. `[0-9]+\\\\.[0-9]+\\\\.[0-9]+[0-9A-Za-z.-]*`; no capture group — grep -oE prints the whole match). Use `probe` for installed binaries/CLIs whose version is only knowable by running them (rtk, twitter-cli). `tier` is informational only (A=proactive-adopt, B=reactive-adopt per the HIMMEL-850 audit) and appears in the guard's output so a reader can tell expected-churn (Tier B usually reads BEHIND by design) from a genuine stale pin. Installed marketplaces (caveman, obsidian-skills, openai-codex, claude-video, claude-plugins-official, ...) are NOT listed here: they are discovered dynamically from ~/.claude/plugins/known_marketplaces.json (DRIFT_KNOWN_MARKETPLACES override) so the guard auto-covers any future marketplace install, each checked as a commit_head/checkout against its source repo. The additive-only-delta audit for the true forks (claude-obsidian, telegram-himmel, pr-review-toolkit-himmel, qmd) is a documented MANUAL step — see the script header.",
+  "entries": [
+    {
+      "name": "claude-hud",
+      "kind": "commit_head",
+      "mode": "pin",
+      "tracked_repo": "jarrodwatts/claude-hud",
+      "pinned_commit": "b83b44593af24de1db6183788a51d08715501c02",
+      "tier": "A",
+      "note": "Vendored at marketplace/plugins/claude-hud (VENDORED.md); pin = upstream v0.3.0. The local vendored-tree drift (our own edits) is separately guarded by scripts/statusline/check-hud-drift.sh (himmel-dev pre-commit); this entry guards UPSTREAM advance. Not in marketplace.json by design — it is the statusline renderer (wired via node), not a marketplace plugin."
+    },
+    {
+      "name": "claude-statusline",
+      "kind": "commit_head",
+      "mode": "pin",
+      "tracked_repo": "nilbuild/claude-statusline",
+      "pinned_commit": "3f64887",
+      "tier": "A",
+      "note": "Vendored at scripts/statusline/ (VENDORED.md), synced via the yotamleo/claude-statusline fork. tracked_repo is the TRUE upstream (nilbuild), not the fork — pointing this at the fork would let nilbuild advance while the fork sat stale and still read CURRENT, exactly the false-negative class this guard exists to close. BEHIND here means nilbuild has moved past our pinned_commit: pull nilbuild into the fork, re-vendor, then bump pinned_commit here. Short SHA resolved via gh."
+    },
+    {
+      "name": "hermes-agent",
+      "kind": "commit_head",
+      "mode": "checkout",
+      "tracked_repo": "NousResearch/hermes-agent",
+      "checkout_path": "${LOCALAPPDATA}/hermes/hermes-agent",
+      "tier": "B",
+      "note": "Editable pip checkout (the multi-provider gateway). Tier B / high-churn (18k+ open PRs): reads BEHIND by design; that IS the signal — consult the HIMMEL-850 steal-list when a real bug hits. UNCHECKED if the checkout is absent on this machine (CI / fresh clone)."
+    },
+    {
+      "name": "rtk",
+      "kind": "tag_release",
+      "mode": "probe",
+      "tracked_repo": "rtk-ai/rtk",
+      "version_command": "rtk --version",
+      "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+[0-9A-Za-z.-]*",
+      "tier": "B",
+      "note": "Installed binary at ~/.local/bin/rtk. Tier B (reactive); known git-diff rewrite bug HIMMEL-270 is NOT directly fixed upstream. UNCHECKED if rtk absent / --version yields no parseable version."
+    },
+    {
+      "name": "twitter-cli",
+      "kind": "tag_release",
+      "mode": "probe",
+      "tracked_repo": "public-clis/twitter-cli",
+      "version_command": "twitter --version",
+      "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+[0-9A-Za-z.-]*",
+      "tier": "A",
+      "note": "Installed CLI at ~/.local/bin/twitter (consumed by the telegram clipper). Tier A (proactive). UNCHECKED if twitter absent / --version yields no parseable version."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Extends `scripts/check-plugin-drift.sh` (HIMMEL-322) to EVERY carried upstream via a new data-driven registry `scripts/upstreams.json` (discriminated union `kind=commit_head|tag_release` × probe/checkout modes) — the HIMMEL-850 audit's "always sync + additive" goal state. New coverage: claude-hud (VENDORED.manifest), claude-statusline (tracks the TRUE upstream nilbuild — BEHIND = upstream advanced, fork+vendored need a sync pass), hermes-agent (editable checkout HEAD), rtk + twitter-cli (binary version probes, 10s-bounded), and all installed GitHub marketplaces (auto-discovered from known_marketplaces.json; entries lacking installLocation get a named UNCHECKED skip). Additive-only-delta audit for the 4 true forks documented as a manual step (per ticket allowance).

Contract preserved and hardened: exit 2 drift / 0 fail-open with note / 3 incomplete; every unresolvable state is an explicit UNCHECKED with `incomplete=1` — including probe timeouts on BOTH paths (coreutils `timeout` rc=124/137 and a bash-native watchdog fallback when `timeout` is absent, with best-effort process-group cleanup). Emitter→consumer protocol uses the ASCII unit separator (version_regex fields can contain `|`).

## CR trail (4 rounds)

- R1: panel [codex-3] "tr masks python parse failures" DISPROVED twice (pipefail + PIPESTATUS; test 7e reproduces exit 3 empirically). Silent-failure hunt: unbounded no-`timeout` probe → watchdog fallback + hang tests. codex-adv: statusline tracked the fork not nilbuild (fixed); marketplace installLocation shape-robustness (fixture-tested named skip). 2 PRE-EXISTING contract gaps in the HIMMEL-322 sections found out-of-diff → filed HIMMEL-873.
- R2: unit-separator protocol (red-green verified against a `|`-bearing regex), watchdog group-kill via setsid-when-available, test hygiene.
- R3: `timeout`-path rc=124/137 → UNCHECKED (symmetric with the fallback).
- R4: panel clean.

## Tests

`scripts/test-check-plugin-drift.sh`: 55 hermetic checks green (stubbed gh, no network; per-kind/mode UNCHECKED shapes, drift-precedence, malformed registry, both hang paths, `|`-in-regex protocol, shape-robustness fixture). shellcheck clean.

## Provenance

GLM worker impl (31491290) + 3 Sonnet CR rounds; parent-reviewed (Fable s29). Follow-up: HIMMEL-873 (pre-existing gaps).
