### PR TITLE
fix(hooks): [HIMMEL-851] destructive-floor spec fixes, parity-locked (U1-U3, O1 + 7 adversarial rounds)

### DIFF
--- a/scripts/hermes/assets/parity_guard.py
+++ b/scripts/hermes/assets/parity_guard.py
@@ -90,20 +90,79 @@ TERMINAL_FORBIDDEN_PATHS = re.compile(
     + r"|\.env\b|/\.ssh/|\.git-credentials|hosts\.yml|\.pem\b|\.key\b"
 )
 
+# Command position: string start or right after a separator (; & | ( newline).
+# Deliberately NOT a plain space/quote, so a blocked verb quoted inside a
+# commit message ("… git push later") does not false-block. Used by the EXT_*
+# external-write fence further below (moved up here so the destructive variant
+# can build on it).
+_CMDPOS = r"(?:^|[;&|(\n])\s*"
+
+# Destructive-only command-position anchor (O1 + CR round 1, HIMMEL-851).
+# _CMDPOS PLUS, for the TERMINAL_DESTRUCTIVE bare-command-name atoms only
+# (format, schtasks, taskkill, shutdown, icacls, …): a backtick separator
+# (command substitution is command position) and a BOUNDED tolerance for
+# common launcher prefixes — env-var assignments (x=1 cmd), sudo, env,
+# cmd /c, powershell/pwsh -c/-command — plus one optional quote before the
+# atom (a quoted word in command position still executes) and (CR r2) a
+# bounded EXECUTABLE-PATH prefix — optional Windows drive + path segments
+# ending in "/" — so `/sbin/shutdown`, `./shutdown`, and
+# `c:/windows/system32/shutdown.exe` (quoted or not; norm() folds "\" to "/")
+# are refused like the bare name. The path prefix sits AFTER the command-
+# position anchor, so mid-argument words (`git log --pretty=format:%H`,
+# `grep -rn format src/`, `echo shutdown`, a commit message mentioning
+# "reboot") stay allowed, and the atoms' trailing boundary keeps
+# `format-table`-style basenames allowed. The exe-path prefix also applies
+# before each WRAPPER token (CR r4), so `/usr/bin/env shutdown` /
+# `/usr/bin/sudo shutdown` / `c:/windows/system32/cmd.exe /c shutdown` are
+# refused like the bare-wrapper forms. sudo/env tolerate their own flag runs
+# (CR r6: `sudo -n`, `env -i`), each flag may optionally consume one following
+# non-dash value token (CR r7: `sudo -u root`, `env -u PATH` — generic, no
+# per-option table; over-consumes at worst one benign token → over-block in
+# exotic cases, never a bypass), and env also tolerates assignment arguments
+# (`env -i foo=bar shutdown`). Mirrors the .sh CMDPOS idiom (HIMMEL-754) + its
+# CR-r1..r7 extensions. Deliberately NOT a general shell parser — the RESIDUAL
+# documented gap is QUOTED-PAYLOAD wrappers (`bash -c "shutdown …"`, `sh -c`,
+# xargs / nohup chains), which stays out of scope per the ticket's
+# no-general-parser rule. This bounded grammar is intentionally NOT an arms
+# race: further wrapper permutations belong to the HIMMEL-912 shared-tokenizer
+# follow-up, and the .sh CC-hook + auto-mode classifier remain the outer
+# defense layers. NOT used by the EXT_* fence — its narrower anchor and
+# documented limits are intentional.
+# Bounded executable-path prefix: optional quote + optional drive letter +
+# one slash-terminated segment run. "/" only — norm() folds "\" to "/".
+_EXE_PREFIX = r"[\"']?(?:[a-z]:)?(?:[^\s|;&`\"']*/)?"
+# Quote-aware assignment (CR r5): FOO='a b' / FOO="a b" / FOO=bare. Shared by
+# the env-prefix assignment tolerance and the leading env-assignment prefix so
+# a quoted value's space does not drop the verb out of command position.
+_ASSIGN = r"[a-z0-9_]+=(?:'[^']*'|\"[^\"]*\"|[^\s|;&]*)"
+_CMDPOS_DESTRUCTIVE = (
+    r"(?:^|[;&|(`\n])\s*"
+    + r"(?:(?:" + _ASSIGN
+    + r"|" + _EXE_PREFIX + r"(?:sudo(?:\s+-\S+(?:\s+[^-\s]\S*)?)*"   # sudo + flags, each with an optional value token (CR r6/r7)
+    + r"|env(?:\s+(?:-\S+(?:\s+[^-\s]\S*)?|" + _ASSIGN + r"))*"      # env + flags(+value)/assignments (CR r6/r7)
+    + r"|cmd(?:\.exe)?(?:\s+/\w+(?::\w+)?)*\s+/c"        # cmd accepts /d /s /e:on … before /c (CR r3)
+    + r"|(?:powershell|pwsh)(?:\.exe)?(?:\s+-\S+)*\s+-c\w*"
+    + r"))\s+)*"
+    + _EXE_PREFIX
+)
+
 # Catastrophic / shared-machine / irreversible classes only.
 # Routine git, gh, mv, cp, and non-recursive rm are intentionally NOT here.
 TERMINAL_DESTRUCTIVE = re.compile(
-    r"\brm\b[^|;&\n]*\s-\w*r"                 # recursive rm (rm -r / -rf / -Rf)
-    r"|\brm\b[^|;&\n]*--recursive"
-    r"|\b(del|erase|rd|rmdir)\b[^|;&\n]*/s"   # recursive Windows delete
-    r"|\bformat\b|\bmkfs|\bdiskpart\b|\bcipher\s+/w|\bbcdedit\b"
-    r"|\bschtasks\b"                          # protects scheduled jobs
-    r"|\btaskkill\b|\bstop-process\b|\bpskill\b|\bkill\s+-9"
-    r"|\bshutdown\b|\breboot\b|\blogoff\b"
-    r"|\breg\s+(add|delete)\b|\bicacls\b|\btakeown\b"
-    r"|\bgit\s+push\b[^|;&\n]*(--force|--force-with-lease|\s-f\b)"
-    r"|\bgit\s+(reset\s+--hard|clean\s+-\w*f|filter-branch)\b"
-    r"|\bcurl[^|;&]*\|\s*(ba)?sh|\bwget[^|;&]*\|\s*(ba)?sh"
+    r"\brm\b[^|;&\n]*(?:\s|\$\{ifs\})[\"']?-\w*r"   # recursive rm (rm -r/-rf/-Rf); tolerates a quoted flag + ${IFS} separator (HIMMEL-851 U2/U3)
+    + r"|\brm\b[^|;&\n]*--recursive"
+    + r"|\b(del|erase|rd|rmdir)\b[^|;&\n]*/s(?:[^A-Za-z0-9_.-]|$)"  # recursive Windows delete; /s bound to the switch, not a path prefix like /scripts (HIMMEL-851 U1)
+    + r"|" + _CMDPOS_DESTRUCTIVE + r"(?:(?:format|diskpart|bcdedit)(?:\.exe)?(?:[^A-Za-z0-9_.-]|$)|mkfs)"
+    + r"|\bcipher\s+/w"
+    + r"|" + _CMDPOS_DESTRUCTIVE + r"schtasks(?:\.exe)?(?:[^A-Za-z0-9_.-]|$)"    # protects scheduled jobs
+    + r"|" + _CMDPOS_DESTRUCTIVE + r"(?:taskkill|stop-process|pskill)(?:\.exe)?(?:[^A-Za-z0-9_.-]|$)"
+    + r"|\bkill\s+-9"
+    + r"|" + _CMDPOS_DESTRUCTIVE + r"(?:shutdown|reboot|logoff)(?:\.exe)?(?:[^A-Za-z0-9_.-]|$)"
+    + r"|\breg\s+(add|delete)\b"
+    + r"|" + _CMDPOS_DESTRUCTIVE + r"(?:icacls|takeown)(?:\.exe)?(?:[^A-Za-z0-9_.-]|$)"
+    + r"|\bgit\s+push\b[^|;&\n]*(--force|--force-with-lease|\s-f\b)"
+    + r"|\bgit\s+(reset\s+--hard|clean\s+-\w*f|filter-branch)\b"
+    + r"|\bcurl[^|;&]*\|\s*(ba)?sh|\bwget[^|;&]*\|\s*(ba)?sh"
 )
 
 # Container privesc shapes (block-docker-privesc parity, HIMMEL-731). Membership
