### PR TITLE
feat(telegram): [HIMMEL-721] cheap pre-spawn triage for group messages

### DIFF
--- a/scripts/telegram/README.md
+++ b/scripts/telegram/README.md
@@ -166,6 +166,47 @@ allowlist edit.
 — plain message ingested, bounded run replied INTO the group, DM untouched;
 an allowlisted channel — first post surfaced its id via the gated-out log,
 allowlisted + restarted, posts then processed with replies into the channel.
+## Group triage (HIMMEL-721)
+
+Plain group/channel chat is fronted by a cheap classifier before the bridge
+spawns a bounded Claude run. DMs and explicit operator routes (`status`,
+`sessions`, `stop <ticket>`, `work on <ticket>`, ticket follow-ups, and enabled
+trusted auto-actions) bypass triage.
+
+The gate runs BEFORE the message is enqueued: the classifier sees the message
+text first, and only a spawn verdict writes anything to the session inbox.
+
+Environment:
+
+- `TELEGRAM_TRIAGE=off` disables group triage. Default is on. The match is an
+  exact, lowercase `off` — any other value leaves triage enabled.
+- `TELEGRAM_TRIAGE_MODEL` selects the Hermes model. Default: `deepseek-chat`.
+- `TELEGRAM_TRIAGE_PROVIDER` selects the Hermes provider. Default: `deepseek`.
+- `TELEGRAM_TRIAGE_TIMEOUT_MS` is the classifier deadline in milliseconds.
+  Default: `20000` (20s). A non-numeric or non-positive value falls back to the
+  default. On expiry the call fails open (see below).
+
+Verdicts:
+
+- `ignore` drops the message — it is never enqueued, so no bounded run spawns
+  and a later delivery sweep has nothing to resurrect. The skip is logged.
+- `ack` drops the message like `ignore` (no reusable reply path yet); the skip
+  is logged.
+- `spawn-low` enqueues the message and, when the session is idle/done at triage
+  time, spawns through the normal session path with model override `haiku`.
+- `spawn-high` enqueues the message and preserves the existing default
+  bounded-run model behavior.
+
+The classifier is fail-open: errors, timeouts, and unparseable output all become
+`spawn-high`, so a broken cheap lane does not drop actionable messages. The
+triage prompt includes the message text only, not sender/chat metadata or local
+paths.
+
+**Known limitation:** the `spawn-low` `haiku` override applies only to the
+direct spawn that fires when the session is idle/done at triage time. A message
+queued behind a busy (running) session is later delivered by the ordinary
+delivery sweep at the default model — the override is not persisted through the
+inbox queue. Deferred to a follow-up; not fixed here.
 
 **Consolidation pattern:** Telegram channels don't contain groups — to funnel
 many sources through one allowlisted chat, forward/post their content INTO a

