### PR TITLE
feat(himmelctl): manifest + target-keyed state + status probe engine

### DIFF
--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -321,6 +321,28 @@ To **update** an existing checkout later, run `/himmel-update` (or `bash scripts
 `git pull` is what delivers himmel updates — marketplace `autoUpdate` does not.
 See [`updating.md`](updating.md).
 
+### `himmelctl status` — read-only install-state check (HIMMEL-756)
+
+```bash
+node scripts/himmelctl/bin.js status [--items a,b] [--json]
+```
+
+Diffs desired state (the manifest at `scripts/install/manifest.json`, crossed
+with your recorded install state) against actual state (live probes),
+severity-grouped (red/degraded/green/n/a). Read-only: never prompts;
+never mutates on repeat runs (the first check for a given target may
+persist one derived state entry — the sanctioned derive-write). `--items`
+scopes the run to a comma-list of item ids; `--json` emits stable
+machine-readable output instead of text.
+
+The scope comes from your last wizard run (the cached
+`~/.claude/himmel/install-profile.json`): under **project** scope the target
+is keyed by the directory you run it from — run it from the adopted
+project's root; under **user** scope the target is the single `user` entry
+regardless of cwd. (A per-run scope override lands with the Phase-2 verbs.)
+It's the shared pre-check/post-check/enable-time primitive later himmelctl
+verbs (install/uninstall/enable) build on.
+
 #### Guardrail mode — global vs project (HIMMEL-709)
 
 The three generic guardrails (`auto-approve-safe-bash`, `block-edit-on-main`,

--- a/scripts/himmelctl/bin.js
+++ b/scripts/himmelctl/bin.js
@@ -17,12 +17,16 @@
 //   node scripts/himmelctl/bin.js --help
 //   node scripts/himmelctl/bin.js install [--dry-run] [--from-profile <path>] [--advanced]
 //   node scripts/himmelctl/bin.js uninstall [--dry-run]
+//   node scripts/himmelctl/bin.js status [--items <a,b>] [--json]
 
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const readline = require('readline');
 const { spawnSync } = require('child_process');
+const { cacheDir, profileForVault, which } = require('./lib/helpers.js');
+const stateLib = require('./lib/state.js');
+const probesLib = require('./lib/probes.js');
 
 // Tools every himmel adopter needs before any question makes sense — mirrors
 // adopt.sh require_tools (bash/git/jq/python3) PLUS at least one JS package
@@ -34,11 +38,16 @@ const USAGE = `usage: himmelctl <command> [options]
 commands:
   install                install himmel into this project or your user scope
   uninstall               offboard himmel from this machine (thin wrapper)
+  status                  read-only severity diff of installed vs desired items;
+                          run from the adopted project's root for project scope,
+                          or from the himmel checkout for user scope
 
 options:
   --from-profile <path>  install non-interactively from a saved profile cache
   --advanced             reserved: surface advanced options (parsed, not yet honored)
   --dry-run              print the derived install plan without executing
+  --items <a,b>          status: scope the run to these item ids (comma list)
+  --json                 status: emit stable machine-readable JSON instead of text
   -h, --help             show this help`;
 
 // Parse the CLI args into a plain object. Unknown args are a hard error (exit
@@ -51,6 +60,8 @@ function parseArgs(argv) {
     fromProfile: null, // reserved (T0: parse only)
     advanced: false,   // reserved (T0: parse only)
     dryRun: false,
+    items: null,       // status: --items comma list (null = no filter)
+    json: false,       // status: --json
   };
   const setSubcommand = (name) => {
     if (args.subcommand !== null) {
@@ -68,6 +79,25 @@ function parseArgs(argv) {
         break;
       case 'uninstall':
         setSubcommand('uninstall');
+        break;
+      case 'status':
+        setSubcommand('status');
+        break;
+      case '--items': {
+        const raw = argv[++i];
+        if (raw === undefined) {
+          console.error('himmelctl: --items requires a comma-separated id list');
+          process.exit(2);
+        }
+        args.items = raw.split(',').map((s) => s.trim()).filter(Boolean);
+        if (args.items.length === 0) {
+          console.error('himmelctl: --items requires at least one non-empty id');
+          process.exit(2);
+        }
+        break;
+      }
+      case '--json':
+        args.json = true;
         break;
       case '--from-profile':
         args.fromProfile = argv[++i];
@@ -105,23 +135,8 @@ function repoRoot() {
   return process.env.HIMMELCTL_REPO_ROOT || himmelRoot();
 }
 
-// Resolve <tool> on PATH like `command -v` would, checking the bare name plus
-// the Windows executable extensions so the same scan works on win32/posix.
-// Uses path.delimiter, which is the separator Node actually sees in
-// process.env.PATH (';' on win32, ':' on posix).
-function which(tool) {
-  const exts = process.platform === 'win32' ? ['', '.exe', '.cmd', '.bat'] : [''];
-  const dirs = (process.env.PATH || '').split(path.delimiter);
-  for (const dir of dirs) {
-    if (!dir) continue;
-    for (const ext of exts) {
-      try {
-        if (fs.existsSync(path.join(dir, tool + ext))) return path.join(dir, tool + ext);
-      } catch (_e) { /* unreadable dir — skip */ }
-    }
-  }
-  return null;
-}
+// which()/cacheDir()/profileForVault() live in lib/helpers.js (HIMMEL-756
+// T1.2a extraction) — required above.
 
 // Return the missing hard-gate tools: any of bash/git/jq/python3 absent, plus
 // 'npm' when neither npm nor bun is present (matches adopt.sh require_tools
@@ -449,10 +464,7 @@ function defaultAnswers() {
 // seam as HIMMELCTL_INTERACTIVE, and genuinely useful for CI (and essential
 // for hermetic tests: under Git Bash, HOME does NOT propagate into node.exe
 // children, so ~/.claude/himmel/ cannot be redirected via fake-HOME alone).
-
-function cacheDir() {
-  return process.env.HIMMELCTL_CACHE_DIR || path.join(os.homedir(), '.claude', 'himmel');
-}
+// (cacheDir() itself lives in lib/helpers.js — required above.)
 
 function cachePath() {
   return path.join(cacheDir(), 'install-profile.json');
@@ -544,10 +556,7 @@ function loadProfile(p) {
 //                      luna-upgrade-all.sh or wire-luna-vault.sh here).
 //   existing         → handled BEFORE this is reached (see the runPlan gate
 //                       below) — T5b, STAMPED-only (see isStampedLunaVault).
-function profileForVault(answers) {
-  const mode = answers.vault && answers.vault.mode;
-  return mode === 'default-template' ? 'all' : 'core';
-}
+// (profileForVault() itself lives in lib/helpers.js — required above.)
 
 // T5b: is <vaultPath> a STAMPED luna-second-brain vault? Reuses the EXACT
 // signal scripts/luna-upgrade-all.sh's classify_vault() treats as
@@ -1007,6 +1016,129 @@ async function cmdUninstall(args) {
   return runSpawn(cmd);
 }
 
+// ── status (HIMMEL-756 T1.5/T1.6) ────────────────────────────────────────
+//
+// A read-only severity diff: desired = the target's manifest-derived
+// `enabled` flags (lib/state.js), actual = a fresh probe run (lib/probes.js)
+// for every desired-enabled item. NEVER prompts (no readline anywhere in
+// this section) and NEVER mutates on its own — the ONLY sanctioned write is
+// deriving a target's FIRST entry when the install-profile cache exists but
+// state.json has no entry yet for this target (ensureTarget's own
+// documented derive-if-missing path); that derived entry is persisted here
+// via state.save() so it doesn't need re-deriving on every future run. An
+// already-present target entry is read as-is with zero writes.
+//
+// Target resolution mirrors adopt.sh / state.js's own targetKeyForScope
+// (not exported — replicated here as the same one-line formula its module
+// header documents): project scope keys off path.resolve(process.cwd()),
+// user scope is the literal "user" key. `status` must therefore be run from
+// the same location the corresponding `install` was run from — the
+// adopted project's root for project scope, or the himmel checkout for
+// user scope (review carry-forward #1).
+
+// The ONE place per-item probe ctx is constructed for `status`. Special
+// case (and the ONLY one): luna-vault-scaffold's ctx.targetPath is the
+// cached vault.path answer (expanded), not the scope's normal target root —
+// its probe descriptor is a {vaultPath} placeholder with no other source of
+// truth (review carry-forward #2).
+function ctxForItem(item, cachedAnswers, baseTargetPath, scope) {
+  const targetPath = item.id === 'luna-vault-scaffold'
+    ? expandHome(cachedAnswers.vault && cachedAnswers.vault.path)
+    : baseTargetPath;
+  return { repoRoot: repoRoot(), targetPath, scope, env: process.env };
+}
+
+function loadManifest() {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot(), 'scripts', 'install', 'manifest.json'), 'utf8'));
+}
+
+async function cmdStatus(args) {
+  const manifest = loadManifest();
+
+  const profilePath = cachePath();
+  if (!fs.existsSync(profilePath)) {
+    console.error('himmelctl: no himmelctl install profile found — run himmelctl install first');
+    return 2;
+  }
+  const cachedAnswers = loadProfile(profilePath);
+
+  let items = manifest.items;
+  if (args.items) {
+    const known = new Set(manifest.items.map((i) => i.id));
+    for (const id of args.items) {
+      if (!known.has(id)) {
+        console.error(`himmelctl: unknown --items id: ${id}`);
+        return 2;
+      }
+    }
+    const wanted = new Set(args.items);
+    items = manifest.items.filter((i) => wanted.has(i.id));
+  }
+
+  const scope = cachedAnswers.scope;
+  const targetKey = scope === 'user' ? 'user' : path.resolve(process.cwd());
+  const baseTargetPath = scope === 'user' ? repoRoot() : path.resolve(process.cwd());
+
+  const state = stateLib.load();
+  const existedBefore = Boolean(state.targets[targetKey]);
+  const target = stateLib.ensureTarget(state, manifest, cachedAnswers);
+  if (!existedBefore) stateLib.save(state);
+
+  const results = [];
+  for (const item of items) {
+    const entry = target.items[item.id];
+    const desired = Boolean(entry && entry.enabled);
+    if (!desired) {
+      results.push({
+        id: item.id, kind: item.kind, desired: false, actual: null,
+        severity: 'n/a', detail: 'not enabled for this target (profile/scope)',
+      });
+      continue;
+    }
+    const ctx = ctxForItem(item, cachedAnswers, baseTargetPath, scope);
+    const probe = probesLib.runProbe(item, ctx);
+    let severity;
+    let detail = probe.detail;
+    if (probe.actual === 'present') {
+      severity = 'green';
+    } else if (probe.actual === 'degraded') {
+      severity = 'degraded';
+    } else {
+      severity = 'red';
+      // Review carry-forward #3: pre-commit-hooks reads absent for a
+      // generic adopter (targetPath-relative, adopt.sh never lays this
+      // file) — that is the intended "does THIS project carry the gate"
+      // semantic, not a broken install; say so plainly.
+      if (item.id === 'pre-commit-hooks') detail = 'no .pre-commit-config.yaml in this project';
+    }
+    results.push({ id: item.id, kind: item.kind, desired: true, actual: probe.actual, severity, detail });
+  }
+
+  results.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  const summary = { red: 0, degraded: 0, green: 0, na: 0 };
+  for (const r of results) {
+    if (r.severity === 'red') summary.red++;
+    else if (r.severity === 'degraded') summary.degraded++;
+    else if (r.severity === 'green') summary.green++;
+    else summary.na++;
+  }
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify({ schemaVersion: 1, target: targetKey, items: results, summary }) + '\n');
+    return 0;
+  }
+
+  const groupOrder = { red: 0, degraded: 1, green: 2, 'n/a': 3 };
+  const printed = results.slice().sort((a, b) => {
+    const byGroup = groupOrder[a.severity] - groupOrder[b.severity];
+    return byGroup !== 0 ? byGroup : (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
+  });
+  for (const r of printed) console.log(`${r.severity}  ${r.id}  ${r.detail}`);
+  console.log(`${summary.red} red, ${summary.degraded} degraded, ${summary.green} green, ${summary.na} n/a`);
+  return 0;
+}
+
 async function main() {
   const argv = process.argv.slice(2);
   // --help / -h (anywhere) or no args → usage banner, exit 0.
@@ -1025,6 +1157,9 @@ async function main() {
   }
   if (args.subcommand === 'uninstall') {
     return await cmdUninstall(args);
+  }
+  if (args.subcommand === 'status') {
+    return await cmdStatus(args);
   }
   // parseArgs already rejected unknown subcommands, so this is unreachable.
   console.error(`himmelctl: unknown command: ${args.subcommand}`);

--- a/scripts/himmelctl/lib/helpers.js
+++ b/scripts/himmelctl/lib/helpers.js
@@ -1,0 +1,51 @@
+'use strict';
+// scripts/himmelctl/lib/helpers.js — shared helpers extracted out of bin.js
+// (HIMMEL-756 T1.2a). Pure refactor: same implementations, same call sites,
+// same seam env vars (HIMMELCTL_CACHE_DIR) — bin.js now `require`s these
+// instead of defining them inline.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Resolve <tool> on PATH like `command -v` would, checking the bare name plus
+// the Windows executable extensions so the same scan works on win32/posix.
+// Uses path.delimiter, which is the separator Node actually sees in
+// process.env.PATH (';' on win32, ':' on posix).
+function which(tool) {
+  const exts = process.platform === 'win32' ? ['', '.exe', '.cmd', '.bat'] : [''];
+  const dirs = (process.env.PATH || '').split(path.delimiter);
+  for (const dir of dirs) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      try {
+        if (fs.existsSync(path.join(dir, tool + ext))) return path.join(dir, tool + ext);
+      } catch (_e) { /* unreadable dir — skip */ }
+    }
+  }
+  return null;
+}
+
+// The interactive answers are cached so the same install can be replayed
+// non-interactively via --from-profile. The cache dir defaults to
+// ~/.claude/himmel/ but is overridable via HIMMELCTL_CACHE_DIR — same class of
+// seam as HIMMELCTL_INTERACTIVE, and genuinely useful for CI (and essential
+// for hermetic tests: under Git Bash, HOME does NOT propagate into node.exe
+// children, so ~/.claude/himmel/ cannot be redirected via fake-HOME alone).
+function cacheDir() {
+  return process.env.HIMMELCTL_CACHE_DIR || path.join(os.homedir(), '.claude', 'himmel');
+}
+
+// T5a (locked Q4): map a vault mode to an adopt.sh profile.
+//   none             → core
+//   default-template → all (adopt.sh itself scaffolds the vault from
+//                      templates/luna-second-brain — the wizard must NOT call
+//                      luna-upgrade-all.sh or wire-luna-vault.sh here).
+//   existing         → handled BEFORE this is reached (see the runPlan gate
+//                       below) — T5b, STAMPED-only (see isStampedLunaVault).
+function profileForVault(answers) {
+  const mode = answers.vault && answers.vault.mode;
+  return mode === 'default-template' ? 'all' : 'core';
+}
+
+module.exports = { cacheDir, profileForVault, which };

--- a/scripts/himmelctl/lib/probes.js
+++ b/scripts/himmelctl/lib/probes.js
@@ -1,0 +1,302 @@
+'use strict';
+// scripts/himmelctl/lib/probes.js — the himmelctl probe engine (HIMMEL-756
+// T1.4): one function per probe.type, EXACTLY the seven in
+// scripts/install/manifest-lint.mjs's PROBE_TYPES vocabulary. Every probe is
+// a PURE READ (no writes, no prompts, no env mutation) returning
+// `{ actual: "present"|"absent"|"degraded", detail: "<string>" }`.
+//
+// Export: runProbe(item, ctx) where ctx = { repoRoot, targetPath, scope, env }.
+// `env` is forwarded (not process.env directly) to every spawned child
+// process (cmd:has_qmd, qmd-index, handover-dir all shell out to bash), so a
+// hermetic test can hand a fully-controlled env object without mutating the
+// real process.env; falls back to process.env when ctx.env is omitted. The
+// `dep` probe is the one exception — see its function below.
+//
+// ── Design calls made resolving ambiguity in the T1.3 brief's shorthand ────
+//
+// "file-exists → fs.existsSync(resolve(repoRoot/targetPath, descriptor.path))"
+// undersells a real split in the manifest: most file-exists items check
+// something adopt.sh's PORTABLE_FILES actually copies into the ADOPTED
+// project (pre-commit-hooks' .pre-commit-config.yaml, guardrail-scope's
+// scripts/guardrails/lib.sh) — those resolve against ctx.targetPath. A
+// handful check himmel's OWN repo-only build/tooling artifacts that are
+// NEVER copied into any target (jira-cli-dist-build, bitbucket-cli-build,
+// doc-guard-map — the latter is kind:"wiring" like guardrail-scope, so kind
+// alone doesn't separate them) — those always resolve against ctx.repoRoot,
+// regardless of scope. REPO_ROOT_FILE_EXISTS_IDS below is the explicit,
+// commented exception list; a new file-exists item added to the manifest
+// defaults to targetPath-relative for scope=project, repoRoot-relative for
+// scope=user, and needs a look here if it's actually a repo-only artifact.
+//
+// "settings-key → parse the scope-appropriate settings.json" is similarly
+// shorthand: descriptor.file is generic (".claude/settings.json" for the
+// wiring/plugin items, ".env" for jira-env-keys) — resolveConfigFile() below
+// resolves ".env" against ctx.repoRoot ALWAYS (both scopes), per the
+// documented convention (CLAUDE.md: jira CLI always invoked by absolute path
+// from the primary checkout; adopt.sh's fill_env_core comment: "adopt copies
+// only portable hooks -- never the Jira CLI -- so an adopted repo always
+// invokes node $HIMMEL_ROOT/scripts/jira/..., whose repoRoot() reads
+// $HIMMEL_ROOT/.env"), and every other file against the scope-appropriate
+// base (project: ctx.targetPath; user: $HOME), matching bin.js's own
+// settingsPathForScope().
+//
+// "settings-hooks → contains the himmel marker(s) named in the descriptor" —
+// the settings-hooks descriptor shape (manifest-lint.mjs) carries no markers
+// field; PRETOOLUSE_MARKERS below is the actual himmel PreToolUse hook
+// trio, sourced from wire-pretooluse-hooks.sh's own dedup regex
+// (scripts/hooks/(auto-approve-safe-bash|block-edit-on-main|
+// block-read-secrets)[.]sh) — the single other place this trio is
+// enumerated. Keep both lists in sync if that trio ever changes.
+//
+// "qmd-index → qmd data/collections dir present + non-empty" — qmd's actual
+// on-disk data-dir layout has no stable, documented path anywhere in this
+// repo (grepped scripts/lib/qmd-bin.sh and its test suite — confirmed absent
+// before writing this). Per the brief's own fallback instruction, this adds
+// a thin `has_index` predicate to scripts/lib/qmd-bin.sh (checks `qmd
+// collection list` succeeds and is non-empty) and the probe here goes one
+// step further, matching the specific collection NAMES the descriptor lists
+// against that same `collection list` output (mirroring
+// qmd_register_collection's own `^${name}\b` idempotency check) so the
+// result is precise instead of a single yes/no.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { which } = require('./helpers.js');
+
+// ── file-exists ──────────────────────────────────────────────────────────
+
+// Himmel-repo-only file-exists items: their descriptor.path is a build/
+// tooling artifact adopt.sh's PORTABLE_FILES never copies into any adopted
+// target, so it must resolve against ctx.repoRoot even for scope:"project"
+// items (jira-cli-dist-build, bitbucket-cli-build are also kind:"dep" — see
+// the DEFAULT_DEP_REPO_ROOT rule below, which already covers them; listed
+// here too for a single self-contained source of truth). doc-guard-map is
+// kind:"wiring" (like guardrail-scope, which IS targetPath-relative), so
+// kind alone can't separate them — this is the one genuine exception.
+const REPO_ROOT_FILE_EXISTS_IDS = new Set(['jira-cli-dist-build', 'bitbucket-cli-build', 'doc-guard-map']);
+
+function probeFileExists(item, ctx) {
+  const raw = item.probe.path;
+  if (raw.indexOf('{vaultPath}') !== -1) {
+    if (!ctx.targetPath) {
+      return { actual: 'absent', detail: 'vaultPath placeholder unresolved: ctx.targetPath is empty' };
+    }
+    const resolved = path.resolve(raw.replace('{vaultPath}', ctx.targetPath));
+    return { actual: fs.existsSync(resolved) ? 'present' : 'absent', detail: resolved };
+  }
+  const base = (ctx.scope === 'user' || REPO_ROOT_FILE_EXISTS_IDS.has(item.id)) ? ctx.repoRoot : ctx.targetPath;
+  const resolved = path.resolve(base, raw);
+  return { actual: fs.existsSync(resolved) ? 'present' : 'absent', detail: resolved };
+}
+
+// ── settings-key / settings-hooks shared file resolution ────────────────
+
+// Resolve a settings-key/settings-hooks descriptor's `file` against the
+// scope-appropriate base. ".env" is special-cased to ALWAYS resolve against
+// ctx.repoRoot (both scopes) — see the module header comment. Every other
+// file resolves against ctx.targetPath (project scope) or $HOME (user
+// scope), matching bin.js's settingsPathForScope().
+function resolveConfigFile(file, ctx) {
+  if (file === '.env') return path.join(ctx.repoRoot, '.env');
+  const home = (ctx.env && ctx.env.HOME) || os.homedir();
+  const base = ctx.scope === 'user' ? home : ctx.targetPath;
+  return path.join(base, file);
+}
+
+function getDotPath(obj, dotPath) {
+  return dotPath.split('.').reduce((acc, k) => (acc && typeof acc === 'object' ? acc[k] : undefined), obj);
+}
+
+function nonEmpty(v) {
+  if (v === undefined || v === null || v === '') return false;
+  if (Array.isArray(v)) return v.length > 0;
+  if (typeof v === 'object') return Object.keys(v).length > 0;
+  return true;
+}
+
+// Minimal KEY=VALUE .env parser: skips blank lines/comments, strips a single
+// layer of matching quotes. Good enough for the jira-env-keys probe's
+// presence check — this never writes or reinterprets the file.
+function parseDotEnv(raw) {
+  const out = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const t = line.trim();
+    if (!t || t.charAt(0) === '#') continue;
+    const eq = t.indexOf('=');
+    if (eq === -1) continue;
+    const k = t.slice(0, eq).trim();
+    let v = t.slice(eq + 1).trim();
+    if (v.length >= 2 && ((v[0] === '"' && v[v.length - 1] === '"') || (v[0] === "'" && v[v.length - 1] === "'"))) {
+      v = v.slice(1, -1);
+    }
+    out[k] = v;
+  }
+  return out;
+}
+
+// ── settings-key ─────────────────────────────────────────────────────────
+
+function probeSettingsKey(item, ctx) {
+  const filePath = resolveConfigFile(item.probe.file, ctx);
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (_e) {
+    return { actual: 'absent', detail: `cannot read ${filePath}` };
+  }
+  let data;
+  try {
+    data = item.probe.file === '.env' ? parseDotEnv(raw) : JSON.parse(raw);
+  } catch (_e) {
+    return { actual: 'absent', detail: `cannot parse ${filePath}` };
+  }
+  const keys = item.probe.keys || [item.probe.key];
+  const getVal = item.probe.file === '.env' ? (k) => data[k] : (k) => getDotPath(data, k);
+  const missing = keys.filter((k) => !nonEmpty(getVal(k)));
+  if (missing.length === 0) return { actual: 'present', detail: filePath };
+  return { actual: 'absent', detail: `missing/empty key(s) in ${filePath}: ${missing.join(', ')}` };
+}
+
+// ── settings-hooks ───────────────────────────────────────────────────────
+
+// The himmel PreToolUse hook trio — see the module header comment for where
+// this is otherwise enumerated (wire-pretooluse-hooks.sh's dedup regex).
+const PRETOOLUSE_MARKERS = ['auto-approve-safe-bash', 'block-edit-on-main', 'block-read-secrets'];
+
+function collectHookCommands(hooksArray) {
+  const commands = [];
+  if (!Array.isArray(hooksArray)) return commands;
+  for (const stanza of hooksArray) {
+    if (stanza && Array.isArray(stanza.hooks)) {
+      for (const h of stanza.hooks) {
+        if (h && typeof h.command === 'string') commands.push(h.command);
+      }
+    }
+  }
+  return commands;
+}
+
+function probeSettingsHooks(item, ctx) {
+  const filePath = resolveConfigFile(item.probe.file, ctx);
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (_e) {
+    return { actual: 'absent', detail: `cannot read/parse ${filePath}` };
+  }
+  const commands = collectHookCommands(getDotPath(data, item.probe.key));
+  const found = PRETOOLUSE_MARKERS.filter((m) => commands.some((c) => c.indexOf(m) !== -1));
+  if (found.length === PRETOOLUSE_MARKERS.length) {
+    return { actual: 'present', detail: filePath };
+  }
+  if (found.length === 0) {
+    return { actual: 'absent', detail: `no himmel PreToolUse markers found in ${filePath}` };
+  }
+  const missing = PRETOOLUSE_MARKERS.filter((m) => found.indexOf(m) === -1);
+  return { actual: 'degraded', detail: `${found.length}/${PRETOOLUSE_MARKERS.length} himmel PreToolUse markers found in ${filePath} (missing: ${missing.join(', ')})` };
+}
+
+// ── shared spawn helper (probe hang guard) ──────────────────────────────
+
+// Bound every spawnSync-based probe (cmd:has_qmd, qmd-index, handover-dir —
+// each shells out to bash, which can hang if the sourced resolver script or
+// a downstream binary (qmd, bun) wedges): 10s timeout + SIGKILL so a hung
+// child can't block `status` forever. r.timedOut is set so callers can
+// surface a hang as actual:"degraded" instead of misreading it as a plain
+// negative ("absent") probe result.
+function spawnProbeSync(cmd, args, opts) {
+  const r = spawnSync(cmd, args, Object.assign({ timeout: 10000, killSignal: 'SIGKILL' }, opts));
+  r.timedOut = Boolean((r.error && r.error.code === 'ETIMEDOUT') || r.signal);
+  return r;
+}
+
+// ── cmd:has_qmd ──────────────────────────────────────────────────────────
+
+function probeCmdHasQmd(item, ctx) {
+  const resolverPath = path.resolve(ctx.repoRoot, item.probe.resolver);
+  const r = spawnProbeSync('bash', ['-c', `. "${resolverPath}" && has_qmd`], { env: ctx.env || process.env });
+  if (r.timedOut) return { actual: 'degraded', detail: 'cmd:has_qmd probe timed out after 10s' };
+  if (r.error) return { actual: 'absent', detail: `spawn error: ${r.error.message}` };
+  return r.status === 0
+    ? { actual: 'present', detail: 'has_qmd rc=0' }
+    : { actual: 'absent', detail: `has_qmd rc=${r.status}` };
+}
+
+// ── qmd-index ────────────────────────────────────────────────────────────
+
+function probeQmdIndex(item, ctx) {
+  const resolverPath = path.resolve(ctx.repoRoot, 'scripts/lib/qmd-bin.sh');
+  const collections = item.probe.collections;
+  const r = spawnProbeSync('bash', ['-c', `. "${resolverPath}" && has_qmd && qmd_cmd collection list`],
+    { env: ctx.env || process.env, encoding: 'utf8' });
+  if (r.timedOut) return { actual: 'degraded', detail: 'qmd-index probe timed out after 10s' };
+  if (r.error || r.status !== 0) {
+    return { actual: 'absent', detail: 'qmd absent or collection list failed' };
+  }
+  const listed = (r.stdout || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const isListed = (name) => listed.some((l) => l === name || l.indexOf(`${name} `) === 0 || l.indexOf(`${name}\t`) === 0);
+  const present = collections.filter(isListed);
+  if (present.length === collections.length) {
+    return { actual: 'present', detail: `all collections registered: ${collections.join(', ')}` };
+  }
+  if (present.length === 0) {
+    return { actual: 'absent', detail: 'no expected collections registered' };
+  }
+  const missing = collections.filter((c) => !isListed(c));
+  return { actual: 'degraded', detail: `${present.length}/${collections.length} collections registered (missing: ${missing.join(', ')})` };
+}
+
+// ── handover-dir ─────────────────────────────────────────────────────────
+
+function probeHandoverDir(item, ctx) {
+  const resolverPath = path.resolve(ctx.repoRoot, item.probe.resolver);
+  const cwd = ctx.targetPath || ctx.repoRoot;
+  const r = spawnProbeSync('bash', ['-c', `. "${resolverPath}" && handover_root`],
+    { env: ctx.env || process.env, cwd, encoding: 'utf8' });
+  if (r.timedOut) return { actual: 'degraded', detail: 'handover-dir probe timed out after 10s' };
+  if (!r.error && r.status === 0 && r.stdout && r.stdout.trim()) {
+    return { actual: 'present', detail: r.stdout.trim() };
+  }
+  return { actual: 'absent', detail: (r.stderr || '').trim() || 'handover_root did not resolve' };
+}
+
+// ── dep ──────────────────────────────────────────────────────────────────
+
+// which() (lib/helpers.js) reads process.env.PATH directly — a hermetic test
+// exercises this probe by setting PATH on the OUTER shell invocation (the
+// same convention as helpers.js itself and every sibling test-wizard-*.sh
+// suite), not by threading ctx.env through.
+function probeDep(item, ctx) {
+  const cmd = item.probe.cmd || (process.platform === 'win32' ? item.probe.win32 : item.probe.posix);
+  const found = which(cmd);
+  return found
+    ? { actual: 'present', detail: found }
+    : { actual: 'absent', detail: `'${cmd}' not found on PATH` };
+}
+
+// ── dispatch ─────────────────────────────────────────────────────────────
+
+const PROBES = {
+  'file-exists': probeFileExists,
+  'settings-key': probeSettingsKey,
+  'settings-hooks': probeSettingsHooks,
+  'cmd:has_qmd': probeCmdHasQmd,
+  'qmd-index': probeQmdIndex,
+  'handover-dir': probeHandoverDir,
+  dep: probeDep,
+};
+
+// Run the probe for one manifest item. ctx = { repoRoot, targetPath, scope,
+// env }. An unrecognized probe.type (should never happen — manifest-lint.mjs
+// gates the manifest itself) reads absent rather than throwing, so a single
+// bad item can't abort a whole probe sweep.
+function runProbe(item, ctx) {
+  const type = item.probe && item.probe.type;
+  const fn = PROBES[type];
+  if (!fn) return { actual: 'absent', detail: `unknown probe type '${type}'` };
+  return fn(item, ctx);
+}
+
+module.exports = { runProbe };

--- a/scripts/himmelctl/lib/state.js
+++ b/scripts/himmelctl/lib/state.js
@@ -1,0 +1,104 @@
+'use strict';
+// scripts/himmelctl/lib/state.js — target-keyed install state (HIMMEL-756
+// T1.3). Reads/writes <cacheDir()>/state.json, himmelctl's OWN record of
+// "what does this target look like right now" — a SEPARATE artifact from the
+// wizard's install-profile.json cache (the ANSWERS that drove an install),
+// which this module never reads or mutates directly (callers pass the
+// already-loaded answers object in).
+//
+// Shape:
+//   { schemaVersion: 1, harness: "claude", targets: {
+//       "<targetPathAbs>" | "user": {
+//         profile, scope, items: { <id>: { enabled, overrides } }, lastEnsured
+//       }
+//   } }
+//
+// Derivation (first run for a target with no entry) is PURE manifest
+// membership: profile = profileForVault(cachedAnswers) (lib/helpers.js), and
+// an item's enabled = item.profiles.includes(profile) &&
+// item.scopes.includes(scope) — with exactly ONE exception: `handover-wiring`
+// tracks cachedAnswers.handover.mode !== 'none' directly (membership alone
+// can't see whether handover was actually wired). No role/pluginSet
+// branching here — explicitly Phase 2 (a later HIMMEL-756 follow-on).
+//
+// HIMMELCTL_CACHE_DIR overrides the cache dir (see lib/helpers.js) — the same
+// seam hermetic tests use to redirect ~/.claude/himmel/ under Git Bash, where
+// HOME does not propagate into node.exe children.
+
+const fs = require('fs');
+const path = require('path');
+const { cacheDir, profileForVault } = require('./helpers.js');
+
+function statePath() {
+  return path.join(cacheDir(), 'state.json');
+}
+
+function emptyState() {
+  return { schemaVersion: 1, harness: 'claude', targets: {} };
+}
+
+// Load the on-disk state, or an empty schema-shaped default when no
+// state.json exists yet (first run). A malformed file surfaces its parse
+// error to the caller rather than silently resetting to empty — state.json
+// is himmelctl's own artifact, and a corrupt copy should be investigated,
+// not discarded.
+function load() {
+  const p = statePath();
+  if (!fs.existsSync(p)) return emptyState();
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+// Persist `state` via atomic temp-file + rename — mirrors
+// scripts/lib/register-auto-arm-hook.sh's `$SETTINGS.tmp` + `mv` pattern for
+// settings.json, so a crash mid-write never leaves a truncated state.json.
+// 2-space indent + trailing newline (matches bin.js's serialize()); a saved
+// state.json round-trips byte-identically across repeated saves of the same
+// object (JS objects preserve string-key insertion order, so re-stringifying
+// a just-parsed object reproduces the same key order it was read in).
+function save(state) {
+  const dir = cacheDir();
+  fs.mkdirSync(dir, { recursive: true });
+  const p = statePath();
+  const tmp = `${p}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2) + '\n');
+  fs.renameSync(tmp, p);
+}
+
+// The state.targets key for a given scope: project scope keys off the
+// current project directory (absolute — mirrors bin.js's
+// settingsPathForScope()/adopt.sh's own --target default of $PWD, since
+// install-profile.json itself carries no per-project target path); user
+// scope is always the literal string "user".
+function targetKeyForScope(scope) {
+  return scope === 'user' ? 'user' : path.resolve(process.cwd());
+}
+
+// Derive a fresh target entry from the manifest + cached wizard answers.
+// Pure — never reads or writes state.json, never touches install-profile.json.
+function deriveTarget(manifest, cachedAnswers) {
+  const profile = profileForVault(cachedAnswers);
+  const scope = cachedAnswers.scope;
+  const items = {};
+  for (const item of manifest.items) {
+    let enabled = item.profiles.includes(profile) && item.scopes.includes(scope);
+    if (item.id === 'handover-wiring') {
+      enabled = Boolean(cachedAnswers.handover) && cachedAnswers.handover.mode !== 'none';
+    }
+    items[item.id] = { enabled, overrides: {} };
+  }
+  return { profile, scope, items, lastEnsured: null };
+}
+
+// Add the derived entry for this target if missing; return the (possibly
+// pre-existing) entry either way. Never overwrites an existing entry — a
+// target that already has state is left alone (re-deriving/repairing belongs
+// to a later reconcile path, not this first-run seam).
+function ensureTarget(state, manifest, cachedAnswers) {
+  const key = targetKeyForScope(cachedAnswers.scope);
+  if (!state.targets[key]) {
+    state.targets[key] = deriveTarget(manifest, cachedAnswers);
+  }
+  return state.targets[key];
+}
+
+module.exports = { load, save, deriveTarget, ensureTarget };

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -1,0 +1,543 @@
+#!/usr/bin/env bash
+# test-wizard-probes.sh — hermetic tests for scripts/himmelctl/lib/probes.js
+# (HIMMEL-756 T1.4): the seven-probe-type engine, run against the REAL
+# scripts/install/manifest.json descriptors (so a manifest authoring drift
+# breaks THIS suite, not silently). Mirrors sibling test-wizard-*.sh
+# conventions: scripts/lib/hermetic-path.sh's link_hermetic_tool/scrub_path
+# for curated stub PATHs, node launched by absolute path, winpath for
+# node.exe's MSYS-path blindness.
+#
+# Covers, present AND absent (plus degraded where the probe type supports a
+# tri-state result):
+#   file-exists    targetPath-relative (guardrail-scope), the repoRoot-
+#                  relative exception (jira-cli-dist-build — proves it
+#                  ignores a targetPath that DOES carry the file), and the
+#                  {vaultPath} placeholder (luna-vault-scaffold).
+#   settings-key   dot-path single key (wiring-statusline), simple
+#                  non-dotted key (claude-plugins-pluginSet), and the .env
+#                  ALL-keys-required union resolving against repoRoot for
+#                  BOTH scopes (jira-env-keys).
+#   settings-hooks present (all 3 himmel PreToolUse markers) / degraded
+#                  (1 of 3) / absent (none) (wiring-pretooluse).
+#   cmd:has_qmd    qmd-binary, via a stubbed `qmd` on PATH.
+#   qmd-index      present (all 4 collections) / degraded (2 of 4) / absent
+#                  (no qmd on PATH).
+#   handover-dir   handover-wiring — HANDOVER_DIR set (ctx.env pass-through,
+#                  not process.env mutation) / unset with a non-repo cwd.
+#   dep            single-cmd (rtk) and the win32/posix platform union
+#                  (scheduler-backend), each present/absent via stub PATH.
+#   purity         a full sweep over every manifest.json item leaves the
+#                  fixture repo + vault trees byte-identical (sha256
+#                  snapshot before/after).
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+probes_lib="$repo_root/scripts/himmelctl/lib/probes.js"
+manifest_path="$repo_root/scripts/install/manifest.json"
+[ -f "$probes_lib" ] || { echo "FAIL: $probes_lib not found" >&2; exit 1; }
+[ -f "$manifest_path" ] || { echo "FAIL: $manifest_path not found" >&2; exit 1; }
+command -v node >/dev/null 2>&1 || { echo "FAIL: node required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq required" >&2; exit 1; }
+command -v sha256sum >/dev/null 2>&1 || { echo "FAIL: sha256sum required" >&2; exit 1; }
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+node_bin=$(command -v node)
+
+# shellcheck source=lib/hermetic-path.sh
+# shellcheck disable=SC1091
+. "$repo_root/scripts/lib/hermetic-path.sh"
+
+work=$(mktemp -d)
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT
+
+# winpath <path> — echo <path> unchanged on posix, or its Windows form on
+# git-bash/MSYS/Cygwin (node.exe misresolves MSYS /tmp-style paths).
+winpath() {
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) cygpath -m "$1" 2>/dev/null || printf '%s' "$1" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+is_win32() {
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# build_path <stub_dir> <present_tools...> -- <absent_tools...> (copied from
+# the sibling suites: link the named present tools off the CURRENT PATH into
+# <stub_dir>, then echo a PATH with the stub prepended and the named absent
+# tools scrubbed).
+build_path() {
+  local _stub="$1"; shift
+  local _present=() _absent=() _stage=0 _t
+  for _t in "$@"; do
+    if [ "$_t" = "--" ]; then _stage=1; continue; fi
+    if [ "$_stage" -eq 0 ]; then _present+=("$_t"); else _absent+=("$_t"); fi
+  done
+  for _t in "${_present[@]}"; do
+    link_hermetic_tool "$_t" "$_stub"
+  done
+  local _scrubbed="$PATH"
+  if [ "${#_absent[@]}" -gt 0 ]; then
+    _scrubbed=$(scrub_path "$PATH" "${_absent[@]}")
+  fi
+  printf '%s:%s' "$_stub" "$_scrubbed"
+}
+
+# snapshot_dir <dir> — sorted "relpath sha256" pairs, for a before/after
+# byte-identity check that doesn't depend on tar's metadata quirks. Portable
+# across bash 3.2 + BSD sort (no -z/-print0/xargs -0 on macOS's base sort).
+snapshot_dir() {
+  ( cd "$1" && find . -type f | LC_ALL=C sort | while IFS= read -r f; do sha256sum "$f"; done )
+}
+
+probes_lib_w="$(winpath "$probes_lib")"
+manifest_w="$(winpath "$manifest_path")"
+repo_root_w="$(winpath "$repo_root")"
+
+# ── file-exists: targetPath-relative (guardrail-scope) ──────────────────────
+feA_present="$work/feA-present"; mkdir -p "$feA_present/scripts/guardrails"
+: > "$feA_present/scripts/guardrails/lib.sh"
+feA_absent="$work/feA-absent"; mkdir -p "$feA_absent"
+
+outA1=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-scope');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$(winpath "$feA_present")', scope: 'project', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outA1" | jq -e '.actual == "present"' >/dev/null || fail "file-exists targetPath-relative present: (got: $outA1)"
+outA2=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-scope');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$(winpath "$feA_absent")', scope: 'project', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outA2" | jq -e '.actual == "absent"' >/dev/null || fail "file-exists targetPath-relative absent: (got: $outA2)"
+echo "ok: file-exists targetPath-relative (guardrail-scope) present/absent"
+
+# ── file-exists: repoRoot-relative exception (jira-cli-dist-build) ─────────
+# The target ALSO carries the file, at the identical relative path — proves
+# the probe resolves against repoRoot, not targetPath, for this item.
+feB_repo_absent="$work/feB-repo-absent"; mkdir -p "$feB_repo_absent"
+feB_repo_present="$work/feB-repo-present"; mkdir -p "$feB_repo_present/scripts/jira/dist"
+: > "$feB_repo_present/scripts/jira/dist/index.js"
+feB_target_with_file="$work/feB-target"; mkdir -p "$feB_target_with_file/scripts/jira/dist"
+: > "$feB_target_with_file/scripts/jira/dist/index.js"
+
+outB1=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'jira-cli-dist-build');
+const ctx = { repoRoot: '$(winpath "$feB_repo_absent")', targetPath: '$(winpath "$feB_target_with_file")', scope: 'project', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outB1" | jq -e '.actual == "absent"' >/dev/null \
+  || fail "file-exists repoRoot-relative exception: expected absent (repoRoot lacks the file even though targetPath has it) (got: $outB1)"
+outB2=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'jira-cli-dist-build');
+const ctx = { repoRoot: '$(winpath "$feB_repo_present")', targetPath: '$(winpath "$work/feB-nonexistent-target")', scope: 'project', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outB2" | jq -e '.actual == "present"' >/dev/null \
+  || fail "file-exists repoRoot-relative exception: expected present (repoRoot has the file; targetPath doesn't exist at all) (got: $outB2)"
+echo "ok: file-exists repoRoot-relative exception (jira-cli-dist-build) ignores targetPath"
+
+# ── file-exists: {vaultPath} placeholder (luna-vault-scaffold) ─────────────
+feC_present="$work/feC-vault-present"; mkdir -p "$feC_present"
+: > "$feC_present/.vault-template.json"
+feC_absent="$work/feC-vault-absent"; mkdir -p "$feC_absent"
+
+outC1=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'luna-vault-scaffold');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$(winpath "$feC_present")', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outC1" | jq -e '.actual == "present"' >/dev/null || fail "file-exists {vaultPath} present: (got: $outC1)"
+outC2=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'luna-vault-scaffold');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$(winpath "$feC_absent")', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outC2" | jq -e '.actual == "absent"' >/dev/null || fail "file-exists {vaultPath} absent: (got: $outC2)"
+echo "ok: file-exists {vaultPath} placeholder (luna-vault-scaffold) present/absent"
+
+# ── settings-key: dot-path single key (wiring-statusline) ─────────────────
+sk1_present="$work/sk1-present"; mkdir -p "$sk1_present/.claude"
+printf '{"statusLine":{"command":"bash foo.sh"}}' > "$sk1_present/.claude/settings.json"
+sk1_absent="$work/sk1-absent"; mkdir -p "$sk1_absent/.claude"
+printf '{"statusLine":{}}' > "$sk1_absent/.claude/settings.json"
+
+outSK1p=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'wiring-statusline');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$(winpath "$sk1_present")', scope: 'project', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outSK1p" | jq -e '.actual == "present"' >/dev/null || fail "settings-key dot-path present: (got: $outSK1p)"
+outSK1a=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'wiring-statusline');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$(winpath "$sk1_absent")', scope: 'project', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outSK1a" | jq -e '.actual == "absent"' >/dev/null || fail "settings-key dot-path absent: (got: $outSK1a)"
+echo "ok: settings-key dot-path single key (wiring-statusline) present/absent"
+
+# ── settings-key: simple non-dotted key (claude-plugins-pluginSet) ─────────
+sk2_present="$work/sk2-present"; mkdir -p "$sk2_present/.claude"
+printf '{"enabledPlugins":{"foo@bar":true}}' > "$sk2_present/.claude/settings.json"
+sk2_absent="$work/sk2-absent"; mkdir -p "$sk2_absent/.claude"
+printf '{"enabledPlugins":{}}' > "$sk2_absent/.claude/settings.json"
+
+outSK2p=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'claude-plugins-pluginSet');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$(winpath "$sk2_present")', scope: 'project', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outSK2p" | jq -e '.actual == "present"' >/dev/null || fail "settings-key simple key present: (got: $outSK2p)"
+outSK2a=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'claude-plugins-pluginSet');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$(winpath "$sk2_absent")', scope: 'project', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outSK2a" | jq -e '.actual == "absent"' >/dev/null || fail "settings-key simple key absent (empty object): (got: $outSK2a)"
+echo "ok: settings-key simple non-dotted key (claude-plugins-pluginSet) present/absent"
+
+# ── settings-key: .env ALL-keys-required union (jira-env-keys) ────────────
+# Resolves against repoRoot for BOTH scopes (CLAUDE.md / adopt.sh
+# fill_env_core convention) — proven by using scope 'user' here too.
+sk3_repo_present="$work/sk3-repo-present"; mkdir -p "$sk3_repo_present"
+cat > "$sk3_repo_present/.env" <<'ENV'
+JIRA_BASE_URL=https://example.atlassian.net
+JIRA_EMAIL=me@example.com
+JIRA_API_TOKEN=tok123
+JIRA_PROJECT_KEY=HIMMEL
+ENV
+sk3_repo_missing="$work/sk3-repo-missing"; mkdir -p "$sk3_repo_missing"
+cat > "$sk3_repo_missing/.env" <<'ENV'
+JIRA_BASE_URL=https://example.atlassian.net
+JIRA_EMAIL=me@example.com
+JIRA_PROJECT_KEY=HIMMEL
+ENV
+
+outSK3p=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'jira-env-keys');
+const ctx = { repoRoot: '$(winpath "$sk3_repo_present")', targetPath: '$repo_root_w', scope: 'project', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outSK3p" | jq -e '.actual == "present"' >/dev/null || fail "settings-key .env all-keys present: (got: $outSK3p)"
+outSK3a=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'jira-env-keys');
+const ctx = { repoRoot: '$(winpath "$sk3_repo_missing")', targetPath: '$repo_root_w', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outSK3a" | jq -e '.actual == "absent"' >/dev/null || fail "settings-key .env missing-one-key absent: (got: $outSK3a)"
+echo "$outSK3a" | jq -e '.detail | contains("JIRA_API_TOKEN")' >/dev/null \
+  || fail "settings-key .env absent detail should name the missing key JIRA_API_TOKEN (got: $outSK3a)"
+echo "ok: settings-key .env ALL-keys-required (jira-env-keys), resolves against repoRoot for both scopes"
+
+# ── settings-hooks: present (3/3) / degraded (1/3) / absent (0) ────────────
+sh_present="$work/sh-present"; mkdir -p "$sh_present/.claude"
+cat > "$sh_present/.claude/settings.json" <<'JSON'
+{"hooks":{"PreToolUse":[
+  {"matcher":"Bash","hooks":[{"type":"command","command":"bash \"/x/scripts/hooks/auto-approve-safe-bash.sh\""}]},
+  {"matcher":"Edit","hooks":[{"type":"command","command":"bash \"/x/scripts/hooks/block-edit-on-main.sh\""}]},
+  {"matcher":"Read","hooks":[{"type":"command","command":"bash \"/x/scripts/hooks/block-read-secrets.sh\""}]}
+]}}
+JSON
+sh_degraded="$work/sh-degraded"; mkdir -p "$sh_degraded/.claude"
+cat > "$sh_degraded/.claude/settings.json" <<'JSON'
+{"hooks":{"PreToolUse":[
+  {"matcher":"Bash","hooks":[{"type":"command","command":"bash \"/x/scripts/hooks/auto-approve-safe-bash.sh\""}]}
+]}}
+JSON
+sh_absent="$work/sh-absent"; mkdir -p "$sh_absent/.claude"
+printf '{"hooks":{"PreToolUse":[]}}' > "$sh_absent/.claude/settings.json"
+
+outSHp=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'wiring-pretooluse');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$(winpath "$sh_present")', scope: 'project', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outSHp" | jq -e '.actual == "present"' >/dev/null || fail "settings-hooks present (3/3): (got: $outSHp)"
+outSHd=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'wiring-pretooluse');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$(winpath "$sh_degraded")', scope: 'project', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outSHd" | jq -e '.actual == "degraded"' >/dev/null || fail "settings-hooks degraded (1/3): (got: $outSHd)"
+echo "$outSHd" | jq -e '.detail | contains("block-edit-on-main")' >/dev/null \
+  || fail "settings-hooks degraded detail should name a missing marker (got: $outSHd)"
+outSHa=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'wiring-pretooluse');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$(winpath "$sh_absent")', scope: 'project', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outSHa" | jq -e '.actual == "absent"' >/dev/null || fail "settings-hooks absent (0/3): (got: $outSHa)"
+echo "ok: settings-hooks (wiring-pretooluse) present/degraded/absent"
+
+# ── cmd:has_qmd (qmd-binary) ────────────────────────────────────────────────
+hq_present_stub="$work/hq-present-bin"; mkdir -p "$hq_present_stub"
+pathHQpresent=$(build_path "$hq_present_stub" bash git jq -- bun)
+cat > "$hq_present_stub/qmd" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$hq_present_stub/qmd"
+
+outHQp=$(PATH="$pathHQpresent" "$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'qmd-binary');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outHQp" | jq -e '.actual == "present"' >/dev/null || fail "cmd:has_qmd present: (got: $outHQp)"
+
+hq_absent_stub="$work/hq-absent-bin"; mkdir -p "$hq_absent_stub"
+pathHQabsent=$(build_path "$hq_absent_stub" bash git jq -- bun qmd)
+outHQa=$(PATH="$pathHQabsent" "$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'qmd-binary');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outHQa" | jq -e '.actual == "absent"' >/dev/null || fail "cmd:has_qmd absent: (got: $outHQa)"
+echo "ok: cmd:has_qmd (qmd-binary) present/absent"
+
+# ── qmd-index: present (4/4) / degraded (2/4) / absent (no qmd) ───────────
+qi_present_stub="$work/qi-present-bin"; mkdir -p "$qi_present_stub"
+pathQIpresent=$(build_path "$qi_present_stub" bash git jq -- bun)
+cat > "$qi_present_stub/qmd" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "collection" ] && [ "$2" = "list" ]; then
+  printf 'himmel\nluna\n'
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$qi_present_stub/qmd"
+outQIp=$(PATH="$pathQIpresent" "$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'qmd-index');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outQIp" | jq -e '.actual == "present"' >/dev/null || fail "qmd-index present (4/4): (got: $outQIp)"
+
+qi_degraded_stub="$work/qi-degraded-bin"; mkdir -p "$qi_degraded_stub"
+pathQIdegraded=$(build_path "$qi_degraded_stub" bash git jq -- bun)
+cat > "$qi_degraded_stub/qmd" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "collection" ] && [ "$2" = "list" ]; then
+  printf 'himmel\n'
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$qi_degraded_stub/qmd"
+outQId=$(PATH="$pathQIdegraded" "$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'qmd-index');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outQId" | jq -e '.actual == "degraded"' >/dev/null || fail "qmd-index degraded (2/4): (got: $outQId)"
+echo "$outQId" | jq -e '.detail | contains("luna")' >/dev/null \
+  || fail "qmd-index degraded detail should name a missing collection (got: $outQId)"
+
+qi_absent_stub="$work/qi-absent-bin"; mkdir -p "$qi_absent_stub"
+pathQIabsent=$(build_path "$qi_absent_stub" bash git jq -- bun qmd)
+outQIa=$(PATH="$pathQIabsent" "$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'qmd-index');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outQIa" | jq -e '.actual == "absent"' >/dev/null || fail "qmd-index absent (no qmd on PATH): (got: $outQIa)"
+echo "ok: qmd-index present/degraded/absent"
+
+# ── handover-dir (handover-wiring) ──────────────────────────────────────────
+hd_present_dir="$work/hd-present-handoverdir"; mkdir -p "$hd_present_dir"
+outHDp=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'handover-wiring');
+const env = Object.assign({}, process.env, { HANDOVER_DIR: '$(winpath "$hd_present_dir")' });
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'project', env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outHDp" | jq -e '.actual == "present"' >/dev/null || fail "handover-dir present (HANDOVER_DIR set via ctx.env): (got: $outHDp)"
+
+hd_absent_cwd="$work/hd-absent-not-a-repo"; mkdir -p "$hd_absent_cwd"
+outHDa=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'handover-wiring');
+const env = Object.assign({}, process.env);
+delete env.HANDOVER_DIR;
+const ctx = { repoRoot: '$(winpath "$hd_absent_cwd")', targetPath: '$(winpath "$hd_absent_cwd")', scope: 'project', env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outHDa" | jq -e '.actual == "absent"' >/dev/null \
+  || fail "handover-dir absent (HANDOVER_DIR unset, cwd not a git repo, no inline handovers/): (got: $outHDa)"
+echo "ok: handover-dir (handover-wiring) present/absent, exercising ctx.env pass-through"
+
+# ── dep: single-cmd (rtk) ────────────────────────────────────────────────────
+dep_present_stub="$work/dep-present-bin"; mkdir -p "$dep_present_stub"
+pathDeppresent=$(build_path "$dep_present_stub" bash git jq -- rtk)
+cat > "$dep_present_stub/rtk" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$dep_present_stub/rtk"
+outDepP=$(PATH="$pathDeppresent" "$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'rtk');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outDepP" | jq -e '.actual == "present"' >/dev/null || fail "dep single-cmd (rtk) present: (got: $outDepP)"
+
+dep_absent_stub="$work/dep-absent-bin"; mkdir -p "$dep_absent_stub"
+pathDepabsent=$(build_path "$dep_absent_stub" bash git jq -- rtk)
+outDepA=$(PATH="$pathDepabsent" "$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'rtk');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outDepA" | jq -e '.actual == "absent"' >/dev/null || fail "dep single-cmd (rtk) absent: (got: $outDepA)"
+echo "ok: dep single-cmd (rtk) present/absent"
+
+# ── dep: win32/posix platform union (scheduler-backend) ────────────────────
+if is_win32; then sched_name="schtasks"; else sched_name="at"; fi
+
+dep_sched_present="$work/dep-sched-present-bin"; mkdir -p "$dep_sched_present"
+pathSchedPresent=$(build_path "$dep_sched_present" bash git jq -- "$sched_name")
+cat > "$dep_sched_present/$sched_name" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$dep_sched_present/$sched_name"
+outSchedP=$(PATH="$pathSchedPresent" "$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'scheduler-backend');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outSchedP" | jq -e '.actual == "present"' >/dev/null \
+  || fail "dep platform-branch (scheduler-backend, $sched_name) present: (got: $outSchedP)"
+
+dep_sched_absent="$work/dep-sched-absent-bin"; mkdir -p "$dep_sched_absent"
+pathSchedAbsent=$(build_path "$dep_sched_absent" bash git jq -- "$sched_name")
+outSchedA=$(PATH="$pathSchedAbsent" "$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'scheduler-backend');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outSchedA" | jq -e '.actual == "absent"' >/dev/null \
+  || fail "dep platform-branch (scheduler-backend, $sched_name) absent: (got: $outSchedA)"
+echo "ok: dep platform-branch (scheduler-backend) picks '$sched_name' on this platform, present/absent"
+
+# ── purity: full sweep over every manifest item, fixture tree byte-identical ─
+purity_root="$work/purity-repo"
+mkdir -p "$purity_root/scripts/jira/dist" "$purity_root/scripts/bitbucket/dist" \
+  "$purity_root/scripts/guardrails" "$purity_root/scripts/lanes" "$purity_root/scripts/telegram" \
+  "$purity_root/scripts/graphify" "$purity_root/scripts/lib" "$purity_root/handovers" "$purity_root/.claude"
+: > "$purity_root/scripts/jira/dist/index.js"
+: > "$purity_root/scripts/bitbucket/dist/index.js"
+: > "$purity_root/scripts/guardrails/lib.sh"
+: > "$purity_root/scripts/lanes/lanes.json"
+: > "$purity_root/scripts/telegram/telegram-api.ts"
+: > "$purity_root/scripts/graphify/check-graph-freshness.sh"
+: > "$purity_root/scripts/lib/doc-guard-map.sh"
+: > "$purity_root/.pre-commit-config.yaml"
+cat > "$purity_root/.env" <<'ENV'
+JIRA_BASE_URL=https://example.atlassian.net
+JIRA_EMAIL=me@example.com
+JIRA_API_TOKEN=tok123
+JIRA_PROJECT_KEY=HIMMEL
+ENV
+cat > "$purity_root/.claude/settings.json" <<'JSON'
+{"statusLine":{"command":"bash foo.sh"},"enabledPlugins":{"foo@bar":true},
+ "hooks":{"PreToolUse":[
+   {"matcher":"Bash","hooks":[{"type":"command","command":"bash \"/x/scripts/hooks/auto-approve-safe-bash.sh\""}]},
+   {"matcher":"Edit","hooks":[{"type":"command","command":"bash \"/x/scripts/hooks/block-edit-on-main.sh\""}]},
+   {"matcher":"Read","hooks":[{"type":"command","command":"bash \"/x/scripts/hooks/block-read-secrets.sh\""}]}
+ ]}}
+JSON
+purity_vault="$work/purity-vault"; mkdir -p "$purity_vault"
+: > "$purity_vault/.vault-template.json"
+
+purity_before=$(snapshot_dir "$purity_root")
+purity_vault_before=$(snapshot_dir "$purity_vault")
+
+sweepOut=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const repoRoot = '$(winpath "$purity_root")';
+const targetPath = '$(winpath "$purity_root")';
+const vaultPath = '$(winpath "$purity_vault")';
+const results = [];
+for (const item of manifest.items) {
+  const scope = item.scopes.includes('project') ? 'project' : 'user';
+  const tp = item.id === 'luna-vault-scaffold' ? vaultPath : targetPath;
+  const ctx = { repoRoot, targetPath: tp, scope, env: process.env };
+  results.push(Object.assign({ id: item.id }, runProbe(item, ctx)));
+}
+console.log(JSON.stringify(results));
+")
+
+purity_after=$(snapshot_dir "$purity_root")
+purity_vault_after=$(snapshot_dir "$purity_vault")
+
+[ "$purity_before" = "$purity_after" ] || fail "purity: fixture repo/target tree was mutated by the probe sweep"
+[ "$purity_vault_before" = "$purity_vault_after" ] || fail "purity: fixture vault tree was mutated by the probe sweep"
+
+sweepCount=$(echo "$sweepOut" | jq 'length')
+manifestCount=$(jq '.items | length' "$manifest_path")
+[ "$sweepCount" -eq "$manifestCount" ] || fail "purity: expected $manifestCount probe results (one per manifest item), got $sweepCount"
+echo "ok: purity — full probe sweep over all $manifestCount manifest items left every fixture tree byte-identical"
+
+echo "PASS"

--- a/scripts/himmelctl/test/test-wizard-state.sh
+++ b/scripts/himmelctl/test/test-wizard-state.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# test-wizard-state.sh — hermetic tests for scripts/himmelctl/lib/state.js
+# (HIMMEL-756 T1.3): target-keyed install state derived from the manifest +
+# the wizard's cached install-profile answers. Mirrors sibling test-wizard-*
+# suites: a fake HOME + HIMMELCTL_CACHE_DIR so nothing touches the real
+# ~/.claude/himmel/, node launched by absolute path, winpath for node.exe's
+# MSYS-path blindness. state.js has no shell-out surface (pure fs read/write
+# against HIMMELCTL_CACHE_DIR), so no HIMMELCTL_REPO_ROOT fixture is needed —
+# the REAL scripts/install/manifest.json is read (read-only reference, safe).
+#
+# Covers:
+#   A. deriveTarget() — role=adopter, vault.mode=default-template (profile
+#      "all"), scope=project: the golden-six manifest items (all∈profiles,
+#      project∈scopes) are enabled:true; handover-wiring tracks
+#      handover.mode (external -> true, none -> false) independent of
+#      manifest membership.
+#   B. ensureTarget() — one project target + one "user" target coexist in
+#      the same state object with no key collision.
+#   C. save()/load() round-trip byte-stably across two saves.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+state_lib="$repo_root/scripts/himmelctl/lib/state.js"
+manifest_path="$repo_root/scripts/install/manifest.json"
+[ -f "$state_lib" ] || { echo "FAIL: $state_lib not found" >&2; exit 1; }
+[ -f "$manifest_path" ] || { echo "FAIL: $manifest_path not found" >&2; exit 1; }
+command -v node >/dev/null 2>&1 || { echo "FAIL: node required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq required" >&2; exit 1; }
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+node_bin=$(command -v node)
+
+work=$(mktemp -d)
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT
+
+# winpath <path> — echo <path> unchanged on posix, or its Windows form on
+# git-bash/MSYS/Cygwin (node.exe misresolves MSYS /tmp-style paths).
+winpath() {
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) cygpath -m "$1" 2>/dev/null || printf '%s' "$1" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+state_lib_w="$(winpath "$state_lib")"
+manifest_w="$(winpath "$manifest_path")"
+
+# ── Case A: deriveTarget() — golden-six + handover-wiring exception ────────
+caseA_dir="$work/caseA-target"; mkdir -p "$caseA_dir"
+homeA="$work/homeA"; mkdir -p "$homeA"
+cacheA="$work/cacheA"
+
+out=$(cd "$caseA_dir" && HOME="$homeA" HIMMELCTL_CACHE_DIR="$(winpath "$cacheA")" "$node_bin" -e "
+const state = require('$state_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const answers = {
+  role: 'adopter', tier: 'standard', scope: 'project',
+  vault: { mode: 'default-template', path: '~/vault' },
+  handover: { mode: 'external', path: '~/h' },
+  pluginSet: 'lean', lanes: [], alwaysOn: false,
+};
+console.log(JSON.stringify(state.deriveTarget(manifest, answers)));
+")
+
+echo "$out" | jq -e '.profile == "all"' >/dev/null || fail "caseA: profile should be 'all' (got: $out)"
+echo "$out" | jq -e '.scope == "project"' >/dev/null || fail "caseA: scope should be 'project' (got: $out)"
+for id in pre-commit-hooks wiring-pretooluse wiring-statusline jira-cli-dist-build bitbucket-cli-build guardrail-scope; do
+  echo "$out" | jq -e --arg id "$id" '.items[$id].enabled == true' >/dev/null \
+    || fail "caseA: golden item '$id' should be enabled:true (got: $out)"
+done
+echo "$out" | jq -e '.items["handover-wiring"].enabled == true' >/dev/null \
+  || fail "caseA: handover-wiring should be enabled:true when handover.mode=external (got: $out)"
+echo "ok: caseA golden-six items + handover-wiring(external) all enabled:true"
+
+outNone=$(cd "$caseA_dir" && HOME="$homeA" HIMMELCTL_CACHE_DIR="$(winpath "$cacheA")" "$node_bin" -e "
+const state = require('$state_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const answers = {
+  role: 'adopter', tier: 'standard', scope: 'project',
+  vault: { mode: 'default-template', path: '~/vault' },
+  handover: { mode: 'none', path: '' },
+  pluginSet: 'lean', lanes: [], alwaysOn: false,
+};
+console.log(JSON.stringify(state.deriveTarget(manifest, answers)));
+")
+echo "$outNone" | jq -e '.items["handover-wiring"].enabled == false' >/dev/null \
+  || fail "caseA: handover-wiring should be enabled:false when handover.mode=none (got: $outNone)"
+echo "ok: caseA handover-wiring(none) -> disabled"
+
+# ── Case B: ensureTarget() — project + user targets coexist, no collision ──
+caseB_dir="$work/caseB-project"; mkdir -p "$caseB_dir"
+homeB="$work/homeB"; mkdir -p "$homeB"
+cacheB="$work/cacheB"
+
+outB=$(cd "$caseB_dir" && HOME="$homeB" HIMMELCTL_CACHE_DIR="$(winpath "$cacheB")" "$node_bin" -e "
+const state = require('$state_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const projectAnswers = { role:'adopter', tier:'standard', scope:'project', vault:{mode:'none',path:''}, handover:{mode:'inline',path:''}, pluginSet:'lean', lanes:[], alwaysOn:false };
+const userAnswers = { role:'adopter', tier:'standard', scope:'user', vault:{mode:'none',path:''}, handover:{mode:'inline',path:''}, pluginSet:'lean', lanes:[], alwaysOn:false };
+let s = state.load();
+state.ensureTarget(s, manifest, projectAnswers);
+state.ensureTarget(s, manifest, userAnswers);
+state.save(s);
+console.log(JSON.stringify(s));
+")
+
+keysCount=$(echo "$outB" | jq '.targets | keys | length')
+[ "$keysCount" -eq 2 ] || fail "caseB: expected exactly 2 target keys (got $keysCount): $outB"
+echo "$outB" | jq -e '.targets["user"]' >/dev/null || fail "caseB: missing the literal 'user' target key (got: $outB)"
+echo "$outB" | jq -e '.targets["user"].scope == "user"' >/dev/null \
+  || fail "caseB: 'user' target entry should have scope 'user' (got: $outB)"
+echo "$outB" | jq -e '[.targets | to_entries[] | select(.key != "user")][0].value.scope == "project"' >/dev/null \
+  || fail "caseB: the non-'user' target entry should have scope 'project' (got: $outB)"
+echo "ok: caseB project + 'user' targets coexist in one state object, no key collision"
+
+# ── Case C: save()/load() round-trip byte-stably across two saves ──────────
+caseC_dir="$work/caseC-target"; mkdir -p "$caseC_dir"
+homeC="$work/homeC"; mkdir -p "$homeC"
+cacheC="$work/cacheC"
+
+(cd "$caseC_dir" && HOME="$homeC" HIMMELCTL_CACHE_DIR="$(winpath "$cacheC")" "$node_bin" -e "
+const state = require('$state_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const answers = { role:'adopter', tier:'standard', scope:'project', vault:{mode:'none',path:''}, handover:{mode:'inline',path:''}, pluginSet:'lean', lanes:[], alwaysOn:false };
+let s = state.load();
+state.ensureTarget(s, manifest, answers);
+state.save(s);
+")
+statePathC="$cacheC/state.json"
+[ -f "$statePathC" ] || fail "caseC: state.json was not written at $statePathC"
+cp "$statePathC" "$work/state-save1.json"
+
+(cd "$caseC_dir" && HOME="$homeC" HIMMELCTL_CACHE_DIR="$(winpath "$cacheC")" "$node_bin" -e "
+const state = require('$state_lib_w');
+let s = state.load();
+state.save(s);
+")
+cmp -s "$work/state-save1.json" "$statePathC" \
+  || fail "caseC: state.json should round-trip byte-identically across two saves"
+echo "ok: caseC write->read round-trips byte-stably across two saves"
+
+echo "PASS"

--- a/scripts/himmelctl/test/test-wizard-status-cmd.sh
+++ b/scripts/himmelctl/test/test-wizard-status-cmd.sh
@@ -69,7 +69,7 @@ JSON
 # snapshot_dir <dir> — sorted "relpath sha256" pairs, for a before/after
 # byte-identity check that doesn't depend on tar's metadata quirks.
 snapshot_dir() {
-  ( cd "$1" && find . -type f -print0 | sort -z | xargs -0 sha256sum )
+  ( cd "$1" && find . -type f | LC_ALL=C sort | while IFS= read -r f; do sha256sum "$f"; done )
 }
 
 # ── shared fixture repo root (HIMMELCTL_REPO_ROOT) ──────────────────────────

--- a/scripts/himmelctl/test/test-wizard-status-cmd.sh
+++ b/scripts/himmelctl/test/test-wizard-status-cmd.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# test-wizard-status-cmd.sh — hermetic tests for the himmelctl `status`
+# subcommand (HIMMEL-756 T1.5/T1.6): the severity-grouped diff between
+# desired (state.js-derived) and actual (probes.js) per manifest item, plus
+# its stable --json mode. Mirrors sibling test-wizard-*.sh conventions: a
+# fake HOME + HIMMELCTL_CACHE_DIR + HIMMELCTL_REPO_ROOT fixture, node
+# launched by absolute path, winpath for node.exe's MSYS-path blindness.
+# `status` never prompts (no readline anywhere in its code path) and never
+# shells out to a stub-able installer, so — unlike test-wizard-derive.sh —
+# there is no install/uninstall script stub to fake; the fixture only needs
+# a real copy of scripts/install/manifest.json plus the handful of files
+# the chosen probe set reads.
+#
+# Covers:
+#   a. `status --help` / bare `--help` both list the status subcommand.
+#   b. a fixture with a known-missing enabled item (pre-commit-hooks: no
+#      .pre-commit-config.yaml in the target) reads severity red, exit 0,
+#      and its detail plainly names the missing file (review carry-forward
+#      #3) rather than implying a broken install.
+#   c. --items scoping: only the listed ids appear in the output; an
+#      unknown id exits 2 naming it.
+#   d. no install-profile cache -> exit 2 with the exact "run himmelctl
+#      install first" message, and no state.json is created.
+#   e. --json: valid JSON, byte-identical across two consecutive runs,
+#      summary.red equals the count of severity=="red" items, items sorted
+#      by id.
+#   f. no-prompt guard: stdin closed (</dev/null) does not hang or error.
+#   g. purity: beyond ensureTarget's ONE sanctioned first-derive write to
+#      state.json, a second run leaves the whole fixture tree (repo fixture,
+#      target, cache) byte-identical.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+wizard="$repo_root/scripts/himmelctl/bin.js"
+manifest_path="$repo_root/scripts/install/manifest.json"
+[ -f "$wizard" ] || { echo "FAIL: $wizard not found" >&2; exit 1; }
+[ -f "$manifest_path" ] || { echo "FAIL: $manifest_path not found" >&2; exit 1; }
+command -v node >/dev/null 2>&1 || { echo "FAIL: node required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq required" >&2; exit 1; }
+command -v sha256sum >/dev/null 2>&1 || { echo "FAIL: sha256sum required" >&2; exit 1; }
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+node_bin=$(command -v node)
+
+work=$(mktemp -d)
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT
+
+# winpath <path> — echo <path> unchanged on posix, or its Windows form on
+# git-bash/MSYS/Cygwin (node.exe misresolves MSYS /tmp-style paths).
+winpath() {
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) cygpath -m "$1" 2>/dev/null || printf '%s' "$1" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+# write_cache <path> <role> <scope> <vault-mode> <vault-path> <handover-mode>
+#             <handover-path> <plugin-set> — a minimal valid Draft-A profile
+#             (same shape test-wizard-derive.sh's write_cache writes).
+write_cache() {
+  cat > "$1" <<JSON
+{"role":"$2","tier":"standard","scope":"$3","vault":{"mode":"$4","path":"$5"},"handover":{"mode":"$6","path":"$7"},"pluginSet":"$8","lanes":[],"alwaysOn":false}
+JSON
+}
+
+# snapshot_dir <dir> — sorted "relpath sha256" pairs, for a before/after
+# byte-identity check that doesn't depend on tar's metadata quirks.
+snapshot_dir() {
+  ( cd "$1" && find . -type f -print0 | sort -z | xargs -0 sha256sum )
+}
+
+# ── shared fixture repo root (HIMMELCTL_REPO_ROOT) ──────────────────────────
+# A real copy of manifest.json plus the handful of repoRoot-relative files
+# the chosen probe set reads: jira/bitbucket dist builds (file-exists),
+# doc-guard-map.sh (file-exists, REPO_ROOT_FILE_EXISTS_IDS), .env (settings-
+# key, jira-env-keys — always repoRoot-relative per both scopes).
+fixtureRepo="$work/repo"
+mkdir -p "$fixtureRepo/scripts/install" "$fixtureRepo/scripts/jira/dist" \
+  "$fixtureRepo/scripts/bitbucket/dist" "$fixtureRepo/scripts/lib"
+cp "$manifest_path" "$fixtureRepo/scripts/install/manifest.json"
+: > "$fixtureRepo/scripts/jira/dist/index.js"
+: > "$fixtureRepo/scripts/bitbucket/dist/index.js"
+: > "$fixtureRepo/scripts/lib/doc-guard-map.sh"
+cat > "$fixtureRepo/.env" <<'ENV'
+JIRA_BASE_URL=https://example.atlassian.net
+JIRA_EMAIL=me@example.com
+JIRA_API_TOKEN=tok123
+JIRA_PROJECT_KEY=HIMMEL
+ENV
+
+# ── case a: --help / status --help both list the status subcommand ────────
+outHelp1=$("$node_bin" "$wizard" --help)
+echo "$outHelp1" | grep -q 'status' || fail "case a: bare --help should list the status subcommand (got: $outHelp1)"
+outHelp2=$("$node_bin" "$wizard" status --help)
+echo "$outHelp2" | grep -q 'status' || fail "case a: 'status --help' should list the status subcommand (got: $outHelp2)"
+echo "ok: case a — --help / status --help list the status subcommand"
+
+# ── shared target + cache for cases b/e/f/g (one target, sequential runs) ──
+targetBE="$work/target-be"
+mkdir -p "$targetBE/.claude" "$targetBE/scripts/guardrails"
+: > "$targetBE/scripts/guardrails/lib.sh"
+# Deliberately NO .pre-commit-config.yaml — the known-missing enabled item
+# for case b. settings.json carries wiring-statusline + claude-plugins-
+# pluginSet green, but no hooks.PreToolUse markers (wiring-pretooluse red).
+cat > "$targetBE/.claude/settings.json" <<'JSON'
+{"statusLine":{"command":"bash foo.sh"},"enabledPlugins":{"foo@bar":true}}
+JSON
+cacheBE="$work/cache-be"; mkdir -p "$cacheBE"
+write_cache "$cacheBE/install-profile.json" adopter project none "" inline "" lean
+
+runStatusBE() {
+  ( cd "$targetBE" && HIMMELCTL_REPO_ROOT="$(winpath "$fixtureRepo")" HIMMELCTL_CACHE_DIR="$(winpath "$cacheBE")" HOME="$work/home" \
+      "$node_bin" "$wizard" status "$@" )
+}
+
+# ── case b: known-missing enabled item -> red, exit 0, plain detail ────────
+set +e
+outB=$(runStatusBE --json); rcB=$?
+set -e
+[ "$rcB" -eq 0 ] || fail "case b: status should exit 0 regardless of reds (got rc=$rcB)"
+echo "$outB" | jq -e '.items[] | select(.id=="pre-commit-hooks") | .severity == "red"' >/dev/null \
+  || fail "case b: pre-commit-hooks should be red when .pre-commit-config.yaml is absent (got: $outB)"
+echo "$outB" | jq -e '.items[] | select(.id=="pre-commit-hooks") | .detail == "no .pre-commit-config.yaml in this project"' >/dev/null \
+  || fail "case b: pre-commit-hooks detail should plainly name the missing file, not imply a broken install (got: $outB)"
+echo "ok: case b — known-missing enabled item (pre-commit-hooks) reads red, exit 0, plain detail"
+
+# ── case f: no-prompt guard — stdin closed must not hang or error ──────────
+set +e
+( cd "$targetBE" && HIMMELCTL_REPO_ROOT="$(winpath "$fixtureRepo")" HIMMELCTL_CACHE_DIR="$(winpath "$cacheBE")" HOME="$work/home" \
+      "$node_bin" "$wizard" status < /dev/null ) >/dev/null; rcF=$?
+set -e
+[ "$rcF" -eq 0 ] || fail "case f: status with closed stdin should exit 0, not hang/error (got rc=$rcF)"
+echo "ok: case f — closed stdin does not hang or error"
+
+# ── case e: --json determinism ──────────────────────────────────────────────
+outE1=$(runStatusBE --json)
+outE2=$(runStatusBE --json)
+[ "$outE1" = "$outE2" ] || fail "case e: two consecutive --json runs should be byte-identical"
+echo "$outE1" | jq -e . >/dev/null || fail "case e: --json output should be valid JSON"
+redCount=$(echo "$outE1" | jq '[.items[] | select(.severity=="red")] | length')
+summaryRed=$(echo "$outE1" | jq '.summary.red')
+[ "$redCount" -eq "$summaryRed" ] || fail "case e: summary.red ($summaryRed) should equal the count of severity==red items ($redCount)"
+[ "$redCount" -gt 0 ] || fail "case e: fixture should contain at least one red item (got 0 — fixture drifted)"
+idsActual=$(echo "$outE1" | jq -c '[.items[].id]')
+idsSorted=$(echo "$outE1" | jq -c '[.items[].id] | sort')
+[ "$idsActual" = "$idsSorted" ] || fail "case e: items should be sorted by id (got: $idsActual, sorted: $idsSorted)"
+echo "ok: case e — --json byte-identical across runs, summary.red consistent, items sorted by id"
+
+# ── case g: purity — beyond the one sanctioned first-derive write ─────────
+# The runs above already exercised this target/cache pair repeatedly, so a
+# state.json entry for it already exists (sanctioned first write already
+# happened). Snapshot now, run once more, and confirm nothing changed.
+snapBefore=$(snapshot_dir "$work")
+runStatusBE --json >/dev/null
+snapAfter=$(snapshot_dir "$work")
+[ "$snapBefore" = "$snapAfter" ] || fail "case g: a run against an already-derived target should leave the fixture tree byte-identical"
+echo "ok: case g — purity: a run against an already-derived target performs zero writes"
+
+# ── case c: --items scoping + unknown id ───────────────────────────────────
+targetC="$work/target-c"; mkdir -p "$targetC/.claude" "$targetC/scripts/guardrails"
+: > "$targetC/scripts/guardrails/lib.sh"
+cat > "$targetC/.claude/settings.json" <<'JSON'
+{"statusLine":{"command":"bash foo.sh"},"enabledPlugins":{"foo@bar":true}}
+JSON
+cacheC="$work/cache-c"; mkdir -p "$cacheC"
+write_cache "$cacheC/install-profile.json" adopter project none "" inline "" lean
+
+outC=$( cd "$targetC" && HIMMELCTL_REPO_ROOT="$(winpath "$fixtureRepo")" HIMMELCTL_CACHE_DIR="$(winpath "$cacheC")" HOME="$work/home" \
+      "$node_bin" "$wizard" status --items pre-commit-hooks,jira-cli-dist-build --json )
+count=$(echo "$outC" | jq '.items | length')
+[ "$count" -eq 2 ] || fail "case c: --items should scope the run to exactly 2 items (got $count): $outC"
+echo "$outC" | jq -e '[.items[].id] == ["jira-cli-dist-build","pre-commit-hooks"]' >/dev/null \
+  || fail "case c: --items should scope the run to exactly the listed ids (got: $outC)"
+
+set +e
+errC=$( cd "$targetC" && HIMMELCTL_REPO_ROOT="$(winpath "$fixtureRepo")" HIMMELCTL_CACHE_DIR="$(winpath "$cacheC")" HOME="$work/home" \
+      "$node_bin" "$wizard" status --items bogus-unknown-id 2>&1 )
+rcC=$?
+set -e
+[ "$rcC" -eq 2 ] || fail "case c: an unknown --items id should exit 2 (got rc=$rcC): $errC"
+echo "$errC" | grep -q 'bogus-unknown-id' || fail "case c: the unknown-id error should name it (got: $errC)"
+echo "ok: case c — --items scoping + unknown id exits 2 naming it"
+
+set +e
+errC2=$( cd "$targetC" && HIMMELCTL_REPO_ROOT="$(winpath "$fixtureRepo")" HIMMELCTL_CACHE_DIR="$(winpath "$cacheC")" HOME="$work/home" \
+      "$node_bin" "$wizard" status --items "," 2>&1 )
+rcC2=$?
+set -e
+[ "$rcC2" -eq 2 ] || fail "case c: --items with no non-whitespace ids should exit 2 (got rc=$rcC2): $errC2"
+echo "$errC2" | grep -qF 'requires at least one non-empty id' || fail "case c: the empty-items error should name the requirement (got: $errC2)"
+echo "ok: case c — --items with only commas/whitespace exits 2"
+
+# ── case d: missing install-profile cache -> exit 2, no state.json ────────
+targetD="$work/target-d"; mkdir -p "$targetD"
+cacheD="$work/cache-d-empty"; mkdir -p "$cacheD"
+
+set +e
+errD=$( cd "$targetD" && HIMMELCTL_REPO_ROOT="$(winpath "$fixtureRepo")" HIMMELCTL_CACHE_DIR="$(winpath "$cacheD")" HOME="$work/home" \
+      "$node_bin" "$wizard" status 2>&1 )
+rcD=$?
+set -e
+[ "$rcD" -eq 2 ] || fail "case d: missing install-profile cache should exit 2 (got rc=$rcD): $errD"
+echo "$errD" | grep -qF 'no himmelctl install profile found' || fail "case d: expected the 'no himmelctl install profile found' message (got: $errD)"
+echo "$errD" | grep -qF 'run himmelctl install first' || fail "case d: expected the 'run himmelctl install first' message (got: $errD)"
+[ ! -f "$cacheD/state.json" ] || fail "case d: state.json must NOT be created when the install-profile cache is missing"
+echo "ok: case d — missing install-profile cache exits 2 with the exact message, no state.json created"
+
+echo "PASS"

--- a/scripts/himmelctl/test/test-wizard-status-golden.sh
+++ b/scripts/himmelctl/test/test-wizard-status-golden.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+# test-wizard-status-golden.sh — the #276-class golden fixture (HIMMEL-756
+# T1.7): a single project-scope target whose himmelctl state.json marks
+# EXACTLY six items desired-enabled — qmd-binary, qmd-index,
+# wiring-statusline, wiring-pretooluse, jira-cli-dist-build,
+# handover-wiring — every other manifest item disabled, and every one of
+# the six probes ABSENT by hermetic construction (never by luck: the suite
+# runner inherits the real PATH + parent env, so each condition is actively
+# scrubbed/unset/omitted rather than assumed missing). Mirrors sibling
+# test-wizard-status-cmd.sh / test-wizard-probes.sh conventions: a fake
+# HOME + HIMMELCTL_CACHE_DIR + HIMMELCTL_REPO_ROOT fixture,
+# scripts/lib/hermetic-path.sh's link_hermetic_tool/scrub_path for curated
+# stub PATHs, node launched by absolute path, winpath for node.exe's
+# MSYS-path blindness.
+#
+# The state entry is authored directly rather than reverse-engineered from
+# a single deriveTarget() profile: no single profile/scope combination in
+# the real manifest yields "these six and only these six" (e.g. profile
+# 'luna' + scope 'project' would ALSO enable claude-plugins-pluginSet).
+# state.json is himmelctl's OWN artifact (lib/state.js's module header: a
+# SEPARATE artifact from install-profile.json, read/written by a stable
+# public schema) — so the fixture runs ONE real `status` invocation to let
+# ensureTarget derive-and-save the target entry under its real key (however
+# path.resolve(cwd) stringifies on this platform — avoids reproducing that
+# string by hand), then patches the saved items map via jq to the exact
+# six-true/rest-false split the brief specifies. That patch (plus the one
+# ensureTarget write it rides on) is the ONE sanctioned mutation; the sha256
+# purity sweep (case d) snapshots AFTER it, so every read-only status
+# invocation in cases (a)/(b) is held to true zero-diff.
+#
+# Covers:
+#   a. `status --json --items <six-csv>` reports EXACTLY those six, all
+#      severity=="red", summary.red==6 (and, as a bonus over the literal
+#      --items-scoped requirement: a --items-less run root-to-tip proves
+#      the STATE itself — not just the query — carries only six reds
+#      against the full manifest: summary.red==6, na==manifestCount-6).
+#   b. DISCRIMINATION: six flip cases. Each flips ONE condition to present
+#      via a hermetic-env change scoped to that ONE invocation (extra PATH
+#      entry, an env var, or a file edit — never a permanent fixture
+#      mutation that survives past its own case) and asserts that item —
+#      and, honestly, ONLY it, with one documented exception: qmd-index's
+#      own probe requires has_qmd to succeed as a hard precondition
+#      (scripts/lib/qmd-bin.sh's has_index chains `has_qmd && qmd_cmd
+#      collection list`), so flipping qmd-index to present necessarily also
+#      flips qmd-binary to present — a REAL causal coupling in the probe
+#      engine, not a fixture shortcut, and the flip-2 case asserts it
+#      explicitly rather than hiding it.
+#   c. manifest-lint regression re-run against the REAL repo manifest.
+#   d. purity: the full golden run (case a + all six flips, each restored)
+#      leaves the fixture tree byte-identical, beyond the one sanctioned
+#      derive+patch write that happens before the snapshot baseline.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+wizard="$repo_root/scripts/himmelctl/bin.js"
+manifest_path="$repo_root/scripts/install/manifest.json"
+lint_script="$repo_root/scripts/install/manifest-lint.mjs"
+qmd_bin_lib="$repo_root/scripts/lib/qmd-bin.sh"
+handover_path_lib="$repo_root/scripts/lib/handover-path.sh"
+[ -f "$wizard" ] || { echo "FAIL: $wizard not found" >&2; exit 1; }
+[ -f "$manifest_path" ] || { echo "FAIL: $manifest_path not found" >&2; exit 1; }
+[ -f "$lint_script" ] || { echo "FAIL: $lint_script not found" >&2; exit 1; }
+[ -f "$qmd_bin_lib" ] || { echo "FAIL: $qmd_bin_lib not found" >&2; exit 1; }
+[ -f "$handover_path_lib" ] || { echo "FAIL: $handover_path_lib not found" >&2; exit 1; }
+command -v node >/dev/null 2>&1 || { echo "FAIL: node required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq required" >&2; exit 1; }
+command -v sha256sum >/dev/null 2>&1 || { echo "FAIL: sha256sum required" >&2; exit 1; }
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+node_bin=$(command -v node)
+
+# shellcheck source=lib/hermetic-path.sh
+# shellcheck disable=SC1091
+. "$repo_root/scripts/lib/hermetic-path.sh"
+
+work=$(mktemp -d)
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT
+
+# winpath <path> — echo <path> unchanged on posix, or its Windows form on
+# git-bash/MSYS/Cygwin (node.exe misresolves MSYS /tmp-style paths).
+winpath() {
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) cygpath -m "$1" 2>/dev/null || printf '%s' "$1" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+# snapshot_dir <dir> — sorted "relpath sha256" pairs, for a before/after
+# byte-identity check that doesn't depend on tar's metadata quirks. Portable
+# across bash 3.2 + BSD sort (no -z/-print0/xargs -0 on macOS's base sort).
+snapshot_dir() {
+  ( cd "$1" && find . -type f | LC_ALL=C sort | while IFS= read -r f; do sha256sum "$f"; done )
+}
+
+# write_cache <path> <role> <scope> <vault-mode> <vault-path> <handover-mode>
+#             <handover-path> <plugin-set> — a minimal valid Draft-A profile
+#             (same shape test-wizard-status-cmd.sh's write_cache writes).
+write_cache() {
+  cat > "$1" <<JSON
+{"role":"$2","tier":"standard","scope":"$3","vault":{"mode":"$4","path":"$5"},"handover":{"mode":"$6","path":"$7"},"pluginSet":"$8","lanes":[],"alwaysOn":false}
+JSON
+}
+
+SIX_IDS_CSV="qmd-binary,qmd-index,wiring-statusline,wiring-pretooluse,jira-cli-dist-build,handover-wiring"
+SIX_IDS_JSON='["qmd-binary","qmd-index","wiring-statusline","wiring-pretooluse","jira-cli-dist-build","handover-wiring"]'
+SIX_SORTED_JSON='["handover-wiring","jira-cli-dist-build","qmd-binary","qmd-index","wiring-pretooluse","wiring-statusline"]'
+
+# ── fixture repo root (HIMMELCTL_REPO_ROOT) ─────────────────────────────────
+# A real copy of manifest.json, the two resolver libs the six items' probes
+# actually source (scripts/lib/qmd-bin.sh for qmd-binary/qmd-index,
+# scripts/lib/handover-path.sh for handover-wiring — control 1/2/6 need the
+# REAL resolvers present so a later "flip to present" is genuinely possible,
+# not just permanently absent because the sourced file itself 404s), and an
+# EMPTY scripts/jira/dist/ (control 5: jira-cli-dist-build's file-exists
+# probe resolves repoRoot-relative — the dir exists so the flip only ever
+# adds/removes the one file, never a directory, keeping the purity diff
+# clean). No handovers/ dir here (control 6 doesn't need it — see below).
+fixtureRepo="$work/repo"
+mkdir -p "$fixtureRepo/scripts/install" "$fixtureRepo/scripts/lib" "$fixtureRepo/scripts/jira/dist"
+cp "$manifest_path" "$fixtureRepo/scripts/install/manifest.json"
+cp "$qmd_bin_lib" "$fixtureRepo/scripts/lib/qmd-bin.sh"
+cp "$handover_path_lib" "$fixtureRepo/scripts/lib/handover-path.sh"
+fixtureRepo_w="$(winpath "$fixtureRepo")"
+
+# ── target (project scope) ──────────────────────────────────────────────────
+# Control 3/4: settings.json IS present (so the probes read a real parsed
+# object, not a "file missing" absent) but carries neither
+# statusLine.command nor any himmel PreToolUse marker.
+targetGolden="$work/target"
+mkdir -p "$targetGolden/.claude"
+baselineSettingsJson='{"statusLine":{},"hooks":{"PreToolUse":[]}}'
+printf '%s' "$baselineSettingsJson" > "$targetGolden/.claude/settings.json"
+
+homeDir="$work/home"; mkdir -p "$homeDir/.claude"
+cacheDir="$work/cache"; mkdir -p "$cacheDir"
+cacheDir_w="$(winpath "$cacheDir")"
+
+write_cache "$cacheDir/install-profile.json" adopter project none "" inline "" lean
+
+# ── control 1/2: hermetic PATH — bash (+ git, for handover_root's `git
+# rev-parse`) present via link_hermetic_tool, bun + qmd scrubbed via
+# scrub_path (never assumed absent by luck — actively excluded even though
+# the suite runner's own real PATH may carry either or both). ────────────
+baseStub="$work/stub-base"; mkdir -p "$baseStub"
+link_hermetic_tool bash "$baseStub"
+link_hermetic_tool git "$baseStub"
+scrubbedBase=$(scrub_path "$PATH" bun qmd)
+basePath="$baseStub:$scrubbedBase"
+
+# ── flip fixtures, created ONCE up front (never mutated in place) so they
+# read identically in the before/after purity snapshot ─────────────────────
+qmdMinStub="$work/qmd-min-stub"; mkdir -p "$qmdMinStub"
+cat > "$qmdMinStub/qmd" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$qmdMinStub/qmd"
+
+qmdFullStub="$work/qmd-full-stub"; mkdir -p "$qmdFullStub"
+cat > "$qmdFullStub/qmd" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "collection" ] && [ "$2" = "list" ]; then
+  printf 'himmel\nluna\n'
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$qmdFullStub/qmd"
+
+handoverTarget="$work/handover-target"; mkdir -p "$handoverTarget"
+
+# run_status <extra-path-prefix|""> <handover-dir|""> — one status
+# invocation, --json --items <the six>, scope=project, cwd=targetGolden.
+# HANDOVER_DIR is explicitly unset by default (control 6 — the suite
+# runner's OWN real env may carry an operator HANDOVER_DIR; an inherited
+# value would make handover-wiring read present by luck, not absence).
+run_status() {
+  local extra="$1" handoverDir="$2" pathVal="$basePath"
+  [ -n "$extra" ] && pathVal="$extra:$basePath"
+  if [ -n "$handoverDir" ]; then
+    ( cd "$targetGolden" && HANDOVER_DIR="$(winpath "$handoverDir")" HIMMELCTL_REPO_ROOT="$fixtureRepo_w" HIMMELCTL_CACHE_DIR="$cacheDir_w" HOME="$homeDir" PATH="$pathVal" \
+        "$node_bin" "$wizard" status --json --items "$SIX_IDS_CSV" )
+  else
+    ( cd "$targetGolden" && unset HANDOVER_DIR && HIMMELCTL_REPO_ROOT="$fixtureRepo_w" HIMMELCTL_CACHE_DIR="$cacheDir_w" HOME="$homeDir" PATH="$pathVal" \
+        "$node_bin" "$wizard" status --json --items "$SIX_IDS_CSV" )
+  fi
+}
+
+# run_status_full — same as run_status but WITHOUT --items (the bonus
+# whole-manifest check in case a).
+run_status_full() {
+  ( cd "$targetGolden" && unset HANDOVER_DIR && HIMMELCTL_REPO_ROOT="$fixtureRepo_w" HIMMELCTL_CACHE_DIR="$cacheDir_w" HOME="$homeDir" PATH="$basePath" \
+      "$node_bin" "$wizard" status --json )
+}
+
+# assert_items_severity <json> <label> <id:severity>... — one jq -e check
+# per pair, naming the item + json on failure.
+assert_items_severity() {
+  local json="$1" label="$2" pair id sev
+  shift 2
+  for pair in "$@"; do
+    id="${pair%%:*}"; sev="${pair#*:}"
+    echo "$json" | jq -e --arg id "$id" --arg sev "$sev" \
+      '.items[] | select(.id==$id) | .severity == $sev' >/dev/null \
+      || fail "$label: expected $id severity=$sev (got: $(echo "$json" | jq -c --arg id "$id" '.items[] | select(.id==$id)'))"
+  done
+}
+
+# ── seed state.json: run once to derive (ensureTarget's ONE sanctioned
+# first-write), then patch the saved items map to the exact six-true/
+# rest-false split. A cheap, spawn-free item (pre-commit-hooks) is used for
+# the seed run's own --items so this step never shells out to bash. ───────
+( cd "$targetGolden" && HIMMELCTL_REPO_ROOT="$fixtureRepo_w" HIMMELCTL_CACHE_DIR="$cacheDir_w" HOME="$homeDir" PATH="$basePath" \
+    "$node_bin" "$wizard" status --json --items pre-commit-hooks >/dev/null ) \
+  || fail "setup: seed status run failed"
+
+targetKey=$(jq -r '.targets | keys[0]' "$cacheDir/state.json")
+if [ -z "$targetKey" ] || [ "$targetKey" = "null" ]; then
+  fail "setup: state.json has no derived target key"
+fi
+
+jq --arg key "$targetKey" --argjson six "$SIX_IDS_JSON" '
+  .targets[$key].items = (.targets[$key].items
+    | with_entries(.value.enabled = ((.key as $k | $six | index($k)) != null)))
+' "$cacheDir/state.json" > "$cacheDir/state.json.tmp" && mv "$cacheDir/state.json.tmp" "$cacheDir/state.json"
+
+enabledIds=$(jq -c --arg key "$targetKey" '[.targets[$key].items | to_entries[] | select(.value.enabled) | .key] | sort' "$cacheDir/state.json")
+[ "$enabledIds" = "$(echo "$SIX_SORTED_JSON" | jq -c 'sort')" ] \
+  || fail "setup: patched state.json does not carry EXACTLY the six desired-enabled ids (got: $enabledIds)"
+echo "ok: setup — state.json target entry marks exactly the six ids desired-enabled, all others disabled"
+
+# ── case (d) purity baseline: taken AFTER the one sanctioned derive+patch
+# write, so every read-only status invocation from here on is held to true
+# zero-diff. ─────────────────────────────────────────────────────────────
+snapBefore=$(snapshot_dir "$work")
+
+# ── case (a): all six red, correctly grouped, nothing else red ────────────
+outA=$(run_status "" "")
+countA=$(echo "$outA" | jq '.items | length')
+[ "$countA" -eq 6 ] || fail "case a: expected 6 items in the --items-scoped result (got $countA): $outA"
+idsA=$(echo "$outA" | jq -c '[.items[].id]')
+[ "$idsA" = "$SIX_SORTED_JSON" ] || fail "case a: expected exactly the six ids sorted (got: $idsA)"
+allRed=$(echo "$outA" | jq -c '[.items[].severity] | unique')
+[ "$allRed" = '["red"]' ] || fail "case a: expected every item severity=red (got severities: $allRed): $outA"
+echo "$outA" | jq -e '.summary.red == 6 and .summary.degraded == 0 and .summary.green == 0 and .summary.na == 0' >/dev/null \
+  || fail "case a: expected summary {red:6,degraded:0,green:0,na:0} (got: $(echo "$outA" | jq -c '.summary'))"
+echo "ok: case a — status --json --items <the-six> reports exactly those six, all red, summary.red==6"
+
+# bonus: the STATE itself (not just the --items-scoped query) carries only
+# six reds against the FULL manifest.
+manifestCount=$(jq '.items | length' "$manifest_path")
+outAFull=$(run_status_full)
+echo "$outAFull" | jq -e --argjson n "$manifestCount" \
+  '(.items | length) == $n and .summary.red == 6 and .summary.degraded == 0 and .summary.green == 0 and .summary.na == ($n - 6)' >/dev/null \
+  || fail "case a (bonus): expected the full $manifestCount-item run to read {red:6, na:$((manifestCount - 6))} (got: $(echo "$outAFull" | jq -c '.summary'))"
+echo "ok: case a (bonus) — a --items-less run against the same state confirms only six reds against the whole manifest"
+
+# ── case (b): six discrimination flips, each restored after ────────────────
+
+# flip 1 — qmd-binary: minimal qmd stub on PATH (has_qmd succeeds; no
+# collection-list support, so qmd-index stays absent — genuine isolation).
+out1=$(run_status "$qmdMinStub" "")
+assert_items_severity "$out1" "flip qmd-binary" \
+  "qmd-binary:green" "qmd-index:red" "wiring-statusline:red" "wiring-pretooluse:red" \
+  "jira-cli-dist-build:red" "handover-wiring:red"
+echo "ok: flip 1/6 — qmd-binary alone leaves the red set (qmd-index stays red: no collection-list support in the minimal stub)"
+
+# flip 2 — qmd-index: a qmd stub that ALSO answers `collection list` with
+# all 4 required collections. qmd-binary's has_qmd probe necessarily also
+# reads present here — a REAL dependency in the probe engine (has_index
+# chains has_qmd && qmd_cmd collection list), not a fixture leak — asserted
+# explicitly rather than hidden.
+out2=$(run_status "$qmdFullStub" "")
+assert_items_severity "$out2" "flip qmd-index" \
+  "qmd-index:green" "qmd-binary:green" "wiring-statusline:red" "wiring-pretooluse:red" \
+  "jira-cli-dist-build:red" "handover-wiring:red"
+echo "ok: flip 2/6 — qmd-index leaves the red set (qmd-binary necessarily follows: documented has_qmd precondition); the other four stay red"
+
+# flip 3 — wiring-statusline: add statusLine.command, leave hooks untouched.
+printf '{"statusLine":{"command":"bash foo.sh"},"hooks":{"PreToolUse":[]}}' > "$targetGolden/.claude/settings.json"
+out3=$(run_status "" "")
+assert_items_severity "$out3" "flip wiring-statusline" \
+  "wiring-statusline:green" "wiring-pretooluse:red" "qmd-binary:red" "qmd-index:red" \
+  "jira-cli-dist-build:red" "handover-wiring:red"
+printf '%s' "$baselineSettingsJson" > "$targetGolden/.claude/settings.json"
+echo "ok: flip 3/6 — wiring-statusline alone leaves the red set; restored"
+
+# flip 4 — wiring-pretooluse: add all 3 himmel PreToolUse markers, leave
+# statusLine untouched.
+cat > "$targetGolden/.claude/settings.json" <<'JSON'
+{"statusLine":{},"hooks":{"PreToolUse":[
+  {"matcher":"Bash","hooks":[{"type":"command","command":"bash \"/x/scripts/hooks/auto-approve-safe-bash.sh\""}]},
+  {"matcher":"Edit","hooks":[{"type":"command","command":"bash \"/x/scripts/hooks/block-edit-on-main.sh\""}]},
+  {"matcher":"Read","hooks":[{"type":"command","command":"bash \"/x/scripts/hooks/block-read-secrets.sh\""}]}
+]}}
+JSON
+out4=$(run_status "" "")
+assert_items_severity "$out4" "flip wiring-pretooluse" \
+  "wiring-pretooluse:green" "wiring-statusline:red" "qmd-binary:red" "qmd-index:red" \
+  "jira-cli-dist-build:red" "handover-wiring:red"
+printf '%s' "$baselineSettingsJson" > "$targetGolden/.claude/settings.json"
+echo "ok: flip 4/6 — wiring-pretooluse alone leaves the red set; restored"
+
+# flip 5 — jira-cli-dist-build: create the repoRoot-relative dist file.
+: > "$fixtureRepo/scripts/jira/dist/index.js"
+out5=$(run_status "" "")
+assert_items_severity "$out5" "flip jira-cli-dist-build" \
+  "jira-cli-dist-build:green" "wiring-statusline:red" "wiring-pretooluse:red" \
+  "qmd-binary:red" "qmd-index:red" "handover-wiring:red"
+rm -f "$fixtureRepo/scripts/jira/dist/index.js"
+echo "ok: flip 5/6 — jira-cli-dist-build alone leaves the red set; restored"
+
+# flip 6 — handover-wiring: HANDOVER_DIR set to a real directory for this
+# ONE invocation only (never persisted into the ambient env).
+out6=$(run_status "" "$handoverTarget")
+assert_items_severity "$out6" "flip handover-wiring" \
+  "handover-wiring:green" "wiring-statusline:red" "wiring-pretooluse:red" \
+  "qmd-binary:red" "qmd-index:red" "jira-cli-dist-build:red"
+echo "ok: flip 6/6 — handover-wiring alone leaves the red set"
+
+# ── case (c): manifest-lint regression re-run against the REAL manifest ────
+set +e
+lintOut=$("$node_bin" "$lint_script" 2>&1)
+lintRc=$?
+set -e
+[ "$lintRc" -eq 0 ] || fail "case c: manifest-lint regression failed (rc=$lintRc): $lintOut"
+echo "ok: case c — manifest-lint regression re-run passes"
+
+# ── case (d): purity — the full golden run (case a + all six flips,
+# each restored) left the fixture tree byte-identical to the post-setup
+# baseline. ─────────────────────────────────────────────────────────────
+snapAfter=$(snapshot_dir "$work")
+[ "$snapBefore" = "$snapAfter" ] || fail "case d: the golden run (case a + six flips) mutated the fixture tree beyond the sanctioned setup write"
+echo "ok: case d — purity: case a + all six flips (each restored) left the fixture tree byte-identical"
+
+echo "PASS"

--- a/scripts/himmelctl/test/test-wizard-status-multitarget.sh
+++ b/scripts/himmelctl/test/test-wizard-status-multitarget.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# test-wizard-status-multitarget.sh — himmelctl `status` against a state.json
+# carrying TWO coexisting targets (HIMMEL-756 T1.8): one project-scope temp
+# repo target (keyed by path.resolve(cwd), lib/state.js's targetKeyForScope)
+# and one "user" target (the literal "user" key). Mirrors sibling
+# test-wizard-status-cmd.sh / test-wizard-status-golden.sh conventions: a
+# fake HOME + HIMMELCTL_CACHE_DIR + HIMMELCTL_REPO_ROOT fixture, node
+# launched by absolute path, winpath for node.exe's MSYS-path blindness.
+#
+# Both targets share ONE cache dir (HIMMELCTL_CACHE_DIR), so ONE state.json
+# accumulates both entries — install-profile.json's `scope` field is the
+# ONLY thing that picks which target a given `status` invocation resolves
+# against (project scope -> cwd-keyed; user scope -> the "user" key), and
+# it's overwritten between runs the same way a real adopter would re-run
+# `install` with a different scope answer. wiring-statusline (settings-key,
+# resolves against ctx.targetPath for project scope / $HOME for user scope)
+# is the shared litmus item: authored desired-enabled on BOTH target
+# entries directly (state.json's own documented schema — see
+# lib/state.js's module header), independent of the manifest's own
+# scopes:["project"] restriction, which gates deriveTarget()'s natural
+# derivation, not the probe or the hand-authored state read here.
+#
+# Covers:
+#   a. status against target A reports A's red/green set; flipping the
+#      wiring on B's scope (adding statusLine.command to the user-scope
+#      $HOME/.claude/settings.json) does NOT change A's report — and the
+#      reverse (flipping A's targetPath-relative settings.json) does NOT
+#      change B's report either. Both directions re-probed live (not a
+#      cached/stale read) at each step.
+#   b. --items subset scoping works per target (each target's run returns
+#      exactly the requested ids, scoped to THAT target's own state).
+#   c. the state file's OTHER target entry is byte-untouched (jq -S
+#      comparison, plus a whole-file sha256) after a run against one target
+#      — running against A only ever touches state.targets[[A's key]].
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+wizard="$repo_root/scripts/himmelctl/bin.js"
+manifest_path="$repo_root/scripts/install/manifest.json"
+[ -f "$wizard" ] || { echo "FAIL: $wizard not found" >&2; exit 1; }
+[ -f "$manifest_path" ] || { echo "FAIL: $manifest_path not found" >&2; exit 1; }
+command -v node >/dev/null 2>&1 || { echo "FAIL: node required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq required" >&2; exit 1; }
+command -v sha256sum >/dev/null 2>&1 || { echo "FAIL: sha256sum required" >&2; exit 1; }
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+node_bin=$(command -v node)
+
+work=$(mktemp -d)
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT
+
+# winpath <path> — echo <path> unchanged on posix, or its Windows form on
+# git-bash/MSYS/Cygwin (node.exe misresolves MSYS /tmp-style paths).
+winpath() {
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) cygpath -m "$1" 2>/dev/null || printf '%s' "$1" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+# write_cache <path> <role> <scope> <vault-mode> <vault-path> <handover-mode>
+#             <handover-path> <plugin-set> — a minimal valid Draft-A profile
+#             (same shape test-wizard-status-cmd.sh's write_cache writes).
+write_cache() {
+  cat > "$1" <<JSON
+{"role":"$2","tier":"standard","scope":"$3","vault":{"mode":"$4","path":"$5"},"handover":{"mode":"$6","path":"$7"},"pluginSet":"$8","lanes":[],"alwaysOn":false}
+JSON
+}
+
+# ── shared fixture repo root (HIMMELCTL_REPO_ROOT) ──────────────────────────
+fixtureRepo="$work/repo"
+mkdir -p "$fixtureRepo/scripts/install"
+cp "$manifest_path" "$fixtureRepo/scripts/install/manifest.json"
+fixtureRepo_w="$(winpath "$fixtureRepo")"
+
+# ── target A (project scope) ────────────────────────────────────────────────
+targetA="$work/targetA"; mkdir -p "$targetA/.claude"
+baselineSettings='{"statusLine":{},"hooks":{"PreToolUse":[]}}'
+printf '%s' "$baselineSettings" > "$targetA/.claude/settings.json"
+
+# ── target B (user scope — $HOME/.claude/settings.json) ────────────────────
+homeDir="$work/home"; mkdir -p "$homeDir/.claude"
+printf '%s' "$baselineSettings" > "$homeDir/.claude/settings.json"
+
+cacheDir="$work/cache"; mkdir -p "$cacheDir"
+cacheDir_w="$(winpath "$cacheDir")"
+
+# runA <items-csv> — status against target A (project scope, cwd=targetA).
+# Rewrites install-profile.json's scope to 'project' first (shared cache
+# dir — the profile records whichever scope a real adopter answered last).
+runA() {
+  write_cache "$cacheDir/install-profile.json" adopter project none "" inline "" lean
+  ( cd "$targetA" && HIMMELCTL_REPO_ROOT="$fixtureRepo_w" HIMMELCTL_CACHE_DIR="$cacheDir_w" HOME="$homeDir" \
+      "$node_bin" "$wizard" status --json --items "$1" )
+}
+
+# runB <items-csv> — status against target B (user scope; targetPath =
+# repoRoot() regardless of cwd, per bin.js's cmdStatus — cwd is irrelevant
+# here, so no `cd` is needed).
+runB() {
+  write_cache "$cacheDir/install-profile.json" adopter user none "" inline "" lean
+  ( HIMMELCTL_REPO_ROOT="$fixtureRepo_w" HIMMELCTL_CACHE_DIR="$cacheDir_w" HOME="$homeDir" \
+      "$node_bin" "$wizard" status --json --items "$1" )
+}
+
+# ── seed both target entries (ensureTarget's derive-and-save, once each),
+# then patch wiring-statusline desired-enabled directly on BOTH entries —
+# state.json is himmelctl's own documented-schema artifact (lib/state.js),
+# authored here independent of the manifest's scopes:["project"] gate
+# (which governs deriveTarget()'s natural derivation, not this hand-authored
+# read). ─────────────────────────────────────────────────────────────────
+runA wiring-statusline >/dev/null || fail "setup: seed run against A failed"
+runB wiring-statusline >/dev/null || fail "setup: seed run against B failed"
+
+targetKeys=$(jq -r '.targets | keys[]' "$cacheDir/state.json")
+[ "$(echo "$targetKeys" | wc -l)" -eq 2 ] || fail "setup: expected exactly 2 target entries in state.json (got: $targetKeys)"
+echo "$targetKeys" | grep -qx 'user' || fail "setup: expected a 'user' target entry (got: $targetKeys)"
+targetKeyA=$(echo "$targetKeys" | grep -vx 'user')
+[ -n "$targetKeyA" ] || fail "setup: could not identify target A's key"
+
+jq --arg ka "$targetKeyA" '
+  .targets[$ka].items["wiring-statusline"].enabled = true |
+  .targets["user"].items["wiring-statusline"].enabled = true
+' "$cacheDir/state.json" > "$cacheDir/state.json.tmp" && mv "$cacheDir/state.json.tmp" "$cacheDir/state.json"
+echo "ok: setup — state.json carries two target entries (A + user), wiring-statusline desired-enabled on both"
+
+sevOf() { # <json>
+  echo "$1" | jq -r '.items[0].severity'
+}
+
+# ── case (a): baseline — both red (neither settings.json carries the key) ──
+sevA0=$(sevOf "$(runA wiring-statusline)")
+sevB0=$(sevOf "$(runB wiring-statusline)")
+[ "$sevA0" = "red" ] || fail "case a: expected target A baseline severity=red (got: $sevA0)"
+[ "$sevB0" = "red" ] || fail "case a: expected target B baseline severity=red (got: $sevB0)"
+echo "ok: case a (baseline) — both A and B read red before either is flipped"
+
+# ── case (a): flip B, confirm A is unaffected, confirm B updated ───────────
+printf '{"statusLine":{"command":"bash foo.sh"},"hooks":{"PreToolUse":[]}}' > "$homeDir/.claude/settings.json"
+sevA1=$(sevOf "$(runA wiring-statusline)")
+sevB1=$(sevOf "$(runB wiring-statusline)")
+[ "$sevA1" = "red" ] || fail "case a: flipping B's wiring must NOT change A's report (got A severity: $sevA1)"
+[ "$sevB1" = "green" ] || fail "case a: B's own report should read green after its wiring was flipped (got: $sevB1)"
+printf '%s' "$baselineSettings" > "$homeDir/.claude/settings.json"
+echo "ok: case a — toggling B's wiring does not bleed into A's report (A stayed red); B's own report updated correctly"
+
+# ── case (a): flip A, confirm B is unaffected (reverse direction), confirm
+# A updated ─────────────────────────────────────────────────────────────
+printf '{"statusLine":{"command":"bash foo.sh"},"hooks":{"PreToolUse":[]}}' > "$targetA/.claude/settings.json"
+sevB2=$(sevOf "$(runB wiring-statusline)")
+sevA2=$(sevOf "$(runA wiring-statusline)")
+[ "$sevB2" = "red" ] || fail "case a: flipping A's wiring must NOT change B's report (got B severity: $sevB2)"
+[ "$sevA2" = "green" ] || fail "case a: A's own report should read green after its wiring was flipped (got: $sevA2)"
+printf '%s' "$baselineSettings" > "$targetA/.claude/settings.json"
+echo "ok: case a — toggling A's wiring does not bleed into B's report (B stayed red); A's own report updated correctly (vice versa proven)"
+
+# ── case (c) snapshot point: capture B's exact entry + the whole-file hash
+# BEFORE the batch of A-only runs below (both settings.json files are back
+# at baseline here, matching the post-setup fixture state). ───────────────
+stateBefore=$(sha256sum "$cacheDir/state.json")
+userEntryBefore=$(jq -S '.targets["user"]' "$cacheDir/state.json")
+
+# ── case (b): --items subset scoping is per-target ─────────────────────────
+outSubA=$(runA "wiring-statusline,jira-cli-dist-build")
+countSubA=$(echo "$outSubA" | jq '.items | length')
+[ "$countSubA" -eq 2 ] || fail "case b: --items should scope target A's run to exactly 2 items (got $countSubA): $outSubA"
+echo "$outSubA" | jq -e '[.items[].id] == ["jira-cli-dist-build","wiring-statusline"]' >/dev/null \
+  || fail "case b: --items should scope target A's run to exactly the listed ids (got: $outSubA)"
+
+outSubB=$(runB "wiring-statusline,jira-cli-dist-build")
+countSubB=$(echo "$outSubB" | jq '.items | length')
+[ "$countSubB" -eq 2 ] || fail "case b: --items should scope target B's run to exactly 2 items (got $countSubB): $outSubB"
+echo "$outSubB" | jq -e '[.items[].id] == ["jira-cli-dist-build","wiring-statusline"]' >/dev/null \
+  || fail "case b: --items should scope target B's run to exactly the listed ids (got: $outSubB)"
+echo "ok: case b — --items subset scoping works independently per target"
+
+# ── case (c): after a batch of runs against A only, B's entry (and the
+# whole state.json) is byte-untouched. ─────────────────────────────────────
+runA wiring-statusline >/dev/null
+runA "wiring-statusline,jira-cli-dist-build" >/dev/null
+stateAfter=$(sha256sum "$cacheDir/state.json")
+userEntryAfter=$(jq -S '.targets["user"]' "$cacheDir/state.json")
+[ "$stateBefore" = "$stateAfter" ] || fail "case c: state.json changed after a batch of runs against A only (expected zero writes — both targets already had entries)"
+[ "$userEntryBefore" = "$userEntryAfter" ] || fail "case c: target B's entry changed after runs against A only"
+echo "ok: case c — the other target's state entry (and the whole state.json) is byte-untouched after runs against one target"
+
+echo "PASS"

--- a/scripts/install/manifest-lint.mjs
+++ b/scripts/install/manifest-lint.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+// scripts/install/manifest-lint.mjs — validates scripts/install/manifest.json
+// against the Phase-1 probe-only schema (HIMMEL-756 T1.2). Zero-dep ESM.
+//
+// Checks per item:
+//   (a) exactly the six keys: id, kind, scopes, profiles, deps, probe
+//   (b) kind is never 'hardening' and is one of the fixed KIND vocabulary
+//   (c) probe.type is one of the fixed PROBE_TYPES vocabulary
+//   (d) ids are unique across the manifest
+//   (e) every deps[] entry references an existing item id
+//   (f) probe descriptor shape matches its type's contract (below) — closed
+//       shapes: unknown/extra fields are a lint error, same as missing ones.
+//
+// Per-type probe descriptor shape contract (single normative source — the
+// probe interpreter (HIMMEL-756 T1.3) MUST consume descriptors that satisfy
+// this table; the two shapes below vary legitimately across items and are
+// each machine-checked, not flattened):
+//
+//   type              | fields (all required unless noted)
+//   ------------------|--------------------------------------------------
+//   file-exists       | path: string
+//   settings-key      | file: string; EXACTLY ONE of key: string XOR
+//                     | keys: non-empty string[]
+//   settings-hooks    | file: string; key: string
+//   cmd:has_qmd       | resolver: string
+//   qmd-index         | collections: non-empty string[]
+//   handover-dir      | resolver: string
+//   dep               | EXACTLY ONE of cmd: string XOR (win32: string AND
+//                     | posix: string) — the win32/posix pair is the
+//                     | platform-branched variant used by scheduler-backend
+//
+// Usage:
+//   node scripts/install/manifest-lint.mjs [path-to-manifest.json]
+// The manifest path defaults to manifest.json next to this script; override
+// via a CLI arg (argv[2]) OR the MANIFEST_PATH env var (CLI arg wins if both
+// are given) — this is the seam the brief's self-test uses to lint a
+// corrupted temp copy without touching the real manifest.
+//
+// Exits 0 on a clean manifest; exits 1 and prints one message per violation
+// otherwise.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const KINDS = ['hook', 'plugin', 'dep', 'wiring', 'vault', 'scheduler', 'lane', 'mcp'];
+const PROBE_TYPES = ['file-exists', 'settings-key', 'settings-hooks', 'cmd:has_qmd', 'qmd-index', 'handover-dir', 'dep'];
+const ITEM_KEYS = ['id', 'kind', 'scopes', 'profiles', 'deps', 'probe'];
+
+function resolveManifestPath() {
+  const argPath = process.argv[2];
+  if (argPath) return path.resolve(argPath);
+  if (process.env.MANIFEST_PATH) return path.resolve(process.env.MANIFEST_PATH);
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.join(here, 'manifest.json');
+}
+
+function isNonEmptyStringArray(v) {
+  return Array.isArray(v) && v.length > 0 && v.every((x) => typeof x === 'string');
+}
+
+// (f) validates probe descriptor shape against the per-type contract
+// documented in the header comment. Pushes one message per violation
+// (missing/wrong-typed required field, extra/unknown field) into errors.
+function checkProbeShape(probe, label, errors) {
+  if (!probe || typeof probe !== 'object') return;
+  const type = probe.type;
+  const otherKeys = Object.keys(probe).filter((k) => k !== 'type');
+  const extraOf = (allowed) => otherKeys.filter((k) => !allowed.includes(k));
+  const reportExtra = (allowed) => {
+    const ex = extraOf(allowed);
+    if (ex.length > 0) errors.push(`${label}: probe type '${type}' has unexpected field(s) [${ex.join(', ')}]`);
+  };
+
+  switch (type) {
+    case 'file-exists': {
+      if (typeof probe.path !== 'string') errors.push(`${label}: probe type 'file-exists' requires 'path' (string)`);
+      reportExtra(['path']);
+      break;
+    }
+    case 'settings-key': {
+      if (typeof probe.file !== 'string') errors.push(`${label}: probe type 'settings-key' requires 'file' (string)`);
+      const hasKey = Object.prototype.hasOwnProperty.call(probe, 'key');
+      const hasKeys = Object.prototype.hasOwnProperty.call(probe, 'keys');
+      if (hasKey === hasKeys) {
+        errors.push(`${label}: probe type 'settings-key' requires exactly one of 'key' (string) or 'keys' (non-empty string array), got ${hasKey ? 'both' : 'neither'}`);
+      } else if (hasKey && typeof probe.key !== 'string') {
+        errors.push(`${label}: probe type 'settings-key' field 'key' must be a string`);
+      } else if (hasKeys && !isNonEmptyStringArray(probe.keys)) {
+        errors.push(`${label}: probe type 'settings-key' field 'keys' must be a non-empty array of strings`);
+      }
+      reportExtra(['file', 'key', 'keys']);
+      break;
+    }
+    case 'settings-hooks': {
+      if (typeof probe.file !== 'string') errors.push(`${label}: probe type 'settings-hooks' requires 'file' (string)`);
+      if (typeof probe.key !== 'string') errors.push(`${label}: probe type 'settings-hooks' requires 'key' (string)`);
+      reportExtra(['file', 'key']);
+      break;
+    }
+    case 'cmd:has_qmd': {
+      if (typeof probe.resolver !== 'string') errors.push(`${label}: probe type 'cmd:has_qmd' requires 'resolver' (string)`);
+      reportExtra(['resolver']);
+      break;
+    }
+    case 'qmd-index': {
+      if (!isNonEmptyStringArray(probe.collections)) errors.push(`${label}: probe type 'qmd-index' requires 'collections' (non-empty array of strings)`);
+      reportExtra(['collections']);
+      break;
+    }
+    case 'handover-dir': {
+      if (typeof probe.resolver !== 'string') errors.push(`${label}: probe type 'handover-dir' requires 'resolver' (string)`);
+      reportExtra(['resolver']);
+      break;
+    }
+    case 'dep': {
+      const hasCmd = Object.prototype.hasOwnProperty.call(probe, 'cmd');
+      const hasWin32 = Object.prototype.hasOwnProperty.call(probe, 'win32');
+      const hasPosix = Object.prototype.hasOwnProperty.call(probe, 'posix');
+      const hasPlatformPair = hasWin32 && hasPosix;
+      if (hasCmd && (hasWin32 || hasPosix)) {
+        errors.push(`${label}: probe type 'dep' requires exactly one of 'cmd' (string) or 'win32'+'posix' (both strings), got both`);
+      } else if (hasCmd) {
+        if (typeof probe.cmd !== 'string') errors.push(`${label}: probe type 'dep' field 'cmd' must be a string`);
+      } else if (hasWin32 || hasPosix) {
+        if (!hasPlatformPair || typeof probe.win32 !== 'string' || typeof probe.posix !== 'string') {
+          errors.push(`${label}: probe type 'dep' requires both 'win32' and 'posix' (strings) when not using 'cmd'`);
+        }
+      } else {
+        errors.push(`${label}: probe type 'dep' requires exactly one of 'cmd' (string) or 'win32'+'posix' (both strings), got neither`);
+      }
+      reportExtra(['cmd', 'win32', 'posix']);
+      break;
+    }
+    default:
+      // unknown probe.type is already reported by check (c); nothing to
+      // validate further for a type outside the fixed vocabulary.
+      break;
+  }
+}
+
+function lint(manifest) {
+  const errors = [];
+  const items = Array.isArray(manifest.items) ? manifest.items : [];
+  const ids = new Set(items.map((it) => it && it.id));
+
+  for (const it of items) {
+    if (it === null || typeof it !== 'object' || Array.isArray(it)) {
+      errors.push('item must be an object');
+      continue;
+    }
+
+    const label = it.id || '<unknown id>';
+
+    // (a) exactly the six keys.
+    const keys = Object.keys(it);
+    const missing = ITEM_KEYS.filter((k) => !keys.includes(k));
+    const extra = keys.filter((k) => !ITEM_KEYS.includes(k));
+    if (missing.length > 0 || extra.length > 0) {
+      errors.push(`${label}: expected exactly keys [${ITEM_KEYS.join(', ')}], missing=[${missing.join(', ')}] extra=[${extra.join(', ')}]`);
+    }
+
+    // (b) kind never 'hardening', kind in KINDS.
+    if (it.kind === 'hardening') {
+      errors.push(`${label}: kind 'hardening' is not permitted`);
+    } else if (!KINDS.includes(it.kind)) {
+      errors.push(`${label}: kind '${it.kind}' not in [${KINDS.join(', ')}]`);
+    }
+
+    // (c) probe.type in PROBE_TYPES.
+    const probeType = it.probe && it.probe.type;
+    if (!PROBE_TYPES.includes(probeType)) {
+      errors.push(`${label}: probe.type '${probeType}' not in [${PROBE_TYPES.join(', ')}]`);
+    }
+
+    // (f) probe descriptor shape matches its type's contract.
+    checkProbeShape(it.probe, label, errors);
+
+    // (e) every deps[] entry references an existing item id. 'deps' absent
+    // is treated as empty; present-but-non-array is a lint error rather
+    // than silently skipped.
+    if (Array.isArray(it.deps)) {
+      for (const d of it.deps) {
+        if (!ids.has(d)) {
+          errors.push(`${label}: deps entry '${d}' does not reference an existing item id`);
+        }
+      }
+    } else if (Object.prototype.hasOwnProperty.call(it, 'deps')) {
+      errors.push(`${label}: 'deps' must be an array`);
+    }
+  }
+
+  // (d) ids unique.
+  const seen = new Set();
+  for (const it of items) {
+    const id = it && it.id;
+    if (seen.has(id)) errors.push(`duplicate item id: '${id}'`);
+    seen.add(id);
+  }
+
+  return errors;
+}
+
+function main() {
+  const manifestPath = resolveManifestPath();
+  const raw = readFileSync(manifestPath, 'utf8');
+  const manifest = JSON.parse(raw);
+  const errors = lint(manifest);
+  if (errors.length > 0) {
+    console.error(`manifest-lint: ${errors.length} violation(s) in ${manifestPath}`);
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+  const items = Array.isArray(manifest.items) ? manifest.items : [];
+  console.log(`manifest-lint: OK (${items.length} items) — ${manifestPath}`);
+  process.exit(0);
+}
+
+main();

--- a/scripts/install/manifest.json
+++ b/scripts/install/manifest.json
@@ -1,0 +1,238 @@
+{
+  "schemaVersion": 1,
+  "harness": "claude",
+  "items": [
+    {
+      "id": "pre-commit-hooks",
+      "kind": "hook",
+      "scopes": ["project"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "file-exists", "path": ".pre-commit-config.yaml" }
+    },
+    {
+      "id": "wiring-pretooluse",
+      "kind": "wiring",
+      "scopes": ["project"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "settings-hooks", "file": ".claude/settings.json", "key": "hooks.PreToolUse" }
+    },
+    {
+      "id": "wiring-statusline",
+      "kind": "wiring",
+      "scopes": ["project"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "settings-key", "file": ".claude/settings.json", "key": "statusLine.command" }
+    },
+    {
+      "id": "jira-cli-dist-build",
+      "kind": "dep",
+      "scopes": ["project"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "file-exists", "path": "scripts/jira/dist/index.js" }
+    },
+    {
+      "id": "jira-env-keys",
+      "kind": "dep",
+      "scopes": ["project", "user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "settings-key", "file": ".env", "keys": ["JIRA_BASE_URL", "JIRA_EMAIL", "JIRA_API_TOKEN", "JIRA_PROJECT_KEY"] }
+    },
+    {
+      "id": "bitbucket-cli-build",
+      "kind": "dep",
+      "scopes": ["project"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "file-exists", "path": "scripts/bitbucket/dist/index.js" }
+    },
+    {
+      "id": "qmd-binary",
+      "kind": "dep",
+      "scopes": ["project", "user"],
+      "profiles": ["luna", "all"],
+      "deps": [],
+      "probe": { "type": "cmd:has_qmd", "resolver": "scripts/lib/qmd-bin.sh" }
+    },
+    {
+      "id": "qmd-index",
+      "kind": "vault",
+      "scopes": ["project", "user"],
+      "profiles": ["luna", "all"],
+      "deps": ["qmd-binary"],
+      "probe": { "type": "qmd-index", "collections": ["himmel", "luna"] }
+    },
+    {
+      "id": "luna-vault-scaffold",
+      "kind": "vault",
+      "scopes": ["user"],
+      "profiles": ["luna", "all"],
+      "deps": [],
+      "probe": { "type": "file-exists", "path": "{vaultPath}/.vault-template.json" }
+    },
+    {
+      "id": "claude-plugins-pluginSet",
+      "kind": "plugin",
+      "scopes": ["project"],
+      "profiles": ["core", "luna", "all"],
+      "deps": [],
+      "probe": { "type": "settings-key", "file": ".claude/settings.json", "key": "enabledPlugins" }
+    },
+    {
+      "id": "handover-wiring",
+      "kind": "wiring",
+      "scopes": ["project", "user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "handover-dir", "resolver": "scripts/lib/handover-path.sh" }
+    },
+    {
+      "id": "scheduler-backend",
+      "kind": "scheduler",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "dep", "win32": "schtasks", "posix": "at" }
+    },
+    {
+      "id": "guardrail-scope",
+      "kind": "wiring",
+      "scopes": ["project"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "file-exists", "path": "scripts/guardrails/lib.sh" }
+    },
+    {
+      "id": "hermes-lanes",
+      "kind": "lane",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "file-exists", "path": "scripts/lanes/lanes.json" }
+    },
+    {
+      "id": "telegram-bridge",
+      "kind": "lane",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "file-exists", "path": "scripts/telegram/telegram-api.ts" }
+    },
+    {
+      "id": "rtk",
+      "kind": "dep",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "dep", "cmd": "rtk" }
+    },
+    {
+      "id": "uv",
+      "kind": "dep",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "dep", "cmd": "uv" }
+    },
+    {
+      "id": "npm-less-node",
+      "kind": "dep",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": ["node"],
+      "probe": { "type": "dep", "cmd": "npm" }
+    },
+    {
+      "id": "node",
+      "kind": "dep",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "dep", "cmd": "node" }
+    },
+    {
+      "id": "bun",
+      "kind": "dep",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "dep", "cmd": "bun" }
+    },
+    {
+      "id": "jq",
+      "kind": "dep",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "dep", "cmd": "jq" }
+    },
+    {
+      "id": "git",
+      "kind": "dep",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "dep", "cmd": "git" }
+    },
+    {
+      "id": "python3",
+      "kind": "dep",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "dep", "cmd": "python3" }
+    },
+    {
+      "id": "shellcheck",
+      "kind": "dep",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "dep", "cmd": "shellcheck" }
+    },
+    {
+      "id": "gitleaks",
+      "kind": "dep",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "dep", "cmd": "gitleaks" }
+    },
+    {
+      "id": "pre-commit",
+      "kind": "dep",
+      "scopes": ["project", "user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "dep", "cmd": "pre-commit" }
+    },
+    {
+      "id": "gh",
+      "kind": "dep",
+      "scopes": ["user"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "dep", "cmd": "gh" }
+    },
+    {
+      "id": "graphify",
+      "kind": "dep",
+      "scopes": ["user"],
+      "profiles": ["core", "luna", "all"],
+      "deps": [],
+      "probe": { "type": "file-exists", "path": "scripts/graphify/check-graph-freshness.sh" }
+    },
+    {
+      "id": "doc-guard-map",
+      "kind": "wiring",
+      "scopes": ["project"],
+      "profiles": ["core", "all"],
+      "deps": [],
+      "probe": { "type": "file-exists", "path": "scripts/lib/doc-guard-map.sh" }
+    }
+  ]
+}

