### PR TITLE
fix(cadence): [HIMMEL-969] stamp probe covers codex-sweep + graphmap runners; readers probe all three homes with emitter-parity resolution (#1191)

### DIFF
--- a/scripts/himmel-doctor.sh
+++ b/scripts/himmel-doctor.sh
@@ -314,30 +314,41 @@ EOF
     fi
 }
 
-# --- C8: stale pipeline-cadence runners (armed before a format change) ----------
-# The pipeline-cadence runners (.bat/.sh) are GENERATED at arm time and NOT
-# regenerated on a code change (HIMMEL-588), so a cadence armed before a
-# runner-format change (e.g. the HIMMEL-575 --settings auto-approve injection)
-# keeps firing the old format with no nudge. Read-only: compare the version
-# stamped into the runners against the current CADENCE_RUNNER_FORMAT_VERSION and
-# point a stale one at `arm --force`. No --fix — a re-arm touches the OS
-# scheduler, so this stays advisory (mirrors C7).
+# --- C8: stale cadence runners (armed before a format change) -----------------
+# The cadence runners (.bat/.sh) are GENERATED at arm time and NOT regenerated
+# on a code change (HIMMEL-588/HIMMEL-969), so a cadence armed before a
+# runner-format change keeps firing the old format with no nudge. Read-only:
+# compare the version stamped into the runners against the current
+# CADENCE_RUNNER_FORMAT_VERSION and point stale ones at `arm --force`. No --fix
+# — a re-arm touches the OS scheduler, so this stays advisory (mirrors C7).
 check_c8() {
-    # Default must match pipeline-cadence.sh's runner home EXACTLY — that is
-    # $HOME/.claude/pipeline-cadence (it keys off $HOME, NOT $CLAUDE_DIR), so use
-    # $HOME here too rather than $CLAUDE_DIR_R, which would diverge when an
-    # operator relocates .claude via CLAUDE_DIR. PIPELINE_BAT_DIR overrides both.
-    local bat_dir="${PIPELINE_BAT_DIR:-${HOME:-}/.claude/pipeline-cadence}" ver
-    if ! ver="$(cadence_runner_stamp "$bat_dir")"; then
-        emit OK C8-cadence "no armed pipeline-cadence runners (skipped)"
-        return
-    fi
-    if [ "$ver" -lt "$CADENCE_RUNNER_FORMAT_VERSION" ]; then
-        emit WARN C8-cadence \
-            "pipeline-cadence runners are stale (format v$ver < v$CADENCE_RUNNER_FORMAT_VERSION) — armed before a runner-format change, still firing the old format" \
-            "re-arm: bash scripts/luna/pipeline-cadence.sh arm --force"
-    else
-        emit OK C8-cadence "pipeline-cadence runners current (format v$ver)"
+    # Defaults must match each emitter's runner home EXACTLY — the emitters
+    # key off resolve_user_home (USERPROFILE via cygpath before $HOME on
+    # Windows Git-Bash, HIMMEL-645), NOT $CLAUDE_DIR, so probe via the lib's
+    # cadence_user_home rather than $HOME or $CLAUDE_DIR_R.
+    # PIPELINE_BAT_DIR/SWEEP_BAT_DIR/GRAPHMAP_BAT_DIR override those homes.
+    local label bat_dir rearm ver saw_any=0 uh
+    uh="$(cadence_user_home)"
+    while IFS='|' read -r label bat_dir rearm; do
+        [ -n "$label" ] || continue
+        if ! ver="$(cadence_runner_stamp "$bat_dir")"; then
+            continue
+        fi
+        saw_any=1
+        if [ "$ver" -lt "$CADENCE_RUNNER_FORMAT_VERSION" ]; then
+            emit WARN C8-cadence \
+                "$label runners are stale (format v$ver < v$CADENCE_RUNNER_FORMAT_VERSION) — armed before a runner-format change, still firing the old format" \
+                "re-arm: $rearm"
+        else
+            emit OK C8-cadence "$label runners current (format v$ver)"
+        fi
+    done <<EOF
+pipeline-cadence|${PIPELINE_BAT_DIR:-$uh/.claude/pipeline-cadence}|bash scripts/luna/pipeline-cadence.sh arm --force
+codex-sweep-cadence|${SWEEP_BAT_DIR:-$uh/.claude/codex-sweep-cadence}|bash scripts/cleanup/codex-sweep-cadence.sh arm --force
+graphmap-cadence|${GRAPHMAP_BAT_DIR:-$uh/.claude/graphmap-cadence}|bash scripts/luna/graphmap-cadence.sh arm --force
+EOF
+    if [ "$saw_any" -eq 0 ]; then
+        emit OK C8-cadence "no armed cadence runners (skipped)"
     fi
 }
 

