### PR TITLE
fix(cr): qwen seat refresh - qwen-flash pin, responding-model ledger, seat dropped until healed

### DIFF
--- a/scripts/cr/critic-panel.sh
+++ b/scripts/cr/critic-panel.sh
@@ -353,6 +353,7 @@ _run_cfp_member() {
 #      ("" = no quota-exhaustion fallback). Iterated in order, each at most once.
 # $6 = perspective for this slug (optional; "" = no --perspective-file), threaded
 #      into the fallback re-run so it uses the SAME invocation path as the primary
+# $7 = primary model for this slug (used only for availability metadata)
 # ---------------------------------------------------------------------------
 process_member() {
     _pm_slug="$1"
@@ -361,7 +362,12 @@ process_member() {
     _pm_err_file="${4:-}"
     _pm_fallback="${5:-}"
     _pm_perspective="${6:-}"
-    _pm_avail="panel-availability: $_pm_slug ok"
+    _pm_model="${7:-}"
+    if [ -n "$_pm_model" ]; then
+        _pm_avail="panel-availability: $_pm_slug ok responding-model($_pm_model)"
+    else
+        _pm_avail="panel-availability: $_pm_slug ok"
+    fi
     _fb_out=""
     _fb_err=""
 
@@ -531,7 +537,7 @@ if [ "$CRITIC_PARALLEL" = "0" ]; then
             fi
         fi
 
-        process_member "$slug" "$_seq_out" "$rc" "$_seq_err" "$fallback_chain" "$perspective"
+        process_member "$slug" "$_seq_out" "$rc" "$_seq_err" "$fallback_chain" "$perspective" "$model"
 
     done << ROWSEOF
 $rows
@@ -602,7 +608,9 @@ ROWSEOF
         # rc_val stays at its initialized 1 → process_member treats the member as
         # unavailable (safe). The benign case (rc=0, .out empty) is also handled:
         # process_member sees zero findings and counts the member as responded.
-        process_member "$slug" "$outdir/$i.out" "$rc_val" "$outdir/$i.err" "$fb_val" "$persp_val"
+        model_val=""
+        read -r model_val < "$outdir/$i.model" 2>/dev/null || true
+        process_member "$slug" "$outdir/$i.out" "$rc_val" "$outdir/$i.err" "$fb_val" "$persp_val" "$model_val"
         i=$((i + 1))
     done
 fi

--- a/scripts/cr/critics.json
+++ b/scripts/cr/critics.json
@@ -1,7 +1,6 @@
 {
   "_compliance": "panel/router lanes must terminate per-token keys only; the Z.ai Coding-Plan subscription (and any subscription lane) is launcher-only (ToS restricts it to officially supported tools) — never behind a panel or router.",
   "panel": [
-    { "slug": "qwen3coder", "model": "qwen3-coder-plus", "provider": "alibaba-coding-plan", "tier": "free", "fallback_models": ["qwen-plus", "qwen3.7-max", "qwen3-max", "qwq-plus", "qwen-flash"] },
     { "slug": "qwenor",     "model": "qwen/qwen3-next-80b-a3b-instruct:free", "provider": "openrouter", "route_provider": "openrouter", "tier": "free" },
     { "slug": "codex",      "model": "gpt-5.5",                             "provider": "openai-codex", "tier": "paid" }
   ]

--- a/scripts/cr/ledger-append.sh
+++ b/scripts/cr/ledger-append.sh
@@ -9,11 +9,12 @@ set -uo pipefail
 kind="${1:-}"; shift || true
 [ "$kind" = "finding" ] || [ "$kind" = "avail" ] || [ "$kind" = "usage" ] || { echo "ledger-append.sh: kind must be finding|avail|usage" >&2; exit 2; }
 
-branch="" head="" model="" id="" severity="" file="" line="" verdict="" status="" artifact="diff" perspective="off"
+branch="" head="" model="" responding_model="" id="" severity="" file="" line="" verdict="" status="" artifact="diff" perspective="off"
 prompt_chars="" response_chars=""
 while [ $# -gt 0 ]; do case "$1" in
   --branch) branch="$2"; shift 2;; --head) head="$2"; shift 2;;
-  --model) model="$2"; shift 2;; --id) id="$2"; shift 2;;
+  --model) model="$2"; shift 2;; --responding-model) responding_model="$2"; shift 2;;
+  --id) id="$2"; shift 2;;
   --severity) severity="$2"; shift 2;; --file) file="$2"; shift 2;;
   --line) line="$2"; shift 2;; --verdict) verdict="$2"; shift 2;;
   --status) status="$2"; shift 2;;
