### PR TITLE
feat(setup): [HIMMEL-877] qmd installs from the himmel fork (clone+build+junction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ without any of it.
   `/archive-clips`. Turns a clip inbox into a self-maintaining knowledge base.
 - **[qmd](https://www.npmjs.com/package/@tobilu/qmd)** — a fast local search
   engine (BM25 + vector) over your markdown, exposed to Claude as an MCP server
-  (`qmd@qmd`); the standalone CLI installs via `bun add -g @tobilu/qmd`. This is
-  the retrieval layer over the substrate; it indexes the files, it does not
-  replace them (see above).
+  (`qmd@qmd`); the standalone CLI installs from himmel's qmd fork via
+  `bash scripts/lib/qmd-bin.sh install` (run automatically by setup/adopt).
+  This is the retrieval layer over the substrate; it indexes the files, it
+  does not replace them (see above).
 - **[claude-obsidian](https://github.com/yotamleo/claude-obsidian)** — a SHA-pinned
   fork of [AgriciDaniel/claude-obsidian](https://github.com/AgriciDaniel/claude-obsidian);
   skills for operating an Obsidian wiki vault: ingest, query, save, and **vault

--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -77,7 +77,7 @@ Every other script is bash 3.2-compatible.
 
 These tools show up in only one script — easy to drop if not on PATH (the affected feature degrades):
 
-- `cygpath` (Windows-only path translation) → `scripts/handover/arm-resume.sh` only.
+- `cygpath` (Windows-only path translation) → `scripts/handover/arm-resume.sh` and `scripts/lib/qmd-bin.sh` (junction creation, HIMMEL-877); falls back to the unconverted path when absent.
 - `shellcheck`, `gitleaks` → `scripts/machine-setup/ubuntu.sh` bootstrap only; pre-commit framework re-fetches them per-hook so they don't need to be on PATH for normal use.
 - `pipx` → fallback in `setup.sh` + `ubuntu.sh` only (uv is primary).
 - `qmd` → `setup.sh` step 4 only (collection register); optional if you don't use qmd search.
@@ -410,14 +410,23 @@ same PHI-tier refusal, but subtree-wide.
 qmd is a local markdown search engine (BM25 + vector + rerank). himmel's fork
 runs it as a **shared HTTP daemon** (`localhost:8181`, HIMMEL-592) auto-brought-up
 by the `qmd` plugin's SessionStart hook, so every session shares one read-only
-index. The standalone CLI is installed via **bun** (project rule: bun, never npm).
-`bash scripts/setup.sh` step `[4/10]` + `adopt.sh`'s `wire_qmd_core` already
-register the `himmel` collection and best-effort `qmd pull`; this section is the
-**manual bootstrap** if you skipped those or want the luna vault indexed too.
+index. The standalone CLI installs from the **himmel qmd fork**
+(`yotamleo/qmd#himmel-main`) — never upstream `bun add -g @tobilu/qmd`, which
+EPERM-wedges on this project's machines (zombie `qmd mcp` stdio processes hold
+locks) and bun blocks its postinstall script (HIMMEL-877). `bun` itself is
+still required to build the clone (project rule: bun, never npm — see §1
+foundational table). `bash scripts/setup.sh` step `[4/10]` + `adopt.sh`'s
+`wire_qmd_core` already run this install, register the `himmel` collection,
+and best-effort `qmd pull`; this section is the **manual bootstrap** if you
+skipped those or want the luna vault indexed too.
 
 ```bash
-# 1. Install the qmd CLI (bun global). bun itself: see §1 foundational table.
-bun add -g @tobilu/qmd@latest
+# 1. Install the qmd CLI: clone the fork, build it with bun, then junction
+#    (Windows) / symlink (POSIX) it onto the bun-global @tobilu/qmd path —
+#    scripts/lib/qmd-bin.sh is the single chokepoint (also used by adopt.sh/
+#    setup.sh); repo/branch/clone-dir are overridable via QMD_FORK_REPO /
+#    QMD_FORK_BRANCH / QMD_FORK_DIR. Idempotent — re-run to update.
+bash scripts/lib/qmd-bin.sh install
 
 # 2. Pull the embedding + rerank models. WARNING: ~2.1 GB download — Ctrl-C-safe
 #    (re-run resumes); run once. Semantic search needs these.

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -89,6 +89,16 @@ Installed via `extraKnownMarketplaces` in `settings.json`.
 **MCP server:** `plugin:qmd:qmd` — exposes `query`, `get`, `multi_get`, `status` tools.
 **Usage:** Searching local knowledge base, notes, docs.
 
+**CLI install (HIMMEL-877):** the standalone `qmd` CLI installs from the
+**himmel qmd fork** (`yotamleo/qmd#himmel-main`) via `scripts/lib/qmd-bin.sh`'s
+`qmd_install` (clone → `bun install && bun run build` → junction/symlink onto
+the bun-global `@tobilu/qmd` path) — never upstream `bun add -g @tobilu/qmd`,
+which EPERM-wedges on this project's machines and bun blocks its postinstall
+script. `adopt.sh`/`setup.sh` (bash) and `adopt.ps1`/`setup.ps1` (pwsh, which
+delegates via `bash scripts/lib/qmd-bin.sh install` rather than duplicating
+the recipe) both call this. Idempotent; overridable via `QMD_FORK_REPO` /
+`QMD_FORK_BRANCH` / `QMD_FORK_DIR`.
+
 **Shared HTTP singleton (HIMMEL-592):** himmel vendors `qmd@himmel`
 (`marketplace/plugins/qmd/`, a thin fork of upstream `qmd@qmd`) whose only
 delta is that the `qmd` MCP server is declared as an HTTP endpoint
@@ -358,10 +368,10 @@ metered per token, so the framing is "keep working past the cap", never
 |---|---|
 | `ANTHROPIC_BASE_URL` | `https://api.z.ai/api/anthropic` |
 | `ANTHROPIC_AUTH_TOKEN` | `$ZAI_API_KEY` |
-| `ANTHROPIC_MODEL` | `glm-5.2` |
+| `ANTHROPIC_MODEL` | `glm-5.2[1m]` |
 | `ANTHROPIC_DEFAULT_HAIKU_MODEL` | `glm-4.7` |
-| `ANTHROPIC_DEFAULT_SONNET_MODEL` | `glm-5.2` |
-| `ANTHROPIC_DEFAULT_OPUS_MODEL` | `glm-5.2` |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | `glm-5.2[1m]` |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL` | `glm-5.2[1m]` |
 | `CLAUDE_CONFIG_DIR` | `$HOME/.claude-glm` |
 
 **Key resolution:** shell env `ZAI_API_KEY` first, else the himmel repo `.env`
@@ -440,7 +450,7 @@ router (`ANTHROPIC_BASE_URL=http://127.0.0.1:$OMNIROUTE_PORT`, default port
 `20128`; host fixed — the router is loopback-only by charter), authenticates
 with a router-issued client key `OMNIROUTE_API_KEY` (shell env first, else the
 himmel repo `.env`; the Z.ai key never appears in this launcher), keeps the
-GLM tier-alias mapping (`glm-5.2`/`glm-4.7`), and seeds its own isolated
+GLM tier-alias mapping (`glm-5.2[1m]`/`glm-4.7`), and seeds its own isolated
 `$HOME/.claude-routed`. Guard config is **deliberately shared** with
 claude-glm at `~/.config/claude-glm/{phi-roots,egress-denylist}` — one guard
 source of truth across launcher lanes. A bare `ANTHROPIC_BASE_URL` export is
@@ -481,7 +491,7 @@ fresh git worktree + `glm/<slug>` branch, resolves the GLM env block
 -parity `ANTHROPIC_*` vars), runs the D2 egress guard (`glm-guard.ts`), composes
 the worker prompt with minted `outbox.jsonl` / `context.md` paths, and drives
 the run through the `runSession(…, lane:"glm")` seam in `run.ts`. GLM runs pin
-`--model opus` (→ `glm-5.2`) and ignore `TELEGRAM_CLAUDE_MODEL`. Sessions live
+`--model opus` (→ `glm-5.2[1m]`) and ignore `TELEGRAM_CLAUDE_MODEL`. Sessions live
 under `<BRIDGE_ROOT>/glm-sessions/` (default `~/.claude/handover/bridge/`) —
 **outside** the poller's `sessions/` tree, so nothing here is double-spawned or
 Telegram-flushed. A blocked worker can record a capability request and degrade

--- a/marketplace/plugins/qmd/README.md
+++ b/marketplace/plugins/qmd/README.md
@@ -54,7 +54,11 @@ silent empty index).
 
 ## Upstream watch
 