@@ -470,10 +529,8 @@ def terminal_phi_egress_reason(cmd_norm: str):
 # unconditional PHI read-fence — not this scan — is the load-bearing egress control.
 _ENGINE_UNTRUSTED = re.compile(r"z\.ai|glm|zhipu")
 
-# Command position: string start or right after a separator (; & | ( newline).
-# Deliberately NOT a space/quote, so a blocked verb quoted inside a commit message
-# ("… git push later") does not false-block — parity with the sibling hook.
-_CMDPOS = r"(?:^|[;&|(\n])\s*"
+# _CMDPOS (command-position anchor) is defined above TERMINAL_DESTRUCTIVE —
+# shared by both use sites.
 EXT_GIT_PUSH = re.compile(_CMDPOS + r"git(?:\.exe)?(?:\s+-\S+(?:\s+\S+)?)*\s+push(?:\s|$)")
 EXT_GIT_URL = re.compile(
     _CMDPOS + r"git(?:\.exe)?(?:\s+-\S+(?:\s+\S+)?)*\s+"

--- a/scripts/hermes/test-parity-guard.sh
+++ b/scripts/hermes/test-parity-guard.sh
@@ -83,6 +83,124 @@ g "rm -rf"         block '{"tool_name":"terminal","tool_input":{"command":"rm -r
 g "plain rm"       allow '{"tool_name":"terminal","tool_input":{"command":"rm tmp.txt"}}'
 g "schtasks"       block '{"tool_name":"terminal","tool_input":{"command":"schtasks /delete /tn X"}}'
 
+echo "== parity_guard: destructive-floor spec fixes (HIMMEL-851) =="
+# U1: /s is bound to the switch, not a path prefix — `rd /scripts` is not a
+# recursive-delete switch, it's an argument that merely starts with "/s".
+g "rd /scripts (path, not switch)" allow '{"tool_name":"terminal","tool_input":{"command":"rd /scripts foo"}}'
+# U2: a quoted -rf flag must not defeat the recursive-rm pattern.
+g "rm quoted -rf flag" block '{"tool_name":"terminal","tool_input":{"command":"rm \"-rf\" file"}}'
+# U3: ${IFS} (a common word-split bypass) is whitespace-equivalent here.
+# shellcheck disable=SC2016  # label is a literal string, not meant to expand
+g 'rm ${IFS}-separated -rf' block '{"tool_name":"terminal","tool_input":{"command":"rm${IFS}-rf${IFS}x"}}'
+# U3: backslash-newline continuation. Built via python (not hand-escaped bash)
+# so the embedded backslash + real newline reach the guard exactly as a shell
+# line-continuation would produce them, with correct JSON encoding guaranteed.
+CONT_JSON="$("$PY" -c "
+import json, sys
+cmd = 'rm ' + chr(92) + chr(10) + '-rf x'
+print(json.dumps({'tool_name': 'terminal', 'tool_input': {'command': cmd}}))
+")"
+g "rm backslash-continuation -rf" block "$CONT_JSON"
+# O1: bare command-name atoms (format/schtasks/taskkill/shutdown/icacls
+# classes) must only fire in command position, not embedded mid-argument.
+g "git log --pretty=format: allowed" allow '{"tool_name":"terminal","tool_input":{"command":"git log --pretty=format:%H -n 5"}}'
+g "grep -rn format src/ allowed"     allow '{"tool_name":"terminal","tool_input":{"command":"grep -rn format src/"}}'
+g "echo shutdown mid-argument allowed" allow '{"tool_name":"terminal","tool_input":{"command":"echo shutdown"}}'
+# CR r1 (HIMMEL-851): bounded launcher-wrapper tolerance in command position -
+# wrapped destructive verbs must still be refused, mirroring the .sh CMDPOS.
+g "sudo shutdown refused"            block '{"tool_name":"terminal","tool_input":{"command":"sudo shutdown -h now"}}'
+g "env-assign prefix shutdown refused" block '{"tool_name":"terminal","tool_input":{"command":"x=1 shutdown -h now"}}'
+g "cmd /c shutdown refused"          block '{"tool_name":"terminal","tool_input":{"command":"cmd /c shutdown /s /t 0"}}'
+# CR r3 (HIMMEL-851): cmd accepts switches (/d /s /e:on …) before /c.
+g "cmd /d /c shutdown refused"       block '{"tool_name":"terminal","tool_input":{"command":"cmd /d /c shutdown /s /t 0"}}'
+g "cmd.exe /d /s /c shutdown refused" block '{"tool_name":"terminal","tool_input":{"command":"cmd.exe /d /s /c shutdown /s /t 0"}}'
+g "powershell -command stop-process refused" block '{"tool_name":"terminal","tool_input":{"command":"powershell -command stop-process -name foo"}}'
+BACKTICK_JSON="$("$PY" -c "
+import json
+cmd = 'echo ' + chr(96) + 'format c:' + chr(96)
+print(json.dumps({'tool_name': 'terminal', 'tool_input': {'command': cmd}}))
+")"
+g "backtick-wrapped format refused"  block "$BACKTICK_JSON"
+# CR r2 (HIMMEL-851): path-qualified destructive executables - a bounded
+# exe-path prefix (optional drive + /-terminated segments) after the anchor,
+# mirroring the .sh CMDPOS. The atoms' trailing boundary keeps format-* names
+# allowed; mid-argument words stay allowed (not at command position).
+g "/sbin/shutdown refused"           block '{"tool_name":"terminal","tool_input":{"command":"/sbin/shutdown -h now"}}'
+g "./shutdown relative refused"      block '{"tool_name":"terminal","tool_input":{"command":"./shutdown -h now"}}'
+g "drive-path shutdown.exe refused"  block '{"tool_name":"terminal","tool_input":{"command":"c:/windows/system32/shutdown.exe /s /t 0"}}'
+QUOTEDPATH_JSON="$("$PY" -c "
+import json
+q = chr(34)
+cmd = 'x; ' + q + 'c:/windows/system32/shutdown.exe' + q + ' /s'
+print(json.dumps({'tool_name': 'terminal', 'tool_input': {'command': cmd}}))
+")"
+g "quoted drive-path shutdown refused" block "$QUOTEDPATH_JSON"
+BSLASHPATH_JSON="$("$PY" -c "
+import json
+b = chr(92)
+cmd = 'c:' + b + 'windows' + b + 'system32' + b + 'shutdown.exe /s /t 0'
+print(json.dumps({'tool_name': 'terminal', 'tool_input': {'command': cmd}}))
+")"
+g "backslash drive-path shutdown refused" block "$BSLASHPATH_JSON"
+g "format-data path basename allowed" allow '{"tool_name":"terminal","tool_input":{"command":"x; foo/format-data bar"}}'
+# CR r4 (HIMMEL-851): path-qualified launcher wrappers - the exe-path prefix
+# also applies before each wrapper token, mirroring the .sh CMDPOS. Residual
+# documented gap (both impls): quoted-payload wrappers (bash -c "...", sh -c,
+# xargs / nohup chains) - out of scope per the no-general-parser rule.
+g "/usr/bin/env shutdown refused"    block '{"tool_name":"terminal","tool_input":{"command":"/usr/bin/env shutdown -h now"}}'
+g "/usr/bin/sudo shutdown refused"   block '{"tool_name":"terminal","tool_input":{"command":"/usr/bin/sudo shutdown -h now"}}'
+g "path-qualified cmd.exe /c shutdown refused" block '{"tool_name":"terminal","tool_input":{"command":"c:/windows/system32/cmd.exe /c shutdown /s /t 0"}}'
+g "/usr/bin/env python3 benign allowed" allow '{"tool_name":"terminal","tool_input":{"command":"/usr/bin/env python3 build.py"}}'
+# CR r5 (HIMMEL-851): assignment VALUE is quote-aware - FOO='a b' <verb> must
+# not drop the verb out of command position. Built via python so the embedded
+# quotes reach the guard with correct JSON encoding.
+SQASSIGN_JSON="$("$PY" -c "
+import json
+q = chr(39)
+cmd = 'foo=' + q + 'a b' + q + ' shutdown -h now'
+print(json.dumps({'tool_name': 'terminal', 'tool_input': {'command': cmd}}))
+")"
+g "single-quoted assign shutdown refused" block "$SQASSIGN_JSON"
+DQASSIGN_JSON="$("$PY" -c "
+import json
+q = chr(34)
+cmd = 'foo=' + q + 'a b' + q + ' schtasks /delete /f'
+print(json.dumps({'tool_name': 'terminal', 'tool_input': {'command': cmd}}))
+")"
+g "double-quoted assign schtasks refused" block "$DQASSIGN_JSON"
+ECHOASSIGN_JSON="$("$PY" -c "
+import json
+sq, dq = chr(39), chr(34)
+cmd = 'echo ' + dq + 'FOO=' + sq + 'a b' + sq + ' shutdown' + dq
+print(json.dumps({'tool_name': 'terminal', 'tool_input': {'command': cmd}}))
+")"
+g "echo'd quoted assign+verb allowed" allow "$ECHOASSIGN_JSON"
+# CR r6 (HIMMEL-851): sudo/env tolerate flag runs (env also assignment args),
+# mirroring the .sh CMDPOS. Bounded grammar - further wrapper permutations
+# are HIMMEL-912 (shared tokenizer); this + the CC-hook + the auto-mode
+# classifier remain the outer defense layers.
+g "sudo -n shutdown refused"         block '{"tool_name":"terminal","tool_input":{"command":"sudo -n shutdown -h now"}}'
+g "env -i shutdown refused"          block '{"tool_name":"terminal","tool_input":{"command":"env -i shutdown -h now"}}'
+g "env -i foo=bar shutdown refused"  block '{"tool_name":"terminal","tool_input":{"command":"env -i foo=bar shutdown -h now"}}'
+g "sudo -n apt benign allowed"       allow '{"tool_name":"terminal","tool_input":{"command":"sudo -n apt update"}}'
+g "env -i printenv benign allowed"   allow '{"tool_name":"terminal","tool_input":{"command":"env -i printenv"}}'
+# CR r7 (HIMMEL-851): wrapper flags may each consume one following value token
+# (generic, no per-option table; over-consumes at worst one benign token,
+# never a bypass), mirroring the .sh CMDPOS.
+g "sudo -u root shutdown refused"    block '{"tool_name":"terminal","tool_input":{"command":"sudo -u root shutdown -h now"}}'
+g "env -u path shutdown refused"     block '{"tool_name":"terminal","tool_input":{"command":"env -u path shutdown -h now"}}'
+g "sudo -u root -g wheel taskkill refused" block '{"tool_name":"terminal","tool_input":{"command":"sudo -u root -g wheel taskkill /f"}}'
+g "sudo -u root ls benign allowed"   allow '{"tool_name":"terminal","tool_input":{"command":"sudo -u root ls"}}'
+g "sudo -u root apt benign allowed"  allow '{"tool_name":"terminal","tool_input":{"command":"sudo -u root apt update"}}'
+g "env -u path printenv benign allowed" allow '{"tool_name":"terminal","tool_input":{"command":"env -u path printenv"}}'
+REBOOT_JSON="$("$PY" -c "
+import json
+q = chr(34)
+cmd = 'git commit -m ' + q + 'fix reboot loop' + q
+print(json.dumps({'tool_name': 'terminal', 'tool_input': {'command': cmd, 'cwd': '$FR'}}))
+")"
+g "commit msg mentions reboot allowed" allow "$REBOOT_JSON"
+
 echo "== parity_guard: block-edit-on-main parity (HIMMEL-731) =="
 g "write into repo on main refused"    block "{\"tool_name\":\"write_file\",\"tool_input\":{\"path\":\"$MR/src/foo.sh\"}}"
 g "delete in repo on main refused"     block "{\"tool_name\":\"delete_file\",\"tool_input\":{\"path\":\"$MR/src/old.sh\"}}"

--- a/scripts/hooks/block-destructive-commands.sh
+++ b/scripts/hooks/block-destructive-commands.sh
@@ -60,17 +60,56 @@ deny() {
 # that parity_guard names tolerates an optional .exe suffix for the Windows lane.
 # Bare-name atoms (format/schtasks/taskkill/shutdown/icacls classes) anchor to
 # COMMAND POSITION - start of command or right after a separator, tolerating
-# whitespace and env-var assignment prefixes - so the bare word inside an
-# argument (git log --pretty=format:, grep -rn format src/) does not match.
-# Mirrors parity_guard.py's _CMDPOS idiom for the external-write fence.
-CMDPOS='(^|[|;&(`])[[:space:]]*([[:alnum:]_]+=[^[:space:]|;&]*[[:space:]]+)*'
-if contains '(^|[^[:alnum:]_.-])rm(\.exe)?([^[:alnum:]_.-][^|;&]*)?[[:space:]]-[[:alnum:]_]*r'; then
+# whitespace, env-var assignment prefixes, and (HIMMEL-851 CR r1) a BOUNDED set
+# of launcher wrappers - sudo, env, cmd [/switches] /c, powershell/pwsh
+# [-flags] -c/-command - plus
+# one optional quote before the atom (a quoted word in command position still
+# executes) and (CR r2) a bounded EXECUTABLE-PATH prefix - optional Windows
+# drive + path segments ending in "/" or "\" - so /sbin/<name>, ./<name>, and
+# drive-qualified <name>.exe forms (quoted or not) are refused like the bare
+# name. The exe-path prefix also applies before each WRAPPER token (CR r4),
+# so /usr/bin/env <name>, /usr/bin/sudo <name>, and a path-qualified
+# cmd.exe /c are refused like the bare-wrapper forms. sudo/env tolerate their
+# own flag runs (CR r6: sudo -n, env -i), each flag may optionally consume one
+# following non-dash value token (CR r7: sudo -u root, env -u PATH - generic,
+# no per-option table; over-consumes at worst one benign token, never a
+# bypass), and env also tolerates assignment arguments (env -i foo=bar
+# shutdown). The bare word inside an argument
+# (git log --pretty=format:, grep -rn format src/, echo shutdown) still does
+# not match, and the atoms' trailing boundary keeps format-table-style
+# basenames allowed. Deliberately NOT a general shell parser - the RESIDUAL
+# documented gap is QUOTED-PAYLOAD wrappers (bash -c "<verb> ...", sh -c,
+# xargs / nohup chains), out of scope per the ticket's no-general-parser rule.
+# This bounded grammar is intentionally NOT an arms race: further wrapper
+# permutations belong to the HIMMEL-912 shared-tokenizer follow-up, and this
+# CC-hook + the auto-mode classifier remain the outer defense layers. Mirrors
+# parity_guard.py's _CMDPOS_DESTRUCTIVE (shared contract).
+# Assignment VALUE is quote-aware (CR r5): FOO='a b' / FOO="a b" would
+# otherwise break prefix consumption at the space and drop the verb out of
+# command position. Factored into ASSIGN so the env-prefix (CR r6) reuses it.
+EXEPFX='["'\'']?([a-z]:)?([^[:space:]|;&`"'\'']*[/\\])?'
+ASSIGN='[[:alnum:]_]+=('\''[^'\'']*'\''|"[^"]*"|[^[:space:]|;&]*)'
+CMDPOS='(^|[|;&(`])[[:space:]]*(('"$ASSIGN"'|'"$EXEPFX"'(sudo([[:space:]]+-[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?)*|env([[:space:]]+(-[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?|'"$ASSIGN"'))*|cmd(\.exe)?([[:space:]]+/[[:alnum:]]+(:[[:alnum:]]+)?)*[[:space:]]+/c|(powershell|pwsh)(\.exe)?([[:space:]]+-[^[:space:]]+)*[[:space:]]+-c[[:alnum:]]*))[[:space:]]+)*'"$EXEPFX"
+# Separator before the flag tolerates a real space OR a lowercased ${IFS}
+# token (a common word-split bypass), and the flag itself tolerates one
+# leading quote char - both `-rf` and `"-rf"`/`'-rf'` trip it (HIMMEL-851 U2/U3).
+if contains '(^|[^[:alnum:]_.-])rm(\.exe)?([^[:alnum:]_.-][^|;&]*)?([[:space:]]|\$\{ifs\})['\''"]?-[[:alnum:]_]*r'; then
     deny "recursive rm"
 fi
 if contains '(^|[^[:alnum:]_.-])rm(\.exe)?([^[:alnum:]_.-]|$)[^|;&]*--recursive([^[:alnum:]_-]|$)'; then
     deny "recursive rm"
 fi
-if contains '(^|[^[:alnum:]_.-])(del|erase|rd|rmdir)(\.exe)?([^[:alnum:]_.-]|$)[^|;&]*/s'; then
+# Backslash-newline continuation: newlines are already folded to ';' above, so
+# `rm \<newline>-rf` becomes `rm \;-rf` here - the literal backslash before the
+# folded separator is the tell (HIMMEL-851 U3). `;+` (not a single `;`): on
+# Windows, jq's text-mode stdout turns the JSON-decoded `\n` into `\r\n`, so
+# ONE real newline folds to TWO semicolons here - tolerate either.
+if contains '(^|[^[:alnum:]_.-])rm(\.exe)?[[:space:]]*\\[[:space:]]*;+[[:space:]]*-[[:alnum:]_]*r'; then
+    deny "recursive rm (line continuation)"
+fi
+# /s is bound to the switch (space/another switch/end), not a path prefix -
+# `rd /scripts` must not false-trip on the "/s" substring (HIMMEL-851 U1).
+if contains '(^|[^[:alnum:]_.-])(del|erase|rd|rmdir)(\.exe)?([^[:alnum:]_.-]|$)[^|;&]*/s([^[:alnum:]_.-]|$)'; then
     deny "recursive Windows delete"
 fi
 # mkfs keeps no trailing boundary (parity: \bmkfs) so mkfs.ext4 still matches.

--- a/scripts/hooks/test-block-destructive-commands.sh
+++ b/scripts/hooks/test-block-destructive-commands.sh
@@ -61,6 +61,43 @@ assert_rc "mkfs.ext4 /dev/sda"         2 "$(run_case "$(j_bash 'mkfs.ext4 /dev/s
 assert_rc "FOO=1 shutdown -r"          2 "$(run_case "$(j_bash 'FOO=1 shutdown -r')")"
 # shellcheck disable=SC2016  # literal backtick payload is the point of this case
 assert_rc "backtick format subst"      2 "$(run_case "$(j_bash 'echo `format c:`')")"
+assert_rc "rm quoted -rf flag"          2 "$(run_case "$(j_bash 'rm "-rf" file')")"
+# shellcheck disable=SC2016  # literal ${IFS} payload is the point of this case
+assert_rc 'rm ${IFS}-separated -rf'     2 "$(run_case "$(j_bash 'rm${IFS}-rf${IFS}x')")"
+# Backslash-newline continuation (HIMMEL-851 U3): real multi-line single-quoted
+# string so the literal backslash + newline reach the hook exactly as a shell
+# line-continuation would produce them.
+cont_cmd='rm \
+-rf x'
+assert_rc "rm backslash-continuation -rf" 2 "$(run_case "$(j_bash "$cont_cmd")")"
+# CR r1 (HIMMEL-851): bounded launcher-wrapper tolerance in command position.
+assert_rc "sudo shutdown"               2 "$(run_case "$(j_bash 'sudo shutdown -h now')")"
+assert_rc "x=1 shutdown"                2 "$(run_case "$(j_bash 'x=1 shutdown -h now')")"
+# CR r5 (HIMMEL-851): assignment VALUE is quote-aware.
+assert_rc "single-quoted assign shutdown" 2 "$(run_case "$(j_bash "foo='a b' shutdown -h now")")"
+assert_rc "double-quoted assign schtasks" 2 "$(run_case "$(j_bash 'foo="a b" schtasks /delete /f')")"
+assert_rc "cmd /c shutdown"             2 "$(run_case "$(j_bash 'cmd /c shutdown /s /t 0')")"
+assert_rc "cmd /d /c shutdown"          2 "$(run_case "$(j_bash 'cmd /d /c shutdown /s /t 0')")"
+assert_rc "cmd.exe /d /s /c shutdown"   2 "$(run_case "$(j_bash 'cmd.exe /d /s /c shutdown /s /t 0')")"
+assert_rc "powershell -command stop-process" 2 "$(run_case "$(j_bash 'powershell -command stop-process -name foo')")"
+# CR r2 (HIMMEL-851): path-qualified destructive executables.
+assert_rc "/sbin/shutdown"              2 "$(run_case "$(j_bash '/sbin/shutdown -h now')")"
+assert_rc "./shutdown relative"         2 "$(run_case "$(j_bash './shutdown -h now')")"
+assert_rc "drive-path shutdown.exe"     2 "$(run_case "$(j_bash 'c:/windows/system32/shutdown.exe /s /t 0')")"
+assert_rc "quoted drive-path shutdown"  2 "$(run_case "$(j_bash '"C:/Windows/System32/shutdown.exe" /s /t 0')")"
+assert_rc "backslash drive-path shutdown" 2 "$(run_case "$(j_bash 'C:\Windows\System32\shutdown.exe /s /t 0')")"
+# CR r4 (HIMMEL-851): path-qualified launcher wrappers.
+assert_rc "/usr/bin/env shutdown"       2 "$(run_case "$(j_bash '/usr/bin/env shutdown -h now')")"
+assert_rc "/usr/bin/sudo shutdown"      2 "$(run_case "$(j_bash '/usr/bin/sudo shutdown -h now')")"
+assert_rc "path-qualified cmd.exe /c shutdown" 2 "$(run_case "$(j_bash 'c:/windows/system32/cmd.exe /c shutdown /s /t 0')")"
+# CR r6 (HIMMEL-851): sudo/env tolerate their own flag runs (+ env assignments).
+assert_rc "sudo -n shutdown"            2 "$(run_case "$(j_bash 'sudo -n shutdown -h now')")"
+assert_rc "env -i shutdown"             2 "$(run_case "$(j_bash 'env -i shutdown -h now')")"
+assert_rc "env -i foo=bar shutdown"     2 "$(run_case "$(j_bash 'env -i foo=bar shutdown -h now')")"
+# CR r7 (HIMMEL-851): wrapper flags may each consume one following value token.
+assert_rc "sudo -u root shutdown"       2 "$(run_case "$(j_bash 'sudo -u root shutdown -h now')")"
+assert_rc "env -u path shutdown"        2 "$(run_case "$(j_bash 'env -u path shutdown -h now')")"
+assert_rc "sudo -u root -g wheel taskkill" 2 "$(run_case "$(j_bash 'sudo -u root -g wheel taskkill /f')")"
 
 # --- ALLOW cases (expect rc=0) ---
 assert_rc "rmtemp.sh -r foo"           0 "$(run_case "$(j_bash 'rmtemp.sh -r foo')")"
@@ -78,6 +115,16 @@ assert_rc "git log quoted format"      0 "$(run_case "$(j_bash 'git log --pretty
 assert_rc "grep -rn format src/"       0 "$(run_case "$(j_bash 'grep -rn format src/')")"
 assert_rc "rg format scripts/"         0 "$(run_case "$(j_bash 'rg "format" scripts/')")"
 assert_rc "commit msg mentions reboot" 0 "$(run_case "$(j_bash 'git commit -m "fix reboot loop"')")"
+assert_rc "rd /scripts (path, not switch)" 0 "$(run_case "$(j_bash 'rd /scripts foo')")"
+assert_rc "echo shutdown mid-argument"  0 "$(run_case "$(j_bash 'echo shutdown')")"
+assert_rc "format-data path basename"   0 "$(run_case "$(j_bash 'x; foo/format-data bar')")"
+assert_rc "/usr/bin/env python3 benign" 0 "$(run_case "$(j_bash '/usr/bin/env python3 build.py')")"
+assert_rc "echo'd quoted assign+verb"   0 "$(run_case "$(j_bash "echo \"FOO='a b' shutdown\"")")"
+assert_rc "sudo -n apt benign"          0 "$(run_case "$(j_bash 'sudo -n apt update')")"
+assert_rc "env -i printenv benign"      0 "$(run_case "$(j_bash 'env -i printenv')")"
+assert_rc "sudo -u root ls benign"      0 "$(run_case "$(j_bash 'sudo -u root ls')")"
+assert_rc "sudo -u root apt benign"     0 "$(run_case "$(j_bash 'sudo -u root apt update')")"
+assert_rc "env -u path printenv benign" 0 "$(run_case "$(j_bash 'env -u path printenv')")"
 assert_rc "non-terminal tool"          0 "$(run_case '{"tool_name":"Read","tool_input":{"file_path":"README.md"}}')"
 assert_rc "empty payload"              0 "$(run_case '{}')"
 


### PR DESCRIPTION
## Summary
- [HIMMEL-851] Four spec fixes to the destructive-command floor, parity-locked across scripts/hooks/block-destructive-commands.sh and scripts/hermes/assets/parity_guard.py: U1 (the recursive switch is bound to switch position — a path argument starting with a slash after the Windows remove-dir verb no longer false-trips), U2 (quoted recursive flags), U3 (IFS-expansion + backslash-continuation shapes, bounded per ticket), O1 (command-position anchoring ported to py — `git log --pretty=format:%H`, `grep -rn format src/`, commit messages mentioning reboot no longer false-block).
- The O1 port then survived **7 codex adversarial rounds**, each fixed RED-first in BOTH impls: backtick command position + env-assignment prefixes (r1), path-qualified executables (r2), cmd switches before /c (r3), path-qualified launchers (r4), quoted assignment values (r5), wrapper flags (r6), wrapper flag-values — generic, no per-option tables (r7).
- Explicit residual contract in both anchor comments: quoted-payload wrappers (`bash -c "…"`, xargs/nohup chains) are out of scope per the ticket's no-general-parser rule → **HIMMEL-912** (shared tokenizer follow-up); the CC hook + auto-mode classifier are the named outer defense layers.

## Verification
- Mirrored suites: test-block-destructive-commands.sh **76/76**, test-parity-guard.sh **124/124** (1 pre-existing environmental symlink skip). Every round's bypass probes re-run green at the final tip; no previously-passing case weakened at any round.
- CR: panel agreed+fixed; codex adversarial rounds 1-7 all fixed; the greedy-backtracking edge (valueless wrapper flag followed by a protected verb) empirically verified blocked in both impls. Private PR trail on HIMMEL-851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[HIMMEL-851]: https://yotamleo.atlassian.net/browse/HIMMEL-851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