### PR TITLE
propagate: chat-note enrichment (HIMMEL-833) + GLM await watchdog (HIMMEL-883)

### DIFF
--- a/docs/internals/egress-matrix.md
+++ b/docs/internals/egress-matrix.md
@@ -23,6 +23,12 @@ Alibaba for embeddings).
 - **Load-bearing nuance:** embedding, rerank, and vision-embedding send FULL
   content (text or images) to the provider. An "embedding lane" is content
   egress, not metadata egress, and is gated accordingly.
+- **enrichment (HIMMEL-833)** is content egress like extraction — full note
+  bodies leave the machine, plus the vault-wide top-200 tag vocabulary (tag
+  names only, derived from all vault markdown) sent with each request as the
+  allowed-tags list; its `luna-personal × deepseek` cell was **ratified
+  2026-07-10** (operator, HIMMEL-833): `allow+log` (the ledger obligation
+  survives ratification — never plain `allow`).
 
 ## Corpus resolution (shared primitives, not new ones)
 

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -550,11 +550,17 @@ itself). NOT for tasks that need the result files in the current session.
 Task tool -> glm-subagent -> bun scripts/telegram/spawn-glm.ts "<task>" --cwd <himmel> --name <slug> [--timeout-mins <n>]
 ```
 
-Dispatched DETACHED + polled (reading `meta.json` `status`) when `--timeout-mins`
-exceeds the Bash tool's 10-minute single-call cap. Registered as the
-`glm-subagent` lane in `scripts/lanes/lanes.json` (same `ZAI_API_KEY` probe as the
-`glm` lane). Reuses spawn-glm's worktree isolation + guard chain verbatim (no new
-fence surface). Red-path test: `scripts/hooks/test-glm-subagent-path.sh`.
+Dispatched DETACHED + awaited via `scripts/lanes/await-glm-worker.sh` (HIMMEL-883)
+when `--timeout-mins` exceeds the Bash tool's 10-minute single-call cap: the
+canonical bounded watchdog polls the session's `meta.json` in FOREGROUND windows
+(`--slug <slug> --max-mins 8`, rc 0 terminal / 3 still-running-re-invoke / 2 no
+session) and the dispatcher must reach a terminal result inside its own turn —
+never end the turn promising a background monitor will report later (the
+monitor-orphan trap: a silently-dead monitor stranded the parent session ~4h,
+2026-07-10). Tests: `scripts/lanes/tests/test-await-glm-worker.sh`. Registered as
+the `glm-subagent` lane in `scripts/lanes/lanes.json` (same `ZAI_API_KEY` probe as
+the `glm` lane). Reuses spawn-glm's worktree isolation + guard chain verbatim (no
+new fence surface). Red-path test: `scripts/hooks/test-glm-subagent-path.sh`.
 
 ---
 
@@ -697,6 +703,13 @@ on demand; nothing here runs automatically.
   cap → leaves the mechanical note untouched). Detail:
   `docs/luna/end-session-wiki.md` → Crystallization.
 - `scripts/luna/fold-chat-history.py` — Fold an exported provider chat history (ChatGPT now; Gemini rides HIMMEL-391) into the luna vault as `chats/gpt/` notes (provider id maps to a vault subdir, e.g. `chatgpt` → `gpt`) + gitignored assets; create-only idempotent, `--dry-run` first (HIMMEL-832).
+- `scripts/luna/enrich-chat-notes.py` — **Chat-note enrichment pass** (HIMMEL-833).
+  DeepSeek summary + vocab-constrained tags + locally-computed Related Notes for
+  `enriched: false` chat-import notes under `<vault>/chats/`; flips each note to
+  `enriched: true` (incremental, interruptible; rewrites existing notes in
+  place — sibling of the create-only `fold-chat-history.py`). Egress-matrix-gated under purpose `enrichment`
+  (pending-operator until HIMMEL-833 ratification), ledgered per run
+  (`GRAPHIFY_LEDGER`), DeepSeek off-peak advisory. `--dry-run` first.
 
 ---
 

--- a/marketplace/plugins/himmel-ops/agents/glm-subagent.md
+++ b/marketplace/plugins/himmel-ops/agents/glm-subagent.md
@@ -58,18 +58,27 @@ bun "$CLAUDE_PROJECT_DIR/scripts/telegram/spawn-glm.ts" "<task prompt>" \
   > "${TMPDIR:-/tmp}/glm-dispatch-<slug>.log" 2>&1 &
 ```
 
-Then poll with repeated SHORT Bash calls (each well under the cap) — read the
-session `status` roughly every 60s until it leaves `"running"`. The session
-dir is the newest match under
-`~/.claude/handover/bridge/glm-sessions/glm-<slug>-*`:
+Then await with the canonical watchdog (HIMMEL-883) — repeated FOREGROUND
+Bash calls, each bounded under the Bash-tool cap:
 
 ```
-d=$(ls -dt "$HOME/.claude/handover/bridge/glm-sessions/glm-<slug>-"* 2>/dev/null | head -1)
-status=$(grep -o '"status"[^,]*' "$d/meta.json" 2>/dev/null)
+bash "$CLAUDE_PROJECT_DIR/scripts/lanes/await-glm-worker.sh" --slug <slug> --max-mins 8
 ```
 
-Stop polling once `status` is one of `done`, `failed`, `capped`, `blocked`,
-`timeout`.
+Exit codes: `0` = worker reached a terminal status (`done` / `failed` /
+`capped` / `blocked` / `timeout`; meta.json + outbox tail are printed for
+you) · `3` = still running when the window closed, re-invoke the same
+command to keep waiting · `2` = no session found (report that as a
+dispatch failure).
+
+**HARD RULE (HIMMEL-883 — the monitor-orphan trap):** you MUST reach a
+terminal await result (rc 0 or 2) INSIDE this turn, looping on rc 3, and
+your FINAL message must carry the worker's final state. NEVER end your
+turn saying a background monitor / poll loop "will re-invoke me" or "will
+report later" — that monitor can die silently and the parent session
+strands for hours (observed 2026-07-10). If your overall task budget runs
+out while the worker is still running, say exactly that, with the session
+dir path, so the parent can take over the await.
 
 ## What to return
 

--- a/scripts/guardrails/egress-matrix.json
+++ b/scripts/guardrails/egress-matrix.json
@@ -30,7 +30,7 @@
     "alibaba": { "region": "CN-account, ap-southeast-1 endpoint", "note": "qwen text lanes + free-quota modality bank (HIMMEL-729/765)" },
     "google-gemini": { "region": "US", "note": "DE-LISTED; keys deliberately unset" }
   },
