### PR TITLE
fix(obs): [HIMMEL-922] installer uses pinned release artifacts — no winget/msiexec on the default path (#1197)

### DIFF
--- a/scripts/observability/install-stack.ps1
+++ b/scripts/observability/install-stack.ps1
@@ -91,9 +91,61 @@ $grafanaLogs = Join-Path $stateRoot 'grafana-logs'
 $grafanaPlugins = Join-Path $stateRoot 'grafana-plugins'
 New-Item -ItemType Directory -Path $stateRoot, $promData, $grafanaData, $grafanaLogs, $grafanaPlugins -Force | Out-Null
 
-Invoke-PackageInstall -Name 'Prometheus' -WingetIds @('Prometheus.Prometheus') -ScoopName 'prometheus'
-Invoke-PackageInstall -Name 'Grafana OSS' -WingetIds @('GrafanaLabs.GrafanaOSS', 'GrafanaLabs.Grafana.OSS', 'GrafanaLabs.Grafana') -ScoopName 'grafana'
-Invoke-PackageInstall -Name 'windows_exporter' -WingetIds @('Prometheus.WindowsExporter', 'prometheus-community.windows_exporter') -ScoopName 'windows_exporter'
+# Pinned official release artifacts into the state root — NO winget/msiexec
+# on the default path (live s53 install: Prometheus has no winget package at
+# all, and the Grafana / windows_exporter MSIs are perMachine -> an invisible
+# UAC wait under automation, msiexec mutex deadlocks). Everything below is
+# elevation-free and user-scoped, matching the user-level scheduled tasks.
+$promVersion = '3.13.1'
+$grafanaVersion = '13.1.0'
+$weVersion = '0.31.7'
+# Pinned SHA-256 of each artifact, from the projects' published checksum
+# files (prometheus sha256sums.txt, dl.grafana.com .sha256, windows_exporter
+# sha256sums.txt). Bump these together with the versions.
+$promSha256 = '5409abdcac847984ab7869d7814e6e8cff65b4411d62e7477b960b92eadfa08a'
+$grafanaSha256 = '2c5c0733fc87129334333987799e26807a5eef1572c40941909d948392cf29f4'
+$weSha256 = '288252baf470da41494420250e68b5358992701298f77a36d821992b589eccdd'
+$promBinDir = Join-Path $stateRoot "prometheus-$promVersion"
+$grafanaHomeDir = Join-Path $stateRoot "grafana-$grafanaVersion"
+$weBinDir = Join-Path $stateRoot "windows_exporter-$weVersion"
+
+function Assert-FileHash {
+  param([string]$Path, [string]$Expected, [string]$Name)
+  $actual = (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+  if ($actual -ne $Expected.ToLowerInvariant()) {
+    Remove-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+    throw "SHA-256 mismatch for $Name (expected $Expected, got $actual) - download deleted, refusing to install it."
+  }
+}
+
+if (-not (Test-Path (Join-Path $promBinDir 'prometheus.exe'))) {
+  Write-Step "Downloading Prometheus v$promVersion release zip"
+  $promZip = Join-Path $stateRoot "prometheus-$promVersion.zip"
+  Invoke-WebRequest -Uri "https://github.com/prometheus/prometheus/releases/download/v$promVersion/prometheus-$promVersion.windows-amd64.zip" -OutFile $promZip
+  Assert-FileHash -Path $promZip -Expected $promSha256 -Name 'Prometheus zip'
+  Expand-Archive -LiteralPath $promZip -DestinationPath $stateRoot -Force
+  # A partial dir from an aborted run would make Move-Item nest instead of rename.
+  if (Test-Path $promBinDir) { Remove-Item -LiteralPath $promBinDir -Recurse -Force }
+  Move-Item -LiteralPath (Join-Path $stateRoot "prometheus-$promVersion.windows-amd64") -Destination $promBinDir -Force
+  Remove-Item -LiteralPath $promZip -Force -ErrorAction SilentlyContinue
+}
+
+if (-not (Test-Path (Join-Path $grafanaHomeDir 'bin\grafana.exe'))) {
+  Write-Step "Downloading Grafana OSS v$grafanaVersion release zip"
+  $grafanaZip = Join-Path $stateRoot "grafana-$grafanaVersion.zip"
+  Invoke-WebRequest -Uri "https://dl.grafana.com/oss/release/grafana-$grafanaVersion.windows-amd64.zip" -OutFile $grafanaZip
+  Assert-FileHash -Path $grafanaZip -Expected $grafanaSha256 -Name 'Grafana zip'
+  Expand-Archive -LiteralPath $grafanaZip -DestinationPath $stateRoot -Force
+  Remove-Item -LiteralPath $grafanaZip -Force -ErrorAction SilentlyContinue
+}
+
+if (-not (Test-Path (Join-Path $weBinDir 'windows_exporter.exe'))) {
+  Write-Step "Downloading windows_exporter v$weVersion release binary"
+  New-Item -ItemType Directory -Path $weBinDir -Force | Out-Null
+  $weExe = Join-Path $weBinDir 'windows_exporter.exe'
+  Invoke-WebRequest -Uri "https://github.com/prometheus-community/windows_exporter/releases/download/v$weVersion/windows_exporter-$weVersion-amd64.exe" -OutFile $weExe
+  Assert-FileHash -Path $weExe -Expected $weSha256 -Name 'windows_exporter binary'
+}
 if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
   Invoke-PackageInstall -Name 'Bun' -WingetIds @('Oven-sh.Bun') -ScoopName 'bun'
 }
@@ -102,9 +154,25 @@ if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
 # registry scopes so Resolve-RequiredCommand works on a clean machine.
 $env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('Path', 'User')
 
-$prometheusExe = Resolve-RequiredCommand -DisplayName 'Prometheus' -Names @('prometheus.exe', 'prometheus')
-$grafanaExe = Resolve-RequiredCommand -DisplayName 'Grafana' -Names @('grafana-server.exe', 'grafana-server')
-$windowsExporterExe = Resolve-RequiredCommand -DisplayName 'windows_exporter' -Names @('windows_exporter.exe', 'windows_exporter')
+$prometheusExe = if (Test-Path (Join-Path $promBinDir 'prometheus.exe')) {
+  Join-Path $promBinDir 'prometheus.exe'
+} else {
+  Resolve-RequiredCommand -DisplayName 'Prometheus' -Names @('prometheus.exe', 'prometheus')
+}
+# Modern Grafana ships bin\grafana.exe (the `server` subcommand replaced the
+# old grafana-server.exe binary).
+$grafanaExe = if (Test-Path (Join-Path $grafanaHomeDir 'bin\grafana.exe')) {
+  Join-Path $grafanaHomeDir 'bin\grafana.exe'
+} else {
+  Resolve-RequiredCommand -DisplayName 'Grafana' -Names @('grafana.exe', 'grafana-server.exe', 'grafana-server')
+}
+$grafanaServerArgPrefix = ''
+if ((Split-Path -Leaf $grafanaExe) -eq 'grafana.exe') { $grafanaServerArgPrefix = 'server ' }
+$windowsExporterExe = if (Test-Path (Join-Path $weBinDir 'windows_exporter.exe')) {
+  Join-Path $weBinDir 'windows_exporter.exe'
+} else {
+  Resolve-RequiredCommand -DisplayName 'windows_exporter' -Names @('windows_exporter.exe', 'windows_exporter')
+}
 $bunExe = Resolve-RequiredCommand -DisplayName 'Bun' -Names @('bun.exe', 'bun')
 
 $prometheusConfig = Join-Path $stateRoot 'prometheus.yml'
@@ -140,7 +208,7 @@ Register-LogonTask `
 Register-LogonTask `
   -TaskName 'himmel-observability-grafana' `
   -Execute $grafanaExe `
-  -Arguments "--homepath `"$grafanaHome`" --config `"$grafanaIni`"" `
+  -Arguments "$grafanaServerArgPrefix--homepath `"$grafanaHome`" --config `"$grafanaIni`"" `
   -WorkingDirectory $grafanaHome
 
 Register-LogonTask `


### PR DESCRIPTION

## Summary
The live Phase A install (s53, this host) hit three real defects:
Prometheus has NO winget package at all; the Grafana/windows_exporter
perMachine MSIs deadlock under automation (invisible UAC wait → msiexec
mutex → 1618 for every later install); modern Grafana ships
bin/grafana.exe (server subcommand), and its zip extracts to
grafana-<ver>/. The installer now downloads pinned official release
artifacts (Prometheus zip, Grafana OSS zip, windows_exporter single exe)
into the state root — fully user-scoped and elevation-free, matching the
user-level scheduled tasks — plus CR-round hardening (version-qualified
windows_exporter dir, partial-dir guard, silent zip cleanup).

## Live verification (this host)
All four tasks registered + started; Prometheus/-​/ready, Grafana
/api/health, windows_exporter and the flow exporter all 200; Prometheus
`up == 1` for all three jobs; war-room dashboard imported and rendering.

## CR evidence
Round 1: lagunaor+codex 2 Important (1 agreed+fixed, 1 disproved by the
live extract), CodeRabbit CLI 1 agreed+fixed. Round 2 (post-fix):
CodeRabbit CLI zero; codex 2 Important both disproved by the live
deployment (grafana home resolves through the exe path to the pinned dir
— the running task + health 200 are the evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai
-->
## Summary by CodeRabbit

- **New Features**
- Observability setup now installs pinned versions of Prometheus,
Grafana, and Windows Exporter directly from official release artifacts.
- Existing installations are detected and reused to avoid unnecessary
downloads.
- Grafana setup supports modern executable layouts and configures its
scheduled task with the appropriate startup command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Observability components are now installed from pinned official releases with SHA-256 verification.
  * Installation safely cleans up incomplete downloads and uses versioned locations.

* **Bug Fixes**
  * Improved discovery and startup of Prometheus, Grafana, and Windows Exporter.
  * Updated Grafana startup handling for current executable behavior.
  * Existing verification URLs and automatic task startup remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->