### PR TITLE
feat(luna): [HIMMEL-506] pipeline-cadence per-leg --model pins + frequency shift

### DIFF
--- a/.agents/skills/pipeline-cadence/SKILL.md
+++ b/.agents/skills/pipeline-cadence/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: pipeline-cadence
-description: Arm/inspect/remove the recurring luna clip-pipeline cadence (daily harvest+triage, weekly synthesize+archive, monthly health) via schtasks/cron. Dedup-guarded. Use when the user asks to arm/check/disarm the clip-pipeline cadence or runs /pipeline-cadence.
+description: Arm/inspect/remove the recurring luna clip-pipeline cadence (daily harvest+triage, daily synthesize+archive, weekly health) via schtasks/cron, each leg pinned to a cheap --model. Dedup-guarded. Use when the user asks to arm/check/disarm the clip-pipeline cadence or runs /pipeline-cadence.
 ---
 
 # pipeline-cadence
 
 When the user asks to arm/inspect/remove the clip-pipeline cadence, run:
 
-    bash scripts/luna/pipeline-cadence.sh arm|status|disarm [--harvest-time HH:MM] [--synth-day DAY] [--synth-time HH:MM] [--health-day N] [--health-time HH:MM] [--vault PATH] [--force] [--dry-run]
+    bash scripts/luna/pipeline-cadence.sh arm|status|disarm [--harvest-time HH:MM] [--synth-time HH:MM] [--health-day DAY] [--health-time HH:MM] [--harvest-model M] [--synth-model M] [--health-model M] [--vault PATH] [--force] [--dry-run]
 
 Registers the luna clip-pipeline's recurring runs with the OS scheduler
 (Windows `schtasks` / POSIX crontab), following the `arm-resume.sh` precedent
 (direct scheduler invoke, dedup guard `# HIMMEL-Pipeline-*`, runner indirection).
-Each run launches a bounded interactive claude session (`claude … < /dev/null`,
-NOT `--print` — stays on Max quota). This shells the SANCTIONED cadence path —
+Each run launches a bounded interactive claude session (`claude … < NUL` on
+Windows / `< /dev/null` on POSIX, NOT `--print` — stays on Max quota). This shells the SANCTIONED cadence path —
 never hand-roll `schtasks`/`cron`. See `.claude/commands/pipeline-cadence.md`.

--- a/.claude/commands/pipeline-cadence.md
+++ b/.claude/commands/pipeline-cadence.md
@@ -1,6 +1,6 @@
 ---
-description: Arm/inspect/remove the recurring clip-pipeline cadence (daily /harvest-clips + /triage-clips, weekly /synthesize-clips + /archive-clips, monthly /obsidian-health) via schtasks (Windows) or cron (POSIX), interactive-claude shaped. Dedup-guarded. HIMMEL-255/265/357.
-argument-hint: arm|status|disarm [--harvest-time HH:MM] [--synth-day DAY] [--synth-time HH:MM] [--health-day N] [--health-time HH:MM] [--vault PATH] [--force] [--dry-run]
+description: Arm/inspect/remove the recurring clip-pipeline cadence (daily /harvest-clips + /triage-clips, daily /synthesize-clips + /archive-clips, weekly /obsidian-health) via schtasks (Windows) or cron (POSIX), interactive-claude shaped with per-leg --model pins. Dedup-guarded. HIMMEL-255/265/357/506.
+argument-hint: arm|status|disarm [--harvest-time HH:MM] [--synth-time HH:MM] [--health-day DAY] [--health-time HH:MM] [--harvest-model M] [--synth-model M] [--health-model M] [--vault PATH] [--force] [--dry-run]
 ---
 
 Register the luna clip-pipeline's recurring maintenance runs with the OS
@@ -11,25 +11,31 @@ scheduler invoke, dedup guard, runner indirection (`.bat` with
 values on POSIX, crontab entries marker-tagged `# HIMMEL-Pipeline-*`).
 
 Armed defaults (operator decision pinned on HIMMEL-255; daily harvest leg
-added on HIMMEL-357; overridable via flags):
+added on HIMMEL-357; model pins + frequency shift on HIMMEL-506; overridable
+via flags):
 
-| Task | Schedule | Runs |
-|---|---|---|
-| `HIMMEL-Pipeline-Harvest` | daily 02:00 | `/harvest-clips`, then `/triage-clips` chained in the same session |
-| `HIMMEL-Pipeline-Synthesize` | weekly Sun 03:00 | `/synthesize-clips`, then `/archive-clips` chained in the same session |
-| `HIMMEL-Pipeline-Health` | monthly 1st 04:00 | `/obsidian-health` |
+| Task | Schedule | Model | Runs |
+|---|---|---|---|
+| `HIMMEL-Pipeline-Harvest` | daily 02:00 | sonnet | `/harvest-clips`, then `/triage-clips` chained in the same session |
+| `HIMMEL-Pipeline-Synthesize` | daily 03:00 | sonnet | `/synthesize-clips`, then `/archive-clips` chained in the same session |
+| `HIMMEL-Pipeline-Health` | weekly Sun 04:00 | haiku | `/obsidian-health` |
 