-  "purposes": ["extraction", "embedding", "rerank", "inference", "vision-embedding"],
+  "purposes": ["extraction", "embedding", "rerank", "inference", "vision-embedding", "enrichment"],
   "rules": [
     {
       "corpus": "salus", "provider": "local-ollama", "purpose": "*",
@@ -133,6 +133,11 @@
       "corpus": "luna-personal", "provider": "deepseek", "purpose": "extraction",
       "verdict": "allow+log",
       "why": "operator override 2026-07-05 (speed): luna non-Clippings graphify extraction on DeepSeek, single model, ledgered per run"
+    },
+    {
+      "corpus": "luna-personal", "provider": "deepseek", "purpose": "enrichment",
+      "verdict": "allow+log",
+      "why": "operator ratification 2026-07-10 (HIMMEL-833): chat-note enrichment — full note bodies of luna/chats/* to DeepSeek, plus the vault-wide top-200 tag vocabulary (tag names only) sent with each request as the allowed-tags list; exposure-identical in kind to the 2026-07-05 extraction override; ledgered per run incl. vocab_tags (log obligation survives ratification, never plain allow)"
     },
     {
       "corpus": "luna-personal", "provider": "alibaba", "purpose": "embedding",

--- a/scripts/guardrails/test-egress-matrix.mjs
+++ b/scripts/guardrails/test-egress-matrix.mjs
@@ -97,6 +97,15 @@ for (const r of pendingRules) {
     `pending cell ${r.corpus} x ${r.provider} x ${r.purpose} must evaluate deny via its own pending-operator rule (shadowed by an earlier rule?), got ${effective}/${rule?.verdict}`);
 }
 
+// 5e. HIMMEL-833: the enrichment cell must exist and may only ever be
+//     pending-operator (pre-ratification) or allow+log (post) — never a
+//     plain allow: the ledger obligation survives ratification.
+const enrichmentRule = m.rules.find(r =>
+  r.corpus === "luna-personal" && r.provider === "deepseek" && r.purpose === "enrichment");
+assert(enrichmentRule, "missing luna-personal x deepseek x enrichment rule (HIMMEL-833)");
+assert(["pending-operator", "allow+log"].includes(enrichmentRule.verdict),
+  `enrichment cell must be pending-operator or allow+log, got ${enrichmentRule.verdict}`);
+
 // 5b. Fail-closed for UNDECLARED inputs — the exact shape a resolver bug
 //     produces (a path that fails to classify into a known corpus)
 assert(evaluate("mystery-corpus", "mystery-provider", "mystery-purpose").effective === "deny",

--- a/scripts/lanes/await-glm-worker.sh
+++ b/scripts/lanes/await-glm-worker.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# await-glm-worker.sh - canonical bounded await for a GLM lane worker (HIMMEL-883).
+#
+# WHY: dispatchers repeatedly ended their turn promising "a background monitor
+# will re-invoke me when the worker finishes"; that monitor can die silently
+# and the parent session strands (observed 2026-07-10: worker done at 10:15Z,
+# parent idled ~4h). This script is the structural replacement: a FOREGROUND,
+# bounded poll of the worker session's meta.json that the dispatcher repeats
+# inside its own turn until the worker reaches a terminal status.
+#
+# Usage:
+#   await-glm-worker.sh [--session-dir <dir> | --slug <slug>] [--max-mins <n>]
+#
+#   --session-dir  exact worker session dir (contains meta.json)
+#   --slug         worker slug; resolves the NEWEST session dir matching
+#                  glm-<slug>-* under the glm-sessions root
+#                  (BRIDGE_ROOT or ~/.claude/handover/bridge, + /glm-sessions)
+#   --max-mins     how long THIS invocation polls before giving up (default 8;
+#                  keep <= 8 so a Bash-tool call stays under its 10-min cap)
+#
+# Exit codes:
+#   0  worker reached a terminal status (meta.json + outbox tail printed)
+#   2  no session dir / meta.json found
+#   3  worker still running when the window closed (caller loops: re-invoke)
+set -u
+
+POLL_SECS=10
+
+session_dir=""
+slug=""
+max_mins=8
+while [ $# -gt 0 ]; do
+    case "$1" in
+        # Guard the value: a bare `--slug` (value missing) would make `shift 2`
+        # fail under set -u without set -e, leaving $# unchanged → infinite loop.
+        # Fail fast like the unknown-arg case instead.
+        --session-dir) [ $# -ge 2 ] || { echo "await-glm-worker: $1 needs a value" >&2; exit 2; }; session_dir="$2"; shift 2 ;;
+        --slug) [ $# -ge 2 ] || { echo "await-glm-worker: $1 needs a value" >&2; exit 2; }; slug="$2"; shift 2 ;;
+        --max-mins) [ $# -ge 2 ] || { echo "await-glm-worker: $1 needs a value" >&2; exit 2; }; max_mins="$2"; shift 2 ;;
+        *) echo "await-glm-worker: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$session_dir" ] && [ -z "$slug" ]; then
+    echo "await-glm-worker: need --session-dir or --slug" >&2
+    exit 2
+fi
+
+resolve_session_dir() {
+    # newest glm-<slug>-* dir; the trailing component is a millisecond epoch,
+    # so lexical sort of equal-length stamps orders by recency
+    find "$GLM_SESSIONS_ROOT" -maxdepth 1 -type d -name "glm-${slug}-*" 2>/dev/null | sort | tail -1
+}
+
+GLM_SESSIONS_ROOT="${BRIDGE_ROOT:-$HOME/.claude/handover/bridge}/glm-sessions"
+
+deadline=$(( $(date +%s) + max_mins * 60 ))
+while :; do
+    d="$session_dir"
+    if [ -z "$d" ]; then
+        d="$(resolve_session_dir)"
+    fi
+    if [ -n "$d" ] && [ -f "$d/meta.json" ]; then
+        # Positively require a KNOWN terminal status (the finalMeta set in
+        # spawn-glm.ts) before completing. Anything else — "running", an
+        # unrecognized status, or a torn read mid-rewrite — is treated as
+        # not-yet-terminal and falls through to the deadline check, so we keep
+        # polling instead of falsely completing on a partial write. This is the
+        # exact strand (premature terminal) the watchdog exists to prevent.
+        # Whitespace-tolerant because a producer reformat must not silently
+        # break detection (producer currently emits JSON.stringify(...,null,2)).
+        if grep -qE '"status"[[:space:]]*:[[:space:]]*"(done|failed|capped|blocked|timeout)"' "$d/meta.json"; then
+            echo "await-glm-worker: TERMINAL: $d"
+            cat "$d/meta.json"
+            echo
+            if [ -f "$d/outbox.jsonl" ]; then
+                echo "--- outbox tail ---"
+                tail -3 "$d/outbox.jsonl"
+            fi
+            exit 0
+        fi
+        # not terminal yet — fall through to the deadline check
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+        if [ -z "$d" ] || [ ! -f "$d/meta.json" ]; then
+            echo "await-glm-worker: no session found (slug=${slug:-} dir=${session_dir:-}) under $GLM_SESSIONS_ROOT" >&2
+            exit 2
+        fi
+        echo "await-glm-worker: still running after ${max_mins}m: $d (re-invoke to keep waiting)"
+        exit 3
+    fi
+    sleep "$POLL_SECS"
+done

--- a/scripts/lanes/tests/test-await-glm-worker.sh
+++ b/scripts/lanes/tests/test-await-glm-worker.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Hermetic tests for await-glm-worker.sh (HIMMEL-883). Fixture sessions in a
+# temp BRIDGE_ROOT; never touches the real glm-sessions root.
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SUT="$HERE/../await-glm-worker.sh"
+TMP="$(mktemp -d -t await-glm-test.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+export BRIDGE_ROOT="$TMP/bridge"
+
+fails=0
+check() { # <name> <expected-rc> <actual-rc>
+    if [ "$2" -eq "$3" ]; then
+        echo "ok   $1"
+    else
+        echo "FAIL $1 (expected rc=$2 got rc=$3)"
+        fails=$((fails + 1))
+    fi
+}
+
+mk_session() { # <name> <status> -> echoes dir
+    d="$BRIDGE_ROOT/glm-sessions/$1"
+    mkdir -p "$d"
+    printf '{\n  "status": "%s",\n  "pid": 1\n}\n' "$2" > "$d/meta.json"
+    echo "$d"
+}
+
+# 1. terminal session by explicit --session-dir -> rc 0, prints meta
+d=$(mk_session "glm-t1-1000000000001" "done")
+printf '{"text":"[done] all green"}\n' > "$d/outbox.jsonl"
+out=$(bash "$SUT" --session-dir "$d" --max-mins 1)
+check "terminal-by-dir rc" 0 $?
+case "$out" in
+    *'"status": "done"'*'[done] all green'*) echo "ok   terminal-by-dir output" ;;
+    *) echo "FAIL terminal-by-dir output: $out"; fails=$((fails + 1)) ;;
+esac
+
+# 2. slug resolution picks the NEWEST session (older done ignored in favor of
+#    newer timeout)
+mk_session "glm-t2-1000000000001" "done" >/dev/null
+mk_session "glm-t2-1000000000002" timeout >/dev/null
+out=$(bash "$SUT" --slug t2 --max-mins 1)
+check "newest-by-slug rc" 0 $?
+case "$out" in
+    *1000000000002*'"status": "timeout"'*) echo "ok   newest-by-slug output" ;;
+    *) echo "FAIL newest-by-slug output: $out"; fails=$((fails + 1)) ;;
+esac
+
+# 3. missing session -> rc 2 (window must elapse first; use tiny window via
+#    POLL override through max-mins 0 -> immediate deadline)
+bash "$SUT" --slug does-not-exist --max-mins 0 >/dev/null 2>&1
+check "missing-session rc" 2 $?
+
+# 4. still-running session -> rc 3 after the window closes
+d=$(mk_session "glm-t4-1000000000001" running)
+bash "$SUT" --session-dir "$d" --max-mins 0 >/dev/null
+check "still-running rc" 3 $?
+
+# 5. no selector -> rc 2
+bash "$SUT" --max-mins 0 >/dev/null 2>&1
+check "no-selector rc" 2 $?
+
+# 6. running session that flips to done mid-poll -> rc 0
+d=$(mk_session "glm-t6-1000000000001" running)
+( sleep 12; printf '{\n  "status": "done",\n  "pid": 1\n}\n' > "$d/meta.json" ) &
+flipper=$!
+bash "$SUT" --session-dir "$d" --max-mins 1 >/dev/null
+rc=$?
+wait "$flipper" 2>/dev/null
+check "flip-to-done rc" 0 "$rc"
+
+# 7. SLUG mode: session dir does not exist at poll start, appears mid-window
+#    -> rc 0 (proves resolve_session_dir re-runs on every loop iteration; a
+#    hoisted one-shot resolution would fail this)
+( sleep 12; mk_session "glm-t7-1000000000001" "done" >/dev/null ) &
+flipper=$!
+bash "$SUT" --slug t7 --max-mins 1 >/dev/null
+rc=$?
+wait "$flipper" 2>/dev/null
+check "slug-late-appear rc" 0 "$rc"
+
+# 8. SLUG mode: running session flips to done mid-window -> rc 0 (re-poll of a
+#    slug-resolved dir, the documented primary invocation shape)
+d=$(mk_session "glm-t8-1000000000001" running)
+( sleep 12; printf '{\n  "status": "done",\n  "pid": 1\n}\n' > "$d/meta.json" ) &
+flipper=$!
+bash "$SUT" --slug t8 --max-mins 1 >/dev/null
+rc=$?
+wait "$flipper" 2>/dev/null
+check "slug-flip-to-done rc" 0 "$rc"
+
+# 9. unknown flag -> rc 2 (bad-args branch of the parser)
+bash "$SUT" --bogus x --max-mins 0 >/dev/null 2>&1
+check "unknown-arg rc" 2 $?
+
+# 10. value-taking flag with no value -> rc 2, not an infinite loop (HIMMEL-883
+# codex-adv). timeout-guard so a regression to `shift 2` hangs the check, not CI.
+if command -v timeout >/dev/null 2>&1; then
+    timeout 5 bash "$SUT" --slug >/dev/null 2>&1
+else
+    bash "$SUT" --slug >/dev/null 2>&1
+fi
+check "missing-value rc" 2 $?
+
+# 11. unrecognized / partial status -> NOT terminal (rc 3). Guards against false
+# completion on a torn/corrupt meta write; only a known terminal status ends it
+# (HIMMEL-883 codex-adv round 4).
+d=$(mk_session "glm-t11-1000000000001" "partial-write-xyz")
+bash "$SUT" --session-dir "$d" --max-mins 0 >/dev/null 2>&1
+check "unknown-status-not-terminal rc" 3 $?
+
+echo
+if [ "$fails" -gt 0 ]; then
+    echo "test-await-glm-worker: $fails FAILURE(S)"
+    exit 1
+fi
+echo "test-await-glm-worker: all tests pass"

