### PR TITLE
feat(vm): [HIMMEL-870] vmsdk physical-station entries — per-entry host + key auth for the SSH-generic surface

### DIFF
--- a/scripts/lib/test-vmsdk.py
+++ b/scripts/lib/test-vmsdk.py
@@ -5,7 +5,9 @@ Hermetic tests mock `vbox` and the SSH client, so they run on any box. The
 `TestLiveUbuntu` class is guarded by a reachability probe and is skipped (not
 failed) when ubuntu_new is not up on 127.0.0.1:2222.
 """
+import json
 import os
+import shutil
 import socket
 import sys
 import unittest
@@ -1066,6 +1068,235 @@ class TestTriggerCLI(unittest.TestCase):
             rc = vmsdk.main(["ubuntu_new", "push", "h.md"])
         self.assertEqual(rc, 0)
         p.assert_called_once_with("h.md", "~/handover-inbox/h.md")
+
+
+class TestStation(unittest.TestCase):
+    """Physical SSH station entries (HIMMEL-870) — kind: "station", key auth
+    via an SSH alias resolved through ~/.ssh/config. All station fixtures use
+    a temp registry (registry_path=) so they never depend on the real
+    scripts/lib/vms.json win2 entry (hermetic, no network)."""
+
+    def setUp(self):
+        import tempfile
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(self.tmp, ignore_errors=True))
+
+    def _write_registry(self, reg):
+        p = Path(self.tmp) / "vms.json"
+        p.write_text(json.dumps(reg))
+        return str(p)
+
+    def _vm(self, **overrides):
+        spec = {"os": "windows", "kind": "station", "host": "teststation",
+                "auth": "key", "user": "testuser",
+                "repo_path": "~/repo/himmel"}
+        spec.update(overrides)
+        reg_path = self._write_registry({"teststation": spec})
+        return vmsdk.VM("teststation", registry_path=reg_path)
+
+    # --- construction ---
+    def test_station_resolves_fields_no_env_needed(self):
+        # Clear every env var EXCEPT the HOME var expanduser() itself relies
+        # on — the point of this test is that a station needs no VM creds
+        # (ubuntu_vm_user etc.), not that expanduser() stops working.
+        home_key = "USERPROFILE" if os.name == "nt" else "HOME"
+        keep = {home_key: os.environ[home_key]} if home_key in os.environ else {}
+        with mock.patch.dict(os.environ, keep, clear=True):
+            vm = self._vm()
+        self.assertEqual(vm.kind, "station")
+        self.assertEqual(vm.auth, "key")
+        self.assertEqual(vm.host, "teststation")
+        self.assertIsNone(vm.port)
+        self.assertIsNone(vm.password)
+        self.assertEqual(vm.user, "testuser")
+        # repo_path is expanduser'd at construction so a tilde form (the
+        # portable shape a registry entry should use) resolves usably.
+        self.assertEqual(vm.repo_path, os.path.expanduser("~/repo/himmel"))
+
+    def test_station_missing_host_raises(self):
+        reg_path = self._write_registry({"nohostbox": {"os": "windows", "kind": "station"}})
+        with self.assertRaises(vmsdk.VMError) as cm:
+            vmsdk.VM("nohostbox", registry_path=reg_path)
+        self.assertIn("host", str(cm.exception))
+
+    def test_vm_entry_back_compat_unchanged(self):
+        """Existing (non-station) registry entries behave exactly as before:
+        kind defaults to "vm", auth defaults to "password", loopback host/port,
+        password-env auth — VM back-compat is the explicit requirement here."""
+        with mock.patch.dict(os.environ,
+                             {"ubuntu_vm_user": "osboxes", "ubuntu_vm_pass": "pw"}, clear=False):
+            with mock.patch.object(vmsdk, "_load_dotenv_into_env"):
+                vm = vmsdk.VM("ubuntu_new")
+        self.assertEqual(vm.kind, "vm")
+        self.assertEqual(vm.auth, "password")
+        self.assertEqual(vm.host, "127.0.0.1")
+        self.assertEqual(vm.port, 2222)
+        self.assertEqual(vm.user, "osboxes")
+        self.assertEqual(vm.password, "pw")
+        self.assertIsNone(vm.repo_path)
+
+    # --- ssh() alias resolution / key auth ---
+    def test_ssh_resolves_alias_via_ssh_config_key_auth(self):
+        vm = self._vm()
+        ssh_config_text = (
+            "Host teststation\n"
+            "  HostName 10.0.0.5\n"
+            "  Port 2200\n"
+            "  User testuser\n"
+            "  IdentityFile ~/.ssh/id_ed25519_win2\n"
+        )
+        calls = []
+
+        class _FakeSSH:
+            def set_missing_host_key_policy(self, policy):
+                pass
+            def connect(self, **kw):
+                calls.append(kw)
+            def close(self):
+                pass
+
+        import paramiko
+        with mock.patch.object(vmsdk, "_read_ssh_config_text", return_value=ssh_config_text), \
+             mock.patch.object(paramiko, "SSHClient", return_value=_FakeSSH()):
+            client = vm.ssh()
+        self.assertIsInstance(client, _FakeSSH)
+        self.assertEqual(len(calls), 1)
+        kw = calls[0]
+        self.assertEqual(kw["hostname"], "10.0.0.5")
+        self.assertEqual(kw["port"], 2200)
+        self.assertEqual(kw["username"], "testuser")
+        self.assertIn("id_ed25519_win2", kw["key_filename"])
+        self.assertNotIn("password", kw)
+
+    def test_ssh_falls_back_to_alias_and_registry_user_without_ssh_config(self):
+        """No matching Host block -> resolve to the bare alias / registry user."""
+        vm = self._vm()
+
+        class _FakeSSH:
+            kw = None
+            def set_missing_host_key_policy(self, policy):
+                pass
+            def connect(self, **kw):
+                self.kw = kw
+            def close(self):
+                pass
+
+        fake = _FakeSSH()
+        import paramiko
+        with mock.patch.object(vmsdk, "_read_ssh_config_text", return_value=""), \
+             mock.patch.object(paramiko, "SSHClient", return_value=fake):
+            vm.ssh()
+        self.assertEqual(fake.kw["hostname"], "teststation")
+        self.assertEqual(fake.kw["username"], "testuser")   # registry user, no ssh_config override
+        self.assertEqual(fake.kw["port"], 22)
+        self.assertNotIn("password", fake.kw)
+
+    def test_ssh_no_user_anywhere_raises_clear_vmerror(self):
+        """No registry user AND no ssh_config User for the alias -> a clear
+        VMError naming the entry + both places a user can be set, instead of
+        paramiko.connect(username=None) failing cryptically (HIMMEL-870 CR round-1)."""
+        vm = self._vm(user=None)
+
+        class _FakeSSH:
+            def set_missing_host_key_policy(self, policy):
+                pass
+            def connect(self, **kw):
+                raise AssertionError("connect() must not be reached when user is unresolved")
+            def close(self):
+                pass
+
+        import paramiko
+        with mock.patch.object(vmsdk, "_read_ssh_config_text", return_value=""), \
+             mock.patch.object(paramiko, "SSHClient", return_value=_FakeSSH()):
+            with self.assertRaises(vmsdk.VMError) as cm:
+                vm.ssh()
+        msg = str(cm.exception)
+        self.assertIn("teststation", msg)
+        self.assertIn("vms.json", msg)
+        self.assertIn("~/.ssh/config", msg)
+
+    # --- run() command construction: alias-reached, no password env ---
+    def test_run_uses_station_ssh_no_password(self):
+        vm = self._vm()
+        fake = _FakeClient(rc=0, out="hi\n", err="")
+        with mock.patch.object(vm, "ssh", return_value=fake):
+            rc, out = vm.run("echo hi")
+        self.assertEqual(rc, 0)
+        self.assertIn("hi", out)
+        self.assertIsNone(vm.password)   # never set for a station
+
+    # --- sync_repo: alias branch, no port/-i/loopback ---
+    def test_sync_repo_station_uses_alias_no_port_no_key_flag(self):
+        vm = self._vm()
+        calls = []
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            return mock.Mock(returncode=0, stderr="")
+        with mock.patch.object(vmsdk.subprocess, "run", side_effect=fake_run):
+            vm.sync_repo(r"C:\Users\x\himmel")
+        pipe = " ".join(str(a) for a in calls[0])
+        self.assertIn("teststation", pipe)
+        self.assertNotIn("ssh -p", pipe)     # no port flag on the ssh invocation
+        self.assertNotIn("-i ", pipe)        # no explicit identity flag
+        self.assertNotIn("@127.0.0.1", pipe)
+        self.assertIn("BatchMode=yes", pipe)
+
+    def test_sync_repo_station_pins_registry_user_at_alias(self):
+        """Registry user must be pinned as user@alias, so sync_repo can't drift
+        from ssh()'s resolved user when the registry user differs from
+        ssh_config's User for the same Host (HIMMEL-870 CR round-1)."""
+        vm = self._vm(user="testuser")
+        calls = []
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            return mock.Mock(returncode=0, stderr="")
+        with mock.patch.object(vmsdk.subprocess, "run", side_effect=fake_run):
+            vm.sync_repo(r"C:\Users\x\himmel")
+        pipe = " ".join(str(a) for a in calls[0])
+        self.assertIn("testuser@teststation", pipe)
+
+    def test_sync_repo_station_bare_alias_when_no_registry_user(self):
+        """No registry user -> bare alias, unchanged from the pre-fix shape
+        (ssh_config's own User, if any, still applies via the alias)."""
+        vm = self._vm(user=None)
+        calls = []
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            return mock.Mock(returncode=0, stderr="")
+        with mock.patch.object(vmsdk.subprocess, "run", side_effect=fake_run):
+            vm.sync_repo(r"C:\Users\x\himmel")
+        pipe = " ".join(str(a) for a in calls[0])
+        self.assertNotIn("@teststation", pipe)
+        self.assertIn("teststation", pipe)
+
+    # --- lifecycle ops are VM-only: stations raise the typed error ---
+    def test_lifecycle_ops_raise_station_lifecycle_error(self):
+        vm = self._vm()
+        ops = [
+            ("up", lambda: vm.up()),
+            ("down", lambda: vm.down()),
+            ("ensure_up", lambda: vm.ensure_up()),
+            ("snapshots", lambda: vm.snapshots()),
+            ("snapshot", lambda: vm.snapshot("clean")),
+            ("restore", lambda: vm.restore("clean")),
+            ("baseline", lambda: vm.baseline("clean")),
+            ("provision", lambda: vm.provision()),
+            ("e2e", lambda: vm.run_e2e()),
+        ]
+        for name, call in ops:
+            with self.subTest(op=name):
+                with self.assertRaises(vmsdk.StationLifecycleError) as cm:
+                    call()
+                self.assertIn("teststation", str(cm.exception))
+                self.assertIsInstance(cm.exception, vmsdk.VMError)
+
+    def test_cli_lifecycle_on_station_exits_1_not_traceback(self):
+        reg_path = self._write_registry({"teststation": {
+            "os": "windows", "kind": "station", "host": "teststation",
+            "auth": "key", "user": "testuser"}})
+        with mock.patch.object(vmsdk, "_REGISTRY", Path(reg_path)):
+            rc = vmsdk.main(["teststation", "up"])
+        self.assertEqual(rc, 1)
 
 
 def _ubuntu_up():

