### PR TITLE
refactor(handover): script-driven /handover-resume (drop 47KB skill load)

### DIFF
--- a/.claude/commands/handover-resume.md
+++ b/.claude/commands/handover-resume.md
@@ -1,6 +1,6 @@
 ---
-allowed-tools: Skill, Bash, Read, Glob, Grep, AskUserQuestion
-description: Resume a tracked handover item to continue the chain — surface its cold-start (brief/context, latest session, open bugs, CR findings). No arg → pick from active items. Read-only (no worktree gate). The token-lean equivalent of "load <ID>". To recover an interrupted/armed session, use /handover-resume-armed instead. HIMMEL-1034.
+allowed-tools: Bash, Read, AskUserQuestion
+description: Resume a tracked handover item to continue the chain — surface its cold-start (brief/context, latest session, open bugs, CR findings). No arg → pick from active items. Read-only (no worktree gate). Script-driven — calls scripts/handover/resume.sh directly, does NOT load the 47KB handover skill (HIMMEL-1038). The token-lean equivalent of "load <ID>". To recover an interrupted/armed session, use /handover-resume-armed instead. HIMMEL-1034.
 argument-hint: "[#N | HIMMEL-N | <ID>]  (omit → pick from active items; append 'overnight' for overnight mode)"
 ---
 
@@ -9,39 +9,48 @@ work*. It is deliberately distinct from `/handover-resume-armed`, which
 *recovers* an interrupted/armed session's stop-point (transcript + last
 `AskUserQuestion`). resume ≠ recovery.
 
+**Script-driven (HIMMEL-1038):** resume is read-only and fully mechanical, so
+this command calls `scripts/handover/resume.sh` directly and does **not** invoke
+the handover skill — avoiding the ~47KB `SKILL.md` load (~7% of context) that the
+skill path incurred. The script resolves the target repo + bucket from
+`~/.claude/handover/registry.json` (HANDOVER_DIR comes from the environment).
+
 ## What to do
 
 1. Parse `$ARGUMENTS`:
-   - If the word **`overnight`** appears anywhere in `$ARGUMENTS`, set an
-     overnight flag and strip that token first.
+   - If the word **`overnight`** appears anywhere, set an overnight flag and strip
+     that token first.
    - Of the remaining tokens: **zero or one** is accepted. The single token (if
      present) is the item ID: `#N`, `HIMMEL-N`, or a bare number. Omit → no ID.
-   - **Reject anything else.** If, after stripping `overnight`, more than one
-     token remains — or the lone token is not a valid ID form (`#N` /
-     `<PROJECT>-N` / bare number) — do NOT guess: stop and print a clear
-     unsupported-argument error naming the accepted forms
-     (`/handover-resume [ID] [overnight]`). Note that the phase-2 chain-action
-     params (`merge-private`, `merge-public`, `propagate-only`, `minerva-full`,
-     `plan-only`, `arm-successor`) are **not implemented yet**, so a token like
-     `merge` is unsupported today rather than silently ignored.
+   - **Reject anything else.** If, after stripping `overnight`, more than one token
+     remains — or the lone token is not a valid ID form — do NOT guess: stop and
+     print a clear unsupported-argument error naming the accepted forms
+     (`/handover-resume [ID] [overnight]`). The phase-2 chain-action params
+     (`merge-private`, `merge-public`, `propagate-only`, `minerva-full`,
+     `plan-only`, `arm-successor`) are **not implemented yet** (HIMMEL-1034), so a
+     token like `merge` is unsupported today rather than silently ignored.
+     (The script also validates the ID form and exits rc 2 on a bad one, but do
+     the reject up-front so a bad token never reaches the script.)
 
