### PR TITLE
fix(handover): [HIMMEL-938] locale-adaptive schtasks /sd + post-arm NextRunTime verify (#1165)

### DIFF
--- a/docs/internals/environment-gotchas.md
+++ b/docs/internals/environment-gotchas.md
@@ -299,9 +299,17 @@ out; the task sits `State=Ready`, `LastRun=never`, result `267011` /
 `SCHED_S_TASK_HAS_NOT_RUN` — a silent no-launch). After ANY scheduled-task
 creation on a machine not yet proven, verify
 `(Get-ScheduledTaskInfo <name>).NextRunTime` is the intended datetime — never
-trust the creation SUCCESS message. The locale-proof route is a `/create /xml`
-task definition (see the UTF-16-prolog section above) instead of `/sd`
-strings; HIMMEL-870 tracks moving `arm-resume.sh` onto it.
+trust the creation SUCCESS message.
+
+`arm-resume.sh` is now structurally guarded against this (HIMMEL-938): its
+Windows path reads `HKCU\Control Panel\International\sShortDate` and renders
+`/sd` in the machine's own pattern (falling back to the old hardcoded
+`MM/dd/yyyy` on any registry-read failure), then runs the
+`Get-ScheduledTaskInfo` check above after every create — a mismatch beyond a
+120s tolerance (or a missing/null `NextRunTime`) deletes the just-created task and refuses
+(rc=2) instead of leaving a silent months-out arm. Any OTHER hand-rolled
+`schtasks /create /sd` call outside `arm-resume.sh` remains exposed to this
+trap (and remains forbidden — go through `arm-resume.sh`).
 
 ## MSYS `/tmp` is the Windows user temp dir — temp cleaners delete it under you
 

--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -382,11 +382,15 @@ esac
 #   START_DATE   MM/DD/YYYY   — schtasks /sd. FIXES the bug where /st with no
 #                /sd defaulted to TODAY, so a time already past today gave
 #                "Next Run Time: N/A" and never fired (HIMMEL-204). NOTE:
-#                schtasks /sd parses per the user's Windows short-date LOCALE;
-#                MM/DD/YYYY is correct for US-format machines (this repo's
-#                operator env). On a dd/MM/yyyy locale schtasks would reject or
-#                misread it — locale-adaptive /sd is a follow-up if this tool
-#                ever runs on a non-US Windows box.
+#                schtasks /sd parses per the user's Windows short-date LOCALE,
+#                so this MM/DD/YYYY value is only a DEFAULT — the Windows
+#                branch of schedule_arm re-renders it in the machine's own
+#                locale (via _win_short_date_pattern + a registry read) right
+#                before /create, and verifies the registered NextRunTime
+#                afterward (HIMMEL-938; a dd/MM/yyyy machine, e.g. win2,
+#                previously misread MM/DD/YYYY and armed months out with no
+#                error). Non-Windows platforms never read this field as a
+#                schtasks /sd — it stays MM/DD/YYYY here as a harmless default.
 #   AT_STAMP     YYYYMMDDhhmm — at -t, an exact datetime (replaces the
 #                today/tomorrow heuristic that broke for resets >24h out).
 # Capture FIRST (explicit || handler — a $(...) failure inside a heredoc
@@ -1900,6 +1904,116 @@ _crontab_schedule() {
     echo "    crontab -l | grep -v 'HIMMEL-Resume' | crontab -"
 }
 
