### PR TITLE
fix(guardrails): [HIMMEL-876] block-edit-on-main exempts untracked+gitignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ logs/gemini/
 .himmel-dev
 # per-operator CR registry overlay (account quota state) — never commit (HIMMEL-727)
 scripts/cr/critics.local.json
+# machine-local grok tool-schema cache dir — never commit (HIMMEL-876)
+/mcps/

--- a/scripts/hooks/block-edit-on-main.sh
+++ b/scripts/hooks/block-edit-on-main.sh
@@ -28,6 +28,13 @@
 # The check is anchored to repo_real (the EDITED FILE's repo root), so a
 # marker in a parent repo cannot leak the opt-out onto a nested repo.
 #
+# Exemption: a file that is BOTH untracked AND gitignored is allowed,
+# regardless of branch — it cannot land in an on-main commit, so the block
+# would be a false positive (HIMMEL-876, e.g. the operator-local
+# scripts/cr/critics.local.json overlay). EXCEPT the secret-file class
+# (.env, keys, credentials — mirrored from block-read-secrets.sh): those
+# are gitignored BECAUSE they are sensitive, and stay denied.
+#
 # Hook input arrives on stdin as JSON. Exit codes:
 #   0 — allow (default for any non-blocking path)
 #   2 — block; stderr is shown to Claude and the user
@@ -221,6 +228,59 @@ elif [ "$branch_rc" -ne 0 ]; then
     exit 2
 else
     block_reason="main"
+fi
+
+# Secret-file class (HIMMEL-876 CR carve-out). MIRRORS is_secret_path() in
+# block-read-secrets.sh — that hook is the source of truth for this pattern
+# set; KEEP THE TWO LISTS IN SYNC when either changes. A secret file (.env,
+# keys, credentials) is typically gitignored precisely BECAUSE it is
+# sensitive machine-local state — exempting it below would let an unattended
+# Write clobber the REAL .env in the primary checkout, a trust-boundary
+# regression the pre-exemption hook incidentally prevented. Basename match,
+# path-prefix agnostic, globs only. The basename is lowercased BEFORE the
+# match (tr, bash-3.2-safe — no ${var,,}): git ls-files/check-ignore fold
+# case on Windows/macOS (core.ignorecase=true), so `.ENV` would otherwise
+# slip past these lowercase arms yet still read as ignored (matching .env)
+# and take the exemption — clobbering the real .env on a case-insensitive
+# filesystem. Case arms stay lowercase.
+is_secret_basename() {
+    local base="${1##*/}"
+    base=$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')
+    case "$base" in
+        # Non-secret env TEMPLATES (committed placeholders) — carved out
+        # BEFORE the .env.* secret arm, first-match-wins (same order as
+        # block-read-secrets.sh).
+        .env.example|.env.sample|.env.template|.env.dist) return 1 ;;
+        .env|.env.*|.envrc|id_rsa|id_ed25519|credentials.json|secrets.yaml|secrets.yml)
+            return 0 ;;
+        *.pem|*.key|*.p12|*.pfx)
+            return 0 ;;
+    esac
+    return 1
+}
+
+# Untracked + gitignored exemption (HIMMEL-876): the guard's purpose is
+# protecting TRACKED code from an on-main/primary-feature commit — a file
+# that is both untracked AND gitignored (e.g. the HIMMEL-727 operator-local
+# scripts/cr/critics.local.json overlay) can never end up in such a commit,
+# so blocking it is a false positive. Only exempt when BOTH hold: an
+# untracked-but-NOT-ignored file could still be `git add`ed and committed,
+# so that stays blocked. `ls-files --error-unmatch` rc=1 means untracked;
+# any other rc (0=tracked, >1=git error) skips the exemption and falls
+# through to the existing block below — fail CLOSED on any git-command
+# surprise, never allow on error. Short-circuited: this only runs once we
+# already know the edit would otherwise be denied.
+#
+# Secret-class carve-out: a file in the secret-file class above NEVER takes
+# this exemption, even when untracked+gitignored — it falls through to the
+# existing deny, preserving the incidental protection of the real .env /
+# keys in the primary checkout from unattended clobbering.
+if ! is_secret_basename "$file_real"; then
+    ls_rc=0
+    git -C "$repo_real" ls-files --error-unmatch -- "$file_real" >/dev/null 2>&1 || ls_rc=$?
+    if [ "$ls_rc" -eq 1 ] && git -C "$repo_real" check-ignore -q -- "$file_real" >/dev/null 2>&1; then
+        exit 0
+    fi
 fi
 
 # Both block reasons are "feature work in the PRIMARY checkout" (on main, or on

