### PR TITLE
feat(obs): [HIMMEL-923] host detectors — RAM per agent tree + orphan-class metrics in the flow exporter

### DIFF
--- a/scripts/observability/README.md
+++ b/scripts/observability/README.md
@@ -53,7 +53,8 @@ Shape:
   "expected_tasks": [
     "himmel-pipeline-harvest"
   ],
-  "vault_path": "C:/Users/you/Documents/luna"
+  "vault_path": "C:/Users/you/Documents/luna",
+  "host_detectors_ttl_seconds": 60
 }
 ```
 
@@ -67,6 +68,8 @@ Rules:
 - `expected_tasks` is Windows-only. Non-Windows platforms omit the scheduled
   task family and add a comment in `/metrics`.
 - `vault_path` is optional. Without it, Luna backlog metrics are omitted.
+- `host_detectors_ttl_seconds` controls the Windows host detector cache. It
+  defaults to 60 seconds.
 
 ## Metrics
 
@@ -80,6 +83,23 @@ registry labels, such as `posture="conserve"`, when present.
 
 Scheduled task and Luna backlog walks are cached for 60s. The flow ledger fold
 runs on every scrape so in-flight age and stall inference are fresh.
+
+Host detector metrics are collected by
+`scripts/observability/host-detectors.ps1`, which takes one `Win32_Process`
+snapshot and emits JSON for the exporter. The detector is report-only: it does
+not write state and does not control processes. On non-Windows hosts, or when
+PowerShell collection fails, these families are omitted and `/metrics` includes
+an explanatory `# agent_tree_*/orphan_* omitted: ...` comment.
+
+- `agent_tree_rss_bytes{class="..."}` - working-set bytes summed by process
+  tree class (`claude`, `codex-app-server`, `codex-exec`, `hermes-gateway`,
+  `telegram-bridge`, `mcp-standalone`, `other`).
+- `agent_tree_process_count{class="..."}` - process count for the same tree
+  classes.
+- `orphan_process_count{class="..."}` - report-only orphan-shaped process count
+  by detector class (`codex-fleet`, `codex-exec-registry`,
+  `hermes-gateway-orphan`, `codex-app-server-orphan`,
+  `mcp-dead-parent-unattributed`).
 
 ## Install on Windows
 
@@ -110,8 +130,6 @@ Import `dashboards/war-room-system.json` into Grafana and bind the
 
 ## Deliberately not here
 
-- RAM process trees, orphan attribution, and per-subtree memory panels:
-  HIMMEL-924.
 - Alert rules and Telegram alerting.
 - Loki or log ingestion.
 - Docker, brew, apt, or other Phase B packaging.

--- a/scripts/observability/flow-exporter.test.ts
+++ b/scripts/observability/flow-exporter.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { renderMetrics, createExporterCache } from "./flow-exporter";
+import { renderMetrics, createExporterCache, parseHostDetectorJson } from "./flow-exporter";
 import { serializeFlowRunEnd, serializeFlowRunStart, type FlowRunEnd, type FlowRunStart } from "../telegram/flow-run-ledger";
 import { serializeQuotaGauge, type QuotaGaugeRecord } from "../telegram/quota-gauge";
 
@@ -124,6 +124,7 @@ flow_run_items_processed_total{flow="pipeline-harvest"} 20
 flow_run_in_flight{flow="pipeline-harvest"} 1
 flow_run_in_flight{flow="pipeline-silent"} 0
 flow_run_in_flight{flow="pipeline-synthesize"} 0
+# agent_tree_*/orphan_* omitted: platform has no Windows process tree API
 # HELP flow_exporter_scrape_duration_seconds Wall-clock duration of this exporter scrape.
 # TYPE flow_exporter_scrape_duration_seconds gauge
 flow_exporter_scrape_duration_seconds 0