+# _win_short_date_pattern (HIMMEL-938): read the machine's Windows short-date
+# format from the registry so schedule_arm's Windows branch can render
+# `schtasks /sd` in the LOCALE schtasks itself will parse it with — schtasks
+# reads /sd per-locale, and a hardcoded MM/dd/yyyy silently misreads as
+# day-first on a dd/MM/yyyy machine (win2, 4 recurrences), arming the task
+# months out with no error. MSYS_NO_PATHCONV=1 is the same idiom every other
+# schtasks/reg call in this file uses (HIMMEL-125) — without it gitbash
+# mangles the /v flag into a Windows-rooted path. ANY failure (missing reg,
+# unreadable key, empty/unparseable value) falls back to "MM/dd/yyyy" —
+# byte-identical to the pre-HIMMEL-938 hardcoded behavior. Returns 0 when
+# the pattern came from the registry, 1 when the fallback was used -- the
+# caller must know the difference: a fallback pattern on a day-first
+# machine re-opens the misarm class, so when the post-arm verify is ALSO
+# unavailable the arm must fail closed instead of standing unverified
+# (codex-adv-8). Either way a usable pattern is printed.
+_win_short_date_pattern() {
+    local _reg_out _pat
+    _reg_out=$(MSYS_NO_PATHCONV=1 reg query "HKCU\Control Panel\International" /v sShortDate 2>/dev/null) || {
+        printf '%s\n' "MM/dd/yyyy"
+        return 1
+    }
+    # Everything after the REG_SZ column, NOT $NF — some locales' sShortDate
+    # legitimately contains spaces (e.g. "yyyy. MM. dd."), and a last-field
+    # grab would truncate the pattern to its final token.
+    _pat=$(printf '%s\n' "$_reg_out" | sed -n 's/.*sShortDate[[:space:]]\{1,\}REG_SZ[[:space:]]\{1,\}//p' | head -n 1 | tr -d '\r' | sed 's/[[:space:]]*$//')
+    if [ -z "$_pat" ]; then
+        printf '%s\n' "MM/dd/yyyy"
+        return 1
+    fi
+    printf '%s\n' "$_pat"
+}
+
+# _win_delete_bad_task <task-name> (HIMMEL-938, codex-adv-11): delete a task
+# the post-arm verify rejected, LOUDLY surfacing a failed delete -- a
+# known-mistimed task left scheduled would relaunch at the wrong moment
+# while the ERR above implied it was cleaned up. Callers exit 2 either way;
+# this only controls what the operator is told.
+_win_delete_bad_task() {
+    if MSYS_NO_PATHCONV=1 schtasks /delete /tn "$1" /f >/dev/null 2>&1; then
+        return 0
+    fi
+    echo "ERR arm-resume: FAILED to delete the rejected task '$1' -- a known-mistimed task is STILL SCHEDULED. Remove it manually: schtasks /delete /tn \"$1\" /f" >&2
+    return 1
+}
+
+# _win_render_short_date <epoch> <pattern> (HIMMEL-938): render TARGET_EPOCH
+# as a schtasks-parseable date string in the given Windows short-date
+# pattern (e.g. "dd/MM/yyyy", "M/d/yyyy", "yyyy-MM-dd"). Scans the pattern
+# for runs of d/M/y: a `d`/`M` run always zero-pads to >=2 digits (even a
+# single-letter token like the real Windows en-US DEFAULT "M/d/yyyy" —
+# verified live on the operator's own box, which is NOT "MM/dd/yyyy" as
+# originally assumed). HIMMEL-938 is about the day/month ORDER a locale
+# implies, not digit width, and schtasks parses "7/2/2026" and "07/02/2026"
+# identically — so fixing width at >=2 keeps a same-order locale's /sd value
+# byte-identical to the pre-HIMMEL-938 hardcoded render (only a genuinely
+# reordered pattern, e.g. dd/MM/yyyy, changes the emitted string). A `y` run
+# of length <=2 renders a 2-digit year, longer renders 4-digit; a `d` run of
+# length >=3 is a day-NAME token (e.g. "dddd" in a locale whose short-date
+# pattern embeds a weekday) — schtasks /sd takes a numeric date only, so
+# that token is DROPPED along with one adjacent separator (preferring the
+# separator right after it, else the one already emitted before it) rather
+# than emitted literally. Any other character (separators: /, -, ., space,
+# comma) passes through unchanged. On render failure (bad pattern/args)
+# prints nothing — the caller falls back to the existing MM/dd/yyyy
+# START_DATE.
+_win_render_short_date() {
+    py_armor_capture -c '
+import sys, datetime, re
+epoch = int(sys.argv[1])
+pattern = sys.argv[2]
+# Month-NAME pictures (MMM/MMMM) and era pictures (g/gg) cannot be rendered
+# numerically -- a dd-MMM-yy locale expects a month NAME in /sd, so a
+# numeric render would misparse (coderabbit-4). Print nothing = render
+# failure; the caller falls back to MM/dd/yyyy AND marks the locale path
+# degraded, which the post-arm verify / dual-failure logic covers.
+if re.search(r"M{3,}|g", pattern):
+    sys.exit(0)
+dt = datetime.datetime.fromtimestamp(epoch).astimezone()
+out = []
+i, n = 0, len(pattern)
+while i < n:
+    c = pattern[i]
+    if c in "dMy":
+        j = i
+        while j < n and pattern[j] == c:
+            j += 1
+        run_len = j - i
+        if c == "d" and run_len >= 3:
+            # Day-name token -- drop it (numeric /sd only) plus one
+            # adjacent separator so the rendered string stays parseable.
+            if j < n and not pattern[j].isalpha():
+                j += 1
+            elif out and not out[-1].isalnum():
+                out.pop()
+        else:
+            if c == "y":
+                val = dt.year % 100 if run_len <= 2 else dt.year
+                width = 2 if run_len <= 2 else 4
+            else:
+                val = dt.day if c == "d" else dt.month
+                width = max(run_len, 2)
+            out.append(str(val).zfill(width))
+        i = j
+    else:
+        out.append(c)
+        i += 1
+print("".join(out))
+' "$1" "$2"
+}
+
 schedule_arm() {
     case "$PLATFORM" in
         windows)
@@ -2088,8 +2202,34 @@ schedule_arm() {
                 fi
             } > "$bat_path"
 
+            # HIMMEL-938 Part A: re-render START_DATE in the MACHINE's own
+            # Windows short-date locale right before it's used as /sd —
+            # schtasks parses /sd per-locale, so the MM/DD/YYYY default
+            # derived above is only correct on a US-format machine. Any
+            # render failure (empty PY_ARMOR_OUT) falls back to the
+            # original START_DATE, i.e. exactly the pre-HIMMEL-938 behavior.
+            # _locale_degraded=1 when the /sd value did NOT come from a
+            # successful registry-read + render (fallback used). On its own
+            # that only degrades locale-correctness -- but if the post-arm
+            # verify below is ALSO unavailable, BOTH safeguards are down and
+            # a day-first machine is back in the original misarm class, so
+            # that combination fails closed (codex-adv-8).
+            local _win_pat _win_sd _locale_degraded
+            _locale_degraded=0
+            if ! _win_pat=$(_win_short_date_pattern); then
+                _locale_degraded=1
+            fi
+            _win_sd=""
+            if _win_render_short_date "$TARGET_EPOCH" "$_win_pat"; then
+                _win_sd="$PY_ARMOR_OUT"
+            fi
+            if [ -z "$_win_sd" ]; then
+                _win_sd="$START_DATE"
+                _locale_degraded=1
+            fi
+
             if [ "$DRY_RUN" -eq 1 ]; then
-                echo "DRY arm-resume: would schtasks /create /tn $TASK_NAME /tr $bat_path_win /sc ONCE /st $RESUME_TIME /sd $START_DATE /f"
+                echo "DRY arm-resume: would schtasks /create /tn $TASK_NAME /tr $bat_path_win /sc ONCE /st $RESUME_TIME /sd $_win_sd /f"
                 echo "DRY arm-resume: .bat content:"
                 sed 's/^/    /' "$bat_path"
                 rm -f "$bat_path"
