### PR TITLE
fix(setup): [HIMMEL-880] shared hermetic-path lib; preflight-adopter suite keeps bash resolvable

### DIFF
--- a/scripts/lib/hermetic-path.sh
+++ b/scripts/lib/hermetic-path.sh
@@ -1,0 +1,99 @@
+# shellcheck shell=bash
+# scripts/lib/hermetic-path.sh
+#
+# Shared hermetic-PATH helpers for test suites that invoke a target script
+# under a PATH stripped of specific toolchain binaries (uv/pipx/node/npm/
+# bun/qmd, ...) so the suite can observe the target's "tool absent" branches
+# without depending on (or being confused by) the real dev machine's
+# toolchain.
+#
+# HIMMEL-874 / HIMMEL-880: on stock Ubuntu, npm (and other scrubbed tools)
+# lives in /usr/bin alongside bash and coreutils. Dropping every PATH dir
+# that carries a scrubbed tool therefore drops /usr/bin wholesale, which
+# takes bash itself down with it -- every subsequent
+# `PATH="$scrubbed" bash "$target" ...` invocation then fails to resolve
+# `bash` before running a single line of the target script. HIMMEL-874 fixed
+# this for scripts/test-adopt.sh by pre-linking bash + the essential tools
+# the target script needs into a hermetic stub dir BEFORE computing the
+# scrub, then prepending that stub dir to the scrubbed PATH so those tools
+# stay resolvable no matter which real dirs get dropped. HIMMEL-880 extracts
+# that fix here so scripts/test-preflight-adopter.sh (which had the identical
+# bug, added in the same HIMMEL-842 commit) can share it instead of
+# re-diverging.
+#
+# FUNCTIONS ONLY -- sourcing this file has no side effects. Callers:
+#
+#   1. link_hermetic_tool <tool> [dest_dir]
+#      Symlink <tool> (resolved via the CURRENT, un-scrubbed PATH) into
+#      dest_dir (default: $work/bin -- callers must set $work, or pass an
+#      explicit dest_dir). dest_dir must already exist (mkdir -p it)
+#      before calling -- the function never creates it. Falls back to a
+#      wrapper script that execs the real binary by absolute path if
+#      `ln -s` fails (e.g. no symlink support), and to a plain copy for
+#      `bash` specifically (a wrapper script needs a real bash on PATH to
+#      exec via its own #!/usr/bin/env bash shebang, so a wrapper can't
+#      bootstrap bash itself). Calls the caller's `fail "..."` (must be
+#      defined by the sourcing script, matching each suite's own
+#      diagnostic style) when the tool can't be found before the scrub OR
+#      when a fallback itself fails (bash copy, wrapper write, chmod).
+#
+#   2. path_dir_has_scrubbed_tool <dir> <tool>...
+#      True (rc 0) if <dir> carries any of the named tools (checked bare,
+#      .exe, .cmd for Windows).
+#
+#   3. scrub_path <path> <tool>...
+#      Returns <path> (colon-separated) with every dir carrying any named
+#      tool dropped wholesale. Empty PATH segments (leading, trailing, or
+#      mid-string "::") are ALWAYS dropped by design: an empty segment
+#      means implicit-cwd search, which a hermetic test PATH must never do.
+#
+# Callers MUST link bash + whatever tools their target script needs into a
+# stub dir BEFORE calling scrub_path, then prepend that stub dir ahead of the
+# scrubbed PATH on every hermetic invocation.
+
+link_hermetic_tool() {
+  local _tool="$1" _dest="${2:-$work/bin}" _src
+  _src=$(command -v "$_tool" 2>/dev/null) || fail "required test tool not found before PATH scrub: $_tool"
+  case "$_src" in
+    "$_dest/"*) return 0 ;;
+  esac
+  if ! ln -s "$_src" "$_dest/$_tool" 2>/dev/null; then
+    # bash can't get a self-referential wrapper (the wrapper below execs via
+    # #!/usr/bin/env bash, which needs a real bash on PATH). On symlink-
+    # restricted shells, copy the binary instead of hard-failing the suite.
+    if [ "$_tool" = "bash" ]; then
+      cp "$_src" "$_dest/bash" || fail "could not copy bash into hermetic stub dir"
+      chmod +x "$_dest/bash"
+      return 0
+    fi
+    {
+      printf '%s\n' '#!/usr/bin/env bash'
+      printf 'exec "%s" "$@"\n' "$_src"
+    } > "$_dest/$_tool" || fail "could not write hermetic wrapper for $_tool"
+    chmod +x "$_dest/$_tool" || fail "could not chmod hermetic wrapper for $_tool"
+  fi
+}
+
+path_dir_has_scrubbed_tool() {
+  local _dir="$1"; shift
+  local _tool
+  for _tool in "$@"; do
+    [ -x "$_dir/$_tool" ] && return 0
+    [ -x "$_dir/$_tool.exe" ] && return 0
+    [ -x "$_dir/$_tool.cmd" ] && return 0
+  done
+  return 1
+}
+
+scrub_path() {
+  local _in="$1"; shift
+  local _out="" _d _save_ifs2
+  _save_ifs2="$IFS"; IFS=':'
+  for _d in $_in; do
+    [ -n "$_d" ] || continue
+    path_dir_has_scrubbed_tool "$_d" "$@" && continue
+    _out="${_out:+$_out:}$_d"
+  done
+  IFS="$_save_ifs2"
+  printf '%s' "$_out"
+}

