### PR TITLE
chore(obs): [HIMMEL-922] silence progress rendering in install-stack.ps1

### DIFF
--- a/scripts/observability/install-stack.ps1
+++ b/scripts/observability/install-stack.ps1
@@ -3,6 +3,9 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+# Progress rendering makes Invoke-WebRequest downloads crawl in remote/task
+# contexts (no console to render into); silence it for the whole install.
+$ProgressPreference = 'SilentlyContinue'
 
 function Write-Step {
   param([string]$Message)


### PR DESCRIPTION
Private #1200. One-line `$ProgressPreference = 'SilentlyContinue'` at the top of the installer (operator-reported slow downloads in remote/task contexts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed download progress output during installation to provide cleaner results in remote and automated task environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->