### PR TITLE
feat(guardrails): [HIMMEL-881] .graphify-backend file declaration for in-session LLM-free update runs

### DIFF
--- a/docs/internals/egress-matrix.md
+++ b/docs/internals/egress-matrix.md
@@ -59,6 +59,42 @@ filesystem marker walks use the original path form) so Windows Git-Bash
 candidates and the Bash tool's always-MSYS `$PWD` match the drive-lettered
 corpus roots.
 
+### `.graphify-backend` file-declared backend (HIMMEL-881)
+
+`graphify update` (and other LLM-free subcommands) take no `--backend` on the
+CLI, so a non-himmel corpus needs a declared provider from elsewhere to
+satisfy the fence's no-backend policy. `GRAPHIFY_DECLARED_BACKEND` (HIMMEL-779)
+covers this, but it is launching-shell-only by design — a per-call `VAR=x`
+prefix or an in-session `export` never reaches the PreToolUse hook process —
+so an in-session or headless `graphify update` run could never satisfy it
+without a session restart. A `.graphify-backend` file in the **exact same
+directory** as the `.graphify-corpus` marker (not any other ancestor
+directory) is a second, per-run way to supply the same declaration:
+single-line, trimmed, non-empty, safe-charset (`[A-Za-z0-9._-]+`) backend
+name; empty, multiline, unreadable, or invalid content is a fail-closed
+**deny**, same as an invalid `.graphify-corpus` marker. Precedence:
+`GRAPHIFY_DECLARED_BACKEND` wins when set; the file is consulted only when the
+env var is unset. Scoped identically to the env var (LLM-free subcommand +
+non-himmel corpus only). The file's value flows through the same matrix eval
+as a real `--backend` token — not a bypass — and any declared-backend
+substitution (env or file) **always** leaves a ledger line on every
+allow-family verdict — even a plain `allow` matrix cell on a real
+(non-marker) root — carrying a `declared_backend_source` field (`"env"` or
+`"file"`) so audits can tell the two paths apart and no declaration-reached
+run goes unrecorded. **All-dirs-must-agree:**
+when one invocation carries multiple marker-derived targets, every
+`.graphify-corpus` marker directory is consulted (not only the
+rank-winning target's — equal-rank argument ordering must not pick which
+declaration gets read): each dir must carry a valid `.graphify-backend` and
+all files must declare the same value; a missing, unreadable, or invalid
+file in any dir, or two differing values, is a fail-closed **deny**
+regardless of argument order. **Staged-only:** file declarations are honored
+only when *every* classified target in the invocation is a marker-declared
+staged copy — any target that classifies via a real configured root disables
+the file path outright (a staged copy's declaration must not vouch for a
+real vault path listed beside it); mixed staged+real invocations need
+`--backend` or the launching-shell env var.
+
 ## Consumers
 
 | Surface | What it reads |

--- a/scripts/guardrails/graphify-fence.sh
+++ b/scripts/guardrails/graphify-fence.sh
@@ -88,7 +88,11 @@
 #                            Like GRAPHIFY_SALUS_LOCAL_OK/GRAPHIFY_CLIPPINGS_GLM_OK
 #                            above, this is a launching-shell-only trust boundary:
 #                            set it in the shell that launches the agent, not
-#                            per-call.
+#                            per-call. HIMMEL-881: a `.graphify-backend` file
+#                            alongside the `.graphify-corpus` marker is a second,
+#                            in-session way to satisfy the same declaration (see
+#                            the HIMMEL-881 NOW HANDLED note below) - this env var
+#                            still wins when BOTH are present.
 #
 # Exit codes: 0 = allow (ledger written where the matched cell requires it);
 # 2 = deny (stderr carries the reason).
@@ -167,6 +171,37 @@
 #     resolving against a cwd the fence can no longer vouch for. An absolute
 #     target is cwd-independent and still classifies normally.
 #
+# NOW HANDLED (HIMMEL-881):
+#   - `.graphify-backend` file-declared backend: GRAPHIFY_DECLARED_BACKEND is a
+#     launching-shell-only env var (a per-call VAR=x prefix or an in-session
+#     export never reaches the PreToolUse hook process), so an in-session/
+#     headless `graphify update` on a non-himmel corpus could never satisfy the
+#     no-backend policy without a session restart. A `.graphify-backend` file
+#     sitting in the EXACT SAME directory as the `.graphify-corpus` marker that
+#     declared the corpus (not any other ancestor directory - see
+#     _graphify_backend_marker) is a second way to supply the same declaration:
+#     single-line, trimmed, non-empty, safe-charset (`[A-Za-z0-9._-]+`) backend
+#     name; empty, multiline, unreadable, or invalid-charset content DENIES
+#     (fail-closed), same as an invalid `.graphify-corpus` marker. Precedence:
+#     GRAPHIFY_DECLARED_BACKEND wins if set; the file is consulted only when the
+#     env var is unset. Scoped identically to the env var (LLM-free subcommand +
+#     non-himmel corpus only - see _llm_free_subcmd). The file's value flows
+#     through the SAME matrix eval as a real --backend token (not a bypass), and
+#     every ledger line the declaration touches records a `declared_backend_source`
+#     field (`"env"` or `"file"`) so audits can distinguish the two paths.
+#     ALL-DIRS-MUST-AGREE (codex-adv-1): when MULTIPLE marker-derived targets
+#     appear in one invocation, EVERY marker directory is consulted (not only
+#     the rank winner's - equal-rank argument ordering must not pick which
+#     `.graphify-backend` gets read): every dir must carry a valid file AND
+#     all files must declare the SAME value; any missing/unreadable/invalid
+#     file, or two differing values, DENIES regardless of argument order.
+#     STAGED-ONLY (codex-adv-2): file declarations are honored ONLY when EVERY
+#     classified target in the invocation is a marker-declared staged copy -
+#     any target classified via a REAL configured root disables the file path
+#     entirely (a staged copy's declaration must not vouch for a real vault
+#     path listed beside it); mixed staged+real invocations need --backend or
+#     the launching-shell env var.
+#
 # Accepted static-analysis limitations (the load-bearing PHI guard is the
 # file-tool fence parity_guard, not this command-text guard):
 #   (a) quoted-separator mis-split - a path with embedded spaces, or a quoted
@@ -208,6 +243,28 @@
 #       trade-off: a false deny (an absolute-safe cd the agent could have
 #       resolved) costs a retry; silently trusting a guessed post-cd cwd would
 #       be fail-open.