--- a/scripts/himmel-update.sh
+++ b/scripts/himmel-update.sh
@@ -237,20 +237,31 @@ update_codex() {
     return 0
 }
 
-# ─── stale pipeline-cadence runner nudge (HIMMEL-588) ────────────────────────
-# The pipeline-cadence runners (.bat/.sh) are GENERATED at arm time and NOT
-# regenerated on a code pull — so a `git pull` that changes the runner format
-# leaves an already-armed cadence firing the OLD format until a manual
-# `arm --force`. This surfaces that right after the pull. Advisory; never fails
-# the update. PIPELINE_BAT_DIR mirrors pipeline-cadence.sh's runner-home seam.
+# ─── stale cadence runner nudge (HIMMEL-588/HIMMEL-969) ──────────────────────
+# Cadence runners (.bat/.sh) are GENERATED at arm time and NOT regenerated on a
+# code pull — so a `git pull` that changes the runner format leaves an
+# already-armed cadence firing the OLD format until a manual `arm --force`.
+# This surfaces that right after the pull. Advisory; never fails the update.
+# *_BAT_DIR env seams mirror each emitter's runner home; defaults resolve via
+# cadence_user_home (emitter parity — USERPROFILE via cygpath before $HOME on
+# Windows Git-Bash, HIMMEL-645/969 — a bare $HOME would probe the MSYS dir).
 report_cadence_stale() {
-    local bat_dir="${PIPELINE_BAT_DIR:-$HOME/.claude/pipeline-cadence}" ver
-    ver="$(cadence_runner_stamp "$bat_dir")" || return 0
-    [ "$ver" -lt "$CADENCE_RUNNER_FORMAT_VERSION" ] || return 0
-    echo ""
-    echo "==> pipeline-cadence runners are STALE (format v$ver < v$CADENCE_RUNNER_FORMAT_VERSION)"
-    echo "    Armed before a runner-format change — re-arm to pick up the new format:"
-    echo "        bash scripts/luna/pipeline-cadence.sh arm --force"
+    local label bat_dir rearm ver uh
+    uh="$(cadence_user_home)"
+    while IFS='|' read -r label bat_dir rearm; do
+        [ -n "$label" ] || continue
+        ver="$(cadence_runner_stamp "$bat_dir")" || continue
+        [ "$ver" -lt "$CADENCE_RUNNER_FORMAT_VERSION" ] || continue
+        echo ""
+        echo "==> $label runners are STALE (format v$ver < v$CADENCE_RUNNER_FORMAT_VERSION)"
+        echo "    Armed before a runner-format change — re-arm to pick up the new format:"
+        echo "        $rearm"
+    done <<EOF
+pipeline-cadence|${PIPELINE_BAT_DIR:-$uh/.claude/pipeline-cadence}|bash scripts/luna/pipeline-cadence.sh arm --force
+codex-sweep-cadence|${SWEEP_BAT_DIR:-$uh/.claude/codex-sweep-cadence}|bash scripts/cleanup/codex-sweep-cadence.sh arm --force
+graphmap-cadence|${GRAPHMAP_BAT_DIR:-$uh/.claude/graphmap-cadence}|bash scripts/luna/graphmap-cadence.sh arm --force
+EOF
+    return 0
 }
 
 # ─── guardrail-mode block drift check (HIMMEL-709) ───────────────────────────

--- a/scripts/lib/cadence-format.sh
+++ b/scripts/lib/cadence-format.sh
@@ -1,19 +1,18 @@
 #!/usr/bin/env bash
-# cadence-format.sh — shared runner-format version + staleness probe for the
-# pipeline cadence (HIMMEL-588).
+# cadence-format.sh — shared runner-format version + staleness probe for
+# generated cadence runners (HIMMEL-588/HIMMEL-969).
 #