-The standalone `qmd` CLI (bun: `bun add -g @tobilu/qmd`) still updates
-independently; this fork only pins the plugin **manifest + skill**, which is
-low-churn. Re-sync `skills/qmd/` from `tobi/qmd` if the upstream search skill
-changes materially.
+The standalone `qmd` CLI now installs from himmel's own fork
+(`yotamleo/qmd#himmel-main`, cloned + built with bun, then junctioned/
+symlinked onto the bun-global `@tobilu/qmd` path — `scripts/lib/qmd-bin.sh`,
+HIMMEL-877), not `bun add -g @tobilu/qmd` upstream (that command EPERM-wedges
+on this project's machines and bun blocks its postinstall script). This
+plugin's **manifest + skill** stay pinned separately and are low-churn.
+Re-sync `skills/qmd/` from `tobi/qmd` if the upstream search skill changes
+materially; re-sync the CLI fork per `docs/setup/new-machine.md`.

--- a/marketplace/plugins/qmd/scripts/ensure-qmd-daemon.sh
+++ b/marketplace/plugins/qmd/scripts/ensure-qmd-daemon.sh
@@ -101,7 +101,7 @@ fi
 # ---- Dead: start the daemon ------------------------------------------------
 if ! QMD_BIN="$(resolve_qmd)"; then
   echo "ensure-qmd-daemon: ERROR - qmd is not installed / not on PATH." >&2
-  echo "  Install it: bun add -g @tobilu/qmd@latest" >&2
+  echo "  Install it: bash <himmel-repo>/scripts/lib/qmd-bin.sh install (HIMMEL-877)" >&2
   exit 1
 fi
 

--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -247,16 +247,20 @@ function FillEnv-Core {
 }
 
 # --- qmd resolver + helpers (HIMMEL-752; mirror of scripts/lib/qmd-bin.sh) ---
-# pwsh cannot source bash, so the resolver + install/register/pull logic is
-# duplicated inline (parity with setup.ps1's qmd block). UPDATE qmd-bin.sh +
-# setup.ps1 + adopt.ps1 together; scripts/lib/test-qmd-bin.sh is the canonical
-# behavior spec. Honors $env:BUN_INSTALL for relocated bun roots.
+# pwsh cannot source bash, so the RESOLVER (Invoke-Qmd/Test-Qmd) + REGISTER
+# logic is duplicated inline (parity with setup.ps1's qmd block) -- UPDATE
+# qmd-bin.sh + setup.ps1 + adopt.ps1 together; scripts/lib/test-qmd-bin.sh is
+# the canonical behavior spec. The INSTALL step (Install-Qmd below) is NOT
+# duplicated: it delegates to `bash scripts/lib/qmd-bin.sh install` (HIMMEL-877)
+# so the clone/build/junction recipe has exactly one implementation. Honors
+# $env:BUN_INSTALL for relocated bun roots.
 $QmdBunRoot = if ($env:BUN_INSTALL) { $env:BUN_INSTALL } else { Join-Path $HOME '.bun' }
 $QmdBunJs = Join-Path $QmdBunRoot 'install\global\node_modules\@tobilu\qmd\dist\cli\qmd.js'
-# G3 (HIMMEL-752): NO --ignore-scripts - it blocked better-sqlite3's native
-# build (prebuild-install || node-gyp rebuild --release) and crashed qmd on
-# platforms with no prebuilt binary (fresh macOS arm64 / new node major).
-$QmdInstallHint = 'bun add -g @tobilu/qmd@latest'
+# HIMMEL-877: qmd installs from the himmel qmd fork (yotamleo/qmd#himmel-main
+# via scripts/lib/qmd-bin.sh), never upstream `bun add -g @tobilu/qmd` --
+# that command EPERM-wedges on this project's machines and bun blocks its
+# postinstall script.
+$QmdInstallHint = "bash `"$HimmelRoot/scripts/lib/qmd-bin.sh`" install"
 
 function Invoke-Qmd {
     param([Parameter(ValueFromRemainingArguments=$true)] [string[]] $QmdArgs)
@@ -276,50 +280,45 @@ function Test-Qmd {
     return [bool](Get-Command qmd -ErrorAction SilentlyContinue)
 }
 
-# Mirror of qmd_install(): run the hint, verify --version, heal a missing
-# better-sqlite3 native build, return an honest int rc. All native output is
-# redirected away so the return value stays a clean int (Write-Host writes to
-# the host stream, not the pipeline).
+# Resolve GIT Bash explicitly for the qmd-bin.sh delegation -- same pattern
+# as FillEnv-Core below: a bare `bash` often resolves to the System32 (or
+# WindowsApps) WSL stub, which cannot run Git-Bash scripts against C:/...
+# paths. Require-Tools does NOT verify bash. Returns $null when no usable
+# Git Bash exists; callers WARN + skip, never invoke the WSL stub.
+function Resolve-QmdGitBash {
+    $gitBash = "C:\Program Files\Git\bin\bash.exe"
+    if (Test-Path $gitBash) { return $gitBash }
+    $bc = Get-Command bash -ErrorAction SilentlyContinue
+    if ($bc -and $bc.Source -notmatch 'System32|WindowsApps') { return $bc.Source }
+    return $null
+}
+
+# Delegates to the ONE clone/build/junction implementation (HIMMEL-877):
+# `bash scripts/lib/qmd-bin.sh install` (git-clone the himmel qmd fork, `bun
+# install && bun run build`, then junction/symlink it onto the bun-global
+# @tobilu/qmd path -- idempotent, WARN-not-fail). Returns an honest int rc.
 function Install-Qmd {
-    Write-Host "Installing qmd via bun..."
-    Invoke-Expression $script:QmdInstallHint *> $null
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "  bun add failed (exit $LASTEXITCODE) - qmd not installed." -ForegroundColor Yellow
-        return $LASTEXITCODE
-    }
-    # Verify the binary runs - a broken better-sqlite3 native build dies here
-    # even though the package is present.
-    Invoke-Qmd --version *> $null
-    if ($LASTEXITCODE -eq 0) {
-        Write-Host "  qmd installed and verified."
-        return 0
-    }
-    # Heal: rebuild better-sqlite3 in place, then re-verify (HIMMEL-752).
-    $bsqlite = Join-Path $script:QmdBunRoot 'install\global\node_modules\better-sqlite3'
-    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
-        # A missing npm would raise a terminating CommandNotFoundException under
-        # EAP='Stop' and abort adopt - check first, WARN, honest rc (CR fix).
-        Write-Host "  WARNING: npm not found - cannot rebuild better-sqlite3." -ForegroundColor Yellow
+    Write-Host "Installing qmd fork via bash scripts/lib/qmd-bin.sh..."
+    $gitBash = Resolve-QmdGitBash
+    if (-not $gitBash) {
+        Write-Host "  WARNING: Git Bash not found - cannot run the qmd fork installer." -ForegroundColor Yellow
+        Write-Host "  Manual: install Git for Windows, then run: bash `"$HimmelRoot/scripts/lib/qmd-bin.sh`" install" -ForegroundColor Yellow
         return 1
     }
-    if (Test-Path $bsqlite) {
-        Write-Host "  qmd present but --version failed - rebuilding better-sqlite3 native module..."
-        Push-Location $bsqlite
-        try { npm run build-release *> $null } finally { Pop-Location }
-        if ($LASTEXITCODE -eq 0) {
-            Invoke-Qmd --version *> $null
-            if ($LASTEXITCODE -eq 0) {
-                Write-Host "  qmd verified after native rebuild."
-                return 0
-            }
-            Write-Host "  WARNING: native rebuild ran but qmd --version still fails (exit $LASTEXITCODE)." -ForegroundColor Yellow
-        } else {
-            Write-Host "  WARNING: better-sqlite3 native build failed (need a compiler toolchain?)." -ForegroundColor Yellow
-        }
-    } else {
-        Write-Host "  WARNING: better-sqlite3 not found at $bsqlite - cannot heal." -ForegroundColor Yellow
-    }
-    return 1
+    & $gitBash "$HimmelRoot/scripts/lib/qmd-bin.sh" install
+    return $LASTEXITCODE
+}
+
+# Mirror of qmd_fork_served() via the shared bash CLI verb (HIMMEL-877 CR
+# codex-adv-1): the install gate is "fork already served", NOT presence
+# (Test-Qmd) -- a machine carrying the old upstream bun-global install is
+# qmd-present but must still MIGRATE to the fork. Returns $false when no
+# usable Git Bash exists so the install path (which re-checks) is attempted.
+function Test-QmdForkServed {
+    $gitBash = Resolve-QmdGitBash
+    if (-not $gitBash) { return $false }
+    & $gitBash "$HimmelRoot/scripts/lib/qmd-bin.sh" fork-served *> $null
+    return ($LASTEXITCODE -eq 0)
 }
 
 # Mirror of qmd_register_collection(): idempotent + WARN-not-fail, returns an
@@ -389,12 +388,24 @@ function Wire-QmdCoreInner {
             $ErrorActionPreference = $savedEAP
         }
     }
-    # Install the qmd CLI if missing. Install-Qmd verifies + heals (HIMMEL-752 G3).
+    # Install the qmd CLI unless the FORK is already the served install
+    # (HIMMEL-877 CR codex-adv-1): gate on Test-QmdForkServed, NOT presence
+    # (Test-Qmd) - a machine carrying the old upstream bun-global install is
+    # qmd-present but must still MIGRATE to the fork. Install-Qmd re-checks
+    # internally as the second line of defense.
     if ($DryRun) {
-        if (-not (Test-Qmd)) { Write-Host "DRY: Install-Qmd" }
-    } elseif (-not (Test-Qmd)) {
+        if (-not (Test-QmdForkServed)) { Write-Host "DRY: Install-Qmd" }
+    } elseif (-not (Test-QmdForkServed)) {
         $installRc = Install-Qmd
-        if ($installRc -ne 0) { Write-Host "  WARNING: qmd install failed (rc=$installRc) - continuing without qmd." -ForegroundColor Yellow }
+        if ($installRc -ne 0) {
+            Write-Host "  WARNING: qmd install failed (rc=$installRc) - continuing without qmd." -ForegroundColor Yellow
+        } elseif (-not (Test-Qmd)) {
+            # CR silent-divergence guard: the bash installer reported success
+            # but this pwsh session cannot resolve the install - name both
+            # facts + where to look instead of continuing silently.
+            Write-Host "  WARNING: qmd install reported success but qmd is still not resolvable from PowerShell." -ForegroundColor Yellow
+            Write-Host "  Inspect: $script:QmdBunJs (expected bun-global install path)." -ForegroundColor Yellow
+        }
     }
     # G4: pull models (~2.1 GB). Size caveat FIRST so the operator can Ctrl-C
     # before the download, then best-effort pull.

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -45,8 +45,8 @@ HIMMEL_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 . "$SCRIPT_DIR/lib/wire-pretooluse-hooks.sh"
 
 # qmd resolver + install/register helpers (HIMMEL-752 qmd wiring). Provides
-# has_qmd / qmd_cmd / qmd_install / qmd_register_collection, consumed by
-# wire_qmd_core() and do_luna().
+# has_qmd / qmd_cmd / qmd_install / qmd_fork_served / qmd_register_collection,
+# consumed by wire_qmd_core() and do_luna().
 # shellcheck source=scripts/lib/qmd-bin.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/qmd-bin.sh"
@@ -248,8 +248,9 @@ fill_env_core() {
 
 # wire_qmd_core — wire the qmd search stack end-to-end (HIMMEL-752 G1/G3/G4):
 # fix the broken plugin-cache stub, install the qmd CLI if missing (qmd_install
-# verifies the binary and heals a missing better-sqlite3 native build), pull the
-# embedding/rerank models, and register the himmel clone as a collection.
+# clones the himmel qmd fork, builds it with bun, and junctions/symlinks it
+# onto the bun-global @tobilu/qmd path -- HIMMEL-877), pull the embedding/rerank
+# models, and register the himmel clone as a collection.
 # Best-effort throughout: every failure WARNs and returns 0 so a missing or
 # broken qmd never aborts an adopt. Called from do_core() after install_plugins
 # (the qmd Claude plugin lands there; this makes the qmd CLI + models work).
@@ -269,10 +270,15 @@ wire_qmd_core() {
     bash "$HIMMEL_ROOT/scripts/lib/fix-qmd-stub.sh" \
       || echo "  WARNING: fix-qmd-stub failed — continuing." >&2
   fi
-  # Install the qmd CLI if missing. qmd_install verifies + heals (HIMMEL-752 G3).
+  # Install the qmd CLI unless the FORK is already the served install
+  # (clone the fork + build + link -- HIMMEL-877). The gate is
+  # qmd_fork_served, NOT has_qmd: a machine carrying the old upstream
+  # bun-global install is qmd-present but must still MIGRATE to the fork
+  # (CR codex-adv-1); qmd_install itself re-checks as the second line of
+  # defense and backs the upstream directory up before linking.
   if [[ $DRY_RUN -eq 1 ]]; then
-    has_qmd || echo "DRY: qmd_install"
-  elif ! has_qmd; then
+    qmd_fork_served || echo "DRY: qmd_install"
+  elif ! qmd_fork_served; then
     qmd_install || echo "  WARNING: qmd install failed — continuing without qmd." >&2
   fi
   # G4: pull the embedding/rerank models. Size caveat FIRST so the operator can

--- a/scripts/lib/fix-qmd-stub.sh
+++ b/scripts/lib/fix-qmd-stub.sh
@@ -161,7 +161,7 @@ if [ "$BUN_QMD_NO_BUN" -eq 1 ]; then
 else
   echo "qmd: not found (plugin dist missing; no bun global install; nothing else on PATH)." >&2
 fi
-echo "Install: bun add -g @tobilu/qmd@latest" >&2
+echo "Install: bash <himmel-repo>/scripts/lib/qmd-bin.sh install (or re-run adopt.sh/setup.sh -- HIMMEL-877)" >&2
 exit 127
 STUB
   then

--- a/scripts/lib/qmd-bin.sh
+++ b/scripts/lib/qmd-bin.sh
@@ -17,70 +17,342 @@
 # source this lib; this resolver stays as the consumer-side path until
 # the upstream plugin fix is pulled.
 #
-# Project rule: qmd is installed via bun, never npm. Bash callers get
-# the install hint via qmd_install_hint() (single source of truth for
-# bash); qmd_install() runs that hint, verifies the binary actually
-# works, and heals a missing better-sqlite3 native build (HIMMEL-752:
-# the old --ignore-scripts hint blocked better-sqlite3's native build
-# and crashed qmd on platforms without a prebuilt binary, so the hint
-# no longer carries it). qmd_register_collection() is the shared
-# idempotent collection-registration helper used by setup.sh + adopt.sh.
-# The pwsh mirrors in scripts/setup.ps1 + scripts/adopt.ps1, and the
-# bash stub-error hint line in scripts/lib/fix-qmd-stub.sh, hardcode
-# the same string and must be updated in lockstep.
+# HIMMEL-877: qmd installs from the himmel FORK (yotamleo/qmd, default
+# branch himmel-main), never upstream `bun add -g @tobilu/qmd` -- that
+# command EPERM-wedges on this project's machines (zombie `qmd mcp` stdio
+# node processes hold locks) and bun blocks the postinstall script. The
+# proven recipe (done by hand on the primary machine, now automated here):
+# clone the fork to a stable dir, `bun install && bun run build` in the
+# clone, then a directory junction (Windows) / symlink (POSIX) at
+# ~/.bun/install/global/node_modules/@tobilu/qmd pointing at the clone --
+# bun's stock global shims then transparently serve the fork from the
+# same path every other consumer (qmd_cmd, has_qmd, the fix-qmd-stub
+# patched stub) already resolves. qmd_install() is idempotent: it detects
+# an already-fork-served install (global path already links to the fork
+# clone AND `qmd --version` reports >= QMD_FORK_MIN_VERSION) and skips.
+# Fork repo/branch/clone-dir are overridable via QMD_FORK_REPO /
+# QMD_FORK_BRANCH / QMD_FORK_DIR for testing or a private mirror.
+# qmd_register_collection() is the shared idempotent collection-
+# registration helper used by setup.sh + adopt.sh. Executed directly
+# (not sourced), this file also answers `install` on argv (see the CLI
+# entry at the bottom) so the pwsh mirrors (scripts/setup.ps1,
+# scripts/adopt.ps1) can delegate to this ONE implementation instead of
+# duplicating the clone/build/link recipe natively.
 
+# Fork config -- overridable per call (env var set before sourcing/calling).
+_qmd_fork_repo() { printf '%s\n' "${QMD_FORK_REPO:-https://github.com/yotamleo/qmd.git}"; }
+_qmd_fork_branch() { printf '%s\n' "${QMD_FORK_BRANCH:-himmel-main}"; }
+_qmd_fork_dir() { printf '%s\n' "${QMD_FORK_DIR:-$HOME/.himmel/qmd-fork}"; }
+_qmd_fork_min_version() { printf '%s\n' "${QMD_FORK_MIN_VERSION:-2.6.3}"; }
+
+# Prints the manual recipe (clone + build + link). Best-effort documentation
+# text embedded in WARN messages -- NOT eval'd (HIMMEL-877 dropped the old
+# single-command `bun add -g @tobilu/qmd@latest` eval path; qmd_install()
+# below runs the multi-step recipe directly).
 qmd_install_hint() {
-  echo 'bun add -g @tobilu/qmd@latest'
+  local fork_dir branch global_dir
+  fork_dir="$(_qmd_fork_dir)"
+  branch="$(_qmd_fork_branch)"
+  global_dir="$(_qmd_global_dir)"
+  printf '%s\n' \
+    "git clone -b $branch $(_qmd_fork_repo) $fork_dir" \
+    "(cd $fork_dir && bun install && bun run build)" \
+    "link $fork_dir over $global_dir (Windows: mklink /J; POSIX: ln -s) -- or re-run qmd_install"
 }
 
-# Install qmd via the canonical hint, then verify the binary actually
-# runs. Returns an honest rc: 0 ONLY when `qmd_cmd --version` succeeds.
-# HIMMEL-752: the old `--ignore-scripts` hint blocked better-sqlite3's
-# native build (its install script is `prebuild-install || node-gyp
-# rebuild --release`), so on machines with no prebuilt binary (fresh
-# macOS arm64 / new node major) every qmd command died with "Could not
-# locate the bindings file". The hint now runs the full install; if the
-# postinstall was skipped (bun does this for untrusted packages) or a
-# prebuild is missing, fall back to a node-gyp build-release inside the
-# better-sqlite3 dir, then re-verify. WARN-not-fail by contract: the
-# rc is honest, callers (adopt.sh, ubuntu.sh) decide whether
-# a qmd failure aborts. Every external command is under an `if` guard so
-# a caller's `set -e` cannot abort mid-install before the rc is returned.
-qmd_install() {
-  local bun_root _bsqlite
-  echo "Installing qmd via bun..."
-  # Run the canonical hint command (single source of truth; a trusted
-  # hardcoded literal, so eval is safe here - never feed it untrusted input).
-  if ! eval "$(qmd_install_hint)"; then
-    echo "  bun add failed - qmd not installed." >&2
-    return 1
+# True on Git Bash / MSYS / Cygwin.
+_qmd_is_windows() {
+  case "$(uname -s 2>/dev/null || echo)" in
+    MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Windows-native absolute path for a POSIX path, for native tools (mklink,
+# fsutil) invoked via cmd. Falls back to the input unchanged when cygpath is
+# unavailable.
+_qmd_win_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w -- "$1" 2>/dev/null || printf '%s\n' "$1"
+  else
+    printf '%s\n' "$1"
   fi
-  # Verify the binary actually runs. has_qmd is presence-only by design,
-  # so probe --version directly: a broken better-sqlite3 native build
-  # (missing bindings file) dies here even though the package is present.
-  if qmd_cmd --version >/dev/null 2>&1; then
-    echo "  qmd installed and verified."
+}
+
+# Canonical form of an EXISTING directory, comparable across a Windows
+# junction traversal: `cd + pwd -P` resolves the reparse point, but MSYS can
+# print the result through a different mount-table alias than a direct `cd`
+# to the same real location (e.g. .../AppData/Local/Temp/... resolving as
+# /tmp/... through a junction but /c/Users/.../Temp/... directly) -- the two
+# forms are NOT string-equal even though they name the same directory.
+# cygpath -w normalizes both back to one Windows path, which is alias-free.
+# POSIX has no such aliasing, so plain `pwd -P` is enough there.
+_qmd_canonical_dir() {
+  local real
+  real="$(cd -- "$1" 2>/dev/null && pwd -P)" || return 1
+  [ -n "$real" ] || return 1
+  if _qmd_is_windows; then
+    _qmd_win_path "$real"
+  else
+    printf '%s\n' "$real"
+  fi
+}
+
+# True if the bun-global @tobilu/qmd path already resolves to the fork clone
+# dir (both must exist). The core of qmd_install()'s idempotency check.
+_qmd_global_points_to_fork() {
+  local global_dir fork_dir g f
+  global_dir="$(_qmd_global_dir)"
+  fork_dir="$(_qmd_fork_dir)"
+  [ -d "$global_dir" ] || return 1
+  [ -d "$fork_dir" ] || return 1
+  g="$(_qmd_canonical_dir "$global_dir")" || return 1
+  f="$(_qmd_canonical_dir "$fork_dir")" || return 1
+  [ -n "$g" ] && [ "$g" = "$f" ]
+}
+
+# $1 >= $2 for dotted version strings (e.g. "2.6.3" >= "2.6.3"). $1 may carry
+# a prefix/suffix (e.g. "qmd 2.6.10 (himmel-main)") -- the first x.y.z run is
+# extracted. bash-3.2-safe (no arrays, no [[ =~ ]] version-compare builtin).
+_qmd_version_ge() {
+  local actual min a1 a2 a3 m1 m2 m3 _save_ifs
+  actual="$(printf '%s' "$1" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
+  [ -n "$actual" ] || return 1
+  min="$2"
+  _save_ifs="$IFS"
+  IFS=.
+  # shellcheck disable=SC2086
+  # Unquoted on purpose: IFS=. splits the dotted version into 3 fields.
+  set -- $actual
+  a1="$1"; a2="$2"; a3="$3"
+  # shellcheck disable=SC2086
+  set -- $min
+  m1="$1"; m2="$2"; m3="$3"
+  IFS="$_save_ifs"
+  [ "$a1" -gt "$m1" ] 2>/dev/null && return 0
+  [ "$a1" -lt "$m1" ] 2>/dev/null && return 1
+  [ "$a2" -gt "$m2" ] 2>/dev/null && return 0
+  [ "$a2" -lt "$m2" ] 2>/dev/null && return 1
+  [ "$a3" -ge "$m3" ] 2>/dev/null
+}
+
+# True if $1 is a symlink (POSIX) or a Windows directory junction / reparse
+# point. Read-only probe -- never mutates.
+_qmd_is_link() {
+  [ -L "$1" ] && return 0
+  if _qmd_is_windows && [ -d "$1" ]; then
+    MSYS_NO_PATHCONV=1 fsutil reparsepoint query "$(_qmd_win_path "$1")" >/dev/null 2>&1
+    return $?
+  fi
+  return 1
+}
+
+# Remove a CONFIRMED link, never the directory it points at: Windows'
+# native rmdir on a junction deletes only the reparse point (verified --
+# the target's contents survive); `rm -f` on a POSIX symlink is likewise
+# link-only. Never call this on a real (non-link) directory. On failure the
+# tool's output is captured in _QMD_LINK_ERR for the caller's ERROR message
+# (CR: >/dev/null swallowed the actionable rmdir/mklink diagnostics).
+_qmd_remove_link() {
+  if _qmd_is_windows; then
+    _QMD_LINK_ERR=$(MSYS_NO_PATHCONV=1 cmd /c rmdir "$(_qmd_win_path "$1")" 2>&1)
+  else
+    _QMD_LINK_ERR=$(rm -f -- "$1" 2>&1)
+  fi
+}
+
+# Create a directory junction ($2 -> $1 on Windows) or a symlink (POSIX).
+# $1 = target (the fork clone), $2 = link path (the bun-global @tobilu/qmd
+# dir). On failure the tool's output is captured in _QMD_LINK_ERR.
+_qmd_link() {
+  if _qmd_is_windows; then
+    _QMD_LINK_ERR=$(MSYS_NO_PATHCONV=1 cmd /c mklink /J "$(_qmd_win_path "$2")" "$(_qmd_win_path "$1")" 2>&1)
+  else
+    _QMD_LINK_ERR=$(ln -s -- "$1" "$2" 2>&1)
+  fi
+}
+
+# Deterministic backup name for an existing REAL directory at $1: never a
+# timestamp (non-reproducible, hard to assert on in tests) -- a fixed
+# `.pre-fork-backup` suffix, numbered on collision from a prior aborted run.
+_qmd_backup_name() {
+  local base="$1.pre-fork-backup" n
+  if [ ! -e "$base" ]; then
+    printf '%s\n' "$base"
     return 0
   fi
-  # Heal: bun may skip the postinstall for untrusted packages, and the
-  # better-sqlite3 prebuild may be missing on a new platform. Build the
-  # native module in place, then re-verify (HIMMEL-752).
-  bun_root="${BUN_INSTALL:-$HOME/.bun}"
-  _bsqlite="$bun_root/install/global/node_modules/better-sqlite3"
-  if [ -d "$_bsqlite" ]; then
-    echo "  qmd present but --version failed - rebuilding better-sqlite3 native module..."
-    if (cd "$_bsqlite" && npm run build-release) >/dev/null 2>&1; then
-      if qmd_cmd --version >/dev/null 2>&1; then
-        echo "  qmd verified after native rebuild."
-        return 0
+  n=1
+  while [ -e "$base.$n" ]; do
+    n=$((n + 1))
+  done
+  printf '%s\n' "$base.$n"
+}
+
+# Point the bun-global @tobilu/qmd path at the fork clone. Idempotent
+# (no-ops if already correct). A stale link (wrong target) is removed
+# outright (link-only, safe); a REAL pre-existing directory is moved aside
+# under a deterministic backup name first -- it is NEVER deleted, and on a
+# link failure it is RESTORED (CR rollback: the failure mode this recipe
+# exists for -- a locked path held by zombie `qmd mcp` processes -- must
+# not leave the global path ABSENT with the old install stranded in the
+# backup dir).
+_qmd_ensure_global_link() {
+  local fork_dir global_dir global_parent backup=""
+  fork_dir="$(_qmd_fork_dir)"
+  global_dir="$(_qmd_global_dir)"
+  global_parent="$(dirname -- "$global_dir")"
+
+  if _qmd_global_points_to_fork; then
+    return 0
+  fi
+
+  # Surface a parent-dir mkdir failure as the root cause instead of the
+  # generic link error it would otherwise cascade into (CR).
+  if ! mkdir -p -- "$global_parent" 2>/dev/null; then
+    echo "  ERROR: could not create $global_parent (permissions?) - cannot link the fork." >&2
+    return 1
+  fi
+
+  if [ -e "$global_dir" ] || [ -L "$global_dir" ]; then
+    if _qmd_is_link "$global_dir"; then
+      echo "  Removing stale link at $global_dir..."
+      if ! _qmd_remove_link "$global_dir"; then
+        echo "  ERROR: could not remove stale link at $global_dir${_QMD_LINK_ERR:+: $_QMD_LINK_ERR}" >&2
+        return 1
       fi
-      echo "  WARNING: native rebuild ran but qmd --version still fails." >&2
     else
-      echo "  WARNING: better-sqlite3 native build failed (need a compiler toolchain?)." >&2
+      backup="$(_qmd_backup_name "$global_dir")"
+      echo "  Existing real directory at $global_dir - moving aside to $backup" >&2
+      if ! mv -- "$global_dir" "$backup"; then
+        echo "  ERROR: could not move aside existing $global_dir" >&2
+        return 1
+      fi
+    fi
+  fi
+
+  if ! _qmd_link "$fork_dir" "$global_dir"; then
+    echo "  ERROR: failed to link $global_dir -> $fork_dir${_QMD_LINK_ERR:+: $_QMD_LINK_ERR}" >&2
+    # Rollback: put the moved-aside directory back so the machine is no
+    # worse off than before this attempt (the old install keeps resolving).
+    if [ -n "$backup" ]; then
+      if mv -- "$backup" "$global_dir"; then
+        echo "  Restored the previous directory at $global_dir (no change applied)." >&2
+      else
+        echo "  ERROR: restore ALSO failed - your previous install is stranded at:" >&2
+        echo "         $backup" >&2
+        echo "         move it back by hand to: $global_dir" >&2
+      fi
+    fi
+    return 1
+  fi
+  if [ -n "$backup" ]; then
+    echo "  Note: previous @tobilu/qmd install preserved at $backup - remove it once the fork install is confirmed."
+  fi
+  return 0
+}
+
+# True when the fork is already the SERVED install: the bun-global
+# @tobilu/qmd path resolves to the fork clone AND the version probe reports
+# >= QMD_FORK_MIN_VERSION. This is the caller-side install gate (HIMMEL-877
+# CR codex-adv-1): callers must gate qmd_install on THIS, never on presence
+# (has_qmd) -- a machine carrying the old upstream bun-global install (the
+# exact population this change migrates) is qmd-PRESENT but not fork-served,
+# and a presence gate would skip the migration entirely. Also exposed as the
+# `fork-served` CLI verb so the pwsh mirrors share the same predicate.
+qmd_fork_served() {
+  local ver
+  _qmd_global_points_to_fork || return 1
+  ver="$(qmd_cmd --version 2>/dev/null)" || return 1
+  _qmd_version_ge "$ver" "$(_qmd_fork_min_version)"
+}
+
+# Install/update the qmd fork and serve it from the bun-global @tobilu/qmd
+# path (HIMMEL-877). Returns an honest rc: 0 ONLY when `qmd_cmd --version`
+# verifiably succeeds afterward. WARN-not-fail by contract -- callers
+# (adopt.sh/adopt.ps1, setup.sh/setup.ps1, ubuntu.sh) decide whether a qmd
+# failure aborts. Every external command is under an `if`/`&&` guard so a
+# caller's `set -e` cannot abort mid-install before the rc is returned.
+#
+# Idempotent: skips cleanly when qmd_fork_served (global path already links
+# to the fork clone AND the version probe passes); still falls through to
+# update+rebuild+re-link on a stale/older clone.
+qmd_install() {
+  local fork_dir branch repo global_dir origin_url
+
+  fork_dir="$(_qmd_fork_dir)"
+  branch="$(_qmd_fork_branch)"
+  repo="$(_qmd_fork_repo)"
+  global_dir="$(_qmd_global_dir)"
+
+  if qmd_fork_served; then
+    echo "  qmd fork already installed and served ($(qmd_cmd --version 2>/dev/null)) - skipping."
+    return 0
+  fi
+
+  echo "Installing qmd fork ($repo#$branch)..."
+
+  if ! command -v git >/dev/null 2>&1; then
+    echo "  git not found - cannot clone the qmd fork." >&2
+    return 1
+  fi
+  if ! command -v bun >/dev/null 2>&1; then
+    echo "  bun not found - cannot build the qmd fork." >&2
+    return 1
+  fi
+
+  if [ -d "$fork_dir/.git" ]; then
+    # HIMMEL-877 CR codex-adv-2: never hard-reset a repo the installer does
+    # not own. QMD_FORK_DIR is operator-overridable -- pointed at an
+    # unrelated working repo, the fetch/checkout/reset below would DESTROY
+    # its local changes. Refuse (WARN + nonzero, dir untouched) unless the
+    # clone's origin matches QMD_FORK_REPO; refuse a dirty worktree too,
+    # overridable only via QMD_FORK_FORCE=1.
+    origin_url="$(git -C "$fork_dir" remote get-url origin 2>/dev/null)"
+    if [ "$origin_url" != "$repo" ]; then
+      echo "  WARNING: $fork_dir exists but its origin ('$origin_url') is not $repo - refusing to touch it." >&2
+      echo "  Point QMD_FORK_DIR at a dedicated location, or fix the clone's origin remote." >&2
+      return 1
+    fi
+    if [ -n "$(git -C "$fork_dir" status --porcelain 2>/dev/null)" ] && [ "${QMD_FORK_FORCE:-0}" != "1" ]; then
+      echo "  WARNING: $fork_dir has uncommitted changes - refusing to hard-reset it." >&2
+      echo "  Commit/stash them, or re-run with QMD_FORK_FORCE=1 to discard them." >&2
+      return 1
+    fi
+    echo "  qmd fork clone exists at $fork_dir - updating $branch..."
+    if ! ( cd "$fork_dir" \
+           && git fetch origin "$branch" \
+           && git checkout "$branch" \
+           && git reset --hard "origin/$branch" ); then
+      echo "  WARNING: qmd fork fetch/checkout failed - building the existing clone contents as-is." >&2
     fi
   else
-    echo "  WARNING: better-sqlite3 not found at $_bsqlite - cannot heal." >&2
+    if ! mkdir -p -- "$(dirname -- "$fork_dir")"; then
+      echo "  ERROR: could not create $(dirname -- "$fork_dir")" >&2
+      return 1
+    fi
+    if ! git clone --depth 1 --branch "$branch" --single-branch "$repo" "$fork_dir"; then
+      echo "  qmd fork clone failed." >&2
+      return 1
+    fi
   fi
+
+  echo "  Building qmd fork (bun install && bun run build)..."
+  if ! ( cd "$fork_dir" && bun install && bun run build ); then
+    echo "  WARNING: qmd fork build failed - continuing without qmd." >&2
+    echo "  Manual: (cd $fork_dir && bun install && bun run build)" >&2
+    return 1
+  fi
+
+  if ! _qmd_ensure_global_link; then
+    echo "  WARNING: qmd fork built but could not be linked at $global_dir." >&2
+    return 1
+  fi
+
+  if qmd_cmd --version >/dev/null 2>&1; then
+    echo "  qmd fork installed and verified ($(qmd_cmd --version 2>/dev/null))."
+    return 0
+  fi
+  echo "  WARNING: qmd fork installed but --version still fails." >&2
   return 1
 }
 
@@ -125,6 +397,14 @@ _qmd_bun_js() {
   echo "$bun_root/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
 }
 
+# Resolve the bun-global @tobilu/qmd package DIRECTORY (parent of dist/cli/
+# qmd.js above) -- this is the path qmd_install() junctions/symlinks onto
+# the fork clone so bun's stock global shims serve it.
+_qmd_global_dir() {
+  local bun_root="${BUN_INSTALL:-$HOME/.bun}"
+  echo "$bun_root/install/global/node_modules/@tobilu/qmd"
+}
+
 qmd_cmd() {
   local bun_qmd
   bun_qmd="$(_qmd_bun_js)"
@@ -148,3 +428,18 @@ has_qmd() {
   fi
   command -v qmd >/dev/null 2>&1
 }
+
+# CLI entry -- only when EXECUTED (not sourced). Lets the pwsh mirrors
+# (scripts/setup.ps1, scripts/adopt.ps1) delegate to this ONE
+# implementation (`bash scripts/lib/qmd-bin.sh install`) instead of
+# duplicating the fork clone/build/link recipe natively (HIMMEL-877).
+if [ "${BASH_SOURCE[0]:-}" = "${0:-}" ]; then
+  case "${1:-}" in
+    install) qmd_install ;;
+    # fork-served: rc 0 iff the fork is already the served install (the
+    # caller-side install gate -- see qmd_fork_served above). Lets the pwsh
+    # mirrors share the bash predicate instead of duplicating it.
+    fork-served) qmd_fork_served ;;
+    *) echo "Usage: bash scripts/lib/qmd-bin.sh install|fork-served" >&2; exit 2 ;;
+  esac
+fi

--- a/scripts/lib/test-fix-qmd-stub.sh
+++ b/scripts/lib/test-fix-qmd-stub.sh
@@ -397,7 +397,7 @@ echo "[test-fix-qmd-stub] patched stub — nothing available => rc=127 + hint"
 rc=0
 errout="$(HOME="$tmpdir" BUN_INSTALL='' PATH="$verdir/bin:/usr/bin:/bin" "$verdir/bin/qmd" --version 2>&1 >/dev/null)" || rc=$?
 assert "rc=127 when no qmd available" test "$rc" -eq 127
-assert "error mentions bun install hint" grep -q 'bun add -g @tobilu/qmd' <<<"$errout"
+assert "error mentions the qmd-bin.sh install hint" grep -q 'qmd-bin.sh install' <<<"$errout"
 
 echo "[test-fix-qmd-stub] consumer integration — setup scripts invoke the fixer"
 repo_root="$(cd "$SCRIPT_DIR/../.." && pwd)"

--- a/scripts/lib/test-qmd-bin.sh
+++ b/scripts/lib/test-qmd-bin.sh
@@ -27,13 +27,15 @@ assert() {
   fi
 }
 
-echo "[test-qmd-bin] qmd_install_hint emits bun command"
+echo "[test-qmd-bin] qmd_install_hint emits the fork clone+build+link recipe (HIMMEL-877)"
 hint="$(qmd_install_hint)"
-assert "hint mentions bun add" grep -q '^bun add ' <<<"$hint"
-assert "hint mentions @tobilu/qmd" grep -q '@tobilu/qmd' <<<"$hint"
+assert "hint mentions git clone" grep -q '^git clone ' <<<"$hint"
+assert "hint mentions the himmel fork repo" grep -q 'yotamleo/qmd' <<<"$hint"
+assert "hint mentions the himmel-main branch" grep -q 'himmel-main' <<<"$hint"
+assert "hint mentions bun install/build" grep -q 'bun install && bun run build' <<<"$hint"
 # shellcheck disable=SC2016
 # Single quotes intentional — $1 expands inside the spawned bash -c subshell.
-assert "hint does NOT mention npm" bash -c '! grep -q "npm install" <<<"$1"' _ "$hint"
+assert "hint does NOT mention upstream bun add -g" bash -c '! grep -q "bun add -g" <<<"$1"' _ "$hint"
 
 echo "[test-qmd-bin] qmd_cmd resolver — prefer bun"
 tmpdir="$(mktemp -d)"
@@ -109,10 +111,11 @@ rc=0
 HOME="$tmpdir" PATH="$tmpdir/bin:$PATH" BUN_INSTALL="$tmpdir/custom-bun" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_cmd --version' >/dev/null 2>&1 || rc=$?
 assert "wrapped command rc=42 propagates" test "$rc" -eq 42
 
-echo "[test-qmd-bin] qmd_install_hint drops --ignore-scripts (HIMMEL-752 G3)"
-# shellcheck disable=SC2016
-# Single quotes intentional - $1 expands inside the spawned bash -c subshell.
-assert "hint does NOT contain --ignore-scripts" bash -c '! grep -q -- "--ignore-scripts" <<<"$1"' _ "$(qmd_install_hint)"
+echo "[test-qmd-bin] QMD_FORK_REPO / QMD_FORK_BRANCH / QMD_FORK_DIR overrides (HIMMEL-877)"
+override_hint="$(QMD_FORK_REPO=https://example.test/mirror/qmd.git QMD_FORK_BRANCH=my-branch QMD_FORK_DIR=/custom/fork/dir qmd_install_hint)"
+assert "hint honors QMD_FORK_REPO override" grep -q 'example.test/mirror/qmd.git' <<<"$override_hint"
+assert "hint honors QMD_FORK_BRANCH override" grep -q 'my-branch' <<<"$override_hint"
+assert "hint honors QMD_FORK_DIR override" grep -q '/custom/fork/dir' <<<"$override_hint"
 
 echo "[test-qmd-bin] has_qmd is presence-only (does not invoke binary)"
 # Make the bun-js path point at a broken/empty script that would error on run.
@@ -122,56 +125,252 @@ rc=0
 HOME="$tmpdir" PATH="$tmpdir/bin:$PATH" BUN_INSTALL="$tmpdir/broken-bun" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; has_qmd' || rc=$?
 assert "has_qmd=true even when bun-js is broken (presence only)" test "$rc" -eq 0
 
-echo "[test-qmd-bin] qmd_install() happy / heal / honest-fail (HIMMEL-752 G3)"
-# Hermetic stub env: a fake `bun` (tells 'add' apart from a qmd run by $1),
-# a fake `npm` (drops a heal marker), a fake qmd.js so qmd_cmd resolves via bun,
-# and a better-sqlite3 dir for the heal path. Lives under $tmpdir so the EXIT
-# trap cleans it. Stubs read behavior from env vars so one env covers all paths.
+echo "[test-qmd-bin] qmd_install() fork clone+build+link recipe (HIMMEL-877)"
+# Hermetic stub env: a fake `git` (clone creates a .git marker + package.json;
+# fetch/checkout/reset are individually controllable) and a fake `bun`
+# (install/run-build individually controllable; any other invocation is the
+# qmd_cmd dispatch `bun <qmd.js> --version`, which prints a fake version).
+# Both stubs append every call to a log file so tests can assert on call
+# counts (e.g. the idempotent-skip case must invoke NEITHER). Lives under
+# $tmpdir so the EXIT trap cleans it up.
 id2="$tmpdir/install"
-mkdir -p "$id2/bin" "$id2/.bun/install/global/node_modules/@tobilu/qmd/dist/cli" \
-         "$id2/.bun/install/global/node_modules/better-sqlite3"
-: > "$id2/.bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
+mkdir -p "$id2/bin"
+cat > "$id2/bin/git" <<'STUB'
+#!/usr/bin/env bash
+# The owned-dir guard probes run as `git -C <dir> remote|status ...` --
+# strip the -C pair so the verb lands in $1 for the case dispatch.
+if [ "$1" = "-C" ]; then shift 2; fi
+echo "GIT $*" >> "${GIT_LOG:?}"
+case "$1" in
+  clone)
+    [ "${STUB_GIT_CLONE_RC:-0}" -eq 0 ] || exit "$STUB_GIT_CLONE_RC"
+    target="${!#}"
+    mkdir -p "$target/.git"
+    echo '{}' > "$target/package.json"
+    exit 0
+    ;;
+  fetch|checkout|reset) exit "${STUB_GIT_FETCH_RC:-0}" ;;
+  remote)
+    # `remote get-url origin` ownership probe: default answers the default
+    # fork repo URL so owned-clone scenarios pass the guard.
+    printf '%s\n' "${STUB_GIT_ORIGIN_URL:-https://github.com/yotamleo/qmd.git}"
+    exit 0
+    ;;
+  status)
+    # `status --porcelain` dirty probe: empty default = clean worktree.
+    printf '%s' "${STUB_GIT_DIRTY:-}"
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$id2/bin/git"
 cat > "$id2/bin/bun" <<'STUB'
 #!/usr/bin/env bash
