### PR TITLE
fix(handover): [HIMMEL-882] arms registry lifecycle — consume-on-acquire + owner-token mutex (856 phase 2)

### DIFF
--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -87,7 +87,13 @@
 #      (HIMMEL-856). Override with QUEUE_LOCK_TAKEOVER=1.
 #   8  refused — this handover already has a PENDING arm recorded on
 #      ANOTHER host in the cross-machine arms registry (HIMMEL-856; the
-#      win2+main double-arm shape). Override with ARM_DUP_OK=1.
+#      win2+main double-arm shape). Override with ARM_DUP_OK=1. A record
+#      stops being PENDING (and stops causing this refusal) once the arm it
+#      names actually fires and the relaunched session acquires its queue
+#      lock — queue-lock.sh CONSUMES (drops) it at that point (HIMMEL-882);
+#      this script also prunes ITS OWN host's prior records for the same
+#      handover on every re-arm, so neither a fired arm nor a superseded
+#      re-arm blocks a later cross-host arm forever.
 set -euo pipefail
 
 RESUME_TIME=""
@@ -1443,29 +1449,209 @@ fi
 # _arm_registry_foreign_hits <registry-file> <handover-path> <this-host> --
 # print a "; "-joined summary of every registry line recording an arm for
 # <handover-path> on a host OTHER than <this-host> (empty = none). Always
-# rc 0 (errexit-safe: greps are || true-guarded, the loop ends in a case).
+# rc 0 (errexit-safe: the loop ends in string ops, nothing unguarded).
+# HIMMEL-882: a consumed arm no longer has a record at all (queue-lock.sh's
+# acquire DROPS this host's record(s) at session start -- retention, round
+# 3), and any legacy '"fired":"true"'-marked line from the earlier marking
+# revision is skipped here (and GC'd by the next locked rewrite) -- this is
+# what lets a re-arm from another host stop hard-refusing (rc=8) once the
+# original arm has actually fired, instead of forever.
 _arm_registry_foreign_hits() {
     local _reg="$1" _ho="$2" _this_host="$3"
-    local _needle _hits="" _line _rhost _rfire _rtask
-    _needle="\"handover\":\"$(printf '%s' "$_ho" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')\""
+    local _needle _this_esc _hits="" _line _rhost _rfire _rtask
+    # Both needles are JSON-escaped with the shared writer-side escape so an
+    # escaped stored value (e.g. a backslash Windows path, doubled on write)
+    # compares equal (round-2 -- raw-vs-escaped never matches).
+    _hp_json_escape "$_ho"
+    _needle="\"handover\":\"$_HP_ESC\""
+    _hp_json_escape "$_this_host"; _this_esc="$_HP_ESC"
     [ -f "$_reg" ] || { printf '%s' ""; return 0; }
-    while IFS= read -r _line; do
+    # `|| [ -n "$_line" ]`: read returns 1 at EOF-without-newline while
+    # still filling the variable -- without the guard a final record
+    # lacking a trailing newline would be invisible to this scan.
+    # Field extraction is the shared pure-bash _hp_json_field (round-3:
+    # zero forks per line; the grep|head|sed pipelines this replaces cost
+    # ~185-200ms/LINE on Windows/Git-Bash).
+    while IFS= read -r _line || [ -n "$_line" ]; do
         [ -z "$_line" ] && continue
         case "$_line" in
             *"$_needle"*) ;;
             *) continue ;;
         esac
-        # `|| true` on each: grep -o exits 1 on no-match, and under
-        # `set -o pipefail` that would otherwise abort the whole arm on a
-        # registry line missing one of these fields.
-        _rhost=$(printf '%s' "$_line" | grep -o '"host":"[^"]*"' | head -1 | sed -e 's/^"host":"//' -e 's/"$//') || true
+        case "$_line" in
+            *'"fired":"true"'*) continue ;;
+        esac
+        _hp_json_field "$_line" host; _rhost="$_HP_FIELD"
         [ -z "$_rhost" ] && continue
-        [ "$_rhost" = "$_this_host" ] && continue
-        _rfire=$(printf '%s' "$_line" | grep -o '"fire-at":"[^"]*"' | head -1 | sed -e 's/^"fire-at":"//' -e 's/"$//') || true
-        _rtask=$(printf '%s' "$_line" | grep -o '"task-name":"[^"]*"' | head -1 | sed -e 's/^"task-name":"//' -e 's/"$//') || true
+        [ "$_rhost" = "$_this_esc" ] && continue
+        _hp_json_field "$_line" fire-at;   _rfire="$_HP_FIELD"
+        _hp_json_field "$_line" task-name; _rtask="$_HP_FIELD"
         _hits="${_hits:+$_hits; }host=$_rhost fire-at=$_rfire task=$_rtask"
     done < "$_reg"
     printf '%s' "$_hits"
+}
+
+# _arm_registry_mutex_acquire <registry-file> -- HIMMEL-882 CR round-2/3:
+# acquire the short-lived mkdir-CAS mutex (<registry>.lock, a DIRECTORY)
+# that serializes every arms.jsonl read-filter-rewrite writer. MUST stay
+# path- and protocol-identical to queue-lock.sh's _ql_arms_mutex_acquire --
+# the consume there and the prune-and-append here race each other on the
+# same file (one registry per handover ROOT, so an arm on handover A and a
+# session start on handover B are concurrent writers; last mv would win and
+# drop the other's update). On success the lock dir carries an `owner`
+# token file and $_ARM_REGISTRY_MUTEX_TOKEN names it -- release/mv are
+# compare-then-act against that token (round-3: a holder reclaimed after
+# the 60s staleness expiry must not blind-rmdir the reclaimer's lock or mv
+# a stale snapshot over its rewrite). Bounded: nominal ~4s of 0.1s retries
+# (platform-dependent -- measured ~2x that, ~8.7s, on Windows/Git-Bash from
+# per-iteration mkdir+sleep overhead), then rc 1 -- the caller keeps the
+# fail-open contract (WARN + skip, never fail the arm). A mutex stranded by
+# a crashed writer is cleared when its dir mtime is >=60s old, re-probed
+# every 10th iteration across the retry budget (round-4: NOT every
+# iteration -- py_armor_mtime forks python and Windows python startup is
+# ~100-300ms; probing every 10th yields ~4 probes across the ~40-iteration
+# budget, bounding the extra forks while still catching a lock that crosses
+# the 60s threshold mid-wait -- a lock that was, say, 56s old when this
+# contender started is not yet stale at _tries==0 but would previously
+# never be re-checked, burning the whole retry budget instead of
+# reclaiming it; a failed probe never clears). errexit-safe: every probe is
+# guarded, the loop exits only via return.
+_ARM_REGISTRY_MUTEX_TOKEN=""
+_arm_registry_mutex_acquire() {
+    local _reg="$1" _lockd _tries=0 _m _now _tok
+    _lockd="$_reg.lock"
+    while :; do
+        if mkdir "$_lockd" 2>/dev/null; then
+            # Brand the lock (see queue-lock.sh's twin for the rationale).
+            _tok="pid$$-r$RANDOM"
+            if ! printf '%s' "$_tok" > "$_lockd/owner" 2>/dev/null; then
+                rm -f "$_lockd/owner" 2>/dev/null
+                rmdir "$_lockd" 2>/dev/null
+                return 1
+            fi
+            _ARM_REGISTRY_MUTEX_TOKEN="$_tok"
+            return 0
+        fi
+        if [ $(( _tries % 10 )) -eq 0 ]; then
+            _m=$(py_armor_mtime "$_lockd") || _m=""
+            _now=$(date -u +%s 2>/dev/null) || _now=""
+            if [ -n "$_m" ] && [ -n "$_now" ] && [ $(( _now - _m )) -ge 60 ]; then
+                rm -rf "$_lockd" 2>/dev/null
+            fi
+        fi
+        _tries=$((_tries + 1))
+        if [ "$_tries" -ge 40 ]; then
+            return 1
+        fi
+        sleep 0.1
+    done
+}
+
+# _arm_registry_mutex_release <registry-file> <token> -- compare-then-delete
+# (round-3, twin of queue-lock.sh's _ql_arms_mutex_release): release the
+# arms mutex ONLY if its owner token is still ours. A mismatch means the
+# lock was reclaimed from under us mid-rewrite -- WARN loudly and leave the
+# reclaimer's lock alone (rc 1); the caller has already skipped its stale
+# mv on the same comparison. Residual (accepted): a reclaim landing between
+# the token read and the rmdir can still lose its lock -- a microsecond
+# window vs the whole-rewrite window this closes.
+_arm_registry_mutex_release() {
+    local _reg="$1" _tok="$2" _cur=""
+    _cur=$(cat "$_reg.lock/owner" 2>/dev/null) || _cur=""
+    if [ "$_cur" != "$_tok" ]; then
+        echo "WARN arm-resume: the arms-registry mutex ($_reg.lock) was reclaimed by another writer mid-rewrite (owner token mismatch: now '${_cur:-none}') -- leaving their lock in place; this rewrite was discarded" >&2
+        return 1
+    fi
+    rm -f "$_reg.lock/owner" 2>/dev/null
+    rmdir "$_reg.lock" 2>/dev/null
+    return 0
+}
+
+# _arm_registry_replace_and_append <registry-file> <host> <handover-path>
+# <new-record-line> -- HIMMEL-882: drop any existing line whose host AND
+# handover match (this host's own prior record(s) for this same handover),
+# GC any legacy '"fired":"true"'-marked line in passing (retention, round
+# 3 -- fired records are inert; both rewriters drop them so the registry
+# stays O(active arms)), then append <new-record-line>. Without the prune,
+# a re-arm or --force replace of the SAME handover on the SAME host left
+# the superseded line sitting in arms.jsonl forever: harmless to THIS host
+# (the dedup check above only looks at foreign hosts) but a permanent rc=8
+# trap for the NEXT host that tries to arm this handover. CRASH-atomic:
+# filtered+new content goes to a same-dir temp file, then mv into place --
+# a mid-write crash never leaves a torn arms.jsonl. Temp+mv alone does NOT
+# cover a CONCURRENT rewriter, so the whole read-filter-rewrite runs under
+# the OWNER-TOKENED _arm_registry_mutex_acquire mkdir-CAS mutex shared with
+# queue-lock.sh's consume, and the mv happens only while the owner token
+# still names us. Needles are escaped with the shared _hp_json_escape
+# (round-2 -- the stored values are JSON-escaped; raw-vs-escaped never
+# matches). rc 1 on mutex timeout, mid-rewrite theft, or any write failure
+# (caller WARNs and moves on); rc 0 on success. Single unlock point:
+# failures only set _rc and fall through to the token-checked release
+# (which WARNs about a theft). round-4 (sfh-2): on a write failure (not a
+# mutex timeout/theft) $_ARM_REGISTRY_REPLACE_ERR carries the first line of
+# the OS error (disk full / permission denied / RO-fs / AV lock, ...) so
+# the caller's WARN can name it instead of reading identically to a mutex
+# timeout; empty on success or on a mutex-timeout/theft failure.
+_ARM_REGISTRY_REPLACE_ERR=""
+_arm_registry_replace_and_append() {
+    local _reg="$1" _host="$2" _ho="$3" _new="$4"
+    local _tmp="$_reg.tmp.$$" _tok _cur _line _l_host _l_ho _host_esc _ho_esc _rc=0 _werr=""
+    _ARM_REGISTRY_REPLACE_ERR=""
+    if ! _arm_registry_mutex_acquire "$_reg"; then
+        echo "WARN arm-resume: could not lock the arms registry ($_reg.lock) -- skipping the registry rewrite for this arm (a mutex stuck from a crashed writer self-expires after 60s)" >&2
+        return 1
+    fi
+    _tok="$_ARM_REGISTRY_MUTEX_TOKEN"
+    _hp_json_escape "$_host"; _host_esc="$_HP_ESC"
+    _hp_json_escape "$_ho";   _ho_esc="$_HP_ESC"
+    # round-4 (sfh-2): capture stderr instead of discarding it -- see
+    # queue-lock.sh's twin for the rationale (2>/dev/null made a real write
+    # failure read identically to a mutex timeout/theft).
+    if _werr=$( { : > "$_tmp"; } 2>&1 ); then
+        if [ -f "$_reg" ]; then
+            # `|| [ -n "$_line" ]`: read returns 1 at EOF-without-newline
+            # while still filling the variable -- without the guard the
+            # rewrite silently DELETES a final record lacking a trailing
+            # newline (round-2 Critical). Blank lines are dropped on
+            # rewrite. ZERO forks per line (round-3 Critical):
+            # _hp_json_field returns via $_HP_FIELD, no $().
+            while IFS= read -r _line || [ -n "$_line" ]; do
+                [ -z "$_line" ] && continue
+                case "$_line" in
+                    *'"fired":"true"'*) continue ;;   # GC legacy fired-marked line
+                esac
+                _hp_json_field "$_line" host;     _l_host="$_HP_FIELD"
+                _hp_json_field "$_line" handover; _l_ho="$_HP_FIELD"
+                if [ "$_l_host" = "$_host_esc" ] && [ "$_l_ho" = "$_ho_esc" ]; then
+                    continue   # superseded by $_new -- drop
+                fi
+                printf '%s\n' "$_line" >> "$_tmp" || { _rc=1; break; }
+            done < "$_reg"
+        fi
+        if [ "$_rc" -eq 0 ]; then
+            printf '%s\n' "$_new" >> "$_tmp" || _rc=1
+        fi
+        if [ "$_rc" -eq 0 ]; then
+            # OWNER-TOKEN verify (round-3): mv only while the mutex still
+            # names us -- see queue-lock.sh's twin for the rationale. The
+            # cat->mv window below is residual (accepted), same class as
+            # _arm_registry_mutex_release's token-read->rmdir gap.
+            _cur=$(cat "$_reg.lock/owner" 2>/dev/null) || _cur=""
+            if [ "$_cur" = "$_tok" ]; then
+                _werr=$(mv -f "$_tmp" "$_reg" 2>&1) || _rc=1
+            else
+                _rc=1   # reclaimed mid-rewrite: snapshot stale, skip the mv
+            fi
+        fi
+    else
+        _rc=1
+    fi
+    if [ "$_rc" -ne 0 ]; then
+        rm -f "$_tmp" 2>/dev/null
+        [ -n "$_werr" ] && _ARM_REGISTRY_REPLACE_ERR="${_werr%%$'\n'*}"
+    fi
+    _arm_registry_mutex_release "$_reg" "$_tok" || true
+    return "$_rc"
 }
 
 # _arm_hostname -- this machine's identity for registry records/compares.
