### PR TITLE
feat(clean): [HIMMEL-970] stray-sweep for de-registered worktree husks in clean-garden prune (#1190)

### DIFF
--- a/scripts/clean-garden.sh
+++ b/scripts/clean-garden.sh
@@ -229,6 +229,36 @@ while IFS= read -r line; do
 done < <(git -C "$PRIMARY_WORKTREE" worktree list --porcelain)
 flush_record
 
+registered_worktree_path() {
+    local candidate="$1" candidate_norm wt wt_norm
+    candidate_norm=$(cd "$candidate" 2>/dev/null && pwd || echo "$candidate")
+    for wt in "${WT_PATHS[@]}"; do
+        wt_norm=$(cd "$wt" 2>/dev/null && pwd || echo "$wt")
+        if [ "$candidate_norm" = "$wt_norm" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+human_kib() {
+    awk -v kib="${1:-0}" 'BEGIN {
+        bytes = kib * 1024
+        split("B K M G T", unit)
+        value = bytes
+        idx = 1
+        while (value >= 1024 && idx < 5) {
+            value = value / 1024
+            idx++
+        }
+        if (idx == 1 || value >= 10) {
+            printf "%.0f%s", value, unit[idx]
+        } else {
+            printf "%.1f%s", value, unit[idx]
+        }
+    }'
+}
+
 PRUNED=0
 PARTIAL=0
 SKIPPED=0
@@ -335,6 +365,56 @@ if [ "$NO_PRUNE" -eq 0 ]; then
         fi
     done
     echo "clean-garden: prune summary — $PRUNED pruned, $PARTIAL partial, $SKIPPED skipped, $FAILED failed"
+
+    STRAY_HOME="$PRIMARY_WORKTREE/.claude/worktrees"
+    if [ -d "$STRAY_HOME" ]; then
+        STRAY_FOUND=0
+        STRAY_SWEPT=0
+        STRAY_FAILED=0
+        STRAY_RECLAIMED_KIB=0
+        while IFS= read -r stray_dir; do
+            [ -n "$stray_dir" ] || continue
+            stray_norm=$(cd "$stray_dir" 2>/dev/null && pwd || echo "$stray_dir")
+            if [ "$stray_norm" = "$PRIMARY_WORKTREE" ]; then
+                log "  stray-sweep skip primary-looking path: $stray_dir"
+                continue
+            fi
+            if registered_worktree_path "$stray_dir"; then
+                log "  stray-sweep keep registered worktree: $stray_dir"
+                continue
+            fi
+            # Fresh = ANY entry inside the husk modified in the last 24h, not
+            # just the top-level dir mtime (nested writes by an in-flight
+            # session don't touch the top dir's mtime).
+            if find "$stray_dir" -mmin -1440 -print 2>/dev/null | grep -q .; then
+                log "  stray-sweep skip fresh husk: $stray_dir"
+                continue
+            fi
+
+            STRAY_FOUND=$((STRAY_FOUND+1))
+            stray_kib=$(du -sk "$stray_dir" 2>/dev/null | awk '{ print $1 }') || stray_kib=0
+            stray_kib=${stray_kib:-0}
+
+            if [ "$DRY_RUN" -eq 1 ]; then
+                echo "DRY clean-garden: would sweep stray husk $stray_dir"
+                STRAY_SWEPT=$((STRAY_SWEPT+1))
+                STRAY_RECLAIMED_KIB=$((STRAY_RECLAIMED_KIB+stray_kib))
+                continue
+            fi
+            if rm -rf "$stray_dir" 2>/dev/null; then
+                log "  swept stray husk: $stray_dir"
+                STRAY_SWEPT=$((STRAY_SWEPT+1))
+                STRAY_RECLAIMED_KIB=$((STRAY_RECLAIMED_KIB+stray_kib))
+            else
+                echo "WARN clean-garden: failed to sweep stray husk $stray_dir" >&2
+                STRAY_FAILED=$((STRAY_FAILED+1))
+            fi
+        done < <(find "$STRAY_HOME" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+        if [ "$STRAY_FOUND" -gt 0 ]; then
+            STRAY_SIZE=$(human_kib "$STRAY_RECLAIMED_KIB")
+            echo "clean-garden: stray-sweep — $STRAY_SWEPT swept, $STRAY_FAILED failed ($STRAY_SIZE reclaimed)"
+        fi
+    fi
 
     # CR-pending marker sweep: remove stale markers for branches that no
     # longer exist locally AND have no open PR. Markers for branches that are

--- a/scripts/test-clean-stray-sweep.sh
+++ b/scripts/test-clean-stray-sweep.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Hermetic test for clean-garden's de-registered worktree husk sweep
+# (HIMMEL-970). Temp git repos + direct .claude/worktrees children.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLEAN_GARDEN="$SCRIPT_DIR/clean-garden.sh"
+
+PASS=0
+FAIL=0
+TMP_ROOT=""
+TMP_ROOT_UNIX=""
+
+# shellcheck disable=SC2317,SC2329  # invoked indirectly via `trap cleanup EXIT`
+cleanup() {
+    if [ -n "$TMP_ROOT_UNIX" ] && [ -d "$TMP_ROOT_UNIX" ]; then
+        rm -rf "$TMP_ROOT_UNIX" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; if [ $# -ge 2 ]; then printf '    %s\n' "$2"; fi; FAIL=$((FAIL+1)); }
+
+TMP_ROOT=$(mktemp -d)
+TMP_ROOT_UNIX="$TMP_ROOT"
+if command -v cygpath >/dev/null 2>&1; then
+    TMP_ROOT=$(cygpath -m "$TMP_ROOT")
+fi
+
+make_repo() {
+    local name="$1" repo
+    repo="$TMP_ROOT/$name"
+    git init -q --initial-branch=main "$repo" 2>/dev/null || {
+        git init -q "$repo"
+        git -C "$repo" symbolic-ref HEAD refs/heads/main || true
+    }
+    git -C "$repo" config user.email t@test.com
+    git -C "$repo" config user.name t
+    printf 'base\n' > "$repo/README"
+    git -C "$repo" add README
+    git -C "$repo" commit -q -m "base"
+    git -C "$repo" branch -m main 2>/dev/null || true
+    printf '%s\n' "$repo"
+}
+
+# Age a husk RECURSIVELY: the sweep's freshness gate treats ANY entry modified
+# in the last 24h as in-flight, so fixtures must age the dir and its contents.
+touch_old() {
+    local entry
+    while IFS= read -r entry; do
+        touch -d '2 days ago' "$entry" 2>/dev/null || touch -t 202001010000 "$entry"
+    done < <(find "$1" -print 2>/dev/null)
+}
+
+run_clean() {
+    local repo="$1"; shift
+    (
+        cd "$repo" || exit 1
+        bash "$CLEAN_GARDEN" --prune-only "$@" 2>&1
+    )
+}
+
+echo "RUN A: old de-registered husk is swept"
+REPO_A=$(make_repo repo-a)
+HUSK_A="$REPO_A/.claude/worktrees/feat+old-husk"
+mkdir -p "$HUSK_A"
+printf 'stray\n' > "$HUSK_A/file.txt"
+touch_old "$HUSK_A"
+out_a=$(run_clean "$REPO_A") || fail "run_clean exited nonzero (repo-a)" "$out_a"
+if [ ! -d "$HUSK_A" ]; then
+    pass "old husk swept"
+else
+    fail "old husk still exists" "$out_a"
+fi
+case "$out_a" in
+    *"clean-garden: stray-sweep — 1 swept, 0 failed ("*" reclaimed)"*) pass "old husk summary counts sweep and size" ;;
+    *) fail "expected stray-sweep summary for old husk" "$out_a" ;;
+esac
+
+echo "RUN B: fresh de-registered husk is skipped"
+REPO_B=$(make_repo repo-b)
+HUSK_B="$REPO_B/.claude/worktrees/feat+fresh-husk"
+mkdir -p "$HUSK_B"
+printf 'fresh\n' > "$HUSK_B/file.txt"
+out_b=$(run_clean "$REPO_B") || fail "run_clean exited nonzero (repo-b)" "$out_b"
+if [ -d "$HUSK_B" ]; then
+    pass "fresh husk kept"
+else
+    fail "fresh husk was swept" "$out_b"
+fi
+case "$out_b" in
+    *"stray-sweep"*) fail "fresh-only run printed stray-sweep summary" "$out_b" ;;
+    *) pass "fresh-only run stays quiet" ;;
+esac
+
+echo "RUN C: registered worktree under .claude/worktrees is never swept"
+REPO_C=$(make_repo repo-c)
+mkdir -p "$REPO_C/.claude/worktrees"
+WT_C="$REPO_C/.claude/worktrees/feat+registered"
+git -C "$REPO_C" worktree add -q "$WT_C" -b feat/registered >/dev/null 2>&1
+touch_old "$WT_C"
+out_c=$(run_clean "$REPO_C") || fail "run_clean exited nonzero (repo-c)" "$out_c"
+if [ -d "$WT_C" ] && git -C "$REPO_C" worktree list --porcelain | grep -Fq "worktree $WT_C"; then
+    pass "registered worktree kept"
+else
+    fail "registered worktree was swept or de-registered" "$out_c"
+fi
+case "$out_c" in
+    *"stray-sweep"*) fail "registered-only run printed stray-sweep summary" "$out_c" ;;
+    *) pass "registered-only run stays quiet" ;;
+esac
+
+echo "RUN D: dry-run reports would-sweep and removes nothing"
+REPO_D=$(make_repo repo-d)
+HUSK_D="$REPO_D/.claude/worktrees/feat+dry-husk"
+mkdir -p "$HUSK_D"
+printf 'dry\n' > "$HUSK_D/file.txt"
+touch_old "$HUSK_D"
+out_d=$(run_clean "$REPO_D" --dry-run) || fail "run_clean exited nonzero (repo-d)" "$out_d"
+# Match by dir basename, not the full $HUSK_D: on Windows the harness path is
+# cygpath-mixed (C:/...) while clean-garden prints the POSIX form (/tmp/...).
+case "$out_d" in
+    *"DRY clean-garden: would sweep stray husk "*"/feat+dry-husk"*) pass "dry-run reports would-sweep" ;;
+    *) fail "dry-run did not report would-sweep" "$out_d" ;;
+esac
+if [ -d "$HUSK_D" ]; then
+    pass "dry-run removes nothing"
+else
+    fail "dry-run removed husk" "$out_d"
+fi
+case "$out_d" in
+    *"clean-garden: stray-sweep — 1 swept, 0 failed ("*" reclaimed)"*) pass "dry-run summary counts would-sweep" ;;
+    *) fail "dry-run summary missing" "$out_d" ;;
+esac
+
+echo "RUN E: no husks stays quiet"
+REPO_E=$(make_repo repo-e)
+out_e=$(run_clean "$REPO_E") || fail "run_clean exited nonzero (repo-e)" "$out_e"
+case "$out_e" in
+    *"stray-sweep"*) fail "no-husk run printed stray-sweep summary" "$out_e" ;;
+    *) pass "no-husk run has no stray-sweep summary" ;;
+esac
+
+echo "RUN F: old husk dir with a FRESH nested file is skipped (in-flight)"
+REPO_F=$(make_repo repo-f)
+HUSK_F="$REPO_F/.claude/worktrees/feat+deep-fresh"
+mkdir -p "$HUSK_F/nested"
+printf 'old\n' > "$HUSK_F/old.txt"
+touch_old "$HUSK_F"
+printf 'live\n' > "$HUSK_F/nested/live.txt"   # fresh nested write, top dir aged below
+touch -d '2 days ago' "$HUSK_F" 2>/dev/null || touch -t 202001010000 "$HUSK_F"
+out_f=$(run_clean "$REPO_F") || fail "run_clean exited nonzero (repo-f)" "$out_f"
+if [ -d "$HUSK_F" ]; then
+    pass "old-dir/fresh-content husk kept"
+else
+    fail "old-dir/fresh-content husk was swept (freshness gate not recursive)" "$out_f"
+fi
+
+echo
+echo "===================================="
+echo "test summary: $PASS passed, $FAIL failed"
+echo "===================================="
+if [ "$FAIL" -gt 0 ]; then exit 1; fi
+exit 0