--- a/scripts/lib/qmd-bin.sh
+++ b/scripts/lib/qmd-bin.sh
@@ -520,6 +520,22 @@ has_qmd() {
   command -v qmd >/dev/null 2>&1
 }
 
+# True (rc 0) iff `qmd collection list` succeeds and lists at least one
+# collection (HIMMEL-756 T1.4: the himmelctl `qmd-index` probe's presence
+# signal). qmd's actual on-disk data/index directory layout is an internal
+# implementation detail with no stable path documented anywhere in this repo
+# to probe directly (unlike the fork clone dir / bun-global link dir above,
+# both of which ARE this resolver's own paths) — so this checks the
+# registered-collections signal through qmd itself instead of guessing a
+# filesystem location. Presence-only in the has_qmd sense: a real `qmd
+# collection list` invocation runs (unlike has_qmd, which never invokes the
+# binary), so a broken qmd surfaces here as absent rather than masked.
+has_index() {
+  local out
+  out=$(qmd_cmd collection list 2>/dev/null) || return 1
+  [ -n "$(printf '%s' "$out" | tr -d '[:space:]')" ]
+}
+
 # CLI entry -- only when EXECUTED (not sourced). Lets the pwsh mirrors
 # (scripts/setup.ps1, scripts/adopt.ps1) delegate to this ONE
 # implementation (`bash scripts/lib/qmd-bin.sh install`) instead of
