### PR TITLE
fix(qmd): [HIMMEL-928] daemon dead on 8181 - bun-js-first resolution, node-side binding self-heal, logon boot task

### DIFF
--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -120,6 +120,17 @@ README's fork-delta section).
   a non-qmd listener on 8181 fails loudly as a port collision instead of
   counting as alive). A manual operator twin for PowerShell lives at
   `scripts/qmd/ensure-qmd-daemon.ps1`. Stop the daemon with `qmd mcp stop`.
+  Both resolve qmd as `bun <bun-global dist/cli/qmd.js>` first (HIMMEL-928):
+  the bun bin shim honors the CLI's node shebang and hands the daemon to
+  node, where qmd needs the better-sqlite3 native binding (bun-side qmd uses
+  `bun:sqlite`) — a binding bun's install blocks by default and that breaks
+  again on every node ABI bump.
+- **Boot survival (Windows, lean-invoke):**
+  `scripts/qmd/register-qmd-daemon-logon.ps1` registers a per-user ONLOGON
+  scheduled task (`qmd-mcp-daemon`) running the ensure twin, so the daemon is
+  back up after a reboot without waiting for the first Claude session
+  (HIMMEL-928). One-shot per machine; remove with
+  `Unregister-ScheduledTask -TaskName 'qmd-mcp-daemon' -Confirm:$false`.
 - **Freshness:** the index is sqlite+WAL, read per query, so docs added by the
   existing `qmd update` cadence are served by the running daemon immediately —
   no daemon restart or watch mechanism, cadence unchanged.

--- a/marketplace/plugins/qmd/scripts/ensure-qmd-daemon.sh
+++ b/marketplace/plugins/qmd/scripts/ensure-qmd-daemon.sh
@@ -23,10 +23,10 @@
 # that budget. Note: a malformed QMD_MCP_URL override looks identical to
 # daemon-dead (curl stderr is discarded by design).
 #
-# qmd resolution is inlined (bun global bin FIRST, then PATH; .exe variant
-# on Windows) - self-contained mirror of the essentials of
-# himmel's scripts/lib/qmd-bin.sh, which this plugin copy cannot source
-# because the plugin must work outside a himmel checkout.
+# qmd resolution is inlined (bun + the bun-global qmd.js FIRST, then the bun
+# bin shim, then PATH; .exe variant on Windows) - self-contained mirror of the
+# essentials of himmel's scripts/lib/qmd-bin.sh, which this plugin copy cannot
+# source because the plugin must work outside a himmel checkout.
 # bash 3.2-safe, shellcheck clean, ASCII-only.
 #
 # Test seams (used only by scripts/qmd/test-ensure-qmd-daemon.sh in the
@@ -65,22 +65,45 @@ is_qmd_shaped() {
   printf '%s' "$1" | grep -Eq '"serverInfo"[[:space:]]*:[[:space:]]*\{[^}]*"name"[[:space:]]*:[[:space:]]*"qmd"'
 }
 
