### PR TITLE
fix(handover): queue-lock takeover + re-acquire CAS get the noclobber owner-file arbiter

### DIFF
--- a/scripts/handover/queue-lock.sh
+++ b/scripts/handover/queue-lock.sh
@@ -468,6 +468,20 @@ _ql_arms_mutex_release() {
     return 0
 }
 
+# Drop a takeover claim only while its atomic owner brand still names us.
+# A taker that outlives the 120s claim TTL must not remove a reclaimer's
+# newly created generation.
+_ql_takeover_claim_release() {
+    local claim="$1" token="$2" current=""
+    current=$(cat "$claim/owner" 2>/dev/null) || current=""
+    if [ "$current" != "$token" ]; then
+        return 1
+    fi
+    rm -f "$claim/owner" 2>/dev/null
+    rmdir "$claim" 2>/dev/null
+    return 0
+}
+
 queue_lock_acquire() {
     local ho="${1:-}" session="${2:-}"
     if [ -z "$ho" ]; then
@@ -491,18 +505,34 @@ queue_lock_acquire() {
         echo "queue-lock: cannot create the lock parent dir '$(dirname "$lockdir")' (permissions? a file in the way?)" >&2
         return 1
     fi
+    # uutils mkdir can report success to concurrent creators of the same
+    # directory. The owner create is the real CAS: bash noclobber maps to
+    # open(O_CREAT|O_EXCL), so only its winner may brand owner.json.
     if mkdir "$lockdir" 2>/dev/null; then
-        if ! _ql_write_owner "$lockdir" "$session" "$host" "$ho" "$now" "$now"; then
-            # C3: never report acquired over a failed owner write -- the
-            # torn lock would parse as CORRUPT-held (fail-closed) forever.
-            rm -rf "$lockdir" 2>/dev/null
-            echo "queue-lock: acquire FAILED -- owner.json could not be written; the lock dir was removed, nothing is acquired" >&2
+        if ( set -C; printf '%s' "$session" > "$lockdir/owner" ) 2>/dev/null; then
+            if ! _ql_write_owner "$lockdir" "$session" "$host" "$ho" "$now" "$now"; then
+                # C3: never report acquired over a failed owner write -- the
+                # torn lock would parse as CORRUPT-held (fail-closed) forever.
+                rm -rf "$lockdir" 2>/dev/null
+                echo "queue-lock: acquire FAILED -- owner.json could not be written; the lock dir was removed, nothing is acquired" >&2
+                return 1
+            fi
+            echo "queue-lock: acquired (session=$session host=$host)"
+            _ql_arms_registry_retire_fired "$ho"
+            echo "release-token: $session"
+            return 0
+        elif [ ! -e "$lockdir/owner" ]; then
+            # Owner create failed with NO winner branded (ENOSPC/ACL/IO --
+            # not a lost race; codex-adv 981-r1): an unbranded dir would
+            # wedge every future taker on manual cleanup. rmdir (never
+            # rm -rf) is race-safe -- it only removes an EMPTY dir, so a
+            # racer branding between the check and here makes it a no-op.
+            rmdir "$lockdir" 2>/dev/null
+            echo "queue-lock: acquire FAILED -- the owner file could not be created (disk full? permissions?); the empty lock dir was removed, nothing is acquired" >&2
             return 1
         fi
-        echo "queue-lock: acquired (session=$session host=$host)"
-        _ql_arms_registry_retire_fired "$ho"
-        echo "release-token: $session"
-        return 0
+        # owner exists: a uutils co-winner branded first -- we LOST the
+        # arbiter; fall through to the loser/spin path below.
     fi
 
     # Lost the mkdir race, but the WINNER may not have finished writing
@@ -599,7 +629,12 @@ queue_lock_acquire() {
                 echo "WARN queue-lock: cannot age the takeover claim '$claim' (mtime probe failed) -- treating it as fresh. If it is stuck from a crashed taker, remove it manually: rm -rf '$claim'" >&2
             fi
         fi
-        if ! mkdir "$claim" 2>/dev/null; then
+        # mkdir success is provisional on uutils. Atomically brand the
+        # claim with bash noclobber; a co-winner leaves the true winner's
+        # directory/owner untouched and follows the normal held path.
+        local claim_token="pid$$-r$RANDOM"
+        if ! mkdir "$claim" 2>/dev/null \
+            || ! ( set -C; printf '%s' "$claim_token" > "$claim/owner" ) 2>/dev/null; then
             {
                 echo "queue-lock: held -- another taker holds the takeover claim for this queue right now ($claim)"
                 echo "Try again shortly, or check: queue-lock.sh status"
@@ -610,7 +645,7 @@ queue_lock_acquire() {
         local v_raw
         v_raw=$(cat "$lockdir/owner.json" 2>/dev/null) || v_raw=""
         if [ "$v_raw" != "$o_raw" ]; then
-            rmdir "$claim" 2>/dev/null
+            _ql_takeover_claim_release "$claim" "$claim_token" || true
             local n_session n_host
             n_session=$(_ql_json_field_str "$v_raw" session)
             n_host=$(_ql_json_field_str "$v_raw" host)
@@ -622,19 +657,36 @@ queue_lock_acquire() {
         fi
         # Step 3: destroy the verified-stale generation, fresh-acquire.
         rm -rf "$lockdir" 2>/dev/null
+        # Same owner-file arbiter as the fresh acquire above: a uutils
+        # mkdir co-winner must not overwrite or remove the true winner.
+        # And same write-failure contract (codex-adv 981-r1): a failed owner
+        # create with NO winner branded is an IO/permissions error, not a
+        # lost race -- rmdir the unbranded dir (race-safe: rmdir refuses a
+        # non-empty dir) instead of leaving a queue-wedging husk.
+        local takeover_owner_ok=0
         if mkdir "$lockdir" 2>/dev/null; then
+            if ( set -C; printf '%s' "$session" > "$lockdir/owner" ) 2>/dev/null; then
+                takeover_owner_ok=1
+            elif [ ! -e "$lockdir/owner" ]; then
+                rmdir "$lockdir" 2>/dev/null
+                _ql_takeover_claim_release "$claim" "$claim_token" || true
+                echo "queue-lock: takeover FAILED -- the owner file could not be created (disk full? permissions?); the empty lock dir was removed, nothing is acquired" >&2
+                return 1
+            fi
+        fi
+        if [ "$takeover_owner_ok" -eq 1 ]; then
             if ! _ql_write_owner "$lockdir" "$session" "$host" "$ho" "$now" "$now"; then
                 # C3: same contract as the fresh path -- never report a
                 # takeover over a failed owner write.
                 rm -rf "$lockdir" 2>/dev/null
-                rmdir "$claim" 2>/dev/null
+                _ql_takeover_claim_release "$claim" "$claim_token" || true
                 echo "queue-lock: takeover FAILED -- owner.json could not be written; the lock dir was removed, nothing is acquired" >&2
                 return 1
             fi
             printf '%s took over from session=%s host=%s started=%s heartbeat=%s reason=%s new_session=%s new_host=%s\n' \
                 "$now" "$o_session" "$o_host" "$o_started" "$o_heartbeat" "$reason" "$session" "$host" \
                 >> "$lockdir/takeovers.log"
-            rmdir "$claim" 2>/dev/null
+            _ql_takeover_claim_release "$claim" "$claim_token" || true
             echo "queue-lock: took over ($reason) -- previous holder: session=$o_session host=$o_host" >&2
             echo "queue-lock: acquired (session=$session host=$host)"
             _ql_arms_registry_retire_fired "$ho"
@@ -642,7 +694,7 @@ queue_lock_acquire() {
             return 0
         fi
         # Lost the rm->mkdir gap to a fresh acquirer -- it owns the lock.
-        rmdir "$claim" 2>/dev/null
+        _ql_takeover_claim_release "$claim" "$claim_token" || true
         local l_session="" l_host=""
         if [ -f "$lockdir/owner.json" ]; then
             l_session=$(_ql_json_field "$lockdir/owner.json" session)

--- a/scripts/handover/test-queue-lock.sh
+++ b/scripts/handover/test-queue-lock.sh
@@ -840,6 +840,85 @@ fi
 QUEUE_LOCK_FORCE_RELEASE=1 bash "$LIB" release "$HO29" >/dev/null 2>&1
 rm -f "$ARMS_REGISTRY"
 
+# --- T32: takeover-claim mkdir co-winner loses the owner-file arbiter -----
+# Simulate uutils returning rc=0 after another taker already created and
+# branded the same claim. The loser must not remove the winner's claim or
+# advance far enough to destroy the stale lock generation.
+HO32="$HANDOVER_DIR/HIMMEL-856-test/next-session-32.md"
+: > "$HO32"
+LOCKDIR32="$HANDOVER_DIR/.locks/queue/HIMMEL-856-test__next-session-32.lock"
+mkdir -p "$LOCKDIR32"
+printf '{"session":"dead-session","host":"old-host","handover":"%s","started":"2020-01-01T00:00:00Z","heartbeat":"2020-01-01T00:00:00Z"}\n' \
+    "$HO32" > "$LOCKDIR32/owner.json"
+t32_out=$(bash -c '
+    . "$1"
+    lockdir="$2"
+    claim="${lockdir}.claim"
+    mkdir() {
+        if [ "${1:-}" = "$claim" ]; then
+            command mkdir -p "$claim"
+            printf "%s" "winner-claim" > "$claim/owner"
+            return 0
+        fi
+        command mkdir "$@"
+    }
+    queue_lock_acquire "$3" "loser-claim" >/dev/null 2>&1
+    echo "RC=$?"
+    echo "CLAIM_OWNER=$(cat "$claim/owner" 2>/dev/null)"
+    echo "LOCK_OWNER=$(cat "$lockdir/owner.json" 2>/dev/null)"
+' _ "$LIB" "$LOCKDIR32" "$HO32" 2>&1)
+if printf '%s' "$t32_out" | grep -q '^RC=2$' \
+    && printf '%s' "$t32_out" | grep -q '^CLAIM_OWNER=winner-claim$' \
+    && printf '%s' "$t32_out" | grep -q 'LOCK_OWNER=.*"session":"dead-session"'; then
+    pass "T32: claim-arbiter loser leaves winner claim + stale generation intact"
+else
+    fail "T32: claim-arbiter loser damaged winner state (out=$t32_out)"
+fi
+rm -rf "$LOCKDIR32" "${LOCKDIR32}.claim"
+
+# --- T33: post-rm lockdir mkdir co-winner loses owner-file arbiter --------
+# The first lockdir mkdir sees the stale fixture. On the post-rm mkdir,
+# simulate a concurrent fresh winner plus uutils' false rc=0 for this loser.
+# The loser must preserve both the winner's arbiter and owner.json.
+HO33="$HANDOVER_DIR/HIMMEL-856-test/next-session-33.md"
+: > "$HO33"
+LOCKDIR33="$HANDOVER_DIR/.locks/queue/HIMMEL-856-test__next-session-33.lock"
+mkdir -p "$LOCKDIR33"
+printf '{"session":"dead-session","host":"old-host","handover":"%s","started":"2020-01-01T00:00:00Z","heartbeat":"2020-01-01T00:00:00Z"}\n' \
+    "$HO33" > "$LOCKDIR33/owner.json"
+t33_out=$(bash -c '
+    . "$1"
+    lockdir="$2"
+    ho="$3"
+    lockdir_mkdir_count=0
+    mkdir() {
+        if [ "${1:-}" = "$lockdir" ]; then
+            lockdir_mkdir_count=$((lockdir_mkdir_count + 1))
+            if [ "$lockdir_mkdir_count" -eq 2 ]; then
+                command mkdir -p "$lockdir"
+                printf "%s" "winner-reacquire" > "$lockdir/owner"
+                printf "{\"session\":\"winner-reacquire\",\"host\":\"winner-host\",\"handover\":\"%s\",\"started\":\"2026-01-01T00:00:00Z\",\"heartbeat\":\"2026-01-01T00:00:00Z\"}\n" "$ho" > "$lockdir/owner.json"
+                return 0
+            fi
+        fi
+        command mkdir "$@"
+    }
+    queue_lock_acquire "$ho" "loser-reacquire" >/dev/null 2>&1
+    echo "RC=$?"
+    echo "ARBITER=$(cat "$lockdir/owner" 2>/dev/null)"
+    echo "LOCK_OWNER=$(cat "$lockdir/owner.json" 2>/dev/null)"
+    [ -e "${lockdir}.claim" ] && echo "CLAIM_LEFT=yes" || echo "CLAIM_LEFT=no"
+' _ "$LIB" "$LOCKDIR33" "$HO33" 2>&1)
+if printf '%s' "$t33_out" | grep -q '^RC=2$' \
+    && printf '%s' "$t33_out" | grep -q '^ARBITER=winner-reacquire$' \
+    && printf '%s' "$t33_out" | grep -q 'LOCK_OWNER=.*"session":"winner-reacquire"' \
+    && printf '%s' "$t33_out" | grep -q '^CLAIM_LEFT=no$'; then
+    pass "T33: post-rm arbiter loser leaves winner lock intact + drops own claim"
+else
+    fail "T33: post-rm arbiter loser damaged winner state (out=$t33_out)"
+fi
+rm -rf "$LOCKDIR33" "${LOCKDIR33}.claim"
+
 echo "---"
 echo "PASSED=$PASSED FAILED=$FAILED"
 [ "$FAILED" = 0 ]


### PR DESCRIPTION
## Summary
Public propagation of the queue-lock arbiter completion — noclobber owner-file arbiter at the takeover + re-acquire CAS sites, wedge-free IO-failure handling, +T32/T33 (single squash of the private change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue locking reliability during concurrent acquisitions and stale-lock takeovers.
  * Prevented invalid or incomplete lock states when ownership metadata cannot be written.
  * Ensured losing takeover attempts cannot remove or overwrite a winning claim.
  * Cleaned up failed takeover claims to prevent stale lock artifacts and wedged queues.

* **Tests**
  * Added regression coverage for concurrent takeover races and ownership arbitration.
  * Verified winner state remains intact and losing claims are properly removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->