### PR TITLE
fix(cleanup): [HIMMEL-930] drop @() double-wrap on Get-BlindClientPids caller - blind-client gate always refused -Kill (#1161)

### DIFF
--- a/scripts/cleanup/sweep-codex-orphans.ps1
+++ b/scripts/cleanup/sweep-codex-orphans.ps1
@@ -383,7 +383,11 @@ Write-Host ("[sweep-codex-orphans] flat PID list ({0}): {1}" -f $flatPids.Count,
 # Blind-client gate (silent-failure CR): a client whose CommandLine WMI hides
 # from us may be holding a pipe we cannot see, so every ORPHAN verdict above is
 # suspect. Warn always; refuse -Kill (report stays useful, nothing is stopped).
-$blindClients = @(Get-BlindClientPids -Procs $records)
+# NB: NO @() wrap on the call (HIMMEL-930) - Get-BlindClientPids returns via
+# unary comma so the array survives raw assignment (wrapping it in @() would
+# re-box an EMPTY result into a 1-element wrapper, permanently tripping this
+# gate: Count=1 even with zero blind clients).
+$blindClients = Get-BlindClientPids -Procs $records
 if ($blindClients.Count -gt 0) {
   Write-Warning ("[sweep-codex-orphans] client pid(s) {0} have no visible CommandLine (elevation/session gap) - the client-liveness signal is unreliable; orphan classifications above may be WRONG." -f ($blindClients -join ', '))
 }

--- a/scripts/cleanup/test-sweep-codex-orphans.ps1
+++ b/scripts/cleanup/test-sweep-codex-orphans.ps1
@@ -226,6 +226,29 @@ Check 'blind clients = {900,902}'      (($blind -join ',') -eq '900,902') "got=$
 $noBlind = Get-BlindClientPids -Procs @( (Rec 901 1 'claude.exe' (ClientRef 'tok9')) )
 Check 'all-visible -> empty'           ($noBlind.Count -eq 0) "got count=$($noBlind.Count)"
 
+# --- Test 6d: caller-path @() wrap regression (HIMMEL-930) -------------------
+# Get-BlindClientPids is array-guaranteed by its own unary-comma return (Test
+# 6c). That guarantee is worthless if the CALLER re-wraps the result in @():
+# @() re-boxes an EMPTY inner array into a ONE-element wrapper, so the
+# production caller's `$blindClients.Count` read 1 even with zero blind
+# clients - the elevation/session-gap warning ALWAYS fired and -Kill ALWAYS
+# refused (exit 1) on every machine, regardless of actual visibility. The
+# harness has no Get-CimInstance mock to drive the production path end-to-end,
+# so this pins the exact expression shape at both the source-text level (the
+# caller line must not be @()-wrapped) and the behavioral level (unwrapped ==
+# correct, @()-wrapped == the bug), so a regression back to @() is caught
+# either way.
+Write-Host "Test 6d: caller-path @() wrap regression (HIMMEL-930)"
+$noBlindProcs = @( (Rec 901 1 'claude.exe' (ClientRef 'tok9')) )
+$callerUnwrapped = Get-BlindClientPids -Procs $noBlindProcs
+Check 'unwrapped caller expression: zero blind clients -> Count 0' ($callerUnwrapped.Count -eq 0) "got count=$($callerUnwrapped.Count)"
+$callerOldWrap = @(Get-BlindClientPids -Procs $noBlindProcs)
+Check 'OLD @()-wrapped expression on empty result -> Count 1 (documents the bug)' ($callerOldWrap.Count -eq 1) "got count=$($callerOldWrap.Count)"
+$callerSrc = Get-Content -LiteralPath $Helper -Raw
+Check 'production source: blindClients assignment is NOT @()-wrapped' `
+  ($callerSrc -match '\$blindClients\s*=\s*Get-BlindClientPids' -and $callerSrc -notmatch '\$blindClients\s*=\s*@\(\s*Get-BlindClientPids') `
+  'caller line regressed to the @() wrap'
+
 # --- Test 7: malformed argv fails fast (no hang, no production execution) ----
 # PowerShell's parameter binder rejects unknown params / stray positionals
 # BEFORE the script body runs, so these never reach Get-CimInstance or any kill


### PR DESCRIPTION
Public propagation of private squash 92e7a299 (HIMMEL-930).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected empty-result handling during orphan cleanup, preventing false warnings and unnecessary safety-gate triggers.

* **Tests**
  * Added regression coverage to verify correct empty-result behavior and prevent the issue from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->