-# Resolve the qmd binary: bun global bin FIRST ($HOME/.bun/bin/qmd, .exe
-# variant on Windows), then PATH. Bun-first matches scripts/lib/qmd-bin.sh
-# (himmel repo): a broken Windows qmd stub can shadow PATH (HIMMEL-163), so
-# the known-good bun install wins when present. Provenance: minimal inline
-# mirror of qmd-bin.sh - see header.
+# Resolve how to invoke qmd. Sets QMD_BIN (argv0) and QMD_BIN_ARG1 (optional
+# first arg). Preference order (HIMMEL-928):
+#   1. bun + the bun-global @tobilu/qmd dist/cli/qmd.js -> `bun <qmd.js>`
+#   2. bun global bin shim ($HOME/.bun/bin/qmd, .exe variant on Windows)
+#   3. PATH
+# bun-js FIRST is load-bearing, not just parity with qmd_cmd in himmel's
+# scripts/lib/qmd-bin.sh: the bin shim honors the CLI's node shebang and runs
+# qmd under NODE, and the --daemon child is spawned via process.execPath - so
+# a shim-started daemon runs under whatever node is installed. Under bun qmd
+# uses bun:sqlite; under node it needs the better-sqlite3 native binding,
+# which bun's install blocks by default and which breaks again on every node
+# ABI bump (reproduced live: absent binding + node 26 killed the daemon at
+# startup - HIMMEL-928). `bun <qmd.js>` makes process.execPath = bun and the
+# daemon child inherits it. Bun-before-PATH:
+# a broken Windows qmd stub can shadow PATH (HIMMEL-163), so the known-good
+# bun install wins when present. Provenance: minimal inline mirror of
+# qmd-bin.sh - see header.
 resolve_qmd() {
-  if [ -x "$HOME/.bun/bin/qmd" ]; then
-    echo "$HOME/.bun/bin/qmd"
+  # One bun root for BOTH the js and the shim fallbacks: a relocated
+  # BUN_INSTALL must not resolve the js from one root and the shim from
+  # $HOME/.bun (CodeRabbit, PR #1134).
+  bun_root="${BUN_INSTALL:-$HOME/.bun}"
+  bun_js="$bun_root/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
+  if [ -f "$bun_js" ] && command -v bun >/dev/null 2>&1; then
+    QMD_BIN="bun"
+    QMD_BIN_ARG1="$bun_js"
     return 0
   fi
-  if [ -f "$HOME/.bun/bin/qmd.exe" ]; then
-    echo "$HOME/.bun/bin/qmd.exe"
+  QMD_BIN_ARG1=""
+  if [ -x "$bun_root/bin/qmd" ]; then
+    QMD_BIN="$bun_root/bin/qmd"
+    return 0
+  fi
+  if [ -f "$bun_root/bin/qmd.exe" ]; then
+    QMD_BIN="$bun_root/bin/qmd.exe"
     return 0
   fi
   if command -v qmd >/dev/null 2>&1; then
-    echo "qmd"
+    QMD_BIN="qmd"
     return 0
   fi
   return 1
@@ -99,7 +122,7 @@ if [ -n "$body" ]; then
 fi
 
 # ---- Dead: start the daemon ------------------------------------------------
-if ! QMD_BIN="$(resolve_qmd)"; then
+if ! resolve_qmd; then
   echo "ensure-qmd-daemon: ERROR - qmd is not installed / not on PATH." >&2
   echo "  Install it: bash <himmel-repo>/scripts/lib/qmd-bin.sh install (HIMMEL-877)" >&2
   exit 1
@@ -109,11 +132,13 @@ fi
 # "Already running (PID N)" and exits 0. Bound the start with timeout(1)
 # so a hung qmd/bun start cannot stall SessionStart; when timeout(1) is
 # absent (rare platform), degrade to an unbounded start.
+# ${QMD_BIN_ARG1:+"$QMD_BIN_ARG1"} expands to the quoted qmd.js path on the
+# bun-js resolution and to NOTHING (no empty argv slot) otherwise.
 start_rc=0
 if command -v timeout >/dev/null 2>&1; then
-  start_out="$(timeout -k 5 "$QMD_START_TIMEOUT" "$QMD_BIN" mcp --http --daemon 2>&1)" || start_rc=$?
+  start_out="$(timeout -k 5 "$QMD_START_TIMEOUT" "$QMD_BIN" ${QMD_BIN_ARG1:+"$QMD_BIN_ARG1"} mcp --http --daemon 2>&1)" || start_rc=$?
 else
-  start_out="$("$QMD_BIN" mcp --http --daemon 2>&1)" || start_rc=$?
+  start_out="$("$QMD_BIN" ${QMD_BIN_ARG1:+"$QMD_BIN_ARG1"} mcp --http --daemon 2>&1)" || start_rc=$?
 fi
 if [ "$start_rc" -eq 124 ] || [ "$start_rc" -eq 137 ]; then
   echo "ensure-qmd-daemon: ERROR - 'qmd mcp --http --daemon' timed out after ${QMD_START_TIMEOUT}s (killed)." >&2
@@ -137,5 +162,13 @@ done
 echo "ensure-qmd-daemon: ERROR - started 'qmd mcp --http --daemon' but nothing came alive on $QMD_MCP_URL." >&2
 echo "  qmd output was:" >&2
 printf '%s\n' "$start_out" | sed 's/^/    /' >&2
+if [ -z "${QMD_BIN_ARG1:-}" ]; then
+  # Non-bun-js resolution: the daemon was started via '$QMD_BIN' - a
+  # node-shebang shim/PATH path, the exact fragile leg HIMMEL-928 fixed.
+  # Most likely cause: the node-side better-sqlite3 binding is missing.
+  echo "  (daemon was started via '$QMD_BIN', not 'bun <qmd.js>' - if node's" >&2
+  echo "  better-sqlite3 binding is missing, fix with:" >&2
+  echo "  bash <himmel-repo>/scripts/lib/qmd-bin.sh install)" >&2
+fi
 echo "  Check the daemon log: ~/.cache/qmd/mcp.log" >&2
 exit 1

--- a/scripts/lib/qmd-bin.sh
+++ b/scripts/lib/qmd-bin.sh
@@ -61,6 +61,51 @@ _qmd_fork_min_version() { printf '%s\n' "${QMD_FORK_MIN_VERSION:-2.6.3}"; }
 # cleared at the start of any update attempt. HEAD alone cannot distinguish
 # "checked out the pin" from "successfully BUILT the pin".
 _qmd_build_stamp() { printf '%s\n' "$(_qmd_fork_dir)/.himmel-build-ok"; }
+# better-sqlite3's native binding inside the fork clone (HIMMEL-928). Only
+# the NODE runtime consumes it: under bun qmd takes the bun:sqlite branch
+# (src/db.ts isBun; bun refuses to dlopen better-sqlite3 at all --
+# oven-sh/bun#4290). bun BLOCKS the package's postinstall (the fork lists it
+# only under pnpm's onlyBuiltDependencies; there is no bun trustedDependencies
+# key), so `bun install` alone leaves the binding absent -- every node-run
+# DB-opening qmd op (e.g. via the bun bin shim, which honors the node shebang)
+# then dies with "Could not locate the bindings file" while `qmd --version`
+# still passes (it never opens the DB). qmd_install fetches the prebuild
+# explicitly UNDER NODE (node's ABI is the one that matters); qmd_fork_served
+# treats a non-loadable binding as not-served so a broken install converges on
+# the next install pass.
+_qmd_sqlite_binding() { printf '%s\n' "$(_qmd_fork_dir)/node_modules/better-sqlite3/build/Release/better_sqlite3.node"; }
+
+# True when the node-side better-sqlite3 binding actually LOADS -- an
+# existence-only check would bless a wrong-ABI or corrupt artifact (file
+# present, `qmd --version` passes, every node-run DB open still dies at
+# dlopen; HIMMEL-928 CR codex-adv). The probe must be a FILE INSIDE THE
+# CLONE: node resolves a bare require() relative to the SCRIPT's location,
+# so a /tmp probe would hit a different copy (observed live: bun's global
+# install cache, at a different version). Asserts the success marker, not
+# just the exit code. Vacuously true when node is absent -- nothing on the
+# machine can exercise the node path then, and a machine that later gains
+# node converges on the next install pass. On failure the probe's full
+# output (the real dlopen/ABI error text) is kept in
+# _QMD_BINDING_PROBE_ERR for the caller's WARNING (CR: 2>/dev/null threw
+# away the one diagnostic that makes a native-module failure debuggable).
+_qmd_sqlite_binding_ok() {
+  local probe probe_out
+  _QMD_BINDING_PROBE_ERR=""
+  command -v node >/dev/null 2>&1 || return 0
+  if [ ! -f "$(_qmd_sqlite_binding)" ]; then
+    _QMD_BINDING_PROBE_ERR="binding file missing: $(_qmd_sqlite_binding)"
+    return 1
+  fi
+  probe="$(_qmd_fork_dir)/.himmel-binding-probe.cjs"
+  printf "new (require('better-sqlite3'))(':memory:');\nconsole.log('qmd-binding-ok');\n" > "$probe" 2>/dev/null || return 1
+  probe_out="$(node "$probe" 2>&1)"
+  rm -f -- "$probe"
+  if printf '%s\n' "$probe_out" | grep -q '^qmd-binding-ok$'; then
+    return 0
+  fi
+  _QMD_BINDING_PROBE_ERR="$probe_out"
+  return 1
+}
 
 # Prints the manual recipe (clone + build + link). Best-effort documentation
 # text embedded in WARN messages -- NOT eval'd (HIMMEL-877 dropped the old
@@ -299,6 +344,9 @@ qmd_fork_served() {
   # next install pass.
   stamp="$(cat "$(_qmd_build_stamp)" 2>/dev/null)" || return 1
   [ "$stamp" = "$(_qmd_fork_ref)" ] || return 1
+  # The version probe below does NOT open the DB, so it cannot see a missing
+  # or non-loadable better-sqlite3 binding (HIMMEL-928) -- load it for real.
+  _qmd_sqlite_binding_ok || return 1
   ver="$(qmd_cmd --version 2>/dev/null)" || return 1
   _qmd_version_ge "$ver" "$(_qmd_fork_min_version)"
 }
@@ -424,6 +472,32 @@ qmd_install() {
     echo "  WARNING: qmd fork build failed - continuing without qmd." >&2
     echo "  Manual: (cd $fork_dir && bun install && bun run build)" >&2
     return 1
+  fi
+
+  # Fetch better-sqlite3's native binding explicitly (HIMMEL-928): bun blocks
+  # the package's postinstall, so `bun install` above never produces it -- see
+  # _qmd_sqlite_binding. Fetch UNDER NODE: only the node runtime ever loads
+  # better-sqlite3 (bun takes the bun:sqlite branch and refuses the package
+  # outright, oven-sh/bun#4290), so the prebuild must match node's ABI. A
+  # wrong-ABI or corrupt artifact is removed first so the fetch replaces it
+  # (CR codex-adv: existence alone must never bless the binding). Skipped when
+  # node is absent -- nothing can exercise the node path then. `|| true`: the
+  # load-check is the real gate, and every external command here must stay
+  # set-e-safe for callers.
+  if command -v node >/dev/null 2>&1 && ! _qmd_sqlite_binding_ok; then
+    echo "  Fetching better-sqlite3 native binding for node (bun blocks its postinstall)..."
+    rm -f -- "$(_qmd_sqlite_binding)"
+    ( cd "$fork_dir/node_modules/better-sqlite3" && node ../prebuild-install/bin.js ) || true
+    if ! _qmd_sqlite_binding_ok; then
+      echo "  WARNING: better-sqlite3 native binding still not loadable under node - node-run qmd cannot open its index." >&2
+      if [ -n "${_QMD_BINDING_PROBE_ERR:-}" ]; then
+        # shellcheck disable=SC2001
+        # Per-line indent - parameter expansion doesn't replicate sed's per-line anchor cleanly.
+        printf '%s\n' "$_QMD_BINDING_PROBE_ERR" | sed 's/^/    /' >&2
+      fi
+      echo "  Manual: (cd $fork_dir/node_modules/better-sqlite3 && node ../prebuild-install/bin.js)" >&2
+      return 1
+    fi
   fi
 
   if ! _qmd_ensure_global_link; then

--- a/scripts/lib/test-qmd-bin.sh
+++ b/scripts/lib/test-qmd-bin.sh
@@ -212,7 +212,17 @@ cat > "$id2/bin/bun" <<'STUB'
 #!/usr/bin/env bash
 echo "BUN $*" >> "${BUN_LOG:?}"
 case "$1" in
-  install) exit "${STUB_BUN_INSTALL_RC:-0}" ;;
+  install)
+    [ "${STUB_BUN_INSTALL_RC:-0}" -eq 0 ] || exit "$STUB_BUN_INSTALL_RC"
+    # Mirror what a real `bun install` materializes for the HIMMEL-928
+    # binding step: the better-sqlite3 + prebuild-install package dirs --
+    # but NOT the compiled binding (bun blocks that postinstall; the
+    # binding only appears via the node-run prebuild fetch, stubbed in
+    # $id2/bin/node).
+    mkdir -p node_modules/better-sqlite3 node_modules/prebuild-install
+    : > node_modules/prebuild-install/bin.js
+    exit 0
+    ;;
   run)
     [ "$2" = "build" ] || exit 0
     [ "${STUB_BUN_BUILD_RC:-0}" -eq 0 ] || exit "$STUB_BUN_BUILD_RC"
