### PR TITLE
docs(context): canonical context-lean architecture doc + collapse root ENFORCEMENT block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,53 +295,28 @@ Autonomous end-to-end execution of a well-scoped ticket: see
 
 ## ENFORCEMENT (runs automatically)
 
-himmel enforces structurally, not by prose: **12 PreToolUse hooks**
-(`auto-approve-safe-bash`, `block-edit-on-main`, `block-read-secrets`,
-`block-rogue-claude-schedule` — blocks raw scheduler-arms of claude that bypass
-arm-resume.sh (System32-cwd trap, HIMMEL-647),
-`block-backend-tier` — registry-driven MCP guard, replaces `block-mcp-when-plugin-exists`,
-`auto-arm-on-cap`, `check-cr-marker-on-pr-create`, and `block-docker-privesc` —
-root-equivalent docker/podman mount+privilege guard, HIMMEL-441, shipped via the
-himmel-ops plugin `hooks.json` so it's live only after `/himmel-update` + a fresh
-session; likewise `block-merged-pr-commit` — hygiene guard that blocks committing
-onto a merged-PR branch, HIMMEL-512, same plugin delivery; `block-unresolved-cr-merge` —
-blocks `gh pr merge` while CodeRabbit review threads are unresolved or its check-run
-is in-flight on the head SHA, fail-open on every API/dep error, bypass
-`CR_MERGE_GATE_OK=1` — HIMMEL-936, same plugin delivery; `block-rogue-codex-wsl` — blocks raw `wsl … codex exec` dispatches that bypass the WSL-lane chokepoint (HIMMEL-999, same plugin delivery); and `guard-implementor-dispatch` —
-bank-aware cost guard that blocks a Sonnet/Opus/top-model implementor-shaped Agent dispatch
-when the 5-hour bank is at/above 80% (advisory-only at 65%), fail-open on every infra
-error, bypass `IMPL_GUARD_OK=1` — HIMMEL-920, same plugin delivery), **1 PostToolUse hook**
-(`auto-arm-on-subagent-cap` — detects cap in Agent tool results, HIMMEL-276),
-**pre-commit/commit-msg/pre-push gates** (source of truth
-`.pre-commit-config.yaml`; pre-push incl. `check-platforms-tested`;
-pre-commit+pre-push `doc-guard` — himmel-dev-only, blocks ADDING a
-command/skill without updating `docs/commands-catalog.md`, gated by
-`.himmel-dev` marker; pre-commit `agents-md-fresh` — himmel-dev-only, blocks a
-stale `AGENTS.md` (regenerate from this file via
-`scripts/agents-md/generate.mjs`, HIMMEL-471)), a
-`UserPromptSubmit` hook (`improve-on-submit.sh`,
-default OFF), a `SessionStart` hook (`inject-initiative.sh` — opt-in
-`HIMMEL_INITIATIVE` drive-to-ship directive over the shared leg grammar
-(`scripts/lib/initiative-legs.sh`, HIMMEL-443): `1`/`all` or a comma-subset of
-`plan,execute,prcheck,pr,ticket,merge,public,handover`; `HIMMEL_OVERNIGHT`
-selects the overnight profile reading `HIMMEL_INITIATIVE_OVERNIGHT`; default OFF,
-advisory only; HIMMEL-425), and shared **guardrail predicates** (`scripts/guardrails/lib.sh`).
-Hook bypass = session env var set in the LAUNCHING shell (e.g.
-`EDIT_ON_MAIN_OK=1 claude`); a per-call prefix does NOT work. Per-repo opt-out:
-a local gitignored `.single-writer` at a repo root allows on-main edits there
-(single-writer repos — personal vaults, state repos — that commit straight to
-main by design); clones without the marker stay protected. Remote auto-actions
-(Telegram `/arm`, HIMMEL-424): the trusted bridge parses + invokes directly (agent
-out of the trust path); operator-identity (DM or allowlisted group), typed-only,
-forwarded-refused; default OFF behind `TELEGRAM_AUTO_ACTIONS` (per-op flag, grammar
-mirrors `HIMMEL_INITIATIVE`). Per-hook
-behaviour, the full gate list, the guardrail matrix, and the `/arm` surface:
-[`docs/internals/enforcement.md`](docs/internals/enforcement.md). Required
-environment (HIMMEL-123):
+himmel enforces structurally, not by prose: PreToolUse hooks (safe-bash
+auto-approve; the edit-on-main / read-secrets / backend-tier / CR-marker /
+unresolved-CR-merge / merged-PR-commit / docker-privesc / rogue-schedule /
+rogue-codex-wsl guards; `guard-implementor-dispatch` bank guard; the cap-arm
+hooks), a PostToolUse cap-arm hook, **pre-commit/commit-msg/pre-push gates**
+(source of truth `.pre-commit-config.yaml`), and opt-in `SessionStart` /
+`UserPromptSubmit` hooks (`inject-initiative.sh` `HIMMEL_INITIATIVE`,
+`improve-on-submit.sh` — both default OFF). The full per-hook behaviour, the
+gate list, the guardrail matrix, the Telegram `/arm` surface, and billing
+detail: [`docs/internals/enforcement.md`](docs/internals/enforcement.md).
+
+**Session-critical (kept inline — needed at a glance):** hook bypass = a session
+env var set in the LAUNCHING shell (e.g. `EDIT_ON_MAIN_OK=1 claude`); a per-call
+prefix does NOT work. Per-repo opt-out: a local gitignored `.single-writer` at a
+repo root allows on-main edits there (single-writer repos — personal vaults,
+state repos — that commit straight to main by design); clones without the marker
+stay protected. Required environment (HIMMEL-123):
 [`docs/setup/new-machine.md`](docs/setup/new-machine.md#1-required-environment-himmel-123).
 
 ## REFERENCE INDEX
 
+- [`docs/internals/context-architecture.md`](docs/internals/context-architecture.md) — the lean-surface doctrine: where knowledge lives (4 rules, layering model, the nesting trap, memory-as-map). The anchor for the HIMMEL-177/195 frame above.
 - [`docs/internals/enforcement.md`](docs/internals/enforcement.md) — pre-commit + all hooks + guardrails + billing detail.
 - [`docs/internals/handover-system.md`](docs/internals/handover-system.md) — full handover system + user-slug resolution.
 - [`docs/internals/jira-plugin.md`](docs/internals/jira-plugin.md) — Jira plugin↔MCP op mapping.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,7 +298,7 @@ Autonomous end-to-end execution of a well-scoped ticket: see
 himmel enforces structurally, not by prose: PreToolUse hooks (safe-bash
 auto-approve; the edit-on-main / read-secrets / backend-tier / CR-marker /
 unresolved-CR-merge / merged-PR-commit / docker-privesc / rogue-schedule /
-rogue-codex-wsl guards; `guard-implementor-dispatch` bank guard; the cap-arm
+rogue-codex-wsl guards; `guard-implementor-dispatch` cost guard; the cap-arm
 hooks), a PostToolUse cap-arm hook, **pre-commit/commit-msg/pre-push gates**
 (source of truth `.pre-commit-config.yaml`), and opt-in `SessionStart` /
 `UserPromptSubmit` hooks (`inject-initiative.sh` `HIMMEL_INITIATIVE`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,7 @@ Autonomous end-to-end execution of a well-scoped ticket: see
 himmel enforces structurally, not by prose: PreToolUse hooks (safe-bash
 auto-approve; the edit-on-main / read-secrets / backend-tier / CR-marker /
 unresolved-CR-merge / merged-PR-commit / docker-privesc / rogue-schedule /
-rogue-codex-wsl guards; `guard-implementor-dispatch` bank guard; the cap-arm
+rogue-codex-wsl guards; `guard-implementor-dispatch` cost guard; the cap-arm
 hooks), a PostToolUse cap-arm hook, **pre-commit/commit-msg/pre-push gates**
 (source of truth `.pre-commit-config.yaml`), and opt-in `SessionStart` /
 `UserPromptSubmit` hooks (`inject-initiative.sh` `HIMMEL_INITIATIVE`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,53 +257,28 @@ Autonomous end-to-end execution of a well-scoped ticket: see
 
 ## ENFORCEMENT (runs automatically)
 
-himmel enforces structurally, not by prose: **12 PreToolUse hooks**
-(`auto-approve-safe-bash`, `block-edit-on-main`, `block-read-secrets`,
-`block-rogue-claude-schedule` — blocks raw scheduler-arms of claude that bypass
-arm-resume.sh (System32-cwd trap, HIMMEL-647),
-`block-backend-tier` — registry-driven MCP guard, replaces `block-mcp-when-plugin-exists`,
-`auto-arm-on-cap`, `check-cr-marker-on-pr-create`, and `block-docker-privesc` —
-root-equivalent docker/podman mount+privilege guard, HIMMEL-441, shipped via the
-himmel-ops plugin `hooks.json` so it's live only after `/himmel-update` + a fresh
-session; likewise `block-merged-pr-commit` — hygiene guard that blocks committing
-onto a merged-PR branch, HIMMEL-512, same plugin delivery; `block-unresolved-cr-merge` —
-blocks `gh pr merge` while CodeRabbit review threads are unresolved or its check-run
-is in-flight on the head SHA, fail-open on every API/dep error, bypass
-`CR_MERGE_GATE_OK=1` — HIMMEL-936, same plugin delivery; `block-rogue-codex-wsl` — blocks raw `wsl … codex exec` dispatches that bypass the WSL-lane chokepoint (HIMMEL-999, same plugin delivery); and `guard-implementor-dispatch` —
-bank-aware cost guard that blocks a Sonnet/Opus/Fable implementor-shaped Agent dispatch
-when the 5-hour bank is at/above 80% (advisory-only at 65%), fail-open on every infra
-error, bypass `IMPL_GUARD_OK=1` — HIMMEL-920, same plugin delivery), **1 PostToolUse hook**
-(`auto-arm-on-subagent-cap` — detects cap in Agent tool results, HIMMEL-276),
-**pre-commit/commit-msg/pre-push gates** (source of truth
-`.pre-commit-config.yaml`; pre-push incl. `check-platforms-tested`;
-pre-commit+pre-push `doc-guard` — himmel-dev-only, blocks ADDING a
-command/skill without updating `docs/commands-catalog.md`, gated by
-`.himmel-dev` marker; pre-commit `agents-md-fresh` — himmel-dev-only, blocks a
-stale `AGENTS.md` (regenerate from this file via
-`scripts/agents-md/generate.mjs`, HIMMEL-471)), a
-`UserPromptSubmit` hook (`improve-on-submit.sh`,
-default OFF), a `SessionStart` hook (`inject-initiative.sh` — opt-in
-`HIMMEL_INITIATIVE` drive-to-ship directive over the shared leg grammar
-(`scripts/lib/initiative-legs.sh`, HIMMEL-443): `1`/`all` or a comma-subset of
-`plan,execute,prcheck,pr,ticket,merge,public,handover`; `HIMMEL_OVERNIGHT`
-selects the overnight profile reading `HIMMEL_INITIATIVE_OVERNIGHT`; default OFF,
-advisory only; HIMMEL-425), and shared **guardrail predicates** (`scripts/guardrails/lib.sh`).
-Hook bypass = session env var set in the LAUNCHING shell (e.g.
-`EDIT_ON_MAIN_OK=1 claude`); a per-call prefix does NOT work. Per-repo opt-out:
-a local gitignored `.single-writer` at a repo root allows on-main edits there
-(single-writer repos — personal vaults, state repos — that commit straight to
-main by design); clones without the marker stay protected. Remote auto-actions
-(Telegram `/arm`, HIMMEL-424): the trusted bridge parses + invokes directly (agent
-out of the trust path); operator-identity (DM or allowlisted group), typed-only,
-forwarded-refused; default OFF behind `TELEGRAM_AUTO_ACTIONS` (per-op flag, grammar
-mirrors `HIMMEL_INITIATIVE`). Per-hook
-behaviour, the full gate list, the guardrail matrix, and the `/arm` surface:
-[`docs/internals/enforcement.md`](docs/internals/enforcement.md). Required
-environment (HIMMEL-123):
+himmel enforces structurally, not by prose: PreToolUse hooks (safe-bash
+auto-approve; the edit-on-main / read-secrets / backend-tier / CR-marker /
+unresolved-CR-merge / merged-PR-commit / docker-privesc / rogue-schedule /
+rogue-codex-wsl guards; `guard-implementor-dispatch` bank guard; the cap-arm
+hooks), a PostToolUse cap-arm hook, **pre-commit/commit-msg/pre-push gates**
+(source of truth `.pre-commit-config.yaml`), and opt-in `SessionStart` /
+`UserPromptSubmit` hooks (`inject-initiative.sh` `HIMMEL_INITIATIVE`,
+`improve-on-submit.sh` — both default OFF). The full per-hook behaviour, the
+gate list, the guardrail matrix, the Telegram `/arm` surface, and billing
+detail: [`docs/internals/enforcement.md`](docs/internals/enforcement.md).
+
+**Session-critical (kept inline — needed at a glance):** hook bypass = a session
+env var set in the LAUNCHING shell (e.g. `EDIT_ON_MAIN_OK=1 claude`); a per-call
+prefix does NOT work. Per-repo opt-out: a local gitignored `.single-writer` at a
+repo root allows on-main edits there (single-writer repos — personal vaults,
+state repos — that commit straight to main by design); clones without the marker
+stay protected. Required environment (HIMMEL-123):
 [`docs/setup/new-machine.md`](docs/setup/new-machine.md#1-required-environment-himmel-123).
 
 ## REFERENCE INDEX
 
+- [`docs/internals/context-architecture.md`](docs/internals/context-architecture.md) — the lean-surface doctrine: where knowledge lives (4 rules, layering model, the nesting trap, memory-as-map). The anchor for the HIMMEL-177/195 frame above.
 - [`docs/internals/enforcement.md`](docs/internals/enforcement.md) — pre-commit + all hooks + guardrails + billing detail.
 - [`docs/internals/handover-system.md`](docs/internals/handover-system.md) — full handover system + user-slug resolution.
 - [`docs/internals/jira-plugin.md`](docs/internals/jira-plugin.md) — Jira plugin↔MCP op mapping.

--- a/docs/internals/context-architecture.md
+++ b/docs/internals/context-architecture.md
@@ -1,0 +1,112 @@
+# Context architecture — the lean-surface doctrine
+
+Canonical reference for **where knowledge lives** in himmel so the
+always-loaded surface stays small. Every token in `CLAUDE.md`, `MEMORY.md`,
+an enabled plugin's catalog, or a loaded skill is paid **in every session** —
+and again in **every subagent context**. The discipline here keeps that fixed
+cost low without losing the knowledge: push detail to layers that load **on
+demand**, and make retrieval — not always-loaded prose — the default.
+
+This doc is the anchor. The operating rules that reference it —
+[`CLAUDE.md`](../../CLAUDE.md) (the layer-selection frame, HIMMEL-177 /
+HIMMEL-195), [`operator-conventions.md`](../operator-conventions.md#memory--claudemd-hygiene)
+(the habits), and [`enforcement.md`](enforcement.md#operator-conventions--worked-examples)
+(worked escalation examples) — point here rather than restating it.
+
+## The four converging rules
+
+Distilled from a multi-author synthesis of the "CLAUDE.md patterns" corpus:
+
+1. **Short beats long.** A shorter always-loaded file is read; a long one is
+   skimmed and then ignored — by both the operator and the model. Length erodes
+   the authority of every rule in the file.
+2. **Nested beats one giant file.** Scope knowledge to where it applies (see
+   the layering model) instead of piling it into one root file.
+3. **State, not a prompt.** The root file is repo *memory* — why / map / rules /
+   workflows — not a personality or a coding-philosophy essay. Anything
+   derivable from the code, git, or the README does not belong in it.
+4. **Spend the first dollar of leverage.** Optimize the highest-frequency,
+   always-paid surface first (root file size, enabled-plugin count) before
+   micro-tuning rarely-loaded layers.
+
+**Anti-patterns to keep out of the always-loaded surface:** coding philosophy,
+architecture summaries (→ README), generic style guidance, codebase-derivable
+facts, and anything that contradicts another file.
+
+## The layering model — where each thing lands
+
+Pick the **cheapest layer that still fires when needed**. The always-loaded
+root is the most expensive layer; use it only for what must shape every task.
+
+| Content type | Lands in | Loads |
+|---|---|---|
+| Frame-shaping, **cross-cutting** rules | root `CLAUDE.md` (kept lean) | always |
+| Domain-local **dev** conventions | nested subtree `CLAUDE.md` | only when working in that subtree |
+| Cross-cutting **operational** ("when stuck") rules | a load-on-trigger skill / `docs/internals/` playbook | on the symptom |
+| Reference detail | `docs/` via a pointer | on demand |
+| Safety-critical rules | a **structural** hook / pre-commit / pre-push gate | enforced, not remembered |
+| Durable facts (memory) | compounded into a searchable substrate; slim index | on query |
+
+### The nesting trap (the rule that reshapes rule 2)
+
+A subtree `CLAUDE.md` loads **only when the model is working inside that
+subtree**. That makes nesting exactly right for **domain-local dev
+conventions** (e.g. Jira-CLI invocation rules under `scripts/jira/`) — and
+exactly **wrong** for **cross-cutting operational rules**. Push a rule that
+applies to *every* session (a shell-command-shape rule, a "prefer X over Y"
+routing rule) into a subtree and **it stops firing** the moment you are editing
+elsewhere.
+
+So:
+
+- **Domain-local → subtree `CLAUDE.md`.** Fires where it's relevant, costs
+  nothing elsewhere.
+- **Cross-cutting operational → load-on-trigger skill**, not a subtree. Fires
+  on the symptom (a denial, a friction point) regardless of cwd. This is why
+  operational "when stuck" detail is kept out of both the root file *and* the
+  subtree files.
+- **Cross-cutting frame-shaping → the root file**, kept short.
+- **Safety-critical → a structural gate.** Prose does not enforce; on the
+  second drift of an instructional rule, escalate it to a hook/gate rather than
+  writing stronger prose (HIMMEL-195).
+
+## Memory as a map, not a backend
+
+The same principle applies to durable facts. The always-loaded memory index is
+the **map** — one line per fact, pulled by relevance — while the facts
+themselves live in a searchable substrate and are retrieved by query. When the
+index nears its load budget, compound the durable facts out into the substrate
+and slim the index (himmel does this via the `memory-compound` skill,
+HIMMEL-569); the index never becomes the store.
+
+Two guards keep retrieval honest:
+
+- **Curate the map.** Pure semantic retrieval *structurally forgets* — an
+  un-curated index silently drops what it can't surface. The index must be
+  maintained, not dumped into.
+- **Mark staleness.** A recalled fact reflects what was true when written. The
+  memory layer supports *optional* `confidence` + `verified:` markers (defined in
+  [`operator-conventions.md`](../operator-conventions.md#memory--claudemd-hygiene));
+  the invariant — required with or without those markers — is that when a recalled
+  fact is found stale, you re-check and update it (or delete it), never act on a
+  stale claim silently.
+
+## Where the canonical pieces live
+
+- **Layer-selection frame** (lean-invoke vs default-rule vs default-hook vs
+  defer) + **structural > instructional** escalation → [`CLAUDE.md`](../../CLAUDE.md)
+  (HIMMEL-177 / HIMMEL-195).
+- **The habits** (no operational rules in the root, verify universal claims,
+  generic example names, specs live in the state repo, memory staleness
+  frontmatter) → [`operator-conventions.md`](../operator-conventions.md#memory--claudemd-hygiene).
+- **Worked escalation examples** (an instructional rule hardening into a
+  structural gate) → [`enforcement.md`](enforcement.md#operator-conventions--worked-examples).
+- **The always-on enforcement surface** (hooks + gates) → [`enforcement.md`](enforcement.md).
+
+## Maintenance — the surface re-accretes
+
+The lean surface is not self-sustaining: rules pile back onto the root file over
+time. Treat root-file growth as debt. Before adding anything to the
+always-loaded surface, ask which row of the layering table it belongs to — the
+answer is rarely the root file. When reference detail already exists in a
+`docs/` file, the root should carry a **pointer**, not a copy.

--- a/docs/operator-conventions.md
+++ b/docs/operator-conventions.md
@@ -83,7 +83,7 @@ Canonical — linked, not restated:
 
 ## Memory & CLAUDE.md hygiene
 
-These shape what goes WHERE — the layer-selection discipline. The frame is canonical (HIMMEL-177 / HIMMEL-195 in [`CLAUDE.md`](../CLAUDE.md#operator-conventions-calibrated-through-repeated-sessions) + worked examples in [`docs/internals/enforcement.md`](internals/enforcement.md#operator-conventions--worked-examples)). Inlined habits:
+These shape what goes WHERE — the layer-selection discipline. The doctrine (4 rules, the layering model, the nesting trap, memory-as-map) is canonical in [`docs/internals/context-architecture.md`](internals/context-architecture.md); the layer-selection frame is in [`CLAUDE.md`](../CLAUDE.md#operator-conventions-calibrated-through-repeated-sessions) (HIMMEL-177 / HIMMEL-195) with worked examples in [`docs/internals/enforcement.md`](internals/enforcement.md#operator-conventions--worked-examples). Inlined habits:
 
 - **No operational "when stuck" rules in `CLAUDE.md`.** It is loaded every session and is prunable under context pressure, so detail Claude needs *when stuck* may be gone exactly when needed; it is also per-user/per-repo. Put operational guidance in a repo-distributed load-on-trigger skill / `docs/internals/` playbook, or fix it structurally in code (then there's no rule to maintain). This very doc is the application of that principle.
 - **Verify universal-quantifier claims before writing them.** Don't write "each/every X has Y" in `CLAUDE.md` without running the count first (`ls X | wc` vs `ls test-X | wc`). If not 1:1, write "Most X have Y — add one for new X". A false universal misleads every future session. Pair a correctness reviewer with the CLAUDE.md best-practice audit on CLAUDE.md PRs — they catch different misses.


### PR DESCRIPTION
Consolidates the context-lean doctrine into one reference doc and trims the
always-loaded root memory:

- new `docs/internals/context-architecture.md` — the lean-surface doctrine
  (4 rules, layering model, the nesting trap, memory-as-map)
- `CLAUDE.md` / `AGENTS.md` ENFORCEMENT section collapsed to a pointer into that
  doc instead of an inline wall of prose

Propagated from private himmel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new guidance on organizing system context using the “lean-surface doctrine,” including layering, nesting-trap behavior, and durable-fact “map” vs searchable substrate concepts.
  * Condensed and reorganized enforcement documentation to keep high-level structure while directing detailed hook behavior to the appropriate internals page.
  * Updated operator conventions to reference the new context-architecture guidance as the canonical source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->