### PR TITLE
feat(handover): [HIMMEL-901] arm-resume proxy leg

### DIFF
--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -253,6 +253,18 @@ command -v telemetry_emit >/dev/null 2>&1 || telemetry_emit() { return 0; }
 . "$SCRIPT_DIR/../lib/handover-path.sh" 2>/dev/null || true
 command -v handover_root >/dev/null 2>&1 || handover_root() { return 2; }
 
+# HIMMEL_HEADROOM_PROXY flag parser (HIMMEL-901): same fail-open contract as
+# the two libs above — an absent/broken lib just means the .env fallback
+# never activates (the process-env check right below still works either
+# way), never a broken arm. CR round: the failure WARNs once here at source
+# time (not inside the stub, which would repeat) — an operator relying on
+# the .env flag deserves to know the fallback is disabled.
+# shellcheck source=../lib/headroom-proxy.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/headroom-proxy.sh" 2>/dev/null \
+    || echo "WARN arm-resume: headroom-proxy lib failed to load -- .env HIMMEL_HEADROOM_PROXY fallback disabled (process env still honored)" >&2
+command -v _headroom_proxy_env_file_active >/dev/null 2>&1 || _headroom_proxy_env_file_active() { return 1; }
+
 # Canonicalise a path, tolerating non-existent ones: GNU realpath -m, else
 # armored python3 pathlib, else the input unchanged (best effort — matches
 # the prior inline fallback chains).
@@ -266,6 +278,23 @@ _arm_realpath() {
     fi
     [ -n "$_p" ] || _p="$1"
     printf '%s\n' "$_p"
+}
+
+# _cmd_metachar_escape <value> — echo <value> with the same CMD-metachar
+# escaping schedule_arm's Windows .bat generator applies inline to the cd
+# path / prompt / --channels spec below (HIMMEL-901: reused for the headroom
+# proxy binary path so a fourth copy of the same six-substitution block
+# isn't pasted in). % & ^ < > | can inject commands at .bat fire time.
+_cmd_metachar_escape() {
+    local v="$1"
+    v="${v//\"/\\\"}"
+    v="${v//%/%%}"
+    v="${v//^/^^}"
+    v="${v//&/^&}"
+    v="${v//</^<}"
+    v="${v//>/^>}"
+    v="${v//|/^|}"
+    printf '%s' "$v"
 }
 
 # Resolve the requested slot to an absolute epoch (TARGET_EPOCH). Three forms:
@@ -397,6 +426,60 @@ case "${OSTYPE:-$(uname -s 2>/dev/null || echo unknown)}" in
         exit 2
         ;;
 esac
+
+# HIMMEL_HEADROOM_PROXY (HIMMEL-901): route the armed relaunch through the
+# local headroom Anthropic-API proxy (127.0.0.1:8787) when the operator has
+# opted in. Resolved ONCE here, at arm time, and baked into whichever
+# launcher schedule_arm emits below — the fired relaunch never re-reads this
+# flag. Only the exact value "1" activates: the process env at arm time wins
+# outright (HIMMEL_HEADROOM_PROXY set-but-not-"1" is INACTIVE, same as
+# unset); only when the process env carries no signal at all does the
+# himmel repo-root .env get consulted as a fallback. When inactive
+# (the default), every launcher below stays BYTE-IDENTICAL to pre-901
+# output — this block is the only thing that can turn it on.
+# Known minimal-slice limitation (CR round): the .env fallback resolves
+# against the checkout THIS script physically lives in (SCRIPT_DIR/../..),
+# so arming from a worktree does not see the primary checkout's untracked
+# .env — the process env is the worktree-safe path.
+HEADROOM_PROXY_ACTIVE=0
+if [ -n "${HIMMEL_HEADROOM_PROXY+x}" ]; then
+    [ "$HIMMEL_HEADROOM_PROXY" = "1" ] && HEADROOM_PROXY_ACTIVE=1
+elif _headroom_proxy_env_file_active "$(cd "$SCRIPT_DIR/../.." && pwd)"; then
+    HEADROOM_PROXY_ACTIVE=1
+fi
+# Port fixed at 8787 for this slice — no port config (HIMMEL-901 minimal
+# slice; a variable only to avoid repeating the literal across 3 platform
+# launchers). HEADROOM_BIN: operator override wins; else the platform
+# default venv layout. Only resolved when the flag is active, so an
+# inactive arm never even looks at $HOME/.headroom-venv.
+HEADROOM_PROXY_PORT=8787
+# CR round (HIMMEL-901): resolve curl ONCE at arm time and bake the ABSOLUTE
+# path into the launcher — scheduler contexts fire with a minimal PATH (the
+# same reason claude/cygpath are resolved at arm time above), so a bare
+# `curl` in the launcher could miss at fire time, fail both livez checks,
+# and silently send the launch bare even with a healthy proxy. No curl at
+# arm time -> one honest WARN and a plain pre-901 launcher (deactivate)
+# rather than baking a known-broken check.
+HEADROOM_CURL=""
+if [ "$HEADROOM_PROXY_ACTIVE" -eq 1 ]; then
+    if ! HEADROOM_CURL=$(command -v curl 2>/dev/null) || [ -z "$HEADROOM_CURL" ]; then
+        echo "WARN arm-resume: curl not on PATH -- the armed launch will fail-open to bare (proxy livez unverifiable)" >&2
+        HEADROOM_PROXY_ACTIVE=0
+    fi
+fi
+if [ "$HEADROOM_PROXY_ACTIVE" -eq 1 ] && [ -z "${HEADROOM_BIN:-}" ]; then
+    if [ "$PLATFORM" = windows ]; then
+        HEADROOM_BIN="$HOME/.headroom-venv/Scripts/headroom.exe"
+    else
+        HEADROOM_BIN="$HOME/.headroom-venv/bin/headroom"
+    fi
+fi
+# Non-blocking existence probe (CR round): a missing/non-executable headroom
+# binary still arms — fail-open is the design — but the operator hears about
+# it NOW instead of discovering a silently-bare session after the fire.
+if [ "$HEADROOM_PROXY_ACTIVE" -eq 1 ]; then
+    [ -x "$HEADROOM_BIN" ] || echo "WARN arm-resume: HEADROOM_BIN '$HEADROOM_BIN' not found/executable -- fire-time start will fail-open to bare" >&2
+fi
 
 # Tool detection per platform.
 case "$PLATFORM" in
