### PR TITLE
fix(ci): zombie CodeRabbit check-run override — success status + clean threads unblocks the merge gate

### DIFF
--- a/scripts/check-ci.sh
+++ b/scripts/check-ci.sh
@@ -44,6 +44,8 @@
 #   CHECK_CI_POLL_INTERVAL — seconds between grace-window probes (default 10;
 #                            tests set 0; non-numeric falls back to default)
 #   CHECK_CI_SETTLE        — default for --settle (flag wins)
+#   CR_ZOMBIE_CHECKRUN_MINS — minimum CodeRabbit in-progress age for the
+#                             success-status + clean-threads override (default 90)
 #
 # Un-maskable verdict (HIMMEL-974): every exit path additionally prints
 # "check-ci: verdict exit=N" to STDOUT via an EXIT trap installed after arg
@@ -114,6 +116,11 @@ pr_checks() {
 
 pr_view() {
     if [ -n "$selector" ]; then gh pr view "$selector" "$@"; else gh pr view "$@"; fi
+}
+
+started_epoch() {
+    date -u -d "$1" +%s 2>/dev/null && return 0
+    date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "$1" +%s 2>/dev/null
 }
 
 red_exit() {
@@ -206,15 +213,6 @@ if [ "$THREADS_ONLY" -eq 0 ]; then
         exit 2
     fi
 
-    # Watch round 1: authoritative red/green for the checks registered so far.
-    watch_round
-
-    # Settle round (codex-adv-1): give slow-registering check runs time to appear,
-    # then watch again — round 2 waits for (or fails fast on) any late arrivals.
-    if [ "$SETTLE" -gt 0 ]; then
-        sleep "$SETTLE"
-        watch_round
-    fi
 fi
 
 # Thread gate: checks green is not merge-safe while PR review comments sit
@@ -229,87 +227,180 @@ ctx="checks green but "
 # failed call can never silently read as "no decision".
 pr_json=$(pr_view --json url,reviewDecision --jq '"\(.url)|\(.reviewDecision)"' 2>/dev/null)
 pr_url=${pr_json%%|*}
-review_decision=${pr_json##*|}
 case "$pr_url" in
     https://github.com/*/pull/*) ;;
     *)
         echo "check-ci: ${ctx}cannot resolve the PR (gh pr view gave '${pr_url:-nothing}') — re-run, or verify with gh pr view" >&2
         exit 2 ;;
 esac
-
-# An explicit CHANGES_REQUESTED review is a merge blocker. Approval is NOT
-# required — single-operator repos carry no GitHub approval objects (the CR
-# flow is the approval gate); only the affirmative "do not merge" signal blocks.
-if [ "$review_decision" = "CHANGES_REQUESTED" ]; then
-    echo "check-ci: ${ctx}a review requests changes on this PR — address it (and resolve its threads), then re-run" >&2
-    exit 3
-fi
 num=${pr_url##*/}
 nwo=${pr_url#https://github.com/}
 owner=${nwo%%/*}
 repo_rest=${nwo#*/}
 repo=${repo_rest%%/*}
 
-# Paginate: first:100 alone would let unresolved threads beyond page one slip
-# through the gate. Each page reports "<unresolved-count> <hasNextPage> <endCursor>".
-unresolved=0
-cursor=""
-pages=0
-while :; do
-    # Hard page cap: bounds EVERY malformed-pagination shape (incl. non-adjacent
-    # cursor cycles like A→B→A that a last-cursor comparison can't see) at
-    # 50 pages = 5000 threads — far beyond any real PR. Fail closed past it.
-    pages=$((pages + 1))
-    if [ "$pages" -gt 50 ]; then
-        echo "check-ci: ${ctx}the review-thread query did not terminate within 50 pages (cursor cycle?) — check threads manually on PR #$num" >&2
-        exit 2
-    fi
-    # Positional args are free after option parsing — reuse them for the
-    # conditional cursor without an unquoted expansion.
-    sent_cursor="$cursor"
-    set -- -f o="$owner" -f r="$repo" -F n="$num"
-    [ -n "$cursor" ] && set -- "$@" -f c="$cursor"
-    # shellcheck disable=SC2016  # $o/$r/$n/$c are GraphQL variables — literal on purpose
-    page=$(gh api graphql \
-        -f query='query($o:String!,$r:String!,$n:Int!,$c:String){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100,after:$c){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}' \
-        "$@" \
-        --jq '.data.repository.pullRequest.reviewThreads | "\([.nodes[] | select(.isResolved | not)] | length) \(.pageInfo.hasNextPage) \(.pageInfo.endCursor)"' 2>/dev/null)
-    page_count=${page%% *}
-    rest=${page#* }
-    has_next=${rest%% *}
-    cursor=${rest#* }
-    case "$page_count" in
-        ''|*[!0-9]*)
-            echo "check-ci: ${ctx}the review-thread query failed — re-run, or check threads manually on PR #$num" >&2
-            exit 2 ;;
-    esac
-    case "$has_next" in
-        true|false) ;;
+# review_state_gate — the CHANGES_REQUESTED blocker + the paginated
+# unresolved-thread gate, as one re-runnable unit. It runs BEFORE the zombie
+# probe (fail-fast, and the override's zero-unresolved evidence) and AGAIN
+# after the final watch/settle on every success path (codex-adv 980-r2):
+# review state can change during a long watch WITHOUT moving the head SHA —
+# a pre-watch snapshot must never be what gets certified.
+review_state_gate() {
+    local decision unresolved cursor pages sent_cursor page page_count rest has_next
+    # Fresh reviewDecision each call (the module-top pr_json copy would be a
+    # stale snapshot by the post-watch call). An explicit CHANGES_REQUESTED
+    # review is a merge blocker. Approval is NOT required — single-operator
+    # repos carry no GitHub approval objects (the CR flow is the approval
+    # gate); only the affirmative "do not merge" signal blocks.
+    # Fail CLOSED on a failed/malformed refresh (coderabbit 980-r3): an empty
+    # snapshot would otherwise skip the CHANGES_REQUESTED check silently.
+    decision=$(pr_view --json url,reviewDecision --jq '"\(.url)|\(.reviewDecision)"' 2>/dev/null)
+    case "$decision" in
+        https://github.com/*/pull/*"|"*) decision=${decision##*|} ;;
         *)
-            echo "check-ci: ${ctx}the review-thread query returned a malformed page (hasNextPage='$has_next') — re-run, or check threads manually on PR #$num" >&2
+            echo "check-ci: ${ctx}could not refresh the PR review decision (gh pr view gave '${decision:-nothing}') — re-run" >&2
             exit 2 ;;
     esac
-    if [ "$has_next" = "true" ] && { [ -z "$cursor" ] || [ "$cursor" = "null" ]; }; then
-        echo "check-ci: ${ctx}the review-thread query returned a malformed page (hasNextPage=true with no cursor) — re-run, or check threads manually on PR #$num" >&2
-        exit 2
+    if [ "$decision" = "CHANGES_REQUESTED" ]; then
+        echo "check-ci: ${ctx}a review requests changes on this PR — address it (and resolve its threads), then re-run" >&2
+        exit 3
     fi
-    # A repeated cursor with hasNextPage=true would loop forever — fail closed.
-    if [ "$has_next" = "true" ] && [ "$cursor" = "$sent_cursor" ]; then
-        echo "check-ci: ${ctx}the review-thread query returned a malformed page (cursor did not advance) — re-run, or check threads manually on PR #$num" >&2
-        exit 2
+
+    # Paginate: first:100 alone would let unresolved threads beyond page one slip
+    # through the gate. Each page reports "<unresolved-count> <hasNextPage> <endCursor>".
+    unresolved=0
+    cursor=""
+    pages=0
+    while :; do
+        # Hard page cap: bounds EVERY malformed-pagination shape (incl. non-adjacent
+        # cursor cycles like A→B→A that a last-cursor comparison can't see) at
+        # 50 pages = 5000 threads — far beyond any real PR. Fail closed past it.
+        pages=$((pages + 1))
+        if [ "$pages" -gt 50 ]; then
+            echo "check-ci: ${ctx}the review-thread query did not terminate within 50 pages (cursor cycle?) — check threads manually on PR #$num" >&2
+            exit 2
+        fi
+        # Positional args are free after option parsing — reuse them for the
+        # conditional cursor without an unquoted expansion (function-local $@).
+        sent_cursor="$cursor"
+        set -- -f o="$owner" -f r="$repo" -F n="$num"
+        [ -n "$cursor" ] && set -- "$@" -f c="$cursor"
+        # shellcheck disable=SC2016  # $o/$r/$n/$c are GraphQL variables — literal on purpose
+        page=$(gh api graphql \
+            -f query='query($o:String!,$r:String!,$n:Int!,$c:String){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:100,after:$c){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}' \
+            "$@" \
+            --jq '.data.repository.pullRequest.reviewThreads | "\([.nodes[] | select(.isResolved | not)] | length) \(.pageInfo.hasNextPage) \(.pageInfo.endCursor)"' 2>/dev/null)
+        page_count=${page%% *}
+        rest=${page#* }
+        has_next=${rest%% *}
+        cursor=${rest#* }
+        case "$page_count" in
+            ''|*[!0-9]*)
+                echo "check-ci: ${ctx}the review-thread query failed — re-run, or check threads manually on PR #$num" >&2
+                exit 2 ;;
+        esac
+        case "$has_next" in
+            true|false) ;;
+            *)
+                echo "check-ci: ${ctx}the review-thread query returned a malformed page (hasNextPage='$has_next') — re-run, or check threads manually on PR #$num" >&2
+                exit 2 ;;
+        esac
+        if [ "$has_next" = "true" ] && { [ -z "$cursor" ] || [ "$cursor" = "null" ]; }; then
+            echo "check-ci: ${ctx}the review-thread query returned a malformed page (hasNextPage=true with no cursor) — re-run, or check threads manually on PR #$num" >&2
+            exit 2
+        fi
+        # A repeated cursor with hasNextPage=true would loop forever — fail closed.
+        if [ "$has_next" = "true" ] && [ "$cursor" = "$sent_cursor" ]; then
+            echo "check-ci: ${ctx}the review-thread query returned a malformed page (cursor did not advance) — re-run, or check threads manually on PR #$num" >&2
+            exit 2
+        fi
+        unresolved=$((unresolved + page_count))
+        [ "$has_next" = "true" ] || break
+    done
+    if [ "$unresolved" -gt 0 ]; then
+        echo "check-ci: ${ctx}$unresolved unresolved review thread(s) on PR #$num — address each comment, resolve its thread, re-run" >&2
+        exit 3
     fi
-    unresolved=$((unresolved + page_count))
-    [ "$has_next" = "true" ] || break
-done
-if [ "$unresolved" -gt 0 ]; then
-    echo "check-ci: ${ctx}$unresolved unresolved review thread(s) on PR #$num — address each comment, resolve its thread, re-run" >&2
-    exit 3
+}
+
+review_state_gate
+
+zombie_override=0
+if [ "$THREADS_ONLY" -eq 0 ]; then
+    zombie_mins="${CR_ZOMBIE_CHECKRUN_MINS:-90}"
+    case "$zombie_mins" in ''|*[!0-9]*) zombie_mins=90 ;; esac
+    # 10# guard (coderabbit 980-r4): a leading-zero value ("090") passes
+    # the digit check but blows up base-8 arithmetic in $((… * 60)).
+    zombie_mins=$((10#$zombie_mins))
+    runs=$(gh api "repos/$owner/$repo/commits/$head0/check-runs?per_page=100" 2>/dev/null) || runs=""
+    pending_runs=$(printf '%s' "$runs" | jq -r \
+        '[.check_runs[]? | select(.name=="CodeRabbit") | select(.status!="completed")] | length' \
+        2>/dev/null || true)
+    started=$(printf '%s' "$runs" | jq -r \
+        '[.check_runs[]? | select(.name=="CodeRabbit") | select(.status=="in_progress") | .started_at // empty] | max // empty' \
+        2>/dev/null || true)
+    started_count=$(printf '%s' "$runs" | jq -r \
+        '[.check_runs[]? | select(.name=="CodeRabbit") | select(.status=="in_progress") | select(.started_at != null)] | length' \
+        2>/dev/null || true)
+    run_started=$(started_epoch "$started" 2>/dev/null || true)
+    now_epoch=$(date -u +%s 2>/dev/null || true)
+    if [ -n "$pending_runs" ] && [ "$started_count" = "$pending_runs" ] \
+        && [ "$pending_runs" -gt 0 ] 2>/dev/null \
+        && [ -n "$run_started" ] && [ -n "$now_epoch" ] \
+        && [ $((now_epoch - run_started)) -gt $((zombie_mins * 60)) ]; then
+        statuses=$(gh api "repos/$owner/$repo/commits/$head0/status" 2>/dev/null) || statuses=""
+        status_state=$(printf '%s' "$statuses" | jq -r \
+            '[.statuses[]? | select(.context=="CodeRabbit")][0].state // empty' \
+            2>/dev/null || true)
+        other_pending=$(pr_checks --json name,bucket --jq \
+            '[.[] | select(.name != "CodeRabbit") | select(.bucket != "pass" and .bucket != "skipping")] | length' \
+            2>/dev/null || true)
+        if [ "$status_state" = "success" ] && [ "$other_pending" = "0" ]; then
+            echo "zombie check-run override: CodeRabbit run in_progress since $started (>${zombie_mins}m) but commit status=success + 0 unresolved threads — treating as completed (HIMMEL-980)"
+            zombie_override=1
+        fi
+    fi
 fi
 
 if [ "$THREADS_ONLY" -eq 1 ]; then
     echo "check-ci: all review threads resolved (PR #$num)"
     exit 0
 fi
+
+# The override skips the hanging watch, but it must NOT skip the settle
+# protection (codex-adv-2): a non-CodeRabbit check registering right after the
+# other_pending snapshot would otherwise never be observed. Keep the settle
+# window and re-probe; any late arrival drops the override back to the watch
+# path (which waits for — or fails fast on — the newcomer).
+if [ "$zombie_override" -eq 1 ] && [ "$SETTLE" -gt 0 ]; then
+    sleep "$SETTLE"
+    late_pending=$(pr_checks --json name,bucket --jq \
+        '[.[] | select(.name != "CodeRabbit") | select(.bucket != "pass" and .bucket != "skipping")] | length' \
+        2>/dev/null || true)
+    if [ "$late_pending" != "0" ]; then
+        echo "zombie override dropped: ${late_pending:-?} non-CodeRabbit check(s) pending after the ${SETTLE}s settle window — falling back to the watch path"
+        zombie_override=0
+    fi
+fi
+
+if [ "$zombie_override" -eq 0 ]; then
+    # Watch round 1: authoritative red/green for the checks registered so far.
+    watch_round
+
+    # Settle round (codex-adv-1): give slow-registering check runs time to appear,
+    # then watch again — round 2 waits for (or fails fast on) any late arrivals.
+    if [ "$SETTLE" -gt 0 ]; then
+        sleep "$SETTLE"
+        watch_round
+    fi
+fi
+
+# Re-verify review state AFTER the watch/settle (codex-adv 980-r2): a review
+# can request changes or a new unresolved thread can land during a long watch
+# without moving the head SHA — certifying the pre-watch snapshot would let
+# merge-on-green proceed over fresh blocking feedback. Runs on the zombie
+# override path too (the settle window is short, but not zero).
+review_state_gate
 
 # Re-read the head: the green verdict only holds for the SHA we watched.
 head1=$(pr_view --json headRefOid --jq .headRefOid 2>/dev/null)

--- a/scripts/hooks/block-unresolved-cr-merge.sh
+++ b/scripts/hooks/block-unresolved-cr-merge.sh
@@ -2,7 +2,8 @@
 # PreToolUse hook: block-unresolved-cr-merge.sh
 #
 # Blocks `gh pr merge` while the PR has unresolved CodeRabbit review threads
-# or a CodeRabbit check-run still running on the head SHA (HIMMEL-936;
+# or a CodeRabbit check-run still running on the head SHA (HIMMEL-936), except
+# a proven old zombie backed by success status + zero unresolved threads (HIMMEL-980;
 # operator rule 2026-07-11: never merge over unresolved CodeRabbit remarks).
 # Sibling of check-cr-marker-on-pr-create.sh / block-merged-pr-commit.sh.
 #

--- a/scripts/hooks/test-block-unresolved-cr-merge.sh
+++ b/scripts/hooks/test-block-unresolved-cr-merge.sh
@@ -22,14 +22,24 @@ case "$1 $2" in
     echo '{"number":42,"headRefOid":"abc123","url":"https://github.com/o/r/pull/42"}' ;;
   "api graphql")
     case "$GH_STUB_MODE" in
-      unresolved) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
-      other-author) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"someuser"}}]}}]}}}}}' ;;
-      *) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
+      unresolved|zombie-unresolved) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
+      other-author) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"someuser"}}]}}]}}}}}' ;;
+      zombie-paged) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":true},"nodes":[{"isResolved":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
+      zombie-nopageinfo) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
+      *) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
     esac ;;
   "api repos/o/r/commits/abc123/check-runs"*)
     case "$GH_STUB_MODE" in
-      inflight) echo '{"check_runs":[{"name":"CodeRabbit","status":"in_progress","conclusion":null}]}' ;;
+      inflight|zombie|zombie-unresolved|zombie-no-status|zombie-status-error|zombie-paged|zombie-nopageinfo) echo '{"check_runs":[{"name":"CodeRabbit","status":"in_progress","started_at":"2000-01-01T00:00:00Z","conclusion":null}]}' ;;
+      young) echo "{\"check_runs\":[{\"name\":\"CodeRabbit\",\"status\":\"in_progress\",\"started_at\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"conclusion\":null}]}" ;;
       *)        echo '{"check_runs":[{"name":"CodeRabbit","status":"completed","conclusion":"success"}]}' ;;
+    esac ;;
+  "api repos/o/r/commits/abc123/status")
+    case "$GH_STUB_MODE" in
+      zombie|zombie-unresolved|zombie-paged|zombie-nopageinfo) echo '{"statuses":[{"context":"CodeRabbit","state":"success"}]}' ;;
+      zombie-status-error) exit 1 ;;
+      zombie-no-status) echo '{"statuses":[]}' ;;
+      *) echo '{"statuses":[{"context":"CodeRabbit","state":"pending"}]}' ;;
     esac ;;
   *) echo '{}' ;;
 esac
@@ -58,6 +68,15 @@ GH_STUB_MODE=unresolved t merge-with-unresolved-blocks   2 Bash "gh pr merge 42 
 GH_STUB_MODE=clean      t merge-clean-allows             0 Bash "gh pr merge 42 --squash"
 GH_STUB_MODE=error      t api-error-fails-open           0 Bash "gh pr merge 42 --squash"
 GH_STUB_MODE=inflight   t inflight-review-blocks         2 Bash "gh pr merge 42 --squash"
+GH_STUB_MODE=zombie     t zombie-review-allows           0 Bash "gh pr merge 42 --squash"
+GH_STUB_MODE=young      t young-inflight-blocks          2 Bash "gh pr merge 42 --squash"
+GH_STUB_MODE=zombie-no-status t zombie-no-success-blocks 2 Bash "gh pr merge 42 --squash"
+GH_STUB_MODE=zombie-unresolved t zombie-unresolved-blocks 2 Bash "gh pr merge 42 --squash"
+GH_STUB_MODE=zombie-status-error t zombie-status-error-blocks 2 Bash "gh pr merge 42 --squash"
+GH_STUB_MODE=zombie-paged t zombie-paged-threads-blocks 2 Bash "gh pr merge 42 --squash"
+GH_STUB_MODE=zombie-nopageinfo t zombie-nopageinfo-blocks 2 Bash "gh pr merge 42 --squash"
+GH_STUB_MODE=other-author t other-author-thread-allows 0 Bash "gh pr merge 42 --squash"
+CR_ZOMBIE_CHECKRUN_MINS=090 GH_STUB_MODE=zombie t zombie-leading-zero-mins-allows 0 Bash "gh pr merge 42 --squash"
 GH_STUB_MODE=unresolved t non-merge-passthrough          0 Bash "gh pr view 42"
 GH_STUB_MODE=unresolved t string-literal-passthrough     0 Bash "echo \\\"gh pr merge 42\\\""
 GH_STUB_MODE=unresolved t powershell-payload-blocks      2 PowerShell "gh pr merge 42 --squash"
@@ -86,6 +105,7 @@ for pt in non-merge-passthrough string-literal-passthrough quoted-merge-text-pas
 done
 # block reason surfaces on stderr (hook contract: stderr shown to model+user)
 grep -qi "unresolved" "$TMP/err-merge-with-unresolved-blocks" || { echo "FAIL stderr reason missing"; fail=$((fail+1)); }
+grep -q "zombie check-run override:.*commit status=success + 0 unresolved threads.*HIMMEL-980" "$TMP/err-zombie-review-allows" || { echo "FAIL zombie override line missing"; fail=$((fail+1)); }
 
 echo "pass=$pass fail=$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/lib/cr-merge-gate.sh
+++ b/scripts/lib/cr-merge-gate.sh
@@ -15,6 +15,7 @@
 #   EVERYTHING else (gh missing, API error, no PR, parse failure) fails OPEN
 #   (rc 0/3) with a "cr-merge-gate: degraded (...) - failing open" stderr note.
 #   CR_MERGE_GATE_OK=1 or CR_PROFILE=none skip the gate entirely (rc 0).
+#   CR_ZOMBIE_CHECKRUN_MINS sets the old-run override threshold (default 90).
 #
 # Sourceable from hooks and scripts: uses only `return`, never `exit`;
 # does not toggle set -e. bash 3.2-safe. Each `jq` command substitution is
@@ -24,6 +25,11 @@
 # HIMMEL-936.
 
 _cmg_degrade() { echo "cr-merge-gate: degraded ($*) - failing open" >&2; }
+
+_cmg_started_epoch() {
+    date -u -d "$1" +%s 2>/dev/null && return 0
+    date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "$1" +%s 2>/dev/null
+}
 
 cr_merge_gate() {
     [ "${CR_MERGE_GATE_OK:-0}" = "1" ] && return 0
@@ -50,16 +56,37 @@ cr_merge_gate() {
     if [ -z "$owner" ] || [ -z "$name" ]; then _cmg_degrade "cannot parse owner/name from $url"; return 0; fi
 
     # 1) unresolved coderabbitai review threads
-    local threads unresolved
+    local threads unresolved threads_page_complete
     # shellcheck disable=SC2016  # GraphQL variables ($owner/$name/$number) are literal here
     threads=$(gh api graphql \
         -f owner="$owner" -f name="$name" -F number="$num" \
-        -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved path line comments(first:1){nodes{author{login}}}}}}}}' \
+        -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved path line comments(first:1){nodes{author{login}}}}}}}}' \
         2>/dev/null) || { _cmg_degrade "reviewThreads query failed"; return 0; }
+    # Page-completeness marker (HIMMEL-980 codex-adv-1): this single-page query
+    # is the hook's ONLY thread evidence. That is unchanged for the plain gate
+    # (>100-thread PRs keep the pre-existing first-page behavior), but the
+    # zombie override below must NOT certify "zero unresolved threads" it never
+    # saw — so the override is disabled whenever a second page exists.
+    # `== false` on purpose (coderabbit 980-r2): only an EXPLICIT
+    # hasNextPage:false proves completeness — a missing/null pageInfo yields
+    # "false" here (override stays disabled). jq's `//` operator cannot express
+    # this: `hasNextPage // true` swallows a legitimate false.
+    threads_page_complete=$(printf '%s' "$threads" | jq -r \
+        '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage == false' \
+        2>/dev/null || echo false)
     unresolved=$(printf '%s' "$threads" | jq -r \
         '[.data.repository.pullRequest.reviewThreads.nodes[]? | select(.isResolved==false) | select((.comments.nodes[0].author.login // "") | test("coderabbit"; "i"))] | length' \
         2>/dev/null || true)
     if [ -z "$unresolved" ]; then _cmg_degrade "reviewThreads parse failed"; return 0; fi
+    # >100 threads with zero unresolved ON PAGE ONE is not a pass — it is
+    # positive evidence of threads this single-page query never counted
+    # (coderabbit 980-r3). Unlike an API/parse failure (degrade, fail open),
+    # this blocks: the state is knowable, just not from one page. A real PR
+    # with 100+ CodeRabbit threads is pathological — check manually or bypass.
+    if [ "$unresolved" -eq 0 ] 2>/dev/null && [ "$threads_page_complete" != "true" ]; then
+        echo "BLOCK: PR #$num has more review threads than the gate's single page (100) — cannot certify zero unresolved CodeRabbit threads. Check threads manually, or bypass with CR_MERGE_GATE_OK=1."
+        return 2
+    fi
     if [ "$unresolved" -gt 0 ] 2>/dev/null; then
         # List the offending threads (path:line) so the block is actionable and
         # the bypass is front-and-center (false-block trust erosion mitigation,
@@ -80,6 +107,38 @@ cr_merge_gate() {
         2>/dev/null || true)
     if [ -z "$pending" ]; then _cmg_degrade "check-runs parse failed"; return 0; fi
     if [ "$pending" -gt 0 ] 2>/dev/null; then
+        local zombie_mins started started_count started_epoch now_epoch age_secs statuses status_state
+        zombie_mins="${CR_ZOMBIE_CHECKRUN_MINS:-90}"
+        case "$zombie_mins" in ''|*[!0-9]*) zombie_mins=90 ;; esac
+        # 10# guard (coderabbit 980-r4): a leading-zero value ("090") passes
+        # the digit check but blows up base-8 arithmetic in $((… * 60)).
+        zombie_mins=$((10#$zombie_mins))
+        started=$(printf '%s' "$runs" | jq -r \
+            '[.check_runs[]? | select(.name=="CodeRabbit") | select(.status=="in_progress") | .started_at // empty] | max // empty' \
+            2>/dev/null || true)
+        started_count=$(printf '%s' "$runs" | jq -r \
+            '[.check_runs[]? | select(.name=="CodeRabbit") | select(.status=="in_progress") | select(.started_at != null)] | length' \
+            2>/dev/null || true)
+        started_epoch=$(_cmg_started_epoch "$started" 2>/dev/null || true)
+        now_epoch=$(date -u +%s 2>/dev/null || true)
+        # threads_page_complete must be exactly "true": any second page (or a
+        # malformed/missing pageInfo) means the zero-unresolved evidence did not
+        # cover every thread, and the override may not certify what it never
+        # saw (codex-adv-1). The plain in-flight BLOCK below still runs either way.
+        if [ "$threads_page_complete" = "true" ] \
+            && [ "$started_count" = "$pending" ] && [ -n "$started_epoch" ] && [ -n "$now_epoch" ]; then
+            age_secs=$((now_epoch - started_epoch))
+            if [ "$age_secs" -gt $((zombie_mins * 60)) ]; then
+                statuses=$(gh api "repos/$owner/$name/commits/$head/status" 2>/dev/null) || statuses=""
+                status_state=$(printf '%s' "$statuses" | jq -r \
+                    '[.statuses[]? | select(.context=="CodeRabbit")][0].state // empty' \
+                    2>/dev/null || true)
+                if [ "$status_state" = "success" ]; then
+                    echo "zombie check-run override: CodeRabbit run in_progress since $started (>${zombie_mins}m) but commit status=success + 0 unresolved threads — treating as completed (HIMMEL-980)" >&2
+                    return 0
+                fi
+            fi
+        fi
         echo "BLOCK: CodeRabbit is still reviewing head $head of PR #$num (check-run not completed). Wait for it, then re-check threads. Bypass: CR_MERGE_GATE_OK=1."
         return 2
     fi

--- a/scripts/test-check-ci.sh
+++ b/scripts/test-check-ci.sh
@@ -68,6 +68,25 @@ cat > "$STUBDIR/gh" <<'EOF'
 echo "$*" >> "$GH_STUB_ARGS"
 cmd="${1:-}"
 if [ "$cmd" = "api" ]; then
+    case "${2:-}" in
+        repos/octo/demo/commits/sha1/check-runs*)
+            case "$GH_STUB_MODE" in
+                zombie|zombie-no-status|zombie-status-error|zombie-late)
+                    echo '{"check_runs":[{"name":"CodeRabbit","status":"in_progress","started_at":"2000-01-01T00:00:00Z"}]}' ;;
+                zombie-young)
+                    echo "{\"check_runs\":[{\"name\":\"CodeRabbit\",\"status\":\"in_progress\",\"started_at\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}]}" ;;
+                *) echo '{"check_runs":[]}' ;;
+            esac
+            exit 0 ;;
+        repos/octo/demo/commits/sha1/status)
+            case "$GH_STUB_MODE" in
+                zombie|zombie-late) echo '{"statuses":[{"context":"CodeRabbit","state":"success"}]}' ;;
+                zombie-status-error) echo "status boom" >&2; exit 1 ;;
+                zombie-no-status) echo '{"statuses":[]}' ;;
+                *) echo '{"statuses":[{"context":"CodeRabbit","state":"pending"}]}' ;;
+            esac
+            exit 0 ;;
+    esac
     if [ "${GH_STUB_THREADS:-0}" = "fail" ]; then echo "graphql boom" >&2; exit 1; fi
     if [ "${GH_STUB_THREADS:-0}" = "badnext" ]; then echo "0 banana cursor1"; exit 0; fi
     if [ "${GH_STUB_THREADS:-0}" = "nullcursor" ]; then echo "0 true null"; exit 0; fi
@@ -78,6 +97,16 @@ if [ "$cmd" = "api" ]; then
         echo $((a+1)) > "$GH_STUB_API"
         # alternate cursorA / cursorB forever: A→B→A cycle, hasNextPage always true
         if [ $((a % 2)) -eq 0 ]; then echo "0 true cursorA"; else echo "0 true cursorB"; fi
+        exit 0
+    fi
+    if [ "${GH_STUB_THREADS:-0}" = "latethread" ]; then
+        # First thread query (pre-watch gate) is clean; every later query
+        # (the post-watch re-verification) reports one unresolved thread —
+        # a review comment that landed DURING the watch (codex-adv 980-r2).
+        a=$(cat "$GH_STUB_API" 2>/dev/null)
+        a=${a:-0}
+        echo $((a+1)) > "$GH_STUB_API"
+        if [ "$a" -eq 0 ]; then echo "0 false null"; else echo "1 false null"; fi
         exit 0
     fi
     if [ "${GH_STUB_THREADS:-0}" = "paged" ]; then
@@ -122,7 +151,17 @@ case " $* " in *" --watch "*) is_watch=1 ;; esac
 # structured red confirm (--json bucket): the script's --jq yields a bare count
 case " $* " in
     *" --json "*)
-        if [ "$GH_STUB_MODE" = "red-liar" ]; then echo 0; else echo 1; fi
+        case "$GH_STUB_MODE" in
+            zombie-late)
+                # First checks --json probe (zombie other_pending snapshot)
+                # sees 0; the settle re-probe (and later calls) see 1 late
+                # arrival. Count only `pr checks … --json` lines — pr_view's
+                # `--json headRefOid` calls land in the same args log.
+                njson=$(grep -c "^pr checks .*--json" "$GH_STUB_ARGS" 2>/dev/null); njson=${njson:-1}
+                if [ "$njson" -le 1 ]; then echo 0; else echo 1; fi ;;
+            red-liar|zombie|zombie-young|zombie-no-status|zombie-status-error) echo 0 ;;
+            *) echo 1 ;;
+        esac
         exit 0 ;;
 esac
 case "$GH_STUB_MODE" in
@@ -162,6 +201,13 @@ case "$GH_STUB_MODE" in
         exit 8 ;;
     watch-error)
         if [ "$is_watch" -eq 1 ]; then echo "HTTP 401: Bad credentials (https://api.github.com/graphql)" >&2; exit 1; fi
+        exit 8 ;;
+    zombie|zombie-young|zombie-no-status|zombie-status-error)
+        if [ "$is_watch" -eq 1 ]; then echo "gh stub: zombie watch must not complete" >&2; exit 99; fi
+        exit 8 ;;
+    zombie-late)
+        # After the dropped override the watch path MUST run — and completes green.
+        if [ "$is_watch" -eq 1 ]; then echo "All checks were successful"; exit 0; fi
         exit 8 ;;
     *)
         echo "gh stub: unknown GH_STUB_MODE '$GH_STUB_MODE'" >&2; exit 99 ;;
@@ -420,7 +466,49 @@ run red-liar
 assert_rc 2 "26 red-liar rc 2"
 assert_err_has "no check is in the fail bucket" "26 structured-confirm message"
 
+# 27 — old in-progress CodeRabbit + successful same-head commit status + clean
+# threads overrides the zombie and never enters the hanging watch.
+run zombie
+assert_rc 0 "27 zombie override rc 0"
+assert_out_has "zombie check-run override:" "27 zombie override loud line"
+assert_out_has "commit status=success + 0 unresolved threads" "27 zombie evidence printed"
+
+# 28 — a young in-progress run remains blocking (the watch path cannot certify).
+run zombie-young
+assert_rc 2 "28 young in-progress still blocks"
+
+# 29 — old run without successful commit status remains blocking.
+run zombie-no-status
+assert_rc 2 "29 old run without success still blocks"
+
+# 30 — unresolved threads prevent override before the status probe.
+THREADS_OVERRIDE=1
+run zombie
+assert_rc 3 "30 old success with unresolved thread blocks"
+
+# 31 — status API errors are no-override and remain fail-closed.
+run zombie-status-error
+assert_rc 2 "31 status probe error still blocks"
+
+# 32 — a non-CodeRabbit check registering during the settle window drops the
+# override: the run falls back to the watch path (which completes green here)
+# instead of certifying on the stale snapshot (codex-adv-2).
+SETTLE_OVERRIDE=1
+run zombie-late
+assert_rc 0 "32 late-check settle re-probe rc 0 via watch path"
+assert_out_has "zombie check-run override:" "32 override initially taken"
+assert_out_has "zombie override dropped:" "32 override dropped on late arrival"
+grep -q -- "--watch" "$STUBDIR/args.log" || { echo "FAIL: 32 watch path never ran"; FAIL=$((FAIL+1)); }
+
+# 33 — an unresolved thread landing DURING the watch (head SHA unmoved) is
+# caught by the post-watch review-state re-verification, not certified from
+# the stale pre-watch snapshot (codex-adv 980-r2).
+THREADS_OVERRIDE=latethread
+run register-then-green
+assert_rc 3 "33 late thread post-watch blocks"
+assert_err_has "unresolved review thread" "33 late-thread reason printed"
+
 echo
 echo "ran $COUNT cases; PASS=$PASS FAIL=$FAIL"
-if [ "$COUNT" -ne 27 ]; then echo "CASE-COUNT MISMATCH: ran $COUNT want 27"; exit 1; fi
+if [ "$COUNT" -ne 34 ]; then echo "CASE-COUNT MISMATCH: ran $COUNT want 34"; exit 1; fi
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
Public propagation of the zombie CodeRabbit check-run override (single squash of the private change): full-evidence override in both merge-gate twins, post-watch review-state re-verification, page-completeness proof, 10# env guard; hook suite 25/25, check-ci suite 79 asserts / 34 cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge checks to reliably detect requested changes and unresolved review threads, including threads added during final verification.
  * Added safer handling for invalid pull request links, incomplete review data, pagination issues, and status-check errors.
  * Refined treatment of long-running checks to prevent premature merge approval.

* **Tests**
  * Expanded coverage for delayed reviews, pagination, status failures, and long-running check scenarios.
  * Added configurable timing validation for review-check overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->