### PR TITLE
feat(graphify): [HIMMEL-907] check-graph-freshness guard

### DIFF
--- a/scripts/graphify/check-graph-freshness.sh
+++ b/scripts/graphify/check-graph-freshness.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# check-graph-freshness.sh — freshness + corpus-orphan CHECK for one graphify-out
+# snapshot (HIMMEL-621/824/825 family). The check companion to
+# refresh-graph-map.sh (HIMMEL-825): the refresher REBUILDS the graph; this tells
+# a caller (scheduler / operator / query path) whether an existing graphify-out/
+# is still trustworthy to query, or has gone stale / orphaned.
+#
+# WHY: graphify graphs are point-in-time snapshots under <repo>/graphify-out/.
+# They drift silently as the corpus changes, and a graphify-out can be left
+# pointing at a corpus that no longer exists (orphaned) — queries against a
+# stale/orphaned graph return confidently-wrong structure. This guard fails loud
+# before that happens.
+#
+# WHAT IT CHECKS (exit code):
+#   rc=2 FAIL — out dir missing; manifest.json missing/unparseable/empty;
+#               --corpus-root given but the dir does not exist;
+#               corpus orphaned (no --corpus-root AND no .graphify_root marker,
+#               OR no file named in manifest.json resolves under the corpus root).
+#   rc=1 WARN — graph.json (or manifest.json if graph.json is absent) mtime is
+#               older than --max-age-days.
+#   rc=0 OK   — fresh AND corpus verified; prints exactly one line:
+#               "graph-freshness: OK (<age-days>d old, corpus verified)"
+#
+# CORPUS RESOLUTION (orphan detection):
+#   --corpus-root given → that dir is the corpus root (must exist); the orphan
+#     check is skipped (the operator asserted the corpus).
+#   no --corpus-root → the .graphify_root marker file in the out dir is read; its
+#     first non-blank line is the corpus-root path (absolute, or relative to the
+#     out dir's parent). Marker absent OR empty → orphan (rc=2). With the root
+#     resolved, at least one file NAMED in manifest.json must exist under it;
+#     none found → orphan (rc=2).
+#
+# Usage:
+#   check-graph-freshness.sh --out <graphify-out dir> [--max-age-days N] [--corpus-root <path>]
+#
+# Exit: 0 ok; 1 stale (warn) / usage; 2 fail (missing/orphaned/unparseable).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REFRESH="$HERE/refresh-graph-map.sh"
+
+OUT="" MAX_AGE_DAYS=7 CORPUS_ROOT=""
+usage() { echo "usage: check-graph-freshness.sh --out <graphify-out dir> [--max-age-days N] [--corpus-root <path>]" >&2; exit 1; }
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --out) OUT="${2:-}"; shift 2 ;;
+    --max-age-days) MAX_AGE_DAYS="${2:-}"; shift 2 ;;
+    --corpus-root) CORPUS_ROOT="${2:-}"; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "check-graph-freshness: unknown flag: $1" >&2; usage ;;
+  esac
+done
+[ -n "$OUT" ] || usage
+case "$MAX_AGE_DAYS" in
+  ''|*[!0-9]*) echo "check-graph-freshness: --max-age-days must be a non-negative integer, got: $MAX_AGE_DAYS" >&2; exit 1 ;;
+esac
+
+# Remediation embedded in every non-OK message: the refresh invocation shape
+# (mirrors refresh-graph-map.sh's own usage).
+REMEDIATION="Rebuild with: bash $REFRESH --name <N> --corpus-root <path> --backend deepseek --maps-dir <vault>/60-Maps --title \"<Title>\" --slug <slug>"
+
+# python3 is required (manifest.json parse + cross-platform mtime). `stat -c %Y`
+# is GNU-only and `stat -f %m` is BSD-only, so mtime goes through python3.
+command -v python3 >/dev/null 2>&1 || {
+  echo "graph-freshness: FAIL python3 not found (needed to parse manifest.json + read mtime)." >&2
+  echo "  $REMEDIATION" >&2; exit 2
+}
+
+# FAIL: print a one-line reason + the remediation, exit 2.
+fail() {
+  echo "graph-freshness: FAIL $1" >&2
+  echo "  $REMEDIATION" >&2
+  exit 2
+}
+
+# --- 1. out dir ---
+[ -d "$OUT" ] || fail "out dir not found: $OUT"
+
+# --- 2. manifest.json present + parseable (flat object of filename -> {...}) ---
+MANIFEST="$OUT/manifest.json"
+[ -f "$MANIFEST" ] || fail "manifest.json missing at $MANIFEST."
+# Emit one manifest key per line; exit non-zero on unparseable / non-object / empty.
+if ! KEYS="$(python3 - "$MANIFEST" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    d = json.load(fh)
+if not isinstance(d, dict) or not d:
+    sys.exit(1)
+for k in d:
+    print(k)
+PYEOF
+)"; then
+  fail "manifest.json at $MANIFEST is not a non-empty JSON object (unparseable/empty)."
+fi
+
+# --- 3. corpus resolution + orphan check ---
+if [ -n "$CORPUS_ROOT" ]; then
+  # operator asserted the corpus root; only require it to exist.
+  [ -d "$CORPUS_ROOT" ] || fail "--corpus-root not found: $CORPUS_ROOT."
+  CORPUS_RESOLVED="$CORPUS_ROOT"
+else
+  MARKER="$OUT/.graphify_root"
+  [ -f "$MARKER" ] || fail "corpus orphaned: no --corpus-root given and no .graphify_root marker in $OUT (cannot locate the corpus this graph was built from)."
+  # first non-blank line of the marker = corpus-root path
+  MARKER_ROOT="$(grep -m1 -v '^[[:space:]]*$' "$MARKER" 2>/dev/null || true)"
+  [ -n "$MARKER_ROOT" ] || fail "corpus orphaned: .graphify_root marker in $OUT is empty (cannot locate the corpus)."
+  # absolute (POSIX /c/... or drive C:\...) as-is; else relative to the out dir's parent
+  case "$MARKER_ROOT" in
+    /*|[A-Za-z]:*) CORPUS_RESOLVED="$MARKER_ROOT" ;;
+    *)             CORPUS_RESOLVED="$OUT/../$MARKER_ROOT" ;;
+  esac
+  # at least one manifest-named file must exist under the resolved corpus root.
+  # Keys are UNTRUSTED (a corrupt/crafted manifest could carry absolute or
+  # ..-traversal paths that "verify" via files OUTSIDE the root — codex CR):
+  # only plain relative keys may join the path; others are skipped.
+  found=0
+  while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    case "$key" in
+      /*|[A-Za-z]:*|../*|*/../*|*/..|..) continue ;;
+    esac
+    if [ -e "$CORPUS_RESOLVED/$key" ]; then found=1; break; fi
+  done <<< "$KEYS"
+  [ "$found" -eq 1 ] || fail "corpus orphaned: no file named in manifest.json exists under $CORPUS_RESOLVED (graph references a gone/moved corpus)."
+fi
+
+# --- 4. age check (graph.json preferred, else manifest.json mtime) ---
+AGE_FILE="$OUT/graph.json"
+[ -f "$AGE_FILE" ] || AGE_FILE="$MANIFEST"
+# verdict = STALE when real-valued age (days) > max-age-days; floor days for display.
+AGE_OUT="$(python3 -c 'import os,sys,time
+age=(time.time()-os.path.getmtime(sys.argv[1]))/86400.0
+print("STALE" if age > float(sys.argv[2]) else "FRESH", int(age))' "$AGE_FILE" "$MAX_AGE_DAYS")" \
+  || fail "cannot read mtime of $AGE_FILE."
+read -r AGE_VERDICT AGE_DAYS_FLOOR <<< "$AGE_OUT"
+if [ "$AGE_VERDICT" = "STALE" ]; then
+  echo "graph-freshness: WARN $AGE_FILE is ${AGE_DAYS_FLOOR}d old (older than --max-age-days $MAX_AGE_DAYS)." >&2
+  echo "  $REMEDIATION" >&2
+  exit 1
+fi
+
+echo "graph-freshness: OK (${AGE_DAYS_FLOOR}d old, corpus verified)"

