### PR TITLE
fix(ci): [HIMMEL-963] deflake critic-panel J1/K1/K2 + preserve failed-suite logs (#1159)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,4 +206,17 @@ jobs:
           sudo systemctl enable --now atd || sudo service atd start || true
       # Explicit `bash` prefix: on windows-latest the default run shell is pwsh,
       # but Git Bash is preinstalled + on PATH, so `bash …` runs under MSYS2.
+      # FAIL_LOG_DIR: full failed-suite logs land there and upload as an
+      # artifact below — the inline tail is bounded, so without this the
+      # failing assertion can be unrecoverable from Actions logs (HIMMEL-963).
       - run: bash scripts/ci/run-shell-tests.sh
+        env:
+          FAIL_LOG_DIR: failed-suite-logs
+      - name: Upload failed-suite logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shell-unit-failed-logs-${{ matrix.os }}
+          path: failed-suite-logs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/scripts/ci/run-shell-tests.sh
+++ b/scripts/ci/run-shell-tests.sh
@@ -197,9 +197,18 @@ while IFS= read -r suite; do
     failed_suites="${failed_suites}  ${suite} (rc=${rc})
 "
     printf '[FAIL] %s (rc=%s, %ss)\n' "$suite" "$rc" "$dur"
-    echo '----- last 20 lines -----'
-    tail -20 "$log" | sed 's/^/    /'
+    echo '----- last 100 lines -----'
+    tail -n 100 "$log" | sed 's/^/    /'
     echo '--------------------------'
+    # Preserve the FULL failed-suite log when FAIL_LOG_DIR is set (CI uploads
+    # it as an artifact — HIMMEL-963: tail-only + rm made the failing
+    # assertion unrecoverable from Actions logs). Injective escape (_ -> _u,
+    # / -> _s) so distinct relpaths like a/b and a_b can't collide.
+    if [ -n "${FAIL_LOG_DIR:-}" ]; then
+      mkdir -p "$FAIL_LOG_DIR"
+      safe_relpath=$(printf '%s' "$relpath" | sed 's/_/_u/g; s#/#_s#g')
+      cp "$log" "$FAIL_LOG_DIR/$safe_relpath.log"
+    fi
   fi
   rm -f "$log"
 done < "$suites_file"

--- a/scripts/cr/test-critic-panel.sh
+++ b/scripts/cr/test-critic-panel.sh
@@ -180,11 +180,31 @@ chmod +x "$STUB_HANG"
 HANG_JSON="$tmp/critics-hang.json"
 printf '%s\n' '{"panel":[{"slug":"hang-critic","model":"fake/hang","provider":"test","tier":"free"}]}' > "$HANG_JSON"
 
+# retry_once <case-fn> — loaded-runner tolerance for the timing-sensitive
+# cases below (HIMMEL-963: J1/K1/K2 flip under CI runner contention). Runs the
+# case as a silent probe; on failure re-runs it ONCE and lets the checks after
+# report on the second attempt's captured globals. Never masks a deterministic
+# failure — a real bug fails both attempts.
+retry_once() {
+    "$1" && return 0
+    echo "note - $1: probe failed once, retrying (loaded-runner tolerance)"
+    "$1" || true
+}
+
 # Only run this test if 'timeout' is available (same condition as the panel uses)
 if command -v timeout > /dev/null 2>&1; then
-    j_rc=0
-    stderr_j="$(printf '%s' "$DIFF" | CRITIC_TIMEOUT_SECS=2 CRITICS_JSON="$HANG_JSON" CRITIC_FIRST_PASS="$STUB_HANG" \
-        timeout 5 bash "$PANEL" 2>&1 >/dev/null)" || j_rc=$?
+    # Outer timeout 20 (was 5): only a backstop against a genuinely hung panel.
+    # The tight 5s margin raced panel startup + the 2s member timeout on loaded
+    # runners (outer kill -> rc=124, stderr lines never emitted).
+    j1_case() {
+        j_rc=0
+        stderr_j="$(printf '%s' "$DIFF" | CRITIC_TIMEOUT_SECS=2 CRITICS_JSON="$HANG_JSON" CRITIC_FIRST_PASS="$STUB_HANG" \
+            timeout 20 bash "$PANEL" 2>&1 >/dev/null)" || j_rc=$?
+        printf '%s' "$stderr_j" | grep -qF "unavailable (timeout 2s)" \
+            && printf '%s' "$stderr_j" | grep -qF "hang-critic" \
+            && [ "$j_rc" = "1" ]
+    }
+    retry_once j1_case
 
     check_contains "J1: hung member timeout in stderr" "$stderr_j" "unavailable (timeout 2s)"
     check_contains "J1: hung member slug in stderr" "$stderr_j" "hang-critic"
@@ -272,8 +292,14 @@ PYEOF
     printf '%s' "$DATA_2" > "$tmp/critics-2.json"
 
     # (a) byte-identical convergence: slow-critic-0 + instant-critic-1, parallel == sequential
-    out_seq="$(printf '%s' "$DIFF" | CRITICS_JSON="$tmp/critics-2.json" CRITIC_FIRST_PASS="$STUB_SLOW" CRITIC_PARALLEL=0 timeout 30 bash "$PANEL" 2>/dev/null)"
-    out_par="$(printf '%s' "$DIFF" | CRITICS_JSON="$tmp/critics-2.json" CRITIC_FIRST_PASS="$STUB_SLOW" CRITIC_PARALLEL=1 timeout 30 bash "$PANEL" 2>/dev/null)"
+    # timeout 60 (was 30) + retry_once: the merge logic is deterministic, but a
+    # thrashing runner can trip the outer timeout and truncate one capture.
+    k1_case() {
+        out_seq="$(printf '%s' "$DIFF" | CRITICS_JSON="$tmp/critics-2.json" CRITIC_FIRST_PASS="$STUB_SLOW" CRITIC_PARALLEL=0 timeout 60 bash "$PANEL" 2>/dev/null)"
+        out_par="$(printf '%s' "$DIFF" | CRITICS_JSON="$tmp/critics-2.json" CRITIC_FIRST_PASS="$STUB_SLOW" CRITIC_PARALLEL=1 timeout 60 bash "$PANEL" 2>/dev/null)"
+        [ -n "$out_seq" ] && [ "$out_seq" = "$out_par" ]
+    }
+    retry_once k1_case
     check "K1: parallel output identical to sequential (slow critic-0)" "$out_seq" "$out_par"
 
     # (b) registry order: qwen3coder-1 must appear before gptoss-* in merged output
@@ -289,8 +315,14 @@ PYEOF
     # K2: Parallel member-drop — kimi fails in parallel mode; check availability + header
     # Note: critics-all.json has kimi which fails (stub exits 1 for kimi model)
     # Run twice: once for stderr, once for stdout (can't capture both at once cleanly)
-    stderr_k2="$(printf '%s' "$DIFF" | CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" CRITIC_PARALLEL=1 timeout 30 bash "$PANEL" 2>&1 >/dev/null)"
-    out_k2="$(printf '%s' "$DIFF" | CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" CRITIC_PARALLEL=1 timeout 30 bash "$PANEL" 2>/dev/null)"
+    # timeout 60 (was 30) + retry_once: same loaded-runner tolerance as K1.
+    k2_case() {
+        stderr_k2="$(printf '%s' "$DIFF" | CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" CRITIC_PARALLEL=1 timeout 60 bash "$PANEL" 2>&1 >/dev/null)"
+        out_k2="$(printf '%s' "$DIFF" | CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" CRITIC_PARALLEL=1 timeout 60 bash "$PANEL" 2>/dev/null)"
+        printf '%s' "$stderr_k2" | grep -qF 'panel-availability: kimi unavailable' \
+            && printf '%s' "$out_k2" | grep -qF '(2/3 critics responded)'
+    }
+    retry_once k2_case
     check "K2: parallel kimi unavailable" "$(printf '%s\n' "$stderr_k2" | grep -cF 'panel-availability: kimi unavailable')" "1"
     check "K2: parallel header 2/3" "$(printf '%s\n' "$out_k2" | grep -cF '(2/3 critics responded)')" "1"
 


### PR DESCRIPTION
Public propagation of private squash 394bbaf9 (HIMMEL-963).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for timeout-sensitive critic-panel checks by allowing selected probes to retry once before reporting failure.
  - Increased safety time limits for parallel and hung-member test scenarios.

- **Tests**
  - Failure reports now include the last 100 lines of each failed test suite.
  - Complete logs from failed suites are preserved and uploaded as build artifacts for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->