### PR TITLE
feat(handover): [HIMMEL-856] session queue locks + cross-machine arms registry (phase 1)

### DIFF
--- a/docs/handover/overnight-mode.md
+++ b/docs/handover/overnight-mode.md
@@ -11,8 +11,29 @@ Do **not** use overnight mode when:
 - The work touches multiple independent subsystems (split into separate tickets first).
 - Destructive ops outside the worktree are required.
 
-## The 11 phases
+## The 11 phases (+ step 0: queue lock)
 
+0. **Queue lock (HIMMEL-856)** — before Phase 1, run
+   `bash scripts/handover/queue-lock.sh acquire <handover-path>`. rc=0
+   (fresh acquire or an automatic stale takeover) proceeds straight to
+   Phase 1 — **capture the `release-token: <token>` line the acquire
+   prints and keep the token for Phase 11**: `release` (and `heartbeat`)
+   refuse without it, so a late or wrong-session release can never rm a
+   live lock. **rc=2** means the queue is owned by a LIVE session elsewhere
+   right now (the exact 2026-07-10 00:51 double-fire shape) — do NOT
+   proceed on this queue: load the coordination file, pick a different
+   queue, or stop with a clear message to the operator. Do not set
+   `QUEUE_LOCK_TAKEOVER=1` to push past a FRESH lock unless you have
+   independently confirmed the other holder is gone (the operator said so,
+   or the machine it names is verifiably offline) — a live double-acquire
+   is the failure this step exists to prevent. Release the lock at wrap
+   (Phase 11, with the captured token) or via `/stop`; an un-released lock
+   is covered by the TTL (default **6 h** — sized to cover the 3-4 h
+   overnight budget; `QUEUE_LOCK_TTL_SECONDS` tunes it, and wiring periodic
+   `queue-lock.sh heartbeat <handover-path> <token>` refreshes into long
+   sessions is the future lever for tightening it back down — TTL sizing
+   is an open operator question on the HIMMEL-856 design) so a crashed
+   session never strands the queue.
 1. **Plan** — `superpowers:writing-plans` on the active brief; commit to `<plans-root>/YYYY-MM-DD-<slug>.md` where `<plans-root>` resolves as:
    - `$HANDOVER_DIR/plans/` when `HANDOVER_DIR` is set (Mode B — plans live with handover state in `<state-repo>/handovers/plans/`).
    - `<repo>/docs/superpowers/plans/` otherwise (Mode A default — backwards-compat;
@@ -34,7 +55,7 @@ Do **not** use overnight mode when:
    Then the push passes the `platforms-tested` / HIMMEL-176 gates first-try with no amend. **Do NOT commit first, hit the gate, then `git commit --amend` to add the trailer** — the auto-mode classifier flags that reactive amend as security-gate circumvention and HARD-blocks it (uncleable, even with operator approval).
 9. **Merge** — `gh pr merge --squash` once CR is clean. **Default to a PLAIN squash merge — do NOT add `--admin`** (HIMMEL-224). `--admin` exists to bypass *branch protection*; this repo has none (the protection API returns 403 on a free private repo, and `reviewDecision` is empty), so `--admin` bypasses nothing useful yet it trips the auto-mode classifier's "bypassing the approval gate = destructive op outside the worktree" HARD-veto (see § Block-only criteria) — which is exactly what stalled the HIMMEL-221 run. Only reach for `--admin` if the repo *actually* has branch protection that blocks the plain merge, and then only with `GH_ADMIN_MERGE_OK=1` set in the launching shell (the `scripts/handover/pr-merge.sh` helper encodes this plain-first/admin-fallback logic). **If the merge is blocked for any reason, load the `himmel-ops:stuck-playbook` skill** (§ "a PR merge was blocked"), then — rather than guessing or routing around the block — record the merge as a one-action operator step in the Phase 11 handover. Retrying a blocked merge via a different command path is flagged as evasion and hardens the block.
 10. **Jira** — invoke the CLI as `node scripts/jira/dist/index.js transition <KEY> "<state>"` (NOT the global `jira` shim — it points at an unrelated, often-broken `jira-cli` package). This runs autonomously **provided the specific standing allow-rule `Bash(node scripts/jira/dist/index.js:*)` is present** — a generic `Bash(node *)` is NOT enough to authorize an external write (see § Auto-mode classifier). If the rule is missing, a transition is classifier-blocked; do NOT retry via a different path (evasion) — record it as an operator action in Phase 11 and have the operator add the rule once (it then works for all future runs).
-11. **Handover** — write `next-session-<N+1>.md` (or whichever increment) in the right dir, file followup tickets for non-blocking findings, record any classifier-blocked Jira transitions as explicit operator actions, update `status.md` + `roadmap.md`, commit + push (trailers in the first commit per Phase 8).
+11. **Handover** — write `next-session-<N+1>.md` (or whichever increment) in the right dir, file followup tickets for non-blocking findings, record any classifier-blocked Jira transitions as explicit operator actions, update `status.md` + `roadmap.md`, commit + push (trailers in the first commit per Phase 8). **Release the step-0 queue lock** (`bash scripts/handover/queue-lock.sh release <handover-path> <release-token>` — the token captured from the step-0 acquire output; if it was lost, `QUEUE_LOCK_FORCE_RELEASE=1 bash scripts/handover/queue-lock.sh release <handover-path>` force-releases loudly and logs the override) as part of this phase — the TTL is a safety net for a crashed session, not a substitute for releasing on a clean wrap.
 
 ## Fable-5 launch preamble (HIMMEL-281)
 

--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -82,6 +82,12 @@
 #   6  time collision — the requested time exactly matches another HIMMEL-*
 #      scheduled task (HIMMEL-407). Pass --force to override, or choose a
 #      different time (suggest_free_slot prints nearby free options).
+#   7  refused — the handover's queue lock (scripts/handover/queue-lock.sh)
+#      is currently FRESH: a session is LIVE on this queue right now
+#      (HIMMEL-856). Override with QUEUE_LOCK_TAKEOVER=1.
+#   8  refused — this handover already has a PENDING arm recorded on
+#      ANOTHER host in the cross-machine arms registry (HIMMEL-856; the
+#      win2+main double-arm shape). Override with ARM_DUP_OK=1.
 set -euo pipefail
 
 RESUME_TIME=""
@@ -226,6 +232,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/../lib/telemetry.sh" 2>/dev/null || true
 command -v telemetry_emit >/dev/null 2>&1 || telemetry_emit() { return 0; }
+
+# handover_root (HIMMEL-856): resolves the single handover root (Mode A
+# inline vs Mode B external HANDOVER_DIR) so the queue-lock + arms-registry
+# checks below read/write the SAME root every other scripts/handover/*.sh
+# script uses -- never a hardcoded ./handovers/ (scripts/handover/CLAUDE.md
+# hard rule). Same caller-side fail-open contract as telemetry.sh above
+# (HIMMEL-236 T24): an absent/broken lib must never break arming -- a
+# missing handover_root just means the queue-lock/arms-registry checks
+# below WARN and skip (see their own guard), same as the existing dedup/
+# collision checks proceed unaffected.
+# shellcheck source=../lib/handover-path.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/handover-path.sh" 2>/dev/null || true
+command -v handover_root >/dev/null 2>&1 || handover_root() { return 2; }
 
 # Canonicalise a path, tolerating non-existent ones: GNU realpath -m, else
 # armored python3 pathlib, else the input unchanged (best effort — matches
@@ -1394,6 +1414,131 @@ if [ "$DEDUP_ANY" -eq 0 ]; then
     fi
 fi
 
+# HIMMEL-856: queue-lock FRESH-holder refusal + cross-machine arms-registry
+# dedup -- the two double-fire vectors from the 2026-07-10 00:51 incident
+# that the existing same-machine dedup above cannot see: (a) a LIVE session
+# is actively working this queue right now (scripts/handover/queue-lock.sh),
+# and (b) this SAME handover already has a PENDING arm recorded on ANOTHER
+# host (schtasks/cron are per-machine, so win2 arming a handover was
+# invisible to main arming the same handover until this registry). Both
+# checks are skipped -- WARN, never fail-closed -- when the handover root
+# can't be resolved (HANDOVER_DIR unset and no inline handovers/ dir yet):
+# this mechanism is additive infrastructure and must never brick every arm.
+#
+# LAYERED DEFENSE -- why check-then-append is acceptable here (HIMMEL-856
+# CR, codex-1): the registry is a git-synced FILE shared across machines,
+# so the pre-arm check and the append below cannot be made atomic across
+# hosts -- two hosts arming in the same sync window can both pass the
+# check. That is BY DESIGN: the registry is the ADVISORY EARLY-WARNING
+# layer (catch the double-arm before either session fires); the queue lock
+# taken at session start (overnight step 0 / queue-lock.sh acquire) is the
+# ENFORCING layer -- a double-arm that slips through the registry still
+# serializes there, with exactly one winner. The cheap mitigation for the
+# window is the post-append re-read at the bottom of this script: after
+# recording our own arm we re-scan the registry and, if another host's arm
+# for the same handover became visible, print a LOUD operator warning
+# naming the hosts (no non-zero exit -- the arm already happened; the
+# warning is the value). Do not re-raise this as a race bug.
+
+# _arm_registry_foreign_hits <registry-file> <handover-path> <this-host> --
+# print a "; "-joined summary of every registry line recording an arm for
+# <handover-path> on a host OTHER than <this-host> (empty = none). Always
+# rc 0 (errexit-safe: greps are || true-guarded, the loop ends in a case).
+_arm_registry_foreign_hits() {
+    local _reg="$1" _ho="$2" _this_host="$3"
+    local _needle _hits="" _line _rhost _rfire _rtask
+    _needle="\"handover\":\"$(printf '%s' "$_ho" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')\""
+    [ -f "$_reg" ] || { printf '%s' ""; return 0; }
+    while IFS= read -r _line; do
+        [ -z "$_line" ] && continue
+        case "$_line" in
+            *"$_needle"*) ;;
+            *) continue ;;
+        esac
+        # `|| true` on each: grep -o exits 1 on no-match, and under
+        # `set -o pipefail` that would otherwise abort the whole arm on a
+        # registry line missing one of these fields.
+        _rhost=$(printf '%s' "$_line" | grep -o '"host":"[^"]*"' | head -1 | sed -e 's/^"host":"//' -e 's/"$//') || true
+        [ -z "$_rhost" ] && continue
+        [ "$_rhost" = "$_this_host" ] && continue
+        _rfire=$(printf '%s' "$_line" | grep -o '"fire-at":"[^"]*"' | head -1 | sed -e 's/^"fire-at":"//' -e 's/"$//') || true
+        _rtask=$(printf '%s' "$_line" | grep -o '"task-name":"[^"]*"' | head -1 | sed -e 's/^"task-name":"//' -e 's/"$//') || true
+        _hits="${_hits:+$_hits; }host=$_rhost fire-at=$_rfire task=$_rtask"
+    done < "$_reg"
+    printf '%s' "$_hits"
+}
+
+# _arm_hostname -- this machine's identity for registry records/compares.
+_arm_hostname() {
+    local _h=""
+    _h=$(hostname 2>/dev/null) || _h=""
+    [ -z "$_h" ] && _h="${COMPUTERNAME:-${HOSTNAME:-unknown-host}}"
+    printf '%s' "$_h"
+}
+
+HIMMEL_856_HR_ROOT=""
+HIMMEL_856_HR_ROOT=$(handover_root 2>/dev/null) || HIMMEL_856_HR_ROOT=""
+if [ -z "$HIMMEL_856_HR_ROOT" ]; then
+    echo "WARN arm-resume: could not resolve the handover root -- skipping queue-lock + arms-registry checks (HIMMEL-856)" >&2
+else
+    QUEUE_LOCK_SH="$SCRIPT_DIR/queue-lock.sh"
+    if [ -f "$QUEUE_LOCK_SH" ]; then
+        # `|| _ql_status_rc=$?` (not a bare assignment) -- under `set -e`,
+        # `var=$(cmd)` where cmd exits non-zero (rc=11/12 = held here, a
+        # normal outcome, not a script error) would otherwise abort the
+        # whole arm right here instead of reaching the rc-7 refusal below.
+        _ql_status_rc=0
+        _ql_status_out=$(bash "$QUEUE_LOCK_SH" status "$HANDOVER_PATH" 2>&1) || _ql_status_rc=$?
+        if [ "$_ql_status_rc" -eq 11 ]; then
+            if [ "${QUEUE_LOCK_TAKEOVER:-}" = "1" ]; then
+                {
+                    echo "WARN arm-resume: queue lock is FRESH for this handover -- arming anyway (QUEUE_LOCK_TAKEOVER=1):"
+                    printf '%s\n' "$_ql_status_out" | sed 's/^/    /'
+                } >&2
+            else
+                {
+                    echo "ERR arm-resume: refusing to arm -- a session is LIVE on this handover's queue right now:"
+                    printf '%s\n' "$_ql_status_out" | sed 's/^/    /'
+                    echo "Two live sessions on the same queue is exactly the 2026-07-10 00:51 double-fire (HIMMEL-856)."
+                    echo "Override with QUEUE_LOCK_TAKEOVER=1 if you are certain the holder is gone/stale."
+                } >&2
+                exit 7
+            fi
+        elif [ "$_ql_status_rc" -ne 0 ] && [ "$_ql_status_rc" -ne 12 ]; then
+            # rc 0 = free, 12 = held-but-STALE (arming over a stale lock is
+            # fine -- the session-start acquire supersedes it). Anything
+            # else means the status check itself broke -- say so instead of
+            # silently proceeding as if the queue were verified free.
+            echo "WARN arm-resume: queue-lock status failed (rc=$_ql_status_rc) -- proceeding WITHOUT the queue-lock check:" >&2
+            printf '%s\n' "$_ql_status_out" | sed 's/^/    /' >&2
+        fi
+        unset _ql_status_out _ql_status_rc
+    else
+        # Missing script is a skipped check, not a silent pass -- same WARN
+        # contract as the unresolvable-handover-root branch above.
+        echo "WARN arm-resume: queue-lock.sh not found at '$QUEUE_LOCK_SH' -- skipping the queue-lock check (HIMMEL-856)" >&2
+    fi
+
+    HIMMEL_856_ARMS_REGISTRY="$HIMMEL_856_HR_ROOT/.locks/arms.jsonl"
+    if [ -f "$HIMMEL_856_ARMS_REGISTRY" ]; then
+        _arm_dup_hits=$(_arm_registry_foreign_hits "$HIMMEL_856_ARMS_REGISTRY" "$HANDOVER_PATH" "$(_arm_hostname)")
+        if [ -n "$_arm_dup_hits" ]; then
+            if [ "${ARM_DUP_OK:-}" = "1" ]; then
+                echo "WARN arm-resume: this handover already has a PENDING arm on another host ($_arm_dup_hits) -- arming anyway (ARM_DUP_OK=1)" >&2
+            else
+                {
+                    echo "ERR arm-resume: refusing to arm -- this handover already has a PENDING arm recorded on another host:"
+                    echo "    $_arm_dup_hits"
+                    echo "This is the win2+main-both-arming shape from the 2026-07-10 00:51 incident (HIMMEL-856)."
+                    echo "Override with ARM_DUP_OK=1 if you are certain the other host's arm is stale/cancelled."
+                } >&2
+                exit 8
+            fi
+        fi
+        unset _arm_dup_hits
+    fi
+fi
+
 # HIMMEL-407: time-collision check — runs AFTER the same-handover dedup block
 # and BEFORE schedule_arm. Runs even under --dry-run (it mutates nothing).
 # On exact-minute collision: rc=6 (HARD-REFUSE) unless --force or --dedup-any.
