### PR TITLE
fix(graphify): [HIMMEL-907] refresh stamps manifest.json + .graphify_root (transactional, scratch-walked)

### DIFF
--- a/scripts/graphify/refresh-graph-map.sh
+++ b/scripts/graphify/refresh-graph-map.sh
@@ -69,6 +69,10 @@ REPORT="$OUT_DIR/GRAPH_REPORT.md"
 
 if [ "$DO_UPDATE" -eq 1 ]; then
   command -v "$GRAPHIFY_MAP" >/dev/null 2>&1 || { echo "refresh-graph-map: '$GRAPHIFY_MAP' not on PATH (needed for --update; use --no-update to publish from an existing report)" >&2; exit 2; }
+  # F3 (HIMMEL-907): python3 writes the freshness manifest (see stamp step
+  # below). Preflight it next to the graphify check so a python3-less box fails
+  # BEFORE the scratch copy / paid extraction — never after promoting a new graph.
+  command -v python3 >/dev/null 2>&1 || { echo "refresh-graph-map: python3 not found (needed to write manifest.json for freshness verification)" >&2; exit 2; }
   # Fence-safe incremental refresh on a scratchpad COPY (never the live corpus).
   # Always work inside a uniquely-named, launcher-OWNED subdir (PID-suffixed) so
   # we never rm -rf an operator-supplied --scratch that may point at an existing
@@ -91,10 +95,72 @@ if [ "$DO_UPDATE" -eq 1 ]; then
   echo "refresh-graph-map: incremental update on scratchpad copy ($SCRATCH) backend=$BACKEND" >&2
   "$GRAPHIFY_MAP" "$SCRATCH" --update --backend "$BACKEND" --max-concurrency 6 --api-timeout 300 >&2 || { echo "refresh-graph-map: graphify --update failed" >&2; exit 2; }
   "$GRAPHIFY_MAP" cluster-only "$SCRATCH" --backend "$BACKEND" >&2 || { echo "refresh-graph-map: cluster-only failed" >&2; exit 2; }
-  # Promote the refreshed derived artifacts into the corpus's repo-local graphify-out.
+  # HIMMEL-907: stamp freshness artifacts so the companion guard
+  # check-graph-freshness.sh can VERIFY this graph (not "fresh by age" only).
+  # Source-of-truth for shape is the guard's parser: manifest.json = flat
+  # non-empty JSON object of corpus-relative path -> {mtime} (the parser uses
+  # the KEYS to prove the corpus still exists; values are free-form, so we carry
+  # the file mtime as honest provenance — stored as an INT epoch for compact,
+  # human-greppable provenance — and invent nothing else); .graphify_root =
+  # first non-blank line is the corpus root. graphify itself emits no manifest,
+  # so we synthesize one from the same corpus predicate the extraction copy used
+  # (find -name '*.md' -not -path './graphify-out/*'). A zero-md corpus stamps
+  # `{}`, which the guard rejects with rc=2 — fail-loud by design, no
+  # special-casing. Only written on a SUCCESSFUL refresh — this branch is reached
+  # solely after graphify --update + cluster-only both succeeded; a failed run
+  # exits above before reaching here, so we never stamp a failed run as fresh.
+  #
+  # F1: walk the SCRATCH copy (the exact corpus the graph saw), NOT the live
+  # corpus — a file added/removed mid-extraction would otherwise make
+  # manifest.json attest a corpus state the graph never saw. The scratch's own
+  # graphify-out is pruned so GRAPH_REPORT.md doesn't leak into the keys. Keys
+  # stay corpus-relative (scratch mirrors the corpus's relative md layout).
+  #
+  # F2: transactional promote so any interruption (disk full, kill, python3
+  # gone mid-run, ...) leaves a stamp-LESS out dir the guard fails closed on —
+  # never a NEW graph beside OLD stamps. Order: build the new manifest into a
+  # tmp name -> invalidate the old stamps -> promote the derived graph ->
+  # atomically install the new stamps (same-dir mv + marker write).
   mkdir -p "$OUT_DIR"
