### PR TITLE
feat(cr): [HIMMEL-936] merge gate - block gh pr merge on unresolved CodeRabbit remarks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,7 @@ Autonomous end-to-end execution of a well-scoped ticket: see
 
 ## ENFORCEMENT (runs automatically)
 
-himmel enforces structurally, not by prose: **9 PreToolUse hooks**
+himmel enforces structurally, not by prose: **10 PreToolUse hooks**
 (`auto-approve-safe-bash`, `block-edit-on-main`, `block-read-secrets`,
 `block-rogue-claude-schedule` — blocks raw scheduler-arms of claude that bypass
 arm-resume.sh (System32-cwd trap, HIMMEL-647),
@@ -304,7 +304,10 @@ arm-resume.sh (System32-cwd trap, HIMMEL-647),
 root-equivalent docker/podman mount+privilege guard, HIMMEL-441, shipped via the
 himmel-ops plugin `hooks.json` so it's live only after `/himmel-update` + a fresh
 session; likewise `block-merged-pr-commit` — hygiene guard that blocks committing
-onto a merged-PR branch, HIMMEL-512, same plugin delivery), **1 PostToolUse hook**
+onto a merged-PR branch, HIMMEL-512, same plugin delivery; and
+`block-unresolved-cr-merge` — blocks `gh pr merge` while CodeRabbit review threads
+are unresolved or its check-run is in-flight on the head SHA, fail-open on every
+API/dep error, bypass `CR_MERGE_GATE_OK=1` — HIMMEL-936, same plugin delivery), **1 PostToolUse hook**
 (`auto-arm-on-subagent-cap` — detects cap in Agent tool results, HIMMEL-276),
 **pre-commit/commit-msg/pre-push gates** (source of truth
 `.pre-commit-config.yaml`; pre-push incl. `check-platforms-tested`;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ Autonomous end-to-end execution of a well-scoped ticket: see
 
 ## ENFORCEMENT (runs automatically)
 
-himmel enforces structurally, not by prose: **9 PreToolUse hooks**
+himmel enforces structurally, not by prose: **10 PreToolUse hooks**
 (`auto-approve-safe-bash`, `block-edit-on-main`, `block-read-secrets`,
 `block-rogue-claude-schedule` — blocks raw scheduler-arms of claude that bypass
 arm-resume.sh (System32-cwd trap, HIMMEL-647),
@@ -266,7 +266,10 @@ arm-resume.sh (System32-cwd trap, HIMMEL-647),
 root-equivalent docker/podman mount+privilege guard, HIMMEL-441, shipped via the
 himmel-ops plugin `hooks.json` so it's live only after `/himmel-update` + a fresh
 session; likewise `block-merged-pr-commit` — hygiene guard that blocks committing
-onto a merged-PR branch, HIMMEL-512, same plugin delivery), **1 PostToolUse hook**
+onto a merged-PR branch, HIMMEL-512, same plugin delivery; and
+`block-unresolved-cr-merge` — blocks `gh pr merge` while CodeRabbit review threads
+are unresolved or its check-run is in-flight on the head SHA, fail-open on every
+API/dep error, bypass `CR_MERGE_GATE_OK=1` — HIMMEL-936, same plugin delivery), **1 PostToolUse hook**
 (`auto-arm-on-subagent-cap` — detects cap in Agent tool results, HIMMEL-276),
 **pre-commit/commit-msg/pre-push gates** (source of truth
 `.pre-commit-config.yaml`; pre-push incl. `check-platforms-tested`;

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -108,13 +108,14 @@ the env var.
 
 Seven hooks wired in `.claude/settings.json` fire BEFORE Claude executes
 tool calls. Six BLOCK risky operations; one (`auto-approve-safe-bash`)
-GRANTS permission for safe ones so they don't hang. An eighth and ninth
-block hook, `block-docker-privesc.sh` (HIMMEL-441) and
-`block-merged-pr-commit.sh` (HIMMEL-512), are shipped via the **himmel-ops
-plugin `hooks.json`** rather than `.claude/settings.json` (so they can be
-agent-installed without a settings self-mod veto — same delivery path as
-`inject-minerva-critic.sh`); both are live only after `/himmel-update`
-(marketplace re-sync) + a fresh session.
+GRANTS permission for safe ones so they don't hang. An eighth, ninth, and
+tenth block hook — `block-docker-privesc.sh` (HIMMEL-441),
+`block-merged-pr-commit.sh` (HIMMEL-512), and `block-unresolved-cr-merge.sh`
+(HIMMEL-936) — are shipped via the **himmel-ops plugin `hooks.json`** rather
+than `.claude/settings.json` (so they can be agent-installed without a
+settings self-mod veto — same delivery path as `inject-minerva-critic.sh`);
+all three are live only after `/himmel-update` (marketplace re-sync) + a
+fresh session.
 
 **Bypass convention (applies to the four DENY hooks):** session-sticky
 env vars must be set in the shell that LAUNCHED Claude Code
@@ -297,6 +298,43 @@ live only after `/himmel-update` (marketplace re-sync) + a fresh session.
 
 Paired artifacts: `scripts/lib/branch-shipped.sh` (predicate),
 `scripts/hooks/test-block-merged-pr-commit.sh` (smoke suite).
+
+### `block-unresolved-cr-merge.sh` — CodeRabbit merge-remark gate (HIMMEL-936)
+
+Fires on Bash/PowerShell. Blocks a `gh pr merge` while the target PR has
+unresolved CodeRabbit review threads OR a CodeRabbit check-run still queued
+or in-progress on the head SHA — structural enforcement of the operator's
+"never merge over unresolved CodeRabbit remarks" rule (HIMMEL-195:
+structural > instructional). The signal is `cr_merge_gate <pr-selector>
+[<owner/repo>]` from `scripts/lib/cr-merge-gate.sh`, which runs a GraphQL
+`reviewThreads` query (counts unresolved threads whose first-comment author
+matches `coderabbit`, covering both `coderabbitai` and `coderabbitai[bot]`
+login forms) and a `check-runs` query on the head SHA. The same predicate is
+called from `scripts/handover/pr-merge.sh` (GitHub forge only) before its
+mergeability poll, so machines without the plugin hook still get the gate on
+that path (a block there exits `pr-merge.sh` with code 5, distinct from a
+real `gh pr merge` failure's code 4).
+
+**Fail-OPEN posture:** deny ONLY on positive evidence. Every other path
+exits 0 — `gh`/`jq` missing, `gh pr view` failure, incomplete PR metadata,
+GraphQL/check-runs API error, jq parse failure, no `gh pr merge` at command
+position, unresolvable selector. Each fail-open path emits a
+``cr-merge-gate: degraded (<why>) - failing open`` note to stderr so the
+uncertainty is visible without blocking. A repo without the CodeRabbit app
+has no `coderabbitai` threads, so the gate is inert there.
+
+**Bypass:** `CR_MERGE_GATE_OK=1` set in the shell that LAUNCHED Claude
+(same session-sticky convention as the other block-* hooks). Setting
+`CR_PROFILE=none` (the per-user CR opt-out) skips the gate entirely.
+
+**Delivery:** shipped via the **himmel-ops plugin `hooks.json`** (same
+exec-if-exists `$CLAUDE_PROJECT_DIR` pattern as `block-docker-privesc` /
+`block-merged-pr-commit`); live only after `/himmel-update` (marketplace
+re-sync) + a fresh session.
+
+Paired artifacts: `scripts/lib/cr-merge-gate.sh` (predicate),
+`scripts/lib/test-cr-merge-gate.sh` and
+`scripts/hooks/test-block-unresolved-cr-merge.sh` (smoke suites).
 
 ### `block-lesson-enforcement-writes.sh` — lesson-loop write-fence (HIMMEL-767)
 

--- a/marketplace/plugins/himmel-ops/hooks/hooks.json
+++ b/marketplace/plugins/himmel-ops/hooks/hooks.json
@@ -29,6 +29,15 @@
         ]
       },
       {
+        "matcher": "Bash|PowerShell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/block-unresolved-cr-merge.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; fi'"
+          }
+        ]
+      },
+      {
         "matcher": "Bash|PowerShell|mcp__.*",
         "hooks": [
           {

--- a/scripts/handover/pr-merge.sh
+++ b/scripts/handover/pr-merge.sh
@@ -23,6 +23,7 @@
 #   2  required tool missing
 #   3  not on a handover/* branch (refuses)
 #   4  gh pr merge failed
+#   5  blocked by the CR merge gate (unresolved CodeRabbit remarks - HIMMEL-936)
 #
 # Environment overrides:
 #   FORGE / GH_CMD / BITBUCKET_CMD   Forge-seam overrides (HIMMEL-326). The PR
@@ -118,6 +119,24 @@ fi
 if [ "$DRY_RUN" -eq 1 ]; then
     echo "DRY pr-merge: would squash-merge PR #$pr_num on $forge (delete source branch)"
     exit 0
+fi
+
+# HIMMEL-936: CR merge gate on the same predicate as the PreToolUse hook, so
+# machines without the plugin hook still get the gate on this path. Placed
+# before the mergeability poll so a CR-blocked merge fails fast (exit 5)
+# instead of burning the 5x3s poll (plan-critic #7). GitHub-only: cr_merge_gate
+# resolves via gh; the bitbucket forge skips it.
+if [ "$forge" = "github" ]; then
+    # shellcheck disable=SC1091
+    if . "$SCRIPT_DIR/../lib/cr-merge-gate.sh" 2>/dev/null; then
+        _gate_reason=""
+        _gate_rc=0
+        _gate_reason=$(cr_merge_gate "$pr_num") || _gate_rc=$?
+        if [ "$_gate_rc" = "2" ]; then
+            echo "pr-merge: CR gate: $_gate_reason" >&2
+            exit 5
+        fi
+    fi
 fi
 
 # Bounded poll for mergeability to settle before merging (HIMMEL-179 sharp#1) —

--- a/scripts/handover/test-pr-merge.sh
+++ b/scripts/handover/test-pr-merge.sh
@@ -34,6 +34,7 @@ fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1" >&2; }
 # callers can assert on --admin presence/absence.
 LAST_GH_LOG=""
 LAST_OUT=""
+LAST_ERR=""
 run_case() {
     local branch="$1" expected="$2" name="$3"; shift 3
     # Drop a leading `--` separator if present.
@@ -57,6 +58,20 @@ case "$verb" in
         echo "42"
         ;;
     "pr view")
+        # HIMMEL-936 CR-gate metadata call is `gh pr view <sel> --json
+        # number,headRefOid,url`; the mergeability poll is `gh pr view <pr>
+        # --json mergeable`. Distinguish by the requested --json fields.
+        # STUB_CR_BLOCK=1 answers the metadata call with parseable JSON so
+        # cr_merge_gate proceeds to its graphql arm; otherwise echo non-JSON
+        # so the gate degrades + fails open (existing cases stay green).
+        if printf ' %s ' "$@" | grep -q 'headRefOid'; then
+            if [ "${STUB_CR_BLOCK:-0}" = "1" ]; then
+                echo '{"number":42,"headRefOid":"abc123","url":"https://github.com/o/r/pull/42"}'
+            else
+                echo "${STUB_VIEW_MERGEABLE:-MERGEABLE}"
+            fi
+            exit 0
+        fi
         # Mergeability poll (HIMMEL-179). pr-merge calls:
         #   gh pr view <pr> --json mergeable --jq '.mergeable'
         if [ "${STUB_VIEW_FAIL:-0}" = "1" ]; then
@@ -91,6 +106,17 @@ case "$verb" in
         fi
         echo "merged"
         ;;
+    "api graphql")
+        # HIMMEL-936 CR-gate reviewThreads query: one unresolved coderabbitai
+        # thread (fixture copied from test-cr-merge-gate.sh).
+        echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}'
+        ;;
+    "api repos"*)
+        # HIMMEL-936 CR-gate check-runs query: completed CodeRabbit check-run.
+        # Not reached when the threads arm already blocks, but stubbed for
+        # completeness / the in-flight arm.
+        echo '{"check_runs":[{"name":"CodeRabbit","status":"completed","conclusion":"success"}]}'
+        ;;
     *) ;;
 esac
 STUB