@@ -1832,17 +2018,34 @@ telemetry_emit handover-arm-resume armed "time=$RESUME_TIME" "force=$FORCE"
 # HIMMEL-856: record this arm in the cross-machine arms registry, same
 # dry-run gate as telemetry above. Best-effort -- a registry write failure
 # must never fail an arm that already succeeded (fail-open, loud trail).
+# HIMMEL-882: prune this SAME host's prior record(s) for this SAME handover
+# before appending the fresh one (see _arm_registry_replace_and_append) --
+# closes the re-arm/--force accumulation gap that would otherwise block a
+# later cross-host arm forever, on top of the consume queue-lock.sh does at
+# session start (see its own HIMMEL-882 comment).
 if [ -n "${HIMMEL_856_HR_ROOT:-}" ]; then
     _arm_host=$(_arm_hostname)
-    mkdir -p "$HIMMEL_856_HR_ROOT/.locks" 2>/dev/null
-    if ! printf '{"host":"%s","handover":"%s","fire-at":"%s","task-name":"%s"}\n' \
-        "$(printf '%s' "$_arm_host" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" \
-        "$(printf '%s' "$HANDOVER_PATH" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" \
-        "$(printf '%s' "$AT_STAMP" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" \
-        "$(printf '%s' "$TASK_NAME" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')" \
-        >> "$HIMMEL_856_HR_ROOT/.locks/arms.jsonl" 2>/dev/null; then
-        echo "WARN arm-resume: failed to append the arms.jsonl registry record (the arm itself still succeeded)" >&2
+    # `|| true`: an unwritable .locks (e.g. a FILE squatting on the dir
+    # path) must not errexit-abort a script whose arm ALREADY succeeded --
+    # the failure surfaces as the replace-and-append WARN below instead.
+    mkdir -p "$HIMMEL_856_HR_ROOT/.locks" 2>/dev/null || true
+    # Values are escaped with the shared _hp_json_escape (round-3) -- the
+    # SAME transform every reader's needle uses, so escaped-vs-escaped
+    # comparisons hold by construction.
+    _hp_json_escape "$_arm_host";     _arm_rec_host="$_HP_ESC"
+    _hp_json_escape "$HANDOVER_PATH"; _arm_rec_ho="$_HP_ESC"
+    _hp_json_escape "$AT_STAMP";      _arm_rec_fire="$_HP_ESC"
+    _hp_json_escape "$TASK_NAME";     _arm_rec_task="$_HP_ESC"
+    _arm_new_record=$(printf '{"host":"%s","handover":"%s","fire-at":"%s","task-name":"%s"}' \
+        "$_arm_rec_host" "$_arm_rec_ho" "$_arm_rec_fire" "$_arm_rec_task")
+    unset _arm_rec_host _arm_rec_ho _arm_rec_fire _arm_rec_task
+    if ! _arm_registry_replace_and_append "$HIMMEL_856_HR_ROOT/.locks/arms.jsonl" "$_arm_host" "$HANDOVER_PATH" "$_arm_new_record"; then
+        # round-4 (sfh-2): fold the first line of the captured write error
+        # (if any -- empty on a mutex timeout/theft) so this WARN reads
+        # differently from those cases.
+        echo "WARN arm-resume: failed to append the arms.jsonl registry record (the arm itself still succeeded)${_ARM_REGISTRY_REPLACE_ERR:+ (write error: $_ARM_REGISTRY_REPLACE_ERR)}" >&2
     fi
+    unset _arm_new_record
     # Post-append re-read (HIMMEL-856 CR, codex-1 -- see the LAYERED
     # DEFENSE comment at the pre-arm check): the check-then-append pair
     # above cannot be atomic across machines, so AFTER recording our own

--- a/scripts/handover/queue-lock.sh
+++ b/scripts/handover/queue-lock.sh
@@ -63,6 +63,27 @@
 # the previous and new holder, so the next reader sees the trail. `status`
 # warns when a FRESH lock's heartbeat age exceeds half the TTL (aging).
 #
+# ARMS REGISTRY LIFECYCLE (HIMMEL-882): arm-resume.sh (HIMMEL-856) records a
+# PENDING record in <handover-root>/.locks/arms.jsonl every time it arms a
+# relaunch, and refuses (rc=8) to re-arm a handover that already has a
+# PENDING record on another host. Nothing previously retired a record when
+# its arm fired, so that refusal was permanent -- ARM_DUP_OK=1 was needed on
+# every re-arm forever, even long after the original arm had fired and its
+# session finished. A successful `acquire` -- the session actually starting
+# on this handover's queue -- is proof this host's PENDING arm(s) for it
+# have fired, so `acquire` CONSUMES them (drops the record(s); see
+# _ql_arms_registry_retire_fired -- CR round-3 retention: fired records are
+# inert, so the registry stays O(active arms) instead of growing forever).
+# This closes the gap on the reading side; arm-resume.sh separately prunes
+# its OWN host's stale records at re-schedule time (its own HIMMEL-882
+# comment) so a superseded arm that never fires doesn't linger either.
+# Registry rewrites here and in arm-resume.sh are serialized by a
+# short-lived OWNER-TOKENED mkdir-CAS mutex at <registry>.lock (rounds 2/3)
+# -- the read-filter-rewrite pair is a lost-update race between concurrent
+# writers that the original append-only `>>` never had, and the owner token
+# stops a holder that outlived the mutex expiry from clobbering its
+# reclaimer.
+#
 # EXIT CODES:
 #   acquire:   0  lock acquired (fresh dir, stale takeover, or forced
 #                 takeover -- stderr says which); the last stdout line is