+#   (g) backend DECLARATIONS are assertions, not runtime bindings (HIMMEL-881
+#       codex-adv round-3, adjudicated accepted-by-design): for no-backend
+#       LLM-free subcommands the fence cannot see which cloud key graphify's
+#       auto-detection will actually pick, so BOTH declaration paths - the
+#       operator-set GRAPHIFY_DECLARED_BACKEND env var AND the agent-writable
+#       `.graphify-backend` file - feed the matrix an unverified claim. The
+#       file path widens WHO can assert (agent vs launching shell) but not
+#       WHAT is verified; compensating controls: staged-only + all-dirs-must-
+#       agree + safe-charset validation, and the ledger records
+#       `declared_backend_source` ("env"/"file") so a misattributed run stays
+#       auditable. The true fix is upstream: `graphify update --backend` (the
+#       G-U issue), at which point the explicit-flag path replaces both
+#       declaration substitutes. Relatedly, _graphify_backend_marker's
+#       [ -f ]/[ -r ]/cat sequence follows symlinks and has a TOCTOU window -
+#       accepted-by-design: the marker dir is agent-controlled staging anyway
+#       (a symlink/race asserts nothing the agent couldn't assert by writing
+#       the file directly); same pre-existing pattern as _graphify_corpus_marker.
+#   (h) a marker directory whose NAME contains an embedded newline corrupts the
+#       newline-joined marker-dir list invariant, but degrades to a FALSE DENY
+#       (the fragments resolve to no valid `.graphify-backend` -> deny), never a
+#       bypass; the command-token path already denies earlier at tokenization -
+#       only the cwd-fallback can carry such a name in.
 set -uo pipefail
 set -f  # no pathname expansion when we word-split the command / a path
 
@@ -434,7 +491,11 @@ _salus_marked() {
 # vaults; a copy classifies as nothing without this). First marker found wins.
 # Echoes ONE of:
 #   ""                                      no marker found
-#   "declared<TAB><corpus>"                 first line is a valid corpus name
+#   "declared<TAB><corpus><TAB><dir>"       first line is a valid corpus name;
+#                                            <dir> is the marker's own directory
+#                                            (HIMMEL-881: so a caller can look for
+#                                            a co-located `.graphify-backend` file
+#                                            in the SAME dir, not any ancestor)
 #   "__marker_unreadable__<TAB><markerpath>" marker exists but is not a readable regular file
 #   "__marker_bad__<TAB><markerpath><TAB><content>" empty / unknown first line
 _graphify_corpus_marker() {
@@ -456,7 +517,7 @@ _graphify_corpus_marker() {
             line="${line%"${line##*[![:space:]]}"}"   # trim trailing whitespace
             case "$line" in
                 salus|luna-personal|luna-clippings|handover-state|himmel-code)
-                    printf 'declared\t%s' "$line" ;;
+                    printf 'declared\t%s\t%s' "$line" "$d" ;;
                 *)  printf '__marker_bad__\t%s\t%s' "$mk" "$line" ;;
             esac
             return
@@ -465,6 +526,45 @@ _graphify_corpus_marker() {
         d="${d%/*}"
     done
     return 0
+}
+
+# _graphify_backend_marker <dir> -> checks EXACTLY <dir> (NO ancestor walk - a
+# `.graphify-backend` file elsewhere in the tree does not count, only the SAME
+# directory as the `.graphify-corpus` marker that declared the corpus, see the
+# HIMMEL-881 header note) for a file declaring a backend name that satisfies the
+# GRAPHIFY_DECLARED_BACKEND substitution in apply_verdict when the env var is
+# unset. Same fail-closed contract as `.graphify-corpus`: single-line, trimmed,
+# non-empty, safe-charset content only. Echoes ONE of:
+#   ""                                        no `.graphify-backend` in <dir>
+#   "declared<TAB><backend>"                  single-line, non-empty, safe backend name
+#   "__backend_unreadable__<TAB><path>"       exists but not a readable regular file
+#   "__backend_bad__<TAB><path><TAB><reason>" empty / multiline / invalid-charset content
+_graphify_backend_marker() {
+    local d="$1" mk content trimmed
+    mk="$d/.graphify-backend"
+    [ -e "$mk" ] || { printf ''; return; }
+    if ! { [ -f "$mk" ] && [ -r "$mk" ]; }; then
+        printf '__backend_unreadable__\t%s' "$mk"; return
+    fi
+    # Command substitution strips ALL trailing newlines, so a multiline check on
+    # the result only needs to look for an EMBEDDED newline (a trailing-newline-
+    # only file, the common `printf 'x\n' >` shape, still reduces to one line).
+    content="$(cat "$mk" 2>/dev/null)"
+    content="${content%$'\r'}"
+    case "$content" in
+        *$'\n'*)
+            printf '__backend_bad__\t%s\t%s' "$mk" "multiline content"; return ;;
+    esac
+    trimmed="${content#"${content%%[![:space:]]*}"}"   # trim leading whitespace
+    trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"   # trim trailing whitespace
+    if [ -z "$trimmed" ]; then
+        printf '__backend_bad__\t%s\t%s' "$mk" "empty"; return
+    fi
+    case "$trimmed" in
+        *[!A-Za-z0-9._-]*)
+            printf '__backend_bad__\t%s\t%s' "$mk" "invalid characters"; return ;;
+    esac
+    printf 'declared\t%s' "$trimmed"
 }
 
 # _under_any_list <abs-path> <listfile> -> echoes hit | miss | unreadable.
@@ -483,7 +583,7 @@ _under_any_list() {
 
 # classify <target-path> -> echoes corpus, "__unreadable__", or "" (unclassifiable).
 classify() {
-    local apfs ap name rc mk
+    local apfs ap name rc mk rest mcorpus mdir
     # Two forms of the same path: apfs = the ORIGINAL absolute form, used for
     # every FILESYSTEM check (.salus / .graphify-corpus ancestor stat-walks -
     # on a POSIX box a real `/c/...` path only exists in this form; the
@@ -513,8 +613,10 @@ classify() {
     # luna/handover/himmel roots beat this - a marker inside a CONFIGURED vault
     # can NOT relax classification). Consult a `.graphify-corpus` staging marker
     # so a scratchpad COPY can declare its origin corpus. Marker-derived hits
-    # carry an `@declared` suffix (callers strip it, but always ledger the
-    # invocation).
+    # carry an `@declared` suffix plus a tab-separated marker directory
+    # (callers strip the suffix, but always ledger the invocation; HIMMEL-881:
+    # the directory lets apply_verdict look for a co-located `.graphify-backend`
+    # file in that SAME directory, not any other ancestor).
     # GATED on a configured luna root (silent-failure CR round): the real-root-
     # beats-marker guarantee for the most sensitive non-PHI corpus depends on
     # LUNA_VAULT/LUNA_VAULT_PATH being set - with it EMPTY the luna branch above
@@ -525,7 +627,12 @@ classify() {
     if [ -n "$LUNA_ROOT" ]; then
         mk="$(_graphify_corpus_marker "$apfs")"
         case "$mk" in
-            declared$'\t'*)          echo "${mk#declared$'\t'}@declared"; return ;;
+            declared$'\t'*)
+                rest="${mk#declared$'\t'}"
+                mcorpus="${rest%%$'\t'*}"
+                mdir="${rest#*$'\t'}"
+                printf '%s@declared\t%s' "$mcorpus" "$mdir"
+                return ;;
             __marker_unreadable__*)  echo "$mk"; return ;;
             __marker_bad__*)         echo "$mk"; return ;;
         esac
