### PR TITLE
fix(handover): [HIMMEL-998] WSL-station .bat launch quoted the -d value — wsl.exe resolves the quotes into the distro name

### DIFF
--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -2328,7 +2328,15 @@ schedule_arm() {
                 printf 'del /q "%%FLOW_RUN_TMP%%" >NUL 2>&1
 '
                 if [ -n "$WSL_DISTRO" ]; then
-                    printf 'wsl.exe -d "%s" -e bash -lc "%s"\r\n' "$WSL_DISTRO" "$wsl_launch"
+                    # -d value MUST be unquoted (HIMMEL-998): wsl.exe splits its
+                    # pre--e command line naively and does NOT strip CMD-level
+                    # double quotes, so -d "Ubuntu" resolves the five-char name
+                    # plus quotes -> WSL_E_DISTRO_NOT_FOUND (rc -1, live win2
+                    # fire). Interactive tests never caught it because bash/
+                    # PowerShell strip the quotes before wsl.exe sees them;
+                    # only the emitted .bat passes them through. Safe unquoted:
+                    # WSL_DISTRO is validated ^[A-Za-z0-9._-]+$ at parse time.
+                    printf 'wsl.exe -d %s -e bash -lc "%s"\r\n' "$WSL_DISTRO" "$wsl_launch"
                 else
                     printf 'cd /d "%s" || exit /b 1\r\n' "$c"
                     if [ "$HEADROOM_PROXY_ACTIVE" -eq 1 ]; then

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -1716,7 +1716,10 @@ out=$(HIMMEL_HEADROOM_PROXY=0 ARM_BRIDGE_LIVE=0 WSL_STUB_MODE=ok \
     --wsl-distro ubuntu --channels 'plugin:test@local' --force --dry-run 2>&1)
 rc=$?
 assert_rc "T-wsl body exits 0" 0 "$rc"
-assert_contains "T-wsl body uses quoted distro + login shell" 'wsl.exe -d "ubuntu" -e bash -lc' "$out"
+assert_contains "T-wsl body uses unquoted distro + login shell" 'wsl.exe -d ubuntu -e bash -lc' "$out"
+# HIMMEL-998: a quoted -d value reaches wsl.exe verbatim from the .bat (cmd
+# does not strip it, wsl.exe does not either) -> WSL_E_DISTRO_NOT_FOUND.
+assert_not_contains "T-wsl body never quotes the -d value" 'wsl.exe -d "' "$out"
 assert_contains "T-wsl body has in-distro cd+claude" "cd '$WSL_CWD' && claude" "$out"
 assert_not_contains "T-wsl no caret escapes inside CMD quotes" '^&' "$out"
 assert_contains "T-wsl prompt precedes channels" "'load $WSL_HO overnight mode' --channels 'plugin:test@local'" "$out"
@@ -1809,7 +1812,7 @@ out=$(HIMMEL_HEADROOM_PROXY=1 WSL_STUB_MODE=ok \
 rc=$?
 assert_rc "T-wsl headroom combination exits 0" 0 "$rc"
 assert_contains "T-wsl headroom skip warns" "proxy gate skipped for a WSL-station arm" "$out"
-assert_contains "T-wsl headroom skip emits plain launch" 'wsl.exe -d "ubuntu" -e bash -lc' "$out"
+assert_contains "T-wsl headroom skip emits plain launch" 'wsl.exe -d ubuntu -e bash -lc' "$out"
 assert_not_contains "T-wsl headroom skip omits proxy gate" "livez" "$out"
 
 # V1: DD/MM locale render. `reg` reports a dd/MM/yyyy short-date pattern;


### PR DESCRIPTION
Private #1198. wsl.exe does not strip CMD-level quotes around the `-d` value when launched from a .bat — the scheduled-task WSL-station launch failed with `WSL_E_DISTRO_NOT_FOUND` while every bash/PowerShell test passed (those shells strip the quotes first). Fix: emit `-d <distro>` unquoted (name charset-validated at parse time); regression assertions added. Live-verified via a station fire (ledger row + in-distro session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Windows WSL launches so distribution names are passed correctly when scheduled tasks run.
  * Improved reliability of WSL handover and headroom-related launch commands.

* **Tests**
  * Updated validation to confirm correct distribution argument handling and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->