+  CORPUS_ROOT_ABS="$(cd "$CORPUS_ROOT" && pwd)"
+  OUT_DIR_ABS="$(cd "$OUT_DIR" && pwd)"
+  SCRATCH_ABS="$(cd "$SCRATCH" && pwd)"
+  # 1. build the new manifest from the scratch corpus into a tmp name (atomic
+  #    content write is fine — it's a tmp name, not the stamp itself).
+  python3 - "$SCRATCH_ABS" "$OUT_DIR_ABS" <<'PYEOF'
+import json, os, sys
+root, out = sys.argv[1], sys.argv[2]
+scratch_out = os.path.join(root, "graphify-out")
+manifest = {}
+for dirpath, dirs, files in os.walk(root):
+    # prune the derived out dir graphify wrote into the scratch so it doesn't
+    # leak GRAPH_REPORT.md into the manifest keys.
+    dirs[:] = [d for d in dirs if os.path.join(dirpath, d) != scratch_out]
+    for fn in files:
+        if not fn.endswith(".md"):
+            continue
+        full = os.path.join(dirpath, fn)
+        rel = os.path.relpath(full, root).replace(os.sep, "/")
+        try:
+            mtime = int(os.path.getmtime(full))
+        except OSError:
+            mtime = 0
+        manifest[rel] = {"mtime": mtime}
+with open(os.path.join(out, ".manifest.tmp"), "w") as fh:
+    json.dump(manifest, fh, sort_keys=True)
+    fh.write("\n")
+PYEOF
+  # 2. INVALIDATE the old stamps so a half-promoted out dir is never mistaken
+  #    for fresh (no manifest marker <-> guard fails closed).
+  rm -f "$OUT_DIR/manifest.json" "$OUT_DIR/.graphify_root"
+  # 3. promote the refreshed derived artifacts into the corpus's repo-local out.
   cp "$SCRATCH/graphify-out/graph.json" "$OUT_DIR/graph.json"
   cp "$SCRATCH/graphify-out/GRAPH_REPORT.md" "$REPORT"
+  # 4. STAMP: same-dir rename = atomic install of the manifest, then (re)write
+  #    the marker. .graphify_root stays CORPUS_ROOT_ABS — the guard joins the
+  #    corpus-relative manifest keys against the LIVE corpus root.
+  mv "$OUT_DIR/.manifest.tmp" "$OUT_DIR/manifest.json"
+  printf '%s\n' "$CORPUS_ROOT_ABS" > "$OUT_DIR/.graphify_root"
   rm -rf "$SCRATCH"   # eager clean on success; the EXIT trap is the failure-path backstop
 fi
 

--- a/scripts/graphify/test-refresh-graph-map.sh
+++ b/scripts/graphify/test-refresh-graph-map.sh
@@ -71,12 +71,21 @@ ls "$SCRATCH_PARENT"/graphify-refresh-* >/dev/null 2>&1 && fail "owned scratch s
 
 # --- T2: --no-update publishes from an existing repo-local report without re-extracting ---
 printf 'SENTINEL-EXISTING' > "$CORPUS/graphify-out/graph.json"   # must NOT be overwritten under --no-update
+# F4 (HIMMEL-907): a .md added AFTER T1's stamp but BEFORE this no-update run
+# must NOT appear in manifest.json — pins that --no-update never re-stamps (a
+# refactor dragging the stamp block below the fi would re-attest old graphs).
+printf '# t2 added\nadded between T1 stamp and no-update\n' > "$CORPUS/notes/t2-added.md"
 rm -f "$MAPS/graphify-luna-map.md"
 out=$( bash "$SCRIPT" --name luna --corpus-root "$CORPUS" --maps-dir "$MAPS" \
   --title "Graphify Luna Map" --slug graphify-luna-map --no-update 2>&1 ); rc=$?
 [ "$rc" -eq 0 ] || fail "no-update exit 0 (got $rc): $out"
 [ -f "$MAPS/graphify-luna-map.md" ] && pass "T2 no-update republishes MOC" || fail "T2 no-update MOC"
 grep -q "SENTINEL-EXISTING" "$CORPUS/graphify-out/graph.json" 2>/dev/null && pass "T2 no-update leaves graph.json untouched" || fail "T2 graph.json clobbered under --no-update"