@@ -221,4 +222,100 @@ test("scheduled-task scrape is platform-gated and TTL-cached", async () => {
   const linux = await renderMetrics({ nowMs: NOW, configPath: config, flowLedgerPath: ledger, quotaLedgerPath: join(tmp, "none"), platform: "linux", cache: createExporterCache() });
   expect(linux).toContain("# scheduled_task_* omitted: platform has no Windows Scheduled Tasks API");
   expect(linux).not.toContain("scheduled_task_exists");
+});
+
+test("host detector JSON parser normalizes detector output", () => {
+  const parsed = parseHostDetectorJson(JSON.stringify({
+    trees: [
+      { class: "claude", rss_bytes: 1234, process_count: 2 },
+      { class: "", rss_bytes: 999, process_count: 1 },
+      { class: "other", rss_bytes: -1, process_count: Number.NaN },
+    ],
+    orphans: [
+      { class: "codex-fleet", count: 3 },
+      { class: "ignored" },
+    ],
+  }));
+  expect(parsed.trees).toEqual([
+    { class: "claude", rss_bytes: 1234, process_count: 2 },
+    { class: "other", rss_bytes: 0, process_count: 0 },
+  ]);
+  expect(parsed.orphans).toEqual([
+    { class: "codex-fleet", count: 3 },
+    { class: "ignored", count: 0 },
+  ]);
+});
+
+test("host detector metrics render from fixture data", async () => {
+  const config = join(tmp, "observability.json");
+  const ledger = join(tmp, "flow-runs.jsonl");
+  writeFileSync(config, JSON.stringify({ host_detectors_ttl_seconds: 30 }));
+  writeLines(ledger, []);
+
+  const body = await renderMetrics({
+    nowMs: NOW,
+    configPath: config,
+    flowLedgerPath: ledger,
+    quotaLedgerPath: join(tmp, "none"),
+    platform: "win32",
+    hostDetectorRunner: () => JSON.stringify({
+      trees: [
+        { class: "claude", rss_bytes: 2048, process_count: 2 },
+        { class: "other", rss_bytes: 512, process_count: 1 },
+      ],
+      orphans: [
+        { class: "codex-fleet", count: 1 },
+      ],
+    }),
+  });
+
+  expect(body).toContain('# HELP agent_tree_rss_bytes Working-set bytes summed by agent process tree class.');
+  expect(body).toContain('agent_tree_rss_bytes{class="claude"} 2048');
+  expect(body).toContain('agent_tree_process_count{class="other"} 1');
+  expect(body).toContain('orphan_process_count{class="codex-fleet"} 1');
+});
+
+test("host detector scrape is platform-gated and fail-soft on runner errors", async () => {
+  const ledger = join(tmp, "flow-runs.jsonl");
+  writeLines(ledger, []);
+  const base = { nowMs: NOW, flowLedgerPath: ledger, quotaLedgerPath: join(tmp, "none") };
+
+  const linux = await renderMetrics({ ...base, platform: "linux", hostDetectorRunner: () => { throw new Error("should not run"); } });
+  expect(linux).toContain("# agent_tree_*/orphan_* omitted: platform has no Windows process tree API");
+  expect(linux).not.toContain("agent_tree_rss_bytes");
+
+  const failed = await renderMetrics({
+    ...base,
+    platform: "win32",
+    hostDetectorRunner: () => { throw new Error("powershell failed"); },
+  });
+  expect(failed).toContain("# agent_tree_*/orphan_* omitted: powershell failed");
+  expect(failed).not.toContain("orphan_process_count");
+});
+
+test("host detector scrape uses TTL cache and drops cache on refresh failure", async () => {
+  const config = join(tmp, "observability.json");
+  const ledger = join(tmp, "flow-runs.jsonl");
+  writeFileSync(config, JSON.stringify({ host_detectors_ttl_seconds: 2 }));
+  writeLines(ledger, []);
+  const cache = createExporterCache();
+  let calls = 0;
+  const runner = () => {
+    calls++;
+    if (calls === 2) throw new Error("expired refresh failed");
+    return {
+      trees: [{ class: "claude", rss_bytes: 1000, process_count: 1 }],
+      orphans: [{ class: "codex-fleet", count: 0 }],
+    };
+  };
+
+  const first = await renderMetrics({ nowMs: NOW, configPath: config, flowLedgerPath: ledger, quotaLedgerPath: join(tmp, "none"), platform: "win32", hostDetectorRunner: runner, cache });
+  const second = await renderMetrics({ nowMs: NOW + 1000, configPath: config, flowLedgerPath: ledger, quotaLedgerPath: join(tmp, "none"), platform: "win32", hostDetectorRunner: runner, cache });
+  const third = await renderMetrics({ nowMs: NOW + 3000, configPath: config, flowLedgerPath: ledger, quotaLedgerPath: join(tmp, "none"), platform: "win32", hostDetectorRunner: runner, cache });
+
+  expect(calls).toBe(2);
+  expect(first).toContain('agent_tree_rss_bytes{class="claude"} 1000');
+  expect(second).toContain('agent_tree_process_count{class="claude"} 1');
+  expect(third).toContain("# agent_tree_*/orphan_* omitted: expired refresh failed");
+  expect(third).not.toContain("agent_tree_rss_bytes");
 });

--- a/scripts/observability/flow-exporter.ts
+++ b/scripts/observability/flow-exporter.ts
@@ -10,6 +10,7 @@ const LOOKBACK_MS = 14 * 24 * 60 * 60 * 1000;
 const DEFAULT_STALL_DEADLINE_SECONDS = 6 * 60 * 60;
 const CACHE_TTL_MS = 60 * 1000;
 const SCHEDULER_QUERY_TIMEOUT_MS = 10 * 1000;
