### PR TITLE
docs(setup): tokensave + graphify MCP onboarding for new users

### DIFF
--- a/.claude/mcp-profiles/README.md
+++ b/.claude/mcp-profiles/README.md
@@ -27,6 +27,11 @@ gitignored** — they carry your `OBSIDIAN_API_KEY` and `C:\Users\…` paths, wh
 must never hit git. Only the generator + `profiles.json` manifest + this README
 are committed.
 
+Every profile includes **tokensave** (the T0 always-on server) — if the
+generator exits with `unresolved server "tokensave"`, it isn't registered on
+this machine yet. Install + register it first:
+[`docs/setup/new-machine.md` §8](../../docs/setup/new-machine.md#8-mcp-servers).
+
 ## Launch a lean session
 
 ```powershell

--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -842,6 +842,89 @@ For per-repo opt-out, env-var disable, dry-run mode, and full operational refere
 
 ## 8. MCP Servers
 
+### tokensave — recommended for every adopter (T0 always-on)
+
+tokensave is the code-graph MCP server the harness leans on for
+symbol-level code exploration — it is the **T0 always-on** tier in the
+MCP fleet map ([`docs/tooling-catalog.md`](../tooling-catalog.md)) and is
+included in **every** lean launch profile
+(`.claude/mcp-profiles/profiles.json`). Without it, profile launches and
+the CLAUDE.md retrieval routing (qmd → graphify → tokensave) silently
+degrade — the server just never comes up.
+
+Install the binary (pick one):
+
+```powershell
+# Windows
+scoop bucket add tokensave https://github.com/aovestdipaperino/scoop-bucket
+scoop install tokensave
+```
+
+```bash
+# macOS
+brew install aovestdipaperino/tap/tokensave
+# any platform (Rust)
+cargo install tokensave
+```
+
+(Prebuilt binaries for macOS/Linux/Windows are also on the
+[GitHub releases page](https://github.com/aovestdipaperino/tokensave/releases).)
+
+Register it with Claude Code (writes the MCP server entry into your
+global config):
+
+```bash
+tokensave install --agent claude
+```
+
+Then initialize the knowledge graph **per project** (opt-in by design —
+`sync` only updates projects already initialized):
+
+```bash
+cd /path/to/repo
+tokensave init     # first time — creates .tokensave/ with the graph DB
+tokensave sync     # afterwards — refresh the graph
+```
+
+Verify: run `tokensave doctor` (checks installation, configuration, and
+agent integration), then start a fresh Claude Code session in the repo and
+confirm the `tokensave` MCP server is connected (`claude mcp list`).
+
+### graphify — optional knowledge-graph CLI + MCP server (HIMMEL-621/891)
+
+graphify powers the structure/architecture leg of the retrieval routing
+(qmd finds content, **graphify explains structure**, tokensave serves
+code — `CLAUDE.md`). Opt-in — install via setup:
+
+```bash
+bash scripts/setup.sh --with-graphify
+```
+
+(Installs the himmel fork via `uv tool install` at a pinned commit SHA;
+an existing foreign graphify install is adopted as-is, never reinstalled —
+see `scripts/lib/graphify-bin.sh`.)
+
+The install exposes two binaries: `graphify` (the CLI) and `graphify-mcp`
+(the MCP server). Register the server with Claude Code — use the absolute
+path, not the bare name (`/himmel-doctor` flags PATH-fragile
+bare-interpreter MCP entries). `uv tool install` places entry points in
+the directory `uv tool dir --bin` reports (usually `~/.local/bin` on
+Linux/macOS; on Windows the executable is copied there as
+`graphify-mcp.exe`) — derive the path rather than hard-coding it:
+
+```bash
+claude mcp add --scope user graphify -- "$(uv tool dir --bin)/graphify-mcp"
+```
+
+(PowerShell:
+`claude mcp add --scope user graphify -- "$(uv tool dir --bin)\graphify-mcp.exe"`.)
+
+Graph refresh stays lean-invoke (`graphify <corpus-copy> --update`), never
+a hook; extraction backends are governed by the egress matrix — see the
+graphify section in `CLAUDE.md`.
+
+### Optional integrations
+
 > **Skip** if you don't use the Luna vault or Atlassian (Jira/Confluence). Both entries here are optional integrations.
 
 Configure in Claude Code settings (`~/.claude/settings.json`):
@@ -915,6 +998,14 @@ state outside the bridge root.
 - [ ] Worktree round-trip: `/worktree test/smoke` creates a worktree; `/clean` removes it after merging
 
 ### OPTIONAL — per integration
+
+**tokensave (recommended):**
+- [ ] `tokensave --version` works
+- [ ] `tokensave doctor` passes
+- [ ] `.tokensave/` exists in the repo (`tokensave init` ran) and a fresh session lists the `tokensave` MCP server as connected
+
+**graphify:**
+- [ ] `graphify --version` works and a fresh session lists the `graphify` MCP server as connected
 
 **Jira / HIMMEL project:**
 - [ ] `node scripts/jira/dist/index.js list` returns HIMMEL issues

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -629,6 +629,15 @@ Specs saved to: `docs/superpowers/specs/YYYY-MM-DD-feature.md`
 
 ---
 
+## tokensave (MCP server)
+
+**What:** Code-graph MCP server (single Rust binary) — indexes a repo into a symbol-level knowledge graph (per-project `.tokensave/` sqlite DB) and serves exploration + analysis tools over it. The harness's designated organ for symbol-level code ops in the retrieval routing (qmd finds content, graphify explains structure, **tokensave serves code** — CLAUDE.md, HIMMEL-621).
+**MCP tools:** `tokensave_context` (natural-language exploration — first call for any code question), `tokensave_search`, `tokensave_callers` / `tokensave_callees`, `tokensave_impact`, plus a wide discovery/analysis/edit surface.
+**Install + register:** binary via scoop (Windows) / brew (macOS) / `cargo install tokensave`, then `tokensave install --agent claude`; per-repo `tokensave init` once, `tokensave sync` to refresh. Full steps: [`docs/setup/new-machine.md` §8](setup/new-machine.md#8-mcp-servers).
+**Tier:** T0 always-on — the one server included in *every* lean profile (`.claude/mcp-profiles/profiles.json`).
+
+---
+
 ## MCP fleet — tiered lean profiles (`scripts/mcp/build-mcp-profiles.mjs`, HIMMEL-719)
 
 **What:** Every session spawns the full MCP fleet at startup (per-session, not


### PR DESCRIPTION
## Summary
Public propagation of the tokensave + graphify MCP onboarding guide for new users (docs-only single squash of the private change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added setup guidance for the recommended `tokensave` integration, including installation, registration, project initialization, synchronization, and verification.
  - Documented optional `graphify` integration, including installation, MCP registration, refresh behavior, and verification steps.
  - Added `tokensave` to the tooling catalog as a T0 always-on code-graph MCP server.
  - Clarified that generated profiles require `tokensave` to be available on each machine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->