-# The pipeline-cadence runners (.bat/.sh) and the cadence-settings.json fragment
-# are GENERATED artifacts, baked at arm time (scripts/luna/pipeline-cadence.sh).
-# They hard-code paths, the prompt, and (since HIMMEL-575) the --settings
-# auto-approve injection — and they are NOT regenerated when the himmel code
-# changes. So an operator who armed BEFORE a runner-format change keeps firing
-# stale runners with no nudge (this is exactly what bit HIMMEL-575: the
-# --settings injection only took effect after a manual `arm --force`).
+# Cadence runners (.bat/.sh) are GENERATED artifacts, baked at arm time by the
+# cadence emitters. They hard-code paths/payload config and are NOT regenerated
+# when the himmel code changes. So an operator who armed BEFORE a runner-format
+# change keeps firing stale runners with no nudge (this is exactly what bit
+# HIMMEL-575: the --settings injection only took effect after a manual
+# `arm --force`).
 #
-# This lib is the single source of truth: the WRITER (pipeline-cadence.sh) stamps
+# This lib is the single source of truth: WRITERS stamp
 # CADENCE_RUNNER_FORMAT_VERSION into every runner at arm time, and the READERS
-# (himmel-doctor C8, himmel-update post-pull nudge) probe the stamp to detect a
-# stale armed cadence and point the operator at `/pipeline-cadence arm --force`.
+# (himmel-doctor C8, himmel-update post-pull nudge) probe the stamp to detect
+# stale armed cadences and point the operator at the matching `arm --force`.
 #
 # Sourced, not executed. bash 3.2-safe; no side effects.
 
@@ -33,22 +32,50 @@ CADENCE_RUNNER_FORMAT_VERSION=2
 # (.bat: `rem <marker> N`; .sh: `# <marker> N`).
 CADENCE_FORMAT_MARKER="himmel-cadence-runner-format:"
 
+# Basename registry for generated cadence runners. Keep explicit: a stray
+# foreign *.bat/*.sh in a runner dir must not poison the staleness probe.
+# shellcheck disable=SC2034  # consumed by cadence_runner_stamp callers/tests
+CADENCE_RUNNER_BASENAMES="pipeline-harvest pipeline-synthesize pipeline-health codex-sweep graphmap-luna graphmap-himmel"
+
+# cadence_user_home
+# The runner homes the EMITTERS write under key off resolve_user_home
+# (HIMMEL-645: on Windows Git-Bash $HOME can be the MSYS home while
+# ~/.claude lives under the Windows profile — prefer USERPROFILE via
+# cygpath). READERS must resolve the same way or they probe an empty MSYS
+# dir and report "no armed cadence" on exactly the machines the Windows-only
+# codex-sweep cadence runs on (HIMMEL-969 codex-adv finding). Same body as
+# the emitters' resolve_user_home; kept here so the readers share one copy.
+cadence_user_home() {
+    if [ -n "${USERPROFILE:-}" ] && command -v cygpath >/dev/null 2>&1; then
+        cygpath -u "$USERPROFILE" 2>/dev/null || printf '%s' "$USERPROFILE"
+    else
+        printf '%s' "${HOME:-${USERPROFILE:-/tmp}}"
+    fi
+}
+
 # cadence_runner_stamp <bat_dir>
-# Echo the format version stamped in the runners under <bat_dir> (0 when runners
-# exist but carry no stamp — i.e. armed before HIMMEL-588). Return:
+# Echo the MINIMUM format version stamped across the runners under <bat_dir>
+# (an unstamped runner reads as 0 — i.e. armed before HIMMEL-588). Minimum,
+# not first-found: a multi-runner re-arm interrupted between writes leaves a
+# mixed set, and one current runner must not mask a stale sibling
+# (HIMMEL-969 codex-adv finding). Return:
 #   0 — at least one runner present (version echoed on stdout)
 #   1 — no runners present (cadence not armed via this dir)
 cadence_runner_stamp() {
-    local dir="$1" f ver
-    for f in "$dir"/pipeline-harvest.bat "$dir"/pipeline-synthesize.bat \
-             "$dir"/pipeline-health.bat "$dir"/pipeline-harvest.sh \
-             "$dir"/pipeline-synthesize.sh "$dir"/pipeline-health.sh; do
-        [ -f "$f" ] || continue
-        ver="$(grep -oE "${CADENCE_FORMAT_MARKER}[[:space:]]*[0-9]+" "$f" 2>/dev/null \
-            | head -1 | grep -oE '[0-9]+$' || true)"
-        [ -n "$ver" ] || ver=0
-        printf '%s' "$ver"
-        return 0
+    local dir="$1" name ext f ver min=""
+    for name in $CADENCE_RUNNER_BASENAMES; do
+        for ext in bat sh; do
+            f="$dir/$name.$ext"
+            [ -f "$f" ] || continue
+            ver="$(grep -oE "${CADENCE_FORMAT_MARKER}[[:space:]]*[0-9]+" "$f" 2>/dev/null \
+                | head -1 | grep -oE '[0-9]+$' || true)"
+            [ -n "$ver" ] || ver=0
+            if [ -z "$min" ] || [ "$ver" -lt "$min" ]; then
+                min="$ver"
+            fi
+        done
     done
-    return 1
+    [ -n "$min" ] || return 1
+    printf '%s' "$min"
+    return 0
 }

