### PR TITLE
fix(handover): T25 lost-update root cause — noclobber arbiter (both mutex twins) + test-adopt hermetic ln

### DIFF
--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -1609,15 +1609,18 @@ _arm_registry_mutex_acquire() {
     _lockd="$_reg.lock"
     while :; do
         if mkdir "$_lockd" 2>/dev/null; then
-            # Brand the lock (see queue-lock.sh's twin for the rationale).
+            # Brand the lock (see queue-lock.sh's twin for the full uutils
+            # rationale, HIMMEL-966): mkdir is NOT a reliable mutex primitive
+            # on uutils coreutils (concurrent mkdir can BOTH return rc=0), so
+            # the OWNER create via set -C (noclobber) -- a single kernel
+            # open(O_CREAT|O_EXCL) by bash itself -- is the real arbiter.
+            # A losing co-winner leaves the winner's lock alone and falls
+            # through to the spin/reclaim path.
             _tok="pid$$-r$RANDOM"
-            if ! printf '%s' "$_tok" > "$_lockd/owner" 2>/dev/null; then
-                rm -f "$_lockd/owner" 2>/dev/null
-                rmdir "$_lockd" 2>/dev/null
-                return 1
+            if ( set -C; printf '%s' "$_tok" > "$_lockd/owner" ) 2>/dev/null; then
+                _ARM_REGISTRY_MUTEX_TOKEN="$_tok"
+                return 0
             fi
-            _ARM_REGISTRY_MUTEX_TOKEN="$_tok"
-            return 0
         fi
         if [ $(( _tries % 10 )) -eq 0 ]; then
             _m=$(py_armor_mtime "$_lockd") || _m=""

--- a/scripts/handover/queue-lock.sh
+++ b/scripts/handover/queue-lock.sh
@@ -408,17 +408,29 @@ _ql_arms_mutex_acquire() {
     while :; do
         if mkdir "$lockd" 2>/dev/null; then
             # Brand the lock. pid alone is unique among LIVE processes;
-            # $RANDOM guards the recycled-pid edge. A failed brand write is
-            # a failed acquire (fail-open) -- an unbranded lock would make
-            # every release read as a theft.
+            # $RANDOM guards the recycled-pid edge.
+            #
+            # mkdir is NOT a reliable mutual-exclusion primitive on every
+            # platform: uutils coreutils 0.8.0 (the Rust coreutils shipped on
+            # some Windows/WSL apt boxes) resolves two CONCURRENT mkdir of the
+            # same path to BOTH rc=0 -- a non-atomic check-then-create that
+            # breaks the mkdir(2) EEXIST guarantee this lock relied on
+            # (HIMMEL-966; measured ~96% double-win on ext4, so two writers
+            # entered the arms-registry critical section at once and one
+            # consume was lost). So the OWNER create, not the mkdir, is the
+            # real arbiter: set -C (noclobber) makes it a single kernel
+            # open(O_CREAT|O_EXCL) -- performed by bash itself, no coreutils
+            # binary -- atomic on every POSIX fs. Exactly one co-winner of a
+            # double-won mkdir wins this create; the losers leave the winner's
+            # lock alone and fall through to the spin/reclaim path.
             tok="pid$$-r$RANDOM"
-            if ! printf '%s' "$tok" > "$lockd/owner" 2>/dev/null; then
-                rm -f "$lockd/owner" 2>/dev/null
-                rmdir "$lockd" 2>/dev/null
-                return 1
+            if ( set -C; printf '%s' "$tok" > "$lockd/owner" ) 2>/dev/null; then
+                _QL_ARMS_MUTEX_TOKEN="$tok"
+                return 0
             fi
-            _QL_ARMS_MUTEX_TOKEN="$tok"
-            return 0
+            # Lost the O_EXCL owner create to a co-winner that branded first
+            # -- it is the true holder; do NOT tear down its lock. Fall
+            # through and retry (spin, or reclaim if it later goes stale).
         fi
         if [ $(( tries % 10 )) -eq 0 ]; then
             m=$(py_armor_mtime "$lockd") || m=""

--- a/scripts/test-adopt.sh
+++ b/scripts/test-adopt.sh
@@ -79,7 +79,7 @@ chmod +x "$work/bin/claude"
 # shellcheck disable=SC1091
 . "$repo_root/scripts/lib/hermetic-path.sh"
 
-for _tool in bash git jq python3 grep sed cat cp mv rm mkdir chmod diff wc tr head tail basename dirname mktemp sort cut; do
+for _tool in bash git jq python3 grep sed cat cp mv rm ln mkdir chmod diff wc tr head tail basename dirname mktemp sort cut; do
   link_hermetic_tool "$_tool"
 done
 


### PR DESCRIPTION
## Summary
Public propagation of the T25 lost-update root-cause fix — non-atomic mkdir (uutils coreutils 0.8.0) replaced with a noclobber O_EXCL owner-file arbiter on both mutex writer paths; test-adopt gets a hermetic ln (single squash of the private change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock handling to prevent concurrent processes from incorrectly claiming the same lock.
  * Increased reliability of mutex acquisition and retry behavior across supported environments.
  * Updated hermetic test setup to use the intended set and ordering of command-line tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->