+if grep -q "t2-added.md" "$CORPUS/graphify-out/manifest.json" 2>/dev/null; then
+  fail "T2/F4 --no-update re-stamped manifest (gained t2-added.md)"
+else
+  pass "T2/F4 --no-update did not re-stamp manifest"
+fi
 
 # --- T2c: --no-update works even when graphify is NOT on PATH (publish-only
 # must not require the extraction tool — CR: code-reviewer). node must stay
@@ -106,6 +115,194 @@ bash "$SCRIPT" --name luna --corpus-root "$CORPUS" --maps-dir "$MAPS" \
 rc=$?
 [ "$rc" -ne 0 ] && pass "T5 garbage report → non-zero exit (publish refused)" || fail "T5 garbage report exit code (got $rc)"
 grep -q "GOOD-MAP-KEEP" "$MAPS/graphify-luna-map.md" 2>/dev/null && pass "T5 last-good MOC not clobbered by garbage report" || fail "T5 garbage report clobbered the good MOC"
+
+# --- T6: HIMMEL-907 a SUCCESSFUL refresh stamps manifest.json + .graphify_root
+# at the out root, and check-graph-freshness.sh PASSES on that dir. This last
+# assertion is the real acceptance: the guard can VERIFY the refreshed graph
+# (no longer "fresh by age" only). Uses its own hermetic corpus so it is
+# independent of the T1-T5 mutations above. ---
+FRESH="$WS/fresh"; FCORPUS="$FRESH/corpus"; FMAPS="$FRESH/maps"
+mkdir -p "$FCORPUS/notes" "$FMAPS"
+printf '# a\nalpha content\n' > "$FCORPUS/a.md"
+printf '# b\nbeta content\n' > "$FCORPUS/notes/b.md"
+out=$( bash "$SCRIPT" --name fresh --corpus-root "$FCORPUS" --backend deepseek \
+  --maps-dir "$FMAPS" --title "Fresh Map" --slug fresh-map --corpus-tag fresh 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] || { fail "T6 refresh exit 0 (got $rc): $out"; }
+FOUT="$FCORPUS/graphify-out"
+[ -f "$FOUT/manifest.json" ] && pass "T6 manifest.json written at out root" || fail "T6 manifest.json missing at out root"
+[ -f "$FOUT/.graphify_root" ] && pass "T6 .graphify_root marker written" || fail "T6 .graphify_root marker missing"
+out=$( bash "$HERE/check-graph-freshness.sh" --out "$FOUT" --max-age-days 7 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] && pass "T6 guard PASSES on refreshed dir (corpus verified)" || fail "T6 guard should PASS on refreshed dir (got rc=$rc): $out"
+
+# --- T6b: manifest.json shape — a non-empty object keyed by corpus md paths
+# (the source of truth for shape is the guard's parser: keys only; values are
+# free-form). ---
+python3 - "$FOUT/manifest.json" <<'PY' 2>/dev/null && pass "T6b manifest.json is a non-empty object keyed by corpus md paths" || fail "T6b manifest.json shape"
+import json, sys
+d = json.load(open(sys.argv[1]))
+assert isinstance(d, dict) and d, "manifest is not a non-empty object"
+assert "a.md" in d and "notes/b.md" in d, "expected corpus md keys missing"
+# F5 (HIMMEL-907): the derived out dir must be pruned from the manifest walk —
+# GRAPH_REPORT.md sits in graphify-out/ at walk time and must not leak into keys.
+assert not any(k.startswith("graphify-out/") for k in d), "graphify-out leaked into manifest keys"
+PY
+
+# --- T6c: a FAILED refresh stamps NOTHING (graphify --update fails -> exit 2
+# before manifest/marker writing; a fresh out dir is left with neither). ---
+FAILBIN="$WS/failbin"; mkdir -p "$FAILBIN"
+cat > "$FAILBIN/graphify" <<'STUB'
+#!/usr/bin/env bash
+echo "simulated graphify failure" >&2
+exit 2
+STUB
+chmod +x "$FAILBIN/graphify"
+FCORPUS2="$WS/failcorpus"; FMAPS2="$WS/failmaps"
+mkdir -p "$FCORPUS2/notes" "$FMAPS2"
+printf '# x\n' > "$FCORPUS2/x.md"
+out=$( env GRAPHIFY_MAP_BIN="$FAILBIN/graphify" PATH="$FAILBIN:$PATH" \
+  bash "$SCRIPT" --name fail --corpus-root "$FCORPUS2" --backend deepseek \
+  --maps-dir "$FMAPS2" --title "Fail Map" --slug fail-map --corpus-tag fail 2>&1 ); rc=$?
+[ "$rc" -eq 2 ] && pass "T6c failed refresh exits 2" || fail "T6c failed refresh should exit 2 (got $rc): $out"
+FOUT2="$FCORPUS2/graphify-out"
+if [ -e "$FOUT2/manifest.json" ] || [ -e "$FOUT2/.graphify_root" ]; then
+  fail "T6c failed refresh stamped freshness artifacts (must never stamp a failed run as fresh)"
+else
+  pass "T6c failed refresh stamped nothing"
+fi
+
+# --- T6d: idempotent re-run — a second successful refresh rewrites the same
+# artifacts and the guard still PASSES. ---
+# F6 (HIMMEL-907): add a NEW .md between the T6 stamp and this re-run; the
+# re-run manifest must CONTAIN it (refresh semantics — a real re-walk — not mere
+# presence of the old manifest).
+printf '# t6d added\nadded between T6 and the idempotent re-run\n' > "$FCORPUS/notes/t6d-added.md"
+out=$( bash "$SCRIPT" --name fresh --corpus-root "$FCORPUS" --backend deepseek \
+  --maps-dir "$FMAPS" --title "Fresh Map" --slug fresh-map --corpus-tag fresh 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] || fail "T6d idempotent re-run exit 0 (got $rc): $out"
+[ -f "$FOUT/manifest.json" ] && [ -f "$FOUT/.graphify_root" ] && pass "T6d artifacts present after re-run" || fail "T6d artifacts missing after re-run"
+grep -q "t6d-added.md" "$FOUT/manifest.json" 2>/dev/null && pass "T6d/F6 re-run manifest gained the new key (real refresh)" || fail "T6d/F6 re-run manifest missing the new key (stale, not a real rewrite)"
+out=$( bash "$HERE/check-graph-freshness.sh" --out "$FOUT" --max-age-days 7 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] && pass "T6d guard PASSES after idempotent re-run" || fail "T6d guard should PASS after re-run (got rc=$rc): $out"
+
+# --- T6e (HIMMEL-907 F1): manifest.json must come from the SCRATCH corpus the
+# graph actually saw, NOT the live corpus. A graphify stub that, mid --update,
+# ALSO drops a new .md into the LIVE corpus (via MUTATE_TARGET) — the manifest
+# must NOT attest that file: the scratch copy was made before the mutation, so
+# the graph never saw it. RED until the manifest walks the scratch copy. ---
+ECORPUS="$WS/ecorpus"; EMAPS="$WS/emaps"; mkdir -p "$ECORPUS/notes" "$EMAPS"
+printf '# e\nexisting\n' > "$ECORPUS/notes/e.md"
+EBIN="$WS/ebin"; mkdir -p "$EBIN"
+cat > "$EBIN/graphify" <<STUB
+#!/usr/bin/env bash
+# args: either "<path> --update ..." or "cluster-only <path> ..."
+target=""
+if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
+mkdir -p "\$target/graphify-out"
+printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
+$REPORT_FIXTURE
+RPT
+# mid-extraction mutation of the LIVE corpus — the graph (run on the scratch
+# copy) never sees this file, so the manifest must not attest it.
+if [ "\$1" != "cluster-only" ] && [ -n "\$MUTATE_TARGET" ]; then
+  printf '# mutated\nmutated during extraction\n' > "\$MUTATE_TARGET/MUTATED-DURING-EXTRACTION.md"
+fi
+exit 0
+STUB
+chmod +x "$EBIN/graphify"
+out=$( MUTATE_TARGET="$ECORPUS" GRAPHIFY_MAP_BIN="$EBIN/graphify" PATH="$EBIN:$PATH" \
+  bash "$SCRIPT" --name emut --corpus-root "$ECORPUS" --backend deepseek \
+  --maps-dir "$EMAPS" --title "E Map" --slug e-map --corpus-tag e 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] || { fail "T6e mutate-stub refresh exit 0 (got $rc): $out"; }
+if grep -q "MUTATED-DURING-EXTRACTION.md" "$ECORPUS/graphify-out/manifest.json" 2>/dev/null; then
+  fail "T6e manifest attests a file mutated mid-extraction (must walk scratch, not live corpus)"
+else
+  pass "T6e manifest excludes mid-extraction corpus mutation (walks scratch copy)"
+fi
+
+# --- T6f (HIMMEL-907 F2+F3): a python3-less box must fail BEFORE spending
+# extraction money AND before promoting a new graph. Run under a hermetic PATH
+# that carries every tool the script needs EXCEPT python3 (graphify stays an
+# absolute GRAPHIFY_MAP_BIN); pre-seed a sentinel graph.json; assert rc=2, stderr
+# mentions python3, AND the sentinel is UNCHANGED (no promotion happened). RED
+# until the python3 preflight is hoisted above the promote step. ---
+# shellcheck source=../lib/hermetic-path.sh
+# shellcheck disable=SC1091
+. "$HERE/../lib/hermetic-path.sh"
+HBIN="$WS/hbin"; mkdir -p "$HBIN"
+for _tool in bash env find cp mkdir rm mv dirname date cat node; do
+  link_hermetic_tool "$_tool" "$HBIN"
+done
+# Hermetic PATH carrying every tool EXCEPT python3. scrub_path drops every dir
+# that carries python3. On stock Ubuntu python3 shares /usr/bin with bash +
+# coreutils, so the blind scrub takes bash down too — the linked $HBIN stub bin
+# (prepended) restores them there. On Git Bash/MSys python3 lives in a user dir
+# (not /usr/bin), so the scrub leaves the real /usr/bin tools — and the COPIED
+# stubs in $HBIN can't load msys-2.0.dll from the stub dir anyway, so prefer the
+# scrubbed REAL path when it still runs bash; fall back to the stub bin only when
+# the scrub took bash down (probe = actually exec, not just command -v, because a
+# copied-but-DLL-broken bash still resolves via command -v on MSys).
+PYFREE="$(scrub_path "$PATH" python3)"
+HPATH="$HBIN:$PYFREE"
+if PATH="$PYFREE" bash -c 'true' 2>/dev/null; then HPATH="$PYFREE"; fi
+# belt-and-braces: the chosen hermetic PATH must really lack python3.
+if PATH="$HPATH" command -v python3 >/dev/null 2>&1; then
+  fail "T6f hermetic PATH still resolves python3 — scrub did not isolate it"
+fi
+PBIN="$WS/pbin"; mkdir -p "$PBIN"
+cat > "$PBIN/graphify" <<STUB
+#!/usr/bin/env bash
+target=""
+if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
+mkdir -p "\$target/graphify-out"
+printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
+$REPORT_FIXTURE
+RPT
+exit 0
+STUB
+chmod +x "$PBIN/graphify"
+PCORPUS="$WS/pcorpus"; PMAPS="$WS/pmaps"; mkdir -p "$PCORPUS/graphify-out" "$PMAPS"
+printf '# c\ncontent\n' > "$PCORPUS/c.md"
+printf 'SENTINEL-PRE-PYTHON' > "$PCORPUS/graphify-out/graph.json"
+out=$( PATH="$HPATH" GRAPHIFY_MAP_BIN="$PBIN/graphify" \
+  bash "$SCRIPT" --name hpy --corpus-root "$PCORPUS" --backend deepseek \
+  --maps-dir "$PMAPS" --title "H Map" --slug h-map --corpus-tag h 2>&1 ); rc=$?
+[ "$rc" -eq 2 ] && pass "T6f python3-less box exits 2" || fail "T6f python3-less box should exit 2 (got $rc): $out"
+echo "$out" | grep -q "python3" && pass "T6f stderr mentions python3" || fail "T6f stderr should mention python3: $out"
+grep -q "SENTINEL-PRE-PYTHON" "$PCORPUS/graphify-out/graph.json" 2>/dev/null \
+  && pass "T6f sentinel graph.json unchanged (no promotion before python3 check)" \
+  || fail "T6f sentinel graph.json clobbered (promoted before the python3 check)"
+
+# --- T6g (HIMMEL-907 F2/F7): publish-failure semantics. A graphify stub that
+# emits a VALID graph.json but a GARBAGE report (unparseable by the curator) →
+# the run exits NON-ZERO at the publish step, AND the freshness stamps ARE
+# present: the graph itself is fresh (promote + stamp happen before publish), so
+# only the MOC publish failed. Pins F2's invariant that stamps precede publish
+# and survive a publish failure. ---
+GBIN="$WS/gbin"; mkdir -p "$GBIN"
+cat > "$GBIN/graphify" <<STUB
+#!/usr/bin/env bash
+target=""
+if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
+mkdir -p "\$target/graphify-out"
+printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf 'totally unparseable garbage report - no recognizable headers at all\n' > "\$target/graphify-out/GRAPH_REPORT.md"
+exit 0
+STUB
+chmod +x "$GBIN/graphify"
+GCORPUS="$WS/gcorpus"; GMAPS="$WS/gmaps"; mkdir -p "$GCORPUS/notes" "$GMAPS"
+printf '# g\ncontent\n' > "$GCORPUS/notes/g.md"
+out=$( GRAPHIFY_MAP_BIN="$GBIN/graphify" PATH="$GBIN:$PATH" \
+  bash "$SCRIPT" --name gbg --corpus-root "$GCORPUS" --backend deepseek \
+  --maps-dir "$GMAPS" --title "G Map" --slug g-map --corpus-tag g 2>&1 ); rc=$?
+[ "$rc" -ne 0 ] && pass "T6g garbage report → non-zero exit at publish" || fail "T6g garbage report should exit non-zero (got $rc): $out"
+GOUT="$GCORPUS/graphify-out"
+if [ -f "$GOUT/manifest.json" ] && [ -f "$GOUT/.graphify_root" ]; then
+  pass "T6g freshness stamps present despite publish failure (graph is fresh)"
+else
+  fail "T6g freshness stamps missing after publish failure (F2 stamp-before-publish broke)"
+fi
 
 if [ "$FAILS" -ne 0 ]; then echo "$FAILS FAILURES"; exit 1; fi
 echo "ALL PASS"