--- a/scripts/test-himmel-doctor.sh
+++ b/scripts/test-himmel-doctor.sh
@@ -6,6 +6,8 @@ set -uo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 DOC="$REPO_ROOT/scripts/himmel-doctor.sh"
 [ -f "$DOC" ] || { echo "FAIL: $DOC not found"; exit 1; }
+CADENCE_VER="$(sed -n 's/^CADENCE_RUNNER_FORMAT_VERSION=//p' "$REPO_ROOT/scripts/lib/cadence-format.sh" | head -1)"
+STALE_CADENCE_VER=$((CADENCE_VER - 1))
 
 # Hermeticity: never let an inherited LUNA_VAULT_PATH point C3 at the operator's
 # real vault (HOME is redirected per-case, but C3 probes $LUNA_VAULT_PATH first).
@@ -14,6 +16,13 @@ export LUNA_VAULT_PATH=""
 # Hermeticity: C14 reads OLLAMA_NO_CLOUD from the live env — never let an
 # inherited value from the launching shell leak into the default test runs.
 unset OLLAMA_NO_CLOUD
+
+# Hermeticity (HIMMEL-969): C8's runner-home defaults resolve via
+# cadence_user_home (USERPROFILE via cygpath on Windows) — per-case HOME
+# redirection does NOT cover that, so pin all three seams to empty dirs
+# globally; C8 cases override them per-case.
+C8_EMPTY="$(mktemp -d)"
+export PIPELINE_BAT_DIR="$C8_EMPTY/pipeline" SWEEP_BAT_DIR="$C8_EMPTY/sweep" GRAPHMAP_BAT_DIR="$C8_EMPTY/graphmap"
 
 failures=0
 pass() { printf '  PASS  %s\n' "$1"; }
@@ -350,32 +359,59 @@ if [ "$_static_fail" -eq 0 ]; then
     pass "C7 STATIC: no destructive verbs in check_c7 body"
 fi
 
-# ── C8: stale pipeline-cadence runner detection (HIMMEL-588) ──────────────────
+# ── C8: stale cadence runner detection (HIMMEL-588/HIMMEL-969) ───────────────
 echo "== C8: no armed cadence runners -> OK C8-cadence =="
 t="$(mktemp -d)"; mkdir -p "$t/claude"; write_settings "$t/claude" "$WRAPPER"
-out="$(RESOLVE_NODE_PROBE_DIRS="$FAKENODE" PIPELINE_BAT_DIR="$t/cadence-empty" \
+out="$(RESOLVE_NODE_PROBE_DIRS="$FAKENODE" PIPELINE_BAT_DIR="$t/pipeline-empty" \
+    SWEEP_BAT_DIR="$t/sweep-empty" GRAPHMAP_BAT_DIR="$t/graphmap-empty" \
     DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" \
     bash "$DOC" --no-color 2>&1)"
-if printf '%s' "$out" | grep -q 'OK   C8-cadence'; then pass "C8 -> OK (no runners)"; else fail "C8 -> $(printf '%s' "$out" | grep C8)"; fi
+if printf '%s' "$out" | grep -q 'OK   C8-cadence: no armed cadence runners (skipped)'; then pass "C8 -> OK (no runners)"; else fail "C8 -> $(printf '%s' "$out" | grep C8)"; fi
 rm -rf "$t"
 
-echo "== C8: stale runner (no format stamp) -> WARN C8-cadence =="
-t="$(mktemp -d)"; mkdir -p "$t/claude" "$t/cadence"; write_settings "$t/claude" "$WRAPPER"
-# A runner with NO format marker simulates a cadence armed before HIMMEL-588.
-printf '#!/bin/sh\necho old runner\n' > "$t/cadence/pipeline-harvest.sh"
-out="$(RESOLVE_NODE_PROBE_DIRS="$FAKENODE" PIPELINE_BAT_DIR="$t/cadence" \
+echo "== C8: stale codex-sweep runner -> WARN + codex re-arm hint =="
+t="$(mktemp -d)"; mkdir -p "$t/claude" "$t/sweep"; write_settings "$t/claude" "$WRAPPER"
+printf 'rem himmel-cadence-runner-format: %s\r\n' "$STALE_CADENCE_VER" > "$t/sweep/codex-sweep.bat"
+out="$(RESOLVE_NODE_PROBE_DIRS="$FAKENODE" PIPELINE_BAT_DIR="$t/pipeline-empty" \
+    SWEEP_BAT_DIR="$t/sweep" GRAPHMAP_BAT_DIR="$t/graphmap-empty" \
     DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" \
     bash "$DOC" --no-color 2>&1)"