--- a/scripts/luna/enrich-chat-notes.py
+++ b/scripts/luna/enrich-chat-notes.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+"""enrich-chat-notes — DeepSeek enrichment pass over enriched:false chat-import notes.
+
+HIMMEL-833. Sibling of fold-chat-history.py (HIMMEL-832). Per note: one
+DeepSeek call (up to 2 attempts on invalid response shape) (summary +
+vocab-constrained tags); each request also carries the vault-wide top-200
+tag vocabulary (tag names only, from all vault markdown) alongside the note
+payload as the allowed-tags list. Related Notes are computed LOCALLY by tag
+overlap (zero egress). Egress is gated by the egress matrix (purpose:
+enrichment) and ledgered per run.
+
+This tool is luna-personal-only by design: the corpus in the gate query and
+ledger is PINNED (not resolved from --vault), and --vault is allow-listed to
+the configured LUNA_VAULT/LUNA_VAULT_PATH root (Clippings/ excluded).
+Classification mirrors the egress guards (graphify-fence.sh classify()):
+a .salus marker and the phi-roots/egress-denylist config roots are refused
+(fail-closed on an unreadable guard config), and only a vault at/under the
+configured luna root classifies as luna-personal — so the pinned corpus
+literal is truthful even before the gate/ledger run.
+
+Usage:
+  python scripts/luna/enrich-chat-notes.py --vault <vault-dir> [--limit N] [--dry-run]
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):  # Windows cp1252 trap
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
+MODEL = "deepseek-chat"
+VOCAB_TOP = 200
+RELATED_MIN_SHARED = 2
+RELATED_MAX = 5
+PEAK_HOURS_UTC = (1, 2, 3, 6, 7, 8, 9)
+API_URL = "https://api.deepseek.com/chat/completions"
+SKIP_DIRS = {".obsidian", ".trash", ".git", "graphify-out", "_assets", "assets"}
+
+
+def split_frontmatter(text):
+    """(fm_lines, body) or None when no closed frontmatter block."""
+    lines = text.split("\n")
+    if not lines or lines[0] != "---":
+        return None
+    for i in range(1, len(lines)):
+        if lines[i] == "---":
+            return lines[1:i], "\n".join(lines[i + 1:])
+    return None
+
+
+def fm_value(fm_lines, key):
+    prefix = key + ":"
+    for ln in fm_lines:
+        if ln.startswith(prefix):
+            return ln[len(prefix):].strip()
+    return None
+
+
+def parse_flow_tags(raw):
+    """Flow-style '[a, b]' -> list. Anything else -> None (out of contract)."""
+    raw = raw.strip()
+    if not (raw.startswith("[") and raw.endswith("]")):
+        return None
+    inner = raw[1:-1].strip()
+    if not inner:
+        return []
+    return [t.strip().strip('"').strip("'") for t in inner.split(",") if t.strip()]
+
+
+def scan_candidates(vault, limit):
+    """Sorted enriched:false notes under <vault>/chats/, assets dirs skipped."""
+    chats = vault / "chats"
+    out = []
+    if not chats.is_dir():
+        return out
+    for p in sorted(chats.rglob("*.md")):
+        rel_dirs = p.relative_to(chats).parts[:-1]
+        if any(d in ("assets", "_assets") for d in rel_dirs):
+            continue
+        try:
+            parts = split_frontmatter(p.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            continue
+        if parts and fm_value(parts[0], "enriched") == "false":
+            out.append(p)
+            if limit is not None and len(out) >= limit:
+                break
+    return out
+
+
+def build_payload(text):
+    """Body text for the API: frontmatter stripped, asset pointers dropped.
+
+    Full body is sent (no truncation) per operator directive HIMMEL-833:
+    truncation risks losing context for summary/tag inference. An
+    over-context-window note fails the API call and is skipped via the
+    existing per-note failure path."""
+    parts = split_frontmatter(text)
+    body = parts[1] if parts else text
+    kept = [ln for ln in body.split("\n")
+            if not ln.lstrip().startswith(("![[", "[image:", "[audio:"))]
+    return "\n".join(kept).strip()
+
+
+def note_title(text, fallback):
+    parts = split_frontmatter(text)
+    body = parts[1] if parts else text
+    for ln in body.split("\n"):
+        if ln.startswith("# "):
+            return ln[2:].strip()
+    return fallback
+
+
+def scan_vault_index(vault):
+    """(vocab top-VOCAB_TOP by frequency then name, {path: (stem, tags set)})."""
+    counts = {}
+    index = {}
+    for p in sorted(vault.rglob("*.md")):
+        rel_dirs = p.relative_to(vault).parts[:-1]
+        if any(d in SKIP_DIRS for d in rel_dirs):
+            continue
+        try:
+            text = p.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        tags = []
+        parts = split_frontmatter(text)
+        if parts:
+            raw = fm_value(parts[0], "tags")
+            if raw is not None:
+                tags = parse_flow_tags(raw) or []
+        for t in tags:
+            counts[t] = counts.get(t, 0) + 1
+        index[p] = (p.stem, set(tags))
+    vocab = [t for t, _ in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))]
+    return vocab[:VOCAB_TOP], index
+
+
+def generic_tags(vault):
+    """Tags too generic to score relatedness: chat-import + provider dir names."""
+    g = {"chat-import"}
+    chats = vault / "chats"
+    if chats.is_dir():
+        g |= {d.name for d in chats.iterdir() if d.is_dir()}
+    return g
+
+
+def related_notes(note_path, tags, index, generic):
+    """<=RELATED_MAX stems sharing >=RELATED_MIN_SHARED non-generic tags."""
+    generic_lc = {g.lower() for g in generic}
+    want = {t.lower() for t in tags} - generic_lc
+    scored = []
+    for p, (stem, ptags) in index.items():
+        if p == note_path:
+            continue
+        shared = len(want & ({t.lower() for t in ptags} - generic_lc))
+        if shared >= RELATED_MIN_SHARED:
+            scored.append((-shared, str(p), stem))
+    scored.sort()
+    return [stem for _, _, stem in scored[:RELATED_MAX]]
+
+
+def salus_marked(root):
+    """True if a `.salus` marker sits at root or any ancestor (PHI vault)."""
+    d = root.resolve()
+    for cand in (d, *d.parents):
+        if (cand / ".salus").exists():
+            return True
+    return False
+
+
+PHI_LIST_NAMES = ("phi-roots", "egress-denylist")
+
+
+def _is_under(p, root):
+    """Windows-safe containment: case-normalized resolved-path comparison."""
+    try:
+        a = os.path.normcase(str(Path(p).resolve()))
+        b = os.path.normcase(str(Path(root).resolve()))
+    except OSError:
+        return False
+    b = b.rstrip("/\\")
+    return a == b or a.startswith(b + os.sep) or a.startswith(b + "/")
+
+
+def classify_vault(vault):
+    """Allow-list corpus classification of --vault, mirroring the egress
+    guards' classify() precedence (graphify-fence.sh): .salus marker ->
+    refuse; phi-roots / egress-denylist config lists (unreadable = fail
+    closed) -> refuse; then ONLY a vault at/under the configured
+    LUNA_VAULT / LUNA_VAULT_PATH root (excluding Clippings/) classifies
+    as luna-personal. Everything else is refused.
+    Returns ("luna-personal", "") or ("", reason)."""
+    root = vault.resolve()
+    if salus_marked(root):
+        return "", ".salus-marked vault (PHI)"
+    cfg = Path(os.environ.get("CLAUDE_GLM_CONFIG_DIR")
+               or (Path.home() / ".config" / "claude-glm"))
+    for name in PHI_LIST_NAMES:
+        lf = cfg / name
+        if lf.exists():
+            if not lf.is_file():
+                return "", f"unreadable guard config {name} (fail closed)"
+            try:
+                lines = lf.read_text(encoding="utf-8").splitlines()
+            except (OSError, UnicodeDecodeError):
+                return "", f"unreadable guard config {name} (fail closed)"
+            for line in lines:
+                r = line.strip().rstrip("/\\")
+                if r and _is_under(root, r):
+                    return "", f"protected root ({name})"
+    luna = os.environ.get("LUNA_VAULT") or os.environ.get("LUNA_VAULT_PATH")
+    if not luna:
+        return "", "LUNA_VAULT/LUNA_VAULT_PATH not set (fail closed)"
+    if not _is_under(root, luna):
+        return "", "vault is not the configured luna root"
+    if _is_under(root, Path(luna) / "Clippings"):
+        return "", "luna-clippings is not luna-personal"
+    return "luna-personal", ""
+
+
+def primary_root(script_dir):
+    """Primary checkout root (worktrees lack .env, like the jira dist/).
+
+    Egress policy is deliberately read from this PRIMARY root, not the
+    worktree: a worktree cannot self-approve egress by editing its local
+    matrix copy, so a pre-merge worktree run sees the old matrix and fails
+    closed (default deny)."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(script_dir), "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True, timeout=15)
+        if out.returncode == 0 and out.stdout.strip():
+            gd = Path(out.stdout.strip())
+            if not gd.is_absolute():  # git may print a relative '.git'
+                gd = (script_dir / gd).resolve()
+            return gd.parent
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return script_dir.parent.parent
+
+
+def resolve_api_key(script_dir):
+    """Env DEEPSEEK_API_KEY wins; else the PRIMARY checkout's .env.
+    Never resolves from the process CWD (HIMMEL-460 trap)."""
+    key = os.environ.get("DEEPSEEK_API_KEY")
+    if key:
+        return key
+    envf = primary_root(script_dir) / ".env"
+    if not envf.is_file():
+        return None
+    for ln in envf.read_text(encoding="utf-8").splitlines():
+        ln = ln.strip()
+        if ln.startswith("DEEPSEEK_API_KEY="):
+            val = ln.split("=", 1)[1].strip().strip('"').strip("'")
+            return val or None
+    return None
+
+
+def _run_gate_eval(repo_root):
+    """(returncode, stdout, stderr) of the matrix eval. Seam for tests."""
+    helper = repo_root / "scripts" / "guardrails" / "egress-matrix-eval.mjs"
+    out = subprocess.run(
+        ["node", str(helper), "luna-personal", "deepseek", "enrichment"],
+        capture_output=True, text=True, timeout=30)
+    return out.returncode, out.stdout, out.stderr
+
+
+def egress_gate(repo_root):
+    """(verdict, note). ('error', msg) on subprocess failure/nonzero exit."""
+    try:
+        rc, stdout, stderr = _run_gate_eval(repo_root)
+    except (OSError, subprocess.SubprocessError) as e:
+        return ("error", str(e))
+    if rc != 0:
+        return ("error", (stderr or stdout).strip())
+    verdict, _, note = stdout.strip().split("\n")[0].partition("\t")
+    return (verdict, note)
+
+
+def ledger_append(chats_root, count, vocab_count):
+    """One JSONL audit line BEFORE first egress. False = caller must refuse.
+
+    `count` = notes egressed this run; `vocab_count` = number of vault-wide
+    tag names carried with each request (the allowed-tags vocabulary)."""
+    path = Path(os.environ.get("GRAPHIFY_LEDGER")
+                or Path.home() / ".claude" / "graphify-egress.jsonl")
+    rec = {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "path": str(chats_root),
+        "corpus": "luna-personal",
+        "provider": "deepseek",
+        "purpose": "enrichment",
+        "verdict": "allow+log",
+        "tool": "enrich-chat-notes",
+        "notes": count,
+        "vocab_tags": vocab_count,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+    except OSError as e:
+        print(f"enrich-chat-notes: ledger append error: {e}", file=sys.stderr)
+        return False
+    return True
+
+
+def offpeak_warn():
+    hour = datetime.now(timezone.utc).hour
+    if hour in PEAK_HOURS_UTC:
+        nxt = next(h % 24 for h in range(hour + 1, hour + 25)
+                   if h % 24 not in PEAK_HOURS_UTC)
+        print(f"enrich-chat-notes: WARN inside DeepSeek peak window (2x); "
+              f"off-peak resumes {nxt:02d}:00 UTC. Advisory.", file=sys.stderr)
+
+
+SYSTEM_PROMPT = (
+    "You summarize chat conversations for a personal knowledge vault. "
+    'Reply with JSON only: {"summary": "1-2 sentence English summary", '
+    '"tags": [3 to 8 tags chosen STRICTLY from the provided vocabulary]}')
+
+
+def _http_post(api_key, body):
+    req = urllib.request.Request(
+        API_URL,
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json",
+                 "Authorization": "Bearer " + api_key},
+        method="POST")
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def call_deepseek(api_key, title, payload, vocab, post=None):
+    """One enrichment call. Sends the note payload plus the vault-wide tag
+    vocabulary (`vocab`, tag names only — the allowed-tags list) to the
+    provider; returns the model's parsed JSON dict. Raises
+    urllib.error.*/OSError/ValueError/KeyError/TypeError/IndexError on
+    failure (TypeError/IndexError cover malformed response shapes such as an
+    empty choices list or a null content)."""
+    post = post or _http_post
+    body = {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content":
+                "Vocabulary: " + ", ".join(vocab)
+                + "\n\nTitle: " + title + "\n\nTranscript:\n" + payload},
+        ],
+        "response_format": {"type": "json_object"},
+        "temperature": 0.2,
+        "max_tokens": 500,
+    }
+    data = None
+    for attempt in range(3):
+        try:
+            data = post(api_key, body)
+            break
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 500, 502, 503) and attempt < 2:
+                time.sleep(2 ** attempt * 2)
+                continue
+            raise
+        except (urllib.error.URLError, TimeoutError, OSError):
+            if attempt < 2:
+                time.sleep(2 ** attempt * 2)
+                continue
+            raise
+    return json.loads(data["choices"][0]["message"]["content"])
+
+
+def validate_result(raw, vocab):
+    """{'summary','tags'} with vocab-filtered tags, or None on bad shape."""
+    if not isinstance(raw, dict):
+        return None
+    summary, tags = raw.get("summary"), raw.get("tags")
+    if not isinstance(summary, str) or not summary.strip():
+        return None
+    if not isinstance(tags, list):
+        return None
+    by_lower = {}
+    for v in vocab:
+        by_lower.setdefault(v.lower(), v)
+    seen, kept = set(), []
+    for t in tags:
+        if not isinstance(t, str):
+            continue
+        k = t.strip().lower()
+        if k in by_lower and k not in seen:
+            seen.add(k)
+            kept.append(by_lower[k])
+    if not kept:
+        return None  # every model tag failed the vocab filter: no enrichment
+    return {"summary": " ".join(summary.split()), "tags": kept[:8]}
+
+
+def yaml_quote(s):
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def enrich_note_text(text, summary, new_tags, related, today, model=MODEL):
+    """(new_text, None) on success, or (None, reason) when out of the
+    frontmatter contract — reason is one of "unclosed-frontmatter",
+    "no-tags-key", "block-style-tags", "no-enriched-key"."""
+    parts = split_frontmatter(text)
+    if not parts:
+        return None, "unclosed-frontmatter"
+    fm, body = parts
+    raw_tags = fm_value(fm, "tags")
+    if raw_tags is None:
+        return None, "no-tags-key"  # contract: exactly what fold-chat-history emits (tags: always present)
+    existing = parse_flow_tags(raw_tags)
+    if existing is None:
+        return None, "block-style-tags"  # skip rather than risk corruption
+    merged = list(existing or [])
+    lower = {t.lower() for t in merged}
+    for t in new_tags:
+        if t.lower() not in lower:
+            lower.add(t.lower())
+            merged.append(t)
+    out, flipped = [], False
+    for ln in fm:
+        if ln.startswith("tags:"):
+            out.append("tags: [" + ", ".join(merged) + "]")
+        elif ln.startswith("enriched:"):
+            out.append("enriched: true")
+            flipped = True
+        else:
+            out.append(ln)
+    if not flipped:
+        return None, "no-enriched-key"
+    out.append("summary: " + yaml_quote(" ".join(summary.split())))
+    out.append("enriched_at: " + today)
+    out.append("enriched_model: " + model)
+    new_body = body
+    if related and "\n## Related Notes" not in "\n" + body:
+        new_body = (body.rstrip("\n") + "\n\n## Related Notes\n\n"
+                    + "\n".join("- [[" + r + "]]" for r in related) + "\n")
+    return "\n".join(["---"] + out + ["---"]) + "\n" + new_body, None
+
+
+def write_atomic(path, text):
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="DeepSeek enrichment pass over enriched:false chat-import notes (HIMMEL-833)")
+    ap.add_argument("--vault", required=True, help="vault root (contains chats/)")
+    ap.add_argument("--limit", type=int, default=None, help="max notes this run")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="list candidates + payload sizes; no egress, no writes")
+    args = ap.parse_args(argv)
+    vault = Path(args.vault)
+    if not (vault / "chats").is_dir():
+        print(f"enrich-chat-notes: no chats/ under {vault}", file=sys.stderr)
+        return 2
+    corpus, why = classify_vault(vault)
+    if corpus != "luna-personal":
+        print(f"enrich-chat-notes: REFUSE — {why}; this tool is "
+              "luna-personal-only", file=sys.stderr)
+        return 2
+
+    candidates = scan_candidates(vault, args.limit)
+    if args.dry_run:
+        vocab, _ = scan_vault_index(vault)
+        print(f"DRY RUN: {len(candidates)} candidate notes; vocab {len(vocab)} tags")
+        for p in candidates:
+            payload = build_payload(p.read_text(encoding="utf-8"))
+            print(f"  {p.relative_to(vault)}  ({len(payload)} chars)")
+        return 0
+    if not candidates:
+        print("enrich-chat-notes: nothing to do (0 enriched:false notes)")
+        return 0
+
+    script_dir = Path(__file__).resolve().parent
+    root = primary_root(script_dir)
+    # Policy is read from the PRIMARY checkout, not this worktree: a worktree
+    # cannot self-approve egress by editing its local matrix copy, so a
+    # pre-merge worktree run sees the old matrix and fails closed (default deny).
+    verdict, vnote = egress_gate(root)
+    if verdict != "allow+log":
+        # plain allow is a misconfiguration for enrichment: the ledger
+        # obligation is part of the ratified deal (spec: never unaudited)
+        print(f"enrich-chat-notes: REFUSE egress (verdict={verdict}: {vnote})",
+              file=sys.stderr)
+        return 2
+    key = resolve_api_key(script_dir)
+    if not key:
+        print("enrich-chat-notes: DEEPSEEK_API_KEY not set (env or primary .env)",
+              file=sys.stderr)
+        return 2
+    offpeak_warn()
+    vocab, index = scan_vault_index(vault)
+    gset = generic_tags(vault)
+    if not ledger_append(vault / "chats", len(candidates), len(vocab)):
+        print("enrich-chat-notes: ledger append failed; refusing to egress",
+              file=sys.stderr)
+        return 2
+
+    today = f"{datetime.now(timezone.utc):%Y-%m-%d}"
+    done = failed = 0
+    for p in candidates:
+        text = p.read_text(encoding="utf-8")
+        payload = build_payload(text)
+        title = note_title(text, p.stem)
+        result = None
+        last_exc = None
+        for _ in range(2):  # one extra attempt on unparseable/invalid shape
+            try:
+                raw = call_deepseek(key, title, payload, vocab)
+            except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError,
+                    OSError, ValueError, KeyError, TypeError, IndexError) as e:
+                last_exc = e
+                continue
+            last_exc = None
+            result = validate_result(raw, vocab)
+            if result:
+                break
+        if not result:
+            failed += 1
+            if last_exc is not None:
+                print(f"enrich-chat-notes: SKIP (api/shape failure: "
+                      f"{type(last_exc).__name__}: {last_exc}) {p.name}",
+                      file=sys.stderr)
+            else:
+                print(f"enrich-chat-notes: SKIP (invalid response shape) {p.name}",
+                      file=sys.stderr)
+            continue
+        related = related_notes(p, result["tags"], index, gset)
+        new_text, reason = enrich_note_text(text, result["summary"], result["tags"],
+                                            related, today)
+        if new_text is None:
+            failed += 1
+            print(f"enrich-chat-notes: SKIP (frontmatter out of contract: {reason}) {p.name}",
+                  file=sys.stderr)
+            continue
+        write_atomic(p, new_text)
+        # later notes in THIS run see this note's fresh tags (spec: in-run index)
+        merged = set(parse_flow_tags(
+            fm_value(split_frontmatter(new_text)[0], "tags")) or [])
+        index[p] = (p.stem, merged)
+        done += 1
+        print(f"enrich-chat-notes: enriched {p.relative_to(vault)}")
+    remaining = len(scan_candidates(vault, None))
+    print(f"enrich-chat-notes: done={done} failed={failed} remaining={remaining}")
+    if done == 0 and failed > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/luna/test-enrich-chat-notes.py
+++ b/scripts/luna/test-enrich-chat-notes.py
@@ -1,0 +1,772 @@
+#!/usr/bin/env python3
+"""Hermetic tests for enrich-chat-notes (stdlib unittest).
+
+Run: python scripts/luna/test-enrich-chat-notes.py
+"""
+import contextlib
+import datetime as _dt
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+import urllib.error
+from pathlib import Path
+
+_MOD_PATH = Path(__file__).resolve().parent / "enrich-chat-notes.py"
+_SPEC = importlib.util.spec_from_file_location("enrich_chat_notes", _MOD_PATH)
+mod = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(mod)
+
+
+class _FakeDateTime:
+    """Stand-in for the datetime class: now(...) always returns `fixed`.
+
+    Used to pin the UTC instant the script reads (enriched_at date + the
+    off-peak hour) without depending on wall-clock time."""
+    def __init__(self, fixed):
+        self._fixed = fixed
+
+    def now(self, tz=None):
+        return self._fixed
+
+
+def note(enriched="false", tags="[chat-import, gpt]", title="Test chat",
+         body_extra=""):
+    return (
+        "---\n"
+        "type: chat-import\n"
+        "source: chatgpt\n"
+        "conversation_id: conv-1\n"
+        "created: 2025-08-21\n"
+        "messages: 2\n"
+        f"tags: {tags}\n"
+        f"enriched: {enriched}\n"
+        "---\n"
+        "\n"
+        f"# {title}\n"
+        "\n"
+        "## 🧑 User\n"
+        "\n"
+        "hello\n"
+        "\n"
+        "## 🤖 Assistant\n"
+        "\n"
+        "world\n" + body_extra
+    )
+
+
+class TestFrontmatter(unittest.TestCase):
+    def test_roundtrip_fields(self):
+        fm, body = mod.split_frontmatter(note())
+        self.assertEqual(mod.fm_value(fm, "enriched"), "false")
+        self.assertEqual(mod.fm_value(fm, "tags"), "[chat-import, gpt]")
+        self.assertIn("# Test chat", body)
+
+    def test_no_frontmatter_returns_none(self):
+        self.assertIsNone(mod.split_frontmatter("# Just a heading\n"))
+
+    def test_unclosed_frontmatter_returns_none(self):
+        self.assertIsNone(mod.split_frontmatter("---\ntags: [a]\nno closer\n"))
+
+    def test_flow_tags(self):
+        self.assertEqual(mod.parse_flow_tags("[a, b]"), ["a", "b"])
+        self.assertEqual(mod.parse_flow_tags("[]"), [])
+        self.assertEqual(mod.parse_flow_tags('["x", \'y\']'), ["x", "y"])
+        self.assertIsNone(mod.parse_flow_tags("block"))  # block style
+
+
+class TestScan(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.vault = Path(self.td.name)
+        self.gpt = self.vault / "chats" / "gpt" / "2025-08"
+        self.gpt.mkdir(parents=True)
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def test_picks_only_enriched_false(self):
+        (self.gpt / "a.md").write_text(note("false"), encoding="utf-8")
+        (self.gpt / "b.md").write_text(note("true"), encoding="utf-8")
+        (self.gpt.parent / "_index.md").write_text("# Index\n", encoding="utf-8")
+        assets = self.gpt.parent / "_assets"
+        assets.mkdir()
+        (assets / "x.md").write_text(note("false"), encoding="utf-8")
+        got = mod.scan_candidates(self.vault, None)
+        self.assertEqual([p.name for p in got], ["a.md"])
+
+    def test_limit_and_order(self):
+        for name in ("c.md", "a.md", "b.md"):
+            (self.gpt / name).write_text(note("false"), encoding="utf-8")
+        got = mod.scan_candidates(self.vault, 2)
+        self.assertEqual([p.name for p in got], ["a.md", "b.md"])
+
+    def test_scan_skips_non_utf8(self):
+        # a binary / locked / non-UTF-8 .md under chats/ must not crash the scan
+        (self.gpt / "bad.md").write_bytes(b"\xff\xfe\x00bad bytes")
+        (self.gpt / "good.md").write_text(note("false"), encoding="utf-8")
+        got = mod.scan_candidates(self.vault, None)
+        self.assertEqual([p.name for p in got], ["good.md"])
+
+
+class TestPayload(unittest.TestCase):
+    def test_strips_frontmatter_and_pointers(self):
+        text = note(body_extra="\n![[assets/img.png]]\n[image: f1 — not in export archive]\n[audio: not in export archive]\n")
+        payload = mod.build_payload(text)
+        self.assertNotIn("conversation_id", payload)
+        self.assertNotIn("![[", payload)
+        self.assertNotIn("[image:", payload)
+        self.assertNotIn("[audio:", payload)
+        self.assertIn("hello", payload)
+
+    def test_long_body_passes_through_untruncated(self):
+        text = note(body_extra="x" * 20000)
+        payload = mod.build_payload(text)
+        self.assertNotIn("[truncated]", payload)
+        self.assertEqual(payload.count("x"), 20000)  # full body preserved
+        self.assertGreater(len(payload), 10000)
+
+    def test_title_extraction(self):
+        self.assertEqual(mod.note_title(note(title="שיחה בעברית"), "fb"), "שיחה בעברית")
+        self.assertEqual(mod.note_title("no heading here", "fb"), "fb")
+
+
+class TestIndexAndRelated(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.vault = Path(self.td.name)
+        (self.vault / "chats" / "gpt").mkdir(parents=True)
+        (self.vault / "notes").mkdir()
+        (self.vault / ".obsidian").mkdir()
+        (self.vault / "notes" / "jira-guide.md").write_text(
+            "---\ntags: [jira, workflow, agile]\n---\n# Jira guide\n", encoding="utf-8")
+        (self.vault / "notes" / "poems.md").write_text(
+            "---\ntags: [poetry, writing]\n---\n# Poems\n", encoding="utf-8")
+        (self.vault / ".obsidian" / "cfg.md").write_text(
+            "---\ntags: [hidden]\n---\n", encoding="utf-8")
+        self.chat = self.vault / "chats" / "gpt" / "2025-08-21-Poem-about-Jira.md"
+        self.chat.write_text(note(), encoding="utf-8")
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def test_vocab_and_index(self):
+        vocab, index = mod.scan_vault_index(self.vault)
+        self.assertIn("jira", vocab)
+        self.assertNotIn("hidden", vocab)  # .obsidian skipped
+        self.assertIn(self.vault / "notes" / "jira-guide.md", index)
+
+    def test_generic_tags(self):
+        self.assertEqual(mod.generic_tags(self.vault), {"chat-import", "gpt"})
+
+    def test_related_scoring(self):
+        _, index = mod.scan_vault_index(self.vault)
+        generic = mod.generic_tags(self.vault)
+        got = mod.related_notes(self.chat, ["jira", "workflow", "chat-import", "gpt"],
+                                index, generic)
+        self.assertEqual(got, ["jira-guide"])  # 2 shared; poems has 0
+
+    def test_related_self_excluded_and_threshold(self):
+        _, index = mod.scan_vault_index(self.vault)
+        generic = mod.generic_tags(self.vault)
+        got = mod.related_notes(self.chat, ["chat-import", "gpt", "poetry"],
+                                index, generic)
+        self.assertEqual(got, [])  # generic ignored; 1 shared < 2
+
+    def test_related_cap_and_tiebreak(self):
+        for i in range(7):
+            (self.vault / "notes" / f"n{i}.md").write_text(
+                "---\ntags: [jira, workflow]\n---\n", encoding="utf-8")
+        _, index = mod.scan_vault_index(self.vault)
+        got = mod.related_notes(self.chat, ["jira", "workflow"], index,
+                                mod.generic_tags(self.vault))
+        self.assertEqual(len(got), mod.RELATED_MAX)
+        self.assertEqual(got, sorted(got))  # path tie-break = sorted stems here
+
+
+class TestKeyAndRoot(unittest.TestCase):
+    def test_env_key_wins(self):
+        os.environ["DEEPSEEK_API_KEY"] = "sk-env"
+        try:
+            self.assertEqual(mod.resolve_api_key(Path(".")), "sk-env")
+        finally:
+            del os.environ["DEEPSEEK_API_KEY"]
+
+    def test_dotenv_fallback_from_primary_root(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / ".env").write_text(
+                "OTHER=1\nDEEPSEEK_API_KEY=sk-dotenv\n", encoding="utf-8")
+            os.environ.pop("DEEPSEEK_API_KEY", None)
+            orig = mod.primary_root
+            mod.primary_root = lambda d: root
+            try:
+                self.assertEqual(mod.resolve_api_key(Path(".")), "sk-dotenv")
+            finally:
+                mod.primary_root = orig
+
+    def test_missing_key_returns_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            os.environ.pop("DEEPSEEK_API_KEY", None)
+            orig = mod.primary_root
+            mod.primary_root = lambda d: Path(td)
+            try:
+                self.assertIsNone(mod.resolve_api_key(Path(".")))
+            finally:
+                mod.primary_root = orig
+
+
+class TestGateAndLedger(unittest.TestCase):
+    def test_gate_parses_verdict_line(self):
+        orig = mod._run_gate_eval
+        mod._run_gate_eval = lambda root: (0, "allow+log\toperator override\n", "")
+        try:
+            self.assertEqual(mod.egress_gate(Path(".")),
+                             ("allow+log", "operator override"))
+        finally:
+            mod._run_gate_eval = orig
+
+    def test_gate_nonzero_exit_is_error(self):
+        orig = mod._run_gate_eval
+        mod._run_gate_eval = lambda root: (2, "", "boom")
+        try:
+            self.assertEqual(mod.egress_gate(Path("."))[0], "error")
+        finally:
+            mod._run_gate_eval = orig
+
+    def test_ledger_shape(self):
+        with tempfile.TemporaryDirectory() as td:
+            ledger = Path(td) / "led.jsonl"
+            os.environ["GRAPHIFY_LEDGER"] = str(ledger)
+            try:
+                ok = mod.ledger_append(Path("/v/chats"), 7, 200)
+            finally:
+                del os.environ["GRAPHIFY_LEDGER"]
+            self.assertTrue(ok)
+            rec = json.loads(ledger.read_text(encoding="utf-8").strip())
+            self.assertEqual(rec["purpose"], "enrichment")
+            self.assertEqual(rec["tool"], "enrich-chat-notes")
+            self.assertEqual(rec["corpus"], "luna-personal")
+            self.assertEqual(rec["provider"], "deepseek")
+            self.assertEqual(rec["verdict"], "allow+log")
+            self.assertEqual(rec["notes"], 7)
+            self.assertEqual(rec["vocab_tags"], 200)
+            for k in ("ts", "path"):
+                self.assertIn(k, rec)
+
+    def test_ledger_failure_returns_false(self):
+        os.environ["GRAPHIFY_LEDGER"] = os.devnull + "/nope/led.jsonl"
+        try:
+            self.assertFalse(mod.ledger_append(Path("/v/chats"), 1, 200))
+        finally:
+            del os.environ["GRAPHIFY_LEDGER"]
+
+    def test_ledger_failure_prints_reason(self):
+        os.environ["GRAPHIFY_LEDGER"] = os.devnull + "/nope/led.jsonl"
+        buf = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(buf):
+                ok = mod.ledger_append(Path("/v/chats"), 1, 200)
+        finally:
+            del os.environ["GRAPHIFY_LEDGER"]
+        self.assertFalse(ok)
+        self.assertIn("ledger append error", buf.getvalue())
+
+
+class TestRealMatrixWrapper(unittest.TestCase):
+    """REAL eval + REAL matrix (not stubbed): pins the governance premise.
+    The wrapper collapses pending-operator -> deny on stdout, so the
+    accepted set here survives the operator's ratification flip."""
+    def test_enrichment_triple_verdict(self):
+        repo = Path(__file__).resolve().parents[2]
+        helper = repo / "scripts" / "guardrails" / "egress-matrix-eval.mjs"
+        try:
+            out = subprocess.run(
+                ["node", str(helper), "luna-personal", "deepseek", "enrichment"],
+                capture_output=True, text=True, timeout=30)
+        except (OSError, subprocess.SubprocessError):
+            self.skipTest("node not available")
+        self.assertEqual(out.returncode, 0, out.stderr)
+        verdict = out.stdout.split("\t", 1)[0].strip()
+        self.assertIn(verdict, ("deny", "allow+log"))
+
+
+class TestDeepseekClient(unittest.TestCase):
+    def test_call_builds_request_and_parses(self):
+        seen = {}
+        def fake_post(key, body):
+            seen["key"], seen["body"] = key, body
+            return {"choices": [{"message": {"content":
+                json.dumps({"summary": "s.", "tags": ["jira"]})}}]}
+        got = mod.call_deepseek("sk-x", "T", "hello", ["jira", "poetry"],
+                                post=fake_post)
+        self.assertEqual(got, {"summary": "s.", "tags": ["jira"]})
+        self.assertEqual(seen["key"], "sk-x")
+        self.assertEqual(seen["body"]["model"], mod.MODEL)
+        self.assertEqual(seen["body"]["response_format"], {"type": "json_object"})
+        user = seen["body"]["messages"][1]["content"]
+        self.assertIn("jira, poetry", user)
+        self.assertIn("Title: T", user)
+
+    def test_retry_then_success(self):
+        calls = {"n": 0}
+        def flaky(key, body):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise urllib.error.URLError("down")
+            return {"choices": [{"message": {"content": "{}"}}]}
+        orig = mod.time.sleep
+        mod.time.sleep = lambda s: None
+        try:
+            got = mod.call_deepseek("k", "t", "p", [], post=flaky)
+        finally:
+            mod.time.sleep = orig
+        self.assertEqual(got, {})
+        self.assertEqual(calls["n"], 3)
+
+    def test_exhausted_retries_raise(self):
+        def dead(key, body):
+            raise urllib.error.URLError("down")
+        orig = mod.time.sleep
+        mod.time.sleep = lambda s: None
+        try:
+            with self.assertRaises(urllib.error.URLError):
+                mod.call_deepseek("k", "t", "p", [], post=dead)
+        finally:
+            mod.time.sleep = orig
+
+    def test_validate_filters_tags(self):
+        got = mod.validate_result(
+            {"summary": "  a\nb  ", "tags": ["JIRA", "nope", "jira", 7]},
+            ["jira", "poetry"])
+        self.assertEqual(got, {"summary": "a b", "tags": ["jira"]})
+
+    def test_validate_rejects_bad_shapes(self):
+        self.assertIsNone(mod.validate_result("not a dict", []))
+        self.assertIsNone(mod.validate_result({"summary": "", "tags": []}, []))
+        self.assertIsNone(mod.validate_result({"summary": "s", "tags": "x"}, []))
+
+
+class TestWriteBack(unittest.TestCase):
+    def test_full_enrichment_rewrite(self):
+        got, _ = mod.enrich_note_text(
+            note(), 'He said: "shalom" \\o/', ["jira", "poetry"],
+            ["jira-guide"], "2026-07-10")
+        fm, body = mod.split_frontmatter(got)
+        self.assertEqual(mod.fm_value(fm, "enriched"), "true")
+        self.assertEqual(mod.fm_value(fm, "tags"),
+                         "[chat-import, gpt, jira, poetry]")
+        self.assertEqual(mod.fm_value(fm, "enriched_at"), "2026-07-10")
+        self.assertEqual(mod.fm_value(fm, "enriched_model"), mod.MODEL)
+        self.assertEqual(mod.fm_value(fm, "summary"),
+                         '"He said: \\"shalom\\" \\\\o/"')
+        self.assertIn("## Related Notes", body)
+        self.assertIn("- [[jira-guide]]", body)
+        self.assertIn("# Test chat", body)  # body preserved
+
+    def test_no_related_no_section(self):
+        got, _ = mod.enrich_note_text(note(), "s.", [], [], "2026-07-10")
+        self.assertNotIn("## Related Notes", got)
+
+    def test_existing_section_not_duplicated(self):
+        text = note(body_extra="\n## Related Notes\n\n- [[old]]\n")
+        got, _ = mod.enrich_note_text(text, "s.", [], ["new"], "2026-07-10")
+        self.assertEqual(got.count("## Related Notes"), 1)
+        self.assertNotIn("[[new]]", got)
+
+    def test_block_style_tags_out_of_contract(self):
+        text = note().replace("tags: [chat-import, gpt]", "tags:\n  - a")
+        self.assertEqual(mod.enrich_note_text(text, "s.", [], [], "2026-07-10"),
+                         (None, "block-style-tags"))
+
+    def test_no_frontmatter_out_of_contract(self):
+        self.assertEqual(mod.enrich_note_text("# x\n", "s.", [], [], "2026-07-10"),
+                         (None, "unclosed-frontmatter"))
+
+    def test_no_enriched_key_out_of_contract(self):
+        text = ("---\ntype: chat-import\ntags: [chat-import]\n---\n"
+                "# No enriched key\n")
+        self.assertEqual(mod.enrich_note_text(text, "s.", [], [], "2026-07-10"),
+                         (None, "no-enriched-key"))
+
+    def test_no_tags_key_out_of_contract(self):
+        # frontmatter with NO tags: line is out of contract (fold always emits
+        # one) -> inferred tags must not be silently dropped; skip the note.
+        text = ("---\ntype: chat-import\nenriched: false\n---\n# No tags key\n")
+        self.assertEqual(mod.enrich_note_text(text, "s.", ["jira"], [], "2026-07-10"),
+                         (None, "no-tags-key"))
+
+    def test_tag_merge_dedups_case_insensitive(self):
+        got, _ = mod.enrich_note_text(note(), "s.", ["GPT", "jira"], [], "2026-07-10")
+        fm, _ = mod.split_frontmatter(got)
+        self.assertEqual(mod.fm_value(fm, "tags"), "[chat-import, gpt, jira]")
+
+    def test_write_atomic_replaces(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "n.md"
+            p.write_text("old", encoding="utf-8")
+            mod.write_atomic(p, "new")
+            self.assertEqual(p.read_text(encoding="utf-8"), "new")
+            self.assertEqual([f.name for f in Path(td).iterdir()], ["n.md"])
+
+
+def _mk_vault(td):
+    vault = Path(td)
+    gpt = vault / "chats" / "gpt" / "2025-08"
+    gpt.mkdir(parents=True)
+    (gpt / "a.md").write_text(note("false"), encoding="utf-8")
+    (gpt / "b.md").write_text(note("true"), encoding="utf-8")
+    (vault / "notes").mkdir()
+    (vault / "notes" / "jira-guide.md").write_text(
+        "---\ntags: [jira, workflow]\n---\n# Jira guide\n", encoding="utf-8")
+    return vault
+
+
+class TestOffpeak(unittest.TestCase):
+    def _warn_at(self, hour):
+        orig = mod.datetime
+        mod.datetime = _FakeDateTime(
+            _dt.datetime(2026, 7, 10, hour, 0, tzinfo=_dt.timezone.utc))
+        buf = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(buf):
+                mod.offpeak_warn()
+        finally:
+            mod.datetime = orig
+        return buf.getvalue()
+
+    def test_next_window_at_hour_2_is_04(self):
+        self.assertIn("resumes 04:00 UTC", self._warn_at(2))
+
+    def test_next_window_at_hour_9_is_10(self):
+        self.assertIn("resumes 10:00 UTC", self._warn_at(9))
+
+    def test_no_warn_outside_peak(self):
+        self.assertEqual(self._warn_at(0), "")
+
+
+class TestVaultClassification(unittest.TestCase):
+    """Allow-list classification of --vault (mirrors graphify-fence
+    classify() precedence). Hermetic: pops LUNA_VAULT/LUNA_VAULT_PATH/
+    CLAUDE_GLM_CONFIG_DIR and points CLAUDE_GLM_CONFIG_DIR at a temp dir
+    so the operator's real config is never read."""
+    def setUp(self):
+        self._env = {k: os.environ.pop(k, None)
+                     for k in ("DEEPSEEK_API_KEY", "GRAPHIFY_LEDGER",
+                               "LUNA_VAULT", "LUNA_VAULT_PATH",
+                               "CLAUDE_GLM_CONFIG_DIR")}
+        self._cfg_td = tempfile.TemporaryDirectory()
+        os.environ["CLAUDE_GLM_CONFIG_DIR"] = self._cfg_td.name
+        self._orig = (mod.egress_gate, mod.resolve_api_key,
+                      mod.call_deepseek, mod.ledger_append)
+
+    def tearDown(self):
+        (mod.egress_gate, mod.resolve_api_key,
+         mod.call_deepseek, mod.ledger_append) = self._orig
+        self._cfg_td.cleanup()
+        for k, v in self._env.items():
+            if v is not None:
+                os.environ[k] = v
+            else:
+                os.environ.pop(k, None)
+
+    def _stub_throw(self):
+        def _boom(*a, **k):
+            raise AssertionError("must not be called on a refused vault")
+        mod.egress_gate = _boom
+        mod.ledger_append = _boom
+        mod.call_deepseek = _boom
+
+    def _cfg(self, name):
+        return Path(self._cfg_td.name) / name
+
+    def test_salus_at_root_refuses_before_any_call(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = Path(td)
+            (vault / "chats").mkdir()
+            (vault / ".salus").write_text("", encoding="utf-8")
+            self._stub_throw()
+            self.assertEqual(mod.main(["--vault", str(vault)]), 2)
+
+    def test_salus_in_parent_refuses(self):
+        with tempfile.TemporaryDirectory() as td:
+            parent = Path(td)
+            (parent / ".salus").write_text("", encoding="utf-8")
+            vault = parent / "vault"
+            (vault / "chats").mkdir(parents=True)
+            self._stub_throw()
+            self.assertEqual(mod.main(["--vault", str(vault)]), 2)
+
+    def test_vault_in_phi_roots_refuses(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = Path(td)
+            (vault / "chats").mkdir()
+            os.environ["LUNA_VAULT_PATH"] = str(vault)  # would pass otherwise
+            self._cfg("phi-roots").write_text(str(vault) + "\n", encoding="utf-8")
+            self._stub_throw()
+            self.assertEqual(mod.main(["--vault", str(vault)]), 2)
+
+    def test_vault_in_egress_denylist_refuses(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = Path(td)
+            (vault / "chats").mkdir()
+            os.environ["LUNA_VAULT_PATH"] = str(vault)
+            self._cfg("egress-denylist").write_text(str(vault) + "\n", encoding="utf-8")
+            self._stub_throw()
+            self.assertEqual(mod.main(["--vault", str(vault)]), 2)
+
+    def test_phi_roots_as_directory_fails_closed(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = Path(td)
+            (vault / "chats").mkdir()
+            os.environ["LUNA_VAULT_PATH"] = str(vault)
+            self._cfg("phi-roots").mkdir()  # not a readable file -> fail closed
+            self._stub_throw()
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                rc = mod.main(["--vault", str(vault)])
+            self.assertEqual(rc, 2)
+            self.assertIn("fail closed", buf.getvalue())
+
+    def test_no_luna_root_refuses(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = Path(td)
+            (vault / "chats").mkdir()
+            # LUNA_VAULT / LUNA_VAULT_PATH both unset (popped in setUp)
+            self._stub_throw()
+            self.assertEqual(mod.main(["--vault", str(vault)]), 2)
+
+    def test_vault_not_under_luna_root_refuses(self):
+        with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as sib:
+            vault = Path(td)
+            (vault / "chats").mkdir()
+            os.environ["LUNA_VAULT_PATH"] = sib  # a different root
+            self._stub_throw()
+            self.assertEqual(mod.main(["--vault", str(vault)]), 2)
+
+    def test_luna_clippings_is_not_luna_personal(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            os.environ["LUNA_VAULT_PATH"] = str(root)
+            vault = root / "Clippings"
+            (vault / "chats").mkdir(parents=True)
+            self._stub_throw()
+            self.assertEqual(mod.main(["--vault", str(vault)]), 2)
+
+    def test_dry_run_refuses_non_allowed_vault(self):
+        with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as sib:
+            vault = Path(td)
+            gpt = vault / "chats" / "gpt"
+            gpt.mkdir(parents=True)
+            (gpt / "a.md").write_text(note("false"), encoding="utf-8")
+            os.environ["LUNA_VAULT_PATH"] = sib  # vault not allowed
+            self._stub_throw()
+            before = (gpt / "a.md").read_text(encoding="utf-8")
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                rc = mod.main(["--vault", str(vault), "--dry-run"])
+            self.assertEqual(rc, 2)
+            self.assertNotIn("DRY RUN", buf.getvalue())  # no payload printing
+            self.assertEqual((gpt / "a.md").read_text(encoding="utf-8"), before)
+
+    def test_happy_path_allowed_vault_enriches(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = _mk_vault(td)
+            os.environ["LUNA_VAULT_PATH"] = str(vault)
+            mod.egress_gate = lambda root: ("allow+log", "ok")
+            mod.resolve_api_key = lambda d: "sk"
+            mod.ledger_append = lambda root, n, v: True
+            mod.call_deepseek = lambda *a, **k: {"summary": "s.",
+                                                 "tags": ["jira", "workflow"]}
+            rc = mod.main(["--vault", str(vault)])
+            self.assertEqual(rc, 0)
+            text = (vault / "chats" / "gpt" / "2025-08" / "a.md").read_text(encoding="utf-8")
+            fm, _ = mod.split_frontmatter(text)
+            self.assertEqual(mod.fm_value(fm, "enriched"), "true")
+
+    def test_gate_corpus_is_pinned_luna_personal(self):
+        seen = {}
+        fake_proc = types.SimpleNamespace(
+            returncode=0, stdout="allow+log\tok", stderr="")
+
+        def fake_run(argv, **kw):
+            seen["argv"] = list(argv)
+            return fake_proc
+        orig = mod.subprocess.run
+        mod.subprocess.run = fake_run
+        try:
+            rc, _out, _err = mod._run_gate_eval(Path("/repo"))
+        finally:
+            mod.subprocess.run = orig
+        self.assertEqual(rc, 0)
+        self.assertIn("luna-personal", seen["argv"])
+        self.assertIn("enrichment", seen["argv"])
+
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        self._env = {k: os.environ.pop(k, None)
+                     for k in ("DEEPSEEK_API_KEY", "GRAPHIFY_LEDGER",
+                               "LUNA_VAULT", "LUNA_VAULT_PATH",
+                               "CLAUDE_GLM_CONFIG_DIR")}
+        self._cfg_td = tempfile.TemporaryDirectory()
+        os.environ["CLAUDE_GLM_CONFIG_DIR"] = self._cfg_td.name
+        self._orig = (mod.egress_gate, mod.resolve_api_key,
+                      mod.call_deepseek, mod.ledger_append, mod.classify_vault)
+        # These tests cover the post-classification flow (gate/ledger/key/api),
+        # not classification itself — short-circuit it so the operator's real
+        # env/config is never consulted. TestVaultClassification owns classify.
+        mod.classify_vault = lambda v: ("luna-personal", "")
+
+    def tearDown(self):
+        (mod.egress_gate, mod.resolve_api_key,
+         mod.call_deepseek, mod.ledger_append, mod.classify_vault) = self._orig
+        self._cfg_td.cleanup()
+        for k, v in self._env.items():
+            if v is not None:
+                os.environ[k] = v
+            else:
+                os.environ.pop(k, None)
+
+    def test_dry_run_writes_nothing_and_calls_nothing(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = _mk_vault(td)
+            mod.egress_gate = lambda root: (_ for _ in ()).throw(AssertionError("gate called"))
+            mod.call_deepseek = lambda *a, **k: (_ for _ in ()).throw(AssertionError("api called"))
+            before = (vault / "chats" / "gpt" / "2025-08" / "a.md").read_text(encoding="utf-8")
+            rc = mod.main(["--vault", str(vault), "--dry-run"])
+            self.assertEqual(rc, 0)
+            self.assertEqual((vault / "chats" / "gpt" / "2025-08" / "a.md")
+                             .read_text(encoding="utf-8"), before)
+
+    def test_gate_deny_refuses_before_any_call(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = _mk_vault(td)
+            mod.egress_gate = lambda root: ("deny", "pending")
+            mod.call_deepseek = lambda *a, **k: (_ for _ in ()).throw(AssertionError("api called"))
+            self.assertEqual(mod.main(["--vault", str(vault)]), 2)
+
+    def test_plain_allow_also_refuses(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = _mk_vault(td)
+            mod.egress_gate = lambda root: ("allow", "misconfigured")
+            self.assertEqual(mod.main(["--vault", str(vault)]), 2)
+
+    def test_ledger_failure_refuses_before_any_call(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = _mk_vault(td)
+            mod.egress_gate = lambda root: ("allow+log", "ok")
+            mod.resolve_api_key = lambda d: "sk"
+            mod.ledger_append = lambda root, n, v: False
+            mod.call_deepseek = lambda *a, **k: (_ for _ in ()).throw(AssertionError("api called"))
+            self.assertEqual(mod.main(["--vault", str(vault)]), 2)
+
+    def test_missing_key_refuses(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = _mk_vault(td)
+            mod.egress_gate = lambda root: ("allow+log", "ok")
+            mod.resolve_api_key = lambda d: None
+            self.assertEqual(mod.main(["--vault", str(vault)]), 2)
+
+    def test_happy_path_enriches_and_flips(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = _mk_vault(td)
+            mod.egress_gate = lambda root: ("allow+log", "ok")
+            mod.resolve_api_key = lambda d: "sk"
+            mod.ledger_append = lambda root, n, v: True
+            mod.call_deepseek = lambda *a, **k: {"summary": "s.",
+                                                 "tags": ["jira", "workflow"]}
+            rc = mod.main(["--vault", str(vault)])
+            self.assertEqual(rc, 0)
+            text = (vault / "chats" / "gpt" / "2025-08" / "a.md").read_text(encoding="utf-8")
+            fm, body = mod.split_frontmatter(text)
+            self.assertEqual(mod.fm_value(fm, "enriched"), "true")
+            self.assertIn("- [[jira-guide]]", body)
+            # rerun: idempotent, nothing left to do
+            self.assertEqual(mod.main(["--vault", str(vault)]), 0)
+
+    def test_api_failure_skips_note_and_returns_1(self):
+        with tempfile.TemporaryDirectory() as td:
+            vault = _mk_vault(td)
+            mod.egress_gate = lambda root: ("allow+log", "ok")
+            mod.resolve_api_key = lambda d: "sk"
+            mod.ledger_append = lambda root, n, v: True
+            def boom(*a, **k):
+                raise urllib.error.URLError("down")
+            mod.call_deepseek = boom
+            rc = mod.main(["--vault", str(vault)])
+            self.assertEqual(rc, 1)  # candidates present, zero progress
+            text = (vault / "chats" / "gpt" / "2025-08" / "a.md").read_text(encoding="utf-8")
+            self.assertIn("enriched: false", text)
+
+    def test_no_chats_dir_is_config_error(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(mod.main(["--vault", td]), 2)
+
+    def test_shape_exception_skips_with_diagnostic(self):
+        # a malformed 200 (e.g. empty choices) raises IndexError inside
+        # call_deepseek; it must be caught, the note skipped with a diagnostic,
+        # and the run continue (rc=1: candidate present, zero progress).
+        with tempfile.TemporaryDirectory() as td:
+            vault = _mk_vault(td)
+            mod.egress_gate = lambda root: ("allow+log", "ok")
+            mod.resolve_api_key = lambda d: "sk"
+            mod.ledger_append = lambda root, n, v: True
+
+            def boom(*a, **k):
+                raise IndexError("choices empty")
+            mod.call_deepseek = boom
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                rc = mod.main(["--vault", str(vault)])
+            self.assertEqual(rc, 1)
+            self.assertIn("IndexError", buf.getvalue())
+            self.assertIn("choices empty", buf.getvalue())
+            text = (vault / "chats" / "gpt" / "2025-08" / "a.md").read_text(encoding="utf-8")
+            self.assertIn("enriched: false", text)
+
+    def test_empty_surviving_tags_skips(self):
+        # every model tag fails the vocab filter -> validate_result returns
+        # None -> note stays enriched: false, rc=1 (candidate, zero progress).
+        with tempfile.TemporaryDirectory() as td:
+            vault = _mk_vault(td)
+            mod.egress_gate = lambda root: ("allow+log", "ok")
+            mod.resolve_api_key = lambda d: "sk"
+            mod.ledger_append = lambda root, n, v: True
+            mod.call_deepseek = lambda *a, **k: {"summary": "s.",
+                                                 "tags": ["not-in-vocab"]}
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                rc = mod.main(["--vault", str(vault)])
+            self.assertEqual(rc, 1)
+            self.assertIn("invalid response shape", buf.getvalue())
+            text = (vault / "chats" / "gpt" / "2025-08" / "a.md").read_text(encoding="utf-8")
+            self.assertIn("enriched: false", text)
+
+    def test_enriched_at_uses_utc_date(self):
+        fixed = _dt.datetime(2026, 7, 10, 23, 59, tzinfo=_dt.timezone.utc)
+        orig = mod.datetime
+        mod.datetime = _FakeDateTime(fixed)
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                vault = _mk_vault(td)
+                mod.egress_gate = lambda root: ("allow+log", "ok")
+                mod.resolve_api_key = lambda d: "sk"
+                mod.ledger_append = lambda root, n, v: True
+                mod.call_deepseek = lambda *a, **k: {"summary": "s.",
+                                                     "tags": ["jira"]}
+                mod.main(["--vault", str(vault)])
+                text = (vault / "chats" / "gpt" / "2025-08" / "a.md").read_text(encoding="utf-8")
+                fm, _ = mod.split_frontmatter(text)
+                self.assertEqual(mod.fm_value(fm, "enriched_at"), "2026-07-10")
+        finally:
+            mod.datetime = orig
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Propagates three private merges to public:

- **HIMMEL-833** — `scripts/luna/enrich-chat-notes.py` (+ hermetic test suite): a DeepSeek enrichment pass for `enriched: false` chat-import notes — summary, vocab-constrained merged tags, and a locally-computed `## Related Notes` section (zero extra egress). Every real run is gated through the egress matrix and ledgered.
- **HIMMEL-833 governance** — new egress-matrix purpose `enrichment`; the `luna-personal × deepseek × enrichment` cell is `allow+log` (operator-ratified). The gate refuses plain `allow` — the per-run ledger obligation stands.
- **HIMMEL-883** — `scripts/lanes/await-glm-worker.sh` (+ tests, + `glm-subagent.md` hard rule): the canonical bounded foreground await for a GLM worker, fixing the monitor-orphan trap where a dispatcher stranded after promising a background monitor would re-invoke it. Positively matches a known terminal status, fails fast on malformed args, invoked via `bash` for Linux-CI parity.

Code-only propagation (private paths auto-excluded; leak scan clean).
