### PR TITLE
fix(luna-vitals): [HIMMEL-801] warn on dataPoint with no typed payload field

### DIFF
--- a/scripts/luna-vitals/connectors/map/derive.test.ts
+++ b/scripts/luna-vitals/connectors/map/derive.test.ts
@@ -257,11 +257,51 @@ describe('deriveRestingHeartRate', () => {
     expect(rows.some((r) => r.date === '2026-06-27')).toBe(true);
     expect(rows.some((r) => r.date === '2026-06-28')).toBe(true);
   });
+
+  test('dataPoint with no typed payload field → skipped WITH a stderr warning (HIMMEL-801)', () => {
+    // A malformed point carrying only name/dataSource (no beatsPerMinute payload
+    // field) is dropped — but no longer silently: a [google-health] stderr line fires.
+    const errSpy = spyOn(console, 'error');
+    try {
+      const rows = deriveRestingHeartRate({
+        dataPoints: [{ name: 'heartRate', dataSource: { platform: 'HEALTH_CONNECT' } }],
+      });
+      expect(rows).toEqual([]);
+      expect(errSpy).toHaveBeenCalledWith(
+        '[google-health] heart-rate dataPoint 0: no typed payload field - skipped',
+      );
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
 });
 
 // ── deriveSleep ───────────────────────────────────────────────────────────────
 
 describe('deriveSleep', () => {
+  test('dataPoint with no typed payload field → skipped WITH a warning (returned + stderr) (HIMMEL-801)', () => {
+    // A malformed point with only name/dataSource (no typed sleep payload) is
+    // dropped — now through the same warn() channel as the other parse-loop drops:
+    // a durable, undated SleepWarning (index-embedded so it never dedup-collides)
+    // plus the [google-health] stderr line.
+    const errSpy = spyOn(console, 'error');
+    try {
+      const { rows, warnings } = deriveSleep({
+        dataPoints: [{ name: 'sleep', dataSource: { platform: 'HEALTH_CONNECT' } }],
+      });
+      expect(rows).toEqual([]);
+      expect(warnings).toContainEqual({
+        date: undefined,
+        text: 'sleep dataPoint 0: no typed payload field - skipped',
+      });
+      expect(errSpy).toHaveBeenCalledWith(
+        '[google-health] sleep dataPoint 0: no typed payload field - skipped',
+      );
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
   test('2026-06-28: main session 8h31m (sleep_in_bed_hours=8.5); nap excluded from main value', async () => {
     // Fixture: session 1 (01:24Z–09:55Z = 511 min = main) + session 2 nap (14:00Z–14:40Z = 40 min).
     // Both end on 2026-06-28 local (UTC+2). Main = session 1 (511 > 40).

--- a/scripts/luna-vitals/connectors/map/derive.ts
+++ b/scripts/luna-vitals/connectors/map/derive.ts
@@ -171,10 +171,17 @@ type DataPoint = Record<string, unknown>;
 export function deriveRestingHeartRate(response: { dataPoints?: unknown[] }): ExtractedRow[] {
   const byDate = new Map<string, { bpms: number[]; platform: string }>();
 
-  for (const dp of response.dataPoints ?? []) {
+  for (const [i, dp] of (response.dataPoints ?? []).entries()) {
     const point = dp as DataPoint;
     const fieldKey = Object.keys(point).find((k) => k !== 'name' && k !== 'dataSource');
-    if (!fieldKey) continue;
+    if (!fieldKey) {
+      // A malformed point with no typed payload field is dropped — but not
+      // silently (HIMMEL-801): emit the [google-health] stderr signal that the
+      // rest of this connector uses. deriveRestingHeartRate returns a bare
+      // ExtractedRow[] with no warnings channel, so stderr is the signal here.
+      console.error(`[google-health] heart-rate dataPoint ${i}: no typed payload field - skipped`);
+      continue;
+    }
     const fo = point[fieldKey] as any;
 
     const civilDate = fo?.sampleTime?.civilTime?.date as
@@ -273,7 +280,7 @@ export type SleepWarning = { date?: string; text: string };
  *   ALSO printed to stderr as `[google-health] <text>` — the stderr behavior
  *   predates HIMMEL-794 and is unchanged; the returned copy is additive so `pull`
  *   can record it durably on the review artifact (window-scoped there, see
- *   google-health.ts). Five warning-producing paths, all with row emission
+ *   google-health.ts). Six warning-producing paths, all with row emission
  *   unchanged: (1) a session dropped because its interval is missing
  *   startTime/endTime entirely (`sleep dataPoint <i> (<date>): missing interval …`,
  *   dated when an end date is still derivable from civilEndTime or
@@ -290,9 +297,11 @@ export type SleepWarning = { date?: string; text: string };
  *   Paths 1-3 (session-scoped) embed the dataPoint index in the text so distinct
  *   events never share a text — the merge CLI dedups warnings by exact text, so
  *   identical text must mean the same event (over-reporting across re-pulls with
- *   different windows is the accepted safe direction). A dataPoint with no typed
- *   payload field at all (the fieldKey lookup fails) is still skipped WITHOUT a
- *   warning — deliberate scope-out, tracked in HIMMEL-801.
+ *   different windows is the accepted safe direction). (6) a dataPoint with no
+ *   typed payload field at all (the fieldKey lookup fails) is skipped WITH an
+ *   undated, index-embedded warning (`sleep dataPoint <i>: no typed payload
+ *   field - skipped`) — HIMMEL-801; the sibling deriveRestingHeartRate emits the
+ *   same drop as a stderr-only [google-health] line (it has no warnings channel).
  *
  * Source: 'google-health:sleep:<platform>'.
  * Each emitted row passes validateRow before being returned.
@@ -317,7 +326,14 @@ export function deriveSleep(response: { dataPoints?: unknown[] }): { rows: Extra
   for (const [i, dp] of (response.dataPoints ?? []).entries()) {
     const point = dp as DataPoint;
     const fieldKey = Object.keys(point).find((k) => k !== 'name' && k !== 'dataSource');
-    if (!fieldKey) continue;
+    if (!fieldKey) {
+      // A malformed point with no typed sleep payload is dropped through the
+      // same warn() channel as the other parse-loop drops (HIMMEL-801): a
+      // durable, undated SleepWarning (index-embedded so distinct drops never
+      // dedup-collide) plus the stderr line. No date is derivable here.
+      warn(`sleep dataPoint ${i}: no typed payload field - skipped`);
+      continue;
+    }
     const fo = point[fieldKey] as any;
     const interval = fo?.interval;
 


### PR DESCRIPTION
## Summary
`deriveSleep` and `deriveRestingHeartRate` (`scripts/luna-vitals/connectors/map/derive.ts`) silently `continue`d — dropping a dataPoint — when its `fieldKey` lookup failed (a malformed point carrying only `name`/`dataSource`, no typed payload). The point vanished with no stderr line and no artifact warning (documented scope-out from HIMMEL-794).

- **`deriveSleep`** — the `!fieldKey` skip now routes through the existing `warn()` helper: a durable, undated, index-embedded `SleepWarning` plus the `[google-health]` stderr line (sixth `warn()`-producing parse-loop path, consistent with the other five; index-embedding keeps the merge CLI's exact-text dedup from collapsing distinct drops).
- **`deriveRestingHeartRate`** — returns a bare `ExtractedRow[]` with no warnings channel, so the skip emits a stderr-only `[google-health]` line (loop switched to `.entries()` for the index). A durable channel would ripple a new return shape through `google-health.ts` + the artifact schema — deliberately out of scope.
- Docstring updated (Five → Six warning paths).

## Test plan
- Two new `derive.test.ts` tests assert row-dropped + warning-emitted for both functions (exact stderr via `toHaveBeenCalledWith`, plus the returned `SleepWarning` for sleep)
- Full luna-vitals suite: 170 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