--- a/scripts/telegram/poller.test.ts
+++ b/scripts/telegram/poller.test.ts
@@ -6,9 +6,11 @@ import { readNewLines, readMeta, writeMeta, ensureSession, appendLine, sessionDi
 import { ingestUpdates, loadOffset, handleInbound, handleAutoCommand, replyViaOutbox, runAndSettle, reconcile, flushOutboxes, isRetryDue, peekPending, commitPending, makeRunFn, makeAllow, makeDispatcher, makeFetchVoice, sweepStuckRunning, signalTyping, guarded, deliverAllPending, sweepAttachments, resolveRetentionMs, noticeText, type FetchImageFn } from "./poller";
 import { readFile, writeFile, mkdir, utimes } from "node:fs/promises";
 import { isAllowed, vaultForChat } from "./gate";
+import type { TriageVerdict } from "./triage";
 
 const root = () => mkdtempSync(join(tmpdir(), "poller-"));
 const allowAll = () => true;
+const spawnHighTriage = async (): Promise<TriageVerdict> => "spawn-high";
 
 // --- retry cap + run.log (HIMMEL-262/263) ---
 
@@ -425,10 +427,120 @@ test("chat routes to __chat__ session", async () => {
 
 test("group chat routes to its own group_<chat_id> session with meta.chat_id = the group", async () => {
   const r = root(); const ran: string[] = [];
-  await handleInbound(r, { from:1, chat_id:-1009999999, text:"hello group" }, async (s:string)=>{ran.push(s);});
+  await handleInbound(r, { from:1, chat_id:-1009999999, text:"hello group" }, async (s:string)=>{ran.push(s);}, undefined, spawnHighTriage);
   expect(ran).toEqual(["group_-1009999999"]);
   const m = await readMeta(r, "group_-1009999999");
   expect(m?.chat_id).toBe(-1009999999);
+});
+
+test("group chat ignores cheap-triaged chatter without spawning", async () => {
+  const r = root(); const ran: string[] = []; const triaged: string[] = [];
+  await handleInbound(r, { from:1, chat_id:-50, text:"lol nice" },
+    async (s:string) => { ran.push(s); },
+    undefined,
+    async (text): Promise<TriageVerdict> => { triaged.push(text); return "ignore"; });
+
+  expect(triaged).toEqual(["lol nice"]);
+  expect(ran).toEqual([]);
+  // Gate runs BEFORE the enqueue (HIMMEL-721 CR): on `ignore` the session is
+  // never materialized and nothing is written to the inbox. readMeta null ⇒ the
+  // session dir was never created; the inbox read throwing ⇒ never enqueued.
+  expect(await readMeta(r, "group_-50")).toBeNull();
+  let inboxPresent = true;
+  try { await readFile(join(sessionDir(r, "group_-50"), "inbox.jsonl"), "utf8"); } catch { inboxPresent = false; }
+  expect(inboxPresent).toBe(false);
+});
+
+// HIMMEL-721 CR regression: an ignored group message must NOT be resurrected by
+// the main loop's unconditional deliverAllPending (mirrors poller.ts ~905). The
+// gate drops it before enqueue, so there is no inbox content and no session to
+// deliver — zero runs across the sweep.
+test("ignore verdict: deliverAllPending fires zero runs and finds no pending inbox", async () => {
+  const r = root(); const ran: string[] = [];
+  const ignoreTriage = async (): Promise<TriageVerdict> => "ignore";
+  await handleInbound(r, { from:1, chat_id:-50, text:"lol nice" },
+    async (s:string) => { ran.push(s); }, undefined, ignoreTriage);
+  await deliverAllPending(r, async (s:string) => { ran.push(s); }, new Date(), () => sessionsList(r));
+
+  expect(ran).toEqual([]);
+  expect(await readMeta(r, "group_-50")).toBeNull();
+});
+
+test("ack verdict: deliverAllPending fires zero runs and finds no pending inbox", async () => {
+  const r = root(); const ran: string[] = [];
+  const ackTriage = async (): Promise<TriageVerdict> => "ack";
+  await handleInbound(r, { from:1, chat_id:-50, text:"ok thanks" },
+    async (s:string) => { ran.push(s); }, undefined, ackTriage);
+  await deliverAllPending(r, async (s:string) => { ran.push(s); }, new Date(), () => sessionsList(r));
+
+  expect(ran).toEqual([]);
+  expect(await readMeta(r, "group_-50")).toBeNull();
+});
+
+// HIMMEL-721: an ignored message is dropped even when the session is mid-run —
+// the gate returns before appendLine, so a running session's inbox never grows
+// with triaged-away chatter.
+test("ignore verdict while session is running: chatter is not appended to the inbox", async () => {
+  const r = root();
+  await ensureSession(r, "group_-50");
+  await writeMeta(r, "group_-50", { ...freshMeta(-50), status: "running" });
+  await appendLine(join(sessionDir(r, "group_-50"), "inbox.jsonl"), JSON.stringify({ text: "real work" }));
+  const ignoreTriage = async (): Promise<TriageVerdict> => "ignore";
+
+  await handleInbound(r, { from:1, chat_id:-50, text:"more chatter" },
+    async () => { throw new Error("run must not fire for ignored chatter"); }, undefined, ignoreTriage);
+
+  // only the pre-existing line remains; the chatter was never enqueued
+  expect((await peekPending(r, "group_-50")).count).toBe(1);
+  expect((await readMeta(r, "group_-50"))?.status).toBe("running");
+});
+
+test("group chat spawn-low triage passes haiku as the run model override", async () => {
+  const r = root(); const ran: any[] = [];
+  await handleInbound(r, { from:1, chat_id:-50, text:"can you summarize this?" },
+    async (session:string, modelOverride?: string) => { ran.push({ session, modelOverride }); },
+    undefined,
+    async (): Promise<TriageVerdict> => "spawn-low");
+
+  expect(ran).toEqual([{ session: "group_-50", modelOverride: "haiku" }]);
+});
+
+test("DM chat bypasses cheap triage", async () => {
+  const r = root(); const ran: string[] = []; let triaged = false;
+  await handleInbound(r, { from:1, chat_id:7, text:"hello" },
+    async (s:string) => { ran.push(s); },
+    undefined,
+    async (): Promise<TriageVerdict> => { triaged = true; return "ignore"; });
+
+  expect(triaged).toBe(false);
+  expect(ran).toEqual(["__chat__"]);
+});
+
+test("control routes bypass cheap triage", async () => {
+  const r = root(); let ran = false; let triaged = false;
+  await handleInbound(r, { from:1, chat_id:-50, text:"status" },
+    async () => { ran = true; },
+    undefined,
+    async (): Promise<TriageVerdict> => { triaged = true; return "ignore"; });
+
+  expect(triaged).toBe(false);
+  expect(ran).toBe(false);
+});
+
+test("TELEGRAM_TRIAGE=off disables cheap triage for group chat", async () => {
+  const r = root(); const ran: string[] = []; let triaged = false;
+  process.env.TELEGRAM_TRIAGE = "off";
+  try {
+    await handleInbound(r, { from:1, chat_id:-50, text:"group chatter" },
+      async (s:string) => { ran.push(s); },
+      undefined,
+      async (): Promise<TriageVerdict> => { triaged = true; return "ignore"; });
+  } finally {
+    delete process.env.TELEGRAM_TRIAGE;
+  }
+
+  expect(triaged).toBe(false);
+  expect(ran).toEqual(["group_-50"]);
 });
 
 test("ticket session chat_id is pinned by its creator; a group followup does not re-route it", async () => {
@@ -445,7 +557,7 @@ test("group and DM chat sessions stay separate; group reply flushes to the group
   const r = root();
   const fakeRun = async (_s:string)=>{};
   await handleInbound(r, { from:1, chat_id:7, text:"dm" }, fakeRun);
-  await handleInbound(r, { from:1, chat_id:-50, text:"group" }, fakeRun);
+  await handleInbound(r, { from:1, chat_id:-50, text:"group" }, fakeRun, undefined, spawnHighTriage);
   expect((await readMeta(r, "__chat__"))?.chat_id).toBe(7);          // DM unchanged
   expect((await readMeta(r, "group_-50"))?.chat_id).toBe(-50);
   await appendLine(join(sessionDir(r,"group_-50"),"outbox.jsonl"), JSON.stringify({ text:"reply" }));
@@ -838,7 +950,7 @@ test("ingest with no fetchDoc wired: document forwarded text-only (no crash)", a
 
 test("handleInbound forwards document_path + document_name into the session inbox line", async () => {
   const r = root();
-  await handleInbound(r, { from: 1, chat_id: -50, text: "file this", ts: 5, document_path: "/tmp/att/42.pdf", document_name: "results.pdf" }, async () => {});
+  await handleInbound(r, { from: 1, chat_id: -50, text: "file this", ts: 5, document_path: "/tmp/att/42.pdf", document_name: "results.pdf" }, async () => {}, undefined, spawnHighTriage);
   const lines = await readNewLines(join(sessionDir(r, "group_-50"), "inbox.jsonl"), join(sessionDir(r, "group_-50"), "inbox.jsonl.cursor.test"));
   expect(lines.length).toBe(1);
   expect(lines[0].document_path).toBe("/tmp/att/42.pdf");
@@ -1327,7 +1439,7 @@ test("handleInbound: a NON-operator /arm in a shared group falls through to chat
   const r = root(); const fired: any[] = []; const ran: string[] = [];
   // a different member (from=9) of the same group; isOperator(9)=false → powerless chat
   await handleInbound(r, { from:9, chat_id:-50, text:"/arm HIMMEL-1", forwarded:false, caption:false },
-    async (s:string) => { ran.push(s); }, autoGate(["arm-resume"], fired, (from) => from === 5));
+    async (s:string) => { ran.push(s); }, autoGate(["arm-resume"], fired, (from) => from === 5), spawnHighTriage);
   expect(fired.length).toBe(0);
   expect(ran).toEqual(["group_-50"]);   // ordinary chat
 });

--- a/scripts/telegram/poller.ts
+++ b/scripts/telegram/poller.ts
@@ -7,6 +7,7 @@ import { dispatchAutoAction, parseEnabledOps, KNOWN_OPS, appendAuditLine, type R
 import { getUpdates, sendMessage, sendChatAction, getFile, downloadFile } from "./telegram-api";
 import { isAllowed, isGroupAllowed, loadAccess, vaultForChat, type Access } from "./gate";
 import { runSession, buildPrompt, type BusPaths, type PermissionMode } from "./run";
+import { classifyForSpawn, type TriageVerdict, type TriageModelOverride } from "./triage";
 import { transcribe } from "./transcribe";
 
 // Retry backoff for a capped session (ms). On a cap, settle retry_at = now + RETRY_MS
@@ -259,7 +260,8 @@ export async function ingestUpdates(root: string, updates: any[], allow: AllowFn
 }
 
 export type DeliveredMsg = { from: number; chat_id: number; text: string; ts?: number; forwarded?: boolean; caption?: boolean; image_path?: string; document_path?: string; document_name?: string };
-export type RunFn = (session: string) => Promise<void>;
+export type RunFn = (session: string, modelOverride?: TriageModelOverride) => Promise<void>;
+export type TriageFn = (text: string, sessionLabel?: string) => Promise<TriageVerdict>;
 
 // Auto-command gate (HIMMEL-424 B2). `fire` is FIRE-AND-FORGET so a slow arm never
 // blocks the ingest loop; `enabledOps` is parsed from TELEGRAM_AUTO_ACTIONS (empty by
@@ -275,7 +277,7 @@ export type AutoGate = { enabledOps: Set<string>; authorize: (from: number, chat
 
 // Single-threaded dispatch: the poller calls handleInbound serially, so the
 // "status === running" in-flight check needs no atomic CAS.
-export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn, auto?: AutoGate): Promise<void> {
+export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn, auto?: AutoGate, triage: TriageFn = (text, sessionLabel) => classifyForSpawn(text, { sessionLabel })): Promise<void> {
   const route = classify(msg.text);
   // control verbs act directly; minimal handling for v2.2 (status/sessions/stop)
   if (route.kind === "control") {
@@ -303,6 +305,35 @@ export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn,
   const chatSession = msg.chat_id < 0 ? `group_${msg.chat_id}` : "__chat__";
   // A non-eligible auto-command (group / caption / disabled-op) routes as chat.
   const session = (route.kind === "chat" || route.kind === "auto") ? chatSession : route.ticket;
+  // CHEAP TRIAGE GATE (HIMMEL-721) — runs BEFORE the message is enqueued. The
+  // session id is a pure derivation (above), so the gate needs no session I/O.
+  // On ignore/ack the message is DROPPED PERMANENTLY: nothing is written to
+  // inbox.jsonl, the consumed cursor never moves, and a later deliverAllPending
+  // has nothing to resurrect — triage is truthful rather than a no-op (the prior
+  // order appended the line first, so the main loop's unconditional
+  // deliverAllPending re-spawned the "ignored" chatter in the same poll tick).
+  // Deliberate tradeoff: chatter triaged away is dropped, not delayed; a crash
+  // mid-triage loses only that one piece of chatter, and the classifier is
+  // fail-open (any error → spawn-high) so a real failure still enqueues + spawns.
+  let modelOverride: TriageModelOverride | undefined;
+  if (msg.chat_id < 0 && (route.kind === "chat" || route.kind === "auto") && process.env.TELEGRAM_TRIAGE !== "off") {
+    const verdict = await triage(msg.text, session);
+    switch (verdict) {
+      case "ignore":
+      case "ack":
+        console.error(`[poller] triage ${verdict}: dropped (never enqueued) for ${session}`);
+        return;
+      case "spawn-low":
+        modelOverride = "haiku";
+        break;
+      case "spawn-high":
+        break;
+      // exhaustive (mirrors noticeText): a future 5th verdict is a compile error,
+      // not a silent fall-through that spawns untriaged.
+      default:
+        return ((_: never) => { throw new Error(`unhandled triage verdict: ${String(_)}`); })(verdict);
+    }
+  }
   const { created } = await ensureSession(root, session);
   let meta = await readMeta(root, session);
   if (created || !meta) {
@@ -316,7 +347,7 @@ export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn,
   }
   const line = route.kind === "followup" ? route.text : msg.text;
   await appendLine(join(sessionDir(root, session), "inbox.jsonl"), JSON.stringify({ text: line, from: msg.from, ts: msg.ts ?? 0, ...(msg.image_path ? { image_path: msg.image_path } : {}), ...(msg.document_path ? { document_path: msg.document_path, document_name: msg.document_name } : {}) }));
-  if (meta.status === "idle" || meta.status === "done") await run(session);
+  if (meta.status === "idle" || meta.status === "done") await run(session, modelOverride);
 }
 
 // Map the auto-action.sh exit code to an audit result label.
@@ -579,7 +610,7 @@ const MAX_RETRIES = Number(process.env.TELEGRAM_MAX_RETRIES ?? 3);
 // are filed into, from its meta.chat_id (gate.vaultForChat over loaded access).
 // Optional — when absent or it returns null, the prompt carries no file-into-vault clause.
 export type VaultForFn = (chatId: number) => string | null;
-export function makeRunFn(root: string, repoCwd: string, runImpl: (prompt: string, cwd: string, permissionMode?: PermissionMode) => Promise<RunResult> = runSession, deadlineMs: number = RUN_DEADLINE_MS, notify?: NotifyFn, maxRetries: number = MAX_RETRIES, vaultFor?: VaultForFn): RunFn {
+export function makeRunFn(root: string, repoCwd: string, runImpl: (prompt: string, cwd: string, permissionMode?: PermissionMode, lane?: "glm", modelOverride?: string) => Promise<RunResult> = runSession, deadlineMs: number = RUN_DEADLINE_MS, notify?: NotifyFn, maxRetries: number = MAX_RETRIES, vaultFor?: VaultForFn): RunFn {
   const retryAt = () => new Date(Date.now() + RETRY_MS).toISOString();
   const noticed = new Set<string>();
   const safeNotify = async (session: string, retryAtIso: string, kind: NotifyKind) => {
@@ -587,7 +618,7 @@ export function makeRunFn(root: string, repoCwd: string, runImpl: (prompt: strin
     try { await notify(session, retryAtIso, kind); }
     catch (e) { console.error("[poller] " + kind + " notify failed for " + session + ": " + e); }
   };
-  const runOnce = async (session: string): Promise<void> => {
+  const runOnce = async (session: string, modelOverride?: TriageModelOverride): Promise<void> => {
     const sd = sessionDir(root, session);
     const parked = await readMeta(root, session);
     if (parked?.status === "failed") return;                    // retry cap exhausted — wait for a new message
@@ -610,7 +641,7 @@ export function makeRunFn(root: string, repoCwd: string, runImpl: (prompt: strin
     const sessionCwd = vault ?? repoCwd;
     const permissionMode = vault ? "bypassPermissions" : undefined;
     const paths: BusPaths = { inbox: join(sd, "inbox.pending.jsonl"), outbox: join(sd, "outbox.jsonl"), context: join(sd, "context.md"), cwd: repoCwd, sessionCwd };
-    const res = await runAndSettle(root, session, () => withDeadline(runImpl(buildPrompt(session, paths, vault), sessionCwd, permissionMode), deadlineMs), undefined, retryAt);
+    const res = await runAndSettle(root, session, () => withDeadline(runImpl(buildPrompt(session, paths, vault), sessionCwd, permissionMode, undefined, modelOverride), deadlineMs), undefined, retryAt);
     // run.log (HIMMEL-262): persist the run's output tail — before this, a dead
     // run's stdout/stderr vanished and failures were undebuggable
     const logHead = `[${new Date().toISOString()}] session=${session} code=${res.code} capped=${res.capped} blocked=${res.blocked ?? false} pid=${res.pid}\n`;

--- a/scripts/telegram/run.ts
+++ b/scripts/telegram/run.ts
@@ -156,7 +156,7 @@ export function laneModel(lane?: "glm"): string | undefined {
   return lane === "glm" ? GLM_MODEL_ALIAS : undefined;
 }
 
-export async function runSession(prompt: string, cwd: string, permissionMode?: PermissionMode, lane?: "glm"): Promise<{ code: number; capped: boolean; blocked: boolean; timedOut: boolean; pid: number; tail?: string }> {
+export async function runSession(prompt: string, cwd: string, permissionMode?: PermissionMode, lane?: "glm", modelOverride?: string): Promise<{ code: number; capped: boolean; blocked: boolean; timedOut: boolean; pid: number; tail?: string }> {
   const env = sessionEnv(lane);
   // PERMISSION POSTURE (HIMMEL-314; see also HIMMEL-203, HIMMEL-578):
   // the bounded run inherits the operator's default permission mode (accept-edits)
@@ -170,7 +170,7 @@ export async function runSession(prompt: string, cwd: string, permissionMode?: P
   // else the FILE-and-commit flow deadlocks on un-answerable prompts. bypass does
   // NOT loosen containment: the VAULT's PreToolUse hooks (e.g. block-cloud-egress)
   // still fire and HARD-block web/cloud/push. Non-vault sessions keep the default.
-  const { cmd } = buildRunArgs(prompt, permissionMode, laneModel(lane));
+  const { cmd } = buildRunArgs(prompt, permissionMode, modelOverride ?? laneModel(lane));
   const p = spawn(cmd, { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe", env });
   const pid = p.pid;
   const timeoutMs = Number(process.env.RUN_TIMEOUT_MS ?? 30 * 60 * 1000);

--- a/scripts/telegram/triage.test.ts
+++ b/scripts/telegram/triage.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+import { classifyForSpawn, parseTriageVerdict, type TriageVerdict } from "./triage";
+import { REPO_ROOT } from "./run";
+
+test("parseTriageVerdict accepts the four strict single-token verdicts", () => {
+  for (const verdict of ["ignore", "ack", "spawn-low", "spawn-high"] as TriageVerdict[]) {
+    expect(parseTriageVerdict(verdict)).toBe(verdict);
+  }
+});
+
+test("parseTriageVerdict fails open on garbage or extra text", () => {
+  expect(parseTriageVerdict("")).toBe("spawn-high");
+  expect(parseTriageVerdict("ignore this")).toBe("spawn-high");
+  expect(parseTriageVerdict("SPAWN-LOW")).toBe("spawn-high");
+  expect(parseTriageVerdict("maybe")).toBe("spawn-high");
+});
+
+test("classifyForSpawn shells through the cheap classifier and parses its verdict", async () => {
+  const calls: any[] = [];
+  const verdict = await classifyForSpawn("ship this?", {
+    invoke: async (args, input) => {
+      calls.push({ args, input });
+      return "spawn-low\n";
+    },
+    timeoutMs: 1000,
+  });
+
+  expect(verdict).toBe("spawn-low");
+  expect(calls).toHaveLength(1);
+  expect(calls[0].args).toEqual(["bash", join(REPO_ROOT, "scripts", "hermes", "invoke.sh"), "--model", "deepseek-chat", "--provider", "deepseek"]);
+  expect(calls[0].input).toContain("ship this?");
+  expect(calls[0].input).not.toContain("chat_id");
+});
+
+test("classifyForSpawn fails open on classifier timeout", async () => {
+  const verdict = await classifyForSpawn("hello", {
+    invoke: async () => {
+      await Bun.sleep(100);
+      return "ignore";
+    },
+    timeoutMs: 5,
+  });
+
+  expect(verdict).toBe("spawn-high");
+});
+
+test("TELEGRAM_TRIAGE_TIMEOUT_MS env var is honored when no deps.timeoutMs is given", async () => {
+  process.env.TELEGRAM_TRIAGE_TIMEOUT_MS = "20";
+  try {
+    // no deps.timeoutMs ⇒ the env deadline (20ms) must govern; the slow invoke
+    // (500ms) loses → fail-open spawn-high.
+    const verdict = await classifyForSpawn("hello", {
+      invoke: async () => { await Bun.sleep(500); return "ignore"; },
+    });
+    expect(verdict).toBe("spawn-high");
+  } finally {
+    delete process.env.TELEGRAM_TRIAGE_TIMEOUT_MS;
+  }
+});
+
+test("TELEGRAM_TRIAGE_TIMEOUT_MS falls back to the default on garbage / non-positive values", async () => {
+  for (const bad of ["0", "-5", "garbage", ""]) {
+    process.env.TELEGRAM_TRIAGE_TIMEOUT_MS = bad;
+    try {
+      // A fast-resolving invoke must win against the (defaulted) deadline and
+      // parse to spawn-low — proving the bad value did NOT collapse the timeout
+      // to 0/NaN (which would race-reject before invoke resolves).
+      const verdict = await classifyForSpawn("ship this?", {
+        invoke: async () => "spawn-low\n",
+      });
+      expect(verdict).toBe("spawn-low");
+    } finally {
+      delete process.env.TELEGRAM_TRIAGE_TIMEOUT_MS;
+    }
+  }
+});
+
+test("cancelable timeout: a fast-resolving invoke leaves no unhandled rejection", async () => {
+  // The old Promise.race-against-Bun.sleep().then(throw) leaked: when invoke
+  // won, the sleep promise later fired its throw as an unhandledRejection. The
+  // setTimeout/clearTimeout-in-finally fix clears the timer, so nothing fires.
+  const rejections: unknown[] = [];
+  const handler = (reason: unknown) => { rejections.push(reason); };
+  process.on("unhandledRejection", handler);
+  try {
+    const verdict = await classifyForSpawn("ship this?", {
+      invoke: async () => "spawn-low\n",
+      timeoutMs: 1000,
+    });
+    expect(verdict).toBe("spawn-low");
+    await Bun.sleep(50);   // give the runtime a turn to surface any late throw
+    expect(rejections).toEqual([]);
+  } finally {
+    process.off("unhandledRejection", handler);
+  }
+});

--- a/scripts/telegram/triage.ts
+++ b/scripts/telegram/triage.ts
@@ -1,0 +1,101 @@
+import { spawn } from "bun";
+import { join } from "node:path";
+import { REPO_ROOT, killTree } from "./run";
+
+export type TriageVerdict = "ignore" | "ack" | "spawn-low" | "spawn-high";
+// The only model the triage seam ever injects is the spawn-low haiku override
+// (HIMMEL-671). A literal type — not bare `string` — so a future verdict that
+// mints a different override is a compile error at the producer, not a silent
+// fall-through to the default model.
+export type TriageModelOverride = "haiku";
+export type TriageInvokeFn = (args: string[], prompt: string) => Promise<string>;
+export type TriageDeps = { invoke?: TriageInvokeFn; timeoutMs?: number; sessionLabel?: string };
+
+const VERDICTS = new Set<TriageVerdict>(["ignore", "ack", "spawn-low", "spawn-high"]);
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+export function parseTriageVerdict(raw: string): TriageVerdict {
+  const t = raw.trim();
+  return VERDICTS.has(t as TriageVerdict) ? (t as TriageVerdict) : "spawn-high";
+}
+
+// TELEGRAM_TRIAGE_TIMEOUT_MS (HIMMEL-721 CR): env-tunable classifier deadline.
+// Default stays 20s. NaN / non-positive falls back to the default so a malformed
+// value can never disable the timeout (a missing deadline would let a hung
+// hermes child wedge the ingest loop).
+function resolveTimeoutMs(): number {
+  const raw = Number(process.env.TELEGRAM_TRIAGE_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TIMEOUT_MS;
+}
+
+function triagePrompt(text: string): string {
+  return [
+    "Classify this Telegram group message for whether it needs an agent spawn.",
+    "Answer with exactly one token: ignore, ack, spawn-low, or spawn-high.",
+    "Message:",
+    text,
+  ].join("\n");
+}
+
+async function defaultInvoke(args: string[], prompt: string, timeoutMs: number): Promise<string> {
+  const p = spawn([...args, prompt], { stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+  let timedOut = false;
+  return await new Promise<string>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      timedOut = true;
+      // killTree (HIMMEL-246): on Windows a bare p.kill() orphans the hermes
+      // python grandchild — taskkill /T /F takes the whole spawn tree.
+      killTree(p.pid, (s) => p.kill(s as any));
+      reject(new Error("triage timeout"));
+    }, timeoutMs);
+
+    Promise.all([
+      new Response(p.stdout).text(),
+      new Response(p.stderr).text(),
+      p.exited,
+    ]).then(([stdout, stderr, code]) => {
+      if (timedOut) return;
+      if (code !== 0) reject(new Error(`triage exited ${code}: ${stderr.slice(-512)}`));
+      else resolve(stdout);
+    }).catch(reject).finally(() => { clearTimeout(timer); });
+  });
+}
+
+// Cancelable timeout for the INJECTED-invoke path (tests / a fake classifier).
+// Replaces a Promise.race against Bun.sleep().then(throw): when invoke won that
+// race, the sleep promise later fired its throw as an UNHANDLED REJECTION. The
+// setTimeout/clearTimeout-in-finally pattern (same as defaultInvoke) clears the
+// timer once invoke settles, so no late throw ever fires.
+function invokeWithTimeout(invokeP: Promise<string>, timeoutMs: number): Promise<string> {
+  let timedOut = false;
+  return new Promise<string>((resolve, reject) => {
+    const timer = setTimeout(() => { timedOut = true; reject(new Error("triage timeout")); }, timeoutMs);
+    invokeP.then(
+      (out) => { if (!timedOut) resolve(out); },
+      (err) => { if (!timedOut) reject(err); },
+    ).finally(() => { clearTimeout(timer); });
+  });
+}
+
+export async function classifyForSpawn(text: string, deps: TriageDeps = {}): Promise<TriageVerdict> {
+  const model = process.env.TELEGRAM_TRIAGE_MODEL?.trim() || "deepseek-chat";
+  const provider = process.env.TELEGRAM_TRIAGE_PROVIDER?.trim() || "deepseek";
+  // Absolute path: the poller's cwd is not guaranteed to be the repo root.
+  const args = ["bash", join(REPO_ROOT, "scripts", "hermes", "invoke.sh"), "--model", model, "--provider", provider];
+  // deps.timeoutMs (tests) wins; otherwise the env-tunable deadline.
+  const timeoutMs = deps.timeoutMs ?? resolveTimeoutMs();
+  const label = deps.sessionLabel ?? "unknown-session";
+
+  try {
+    const prompt = triagePrompt(text);
+    const output = deps.invoke
+      ? await invokeWithTimeout(deps.invoke(args, prompt), timeoutMs)
+      : await defaultInvoke(args, prompt, timeoutMs);
+    return parseTriageVerdict(output);
+  } catch (e) {
+    // sessionLabel (HIMMEL-721 CR): correlate the fail-open to the session so a
+    // dropped-to-spawn-high chatter is traceable in the log alongside the poller state.
+    console.error(`[telegram-triage] fail-open for ${label}: ${e}`);
+    return "spawn-high";
+  }
+}


### PR DESCRIPTION
Public mirror of private PR #1136 (squash `7c031789`), HIMMEL-721.

Cheap pre-spawn triage for telegram group messages: the bridge poller runs a lightweight triage pass before spawning a full agent session, so non-actionable group chatter no longer costs a session spawn.

Verification: prep worktree byte-verified against the private squash; telegram bun suite green in-worktree (the 17 known local-env fails are pre-existing spawn-glm pin fails that public CI's bun suites pass). CR matrix clean on private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent triage for group and channel messages before processing.
  * Unnecessary chatter can be ignored or acknowledged without creating sessions or runs.
  * Relevant messages can trigger standard or lower-cost processing.
  * Added configurable triage timeout, model/provider selection, and opt-out behavior.
  * Triage failures safely continue processing messages with the standard priority.

* **Documentation**
  * Documented triage routes, verdicts, configuration options, timing, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->