--- a/scripts/lib/vms.json
+++ b/scripts/lib/vms.json
@@ -1,4 +1,5 @@
 {
   "ubuntu_new":        { "os": "ubuntu",  "ssh_port": 2222, "user_env": "ubuntu_vm_user",  "pass_env": "ubuntu_vm_pass" },
-  "win11_base_himmel": { "os": "windows", "ssh_port": 2223, "user_env": "windows_vm_user", "pass_env": "windows_vm_pass" }
+  "win11_base_himmel": { "os": "windows", "ssh_port": 2223, "user_env": "windows_vm_user", "pass_env": "windows_vm_pass" },
+  "win2":              { "os": "windows", "kind": "station", "host": "win2", "auth": "key", "repo_path": "~/Documents/github/himmel" }
 }

--- a/scripts/lib/vmsdk.py
+++ b/scripts/lib/vmsdk.py
@@ -4,10 +4,17 @@ VM SDK (HIMMEL-491) — an easy-to-use class over scripts/lib/vbox.py for drivin
 the cross-OS test VMs: power, snapshots (so we don't re-provision), shallow
 clone, and provision + e2e delegation.
 
+Also covers physical SSH "stations" (HIMMEL-870, registry `kind: "station"`) —
+reached via an SSH alias + key auth resolved through ~/.ssh/config instead of
+loopback port-forward + password env. Stations share the SSH-generic surface
+(run/ssh/trigger_claude/sync_repo/drive_claude) but have no VirtualBox
+lifecycle; up/down/snapshot/provision/e2e raise StationLifecycleError.
+
 Stdlib + paramiko + python-dotenv (already deps of the *-vm-setup.py scripts;
-no new deps). Loopback-only. Reads SSH creds from the PRIMARY checkout's .env
-(the gitignored .env is NOT copied into worktrees, so it is resolved via the
-parent of `git rev-parse --git-common-dir`, matching scripts/lib/load-dotenv.sh).
+no new deps). Loopback-only for VM entries. Reads SSH creds from the PRIMARY
+checkout's .env (the gitignored .env is NOT copied into worktrees, so it is
+resolved via the parent of `git rev-parse --git-common-dir`, matching
+scripts/lib/load-dotenv.sh).
 
 CLI: python scripts/lib/vmsdk.py <vm> <up|down|snapshot NAME|restore NAME|
                                       baseline NAME|clone [REF]|provision|e2e|