@@ -2099,13 +2239,152 @@ schedule_arm() {
             local err_file
             err_file=$(mktemp -t arm-resume.err.XXXXXX)
             # MSYS_NO_PATHCONV=1: see HIMMEL-125 note in list_existing.
-            if ! MSYS_NO_PATHCONV=1 schtasks /create /tn "$TASK_NAME" /tr "$bat_path_win" /sc ONCE /st "$RESUME_TIME" /sd "$START_DATE" /f 2>"$err_file"; then
+            if ! MSYS_NO_PATHCONV=1 schtasks /create /tn "$TASK_NAME" /tr "$bat_path_win" /sc ONCE /st "$RESUME_TIME" /sd "$_win_sd" /f 2>"$err_file"; then
                 echo "ERR arm-resume: schtasks /create failed:" >&2
                 cat "$err_file" >&2
                 rm -f "$err_file" "$bat_path"
                 exit 4
             fi
             rm -f "$err_file"
+            # Epoch at create-completion (codex-adv-3): if /create itself
+            # finished AFTER the target (slow setup on a tight lead), the
+            # ONCE task registers already-expired and can never fire -- a
+            # later NEXTRUN-NONE must then be a refused arm, never
+            # "consumed". Captured here, read in the verify branch below.
+            local _create_done_epoch
+            _create_done_epoch=$(date +%s)
+
+            # HIMMEL-938 Part B: post-arm NextRunTime verify. A successful
+            # schtasks /create rc=0 is not proof the task will fire at the
+            # intended moment -- a misregistered /sd (wrong locale, or any
+            # other silent misparse) still returns rc=0, and the task then
+            # just sits Ready and never fires (or fires months out — the
+            # exact HIMMEL-938 bug). Get-ScheduledTaskInfo's .NextRunTime is
+            # a real DateTime (locale-independent), unlike `schtasks /query`
+            # output, so it's the trustworthy cross-check. Fail-OPEN on the
+            # PROBE itself (missing/broken PowerShell must never block an
+            # otherwise-good arm -- WARN and let the arm stand); fail-CLOSED
+            # on a bad ANSWER (a confirmed months-out registration is worse
+            # than no arm at all -- delete the just-created task and refuse).
+            # Skipped entirely under --dry-run (the DRY branch above already
+            # returned).
+            local _verify_err _ps_out _ps_rc
+            _verify_err=$(mktemp -t arm-resume.verify-err.XXXXXX)
+            _ps_rc=0
+            # `|| _ps_rc=$?` (not a bare trailing `_ps_rc=$?`): under this
+            # file's `set -e`, a failing command substitution assigned
+            # straight to a variable aborts the script right there — same
+            # armor idiom py_armor_capture uses to stay errexit-safe.
+            # -ErrorAction Stop + try/catch (codex-adv-10): NEXTRUN-NONE must
+            # mean a SUCCESSFUL query that definitively found no next run --
+            # task-not-found maps to it via the locale-independent
+            # ObjectNotFound category; every OTHER query error (access
+            # denied, service failure, missing cmdlet) exits nonzero and
+            # takes the probe-failure path instead of masquerading as an
+            # authoritative answer.
+            _ps_out=$(powershell -NoProfile -NonInteractive -Command "
+                try {
+                    \$t = Get-ScheduledTaskInfo -TaskPath '\' -TaskName '$TASK_NAME' -ErrorAction Stop
+                    if (\$null -eq \$t.NextRunTime) { 'NEXTRUN-NONE' }
+                    else { [int64]([DateTimeOffset]\$t.NextRunTime.ToUniversalTime()).ToUnixTimeSeconds() }
+                } catch {
+                    # CommandNotFoundException (ScheduledTasks module absent)
+                    # ALSO carries the ObjectNotFound category -- it must
+                    # stay a probe failure, not a task-not-found answer
+                    # (coderabbit-1).
+                    if (\$_.Exception -is [System.Management.Automation.CommandNotFoundException]) { Write-Error \$_; exit 1 }
+                    elseif (\$_.CategoryInfo.Category -eq 'ObjectNotFound') { 'NEXTRUN-NONE' }
+                    else { Write-Error \$_; exit 1 }
+                }
+            " 2>"$_verify_err") || _ps_rc=$?
+            if [ "$_ps_rc" -ne 0 ] || [ -z "$_ps_out" ]; then
+                if [ "$_locale_degraded" -eq 1 ]; then
+                    # BOTH safeguards down: the /sd came from the US-format
+                    # fallback AND the verify can't check what actually
+                    # registered -- on a day-first machine this is exactly
+                    # the silent months-out misarm again. Loud no-arm wins.
+                    echo "ERR arm-resume: locale detection fell back to MM/dd/yyyy AND the post-arm verify could not run (rc=$_ps_rc) -- with both safeguards unavailable a mistimed arm would be silent. Deleting the task; fix 'reg'/'powershell' availability and re-arm." >&2
+                    sed 's/^/    /' "$_verify_err" >&2
+                    rm -f "$_verify_err"
+                    _win_delete_bad_task "$TASK_NAME" || true
+                    rm -f "$bat_path"
+                    exit 2
+                fi
+                echo "WARN arm-resume: post-arm NextRunTime verify could not run (rc=$_ps_rc) -- arm stands unverified:" >&2
+                sed 's/^/    /' "$_verify_err" >&2
+                rm -f "$_verify_err"
+            else
+                rm -f "$_verify_err"
+                _ps_out=$(printf '%s' "$_ps_out" | tr -d '\r\n ')
+                if [ "$_ps_out" = "NEXTRUN-NONE" ]; then
+                    # Create->verify race guard (codex-adv-1/-2): the emitted
+                    # .bat deletes its OWN task registration as its first
+                    # action, so a target whose time ARRIVED between /create
+                    # and this probe can legitimately be gone -- consumed,
+                    # not misarmed. A scheduler never fires EARLY, so a
+                    # missing task whose target is still in the future
+                    # cannot have fired -- that is a bad registration (e.g. a
+                    # past-date /sd misparse also registers with no
+                    # NextRunTime), and lead time alone must not excuse it.
+                    local _now_epoch _lead
+                    _now_epoch=$(date +%s)
+                    _lead=$((TARGET_EPOCH - _now_epoch))
+                    # Consumed iff created-before-target AND verified-after-
+                    # target -- a task created after its target registers
+                    # expired and never fires (codex-adv-3), and one whose
+                    # target is still future cannot have fired, even by a
+                    # second: the scheduler never fires early and every
+                    # epoch here reads the same local clock, so no skew
+                    # grace is warranted (codex-adv-2/-4). Everything else
+                    # refuses loudly.
+                    # Strict < : a create completing WITHIN the target second
+                    # is ambiguous (may have registered after the trigger
+                    # instant) -- ambiguity refuses (codex-adv-6).
+                    if [ "$_lead" -le 0 ] && [ "$_create_done_epoch" -lt "$TARGET_EPOCH" ]; then
+                        echo "WARN arm-resume: post-arm verify found no task '$TASK_NAME' and the target time has passed (lead=${_lead}s, created ${_create_done_epoch} <= target ${TARGET_EPOCH}) -- it fired and self-deleted during the create->verify window; treating the arm as consumed, not failed." >&2
+                    else
+                        echo "ERR arm-resume: post-arm verify found NO NextRunTime for '$TASK_NAME' (requested $RESUME_TIME on $_win_sd, epoch=$TARGET_EPOCH, lead=${_lead}s, create-done=$_create_done_epoch -- a still-future target cannot have fired, and a task created after its target never fires). Deleting the bad task -- this is the HIMMEL-938 silent-misarm class." >&2
+                        _win_delete_bad_task "$TASK_NAME" || true
+                        rm -f "$bat_path"
+                        exit 2
+                    fi
+                else
+                case "$_ps_out" in
+                    *[!0-9]*|'')
+                        if [ "$_locale_degraded" -eq 1 ]; then
+                            # Same dual-failure class as the dead-probe path
+                            # above: garbage output is no usable confirmation
+                            # either (codex-adv-9).
+                            echo "ERR arm-resume: locale detection fell back to MM/dd/yyyy AND the post-arm verify returned a non-numeric NextRunTime ('$_ps_out') -- with both safeguards unavailable a mistimed arm would be silent. Deleting the task; fix 'reg'/'powershell' availability and re-arm." >&2
+                            _win_delete_bad_task "$TASK_NAME" || true
+                            rm -f "$bat_path"
+                            exit 2
+                        fi
+                        echo "WARN arm-resume: post-arm verify returned a non-numeric NextRunTime ('$_ps_out') -- arm stands unverified" >&2
+                        ;;
+                    *)
+                        local _diff
+                        if [ "$_ps_out" -gt "$TARGET_EPOCH" ]; then
+                            _diff=$((_ps_out - TARGET_EPOCH))
+                        else
+                            _diff=$((TARGET_EPOCH - _ps_out))
+                        fi
+                        # A healthy arm registers NextRunTime on the exact
+                        # requested minute, so anything beyond scheduler
+                        # resolution (120s) is a real mistime -- a one-day-
+                        # late registration misses the resume window just as
+                        # surely as a months-out one (codex-adv-5; tightened
+                        # from the ticket's original 24h sketch).
+                        if [ "$_diff" -gt 120 ]; then
+                            echo "ERR arm-resume: post-arm verify mismatch for '$TASK_NAME' -- requested epoch=$TARGET_EPOCH ($RESUME_TIME on $_win_sd), registered NextRunTime epoch=$_ps_out (diff=${_diff}s > 120s tolerance). Deleting the bad task -- this is the HIMMEL-938 mistimed-arm class." >&2
+                            _win_delete_bad_task "$TASK_NAME" || true
+                            rm -f "$bat_path"
+                            exit 2
+                        fi
+                        ;;
+                esac
+                fi
+            fi
             ;;
         linux)
             if command -v at >/dev/null 2>&1; then

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -139,7 +139,25 @@ cat > "$SCHED_STUB_T17/at" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-chmod +x "$SCHED_STUB_T17/schtasks" "$SCHED_STUB_T17/atq" "$SCHED_STUB_T17/at"
+# HIMMEL-938: schtasks /create above is a stateless "always succeeds" fake —
+# it never actually registers anything with the real OS scheduler. On an
+# ACTUAL Windows box (this suite runs on Windows dev machines, not just
+# Linux CI), arm-resume's post-arm verify would otherwise fall through to
+# the REAL powershell, query the REAL (nonexistent, since /create was
+# faked) task, and correctly-but-spuriously refuse (rc=2) every non-dry-run
+# arm through this stub. Stubbing powershell to echo "right now" keeps the
+# fake create/verify pair internally consistent — the tests below that use
+# this stub for a REAL (non-dry-run) arm care about dedup/worktree/naming
+# behavior, not the verify feature itself.
+cat > "$SCHED_STUB_T17/powershell" <<'EOF'
+#!/usr/bin/env bash
+# Probe "unavailable" -> arm-resume's verify fail-opens (WARN, arm stands).
+# Faking a NextRunTime here would need the requested TARGET_EPOCH, which the
+# stub can't know; the fail-open path is the honest fake for tests that
+# exercise dedup/worktree/naming, not the verify feature itself.
+exit 1
+EOF
+chmod +x "$SCHED_STUB_T17/schtasks" "$SCHED_STUB_T17/atq" "$SCHED_STUB_T17/at" "$SCHED_STUB_T17/powershell"
 
 # ---------------------------------------------------------------------------
 # T1: --cwd <dir> overrides everything, even when resume_cwd is set
