### PR TITLE
Lean-floor: drop atlassian + add /handover-resume command

### DIFF
--- a/docs/commands-catalog.md
+++ b/docs/commands-catalog.md
@@ -63,6 +63,7 @@ and their rows are paraphrased one-liners rather than verbatim frontmatter
 | /handover-link | Report or check where Claude is reading/writing handover state (inline ./handovers or external $HANDOVER_DIR) |
 | /handover-pr-open | Open or update the PR for the current handover/<TICKET>-<slug> branch (HIMMEL-141). |
 | /handover-pr-merge | Squash-merge the PR for the current handover/<TICKET>-<slug> branch (HIMMEL-141). |
+| /handover-resume (handover) | Chain-resume a tracked handover item to continue work — surfaces its cold-start (brief/context, latest session, open bugs, CR findings); no arg picks from active items; append `overnight` for overnight mode. Thin wrapper on the `handover:handover` skill's `handover-resume` op (the token-lean equivalent of "load <ID>"). Distinct from /handover-resume-armed (armed-session recovery). HIMMEL-1034. |
 | /handover-resume-armed | Fast-resume from the last armed session — surface its transcript + stop-point (the answered AskUserQuestion = the agreed continuation) with no manual JSONL archaeology. HIMMEL-208. |
 | /handover-setup | First-time handover bootstrap — asks where handover state should live, persists it to .env as HANDOVER_DIR, then runs init (new) or register (existing). Use on a fresh machine/repo before /handover new-epic etc. |
 | /morning-report | Generate the dated 🌅 Morning Report from live git/gh/jira/worktree state at ~zero Claude tokens (no-token default; opt-in --llm enriches TL;DR + Suggested order + theme-clustered Backlog). HIMMEL-574. |

--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -669,11 +669,14 @@ Plugins live at `~/.claude/plugins/`. Different install methods per plugin — r
 
 ### Lean profile — disabled by default, enable on need (HIMMEL-816)
 
