### PR TITLE
docs(setup): correct tokensave failure-mode — generator fails loudly, only routing degrades silently

### DIFF
--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -848,9 +848,11 @@ tokensave is the code-graph MCP server the harness leans on for
 symbol-level code exploration — it is the **T0 always-on** tier in the
 MCP fleet map ([`docs/tooling-catalog.md`](../tooling-catalog.md)) and is
 included in **every** lean launch profile
-(`.claude/mcp-profiles/profiles.json`). Without it, profile launches and
-the CLAUDE.md retrieval routing (qmd → graphify → tokensave) silently
-degrade — the server just never comes up.
+(`.claude/mcp-profiles/profiles.json`). Without it, profile generation
+fails loudly — the generator exits with `unresolved server "tokensave"`
+until the server is registered — and the CLAUDE.md retrieval routing
+(qmd → graphify → tokensave) silently degrades: the server just never
+comes up.
 
 Install the binary (pick one):
 


### PR DESCRIPTION
## Summary
Follow-up promised on #417: corrects the tokensave failure-mode sentence — the profiles generator fails loudly ('unresolved server "tokensave"'), only the retrieval routing degrades silently (docs-only single squash of the private change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified setup guidance for the tokensave recommendation.
  * Documented that missing configuration causes profile generation to fail and prevents CLAUDE.md retrieval routing from functioning correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->