### PR TITLE
fix(setup): rtk hook wiring - auto-patch, guard reconcile after clone, transactional restore

### DIFF
--- a/scripts/hooks/test-reconcile-rtk-hook.sh
+++ b/scripts/hooks/test-reconcile-rtk-hook.sh
@@ -28,6 +28,10 @@
 #   12. No hooks.PreToolUse key → byte-for-byte unchanged (no spurious []).
 #   13. Two guards in the SAME hooks array → collapse (intra-array branch).
 #   14. Bare entry beside a non-rtk hook → matcher + sibling preserved.
+#   15. Stale-path guard + fresh bare → ONE guard at the CURRENT path.
+#   16. Custom command mentioning the guard path → never rewritten.
+#   17. Custom command BEFORE a real guard → custom kept verbatim, ONE guard.
+#   18. Custom command AFTER a real guard → custom kept verbatim, ONE guard.
 
 set -uo pipefail
 
@@ -252,6 +256,88 @@ if [ "$(guard_count "$f")" -eq 1 ] \
     assert_pass "matcher 'Bash' + sibling hook preserved, 1 guard"
 else
     assert_fail "matcher/sibling not preserved: $(jq -c . "$f")"
+fi
+
+# ---------- 15. Stale guard path + fresh bare → ONE guard at the CURRENT path ----------
+# HIMMEL-985: settings restored from another machine/username/checkout carry a
+# guard entry with an old absolute path. Dedup keeps the FIRST guard in
+# document order, so without the normalize stage the stale entry would win and
+# the freshly swapped one be dropped — setup would report success while the
+# hook points at a missing wrapper.
+echo "Test 15: stale-path guard + new bare entry normalize to the current guard path"
+f="$work/stale.json"
+jq -n '{hooks:{PreToolUse:[
+    {matcher:"Bash",hooks:[{type:"command",command:"bash \"/old/checkout/scripts/hooks/rtk-hook-guard.sh\""}]},
+    {matcher:"Bash",hooks:[{type:"command",command:"rtk hook claude"}]}
+]}}' > "$f"
+reconcile "$f"
+if [ "$(guard_count "$f")" -eq 1 ] && [ "$(bare_count "$f")" -eq 0 ] \
+   && jq -e --arg g "$GUARD" '[.hooks.PreToolUse[]?.hooks[]?.command] | any(. == $g)' "$f" >/dev/null \
+   && ! jq -e '[.hooks.PreToolUse[]?.hooks[]?.command] | any(contains("/old/checkout/"))' "$f" >/dev/null; then
+    assert_pass "1 guard at the current himmel path, stale path gone"
+else
+    assert_fail "stale guard survived or wrong path: $(jq -c . "$f")"
+fi
+
+# ---------- 16. Custom command MENTIONING the guard path is never rewritten ----------
+# The normalize stage is deliberately narrower than dedup: only a PLAIN
+# `bash "<path>/rtk-hook-guard.sh"` invocation is rewritten. An operator's
+# custom wrapper that merely mentions the guard path keeps its exact text
+# (non-destructive contract; CR round-5 finding).
+echo "Test 16: a custom wrapper mentioning rtk-hook-guard.sh keeps its exact command"
+f="$work/custom.json"
+custom='bash /x/wrap.sh --then "/opt/other/scripts/hooks/rtk-hook-guard.sh"'
+jq -n --arg c "$custom" '{hooks:{PreToolUse:[
+    {matcher:"Bash",hooks:[{type:"command",command:$c}]}
+]}}' > "$f"
+if ! reconcile "$f"; then
+    assert_fail "reconcile exited non-zero on the custom-wrapper fixture"
+elif jq -e --arg c "$custom" '[.hooks.PreToolUse[]?.hooks[]?.command] | any(. == $c)' "$f" >/dev/null; then
+    assert_pass "custom wrapper command preserved verbatim"
+else
+    assert_fail "custom wrapper was rewritten: $(jq -c . "$f")"
+fi
+
+# plain_guard_count <file>  — hook objects whose command IS the current guard
+# (exact match; narrower than guard_count's contains(), which also counts a
+# custom wrapper that mentions the guard path).
+plain_guard_count() {
+    jq --arg g "$GUARD" '[.hooks.PreToolUse[]?.hooks[]? | select((.command // "") == $g)] | length' "$1"
+}
+
+# ---------- 17. Custom wrapper BEFORE a real guard → both survive dedup ----------
+# Dedup must collapse only PLAIN guard invocations. A custom wrapper listed
+# first must not swallow the real guard (contains()-era dedup kept the first
+# guard-ish entry in document order, deleting whichever came second).
+echo "Test 17: custom wrapper before a real guard - custom kept verbatim, one plain guard"
+f="$work/custom-first.json"
+jq -n --arg c "$custom" --arg g "$GUARD" '{hooks:{PreToolUse:[
+    {matcher:"Bash",hooks:[{type:"command",command:$c}]},
+    {matcher:"Bash",hooks:[{type:"command",command:$g}]}
+]}}' > "$f"
+if ! reconcile "$f"; then
+    assert_fail "reconcile exited non-zero on the custom-before-guard fixture"
+elif [ "$(jq --arg c "$custom" '[.hooks.PreToolUse[]?.hooks[]?.command | select(. == $c)] | length' "$f")" -eq 1 ] \
+   && [ "$(plain_guard_count "$f")" -eq 1 ]; then
+    assert_pass "custom wrapper kept verbatim exactly once, exactly one plain guard remains"
+else
+    assert_fail "custom-before-guard mangled: $(jq -c . "$f")"
+fi
+
+# ---------- 18. Custom wrapper AFTER a real guard → both survive dedup ----------
+echo "Test 18: custom wrapper after a real guard - custom kept verbatim, one plain guard"
+f="$work/custom-second.json"
+jq -n --arg c "$custom" --arg g "$GUARD" '{hooks:{PreToolUse:[
+    {matcher:"Bash",hooks:[{type:"command",command:$g}]},
+    {matcher:"Bash",hooks:[{type:"command",command:$c}]}
+]}}' > "$f"
+if ! reconcile "$f"; then
+    assert_fail "reconcile exited non-zero on the custom-after-guard fixture"
+elif [ "$(jq --arg c "$custom" '[.hooks.PreToolUse[]?.hooks[]?.command | select(. == $c)] | length' "$f")" -eq 1 ] \
+   && [ "$(plain_guard_count "$f")" -eq 1 ]; then
+    assert_pass "custom wrapper kept verbatim exactly once, exactly one plain guard remains"
+else
+    assert_fail "custom-after-guard mangled: $(jq -c . "$f")"
 fi
 
 # ---------- summary ----------