-The cadence splits the Luna Digest by frequency: **daily** harvest+triage is
-cheap and idempotent so it keeps the `Clippings/` inbox flowing; **weekly**
-synthesize+archive runs less often because synthesis needs a *batch* to find
-cross-clip themes and archive only graduates clips synthesis has wikilinked;
-**monthly** health is the periodic vault check.
+Each leg launches with an explicit cheap **`--model` pin** (HIMMEL-506) so the
+cadence never inherits the operator's saved default (the scarcest tier) — the
+cheap pins are what make the higher frequencies affordable. **Daily**
+harvest+triage is cheap and idempotent so it keeps the `Clippings/` inbox
+flowing; **daily** synthesize+archive runs every night (synthesis is cheap
+enough once model-pinned, so cross-clip themes surface without a week's lag);
+**weekly** health is the periodic vault check.
 
 Each task launches a **bounded interactive** claude session in the luna
-vault — `claude --settings <fragment> "<prompt>" < NUL` (the `< /dev/null`
-bounded-run primitive). NOT `claude -p`/`--print`: headless invocations bill to
-the separate Agent SDK bucket from 2026-06-15 (HIMMEL-128); this stays on Max
-quota and passes the `no-headless-claude` gate without a marker.
+vault — `claude --model <pin> --settings <fragment> "<prompt>" < NUL` on
+Windows / `< /dev/null` on POSIX (the bounded-run primitive: the session
+runs the full turn on stdin-EOF, then exits clean). NOT `claude -p`/`--print`: headless
+invocations bill to the separate Agent SDK bucket from 2026-06-15 (HIMMEL-128);
+this stays on Max quota and passes the `no-headless-claude` gate without a
+marker. `status` parses each leg's pinned model back out of its runner, so an
+armed-but-wrong-model cadence is visible.
 
 **Auto-approve injection (HIMMEL-575).** The runs fire in the luna vault cwd,
 which has no himmel `.claude/settings.json` — so without help, an autonomous run
@@ -83,7 +89,7 @@ bash scripts/luna/pipeline-cadence.sh $ARGUMENTS
 Common invocations:
 - `/pipeline-cadence status`
 - `/pipeline-cadence arm`
-- `/pipeline-cadence arm --harvest-time 01:30 --synth-day MON --synth-time 02:30 --force`
+- `/pipeline-cadence arm --harvest-time 01:30 --synth-time 02:30 --health-day MON --force`
 - `/pipeline-cadence arm --dry-run`
 - `/pipeline-cadence disarm`
 

--- a/docs/commands-catalog.md
+++ b/docs/commands-catalog.md
@@ -72,7 +72,7 @@ and their rows are paraphrased one-liners rather than verbatim frontmatter
 | /context-hop | Mid-session jump to a fresh claude session when context window is approaching the soft budget. Sibling of /handover-arm-resume. HIMMEL-130. |
 | /retitle | Infer a himmel-canonical session name (TICKET-ID + meaningful name) from the current branch and print a ready-to-paste built-in /rename line. |
 | /overnight-shift | Auto-dispatch N tickets from Jira as parallel subagents — emits plan + confirms before fanout (HIMMEL-134). |
-| /pipeline-cadence | Arm/inspect/remove the recurring clip-pipeline cadence (daily /harvest-clips + /triage-clips, weekly /synthesize-clips + /archive-clips, monthly /obsidian-health) via schtasks (Windows) or cron (POSIX), interactive-claude shaped. Dedup-guarded. HIMMEL-255/265/357. |
+| /pipeline-cadence | Arm/inspect/remove the recurring clip-pipeline cadence (daily /harvest-clips + /triage-clips, daily /synthesize-clips + /archive-clips, weekly /obsidian-health) via schtasks (Windows) or cron (POSIX), interactive-claude shaped with per-leg --model pins. Dedup-guarded. HIMMEL-255/265/357/506. |
 | /end-session-wiki-setup | Configure which Obsidian vault the end-session-wiki hook captures sessions into — writes LUNA_VAULT_PATH (global) or .claude/end-session-wiki.json vault_path (this repo only). |
 | /stop | Graceful-halt marker for in-progress /overnight-shift sessions (HIMMEL-137). |
 

--- a/docs/luna/compounding.md
+++ b/docs/luna/compounding.md
@@ -54,7 +54,7 @@ writes proposal pages to `Clippings/_synthesis/`. Proposals only — it never
 restructures the vault.
 
 - **Entry point:** `/synthesize-clips`
-- **Cadence:** weekly (after a batch of triage runs gives it enough to work with)
+- **Cadence:** daily (HIMMEL-506 — synthesis runs nightly once model-pinned)
 
 ### Stage 4 — Archive
 
@@ -71,9 +71,14 @@ cadence:
 
 | Frequency | Stages | Command |
 |-----------|--------|---------|
-| Daily | Harvest + Triage | `/harvest-clips` → `/triage-clips` |
-| Weekly | Synthesize + Archive | `/synthesize-clips` → `/archive-clips` |
-| Monthly | Vault health | `/obsidian-health` |
+| Daily (02:00) | Harvest + Triage | `/harvest-clips` → `/triage-clips` |
+| Daily (03:00) | Synthesize + Archive | `/synthesize-clips` → `/archive-clips` |
+| Weekly (Sun 04:00) | Vault health | `/obsidian-health` |
+
+Each leg launches with an explicit cheap `--model` pin
+(harvest/synth = `sonnet`, health = `haiku` — HIMMEL-506) so the cadence
+never inherits the operator's saved default tier; the cheap pins are what
+make the daily synthesize frequency affordable.
 
 Run `/pipeline-cadence status` to see current scheduler state, or
 `/pipeline-cadence arm` to set it up.
@@ -165,7 +170,7 @@ quietly compounds and one with silent gaps.
 | Tier | What it captures | Entry point |
 |------|------------------|-------------|
 | **Automatic** | Session **summary** (decisions/commands/follow-ups) on graceful `SessionEnd` — enabled by default (HIMMEL-469) | `end-session-wiki` hook — no action required |
-| **Semi-automatic** (scheduled) | Inbox clips → triaged + synthesized notes; periodic vault health | `/pipeline-cadence arm` schedules `/harvest-clips`→`/triage-clips` (daily), `/synthesize-clips`→`/archive-clips` (weekly), `/obsidian-health` (monthly). Generic `/schedule` + `/loop` drive any recurring pass. |
+| **Semi-automatic** (scheduled) | Inbox clips → triaged + synthesized notes; periodic vault health | `/pipeline-cadence arm` schedules `/harvest-clips`→`/triage-clips` (daily), `/synthesize-clips`→`/archive-clips` (daily), `/obsidian-health` (weekly) — each leg pinned to a cheap `--model` (HIMMEL-506). Generic `/schedule` + `/loop` drive any recurring pass. |
 | **Manual** (you invoke it) | The mid-session findings/sources the automatic path misses | see list below |
 
 **Manual capture — what you must invoke explicitly:**

--- a/docs/luna/end-session-wiki.md
+++ b/docs/luna/end-session-wiki.md
@@ -59,7 +59,7 @@ flowchart TD
 - **Lane 1 (session capture)** routes per session to its configured vault
   (multi-vault under `--all`; no configured/real vault → skip — HIMMEL-590 F7).
   **There is no nightly pass over `sessions/`.**
-- **Lane 2 (clip pipeline)** is the `pipeline-cadence` nightly/weekly/monthly and
+- **Lane 2 (clip pipeline)** is the `pipeline-cadence` daily + weekly and
   operates on `Clippings/` **only** — it does **not** touch `sessions/`.
 - **Lane 3 (memory-compound)** compounds the agent's `project_*` memories into the
   luna substrate (HIMMEL-564) — separate again, not session notes.

--- a/scripts/lib/cadence-format.sh
+++ b/scripts/lib/cadence-format.sh
@@ -21,8 +21,13 @@
 # be re-armed (--force) to take effect. Runners armed before the stamp existed
 # carry no marker and read as version 0 (stale). New users (first arm after a
 # bump) get the current version automatically, so they never false-positive.
+#
+# v2 (HIMMEL-506): per-leg --model pins injected into every runner + the
+# synthesize/health frequency shift (weekly→daily, monthly→weekly). An armed
+# v1 cadence still fires, but on the OLD frequencies with NO model pin (so it
+# inherits the operator's saved default tier) — nudge `arm --force`.
 # shellcheck disable=SC2034  # consumed by sourcing scripts (pipeline-cadence/doctor/update)
-CADENCE_RUNNER_FORMAT_VERSION=1
+CADENCE_RUNNER_FORMAT_VERSION=2
 
 # Marker line stamped into each generated runner
 # (.bat: `rem <marker> N`; .sh: `# <marker> N`).

--- a/scripts/luna/pipeline-cadence.sh
+++ b/scripts/luna/pipeline-cadence.sh
@@ -2,32 +2,37 @@
 # pipeline-cadence.sh — arm/status/disarm the recurring clip-pipeline
 # cadence (HIMMEL-255).
 #
-# The luna vault's runbooks table says /synthesize-clips = "weekly or
-# after a clip batch" and /obsidian-health = "monthly or after big
-# ingests" — but nothing was scheduled; every run was operator-
+# The luna vault's runbooks table gives only loose guidance
+# (/synthesize-clips = "after a clip batch", /obsidian-health = "after
+# big ingests") — but nothing was scheduled; every run was operator-
 # remembered. The pipeline is idempotent at every stage by design
 # (markers: harvested_at, processed, synthesis dedup window, _done/
 # move) — exactly the cron-safe shape. This script registers the three
 # recurring jobs with the OS scheduler, following the
 # scripts/handover/arm-resume.sh precedent (HIMMEL-122):
 #
-#   HIMMEL-Pipeline-Harvest     daily   (default 02:00)            HIMMEL-357/798
-#       claude "/harvest-clips ... then /triage-clips ... then /ig-media-enrich ..." < NUL
-#   HIMMEL-Pipeline-Synthesize  weekly  (default Sun 03:00)
-#       claude "/synthesize-clips … then /archive-clips …" < NUL
-#   HIMMEL-Pipeline-Health      monthly (default 1st 04:00)
-#       claude "/obsidian-health …" < NUL
+#   HIMMEL-Pipeline-Harvest     daily   (default 02:00, model: sonnet)  HIMMEL-357/798
+#       claude --model sonnet "/harvest-clips ... then /triage-clips ... then /ig-media-enrich ..." < NUL
+#   HIMMEL-Pipeline-Synthesize  daily   (default 03:00, model: sonnet)
+#       claude --model sonnet "/synthesize-clips … then /archive-clips …" < NUL
+#   HIMMEL-Pipeline-Health      weekly  (default Sun 04:00, model: haiku)
+#       claude --model haiku "/obsidian-health …" < NUL
 #
 # Defaults are the operator decision pinned on HIMMEL-255 (2026-06-10),
-# plus the daily harvest+triage leg added on HIMMEL-357 (2026-06-17)
-# and the bounded ig-media-enrich chain link added on HIMMEL-798:
+# plus the daily harvest+triage leg added on HIMMEL-357 (2026-06-17),
+# the bounded ig-media-enrich chain link added on HIMMEL-798, and the
+# per-leg model pins + frequency shift on HIMMEL-506 (2026-07-11):
 # harvest+triage+ig-media-enrich daily at 02:00 (cheap, idempotent,
 # keeps the Clippings/ inbox flowing and drains pending Instagram media
-# across nights); synthesize weekly Sunday 03:00 with /archive-clips
-# chained after in the SAME session (synthesis needs a batch to find
-# cross-clip themes, so it runs weekly not daily; archive only graduates
-# clips synthesis has wikilinked, so it follows synth); health monthly
-# on the 1st at 04:00; machine assumed awake. All overridable via flags.
+# across nights); synthesize+archive DAILY at 03:00 — synthesis is now
+# cheap enough to run nightly once pinned to a cheap model, so cross-clip
+# themes surface without a week's lag (archive only graduates clips
+# synthesis has wikilinked, so it follows synth in the SAME session);
+# health WEEKLY on Sunday at 04:00; machine assumed awake. Every leg
+# launches with an explicit --model pin (harvest/synth=sonnet,
+# health=haiku) so the cadence never inherits the operator's saved
+# default (the scarcest tier) — the cheap pins are what make the higher
+# frequencies affordable. All overridable via flags.
 #
 # The armed command is interactive-claude shaped — `claude "<prompt>"`
 # with stdin redirected from NUL (the bounded-run primitive: the session
@@ -50,9 +55,9 @@
 #
 # Usage:
 #   bash scripts/luna/pipeline-cadence.sh arm [--harvest-time HH:MM]
-#       [--ig-limit N] [--synth-day DAY] [--synth-time HH:MM]
-#       [--health-day N] [--health-time HH:MM] [--vault PATH]
-#       [--force] [--dry-run]
+#       [--ig-limit N] [--synth-time HH:MM] [--health-day DAY]
+#       [--health-time HH:MM] [--harvest-model M] [--synth-model M]
+#       [--health-model M] [--vault PATH] [--force] [--dry-run]
 #   bash scripts/luna/pipeline-cadence.sh status
 #   bash scripts/luna/pipeline-cadence.sh disarm
 #
@@ -120,13 +125,18 @@ SETTINGS_FRAGMENT="$BAT_DIR/cadence-settings.json"
 . "$(dirname "${BASH_SOURCE[0]}")/../lib/cadence-format.sh"
 
 # Operator-decision defaults (HIMMEL-255 pinned comment, 2026-06-10;
-# harvest leg added on HIMMEL-357, 2026-06-17).
+# harvest leg added on HIMMEL-357, 2026-06-17; model pins + frequency
+# shift on HIMMEL-506, 2026-07-11: synth weekly->daily, health
+# monthly->weekly, per-leg --model pins so the cadence never inherits
+# the operator's saved default tier).
 HARVEST_TIME="02:00"
 IG_LIMIT="10"
-SYNTH_DAY="SUN"
 SYNTH_TIME="03:00"
-HEALTH_DAY="1"
+HEALTH_DAY="SUN"
 HEALTH_TIME="04:00"
+HARVEST_MODEL="sonnet"
+SYNTH_MODEL="sonnet"
+HEALTH_MODEL="haiku"
 
 # Default vault resolution (cross-platform; HIMMEL-642). Honors
 # LUNA_VAULT_PATH first — the vault path adopt.sh persists into
@@ -149,8 +159,8 @@ DRY_RUN=0
 # the OEM codepage, where UTF-8 punctuation mojibakes into the prompt.
 DAILY_CHAIN="/harvest-clips + /triage-clips + /ig-media-enrich"
 HARVEST_PROMPT=""
-SYNTH_PROMPT="Run /synthesize-clips to completion, then run /archive-clips. This is the scheduled weekly pipeline cadence run (HIMMEL-255) - fully autonomous, no user prompts; report results and exit."
-HEALTH_PROMPT="Run /obsidian-health to completion. This is the scheduled monthly pipeline cadence run (HIMMEL-255) - fully autonomous, no user prompts; report results and exit."
+SYNTH_PROMPT="Run /synthesize-clips to completion, then run /archive-clips. This is the scheduled daily pipeline cadence run (HIMMEL-255) - fully autonomous, no user prompts; report results and exit."
+HEALTH_PROMPT="Run /obsidian-health to completion. This is the scheduled weekly pipeline cadence run (HIMMEL-255) - fully autonomous, no user prompts; report results and exit."
 
 usage() {
     cat <<'EOF'
@@ -158,16 +168,18 @@ Usage: pipeline-cadence.sh <arm|status|disarm> [flags]
 
 Arm the OS scheduler with the recurring clip-pipeline cadence
 (HIMMEL-255/357/798): daily /harvest-clips (+ /triage-clips and
-/ig-media-enrich chained after in the same session), weekly
-/synthesize-clips (+ /archive-clips chained
-after) and monthly /obsidian-health, run against the luna vault as
-interactive bounded claude sessions.
+/ig-media-enrich chained after in the same session), daily
+/synthesize-clips (+ /archive-clips chained after) and weekly
+/obsidian-health, run against the luna vault as interactive bounded
+claude sessions. Each leg launches with an explicit cheap --model pin
+(HIMMEL-506) so the cadence never inherits the operator's saved default.
 
 Subcommands:
   arm      Register all three recurring tasks. Dedup-guarded: refuses
            (rc=3) if any HIMMEL-Pipeline-* task already exists; --force
            replaces.
-  status   Show which cadence tasks are armed (+ next run time).
+  status   Show which cadence tasks are armed (+ next run time + the
+           pinned model parsed back out of each runner).
   disarm   Remove all tasks (idempotent; rc=0 if nothing was armed).
 
 Flags (arm only, except --dry-run):
@@ -175,12 +187,12 @@ Flags (arm only, except --dry-run):
                          24h local (default 02:00)
   --ig-limit <N>         Daily /ig-media-enrich --limit N (default 10;
                          0 = unlimited)
-  --synth-day <DAY>      Weekly synthesize day: MON..SUN   (default SUN)
-  --synth-time <HH:MM>   Weekly synthesize time, 24h local (default 03:00)
-  --health-day <N>       Monthly health day-of-month, 1-28 (default 1;
-                         max 28 — 29-31 rejected: schtasks MONTHLY skips
-                         months lacking that day)
-  --health-time <HH:MM>  Monthly health time, 24h local    (default 04:00)
+  --synth-time <HH:MM>   Daily synthesize time, 24h local (default 03:00)
+  --health-day <DAY>     Weekly health day: MON..SUN (default SUN)
+  --health-time <HH:MM>  Weekly health time, 24h local (default 04:00)
+  --harvest-model <m>    claude --model for the harvest leg (default sonnet)
+  --synth-model <m>      claude --model for the synthesize leg (default sonnet)
+  --health-model <m>     claude --model for the health leg (default haiku)
   --vault <PATH>         Luna vault root (default: $LUNA_VAULT_PATH if set,
                          else <user-profile>/Documents/luna — on Windows
                          Git-Bash the Windows profile, not the MSYS $HOME)
@@ -213,14 +225,21 @@ while [ $# -gt 0 ]; do
         --harvest-time=*) HARVEST_TIME="${1#--harvest-time=}"; shift ;;
         --ig-limit)      IG_LIMIT="${2:-}"; shift 2 ;;
         --ig-limit=*)    IG_LIMIT="${1#--ig-limit=}"; shift ;;
