### PR TITLE
fix(obs): [HIMMEL-921] ledger lib self-heals PATH when invoked via bare usr/bin bash.exe (#1195)

### DIFF
--- a/scripts/lib/flow-run-ledger.sh
+++ b/scripts/lib/flow-run-ledger.sh
@@ -4,6 +4,16 @@
 # lifecycle rows and appends them to ~/.himmel/flow-runs.jsonl by default.
 # bash 3.2-safe (no associative arrays, no mapfile).
 
+# PATH self-heal: emitted .bat runners invoke this lib via the bare
+# usr\bin\bash.exe (the arm-time `command -v bash` resolution), which does
+# NOT bootstrap the MSYS PATH the way the bin\bash.exe wrapper does. On a
+# host whose WINDOWS PATH lacks Git's usr\bin (live win2 station fire, s53),
+# dirname/date/mkdir/mv are all missing and the append silently dies. The
+# in-process /usr/bin mount always exists for an MSYS bash, so heal from it.
+command -v dirname >/dev/null 2>&1 && command -v date >/dev/null 2>&1 \
+    && command -v mkdir >/dev/null 2>&1 && command -v mv >/dev/null 2>&1 \
+    || PATH="/usr/bin:/bin:$PATH"
+
 _fr_src="${BASH_SOURCE[0]:-$0}"
 _fr_self_dir=$(cd "$(dirname "$_fr_src")" 2>/dev/null && pwd) || _fr_self_dir="$(dirname "$_fr_src")"
 # shellcheck source=flow-run-ledger-path.sh


### PR DESCRIPTION

## Summary
Second live win2 station fire (s53) still wrote no ledger rows even
after #1194: the emitted .bat invokes the lib via the arm-time `command
-v bash` resolution = `usr\bin\bash.exe`, which does NOT bootstrap the
MSYS PATH the `bin\bash.exe` wrapper provides. On a host whose Windows
PATH lacks Git's usr\bin (win2), dirname/date/mkdir/mv were all missing
— path resolution collapsed and the append silently died. My dev machine
masked it (its Windows PATH carries Git's usr\bin).

Fix: the lib prepends the in-process `/usr/bin` MSYS mount when
`dirname` is unresolvable (one builtin probe, zero cost on healthy
PATHs). Verified under `env -i PATH=System32` with the raw usr/bin
bash.exe: full canonical row written.

## CR evidence
Panel 2/2 (lagunaor + paid codex): 0 findings. CodeRabbit CLI: 0
findings. codex-adv: timeout (fail-open). Contract tests 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai
-->
## Summary by CodeRabbit

* **Bug Fixes**
* Improved reliability of ledger updates in certain Windows/MSYS
environments by adding a startup check that ensures required system
utilities are available, automatically repairing the PATH when they
aren’t.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved script reliability by automatically restoring access to essential system utilities when they are missing from the current environment.
  - Prevented ledger and append operations from silently failing in affected shell environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->