### PR TITLE
fix(guardrails): [HIMMEL-879] case-fold + normalization-hardened shared secret-basename predicate

### DIFF
--- a/scripts/guardrails/lib.sh
+++ b/scripts/guardrails/lib.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 # scripts/guardrails/lib.sh - shared git-state predicates.
 #
-# Sourced by:
+# Sourced by (non-exhaustive - grep for `guardrails/lib.sh` for the full
+# consumer set):
 #   - scripts/hooks/check-worktree-isolation.sh
 #   - scripts/hooks/check-pr-lane-isolation.sh
 #   - scripts/hooks/check-merged-branch.sh
 #   - scripts/hooks/check-push-target.sh
 #   - scripts/hooks/block-edit-on-main.sh
+#   - scripts/hooks/block-read-secrets.sh
 #   - scripts/guardrails/guard-gh.sh
 #
 # Contract: each predicate returns one of:
@@ -284,4 +286,66 @@ warn_doc_guard_off() {
         echo "⚠ doc-guard is OFF: this looks like a himmel-source checkout but .himmel-dev is missing. Run 'touch .himmel-dev' (see docs/contributing.md) to enable the catalog-sync gate." >&2
     fi
     return 0
+}
+
+# is_secret_basename PATH_OR_TOKEN
+# True iff PATH_OR_TOKEN's basename matches a secret-file pattern (.env,
+# .envrc, id_rsa, id_ed25519, credentials.json, secrets.y[a]ml, *.pem, *.key,
+# *.p12, *.pfx). Basename match only (path-prefix agnostic); globs, no regex.
+# Non-secret env TEMPLATES (.env.example, .env.sample, .env.template,
+# .env.dist — committed, scrubbed placeholders) are carved out BEFORE the
+# .env.* arm (first-match-wins) so reading them is allowed.
+#
+# BOTH separators are treated as basename boundaries: `/` and `\` -
+# backslash is a path separator on Windows, and tool inputs (Read/Grep
+# file_path, PowerShell commands) carry native backslash paths there, so
+# stripping only `/` would let `C:\repo\.ENV` through as one giant
+# non-matching "basename" (HIMMEL-879). On POSIX a literal backslash in a
+# filename over-matches toward blocking - fail-closed, acceptable.
+#
+# The basename is lowercased BEFORE matching (tr, bash-3.2-safe - no
+# ${var,,}): git ls-files/check-ignore fold case on Windows/macOS
+# (core.ignorecase=true), so a mixed-case name (.ENV, ID_RSA) would
+# otherwise dodge these lowercase case-arms while the filesystem still
+# treats it as the same file (HIMMEL-879). Case arms below stay lowercase.
+#
+# Trailing SPACES and DOTS are then stripped (same normalization-divergence
+# class): Win32 CreateFile / Node fs strip trailing spaces and dots from
+# path components, so ".env " / ".env." open the SAME file as .env - the
+# predicate mirrors that OS normalization or the literal-string match lets
+# them through. This also normalizes ".env.example " onto the template
+# carve-out (allowed), consistent with what the OS actually opens.
+#
+# A single leading/trailing quote char (' or ") is stripped first - a caller
+# that tokenizes raw shell command text (block-read-secrets.sh) may hand in
+# a token still carrying a quote glued on by its quote-naive splitter (e.g.
+# `'.env'` from `cat '.env'`); a clean path (block-edit-on-main.sh, jq-
+# extracted) passes through the strip unchanged.
+#
+# Shared by block-read-secrets.sh and block-edit-on-main.sh - this predicate
+# is the single source of truth for the secret-basename pattern list; do NOT
+# fork a second copy. Deterministic - always returns 0 or 1, never 2 (rc=2 is
+# reserved for "predicate cannot be evaluated", which never applies here).
+is_secret_basename() {
+    local p="${1#\"}"; p="${p#\'}"
+    p="${p%\"}"; p="${p%\'}"
+    local base="${p##*/}"
+    base="${base##*\\}"
+    base=$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')
+    # Strip ALL trailing spaces/dots (Windows path-component normalization,
+    # see header). bash-3.2-safe loop; terminates on empty string.
+    while :; do
+        case "$base" in
+            *" "|*.) base="${base%?}" ;;
+            *)       break ;;
+        esac
+    done
+    case "$base" in
+        .env.example|.env.sample|.env.template|.env.dist) return 1 ;;
+        .env|.env.*|.envrc|id_rsa|id_ed25519|credentials.json|secrets.yaml|secrets.yml)
+            return 0 ;;
+        *.pem|*.key|*.p12|*.pfx)
+            return 0 ;;
+    esac
+    return 1
 }