-        --synth-day)     SYNTH_DAY="${2:-}"; shift 2 ;;
-        --synth-day=*)   SYNTH_DAY="${1#--synth-day=}"; shift ;;
+        --synth-day|--synth-day=*)
+            echo "ERR pipeline-cadence: --synth-day is no longer supported — synthesize is daily now (HIMMEL-506); use --synth-time to set the time" >&2
+            exit 1 ;;
         --synth-time)    SYNTH_TIME="${2:-}"; shift 2 ;;
         --synth-time=*)  SYNTH_TIME="${1#--synth-time=}"; shift ;;
         --health-day)    HEALTH_DAY="${2:-}"; shift 2 ;;
         --health-day=*)  HEALTH_DAY="${1#--health-day=}"; shift ;;
         --health-time)   HEALTH_TIME="${2:-}"; shift 2 ;;
         --health-time=*) HEALTH_TIME="${1#--health-time=}"; shift ;;
+        --harvest-model)   HARVEST_MODEL="${2:-}"; shift 2 ;;
+        --harvest-model=*) HARVEST_MODEL="${1#--harvest-model=}"; shift ;;
+        --synth-model)   SYNTH_MODEL="${2:-}"; shift 2 ;;
+        --synth-model=*) SYNTH_MODEL="${1#--synth-model=}"; shift ;;
+        --health-model)  HEALTH_MODEL="${2:-}"; shift 2 ;;
+        --health-model=*) HEALTH_MODEL="${1#--health-model=}"; shift ;;
         --vault)         VAULT="${2:-}"; shift 2 ;;
         --vault=*)       VAULT="${1#--vault=}"; shift ;;
         --force)         FORCE=1; shift ;;
@@ -390,6 +409,52 @@ task_summary() {
     esac
 }
 
+# Map a cadence task name to its generated runner file path (.bat on
+# Windows, .sh on POSIX) so status can surface the pinned model (HIMMEL-506).
+# Returns the path on stdout; rc 1 on an unknown name.
+runner_for_name() {
+    local base ext
+    case "$1" in
+        "$TASK_HARVEST") base="pipeline-harvest" ;;
+        "$TASK_SYNTH")   base="pipeline-synthesize" ;;
+        "$TASK_HEALTH")  base="pipeline-health" ;;
+        *) return 1 ;;
+    esac
+    case "$PLATFORM" in
+        windows) ext="bat" ;;
+        *)       ext="sh" ;;
+    esac
+    printf '%s/%s.%s' "$BAT_DIR" "$base" "$ext"
+}
+
+# Read the --model pin back out of a generated runner (.bat or .sh) so
+# status can flag an armed-but-wrong-model cadence (HIMMEL-506). Both
+# emitters inject `--model <m>` right after the binary; this greps that
+# token. rc 1 when the runner is absent (not armed / dry-run), empty
+# stdout when armed without a stampable pin (pre-HIMMEL-506 runner).
+runner_model() {
+    local f="$1"
+    [ -f "$f" ] || return 1
+    grep -oE -- '--model[[:space:]]+[^[:space:]]+' "$f" 2>/dev/null \
+        | head -1 | sed 's/^--model[[:space:]]*//' | tr -d '"' || true
+}
+
+# Status suffix: " [model: <m>]" when the runner carries a --model pin;
+# " [runner missing]" when the scheduler entry is armed but its generated
+# runner file is gone (every fire fails — distinguished from the
+# intentional pre-HIMMEL-506 no-pin case, which exists on disk and stays
+# silent rather than print "model: unknown"); empty otherwise. Without this
+# guard a deleted runner read identically to a healthy v1 runner, so status
+# reported ARMED while every fire failed (HIMMEL-506 CR fix).
+model_suffix() {
+    local runner model
+    runner=$(runner_for_name "$1" 2>/dev/null) || return 0
+    [ -f "$runner" ] || { printf ' [runner missing]'; return 0; }
+    model=$(runner_model "$runner") || return 0
+    [ -n "$model" ] && printf ' [model: %s]' "$model"
+    return 0
+}
+
 status_one() {
     local name="$1" next qrc=0
     query_one "$name" || qrc=$?
@@ -399,7 +464,7 @@ status_one() {
             # operator env); fall back to plain ARMED when absent.
             next=$(printf '%s\n' "$QUERY_OUT" | grep -i 'Next Run Time' | head -1 \
                 | sed 's/^[^:]*:[[:space:]]*//' || true)
-            echo "ARMED      $name${next:+ (next run: $next)}$(task_summary "$name")"
+            echo "ARMED      $name${next:+ (next run: $next)}$(task_summary "$name")$(model_suffix "$name")"
             ;;
         1)  echo "not armed  $name$(task_summary "$name")" ;;
         *)
@@ -511,12 +576,23 @@ cmd_disarm() {
 # transient console (03:00 Sunday) whose output would otherwise vanish;
 # `status` surfaces the log.
 emit_bat() {
-    local vault_win_esc="$1" claude_win="$2" prompt_esc="$3" log_win_esc="$4" settings_esc="$5"
+    local vault_win_esc="$1" claude_win="$2" prompt_esc="$3" log_win_esc="$4" settings_esc="$5" model="$6"
+    # cmd_escape the per-leg model (HIMMEL-506 CR fix): every other value
+    # interpolated below is already escaped, but the model was a raw "%s" -
+    # a value carrying " % & ^ < > | would corrupt the .bat at fire time.
+    # validate_arm_inputs rejects metacharacters at the gate; escape here
+    # too (defense in depth - the gate also guards emit_runner's printf '%q').
+    local model_esc
+    model_esc=$(cmd_escape "$model")
     printf 'rem %s %s\r\n' "$CADENCE_FORMAT_MARKER" "$CADENCE_RUNNER_FORMAT_VERSION"
     printf 'if exist "%s" move /y "%s" "%s.prev" > NUL 2>&1\r\n' "$log_win_esc" "$log_win_esc" "$log_win_esc"
     printf 'echo [fired %%DATE%% %%TIME%%] >> "%s" 2>&1\r\n' "$log_win_esc"
     printf 'cd /d "%s" >> "%s" 2>&1 || exit /b 1\r\n' "$vault_win_esc" "$log_win_esc"
-    printf '"%s" --settings "%s" "%s" < NUL >> "%s" 2>&1\r\n' "$claude_win" "$settings_esc" "$prompt_esc" "$log_win_esc"
+    # HIMMEL-918: lift claude's 600s background-task wait ceiling — triage
+    # dispatches clip batches as bg tasks and the default ceiling silently
+    # truncated nightly runs mid-batch.
+    printf 'set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0\r\n'
+    printf '"%s" --model "%s" --settings "%s" "%s" < NUL >> "%s" 2>&1\r\n' "$claude_win" "$model_esc" "$settings_esc" "$prompt_esc" "$log_win_esc"
 }
 
 # Emit the JSON settings fragment that wires the auto-approve-safe-bash hook by
@@ -575,16 +651,15 @@ dow_long() {
     esac
 }
 
-# Per-cadence <CalendarTrigger> schedule fragments. SYNTH_DAY / HEALTH_DAY
-# are already validated (MON..SUN / 1-28) by validate_arm_inputs.
+# Per-cadence <CalendarTrigger> schedule fragments. HEALTH_DAY is already
+# validated (MON..SUN) by validate_arm_inputs. Harvest and synthesize are
+# both daily (HIMMEL-506); health is weekly on HEALTH_DAY.
 schedule_daily_xml() {
     printf '      <ScheduleByDay>\n        <DaysInterval>1</DaysInterval>\n      </ScheduleByDay>'
 }
 schedule_weekly_xml() {
-    printf '      <ScheduleByWeek>\n        <DaysOfWeek>\n          <%s />\n        </DaysOfWeek>\n        <WeeksInterval>1</WeeksInterval>\n      </ScheduleByWeek>' "$(dow_long "$SYNTH_DAY")"
-}
-schedule_monthly_xml() {
-    printf '      <ScheduleByMonth>\n        <DaysOfMonth>\n          <Day>%s</Day>\n        </DaysOfMonth>\n        <Months>\n          <January /><February /><March /><April /><May /><June /><July /><August /><September /><October /><November /><December />\n        </Months>\n      </ScheduleByMonth>' "$HEALTH_DAY"
+    local day="$1"
+    printf '      <ScheduleByWeek>\n        <DaysOfWeek>\n          <%s />\n        </DaysOfWeek>\n        <WeeksInterval>1</WeeksInterval>\n      </ScheduleByWeek>' "$(dow_long "$day")"
 }
 
 # Emit one task XML: a CalendarTrigger at the given local time with the
@@ -657,20 +732,45 @@ schtasks_create_xml() {
     return "$rc"
 }
 
+# Validate a per-leg --*-model value (HIMMEL-506 CR fix). Defense in
+# depth: a conservative identifier grammar rejects empty/whitespace and
+# every shell/CMD metacharacter BEFORE the value is interpolated into a
+# runner, so a model like a"&b can't corrupt the .bat (which additionally
+# cmd_escapes it via emit_bat) or break the cron re-parse (emit_runner
+# pre-quotes with printf '%q'). Known aliases (sonnet|opus|haiku|fable)
+# and dotted full ids (containing '.' or a 'claude-' prefix) arm silently;
+# any other grammar-valid value earns a non-fatal WARNING so a future
+# model name never hard-breaks arming. POSIX-safe `case` (not [[ =~ ]]):
+# it matches the WHOLE string, so a trailing newline can't slip a second
+# line past an anchored regex the way `grep -E '^...$'` would.
+validate_model_name() {
+    local flag="$1" val="$2"
+    # Grammar: first char [A-Za-z0-9], rest [A-Za-z0-9._:-]*. Glob, not
+    # regex: `*[!class]` flags ANY disallowed char anywhere; `[._:-]*`
+    # catches a leading . _ : - (and "" catches empty). The '-' is last
+    # in each class so it is a literal, not a range endpoint.
+    case "$val" in
+        ""|*[!A-Za-z0-9._:-]*|[._:-]*)
+            echo "ERR pipeline-cadence: $flag must match [A-Za-z0-9][A-Za-z0-9._:-]* (empty, whitespace, and shell/CMD metacharacters are rejected), got: $val" >&2
+            return 1
+            ;;
+    esac
+    case "$val" in
+        sonnet|opus|haiku|fable) return 0 ;;
+        *.*|claude-*) return 0 ;;
+        *)
+            echo "WARN pipeline-cadence: $flag '$val' is not a known alias (sonnet|opus|haiku|fable) or dotted full id; arming anyway - verify the model name" >&2
+            return 0
+            ;;
+    esac
+}
+
 # Input validation shared by the schtasks and cron arm paths. Upcases
