### PR TITLE
fix(test): station-env isolation — apt-node /usr/bin collision + at-less hosts + hook-type provisioning docs

### DIFF
--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -79,6 +79,14 @@ ADR evaluated both (win2, 2026-07-12):
   to run on a Windows host; the Linux column of this doc applies. Windows-side
   control-plane pieces (schtasks arming) remain reachable via interop
   (`schtasks.exe` callable from WSL, ~70 ms overhead).
+  **Provisioning gate hooks (HIMMEL-966):** in the in-distro himmel clone,
+  run `bash scripts/setup.sh` (it installs all three hook types), or if
+  installing manually, ALL THREE:
+  `pre-commit install --hook-type pre-commit --hook-type commit-msg --hook-type pre-push`.
+  A bare `pre-commit install` installs only the pre-commit hook type — the
+  commit-msg + pre-push gates (attestation trailers, CR-marker write,
+  conventional-commit lint) are then silently absent and the first push
+  goes out ungated (the HIMMEL-955 workday hit exactly this).
 
 **Git Bash remains the tested default** for Windows stations until the
 HIMMEL-955 WSL-station pilot reaches an ADOPT verdict. If you run WSL from Git
@@ -589,6 +597,7 @@ git clone <luna-remote> ~/Documents/luna
 cd ~/Documents/luna
 uv tool install pre-commit   # or: pipx install pre-commit
 pre-commit install
+pre-commit install --hook-type commit-msg
 pre-commit install --hook-type pre-push
 
 # Verify

--- a/scripts/guardrails/test-graphify-fence.sh
+++ b/scripts/guardrails/test-graphify-fence.sh
@@ -259,9 +259,20 @@ run_fence deny no "$HIMMEL" "unwritable ledger allow+log -> deny, no partial lin
 out=$( cd "$HIMMEL" && env -u HOME -u CLAUDE_GLM_CONFIG_DIR "$BASH_BIN" "$FENCE" "graphify update $HIMMEL/scripts/thing.sh --backend deepseek" 2>&1 ); rc=$?
 if [ "$rc" -eq 2 ]; then pass "trap: HOME unset -> rc 2"; else fail "trap: HOME unset expected rc=2 got rc=$rc out=$out"; fi
 
-# (8) node absent (PATH stripped to /usr/bin, which has coreutils but not node) -> rc 2
+# (8) node absent -> rc 2. PATH needs coreutils but NOT node; on apt-node
+# systems node lives IN /usr/bin (HIMMEL-966), so mirror it minus node.
+NONODE_BIN=/usr/bin
+if [ -x /usr/bin/node ] || [ -x /usr/bin/node.exe ]; then
+    NONODE_BIN="$WS/nonode-bin"
+    mkdir -p "$NONODE_BIN"
+    for _f in /usr/bin/*; do
+        _b="${_f##*/}"
+        case "$_b" in node|node.exe|nodejs) continue ;; esac
+        ln -s "$_f" "$NONODE_BIN/$_b" 2>/dev/null || true
+    done
+fi
 run_fence deny no "$HIMMEL" "node absent -> rc 2 (fail-closed)" \
-    "graphify update $HIMMEL/scripts/thing.sh --backend deepseek" PATH=/usr/bin
+    "graphify update $HIMMEL/scripts/thing.sh --backend deepseek" PATH="$NONODE_BIN"
 
 # (9) unreadable phi-roots (a directory sits at the phi-roots path) -> rc 2
 run_fence deny no "$HIMMEL" "unreadable phi-roots -> rc 2" \

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -272,7 +272,8 @@ assert_not_contains "T7 no discoverability warning for CRLF handover" "no --cwd 
 # ---------------------------------------------------------------------------
 HO=$(make_handover "$WORK_REPO")
 PAST_HHMM=$(python3 -c 'import datetime; print((datetime.datetime.now()-datetime.timedelta(minutes=2)).strftime("%H:%M"))')
-out=$(bash "$ARM" --time "$PAST_HHMM" --handover "$HO" --force --dry-run 2>&1)
+# HIMMEL-966: host `at` must not be a dependency; pin the posix backend with the stub.
+out=$(PATH="$SCHED_STUB_T17:$PATH" bash "$ARM" --time "$PAST_HHMM" --handover "$HO" --force --dry-run 2>&1)
 rc=$?
 assert_rc "T8 past --time exits 0 (force+dry)" 0 "$rc"
 case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