--- a/scripts/hooks/test-block-edit-on-main.sh
+++ b/scripts/hooks/test-block-edit-on-main.sh
@@ -354,6 +354,128 @@ assert_rc "T26 EDIT_ON_MAIN_OK=1 + marker present allows (env bypass wins)" 0 \
 assert_rc "T27 EDIT_ON_MAIN_OK=1 allows feature branch in primary (HIMMEL-507)" 0 \
     "$(rc_of "$SANDBOX/featrepo/foo.js" EDIT_ON_MAIN_OK=1)"
 
+# --- HIMMEL-876: untracked+gitignored exemption cases ---
+
+# T28: TRACKED file on main -> BLOCK, even when it also matches a .gitignore
+# pattern (force-added). Proves `ls-files --error-unmatch` (tracked) wins over
+# `check-ignore` — a tracked file is never exempted, since it CAN be committed.
+mkrepo "$SANDBOX/trackedrepo" main
+printf '*.local.json\n' > "$SANDBOX/trackedrepo/.gitignore"
+printf '{}\n' > "$SANDBOX/trackedrepo/tracked.local.json"
+git -C "$SANDBOX/trackedrepo" add -f .gitignore tracked.local.json
+git -C "$SANDBOX/trackedrepo" -c user.email=t@t -c user.name=t commit -q -m init
+assert_rc "T28 tracked file (even if gitignore-matching) on main blocks" 2 \
+    "$(rc_of "$SANDBOX/trackedrepo/tracked.local.json")"
+
+# T29: UNTRACKED + gitignored file on main -> ALLOW (the false-positive fix —
+# mirrors the real HIMMEL-876 case, scripts/cr/critics.local.json).
+mkrepo "$SANDBOX/ignoredrepo" main
+printf '*.local.json\n' > "$SANDBOX/ignoredrepo/.gitignore"
+git -C "$SANDBOX/ignoredrepo" add .gitignore
+git -C "$SANDBOX/ignoredrepo" -c user.email=t@t -c user.name=t commit -q -m init
+printf '{}\n' > "$SANDBOX/ignoredrepo/critics.local.json"
+assert_rc "T29 untracked+gitignored file on main allows (HIMMEL-876)" 0 \
+    "$(rc_of "$SANDBOX/ignoredrepo/critics.local.json")"
+
+# T30: UNTRACKED but NOT gitignored file on main (repo HAS a .gitignore, just
+# one that doesn't match this file) -> BLOCK. Could still be `git add`ed.
+printf '{}\n' > "$SANDBOX/ignoredrepo/plain.js"
+assert_rc "T30 untracked-but-not-ignored file on main blocks (HIMMEL-876)" 2 \
+    "$(rc_of "$SANDBOX/ignoredrepo/plain.js")"
+
+# T31: untracked+gitignored file on a FEATURE branch in the PRIMARY checkout
+# (block_reason=primary-feature) -> ALLOW. Proves the exemption covers both
+# block paths (mirrors T25's coverage of the .single-writer opt-out).
+mkrepo "$SANDBOX/ignoredfeatrepo" feat/x
+printf '*.local.json\n' > "$SANDBOX/ignoredfeatrepo/.gitignore"
+git -C "$SANDBOX/ignoredfeatrepo" add .gitignore
+git -C "$SANDBOX/ignoredfeatrepo" -c user.email=t@t -c user.name=t commit -q -m init
+printf '{}\n' > "$SANDBOX/ignoredfeatrepo/critics.local.json"
+assert_rc "T31 untracked+gitignored file on feature-branch primary allows (HIMMEL-876)" 0 \
+    "$(rc_of "$SANDBOX/ignoredfeatrepo/critics.local.json")"
+
+# T32: a git failure DURING the ls-files/check-ignore check (a stub `git` on
+# PATH that fails just those two subcommands, real git otherwise) -> fail
+# CLOSED (BLOCK). Uses ignoredrepo (has a real .gitignore match) to prove the
+# would-be-exempted case still blocks when the check itself errors.
+GITSTUB_BIN=$(mktemp -d)
+REAL_GIT=$(command -v git)
+cat > "$GITSTUB_BIN/git" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+    case "\$a" in
+        ls-files|check-ignore) exit 129 ;;
+    esac
+done
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$GITSTUB_BIN/git"
+assert_rc "T32 git failure during untracked/ignore check fails closed (HIMMEL-876)" 2 \
+    "$(rc_of "$SANDBOX/ignoredrepo/critics.local.json" PATH="$GITSTUB_BIN:$PATH")"
+rm -rf "$GITSTUB_BIN" 2>/dev/null || true
+
+# T33/T34: secret-class carve-out (HIMMEL-876 CR). An untracked+gitignored
+# file whose basename is in the block-read-secrets.sh secret set (.env,
+# id_ed25519, ...) NEVER takes the exemption — it stays BLOCKED on main,
+# preserving the incidental protection of the real .env in the primary
+# checkout from unattended clobbering.
+mkrepo "$SANDBOX/secretrepo" main
+printf '.env\nid_ed25519\n' > "$SANDBOX/secretrepo/.gitignore"
+git -C "$SANDBOX/secretrepo" add .gitignore
+git -C "$SANDBOX/secretrepo" -c user.email=t@t -c user.name=t commit -q -m init
+printf 'KEY=x\n' > "$SANDBOX/secretrepo/.env"
+printf 'key\n' > "$SANDBOX/secretrepo/id_ed25519"
+assert_rc "T33 untracked+gitignored .env on main still blocks (secret carve-out)" 2 \
+    "$(rc_of "$SANDBOX/secretrepo/.env")"
+assert_rc "T34 untracked+gitignored id_ed25519 on main still blocks (secret carve-out)" 2 \
+    "$(rc_of "$SANDBOX/secretrepo/id_ed25519")"
+
+# T35: the non-secret allow case (T29's critics.local.json shape) still
+# ALLOWS after the carve-out — the exemption itself is unchanged for the
+# operator-local-state class it was built for. Also locks the lowercase
+# fold in is_secret_basename: an already-lowercase non-secret basename
+# must be unaffected by the case-insensitivity fix.
+assert_rc "T35 untracked+gitignored critics.local.json still allows after carve-out" 0 \
+    "$(rc_of "$SANDBOX/ignoredrepo/critics.local.json")"
+
+# T36: stub ONLY check-ignore to fail (rc=128) while ls-files stays REAL and
+# returns rc=1 (untracked) -> must still BLOCK. Locks the &&-short-circuit
+# fail-closed guarantee: T32 fails ls-files first, so the check-ignore leg
+# of the conjunction was never actually reached by a test until now.
+CIONLY_BIN=$(mktemp -d)
+REAL_GIT=$(command -v git)
+cat > "$CIONLY_BIN/git" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+    case "\$a" in
+        check-ignore) exit 128 ;;
+    esac
+done
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$CIONLY_BIN/git"
+assert_rc "T36 check-ignore failure alone fails closed (ls-files real, HIMMEL-876)" 2 \
+    "$(rc_of "$SANDBOX/ignoredrepo/critics.local.json" PATH="$CIONLY_BIN:$PATH")"
+rm -rf "$CIONLY_BIN" 2>/dev/null || true
+
+# T37: mixed-case secret basenames (.ENV, ID_RSA) untracked, with a lowercase
+# gitignore, on main -> BLOCKED. On a case-INsensitive host (Windows/macOS,
+# core.ignorecase=true) check-ignore folds .ENV onto the '.env' ignore line,
+# so only the lowercased is_secret_basename carve-out denies; on a
+# case-SENSITIVE host (Linux CI) .ENV is simply not ignored and the
+# untracked-not-ignored fall-through denies. Either layer -> rc=2; the
+# assertion is deliberately layer-agnostic.
+mkrepo "$SANDBOX/casesecretrepo" main
+printf '.env\nid_rsa\n' > "$SANDBOX/casesecretrepo/.gitignore"
+git -C "$SANDBOX/casesecretrepo" add .gitignore
+git -C "$SANDBOX/casesecretrepo" -c user.email=t@t -c user.name=t commit -q -m init
+printf 'KEY=x\n' > "$SANDBOX/casesecretrepo/.ENV"
+printf 'key\n' > "$SANDBOX/casesecretrepo/ID_RSA"
+assert_rc "T37 untracked .ENV on main blocks (case-insensitive carve-out)" 2 \
+    "$(rc_of "$SANDBOX/casesecretrepo/.ENV")"
+assert_rc "T37b untracked ID_RSA on main blocks (case-insensitive carve-out)" 2 \
+    "$(rc_of "$SANDBOX/casesecretrepo/ID_RSA")"
+
 # Clean up the worktree registration before removing the sandbox (avoids a
 # dangling `git worktree` admin record under SANDBOX/wtrepo).
 git -C "$SANDBOX/wtrepo" worktree remove --force "$SANDBOX/wtrepo/.claude/worktrees/feat+x" 2>/dev/null || true