-# SYNTH_DAY in place.
+# HEALTH_DAY in place.
 validate_arm_inputs() {
     local day_ok=0 d
     if ! [[ "$HARVEST_TIME" =~ ^([01][0-9]|2[0-3]):[0-5][0-9]$ ]]; then
         echo "ERR pipeline-cadence: --harvest-time must be HH:MM (24h), got: $HARVEST_TIME" >&2
-        exit 1
-    fi
-    SYNTH_DAY=$(printf '%s' "$SYNTH_DAY" | tr '[:lower:]' '[:upper:]')
-    for d in MON TUE WED THU FRI SAT SUN; do
-        [ "$SYNTH_DAY" = "$d" ] && day_ok=1
-    done
-    if [ "$day_ok" -ne 1 ]; then
-        echo "ERR pipeline-cadence: --synth-day must be MON..SUN, got: $SYNTH_DAY" >&2
         exit 1
     fi
     if ! [[ "$SYNTH_TIME" =~ ^([01][0-9]|2[0-3]):[0-5][0-9]$ ]]; then
@@ -681,16 +781,33 @@ validate_arm_inputs() {
         echo "ERR pipeline-cadence: --ig-limit must be a non-negative integer, got: $IG_LIMIT" >&2
         exit 1
     fi
-    # 1-28 only: schtasks MONTHLY /d 29-31 skips months lacking that day
-    # (and cron's day-of-month field has the same problem).
-    if ! [[ "$HEALTH_DAY" =~ ^([1-9]|1[0-9]|2[0-8])$ ]]; then
-        echo "ERR pipeline-cadence: --health-day must be 1-28, got: $HEALTH_DAY" >&2
+    # Health is weekly now (HIMMEL-506): --health-day is a weekday
+    # MON..SUN, not a day-of-month. A numeric 1-28 is the old monthly
+    # semantics — reject it with a pointer to the new weekday meaning.
+    HEALTH_DAY=$(printf '%s' "$HEALTH_DAY" | tr '[:lower:]' '[:upper:]')
+    day_ok=0
+    for d in MON TUE WED THU FRI SAT SUN; do
+        [ "$HEALTH_DAY" = "$d" ] && day_ok=1
+    done
+    if [ "$day_ok" -ne 1 ]; then
+        echo "ERR pipeline-cadence: --health-day must be a weekday MON..SUN (health is weekly now — HIMMEL-506), got: $HEALTH_DAY" >&2
         exit 1
     fi
     if ! [[ "$HEALTH_TIME" =~ ^([01][0-9]|2[0-3]):[0-5][0-9]$ ]]; then
         echo "ERR pipeline-cadence: --health-time must be HH:MM (24h), got: $HEALTH_TIME" >&2
         exit 1
     fi
+    # Per-leg model pins (HIMMEL-506): each --*-model must match a
+    # conservative identifier grammar ([A-Za-z0-9][A-Za-z0-9._:-]*) -
+    # this rejects empty/whitespace AND every shell/CMD metacharacter
+    # before the value reaches a runner. The .bat emitter additionally
+    # cmd_escapes the value (emit_bat) and the cron emitter pre-quotes it
+    # with printf '%q' (emit_runner) - defense in depth, never the sole
+    # guard. claude's own runtime error on a bad name is a last line, not
+    # the first.
+    validate_model_name "--harvest-model" "$HARVEST_MODEL" || exit 1
+    validate_model_name "--synth-model"  "$SYNTH_MODEL"  || exit 1
+    validate_model_name "--health-model" "$HEALTH_MODEL" || exit 1
     if [ ! -d "$VAULT" ]; then
         echo "ERR pipeline-cadence: --vault is not a directory: $VAULT" >&2
         exit 1
@@ -801,8 +918,8 @@ cmd_arm() {
     # once and reused by the dry-run preview and the real create below.
     local sched_harvest sched_synth sched_health
     sched_harvest=$(schedule_daily_xml)
-    sched_synth=$(schedule_weekly_xml)
-    sched_health=$(schedule_monthly_xml)
+    sched_synth=$(schedule_daily_xml)
+    sched_health=$(schedule_weekly_xml "$HEALTH_DAY")
 
     # The .bat runner is the task's Exec Command. cygpath -w is a pure
     # string transform (the .bat need not exist yet), so resolve the win
@@ -826,16 +943,16 @@ cmd_arm() {
         echo "DRY pipeline-cadence: would write $SETTINGS_FRAGMENT:"
         emit_settings_fragment "$hook_path_m" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $bat_harvest:"
-        emit_bat "$vault_esc" "$claude_win" "$harvest_esc" "$log_harvest_esc" "$settings_esc" | sed 's/^/    /'
+        emit_bat "$vault_esc" "$claude_win" "$harvest_esc" "$log_harvest_esc" "$settings_esc" "$HARVEST_MODEL" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $bat_synth:"
-        emit_bat "$vault_esc" "$claude_win" "$synth_esc" "$log_synth_esc" "$settings_esc" | sed 's/^/    /'
+        emit_bat "$vault_esc" "$claude_win" "$synth_esc" "$log_synth_esc" "$settings_esc" "$SYNTH_MODEL" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $bat_health:"
-        emit_bat "$vault_esc" "$claude_win" "$health_esc" "$log_health_esc" "$settings_esc" | sed 's/^/    /'
+        emit_bat "$vault_esc" "$claude_win" "$health_esc" "$log_health_esc" "$settings_esc" "$HEALTH_MODEL" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would schtasks /create /tn $TASK_HARVEST /xml <daily $HARVEST_TIME, StartWhenAvailable=true> /f"
         emit_task_xml "$bat_harvest_win" "$HARVEST_TIME" "$sched_harvest" | sed 's/^/    /'
-        echo "DRY pipeline-cadence: would schtasks /create /tn $TASK_SYNTH /xml <weekly $SYNTH_DAY $SYNTH_TIME, StartWhenAvailable=true> /f"
+        echo "DRY pipeline-cadence: would schtasks /create /tn $TASK_SYNTH /xml <daily $SYNTH_TIME, StartWhenAvailable=true> /f"
         emit_task_xml "$bat_synth_win" "$SYNTH_TIME" "$sched_synth" | sed 's/^/    /'
-        echo "DRY pipeline-cadence: would schtasks /create /tn $TASK_HEALTH /xml <monthly day $HEALTH_DAY $HEALTH_TIME, StartWhenAvailable=true> /f"
+        echo "DRY pipeline-cadence: would schtasks /create /tn $TASK_HEALTH /xml <weekly $HEALTH_DAY $HEALTH_TIME, StartWhenAvailable=true> /f"
         emit_task_xml "$bat_health_win" "$HEALTH_TIME" "$sched_health" | sed 's/^/    /'
         echo "pipeline-cadence: dry-run complete (no changes made)"
         return 0
@@ -843,9 +960,9 @@ cmd_arm() {
 
     mkdir -p "$BAT_DIR"
     emit_settings_fragment "$hook_path_m" > "$SETTINGS_FRAGMENT"
-    emit_bat "$vault_esc" "$claude_win" "$harvest_esc" "$log_harvest_esc" "$settings_esc" > "$bat_harvest"
-    emit_bat "$vault_esc" "$claude_win" "$synth_esc"  "$log_synth_esc"  "$settings_esc" > "$bat_synth"
-    emit_bat "$vault_esc" "$claude_win" "$health_esc" "$log_health_esc" "$settings_esc" > "$bat_health"
+    emit_bat "$vault_esc" "$claude_win" "$harvest_esc" "$log_harvest_esc" "$settings_esc" "$HARVEST_MODEL" > "$bat_harvest"
+    emit_bat "$vault_esc" "$claude_win" "$synth_esc"  "$log_synth_esc"  "$settings_esc" "$SYNTH_MODEL"   > "$bat_synth"
+    emit_bat "$vault_esc" "$claude_win" "$health_esc" "$log_health_esc" "$settings_esc" "$HEALTH_MODEL"  > "$bat_health"
 
     local err_file
     err_file=$(mktemp -t pipeline-cadence.err.XXXXXX)
@@ -889,10 +1006,10 @@ cmd_arm() {
     cat <<EOF
 
 ================================================================
-  PIPELINE CADENCE ARMED (HIMMEL-255 / HIMMEL-357 / HIMMEL-798)
-  $TASK_HARVEST     daily   $HARVEST_TIME       -> $DAILY_CHAIN
-  $TASK_SYNTH  weekly  $SYNTH_DAY $SYNTH_TIME  -> /synthesize-clips + /archive-clips
-  $TASK_HEALTH      monthly day $HEALTH_DAY $HEALTH_TIME -> /obsidian-health
+  PIPELINE CADENCE ARMED (HIMMEL-255 / HIMMEL-357 / HIMMEL-506 / HIMMEL-798)
+  $TASK_HARVEST  daily   $HARVEST_TIME  [model: $HARVEST_MODEL]  -> $DAILY_CHAIN
+  $TASK_SYNTH    daily   $SYNTH_TIME    [model: $SYNTH_MODEL]    -> /synthesize-clips + /archive-clips
+  $TASK_HEALTH   weekly  $HEALTH_DAY $HEALTH_TIME [model: $HEALTH_MODEL] -> /obsidian-health
   Vault: $vault_win
   Runner .bats: $BAT_DIR
 
@@ -1005,7 +1122,7 @@ cron_existing() {
 # arrive pre-quoted with printf %q.
 # shellcheck disable=SC2016  # single-quoted $log/$(date)/_rc are emitted literally for the runner's own /bin/sh to expand at fire time
 emit_runner() {
-    local name="$1" q_vault="$2" q_claude="$3" q_prompt="$4" q_log="$5" q_settings="$6" q_node_dir="${7:-}"
+    local name="$1" q_vault="$2" q_claude="$3" q_prompt="$4" q_log="$5" q_settings="$6" q_node_dir="${7:-}" q_model="${8:-}"
     printf '#!/bin/sh\n'
     printf '# %s runner — generated by pipeline-cadence.sh arm (HIMMEL-265)\n' "$name"
     printf '# %s %s\n' "$CADENCE_FORMAT_MARKER" "$CADENCE_RUNNER_FORMAT_VERSION"
@@ -1026,7 +1143,8 @@ emit_runner() {
     printf '{\n'
     printf '    echo "[fired $(date '\''+%%Y-%%m-%%d %%H:%%M:%%S'\'')]"\n'
     printf '    cd %s || exit 1\n' "$q_vault"
-    printf '    _rc=0; %s --settings %s %s < /dev/null || _rc=$?\n' "$q_claude" "$q_settings" "$q_prompt"
+    # HIMMEL-918: lift claude's 600s background-task wait ceiling (see emit_bat).
+    printf '    _rc=0; CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 %s --model %s --settings %s %s < /dev/null || _rc=$?\n' "$q_claude" "$q_model" "$q_settings" "$q_prompt"
     printf '    echo "[exit rc=$_rc]"\n'
     printf '} >> "$log" 2>&1\n'
 }
@@ -1044,7 +1162,7 @@ cron_status() {
         entry=$(printf '%s\n' "$CRON_TAB" | grep -F "# $name" | head -1 || true)
         if [ -n "$entry" ]; then
             sched=$(printf '%s' "$entry" | awk '{print $1, $2, $3, $4, $5}')
-            echo "ARMED      $name (cron: $sched)$(task_summary "$name")"
+            echo "ARMED      $name (cron: $sched)$(task_summary "$name")$(model_suffix "$name")"
         else
             echo "not armed  $name$(task_summary "$name")"
         fi
@@ -1144,7 +1262,7 @@ cron_arm() {
         fi
     fi
 
-    local q_vault q_claude q_node_dir q_harvest_prompt q_synth_prompt q_health_prompt q_log_harvest q_log_synth q_log_health
+    local q_vault q_claude q_node_dir q_harvest_prompt q_synth_prompt q_health_prompt q_log_harvest q_log_synth q_log_health q_harvest_model q_synth_model q_health_model
     q_vault=$(printf '%q' "$VAULT")
     q_claude=$(printf '%q' "$claude_bin")
     q_node_dir=$([ -n "$node_dir" ] && printf '%q' "$node_dir" || printf '')
@@ -1154,6 +1272,9 @@ cron_arm() {
     q_log_harvest=$(printf '%q' "$BAT_DIR/pipeline-harvest.log")
     q_log_synth=$(printf '%q' "$BAT_DIR/pipeline-synthesize.log")
     q_log_health=$(printf '%q' "$BAT_DIR/pipeline-health.log")
+    q_harvest_model=$(printf '%q' "$HARVEST_MODEL")
+    q_synth_model=$(printf '%q' "$SYNTH_MODEL")
+    q_health_model=$(printf '%q' "$HEALTH_MODEL")
     # Settings fragment (HIMMEL-575): the `claude --settings` target, shared by
     # all three runners. The hook path inside the fragment is the POSIX absolute
     # path (JSON-safe — no backslashes — and bash-readable).
@@ -1163,24 +1284,24 @@ cron_arm() {
         echo "WARN pipeline-cadence: auto-approve hook not readable at $AUTO_APPROVE_HOOK (cadence runs may stall on compound-bash prompts)" >&2
 
     local dow harvest_hh harvest_mm synth_hh synth_mm health_hh health_mm
-    dow=$(dow_num "$SYNTH_DAY")
+    dow=$(dow_num "$HEALTH_DAY")
     harvest_hh="${HARVEST_TIME%:*}"; harvest_mm="${HARVEST_TIME#*:}"
     synth_hh="${SYNTH_TIME%:*}"; synth_mm="${SYNTH_TIME#*:}"
     health_hh="${HEALTH_TIME%:*}"; health_mm="${HEALTH_TIME#*:}"
     local entry_harvest entry_synth entry_health
     entry_harvest="$harvest_mm $harvest_hh * * * $(cron_escape "$CRON_RUNNER_HARVEST") # $TASK_HARVEST"
-    entry_synth="$synth_mm $synth_hh * * $dow $(cron_escape "$CRON_RUNNER_SYNTH") # $TASK_SYNTH"
-    entry_health="$health_mm $health_hh $HEALTH_DAY * * $(cron_escape "$CRON_RUNNER_HEALTH") # $TASK_HEALTH"
+    entry_synth="$synth_mm $synth_hh * * * $(cron_escape "$CRON_RUNNER_SYNTH") # $TASK_SYNTH"
+    entry_health="$health_mm $health_hh * * $dow $(cron_escape "$CRON_RUNNER_HEALTH") # $TASK_HEALTH"
 
     if [ "$DRY_RUN" -eq 1 ]; then
         echo "DRY pipeline-cadence: would write $SETTINGS_FRAGMENT:"
         emit_settings_fragment "$AUTO_APPROVE_HOOK" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $CRON_RUNNER_HARVEST:"
-        emit_runner "$TASK_HARVEST" "$q_vault" "$q_claude" "$q_harvest_prompt" "$q_log_harvest" "$q_settings" "$q_node_dir" | sed 's/^/    /'
+        emit_runner "$TASK_HARVEST" "$q_vault" "$q_claude" "$q_harvest_prompt" "$q_log_harvest" "$q_settings" "$q_node_dir" "$q_harvest_model" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $CRON_RUNNER_SYNTH:"
-        emit_runner "$TASK_SYNTH" "$q_vault" "$q_claude" "$q_synth_prompt" "$q_log_synth" "$q_settings" "$q_node_dir" | sed 's/^/    /'
+        emit_runner "$TASK_SYNTH" "$q_vault" "$q_claude" "$q_synth_prompt" "$q_log_synth" "$q_settings" "$q_node_dir" "$q_synth_model" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $CRON_RUNNER_HEALTH:"
-        emit_runner "$TASK_HEALTH" "$q_vault" "$q_claude" "$q_health_prompt" "$q_log_health" "$q_settings" "$q_node_dir" | sed 's/^/    /'
+        emit_runner "$TASK_HEALTH" "$q_vault" "$q_claude" "$q_health_prompt" "$q_log_health" "$q_settings" "$q_node_dir" "$q_health_model" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would add crontab entries:"
         echo "    $entry_harvest"
         echo "    $entry_synth"
@@ -1203,9 +1324,9 @@ cron_arm() {
     local tmp_harvest="$CRON_RUNNER_HARVEST.tmp.$$" tmp_synth="$CRON_RUNNER_SYNTH.tmp.$$" tmp_health="$CRON_RUNNER_HEALTH.tmp.$$"
     local tmp_settings="$SETTINGS_FRAGMENT.tmp.$$"
     emit_settings_fragment "$AUTO_APPROVE_HOOK" > "$tmp_settings"
-    emit_runner "$TASK_HARVEST" "$q_vault" "$q_claude" "$q_harvest_prompt" "$q_log_harvest" "$q_settings" "$q_node_dir" > "$tmp_harvest"
-    emit_runner "$TASK_SYNTH"  "$q_vault" "$q_claude" "$q_synth_prompt"  "$q_log_synth"  "$q_settings" "$q_node_dir" > "$tmp_synth"
-    emit_runner "$TASK_HEALTH" "$q_vault" "$q_claude" "$q_health_prompt" "$q_log_health" "$q_settings" "$q_node_dir" > "$tmp_health"
+    emit_runner "$TASK_HARVEST" "$q_vault" "$q_claude" "$q_harvest_prompt" "$q_log_harvest" "$q_settings" "$q_node_dir" "$q_harvest_model" > "$tmp_harvest"
+    emit_runner "$TASK_SYNTH"  "$q_vault" "$q_claude" "$q_synth_prompt"  "$q_log_synth"  "$q_settings" "$q_node_dir" "$q_synth_model"   > "$tmp_synth"
+    emit_runner "$TASK_HEALTH" "$q_vault" "$q_claude" "$q_health_prompt" "$q_log_health" "$q_settings" "$q_node_dir" "$q_health_model"  > "$tmp_health"
     chmod +x "$tmp_harvest" "$tmp_synth" "$tmp_health"
 
     # Single atomic rewrite: everything that isn't ours, then all three
@@ -1233,10 +1354,10 @@ cron_arm() {
     cat <<EOF
 
 ================================================================
-  PIPELINE CADENCE ARMED (HIMMEL-255 / HIMMEL-265 cron / HIMMEL-357 / HIMMEL-798)
-  $TASK_HARVEST     daily   $HARVEST_TIME       -> $DAILY_CHAIN
-  $TASK_SYNTH  weekly  $SYNTH_DAY $SYNTH_TIME  -> /synthesize-clips + /archive-clips
-  $TASK_HEALTH      monthly day $HEALTH_DAY $HEALTH_TIME -> /obsidian-health
+  PIPELINE CADENCE ARMED (HIMMEL-255 / HIMMEL-265 cron / HIMMEL-357 / HIMMEL-506 / HIMMEL-798)
+  $TASK_HARVEST  daily   $HARVEST_TIME  [model: $HARVEST_MODEL]  -> $DAILY_CHAIN
+  $TASK_SYNTH    daily   $SYNTH_TIME    [model: $SYNTH_MODEL]    -> /synthesize-clips + /archive-clips
+  $TASK_HEALTH   weekly  $HEALTH_DAY $HEALTH_TIME [model: $HEALTH_MODEL] -> /obsidian-health
   Vault: $VAULT
   Runner .sh: $BAT_DIR
 

--- a/scripts/luna/test-graphmap-cadence.sh
+++ b/scripts/luna/test-graphmap-cadence.sh
@@ -240,8 +240,8 @@ himmel_sh=$(cat "$CRON_DIR/graphmap-himmel.sh" 2>/dev/null || echo MISSING)
 # strip the escapes before multi-word asserts.
 luna_sh_plain=${luna_sh//\\/}
 himmel_sh_plain=${himmel_sh//\\/}
-assert_contains "luna runner stamps the format version (HIMMEL-588)"   "# himmel-cadence-runner-format: 1" "$luna_sh"
-assert_contains "himmel runner stamps the format version (HIMMEL-588)" "# himmel-cadence-runner-format: 1" "$himmel_sh"
+assert_contains "luna runner stamps the format version (HIMMEL-588)"   "# himmel-cadence-runner-format: 2" "$luna_sh"
+assert_contains "himmel runner stamps the format version (HIMMEL-588)" "# himmel-cadence-runner-format: 2" "$himmel_sh"
 assert_contains "luna runner fires refresh-graph-map.sh"   "refresh-graph-map.sh" "$luna_sh_plain"
 assert_contains "luna runner names the luna corpus"        "--name luna"          "$luna_sh"
 assert_contains "luna runner sets the luna slug"           "--slug graphify-luna-map" "$luna_sh"
@@ -618,8 +618,8 @@ assert_contains "himmel Exec points at runner bat" "graphmap-himmel.bat" "$himme
 echo "TEST: .bat runners fire bash refresh-graph-map.sh with the right payload"
 luna_bat=$(cat "$BAT_DIR/graphmap-luna.bat" 2>/dev/null || echo MISSING)
 himmel_bat=$(cat "$BAT_DIR/graphmap-himmel.bat" 2>/dev/null || echo MISSING)
-assert_contains "luna bat stamps the format version (HIMMEL-588)"   "rem himmel-cadence-runner-format: 1" "$luna_bat"
-assert_contains "himmel bat stamps the format version (HIMMEL-588)" "rem himmel-cadence-runner-format: 1" "$himmel_bat"
+assert_contains "luna bat stamps the format version (HIMMEL-588)"   "rem himmel-cadence-runner-format: 2" "$luna_bat"
+assert_contains "himmel bat stamps the format version (HIMMEL-588)" "rem himmel-cadence-runner-format: 2" "$himmel_bat"
 assert_contains "luna bat cds into himmel root" 'cd /d "' "$luna_bat"
 assert_contains "luna bat fires refresh-graph-map.sh" "refresh-graph-map.sh" "$luna_bat"
 assert_contains "luna bat names the luna corpus"      "--name luna"          "$luna_bat"

--- a/scripts/luna/test-pipeline-cadence.sh
+++ b/scripts/luna/test-pipeline-cadence.sh
@@ -4,11 +4,12 @@
 # HIMMEL-362 XML-based schtasks create carrying StartWhenAvailable).
 #
 # Three cadence tasks are armed: HIMMEL-Pipeline-Harvest (daily 02:00 ->
-# /harvest-clips + /triage-clips), HIMMEL-Pipeline-Synthesize (weekly Sun
-# 03:00 -> /synthesize-clips + /archive-clips), HIMMEL-Pipeline-Health
-# (monthly 1st 04:00 -> /obsidian-health). The harvest leg is exercised
-# alongside synth/health throughout the dry-run / arm / shape / status /
-# dedup / force / disarm / rollback tests below.
+# /harvest-clips + /triage-clips), HIMMEL-Pipeline-Synthesize (daily 03:00
+# -> /synthesize-clips + /archive-clips), HIMMEL-Pipeline-Health (weekly
+# Sun 04:00 -> /obsidian-health). Each leg launches with an explicit
+# --model pin (harvest/synth=sonnet, health=haiku — HIMMEL-506). The
+# harvest leg is exercised alongside synth/health throughout the dry-run
+# / arm / shape / status / dedup / force / disarm / rollback tests below.
 #
 # Strategy: replace the scheduler with a fake — schtasks via the
 # PIPELINE_SCHTASKS seam (records /create args + simulates /query and
@@ -330,14 +331,25 @@ assert_rc "cron bad --health-day (31) -> rc 1" 1 "$rc"
 rc=0; out=$(run_cron arm --vault "$VAULT" --ig-limit abc 2>&1) || rc=$?
 assert_rc "cron bad --ig-limit (abc) -> rc 1" 1 "$rc"
 assert_contains "cron bad --ig-limit message names flag" "--ig-limit must be a non-negative integer" "$out"
+# HIMMEL-506: --synth-day removed (synthesize is daily); --health-day is now
+# a weekday MON..SUN (a numeric 1-28 is the old monthly semantics, rejected
+# with a pointer); model pins must be non-empty.
+rc=0; out=$(run_cron arm --vault "$VAULT" --synth-day mon 2>&1) || rc=$?
+assert_rc "cron removed --synth-day -> rc 1 (HIMMEL-506)" 1 "$rc"
+assert_contains "cron --synth-day message points at daily" "daily now" "$out"
+rc=0; out=$(run_cron arm --vault "$VAULT" --health-day 15 2>&1) || rc=$?
+assert_rc "cron numeric --health-day (15) -> rc 1 (now weekday)" 1 "$rc"
+assert_contains "cron numeric --health-day message points at MON..SUN" "MON..SUN" "$out"
+rc=0; out=$(run_cron arm --vault "$VAULT" --health-model "" 2>&1) || rc=$?
+assert_rc "cron empty --health-model -> rc 1 (HIMMEL-506)" 1 "$rc"
 
 # Test C2: arm --dry-run touches nothing --------------------------------------
 
 echo "TEST: cron arm --dry-run prints plan, installs nothing"
 out=$(run_cron arm --vault "$VAULT" --dry-run)
 assert_contains "dry-run daily harvest entry" "00 02 * * *" "$out"
-assert_contains "dry-run weekly entry"  "00 03 * * 0" "$out"
-assert_contains "dry-run monthly entry" "00 04 1 * *" "$out"
+assert_contains "dry-run daily synth entry"   "00 03 * * *" "$out"
+assert_contains "dry-run weekly health entry" "00 04 * * 0" "$out"
 assert_contains "dry-run harvest marker" "# HIMMEL-Pipeline-Harvest" "$out"
 assert_contains "dry-run synth marker"  "# HIMMEL-Pipeline-Synthesize" "$out"
 assert_contains "dry-run shows bounded run" "< /dev/null" "$out"
@@ -366,8 +378,8 @@ if command -v node >/dev/null 2>&1; then
 fi
 tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
 assert_contains "daily harvest entry 02:00"  "00 02 * * *" "$tab"
-assert_contains "weekly entry SUN 03:00"  "00 03 * * 0" "$tab"
-assert_contains "monthly entry 1st 04:00" "00 04 1 * *" "$tab"
+assert_contains "daily synth entry 03:00"    "00 03 * * *" "$tab"
+assert_contains "weekly health entry SUN 04:00" "00 04 * * 0" "$tab"
 assert_contains "harvest entry marker-tagged" "# HIMMEL-Pipeline-Harvest"     "$tab"
 assert_contains "synth entry marker-tagged"  "# HIMMEL-Pipeline-Synthesize" "$tab"
 assert_contains "health entry marker-tagged" "# HIMMEL-Pipeline-Health"     "$tab"
@@ -387,9 +399,9 @@ echo "TEST: runner .sh is bounded interactive claude (no headless flags)"
 harvest_sh=$(cat "$CRON_DIR/pipeline-harvest.sh" 2>/dev/null || echo MISSING)
 synth_sh=$(cat "$CRON_DIR/pipeline-synthesize.sh" 2>/dev/null || echo MISSING)
 health_sh=$(cat "$CRON_DIR/pipeline-health.sh" 2>/dev/null || echo MISSING)
-assert_contains "harvest runner stamps the format version (HIMMEL-588)" "# himmel-cadence-runner-format: 1" "$harvest_sh"
-assert_contains "synth runner stamps the format version (HIMMEL-588)"   "# himmel-cadence-runner-format: 1" "$synth_sh"
-assert_contains "health runner stamps the format version (HIMMEL-588)"  "# himmel-cadence-runner-format: 1" "$health_sh"
+assert_contains "harvest runner stamps the format version (HIMMEL-588)" "# himmel-cadence-runner-format: 2" "$harvest_sh"
+assert_contains "synth runner stamps the format version (HIMMEL-588)"   "# himmel-cadence-runner-format: 2" "$synth_sh"
+assert_contains "health runner stamps the format version (HIMMEL-588)"  "# himmel-cadence-runner-format: 2" "$health_sh"
 assert_contains "harvest runner cds into vault" "cd $VAULT || exit 1" "$harvest_sh"
 assert_contains "harvest runner runs /harvest-clips" "/harvest-clips" "$harvest_sh"
 assert_contains "harvest runner chains /triage-clips" "/triage-clips" "$harvest_sh"
@@ -418,6 +430,19 @@ for what in harvest synth health; do
         pass "$what runner has no headless claude flags"
     fi
 done
+
+# Test C4c: per-leg --model pins (HIMMEL-506) — every runner carries an
+# explicit --model right after the binary so the cadence never inherits the
+# operator's saved default tier. Defaults: harvest/synth=sonnet, health=haiku.
+echo "TEST: cron runners carry the per-leg --model pin (HIMMEL-506)"
+assert_contains "harvest runner pins --model sonnet" "--model sonnet" "$harvest_sh"
+assert_contains "synth runner pins --model sonnet"   "--model sonnet" "$synth_sh"
+assert_contains "health runner pins --model haiku"    "--model haiku"  "$health_sh"
+
+echo "TEST: cron runners lift the 600s bg-wait ceiling (HIMMEL-918)"
+assert_contains "harvest runner lifts bg-wait ceiling" "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0" "$harvest_sh"
+assert_contains "synth runner lifts bg-wait ceiling"   "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0" "$synth_sh"
+assert_contains "health runner lifts bg-wait ceiling"  "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0" "$health_sh"
 
 # Test C4b: --settings injection wires the auto-approve hook (HIMMEL-575) -------
 
@@ -468,6 +493,17 @@ assert_contains "cron synthesize armed" "ARMED      HIMMEL-Pipeline-Synthesize" 
 assert_contains "cron health armed"     "ARMED      HIMMEL-Pipeline-Health"     "$out"
 assert_contains "cron status daily row mentions ig-media-enrich" "/ig-media-enrich" "$out"
 assert_contains "cron status surfaces run log state" "run log" "$out"
+# HIMMEL-506: status parses the --model pin back out of each runner so an
+# armed-but-wrong-model cadence is visible. Scope each pin to its OWN status
+# line — harvest and synth are both [model: sonnet], so a whole-output check
+# would pass even if one leg's pin were wrong or missing.
+harvest_line=$(printf '%s\n' "$out" | grep 'HIMMEL-Pipeline-Harvest')
+synth_line=$(printf '%s\n' "$out"   | grep 'HIMMEL-Pipeline-Synthesize')
+health_line=$(printf '%s\n' "$out"  | grep 'HIMMEL-Pipeline-Health')
+assert_contains "cron harvest status line armed"      "ARMED"           "$harvest_line"
+assert_contains "cron harvest status shows model pin" "[model: sonnet]" "$harvest_line"
+assert_contains "cron synth status shows model pin"   "[model: sonnet]" "$synth_line"
+assert_contains "cron health status shows model pin"  "[model: haiku]"  "$health_line"
 
 # Test C5b: status_log rotated-log message (#299) ------------------------------
 # When .log is absent but .log.prev is present (post-rotation window before
@@ -489,6 +525,27 @@ else
 fi
 rm -f "$CRON_DIR/pipeline-synthesize.log.prev"
 
+# Test C5c: a deleted runner file surfaces as [runner missing], NOT plain
+# ARMED (HIMMEL-506 CR fix). A scheduler entry whose generated runner file is
+# gone fires-and-fails every time — status must distinguish that from the
+# intentional pre-HIMMEL-506 no-pin case (which exists on disk and is silent).
+# model_suffix is shared by the cron + schtasks status paths, so this covers
+# the fix on EVERY platform (the schtasks 9d mirror is Windows-only).
+
+echo "TEST: cron armed task with runner file deleted shows [runner missing]"
+cp "$CRON_DIR/pipeline-synthesize.sh" "$CRON_DIR/pipeline-synthesize.sh.bak"
+rm -f "$CRON_DIR/pipeline-synthesize.sh"
+rc=0; out=$(run_cron status) || rc=$?
+assert_rc "cron runner-missing status does not error" 0 "$rc"
+synth_line=$(printf '%s\n' "$out" | grep 'HIMMEL-Pipeline-Synthesize')
+assert_contains "cron synth runner-missing shows [runner missing]" "[runner missing]" "$synth_line"
+assert_not_contains "cron synth runner-missing has no [model:] suffix" "[model:" "$synth_line"
+# Other legs untouched — harvest still shows its pin, proving the pinned /
+# runner-missing states are distinguished in one status output.
+harvest_line=$(printf '%s\n' "$out" | grep 'HIMMEL-Pipeline-Harvest')
+assert_contains "cron harvest still pinned while synth runner missing" "[model: sonnet]" "$harvest_line"
+mv "$CRON_DIR/pipeline-synthesize.sh.bak" "$CRON_DIR/pipeline-synthesize.sh"
+
 # Test C6: re-arm without --force -> dedup block -------------------------------
 
 echo "TEST: cron re-arm without --force blocked (rc 3)"
@@ -505,14 +562,15 @@ fi
 
 echo "TEST: cron re-arm --force applies flag overrides"
 out=$(run_cron arm --vault "$VAULT" --force \
-    --harvest-time 01:15 --ig-limit 25 --synth-day mon --synth-time 02:30 --health-day 15 --health-time 05:00 2>&1)
+    --harvest-time 01:15 --ig-limit 25 --synth-time 02:30 --health-day wed --health-time 05:00 --harvest-model opus 2>&1)
 tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
 harvest_sh=$(cat "$CRON_DIR/pipeline-harvest.sh" 2>/dev/null || echo MISSING)
 assert_contains "cron daily harvest override"                  "15 01 * * *" "$tab"
 # %q-escaped prompt: strip backslashes for the multi-word assert (HIMMEL-798).
 assert_contains "cron --ig-limit override reaches harvest runner" "/ig-media-enrich --limit 25" "${harvest_sh//\\/}"
-assert_contains "cron weekly override (lowercase day upcased)" "30 02 * * 1" "$tab"
-assert_contains "cron monthly override"                        "00 05 15 * *" "$tab"
+assert_contains "cron --harvest-model override reaches runner (HIMMEL-506)" "--model opus" "${harvest_sh//\\/}"
+assert_contains "cron daily synth override (time only, daily)" "30 02 * * *" "$tab"
+assert_contains "cron weekly health override (WED upcased)"    "00 05 * * 3" "$tab"
 assert_contains "unrelated entry survives --force re-arm" "keep-me" "$tab"
 if [ "$(grep -c 'HIMMEL-Pipeline-' "$CSTATE/crontab")" -eq 3 ]; then
     pass "still exactly three entries after --force re-arm"
@@ -767,9 +825,12 @@ log=$(cat "$FIRE_DIR/pipeline-synthesize.log" 2>/dev/null || echo MISSING)
 assert_contains "fire log captures claude output" "claude-stub-ran" "$log"
 assert_contains "fire log carries the [fired stamp" "[fired" "$log"
 recdata=$(cat "$REC" 2>/dev/null || echo MISSING)
-# HIMMEL-575: the runner now injects `--settings <fragment>` before the prompt,
-# so claude sees exactly three argv: --settings, the fragment path, the prompt.
-assert_contains "claude invoked with --settings injection" "argc=3" "$recdata"
+# HIMMEL-506/575: the runner injects `--model <pin>` then `--settings
+# <fragment>` before the prompt, so claude sees five argv: --model, the
+# pinned model, --settings, the fragment path, the prompt.
+assert_contains "claude invoked with --model + --settings injection" "argc=5" "$recdata"
+assert_contains "model flag passed to claude" "arg=--model" "$recdata"
+assert_contains "model value (sonnet) passed to claude" "arg=sonnet" "$recdata"
 assert_contains "settings flag passed to claude" "arg=--settings" "$recdata"
 assert_contains "settings fragment path passed to claude" "cadence-settings.json" "$recdata"
 assert_contains "chained prompt intact as a SINGLE argv" \
@@ -964,9 +1025,30 @@ assert_rc "bad --harvest-time (no leading zero) -> rc 1" 1 "$rc"
 rc=0; out=$(run_pc arm --vault "$VAULT" --synth-time 25:00 2>&1) || rc=$?
 assert_rc "bad --synth-time -> rc 1" 1 "$rc"
 rc=0; out=$(run_pc arm --vault "$VAULT" --synth-day FUNDAY 2>&1) || rc=$?
-assert_rc "bad --synth-day -> rc 1" 1 "$rc"
+assert_rc "removed --synth-day -> rc 1 (HIMMEL-506)" 1 "$rc"
+assert_contains "--synth-day message points at daily" "daily now" "$out"
 rc=0; out=$(run_pc arm --vault "$VAULT" --health-day 31 2>&1) || rc=$?
 assert_rc "bad --health-day (31) -> rc 1" 1 "$rc"
+# HIMMEL-506: a numeric 1-28 was the OLD monthly semantics — now rejected
+# with a pointer to the new weekday meaning (MON..SUN).
+rc=0; out=$(run_pc arm --vault "$VAULT" --health-day 15 2>&1) || rc=$?
+assert_rc "numeric --health-day (15) -> rc 1 (now weekday)" 1 "$rc"
+assert_contains "numeric --health-day message points at MON..SUN" "MON..SUN" "$out"
+rc=0; out=$(run_pc arm --vault "$VAULT" --harvest-model "" 2>&1) || rc=$?
+assert_rc "empty --harvest-model -> rc 1 (HIMMEL-506)" 1 "$rc"
+assert_contains "empty --harvest-model message names the flag + grammar" "--harvest-model must match [A-Za-z0-9][A-Za-z0-9._:-]*" "$out"
+# HIMMEL-506 CR fix: a model value carrying " and & (CMD metacharacters)
+# must be REJECTED by the grammar gate before it can reach emit_bat's
+# raw "%s" interpolation. Names the offending flag + value.
+rc=0; out=$(run_pc arm --vault "$VAULT" --harvest-model 'a"&b' 2>&1) || rc=$?
+assert_rc "hostile --harvest-model (\" and &) -> rc 1 (HIMMEL-506)" 1 "$rc"
+assert_contains "hostile model message names the flag" "--harvest-model" "$out"
+assert_contains "hostile model message names the grammar" "[A-Za-z0-9][A-Za-z0-9._:-]*" "$out"
+assert_contains "hostile model message echoes the offending value" "a\"&b" "$out"
+# Whitespace-only slips the old [ -z ] check; the grammar rejects it.
+rc=0; out=$(run_pc arm --vault "$VAULT" --harvest-model " " 2>&1) || rc=$?
+assert_rc "whitespace-only --harvest-model -> rc 1 (HIMMEL-506)" 1 "$rc"
+assert_contains "whitespace model message names the flag" "--harvest-model" "$out"
 rc=0; out=$(run_pc arm --vault "$VAULT" --ig-limit -3 2>&1) || rc=$?
 assert_rc "bad --ig-limit (-3) -> rc 1" 1 "$rc"
 assert_contains "bad --ig-limit message names flag" "--ig-limit must be a non-negative integer" "$out"
@@ -986,13 +1068,13 @@ echo "TEST: arm --dry-run prints plan, registers nothing"
 out=$(run_pc arm --vault "$VAULT" --dry-run)
 # HIMMEL-362: create is now XML-based; dry-run previews the /xml create line
 # + the generated task XML (trigger + StartWhenAvailable).
-assert_contains "dry-run daily create"   "/tn HIMMEL-Pipeline-Harvest /xml" "$out"
-assert_contains "dry-run weekly create"  "/tn HIMMEL-Pipeline-Synthesize /xml" "$out"
-assert_contains "dry-run monthly create" "/tn HIMMEL-Pipeline-Health /xml" "$out"
+assert_contains "dry-run daily create"         "/tn HIMMEL-Pipeline-Harvest /xml" "$out"
+assert_contains "dry-run daily synth create"   "/tn HIMMEL-Pipeline-Synthesize /xml" "$out"
+assert_contains "dry-run weekly health create" "/tn HIMMEL-Pipeline-Health /xml" "$out"
 assert_contains "dry-run XML has StartWhenAvailable" "<StartWhenAvailable>true</StartWhenAvailable>" "$out"
-assert_contains "dry-run XML daily schedule"   "<ScheduleByDay>"   "$out"
-assert_contains "dry-run XML weekly Sunday"    "<Sunday />"        "$out"
-assert_contains "dry-run XML monthly day 1"    "<Day>1</Day>"      "$out"
+assert_contains "dry-run XML daily schedule (harvest+synth)" "<ScheduleByDay>" "$out"
+assert_contains "dry-run XML weekly health Sunday"          "<Sunday />"      "$out"
+assert_not_contains "dry-run XML has no monthly schedule (HIMMEL-506)" "<Day>" "$out"
 assert_contains "dry-run shows bounded run" "< NUL" "$out"
 if [ -z "$(ls -A "$STATE/tasks" 2>/dev/null)" ]; then
     pass "dry-run registered no tasks"
@@ -1007,19 +1089,19 @@ fi
 
 # Test 5: arm registers both tasks with operator-decision defaults ----------
 
-echo "TEST: arm registers weekly SUN 03:00 + monthly 1st 04:00"
+echo "TEST: arm registers daily 02:00/03:00 + weekly SUN 04:00"
 out=$(run_pc arm --vault "$VAULT")
 assert_contains "arm banner" "PIPELINE CADENCE ARMED" "$out"
 harvest_args=$(cat "$STATE/tasks/HIMMEL-Pipeline-Harvest" 2>/dev/null || echo MISSING)
 synth_args=$(cat "$STATE/tasks/HIMMEL-Pipeline-Synthesize" 2>/dev/null || echo MISSING)
 health_args=$(cat "$STATE/tasks/HIMMEL-Pipeline-Health" 2>/dev/null || echo MISSING)
 # HIMMEL-362: tasks are created from XML; the fake records the XML content.
-assert_contains "daily schedule (XML)"   "<ScheduleByDay>"  "$harvest_args"
-assert_contains "daily time (XML)"       "T02:00:00"        "$harvest_args"
-assert_contains "weekly schedule (XML)"  "<Sunday />"       "$synth_args"
-assert_contains "weekly time (XML)"      "T03:00:00"        "$synth_args"
-assert_contains "monthly schedule (XML)" "<Day>1</Day>"     "$health_args"
-assert_contains "monthly time (XML)"     "T04:00:00"        "$health_args"
+assert_contains "daily harvest schedule (XML)" "<ScheduleByDay>"  "$harvest_args"
+assert_contains "daily harvest time (XML)"     "T02:00:00"        "$harvest_args"
+assert_contains "daily synth schedule (XML)"   "<ScheduleByDay>"  "$synth_args"
+assert_contains "daily synth time (XML)"       "T03:00:00"        "$synth_args"
+assert_contains "weekly health schedule (XML)" "<Sunday />"       "$health_args"
+assert_contains "weekly health time (XML)"     "T04:00:00"        "$health_args"
 assert_contains "harvest XML StartWhenAvailable" "<StartWhenAvailable>true</StartWhenAvailable>" "$harvest_args"
 assert_contains "synth XML StartWhenAvailable"   "<StartWhenAvailable>true</StartWhenAvailable>" "$synth_args"
 assert_contains "health XML StartWhenAvailable"  "<StartWhenAvailable>true</StartWhenAvailable>" "$health_args"
@@ -1033,9 +1115,9 @@ echo "TEST: .bat runners are bounded interactive claude (no headless flags)"
 harvest_bat=$(cat "$BAT_DIR/pipeline-harvest.bat" 2>/dev/null || echo MISSING)
 synth_bat=$(cat "$BAT_DIR/pipeline-synthesize.bat" 2>/dev/null || echo MISSING)
 health_bat=$(cat "$BAT_DIR/pipeline-health.bat" 2>/dev/null || echo MISSING)
-assert_contains "harvest bat stamps the format version (HIMMEL-588)" "rem himmel-cadence-runner-format: 1" "$harvest_bat"
-assert_contains "synth bat stamps the format version (HIMMEL-588)"   "rem himmel-cadence-runner-format: 1" "$synth_bat"
-assert_contains "health bat stamps the format version (HIMMEL-588)"  "rem himmel-cadence-runner-format: 1" "$health_bat"
+assert_contains "harvest bat stamps the format version (HIMMEL-588)" "rem himmel-cadence-runner-format: 2" "$harvest_bat"
+assert_contains "synth bat stamps the format version (HIMMEL-588)"   "rem himmel-cadence-runner-format: 2" "$synth_bat"
+assert_contains "health bat stamps the format version (HIMMEL-588)"  "rem himmel-cadence-runner-format: 2" "$health_bat"
 assert_contains "harvest bat cds into vault" 'cd /d "' "$harvest_bat"
 assert_contains "harvest bat runs /harvest-clips" "/harvest-clips" "$harvest_bat"
 assert_contains "harvest bat chains /triage-clips" "/triage-clips" "$harvest_bat"
@@ -1068,6 +1150,18 @@ for what in harvest synth health; do
         pass "$what bat has no headless claude flags"
     fi
 done
+
+# Test 6c: per-leg --model pins in the .bat runners (HIMMEL-506) — every
+# runner carries `--model "<m>"` right after the binary.
+echo "TEST: .bat runners carry the per-leg --model pin (HIMMEL-506)"
+assert_contains "harvest bat pins --model sonnet" '--model "sonnet"' "$harvest_bat"
+assert_contains "synth bat pins --model sonnet"   '--model "sonnet"' "$synth_bat"
+assert_contains "health bat pins --model haiku"    '--model "haiku"'  "$health_bat"
+
+echo "TEST: .bat runners lift the 600s bg-wait ceiling (HIMMEL-918)"
+assert_contains "harvest bat lifts bg-wait ceiling" "set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0" "$harvest_bat"
+assert_contains "synth bat lifts bg-wait ceiling"   "set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0" "$synth_bat"
+assert_contains "health bat lifts bg-wait ceiling"  "set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0" "$health_bat"
 
 # Test 6b: --settings injection wires the auto-approve hook (HIMMEL-575) ------
 
@@ -1109,6 +1203,17 @@ assert_contains "synthesize armed" "ARMED      HIMMEL-Pipeline-Synthesize" "$out
 assert_contains "health armed"     "ARMED      HIMMEL-Pipeline-Health"     "$out"
 assert_contains "status daily row mentions ig-media-enrich" "/ig-media-enrich" "$out"
 assert_contains "status surfaces run log state" "run log" "$out"
+# HIMMEL-506: status parses the --model pin back out of each .bat runner.
+# Scope each pin to its OWN status line — harvest and synth are both
+# [model: sonnet], so a whole-output check would pass even if one leg's pin
+# were wrong or missing.
+harvest_line=$(printf '%s\n' "$out" | grep 'HIMMEL-Pipeline-Harvest')
+synth_line=$(printf '%s\n' "$out"   | grep 'HIMMEL-Pipeline-Synthesize')
+health_line=$(printf '%s\n' "$out"  | grep 'HIMMEL-Pipeline-Health')
+assert_contains "harvest status line armed"      "ARMED"           "$harvest_line"
+assert_contains "harvest status shows model pin" "[model: sonnet]" "$harvest_line"
+assert_contains "synth status shows model pin"   "[model: sonnet]" "$synth_line"
+assert_contains "health status shows model pin"  "[model: haiku]"  "$health_line"
 
 # Test 7b: status surfaces the rotated .log.prev evidence ---------------------
 # Rotation keeps one prior run as .log.prev; right after a fire the
@@ -1142,22 +1247,61 @@ fi
 
 echo "TEST: re-arm --force applies flag overrides"
 out=$(run_pc arm --vault "$VAULT" --force \
-    --harvest-time 01:15 --ig-limit 0 --synth-day mon --synth-time 02:30 --health-day 15 --health-time 05:00 2>&1)
+    --harvest-time 01:15 --ig-limit 0 --synth-time 02:30 --health-day wed --health-time 05:00 --harvest-model opus 2>&1)
 harvest_args=$(cat "$STATE/tasks/HIMMEL-Pipeline-Harvest" 2>/dev/null || echo MISSING)
 synth_args=$(cat "$STATE/tasks/HIMMEL-Pipeline-Synthesize" 2>/dev/null || echo MISSING)
 health_args=$(cat "$STATE/tasks/HIMMEL-Pipeline-Health" 2>/dev/null || echo MISSING)
 harvest_bat=$(cat "$BAT_DIR/pipeline-harvest.bat" 2>/dev/null || echo MISSING)
-assert_contains "daily override (XML time)"               "T01:15:00"   "$harvest_args"
+assert_contains "daily harvest override (XML time)"       "T01:15:00"   "$harvest_args"
 assert_contains "--ig-limit 0 reaches harvest bat"         "/ig-media-enrich --limit 0" "$harvest_bat"
-assert_contains "weekly override (lowercase day upcased)" "<Monday />"  "$synth_args"
-assert_contains "weekly override (XML time)"              "T02:30:00"   "$synth_args"
-assert_contains "monthly override (XML day)"              "<Day>15</Day>" "$health_args"
-assert_contains "monthly override (XML time)"             "T05:00:00"   "$health_args"
+assert_contains "--harvest-model override reaches bat (HIMMEL-506)" '--model "opus"' "$harvest_bat"
+assert_contains "daily synth override (daily schedule)"   "<ScheduleByDay>" "$synth_args"
+assert_contains "daily synth override (XML time)"         "T02:30:00"   "$synth_args"
+assert_contains "weekly health override (WED upcased)"    "<Wednesday />" "$health_args"
+assert_contains "weekly health override (XML time)"       "T05:00:00"   "$health_args"
 if [ "$(find "$STATE/tasks" -mindepth 1 | wc -l)" -eq 3 ]; then
     pass "still exactly three tasks after --force re-arm"
 else
     fail "duplicate tasks after --force re-arm" "$(ls "$STATE/tasks")"
 fi
+
+# Test 9b: --force re-arm model pin round-trips through status (HIMMEL-506).
+# status parses the --model token back out of the .bat runner; after a
+# --force re-arm with --harvest-model opus, the harvest status line must
+# show [model: opus].
+echo "TEST: --force re-arm harvest model pin round-trips via status"
+out=$(run_pc status)
+harvest_line=$(printf '%s\n' "$out" | grep 'HIMMEL-Pipeline-Harvest')
+assert_contains "status round-trips --force harvest model pin" "[model: opus]" "$harvest_line"
+
+# Test 9c: pre-HIMMEL-506 runner (no --model token) stays silent in status
+# (HIMMEL-506). A v1 runner never carried --model; status must NOT print a
+# [model: ...] suffix for it (no "model: unknown", no error). Emulate by
+# stripping the --model token the v1 emitter never wrote. disarm (Test 10)
+# removes the modified runner right after, so no cleanup needed here.
+echo "TEST: v1 runner without --model pin shows no model suffix in status"
+sed 's/ --model "[^"]*"//' "$BAT_DIR/pipeline-harvest.bat" > "$BAT_DIR/pipeline-harvest.bat.v1"
+mv "$BAT_DIR/pipeline-harvest.bat.v1" "$BAT_DIR/pipeline-harvest.bat"
+rc=0; out=$(run_pc status) || rc=$?
+assert_rc "v1 runner status does not error" 0 "$rc"
+harvest_line=$(printf '%s\n' "$out" | grep 'HIMMEL-Pipeline-Harvest')
+assert_not_contains "v1 harvest runner has no [model:] suffix" "[model:" "$harvest_line"
+assert_not_contains "v1 runner status has no 'model: unknown'" "model: unknown" "$out"
+
+# Test 9d: a deleted runner file surfaces as [runner missing], NOT plain ARMED
+# (HIMMEL-506 CR fix). The schtasks mirror of cron C5c: a scheduler entry whose
+# .bat runner is gone fires-and-fails every time, so status must distinguish
+# it from the v1 no-pin runner above (9c, which exists on disk and is silent).
+# Backs up + restores the runner so Test 10's disarm state is unaffected.
+echo "TEST: armed task with .bat runner deleted shows [runner missing]"
+cp "$BAT_DIR/pipeline-synthesize.bat" "$BAT_DIR/pipeline-synthesize.bat.bak"
+rm -f "$BAT_DIR/pipeline-synthesize.bat"
+rc=0; out=$(run_pc status) || rc=$?
+assert_rc "runner-missing status does not error" 0 "$rc"
+synth_line=$(printf '%s\n' "$out" | grep 'HIMMEL-Pipeline-Synthesize')
+assert_contains "synth runner-missing shows [runner missing]" "[runner missing]" "$synth_line"
+assert_not_contains "synth runner-missing has no [model:] suffix" "[model:" "$synth_line"
+mv "$BAT_DIR/pipeline-synthesize.bat.bak" "$BAT_DIR/pipeline-synthesize.bat"
 
 # Test 10: disarm + idempotent second disarm ---------------------------------
 

--- a/scripts/test-himmel-doctor.sh
+++ b/scripts/test-himmel-doctor.sh
@@ -356,7 +356,7 @@ rm -rf "$t"
 
 echo "== C8: current runner (stamped) -> OK C8-cadence =="
 t="$(mktemp -d)"; mkdir -p "$t/claude" "$t/cadence"; write_settings "$t/claude" "$WRAPPER"
-printf '#!/bin/sh\n# himmel-cadence-runner-format: 1\necho current runner\n' > "$t/cadence/pipeline-harvest.sh"
+printf '#!/bin/sh\n# himmel-cadence-runner-format: 2\necho current runner\n' > "$t/cadence/pipeline-harvest.sh"
 out="$(RESOLVE_NODE_PROBE_DIRS="$FAKENODE" PIPELINE_BAT_DIR="$t/cadence" \
     DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" \
     bash "$DOC" --no-color 2>&1)"


### PR DESCRIPTION
Public mirror of private PR #1137 (squash `d920b017`), HIMMEL-506.

Pipeline-cadence per-leg `--model` pins (daily harvest 02:00 sonnet / daily synthesize 03:00 sonnet / weekly health SUN 04:00 haiku) plus the cadence frequency shift. Docs (`docs/luna/*`) and the commands catalog updated to match.

Verification: prep worktree byte-verified against the private squash; in-worktree suite green (s43). Cadence re-armed post-merge on private with NextRunTime verified. CR matrix clean on private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-stage model selection for harvest, synthesis, and health.
  - Scheduler status now shows the configured model per task and flags missing runners.
  - Updated health scheduling to use weekday-based setup.

- **Changes**
  - Synthesis/archiving now run daily.
  - Health checks now run weekly (Sunday) instead of monthly.
  - Updated Windows and POSIX scheduling behavior and CLI options (including removal of the old synth-day option).

- **Documentation**
  - Refreshed pipeline-cadence command docs, examples, and workflow guides to match the new schedule and flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->