### PR TITLE
fix(setup): graphify install carries the mcp dep; WSL shares the Windows graph store

### DIFF
--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -921,6 +921,19 @@ claude mcp add --scope user graphify -- "$(uv tool dir --bin)/graphify-mcp"
 (PowerShell:
 `claude mcp add --scope user graphify -- "$(uv tool dir --bin)\graphify-mcp.exe"`.)
 
+Claude Code is the only agent graphify needs — the MCP registration above is
+the whole integration (no codex/other-CLI prerequisite).
+
+**Windows + WSL on one machine share ONE graph store.** Graph extraction is
+LLM-backed (real spend), so the WSL side must not regenerate what the Windows
+side already extracted. The store (`~/.graphify/` — plain JSON, no
+sqlite/WAL hazard) is shared automatically: `graphify_install` on WSL
+symlinks `~/.graphify` at the Windows user's store — only when that Windows
+store exists (manual: `bash scripts/lib/graphify-bin.sh share-store`). Both
+sides then read AND contribute to the same graphs. A WSL store that already
+has content is never replaced or auto-merged into the Windows one — how to
+merge pre-existing WSL data is your call.
+
 Graph refresh stays lean-invoke (`graphify <corpus-copy> --update`), never
 a hook; extraction backends are governed by the egress matrix — see the
 graphify section in `CLAUDE.md`.

--- a/scripts/lib/graphify-bin.sh
+++ b/scripts/lib/graphify-bin.sh
@@ -57,8 +57,13 @@ _graphify_bin_name() { printf '%s\n' "graphify"; }
 # Prints the manual install recipe (best-effort documentation text embedded
 # in WARN messages -- NOT eval'd elsewhere; graphify_install() below runs the
 # equivalent command directly).
+# `--with mcp` (HIMMEL-996): the fork's pyproject does not declare the `mcp`
+# python package as a dependency, but the graphify-mcp entrypoint imports it
+# at startup -- without this the CLI works and the MCP server crashes on
+# every fresh install (hit on all 3 stations in the HIMMEL-985 parity audit).
+# Drop the flag once the fork declares the dependency itself.
 graphify_install_hint() {
-  printf '%s\n' "uv tool install --from $(_graphify_pinned_source) $(_graphify_pypi_name)"
+  printf '%s\n' "uv tool install --with mcp --from $(_graphify_pinned_source) $(_graphify_pypi_name)"
 }
 
 # Presence check ONLY -- does not invoke the binary, so a real runtime error
@@ -145,6 +150,19 @@ graphify_install() {
         else
           echo "  graphify already installed (source=foreign) -- adopting the existing install, not installing over it."
         fi
+        # Adopt is non-invasive by contract -- WARN (never reinstall) when the
+        # adopted install carries the HIMMEL-996 missing-mcp-dep defect, and
+        # say so honestly when the layout cannot be validated at all.
+        case "$(_graphify_mcp_import_ok; echo $?)" in
+          1)
+            echo "  WARNING: the adopted graphify install cannot import the 'mcp' package -- graphify-mcp will crash at startup." >&2
+            echo "  Fix with: $(graphify_install_hint) (add --force to replace the existing install)" >&2
+            ;;
+          2)
+            echo "  NOTE: could not validate the adopted install's mcp import (unrecognized install layout) -- if graphify-mcp crashes at startup, reinstall: $(graphify_install_hint)"
+            ;;
+        esac
+        graphify_wsl_share_store
         return 0
       fi
       # CR-r2: install metadata exists but the binary does not resolve
@@ -164,18 +182,100 @@ graphify_install() {
     echo "  uv not found -- cannot install graphify." >&2
     return 1
   fi
-  if ! uv tool install --from "$(_graphify_pinned_source)" "$(_graphify_pypi_name)"; then
+  if ! uv tool install --with mcp --from "$(_graphify_pinned_source)" "$(_graphify_pypi_name)"; then
     echo "  ERROR: graphify install failed." >&2
     return 1
   fi
 
   if has_graphify; then
+    case "$(_graphify_mcp_import_ok; echo $?)" in
+      1)
+        echo "  WARNING: graphify installed but its MCP entrypoint cannot import the 'mcp' package." >&2
+        echo "  graphify-mcp will crash at startup -- reinstall manually: $(graphify_install_hint)" >&2
+        return 1
+        ;;
+      2)
+        echo "  NOTE: could not validate the mcp import (unrecognized install layout) -- if graphify-mcp crashes at startup, reinstall: $(graphify_install_hint)"
+        ;;
+    esac
     echo "  graphify installed and verified (source=himmel-fork)."