@@ -1683,6 +1828,46 @@ fi
 # measure-during protocol wants — one append, after the dry-run gate so
 # --dry-run keeps its "touch nothing" contract.
 telemetry_emit handover-arm-resume armed "time=$RESUME_TIME" "force=$FORCE"
+
+# HIMMEL-856: record this arm in the cross-machine arms registry, same
+# dry-run gate as telemetry above. Best-effort -- a registry write failure
+# must never fail an arm that already succeeded (fail-open, loud trail).
+if [ -n "${HIMMEL_856_HR_ROOT:-}" ]; then
+    _arm_host=$(_arm_hostname)
+    mkdir -p "$HIMMEL_856_HR_ROOT/.locks" 2>/dev/null
+    if ! printf '{"host":"%s","handover":"%s","fire-at":"%s","task-name":"%s"}\n' \
+        "$(printf '%s' "$_arm_host" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" \
+        "$(printf '%s' "$HANDOVER_PATH" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" \
+        "$(printf '%s' "$AT_STAMP" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" \
+        "$(printf '%s' "$TASK_NAME" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" \
+        >> "$HIMMEL_856_HR_ROOT/.locks/arms.jsonl" 2>/dev/null; then
+        echo "WARN arm-resume: failed to append the arms.jsonl registry record (the arm itself still succeeded)" >&2
+    fi
+    # Post-append re-read (HIMMEL-856 CR, codex-1 -- see the LAYERED
+    # DEFENSE comment at the pre-arm check): the check-then-append pair
+    # above cannot be atomic across machines, so AFTER recording our own
+    # arm, re-scan the registry. If another host's arm for this same
+    # handover is now visible (it landed in the check->append window, or
+    # was let through with ARM_DUP_OK=1), tell the operator LOUDLY which
+    # hosts double-armed. No non-zero exit -- the arm already happened;
+    # the queue lock at session start is the layer that serializes the
+    # actual double-fire.
+    _arm_post_hits=$(_arm_registry_foreign_hits "$HIMMEL_856_HR_ROOT/.locks/arms.jsonl" "$HANDOVER_PATH" "$_arm_host")
+    if [ -n "$_arm_post_hits" ]; then
+        {
+            echo "=================================================================="
+            echo "  WARN arm-resume: DOUBLE-ARM DETECTED (HIMMEL-856)"
+            echo "  This handover now has PENDING arms on MULTIPLE hosts:"
+            echo "      this host:  $_arm_host"
+            echo "      also armed: $_arm_post_hits"
+            echo "  Cancel one of them (schtasks /delete on the losing host, or"
+            echo "  its cron/at equivalent) -- otherwise both will fire and"
+            echo "  serialize only at the queue lock, wasting a session slot."
+            echo "=================================================================="
+        } >&2
+    fi
+    unset _arm_host _arm_post_hits
+fi
 
 cat <<EOF
 

