### PR TITLE
feat(obs): [HIMMEL-922] flow exporter + local Prometheus/Grafana Phase A stack + war-room dashboard (#1196)

### DIFF
--- a/scripts/observability/README.md
+++ b/scripts/observability/README.md
@@ -1,0 +1,117 @@
+# himmel observability Phase A
+
+Phase A is a local, passive Prometheus/Grafana stack for the Windows host. The
+flow exporter is a tiny Bun HTTP server bound to `127.0.0.1:9877`; Prometheus
+scrapes it every 60s and also scrapes `windows_exporter` on `127.0.0.1:9182`.
+
+## Passivity invariant
+
+The exporter is a pure reader. It never writes ledgers, never mutates the vault,
+never starts or kills processes, and never enforces quota or flow policy. Missing
+data stays missing: metric families are omitted when their substrate is absent.
+The only explicit zero for a silent configured flow is
+`flow_run_in_flight{flow} 0`.
+
+Flow outcome counters are folded from the sliding 14 day ledger window at scrape
+time, reading both `flow-runs.jsonl` and `flow-runs.jsonl.1`. The
+`flow_run_outcome_total` family keeps the counter name and type the ratified
+design (§3) pins, but its values are WINDOW-FOLDED: they decrease when rows age
+past 14 days, which Prometheus reads as a counter reset — `rate()`/`increase()`
+then briefly overcount around a slide. For the war-room panels (7d ranges over
+a 14d window, low row churn) that artifact is small and accepted; if it ever
+misleads, the fix is in-process monotonic accumulation in the collector child
+(HIMMEL-924), not a family rename here.
+
+Unpaired `start` rows older than a flow deadline are exported as inferred
+`stalled` outcomes. The flow-run ledger itself never contains `stalled`.
+
+## Configuration
+
+Default config path:
+
+```text
+~/.himmel/observability.json
+```
+
+Override:
+
+```text
+HIMMEL_OBSERVABILITY_CONFIG=/path/to/observability.json
+```
+
+Shape:
+
+```json
+{
+  "flows": [
+    {
+      "name": "pipeline-harvest",
+      "cadence_seconds": 86400,
+      "stall_deadline_seconds": 7200
+    }
+  ],
+  "expected_tasks": [
+    "himmel-pipeline-harvest"
+  ],
+  "vault_path": "C:/Users/you/Documents/luna"
+}
+```
+
+Rules:
+
+- `stall_deadline_seconds` wins when present.
+- Otherwise the stall deadline is `2 * cadence_seconds`.
+- Unknown flows seen only in the ledger default to a 6 hour stall deadline.
+- Missing config is valid; the exporter still serves metrics derivable from
+  ledgers alone.
+- `expected_tasks` is Windows-only. Non-Windows platforms omit the scheduled
+  task family and add a comment in `/metrics`.
+- `vault_path` is optional. Without it, Luna backlog metrics are omitted.
+
+## Metrics
+
+Flow metrics are derived from `~/.himmel/flow-runs.jsonl` unless
+`HIMMEL_FLOW_RUNS_LEDGER` overrides the path.
+
+Quota metrics are re-exported through `scripts/telegram/quota-gauge.ts` from
+`~/.himmel/quota-gauge.jsonl` unless `HIMMEL_QUOTA_GAUGE_LEDGER` overrides the
+path. Lane budget metadata from `scripts/lanes/lanes.json` may appear as
+registry labels, such as `posture="conserve"`, when present.
+
+Scheduled task and Luna backlog walks are cached for 60s. The flow ledger fold
+runs on every scrape so in-flight age and stall inference are fresh.
+
+## Install on Windows
+
+From a PowerShell session in the repo:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/observability/install-stack.ps1
+```
+
+The script installs or verifies Prometheus, Grafana OSS, `windows_exporter`, and
+Bun, copies `prometheus.yml` under `%LOCALAPPDATA%\himmel\observability`, and
+registers user-level logon scheduled tasks:
+
+- `himmel-observability-prometheus`
+- `himmel-observability-grafana`
+- `himmel-observability-windows-exporter`
+- `himmel-observability-flow-exporter`
+
+URLs after the tasks are running:
+
+- Prometheus: `http://127.0.0.1:9090`
+- Grafana: `http://127.0.0.1:3000`
+- Flow exporter: `http://127.0.0.1:9877/metrics`
+- windows_exporter: `http://127.0.0.1:9182/metrics`
+
+Import `dashboards/war-room-system.json` into Grafana and bind the
+`${DS_PROMETHEUS}` variable to the local Prometheus datasource.
+
+## Deliberately not here
+
+- RAM process trees, orphan attribution, and per-subtree memory panels:
+  HIMMEL-924.
+- Alert rules and Telegram alerting.
+- Loki or log ingestion.
+- Docker, brew, apt, or other Phase B packaging.

--- a/scripts/observability/dashboards/war-room-system.json
+++ b/scripts/observability/dashboards/war-room-system.json
@@ -1,0 +1,291 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "Flows",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 86400 },
+              { "color": "red", "value": 172800 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        { "expr": "time() - flow_run_last_success_timestamp", "legendFormat": "{{flow}}", "refId": "A" }
+      ],
+      "title": "Last success age",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "mappings": [], "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 1 },
+      "id": 3,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        { "expr": "sum by (flow,outcome) (increase(flow_run_outcome_total[7d]))", "legendFormat": "{{flow}} {{outcome}}", "refId": "A" }
+      ],
+      "title": "Last outcomes and 7d movement",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "decimals": 2, "mappings": [], "max": 1, "min": 0, "unit": "percentunit" }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 1 },
+      "id": 4,
+      "options": { "displayMode": "gradient", "maxVizHeight": 300, "minVizHeight": 10, "minVizWidth": 0, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "showUnfilled": true, "valueMode": "color" },
+      "targets": [
+        { "expr": "sum by (flow) (increase(flow_run_outcome_total{outcome=\"complete\"}[7d])) / clamp_min(sum by (flow) (increase(flow_run_outcome_total{outcome=~\"complete|truncated\"}[7d])), 1)", "legendFormat": "{{flow}}", "refId": "A" }
+      ],
+      "title": "Success vs truncation rate 7d",
+      "type": "bargauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "mappings": [], "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 1 },
+      "id": 5,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        { "expr": "flow_run_items_processed", "legendFormat": "{{flow}}", "refId": "A" },
+        { "expr": "flow_run_in_flight", "legendFormat": "{{flow}} in flight", "refId": "B" }
+      ],
+      "title": "Items and in-flight runs",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 6 },
+      "id": 6,
+      "panels": [],
+      "title": "Schedulers",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "mappings": [{ "options": { "0": { "text": "missing" }, "1": { "text": "exists" } }, "type": "value" }], "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] } }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 7 },
+      "id": 7,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        { "expr": "scheduled_task_exists", "legendFormat": "{{task}}", "refId": "A" }
+      ],
+      "title": "Task exists",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "mappings": [{ "options": { "0": { "text": "disabled" }, "1": { "text": "enabled" } }, "type": "value" }], "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] } }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 7 },
+      "id": 8,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        { "expr": "scheduled_task_enabled", "legendFormat": "{{task}}", "refId": "A" }
+      ],
+      "title": "Task enabled",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "mappings": [], "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 7 },
+      "id": 9,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        { "expr": "clamp_min(time() - scheduled_task_next_run_timestamp, 0)", "legendFormat": "{{task}}", "refId": "A" }
+      ],
+      "title": "Next run overdue by",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 12 },
+      "id": 10,
+      "panels": [],
+      "title": "Luna pipeline",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "mappings": [], "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 13 },
+      "id": 11,
+      "options": { "displayMode": "gradient", "maxVizHeight": 300, "minVizHeight": 10, "minVizWidth": 0, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "showUnfilled": true, "valueMode": "color" },
+      "targets": [
+        { "expr": "luna_inbox_backlog", "legendFormat": "{{stage}}", "refId": "A" }
+      ],
+      "title": "Inbox backlog",
+      "type": "bargauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "mappings": [], "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 13 },
+      "id": 12,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        { "expr": "luna_inbox_backlog{stage=\"unharvested\"}", "legendFormat": "unharvested", "refId": "A" }
+      ],
+      "title": "Harvest lag proxy",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "mappings": [], "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 13 },
+      "id": 13,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        { "expr": "luna_done_graduations_month", "legendFormat": "current month", "refId": "A" }
+      ],
+      "title": "Graduations this month",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
+      "id": 14,
+      "panels": [],
+      "title": "Host",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "mappings": [], "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 19 },
+      "id": 15,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "targets": [
+        { "expr": "up{job=~\"flow-exporter|windows_exporter|prometheus\"}", "legendFormat": "{{job}}", "refId": "A" }
+      ],
+      "title": "Exporter health",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "mappings": [], "unit": "percentunit" }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 19 },
+      "id": 16,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        { "expr": "1 - avg by (instance) (rate(windows_cpu_time_total{mode=\"idle\"}[5m]))", "legendFormat": "CPU {{instance}}", "refId": "A" }
+      ],
+      "title": "CPU baseline",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "mappings": [], "unit": "percentunit" }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 19 },
+      "id": 17,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "none" } },
+      "targets": [
+        { "expr": "1 - (windows_os_physical_memory_free_bytes / windows_cs_physical_memory_bytes)", "legendFormat": "RAM {{instance}}", "refId": "A" }
+      ],
+      "title": "RAM baseline",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 19 },
+      "id": 18,
+      "options": { "code": { "language": "plaintext", "showLineNumbers": false, "showMiniMap": false }, "content": "RAM process trees, orphan detection, and per-subtree attribution are intentionally out of scope for HIMMEL-922. They belong to HIMMEL-924.", "mode": "markdown" },
+      "title": "HIMMEL-924 placeholder",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+      "id": 19,
+      "panels": [],
+      "title": "Lanes/bank",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 65 },
+              { "color": "red", "value": 80 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 25 },
+      "id": 20,
+      "options": { "displayMode": "gradient", "maxVizHeight": 300, "minVizHeight": 10, "minVizWidth": 0, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "showUnfilled": true, "valueMode": "color" },
+      "targets": [
+        { "expr": "lane_quota_used_pct", "legendFormat": "{{lane}} {{posture}}", "refId": "A" }
+      ],
+      "title": "Lane quota used",
+      "type": "bargauge"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["himmel", "observability"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "War room — system",
+  "uid": "himmel-war-room-system",
+  "version": 1,
+  "weekStart": ""
+}

