### PR TITLE
feat(cr): /cr-tune self-evolution miner + free-critic probation swap

### DIFF
--- a/.claude/commands/cr-tune.md
+++ b/.claude/commands/cr-tune.md
@@ -1,0 +1,15 @@
+---
+description: Mine the CR ledger for disproved classes per critic and draft citation-backed tuning proposals (.coderabbit.yaml / critics.json) — proposals only, never auto-applied
+---
+
+1. Run the mechanical miner and the scorecard:
+   ```bash
+   bash scripts/cr/cr-tune.sh
+   bash scripts/cr/cr-scores.sh
+   ```
+2. Judgment layer (the session): map each disproved cluster / calibration flag / re-litigation signal to a named concept class (e.g. "test-fixture over-verification", "CR-round re-litigation", "docs-mirror noise"). Evidence bar: a proposal needs ≥3 supporting disproved rows from ONE cluster OR an operator-confirmed known-limitation pattern; anything thinner is listed under "weak signals — do not tune yet".
+3. Draft proposals — each citing its ledger rows (`ts head finding_id file:line`):
+   - `.coderabbit.yaml`: `reviews.path_instructions` additions/edits (path_instructions outrank CodeRabbit "learnings", so the yaml is the durable channel).
+   - `scripts/cr/critics.json`: per-critic prompt/routing adjustments; confirm or contradict `cr-scores.sh` drop advice.
+4. Write the proposals to `<handover-root>/cr-tune/proposals-YYYY-MM-DD.md` — resolve the root via `scripts/lib/handover-path.sh` using `handover_root_ensure` (NOT plain `handover_root`, which never mkdirs), then `mkdir -p "<root>/cr-tune"` before writing, and `test -f` the resulting file before surfacing the path. NEVER edit `.coderabbit.yaml` or `critics.json` in the same run — config changes are operator-approved PRs that cite the proposal file.
+5. Re-run note: the miner is read-only and idempotent; re-running after new /pr-check rounds refreshes the clusters.

--- a/docs/commands-catalog.md
+++ b/docs/commands-catalog.md
@@ -48,6 +48,7 @@ and their rows are paraphrased one-liners rather than verbatim frontmatter
 | /pr-check | Run the multi-agent CR review on the current branch and clear the pre-push marker on clean output |
 | /check-ci | Token-free PR merge-gate watcher — one process loops inside gh pr checks --watch --fail-fast, then verifies zero unresolved review threads and no changes-requested review, and returns a single exit code (0=green+resolved, 1=red, 2=cannot evaluate/no PR/usage error, 3=unresolved threads or changes requested), so merge-on-green costs ~zero tokens (HIMMEL-949). |
 | /cr-scores | Print the per-critic agreed/availability scorecard and surface drop advice |
+| /cr-tune | Mine the CR ledger for disproved classes per critic and draft citation-backed tuning proposals (.coderabbit.yaml / critics.json) — proposals only, never auto-applied |
 | /claude-md-audit | Audit changed CLAUDE.md files against the claude-md-improver rubric before PR — audit-only, applies no edits on its own |
 | /shell-lint | Pre-emptive advisory shell lint — run shellcheck + UTF-8 BOM + errexit-leak checks on staged shell (or named files) BEFORE the commit attempt, so the loop fixes issues instead of bouncing off the pre-commit gate (HIMMEL-478). |
 | /guardrail-sim | Pre-flight guardrail simulator — feed planned Bash commands on stdin and it flags/rewrites the predictable himmel guardrail collisions (compound→single, WSL-bash→Git Bash, destructive-git, on-main-write) + a curated learnings file, before they stall a run (HIMMEL-475). |