-2. Invoke the handover skill's read-only `handover-resume` operation with the
-   ID (or no ID). Use the **Skill** tool → `handover` with args
-   `handover-resume <ID>` (pass no ID to run the picker).
+2. Run the resume script (read-only) from the repo root:
+   - **ID given:** `bash scripts/handover/resume.sh <ID>` — prints the item's
+     latest session's Cold-Start Prompt (fallback: `brief.md`/`context.md`), any
+     open bugs, the latest CR findings, and a stale nudge. Present that output.
+   - **No ID:** `bash scripts/handover/resume.sh --list` prints active items, one
+     per line as `ID<TAB>slug<TAB>status<TAB>type`. Offer the top items via
+     **AskUserQuestion** (plus an "Other (enter ID)" option), then run
+     `bash scripts/handover/resume.sh <chosen-ID>`. If `--list` prints nothing,
+     free-text prompt for an ID.
+   - **Non-zero exit:** relay the script's stderr line and stop — `rc 2` =
+     usage/hard error (bad ID form, unreadable registry), `rc 3` = graceful (no
+     repo match in the registry, or no item with that ID).
 
-   The skill op (read-only — no worktree gate) resolves the target repo +
-   bucket and then:
-   - **no ID** → runs the No-ID picker over active items and prompts for one.
-   - **`#N` / `HIMMEL-N` / bare ID** → finds the item and prints its latest
-     session's Cold-Start Prompt (or the brief/context as a fallback), plus any
-     open bugs and the latest CR findings.
-
-3. Act on the printed cold-start: load the referenced files and continue the
-   work from the item's stop-point.
+3. Act on the printed cold-start: load the referenced files and continue the work
+   from the item's stop-point.
 
 4. **If the overnight flag was set** (e.g. `/handover-resume HIMMEL-1033 overnight`):
-   after loading the item, treat this as the overnight-mode trigger for that
-   item's latest `next-session-*.md` and run the autonomous pipeline per
+   after loading the item, treat this as the overnight-mode trigger for that item's
+   latest `next-session-*.md` and run the autonomous pipeline per
    [`docs/handover/overnight-mode.md`](../../../../docs/handover/overnight-mode.md)
    without pausing between phases.
 

--- a/.claude/commands/handover-resume.md
+++ b/.claude/commands/handover-resume.md
@@ -51,7 +51,7 @@ skill path incurred. The script resolves the target repo + bucket from
 4. **If the overnight flag was set** (e.g. `/handover-resume HIMMEL-1033 overnight`):
    after loading the item, treat this as the overnight-mode trigger for that item's
    latest `next-session-*.md` and run the autonomous pipeline per
-   [`docs/handover/overnight-mode.md`](../../../../docs/handover/overnight-mode.md)
+   [`docs/handover/overnight-mode.md`](../../docs/handover/overnight-mode.md)
    without pausing between phases.
 
 ## Not yet implemented (phase 2 — HIMMEL-1034)

