### PR TITLE
test(cr): [HIMMEL-994] merge-gate stub fixtures carry pageInfo — un-red the allow cases (#1188)

### DIFF
--- a/scripts/lib/test-cr-merge-gate.sh
+++ b/scripts/lib/test-cr-merge-gate.sh
@@ -22,9 +22,13 @@ case "$1 $2" in
   "api graphql")
     case "$GH_STUB_MODE" in
       api-error) exit 1 ;;
-      unresolved) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
-      other-author) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"someuser"}}]}}]}}}}}' ;;
-      *) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
+      # pageInfo mirrors the real API: the gate's query requests it, so GitHub
+      # always returns it (HIMMEL-994 — fixtures without it hit the 980-r3
+      # page-completeness BLOCK and mis-fail the allow cases).
+      unresolved) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
+      other-author) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"someuser"}}]}}]}}}}}' ;;
+      paged) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":true},"nodes":[{"isResolved":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
+      *) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}' ;;
     esac ;;
   "api repos/o/r/commits/abc123/check-runs"*)
     case "$GH_STUB_MODE" in
@@ -52,6 +56,9 @@ t() { # t <name> <expected-rc> — runs cr_merge_gate 42 o/r with current env
 GH_STUB_MODE=unresolved   t unresolved-cr-thread-blocks 2
 GH_STUB_MODE=clean        t resolved-threads-allow 0
 GH_STUB_MODE=other-author t other-author-unresolved-allows 0
+# zero unresolved on page one + hasNextPage:true = threads the single-page
+# query never counted -> BLOCK, not a pass (980-r3)
+GH_STUB_MODE=paged        t incomplete-page-blocks 2
 GH_STUB_MODE=inflight     t checkrun-in-flight-blocks 2
 # pr view itself fails -> rc=3 (selector unresolvable; still an allow, but
 # lets the hook retry with a better anchor - codex-1/codex-adv-1 CR round)


### PR DESCRIPTION

## Summary
- Public main shell-unit went red after #420 (HIMMEL-980 propagation):
`test-cr-merge-gate.sh` fails `resolved-threads-allow` +
`other-author-unresolved-allows` (rc=2 want=0), and blocks public #421
(HIMMEL-981) from going green.
- Root cause: the 980-r3 page-completeness block requires an EXPLICIT
`pageInfo.hasNextPage:false` to certify zero unresolved threads, but the
gh stub's graphql fixtures never carried `pageInfo` — the allow cases
hit the >100-threads BLOCK. Real API responses always include requested
`pageInfo`; the gate is correct, the fixtures were stale.
- Fix: fixtures now carry `pageInfo` (mirroring the queried shape); adds
`incomplete-page-blocks` (hasNextPage:true + zero unresolved → rc=2) so
the r3 block is covered on purpose; the `inflight` fixture now reaches
the check-run gate it claims to test.

## Test plan
- [x] `bash scripts/lib/test-cr-merge-gate.sh` — 9/9 on Windows Git Bash
- [x] same suite 9/9 on WSL (ubuntu)

## CR
- /pr-check clean: panel (lagunaor+codex gpt-5.5) 0 findings; codex-adv
approve; coderabbit 1 major DISPROVED (suggested adding `endCursor` —
the gate's query requests `pageInfo{hasNextPage}` only, so real
responses carry no endCursor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai
-->

## Summary by CodeRabbit

* **Tests**
* Expanded merge-gate test fixtures to cover paginated review-thread
results.
* Added coverage verifying that unresolved threads on incomplete pages
correctly block the gate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge validation when review-thread results span multiple pages.
  * Incomplete review data now correctly blocks the merge instead of allowing it based only on the first page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->