@@ -123,6 +149,7 @@ STUB
     cp "$tmp/err" "$keep/err" 2>/dev/null
     LAST_GH_LOG="$keep/gh.log"
     LAST_OUT="$keep/out"
+    LAST_ERR="$keep/err"
     if [ "$rc" -ne "$expected" ]; then
         fail "$name: expected exit $expected, got $rc (err: $(cat "$keep/err"))"
         rm -rf "$tmp"
@@ -146,6 +173,9 @@ assert_out_has() {
 }
 assert_out_lacks() {
     if grep -qF -- "$1" "$LAST_OUT"; then fail "$2 (out: $(cat "$LAST_OUT"))"; else pass; fi
+}
+assert_err_has() {
+    if grep -qF -- "$1" "$LAST_ERR"; then pass; else fail "$2 (err: $(cat "$LAST_ERR"))"; fi
 }
 
 echo "test-pr-merge.sh"
@@ -228,6 +258,19 @@ fi
 if STUB_VIEW_FAIL=1 \
     run_case "handover/x-slug" 0 "poll: gh pr view failure falls through to merge"; then
     assert_log_has "pr merge 42 --squash" "view failure still attempts merge"
+fi
+
+# --- HIMMEL-936: CR merge gate blocks before the poll (exit 5) ---
+# STUB_CR_BLOCK=1 arms the gate's pr-view metadata arm + the graphql arm so
+# cr_merge_gate positively confirms an unresolved coderabbitai thread. The
+# gate runs BEFORE the mergeability poll, so neither the poll's pr view nor
+# `gh pr merge` is reached. Existing cases above stay green by design: their
+# stub returns non-JSON for the gate's pr-view (headRefOid branch, STUB_CR_BLOCK
+# unset), so cr_merge_gate degrades and fails open (plan-critic #4).
+if STUB_CR_BLOCK=1 \
+    run_case "handover/x-slug" 5 "CR-gate block exits 5 before poll"; then
+    assert_log_lacks "pr merge" "CR-gate block does not attempt merge"
+    assert_err_has    "CR gate" "CR-gate block reports CR gate on stderr"
 fi
 
 # --- summary ---

