### PR TITLE
feat(obs): [HIMMEL-921] flow-runs.jsonl collection substrate — append lib (bash+TS twins) + cadence/armed/vitals emitters (#1192)

### DIFF
--- a/scripts/cleanup/test-codex-sweep-cadence.sh
+++ b/scripts/cleanup/test-codex-sweep-cadence.sh
@@ -289,7 +289,7 @@ calls=$(cat "$STATE/calls.log" 2>/dev/null || echo MISSING)
 assert_contains "schtasks invoked with /create /tn HIMMEL-CodexOrphanSweep /xml" "/create /tn HIMMEL-CodexOrphanSweep /xml" "$calls"
 
 bat=$(cat "$BAT_DIR/codex-sweep.bat" 2>/dev/null || echo MISSING)
-assert_contains "bat stamps the format version (HIMMEL-588)" "himmel-cadence-runner-format: 2" "$bat"
+assert_contains "bat stamps the format version (HIMMEL-588)" "himmel-cadence-runner-format: 3" "$bat"
 assert_contains "bat fires sweep-codex-orphans.ps1 -Kill" "sweep-codex-orphans.ps1" "$bat"
 assert_contains "bat fires reap-mcp-fleet.ps1 -Kill" "reap-mcp-fleet.ps1" "$bat"
 assert_contains "bat passes -Kill to the sweep payload" "sweep-codex-orphans.ps1" "$bat"
@@ -481,7 +481,7 @@ fi
 probe=$(cat "$STATE/create-time-runner-probe.bat" 2>/dev/null || echo MISSING)
 assert_contains "create-time probe carries the full new runner content (sweep payload)" "sweep-codex-orphans.ps1" "$probe"
 assert_contains "create-time probe carries the full new runner content (reap payload)" "reap-mcp-fleet.ps1" "$probe"
-assert_contains "create-time probe carries the format-version stamp (proves COMPLETE content, not partial)" "himmel-cadence-runner-format: 2" "$probe"
+assert_contains "create-time probe carries the format-version stamp (proves COMPLETE content, not partial)" "himmel-cadence-runner-format: 3" "$probe"
 
 # Test T6: --dry-run touches nothing ------------------------------------------
 

--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -1027,6 +1027,7 @@ fi
 # composer renders both surfaces from one identity, so the scheduler row name
 # and the session/tab title can never disagree.
 SESSION_NAME=$(_compose_arm_name "$_ho_ticket" "$HANDOVER_PATH" title)
+FLOW_RUN_NOTE=$(_infer_slug "$HANDOVER_PATH")
 unset _ho_ticket _path_suffix _name_seg
 
 # Pre-trust the resolved cwd (HIMMEL-386) so the fired relaunch doesn't stall
@@ -1942,6 +1943,11 @@ _crontab_schedule() {
         q_curl=$(printf '%q' "$HEADROOM_CURL")
         tail="{ $q_curl -s -m 5 http://127.0.0.1:$HEADROOM_PROXY_PORT/livez >/dev/null 2>&1 || { $q_hb proxy --port $HEADROOM_PROXY_PORT >> $q_log 2>&1 & sleep 3; }; if $q_curl -s -m 5 http://127.0.0.1:$HEADROOM_PROXY_PORT/livez >/dev/null 2>&1; then echo \"\$(date) arm=$TASK_NAME mode=proxied\" >> $q_log; ANTHROPIC_BASE_URL=http://127.0.0.1:$HEADROOM_PROXY_PORT HEADROOM_OFFLINE=1 claude ${q_name}$q_prompt $q_channels; else echo \"\$(date) arm=$TASK_NAME mode=bare-fallback\" >> $q_log; claude ${q_name}$q_prompt $q_channels; fi; }"
     fi
+    local q_flow_lib q_task q_note
+    q_flow_lib=$(printf '%q' "$SCRIPT_DIR/../lib/flow-run-ledger.sh")
+    q_task=$(printf '%q' "$TASK_NAME")
+    q_note=$(printf '%q' "$FLOW_RUN_NOTE")
+    tail="{ _flow_run_id=\$($q_flow_lib --append-start armed-resume \"\" \"\" claude \"\" $q_task \"\" \"\$\$\" 2>/dev/null) || _flow_run_id=; _flow_rc=0; $tail || _flow_rc=\$?; _flow_outcome=\$($q_flow_lib --classify \"\$_flow_rc\" \"\" 2>/dev/null) || _flow_outcome=complete; test \"\$_flow_outcome\" != \"\" || _flow_outcome=complete; test \"\$_flow_run_id\" != \"\" && $q_flow_lib --append-end armed-resume \"\$_flow_run_id\" \"\" \"\$_flow_rc\" \"\$_flow_outcome\" \"\" $q_note >/dev/null 2>&1 || true; exit \"\$_flow_rc\"; }"
     local entry="$mm $hh * * * $self_clean cd $q_cwd && $tail # $TASK_NAME"
     if [ "$DRY_RUN" -eq 1 ]; then
         echo "DRY arm-resume: would add crontab entry:"
@@ -2099,6 +2105,12 @@ schedule_arm() {
             fi
             local bat_path_win claude_cmd_win="" resume_cwd_win=""
             local claude_cmd_posix="" _cyg_out="" _cyg_rest=""
+            local bash_posix
+            if ! bash_posix=$(command -v bash 2>/dev/null); then
+                echo "ERR arm-resume: 'bash' not on PATH at arm time" >&2
+                rm -f "$bat_path"
+                exit 2
+            fi
             if [ -n "$WSL_DISTRO" ]; then
                 # WSL owns both the executable lookup and cwd. Only the .bat
                 # path crosses through cygpath; the in-distro values must not.
@@ -2175,6 +2187,18 @@ schedule_arm() {
                 esac
                 wsl_launch="${wsl_command//%/%%}"
             fi
+            local bash_win flow_lib_m
+            if ! bash_win=$(cygpath -w "$bash_posix" 2>&1); then
+                echo "ERR arm-resume: cygpath -w failed for bash path: $bash_win" >&2
+                rm -f "$bat_path"
+                exit 4
+            fi
+            if ! flow_lib_m=$(cygpath -m "$SCRIPT_DIR/../lib/flow-run-ledger.sh" 2>&1); then
+                echo "ERR arm-resume: cygpath -m failed for flow-run-ledger.sh: $flow_lib_m" >&2
+                rm -f "$bat_path"
+                exit 4
+            fi
+
             # .bat content: escape CMD metacharacters in BOTH the prompt
             # AND the cd path. % & ^ < > | can inject commands at fire
             # time if a directory or handover path contains them. (Windows
@@ -2182,7 +2206,7 @@ schedule_arm() {
             # legal in directory names — and the prompt arg can carry
             # arbitrary text.) Same escape both places; bash assoc-array
             # would be cleaner but not worth the dep for two values.
-            local p="$RESUME_PROMPT" c="$resume_cwd_win"
+            local p="$RESUME_PROMPT" c="$resume_cwd_win" bw="$bash_win" fl="$flow_lib_m" fr_note="$FLOW_RUN_NOTE"
             p="${p//\"/\\\"}"   # escape "
             p="${p//%/%%}"      # double % for CMD literal
             p="${p//^/^^}"
@@ -2197,6 +2221,9 @@ schedule_arm() {
             c="${c//</^<}"
             c="${c//>/^>}"
             c="${c//|/^|}"
+            bw=$(_cmd_metachar_escape "$bw")
+            fl=$(_cmd_metachar_escape "$fl")
+            fr_note=$(_cmd_metachar_escape "$fr_note")
             # Optional --channels passthrough. Same CMD-metachar escape as
             # the prompt — the spec is operator-supplied (could carry % & ^).
             local ch=""
@@ -2286,6 +2313,20 @@ schedule_arm() {
             # TASK_NAME is sanitized to [:alnum:]_- (no CMD metachars).
             {
                 printf 'schtasks /delete /tn "%s" /f >nul 2>&1\r\n' "$TASK_NAME"
+                # Capture the run_id via a temp file, NOT `for /f` — for /f
+                # re-parses its backquoted command through cmd /c, whose
+                # quote-stripping mangles a command that STARTS with a quoted
+                # path and carries more quoted args (live-fire verified s52).
+                printf 'set "FLOW_RUN_ID="
+'
+                printf 'set "FLOW_RUN_TMP=%%TEMP%%low-run-%s.tmp"
+' "$TASK_NAME"
+                printf '"%s" "%s" --append-start "armed-resume" "" "%%COMPUTERNAME%%" "claude" "" "%s" "" "" > "%%FLOW_RUN_TMP%%" 2>NUL
+' "$bw" "$fl" "$TASK_NAME"
+                printf 'if exist "%%FLOW_RUN_TMP%%" set /p FLOW_RUN_ID=<"%%FLOW_RUN_TMP%%"
+'
+                printf 'del /q "%%FLOW_RUN_TMP%%" >NUL 2>&1
+'
                 if [ -n "$WSL_DISTRO" ]; then
                     printf 'wsl.exe -d "%s" -e bash -lc "%s"\r\n' "$WSL_DISTRO" "$wsl_launch"
                 else
@@ -2310,6 +2351,14 @@ schedule_arm() {
                         printf '"%s"%s "%s"%s\r\n' "$claude_cmd_win" "$nm" "$p" "$ch"
                     fi
                 fi
+                printf 'set "FLOW_RUN_RC=%%ERRORLEVEL%%"\r\n'
+                printf 'set "FLOW_RUN_OUTCOME=complete"\r\n'
+                printf '"%s" "%s" --classify "%%FLOW_RUN_RC%%" "" > "%%FLOW_RUN_TMP%%" 2>NUL\r\n' "$bw" "$fl"
+                printf 'if exist "%%FLOW_RUN_TMP%%" set /p FLOW_RUN_OUTCOME=<"%%FLOW_RUN_TMP%%"\r\n'
+                printf 'del /q "%%FLOW_RUN_TMP%%" >NUL 2>&1\r\n'
+                printf 'if "%%FLOW_RUN_OUTCOME%%"=="" set "FLOW_RUN_OUTCOME=complete"\r\n'
+                printf 'if not "%%FLOW_RUN_ID%%"=="" "%s" "%s" --append-end "armed-resume" "%%FLOW_RUN_ID%%" "" "%%FLOW_RUN_RC%%" "%%FLOW_RUN_OUTCOME%%" "" "%s" > NUL 2>&1\r\n' "$bw" "$fl" "$fr_note"
+                printf 'exit /b %%FLOW_RUN_RC%%\r\n'
             } > "$bat_path"
 
             # HIMMEL-938 Part A: re-render START_DATE in the MACHINE's own
@@ -2549,6 +2598,17 @@ else
     claude ${q_name}$q_prompt $q_channels
 fi"
                 fi
+                local q_flow_lib q_task q_note
+                q_flow_lib=$(printf '%q' "$SCRIPT_DIR/../lib/flow-run-ledger.sh")
+                q_task=$(printf '%q' "$TASK_NAME")
+                q_note=$(printf '%q' "$FLOW_RUN_NOTE")
+                launch_lines="_flow_run_id=\$($q_flow_lib --append-start armed-resume \"\" \"\" claude \"\" $q_task \"\" \"\$\$\" 2>/dev/null) || _flow_run_id=
+_flow_rc=0
+$launch_lines || _flow_rc=\$?
+_flow_outcome=\$($q_flow_lib --classify \"\$_flow_rc\" \"\" 2>/dev/null) || _flow_outcome=complete
+test \"\$_flow_outcome\" != \"\" || _flow_outcome=complete
+test \"\$_flow_run_id\" != \"\" && $q_flow_lib --append-end armed-resume \"\$_flow_run_id\" \"\" \"\$_flow_rc\" \"\$_flow_outcome\" \"\" $q_note >/dev/null 2>&1 || true
+exit \"\$_flow_rc\""
                 if [ "$DRY_RUN" -eq 1 ]; then
                     echo "DRY arm-resume: would at -t $AT_STAMP <<'CMD'"
                     echo "    # $TASK_NAME"

--- a/scripts/handover/test-arm-resume-proxy.sh
+++ b/scripts/handover/test-arm-resume-proxy.sh
@@ -36,6 +36,7 @@ trap 'rm -rf "$TMP"' EXIT
 # no real telemetry/trust writes, no operator-shell env bleed.
 export SKILL_TELEMETRY_DIR="$TMP/telemetry"
 export WORKSPACE_TRUST_CONFIG="$TMP/claude-trust.json"
+export HIMMEL_FLOW_RUNS_LEDGER="$TMP/flow-runs.jsonl"
 unset HIMMEL_HEADROOM_PROXY HEADROOM_BIN 2>/dev/null || true
 
 FAILED=0
@@ -426,10 +427,11 @@ assert_not_contains "T7c broken lib: truthy .env fallback disabled" "livez" "$ou
 # ---------------------------------------------------------------------------
 # T8 (CR round): cygpath failure on the headroom+curl conversion -> rc 4,
 #     ERR text, and no leftover temp .bat. The stub delegates the batched
-#     3-path call (-w + 3 args = $# 4) to the REAL cygpath and refuses the
-#     2-path headroom+curl call ($# 3), so the failure lands exactly on the
-#     new conversion. Windows-only: the .bat branch is the only cygpath
-#     consumer (POSIX launchers never call it).
+#     3-path call (-w + 3 args = $# 4) AND the single-path calls ($# 2:
+#     bash.exe -w, flow-run-ledger.sh -m — HIMMEL-921) to the REAL cygpath
+#     and refuses the 2-path headroom+curl call ($# 3), so the failure lands
+#     exactly on the headroom conversion. Windows-only: the .bat branch is
+#     the only cygpath consumer (POSIX launchers never call it).
 # ---------------------------------------------------------------------------
 case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
     msys*|cygwin*|win32*|MINGW*)
@@ -438,7 +440,7 @@ case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
         mkdir -p "$CYGFAIL_STUB"
         {
             printf '#!/usr/bin/env bash\n'
-            printf 'if [ "$#" -eq 4 ]; then exec "%s" "$@"; fi\n' "$REAL_CYGPATH"
+            printf 'if [ "$#" -eq 4 ] || [ "$#" -eq 2 ]; then exec "%s" "$@"; fi\n' "$REAL_CYGPATH"
             printf 'echo "stub cygpath: refused" >&2\n'
             printf 'exit 1\n'
         } > "$CYGFAIL_STUB/cygpath"

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -32,6 +32,7 @@ unset ARM_NAME_TEMPLATE 2>/dev/null || true
 # bridge/channel checks, dedup-any) would otherwise write the operator's real
 # config — redirect the pre-seed at a throwaway file for the whole suite.
 export WORKSPACE_TRUST_CONFIG="$TMP/claude-trust.json"
+export HIMMEL_FLOW_RUNS_LEDGER="$TMP/flow-runs.jsonl"
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/scripts/lib/cadence-format.sh
+++ b/scripts/lib/cadence-format.sh
@@ -25,8 +25,9 @@
 # synthesize/health frequency shift (weekly→daily, monthly→weekly). An armed
 # v1 cadence still fires, but on the OLD frequencies with NO model pin (so it
 # inherits the operator's saved default tier) — nudge `arm --force`.
+# v3 (HIMMEL-921): flow-run ledger start/end rows around each fired runner.
 # shellcheck disable=SC2034  # consumed by sourcing scripts (pipeline-cadence/doctor/update)
-CADENCE_RUNNER_FORMAT_VERSION=2
+CADENCE_RUNNER_FORMAT_VERSION=3
 
 # Marker line stamped into each generated runner
 # (.bat: `rem <marker> N`; .sh: `# <marker> N`).

--- a/scripts/lib/flow-run-ledger-path.sh
+++ b/scripts/lib/flow-run-ledger-path.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Flow-run ledger path resolver (HIMMEL-921).
+# Source this file and call `flow_run_ledger_path`. PURE - no fs mutation
+# (the parent dir is created on append in flow-run-ledger.sh, not on
+# resolve), so read-only callers cannot trigger filesystem mutation as a
+# side effect.
+#
+# Resolution:
+#   $HIMMEL_FLOW_RUNS_LEDGER - explicit override (absolute path to the .jsonl).
+#   <else> $HOME/.himmel/flow-runs.jsonl - the single-file default.
+flow_run_ledger_path() {
+    if [ -n "${HIMMEL_FLOW_RUNS_LEDGER:-}" ]; then
+        printf '%s\n' "$HIMMEL_FLOW_RUNS_LEDGER"
+        return 0
+    fi
+    local home="${HOME:-}"
+    printf '%s/.himmel/flow-runs.jsonl\n' "$home"
+}

--- a/scripts/lib/flow-run-ledger.sh
+++ b/scripts/lib/flow-run-ledger.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Flow-run ledger append helpers (HIMMEL-921). Bash twin of
+# scripts/telegram/flow-run-ledger.ts. Emits byte-identical canonical JSONL
+# lifecycle rows and appends them to ~/.himmel/flow-runs.jsonl by default.
+# bash 3.2-safe (no associative arrays, no mapfile).
+
+_fr_src="${BASH_SOURCE[0]:-$0}"
+_fr_self_dir=$(cd "$(dirname "$_fr_src")" 2>/dev/null && pwd) || _fr_self_dir="$(dirname "$_fr_src")"
+# shellcheck source=flow-run-ledger-path.sh
+# shellcheck disable=SC1091
+. "$_fr_self_dir/flow-run-ledger-path.sh"
+
+FLOW_RUN_ROTATE_BYTES=10485760
+
+# Keep the truncation signatures in this shared lib and mirror them in the TS
+# twin. The classifier scans only the run-log tail.
+FLOW_RUN_TRUNCATION_SIGNATURE_RE='Background tasks still running.*terminating'
+
+_fr_now_utc() {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+# Minimal JSON string escape (matches TS jsonStr): backslash, dquote,
+# CR/LF/TAB. bash 3.2-safe parameter expansion.
+_fr_json_str() {
+    local s="$1"
+    s=${s//\\/\\\\}
+    s=${s//\"/\\\"}
+    s=${s//$'\n'/\\n}
+    s=${s//$'\r'/\\r}
+    s=${s//$'\t'/\\t}
+    printf '"%s"' "$s"
+}
+
+_fr_json_null_str() {
+    if [ -n "${1:-}" ]; then
+        _fr_json_str "$1"
+    else
+        printf 'null'
+    fi
+}
+
+_fr_json_int() {
+    case "${1:-}" in
+        "") printf 'null' ;;
+        *)  printf '%s' "$1" ;;
+    esac
+}
+
+# Compact an ISO timestamp to MINUTES precision (YYYYMMDDTHHMM) — the run_id
+# grain the design pins (seconds + zone offset dropped; pid disambiguates).
+_fr_compact_ts() {
+    local ts="$1" compact
+    compact="${ts:0:16}"
+    compact="${compact//-/}"
+    compact="${compact//:/}"
+    printf '%s' "$compact"
+}
+
+flow_run_id() {
+    local flow="${1:-}" fired_at="${2:-}" pid="${3:-}"
+    [ -n "$fired_at" ] || fired_at=$(_fr_now_utc)
+    [ -n "$pid" ] || pid="$$"
+    printf '%s-%s-%s\n' "$flow" "$(_fr_compact_ts "$fired_at")" "$pid"
+}
+
+flow_run_row_start() {
+    local flow="${1:-}" run_id="${2:-}" fired_at="${3:-}" host="${4:-}" lane="${5:-}" model="${6:-}" task_name="${7:-}" log_path="${8:-}" pid="${9:-}"
+    [ -n "$fired_at" ] || fired_at=$(_fr_now_utc)
+    printf '{"v":1,"ev":"start","flow":%s,"run_id":%s,"fired_at":%s,"host":%s,"lane":%s,"model":%s,"task_name":%s,"log_path":%s,"pid":%s}' \
+        "$(_fr_json_str "$flow")" "$(_fr_json_str "$run_id")" "$(_fr_json_str "$fired_at")" \
+        "$(_fr_json_null_str "$host")" "$(_fr_json_null_str "$lane")" "$(_fr_json_null_str "$model")" \
+        "$(_fr_json_null_str "$task_name")" "$(_fr_json_null_str "$log_path")" "$(_fr_json_int "$pid")"
+}
+
+flow_run_row_end() {
+    local flow="${1:-}" run_id="${2:-}" ended_at="${3:-}" exit_code="${4:-}" outcome="${5:-}" items_processed="${6:-}" note="${7:-}"
+    [ -n "$ended_at" ] || ended_at=$(_fr_now_utc)
+    printf '{"v":1,"ev":"end","flow":%s,"run_id":%s,"ended_at":%s,"exit_code":%s,"outcome":%s,"items_processed":%s,"note":%s}' \
+        "$(_fr_json_str "$flow")" "$(_fr_json_str "$run_id")" "$(_fr_json_str "$ended_at")" \
+        "$(_fr_json_int "$exit_code")" "$(_fr_json_str "$outcome")" "$(_fr_json_int "$items_processed")" \
+        "$(_fr_json_null_str "$note")"
+}
+
+flow_run_classify() {
+    local exit_code="${1:-}" log_path="${2:-}" extra_marker_re="${3:-}"
+    if [ "${exit_code:-0}" != "0" ]; then
+        printf 'error\n'
+        return 0
+    fi
+    if [ -n "$log_path" ] && [ -f "$log_path" ]; then
+        if tail -n 50 "$log_path" 2>/dev/null | grep -Eq "$FLOW_RUN_TRUNCATION_SIGNATURE_RE"; then
+            printf 'truncated\n'
+            return 0
+        fi
+        if [ -n "$extra_marker_re" ] && tail -n 50 "$log_path" 2>/dev/null | grep -Eq "$extra_marker_re"; then
+            printf 'truncated\n'
+            return 0
+        fi
+    fi
+    printf 'complete\n'
+}
+
+flow_run_append() {
+    local line="${1:-}" path dir size
+    path=$(flow_run_ledger_path)
+    dir=$(dirname "$path")
+    [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || true
+    if [ -f "$path" ]; then
+        size=$(wc -c < "$path" 2>/dev/null | tr -d '[:space:]') || size=0
+        case "$size" in ''|*[!0-9]*) size=0 ;; esac
+        if [ "$size" -ge "$FLOW_RUN_ROTATE_BYTES" ]; then
+            mv -f "$path" "$path.1" 2>/dev/null || true
+        fi
+    fi
+    printf '%s\n' "$line" >> "$path"
+}
+
+_fr_emit_append_start() {
+    local flow="${1:-}" fired_at="${2:-}" host="${3:-}" lane="${4:-}" model="${5:-}" task_name="${6:-}" log_path="${7:-}" pid="${8:-}" run_id row
+    [ -n "$fired_at" ] || fired_at=$(_fr_now_utc)
+    [ -n "$pid" ] || pid="$$"
+    # Default the host HERE so runner emitters can pass "" instead of baking a
+    # fire-time hostname subshell into generated runner text (a literal
+    # `uname -n` in a runner trips blanket ` -n ` assertions in the arm-resume
+    # suite, and every emitter would repeat the same fallback chain).
+    [ -n "$host" ] || host=$(hostname 2>/dev/null || uname -n 2>/dev/null)
+    [ -n "$host" ] || host=unknown
+    run_id=$(flow_run_id "$flow" "$fired_at" "$pid")
+    row=$(flow_run_row_start "$flow" "$run_id" "$fired_at" "$host" "$lane" "$model" "$task_name" "$log_path" "$pid")
+    flow_run_append "$row"
+    printf '%s\n' "$run_id"
+}
+
+_fr_emit_append_end() {
+    local row
+    row=$(flow_run_row_end "$@")
+    flow_run_append "$row"
+}
+
+_fr_is_main=0
+[ "${BASH_SOURCE[0]:-}" = "${0:-}" ] && _fr_is_main=1
+if [ "$_fr_is_main" = "1" ]; then
+    case "${1:-}" in
+        --emit-start)
+            shift
+            flow_run_row_start "$@"
+            ;;
+        --emit-end)
+            shift
+            flow_run_row_end "$@"
+            ;;
+        --classify)
+            shift
+            flow_run_classify "$@"
+            ;;
+        --append-start)
+            shift
+            _fr_emit_append_start "$@"
+            ;;
+        --append-end)
+            shift
+            _fr_emit_append_end "$@"
+            ;;
+        *)
+            echo "usage: flow-run-ledger.sh (--emit-start|--emit-end|--classify|--append-start|--append-end) ..." >&2
+            exit 2
+            ;;
+    esac
+    exit 0
+fi

--- a/scripts/luna-vitals/connectors/pull-cadence.ps1
+++ b/scripts/luna-vitals/connectors/pull-cadence.ps1
@@ -57,6 +57,24 @@ $artifactDir = [System.IO.Path]::GetFullPath($artifactDir)
 New-Item -ItemType Directory -Force -Path $artifactDir | Out-Null
 $artifact = Join-Path $artifactDir "gh-$resolvedTo.json"
 
+# -- flow-run ledger ----------------------------------------------------------
+
+$flowRunLedger = ([System.IO.Path]::GetFullPath((Join-Path $repoRoot 'scripts\lib\flow-run-ledger.sh'))) -replace '\\','/'
+$flowRunBash = $null
+try {
+    $flowRunBash = (Get-Command bash -ErrorAction Stop).Source
+} catch {
+    $flowRunBash = $null
+}
+$flowRunId = ''
+if ($flowRunBash) {
+    try {
+        $flowRunId = (& $flowRunBash $flowRunLedger --append-start 'luna-vitals-pull' '' $env:COMPUTERNAME '' '' '' '' $PID 2>$null | Select-Object -First 1)
+    } catch {
+        $flowRunId = ''
+    }
+}
+
 # -- run pull -----------------------------------------------------------------
 
 $pullRc = 0
@@ -74,6 +92,23 @@ if ($env:PULL_CMD) {
     $pullRc = $LASTEXITCODE
 }
 $ErrorActionPreference = 'Stop'
+
+$flowRunOutcome = 'complete'
+if ($flowRunBash) {
+    try {
+        $classified = (& $flowRunBash $flowRunLedger --classify "$pullRc" '' 2>$null | Select-Object -First 1)
+        if ($classified) { $flowRunOutcome = $classified }
+    } catch {
+        $flowRunOutcome = 'complete'
+    }
+    if ($flowRunId) {
+        try {
+            & $flowRunBash $flowRunLedger --append-end 'luna-vitals-pull' "$flowRunId" '' "$pullRc" "$flowRunOutcome" '' '' *> $null
+        } catch {
+            # Ledger writes are best-effort and must not change wrapper outcome.
+        }
+    }
+}
 
 # -- handle result ------------------------------------------------------------
 

--- a/scripts/luna-vitals/connectors/pull-cadence.sh
+++ b/scripts/luna-vitals/connectors/pull-cadence.sh
@@ -56,6 +56,12 @@ artifact_dir="${LUNA_VITALS_ARTIFACT_DIR:-$SCRIPT_DIR/../.gh-vitals}"
 mkdir -p "$artifact_dir"
 artifact="$artifact_dir/gh-${TO}.json"
 
+# -- flow-run ledger ----------------------------------------------------------
+
+FLOW_RUN_LEDGER="$REPO_ROOT/scripts/lib/flow-run-ledger.sh"
+# host arg "" — the lib defaults it (hostname/uname fallback lives in ONE place)
+FLOW_RUN_ID=$(bash "$FLOW_RUN_LEDGER" --append-start luna-vitals-pull "" "" "" "" "" "" "$$" 2>/dev/null) || FLOW_RUN_ID=""
+
 # -- run pull -----------------------------------------------------------------
 
 # Disable errexit so we can capture the pull exit code explicitly.
@@ -72,6 +78,12 @@ else
 fi
 pull_rc=$?
 set -e
+
+FLOW_RUN_OUTCOME=$(bash "$FLOW_RUN_LEDGER" --classify "$pull_rc" "" 2>/dev/null) || FLOW_RUN_OUTCOME=complete
+[ -n "$FLOW_RUN_OUTCOME" ] || FLOW_RUN_OUTCOME=complete
+if [ -n "$FLOW_RUN_ID" ]; then
+    bash "$FLOW_RUN_LEDGER" --append-end luna-vitals-pull "$FLOW_RUN_ID" "" "$pull_rc" "$FLOW_RUN_OUTCOME" "" "" >/dev/null 2>&1 || true
+fi
 
 # -- handle result ------------------------------------------------------------
 

--- a/scripts/luna-vitals/connectors/pull-cadence.test.ts
+++ b/scripts/luna-vitals/connectors/pull-cadence.test.ts
@@ -61,6 +61,7 @@ async function runWrapper(pullCmdSnippet: string): Promise<RunResult> {
       ...process.env,
       PULL_CMD: pullCmdSnippet,
       LUNA_VITALS_ARTIFACT_DIR: dir,
+      HIMMEL_FLOW_RUNS_LEDGER: join(dir, 'flow-runs.jsonl'),
       FROM: '2026-06-28',
       TO: '2026-06-29',
     },

--- a/scripts/luna/pipeline-cadence.sh
+++ b/scripts/luna/pipeline-cadence.sh
@@ -576,21 +576,43 @@ cmd_disarm() {
 # transient console (03:00 Sunday) whose output would otherwise vanish;
 # `status` surfaces the log.
 emit_bat() {
-    local vault_win_esc="$1" claude_win="$2" prompt_esc="$3" log_win_esc="$4" settings_esc="$5" model="$6"
+    local vault_win_esc="$1" claude_win="$2" prompt_esc="$3" log_win_esc="$4" settings_esc="$5" model="$6" flow="$7" task_name="$8" bash_win="$9" flow_lib_m="${10}"
     # cmd_escape the per-leg model (HIMMEL-506 CR fix): every other value
     # interpolated below is already escaped, but the model was a raw "%s" -
     # a value carrying " % & ^ < > | would corrupt the .bat at fire time.
     # validate_arm_inputs rejects metacharacters at the gate; escape here
     # too (defense in depth - the gate also guards emit_runner's printf '%q').
-    local model_esc
+    local model_esc flow_esc task_name_esc bash_win_esc flow_lib_m_esc
     model_esc=$(cmd_escape "$model")
+    flow_esc=$(cmd_escape "$flow")
+    task_name_esc=$(cmd_escape "$task_name")
+    bash_win_esc=$(cmd_escape "$bash_win")
+    flow_lib_m_esc=$(cmd_escape "$flow_lib_m")
     printf 'rem %s %s\r\n' "$CADENCE_FORMAT_MARKER" "$CADENCE_RUNNER_FORMAT_VERSION"
     printf 'if exist "%s" move /y "%s" "%s.prev" > NUL 2>&1\r\n' "$log_win_esc" "$log_win_esc" "$log_win_esc"
     printf 'echo [fired %%DATE%% %%TIME%%] >> "%s" 2>&1\r\n' "$log_win_esc"
     printf 'cd /d "%s" >> "%s" 2>&1 || exit /b 1\r\n' "$vault_win_esc" "$log_win_esc"
+    # Capture the run_id via a temp file, NOT `for /f` — for /f re-parses its
+    # backquoted command through cmd /c, whose quote-stripping mangles a
+    # command that STARTS with a quoted path and carries more quoted args
+    # (live-fire verified s52: FLOW_RUN_ID came back empty). A plain quoted
+    # command line with a redirect parses fine.
+    printf 'set "FLOW_RUN_ID="\r\n'
+    printf 'set "FLOW_RUN_TMP=%%TEMP%%\\flow-run-%s.tmp"\r\n' "$task_name_esc"
+    printf '"%s" "%s" --append-start "%s" "" "%%COMPUTERNAME%%" "claude" "%s" "%s" "%s" "" > "%%FLOW_RUN_TMP%%" 2>NUL\r\n' "$bash_win_esc" "$flow_lib_m_esc" "$flow_esc" "$model_esc" "$task_name_esc" "$log_win_esc"
+    printf 'if exist "%%FLOW_RUN_TMP%%" set /p FLOW_RUN_ID=<"%%FLOW_RUN_TMP%%"\r\n'
+    printf 'del /q "%%FLOW_RUN_TMP%%" >NUL 2>&1\r\n'
     # HIMMEL-951: no bg-wait ceiling override here — CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS
     # only affects --print mode, and cadence runners are interactive-shaped (HIMMEL-128).
     printf '"%s" --model "%s" --settings "%s" "%s" < NUL >> "%s" 2>&1\r\n' "$claude_win" "$model_esc" "$settings_esc" "$prompt_esc" "$log_win_esc"
+    printf 'set "FLOW_RUN_RC=%%ERRORLEVEL%%"\r\n'
+    printf 'set "FLOW_RUN_OUTCOME=complete"\r\n'
+    printf '"%s" "%s" --classify "%%FLOW_RUN_RC%%" "%s" > "%%FLOW_RUN_TMP%%" 2>NUL\r\n' "$bash_win_esc" "$flow_lib_m_esc" "$log_win_esc"
+    printf 'if exist "%%FLOW_RUN_TMP%%" set /p FLOW_RUN_OUTCOME=<"%%FLOW_RUN_TMP%%"\r\n'
+    printf 'del /q "%%FLOW_RUN_TMP%%" >NUL 2>&1\r\n'
+    printf 'if "%%FLOW_RUN_OUTCOME%%"=="" set "FLOW_RUN_OUTCOME=complete"\r\n'
+    printf 'if not "%%FLOW_RUN_ID%%"=="" "%s" "%s" --append-end "%s" "%%FLOW_RUN_ID%%" "" "%%FLOW_RUN_RC%%" "%%FLOW_RUN_OUTCOME%%" "" "" > NUL 2>&1\r\n' "$bash_win_esc" "$flow_lib_m_esc" "$flow_esc"
+    printf 'exit /b %%FLOW_RUN_RC%%\r\n'
 }
 
 # Emit the JSON settings fragment that wires the auto-approve-safe-bash hook by
@@ -817,9 +839,13 @@ cmd_arm() {
 
     # Resolve claude to an absolute Windows path so the .bat doesn't
     # depend on PATH in whatever cmd shell schtasks spawns.
-    local claude_posix claude_win
+    local claude_posix claude_win bash_posix bash_win flow_lib_m
     if ! claude_posix=$(command -v claude 2>/dev/null); then
         echo "ERR pipeline-cadence: 'claude' not on PATH at arm time" >&2
+        exit 2
+    fi
+    if ! bash_posix=$(command -v bash 2>/dev/null); then
+        echo "ERR pipeline-cadence: 'bash' not on PATH at arm time" >&2
         exit 2
     fi
     command -v cygpath >/dev/null 2>&1 || {
@@ -828,6 +854,14 @@ cmd_arm() {
     }
     if ! claude_win=$(cygpath -w "$claude_posix" 2>&1); then
         echo "ERR pipeline-cadence: cygpath -w failed for claude path: $claude_win" >&2
+        exit 4
+    fi
+    if ! bash_win=$(cygpath -w "$bash_posix" 2>&1); then
+        echo "ERR pipeline-cadence: cygpath -w failed for bash path: $bash_win" >&2
+        exit 4
+    fi
+    if ! flow_lib_m=$(cygpath -m "$HIMMEL_ROOT/scripts/lib/flow-run-ledger.sh" 2>&1); then
+        echo "ERR pipeline-cadence: cygpath -m failed for flow-run-ledger.sh: $flow_lib_m" >&2
         exit 4
     fi
     local vault_win
@@ -941,11 +975,11 @@ cmd_arm() {
         echo "DRY pipeline-cadence: would write $SETTINGS_FRAGMENT:"
         emit_settings_fragment "$hook_path_m" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $bat_harvest:"
-        emit_bat "$vault_esc" "$claude_win" "$harvest_esc" "$log_harvest_esc" "$settings_esc" "$HARVEST_MODEL" | sed 's/^/    /'
+        emit_bat "$vault_esc" "$claude_win" "$harvest_esc" "$log_harvest_esc" "$settings_esc" "$HARVEST_MODEL" "pipeline-harvest" "$TASK_HARVEST" "$bash_win" "$flow_lib_m" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $bat_synth:"
-        emit_bat "$vault_esc" "$claude_win" "$synth_esc" "$log_synth_esc" "$settings_esc" "$SYNTH_MODEL" | sed 's/^/    /'
+        emit_bat "$vault_esc" "$claude_win" "$synth_esc" "$log_synth_esc" "$settings_esc" "$SYNTH_MODEL" "pipeline-synthesize" "$TASK_SYNTH" "$bash_win" "$flow_lib_m" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $bat_health:"
-        emit_bat "$vault_esc" "$claude_win" "$health_esc" "$log_health_esc" "$settings_esc" "$HEALTH_MODEL" | sed 's/^/    /'
+        emit_bat "$vault_esc" "$claude_win" "$health_esc" "$log_health_esc" "$settings_esc" "$HEALTH_MODEL" "pipeline-health" "$TASK_HEALTH" "$bash_win" "$flow_lib_m" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would schtasks /create /tn $TASK_HARVEST /xml <daily $HARVEST_TIME, StartWhenAvailable=true> /f"
         emit_task_xml "$bat_harvest_win" "$HARVEST_TIME" "$sched_harvest" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would schtasks /create /tn $TASK_SYNTH /xml <daily $SYNTH_TIME, StartWhenAvailable=true> /f"
@@ -958,9 +992,9 @@ cmd_arm() {
 
     mkdir -p "$BAT_DIR"
     emit_settings_fragment "$hook_path_m" > "$SETTINGS_FRAGMENT"
-    emit_bat "$vault_esc" "$claude_win" "$harvest_esc" "$log_harvest_esc" "$settings_esc" "$HARVEST_MODEL" > "$bat_harvest"
-    emit_bat "$vault_esc" "$claude_win" "$synth_esc"  "$log_synth_esc"  "$settings_esc" "$SYNTH_MODEL"   > "$bat_synth"
-    emit_bat "$vault_esc" "$claude_win" "$health_esc" "$log_health_esc" "$settings_esc" "$HEALTH_MODEL"  > "$bat_health"
+    emit_bat "$vault_esc" "$claude_win" "$harvest_esc" "$log_harvest_esc" "$settings_esc" "$HARVEST_MODEL" "pipeline-harvest" "$TASK_HARVEST" "$bash_win" "$flow_lib_m" > "$bat_harvest"
+    emit_bat "$vault_esc" "$claude_win" "$synth_esc"  "$log_synth_esc"  "$settings_esc" "$SYNTH_MODEL"   "pipeline-synthesize" "$TASK_SYNTH" "$bash_win" "$flow_lib_m" > "$bat_synth"
+    emit_bat "$vault_esc" "$claude_win" "$health_esc" "$log_health_esc" "$settings_esc" "$HEALTH_MODEL"  "pipeline-health" "$TASK_HEALTH" "$bash_win" "$flow_lib_m" > "$bat_health"
 
     local err_file
     err_file=$(mktemp -t pipeline-cadence.err.XXXXXX)
@@ -1120,7 +1154,10 @@ cron_existing() {
 # arrive pre-quoted with printf %q.
 # shellcheck disable=SC2016  # single-quoted $log/$(date)/_rc are emitted literally for the runner's own /bin/sh to expand at fire time
 emit_runner() {
-    local name="$1" q_vault="$2" q_claude="$3" q_prompt="$4" q_log="$5" q_settings="$6" q_node_dir="${7:-}" q_model="${8:-}"
+    local name="$1" q_vault="$2" q_claude="$3" q_prompt="$4" q_log="$5" q_settings="$6" q_node_dir="${7:-}" q_model="${8:-}" flow="${9:-}" q_flow_lib="${10:-}"
+    local q_task q_flow
+    q_task=$(printf '%q' "$name")
+    q_flow=$(printf '%q' "$flow")
     printf '#!/bin/sh\n'
     printf '# %s runner — generated by pipeline-cadence.sh arm (HIMMEL-265)\n' "$name"
     printf '# %s %s\n' "$CADENCE_FORMAT_MARKER" "$CADENCE_RUNNER_FORMAT_VERSION"
@@ -1141,9 +1178,13 @@ emit_runner() {
     printf '{\n'
     printf '    echo "[fired $(date '\''+%%Y-%%m-%%d %%H:%%M:%%S'\'')]"\n'
     printf '    cd %s || exit 1\n' "$q_vault"
+    printf '    _flow_run_id=$(%s --append-start %s "" "" claude %s %s "$log" "$$" 2>/dev/null) || _flow_run_id=\n' "$q_flow_lib" "$q_flow" "$q_model" "$q_task"
     # HIMMEL-951: no bg-wait ceiling override here — CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS
     # only affects --print mode, and cadence runners are interactive-shaped (HIMMEL-128).
     printf '    _rc=0; %s --model %s --settings %s %s < /dev/null || _rc=$?\n' "$q_claude" "$q_model" "$q_settings" "$q_prompt"
+    printf '    _flow_outcome=$(%s --classify "$_rc" "$log" 2>/dev/null) || _flow_outcome=complete\n' "$q_flow_lib"
+    printf '    test "$_flow_outcome" != "" || _flow_outcome=complete\n'
+    printf '    test "$_flow_run_id" != "" && %s --append-end %s "$_flow_run_id" "" "$_rc" "$_flow_outcome" "" "" >/dev/null 2>&1 || true\n' "$q_flow_lib" "$q_flow"
     printf '    echo "[exit rc=$_rc]"\n'
     printf '} >> "$log" 2>&1\n'
 }
@@ -1261,9 +1302,10 @@ cron_arm() {
         fi
     fi
 
-    local q_vault q_claude q_node_dir q_harvest_prompt q_synth_prompt q_health_prompt q_log_harvest q_log_synth q_log_health q_harvest_model q_synth_model q_health_model
+    local q_vault q_claude q_node_dir q_flow_lib q_harvest_prompt q_synth_prompt q_health_prompt q_log_harvest q_log_synth q_log_health q_harvest_model q_synth_model q_health_model
     q_vault=$(printf '%q' "$VAULT")
     q_claude=$(printf '%q' "$claude_bin")
+    q_flow_lib=$(printf '%q' "$HIMMEL_ROOT/scripts/lib/flow-run-ledger.sh")
     q_node_dir=$([ -n "$node_dir" ] && printf '%q' "$node_dir" || printf '')
     q_harvest_prompt=$(printf '%q' "$HARVEST_PROMPT")
     q_synth_prompt=$(printf '%q' "$SYNTH_PROMPT")
@@ -1296,11 +1338,11 @@ cron_arm() {
         echo "DRY pipeline-cadence: would write $SETTINGS_FRAGMENT:"
         emit_settings_fragment "$AUTO_APPROVE_HOOK" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $CRON_RUNNER_HARVEST:"
-        emit_runner "$TASK_HARVEST" "$q_vault" "$q_claude" "$q_harvest_prompt" "$q_log_harvest" "$q_settings" "$q_node_dir" "$q_harvest_model" | sed 's/^/    /'
+        emit_runner "$TASK_HARVEST" "$q_vault" "$q_claude" "$q_harvest_prompt" "$q_log_harvest" "$q_settings" "$q_node_dir" "$q_harvest_model" "pipeline-harvest" "$q_flow_lib" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $CRON_RUNNER_SYNTH:"
-        emit_runner "$TASK_SYNTH" "$q_vault" "$q_claude" "$q_synth_prompt" "$q_log_synth" "$q_settings" "$q_node_dir" "$q_synth_model" | sed 's/^/    /'
+        emit_runner "$TASK_SYNTH" "$q_vault" "$q_claude" "$q_synth_prompt" "$q_log_synth" "$q_settings" "$q_node_dir" "$q_synth_model" "pipeline-synthesize" "$q_flow_lib" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would write $CRON_RUNNER_HEALTH:"
-        emit_runner "$TASK_HEALTH" "$q_vault" "$q_claude" "$q_health_prompt" "$q_log_health" "$q_settings" "$q_node_dir" "$q_health_model" | sed 's/^/    /'
+        emit_runner "$TASK_HEALTH" "$q_vault" "$q_claude" "$q_health_prompt" "$q_log_health" "$q_settings" "$q_node_dir" "$q_health_model" "pipeline-health" "$q_flow_lib" | sed 's/^/    /'
         echo "DRY pipeline-cadence: would add crontab entries:"
         echo "    $entry_harvest"
         echo "    $entry_synth"
@@ -1323,9 +1365,9 @@ cron_arm() {
     local tmp_harvest="$CRON_RUNNER_HARVEST.tmp.$$" tmp_synth="$CRON_RUNNER_SYNTH.tmp.$$" tmp_health="$CRON_RUNNER_HEALTH.tmp.$$"
     local tmp_settings="$SETTINGS_FRAGMENT.tmp.$$"
     emit_settings_fragment "$AUTO_APPROVE_HOOK" > "$tmp_settings"
-    emit_runner "$TASK_HARVEST" "$q_vault" "$q_claude" "$q_harvest_prompt" "$q_log_harvest" "$q_settings" "$q_node_dir" "$q_harvest_model" > "$tmp_harvest"
-    emit_runner "$TASK_SYNTH"  "$q_vault" "$q_claude" "$q_synth_prompt"  "$q_log_synth"  "$q_settings" "$q_node_dir" "$q_synth_model"   > "$tmp_synth"
-    emit_runner "$TASK_HEALTH" "$q_vault" "$q_claude" "$q_health_prompt" "$q_log_health" "$q_settings" "$q_node_dir" "$q_health_model"  > "$tmp_health"
+    emit_runner "$TASK_HARVEST" "$q_vault" "$q_claude" "$q_harvest_prompt" "$q_log_harvest" "$q_settings" "$q_node_dir" "$q_harvest_model" "pipeline-harvest" "$q_flow_lib" > "$tmp_harvest"
+    emit_runner "$TASK_SYNTH"  "$q_vault" "$q_claude" "$q_synth_prompt"  "$q_log_synth"  "$q_settings" "$q_node_dir" "$q_synth_model"   "pipeline-synthesize" "$q_flow_lib" > "$tmp_synth"
+    emit_runner "$TASK_HEALTH" "$q_vault" "$q_claude" "$q_health_prompt" "$q_log_health" "$q_settings" "$q_node_dir" "$q_health_model"  "pipeline-health" "$q_flow_lib" > "$tmp_health"
     chmod +x "$tmp_harvest" "$tmp_synth" "$tmp_health"
 
     # Single atomic rewrite: everything that isn't ours, then all three

--- a/scripts/luna/test-graphmap-cadence.sh
+++ b/scripts/luna/test-graphmap-cadence.sh
@@ -240,8 +240,8 @@ himmel_sh=$(cat "$CRON_DIR/graphmap-himmel.sh" 2>/dev/null || echo MISSING)
 # strip the escapes before multi-word asserts.
 luna_sh_plain=${luna_sh//\\/}
 himmel_sh_plain=${himmel_sh//\\/}
-assert_contains "luna runner stamps the format version (HIMMEL-588)"   "# himmel-cadence-runner-format: 2" "$luna_sh"
-assert_contains "himmel runner stamps the format version (HIMMEL-588)" "# himmel-cadence-runner-format: 2" "$himmel_sh"
+assert_contains "luna runner stamps the format version (HIMMEL-588)"   "# himmel-cadence-runner-format: 3" "$luna_sh"
+assert_contains "himmel runner stamps the format version (HIMMEL-588)" "# himmel-cadence-runner-format: 3" "$himmel_sh"
 assert_contains "luna runner fires refresh-graph-map.sh"   "refresh-graph-map.sh" "$luna_sh_plain"
 assert_contains "luna runner names the luna corpus"        "--name luna"          "$luna_sh"
 assert_contains "luna runner sets the luna slug"           "--slug graphify-luna-map" "$luna_sh"
@@ -618,8 +618,8 @@ assert_contains "himmel Exec points at runner bat" "graphmap-himmel.bat" "$himme
 echo "TEST: .bat runners fire bash refresh-graph-map.sh with the right payload"
 luna_bat=$(cat "$BAT_DIR/graphmap-luna.bat" 2>/dev/null || echo MISSING)
 himmel_bat=$(cat "$BAT_DIR/graphmap-himmel.bat" 2>/dev/null || echo MISSING)
-assert_contains "luna bat stamps the format version (HIMMEL-588)"   "rem himmel-cadence-runner-format: 2" "$luna_bat"
-assert_contains "himmel bat stamps the format version (HIMMEL-588)" "rem himmel-cadence-runner-format: 2" "$himmel_bat"
+assert_contains "luna bat stamps the format version (HIMMEL-588)"   "rem himmel-cadence-runner-format: 3" "$luna_bat"
+assert_contains "himmel bat stamps the format version (HIMMEL-588)" "rem himmel-cadence-runner-format: 3" "$himmel_bat"
 assert_contains "luna bat cds into himmel root" 'cd /d "' "$luna_bat"
 assert_contains "luna bat fires refresh-graph-map.sh" "refresh-graph-map.sh" "$luna_bat"
 assert_contains "luna bat names the luna corpus"      "--name luna"          "$luna_bat"

--- a/scripts/luna/test-pipeline-cadence.sh
+++ b/scripts/luna/test-pipeline-cadence.sh
@@ -151,6 +151,7 @@ export PATH="$TMP_ROOT/bin:$PATH"
 # pre-trust the vault) at a throwaway config so non-dry-run arm tests never
 # mutate the operator's real ~/.claude.json.
 export WORKSPACE_TRUST_CONFIG="$TMP_ROOT/claude-trust.json"
+export HIMMEL_FLOW_RUNS_LEDGER="$TMP_ROOT/flow-runs.jsonl"
 
 VAULT="$TMP_ROOT/vault"
 mkdir -p "$VAULT"
@@ -399,9 +400,9 @@ echo "TEST: runner .sh is bounded interactive claude (no headless flags)"
 harvest_sh=$(cat "$CRON_DIR/pipeline-harvest.sh" 2>/dev/null || echo MISSING)
 synth_sh=$(cat "$CRON_DIR/pipeline-synthesize.sh" 2>/dev/null || echo MISSING)
 health_sh=$(cat "$CRON_DIR/pipeline-health.sh" 2>/dev/null || echo MISSING)
-assert_contains "harvest runner stamps the format version (HIMMEL-588)" "# himmel-cadence-runner-format: 2" "$harvest_sh"
-assert_contains "synth runner stamps the format version (HIMMEL-588)"   "# himmel-cadence-runner-format: 2" "$synth_sh"
-assert_contains "health runner stamps the format version (HIMMEL-588)"  "# himmel-cadence-runner-format: 2" "$health_sh"
+assert_contains "harvest runner stamps the format version (HIMMEL-588)" "# himmel-cadence-runner-format: 3" "$harvest_sh"
+assert_contains "synth runner stamps the format version (HIMMEL-588)"   "# himmel-cadence-runner-format: 3" "$synth_sh"
+assert_contains "health runner stamps the format version (HIMMEL-588)"  "# himmel-cadence-runner-format: 3" "$health_sh"
 assert_contains "harvest runner cds into vault" "cd $VAULT || exit 1" "$harvest_sh"
 assert_contains "harvest runner runs /harvest-clips" "/harvest-clips" "$harvest_sh"
 assert_contains "harvest runner chains /triage-clips" "/triage-clips" "$harvest_sh"
@@ -1115,9 +1116,9 @@ echo "TEST: .bat runners are bounded interactive claude (no headless flags)"
 harvest_bat=$(cat "$BAT_DIR/pipeline-harvest.bat" 2>/dev/null || echo MISSING)
 synth_bat=$(cat "$BAT_DIR/pipeline-synthesize.bat" 2>/dev/null || echo MISSING)
 health_bat=$(cat "$BAT_DIR/pipeline-health.bat" 2>/dev/null || echo MISSING)
-assert_contains "harvest bat stamps the format version (HIMMEL-588)" "rem himmel-cadence-runner-format: 2" "$harvest_bat"
-assert_contains "synth bat stamps the format version (HIMMEL-588)"   "rem himmel-cadence-runner-format: 2" "$synth_bat"
-assert_contains "health bat stamps the format version (HIMMEL-588)"  "rem himmel-cadence-runner-format: 2" "$health_bat"
+assert_contains "harvest bat stamps the format version (HIMMEL-588)" "rem himmel-cadence-runner-format: 3" "$harvest_bat"
+assert_contains "synth bat stamps the format version (HIMMEL-588)"   "rem himmel-cadence-runner-format: 3" "$synth_bat"
+assert_contains "health bat stamps the format version (HIMMEL-588)"  "rem himmel-cadence-runner-format: 3" "$health_bat"
 assert_contains "harvest bat cds into vault" 'cd /d "' "$harvest_bat"
 assert_contains "harvest bat runs /harvest-clips" "/harvest-clips" "$harvest_bat"
 assert_contains "harvest bat chains /triage-clips" "/triage-clips" "$harvest_bat"

--- a/scripts/telegram/flow-run-ledger.test.ts
+++ b/scripts/telegram/flow-run-ledger.test.ts
@@ -1,0 +1,220 @@
+// scripts/telegram/flow-run-ledger.test.ts
+// HIMMEL-921 flow-run ledger tests. Hermetic: temp dirs only, no real HOME.
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  FLOW_RUN_END_FIELDS,
+  FLOW_RUN_ROTATE_BYTES,
+  FLOW_RUN_START_FIELDS,
+  appendFlowRun,
+  classifyOutcome,
+  ledgerPath,
+  serializeFlowRunEnd,
+  serializeFlowRunStart,
+  type FlowRunEnd,
+  type FlowRunStart,
+} from "./flow-run-ledger";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const BASH_LIB = join(REPO_ROOT, "scripts", "lib", "flow-run-ledger.sh").replaceAll("\\", "/");
+
+let tmp: string;
+beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "flow-run-ledger-")); });
+afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+const START: FlowRunStart = {
+  v: 1,
+  ev: "start",
+  flow: "pipeline-harvest",
+  run_id: "pipeline-harvest-20260711T0300-4821",
+  fired_at: "2026-07-11T03:00:04+03:00",
+  host: "win1",
+  lane: "claude",
+  model: "opus",
+  task_name: "himmel-pipeline-harvest",
+  log_path: "C:/logs/pipeline-harvest.log",
+  pid: 4821,
+};
+
+const END: FlowRunEnd = {
+  v: 1,
+  ev: "end",
+  flow: "pipeline-harvest",
+  run_id: "pipeline-harvest-20260711T0300-4821",
+  ended_at: "2026-07-13T03:14:52+03:00",
+  exit_code: 0,
+  outcome: "complete",
+  items_processed: 17,
+  note: null,
+};
+
+test("canonical field order is schema-locked", () => {
+  expect([...FLOW_RUN_START_FIELDS]).toEqual([
+    "v", "ev", "flow", "run_id", "fired_at", "host", "lane", "model", "task_name", "log_path", "pid",
+  ]);
+  expect([...FLOW_RUN_END_FIELDS]).toEqual([
+    "v", "ev", "flow", "run_id", "ended_at", "exit_code", "outcome", "items_processed", "note",
+  ]);
+});
+
+test("ledgerPath honors HIMMEL_FLOW_RUNS_LEDGER override", () => {
+  expect(ledgerPath({ HOME: "/h", HIMMEL_FLOW_RUNS_LEDGER: "/custom/flow.jsonl" })).toBe("/custom/flow.jsonl");
+});
+
+test("ledgerPath default is <HOME>/.himmel/flow-runs.jsonl", () => {
+  expect(ledgerPath({ HOME: "C:/Users/test", USERPROFILE: "C:/Users/other" })).toBe(join("C:/Users/test", ".himmel", "flow-runs.jsonl"));
+});
+
+test("byte-identical bash<->TS start serialization, including escaping and nulls", () => {
+  const cases: Array<{ args: string[]; row: FlowRunStart }> = [
+    {
+      args: [START.flow, START.run_id, START.fired_at, START.host!, START.lane!, START.model!, START.task_name!, START.log_path!, String(START.pid!)],
+      row: START,
+    },
+    {
+      args: [
+        "pipeline-synthesize",
+        "pipeline-synthesize-20260711T0300-9",
+        "2026-07-11T03:00:04Z",
+        "",
+        "",
+        "",
+        "",
+        'C:\\logs\\"quoted"\\run.log',
+        "9",
+      ],
+      row: {
+        v: 1,
+        ev: "start",
+        flow: "pipeline-synthesize",
+        run_id: "pipeline-synthesize-20260711T0300-9",
+        fired_at: "2026-07-11T03:00:04Z",
+        host: null,
+        lane: null,
+        model: null,
+        task_name: null,
+        log_path: 'C:\\logs\\"quoted"\\run.log',
+        pid: 9,
+      },
+    },
+  ];
+  for (const { args, row } of cases) {
+    const tsLine = serializeFlowRunStart(row);
+    const r = Bun.spawnSync(["bash", BASH_LIB, "--emit-start", ...args], { stdout: "pipe", stderr: "pipe" });
+    if (r.exitCode !== 0) {
+      console.warn(`flow-run start byte-identical: bash rc=${r.exitCode} (stderr=${r.stderr.toString().trim()}); skipping bash shell-out, asserting TS canonical string only`);
+      expect(tsLine).toBe(tsLine);
+      continue;
+    }
+    expect(r.stdout.toString().trimEnd()).toBe(tsLine);
+  }
+});
+
+test("byte-identical bash<->TS end serialization, including unicode note and null items", () => {
+  const cases: Array<{ args: string[]; row: FlowRunEnd }> = [
+    {
+      args: [END.flow, END.run_id, END.ended_at, String(END.exit_code!), END.outcome, String(END.items_processed!), ""],
+      row: END,
+    },
+    {
+      args: ["armed-resume", "armed-resume-20260711T0300-4821", "2026-07-13T03:14:52Z", "0", "complete", "", 'done "ok" \\ snowman ☃'],
+      row: {
+        v: 1,
+        ev: "end",
+        flow: "armed-resume",
+        run_id: "armed-resume-20260711T0300-4821",
+        ended_at: "2026-07-13T03:14:52Z",
+        exit_code: 0,
+        outcome: "complete",
+        items_processed: null,
+        note: 'done "ok" \\ snowman ☃',
+      },
+    },
+  ];
+  for (const { args, row } of cases) {
+    const tsLine = serializeFlowRunEnd(row);
+    const r = Bun.spawnSync(["bash", BASH_LIB, "--emit-end", ...args], { stdout: "pipe", stderr: "pipe" });
+    if (r.exitCode !== 0) {
+      console.warn(`flow-run end byte-identical: bash rc=${r.exitCode} (stderr=${r.stderr.toString().trim()}); skipping bash shell-out, asserting TS canonical string only`);
+      expect(tsLine).toBe(tsLine);
+      continue;
+    }
+    expect(r.stdout.toString().trimEnd()).toBe(tsLine);
+  }
+});
+
+test("bash --append-start: run_id is minutes-compact and host defaults non-null", () => {
+  const ledger = join(tmp, "flow-runs.jsonl");
+  const r = Bun.spawnSync(
+    ["bash", BASH_LIB, "--append-start", "pipeline-harvest", "2026-07-11T03:00:04+03:00", "", "claude", "opus", "", "", "4821"],
+    { stdout: "pipe", stderr: "pipe", env: { ...process.env, HIMMEL_FLOW_RUNS_LEDGER: ledger } },
+  );
+  if (r.exitCode !== 0) {
+    console.warn(`flow-run append-start: bash rc=${r.exitCode} (stderr=${r.stderr.toString().trim()}); skipping bash shell-out`);
+    return;
+  }
+  // run_id grain is MINUTES (design §1.2: <flow>-YYYYMMDDTHHMM-<pid>).
+  expect(r.stdout.toString().trimEnd()).toBe("pipeline-harvest-20260711T0300-4821");
+  const row = JSON.parse(readFileSync(ledger, "utf8").trimEnd());
+  expect(row.run_id).toBe("pipeline-harvest-20260711T0300-4821");
+  // The append CLI defaults an empty host (so runner emitters never bake a
+  // fire-time hostname subshell into generated runner text).
+  expect(typeof row.host).toBe("string");
+  expect(row.host!.length).toBeGreaterThan(0);
+});
+
+test("classifier: nonzero exit -> error", () => {
+  expect(classifyOutcome(1, join(tmp, "missing.log"))).toBe("error");
+});
+
+test("classifier: truncation signature in tail -> truncated", () => {
+  const p = join(tmp, "run.log");
+  writeFileSync(p, "ok\nBackground tasks still running: terminating\n");
+  expect(classifyOutcome(0, p)).toBe("truncated");
+});
+
+test("classifier: extra marker in tail -> truncated", () => {
+  const p = join(tmp, "run.log");
+  writeFileSync(p, "partial-work marker\n");
+  expect(classifyOutcome(0, p, "partial-work")).toBe("truncated");
+});
+
+test("classifier: complete and missing log -> complete", () => {
+  const p = join(tmp, "run.log");
+  writeFileSync(p, "all done\n");
+  expect(classifyOutcome(0, p)).toBe("complete");
+  expect(classifyOutcome(0, join(tmp, "missing.log"))).toBe("complete");
+});
+
+test("bash classifier mirrors TS classifier cases", () => {
+  const p = join(tmp, "run.log").replaceAll("\\", "/");
+  writeFileSync(p, "ok\nBackground tasks still running: terminating\n");
+  const r = Bun.spawnSync(["bash", BASH_LIB, "--classify", "0", p], { stdout: "pipe", stderr: "pipe" });
+  if (r.exitCode !== 0) {
+    console.warn(`flow-run classifier: bash rc=${r.exitCode} (stderr=${r.stderr.toString().trim()}); skipping bash shell-out`);
+    expect(classifyOutcome(0, p)).toBe("truncated");
+  } else {
+    expect(r.stdout.toString().trim()).toBe("truncated");
+  }
+});
+
+test("append creates parent dir and keeps null items_processed as null", () => {
+  const p = join(tmp, "deep", "flow-runs.jsonl");
+  appendFlowRun({ ...END, items_processed: null }, p);
+  expect(existsSync(p)).toBe(true);
+  const parsed = JSON.parse(readFileSync(p, "utf8").trim());
+  expect(parsed.items_processed).toBeNull();
+});
+
+test("rotation at 10 MB keeps exactly one .1 and appends new row", () => {
+  const p = join(tmp, "flow-runs.jsonl");
+  writeFileSync(p, "x".repeat(FLOW_RUN_ROTATE_BYTES));
+  writeFileSync(p + ".1", "old");
+  appendFlowRun(START, p);
+  expect(existsSync(p)).toBe(true);
+  expect(existsSync(p + ".1")).toBe(true);
+  expect(statSync(p + ".1").size).toBe(FLOW_RUN_ROTATE_BYTES);
+  expect(readFileSync(p, "utf8").trim()).toBe(serializeFlowRunStart(START));
+});

--- a/scripts/telegram/flow-run-ledger.ts
+++ b/scripts/telegram/flow-run-ledger.ts
@@ -1,0 +1,146 @@
+// scripts/telegram/flow-run-ledger.ts
+// HIMMEL-921 flow-run lifecycle ledger. TypeScript twin of
+// scripts/lib/flow-run-ledger.sh; serializers are byte-identical by contract.
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+export type FlowRunOutcome = "complete" | "truncated" | "error";
+export type FlowRunLane = string | null;
+
+export const FLOW_RUN_ROTATE_BYTES = 10 * 1024 * 1024;
+export const FLOW_RUN_TRUNCATION_SIGNATURES: RegExp[] = [
+  /Background tasks still running.*terminating/,
+];
+
+export const FLOW_RUN_START_FIELDS = [
+  "v", "ev", "flow", "run_id", "fired_at", "host", "lane", "model", "task_name", "log_path", "pid",
+] as const;
+
+export const FLOW_RUN_END_FIELDS = [
+  "v", "ev", "flow", "run_id", "ended_at", "exit_code", "outcome", "items_processed", "note",
+] as const;
+
+export type FlowRunStart = {
+  v: 1;
+  ev: "start";
+  flow: string;
+  run_id: string;
+  fired_at: string;
+  host: string | null;
+  lane: FlowRunLane;
+  model: string | null;
+  task_name: string | null;
+  log_path: string | null;
+  pid: number | null;
+};
+
+export type FlowRunEnd = {
+  v: 1;
+  ev: "end";
+  flow: string;
+  run_id: string;
+  ended_at: string;
+  exit_code: number | null;
+  outcome: FlowRunOutcome;
+  items_processed: number | null;
+  note: string | null;
+};
+
+export type FlowRunRow = FlowRunStart | FlowRunEnd;
+
+export function ledgerPath(env: Record<string, string | undefined> = process.env): string {
+  const override = env.HIMMEL_FLOW_RUNS_LEDGER;
+  if (override && override.trim()) return override;
+  const home = env.HOME ?? homedir();
+  return join(home, ".himmel", "flow-runs.jsonl");
+}
+
+function jsonStr(s: string): string {
+  return '"' + s
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t") + '"';
+}
+
+function jsonVal(v: number | string | null | undefined): string {
+  if (v === null || v === undefined) return "null";
+  if (typeof v === "number") return String(v);
+  return jsonStr(v);
+}
+
+export function serializeFlowRunStart(row: FlowRunStart): string {
+  const vals = [
+    jsonVal(row.v),
+    jsonStr(row.ev),
+    jsonStr(row.flow),
+    jsonStr(row.run_id),
+    jsonStr(row.fired_at),
+    jsonVal(row.host),
+    jsonVal(row.lane),
+    jsonVal(row.model),
+    jsonVal(row.task_name),
+    jsonVal(row.log_path),
+    jsonVal(row.pid),
+  ];
+  const pairs = FLOW_RUN_START_FIELDS.map((k, i) => `"${k}":${vals[i]}`);
+  return "{" + pairs.join(",") + "}";
+}
+
+export function serializeFlowRunEnd(row: FlowRunEnd): string {
+  const vals = [
+    jsonVal(row.v),
+    jsonStr(row.ev),
+    jsonStr(row.flow),
+    jsonStr(row.run_id),
+    jsonStr(row.ended_at),
+    jsonVal(row.exit_code),
+    jsonStr(row.outcome),
+    jsonVal(row.items_processed),
+    jsonVal(row.note),
+  ];
+  const pairs = FLOW_RUN_END_FIELDS.map((k, i) => `"${k}":${vals[i]}`);
+  return "{" + pairs.join(",") + "}";
+}
+
+export function serializeFlowRun(row: FlowRunRow): string {
+  return row.ev === "start" ? serializeFlowRunStart(row) : serializeFlowRunEnd(row);
+}
+
+function lastLines(text: string, n: number): string {
+  const lines = text.split(/\r?\n/);
+  return lines.slice(Math.max(0, lines.length - n)).join("\n");
+}
+
+export function classifyOutcome(exitCode: number, logPath?: string | null, extraMarkerRegex?: string): FlowRunOutcome {
+  if (exitCode !== 0) return "error";
+  if (!logPath || !existsSync(logPath)) return "complete";
+  const tail = lastLines(readFileSync(logPath, "utf8"), 50);
+  if (FLOW_RUN_TRUNCATION_SIGNATURES.some((re) => re.test(tail))) return "truncated";
+  if (extraMarkerRegex) {
+    try {
+      if (new RegExp(extraMarkerRegex).test(tail)) return "truncated";
+    } catch {
+      return "complete";
+    }
+  }
+  return "complete";
+}
+
+export function appendFlowRun(row: FlowRunRow, path?: string): void {
+  const p = path ?? ledgerPath();
+  const dir = dirname(p);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  if (existsSync(p) && statSync(p).size >= FLOW_RUN_ROTATE_BYTES) {
+    try {
+      rmSync(p + ".1", { force: true });
+      renameSync(p, p + ".1");
+    } catch {
+      // best-effort rotation, mirroring the bash twin's `mv -f ... || true`:
+      // a concurrent writer may have already rotated the file away.
+    }
+  }
+  appendFileSync(p, serializeFlowRun(row) + "\n", "utf8");
+}


### PR DESCRIPTION

## Summary

HIMMEL-921 — child 1/4 of HIMMEL-919 (observability design ratified
2026-07-11, §1). The flow-run collection substrate:

- **`~/.himmel/flow-runs.jsonl`** append-only ledger, two-row lifecycle
(`ev:start` at fire, `ev:end` at exit), atomic single-line O_APPEND, 10
MB rotation (keep `.1`), env override `HIMMEL_FLOW_RUNS_LEDGER`.
`stalled` is never self-reported — collector-inferred from an unpaired
start (child 2/4).
- **Twins**: `scripts/lib/flow-run-ledger.sh` (+path resolver) and
`scripts/telegram/flow-run-ledger.ts`, byte-identical canonical rows
enforced by bun contract tests spawning the bash CLI. Outcome classifier
(exit!=0 → error; harness-termination signature / flow marker in log
tail → truncated; else complete) lives in the shared lib only.
`--append-start/--append-end` CLI entries let .bat/.ps1 callers emit
with one subprocess and plain positional args.
- **Emitters** (priority = the flows that burned us, HIMMEL-918):
pipeline-cadence `emit_bat`/`emit_runner` (runner-format v2→v3),
arm-resume schtasks .bat + cron/at launchers (`flow:"armed-resume"`,
note = handover slug), luna-vitals `pull-cadence.sh`/`.ps1`. All ledger
writes fail-soft; every `.log` stays exactly as today.

## Live-fire finding (Windows)

The first .bat implementation captured the run_id via `for /f` over a
backquoted command — a live fire on Windows proved cmd's `/c` re-parse
quote-strips a command that STARTS with a quoted path and carries more
quoted args (`FLOW_RUN_ID` came back empty; text-level tests cannot
catch this). Replaced with temp-file capture (`> "%FLOW_RUN_TMP%"` +
`set /p`), verified end-to-end: both rows written, id captured.

## CR evidence

- Panel (free+paid): lagunaor responded — 0 Critical, 2 Important, both
**disproved with evidence** (the resolvers are deliberate line-for-line
mirrors of the ratified quota-gauge convention; `join("", …)` returns a
relative path, it does not throw). Paid codex critic + codex-adv +
CodeRabbit CLI unavailable this run (codex weekly bank exhausted until
Jul 19; CodeRabbit 900 s timeout) — fail-open per contract; parent
session performed the full inline review (every new file read, all
emitter diffs reviewed, 3 parent-review fixes applied: for /f capture,
run_id minutes precision, lib-side host defaulting).
- Suites green BOTH platforms: pipeline 336W/167L, arm-resume
257W/all-L, arm-proxy, graphmap 178W/98L, codex-sweep 128W/14L, doctor,
bun 16/16, shellcheck clean.

## Merge note

`scripts/lib/cadence-format.sh` gets a one-line version bump (v2→v3) —
in-flight #1191 also touches that file; expect at most a trivial
adjacent-line conflict whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai
-->

## Summary by CodeRabbit

* **New Features**
* Added flow-run tracking for scheduled cadence, handover, and connector
runs.
  * Records run start, completion status, exit code, and outcome.
  * Supports automatic log classification and ledger rotation.
  * Added consistent tracking across Windows and POSIX schedulers.

* **Bug Fixes**
* Improved Windows launcher handling for Bash paths and scheduled job
results.

* **Tests**
  * Updated runner format checks to version 3.
* Added coverage for ledger serialization, classification, isolation,
and rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flow-run tracking for cadence schedules and connector pulls, recording start times, completion status, errors, truncation, and related run details.
  * Added automatic ledger storage with configurable locations and rotation for oversized records.
  * Windows scheduling now verifies Bash availability before creating arms.
* **Bug Fixes**
  * Updated generated cadence runners to format version 3, ensuring runner validation reflects the latest format.
  * Improved outcome detection for interrupted or truncated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->