### PR TITLE
feat(luna-vitals): [HIMMEL-794] durable degraded-data signal in ReviewArtifact

### DIFF
--- a/scripts/luna-vitals/cli.ts
+++ b/scripts/luna-vitals/cli.ts
@@ -38,6 +38,9 @@ async function main(): Promise<void> {
     const det: ExtractedRow[] = [];
     const llm: ExtractedRow[] = [];
     const buckets: string[] = [];
+    // Collect warnings from input artifacts in input order; merged onto the output
+    // artifact (deduped) when non-empty. A clean merge stays byte-identical to pre-794.
+    const collectedWarnings: string[] = [];
     const valueFlags = new Set(["out", "metrics", "note-date", "dir"]);
     let pool: ExtractedRow[] = llm; // bare positional inputs default to the LLM pool
     for (let i = 0; i < rest.length; i++) {
@@ -49,22 +52,38 @@ async function main(): Promise<void> {
         const art = await readArtifact(a);
         pool.push(...art.rows);
         buckets.push(art.bucket);
+        collectedWarnings.push(...(art.warnings ?? []));
       } else if (!a.endsWith(".json")) {
         // A bare positional that is not a .json artifact is not an input — warn
         // (naming it) instead of silently dropping it, so a typo'd path is visible.
         console.error(`[luna-vitals] warning: ignoring positional argument that is not a .json artifact: ${a}`);
       }
     }
-    if (!det.length && !llm.length) { console.error("usage: merge [--det <det.json>...] [--llm <llm.json>...] --out <merged.json> (no input artifacts found)"); process.exit(1); }
+    // Fail fast unless the inputs carry at least one row OR one warning: a valid
+    // degraded pull can produce a rows-empty artifact whose warnings still must
+    // merge through (HIMMEL-794), but rows-empty AND warnings-empty inputs
+    // (including zero artifact files) are a total extraction failure — error out.
+    if (!det.length && !llm.length && !collectedWarnings.length) { console.error("usage: merge [--det <det.json>...] [--llm <llm.json>...] --out <merged.json> (no input artifacts found)"); process.exit(1); }
     const uniq = [...new Set(buckets)];
     const bucket = uniq.length === 1 ? uniq[0] : `merged(${uniq.join(",")})`;
-    await writeArtifact(out, mergeRows({ deterministic: det, llm, bucket }));
+    const merged = mergeRows({ deterministic: det, llm, bucket });
+    if (collectedWarnings.length) {
+      // Dedupe exact-duplicate warnings across inputs (mirrors the buckets uniq
+      // behavior) — the same degraded date re-appearing in two artifacts warns once.
+      merged.warnings = [...new Set(collectedWarnings)];
+    }
+    await writeArtifact(out, merged);
     console.error(`[luna-vitals] merged ${det.length} deterministic + ${llm.length} llm rows -> ${out}`);
   } else if (cmd === "write") {
     const file = rest[0];
     const dir = flag(rest, "dir");
     if (!file || !dir) { console.error("usage: write <artifact.json> --dir <50-Vitals>"); process.exit(1); }
-    const res = await writeSeries(await readArtifact(file), dir);
+    const artifact = await readArtifact(file);
+    // Surface artifact warnings on stderr — advisory only, never blocks: unlike
+    // unresolved conflicts, degraded data was already handled at derive time by row
+    // omission. Not persisted past the artifact.
+    for (const w of artifact.warnings ?? []) console.error(`[luna-vitals] artifact warning: ${w}`);
+    const res = await writeSeries(artifact, dir);
     for (const r of res) console.error(`[luna-vitals] ${r.metric}: ${r.n} rows -> ${r.path}`);
   } else {
     console.error(`unknown command: ${cmd ?? "(none)"} — use parse|merge|write`);

--- a/scripts/luna-vitals/connectors/SCHEMA.md
+++ b/scripts/luna-vitals/connectors/SCHEMA.md
@@ -52,14 +52,55 @@ If any non-AWAKE stage in the main sleep session has an unparseable start/end ti
 and a `[google-health]` stderr warning is printed. Invalid AWAKE stages never enter the
 asleep sum, so they do not trigger the degraded path.
 
-Known limitations (tracked in HIMMEL-794): the warning is **stderr-only** — the review
-artifact carries no warnings field, so a degraded date looks identical to a genuinely
-stage-less classic session in the artifact JSON, and `writeSeries` leaves any previously
-written `sleep_hours` value for that date untouched (metrics absent from artifact rows
-are never rewritten). Adjacent silent skips predating HIMMEL-793: a session with no
-`civilEndTime` and no `endUtcOffset`, or an unparseable session interval, is dropped
-entirely without a warning; a non-array `stages` field is coerced to `[]` (treated as
-classic stage-less).
+### Durable warnings field (HIMMEL-794)
+The degraded warning above is now ALSO recorded durably in the review artifact's optional
+`warnings: string[]` field — absent from the JSON when there are no warnings, written by
+`pull` and preserved through `merge` (deduped across inputs). A clean pull keeps producing
+a byte-identical artifact to pre-HIMMEL-794; a pull whose sleep payload triggers a
+degraded date carries `warnings: ["sleep <date>: malformed stage timestamps - sleep_hours
+omitted (degraded stage data)"]`. The stderr line is unchanged — the artifact copy is
+additive. A dated warning is recorded on the artifact only when its date falls inside the
+pull's `[from, to]` window (matching the rows filter); a warning with no derivable date is
+always recorded regardless of window.
+
+Four adjacent paths that previously skipped silently now each produce a warning too
+(stderr + artifact); row-emission behavior is unchanged for all four. The three
+session-scoped warnings embed the dataPoint index (`sleep dataPoint <i> …`) so two
+distinct dropped sessions never share a text — `merge` dedups warnings by exact text,
+so identical text must mean the same event:
+- A session whose interval is missing `startTime`/`endTime` entirely is still dropped:
+  `sleep dataPoint <i> (<date>): missing interval startTime/endTime - session dropped` when
+  an end date is still derivable (from `civilEndTime` or `endTime` + `endUtcOffset`),
+  undated (`sleep dataPoint <i>: missing interval startTime/endTime - session dropped`)
+  otherwise.
+- A session with no `civilEndTime` and no `endUtcOffset` (no date derivable) is still
+  dropped: `sleep dataPoint <i> ending <endTime>: no civilEndTime and no endUtcOffset - session dropped`.
+- An unparseable session interval (`startMs`/`endMs` not finite) is still dropped:
+  `sleep dataPoint <i> (<date>): unparseable interval start/end - session dropped` (undated
+  `sleep dataPoint <i>: unparseable interval start/end - session dropped` when a garbage
+  `endTime` makes the date underivable).
+- A non-array `stages` field is still coerced to `[]` (stage-less: `sleep_in_bed_hours`
+  emits, `sleep_hours` does not): `sleep <date>: non-array "stages" field - treated as
+  stage-less (sleep_hours unavailable)`. The warning refers to the MAIN session for the
+  date — a malformed shorter/nap session does not warn, since it never contributes rows.
+  An absent `stages` field is the normal classic stage-less case and produces NO warning.
+
+`write` surfaces any artifact `warnings` on stderr as `[luna-vitals] artifact warning:
+<text>` before writing series — advisory only, does not block the write. Warnings are
+not persisted past the artifact (writeSeries ignores them).
+
+### Known limitations
+`writeSeries` only overlays emitted rows onto the existing on-disk CSV — metrics absent
+from artifact rows are never rewritten, so a degraded date's previously written
+`sleep_hours` value is left untouched (the operator must repair that series manually).
+Intentional; noted under HIMMEL-794.
+
+A merged artifact's warnings record DERIVATION-TIME loss, not final-artifact state — a
+warned (metric, date) gap may have been filled by the other merge pool, so a warning does
+not guarantee the merged rows lack that date.
+
+A sleep dataPoint with no recognizable typed payload field at all is dropped WITHOUT a
+warning (deliberate scope-out — HIMMEL-801).
 
 ## Derived
 - `rhr_bpm` ← heart-rate raw samples: per civil day, take a low estimator

--- a/scripts/luna-vitals/connectors/google-health.test.ts
+++ b/scripts/luna-vitals/connectors/google-health.test.ts
@@ -274,4 +274,223 @@ describe('pull', () => {
     expect(err.message.toLowerCase()).toContain('re-consent');
     expect(err.message).not.toContain('fake-rtoken');
   });
+
+  test('degraded sleep date → artifact carries the warning in warnings[]', async () => {
+    // A sleep payload whose main session has a malformed non-AWAKE stage → degraded.
+    // pull must surface the deriveSleep warning durably on the returned artifact
+    // (HIMMEL-794); row emission is unchanged (sleep_in_bed_hours only).
+    const degradedSleep = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-01T22:00:00Z',
+              startUtcOffset: '0s',
+              endTime: '2026-01-02T06:00:00Z',
+              endUtcOffset: '0s',
+            },
+            stages: [
+              { startTime: '2026-01-01T22:00:00Z', endTime: '2026-01-02T02:00:00Z', type: 'LIGHT' },
+              { startTime: 'not-a-timestamp', endTime: 'also-garbage', type: 'DEEP' },
+            ],
+          },
+        },
+      ],
+    };
+
+    const degradedFetch = async (url: string, _init?: RequestInit): Promise<FakeResponse> => {
+      if (url.includes('oauth2.googleapis.com/token')) {
+        return { ok: true, status: 200, json: async () => ({ access_token: 't', token_type: 'Bearer' }) };
+      }
+      const match = url.match(/\/dataTypes\/([^/?]+)\/dataPoints/);
+      if (match && match[1] === 'sleep') {
+        return { ok: true, status: 200, json: async () => degradedSleep };
+      }
+      return { ok: true, status: 200, json: async () => ({ dataPoints: [] }) };
+    };
+
+    const artifact = await pull({
+      from: '2024-01-01',
+      to: '2026-12-31',
+      cfg: FAKE_CFG,
+      fetchImpl: degradedFetch as unknown as typeof fetch,
+    });
+
+    expect(artifact.warnings).toContain(
+      'sleep 2026-01-02: malformed stage timestamps - sleep_hours omitted (degraded stage data)',
+    );
+    const inBedRow = artifact.rows.find(
+      (r) => r.metric === 'sleep_in_bed_hours' && r.date === '2026-01-02',
+    );
+    expect(inBedRow).toBeDefined();
+    expect(inBedRow!.value).toBe(8.0);
+    expect(artifact.rows.some((r) => r.metric === 'sleep_hours')).toBe(false);
+  });
+
+  test('clean pull → warnings key is ABSENT (undefined, not [])', async () => {
+    // The fixtures are clean (no degraded/dropped/non-array sleep) → pull omits the
+    // warnings key entirely, so a clean artifact is byte-identical to pre-HIMMEL-794.
+    const artifact = await pull({
+      from: '2024-01-01',
+      to: '2026-12-31',
+      cfg: FAKE_CFG,
+      fetchImpl: asFetch(makeFakeFetch()),
+    });
+    expect(artifact.warnings).toBeUndefined();
+  });
+
+  /** Builds a fake fetchImpl that serves `sleepFixture` for the sleep dataType and empty pages otherwise. */
+  function sleepOnlyFetch(sleepFixture: { dataPoints: unknown[] }) {
+    return async (url: string, _init?: RequestInit): Promise<FakeResponse> => {
+      if (url.includes('oauth2.googleapis.com/token')) {
+        return { ok: true, status: 200, json: async () => ({ access_token: 't', token_type: 'Bearer' }) };
+      }
+      const match = url.match(/\/dataTypes\/([^/?]+)\/dataPoints/);
+      if (match && match[1] === 'sleep') {
+        return { ok: true, status: 200, json: async () => sleepFixture };
+      }
+      return { ok: true, status: 200, json: async () => ({ dataPoints: [] }) };
+    };
+  }
+
+  test('degraded sleep date OUTSIDE the pull window → artifact has NO warnings key (HIMMEL-794 Fix A)', async () => {
+    // Same degraded session as above (date 2026-01-02), but the pull window
+    // (2024-01-01..2025-01-01) does not cover it — the dated warning must be
+    // window-dropped exactly like its row is (rows are already filtered by window).
+    const degradedSleep = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-01T22:00:00Z',
+              startUtcOffset: '0s',
+              endTime: '2026-01-02T06:00:00Z',
+              endUtcOffset: '0s',
+            },
+            stages: [
+              { startTime: '2026-01-01T22:00:00Z', endTime: '2026-01-02T02:00:00Z', type: 'LIGHT' },
+              { startTime: 'not-a-timestamp', endTime: 'also-garbage', type: 'DEEP' },
+            ],
+          },
+        },
+      ],
+    };
+
+    const artifact = await pull({
+      from: '2024-01-01',
+      to: '2025-01-01',
+      cfg: FAKE_CFG,
+      fetchImpl: sleepOnlyFetch(degradedSleep) as unknown as typeof fetch,
+    });
+
+    expect(artifact.warnings).toBeUndefined();
+    expect(artifact.rows.some((r) => r.date === '2026-01-02')).toBe(false);
+  });
+
+  test('no-date-derivable dropped session → warning is kept regardless of window (undateable = conservative keep)', async () => {
+    // A session with no civilEndTime and no endUtcOffset has no derivable date, so
+    // the warning's `date` is undefined — it must be kept no matter what the pull
+    // window is (HIMMEL-794 Fix A: `!w.date` always keeps).
+    const droppedSleep = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-01T22:00:00Z',
+              endTime: '2026-01-02T06:00:00Z',
+            },
+          },
+        },
+      ],
+    };
+
+    const artifact = await pull({
+      from: '2020-01-01',
+      to: '2020-01-02',
+      cfg: FAKE_CFG,
+      fetchImpl: sleepOnlyFetch(droppedSleep) as unknown as typeof fetch,
+    });
+
+    expect(artifact.warnings).toContain(
+      'sleep dataPoint 0 ending 2026-01-02T06:00:00Z: no civilEndTime and no endUtcOffset - session dropped',
+    );
+  });
+
+  test('missing-startTime session with civilEndTime OUTSIDE the pull window → artifact has NO warnings key (CR round 2)', async () => {
+    // The missing-interval warning is DATED when an end date is derivable
+    // (civilEndTime here), so it must be window-scoped like any other dated
+    // warning — an out-of-window malformed session must not pollute this artifact.
+    const missingStartSleep = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              endTime: '2026-01-02T06:00:00Z',
+              civilEndTime: { date: { year: 2026, month: 1, day: 2 } },
+            },
+          },
+        },
+      ],
+    };
+
+    const artifact = await pull({
+      from: '2024-01-01',
+      to: '2025-01-01',
+      cfg: FAKE_CFG,
+      fetchImpl: sleepOnlyFetch(missingStartSleep) as unknown as typeof fetch,
+    });
+
+    expect(artifact.warnings).toBeUndefined();
+  });
+
+  test('one pull producing two distinct warnings (dropped session + degraded date) → both present, in order', async () => {
+    // First data point: dropped (no civilEndTime/endUtcOffset, no date). Second:
+    // a valid, in-window main session degraded by a malformed non-AWAKE stage.
+    // Parse-loop warnings (the drop) precede per-date warnings (the degradation) —
+    // the two-phase order documented on deriveSleep.
+    const twoWarningsSleep = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-05-01T22:00:00Z',
+              endTime: '2026-05-02T06:00:00Z',
+            },
+          },
+        },
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-01T22:00:00Z',
+              startUtcOffset: '0s',
+              endTime: '2026-01-02T06:00:00Z',
+              endUtcOffset: '0s',
+            },
+            stages: [
+              { startTime: '2026-01-01T22:00:00Z', endTime: '2026-01-02T02:00:00Z', type: 'LIGHT' },
+              { startTime: 'not-a-timestamp', endTime: 'also-garbage', type: 'DEEP' },
+            ],
+          },
+        },
+      ],
+    };
+
+    const artifact = await pull({
+      from: '2024-01-01',
+      to: '2026-12-31',
+      cfg: FAKE_CFG,
+      fetchImpl: sleepOnlyFetch(twoWarningsSleep) as unknown as typeof fetch,
+    });
+
+    expect(artifact.warnings).toEqual([
+      'sleep dataPoint 0 ending 2026-05-02T06:00:00Z: no civilEndTime and no endUtcOffset - session dropped',
+      'sleep 2026-01-02: malformed stage timestamps - sleep_hours omitted (degraded stage data)',
+    ]);
+  });
 });