@@ -531,6 +547,10 @@ if [ "${BASH_SOURCE[0]:-}" = "${0:-}" ]; then
     # caller-side install gate -- see qmd_fork_served above). Lets the pwsh
     # mirrors share the bash predicate instead of duplicating it.
     fork-served) qmd_fork_served ;;
-    *) echo "Usage: bash scripts/lib/qmd-bin.sh install|fork-served" >&2; exit 2 ;;
+    # has-index: rc 0 iff has_index (see above) -- lets probes.js (HIMMEL-756
+    # T1.4) and any other non-bash consumer share the same predicate via a
+    # single subprocess call instead of sourcing this file.
+    has-index) has_index ;;
+    *) echo "Usage: bash scripts/lib/qmd-bin.sh install|fork-served|has-index" >&2; exit 2 ;;
   esac
 fi

--- a/scripts/test-adopt.sh
+++ b/scripts/test-adopt.sh
@@ -638,6 +638,11 @@ run_wizard_suite himmelctl/test/test-wizard-derive.sh          "test-wizard-deri
 run_wizard_suite himmelctl/test/test-wizard-uninstall.sh       "test-wizard-uninstall"
 run_wizard_suite himmelctl/test/test-wizard-noinstall-guard.sh "test-wizard-noinstall-guard"
 run_wizard_suite himmelctl/test/test-wizard-bootstrap.sh       "test-wizard-bootstrap"