--- a/scripts/test-adopt.sh
+++ b/scripts/test-adopt.sh
@@ -75,28 +75,9 @@ exit 0
 STUB
 chmod +x "$work/bin/claude"
 
-link_hermetic_tool() {
-  local _tool="$1" _dest="${2:-$work/bin}" _src
-  _src=$(command -v "$_tool" 2>/dev/null) || fail "required test tool not found before PATH scrub: $_tool"
-  case "$_src" in
-    "$_dest/"*) return 0 ;;
-  esac
-  if ! ln -s "$_src" "$_dest/$_tool" 2>/dev/null; then
-    # bash can't get a self-referential wrapper (the wrapper below execs via
-    # #!/usr/bin/env bash, which needs a real bash on PATH). On symlink-
-    # restricted shells, copy the binary instead of hard-failing the suite.
-    if [ "$_tool" = "bash" ]; then
-      cp "$_src" "$_dest/bash" || fail "could not copy bash into hermetic stub dir"
-      chmod +x "$_dest/bash"
-      return 0
-    fi
-    {
-      printf '%s\n' '#!/usr/bin/env bash'
-      printf 'exec "%s" "$@"\n' "$_src"
-    } > "$_dest/$_tool"
-    chmod +x "$_dest/$_tool"
-  fi
-}
+# shellcheck source=lib/hermetic-path.sh
+# shellcheck disable=SC1091
+. "$repo_root/scripts/lib/hermetic-path.sh"
 
 for _tool in bash git jq python3 grep sed cat cp mv rm mkdir chmod diff wc tr head tail basename dirname mktemp sort cut; do
   link_hermetic_tool "$_tool"
@@ -123,16 +104,6 @@ PATH="$ut/stub:$PATH" link_hermetic_tool bash "$ut/bin"
 [ "$("$ut/bin/bash" -c 'echo ok')" = "ok" ] || fail "link_hermetic_tool self-test: bash copy-fallback produced a non-working bash"
 echo "ok: link_hermetic_tool wrapper-fallback (jq) + bash copy-fallback verified under forced ln failure"
 
-path_dir_has_scrubbed_tool() {
-  local _dir="$1" _tool
-  for _tool in qmd bun npm node uv pipx; do
-    [ -x "$_dir/$_tool" ] && return 0
-    [ -x "$_dir/$_tool.exe" ] && return 0
-    [ -x "$_dir/$_tool.cmd" ] && return 0
-  done
-  return 1
-}
-
 # Hermeticity (HIMMEL-752 CR): scrub every dir carrying a real qmd, bun, npm,
 # node, uv, or pipx from the suite-wide PATH. With bun absent, wire_qmd_core
 # takes its documented clean-skip branch, so NO test can fire a real
@@ -148,20 +119,10 @@ path_dir_has_scrubbed_tool() {
 # stubbed npm on top of this scrubbed base to exercise the build path; 12/13
 # re-add a stubbed node (and 13 a stubbed bun) for the npm-less-node preflight.
 #
-# Factored out so the exact scrub logic can also run over a synthetic PATH
-# (self-test below) without touching the suite's real PATH.
-scrub_path() {
-  local _in="$1" _out="" _d _save_ifs2
-  _save_ifs2="$IFS"; IFS=':'
-  for _d in $_in; do
-    path_dir_has_scrubbed_tool "$_d" && continue
-    _out="${_out:+$_out:}$_d"
-  done
-  IFS="$_save_ifs2"
-  printf '%s' "$_out"
-}
-
-qmd_free_path=$(scrub_path "$PATH")
+# Factored out (scripts/lib/hermetic-path.sh) so the exact scrub logic can
+# also run over a synthetic PATH (self-test below) without touching the
+# suite's real PATH.
+qmd_free_path=$(scrub_path "$PATH" qmd bun npm node uv pipx)
 export PATH="$work/bin:$qmd_free_path"
 PATH="$work/bin" command -v bash >/dev/null 2>&1 \
   || fail "hermetic stub dir must provide bash even if every scrubbed dir is removed"
@@ -179,7 +140,7 @@ done
 coloc="$work/coloc"; mkdir -p "$coloc"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$coloc/npm"; chmod +x "$coloc/npm"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$coloc/sed"; chmod +x "$coloc/sed"
-synthetic_scrubbed=$(scrub_path "$coloc:$work/bin")
+synthetic_scrubbed=$(scrub_path "$coloc:$work/bin" qmd bun npm node uv pipx)
 case ":$synthetic_scrubbed:" in
   *":$coloc:"*) fail "self-test: co-located dir with npm+sed was not scrubbed" ;;
 esac

