### PR TITLE
fix(himmelctl): [HIMMEL-935] CodeRabbit #1126 findings - ExecutionPolicy, REPO_ROOT pinning, winget UX, PS5 probe

### DIFF
--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -262,7 +262,7 @@ the required-environment table (HIMMEL-460).
 |---|---|---|
 | role | `adopter` \| `contributor` | Default: `contributor` only when origin ends in `himmel` AND the repo root carries a `.himmel-dev` marker (a contributor dev checkout); every other case — including a fresh official clone — defaults to `adopter`. |
 | scope | `project` \| `user` | Adopter only (contributor is always `user`). |
-| vault | `none` \| `default-template` \| `existing` | `default-template` scaffolds a luna vault from template; `existing` wires a STAMPED luna vault (non-luna→luna conversion deferred — HIMMEL-862). |
+| vault | `none` \| `default-template` \| `existing` | `none` scaffolds no vault; `default-template` scaffolds a luna vault from template; `existing` wires a STAMPED luna vault (non-luna→luna conversion deferred — HIMMEL-862). Skipping adopt.sh/setup.sh wiring entirely (no pre-commit hooks/guardrails/statusline/env.HIMMEL_REPO — operator wires manually) has no in-wizard option: don't run the wizard. |
 | handover | `inline` \| `external` | `external` persists `HANDOVER_DIR` to an external state repo. |
 | pluginSet | `lean` \| `full` | `lean` is the default (HIMMEL-816); `full` runs the documented per-plugin enable step (§6). |
 