-if printf '%s' "$out" | grep -q 'WARN C8-cadence'; then pass "C8 -> WARN (stale runner)"; else fail "C8 -> $(printf '%s' "$out" | grep C8)"; fi
+if printf '%s' "$out" | grep -q 'WARN C8-cadence: codex-sweep-cadence runners are stale' \
+    && printf '%s' "$out" | grep -q 'bash scripts/cleanup/codex-sweep-cadence.sh arm --force'; then
+    pass "C8 -> WARN (stale codex-sweep runner)"
+else
+    fail "C8 -> $(printf '%s' "$out" | grep C8)"
+fi
 rm -rf "$t"
 
-echo "== C8: current runner (stamped) -> OK C8-cadence =="
-t="$(mktemp -d)"; mkdir -p "$t/claude" "$t/cadence"; write_settings "$t/claude" "$WRAPPER"
-printf '#!/bin/sh\n# himmel-cadence-runner-format: 2\necho current runner\n' > "$t/cadence/pipeline-harvest.sh"
-out="$(RESOLVE_NODE_PROBE_DIRS="$FAKENODE" PIPELINE_BAT_DIR="$t/cadence" \
+echo "== C8: stale graphmap runner -> WARN + graphmap re-arm hint =="
+t="$(mktemp -d)"; mkdir -p "$t/claude" "$t/graphmap"; write_settings "$t/claude" "$WRAPPER"
+printf '#!/bin/sh\n# himmel-cadence-runner-format: %s\necho old graphmap\n' "$STALE_CADENCE_VER" > "$t/graphmap/graphmap-luna.sh"
+out="$(RESOLVE_NODE_PROBE_DIRS="$FAKENODE" PIPELINE_BAT_DIR="$t/pipeline-empty" \
+    SWEEP_BAT_DIR="$t/sweep-empty" GRAPHMAP_BAT_DIR="$t/graphmap" \
     DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" \
     bash "$DOC" --no-color 2>&1)"
-if printf '%s' "$out" | grep -q 'OK   C8-cadence' && printf '%s' "$out" | grep -q 'current'; then pass "C8 -> OK (current runner)"; else fail "C8 -> $(printf '%s' "$out" | grep C8)"; fi
+if printf '%s' "$out" | grep -q 'WARN C8-cadence: graphmap-cadence runners are stale' \
+    && printf '%s' "$out" | grep -q 'bash scripts/luna/graphmap-cadence.sh arm --force'; then
+    pass "C8 -> WARN (stale graphmap runner)"
+else
+    fail "C8 -> $(printf '%s' "$out" | grep C8)"
+fi
+rm -rf "$t"
+
+echo "== C8: pipeline-only current runner -> OK, no false nudges =="
+t="$(mktemp -d)"; mkdir -p "$t/claude" "$t/pipeline"; write_settings "$t/claude" "$WRAPPER"
+printf '#!/bin/sh\n# himmel-cadence-runner-format: %s\necho current runner\n' "$CADENCE_VER" > "$t/pipeline/pipeline-harvest.sh"
+out="$(RESOLVE_NODE_PROBE_DIRS="$FAKENODE" PIPELINE_BAT_DIR="$t/pipeline" \
+    SWEEP_BAT_DIR="$t/sweep-empty" GRAPHMAP_BAT_DIR="$t/graphmap-empty" \
+    DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" \
+    bash "$DOC" --no-color 2>&1)"
+if printf '%s' "$out" | grep -q 'OK   C8-cadence: pipeline-cadence runners current' \
+    && ! printf '%s' "$out" | grep -q 'WARN C8-cadence'; then
+    pass "C8 -> OK (pipeline-only current runner)"
+else
+    fail "C8 -> $(printf '%s' "$out" | grep C8)"
+fi
 rm -rf "$t"
 
 echo "== C9 linux at+atd live -> OK =="