--- a/scripts/cr/cr-tune.sh
+++ b/scripts/cr/cr-tune.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016  # Single quotes in node -e intentional (shell vars set via env)
+# scripts/cr/cr-tune.sh — CR self-evolution ledger miner (HIMMEL-978)
+# Mechanically mines the CR ledger for the signals the /cr-tune runbook turns
+# into tuning proposals: per-model verdict stats, per-(model,severity)
+# calibration flags, disproved clusters with row citations, and re-litigation
+# (CR-round-marker) signals. READ-ONLY on the ledger; the judgment layer
+# (taxonomy + proposals) lives in .claude/commands/cr-tune.md.
+# Usage: cr-tune.sh [--window N] [--min-cite N] [--json]
+# Reads CR_LEDGER (default: $(git rev-parse --git-common-dir)/cr-critic-scores.jsonl)
+# Exit: 0 success (incl. empty ledger), 2 usage error.
+set -uo pipefail
+
+WINDOW=0      # last-N-heads window; 0 = all heads
+MIN_CITE=3    # min disproved rows for a cluster / calibration flag
+JSON=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --window)   [ $# -ge 2 ] || { echo "cr-tune.sh: --window requires an argument" >&2; exit 2; }; case "$2" in ''|*[!0-9]*) echo "cr-tune.sh: --window requires a non-negative integer" >&2; exit 2;; esac; WINDOW="$2"; shift 2;;
+    --min-cite) [ $# -ge 2 ] || { echo "cr-tune.sh: --min-cite requires an argument" >&2; exit 2; }; case "$2" in ''|*[!0-9]*) echo "cr-tune.sh: --min-cite requires a non-negative integer" >&2; exit 2;; esac; MIN_CITE="$2"; shift 2;;
+    --json)     JSON=1; shift;;
+    *) echo "cr-tune.sh: unknown option $1" >&2; exit 2;;
+  esac
+done
+
+ledger="${CR_LEDGER:-$(git rev-parse --git-common-dir 2>/dev/null)/cr-critic-scores.jsonl}"
+if [ ! -f "$ledger" ] || [ ! -s "$ledger" ]; then
+  echo "no critic scores recorded yet (ledger: $ledger)"
+  exit 0
+fi
+
+WINDOW="$WINDOW" MIN_CITE="$MIN_CITE" JSON="$JSON" LEDGER="$ledger" node -e '
+const fs = require("fs");
+const WINDOW_N  = Number(process.env.WINDOW);
+const MIN_CITE  = Number(process.env.MIN_CITE);
+const JSON_OUT  = process.env.JSON === "1";
+const ledger    = process.env.LEDGER;
+
+const records = [];
+for (const l of fs.readFileSync(ledger, "utf8").split("\n").filter(Boolean)) {
+  try { records.push(JSON.parse(l)); } catch (_) { /* skip malformed */ }
+}
+
+// Optional last-N-heads window (same computation as cr-scores.sh).
+let recs = records;
+if (WINDOW_N > 0) {
+  const headTs = {};
+  for (const r of records) {
+    if (!r.head) continue;
+    if (!headTs[r.head] || r.ts < headTs[r.head]) headTs[r.head] = r.ts;
+  }
+  const allHeads = Object.entries(headTs).sort((a,b)=>a[1]<b[1]?-1:1).map(e=>e[0]);
+  const win = new Set(allHeads.slice(-WINDOW_N));
+  recs = records.filter(r => !r.head || win.has(r.head));
+}
+
+const findings = recs.filter(r => r.kind === "finding");
+const avails   = recs.filter(r => r.kind === "avail");
+
+// ── per-model verdict stats ──
+const VALID_VERDICTS = new Set(["agreed","disproved","conflict","unaddressed"]);
+const models = {};
+for (const f of findings) {
+  const m = models[f.model] = models[f.model] || { model: f.model, n: 0, agreed: 0, disproved: 0, conflict: 0, unaddressed: 0, avail_ok: 0, avail_n: 0 };
+  m.n++;
+  if (VALID_VERDICTS.has(f.verdict)) m[f.verdict]++;
+}
+for (const a of avails) {
+  const m = models[a.model] = models[a.model] || { model: a.model, n: 0, agreed: 0, disproved: 0, conflict: 0, unaddressed: 0, avail_ok: 0, avail_n: 0 };
+  m.avail_n++;
+  if (a.status === "ok") m.avail_ok++;
+}
+const modelRows = Object.values(models).sort((a,b)=>b.n-a.n);
+
+// ── per-(model,severity) calibration flags ──
+const calibMap = {};
+for (const f of findings) {
+  const k = f.model + " " + (f.severity || "?");
+  const c = calibMap[k] = calibMap[k] || { model: f.model, severity: f.severity || "?", n: 0, disproved: 0 };
+  c.n++;
+  if (f.verdict === "disproved") c.disproved++;
+}
+const calibration = Object.values(calibMap)
+  .filter(c => c.n >= MIN_CITE && c.disproved / c.n >= 0.8)
+  .sort((a,b)=>b.disproved-a.disproved);
+
+// ── disproved clusters by (model, path bucket) ──
+const bucketOf = (file) => {
+  const base = (file || "").split("/").pop() || "";
+  if (/^test-|[-_.]test\./.test(base)) return "test-fixture";
+  const segs = (file || "").split("/");
+  return segs.slice(0, Math.min(2, Math.max(1, segs.length - 1))).join("/") || "(root)";
+};
+const clusterMap = {};
+for (const f of findings) {
+  if (f.verdict !== "disproved") continue;
+  const k = f.model + " " + bucketOf(f.file);
+  const c = clusterMap[k] = clusterMap[k] || { model: f.model, bucket: bucketOf(f.file), n: 0, citations: [] };
+  c.n++;
+  c.citations.push({ ts: f.ts, head: f.head, id: f.finding_id, file: f.file, line: f.line });
+}
+const clusters = Object.values(clusterMap).filter(c => c.n >= MIN_CITE).sort((a,b)=>b.n-a.n);
+
+// ── re-litigation: round-marker finding_ids (…-r2-…, -r10-…) ──
+const relitMap = {};
+for (const f of findings) {
+  if (!/-r(?:[2-9]|[1-9][0-9]+)-/.test(f.finding_id || "")) continue;
+  const m = relitMap[f.model] = relitMap[f.model] || { model: f.model, n: 0, disproved: 0, citations: [] };
+  m.n++;
+  if (f.verdict === "disproved") m.disproved++;
+  m.citations.push({ ts: f.ts, head: f.head, id: f.finding_id, file: f.file, line: f.line, verdict: f.verdict });
+}
+const relitigation = Object.values(relitMap).sort((a,b)=>b.n-a.n);
+
+const out = { models: modelRows, calibration, clusters, relitigation };
+if (JSON_OUT) { console.log(JSON.stringify(out, null, 2)); process.exit(0); }
+
+const pct = (a,b) => b ? Math.round(100*a/b) + "%" : "-";
+console.log("== per-model verdicts ==");
+for (const m of modelRows) {
+  console.log(`${m.model}: n=${m.n} agreed=${m.agreed} (${pct(m.agreed,m.n)}) disproved=${m.disproved} (${pct(m.disproved,m.n)}) conflict=${m.conflict} unaddressed=${m.unaddressed} avail=${m.avail_ok}/${m.avail_n} ok`);
+}
+console.log("");
+console.log("== severity calibration flags (n>=" + MIN_CITE + ", disproved>=80%) ==");
+if (!calibration.length) console.log("(none)");
+for (const c of calibration) {
+  console.log(`${c.model} ${c.severity}: ${c.disproved}/${c.n} disproved (${pct(c.disproved,c.n)})`);
+}
+console.log("");
+console.log("== disproved clusters (n>=" + MIN_CITE + ") ==");
+if (!clusters.length) console.log("(none)");
+for (const c of clusters) {
+  console.log(`${c.model} ${c.bucket}: ${c.n} disproved`);
+  for (const t of c.citations) console.log(`  - ${t.ts} ${t.head} ${t.id} ${t.file}:${t.line}`);
+}
+console.log("");
+console.log("== re-litigation signals (finding_id round markers -rN-) ==");
+if (!relitigation.length) console.log("(none)");
+for (const r of relitigation) {
+  console.log(`${r.model}: ${r.n} round-marker findings, ${r.disproved} disproved`);
+  for (const t of r.citations) console.log(`  - ${t.ts} ${t.head} ${t.id} ${t.file}:${t.line} ${t.verdict}`);
+}
+'