--- a/scripts/observability/flow-exporter.test.ts
+++ b/scripts/observability/flow-exporter.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { renderMetrics, createExporterCache } from "./flow-exporter";
+import { serializeFlowRunEnd, serializeFlowRunStart, type FlowRunEnd, type FlowRunStart } from "../telegram/flow-run-ledger";
+import { serializeQuotaGauge, type QuotaGaugeRecord } from "../telegram/quota-gauge";
+
+let tmp: string;
+beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "flow-exporter-")); });
+afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+const NOW = Date.parse("2026-07-13T12:00:00Z");
+
+function epoch(iso: string): number {
+  return Math.floor(Date.parse(iso) / 1000);
+}
+
+function flowStart(flow: string, runId: string, firedAt: string): FlowRunStart {
+  return {
+    v: 1,
+    ev: "start",
+    flow,
+    run_id: runId,
+    fired_at: firedAt,
+    host: "test-host",
+    lane: "claude",
+    model: "opus",
+    task_name: null,
+    log_path: null,
+    pid: 123,
+  };
+}
+
+function flowEnd(flow: string, runId: string, endedAt: string, outcome: FlowRunEnd["outcome"], items: number | null): FlowRunEnd {
+  return {
+    v: 1,
+    ev: "end",
+    flow,
+    run_id: runId,
+    ended_at: endedAt,
+    exit_code: outcome === "error" ? 1 : 0,
+    outcome,
+    items_processed: items,
+    note: null,
+  };
+}
+
+function quota(partial: Partial<QuotaGaugeRecord>): QuotaGaugeRecord {
+  return {
+    v: 1,
+    ts: "2026-07-13T11:59:30Z",
+    lane: "glm",
+    source: "test",
+    used_pct: 62,
+    window: "5h",
+    reset_at: null,
+    tier: null,
+    glm_peak: false,
+    note: null,
+    ...partial,
+  };
+}
+
+function writeLines(path: string, lines: string[]): void {
+  writeFileSync(path, lines.join("\n") + "\n");
+}
+
+function normalizeMetrics(body: string): string {
+  return body.replace(/^flow_exporter_scrape_duration_seconds .+$/m, "flow_exporter_scrape_duration_seconds 0");
+}
+
+test("golden scrape folds active and rotated flow ledgers", async () => {
+  const ledger = join(tmp, "flow-runs.jsonl");
+  const config = join(tmp, "observability.json");
+  writeFileSync(config, JSON.stringify({
+    flows: [
+      { name: "pipeline-harvest", cadence_seconds: 86400, stall_deadline_seconds: 7200 },
+      { name: "pipeline-synthesize", cadence_seconds: 3600 },
+      { name: "pipeline-silent", cadence_seconds: 60 },
+    ],
+  }));
+  writeLines(ledger + ".1", [
+    serializeFlowRunStart(flowStart("pipeline-harvest", "h1", "2026-07-12T09:00:00Z")),
+    serializeFlowRunEnd(flowEnd("pipeline-harvest", "h1", "2026-07-12T10:00:00Z", "complete", 17)),
+    serializeFlowRunStart(flowStart("pipeline-synthesize", "s1", "2026-07-12T11:00:00Z")),
+    serializeFlowRunEnd(flowEnd("pipeline-synthesize", "s1", "2026-07-12T11:05:00Z", "truncated", null)),
+  ]);
+  writeLines(ledger, [
+    serializeFlowRunStart(flowStart("pipeline-harvest", "h2", "2026-07-13T08:00:00Z")),
+    serializeFlowRunEnd(flowEnd("pipeline-harvest", "h2", "2026-07-13T08:15:00Z", "error", 3)),
+    serializeFlowRunStart(flowStart("pipeline-harvest", "h3", "2026-07-13T11:50:00Z")),
+  ]);
+
+  const body = normalizeMetrics(await renderMetrics({
+    nowMs: NOW,
+    configPath: config,
+    flowLedgerPath: ledger,
+    quotaLedgerPath: join(tmp, "missing-quota.jsonl"),
+    platform: "linux",
+  }));
+
+  expect(body).toBe(`# HELP flow_run_last_success_timestamp Epoch seconds of the last complete run end row in the 14d ledger window.
+# TYPE flow_run_last_success_timestamp gauge
+flow_run_last_success_timestamp{flow="pipeline-harvest"} ${epoch("2026-07-12T10:00:00Z")}
+# HELP flow_run_outcome_total Runs by outcome in the sliding 14d ledger window; exporter restarts and window slides can reset this counter.
+# TYPE flow_run_outcome_total counter
+flow_run_outcome_total{flow="pipeline-harvest",outcome="complete"} 1
+flow_run_outcome_total{flow="pipeline-harvest",outcome="truncated"} 0
+flow_run_outcome_total{flow="pipeline-harvest",outcome="error"} 1
+flow_run_outcome_total{flow="pipeline-harvest",outcome="stalled"} 0
+flow_run_outcome_total{flow="pipeline-synthesize",outcome="complete"} 0
+flow_run_outcome_total{flow="pipeline-synthesize",outcome="truncated"} 1
+flow_run_outcome_total{flow="pipeline-synthesize",outcome="error"} 0
+flow_run_outcome_total{flow="pipeline-synthesize",outcome="stalled"} 0
+# HELP flow_run_items_processed Last ended run items_processed value; null is omitted.
+# TYPE flow_run_items_processed gauge
+flow_run_items_processed{flow="pipeline-harvest"} 3
+# HELP flow_run_items_processed_total Sum of non-null items_processed values in the sliding 14d ledger window.
+# TYPE flow_run_items_processed_total counter
+flow_run_items_processed_total{flow="pipeline-harvest"} 20
+# HELP flow_run_in_flight Unpaired start rows still within the flow stall deadline.
+# TYPE flow_run_in_flight gauge
+flow_run_in_flight{flow="pipeline-harvest"} 1
+flow_run_in_flight{flow="pipeline-silent"} 0
+flow_run_in_flight{flow="pipeline-synthesize"} 0
+# HELP flow_exporter_scrape_duration_seconds Wall-clock duration of this exporter scrape.
+# TYPE flow_exporter_scrape_duration_seconds gauge
+flow_exporter_scrape_duration_seconds 0
+# HELP flow_exporter_ledger_rows Parsed flow-run ledger rows inside the 14d window.
+# TYPE flow_exporter_ledger_rows gauge
+flow_exporter_ledger_rows 7
+`);
+  expect(body).not.toContain('flow_run_last_success_timestamp{flow="pipeline-silent"');
+  expect(body).not.toContain('flow_run_items_processed{flow="pipeline-synthesize"');
+});
+
+test("stall inference separates expired unpaired starts from in-flight starts", async () => {
+  const ledger = join(tmp, "flow-runs.jsonl");
+  const config = join(tmp, "observability.json");
+  writeFileSync(config, JSON.stringify({ flows: [{ name: "short-flow", cadence_seconds: 100 }] }));
+  writeLines(ledger, [
+    serializeFlowRunStart(flowStart("short-flow", "old", "2026-07-13T11:55:00Z")),
+    serializeFlowRunStart(flowStart("short-flow", "new", "2026-07-13T11:58:20Z")),
+  ]);
+  const body = await renderMetrics({ nowMs: NOW, configPath: config, flowLedgerPath: ledger, quotaLedgerPath: join(tmp, "none") });
+  expect(body).toContain('flow_run_outcome_total{flow="short-flow",outcome="stalled"} 1');
+  expect(body).toContain('flow_run_in_flight{flow="short-flow"} 1');
+});
+
+test("active ledger without config uses default six-hour stall deadline", async () => {
+  const ledger = join(tmp, "flow-runs.jsonl");
+  writeLines(ledger, [
+    serializeFlowRunStart(flowStart("unconfigured-flow", "old", "2026-07-13T04:59:00Z")),
+  ]);
+  const body = await renderMetrics({
+    nowMs: NOW,
+    configPath: join(tmp, "missing-observability.json"),
+    flowLedgerPath: ledger,
+    quotaLedgerPath: join(tmp, "none"),
+  });
+  expect(body).toContain('flow_run_outcome_total{flow="unconfigured-flow",outcome="stalled"} 1');
+  expect(body).toContain('flow_run_in_flight{flow="unconfigured-flow"} 0');
+});
+
+test("quota gauge ledger is re-exported through quotaGaugeRead", async () => {
+  const flowLedger = join(tmp, "flow-runs.jsonl");
+  const quotaLedger = join(tmp, "quota-gauge.jsonl");
+  const lanes = join(tmp, "lanes.json");
+  writeLines(flowLedger, []);
+  writeLines(quotaLedger, [serializeQuotaGauge(quota({ lane: "glm", used_pct: 62 }))]);
+  writeFileSync(lanes, JSON.stringify({ lanes: [{ id: "glm", budget: { posture: "conserve" } }] }));
+  const body = await renderMetrics({ nowMs: NOW, flowLedgerPath: flowLedger, quotaLedgerPath: quotaLedger, lanesPath: lanes });
+  expect(body).toContain('# HELP lane_quota_used_pct Latest observed quota used percentage per lane from the passive quota gauge ledger.');
+  expect(body).toContain('lane_quota_used_pct{lane="glm",posture="conserve"} 62');
+});
+
+test("luna backlog counts inbox stages and monthly graduations, read-only", async () => {
+  const ledger = join(tmp, "flow-runs.jsonl");
+  const config = join(tmp, "observability.json");
+  const vault = join(tmp, "vault");
+  const clippings = join(vault, "Clippings");
+  const month = new Date(NOW).toISOString().slice(0, 7);
+  const done = join(clippings, "_done", month);
+  writeLines(ledger, []);
+  writeFileSync(config, JSON.stringify({ vault_path: vault }));
+  mkdirSync(done, { recursive: true });
+  writeFileSync(join(clippings, "a.md"), "---\nprocessed: true\nharvested_at: 2026-07-01\n---\nbody\n");
+  writeFileSync(join(clippings, "b.md"), "---\nharvested_at: 2026-07-02\n---\nbody\n");
+  writeFileSync(join(clippings, "c.md"), "---\ntitle: raw\n---\nbody\n");
+  writeFileSync(join(done, "old.md"), "graduated\n");
+
+  const body = await renderMetrics({ nowMs: NOW, configPath: config, flowLedgerPath: ledger, quotaLedgerPath: join(tmp, "none") });
+  expect(body).toContain('luna_inbox_backlog{stage="unprocessed"} 2');
+  expect(body).toContain('luna_inbox_backlog{stage="unharvested"} 1');
+  expect(body).toContain("luna_done_graduations_month 1");
+});
+
+test("scheduled-task scrape is platform-gated and TTL-cached", async () => {
+  const config = join(tmp, "observability.json");
+  const ledger = join(tmp, "flow-runs.jsonl");
+  writeFileSync(config, JSON.stringify({ expected_tasks: ["himmel-pipeline-harvest", "himmel-pipeline-synthesize"] }));
+  writeLines(ledger, []);
+  const cache = createExporterCache();
+  let calls = 0;
+  const runner = () => {
+    calls++;
+    return [
+      { task: "himmel-pipeline-harvest", exists: 1 as const, enabled: 1 as const, next_run_timestamp: 1783915200 },
+      { task: "himmel-pipeline-synthesize", exists: 0 as const, enabled: 0 as const, next_run_timestamp: null },
+    ];
+  };
+  const first = await renderMetrics({ nowMs: NOW, configPath: config, flowLedgerPath: ledger, quotaLedgerPath: join(tmp, "none"), platform: "win32", schedulerRunner: runner, cache });
+  const second = await renderMetrics({ nowMs: NOW + 1000, configPath: config, flowLedgerPath: ledger, quotaLedgerPath: join(tmp, "none"), platform: "win32", schedulerRunner: runner, cache });
+  expect(calls).toBe(1);
+  expect(first).toContain('scheduled_task_exists{task="himmel-pipeline-harvest"} 1');
+  expect(first).toContain('scheduled_task_enabled{task="himmel-pipeline-harvest"} 1');
+  expect(first).toContain('scheduled_task_next_run_timestamp{task="himmel-pipeline-harvest"} 1783915200');
+  expect(second).toContain('scheduled_task_exists{task="himmel-pipeline-synthesize"} 0');
+
+  const linux = await renderMetrics({ nowMs: NOW, configPath: config, flowLedgerPath: ledger, quotaLedgerPath: join(tmp, "none"), platform: "linux", cache: createExporterCache() });
+  expect(linux).toContain("# scheduled_task_* omitted: platform has no Windows Scheduled Tasks API");
+  expect(linux).not.toContain("scheduled_task_exists");
+});