@@ -299,7 +300,8 @@ FIVE_RESET=$(python3 -c 'import datetime; print((datetime.datetime.now(datetime.
 SEVEN_RESET=$(python3 -c 'import datetime; print((datetime.datetime.now(datetime.timezone.utc)+datetime.timedelta(days=6)).isoformat())')
 printf '{"five_hour":{"utilization":0.0,"resets_at":"%s"},"seven_day":{"utilization":15.0,"resets_at":"%s"}}' \
     "$FIVE_RESET" "$SEVEN_RESET" > "$SLOT_CACHE"
-out=$(RESUME_SLOT_CACHE="$SLOT_CACHE" SLOT_MAX_AGE=0 bash "$ARM" --time smart --handover "$HO" --force --dry-run 2>&1)
+# HIMMEL-966: host `at` must not be a dependency; pin the posix backend with the stub.
+out=$(RESUME_SLOT_CACHE="$SLOT_CACHE" SLOT_MAX_AGE=0 PATH="$SCHED_STUB_T17:$PATH" bash "$ARM" --time smart --handover "$HO" --force --dry-run 2>&1)
 rc=$?
 assert_rc "T9 --time smart exits 0 (force+dry)" 0 "$rc"
 assert_contains "T9 smart banner shows bank-free ASAP" "smart -> " "$out"

--- a/scripts/himmelctl/test/test-wizard-bootstrap.sh
+++ b/scripts/himmelctl/test/test-wizard-bootstrap.sh
@@ -164,7 +164,7 @@ echo "ok: caseA(sh) node present -> short-circuits straight to hand-off, install
 # ── bootstrap.sh — Case B: --dry-run, node absent -> plan+hand-off only ────
 stubB="$work/shB"; mkdir -p "$stubB"
 build_sudo_stub "$stubB" 0
-cB=$(build_path "$stubB" uname -- node)
+cB=$(build_path "$stubB" uname dirname bash ln cp -- node)
 fixtureB="$work/shB-fixture"; build_bin_js_fixture "$fixtureB"
 set +e
 out=$(PATH="$cB" HIMMELCTL_REPO_ROOT="$(winpath "$fixtureB")" \
@@ -185,7 +185,7 @@ echo "ok: caseB(sh) --dry-run node-absent -> plan+hand-off printed, nothing muta
 stubC="$work/shC"; mkdir -p "$stubC"
 build_sudo_stub "$stubC" 0
 build_aptget_stub "$stubC"
-cC=$(build_path "$stubC" uname -- node)
+cC=$(build_path "$stubC" uname dirname bash ln cp -- node)
 fixtureC="$work/shC-fixture"; build_bin_js_fixture "$fixtureC"
 set +e
 out=$(PATH="$cC" HIMMELCTL_REPO_ROOT="$(winpath "$fixtureC")" \
@@ -205,7 +205,7 @@ echo "ok: caseC(sh) node absent, install doesn't refresh PATH -> single re-run l
 stubD="$work/shD"; mkdir -p "$stubD"
 build_sudo_stub "$stubD" 1
 build_aptget_stub "$stubD"
-cD=$(build_path "$stubD" uname -- node)
+cD=$(build_path "$stubD" uname dirname bash ln cp -- node)
 fixtureD="$work/shD-fixture"; build_bin_js_fixture "$fixtureD"
 set +e
 out=$(PATH="$cD" HIMMELCTL_REPO_ROOT="$(winpath "$fixtureD")" \
@@ -223,7 +223,7 @@ echo "ok: caseD(sh) node absent, install refreshes PATH -> chains to bin.js"
 # ── bootstrap.sh — Case F: FIX 1 -- apt plan no longer asks for bun ────────
 stubF="$work/shF"; mkdir -p "$stubF"
 build_sudo_stub "$stubF" 0
-cF=$(build_path "$stubF" uname -- node)
+cF=$(build_path "$stubF" uname dirname bash ln cp -- node)
 fixtureF="$work/shF-fixture"; build_bin_js_fixture "$fixtureF"
 set +e
 out=$(PATH="$cF" HIMMELCTL_REPO_ROOT="$(winpath "$fixtureF")" \
@@ -253,7 +253,7 @@ printf 'sudo: %s\n' "\$*" >> "$stubG/install-calls.log"
 exit 1
 STUB
 chmod +x "$stubG/sudo"
-cG=$(build_path "$stubG" uname -- node)
+cG=$(build_path "$stubG" uname dirname bash ln cp -- node)
 fixtureG="$work/shG-fixture"; build_bin_js_fixture "$fixtureG"
 set +e
 out=$(PATH="$cG" HIMMELCTL_REPO_ROOT="$(winpath "$fixtureG")" \

--- a/scripts/lib/test-resolve-node.sh
+++ b/scripts/lib/test-resolve-node.sh
@@ -15,10 +15,28 @@ failures=0
 pass() { printf '  PASS  %s\n' "$1"; }
 fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures+1)); }
 
-# A realistic "node not on PATH" still has coreutils (/usr/bin). Use the dir
-# that actually holds sort/ls so resolve_node's nvm/fnm pipeline works, while
-# node stays absent from it. (Setting PATH=/nonexistent would also strip sort.)
-UTILS_DIR="$(dirname "$(command -v sort)")"
+# A realistic "node not on PATH" still needs coreutils — but on apt-node
+# systems node LIVES in the coreutils dir (/usr/bin, HIMMEL-966), so use
+# a curated symlink dir carrying only the tools these cases need.
+UTILS_ROOT="$(mktemp -d)"
+trap 'rm -rf "$UTILS_ROOT"' EXIT
+UTILS_DIR="$UTILS_ROOT/utils"
+mkdir -p "$UTILS_DIR"
+for _t in sort tail; do
+    _p="$(command -v "$_t" 2>/dev/null)" && ln -s "$_p" "$UTILS_DIR/$_t" 2>/dev/null
+done
+# Windows Git Bash: a symlink/copy of an MSYS tool loses its msys-2.0.dll
+# neighborhood and won't run — probe, then fall back to the coreutils dir
+# (node is never colocated with coreutils on those hosts).
+if ! PATH="$UTILS_DIR" sort </dev/null >/dev/null 2>&1; then
+    UTILS_DIR="$(dirname "$(command -v sort)")"
+    # Self-diagnose the one bad combination (fallback dir DOES carry node —
+    # the HIMMEL-966 apt-node class): the PATH-cleared cases below will fail;
+    # say why up front instead of leaving a puzzling red run.
+    if [ -x "$UTILS_DIR/node" ] || [ -x "$UTILS_DIR/node.exe" ]; then
+        echo "WARN: curated utils dir unusable AND fallback $UTILS_DIR carries node — PATH-cleared cases will fail (HIMMEL-966)" >&2
+    fi
+fi
 
 # A fake node binary (executable, content irrelevant — resolve_node only checks -x).
 make_fake_node() {

--- a/scripts/lib/test-run-node.sh
+++ b/scripts/lib/test-run-node.sh
@@ -11,7 +11,28 @@ failures=0
 pass() { printf '  PASS  %s\n' "$1"; }
 fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures+1)); }
 
-UTILS_DIR="$(dirname "$(command -v sort)")"
+# A realistic "node not on PATH" still needs coreutils — but on apt-node
+# systems node LIVES in the coreutils dir (/usr/bin, HIMMEL-966), so use
+# a curated symlink dir carrying only the tools these cases need.
+UTILS_ROOT="$(mktemp -d)"
+trap 'rm -rf "$UTILS_ROOT"' EXIT
+UTILS_DIR="$UTILS_ROOT/utils"
+mkdir -p "$UTILS_DIR"
+for _t in bash dirname sort tail cat mkdir date; do
+    _p="$(command -v "$_t" 2>/dev/null)" && ln -s "$_p" "$UTILS_DIR/$_t" 2>/dev/null
+done
+# Windows Git Bash: a symlink/copy of an MSYS tool loses its msys-2.0.dll
+# neighborhood and won't run — probe, then fall back to the coreutils dir
+# (node is never colocated with coreutils on those hosts).
+if ! PATH="$UTILS_DIR" bash -c 'sort </dev/null >/dev/null 2>&1 && command -v dirname >/dev/null' 2>/dev/null; then
+    UTILS_DIR="$(dirname "$(command -v sort)")"
+    # Self-diagnose the one bad combination (fallback dir DOES carry node —
+    # the HIMMEL-966 apt-node class): the PATH-cleared cases below will fail;
+    # say why up front instead of leaving a puzzling red run.
+    if [ -x "$UTILS_DIR/node" ] || [ -x "$UTILS_DIR/node.exe" ]; then
+        echo "WARN: curated utils dir unusable AND fallback $UTILS_DIR carries node — PATH-cleared cases will fail (HIMMEL-966)" >&2
+    fi
+fi
 
 # A fake node: $1 is the "script" path (we route on its basename), rest are args.
 make_fake_node() {

--- a/scripts/test-himmel-doctor.sh
+++ b/scripts/test-himmel-doctor.sh
@@ -45,6 +45,21 @@ for _tool in bash sh git jq sort tail sed cat date mktemp mkdir dirname uname wc
     _p="$(command -v "$_tool" 2>/dev/null)" && ln -sf "$_p" "$NOGH/$_tool" 2>/dev/null
 done
 
+# Curated PATH WITHOUT node (same trick as NOGH): on apt-node systems
+# node shares /usr/bin with the tools above, so TOOLS_PATH cannot
+# exclude it by dropping dirs (HIMMEL-966).
+NONODE="$FAKEROOT/nonode"; mkdir -p "$NONODE"
+for _t in bash sh git jq sort tail sed cat date mktemp mkdir dirname uname wc tr head cp rm mv chmod grep basename find ls; do
+    _p="$(command -v "$_t" 2>/dev/null)" && ln -s "$_p" "$NONODE/$_t" 2>/dev/null
+done
+# Windows Git Bash symlinks to .exe tools don't execute — fall back to
+# TOOLS_PATH there (node is never in the coreutils dirs on those hosts).
+if PATH="$NONODE" bash -c 'git --version >/dev/null 2>&1 && ! command -v node >/dev/null 2>&1' 2>/dev/null; then
+    NODELESS_PATH="$NONODE"
+else
+    NODELESS_PATH="$TOOLS_PATH"
+fi
+
 # $1=claude dir, $2=JSON-encoded caveman SessionStart command
 write_settings() {
     mkdir -p "$1"
@@ -108,7 +123,7 @@ rm -rf "$t"
 
 echo "== wrapper-form but NO node anywhere -> C1 FAIL (R4/P5) =="
 t="$(mktemp -d)"; write_settings "$t/claude" "$WRAPPER"
-out="$(PATH="$TOOLS_PATH" RESOLVE_NODE_PROBE_DIRS="" RESOLVE_NODE_NVM_ROOT="$t/none" FNM_DIR="$t/none" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"; rc=$?
+out="$(PATH="$NODELESS_PATH" RESOLVE_NODE_PROBE_DIRS="" RESOLVE_NODE_NVM_ROOT="$t/none" FNM_DIR="$t/none" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"; rc=$?
 if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q 'FAIL C1-node'; then pass "wrapper+no-node -> rc1 FAIL"; else fail "wrapper+no-node -> rc=$rc; $(printf '%s' "$out" | grep C1-node)"; fi
 rm -rf "$t"
 
@@ -138,7 +153,7 @@ fi
 
 echo "== bare 'node' caveman cmd + node off PATH -> C1 WARN =="
 t="$(mktemp -d)"; write_settings "$t/claude" '"node \"X/hooks/caveman-activate.js\""'
-out="$(PATH="$TOOLS_PATH" RESOLVE_NODE_PROBE_DIRS="" RESOLVE_NODE_NVM_ROOT="$t/none" FNM_DIR="$t/none" DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"
+out="$(PATH="$NODELESS_PATH" RESOLVE_NODE_PROBE_DIRS="" RESOLVE_NODE_NVM_ROOT="$t/none" FNM_DIR="$t/none" DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" bash "$DOC" --no-color 2>&1)"
 if printf '%s' "$out" | grep -q 'WARN C1-node'; then pass "bare-node -> C1 WARN"; else fail "bare-node -> $(printf '%s' "$out" | grep C1-node)"; fi
 rm -rf "$t"
 


### PR DESCRIPTION
## Summary
Public propagation of the station-env test isolation fixes — apt-node /usr/bin collision + at-less hosts + hook-type provisioning docs (single squash of the private change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified workstation setup requirements for installing all required commit hooks.
  - Updated Luna vault setup steps to include `commit-msg` and `pre-push` hooks.

- **Tests**
  - Improved reliability of no-Node and scheduler-related test scenarios across supported environments.
  - Added controlled command-path handling to make test outcomes more deterministic and portable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->