--- a/scripts/cr/critics.json
+++ b/scripts/cr/critics.json
@@ -1,8 +1,8 @@
 {
   "_compliance": "panel/router lanes must terminate per-token keys only; the Z.ai Coding-Plan subscription (and any subscription lane) is launcher-only (ToS restricts it to officially supported tools) — never behind a panel or router.",
   "panel": [
-    { "slug": "qwenor",     "model": "qwen/qwen3-next-80b-a3b-instruct:free", "provider": "openrouter", "route_provider": "openrouter", "tier": "free",
-      "fallback_models": ["qwen/qwen3-coder:free", "openai/gpt-oss-120b:free", "openai/gpt-oss-20b:free"],
+    { "slug": "lagunaor",  "model": "poolside/laguna-xs-2.1:free", "provider": "openrouter", "route_provider": "openrouter", "tier": "free",
+      "fallback_models": ["cohere/north-mini-code:free", "tencent/hy3:free"],
       "fallback_trigger": "any",
       "fallback_provider": "openrouter" },
     { "slug": "codex",      "model": "gpt-5.5",                             "provider": "openai-codex", "tier": "paid" }

--- a/scripts/cr/test-cr-tune.sh
+++ b/scripts/cr/test-cr-tune.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015  # A && B || C intentional in check() and final assert
+# Test harness for cr-tune.sh (HIMMEL-978)
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"; SCRIPT="$HERE/cr-tune.sh"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+fails=0
+
+check() { [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+contains() { echo "$2" | grep -qF "$3" && echo "ok - $1" || { echo "FAIL - $1: output does not contain [$3]"; fails=$((fails+1)); }; }
+not_contains() { echo "$2" | grep -qF "$3" && { echo "FAIL - $1: output must NOT contain [$3]"; fails=$((fails+1)); } || echo "ok - $1"; }
+
+# ---------------------------------------------------------------------------
+# Fixture: Task-1 test data as specified in the brief
+# ---------------------------------------------------------------------------
+{
+  echo '{"kind":"finding","ts":"2026-07-01T10:00:00Z","branch":"b1","head":"aaaa111","model":"modelA","finding_id":"modelA-1","severity":"imp","file":"scripts/foo.sh","line":10,"verdict":"agreed"}'
+  echo '{"kind":"finding","ts":"2026-07-01T10:01:00Z","branch":"b1","head":"aaaa111","model":"modelA","finding_id":"modelA-2","severity":"imp","file":"scripts/foo.sh","line":20,"verdict":"agreed"}'
+  echo '{"kind":"finding","ts":"2026-07-01T10:02:00Z","branch":"b1","head":"aaaa111","model":"modelA","finding_id":"modelA-3","severity":"crit","file":"scripts/bar.sh","line":5,"verdict":"disproved"}'
+  echo '{"kind":"finding","ts":"2026-07-02T10:00:00Z","branch":"b2","head":"bbbb222","model":"modelB","finding_id":"modelB-1","severity":"crit","file":"scripts/test-foo.sh","line":1,"verdict":"disproved"}'
+  echo '{"kind":"finding","ts":"2026-07-02T10:01:00Z","branch":"b2","head":"bbbb222","model":"modelB","finding_id":"modelB-2","severity":"crit","file":"scripts/test-bar.sh","line":2,"verdict":"disproved"}'
+  echo '{"kind":"finding","ts":"2026-07-02T10:02:00Z","branch":"b2","head":"bbbb222","model":"modelB","finding_id":"modelB-3","severity":"crit","file":"scripts/test-baz.sh","line":3,"verdict":"disproved"}'
+  echo '{"kind":"finding","ts":"2026-07-03T10:00:00Z","branch":"b3","head":"cccc333","model":"modelB","finding_id":"modelB-r2-1","severity":"imp","file":"scripts/check-ci.sh","line":9,"verdict":"disproved"}'
+  echo '{"kind":"finding","ts":"2026-07-03T10:01:00Z","branch":"b3","head":"cccc333","model":"modelA","finding_id":"modelA-4","severity":"sug","file":"docs/x.md","line":1,"verdict":"unaddressed"}'
+  echo '{"kind":"avail","ts":"2026-07-01T10:00:00Z","branch":"b1","head":"aaaa111","model":"modelA","status":"ok"}'
+  echo '{"kind":"avail","ts":"2026-07-02T10:00:00Z","branch":"b2","head":"bbbb222","model":"modelA","status":"unavailable"}'
+  echo '{"kind":"avail","ts":"2026-07-02T10:00:01Z","branch":"b2","head":"bbbb222","model":"modelB","status":"ok"}'
+  echo '{"kind":"finding","ts":"2026-07-01T10:03:00Z","branch":"b1","head":"aaaa111","model":"modelC","finding_id":"modelC-1","severity":"imp","file":"scripts/qux.sh","line":7,"verdict":"n"}'
+  echo '{"kind":"finding","ts":"2026-07-01T10:04:00Z","branch":"b1","head":"aaaa111","model":"modelC","finding_id":"modelC-r10-1","severity":"imp","file":"scripts/qux.sh","line":8,"verdict":"agreed"}'
+  echo '{"kind":"usage","ts":"2026-07-01T10:00:00Z","model":"modelA","est_tokens":123}'
+  echo 'not-json-garbage-line'
+} > "$tmp/ledger.jsonl"
+
+# ── Run the script and capture output ──────────────────────────────────────
+out="$(CR_LEDGER="$tmp/ledger.jsonl" bash "$SCRIPT" 2>&1)"
+rc=$?
+
+# ── Task-1 Assertions ─────────────────────────────────────────────────────
+# 1. modelA row: n=4, agreed=2, disproved=1, unaddressed=1, avail 1/2 ok
+contains "modelA row present" "$out" "modelA"
+contains "modelA n=4" "$out" "modelA: n=4"
+contains "modelA agreed=2" "$out" "agreed=2"
+contains "modelA disproved=1" "$out" "disproved=1"
+contains "modelA unaddressed=1" "$out" "unaddressed=1"
+contains "modelA avail 1/2" "$out" "avail=1/2"
+
+# 2. modelB row: n=4, disproved=4 (100%)
+contains "modelB row present" "$out" "modelB"
+contains "modelB n=4" "$out" "modelB: n=4"
+contains "modelB disproved=4" "$out" "disproved=4"
+contains "modelB disproved 100%" "$out" "disproved=4 (100%)"
+
+# 3. severity-calibration section flags modelB crit as 3/3 disproved (100%)
+#    (the flag threshold is: n>=3 AND disproved >=80%)
+contains "severity calibration section present" "$out" "== severity calibration flags"
+contains "modelB crit flag present" "$out" "modelB crit:"
+contains "modelB crit 3/3 disproved" "$out" "3/3 disproved (100%)"
+
+# 4. severity-calibration section does NOT flag modelA
+#    (modelA crit n=1, below n>=3 threshold)
+not_contains "modelA crit not flagged" "$out" "modelA crit:"
+
+# 5. Malformed line + usage rows ignored without error (rc=0)
+check "exit code 0" "$rc" "0"
+
+# ── Task-2 Assertions ─────────────────────────────────────────────────────
+# 6. clusters section: modelB test-fixture cluster n=3, with the three citations
+contains "clusters section present" "$out" "== disproved clusters"
+contains "modelB test-fixture cluster n=3" "$out" "modelB test-fixture: 3 disproved"
+contains "modelB test-fixture citation test-foo.sh:1" "$out" "scripts/test-foo.sh:1"
+contains "modelB test-fixture citation test-bar.sh:2" "$out" "scripts/test-bar.sh:2"
+contains "modelB test-fixture citation test-baz.sh:3" "$out" "scripts/test-baz.sh:3"
+
+# 7. clusters section does NOT contain a modelA cluster (only 1 disproved row — below MIN_CITE)
+not_contains "modelA cluster not present (below MIN_CITE)" "$out" "modelA scripts:"
+
+# 8. re-litigation section: modelB with 1 round-marker finding (modelB-r2-1), disproved
+contains "re-litigation section present" "$out" "== re-litigation signals"
+contains "modelB re-litigation 1 round-marker, 1 disproved" "$out" "modelB: 1 round-marker findings, 1 disproved"
+contains "modelB re-litigation citation modelB-r2-1" "$out" "modelB-r2-1"
+
+# 9. --min-cite 1: modelA's single disproved row now appears as a modelA scripts cluster
+out_mincite1="$(CR_LEDGER="$tmp/ledger.jsonl" bash "$SCRIPT" --min-cite 1 2>&1)"
+contains "--min-cite 1: modelA scripts cluster n=1" "$out_mincite1" "modelA scripts: 1 disproved"
+
+# 10. --json completeness: all four arrays populated
+CR_LEDGER="$tmp/ledger.jsonl" bash "$SCRIPT" --json | node -e 'const j=JSON.parse(require("fs").readFileSync(0,"utf8")); if(!(j.models.length&&j.calibration.length&&j.clusters.length&&j.relitigation.length)) process.exit(1)'
+rc_json=$?
+check "--json completeness (all four arrays populated)" "$rc_json" "0"
+
+# 11. empty ledger: message + rc=0
+: > "$tmp/empty.jsonl"
+out_empty="$(CR_LEDGER="$tmp/empty.jsonl" bash "$SCRIPT" 2>&1)"
+rc_empty=$?
+contains "empty ledger message" "$out_empty" "no critic scores recorded yet"
+check "empty ledger rc=0" "$rc_empty" "0"
+
+# 12. usage errors: --bogus rc=2, --window (missing arg) rc=2
+CR_LEDGER="$tmp/ledger.jsonl" bash "$SCRIPT" --bogus >/dev/null 2>&1
+rc_bogus=$?
+check "--bogus rc=2" "$rc_bogus" "2"
+
+CR_LEDGER="$tmp/ledger.jsonl" bash "$SCRIPT" --window >/dev/null 2>&1
+rc_window_missing=$?
+check "--window (missing arg) rc=2" "$rc_window_missing" "2"
+
+# 13. --window 1 on the fixture: only head cccc333 rows counted (modelA n=1, modelB n=1)
+out_window1="$(CR_LEDGER="$tmp/ledger.jsonl" bash "$SCRIPT" --window 1 2>&1)"
+contains "--window 1: modelA n=1" "$out_window1" "modelA: n=1"
+contains "--window 1: modelB n=1" "$out_window1" "modelB: n=1"
+
+# ── Task-2 hardening assertions (coderabbit round 1) ──────────────────────
+# 14. verdict whitelist: modelC's verdict:"n" row counts in n= totals but must
+#     not mutate any accumulator field (unguarded m[f.verdict]++ would bump n twice)
+contains "verdict whitelist: bogus verdict counts in n only" "$out" "modelC: n=2 agreed=1 (50%) disproved=0 (0%) conflict=0 unaddressed=0"
+
+# 15. round-marker regex detects -r10- (two-digit rounds)
+contains "-r10- round marker detected" "$out" "modelC: 1 round-marker findings, 0 disproved"
+contains "-r10- citation present" "$out" "modelC-r10-1"
+
+# 16. numeric arg validation: --window abc rc=2, --min-cite -1 rc=2
+CR_LEDGER="$tmp/ledger.jsonl" bash "$SCRIPT" --window abc >/dev/null 2>&1
+rc_window_abc=$?
+check "--window abc rc=2" "$rc_window_abc" "2"
+
+CR_LEDGER="$tmp/ledger.jsonl" bash "$SCRIPT" --min-cite -1 >/dev/null 2>&1
+rc_mincite_neg=$?
+check "--min-cite -1 rc=2" "$rc_mincite_neg" "2"
+
+# ── END ─────────────────────────────────────────────────────────────────────
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
## Summary
Public propagation of /cr-tune — the CR-ledger self-evolution miner (citation-backed tuning proposals, never auto-applied), its hermetic test suite, the runbook command, and the free-critic probation swap (single squash of the private change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/cr-tune` to analyze code review feedback and generate citation-backed tuning proposals.
  * Added filtering and JSON output options for tuning-signal reports.
  * Added detection of calibration issues, repeated findings, and disproved review clusters.
  * Updated the available review critic configuration.

* **Documentation**
  * Documented the new `/cr-tune` command and proposal-only workflow.

* **Tests**
  * Added coverage for report generation, validation, empty data, JSON output, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->