--- a/scripts/test-himmel-update-hermes.sh
+++ b/scripts/test-himmel-update-hermes.sh
@@ -45,32 +45,84 @@ git -C "$tmp/direct" remote add origin https://github.com/NousResearch/hermes-ag
 out=$(HERMES_HOME="$tmp/direct" update_hermes check 2>&1)
 check "direct checkout tolerated" "could not reach origin|hermes is current|update available" "$out"
 
-# ── report_cadence_stale() — stale pipeline-cadence runner nudge (HIMMEL-588) ──
-# Same lib seam; PIPELINE_BAT_DIR points at a fixture runner dir.
+# ── report_cadence_stale() — stale cadence runner nudge (HIMMEL-588/969) ─────
+# Same lib seams; *_BAT_DIR point at fixture runner dirs.
 
-# Case 5: no runners present → silent no-op (cadence not armed via this dir).
-out=$(PIPELINE_BAT_DIR="$tmp/cad-empty" report_cadence_stale 2>&1)
+# Case 5: no runners present anywhere → silent no-op (cadences not armed).
+out=$(PIPELINE_BAT_DIR="$tmp/cad-empty" SWEEP_BAT_DIR="$tmp/sweep-empty" \
+  GRAPHMAP_BAT_DIR="$tmp/graphmap-empty" report_cadence_stale 2>&1)
 if [ -z "$out" ]; then echo "ok: cadence absent → silent"; else echo "FAIL: cadence absent not silent"; printf '%s\n' "$out"; fail=1; fi
 
-# Case 6: runner with no format stamp (armed before HIMMEL-588) → STALE nudge.
+# Case 6: codex-sweep.bat stamped current → shared probe returns its version.
+mkdir -p "$tmp/cad-codex-current"
+printf 'rem himmel-cadence-runner-format: %s\r\n' "$CADENCE_RUNNER_FORMAT_VERSION" \
+  > "$tmp/cad-codex-current/codex-sweep.bat"
+ver=$(cadence_runner_stamp "$tmp/cad-codex-current")
+if [ "$ver" = "$CADENCE_RUNNER_FORMAT_VERSION" ]; then echo "ok: codex-sweep stamp probed"; else echo "FAIL: codex-sweep stamp probe got '$ver'"; fail=1; fi
+
+# Case 7: pipeline runner with no format stamp (armed before HIMMEL-588) →
+# STALE nudge with pipeline re-arm hint.
 mkdir -p "$tmp/cad-stale"
 printf '#!/bin/sh\necho old\n' > "$tmp/cad-stale/pipeline-harvest.sh"
-out=$(PIPELINE_BAT_DIR="$tmp/cad-stale" report_cadence_stale 2>&1)
-check "stale cadence nudged" "runners are STALE|arm --force" "$out"
+out=$(PIPELINE_BAT_DIR="$tmp/cad-stale" SWEEP_BAT_DIR="$tmp/sweep-empty" \
+  GRAPHMAP_BAT_DIR="$tmp/graphmap-empty" report_cadence_stale 2>&1)
+check "stale pipeline cadence nudged (message)" "pipeline-cadence runners are STALE" "$out"
+check "stale pipeline cadence nudged (rearm hint)" "bash scripts/luna/pipeline-cadence.sh arm --force" "$out"
 