--- a/scripts/hooks/block-unresolved-cr-merge.sh
+++ b/scripts/hooks/block-unresolved-cr-merge.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block-unresolved-cr-merge.sh
+#
+# Blocks `gh pr merge` while the PR has unresolved CodeRabbit review threads
+# or a CodeRabbit check-run still running on the head SHA (HIMMEL-936;
+# operator rule 2026-07-11: never merge over unresolved CodeRabbit remarks).
+# Sibling of check-cr-marker-on-pr-create.sh / block-merged-pr-commit.sh.
+#
+# Exit: 0 allow (incl. every fail-open path), 2 block (stderr shown to model).
+# Bypass: CR_MERGE_GATE_OK=1 in the LAUNCHING shell. CR_PROFILE=none skips.
+set -uo pipefail
+# NOT set -e: fail-open hook, must never abort on a sub-call's rc 1.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+[ "${CR_MERGE_GATE_OK:-0}" = "1" ] && exit 0
+[ "${CR_PROFILE:-}" = "none" ] && exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0   # cannot parse stdin: fail open
+
+payload=$(cat) || exit 0
+
+# Fast path: skip the jq spawn unless the raw payload could contain a merge.
+# Deliberately LOOSE (`merge` anywhere, not the exact phrase): a double-spaced
+# `gh  pr  merge` must NOT dodge the gate via the fast path (plan-critic #2);
+# non-merge commands mentioning "merge" fall through to the cheap regex below.
+case "$payload" in
+    *merge*) ;;
+    *) exit 0 ;;
+esac
+
+cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+[ -z "$cmd" ] && exit 0
+
+# Quote-blindness guard (coderabbit CR round): match + tokenize on a copy with
+# each QUOTED SPAN replaced by the placeholder token Q - text inside quotes can
+# neither look like a command boundary (`git commit -m "done; gh pr merge 42"`
+# is NOT a merge - false-block vector) nor smuggle a quoted selector, while
+# token POSITIONS survive so value-taking flags (`--repo "o/r" 42`) still
+# consume exactly one token (coderabbit app round: full deletion collapsed
+# positions and let --repo eat the selector). An unbalanced quote leaves
+# residue whose worst case is a mis-extracted selector -> rc=3 re-anchor ->
+# fail-open, never a false block on quoted text.
+cmd_stripped=$(printf '%s' "$cmd" | sed -e "s/'[^']*'/Q/g" -e 's/"[^"]*"/Q/g')
+
+# Command-position anchor (POSIX classes - BSD grep lacks \s/\b; coderabbit
+# app round). `merge` must be followed by whitespace or end-of-string.
+# shellcheck disable=SC2016  # literal backtick/$( in the class - intentional
+if ! printf '%s' "$cmd_stripped" | grep -qE '(^|[;&|`$(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'; then
+    exit 0
+fi
+
+# Isolate the SEGMENT containing `gh pr merge` before tokenizing. A whole-
+# command token walk trips on earlier `merge` words: `git merge main && gh pr
+# merge 42` would take "main" as the selector (plan-critic #1). Split on
+# ; && || and newlines (NOT |) with bash-native expansion - BSD sed leaves
+# \n LITERAL in replacements, which silently broke this split on macOS
+# (coderabbit app round) - then pick the first matching segment.
+merge_segment=""
+normalised=${cmd_stripped//&&/$'\n'}
+normalised=${normalised//||/$'\n'}
+normalised=${normalised//;/$'\n'}
+while IFS= read -r segment || [ -n "$segment" ]; do
+    # shellcheck disable=SC2016  # literal backtick/$( in the class - intentional
+    if printf '%s' "$segment" | grep -qE '(^|[`$(])[[:space:]]*gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'; then
+        merge_segment="$segment"
+        break
+    fi
+done <<EOF
+$normalised
+EOF
+[ -z "$merge_segment" ] && exit 0
+
+# Extract the selector + --repo from the merge segment only;
+# selector = first non-flag token after the `merge` verb.
+sel=""; repo=""
+set -f
+# shellcheck disable=SC2086
+set -- $merge_segment
+set +f
+seen_merge=0
+while [ "$#" -gt 0 ]; do
+    if [ "$seen_merge" = "0" ]; then
+        [ "$1" = "merge" ] && seen_merge=1
+        shift; continue
+    fi
+    case "$1" in
+        --repo=*) repo="${1#--repo=}" ;;
+        --repo|-R) if [ "$#" -ge 2 ]; then repo="$2"; shift; fi ;;
+        # gh pr merge's own value-taking flags: consume the value token so it
+        # is never mistaken for the selector (coderabbit CR round; the rc=3
+        # re-anchor still backstops flags this list misses).
+        -b|--body|-F|--body-file|-t|--subject|--match-head-commit|-A|--author-email)
+            if [ "$#" -ge 2 ]; then shift; fi ;;
+        --*|-*) ;;             # other flags: ignore (an unknown value-taking
+                               # flag may feed a value token; a wrong selector
+                               # only fails gh pr view = rc 3 -> re-anchor,
+                               # never a false block)
+        *) [ -z "$sel" ] && sel="$1" ;;
+    esac
+    shift
+done
+
+# Strip surrounding quotes the tokenizer preserved: `gh pr merge "42"` must
+# not hand the literal `"42"` to gh (codex-adv-1 — quoted selector dodged the
+# gate via the pr-view fail-open).
+sel="${sel#\"}"; sel="${sel%\"}"; sel="${sel#\'}"; sel="${sel%\'}"
+repo="${repo#\"}"; repo="${repo%\"}"; repo="${repo#\'}"; repo="${repo%\'}"
+
+# The cwd branch — fallback anchor when no/bad selector was extracted.
+cwd_branch=""
+cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)
+if [ -n "$cwd" ] && command -v git >/dev/null 2>&1; then
+    cwd_branch=$(git -C "$cwd" branch --show-current 2>/dev/null || true)
+fi
+
+# No explicit selector: gh infers the current branch; do the same.
+[ -z "$sel" ] && sel="$cwd_branch"
+[ -z "$sel" ] && exit 0   # cannot resolve target: fail open
+
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/cr-merge-gate.sh" 2>/dev/null || exit 0
+
+reason=""
+rc=0
+reason=$(cr_merge_gate "$sel" "$repo") || rc=$?
+if [ "$rc" = "3" ] && [ -n "$cwd_branch" ]; then
+    # The extracted token did not resolve to a PR (a value-taking flag's
+    # argument or leftover quoting mistaken for the selector — codex-1).
+    # Re-anchor to the cwd branch IN THE CWD REPO (drop the extracted repo:
+    # it may itself be a quote placeholder — coderabbit app round) so
+    # ordinary CLI syntax cannot dodge the gate; if this ALSO fails to
+    # resolve, the gate stays fail-open. Guard against re-running the
+    # identical lookup (same branch, no repo override).
+    if [ "$cwd_branch" != "$sel" ] || [ -n "$repo" ]; then
+        rc=0
+        reason=$(cr_merge_gate "$cwd_branch" "") || rc=$?
+    fi
+fi
+if [ "$rc" = "2" ]; then
+    echo "block-unresolved-cr-merge: $reason" >&2
+    exit 2
+fi
+exit 0