@@ -31,7 +32,7 @@ touch "$ledger" || { echo "ledger-append.sh: cannot write $ledger" >&2; exit 2; 
 
 ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 # Build the record + a dedup grep key via node (safe JSON + escaping).
-KIND="$kind" BRANCH="$branch" HEAD_="$head" MODEL="$model" ID="$id" SEV="$severity" \
+KIND="$kind" BRANCH="$branch" HEAD_="$head" MODEL="$model" RESPONDING_MODEL="$responding_model" ID="$id" SEV="$severity" \
 FILE="$file" LINE="$line" VERDICT="$verdict" STATUS="$status" \
 PROMPT_CHARS="$prompt_chars" RESPONSE_CHARS="$response_chars" TS="$ts" LEDGER="$ledger" ARTIFACT="$artifact" PERSPECTIVE="$perspective" node -e '
   const fs=require("fs"), e=process.env;
@@ -40,6 +41,7 @@ PROMPT_CHARS="$prompt_chars" RESPONSE_CHARS="$response_chars" TS="$ts" LEDGER="$
   let rec, dup;
   if(e.KIND==="finding"){
     rec={kind:"finding",ts:e.TS,branch:e.BRANCH,head:e.HEAD_,model:e.MODEL,finding_id:e.ID,severity:e.SEV,file:e.FILE,line:Number(e.LINE)||e.LINE,verdict:e.VERDICT,artifact:e.ARTIFACT,perspective:e.PERSPECTIVE};
+    if(e.RESPONDING_MODEL) rec.responding_model=e.RESPONDING_MODEL;
     dup=existing.some(l=>{try{const o=JSON.parse(l);return o.kind==="finding"&&o.head===e.HEAD_&&o.finding_id===e.ID&&(o.artifact||"diff")===e.ARTIFACT&&(o.perspective||"off")===e.PERSPECTIVE;}catch{return false;}});
   } else if(e.KIND==="usage"){
     // chars/4 token estimate (hermes does not expose real usage via the one-shot
@@ -47,9 +49,11 @@ PROMPT_CHARS="$prompt_chars" RESPONSE_CHARS="$response_chars" TS="$ts" LEDGER="$
     const pc=Math.max(0, Number(e.PROMPT_CHARS)||0), rc=Math.max(0, Number(e.RESPONSE_CHARS)||0);
     const ept=Math.round(pc/4), ect=Math.round(rc/4);
     rec={kind:"usage",ts:e.TS,branch:e.BRANCH,head:e.HEAD_,model:e.MODEL,prompt_chars:pc,response_chars:rc,est_prompt_tokens:ept,est_completion_tokens:ect,est_total_tokens:ept+ect,estimated:true,artifact:e.ARTIFACT,perspective:e.PERSPECTIVE};
+    if(e.RESPONDING_MODEL) rec.responding_model=e.RESPONDING_MODEL;
     dup=existing.some(l=>{try{const o=JSON.parse(l);return o.kind==="usage"&&o.head===e.HEAD_&&o.model===e.MODEL&&(o.artifact||"diff")===e.ARTIFACT&&(o.perspective||"off")===e.PERSPECTIVE;}catch{return false;}});
   } else {
     rec={kind:"avail",ts:e.TS,branch:e.BRANCH,head:e.HEAD_,model:e.MODEL,status:e.STATUS,artifact:e.ARTIFACT,perspective:e.PERSPECTIVE};
+    if(e.RESPONDING_MODEL) rec.responding_model=e.RESPONDING_MODEL;
     dup=existing.some(l=>{try{const o=JSON.parse(l);return o.kind==="avail"&&o.head===e.HEAD_&&o.model===e.MODEL&&(o.artifact||"diff")===e.ARTIFACT&&(o.perspective||"off")===e.PERSPECTIVE;}catch{return false;}});
   }
   if(dup) process.exit(0);

--- a/scripts/cr/test-critic-panel-fallback.sh
+++ b/scripts/cr/test-critic-panel-fallback.sh
@@ -95,6 +95,15 @@ if [ "\$model" = "$PRI" ]; then
         exhaust)
             printf 'Alibaba: you have exceeded your allocated quota for qwen3-coder-plus\\n' >&2
             exit 1 ;;
+        ok)
+            printf '# %s First-Pass Review\\n' "\$slug"
+            printf '\\n'
+            printf '## Critical Issues (0 found)\\n'
+            printf '\\n'
+            printf '## Important Issues (0 found)\\n'
+            printf '\\n'
+            printf '## Suggestions (0 found)\\n'
+            exit 0 ;;
         generic)
             printf 'connection refused\\n' >&2
             exit 1 ;;
@@ -137,6 +146,16 @@ run_case() {
         FB_STUB_MODE="$_mode" FB_FALLBACK_FAIL="$_fbf" FB_CAPTURE="$_cap" \
         bash "$PANEL" >"$_outf" 2>"$_errf"
 }
