### PR TITLE
docs(himmelctl): lead adopter docs with himmelctl; collapse adopt.sh flag-matrix mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,14 @@ shell-and-package install (Linux / macOS / Windows Git Bash).
 ```bash
 git clone https://github.com/yotamleo/Himmel
 cd himmel
-
-# Linux / macOS / Git Bash
-bash scripts/setup.sh
-
-# Windows PowerShell
-powershell -File scripts\setup.ps1
+node scripts/himmelctl/bin.js install
 ```
+
+Node-less machine? Bootstrap first: `bash scripts/himmelctl/bootstrap.sh`
+(Windows: `powershell -ExecutionPolicy Bypass -File scripts\himmelctl\bootstrap.ps1`), then re-run
+`install`. Under the hood the wizard runs `scripts/setup.sh` /
+`scripts\setup.ps1` for this standalone path — invoke those directly for the
+manual or CI path.
 
 Minimum environment (set in the shell that launches Claude or your daily
 work shell):
@@ -228,10 +229,13 @@ per-platform shell setup — lives at
 [`docs/setup/new-machine.md`](docs/setup/new-machine.md).
 
 Adopting himmel in your own repo (or user scope) is one command —
+`node scripts/himmelctl/bin.js install` walks you through it
+interactively. Under the hood it runs
 `bash scripts/adopt.sh --profile core --scope project --target /path/to/repo`
-brings the harness (hooks + guardrails + worktree commands + marketplace
-plugins/skills) over in one shot. Profiles, scopes, the Windows `adopt.ps1`
-twin, and the à-la-carte parts:
+(brings the harness — hooks + guardrails + worktree commands + marketplace
+plugins/skills — over in one shot); invoke that directly for the manual or
+CI path. Full profile/scope matrix, the Windows `adopt.ps1` twin, and the
+à-la-carte parts:
 [`docs/setup/use-on-your-project.md`](docs/setup/use-on-your-project.md).
 
 Claude Code global config (`~/.claude/`) setup: see

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -227,7 +227,7 @@ guard is yours to lift:
 | Adopt the core in another repo | [setup/use-on-your-project.md](setup/use-on-your-project.md) |
 | Full machine setup + gotchas | [setup/new-machine.md](setup/new-machine.md) |
 | Update the harness + upgrade the vault | [setup/updating.md](setup/updating.md) |