-`docs/setup/settings-template.json` ships **lean**: 12 `@claude-plugins-official`
-plugins, `obsidian@obsidian-skills`, and `caveman@caveman` (HIMMEL-701) are
-`false` in `enabledPlugins` — every adopter and every re-provisioned operator
-machine gets the minimal set by default instead of re-creating the maximal
-31-plugin install every time. Turn any of these back on with one command
+`docs/setup/settings-template.json` ships **lean**: 13 re-enableable
+`@claude-plugins-official` plugins (the table below), `obsidian@obsidian-skills`,
+and `caveman@caveman` (HIMMEL-701) are `false` in `enabledPlugins` — every adopter
+and every re-provisioned operator machine gets the minimal set by default instead
+of re-creating the maximal 31-plugin install every time. (A 14th
+`@claude-plugins-official` entry, `pr-review-toolkit`, is also `false` but is not
+listed for re-enable — himmel ships its own `pr-review-toolkit-himmel` fork.)
+Turn any of these back on with one command
 (`--scope user` shown; swap for `project`/`local` per [Scope](#scope-user-vs-project) above):
 
 | Plugin | Enable command | Note |
@@ -690,6 +693,7 @@ machine gets the minimal set by default instead of re-creating the maximal
 | `commit-commands@claude-plugins-official` | `claude plugin install commit-commands@claude-plugins-official --scope user` | |
 | `playground@claude-plugins-official` | `claude plugin install playground@claude-plugins-official --scope user` | |
 | `skill-creator@claude-plugins-official` | `claude plugin install skill-creator@claude-plugins-official --scope user` | |
+| `atlassian@claude-plugins-official` | `claude plugin install atlassian@claude-plugins-official --scope user` | **enable-on-need:** Jira is CLI-first per project rules (`scripts/jira/dist/index.js`) — enable only when a session needs interactive Confluence/Atlassian skills. The optional atlassian **MCP** integration is separate (see [Optional integrations](#optional-integrations)) |
 | `obsidian@obsidian-skills` | `claude plugin marketplace add kepano/obsidian-skills` then `claude plugin install obsidian@obsidian-skills --scope user` | `obsidian-triage` falls back to plain markdown when this isn't enabled (documented in the command body) — enable if you need proper OFM parity |
 | `caveman@caveman` | `claude plugin marketplace add JuliusBrussee/caveman` then `claude plugin install caveman@caveman --scope user` | Caveman compression mode + cavecrew subagents (HIMMEL-701) |
 

--- a/docs/setup/settings-template.json
+++ b/docs/setup/settings-template.json
@@ -94,7 +94,7 @@
     "agent-sdk-dev@claude-plugins-official": false,
     "hookify@claude-plugins-official": true,
     "playground@claude-plugins-official": false,
-    "atlassian@claude-plugins-official": true,
+    "atlassian@claude-plugins-official": false,
     "obsidian@obsidian-skills": false,
     "qmd@qmd": false,
     "qmd@himmel": true,

--- a/marketplace/plugins/handover/README.md
+++ b/marketplace/plugins/handover/README.md
@@ -49,7 +49,7 @@ though the himmel repo also wires explicit `/handover *` commands.
 | `new-task <epic-id> <name>` | Create a task inside an epic (inherits the epic's source bucket; optional Jira Task linked via Epic Link). |
 | `new-standalone <name>` | Create a standalone (optional Jira Story). |
 | `update-status` | Regenerate `status.md` + `roadmap.md` + `tech-debt.md` from filesystem state. Run after any mutation. |
-| `handover-resume #N` | Resume a tracked item — surface its brief, decisions, and stop-point. Read-only (no worktree gate). |
+| `handover-resume #N` (or `/handover-resume [ID] [overnight]`) | Resume a tracked item — surface its brief, decisions, and stop-point. Read-only (no worktree gate). Forms: **no ID** → picker over active items; **`#N`/`HIMMEL-N`/bare number** → that item; append **`overnight`** → overnight-mode trigger. The `/handover-resume` slash command is a token-lean wrapper for this op (≡ "load #N"); distinct from `/handover-resume-armed`, which recovers an interrupted/armed session. |
 | `/handover bug <add\|fix\|status>` | Quick-add / update a bug in the active item's `bugs.md` (status + FAILED/WORKED fixes-tried). The circular-debugging breaker. |
 | `/handover bugs [--open]` | Cross-item dashboard of every tracked bug (item / id / status / symptom / #fixes + totals). Read-only. |
 | `/handover lessons` | Proposal-only sweep: recurring resolved-bug symptoms + CR findings as lesson candidates. Writes nothing. |

--- a/marketplace/plugins/handover/commands/handover-resume.md
+++ b/marketplace/plugins/handover/commands/handover-resume.md
@@ -1,0 +1,54 @@
+---
+allowed-tools: Skill, Bash, Read, Glob, Grep, AskUserQuestion
+description: Resume a tracked handover item to continue the chain — surface its cold-start (brief/context, latest session, open bugs, CR findings). No arg → pick from active items. Read-only (no worktree gate). The token-lean equivalent of "load <ID>". To recover an interrupted/armed session, use /handover-resume-armed instead. HIMMEL-1034.
+argument-hint: "[#N | HIMMEL-N | <ID>]  (omit → pick from active items; append 'overnight' for overnight mode)"
+---
+
+This is the **chain-resume** path — load a tracked handover item to *continue
+work*. It is deliberately distinct from `/handover-resume-armed`, which
+*recovers* an interrupted/armed session's stop-point (transcript + last
+`AskUserQuestion`). resume ≠ recovery.
+
+## What to do
+
+1. Parse `$ARGUMENTS`:
+   - If the word **`overnight`** appears anywhere in `$ARGUMENTS`, set an
+     overnight flag and strip that token first.
+   - Of the remaining tokens: **zero or one** is accepted. The single token (if
+     present) is the item ID: `#N`, `HIMMEL-N`, or a bare number. Omit → no ID.
+   - **Reject anything else.** If, after stripping `overnight`, more than one
+     token remains — or the lone token is not a valid ID form (`#N` /
+     `<PROJECT>-N` / bare number) — do NOT guess: stop and print a clear
+     unsupported-argument error naming the accepted forms
+     (`/handover-resume [ID] [overnight]`). Note that the phase-2 chain-action
+     params (`merge-private`, `merge-public`, `propagate-only`, `minerva-full`,
+     `plan-only`, `arm-successor`) are **not implemented yet**, so a token like
+     `merge` is unsupported today rather than silently ignored.
+
+2. Invoke the handover skill's read-only `handover-resume` operation with the
+   ID (or no ID). Use the **Skill** tool → `handover` with args
+   `handover-resume <ID>` (pass no ID to run the picker).
+
+   The skill op (read-only — no worktree gate) resolves the target repo +
+   bucket and then:
+   - **no ID** → runs the No-ID picker over active items and prompts for one.
+   - **`#N` / `HIMMEL-N` / bare ID** → finds the item and prints its latest
+     session's Cold-Start Prompt (or the brief/context as a fallback), plus any
+     open bugs and the latest CR findings.
+
+3. Act on the printed cold-start: load the referenced files and continue the
+   work from the item's stop-point.
+
+4. **If the overnight flag was set** (e.g. `/handover-resume HIMMEL-1033 overnight`):
+   after loading the item, treat this as the overnight-mode trigger for that
+   item's latest `next-session-*.md` and run the autonomous pipeline per
+   [`docs/handover/overnight-mode.md`](../../../../docs/handover/overnight-mode.md)
+   without pausing between phases.
+
+## Not yet implemented (phase 2 — HIMMEL-1034)
+
+Chain-action params — `merge-private`, `merge-public`, `propagate-only`,
+`minerva-full`, `plan-only`, `arm-successor` — will delegate to the existing
+initiative-leg (`scripts/lib/initiative-legs.sh`), `arm-resume`, minerva, and
+propagate-public systems. This MVP ships plain chain-resume + the `overnight`
+passthrough only.


### PR DESCRIPTION
Drops the atlassian plugin from the adopter lean floor (jira is CLI-first; enable-on-need) and adds a token-lean /handover-resume chain-resume command. Ports HIMMEL-1033/1034.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `/handover-resume` command for resuming tracked handover items, with optional item selection and overnight mode.
  * Added argument validation and support for item IDs in multiple formats.
  * Added overnight pipeline passthrough for the selected handover item.

* **Documentation**
  * Expanded handover command guidance and clarified read-only behavior.
  * Updated setup documentation for disabled-by-default plugins, including Atlassian integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->