--- a/scripts/luna-vitals/connectors/google-health.ts
+++ b/scripts/luna-vitals/connectors/google-health.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { MAPPINGS } from './map/table';
 import { extractRows, pointDate } from './map/shape';
-import { aggregateRows, deriveRestingHeartRate, deriveSleep } from './map/derive';
+import { aggregateRows, deriveRestingHeartRate, deriveSleep, type SleepWarning } from './map/derive';
 import {
   getAccessToken,
   buildAuthUrl,
@@ -15,7 +15,7 @@ import {
   RECONSENT_EXIT,
 } from './auth/oauth';
 import { fetchDataPoints, filterByDateWindow } from './fetch/dataType';
-import { type ExtractedRow, type ReviewArtifact, writeArtifact } from '../src/types';
+import { type ExtractedRow, type ReviewArtifact, writeArtifact, isValidISODate } from '../src/types';
 
 // ── internal fetch type ───────────────────────────────────────────────────────
 
@@ -91,6 +91,11 @@ export async function pull(opts: {
 
   // 4. Produce rows from each fetched response.
   const allRows: ExtractedRow[] = [];
+  // Sleep-derivation warnings (degraded stage data, dropped sessions, non-array
+  // stages) collected from deriveSleep as { date?, text } — window-filtered below
+  // against opts.from/to, then recorded durably (texts only) on the artifact when
+  // non-empty. deriveSleep already printed each to stderr; pull does not re-print.
+  const artifactWarnings: SleepWarning[] = [];
 
   for (const [dataTypeId, points] of fetched) {
     const response = { dataPoints: points };
@@ -100,7 +105,9 @@ export async function pull(opts: {
       allRows.push(...deriveRestingHeartRate(response));
     } else if (dataTypeId === 'sleep') {
       // derive: longest session per date → sleep_hours + sleep_in_bed_hours
-      allRows.push(...deriveSleep(response));
+      const { rows, warnings } = deriveSleep(response);
+      allRows.push(...rows);
+      artifactWarnings.push(...warnings);
     } else {
       // Standard path: for each mapping on this dataTypeId, extract + aggregate.
       const mappings = MAPPINGS.filter(
@@ -121,7 +128,24 @@ export async function pull(opts: {
     return 0;
   });
 
-  return { bucket: `${opts.from}..${opts.to}`, rows: sorted, conflicts: [] };
+  // Keep a warning only when it belongs to this pull's window (matching the rows
+  // filter above): no date (`!w.date`), or an undateable/garbage date
+  // (`!isValidISODate(w.date)` — an undateable data-loss warning is kept
+  // conservatively rather than window-dropped; defensive only now — deriveSleep
+  // guarantees valid-or-undefined dates), or a real date inside
+  // [opts.from, opts.to] (string compare is correct for ISO dates).
+  const keptWarnings = artifactWarnings.filter(
+    (w) => !w.date || !isValidISODate(w.date) || (opts.from <= w.date && w.date <= opts.to),
+  );
+
+  // warnings only when non-empty — a clean pull produces a byte-identical artifact
+  // to pre-HIMMEL-794 (no warnings key in the JSON).
+  return {
+    bucket: `${opts.from}..${opts.to}`,
+    rows: sorted,
+    conflicts: [],
+    ...(keptWarnings.length ? { warnings: keptWarnings.map((w) => w.text) } : {}),
+  };
 }
 
 // ── .env helpers ──────────────────────────────────────────────────────────────

--- a/scripts/luna-vitals/connectors/map/derive.test.ts
+++ b/scripts/luna-vitals/connectors/map/derive.test.ts
@@ -266,7 +266,7 @@ describe('deriveSleep', () => {
     // Fixture: session 1 (01:24Z–09:55Z = 511 min = main) + session 2 nap (14:00Z–14:40Z = 40 min).
     // Both end on 2026-06-28 local (UTC+2). Main = session 1 (511 > 40).
     const fixture = await loadFixture('sleep');
-    const rows = deriveSleep(fixture);
+    const { rows } = deriveSleep(fixture);
 
     const inBedRow = rows.find(
       (r) => r.metric === 'sleep_in_bed_hours' && r.date === '2026-06-28',
@@ -280,7 +280,7 @@ describe('deriveSleep', () => {
     // Main session (01:24Z–09:55Z) starts with 20 min AWAKE stage.
     // Non-AWAKE stages sum: 86+55+50+95+45+55+105 = 491 min = 8.183→ 8.2 h
     const fixture = await loadFixture('sleep');
-    const rows = deriveSleep(fixture);
+    const { rows } = deriveSleep(fixture);
 
     const inBedRow = rows.find(
       (r) => r.metric === 'sleep_in_bed_hours' && r.date === '2026-06-28',
@@ -295,7 +295,7 @@ describe('deriveSleep', () => {
     // Session 3: 2026-06-26T22:30Z – 2026-06-27T05:30Z, endUtcOffset "7200s"
     // Local end: 05:30Z + 2h = 07:30 → date 2026-06-27. Duration = 7h exactly.
     const fixture = await loadFixture('sleep');
-    const rows = deriveSleep(fixture);
+    const { rows } = deriveSleep(fixture);
 
     const inBedRow = rows.find(
       (r) => r.metric === 'sleep_in_bed_hours' && r.date === '2026-06-27',
@@ -308,7 +308,7 @@ describe('deriveSleep', () => {
 
   test('all emitted rows have correct metric, valid date, finite value, typed source', async () => {
     const fixture = await loadFixture('sleep');
-    const rows = deriveSleep(fixture);
+    const { rows } = deriveSleep(fixture);
 
     // fixture has sessions on 2026-06-27 and 2026-06-28, both stage-backed → 4 rows total (2 per date)
     expect(rows.length).toBe(4);
@@ -321,8 +321,9 @@ describe('deriveSleep', () => {
     }
   });
 
-  test('classic session (no stages) → sleep_in_bed_hours only, no sleep_hours row', () => {
-    // Fitbit classic-era sync: interval present, stages array absent/empty.
+  test('classic session (no stages) → sleep_in_bed_hours only, no sleep_hours row, no warning', () => {
+    // Fitbit classic-era sync: interval present, stages array absent/empty. An absent
+    // stages field is the normal stage-less case — NO warning (HIMMEL-794).
     const fixture = {
       dataPoints: [
         {
@@ -338,15 +339,16 @@ describe('deriveSleep', () => {
         },
       ],
     };
-    const rows = deriveSleep(fixture);
+    const { rows, warnings } = deriveSleep(fixture);
 
     expect(rows.length).toBe(1);
     expect(rows[0].metric).toBe('sleep_in_bed_hours');
     expect(rows[0].value).toBe(8.0);
     expect(rows.some((r) => r.metric === 'sleep_hours')).toBe(false);
+    expect(warnings).toEqual([]);
   });
 
-  test('stages session → emits both sleep_hours (asleep) and sleep_in_bed_hours (span)', () => {
+  test('stages session → emits both sleep_hours (asleep) and sleep_in_bed_hours (span); clean → warnings []', () => {
     const fixture = {
       dataPoints: [
         {
@@ -374,13 +376,14 @@ describe('deriveSleep', () => {
         },
       ],
     };
-    const rows = deriveSleep(fixture);
+    const { rows, warnings } = deriveSleep(fixture);
 
     expect(rows.length).toBe(2);
     const inBedRow = rows.find((r) => r.metric === 'sleep_in_bed_hours')!;
     const asleepRow = rows.find((r) => r.metric === 'sleep_hours')!;
     expect(inBedRow.value).toBe(8.0); // full 22:00–06:00 span
     expect(asleepRow.value).toBe(7.5); // AWAKE 30min excluded
+    expect(warnings).toEqual([]);
   });
 
   test('all-AWAKE stages session → sleep_in_bed_hours only, no sleep_hours row (asleep sum is 0)', () => {
@@ -409,7 +412,7 @@ describe('deriveSleep', () => {
         },
       ],
     };
-    const rows = deriveSleep(fixture);
+    const { rows } = deriveSleep(fixture);
 
     expect(rows.length).toBe(1);
     expect(rows[0].metric).toBe('sleep_in_bed_hours');
@@ -450,20 +453,20 @@ describe('deriveSleep', () => {
         },
       ],
     };
-    // The stderr warning is part of the degraded contract (it is the only
-    // operator-visible signal today — see SCHEMA.md / HIMMEL-794). Assert while
-    // the spy is live — mockRestore() clears the recorded calls.
+    // The degraded warning goes BOTH to stderr (the pre-HIMMEL-793 operator signal)
+    // and, since HIMMEL-794, into the returned warnings[] (the durable artifact copy).
+    // Assert both while the spy is live — mockRestore() clears the recorded calls.
+    const degradedText = 'sleep 2026-01-02: malformed stage timestamps - sleep_hours omitted (degraded stage data)';
     const errSpy = spyOn(console, 'error');
     try {
-      const rows = deriveSleep(fixture);
+      const { rows, warnings } = deriveSleep(fixture);
 
       expect(rows.length).toBe(1);
       expect(rows[0].metric).toBe('sleep_in_bed_hours');
       expect(rows[0].value).toBe(8.0);
       expect(rows.some((r) => r.metric === 'sleep_hours')).toBe(false);
-      expect(errSpy).toHaveBeenCalledWith(
-        '[google-health] sleep 2026-01-02: malformed stage timestamps - sleep_hours omitted (degraded stage data)',
-      );
+      expect(warnings.map((w) => w.text)).toContain(degradedText);
+      expect(errSpy).toHaveBeenCalledWith(`[google-health] ${degradedText}`);
     } finally {
       errSpy.mockRestore();
     }
@@ -500,7 +503,7 @@ describe('deriveSleep', () => {
         },
       ],
     };
-    const rows = deriveSleep(fixture);
+    const { rows } = deriveSleep(fixture);
 
     expect(rows.length).toBe(2);
     const inBedRow = rows.find((r) => r.metric === 'sleep_in_bed_hours')!;
@@ -509,8 +512,243 @@ describe('deriveSleep', () => {
     expect(asleepRow.value).toBe(8.0); // full 8h LIGHT span, garbage AWAKE ignored
   });
 
-  test('empty dataPoints → []', () => {
-    expect(deriveSleep({ dataPoints: [] })).toEqual([]);
-    expect(deriveSleep({})).toEqual([]);
+  test('dataPoint whose interval lacks endTime → dropped, no rows, exact warning (HIMMEL-794 Fix D)', () => {
+    // interval.startTime present but endTime absent — and no civilEndTime or
+    // endUtcOffset either, so no end date is derivable and the warning is UNDATED.
+    const fixture = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-01T22:00:00Z',
+            },
+          },
+        },
+      ],
+    };
+    const { rows, warnings } = deriveSleep(fixture);
+
+    expect(rows).toEqual([]);
+    expect(warnings).toContainEqual({
+      date: undefined,
+      text: 'sleep dataPoint 0: missing interval startTime/endTime - session dropped',
+    });
+  });
+
+  test('REGRESSION: TWO sessions both missing intervals → two DISTINCT warnings (indices differ) (CR round 4)', () => {
+    // The undated missing-interval text used to be a static string, so N dropped
+    // sessions collapsed to 1 after merge's Set dedup. The embedded dataPoint index
+    // keeps genuinely-distinct events textually distinct.
+    const fixture = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: { interval: { startTime: '2026-01-01T22:00:00Z' } },
+        },
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: { interval: { startTime: '2026-01-03T22:00:00Z' } },
+        },
+      ],
+    };
+    const { rows, warnings } = deriveSleep(fixture);
+
+    expect(rows).toEqual([]);
+    expect(warnings.map((w) => w.text)).toEqual([
+      'sleep dataPoint 0: missing interval startTime/endTime - session dropped',
+      'sleep dataPoint 1: missing interval startTime/endTime - session dropped',
+    ]);
+    // The two texts must be distinct — flat Set dedup must not collapse them.
+    expect(new Set(warnings.map((w) => w.text)).size).toBe(2);
+  });
+
+  test('garbage endTime alongside endUtcOffset → UNDATED unparseable warning, no NaN embedded (CR round 4)', () => {
+    // computeLocalDate on a garbage endTime yields "NaN-NaN-NaN" — the NaN-date
+    // guard resets it to undefined, so the unparseable warning uses its undated
+    // variant instead of embedding a garbage date.
+    const fixture = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-01T22:00:00Z',
+              endTime: 'garbage-end',
+              endUtcOffset: '7200s',
+            },
+          },
+        },
+      ],
+    };
+    const { rows, warnings } = deriveSleep(fixture);
+
+    expect(rows).toEqual([]);
+    expect(warnings).toContainEqual({
+      date: undefined,
+      text: 'sleep dataPoint 0: unparseable interval start/end - session dropped',
+    });
+    expect(warnings.some((w) => w.text.includes('NaN'))).toBe(false);
+  });
+
+  test('dataPoint missing startTime but WITH civilEndTime → dropped, warning carries the date (CR round 2)', () => {
+    // startTime absent but the end date IS derivable (civilEndTime present) — the
+    // missing-interval warning must be dated so the pull-side window filter can
+    // scope it (an undated warning would survive EVERY pull window).
+    const fixture = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              endTime: '2026-01-02T06:00:00Z',
+              civilEndTime: { date: { year: 2026, month: 1, day: 2 } },
+            },
+          },
+        },
+      ],
+    };
+    const { rows, warnings } = deriveSleep(fixture);
+
+    expect(rows).toEqual([]);
+    expect(warnings).toContainEqual({
+      date: '2026-01-02',
+      text: 'sleep dataPoint 0 (2026-01-02): missing interval startTime/endTime - session dropped',
+    });
+  });
+
+  test('session with no civilEndTime and no endUtcOffset → dropped, no rows, exact warning', () => {
+    // An interval with startTime + endTime but neither civilEndTime nor endUtcOffset:
+    // no local end date can be derived, so the session is dropped. HIMMEL-794: the
+    // drop is now warned (stderr + artifact) instead of silent; row emission unchanged.
+    const fixture = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-01T22:00:00Z',
+              endTime: '2026-01-02T06:00:00Z',
+            },
+          },
+        },
+      ],
+    };
+    const { rows, warnings } = deriveSleep(fixture);
+
+    expect(rows).toEqual([]);
+    // No date derivable at all for this path — `date` is undefined (HIMMEL-794 Fix A).
+    expect(warnings).toContainEqual({
+      date: undefined,
+      text: 'sleep dataPoint 0 ending 2026-01-02T06:00:00Z: no civilEndTime and no endUtcOffset - session dropped',
+    });
+  });
+
+  test('session with unparseable interval start/end → dropped, no rows, exact warning', () => {
+    // civilEndTime is present so a date IS derivable, but the interval start/end are
+    // unparseable (Date.parse → NaN) → no duration → session dropped. HIMMEL-794: warned.
+    const fixture = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: 'garbage',
+              endTime: 'also-garbage',
+              civilEndTime: { date: { year: 2026, month: 1, day: 2 } },
+            },
+          },
+        },
+      ],
+    };
+    const { rows, warnings } = deriveSleep(fixture);
+
+    expect(rows).toEqual([]);
+    // civilEndTime made a date derivable, so the warning carries it (HIMMEL-794 Fix A).
+    expect(warnings).toContainEqual({
+      date: '2026-01-02',
+      text: 'sleep dataPoint 0 (2026-01-02): unparseable interval start/end - session dropped',
+    });
+  });
+
+  test('non-array "stages" field → sleep_in_bed_hours only, no sleep_hours, exact warning', () => {
+    // stages is a STRING (present but non-array): coerced to [] (stage-less —
+    // sleep_in_bed_hours emits from the interval, sleep_hours does not) and warned.
+    // Contrast the classic case above, where an ABSENT stages field warns nothing.
+    const fixture = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-01T22:00:00Z',
+              startUtcOffset: '0s',
+              endTime: '2026-01-02T06:00:00Z',
+              endUtcOffset: '0s',
+            },
+            stages: 'not-an-array',
+          },
+        },
+      ],
+    };
+    const { rows, warnings } = deriveSleep(fixture);
+
+    expect(rows.length).toBe(1);
+    expect(rows[0].metric).toBe('sleep_in_bed_hours');
+    expect(rows[0].value).toBe(8.0);
+    expect(rows.some((r) => r.metric === 'sleep_hours')).toBe(false);
+    // Single session IS the main session, so it still warns, now carrying its date.
+    expect(warnings).toContainEqual({
+      date: '2026-01-02',
+      text: 'sleep 2026-01-02: non-array "stages" field - treated as stage-less (sleep_hours unavailable)',
+    });
+  });
+
+  test('REGRESSION: malformed non-array stages on a shorter NAP session does not warn (main session wins) — HIMMEL-794 Fix B / codex-adv-2', () => {
+    // A clean, longer main session (valid stages) plus a shorter same-date nap
+    // session whose `stages` field is malformed. Only the MAIN session may warn —
+    // a malformed nap that never contributes rows must not produce a warning that
+    // contradicts the sleep_hours row emitted from the clean main session.
+    const fixture = {
+      dataPoints: [
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-01T22:00:00Z',
+              startUtcOffset: '0s',
+              endTime: '2026-01-02T06:00:00Z',
+              endUtcOffset: '0s',
+            },
+            stages: [
+              { startTime: '2026-01-01T22:00:00Z', endTime: '2026-01-02T06:00:00Z', type: 'LIGHT' },
+            ],
+          },
+        },
+        {
+          dataSource: { platform: 'HEALTH_CONNECT' },
+          sleep: {
+            interval: {
+              startTime: '2026-01-02T14:00:00Z',
+              startUtcOffset: '0s',
+              endTime: '2026-01-02T14:40:00Z',
+              endUtcOffset: '0s',
+            },
+            stages: 'not-an-array',
+          },
+        },
+      ],
+    };
+    const { rows, warnings } = deriveSleep(fixture);
+
+    const asleepRow = rows.find((r) => r.metric === 'sleep_hours' && r.date === '2026-01-02');
+    expect(asleepRow).toBeDefined();
+    expect(asleepRow!.value).toBe(8.0); // main session's full 8h LIGHT span
+    expect(warnings.some((w) => w.text.includes('non-array "stages"'))).toBe(false);
+  });
+
+  test('empty dataPoints → { rows: [], warnings: [] }', () => {
+    expect(deriveSleep({ dataPoints: [] })).toEqual({ rows: [], warnings: [] });
+    expect(deriveSleep({})).toEqual({ rows: [], warnings: [] });
   });
 });