--- a/scripts/test-preflight-adopter.sh
+++ b/scripts/test-preflight-adopter.sh
@@ -61,23 +61,34 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# shellcheck source=lib/hermetic-path.sh
+# shellcheck disable=SC1091
+. "$repo_root/scripts/lib/hermetic-path.sh"
+
 # Hermeticity: scrub every dir carrying a real uv/pipx/node/npm/bun off PATH so
 # no scenario below can observe (or be confused by) the real dev machine's
 # toolchain. Scenarios re-add their own stubs on top of this scrubbed base.
-scrub_path=""
-_save_ifs="$IFS"; IFS=':'
-for _d in $PATH; do
-  { [ -x "$_d/uv" ] || [ -x "$_d/pipx" ] || [ -x "$_d/node" ] || [ -x "$_d/npm" ] || [ -x "$_d/bun" ]; } && continue
-  scrub_path="${scrub_path:+$scrub_path:}$_d"
+#
+# HIMMEL-880: on stock Ubuntu npm lives in /usr/bin alongside bash itself, so
+# the scrub below drops bash wholesale and every `PATH="$tool_free_path" bash
+# ...` invocation below fails to resolve bash before running a single line of
+# the target script (the identical bug HIMMEL-874 fixed in test-adopt.sh).
+# Pre-link bash + the tools preflight-adopter.sh needs into a hermetic stub
+# dir BEFORE scrubbing, then prepend that stub dir on every invocation below.
+mkdir -p "$work/bin"
+for _tool in bash dirname sed; do
+  link_hermetic_tool "$_tool"
 done
-IFS="$_save_ifs"
+tool_free_path=$(scrub_path "$PATH" uv pipx node npm bun)
+PATH="$work/bin" command -v bash >/dev/null 2>&1 \
+  || fail "hermetic stub dir must provide bash even if every scrubbed dir is removed"
 
 # ── 1. standalone, fully clean env -> "0 warnings", exit 0 ───────────────────
 c1bin="$work/c1bin"; mkdir -p "$c1bin"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$c1bin/uv"; chmod +x "$c1bin/uv"
 mkdir -p "$real_jira_dist"; : > "$real_jira_dist/index.js"
 mkdir -p "$real_jira_node_modules"
-out=$(PATH="$c1bin:$scrub_path" bash "$preflight" 2>&1); rc=$?
+out=$(PATH="$c1bin:$work/bin:$tool_free_path" bash "$preflight" 2>&1); rc=$?
 rm -rf "$real_jira_dist" "$real_jira_node_modules"
 [ "$rc" -eq 0 ] || fail "clean env: expected exit 0, got $rc"
 printf '%s' "$out" | grep -q '0 warnings' || fail "clean env: missing '0 warnings' summary (got: $out)"
@@ -89,7 +100,7 @@ c2bin="$work/c2bin"; mkdir -p "$c2bin"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$c2bin/pipx"; chmod +x "$c2bin/pipx"
 mkdir -p "$real_jira_dist"; : > "$real_jira_dist/index.js"
 mkdir -p "$real_jira_node_modules"
-out=$(PATH="$c2bin:$scrub_path" bash "$preflight" 2>&1); rc=$?
+out=$(PATH="$c2bin:$work/bin:$tool_free_path" bash "$preflight" 2>&1); rc=$?
 rm -rf "$real_jira_dist" "$real_jira_node_modules"
 [ "$rc" -eq 0 ] || fail "pipx-only: expected exit 0, got $rc"
 printf '%s' "$out" | grep -q '0 warnings' || fail "pipx-only: missing '0 warnings' summary (got: $out)"
@@ -99,7 +110,7 @@ echo "ok: pipx present (uv absent) reports 0 warnings, exit 0"
 # ── 3. uv+pipx both absent -> WARN, exit 0 (non-strict default) ──────────────
 mkdir -p "$real_jira_dist"; : > "$real_jira_dist/index.js"
 mkdir -p "$real_jira_node_modules"
