### PR TITLE
fix(obs): [HIMMEL-921] armed-resume .bat flow-run tmp path lost its backslash-f to a printf form-feed escape (#1194)

### DIFF
--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -2319,7 +2319,7 @@ schedule_arm() {
                 # path and carries more quoted args (live-fire verified s52).
                 printf 'set "FLOW_RUN_ID="
 '
-                printf 'set "FLOW_RUN_TMP=%%TEMP%%low-run-%s.tmp"
+                printf 'set "FLOW_RUN_TMP=%%TEMP%%\\flow-run-%s.tmp"
 ' "$TASK_NAME"
                 printf '"%s" "%s" --append-start "armed-resume" "" "%%COMPUTERNAME%%" "claude" "" "%s" "" "" > "%%FLOW_RUN_TMP%%" 2>NUL
 ' "$bw" "$fl" "$TASK_NAME"

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -1721,6 +1721,10 @@ assert_contains "T-wsl body has in-distro cd+claude" "cd '$WSL_CWD' && claude" "
 assert_not_contains "T-wsl no caret escapes inside CMD quotes" '^&' "$out"
 assert_contains "T-wsl prompt precedes channels" "'load $WSL_HO overnight mode' --channels 'plugin:test@local'" "$out"
 assert_not_contains "T-wsl body drops Windows cd" "cd /d" "$out"
+# Regression (s52/s53 live fire): the flow-run tmp path must carry a LITERAL
+# backslash-f — a mangled printf escape (\f form feed) makes an invalid
+# Windows filename and the capture silently no-ops on a real fire.
+assert_contains "T-wsl bat carries the flow-run tmp path verbatim" 'FLOW_RUN_TMP=%TEMP%\flow-run-' "$out"
 
 # Prompt escaping is driven by the handover path: bash-single-quote per
 # field, then %->%% for the .bat — & and ^ stay LITERAL inside the CMD


### PR DESCRIPTION

## Summary
Live win2 station fire (s53, HIMMEL-965 e2e) exposed it: the s52
merge-conflict resolution injected the FLOW_RUN_TMP printf format
through a python string layer, collapsing the literal backslash-f into a
0x0C form feed. The emitted .bat set FLOW_RUN_TMP to an invalid Windows
filename, the redirect failed, and armed-resume start/end ledger rows
silently never landed (the claude launch itself was unaffected — CMD
continues past the failed line, probe-verified).

Fix: restore the literal escape (byte-verified against emit_bat in
pipeline-cadence.sh, which was authored via editor and never corrupted)
+ a T-wsl regression assert pinning the emitted
`FLOW_RUN_TMP=%TEMP%\flow-run-` text so a mangled escape can never pass
the suite again.

## CR evidence
Panel 2/2 (lagunaor + paid codex): 0 findings. CodeRabbit CLI: 0
findings. codex-adv: approve. arm-resume suite green Windows + Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai
-->

## Summary by CodeRabbit

* **Bug Fixes**
* Fixed Windows scheduled launcher temporary-file paths so flow-run
files are created and accessed in the correct `%TEMP%` location.
* Prevented path formatting issues that could interfere with
temporary-file handling.

* **Tests**
* Added regression coverage to verify correct Windows temporary-path
rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows launcher temp-file path handling so flow runs can reliably create and read temporary files.
  * Improved compatibility with Windows path formatting when launching flows through WSL.

* **Tests**
  * Added regression coverage to verify correct Windows temporary-file paths are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->