--- a/scripts/luna-vitals/connectors/map/derive.ts
+++ b/scripts/luna-vitals/connectors/map/derive.ts
@@ -6,7 +6,7 @@
  * deriveSleep: extract sleep_hours + sleep_in_bed_hours from sleep dataPoints.
  */
 import type { Mapping } from './table';
-import { type ExtractedRow, validateRow } from '../../src/types';
+import { type ExtractedRow, validateRow, isValidISODate } from '../../src/types';
 
 // ── shared helpers ────────────────────────────────────────────────────────────
 
@@ -220,7 +220,18 @@ type SleepSession = {
   durationMs: number;
   stages: SleepStage[];
   platform: string;
+  // True when this session's raw `stages` field was present but non-array (malformed).
+  // The warning for this is deferred to the per-date main-session-selection loop
+  // below (Fix B / HIMMEL-794 codex-adv-2): a malformed NAP alongside a clean main
+  // session must not warn, since the emitted sleep_hours row never came from it.
+  stagesMalformed: boolean;
 };
+
+// Internal warning shape carrying the date a warning pertains to, when one is
+// known. `date` is undefined when no local calendar date could be derived at all
+// (the pull-side window filter always keeps an undateable warning — see
+// google-health.ts). Exported so google-health.ts can type its collected warnings.
+export type SleepWarning = { date?: string; text: string };
 
 /**
  * Derive sleep_hours and sleep_in_bed_hours from sleep dataPoints.
@@ -251,43 +262,137 @@ type SleepSession = {
  *   from the session interval, not the stages) and a stderr warning is printed. Invalid
  *   AWAKE stages never enter the sum, so they do NOT trigger the degraded path.
  *
+ * Returns { rows, warnings }: `rows` are the emitted ExtractedRows; `warnings` is a
+ *   SleepWarning[] (`{ date?: string; text: string }`, possibly empty) of
+ *   degradation/drop signals — `date` is the warning's local calendar date when one
+ *   is derivable, undefined otherwise. Order is deterministic for identical input,
+ *   but is NOT a single global encounter order across warning types: it is two-phase
+ *   — parse-loop warnings (dropped sessions; the missing-interval path) come first
+ *   in data-point order, then per-date warnings (degraded stage data; non-array
+ *   stages on the MAIN session) in per-date main-session order. Each warning is
+ *   ALSO printed to stderr as `[google-health] <text>` — the stderr behavior
+ *   predates HIMMEL-794 and is unchanged; the returned copy is additive so `pull`
+ *   can record it durably on the review artifact (window-scoped there, see
+ *   google-health.ts). Five warning-producing paths, all with row emission
+ *   unchanged: (1) a session dropped because its interval is missing
+ *   startTime/endTime entirely (`sleep dataPoint <i> (<date>): missing interval …`,
+ *   dated when an end date is still derivable from civilEndTime or
+ *   endTime + endUtcOffset, `sleep dataPoint <i>: missing interval …` otherwise);
+ *   (2) a session dropped because neither civilEndTime nor endUtcOffset is present
+ *   (no date derivable — `sleep dataPoint <i> ending <endTime>: no civilEndTime …`);
+ *   (3) a session dropped because its interval start/end is unparseable
+ *   (`sleep dataPoint <i> (<date>): unparseable interval …`, undated when a garbage
+ *   endTime makes the date underivable); (4) a degraded main session (see above);
+ *   (5) a non-array `stages` field on the MAIN session for a date, coerced to
+ *   stage-less (an absent `stages` field is the normal classic case and does NOT
+ *   warn; a malformed shorter/nap session that loses main-session selection does
+ *   NOT warn either — it contributes no rows, see Fix B / HIMMEL-794 codex-adv-2).
+ *   Paths 1-3 (session-scoped) embed the dataPoint index in the text so distinct
+ *   events never share a text — the merge CLI dedups warnings by exact text, so
+ *   identical text must mean the same event (over-reporting across re-pulls with
+ *   different windows is the accepted safe direction). A dataPoint with no typed
+ *   payload field at all (the fieldKey lookup fails) is still skipped WITHOUT a
+ *   warning — deliberate scope-out, tracked in HIMMEL-801.
+ *
  * Source: 'google-health:sleep:<platform>'.
  * Each emitted row passes validateRow before being returned.
  */
