### PR TITLE
feat(graphify): [HIMMEL-891] fork + install-from-fork wiring (SHA-pinned, foreign-install-safe)

### DIFF
--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -25,6 +25,11 @@
 #   -DryRun           Print actions instead of doing them.
 #   -FillEnv          Interactively fill the himmel clone's .env (creates it from
 #                     .env.example if absent). Needs Git Bash. Enter to skip a var.
+#   -WithGraphify     Opt in to installing the graphify knowledge-graph CLI
+#                     (himmel fork) during a `core`/`all` adopt. Off by
+#                     default -- the adoption verdict stays open (HIMMEL-621);
+#                     this switch only installs the CLI (never over an
+#                     existing foreign install -- see scripts/lib/graphify-bin.sh).
 #
 # Idempotent: re-running adds nothing already present.
 
@@ -37,7 +42,8 @@ param(
     [string]$Target,
     [string]$LunaTarget,
     [switch]$DryRun,
-    [switch]$FillEnv
+    [switch]$FillEnv,
+    [switch]$WithGraphify
 )
 
 $ErrorActionPreference = 'Stop'
@@ -427,6 +433,65 @@ function Wire-QmdCoreInner {
     }
 }
 
+# Delegates to the ONE detect/install implementation (HIMMEL-891):
+# `bash scripts/lib/graphify-bin.sh install` (uv-tool-installs graphify from
+# the himmel fork, UNLESS an existing install -- himmel-fork or foreign -- is
+# already present, in which case it is adopted as-is). Reuses
+# Resolve-QmdGitBash (generic bash resolution, not qmd-specific despite the
+# name). Returns an honest int rc.
+function Install-Graphify {
+    Write-Host "Installing graphify via bash scripts/lib/graphify-bin.sh..."
+    $gitBash = Resolve-QmdGitBash
+    if (-not $gitBash) {
+        Write-Host "  WARNING: Git Bash not found - cannot run the graphify installer." -ForegroundColor Yellow
+        Write-Host "  Manual: install Git for Windows, then run: bash `"$HimmelRoot/scripts/lib/graphify-bin.sh`" install" -ForegroundColor Yellow
+        return 1
+    }
+    # Route the bash script's stdout through Write-Host (host stream, not the
+    # pipeline) instead of letting it fall straight into the function's own
+    # output -- otherwise `$installRc = Install-Graphify` captures an ARRAY
+    # (every emitted line + the trailing int), and `-ne 0` on that array is
+    # true whenever ANY element is nonzero-ish -- a false-positive WARNING on
+    # every successful install that prints output (which is all of them).
+    & $gitBash "$HimmelRoot/scripts/lib/graphify-bin.sh" install | ForEach-Object { Write-Host $_ }
+    return $LASTEXITCODE
+}
+
+# Wire-GraphifyCore -- opt-in install of the graphify knowledge-graph CLI
+# (HIMMEL-891). Unlike Wire-QmdCore, this is NOT called unconditionally --
+# Do-Core below only calls it when -WithGraphify was passed. WARN-not-fail:
+# a missing Git Bash/uv or a network hiccup must not abort adopt. Honors
+# -DryRun.
+function Wire-GraphifyCore {
+    Write-Host "---- Wiring graphify (opt-in, -WithGraphify) ----"
+    if ($DryRun) {
+        Write-Host "DRY: Install-Graphify"
+        return
+    }
+    # WARN-not-fail structural guarantee (CR-r2): under this script's
+    # EAP='Stop', a $PSNativeCommandUseErrorActionPreference=$true config
+    # turns the bash installer's nonzero exit into a TERMINATING error
+    # before Install-Graphify can return $LASTEXITCODE -- aborting the whole
+    # adopt on an optional step. Decouple both for this block only; restore
+    # in finally (same guard as Wire-QmdCore / Build-JiraCli).
+    $savedNativeEAP = $null
+    if (Test-Path variable:PSNativeCommandUseErrorActionPreference) {
+        $savedNativeEAP = $PSNativeCommandUseErrorActionPreference
+    }
+    $global:PSNativeCommandUseErrorActionPreference = $false
+    $savedEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $installRc = Install-Graphify
+        if ($installRc -ne 0) {
+            Write-Host "  WARNING: graphify install failed (rc=$installRc) - continuing without graphify." -ForegroundColor Yellow
+        }
+    } finally {
+        $ErrorActionPreference = $savedEAP
+        if ($null -ne $savedNativeEAP) { $global:PSNativeCommandUseErrorActionPreference = $savedNativeEAP }
+    }
+}
+
 # Build-JiraCli -- build scripts/jira/dist/index.js (HIMMEL-842 gap 3). dist/ is
 # a gitignored build artifact, so a fresh clone bootstrapped via adopt.ps1 hits
 # MODULE_NOT_FOUND without this (CLAUDE.md's "worktrees lack dist/" warning is
@@ -512,6 +577,7 @@ function Do-Core {
     Install-Plugins
     Build-JiraCli
     Wire-QmdCore
+    if ($WithGraphify) { Wire-GraphifyCore }
     Wire-StatuslineCore
     Wire-HimmelRepoCore
     if ($FillEnv) { FillEnv-Core }

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -31,6 +31,11 @@
 #   --dry-run           Print actions instead of doing them.
 #   --fill-env          Interactively fill the himmel clone's .env (creates it
 #                       from .env.example if absent). Enter to skip a var.
+#   --with-graphify     Opt in to installing the graphify knowledge-graph CLI
+#                       (himmel fork) during a `core`/`all` adopt. Off by
+#                       default — the adoption verdict stays open (HIMMEL-621);
+#                       this flag only installs the CLI (never over an
+#                       existing foreign install — see scripts/lib/graphify-bin.sh).
 #
 # Idempotent: re-running adds nothing already present.
 set -euo pipefail
@@ -51,6 +56,14 @@ HIMMEL_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/qmd-bin.sh"
 
+# graphify resolver (HIMMEL-891). Provides has_graphify / graphify_install /
+# graphify_source / graphify_install_hint, consumed by wire_graphify_core()
+# (opt-in via --with-graphify — unlike qmd, graphify is NOT wired by default;
+# the adoption verdict stays open, HIMMEL-621).
+# shellcheck source=scripts/lib/graphify-bin.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/graphify-bin.sh"
+
 # Adopter preflight checks (HIMMEL-842). Provides the shared WARN-not-fail
 # checks (uv/pipx, npm-less-node, jira-dist) consumed by require_tools() below.
 # The standalone scripts/preflight-adopter.sh runner sources the same lib, so the
@@ -67,17 +80,19 @@ LUNA_TARGET=""
 LUNA_TARGET_SET=0
 DRY_RUN=0
 FILL_ENV=0
+WITH_GRAPHIFY=0
 
 # ── Parse args ───────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --profile)      PROFILE="$2"; shift 2 ;;
-    --scope)        SCOPE="$2"; shift 2 ;;
-    --target)       TARGET="$2"; shift 2 ;;
-    --luna-target)  LUNA_TARGET="$2"; LUNA_TARGET_SET=1; shift 2 ;;
-    --dry-run)      DRY_RUN=1; shift ;;
-    --fill-env)     FILL_ENV=1; shift ;;
-    -h|--help)      sed -n '2,/^set -e/p' "$0" | sed 's/^# \{0,1\}//' | sed '$d'; exit 0 ;;
+    --profile)        PROFILE="$2"; shift 2 ;;
+    --scope)          SCOPE="$2"; shift 2 ;;
+    --target)         TARGET="$2"; shift 2 ;;
+    --luna-target)    LUNA_TARGET="$2"; LUNA_TARGET_SET=1; shift 2 ;;
+    --dry-run)        DRY_RUN=1; shift ;;
+    --fill-env)       FILL_ENV=1; shift ;;
+    --with-graphify)  WITH_GRAPHIFY=1; shift ;;
+    -h|--help)        sed -n '2,/^set -e/p' "$0" | sed 's/^# \{0,1\}//' | sed '$d'; exit 0 ;;
     *) echo "ERROR: unknown flag: $1" >&2; exit 2 ;;
   esac
 done
@@ -300,6 +315,21 @@ wire_qmd_core() {
   fi
 }
 
+# wire_graphify_core — opt-in install of the graphify knowledge-graph CLI
+# (HIMMEL-891). Unlike wire_qmd_core, this is NOT called unconditionally —
+# do_core() below only calls it when --with-graphify was passed. Detects +
+# adopts a foreign or already-himmel-fork install (graphify_install's own
+# contract); never installs over an existing install. WARN-not-fail: a
+# missing uv or a network hiccup must not abort adopt. Honors --dry-run.
+wire_graphify_core() {
+  echo "──── Wiring graphify (opt-in, --with-graphify) ────"
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "DRY: graphify_install"
+    return 0
+  fi
+  graphify_install || echo "  WARNING: graphify install failed — continuing without graphify." >&2
+}
+
 # build_jira_cli — build scripts/jira/dist/index.js (HIMMEL-842 gap 3). dist/ is
 # a gitignored build artifact, so a fresh clone bootstrapped via adopt.sh hits
 # MODULE_NOT_FOUND without this (CLAUDE.md's "worktrees lack dist/" warning is
@@ -373,6 +403,7 @@ do_core() {
   install_plugins
   build_jira_cli
   wire_qmd_core
+  [[ $WITH_GRAPHIFY -eq 1 ]] && wire_graphify_core
   wire_statusline_core
   wire_himmel_repo_core
   [[ $FILL_ENV -eq 1 ]] && fill_env_core

--- a/scripts/lib/graphify-bin.sh
+++ b/scripts/lib/graphify-bin.sh
@@ -1,0 +1,191 @@
+# shellcheck shell=bash
+# scripts/lib/graphify-bin.sh
+#
+# Resolver for the graphify CLI (HIMMEL-891). graphify is a knowledge-graph
+# tool distributed via PyPI as `graphifyy` (binary name `graphify`, upstream
+# Graphify-Labs/graphify, MIT). This resolver installs it from the himmel
+# fork (yotamleo/graphify, pinned to a full commit SHA; himmel-main is the
+# fork's tracking branch — HIMMEL-891 plumbing; the ADOPTION VERDICT stays
+# open under HIMMEL-621) via
+# `uv tool install --from git+<fork>@<pinned-sha> graphifyy`. uv tool installs
+# are already self-isolating (their own venv + a shim in uv's tool bin dir),
+# so — unlike scripts/lib/qmd-bin.sh's bun-global junction — there is no
+# separate PATH-provider step here: the shim lands in uv's tool bin dir,
+# which setup.sh/adopt.sh already put on PATH for uv/pre-commit/jira.
+#
+# Foreign-install safety (operator requirement, 2026-07-11): before
+# installing, detect whether graphify is ALREADY present — either as a
+# `uv tool list` entry for graphifyy, or as any `graphify` resolved on PATH
+# by another means (pip, pipx, homebrew, manual build, ...). An existing
+# install is ADOPTED as-is and never reinstalled, shadowed, or duplicated.
+# graphify_source() reports which case applies (see below) so callers can
+# log provenance. Install-if-missing only.
+#
+# graphify_install() is idempotent: it re-checks graphify_source() first and
+# skips cleanly whenever ANY install is already present (himmel-fork or
+# foreign) — it only ever installs into a genuinely empty slot. Adopted
+# installs must also RESOLVE (CR-r2): uv metadata with no working binary
+# (stale receipt, missing shim, uv tool bin dir off PATH) WARNs with the
+# remediation and returns nonzero — never a silent success, and never an
+# auto-reinstall over existing uv metadata (that could clobber a foreign
+# install's state).
+#
+# Fork repo/ref are overridable via GRAPHIFY_FORK_REPO / GRAPHIFY_FORK_REF
+# for testing or a private mirror (mirrors QMD_FORK_REPO/QMD_FORK_BRANCH).
+
+# Fork config -- overridable per call (env var set before sourcing/calling).
+#
+# PIN (HIMMEL-891 CR-1/CR-r3): the install ref is a FULL COMMIT SHA on the
+# fork -- not the himmel-main branch, and not a tag either. A mutable branch
+# (or a force-moved tag: tags are NOT immutable) is a supply-chain trust
+# boundary on new-machine bootstrap: anyone who can move the ref moves what
+# every future `setup.sh --with-graphify` installs, silently. The commit SHA
+# is the only content-addressed, unmovable ref -- and unlike the marketplace
+# installer (tag/branch names only, hence claude-obsidian's tag pin),
+# `uv tool install --from git+...` resolves commit revs, so the stricter pin
+# is available here. The fork tag v0.9.13-himmel.1 points at this same
+# commit as human-readable release provenance. himmel-main stays the fork's
+# TRACKING branch (where upstream merges land); a pin bump is a reviewed
+# change to this file.
+_graphify_fork_repo() { printf '%s\n' "${GRAPHIFY_FORK_REPO:-https://github.com/yotamleo/graphify}"; }
+# = v0.9.13-himmel.1
+_graphify_fork_ref() { printf '%s\n' "${GRAPHIFY_FORK_REF:-df74ab44817d3b7f8ecafb333ec99899fe634f9d}"; }
+_graphify_pinned_source() { printf 'git+%s@%s\n' "$(_graphify_fork_repo)" "$(_graphify_fork_ref)"; }
+_graphify_pypi_name() { printf '%s\n' "graphifyy"; }
+_graphify_bin_name() { printf '%s\n' "graphify"; }
+
+# Prints the manual install recipe (best-effort documentation text embedded
+# in WARN messages -- NOT eval'd elsewhere; graphify_install() below runs the
+# equivalent command directly).
+graphify_install_hint() {
+  printf '%s\n' "uv tool install --from $(_graphify_pinned_source) $(_graphify_pypi_name)"
+}
+
+# Presence check ONLY -- does not invoke the binary, so a real runtime error
+# reaches the caller instead of being masked as "graphify not installed".
+has_graphify() {
+  command -v "$(_graphify_bin_name)" >/dev/null 2>&1
+}
+
+# Resolve the uv tool directory (where per-tool venvs + receipts live).
+# Falls back to uv's documented default when `uv tool dir` itself is
+# unavailable (uv missing, or the subcommand errors) -- best-effort only,
+# used solely to look up an existing receipt for provenance, never to
+# decide whether uv itself is usable.
+_graphify_uv_tool_dir() {
+  local d
+  if command -v uv >/dev/null 2>&1; then
+    d="$(uv tool dir 2>/dev/null)" && [ -n "$d" ] && { printf '%s\n' "$d"; return 0; }
+  fi
+  printf '%s\n' "$HOME/.local/share/uv/tools"
+}
+
+# True if `uv tool list` shows the graphifyy package installed.
+_graphify_uv_has_package() {
+  command -v uv >/dev/null 2>&1 || return 1
+  uv tool list 2>/dev/null | grep -qE "^$(_graphify_pypi_name)([[:space:]]|\$)"
+}
+
+# Reports the provenance of an existing graphify install:
+#   "himmel-fork"  -- installed via uv from THIS fork at THIS pinned ref
+#   "foreign"      -- installed some other way (uv from elsewhere, uv from
+#                     the same repo at a DIFFERENT ref, pip, pipx, homebrew,
+#                     manual build, ...)
+#   ""             -- not installed at all (rc 1)
+# himmel-fork requires the receipt to carry BOTH the fork repo URL AND the
+# pinned ref, each matched as a FIXED string (grep -qF -- no regex surprises
+# from dots in URLs/versions, and a same-repo-different-ref install
+# classifies as foreign, CR-2). Two separate fixed-string probes rather than
+# one `git+<url>@<ref>` match because uv serializes git sources into the
+# receipt as separate keys (git = "<url>", rev = "<ref>") -- the combined
+# literal never appears there. The receipt check is best-effort (a missing/
+# unreadable receipt for a uv-managed graphifyy install is treated as
+# foreign, never as "not installed" -- the package IS present, we just
+# can't prove the source).
+graphify_source() {
+  local tool_dir receipt
+  if _graphify_uv_has_package; then
+    tool_dir="$(_graphify_uv_tool_dir)"
+    receipt="$tool_dir/$(_graphify_pypi_name)/uv-receipt.toml"
+    if [ -f "$receipt" ] \
+       && grep -qF "$(_graphify_fork_repo)" "$receipt" 2>/dev/null \
+       && grep -qF "$(_graphify_fork_ref)" "$receipt" 2>/dev/null; then
+      printf '%s\n' "himmel-fork"
+    else
+      printf '%s\n' "foreign"
+    fi
+    return 0
+  fi
+  if has_graphify; then
+    printf '%s\n' "foreign"
+    return 0
+  fi
+  printf '%s\n' ""
+  return 1
+}
+
+# Install graphify from the himmel fork via `uv tool install`, UNLESS an
+# install is already present (adopt it instead -- see graphify_source()
+# above). Returns an honest rc: 0 when graphify ends up resolvable one way
+# or another (adopted or freshly installed), nonzero on a genuine failure.
+# WARN-not-fail by contract -- callers (setup.sh/adopt.sh + pwsh mirrors)
+# decide whether a graphify failure aborts; this function only reports.
+graphify_install() {
+  local src
+
+  # graphify_source returns rc 1 on "not installed" -- harmless here (empty
+  # src falls through to the install path), but guard it so a caller running
+  # under `set -e` without an || context can never abort on the probe (CR-6).
+  src="$(graphify_source)" || true
+  case "$src" in
+    himmel-fork|foreign)
+      if has_graphify; then
+        if [ "$src" = "himmel-fork" ]; then
+          echo "  graphify already installed (source=himmel-fork) -- skipping install."
+        else
+          echo "  graphify already installed (source=foreign) -- adopting the existing install, not installing over it."
+        fi
+        return 0
+      fi
+      # CR-r2: install metadata exists but the binary does not resolve
+      # (stale receipt, missing shim, uv tool bin dir off PATH). Do NOT
+      # auto-reinstall over existing uv metadata -- that could clobber a
+      # foreign install's state. WARN with the remediation + honest nonzero;
+      # callers are WARN-and-continue by contract.
+      echo "  WARNING: graphify install metadata found (source=$src) but '$(_graphify_bin_name)' is not resolvable on PATH." >&2
+      echo "  uv drops its shims in the uv tool bin dir -- check it is on PATH (uv tool update-shell)." >&2
+      echo "  Not reinstalling over the existing uv install -- fix PATH, or reinstall manually: $(graphify_install_hint)" >&2
+      return 1
+      ;;
+  esac
+
+  echo "Installing graphify ($(_graphify_pinned_source))..."
+  if ! command -v uv >/dev/null 2>&1; then
+    echo "  uv not found -- cannot install graphify." >&2
+    return 1
+  fi
+  if ! uv tool install --from "$(_graphify_pinned_source)" "$(_graphify_pypi_name)"; then
+    echo "  ERROR: graphify install failed." >&2
+    return 1
+  fi
+
+  if has_graphify; then
+    echo "  graphify installed and verified (source=himmel-fork)."
+    return 0
+  fi
+  echo "  WARNING: graphify installed but '$(_graphify_bin_name)' is still not resolvable on PATH." >&2
+  echo "  uv drops its shims in the uv tool bin dir -- check it is on PATH (uv tool update-shell)." >&2
+  return 1
+}
+
+# CLI entry -- only when EXECUTED (not sourced). Lets the pwsh mirrors
+# (scripts/setup.ps1, scripts/adopt.ps1) delegate to this ONE implementation
+# (`bash scripts/lib/graphify-bin.sh install`) instead of duplicating the
+# detect/install recipe natively (mirrors qmd-bin.sh's CLI entry, HIMMEL-877).
+if [ "${BASH_SOURCE[0]:-}" = "${0:-}" ]; then
+  case "${1:-}" in
+    install) graphify_install ;;
+    source)  graphify_source ;;
+    *) echo "Usage: bash scripts/lib/graphify-bin.sh install|source" >&2; exit 2 ;;
+  esac
+fi

--- a/scripts/lib/test-graphify-bin.sh
+++ b/scripts/lib/test-graphify-bin.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# scripts/lib/test-graphify-bin.sh — smoke test for graphify-bin.sh resolver
+# (HIMMEL-891).
+#
+# Hermetic: the operator machine already carries a REAL `uv tool install
+# graphifyy` (v0.9.10, per HIMMEL-891 context) — every scenario below scrubs
+# any PATH dir carrying a real `uv` or `graphify` (scripts/lib/hermetic-path.sh
+# scrub_path) before layering in a stub `uv` (argv-logging to a file, behavior
+# controlled by env vars) ahead of it. No network, no real installs.
+#
+# Validates:
+#   1. graphify_install_hint emits the uv-tool-install recipe pinned to a
+#      full commit SHA, never a movable branch/tag (+ REPO/REF overrides;
+#      the 40-hex pin policy has its own dedicated assertion).
+#   2. has_graphify is presence-only.
+#   3. missing -> exactly one `uv tool install` call; graphify then resolvable.
+#   4. idempotent re-run -> still exactly one call total (skip, adopt as
+#      himmel-fork).
+#   5. foreign install (uv tool list shows graphifyy from elsewhere, OR the
+#      same repo at a DIFFERENT ref, OR a receipt-less uv package, OR a bare
+#      PATH-resolved graphify with no uv package at all) -> adopted, ZERO
+#      install calls, every way.
+#   6. no uv on PATH / install failure / installed-but-unresolvable -> WARN +
+#      honest nonzero rc, never crashes.
+#   7. consumer wiring — setup.sh/adopt.sh source graphify-bin.sh and call
+#      graphify_install (regression guard for the opt-in wiring itself).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib/graphify-bin.sh
+. "$SCRIPT_DIR/graphify-bin.sh"
+# shellcheck source=scripts/lib/hermetic-path.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/hermetic-path.sh"
+
+pass=0
+fail=0
+assert() {
+  local desc="$1"; shift
+  if "$@"; then
+    pass=$((pass+1))
+    echo "  ok: $desc"
+  else
+    fail=$((fail+1))
+    echo "  FAIL: $desc"
+  fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Base PATH carrying neither a real `uv` nor a real `graphify`.
+base_path="$(scrub_path "$PATH" uv graphify)"
+
+echo "[test-graphify-bin] graphify_install_hint (HIMMEL-891)"
+hint="$(graphify_install_hint)"
+assert "hint uses uv tool install" grep -q '^uv tool install ' <<<"$hint"
+assert "hint mentions the himmel fork repo" grep -q 'yotamleo/graphify' <<<"$hint"
+assert "hint pins a full commit SHA (CR-r3), not a movable ref" grep -qE '@[0-9a-f]{40} ' <<<"$hint"
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "hint does NOT install from the mutable himmel-main branch" \
+  bash -c '! grep -q "@himmel-main" <<<"$1"' _ "$hint"
+assert "hint mentions the graphifyy package" grep -q 'graphifyy$' <<<"$hint"
+
+echo "[test-graphify-bin] pin policy (CR-r3): the configured ref IS a full 40-hex commit SHA"
+# Tags/branches are force-movable; only a commit SHA is content-addressed.
+# This pins the POLICY so a future 'bump the pin' change that swaps in a tag
+# or branch name fails here. (Run with the env override cleared -- the test
+# targets the committed default.)
+default_ref="$(env -u GRAPHIFY_FORK_REF bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; _graphify_fork_ref')"
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "default GRAPHIFY_FORK_REF is a full 40-hex SHA" \
+  bash -c 'printf "%s" "$1" | grep -qE "^[0-9a-f]{40}$"' _ "$default_ref"
+
+echo "[test-graphify-bin] GRAPHIFY_FORK_REPO / GRAPHIFY_FORK_REF overrides"
+override_hint="$(GRAPHIFY_FORK_REPO=https://example.test/mirror/graphify GRAPHIFY_FORK_REF=my-ref graphify_install_hint)"
+assert "hint honors GRAPHIFY_FORK_REPO override" grep -q 'example.test/mirror/graphify' <<<"$override_hint"
+assert "hint honors GRAPHIFY_FORK_REF override" grep -q 'my-ref' <<<"$override_hint"
+
+echo "[test-graphify-bin] has_graphify is presence-only"
+noreal_home="$tmpdir/noreal"; mkdir -p "$noreal_home"
+rc=0
+PATH="$base_path" HOME="$noreal_home" bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; has_graphify' || rc=$?
+assert "has_graphify=false with no graphify on PATH" test "$rc" -ne 0
+
+# ── Stub uv: logs every call to UV_LOG; `tool list` echoes UV_LIST_FILE;
+#    `tool dir` echoes UV_TOOL_DIR; `tool install --from <url> graphifyy`
+#    writes a matching uv-receipt.toml under UV_TOOL_DIR, appends to
+#    UV_LIST_FILE, and drops a working `graphify` shim into UV_BIN_DIR
+#    (simulating uv's own tool-bin-dir shim) unless STUB_UV_INSTALL_RC != 0.
+stub_dir="$tmpdir/stub"
+mkdir -p "$stub_dir/bin"
+cat > "$stub_dir/bin/uv" <<'STUB'
+#!/usr/bin/env bash
+echo "UV $*" >> "${UV_LOG:?}"
+if [ "$1" = "tool" ] && [ "$2" = "list" ]; then
+  [ -f "${UV_LIST_FILE:?}" ] && cat "$UV_LIST_FILE"
+  exit 0
+fi
+if [ "$1" = "tool" ] && [ "$2" = "dir" ]; then
+  printf '%s\n' "${UV_TOOL_DIR:?}"
+  exit 0
+fi
+if [ "$1" = "tool" ] && [ "$2" = "install" ]; then
+  [ "${STUB_UV_INSTALL_RC:-0}" -eq 0 ] || exit "${STUB_UV_INSTALL_RC}"
+  mkdir -p "${UV_TOOL_DIR:?}/graphifyy"
+  # $3=--from $4=<git+url@ref> $5=graphifyy — matches graphify_install()'s
+  # exact argv shape. Write the receipt in uv's REAL serialization (git and
+  # rev as SEPARATE keys, no combined git+url@ref literal) so the provenance
+  # probes are exercised against what a real install leaves behind (CR-2).
+  src="${4#git+}"
+  printf 'requirements = [{ name = "graphifyy", git = "%s", rev = "%s" }]\n' \
+    "${src%@*}" "${src##*@}" > "${UV_TOOL_DIR}/graphifyy/uv-receipt.toml"
+  printf 'graphifyy v0.0.0-test\n' >> "${UV_LIST_FILE:?}"
+  mkdir -p "${UV_BIN_DIR:?}"
+  cat > "${UV_BIN_DIR}/graphify" <<'INNER'
+#!/usr/bin/env bash
+echo "GRAPHIFY STUB $*"
+INNER
+  chmod +x "${UV_BIN_DIR}/graphify"
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$stub_dir/bin/uv"
+
+echo "[test-graphify-bin] missing -> exactly one uv install call; then idempotent re-run"
+fresh_home="$tmpdir/fresh"; mkdir -p "$fresh_home"
+fresh_tools="$tmpdir/fresh-tools"; mkdir -p "$fresh_tools"
+fresh_list="$tmpdir/fresh-list"; : > "$fresh_list"
+fresh_bin="$tmpdir/fresh-bin"; mkdir -p "$fresh_bin"
+fresh_log="$tmpdir/fresh-uvlog"; : > "$fresh_log"
+fresh_path="$fresh_bin:$stub_dir/bin:$base_path"
+
+out=$(HOME="$fresh_home" PATH="$fresh_path" UV_TOOL_DIR="$fresh_tools" UV_LIST_FILE="$fresh_list" \
+      UV_BIN_DIR="$fresh_bin" UV_LOG="$fresh_log" \
+      bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_install; echo "RC=$?"' 2>&1)
+assert "missing: rc 0" grep -q '^RC=0$' <<<"$out"
+assert "missing: exactly one uv tool install call" test "$(grep -c 'UV tool install' "$fresh_log")" -eq 1
+assert "missing: graphify shim landed on PATH" test -x "$fresh_bin/graphify"
+assert "missing: has_graphify true post-install" \
+  bash -c 'PATH="'"$fresh_path"'" HOME="'"$fresh_home"'" . "'"$SCRIPT_DIR"'/graphify-bin.sh"; has_graphify'
+
+out2=$(HOME="$fresh_home" PATH="$fresh_path" UV_TOOL_DIR="$fresh_tools" UV_LIST_FILE="$fresh_list" \
+       UV_BIN_DIR="$fresh_bin" UV_LOG="$fresh_log" \
+       bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_install; echo "RC=$?"' 2>&1)
+assert "idempotent re-run: rc 0" grep -q '^RC=0$' <<<"$out2"
+assert "idempotent re-run: reports adopted himmel-fork" grep -q 'source=himmel-fork' <<<"$out2"
+assert "idempotent re-run: still exactly one install call total" test "$(grep -c 'UV tool install' "$fresh_log")" -eq 1
+
+echo "[test-graphify-bin] foreign uv-list entry, binary NOT resolvable -> WARN + nonzero, no install (CR-r2)"
+# uv metadata says graphifyy is installed (foreign receipt) but NO graphify
+# resolves on PATH (stale receipt / missing shim / uv bin dir off PATH).
+# Adopting that silently would report success for a broken install; the
+# adopted path must require has_graphify and answer WARN + honest nonzero --
+# and still never auto-reinstall over the foreign uv metadata.
+funiv_home="$tmpdir/foreignuv"; mkdir -p "$funiv_home"
+funiv_tools="$tmpdir/foreignuv-tools"; mkdir -p "$funiv_tools/graphifyy"
+printf 'requirements = ["graphifyy==1.2.3"]\n' > "$funiv_tools/graphifyy/uv-receipt.toml"
+funiv_list="$tmpdir/foreignuv-list"; printf 'graphifyy v1.2.3\n' > "$funiv_list"
+funiv_log="$tmpdir/foreignuv-uvlog"; : > "$funiv_log"
+funiv_path="$stub_dir/bin:$base_path"
+
+out=$(HOME="$funiv_home" PATH="$funiv_path" UV_TOOL_DIR="$funiv_tools" UV_LIST_FILE="$funiv_list" \
+      UV_BIN_DIR="$tmpdir/foreignuv-bin" UV_LOG="$funiv_log" \
+      bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_install; echo "RC=$?"' 2>&1)
+assert "foreign(uv-list, unresolvable): rc nonzero" grep -qv '^RC=0$' <<<"$out"
+assert "foreign(uv-list, unresolvable): WARNs 'not resolvable on PATH'" grep -qi 'not resolvable on PATH' <<<"$out"
+assert "foreign(uv-list, unresolvable): names source=foreign" grep -q 'source=foreign' <<<"$out"
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "foreign(uv-list, unresolvable): no install call (never reinstall over uv metadata)" \
+  bash -c '! grep -q "tool install" "$1"' _ "$funiv_log"
+
+echo "[test-graphify-bin] foreign uv-list entry, binary resolvable -> adopted rc 0, no install"
+# Same foreign uv metadata, but a working graphify IS on PATH -> clean adopt.
+funivok_bin="$tmpdir/foreignuv-okbin"; mkdir -p "$funivok_bin"
+cat > "$funivok_bin/graphify" <<'EOF'
+#!/usr/bin/env bash
+echo "FOREIGN UV GRAPHIFY $*"
+EOF
+chmod +x "$funivok_bin/graphify"
+: > "$funiv_log"
+out=$(HOME="$funiv_home" PATH="$funivok_bin:$funiv_path" UV_TOOL_DIR="$funiv_tools" UV_LIST_FILE="$funiv_list" \
+      UV_BIN_DIR="$tmpdir/foreignuv-bin" UV_LOG="$funiv_log" \
+      bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_install; echo "RC=$?"' 2>&1)
+assert "foreign(uv-list, resolvable): rc 0" grep -q '^RC=0$' <<<"$out"
+assert "foreign(uv-list, resolvable): reports source=foreign adopt" grep -q 'source=foreign' <<<"$out"
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "foreign(uv-list, resolvable): no install call" bash -c '! grep -q "tool install" "$1"' _ "$funiv_log"
+
+echo "[test-graphify-bin] foreign install via bare PATH graphify (no uv package) -> adopted, no install"
+funpath_home="$tmpdir/foreignpath"; mkdir -p "$funpath_home"
+funpath_bin="$tmpdir/foreignpath-bin"; mkdir -p "$funpath_bin"
+cat > "$funpath_bin/graphify" <<'EOF'
+#!/usr/bin/env bash
+echo "FOREIGN GRAPHIFY $*"
+EOF
+chmod +x "$funpath_bin/graphify"
+funpath_list="$tmpdir/foreignpath-list"; : > "$funpath_list"
+funpath_log="$tmpdir/foreignpath-uvlog"; : > "$funpath_log"
+funpath_path="$funpath_bin:$stub_dir/bin:$base_path"
+
+out=$(HOME="$funpath_home" PATH="$funpath_path" UV_TOOL_DIR="$tmpdir/foreignpath-tools" UV_LIST_FILE="$funpath_list" \
+      UV_BIN_DIR="$tmpdir/foreignpath-bin2" UV_LOG="$funpath_log" \
+      bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_install; echo "RC=$?"' 2>&1)
+assert "foreign(PATH): rc 0" grep -q '^RC=0$' <<<"$out"
+assert "foreign(PATH): reports source=foreign" grep -q 'source=foreign' <<<"$out"
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "foreign(PATH): no install call" bash -c '! grep -q "tool install" "$1"' _ "$funpath_log"
+assert "foreign(PATH): has_graphify true (adopted binary resolvable)" \
+  bash -c 'PATH="'"$funpath_path"'" HOME="'"$funpath_home"'" . "'"$SCRIPT_DIR"'/graphify-bin.sh"; has_graphify'
+
+echo "[test-graphify-bin] graphify_source direct receipt match -> himmel-fork"
+fork_home="$tmpdir/forkdirect"; mkdir -p "$fork_home"
+fork_tools="$tmpdir/forkdirect-tools"; mkdir -p "$fork_tools/graphifyy"
+printf 'requirements = [{ name = "graphifyy", git = "https://github.com/yotamleo/graphify", rev = "df74ab44817d3b7f8ecafb333ec99899fe634f9d" }]\n' \
+  > "$fork_tools/graphifyy/uv-receipt.toml"
+fork_list="$tmpdir/forkdirect-list"; printf 'graphifyy v0.9.13\n' > "$fork_list"
+src=$(UV_TOOL_DIR="$fork_tools" UV_LIST_FILE="$fork_list" UV_LOG="$tmpdir/forkdirect-log" \
+      PATH="$stub_dir/bin:$base_path" HOME="$fork_home" \
+      bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_source')
+assert "direct receipt match (real uv git/rev serialization) -> himmel-fork" test "$src" = "himmel-fork"
+# CR-r2: the SAME himmel-fork metadata with no resolvable binary must not
+# report success either -- WARN + nonzero, zero install calls.
+fork_log="$tmpdir/forkdirect-uvlog"; : > "$fork_log"
+out=$(HOME="$fork_home" PATH="$stub_dir/bin:$base_path" UV_TOOL_DIR="$fork_tools" UV_LIST_FILE="$fork_list" \
+      UV_BIN_DIR="$tmpdir/forkdirect-bin" UV_LOG="$fork_log" \
+      bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_install; echo "RC=$?"' 2>&1)
+assert "himmel-fork metadata, unresolvable: rc nonzero" grep -qv '^RC=0$' <<<"$out"
+assert "himmel-fork metadata, unresolvable: WARNs 'not resolvable on PATH'" grep -qi 'not resolvable on PATH' <<<"$out"
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "himmel-fork metadata, unresolvable: no install call" bash -c '! grep -q "tool install" "$1"' _ "$fork_log"
+
+echo "[test-graphify-bin] same repo, DIFFERENT ref -> foreign (CR-2: provenance = exact pin)"
+sameref_home="$tmpdir/samerepo"; mkdir -p "$sameref_home"
+sameref_tools="$tmpdir/samerepo-tools"; mkdir -p "$sameref_tools/graphifyy"
+printf 'requirements = [{ name = "graphifyy", git = "https://github.com/yotamleo/graphify", rev = "himmel-main" }]\n' \
+  > "$sameref_tools/graphifyy/uv-receipt.toml"
+sameref_list="$tmpdir/samerepo-list"; printf 'graphifyy v0.9.13\n' > "$sameref_list"
+src=$(UV_TOOL_DIR="$sameref_tools" UV_LIST_FILE="$sameref_list" UV_LOG="$tmpdir/samerepo-log" \
+      PATH="$stub_dir/bin:$base_path" HOME="$sameref_home" \
+      bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_source')
+assert "same-repo-different-ref receipt -> foreign" test "$src" = "foreign"
+sameref_uvlog="$tmpdir/samerepo-uvlog"; : > "$sameref_uvlog"
+# A resolvable binary rides this run: the point here is CR-2 (adopt, never
+# reinstall over a different-ref install) -- the unresolvable-metadata rc is
+# covered by the CR-r2 scenarios above/below.
+sameref_bin="$tmpdir/samerepo-okbin"; mkdir -p "$sameref_bin"
+cat > "$sameref_bin/graphify" <<'EOF'
+#!/usr/bin/env bash
+echo "SAMEREPO GRAPHIFY $*"
+EOF
+chmod +x "$sameref_bin/graphify"
+out=$(HOME="$sameref_home" PATH="$sameref_bin:$stub_dir/bin:$base_path" UV_TOOL_DIR="$sameref_tools" \
+      UV_LIST_FILE="$sameref_list" UV_BIN_DIR="$tmpdir/samerepo-bin" UV_LOG="$sameref_uvlog" \
+      bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_install; echo "RC=$?"' 2>&1)
+assert "same-repo-different-ref: install adopts (rc 0)" grep -q '^RC=0$' <<<"$out"
+assert "same-repo-different-ref: reported as source=foreign" grep -q 'source=foreign' <<<"$out"
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "same-repo-different-ref: no install call" bash -c '! grep -q "tool install" "$1"' _ "$sameref_uvlog"
+
+echo "[test-graphify-bin] uv-managed package with MISSING receipt -> foreign (CR-6 pin)"
+norcpt_home="$tmpdir/noreceipt"; mkdir -p "$norcpt_home"
+norcpt_tools="$tmpdir/noreceipt-tools"; mkdir -p "$norcpt_tools/graphifyy"
+norcpt_list="$tmpdir/noreceipt-list"; printf 'graphifyy v0.9.13\n' > "$norcpt_list"
+src=$(UV_TOOL_DIR="$norcpt_tools" UV_LIST_FILE="$norcpt_list" UV_LOG="$tmpdir/noreceipt-log" \
+      PATH="$stub_dir/bin:$base_path" HOME="$norcpt_home" \
+      bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_source')
+assert "missing receipt -> foreign (present but unprovable, never 'not installed')" test "$src" = "foreign"
+
+echo "[test-graphify-bin] no uv on PATH -> WARN + nonzero rc"
+nouv_home="$tmpdir/nouv"; mkdir -p "$nouv_home"
+out=$(HOME="$nouv_home" PATH="$base_path" bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_install; echo "RC=$?"' 2>&1)
+assert "no-uv: rc nonzero" grep -qv '^RC=0$' <<<"$out"
+assert "no-uv: WARNs" grep -qi 'uv not found' <<<"$out"
+
+echo "[test-graphify-bin] uv install failure -> WARN + nonzero rc"
+ufail_home="$tmpdir/ufail"; mkdir -p "$ufail_home"
+ufail_tools="$tmpdir/ufail-tools"; mkdir -p "$ufail_tools"
+ufail_list="$tmpdir/ufail-list"; : > "$ufail_list"
+ufail_log="$tmpdir/ufail-uvlog"; : > "$ufail_log"
+out=$(HOME="$ufail_home" PATH="$stub_dir/bin:$base_path" UV_TOOL_DIR="$ufail_tools" UV_LIST_FILE="$ufail_list" \
+      UV_BIN_DIR="$tmpdir/ufail-bin" UV_LOG="$ufail_log" STUB_UV_INSTALL_RC=1 \
+      bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_install; echo "RC=$?"' 2>&1)
+assert "install-fail: rc nonzero" grep -qv '^RC=0$' <<<"$out"
+assert "install-fail: ERROR reported" grep -qi 'graphify install failed' <<<"$out"
+
+echo "[test-graphify-bin] install succeeds but shim NOT on PATH -> WARN + honest nonzero rc (CR-4)"
+# The stub drops the shim into UV_BIN_DIR as usual, but UV_BIN_DIR is NOT part
+# of the invocation PATH -- the post-install has_graphify probe must fail, and
+# graphify_install must say so honestly (WARNING + nonzero) instead of
+# reporting a resolvable install.
+nopath_home="$tmpdir/nopath"; mkdir -p "$nopath_home"
+nopath_tools="$tmpdir/nopath-tools"; mkdir -p "$nopath_tools"
+nopath_list="$tmpdir/nopath-list"; : > "$nopath_list"
+nopath_bin="$tmpdir/nopath-bin"; mkdir -p "$nopath_bin"
+nopath_log="$tmpdir/nopath-uvlog"; : > "$nopath_log"
+out=$(HOME="$nopath_home" PATH="$stub_dir/bin:$base_path" UV_TOOL_DIR="$nopath_tools" \
+      UV_LIST_FILE="$nopath_list" UV_BIN_DIR="$nopath_bin" UV_LOG="$nopath_log" \
+      bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_install; echo "RC=$?"' 2>&1)
+assert "unresolvable: install WAS attempted (one uv call)" test "$(grep -c 'UV tool install' "$nopath_log")" -eq 1
+assert "unresolvable: rc nonzero" grep -qv '^RC=0$' <<<"$out"
+assert "unresolvable: WARNs 'not resolvable on PATH'" grep -qi 'not resolvable on PATH' <<<"$out"
+
+echo "[test-graphify-bin] consumer wiring — setup.sh/adopt.sh source graphify-bin.sh (HIMMEL-891)"
+repo_root="$(cd "$SCRIPT_DIR/../.." && pwd)"
+assert "setup.sh sources graphify-bin.sh" grep -q 'lib/graphify-bin.sh' "$repo_root/scripts/setup.sh"
+assert "setup.sh calls graphify_install" grep -q 'graphify_install' "$repo_root/scripts/setup.sh"
+assert "adopt.sh sources graphify-bin.sh" grep -q 'lib/graphify-bin.sh' "$repo_root/scripts/adopt.sh"
+assert "adopt.sh calls graphify_install" grep -q 'graphify_install' "$repo_root/scripts/adopt.sh"
+
+echo
+echo "[test-graphify-bin] pass=$pass fail=$fail"
+test "$fail" -eq 0

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,12 +1,16 @@
 # New-machine setup for the himmel repo.
-# Run once after cloning: .\scripts\setup.ps1 [-WithCs] [-WithJira]
+# Run once after cloning: .\scripts\setup.ps1 [-WithCs] [-WithJira] [-WithGraphify]
 #
-# -WithCs   : install claude-squad (cs) at the end of setup. Without the
-#             switch, interactive shells prompt; non-interactive shells skip.
-#             See docs/setup/claude-squad.md.
-# -WithJira : require Jira configuration — abort if JIRA_PROJECT_KEY is
-#             unset. Without the switch the check downgrades to a skip
-#             notice (HIMMEL-285).
+# -WithCs        : install claude-squad (cs) at the end of setup. Without the
+#                  switch, interactive shells prompt; non-interactive shells skip.
+#                  See docs/setup/claude-squad.md.
+# -WithJira      : require Jira configuration — abort if JIRA_PROJECT_KEY is
+#                  unset. Without the switch the check downgrades to a skip
+#                  notice (HIMMEL-285).
+# -WithGraphify  : install the graphify knowledge-graph CLI (himmel fork) at
+#                  the end of setup. Without the switch, interactive shells
+#                  prompt; non-interactive shells skip. Adoption verdict is
+#                  still open (HIMMEL-621) — this only installs the CLI.
 # -FillEnv  : after creating .env, interactively prompt for each must-set value
 #             (Enter to skip). Non-interactive shells no-op. Shells out to the
 #             bash fill-env.sh (Git Bash verified in [0/10]). (HIMMEL-453)
@@ -15,6 +19,7 @@
 param(
     [switch]$WithCs,
     [switch]$WithJira,
+    [switch]$WithGraphify,
     [switch]$FillEnv
 )
 
@@ -602,6 +607,56 @@ if ($installCs) {
 } else {
     if (-not $WithCs -and [Environment]::UserInteractive) {
         Write-Host "  Skipped. See docs\setup\claude-squad.md to install later."
+    }
+}
+Write-Host ""
+
+# --- graphify (knowledge-graph CLI) -- OPTIONAL (HIMMEL-891) ---
+# Opt-in only. Triggered by -WithGraphify OR interactive prompt (default N).
+# Non-interactive shells without the switch skip silently -- mirrors the cs
+# opt-in above. Adoption verdict stays open (HIMMEL-621); this only installs
+# the CLI (delegates to the ONE bash implementation, scripts/lib/graphify-bin.sh
+# -- Git Bash is a verified [0/10] prereq, so it is always present here).
+#
+# Failure here is non-fatal: graphify is optional. WARN and continue.
+Write-Host "OPTIONAL: graphify (knowledge-graph CLI)..."
+$installGraphify = $false
+if ($WithGraphify) {
+    $installGraphify = $true
+} elseif ([Environment]::UserInteractive -and -not [Console]::IsInputRedirected) {
+    $resp = Read-Host "  Install graphify (knowledge-graph CLI) now? [y/N]"
+    if ($resp -match '^[yY]') { $installGraphify = $true }
+} else {
+    Write-Host "  Skipped (non-interactive, no -WithGraphify switch)."
+}
+
+if ($installGraphify) {
+    # WARN-not-fail structural guarantee (CR): this script runs under
+    # $ErrorActionPreference='Stop' + a trap; on PS configs where
+    # $PSNativeCommandUseErrorActionPreference=$true a nonzero bash exit
+    # becomes TERMINATING before the $LASTEXITCODE warn-check below can run,
+    # aborting the whole setup on an optional step. Decouple both for this
+    # block only; restore in finally (mirrors adopt.ps1's Wire-QmdCore guard).
+    $savedNativeEAP = $null
+    if (Test-Path variable:PSNativeCommandUseErrorActionPreference) {
+        $savedNativeEAP = $PSNativeCommandUseErrorActionPreference
+    }
+    $global:PSNativeCommandUseErrorActionPreference = $false
+    $savedEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & bash "$RepoRoot/scripts/lib/graphify-bin.sh" install
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  WARNING: graphify install failed (rc=$LASTEXITCODE); setup continues." -ForegroundColor Yellow
+            Write-Host "  Retry manually: bash `"$RepoRoot/scripts/lib/graphify-bin.sh`" install" -ForegroundColor Yellow
+        }
+    } finally {
+        $ErrorActionPreference = $savedEAP
+        if ($null -ne $savedNativeEAP) { $global:PSNativeCommandUseErrorActionPreference = $savedNativeEAP }
+    }
+} else {
+    if (-not $WithGraphify -and [Environment]::UserInteractive) {
+        Write-Host "  Skipped. Install later: bash `"$RepoRoot/scripts/lib/graphify-bin.sh`" install"
     }
 }
 Write-Host ""

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -20,27 +20,33 @@ SETUP_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # no flag uses them yet, but reserve the pattern.
 WITH_CS=0
 WITH_JIRA=0
+WITH_GRAPHIFY=0
 FILL_ENV=0
 setup_extra_args=()
 while [ $# -gt 0 ]; do
   case "$1" in
     --with-cs) WITH_CS=1 ;;
     --with-jira) WITH_JIRA=1 ;;
+    --with-graphify) WITH_GRAPHIFY=1 ;;
     --fill-env) FILL_ENV=1 ;;
     --help|-h)
       cat <<'USAGE'
-Usage: bash scripts/setup.sh [--with-cs] [--with-jira] [--fill-env]
+Usage: bash scripts/setup.sh [--with-cs] [--with-jira] [--with-graphify] [--fill-env]
 
 Optional flags:
-  --with-cs    Install claude-squad (cs) at the end of setup.
-               Without the flag, interactive shells prompt; non-interactive
-               shells skip. See docs/setup/claude-squad.md.
-  --with-jira  Require Jira configuration: abort setup if JIRA_PROJECT_KEY
-               is unset. Without the flag the check downgrades to a skip
-               notice and Jira-dependent next-steps are omitted.
-  --fill-env   After creating .env, interactively prompt for each must-set
-               value (Enter to skip / keep current). Non-interactive shells
-               no-op. Without the flag, .env keeps the .env.example placeholders.
+  --with-cs        Install claude-squad (cs) at the end of setup.
+                   Without the flag, interactive shells prompt; non-interactive
+                   shells skip. See docs/setup/claude-squad.md.
+  --with-jira      Require Jira configuration: abort setup if JIRA_PROJECT_KEY
+                   is unset. Without the flag the check downgrades to a skip
+                   notice and Jira-dependent next-steps are omitted.
+  --with-graphify  Install the graphify knowledge-graph CLI (himmel fork) at
+                   the end of setup. Without the flag, interactive shells
+                   prompt; non-interactive shells skip. Adoption verdict is
+                   still open (HIMMEL-621) — this only installs the CLI.
+  --fill-env       After creating .env, interactively prompt for each must-set
+                   value (Enter to skip / keep current). Non-interactive shells
+                   no-op. Without the flag, .env keeps the .env.example placeholders.
 USAGE
       exit 0
       ;;
@@ -141,6 +147,12 @@ cd "$REPO_ROOT"
 # shellcheck source=lib/qmd-bin.sh
 # shellcheck disable=SC1091
 . "$REPO_ROOT/scripts/lib/qmd-bin.sh"
+# graphify resolver (HIMMEL-891). Provides has_graphify / graphify_install /
+# graphify_source / graphify_install_hint, consumed by the OPTIONAL graphify
+# step below.
+# shellcheck source=lib/graphify-bin.sh
+# shellcheck disable=SC1091
+. "$REPO_ROOT/scripts/lib/graphify-bin.sh"
 
 # --- Claude Code CLI (the runtime himmel harnesses) — soft check ---
 # Not a hard requirement of setup itself (the steps below configure the repo and
@@ -405,6 +417,38 @@ if [ "$_install_cs" = "1" ]; then
 else
   if [ "$WITH_CS" != "1" ] && { [ -t 0 ] && [ -t 1 ]; }; then
     echo "  Skipped. See docs/setup/claude-squad.md to install later."
+  fi
+fi
+echo ""
+
+# --- graphify (knowledge-graph CLI) — OPTIONAL (HIMMEL-891) ---
+# Opt-in only. Triggered by --with-graphify OR interactive prompt (default N).
+# Non-interactive shells without the flag skip silently — mirrors the cs
+# opt-in above. Adoption verdict stays open (HIMMEL-621); this only installs
+# the CLI (himmel fork, never over an existing foreign install — see
+# scripts/lib/graphify-bin.sh).
+#
+# Failure here is non-fatal: graphify is optional, so a missing uv or a
+# network hiccup shouldn't abort the rest of setup. We WARN and continue.
+echo "OPTIONAL: graphify (knowledge-graph CLI)..."
+_install_graphify=0
+if [ "$WITH_GRAPHIFY" = "1" ]; then
+  _install_graphify=1
+elif [ -t 0 ] && [ -t 1 ]; then
+  printf "  Install graphify (knowledge-graph CLI) now? [y/N] "
+  read -r _ans
+  case "$_ans" in
+    [yY]|[yY][eE][sS]) _install_graphify=1 ;;
+  esac
+else
+  echo "  Skipped (non-interactive, no --with-graphify flag)."
+fi
+
+if [ "$_install_graphify" = "1" ]; then
+  graphify_install || echo "  WARNING: graphify install failed; setup continues." >&2
+else
+  if [ "$WITH_GRAPHIFY" != "1" ] && { [ -t 0 ] && [ -t 1 ]; }; then
+    echo "  Skipped. Install later: $(graphify_install_hint)"
   fi
 fi
 echo ""

--- a/scripts/test-adopt.ps1
+++ b/scripts/test-adopt.ps1
@@ -347,6 +347,48 @@ exit /b 0
   if ($outJ -match "jira CLI built") { Pass "Build-JiraCli reports built" } else { Fail "missing success message (got: $outJ)" }
 
   Write-Host ""
+  Write-Host "== scenario K: Install-Graphify failure is WARN-not-fail under native-EAP coupling (HIMMEL-891 CR-r2) =="
+  # -WithGraphify with uv AND graphify scrubbed off PATH -> the bash installer
+  # (scripts/lib/graphify-bin.sh, run via the machine's real Git Bash when
+  # present, else the Git-Bash-not-found branch) exits nonzero either way.
+  # The child run is launched through a wrapper that FORCES the fatal-warn
+  # coupling ($ErrorActionPreference='Stop' +
+  # $PSNativeCommandUseErrorActionPreference=$true) -- without
+  # Wire-GraphifyCore's saved/restored-preferences guard, the installer's
+  # nonzero exit becomes a terminating error and the whole adopt aborts;
+  # with the guard, adopt WARNs and completes rc 0.
+  $StubDirK = Join-Path $TMP "binK"
+  $TargetK  = Join-Path $TMP "targetK"
+  New-Item -ItemType Directory -Force -Path $StubDirK,$TargetK | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $TargetK '.claude') | Out-Null
+  Set-Content -Path (Join-Path $TargetK '.claude\settings.json') -Value '{}'
+  foreach ($name in @("git","python3")) {
+    Set-Content -Path (Join-Path $StubDirK "$name.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+  }
+  Set-Content -Path (Join-Path $StubDirK "jq.cmd")   -Encoding ASCII -Value "@echo off`r`necho {}`r`nexit /b 0`r`n"
+  Set-Content -Path (Join-Path $StubDirK "pwsh.cmd") -Encoding ASCII -Value "@echo off`r`nexit /b 0`r`n"
+
+  $WrapperK = Join-Path $TMP "runK.ps1"
+  Set-Content -Path $WrapperK -Value @"
+`$ErrorActionPreference = 'Stop'
+`$PSNativeCommandUseErrorActionPreference = `$true
+& "$Installer" -Profile core -Scope project -Target "$TargetK" -WithGraphify
+exit 0
+"@
+
+  $env:Path = "$StubDirK;$env:SystemRoot\System32;$env:SystemRoot"
+  try {
+    $outK = & $realPwsh -NoProfile -NonInteractive -File $WrapperK 2>&1 | Out-String
+    $codeK = $LASTEXITCODE
+  } finally {
+    $env:Path = $oldPath
+  }
+
+  if ($codeK -eq 0) { Pass "graphify installer failure does not abort adopt (rc=0 under native-EAP coupling)" } else { Fail "graphify installer failure aborted adopt (rc=$codeK; guard regression). Output: $outK" }
+  if ($outK -match [regex]::Escape("Wiring graphify (opt-in")) { Pass "graphify wiring banner printed (-WithGraphify honored)" } else { Fail "missing graphify wiring banner (got: $outK)" }
+  if ($outK -match "WARNING.*graphify install failed") { Pass "installer failure surfaced as the WARN-and-continue message" } else { Fail "missing graphify install-failed WARNING (got: $outK)" }
+
+  Write-Host ""
   if ($script:fails -eq 0) { Write-Host "ALL PASS" } else { Write-Host "$($script:fails) FAILED" -ForegroundColor Red; exit 1 }
 } finally {
   Remove-Item -Recurse -Force $RealJiraDist -ErrorAction SilentlyContinue

--- a/scripts/test-adopt.sh
+++ b/scripts/test-adopt.sh
@@ -312,9 +312,11 @@ exit 0
 STUB
 chmod +x "$qbin/bun"
 qhome="$work/qhome"; mkdir -p "$qhome"
+# --with-graphify rides this dry-run (HIMMEL-891 CR-5b): opted-in + --dry-run
+# must emit the graphify DRY line (and nothing real — dry-run never installs).
 set +e
 out=$(PATH="$qbin:$work/bin:$qmd_free_path" HOME="$qhome" bash "$adopt" \
-      --profile all --scope user --target "$work/ign-q" --luna-target "$work/qvault" --dry-run 2>&1); rc=$?
+      --profile all --scope user --target "$work/ign-q" --luna-target "$work/qvault" --with-graphify --dry-run 2>&1); rc=$?
 set -e
 [ "$rc" -eq 0 ] || fail "dry-run adopt exited rc=$rc (expected 0)"
 printf '%s' "$out" | grep -q 'DRY:.*fix-qmd-stub'    || fail "dry-run missing fix-qmd-stub DRY line"
@@ -322,10 +324,12 @@ printf '%s' "$out" | grep -q 'DRY: qmd_install'      || fail "dry-run missing qm
 printf '%s' "$out" | grep -q 'DRY: qmd pull'         || fail "dry-run missing qmd pull DRY line"
 printf '%s' "$out" | grep -q 'DRY: qmd_register_collection .* himmel$' || fail "dry-run missing himmel register DRY line"
 printf '%s' "$out" | grep -q 'DRY: qmd_register_collection .* luna$'   || fail "dry-run missing luna register DRY line"
+printf '%s' "$out" | grep -q 'Wiring graphify (opt-in' || fail "dry-run --with-graphify missing the graphify wiring banner"
+printf '%s' "$out" | grep -q 'DRY: graphify_install'   || fail "dry-run --with-graphify missing graphify_install DRY line"
 # HIMMEL-842 gap 3: build_jira_cli runs after install_plugins; with npm scrubbed
 # suite-wide and bun stubbed present, it picks bun and emits its DRY build line.
 printf '%s' "$out" | grep -q 'DRY:.*(cd scripts/jira && bun install && bun run build)' || fail "dry-run missing build_jira_cli DRY line"
-echo "ok: dry-run emits all qmd step DRY lines (core G1/G3/G4 + luna G5) + build_jira_cli"
+echo "ok: dry-run emits all qmd step DRY lines (core G1/G3/G4 + luna G5) + build_jira_cli + graphify opt-in DRY"
 
 # ── 11. HIMMEL-877 qmd WARN-not-fail: a failing qmd install never aborts adopt
 # bun present (stubbed) + a `git` stub that fails on `clone` + has_qmd=false
@@ -345,6 +349,17 @@ cat > "$fbin/git" <<'STUB'
 exit 0
 STUB
 chmod +x "$fbin/git"
+# Argv-logging uv stub (HIMMEL-891 CR-5a): this run passes NO --with-graphify,
+# so graphify must stay completely un-wired — the stub's log proves no
+# `uv tool install` ever fires on a default core adopt (the HIMMEL-621
+# open-verdict contract: opt-in only, never default).
+cat > "$fbin/uv" <<STUB
+#!/usr/bin/env bash
+echo "UV \$*" >> "$work/uv-calls-11"
+exit 0
+STUB
+chmod +x "$fbin/uv"
+: > "$work/uv-calls-11"
 fhome="$work/fhome"; mkdir -p "$fhome"
 set +e
 out=$(PATH="$fbin:$work/bin:$qmd_free_path" HOME="$fhome" bash "$adopt" \
@@ -354,6 +369,14 @@ set -e
 printf '%s' "$out" | grep -q 'Installing qmd fork' || fail "qmd_install not invoked (call order)"
 printf '%s' "$out" | grep -Eq 'WARNING.*qmd install failed' || fail "missing qmd install WARNING (WARN-not-fail)"
 echo "ok: qmd install failure WARNs and adopt continues (WARN-not-fail, rc=0)"
+# HIMMEL-891 CR-5a: graphify default-OFF, behaviorally asserted on the run above.
+if printf '%s' "$out" | grep -q 'Wiring graphify'; then
+  fail "default core adopt (no --with-graphify) ran the graphify wiring (opt-in regression)"
+fi
+if grep -q 'tool install' "$work/uv-calls-11"; then
+  fail "default core adopt (no --with-graphify) invoked uv tool install (opt-in regression)"
+fi
+echo "ok: graphify stays un-wired on a default core adopt (opt-in only, zero uv installs)"
 
 # ── 11b. HIMMEL-877 CR codex-adv-1: an existing UPSTREAM install MIGRATES ────
 # A real @tobilu/qmd directory at the bun-global path + a working stubbed bun


### PR DESCRIPTION
## Summary
- [HIMMEL-891] graphify becomes reproducible plumbing: fork yotamleo/graphify created (himmel-main tracks upstream v8 head; release tag v0.9.13-himmel.1), and scripts/lib/graphify-bin.sh installs from it via uv, **pinned to the full commit SHA** (df74ab44…, tag kept as human-readable provenance) — policy-tested (ref must be 40-hex).
- **Foreign installs are never broken**: uv-list + PATH detection → adopt + provenance (exact-pin two-probe match against uv's git/rev receipt keys; same-repo-different-ref = foreign); install only into an empty slot; idempotent; adopted-but-unresolvable → honest WARN + nonzero, no auto-reinstall over foreign metadata.
- Opt-in wiring in setup.sh/adopt.sh (+ .ps1 twins, PSNative-EAP-guarded so optional-tool failure never aborts adoption/setup); consumers unchanged; default-OFF behaviorally asserted (HIMMEL-621 verdict stays open).

## CR trail (3 rounds)
- Panel provenance-ignores-branch → exact-pin match; codex-adv r1 (unpinned branch, PS fatal-warn, unresolvable state) → immutable pin + guards + tests; r2 (adopt.ps1 guard gap, adopted-unresolvable success) → fixed + pwsh scenario K; r3 (tag→SHA) → SHA pin + policy test.
- Suites: test-graphify-bin.sh 47/47; test-adopt.sh PASS; test-adopt.ps1 A–K ALL PASS; shellcheck clean. Verified independently by the orchestrator. Private PR #1116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[HIMMEL-891]: https://yotamleo.atlassian.net/browse/HIMMEL-891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