@@ -613,7 +631,16 @@ cat > "$ARMED_STUB/claude" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-chmod +x "$ARMED_STUB/schtasks" "$ARMED_STUB/atq" "$ARMED_STUB/at" "$ARMED_STUB/claude"
+# HIMMEL-938: see the matching comment on SCHED_STUB_T17 above — /create is a
+# stateless fake, so on a real Windows box the post-arm verify needs its own
+# fake to stay internally consistent (else a real powershell query for a
+# task that was never really created would correctly refuse the arm).
+cat > "$ARMED_STUB/powershell" <<'EOF'
+#!/usr/bin/env bash
+# Probe "unavailable" -> verify fail-opens (see SCHED_STUB_T17 note).
+exit 1
+EOF
+chmod +x "$ARMED_STUB/schtasks" "$ARMED_STUB/atq" "$ARMED_STUB/at" "$ARMED_STUB/claude" "$ARMED_STUB/powershell"
 
 TELEMETRY_T23="$TMP/telemetry-t23"
 HO=$(make_handover "$WORK_REPO")
@@ -792,7 +819,17 @@ EOF
 #!/usr/bin/env bash
 exit 0
 EOF
-    chmod +x "$dir/schtasks" "$dir/at" "$dir/atq" "$dir/atrm" "$dir/claude"
+    # HIMMEL-938: same reasoning as the SCHED_STUB_T17/ARMED_STUB comments
+    # above — the stateful schtasks stub's /create records a task name but
+    # never talks to the real scheduler, so a real Windows box's post-arm
+    # verify needs its own fake or every T25+ non-dry-run arm through this
+    # stub would be spuriously refused.
+    cat > "$dir/powershell" <<'EOF'
+#!/usr/bin/env bash
+# Probe "unavailable" -> verify fail-opens (see SCHED_STUB_T17 note).
+exit 1
+EOF
+    chmod +x "$dir/schtasks" "$dir/at" "$dir/atq" "$dir/atrm" "$dir/claude" "$dir/powershell"
 }
 
 # Count armed slots in the platform's state location.
@@ -1602,6 +1639,453 @@ mac_env bash "$ARM" --time "$FUTURE_TIME" --handover "$MAC_HO" --force >/dev/nul
 n="$(grep -c 'HIMMEL-Resume-' "$CRON_STORE" 2>/dev/null)" || n=0
 if [ "$n" -eq 2 ]; then echo "PASS macOS --force on A leaves sibling B (2 slots)"; else echo "FAIL macOS sibling preserve entries=$n"; FAILED=$((FAILED+1)); fi
 if [ -n "$b_line" ] && grep -qF "$b_line" "$CRON_STORE" 2>/dev/null; then echo "PASS macOS sibling B line survived --force on A"; else echo "FAIL macOS sibling B line wiped"; FAILED=$((FAILED+1)); fi
