### PR TITLE
fix(luna): [HIMMEL-951] drop no-op bg-wait ceiling from cadence runners + jarvis-subsystems doc nits (#1160)

### DIFF
--- a/docs/jarvis-subsystems.md
+++ b/docs/jarvis-subsystems.md
@@ -81,7 +81,7 @@ scoped grant instead of deadlocking or running under blanket bypass.
 session's `outbox.jsonl`. The parent/operator is the single adjudicator per
 session and responds via a lean CLI:
 
-```
+```sh
 bun scripts/telegram/adjudicate.ts list                    # surface pending escalations
 bun scripts/telegram/adjudicate.ts grant  <sessionDir> --arm <arm> --pattern <re> [--ttl m] [--uses n]
 bun scripts/telegram/adjudicate.ts refuse <sessionDir> <index>
@@ -112,7 +112,9 @@ vendored `scripts/statusline/` bar with a where-are-we ledger line). See
 **[../scripts/statusline/README.md](../scripts/statusline/README.md)** for the
 vendored bar's options and
 **[../scripts/statusline/VENDORED.md](../scripts/statusline/VENDORED.md)**
-for the fork-sync provenance.
+for the fork-sync provenance. If the configured statusline command path is
+removed or absent, the statusline silently disappears instead of reporting an
+error.
 
 ## Clipper pipeline
 
@@ -122,7 +124,7 @@ triaged, synthesized, filed knowledge — the capture arm of the luna second-bra
 
 **The stages** (each an idempotent `obsidian-triage` skill, safe to re-run):
 
-1. **`/harvest-clips`** — marks each clip harvest-ready; github URLs are
+1. **`/harvest-clips`** — marks each clip harvest-ready; GitHub URLs are
    dispatched to repo synthesis.
 2. **`/triage-clips`** — summarizes, infers tags against the vault tag set,
    suggests related notes, extracts action items to the daily note.

--- a/scripts/luna/pipeline-cadence.sh
+++ b/scripts/luna/pipeline-cadence.sh
@@ -588,10 +588,8 @@ emit_bat() {
     printf 'if exist "%s" move /y "%s" "%s.prev" > NUL 2>&1\r\n' "$log_win_esc" "$log_win_esc" "$log_win_esc"
     printf 'echo [fired %%DATE%% %%TIME%%] >> "%s" 2>&1\r\n' "$log_win_esc"
     printf 'cd /d "%s" >> "%s" 2>&1 || exit /b 1\r\n' "$vault_win_esc" "$log_win_esc"
-    # HIMMEL-918: lift claude's 600s background-task wait ceiling — triage
-    # dispatches clip batches as bg tasks and the default ceiling silently
-    # truncated nightly runs mid-batch.
-    printf 'set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0\r\n'
+    # HIMMEL-951: no bg-wait ceiling override here — CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS
+    # only affects --print mode, and cadence runners are interactive-shaped (HIMMEL-128).
     printf '"%s" --model "%s" --settings "%s" "%s" < NUL >> "%s" 2>&1\r\n' "$claude_win" "$model_esc" "$settings_esc" "$prompt_esc" "$log_win_esc"
 }
 
@@ -1143,8 +1141,9 @@ emit_runner() {
     printf '{\n'
     printf '    echo "[fired $(date '\''+%%Y-%%m-%%d %%H:%%M:%%S'\'')]"\n'
     printf '    cd %s || exit 1\n' "$q_vault"
-    # HIMMEL-918: lift claude's 600s background-task wait ceiling (see emit_bat).
-    printf '    _rc=0; CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 %s --model %s --settings %s %s < /dev/null || _rc=$?\n' "$q_claude" "$q_model" "$q_settings" "$q_prompt"
+    # HIMMEL-951: no bg-wait ceiling override here — CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS
+    # only affects --print mode, and cadence runners are interactive-shaped (HIMMEL-128).
+    printf '    _rc=0; %s --model %s --settings %s %s < /dev/null || _rc=$?\n' "$q_claude" "$q_model" "$q_settings" "$q_prompt"
     printf '    echo "[exit rc=$_rc]"\n'
     printf '} >> "$log" 2>&1\n'
 }

--- a/scripts/luna/test-pipeline-cadence.sh
+++ b/scripts/luna/test-pipeline-cadence.sh
@@ -439,10 +439,10 @@ assert_contains "harvest runner pins --model sonnet" "--model sonnet" "$harvest_
 assert_contains "synth runner pins --model sonnet"   "--model sonnet" "$synth_sh"
 assert_contains "health runner pins --model haiku"    "--model haiku"  "$health_sh"
 
-echo "TEST: cron runners lift the 600s bg-wait ceiling (HIMMEL-918)"
-assert_contains "harvest runner lifts bg-wait ceiling" "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0" "$harvest_sh"
-assert_contains "synth runner lifts bg-wait ceiling"   "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0" "$synth_sh"
-assert_contains "health runner lifts bg-wait ceiling"  "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0" "$health_sh"
+echo "TEST: cron runners omit the print-only bg-wait ceiling override (HIMMEL-951)"
+assert_not_contains "harvest runner omits bg-wait ceiling override" "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS" "$harvest_sh"
+assert_not_contains "synth runner omits bg-wait ceiling override"   "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS" "$synth_sh"
+assert_not_contains "health runner omits bg-wait ceiling override"  "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS" "$health_sh"
 
 # Test C4b: --settings injection wires the auto-approve hook (HIMMEL-575) -------
 
@@ -1158,10 +1158,10 @@ assert_contains "harvest bat pins --model sonnet" '--model "sonnet"' "$harvest_b
 assert_contains "synth bat pins --model sonnet"   '--model "sonnet"' "$synth_bat"
 assert_contains "health bat pins --model haiku"    '--model "haiku"'  "$health_bat"
 
-echo "TEST: .bat runners lift the 600s bg-wait ceiling (HIMMEL-918)"
-assert_contains "harvest bat lifts bg-wait ceiling" "set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0" "$harvest_bat"
-assert_contains "synth bat lifts bg-wait ceiling"   "set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0" "$synth_bat"
-assert_contains "health bat lifts bg-wait ceiling"  "set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0" "$health_bat"
+echo "TEST: .bat runners omit the print-only bg-wait ceiling override (HIMMEL-951)"
+assert_not_contains "harvest bat omits bg-wait ceiling override" "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS" "$harvest_bat"
+assert_not_contains "synth bat omits bg-wait ceiling override"   "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS" "$synth_bat"
+assert_not_contains "health bat omits bg-wait ceiling override"  "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS" "$health_bat"
 
 # Test 6b: --settings injection wires the auto-approve hook (HIMMEL-575) ------
 


### PR DESCRIPTION
Public propagation of private squash cbdad401 (HIMMEL-951).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that configured statusline commands silently disappear when their path is missing.
  * Improved CLI example formatting and standardized GitHub capitalization.

* **Bug Fixes**
  * Updated scheduled cadence runners to avoid applying an unnecessary print-mode wait setting, improving interactive run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->