-# Case 7: runner stamped at the current version → no nudge.
+# Case 8: codex-sweep.bat stamped stale → STALE nudge with codex re-arm hint.
+mkdir -p "$tmp/cad-codex-stale"
+printf 'rem himmel-cadence-runner-format: %s\r\n' "$((CADENCE_RUNNER_FORMAT_VERSION - 1))" \
+  > "$tmp/cad-codex-stale/codex-sweep.bat"
+out=$(PIPELINE_BAT_DIR="$tmp/cad-empty" SWEEP_BAT_DIR="$tmp/cad-codex-stale" \
+  GRAPHMAP_BAT_DIR="$tmp/graphmap-empty" report_cadence_stale 2>&1)
+check "stale codex-sweep cadence nudged (message)" "codex-sweep-cadence runners are STALE" "$out"
+check "stale codex-sweep cadence nudged (rearm hint)" "bash scripts/cleanup/codex-sweep-cadence.sh arm --force" "$out"
+
+# Case 9: graphmap runner stamped stale → STALE nudge with graphmap re-arm hint.
+mkdir -p "$tmp/cad-graphmap-stale"
+printf '#!/bin/sh\n# himmel-cadence-runner-format: %s\necho old\n' "$((CADENCE_RUNNER_FORMAT_VERSION - 1))" \
+  > "$tmp/cad-graphmap-stale/graphmap-himmel.sh"
+out=$(PIPELINE_BAT_DIR="$tmp/cad-empty" SWEEP_BAT_DIR="$tmp/sweep-empty" \
+  GRAPHMAP_BAT_DIR="$tmp/cad-graphmap-stale" report_cadence_stale 2>&1)
+check "stale graphmap cadence nudged (message)" "graphmap-cadence runners are STALE" "$out"
+check "stale graphmap cadence nudged (rearm hint)" "bash scripts/luna/graphmap-cadence.sh arm --force" "$out"
+
+# Case 10: pipeline-only runner stamped at the current version → no nudge and
+# empty codex/graphmap dirs do not false-positive.
 mkdir -p "$tmp/cad-current"
 printf '#!/bin/sh\n# himmel-cadence-runner-format: %s\necho cur\n' "$CADENCE_RUNNER_FORMAT_VERSION" \
     > "$tmp/cad-current/pipeline-harvest.sh"
-out=$(PIPELINE_BAT_DIR="$tmp/cad-current" report_cadence_stale 2>&1)
+out=$(PIPELINE_BAT_DIR="$tmp/cad-current" SWEEP_BAT_DIR="$tmp/sweep-empty" \
+  GRAPHMAP_BAT_DIR="$tmp/graphmap-empty" report_cadence_stale 2>&1)
 if [ -z "$out" ]; then echo "ok: current cadence → silent"; else echo "FAIL: current cadence wrongly nudged"; printf '%s\n' "$out"; fail=1; fi
 
-# Case 8: malformed marker (present but no version number) → safe fallback to
+# Case 11: malformed marker (present but no version number) → safe fallback to
 # version 0 → treated as stale (nudge), never a crash under set -e.
 mkdir -p "$tmp/cad-malformed"
 printf '#!/bin/sh\n# himmel-cadence-runner-format:\necho bad\n' > "$tmp/cad-malformed/pipeline-harvest.sh"
-out=$(PIPELINE_BAT_DIR="$tmp/cad-malformed" report_cadence_stale 2>&1)
-check "malformed stamp → stale fallback" "runners are STALE|arm --force" "$out"
+out=$(PIPELINE_BAT_DIR="$tmp/cad-malformed" SWEEP_BAT_DIR="$tmp/sweep-empty" \
+  GRAPHMAP_BAT_DIR="$tmp/graphmap-empty" report_cadence_stale 2>&1)
+check "malformed stamp → stale fallback (message)" "pipeline-cadence runners are STALE" "$out"
+check "malformed stamp → stale fallback (rearm hint)" "bash scripts/luna/pipeline-cadence.sh arm --force" "$out"
+
+# Case 12: MIXED runner versions in one dir → probe returns the MINIMUM (one
+# current runner must not mask a stale sibling — interrupted re-arm).
+mkdir -p "$tmp/cad-mixed"
+printf '#!/bin/sh\n# himmel-cadence-runner-format: %s\necho cur\n' "$CADENCE_RUNNER_FORMAT_VERSION" \
+  > "$tmp/cad-mixed/pipeline-harvest.sh"
+printf '#!/bin/sh\n# himmel-cadence-runner-format: %s\necho old\n' "$((CADENCE_RUNNER_FORMAT_VERSION - 1))" \
+  > "$tmp/cad-mixed/pipeline-health.sh"
+ver=$(cadence_runner_stamp "$tmp/cad-mixed")
+if [ "$ver" = "$((CADENCE_RUNNER_FORMAT_VERSION - 1))" ]; then echo "ok: mixed versions → minimum wins"; else echo "FAIL: mixed-version probe got '$ver'"; fail=1; fi
+out=$(PIPELINE_BAT_DIR="$tmp/cad-mixed" SWEEP_BAT_DIR="$tmp/sweep-empty" \
+  GRAPHMAP_BAT_DIR="$tmp/graphmap-empty" report_cadence_stale 2>&1)
+check "mixed-version cadence nudged" "pipeline-cadence runners are STALE" "$out"
+
+# Case 13: cadence_user_home — with USERPROFILE unset it echoes $HOME verbatim
+# (the POSIX leg; the Windows USERPROFILE/cygpath leg is exercised by real
+# Git-Bash runs where the two homes coincide).
+uh=$(USERPROFILE='' HOME="$tmp/fake-home" cadence_user_home)
+if [ "$uh" = "$tmp/fake-home" ]; then echo "ok: cadence_user_home falls back to HOME"; else echo "FAIL: cadence_user_home got '$uh'"; fail=1; fi
 
 if [ "$fail" -eq 0 ]; then
   echo "PASS: himmel-update hermes smoke test"