@@ -42,6 +49,18 @@ class VMError(RuntimeError):
     pass
 
 
+class StationLifecycleError(VMError):
+    """A VM-lifecycle/provisioning op was invoked on a station entry.
+
+    Stations (HIMMEL-870) are physical SSH hosts — they have no VirtualBox
+    power/snapshot/provision surface, only the SSH-generic exec/trigger surface.
+    Subclasses VMError so the CLI's ``except VMError`` handler still reports it
+    cleanly instead of dumping a traceback. The message names the entry as a
+    station and the op as VM-only.
+    """
+    pass
+
+
 def _env_path():
     """Path to the PRIMARY checkout's .env (not the worktree's — it has none)."""
     here = Path(__file__).resolve().parent
@@ -71,6 +90,23 @@ def _load_registry(path=None):
     return json.loads(p.read_text())
 
 
+def _read_ssh_config_text():
+    """Return ``~/.ssh/config`` text, or '' if absent/unreadable.
+
+    paramiko does NOT consult ssh_config on connect (the OS ``ssh`` binary
+    does), so a station's registry ``host`` is an alias whose real
+    HostName/Port/User/IdentityFile live in the operator's ssh_config. This is
+    the single read seam — mocked in tests so station ssh() never touches the
+    real operator config (hermetic).
+    """
+    cfg_path = os.path.expanduser("~/.ssh/config")
+    try:
+        with open(cfg_path) as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
 def _repo_root():
     return _env_path().parent
 