@@ -1771,7 +1854,28 @@ _crontab_schedule() {
     # stays ONE arg through the /bin/sh re-parse at fire time. Empty -> omit.
     [ -n "$SESSION_NAME" ] && q_name="-n $(printf '%q' "$SESSION_NAME") "
     local self_clean="crontab -l 2>/dev/null | grep -vE '# ${TASK_NAME}\$' | crontab -;"
-    local entry="$mm $hh * * * $self_clean cd $q_cwd && claude ${q_name}$q_prompt $q_channels # $TASK_NAME"
+    # HIMMEL_HEADROOM_PROXY (HIMMEL-901): a crontab entry is ONE line, so the
+    # livez-check-then-launch logic (same shape as the `at` branch's
+    # $launch_lines) has to be a single ';'-joined compound wrapped in its
+    # own `{ ; }` group — `cd ... && { ...; }` keeps `cd` a hard gate (plain
+    # `&&`/`||` chaining without the group would let a failed cd fall
+    # through into starting the proxy, since `&&`/`||` are left-associative
+    # at equal precedence). Inactive -> $tail is byte-identical to the
+    # pre-901 line (zero behavior change).
+    # CR round: absolute curl path ($q_curl) + one mode-marker echo per
+    # branch (HIMMEL-897 trail). The marker uses `echo "\$(date) ..."`, NOT
+    # printf: cron treats an unescaped % in the command as end-of-command +
+    # stdin, so a printf format string would truncate the entry. `\$(date)`
+    # lands literally and evaluates at fire time.
+    local tail="claude ${q_name}$q_prompt $q_channels"
+    if [ "$HEADROOM_PROXY_ACTIVE" -eq 1 ]; then
+        local q_hb q_log q_curl
+        q_hb=$(printf '%q' "$HEADROOM_BIN")
+        q_log=$(printf '%q' "$HOME/.headroom-proxy.log")
+        q_curl=$(printf '%q' "$HEADROOM_CURL")
+        tail="{ $q_curl -s -m 5 http://127.0.0.1:$HEADROOM_PROXY_PORT/livez >/dev/null 2>&1 || { $q_hb proxy --port $HEADROOM_PROXY_PORT >> $q_log 2>&1 & sleep 3; }; if $q_curl -s -m 5 http://127.0.0.1:$HEADROOM_PROXY_PORT/livez >/dev/null 2>&1; then echo \"\$(date) arm=$TASK_NAME mode=proxied\" >> $q_log; ANTHROPIC_BASE_URL=http://127.0.0.1:$HEADROOM_PROXY_PORT HEADROOM_OFFLINE=1 claude ${q_name}$q_prompt $q_channels; else echo \"\$(date) arm=$TASK_NAME mode=bare-fallback\" >> $q_log; claude ${q_name}$q_prompt $q_channels; fi; }"
+    fi
+    local entry="$mm $hh * * * $self_clean cd $q_cwd && $tail # $TASK_NAME"
     if [ "$DRY_RUN" -eq 1 ]; then
         echo "DRY arm-resume: would add crontab entry:"
         echo "    $entry"
@@ -1893,6 +1997,35 @@ schedule_arm() {
             # in "<TICKET> <name>" stays a single argv entry. Empty -> omit.
             local nm=""
             [ -n "$SESSION_NAME" ] && nm=" -n \"$SESSION_NAME\""
+            # HIMMEL_HEADROOM_PROXY (HIMMEL-901): a SEPARATE cygpath call
+            # (not folded into the batched bat/claude/cwd conversion above)
+            # so the existing HIMMEL-708 3-path split logic stays untouched
+            # when the flag is off — this only spawns when the flag is on.
+            # CR round: curl gets the same treatment as HEADROOM_BIN (one
+            # cygpath spawn for both) so the livez checks below carry an
+            # ABSOLUTE curl path — see the HEADROOM_CURL resolution comment.
+            local hb="" cu=""
+            if [ "$HEADROOM_PROXY_ACTIVE" -eq 1 ]; then
+                local _hp_cyg_out _hp_cyg_rest headroom_bin_win curl_bin_win
+                if ! _hp_cyg_out=$(cygpath -w "$HEADROOM_BIN" "$HEADROOM_CURL" 2>&1); then
+                    echo "ERR arm-resume: cygpath -w failed converting [headroom=$HEADROOM_BIN curl=$HEADROOM_CURL]: $_hp_cyg_out" >&2
+                    rm -f "$bat_path"
+                    exit 4
+                fi
+                headroom_bin_win="${_hp_cyg_out%%$'\n'*}"
+                _hp_cyg_rest="${_hp_cyg_out#*$'\n'}"
+                curl_bin_win="${_hp_cyg_rest%%$'\n'*}"
+                # Same incomplete-output guard as the batched 3-path split
+                # above (HIMMEL-708 CR): a cygpath that exits 0 with fewer
+                # lines must not leave curl_bin_win aliasing headroom_bin_win.
+                if [ -z "$headroom_bin_win" ] || [ -z "$curl_bin_win" ] || [ "$_hp_cyg_out" = "$_hp_cyg_rest" ]; then
+                    echo "ERR arm-resume: cygpath -w produced incomplete output (headroom/curl): $_hp_cyg_out" >&2
+                    rm -f "$bat_path"
+                    exit 4
+                fi
+                hb=$(_cmd_metachar_escape "$headroom_bin_win")
+                cu=$(_cmd_metachar_escape "$curl_bin_win")
+            fi
             # Self-clean FIRST: a /sc ONCE task lingers in Task Scheduler
             # after it fires (Ready/completed), accumulating stale jobs and
             # blocking a future same-handover arm without --force. So the
@@ -1910,10 +2043,49 @@ schedule_arm() {
             # Prompt MUST come before --channels: --channels is variadic
             # (consumes following args), so a trailing positional prompt
             # gets parsed as a bogus channel entry ("must be tagged" → exit 1).
+            # HIMMEL_HEADROOM_PROXY (HIMMEL-901): when active, gate the
+            # claude launch on a livez check, starting the proxy DETACHED
+            # if it's down and giving it ~3s before rechecking. Fail-open:
+            # if it's STILL down after the retry, fall through to a bare
+            # launch (a broken proxy must never block the relaunch) — the
+            # log at %USERPROFILE%\.headroom-proxy.log is the only trail.
+            # `start "" /b cmd /c "..."` (not `start "" /b <exe> ... >>log`,
+            # which does not reliably redirect the child) is the verified
+            # detached-with-redirection form. `if errorlevel 1` reads the
+            # LAST command's exit code, so the second `if errorlevel 1`
+            # below correctly reflects either the original livez check (skip
+            # branch never ran) or the retry livez check (skip branch ran) —
+            # no delayed-expansion (!VAR!) needed anywhere. %USERPROFILE% is
+            # a literal CMD env-var reference (NOT run through the %->%%
+            # escaping below, which is for literal-data percents only).
+            # CR round: each branch appends ONE mode-marker line to the
+            # proxy log before launching (proxied vs bare-fallback) — the
+            # HIMMEL-897 measurement trail; without it a fired launch is
+            # indistinguishable after the fact. %DATE%/%TIME% expand when
+            # CMD parses the if-block, close enough to launch time.
+            # TASK_NAME is sanitized to [:alnum:]_- (no CMD metachars).
             {
                 printf 'schtasks /delete /tn "%s" /f >nul 2>&1\r\n' "$TASK_NAME"
                 printf 'cd /d "%s" || exit /b 1\r\n' "$c"
-                printf '"%s"%s "%s"%s\r\n' "$claude_cmd_win" "$nm" "$p" "$ch"
+                if [ "$HEADROOM_PROXY_ACTIVE" -eq 1 ]; then
+                    printf '"%s" -s -m 5 http://127.0.0.1:%s/livez >nul 2>&1\r\n' "$cu" "$HEADROOM_PROXY_PORT"
+                    printf 'if errorlevel 1 (\r\n'
+                    printf '    start "" /b cmd /c ""%s" proxy --port %s >> "%%USERPROFILE%%\\.headroom-proxy.log" 2>&1"\r\n' "$hb" "$HEADROOM_PROXY_PORT"
+                    printf '    ping -n 4 127.0.0.1 >nul\r\n'
+                    printf '    "%s" -s -m 5 http://127.0.0.1:%s/livez >nul 2>&1\r\n' "$cu" "$HEADROOM_PROXY_PORT"
+                    printf ')\r\n'
+                    printf 'if errorlevel 1 (\r\n'
+                    printf '    echo %%DATE%% %%TIME%% arm=%s mode=bare-fallback>> "%%USERPROFILE%%\\.headroom-proxy.log"\r\n' "$TASK_NAME"
+                    printf '    "%s"%s "%s"%s\r\n' "$claude_cmd_win" "$nm" "$p" "$ch"
+                    printf ') else (\r\n'
+                    printf '    echo %%DATE%% %%TIME%% arm=%s mode=proxied>> "%%USERPROFILE%%\\.headroom-proxy.log"\r\n' "$TASK_NAME"
+                    printf '    set "ANTHROPIC_BASE_URL=http://127.0.0.1:%s"\r\n' "$HEADROOM_PROXY_PORT"
+                    printf '    set "HEADROOM_OFFLINE=1"\r\n'
+                    printf '    "%s"%s "%s"%s\r\n' "$claude_cmd_win" "$nm" "$p" "$ch"
+                    printf ')\r\n'
+                else
+                    printf '"%s"%s "%s"%s\r\n' "$claude_cmd_win" "$nm" "$p" "$ch"
+                fi
             } > "$bat_path"
 
             if [ "$DRY_RUN" -eq 1 ]; then
@@ -1963,11 +2135,36 @@ schedule_arm() {
                 # -n <session name> (HIMMEL-702): %q so "<TICKET> <name>"
                 # stays one arg after the /bin/sh re-parse. Empty -> omit.
                 [ -n "$SESSION_NAME" ] && q_name="-n $(printf '%q' "$SESSION_NAME") "
+                # HIMMEL_HEADROOM_PROXY (HIMMEL-901): $launch_lines is the
+                # plain 'claude ...' line unless the flag is active, in
+                # which case it becomes a livez-check-then-launch block
+                # (same shape as _crontab_schedule's $tail above) — built
+                # ONCE so the dry-run echo and the real heredoc can't drift
+                # apart. Inactive -> byte-identical to the pre-901 line.
+                # CR round: absolute curl path ($q_curl — see HEADROOM_CURL)
+                # + one mode-marker echo per branch (HIMMEL-897 trail).
+                # `\$(date)` is escaped so it lands LITERALLY in the job
+                # body and evaluates at FIRE time, not arm time.
+                local launch_lines="claude ${q_name}$q_prompt $q_channels"
+                if [ "$HEADROOM_PROXY_ACTIVE" -eq 1 ]; then
+                    local q_hb q_log q_curl
+                    q_hb=$(printf '%q' "$HEADROOM_BIN")
+                    q_log=$(printf '%q' "$HOME/.headroom-proxy.log")
+                    q_curl=$(printf '%q' "$HEADROOM_CURL")
+                    launch_lines="$q_curl -s -m 5 http://127.0.0.1:$HEADROOM_PROXY_PORT/livez >/dev/null 2>&1 || { $q_hb proxy --port $HEADROOM_PROXY_PORT >> $q_log 2>&1 & sleep 3; }
+if $q_curl -s -m 5 http://127.0.0.1:$HEADROOM_PROXY_PORT/livez >/dev/null 2>&1; then
+    echo \"\$(date) arm=$TASK_NAME mode=proxied\" >> $q_log
+    ANTHROPIC_BASE_URL=http://127.0.0.1:$HEADROOM_PROXY_PORT HEADROOM_OFFLINE=1 claude ${q_name}$q_prompt $q_channels
+else
+    echo \"\$(date) arm=$TASK_NAME mode=bare-fallback\" >> $q_log
+    claude ${q_name}$q_prompt $q_channels
+fi"
+                fi
                 if [ "$DRY_RUN" -eq 1 ]; then
                     echo "DRY arm-resume: would at -t $AT_STAMP <<'CMD'"
                     echo "    # $TASK_NAME"
                     echo "    cd $q_cwd || exit 1"
-                    echo "    claude ${q_name}$q_prompt $q_channels"
+                    printf '%s\n' "$launch_lines" | sed 's/^/    /'
                     echo "    CMD"
                     return 0
                 fi
@@ -1980,7 +2177,7 @@ schedule_arm() {
                 if ! at -t "$AT_STAMP" 2>"$err_file" <<CMD
 # $TASK_NAME
 cd $q_cwd || exit 1
-claude ${q_name}$q_prompt $q_channels
+$launch_lines
 CMD
                 then
                     echo "ERR arm-resume: at -t $AT_STAMP failed:" >&2

--- a/scripts/handover/test-arm-resume-proxy.sh
+++ b/scripts/handover/test-arm-resume-proxy.sh
@@ -1,0 +1,505 @@
+#!/usr/bin/env bash
+# test-arm-resume-proxy.sh -- regression test for the HIMMEL-901
+# HIMMEL_HEADROOM_PROXY arm-time flag added to
+# scripts/handover/arm-resume.sh + scripts/lib/headroom-proxy.sh.
+#
+# Kept SEPARATE from the (already large) test-arm-resume.sh, same rationale
+# as test-arm-resume-queue-lock.sh: this ticket's surface stays
+# independently reviewable. Shares the same stubbing conventions (PATH-
+# stubbed schtasks/atq/at so no real scheduler job is ever created; a
+# throwaway WORKSPACE_TRUST_CONFIG/SKILL_TELEMETRY_DIR so no operator state
+# is touched) and the same OSTYPE-override trick test-arm-resume.sh's
+# mac_env() uses (S4/macOS block) to exercise the POSIX at/crontab code
+# paths from a Windows/Git-Bash runner: a bash child process HONORS an
+# inherited/exported OSTYPE even though it looks like a bash-internal
+# variable (verified empirically before relying on it here).
+#
+# Everything below runs under --dry-run: touches no real scheduler, no real
+# ~/.headroom-venv, no real network. bash-3.2-safe, ASCII-only.
+#
+# CR round additions: mode-marker lines (HIMMEL-897 trail), absolute-curl
+# baking, metachar escaping proof, lib fail-open, cygpath-failure, and the
+# curl-missing arm-time deactivation.
+#
+# Usage: bash scripts/handover/test-arm-resume-proxy.sh
+# Exit:  0 = all pass, 1 = one or more failures.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ARM="$SCRIPT_DIR/arm-resume.sh"
+LIB="$SCRIPT_DIR/../lib/headroom-proxy.sh"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Hermetic shields (same as test-arm-resume.sh / test-arm-resume-queue-lock.sh):
+# no real telemetry/trust writes, no operator-shell env bleed.
+export SKILL_TELEMETRY_DIR="$TMP/telemetry"
+export WORKSPACE_TRUST_CONFIG="$TMP/claude-trust.json"
+unset HIMMEL_HEADROOM_PROXY HEADROOM_BIN 2>/dev/null || true
+
+FAILED=0
+assert_rc() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS $label (rc=$actual)"
+    else
+        echo "FAIL $label -- expected rc=$expected, got rc=$actual"
+        FAILED=$((FAILED + 1))
+    fi
+}
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    case "$haystack" in
+        *"$needle"*) echo "PASS $label" ;;
+        *) echo "FAIL $label -- output missing: $needle"; FAILED=$((FAILED + 1)) ;;
+    esac
+}
+assert_not_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    case "$haystack" in
+        *"$needle"*) echo "FAIL $label -- output unexpectedly contains: $needle"; FAILED=$((FAILED + 1)) ;;
+        *) echo "PASS $label" ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+WORK_REPO="$TMP/work-repo"
+mkdir -p "$WORK_REPO"
+git init -q "$WORK_REPO"
+HANDOVER_DIR="$TMP/statedocs/handovers"
+mkdir -p "$HANDOVER_DIR"
+git init -q "$TMP/statedocs"
+FUTURE_TIME="23:59"
+
+make_handover() {
+    local path="$HANDOVER_DIR/handover-$RANDOM.md"
+    {
+        printf -- '---\n'
+        printf 'session_kind: test\n'
+        printf 'resume_cwd: %s\n' "$WORK_REPO"
+        printf -- '---\n'
+        printf '# Test handover\n'
+    } > "$path"
+    printf '%s' "$path"
+}
+
+# Empty-scheduler stub (same pattern as test-arm-resume.sh SCHED_STUB_T17):
+# /query (and atq/at) return nothing, rc 0 -- reads as "no existing jobs" so
+# dedup/collision never interferes with these HIMMEL-901-specific assertions.
+SCHED_STUB="$TMP/sched-stub"
+mkdir -p "$SCHED_STUB"
+cat > "$SCHED_STUB/schtasks" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$SCHED_STUB/atq" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$SCHED_STUB/at" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$SCHED_STUB/schtasks" "$SCHED_STUB/atq" "$SCHED_STUB/at"
+
+# ---------------------------------------------------------------------------
+# T1: flag OFF (env unset, no repo-root .env signal) -- Windows dry-run .bat
+#     content carries NO proxy lines. No-regression guard: this worktree's
+#     root has no .env (verified before writing this test), and
+#     HIMMEL_HEADROOM_PROXY/HEADROOM_BIN are explicitly unset above.
+# ---------------------------------------------------------------------------
+HO=$(make_handover)
+out=$(PATH="$SCHED_STUB:$PATH" bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T1 flag-off dry-run exits 0" 0 "$rc"
+assert_not_contains "T1 no ANTHROPIC_BASE_URL" "ANTHROPIC_BASE_URL" "$out"
+assert_not_contains "T1 no livez check" "livez" "$out"
+assert_not_contains "T1 no HEADROOM_OFFLINE" "HEADROOM_OFFLINE" "$out"
+assert_not_contains "T1 no mode marker" "mode=" "$out"
+assert_not_contains "T1 no detached proxy start" 'cmd /c "' "$out"
+
+# ---------------------------------------------------------------------------
+# T2: HIMMEL_HEADROOM_PROXY=1 in the process env -- the dry-run launcher
+#     carries the livez check (ABSOLUTE curl path -- CR round), the detached
+#     start, the env injection, the fail-open branch structure, and one
+#     mode-marker line per branch (proxied / bare-fallback, HIMMEL-897).
+#     CMD-specific shapes are gated to Windows; the POSIX twin shapes are
+#     pinned by T5/T6 via the OSTYPE override.
+# ---------------------------------------------------------------------------
+HO=$(make_handover)
+out=$(HIMMEL_HEADROOM_PROXY=1 PATH="$SCHED_STUB:$PATH" bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T2 flag-on dry-run exits 0" 0 "$rc"
+assert_contains "T2 livez check present" "-s -m 5 http://127.0.0.1:8787/livez" "$out"
+assert_contains "T2 proxy --port 8787 invoked" "proxy --port 8787" "$out"
+assert_contains "T2 log path present" '.headroom-proxy.log' "$out"
+assert_contains "T2 mode=proxied marker baked in" "mode=proxied" "$out"
+assert_contains "T2 mode=bare-fallback marker baked in" "mode=bare-fallback" "$out"
+assert_contains "T2 marker carries the arm identity" "arm=HIMMEL-Resume-" "$out"
+assert_contains "T2 default headroom bin path baked in" "headroom-venv" "$out"
+case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
+    msys*|cygwin*|win32*|MINGW*)
+        assert_contains "T2 detached start line present" 'start "" /b cmd /c "' "$out"
+        assert_contains "T2 ANTHROPIC_BASE_URL set" 'set "ANTHROPIC_BASE_URL=http://127.0.0.1:8787"' "$out"
+        assert_contains "T2 HEADROOM_OFFLINE set" 'set "HEADROOM_OFFLINE=1"' "$out"
+        assert_contains "T2 errorlevel gate present" "if errorlevel 1 (" "$out"
+        assert_contains "T2 fail-open else branch present" ") else (" "$out"
+        EXPECTED_CURL_WIN=$(cygpath -w "$(command -v curl)")
+        assert_contains "T2 absolute curl path baked in" "\"$EXPECTED_CURL_WIN\" -s -m 5" "$out"
+        ;;
+    *)
+        assert_contains "T2 ANTHROPIC_BASE_URL exported inline" "ANTHROPIC_BASE_URL=http://127.0.0.1:8787" "$out"
+        assert_contains "T2 HEADROOM_OFFLINE exported inline" "HEADROOM_OFFLINE=1" "$out"
+        EXPECTED_CURL_POSIX=$(printf '%q' "$(command -v curl)")
+        assert_contains "T2 absolute curl path baked in" "$EXPECTED_CURL_POSIX -s -m 5" "$out"
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
+# T3a: direct unit tests of the sourceable .env parser
+#      (_headroom_proxy_env_file_active in scripts/lib/headroom-proxy.sh).
+#      arm-resume.sh itself is NOT safely sourceable (parses "$@", calls
+#      exit unconditionally at the end), so the parser was split into this
+#      small lib specifically so it -- and only it -- can be sourced
+#      directly here without touching the real scheduler or exiting the
+#      test runner.
+# ---------------------------------------------------------------------------
+(
+    # shellcheck source=../lib/headroom-proxy.sh
+    # shellcheck disable=SC1090,SC1091
+    . "$LIB"
+    ENVDIR="$TMP/envunit"
+    mkdir -p "$ENVDIR"
+    printf 'HIMMEL_HEADROOM_PROXY=1\n' > "$ENVDIR/.env"
+    if _headroom_proxy_env_file_active "$ENVDIR"; then echo "PASS T3a plain =1 activates"; else echo "FAIL T3a plain =1"; fi
+    printf 'export HIMMEL_HEADROOM_PROXY=1\n' > "$ENVDIR/.env"
+    if _headroom_proxy_env_file_active "$ENVDIR"; then echo "PASS T3a export-prefixed =1 activates"; else echo "FAIL T3a export prefix"; fi
+    printf 'HIMMEL_HEADROOM_PROXY=0\n' > "$ENVDIR/.env"
+    if _headroom_proxy_env_file_active "$ENVDIR"; then echo "FAIL T3a =0 must NOT activate"; else echo "PASS T3a =0 stays inactive"; fi
+    printf '# comment\n\nOTHER=1\nHIMMEL_HEADROOM_PROXY=1\n' > "$ENVDIR/.env"
+    if _headroom_proxy_env_file_active "$ENVDIR"; then echo "PASS T3a comments/blank lines/other vars tolerated"; else echo "FAIL T3a mixed content"; fi
+    printf 'HIMMEL_HEADROOM_PROXY=1\r\n' > "$ENVDIR/.env"
+    if _headroom_proxy_env_file_active "$ENVDIR"; then echo "PASS T3a CRLF-terminated .env tolerated"; else echo "FAIL T3a CRLF .env"; fi
+    rm -f "$ENVDIR/.env"
+    if _headroom_proxy_env_file_active "$ENVDIR"; then echo "FAIL T3a missing .env must NOT activate"; else echo "PASS T3a missing .env stays inactive"; fi
+) | while IFS= read -r line; do
+    echo "$line"
+    case "$line" in FAIL*) : > "$TMP/t3a-failed" ;; esac
+done
+[ -f "$TMP/t3a-failed" ] && FAILED=$((FAILED + 1))
+
+# ---------------------------------------------------------------------------
+# T3b/T3c: end-to-end .env fallback through the REAL arm-resume.sh, in an
+#     ISOLATED copy of the repo layout (same technique test-arm-resume.sh's
+#     T24 FAILOPEN block uses) so a controlled <root>/.env sits exactly
+#     where SCRIPT_DIR/../.. resolves it, without touching this worktree's
+#     real (absent) .env.
+# ---------------------------------------------------------------------------
+ENVROOT="$TMP/envfallback"
+mkdir -p "$ENVROOT/scripts/handover" "$ENVROOT/scripts/lib"
+cp "$ARM" "$ENVROOT/scripts/handover/arm-resume.sh"
+cp "$SCRIPT_DIR/../lib/py-armor.sh" "$ENVROOT/scripts/lib/py-armor.sh"
+cp "$LIB" "$ENVROOT/scripts/lib/headroom-proxy.sh"
+
+# T3b: process env UNSET, repo-root .env carries HIMMEL_HEADROOM_PROXY=1 ->
+#      falls back to the file -> proxy lines present.
+printf 'HIMMEL_HEADROOM_PROXY=1\n' > "$ENVROOT/.env"
+HO=$(make_handover)
+out=$(env -u HIMMEL_HEADROOM_PROXY PATH="$SCHED_STUB:$PATH" \
+    bash "$ENVROOT/scripts/handover/arm-resume.sh" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T3b .env fallback dry-run exits 0" 0 "$rc"
+assert_contains "T3b .env fallback activates the proxy lines" "-s -m 5 http://127.0.0.1:8787/livez" "$out"
+
+# T3c: process env EXPLICITLY set to a non-"1" value wins over a .env that
+#      says "1" -- proves (a) process env always wins over the file, and
+#      (b) only the exact value "1" activates (a set-but-wrong value is
+#      NOT the same as unset -- it does not fall through to the file).
+HO=$(make_handover)
+out=$(HIMMEL_HEADROOM_PROXY=0 PATH="$SCHED_STUB:$PATH" \
+    bash "$ENVROOT/scripts/handover/arm-resume.sh" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T3c process-env=0 dry-run exits 0" 0 "$rc"
+assert_not_contains "T3c process-env=0 overrides a truthy .env (stays inactive)" "livez" "$out"
+
+# T3d (CR round): set-but-EMPTY process env counts as set-and-inactive and
+#     does NOT fall through to the truthy .env -- pins the ${VAR+x} set-test
+#     against a regression to [ -n "$VAR" ] (which would treat empty as
+#     unset and wrongly consult the file).
+HO=$(make_handover)
+out=$(HIMMEL_HEADROOM_PROXY='' PATH="$SCHED_STUB:$PATH" \
+    bash "$ENVROOT/scripts/handover/arm-resume.sh" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T3d set-but-empty process env dry-run exits 0" 0 "$rc"
+assert_not_contains "T3d set-but-empty env does NOT fall through to .env" "livez" "$out"
+
+# ---------------------------------------------------------------------------
+# T4: HEADROOM_BIN override lands in the generated launcher (cygpath-
+#     converted + CMD-escaped on Windows; %q-quoted on POSIX). Uses a path
+#     WITH a space to prove the quoting survives it. The file deliberately
+#     does NOT exist -> also pins the arm-time existence WARN (CR round,
+#     non-blocking: rc stays 0).
+# ---------------------------------------------------------------------------
+CUSTOM_HB="$TMP/custom bin/headroom.exe"
+mkdir -p "$TMP/custom bin"
+case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
+    msys*|cygwin*|win32*|MINGW*) EXPECTED_HB=$(cygpath -w "$CUSTOM_HB") ;;
+    *)                           EXPECTED_HB=$(printf '%q' "$CUSTOM_HB") ;;
+esac
+HO=$(make_handover)
+out=$(HIMMEL_HEADROOM_PROXY=1 HEADROOM_BIN="$CUSTOM_HB" PATH="$SCHED_STUB:$PATH" \
+    bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T4 HEADROOM_BIN override dry-run exits 0" 0 "$rc"
+assert_contains "T4 custom headroom bin path baked into launcher" "$EXPECTED_HB" "$out"
+assert_not_contains "T4 default headroom-venv path NOT used" "headroom-venv" "$out"
+assert_contains "T4 arm-time WARN for a missing/non-exec HEADROOM_BIN" "not found/executable" "$out"
+
+# ---------------------------------------------------------------------------
+# T4b (CR round): CMD-metachar escaping on the HEADROOM_BIN path actually
+#     bites -- a dir name carrying % and & must land in the .bat with % as
+#     %% and & as ^& (the _cmd_metachar_escape treatment; T4's space never
+#     exercised the substitutions). POSIX: the same path must land %q-quoted.
+# ---------------------------------------------------------------------------
+MBIN_DIR="$TMP/hea%dr&om"
+mkdir -p "$MBIN_DIR"
+MBIN="$MBIN_DIR/headroom.exe"
+HO=$(make_handover)
+out=$(HIMMEL_HEADROOM_PROXY=1 HEADROOM_BIN="$MBIN" PATH="$SCHED_STUB:$PATH" \
+    bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T4b metachar HEADROOM_BIN dry-run exits 0" 0 "$rc"
+case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
+    msys*|cygwin*|win32*|MINGW*)
+        assert_contains "T4b percent doubled for CMD" 'hea%%dr' "$out"
+        assert_contains "T4b ampersand caret-escaped for CMD" '^&om' "$out"
+        ;;
+    *)
+        EXPECTED_MBIN=$(printf '%q' "$MBIN")
+        assert_contains "T4b metachar path %q-quoted for sh" "$EXPECTED_MBIN" "$out"
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
+# T5: macOS backend (crontab) -- OSTYPE override, same technique as
+#     test-arm-resume.sh's mac_env(). Verified empirically that a bash
+#     child process honors an inherited/exported OSTYPE.
+# ---------------------------------------------------------------------------
+MACBIN="$TMP/macbin"; mkdir -p "$MACBIN"
+printf '#!/bin/sh\necho "at MUST NOT be called on macOS" >&2; exit 1\n' > "$MACBIN/at"; chmod +x "$MACBIN/at"
+printf '#!/bin/sh\nexit 0\n' > "$MACBIN/atq"; chmod +x "$MACBIN/atq"
+cat > "$MACBIN/crontab" <<'EOF'
+#!/bin/sh
+case "$1" in
+  -l) exit 0 ;;
+  -)  cat > /dev/null ;;
+  *)  exit 0 ;;
+esac
+EOF
+chmod +x "$MACBIN/crontab"
+mac_env() { env PATH="$MACBIN:$PATH" OSTYPE="darwin23" "$@"; }
+
+# Expected POSIX curl reference for T5/T6 (CR round): the launchers bake the
+# %q-quoted absolute path resolved at arm time.
+EXPECTED_CURL_Q=$(printf '%q' "$(command -v curl)")
+
+# T5a: flag ON -- the one-line compound tail carries the proxy markers.
+HO=$(make_handover)
+out=$(mac_env env HIMMEL_HEADROOM_PROXY=1 bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T5a macOS/crontab flag-on dry-run exits 0" 0 "$rc"
+assert_contains "T5a crontab entry" "crontab entry" "$out"
+assert_contains "T5a absolute curl path in livez check" "$EXPECTED_CURL_Q -s -m 5 http://127.0.0.1:8787/livez" "$out"
+assert_contains "T5a ANTHROPIC_BASE_URL inline-exported" "ANTHROPIC_BASE_URL=http://127.0.0.1:8787" "$out"
+assert_contains "T5a HEADROOM_OFFLINE inline-exported" "HEADROOM_OFFLINE=1" "$out"
+assert_contains "T5a proxy started detached in background" "proxy --port 8787" "$out"
+assert_contains "T5a mode=proxied marker baked in" "mode=proxied" "$out"
+assert_contains "T5a mode=bare-fallback marker baked in" "mode=bare-fallback" "$out"
+assert_contains "T5a marker timestamp is fire-time (literal date sub)" 'arm=HIMMEL-Resume-' "$out"
+
+# T5b: flag OFF -- no-regression guard on the crontab path (negative-marker
+# set aligned with T1/T6b, CR round).
+HO=$(make_handover)
+out=$(mac_env bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T5b macOS/crontab flag-off dry-run exits 0" 0 "$rc"
+assert_not_contains "T5b no ANTHROPIC_BASE_URL" "ANTHROPIC_BASE_URL" "$out"
+assert_not_contains "T5b no livez check" "livez" "$out"
+assert_not_contains "T5b no HEADROOM_OFFLINE" "HEADROOM_OFFLINE" "$out"
+assert_not_contains "T5b no mode marker" "mode=" "$out"
+
+# ---------------------------------------------------------------------------
+# T6: linux backend (at) -- OSTYPE override with `at`/`atq` present so
+#     schedule_arm takes the `at` heredoc branch, not the crontab fallback.
+# ---------------------------------------------------------------------------
+LINBIN="$TMP/linbin"; mkdir -p "$LINBIN"
+printf '#!/bin/sh\nexit 0\n' > "$LINBIN/atq"; chmod +x "$LINBIN/atq"
+printf '#!/bin/sh\ncat >/dev/null\nexit 0\n' > "$LINBIN/at"; chmod +x "$LINBIN/at"
+lin_env() { env PATH="$LINBIN:$PATH" OSTYPE="linux-gnu" "$@"; }
+
+# T6a: flag ON -- the heredoc body carries the proxy markers.
+HO=$(make_handover)
+out=$(lin_env env HIMMEL_HEADROOM_PROXY=1 bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T6a linux/at flag-on dry-run exits 0" 0 "$rc"
+assert_contains "T6a at -t heredoc" "would at -t" "$out"
+assert_contains "T6a absolute curl path in livez check" "$EXPECTED_CURL_Q -s -m 5 http://127.0.0.1:8787/livez" "$out"
+assert_contains "T6a if-curl gate present" "if $EXPECTED_CURL_Q -s -m 5" "$out"
+assert_contains "T6a ANTHROPIC_BASE_URL inline-exported" "ANTHROPIC_BASE_URL=http://127.0.0.1:8787" "$out"
+assert_contains "T6a HEADROOM_OFFLINE inline-exported" "HEADROOM_OFFLINE=1" "$out"
+assert_contains "T6a proxy started detached in background" "proxy --port 8787" "$out"
+assert_contains "T6a mode=proxied marker baked in" "mode=proxied" "$out"
+assert_contains "T6a mode=bare-fallback marker baked in" "mode=bare-fallback" "$out"
+
+# T6b: flag OFF -- no-regression guard on the at path (negative-marker set
+# aligned with T1/T5b, CR round).
+HO=$(make_handover)
+out=$(lin_env bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T6b linux/at flag-off dry-run exits 0" 0 "$rc"
+assert_not_contains "T6b no ANTHROPIC_BASE_URL" "ANTHROPIC_BASE_URL" "$out"
+assert_not_contains "T6b no livez check" "livez" "$out"
+assert_not_contains "T6b no HEADROOM_OFFLINE" "HEADROOM_OFFLINE" "$out"
+assert_not_contains "T6b no mode marker" "mode=" "$out"
+
+# T6c (CR round): POSIX HEADROOM_BIN override with a metachar + space path
+# proves the %q quoting end-to-end on BOTH sh-variant launchers (at heredoc
+# via lin_env, crontab one-liner via mac_env).
+POSIX_HB="$TMP/head room/hea&droom"
+mkdir -p "$TMP/head room"
+EXPECTED_POSIX_HB=$(printf '%q' "$POSIX_HB")
+HO=$(make_handover)
+out=$(lin_env env HIMMEL_HEADROOM_PROXY=1 HEADROOM_BIN="$POSIX_HB" \
+    bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T6c linux/at metachar HEADROOM_BIN dry-run exits 0" 0 "$rc"
+assert_contains "T6c at heredoc bakes the %q-quoted bin" "$EXPECTED_POSIX_HB proxy --port 8787" "$out"
+HO=$(make_handover)
+out=$(mac_env env HIMMEL_HEADROOM_PROXY=1 HEADROOM_BIN="$POSIX_HB" \
+    bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T6c macOS/crontab metachar HEADROOM_BIN dry-run exits 0" 0 "$rc"
+assert_contains "T6c crontab entry bakes the %q-quoted bin" "$EXPECTED_POSIX_HB proxy --port 8787" "$out"
+
+# ---------------------------------------------------------------------------
+# T7 (CR round): lib fail-open -- arm-resume must behave identically when
+#     scripts/lib/headroom-proxy.sh is ABSENT or syntactically BROKEN
+#     (mirrors test-arm-resume.sh T24's telemetry-lib pattern). The source
+#     failure now WARNs (Suggestion A) -- assert the WARN is present AND
+#     that the process-env flag still works without the lib.
+# ---------------------------------------------------------------------------
+LIBFAIL="$TMP/libfail"
+mkdir -p "$LIBFAIL/scripts/handover" "$LIBFAIL/scripts/lib"
+cp "$ARM" "$LIBFAIL/scripts/handover/arm-resume.sh"
+cp "$SCRIPT_DIR/../lib/py-armor.sh" "$LIBFAIL/scripts/lib/py-armor.sh"
+printf 'HIMMEL_HEADROOM_PROXY=1\n' > "$LIBFAIL/.env"
+# (a) lib ABSENT: arm works (rc 0), WARNs, and the truthy .env is IGNORED
+#     (fallback disabled without the parser).
+HO=$(make_handover)
+out=$(env -u HIMMEL_HEADROOM_PROXY PATH="$SCHED_STUB:$PATH" \
+    bash "$LIBFAIL/scripts/handover/arm-resume.sh" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T7a absent lib: arm still works (rc 0)" 0 "$rc"
+assert_contains "T7a absent lib: source-failure WARN emitted" "headroom-proxy lib failed to load" "$out"
+assert_not_contains "T7a absent lib: truthy .env fallback disabled" "livez" "$out"
+# (b) lib ABSENT but process env =1: the flag still activates (env check
+#     does not depend on the lib).
+HO=$(make_handover)
+out=$(HIMMEL_HEADROOM_PROXY=1 PATH="$SCHED_STUB:$PATH" \
+    bash "$LIBFAIL/scripts/handover/arm-resume.sh" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T7b absent lib + process env: arm exits 0" 0 "$rc"
+assert_contains "T7b absent lib + process env: proxy lines present" "livez" "$out"
+# (c) lib BROKEN (bash syntax error): same invariants as (a).
+printf 'if [ broken\nthen (\n' > "$LIBFAIL/scripts/lib/headroom-proxy.sh"
+HO=$(make_handover)
+out=$(env -u HIMMEL_HEADROOM_PROXY PATH="$SCHED_STUB:$PATH" \
+    bash "$LIBFAIL/scripts/handover/arm-resume.sh" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T7c broken lib: arm still works (rc 0)" 0 "$rc"
+assert_contains "T7c broken lib: source-failure WARN emitted" "headroom-proxy lib failed to load" "$out"
+assert_not_contains "T7c broken lib: truthy .env fallback disabled" "livez" "$out"
+
+# ---------------------------------------------------------------------------
+# T8 (CR round): cygpath failure on the headroom+curl conversion -> rc 4,
+#     ERR text, and no leftover temp .bat. The stub delegates the batched
+#     3-path call (-w + 3 args = $# 4) to the REAL cygpath and refuses the
+#     2-path headroom+curl call ($# 3), so the failure lands exactly on the
+#     new conversion. Windows-only: the .bat branch is the only cygpath
+#     consumer (POSIX launchers never call it).
+# ---------------------------------------------------------------------------
+case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
+    msys*|cygwin*|win32*|MINGW*)
+        REAL_CYGPATH=$(command -v cygpath)
+        CYGFAIL_STUB="$TMP/cygfail-stub"
+        mkdir -p "$CYGFAIL_STUB"
+        {
+            printf '#!/usr/bin/env bash\n'
+            printf 'if [ "$#" -eq 4 ]; then exec "%s" "$@"; fi\n' "$REAL_CYGPATH"
+            printf 'echo "stub cygpath: refused" >&2\n'
+            printf 'exit 1\n'
+        } > "$CYGFAIL_STUB/cygpath"
+        chmod +x "$CYGFAIL_STUB/cygpath"
+        T8_TMPDIR="$TMP/t8-tmp"
+        mkdir -p "$T8_TMPDIR"
+        HO=$(make_handover)
+        out=$(TMPDIR="$T8_TMPDIR" HIMMEL_HEADROOM_PROXY=1 PATH="$CYGFAIL_STUB:$SCHED_STUB:$PATH" \
+            bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+        rc=$?
+        assert_rc "T8 cygpath failure on headroom conversion exits 4" 4 "$rc"
+        assert_contains "T8 ERR names the failed conversion" "cygpath -w failed converting" "$out"
+        if find "$T8_TMPDIR" -name 'himmel-resume.*.bat' 2>/dev/null | grep -q .; then
+            echo "FAIL T8 leftover temp .bat not cleaned up"
+            FAILED=$((FAILED + 1))
+        else
+            echo "PASS T8 no leftover temp .bat"
+        fi
+        ;;
+    *)
+        echo "SKIP T8 (cygpath failure path is Windows-only)"
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
+# T9 (CR round): curl missing at arm time -> one honest WARN, launcher
+#     emitted WITHOUT the proxy block (plain pre-901 launch), rc 0. curl is
+#     hidden by rebuilding PATH from /usr/bin (Git Bash and most Linux
+#     distros keep curl elsewhere) + the scheduler stub + python3's own dir
+#     (py-armor needs it for the time fields). Skip-guarded: if curl is
+#     still resolvable on the restricted PATH (e.g. a distro with
+#     /usr/bin/curl), the hermetic premise fails, so document and skip
+#     rather than assert on a broken fixture.
+# ---------------------------------------------------------------------------
+PY3BIN=$(command -v python3 2>/dev/null || true)
+RESTRICTED_PATH="$SCHED_STUB:/usr/bin"
+[ -n "$PY3BIN" ] && RESTRICTED_PATH="$RESTRICTED_PATH:$(dirname "$PY3BIN")"
+if env PATH="$RESTRICTED_PATH" bash -c 'command -v curl' >/dev/null 2>&1; then
+    echo "SKIP T9 (curl still resolvable on the restricted PATH; cannot fake a curl-less arm here)"
+else
+    HO=$(make_handover)
+    out=$(env PATH="$RESTRICTED_PATH" HIMMEL_HEADROOM_PROXY=1 \
+        bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+    rc=$?
+    assert_rc "T9 curl-missing arm still exits 0" 0 "$rc"
+    assert_contains "T9 arm-time WARN about missing curl" "curl not on PATH" "$out"
+    # Needle is the URL path "/livez" (with slash): the WARN itself says
+    # "proxy livez unverifiable", so a bare "livez" would false-positive
+    # on the very WARN this test requires.
+    assert_not_contains "T9 launcher emitted WITHOUT the proxy block" "/livez" "$out"
+    assert_not_contains "T9 no mode marker without the proxy block" "mode=" "$out"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+if [ "$FAILED" -gt 0 ]; then
+    echo "---"
+    echo "FAIL $FAILED case(s)"
+    exit 1
+fi
+echo "---"
+echo "PASS all cases"
+exit 0

--- a/scripts/lib/headroom-proxy.sh
+++ b/scripts/lib/headroom-proxy.sh
@@ -1,0 +1,36 @@
+# shellcheck shell=bash
+# scripts/lib/headroom-proxy.sh -- HIMMEL_HEADROOM_PROXY flag resolution
+# (HIMMEL-901).
+#
+# Small + sourceable (no top-level side effects, never calls exit) so both
+# arm-resume.sh and its test suite can use the SAME parser instead of two
+# copies drifting apart. arm-resume.sh itself is NOT safely sourceable (it
+# parses "$@" and unconditionally exits at the end), so this helper was
+# split out rather than testing the parser via the real script.
+#
+# _headroom_proxy_env_file_active <repo-root> -- rc 0 if <repo-root>/.env
+# contains a HIMMEL_HEADROOM_PROXY=1 line (optional 'export ' prefix,
+# comments/blank lines ignored). Only the exact value "1" activates -- any
+# other value (0, true, ...) or a missing/unreadable file is rc 1. This is
+# only the FILE-fallback half of flag resolution; the caller checks the
+# process env first (arm-resume.sh: HIMMEL_HEADROOM_PROXY set in the
+# launching shell always wins over the repo-root .env).
+# Errexit-safe: every branch is a `case`/`return`, nothing unguarded.
+_headroom_proxy_env_file_active() {
+    local _envfile="$1/.env" _line _val
+    [ -f "$_envfile" ] || return 1
+    while IFS= read -r _line || [ -n "$_line" ]; do
+        _line="${_line%$'\r'}"   # tolerate CRLF .env files
+        case "$_line" in
+            ''|'#'*) continue ;;
+            'export '*) _val="${_line#export }" ;;
+            *)         _val="$_line" ;;
+        esac
+        case "$_val" in
+            HIMMEL_HEADROOM_PROXY=*) _val="${_val#HIMMEL_HEADROOM_PROXY=}" ;;
+            *) continue ;;
+        esac
+        [ "$_val" = "1" ] && return 0
+    done < "$_envfile"
+    return 1
+}


### PR DESCRIPTION
## HIMMEL-901 (minimal leg) — arm-resume routes armed relaunches through the headroom proxy

When `HIMMEL_HEADROOM_PROXY=1` is active at ARM time (process env wins; himmel repo-root `.env` fallback via new sourceable `scripts/lib/headroom-proxy.sh`), the generated relaunch launcher — all three platform variants (Windows `.bat`/schtasks, POSIX `at` heredoc, crontab one-liner) — gains a livez-check-then-launch block:

1. `curl` (resolved to an ABSOLUTE path at arm time — scheduler contexts have minimal PATH) probes `http://127.0.0.1:8787/livez`
2. down → start `HEADROOM_BIN` detached (`~/.headroom-venv` default, env-overridable), log to `~/.headroom-proxy.log`, ~3s wait, re-probe
3. live → launch claude with `ANTHROPIC_BASE_URL=http://127.0.0.1:8787` + `HEADROOM_OFFLINE=1`
4. still down → BARE launch (fail-open — a broken proxy never blocks an unattended relaunch)
5. either way, one `mode=proxied|bare-fallback` marker line lands in the proxy log (the HIMMEL-897 measurement trail)

Flag inactive (the default) → launcher output **byte-identical** to pre-901 (pinned by tests). Arm-time WARNs (non-blocking) on: missing curl (emits a plain launcher rather than a known-broken check), non-executable HEADROOM_BIN, lib source failure.

### CR trail
Critic panel ×2 (free+paid, final run clean) + code-reviewer / silent-failure-hunter / pr-test-analyzer matrix (Sonnet). Fix round addressed: mode-marker gap + bare-curl PATH gap (silent-failure), 4 test-coverage gaps incl. CMD-metachar escaping proof, lib fail-open, cygpath-failure rc=4, set-but-empty flag semantics (test-analyzer), worktree/.env limitation doc note (code-reviewer).

### Tests
`test-arm-resume-proxy.sh`: 87 assertions green (flag-off byte-identity ×3 platforms, flag-on structure ×3, .env parser units incl. CRLF, precedence, HEADROOM_BIN metachar escaping, cygpath/curl failure paths). Full pre-existing `test-arm-resume.sh` + `test-arm-resume-queue-lock.sh`: green, zero regressions. Shellcheck clean. Empirically validated launcher shapes (real detached HttpListener for the Windows redirect pattern; stub binaries for the POSIX compounds).

Gated context: this is the launch-path minimal slice only — defaults stay OFF; the full 901 story (lane-aware injection, himmelctl/install, both-station defaults) remains gated on the HIMMEL-897 ADOPT verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