@@ -611,22 +718,28 @@ _json_escape() {
     printf '%s' "$s"
 }
 
-# ledger_append <path> <corpus> <backend> <provider> <verdict> [declared] -> 0 on
-# a durable write, 1 on any failure (unwritable dir / file). Callers DENY on
-# failure: an allow+log verdict without its ledger line is not allowed. When the
-# optional 6th arg is "1" (ANY token in the invocation classified via a
-# `.graphify-corpus` marker - invocation-wide, not just the winning token) an
-# extra `"declared":true` field is emitted so a mis-declared marker cannot dodge
-# audit.
+# ledger_append <path> <corpus> <backend> <provider> <verdict> [declared]
+#   [backend_source] -> 0 on a durable write, 1 on any failure (unwritable dir /
+# file). Callers DENY on failure: an allow+log verdict without its ledger line
+# is not allowed. When the optional 6th arg is "1" (ANY token in the invocation
+# classified via a `.graphify-corpus` marker - invocation-wide, not just the
+# winning token) an extra `"declared":true` field is emitted so a mis-declared
+# marker cannot dodge audit. When the optional 7th arg is non-empty ("env" or
+# "file", HIMMEL-881: which path supplied a backend for the no-backend
+# GRAPHIFY_DECLARED_BACKEND substitution) an extra `"declared_backend_source"`
+# field is emitted so audits can distinguish env-declared vs file-declared runs;
+# apply_verdict's allow branch calls this for EVERY declaration-reached run
+# (declared corpus OR declared backend), even on a plain `allow` cell.
 ledger_append() {
-    local dir ts ep decl=""
+    local dir ts ep decl="" bsrc=""
     [ "${6:-}" = 1 ] && decl=',"declared":true'
+    [ -n "${7:-}" ] && bsrc=",\"declared_backend_source\":\"$(_json_escape "${7}")\""
     dir="$(dirname "$LEDGER")"
     mkdir -p "$dir" || return 1
     ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%s)"
     ep="$(_json_escape "$1")"
-    printf '{"ts":"%s","path":"%s","corpus":"%s","backend":"%s","provider":"%s","verdict":"%s","tool":"graphify"%s}\n' \
-        "$ts" "$ep" "$2" "$3" "$4" "$5" "$decl" >> "$LEDGER" || return 1
+    printf '{"ts":"%s","path":"%s","corpus":"%s","backend":"%s","provider":"%s","verdict":"%s","tool":"graphify"%s%s}\n' \
+        "$ts" "$ep" "$2" "$3" "$4" "$5" "$decl" "$bsrc" >> "$LEDGER" || return 1
     return 0
 }
 
@@ -641,40 +754,113 @@ _llm_free_subcmd() {
     esac
 }
 