@@ -83,12 +119,28 @@ class VM:
         spec = reg[name]
         self.name = name
         self.os = spec["os"]
-        self.port = spec["ssh_port"]
-        self.host = HOST
-        _load_dotenv_into_env()
-        self.user = self._req_env(spec["user_env"])
-        self.password = self._req_env(spec["pass_env"])
+        self.kind = spec.get("kind", "vm")   # "vm" (default, back-compat) | "station"
+        self.auth = spec.get("auth", "key" if self.kind == "station" else "password")
         self._client = None
+        if self.kind == "station":
+            # Physical SSH host (HIMMEL-870): reached by alias + key auth via
+            # ~/.ssh/config. No VirtualBox lifecycle, no loopback port-forward,
+            # no password env. host/port/identity are resolved at connect time.
+            if "host" not in spec:
+                raise VMError(f"station {name!r} requires a 'host' (SSH alias)")
+            self.host = spec["host"]
+            self.port = None
+            self.user = spec.get("user")   # ssh_config may also supply it
+            self.password = None
+            repo_path = spec.get("repo_path")
+            self.repo_path = os.path.expanduser(repo_path) if repo_path else None
+        else:
+            self.port = spec["ssh_port"]
+            self.host = HOST
+            _load_dotenv_into_env()
+            self.user = self._req_env(spec["user_env"])
+            self.password = self._req_env(spec["pass_env"])
+            self.repo_path = None
 
     @staticmethod
     def _req_env(key):