+const HOST_DETECTOR_TIMEOUT_MS = 10 * 1000;
 const DEFAULT_PORT = 9877;
 
 type FlowConfig = {
@@ -22,6 +23,7 @@ type ObservabilityConfig = {
   flows?: FlowConfig[];
   expected_tasks?: string[];
   vault_path?: string;
+  host_detectors_ttl_seconds?: number;
 };
 
 type ScheduledTaskSample = {
@@ -33,6 +35,24 @@ type ScheduledTaskSample = {
 
 type SchedulerRunner = (tasks: string[]) => ScheduledTaskSample[] | Promise<ScheduledTaskSample[]>;
 
+type HostTreeSample = {
+  class: string;
+  rss_bytes: number;
+  process_count: number;
+};
+
+type HostOrphanSample = {
+  class: string;
+  count: number;
+};
+
+type HostDetectorResult = {
+  trees: HostTreeSample[];
+  orphans: HostOrphanSample[];
+};
+
+type HostDetectorRunner = () => unknown | Promise<unknown>;
+
 type Cached<T> = {
   key: string;
   fetchedAtMs: number;
@@ -41,6 +61,7 @@ type Cached<T> = {
 
 export type ExporterCache = {
   scheduler?: Cached<{ samples: ScheduledTaskSample[]; comments: string[] }>;
+  hostDetectors?: Cached<HostDetectorResult>;
   luna?: Cached<{ samples: string[] }>;
 };
 
@@ -53,6 +74,7 @@ export type RenderMetricsOptions = {
   lanesPath?: string;
   platform?: NodeJS.Platform;
   schedulerRunner?: SchedulerRunner;
+  hostDetectorRunner?: HostDetectorRunner;
   cache?: ExporterCache;
 };
 
@@ -372,6 +394,114 @@ function buildScheduledTaskLines(samples: ScheduledTaskSample[], comments: strin
   return { lines, comments };
 }
 
+function hostDetectorTtlMs(config: ObservabilityConfig): number {
+  const seconds = config.host_detectors_ttl_seconds;
+  return typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : CACHE_TTL_MS;
+}
+
+function asNonNegativeNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+export function parseHostDetectorJson(raw: unknown): HostDetectorResult {
+  const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("host-detectors output is not an object");
+  }
+  const row = parsed as Record<string, unknown>;
+  const treesRaw = Array.isArray(row.trees) ? row.trees : [];
+  const orphansRaw = Array.isArray(row.orphans) ? row.orphans : [];
+  return {
+    trees: treesRaw.flatMap((item) => {
+      if (!item || typeof item !== "object") return [];
+      const tree = item as Record<string, unknown>;
+      if (typeof tree.class !== "string" || !tree.class) return [];
+      return [{
+        class: tree.class,
+        rss_bytes: asNonNegativeNumber(tree.rss_bytes),
+        process_count: asNonNegativeNumber(tree.process_count),
+      }];
+    }),
+    orphans: orphansRaw.flatMap((item) => {
+      if (!item || typeof item !== "object") return [];
+      const orphan = item as Record<string, unknown>;
+      if (typeof orphan.class !== "string" || !orphan.class) return [];
+      return [{
+        class: orphan.class,
+        count: asNonNegativeNumber(orphan.count),
+      }];
+    }),
+  };
+}
+
+async function runWindowsHostDetectors(): Promise<HostDetectorResult> {
+  const scriptPath = join(import.meta.dir, "host-detectors.ps1");
+  const proc = Bun.spawn(["powershell", "-NoProfile", "-File", scriptPath], { stdout: "pipe", stderr: "pipe" });
+  const timer = setTimeout(() => {
+    try { proc.kill(); } catch { /* already gone */ }
+  }, HOST_DETECTOR_TIMEOUT_MS);
+  try {
+    // Drain both pipes CONCURRENTLY with exit: awaiting exited first can
+    // deadlock if the child fills a pipe buffer before exiting (codex-5).
+    const [exitCode, out, err] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    clearTimeout(timer);
+    if (exitCode !== 0) {
+      throw new Error(err.trim() || `host-detectors exited ${exitCode}`);
+    }
+    return parseHostDetectorJson(out);
+  } catch (e) {
+    clearTimeout(timer);
+    throw e;
+  }
+}
+
+function hostDetectorOmitComment(reason: string): string {
+  return `# agent_tree_*/orphan_* omitted: ${reason.replace(/\s+/g, " ").trim() || "host-detectors query failed"}`;
+}
+
+async function hostDetectorMetrics(
+  config: ObservabilityConfig,
+  opts: Required<Pick<RenderMetricsOptions, "platform" | "nowMs" | "cache">> & { hostDetectorRunner?: HostDetectorRunner },
+): Promise<{ lines: string[]; comments: string[] }> {
+  if (opts.platform !== "win32") {
+    return { lines: [], comments: [hostDetectorOmitComment("platform has no Windows process tree API")] };
+  }
+
+  const key = "host-detectors";
+  const ttlMs = hostDetectorTtlMs(config);
+  if (opts.cache.hostDetectors && opts.cache.hostDetectors.key === key && opts.nowMs - opts.cache.hostDetectors.fetchedAtMs < ttlMs) {
+    return buildHostDetectorLines(opts.cache.hostDetectors.value);
+  }
+
+  const runner = opts.hostDetectorRunner ?? runWindowsHostDetectors;
+  try {
+    const result = parseHostDetectorJson(await runner());
+    opts.cache.hostDetectors = { key, fetchedAtMs: opts.nowMs, value: result };
+    return buildHostDetectorLines(result);
+  } catch (e) {
+    delete opts.cache.hostDetectors;
+    const message = e instanceof Error && e.message ? e.message : "host-detectors query failed";
+    return { lines: [], comments: [hostDetectorOmitComment(message)] };
+  }
+}
+
+function buildHostDetectorLines(result: HostDetectorResult): { lines: string[]; comments: string[] } {
+  const trees = [...result.trees].sort((a, b) => a.class.localeCompare(b.class));
+  const orphans = [...result.orphans].sort((a, b) => a.class.localeCompare(b.class));
+  const lines: string[] = [];
+  addFamily(lines, "agent_tree_rss_bytes", "Working-set bytes summed by agent process tree class.", "gauge",
+    trees.map((s) => sample("agent_tree_rss_bytes", { class: s.class }, s.rss_bytes)));
+  addFamily(lines, "agent_tree_process_count", "Process count summed by agent process tree class.", "gauge",
+    trees.map((s) => sample("agent_tree_process_count", { class: s.class }, s.process_count)));
+  addFamily(lines, "orphan_process_count", "Report-only orphan-shaped process count by detector class.", "gauge",
+    orphans.map((s) => sample("orphan_process_count", { class: s.class }, s.count)));
+  return { lines, comments: [] };
+}
+
 function frontmatter(text: string): string {
   if (!text.startsWith("---")) return "";
   const end = text.indexOf("\n---", 3);
@@ -507,6 +637,15 @@ export async function renderMetrics(options: RenderMetricsOptions = {}): Promise
   });
   lines.push(...scheduled.comments);
   lines.push(...scheduled.lines);
+
+  const host = await hostDetectorMetrics(cfg, {
+    platform: options.platform ?? process.platform,
+    nowMs,
+    cache,
+    hostDetectorRunner: options.hostDetectorRunner,
+  });
+  lines.push(...host.comments);
+  lines.push(...host.lines);
 
   lines.push(...lunaMetrics(cfg, nowMs, cache));
   lines.push(...quotaMetrics(quotaPath, lanesPath, nowMs));

--- a/scripts/observability/host-detectors.ps1
+++ b/scripts/observability/host-detectors.ps1
@@ -1,0 +1,329 @@
+# HIMMEL-923 host-level observability detectors.
+# Report-only: emits JSON for the flow exporter and never controls processes.
+[CmdletBinding()]
+param(
+  [switch]$AsLibrary
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+# Capture our own switch BEFORE dot-sourcing: the reaper's param binding runs
+# in THIS scope and its -AsLibrary overwrites our $AsLibrary, so the guard
+# below would otherwise always return and main would silently never run.
+$HostDetectorsAsLibrary = [bool]$AsLibrary
+$Reaper = Join-Path $PSScriptRoot '..\codex\reap-mcp-fleet.ps1'
+. $Reaper -AsLibrary
+
+$TreeClassOrder = @(
+  'claude',
+  'codex-app-server',
+  'codex-exec',
+  'hermes-gateway',
+  'telegram-bridge',
+  'mcp-standalone',
+  'other'
+)
+
+$OrphanClassOrder = @(
+  'codex-fleet',
+  'codex-exec-registry',
+  'hermes-gateway-orphan',
+  'codex-app-server-orphan',
+  'mcp-dead-parent-unattributed'
+)
+
+function ConvertTo-DetectorRecord {
+  param([Parameter(Mandatory)]$Proc)
+  $rss = 0L
+  if ($null -ne $Proc.WorkingSetSize) { $rss = [int64]$Proc.WorkingSetSize }
+  [pscustomobject]@{
+    ProcessId       = [int]$Proc.ProcessId
+    ParentProcessId = [int]$Proc.ParentProcessId
+    Name            = [string]$Proc.Name
+    CommandLine     = [string]$Proc.CommandLine
+    CreationDate    = $Proc.CreationDate
+    WorkingSetSize  = $rss
+  }
+}
+
+function New-ByPid {
+  param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs)
+  $byPid = @{}
+  foreach ($p in $Procs) {
+    if ($null -ne $p.ProcessId) { $byPid[[string]$p.ProcessId] = $p }
+  }
+  return $byPid
+}
+
+function Get-CodexJobsDir {
+  if ($env:CODEX_JOBS_DIR) { return $env:CODEX_JOBS_DIR }
+  # $userHome, not $home: $HOME is a read-only PowerShell automatic variable.
+  $userHome = if ($env:USERPROFILE) { $env:USERPROFILE } else { $HOME }
+  return (Join-Path $userHome '.himmel\state\codex-exec-jobs')
+}
+
+function Read-CodexExecJobs {
+  param([string]$JobsDir = '')
+  $dir = if ($JobsDir) { $JobsDir } else { Get-CodexJobsDir }
+  if (-not $dir -or -not (Test-Path -LiteralPath $dir)) { return @() }
+
+  $jobs = New-Object System.Collections.ArrayList
+  foreach ($jf in @(Get-ChildItem -LiteralPath $dir -Filter '*.json' -File -ErrorAction SilentlyContinue)) {
+    try {
+      $job = Get-Content -Raw -LiteralPath $jf.FullName | ConvertFrom-Json
+      if (-not $job.codex_pid) { continue }
+      $started = $null
+      if ($job.started_at) {
+        $parsed = 0L
+        if ([long]::TryParse([string]$job.started_at, [ref]$parsed)) { $started = $parsed }
+      }
+      [void]$jobs.Add([pscustomobject]@{
+        CodexPid  = [int]$job.codex_pid
+        StartedAt = $started
+      })
+    } catch {
+      continue
+    }
+  }
+  return $jobs.ToArray()
+}
+
+function Test-ClaudeRoot {
+  param([Parameter(Mandatory)]$Proc)
+  return ($Proc.Name -and ($Proc.Name -ieq 'claude.exe'))
+}
+
+function Test-CodexAppServerRoot {
+  param([Parameter(Mandatory)]$Proc)
+  $cl = [string]$Proc.CommandLine
+  if ($cl -match 'app-server-broker\.mjs') { return $true }
+  return ($Proc.Name -and ($Proc.Name -ieq 'codex.exe') -and $cl -match '\bapp-server\b')
+}
+
+function Test-HermesGatewayRoot {
+  param([Parameter(Mandatory)]$Proc)
+  $cl = [string]$Proc.CommandLine
+  if (-not $cl) { return $false }
+  return ($cl -match '(^|\s)hermes(\.exe)?\s+gateway(\s|$)') -or ($cl -match 'hermes_cli' -and $cl -match '\bgateway\b')
+}
+
+function Test-TelegramBridgeRoot {
+  param([Parameter(Mandatory)]$Proc)
+  if (-not $Proc.Name -or ($Proc.Name -ine 'bun.exe' -and $Proc.Name -ine 'bun')) { return $false }
+  $cl = [string]$Proc.CommandLine
+  return $cl -match 'scripts[\\/]+telegram' -or $cl -match '(supervisor|poller)\.ts' -or $cl -match 'telegram-himmel'
+}
+
+function Test-McpStandaloneRoot {
+  param([Parameter(Mandatory)]$Proc)
+  if (-not (Test-McpShaped -Proc $Proc)) { return $false }
+  if (Test-CodexOwned -Proc $Proc) { return $false }
+  $cl = [string]$Proc.CommandLine
+  return $cl -match '\b(qmd|mcp-obsidian|obsidian.*mcp|mcp.*server|server\.ts)\b'
+}
+
+function Get-ProcessClass {
+  param(
+    [Parameter(Mandatory)]$Proc,
+    [Parameter(Mandatory)][hashtable]$CodexExecRoots
+  )
+  if ($CodexExecRoots.ContainsKey([string]$Proc.ProcessId)) { return 'codex-exec' }
+  if (Test-ClaudeRoot -Proc $Proc) { return 'claude' }
+  if (Test-CodexAppServerRoot -Proc $Proc) { return 'codex-app-server' }
+  if (Test-HermesGatewayRoot -Proc $Proc) { return 'hermes-gateway' }
+  if (Test-TelegramBridgeRoot -Proc $Proc) { return 'telegram-bridge' }
+  if (Test-McpStandaloneRoot -Proc $Proc) { return 'mcp-standalone' }
+  return $null
+}
+
+function Test-HasClassAncestor {
+  param(
+    [Parameter(Mandatory)]$Proc,
+    [Parameter(Mandatory)][hashtable]$ByPid,
+    [Parameter(Mandatory)][hashtable]$CandidateClasses
+  )
+  $seen = @{}
+  $cur = $Proc.ParentProcessId
+  $depth = 0
+  while ($null -ne $cur -and $cur -ne 0 -and $depth -lt 64) {
+    $depth++
+    $key = [string]$cur
+    if ($seen.ContainsKey($key)) { return $false }
+    $seen[$key] = $true
+    if (-not $ByPid.ContainsKey($key)) { return $false }
+    if ($CandidateClasses.ContainsKey($key)) { return $true }
+    $cur = $ByPid[$key].ParentProcessId
+  }
+  return $false
+}
+
+function Find-NearestRootPid {
+  param(
+    [Parameter(Mandatory)]$Proc,
+    [Parameter(Mandatory)][hashtable]$ByPid,
+    [Parameter(Mandatory)][hashtable]$RootClasses
+  )
+  $seen = @{}
+  $cur = $Proc.ProcessId
+  $depth = 0
+  while ($null -ne $cur -and $cur -ne 0 -and $depth -lt 64) {
+    $depth++
+    $key = [string]$cur
+    if ($seen.ContainsKey($key)) { return $null }
+    $seen[$key] = $true
+    if ($RootClasses.ContainsKey($key)) { return [int]$cur }
+    if (-not $ByPid.ContainsKey($key)) { return $null }
+    $cur = $ByPid[$key].ParentProcessId
+  }
+  return $null
+}
+
+function Get-AgentTreeRows {
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Jobs
+  )
+  $byPid = New-ByPid -Procs $Procs
+  $codexExecRoots = @{}
+  foreach ($job in $Jobs) {
+    if ($null -ne $job.CodexPid -and $byPid.ContainsKey([string]$job.CodexPid)) {
+      $codexExecRoots[[string]$job.CodexPid] = $job.StartedAt
+    }
+  }
+
+  $candidateClasses = @{}
+  foreach ($p in $Procs) {
+    $class = Get-ProcessClass -Proc $p -CodexExecRoots $codexExecRoots
+    if ($class) { $candidateClasses[[string]$p.ProcessId] = $class }
+  }
+
+  $rootClasses = @{}
+  foreach ($p in $Procs) {
+    $key = [string]$p.ProcessId
+    if (-not $candidateClasses.ContainsKey($key)) { continue }
+    if (-not (Test-HasClassAncestor -Proc $p -ByPid $byPid -CandidateClasses $candidateClasses)) {
+      $rootClasses[$key] = $candidateClasses[$key]
+    }
+  }
+
+  $byRootPid = @{}
+  foreach ($rootKey in $rootClasses.Keys) {
+    $rootPid = [int]$rootKey
+    $startedAt = $null
+    if ($codexExecRoots.ContainsKey($rootKey)) { $startedAt = $codexExecRoots[$rootKey] }
+    $tree = New-Object System.Collections.ArrayList
+    [void]$tree.Add($rootPid)
+    foreach ($d in @(Get-DescendantPids -Procs $Procs -RootPid $rootPid -StartedAtEpoch $startedAt)) {
+      [void]$tree.Add([int]$d)
+    }
+    $byRootPid[$rootKey] = $tree.ToArray()
+  }
+
+  $totals = @{}
+  foreach ($class in $TreeClassOrder) {
+    $totals[$class] = [pscustomobject]@{ class = $class; rss_bytes = 0L; process_count = 0 }
+  }
+
+  $assigned = @{}
+  foreach ($rootKey in $rootClasses.Keys) {
+    $class = $rootClasses[$rootKey]
+    foreach ($treePid in @($byRootPid[$rootKey])) {
+      $pidKey = [string]$treePid
+      if (-not $byPid.ContainsKey($pidKey)) { continue }
+      $nearest = Find-NearestRootPid -Proc $byPid[$pidKey] -ByPid $byPid -RootClasses $rootClasses
+      if ($null -eq $nearest -or [string]$nearest -ne $rootKey) { continue }
+      $assigned[$pidKey] = $true
+      $totals[$class].rss_bytes += [int64]$byPid[$pidKey].WorkingSetSize
+      $totals[$class].process_count++
+    }
+  }
+
+  foreach ($p in $Procs) {
+    $key = [string]$p.ProcessId
+    if ($assigned.ContainsKey($key)) { continue }
+    $totals['other'].rss_bytes += [int64]$p.WorkingSetSize
+    $totals['other'].process_count++
+  }
+
+  return @($TreeClassOrder | ForEach-Object { $totals[$_] })
+}
+
+function Get-OrphanRows {
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Jobs
+  )
+  $byPid = New-ByPid -Procs $Procs
+  $counts = @{}
+  foreach ($class in $OrphanClassOrder) { $counts[$class] = 0 }
+
+  $fleet = @(Get-OrphanFleet -Procs $Procs)
+  $counts['codex-fleet'] = $fleet.Count
+  $attributedPids = @{}
+  foreach ($f in $fleet) { $attributedPids[[string]$f.ProcessId] = $true }
+
+  foreach ($job in $Jobs) {
+    if ($null -eq $job.CodexPid) { continue }
+    if ($byPid.ContainsKey([string]$job.CodexPid)) { continue }
+    $desc = @(Get-DescendantPids -Procs $Procs -RootPid ([int]$job.CodexPid) -StartedAtEpoch $job.StartedAt)
+    $counts['codex-exec-registry'] += $desc.Count
+    foreach ($d in $desc) { $attributedPids[[string]$d] = $true }
+  }
+
+  foreach ($p in $Procs) {
+    if (Test-CodexAppServerRoot -Proc $p) {
+      $anc = Resolve-Ancestry -Proc $p -ByPid $byPid
+      if ($null -ne $anc.DeadAncestorPid -and -not $anc.HasLiveSupervisor) {
+        $counts['codex-app-server-orphan']++
+      }
+    }
+    if (Test-HermesGatewayRoot -Proc $p) {
+      $anc = Resolve-Ancestry -Proc $p -ByPid $byPid
+      if ($null -ne $anc.DeadAncestorPid -and -not $anc.HasLiveSupervisor) {
+        $counts['hermes-gateway-orphan']++
+      }
+    }
+    if (Test-McpShaped -Proc $p) {
+      $parent = [int]$p.ParentProcessId
+      if ($parent -ne 0 -and -not $byPid.ContainsKey([string]$parent) -and -not (Test-CodexOwned -Proc $p) -and -not $attributedPids.ContainsKey([string]$p.ProcessId)) {
+        $counts['mcp-dead-parent-unattributed']++
+      }
+    }
+  }
+
+  return @($OrphanClassOrder | ForEach-Object {
+    [pscustomobject]@{ class = $_; count = [int]$counts[$_] }
+  })
+}
+
+function Invoke-HostDetectorSnapshot {
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    # Untyped on purpose: [object[]] + [AllowNull()] still fails binding on
+    # an omitted param under Windows PowerShell 5.1. $null means read from disk.
+    [AllowNull()]$Jobs = $null,
+    [string]$JobsDir = ''
+  )
+  $records = @($Procs | ForEach-Object { ConvertTo-DetectorRecord -Proc $_ })
+  # @() wraps the WHOLE conditional: a statement-assignment whose branch
+  # emits an empty array yields $null (zero pipeline objects), which then
+  # fails the Mandatory -Jobs binding downstream when no codex jobs exist.
+  $jobRows = @(if ($null -ne $Jobs) { $Jobs } else { Read-CodexExecJobs -JobsDir $JobsDir })
+  [pscustomobject]@{
+    trees   = @(Get-AgentTreeRows -Procs $records -Jobs $jobRows)
+    orphans = @(Get-OrphanRows -Procs $records -Jobs $jobRows)
+  }
+}
+
+if ($HostDetectorsAsLibrary) { return }
+
+try {
+  $records = @(Get-CimInstance Win32_Process -ErrorAction Stop | ForEach-Object { ConvertTo-DetectorRecord -Proc $_ })
+  Invoke-HostDetectorSnapshot -Procs $records | ConvertTo-Json -Compress -Depth 6
+} catch {
+  # Not Write-Error: with $ErrorActionPreference='Stop' it throws inside the
+  # catch and the message is lost before exit.
+  [Console]::Error.WriteLine("[host-detectors] could not collect host detector snapshot: $_")
+  exit 1
+}