-out=$(PATH="$scrub_path" bash "$preflight" 2>&1); rc=$?
+out=$(PATH="$work/bin:$tool_free_path" bash "$preflight" 2>&1); rc=$?
 rm -rf "$real_jira_dist" "$real_jira_node_modules"
 [ "$rc" -eq 0 ] || fail "uv/pipx gap: non-strict should exit 0, got $rc"
 printf '%s' "$out" | grep -q "neither 'uv' nor 'pipx' found" || fail "uv/pipx gap: missing WARN text (got: $out)"
@@ -112,7 +123,7 @@ printf '#!/usr/bin/env bash\nexit 0\n' > "$c4bin/uv";   chmod +x "$c4bin/uv"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$c4bin/node"; chmod +x "$c4bin/node"
 mkdir -p "$real_jira_dist"; : > "$real_jira_dist/index.js"
 mkdir -p "$real_jira_node_modules"
-out=$(PATH="$c4bin:$scrub_path" bash "$preflight" 2>&1); rc=$?
+out=$(PATH="$c4bin:$work/bin:$tool_free_path" bash "$preflight" 2>&1); rc=$?
 rm -rf "$real_jira_dist" "$real_jira_node_modules"
 [ "$rc" -eq 0 ] || fail "node-without-npm: non-strict should exit 0, got $rc"
 printf '%s' "$out" | grep -q "'node' found but 'npm' is missing" || fail "node-without-npm: missing WARN text (got: $out)"
@@ -122,7 +133,7 @@ echo "ok: node-without-npm WARNs and exits 0 (non-strict)"
 c5bin="$work/c5bin"; mkdir -p "$c5bin"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$c5bin/uv"; chmod +x "$c5bin/uv"
 # real_jira_dist / real_jira_node_modules stay absent (moved-aside baseline).
-out=$(PATH="$c5bin:$scrub_path" bash "$preflight" 2>&1); rc=$?
+out=$(PATH="$c5bin:$work/bin:$tool_free_path" bash "$preflight" 2>&1); rc=$?
 [ "$rc" -eq 0 ] || fail "jira-dist gap: non-strict should exit 0, got $rc"
 printf '%s' "$out" | grep -q 'scripts/jira/dist/index.js not built' || fail "jira-dist gap: missing WARN text (got: $out)"
 echo "ok: jira dist+node_modules absent WARNs and exits 0 (non-strict)"
@@ -132,7 +143,7 @@ echo "ok: jira dist+node_modules absent WARNs and exits 0 (non-strict)"
 c6bin="$work/c6bin"; mkdir -p "$c6bin"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$c6bin/uv"; chmod +x "$c6bin/uv"
 set +e
-out=$(PATH="$c6bin:$scrub_path" bash "$preflight" --strict 2>&1); rc=$?
+out=$(PATH="$c6bin:$work/bin:$tool_free_path" bash "$preflight" --strict 2>&1); rc=$?
 set -e
 [ "$rc" -eq 1 ] || fail "--strict with a WARN present should exit 1, got $rc"
 printf '%s' "$out" | grep -q 'Re-run with --strict' || true  # informational only when warns==0; not asserted here
@@ -143,7 +154,7 @@ c7bin="$work/c7bin"; mkdir -p "$c7bin"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$c7bin/uv"; chmod +x "$c7bin/uv"
 mkdir -p "$real_jira_dist"; : > "$real_jira_dist/index.js"
 mkdir -p "$real_jira_node_modules"
-out=$(PATH="$c7bin:$scrub_path" bash "$preflight" --strict 2>&1); rc=$?
+out=$(PATH="$c7bin:$work/bin:$tool_free_path" bash "$preflight" --strict 2>&1); rc=$?
 rm -rf "$real_jira_dist" "$real_jira_node_modules"
 [ "$rc" -eq 0 ] || fail "--strict with a clean env should exit 0, got $rc"
 printf '%s' "$out" | grep -q '0 warnings' || fail "--strict clean env: missing '0 warnings' summary (got: $out)"


### PR DESCRIPTION
Public leg of private #1095 (HIMMEL-880).

`test-preflight-adopter.sh` carried the identical hermetic PATH-scrub bug HIMMEL-874 fixed in `test-adopt.sh` — the scrub dropped every PATH dir carrying uv/pipx/node/npm/bun with no bash pre-link. New shared lib `scripts/lib/hermetic-path.sh` (extracted from `test-adopt.sh`, tool list parameterized); both suites are consumers. Suites: 9/9 + 27/27; shellcheck clean; 2 CR rounds (panel + codex adversarial + 4 pr-review-toolkit reviewers) clean at ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