-# apply_verdict <corpus> <target> <backend-raw> [declared] [subcmd] -> return 0
-# (allow, ledger written where required) or DENY (exit 2). When <declared> is 1
-# ANY classified token in the invocation came from a `.graphify-corpus` marker
-# (invocation-wide - not only the rank-winning token, so argument ordering
-# cannot suppress the audit): ALWAYS ledger the run, even on a plain `allow`
-# cell (a mis-declared marker must not also dodge audit). <subcmd> (HIMMEL-779
-# CR round-1) is the recorded graphify subcommand token, used to scope
-# GRAPHIFY_DECLARED_BACKEND to the LLM-free set - empty when the invocation had
-# no genuine subcommand word (a position-0 path-like token).
+# apply_verdict <corpus> <target> <backend-raw> [declared] [subcmd] [marker_dir]
+#   [any_real_root]
+# -> return 0 (allow, ledger written where required) or DENY (exit 2). When
+# <declared> is 1 ANY classified token in the invocation came from a
+# `.graphify-corpus` marker (invocation-wide - not only the rank-winning
+# token, so argument ordering cannot suppress the audit): ALWAYS ledger the
+# run, even on a plain `allow` cell (a mis-declared marker must not also dodge
+# audit). The same always-ledger applies to ANY declared-backend substitution
+# (env or file): a run whose backend came from a declaration rather than an
+# explicit --backend leaves a ledger line on every allow-family verdict, even
+# a plain `allow` cell on a real (non-marker) root, so limitation (g)'s audit
+# guarantee holds for both declaration paths. <subcmd> (HIMMEL-779 CR round-1) is the recorded graphify subcommand
+# token, used to scope GRAPHIFY_DECLARED_BACKEND (and, HIMMEL-881, the
+# `.graphify-backend` file) to the LLM-free set - empty when the invocation had
+# no genuine subcommand word (a position-0 path-like token). <marker_dir>
+# (HIMMEL-881) is a NEWLINE-SEPARATED dedup'd list of the directory of EVERY
+# `.graphify-corpus` marker that classified a token in the invocation (the
+# cwd-fallback path passes its single dir as a 1-entry list) - the ONLY
+# directories apply_verdict will check for co-located `.graphify-backend`
+# files (never any other ancestor). ALL listed dirs must carry a valid file
+# and agree on one value (codex-adv-1: equal-rank argument ordering must not
+# pick which declaration gets read - fail closed on any missing/invalid/
+# conflicting entry). <any_real_root> (codex-adv-2) is 1 when ANY classified
+# token in the invocation resolved via a REAL configured root rather than a
+# `.graphify-corpus` marker: file declarations are then disabled outright
+# (STAGED-ONLY - a staged copy's declaration must not vouch for a real vault
+# path listed beside it). Defaults to 1 (fail-closed) when omitted.
 apply_verdict() {
-    local corpus="$1" target="$2" backend_raw="$3" declared="${4:-0}" subcmd="${5:-}"
+    local corpus="$1" target="$2" backend_raw="$3" declared="${4:-0}" subcmd="${5:-}" marker_dir="${6:-}" any_real_root="${7:-1}"
     local backend_effective provider verdict everr eout emsg optvar optval
+    local declared_backend_source="" no_backend_msg bm rest bpath breason
+    local agreed agreed_dir mdir_i val
 
-    if [ -z "$backend_raw" ]; then
+    if [ -z "$backend_raw" ] && [ "$corpus" != "himmel-code" ]; then
         # graphify's `update` (and other LLM-free subcommands, see
         # _llm_free_subcmd) take NO --backend on the CLI (re-extraction is
         # local), yet this fence needs a declared provider to apply the matrix
-        # for any non-himmel corpus. Accept a declared backend via env
-        # (HIMMEL-779) ONLY when BOTH (a) the subcommand is LLM-free and (b)
-        # the corpus is non-himmel - for himmel-code with no flag the
-        # local-ollama default stands unconditionally below; a declared value
-        # must NOT override it (HIMMEL-779 CR round-1: it previously did,
-        # since this check ran for ANY subcommand/corpus whenever the env var
-        # was set). A provider-using (non-LLM-free) subcommand with no
-        # --backend still hits the deny below even when the env var is set -
-        # declaration cannot substitute for a real --backend on a subcommand
-        # whose CLI actually accepts one. The declared value flows through the
-        # SAME matrix eval + provider map as a real --backend token either way
-        # (it is NOT a bypass).
-        if [ "$corpus" != "himmel-code" ] && _llm_free_subcmd "$subcmd" && [ -n "${GRAPHIFY_DECLARED_BACKEND:-}" ]; then
-            backend_raw="$GRAPHIFY_DECLARED_BACKEND"
-        elif [ "$corpus" != "himmel-code" ]; then
-            deny "pass --backend explicitly or set GRAPHIFY_DECLARED_BACKEND on an LLM-free subcommand (GRAPHIFY_DECLARED_BACKEND only applies to LLM-free subcommands (update)) (graphify auto-detects cloud keys; the fence cannot see which) [corpus=$corpus subcommand=${subcmd:-<none>}]"
+        # for any non-himmel corpus. Accept a declared backend ONLY when the
+        # subcommand is LLM-free - for himmel-code with no flag the
+        # local-ollama default stands unconditionally (this whole block is
+        # skipped, see the outer `&&`); a declared value must NOT override it
+        # (HIMMEL-779 CR round-1). A provider-using (non-LLM-free) subcommand
+        # with no --backend still hits the deny below even when a declaration
+        # is available - declaration cannot substitute for a real --backend on
+        # a subcommand whose CLI actually accepts one. Either declared value
+        # flows through the SAME matrix eval + provider map as a real
+        # --backend token (it is NOT a bypass). Two declaration paths, in
+        # precedence order (HIMMEL-881 adds the second):
+        #   1. GRAPHIFY_DECLARED_BACKEND env var (launching-shell-only; a
+        #      per-call VAR=x prefix or in-session export never reaches this
+        #      hook process).
+        #   2. `.graphify-backend` files in the EXACT SAME directories as the
+        #      `.graphify-corpus` markers that classified tokens in this
+        #      invocation (marker_dir, a newline-separated dedup'd list) - a
+        #      per-run, in-session-settable alternative for headless/in-
+        #      session `graphify update` runs that cannot restart the session
+        #      to set the env var. Consulted ONLY when the env var is unset.
+        #      ALL-DIRS-MUST-AGREE (codex-adv-1): EVERY listed dir must carry
+        #      a valid file and all files must declare the SAME value - a
+        #      missing/unreadable/invalid file in ANY dir, or two differing
+        #      values, DENIES regardless of argument order (a safe copy's
+        #      declaration must not vouch for a co-listed copy that lacks or
+        #      contradicts its own).
+        no_backend_msg="pass --backend explicitly, set GRAPHIFY_DECLARED_BACKEND in the launching shell, or add a .graphify-backend file next to the .graphify-corpus marker (GRAPHIFY_DECLARED_BACKEND / .graphify-backend only apply to LLM-free subcommands (update)) (graphify auto-detects cloud keys; the fence cannot see which) [corpus=$corpus subcommand=${subcmd:-<none>}]"
+        if _llm_free_subcmd "$subcmd"; then
+            if [ -n "${GRAPHIFY_DECLARED_BACKEND:-}" ]; then
+                backend_raw="$GRAPHIFY_DECLARED_BACKEND"
+                declared_backend_source="env"
+            elif [ -n "$marker_dir" ]; then
+                # STAGED-ONLY (codex-adv-2): a file declaration is honored
+                # ONLY when EVERY classified target is a marker-declared
+                # staged copy. Any real-root target in the same invocation
+                # disables the file path outright - deny before reading any
+                # file (the staged copy's declaration must not vouch for the
+                # real path; the winning corpus here may well BE the real
+                # path's).
+                if [ "$any_real_root" = 1 ]; then
+                    deny "$no_backend_msg (.graphify-backend file declarations apply only when EVERY classified target is a marker-declared staged copy - this invocation mixes staged and real-root targets; use --backend or set GRAPHIFY_DECLARED_BACKEND in the launching shell)"
+                fi
+                agreed=""; agreed_dir=""
+                while IFS= read -r mdir_i; do
+                    [ -n "$mdir_i" ] || continue
+                    bm="$(_graphify_backend_marker "$mdir_i")"
+                    case "$bm" in
+                        declared$'\t'*)
+                            val="${bm#declared$'\t'}"
+                            if [ -n "$agreed" ] && [ "$(_lc "$val")" != "$(_lc "$agreed")" ]; then
+                                deny "conflicting .graphify-backend declarations across staged corpus markers ($agreed_dir=$agreed $mdir_i=$val); all marker dirs must agree (fail-closed)"
+                            fi
+                            if [ -z "$agreed" ]; then agreed="$val"; agreed_dir="$mdir_i"; fi
+                            ;;
+                        __backend_unreadable__$'\t'*)
+                            deny ".graphify-backend marker ${bm#__backend_unreadable__$'\t'} exists but is not a readable regular file (fail-closed)" ;;
+                        __backend_bad__$'\t'*)
+                            rest="${bm#__backend_bad__$'\t'}"; bpath="${rest%%$'\t'*}"; breason="${rest#*$'\t'}"
+                            deny ".graphify-backend marker $bpath declares an invalid backend ($breason); must be a single-line, non-empty backend name (fail-closed)" ;;
+                        '')
+                            deny "no .graphify-backend file in staged corpus marker dir $mdir_i (every marker dir in the invocation needs one); $no_backend_msg" ;;
+                    esac
+                done <<< "$marker_dir"
+                if [ -n "$agreed" ]; then
+                    backend_raw="$agreed"
+                    declared_backend_source="file"
+                fi
+            fi
         fi
