### PR TITLE
chore: [HIMMEL-1024] gitignore handovers/.locks/ arm-resume lock clutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ Thumbs.db
 # the hooks write these into himmel handovers/ as untracked clutter on main.
 # (Followup: redirect the hook write path to HANDOVER_DIR — see HIMMEL ticket.)
 handovers/auto-arm-status-*.md
+# arm-resume lock files (arms.jsonl) — transient arming-lock state that lands in
+# the himmel handovers/ stub as untracked clutter; observed staged on main
+# (HIMMEL-1024), same class as the auto-arm-status snapshots above.
+handovers/.locks/
 # Overnight-mode reports/recovery artifacts — auto-generated session state
 # (morning-report.sh et al.) that belongs in the state repo, not the himmel
 # handovers/ stub. Archived copies live in <state-repo> handovers/yotamleo/himmel/.


### PR DESCRIPTION
Ignore the arm-resume lock directory (`handovers/.locks/`) — transient arming-lock state that lands in the himmel `handovers/` stub as untracked clutter, same class as the existing `auto-arm-status-*.md` snapshots just above it in this file.

One-line `.gitignore` addition; no code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved repository housekeeping by excluding transient handover lock files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->