### PR DESCRIPTION
## HIMMEL-876 — block-edit-on-main exempts untracked+gitignored files (with a secrets-class carve-out)

The guard protects TRACKED code from on-main/primary-feature commits. A file that is BOTH untracked AND gitignored (e.g. the HIMMEL-727 operator-local `scripts/cr/critics.local.json` quota overlay) can never land in such a commit, so blocking it forced operator hand-apply of quota-state updates (s29, 2026-07-10).

### Behavior
- Exemption (narrow, fail-closed): `git ls-files --error-unmatch` rc==1 exactly (confirmed untracked) AND `git check-ignore -q` rc==0 (confirmed ignored) → allow. Tracked, untracked-not-ignored, or ANY git error → existing deny. Short-circuited: runs only when the edit would otherwise be denied.
- **Secrets-class carve-out** (round 2): a basename matching `block-read-secrets.sh`'s secret set (`.env`, `.envrc`, `id_rsa`, `id_ed25519`, `credentials.json`, `secrets.y[a]ml`, `*.pem/.key/.p12/.pfx`) never takes the exemption — an ignored `.env` on main stays write-protected.
- **Case-insensitive matching** (round 3): the basename is folded via `tr` before the match — `.ENV`/`ID_RSA` cannot bypass the carve-out on case-insensitive filesystems (Windows/macOS `core.ignorecase`).
- Also gitignores `/mcps/` (machine-local grok tool-schema cache, HIMMEL-843 bring-up).

### Tests
T28–T37b (51 total, 0 fail): tracked-wins-over-ignored; allow on main + on primary feature branch; untracked-not-ignored blocked; git-failure fail-closed (ls-files AND check-ignore legs separately); `.env`/`id_ed25519` blocked; `critics.local.json` allowed; mixed-case `.ENV`/`ID_RSA` blocked layer-agnostically. Shellcheck clean.

### CR trail (s30, 2026-07-10)
- Critic panel: 0/0.
- codex adversarial: 1 medium (blanket exemption covers `.env`) — **fixed** (round 2 carve-out); round-2 `code-reviewer` re-adjudicated: VERDICT disproved-after-fix, 0/0.
- `silent-failure-hunter`: 1 Critical (case-sensitivity bypass, reproduced) + 2 Important (T36/T37 coverage) — **all fixed** (round 3).
- Follow-up filed: HIMMEL-879 (same case-fold gap in `block-read-secrets.sh` + shared-predicate extraction).

Implemented by Sonnet (3 rounds); orchestration/adjudication Fable (s30).
