### PR TITLE
fix(lib): [HIMMEL-911] pin qmd fork install to immutable commit SHA (891 precedent, fail-closed)

### DIFF
--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -411,7 +411,8 @@ qmd is a local markdown search engine (BM25 + vector + rerank). himmel's fork
 runs it as a **shared HTTP daemon** (`localhost:8181`, HIMMEL-592) auto-brought-up
 by the `qmd` plugin's SessionStart hook, so every session shares one read-only
 index. The standalone CLI installs from the **himmel qmd fork**
-(`yotamleo/qmd#himmel-main`) — never upstream `bun add -g @tobilu/qmd`, which
+(`yotamleo/qmd`), pinned to an immutable commit SHA rather than a mutable
+branch (HIMMEL-911) — never upstream `bun add -g @tobilu/qmd`, which
 EPERM-wedges on this project's machines (zombie `qmd mcp` stdio processes hold
 locks) and bun blocks its postinstall script (HIMMEL-877). `bun` itself is
 still required to build the clone (project rule: bun, never npm — see §1
@@ -424,8 +425,8 @@ skipped those or want the luna vault indexed too.
 # 1. Install the qmd CLI: clone the fork, build it with bun, then junction
 #    (Windows) / symlink (POSIX) it onto the bun-global @tobilu/qmd path —
 #    scripts/lib/qmd-bin.sh is the single chokepoint (also used by adopt.sh/
-#    setup.sh); repo/branch/clone-dir are overridable via QMD_FORK_REPO /
-#    QMD_FORK_BRANCH / QMD_FORK_DIR. Idempotent — re-run to update.
+#    setup.sh); repo/ref/clone-dir are overridable via QMD_FORK_REPO /
+#    QMD_FORK_REF / QMD_FORK_DIR. Idempotent — re-run to update.
 bash scripts/lib/qmd-bin.sh install
 
 # 2. Pull the embedding + rerank models. WARNING: ~2.1 GB download — Ctrl-C-safe

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -89,15 +89,18 @@ Installed via `extraKnownMarketplaces` in `settings.json`.
 **MCP server:** `plugin:qmd:qmd` — exposes `query`, `get`, `multi_get`, `status` tools.
 **Usage:** Searching local knowledge base, notes, docs.
 
-**CLI install (HIMMEL-877):** the standalone `qmd` CLI installs from the
-**himmel qmd fork** (`yotamleo/qmd#himmel-main`) via `scripts/lib/qmd-bin.sh`'s
-`qmd_install` (clone → `bun install && bun run build` → junction/symlink onto
-the bun-global `@tobilu/qmd` path) — never upstream `bun add -g @tobilu/qmd`,
+**CLI install (HIMMEL-877, pinned HIMMEL-911):** the standalone `qmd` CLI
+installs from the **himmel qmd fork** (`yotamleo/qmd`), pinned to an
+immutable commit SHA (`1032a648447a54eb73df138a3861dd7a9a64c595`, tag
+`v2.6.3-himmel.1` as the human-readable alias) rather than a mutable
+branch, via `scripts/lib/qmd-bin.sh`'s `qmd_install` (clone → fetch/checkout
+the pinned SHA → `bun install && bun run build` → junction/symlink onto the
+bun-global `@tobilu/qmd` path) — never upstream `bun add -g @tobilu/qmd`,
 which EPERM-wedges on this project's machines and bun blocks its postinstall
 script. `adopt.sh`/`setup.sh` (bash) and `adopt.ps1`/`setup.ps1` (pwsh, which
 delegates via `bash scripts/lib/qmd-bin.sh install` rather than duplicating
 the recipe) both call this. Idempotent; overridable via `QMD_FORK_REPO` /
-`QMD_FORK_BRANCH` / `QMD_FORK_DIR`.
+`QMD_FORK_REF` / `QMD_FORK_DIR`.
 
 **Shared HTTP singleton (HIMMEL-592):** himmel vendors `qmd@himmel`
 (`marketplace/plugins/qmd/`, a thin fork of upstream `qmd@qmd`) whose only

--- a/marketplace/plugins/qmd/README.md
+++ b/marketplace/plugins/qmd/README.md
@@ -55,8 +55,9 @@ silent empty index).
 ## Upstream watch
 
 The standalone `qmd` CLI now installs from himmel's own fork