--- a/scripts/handover/queue-lock.sh
+++ b/scripts/handover/queue-lock.sh
@@ -1,0 +1,612 @@
+#!/usr/bin/env bash
+# queue-lock.sh -- structural one-writer-per-queue lock for armed/overnight
+# sessions (HIMMEL-856).
+#
+# WHY: on 2026-07-10 two armed sessions (fleet-parallel-27 + vm-inflight-s28,
+# plus a 3rd sibling) double-fired on the SAME queue and coordinated by
+# PROSE (prove-before-start, a coordination markdown file, per-incident
+# division locks written mid-flight) -- which failed three ways in one
+# night (duplicate dispatch, duplicate shipping, coordination-by-append
+# races). Per the enforcement-strength convention (HIMMEL-195): a rule
+# that drifts >=2 times escalates to STRUCTURAL. This is that escalation
+# for the queue-level collision -- see the design doc referenced from
+# HIMMEL-856 for the full mechanism and the phase-2/3 rollout this seeds.
+#
+# USAGE (invoke as a script, one verb per call):
+#   bash queue-lock.sh acquire   <handover-path> [session-id]
+#   bash queue-lock.sh heartbeat <handover-path> <session-token>
+#   bash queue-lock.sh release   <handover-path> <session-token>
+#   bash queue-lock.sh status    <handover-path>
+#
+# TOKEN CONTRACT (HIMMEL-856 CR, C1): `acquire` records a session token in
+# owner.json (the given session-id, or a generated "<hostname>-pid<pid>")
+# and PRINTS it as the last stdout line: "release-token: <token>". The
+# caller must capture that line and pass the token to `heartbeat` and
+# `release` -- both REFUSE (rc=2, holder info printed) without it or with
+# a token that does not match the current holder. The token is mandatory
+# because separate script invocations cannot re-derive a stable
+# per-session id (a fresh pid would silently "prove" nothing), and a
+# token-less release could rm another session's LIVE lock -- the exact
+# incident class this script exists to prevent. Emergency override when
+# the token is lost: QUEUE_LOCK_FORCE_RELEASE=1 releases regardless,
+# loudly, and logs the forced release to the queue-level
+# .locks/queue/takeovers.log.
+#
+# LOCK LOCATION: a DIRECTORY (mkdir is atomic -- no TOCTOU race between
+# "check" and "create", works on NTFS/Git-Bash without relying on O_EXCL)
+# at:
+#   <handover-root>/.locks/queue/<queue-slug>.lock/
+# containing owner.json (current holder) and, after any takeover,
+# takeovers.log (append-only trail -- the "loud trail" the design
+# principles require instead of failing closed). <handover-root> is
+# resolved via scripts/lib/handover-path.sh's handover_root_ensure, so
+# this follows the same single-root convention every other
+# scripts/handover/*.sh script uses (Mode A inline vs Mode B external
+# HANDOVER_DIR) -- see scripts/handover/CLAUDE.md.
+#
+# QUEUE SLUG: the handover path relativized against the handover root (or
+# used as-is if it doesn't fall under the root), with path separators
+# folded to "__" and every other non [A-Za-z0-9_-] character replaced by
+# "-". Sibling sessions of one epic (different next-session-N.md files)
+# get DIFFERENT slugs on purpose -- this lock catches the SAME-queue
+# double-fire, not all epic parallelism.
+#
+# TTL / STALE TAKEOVER: a lock whose heartbeat is older than
+# QUEUE_LOCK_TTL_SECONDS (default 21600 = 6 h -- sized to cover the 3-4 h
+# overnight-run budget with margin, HIMMEL-856 CR C2; heartbeat refreshes
+# are the future tightening lever once wired into the long-session flow)
+# is STALE. `acquire` against a stale lock SUPERSEDES automatically (armed
+# sessions die, machines sleep -- the design's "fail open with a loud
+# trail" principle). `acquire` against a FRESH foreign lock refuses (rc=2)
+# unless QUEUE_LOCK_TAKEOVER=1 forces the takeover anyway. Every takeover
+# (stale or forced) appends one line to the lock's takeovers.log naming
+# the previous and new holder, so the next reader sees the trail. `status`
+# warns when a FRESH lock's heartbeat age exceeds half the TTL (aging).
+#
+# EXIT CODES:
+#   acquire:   0  lock acquired (fresh dir, stale takeover, or forced
+#                 takeover -- stderr says which); the last stdout line is
+#                 "release-token: <token>"
+#              1  usage error, OR a genuine environment failure (handover
+#                 root unresolvable, mkdir failed for a reason other than
+#                 "already held", owner.json could not be written -- the
+#                 lock dir is removed again, nothing is acquired)
+#              2  refused -- held by a FRESH foreign lock; holder info
+#                 printed to stderr. Callers (arm-resume.sh, the overnight
+#                 pipeline) treat rc=2 as "work is owned elsewhere: pick a
+#                 different queue, or set QUEUE_LOCK_TAKEOVER=1."
+#   heartbeat: 0  heartbeat refreshed
+#              1  usage error / environment failure (incl. a failed
+#                 owner.json rewrite)
+#              2  session token missing, no lock held for this queue, OR
+#                 held by a DIFFERENT session than the token -- refused
+#   release:   0  released (idempotent -- also rc 0 when nothing was held)
+#              1  usage error / environment failure / rm failed to clear
+#                 an existing lock dir (e.g. an open handle on Windows)
+#              2  session token missing or does not match the current
+#                 holder -- refused (QUEUE_LOCK_FORCE_RELEASE=1 overrides)
+#   status:    0  free
+#              1  usage error / environment failure
+#              11 held, FRESH (owner.json printed to stdout; a CORRUPT
+#                 lock dir -- owner.json missing/unreadable -- also
+#                 reports 11, fail-closed, and SAYS it is corrupt)
+#              12 held, STALE -- eligible for takeover (owner.json printed)
+#
+# CONVENTIONS: bash 3.2-safe (no associative arrays, no ${var,,}, no
+# mapfile). `set -uo pipefail`, not -e -- callers care about specific exit
+# codes. ASCII only in this file (a non-ASCII char on a line a shellcheck
+# finding lands on crashes shellcheck -- repo convention).
+
+set -uo pipefail
+
+_QL_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/handover-path.sh
+# shellcheck disable=SC1091
+. "$_QL_SCRIPT_DIR/../lib/handover-path.sh"
+# shellcheck source=../lib/py-armor.sh
+# shellcheck disable=SC1091
+. "$_QL_SCRIPT_DIR/../lib/py-armor.sh"
+
+_ql_usage() {
+    cat <<'EOF'
+Usage: queue-lock.sh acquire   <handover-path> [session-id]
+       queue-lock.sh heartbeat <handover-path> <session-token>
+       queue-lock.sh release   <handover-path> <session-token>
+       queue-lock.sh status    <handover-path>
+
+acquire prints "release-token: <token>" on success -- capture it and pass
+it to heartbeat/release (both refuse without it). Lost the token?
+QUEUE_LOCK_FORCE_RELEASE=1 queue-lock.sh release <handover-path>
+EOF
+}
+
+_ql_now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+_ql_now_epoch() { date -u +%s; }
+
+# _ql_epoch_of_iso <iso8601> -- print epoch seconds, or empty on failure.
+# GNU date first (Git Bash / Linux), BSD date fallback (macOS), armored
+# python3 last resort -- same fallback shape as py_armor_mtime.
+_ql_epoch_of_iso() {
+    local iso="$1" e=""
+    e=$(date -u -d "$iso" +%s 2>/dev/null) || e=""
+    if [ -z "$e" ]; then
+        e=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$iso" +%s 2>/dev/null) || e=""
+    fi
+    if [ -z "$e" ]; then
+        if py_armor_capture -c 'import sys,datetime
+d = datetime.datetime.strptime(sys.argv[1], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=datetime.timezone.utc)
+print(int(d.timestamp()))' "$iso" 2>/dev/null; then
+            e="$PY_ARMOR_OUT"
+        fi
+    fi
+    printf '%s' "$e"
+}
+
+_ql_hostname() {
+    local h=""
+    h=$(hostname 2>/dev/null) || h=""
+    [ -z "$h" ] && h="${COMPUTERNAME:-${HOSTNAME:-unknown-host}}"
+    printf '%s' "$h"
+}
+
+_ql_default_session() { printf '%s-pid%s' "$(_ql_hostname)" "$$"; }
+
+_ql_json_escape() {
+    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+# _ql_json_field <file> <key> -- extract a flat string field's value.
+# The lock JSON is always single-line, flat, all-string values, so a
+# simple grep -o is sufficient (no jq dependency).
+_ql_json_field() {
+    grep -o "\"$2\":\"[^\"]*\"" "$1" 2>/dev/null | head -1 \
+        | sed -e "s/^\"$2\":\"//" -e 's/"$//'
+}
+
+# _ql_json_field_str <json-string> <key> -- same extraction from an
+# in-memory string. acquire parses ALL fields from ONE captured read
+# (o_raw) so the staleness judgment and the CAS takeover verify below
+# operate on the same generation -- N separate file reads could straddle
+# a concurrent owner.json rewrite.
+_ql_json_field_str() {
+    printf '%s' "$1" | grep -o "\"$2\":\"[^\"]*\"" 2>/dev/null | head -1 \
+        | sed -e "s/^\"$2\":\"//" -e 's/"$//'
+}
+
+# _ql_slug <handover-path> -- normalize a handover path to a filesystem-
+# safe queue slug. Relativizes against the handover root when the path
+# falls under it (the common case); otherwise normalizes the raw path.
+# NOTE: "/" folds to "__", so a path containing a literal "__" collides
+# with the same path using "/" at that spot -- theoretical only; the repo
+# handover naming convention never produces "__" in a path component.
+_ql_slug() {
+    local p="${1//\\//}"
+    p="${p%.md}"
+    local root=""
+    root=$(handover_root 2>/dev/null) || root=""
+    if [ -n "$root" ]; then
+        root="${root//\\//}"
+        case "$p" in
+            "$root"/*) p="${p#"$root"/}" ;;
+        esac
+    fi
+    p=$(printf '%s' "$p" | sed 's#/#__#g')
+    printf '%s' "$p" | tr -c 'A-Za-z0-9_-' '-'
+}
+
+# _ql_write_owner -- ATOMIC owner.json write (HIMMEL-856 CR, C3): write to
+# a tmp file in the lock dir, then mv into place (same-dir file rename --
+# atomic; readers never see a torn owner.json), rc-checked at every step.
+# Returns 1 on any failure; callers MUST check and never report a
+# successful acquire/heartbeat over a failed write -- a torn/absent
+# owner.json parses as CORRUPT-held (fail-closed) forever otherwise.
+_ql_write_owner() {
+    local lockdir="$1" session="$2" host="$3" ho="$4" started="$5" heartbeat="$6"
+    local tmp="$lockdir/owner.json.tmp.$$"
+    if ! printf '{"session":"%s","host":"%s","handover":"%s","started":"%s","heartbeat":"%s"}\n' \
+        "$(_ql_json_escape "$session")" \
+        "$(_ql_json_escape "$host")" \
+        "$(_ql_json_escape "$ho")" \
+        "$started" "$heartbeat" \
+        > "$tmp" 2>/dev/null; then
+        rm -f "$tmp" 2>/dev/null
+        return 1
+    fi
+    if ! mv -f "$tmp" "$lockdir/owner.json" 2>/dev/null; then
+        rm -f "$tmp" 2>/dev/null
+        return 1
+    fi
+    return 0
+}
+
+# _ql_lockdir <handover-path> -- print the absolute lock dir path, or
+# nothing (rc 1) if the handover root can't be resolved.
+_ql_lockdir() {
+    local ho="$1" root=""
+    root=$(handover_root_ensure 2>/dev/null) || return 1
+    local slug
+    slug=$(_ql_slug "$ho")
+    printf '%s/.locks/queue/%s.lock' "$root" "$slug"
+}
+
+queue_lock_acquire() {
+    local ho="${1:-}" session="${2:-}"
+    if [ -z "$ho" ]; then
+        _ql_usage >&2
+        return 1
+    fi
+    local lockdir
+    if ! lockdir=$(_ql_lockdir "$ho"); then
+        echo "queue-lock: could not resolve handover root (HANDOVER_DIR unset and no inline handovers/ dir?)" >&2
+        return 1
+    fi
+    session="${session:-$(_ql_default_session)}"
+    local host now
+    host=$(_ql_hostname)
+    now=$(_ql_now_iso)
+
+    # Check the parent mkdir explicitly so a permission failure reports its
+    # true cause instead of surfacing later as a misleading lock-mkdir
+    # failure (HIMMEL-856 CR suggestion).
+    if ! mkdir -p "$(dirname "$lockdir")" 2>/dev/null; then
+        echo "queue-lock: cannot create the lock parent dir '$(dirname "$lockdir")' (permissions? a file in the way?)" >&2
+        return 1
+    fi
+    if mkdir "$lockdir" 2>/dev/null; then
+        if ! _ql_write_owner "$lockdir" "$session" "$host" "$ho" "$now" "$now"; then
+            # C3: never report acquired over a failed owner write -- the
+            # torn lock would parse as CORRUPT-held (fail-closed) forever.
+            rm -rf "$lockdir" 2>/dev/null
+            echo "queue-lock: acquire FAILED -- owner.json could not be written; the lock dir was removed, nothing is acquired" >&2
+            return 1
+        fi
+        echo "queue-lock: acquired (session=$session host=$host)"
+        echo "release-token: $session"
+        return 0
+    fi
+
+    # Lost the mkdir race, but the WINNER may not have finished writing
+    # owner.json yet (mkdir-then-write is not a single atomic step) -- a
+    # concurrent loser landing in that narrow window would otherwise
+    # misread a healthy fresh lock as "corrupt". Bounded spin-wait (up to
+    # ~1s) before concluding genuine corruption.
+    if [ ! -f "$lockdir/owner.json" ]; then
+        local _wait_i=0
+        while [ "$_wait_i" -lt 20 ] && [ ! -f "$lockdir/owner.json" ]; do
+            sleep 0.05
+            _wait_i=$((_wait_i + 1))
+        done
+    fi
+    if [ ! -f "$lockdir/owner.json" ]; then
+        echo "queue-lock: lock dir exists but owner.json is missing/corrupt -- refusing (manual cleanup needed at $lockdir)" >&2
+        return 1
+    fi
+
+    # ONE raw read; every field (and the CAS verify in the takeover branch)
+    # derives from this single captured generation.
+    local o_raw o_session o_host o_started o_heartbeat
+    o_raw=$(cat "$lockdir/owner.json" 2>/dev/null) || o_raw=""
+    o_session=$(_ql_json_field_str "$o_raw" session)
+    o_host=$(_ql_json_field_str "$o_raw" host)
+    o_started=$(_ql_json_field_str "$o_raw" started)
+    o_heartbeat=$(_ql_json_field_str "$o_raw" heartbeat)
+
+    local ttl="${QUEUE_LOCK_TTL_SECONDS:-21600}"
+    case "$ttl" in ''|*[!0-9]*) ttl=21600 ;; esac
+    local hb_epoch now_epoch age=-1 stale=0
+    hb_epoch=$(_ql_epoch_of_iso "$o_heartbeat")
+    now_epoch=$(_ql_now_epoch)
+    if [ -n "$hb_epoch" ] && [ -n "$now_epoch" ]; then
+        age=$(( now_epoch - hb_epoch ))
+        [ "$age" -lt 0 ] && age=0
+        [ "$age" -ge "$ttl" ] && stale=1
+    else
+        echo "WARN queue-lock: could not parse heartbeat '$o_heartbeat' -- treating as FRESH (fail-closed on unparsable timestamps)" >&2
+    fi
+
+    if [ "$stale" -eq 1 ] || [ "${QUEUE_LOCK_TAKEOVER:-}" = "1" ]; then
+        local reason
+        if [ "$stale" -eq 1 ]; then
+            reason="stale (heartbeat age ${age}s >= ttl ${ttl}s)"
+        else
+            reason="forced (QUEUE_LOCK_TAKEOVER=1, lock is still FRESH)"
+        fi
+        # ATOMIC TAKEOVER (HIMMEL-856 CR, codex-2): never write into a lock
+        # dir we did not just create via mkdir. An in-place owner.json
+        # rewrite would let two concurrent stale-acquirers BOTH "win".
+        # NOTE: an earlier revision claimed the old dir via `mv` to a
+        # graveyard name -- observed UNRELIABLE on MSYS/Git-Bash (rc-0 mv
+        # with a missing or empty target under concurrent rename), so the
+        # only atomic primitive this takeover trusts is mkdir:
+        #   1. mkdir <lockdir>.claim -- the exclusive right to take over
+        #      this slug. Exactly one contender wins; every other taker
+        #      reports held (rc=2). A crashed taker's claim expires after
+        #      120s (dir mtime) and is cleared by the next taker.
+        #   2. CAS re-verify UNDER the claim: the lock's owner.json must
+        #      still byte-match the generation judged stale above
+        #      ($o_raw). A mismatch means the lock changed hands since we
+        #      read it (another taker superseded it, or the holder
+        #      heartbeat) -- it is LIVE: drop the claim, report held.
+        #   3. rm -rf the verified-stale dir, then the normal fresh
+        #      `mkdir` acquire + owner.json + takeovers.log trail, then
+        #      drop the claim. A fresh acquirer slipping into the
+        #      rm->mkdir gap just wins instead of us (exactly one mkdir
+        #      succeeds) -- a normal rc-2 loss for us, and a trail-less
+        #      but correct single ownership handoff.
+        # Residual (accepted, microsecond-scale): a holder judged stale
+        # who actively RELEASES between step 2 and step 3, immediately
+        # followed by a fresh third-party acquire inside that same window,
+        # could have that fresh lock rm'd -- it requires a by-definition
+        # dead session to act, plus a third contender, inside a
+        # microsecond window; the fail-open TTL design already accepts
+        # takeover-vs-revival at far larger windows than this.
+        local claim="${lockdir}.claim"
+        # Expire a crashed taker's claim: older than 120s by mtime. A
+        # failed mtime probe treats the claim as fresh (fail-safe: never
+        # clear a claim we cannot age).
+        if [ -d "$claim" ]; then
+            local claim_mtime claim_age
+            claim_mtime=$(py_armor_mtime "$claim")
+            if [ -n "$claim_mtime" ] && [ -n "$now_epoch" ]; then
+                claim_age=$(( now_epoch - claim_mtime ))
+                if [ "$claim_age" -ge 120 ]; then
+                    rm -rf "$claim" 2>/dev/null
+                fi
+            else
+                # Probe failed: fail-closed (treat as fresh -- never clear
+                # a claim we cannot age) but say so, with the manual escape
+                # hatch, instead of a misleading "try again shortly".
+                echo "WARN queue-lock: cannot age the takeover claim '$claim' (mtime probe failed) -- treating it as fresh. If it is stuck from a crashed taker, remove it manually: rm -rf '$claim'" >&2
+            fi
+        fi
+        if ! mkdir "$claim" 2>/dev/null; then
+            {
+                echo "queue-lock: held -- another taker holds the takeover claim for this queue right now ($claim)"
+                echo "Try again shortly, or check: queue-lock.sh status"
+            } >&2
+            return 2
+        fi
+        # CAS re-verify under the claim (step 2).
+        local v_raw
+        v_raw=$(cat "$lockdir/owner.json" 2>/dev/null) || v_raw=""
+        if [ "$v_raw" != "$o_raw" ]; then
+            rmdir "$claim" 2>/dev/null
+            local n_session n_host
+            n_session=$(_ql_json_field_str "$v_raw" session)
+            n_host=$(_ql_json_field_str "$v_raw" host)
+            {
+                echo "queue-lock: takeover aborted -- the lock changed hands since it was read; now held by session=${n_session:-unknown} host=${n_host:-unknown}"
+                echo "Work is owned elsewhere. Pick a different queue, or check again with: queue-lock.sh status"
+            } >&2
+            return 2
+        fi
+        # Step 3: destroy the verified-stale generation, fresh-acquire.
+        rm -rf "$lockdir" 2>/dev/null
+        if mkdir "$lockdir" 2>/dev/null; then
+            if ! _ql_write_owner "$lockdir" "$session" "$host" "$ho" "$now" "$now"; then
+                # C3: same contract as the fresh path -- never report a
+                # takeover over a failed owner write.
+                rm -rf "$lockdir" 2>/dev/null
+                rmdir "$claim" 2>/dev/null
+                echo "queue-lock: takeover FAILED -- owner.json could not be written; the lock dir was removed, nothing is acquired" >&2
+                return 1
+            fi
+            printf '%s took over from session=%s host=%s started=%s heartbeat=%s reason=%s new_session=%s new_host=%s\n' \
+                "$now" "$o_session" "$o_host" "$o_started" "$o_heartbeat" "$reason" "$session" "$host" \
+                >> "$lockdir/takeovers.log"
+            rmdir "$claim" 2>/dev/null
+            echo "queue-lock: took over ($reason) -- previous holder: session=$o_session host=$o_host" >&2
+            echo "queue-lock: acquired (session=$session host=$host)"
+            echo "release-token: $session"
+            return 0
+        fi
+        # Lost the rm->mkdir gap to a fresh acquirer -- it owns the lock.
+        rmdir "$claim" 2>/dev/null
+        local l_session="" l_host=""
+        if [ -f "$lockdir/owner.json" ]; then
+            l_session=$(_ql_json_field "$lockdir/owner.json" session)
+            l_host=$(_ql_json_field "$lockdir/owner.json" host)
+        fi
+        {
+            echo "queue-lock: takeover lost the race -- the queue is now held by session=${l_session:-unknown} host=${l_host:-unknown}"
+            echo "Work is owned elsewhere. Pick a different queue, or check again with: queue-lock.sh status"
+        } >&2
+        return 2
+    fi
+
+    {
+        echo "queue-lock: held (FRESH) by session=$o_session host=$o_host started=$o_started heartbeat=$o_heartbeat (age ${age}s < ttl ${ttl}s)"
+        echo "Work is owned elsewhere. Pick a different queue, or override with QUEUE_LOCK_TAKEOVER=1."
+    } >&2
+    return 2
+}
+
+queue_lock_heartbeat() {
+    local ho="${1:-}" session="${2:-}"
+    if [ -z "$ho" ]; then
+        _ql_usage >&2
+        return 1
+    fi
+    local lockdir
+    if ! lockdir=$(_ql_lockdir "$ho"); then
+        echo "queue-lock: could not resolve handover root" >&2
+        return 1
+    fi
+    # C1: the token is MANDATORY -- a token-less heartbeat could refresh
+    # (and keep alive) another session's lock.
+    if [ -z "$session" ]; then
+        {
+            echo "queue-lock: heartbeat requires the session token printed by acquire (release-token: <token>)"
+            echo "usage: queue-lock.sh heartbeat <handover-path> <session-token>"
+            if [ -f "$lockdir/owner.json" ]; then
+                echo "current holder:"
+                cat "$lockdir/owner.json"
+            else
+                echo "current holder: (no lock currently held)"
+            fi
+        } >&2
+        return 2
+    fi
+    if [ ! -d "$lockdir" ] || [ ! -f "$lockdir/owner.json" ]; then
+        echo "queue-lock: no lock held for this queue -- nothing to heartbeat" >&2
+        return 2
+    fi
+    local o_session o_host o_started
+    o_session=$(_ql_json_field "$lockdir/owner.json" session)
+    o_host=$(_ql_json_field "$lockdir/owner.json" host)
+    o_started=$(_ql_json_field "$lockdir/owner.json" started)
+    if [ "$session" != "$o_session" ]; then
+        echo "queue-lock: heartbeat refused -- held by session=$o_session, not '$session'" >&2
+        return 2
+    fi
+    if ! _ql_write_owner "$lockdir" "$o_session" "$o_host" "$ho" "$o_started" "$(_ql_now_iso)"; then
+        echo "queue-lock: heartbeat FAILED -- owner.json could not be rewritten atomically (the previous heartbeat stays in effect)" >&2
+        return 1
+    fi
+    return 0
+}
+
+queue_lock_release() {
+    local ho="${1:-}" session="${2:-}"
+    if [ -z "$ho" ]; then
+        _ql_usage >&2
+        return 1
+    fi
+    local lockdir
+    if ! lockdir=$(_ql_lockdir "$ho"); then
+        echo "queue-lock: could not resolve handover root" >&2
+        return 1
+    fi
+    # Emergency override (C1): releases regardless of token -- loud on
+    # stderr AND logged to the queue-level takeovers.log (the lock's own
+    # takeovers.log dies with the dir, so the trail lives one level up).
+    if [ "${QUEUE_LOCK_FORCE_RELEASE:-}" = "1" ]; then
+        if [ ! -d "$lockdir" ]; then
+            return 0
+        fi
+        local f_session f_host
+        f_session=$(_ql_json_field "$lockdir/owner.json" session)
+        f_host=$(_ql_json_field "$lockdir/owner.json" host)
+        printf '%s FORCED RELEASE of session=%s host=%s lock=%s (QUEUE_LOCK_FORCE_RELEASE=1, by pid=%s on host=%s)\n' \
+            "$(_ql_now_iso)" "${f_session:-unknown}" "${f_host:-unknown}" "$lockdir" "$$" "$(_ql_hostname)" \
+            >> "$(dirname "$lockdir")/takeovers.log" 2>/dev/null || true
+        echo "WARN queue-lock: FORCED release of session=${f_session:-unknown} host=${f_host:-unknown} (QUEUE_LOCK_FORCE_RELEASE=1) -- logged to $(dirname "$lockdir")/takeovers.log" >&2
+        rm -rf "$lockdir" 2>/dev/null
+        if [ -d "$lockdir" ]; then
+            echo "queue-lock: failed to remove lock dir '$lockdir' -- it still exists (open handle on Windows? permission?); NOT released" >&2
+            return 1
+        fi
+        return 0
+    fi
+    # C1: the token is MANDATORY -- a token-less release would rm another
+    # session's LIVE lock (the exact incident class this script prevents).
+    # Separate script invocations cannot re-derive a stable per-session id,
+    # so a re-derived default would "prove" nothing.
+    if [ -z "$session" ]; then
+        {
+            echo "queue-lock: release requires the session token printed by acquire (release-token: <token>)"
+            echo "usage: queue-lock.sh release <handover-path> <session-token>"
+            if [ -f "$lockdir/owner.json" ]; then
+                echo "current holder:"
+                cat "$lockdir/owner.json"
+            else
+                echo "current holder: (no lock currently held)"
+            fi
+            echo "emergency override (token lost): QUEUE_LOCK_FORCE_RELEASE=1 queue-lock.sh release <handover-path>"
+        } >&2
+        return 2
+    fi
+    if [ ! -d "$lockdir" ]; then
+        return 0
+    fi
+    if [ -f "$lockdir/owner.json" ]; then
+        local o_session
+        o_session=$(_ql_json_field "$lockdir/owner.json" session)
+        if [ -n "$o_session" ] && [ "$o_session" != "$session" ]; then
+            echo "queue-lock: release refused -- held by session=$o_session, not '$session' (QUEUE_LOCK_FORCE_RELEASE=1 to force)" >&2
+            return 2
+        fi
+    fi
+    rm -rf "$lockdir" 2>/dev/null
+    if [ -d "$lockdir" ]; then
+        echo "queue-lock: failed to remove lock dir '$lockdir' -- it still exists (open handle on Windows? permission?); NOT released" >&2
+        return 1
+    fi
+    return 0
+}
+
+queue_lock_status() {
+    local ho="${1:-}"
+    if [ -z "$ho" ]; then
+        _ql_usage >&2
+        return 1
+    fi
+    local lockdir
+    if ! lockdir=$(_ql_lockdir "$ho"); then
+        echo "queue-lock: could not resolve handover root" >&2
+        return 1
+    fi
+    if [ ! -d "$lockdir" ]; then
+        echo "free"
+        return 0
+    fi
+    if [ ! -f "$lockdir/owner.json" ]; then
+        # Distinguish corruption from a live holder in the OUTPUT (a
+        # passthrough caller like arm-resume would otherwise misdiagnose
+        # this as a live session) while keeping rc=11 -- fail-closed.
+        echo "held -- CORRUPT lock dir (owner.json missing/unreadable): $lockdir"
+        echo "manual cleanup once verified dead: rm -rf '$lockdir'"
+        return 11
+    fi
+    cat "$lockdir/owner.json"
+    local ttl="${QUEUE_LOCK_TTL_SECONDS:-21600}"
+    case "$ttl" in ''|*[!0-9]*) ttl=21600 ;; esac
+    local o_heartbeat hb_epoch now_epoch age=-1 stale=0
+    o_heartbeat=$(_ql_json_field "$lockdir/owner.json" heartbeat)
+    hb_epoch=$(_ql_epoch_of_iso "$o_heartbeat")
+    now_epoch=$(_ql_now_epoch)
+    if [ -n "$hb_epoch" ] && [ -n "$now_epoch" ]; then
+        age=$(( now_epoch - hb_epoch ))
+        [ "$age" -lt 0 ] && age=0
+        [ "$age" -ge "$ttl" ] && stale=1
+    else
+        echo "WARN queue-lock: could not parse heartbeat '$o_heartbeat' -- treating as FRESH (fail-closed on unparsable timestamps)" >&2
+    fi
+    if [ "$stale" -eq 1 ]; then
+        echo "status: STALE (age ${age}s >= ttl ${ttl}s)"
+        return 12
+    fi
+    # Aging warning (C2): heartbeat is not yet wired into the long-session
+    # flow, so a FRESH lock past half the TTL is drifting toward a stale
+    # takeover window -- surface it before it becomes one.
+    if [ "$age" -ge 0 ] && [ "$age" -ge $(( ttl / 2 )) ]; then
+        echo "WARN queue-lock: heartbeat age ${age}s exceeds half the TTL (${ttl}s) -- the lock is AGING toward stale; refresh it (queue-lock.sh heartbeat) on long sessions" >&2
+    fi
+    echo "status: FRESH"
+    return 11
+}
+
+_ql_main() {
+    local verb="${1:-}"
+    if [ -n "$verb" ]; then
+        shift
+    fi
+    case "$verb" in
+        acquire)   queue_lock_acquire "$@" ;;
+        heartbeat) queue_lock_heartbeat "$@" ;;
+        release)   queue_lock_release "$@" ;;
+        status)    queue_lock_status "$@" ;;
+        *)
+            _ql_usage >&2
+            return 1
+            ;;
+    esac
+}
+
+# Sourcing guard (bash 3.2-safe form of "is this file executed, not
+# sourced"), same idiom as shared-branch-lock.sh -- lets tests source this
+# file and call the queue_lock_* functions in-process.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+    _ql_main "$@"
+    exit $?
+fi

--- a/scripts/handover/test-arm-resume-queue-lock.sh
+++ b/scripts/handover/test-arm-resume-queue-lock.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# test-arm-resume-queue-lock.sh -- regression test for the HIMMEL-856
+# queue-lock + cross-machine arms-registry integration added to
+# scripts/handover/arm-resume.sh (rc=7 / rc=8 refusals + overrides).
+#
+# Kept SEPARATE from the (already large) test-arm-resume.sh so this
+# ticket's surface stays independently reviewable; both suites run
+# against the same arm-resume.sh and share its stubbing conventions
+# (PATH-stubbed schtasks/atq/at so no real scheduler job is ever
+# created; a throwaway WORKSPACE_TRUST_CONFIG and SKILL_TELEMETRY_DIR
+# so no operator state is touched).
+#
+# Usage: bash scripts/handover/test-arm-resume-queue-lock.sh
+# Exit:  0 = all pass, 1 = one or more failures.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ARM="$SCRIPT_DIR/arm-resume.sh"
+QL="$SCRIPT_DIR/queue-lock.sh"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Hermetic: fresh handover root, no real scheduler, no real telemetry/trust
+# writes (same shields test-arm-resume.sh uses).
+HANDOVER_DIR="$TMP/statedocs/handovers"
+mkdir -p "$HANDOVER_DIR"
+export HANDOVER_DIR
+export SKILL_TELEMETRY_DIR="$TMP/telemetry"
+export WORKSPACE_TRUST_CONFIG="$TMP/claude-trust.json"
+unset QUEUE_LOCK_TAKEOVER QUEUE_LOCK_TTL_SECONDS ARM_DUP_OK 2>/dev/null || true
+
+FUTURE_TIME="23:59"
+HO="$HANDOVER_DIR/HIMMEL-856-test/next-session-1.md"
+mkdir -p "$(dirname "$HO")"
+printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 test handover\n' > "$HO"
+
+FAILED=0
+assert_rc() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS $label (rc=$actual)"
+    else
+        echo "FAIL $label -- expected rc=$expected, got rc=$actual"
+        FAILED=$((FAILED + 1))
+    fi
+}
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    case "$haystack" in
+        *"$needle"*) echo "PASS $label" ;;
+        *) echo "FAIL $label -- output missing: $needle"; FAILED=$((FAILED + 1)) ;;
+    esac
+}
+assert_not_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    case "$haystack" in
+        *"$needle"*) echo "FAIL $label -- output unexpectedly contains: $needle"; FAILED=$((FAILED + 1)) ;;
+        *) echo "PASS $label" ;;
+    esac
+}
+
+# Empty-scheduler stub (same pattern as test-arm-resume.sh SCHED_STUB_T17):
+# /query (and atq/at) return nothing, rc 0 -- reads as "no existing jobs" so
+# the pre-existing same-machine dedup/collision checks never interfere with
+# these HIMMEL-856-specific assertions.
+SCHED_STUB="$TMP/sched-stub"
+mkdir -p "$SCHED_STUB"
+cat > "$SCHED_STUB/schtasks" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$SCHED_STUB/atq" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$SCHED_STUB/at" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$SCHED_STUB/schtasks" "$SCHED_STUB/atq" "$SCHED_STUB/at"
+export PATH="$SCHED_STUB:$PATH"
+
+# --- T1: no lock, no registry -> plain dry-run arm succeeds -----------------
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T1: no lock/registry, dry-run arm" 0 "$rc"
+
+# --- T2: queue lock FRESH -> arm refused rc=7 --------------------------------
+bash "$QL" acquire "$HO" "live-session" >/dev/null 2>&1
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T2: FRESH queue lock refuses arm" 7 "$rc"
+assert_contains "T2: stderr names the live holder" "live-session" "$out"
+assert_contains "T2: stderr names the override" "QUEUE_LOCK_TAKEOVER" "$out"
+
+# --- T3: QUEUE_LOCK_TAKEOVER=1 overrides the FRESH refusal -> rc=0, WARN ----
+out=$(QUEUE_LOCK_TAKEOVER=1 bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T3: QUEUE_LOCK_TAKEOVER=1 overrides FRESH refusal" 0 "$rc"
+assert_contains "T3: WARN present on override" "WARN arm-resume: queue lock is FRESH" "$out"
+
+# --- T4: release -> arm succeeds again without any override -----------------
+bash "$QL" release "$HO" "live-session" >/dev/null 2>&1
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T4: arm succeeds after release" 0 "$rc"
+
+# --- T5: STALE queue lock (TTL=0) does NOT refuse the arm --------------------
+bash "$QL" acquire "$HO" "old-session" >/dev/null 2>&1
+out=$(QUEUE_LOCK_TTL_SECONDS=0 bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T5: STALE lock (TTL=0) does not block arming" 0 "$rc"
+bash "$QL" release "$HO" "old-session" >/dev/null 2>&1
+
+# --- T6: arms.jsonl entry for the SAME host -> not a cross-machine dup ------
+mkdir -p "$HANDOVER_DIR/.locks"
+THIS_HOST=$(hostname 2>/dev/null || echo "${COMPUTERNAME:-${HOSTNAME:-unknown-host}}")
+printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-same-host"}\n' \
+    "$THIS_HOST" "$HO" > "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T6: same-host registry entry is not a cross-machine dup" 0 "$rc"
+
+# --- T7: arms.jsonl entry for a DIFFERENT host, SAME handover -> rc=8 -------
+printf '{"host":"other-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-other-host"}\n' \
+    "$HO" > "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T7: cross-host pending arm refuses (rc=8)" 8 "$rc"
+assert_contains "T7: stderr names the other host" "other-host" "$out"
+assert_contains "T7: stderr names the override" "ARM_DUP_OK" "$out"
+
+# --- T8: ARM_DUP_OK=1 overrides the cross-host refusal -> rc=0, WARN --------
+out=$(ARM_DUP_OK=1 bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T8: ARM_DUP_OK=1 overrides cross-host refusal" 0 "$rc"
+assert_contains "T8: WARN present on override" "WARN arm-resume: this handover already has a PENDING arm" "$out"
+
+# --- T9: arms.jsonl entry for an UNRELATED handover -> no false positive ----
+OTHER_HO="$HANDOVER_DIR/HIMMEL-856-test/next-session-2.md"
+: > "$OTHER_HO"
+printf '{"host":"other-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-unrelated"}\n' \
+    "$OTHER_HO" > "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T9: registry entry for a DIFFERENT handover is not a false-positive dup" 0 "$rc"
+rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
+
+# --- T10: a REAL (non-dry-run) arm against the stubbed scheduler appends a
+#          well-formed line to arms.jsonl ------------------------------------
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" 2>&1)
+rc=$?
+assert_rc "T10: stubbed real arm succeeds" 0 "$rc"
+if [ -f "$HANDOVER_DIR/.locks/arms.jsonl" ] \
+    && grep -q "\"handover\":\"$HO\"" "$HANDOVER_DIR/.locks/arms.jsonl" \
+    && grep -q '"task-name":"HIMMEL-Resume-' "$HANDOVER_DIR/.locks/arms.jsonl"; then
+    echo "PASS T10: arms.jsonl gained a well-formed record for this arm"
+else
+    echo "FAIL T10: arms.jsonl missing/malformed after a real arm ($(cat "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null || echo MISSING))"
+    FAILED=$((FAILED + 1))
+fi
+assert_not_contains "T10: dry-run banner absent on a real (non-dry-run) arm" "dry-run complete" "$out"
+
+# --- T11: post-append double-arm detection (HIMMEL-856 CR, codex-1) ---------
+# The registry check-then-append pair cannot be atomic across machines; the
+# mitigation is a re-read AFTER our own append that warns LOUDLY when another
+# host's arm for the same handover is visible. Simulate the double-arm by
+# pre-seeding the other host's line and arming with ARM_DUP_OK=1 (so the
+# pre-check lets us through, standing in for "their line landed in the
+# check->append window"): the arm must succeed (rc=0 -- the warning is
+# advisory, never a failure) AND the post-append warning must fire, naming
+# the other host.
+HO11="$HANDOVER_DIR/HIMMEL-856-test/next-session-11.md"
+printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t11 handover\n' > "$HO11"
+printf '{"host":"rival-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-rival"}\n' \
+    "$HO11" > "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(ARM_DUP_OK=1 bash "$ARM" --time "$FUTURE_TIME" --handover "$HO11" 2>&1)
+rc=$?
+assert_rc "T11: double-armed arm still succeeds (warning is advisory)" 0 "$rc"
+assert_contains "T11: post-append DOUBLE-ARM warning fires" "DOUBLE-ARM DETECTED" "$out"
+assert_contains "T11: warning names the rival host" "rival-host" "$out"
+# Our own record was still appended alongside the rival's.
+if grep -q "\"handover\":\"$HO11\"" "$HANDOVER_DIR/.locks/arms.jsonl" \
+    && [ "$(grep -c "\"handover\":\"$HO11\"" "$HANDOVER_DIR/.locks/arms.jsonl")" -eq 2 ]; then
+    echo "PASS T11: registry holds both hosts' records after the double-arm"
+else
+    echo "FAIL T11: registry does not hold both records ($(cat "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null || echo MISSING))"
+    FAILED=$((FAILED + 1))
+fi
+rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
+
+# --- T12: no false post-append warning on a clean single-host arm -----------
+HO12="$HANDOVER_DIR/HIMMEL-856-test/next-session-12.md"
+printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t12 handover\n' > "$HO12"
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO12" 2>&1)
+rc=$?
+assert_rc "T12: clean single-host arm succeeds" 0 "$rc"
+assert_not_contains "T12: no DOUBLE-ARM warning on a clean arm" "DOUBLE-ARM DETECTED" "$out"
+
+# --- T13: missing queue-lock.sh -> WARN + arm proceeds (imp-a) ---------------
+# Copy arm-resume.sh (+ its hard-required libs) into an isolated tree that
+# has NO queue-lock.sh next to it -- the check must WARN and skip, matching
+# the missing-handover-root WARN contract, never silently pass or fail.
+FAKE="$TMP/no-ql"
+mkdir -p "$FAKE/handover" "$FAKE/lib"
+cp "$SCRIPT_DIR/arm-resume.sh" "$FAKE/handover/arm-resume.sh"
+cp "$SCRIPT_DIR/../lib/py-armor.sh" "$FAKE/lib/py-armor.sh"
+cp "$SCRIPT_DIR/../lib/handover-path.sh" "$FAKE/lib/handover-path.sh"
+cp "$SCRIPT_DIR/../lib/telemetry.sh" "$FAKE/lib/telemetry.sh" 2>/dev/null || true
+HO13="$HANDOVER_DIR/HIMMEL-856-test/next-session-13.md"
+printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t13 handover\n' > "$HO13"
+out=$(bash "$FAKE/handover/arm-resume.sh" --time "$FUTURE_TIME" --handover "$HO13" --dry-run 2>&1)
+rc=$?
+assert_rc "T13: arm proceeds with queue-lock.sh missing" 0 "$rc"
+assert_contains "T13: WARN names the missing queue-lock.sh" "queue-lock.sh not found" "$out"
+
+# --- T14: unexpected queue-lock status rc -> WARN + arm proceeds (imp-b) ----
+# Same isolated tree, now with a stub queue-lock.sh that exits rc=5 (not
+# 0/11/12): the check must WARN 'proceeding' instead of silently treating
+# a broken status probe as a verified-free queue.
+printf '#!/usr/bin/env bash\necho "stub queue-lock exploded" >&2\nexit 5\n' > "$FAKE/handover/queue-lock.sh"
+out=$(bash "$FAKE/handover/arm-resume.sh" --time "$FUTURE_TIME" --handover "$HO13" --dry-run 2>&1)
+rc=$?
+assert_rc "T14: arm proceeds despite a broken status probe" 0 "$rc"
+assert_contains "T14: WARN reports the unexpected status rc" "queue-lock status failed (rc=5)" "$out"
+
+echo "---"
+echo "FAILED=$FAILED"
+[ "$FAILED" -eq 0 ]

--- a/scripts/handover/test-queue-lock.sh
+++ b/scripts/handover/test-queue-lock.sh
@@ -1,0 +1,409 @@
+#!/usr/bin/env bash
+# test-queue-lock.sh -- regression test for scripts/handover/queue-lock.sh
+# (HIMMEL-856 phase 1).
+#
+# Usage: bash scripts/handover/test-queue-lock.sh
+# Exit:  0 = all pass, 1 = one or more failures.
+#
+# Hermetic: points HANDOVER_DIR at a fresh mktemp -d for every test (never
+# touches the real handover root / HOME). Cleaned up with a trap on EXIT.
+# Invokes the script as a SUBPROCESS (bash queue-lock.sh <verb> ...) since
+# the contract under test is the CLI exit-code table.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/queue-lock.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "PASS: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "FAIL: $1"; FAILED=$((FAILED + 1)); }
+
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+HANDOVER_DIR="$TMPDIR_ROOT/handovers"
+mkdir -p "$HANDOVER_DIR"
+export HANDOVER_DIR
+unset QUEUE_LOCK_TAKEOVER QUEUE_LOCK_TTL_SECONDS
+
+HO1="$HANDOVER_DIR/HIMMEL-856-test/next-session-1.md"
+mkdir -p "$(dirname "$HO1")"
+: > "$HO1"
+
+# --- T1: acquire succeeds, owner.json has all fields ------------------------
+out="$(bash "$LIB" acquire "$HO1" "session-a" 2>&1)"
+rc=$?
+lockdir="$HANDOVER_DIR/.locks/queue/HIMMEL-856-test__next-session-1.lock"
+if [ "$rc" -eq 0 ]; then
+    pass "T1: acquire rc=0"
+else
+    fail "T1: acquire rc=0 (got $rc: $out)"
+fi
+if [ -f "$lockdir/owner.json" ] \
+    && grep -q '"session":"session-a"' "$lockdir/owner.json" \
+    && grep -q '"handover":"' "$lockdir/owner.json" \
+    && grep -q '"started":"' "$lockdir/owner.json" \
+    && grep -q '"heartbeat":"' "$lockdir/owner.json"; then
+    pass "T1: owner.json has session+handover+started+heartbeat"
+else
+    fail "T1: owner.json missing/incomplete ($(cat "$lockdir/owner.json" 2>/dev/null || echo 'MISSING'))"
+fi
+if printf '%s' "$out" | grep -q '^release-token: session-a$'; then
+    pass "T1: acquire prints the release-token line"
+else
+    fail "T1: acquire output missing 'release-token: session-a' (got: $out)"
+fi
+
+# --- T2: second acquire while FRESH -> rc 2, holder info + override hint ----
+err="$(bash "$LIB" acquire "$HO1" "session-b" 2>&1 1>/dev/null)"
+rc=$?
+if [ "$rc" -eq 2 ]; then
+    pass "T2: second acquire while FRESH rc=2"
+else
+    fail "T2: second acquire while FRESH rc=2 (got $rc: $err)"
+fi
+if printf '%s' "$err" | grep -q 'session=session-a' && printf '%s' "$err" | grep -qi 'QUEUE_LOCK_TAKEOVER'; then
+    pass "T2: stderr has holder info + takeover override hint"
+else
+    fail "T2: stderr missing holder info / override hint: $err"
+fi
+
+# --- T3: status FRESH -> rc 11 + owner contents ------------------------------
+out="$(bash "$LIB" status "$HO1" 2>&1)"
+rc=$?
+if [ "$rc" -eq 11 ] && printf '%s' "$out" | grep -q '"session":"session-a"' && printf '%s' "$out" | grep -qi 'FRESH'; then
+    pass "T3: status held-FRESH rc=11 + owner contents"
+else
+    fail "T3: status held-FRESH rc=11 + owner contents (got rc=$rc out=$out)"
+fi
+
+# --- T4: heartbeat by the wrong session is refused; by the right one succeeds
+err="$(bash "$LIB" heartbeat "$HO1" "session-b" 2>&1 1>/dev/null)"
+rc=$?
+if [ "$rc" -eq 2 ]; then
+    pass "T4: heartbeat by wrong session rc=2"
+else
+    fail "T4: heartbeat by wrong session rc=2 (got $rc)"
+fi
+bash "$LIB" heartbeat "$HO1" "session-a" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    pass "T4: heartbeat by holder session rc=0"
+else
+    fail "T4: heartbeat by holder session rc=0 (got $rc)"
+fi
+
+# --- T5: release by the wrong session is refused; by the right one succeeds -
+err="$(bash "$LIB" release "$HO1" "session-b" 2>&1 1>/dev/null)"
+rc=$?
+if [ "$rc" -eq 2 ]; then
+    pass "T5: release by wrong session rc=2"
+else
+    fail "T5: release by wrong session rc=2 (got $rc: $err)"
+fi
+if [ -d "$lockdir" ]; then
+    pass "T5: lock still held after refused release"
+else
+    fail "T5: lock was released despite session mismatch (C1 violation)"
+fi
+bash "$LIB" release "$HO1" "session-a" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ] && [ ! -d "$lockdir" ]; then
+    pass "T5: release by holder session rc=0, lock dir gone"
+else
+    fail "T5: release by holder session rc=0 + gone (got rc=$rc, dir-exists=$([ -d "$lockdir" ] && echo yes || echo no))"
+fi
+
+# --- T6: release of an absent lock (with a token) is idempotent (rc 0) ------
+bash "$LIB" release "$HO1" "any-token" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    pass "T6: release of absent lock rc=0 (idempotent)"
+else
+    fail "T6: release of absent lock rc=0 (got $rc)"
+fi
+
+# --- T7: status free -> rc 0, "free" ----------------------------------------
+out="$(bash "$LIB" status "$HO1" 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "free" ]; then
+    pass "T7: status free rc=0 + 'free'"
+else
+    fail "T7: status free rc=0 + 'free' (got rc=$rc out=$out)"
+fi
+
+# --- T8: re-acquire after release succeeds -----------------------------------
+bash "$LIB" acquire "$HO1" "session-c" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    pass "T8: re-acquire after release rc=0"
+else
+    fail "T8: re-acquire after release rc=0 (got $rc)"
+fi
+
+# --- T9: stale takeover -- QUEUE_LOCK_TTL_SECONDS=0 makes any lock STALE ----
+out="$(QUEUE_LOCK_TTL_SECONDS=0 bash "$LIB" status "$HO1" 2>&1)"
+rc=$?
+if [ "$rc" -eq 12 ] && printf '%s' "$out" | grep -qi 'STALE'; then
+    pass "T9: status STALE under TTL=0 rc=12"
+else
+    fail "T9: status STALE under TTL=0 rc=12 (got rc=$rc out=$out)"
+fi
+err="$(QUEUE_LOCK_TTL_SECONDS=0 bash "$LIB" acquire "$HO1" "session-d" 2>&1 1>/dev/null)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    pass "T9: acquire over a STALE lock (TTL=0) rc=0 (auto-takeover)"
+else
+    fail "T9: acquire over a STALE lock rc=0 (got $rc: $err)"
+fi
+if grep -q 'session-c' "$lockdir/takeovers.log" 2>/dev/null && grep -q 'session-d' "$lockdir/takeovers.log" 2>/dev/null; then
+    pass "T9: takeovers.log records previous + new holder"
+else
+    fail "T9: takeovers.log missing or incomplete ($(cat "$lockdir/takeovers.log" 2>/dev/null || echo MISSING))"
+fi
+if grep -q '"session":"session-d"' "$lockdir/owner.json" 2>/dev/null; then
+    pass "T9: owner.json now shows the new holder"
+else
+    fail "T9: owner.json not updated after takeover"
+fi
+bash "$LIB" release "$HO1" "session-d" >/dev/null 2>&1
+
+# --- T10: forced takeover of a still-FRESH lock via QUEUE_LOCK_TAKEOVER=1 ---
+bash "$LIB" acquire "$HO1" "session-e" >/dev/null 2>&1
+err="$(QUEUE_LOCK_TAKEOVER=1 bash "$LIB" acquire "$HO1" "session-f" 2>&1 1>/dev/null)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    pass "T10: forced takeover of a FRESH lock (QUEUE_LOCK_TAKEOVER=1) rc=0"
+else
+    fail "T10: forced takeover of a FRESH lock rc=0 (got $rc: $err)"
+fi
+if printf '%s' "$err" | grep -qi 'forced'; then
+    pass "T10: forced-takeover message names the reason"
+else
+    fail "T10: forced-takeover message missing 'forced' reason: $err"
+fi
+bash "$LIB" release "$HO1" "session-f" >/dev/null 2>&1
+
+# --- T11: distinct handover paths get DISTINCT locks (sibling queues) -------
+HO2="$HANDOVER_DIR/HIMMEL-856-test/next-session-2.md"
+: > "$HO2"
+bash "$LIB" acquire "$HO1" "session-g" >/dev/null 2>&1
+rc1=$?
+bash "$LIB" acquire "$HO2" "session-h" >/dev/null 2>&1
+rc2=$?
+if [ "$rc1" -eq 0 ] && [ "$rc2" -eq 0 ]; then
+    pass "T11: sibling handovers (next-session-1 vs -2) get independent locks"
+else
+    fail "T11: sibling handovers expected both rc=0, got rc1=$rc1 rc2=$rc2"
+fi
+bash "$LIB" release "$HO1" "session-g" >/dev/null 2>&1
+bash "$LIB" release "$HO2" "session-h" >/dev/null 2>&1
+
+# --- T12: usage errors --------------------------------------------------------
+bash "$LIB" acquire >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 1 ]; then
+    pass "T12: acquire with no args rc=1"
+else
+    fail "T12: acquire with no args rc=1 (got $rc)"
+fi
+bash "$LIB" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 1 ]; then
+    pass "T12: no verb at all rc=1"
+else
+    fail "T12: no verb at all rc=1 (got $rc)"
+fi
+bash "$LIB" bogus-verb "$HO1" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 1 ]; then
+    pass "T12: unknown verb rc=1"
+else
+    fail "T12: unknown verb rc=1 (got $rc)"
+fi
+
+# --- T13: concurrent acquire race -- exactly one of two subshells wins ------
+HO3="$HANDOVER_DIR/HIMMEL-856-test/next-session-3.md"
+: > "$HO3"
+OUT_A="$TMPDIR_ROOT/race-a.rc"
+OUT_B="$TMPDIR_ROOT/race-b.rc"
+( bash "$LIB" acquire "$HO3" "racer-a" >/dev/null 2>&1; echo $? > "$OUT_A" ) &
+( bash "$LIB" acquire "$HO3" "racer-b" >/dev/null 2>&1; echo $? > "$OUT_B" ) &
+wait
+rc_a="$(cat "$OUT_A")"
+rc_b="$(cat "$OUT_B")"
+# Exactly one rc=0 (winner) and one rc=2 (loser, FRESH refusal) -- order is
+# a race, so accept either winner.
+if { [ "$rc_a" -eq 0 ] && [ "$rc_b" -eq 2 ]; } || { [ "$rc_a" -eq 2 ] && [ "$rc_b" -eq 0 ]; }; then
+    pass "T13: concurrent acquire -- exactly one winner (rc_a=$rc_a rc_b=$rc_b)"
+else
+    fail "T13: concurrent acquire -- expected one 0 and one 2, got rc_a=$rc_a rc_b=$rc_b"
+fi
+# The race winner's token is unknown here -- use the emergency override.
+QUEUE_LOCK_FORCE_RELEASE=1 bash "$LIB" release "$HO3" >/dev/null 2>&1
+
+# --- T14: concurrent STALE-takeover race -- exactly one taker wins ----------
+# (HIMMEL-856 CR, codex-2: the takeover must be an atomic rename-then-acquire,
+# never an in-place owner.json rewrite that lets both takers "win".)
+# The stale lock is hand-crafted with an ANCIENT heartbeat under the DEFAULT
+# TTL -- deliberately not QUEUE_LOCK_TTL_SECONDS=0, which would make the
+# winner's brand-new lock instantly stale too and legitimize a second
+# takeover, turning the exactly-one-winner assertion into a coin flip.
+HO4="$HANDOVER_DIR/HIMMEL-856-test/next-session-4.md"
+: > "$HO4"
+LOCKDIR4="$HANDOVER_DIR/.locks/queue/HIMMEL-856-test__next-session-4.lock"
+mkdir -p "$LOCKDIR4"
+printf '{"session":"dead-session","host":"old-host","handover":"%s","started":"2020-01-01T00:00:00Z","heartbeat":"2020-01-01T00:00:00Z"}\n' \
+    "$HO4" > "$LOCKDIR4/owner.json"
+T14_A_RC="$TMPDIR_ROOT/t14-a.rc"; T14_A_ERR="$TMPDIR_ROOT/t14-a.err"
+T14_B_RC="$TMPDIR_ROOT/t14-b.rc"; T14_B_ERR="$TMPDIR_ROOT/t14-b.err"
+( bash "$LIB" acquire "$HO4" "taker-a" >/dev/null 2>"$T14_A_ERR"; echo $? > "$T14_A_RC" ) &
+( bash "$LIB" acquire "$HO4" "taker-b" >/dev/null 2>"$T14_B_ERR"; echo $? > "$T14_B_RC" ) &
+wait
+rc_a="$(cat "$T14_A_RC")"
+rc_b="$(cat "$T14_B_RC")"
+if { [ "$rc_a" -eq 0 ] && [ "$rc_b" -eq 2 ]; } || { [ "$rc_a" -eq 2 ] && [ "$rc_b" -eq 0 ]; }; then
+    pass "T14: concurrent stale-takeover -- exactly one winner (rc_a=$rc_a rc_b=$rc_b)"
+else
+    fail "T14: concurrent stale-takeover -- expected one 0 and one 2, got rc_a=$rc_a rc_b=$rc_b"
+fi
+if [ "$rc_a" -eq 0 ]; then
+    winner="taker-a"; loser_err="$T14_B_ERR"
+else
+    winner="taker-b"; loser_err="$T14_A_ERR"
+fi
+if grep -q "\"session\":\"$winner\"" "$LOCKDIR4/owner.json" 2>/dev/null; then
+    pass "T14: owner.json shows exactly the winning taker ($winner)"
+else
+    fail "T14: owner.json does not show the winner ($(cat "$LOCKDIR4/owner.json" 2>/dev/null || echo MISSING))"
+fi
+if grep -q 'dead-session' "$LOCKDIR4/takeovers.log" 2>/dev/null && grep -q "$winner" "$LOCKDIR4/takeovers.log" 2>/dev/null; then
+    pass "T14: takeovers.log carries old holder + winner"
+elif [ ! -f "$LOCKDIR4/takeovers.log" ] && grep -q "\"session\":\"$winner\"" "$LOCKDIR4/owner.json" 2>/dev/null; then
+    # Rare legal interleaving: the rc-0 acquirer's INITIAL mkdir landed in
+    # the claim-holder's rm->mkdir gap, so it acquired via the FRESH path
+    # (no trail written -- there was no lock dir when it arrived). The
+    # exactly-one-winner property (the actual codex-2 contract) still held.
+    pass "T14: fresh-path winner in the rm->mkdir gap (no trail required)"
+else
+    fail "T14: takeovers.log missing/incomplete ($(cat "$LOCKDIR4/takeovers.log" 2>/dev/null || echo MISSING))"
+fi
+if grep -qi 'held' "$loser_err" 2>/dev/null; then
+    pass "T14: loser reports held-by-other"
+else
+    fail "T14: loser stderr missing held-by-other report ($(cat "$loser_err" 2>/dev/null))"
+fi
+# No takeover-claim debris left behind (every exit path drops the claim).
+T14_DEBRIS=""
+for _g in "$HANDOVER_DIR"/.locks/queue/*.claim "$HANDOVER_DIR"/.locks/queue/*.taken.*; do
+    [ -e "$_g" ] && T14_DEBRIS="$_g"
+done
+if [ -n "$T14_DEBRIS" ]; then
+    fail "T14: takeover-claim debris leaked ($T14_DEBRIS)"
+else
+    pass "T14: no takeover-claim debris left in .locks/queue/"
+fi
+bash "$LIB" release "$HO4" "$winner" >/dev/null 2>&1
+
+# --- T15: mandatory session token on release/heartbeat (HIMMEL-856 CR C1) ---
+HO15="$HANDOVER_DIR/HIMMEL-856-test/next-session-15.md"
+: > "$HO15"
+LOCKDIR15="$HANDOVER_DIR/.locks/queue/HIMMEL-856-test__next-session-15.lock"
+bash "$LIB" acquire "$HO15" "session-t15" >/dev/null 2>&1
+err="$(bash "$LIB" release "$HO15" 2>&1 1>/dev/null)"
+rc=$?
+if [ "$rc" -eq 2 ] && [ -d "$LOCKDIR15" ]; then
+    pass "T15: token-less release refused rc=2, lock still held"
+else
+    fail "T15: token-less release refused rc=2 + held (got rc=$rc, dir-exists=$([ -d "$LOCKDIR15" ] && echo yes || echo no))"
+fi
+if printf '%s' "$err" | grep -q 'session-t15' && printf '%s' "$err" | grep -q 'QUEUE_LOCK_FORCE_RELEASE'; then
+    pass "T15: refusal names the current holder + the emergency override"
+else
+    fail "T15: refusal missing holder info / override hint: $err"
+fi
+bash "$LIB" heartbeat "$HO15" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 2 ]; then
+    pass "T15: token-less heartbeat refused rc=2"
+else
+    fail "T15: token-less heartbeat refused rc=2 (got $rc)"
+fi
+err="$(QUEUE_LOCK_FORCE_RELEASE=1 bash "$LIB" release "$HO15" 2>&1 1>/dev/null)"
+rc=$?
+if [ "$rc" -eq 0 ] && [ ! -d "$LOCKDIR15" ]; then
+    pass "T15: QUEUE_LOCK_FORCE_RELEASE=1 releases without a token"
+else
+    fail "T15: forced release rc=0 + gone (got rc=$rc)"
+fi
+if grep -q 'FORCED RELEASE' "$HANDOVER_DIR/.locks/queue/takeovers.log" 2>/dev/null \
+    && grep -q 'session-t15' "$HANDOVER_DIR/.locks/queue/takeovers.log" 2>/dev/null; then
+    pass "T15: forced release logged to the queue-level takeovers.log"
+else
+    fail "T15: queue-level takeovers.log missing the forced-release record ($(cat "$HANDOVER_DIR/.locks/queue/takeovers.log" 2>/dev/null || echo MISSING))"
+fi
+
+# --- T16: failed owner.json write never reports acquired (HIMMEL-856 CR C3) -
+# Source the script (the sourcing guard skips main) and override the atomic
+# writer to fail; acquire must return non-zero and remove the lock dir.
+HO16="$HANDOVER_DIR/HIMMEL-856-test/next-session-16.md"
+: > "$HO16"
+LOCKDIR16="$HANDOVER_DIR/.locks/queue/HIMMEL-856-test__next-session-16.lock"
+t16_out=$(bash -c '. "$1"; _ql_write_owner() { return 1; }; queue_lock_acquire "$2" "sess-t16"; echo "RC=$?"' _ "$LIB" "$HO16" 2>&1)
+if printf '%s' "$t16_out" | grep -q 'RC=1' && [ ! -d "$LOCKDIR16" ]; then
+    pass "T16: failed owner write -> rc=1 and the lock dir is removed"
+else
+    fail "T16: failed owner write (out=$t16_out, dir-exists=$([ -d "$LOCKDIR16" ] && echo yes || echo no))"
+fi
+if printf '%s' "$t16_out" | grep -q 'acquire FAILED' && ! printf '%s' "$t16_out" | grep -q 'release-token:'; then
+    pass "T16: loud failure, no acquired/token line emitted"
+else
+    fail "T16: failure output wrong (no loud error, or a token line leaked): $t16_out"
+fi
+
+# --- T17: status names a CORRUPT lock dir distinctly (HIMMEL-856 CR imp-c) --
+HO17="$HANDOVER_DIR/HIMMEL-856-test/next-session-17.md"
+: > "$HO17"
+LOCKDIR17="$HANDOVER_DIR/.locks/queue/HIMMEL-856-test__next-session-17.lock"
+mkdir -p "$LOCKDIR17"   # lock dir with NO owner.json = corrupt
+out="$(bash "$LIB" status "$HO17" 2>&1)"
+rc=$?
+if [ "$rc" -eq 11 ] && printf '%s' "$out" | grep -q 'CORRUPT'; then
+    pass "T17: corrupt lock dir -> rc=11 (fail-closed) and says CORRUPT"
+else
+    fail "T17: corrupt lock dir status (got rc=$rc out=$out)"
+fi
+QUEUE_LOCK_FORCE_RELEASE=1 bash "$LIB" release "$HO17" >/dev/null 2>&1
+
+# --- T18: status aging warning past half-TTL; WARN on unparsable heartbeat --
+HO18="$HANDOVER_DIR/HIMMEL-856-test/next-session-18.md"
+: > "$HO18"
+LOCKDIR18="$HANDOVER_DIR/.locks/queue/HIMMEL-856-test__next-session-18.lock"
+mkdir -p "$LOCKDIR18"
+# Heartbeat 2020-01-01: age ~2.05e8s. TTL=300000000 (3e8): half=1.5e8 < age
+# < ttl -> FRESH but AGING.
+printf '{"session":"ager","host":"h","handover":"%s","started":"2020-01-01T00:00:00Z","heartbeat":"2020-01-01T00:00:00Z"}\n' \
+    "$HO18" > "$LOCKDIR18/owner.json"
+err="$(QUEUE_LOCK_TTL_SECONDS=300000000 bash "$LIB" status "$HO18" 2>&1 1>/dev/null)"
+rc=$?
+if [ "$rc" -eq 11 ] && printf '%s' "$err" | grep -qi 'AGING'; then
+    pass "T18: FRESH lock past half-TTL warns AGING (rc stays 11)"
+else
+    fail "T18: aging warning (got rc=$rc err=$err)"
+fi
+printf '{"session":"ager","host":"h","handover":"%s","started":"garbage","heartbeat":"garbage"}\n' \
+    "$HO18" > "$LOCKDIR18/owner.json"
+err="$(bash "$LIB" status "$HO18" 2>&1 1>/dev/null)"
+rc=$?
+if [ "$rc" -eq 11 ] && printf '%s' "$err" | grep -qi 'could not parse heartbeat'; then
+    pass "T18: unparsable heartbeat -> WARN + treated FRESH (rc=11)"
+else
+    fail "T18: unparsable-heartbeat warn (got rc=$rc err=$err)"
+fi
+QUEUE_LOCK_FORCE_RELEASE=1 bash "$LIB" release "$HO18" >/dev/null 2>&1
+
+echo "---"
+echo "PASSED=$PASSED FAILED=$FAILED"
+[ "$FAILED" = 0 ]


### PR DESCRIPTION
## HIMMEL-856 — session queue locks + cross-machine arms registry (phase 1)

Structural one-writer-per-queue guard after the 2026-07-10 00:51 double-fire (two armed sessions worked the same queue). Per the design doc (state-repo specs/design/2026-07-10-himmel-856-session-queue-locks.md).

### Behavior
- `scripts/handover/queue-lock.sh`: `acquire / heartbeat / release / status` over a mkdir-atomic lock dir at `<handover-root>/.locks/queue/<slug>.lock/`.
  - **Stale takeover is CAS-protected**: mkdir claim sentinel → re-verify owner.json byte-match against the generation judged stale → rm → fresh mkdir → write → drop claim. Exactly one winner under concurrent load (60-iteration race hammer, 0 failures). The mv-graveyard alternative was empirically DISPROVEN on MSYS (contended `mv` returns rc-0 with missing/empty target) — recorded in the commit body.
  - **Release/heartbeat tokens are mandatory**: `acquire` prints a capture-friendly `release-token:` line; token-less or wrong-token release refuses rc=2 naming the holder (a token-less release could rm another session's live lock — the incident class itself). Lost token → `QUEUE_LOCK_FORCE_RELEASE=1`, loud + logged.
  - TTL default 6h (> the 3-4h overnight budget; `status` warns AGING past half-TTL; heartbeat documented as the tightening lever — operator TTL question stays open).
  - owner.json written atomically (tmp + same-dir mv, rc-checked); a failed write tears down the lock and returns rc=1 — never a false "acquired". Corrupt lock dirs are labeled CORRUPT (still fail-closed rc=11).
- `arm-resume.sh`: refuses to arm over a FRESH lock (rc=7, `QUEUE_LOCK_TAKEOVER=1` override) or a PENDING arm on another host in the `.locks/arms.jsonl` registry (rc=8, `ARM_DUP_OK=1`); records every successful arm; post-append re-scan prints a loud DOUBLE-ARM banner if a rival host's arm is visible. Layered defense documented in-code: registry = advisory early warning, queue lock = enforcement. All checks WARN-and-skip when infrastructure is absent — arming never bricks.
- `overnight-mode.md`: step-0 acquire (capture the token) + Phase-11 release.

### CR trail (s30, 2026-07-10 — 3 lanes, 2 rounds)
- Critic panel: 2 Critical (non-atomic takeover; check-then-append registry race) — takeover FIXED via the CAS mechanism; registry race mitigated + documented per the layered-defense adjudication.
- `code-reviewer`: VERDICTs agreed on both; independently converged on the same 2 new Criticals as the SFH (below); 2 suggestions → HIMMEL-882 filed (arms.jsonl lifecycle) + slug comment added.
- `silent-failure-hunter`: 3 Critical (token-less release bypass — the docs' own usage; heartbeat-never-wired + 90-min TTL < the workload it guards; torn owner.json = false-acquired immortal lock) + 4 Important — **all fixed** (round 2).

Suites: test-queue-lock 40/40 (8× consecutive + hammer), test-arm-resume-queue-lock 28/28, pre-existing arm-resume regression 219/219; shellcheck clean. Implemented by Sonnet (2 rounds); orchestration/adjudication Fable (s30). Phase 2 (ticket claims, registry lifecycle) = HIMMEL-882 + the design doc's later phases.