@@ -227,18 +237,50 @@ case "$1" in
 esac
 STUB
 chmod +x "$id2/bin/bun"
+# Fake node for the HIMMEL-928 better-sqlite3 binding step. Two verbs:
+#   node <...>/prebuild-install/bin.js   -> the prebuild fetch: create the
+#     binding file in cwd (qmd_install runs it from node_modules/
+#     better-sqlite3), controllable via STUB_NODE_FETCH_RC.
+#   node <...>/.himmel-binding-probe.cjs -> the load-probe: print the
+#     success marker iff the binding file exists next to the probe (i.e.
+#     the fetch really ran) AND STUB_NODE_PROBE_RC does not force a
+#     wrong-ABI/corrupt simulation.
+cat > "$id2/bin/node" <<'STUB'
+#!/usr/bin/env bash
+echo "NODE $*" >> "${NODE_LOG:?}"
+case "$1" in
+  */prebuild-install/bin.js)
+    [ "${STUB_NODE_FETCH_RC:-0}" -eq 0 ] || exit "$STUB_NODE_FETCH_RC"
+    mkdir -p build/Release
+    : > build/Release/better_sqlite3.node
+    exit 0
+    ;;
+  *.himmel-binding-probe.cjs)
+    [ "${STUB_NODE_PROBE_RC:-0}" -eq 0 ] || exit "$STUB_NODE_PROBE_RC"
+    if [ -f "$(dirname "$1")/node_modules/better-sqlite3/build/Release/better_sqlite3.node" ]; then
+      echo "qmd-binding-ok"
+      exit 0
+    fi
+    exit 1
+    ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$id2/bin/node"
 
 git_log="$id2/git-calls"
 bun_log="$id2/bun-calls"