--- a/scripts/lib/reconcile-rtk-hook.sh
+++ b/scripts/lib/reconcile-rtk-hook.sh
@@ -15,9 +15,11 @@
 #   machine-setup. This helper is the on-demand reconcile for that case.
 #
 # CONTRACT: after this runs, the settings file holds EXACTLY ONE PreToolUse
-#   hook object pointing at rtk-hook-guard.sh. It is idempotent (a second run
-#   is a no-op) and duplicate-safe across every starting shape — fresh bare,
-#   guard+bare leftover, N bare, N guard.
+#   hook object with a PLAIN `bash "<path>/rtk-hook-guard.sh"` invocation. It
+#   is idempotent (a second run is a no-op) and duplicate-safe across every
+#   starting shape — fresh bare, guard+bare leftover, N bare, N guard. A
+#   custom operator command that merely MENTIONS the guard path is outside
+#   the managed set: never rewritten, never deduped, never dropped.
 #
 # SCOPE: operates on the ONE settings.json passed as $1. The rtk guard belongs
 #   at USER scope only (~/.claude/settings.json): `rtk init -g` is global and
@@ -38,6 +40,12 @@ set -uo pipefail
 # scripts/machine-setup/ubuntu.sh so the standalone path and the in-setup swap
 # agree on what counts as a raw rtk entry.
 BARE_RTK_RE='^[[:space:]]*rtk[[:space:]]+hook[[:space:]]+claude([[:space:]]|$)'