-export function deriveSleep(response: { dataPoints?: unknown[] }): ExtractedRow[] {
+export function deriveSleep(response: { dataPoints?: unknown[] }): { rows: ExtractedRow[]; warnings: SleepWarning[] } {
   const sessions: SleepSession[] = [];
+  const warnings: SleepWarning[] = [];
+  // Each warning is recorded in `warnings` (durable, returned to the caller) AND
+  // printed to stderr with the [google-health] prefix (the pre-HIMMEL-794 operator
+  // signal, kept byte-identical). The stderr line is `[google-health] ` + text —
+  // `date` is carried only in the returned copy, never in the stderr line.
+  const warn = (text: string, date?: string): void => {
+    warnings.push({ date, text });
+    console.error(`[google-health] ${text}`);
+  };
 
-  for (const dp of response.dataPoints ?? []) {
+  // Parse-loop (session-scoped) warning texts embed the dataPoint index so two
+  // DISTINCT dropped sessions can never share a text — the merge CLI dedups
+  // warnings by exact text, so identical text must mean the same event. (Across
+  // re-pulls with different windows the same session may carry a different index;
+  // over-reporting there is the accepted safe direction.)
+  for (const [i, dp] of (response.dataPoints ?? []).entries()) {
     const point = dp as DataPoint;
     const fieldKey = Object.keys(point).find((k) => k !== 'name' && k !== 'dataSource');
     if (!fieldKey) continue;
     const fo = point[fieldKey] as any;
     const interval = fo?.interval;
-    if (!interval?.startTime || !interval?.endTime) continue;
 
-    // Local end date.
+    // Local end date — derived BEFORE the missing-startTime/endTime guard below, so
+    // that guard's warning can carry a date when one IS derivable (e.g. startTime
+    // missing but civilEndTime present). An undated warning survives EVERY pull
+    // window (conservative keep), so dating it whenever possible keeps an
+    // out-of-window malformed session from polluting unrelated artifacts.
     let date: string | undefined;
     const civil = interval?.civilEndTime?.date as
       | { year: number; month: number; day: number }
       | undefined;
     if (civil) {
       date = toISODate(civil.year, civil.month, civil.day);
-    } else if (interval.endUtcOffset) {
+    } else if (interval?.endTime && interval?.endUtcOffset) {
       date = computeLocalDate(interval.endTime as string, interval.endUtcOffset as string);
-    } else {
+      // A present-but-garbage endTime yields a "NaN-NaN-NaN" date here — treat it
+      // as underivable so no warning ever embeds a garbage date (the unparseable
+      // guard below then uses its undated variant).
+      if (!isValidISODate(date)) date = undefined;
+    }
+
+    if (!interval?.startTime || !interval?.endTime) {
+      // A missing interval entirely, or an interval missing startTime/endTime — no
+      // duration computable, so drop the session (no row) and warn (the fifth
+      // silent-drop path of this class; HIMMEL-794 Fix D), dated when derivable.
+      warn(
+        date !== undefined
+          ? `sleep dataPoint ${i} (${date}): missing interval startTime/endTime - session dropped`
+          : `sleep dataPoint ${i}: missing interval startTime/endTime - session dropped`,
+        date,
+      );
       continue;
     }
 
     const startMs = Date.parse(interval.startTime as string);
     const endMs = Date.parse(interval.endTime as string);
-    if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) continue;
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) {
+      // Unparseable interval — cannot compute a duration, so drop the session.
+      // Checked before the no-date guard below: a garbage endTime alongside a
+      // present endUtcOffset lands here (undated via the NaN-date guard above),
+      // not in the no-civilEndTime/no-endUtcOffset text, which would be wrong.
+      warn(
+        date !== undefined
+          ? `sleep dataPoint ${i} (${date}): unparseable interval start/end - session dropped`
+          : `sleep dataPoint ${i}: unparseable interval start/end - session dropped`,
+        date,
+      );
+      continue;
+    }
+
+    if (date === undefined) {
+      // No way to derive a local end date (endTime parsed fine above, so this
+      // genuinely means neither civilEndTime nor endUtcOffset was present) — drop
+      // the session (no row), but record it so the loss is visible on the review
+      // artifact, not just stderr.
+      warn(`sleep dataPoint ${i} ending ${interval.endTime}: no civilEndTime and no endUtcOffset - session dropped`);
+      continue;
+    }
 
     const platform =
       ((point.dataSource as any)?.platform as string | undefined) ?? 'unknown';
 
-    const stages: SleepStage[] = Array.isArray(fo?.stages) ? fo.stages : [];
+    const rawStages = fo?.stages;
+    // A present-but-non-array `stages` is malformed — coerce to stage-less ([]
+    // below: sleep_in_bed_hours still emits, sleep_hours naturally does not).
+    // Recorded as stagesMalformed rather than warned here: the warning fires only
+    // for the MAIN session for this date, decided after main-session selection
+    // below (Fix B / HIMMEL-794 codex-adv-2) — a malformed shorter/nap session
+    // that loses selection contributes no rows, so nothing needs correcting. An
+    // absent `stages` field is the normal classic stage-less case: no warning.
+    const stagesMalformed = rawStages !== undefined && !Array.isArray(rawStages);
+    const stages: SleepStage[] = Array.isArray(rawStages) ? rawStages : [];
 
-    sessions.push({ date, durationMs: endMs - startMs, stages, platform });
+    sessions.push({ date, durationMs: endMs - startMs, stages, platform, stagesMalformed });
   }
 
   // Pick the main (longest) session per date.
@@ -336,13 +441,16 @@ export function deriveSleep(response: { dataPoints?: unknown[] }): ExtractedRow[
     validateRow(rowInBed);
     rows.push(rowInBed);
 
-    if (degraded) {
+    if (main.stagesMalformed) {
+      // Non-array `stages` field on the MAIN session for this date (Fix B /
+      // HIMMEL-794 codex-adv-2) — main.stages is [] so `degraded`/`sleepHours` above
+      // are trivially false/0; warn here instead, scoped to the winning session.
+      warn(`sleep ${date}: non-array "stages" field - treated as stage-less (sleep_hours unavailable)`, date);
+    } else if (degraded) {
       // Malformed non-AWAKE stage timestamps: the remaining valid stages would
       // under-count sleep, so omit the sleep_hours row rather than emit a misleading
       // figure. sleep_in_bed_hours above is unaffected (derived from the interval).
-      console.error(
-        `[google-health] sleep ${date}: malformed stage timestamps - sleep_hours omitted (degraded stage data)`,
-      );
+      warn(`sleep ${date}: malformed stage timestamps - sleep_hours omitted (degraded stage data)`, date);
     } else if (sleepHours > 0) {
       // Stage-less sessions (classic-era Fitbit) yield sleepHours === 0 — skip rather
       // than emit a misleading 0-hours-asleep row.
@@ -352,5 +460,5 @@ export function deriveSleep(response: { dataPoints?: unknown[] }): ExtractedRow[
     }
   }
 
-  return rows;
+  return { rows, warnings };
 }

--- a/scripts/luna-vitals/src/types.ts
+++ b/scripts/luna-vitals/src/types.ts
@@ -10,7 +10,12 @@ export type Conflict = {
   values: Candidate[];
   chosen: Candidate;
 };
-export type ReviewArtifact = { bucket: string; rows: ExtractedRow[]; conflicts: Conflict[] };
+// Optional operator-facing degradation/degradation-adjacent signals (HIMMEL-794).
+// Absent on a clean pull (byte-identical artifacts to pre-794); present only when
+// deriveSleep recorded a warning (degraded stage data, dropped session, non-array
+// stages). Preserved (and deduped across inputs) by the `merge` CLI command in
+// cli.ts — mergeRows itself never touches warnings. writeSeries ignores it.
+export type ReviewArtifact = { bucket: string; rows: ExtractedRow[]; conflicts: Conflict[]; warnings?: string[] };
 
 const ISO = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -53,9 +58,31 @@ export function validateConflict(c: Conflict): void {
   }
 }
 
+/**
+ * Validate an optional `warnings` field on a ReviewArtifact: when present it must
+ * be a non-empty array of non-empty strings — the documented contract is "absent
+ * when empty, never []", so a present-but-empty array is rejected too. Returns an
+ * error message when the value is malformed, or undefined when valid — absent
+ * (undefined) counts as valid, so artifacts written before HIMMEL-794 (no warnings
+ * field) keep loading unchanged. Shared by writeArtifact (outgoing) and
+ * readArtifact (incoming, which prefixes the path), so both gates reject a
+ * malformed warnings shape identically.
+ */
+function warningsError(warnings: unknown): string | undefined {
+  if (warnings === undefined) return undefined;
+  if (!Array.isArray(warnings)) return `artifact "warnings" must be an array of non-empty strings: ${JSON.stringify(warnings)}`;
+  if (warnings.length === 0) return `artifact "warnings" must be absent when empty (never [])`;
+  for (const w of warnings) {
+    if (typeof w !== "string" || !w) return `artifact "warnings" must be an array of non-empty strings: ${JSON.stringify(warnings)}`;
+  }
+  return undefined;
+}
+
 export async function writeArtifact(path: string, a: ReviewArtifact): Promise<void> {
   a.rows.forEach(validateRow);
   a.conflicts.forEach(validateConflict);
+  const werr = warningsError(a.warnings);
+  if (werr) throw new Error(werr);
   await Bun.write(path, JSON.stringify(a, null, 2));
 }
 
@@ -72,5 +99,7 @@ export async function readArtifact(path: string): Promise<ReviewArtifact> {
   if (!Array.isArray(a.rows) || !Array.isArray(a.conflicts)) throw new Error(`malformed artifact at ${path}: "rows" and "conflicts" must be arrays`);
   a.rows.forEach(validateRow);
   a.conflicts.forEach(validateConflict);
+  const werr = warningsError(a.warnings);
+  if (werr) throw new Error(`malformed artifact at ${path}: ${werr}`);
   return a;
 }

--- a/scripts/luna-vitals/tests/cli.test.ts
+++ b/scripts/luna-vitals/tests/cli.test.ts
@@ -38,6 +38,27 @@ test("parse --note-date anchors inline fields, then merge --det/--llm keeps dete
   // deterministic value (3) wins; no conflict raised across the det/llm boundary
   expect(m.rows).toContainEqual({ metric: "migraine", date: "2024-06-14", value: 3, source: join(FX, "daily-2024-06-14.md") });
   expect(m.conflicts).toEqual([]);
+  // clean merge (no input carried warnings) → warnings key ABSENT (byte-identical to pre-HIMMEL-794)
+  expect(m.warnings).toBeUndefined();
+});
+
+test("merge preserves warnings from inputs (deduped) when an input carries them", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "luna-vitals-cli-warnings-"));
+  const a = join(dir, "a.json");
+  const b = join(dir, "b.json");
+  const merged = join(dir, "merged.json");
+  const w1 = "sleep 2026-01-02: malformed stage timestamps - sleep_hours omitted (degraded stage data)";
+  const w2 = "sleep 2026-01-03: malformed stage timestamps - sleep_hours omitted (degraded stage data)";
+  await Bun.write(a, JSON.stringify({ bucket: "a", conflicts: [], rows: [{ metric: "migraine", date: "2024-06-14", value: 3, source: "a.md" }], warnings: [w1, w2] }));
+  // b re-mentions w1 (a duplicate across inputs) and brings its own row.
+  await Bun.write(b, JSON.stringify({ bucket: "b", conflicts: [], rows: [{ metric: "migraine", date: "2024-06-15", value: 1, source: "b.md" }], warnings: [w1] }));
+  const p = Bun.spawn(["bun", "run", "cli.ts", "merge", a, b, "--out", merged], { cwd: ROOT, stderr: "pipe" });
+  expect(await p.exited).toBe(0);
+  const m = await readJson(merged);
+  // deduped (w1 appears once despite being in both inputs), input order preserved
+  expect(m.warnings).toEqual([w1, w2]);
+  expect(m.rows).toContainEqual({ metric: "migraine", date: "2024-06-14", value: 3, source: "a.md" });
+  expect(m.rows).toContainEqual({ metric: "migraine", date: "2024-06-15", value: 1, source: "b.md" });
 });
 
 test("merge warns on stderr (naming the file) for a positional arg that is not a .json artifact", async () => {
@@ -51,6 +72,73 @@ test("merge warns on stderr (naming the file) for a positional arg that is not a
   expect(err).toContain("notes.md");
   // the ignored positional must not corrupt the real merge — det.json's row survives
   expect((await readJson(merged)).rows).toContainEqual({ metric: "migraine", date: "2024-06-14", value: 3, source: "s" });
+});
+
+test("merge of a single warnings-only artifact (rows: []) exits 0 and carries the warnings through (CR round 3)", async () => {
+  // A valid degraded pull can produce ZERO rows but non-empty warnings (every sleep
+  // session dropped) — the no-input guard must key on artifacts READ, not row counts.
+  const dir = mkdtempSync(join(tmpdir(), "luna-vitals-cli-warnonly-"));
+  const a = join(dir, "a.json");
+  const merged = join(dir, "merged.json");
+  const w = "sleep dataPoint 0: missing interval startTime/endTime - session dropped";
+  await Bun.write(a, JSON.stringify({ bucket: "2026-01-01..2026-01-31", conflicts: [], rows: [], warnings: [w] }));
+  const p = Bun.spawn(["bun", "run", "cli.ts", "merge", a, "--out", merged], { cwd: ROOT, stderr: "pipe" });
+  expect(await p.exited).toBe(0);
+  const m = await readJson(merged);
+  expect(m.rows).toEqual([]);
+  expect(m.warnings).toEqual([w]);
+});
+
+test("merge keeps two distinct dropped-session warnings (indexed texts never collapse under Set dedup) (CR round 4)", async () => {
+  // Two dropped sessions used to share the identical static missing-interval text,
+  // so merge's exact-text dedup collapsed N events into 1. The dataPoint index in
+  // the text keeps them distinct through merge.
+  const dir = mkdtempSync(join(tmpdir(), "luna-vitals-cli-idx-warn-"));
+  const a = join(dir, "a.json");
+  const merged = join(dir, "merged.json");
+  const w0 = "sleep dataPoint 0: missing interval startTime/endTime - session dropped";
+  const w1 = "sleep dataPoint 1: missing interval startTime/endTime - session dropped";
+  await Bun.write(a, JSON.stringify({ bucket: "2026-01-01..2026-01-31", conflicts: [], rows: [], warnings: [w0, w1] }));
+  const p = Bun.spawn(["bun", "run", "cli.ts", "merge", a, "--out", merged], { cwd: ROOT, stderr: "pipe" });
+  expect(await p.exited).toBe(0);
+  expect((await readJson(merged)).warnings).toEqual([w0, w1]);
+});
+
+test("merge of a single rows-empty, warnings-free artifact exits 1 (total extraction failure stays fail-fast) (CR round 5)", async () => {
+  // The warnings-only relaxation must not mask a total extraction failure: an
+  // artifact with zero rows AND zero warnings has nothing to merge — error out.
+  const dir = mkdtempSync(join(tmpdir(), "luna-vitals-cli-empty-"));
+  const a = join(dir, "a.json");
+  await Bun.write(a, JSON.stringify({ bucket: "2026-01-01..2026-01-31", conflicts: [], rows: [] }));
+  const p = Bun.spawn(["bun", "run", "cli.ts", "merge", a, "--out", join(dir, "merged.json")], { cwd: ROOT, stderr: "pipe" });
+  const err = await new Response(p.stderr).text();
+  expect(await p.exited).toBe(1);
+  expect(err).toContain("no input artifacts found");
+});
+
+test("merge with NO artifact inputs at all still exits 1 with the usage message", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "luna-vitals-cli-noinput-"));
+  const p = Bun.spawn(["bun", "run", "cli.ts", "merge", "--out", join(dir, "merged.json")], { cwd: ROOT, stderr: "pipe" });
+  const err = await new Response(p.stderr).text();
+  expect(await p.exited).toBe(1);
+  expect(err).toContain("no input artifacts found");
+});
+
+test("write on an artifact carrying warnings: exit 0, series written, warnings surfaced on stderr and harmlessly ignored (HIMMEL-794 Fix E)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "luna-vitals-cli-write-warnings-"));
+  const artifact = join(dir, "a.json");
+  const w = "sleep 2026-01-02: malformed stage timestamps - sleep_hours omitted (degraded stage data)";
+  await Bun.write(artifact, JSON.stringify({
+    bucket: "2026-01-02..2026-01-02",
+    conflicts: [],
+    rows: [{ metric: "sleep_in_bed_hours", date: "2026-01-02", value: 8.0, source: "google-health:sleep:HEALTH_CONNECT" }],
+    warnings: [w],
+  }));
+  const p = Bun.spawn(["bun", "run", "cli.ts", "write", artifact, "--dir", dir], { cwd: ROOT, stderr: "pipe" });
+  const err = await new Response(p.stderr).text();
+  expect(await p.exited).toBe(0);
+  expect(err).toContain(`[luna-vitals] artifact warning: ${w}`);
+  expect(await Bun.file(join(dir, "sleep_in_bed_hours.csv")).text()).toContain("2026-01-02,8");
 });
 
 test("CLI exits non-zero (not 0) when the parse input file is missing", async () => {

--- a/scripts/luna-vitals/tests/types.test.ts
+++ b/scripts/luna-vitals/tests/types.test.ts
@@ -80,3 +80,58 @@ test("readArtifact rejects a conflict missing the chosen field", async () => {
   await Bun.write(p, JSON.stringify({ bucket: "x", rows: [], conflicts: [{ metric: "migraine", date: "2024-06-14", values: [{ value: 2, source: "a" }, { value: 3, source: "b" }] }] }));
   await expect(readArtifact(p)).rejects.toThrow(/chosen/);
 });
+
+test("writeArtifact/readArtifact round-trips an artifact that carries warnings", async () => {
+  const a: ReviewArtifact = {
+    bucket: "x",
+    rows: [{ metric: "sleep_in_bed_hours", date: "2026-01-02", value: 8.0, source: "google-health:sleep:HEALTH_CONNECT" }],
+    conflicts: [],
+    warnings: ["sleep 2026-01-02: malformed stage timestamps - sleep_hours omitted (degraded stage data)"],
+  };
+  const p = join(tmpdir(), "luna-vitals-warnings-roundtrip.json");
+  await writeArtifact(p, a);
+  expect(await readArtifact(p)).toEqual(a);
+});
+
+test("readArtifact accepts an artifact with NO warnings field (pre-HIMMEL-794 artifact)", async () => {
+  const p = join(tmpdir(), "luna-vitals-no-warnings-field.json");
+  await Bun.write(p, JSON.stringify({ bucket: "x", conflicts: [], rows: [] }));
+  const a = await readArtifact(p);
+  expect(a.warnings).toBeUndefined();
+});
+
+test("readArtifact rejects a non-array warnings field", async () => {
+  const p = join(tmpdir(), "luna-vitals-warnings-nonarray.json");
+  await Bun.write(p, JSON.stringify({ bucket: "x", conflicts: [], rows: [], warnings: "x" }));
+  await expect(readArtifact(p)).rejects.toThrow(/malformed artifact at.*"warnings"/);
+});
+
+test("readArtifact rejects a warnings entry that is not a non-empty string", async () => {
+  const p = join(tmpdir(), "luna-vitals-warnings-nonstring.json");
+  await Bun.write(p, JSON.stringify({ bucket: "x", conflicts: [], rows: [], warnings: [1] }));
+  await expect(readArtifact(p)).rejects.toThrow(/malformed artifact at.*"warnings"/);
+});
+
+test("writeArtifact rejects a non-array warnings field", async () => {
+  const a = { bucket: "x", conflicts: [], rows: [], warnings: "x" } as unknown as ReviewArtifact;
+  await expect(writeArtifact(join(tmpdir(), "luna-vitals-warnings-write-reject.json"), a)).rejects.toThrow(/"warnings"/);
+});
+
+test("readArtifact rejects a warnings entry that is an empty string", async () => {
+  // The `!w` branch of warningsError (as opposed to the `typeof w !== "string"` branch)
+  // — untested before, so a regression dropping it would still pass every other test.
+  const p = join(tmpdir(), "luna-vitals-warnings-emptystring.json");
+  await Bun.write(p, JSON.stringify({ bucket: "x", conflicts: [], rows: [], warnings: [""] }));
+  await expect(readArtifact(p)).rejects.toThrow(/malformed artifact at.*"warnings"/);
+});
+
+test("readArtifact rejects a present-but-empty warnings array (never [])", async () => {
+  const p = join(tmpdir(), "luna-vitals-warnings-empty-array.json");
+  await Bun.write(p, JSON.stringify({ bucket: "x", conflicts: [], rows: [], warnings: [] }));
+  await expect(readArtifact(p)).rejects.toThrow(/absent when empty/);
+});
+
+test("writeArtifact rejects a present-but-empty warnings array (never [])", async () => {
+  const a = { bucket: "x", conflicts: [], rows: [], warnings: [] } as unknown as ReviewArtifact;
+  await expect(writeArtifact(join(tmpdir(), "luna-vitals-warnings-write-empty-reject.json"), a)).rejects.toThrow(/absent when empty/);
+});


### PR DESCRIPTION
## Summary
Follow-up to HIMMEL-793 (public #300). The degraded-sleep warning was stderr-only; this PR makes the signal durable in the review artifact and closes the adjacent silent session-skip paths.

- `ReviewArtifact` gains optional `warnings?: string[]` — absent on a clean pull (byte-identical artifacts to pre-794), validated on both `writeArtifact`/`readArtifact` when present (non-empty array of non-empty strings; present-but-`[]` rejected), tolerated when absent (pre-794 artifacts load unchanged).
- `deriveSleep` returns `{ rows, warnings }` with **five** warning paths (all row-emission behavior unchanged): missing interval `startTime`/`endTime` (dated when derivable); no `civilEndTime` + no `endUtcOffset`; unparseable interval; degraded main-session stages (HIMMEL-793 path); non-array `stages` on the **main** session only. Session-scoped texts embed the dataPoint index so distinct events never share a text.
- `pull` window-scopes dated warnings to `[from, to]` (matching the rows filter); undateable warnings are kept conservatively. Internal shape is structured (`SleepWarning = { date?, text }`); the artifact schema stays a lightweight `string[]`.
- `merge` preserves warnings across inputs (text-level dedup) and accepts warnings-only (rows-empty) artifacts; inputs with zero rows AND zero warnings still fail fast.
- `write` echoes artifact warnings to stderr (advisory, never blocks) before `writeSeries`.
- SCHEMA.md rewritten: durable-warnings contract, per-path texts, window scoping, known limitations.

## Test plan
- Tests: 168 pass / 0 fail in `scripts/luna-vitals` (baseline 140)
- CR: free+paid critic panel clean ×5; codex adversarial passes drove 4 fix rounds; full 5-agent pr-review-toolkit matrix ran twice (base + final HEAD), every Critical/Important finding fixed in-branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