-(`yotamleo/qmd#himmel-main`, cloned + built with bun, then junctioned/
-symlinked onto the bun-global `@tobilu/qmd` path — `scripts/lib/qmd-bin.sh`,
+(`yotamleo/qmd`, pinned to an immutable commit SHA rather than a mutable
+branch — HIMMEL-911 — cloned + built with bun, then junctioned/symlinked
+onto the bun-global `@tobilu/qmd` path — `scripts/lib/qmd-bin.sh`,
 HIMMEL-877), not `bun add -g @tobilu/qmd` upstream (that command EPERM-wedges
 on this project's machines and bun blocks its postinstall script). This
 plugin's **manifest + skill** stay pinned separately and are low-churn.

--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -262,8 +262,9 @@ function FillEnv-Core {
 # $env:BUN_INSTALL for relocated bun roots.
 $QmdBunRoot = if ($env:BUN_INSTALL) { $env:BUN_INSTALL } else { Join-Path $HOME '.bun' }
 $QmdBunJs = Join-Path $QmdBunRoot 'install\global\node_modules\@tobilu\qmd\dist\cli\qmd.js'
-# HIMMEL-877: qmd installs from the himmel qmd fork (yotamleo/qmd#himmel-main
-# via scripts/lib/qmd-bin.sh), never upstream `bun add -g @tobilu/qmd` --
+# HIMMEL-877: qmd installs from the himmel qmd fork (yotamleo/qmd, pinned to
+# an immutable commit SHA rather than a mutable branch — HIMMEL-911 — via
+# scripts/lib/qmd-bin.sh), never upstream `bun add -g @tobilu/qmd` --
 # that command EPERM-wedges on this project's machines and bun blocks its
 # postinstall script.
 $QmdInstallHint = "bash `"$HimmelRoot/scripts/lib/qmd-bin.sh`" install"

--- a/scripts/lib/qmd-bin.sh
+++ b/scripts/lib/qmd-bin.sh
@@ -17,21 +17,31 @@
 # source this lib; this resolver stays as the consumer-side path until
 # the upstream plugin fix is pulled.
 #
-# HIMMEL-877: qmd installs from the himmel FORK (yotamleo/qmd, default
-# branch himmel-main), never upstream `bun add -g @tobilu/qmd` -- that
-# command EPERM-wedges on this project's machines (zombie `qmd mcp` stdio
-# node processes hold locks) and bun blocks the postinstall script. The
-# proven recipe (done by hand on the primary machine, now automated here):
-# clone the fork to a stable dir, `bun install && bun run build` in the
-# clone, then a directory junction (Windows) / symlink (POSIX) at
-# ~/.bun/install/global/node_modules/@tobilu/qmd pointing at the clone --
-# bun's stock global shims then transparently serve the fork from the
-# same path every other consumer (qmd_cmd, has_qmd, the fix-qmd-stub
-# patched stub) already resolves. qmd_install() is idempotent: it detects
-# an already-fork-served install (global path already links to the fork
-# clone AND `qmd --version` reports >= QMD_FORK_MIN_VERSION) and skips.
-# Fork repo/branch/clone-dir are overridable via QMD_FORK_REPO /
-# QMD_FORK_BRANCH / QMD_FORK_DIR for testing or a private mirror.
+# HIMMEL-877: qmd installs from the himmel FORK (yotamleo/qmd), never
+# upstream `bun add -g @tobilu/qmd` -- that command EPERM-wedges on this
+# project's machines (zombie `qmd mcp` stdio node processes hold locks) and
+# bun blocks the postinstall script. The proven recipe (done by hand on the
+# primary machine, now automated here): clone the fork to a stable dir,
+# `bun install && bun run build` in the clone, then a directory junction
+# (Windows) / symlink (POSIX) at ~/.bun/install/global/node_modules/@tobilu/qmd
+# pointing at the clone -- bun's stock global shims then transparently serve
+# the fork from the same path every other consumer (qmd_cmd, has_qmd, the
+# fix-qmd-stub patched stub) already resolves. qmd_install() is idempotent:
+# it detects an already-fork-served install (global path already links to
+# the fork clone AND the clone's HEAD is the pinned commit AND `qmd
+# --version` reports >= QMD_FORK_MIN_VERSION) and skips.
+#
+# PIN (HIMMEL-911): the install ref is a FULL COMMIT SHA on the fork --
+# not the himmel-main branch. himmel-main is a MUTABLE tracking branch
+# (where upstream merges land); a force-push there would silently change
+# what every future `qmd-bin.sh install` runs, with no reviewed repo change
+# -- a supply-chain trust boundary on new-machine bootstrap (mirrors the
+# HIMMEL-891 graphify precedent, scripts/lib/graphify-bin.sh). The commit
+# SHA is the only content-addressed, unmovable ref. The fork tag
+# v2.6.3-himmel.1 points at this same commit as human-readable release
+# provenance; a pin bump is a reviewed change to this file. Fork
+# repo/ref/clone-dir are overridable via QMD_FORK_REPO / QMD_FORK_REF /
+# QMD_FORK_DIR for testing or a private mirror.
 # qmd_register_collection() is the shared idempotent collection-
 # registration helper used by setup.sh + adopt.sh. Executed directly
 # (not sourced), this file also answers `install` on argv (see the CLI
@@ -41,22 +51,29 @@
 
 # Fork config -- overridable per call (env var set before sourcing/calling).
 _qmd_fork_repo() { printf '%s\n' "${QMD_FORK_REPO:-https://github.com/yotamleo/qmd.git}"; }
-_qmd_fork_branch() { printf '%s\n' "${QMD_FORK_BRANCH:-himmel-main}"; }
+# = v2.6.3-himmel.1
+_qmd_fork_ref() { printf '%s\n' "${QMD_FORK_REF:-1032a648447a54eb73df138a3861dd7a9a64c595}"; }
 _qmd_fork_dir() { printf '%s\n' "${QMD_FORK_DIR:-$HOME/.himmel/qmd-fork}"; }
 _qmd_fork_min_version() { printf '%s\n' "${QMD_FORK_MIN_VERSION:-2.6.3}"; }
+# Build-success stamp INSIDE the clone (HIMMEL-911 CR r3): one file, no
+# schema -- its content is the exact pinned SHA the artifacts were BUILT
+# from. Written only after build + link + version verification all succeed;
+# cleared at the start of any update attempt. HEAD alone cannot distinguish
+# "checked out the pin" from "successfully BUILT the pin".
+_qmd_build_stamp() { printf '%s\n' "$(_qmd_fork_dir)/.himmel-build-ok"; }
 
 # Prints the manual recipe (clone + build + link). Best-effort documentation
 # text embedded in WARN messages -- NOT eval'd (HIMMEL-877 dropped the old
 # single-command `bun add -g @tobilu/qmd@latest` eval path; qmd_install()
 # below runs the multi-step recipe directly).
 qmd_install_hint() {
-  local fork_dir branch global_dir
+  local fork_dir ref global_dir
   fork_dir="$(_qmd_fork_dir)"
-  branch="$(_qmd_fork_branch)"
+  ref="$(_qmd_fork_ref)"
   global_dir="$(_qmd_global_dir)"
   printf '%s\n' \
-    "git clone -b $branch $(_qmd_fork_repo) $fork_dir" \
-    "(cd $fork_dir && bun install && bun run build)" \
+    "git clone $(_qmd_fork_repo) $fork_dir" \
+    "(cd $fork_dir && git fetch origin $ref && git checkout $ref && bun install && bun run build)" \
     "link $fork_dir over $global_dir (Windows: mklink /J; POSIX: ln -s) -- or re-run qmd_install"
 }
 
@@ -252,16 +269,36 @@ _qmd_ensure_global_link() {
 }
 
 # True when the fork is already the SERVED install: the bun-global
-# @tobilu/qmd path resolves to the fork clone AND the version probe reports
-# >= QMD_FORK_MIN_VERSION. This is the caller-side install gate (HIMMEL-877
-# CR codex-adv-1): callers must gate qmd_install on THIS, never on presence
-# (has_qmd) -- a machine carrying the old upstream bun-global install (the
-# exact population this change migrates) is qmd-PRESENT but not fork-served,
-# and a presence gate would skip the migration entirely. Also exposed as the
-# `fork-served` CLI verb so the pwsh mirrors share the same predicate.
+# @tobilu/qmd path resolves to the fork clone AND the clone's HEAD is the
+# pinned commit AND the build-success stamp records that exact pin AND the
+# version probe reports >= QMD_FORK_MIN_VERSION. This
+# is the caller-side install gate (HIMMEL-877 CR codex-adv-1): callers must
+# gate qmd_install on THIS, never on presence (has_qmd) -- a machine carrying
+# the old upstream bun-global install (the exact population this change
+# migrates) is qmd-PRESENT but not fork-served, and a presence gate would
+# skip the migration entirely. Also exposed as the `fork-served` CLI verb so
+# the pwsh mirrors share the same predicate.
 qmd_fork_served() {
-  local ver
+  local ver head stamp
   _qmd_global_points_to_fork || return 1
+  # HIMMEL-911 CR r1 codex-adv-1: link-target + version alone would bless an
+  # existing clean install built from the mutable himmel-main branch head --
+  # exactly the population the pin migrates -- and qmd_install would skip it
+  # forever. The clone's resolved HEAD must BE the pinned commit. Guarded:
+  # any git failure = not-served. Cheap + local-only (rev-parse of HEAD
+  # never touches the network).
+  head="$(git -C "$(_qmd_fork_dir)" rev-parse HEAD 2>/dev/null)" || return 1
+  [ "$head" = "$(_qmd_fork_ref)" ] || return 1
+  # HIMMEL-911 CR r3 codex-adv: HEAD==pin is necessary but NOT sufficient --
+  # a drifted upgrade moves HEAD to the pin BEFORE bun runs, so a build
+  # failure would leave HEAD==pin while the OLD dist (built from the mutable
+  # commit) keeps serving, and every retry would skip here forever. The
+  # served artifacts must carry the build-success stamp for this exact pin.
+  # Legacy installs without the stamp (pre-stamp machines) intentionally
+  # read as not-served so they converge onto a stamped pinned build on the
+  # next install pass.
+  stamp="$(cat "$(_qmd_build_stamp)" 2>/dev/null)" || return 1
+  [ "$stamp" = "$(_qmd_fork_ref)" ] || return 1
   ver="$(qmd_cmd --version 2>/dev/null)" || return 1
   _qmd_version_ge "$ver" "$(_qmd_fork_min_version)"
 }
@@ -274,13 +311,15 @@ qmd_fork_served() {
 # caller's `set -e` cannot abort mid-install before the rc is returned.
 #
 # Idempotent: skips cleanly when qmd_fork_served (global path already links
-# to the fork clone AND the version probe passes); still falls through to
-# update+rebuild+re-link on a stale/older clone.
+# to the fork clone AND the clone's HEAD is the pinned commit AND the
+# build-success stamp records that pin AND the version probe passes); still
+# falls through to update+rebuild+re-link on a stale/older/pin-drifted or
+# unstamped (failed/interrupted prior build) clone.
 qmd_install() {
-  local fork_dir branch repo global_dir origin_url
+  local fork_dir ref repo global_dir origin_url
 
   fork_dir="$(_qmd_fork_dir)"
-  branch="$(_qmd_fork_branch)"
+  ref="$(_qmd_fork_ref)"
   repo="$(_qmd_fork_repo)"
   global_dir="$(_qmd_global_dir)"
 
@@ -289,7 +328,7 @@ qmd_install() {
     return 0
   fi
 
-  echo "Installing qmd fork ($repo#$branch)..."
+  echo "Installing qmd fork ($repo@$ref)..."
 
   if ! command -v git >/dev/null 2>&1; then
     echo "  git not found - cannot clone the qmd fork." >&2
@@ -313,27 +352,71 @@ qmd_install() {
       echo "  Point QMD_FORK_DIR at a dedicated location, or fix the clone's origin remote." >&2
       return 1
     fi
+    # HIMMEL-911 CR r3: clear the build-success stamp FIRST (ownership is
+    # established by the origin check above) -- from here until the
+    # post-verification stamp write this machine is NOT fork-served, so an
+    # interrupted or failed upgrade can never be mistaken for served on a
+    # retry. Also keeps our own untracked stamp file from tripping the
+    # dirty-worktree probe below.
+    rm -f -- "$(_qmd_build_stamp)"
     if [ -n "$(git -C "$fork_dir" status --porcelain 2>/dev/null)" ] && [ "${QMD_FORK_FORCE:-0}" != "1" ]; then
       echo "  WARNING: $fork_dir has uncommitted changes - refusing to hard-reset it." >&2
       echo "  Commit/stash them, or re-run with QMD_FORK_FORCE=1 to discard them." >&2
       return 1
     fi
-    echo "  qmd fork clone exists at $fork_dir - updating $branch..."
+    echo "  qmd fork clone exists at $fork_dir - updating to $ref..."
+    # HIMMEL-911 CR r1 codex-adv-2: FAIL CLOSED. The old fallback (WARN +
+    # build the clone contents as-is) silently served an UNPINNED commit
+    # while reporting success -- the exact outcome the pin exists to prevent.
+    # An already-served install stays untouched (nothing rebuilt/re-linked);
+    # WARN-not-fail remains the CALLER's contract: qmd_install returns an
+    # honest nonzero and the caller decides whether that aborts.
     if ! ( cd "$fork_dir" \
-           && git fetch origin "$branch" \
-           && git checkout "$branch" \
-           && git reset --hard "origin/$branch" ); then
-      echo "  WARNING: qmd fork fetch/checkout failed - building the existing clone contents as-is." >&2
+           && git fetch origin "$ref" \
+           && git checkout "$ref" \
+           && git reset --hard "$ref" ); then
+      echo "  ERROR: could not update the qmd fork clone to pinned commit $ref - refusing to build/serve unpinned contents." >&2
+      return 1
     fi
   else
+    # HIMMEL-911 CR r2 codex-adv: never adopt an existing NON-git path.
+    # QMD_FORK_DIR is operator-overridable, so a populated non-git directory
+    # here is USER DATA that predates the installer -- `git init`ing it in
+    # place and then `rm -rf`ing it on a clone failure would destroy it (the
+    # origin-mismatch refusal above only protects dirs that already ARE git
+    # repos). Refuse untouched; only a path THIS invocation creates is ever
+    # cleaned up on failure.
+    if [ -e "$fork_dir" ]; then
+      echo "  WARNING: $fork_dir exists but is not a git clone - refusing to touch it." >&2
+      echo "  Point QMD_FORK_DIR at a dedicated location, or remove the directory yourself." >&2
+      return 1
+    fi
     if ! mkdir -p -- "$(dirname -- "$fork_dir")"; then
       echo "  ERROR: could not create $(dirname -- "$fork_dir")" >&2
       return 1
     fi
-    if ! git clone --depth 1 --branch "$branch" --single-branch "$repo" "$fork_dir"; then
+    # A commit SHA cannot be passed to `git clone --branch` -- GitHub allows
+    # fetching a reachable SHA directly, so init + fetch-by-sha + checkout is
+    # the pinned-ref equivalent of a shallow branch clone (HIMMEL-911).
+    if ! git init "$fork_dir" >/dev/null \
+         || ! git -C "$fork_dir" remote add origin "$repo" \
+         || ! git -C "$fork_dir" fetch --depth 1 origin "$ref" \
+         || ! git -C "$fork_dir" checkout "$ref"; then
       echo "  qmd fork clone failed." >&2
+      # Safe by construction: the refusal above guarantees $fork_dir did not
+      # exist before this invocation created it (never delete what we did
+      # not create -- HIMMEL-911 CR r2).
+      rm -rf -- "$fork_dir"
       return 1
     fi
+  fi
+
+  # Belt-and-braces (HIMMEL-911 CR r1 codex-adv-2): whichever path ran above,
+  # the clone must actually BE at the pinned commit before anything is built
+  # or served -- guards a partial checkout that still returned 0.
+  if [ "$(git -C "$fork_dir" rev-parse HEAD 2>/dev/null)" != "$ref" ]; then
+    echo "  ERROR: $fork_dir HEAD is not the pinned commit $ref - refusing to build/serve it." >&2
+    return 1
   fi
 
   echo "  Building qmd fork (bun install && bun run build)..."
@@ -349,6 +432,14 @@ qmd_install() {
   fi
 
   if qmd_cmd --version >/dev/null 2>&1; then
+    # HIMMEL-911 CR r3: stamp build success only NOW -- build + link +
+    # version verification all passed, so the served artifacts really were
+    # built from the pinned commit. An unwritable stamp keeps the install
+    # honestly not-served (nonzero) instead of silently unstamped.
+    if ! printf '%s\n' "$ref" > "$(_qmd_build_stamp)" 2>/dev/null; then
+      echo "  WARNING: qmd fork verified but the build stamp could not be written." >&2
+      return 1
+    fi
     echo "  qmd fork installed and verified ($(qmd_cmd --version 2>/dev/null))."
     return 0
   fi

--- a/scripts/lib/test-qmd-bin.sh
+++ b/scripts/lib/test-qmd-bin.sh
@@ -31,11 +31,26 @@ echo "[test-qmd-bin] qmd_install_hint emits the fork clone+build+link recipe (HI
 hint="$(qmd_install_hint)"
 assert "hint mentions git clone" grep -q '^git clone ' <<<"$hint"
 assert "hint mentions the himmel fork repo" grep -q 'yotamleo/qmd' <<<"$hint"
-assert "hint mentions the himmel-main branch" grep -q 'himmel-main' <<<"$hint"
+assert "hint pins a full commit SHA (HIMMEL-911), not a movable ref" grep -qE 'fetch origin [0-9a-f]{40} ' <<<"$hint"
+# shellcheck disable=SC2016
+# Single quotes intentional — $1 expands inside the spawned bash -c subshell.
+assert "hint does NOT install from the mutable himmel-main branch" \
+  bash -c '! grep -q "himmel-main" <<<"$1"' _ "$hint"
 assert "hint mentions bun install/build" grep -q 'bun install && bun run build' <<<"$hint"
 # shellcheck disable=SC2016
 # Single quotes intentional — $1 expands inside the spawned bash -c subshell.
 assert "hint does NOT mention upstream bun add -g" bash -c '! grep -q "bun add -g" <<<"$1"' _ "$hint"
+
+echo "[test-qmd-bin] pin policy (HIMMEL-911): the configured ref IS a full 40-hex commit SHA"
+# Tags/branches are force-movable; only a commit SHA is content-addressed.
+# This pins the POLICY so a future 'bump the pin' change that swaps in a tag
+# or branch name fails here. (Run with the env override cleared -- the test
+# targets the committed default.)
+default_ref="$(env -u QMD_FORK_REF bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; _qmd_fork_ref')"
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "default QMD_FORK_REF is a full 40-hex SHA" \
+  bash -c 'printf "%s" "$1" | grep -qE "^[0-9a-f]{40}$"' _ "$default_ref"
 
 echo "[test-qmd-bin] qmd_cmd resolver — prefer bun"
 tmpdir="$(mktemp -d)"
@@ -111,10 +126,10 @@ rc=0
 HOME="$tmpdir" PATH="$tmpdir/bin:$PATH" BUN_INSTALL="$tmpdir/custom-bun" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_cmd --version' >/dev/null 2>&1 || rc=$?
 assert "wrapped command rc=42 propagates" test "$rc" -eq 42
 
-echo "[test-qmd-bin] QMD_FORK_REPO / QMD_FORK_BRANCH / QMD_FORK_DIR overrides (HIMMEL-877)"
-override_hint="$(QMD_FORK_REPO=https://example.test/mirror/qmd.git QMD_FORK_BRANCH=my-branch QMD_FORK_DIR=/custom/fork/dir qmd_install_hint)"
+echo "[test-qmd-bin] QMD_FORK_REPO / QMD_FORK_REF / QMD_FORK_DIR overrides (HIMMEL-877/HIMMEL-911)"
+override_hint="$(QMD_FORK_REPO=https://example.test/mirror/qmd.git QMD_FORK_REF=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef QMD_FORK_DIR=/custom/fork/dir qmd_install_hint)"
 assert "hint honors QMD_FORK_REPO override" grep -q 'example.test/mirror/qmd.git' <<<"$override_hint"
-assert "hint honors QMD_FORK_BRANCH override" grep -q 'my-branch' <<<"$override_hint"
+assert "hint honors QMD_FORK_REF override" grep -q 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' <<<"$override_hint"
 assert "hint honors QMD_FORK_DIR override" grep -q '/custom/fork/dir' <<<"$override_hint"
 
 echo "[test-qmd-bin] has_qmd is presence-only (does not invoke binary)"
@@ -125,8 +140,9 @@ rc=0
 HOME="$tmpdir" PATH="$tmpdir/bin:$PATH" BUN_INSTALL="$tmpdir/broken-bun" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; has_qmd' || rc=$?
 assert "has_qmd=true even when bun-js is broken (presence only)" test "$rc" -eq 0
 
-echo "[test-qmd-bin] qmd_install() fork clone+build+link recipe (HIMMEL-877)"
-# Hermetic stub env: a fake `git` (clone creates a .git marker + package.json;
+echo "[test-qmd-bin] qmd_install() fork clone+build+link recipe (HIMMEL-877/HIMMEL-911)"
+# Hermetic stub env: a fake `git` (init creates a .git marker + package.json,
+# matching what a real `git init` + first fetch/checkout leaves behind;
 # fetch/checkout/reset are individually controllable) and a fake `bun`
 # (install/run-build individually controllable; any other invocation is the
 # qmd_cmd dispatch `bun <qmd.js> --version`, which prints a fake version).
@@ -142,18 +158,44 @@ cat > "$id2/bin/git" <<'STUB'
 if [ "$1" = "-C" ]; then shift 2; fi
 echo "GIT $*" >> "${GIT_LOG:?}"
 case "$1" in
-  clone)
+  init)
+    # `git init <fork_dir>` (HIMMEL-911: a SHA can't be `git clone --branch`ed,
+    # so the fresh-install path is init + fetch-by-sha + checkout).
     [ "${STUB_GIT_CLONE_RC:-0}" -eq 0 ] || exit "$STUB_GIT_CLONE_RC"
-    target="${!#}"
+    target="$2"
     mkdir -p "$target/.git"
     echo '{}' > "$target/package.json"
     exit 0
     ;;
-  fetch|checkout|reset) exit "${STUB_GIT_FETCH_RC:-0}" ;;
   remote)
+    if [ "$2" = "add" ]; then
+      # `remote add origin <url>` -- nothing to simulate, just succeed.
+      exit 0
+    fi
     # `remote get-url origin` ownership probe: default answers the default
     # fork repo URL so owned-clone scenarios pass the guard.
     printf '%s\n' "${STUB_GIT_ORIGIN_URL:-https://github.com/yotamleo/qmd.git}"
+    exit 0
+    ;;
+  fetch|reset) exit "${STUB_GIT_FETCH_RC:-0}" ;;
+  checkout)
+    # A successful checkout moves HEAD to the requested commit -- mirror it
+    # into the head-state file (when the scenario tracks one) so rev-parse
+    # answers realistically after a re-pin (HIMMEL-911).
+    if [ "${STUB_GIT_FETCH_RC:-0}" -eq 0 ] && [ -n "${STUB_GIT_HEAD_FILE:-}" ]; then
+      printf '%s\n' "$2" > "$STUB_GIT_HEAD_FILE"
+    fi
+    exit "${STUB_GIT_FETCH_RC:-0}"
+    ;;
+  rev-parse)
+    # HEAD probe (qmd_fork_served pin gate + qmd_install post-checkout
+    # verify, HIMMEL-911): the head-state file when tracked, else the
+    # STUB_GIT_HEAD env (qmd_install_env defaults it to the pinned ref).
+    if [ -n "${STUB_GIT_HEAD_FILE:-}" ] && [ -f "$STUB_GIT_HEAD_FILE" ]; then
+      cat "$STUB_GIT_HEAD_FILE"
+    else
+      printf '%s\n' "${STUB_GIT_HEAD:-}"
+    fi
     exit 0
     ;;
   status)
