### PR TITLE
fix(ci): [HIMMEL-971] arm-resume V-test schtasks stub + AGENTS.md Fable debrand + MD056 docs rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,7 +308,7 @@ onto a merged-PR branch, HIMMEL-512, same plugin delivery; `block-unresolved-cr-
 blocks `gh pr merge` while CodeRabbit review threads are unresolved or its check-run
 is in-flight on the head SHA, fail-open on every API/dep error, bypass
 `CR_MERGE_GATE_OK=1` — HIMMEL-936, same plugin delivery; and `guard-implementor-dispatch` —
-bank-aware cost guard that blocks a Sonnet/Opus/Fable implementor-shaped Agent dispatch
+bank-aware cost guard that blocks a Sonnet/Opus/top-model implementor-shaped Agent dispatch
 when the 5-hour bank is at/above 80% (advisory-only at 65%), fail-open on every infra
 error, bypass `IMPL_GUARD_OK=1` — HIMMEL-920, same plugin delivery), **1 PostToolUse hook**
 (`auto-arm-on-subagent-cap` — detects cap in Agent tool results, HIMMEL-276),

--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -55,8 +55,9 @@ Complete checklist for getting a new machine to full working state.
 | Git Bash 2.40+ | https://git-scm.com — includes bash 4.4+, `realpath -m`, `mktemp`, `cygpath`. |
 | `schtasks` | Built-in. Used by `scripts/handover/arm-resume.sh` for cron-armed Claude relaunches. **Always invoke under `MSYS_NO_PATHCONV=1`** (per HIMMEL-125) to prevent Git Bash from mangling `/flag` args into Windows paths. |
 | `MSYS_NO_PATHCONV` awareness | Documented in CLAUDE.md handover section. |
-| PowerShell-only is **NOT sufficient** — most operator-facing tooling needs bash. WSL as a *shell swap* under Windows-native Claude Code is not possible either (see the WSL station profile subsection below); native Git Bash is the tested path. |
 | WSL2 / Docker resource caps | If WSL or Docker Desktop is installed, cap them before multi-agent runs. Start with `%UserProfile%\.wslconfig` `memory=16GB`, `processors=8`, `swap=4GB` on a 48 GB / 32-logical-core class host, then tune after measuring. Docker gets separate Desktop/per-container caps. See [environment gotchas](../internals/environment-gotchas.md#windows-wsl--docker-resource-budget). |
+
+PowerShell-only is **NOT sufficient** — most operator-facing tooling needs bash. WSL as a *shell swap* under Windows-native Claude Code is not possible either (see the WSL station profile subsection below); native Git Bash is the tested path.
 
 #### WSL on Windows — two readings, only one of them real (HIMMEL-939)
 

--- a/scripts/agents-md/debrand.json
+++ b/scripts/agents-md/debrand.json
@@ -58,5 +58,10 @@
     "from": "Fable stays CONSERVED (limited release)",
     "to": "The top model stays CONSERVED (limited release)",
     "note": "HIMMEL-806: conservation note added 2026-07-08 — sentence-initial, single line, so the full-phrase match is stable."
+  },
+  {
+    "from": "a Sonnet/Opus/Fable implementor-shaped Agent dispatch",
+    "to": "a Sonnet/Opus/top-model implementor-shaped Agent dispatch",
+    "note": "HIMMEL-920: guard-implementor-dispatch hook description in the ENFORCEMENT section — neutral tier language, same pattern as the Fable-5 lane-table row."
   }
 ]

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -1671,7 +1671,16 @@ for a in "$@"; do
     esac
 done
 EOF
-chmod +x "$WINBIN/claude" "$WINBIN/cygpath"
+# No-op schtasks stub: only satisfies arm-resume's `command -v schtasks`
+# preflight (~line 491) for the dry-run V1/V2/V2b cases below, which return
+# before any create call ever reaches schtasks. On a real Linux box (no
+# System32 schtasks) this preflight would otherwise kill those tests before
+# they reach the locale-render logic under test.
+cat > "$WINBIN/schtasks" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$WINBIN/claude" "$WINBIN/cygpath" "$WINBIN/schtasks"
 win_env() { local _dir="$1"; shift; env PATH="$_dir:$WINBIN:$PATH" OSTYPE="msys" "$@"; }
 
 # V1: DD/MM locale render. `reg` reports a dd/MM/yyyy short-date pattern;


### PR DESCRIPTION
Public propagation of private squash 5a3b77a1 (HIMMEL-971) — fixes the two public shell-unit reds + the MD056 finding from public #396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Windows setup guidance by prioritizing WSL2 and Docker resource recommendations.
  - Updated terminology in enforcement and debranding guidance to use more neutral model-tier language.

- **Tests**
  - Improved cross-platform resume workflow tests so locale-rendering checks run reliably on systems without native Windows task-scheduling tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->