+    graphify_wsl_share_store
     return 0
   fi
   echo "  WARNING: graphify installed but '$(_graphify_bin_name)' is still not resolvable on PATH." >&2
   echo "  uv drops its shims in the uv tool bin dir -- check it is on PATH (uv tool update-shell)." >&2
   return 1
+}
+
+# Probes whether the environment behind the graphify-mcp ENTRYPOINT can
+# import the `mcp` package (its startup dependency -- HIMMEL-996).
+# Interpreter resolution, most-specific first (CR: a PATH-based foreign
+# install -- pip/pipx/brew -- must probe ITS interpreter, not the uv venv):
+#   1. the resolved graphify-mcp console script's shebang python (posix;
+#      Windows .exe launchers carry no readable shebang -- falls through);
+#   2. the uv tool venv's python (bin/ posix, Scripts/ windows layouts).
+# rc 0 = import OK; rc 1 = import FAILS (the known missing-dep defect);
+# rc 2 = no interpreter resolvable -- UNVALIDATED, callers must say so
+# rather than treat it as success.
+_graphify_mcp_import_ok() {
+  local py="" mcp_bin shebang tool_venv c
+  mcp_bin="$(command -v graphify-mcp 2>/dev/null)"
+  if [ -n "$mcp_bin" ] && [ -f "$mcp_bin" ]; then
+    shebang="$(head -1 "$mcp_bin" 2>/dev/null)"
+    case "$shebang" in
+      '#!'*python*)
+        py="${shebang#\#!}"
+        case "$py" in
+          */env\ *) py="$(command -v "${py##* }" 2>/dev/null)" ;;
+          *)        py="${py%% *}" ;;
+        esac
+        [ -n "$py" ] && [ -f "$py" ] || py=""
+        ;;
+    esac
+  fi
+  if [ -z "$py" ]; then
+    tool_venv="$(_graphify_uv_tool_dir)/$(_graphify_pypi_name)"
+    for c in "$tool_venv/bin/python" "$tool_venv/Scripts/python.exe"; do
+      [ -f "$c" ] && { py="$c"; break; }
+    done
+  fi
+  [ -n "$py" ] || return 2
+  "$py" -c 'import mcp' >/dev/null 2>&1 || return 1
+  return 0
+}
+
+# On WSL, share the WINDOWS-side global graph store instead of regenerating:
+# graph extraction is LLM-backed (real spend), and the store is plain JSON
+# (~/.graphify/global-graph.json + manifest -- no sqlite/WAL hazard, so
+# sharing over /mnt/c is safe, unlike .tokensave). Symlinks ~/.graphify at
+# the Windows user's store when: running under WSL, the Windows store
+# exists, and ~/.graphify is absent or an empty directory. Never touches an
+# existing populated ~/.graphify (merge is the operator's call). Best-effort
+# by contract: always returns 0.
+graphify_wsl_share_store() {
+  grep -qi microsoft /proc/version 2>/dev/null || return 0
+  command -v wslpath >/dev/null 2>&1 || return 0
+  command -v cmd.exe >/dev/null 2>&1 || return 0
+  # Cheap check first -- skip the costly cmd.exe interop once already linked.
+  [ -L "$HOME/.graphify" ] && return 0
+  local win_home win_store
+  # cmd.exe interop warns (and can fail) from a linux-fs cwd -- run it from /mnt/c.
+  win_home="$(cd /mnt/c 2>/dev/null && cmd.exe /c 'echo %USERPROFILE%' 2>/dev/null | tr -d '\r')"
+  [ -n "$win_home" ] || return 0
+  win_store="$(wslpath -u "$win_home" 2>/dev/null)/.graphify"
+  [ -d "$win_store" ] || return 0
+  if [ -e "$HOME/.graphify" ]; then
+    if [ -d "$HOME/.graphify" ] && [ -z "$(ls -A "$HOME/.graphify" 2>/dev/null)" ]; then
+      rmdir "$HOME/.graphify" 2>/dev/null || return 0
+    else
+      echo "  graphify store: ~/.graphify already has content -- NOT replacing it with the shared Windows store (merge manually if desired)."
+      return 0
+    fi
+  fi
+  if ln -s "$win_store" "$HOME/.graphify" 2>/dev/null; then
+    echo "  graphify store: linked ~/.graphify -> $win_store (shared Win+WSL store; both sides contribute, nothing regenerates)."
+  fi
+  return 0
 }
 
 # CLI entry -- only when EXECUTED (not sourced). Lets the pwsh mirrors