--- a/scripts/hooks/block-edit-on-main.sh
+++ b/scripts/hooks/block-edit-on-main.sh
@@ -230,35 +230,14 @@ else
     block_reason="main"
 fi
 
-# Secret-file class (HIMMEL-876 CR carve-out). MIRRORS is_secret_path() in
-# block-read-secrets.sh — that hook is the source of truth for this pattern
-# set; KEEP THE TWO LISTS IN SYNC when either changes. A secret file (.env,
-# keys, credentials) is typically gitignored precisely BECAUSE it is
-# sensitive machine-local state — exempting it below would let an unattended
-# Write clobber the REAL .env in the primary checkout, a trust-boundary
-# regression the pre-exemption hook incidentally prevented. Basename match,
-# path-prefix agnostic, globs only. The basename is lowercased BEFORE the
-# match (tr, bash-3.2-safe — no ${var,,}): git ls-files/check-ignore fold
-# case on Windows/macOS (core.ignorecase=true), so `.ENV` would otherwise
-# slip past these lowercase arms yet still read as ignored (matching .env)
-# and take the exemption — clobbering the real .env on a case-insensitive
-# filesystem. Case arms stay lowercase.
-is_secret_basename() {
-    local base="${1##*/}"
-    base=$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')
-    case "$base" in
-        # Non-secret env TEMPLATES (committed placeholders) — carved out
-        # BEFORE the .env.* secret arm, first-match-wins (same order as
-        # block-read-secrets.sh).
-        .env.example|.env.sample|.env.template|.env.dist) return 1 ;;
-        .env|.env.*|.envrc|id_rsa|id_ed25519|credentials.json|secrets.yaml|secrets.yml)
-            return 0 ;;
-        *.pem|*.key|*.p12|*.pfx)
-            return 0 ;;
-    esac
-    return 1
-}
-
+# Secret-file class (HIMMEL-876 CR carve-out). A secret file (.env, keys,
+# credentials) is typically gitignored precisely BECAUSE it is sensitive
+# machine-local state — exempting it below would let an unattended Write
+# clobber the REAL .env in the primary checkout, a trust-boundary regression
+# the pre-exemption hook incidentally prevented. `is_secret_basename` (shared
+# with block-read-secrets.sh, HIMMEL-879 — see scripts/guardrails/lib.sh for
+# the pattern list + case-fold rationale) is sourced above.
+#
 # Untracked + gitignored exemption (HIMMEL-876): the guard's purpose is
 # protecting TRACKED code from an on-main/primary-feature commit — a file
 # that is both untracked AND gitignored (e.g. the HIMMEL-727 operator-local

--- a/scripts/hooks/block-read-secrets.sh
+++ b/scripts/hooks/block-read-secrets.sh
@@ -70,6 +70,10 @@
 #     territory; the gate targets the common accidental shapes.
 #   * `cat <<< .env` here-string normalises to `cat < < < .env` and trips the
 #     `<`-redirect path though it reads no file.
+#   * NTFS alternate data streams: `.env:stream` is not matched (low risk —
+#     POSIX toolchains don't address ADS via the colon syntax).
+#   * 8.3 short names: `ENV~1` is not matched (short-name generation is off
+#     by default on modern NTFS volumes).
 #
 # Hook input arrives on stdin as JSON. Exit codes:
 #   0 — allow (default)
@@ -80,6 +84,14 @@
 # re-enable. Or comment the hook in .claude/settings.json.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../guardrails/lib.sh
+# shellcheck disable=SC1091
+if ! . "$SCRIPT_DIR/../guardrails/lib.sh" 2>/dev/null; then
+    echo "block-read-secrets: cannot source guardrails/lib.sh — refusing to evaluate" >&2
+    exit 2
+fi
+
 if ! command -v jq >/dev/null 2>&1; then
     echo "block-read-secrets: jq not on PATH — refusing to evaluate; install jq or comment the hook in .claude/settings.json" >&2
     exit 2
