### PR TITLE
fix(hooks): guard-implementor-dispatch: absent-model dispatch = DENY at hard threshold

### DIFF
--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -430,10 +430,9 @@ exits 2.
 
 **Decision shape:** a dispatch is only DENY-eligible when BOTH
 `subagent_type` is in the allow-list {`general-purpose`, `claude`,
-`feature-dev:code-architect`} AND `model` is in {`sonnet`, `opus`, `fable`}
-— a deny-list would false-block future reviewer agent types, so an
-absent/empty `model` is capped to WARN, never DENY (it inherits the parent
-loop, which is costly, but can't be confirmed as this-shape-costly).
+`feature-dev:code-architect`} AND `model` is in {`sonnet`, `opus`, `fable`,
+absent/empty}. An absent/empty `model` is DENY-eligible per the HIMMEL-972
+operator ruling: an unnamed dispatch inherits the parent loop.
 `model == haiku` always allows regardless of shape. Beyond the allow-list
 check, the dispatch `prompt` must also match a narrow impl-shaped ERE
 (`implement|apply the fix|write the code|make it pass|fix the
@@ -473,7 +472,7 @@ prefix does not reach the hook process).
 `block-docker-privesc`); live only after `/himmel-update` (marketplace
 re-sync) + a fresh session.
 
-Spec: `scripts/hooks/test-guard-implementor-dispatch.sh` (13 test cases, 27
+Spec: `scripts/hooks/test-guard-implementor-dispatch.sh` (22 test cases, 40
 assertions).
 
 ### `block-glm-external-writes.sh` — GLM-lane external-write deny (HIMMEL-654)

--- a/scripts/hooks/guard-implementor-dispatch.sh
+++ b/scripts/hooks/guard-implementor-dispatch.sh
@@ -26,10 +26,11 @@
 #   5. DENY-tier eligibility is an ALLOW-LIST of known-expensive implementor
 #      shapes (critic Q2 — a deny-list would false-block future reviewer
 #      agent types): subagent_type in {general-purpose, claude,
-#      feature-dev:code-architect} AND model in {sonnet, opus, fable}.
-#      Anything else (incl. an absent/empty model — critic optional #2: it
-#      inherits the parent loop, costly but not confirmable as DENY-worthy)
-#      is capped at WARN-tier, never DENY.
+#      feature-dev:code-architect} AND model in {sonnet, opus, fable, absent/
+#      empty}. An absent/empty model IS DENY-eligible (HIMMEL-972 operator
+#      ruling 2026-07-12: an unnamed dispatch inherits the parent loop — the
+#      exact expensive shape this guard exists for; supersedes the original
+#      critic call).
 #   6. Impl-shaped prompt classifier (case-insensitive ERE, de-greeded per
 #      critic Q1 — dropped `patch` (substring of "dispatch"), bare `commit`,
 #      bare `refactor`: all high false-positive). No match → allow.
@@ -75,9 +76,14 @@
 #   incident class this guard exists for (s40 CR-fix rounds) uses the marker
 #   vocabulary. Same accepted-limitation family as the wrapper-displacement
 #   gaps documented in block-glm-external-writes.sh.
-# - ABSENT MODEL IS WARN-ONLY: an unnamed dispatch inherits the parent loop
-#   (expensive) but its cost cannot be CONFIRMED at hook time — plan-critic
-#   call: advisory, never a false block.
+# - ABSENT MODEL IS DENY-ELIGIBLE (HIMMEL-972): an unnamed dispatch inherits
+#   the parent loop, so it is treated as a known-expensive shape at the hard
+#   threshold. Originally WARN-only (plan-critic call); superseded by the
+#   2026-07-12 operator ruling on the HIMMEL-920 cross-model conflict.
+#   Residual edge (adjudicated, NOT a bug): a HAIKU parent's unnamed dispatch
+#   inherits cheap Haiku yet still denies — accepted because Haiku does not
+#   spawn (CLAUDE.md invariant), naming `haiku` explicitly hits the early
+#   always-allow, and IMPL_GUARD_OK=1 covers the exotic remainder.
 #
 # bash 3.2-compatible (no ${var,,}, no mapfile, no associative arrays).
 set -uo pipefail
@@ -115,7 +121,7 @@ case "$subagent_type" in
 esac
 model_in_set=0
 case "$model_lc" in
-    sonnet|opus|fable) model_in_set=1 ;;
+    sonnet|opus|fable|'') model_in_set=1 ;;
 esac
 eligible_deny=0
 [ "$subagent_in_set" = "1" ] && [ "$model_in_set" = "1" ] && eligible_deny=1

--- a/scripts/hooks/test-guard-implementor-dispatch.sh
+++ b/scripts/hooks/test-guard-implementor-dispatch.sh
@@ -135,12 +135,28 @@ RC7B=$(run_hook t7b "$(payload_full general-purpose sonnet 'implement the fix')"
 assert_rc "T7b IMPL_GUARD_DISABLE bypass rc" 0 "$RC7B"
 assert_empty "T7b IMPL_GUARD_DISABLE bypass stdout" "$(cat "$TMP/out-t7b")"
 
-# T8: Absent model + impl prompt, util=85 → allow + advisory (WARN-tier, NOT deny).
+# T8: Absent model + impl prompt, util=85 → deny per HIMMEL-972.
 CACHE8="$TMP/cache8.json"; mkcache "$CACHE8" 85
 RC8=$(run_hook t8 "$(payload_no_model general-purpose 'implement the fix')" \
     IMPL_GUARD_CACHE_PATH="$CACHE8")
-assert_rc "T8 absent-model rc" 0 "$RC8"
-assert_contains "T8 absent-model advisory JSON" "permissionDecisionReason" "$(cat "$TMP/out-t8")"
+assert_rc "T8 absent-model rc" 2 "$RC8"
+assert_contains "T8 absent-model deny stderr" "glm-subagent" "$(cat "$TMP/err-t8")"
+
+# T8b: Absent model + impl prompt, util=70 → allow + advisory (WARN tier).
+CACHE8B="$TMP/cache8b.json"; mkcache "$CACHE8B" 70
+RC8B=$(run_hook t8b "$(payload_no_model general-purpose 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE8B")
+assert_rc "T8b absent-model WARN rc" 0 "$RC8B"
+assert_contains "T8b absent-model allow decision" '"permissionDecision":"allow"' "$(cat "$TMP/out-t8b")"
+assert_contains "T8b absent-model advisory JSON" "permissionDecisionReason" "$(cat "$TMP/out-t8b")"
+
+# T8c: Absent model + non-allow-listed subagent, util=85 → WARN, never deny.
+CACHE8C="$TMP/cache8c.json"; mkcache "$CACHE8C" 85
+RC8C=$(run_hook t8c "$(payload_no_model caveman:cavecrew-builder 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE8C")
+assert_rc "T8c absent-model non-allow-listed rc" 0 "$RC8C"
+assert_contains "T8c absent-model allow decision" '"permissionDecision":"allow"' "$(cat "$TMP/out-t8c")"
+assert_contains "T8c absent-model advisory JSON" "permissionDecisionReason" "$(cat "$TMP/out-t8c")"
 
 # T9: Haiku impl dispatch, util=85 → allow, silent.
 CACHE9="$TMP/cache9.json"; mkcache "$CACHE9" 85


### PR DESCRIPTION
## Summary

Public propagation of the private HIMMEL-972 squash (`c4d43bd2`): the guard-implementor-dispatch cost guard now treats an **absent/empty model** on an implementor-shaped Agent dispatch as DENY-eligible at the >= 80% hard threshold (an unnamed dispatch inherits the parent tier — the exact expensive shape the guard exists for). WARN tier, subagent allow-list, prompt classifier, haiku early-allow, fail-open contract, and the `IMPL_GUARD_OK=1` escape hatch are unchanged.

Code-only single squash `c4d43bd2~1..c4d43bd2`; byte-verified against private main by the ship flow.

## Test plan

- [x] `bash scripts/hooks/test-guard-implementor-dispatch.sh` → 40 passed, 0 failed
- [x] shell-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dispatch safeguards so absent or empty model selections can be blocked when hard utilization limits and prompt conditions are met.
  * Added support for the `feature-dev:code-architect` dispatch type in enforcement checks.
  * Clarified behavior across low- and high-utilization scenarios.

* **Tests**
  * Expanded coverage for absent-model dispatches, including allowed, advisory, and denied outcomes.
  * Updated enforcement documentation to reflect the revised test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->