### PR TITLE
fix(claudex): [HIMMEL-1027] set cc-codex auto-compact window to codex 272k ceiling

### DIFF
--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -476,6 +476,7 @@ bank, and opens mixed subagent lanes that the plain codex CLI harness does not.
 | `CODEX_MODEL` | `gpt-5.6-sol` by default |
 | `CODEX_HAIKU` | `$CODEX_MODEL` by default |
 | `CODEX_SUBAGENT_MODEL` | `$CODEX_MODEL` by default |
+| `CODEX_CONTEXT_WINDOW` | `272000` by default → `CLAUDE_CODE_AUTO_COMPACT_WINDOW` (twin of `GLM_CONTEXT_WINDOW`). Without it Claude Code assumes its ~200k default for the unrecognized `gpt-5.6-sol` slug and compacts early. gpt-5.6's real window is **~372k** (95% effective ~353k, [openai/codex#32486](https://github.com/openai/codex/issues/32486)); **272k is the 2× pricing cliff, NOT a hard ceiling** — input past 272k bills 2× input / 1.5× output. `272000` is the cost-optimal default (compact at the cliff); raise to `353000` to use the full window at 2× cost past 272k. |
 | `CLIPROXY_API_KEY` | Must match an `api-keys` entry in `~/.cli-proxy-api/config.yaml` |
 | `CLAUDE_CONFIG_DIR` | `$HOME/.claude-codex` |
 

--- a/scripts/claude-codex
+++ b/scripts/claude-codex
@@ -9,6 +9,39 @@ CODEX_PROXY_BASE_URL="${CODEX_PROXY_BASE_URL:-http://127.0.0.1:8317}"
 CODEX_MODEL="${CODEX_MODEL:-gpt-5.6-sol}"
 CODEX_HAIKU="${CODEX_HAIKU:-$CODEX_MODEL}"
 CODEX_SUBAGENT_MODEL="${CODEX_SUBAGENT_MODEL:-$CODEX_MODEL}"
+# CODEX_CONTEXT_WINDOW feeds CLAUDE_CODE_AUTO_COMPACT_WINDOW (export block below)
+# so Claude Code budgets against a real number instead of its ~200k default for
+# the unrecognized gpt-5.6-sol slug — the twin of claude-glm's GLM_CONTEXT_WINDOW.
+# gpt-5.6's actual window is ~372k (95% effective ~353k, openai/codex#32486). The
+# 272000 default is the COST-OPTIMAL compaction point, NOT a hard ceiling: input
+# past 272k bills 2x input / 1.5x output for the whole request, so compacting at
+# the 272k cliff keeps sessions cheap. Raise to CODEX_CONTEXT_WINDOW=353000 to use
+# the full effective window at 2x cost past 272k. HIMMEL-1027.
+CODEX_CONTEXT_WINDOW="${CODEX_CONTEXT_WINDOW:-272000}"
+# CodeRabbit (HIMMEL-1027): validate the override — a non-positive-integer value
+# falls back to the default; a value above the ~372k backend window WARNS, and a
+# value above the 272k 2x-billing cliff NOTES the cost (both honored — warn-not-
+# clamp). Twin-parity with claude-glm.
+case "$CODEX_CONTEXT_WINDOW" in
+  ''|*[!0-9]*) echo "claude-codex: WARNING - CODEX_CONTEXT_WINDOW='$CODEX_CONTEXT_WINDOW' is not a positive integer; using 272000." >&2; CODEX_CONTEXT_WINDOW=272000 ;;
+esac
+# All-digits past here. Guard int64 overflow by digit length BEFORE any arithmetic
+# comparison (a >18-digit value can exceed the shell's integer range); reject zero;
+# warn above the ~372k backend window / note above the 272k cost cliff (HIMMEL-1027).
+if [ "${#CODEX_CONTEXT_WINDOW}" -gt 18 ]; then
+  echo "claude-codex: WARNING - CODEX_CONTEXT_WINDOW=$CODEX_CONTEXT_WINDOW is out of range; using 272000." >&2; CODEX_CONTEXT_WINDOW=272000
+elif [ "$CODEX_CONTEXT_WINDOW" -eq 0 ]; then
+  echo "claude-codex: WARNING - CODEX_CONTEXT_WINDOW=0 is not positive; using 272000." >&2; CODEX_CONTEXT_WINDOW=272000
+else
+  # Independent checks (CodeRabbit HIMMEL-1027): a value >372000 also exceeds the
+  # 272k cliff, so emit BOTH the backend-window warning AND the billing note.
+  if [ "$CODEX_CONTEXT_WINDOW" -gt 372000 ]; then
+    echo "claude-codex: WARNING - CODEX_CONTEXT_WINDOW=$CODEX_CONTEXT_WINDOW exceeds the ~372k gpt-5.6 backend window (95% effective ~353k); the backend may reject prompts past it. Proceeding as set." >&2
+  fi
+  if [ "$CODEX_CONTEXT_WINDOW" -gt 272000 ]; then
+    echo "claude-codex: NOTE - CODEX_CONTEXT_WINDOW=$CODEX_CONTEXT_WINDOW is above the 272k 2x-billing cliff; input past 272k bills 2x (backend window ~372k). Proceeding as set." >&2
+  fi
+fi
 CONFIG_DIR="${HOME}/.claude-codex"
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -523,6 +556,7 @@ export ANTHROPIC_MODEL="$CODEX_MODEL"
 export ANTHROPIC_DEFAULT_HAIKU_MODEL="$CODEX_HAIKU"
 export ANTHROPIC_DEFAULT_SONNET_MODEL="$CODEX_MODEL"
 export ANTHROPIC_DEFAULT_OPUS_MODEL="$CODEX_MODEL"
