### PR TITLE
fix(cr): qwenor picks a live free-tier model dynamically (chain + budget + routed fallbacks)

### DIFF
--- a/scripts/cr/critic-panel.sh
+++ b/scripts/cr/critic-panel.sh
@@ -241,12 +241,18 @@ rows="$(REG="$REG" TIER_FILTER="$TIER_FILTER" node -e '
     // alias base_url -> 401 on the alibaba lane). Primary dispatch only —
     // fallback-chain members stay name-routed (hermes aliases, possibly
     // cross-provider).
+    // Field 6 = FALLBACK_TRIGGER (HIMMEL-953): OPT-IN per row. "any" widens
+    // the process_member retry condition to ANY non-zero rc/timeout instead
+    // of requiring a quota-exhaustion signature match — for a same-tier
+    // candidate chain (e.g. all OpenRouter free models) any failure on one
+    // candidate is reason enough to try the next. "-" (unset) keeps the
+    // HIMMEL-729 exhaustion-only default for every other row.
     process.stdout.write(p.map(r => {
       let chain = Array.isArray(r.fallback_models) ? r.fallback_models
                 : (r.fallback_model ? [r.fallback_model] : []);
       chain = chain.filter(m => typeof m === "string" && m.length);
       const fb = chain.length ? chain.join(",") : "-";
-      return r.slug + "\t" + r.model + "\t" + (r.perspective || "-") + "\t" + fb + "\t" + (r.route_provider || "-");
+      return r.slug + "\t" + r.model + "\t" + (r.perspective || "-") + "\t" + fb + "\t" + (r.route_provider || "-") + "\t" + (r.fallback_trigger || "-") + "\t" + (r.fallback_provider || "-");
     }).join("\n"));
   } catch (e) {
     process.exit(7);
@@ -255,7 +261,7 @@ rows="$(REG="$REG" TIER_FILTER="$TIER_FILTER" node -e '
 
 if [ -z "${rows:-}" ]; then
     echo "critic-panel.sh: registry $REG missing/invalid/empty — anchor-only ($ANCHOR_SLUG)" >&2
-    rows="${ANCHOR_SLUG}	${ANCHOR_MODEL}	-	-	${ANCHOR_PROVIDER}"
+    rows="${ANCHOR_SLUG}	${ANCHOR_MODEL}	-	-	${ANCHOR_PROVIDER}	-	-"
 fi
 
 # Write diff to a temp file so each member can read it via stdin redirect
@@ -317,28 +323,32 @@ _is_quota_exhaustion() {
 # (HIMMEL-737: the chain is iterated in order, each model attempted at most once).
 # ---------------------------------------------------------------------------
 _run_cfp_member() {
-    _rm_model="$1"; _rm_slug="$2"; _rm_persp="${3:-}"; _rm_out="$4"; _rm_err="${5:-/dev/null}"
+    _rm_model="$1"; _rm_slug="$2"; _rm_persp="${3:-}"; _rm_out="$4"; _rm_err="${5:-/dev/null}"; _rm_provider="${6:-}"
+    # Per-attempt timeout override (HIMMEL-953 seat budget): the fallback loop
+    # passes the REMAINING seat budget so a chain of hung candidates cannot
+    # stack N full member timeouts. Unset -> the normal per-member timeout.
+    _rm_to="${_RM_TIMEOUT_SECS:-$CRITIC_TIMEOUT_SECS}"
     if [ -n "$_rm_persp" ]; then
         if [ -n "$_TIMEOUT_BIN" ]; then
-            "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" \
-                --model "$_rm_model" --slug "$_rm_slug" \
+            "$_TIMEOUT_BIN" -k 5 "$_rm_to" bash "$CFP" \
+                --model "$_rm_model" --provider "$_rm_provider" --slug "$_rm_slug" \
                 --perspective-file "$SCRIPT_DIR/$_rm_persp" \
                 < "$tmp" > "$_rm_out" 2>"$_rm_err"
             _rm_rc=$?
         else
-            bash "$CFP" --model "$_rm_model" --slug "$_rm_slug" \
+            bash "$CFP" --model "$_rm_model" --provider "$_rm_provider" --slug "$_rm_slug" \
                 --perspective-file "$SCRIPT_DIR/$_rm_persp" \
                 < "$tmp" > "$_rm_out" 2>"$_rm_err"
             _rm_rc=$?
         fi
     else
         if [ -n "$_TIMEOUT_BIN" ]; then
-            "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" \
-                --model "$_rm_model" --slug "$_rm_slug" \
+            "$_TIMEOUT_BIN" -k 5 "$_rm_to" bash "$CFP" \
+                --model "$_rm_model" --provider "$_rm_provider" --slug "$_rm_slug" \
                 < "$tmp" > "$_rm_out" 2>"$_rm_err"
             _rm_rc=$?
         else
-            bash "$CFP" --model "$_rm_model" --slug "$_rm_slug" \
+            bash "$CFP" --model "$_rm_model" --provider "$_rm_provider" --slug "$_rm_slug" \
                 < "$tmp" > "$_rm_out" 2>"$_rm_err"
             _rm_rc=$?
         fi
@@ -359,6 +369,14 @@ _run_cfp_member() {
 # $6 = perspective for this slug (optional; "" = no --perspective-file), threaded
 #      into the fallback re-run so it uses the SAME invocation path as the primary
 # $7 = primary model for this slug (used only for availability metadata)
+# $8 = fallback PROVIDER for this slug's chain (HIMMEL-953, opt-in): explicit
+#      --provider for every fallback attempt ("" = chain members stay
+#      name-routed — hermes aliases, possibly cross-provider — per HIMMEL-729).
+# $9 = fallback trigger mode for this slug (HIMMEL-953): "any" widens the
+#      retry condition below to ANY non-zero rc (incl. timeout) instead of
+#      requiring a quota-exhaustion signature match. Opt-in per row so the
+#      HIMMEL-729 "don't mask a dead primary lane" contract stays the DEFAULT
+#      for rows that don't set it ("" = exhaustion-signature-only, unchanged).
 # ---------------------------------------------------------------------------
 process_member() {
     _pm_slug="$1"
@@ -368,6 +386,11 @@ process_member() {
     _pm_fallback="${5:-}"
     _pm_perspective="${6:-}"
     _pm_model="${7:-}"
+    # $8 = fallback_provider (HIMMEL-953, OPT-IN): explicit provider for the
+    # fallback CHAIN. Unset -> chain members stay name-routed (hermes aliases,
+    # possibly cross-provider) per the HIMMEL-729 registry contract.
+    _pm_fb_provider="${8:-}"
+    _pm_trigger="${9:-}"
     if [ -n "$_pm_model" ]; then
         _pm_avail="panel-availability: $_pm_slug ok responding-model($_pm_model)"
     else
@@ -376,32 +399,73 @@ process_member() {
     _fb_out=""
     _fb_err=""
 
+    _pm_is_timeout=0
     if [ "$_pm_rc" -eq 124 ] || [ "$_pm_rc" -eq 137 ]; then
+        _pm_is_timeout=1
+    fi
+
+    # Decide up front whether this rc should attempt the fallback chain.
+    # Default (unset trigger): only a quota-exhaustion signature on a
+    # non-timeout failure retries — a bare timeout or a generic failure never
+    # did (HIMMEL-729/737, still the contract for any OTHER row). trigger=any
+    # (HIMMEL-953) widens this to ANY non-zero rc, timeout included — for a
+    # row whose whole chain is same-tier candidates (e.g. all OpenRouter free
+    # models), a plain rate-limit/outage on one candidate is exactly the
+    # signal to try the next, not evidence the lane itself is broken.
+    # Track WHY the chain fires separately from THAT it fires, so the WARN
+    # line below can keep saying "quota-exhausted" only when it is true
+    # (an "any"-triggered generic failure gets its own honest wording).
+    _pm_exhaustion_match=0
+    if [ -n "$_pm_fallback" ] && [ "$_pm_rc" -ne 0 ] && [ "$_pm_is_timeout" -eq 0 ] && _is_quota_exhaustion "$_pm_out_file" "$_pm_err_file"; then
+        _pm_exhaustion_match=1
+    fi
+    _pm_do_fallback=0
+    if [ -n "$_pm_fallback" ] && [ "$_pm_rc" -ne 0 ]; then
+        if [ "$_pm_exhaustion_match" -eq 1 ] || [ "$_pm_trigger" = "any" ]; then
+            _pm_do_fallback=1
+        fi
+    fi
+
+    if [ "$_pm_is_timeout" -eq 1 ] && [ "$_pm_do_fallback" -eq 0 ]; then
         echo "panel-availability: $_pm_slug unavailable (timeout ${CRITIC_TIMEOUT_SECS}s)" >&2
         return
     fi
     if [ "$_pm_rc" -ne 0 ]; then
-        # Quota-exhaustion fallback CHAIN (HIMMEL-729/737): if the slug has a
-        # fallback chain AND the member output/stderr matches an exhaustion
-        # signature, re-run the member through the same critic-first-pass path
-        # with each fallback model IN ORDER, each attempted AT MOST ONCE. First
-        # success wins; a failed attempt logs fallback-failed and advances; all
-        # exhausted -> member unavailable. A plain non-exhaustion failure (or a
-        # timeout, handled above) gets the original unavailable line and NO retry.
-        if [ -n "$_pm_fallback" ] && _is_quota_exhaustion "$_pm_out_file" "$_pm_err_file"; then
+        # Quota-exhaustion (or, with trigger=any, ANY-failure) fallback CHAIN
+        # (HIMMEL-729/737/953): re-run the member through the same
+        # critic-first-pass path with each fallback model IN ORDER, each
+        # attempted AT MOST ONCE. First success wins; a failed attempt logs
+        # fallback-failed and advances; all exhausted -> member unavailable.
+        if [ "$_pm_do_fallback" -eq 1 ]; then
             _fb_success=0
             # Iterate the comma-separated chain in order. IFS=',' splits it at the
             # for-header; the body uses only quoted expansions, so ',' is harmless
             # there. Restored after the loop.
             _fb_old_ifs="$IFS"; IFS=','
+            # Seat budget (HIMMEL-953, codex-adv): the WHOLE chain shares one
+            # extra member-timeout of wall-clock — N hung candidates must not
+            # stack N full timeouts (observed 240s hangs on free tiers would
+            # otherwise block a seat ~4x240s in sequential mode). Each attempt
+            # gets the REMAINING budget via the _run_cfp_member override.
+            _fb_deadline=$((SECONDS + CRITIC_TIMEOUT_SECS))
             for _fb_model in $_pm_fallback; do
                 [ -n "$_fb_model" ] || continue
+                _fb_remaining=$((_fb_deadline - SECONDS))
+                if [ "$_fb_remaining" -le 0 ]; then
+                    echo "panel-availability: $_pm_slug fallback-chain budget exhausted (${CRITIC_TIMEOUT_SECS}s) — remaining candidates skipped" >&2
+                    break
+                fi
+                _RM_TIMEOUT_SECS="$_fb_remaining"
                 _fb_out="$(mktemp -t critic-panel-fb.XXXXXX)"
                 _fb_err="$(mktemp -t critic-panel-fb-err.XXXXXX)"
-                _run_cfp_member "$_fb_model" "$_pm_slug" "$_pm_perspective" "$_fb_out" "$_fb_err"
+                _run_cfp_member "$_fb_model" "$_pm_slug" "$_pm_perspective" "$_fb_out" "$_fb_err" "$_pm_fb_provider"
                 _fb_rc=$_rm_rc
                 if [ "$_fb_rc" -eq 0 ]; then
-                    echo "WARN critic-panel: $_pm_slug quota-exhausted - fell back to $_fb_model" >&2
+                    if [ "$_pm_exhaustion_match" -eq 1 ]; then
+                        echo "WARN critic-panel: $_pm_slug quota-exhausted - fell back to $_fb_model" >&2
+                    else
+                        echo "WARN critic-panel: $_pm_slug failed (rc=$_pm_rc) - fell back to $_fb_model" >&2
+                    fi
                     _pm_avail="panel-availability: $_pm_slug fallback($_fb_model)"
                     _pm_out_file="$_fb_out"
                     _fb_success=1
@@ -415,8 +479,13 @@ process_member() {
                 rm -f "$_fb_out" "$_fb_err"
             done
             IFS="$_fb_old_ifs"
+            unset _RM_TIMEOUT_SECS
             if [ "$_fb_success" -ne 1 ]; then
-                echo "panel-availability: $_pm_slug unavailable (rc=$_pm_rc)" >&2
+                if [ "$_pm_is_timeout" -eq 1 ]; then
+                    echo "panel-availability: $_pm_slug unavailable (timeout ${CRITIC_TIMEOUT_SECS}s)" >&2
+                else
+                    echo "panel-availability: $_pm_slug unavailable (rc=$_pm_rc)" >&2
+                fi
                 return
             fi
         else
@@ -513,13 +582,15 @@ if [ "$CRITIC_PARALLEL" = "0" ]; then
     _seq_out="$(mktemp -t critic-panel-seq.XXXXXX)"
     _seq_err="$(mktemp -t critic-panel-seq-err.XXXXXX)"
 
-    while IFS="	" read -r slug model perspective fallback_chain row_provider; do
+    while IFS="	" read -r slug model perspective fallback_chain row_provider fallback_trigger fb_provider; do
         [ -n "$slug" ] || continue
         # Map the "-" empty-field placeholder back to "" (see the registry
         # emission above — plain empty fields collapse under tab-IFS).
         [ "$perspective" = "-" ] && perspective=""
         [ "$fallback_chain" = "-" ] && fallback_chain=""
         [ "$row_provider" = "-" ] && row_provider=""
+        [ "$fallback_trigger" = "-" ] && fallback_trigger=""
+        [ "$fb_provider" = "-" ] && fb_provider=""
         total=$((total + 1))
 
         # Run this member (with per-member timeout if available). --provider ""
@@ -542,7 +613,7 @@ if [ "$CRITIC_PARALLEL" = "0" ]; then
             fi
         fi
 
-        process_member "$slug" "$_seq_out" "$rc" "$_seq_err" "$fallback_chain" "$perspective" "$model"
+        process_member "$slug" "$_seq_out" "$rc" "$_seq_err" "$fallback_chain" "$perspective" "$model" "$fb_provider" "$fallback_trigger"
 
     done << ROWSEOF
 $rows
@@ -556,21 +627,26 @@ else
 
     # Launch each member indexed by position i (i=0,1,2,...)
     i=0
-    while IFS="	" read -r slug model perspective fallback_chain row_provider; do
+    while IFS="	" read -r slug model perspective fallback_chain row_provider fallback_trigger fb_provider; do
         [ -n "$slug" ] || continue
         # Map the "-" empty-field placeholder back to "" (see the registry
         # emission above — plain empty fields collapse under tab-IFS).
         [ "$perspective" = "-" ] && perspective=""
         [ "$fallback_chain" = "-" ] && fallback_chain=""
         [ "$row_provider" = "-" ] && row_provider=""
+        [ "$fallback_trigger" = "-" ] && fallback_trigger=""
+        [ "$fb_provider" = "-" ] && fb_provider=""
         total=$((total + 1))
         # Write slug and model so the result loop can recover them
         printf '%s' "$slug"  > "$outdir/$i.slug"
         printf '%s' "$model" > "$outdir/$i.model"
-        # Per-row perspective + fallback chain so the result loop can replay them
-        # into process_member (HIMMEL-729/737 quota-exhaustion fallback chain).
-        printf '%s' "$perspective"    > "$outdir/$i.persp"
-        printf '%s' "$fallback_chain" > "$outdir/$i.fb"
+        # Per-row perspective + fallback chain (+ trigger mode, HIMMEL-953) so
+        # the result loop can replay them into process_member (HIMMEL-729/737
+        # quota-exhaustion fallback chain).
+        printf '%s' "$perspective"     > "$outdir/$i.persp"
+        printf '%s' "$fallback_chain"  > "$outdir/$i.fb"
+        printf '%s' "$fallback_trigger" > "$outdir/$i.trigger"
+        printf '%s' "$fb_provider"      > "$outdir/$i.fbprov"
         (
             if [ -n "$perspective" ]; then
                 if [ -n "$_TIMEOUT_BIN" ]; then
@@ -608,6 +684,10 @@ ROWSEOF
         read -r persp_val < "$outdir/$i.persp" 2>/dev/null || true
         fb_val=""
         read -r fb_val < "$outdir/$i.fb" 2>/dev/null || true
+        trig_val=""
+        read -r trig_val < "$outdir/$i.trigger" 2>/dev/null || true
+        fbprov_val=""
+        read -r fbprov_val < "$outdir/$i.fbprov" 2>/dev/null || true
         # Note: if .rc is absent (subshell received a signal during the .out write,
         # e.g. outer timeout SIGKILLs mid-run before the echo $? line runs),
         # rc_val stays at its initialized 1 → process_member treats the member as
@@ -615,7 +695,7 @@ ROWSEOF
         # process_member sees zero findings and counts the member as responded.
         model_val=""
         read -r model_val < "$outdir/$i.model" 2>/dev/null || true
-        process_member "$slug" "$outdir/$i.out" "$rc_val" "$outdir/$i.err" "$fb_val" "$persp_val" "$model_val"
+        process_member "$slug" "$outdir/$i.out" "$rc_val" "$outdir/$i.err" "$fb_val" "$persp_val" "$model_val" "$fbprov_val" "$trig_val"
         i=$((i + 1))
     done
 fi

--- a/scripts/cr/critics.json
+++ b/scripts/cr/critics.json
@@ -1,7 +1,10 @@
 {
   "_compliance": "panel/router lanes must terminate per-token keys only; the Z.ai Coding-Plan subscription (and any subscription lane) is launcher-only (ToS restricts it to officially supported tools) — never behind a panel or router.",
   "panel": [
-    { "slug": "qwenor",     "model": "qwen/qwen3-next-80b-a3b-instruct:free", "provider": "openrouter", "route_provider": "openrouter", "tier": "free" },
+    { "slug": "qwenor",     "model": "qwen/qwen3-next-80b-a3b-instruct:free", "provider": "openrouter", "route_provider": "openrouter", "tier": "free",
+      "fallback_models": ["qwen/qwen3-coder:free", "openai/gpt-oss-120b:free", "openai/gpt-oss-20b:free"],
+      "fallback_trigger": "any",
+      "fallback_provider": "openrouter" },
     { "slug": "codex",      "model": "gpt-5.5",                             "provider": "openai-codex", "tier": "paid" }
   ]
 }

--- a/scripts/cr/test-critic-panel-fallback.sh
+++ b/scripts/cr/test-critic-panel-fallback.sh
@@ -445,6 +445,167 @@ check_contains "11: fallback finding lands in merged stdout" "$out11" \
 check_contains "11: responded 1/1 through the real cfp path" "$out11" "(1/1 critics responded)"
 check "11: exactly 2 invoke calls (primary + one fallback)" "$(cat "$INT_CNT")" "2"
 
+# ===========================================================================
+# HIMMEL-953: fallback_trigger="any" widens the retry condition to ANY
+# non-zero rc (incl. timeout), not just a quota-exhaustion signature match —
+# opt-in per row (e.g. the qwenor seat, whose whole chain is same-tier
+# OpenRouter free candidates: a plain rate-limit on one candidate is reason
+# enough to try the next). Reuses $STUB (already supports FB_STUB_MODE
+# generic/timeout for the primary model).
+# ===========================================================================
+JSON_ANY="$tmp/critics-any.json"
+printf '{"panel":[{"slug":"qwen3coder","model":"%s","provider":"alibaba-coding-plan","tier":"free","fallback_model":"%s","fallback_provider":"openrouter","fallback_trigger":"any"}]}' \
+    "$PRI" "$FB" > "$JSON_ANY"
+
+# --- Case 12: generic non-exhaustion failure (rc=1) -> trigger=any DOES fall back. ---
+run_case generic "$JSON_ANY" "$tmp/out12" "$tmp/err12" "$tmp/cap12"
+stderr12="$(cat "$tmp/err12")"; out12="$(cat "$tmp/out12")"
+fb_calls12=$(grep -cF -- "$FB" "$tmp/cap12")
+check_contains "12: generic rc=1 + trigger=any -> WARN with honest (rc=1) wording" "$stderr12" \
+    "WARN critic-panel: qwen3coder failed (rc=1) - fell back to $FB"
+check_not_contains "12: WARN does NOT claim quota-exhausted for a generic failure" "$stderr12" \
+    "quota-exhausted"
+check_contains "12: panel-availability fallback(<model>) token" "$stderr12" \
+    "panel-availability: qwen3coder fallback($FB)"
+check "12: fallback invoked exactly once" "$fb_calls12" "1"
+check_contains "12: responded 1/1" "$out12" "(1/1 critics responded)"
+
+# --- Case 13: timeout (rc=124) -> trigger=any DOES fall back (unlike Case 3). ---
+run_case timeout "$JSON_ANY" "$tmp/out13" "$tmp/err13" "$tmp/cap13"
+stderr13="$(cat "$tmp/err13")"; out13="$(cat "$tmp/out13")"
+fb_calls13=$(grep -cF -- "$FB" "$tmp/cap13")
+check_contains "13: timeout + trigger=any -> falls back" "$stderr13" \
+    "panel-availability: qwen3coder fallback($FB)"
+check "13: fallback invoked exactly once on a timed-out primary" "$fb_calls13" "1"
+check_contains "13: responded 1/1" "$out13" "(1/1 critics responded)"
+
+# --- Case 14: trigger=any + fallback ALSO fails -> unavailable, rc=1 wording
+# preserved for a generic primary failure (not "timeout"). ---
+run_case generic "$JSON_ANY" "$tmp/out14" "$tmp/err14" "$tmp/cap14" 1
+stderr14="$(cat "$tmp/err14")"
+check_contains "14: exhausted generic+any -> plain unavailable (rc=1)" "$stderr14" \
+    "panel-availability: qwen3coder unavailable (rc=1)"
+check "14: fallback attempted exactly once" "$(grep -cF -- "$FB" "$tmp/cap14")" "1"
+
+# --- Case 15: trigger=any + TIMEOUT + fallback ALSO fails -> unavailable
+# keeps the "(timeout Ns)" wording (not "(rc=124)"), since the primary truly
+# timed out. ---
+run_case timeout "$JSON_ANY" "$tmp/out15" "$tmp/err15" "$tmp/cap15" 1
+stderr15="$(cat "$tmp/err15")"
+check_contains "15: exhausted timeout+any -> unavailable keeps timeout wording" "$stderr15" \
+    "panel-availability: qwen3coder unavailable (timeout"
+check "15: fallback attempted exactly once on exhausted timeout+any" "$(grep -cF -- "$FB" "$tmp/cap15")" "1"
+
+# --- Case 16 (codex-adv, HIMMEL-953): a chain of HUNG candidates shares ONE
+# seat budget — total fallback wall-clock is bounded by CRITIC_TIMEOUT_SECS
+# and candidates past the budget are SKIPPED, not each handed a fresh full
+# member timeout (4x240s stacking risk in sequential mode). ---
+if command -v timeout >/dev/null 2>&1; then
+    FB2="openai/gpt-oss-20b:free"
+    JSON_BUDGET="$tmp/critics-budget.json"
+    printf '{"panel":[{"slug":"qwen3coder","model":"%s","provider":"alibaba-coding-plan","tier":"free","fallback_models":["%s","%s"],"fallback_trigger":"any"}]}' \
+        "$PRI" "$FB" "$FB2" > "$JSON_BUDGET"
+    STUB_BUDGET="$tmp/stub-budget.sh"
+    cat > "$STUB_BUDGET" <<STUBEOF
+#!/usr/bin/env bash
+# primary fails fast; every fallback hangs. exec sleep: Git-Bash timeout
+# does not reap grandchildren, exec keeps the sleep AS the timed process.
+model=""
+while [ \$# -gt 0 ]; do [ "\$1" = "--model" ] && model="\$2"; shift; done
+cat >/dev/null
+printf '%s\n' "\$model" >> "$tmp/cap16"
+[ "\$model" = "$PRI" ] && exit 1
+exec sleep 999
+STUBEOF
+    chmod +x "$STUB_BUDGET"
+    : > "$tmp/cap16"
+    _t16_start=$SECONDS
+    printf '%s' "$DIFF" | CRITICS_JSON="$JSON_BUDGET" CRITIC_FIRST_PASS="$STUB_BUDGET" \
+        CRITIC_TIMEOUT_SECS=2 bash "$PANEL" >"$tmp/out16" 2>"$tmp/err16"
+    _t16_elapsed=$((SECONDS - _t16_start))
+    stderr16="$(cat "$tmp/err16")"
+    check_contains "16: budget-exhausted line after a hung candidate" "$stderr16" \
+        "fallback-chain budget exhausted"
+    check "16: candidate past the budget skipped (never invoked)" "$(grep -cF -- "$FB2" "$tmp/cap16")" "0"
+    check "16: seat wall-clock bounded (no stacked full timeouts)" "$([ "$_t16_elapsed" -le 8 ] && echo yes)" "yes"
+    check_contains "16: member ends unavailable" "$stderr16" \
+        "panel-availability: qwen3coder unavailable"
+else
+    echo "ok - 16: skipped (no timeout binary)"
+fi
+
+# --- Case 17 (codex-adv, HIMMEL-953): fallback attempts PRESERVE the row's
+# route_provider — an all-OpenRouter chain must not fall back name-routed
+# (":free" ids are unresolvable without --provider openrouter). ---
+JSON_RP="$tmp/critics-rp.json"
+printf '{"panel":[{"slug":"qwenor","model":"%s","provider":"openrouter","route_provider":"openrouter","tier":"free","fallback_models":["%s"],"fallback_trigger":"any","fallback_provider":"openrouter"}]}' \
+    "$PRI" "$FB" > "$JSON_RP"
+STUB_RP="$tmp/stub-rp.sh"
+cat > "$STUB_RP" <<STUBEOF
+#!/usr/bin/env bash
+model=""; provider=""
+while [ \$# -gt 0 ]; do
+    [ "\$1" = "--model" ] && model="\$2"
+    [ "\$1" = "--provider" ] && provider="\$2"
+    shift
+done
+cat >/dev/null
+printf '%s provider=%s\n' "\$model" "\$provider" >> "$tmp/cap17"
+if [ "\$model" = "$PRI" ]; then exit 1; fi
+printf '%s\n' "# qwenor First-Pass Review" "" "## Critical Issues (0 found)" "" "## Important Issues (0 found)" "" "## Suggestions (0 found)"
+STUBEOF
+chmod +x "$STUB_RP"
+: > "$tmp/cap17"
+printf '%s' "$DIFF" | CRITICS_JSON="$JSON_RP" CRITIC_FIRST_PASS="$STUB_RP" \
+    bash "$PANEL" >"$tmp/out17" 2>"$tmp/err17"
+check "17: fallback invocation carries the row's route_provider" \
+    "$(grep -cF -- "$FB provider=openrouter" "$tmp/cap17")" "1"
+check_contains "17: fallback succeeded through the routed provider" "$(cat "$tmp/err17")" \
+    "panel-availability: qwenor fallback($FB)"
+
+# --- Case 18 (codex-adv, HIMMEL-953): PARALLEL mode — each member's fallback
+# must use ITS OWN row's route_provider, not the residual provider of the
+# last-parsed registry row. ---
+JSON_2P="$tmp/critics-2p.json"
+printf '{"panel":[{"slug":"qwenor","model":"%s","provider":"openrouter","route_provider":"openrouter","tier":"free","fallback_models":["%s"],"fallback_trigger":"any","fallback_provider":"openrouter"},{"slug":"other","model":"m2-ok","provider":"alibaba-coding-plan","route_provider":"alibaba-coding-plan","tier":"free","fallback_provider":"alibaba-coding-plan"}]}' \
+    "$PRI" "$FB" > "$JSON_2P"
+STUB_2P="$tmp/stub-2p.sh"
+cat > "$STUB_2P" <<STUBEOF
+#!/usr/bin/env bash
+model=""; provider=""
+while [ \$# -gt 0 ]; do
+    [ "\$1" = "--model" ] && model="\$2"
+    [ "\$1" = "--provider" ] && provider="\$2"
+    shift
+done
+cat >/dev/null
+printf '%s provider=%s\n' "\$model" "\$provider" >> "$tmp/cap18"
+if [ "\$model" = "$PRI" ]; then exit 1; fi
+printf '%s\n' "# stub First-Pass Review" "" "## Critical Issues (0 found)" "" "## Important Issues (0 found)" "" "## Suggestions (0 found)"
+STUBEOF
+chmod +x "$STUB_2P"
+: > "$tmp/cap18"
+printf '%s' "$DIFF" | CRITICS_JSON="$JSON_2P" CRITIC_FIRST_PASS="$STUB_2P" \
+    CRITIC_PARALLEL=1 bash "$PANEL" >"$tmp/out18" 2>"$tmp/err18"
+check "18: parallel fallback keeps its OWN row's provider" \
+    "$(grep -cF -- "$FB provider=openrouter" "$tmp/cap18")" "1"
+check "18: parallel fallback never rides the residual row's provider" \
+    "$(grep -cF -- "$FB provider=alibaba-coding-plan" "$tmp/cap18")" "0"
+check_contains "18: both members responded" "$(cat "$tmp/out18")" "(2/2 critics responded)"
+
+# --- Case 19 (codex-adv, HIMMEL-953): WITHOUT fallback_provider the chain
+# stays NAME-ROUTED (empty --provider) — the HIMMEL-729 cross-provider
+# contract must survive the opt-in. ---
+JSON_NR="$tmp/critics-nr.json"
+printf '{"panel":[{"slug":"qwenor","model":"%s","provider":"openrouter","route_provider":"openrouter","tier":"free","fallback_models":["%s"],"fallback_trigger":"any"}]}'     "$PRI" "$FB" > "$JSON_NR"
+STUB_NR="$tmp/stub-nr.sh"
+sed "s|cap17|cap19|" "$STUB_RP" > "$STUB_NR"
+chmod +x "$STUB_NR"
+: > "$tmp/cap19"
+printf '%s' "$DIFF" | CRITICS_JSON="$JSON_NR" CRITIC_FIRST_PASS="$STUB_NR"     bash "$PANEL" >"$tmp/out19" 2>"$tmp/err19"
+check "19: name-routed fallback keeps an EMPTY provider (no row inheritance)"     "$(grep -cF -- "$FB provider=openrouter" "$tmp/cap19")" "0"
+check "19: name-routed fallback WAS attempted"     "$(grep -cF -- "$FB provider=" "$tmp/cap19")" "1"
+
 if [ "$fails" -eq 0 ]; then
     echo "ALL PASS"
 else

--- a/scripts/cr/testdata/stub-cfp.py
+++ b/scripts/cr/testdata/stub-cfp.py
@@ -3,6 +3,8 @@ import sys
 
 model = ""
 slug = ""
+provider = ""
+perspective_file = ""
 args = sys.argv[1:]
 i = 0
 while i < len(args):
@@ -10,6 +12,10 @@ while i < len(args):
         model = args[i+1]; i += 2
     elif args[i] == "--slug" and i+1 < len(args):
         slug = args[i+1]; i += 2
+    elif args[i] == "--provider" and i+1 < len(args):
+        provider = args[i+1]; i += 2
+    elif args[i] == "--perspective-file" and i+1 < len(args):
+        perspective_file = args[i+1]; i += 2
     else:
         i += 1
 
@@ -31,6 +37,29 @@ if model in ("qwen/qwen3-coder-480b-a35b-instruct", "qwen/qwen3.6-35b-a3b", "qwe
     print("")
     print("## Suggestions (1 found)")
     print("- [qwen3coder-3]: rename for clarity [foo.sh:7]")
+    sys.exit(0)
+elif model == "qwen/qwen3-coder:free":
+    # Current ANCHOR_MODEL (qwenor seat, HIMMEL-953) — the anchor-fallback
+    # tests (E, I2) feed this through the stub to prove the anchor MODEL ran.
+    # Argument-sensitive (codex-adv, HIMMEL-953): the anchor-only row must
+    # parse provider=openrouter and NO perspective file — a tab-IFS field
+    # collapse in the anchor literal shifts these and must fail here.
+    if provider != "openrouter":
+        print("stub-cfp: anchor expected --provider openrouter, got:", provider or "<empty>", file=sys.stderr)
+        sys.exit(1)
+    if perspective_file:
+        print("stub-cfp: anchor got unexpected --perspective-file:", perspective_file, file=sys.stderr)
+        sys.exit(1)
+    print("# qwenor First-Pass Review")
+    print("")
+    print("## Critical Issues (1 found)")
+    print("- [qwenor-1]: null dereference in handler [foo.sh:3]")
+    print("")
+    print("## Important Issues (1 found)")
+    print("- [qwenor-2]: unused variable x [foo.sh:5]")
+    print("")
+    print("## Suggestions (1 found)")
+    print("- [qwenor-3]: rename for clarity [foo.sh:7]")
     sys.exit(0)
 elif model == "openai/gpt-oss-120b":
     print("# gptoss First-Pass Review")


### PR DESCRIPTION
Critic-panel resilience: the free OpenRouter seat selects a live model dynamically via an ordered backend-diverse chain with any-failure failover, a shared per-seat timeout budget, and explicitly routed fallbacks (opt-in; name-routed chains unchanged). Includes the anchor reconciliation with the earlier repoint and eight new regression cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable fallback triggers, including fallback on any execution failure.
  * Added support for specifying a fallback provider per critic.
  * Added timeout-aware fallback handling with a shared time budget across fallback attempts.
  * Configured the Qwen critic to use OpenRouter fallback routing.

* **Bug Fixes**
  * Improved timeout and unavailable-status messaging during fallback attempts.
  * Preserved provider routing consistently across sequential and parallel runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->