+        [ -n "$backend_raw" ] || deny "$no_backend_msg"
     fi
     if [ -z "$backend_raw" ]; then
         backend_effective="ollama"      # himmel-code, no flag, no declaration -> local default
@@ -703,14 +889,21 @@ apply_verdict() {
 
     case "$verdict" in
         allow)
-            if [ "$declared" = 1 ]; then
-                ledger_append "$target" "$corpus" "$backend_effective" "$provider" "allow" 1 \
-                    || deny "declared-corpus audit requires the ledger line (ledger unwritable): $corpus x $provider"
+            # Always ledger a run reached via ANY declaration, even on a plain
+            # `allow` cell: a marker-declared corpus (declared=1) OR a
+            # declared-backend substitution (declared_backend_source non-empty
+            # - env or file; HIMMEL-881 final CR: an env-declared run on a
+            # real root previously left NO ledger line here, contradicting
+            # limitation (g)'s audit guarantee). Same principle as the
+            # declared-marker always-ledger; a failed write DENIES.
+            if [ "$declared" = 1 ] || [ -n "$declared_backend_source" ]; then
+                ledger_append "$target" "$corpus" "$backend_effective" "$provider" "allow" "$declared" "$declared_backend_source" \
+                    || deny "declared-corpus/declared-backend audit requires the ledger line (ledger unwritable): $corpus x $provider"
             fi
             return 0
             ;;
         allow+log)
-            ledger_append "$target" "$corpus" "$backend_effective" "$provider" "allow+log" "$declared" \
+            ledger_append "$target" "$corpus" "$backend_effective" "$provider" "allow+log" "$declared" "$declared_backend_source" \
                 || deny "allow+log requires the ledger line (ledger unwritable): $corpus x $provider"
             return 0
             ;;
@@ -721,7 +914,7 @@ apply_verdict() {
                 *) deny "$corpus x $provider x extraction is conditional with no known opt-in (fail-closed)" ;;
             esac
             if [ "$optval" = "1" ]; then
-                ledger_append "$target" "$corpus" "$backend_effective" "$provider" "conditional" "$declared" \
+                ledger_append "$target" "$corpus" "$backend_effective" "$provider" "conditional" "$declared" "$declared_backend_source" \
                     || deny "conditional requires the ledger line (ledger unwritable): $corpus x $provider"
                 return 0
             fi
@@ -754,8 +947,8 @@ _deny_on_classify_sentinel() {
 # (most-restrictive-wins), applies the CWD fallback, then applies the verdict.
 evaluate_invocation() {
     local have_sub=0 subcmd="" want_backend=0 backend="" backend_norm="" backend_set=0 backend_conflict=0
-    local unclassifiable=0 best_rank=-1 best_corpus="" best_target="" any_declared=0
-    local tok st c r declared skip_redir_target=0
+    local unclassifiable=0 best_rank=-1 best_corpus="" best_target="" any_declared=0 marker_dirs="" any_real_root=0
+    local tok st c r declared marker_dir tok_marker_dir skip_redir_target=0
 
     for tok in "$@"; do
         if [ "$skip_redir_target" = 1 ]; then skip_redir_target=0; continue; fi
@@ -817,7 +1010,31 @@ evaluate_invocation() {
         # the always-ledger audit, regardless of whether it wins the rank
         # comparison (else a real-root token of equal/higher rank listed first
         # would suppress the ledger line - argument ordering must not dodge audit).
-        case "$c" in *@declared) c="${c%@declared}"; any_declared=1 ;; esac
+        tok_marker_dir=""
+        case "$c" in
+            *@declared$'\t'*)
+                tok_marker_dir="${c#*@declared$'\t'}"
+                c="${c%%@declared*}"
+                any_declared=1
+                ;;
+        esac
+        # Collect the marker dir of EVERY @declared token (codex-adv-1) - not
+        # only the rank winner's, since equal-rank argument ordering must not
+        # pick which `.graphify-backend` file apply_verdict reads. Dedup'd,
+        # newline-separated (bash 3.2-safe containment check).
+        if [ -n "$tok_marker_dir" ]; then
+            case "$'\n'$marker_dirs$'\n'" in
+                *$'\n'"$tok_marker_dir"$'\n'*) : ;;
+                *) marker_dirs="${marker_dirs:+$marker_dirs$'\n'}$tok_marker_dir" ;;
+            esac
+        elif [ -n "$c" ]; then
+            # A token classified via a REAL configured root (no @declared
+            # suffix). STAGED-ONLY (codex-adv-2): its presence disables the
+            # `.graphify-backend` file path in apply_verdict entirely - a
+            # staged copy's file declaration must not vouch for a real vault
+            # path listed beside it.
+            any_real_root=1
+        fi
         if [ -n "$c" ]; then
             r="$(_rank "$c")"
             if [ "$r" -gt "$best_rank" ]; then
@@ -843,7 +1060,7 @@ evaluate_invocation() {
     fi
 
     if [ -n "$best_corpus" ]; then
-        apply_verdict "$best_corpus" "$best_target" "$backend" "$any_declared" "$subcmd"
+        apply_verdict "$best_corpus" "$best_target" "$backend" "$any_declared" "$subcmd" "$marker_dirs" "$any_real_root"
         return
     fi
 
@@ -861,9 +1078,20 @@ evaluate_invocation() {
     c="$(classify "$TOOL_CWD")"
     _deny_on_classify_sentinel "$c"
     declared=0
-    case "$c" in *@declared) c="${c%@declared}"; declared=1 ;; esac
+    marker_dir=""
+    case "$c" in
+        *@declared$'\t'*)
+            marker_dir="${c#*@declared$'\t'}"
+            c="${c%%@declared*}"
+            declared=1
+            ;;
+    esac
     [ -n "$c" ] || deny "unclassifiable cwd for graphify '$subcmd' (no classifiable path arg): $TOOL_CWD"
-    apply_verdict "$c" "$TOOL_CWD" "$backend" "$declared" "$subcmd"
+    # STAGED-ONLY consistency (codex-adv-2): the single cwd classification is
+    # either marker-declared (any_real_root=0) or real-root (=1; the file
+    # branch is unreachable then anyway since marker_dir is empty).
+    if [ "$declared" = 1 ]; then any_real_root=0; else any_real_root=1; fi
+    apply_verdict "$c" "$TOOL_CWD" "$backend" "$declared" "$subcmd" "$marker_dir" "$any_real_root"
 }
 
 # classify_clause <clause-tokens...> - resolve the command-position token of one

