### PR TITLE
fix(ci): [HIMMEL-934] public CI red - stale test assertions (887) + adopt fixture stub (911)

### DIFF
--- a/scripts/lib/test-fix-qmd-stub.sh
+++ b/scripts/lib/test-fix-qmd-stub.sh
@@ -403,7 +403,19 @@ echo "[test-fix-qmd-stub] consumer integration — setup scripts invoke the fixe
 repo_root="$(cd "$SCRIPT_DIR/../.." && pwd)"
 assert "setup.sh calls fix-qmd-stub.sh" grep -q 'lib/fix-qmd-stub.sh' "$repo_root/scripts/setup.sh"
 assert "setup.ps1 calls fix-qmd-stub.sh" grep -q 'lib/fix-qmd-stub.sh' "$repo_root/scripts/setup.ps1"
-assert "ubuntu.sh calls fix-qmd-stub.sh" grep -q 'lib/fix-qmd-stub.sh' "$repo_root/scripts/machine-setup/ubuntu.sh"
+# HIMMEL-887: ubuntu.sh delegates himmel/luna wiring to `himmelctl bootstrap`
+# (the NOTICE at ubuntu.sh) -- it no longer sources lib/fix-qmd-stub.sh directly.
+# Assert the delegation instead of the removed direct call.
+# shellcheck disable=SC2016
+assert "ubuntu.sh does NOT reference lib/fix-qmd-stub.sh (wiring delegated, HIMMEL-887)" \
+  bash -c '! grep -qF -- "lib/fix-qmd-stub.sh" "$1"' _ "$repo_root/scripts/machine-setup/ubuntu.sh"
+# The NOTICE alone is not the contract: assert the executable delegation
+# statement too (codex-adv finding, HIMMEL-934 CR round).
+# shellcheck disable=SC2016
+assert "ubuntu.sh execs himmelctl bootstrap.sh (delegation is real, HIMMEL-887)" \
+  grep -qF -- 'exec bash "$HIMMEL_PATH/scripts/himmelctl/bootstrap.sh"' "$repo_root/scripts/machine-setup/ubuntu.sh"
+assert "ubuntu.sh prints the himmelctl bootstrap delegation NOTICE (HIMMEL-887)" \
+  grep -q 'delegating to himmelctl bootstrap' "$repo_root/scripts/machine-setup/ubuntu.sh"
 
 echo
 echo "[test-fix-qmd-stub] pass=$pass fail=$fail"

--- a/scripts/lib/test-qmd-bin.sh
+++ b/scripts/lib/test-qmd-bin.sh
@@ -12,6 +12,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=scripts/lib/qmd-bin.sh
+# shellcheck disable=SC1091  # sourced file not in input on test-only commits
 . "$SCRIPT_DIR/qmd-bin.sh"
 
 pass=0
@@ -618,8 +619,23 @@ assert "setup.sh sources qmd-bin.sh" grep -q 'lib/qmd-bin.sh' "$repo_root/script
 # which wraps qmd_cmd - either helper counts as "uses the resolver, not bare qmd".
 assert "setup.sh calls a qmd-bin.sh helper (qmd_cmd/qmd_register_collection)" \
   grep -qE 'qmd_cmd |qmd_register_collection ' "$repo_root/scripts/setup.sh"