@@ -151,16 +172,25 @@ _ql_hostname() {
 
 _ql_default_session() { printf '%s-pid%s' "$(_ql_hostname)" "$$"; }
 
+# JSON escape/extract now delegate to the shared pure-bash helpers in
+# scripts/lib/handover-path.sh (_hp_json_escape / _hp_json_field, HIMMEL-882
+# CR round-3): zero forks per call site that uses them directly, and the
+# extractor is escape-AWARE (scans to the first UNESCAPED closing quote by
+# trailing-backslash parity), so values containing \" and backslash runs --
+# legal in macOS/Linux paths -- extract correctly. These $()-style wrappers
+# keep the existing one-shot call sites unchanged; HOT loops call the _hp_*
+# helpers directly (no substitution fork).
 _ql_json_escape() {
-    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+    _hp_json_escape "$1"
+    printf '%s' "$_HP_ESC"
 }
 
 # _ql_json_field <file> <key> -- extract a flat string field's value.
-# The lock JSON is always single-line, flat, all-string values, so a
-# simple grep -o is sufficient (no jq dependency).
 _ql_json_field() {
-    grep -o "\"$2\":\"[^\"]*\"" "$1" 2>/dev/null | head -1 \
-        | sed -e "s/^\"$2\":\"//" -e 's/"$//'
+    local _raw=""
+    _raw=$(cat "$1" 2>/dev/null) || _raw=""
+    _hp_json_field "$_raw" "$2"
+    printf '%s' "$_HP_FIELD"
 }
 
 # _ql_json_field_str <json-string> <key> -- same extraction from an
@@ -169,8 +199,8 @@ _ql_json_field() {
 # operate on the same generation -- N separate file reads could straddle
 # a concurrent owner.json rewrite.
 _ql_json_field_str() {
-    printf '%s' "$1" | grep -o "\"$2\":\"[^\"]*\"" 2>/dev/null | head -1 \
-        | sed -e "s/^\"$2\":\"//" -e 's/"$//'
+    _hp_json_field "$1" "$2"
+    printf '%s' "$_HP_FIELD"
 }
 
 # _ql_slug <handover-path> -- normalize a handover path to a filesystem-
@@ -191,6 +221,11 @@ _ql_slug() {
         esac
     fi
     p=$(printf '%s' "$p" | sed 's#/#__#g')
+    # NOTE: this final fold also collapses every OTHER non [A-Za-z0-9_-]
+    # separator (space, dot, colon, ...) to "-", so e.g. "foo bar" and
+    # "foo-bar" slug identically -- same theoretical-only caveat as the "/"
+    # fold above; the repo handover naming convention never produces two
+    # distinct paths differing only in which separator they use.
     printf '%s' "$p" | tr -c 'A-Za-z0-9_-' '-'
 }
 
@@ -229,6 +264,198 @@ _ql_lockdir() {
     printf '%s/.locks/queue/%s.lock' "$root" "$slug"
 }
 
+# _ql_arms_registry_retire_fired <handover-path> -- HIMMEL-882 registry
+# lifecycle: on a SUCCESSFUL acquire, CONSUME (drop) every still-pending
+# <handover-root>/.locks/arms.jsonl record for THIS host + this handover.
+# arms.jsonl (scripts/handover/arm-resume.sh, HIMMEL-856) is append-only
+# and nothing previously retired a record when its arm fired -- so a re-arm
+# of the SAME handover from ANOTHER host kept matching the stale record and
+# hard-refusing rc=8 forever (ARM_DUP_OK=1 required on every re-arm). An
+# armed session that reaches the point of acquiring its queue lock has, by
+# definition, fired, so this is the natural place to retire its record(s).
+# RETENTION SHAPE (CR round-3): a fired record is inert coordination state
+# (the foreign-hits scan skips it; takeovers.log + session notes are the
+# audit trail), so instead of marking records "fired" and carrying them
+# forever -- which made the registry O(all arms ever) and a long rewrite a
+# mutex-expiry hazard -- consumed records are DROPPED, and any legacy
+# '"fired":"true"'-marked line (written by the earlier marking revision) is
+# garbage-collected in passing. Both rewriters GC this way, so the file
+# stays O(active arms). Matches by host+handover only (not task-name/
+# fire-at) so it also clears earlier SAME-host records left by a re-arm/
+# --force replace that never itself fired (arm-resume.sh additionally
+# prunes those at re-schedule time -- see its own HIMMEL-882 comment).
+#
+# Best-effort and fail-open: a missing/unresolvable registry, a mutex
+# timeout, a mid-rewrite mutex theft, or a write failure just leaves the
+# record(s) unconsumed (WARN on stderr) -- same contract as the rest of the
+# arms-registry integration (a registry hiccup must never fail an acquire
+# that otherwise succeeded). CRASH-atomic: filtered content is written to a
+# same-dir temp file, then mv'd into place (matches _ql_write_owner's
+# owner.json pattern) so a mid-write crash never leaves a torn arms.jsonl
+# -- but temp+mv alone does NOT protect against a CONCURRENT rewriter, so
+# the whole read-filter-rewrite runs under the OWNER-TOKENED
+# _ql_arms_mutex_acquire mkdir-CAS mutex shared with arm-resume.sh's
+# _arm_registry_replace_and_append, and the mv happens only while the
+# owner token still names us (round-3: a holder that outlives the mutex's
+# 60s staleness expiry gets reclaimed; its snapshot is then stale and its
+# blind mv/rmdir would corrupt the reclaimer's generation).
+_ql_arms_registry_retire_fired() {
+    local ho="$1" root reg host tmp tok cur line l_host l_ho host_esc ho_esc changed=0 failed=0 stolen=0 wfail_err=""
+    # handover_root failure here would require an external race (the root
+    # deleted out from under us mid-acquire): _ql_lockdir already resolved
+    # this same root moments earlier via handover_root_ensure, so this is
+    # structurally can't-happen on this call path -- silent return is
+    # intentional, not an oversight (unlike every other failure branch
+    # below, which WARNs).
+    root=$(handover_root 2>/dev/null) || return 0
+    [ -n "$root" ] || return 0
+    reg="$root/.locks/arms.jsonl"
+    [ -f "$reg" ] || return 0
+    if ! _ql_arms_mutex_acquire "$reg"; then
+        echo "WARN queue-lock: could not lock the arms registry ($reg.lock) -- skipping the consume; this host's arm record stays PENDING (a later acquire or same-host re-arm clears it; a mutex stuck from a crashed writer self-expires after 60s)" >&2
+        return 0
+    fi
+    tok="$_QL_ARMS_MUTEX_TOKEN"
+    # Compare ESCAPED-vs-ESCAPED (round-2): the registry stores JSON-escaped
+    # values, so the needles get the same transform before comparing.
+    host=$(_ql_hostname)
+    _hp_json_escape "$host"; host_esc="$_HP_ESC"
+    _hp_json_escape "$ho";   ho_esc="$_HP_ESC"
+    tmp="$reg.tmp.$$"
+    # round-4 (sfh-2): capture stderr instead of discarding it, so a real
+    # write failure (disk full / permission denied / RO-fs / AV lock) folds
+    # its first line into the WARN below and reads differently from a
+    # mutex timeout or theft -- 2>/dev/null made all of these look like the
+    # same generic "could not rewrite" message.
+    if wfail_err=$( { : > "$tmp"; } 2>&1 ); then
+        # `|| [ -n "$line" ]` (round-2 Critical): read returns 1 at
+        # EOF-without-newline while still filling $line -- without the guard
+        # the rewrite silently DELETES a final record lacking a trailing
+        # newline. Blank lines are dropped on rewrite (aligned with
+        # _arm_registry_replace_and_append). ZERO forks per line (round-3
+        # Critical): _hp_json_field returns via $_HP_FIELD, no $().
+        while IFS= read -r line || [ -n "$line" ]; do
+            [ -z "$line" ] && continue
+            case "$line" in
+                *'"fired":"true"'*) changed=1; continue ;;   # GC legacy fired-marked line
+            esac
+            _hp_json_field "$line" host;     l_host="$_HP_FIELD"
+            _hp_json_field "$line" handover; l_ho="$_HP_FIELD"
+            if [ "$l_host" = "$host_esc" ] && [ "$l_ho" = "$ho_esc" ]; then
+                changed=1
+                continue   # consumed: this acquire IS the arm's session start
+            fi
+            printf '%s\n' "$line" >> "$tmp" || failed=1
+            [ "$failed" -eq 1 ] && break
+        done < "$reg"
+    else
+        failed=1
+    fi
+    if [ "$failed" -eq 0 ] && [ "$changed" -eq 1 ]; then
+        # OWNER-TOKEN verify (round-3): mv only while the mutex still names
+        # us. If it was reclaimed mid-rewrite our snapshot is stale -- skip
+        # the mv (the release below WARNs about the theft). The cat->mv
+        # window is microseconds vs the whole-rewrite window it replaces --
+        # residual (accepted), same class as the release function's
+        # token-read->rmdir gap documented below.
+        cur=$(cat "$reg.lock/owner" 2>/dev/null) || cur=""
+        if [ "$cur" = "$tok" ]; then
+            if wfail_err=$(mv -f "$tmp" "$reg" 2>&1); then
+                echo "queue-lock: consumed this host's pending arms-registry record(s) for this handover (arm fired)" >&2
+            else
+                failed=1
+            fi
+        else
+            stolen=1
+        fi
+    fi
+    if [ "$failed" -eq 1 ]; then
+        echo "WARN queue-lock: could not rewrite the arms registry ($reg) -- consume skipped; this host's arm record stays PENDING (the lock acquire itself is unaffected)${wfail_err:+ (write error: ${wfail_err%%$'\n'*})}" >&2
+    fi
+    if [ "$failed" -eq 1 ] || [ "$stolen" -eq 1 ] || [ "$changed" -eq 0 ]; then
+        rm -f "$tmp" 2>/dev/null
+    fi
+    _ql_arms_mutex_release "$reg" "$tok" || true
+    return 0
+}
+
+# _ql_arms_mutex_acquire <registry-file> -- HIMMEL-882 CR round-2/3: acquire
+# the short-lived mkdir-CAS mutex (<registry>.lock, a DIRECTORY -- the same
+# atomic primitive as the queue lock and the takeover claim above) that
+# serializes every arms.jsonl read-filter-rewrite writer (this script's
+# consume + arm-resume.sh's prune-and-append; the path AND the owner-token
+# protocol must stay identical in both). On success the lock dir carries an
+# `owner` token file and $_QL_ARMS_MUTEX_TOKEN names it -- release/mv are
+# compare-then-act against that token (round-3: a holder reclaimed after
+# the 60s staleness expiry must not blind-rmdir the reclaimer's lock or mv
+# a stale snapshot over its rewrite). Bounded: nominal ~4s of 0.1s retries
+# (platform-dependent -- measured ~2x that, ~8.7s, on Windows/Git-Bash from
+# per-iteration mkdir+sleep overhead), then rc 1 -- callers keep the
+# fail-open contract (WARN + skip the registry op, never fail the
+# acquire/arm). A mutex stranded by a crashed writer is cleared when its
+# dir mtime is >=60s old, re-probed every 10th iteration across the retry
+# budget (round-4: NOT every iteration -- py_armor_mtime forks python and
+# Windows python startup is ~100-300ms; probing every 10th yields ~4 probes
+# across the ~40-iteration budget, bounding the extra forks while still
+# catching a lock that crosses the 60s threshold mid-wait -- a lock that
+# was, say, 56s old when this contender started is not yet stale at
+# tries==0 but would previously never be re-checked, burning the whole
+# retry budget instead of reclaiming it; a failed probe never clears).
+_QL_ARMS_MUTEX_TOKEN=""
+_ql_arms_mutex_acquire() {
+    local reg="$1" lockd tries=0 m now tok
+    lockd="$reg.lock"
+    while :; do
+        if mkdir "$lockd" 2>/dev/null; then
+            # Brand the lock. pid alone is unique among LIVE processes;
+            # $RANDOM guards the recycled-pid edge. A failed brand write is
+            # a failed acquire (fail-open) -- an unbranded lock would make
+            # every release read as a theft.
+            tok="pid$$-r$RANDOM"
+            if ! printf '%s' "$tok" > "$lockd/owner" 2>/dev/null; then
+                rm -f "$lockd/owner" 2>/dev/null
+                rmdir "$lockd" 2>/dev/null
+                return 1
+            fi
+            _QL_ARMS_MUTEX_TOKEN="$tok"
+            return 0
+        fi
+        if [ $(( tries % 10 )) -eq 0 ]; then
+            m=$(py_armor_mtime "$lockd") || m=""
+            now=$(_ql_now_epoch)
+            if [ -n "$m" ] && [ -n "$now" ] && [ $(( now - m )) -ge 60 ]; then
+                rm -rf "$lockd" 2>/dev/null
+            fi
+        fi
+        tries=$((tries + 1))
+        if [ "$tries" -ge 40 ]; then
+            return 1
+        fi
+        sleep 0.1
+    done
+}
+
+# _ql_arms_mutex_release <registry-file> <token> -- compare-then-delete
+# (round-3): release the arms mutex ONLY if its owner token is still ours.
+# A mismatch means the lock was reclaimed from under us (we outlived the
+# 60s staleness expiry mid-rewrite) -- WARN loudly and leave the
+# reclaimer's lock alone (rc 1); the caller has already skipped its stale
+# mv on the same comparison. Residual (accepted): a reclaim landing between
+# the token read and the rmdir can still lose its lock -- a microsecond
+# window vs the whole-rewrite window this closes, same accepted-residual
+# class as the takeover claim's rm->mkdir gap above.
+_ql_arms_mutex_release() {
+    local reg="$1" tok="$2" cur=""
+    cur=$(cat "$reg.lock/owner" 2>/dev/null) || cur=""
+    if [ "$cur" != "$tok" ]; then
+        echo "WARN queue-lock: the arms-registry mutex ($reg.lock) was reclaimed by another writer mid-rewrite (owner token mismatch: now '${cur:-none}') -- leaving their lock in place; this rewrite was discarded" >&2
+        return 1
+    fi
+    rm -f "$reg.lock/owner" 2>/dev/null
+    rmdir "$reg.lock" 2>/dev/null
+    return 0
+}
+
 queue_lock_acquire() {
     local ho="${1:-}" session="${2:-}"
     if [ -z "$ho" ]; then
@@ -261,6 +488,7 @@ queue_lock_acquire() {
             return 1
         fi
         echo "queue-lock: acquired (session=$session host=$host)"
+        _ql_arms_registry_retire_fired "$ho"
         echo "release-token: $session"
         return 0
     fi
@@ -397,6 +625,7 @@ queue_lock_acquire() {
             rmdir "$claim" 2>/dev/null
             echo "queue-lock: took over ($reason) -- previous holder: session=$o_session host=$o_host" >&2
             echo "queue-lock: acquired (session=$session host=$host)"
+            _ql_arms_registry_retire_fired "$ho"
             echo "release-token: $session"
             return 0
         fi

--- a/scripts/handover/test-arm-resume-queue-lock.sh
+++ b/scripts/handover/test-arm-resume-queue-lock.sh
@@ -225,6 +225,178 @@ rc=$?
 assert_rc "T14: arm proceeds despite a broken status probe" 0 "$rc"
 assert_contains "T14: WARN reports the unexpected status rc" "queue-lock status failed (rc=5)" "$out"
 
+# --- T15: re-arming the SAME handover from the SAME host replaces its own --
+# prior arms.jsonl record instead of accumulating a second one (HIMMEL-882).
+# A stale same-host record left behind by a repeated re-arm/--force would
+# otherwise sit in the append-only registry forever -- harmless to THIS
+# host (foreign-hits only looks at OTHER hosts) but a permanent rc=8 trap
+# for the NEXT host that tries to arm this same handover.
+HO15="$HANDOVER_DIR/HIMMEL-856-test/next-session-15.md"
+printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t15 handover\n' > "$HO15"
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO15" 2>&1)
+rc=$?
+assert_rc "T15: first real arm succeeds" 0 "$rc"
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO15" 2>&1)
+rc=$?
+assert_rc "T15: second real arm (re-arm, same host) succeeds" 0 "$rc"
+n=$(grep -c "\"handover\":\"$HO15\"" "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null || echo 0)
+if [ "$n" -eq 1 ]; then
+    echo "PASS T15: exactly one record survives repeated same-host re-arms (got $n)"
+else
+    echo "FAIL T15: expected exactly 1 record after 2 same-host re-arms, got $n ($(cat "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null))"
+    FAILED=$((FAILED + 1))
+fi
+rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
+
+# --- T16: a FIRED foreign-host record no longer blocks a re-arm (HIMMEL-882)
+# queue-lock.sh's acquire marks a record "fired":"true" once the armed
+# session actually starts; that record must stop counting as a PENDING
+# cross-host dup from then on.
+HO16="$HANDOVER_DIR/HIMMEL-856-test/next-session-16.md"
+printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t16 handover\n' > "$HO16"
+printf '{"host":"other-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-fired","fired":"true"}\n' \
+    "$HO16" > "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO16" --dry-run 2>&1)
+rc=$?
+assert_rc "T16: fired foreign-host record no longer blocks re-arm" 0 "$rc"
+assert_not_contains "T16: no rc=8 PENDING-arm refusal for a fired record" "already has a PENDING arm" "$out"
+rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
+
+# --- T17: a STILL-LIVE (unfired) foreign-host record still refuses rc=8 ----
+# (HIMMEL-882 regression guard) -- confirms the fired-skip added for T16 is
+# scoped to records actually marked "fired":"true" and does not silently
+# widen to every foreign record.
+HO17="$HANDOVER_DIR/HIMMEL-856-test/next-session-17b.md"
+printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t17 handover\n' > "$HO17"
+printf '{"host":"other-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-still-live"}\n' \
+    "$HO17" > "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO17" --dry-run 2>&1)
+rc=$?
+assert_rc "T17: still-live (unfired) foreign-host record still refuses rc=8" 8 "$rc"
+rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
+
+# --- T18: MIXED registry -- fired + pending for the SAME handover on -------
+# DIFFERENT hosts (round-2 addendum): the fired record is skipped but the
+# pending one still refuses rc=8, from one multi-line file.
+HO18="$HANDOVER_DIR/HIMMEL-856-test/next-session-18.md"
+printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t18 handover\n' > "$HO18"
+{
+    printf '{"host":"fired-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t18-fired","fired":"true"}\n' "$HO18"
+    printf '{"host":"pending-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t18-pending"}\n' "$HO18"
+} > "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO18" --dry-run 2>&1)
+rc=$?
+assert_rc "T18: mixed registry still refuses on the PENDING record" 8 "$rc"
+assert_contains "T18: refusal names the pending host" "pending-host" "$out"
+assert_not_contains "T18: refusal does not list the fired host as a hit" "fired-host" "$out"
+rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
+
+# --- T19: backslash handover path -- prune still matches (round-2 item 3) --
+# The registry stores JSON-escaped values (backslashes doubled); pre-fix
+# the raw-vs-escaped compare silently disabled the same-host prune, so two
+# arms with a backslash path left two records. On Windows/Git-Bash use the
+# real cygpath -w (backslash) form of the handover; on POSIX a literal
+# backslash is a legal filename character -- both exercise the same
+# escaped-needle compare.
+HO19P="$HANDOVER_DIR/HIMMEL-856-test/next-session-19.md"
+printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t19 handover\n' > "$HO19P"
+if command -v cygpath >/dev/null 2>&1; then
+    HO19=$(cygpath -w "$HO19P")
+else
+    HO19="$HANDOVER_DIR/HIMMEL-856-test/"'back\slash-19.md'
+    printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t19 handover\n' > "$HO19"
+fi
+HO19_ESC=$(printf '%s' "$HO19" | sed -e 's/\\/\\\\/g')
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO19" 2>&1)
+rc=$?
+assert_rc "T19: first arm with a backslash path succeeds" 0 "$rc"
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO19" 2>&1)
+rc=$?
+assert_rc "T19: second arm (re-arm) with a backslash path succeeds" 0 "$rc"
+n=$(grep -cF "\"handover\":\"$HO19_ESC\"" "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null || echo 0)
+if [ "$n" -eq 1 ]; then
+    echo "PASS T19: escaped-path prune matched -- exactly 1 record after 2 re-arms"
+else
+    echo "FAIL T19: expected 1 record for the backslash path, got $n ($(cat "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null))"
+    FAILED=$((FAILED + 1))
+fi
+rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
+
+# --- T20: registry unwritable -> mutex timeout WARN + the arm still --------
+# succeeds (round-2 fail-open contract, addendum item). Portable trigger: a
+# FILE where the .locks dir should be -- mkdir -p fails and the mutex mkdir
+# can never succeed (parent is a file), so the rewrite is skipped after the
+# bounded ~4s wait. No chmod tricks (they don't hold on Windows).
+HD20="$TMP/statedocs-t20/handovers"
+mkdir -p "$HD20/HIMMEL-856-test"
+: > "$HD20/.locks"   # a FILE squatting on the .locks DIR path
+HO20="$HD20/HIMMEL-856-test/next-session-20.md"
+printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t20 handover\n' > "$HO20"
+out=$(HANDOVER_DIR="$HD20" bash "$ARM" --time "$FUTURE_TIME" --handover "$HO20" 2>&1)
+rc=$?
+assert_rc "T20: arm still succeeds when the registry root is unwritable" 0 "$rc"
+assert_contains "T20: WARN names the failed registry append" "failed to append the arms.jsonl registry record" "$out"
+
+# --- T21: cross-script writer race -- arm (prune+append) vs acquire --------
+# (consume) on the SAME registry, different handovers (round-2 High).
+# Pre-mutex, the loser's rewrite was overwritten by the winner's mv (lost
+# update). A few full-arm rounds are enough here -- the 20-round hammer for
+# the mutex itself lives in test-queue-lock.sh T25. End state per round
+# (retention shape, round-3): the arm's NEW record present, the acquire's
+# record CONSUMED -- exactly 1 line, no matter who won the mutex first.
+T21_BAD=""
+t21_i=0
+while [ "$t21_i" -lt 6 ]; do
+    HOA="$HANDOVER_DIR/HIMMEL-856-test/t21-arm-$t21_i.md"
+    printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t21 handover\n' > "$HOA"
+    HOB="$HANDOVER_DIR/HIMMEL-856-test/t21-acq-$t21_i.md"
+    THIS_HOST=$(hostname 2>/dev/null || echo "${COMPUTERNAME:-${HOSTNAME:-unknown-host}}")
+    printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t21-acq"}\n' \
+        "$THIS_HOST" "$HOB" > "$HANDOVER_DIR/.locks/arms.jsonl"
+    ( bash "$ARM" --time "$FUTURE_TIME" --handover "$HOA" >/dev/null 2>&1 ) &
+    ( bash "$QL" acquire "$HOB" "t21-acq-$t21_i" >/dev/null 2>&1 ) &
+    wait
+    if ! grep -qF "\"handover\":\"$HOA\"" "$HANDOVER_DIR/.locks/arms.jsonl" \
+        || grep -q 'HIMMEL-Resume-t21-acq' "$HANDOVER_DIR/.locks/arms.jsonl" \
+        || [ "$(wc -l < "$HANDOVER_DIR/.locks/arms.jsonl")" -ne 1 ]; then
+        T21_BAD="round $t21_i: $(cat "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null)"
+        break
+    fi
+    t21_i=$((t21_i + 1))
+done
+if [ -z "$T21_BAD" ]; then
+    echo "PASS T21: no lost update across 6 arm-vs-acquire race rounds"
+else
+    echo "FAIL T21: cross-script race lost an update ($T21_BAD)"
+    FAILED=$((FAILED + 1))
+fi
+rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
+
+# --- T22: a REAL arm garbage-collects legacy fired-marked lines ------------
+# (round-3 retention): a '"fired":"true"' line (written by the round-1/2
+# marking revision) is inert -- the rewrite drops it in passing, so the
+# registry stays O(active arms). Keeps the T16 INTENT (a fired foreign
+# record must not refuse re-arms) whether the line is still present
+# (dry-run path, T16) or pruned (this rewrite path).
+HO22="$HANDOVER_DIR/HIMMEL-856-test/next-session-22b.md"
+printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t22 handover\n' > "$HO22"
+{
+    printf '{"host":"other-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t22-legacy-fired","fired":"true"}\n' "$HO22"
+    printf '{"host":"other-host","handover":"t22-unrelated.md","fire-at":"202601010000","task-name":"HIMMEL-Resume-t22-pending-bystander"}\n'
+} > "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO22" 2>&1)
+rc=$?
+assert_rc "T22: real arm succeeds over a legacy fired record" 0 "$rc"
+if ! grep -q 'HIMMEL-Resume-t22-legacy-fired' "$HANDOVER_DIR/.locks/arms.jsonl" \
+    && grep -q 'HIMMEL-Resume-t22-pending-bystander' "$HANDOVER_DIR/.locks/arms.jsonl" \
+    && grep -qF "\"handover\":\"$HO22\"" "$HANDOVER_DIR/.locks/arms.jsonl"; then
+    echo "PASS T22: legacy fired line pruned; pending bystander + new record survive"
+else
+    echo "FAIL T22: retention GC wrong ($(cat "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null))"
+    FAILED=$((FAILED + 1))
+fi
+rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
+
 echo "---"
 echo "FAILED=$FAILED"
 [ "$FAILED" -eq 0 ]

