### PR TITLE
feat(graphify): adopt/setup register the graphify MCP server (project + user scope)

### DIFF
--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -932,12 +932,23 @@ an existing foreign graphify install is adopted as-is, never reinstalled —
 see `scripts/lib/graphify-bin.sh`.)
 
 The install exposes two binaries: `graphify` (the CLI) and `graphify-mcp`
-(the MCP server). Register the server with Claude Code — use the absolute
-path, not the bare name (`/himmel-doctor` flags PATH-fragile
-bare-interpreter MCP entries). `uv tool install` places entry points in
-the directory `uv tool dir --bin` reports (usually `~/.local/bin` on
-Linux/macOS; on Windows the executable is copied there as
-`graphify-mcp.exe`) — derive the path rather than hard-coding it:
+(the MCP server). **`setup.sh --with-graphify` (and `adopt.sh --with-graphify`)
+now register the MCP server automatically** (HIMMEL-1047) — `setup.sh` at
+`user` scope, `adopt.sh` at its `--scope` — so the install delivers the
+`mcp__graphify__*` tools, not just the CLI. Registration is idempotent (skips
+when graphify is already registered). The entry point is **scope-dependent**:
+`user`/`local` (a personal config) registers the **absolute** path — robust in
+the MCP launch context, and the form `/himmel-doctor` expects (it flags
+PATH-fragile bare entries); `project` (a committed `.mcp.json`) registers the
+**bare** name so the path stays portable across teammates' machines.
+
+To register (or re-register) manually — the shared implementation, same as the
+installers call — pass the scope explicitly (`user` or `project`, not both;
+`[user|project]` below is a placeholder):
+`bash scripts/lib/graphify-bin.sh register-mcp user`. For `user`/`local` it
+resolves the entry point from the directory `uv tool dir --bin` reports
+(usually `~/.local/bin` on Linux/macOS; on Windows the executable is copied
+there as `graphify-mcp.exe`). The raw equivalent (user scope):
 
 ```bash
 claude mcp add --scope user graphify -- "$(uv tool dir --bin)/graphify-mcp"

--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -467,6 +467,7 @@ function Wire-GraphifyCore {
     Write-Host "---- Wiring graphify (opt-in, -WithGraphify) ----"
     if ($DryRun) {
         Write-Host "DRY: Install-Graphify"
+        Write-Host "DRY: claude mcp add -s $Scope graphify -- <graphify-mcp: absolute path for user/local, bare name for project>"
         return
     }
     # WARN-not-fail structural guarantee (CR-r2): under this script's
@@ -486,11 +487,31 @@ function Wire-GraphifyCore {
         $installRc = Install-Graphify
         if ($installRc -ne 0) {
             Write-Host "  WARNING: graphify install failed (rc=$installRc) - continuing without graphify." -ForegroundColor Yellow
+        } else {
+            # Register the MCP server INSIDE this block: the decoupled native-EAP
+            # posture keeps a nonzero `claude mcp get` (not-registered probe) from
+            # terminating the adopt.
+            Register-GraphifyMcp
         }
     } finally {
         $ErrorActionPreference = $savedEAP
         if ($null -ne $savedNativeEAP) { $global:PSNativeCommandUseErrorActionPreference = $savedNativeEAP }
     }
+}
+
+# Register-GraphifyMcp -- register the graphify MCP server (mcp__graphify__*) at
+# the adopt Scope, delegating to the ONE shared implementation in
+# scripts/lib/graphify-bin.sh (`register-mcp`) rather than duplicating the
+# resolve/add recipe natively (mirrors Install-Graphify's delegation). The bash
+# impl resolves the absolute entrypoint + is idempotent + WARN-not-fail.
+function Register-GraphifyMcp {
+    $gitBash = Resolve-QmdGitBash
+    if (-not $gitBash) {
+        Write-Host "  graphify MCP: Git Bash not found - skipping registration." -ForegroundColor Yellow
+        Write-Host "  Manual: bash `"$HimmelRoot/scripts/lib/graphify-bin.sh`" register-mcp $Scope" -ForegroundColor Yellow
+        return
+    }
+    & $gitBash "$HimmelRoot/scripts/lib/graphify-bin.sh" register-mcp $Scope | ForEach-Object { Write-Host $_ }
 }
 
 # Build-JiraCli -- build scripts/jira/dist/index.js (HIMMEL-842 gap 3). dist/ is