--- a/scripts/handover/resume.sh
+++ b/scripts/handover/resume.sh
@@ -26,6 +26,10 @@ while [ $# -gt 0 ]; do case "$1" in
      id="$1"; shift;;
 esac; done
 
+if [ "$mode" = "list" ] && [ -n "$id" ]; then
+  echo "resume.sh: --list does not accept an ID" >&2; exit 2
+fi
+
 if [ "$mode" = "resume" ] && [ -z "$id" ]; then
   echo "resume.sh: no ID given (use --list for the picker)" >&2; exit 2
 fi
@@ -58,7 +62,8 @@ meta="$(REG="$reg" RR="$rr_canon" node -e '
   process.exit(1);
 ')"; node_rc=$?
 if [ "$node_rc" -eq 2 ]; then echo "resume.sh: registry unreadable ($reg)" >&2; exit 2; fi
-if [ "$node_rc" -ne 0 ]; then echo "resume.sh: repo not registered ($repo_root)" >&2; exit 3; fi
+if [ "$node_rc" -eq 1 ]; then echo "resume.sh: repo not registered ($repo_root)" >&2; exit 3; fi
+if [ "$node_rc" -ne 0 ]; then echo "resume.sh: registry lookup failed (node rc=$node_rc)" >&2; exit 2; fi
 user="${meta%%$'\t'*}"; rest="${meta#*$'\t'}"; bucket="${rest%%$'\t'*}"; jira="${rest#*$'\t'}"
 [ -n "$jira" ] || jira="$bucket"
 jira_uc="$(printf '%s' "$jira" | tr '[:lower:]' '[:upper:]')"
@@ -162,7 +167,7 @@ else
 fi
 
 # --- open bugs + latest CR findings panel (prints nothing when clean) ---
-panel="$(bash "$SCRIPT_DIR/resume-context.sh" --item "$item_dir" 2>/dev/null)"
+panel="$(bash "$SCRIPT_DIR/resume-context.sh" --item "$item_dir")"
 [ -n "$panel" ] && printf '\n%s\n' "$panel"
 
 # --- stale nudge (top-3 lingering/zombie bullets from tech-debt.md) ---

--- a/scripts/handover/resume.sh
+++ b/scripts/handover/resume.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# scripts/handover/resume.sh — read-only chain-resume for a handover item.
+#
+# Given an ID (#N | <PROJECT>-N | bare N), resolves the target repo + bucket
+# from the registry (same resolution as resolve-active-item.sh), finds the
+# item dir, and prints its latest session's Cold-Start Prompt (fallback:
+# context.md / brief.md), then the open-bugs + latest-CR panel
+# (resume-context.sh) and a stale nudge from tech-debt.md. `--list` prints
+# active items for the No-ID picker (the calling command runs the prompt).
+# Read-only — never mutates. Lets /handover-resume skip the 47KB handover
+# SKILL.md load. HIMMEL-1038.
+#
+# Exit: 0 = printed; 2 = usage/hard error; 3 = graceful (no repo match in
+#       registry / item not found).
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+mode="resume" id="" repo_root=""
+while [ $# -gt 0 ]; do case "$1" in
+  --list) mode="list"; shift;;
+  --repo-root) [ $# -ge 2 ] || { echo "resume.sh: --repo-root needs a value" >&2; exit 2; }
+               repo_root="$2"; shift 2;;   # test/override hook (mirrors resolve-active-item.sh)
+  -h|--help) echo "usage: resume.sh <#N|PROJECT-N|N>   |   resume.sh --list" >&2; exit 0;;
+  --*) echo "resume.sh: unknown flag '$1'" >&2; exit 2;;
+  *) if [ -n "$id" ]; then echo "resume.sh: too many arguments (one ID only)" >&2; exit 2; fi
+     id="$1"; shift;;
+esac; done
+
+if [ "$mode" = "resume" ] && [ -z "$id" ]; then
+  echo "resume.sh: no ID given (use --list for the picker)" >&2; exit 2
+fi
+
+# --- handover root + repo/bucket resolution (mirrors resolve-active-item.sh) ---
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/../lib/handover-path.sh" || { echo "resume.sh: cannot source handover-path.sh" >&2; exit 2; }
+root="$(handover_root)" || { echo "resume.sh: handover root unresolved" >&2; exit 2; }
+
+if [ -z "$repo_root" ]; then
+  gcd="$(git -C . rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || { echo "resume.sh: not in a git repo" >&2; exit 3; }
+  repo_root="$(dirname "$gcd")"
+fi
+canon(){ printf '%s' "$1" | tr '\134' '/' | sed 's:/*$::' | tr '[:upper:]' '[:lower:]'; }
+rr_canon="$(canon "$repo_root")"
+
+reg="${HANDOVER_REGISTRY:-$HOME/.claude/handover/registry.json}"
+[ -f "$reg" ] || { echo "resume.sh: registry not found ($reg)" >&2; exit 3; }
+# node exits 0 (match, prints user\tbucket\tjira), 1 (no matching repo ->
+# graceful skip), or 2 (registry unreadable -> hard error). Same contract as
+# resolve-active-item.sh.
+meta="$(REG="$reg" RR="$rr_canon" node -e '
+  const fs=require("fs"), e=process.env;
+  let j; try{ j=JSON.parse(fs.readFileSync(e.REG,"utf8")); }catch(err){ console.error("resume.sh: registry parse error: "+err.message); process.exit(2); }
+  const repos=(j&&j.repos)||{};
+  for(const k of Object.keys(repos)){
+    const p=String(repos[k].path||"").replace(/\\/g,"/").replace(/\/+$/,"").toLowerCase();
+    if(p===e.RR){ process.stdout.write([repos[k].user||"",k,repos[k].jira_project||""].join("\t")); process.exit(0); }
+  }
+  process.exit(1);
+')"; node_rc=$?
+if [ "$node_rc" -eq 2 ]; then echo "resume.sh: registry unreadable ($reg)" >&2; exit 2; fi
+if [ "$node_rc" -ne 0 ]; then echo "resume.sh: repo not registered ($repo_root)" >&2; exit 3; fi
+user="${meta%%$'\t'*}"; rest="${meta#*$'\t'}"; bucket="${rest%%$'\t'*}"; jira="${rest#*$'\t'}"
+[ -n "$jira" ] || jira="$bucket"
+jira_uc="$(printf '%s' "$jira" | tr '[:lower:]' '[:upper:]')"
+
+state_root="$root/$user"
+base="$state_root/$bucket"
+[ -d "$base" ] || base="$state_root"     # no-bucket (flat) fallback
+
+# --- helpers ---
+item_status(){ grep -m1 '^\*\*Status:\*\*' "$1" 2>/dev/null | sed 's/^\*\*Status:\*\*[[:space:]]*//'; }
+is_active(){ case "$1" in not-started|in-progress|pending|planned|blocked) return 0;; *) return 1;; esac; }
+
+# --- list mode (No-ID picker feed: ID<TAB>slug<TAB>status<TAB>type per line) ---
+if [ "$mode" = "list" ]; then
+  printed=0
+  emit(){ # $1=dir $2=primary-file $3=type
+    local d="$1" f="$2" t="$3" bn st id2 slug
+    [ -d "$d" ] || return 0
+    [ -f "$d/$f" ] || return 0
+    st="$(item_status "$d/$f")"
+    is_active "$st" || return 0
+    bn="$(basename "$d")"
+    id2="$(printf '%s' "$bn" | sed -n "s/^\(#\{0,1\}${jira_uc}-[0-9]\{1,\}\|#[0-9]\{1,\}\).*/\1/p")"
+    [ -n "$id2" ] || id2="$bn"
+    slug="${bn#"$id2"-}"
+    printf '%s\t%s\t%s\t%s\n' "$id2" "$slug" "$st" "$t"
+    printed=$((printed+1))
+  }
+  for d in "$base"/epics/*/;         do emit "$d" master-plan.md epic; done
+  for d in "$base"/standalones/*/;   do emit "$d" brief.md standalone; done
+  for d in "$base"/epics/*/tasks/*/; do emit "$d" brief.md task; done
+  [ "$printed" -gt 0 ] || echo "resume.sh: no active items in $bucket" >&2
+  exit 0
+fi
+
+# --- resume mode: normalize ID -> scan forms ---
+raw="${id#\#}"                            # strip a leading #
+if printf '%s' "$raw" | grep -qiE '^[A-Za-z][A-Za-z0-9-]*-[0-9]+$'; then
+  # PROJECT-K form (incl. multi-part keys like LUNA-BRAIN-5) -> key namespace only
+  # (charset-bounded: alnum + hyphen only — no shell metacharacters reach the globs)
+  key="$(printf '%s' "$raw" | tr '[:lower:]' '[:upper:]')"
+  forms=("$key")
+elif printf '%s' "$raw" | grep -qE '^[0-9]+$'; then
+  # bare numeric -> both <JIRA>-N and #N namespaces (routing.md v2 rule)
+  forms=("${jira_uc}-${raw}" "#${raw}")
+else
+  echo "resume.sh: invalid ID '$id' (want #N, ${jira_uc}-N, or a bare number)" >&2
+  exit 2
+fi
+
+# --- scan for the item dir (standalone, epic, epic-task; first match wins) ---
+item_dir="" item_file=""
+for form in "${forms[@]}"; do
+  for pair in "standalones|brief.md" "epics|master-plan.md"; do
+    sub="${pair%%|*}"; pf="${pair#*|}"
+    for d in "$base/$sub/$form-"*/; do
+      [ -d "$d" ] || continue
+      item_dir="${d%/}"; item_file="$pf"; break 3
+    done
+  done
+  for d in "$base"/epics/*/tasks/"$form-"*/; do
+    [ -d "$d" ] || continue
+    item_dir="${d%/}"; item_file="brief.md"; break 2
+  done
+done
+
+if [ -z "$item_dir" ]; then
+  echo "resume.sh: no item with ID '$id' found in bucket '$bucket'" >&2
+  exit 3
+fi
+
+# --- latest next-session-*.md -> Cold-Start Prompt block (trimmed) ---
+# Highest N by numeric compare (portable — no ls / no `sort -V`).
+latest="" latest_n=-1
+for f in "$item_dir"/next-session-*.md; do
+  [ -f "$f" ] || continue
+  n="${f##*/next-session-}"; n="${n%.md}"
+  case "$n" in ''|*[!0-9]*) continue;; esac
+  [ "$n" -gt "$latest_n" ] && { latest_n="$n"; latest="$f"; }
+done
+printf 'Cold-start prompt for %s (repo: %s):\n\n' "$id" "$bucket"
+if [ -n "$latest" ]; then
+  block="$(awk '
+    /^## Cold-Start Prompt[[:space:]]*$/ { inb=1; next }
+    inb && /^## / { inb=0 }
+    inb { L[++n]=$0 }
+    END {
+      for(i=1;i<=n;i++) if(L[i] ~ /[^[:space:]]/){ if(!f)f=i; l=i }
+      for(i=f;i<=l;i++) print L[i]
+    }
+  ' "$latest")"
+  if [ -n "$block" ]; then
+    printf '%s\n' "$block"
+  else
+    printf '(latest session %s has no Cold-Start Prompt block — showing %s)\n\n' "$(basename "$latest")" "$item_file"
+    cat "$item_dir/$item_file"
+  fi
+else
+  printf '(no session file yet for %s — showing %s)\n\n' "$id" "$item_file"
+  cat "$item_dir/$item_file"
+fi
+
+# --- open bugs + latest CR findings panel (prints nothing when clean) ---
+panel="$(bash "$SCRIPT_DIR/resume-context.sh" --item "$item_dir" 2>/dev/null)"
+[ -n "$panel" ] && printf '\n%s\n' "$panel"
+
+# --- stale nudge (top-3 lingering/zombie bullets from tech-debt.md) ---
+td="$state_root/tech-debt.md"
+if [ -f "$td" ]; then
+  nudge="$(awk '
+    /^## (Lingering|Zombie)/ { sec=1; next }
+    /^## / && sec && $0 !~ /^## (Lingering|Zombie)/ { sec=0 }
+    sec && /^- / && $0 !~ /\(none\)/ { print }
+  ' "$td" | head -n3)"
+  if [ -n "$nudge" ]; then
+    printf '\nStale items worth a glance before continuing:\n%s\n\nFull triage: /handover hygiene\n' "$nudge"
+  fi
+fi

