### PR TITLE
feat(hooks): [HIMMEL-920] bank-aware implementor-dispatch guard (PreToolUse on Agent) (#1167)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,7 @@ Autonomous end-to-end execution of a well-scoped ticket: see
 
 ## ENFORCEMENT (runs automatically)
 
-himmel enforces structurally, not by prose: **10 PreToolUse hooks**
+himmel enforces structurally, not by prose: **11 PreToolUse hooks**
 (`auto-approve-safe-bash`, `block-edit-on-main`, `block-read-secrets`,
 `block-rogue-claude-schedule` — blocks raw scheduler-arms of claude that bypass
 arm-resume.sh (System32-cwd trap, HIMMEL-647),
@@ -304,10 +304,13 @@ arm-resume.sh (System32-cwd trap, HIMMEL-647),
 root-equivalent docker/podman mount+privilege guard, HIMMEL-441, shipped via the
 himmel-ops plugin `hooks.json` so it's live only after `/himmel-update` + a fresh
 session; likewise `block-merged-pr-commit` — hygiene guard that blocks committing
-onto a merged-PR branch, HIMMEL-512, same plugin delivery; and
-`block-unresolved-cr-merge` — blocks `gh pr merge` while CodeRabbit review threads
-are unresolved or its check-run is in-flight on the head SHA, fail-open on every
-API/dep error, bypass `CR_MERGE_GATE_OK=1` — HIMMEL-936, same plugin delivery), **1 PostToolUse hook**
+onto a merged-PR branch, HIMMEL-512, same plugin delivery; `block-unresolved-cr-merge` —
+blocks `gh pr merge` while CodeRabbit review threads are unresolved or its check-run
+is in-flight on the head SHA, fail-open on every API/dep error, bypass
+`CR_MERGE_GATE_OK=1` — HIMMEL-936, same plugin delivery; and `guard-implementor-dispatch` —
+bank-aware cost guard that blocks a Sonnet/Opus/Fable implementor-shaped Agent dispatch
+when the 5-hour bank is at/above 80% (advisory-only at 65%), fail-open on every infra
+error, bypass `IMPL_GUARD_OK=1` — HIMMEL-920, same plugin delivery), **1 PostToolUse hook**
 (`auto-arm-on-subagent-cap` — detects cap in Agent tool results, HIMMEL-276),
 **pre-commit/commit-msg/pre-push gates** (source of truth
 `.pre-commit-config.yaml`; pre-push incl. `check-platforms-tested`;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ Autonomous end-to-end execution of a well-scoped ticket: see
 
 ## ENFORCEMENT (runs automatically)
 
-himmel enforces structurally, not by prose: **10 PreToolUse hooks**
+himmel enforces structurally, not by prose: **11 PreToolUse hooks**
 (`auto-approve-safe-bash`, `block-edit-on-main`, `block-read-secrets`,
 `block-rogue-claude-schedule` — blocks raw scheduler-arms of claude that bypass
 arm-resume.sh (System32-cwd trap, HIMMEL-647),
@@ -266,10 +266,13 @@ arm-resume.sh (System32-cwd trap, HIMMEL-647),
 root-equivalent docker/podman mount+privilege guard, HIMMEL-441, shipped via the
 himmel-ops plugin `hooks.json` so it's live only after `/himmel-update` + a fresh
 session; likewise `block-merged-pr-commit` — hygiene guard that blocks committing
-onto a merged-PR branch, HIMMEL-512, same plugin delivery; and
-`block-unresolved-cr-merge` — blocks `gh pr merge` while CodeRabbit review threads
-are unresolved or its check-run is in-flight on the head SHA, fail-open on every
-API/dep error, bypass `CR_MERGE_GATE_OK=1` — HIMMEL-936, same plugin delivery), **1 PostToolUse hook**
+onto a merged-PR branch, HIMMEL-512, same plugin delivery; `block-unresolved-cr-merge` —
+blocks `gh pr merge` while CodeRabbit review threads are unresolved or its check-run
+is in-flight on the head SHA, fail-open on every API/dep error, bypass
+`CR_MERGE_GATE_OK=1` — HIMMEL-936, same plugin delivery; and `guard-implementor-dispatch` —
+bank-aware cost guard that blocks a Sonnet/Opus/Fable implementor-shaped Agent dispatch
+when the 5-hour bank is at/above 80% (advisory-only at 65%), fail-open on every infra
+error, bypass `IMPL_GUARD_OK=1` — HIMMEL-920, same plugin delivery), **1 PostToolUse hook**
 (`auto-arm-on-subagent-cap` — detects cap in Agent tool results, HIMMEL-276),
 **pre-commit/commit-msg/pre-push gates** (source of truth
 `.pre-commit-config.yaml`; pre-push incl. `check-platforms-tested`;

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -108,14 +108,19 @@ the env var.
 
 Seven hooks wired in `.claude/settings.json` fire BEFORE Claude executes
 tool calls. Six BLOCK risky operations; one (`auto-approve-safe-bash`)
-GRANTS permission for safe ones so they don't hang. An eighth, ninth, and
-tenth block hook — `block-docker-privesc.sh` (HIMMEL-441),
-`block-merged-pr-commit.sh` (HIMMEL-512), and `block-unresolved-cr-merge.sh`
-(HIMMEL-936) — are shipped via the **himmel-ops plugin `hooks.json`** rather
-than `.claude/settings.json` (so they can be agent-installed without a
-settings self-mod veto — same delivery path as `inject-minerva-critic.sh`);
-all three are live only after `/himmel-update` (marketplace re-sync) + a
-fresh session.
+GRANTS permission for safe ones so they don't hang. An eighth, ninth, tenth,
+and eleventh hook — `block-docker-privesc.sh` (HIMMEL-441),
+`block-merged-pr-commit.sh` (HIMMEL-512), `block-unresolved-cr-merge.sh`
+(HIMMEL-936), and `guard-implementor-dispatch.sh` (HIMMEL-920) — are shipped
+via the **himmel-ops plugin `hooks.json`** rather than `.claude/settings.json`
+(so they can be agent-installed without a settings self-mod veto — same
+delivery path as `inject-minerva-critic.sh`); all four are live only after
+`/himmel-update` (marketplace re-sync) + a fresh session.
+`block-docker-privesc.sh` and `block-merged-pr-commit.sh` fail CLOSED
+(security boundaries); `block-unresolved-cr-merge.sh` blocks when it can
+evaluate but fails OPEN on every API/dependency error (HIMMEL-936 design);
+`guard-implementor-dispatch.sh` is a COST guard and fails OPEN (see its own
+section below).
 
 **Bypass convention (applies to the four DENY hooks):** session-sticky
 env vars must be set in the shell that LAUNCHED Claude Code
@@ -406,6 +411,70 @@ own precondition check), so it needed no change.
 
 Paired artifacts: `scripts/guardrails/test-lesson-write-fence.sh` (111
 checks), `scripts/hooks/test-block-lesson-enforcement-writes.sh` (9 checks).