+export CLAUDE_CODE_AUTO_COMPACT_WINDOW="$CODEX_CONTEXT_WINDOW"
 export CLAUDE_CODE_SUBAGENT_MODEL="$CODEX_SUBAGENT_MODEL"
 export CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1
 export CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=3

--- a/scripts/claude-codex.ps1
+++ b/scripts/claude-codex.ps1
@@ -31,6 +31,31 @@ $CodexProxyBaseUrl = if ($env:CODEX_PROXY_BASE_URL) { $env:CODEX_PROXY_BASE_URL 
 $CodexModel         = if ($env:CODEX_MODEL) { $env:CODEX_MODEL } else { 'gpt-5.6-sol' }
 $CodexHaiku         = if ($env:CODEX_HAIKU) { $env:CODEX_HAIKU } else { $CodexModel }
 $CodexSubagentModel = if ($env:CODEX_SUBAGENT_MODEL) { $env:CODEX_SUBAGENT_MODEL } else { $CodexModel }
+# CODEX_CONTEXT_WINDOW feeds CLAUDE_CODE_AUTO_COMPACT_WINDOW (env block below) so
+# Claude Code budgets against a real number instead of its ~200k default for the
+# unrecognized gpt-5.6-sol slug — twin of the bash launcher. gpt-5.6's actual
+# window is ~372k (95% effective ~353k, openai/codex#32486). The 272000 default is
+# the COST-OPTIMAL compaction point, NOT a hard ceiling: input past 272k bills 2x
+# input / 1.5x output for the whole request. Raise to CODEX_CONTEXT_WINDOW=353000
+# to use the full effective window at 2x cost past 272k.
+$CodexContextWindow = if ($env:CODEX_CONTEXT_WINDOW) { $env:CODEX_CONTEXT_WINDOW } else { '272000' }
+# CodeRabbit (HIMMEL-1027): validate the override — a non-positive-integer value
+# falls back to the default; above the ~372k backend window WARNS, above the 272k
+# 2x-billing cliff NOTES the cost (both honored — warn-not-clamp, twin-parity).
+[long]$CodexCtxParsed = 0
+if (-not [long]::TryParse($CodexContextWindow, [ref]$CodexCtxParsed) -or $CodexCtxParsed -le 0) {
+  [Console]::Error.WriteLine("claude-codex: WARNING - CODEX_CONTEXT_WINDOW='$CodexContextWindow' is not a positive integer; using 272000.")
+  $CodexContextWindow = '272000'
+} else {
+  # Independent checks (CodeRabbit HIMMEL-1027): a value >372000 also exceeds the
+  # 272k cliff, so emit BOTH the backend-window warning AND the billing note.
+  if ($CodexCtxParsed -gt 372000) {
+    [Console]::Error.WriteLine("claude-codex: WARNING - CODEX_CONTEXT_WINDOW=$CodexCtxParsed exceeds the ~372k gpt-5.6 backend window (95% effective ~353k); the backend may reject prompts past it. Proceeding as set.")
+  }
+  if ($CodexCtxParsed -gt 272000) {
+    [Console]::Error.WriteLine("claude-codex: NOTE - CODEX_CONTEXT_WINDOW=$CodexCtxParsed is above the 272k 2x-billing cliff; input past 272k bills 2x (backend window ~372k). Proceeding as set.")
+  }
+}
 # HOME equivalent: bash uses $HOME; here $env:USERPROFILE so hermetic tests can
 # override the home root per-invocation (PowerShell's $HOME is fixed at startup).
 $HomeDir   = $env:USERPROFILE
@@ -618,6 +643,7 @@ $env:ANTHROPIC_MODEL                = $CodexModel
 $env:ANTHROPIC_DEFAULT_HAIKU_MODEL  = $CodexHaiku
 $env:ANTHROPIC_DEFAULT_SONNET_MODEL = $CodexModel
 $env:ANTHROPIC_DEFAULT_OPUS_MODEL   = $CodexModel
+$env:CLAUDE_CODE_AUTO_COMPACT_WINDOW = $CodexContextWindow
 $env:CLAUDE_CODE_SUBAGENT_MODEL     = $CodexSubagentModel
 $env:CLAUDE_CODE_ALWAYS_ENABLE_EFFORT = '1'
 $env:CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY = '3'

--- a/scripts/claude-glm
+++ b/scripts/claude-glm
@@ -12,6 +12,22 @@ GLM_BASE_URL="https://api.z.ai/api/anthropic"
 GLM_MODEL="${GLM_MODEL:-glm-5.2[1m]}"
 GLM_HAIKU="glm-4.7"
 GLM_CONTEXT_WINDOW="${GLM_CONTEXT_WINDOW:-1000000}"
+# CodeRabbit (HIMMEL-1027): validate the override — a non-positive-integer value
+# falls back to the default; a value above the Z.ai [1m] ceiling WARNS but is
+# honored (warn-not-clamp). Twin-parity with claude-codex.
+case "$GLM_CONTEXT_WINDOW" in
+  ''|*[!0-9]*) echo "claude-glm: WARNING - GLM_CONTEXT_WINDOW='$GLM_CONTEXT_WINDOW' is not a positive integer; using 1000000." >&2; GLM_CONTEXT_WINDOW=1000000 ;;
+esac
+# All-digits past here. Guard int64 overflow by digit length BEFORE any arithmetic
+# comparison (a >18-digit value can exceed the shell's integer range); reject zero;
+# otherwise warn-but-honor above the ceiling (CodeRabbit HIMMEL-1027).
+if [ "${#GLM_CONTEXT_WINDOW}" -gt 18 ]; then
+  echo "claude-glm: WARNING - GLM_CONTEXT_WINDOW=$GLM_CONTEXT_WINDOW is out of range; using 1000000." >&2; GLM_CONTEXT_WINDOW=1000000
+elif [ "$GLM_CONTEXT_WINDOW" -eq 0 ]; then
+  echo "claude-glm: WARNING - GLM_CONTEXT_WINDOW=0 is not positive; using 1000000." >&2; GLM_CONTEXT_WINDOW=1000000
+elif [ "$GLM_CONTEXT_WINDOW" -gt 1000000 ]; then
+  echo "claude-glm: WARNING - GLM_CONTEXT_WINDOW=$GLM_CONTEXT_WINDOW exceeds the Z.ai glm-5.2[1m] 1000000 ceiling. Proceeding as set." >&2
+fi
 CONFIG_DIR="${HOME}/.claude-glm"
 
 HERE="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/claude-glm.ps1