--- a/scripts/handover/test-queue-lock.sh
+++ b/scripts/handover/test-queue-lock.sh
@@ -742,16 +742,22 @@ rm -f "$ARMS_REGISTRY"
 # whole ~40-iteration retry budget without reclaiming a lock that crossed
 # the 60s threshold mid-wait (an immediate follow-up call reclaimed it
 # instantly). The fix re-probes every 10th iteration. Backdate a HELD
-# (never-renewed) lock dir's mtime to a fixed ~56s-old absolute epoch stamp
+# (never-renewed) lock dir's mtime to a fixed ~58s-old absolute epoch stamp
 # -- `touch -d "@<epoch>"`, NOT `touch -t`, which parses local wall-clock
 # and would silently apply the host's UTC offset -- and assert the acquire
 # reclaims it (rc=0) within its bounded retry budget rather than timing out
-# (rc=1).
+# (rc=1). The 58s margin is deliberate: it must stay <60s so the PRE-FIX
+# single tries==0 probe misses it (the regression this guards), yet be high
+# enough that a periodic re-probe crosses 60s within the loop's ~4s sleep
+# floor (40 x 0.1s) on FAST platforms too. At 56s the crossing landed AFTER
+# the last re-probe (try 30, ~3s -> 59s) on fast Linux -- only slow Windows
+# (~8.7s loop) caught it, so CI flaked; at 58s, try 20/30 (>=2s/3s elapsed)
+# reach >=60s on every platform.
 HO31="$HANDOVER_DIR/HIMMEL-856-test/next-session-31.md"
 : > "$HO31"
 mkdir -p "$ARMS_REGISTRY.lock"
 printf '%s' "stale-holder-tok" > "$ARMS_REGISTRY.lock/owner"