+
+### `guard-implementor-dispatch.sh` — bank-aware implementor-dispatch cost guard (HIMMEL-920)
+
+Fires on `Agent`. Structural enforcement of the HIMMEL-195 second-drift rule:
+s40 burned 86% of a 5-hour bank routing four CR-fix rounds to a Sonnet
+subagent while the GLM lane sat available (CLAUDE.md subagent policy: "every
+dispatch names an explicit model... route by lane") — prose didn't stop the
+drift twice.
+
+**THIS IS A COST GUARD, NOT A SECURITY GUARD — it fails OPEN on every
+infrastructure, cache, or unknown-input error** (missing jq, malformed JSON,
+missing/stale/corrupt usage cache), the opposite of the fail-CLOSED block-*
+siblings above; the fail-open precedent is the auto-arm watchdog family, not
+`block-edit-on-main.sh`. When its inputs ARE readable and the policy
+thresholds are met it does deny: an eligible dispatch at HARD utilization
+exits 2.
+
+**Decision shape:** a dispatch is only DENY-eligible when BOTH
+`subagent_type` is in the allow-list {`general-purpose`, `claude`,
+`feature-dev:code-architect`} AND `model` is in {`sonnet`, `opus`, `fable`}
+— a deny-list would false-block future reviewer agent types, so an
+absent/empty `model` is capped to WARN, never DENY (it inherits the parent
+loop, which is costly, but can't be confirmed as this-shape-costly).
+`model == haiku` always allows regardless of shape. Beyond the allow-list
+check, the dispatch `prompt` must also match a narrow impl-shaped ERE
+(`implement|apply the fix|write the code|make it pass|fix the
+(bug|finding|test)` — de-greeded: `patch` (a substring of "dispatch"), bare
+`commit`, and bare `refactor` were all dropped as high-false-positive)
+before the bank check runs at all.
+
+**Bank check:** reads `.five_hour.utilization` from the claude-statusline
+usage cache (`IMPL_GUARD_CACHE_PATH`, default
+`/tmp/claude/statusline-usage-cache.json`); the numeric handling never runs
+bash `[ -ge ]` against a float (the HIMMEL-392 no-stderr hook death) — jq
+validates the value and awk performs the threshold compares. A null /
+non-numeric / out-of-`[0,100]` value (the documented leaked-epoch
+corruption, see `auto-arm-on-cap.sh`) is treated as UNKNOWN, not clamped.
+Missing cache, unstatable, stale (mtime older than
+`IMPL_GUARD_CACHE_MAX_AGE_SECS`, default 300s), an expired `resets_at`
+window, or UNKNOWN → allow + a stderr WARN, never a block; a HARD deny
+additionally requires a provably-live `resets_at` window (else it downgrades
+to the advisory).
+
+**Policy:** util `>= IMPL_GUARD_HARD` (default 80) AND DENY-eligible → exit
+2, naming the utilization, the dispatch shape, and a cheaper-lane redirect
+(`himmel-ops:glm-subagent` shared-branch mode, `codex:codex-rescue`,
+`/lanes`). util `>= IMPL_GUARD_WARN` (default 65) → allow, but via the
+`hookSpecificOutput` `permissionDecision:"allow"` JSON idiom
+(`auto-approve-safe-bash.sh:432` precedent) so the advisory actually reaches
+the model — an exit-0 stderr line is invisible to the model in PreToolUse.
+Below WARN → allow silently.
+
+**Bypass:** `IMPL_GUARD_OK=1` (explicit session override) or
+`IMPL_GUARD_DISABLE=1` (kill switch), both set in the LAUNCHING shell and
+session-sticky (same convention as the other block-* hooks — a per-call env
+prefix does not reach the hook process).
+
+**Delivery:** shipped via the **himmel-ops plugin `hooks.json`** (matcher
+`Agent`, same exec-if-exists `$CLAUDE_PROJECT_DIR` pattern as
+`block-docker-privesc`); live only after `/himmel-update` (marketplace
+re-sync) + a fresh session.
+
+Spec: `scripts/hooks/test-guard-implementor-dispatch.sh` (13 test cases, 27
+assertions).
 
 ### `block-glm-external-writes.sh` — GLM-lane external-write deny (HIMMEL-654)
 

--- a/marketplace/plugins/himmel-ops/hooks/hooks.json
+++ b/marketplace/plugins/himmel-ops/hooks/hooks.json
@@ -63,6 +63,15 @@
             "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/block-lesson-enforcement-writes.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; elif [ \"${HIMMEL_LESSON_LOOP:-0}\" = \"1\" ]; then echo \"block-lesson-enforcement-writes: hook script missing while HIMMEL_LESSON_LOOP=1 (stale checkout?) - failing closed\" >&2; exit 2; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/guard-implementor-dispatch.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; fi'"
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/scripts/hooks/guard-implementor-dispatch.sh
+++ b/scripts/hooks/guard-implementor-dispatch.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# guard-implementor-dispatch.sh — PreToolUse hook (matcher "Agent"): bank-aware
+# cost guard on implementor-shaped subagent dispatches (HIMMEL-920).
+#
+# WHY: structural enforcement of the HIMMEL-195 second-drift rule. s40 burned
+# 86% of a 5-hour bank routing four CR-fix rounds to a Sonnet subagent while
+# the GLM lane sat available (CLAUDE.md subagent policy: "every dispatch
+# names an explicit model... raise effort before tier... route by lane").
+# Prose didn't stop the drift twice, so this hook makes the expensive shape
+# structurally visible/blockable at dispatch time instead of after the fact.
+#
+# THIS IS A COST GUARD, NOT A SECURITY GUARD — it fails OPEN everywhere
+# (opposite of the block-*.sh security siblings, which fail CLOSED on a
+# missing dependency). A bug in this hook must never brick a legitimate
+# Agent dispatch; worst case it silently allows. The fail-open sibling
+# precedent is the auto-arm watchdog family (auto-arm-on-cap.sh,
+# auto-arm-on-subagent-cap.sh), not block-edit-on-main.sh.
+#
+# Decision order (first hit wins — see the critic-hardened plan
+# 2026-07-12-himmel-920-impl-dispatch-guard.md for the full derivation):
+#   1. IMPL_GUARD_DISABLE=1 / IMPL_GUARD_OK=1 (session bypass, launching-shell
+#      convention, same as EDIT_ON_MAIN_OK etc.) → allow silently.
+#   2. jq missing / stdin unparseable / not an Agent call → allow (fail-open).
+#   3. Parse subagent_type / model / prompt from tool_input.
+#   4. model == haiku → always allow (cheap lane, never worth gating).
+#   5. DENY-tier eligibility is an ALLOW-LIST of known-expensive implementor
+#      shapes (critic Q2 — a deny-list would false-block future reviewer
+#      agent types): subagent_type in {general-purpose, claude,
+#      feature-dev:code-architect} AND model in {sonnet, opus, fable}.
+#      Anything else (incl. an absent/empty model — critic optional #2: it
+#      inherits the parent loop, costly but not confirmable as DENY-worthy)
+#      is capped at WARN-tier, never DENY.
+#   6. Impl-shaped prompt classifier (case-insensitive ERE, de-greeded per
+#      critic Q1 — dropped `patch` (substring of "dispatch"), bare `commit`,
+#      bare `refactor`: all high false-positive). No match → allow.
+#   7. Read the 5-hour bank utilization from the claude-statusline cache
+#      (IMPL_GUARD_CACHE_PATH, default /tmp/claude/statusline-usage-cache.json).
+#      Missing cache, unstatable, stale (mtime older than
+#      IMPL_GUARD_CACHE_MAX_AGE_SECS, default 300s), or an unusable value
+#      (null / non-numeric / out of [0,100] range — the documented
+#      leaked-epoch corruption, see auto-arm-on-cap.sh) → allow + a plain
+#      stderr WARN. Never brick on a cold statusline.
+#   8. Policy on a confirmed numeric utilization (float-safe: jq validates
+#      the value and awk performs the threshold compares — never bash
+#      `[ -ge ]` against a float, the HIMMEL-392 no-stderr hook death):
+#        util >= IMPL_GUARD_HARD (default 80) AND DENY-tier-eligible →
+#          exit 2 (block), naming util%, the dispatch shape, and the
+#          cheaper-lane redirect.
+#        util >= IMPL_GUARD_WARN (default 65) [either DENY-eligible but
+#          under HARD, or capped to WARN by step 5] → allow, but emit the
+#          hookSpecificOutput permissionDecision:"allow" JSON idiom
+#          (auto-approve-safe-bash.sh:432 precedent) so the advisory
+#          actually reaches the model — an exit-0 stderr line is INVISIBLE
+#          to the model in PreToolUse.
+#        else → allow silently.
+#
+# Env knobs (all optional, read from the LAUNCHING shell):
+#   IMPL_GUARD_DISABLE=1           kill switch
+#   IMPL_GUARD_OK=1                per-call deliberate override (session-sticky)
+#   IMPL_GUARD_CACHE_PATH          cache file (default /tmp/claude/statusline-usage-cache.json)
+#   IMPL_GUARD_CACHE_MAX_AGE_SECS  staleness bound in seconds (default 300)
+#   IMPL_GUARD_HARD                block threshold, percent (default 80)
+#   IMPL_GUARD_WARN                advisory threshold, percent (default 65)
+#
+# Non-goals (v1, per plan): no GLM-bank preflight, no prompt-length/token
+# estimation, threshold *calibration* beyond the defaults above (HIMMEL-774).
+#
+# Known limitations (chosen tradeoffs, NOT bugs — adjudicated against the
+# codex adversarial round that proposed the opposite):
+# - WORDING-DEPENDENT CLASSIFICATION: prompts phrased without the marker set
+#   ("update the hook", "create the handler") bypass the guard. Widening to
+#   generic verbs (add/update/create/modify/build) was REJECTED by the plan
+#   critic as high-false-positive (research/planning briefs use those verbs
+#   constantly); the parent authoring the prompt is not adversarial, and the
+#   incident class this guard exists for (s40 CR-fix rounds) uses the marker
+#   vocabulary. Same accepted-limitation family as the wrapper-displacement
+#   gaps documented in block-glm-external-writes.sh.
+# - ABSENT MODEL IS WARN-ONLY: an unnamed dispatch inherits the parent loop
+#   (expensive) but its cost cannot be CONFIRMED at hook time — plan-critic
+#   call: advisory, never a false block.
+#
+# bash 3.2-compatible (no ${var,,}, no mapfile, no associative arrays).
+set -uo pipefail
+
+warn() { echo "guard-implementor-dispatch: $*" >&2; }
+
+[ "${IMPL_GUARD_DISABLE:-0}" = "1" ] && exit 0
+[ "${IMPL_GUARD_OK:-0}" = "1" ] && exit 0
+
+hook_dir=$(cd "$(dirname "$0")" && pwd)
+
+# --- Fail open on anything we cannot evaluate (cost guard, not a security boundary) ---
+command -v jq >/dev/null 2>&1 || { warn "jq not on PATH — allowing (fail-open)"; exit 0; }
+
+input=$(cat 2>/dev/null || true)
+[ -n "$input" ] || exit 0
+
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)
+[ "$tool" = "Agent" ] || exit 0   # matcher already scopes to Agent; defensive for direct invocation
+
+subagent_type=$(printf '%s' "$input" | jq -r '.tool_input.subagent_type // empty' 2>/dev/null || true)
+model=$(printf '%s' "$input" | jq -r '.tool_input.model // empty' 2>/dev/null || true)
+prompt=$(printf '%s' "$input" | jq -r '.tool_input.prompt // empty' 2>/dev/null || true)
+
+model_lc=$(printf '%s' "$model" | tr '[:upper:]' '[:lower:]')
+
+# Haiku is always cheap — never worth gating regardless of shape/prompt/bank.
+[ "$model_lc" = "haiku" ] && exit 0
+
+# --- DENY-tier eligibility: ALLOW-LIST of known-expensive implementor shapes ---
+# (critic Q2: a deny-list would false-block future reviewer agent types).
+subagent_in_set=0
+case "$subagent_type" in
+    general-purpose|claude|feature-dev:code-architect) subagent_in_set=1 ;;
+esac
+model_in_set=0
+case "$model_lc" in
+    sonnet|opus|fable) model_in_set=1 ;;
+esac
+eligible_deny=0
+[ "$subagent_in_set" = "1" ] && [ "$model_in_set" = "1" ] && eligible_deny=1
+
+# --- Impl-shaped prompt classifier (case-insensitive ERE, de-greeded) ---
+printf '%s' "$prompt" | grep -Eqi 'implement|apply the fix|write the code|make it pass|fix (the |all )?(bug|finding|test)s?|(address|resolve|remediate) (the |all |every )?((coderabbit|cr|review(er)?) )?(comments?|findings?|feedback)' \
+    || exit 0
+
+shape="${subagent_type:-<no-subagent_type>}/${model:-<no-model>}"
+
+# --- Read the 5-hour bank utilization ---
+CACHE_PATH="${IMPL_GUARD_CACHE_PATH:-/tmp/claude/statusline-usage-cache.json}"
+MAX_AGE="${IMPL_GUARD_CACHE_MAX_AGE_SECS:-300}"
+HARD="${IMPL_GUARD_HARD:-80}"
+WARN_T="${IMPL_GUARD_WARN:-65}"
+
+_py_lib="$hook_dir/../lib/py-armor.sh"
+[ -f "$_py_lib" ] || _py_lib="${CLAUDE_PROJECT_DIR:-}/scripts/lib/py-armor.sh"
+# shellcheck source=../lib/py-armor.sh
+# shellcheck disable=SC1091
+if ! . "$_py_lib" 2>/dev/null; then
+    warn "cannot source py-armor.sh (tried $hook_dir/../lib and \$CLAUDE_PROJECT_DIR/scripts/lib) — cannot verify bank utilization for $shape; allowing"
+    exit 0
+fi
+
+if [ ! -f "$CACHE_PATH" ]; then
+    warn "usage cache not found ($CACHE_PATH) — cannot verify bank utilization for $shape; allowing"
+    exit 0
+fi
+
+cache_mtime=$(py_armor_mtime "$CACHE_PATH")
+case "$cache_mtime" in
+    ''|*[!0-9]*)
+        # Empty OR non-integer: garbage here would error the age arithmetic
+        # under set -u — same fail-open answer as an unavailable timestamp.
+        warn "cannot stat usage cache ($CACHE_PATH) — cannot verify bank utilization for $shape; allowing"
+        exit 0
+        ;;
+esac
+now=$(date +%s)
+age=$(( now - cache_mtime ))
+if [ "$age" -gt "$MAX_AGE" ]; then
+    warn "usage cache stale (age ${age}s > ${MAX_AGE}s) — cannot verify bank utilization for $shape; allowing"
+    exit 0
+fi
+
+# Numeric handling (float-safe, clamp to [0,100]): jq owns the whole compare
+# so bash never runs `[ -ge ]` against a float (kills the hook under set -e —
+# HIMMEL-392). null / non-numeric / out-of-range (e.g. the documented
+# leaked-epoch corruption, auto-arm-on-cap.sh) → UNKNOWN, never coerced to 0.
+util=$(jq -r '
+    (.five_hour.utilization) as $u
+    | if ($u == null) then "UNKNOWN"
+      elif ($u | type) != "number" then "UNKNOWN"
+      elif ($u < 0 or $u > 100) then "UNKNOWN"
+      else ($u | tostring)
+      end
+' "$CACHE_PATH" 2>/dev/null)
+[ -n "$util" ] || util="UNKNOWN"
+
+if [ "$util" = "UNKNOWN" ]; then
+    warn "usage cache utilization unusable (null / non-numeric / out-of-range) — cannot verify bank utilization for $shape; allowing"
+    exit 0
+fi
+
+# Per-window freshness (codex-adv): the cache producer preserves the previous
+# five_hour object when a seven_day-only payload arrives, rewriting the file
+# (fresh mtime) around a STALE five_hour value — so file mtime alone does not
+# establish five-hour freshness. The window's own resets_at bounds the worst
+# case: a utilization whose reset time has PASSED describes an expired window
+# (the bank has reset since) → UNKNOWN, never a spurious DENY. A stale-low
+# value inside a still-live window can only under-warn — the fail-open
+# direction this cost guard already accepts.
+# resets_at appears as an epoch string in the live cache; tolerate ISO forms
+# too (fractional seconds normalized away — fromdateiso8601 rejects .000Z).
+# A HARD deny must be backed by a provably-LIVE window: missing/unparseable
+# resets_at means the value cannot be tied to the current 5h window, so deny
+# authority downgrades to the WARN advisory instead of falsely blocking
+# (codex-adv r3).
+resets_at=$(jq -r '
+    (.five_hour.resets_at // empty) as $r
+    | ($r | tostring) as $s
+    | if ($s | test("^[0-9]+$")) then $s
+      elif ($s | test("T")) then (try ($s | sub("\\.[0-9]+"; "") | sub("\\+00:00$"; "Z") | fromdateiso8601 | tostring) catch "")
+      else "" end
+' "$CACHE_PATH" 2>/dev/null)
+resets_live=0
+if [ -n "$resets_at" ]; then
+    now_epoch=$(date +%s)
+    if [ "$now_epoch" -ge "$resets_at" ] 2>/dev/null; then
+        warn "usage cache five_hour window expired (resets_at $resets_at <= now $now_epoch) — bank has reset since this value; allowing"
+        exit 0
+    fi
+    resets_live=1
+fi
+
+is_hard=$(awk -v v="$util" -v t="$HARD" 'BEGIN{print (v>=t)?1:0}')
+is_warn=$(awk -v v="$util" -v t="$WARN_T" 'BEGIN{print (v>=t)?1:0}')
+util_disp=$(awk -v v="$util" 'BEGIN{printf "%.0f", v}')
+
+if [ "$is_hard" = "1" ] && [ "$eligible_deny" = "1" ] && [ "$resets_live" != "1" ]; then
+    # HARD-worthy but the window cannot be proven live — advisory only.
+    is_warn=1
+fi
+if [ "$is_hard" = "1" ] && [ "$eligible_deny" = "1" ] && [ "$resets_live" = "1" ]; then
+    cat >&2 <<EOF
+guard-implementor-dispatch: 5-hour bank at ${util_disp}% (>= HARD ${HARD}%) —
+refusing this implementor-shaped Agent dispatch ($shape, impl-shaped prompt
+detected).
+
+At this utilization, route implementation / CR-fix work through a cheaper
+lane instead of burning the scarce Sonnet/Opus/Fable weekly quota:
+
+    himmel-ops:glm-subagent   — shared-branch mode (CR-fix rounds)
+    codex:codex-rescue        — Codex lane
+    /lanes                    — live lane inventory for this machine
+
+Deliberate override: relaunch with IMPL_GUARD_OK=1 in the launching shell.
+EOF
+    exit 2
+fi
+
+if [ "$is_warn" = "1" ]; then
+    reason=$(printf '%s' "guard-implementor-dispatch: 5-hour bank at ${util_disp}% (>= WARN ${WARN_T}%) — this $shape implementor dispatch is costly; consider himmel-ops:glm-subagent / codex:codex-rescue / /lanes instead. (IMPL_GUARD_OK=1 to silence)" | jq -Rs . 2>/dev/null) \
+        || reason='"guard-implementor-dispatch: costly implementor dispatch — consider a cheaper lane"'
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":%s}}\n' "$reason"
+    exit 0
+fi
+
+exit 0

--- a/scripts/hooks/test-guard-implementor-dispatch.sh
+++ b/scripts/hooks/test-guard-implementor-dispatch.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Tests for scripts/hooks/guard-implementor-dispatch.sh (HIMMEL-920). Hermetic.
+#
+# Usage: bash scripts/hooks/test-guard-implementor-dispatch.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/guard-implementor-dispatch.sh"
+[ -x "$HOOK" ] || chmod +x "$HOOK" 2>/dev/null || true
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+assert_rc() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "ok   $label (rc=$actual)"
+        pass=$((pass + 1))
+    else
+        echo "FAIL $label — expected rc=$expected, got rc=$actual"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if printf '%s' "$haystack" | grep -qF "$needle"; then
+        echo "ok   $label (contains '$needle')"
+        pass=$((pass + 1))
+    else
+        echo "FAIL $label — did not contain '$needle'"
+        echo "  actual: $haystack"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_empty() {
+    local label="$1" actual="$2"
+    if [ -z "$actual" ]; then
+        echo "ok   $label (empty)"
+        pass=$((pass + 1))
+    else
+        echo "FAIL $label — expected empty, got: $actual"
+        fail=$((fail + 1))
+    fi
+}
+
+# payload_full <subagent_type> <model> <prompt> — all three fields present.
+payload_full() {
+    jq -n --arg st "$1" --arg m "$2" --arg p "$3" \
+        '{"tool_name":"Agent","tool_input":{"subagent_type":$st,"model":$m,"prompt":$p}}'
+}
+
+# payload_no_model <subagent_type> <prompt> — model key OMITTED entirely.
+payload_no_model() {
+    jq -n --arg st "$1" --arg p "$2" \
+        '{"tool_name":"Agent","tool_input":{"subagent_type":$st,"prompt":$p}}'
+}
+
+# mkcache <path> <utilization-literal>
+mkcache() {
+    # resets_at = a FUTURE epoch (live window) — the guard treats an expired
+    # window as UNKNOWN (see T14), so deny/warn fixtures must stay live.
+    printf '{"five_hour":{"utilization":%s,"resets_at":"%s"}}' "$2" "$(( $(date +%s) + 3600 ))" > "$1"
+}
+
+# run_hook <name> <json> [env KEY=VAL ...] — writes stdout/stderr to
+# $TMP/out-<name> / $TMP/err-<name>, returns rc via echo.
+run_hook() {
+    local name="$1" json="$2"; shift 2
+    printf '%s' "$json" | env "$@" bash "$HOOK" >"$TMP/out-$name" 2>"$TMP/err-$name"
+    echo "$?"
+}
+
+echo "=== guard-implementor-dispatch smoke tests ==="
+
+# T1: Impl-shaped general-purpose+sonnet, util=85 → rc=2, stderr names glm-subagent.
+CACHE1="$TMP/cache1.json"; mkcache "$CACHE1" 85
+RC1=$(run_hook t1 "$(payload_full general-purpose sonnet 'please implement the fix for the failing test')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE1")
+assert_rc "T1 hard-deny rc" 2 "$RC1"
+assert_contains "T1 stderr names glm-subagent" "glm-subagent" "$(cat "$TMP/err-t1")"
+
+# T2: Reviewer dispatch (pr-review-toolkit:code-reviewer), reviewer-shaped prompt,
+# util=85 → allow, silent (prompt classifier rejects before the bank check runs).
+CACHE2="$TMP/cache2.json"; mkcache "$CACHE2" 85
+RC2=$(run_hook t2 "$(payload_full pr-review-toolkit:code-reviewer sonnet 'review this PR for quality issues and report findings')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE2")
+assert_rc "T2 reviewer dispatch rc" 0 "$RC2"
+assert_empty "T2 reviewer dispatch stdout" "$(cat "$TMP/out-t2")"
+
+# T3: Impl-shaped, util=70 → allow + permissionDecisionReason advisory JSON.
+CACHE3="$TMP/cache3.json"; mkcache "$CACHE3" 70
+RC3=$(run_hook t3 "$(payload_full general-purpose sonnet 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE3")
+assert_rc "T3 warn-tier rc" 0 "$RC3"
+assert_contains "T3 warn-tier advisory JSON" "permissionDecisionReason" "$(cat "$TMP/out-t3")"
+
+# T4: Impl-shaped, util=20 → allow, silent.
+CACHE4="$TMP/cache4.json"; mkcache "$CACHE4" 20
+RC4=$(run_hook t4 "$(payload_full general-purpose sonnet 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE4")
+assert_rc "T4 low-util rc" 0 "$RC4"
+assert_empty "T4 low-util stdout" "$(cat "$TMP/out-t4")"
+
+# T5: Missing cache → allow + WARN.
+RC5=$(run_hook t5 "$(payload_full general-purpose sonnet 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$TMP/does-not-exist.json")
+assert_rc "T5 missing-cache rc" 0 "$RC5"
+assert_contains "T5 missing-cache stderr WARN" "cache not found" "$(cat "$TMP/err-t5")"
+
+# T6: Stale cache (touch -t, >300s) → allow + WARN.
+CACHE6="$TMP/cache6.json"; mkcache "$CACHE6" 85
+touch -d "1 hour ago" "$CACHE6" 2>/dev/null \
+    || touch -t "$(date -v -1H +%Y%m%d%H%M.%S 2>/dev/null)" "$CACHE6" 2>/dev/null \
+    || true
+RC6=$(run_hook t6 "$(payload_full general-purpose sonnet 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE6")
+assert_rc "T6 stale-cache rc" 0 "$RC6"
+assert_contains "T6 stale-cache stderr WARN" "stale" "$(cat "$TMP/err-t6")"
+
+# T7: IMPL_GUARD_OK=1, util=85 → allow, silent (bypass short-circuits before parsing).
+CACHE7="$TMP/cache7.json"; mkcache "$CACHE7" 85
+RC7=$(run_hook t7 "$(payload_full general-purpose sonnet 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE7" IMPL_GUARD_OK=1)
+assert_rc "T7 IMPL_GUARD_OK bypass rc" 0 "$RC7"
+assert_empty "T7 IMPL_GUARD_OK bypass stdout" "$(cat "$TMP/out-t7")"
+
+# T7b: IMPL_GUARD_DISABLE=1 → allow, silent.
+RC7B=$(run_hook t7b "$(payload_full general-purpose sonnet 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE7" IMPL_GUARD_DISABLE=1)
+assert_rc "T7b IMPL_GUARD_DISABLE bypass rc" 0 "$RC7B"
+assert_empty "T7b IMPL_GUARD_DISABLE bypass stdout" "$(cat "$TMP/out-t7b")"
+
+# T8: Absent model + impl prompt, util=85 → allow + advisory (WARN-tier, NOT deny).
+CACHE8="$TMP/cache8.json"; mkcache "$CACHE8" 85
+RC8=$(run_hook t8 "$(payload_no_model general-purpose 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE8")
+assert_rc "T8 absent-model rc" 0 "$RC8"
+assert_contains "T8 absent-model advisory JSON" "permissionDecisionReason" "$(cat "$TMP/out-t8")"
+
+# T9: Haiku impl dispatch, util=85 → allow, silent.
+CACHE9="$TMP/cache9.json"; mkcache "$CACHE9" 85
+RC9=$(run_hook t9 "$(payload_full general-purpose haiku 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE9")
+assert_rc "T9 haiku rc" 0 "$RC9"
+assert_empty "T9 haiku stdout" "$(cat "$TMP/out-t9")"
+
+# T10: Malformed JSON → allow.
+RC10=$(run_hook t10 'not-json{{{')
+assert_rc "T10a malformed-JSON rc" 0 "$RC10"
+
+# T10b: missing jq (empty PATH; hook exits before touching stdin/other binaries).
+BASH_ABS=$(command -v bash)
+EMPTY_DIR="$TMP/empty-path"
+mkdir -p "$EMPTY_DIR"
+printf '%s' "$(payload_full general-purpose sonnet 'implement the fix')" \
+    | env PATH="$EMPTY_DIR" "$BASH_ABS" "$HOOK" >"$TMP/out-t10b" 2>"$TMP/err-t10b"
+RC10B=$?
+assert_rc "T10b missing-jq rc" 0 "$RC10B"
+
+# T11: Float utilization "84.5" → correct numeric compare (rc=2 at HARD=80).
+CACHE11="$TMP/cache11.json"; mkcache "$CACHE11" 84.5
+RC11=$(run_hook t11 "$(payload_full general-purpose sonnet 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE11")
+assert_rc "T11 float-util hard-deny rc" 2 "$RC11"
+
+# T12: Leaked-epoch utilization (1783836000) → clamped → UNKNOWN → allow + WARN.
+CACHE12="$TMP/cache12.json"; mkcache "$CACHE12" 1783836000
+RC12=$(run_hook t12 "$(payload_full general-purpose sonnet 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE12")
+assert_rc "T12 leaked-epoch rc" 0 "$RC12"
+assert_contains "T12 leaked-epoch stderr WARN" "unusable" "$(cat "$TMP/err-t12")"
+
+# T13: Prompt containing "dispatch" but no marker → allow (the `patch` substring
+# FP — "dispatch" contains "patch" — is dead because `patch` was dropped).
+CACHE13="$TMP/cache13.json"; mkcache "$CACHE13" 85
+RC13=$(run_hook t13 "$(payload_full general-purpose sonnet 'dispatch this task to the subagent')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE13")
+assert_rc "T13 dispatch-no-marker rc" 0 "$RC13"
+assert_empty "T13 dispatch-no-marker stdout" "$(cat "$TMP/out-t13")"
+
+# T14: expired five_hour window (resets_at in the past) → the value predates
+# a bank reset (the producer preserves stale five_hour under a fresh mtime on
+# seven_day-only payloads) → UNKNOWN → allow + WARN, never a spurious DENY.
+CACHE14="$TMP/cache14.json"
+printf '{"five_hour":{"utilization":%s,"resets_at":"%s"}}' 85 "$(( $(date +%s) - 100 ))" > "$CACHE14"
+RC14=$(run_hook t14 "$(payload_full general-purpose sonnet 'implement the fix')"     IMPL_GUARD_CACHE_PATH="$CACHE14")
+assert_rc "T14 expired-window rc (allow)" 0 "$RC14"
+assert_contains "T14 expired-window WARN" "window expired" "$(cat "$TMP/err-t14")"
+
+# T15/T16 (codex-adv round 2): realistic CR-fix dispatch wording — the exact
+# s40 pattern this guard exists for — must classify as impl-shaped.
+CACHE15="$TMP/cache15.json"; mkcache "$CACHE15" 85
+RC15=$(run_hook t15 "$(payload_full general-purpose sonnet 'address the CodeRabbit comments on this PR and push')"     IMPL_GUARD_CACHE_PATH="$CACHE15")
+assert_rc "T15 address-coderabbit-comments rc (deny)" 2 "$RC15"
+RC16=$(run_hook t16 "$(payload_full general-purpose sonnet 'resolve all review findings from the panel')"     IMPL_GUARD_CACHE_PATH="$CACHE15")
+assert_rc "T16 resolve-review-findings rc (deny)" 2 "$RC16"
+
+# T17/T18 (codex-adv r3): HARD deny requires a provably-live window.
+# Absent resets_at -> downgrade to the advisory JSON (never a false block);
+# a fractional-second ISO future resets_at parses and still denies.
+CACHE17="$TMP/cache17.json"
+printf '{"five_hour":{"utilization":85}}' > "$CACHE17"
+RC17=$(run_hook t17 "$(payload_full general-purpose sonnet 'implement the fix')"     IMPL_GUARD_CACHE_PATH="$CACHE17")
+assert_rc "T17 no-resets_at at HARD rc (allow, downgraded)" 0 "$RC17"
+assert_contains "T17 downgraded advisory JSON" "permissionDecisionReason" "$(cat "$TMP/out-t17")"
+CACHE18="$TMP/cache18.json"
+printf '{"five_hour":{"utilization":85,"resets_at":"%s"}}' "$(date -u -d "@$(( $(date +%s) + 3600 ))" '+%Y-%m-%dT%H:%M:%S.000Z' 2>/dev/null || python3 -c "import datetime,time;print(datetime.datetime.utcfromtimestamp(time.time()+3600).strftime('%Y-%m-%dT%H:%M:%S.000Z'))")" > "$CACHE18"
+RC18=$(run_hook t18 "$(payload_full general-purpose sonnet 'implement the fix')"     IMPL_GUARD_CACHE_PATH="$CACHE18")
+assert_rc "T18 fractional-ISO future resets_at rc (deny)" 2 "$RC18"
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Public propagation of private squash d4d8565f (HIMMEL-920).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bank-aware guard for certain high-cost implementor agent dispatches.
  * Dispatches may be blocked at high usage levels or receive an advisory warning at elevated levels.
  * Added bypass options and fail-open handling when usage data is unavailable or invalid.

* **Documentation**
  * Updated enforcement references and setup documentation to describe the new guard and activation requirements.

* **Tests**
  * Added coverage for thresholds, cache conditions, prompt classification, bypasses, and malformed inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->