-assert "ubuntu.sh sources qmd-bin.sh" grep -q 'lib/qmd-bin.sh' "$repo_root/scripts/machine-setup/ubuntu.sh"
-assert "ubuntu.sh calls qmd_cmd" grep -q 'qmd_cmd ' "$repo_root/scripts/machine-setup/ubuntu.sh"
+# HIMMEL-887: ubuntu.sh no longer sources lib/qmd-bin.sh or calls qmd_cmd
+# directly -- himmel/luna wiring delegates to `himmelctl bootstrap` (the NOTICE
+# at ubuntu.sh). Assert the delegation instead of the removed direct wiring.
+# shellcheck disable=SC2016
+assert "ubuntu.sh does NOT reference lib/qmd-bin.sh (wiring delegated, HIMMEL-887)" \
+  bash -c '! grep -qF -- "lib/qmd-bin.sh" "$1"' _ "$repo_root/scripts/machine-setup/ubuntu.sh"
+# shellcheck disable=SC2016
+assert "ubuntu.sh does NOT call qmd_cmd (wiring delegated, HIMMEL-887)" \
+  bash -c '! grep -qF -- "qmd_cmd " "$1"' _ "$repo_root/scripts/machine-setup/ubuntu.sh"
+# The NOTICE alone is not the contract: assert the executable delegation
+# statement too, so removing the exec while keeping the NOTICE fails
+# (codex-adv finding, HIMMEL-934 CR round).
+# shellcheck disable=SC2016
+assert "ubuntu.sh execs himmelctl bootstrap.sh (delegation is real, HIMMEL-887)" \
+  grep -qF -- 'exec bash "$HIMMEL_PATH/scripts/himmelctl/bootstrap.sh"' "$repo_root/scripts/machine-setup/ubuntu.sh"
+assert "ubuntu.sh prints the himmelctl bootstrap delegation NOTICE (HIMMEL-887)" \
+  grep -q 'delegating to himmelctl bootstrap' "$repo_root/scripts/machine-setup/ubuntu.sh"
 
 echo "[test-qmd-bin] has_qmd matches binary presence in this env"
 if has_qmd; then

--- a/scripts/machine-setup/test-ubuntu-settings-jq.sh
+++ b/scripts/machine-setup/test-ubuntu-settings-jq.sh
@@ -53,8 +53,14 @@ assert_fail() {
     echo "  FAIL: $1"
 }
 
-# ---------- mirrored filters + drift guards ----------
-# Each constant below MUST byte-match its counterpart in ubuntu.sh.
+# ---------- fixture transforms + delegation guards ----------
+# HIMMEL-887 removed ubuntu.sh's settings.json patching entirely (it now
+# delegates himmel/luna wiring to `himmelctl bootstrap`). The jq transforms
+# below are therefore no longer mirrored FROM ubuntu.sh — they are retained
+# as the fixture logic Tests 1-4 exercise directly, AND as negative
+# re-introduction sentinels: ubuntu.sh must NOT grow this settings-patch jq
+# back. (No counterpart exists in scripts/himmelctl/ either; the patching was
+# dropped, not relocated.)
 BARE_RTK_RE='^[[:space:]]*rtk[[:space:]]+hook[[:space:]]+claude([[:space:]]|$)'
 # shellcheck disable=SC2016  # single quotes intentional: $re/$cmd are jq variables, not shell
 SWAP_FILTER='(.hooks.PreToolUse[]?.hooks[]? | select((.command // "") | test($re))).command = $cmd'
@@ -64,14 +70,28 @@ GUARD_PRESENT_FILTER='.hooks.PreToolUse // [] | map(.hooks // [] | map(.command)
 # shellcheck disable=SC2016  # single quotes intentional: $hp is a jq variable
 WALK_LINE='| walk(if type == "string" then gsub("<himmel-path>"; $hp) else . end)'
 
-echo "Drift guards: mirrored filters still match ubuntu.sh"
+echo "Delegation guards (HIMMEL-887): ubuntu.sh dropped the settings-patch jq"
 for needle in "$BARE_RTK_RE" "$SWAP_FILTER" "$COUNT_FILTER" "$GUARD_PRESENT_FILTER" "$WALK_LINE"; do
     if grep -qF -- "$needle" "$ubuntu_sh"; then
-        assert_pass "ubuntu.sh still contains: ${needle:0:60}..."
+        assert_fail "ubuntu.sh re-introduced removed settings-patch jq: $needle"
     else
-        assert_fail "ubuntu.sh drifted from mirrored filter: $needle"
+        assert_pass "ubuntu.sh does NOT contain removed settings-patch material: ${needle:0:60}..."
     fi
 done