--- a/scripts/handover/test-resume.sh
+++ b/scripts/handover/test-resume.sh
@@ -102,5 +102,17 @@ HANDOVER_DIR="$root" HANDOVER_REGISTRY="$reg" bash "$R" --repo-root >/dev/null 2
 check "--repo-root without value -> rc 2" "$?" "2"
 HANDOVER_DIR="$root" HANDOVER_REGISTRY="$reg" bash "$R" --repo-root "C:/Work/Other" 5 >/dev/null 2>&1
 check "unregistered repo -> rc 3" "$?" "3"
+run --list HIMMEL-389 >/dev/null 2>&1
+check "--list with an ID -> rc 2" "$?" "2"
+
+# 6. node lookup crash (rc neither 0/1/2) -> hard error, not misreported as graceful skip.
+fakebin="$tmp/fakebin"; mkdir -p "$fakebin"
+cat > "$fakebin/node" <<'SH'
+#!/usr/bin/env bash
+exit 5
+SH
+chmod +x "$fakebin/node"
+PATH="$fakebin:$PATH" HANDOVER_DIR="$root" HANDOVER_REGISTRY="$reg" bash "$R" --repo-root "$RR" 389 >/dev/null 2>&1
+check "node crash (rc=5) -> hard error, not graceful skip" "$?" "2"
 
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/handover/test-resume.sh
+++ b/scripts/handover/test-resume.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+# Hermetic tests for resume.sh — no git repo needed (uses --repo-root override).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; R="$HERE/resume.sh"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+fails=0
+check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+has(){ printf '%s' "$2" | grep -q "$3" && echo "ok - $1" || { echo "FAIL - $1: missing [$3]"; fails=$((fails+1)); }; }
+hasnt(){ printf '%s' "$2" | grep -q "$3" && { echo "FAIL - $1: unexpected [$3]"; fails=$((fails+1)); } || echo "ok - $1"; }
+
+# --- fixture handover tree (Mode B bucket layout) + fake registry ---
+root="$tmp/handovers"; base="$root/yotamleo/himmel"
+mkdir -p "$base/standalones/HIMMEL-389-vault-upgrade" \
+         "$base/standalones/#77-bare-item" \
+         "$base/epics/HIMMEL-414-cr-epic" \
+         "$base/epics/HIMMEL-500-live-epic"
+
+# Standalone with two session files (latest wins) + a Cold-Start block bounded by a later ## heading.
+printf '**Status:** pending\n' > "$base/standalones/HIMMEL-389-vault-upgrade/brief.md"
+cat > "$base/standalones/HIMMEL-389-vault-upgrade/next-session-1.md" <<'MD'
+## Cold-Start Prompt
+
+RESUME-389-V1 old body.
+
+## Overnight Mode Trigger
+ignore me
+MD
+cat > "$base/standalones/HIMMEL-389-vault-upgrade/next-session-2.md" <<'MD'
+# Next Session
+## Cold-Start Prompt
+
+RESUME-389-V2 line one.
+RESUME-389-V2 line two.
+
+## Overnight Mode Trigger
+ignore me too
+MD
+
+# #N standalone, no session file -> fallback to brief.md.
+printf '**Status:** in-progress\nBRIEF-77-MARKER body.\n' > "$base/standalones/#77-bare-item/brief.md"
+
+# Epics: one done (excluded from --list), one live (included).
+printf '**Status:** done\n' > "$base/epics/HIMMEL-414-cr-epic/master-plan.md"
+printf '**Status:** in-progress\n' > "$base/epics/HIMMEL-500-live-epic/master-plan.md"
+
+# Epic-task: a task carries its OWN Jira key (HIMMEL-501), NOT epic-key+subnum —
+# so the ID extractor takes the full key, no truncation. No session file -> brief fallback.
+mkdir -p "$base/epics/HIMMEL-500-live-epic/tasks/HIMMEL-501-first-task"
+printf '**Status:** in-progress\nTASK-501-MARKER body.\n' > "$base/epics/HIMMEL-500-live-epic/tasks/HIMMEL-501-first-task/brief.md"
+
+# tech-debt.md with a Lingering entry -> stale nudge.
+cat > "$root/yotamleo/tech-debt.md" <<'MD'
+## Lingering (decompose me)
+
+- **HIMMEL-999** lingering-example — decompose
+MD
+
+reg="$tmp/registry.json"
+cat > "$reg" <<'JSON'
+{ "repos": { "himmel": {
+  "path": "c:/work/himmel", "user": "yotamleo", "jira_project": "HIMMEL"
+} } }
+JSON
+RR="C:/Work/Himmel"   # mixed-case to prove case-insensitive registry match
+run(){ HANDOVER_DIR="$root" HANDOVER_REGISTRY="$reg" bash "$R" --repo-root "$RR" "$@"; }
+
+# 1. Key form -> latest session's Cold-Start block, trimmed at the next ## heading.
+o="$(run HIMMEL-389)"
+has "key form: latest block"     "$o" "RESUME-389-V2 line one"
+hasnt "key form: excludes overnight" "$o" "Overnight Mode Trigger"
+hasnt "key form: not the older v1"   "$o" "RESUME-389-V1"
+has "key form: stale nudge"      "$o" "lingering-example"
+
+# 2. Bare numeric -> dual scan finds HIMMEL-389.
+has "bare numeric finds key item" "$(run 389)" "RESUME-389-V2 line one"
+
+# 3. #N with no session file -> fallback to brief.md.
+o="$(run 77)"
+has "bare 77 -> #77 fallback brief" "$o" "BRIEF-77-MARKER"
+has "bare 77 -> shows-brief notice" "$o" "no session file yet"
+has "hash form 77 -> #77 fallback"  "$(run '#77')" "BRIEF-77-MARKER"
+
+# 3b. Epic-task path (own KEY-N) -> resolves + falls back to brief.
+o="$(run HIMMEL-501)"
+has "epic-task resolves"       "$o" "TASK-501-MARKER"
+has "epic-task id not truncated" "$o" "for HIMMEL-501"
+
+# 4. --list: active only, excludes the done epic, includes the epic-task.
+o="$(run --list)"
+has "list: live standalone"  "$o" "HIMMEL-389"
+has "list: #77 item"         "$o" "#77"
+has "list: live epic"        "$o" "HIMMEL-500"
+has "list: epic-task row"    "$o" "$(printf 'HIMMEL-501\tfirst-task\tin-progress\ttask')"
+hasnt "list: excludes done"  "$o" "HIMMEL-414"
+
+# 5. Error paths.
+run merge >/dev/null 2>&1; check "invalid ID -> rc 2" "$?" "2"
+run 999999 >/dev/null 2>&1; check "not found -> rc 3" "$?" "3"
+run 1 2 >/dev/null 2>&1; check "too many args -> rc 2" "$?" "2"
+HANDOVER_DIR="$root" HANDOVER_REGISTRY="$reg" bash "$R" --repo-root >/dev/null 2>&1
+check "--repo-root without value -> rc 2" "$?" "2"
+HANDOVER_DIR="$root" HANDOVER_REGISTRY="$reg" bash "$R" --repo-root "C:/Work/Other" 5 >/dev/null 2>&1
+check "unregistered repo -> rc 3" "$?" "3"
+
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
Makes `/handover-resume` a thin invoker of `scripts/handover/resume.sh` rather
than loading the full 47KB handover skill on every resume — surfaces the item
cold-start (brief/context, latest session, open bugs, CR findings) at a fraction
of the token cost.

- `scripts/handover/resume.sh` (+ `test-resume.sh`)
- `.claude/commands/handover-resume.md` rewritten to the script path

Propagated from private himmel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only handover resume CLI that resumes items by ID, shows the latest session context (including Cold-Start block), and surfaces open bugs/findings plus stale technical-debt nudges.
  * Added an `--list` mode to display active items for selection.
  * Improved repo/registry matching and standardized exit codes for hard errors vs not-found cases.

* **Documentation**
  * Updated the resume command instructions with strict argument rules and clarified list/select/resume behavior and error handling.

* **Tests**
  * Added a hermetic test suite covering resolution, listing, fallbacks, repo matching (case-insensitive), and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->