--- a/scripts/himmelctl/bin.js
+++ b/scripts/himmelctl/bin.js
@@ -616,7 +616,7 @@ function deriveCommand(answers) {
   const scriptsDir = path.join(repoRoot(), 'scripts');
   if (answers.role === 'contributor') {
     if (process.platform === 'win32') {
-      return { argv: ['powershell', '-File', path.join(scriptsDir, 'setup.ps1')] };
+      return { argv: ['powershell', '-ExecutionPolicy', 'Bypass', '-File', path.join(scriptsDir, 'setup.ps1')] };
     }
     return { argv: ['bash', path.join(scriptsDir, 'setup.sh')] };
   }
@@ -981,7 +981,7 @@ async function cmdInstall(args) {
 function deriveUninstallCommand() {
   const scriptsDir = path.join(repoRoot(), 'scripts');
   if (process.platform === 'win32') {
-    return { argv: ['powershell', '-File', path.join(scriptsDir, 'uninstall.ps1'), '-Yes'] };
+    return { argv: ['powershell', '-ExecutionPolicy', 'Bypass', '-File', path.join(scriptsDir, 'uninstall.ps1'), '-Yes'] };
   }
   return { argv: ['bash', path.join(scriptsDir, 'uninstall.sh'), '--yes'] };
 }

--- a/scripts/himmelctl/bootstrap.ps1
+++ b/scripts/himmelctl/bootstrap.ps1
@@ -47,8 +47,9 @@ Write-Output "bootstrap: hand-off after install: $handoffCmd"
 if ($DryRun) { exit 0 }
 
 winget install --id OpenJS.NodeJS.LTS -e
-if ($LASTEXITCODE -ne 0) {
-  Write-Warning "winget install --id OpenJS.NodeJS.LTS -e exited $LASTEXITCODE"
+$wingetExit = $LASTEXITCODE
+if ($wingetExit -ne 0) {
+  Write-Warning "winget install --id OpenJS.NodeJS.LTS -e exited $wingetExit"
 }
 # bun is optional (needed later for qmd/telegram features); winget has no
 # reliable bare-name match for it, so it is never part of the plan above.
@@ -60,7 +61,18 @@ if (Test-NodePresent) {
   exit $LASTEXITCODE
 }
 
-# PATH-refresh trap (Draft-A §6): the fresh install's PATH edit is invisible
-# to this process. Print the ONE re-run line rather than chaining blindly.
+# winget genuinely failed AND node is still absent: NOT the PATH-refresh trap
+# (HIMMEL-935 / CR #1126). Fail closed with the actual install failure instead
+# of the re-run line, which implies success and would loop forever re-running a
+# known-failing winget install. ($ErrorActionPreference='Stop' makes Write-Error
+# terminating, so this exits non-zero either way.)
+if ($wingetExit -ne 0) {
+  Write-Error "bootstrap: winget install failed (exit $wingetExit) and node is still not resolvable -- fix the winget failure above and re-run"
+  exit 1
+}
+
+# PATH-refresh trap (Draft-A §6): winget SUCCEEDED but the fresh install's PATH
+# edit is invisible to this process. Print the ONE re-run line rather than
+# chaining blindly.
 Write-Output "bootstrap: node installed but not resolvable in this shell -- open a new terminal and re-run: powershell -ExecutionPolicy Bypass -File `"$scriptDir\bootstrap.ps1`""
 exit 1

--- a/scripts/himmelctl/bootstrap.sh
+++ b/scripts/himmelctl/bootstrap.sh
@@ -45,7 +45,19 @@ install_plan() {
 run_install() {
   case "$(uname -s)" in
     Darwin) brew install node bun ;;
-    *)      sudo apt-get install -y nodejs npm ;;
+    *)
+      # Non-Darwin assumes apt (the only posix plan this shim carries). Do NOT
+      # add distro-specific package managers (yum/dnf/pacman/zypper) — fail
+      # closed with a manual-install pointer naming the detected platform so a
+      # non-apt host never silently mis-runs `sudo apt-get` (HIMMEL-935 / CR #1126).
+      if ! command -v apt-get >/dev/null 2>&1; then
+        echo "bootstrap: no apt-get on this host ($(uname -s) $(uname -r)) -- install Node.js >=18 manually (see https://nodejs.org), put it on PATH, then re-run bootstrap" >&2
+        return 1
+      fi
+      # Refresh the package index first: a fresh host's lists are often
+      # empty/stale and the install fails outright (CodeRabbit r2, #1140).
+      sudo apt-get update && sudo apt-get install -y nodejs npm
+      ;;
   esac
 }
 

--- a/scripts/himmelctl/test/test-wizard-bootstrap.sh
+++ b/scripts/himmelctl/test/test-wizard-bootstrap.sh
@@ -278,7 +278,7 @@ echo "ok: caseG(sh) a genuinely failed apt/brew install -> 'node install failed'
 # test host; apt-get is scrubbed so run_install hits the no-apt-get guard.
 stubH="$work/shH"; mkdir -p "$stubH"
 build_sudo_stub "$stubH" 0
-cH=$(build_path "$stubH" -- node apt-get)
+cH=$(build_path "$stubH" dirname bash -- node apt-get)
 cat > "$stubH/uname" <<STUB
 #!/usr/bin/env bash
 [ "\$1" = "-s" ] && { echo "Linux"; exit 0; }

--- a/scripts/himmelctl/test/test-wizard-bootstrap.sh
+++ b/scripts/himmelctl/test/test-wizard-bootstrap.sh
@@ -27,12 +27,13 @@
 #      `winget install node bun` resolves as a single bad query) — apt gets
 #      `nodejs npm` only, winget gets `--id OpenJS.NodeJS.LTS -e`; a
 #      bun-is-optional note is printed instead.
-#   G. CR r1 FIX 1/2: the platform installer itself EXITS NONZERO (a genuine
-#      apt/winget failure, not just a not-yet-refreshed-PATH) -> bootstrap.sh
-#      prints "node install failed" and aborts immediately (no re-run line);
-#      bootstrap.ps1 prints a Write-Warning with the exit code but still
-#      continues to the usual re-probe + re-run line (FIX 2's warn-not-abort
-#      semantics).
+#   G. CR r1 FIX 1/2 (HIMMEL-935 for ps1): the platform installer itself EXITS
+#      NONZERO (a genuine apt/winget failure, not just a not-yet-refreshed-PATH)
+#      -> bootstrap.sh prints "node install failed" and aborts immediately (no
+#      re-run line); bootstrap.ps1 prints a Write-Warning with the exit code,
+#      then fail-closes with a Write-Error instead of the re-run line (the old
+#      warn-not-abort implied success and looped forever re-running a known-
+#      failing winget install).
 #
 # pwsh availability is optional on posix CI hosts: the .ps1 cases are
 # skipped (not failed) when pwsh isn't found, mirroring the availability
@@ -128,6 +129,19 @@ STUB
   chmod +x "$_dir/sudo"
 }
 
+# build_aptget_stub <dir> — a no-op `apt-get` so bootstrap.sh's non-Darwin
+# `command -v apt-get` presence guard (HIMMEL-935) passes on hosts that lack
+# apt-get (macOS/MINGW), letting the sudo stub intercept `sudo apt-get install`
+# as before. It is never actually invoked — sudo receives apt-get as an arg.
+build_aptget_stub() {
+  local _dir="$1"
+  cat > "$_dir/apt-get" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$_dir/apt-get"
+}
+
 # ── bootstrap.sh — Case A: node present -> short-circuit, no installer ─────
 stubA="$work/shA"; mkdir -p "$stubA"
 cA=$(build_path "$stubA" uname node -- )
@@ -170,6 +184,7 @@ echo "ok: caseB(sh) --dry-run node-absent -> plan+hand-off printed, nothing muta
 # ── bootstrap.sh — Case C: node absent, install doesn't refresh PATH ───────
 stubC="$work/shC"; mkdir -p "$stubC"
 build_sudo_stub "$stubC" 0
+build_aptget_stub "$stubC"
 cC=$(build_path "$stubC" uname -- node)
 fixtureC="$work/shC-fixture"; build_bin_js_fixture "$fixtureC"
 set +e
@@ -189,6 +204,7 @@ echo "ok: caseC(sh) node absent, install doesn't refresh PATH -> single re-run l
 # ── bootstrap.sh — Case D (bonus): install DOES refresh PATH -> chains ─────
 stubD="$work/shD"; mkdir -p "$stubD"
 build_sudo_stub "$stubD" 1
+build_aptget_stub "$stubD"
 cD=$(build_path "$stubD" uname -- node)
 fixtureD="$work/shD-fixture"; build_bin_js_fixture "$fixtureD"
 set +e
@@ -230,6 +246,7 @@ echo "ok: caseF(sh) install plan no longer asks apt for a nonexistent bun packag
 
 # ── bootstrap.sh — Case G: FIX 1 -- a genuine install failure aborts loud ──
 stubG="$work/shG"; mkdir -p "$stubG"
+build_aptget_stub "$stubG"
 cat > "$stubG/sudo" <<STUB
 #!/usr/bin/env bash
 printf 'sudo: %s\n' "\$*" >> "$stubG/install-calls.log"
@@ -253,17 +270,56 @@ printf '%s' "$out" | grep -q 're-run' \
   && fail "caseG(sh): a genuine install failure must NOT chain to bin.js"
 echo "ok: caseG(sh) a genuinely failed apt/brew install -> 'node install failed' printed, aborts immediately, no chain"
 
+# ── bootstrap.sh — Case H: non-Darwin host WITHOUT apt-get fails closed ─────
+# HIMMEL-935 / CR #1126: the non-Darwin branch assumes apt. A host that is
+# neither Darwin nor apt-based must fail closed with a manual-install pointer
+# naming the detected platform, not silently mis-run `sudo apt-get`. A fake
+# `uname` (reporting Linux) forces the non-Darwin branch even on a Darwin/macOS
+# test host; apt-get is scrubbed so run_install hits the no-apt-get guard.
+stubH="$work/shH"; mkdir -p "$stubH"
+build_sudo_stub "$stubH" 0
+cH=$(build_path "$stubH" -- node apt-get)
+cat > "$stubH/uname" <<STUB
+#!/usr/bin/env bash
+[ "\$1" = "-s" ] && { echo "Linux"; exit 0; }
+[ "\$1" = "-r" ] && { echo "99.0-fake"; exit 0; }
+exec /usr/bin/uname "\$@"
+STUB
+chmod +x "$stubH/uname"
+fixtureH="$work/shH-fixture"; build_bin_js_fixture "$fixtureH"
+set +e
+out=$(PATH="$cH" HIMMELCTL_REPO_ROOT="$(winpath "$fixtureH")" \
+      "$bash_bin" "$bootstrap_sh" 2>&1); rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "caseH(sh): a non-Darwin host without apt-get should fail closed (got rc=$rc): $out"
+printf '%s' "$out" | grep -qi 'install Node.js' \
+  || fail "caseH(sh): expected the 'install Node.js >=18 manually' pointer (got: $out)"
+printf '%s' "$out" | grep -qi 'Linux' \
+  || fail "caseH(sh): expected the detected platform named in the message (got: $out)"
+[ -f "$stubH/install-calls.log" ] \
+  && fail "caseH(sh): the installer (sudo apt-get) must NOT be invoked when apt-get is absent (got: $out)"
+echo "ok: caseH(sh) non-Darwin host without apt-get -> fail-closed manual-install pointer, no sudo apt-get"
+
 # ── bootstrap.ps1 cases (skipped if pwsh isn't on this host, or when the
 # host isn't Windows — the winget.cmd/node.exe stubs are Windows-only) ─────
+# Prefer Windows PowerShell 5.1 (powershell.exe, always present on stock
+# Windows) over pwsh (PowerShell 7, a separate install) so the .ps1 cases run
+# on a stock Windows host; fall back to pwsh (HIMMEL-935 / CR #1126). The
+# variable keeps the pwsh_bin name for minimal churn; it holds whichever
+# interpreter was chosen.
 pwsh_bin=""
-command -v pwsh >/dev/null 2>&1 && pwsh_bin=$(command -v pwsh)
+if command -v powershell >/dev/null 2>&1; then
+  pwsh_bin=$(command -v powershell)
+elif command -v pwsh >/dev/null 2>&1; then
+  pwsh_bin=$(command -v pwsh)
+fi
 win_host=0
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*) win_host=1 ;;
 esac
 
 if [ -z "$pwsh_bin" ]; then
-  echo "skip: pwsh not found -- bootstrap.ps1 hermetic cases skipped"
+  echo "skip: no PowerShell interpreter (powershell/pwsh) found -- bootstrap.ps1 hermetic cases skipped"
 elif [ "$win_host" -ne 1 ]; then
   echo "skip: non-Windows host -- bootstrap.ps1 hermetic cases need Windows-only winget.cmd/node.exe stubs"
 else
@@ -348,7 +404,7 @@ STUB
     && fail "caseF(ps1): the winget plan/dry-run preview must NOT mention bun (got: $out)"
   echo "ok: caseF(ps1) winget plan targets --id OpenJS.NodeJS.LTS -e, no bare 'node bun' query"
 
-  # ── bootstrap.ps1 — Case G: FIX 2 -- winget nonzero exit warns, continues ─
+  # ── bootstrap.ps1 — Case G: FIX 2/HIMMEL-935 -- winget nonzero exit fail-closes ─
   stubG2="$work/psG"; mkdir -p "$stubG2"
   cat > "$stubG2/winget.cmd" <<'STUB'
 @echo off
@@ -366,11 +422,13 @@ STUB
     || fail "caseG(ps1): expected winget to have been invoked (out: $out)"
   printf '%s' "$out" | grep -qi 'exited 1' \
     || fail "caseG(ps1): expected the Write-Warning 'exited 1' message (got: $out)"
-  printf '%s' "$out" | grep -q 're-run' \
-    || fail "caseG(ps1): a winget failure should WARN then still continue to the re-run/PATH-refresh message (got: $out)"
+  printf '%s' "$out" | grep -qi 'winget install failed' \
+    || fail "caseG(ps1): expected the fail-closed 'winget install failed' message (HIMMEL-935) (got: $out)"
+  printf '%s' "$out" | grep -q 'open a new terminal' \
+    && fail "caseG(ps1): a genuine winget failure must NOT print the PATH-refresh re-run line (would loop forever) (got: $out)"
   [ -f "$fixtureG2/scripts/himmelctl/bin-js-calls.log" ] \
     && fail "caseG(ps1): must NOT chain to bin.js when node is still unresolvable after a failed winget"
-  echo "ok: caseG(ps1) a failed winget install -> Write-Warning with exit code, still continues to the re-run message (warn-not-abort)"
+  echo "ok: caseG(ps1) a failed winget install -> Write-Warning + fail-closed Write-Error, NO re-run/PATH-refresh loop (HIMMEL-935)"
 fi
 
 echo "PASS"

--- a/scripts/himmelctl/test/test-wizard-derive.sh
+++ b/scripts/himmelctl/test/test-wizard-derive.sh
@@ -427,8 +427,8 @@ set -e
 [ "$rc" -eq 0 ] || fail "caseE: dry-run should succeed (got rc=$rc): $out"
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
-    printf '%s' "$out" | grep -qE 'derived:.*powershell -File .*setup\.ps1$' \
-      || fail "caseE(win32): expected 'powershell -File ...setup.ps1' (got: $out)"
+    printf '%s' "$out" | grep -qE 'derived:.*powershell -ExecutionPolicy Bypass -File .*setup\.ps1$' \
+      || fail "caseE(win32): expected 'powershell -ExecutionPolicy Bypass -File ...setup.ps1' (got: $out)"
     ;;
   *)
     printf '%s' "$out" | grep -qE 'derived:.*bash .*setup\.sh$' \

--- a/scripts/himmelctl/test/test-wizard-preflight.sh
+++ b/scripts/himmelctl/test/test-wizard-preflight.sh
@@ -149,17 +149,56 @@ printf '%s' "$out" | grep -q 'preflight OK' \
 echo "ok: case3 interactive -> exactly 1 $pkgmgr call + recheck passes -> preflight OK"
 
 # ── Case 4: interactive, closed stdin at the install confirm -> no hang ────
+# CR r1 FIX 8 made the confirm EOF-safe so a closed stdin declines instead of
+# looping forever. This case REGRESSION-GUARDS that fix: if the EOF-safe helper
+# ever regresses, the wizard would hang on the confirm and wedge CI. So the
+# invocation runs under a bounded watchdog (mirroring scripts/check-plugin-dift.sh's
+# probe-timeout pattern): `timeout` when present, else a bash-native setsid
+# group-kill fallback. Git-Bash's `timeout` does not reap grandchildren; the
+# wizard spawns none at a closed-stdin confirm, but the setsid fallback
+# (process-group kill) is correct if it ever does. bash 3.2-safe (plain `wait`,
+# no `wait -n`). A hang fails this case instead of wedging CI.
 stub4="$work/case4"; mkdir -p "$stub4"
 c4path=$(build_path "$stub4" bash git python3 npm -- jq)
 h4="$work/h4"; mkdir -p "$h4"
+c4_budget=15
+c4_out="$work/case4.out"
 set +e
-out=$(PATH="$c4path" HOME="$h4" HIMMELCTL_INTERACTIVE=1 \
-      "$node_bin" "$wizard" install </dev/null 2>&1); rc=$?
+if command -v timeout >/dev/null 2>&1; then
+  timeout "$c4_budget" env PATH="$c4path" HOME="$h4" HIMMELCTL_INTERACTIVE=1 \
+    "$node_bin" "$wizard" install </dev/null >"$c4_out" 2>&1
+  rc=$?
+else
+  if command -v setsid >/dev/null 2>&1; then
+    setsid env PATH="$c4path" HOME="$h4" HIMMELCTL_INTERACTIVE=1 \
+      "$node_bin" "$wizard" install </dev/null >"$c4_out" 2>&1 &
+    c4_pid=$!; c4_grouped=1
+  else
+    env PATH="$c4path" HOME="$h4" HIMMELCTL_INTERACTIVE=1 \
+      "$node_bin" "$wizard" install </dev/null >"$c4_out" 2>&1 &
+    c4_pid=$!; c4_grouped=0
+  fi
+  ( sleep "$c4_budget"
+    if [ "$c4_grouped" -eq 1 ]; then kill -9 -- -"$c4_pid" 2>/dev/null
+    else kill -9 "$c4_pid" 2>/dev/null; fi
+  ) &
+  c4_wdog=$!
+  wait "$c4_pid" 2>/dev/null
+  rc=$?
+  kill "$c4_wdog" 2>/dev/null
+  wait "$c4_wdog" 2>/dev/null
+fi
 set -e
+# timeout(1) exits 124 on its own budget; a signal-killed child (the setsid
+# fallback) leaves rc>=128. Either means the confirm HANGS -> fail, not wedge CI.
+if [ "$rc" -eq 124 ] || [ "$rc" -ge 128 ]; then
+  fail "case4: closed-stdin confirm HANGS (regression of the EOF-safe helper) — watchdog killed it at ${c4_budget}s (rc=$rc, out: $(cat "$c4_out" 2>/dev/null))"
+fi
+out="$(cat "$c4_out" 2>/dev/null)"
 [ "$rc" -ne 0 ] || fail "case4: closed-stdin decline at the install confirm should exit non-zero (got rc=$rc): $out"
 printf '%s' "$out" | grep -q 'Install missing tools now' \
   || fail "case4: expected the install-confirm prompt to be shown (got: $out)"
-echo "ok: case4 interactive missing-tool, closed stdin at the confirm -> declines safely (no hang), exit non-zero"
+echo "ok: case4 interactive missing-tool, closed stdin at the confirm -> declines safely (no hang, ${c4_budget}s watchdog), exit non-zero"
 
 # ── Case 5: two subcommands -> hard error rc=2, nothing runs ───────────────
 stub5="$work/case5"; mkdir -p "$stub5"

--- a/scripts/himmelctl/test/test-wizard-uninstall.sh
+++ b/scripts/himmelctl/test/test-wizard-uninstall.sh
@@ -124,8 +124,8 @@ out=$(PATH="$cB" HOME="$hB" HIMMELCTL_INTERACTIVE=0 \
 set -e
 [ "$rc" -eq 0 ] || fail "caseB: dry-run should exit 0 (got rc=$rc): $out"
 if is_win32; then
-  printf '%s' "$out" | grep -qE 'derived:.*powershell -File .*uninstall\.ps1 -Yes$' \
-    || fail "caseB(win32): expected 'powershell -File ...uninstall.ps1 -Yes' (got: $out)"
+  printf '%s' "$out" | grep -qE 'derived:.*powershell -ExecutionPolicy Bypass -File .*uninstall\.ps1 -Yes$' \
+    || fail "caseB(win32): expected 'powershell -ExecutionPolicy Bypass -File ...uninstall.ps1 -Yes' (got: $out)"
 else
   printf '%s' "$out" | grep -qE 'derived:.*bash .*uninstall\.sh --yes$' \
     || fail "caseB(posix): expected 'bash .../uninstall.sh --yes' (got: $out)"

--- a/scripts/machine-setup/ubuntu.sh
+++ b/scripts/machine-setup/ubuntu.sh
@@ -136,4 +136,4 @@ step "Delegate himmel/luna wiring to himmelctl bootstrap (HIMMEL-887)"
 # himmel clone deterministically.
 echo "NOTICE: himmel/luna wiring in this script is soft-deprecated (HIMMEL-887) -- delegating to himmelctl bootstrap. Hard-remove deferred to HIMMEL-755."
 cd "$HIMMEL_PATH"
-exec bash "$HIMMEL_PATH/scripts/himmelctl/bootstrap.sh"
+HIMMELCTL_REPO_ROOT="$HIMMEL_PATH" exec bash "$HIMMEL_PATH/scripts/himmelctl/bootstrap.sh"

--- a/scripts/machine-setup/win11.ps1
+++ b/scripts/machine-setup/win11.ps1
@@ -158,5 +158,8 @@ Write-Step "Delegate himmel/luna wiring to himmelctl bootstrap (HIMMEL-887)"
 # inference targets the himmel clone deterministically.
 Write-Host "NOTICE: himmel/luna wiring in this script is soft-deprecated (HIMMEL-887) -- delegating to himmelctl bootstrap. Hard-remove deferred to HIMMEL-755."
 Set-Location $HimmelPath
+# Pin HIMMELCTL_REPO_ROOT to this clone so a stale inherited value can't
+# redirect the bootstrap hand-off at a different repo's bin.js (HIMMEL-935 / CR #1126).
+$env:HIMMELCTL_REPO_ROOT = $HimmelPath
 & (Join-Path $HimmelPath 'scripts\himmelctl\bootstrap.ps1')
 exit $LASTEXITCODE


### PR DESCRIPTION
Public mirror of private PR #1140 (squash `baac39a8`), HIMMEL-935.

Applies the CodeRabbit #1126 review findings to the himmelctl install wizard: ExecutionPolicy handling in `bootstrap.ps1`, REPO_ROOT pinning, winget install UX, and the PowerShell 5 probe. Test updates in `test-wizard-bootstrap.sh`; `docs/setup/new-machine.md` kept in sync.

Verification: prep worktree byte-verified against the private squash; wizard bootstrap suite green in-worktree (s43). CR matrix clean on private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows setup failure handling to fail closed when package installation fails, avoiding repeated/looping attempts.
  - Hardened Linux installation on systems missing `apt-get`, with clearer guidance and no risky install attempts.
  - Refresh package indexes before installing Node.js and npm on apt-based systems.
  - Ensured delegated installation consistently uses the newly cloned local repository.
- **Documentation**
  - Clarified the wizard’s “vault: none” option: skipping wiring requires not running the wizard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->