+if grep -q 'delegating to himmelctl bootstrap' "$ubuntu_sh"; then
+    assert_pass "ubuntu.sh prints the himmelctl bootstrap delegation NOTICE (HIMMEL-887)"
+else
+    assert_fail "ubuntu.sh missing the himmelctl bootstrap delegation NOTICE (HIMMEL-887)"
+fi
+# The NOTICE alone is not the contract: assert the executable delegation
+# statement too, so removing the exec while keeping the NOTICE fails
+# (codex-adv finding, HIMMEL-934 CR round).
+# shellcheck disable=SC2016  # single quotes intentional: $HIMMEL_PATH is ubuntu.sh's variable
+if grep -qF -- 'exec bash "$HIMMEL_PATH/scripts/himmelctl/bootstrap.sh"' "$ubuntu_sh"; then
+    assert_pass "ubuntu.sh execs himmelctl bootstrap.sh (delegation is real, HIMMEL-887)"
+else
+    assert_fail "ubuntu.sh does not exec himmelctl bootstrap.sh (NOTICE without delegation)"
+fi
 
 # ---------- 1+2+3. Swap filter: guard + bare coexist ----------
 echo "Test 1: bare entry next to an existing guard entry is swapped"
@@ -150,9 +170,10 @@ for cmd_should_skip in 'bash "/opt/himmel/scripts/hooks/rtk-hook-guard.sh"' 'rtk
 done
 
 # ---------- 4. Template patch resolves <himmel-path> ----------
-# Mirror of the PATCH filter in ubuntu.sh step "Patch ~/.claude/settings.json"
-# (drift-guarded above via WALK_LINE; the surrounding additions are exercised
-# by the SessionEnd/SessionStart asserts below).
+# WALK_LINE is the historic <himmel-path> patch transform (HIMMEL-887 removed
+# it from ubuntu.sh; kept here as fixture logic + a re-introduction sentinel
+# in the delegation block above). The surrounding additions are exercised by
+# the SessionEnd/SessionStart asserts below.
 echo "Test 4: patch filter against the real template leaves no <himmel-path>"
 HP='/opt/himmel'
 patched=$(jq \

--- a/scripts/test-adopt.sh
+++ b/scripts/test-adopt.sh
@@ -406,7 +406,16 @@ cat > "$mbin/git" <<'STUB'
 #!/usr/bin/env bash
 if [ "$1" = "-C" ]; then shift 2; fi
 case "$1" in
-  clone) target="${!#}"; mkdir -p "$target/.git"; exit 0 ;;
+  # HIMMEL-911 replaced `git clone` with init+fetch-by-sha+checkout, so the
+  # stub must materialize the dir on `init` (clone kept for back-compat) and
+  # answer the belt-and-braces `rev-parse HEAD` with the pinned fork SHA --
+  # otherwise install refuses before the migration ("moving aside") branch
+  # this case exercises ever runs (HIMMEL-934).
+  clone|init) target="${!#}"; mkdir -p "$target/.git"; exit 0 ;;
+  # Only the exact `rev-parse HEAD` query the pin check performs gets the
+  # SHA; other rev-parse forms keep the silent-success default (coderabbit
+  # finding, HIMMEL-934 CR round).
+  rev-parse) [ "${2:-}" = "HEAD" ] && echo "1032a648447a54eb73df138a3861dd7a9a64c595"; exit 0 ;;
   *) exit 0 ;;
 esac
 STUB


### PR DESCRIPTION
Mirror of private #1141 (squash 5dfea396). Updates test assertions to the HIMMEL-887 himmelctl-bootstrap delegation in ubuntu.sh + adopt fixture stub (911). All 4 suites pass locally in this worktree: 61/61, 115/115, 24/24, adopt PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated machine-setup integration checks to verify delegation to the centralized bootstrap process.
  * Added safeguards ensuring legacy setup and configuration logic is not reintroduced.
  * Improved migration test coverage for both repository cloning and initialization workflows.
  * Updated test fixtures to validate pinned revision handling during migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->