+
+# A PLAIN guard invocation (`bash "<any>/rtk-hook-guard.sh"`, anchored) — the
+# ONLY shape normalize rewrites AND dedup collapses. A custom operator command
+# that merely mentions the guard path matches neither (non-destructive
+# contract; CR round-5 + round-6 coderabbit findings).
+PLAIN_GUARD_RE='^bash "[^"]*/scripts/hooks/rtk-hook-guard[.]sh"$'
 
 reconcile_rtk_hook() {
   local settings="$1" himmel="$2"
@@ -63,23 +71,37 @@ reconcile_rtk_hook() {
   local before after
   before=$(jq -S . "$settings")
 
-  # Two-stage transform:
+  # Three-stage transform:
   #   1. SWAP — every bare `rtk hook claude` hook object's command becomes the
   #      guard command (mirrors ubuntu.sh's inline swap filter, line ~548).
-  #   2. DEDUP — keep only the FIRST guard hook object in document order; drop
-  #      every later guard hook object, then prune any group whose hooks array
-  #      went empty. Non-guard hooks and group fields (matcher, …) are untouched.
+  #   1.5 NORMALIZE — every PLAIN guard invocation (`bash "<any>/rtk-hook-
+  #      guard.sh"`, anchored shape-match) is rewritten to the freshly
+  #      computed guard path (HIMMEL-985: settings restored from another
+  #      machine/username/checkout carry a stale absolute guard path; dedup
+  #      keeps the FIRST guard in document order, so without this the stale
+  #      entry would win and the current one be dropped). Deliberately
+  #      NARROWER than dedup's contains() — a custom operator command that
+  #      merely mentions the guard path is never rewritten (non-destructive
+  #      contract; CR round-5 coderabbit finding).
+  #   2. DEDUP — keep only the FIRST plain guard hook object in document order;
+  #      drop every later plain guard hook object, then prune any group whose
+  #      hooks array went empty. Matches the SAME anchored shape as normalize —
+  #      a custom command that merely mentions the guard path is never dropped
+  #      (it used to be: a broader contains() match silently deleted an
+  #      operator's wrapper whenever a real guard coexisted). Non-guard hooks
+  #      and group fields (matcher, …) are untouched.
   # The DEDUP assignment is gated on `.hooks.PreToolUse` already existing so a
   # settings file that has no PreToolUse key is left byte-for-byte (no spurious
   # `PreToolUse: []` injected) — matching ubuntu.sh's "skip when absent" and the
   # non-destructive contract above.
-  after=$(jq --arg re "$BARE_RTK_RE" --arg guard "$guard" '
+  after=$(jq --arg re "$BARE_RTK_RE" --arg pg "$PLAIN_GUARD_RE" --arg guard "$guard" '
     (.hooks.PreToolUse[]?.hooks[]? | select((.command // "") | test($re))).command = $guard
+    | (.hooks.PreToolUse[]?.hooks[]? | select((.command // "") | test($pg))).command = $guard
     | if ((.hooks? // {}) | has("PreToolUse")) then
         .hooks.PreToolUse |= (
           reduce .[] as $g ({out: [], seen: false};
             ( reduce ($g.hooks // [])[] as $h ({hooks: [], seen: .seen};
-                if (($h.command // "") | contains("rtk-hook-guard.sh"))
+                if (($h.command // "") | test($pg))
                 then (if .seen then . else {hooks: (.hooks + [$h]), seen: true} end)
                 else {hooks: (.hooks + [$h]), seen: .seen}
                 end)

--- a/scripts/machine-setup/test-ubuntu-shim.sh
+++ b/scripts/machine-setup/test-ubuntu-shim.sh
@@ -86,10 +86,15 @@ cat > "$stub_bin/git" <<'EOF'
 if [ "$1" = "clone" ]; then
   target="$*"
   target="${target##* }"
-  mkdir -p "$target/scripts/hooks" "$target/scripts/himmelctl"
+  mkdir -p "$target/scripts/hooks" "$target/scripts/himmelctl" "$target/scripts/lib"
   cat > "$target/scripts/hooks/check-hookspath.sh" <<'INNER'
 #!/usr/bin/env bash
 echo "STUB:check-hookspath"
+exit 0
+INNER
+  cat > "$target/scripts/lib/reconcile-rtk-hook.sh" <<'INNER'
+#!/usr/bin/env bash
+echo "STUB:reconcile-rtk-hook $*"
 exit 0
 INNER
   cat > "$target/scripts/himmelctl/bootstrap.sh" <<'INNER'
@@ -98,7 +103,7 @@ echo "BOOTSTRAP:invoked $*"
 echo "BOOTSTRAP:pwd $PWD"
 exit 0
 INNER
-  chmod +x "$target/scripts/hooks/check-hookspath.sh" "$target/scripts/himmelctl/bootstrap.sh"
+  chmod +x "$target/scripts/hooks/check-hookspath.sh" "$target/scripts/lib/reconcile-rtk-hook.sh" "$target/scripts/himmelctl/bootstrap.sh"
 fi
 exit 0
 EOF
@@ -126,6 +131,7 @@ cat > "$stub_bin/rtk" <<'EOF'
 #!/usr/bin/env bash
 case "$1" in
   --version) echo "rtk-stub 1.0.0"; exit 0 ;;
+  init) echo "STUB:rtk-init $*"; exit 0 ;;
   *) exit 0 ;;
 esac
 EOF
@@ -173,6 +179,30 @@ bootstrap_pwd=$(grep '^BOOTSTRAP:pwd ' "$log" | head -1 | sed 's/^BOOTSTRAP:pwd 
 [ "$bootstrap_pwd" = "$expected_pwd" ] \
   || fail "caseB: bootstrap must be invoked with cwd=\$HIMMEL_PATH ($expected_pwd), got: $bootstrap_pwd"
 echo "ok: caseB provisioning ($provision_line) < notice ($notice_line) < delegated bootstrap ($bootstrap_line), cwd=\$HIMMEL_PATH"
+
+# HIMMEL-985: the shim must reconcile the rtk hook (bare `rtk hook claude`
+# from `rtk init -g --auto-patch` → the rtk-hook-guard wrapper) AFTER the
+# clone (the helper lives in the repo) and BEFORE the delegated bootstrap,
+# passing the user settings.json and the himmel path. The pre-HIMMEL-887
+# monolith did this swap inline; the shim owns it again.
+reconcile_line=$(grep -n '^STUB:reconcile-rtk-hook' "$log" | head -1 | cut -d: -f1)
+[ -n "$reconcile_line" ] || { cat "$log" >&2; fail "caseB: no reconcile-rtk-hook invocation found (log above)"; }
+[ "$bootstrap_line" -gt "$reconcile_line" ] \
+  || fail "caseB: reconcile-rtk-hook (line $reconcile_line) must run before the delegated bootstrap (line $bootstrap_line)"
+# rtk init must be wired AFTER clone validation (adjacent to the reconcile) —
+# wiring before the clone could strand a raw unguarded hook on clone failure.
+rtk_init_line=$(grep -n -Fx 'STUB:rtk-init init -g --auto-patch' "$log" | head -1 | cut -d: -f1)
+hookspath_line=$(grep -n '^STUB:check-hookspath' "$log" | head -1 | cut -d: -f1)
+[ -n "$rtk_init_line" ] || { cat "$log" >&2; fail "caseB: no rtk init -g --auto-patch invocation found (log above)"; }
+[ -n "$hookspath_line" ] || { cat "$log" >&2; fail "caseB: no check-hookspath invocation found (log above)"; }
+[ "$rtk_init_line" -gt "$hookspath_line" ] \
+  || fail "caseB: rtk init (line $rtk_init_line) must run after clone validation (check-hookspath, line $hookspath_line)"
+[ "$reconcile_line" -gt "$rtk_init_line" ] \
+  || fail "caseB: reconcile (line $reconcile_line) must run after rtk init (line $rtk_init_line)"
+reconcile_args=$(grep '^STUB:reconcile-rtk-hook ' "$log" | head -1 | sed 's/^STUB:reconcile-rtk-hook //')
+[ "$reconcile_args" = "$tmp_home/.claude/settings.json $expected_pwd" ] \
+  || fail "caseB: reconcile-rtk-hook args must be '<settings.json> <himmel-path>', got: $reconcile_args"
+echo "ok: caseB reconcile-rtk-hook ($reconcile_line) < bootstrap ($bootstrap_line), args OK"
 
 # ── Case C: --luna-remote -> fail-closed BEFORE any provisioning ───────────
 # Reuses the Case B stub environment (same stub PATH + temp HOME) so a

--- a/scripts/machine-setup/ubuntu.sh
+++ b/scripts/machine-setup/ubuntu.sh
@@ -96,7 +96,9 @@ RTK_DEB="rtk_amd64.deb"
 curl -fL "https://github.com/rtk-ai/rtk/releases/download/${RTK_TAG}/${RTK_DEB}" \
   -o "/tmp/${RTK_DEB}"
 sudo apt install -y "/tmp/${RTK_DEB}"
-rtk init -g
+# Hook wiring (`rtk init -g --auto-patch` + guard reconcile) happens in the
+# clone step below — adjacent to the reconcile so a clone/hookspath failure
+# can never strand a raw unguarded hook (HIMMEL-985 codex-adv finding).
 rtk --version
 
 step "Clone himmel repo"
@@ -111,6 +113,38 @@ cd "$HIMMEL_PATH"
 # gate (no-push-to-main, npm-audit, code-review-before-push, platforms-tested,
 # hookspath-misconfig itself) would be bypassed.
 bash scripts/hooks/check-hookspath.sh
+
+# HIMMEL-985: wire the rtk hook AND immediately swap the bare `rtk hook
+# claude` entry for the himmel rtk-hook-guard wrapper + dedup (HIMMEL-241
+# compound-find fix). Two deliberate properties:
+#   - `--auto-patch`: without it the settings.json hook-patch prompt defaults
+#     to N in non-interactive runs, leaving rtk installed but the rewrite hook
+#     unwired — the drift found on the win2 station.
+#   - Adjacency AFTER clone + hookspath validation: the pre-HIMMEL-887
+#     monolith did the swap inline and the delegated himmelctl flow lost it;
+#     wiring earlier (before the clone) could strand a RAW unguarded hook if
+#     clone/validation failed — raw rtk breaks compound find rewrites.
+# Transactional (mirrors win11.ps1): rtk init mutates settings.json before
+# the reconcile can guard it — on any failure in between, restore the
+# pre-init settings so no partial state leaves a raw unguarded hook behind.
+rtk_settings="$HOME/.claude/settings.json"
+rtk_settings_bak=""
+if [ -f "$rtk_settings" ]; then
+  rtk_settings_bak=$(mktemp)
+  cp "$rtk_settings" "$rtk_settings_bak"
+fi
+if ! { rtk init -g --auto-patch \
+       && bash "$HIMMEL_PATH/scripts/lib/reconcile-rtk-hook.sh" "$rtk_settings" "$HIMMEL_PATH"; }; then
+  if [ -n "$rtk_settings_bak" ]; then
+    cp "$rtk_settings_bak" "$rtk_settings"
+  else
+    rm -f "$rtk_settings"
+  fi
+  rm -f "$rtk_settings_bak"
+  echo "ERROR: rtk hook wiring failed — settings.json restored to its pre-init state" >&2
+  exit 1
+fi
+rm -f "$rtk_settings_bak"
 cd -
 
 step "Delegate himmel/luna wiring to himmelctl bootstrap (HIMMEL-887)"

--- a/scripts/machine-setup/win11.ps1
+++ b/scripts/machine-setup/win11.ps1
@@ -117,7 +117,9 @@ if ($PathParts -notcontains $RtkInstallDir) {
 }
 $env:PATH = "$env:PATH;$RtkInstallDir"
 
-Invoke-Fatal "rtk init -g" { rtk init -g }
+# Hook wiring (`rtk init -g --auto-patch` + guard reconcile) happens after
+# the clone below — adjacent to the reconcile so a clone/hookspath failure
+# can never strand a raw unguarded hook (HIMMEL-985 codex-adv finding).
 Invoke-Fatal "rtk --version" { rtk --version }
 
 Write-Step "Clone himmel repo"
@@ -135,6 +137,58 @@ if ($LASTEXITCODE -ne 0) {
     throw "check-hookspath.ps1 failed (exit $LASTEXITCODE) — refusing to continue on a misconfigured clone."
 }
 Pop-Location
+
+# HIMMEL-985: wire the rtk hook AND immediately swap the bare `rtk hook
+# claude` entry for the himmel rtk-hook-guard wrapper + dedup (HIMMEL-241
+# compound-find fix). Runs after clone + hookspath validation so a failure
+# can never strand a raw unguarded hook — see the matching ubuntu.sh comment.
+# Resolve Git Bash BEFORE rtk init mutates settings.json: derive it from the
+# active git install (works for user-scoped/custom installs, not just
+# Program Files), falling back to PATH minus the System32 WSL bash stub.
+$GitBash = $null
+$GitCmd = Get-Command git -ErrorAction SilentlyContinue
+if ($GitCmd) {
+    # git.exe may resolve from <GitRoot>\cmd, <GitRoot>\bin, or
+    # <GitRoot>\mingw64\bin — walk upward until a level holds bash.
+    $GitDir = Split-Path $GitCmd.Source -Parent
+    for ($i = 0; $i -lt 4 -and -not $GitBash -and $GitDir; $i++) {
+        foreach ($Rel in "bin\bash.exe", "usr\bin\bash.exe") {
+            $BashCandidate = Join-Path $GitDir $Rel
+            if (Test-Path $BashCandidate) { $GitBash = $BashCandidate; break }
+        }
+        $GitDir = Split-Path $GitDir -Parent
+    }
+}
+if (-not $GitBash) {
+    $GitBash = (Get-Command bash.exe -All -ErrorAction SilentlyContinue |
+        Where-Object { $_.Source -notmatch '(?i)\\(System32|Microsoft\\WindowsApps)\\' } |
+        Select-Object -First 1).Source
+}
+if (-not $GitBash) {
+    throw "Git Bash not found (checked the active git install and PATH) — refusing to wire the rtk hook without the reconcile step."
+}
+# Transactional: rtk init mutates settings.json before the reconcile can
+# guard it — on any failure in between, restore the pre-init settings so no
+# partial state leaves a raw unguarded hook behind (CR round-6 finding).
+$SettingsPath = Join-Path $env:USERPROFILE ".claude\settings.json"
+$SettingsExisted = Test-Path -LiteralPath $SettingsPath
+[byte[]]$SettingsBackup = @()
+if ($SettingsExisted) {
+    $SettingsBackup = [System.IO.File]::ReadAllBytes($SettingsPath)
+}
+try {
+    Invoke-Fatal "rtk init -g --auto-patch" { rtk init -g --auto-patch }
+    $HimmelPathFwd = $HimmelPath -replace '\\','/'
+    $SettingsFwd = $SettingsPath -replace '\\','/'
+    Invoke-Fatal "reconcile-rtk-hook.sh" { & $GitBash "$HimmelPathFwd/scripts/lib/reconcile-rtk-hook.sh" $SettingsFwd $HimmelPathFwd }
+} catch {
+    if ($SettingsExisted) {
+        [System.IO.File]::WriteAllBytes($SettingsPath, $SettingsBackup)
+    } else {
+        Remove-Item -LiteralPath $SettingsPath -Force -ErrorAction SilentlyContinue
+    }
+    throw
+}
 
 Write-Step "Delegate himmel/luna wiring to himmelctl bootstrap (HIMMEL-887)"
 # HIMMEL-887: this script is soft-deprecated for himmel/luna WIRING — the


### PR DESCRIPTION
Non-interactive rtk init skipped the settings hook patch; the setup shim had also lost the bare-to-guard swap. Machine-setup now wires rtk with --auto-patch adjacent to the guard reconcile after clone validation, transactionally (settings restored on partial failure), with hardened Git Bash discovery and stale-guard-path normalization in reconcile-rtk-hook.sh. Tests: reconcile suite 20 cases, shim-order assertions.