--- a/scripts/graphify/refresh-graph-map.sh
+++ b/scripts/graphify/refresh-graph-map.sh
@@ -22,6 +22,11 @@
 #       [--corpus-tag luna] [--scratch <dir>] [--no-update]
 #
 # Exit: 0 ok; 1 usage/IO; 2 fence/graphify failure.
+#
+# Freshness guard: this script REBUILDS the graph. To CHECK whether an existing
+# graphify-out/ is still fresh (and not orphaned from its corpus) before querying
+# it, run check-graph-freshness.sh --out <graphify-out> [--max-age-days N]
+# (companion script, same dir). HIMMEL-621/824/825 family.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/graphify/test-check-graph-freshness.sh
+++ b/scripts/graphify/test-check-graph-freshness.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Hermetic test for check-graph-freshness.sh — temp dirs only, never touches a
+# real graphify-out. Run: bash scripts/graphify/test-check-graph-freshness.sh
+# shellcheck disable=SC2015  # A && pass || fail is the intentional test-assert idiom (pass/fail echo, always rc 0)
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/check-graph-freshness.sh"
+FAILS=0
+pass() { echo "  ok: $1"; }
+fail() { echo "  FAIL: $1"; FAILS=$((FAILS+1)); }
+
+WS="$(mktemp -d)"; trap 'rm -rf "$WS"' EXIT
+
+# Build a graphify-out fixture: manifest (flat + nested key) + graph.json + a
+# corpus holding both named files. Does NOT write the .graphify_root marker.
+build_out() {  # $1=out dir, $2=corpus dir
+  mkdir -p "$1" "$2/notes"
+  printf '{"real.md": {"mtime": 0, "ast_hash": "x"}, "notes/sub.md": {"mtime": 0}}\n' > "$1/manifest.json"
+  printf '{"nodes":[],"edges":[]}\n' > "$1/graph.json"
+  printf '# real\n' > "$2/real.md"
+  printf '# sub\n' > "$2/notes/sub.md"
+}
+
+# Backdate a file's mtime by N days (portable os.utime; touch -d is GNU-only).
+backdate_days() {  # $1=file, $2=days ago
+  python3 -c 'import os,sys,time
+f=sys.argv[1]; d=float(sys.argv[2])*86400; now=time.time(); os.utime(f,(now-d,now-d))' "$1" "$2"
+}
+
+# --- T1: ok fresh (marker points at a corpus holding a manifest-named file) ---
+OUT="$WS/t1/graphify-out"; CORPUS="$WS/t1/corpus"; build_out "$OUT" "$CORPUS"
+printf '%s\n' "$CORPUS" > "$OUT/.graphify_root"
+out=$( bash "$SCRIPT" --out "$OUT" --max-age-days 7 2>/dev/null ); rc=$?
+[ "$rc" -eq 0 ] && pass "T1 fresh + verified corpus exits 0" || fail "T1 exit 0 (got $rc): $out"
+printf '%s\n' "$out" | grep -Eq '^graph-freshness: OK \([0-9]+d old, corpus verified\)$' \
+  && pass "T1 OK line shape" || fail "T1 OK line shape: $out"
+
+# --- T2: warn old (graph.json backdated beyond --max-age-days) ---
+OUT="$WS/t2/graphify-out"; CORPUS="$WS/t2/corpus"; build_out "$OUT" "$CORPUS"
+printf '%s\n' "$CORPUS" > "$OUT/.graphify_root"
+backdate_days "$OUT/graph.json" 10
+bash "$SCRIPT" --out "$OUT" --max-age-days 7 >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 1 ] && pass "T2 stale graph -> rc=1 (warn)" || fail "T2 rc=1 (got $rc)"
+
+# --- T2b: under --max-age-days stays OK (comparison not inverted; 3d < 7d) ---
+OUT="$WS/t2b/graphify-out"; CORPUS="$WS/t2b/corpus"; build_out "$OUT" "$CORPUS"
+printf '%s\n' "$CORPUS" > "$OUT/.graphify_root"
+backdate_days "$OUT/graph.json" 3
+out=$( bash "$SCRIPT" --out "$OUT" --max-age-days 7 2>/dev/null ); rc=$?
+[ "$rc" -eq 0 ] && pass "T2b 3d-old graph under --max-age-days 7 -> rc=0" || fail "T2b rc=0 (got $rc): $out"
+
+# --- T3: fail missing manifest ---
+OUT="$WS/t3/graphify-out"; CORPUS="$WS/t3/corpus"; build_out "$OUT" "$CORPUS"
+rm -f "$OUT/manifest.json"
+bash "$SCRIPT" --out "$OUT" >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 2 ] && pass "T3 missing manifest -> rc=2" || fail "T3 rc=2 (got $rc)"
+
+# --- T3b: fail unparseable manifest ---
+OUT="$WS/t3b/graphify-out"; CORPUS="$WS/t3b/corpus"; build_out "$OUT" "$CORPUS"
+printf '{not json' > "$OUT/manifest.json"
+bash "$SCRIPT" --out "$OUT" >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 2 ] && pass "T3b unparseable manifest -> rc=2" || fail "T3b rc=2 (got $rc)"
+
+# --- T4: fail orphaned (no marker AND no --corpus-root) ---
+OUT="$WS/t4/graphify-out"; CORPUS="$WS/t4/corpus"; build_out "$OUT" "$CORPUS"
+# deliberately no .graphify_root, no --corpus-root
+bash "$SCRIPT" --out "$OUT" >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 2 ] && pass "T4 orphaned (no marker, no --corpus-root) -> rc=2" || fail "T4 rc=2 (got $rc)"
+
+# --- T4b: fail orphaned (marker present but no manifest-named file under it) ---
+OUT="$WS/t4b/graphify-out"; CORPUS="$WS/t4b/corpus"; build_out "$OUT" "$CORPUS"
+EMPTYCORPUS="$WS/t4b/empty"; mkdir -p "$EMPTYCORPUS"
+printf '%s\n' "$EMPTYCORPUS" > "$OUT/.graphify_root"
+bash "$SCRIPT" --out "$OUT" >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 2 ] && pass "T4b orphaned (marker -> empty corpus) -> rc=2" || fail "T4b rc=2 (got $rc)"
+
+# --- T4c: traversal/absolute manifest keys must NOT verify the corpus (codex CR) ---
+# Manifest carries only an absolute key and a ..-traversal key, both resolving
+# to REAL files OUTSIDE the (empty) corpus root — the guard must still call it
+# orphaned (rc=2), never "verified" through an escaped path join.
+OUT="$WS/t4c/graphify-out"; CORPUS="$WS/t4c/corpus"; build_out "$OUT" "$CORPUS"
+EMPTYCORPUS="$WS/t4c/empty"; mkdir -p "$EMPTYCORPUS"
+printf '# outside\n' > "$WS/t4c/outside.md"
+printf '{"%s": {"mtime": 0}, "../outside.md": {"mtime": 0}}\n' "$WS/t4c/outside.md" > "$OUT/manifest.json"
+printf '%s\n' "$EMPTYCORPUS" > "$OUT/.graphify_root"
+bash "$SCRIPT" --out "$OUT" >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 2 ] && pass "T4c absolute/traversal manifest keys skipped -> rc=2" || fail "T4c rc=2 (got $rc)"
+
+# --- T5: fail bad --corpus-root (dir does not exist) ---
+OUT="$WS/t5/graphify-out"; CORPUS="$WS/t5/corpus"; build_out "$OUT" "$CORPUS"
+bash "$SCRIPT" --out "$OUT" --corpus-root "$WS/nope" >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 2 ] && pass "T5 missing --corpus-root -> rc=2" || fail "T5 rc=2 (got $rc)"
+
+# --- T6: ok with explicit --corpus-root (no marker needed) ---
+OUT="$WS/t6/graphify-out"; CORPUS="$WS/t6/corpus"; build_out "$OUT" "$CORPUS"
+out=$( bash "$SCRIPT" --out "$OUT" --corpus-root "$CORPUS" --max-age-days 7 2>/dev/null ); rc=$?
+[ "$rc" -eq 0 ] && pass "T6 explicit --corpus-root exits 0 (no marker)" || fail "T6 exit 0 (got $rc): $out"
+
+# --- T7: fail missing out dir ---
+bash "$SCRIPT" --out "$WS/no-such-dir" >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 2 ] && pass "T7 missing out dir -> rc=2" || fail "T7 rc=2 (got $rc)"
+
+# --- T8: usage error on missing --out ---
+bash "$SCRIPT" --max-age-days 7 >/dev/null 2>&1; rc=$?
+[ "$rc" -eq 1 ] && pass "T8 missing --out -> usage rc=1" || fail "T8 usage rc=1 (got $rc)"
+
+if [ "$FAILS" -ne 0 ]; then echo "$FAILS FAILURES"; exit 1; fi
+echo "ALL PASS"


### PR DESCRIPTION
## HIMMEL-907 — graphify freshness/orphan guard

`scripts/graphify/check-graph-freshness.sh` — the CHECK companion to `refresh-graph-map.sh` (which REBUILDS). Graphify graphs are point-in-time snapshots that drift silently, and an out-dir can be orphaned from a gone corpus (the himmel-root `graphify-out/` found 2026-07-11 was exactly this). The guard fails loud before queries trust a stale/orphaned graph.

- rc=2 FAIL: out dir / manifest missing or unparseable; `--corpus-root` missing; corpus orphaned (no `.graphify_root` marker, or no manifest-named file under the resolved root)
- rc=1 WARN: `graph.json` (or manifest fallback) older than `--max-age-days` (default 7)
- rc=0 OK: one-line `graph-freshness: OK (<N>d old, corpus verified)`
- Every non-OK message embeds the exact refresh remediation line.

Built by a GLM worker on `glm/graphify-freshness-guard`; parent-reviewed. CR trail: critic panel ×2 (free+paid) + code-reviewer — one Important found and fixed (manifest keys are untrusted; absolute/`..`-traversal keys are now excluded from the corpus-verify path join, pinned by T4c). 13/13 hermetic tests, shellcheck clean, verified on Windows/Git Bash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