-# 'bun add ...' = install; anything else = a qmd run dispatch (bun <qmd.js> ...).
-if [ "$1" = "add" ]; then exit "${STUB_BUN_ADD_RC:-0}"; fi
-if [ -f "${HEAL_MARKER:-}" ]; then exit 0; fi
-exit "${STUB_BUN_VER_RC:-0}"
+echo "BUN $*" >> "${BUN_LOG:?}"
+case "$1" in
+  install) exit "${STUB_BUN_INSTALL_RC:-0}" ;;
+  run)
+    [ "$2" = "build" ] || exit 0
+    [ "${STUB_BUN_BUILD_RC:-0}" -eq 0 ] || exit "$STUB_BUN_BUILD_RC"
+    mkdir -p dist/cli
+    : > dist/cli/qmd.js
+    exit 0
+    ;;
+  *)
+    [ "${STUB_BUN_VERSION_RC:-0}" -eq 0 ] && printf 'qmd %s\n' "${STUB_QMD_VERSION:-2.6.10}"
+    exit "${STUB_BUN_VERSION_RC:-0}"
+    ;;
+esac
 STUB
 chmod +x "$id2/bin/bun"
-cat > "$id2/bin/npm" <<'STUB'
-#!/usr/bin/env bash
-# Simulate the native build: STUB_NPM_RC=1 = build fails (no heal marker);
-# default = success (drop the heal marker).
-if [ "${STUB_NPM_RC:-0}" -ne 0 ]; then exit "${STUB_NPM_RC}"; fi
-: > "${HEAL_MARKER:?}"
-exit 0
-STUB
-chmod +x "$id2/bin/npm"
-heal_marker="$id2/.healed"
-qmd_install_rc() {
-  HOME="$id2" BUN_INSTALL="$id2/.bun" HEAL_MARKER="$heal_marker" \
-    PATH="$id2/bin:$PATH" \
-    STUB_BUN_ADD_RC="${STUB_BUN_ADD_RC:-0}" STUB_BUN_VER_RC="${STUB_BUN_VER_RC:-0}" \
-    STUB_NPM_RC="${STUB_NPM_RC:-0}" \
-    bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install >/dev/null 2>&1; echo $?'
+
+git_log="$id2/git-calls"
+bun_log="$id2/bun-calls"
+qmd_install_env() { # $1 = HOME dir, remaining = the command to run under it
+  local home="$1"; shift
+  : > "$git_log"; : > "$bun_log"
+  HOME="$home" GIT_LOG="$git_log" BUN_LOG="$bun_log" PATH="$id2/bin:$PATH" \
+    STUB_GIT_CLONE_RC="${STUB_GIT_CLONE_RC:-0}" STUB_GIT_FETCH_RC="${STUB_GIT_FETCH_RC:-0}" \
+    STUB_GIT_ORIGIN_URL="${STUB_GIT_ORIGIN_URL:-}" STUB_GIT_DIRTY="${STUB_GIT_DIRTY:-}" \
+    STUB_BUN_INSTALL_RC="${STUB_BUN_INSTALL_RC:-0}" STUB_BUN_BUILD_RC="${STUB_BUN_BUILD_RC:-0}" \
+    STUB_BUN_VERSION_RC="${STUB_BUN_VERSION_RC:-0}" STUB_QMD_VERSION="${STUB_QMD_VERSION:-2.6.10}" \
+    "$@"
 }
-# happy: install ok + verify ok -> rc 0.
-STUB_BUN_ADD_RC=0; STUB_BUN_VER_RC=0; rm -f "$heal_marker"
-assert "qmd_install happy path returns 0" test "$(qmd_install_rc)" -eq 0
-# honest-fail: bun add fails -> rc nonzero, verify never reached.
-STUB_BUN_ADD_RC=1; STUB_BUN_VER_RC=0; rm -f "$heal_marker"
-assert "qmd_install honest-fail returns nonzero" test "$(qmd_install_rc)" -ne 0
-# heal: install ok, verify fails, npm rebuild heals, re-verify ok -> rc 0.
-STUB_BUN_ADD_RC=0; STUB_BUN_VER_RC=1; STUB_NPM_RC=0; rm -f "$heal_marker"
-assert "qmd_install heal path returns 0" test "$(qmd_install_rc)" -eq 0
-assert "qmd_install heal path ran npm rebuild" test -f "$heal_marker"
-# heal-FAIL: install ok, verify fails, npm rebuild FAILS -> honest rc nonzero
-# (the core HIMMEL-752 honest-rc contract: 0 only when qmd verifiably works).
-STUB_BUN_ADD_RC=0; STUB_BUN_VER_RC=1; STUB_NPM_RC=1; rm -f "$heal_marker"
-assert "qmd_install heal-fail returns nonzero (honest rc)" test "$(qmd_install_rc)" -ne 0
-assert "qmd_install heal-fail left no heal marker" test ! -f "$heal_marker"
-STUB_NPM_RC=0
+
+# -- fresh install: clone + build + link, rc 0 --------------------------------
+fresh_home="$id2/fresh"; mkdir -p "$fresh_home"
+STUB_GIT_CLONE_RC=0 STUB_GIT_FETCH_RC=0 STUB_BUN_INSTALL_RC=0 STUB_BUN_BUILD_RC=0 STUB_BUN_VERSION_RC=0
+out=$(qmd_install_env "$fresh_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+assert "fresh install: rc 0" grep -q '^RC=0$' <<<"$out"
+assert "fresh install: cloned the fork" grep -q 'GIT clone' "$git_log"
+assert "fresh install: built with bun" grep -q 'BUN run build' "$bun_log"
+assert "fresh install: linked at the bun-global @tobilu/qmd path" \
+  test -e "$fresh_home/.bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
+
+# -- idempotent re-run: already fork-served + version ok -> skip, clone/build
+#    never re-run (the version CHECK itself legitimately invokes bun once). --
+out=$(qmd_install_env "$fresh_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+assert "idempotent re-run: rc 0" grep -q '^RC=0$' <<<"$out"
+assert "idempotent re-run: no git call" test ! -s "$git_log"
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "idempotent re-run: did not re-run bun install" bash -c '! grep -q "BUN install" "$1"' _ "$bun_log"
+# shellcheck disable=SC2016
+assert "idempotent re-run: did not re-run bun build" bash -c '! grep -q "BUN run build" "$1"' _ "$bun_log"
+
+# -- qmd_fork_served / `fork-served` CLI verb (the caller-side install gate,
+#    HIMMEL-877 CR codex-adv-1) ------------------------------------------------
+assert "fork-served CLI verb: rc 0 when the fork is served" \
+  qmd_install_env "$fresh_home" bash "$SCRIPT_DIR/qmd-bin.sh" fork-served
+noserve_home="$id2/noserve"
+mkdir -p "$noserve_home/.bun/install/global/node_modules/@tobilu/qmd/dist/cli"
+: > "$noserve_home/.bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
+rc=0
+qmd_install_env "$noserve_home" bash "$SCRIPT_DIR/qmd-bin.sh" fork-served >/dev/null 2>&1 || rc=$?
+assert "fork-served CLI verb: nonzero on an upstream REAL-dir install (qmd present)" test "$rc" -ne 0
+
+# Absolute path to bash (not a bare `bash` PATH lookup): the no-git/no-bun
+# isolation cases below need a PATH that carries ONLY the surviving stub (no
+# fallback to the outer $PATH, or the real git/bun on this dev box would leak
+# in and mask the scenario) -- but a bare `bash -c` would then fail to find
+# bash ITSELF via that same restricted PATH. Resolve it once, outside the
+# restriction.
+bash_bin="$(command -v bash)"
+
+# -- no git on PATH: WARN + rc nonzero, bun never invoked (PATH carries ONLY
+#    the bun stub) -------------------------------------------------------------
+nogit_home="$id2/nogit"; mkdir -p "$nogit_home" "$id2/bin-bun-only"
+cp "$id2/bin/bun" "$id2/bin-bun-only/bun"
+: > "$git_log"; : > "$bun_log"
+out=$(HOME="$nogit_home" GIT_LOG="$git_log" BUN_LOG="$bun_log" \
+      PATH="$id2/bin-bun-only" "$bash_bin" -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+assert "no-git: rc nonzero" grep -qv '^RC=0$' <<<"$out"
+assert "no-git: WARNs" grep -qi 'git not found' <<<"$out"
+assert "no-git: bun never invoked" test ! -s "$bun_log"
+
+# -- no bun on PATH (git present): WARN + rc nonzero (PATH carries ONLY the
+#    git stub) -----------------------------------------------------------------
+nobun_home="$id2/nobun"; mkdir -p "$nobun_home" "$id2/bin-git-only"
+cp "$id2/bin/git" "$id2/bin-git-only/git"
+: > "$git_log"; : > "$bun_log"
+out=$(HOME="$nobun_home" GIT_LOG="$git_log" BUN_LOG="$bun_log" PATH="$id2/bin-git-only" \
+      "$bash_bin" -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+assert "no-bun: rc nonzero" grep -qv '^RC=0$' <<<"$out"
+assert "no-bun: WARNs" grep -qi 'bun not found' <<<"$out"
+
+# -- clone/fetch failure on an EXISTING clone: WARN + continues (build still
+#    runs against the existing, un-updated clone contents). Pre-seed the
+#    clone dir directly (NOT via a first qmd_install call) so the global path
+#    is NOT yet linked -- otherwise the idempotent-skip check above would
+#    short-circuit this run before it ever reaches the fetch/checkout step.
+stale_home="$id2/stalefetch"
+mkdir -p "$stale_home/.himmel/qmd-fork/.git"
+echo '{}' > "$stale_home/.himmel/qmd-fork/package.json"
+STUB_GIT_CLONE_RC=0 STUB_GIT_FETCH_RC=1 STUB_BUN_INSTALL_RC=0 STUB_BUN_BUILD_RC=0 STUB_BUN_VERSION_RC=0
+out=$(qmd_install_env "$stale_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+STUB_GIT_FETCH_RC=0
+assert "fetch-fail: attempted the update (fetch) on the existing clone" grep -q 'GIT fetch' "$git_log"
+assert "fetch-fail: WARNs and continues" grep -qi 'fetch/checkout failed' <<<"$out"
+assert "fetch-fail: still builds + verifies (rc 0)" grep -q '^RC=0$' <<<"$out"
+
+# -- owned-dir guard (HIMMEL-877 CR codex-adv-2): never hard-reset a repo
+#    the installer does not own -------------------------------------------------
+# unrelated origin at QMD_FORK_DIR -> refused untouched, rc nonzero, no fetch.
+unrel_home="$id2/unrelorigin"
+mkdir -p "$unrel_home/.himmel/qmd-fork/.git"
+echo "precious local work" > "$unrel_home/.himmel/qmd-fork/work.txt"
+STUB_GIT_ORIGIN_URL="https://github.com/someone/unrelated.git"
+out=$(qmd_install_env "$unrel_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+STUB_GIT_ORIGIN_URL=""
+assert "unrelated-origin: rc nonzero" grep -qv '^RC=0$' <<<"$out"
+assert "unrelated-origin: refuses with the origin mismatch WARNING" grep -qi 'refusing to touch' <<<"$out"
+# shellcheck disable=SC2016
+assert "unrelated-origin: never fetch/checkout/reset" bash -c '! grep -qE "GIT (fetch|checkout|reset)" "$1"' _ "$git_log"
+assert "unrelated-origin: dir contents untouched" grep -q 'precious local work' "$unrel_home/.himmel/qmd-fork/work.txt"
+
+# dirty owned clone -> refused untouched, rc nonzero.
+dirty_home="$id2/dirtyclone"
+mkdir -p "$dirty_home/.himmel/qmd-fork/.git"
+echo "uncommitted edit" > "$dirty_home/.himmel/qmd-fork/wip.txt"
+STUB_GIT_DIRTY=" M wip.txt"
+out=$(qmd_install_env "$dirty_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+assert "dirty-clone: rc nonzero" grep -qv '^RC=0$' <<<"$out"
+assert "dirty-clone: refuses with the uncommitted-changes WARNING" grep -qi 'uncommitted changes' <<<"$out"
+# shellcheck disable=SC2016
+assert "dirty-clone: never fetch/checkout/reset" bash -c '! grep -qE "GIT (fetch|checkout|reset)" "$1"' _ "$git_log"
+assert "dirty-clone: dir contents untouched" grep -q 'uncommitted edit' "$dirty_home/.himmel/qmd-fork/wip.txt"
+
+# QMD_FORK_FORCE=1 on the same dirty clone -> proceeds (fetch runs, rc 0).
+out=$(qmd_install_env "$dirty_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; QMD_FORK_FORCE=1 qmd_install; echo "RC=$?"' 2>&1)
+STUB_GIT_DIRTY=""
+assert "dirty+FORCE: proceeds to fetch" grep -q 'GIT fetch' "$git_log"
+assert "dirty+FORCE: rc 0" grep -q '^RC=0$' <<<"$out"
+
+# -- build failure: WARN + manual command, rc nonzero --------------------------
+buildfail_home="$id2/buildfail"; mkdir -p "$buildfail_home"
+STUB_GIT_CLONE_RC=0 STUB_GIT_FETCH_RC=0 STUB_BUN_INSTALL_RC=0 STUB_BUN_BUILD_RC=1
+out=$(qmd_install_env "$buildfail_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+STUB_BUN_BUILD_RC=0
+assert "build-fail: rc nonzero" grep -qv '^RC=0$' <<<"$out"
+assert "build-fail: WARNs with the manual command" grep -qi 'build failed' <<<"$out"
+
+# -- existing REAL directory at the global path: moved aside (never deleted),
+#    named deterministically -------------------------------------------------
+realdir_home="$id2/realdir"
+mkdir -p "$realdir_home/.bun/install/global/node_modules/@tobilu/qmd"
+echo "upstream content" > "$realdir_home/.bun/install/global/node_modules/@tobilu/qmd/marker.txt"
+STUB_GIT_CLONE_RC=0 STUB_GIT_FETCH_RC=0 STUB_BUN_INSTALL_RC=0 STUB_BUN_BUILD_RC=0 STUB_BUN_VERSION_RC=0
+out=$(qmd_install_env "$realdir_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+backup="$realdir_home/.bun/install/global/node_modules/@tobilu/qmd.pre-fork-backup"
+assert "real-dir: rc 0" grep -q '^RC=0$' <<<"$out"
+assert "real-dir: moved aside to the deterministic backup name" test -d "$backup"
+assert "real-dir: backup content preserved" grep -q 'upstream content' "$backup/marker.txt"
+assert "real-dir: global path now links to the fork" \
+  test -e "$realdir_home/.bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
+
+# -- existing STALE LINK (pointing elsewhere): removed + replaced, the old
+#    target's contents survive (link-only removal, never recursive). Reuse
+#    the module's OWN _qmd_link (junction on Windows / symlink on POSIX) to
+#    create the fixture, so the test stays correct on either platform without
+#    reimplementing the OS branch. -------------------------------------------
+stalelink_home="$id2/stalelink"
+mkdir -p "$stalelink_home/.bun/install/global/node_modules/@tobilu" "$stalelink_home/elsewhere"
+echo "elsewhere content" > "$stalelink_home/elsewhere/marker.txt"
+bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; _qmd_link "$1" "$2"' _ \
+  "$stalelink_home/elsewhere" "$stalelink_home/.bun/install/global/node_modules/@tobilu/qmd"
+STUB_GIT_CLONE_RC=0 STUB_GIT_FETCH_RC=0 STUB_BUN_INSTALL_RC=0 STUB_BUN_BUILD_RC=0 STUB_BUN_VERSION_RC=0
+out=$(qmd_install_env "$stalelink_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+assert "stale-link: rc 0" grep -q '^RC=0$' <<<"$out"
+assert "stale-link: replaced with a link to the fork" \
+  test -e "$stalelink_home/.bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
+assert "stale-link: old target's contents untouched" grep -q 'elsewhere content' "$stalelink_home/elsewhere/marker.txt"
+
+# -- link failure AFTER a real-dir backup: the backup is RESTORED to the
+#    global path (CR rollback: the old install must keep resolving; the
+#    locked-path failure this recipe exists for must not strand it) -----------
+rollback_home="$id2/rollback"
+mkdir -p "$rollback_home/.bun/install/global/node_modules/@tobilu/qmd"
+echo "upstream content" > "$rollback_home/.bun/install/global/node_modules/@tobilu/qmd/marker.txt"
+STUB_GIT_CLONE_RC=0 STUB_GIT_FETCH_RC=0 STUB_BUN_INSTALL_RC=0 STUB_BUN_BUILD_RC=0 STUB_BUN_VERSION_RC=0
+out=$(qmd_install_env "$rollback_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"
+  _qmd_link() { _QMD_LINK_ERR="stub link failure"; return 1; }
+  qmd_install; echo "RC=$?"' 2>&1)
+assert "link-fail rollback: rc nonzero" grep -qv '^RC=0$' <<<"$out"
+assert "link-fail rollback: ERROR carries the captured link diagnostics" grep -q 'stub link failure' <<<"$out"
+assert "link-fail rollback: announces the restore" grep -qi 'Restored the previous directory' <<<"$out"
+assert "link-fail rollback: original dir is BACK at the global path" \
+  grep -q 'upstream content' "$rollback_home/.bun/install/global/node_modules/@tobilu/qmd/marker.txt"
+assert "link-fail rollback: no stranded backup left behind" \
+  test ! -e "$rollback_home/.bun/install/global/node_modules/@tobilu/qmd.pre-fork-backup"
+
+# -- successful migration prints the backup location (operator affordance) ----
+note_home="$id2/backupnote"
+mkdir -p "$note_home/.bun/install/global/node_modules/@tobilu/qmd"
+echo "upstream content" > "$note_home/.bun/install/global/node_modules/@tobilu/qmd/marker.txt"
+out=$(qmd_install_env "$note_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+assert "backup-note: rc 0" grep -q '^RC=0$' <<<"$out"
+assert "backup-note: names the preserved backup dir" grep -q 'preserved at' <<<"$out"
 
 echo "[test-qmd-bin] qmd_register_collection() add / idempotent-skip / warn (HIMMEL-752)"
 # Hermetic stub env: a fake `qmd` on PATH (no bun-qmd.js, no bun -> qmd_cmd

--- a/scripts/machine-setup/ubuntu.sh
+++ b/scripts/machine-setup/ubuntu.sh
@@ -237,11 +237,12 @@ step "Clone Luna vault + install pre-commit hooks"
 
 step "Install qmd CLI + register himmel/luna collections"
 {
-  # Project rule: qmd installs via bun, not npm. The qmd Claude plugin ships
+  # Project rule: qmd installs from the himmel qmd fork, built with bun,
+  # never upstream npm/bun-add (HIMMEL-877). The qmd Claude plugin ships
   # a path stub that breaks plain `qmd` on Windows; scripts/lib/qmd-bin.sh
-  # picks the working invoker. qmd_install runs the full install + verifies
-  # the binary + heals a missing native build (HIMMEL-752: --ignore-scripts
-  # crashed qmd on platforms without a better-sqlite3 prebuilt binary).
+  # picks the working invoker. qmd_install clones yotamleo/qmd#himmel-main,
+  # builds it (bun install && bun run build), symlinks it onto the
+  # bun-global @tobilu/qmd path, and verifies the binary.
   # shellcheck source=../lib/qmd-bin.sh
   # shellcheck disable=SC1091
   . "$HIMMEL_PATH/scripts/lib/qmd-bin.sh"
@@ -258,10 +259,13 @@ step "Install qmd CLI + register himmel/luna collections"
   # `[ "$_qmd_step_ok" -eq 1 ]` so failure cascades to fail_nonfatal.
   _qmd_step_ok=1
 
-  if ! has_qmd; then
+  # Gate on fork-served, NOT presence (has_qmd): a machine carrying the old
+  # upstream bun-global install is qmd-present but must still MIGRATE to the
+  # fork (HIMMEL-877 CR codex-adv-1).
+  if ! qmd_fork_served; then
     if command -v bun >/dev/null 2>&1; then
-      # qmd_install runs the canonical hint (no --ignore-scripts), verifies
-      # the binary, and heals a missing better-sqlite3 native build (HIMMEL-752).
+      # qmd_install clones the himmel qmd fork, builds it with bun, and
+      # junctions/symlinks it onto the bun-global @tobilu/qmd path (HIMMEL-877).
       # Capture rc *before* the `if`: `if ! cmd; then $?` is 0, not cmd's rc.
       qmd_install
       _qmd_install_rc=$?

--- a/scripts/qmd/ensure-qmd-daemon.ps1
+++ b/scripts/qmd/ensure-qmd-daemon.ps1
@@ -70,7 +70,7 @@ if ($state -eq 'foreign') {
 # dead - start the daemon
 $qmd = Resolve-QmdBin
 if (-not $qmd) {
-    Write-Error "ensure-qmd-daemon: qmd is not on PATH and no fallback at $HOME\.bun\bin\qmd.exe. Install it: bun add -g @tobilu/qmd"
+    Write-Error "ensure-qmd-daemon: qmd is not on PATH and no fallback at $HOME\.bun\bin\qmd.exe. Install it: bash <himmel-repo>/scripts/lib/qmd-bin.sh install (HIMMEL-877)"
     exit 1
 }
 

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -223,17 +223,21 @@ if (Get-Command node -ErrorAction SilentlyContinue) {
 }
 
 # --- qmd collection ---
-# Mirror of scripts/lib/qmd-bin.sh (bash) — pwsh cannot source bash, so
-# resolver logic is duplicated. UPDATE BOTH when changing resolution
-# rules; scripts/lib/test-qmd-bin.sh is the canonical behavior spec.
+# Mirror of scripts/lib/qmd-bin.sh (bash) — pwsh cannot source bash, so the
+# resolver (Invoke-Qmd/Test-Qmd) logic is duplicated. This block only
+# REGISTERS an already-installed qmd (matches bash setup.sh step [4/10] --
+# neither side auto-installs here; that's adopt.sh's/adopt.ps1's job). UPDATE
+# BOTH when changing resolution rules; scripts/lib/test-qmd-bin.sh is the
+# canonical behavior spec.
 #
 # Honors $env:BUN_INSTALL for relocated bun roots, matching the bash lib.
 $QmdBunRoot = if ($env:BUN_INSTALL) { $env:BUN_INSTALL } else { Join-Path $HOME '.bun' }
 $QmdBunJs = Join-Path $QmdBunRoot 'install\global\node_modules\@tobilu\qmd\dist\cli\qmd.js'
-# HIMMEL-752 G3: NO --ignore-scripts. It blocked better-sqlite3's native
-# build (prebuild-install || node-gyp rebuild --release), crashing qmd on
-# machines with no prebuilt binary (fresh macOS arm64 / new node major).
-$QmdInstallHint = 'bun add -g @tobilu/qmd@latest'
+# HIMMEL-877: qmd installs from the himmel qmd fork (yotamleo/qmd#himmel-main),
+# never upstream `bun add -g @tobilu/qmd` (EPERM-wedges on this project's
+# machines; bun blocks its postinstall script). scripts/lib/qmd-bin.sh is the
+# single chokepoint for the clone+build+link recipe.
+$QmdInstallHint = "bash `"$RepoRoot/scripts/lib/qmd-bin.sh`" install"
 
 function Invoke-Qmd {
     param([Parameter(ValueFromRemainingArguments=$true)] [string[]] $QmdArgs)

--- a/scripts/test-adopt.sh
+++ b/scripts/test-adopt.sh
@@ -366,25 +366,78 @@ printf '%s' "$out" | grep -q 'DRY: qmd_register_collection .* luna$'   || fail "
 printf '%s' "$out" | grep -q 'DRY:.*(cd scripts/jira && bun install && bun run build)' || fail "dry-run missing build_jira_cli DRY line"
 echo "ok: dry-run emits all qmd step DRY lines (core G1/G3/G4 + luna G5) + build_jira_cli"
 
-# ── 11. HIMMEL-752 qmd WARN-not-fail: a failing qmd install never aborts adopt
-# bun present (stubbed to exit 1) + has_qmd=false (scrubbed PATH, fake HOME) ->
-# qmd_install is invoked and fails -> wire_qmd_core WARNs, but adopt still exits
-# 0 (qmd is best-effort). Fake HOME keeps settings writes isolated.
+# ── 11. HIMMEL-877 qmd WARN-not-fail: a failing qmd install never aborts adopt
+# bun present (stubbed) + a `git` stub that fails on `clone` + has_qmd=false
+# (scrubbed PATH, fake HOME) -> qmd_install is invoked, the fork clone fails,
+# and wire_qmd_core WARNs, but adopt still exits 0 (qmd is best-effort). The
+# git stub keeps this hermetic — no real network clone of the fork repo. Fake
+# HOME keeps settings writes isolated.
 fbin="$work/fbin"; mkdir -p "$fbin"
 cat > "$fbin/bun" <<'STUB'
 #!/usr/bin/env bash
-exit 1
+exit 0
 STUB
 chmod +x "$fbin/bun"
+cat > "$fbin/git" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "clone" ] && exit 1
+exit 0
+STUB
+chmod +x "$fbin/git"
 fhome="$work/fhome"; mkdir -p "$fhome"
 set +e
 out=$(PATH="$fbin:$work/bin:$qmd_free_path" HOME="$fhome" bash "$adopt" \
       --profile core --scope user --target "$work/ign-f" 2>&1); rc=$?
 set -e
 [ "$rc" -eq 0 ] || fail "adopt must exit 0 when qmd install fails (WARN-not-fail), got rc=$rc"
-printf '%s' "$out" | grep -q 'Installing qmd via bun' || fail "qmd_install not invoked (call order)"
+printf '%s' "$out" | grep -q 'Installing qmd fork' || fail "qmd_install not invoked (call order)"
 printf '%s' "$out" | grep -Eq 'WARNING.*qmd install failed' || fail "missing qmd install WARNING (WARN-not-fail)"
 echo "ok: qmd install failure WARNs and adopt continues (WARN-not-fail, rc=0)"
+
+# ── 11b. HIMMEL-877 CR codex-adv-1: an existing UPSTREAM install MIGRATES ────
+# A real @tobilu/qmd directory at the bun-global path + a working stubbed bun
+# make has_qmd TRUE -- the exact population the fork change repairs. The
+# install gate is qmd_fork_served (not presence), so adopt must still run
+# qmd_install: back the upstream dir up and link the fork over the global
+# path -- never skip and report success on the EPERM-prone upstream install.
+# Stubs keep it hermetic: git clone fabricates the fork clone locally, bun
+# fabricates the build output; no network, fake HOME.
+mbin="$work/mbin"; mkdir -p "$mbin"
+cat > "$mbin/bun" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  install) exit 0 ;;
+  run) [ "$2" = "build" ] && { mkdir -p dist/cli; : > dist/cli/qmd.js; }; exit 0 ;;
+  *) echo "qmd 2.6.10"; exit 0 ;;
+esac
+STUB
+chmod +x "$mbin/bun"
+cat > "$mbin/git" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  clone) target="${!#}"; mkdir -p "$target/.git"; exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$mbin/git"
+mhome="$work/mhome"
+mkdir -p "$mhome/.bun/install/global/node_modules/@tobilu/qmd/dist/cli"
+: > "$mhome/.bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"  # upstream: has_qmd=TRUE
+set +e
+out=$(PATH="$mbin:$work/bin:$qmd_free_path" HOME="$mhome" bash "$adopt" \
+      --profile core --scope user --target "$work/ign-m" 2>&1); rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "migration adopt exited rc=$rc (expected 0)"
+printf '%s' "$out" | grep -q 'Installing qmd fork' \
+  || fail "upstream-present install did not trigger the fork install (presence-gate regression)"
+printf '%s' "$out" | grep -q 'moving aside' || fail "upstream dir was not moved aside"
+[ -d "$mhome/.bun/install/global/node_modules/@tobilu/qmd.pre-fork-backup" ] \
+  || fail "upstream backup dir missing after migration"
+[ -e "$mhome/.himmel/qmd-fork/dist/cli/qmd.js" ] || fail "fork clone was not built"
+[ -e "$mhome/.bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js" ] \
+  || fail "global path does not serve the fork after migration"
+echo "ok: existing upstream install migrates to the fork (backup + link, not skipped)"
 
 # ── 12. HIMMEL-842 gap 2: node-without-npm + no JS package manager -> HARD fail ──
 # Stub node on PATH but provide NO npm; bun is already absent suite-wide, so the


### PR DESCRIPTION
## HIMMEL-877 — qmd installs from the himmel fork (clone + build + junction)

New machines/users get the qmd FORK (yotamleo/qmd#himmel-main, 2.6.3 base: #551/#553 chunking + #705 remote-embed guard chain) instead of upstream `bun add -g @tobilu/qmd` — which EPERM-wedges (zombie `qmd mcp` stdio processes hold locks) and loses to bun's blocked-postinstall.

### Behavior
- Single chokepoint `scripts/lib/qmd-bin.sh qmd_install()`: clone/fetch the fork (`QMD_FORK_REPO/_BRANCH/_DIR` overridable, `--depth 1 --single-branch`), `bun install + bun run build`, then a directory junction (Windows `mklink /J`) or symlink (POSIX) over the bun-global `@tobilu/qmd` path — every existing consumer resolves the fork transparently.
- **Migration gate is fork-served, not presence**: `qmd_fork_served()` (canonical-path compare — `cd+pwd -P` folded through `cygpath -w` to defeat MSYS mount aliasing — AND version ≥ 2.6.3), exposed as a `fork-served` CLI verb; adopt.sh / ubuntu.sh / adopt.ps1 all gate on it, so machines with the old upstream install actually migrate.
- **Owned-dir guard**: the existing-clone update path verifies `origin` URL == `QMD_FORK_REPO` and refuses a dirty worktree (override `QMD_FORK_FORCE=1`) before any `reset --hard` — a stale `QMD_FORK_DIR` can't destroy an unrelated repo.
- **Rollback**: a real pre-existing dir is moved to a deterministic `.pre-fork-backup` name; on link failure the backup is RESTORED (old install keeps resolving) and both paths print loudly if restore fails. Stale links removed link-only. Successful migration prints the preserved-backup note.
- adopt.ps1 delegates to `bash qmd-bin.sh install` via `Resolve-QmdGitBash` (rejects the System32 WSL stub, FillEnv-Core pattern) and reconciles install-rc-0-but-Test-Qmd-false with a named WARNING. mkdir/rmdir/mklink diagnostics surfaced, not swallowed.
- Dropped: the HIMMEL-752 better-sqlite3 heal step (bun-global-specific); build failures land in the generic WARN with a manual hint. Docs updated: new-machine, tooling-catalog, qmd plugin README, top-level README bullet.

### CR trail (s30, 2026-07-10 — 4 lanes, 2 rounds)
- Critic panel: 0/0.
- codex adversarial: 2 high (presence-gate never migrates existing installs; unowned-dir hard reset) — **both fixed**.
- `code-reviewer`: same 2 Criticals independently + 2 doc-accuracy Importants (stale heal comments, README bullet) — **all fixed**.
- `silent-failure-hunter`: 3 Critical (move-then-link-fail strands the install with no restore; bareword `bash` → WSL-stub trap; silent bash/PS view divergence) + 3 Important — **all fixed**.

Suites: test-qmd-bin 80/80, test-adopt PASS (incl. new migrate-from-upstream scenario), test-fix-qmd-stub 59/59, daemon PASS; shellcheck + PS parse clean. Implemented by Sonnet (2 rounds); orchestration/adjudication Fable (s30).