+
+# ===========================================================================
+# Case 0: primary success reports the actual responding model in availability.
+# ===========================================================================
+run_case ok "$JSON" "$tmp/out0" "$tmp/err0" "$tmp/cap0"
+stderr0="$(cat "$tmp/err0")"
+check_contains "0: primary ok availability carries responding model" "$stderr0" \
+    "panel-availability: qwen3coder ok responding-model($PRI)"
+check "0: fallback model NEVER invoked on primary success" \
+    "$(grep -cF -- "$FB" "$tmp/cap0")" "0"
 
 # ===========================================================================
 # Case 1: quota-exhaustion on primary -> fall back ONCE to OpenRouter, succeed.
@@ -195,18 +214,18 @@ check "3: fallback model NEVER invoked on timeout" "$fb_calls3" "0"
 
 # ===========================================================================
 # Case 4: registry row WITHOUT fallback_model + exhaustion failure -> still no
-# fallback (the fallback_model column gates the retry; nothing else does).
-# Locks the contract that absence of fallback_model means plain unavailable even
+# fallback (an empty fallback_models array gates the retry; nothing else does).
+# Locks the contract that no configured fallback means plain unavailable even
 # under an exhaustion signature.
 # ===========================================================================
 JSON_NOFB="$tmp/critics-nofb.json"
-printf '{"panel":[{"slug":"qwen3coder","model":"%s","provider":"alibaba-coding-plan","tier":"free"}]}' "$PRI" > "$JSON_NOFB"
+printf '{"panel":[{"slug":"qwen3coder","model":"%s","provider":"alibaba-coding-plan","tier":"free","fallback_models":[]}]}' "$PRI" > "$JSON_NOFB"
 run_case exhaust "$JSON_NOFB" "$tmp/out4" "$tmp/err4" "$tmp/cap4"
 stderr4="$(cat "$tmp/err4")"
 check_contains "4: no-fallback row -> plain unavailable on exhaustion" "$stderr4" \
     "panel-availability: qwen3coder unavailable (rc=1)"
 check_not_contains "4: NO WARN line" "$stderr4" "WARN critic-panel"
-check "4: fallback model NEVER invoked when row has no fallback_model" \
+check "4: fallback model NEVER invoked when row has empty fallback_models" \
     "$(grep -cF -- "$FB" "$tmp/cap4")" "0"
 
 # ===========================================================================

--- a/scripts/cr/test-ledger-append.sh
+++ b/scripts/cr/test-ledger-append.sh
@@ -12,9 +12,17 @@ check "finding dedup on (head,id)" "$(wc -l < "$L" | tr -d ' ')" "1"
 CR_LEDGER="$L" bash "$LA" finding --branch b --head H2 --model m --id m-1 --severity critical --file f --line 3 --verdict disproved
 check "new head -> new line" "$(wc -l < "$L" | tr -d ' ')" "2"
 
+CR_LEDGER="$L" bash "$LA" finding --branch b --head H5 --model qwen3coder --responding-model qwen-flash --id qwen3coder-1 --severity critical --file f --line 3 --verdict agreed
+check "finding stores responding_model separately from model key" "$(L="$L" node -e 'const o=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).find(r=>r.head==="H5");console.log(o.model+","+o.responding_model)')" "qwen3coder,qwen-flash"
+
 CR_LEDGER="$L" bash "$LA" avail --branch b --head H1 --model m --status ok
 CR_LEDGER="$L" bash "$LA" avail --branch b --head H1 --model m --status ok
 check "avail dedup on (head,model)" "$(grep -c '"kind":"avail"' "$L")" "1"
+
+CR_LEDGER="$L" bash "$LA" avail --branch b --head H5 --model qwen3coder --responding-model qwen-flash --status ok
+CR_LEDGER="$L" bash "$LA" avail --branch b --head H5 --model qwen3coder --responding-model qwen-plus --status ok
+check "avail responding_model does not change dedup key" "$(grep -c '"kind":"avail".*"head":"H5"' "$L")" "1"
+check "avail stores first responding_model" "$(L="$L" node -e 'const o=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).find(r=>r.kind==="avail"&&r.head==="H5");console.log(o.model+","+o.responding_model)')" "qwen3coder,qwen-flash"
 
 # ── usage kind (HIMMEL-485): chars/4 token estimate, dedup on (head,model) ──
 CR_LEDGER="$L" bash "$LA" usage --branch b --head H1 --model codex --prompt-chars 4000 --response-chars 800


### PR DESCRIPTION
Critic-panel refresh: qwen-flash primary pin (dead fallback chain removed), responding-model recorded in the CR ledger (additive, backward-compatible), and the qwen seat dropped from the panel until healed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Panel availability results now identify which model responded when a primary model succeeds.
  - Critic ledger records include the responding model for findings, usage, and availability entries.

- **Bug Fixes**
  - Improved handling of unavailable panels and explicitly configured empty fallback lists.
  - Removed the `qwen3coder` entry from the critic panel configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->