@@ -88,25 +100,12 @@ fi
 input=$(cat)
 tool=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)
 
+# is_secret_path: this hook's name for the shared is_secret_basename predicate
+# (scripts/guardrails/lib.sh, HIMMEL-879 — pattern list + case-fold rationale
+# live there; also shared with block-edit-on-main.sh). Kept as a thin wrapper
+# so the many call sites below don't need to change name.
 is_secret_path() {
-    # Match against basename (path-prefix agnostic). Globs only; no regex.
-    local p="${1#\"}"; p="${p#\'}"
-    p="${p%\"}"; p="${p%\'}"
-    local base="${p##*/}"
-    case "$base" in
-        # Non-secret env TEMPLATES — committed placeholder files whose whole
-        # purpose is to be shareable (the himmel one is verified scrubbed,
-        # HIMMEL-286). Reading these is safe; carve them out BEFORE the .env.*
-        # secret arm (first-match-wins) so the bridge/operator can `cat .env.example`
-        # without the guard mis-firing. Real value files (.env, .env.local,
-        # .env.production, …) are NOT listed here and stay blocked.
-        .env.example|.env.sample|.env.template|.env.dist) return 1 ;;
-        .env|.env.*|.envrc|id_rsa|id_ed25519|credentials.json|secrets.yaml|secrets.yml)
-            return 0 ;;
-        *.pem|*.key|*.p12|*.pfx)
-            return 0 ;;
-    esac
-    return 1
+    is_secret_basename "$@"
 }
 
 is_reader_cmd() {

--- a/scripts/hooks/test-block-edit-on-main.sh
+++ b/scripts/hooks/test-block-edit-on-main.sh
@@ -476,6 +476,21 @@ assert_rc "T37 untracked .ENV on main blocks (case-insensitive carve-out)" 2 \
 assert_rc "T37b untracked ID_RSA on main blocks (case-insensitive carve-out)" 2 \
     "$(rc_of "$SANDBOX/casesecretrepo/ID_RSA")"
 
+# T37c/T37d: trailing-space / trailing-dot secret basenames (".env ", ".env.")
+# on main -> BLOCKED (HIMMEL-879 Windows normalization: Win32 CreateFile /
+# Node fs strip trailing spaces/dots, so ".env " opens the same file as .env).
+# Layer-agnostic like T37: which layer denies depends on the host filesystem
+# (a case/normalization-insensitive check-ignore may fold the name onto the
+# '.env' ignore line and only the stripped is_secret_basename carve-out
+# denies; elsewhere the untracked-not-ignored fall-through denies) — assert
+# only the outward rc=2. No fixture file is created: the hook never requires
+# the edit target to exist (Write targets are pre-creation), and NTFS itself
+# refuses trailing-space/dot names.
+assert_rc "T37c untracked '.env ' (trailing space) on main blocks (HIMMEL-879)" 2 \
+    "$(rc_of "$SANDBOX/casesecretrepo/.env ")"
+assert_rc "T37d untracked '.env.' (trailing dot) on main blocks (HIMMEL-879)" 2 \
+    "$(rc_of "$SANDBOX/casesecretrepo/.env.")"
+
 # Clean up the worktree registration before removing the sandbox (avoids a
 # dangling `git worktree` admin record under SANDBOX/wtrepo).
 git -C "$SANDBOX/wtrepo" worktree remove --force "$SANDBOX/wtrepo/.claude/worktrees/feat+x" 2>/dev/null || true

--- a/scripts/hooks/test-block-read-secrets.sh
+++ b/scripts/hooks/test-block-read-secrets.sh
@@ -145,9 +145,109 @@ assert_rc "Bash bash -c 'sed -i s/a/b/ .env'" 0 "$(run_case "$(j_bash "bash -c '
 # boundary tracking stops the recursed-arg scan at the body's closing quote.
 assert_rc "Bash bash -c 'cat config.json' .env" 0 "$(run_case "$(j_bash "bash -c 'cat config.json' .env")")"
 
+# --- HIMMEL-879: case-varied secret basenames must still block ---
+# Windows/macOS filesystems are case-insensitive; is_secret_path/
+# is_secret_basename must fold case BEFORE matching so a case-varied read
+# (.ENV, ID_RSA, SECRETS.YAML, a mixed-case .pem) doesn't bypass the guard.
+assert_rc "Bash cat .ENV (uppercase)"          2 "$(run_case "$(j_bash 'cat .ENV')")"
+assert_rc "Bash cat ID_RSA (uppercase)"        2 "$(run_case "$(j_bash 'cat ~/.ssh/ID_RSA')")"
+assert_rc "Bash cat SECRETS.YAML (uppercase)"  2 "$(run_case "$(j_bash 'cat SECRETS.YAML')")"
+assert_rc "Bash cat KEY.PEM (uppercase ext)"   2 "$(run_case "$(j_bash 'cat KEY.PEM')")"
+assert_rc "Read .ENV (uppercase)"              2 "$(run_case "$(j_read '/home/user/.ENV')")"
+assert_rc "Grep path=ID_ED25519 (uppercase)"   2 "$(run_case "$(j_grep 'ID_ED25519')")"
+assert_rc "PowerShell Get-Content .ENV"        2 "$(run_case "$(j_pwsh 'Get-Content .ENV')")"
+# Template carve-out is also case-folded: an uppercase committed placeholder
+# still reads as allowed, not as a secret.
+assert_rc "Bash cat .ENV.EXAMPLE (uppercase)"  0 "$(run_case "$(j_bash 'cat .ENV.EXAMPLE')")"
+
+# --- HIMMEL-879: trailing-space/dot normalization bypass (Windows) ---
+# Win32 CreateFile / Node fs strip trailing spaces and dots from path
+# components, so "/repo/.env " opens the SAME file as /repo/.env — the
+# predicate must mirror that or the literal match lets it through.
+assert_rc "Read .env<space> (trailing space)"  2 "$(run_case "$(j_read '/repo/.env ')")"
+assert_rc "Grep path=.env. (trailing dot)"     2 "$(run_case "$(j_grep '/repo/.env.')")"
+
+# Quote + uppercase through the real Bash clause tokenizer: the quote strip
+# and the case fold must compose (`'.ENV'` -> `.ENV` -> `.env`).
+assert_rc "Bash cat '.ENV' (quoted uppercase)" 2 "$(run_case "$(j_bash "cat '.ENV'")")"
+
+# --- HIMMEL-879: native Windows backslash paths ---
+# Read/Grep/PowerShell tool inputs carry backslash paths on Windows; the
+# predicate must treat `\` as a path separator too, or `C:\repo\.ENV`
+# lowercases to one giant non-matching "basename" and slips through.
+assert_rc "Read C:\\repo\\.ENV (backslash path)" 2 \
+    "$(run_case "$(j_read 'C:\repo\.ENV')")"
+assert_rc "PowerShell Get-Content C:\\repo\\.ENV" 2 \
+    "$(run_case "$(j_pwsh 'Get-Content C:\repo\.ENV')")"
+
+# --- Missing guardrails/lib.sh fails CLOSED (mirrors test-block-edit-on-main
+# T19). An unguarded source under set -e exits rc=1, which PreToolUse does NOT
+# block on — fail OPEN. The guard must fail CLOSED (rc=2 + recognisable
+# message), even on a payload it would otherwise block anyway.
+GUARDRAILLESS=$(mktemp -d)
+mkdir -p "$GUARDRAILLESS/hooks"
+cp "$HOOK" "$GUARDRAILLESS/hooks/"
+err=$(printf '%s' "$(j_bash 'cat .env')" | bash "$GUARDRAILLESS/hooks/block-read-secrets.sh" 2>&1 >/dev/null); rc=$?
+assert_rc "Missing guardrails lib fails closed" 2 "$rc"
+case "$err" in
+    *"cannot source guardrails/lib.sh"*) echo "PASS missing-lib refusal message" ;;
+    *) echo "FAIL missing-lib refusal message — got: $err"; FAILED=$((FAILED + 1)) ;;
+esac
+rm -rf "$GUARDRAILLESS" 2>/dev/null || true
+
 # --- BYPASS case (expect rc=0 with READ_SECRETS_OK=1) ---
 assert_rc "Bypass cat .env"                0 "$(run_case "$(j_bash 'cat .env')" "READ_SECRETS_OK=1")"
 assert_rc "Bypass Read .env"               0 "$(run_case "$(j_read '/proj/.env')" "READ_SECRETS_OK=1")"