-t31_epoch=$(( $(date -u +%s) - 56 ))
+t31_epoch=$(( $(date -u +%s) - 58 ))
 touch -d "@$t31_epoch" "$ARMS_REGISTRY.lock"
 t31_out=$(bash -c '
     . "$1"
@@ -760,9 +766,9 @@ t31_out=$(bash -c '
     echo "TOK=$_QL_ARMS_MUTEX_TOKEN"
 ' _ "$LIB" "$ARMS_REGISTRY" 2>&1)
 if printf '%s' "$t31_out" | grep -q '^RC=0$' && printf '%s' "$t31_out" | grep -q '^TOK=pid'; then
-    pass "T31: a ~56s-stale mutex is reclaimed via periodic re-probe within the retry budget"
+    pass "T31: a ~58s-stale mutex is reclaimed via periodic re-probe within the retry budget"
 else
-    fail "T31: ~56s-stale mutex was not reclaimed within budget (out=$t31_out)"
+    fail "T31: ~58s-stale mutex was not reclaimed within budget (out=$t31_out)"
 fi
 rm -f "$ARMS_REGISTRY.lock/owner" 2>/dev/null; rmdir "$ARMS_REGISTRY.lock" 2>/dev/null
 rm -f "$ARMS_REGISTRY"

--- a/scripts/handover/test-queue-lock.sh
+++ b/scripts/handover/test-queue-lock.sh
@@ -404,6 +404,436 @@ else
 fi
 QUEUE_LOCK_FORCE_RELEASE=1 bash "$LIB" release "$HO18" >/dev/null 2>&1
 
+# --- T19: acquire CONSUMES (drops) THIS host's PENDING arms.jsonl ----------
+# record(s) for this handover (HIMMEL-882; retention shape, round-3), and
+# touches nothing else: a sibling record for the SAME host but a DIFFERENT
+# handover, and a record for the SAME handover but a DIFFERENT host, must
+# both survive untouched -- this is the lifecycle fix for arm-resume.sh's
+# permanent rc=8 (a cross-host re-arm kept matching a stale record whose
+# arm had long fired).
+HO19="$HANDOVER_DIR/HIMMEL-856-test/next-session-19.md"
+: > "$HO19"
+HO19_SIBLING="$HANDOVER_DIR/HIMMEL-856-test/next-session-19b.md"
+mkdir -p "$HANDOVER_DIR/.locks"
+THIS_HOST=$(hostname 2>/dev/null || echo "${COMPUTERNAME:-${HOSTNAME:-unknown-host}}")
+ARMS_REGISTRY="$HANDOVER_DIR/.locks/arms.jsonl"
+{
+    printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t19-mine"}\n' "$THIS_HOST" "$HO19"
+    printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t19-sibling"}\n' "$THIS_HOST" "$HO19_SIBLING"
+    printf '{"host":"other-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t19-foreign"}\n' "$HO19"
+} > "$ARMS_REGISTRY"
+err="$(bash "$LIB" acquire "$HO19" "session-t19" 2>&1 1>/dev/null)"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    pass "T19: acquire rc=0"
+else
+    fail "T19: acquire rc=0 (got $rc: $err)"
+fi
+if ! grep -q '"task-name":"HIMMEL-Resume-t19-mine"' "$ARMS_REGISTRY"; then
+    pass "T19: this host's record for this handover was consumed (dropped)"
+else
+    fail "T19: this host's record was not consumed ($(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+if grep -q '"task-name":"HIMMEL-Resume-t19-sibling"' "$ARMS_REGISTRY"; then
+    pass "T19: sibling handover's record (same host) untouched"
+else
+    fail "T19: sibling handover's record was WRONGLY dropped ($(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+if grep -q '"task-name":"HIMMEL-Resume-t19-foreign"' "$ARMS_REGISTRY"; then
+    pass "T19: foreign host's record (same handover) untouched"
+else
+    fail "T19: foreign host's record was WRONGLY dropped ($(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+if [ "$(wc -l < "$ARMS_REGISTRY")" -eq 2 ]; then
+    pass "T19: exactly the 2 bystander lines survive (no corruption/loss)"
+else
+    fail "T19: unexpected registry line count ($(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+if printf '%s' "$err" | grep -qi 'consumed'; then
+    pass "T19: loud trail on the consumed stderr line"
+else
+    fail "T19: no loud trail for the consume rewrite ($err)"
+fi
+bash "$LIB" release "$HO19" "session-t19" >/dev/null 2>&1
+
+# --- T20: acquire is a no-op on the arms registry when no record matches --
+# (no arms.jsonl at all, and a registry with only non-matching records) --
+# never errors, never fabricates a match.
+HO20="$HANDOVER_DIR/HIMMEL-856-test/next-session-20.md"
+: > "$HO20"
+rm -f "$ARMS_REGISTRY"
+bash "$LIB" acquire "$HO20" "session-t20" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ] && [ ! -f "$ARMS_REGISTRY" ]; then
+    pass "T20: acquire with no arms.jsonl at all -- rc=0, no file created"
+else
+    fail "T20: acquire with no arms.jsonl (got rc=$rc, exists=$([ -f "$ARMS_REGISTRY" ] && echo yes || echo no))"
+fi
+bash "$LIB" release "$HO20" "session-t20" >/dev/null 2>&1
+
+# --- T21: a registry WITHOUT a trailing newline never loses its final ------
+# record on rewrite (HIMMEL-882 CR round-2 Critical, live-reproduced):
+# `read` returns 1 at EOF-without-newline while still filling the variable,
+# so without the `|| [ -n "$line" ]` guard the final record was silently
+# DELETED. Two shapes: (a) final record is a NON-matching bystander -- must
+# survive; (b) final record IS the matching one -- must be SEEN and
+# consumed (loud trail), not silently skipped.
+HO21="$HANDOVER_DIR/HIMMEL-856-test/next-session-21.md"
+: > "$HO21"
+{
+    printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t21-mine"}\n' "$THIS_HOST" "$HO21"
+    printf '{"host":"other-host","handover":"unrelated.md","fire-at":"202601010000","task-name":"HIMMEL-Resume-t21-last"}'
+} > "$ARMS_REGISTRY"   # NOTE: final record has NO trailing newline
+bash "$LIB" acquire "$HO21" "session-t21" >/dev/null 2>&1
+if grep -q '"task-name":"HIMMEL-Resume-t21-last"' "$ARMS_REGISTRY"; then
+    pass "T21: final no-newline bystander record survives the rewrite"
+else
+    fail "T21: final no-newline record was DELETED ($(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+if ! grep -q '"task-name":"HIMMEL-Resume-t21-mine"' "$ARMS_REGISTRY"; then
+    pass "T21: matching record still got consumed"
+else
+    fail "T21: matching record not consumed ($(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+bash "$LIB" release "$HO21" "session-t21" >/dev/null 2>&1
+printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t21-solo"}' \
+    "$THIS_HOST" "$HO21" > "$ARMS_REGISTRY"   # single matching record, NO newline
+err="$(bash "$LIB" acquire "$HO21" "session-t21b" 2>&1 1>/dev/null)"
+if printf '%s' "$err" | grep -qi 'consumed' && ! grep -q 't21-solo' "$ARMS_REGISTRY"; then
+    pass "T21: solo no-newline matching record was SEEN and consumed (loud trail)"
+else
+    fail "T21: solo no-newline record not consumed / no trail (err=$err reg=$(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+bash "$LIB" release "$HO21" "session-t21b" >/dev/null 2>&1
+
+# --- T22: odd line shapes consume cleanly without corrupting bystanders ----
+# (round-2 hardening, reshaped for round-3 retention: consumed lines are
+# DROPPED whole, never edited, so trailing whitespace/CR after `}` and a
+# missing closing brace cannot produce invalid JSON -- the field match is
+# shape-insensitive). The bystander line must survive byte-identical.
+HO22="$HANDOVER_DIR/HIMMEL-856-test/next-session-22.md"
+: > "$HO22"
+BYSTANDER22='{"host":"other-host","handover":"unrelated-22.md","fire-at":"202601010000","task-name":"HIMMEL-Resume-t22-bystander"}'
+{
+    printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t22-ws"}   \n' "$THIS_HOST" "$HO22"
+    printf '{"host":"%s","handover":"%s","task-name":"HIMMEL-Resume-t22-garbage"\n' "$THIS_HOST" "$HO22"
+    printf '%s\n' "$BYSTANDER22"
+} > "$ARMS_REGISTRY"
+bash "$LIB" acquire "$HO22" "session-t22" >/dev/null 2>&1
+if ! grep -q 'HIMMEL-Resume-t22-ws' "$ARMS_REGISTRY" && ! grep -q 'HIMMEL-Resume-t22-garbage' "$ARMS_REGISTRY"; then
+    pass "T22: trailing-whitespace + no-brace matching lines both consumed"
+else
+    fail "T22: odd-shaped matching lines not consumed ($(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+if grep -qF "$BYSTANDER22" "$ARMS_REGISTRY" && [ "$(wc -l < "$ARMS_REGISTRY")" -eq 1 ]; then
+    pass "T22: bystander line survives byte-identical"
+else
+    fail "T22: bystander corrupted/lost ($(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+bash "$LIB" release "$HO22" "session-t22" >/dev/null 2>&1
+
+# --- T30: direct fired-GC coverage for the consume path (round-4 test-1) ---
+# The legacy '"fired":"true"'-marked-line GC inside
+# _ql_arms_registry_retire_fired (the unconditional `*'"fired":"true"'*)
+# changed=1; continue` case, matched BEFORE the host/handover compare) had
+# no direct test here -- only its twin in arm-resume.sh's rewriter got
+# end-to-end coverage. Mirrors T22's odd-shape intent: seed a fired-marked
+# line for THIS host's own handover plus an untouched (non-fired) bystander
+# from another host, drive it through the real queue_lock_acquire path, and
+# assert the fired line is gone while the bystander survives byte-identical.
+HO30="$HANDOVER_DIR/HIMMEL-856-test/next-session-30.md"
+: > "$HO30"
+T30_BYSTANDER='{"host":"other-host","handover":"unrelated-30.md","fire-at":"202601010000","task-name":"HIMMEL-Resume-t30-bystander"}'
+{
+    printf '{"host":"%s","handover":"%s","fired":"true","fire-at":"202601010000","task-name":"HIMMEL-Resume-t30-fired"}\n' \
+        "$THIS_HOST" "$HO30"
+    printf '%s\n' "$T30_BYSTANDER"
+} > "$ARMS_REGISTRY"
+bash "$LIB" acquire "$HO30" "session-t30" >/dev/null 2>&1
+if ! grep -q 'HIMMEL-Resume-t30-fired' "$ARMS_REGISTRY"; then
+    pass "T30: legacy fired-marked line is GC'd on acquire (direct consume-path coverage)"
+else
+    fail "T30: fired-marked line survived consume ($(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+if grep -qF "$T30_BYSTANDER" "$ARMS_REGISTRY" && [ "$(wc -l < "$ARMS_REGISTRY")" -eq 1 ]; then
+    pass "T30: non-fired bystander line survives byte-identical"
+else
+    fail "T30: bystander corrupted/lost ($(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+bash "$LIB" release "$HO30" "session-t30" >/dev/null 2>&1
+rm -f "$ARMS_REGISTRY"
+
+# --- T23: escaped-vs-raw compare (round-2): the registry stores JSON- ------
+# escaped values (backslashes doubled), so a raw Windows backslash handover
+# path must still match its own record and be consumed. acquire never stats
+# the handover path, so a fake backslash path exercises this on every
+# platform.
+HO23='C:\fake\HIMMEL-882\next-session-23.md'
+HO23_ESC=$(printf '%s' "$HO23" | sed -e 's/\\/\\\\/g')
+printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t23-bslash"}\n' \
+    "$THIS_HOST" "$HO23_ESC" > "$ARMS_REGISTRY"
+bash "$LIB" acquire "$HO23" "session-t23" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ] && ! grep -q 'HIMMEL-Resume-t23-bslash' "$ARMS_REGISTRY"; then
+    pass "T23: backslash path matches its escaped record and is consumed"
+else
+    fail "T23: backslash-path record not consumed (rc=$rc reg=$(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+QUEUE_LOCK_FORCE_RELEASE=1 bash "$LIB" release "$HO23" >/dev/null 2>&1
+
+# --- T24: the TAKEOVER acquire path also consumes (round-2 addendum) -------
+# T19 covered the fresh-mkdir path only; the stale-takeover branch has its
+# own retire call. Stale fixture per T9/T14: hand-crafted owner.json with
+# an ancient heartbeat under the DEFAULT TTL.
+HO24="$HANDOVER_DIR/HIMMEL-856-test/next-session-24.md"
+: > "$HO24"
+LOCKDIR24="$HANDOVER_DIR/.locks/queue/HIMMEL-856-test__next-session-24.lock"
+mkdir -p "$LOCKDIR24"
+printf '{"session":"dead-session","host":"old-host","handover":"%s","started":"2020-01-01T00:00:00Z","heartbeat":"2020-01-01T00:00:00Z"}\n' \
+    "$HO24" > "$LOCKDIR24/owner.json"
+printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t24-takeover"}\n' \
+    "$THIS_HOST" "$HO24" > "$ARMS_REGISTRY"
+err="$(bash "$LIB" acquire "$HO24" "session-t24" 2>&1 1>/dev/null)"
+rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$err" | grep -qi 'took over'; then
+    pass "T24: acquire went through the stale-takeover path rc=0"
+else
+    fail "T24: expected a stale takeover (got rc=$rc: $err)"
+fi
+if ! grep -q 'HIMMEL-Resume-t24-takeover' "$ARMS_REGISTRY"; then
+    pass "T24: takeover-path acquire consumed the record"
+else
+    fail "T24: takeover-path acquire did not consume ($(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+bash "$LIB" release "$HO24" "session-t24" >/dev/null 2>&1
+
+# --- T25: concurrent rewriters lose no record (round-2 High) ---------------
+# Two acquires on DIFFERENT handovers race the SAME arms.jsonl (one
+# registry per handover root); pre-mutex, both did read-filter-rewrite-mv
+# and the last mv won, losing the other's update. Modest hammer: 20 rounds,
+# each with both records pending plus an untouchable bystander; after both
+# acquires BOTH matching records must be consumed and the bystander must be
+# the only survivor.
+T25_BYSTANDER='{"host":"other-host","handover":"t25-bystander.md","fire-at":"202601010000","task-name":"HIMMEL-Resume-t25-bystander"}'
+T25_BAD=""
+t25_i=0
+while [ "$t25_i" -lt 20 ]; do
+    HOA="$HANDOVER_DIR/HIMMEL-856-test/race-a-$t25_i.md"
+    HOB="$HANDOVER_DIR/HIMMEL-856-test/race-b-$t25_i.md"
+    {
+        printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t25-a"}\n' "$THIS_HOST" "$HOA"
+        printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t25-b"}\n' "$THIS_HOST" "$HOB"
+        printf '%s\n' "$T25_BYSTANDER"
+    } > "$ARMS_REGISTRY"
+    ( bash "$LIB" acquire "$HOA" "t25-a-$t25_i" >/dev/null 2>&1 ) &
+    ( bash "$LIB" acquire "$HOB" "t25-b-$t25_i" >/dev/null 2>&1 ) &
+    wait
+    if [ "$(wc -l < "$ARMS_REGISTRY")" -ne 1 ] \
+        || ! grep -qF "$T25_BYSTANDER" "$ARMS_REGISTRY"; then
+        T25_BAD="round $t25_i: $(cat "$ARMS_REGISTRY" 2>/dev/null)"
+        break
+    fi
+    t25_i=$((t25_i + 1))
+done
+if [ -z "$T25_BAD" ]; then
+    pass "T25: no lost update across 20 concurrent-acquire rounds (bystander sole survivor)"
+else
+    fail "T25: concurrent rewrite lost an update ($T25_BAD)"
+fi
+
+# --- T26: write-failure fail-open (round-2 addendum): tmp create fails -> --
+# WARN + acquire still succeeds + registry left untouched + mutex released.
+# Portable trigger: source the lib in one bash so $$ is knowable, and plant
+# a DIRECTORY at the exact "$reg.tmp.$$" path -- the `: >` redirection then
+# fails on every platform (no chmod tricks, which don't hold on Windows).
+HO26="$HANDOVER_DIR/HIMMEL-856-test/next-session-26.md"
+: > "$HO26"
+printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t26-failopen"}\n' \
+    "$THIS_HOST" "$HO26" > "$ARMS_REGISTRY"
+t26_out=$(bash -c '. "$1"; mkdir -p "$2.tmp.$$"; queue_lock_acquire "$3" "sess-t26"; rc=$?; rmdir "$2.tmp.$$" 2>/dev/null; echo "RC=$rc"' _ "$LIB" "$ARMS_REGISTRY" "$HO26" 2>&1)
+if printf '%s' "$t26_out" | grep -q 'RC=0' && printf '%s' "$t26_out" | grep -q 'release-token: sess-t26'; then
+    pass "T26: acquire still succeeds when the registry rewrite cannot start"
+else
+    fail "T26: acquire failed on a registry write failure (out=$t26_out)"
+fi
+if printf '%s' "$t26_out" | grep -q 'could not rewrite the arms registry'; then
+    pass "T26: loud WARN names the skipped consume"
+else
+    fail "T26: no WARN for the failed registry rewrite (out=$t26_out)"
+fi
+if grep -q 'HIMMEL-Resume-t26-failopen' "$ARMS_REGISTRY" && [ ! -d "$ARMS_REGISTRY.lock" ]; then
+    pass "T26: registry untouched (record stays PENDING) and the arms mutex was released"
+else
+    fail "T26: registry altered or mutex leaked (reg=$(cat "$ARMS_REGISTRY" 2>/dev/null), lock-exists=$([ -d "$ARMS_REGISTRY.lock" ] && echo yes || echo no))"
+fi
+bash "$LIB" release "$HO26" "sess-t26" >/dev/null 2>&1
+rm -f "$ARMS_REGISTRY"
+
+# --- T27: owner-token mutex theft (HIMMEL-882 CR round-3 Critical, --------
+# live-measured): a holder whose rewrite outlives the mutex's 60s mtime
+# self-expiry gets RECLAIMED by a contending writer; pre-token, the slow
+# holder's blind rmdir then released the THIEF's lock (third writer
+# interleaves = silent lost update). Two layers:
+# (a) the mutex protocol itself: backdate the held lock dir (fixed 2020
+#     stamp, always >60s old), a second acquire reclaims it, and the
+#     ORIGINAL holder's release must detect the token mismatch -> WARN +
+#     leave the thief's lock in place;
+# (b) the full rewrite path: with the mutex owner swapped mid-rewrite, the
+#     acquire must SKIP its stale mv (registry unchanged), WARN, and still
+#     rc=0 (fail-open).
+HO27="$HANDOVER_DIR/HIMMEL-856-test/next-session-27.md"
+: > "$HO27"
+t27_out=$(bash -c '
+    . "$1"
+    reg="$2"
+    _ql_arms_mutex_acquire "$reg" || { echo "NOACQ"; exit 1; }
+    orig="$_QL_ARMS_MUTEX_TOKEN"
+    touch -t 202001010000 "$reg.lock"   # 70s-backdated (fixed ancient stamp)
+    if _ql_arms_mutex_acquire "$reg"; then echo "RECLAIMED"; fi
+    thief="$_QL_ARMS_MUTEX_TOKEN"
+    _ql_arms_mutex_release "$reg" "$orig"
+    echo "REL_RC=$?"
+    if [ -d "$reg.lock" ] && [ "$(cat "$reg.lock/owner" 2>/dev/null)" = "$thief" ]; then
+        echo "THIEF_INTACT"
+    fi
+    _ql_arms_mutex_release "$reg" "$thief" >/dev/null 2>&1
+' _ "$LIB" "$ARMS_REGISTRY" 2>&1)
+if printf '%s' "$t27_out" | grep -q 'RECLAIMED'; then
+    pass "T27: 70s-backdated held mutex is reclaimed by a contender"
+else
+    fail "T27: backdated mutex was not reclaimed (out=$t27_out)"
+fi
+if printf '%s' "$t27_out" | grep -q 'REL_RC=1' \
+    && printf '%s' "$t27_out" | grep -q 'reclaimed by another writer' \
+    && printf '%s' "$t27_out" | grep -q 'THIEF_INTACT'; then
+    pass "T27: original holder detects the theft -> WARN + skips rmdir (thief lock intact)"
+else
+    fail "T27: theft not detected / thief lock clobbered (out=$t27_out)"
+fi
+printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t27-victim"}\n' \
+    "$THIS_HOST" "$HO27" > "$ARMS_REGISTRY"
+# (b): stub the mutex acquire to a no-op holding a token that does NOT
+# match the owner file (= the lock was reclaimed mid-rewrite) -- the mv
+# must be skipped, no corruption, acquire still rc=0.
+t27b_out=$(bash -c '
+    . "$1"
+    _ql_arms_mutex_acquire() { _QL_ARMS_MUTEX_TOKEN="orig-tok"; return 0; }
+    mkdir -p "$2.lock"; printf "%s" "thief-tok" > "$2.lock/owner"
+    queue_lock_acquire "$3" "sess-t27b"
+    echo "RC=$?"
+' _ "$LIB" "$ARMS_REGISTRY" "$HO27" 2>&1)
+if printf '%s' "$t27b_out" | grep -q 'RC=0' \
+    && printf '%s' "$t27b_out" | grep -q 'reclaimed by another writer' \
+    && grep -q 'HIMMEL-Resume-t27-victim' "$ARMS_REGISTRY" \
+    && [ "$(cat "$ARMS_REGISTRY.lock/owner" 2>/dev/null)" = "thief-tok" ]; then
+    pass "T27: mid-rewrite theft skips the stale mv (no corruption) + acquire stays rc=0"
+else
+    fail "T27: stale mv not skipped or corruption (out=$t27b_out reg=$(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+rm -f "$ARMS_REGISTRY.lock/owner"; rmdir "$ARMS_REGISTRY.lock" 2>/dev/null
+bash "$LIB" release "$HO27" "sess-t27b" >/dev/null 2>&1
+rm -f "$ARMS_REGISTRY"
+
+# --- T31: mutex staleness is RE-PROBED periodically, not just at tries==0 --
+# (round-4 sfh-1, live-reproduced): pre-fix, _ql_arms_mutex_acquire probed
+# the held lock's mtime staleness ONLY on the first contended iteration. A
+# lock that was already ~56s old when the contender started is not yet
+# stale at tries==0, so the pre-fix code never re-checked and burned its
+# whole ~40-iteration retry budget without reclaiming a lock that crossed
+# the 60s threshold mid-wait (an immediate follow-up call reclaimed it
+# instantly). The fix re-probes every 10th iteration. Backdate a HELD
+# (never-renewed) lock dir's mtime to a fixed ~56s-old absolute epoch stamp
+# -- `touch -d "@<epoch>"`, NOT `touch -t`, which parses local wall-clock
+# and would silently apply the host's UTC offset -- and assert the acquire
+# reclaims it (rc=0) within its bounded retry budget rather than timing out
+# (rc=1).
+HO31="$HANDOVER_DIR/HIMMEL-856-test/next-session-31.md"
+: > "$HO31"
+mkdir -p "$ARMS_REGISTRY.lock"
+printf '%s' "stale-holder-tok" > "$ARMS_REGISTRY.lock/owner"
+t31_epoch=$(( $(date -u +%s) - 56 ))
+touch -d "@$t31_epoch" "$ARMS_REGISTRY.lock"
+t31_out=$(bash -c '
+    . "$1"
+    _ql_arms_mutex_acquire "$2"
+    echo "RC=$?"
+    echo "TOK=$_QL_ARMS_MUTEX_TOKEN"
+' _ "$LIB" "$ARMS_REGISTRY" 2>&1)
+if printf '%s' "$t31_out" | grep -q '^RC=0$' && printf '%s' "$t31_out" | grep -q '^TOK=pid'; then
+    pass "T31: a ~56s-stale mutex is reclaimed via periodic re-probe within the retry budget"
+else
+    fail "T31: ~56s-stale mutex was not reclaimed within budget (out=$t31_out)"
+fi
+rm -f "$ARMS_REGISTRY.lock/owner" 2>/dev/null; rmdir "$ARMS_REGISTRY.lock" 2>/dev/null
+rm -f "$ARMS_REGISTRY"
+
+# --- T28: rewrite perf smoke (round-3 Critical): a 300-line registry -------
+# rewrite completes in <=5s. The pre-fix grep|head|sed pipelines cost
+# ~185-200ms/LINE on Windows/Git-Bash (8+ forks each), so 300 lines
+# exceeded the mutex's own 60s expiry; the pure-bash _hp_json_field
+# extraction is zero-fork per line. A generous 5s bound still catches any
+# O(n)-forks regression.
+HO28="$HANDOVER_DIR/HIMMEL-856-test/next-session-28.md"
+: > "$HO28"
+{
+    printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t28-mine"}\n' "$THIS_HOST" "$HO28"
+    t28_i=0
+    while [ "$t28_i" -lt 299 ]; do
+        printf '{"host":"other-host","handover":"bystander-%s.md","fire-at":"202601010000","task-name":"HIMMEL-Resume-t28-b%s"}\n' "$t28_i" "$t28_i"
+        t28_i=$((t28_i + 1))
+    done
+} > "$ARMS_REGISTRY"
+t28_start=$(date +%s)
+bash "$LIB" acquire "$HO28" "session-t28" >/dev/null 2>&1
+t28_elapsed=$(( $(date +%s) - t28_start ))
+if [ "$t28_elapsed" -le 5 ]; then
+    pass "T28: 300-line registry rewrite completed in ${t28_elapsed}s (<=5s)"
+else
+    fail "T28: 300-line rewrite took ${t28_elapsed}s (>5s -- O(n)-forks regression?)"
+fi
+if [ "$(wc -l < "$ARMS_REGISTRY")" -eq 299 ] && ! grep -q 't28-mine' "$ARMS_REGISTRY"; then
+    pass "T28: all 299 bystanders survive, the matching record was consumed"
+else
+    fail "T28: registry wrong after big rewrite ($(wc -l < "$ARMS_REGISTRY") lines)"
+fi
+bash "$LIB" release "$HO28" "session-t28" >/dev/null 2>&1
+rm -f "$ARMS_REGISTRY"
+
+# --- T29: escaped-quote + backslash values round-trip (round-3: the -------
+# parity-aware _hp_json_field replaces the round-2 extractor whose values
+# mis-truncated at an escaped quote -- macOS/Linux paths may legally
+# contain double quotes). Unit round-trip via the shared lib, then the
+# real acquire flow consumes a record whose handover value carries \" and
+# backslash runs.
+t29_out=$(bash -c '
+    . "$1"
+    raw="we/ird \"quoted\" \\path\\with\\\\runs"
+    _hp_json_escape "$raw"; esc="$_HP_ESC"
+    line="{\"host\":\"h\",\"handover\":\"$esc\",\"task-name\":\"t\"}"
+    _hp_json_field "$line" handover
+    [ "$_HP_FIELD" = "$esc" ] && echo "ROUNDTRIP_OK"
+    _hp_json_field "$line" task-name
+    [ "$_HP_FIELD" = "t" ] && echo "NEXT_FIELD_OK"
+' _ "$SCRIPT_DIR/../lib/handover-path.sh" 2>&1)
+if printf '%s' "$t29_out" | grep -q 'ROUNDTRIP_OK' && printf '%s' "$t29_out" | grep -q 'NEXT_FIELD_OK'; then
+    pass "T29: escaped-quote + backslash value round-trips through escape->extract"
+else
+    fail "T29: escaped-quote round-trip broken (out=$t29_out)"
+fi
+HO29='dir/we ird "quoted" \name-29.md'
+t29_esc=$(bash -c '. "$1"; _hp_json_escape "$2"; printf "%s" "$_HP_ESC"' _ "$SCRIPT_DIR/../lib/handover-path.sh" "$HO29")
+printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t29-quoted"}\n' \
+    "$THIS_HOST" "$t29_esc" > "$ARMS_REGISTRY"
+bash "$LIB" acquire "$HO29" "session-t29" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ] && ! grep -q 'HIMMEL-Resume-t29-quoted' "$ARMS_REGISTRY"; then
+    pass "T29: acquire consumes a record whose path value carries quotes + backslashes"
+else
+    fail "T29: quoted-path record not consumed (rc=$rc reg=$(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+QUEUE_LOCK_FORCE_RELEASE=1 bash "$LIB" release "$HO29" >/dev/null 2>&1
+rm -f "$ARMS_REGISTRY"
+
 echo "---"
 echo "PASSED=$PASSED FAILED=$FAILED"
 [ "$FAILED" = 0 ]

--- a/scripts/lib/handover-path.sh
+++ b/scripts/lib/handover-path.sh
@@ -102,3 +102,60 @@ handover_mode() {
         echo "A"
     fi
 }
+
+# --- flat-JSON helpers for the handover lock/registry files (HIMMEL-882) ---
+# Shared by scripts/handover/queue-lock.sh and scripts/handover/arm-resume.sh
+# (both already source this lib) for owner.json and the cross-machine arms
+# registry (.locks/arms.jsonl). PURE BASH, ZERO FORKS by design: results are
+# returned in globals (_HP_ESC / _HP_FIELD), not on stdout, so hot rewrite
+# loops can call them per line without a command substitution -- the CR
+# round-3 Critical measured the previous printf|grep|head|sed pipelines at
+# ~185-200ms/LINE on Windows/Git-Bash (8+ forks each), which let a ~300-line
+# registry rewrite outlive the arms-mutex's own 60s staleness expiry.
+
+# _hp_json_escape <value> -- JSON-escape a string value into $_HP_ESC
+# (backslashes doubled, double quotes escaped). The inverse pairing of
+# _hp_json_field below: what one writes, the other reads back verbatim.
+_HP_ESC=""
+_hp_json_escape() {
+    _HP_ESC="${1//\\/\\\\}"
+    _HP_ESC="${_HP_ESC//\"/\\\"}"
+}
+
+# _hp_json_field <json-string> <key> -- extract the string value of a flat
+# "key":"value" field into $_HP_FIELD (empty on miss/malformed). The value
+# is returned in its RAW (still-escaped) form, so comparisons stay
+# escaped-vs-escaped against _hp_json_escape output. Escape-AWARE: the
+# value ends at the first UNESCAPED closing quote -- an escaped quote is
+# recognized by trailing-backslash parity (odd run of backslashes before
+# the quote = the quote is escaped and part of the value), so values
+# containing \" and backslash runs extract correctly on every platform
+# (macOS/Linux paths may legally contain double quotes). First occurrence
+# of the key wins, matching the grep|head -1 extractors this replaces.
+_HP_FIELD=""
+_hp_json_field() {
+    local _hp_rest _hp_chunk _hp_bs
+    _HP_FIELD=""
+    case "$1" in
+        *"\"$2\":\""*) ;;
+        *) return 0 ;;
+    esac
+    _hp_rest="${1#*"\"$2\":\""}"
+    while :; do
+        _hp_chunk="${_hp_rest%%\"*}"
+        if [ "$_hp_chunk" = "$_hp_rest" ]; then
+            # no closing quote at all -- malformed field, report a miss
+            _HP_FIELD=""
+            return 0
+        fi
+        _HP_FIELD="$_HP_FIELD$_hp_chunk"
+        _hp_rest="${_hp_rest#*\"}"
+        # trailing-backslash run of the chunk; ## leaves the chunk intact
+        # when it is ALL backslashes (no non-backslash to anchor on).
+        _hp_bs="${_hp_chunk##*[!\\]}"
+        if [ $(( ${#_hp_bs} % 2 )) -eq 0 ]; then
+            return 0   # even parity: the quote was unescaped -- value ends
+        fi
+        _HP_FIELD="$_HP_FIELD\""   # odd parity: escaped quote, keep scanning
+    done
+}

--- a/scripts/lib/test-handover-path.sh
+++ b/scripts/lib/test-handover-path.sh
@@ -111,6 +111,49 @@ got=$(handover_root)
 expected=$(cd "$TMP/external" && pwd)
 assert_eq "T6 trailing slash normalised" "$expected" "$got"
 
+# T7: _hp_json_field / _hp_json_escape unit cases (HIMMEL-882 CR round-4
+# test-2). Direct coverage of the flat-JSON parser/escaper shared by
+# queue-lock.sh and arm-resume.sh (previously only exercised indirectly
+# through their acquire/rewrite flows).
+
+# T7a: a value ending in a backslash immediately before the field's closing
+# quote (the parity boundary) -- the raw value's trailing backslash doubles
+# under _hp_json_escape, so the closing quote must read as UNESCAPED (an
+# EVEN trailing-backslash count) and correctly terminate the value there.
+raw7a=$'abc\\'
+_hp_json_escape "$raw7a"; esc7a="$_HP_ESC"
+line7a="{\"key\":\"$esc7a\",\"next\":\"ok\"}"
+_hp_json_field "$line7a" key
+assert_eq "T7a trailing-backslash value extracts in full (escaped form)" "$esc7a" "$_HP_FIELD"
+_hp_json_field "$line7a" next
+assert_eq "T7a boundary correctly found -- next field still parses" "ok" "$_HP_FIELD"
+
+# T7b: a raw value with a literal backslash immediately adjacent to a
+# literal double-quote -- escaping produces an ODD trailing-backslash run
+# before an ESCAPED quote (the quote is part of the value, not the
+# terminator), so the scan must keep going past it instead of truncating.
+raw7b='x\"y'
+_hp_json_escape "$raw7b"; esc7b="$_HP_ESC"
+line7b="{\"key\":\"$esc7b\"}"
+_hp_json_field "$line7b" key
+assert_eq "T7b backslash-adjacent-to-quote value round-trips" "$esc7b" "$_HP_FIELD"
+
+# T7c: an empty value ("key":"") extracts as the empty string, not a miss,
+# and the scan still finds the next field's boundary correctly.
+line7c='{"key":"","next":"ok"}'
+_hp_json_field "$line7c" key
+assert_eq "T7c empty value extracts as empty string" "" "$_HP_FIELD"
+_hp_json_field "$line7c" next
+assert_eq "T7c boundary correctly found after an empty value" "ok" "$_HP_FIELD"
+
+# T7d: a key entirely absent from the line -- the return-on-miss branch
+# reports the miss via $_HP_FIELD="" rather than leaving a stale value from
+# a prior call.
+_HP_FIELD="stale-from-a-prior-call"
+line7d='{"other":"value"}'
+_hp_json_field "$line7d" key
+assert_eq "T7d absent key resets _HP_FIELD to empty (miss branch)" "" "$_HP_FIELD"
+
 if [ "$FAILED" -gt 0 ]; then
     echo "---"
     echo "FAIL $FAILED case(s)"


### PR DESCRIPTION
## What

Phase 2 of HIMMEL-856 — makes the cross-machine arms registry (`<handover-root>/.locks/arms.jsonl`) **lifecycle-aware** so a fired arm's record is retired instead of lingering forever. Previously the registry was append-only: re-arming a handover from another host after the original arm fired matched the stale record and hard-refused `rc=8` indefinitely (a drift risk on our own guard).

## How

- **Consume-on-acquire** — `queue-lock.sh acquire` (overnight step 0) drops this host's pending arm record(s) for the handover; both rewriters GC any legacy `"fired":"true"` line. Registry stays O(active arms).
- **Same-host prune on re-arm** in `arm-resume.sh`.
- **Owner-token mutex** on every `arms.jsonl` rewrite (twin logic in `queue-lock.sh` + `arm-resume.sh`): acquire brands the lock dir with a token; the `mv` commit runs only while the token still names us; release is compare-then-delete (mismatch → loud WARN, skip both mv and rmdir, fail-open). Fixes a live-proven lock-theft where a ~300-line O(n)-fork rewrite outran the mutex's 60s self-expiry.
- **Pure-bash escape-aware field extraction** (`_hp_json_escape`/`_hp_json_field` in `scripts/lib/handover-path.sh`) — zero forks/line (300-line rewrite: ~60s → ~1s), value ends at the first unescaped quote (trailing-backslash parity).

## CR journey (4 rounds + 2 focused re-reviews)

- **R1-R3**: SFH live-repro'd the final-line-deletion + O(n)-fork mutex-theft window; codex-adv confirmed the concurrent-writer lost-update. Fixed via the owner-token mutex + pure-bash extraction + fired-record retention.
- **R4** (this session): free panel `[codex-1]` (escaped-display) adjudicated cosmetic/unreachable; code-reviewer 0/0; pr-test-analyzer 2 coverage gaps → **fixed** (T30 direct fired-GC, T7a-d parser units); SFH 2 Important → **fixed** (periodic mutex staleness re-probe every 10th retry so a lock crossing 60s mid-wait is reclaimed; distinguishable write-failure WARNs via brace-group stderr capture). Both re-reviewers cleared the R4 delta 0/0, with SFH empirically reproducing pre-fix→post-fix T31.

## Tests

`test-queue-lock.sh` 69/69 (incl. T27 mutex-theft, T28 perf, T30 fired-GC, T31 re-probe regression), `test-arm-resume-queue-lock.sh` 47/47, `test-arm-resume.sh` 219/219, `test-handover-path.sh` (incl. T7a-d parser units), `test-flush.sh` 14/14. shellcheck clean on all sources.

## Follow-ups

- **HIMMEL-884** — structurally wire queue-lock acquire / arms-registry retirement into the scheduler launch path (856 phase 3; from codex-adv). Out of 882 scope; 882 strictly improves the bug on the normal resume path.
- Two SFH R4 suggestions (non-blocking): mirror T31 into the arm-resume suite; capture the mid-loop `printf >> tmp` write failure (unclosed edge of the same class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