--- a/scripts/guardrails/test-graphify-fence.sh
+++ b/scripts/guardrails/test-graphify-fence.sh
@@ -739,6 +739,257 @@ run_fence allow no "$HIMMEL" "bare-word existing SAFE subdir -> himmel-code allo
 run_fence deny no "$WS" "bare-word PHI dir resolves via TOOL_CWD not fence \$PWD -> deny" \
     "graphify nestedphi --backend deepseek" GRAPHIFY_TOOL_CWD="$HIMMEL"
 
+echo "== HIMMEL-881: .graphify-backend file-declared backend (update subcommand) =="
+
+STAGED_BE="$WS/stgbackend"; mkdir -p "$STAGED_BE"; : > "$STAGED_BE/copy.md"
+printf 'luna-personal\n' > "$STAGED_BE/.graphify-corpus"
+printf 'deepseek\n' > "$STAGED_BE/.graphify-backend"
+
+STAGED_BE2="$WS/stgbackend2"; mkdir -p "$STAGED_BE2"; : > "$STAGED_BE2/copy.md"
+printf 'luna-personal\n' > "$STAGED_BE2/.graphify-corpus"
+printf 'glm\n' > "$STAGED_BE2/.graphify-backend"
+
+STAGED_BE_EMPTY="$WS/stgbeempty"; mkdir -p "$STAGED_BE_EMPTY"; : > "$STAGED_BE_EMPTY/copy.md"
+printf 'luna-personal\n' > "$STAGED_BE_EMPTY/.graphify-corpus"
+: > "$STAGED_BE_EMPTY/.graphify-backend"
+
+STAGED_BE_MULTI="$WS/stgbemulti"; mkdir -p "$STAGED_BE_MULTI"; : > "$STAGED_BE_MULTI/copy.md"
+printf 'luna-personal\n' > "$STAGED_BE_MULTI/.graphify-corpus"
+printf 'deepseek\nextra-line\n' > "$STAGED_BE_MULTI/.graphify-backend"
+
+STAGED_BE_BADCHARS="$WS/stgbebadchars"; mkdir -p "$STAGED_BE_BADCHARS"; : > "$STAGED_BE_BADCHARS/copy.md"
+printf 'luna-personal\n' > "$STAGED_BE_BADCHARS/.graphify-corpus"
+printf 'deep seek\n' > "$STAGED_BE_BADCHARS/.graphify-backend"
+
+STAGED_BE_WRONGDIR="$WS/stgbewrong"; mkdir -p "$STAGED_BE_WRONGDIR/sub"; : > "$STAGED_BE_WRONGDIR/sub/copy.md"
+printf 'luna-personal\n' > "$STAGED_BE_WRONGDIR/sub/.graphify-corpus"
+printf 'deepseek\n' > "$STAGED_BE_WRONGDIR/.graphify-backend"   # WRONG dir: parent, not sub/ (the marker dir)
+
+# (BE1) file-declared backend (deepseek) satisfies `update` on a non-himmel
+# corpus with no --backend and no env var -> allow+ledger (luna-personal x
+# deepseek is an allow+log matrix cell).
+run_fence allow yes "$HIMMEL" "file-declared backend satisfies update on non-himmel corpus -> allow+ledger" \
+    "graphify update $STAGED_BE/copy.md"
+
+# (BE2) sanity: the SAME file alone (glm, a deny provider on luna-personal)
+# denies - proves the file genuinely flows through the matrix, not a bypass.
+run_fence deny no "$HIMMEL" "file-declared glm alone denies (matrix still applies)" \
+    "graphify update $STAGED_BE2/copy.md"
+
+# (BE3) env wins over file: file declares glm (denies on its own, see BE2),
+# env declares deepseek (allows) -> allow, proving env precedence over file.
+run_fence allow yes "$HIMMEL" "env backend wins over conflicting file backend -> allow (env precedence)" \
+    "graphify update $STAGED_BE2/copy.md" GRAPHIFY_DECLARED_BACKEND=deepseek
+
+# (BE4) empty .graphify-backend file -> deny (fail-closed).
+run_fence deny no "$HIMMEL" "empty .graphify-backend file -> deny (fail-closed)" \
+    "graphify update $STAGED_BE_EMPTY/copy.md"
+
+# (BE5) multiline .graphify-backend file -> deny (fail-closed).
+run_fence deny no "$HIMMEL" "multiline .graphify-backend file -> deny (fail-closed)" \
+    "graphify update $STAGED_BE_MULTI/copy.md"
+
+# (BE6) backend name with invalid characters -> deny (fail-closed).
+run_fence deny no "$HIMMEL" "backend name with invalid characters -> deny (fail-closed)" \
+    "graphify update $STAGED_BE_BADCHARS/copy.md"
+
+# (BE7) .graphify-backend in the WRONG directory (the parent of the
+# .graphify-corpus marker's own directory, not the marker's directory itself)
+# does not count - treated as absent, falls to the existing no-backend deny.
+run_fence deny no "$HIMMEL" ".graphify-backend in parent dir (not the marker dir) does not count -> deny" \
+    "graphify update $STAGED_BE_WRONGDIR/sub/copy.md"
+
+# (BE8) LLM-free scoping mirrors the env var (F1a above): a non-update
+# subcommand with a file-declared backend still hits the no-backend deny.
+run_fence deny no "$HIMMEL" "file-declared backend on non-update subcommand -> deny (scope)" \
+    "graphify cluster $STAGED_BE/copy.md"
+
+# (BE9) himmel-code marker + co-located .graphify-backend file: the no-flag
+# local-ollama default stands unconditionally for himmel-code (mirrors F1b for
+# the env var) - a hard-deny-provider file must NOT leak through. Ledger IS
+# expected: STAGED_HIM's corpus is marker-declared, and a marker-declared
+# corpus always ledgers even on a plain `allow` cell (see the existing S6
+# "declared himmel-code marker + ollama" case above) - unrelated to the
+# backend file, which this case proves was ignored (no gemini hard-deny hit).
+printf 'gemini\n' > "$STAGED_HIM/.graphify-backend"
+run_fence allow yes "$HIMMEL" "himmel-code marker + .graphify-backend file ignored for no-flag default -> ollama allow" \
+    "graphify update $STAGED_HIM/copy.md"
+
+echo "== HIMMEL-881 codex-adv-1: all marker dirs must agree (order cannot mask a declaration) =="
+
+# STAGED_BE declares deepseek, STAGED_BE2 declares glm, STAGED has NO
+# .graphify-backend (all three are luna-personal-marked, same corpus rank) -
+# before the fix, only the FIRST target's marker dir was consulted, so
+# argument ordering picked which declaration counted (fail-open).
+
+STAGED_BE3="$WS/stgbackend3"; mkdir -p "$STAGED_BE3"; : > "$STAGED_BE3/copy.md"
+printf 'luna-personal\n' > "$STAGED_BE3/.graphify-corpus"
+printf 'deepseek\n' > "$STAGED_BE3/.graphify-backend"
+
+# (MA1a/MA1b) two same-corpus dirs with CONFLICTING declarations (deepseek vs
+# glm) -> deny in BOTH argument orders (glm can no longer hide behind a
+# deepseek dir listed first, and vice versa).
+run_fence deny no "$HIMMEL" "conflicting file backends deepseek-dir first -> deny" \
+    "graphify update $STAGED_BE/copy.md $STAGED_BE2/copy.md"
+run_fence deny no "$HIMMEL" "conflicting file backends glm-dir first -> deny" \
+    "graphify update $STAGED_BE2/copy.md $STAGED_BE/copy.md"
+
+# (MA2a/MA2b) deepseek dir + dir with NO .graphify-backend -> deny in BOTH
+# orders (a declared dir must not vouch for an undeclared co-listed dir).
+run_fence deny no "$HIMMEL" "declared dir + missing-file dir (declared first) -> deny" \
+    "graphify update $STAGED_BE/copy.md $STAGED/copy.md"
+run_fence deny no "$HIMMEL" "declared dir + missing-file dir (missing first) -> deny" \
+    "graphify update $STAGED/copy.md $STAGED_BE/copy.md"
+
+# (MA3) two dirs that AGREE (deepseek + deepseek) -> allow+ledger (agreement
+# is not over-denied; both orders).
+run_fence allow yes "$HIMMEL" "two agreeing file backends -> allow+ledger" \
+    "graphify update $STAGED_BE/copy.md $STAGED_BE3/copy.md"
+run_fence allow yes "$HIMMEL" "two agreeing file backends (reverse order) -> allow+ledger" \
+    "graphify update $STAGED_BE3/copy.md $STAGED_BE/copy.md"
+# the MA3 ledger line (left by the run_fence call above) must attribute the
+# backend to the file declaration path.
+if grep -q '"declared_backend_source":"file"' "$LEDGER" 2>/dev/null; then
+    pass "MA3 ledger attributes backend to declared_backend_source=file"
+else
+    fail "MA3 ledger source: got $(cat "$LEDGER" 2>/dev/null)"
+fi
+
+# (MA4) multiple target files under ONE staged dir -> a single (dedup'd)
+# marker dir -> allow+ledger (the today-path is unchanged).
+: > "$STAGED_BE/copy2.md"
+run_fence allow yes "$HIMMEL" "two targets under one marker dir -> single dedup'd dir, allow+ledger" \
+    "graphify update $STAGED_BE/copy.md $STAGED_BE/copy2.md"
+
+echo "== HIMMEL-881 codex-adv-2: file declaration is STAGED-ONLY (real-root target disables it) =="
+
+# (SO1a/SO1b) staged luna copy (valid agreeing deepseek file) + a REAL luna
+# vault path in ONE update, no --backend / no env: before the fix the staged
+# copy's declaration satisfied the no-backend policy FOR THE REAL PATH (the
+# winning corpus is the real path's) - it must now deny in BOTH orders.
+run_fence deny no "$HIMMEL" "staged copy + REAL luna path (staged first) -> deny (staged-only)" \
+    "graphify update $STAGED_BE/copy.md $LUNA/journal-2026.md"
+run_fence deny no "$HIMMEL" "REAL luna path + staged copy (real first) -> deny (staged-only)" \
+    "graphify update $LUNA/journal-2026.md $STAGED_BE/copy.md"
+
+# (SO2) ALL-staged mixed corpora: staged-himmel + staged-luna, both dirs with
+# agreeing deepseek files -> most-restrictive luna-personal x deepseek ->
+# allow+ledger (the staged-only rule must not over-deny fully-staged runs).
+STAGED_HIM2="$WS/stghim2"; mkdir -p "$STAGED_HIM2"; : > "$STAGED_HIM2/copy.md"
+printf 'himmel-code\n' > "$STAGED_HIM2/.graphify-corpus"
+printf 'deepseek\n' > "$STAGED_HIM2/.graphify-backend"
+run_fence allow yes "$HIMMEL" "all-staged mixed corpora w/ agreeing files -> allow+ledger" \
+    "graphify update $STAGED_HIM2/copy.md $STAGED_BE/copy.md"
+# the SO2 ledger line (left by the run_fence call above) must attribute the
+# backend to the file declaration path.
+if grep -q '"declared_backend_source":"file"' "$LEDGER" 2>/dev/null; then
+    pass "SO2 ledger attributes backend to declared_backend_source=file"
+else
+    fail "SO2 ledger source: got $(cat "$LEDGER" 2>/dev/null)"
+fi
+
+echo "== HIMMEL-881 final CR: unreadable file / cwd-fallback / env-over-mixed / case pins =="
+
+# (FC1) unreadable .graphify-backend -> deny (fail-closed sentinel). Mirrors
+# the S7 unreadable-corpus-marker test; skip gracefully where chmod cannot
+# drop read (admin on Windows, root on Linux).
+STAGED_BE_UR="$WS/stgbeunread"; mkdir -p "$STAGED_BE_UR"; : > "$STAGED_BE_UR/copy.md"
+printf 'luna-personal\n' > "$STAGED_BE_UR/.graphify-corpus"
+printf 'deepseek\n' > "$STAGED_BE_UR/.graphify-backend"
+chmod 000 "$STAGED_BE_UR/.graphify-backend" 2>/dev/null || true
+if [ -r "$STAGED_BE_UR/.graphify-backend" ]; then
+    printf '  SKIP  unreadable .graphify-backend marker (chmod could not drop read perm here)\n'
+else
+    run_fence deny no "$HIMMEL" "unreadable .graphify-backend -> deny (fail-closed)" \
+        "graphify update $STAGED_BE_UR/copy.md"
+fi
+chmod 644 "$STAGED_BE_UR/.graphify-backend" 2>/dev/null || true
+
+# (FC2) cwd-fallback call site: cwd IS the staged dir (marker + backend file
+# co-located), `graphify update` with NO path arg -> the fallback
+# classification is marker-declared, its marker dir is threaded as a 1-entry
+# list, any_real_root=0 -> file declaration satisfies the no-backend policy ->
+# luna-personal x deepseek allow+log, ledger carries source=file.
+rm -f "$LEDGER"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$STAGED_BE" && env $CLEAN_ENV "$BASH_BIN" "$FENCE" "graphify update --force" ) >/dev/null 2>&1; rc_fc2=$?
+if [ "$rc_fc2" -eq 0 ] && grep -q '"declared_backend_source":"file"' "$LEDGER" 2>/dev/null \
+    && grep -q '"corpus":"luna-personal"' "$LEDGER" 2>/dev/null; then
+    pass "cwd-fallback in staged dir -> file declaration honored (allow + source=file)"
+else
+    fail "cwd-fallback file declaration: rc=$rc_fc2 ledger=$(cat "$LEDGER" 2>/dev/null)"
+fi
+
+# (FC3) env + MIXED staged/real invocation: GRAPHIFY_DECLARED_BACKEND=deepseek
+# with a staged dir whose glm file would deny alone (BE2) plus a REAL luna
+# path. DELIBERATE design: env is the operator/launching-shell trust boundary
+# and overrides the staged-only file gate (the file list is never consulted
+# when env is set) -> env wins, luna-personal x deepseek allow+log, ledger
+# records source=env.
+rm -f "$LEDGER"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$HIMMEL" && env $CLEAN_ENV GRAPHIFY_DECLARED_BACKEND=deepseek "$BASH_BIN" "$FENCE" "graphify update $STAGED_BE2/copy.md $LUNA/journal-2026.md" ) >/dev/null 2>&1; rc_fc3=$?
+if [ "$rc_fc3" -eq 0 ] && grep -q '"declared_backend_source":"env"' "$LEDGER" 2>/dev/null; then
+    pass "env declaration wins over mixed staged/real (staged-only gate is file-path-only)"
+else
+    fail "env-over-mixed: rc=$rc_fc3 ledger=$(cat "$LEDGER" 2>/dev/null)"
+fi
+
+# (FC4) fix-1 behavior pin: env-declared run on a REAL root hitting a PLAIN
+# `allow` matrix cell (luna-personal x local-ollama) must ALSO leave a ledger
+# line with source=env and NO declared:true (previously the allow branch only
+# ledgered marker-declared runs - the env-declared line never existed).
+rm -f "$LEDGER"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$HIMMEL" && env $CLEAN_ENV GRAPHIFY_DECLARED_BACKEND=ollama "$BASH_BIN" "$FENCE" "graphify update $LUNA/journal-2026.md" ) >/dev/null 2>&1; rc_fc4=$?
+if [ "$rc_fc4" -eq 0 ] && grep -q '"verdict":"allow"' "$LEDGER" 2>/dev/null \
+    && grep -q '"declared_backend_source":"env"' "$LEDGER" 2>/dev/null \
+    && ! grep -q '"declared":true' "$LEDGER" 2>/dev/null; then
+    pass "env-declared + plain allow cell on real root -> ledgered w/ source=env (fix-1)"
+else
+    fail "plain-allow env ledger pin: rc=$rc_fc4 ledger=$(cat "$LEDGER" 2>/dev/null)"
+fi
+
+# (FC5) case-insensitive agreement: 'Deepseek' vs 'deepseek' across two dirs
+# is NOT a conflict (mirrors _record_backend's lower-cased comparison).
+STAGED_BE_CASE="$WS/stgbecase"; mkdir -p "$STAGED_BE_CASE"; : > "$STAGED_BE_CASE/copy.md"
+printf 'luna-personal\n' > "$STAGED_BE_CASE/.graphify-corpus"
+printf 'Deepseek\n' > "$STAGED_BE_CASE/.graphify-backend"
+run_fence allow yes "$HIMMEL" "case-differing agreeing file backends -> not a conflict -> allow" \
+    "graphify update $STAGED_BE/copy.md $STAGED_BE_CASE/copy.md"
+
+echo "== HIMMEL-881: ledger records declared_backend_source (env vs file) =="
+
+# file-declared backend -> ledger carries declared_backend_source:"file"
+rm -f "$LEDGER"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$HIMMEL" && env $CLEAN_ENV "$BASH_BIN" "$FENCE" "graphify update $STAGED_BE/copy.md" ) >/dev/null 2>&1
+if grep -q '"declared_backend_source":"file"' "$LEDGER" 2>/dev/null; then
+    pass "ledger content: declared_backend_source=file for file-declared backend"
+else
+    fail "ledger content declared_backend_source=file: got $(cat "$LEDGER" 2>/dev/null)"
+fi
+
+# env-declared backend -> ledger carries declared_backend_source:"env"
+rm -f "$LEDGER"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$HIMMEL" && env $CLEAN_ENV GRAPHIFY_DECLARED_BACKEND=deepseek "$BASH_BIN" "$FENCE" "graphify update $LUNA/journal-2026.md" ) >/dev/null 2>&1
+if grep -q '"declared_backend_source":"env"' "$LEDGER" 2>/dev/null; then
+    pass "ledger content: declared_backend_source=env for env-declared backend"
+else
+    fail "ledger content declared_backend_source=env: got $(cat "$LEDGER" 2>/dev/null)"
+fi
+
+# real --backend flag (no declaration involved) -> no declared_backend_source field
+rm -f "$LEDGER"
+# shellcheck disable=SC2086 # CLEAN_ENV is an intentional word-split flag list
+( cd "$HIMMEL" && env $CLEAN_ENV "$BASH_BIN" "$FENCE" "graphify update $LUNA/journal-2026.md --backend deepseek" ) >/dev/null 2>&1
+if ! grep -q 'declared_backend_source' "$LEDGER" 2>/dev/null; then
+    pass "ledger content: no declared_backend_source field for an explicit --backend flag"
+else
+    fail "ledger content unexpected declared_backend_source: got $(cat "$LEDGER" 2>/dev/null)"
+fi
+
 if [ "$failures" -eq 0 ]; then
     echo "OK: all cases passed"
     exit 0


### PR DESCRIPTION
Public leg of private #1097 (HIMMEL-881).

`.graphify-backend` file declaration for in-session LLM-free `graphify update` runs on staged corpus copies: fail-closed validation, env precedence, all-dirs-must-agree, staged-only rule, always-ledger with `declared_backend_source`. 130 fence tests + egress-matrix invariants green; 3 codex-adversarial rounds + 4 pr-review-toolkit reviewers at ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