--- a/scripts/observability/flow-exporter.ts
+++ b/scripts/observability/flow-exporter.ts
@@ -1,0 +1,556 @@
+// HIMMEL-922 passive Prometheus exporter over local flow/quota ledgers.
+// Pure reader: no ledger writes, no process control, no enforcement.
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { ledgerPath as flowRunLedgerPath, type FlowRunEnd, type FlowRunRow, type FlowRunStart } from "../telegram/flow-run-ledger";
+import { ledgerPath as quotaGaugeLedgerPath, quotaGaugeRead } from "../telegram/quota-gauge";
+
+const LOOKBACK_MS = 14 * 24 * 60 * 60 * 1000;
+const DEFAULT_STALL_DEADLINE_SECONDS = 6 * 60 * 60;
+const CACHE_TTL_MS = 60 * 1000;
+const SCHEDULER_QUERY_TIMEOUT_MS = 10 * 1000;
+const DEFAULT_PORT = 9877;
+
+type FlowConfig = {
+  name: string;
+  cadence_seconds?: number;
+  stall_deadline_seconds?: number;
+};
+
+type ObservabilityConfig = {
+  flows?: FlowConfig[];
+  expected_tasks?: string[];
+  vault_path?: string;
+};
+
+type ScheduledTaskSample = {
+  task: string;
+  exists: 0 | 1;
+  enabled?: 0 | 1;
+  next_run_timestamp?: number | null;
+};
+
+type SchedulerRunner = (tasks: string[]) => ScheduledTaskSample[] | Promise<ScheduledTaskSample[]>;
+
+type Cached<T> = {
+  key: string;
+  fetchedAtMs: number;
+  value: T;
+};
+
+export type ExporterCache = {
+  scheduler?: Cached<{ samples: ScheduledTaskSample[]; comments: string[] }>;
+  luna?: Cached<{ samples: string[] }>;
+};
+
+export type RenderMetricsOptions = {
+  env?: Record<string, string | undefined>;
+  nowMs?: number;
+  configPath?: string;
+  flowLedgerPath?: string;
+  quotaLedgerPath?: string;
+  lanesPath?: string;
+  platform?: NodeJS.Platform;
+  schedulerRunner?: SchedulerRunner;
+  cache?: ExporterCache;
+};
+
+type FlowStats = {
+  flow: string;
+  observed: boolean;
+  lastSuccessTimestamp?: number;
+  outcomes: Record<"complete" | "truncated" | "error" | "stalled", number>;
+  latestEndMs?: number;
+  latestItemsProcessed?: number | null;
+  itemsProcessedTotal: number;
+  hasItemsProcessedTotal: boolean;
+  inFlight: number;
+};
+
+type LaneRegistry = {
+  lanes?: Array<{
+    id?: string;
+    budget?: Record<string, unknown>;
+  }>;
+};
+
+function configPath(env: Record<string, string | undefined>): string {
+  const override = env.HIMMEL_OBSERVABILITY_CONFIG;
+  if (override && override.trim()) return override;
+  const home = env.HOME ?? homedir();
+  return join(home, ".himmel", "observability.json");
+}
+
+function readConfig(path: string): ObservabilityConfig {
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as ObservabilityConfig;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function readJsonFile<T>(path: string): T | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+function timestampOf(row: FlowRunRow): number {
+  const ts = row.ev === "start" ? row.fired_at : row.ended_at;
+  const ms = Date.parse(ts);
+  return Number.isFinite(ms) ? ms : NaN;
+}
+
+function deadlineSeconds(flow: string, config: ObservabilityConfig): number {
+  const declared = (config.flows ?? []).find((f) => f.name === flow);
+  if (declared?.stall_deadline_seconds && declared.stall_deadline_seconds > 0) {
+    return declared.stall_deadline_seconds;
+  }
+  if (declared?.cadence_seconds && declared.cadence_seconds > 0) {
+    return declared.cadence_seconds * 2;
+  }
+  return DEFAULT_STALL_DEADLINE_SECONDS;
+}
+
+function emptyStats(flow: string): FlowStats {
+  return {
+    flow,
+    observed: false,
+    outcomes: { complete: 0, truncated: 0, error: 0, stalled: 0 },
+    itemsProcessedTotal: 0,
+    hasItemsProcessedTotal: false,
+    inFlight: 0,
+  };
+}
+
+function parseFlowLedgerRows(path: string, nowMs: number): { rows: FlowRunRow[]; ledgerRows: number } {
+  const cutoff = nowMs - LOOKBACK_MS;
+  const rows: FlowRunRow[] = [];
+  for (const p of [path + ".1", path]) {
+    if (!existsSync(p)) continue;
+    const lines = readFileSync(p, "utf8").split(/\r?\n/);
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let row: FlowRunRow;
+      try {
+        row = JSON.parse(line) as FlowRunRow;
+      } catch {
+        continue;
+      }
+      if (row.v !== 1 || (row.ev !== "start" && row.ev !== "end") || typeof row.flow !== "string") continue;
+      const ms = timestampOf(row);
+      if (!Number.isFinite(ms) || ms < cutoff || ms > nowMs + 60_000) continue;
+      rows.push(row);
+    }
+  }
+  return { rows, ledgerRows: rows.length };
+}
+
+function foldFlowLedger(rows: FlowRunRow[], config: ObservabilityConfig, nowMs: number): Map<string, FlowStats> {
+  const stats = new Map<string, FlowStats>();
+  const starts = new Map<string, FlowRunStart>();
+  const endedRunIds = new Set<string>();
+
+  for (const flow of config.flows ?? []) {
+    if (flow.name) stats.set(flow.name, emptyStats(flow.name));
+  }
+
+  const ensure = (flow: string): FlowStats => {
+    let s = stats.get(flow);
+    if (!s) {
+      s = emptyStats(flow);
+      stats.set(flow, s);
+    }
+    return s;
+  };
+
+  for (const row of rows) {
+    const s = ensure(row.flow);
+    s.observed = true;
+    if (row.ev === "start") {
+      starts.set(row.run_id, row);
+      continue;
+    }
+
+    const end = row as FlowRunEnd;
+    endedRunIds.add(end.run_id);
+    if (end.outcome === "complete" || end.outcome === "truncated" || end.outcome === "error") {
+      s.outcomes[end.outcome]++;
+      const endedMs = Date.parse(end.ended_at);
+      if (end.outcome === "complete" && Number.isFinite(endedMs)) {
+        const epoch = Math.floor(endedMs / 1000);
+        if (s.lastSuccessTimestamp === undefined || epoch > s.lastSuccessTimestamp) {
+          s.lastSuccessTimestamp = epoch;
+        }
+      }
+      if (Number.isFinite(endedMs) && (s.latestEndMs === undefined || endedMs >= s.latestEndMs)) {
+        s.latestEndMs = endedMs;
+        s.latestItemsProcessed = end.items_processed;
+      }
+      if (typeof end.items_processed === "number" && Number.isFinite(end.items_processed)) {
+        s.itemsProcessedTotal += end.items_processed;
+        s.hasItemsProcessedTotal = true;
+      }
+    }
+  }
+
+  for (const start of starts.values()) {
+    if (endedRunIds.has(start.run_id)) continue;
+    const s = ensure(start.flow);
+    const firedMs = Date.parse(start.fired_at);
+    if (!Number.isFinite(firedMs)) continue;
+    const ageS = (nowMs - firedMs) / 1000;
+    if (ageS > deadlineSeconds(start.flow, config)) {
+      s.outcomes.stalled++;
+    } else {
+      s.inFlight++;
+    }
+  }
+
+  return stats;
+}
+
+function escLabel(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
+}
+
+function sample(name: string, labels: Record<string, string>, value: number): string {
+  const entries = Object.entries(labels).sort(([a], [b]) => a.localeCompare(b));
+  const labelText = entries.map(([k, v]) => `${k}="${escLabel(v)}"`).join(",");
+  return labelText ? `${name}{${labelText}} ${formatNumber(value)}` : `${name} ${formatNumber(value)}`;
+}
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(6).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function addFamily(lines: string[], name: string, help: string, type: "gauge" | "counter", samples: string[]): void {
+  if (samples.length === 0) return;
+  lines.push(`# HELP ${name} ${help}`);
+  lines.push(`# TYPE ${name} ${type}`);
+  lines.push(...samples);
+}
+
+function buildFlowMetrics(path: string, config: ObservabilityConfig, nowMs: number): { lines: string[]; ledgerRows: number } {
+  const { rows, ledgerRows } = parseFlowLedgerRows(path, nowMs);
+  const stats = [...foldFlowLedger(rows, config, nowMs).values()].sort((a, b) => a.flow.localeCompare(b.flow));
+  const lines: string[] = [];
+
+  addFamily(lines, "flow_run_last_success_timestamp", "Epoch seconds of the last complete run end row in the 14d ledger window.", "gauge",
+    stats.flatMap((s) => s.lastSuccessTimestamp === undefined ? [] : [sample("flow_run_last_success_timestamp", { flow: s.flow }, s.lastSuccessTimestamp)]));
+
+  const outcomes: Array<"complete" | "truncated" | "error" | "stalled"> = ["complete", "truncated", "error", "stalled"];
+  addFamily(lines, "flow_run_outcome_total", "Runs by outcome in the sliding 14d ledger window; exporter restarts and window slides can reset this counter.", "counter",
+    stats.flatMap((s) => s.observed ? outcomes.map((outcome) => sample("flow_run_outcome_total", { flow: s.flow, outcome }, s.outcomes[outcome])) : []));
+
+  addFamily(lines, "flow_run_items_processed", "Last ended run items_processed value; null is omitted.", "gauge",
+    stats.flatMap((s) => typeof s.latestItemsProcessed === "number" ? [sample("flow_run_items_processed", { flow: s.flow }, s.latestItemsProcessed)] : []));
+
+  addFamily(lines, "flow_run_items_processed_total", "Sum of non-null items_processed values in the sliding 14d ledger window.", "counter",
+    stats.flatMap((s) => s.hasItemsProcessedTotal ? [sample("flow_run_items_processed_total", { flow: s.flow }, s.itemsProcessedTotal)] : []));
+
+  addFamily(lines, "flow_run_in_flight", "Unpaired start rows still within the flow stall deadline.", "gauge",
+    stats.map((s) => sample("flow_run_in_flight", { flow: s.flow }, s.inFlight)));
+
+  return { lines, ledgerRows };
+}
+
+function normalizeTaskSamples(raw: unknown): ScheduledTaskSample[] {
+  const arr = Array.isArray(raw) ? raw : raw ? [raw] : [];
+  const samples: ScheduledTaskSample[] = [];
+  for (const item of arr) {
+    if (!item || typeof item !== "object") continue;
+    const row = item as Record<string, unknown>;
+    const task = typeof row.task === "string" ? row.task : typeof row.Task === "string" ? row.Task : null;
+    if (!task) continue;
+    const exists = row.exists ?? row.Exists;
+    const enabled = row.enabled ?? row.Enabled;
+    const next = row.next_run_timestamp ?? row.NextRunTimestamp;
+    samples.push({
+      task,
+      exists: exists === 1 || exists === true ? 1 : 0,
+      enabled: enabled === 1 || enabled === true ? 1 : 0,
+      next_run_timestamp: typeof next === "number" && Number.isFinite(next) ? next : null,
+    });
+  }
+  return samples;
+}
+
+function powershellArrayLiteral(values: string[]): string {
+  return JSON.stringify(values).replace(/'/g, "''");
+}
+
+async function runWindowsScheduledTasks(tasks: string[]): Promise<ScheduledTaskSample[]> {
+  if (tasks.length === 0) return [];
+  const namesJson = powershellArrayLiteral(tasks);
+  const script = `
+$ErrorActionPreference = 'SilentlyContinue'
+$names = ConvertFrom-Json '${namesJson}'
+# UTC-kind epoch anchor: [datetime]'...Z' parses as LOCAL kind, and DateTime
+# subtraction ignores Kind, which would skew next_run by the UTC offset.
+$epoch = [datetime]::new(1970, 1, 1, 0, 0, 0, [System.DateTimeKind]::Utc)
+$out = foreach ($name in $names) {
+  $task = Get-ScheduledTask -TaskName $name -ErrorAction SilentlyContinue
+  if ($null -eq $task) {
+    [pscustomobject]@{ task = $name; exists = 0; enabled = 0; next_run_timestamp = $null }
+    continue
+  }
+  $enabled = 0
+  if ($task.State -ne 'Disabled') { $enabled = 1 }
+  $nextEpoch = $null
+  $info = Get-ScheduledTaskInfo -TaskName $name -ErrorAction SilentlyContinue
+  if ($null -ne $info -and $null -ne $info.NextRunTime -and $info.NextRunTime -gt $epoch) {
+    $nextEpoch = [int64](($info.NextRunTime.ToUniversalTime() - $epoch).TotalSeconds)
+  }
+  [pscustomobject]@{ task = $name; exists = 1; enabled = $enabled; next_run_timestamp = $nextEpoch }
+}
+$out | ConvertTo-Json -Compress
+`.trim();
+  // Async spawn with a hard timeout: a hung PowerShell must fail this family
+  // closed (omitted), never freeze the scrape server the way a sync spawn
+  // on the request path would.
+  const proc = Bun.spawn(["powershell", "-NoProfile", "-Command", script], { stdout: "pipe", stderr: "pipe" });
+  const timer = setTimeout(() => {
+    try { proc.kill(); } catch { /* already gone */ }
+  }, SCHEDULER_QUERY_TIMEOUT_MS);
+  try {
+    const exitCode = await proc.exited;
+    clearTimeout(timer);
+    if (exitCode !== 0) return [];
+    const out = await new Response(proc.stdout).text();
+    return normalizeTaskSamples(JSON.parse(out));
+  } catch {
+    clearTimeout(timer);
+    return [];
+  }
+}
+
+async function scheduledTaskMetrics(
+  config: ObservabilityConfig,
+  opts: Required<Pick<RenderMetricsOptions, "platform" | "nowMs" | "cache">> & { schedulerRunner?: SchedulerRunner },
+): Promise<{ lines: string[]; comments: string[] }> {
+  const tasks = [...(config.expected_tasks ?? [])].filter(Boolean).sort();
+  if (tasks.length === 0) return { lines: [], comments: [] };
+  if (opts.platform !== "win32") {
+    return { lines: [], comments: ["# scheduled_task_* omitted: platform has no Windows Scheduled Tasks API"] };
+  }
+
+  const key = tasks.join("\0");
+  if (opts.cache.scheduler && opts.cache.scheduler.key === key && opts.nowMs - opts.cache.scheduler.fetchedAtMs < CACHE_TTL_MS) {
+    return buildScheduledTaskLines(opts.cache.scheduler.value.samples, opts.cache.scheduler.value.comments);
+  }
+
+  const runner = opts.schedulerRunner ?? runWindowsScheduledTasks;
+  let samples: ScheduledTaskSample[] = [];
+  const comments: string[] = [];
+  try {
+    samples = normalizeTaskSamples(await runner(tasks));
+    const byTask = new Map(samples.map((s) => [s.task, s]));
+    samples = tasks.map((task) => byTask.get(task) ?? { task, exists: 0, enabled: 0, next_run_timestamp: null });
+  } catch {
+    comments.push("# scheduled_task_* omitted: scheduled-task query failed");
+  }
+  opts.cache.scheduler = { key, fetchedAtMs: opts.nowMs, value: { samples, comments } };
+  return buildScheduledTaskLines(samples, comments);
+}
+
+function buildScheduledTaskLines(samples: ScheduledTaskSample[], comments: string[]): { lines: string[]; comments: string[] } {
+  const ordered = [...samples].sort((a, b) => a.task.localeCompare(b.task));
+  const lines: string[] = [];
+  addFamily(lines, "scheduled_task_exists", "Whether an expected Windows scheduled task exists.", "gauge",
+    ordered.map((s) => sample("scheduled_task_exists", { task: s.task }, s.exists)));
+  addFamily(lines, "scheduled_task_enabled", "Whether an expected Windows scheduled task is enabled.", "gauge",
+    ordered.map((s) => sample("scheduled_task_enabled", { task: s.task }, s.enabled ?? 0)));
+  addFamily(lines, "scheduled_task_next_run_timestamp", "Next run time as epoch seconds from a Date object, never a locale-rendered string.", "gauge",
+    ordered.flatMap((s) => s.exists && typeof s.next_run_timestamp === "number" ? [sample("scheduled_task_next_run_timestamp", { task: s.task }, s.next_run_timestamp)] : []));
+  return { lines, comments };
+}
+
+function frontmatter(text: string): string {
+  if (!text.startsWith("---")) return "";
+  const end = text.indexOf("\n---", 3);
+  if (end < 0) return "";
+  return text.slice(3, end);
+}
+
+function lunaMetrics(config: ObservabilityConfig, nowMs: number, cache: ExporterCache): string[] {
+  const vault = config.vault_path;
+  if (!vault) return [];
+  const key = vault;
+  if (cache.luna && cache.luna.key === key && nowMs - cache.luna.fetchedAtMs < CACHE_TTL_MS) {
+    return cache.luna.value.samples;
+  }
+
+  const samples: string[] = [];
+  const clippings = join(vault, "Clippings");
+  if (!existsSync(clippings)) {
+    cache.luna = { key, fetchedAtMs: nowMs, value: { samples } };
+    return samples;
+  }
+
+  let unprocessed = 0;
+  let unharvested = 0;
+  for (const name of readdirSync(clippings)) {
+    // Per-entry guard: a file vanishing between readdir and stat/read (live
+    // vault) must skip that entry, not abort the whole scrape.
+    try {
+      const path = join(clippings, name);
+      if (!name.endsWith(".md") || !statSync(path).isFile()) continue;
+      const fm = frontmatter(readFileSync(path, "utf8"));
+      if (!/^processed:\s*true\s*$/m.test(fm)) unprocessed++;
+      if (!/^harvested_at:\s*.+$/m.test(fm)) unharvested++;
+    } catch {
+      continue;
+    }
+  }
+
+  addFamily(samples, "luna_inbox_backlog", "Luna clipping inbox backlog by processing stage.", "gauge", [
+    sample("luna_inbox_backlog", { stage: "unprocessed" }, unprocessed),
+    sample("luna_inbox_backlog", { stage: "unharvested" }, unharvested),
+  ]);
+
+  const month = new Date(nowMs).toISOString().slice(0, 7);
+  const doneDir = join(clippings, "_done", month);
+  if (existsSync(doneDir)) {
+    // Same fail-soft contract as the inbox walk: entries (or the whole dir)
+    // vanishing mid-scrape skip silently; the family is omitted, never a 500.
+    try {
+      let count = 0;
+      for (const name of readdirSync(doneDir)) {
+        try {
+          if (name.endsWith(".md") && statSync(join(doneDir, name)).isFile()) count++;
+        } catch {
+          continue;
+        }
+      }
+      addFamily(samples, "luna_done_graduations_month", "Count of Luna clippings graduated into the current YYYY-MM done folder.", "gauge", [
+        sample("luna_done_graduations_month", {}, count),
+      ]);
+    } catch {
+      // done dir vanished mid-scrape: omit family, do not abort.
+    }
+  }
+
+  cache.luna = { key, fetchedAtMs: nowMs, value: { samples } };
+  return samples;
+}
+
+function laneBudgetLabels(lanesPath: string): Map<string, Record<string, string>> {
+  const registry = readJsonFile<LaneRegistry>(lanesPath);
+  const labels = new Map<string, Record<string, string>>();
+  for (const lane of registry?.lanes ?? []) {
+    if (!lane.id || !lane.budget || typeof lane.budget !== "object") continue;
+    const budgetLabels: Record<string, string> = {};
+    for (const [key, value] of Object.entries(lane.budget)) {
+      if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+        budgetLabels[key] = String(value);
+      }
+    }
+    labels.set(lane.id, budgetLabels);
+  }
+  return labels;
+}
+
+function quotaMetrics(path: string, lanesPath: string, nowMs: number): string[] {
+  if (!existsSync(path)) return [];
+  let statuses: ReturnType<typeof quotaGaugeRead>;
+  try {
+    statuses = quotaGaugeRead({ path, nowMs });
+  } catch {
+    // A malformed quota ledger must not abort the whole scrape; the family
+    // is simply omitted this round (absent = dark, never fabricated).
+    return [];
+  }
+  const budget = laneBudgetLabels(lanesPath);
+  const lines: string[] = [];
+  const samples = Object.values(statuses)
+    .filter((s) => typeof s.row?.used_pct === "number")
+    .sort((a, b) => a.lane.localeCompare(b.lane))
+    .map((s) => sample("lane_quota_used_pct", { lane: s.lane, ...(budget.get(s.lane) ?? {}) }, s.row!.used_pct!));
+  addFamily(lines, "lane_quota_used_pct", "Latest observed quota used percentage per lane from the passive quota gauge ledger.", "gauge", samples);
+  return lines;
+}
+
+function defaultLanesPath(): string {
+  return join(import.meta.dir, "..", "lanes", "lanes.json");
+}
+
+export function createExporterCache(): ExporterCache {
+  return {};
+}
+
+export async function renderMetrics(options: RenderMetricsOptions = {}): Promise<string> {
+  const started = performance.now();
+  const env = options.env ?? process.env;
+  const nowMs = options.nowMs ?? Date.now();
+  const cache = options.cache ?? createExporterCache();
+  const cfg = readConfig(options.configPath ?? configPath(env));
+  const flowPath = options.flowLedgerPath ?? flowRunLedgerPath(env);
+  const quotaPath = options.quotaLedgerPath ?? quotaGaugeLedgerPath(env);
+  const lanesPath = options.lanesPath ?? defaultLanesPath();
+
+  const lines: string[] = [];
+  const flow = buildFlowMetrics(flowPath, cfg, nowMs);
+  lines.push(...flow.lines);
+
+  const scheduled = await scheduledTaskMetrics(cfg, {
+    platform: options.platform ?? process.platform,
+    nowMs,
+    cache,
+    schedulerRunner: options.schedulerRunner,
+  });
+  lines.push(...scheduled.comments);
+  lines.push(...scheduled.lines);
+
+  lines.push(...lunaMetrics(cfg, nowMs, cache));
+  lines.push(...quotaMetrics(quotaPath, lanesPath, nowMs));
+
+  const durationS = (performance.now() - started) / 1000;
+  addFamily(lines, "flow_exporter_scrape_duration_seconds", "Wall-clock duration of this exporter scrape.", "gauge", [
+    sample("flow_exporter_scrape_duration_seconds", {}, durationS),
+  ]);
+  addFamily(lines, "flow_exporter_ledger_rows", "Parsed flow-run ledger rows inside the 14d window.", "gauge", [
+    sample("flow_exporter_ledger_rows", {}, flow.ledgerRows),
+  ]);
+
+  return lines.join("\n") + "\n";
+}
+
+export function startFlowExporter(options: RenderMetricsOptions = {}): { stop: () => void; port: number } {
+  const env = options.env ?? process.env;
+  const portRaw = env.HIMMEL_FLOW_EXPORTER_PORT;
+  const port = portRaw && /^\d+$/.test(portRaw) ? Number(portRaw) : DEFAULT_PORT;
+  const cache = options.cache ?? createExporterCache();
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (req.method !== "GET" || url.pathname !== "/metrics") {
+        return new Response("not found\n", { status: 404 });
+      }
+      try {
+        const body = await renderMetrics({ ...options, env, cache });
+        return new Response(body, {
+          headers: { "content-type": "text/plain; version=0.0.4; charset=utf-8" },
+        });
+      } catch {
+        // Fail visible: a render error is a controlled 500, and Prometheus
+        // surfaces it as a failed scrape rather than a hung request.
+        return new Response("metrics render failed\n", { status: 500 });
+      }
+    },
+  });
+  return { stop: () => server.stop(true), port: server.port };
+}
+
+if (import.meta.main) {
+  const server = startFlowExporter();
+  console.log(`flow-exporter listening on 127.0.0.1:${server.port}`);
+}