-| Uninstall / offboard himmel | `node scripts/himmelctl/bin.js uninstall` (execs [`scripts/uninstall.sh`](../scripts/uninstall.sh); see [updating.md](setup/updating.md#uninstalling--offboarding)) |
+| Uninstall / offboard himmel | `node himmel/scripts/himmelctl/bin.js uninstall` (run beside your himmel clone, same as install; execs [`scripts/uninstall.sh`](../scripts/uninstall.sh); see [updating.md](setup/updating.md#uninstalling--offboarding)) |
 
 Working as an LLM in this repo? Start from [`llms.txt`](../llms.txt) — the
 machine-readable map.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,57 +29,33 @@ into a repo you already have, in one command. The full adopter guide is
 > hacking on the harness — is a different path. It's not covered here; see
 > [setup/new-machine.md](setup/new-machine.md#4-himmel-repo).
 
-**Prerequisites** (the adopt script checks them and fails fast with hints):
-`git`, `bash` 3.2+ (**Git Bash** on Windows), `jq`, `python3`, and the
+**Prerequisites** (the wizard checks them and fails fast with hints):
+`git`, `bash` 3.2+ (**Git Bash** on Windows), `node` (node-less machine? the
+bootstrap step below installs it), `jq`, `python3`, and the
 [Claude Code](https://claude.com/claude-code) CLI on your `PATH`. `gh` is
 optional — only the worktree-prune step uses it.
 
-Clone once, then run the one-shot adopt for the profile you want:
+Clone once, then run the install wizard:
 
 ```bash
 git clone https://github.com/yotamleo/himmel
+node himmel/scripts/himmelctl/bin.js install
 ```
 
-**`core`** — the harness (hooks + guardrails + worktree commands + marketplace
-plugins/skills) wired into your repo. *Most people start here.*
+Node-less machine? `bash himmel/scripts/himmelctl/bootstrap.sh` first
+(Windows: `pwsh -ExecutionPolicy Bypass -File himmel\scripts\himmelctl\bootstrap.ps1`),
+then re-run `install`. The wizard asks a few questions (role, scope, vault,
+handover, plugins) and derives the `adopt.sh`/`adopt.ps1` invocation under the
+hood — for example, the most common outcome, `--profile core` at project scope:
 
 ```bash
 bash himmel/scripts/adopt.sh --profile core --scope project --target /path/to/your/repo
-# Windows:  pwsh himmel\scripts\adopt.ps1 -Profile core -Scope project -Target C:\path\to\repo
+# Windows:  pwsh -ExecutionPolicy Bypass -File himmel\scripts\adopt.ps1 -Profile core -Scope project -Target C:\path\to\repo
 ```
 
-**`luna`** — the luna second-brain vault scaffold only (no harness). `--target`
-is the vault directory.
-
-```bash
-bash himmel/scripts/adopt.sh --profile luna --target ~/Documents/luna
-# Windows:  pwsh himmel\scripts\adopt.ps1 -Profile luna -Target $HOME\Documents\luna
-```
-
-**`all`** — `core` + `luna`. The harness lands in `--target`; the vault in
-`--luna-target` (default `~/Documents/luna`).
-
-```bash
-bash himmel/scripts/adopt.sh --profile all --scope project --target /path/to/your/repo --luna-target ~/Documents/luna
-# Windows:  pwsh himmel\scripts\adopt.ps1 -Profile all -Scope project -Target C:\path\to\repo -LunaTarget $HOME\Documents\luna
-```
-
-**User scope** — enable himmel for *you* in every project on this machine
-(wires `~/.claude/settings.json` to reference this clone; nothing is copied
-per-repo). Copy-paste:
-
-```bash
-# core only:
-bash himmel/scripts/adopt.sh --profile core --scope user
-# core + luna vault (vault defaults to ~/Documents/luna):
-bash himmel/scripts/adopt.sh --profile all --scope user --luna-target ~/Documents/luna
-# Windows:  pwsh himmel\scripts\adopt.ps1 -Profile all -Scope user -LunaTarget $HOME\Documents\luna
-```
-
-`--scope project` wires it into your repo (commit the result and anyone who
-clones it gets it); `--scope user` enables it for you in every project on this
-machine. Remove/move and the à-la-carte parts are in
-[use-on-your-project.md](setup/use-on-your-project.md).
+Invoke `adopt.sh`/`adopt.ps1` directly for the manual or CI path. Full
+profile/scope matrix (`luna`, `all`, user scope) and the à-la-carte parts:
+[docs/setup/use-on-your-project.md](setup/use-on-your-project.md).
 
 When the Claude Code plugins (handover, triage, obsidian, …) get
 installed you choose where they're recorded: **user scope** (`~/.claude`, every
@@ -251,7 +227,7 @@ guard is yours to lift:
 | Adopt the core in another repo | [setup/use-on-your-project.md](setup/use-on-your-project.md) |
 | Full machine setup + gotchas | [setup/new-machine.md](setup/new-machine.md) |
 | Update the harness + upgrade the vault | [setup/updating.md](setup/updating.md) |
-| Uninstall / offboard himmel | [`scripts/uninstall.sh`](../scripts/uninstall.sh) (see [updating.md](setup/updating.md#uninstalling--offboarding)) |
+| Uninstall / offboard himmel | `node scripts/himmelctl/bin.js uninstall` (execs [`scripts/uninstall.sh`](../scripts/uninstall.sh); see [updating.md](setup/updating.md#uninstalling--offboarding)) |
 
 Working as an LLM in this repo? Start from [`llms.txt`](../llms.txt) — the
 machine-readable map.

--- a/docs/setup/updating.md
+++ b/docs/setup/updating.md
@@ -107,15 +107,24 @@ Plain `git pull` works too if you don't need the marketplace re-sync.
 
 ## Uninstalling / offboarding
 
-The inverse of setup is [`scripts/uninstall.sh`](../../scripts/uninstall.sh)
-(`scripts\uninstall.ps1` on Windows) — a symmetric six-step teardown of what
-`setup.sh`/`adopt` onboard: stops the Telegram bridge, removes its pairing +
-bridge state, deletes the `HIMMEL-Resume-*` scheduled jobs, uninstalls the
-Claude plugins + marketplaces, uninstalls the repo's git hooks, and unwires the
-user-scope `~/.claude/settings.json` keys himmel added. It is destructive and
-fail-closed (a non-interactive run aborts without `--yes`); preview any run with
-`--dry-run`, and skip individual steps with `--skip-plugins` / `--skip-hooks` /
-`--skip-tasks` / `--skip-settings`.
+The inverse of install is the wizard's `uninstall` subcommand:
+
+```bash
+node scripts/himmelctl/bin.js uninstall --dry-run    # preview; nothing is executed
+node scripts/himmelctl/bin.js uninstall              # actually offboard
+```
+
+Under the hood it derives + confirms, then execs
+[`scripts/uninstall.sh`](../../scripts/uninstall.sh) (`scripts\uninstall.ps1`
+on Windows) — a symmetric six-step teardown of what `setup.sh`/`adopt` onboard:
+stops the Telegram bridge, removes its pairing + bridge state, deletes the
+`HIMMEL-Resume-*` scheduled jobs, uninstalls the Claude plugins + marketplaces,
+uninstalls the repo's git hooks, and unwires the user-scope
+`~/.claude/settings.json` keys himmel added. It is destructive and fail-closed
+(a non-interactive run aborts without `--yes`). Invoke `uninstall.sh` directly
+for the manual or CI path — preview any run with `--dry-run`, and skip
+individual steps with `--skip-plugins` / `--skip-hooks` / `--skip-tasks` /
+`--skip-settings`:
 
 ```bash
 bash scripts/uninstall.sh --dry-run    # preview; nothing is executed

--- a/docs/setup/vms.md
+++ b/docs/setup/vms.md
@@ -2,6 +2,8 @@
 
 Local VMs for testing and automation. Credentials stored in `.env` — see `.env.example` for variable names.
 
+Adopters install himmel via the `himmelctl` wizard (`node scripts/himmelctl/bin.js install`); the VM docs below keep referencing the underlying scripts directly, since VM provisioning is a different (test-harness) path.
+
 To provision a fresh Ubuntu VM run: `python scripts/machine-setup/ubuntu-vm-setup.py`
 
 ## Dependency split — test-harness vs user-runtime (HIMMEL-469)

--- a/docs/setup/windows-clean-machine.md
+++ b/docs/setup/windows-clean-machine.md
@@ -108,6 +108,15 @@ credential helper without it.
 
 ## Phase 3 — himmel + machine setup
 
+> **Just installing himmel for adopter use, not the full dev + lane-fleet
+> setup below?** Clone first, then use the wizard instead:
+> `git clone https://github.com/yotamleo/himmel && cd himmel`, then
+> `powershell -ExecutionPolicy Bypass -File scripts\himmelctl\bootstrap.ps1`
+> (winget-installs node if missing, then hands off to `himmelctl install`).
+> The rest of this phase runs `win11.ps1`, the machine-provisioner script this
+> remote clean-machine walkthrough uses for the full toolchain + lane-fleet +
+> luna setup — it remains in place, not superseded by the wizard.
+
 1. **Clone the DEV repo, not the public mirror.** If your himmel development
    happens in a private repo with a public propagation mirror, `git clone` of
    the public name gives you a stale, differently-numbered history. Check the

--- a/llms.txt
+++ b/llms.txt
@@ -11,14 +11,16 @@ himmel is a harness *for* [Claude Code](https://claude.com/claude-code) — inst
 1. **Add himmel to an existing repo** (most common) — the portable core: hooks + guardrails + worktree workflow + marketplace plugins/skills.
    ```bash
    git clone https://github.com/yotamleo/himmel
-   bash himmel/scripts/adopt.sh --profile core --scope project --target /path/to/your/repo
-   # Windows:  pwsh himmel\scripts\adopt.ps1 -Profile core -Scope project -Target C:\path\to\repo
+   node himmel/scripts/himmelctl/bin.js install
+   # node-less machine, run first: bash himmel/scripts/himmelctl/bootstrap.sh
+   # (Windows: powershell -ExecutionPolicy Bypass -File himmel\scripts\himmelctl\bootstrap.ps1)
    ```
-   Full adopter guide + à-la-carte parts: [docs/setup/use-on-your-project.md](docs/setup/use-on-your-project.md).
-2. **Run / develop himmel standalone** — `git clone https://github.com/yotamleo/himmel && cd himmel && bash scripts/setup.sh` (Windows: `powershell -File scripts\setup.ps1`). Verifies tools, installs the git hooks, builds the Jira CLI, registers the qmd index, writes a ready `.env` (add `--fill-env` for guided per-variable prompts with inline help). Walkthrough: [docs/setup/new-machine.md](docs/setup/new-machine.md#4-himmel-repo).
+   The wizard runs `adopt.sh`/`adopt.ps1` under the hood — manual invocation
+   + à-la-carte parts: [docs/setup/use-on-your-project.md](docs/setup/use-on-your-project.md).
+2. **Run / develop himmel standalone** — same wizard, contributor path: `git clone https://github.com/yotamleo/himmel && cd himmel && node scripts/himmelctl/bin.js install` (node-less: `bash scripts/himmelctl/bootstrap.sh` first). Under the hood it runs `bash scripts/setup.sh` (Windows: `powershell -ExecutionPolicy Bypass -File scripts\setup.ps1`) — verifies tools, installs the git hooks, builds the Jira CLI, registers the qmd index, writes a ready `.env` (add `--fill-env` for guided per-variable prompts with inline help). Walkthrough: [docs/setup/new-machine.md](docs/setup/new-machine.md#4-himmel-repo).
 3. **Diagnose an install that already exists** — run the `himmel-ops:himmel-doctor` skill (`/himmel-doctor`): a read-only, severity-grouped health report for the field problems that bite himmel installs (SessionStart `node: command not found`, a shadowed claude-obsidian plugin, a dirty single-writer luna vault, a repo missing from the handover registry, PATH-fragile MCP servers, un-pruned merged-PR worktrees). `--fix` heals the node wiring; everything else points you at the right command.
 
-Lifecycle after install: update with the `himmel-ops:himmel-update` skill (`/himmel-update` — `git pull` + marketplace re-sync; `autoUpdate` does NOT deliver himmel), upgrade a luna vault with `/luna-upgrade`, and offboard with `scripts/uninstall.sh`. All three: [docs/setup/updating.md](docs/setup/updating.md).
+Lifecycle after install: update with the `himmel-ops:himmel-update` skill (`/himmel-update` — `git pull` + marketplace re-sync; `autoUpdate` does NOT deliver himmel), upgrade a luna vault with `/luna-upgrade`, and offboard with `node scripts/himmelctl/bin.js uninstall` (executes `scripts/uninstall.sh`). All three: [docs/setup/updating.md](docs/setup/updating.md).
 
 ## Start here
 


### PR DESCRIPTION
Adopter-facing docs now lead with the himmelctl install wizard (node scripts/himmelctl/bin.js install; bootstrap shims for node-less machines); raw setup.sh/adopt.sh demoted to what-the-wizard-runs / manual + CI path. Uninstall pointers lead with himmelctl uninstall. adopt.sh command-example duplication collapsed to one canonical example + link to docs/setup/use-on-your-project.md. windows-clean-machine gains the adopter fork (clone -> bootstrap.ps1 -> himmelctl install). ExecutionPolicy Bypass on ps1 examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Quickstart, getting-started, and setup guides to route install/offboard flows through the interactive `himmelctl` wizard (including uninstall via the wizard).
  * Added and expanded “node-less machine” bootstrap instructions before re-running install.
  * Clarified what the wizard does versus the underlying adopt/uninstall commands, including example usage.
  * Refreshed VM and Windows setup guidance (including guidance for “himmel only” use cases).
  * Updated AI-assistant (`llms.txt`) instructions to match the new wizard-based lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->