+++ b/scripts/claude-glm.ps1
@@ -32,6 +32,16 @@ $GlmBaseUrl = 'https://api.z.ai/api/anthropic'
 $GlmModel         = if ($env:GLM_MODEL) { $env:GLM_MODEL } else { 'glm-5.2[1m]' }
 $GlmHaiku         = 'glm-4.7'
 $GlmContextWindow = if ($env:GLM_CONTEXT_WINDOW) { $env:GLM_CONTEXT_WINDOW } else { '1000000' }
+# CodeRabbit (HIMMEL-1027): validate the override — a non-positive-integer value
+# falls back to the default; above the Z.ai [1m] ceiling WARNS but is honored
+# (warn-not-clamp, twin-parity with the bash launcher + claude-codex).
+[long]$GlmCtxParsed = 0
+if (-not [long]::TryParse($GlmContextWindow, [ref]$GlmCtxParsed) -or $GlmCtxParsed -le 0) {
+  [Console]::Error.WriteLine("claude-glm: WARNING - GLM_CONTEXT_WINDOW='$GlmContextWindow' is not a positive integer; using 1000000.")
+  $GlmContextWindow = '1000000'
+} elseif ($GlmCtxParsed -gt 1000000) {
+  [Console]::Error.WriteLine("claude-glm: WARNING - GLM_CONTEXT_WINDOW=$GlmCtxParsed exceeds the Z.ai glm-5.2[1m] 1000000 ceiling. Proceeding as set.")
+}
 
 # HOME equivalent: bash uses $HOME; here $env:USERPROFILE so hermetic tests can
 # override the home root per-invocation (PowerShell's $HOME is fixed at startup).


### PR DESCRIPTION
Sets cc-codex's auto-compact window to the codex operating window (default 272k, cost-optimal) with a validated override guard on both codex and glm launchers + PowerShell twins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable context-window settings for Claude Code launchers.
  - Context-window values now control automatic compaction across supported launchers.
  - Added warnings for values exceeding documented limits or higher-cost billing thresholds.

- **Bug Fixes**
  - Invalid, empty, non-integer, or non-positive settings now fall back to safe defaults.
  - Added safeguards against excessively large values that could cause range issues.

- **Documentation**
  - Documented context-window defaults, effective limits, compaction behavior, and associated pricing considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->