--- a/scripts/observability/install-stack.ps1
+++ b/scripts/observability/install-stack.ps1
@@ -1,0 +1,179 @@
+param(
+  [string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step {
+  param([string]$Message)
+  Write-Output "[observability] $Message"
+}
+
+function Invoke-PackageInstall {
+  param(
+    [string]$Name,
+    [string[]]$WingetIds,
+    [string]$ScoopName
+  )
+
+  if (Get-Command winget -ErrorAction SilentlyContinue) {
+    foreach ($wingetId in $WingetIds) {
+      Write-Step "Installing $Name with winget id $wingetId"
+      winget install --id $wingetId -e --silent --accept-source-agreements --accept-package-agreements
+      if ($LASTEXITCODE -eq 0) { return }
+    }
+    Write-Warning "winget install failed for $Name; trying scoop when available"
+  }
+
+  if (Get-Command scoop -ErrorAction SilentlyContinue) {
+    # prometheus / grafana / windows_exporter live in the extras bucket;
+    # adding it is idempotent-ish (fails benignly when already registered).
+    Write-Step "Ensuring scoop extras bucket"
+    scoop bucket add extras 2>$null | Out-Null
+    Write-Step "Installing $Name with scoop package $ScoopName"
+    scoop install $ScoopName
+    if ($LASTEXITCODE -eq 0) { return }
+  }
+
+  Write-Warning "Could not install $Name automatically. Install it manually, then re-run this script."
+}
+
+function Resolve-RequiredCommand {
+  param(
+    [string]$DisplayName,
+    [string[]]$Names
+  )
+
+  foreach ($name in $Names) {
+    $cmd = Get-Command $name -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+  }
+  throw "Required command for $DisplayName was not found on PATH after install attempt: $($Names -join ', ')"
+}
+
+function Register-LogonTask {
+  param(
+    [string]$TaskName,
+    [string]$Execute,
+    [string]$Arguments,
+    [string]$WorkingDirectory
+  )
+
+  $action = New-ScheduledTaskAction -Execute $Execute -Argument $Arguments -WorkingDirectory $WorkingDirectory
+  $trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+  $settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -ExecutionTimeLimit ([TimeSpan]::Zero) `
+    -RestartCount 3 `
+    -RestartInterval (New-TimeSpan -Minutes 1)
+
+  Register-ScheduledTask `
+    -TaskName $TaskName `
+    -Action $action `
+    -Trigger $trigger `
+    -Settings $settings `
+    -Description "himmel local observability stack task" `
+    -Force | Out-Null
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+if (-not $RepoRoot) {
+  $RepoRoot = (Resolve-Path (Join-Path $scriptDir '..\..')).Path
+} else {
+  $RepoRoot = (Resolve-Path $RepoRoot).Path
+}
+
+$stateRoot = Join-Path $env:LOCALAPPDATA 'himmel\observability'
+$promData = Join-Path $stateRoot 'prometheus-data'
+$grafanaData = Join-Path $stateRoot 'grafana-data'
+$grafanaLogs = Join-Path $stateRoot 'grafana-logs'
+$grafanaPlugins = Join-Path $stateRoot 'grafana-plugins'
+New-Item -ItemType Directory -Path $stateRoot, $promData, $grafanaData, $grafanaLogs, $grafanaPlugins -Force | Out-Null
+
+Invoke-PackageInstall -Name 'Prometheus' -WingetIds @('Prometheus.Prometheus') -ScoopName 'prometheus'
+Invoke-PackageInstall -Name 'Grafana OSS' -WingetIds @('GrafanaLabs.GrafanaOSS', 'GrafanaLabs.Grafana.OSS', 'GrafanaLabs.Grafana') -ScoopName 'grafana'
+Invoke-PackageInstall -Name 'windows_exporter' -WingetIds @('Prometheus.WindowsExporter', 'prometheus-community.windows_exporter') -ScoopName 'windows_exporter'
+if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
+  Invoke-PackageInstall -Name 'Bun' -WingetIds @('Oven-sh.Bun') -ScoopName 'bun'
+}
+
+# winget/scoop add PATH entries this session cannot see yet; refresh from the
+# registry scopes so Resolve-RequiredCommand works on a clean machine.
+$env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('Path', 'User')
+
+$prometheusExe = Resolve-RequiredCommand -DisplayName 'Prometheus' -Names @('prometheus.exe', 'prometheus')
+$grafanaExe = Resolve-RequiredCommand -DisplayName 'Grafana' -Names @('grafana-server.exe', 'grafana-server')
+$windowsExporterExe = Resolve-RequiredCommand -DisplayName 'windows_exporter' -Names @('windows_exporter.exe', 'windows_exporter')
+$bunExe = Resolve-RequiredCommand -DisplayName 'Bun' -Names @('bun.exe', 'bun')
+
+$prometheusConfig = Join-Path $stateRoot 'prometheus.yml'
+Copy-Item -LiteralPath (Join-Path $scriptDir 'prometheus.yml') -Destination $prometheusConfig -Force
+
+$grafanaIni = Join-Path $stateRoot 'grafana.ini'
+@"
+[server]
+http_addr = 127.0.0.1
+http_port = 3000
+
+[paths]
+data = $($grafanaData.Replace('\', '/'))
+logs = $($grafanaLogs.Replace('\', '/'))
+plugins = $($grafanaPlugins.Replace('\', '/'))
+"@ | Set-Content -LiteralPath $grafanaIni -Encoding utf8
+
+$grafanaBin = Split-Path -Parent $grafanaExe
+if ($grafanaBin -like '*\scoop\shims*') {
+  # A scoop shim's parent is the shims dir, not Grafana's install root.
+  $grafanaHome = (scoop prefix grafana).Trim()
+} else {
+  $grafanaHome = Split-Path -Parent $grafanaBin
+}
+$flowExporter = Join-Path $RepoRoot 'scripts\observability\flow-exporter.ts'
+
+Register-LogonTask `
+  -TaskName 'himmel-observability-prometheus' `
+  -Execute $prometheusExe `
+  -Arguments "--config.file=`"$prometheusConfig`" --storage.tsdb.path=`"$promData`" --web.listen-address=127.0.0.1:9090" `
+  -WorkingDirectory $stateRoot
+
+Register-LogonTask `
+  -TaskName 'himmel-observability-grafana' `
+  -Execute $grafanaExe `
+  -Arguments "--homepath `"$grafanaHome`" --config `"$grafanaIni`"" `
+  -WorkingDirectory $grafanaHome
+
+Register-LogonTask `
+  -TaskName 'himmel-observability-windows-exporter' `
+  -Execute $windowsExporterExe `
+  -Arguments "--web.listen-address=127.0.0.1:9182" `
+  -WorkingDirectory $stateRoot
+
+Register-LogonTask `
+  -TaskName 'himmel-observability-flow-exporter' `
+  -Execute $bunExe `
+  -Arguments "run `"$flowExporter`"" `
+  -WorkingDirectory $RepoRoot
+
+# Logon triggers only fire at the NEXT logon; start each task now so the
+# verification URLs below are live immediately after install.
+foreach ($taskName in @(
+    'himmel-observability-prometheus',
+    'himmel-observability-grafana',
+    'himmel-observability-windows-exporter',
+    'himmel-observability-flow-exporter')) {
+  Write-Step "Starting $taskName"
+  Start-ScheduledTask -TaskName $taskName
+}
+
+Write-Output ''
+Write-Output 'Verification:'
+Write-Output '  Prometheus:       http://127.0.0.1:9090'
+Write-Output '  Grafana:          http://127.0.0.1:3000'
+Write-Output '  flow exporter:    http://127.0.0.1:9877/metrics'
+Write-Output '  windows_exporter: http://127.0.0.1:9182/metrics'
+Write-Output '  Scheduled tasks:'
+Write-Output '    himmel-observability-prometheus'
+Write-Output '    himmel-observability-grafana'
+Write-Output '    himmel-observability-windows-exporter'
+Write-Output '    himmel-observability-flow-exporter'

--- a/scripts/observability/install-stack.sh
+++ b/scripts/observability/install-stack.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat >&2 <<'EOF'
+HIMMEL-922 Phase A only ships the Windows local stack installer.
+
+Cross-platform packaging belongs to the ratified Phase B design. This script is
+intentionally a loud placeholder so brew/apt/Docker behavior is not
+half-implemented ahead of that phase.
+EOF
+exit 2

--- a/scripts/observability/prometheus.yml
+++ b/scripts/observability/prometheus.yml
@@ -1,0 +1,18 @@
+global:
+  scrape_interval: 60s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - 127.0.0.1:9090
+
+  - job_name: flow-exporter
+    static_configs:
+      - targets:
+          - 127.0.0.1:9877
+
+  - job_name: windows_exporter
+    static_configs:
+      - targets:
+          - 127.0.0.1:9182


### PR DESCRIPTION

## Summary
919 child 2/4 (design §2–3, ratified). One tiny passive exporter (bun,
127.0.0.1:9877): flow_run_* families window-folded per scrape from
flow-runs.jsonl(+.1) with exporter-inferred stalled (never
self-reported), scheduled_task_* via one PowerShell spawn per 60s TTL
(NextRunTime as DateTime against a UTC-kind epoch anchor, never the
locale string), luna inbox/graduation gauges (read-only, TTL-cached,
fail-soft per entry), lane_quota_used_pct re-export with lanes.json
budget labels. Config ~/.himmel/observability.json. Pure reader;
loopback only; controlled 500 on render failure. Stack: prometheus.yml
(self-scrape + exporter + windows_exporter jobs), install-stack.ps1
(winget/scoop incl. Bun + extras bucket, user-level logon tasks with no
execution time limit + immediate start), Phase B loud-stub .sh, Grafana
war-room dashboard (5 rows; RAM-trees/orphans placeholder → HIMMEL-924),
README.

## CR evidence
3 rounds: r1 panel (paid codex) 2 Important agreed+fixed (Bun install,
prometheus self-scrape); r2 CodeRabbit CLI 4 agreed+fixed (indefinite
task time limit, scrape-isolation guards, 500 handler, overdue-by expr)
+ 1 disproved (counter→gauge rename — family shape pinned by ratified
design §3, window semantics documented honestly in README); r3 both
critics 3 agreed+fixed (_done scan fail-soft, README claim, scoop
extras). Final re-run: panel 2/2 zero + CodeRabbit CLI zero. bun 6/6
incl. golden full-body scrape; live smoke on ephemeral port. Impl via
WSL codex lane (gpt-5.5 high); parent fixed the PS epoch-Kind bug
pre-CR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai
-->
## Summary by CodeRabbit

* **New Features**
* Added a local Windows observability stack with Prometheus and Grafana.
* Added a passive metrics endpoint for flow outcomes, stalled runs,
quotas, Luna pipeline activity, scheduled tasks, and host/exporter
health.
  * Added a “War room — system” Grafana dashboard.
* Added Windows installation automation that configures logon-started
services and prints local verification URLs.
* **Documentation**
* Documented the Phase A setup, configuration options, metric sources,
defaults/overrides, and dashboard guidance.
* **Tests**
* Added coverage for metric rendering, read-only behavior, caching, and
Windows-only scheduled-task scraping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local Windows observability stack with Prometheus, Grafana, system metrics, and flow metrics.
  * Added dashboards for flow health, scheduling, pipeline activity, host health, and capacity usage.
  * Added a metrics endpoint reporting flow outcomes, backlog, quotas, and exporter health.
  * Added a Windows installer that configures and starts the observability services automatically.

* **Documentation**
  * Added setup guidance, configuration options, metric definitions, expected data formats, and scope details.

* **Tests**
  * Added coverage for metric generation, stall detection, backlog tracking, quota reporting, and scheduled-task handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->