--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -511,7 +511,16 @@ function Register-GraphifyMcp {
         Write-Host "  Manual: bash `"$HimmelRoot/scripts/lib/graphify-bin.sh`" register-mcp $Scope" -ForegroundColor Yellow
         return
     }
-    & $gitBash "$HimmelRoot/scripts/lib/graphify-bin.sh" register-mcp $Scope | ForEach-Object { Write-Host $_ }
+    if ($Scope -eq 'project') {
+        # project scope writes the committed .mcp.json relative to CWD (mirrors
+        # Install-Plugins) -- run from $Target so it lands in the adopted repo.
+        Push-Location $Target
+        try {
+            & $gitBash "$HimmelRoot/scripts/lib/graphify-bin.sh" register-mcp $Scope | ForEach-Object { Write-Host $_ }
+        } finally { Pop-Location }
+    } else {
+        & $gitBash "$HimmelRoot/scripts/lib/graphify-bin.sh" register-mcp $Scope | ForEach-Object { Write-Host $_ }
+    }
 }
 
 # Build-JiraCli -- build scripts/jira/dist/index.js (HIMMEL-842 gap 3). dist/ is

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -325,9 +325,15 @@ wire_graphify_core() {
   echo "──── Wiring graphify (opt-in, --with-graphify) ────"
   if [[ $DRY_RUN -eq 1 ]]; then
     echo "DRY: graphify_install"
+    echo "DRY: claude mcp add -s $SCOPE graphify -- <graphify-mcp: absolute path for user/local, bare name for project>"
     return 0
   fi
-  graphify_install || echo "  WARNING: graphify install failed — continuing without graphify." >&2
+  # Install the CLI first; a failed install returns before we try to register
+  # the MCP server (there'd be no graphify-mcp entrypoint to register). MCP
+  # registration is the shared graphify-bin.sh impl — adopt's SCOPE (project|
+  # user) is a valid `claude mcp add -s` scope (HIMMEL-1047).
+  graphify_install || { echo "  WARNING: graphify install failed — continuing without graphify." >&2; return 0; }
+  graphify_register_mcp "$SCOPE"
 }
 
 # build_jira_cli — build scripts/jira/dist/index.js (HIMMEL-842 gap 3). dist/ is

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -333,7 +333,13 @@ wire_graphify_core() {
   # registration is the shared graphify-bin.sh impl — adopt's SCOPE (project|
   # user) is a valid `claude mcp add -s` scope (HIMMEL-1047).
   graphify_install || { echo "  WARNING: graphify install failed — continuing without graphify." >&2; return 0; }
-  graphify_register_mcp "$SCOPE"
+  if [[ "$SCOPE" == "project" ]]; then
+    # project scope writes the committed .mcp.json relative to CWD (mirrors
+    # install_plugins) — run from $TARGET so it lands in the adopted repo.
+    ( cd "$TARGET" && graphify_register_mcp "$SCOPE" )
+  else
+    graphify_register_mcp "$SCOPE"
+  fi
 }
 
 # build_jira_cli — build scripts/jira/dist/index.js (HIMMEL-842 gap 3). dist/ is

--- a/scripts/lib/graphify-bin.sh
+++ b/scripts/lib/graphify-bin.sh
@@ -278,6 +278,83 @@ graphify_wsl_share_store() {
   return 0
 }
 
+# graphify_register_mcp <scope> -- register the graphify MCP server (the
+# mcp__graphify__* tools) with Claude Code at <scope> (local|user|project;
+# default user), so an install actually delivers the MCP tools and not just the
+# CLI (HIMMEL-1047). ONE implementation consumed by setup.sh + adopt.sh (and,
+# via the CLI entry below, the pwsh mirrors). SCOPE-DEPENDENT entrypoint:
+#   - user/local (a PERSONAL config) -> the ABSOLUTE path (robust in the MCP
+#     launch context; matches /himmel-doctor's absolute-not-bare convention).
+#     uv places the shim in `uv tool dir --bin` (graphify-mcp.exe on Windows,
+#     graphify-mcp on posix), with a PATH lookup as fallback.
+#   - project (a COMMITTED .mcp.json) -> the BARE name, PATH-resolved per
+#     machine: a machine-specific absolute path would break for teammates on
+#     other machines (CR HIMMEL-1047).
+# Idempotent PER SCOPE (skips only when graphify already exists AT THE TARGET
+# scope, so a personal user entry never suppresses a project registration) and
+# WARN-not-fail by contract: a missing claude/entrypoint or an add hiccup prints
+# the manual command and returns 0, never aborting the caller.
+graphify_register_mcp() {
+  local scope="${1:-user}" bin_dir mcp_arg="" hint
+  # Scope-appropriate manual hint: project = the portable bare name; user/local =
+  # the absolute path. Used by every "register later / manually" message below so
+  # a project adopter is never told to commit a machine-specific path.
+  if [ "$scope" = "project" ]; then
+    hint="claude mcp add -s $scope graphify -- graphify-mcp"
+  else
+    hint="claude mcp add -s $scope graphify -- \"\$(uv tool dir --bin)/graphify-mcp\""
+  fi
+  if ! command -v claude >/dev/null 2>&1; then
+    echo "  graphify MCP: 'claude' CLI not found -- skipping registration (CLI still installed)." >&2
+    echo "  Register later: $hint" >&2
+    return 0
+  fi
+  if [ "$scope" = "project" ]; then
+    # Committed .mcp.json must stay portable across machines -> bare name,
+    # resolved from PATH per machine (setup/adopt put uv's bin dir on PATH).
+    mcp_arg="graphify-mcp"
+  else
+    # `|| true`: a plain `bin_dir=$(...)` assignment propagates the substitution's
+    # exit status, so under a caller's `set -e` (adopt.sh is `set -euo pipefail`) a
+    # missing/failing uv would ABORT the adopt instead of warn-not-failing.
+    bin_dir="$(uv tool dir --bin 2>/dev/null || true)"
+    if [ -n "$bin_dir" ] && [ -f "$bin_dir/graphify-mcp.exe" ]; then
+      mcp_arg="$bin_dir/graphify-mcp.exe"
+    elif [ -n "$bin_dir" ] && [ -f "$bin_dir/graphify-mcp" ]; then
+      mcp_arg="$bin_dir/graphify-mcp"
+    else
+      mcp_arg="$(command -v graphify-mcp 2>/dev/null || true)"
+    fi
+    if [ -z "$mcp_arg" ]; then
+      echo "  graphify MCP: 'graphify-mcp' entrypoint not found -- skipping (check the uv tool bin dir)." >&2
+      echo "  Register later: $hint" >&2
+      return 0
+    fi
+  fi
+  # Attempt the add AT THE TARGET SCOPE. `claude mcp get` has no scope flag, so an
+  # unscoped pre-check would let a user entry suppress a project add; instead add
+  # directly and treat "already exists in <scope> config" (rc!=0) as an idempotent
+  # skip. Any other failure is WARN-not-fail.
+  local add_out add_rc
+  # `if var=$(...)`: the assignment sits in a condition, where set -e is EXEMPT.
+  # A bare `add_out=$(...)` would propagate a nonzero `claude mcp add` — notably
+  # the COMMON "already exists" idempotent case (rc=1) — and abort a `set -e`
+  # caller (adopt.sh) before the handling below ever runs.
+  if add_out="$(claude mcp add -s "$scope" graphify -- "$mcp_arg" 2>&1)"; then
+    add_rc=0
+  else
+    add_rc=$?
+  fi
+  if [ "$add_rc" -eq 0 ]; then
+    echo "  graphify MCP: registered (scope=$scope, $mcp_arg) -- mcp__graphify__* tools available."
+  elif printf '%s' "$add_out" | grep -qi "already exists"; then
+    echo "  graphify MCP: already registered at $scope scope -- skipping."
+  else
+    echo "  WARNING: graphify MCP registration failed -- CLI works; register manually:" >&2
+    echo "  $hint" >&2
+  fi
+}
+
 # CLI entry -- only when EXECUTED (not sourced). Lets the pwsh mirrors
 # (scripts/setup.ps1, scripts/adopt.ps1) delegate to this ONE implementation
 # (`bash scripts/lib/graphify-bin.sh install`) instead of duplicating the
@@ -287,6 +364,7 @@ if [ "${BASH_SOURCE[0]:-}" = "${0:-}" ]; then
     install) graphify_install ;;
     source)  graphify_source ;;
     share-store) graphify_wsl_share_store ;;
-    *) echo "Usage: bash scripts/lib/graphify-bin.sh install|source|share-store" >&2; exit 2 ;;
+    register-mcp) graphify_register_mcp "${2:-user}" ;;
+    *) echo "Usage: bash scripts/lib/graphify-bin.sh install|source|share-store|register-mcp [scope]" >&2; exit 2 ;;
   esac
 fi

--- a/scripts/lib/test-graphify-bin.sh
+++ b/scripts/lib/test-graphify-bin.sh
@@ -362,6 +362,47 @@ assert "setup.sh calls graphify_install" grep -q 'graphify_install' "$repo_root/
 assert "adopt.sh sources graphify-bin.sh" grep -q 'lib/graphify-bin.sh' "$repo_root/scripts/adopt.sh"
 assert "adopt.sh calls graphify_install" grep -q 'graphify_install' "$repo_root/scripts/adopt.sh"
 
+# HIMMEL-1047: MCP registration is the shared graphify_register_mcp impl, exposed
+# via the `register-mcp` CLI case, called by both installers (adopt at its scope,
+# setup at user scope) and delegated to by the pwsh mirrors.
+assert "graphify-bin.sh defines graphify_register_mcp" grep -q 'graphify_register_mcp()' "$SCRIPT_DIR/graphify-bin.sh"
+assert "graphify-bin.sh CLI exposes register-mcp" grep -q 'register-mcp) graphify_register_mcp' "$SCRIPT_DIR/graphify-bin.sh"
+# Scope forwarding (HIMMEL-1047 CR): setup.sh pins user scope; adopt.sh forwards
+# its own $SCOPE (project|user) — not a hardcoded scope.
+assert "setup.sh registers at user scope" grep -q 'graphify_register_mcp user' "$repo_root/scripts/setup.sh"
+# The grep pattern intentionally matches the LITERAL string graphify_register_mcp "$SCOPE"
+# in adopt.sh (\$ = a literal $ in the BRE); it is not meant to expand here.
+# shellcheck disable=SC2016
+assert "adopt.sh forwards its SCOPE to register" grep -q 'graphify_register_mcp "\$SCOPE"' "$repo_root/scripts/adopt.sh"
+# Project scope must NOT embed a machine-specific absolute path in the committed
+# .mcp.json — the helper branches to the bare name for project scope (CR C14).
+assert "graphify_register_mcp uses bare name for project scope" grep -q 'mcp_arg="graphify-mcp"' "$SCRIPT_DIR/graphify-bin.sh"
+assert "setup.ps1 delegates register-mcp to bash" grep -q 'graphify-bin.sh" register-mcp' "$repo_root/scripts/setup.ps1"
+assert "adopt.ps1 delegates register-mcp to bash" grep -q 'graphify-bin.sh" register-mcp' "$repo_root/scripts/adopt.ps1"
+
+# set -e regression (HIMMEL-1047 CR, codex): a nonzero `claude mcp add` — the
+# COMMON "already exists" idempotent case (rc=1) — must NOT abort a set -e caller
+# (adopt.sh is `set -euo pipefail`). Hermetic: a stub claude returns exists/rc1;
+# project scope avoids any uv/graphify-mcp dependency (bare name).
+se_stub="$(mktemp -d)"
+cat > "$se_stub/claude" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"mcp add"*) echo "MCP server graphify already exists in project config" >&2; exit 1 ;;
+esac
+exit 0
+STUB
+chmod +x "$se_stub/claude"
+se_out="$(PATH="$se_stub:$PATH" bash -c 'set -euo pipefail; . "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_register_mcp project; echo SE-REACHED-END' 2>&1 || true)"
+# $1 is the INNER bash's positional (the passed "$se_out"), intentionally literal.
+# shellcheck disable=SC2016
+assert "set -e caller: nonzero mcp add (already-exists) does not abort" \
+  bash -c 'printf "%s" "$1" | grep -q SE-REACHED-END' _ "$se_out"
+# shellcheck disable=SC2016
+assert "already-exists rc!=0 handled as idempotent skip" \
+  bash -c 'printf "%s" "$1" | grep -qi "already registered at project scope"' _ "$se_out"
+rm -rf "$se_stub"
+
 echo
 echo "[test-graphify-bin] pass=$pass fail=$fail"
 test "$fail" -eq 0

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -505,6 +505,11 @@ if ($installGraphify) {
         if ($LASTEXITCODE -ne 0) {
             Write-Host "  WARNING: graphify install failed (rc=$LASTEXITCODE); setup continues." -ForegroundColor Yellow
             Write-Host "  Retry manually: bash `"$RepoRoot/scripts/lib/graphify-bin.sh`" install" -ForegroundColor Yellow
+        } else {
+            # Register the MCP server so the install delivers the mcp__graphify__*
+            # tools, not just the CLI (HIMMEL-1047). user scope; delegates to the
+            # ONE bash impl. WARN-not-fail; idempotent.
+            & bash "$RepoRoot/scripts/lib/graphify-bin.sh" register-mcp user
         }
     } finally {
         $ErrorActionPreference = $savedEAP

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -411,7 +411,14 @@ else
 fi
 
 if [ "$_install_graphify" = "1" ]; then
-  graphify_install || echo "  WARNING: graphify install failed; setup continues." >&2
+  if graphify_install; then
+    # Register the MCP server so the install delivers the mcp__graphify__* tools,
+    # not just the CLI (HIMMEL-1047). user scope — setup.sh provisions this
+    # machine's own environment. WARN-not-fail; idempotent.
+    graphify_register_mcp user
+  else
+    echo "  WARNING: graphify install failed; setup continues." >&2
+  fi
 else
   if [ "$WITH_GRAPHIFY" != "1" ] && { [ -t 0 ] && [ -t 1 ]; }; then
     echo "  Skipped. Install later: $(graphify_install_hint)"

--- a/scripts/test-adopt.sh
+++ b/scripts/test-adopt.sh
@@ -332,6 +332,9 @@ printf '%s' "$out" | grep -q 'DRY: qmd_register_collection .* himmel$' || fail "
 printf '%s' "$out" | grep -q 'DRY: qmd_register_collection .* luna$'   || fail "dry-run missing luna register DRY line"
 printf '%s' "$out" | grep -q 'Wiring graphify (opt-in' || fail "dry-run --with-graphify missing the graphify wiring banner"
 printf '%s' "$out" | grep -q 'DRY: graphify_install'   || fail "dry-run --with-graphify missing graphify_install DRY line"
+# HIMMEL-1047: --with-graphify also registers the MCP server at the adopt scope
+# (here --scope user), so the dry-run must emit the mcp-add DRY line.
+printf '%s' "$out" | grep -q 'DRY: claude mcp add -s user graphify' || fail "dry-run --with-graphify missing the graphify MCP registration DRY line"
 # HIMMEL-842 gap 3: build_jira_cli runs after install_plugins; with npm scrubbed
 # suite-wide and bun stubbed present, it picks bun and emits its DRY build line.
 printf '%s' "$out" | grep -q 'DRY:.*(cd scripts/jira && bun install && bun run build)' || fail "dry-run missing build_jira_cli DRY line"


### PR DESCRIPTION
Wires graphify's MCP server into the adopt/setup flow so a fresh install gets it
registered at both project and user scope.

- `scripts/adopt.{sh,ps1}`, `scripts/setup.{sh,ps1}`
- `scripts/lib/graphify-bin.sh` (+ `test-graphify-bin.sh`), `scripts/test-adopt.sh`
- `docs/setup/new-machine.md`

Propagated from private himmel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Graphify setup and adoption now automatically register the Graphify MCP server with Claude Code.
  * MCP registration supports user, local, and project scopes with portable project configuration.
  * Dry-run commands now display the MCP registration command.

* **Bug Fixes**
  * Repeated registrations are handled safely without interrupting setup.
  * MCP registration is skipped gracefully when required tools are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->