@@ -186,6 +286,7 @@ if [ "${BASH_SOURCE[0]:-}" = "${0:-}" ]; then
   case "${1:-}" in
     install) graphify_install ;;
     source)  graphify_source ;;
-    *) echo "Usage: bash scripts/lib/graphify-bin.sh install|source" >&2; exit 2 ;;
+    share-store) graphify_wsl_share_store ;;
+    *) echo "Usage: bash scripts/lib/graphify-bin.sh install|source|share-store" >&2; exit 2 ;;
   esac
 fi

--- a/scripts/lib/test-graphify-bin.sh
+++ b/scripts/lib/test-graphify-bin.sh
@@ -64,6 +64,8 @@ assert "hint pins a full commit SHA (CR-r3), not a movable ref" grep -qE '@[0-9a
 assert "hint does NOT install from the mutable himmel-main branch" \
   bash -c '! grep -q "@himmel-main" <<<"$1"' _ "$hint"
 assert "hint mentions the graphifyy package" grep -q 'graphifyy$' <<<"$hint"
+assert "hint carries --with mcp (HIMMEL-996: fork pyproject lacks the mcp dep)" \
+  grep -q -- '--with mcp' <<<"$hint"
 
 echo "[test-graphify-bin] pin policy (CR-r3): the configured ref IS a full 40-hex commit SHA"
 # Tags/branches are force-movable; only a commit SHA is content-addressed.
@@ -108,11 +110,17 @@ fi
 if [ "$1" = "tool" ] && [ "$2" = "install" ]; then
   [ "${STUB_UV_INSTALL_RC:-0}" -eq 0 ] || exit "${STUB_UV_INSTALL_RC}"
   mkdir -p "${UV_TOOL_DIR:?}/graphifyy"
-  # $3=--from $4=<git+url@ref> $5=graphifyy — matches graphify_install()'s
-  # exact argv shape. Write the receipt in uv's REAL serialization (git and
-  # rev as SEPARATE keys, no combined git+url@ref literal) so the provenance
-  # probes are exercised against what a real install leaves behind (CR-2).
-  src="${4#git+}"
+  # Scan argv for the --from value (HIMMEL-996 added `--with mcp` ahead of it,
+  # so positional $4 no longer holds the source). Write the receipt in uv's
+  # REAL serialization (git and rev as SEPARATE keys, no combined git+url@ref
+  # literal) so the provenance probes are exercised against what a real
+  # install leaves behind (CR-2).
+  src=""; prev=""
+  for a in "$@"; do
+    [ "$prev" = "--from" ] && src="$a"
+    prev="$a"
+  done
+  src="${src#git+}"
   printf 'requirements = [{ name = "graphifyy", git = "%s", rev = "%s" }]\n' \
     "${src%@*}" "${src##*@}" > "${UV_TOOL_DIR}/graphifyy/uv-receipt.toml"
   printf 'graphifyy v0.0.0-test\n' >> "${UV_LIST_FILE:?}"