+run_wizard_suite himmelctl/test/test-wizard-state.sh           "test-wizard-state"
+run_wizard_suite himmelctl/test/test-wizard-probes.sh          "test-wizard-probes"
+run_wizard_suite himmelctl/test/test-wizard-status-cmd.sh      "test-wizard-status-cmd"
+run_wizard_suite himmelctl/test/test-wizard-status-golden.sh   "test-wizard-status-golden"
+run_wizard_suite himmelctl/test/test-wizard-status-multitarget.sh "test-wizard-status-multitarget"
 run_wizard_suite machine-setup/test-ubuntu-shim.sh             "test-ubuntu-shim"
 
 # The win11 shim suite is a .ps1 (static source-parse of win11.ps1, HIMMEL-887


### PR DESCRIPTION
himmelctl Phase 1: scripts/install/manifest.json (29-item probe-only manifest + manifest-lint.mjs with per-type probe shape contract), lib/helpers.js extraction, lib/state.js (target-keyed state at ~/.claude/himmel/state.json, derived from the install-profile cache), lib/probes.js (7 fixed probe types, pure reads, 10s spawnSync timeouts), and the read-only 'himmelctl status [--items] [--json]' severity diff. Hermetic acceptance suites: 6-red golden fixture with per-item discrimination flips, multi-target isolation, state/probes/status-cmd — all registered in test-adopt.sh. new-machine.md documents the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `himmelctl status` to perform a read-only severity comparison between desired installation items and current system state.
  - Supports project/user scoping, optional `--items` filtering, and deterministic `--json` output.
  - Added probe checks for files, settings/keys, hooks, commands, vault/index presence, and scheduled tasks.
  - Added `manifest-lint` to validate install manifest structure and dependencies.
  - Added `qmd has-index` to check index availability.
- **Documentation**
  - Documented `himmelctl status` usage, scoping behavior, and output/guarantees.
- **Tests**
  - Added hermetic status, state, and probe test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->