@@ -193,6 +235,7 @@ qmd_install_env() { # $1 = HOME dir, remaining = the command to run under it
   HOME="$home" GIT_LOG="$git_log" BUN_LOG="$bun_log" PATH="$id2/bin:$PATH" \
     STUB_GIT_CLONE_RC="${STUB_GIT_CLONE_RC:-0}" STUB_GIT_FETCH_RC="${STUB_GIT_FETCH_RC:-0}" \
     STUB_GIT_ORIGIN_URL="${STUB_GIT_ORIGIN_URL:-}" STUB_GIT_DIRTY="${STUB_GIT_DIRTY:-}" \
+    STUB_GIT_HEAD="${STUB_GIT_HEAD:-$default_ref}" STUB_GIT_HEAD_FILE="${STUB_GIT_HEAD_FILE:-}" \
     STUB_BUN_INSTALL_RC="${STUB_BUN_INSTALL_RC:-0}" STUB_BUN_BUILD_RC="${STUB_BUN_BUILD_RC:-0}" \
     STUB_BUN_VERSION_RC="${STUB_BUN_VERSION_RC:-0}" STUB_QMD_VERSION="${STUB_QMD_VERSION:-2.6.10}" \
     "$@"
@@ -203,16 +246,29 @@ fresh_home="$id2/fresh"; mkdir -p "$fresh_home"
 STUB_GIT_CLONE_RC=0 STUB_GIT_FETCH_RC=0 STUB_BUN_INSTALL_RC=0 STUB_BUN_BUILD_RC=0 STUB_BUN_VERSION_RC=0
 out=$(qmd_install_env "$fresh_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
 assert "fresh install: rc 0" grep -q '^RC=0$' <<<"$out"
-assert "fresh install: cloned the fork" grep -q 'GIT clone' "$git_log"
+assert "fresh install: initialized the fork clone" grep -q 'GIT init' "$git_log"
+assert "fresh install: added the fork as origin" grep -q 'GIT remote add origin' "$git_log"
+assert "fresh install: fetched the pinned SHA" grep -qE 'GIT fetch --depth 1 origin [0-9a-f]{40}' "$git_log"
+assert "fresh install: checked out the pinned SHA" grep -qE 'GIT checkout [0-9a-f]{40}' "$git_log"
 assert "fresh install: built with bun" grep -q 'BUN run build' "$bun_log"
 assert "fresh install: linked at the bun-global @tobilu/qmd path" \
   test -e "$fresh_home/.bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "fresh install: no git call references the mutable himmel-main branch" \
+  bash -c '! grep -q "himmel-main" "$1"' _ "$git_log"
 
-# -- idempotent re-run: already fork-served + version ok -> skip, clone/build
-#    never re-run (the version CHECK itself legitimately invokes bun once). --
+# -- idempotent re-run: already fork-served (link + pinned HEAD + version ok)
+#    -> skip, clone/build never re-run (the pin gate legitimately runs ONE
+#    read-only `git rev-parse HEAD`, and the version CHECK invokes bun once).
 out=$(qmd_install_env "$fresh_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
 assert "idempotent re-run: rc 0" grep -q '^RC=0$' <<<"$out"
-assert "idempotent re-run: no git call" test ! -s "$git_log"
+assert "idempotent re-run: pin gate probed HEAD (read-only rev-parse, HIMMEL-911)" \
+  grep -q 'GIT rev-parse HEAD' "$git_log"
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "idempotent re-run: no mutating git call (fetch/checkout/reset/init)" \
+  bash -c '! grep -qE "GIT (fetch|checkout|reset|init|clone|remote add)" "$1"' _ "$git_log"
 # shellcheck disable=SC2016
 # Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
 assert "idempotent re-run: did not re-run bun install" bash -c '! grep -q "BUN install" "$1"' _ "$bun_log"
@@ -229,6 +285,76 @@ mkdir -p "$noserve_home/.bun/install/global/node_modules/@tobilu/qmd/dist/cli"
 rc=0
 qmd_install_env "$noserve_home" bash "$SCRIPT_DIR/qmd-bin.sh" fork-served >/dev/null 2>&1 || rc=$?
 assert "fork-served CLI verb: nonzero on an upstream REAL-dir install (qmd present)" test "$rc" -ne 0
+
+# -- pin-drift (HIMMEL-911 CR r1 codex-adv-1): a linked, version-compatible
+#    clone checked out at a DIFFERENT commit must NOT count as served -- that
+#    is exactly the pre-pin population (built from the mutable himmel-main
+#    head) this change migrates. qmd_install must fall through to the update
+#    path and re-pin, never skip. ----------------------------------------------
+drift_head="$id2/drift-head"
+printf '%s\n' "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" > "$drift_head"
+STUB_GIT_HEAD_FILE="$drift_head"
+rc=0
+qmd_install_env "$fresh_home" bash "$SCRIPT_DIR/qmd-bin.sh" fork-served >/dev/null 2>&1 || rc=$?
+assert "pin-drift: fork-served nonzero on a drifted HEAD" test "$rc" -ne 0
+out=$(qmd_install_env "$fresh_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+assert "pin-drift: qmd_install did NOT skip (update-path fetch ran)" grep -q 'GIT fetch' "$git_log"
+assert "pin-drift: re-pinned successfully (rc 0)" grep -q '^RC=0$' <<<"$out"
+assert "pin-drift: clone HEAD is the pinned SHA afterward" grep -q "$default_ref" "$drift_head"
+
+# -- pinned-update failure on a SERVED-but-drifted install: FAIL CLOSED
+#    (HIMMEL-911 CR r1 codex-adv-2). The old fallback (WARN + build the clone
+#    contents as-is) silently served an UNPINNED commit while reporting
+#    success. Now: honest nonzero, ERROR names the pinned SHA, and the
+#    previously served installation is left untouched (no rebuild, no
+#    re-link, clone HEAD not half-updated). ------------------------------------
+printf '%s\n' "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" > "$drift_head"
+STUB_GIT_FETCH_RC=1
+out=$(qmd_install_env "$fresh_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+STUB_GIT_FETCH_RC=0
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "served-drift update-fail: rc nonzero (fail closed)" \
+  bash -c '! grep -q "^RC=0$" <<<"$1"' _ "$out"
+assert "served-drift update-fail: ERROR names the pinned SHA" \
+  grep -q "pinned commit $default_ref" <<<"$out"
+assert "served-drift update-fail: no rebuild (bun never invoked)" test ! -s "$bun_log"
+assert "served-drift update-fail: served link left untouched" \
+  test -e "$fresh_home/.bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
+assert "served-drift update-fail: clone HEAD untouched (still drifted)" \
+  grep -q 'deadbeef' "$drift_head"
+
+# -- build failure DURING a drifted upgrade must not mint a served pin
+#    (HIMMEL-911 CR r3 codex-adv): checkout moves HEAD to the pin BEFORE bun
+#    runs, so a build failure leaves HEAD==pin while the OLD dist (built from
+#    the mutable commit) keeps serving. Without the build-success stamp a
+#    RETRY would see HEAD==pin + version>=min -> served -> skip silently
+#    forever, reporting a valid pinned install over stale artifacts. ------------
+printf '%s\n' "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" > "$drift_head"
+STUB_BUN_BUILD_RC=1
+out=$(qmd_install_env "$fresh_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+STUB_BUN_BUILD_RC=0
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "drift+build-fail: rc nonzero" bash -c '! grep -q "^RC=0$" <<<"$1"' _ "$out"
+assert "drift+build-fail: HEAD did move to the pin (the trap precondition)" \
+  grep -q "$default_ref" "$drift_head"
+# RETRY with bun healthy again: must NOT skip -- the stamp is missing, so
+# fork_served stays false despite HEAD==pin; it must rebuild and succeed.
+out=$(qmd_install_env "$fresh_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+assert "drift+build-fail retry: did NOT skip (update path ran)" grep -q 'GIT fetch' "$git_log"
+assert "drift+build-fail retry: rebuilt" grep -q 'BUN run build' "$bun_log"
+assert "drift+build-fail retry: rc 0" grep -q '^RC=0$' <<<"$out"
+STUB_GIT_HEAD_FILE=""
+
+# -- legacy migration (HIMMEL-911 CR r3): a pre-stamp machine (linked, pinned
+#    HEAD, version ok -- but no .himmel-build-ok stamp) intentionally reads
+#    as NOT-served, so it converges onto a stamped pinned build on its next
+#    install pass. Desired migration behavior, not a bug.
+rm -f "$fresh_home/.himmel/qmd-fork/.himmel-build-ok"
+rc=0
+qmd_install_env "$fresh_home" bash "$SCRIPT_DIR/qmd-bin.sh" fork-served >/dev/null 2>&1 || rc=$?
+assert "legacy no-stamp install: fork-served nonzero (converges onto the stamped pin)" test "$rc" -ne 0
 
 # Absolute path to bash (not a bare `bash` PATH lookup): the no-git/no-bun
 # isolation cases below need a PATH that carries ONLY the surviving stub (no
@@ -259,11 +385,12 @@ out=$(HOME="$nobun_home" GIT_LOG="$git_log" BUN_LOG="$bun_log" PATH="$id2/bin-gi
 assert "no-bun: rc nonzero" grep -qv '^RC=0$' <<<"$out"
 assert "no-bun: WARNs" grep -qi 'bun not found' <<<"$out"
 
-# -- clone/fetch failure on an EXISTING clone: WARN + continues (build still
-#    runs against the existing, un-updated clone contents). Pre-seed the
-#    clone dir directly (NOT via a first qmd_install call) so the global path
-#    is NOT yet linked -- otherwise the idempotent-skip check above would
-#    short-circuit this run before it ever reaches the fetch/checkout step.
+# -- pinned-update failure on an EXISTING unlinked clone: FAIL CLOSED
+#    (HIMMEL-911 CR r1 codex-adv-2) -- never build/link contents that could
+#    not be brought to the pinned SHA. Pre-seed the clone dir directly (NOT
+#    via a first qmd_install call) so the global path is NOT yet linked --
+#    otherwise the idempotent-skip check above would short-circuit this run
+#    before it ever reaches the fetch/checkout step.
 stale_home="$id2/stalefetch"
 mkdir -p "$stale_home/.himmel/qmd-fork/.git"
 echo '{}' > "$stale_home/.himmel/qmd-fork/package.json"
@@ -271,8 +398,21 @@ STUB_GIT_CLONE_RC=0 STUB_GIT_FETCH_RC=1 STUB_BUN_INSTALL_RC=0 STUB_BUN_BUILD_RC=
 out=$(qmd_install_env "$stale_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
 STUB_GIT_FETCH_RC=0
 assert "fetch-fail: attempted the update (fetch) on the existing clone" grep -q 'GIT fetch' "$git_log"
-assert "fetch-fail: WARNs and continues" grep -qi 'fetch/checkout failed' <<<"$out"
-assert "fetch-fail: still builds + verifies (rc 0)" grep -q '^RC=0$' <<<"$out"
+assert "fetch-fail: fetched the pinned SHA, not a branch name" grep -qE 'GIT fetch origin [0-9a-f]{40}' "$git_log"
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "fetch-fail: fails closed (rc nonzero, no as-is fallback build)" \
+  bash -c '! grep -q "^RC=0$" <<<"$1"' _ "$out"
+assert "fetch-fail: ERROR names the pinned SHA" grep -q "pinned commit $default_ref" <<<"$out"
+# shellcheck disable=SC2016
+assert "fetch-fail: did NOT build the unpinned clone" \
+  bash -c '! grep -qE "BUN (install|run build)" "$1"' _ "$bun_log"
+assert "fetch-fail: did NOT link the global path" \
+  test ! -e "$stale_home/.bun/install/global/node_modules/@tobilu/qmd"
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "update path: no git call references the mutable himmel-main branch" \
+  bash -c '! grep -q "himmel-main" "$1"' _ "$git_log"
 
 # -- owned-dir guard (HIMMEL-877 CR codex-adv-2): never hard-reset a repo
 #    the installer does not own -------------------------------------------------
@@ -306,6 +446,41 @@ out=$(qmd_install_env "$dirty_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; QMD
 STUB_GIT_DIRTY=""
 assert "dirty+FORCE: proceeds to fetch" grep -q 'GIT fetch' "$git_log"
 assert "dirty+FORCE: rc 0" grep -q '^RC=0$' <<<"$out"
+
+# -- populated NON-git dir at QMD_FORK_DIR (HIMMEL-911 CR r2 codex-adv):
+#    refused untouched. QMD_FORK_DIR is operator-overridable, so a populated
+#    non-git dir here is USER DATA that predates the installer -- an
+#    init-in-place followed by the clone-failure `rm -rf` cleanup would
+#    destroy it. Even under a forced fetch failure nothing may be created,
+#    fetched, or deleted. --------------------------------------------------------
+nongit_home="$id2/nongitdir"
+mkdir -p "$nongit_home/.himmel/qmd-fork"
+echo "predates the installer" > "$nongit_home/.himmel/qmd-fork/user-data.txt"
+STUB_GIT_FETCH_RC=1
+out=$(qmd_install_env "$nongit_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+STUB_GIT_FETCH_RC=0
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "non-git dir: rc nonzero" bash -c '! grep -q "^RC=0$" <<<"$1"' _ "$out"
+assert "non-git dir: refuses with the not-a-git-clone WARNING" grep -qi 'not a git clone' <<<"$out"
+assert "non-git dir: no git call at all (never init'ed in place)" test ! -s "$git_log"
+assert "non-git dir: pre-existing contents byte-untouched" \
+  grep -q 'predates the installer' "$nongit_home/.himmel/qmd-fork/user-data.txt"
+assert "non-git dir: no .git dir injected" test ! -e "$nongit_home/.himmel/qmd-fork/.git"
+
+# -- fresh-create failure cleanup stays scoped to the dir THIS invocation
+#    created (the non-git refusal above must not break it): NO pre-existing
+#    fork_dir + a fetch failure -> the newly init'ed dir is removed again,
+#    rc nonzero. ----------------------------------------------------------------
+freshfail_home="$id2/freshfail"; mkdir -p "$freshfail_home"
+STUB_GIT_FETCH_RC=1
+out=$(qmd_install_env "$freshfail_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+STUB_GIT_FETCH_RC=0
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "fresh-create fail: rc nonzero" bash -c '! grep -q "^RC=0$" <<<"$1"' _ "$out"
+assert "fresh-create fail: cleaned up ONLY its own newly created dir" \
+  test ! -e "$freshfail_home/.himmel/qmd-fork"
 
 # -- build failure: WARN + manual command, rc nonzero --------------------------
 buildfail_home="$id2/buildfail"; mkdir -p "$buildfail_home"

--- a/scripts/machine-setup/ubuntu.sh
+++ b/scripts/machine-setup/ubuntu.sh
@@ -240,7 +240,8 @@ step "Install qmd CLI + register himmel/luna collections"
   # Project rule: qmd installs from the himmel qmd fork, built with bun,
   # never upstream npm/bun-add (HIMMEL-877). The qmd Claude plugin ships
   # a path stub that breaks plain `qmd` on Windows; scripts/lib/qmd-bin.sh
-  # picks the working invoker. qmd_install clones yotamleo/qmd#himmel-main,
+  # picks the working invoker. qmd_install clones yotamleo/qmd pinned to an
+  # immutable commit SHA rather than a mutable branch (HIMMEL-911),
   # builds it (bun install && bun run build), symlinks it onto the
   # bun-global @tobilu/qmd path, and verifies the binary.
   # shellcheck source=../lib/qmd-bin.sh

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -238,8 +238,9 @@ if (Get-Command node -ErrorAction SilentlyContinue) {
 # Honors $env:BUN_INSTALL for relocated bun roots, matching the bash lib.
 $QmdBunRoot = if ($env:BUN_INSTALL) { $env:BUN_INSTALL } else { Join-Path $HOME '.bun' }
 $QmdBunJs = Join-Path $QmdBunRoot 'install\global\node_modules\@tobilu\qmd\dist\cli\qmd.js'
-# HIMMEL-877: qmd installs from the himmel qmd fork (yotamleo/qmd#himmel-main),
-# never upstream `bun add -g @tobilu/qmd` (EPERM-wedges on this project's
+# HIMMEL-877: qmd installs from the himmel qmd fork (yotamleo/qmd, pinned to
+# an immutable commit SHA rather than a mutable branch — HIMMEL-911), never
+# upstream `bun add -g @tobilu/qmd` (EPERM-wedges on this project's
 # machines; bun blocks its postinstall script). scripts/lib/qmd-bin.sh is the
 # single chokepoint for the clone+build+link recipe.
 $QmdInstallHint = "bash `"$RepoRoot/scripts/lib/qmd-bin.sh`" install"


### PR DESCRIPTION
## Summary
- [HIMMEL-911] `scripts/lib/qmd-bin.sh` installs the qmd fork pinned to an IMMUTABLE full commit SHA (`1032a648…`, tag `v2.6.3-himmel.1` as human-readable provenance) instead of the mutable `himmel-main` head — mirrors the graphify SHA-pin precedent, with a 40-hex policy test. A force-push to the fork can no longer change what new machines execute without a reviewed repo change.
- Served-gate requires the clone's HEAD to equal the pin (existing mutable installs converge onto the pin); update path fails CLOSED on fetch/checkout/reset failure (no unpinned build, served install untouched) with a post-checkout HEAD-equals-pin verify.
- A pre-existing non-git `QMD_FORK_DIR` is refused untouched — failure cleanup can only remove a directory this invocation created.
- Build-success stamp (content = exact pinned SHA, written only after build + link + version verify, cleared before any update attempt) closes the failed-build-then-retry-no-ops trap; legacy stamp-less installs converge on next install.

## Verification
- `test-qmd-bin.sh` 113/113 (each round's fixes RED-first); shellcheck clean; independently re-verified after every round.
- CR: panel 0C/0I (1 doc suggestion, applied) + 3 codex adversarial rounds, all findings real and fixed. Private PR #1119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[HIMMEL-911]: https://yotamleo.atlassian.net/browse/HIMMEL-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