### PR DESCRIPTION

## Summary
- clean-garden prune de-registers a merged-PR worktree but leaves its
directory behind when removal fails (held cwd, Windows file locks);
after `git worktree prune` those husks under `.claude/worktrees/` are
invisible to `git worktree list` and accumulate forever (77 dirs / 386MB
observed on overlord8, HIMMEL-970).
- Adds a stray-sweep pass to the prune phase (`/clean` +
`/clean_garden`; `--no-prune` skips): direct children of
`.claude/worktrees` not registered as worktrees are removed when nothing
inside them was modified in the last 24h (recursive freshness gate —
in-flight session safety). Registered/primary paths are never touched;
DRY_RUN parity; removal failure is a WARN, never an abort; quiet when no
candidates.

## CR
- Round 1: [codex-2] agreed (freshness gate deepened to recursive) ·
[coderabbit-3] agreed (guarded test captures) · [coderabbit-2] disproved
(find -maxdepth/-mmin are repo precedent + BSD-supported) ·
[coderabbit-1]/[lagunaor-1] skipped with reason.
- Round 2: clean — lagunaor portability claims disproved with evidence
(BSD find has -mmin; touch -d lines carry the -t fallback; du -sk is
POSIX), CodeRabbit newline-in-dirname major disproved (validated
type/slug namespace + registered-guard + repo convention).

## Tests
- `scripts/test-clean-stray-sweep.sh` — 11 cases incl. RUN F regression
(old dir + fresh nested file kept). PASS on Windows Git Bash + WSL
Linux.
- `scripts/test-clean-prune-strays.sh` — 23/23 both platforms.

Impl: WSL codex lane (gpt-5.5), parent fire-time review + CR
adjudication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai
-->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of older, unregistered worktree directories.
  * Preserves registered worktrees and recently modified directories.
  * Added dry-run reporting and reclaimed-space summaries.

* **Tests**
* Added coverage for cleanup, freshness checks, registered worktree
protection, dry-run behavior, empty directories, and nested recent
files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of stale, unregistered worktree directories.
  * Preserves active, recently modified, primary, and registered worktrees.
  * Added dry-run support with cleanup counts and reclaimed-space reporting.

* **Tests**
  * Added coverage for stale, active, nested, registered, and dry-run cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->