+node_log="$id2/node-calls"
 qmd_install_env() { # $1 = HOME dir, remaining = the command to run under it
   local home="$1"; shift
-  : > "$git_log"; : > "$bun_log"
-  HOME="$home" GIT_LOG="$git_log" BUN_LOG="$bun_log" PATH="$id2/bin:$PATH" \
+  : > "$git_log"; : > "$bun_log"; : > "$node_log"
+  HOME="$home" GIT_LOG="$git_log" BUN_LOG="$bun_log" NODE_LOG="$node_log" PATH="$id2/bin:$PATH" \
     STUB_GIT_CLONE_RC="${STUB_GIT_CLONE_RC:-0}" STUB_GIT_FETCH_RC="${STUB_GIT_FETCH_RC:-0}" \
     STUB_GIT_ORIGIN_URL="${STUB_GIT_ORIGIN_URL:-}" STUB_GIT_DIRTY="${STUB_GIT_DIRTY:-}" \
     STUB_GIT_HEAD="${STUB_GIT_HEAD:-$default_ref}" STUB_GIT_HEAD_FILE="${STUB_GIT_HEAD_FILE:-}" \
     STUB_BUN_INSTALL_RC="${STUB_BUN_INSTALL_RC:-0}" STUB_BUN_BUILD_RC="${STUB_BUN_BUILD_RC:-0}" \
     STUB_BUN_VERSION_RC="${STUB_BUN_VERSION_RC:-0}" STUB_QMD_VERSION="${STUB_QMD_VERSION:-2.6.10}" \
+    STUB_NODE_FETCH_RC="${STUB_NODE_FETCH_RC:-0}" STUB_NODE_PROBE_RC="${STUB_NODE_PROBE_RC:-0}" \
     "$@"
 }
 