### PR DESCRIPTION
## Summary
- [HIMMEL-907 follow-up] The check-graph-freshness guard (#1110) could not verify the real luna graph — refresh-graph-map.sh never wrote manifest.json / .graphify_root. Now a SUCCESSFUL refresh stamps both (manifest keys = corpus-relative md paths; values {mtime:int} provenance only — the guard parses keys).
- CR round 1 (codex adversarial, 2 HIGHs — both fixed with RED-first tests): manifest is walked from the SCRATCH corpus the graph was actually built from (not the live corpus post-hoc), and promotion is transactional — build manifest tmp → invalidate old stamps → promote graph/report → stamp → clean scratch. Any interruption leaves a stamp-less dir the guard rejects (fail-closed). python3 preflight hoisted before paid extraction.
- Test pins per pr-test-analyzer: --no-update never stamps, graphify-out pruned from manifest keys, idempotent re-run genuinely REWRITES, publish-failure keeps stamps.

## Verification
- refresh suite 28/0, freshness suite 13/0 (guard untouched), shellcheck clean; independently re-run by the orchestrator.
- CR: panel 0C/0I; code-reviewer 0C/0I; pr-test-analyzer 3 Importants (all pinned); codex adversarial round-2 finding (concurrent-refresh interleave) adjudicated PRE-EXISTING → filed as HIMMEL-910. Private PR #1115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