+
+# --- Direct tests of the shared predicate (scripts/guardrails/lib.sh) ---
+# Exercises is_secret_basename in isolation, independent of either hook's
+# tool-dispatch/tokenizer plumbing above.
+LIB_DIR="$(cd "$(dirname "$0")/../guardrails" && pwd)"
+# shellcheck source=../guardrails/lib.sh
+# shellcheck disable=SC1091
+. "$LIB_DIR/lib.sh"
+
+assert_predicate() {
+    local label="$1" expected="$2" arg="$3"
+    local actual=0
+    is_secret_basename "$arg" || actual=$?
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS $label (rc=$actual)"
+    else
+        echo "FAIL $label — expected rc=$expected, got rc=$actual"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+assert_predicate "is_secret_basename .env"                    0 ".env"
+assert_predicate "is_secret_basename .ENV (uppercase)"        0 ".ENV"
+assert_predicate "is_secret_basename /abs/path/.env"          0 "/abs/path/.env"
+assert_predicate "is_secret_basename id_rsa"                  0 "id_rsa"
+assert_predicate "is_secret_basename ID_RSA (uppercase)"      0 "ID_RSA"
+assert_predicate "is_secret_basename SECRETS.YAML (uppercase)" 0 "SECRETS.YAML"
+assert_predicate "is_secret_basename secrets.yml"              0 "secrets.yml"
+assert_predicate "is_secret_basename KEY.PEM (uppercase ext)" 0 "KEY.PEM"
+assert_predicate "is_secret_basename foo.p12"                 0 "foo.p12"
+assert_predicate "is_secret_basename quoted '.env'"            0 "'.env'"
+assert_predicate "is_secret_basename .env.example (template)" 1 ".env.example"
+assert_predicate "is_secret_basename .ENV.EXAMPLE (uppercase template)" 1 ".ENV.EXAMPLE"
+assert_predicate "is_secret_basename README.md (non-secret)"  1 "README.md"
+assert_predicate "is_secret_basename src/README.md"           1 "src/README.md"
+# Trailing-space/dot normalization (Windows strips them; the predicate must too).
+assert_predicate "is_secret_basename '.env ' (trailing space)"     0 ".env "
+assert_predicate "is_secret_basename '.env  ' (two trailing spaces)" 0 ".env  "
+assert_predicate "is_secret_basename '.ENV ' (uppercase + space)"  0 ".ENV "
+assert_predicate "is_secret_basename '.env.' (trailing dot)"       0 ".env."
+assert_predicate "is_secret_basename '.env. ' (dot + space)"       0 ".env. "
+# After stripping, a trailing-space template equals the carve-out — stays
+# ALLOWED, consistent with what the OS actually opens (.env.example).
+assert_predicate "is_secret_basename '.env.example ' (template + space)" 1 ".env.example "
+# Native Windows backslash paths (backslash is a path separator there).
+assert_predicate "is_secret_basename 'C:\\repo\\.ENV' (backslash + case)"  0 'C:\repo\.ENV'
+assert_predicate "is_secret_basename 'C:\\Users\\x\\.ssh\\ID_RSA'"          0 'C:\Users\x\.ssh\ID_RSA'
+assert_predicate "is_secret_basename '\\\\server\\share\\.env' (UNC)"       0 '\\server\share\.env'
+assert_predicate "is_secret_basename 'C:\\repo\\.env ' (backslash + space)" 0 'C:\repo\.env '
+assert_predicate "is_secret_basename 'C:\\repo\\.env.example' (template)"   1 'C:\repo\.env.example'
 
 echo ""
 if [ "$FAILED" -eq 0 ]; then


### PR DESCRIPTION
Public leg of private #1096 (HIMMEL-879).

Shared `is_secret_basename()` predicate in `scripts/guardrails/lib.sh` (case-fold + trailing space/dot strip + backslash separator — three Windows normalization-divergence bypasses closed), consumed by both `block-read-secrets.sh` and `block-edit-on-main.sh`. Suites: 109 + 53 + e2e-symmetry all green; 3 CR rounds (panel + codex adversarial + 4 pr-review-toolkit reviewers), every Critical/Important fixed and live re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