@@ -547,6 +589,43 @@ echo "upstream content" > "$note_home/.bun/install/global/node_modules/@tobilu/q
 out=$(qmd_install_env "$note_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
 assert "backup-note: rc 0" grep -q '^RC=0$' <<<"$out"
 assert "backup-note: names the preserved backup dir" grep -q 'preserved at' <<<"$out"
+
+echo "[test-qmd-bin] better-sqlite3 node-binding gate (HIMMEL-928 / CR codex-adv)"
+# The binding is node-only (bun takes the bun:sqlite branch), bun install
+# never produces it, and existence alone must never bless it -- the gate
+# load-probes and the installer repairs. Uses the $id2/bin/node stub.
+binding="$fresh_home/.himmel/qmd-fork/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+assert "binding gate: fresh install fetched the binding via node prebuild-install" test -f "$binding"
+# present-but-unloadable (wrong-ABI/corrupt simulation): probe forced to fail
+# -> fork-served must read NOT served despite the file existing.
+rc=0
+STUB_NODE_PROBE_RC=1 qmd_install_env "$fresh_home" bash "$SCRIPT_DIR/qmd-bin.sh" fork-served >/dev/null 2>&1 || rc=$?
+assert "binding gate: present-but-unloadable binding = not served" test "$rc" -ne 0
+# missing binding -> not served.
+rm -f "$binding"
+rc=0
+qmd_install_env "$fresh_home" bash "$SCRIPT_DIR/qmd-bin.sh" fork-served >/dev/null 2>&1 || rc=$?
+assert "binding gate: missing binding = not served" test "$rc" -ne 0
+# repair: qmd_install re-fetches under node and converges back to served.
+out=$(qmd_install_env "$fresh_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+assert "binding repair: rc 0" grep -q '^RC=0$' <<<"$out"
+assert "binding repair: prebuild fetch ran under node" grep -q 'prebuild-install/bin.js' "$node_log"
+assert "binding repair: binding restored" test -f "$binding"
+rc=0
+qmd_install_env "$fresh_home" bash "$SCRIPT_DIR/qmd-bin.sh" fork-served >/dev/null 2>&1 || rc=$?
+assert "binding repair: fork-served again afterward" test "$rc" -eq 0
+# fetch failure -> fail closed with the not-loadable WARNING.
+rm -f "$binding"
+STUB_NODE_FETCH_RC=1
+out=$(qmd_install_env "$fresh_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+STUB_NODE_FETCH_RC=0
+# shellcheck disable=SC2016
+# Single quotes intentional -- $1 expands inside the spawned bash -c subshell.
+assert "binding fetch-fail: rc nonzero (fail closed)" bash -c '! grep -q "^RC=0$" <<<"$1"' _ "$out"
+assert "binding fetch-fail: WARNs not-loadable with the manual command" grep -qi 'not loadable under node' <<<"$out"
+# leave fresh_home converged for any later assertions.
+out=$(qmd_install_env "$fresh_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+assert "binding gate: fresh_home re-converged" grep -q '^RC=0$' <<<"$out"
 
 echo "[test-qmd-bin] qmd_register_collection() add / idempotent-skip / warn (HIMMEL-752)"
 # Hermetic stub env: a fake `qmd` on PATH (no bun-qmd.js, no bun -> qmd_cmd

--- a/scripts/qmd/ensure-qmd-daemon.ps1
+++ b/scripts/qmd/ensure-qmd-daemon.ps1
@@ -27,16 +27,34 @@ $ErrorActionPreference = 'Stop'
 
 $InitPayload = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"ensure-qmd-daemon","version":"1"}}}'
 
-function Resolve-QmdBin {
-    # Bun global bin FIRST, PATH second — parity with the plugin bash hook:
-    # a broken Windows qmd stub can shadow PATH (HIMMEL-163), so the
-    # known-good bun install wins when present.
-    $bunExe = Join-Path $HOME '.bun\bin\qmd.exe'
-    if (Test-Path $bunExe) { return $bunExe }
-    $bunShim = Join-Path $HOME '.bun\bin\qmd'
-    if (Test-Path $bunShim) { return $bunShim }
+function Resolve-QmdInvocation {
+    # Returns a string[] argv prefix, or $null when qmd is absent. Preference
+    # order — parity with the plugin bash hook (HIMMEL-928):
+    #   1. bun + the bun-global @tobilu/qmd dist/cli/qmd.js -> @('bun', <qmd.js>)
+    #   2. bun global bin shim ($HOME\.bun\bin\qmd.exe / qmd)
+    #   3. PATH
+    # bun-js FIRST is load-bearing: the bin shim honors the CLI's node shebang
+    # and runs qmd under NODE, and the --daemon child is spawned via
+    # process.execPath — so a shim-started daemon runs under whatever node is
+    # installed. Under bun qmd uses bun:sqlite; under node it needs the
+    # better-sqlite3 native binding, which bun's install blocks by default and
+    # which breaks again on every node ABI bump (reproduced live: absent
+    # binding + node 26 killed the daemon at startup — HIMMEL-928).
+    # Bun-before-PATH: a broken Windows qmd stub can shadow PATH
+    # (HIMMEL-163), so the known-good bun install wins when present.
+    $bunRoot = if ($env:BUN_INSTALL) { $env:BUN_INSTALL } else { Join-Path $HOME '.bun' }
+    $bunJs = Join-Path $bunRoot 'install\global\node_modules\@tobilu\qmd\dist\cli\qmd.js'
+    $bun = Get-Command bun -ErrorAction SilentlyContinue
+    if ($bun -and (Test-Path $bunJs)) { return @($bun.Source, $bunJs) }
+    # Same $bunRoot for the shim fallbacks: a relocated BUN_INSTALL must not
+    # resolve the js from one root and the shim from $HOME\.bun (CodeRabbit,
+    # PR #1134).
+    $bunExe = Join-Path $bunRoot 'bin\qmd.exe'
+    if (Test-Path $bunExe) { return @($bunExe) }
+    $bunShim = Join-Path $bunRoot 'bin\qmd'
+    if (Test-Path $bunShim) { return @($bunShim) }
     $cmd = Get-Command qmd -ErrorAction SilentlyContinue
-    if ($cmd) { return $cmd.Source }
+    if ($cmd) { return @($cmd.Source) }
     return $null
 }
 
@@ -68,7 +86,7 @@ if ($state -eq 'foreign') {
 }
 
 # dead - start the daemon
-$qmd = Resolve-QmdBin
+$qmd = Resolve-QmdInvocation
 if (-not $qmd) {
     Write-Error "ensure-qmd-daemon: qmd is not on PATH and no fallback at $HOME\.bun\bin\qmd.exe. Install it: bash <himmel-repo>/scripts/lib/qmd-bin.sh install (HIMMEL-877)"
     exit 1
@@ -77,9 +95,13 @@ if (-not $qmd) {
 if ($PSCmdlet.ShouldProcess($Url, 'start qmd mcp --http --daemon')) {
     # Bounded start (parity with the bash twin's timeout(1) wrap): a hung
     # qmd/bun start must not stall the caller indefinitely.
-    $job = Start-Job -ScriptBlock { & $using:qmd mcp --http --daemon 2>&1 }
+    $startOut = @()
+    $job = Start-Job -ScriptBlock {
+        $argv = @($using:qmd) + @('mcp', '--http', '--daemon')
+        & $argv[0] @($argv | Select-Object -Skip 1) 2>&1
+    }
     if (Wait-Job $job -Timeout $QmdStartTimeout) {
-        $startOut = Receive-Job $job -ErrorAction SilentlyContinue
+        $startOut = @(Receive-Job $job -ErrorAction SilentlyContinue)
         if ($startOut) { Write-Verbose ($startOut -join [Environment]::NewLine) }
         Remove-Job $job -Force
     } else {
@@ -92,6 +114,9 @@ if ($PSCmdlet.ShouldProcess($Url, 'start qmd mcp --http --daemon')) {
         if ((Test-QmdAlive -ProbeUrl $Url) -eq 'alive') { exit 0 }
         Start-Sleep -Seconds 1
     }
-    Write-Error "ensure-qmd-daemon: started 'qmd mcp --http --daemon' but nothing came alive on $Url. Check the daemon log: $HOME\.cache\qmd\mcp.log"
+    # Include the captured start output (parity with the bash twin, which
+    # unconditionally dumps it on this exact failure path).
+    $startText = if ($startOut) { ($startOut | ForEach-Object { [string]$_ }) -join ' | ' } else { '<none>' }
+    Write-Error "ensure-qmd-daemon: started 'qmd mcp --http --daemon' but nothing came alive on $Url. qmd start output: $startText Check the daemon log: $HOME\.cache\qmd\mcp.log"
     exit 1
 }

--- a/scripts/qmd/register-qmd-daemon-logon.ps1
+++ b/scripts/qmd/register-qmd-daemon-logon.ps1
@@ -1,0 +1,51 @@
+# register-qmd-daemon-logon.ps1 - register a per-user ONLOGON scheduled task
+# that runs ensure-qmd-daemon.ps1, so the shared qmd HTTP MCP daemon
+# (localhost:8181) is back up after every reboot without waiting for the
+# first Claude session's SessionStart hook (HIMMEL-928).
+#
+# Lean-invoke, operator-run (HIMMEL-177): registration is a one-shot per
+# machine, never a hook. Idempotent - re-running overwrites the existing
+# task (-Force). Windows-only by design (the daemon-at-boot convenience);
+# POSIX machines rely on the SessionStart hook. Remove with:
+#   Unregister-ScheduledTask -TaskName 'qmd-mcp-daemon' -Confirm:$false
+# (the exact command for a custom -TaskName is echoed after registration).
+#
+# Single-operator scope: the task registers in the ROOT Task Scheduler
+# folder, and task identity is TaskPath+TaskName - on a genuinely
+# multi-operator machine a second user registering the same default name
+# replaces the first user's task. Out of scope for this personal-harness
+# tool; pass a distinct -TaskName per user if you truly share a machine.
+#
+# Run from the PRIMARY checkout, not a worktree - the task stores an absolute
+# path to ensure-qmd-daemon.ps1 next to this script, and a pruned worktree
+# would leave the task pointing at nothing.
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$TaskName = 'qmd-mcp-daemon'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$ensure = Join-Path $PSScriptRoot 'ensure-qmd-daemon.ps1'
+if (-not (Test-Path $ensure)) {
+    throw "ensure-qmd-daemon.ps1 not found next to this script: $ensure"
+}
+
+# Prefer pwsh (the twin targets PowerShell 7+); Windows PowerShell fallback.
+# -CommandType Application: a profile-defined alias/function named pwsh
+# would otherwise win command precedence and yield an unusable .Source.
+$shell = Get-Command pwsh -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+if (-not $shell) { $shell = Get-Command powershell -CommandType Application -ErrorAction Stop | Select-Object -First 1 }
+
+if ($PSCmdlet.ShouldProcess($TaskName, "register ONLOGON scheduled task -> $ensure")) {
+    $action = New-ScheduledTaskAction -Execute $shell.Source `
+        -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$ensure`""
+    $trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries -StartWhenAvailable
+    Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger `
+        -Settings $settings -Force | Out-Null
+    Write-Host "Registered scheduled task '$TaskName' (at logon: $($shell.Name) -File $ensure)"
+    Write-Host "Remove with: Unregister-ScheduledTask -TaskName '$TaskName' -Confirm:`$false"
+}

--- a/scripts/qmd/test-ensure-qmd-daemon.sh
+++ b/scripts/qmd/test-ensure-qmd-daemon.sh
@@ -14,7 +14,10 @@
 # (f) start "succeeds" but probe never comes alive -> wait loop exhausts,
 # nonzero + "nothing came alive" + mcp.log + start-output passthrough;
 # (g) timeout(1) absent -> degrade branch still starts the daemon and exits 0;
-# (h) bun-global bin is preferred over a PATH qmd (resolution order).
+# (h) bun-global bin is preferred over a PATH qmd (resolution order);
+# (i) bun + the bun-global dist/cli/qmd.js is preferred over the bun bin shim
+#     AND a PATH qmd (HIMMEL-928 - the daemon child must inherit bun, never a
+#     node-shebang shim's node execPath).
 set -u
 
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -226,5 +229,84 @@ grep -qx 'mcp --http --daemon' "$state/qmd-bun.log" || \
   fail "(h) bun-first: bun copy not called with 'mcp --http --daemon'"
 [ ! -f "$state/qmd-decoy.log" ] || fail "(h) bun-first: PATH decoy qmd was invoked"
 echo "ok (h): bun-global qmd preferred over the PATH decoy"
+
+# ---- (i) bun + global qmd.js preferred over the bun bin shim -----------------
+# HIMMEL-928: create the bun-global dist/cli/qmd.js and a mock `bun`; the (h)
+# bun-bin shim and the PATH decoy stay in place - the `bun <qmd.js>` invocation
+# must win them both, so the daemon child inherits bun's execPath (the bin
+# shim honors the CLI's node shebang and would hand the daemon to node, where
+# the bun-ABI better-sqlite3 prebuild refuses to load).
+mkdir -p "$home/.bun/install/global/node_modules/@tobilu/qmd/dist/cli"
+touch "$home/.bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
+cat > "$bin/bun" <<'EOF'
+#!/usr/bin/env bash
+echo "$*" >> "$QMD_MOCK_STATE/qmd-bunjs.log"
+case "$*" in
+  */dist/cli/qmd.js\ mcp\ --http\ --daemon) touch "$QMD_MOCK_STATE/alive" ;;
+esac
+exit 0
+EOF
+chmod +x "$bin/bun"
+rm -f "$state/alive" "$state/qmd-bun.log" "$state/qmd-decoy.log" "$state/qmd-bunjs.log"
+run_ensure sentinel "$bin:$decoy_bin:$safe"
+[ "$rc" -eq 0 ] || fail "(i) bun-js-first: expected rc 0, got $rc ($out)"
+[ -f "$state/qmd-bunjs.log" ] || fail "(i) bun-js-first: bun + qmd.js was not invoked"
+grep -q 'dist/cli/qmd.js mcp --http --daemon' "$state/qmd-bunjs.log" || \
+  fail "(i) bun-js-first: bun not called with '<qmd.js> mcp --http --daemon' (got: $(cat "$state/qmd-bunjs.log"))"
+[ ! -f "$state/qmd-bun.log" ] || fail "(i) bun-js-first: bun bin shim was invoked but the js path should win"
+[ ! -f "$state/qmd-decoy.log" ] || fail "(i) bun-js-first: PATH decoy qmd was invoked"
+echo "ok (i): bun + global qmd.js preferred over the bun bin shim and PATH"
+
+# ---- (i2) BUN_INSTALL override is honored for the bun-js resolution ----------
+# Parity with qmd-bin.sh's own BUN_INSTALL test: the two resolvers are
+# documented mirrors, so both must honor a relocated bun root. The DEFAULT
+# $HOME/.bun global qmd.js stays in place - the override must win over it.
+mkdir -p "$work/custom-bun/install/global/node_modules/@tobilu/qmd/dist/cli"
+touch "$work/custom-bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
+rm -f "$state/alive" "$state/qmd-bunjs.log" "$state/qmd-bun.log" "$state/qmd-decoy.log"
+BUN_INSTALL="$work/custom-bun" run_ensure sentinel "$bin:$decoy_bin:$safe"
+[ "$rc" -eq 0 ] || fail "(i2) BUN_INSTALL: expected rc 0, got $rc ($out)"
+grep -q 'custom-bun' "$state/qmd-bunjs.log" || \
+  fail "(i2) BUN_INSTALL: override path not used (got: $(cat "$state/qmd-bunjs.log" 2>/dev/null))"
+echo "ok (i2): BUN_INSTALL override honored for the bun-js resolution"
+
+# ---- (i3) bun present but global qmd.js ABSENT -> falls back to bun bin shim -
+# Pins the [ -f qmd.js ] && command -v bun conjunction: bun alone must NOT
+# select the js invocation; the (h) bun-bin shim mock takes over instead.
+rm -f "$home/.bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
+rm -f "$state/alive" "$state/qmd-bunjs.log" "$state/qmd-bun.log" "$state/qmd-decoy.log"
+run_ensure sentinel "$bin:$decoy_bin:$safe"
+[ "$rc" -eq 0 ] || fail "(i3) js-absent fallback: expected rc 0, got $rc ($out)"
+[ ! -f "$state/qmd-bunjs.log" ] || fail "(i3) js-absent fallback: bun-js invoked despite missing qmd.js"
+[ -f "$state/qmd-bun.log" ] || fail "(i3) js-absent fallback: bun bin shim was not invoked"
+grep -qx 'mcp --http --daemon' "$state/qmd-bun.log" || \
+  fail "(i3) js-absent fallback: shim not called with 'mcp --http --daemon'"
+echo "ok (i3): bun present without global qmd.js falls back to the bun bin shim"
+
+# ---- (i4) BUN_INSTALL override + missing qmd.js -> shim under the SAME root -
+# CodeRabbit (PR #1134): (i2) covered override+js-present and (i3) covered
+# default-root+js-missing, but never the combination - which is exactly where
+# a $HOME-hardcoded shim fallback breaks under a relocated bun root. The shim
+# must resolve from $BUN_INSTALL/bin, not $HOME/.bun/bin.
+rm -f "$work/custom-bun/install/global/node_modules/@tobilu/qmd/dist/cli/qmd.js"
+mkdir -p "$work/custom-bun/bin"
+cat > "$work/custom-bun/bin/qmd" <<'EOF'
+#!/usr/bin/env bash
+echo "$*" >> "$QMD_MOCK_STATE/qmd-custom-shim.log"
+if [ "$*" = "mcp --http --daemon" ]; then
+  touch "$QMD_MOCK_STATE/alive"
+fi
+exit 0
+EOF
+chmod +x "$work/custom-bun/bin/qmd"
+rm -f "$state/alive" "$state/qmd-bunjs.log" "$state/qmd-bun.log" "$state/qmd-decoy.log" "$state/qmd-custom-shim.log"
+BUN_INSTALL="$work/custom-bun" run_ensure sentinel "$bin:$decoy_bin:$safe"
+[ "$rc" -eq 0 ] || fail "(i4) override+js-absent: expected rc 0, got $rc ($out)"
+[ ! -f "$state/qmd-bunjs.log" ] || fail "(i4) override+js-absent: bun-js invoked despite missing qmd.js"
+[ -f "$state/qmd-custom-shim.log" ] || fail "(i4) override+js-absent: BUN_INSTALL/bin shim was not used"
+grep -qx 'mcp --http --daemon' "$state/qmd-custom-shim.log" || \
+  fail "(i4) override+js-absent: custom shim not called with 'mcp --http --daemon'"
+[ ! -f "$state/qmd-bun.log" ] || fail "(i4) override+js-absent: default \$HOME shim used instead of the BUN_INSTALL root"
+echo "ok (i4): BUN_INSTALL override + missing qmd.js falls back to the override root's shim"
 
 echo "PASS: all ensure-qmd-daemon cases"


### PR DESCRIPTION
Public propagation of private squash aa5c3402 (HIMMEL-928).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QMD daemon startup reliability across Bun and Node environments.
  * Added validation and automatic repair for missing or unloadable SQLite bindings.
  * Enhanced startup failure diagnostics with actionable remediation details.
  * Improved Windows command resolution and daemon output reporting.

* **New Features**
  * Added optional Windows logon registration to automatically restore the QMD daemon after reboot.
  * Added guidance for removing the scheduled task.

* **Documentation**
  * Documented QMD resolution behavior and Windows boot-survival setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->