@@ -97,12 +149,21 @@ class VM:
             raise VMError(f"required env key {key!r} not set (check primary .env)")
         return val
 
+    def _require_vm(self, op):
+        """Guard a VirtualBox/VM-lifecycle op: stations have no such surface."""
+        if self.kind == "station":
+            raise StationLifecycleError(
+                f"{self.name!r} is a station (physical SSH host), not a "
+                f"VirtualBox guest — {op!r} is a VM-only operation")
+
     # --- lifecycle ---
     def up(self):
+        self._require_vm("up")
         vbox.ensure_running(self.name)
         return vbox.wait_for_ssh(self.host, self.port)
 
     def ensure_up(self):
+        self._require_vm("ensure_up")
         try:
             with socket.create_connection((self.host, self.port), timeout=3):
                 return None
@@ -110,6 +171,7 @@ class VM:
             return self.up()
 
     def down(self, graceful=True):
+        self._require_vm("down")
         vbox.power_off(self.name, graceful=graceful)
         self._invalidate()
 
@@ -128,6 +190,31 @@ class VM:
         import paramiko
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        if self.kind == "station":
+            # Key-auth via the SSH alias: paramiko does not read ssh_config on
+            # connect, so the alias's real HostName/Port/User/IdentityFile are
+            # resolved here (the single ssh_config read seam, HIMMEL-870).
+            cfg = paramiko.SSHConfig()
+            cfg.parse(io.StringIO(_read_ssh_config_text()))
+            resolved = cfg.lookup(self.host)
+            hostname = resolved.get("hostname", self.host)
+            port = int(resolved.get("port", 22))
+            user = resolved.get("user") or self.user
+            if not user:
+                raise VMError(
+                    f"station {self.name!r} (alias {self.host!r}) has no SSH user "
+                    f"— set 'user' in the vms.json registry entry or 'User' in the "
+                    f"~/.ssh/config Host block for {self.host!r}")
+            identityfiles = resolved.get("identityfile")
+            key_filename = os.path.expanduser(identityfiles[0]) if identityfiles else None
+            try:
+                client.connect(hostname=hostname, port=port, username=user,
+                               key_filename=key_filename, timeout=10)
+            except Exception as e:
+                raise VMError(
+                    f"ssh to station {self.name} (alias {self.host!r}) failed: {e}") from e
+            self._client = client
+            return client
         try:
             client.connect(hostname=self.host, port=self.port,
                            username=self.user, password=self.password, timeout=10)
@@ -170,16 +257,20 @@ class VM:
 
     # --- snapshots ---
     def snapshots(self):
+        self._require_vm("snapshots")
         return vbox.list_snapshots(self.name)
 
     def snapshot(self, name):
+        self._require_vm("snapshot")
         vbox.take_snapshot(self.name, name)
 
     def restore(self, name):
+        self._require_vm("restore")
         vbox.restore_snapshot(self.name, name)
         self._invalidate()
 
     def baseline(self, snap="clean"):
+        self._require_vm("baseline")
         if snap in self.snapshots():
             self.restore(snap)
             self.up()
@@ -231,6 +322,7 @@ class VM:
 
     # --- per-OS handlers (delegation) ---
     def provision(self):
+        self._require_vm("provision")
         root = _repo_root()
         env = {**os.environ, "PYTHONUTF8": "1"}
         if self.os == "ubuntu":