--- a/scripts/hooks/test-block-unresolved-cr-merge.sh
+++ b/scripts/hooks/test-block-unresolved-cr-merge.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Tests for scripts/hooks/block-unresolved-cr-merge.sh (HIMMEL-936). Hermetic.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/block-unresolved-cr-merge.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export HOME="$TMP/home"; mkdir -p "$HOME"
+
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$*" >> "${GH_STUB_LOG:?}"
+case "${GH_STUB_MODE:?}" in
+  error) exit 1 ;;
+esac
+case "$1 $2" in
+  "pr view")
+    # deadbeef simulates a mis-extracted selector (a value-taking flag's
+    # argument) that resolves to no PR - drives the rc=3 re-anchor path.
+    [ "${3:-}" = "deadbeef" ] && exit 1
+    echo '{"number":42,"headRefOid":"abc123","url":"https://github.com/o/r/pull/42"}' ;;
+  "api graphql")
+    case "$GH_STUB_MODE" in
+      unresolved) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
+      other-author) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"someuser"}}]}}]}}}}}' ;;
+      *) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
+    esac ;;
+  "api repos/o/r/commits/abc123/check-runs"*)
+    case "$GH_STUB_MODE" in
+      inflight) echo '{"check_runs":[{"name":"CodeRabbit","status":"in_progress","conclusion":null}]}' ;;
+      *)        echo '{"check_runs":[{"name":"CodeRabbit","status":"completed","conclusion":"success"}]}' ;;
+    esac ;;
+  *) echo '{}' ;;
+esac
+EOF
+chmod +x "$TMP/bin/gh"
+export PATH="$TMP/bin:$PATH"
+
+# The hook's rc=3 re-anchor resolves the cwd branch - make TMP a repo with a
+# named branch so `git -C "$TMP" branch --show-current` yields `trunk`.
+git init -q -b trunk "$TMP" 2>/dev/null || git init -q "$TMP"
+
+payload() { # payload <tool_name> <command>
+  printf '{"tool_name":"%s","tool_input":{"command":"%s"},"cwd":"%s"}' "$1" "$2" "$TMP"
+}
+
+pass=0; fail=0
+t() { # t <name> <expected-rc> <tool> <command>
+  local name="$1" want="$2" tool="$3" cmd="$4" rc=0
+  export GH_STUB_LOG="$TMP/calls-$name.log"; : > "$GH_STUB_LOG"
+  payload "$tool" "$cmd" | bash "$HOOK" >"$TMP/out-$name" 2>"$TMP/err-$name" || rc=$?
+  if [ "$rc" = "$want" ]; then pass=$((pass+1)); echo "ok   $name"
+  else fail=$((fail+1)); echo "FAIL $name (rc=$rc want=$want)"; sed 's/^/  err: /' "$TMP/err-$name"; fi
+}
+
+GH_STUB_MODE=unresolved t merge-with-unresolved-blocks   2 Bash "gh pr merge 42 --squash"
+GH_STUB_MODE=clean      t merge-clean-allows             0 Bash "gh pr merge 42 --squash"
+GH_STUB_MODE=error      t api-error-fails-open           0 Bash "gh pr merge 42 --squash"
+GH_STUB_MODE=inflight   t inflight-review-blocks         2 Bash "gh pr merge 42 --squash"
+GH_STUB_MODE=unresolved t non-merge-passthrough          0 Bash "gh pr view 42"
+GH_STUB_MODE=unresolved t string-literal-passthrough     0 Bash "echo \\\"gh pr merge 42\\\""
+GH_STUB_MODE=unresolved t powershell-payload-blocks      2 PowerShell "gh pr merge 42 --squash"
+GH_STUB_MODE=unresolved t merge-with-repo-flag-blocks    2 Bash "gh pr merge 42 --squash --repo o/r"
+GH_STUB_MODE=unresolved t compound-earlier-merge-blocks  2 Bash "git merge main && gh pr merge 42 --squash"
+GH_STUB_MODE=unresolved t double-space-merge-blocks      2 Bash "gh  pr  merge 42 --squash"
+# codex-adv-1: quoted selector must not dodge the gate (quoted span vanishes,
+# gate re-anchors to the cwd branch)
+GH_STUB_MODE=unresolved t quoted-selector-blocks         2 Bash "gh pr merge \\\"42\\\" --squash"
+# codex-1/coderabbit: a value-taking flag's argument is consumed, the real
+# selector still gates
+GH_STUB_MODE=unresolved t flag-value-selector-reanchors  2 Bash "gh pr merge --match-head-commit deadbeef 42 --squash"
+# coderabbit false-block vector: a merge phrase INSIDE quotes is not a merge
+GH_STUB_MODE=unresolved t quoted-merge-text-passthrough  0 Bash "git commit -m \\\"done; gh pr merge 42\\\""
+# coderabbit app round: quoted --repo value must not eat the selector (token
+# positions preserved by the Q placeholder; bogus repo re-anchors repo-less)
+GH_STUB_MODE=unresolved t quoted-repo-value-blocks       2 Bash "gh pr merge --repo \\\"o/r\\\" 42 --squash"
+GH_STUB_MODE=unresolved CR_MERGE_GATE_OK=1 t bypass-allows 0 Bash "gh pr merge 42 --squash"
+unset CR_MERGE_GATE_OK
+GH_STUB_MODE=unresolved CR_PROFILE=none t profile-none-allows 0 Bash "gh pr merge 42 --squash"
+unset CR_PROFILE
+
+# passthrough cases must not touch gh at all (coderabbit: assert EVERY one)
+for pt in non-merge-passthrough string-literal-passthrough quoted-merge-text-passthrough; do
+    [ -s "$TMP/calls-$pt.log" ] && { echo "FAIL $pt called gh"; fail=$((fail+1)); }
+done
+# block reason surfaces on stderr (hook contract: stderr shown to model+user)
+grep -qi "unresolved" "$TMP/err-merge-with-unresolved-blocks" || { echo "FAIL stderr reason missing"; fail=$((fail+1)); }
+
+echo "pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/lib/cr-merge-gate.sh
+++ b/scripts/lib/cr-merge-gate.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# cr-merge-gate.sh — shared predicate for the HIMMEL-936 CR merge gate.
+#
+# cr_merge_gate <pr-selector> [<owner/repo>]
+#   rc 0 = allow; rc 2 = block, one-line reason on stdout.
+#   rc 3 = allow, but the SELECTOR did not resolve to a PR (gh pr view failed)
+#          — callers that extracted the selector heuristically (the PreToolUse
+#          hook) should retry once with a better-anchored selector (the cwd
+#          branch) so quoted/mis-tokenized selectors cannot dodge the gate
+#          (codex-1 / codex-adv-1, HIMMEL-936 CR round). Top-level consumers
+#          treat any non-2 rc as allow.
+#   Deny ONLY on positive evidence:
+#     - an unresolved PR review thread whose first comment is by coderabbitai
+#     - a CodeRabbit check-run on the head SHA still queued/in_progress
+#   EVERYTHING else (gh missing, API error, no PR, parse failure) fails OPEN
+#   (rc 0/3) with a "cr-merge-gate: degraded (...) - failing open" stderr note.
+#   CR_MERGE_GATE_OK=1 or CR_PROFILE=none skip the gate entirely (rc 0).
+#
+# Sourceable from hooks and scripts: uses only `return`, never `exit`;
+# does not toggle set -e. bash 3.2-safe. Each `jq` command substitution is
+# made set -e-safe with a trailing `|| true` inside the subshell so that a
+# caller running `set -e` (pr-merge.sh) does not abort on a jq parse failure
+# (a parse failure is a normal fail-open input here, not a hard error).
+# HIMMEL-936.
+
+_cmg_degrade() { echo "cr-merge-gate: degraded ($*) - failing open" >&2; }
+
+cr_merge_gate() {
+    [ "${CR_MERGE_GATE_OK:-0}" = "1" ] && return 0
+    [ "${CR_PROFILE:-}" = "none" ] && return 0
+
+    local sel="${1:-}" repo="${2:-}"
+    if [ -z "$sel" ]; then _cmg_degrade "no PR selector"; return 0; fi
+    command -v gh >/dev/null 2>&1 || { _cmg_degrade "gh not on PATH"; return 0; }
+    command -v jq >/dev/null 2>&1 || { _cmg_degrade "jq not on PATH"; return 0; }
+
+    local meta url num head owner name
+    if [ -n "$repo" ]; then
+        meta=$(gh pr view "$sel" --repo "$repo" --json number,headRefOid,url 2>/dev/null) || { _cmg_degrade "gh pr view failed (selector '$sel' unresolvable)"; return 3; }
+    else
+        meta=$(gh pr view "$sel" --json number,headRefOid,url 2>/dev/null) || { _cmg_degrade "gh pr view failed (selector '$sel' unresolvable)"; return 3; }
+    fi
+    num=$(printf '%s' "$meta" | jq -r '.number // empty' 2>/dev/null || true)
+    head=$(printf '%s' "$meta" | jq -r '.headRefOid // empty' 2>/dev/null || true)
+    url=$(printf '%s' "$meta" | jq -r '.url // empty' 2>/dev/null || true)
+    if [ -z "$num" ] || [ -z "$head" ] || [ -z "$url" ]; then _cmg_degrade "pr metadata incomplete"; return 0; fi
+    # url shape: https://github.com/OWNER/NAME/pull/N
+    owner=$(printf '%s' "$url" | sed -n 's|^https://[^/]*/\([^/]*\)/.*|\1|p')
+    name=$(printf '%s' "$url"  | sed -n 's|^https://[^/]*/[^/]*/\([^/]*\)/.*|\1|p')
+    if [ -z "$owner" ] || [ -z "$name" ]; then _cmg_degrade "cannot parse owner/name from $url"; return 0; fi
+
+    # 1) unresolved coderabbitai review threads
+    local threads unresolved
+    # shellcheck disable=SC2016  # GraphQL variables ($owner/$name/$number) are literal here
+    threads=$(gh api graphql \
+        -f owner="$owner" -f name="$name" -F number="$num" \
+        -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved path line comments(first:1){nodes{author{login}}}}}}}}' \
+        2>/dev/null) || { _cmg_degrade "reviewThreads query failed"; return 0; }
+    unresolved=$(printf '%s' "$threads" | jq -r \
+        '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved==false) | select((.comments.nodes[0].author.login // "") | test("coderabbit"; "i"))] | length' \
+        2>/dev/null || true)
+    if [ -z "$unresolved" ]; then _cmg_degrade "reviewThreads parse failed"; return 0; fi
+    if [ "$unresolved" -gt 0 ] 2>/dev/null; then
+        # List the offending threads (path:line) so the block is actionable and
+        # the bypass is front-and-center (false-block trust erosion mitigation,
+        # plan-critic #5).
+        local locs
+        locs=$(printf '%s' "$threads" | jq -r \
+            '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved==false) | select((.comments.nodes[0].author.login // "") | test("coderabbit"; "i")) | "\(.path // "?"):\(.line // "?")"] | join(", ")' \
+            2>/dev/null || true)
+        echo "BLOCK: $unresolved unresolved CodeRabbit review thread(s) on PR #$num [$locs]. Fix + RESOLVE each thread (operator rule 2026-07-12), or bypass with CR_MERGE_GATE_OK=1 in the launching shell if already adjudicated."
+        return 2
+    fi
+
+    # 2) CodeRabbit check-run still running on the head SHA
+    local runs pending
+    runs=$(gh api "repos/$owner/$name/commits/$head/check-runs?per_page=100" 2>/dev/null) || { _cmg_degrade "check-runs query failed"; return 0; }
+    pending=$(printf '%s' "$runs" | jq -r \
+        '[.check_runs[]? | select(.name=="CodeRabbit") | select(.status!="completed")] | length' \
+        2>/dev/null || true)
+    if [ -z "$pending" ]; then _cmg_degrade "check-runs parse failed"; return 0; fi
+    if [ "$pending" -gt 0 ] 2>/dev/null; then
+        echo "BLOCK: CodeRabbit is still reviewing head $head of PR #$num (check-run not completed). Wait for it, then re-check threads. Bypass: CR_MERGE_GATE_OK=1."
+        return 2
+    fi
+
+    return 0
+}