### PR DESCRIPTION

## Summary
- `cadence_runner_stamp()` enumerated only `pipeline-*` basenames, and
both stamp readers (doctor C8, himmel-update post-pull nudge) probed
only the pipeline runner home — a stale-format armed **codex-sweep**
cadence (the filed gap) or **graphmap** cadence (same class, found while
scoping) never got a staleness nudge.
- Fix: explicit basename registry in `cadence-format.sh` (not a `*.bat`
glob — stray files must not poison the probe); both readers loop all
three runner homes via the emitters' env seams, each stale cadence
pointed at its own `arm --force`. Emitters untouched.
- CR round hardening (codex-adv findings, verified live):
- **Emitter-parity home resolution**: readers now resolve defaults via
shared `cadence_user_home()` (USERPROFILE-via-cygpath before $HOME,
HIMMEL-645) — a bare $HOME probed the wrong MSYS dir on diverged Windows
Git-Bash, worst for the Windows-only codex-sweep cadence.
- **Min-version stamp semantics**: one current runner no longer masks a
stale sibling after an interrupted multi-runner re-arm.
- Verified real + deferred (pre-existing HIMMEL-588 delivery pattern,
noted on ticket): himmel-update sources the lib before `git pull`, so
the run that DELIVERS a probe change still checks with pre-pull
definitions; coverage takes effect the next run.

## CR
Round 1: codex-adv-2/3 + lagunaor-3 agreed → fixed; codex-adv-1 verified
real → deferred (pre-existing, ticket comment); lagunaor-1 disproved
(green positive asserts contradict the separator claim); coderabbit-2
deferred (extraction predates PR, moved verbatim).
Round 2: panel 0/0/0 + CodeRabbit 0 findings, both critics + CodeRabbit
ok (codex-adv timed out, fail-open).

## Tests
- `test-himmel-doctor.sh` — C8 cases: stale codex-sweep (CRLF .bat),
stale graphmap, pipeline-only no-false-nudge, none-armed skip; harness
pins the three runner-home seams globally (USERPROFILE isn't covered by
HOME redirection). ALL PASS.
- `test-himmel-update-hermes.sh` — cases 5–13 incl.
mixed-version-minimum + cadence_user_home fallback. PASS.
- Both suites green on Windows Git Bash + WSL Linux; shellcheck clean.

Impl: WSL codex lane (gpt-5.5), parent fire-time review + CR
adjudication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai
-->
## Summary by CodeRabbit

* **New Features**
* Health checks and update guidance now scan and report staleness for
pipeline, codex-sweep, and graphmap cadence runners.
* Stale warnings are emitted per runner type with the matching `arm
--force` re-arm hint, and non-stale runs are reported as skipped when
appropriate.
* Runner home/path detection is now consistent across supported
environments.

* **Bug Fixes**
* Directories containing mixed runner versions now correctly treat the
oldest format as stale.
* Malformed cadence markers now safely fall back to treating runners as
stale.

* **Tests**
* Expanded the C8 and Hermes smoke tests to cover the new multi-runner
stale scenarios and path fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of outdated cadence runners across pipeline, sweep, and graph workflows.
  * Added clearer guidance for re-arming runners that use an older format.
  * Correctly handles mixed, missing, or malformed runner version markers.
  * Improved runner discovery across supported environments.

* **Tests**
  * Expanded coverage for current, stale, missing, and mixed-version runners across all supported cadence types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->