+
+# ---------------------------------------------------------------------------
+# V1-V5 (HIMMEL-938): Windows /sd locale-aware render + post-arm NextRunTime
+# verify. arm-resume selects PLATFORM from OSTYPE (falling back to uname -s),
+# so — exactly like mac_env above forces OSTYPE=darwin23 to exercise the
+# macOS/crontab branch from any host — win_env forces OSTYPE=msys to exercise
+# the Windows/schtasks branch here, even when this suite runs on ubuntu CI.
+# WINBIN carries the two stubs every case below needs no matter which
+# schtasks/reg/powershell stub it's paired with: `claude` (schedule_arm
+# resolves it via `command -v claude` before writing the .bat, even under
+# --dry-run) and `cygpath` (converts the .bat/claude/cwd paths for the
+# schtasks /tr line; a real Linux box has neither, so both must exist for
+# the Windows branch to get past its own tool-missing guards).
+# ---------------------------------------------------------------------------
+WINBIN="$TMP/win-stub-bin"
+mkdir -p "$WINBIN"
+cat > "$WINBIN/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$WINBIN/cygpath" <<'EOF'
+#!/usr/bin/env bash
+# Minimal stub: echo each non-flag (path) argument on its own line,
+# unchanged. schedule_arm only needs 3 non-empty lines back in argument
+# order -- these tests never inspect the ACTUAL Windows-path form.
+for a in "$@"; do
+    case "$a" in
+        -*) ;;
+        *) printf '%s\n' "$a" ;;
+    esac
+done
+EOF
+chmod +x "$WINBIN/claude" "$WINBIN/cygpath"
+win_env() { local _dir="$1"; shift; env PATH="$_dir:$WINBIN:$PATH" OSTYPE="msys" "$@"; }
+
+# V1: DD/MM locale render. `reg` reports a dd/MM/yyyy short-date pattern;
+# --dry-run so no real scheduler is touched. The expected /sd is computed
+# independently here (mirroring arm-resume's own HH:MM -> today/tomorrow
+# rule), so the assertion is an exact full-string match that's correct
+# regardless of what day the suite happens to run on (no reliance on
+# today's day-of-month differing from today's month).
+V1BIN="$TMP/v1-stub-bin"; mkdir -p "$V1BIN"
+cat > "$V1BIN/reg" <<'EOF'
+#!/usr/bin/env bash
+echo "HKEY_CURRENT_USER\\Control Panel\\International"
+echo "    sShortDate    REG_SZ    dd/MM/yyyy"
+exit 0
+EOF
+chmod +x "$V1BIN/reg"
+V1_HO="$(make_handover "$WORK_REPO")"
+V1_EXPECT=$(python3 -c '
+import datetime, sys
+hh, mm = (int(x) for x in sys.argv[1].split(":"))
+now = datetime.datetime.now().astimezone()
+cand = now.replace(hour=hh, minute=mm, second=0, microsecond=0)
+if cand <= now:
+    cand += datetime.timedelta(days=1)
+print(cand.strftime("%d/%m/%Y"))
+' "$FUTURE_TIME")
+out=$(win_env "$V1BIN" bash "$ARM" --time "$FUTURE_TIME" --handover "$V1_HO" --dry-run 2>&1)
+rc=$?
+assert_rc "V1 dd/MM/yyyy locale dry-run exits 0" 0 "$rc"
+assert_contains "V1 /sd rendered day-first per machine locale" "/sd $V1_EXPECT " "$out"
+
+# V2: registry read fails -> falls back to the pre-HIMMEL-938 MM/dd/yyyy
+# (byte-identical to the old hardcoded behavior). `reg` here mimics a
+# missing/inaccessible key: nonzero exit, nothing useful on stdout.
+V2BIN="$TMP/v2-stub-bin"; mkdir -p "$V2BIN"
+cat > "$V2BIN/reg" <<'EOF'
+#!/usr/bin/env bash
+echo "ERROR: The system was unable to find the specified registry key." >&2
+exit 1
+EOF
+chmod +x "$V2BIN/reg"
+V2_HO="$(make_handover "$WORK_REPO")"
+V2_EXPECT=$(python3 -c '
+import datetime, sys
+hh, mm = (int(x) for x in sys.argv[1].split(":"))
+now = datetime.datetime.now().astimezone()
+cand = now.replace(hour=hh, minute=mm, second=0, microsecond=0)
+if cand <= now:
+    cand += datetime.timedelta(days=1)
+print(cand.strftime("%m/%d/%Y"))
+' "$FUTURE_TIME")
+out=$(win_env "$V2BIN" bash "$ARM" --time "$FUTURE_TIME" --handover "$V2_HO" --dry-run 2>&1)
+rc=$?
+assert_rc "V2 reg-failure dry-run still exits 0" 0 "$rc"
+assert_contains "V2 /sd falls back to MM/dd/yyyy" "/sd $V2_EXPECT " "$out"
+
+# V2b (coderabbit-4): a month-NAME pattern (dd-MMM-yy) cannot be rendered
+# numerically -- the render must refuse and fall back to MM/dd/yyyy (and
+# mark the locale path degraded; the fallback value is what the dry-run
+# print shows).
+V2B_BIN="$TMP/v2b-stub-bin"; mkdir -p "$V2B_BIN"
+cat > "$V2B_BIN/reg" <<'EOF'
+#!/usr/bin/env bash
+echo "HKEY_CURRENT_USER\\Control Panel\\International"
+echo "    sShortDate    REG_SZ    dd-MMM-yy"
+exit 0
+EOF
+chmod +x "$V2B_BIN/reg"
+V2B_HO="$(make_handover "$WORK_REPO")"
+out=$(win_env "$V2B_BIN" bash "$ARM" --time "$FUTURE_TIME" --handover "$V2B_HO" --dry-run 2>&1)
+rc=$?
+assert_rc "V2b month-name pattern dry-run still exits 0" 0 "$rc"
+assert_contains "V2b /sd falls back to MM/dd/yyyy on MMM pattern" "/sd $V2_EXPECT " "$out"
+
+# V3-V5 share a stateless create-ok schtasks stub (with a logged /delete) and
+# an empty-scheduler /query — these are REAL (non-dry-run) arms so the
+# post-arm verify block actually runs. `reg` is intentionally ABSENT from
+# these stub dirs (same as a bare Linux box): the locale render falls back
+# to MM/dd/yyyy, which is irrelevant to what V3-V5 exercise.
+make_verify_stub() {
+    local dir="$1" ps_body="$2"
+    mkdir -p "$dir"
+    cat > "$dir/schtasks" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+    /query)  exit 0 ;;
+    /create) exit 0 ;;
+    /delete) printf '%s\n' "\$*" >> "$dir/delete.log"; exit 0 ;;
+    *)       exit 0 ;;
+esac
+EOF
+    cat > "$dir/powershell" <<EOF
+#!/usr/bin/env bash
+$ps_body
+EOF
+    chmod +x "$dir/schtasks" "$dir/powershell"
+}
+
+# V3: registered NextRunTime is ~180 days from now -> the exact HIMMEL-938
+# months-out class. The powershell stub can't see arm-resume's TARGET_EPOCH,
+# so it computes "now (at verify time) + 180 days" itself -- verify runs
+# moments after arm-resume derived TARGET_EPOCH from the same wall clock, so
+# the two land on the same calendar day and the ~180d gap is unambiguous
+# (far past the 24h OK/ERR threshold either way).
+V3="$TMP/v3-stub-bin"
+make_verify_stub "$V3" 'python3 -c "import time; print(int(time.time()) + 180*86400)"'
+V3_HO="$(make_handover "$WORK_REPO")"
+out=$(TMPDIR="$TMP" win_env "$V3" bash "$ARM" --time "$FUTURE_TIME" --handover "$V3_HO" 2>&1)
+rc=$?
+assert_rc "V3 months-out verify refuses (rc=2)" 2 "$rc"
+assert_contains "V3 ERR mentions NextRunTime" "NextRunTime" "$out"
+if [ -s "$V3/delete.log" ]; then
+    echo "PASS V3 bad task was deleted (schtasks /delete hit)"
+else
+    echo "FAIL V3 expected schtasks /delete to be called"
+    FAILED=$((FAILED + 1))
+fi
+
+# V4: registered NextRunTime matches the requested time exactly -> verify
+# passes, arm stands (rc=0). The stub can't independently derive
+# TARGET_EPOCH either, so the test computes it FIRST (mirroring arm-resume's
+# own HH:MM -> epoch rule) and threads it straight into the stub script --
+# simulating a scheduler that registered exactly what was asked.
+V4_EPOCH=$(python3 -c '
+import datetime, sys
+hh, mm = (int(x) for x in sys.argv[1].split(":"))
+now = datetime.datetime.now().astimezone()
+cand = now.replace(hour=hh, minute=mm, second=0, microsecond=0)
+if cand <= now:
+    cand += datetime.timedelta(days=1)
+print(int(cand.timestamp()))
+' "$FUTURE_TIME")
+V4="$TMP/v4-stub-bin"
+make_verify_stub "$V4" "echo $V4_EPOCH"
+V4_HO="$(make_handover "$WORK_REPO")"
+out=$(TMPDIR="$TMP" win_env "$V4" bash "$ARM" --time "$FUTURE_TIME" --handover "$V4_HO" 2>&1)
+rc=$?
+assert_rc "V4 exact NextRunTime match arms cleanly (rc=0)" 0 "$rc"
+assert_contains "V4 arm banner printed" "RESUME ARMED" "$out"
+if [ -s "$V4/delete.log" ]; then
+    echo "FAIL V4 verify pass must NOT delete the task"
+    FAILED=$((FAILED + 1))
+else
+    echo "PASS V4 verify pass leaves the task in place"
+fi
+
+# V4b (codex-adv-5 boundary): registered NextRunTime is 121s past the
+# request -- just beyond scheduler resolution -> refuse (rc=2) + delete. A
+# healthy arm lands on the exact requested minute, so 121s is already a
+# real mistime (the old 24h tolerance let an exactly-one-day-late
+# registration pass with only a WARN).
+V4B="$TMP/v4b-stub-bin"
+make_verify_stub "$V4B" "echo $((V4_EPOCH + 121))"
+V4B_HO="$(make_handover "$WORK_REPO")"
+out=$(TMPDIR="$TMP" win_env "$V4B" bash "$ARM" --time "$FUTURE_TIME" --handover "$V4B_HO" 2>&1)
+rc=$?
+assert_rc "V4b 121s NextRunTime mismatch refuses (rc=2)" 2 "$rc"
+assert_contains "V4b ERR names the 120s tolerance" "120s tolerance" "$out"
+if [ -s "$V4B/delete.log" ]; then
+    echo "PASS V4b mistimed task was deleted (schtasks /delete hit)"
+else
+    echo "FAIL V4b expected schtasks /delete to be called"
+    FAILED=$((FAILED + 1))
+fi
+
+# V5: the verify PROBE itself fails (powershell exits nonzero, no output)
+# while locale detection WORKS -> fail-OPEN: a WARN, but the arm still
+# stands (rc=0). Distinguishes the infra-failure path (V5) from the
+# bad-answer path (V3): only a CONFIRMED bad answer deletes the task. The
+# reg stub matters (codex-adv-8): with locale detection ALSO down this
+# would be the V8 dual-failure refuse, and on Linux CI there is no real
+# reg to fall back on.
+V5="$TMP/v5-stub-bin"
+make_verify_stub "$V5" 'echo "stub: powershell unavailable" >&2; exit 1'
+cat > "$V5/reg" <<'EOF'
+#!/usr/bin/env bash
+echo "HKEY_CURRENT_USER\\Control Panel\\International"
+echo "    sShortDate    REG_SZ    M/d/yyyy"
+exit 0
+EOF
+chmod +x "$V5/reg"
+V5_HO="$(make_handover "$WORK_REPO")"
+out=$(TMPDIR="$TMP" win_env "$V5" bash "$ARM" --time "$FUTURE_TIME" --handover "$V5_HO" 2>&1)
+rc=$?
+assert_rc "V5 verify-infra-failure still arms (rc=0)" 0 "$rc"
+assert_contains "V5 WARN surfaced for the failed probe" "WARN arm-resume: post-arm NextRunTime verify could not run" "$out"
+if [ -s "$V5/delete.log" ]; then
+    echo "FAIL V5 infra failure must NOT delete the task"
+    FAILED=$((FAILED + 1))
+else
+    echo "PASS V5 infra failure leaves the task in place"
+fi
+
+# V6: NEXTRUN-NONE with a target that PASSED during the create->verify
+# window -> the race guard (codex-adv-1/-2): the .bat self-deletes its task
+# registration on fire, so a task missing AFTER its target time legitimately
+# fired -- the arm is CONSUMED (WARN + rc=0, no delete). The powershell stub
+# simulates the slow probe by sleeping until the target has passed before
+# answering NEXTRUN-NONE. Target = next whole minute (lead 1-60s); if that
+# crosses midnight the HH:MM -> today/tomorrow rule inflates the lead to
+# ~24h -- skip rather than flake (this suite runs overnight).
+V6_PROBE=$(python3 -c '
+import datetime
+now = datetime.datetime.now().astimezone()
+cand = (now + datetime.timedelta(seconds=60)).replace(second=0, microsecond=0)
+if cand <= now:
+    cand += datetime.timedelta(days=1)
+print(cand.strftime("%H:%M"), int((cand - now).total_seconds()))
+')
+NEAR_TIME=${V6_PROBE% *}
+NEAR_LEAD=${V6_PROBE#* }
+if [ "$NEAR_LEAD" -gt 60 ] || [ "$NEAR_LEAD" -lt 10 ]; then
+    # >60 = midnight edge; <10 = arm-resume's own pre-create work could
+    # overshoot the target before /create, flipping the case into
+    # create-after-target (V6c territory) and flaking (coderabbit-5).
+    echo "SKIP V6 consumed-arm race guard (lead ${NEAR_LEAD}s outside the 10-60s reliable window)"
+else
+    V6="$TMP/v6-stub-bin"
+    # Sleep past the target (lead + small margin), then report the task gone
+    # -- simulating a probe that ran after the task fired and self-deleted.
+    make_verify_stub "$V6" "sleep $((NEAR_LEAD + 3))
+echo NEXTRUN-NONE"
+    V6_HO="$(make_handover "$WORK_REPO")"
+    out=$(TMPDIR="$TMP" win_env "$V6" bash "$ARM" --time "$NEAR_TIME" --handover "$V6_HO" 2>&1)
+    rc=$?
+    assert_rc "V6 NEXTRUN-NONE after target passed = consumed (rc=0)" 0 "$rc"
+    assert_contains "V6 WARN says consumed, not failed" "treating the arm as consumed" "$out"
+    if [ -s "$V6/delete.log" ]; then
+        echo "FAIL V6 consumed arm must NOT trigger a delete"
+        FAILED=$((FAILED + 1))
+    else
+        echo "PASS V6 consumed arm leaves scheduler state alone"
+    fi
+fi
+
+# V6b (codex-adv-2 negative): NEXTRUN-NONE while the target is STILL FUTURE
+# (~2min lead) -> a scheduler never fires early, so the task cannot have
+# been consumed; this is a bad registration (e.g. a past-date /sd misparse
+# also registers with no NextRunTime) -> loud refuse (rc=2) + delete.
+V6B_PROBE=$(python3 -c '
+import datetime
+now = datetime.datetime.now().astimezone()
+cand = (now + datetime.timedelta(seconds=150)).replace(second=0, microsecond=0)
+if cand <= now:
+    cand += datetime.timedelta(days=1)
+print(cand.strftime("%H:%M"), int((cand - now).total_seconds()))
+')
+V6B_TIME=${V6B_PROBE% *}
+V6B_LEAD=${V6B_PROBE#* }
+if [ "$V6B_LEAD" -lt 60 ] || [ "$V6B_LEAD" -gt 180 ]; then
+    echo "SKIP V6b future-target NEXTRUN-NONE (midnight edge: computed lead ${V6B_LEAD}s)"
+else
+    V6B="$TMP/v6b-stub-bin"
+    make_verify_stub "$V6B" 'echo NEXTRUN-NONE'
+    V6B_HO="$(make_handover "$WORK_REPO")"
+    out=$(TMPDIR="$TMP" win_env "$V6B" bash "$ARM" --time "$V6B_TIME" --handover "$V6B_HO" 2>&1)
+    rc=$?
+    assert_rc "V6b NEXTRUN-NONE with future target refuses (rc=2)" 2 "$rc"
+    assert_contains "V6b ERR says a still-future target cannot have fired" "cannot have fired" "$out"
+    if [ -s "$V6B/delete.log" ]; then
+        echo "PASS V6b bad task was deleted (schtasks /delete hit)"
+    else
+        echo "FAIL V6b expected schtasks /delete to be called"
+        FAILED=$((FAILED + 1))
+    fi
+fi
+
+# V6c (codex-adv-3): /create itself completed AFTER the target passed (slow
+# setup on a tight lead) -> the ONCE task registered already-expired and can
+# NEVER fire; NEXTRUN-NONE here must refuse (rc=2), never report consumed.
+# The schtasks stub sleeps past the target inside /create to simulate the
+# slow path; the probe answers NEXTRUN-NONE immediately.
+V6C_PROBE=$(python3 -c '
+import datetime
+now = datetime.datetime.now().astimezone()
+cand = (now + datetime.timedelta(seconds=60)).replace(second=0, microsecond=0)
+if cand <= now:
+    cand += datetime.timedelta(days=1)
+print(cand.strftime("%H:%M"), int((cand - now).total_seconds()))
+')
+V6C_TIME=${V6C_PROBE% *}
+V6C_LEAD=${V6C_PROBE#* }
+if [ "$V6C_LEAD" -gt 60 ]; then
+    echo "SKIP V6c create-after-target (midnight edge: computed lead ${V6C_LEAD}s)"
+else
+    V6C="$TMP/v6c-stub-bin"
+    mkdir -p "$V6C"
+    cat > "$V6C/schtasks" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+    /query)  exit 0 ;;
+    /create) sleep $((V6C_LEAD + 3)); exit 0 ;;
+    /delete) printf '%s\n' "\$*" >> "$V6C/delete.log"; exit 0 ;;
+    *)       exit 0 ;;
+esac
+EOF
+    cat > "$V6C/powershell" <<'EOF'
+#!/usr/bin/env bash
+echo NEXTRUN-NONE
+EOF
+    chmod +x "$V6C/schtasks" "$V6C/powershell"
+    V6C_HO="$(make_handover "$WORK_REPO")"
+    out=$(TMPDIR="$TMP" win_env "$V6C" bash "$ARM" --time "$V6C_TIME" --handover "$V6C_HO" 2>&1)
+    rc=$?
+    assert_rc "V6c create-after-target NEXTRUN-NONE refuses (rc=2)" 2 "$rc"
+    assert_contains "V6c ERR notes created-after-target never fires" "created after its target never fires" "$out"
+    if [ -s "$V6C/delete.log" ]; then
+        echo "PASS V6c dead task was deleted (schtasks /delete hit)"
+    else
+        echo "FAIL V6c expected schtasks /delete to be called"
+        FAILED=$((FAILED + 1))
+    fi
+fi
+
+# V7: NEXTRUN-NONE with a FAR target (lead > 180s) -> still the loud-refuse
+# path: a task that vanished long before its fire time was never registered
+# right (the original HIMMEL-938/HIMMEL-204 silent-misarm class). Skip in
+# the last ~10 minutes before midnight, where FUTURE_TIME (23:59) stops
+# being "far".
+V7_LEAD=$(python3 -c '
+import datetime
+now = datetime.datetime.now().astimezone()
+cand = now.replace(hour=23, minute=59, second=0, microsecond=0)
+if cand <= now:
+    cand += datetime.timedelta(days=1)
+print(int((cand - now).total_seconds()))
+')
+if [ "$V7_LEAD" -le 600 ]; then
+    echo "SKIP V7 far-target NEXTRUN-NONE (too close to midnight: lead ${V7_LEAD}s)"
+else
+    V7="$TMP/v7-stub-bin"
+    make_verify_stub "$V7" 'echo NEXTRUN-NONE'
+    V7_HO="$(make_handover "$WORK_REPO")"
+    out=$(TMPDIR="$TMP" win_env "$V7" bash "$ARM" --time "$FUTURE_TIME" --handover "$V7_HO" 2>&1)
+    rc=$?
+    assert_rc "V7 NEXTRUN-NONE far target refuses (rc=2)" 2 "$rc"
+    assert_contains "V7 ERR names the silent-misarm class" "silent-misarm" "$out"
+    if [ -s "$V7/delete.log" ]; then
+        echo "PASS V7 bad task was deleted (schtasks /delete hit)"
+    else
+        echo "FAIL V7 expected schtasks /delete to be called"
+        FAILED=$((FAILED + 1))
+    fi
+fi
+
+# V8 (codex-adv-8): BOTH safeguards down -- locale detection fails (reg
+# errors -> MM/dd/yyyy fallback) AND the verify probe fails -> on a
+# day-first machine this is the original silent-misarm class again, so the
+# arm must fail CLOSED: delete + rc=2, never a silent success.
+V8="$TMP/v8-stub-bin"
+make_verify_stub "$V8" 'echo "stub: powershell unavailable" >&2; exit 1'
+cat > "$V8/reg" <<'EOF'
+#!/usr/bin/env bash
+echo "stub: registry unavailable" >&2
+exit 1
+EOF
+chmod +x "$V8/reg"
+V8_HO="$(make_handover "$WORK_REPO")"
+out=$(TMPDIR="$TMP" win_env "$V8" bash "$ARM" --time "$FUTURE_TIME" --handover "$V8_HO" 2>&1)
+rc=$?
+assert_rc "V8 locale-fallback + probe-failure refuses (rc=2)" 2 "$rc"
+assert_contains "V8 ERR names both safeguards" "both safeguards unavailable" "$out"
+if [ -s "$V8/delete.log" ]; then
+    echo "PASS V8 dual-failure arm was deleted (schtasks /delete hit)"
+else
+    echo "FAIL V8 expected schtasks /delete to be called"
+    FAILED=$((FAILED + 1))
+fi
+
+# V8b (codex-adv-9): locale fallback + probe that SUCCEEDS (rc=0) but emits
+# garbage -- no usable confirmation either -> same dual-failure refuse.
+V8B="$TMP/v8b-stub-bin"
+make_verify_stub "$V8B" 'echo "PS banner noise: not a number"'
+cat > "$V8B/reg" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$V8B/reg"
+V8B_HO="$(make_handover "$WORK_REPO")"
+out=$(TMPDIR="$TMP" win_env "$V8B" bash "$ARM" --time "$FUTURE_TIME" --handover "$V8B_HO" 2>&1)
+rc=$?
+assert_rc "V8b locale-fallback + garbage probe output refuses (rc=2)" 2 "$rc"
+assert_contains "V8b ERR names the non-numeric dual failure" "non-numeric NextRunTime" "$out"
+if [ -s "$V8B/delete.log" ]; then
+    echo "PASS V8b dual-failure arm was deleted (schtasks /delete hit)"
+else
+    echo "FAIL V8b expected schtasks /delete to be called"
+    FAILED=$((FAILED + 1))
+fi
+
+# V9 (codex-adv-11): the verify rejects (months-out answer) but the cleanup
+# /delete FAILS -> the refusal must still exit 2 AND loudly surface that the
+# known-bad task is STILL SCHEDULED (not silently claim cleanup).
+V9="$TMP/v9-stub-bin"
+mkdir -p "$V9"
+cat > "$V9/schtasks" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+    /query)  exit 0 ;;
+    /create) exit 0 ;;
+    /delete) printf '%s\n' "\$*" >> "$V9/delete.log"; exit 1 ;;
+    *)       exit 0 ;;
+esac
+EOF
+cat > "$V9/powershell" <<'EOF'
+#!/usr/bin/env bash
+python3 -c "import time; print(int(time.time()) + 180*86400)"
+EOF
+chmod +x "$V9/schtasks" "$V9/powershell"
+V9_HO="$(make_handover "$WORK_REPO")"
+out=$(TMPDIR="$TMP" win_env "$V9" bash "$ARM" --time "$FUTURE_TIME" --handover "$V9_HO" 2>&1)
+rc=$?
+assert_rc "V9 rejection with failed delete still refuses (rc=2)" 2 "$rc"
+assert_contains "V9 residual-task risk surfaced loudly" "STILL SCHEDULED" "$out"
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
Public propagation of private squash befb988e (HIMMEL-938).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows scheduled-task setup for regional date formats.
  * Added verification that scheduled tasks have the expected next run time.
  * Tasks with missing or significantly incorrect run times are now removed and rejected.
  * Added safe fallback behavior when regional settings cannot be read.

* **Documentation**
  * Documented locale-aware scheduling safeguards and verification behavior.
  * Clarified that direct, hand-crafted scheduling commands remain unsupported.

* **Tests**
  * Added coverage for regional date formats, fallback scenarios, timing tolerances, verification failures, and task cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->