@@ -141,6 +149,8 @@ out=$(HOME="$fresh_home" PATH="$fresh_path" UV_TOOL_DIR="$fresh_tools" UV_LIST_F
       bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_install; echo "RC=$?"' 2>&1)
 assert "missing: rc 0" grep -q '^RC=0$' <<<"$out"
 assert "missing: exactly one uv tool install call" test "$(grep -c 'UV tool install' "$fresh_log")" -eq 1
+assert "missing: install argv carries --with mcp (HIMMEL-996)" \
+  grep -q 'UV tool install --with mcp --from' "$fresh_log"
 assert "missing: graphify shim landed on PATH" test -x "$fresh_bin/graphify"
 assert "missing: has_graphify true post-install" \
   env PATH="$fresh_path" HOME="$fresh_home" bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; has_graphify'
@@ -310,6 +320,40 @@ out=$(HOME="$nopath_home" PATH="$stub_dir/bin:$base_path" UV_TOOL_DIR="$nopath_t
 assert "unresolvable: install WAS attempted (one uv call)" test "$(grep -c 'UV tool install' "$nopath_log")" -eq 1
 assert "unresolvable: rc nonzero" grep -qv '^RC=0$' <<<"$out"
 assert "unresolvable: WARNs 'not resolvable on PATH'" grep -qi 'not resolvable on PATH' <<<"$out"
+
+echo "[test-graphify-bin] _graphify_mcp_import_ok probes the ENTRYPOINT's interpreter (HIMMEL-996)"
+# A console script's shebang python is the most-specific env (covers pip/
+# pipx foreign installs, not just the uv venv). Fake pythons: exit 0 = mcp
+# importable, exit 1 = the missing-dep defect. rc 2 = nothing resolvable.
+probe_dir="$tmpdir/mcp-probe"; mkdir -p "$probe_dir"
+cat > "$probe_dir/py-ok" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$probe_dir/py-fail" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$probe_dir/py-ok" "$probe_dir/py-fail"
+# HOME redirected: the venv-fallback probe path derives a default under
+# $HOME when uv is absent -- the real operator HOME must never leak in.
+probe_home="$tmpdir/probe-home"; mkdir -p "$probe_home"
+printf '#!%s/py-ok python\n' "$probe_dir" > "$probe_dir/graphify-mcp"
+chmod +x "$probe_dir/graphify-mcp"
+rc=0
+HOME="$probe_home" PATH="$probe_dir:$base_path" \
+  bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; _graphify_mcp_import_ok' || rc=$?
+assert "probe rc 0 when the shebang python imports mcp" test "$rc" -eq 0
+printf '#!%s/py-fail python\n' "$probe_dir" > "$probe_dir/graphify-mcp"
+rc=0
+HOME="$probe_home" PATH="$probe_dir:$base_path" \
+  bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; _graphify_mcp_import_ok' || rc=$?
+assert "probe rc 1 when the shebang python cannot import mcp" test "$rc" -eq 1
+rm -f "$probe_dir/graphify-mcp"
+rc=0
+HOME="$probe_home" PATH="$probe_dir:$base_path" \
+  bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; _graphify_mcp_import_ok' || rc=$?
+assert "probe rc 2 (unvalidated) when no interpreter is resolvable" test "$rc" -eq 2
 
 echo "[test-graphify-bin] consumer wiring — setup.sh/adopt.sh source graphify-bin.sh (HIMMEL-891)"
 repo_root="$(cd "$SCRIPT_DIR/../.." && pwd)"


### PR DESCRIPTION
uv tool install now passes --with mcp (fork pyproject omits the dep the graphify-mcp entrypoint imports - fresh installs crashed); post-install probe validates the entrypoint interpreter (shebang-first, uv-venv fallback, honest unvalidated note). New graphify_wsl_share_store (auto + share-store verb) links the WSL ~/.graphify at the Windows store - plain-JSON, both sides contribute, nothing regenerates. Docs: claude-only sufficiency + shared-store behavior. 52 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing Graphify with MCP enabled.
  * Added WSL graph-store sharing with the Windows store when safe.
  * Added a command for manually sharing the graph store.

* **Bug Fixes**
  * Added checks and warnings for missing MCP support during installation.
  * Improved handling of existing Graphify installations.

* **Documentation**
  * Documented Windows and WSL graph-store sharing rules and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->