--- a/scripts/observability/test-host-detectors.ps1
+++ b/scripts/observability/test-host-detectors.ps1
@@ -1,0 +1,102 @@
+# Hermetic fixture tests for host-detectors.ps1 (HIMMEL-923).
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Helper = Join-Path $ScriptDir 'host-detectors.ps1'
+$Pass = 0
+$Fail = 0
+function Pass([string]$Name) { Write-Host "  PASS  $Name"; $script:Pass++ }
+function Fail([string]$Name, [string]$Detail = '') { Write-Host "  FAIL  $Name $Detail"; $script:Fail++ }
+function Check([string]$Name, [bool]$Ok, [string]$Detail = '') { if ($Ok) { Pass $Name } else { Fail $Name $Detail } }
+
+. $Helper -AsLibrary
+
+function Rec($procId, $parentId, $name, $cl, $rss, $created = $null) {
+  [pscustomobject]@{
+    ProcessId       = $procId
+    ParentProcessId = $parentId
+    Name            = $name
+    CommandLine     = $cl
+    WorkingSetSize  = $rss
+    CreationDate    = $created
+  }
+}
+
+function Job($codexPid, $startedAt = $null) {
+  [pscustomobject]@{ CodexPid = $codexPid; StartedAt = $startedAt }
+}
+
+function ByClass($rows, $class) {
+  return ($rows | Where-Object { $_.class -eq $class } | Select-Object -First 1)
+}
+
+$now = Get-Date
+$startedEpoch = [long][DateTimeOffset]::new($now.ToUniversalTime()).ToUnixTimeSeconds()
+$afterStart = $now.AddSeconds(10)
+$beforeStart = $now.AddMinutes(-30)
+
+Write-Host "Test 1: RAM tree classes sum root + descendants, with pid-reuse guard and other residual"
+$treeProcs = @(
+  (Rec 10  1  'claude.exe' 'claude.exe' 1000 $now)
+  (Rec 11  10 'node.exe'   'node child.js' 200 $now)
+
+  (Rec 20  1  'node.exe' 'node qmd-mcp-server.js' 300 $now)
+  (Rec 21  20 'node.exe' 'node helper.js' 50 $now)
+
+  (Rec 30  1  'codex.exe' 'codex exec run' 400 $afterStart)
+  (Rec 31  30 'node.exe'  'node mcp-server.js' 90 $afterStart)
+  (Rec 32  30 'node.exe'  'node old-reused.js' 70 $beforeStart)
+
+  (Rec 40  1  'codex.exe' 'codex.exe app-server' 800 $now)
+  (Rec 41  40 'bun.exe'   'bun server.ts' 20 $now)
+
+  (Rec 90  1  'notepad.exe' 'notepad.exe' 5 $now)
+)
+$tree = @(Get-AgentTreeRows -Procs $treeProcs -Jobs @((Job 30 $startedEpoch)))
+$claude = ByClass $tree 'claude'
+$mcp = ByClass $tree 'mcp-standalone'
+$exec = ByClass $tree 'codex-exec'
+$app = ByClass $tree 'codex-app-server'
+$other = ByClass $tree 'other'
+Check 'claude tree rss/processes = 1200/2' ($claude.rss_bytes -eq 1200 -and $claude.process_count -eq 2) "rss=$($claude.rss_bytes) count=$($claude.process_count)"
+Check 'mcp-standalone tree rss/processes = 350/2' ($mcp.rss_bytes -eq 350 -and $mcp.process_count -eq 2) "rss=$($mcp.rss_bytes) count=$($mcp.process_count)"
+Check 'codex-exec excludes pre-start reused descendant' ($exec.rss_bytes -eq 490 -and $exec.process_count -eq 2) "rss=$($exec.rss_bytes) count=$($exec.process_count)"
+Check 'codex app-server includes server child' ($app.rss_bytes -eq 820 -and $app.process_count -eq 2) "rss=$($app.rss_bytes) count=$($app.process_count)"
+Check 'other residual includes unmatched + reused descendant' ($other.rss_bytes -eq 75 -and $other.process_count -eq 2) "rss=$($other.rss_bytes) count=$($other.process_count)"
+
+Write-Host "Test 2: orphan classes use library lineage predicates and registry descendant walk"
+$UserHome = $env:USERPROFILE
+if (-not $UserHome) { $UserHome = 'C:\Users\fixture' }
+$UserHomeFwd = $UserHome -replace '\\', '/'
+$CODEX_RUNTIME = "$UserHome\AppData\Local\OpenAI\Codex\runtimes\cua_node\1b23c930\bin\node_repl.exe"
+$BUN_LUNA = "run --cwd $UserHomeFwd/.codex/plugins/cache/himmel/luna-correlate/0.2.0 --shell=bun --silent start"
+$orphanProcs = @(
+  (Rec 201 200 'node_repl.exe' $CODEX_RUNTIME 1 $now)
+  (Rec 202 200 'bun.exe' "bun $BUN_LUNA" 1 $now)
+  (Rec 203 202 'bun.exe' 'bun server.ts' 1 $now)
+
+  (Rec 501 500 'cmd.exe'  'cmd.exe /c npx @upstash/context7-mcp' 1 $now)
+  (Rec 502 501 'node.exe' 'node C:\x\npx-cli.js @upstash/context7-mcp' 1 $now)
+
+  (Rec 601 600 'codex.exe' 'codex.exe app-server' 1 $now)
+  (Rec 701 700 'python.exe' 'python -m hermes_cli gateway' 1 $now)
+  (Rec 801 800 'node.exe' 'node qmd-mcp-server.js' 1 $now)
+)
+$orphans = @(Get-OrphanRows -Procs $orphanProcs -Jobs @((Job 500 $startedEpoch)))
+Check 'codex-fleet count = 3' ((ByClass $orphans 'codex-fleet').count -eq 3) "got=$((ByClass $orphans 'codex-fleet').count)"
+Check 'codex-exec-registry descendant process count = 2' ((ByClass $orphans 'codex-exec-registry').count -eq 2) "got=$((ByClass $orphans 'codex-exec-registry').count)"
+Check 'codex app-server orphan count = 1' ((ByClass $orphans 'codex-app-server-orphan').count -eq 1)
+Check 'hermes gateway orphan count = 1' ((ByClass $orphans 'hermes-gateway-orphan').count -eq 1)
+Check 'unattributed dead-parent MCP excludes attributed registry/fleet descendants' ((ByClass $orphans 'mcp-dead-parent-unattributed').count -eq 1) "got=$((ByClass $orphans 'mcp-dead-parent-unattributed').count)"
+
+Write-Host "Test 3: Invoke-HostDetectorSnapshot returns the exporter JSON shape"
+$snapshot = Invoke-HostDetectorSnapshot -Procs $treeProcs -Jobs @((Job 30 $startedEpoch))
+$json = $snapshot | ConvertTo-Json -Compress -Depth 6
+$roundTrip = $json | ConvertFrom-Json
+Check 'snapshot has trees array' ($roundTrip.trees.Count -ge 7)
+Check 'snapshot has orphans array' ($roundTrip.orphans.Count -ge 5)
+
+Write-Host "Results: $Pass passed, $Fail failed"
+if ($Fail -ne 0) { exit 1 }
+exit 0


### PR DESCRIPTION
Private #1199. Design §4.1+§4.2 (HIMMEL-919 child 3/4): report-only RAM-per-agent-tree + orphan-class metrics in the flow exporter, reusing the reaper's -AsLibrary predicates. PS fixtures 12/12, bun 10/10, live-verified. The exporter never kills — remediation stays with the sanctioned reaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows host-detector metrics for agent process-tree memory, process counts, and orphan processes.
  * Added optional cache refresh control with a default 60-second interval.
  * Metrics now include clear omission comments when unsupported or unavailable.

* **Documentation**
  * Documented the new configuration option, metric families, platform limitations, and PowerShell collection behavior.

* **Tests**
  * Added coverage for normalization, caching, platform gating, failures, and host-detector classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->