--- a/scripts/lib/test-cr-merge-gate.sh
+++ b/scripts/lib/test-cr-merge-gate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Tests for scripts/lib/cr-merge-gate.sh (HIMMEL-936). Hermetic: gh is stubbed.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export HOME="$TMP/home"; mkdir -p "$HOME"
+
+# ── stub gh ──────────────────────────────────────────────────────────────────
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$*" >> "${GH_STUB_LOG:?}"
+case "${GH_STUB_MODE:?}" in
+  error) exit 1 ;;
+esac
+case "$1 $2" in
+  "pr view")
+    # api-error mode: pr view SUCCEEDS, later api calls fail (distinguishes
+    # rc=3 selector-unresolvable from rc=0 downstream-API fail-open).
+    echo '{"number":42,"headRefOid":"abc123","url":"https://github.com/o/r/pull/42"}' ;;
+  "api graphql")
+    case "$GH_STUB_MODE" in
+      api-error) exit 1 ;;
+      unresolved) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
+      other-author) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"someuser"}}]}}]}}}}}' ;;
+      *) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
+    esac ;;
+  "api repos/o/r/commits/abc123/check-runs"*)
+    case "$GH_STUB_MODE" in
+      inflight) echo '{"check_runs":[{"name":"CodeRabbit","status":"in_progress","conclusion":null}]}' ;;
+      *)        echo '{"check_runs":[{"name":"CodeRabbit","status":"completed","conclusion":"success"}]}' ;;
+    esac ;;
+  *) echo '{}' ;;
+esac
+EOF
+chmod +x "$TMP/bin/gh"
+export PATH="$TMP/bin:$PATH"
+
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/cr-merge-gate.sh"
+
+pass=0; fail=0
+t() { # t <name> <expected-rc> — runs cr_merge_gate 42 o/r with current env
+  local name="$1" want="$2" rc=0
+  export GH_STUB_LOG="$TMP/calls-$name.log"; : > "$GH_STUB_LOG"
+  cr_merge_gate 42 o/r >"$TMP/out-$name" 2>"$TMP/err-$name" || rc=$?
+  if [ "$rc" = "$want" ]; then pass=$((pass+1)); echo "ok   $name"
+  else fail=$((fail+1)); echo "FAIL $name (rc=$rc want=$want)"; sed 's/^/  err: /' "$TMP/err-$name"; fi
+}
+
+GH_STUB_MODE=unresolved   t unresolved-cr-thread-blocks 2
+GH_STUB_MODE=clean        t resolved-threads-allow 0
+GH_STUB_MODE=other-author t other-author-unresolved-allows 0
+GH_STUB_MODE=inflight     t checkrun-in-flight-blocks 2
+# pr view itself fails -> rc=3 (selector unresolvable; still an allow, but
+# lets the hook retry with a better anchor - codex-1/codex-adv-1 CR round)
+GH_STUB_MODE=error        t gh-error-selector-unresolvable 3
+# pr view succeeds, downstream graphql fails -> plain rc=0 fail-open
+GH_STUB_MODE=api-error    t downstream-api-error-fails-open 0
+
+# bypass env short-circuits BEFORE any gh call
+GH_STUB_MODE=unresolved CR_MERGE_GATE_OK=1 t bypass-env-allows 0
+[ -s "$TMP/calls-bypass-env-allows.log" ] && { echo "FAIL bypass called gh"; fail=$((fail+1)); }
+unset CR_MERGE_GATE_OK
+
+GH_STUB_MODE=unresolved CR_PROFILE=none t cr-profile-none-allows 0
+[ -s "$TMP/calls-cr-profile-none-allows.log" ] && { echo "FAIL profile-none called gh"; fail=$((fail+1)); }
+unset CR_PROFILE
+
+# block reason lands on stdout
+grep -qi "unresolved" "$TMP/out-unresolved-cr-thread-blocks" || { echo "FAIL block reason missing"; fail=$((fail+1)); }
+# degradation notes land on stderr on both fail-open shapes
+grep -qi "degraded" "$TMP/err-gh-error-selector-unresolvable" || { echo "FAIL degradation note missing (rc3)"; fail=$((fail+1)); }
+grep -qi "degraded" "$TMP/err-downstream-api-error-fails-open" || { echo "FAIL degradation note missing (rc0)"; fail=$((fail+1)); }
+
+echo "pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Public mirror of private PR #1154 (squash `bc21118c`), HIMMEL-936.