@@ -253,14 +345,25 @@ class VM:
         under Git Bash to avoid WSL bash and Windows-path mangling.
         """
         bash = GIT_BASH if sys.platform == "win32" else "bash"
-        key = os.path.expanduser("~/.ssh/id_ed25519").replace("\\", "/")
         local_fwd = str(local_root).replace("\\", "/")
         exclude_flags = " ".join(f"--exclude={e}" for e in excludes)
+        if self.kind == "station":
+            # Alias-only: hostname/port/identity come from ~/.ssh/config, same
+            # as ssh()'s resolution (HIMMEL-870) — no password, no -p/-i. When
+            # the registry supplies a user, pin it explicitly so this path
+            # can't silently auth as a different user than ssh()'s resolved
+            # user (registry user vs. ssh_config User could otherwise diverge).
+            target = f"{self.user}@{self.host}" if self.user else self.host
+            ssh_target = (f"-o BatchMode=yes -o StrictHostKeyChecking=accept-new "
+                          f"{target}")
+        else:
+            key = os.path.expanduser("~/.ssh/id_ed25519").replace("\\", "/")
+            ssh_target = (f"-p {self.port} -i {key} "
+                          f"-o BatchMode=yes -o StrictHostKeyChecking=accept-new "
+                          f"{self.user}@127.0.0.1")
         pipe = (
             f"tar czf - {exclude_flags} -C {local_fwd} . "
-            f"| ssh -p {self.port} -i {key} "
-            f"-o BatchMode=yes -o StrictHostKeyChecking=accept-new "
-            f"{self.user}@127.0.0.1 "
+            f"| ssh {ssh_target} "
             f"'mkdir -p {dest} && tar xzf - -C {dest}'"
         )
         argv = [bash, "-c", pipe]
@@ -525,6 +628,7 @@ class VM:
         return rc, out
 
     def run_e2e(self):
+        self._require_vm("e2e")
         if self.os != "ubuntu":
             raise NotImplementedError(
                 "run_e2e is Ubuntu-only today; no host-driven Windows e2e exists "


### PR DESCRIPTION
## Summary

Generalizes `scripts/lib/vmsdk.py` + `scripts/lib/vms.json` from VirtualBox-only to also cover **physical SSH stations** (HIMMEL-870) — the multi-machine orchestration enabler for win2 and future stations:

- Registry entries gain optional `kind: "station"`, `host` (SSH alias), `auth: "key"` — full back-compat: existing VM entries are byte-unchanged and behave exactly as before (loopback+port, password-env).
- The SSH-generic surface — `run()`, `trigger_claude()` (the HIMMEL-835 host→session trigger seam), `sync_repo()`, `drive_claude()`, `push_file()` — works for stations: `ssh()` resolves HostName/Port/User/IdentityFile from `~/.ssh/config` via paramiko's SSHConfig (paramiko doesn't read ssh_config itself), key auth, no password env. User resolution is explicit: config → registry fallback → clear `VMError` naming both places when neither supplies one; station `sync_repo()` pins `user@alias` when the registry carries a user.
- Lifecycle ops (`up/down/snapshot/restore/baseline/provision/run_e2e/ensure_up/snapshots`) stay VM-only — a station entry raises `StationLifecycleError(VMError)` naming the entry + op.
- `win2` added to the registry (station, key auth).

## CR trail

Panel + codex round 1: 2 Importants fixed (explicit user validation at connect; `user@alias` in station sync_repo); 1 qwen "missing `import io`" Critical DISPROVED by direct read (line 25, pre-existing import above the diff context — re-raised and re-disproved in round 2). Round-2 panel: 0 Critical / 0 sustained Important.

## Tests

`scripts/lib/test-vmsdk.py`: 87 tests OK (12 new hermetic `TestStation` tests — construction/back-compat, alias resolution with+without Host block, no-user clear error, lifecycle-op errors across all 9 ops, sync_repo command shapes, CLI exit-1). No real network.

## Provenance

GLM design seed (z.ai lane died on 529s) completed by Sonnet; parent-reviewed (Fable s29). Unlocks arming sessions on win2 via the same vmsdk surface as VMs (HIMMEL-852/862 track).