Structural merge gate: `gh pr merge` is blocked while the PR carries unresolved CodeRabbit review threads or an in-flight CodeRabbit check-run on the head SHA — deny only on positive evidence, fail-open on every API/dep error, bypass `CR_MERGE_GATE_OK=1`, skip via `CR_PROFILE=none`. Delivered as a PreToolUse hook via the himmel-ops plugin plus the same predicate inside `scripts/handover/pr-merge.sh` (exit 5).

Hardened through 3 CR rounds on private (paid codex panel, codex adversarial, CodeRabbit CLI + app): selector-bypass vectors closed (quoted selectors, value-taking flag arity, rc=3 re-anchor to the cwd branch), quoted-text false-block vector closed (Q-placeholder span stripping), BSD-portable splitting and POSIX regex classes.

Verification: hermetic suites — lib 8/8, hook 16/16, pr-merge 35/35; shellcheck clean; CodeRabbit check-run green + zero unresolved threads at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a merge safety gate that prevents GitHub pull requests from being merged while CodeRabbit review threads remain unresolved or CodeRabbit checks are still running.
  * Added clear blocking messages and support for documented bypass options.
  * Merge automation now stops immediately when the gate blocks a merge.

* **Documentation**
  * Updated enforcement and hook documentation to describe the new merge protection.

* **Tests**
  * Added coverage for blocked merges, bypasses, API failures, check-run states, and command parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->