### PR TITLE
feat(drift): nightly fork-drift guard covers graphify + qmd forks

### DIFF
--- a/.github/workflows/fork-drift.yml
+++ b/.github/workflows/fork-drift.yml
@@ -16,6 +16,10 @@ permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: fork-drift-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   drift:
     runs-on: ubuntu-latest
@@ -27,10 +31,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # rtk/twitter-cli (mode: probe) and hermes-agent (mode: checkout) have
+          # no local install/checkout on this runner and always read UNCHECKED
+          # here — that's expected, but it means the full registry would make
+          # this job exit 3 (incomplete) forever, even once real drift clears,
+          # and fork-drift-issue.sh intentionally leaves the tracking issue open
+          # on exit 3 (never auto-closes on an incomplete run). Strip those
+          # machine-local entries for CI so a genuinely all-current registry can
+          # still reach exit 0; a real API failure on a remaining entry still
+          # trips exit 3, unchanged.
+          jq '{entries: [.entries[] | select(.mode != "checkout" and .mode != "probe")]}' \
+            scripts/upstreams.json > fork-drift-ci-upstreams.json
           # The guard's exit code IS the signal (0 current / 2 drift / 3
           # incomplete); capture it without letting `set -e` abort the job.
           set +e
-          bash scripts/check-plugin-drift.sh 2>&1 | tee drift-report.txt
+          DRIFT_REGISTRY=fork-drift-ci-upstreams.json \
+            bash scripts/check-plugin-drift.sh 2>&1 | tee drift-report.txt
           rc=${PIPESTATUS[0]}
           set -e
           echo "rc=$rc" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/fork-drift.yml
+++ b/.github/workflows/fork-drift.yml
@@ -1,0 +1,51 @@
+name: fork-drift
+
+# Nightly upstream-drift watch (HIMMEL-1046). Runs the existing drift guard
+# (scripts/check-plugin-drift.sh + scripts/upstreams.json, HIMMEL-869) — which
+# now also covers the two SHA-pinned lib forks graphify + qmd — and, on real
+# DRIFT (guard exit 2), opens or refreshes ONE consolidated tracking issue
+# (himmel /himmel-doctor convention: never a new issue per run). exit 3
+# (INCOMPLETE — expected in CI, where the probe/checkout registry entries for
+# rtk/twitter/hermes have no local install) is summary-only, never an issue.
+on:
+  schedule:
+    - cron: '41 6 * * *'   # nightly, UTC (offset from ci.yml's 17 7)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run upstream-drift guard
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The guard's exit code IS the signal (0 current / 2 drift / 3
+          # incomplete); capture it without letting `set -e` abort the job.
+          set +e
+          bash scripts/check-plugin-drift.sh 2>&1 | tee drift-report.txt
+          rc=${PIPESTATUS[0]}
+          set -e
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert / clear consolidated drift issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/ci/fork-drift-issue.sh "${{ steps.guard.outputs.rc }}" drift-report.txt
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "### fork-drift — guard exit ${{ steps.guard.outputs.rc }}"
+            echo '```'
+            cat drift-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/check-plugin-drift.sh
+++ b/scripts/check-plugin-drift.sh
@@ -80,6 +80,31 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 MJSON="${DRIFT_MJSON:-$ROOT/marketplace/.claude-plugin/marketplace.json}"
 UPSTREAMS="${DRIFT_UPSTREAMS:-$ROOT/scripts/plugin-upstreams.json}"  # per-plugin true-upstream overrides (may be absent)
 
+# Portable replacement for `sort -V | tail -1`: GNU-only (BSD sort on macOS has
+# no -V), which would silently leave `latest`/`hi` empty on macOS and either
+# mark a tag_release check UNCHECKED or misreport it as BEHIND. Reads
+# newline-separated version strings on stdin (optional leading 'v', extra
+# non-numeric suffixes tolerated) and prints the one with the highest
+# major.minor.patch — via the python3 this class already requires.
+highest_version() {
+  python3 -c '
+import re, sys
+
+def numprefix(s):
+    m = re.match(r"\d+", s)
+    return int(m.group()) if m else 0
+
+def key(v):
+    v = v.strip().lstrip("vV")
+    parts = (v.split(".") + ["0", "0", "0"])[:3]
+    return tuple(numprefix(p) for p in parts)
+
+lines = [l.strip() for l in sys.stdin if l.strip()]
+if lines:
+    print(max(lines, key=key))
+'
+}
+
 if ! command -v gh >/dev/null 2>&1 || ! gh auth status >/dev/null 2>&1; then
   echo "drift-check: gh CLI not available/authenticated — skipping (fail-open)."
   exit 0
@@ -535,7 +560,7 @@ PY
               echo "  $name: ? true upstream unreachable ($repo tags) — UNCHECKED"
               incomplete=1; continue
             fi
-            latest="$(printf '%s\n' "$tags_raw" | grep -E '^v?[0-9]+\.[0-9]+(\.[0-9]+)?$' | sort -V | tail -1)"
+            latest="$(printf '%s\n' "$tags_raw" | grep -E '^v?[0-9]+\.[0-9]+(\.[0-9]+)?$' | highest_version)"
             if [ -z "$latest" ]; then
               echo "  $name: ? no stable version tags found on $repo — UNCHECKED"
               incomplete=1; continue
@@ -547,7 +572,7 @@ PY
           if [ "$norm_local" = "$norm_latest" ]; then
             echo "  $name: CURRENT  (installed $norm_local = $repo latest tag)${tier_note}"
           else
-            hi="$(printf '%s\n%s\n' "$norm_local" "$norm_latest" | sort -V | tail -1)"
+            hi="$(printf '%s\n%s\n' "$norm_local" "$norm_latest" | highest_version)"
             if [ "$hi" = "$norm_local" ]; then
               # Installed is newer than the latest STABLE tag (e.g. a prerelease or
               # locally-built version): not behind upstream's stable line.

--- a/scripts/check-plugin-drift.sh
+++ b/scripts/check-plugin-drift.sh
@@ -38,7 +38,11 @@
 #           same discipline as the claude-obsidian fork override). mode `base`
 #           takes the version from `synced_base`; mode `probe` runs
 #           `version_command` and extracts the version via `version_regex` — for
-#           installed binaries/CLIs (rtk, twitter-cli).
+#           installed binaries/CLIs (rtk, twitter-cli). Optional `latest_source:
+#           release` reads the maintainer's latest-non-prerelease via the Releases
+#           API instead of the highest semver tag — for upstreams whose tags are
+#           NON-MONOTONIC (a stale higher-semver tag would otherwise be a phantom
+#           "latest"; graphify's months-old v1.0.0 vs its current v0.9.x line).
 #      Installed marketplaces (caveman, obsidian-skills, openai-codex,
 #      claude-video, claude-plugins-official, …) are NOT listed in the registry:
 #      they are discovered dynamically from ~/.claude/plugins/known_marketplaces.json
@@ -292,11 +296,14 @@ def expand(p):
     p = re.sub(r'%([A-Za-z_][A-Za-z0-9_]*)%', lambda m: os.environ.get(m.group(1), ''), p)
     return os.path.expanduser(p).replace('\\', '/')
 
-def line(name, kind, repo, mode, v1, v2, tier):
+def line(name, kind, repo, mode, v1, v2, tier, extra=''):
     # \x1f (ASCII unit separator), not '|': version_regex (v2, probe mode) can
     # legitimately contain '|' for regex alternation, which would misalign a
-    # pipe-delimited record.
-    print('\x1f'.join([name, kind, repo, mode, v1 or '', v2 or '', tier or '']))
+    # pipe-delimited record. `extra` (8th field) carries the tag_release
+    # `latest_source` ('release' -> read the maintainer's latest-non-prerelease
+    # via the Releases API instead of the highest semver tag, for upstreams
+    # whose tags are non-monotonic); empty for every other record.
+    print('\x1f'.join([name, kind, repo, mode, v1 or '', v2 or '', tier or '', extra or '']))
 
 if os.path.exists(reg_path) and os.path.getsize(reg_path) > 0:
     d = json.load(open(reg_path))   # malformed -> raises -> class UNCHECKED
@@ -310,9 +317,9 @@ if os.path.exists(reg_path) and os.path.getsize(reg_path) > 0:
         elif kind == 'commit_head' and mode == 'checkout':
             line(e['name'], 'commit_head', repo, 'checkout', expand(e.get('checkout_path', '')), '', tier)
         elif kind == 'tag_release' and mode == 'base':
-            line(e['name'], 'tag_release', repo, 'base', e.get('synced_base', ''), '', tier)
+            line(e['name'], 'tag_release', repo, 'base', e.get('synced_base', ''), '', tier, e.get('latest_source', ''))
         elif kind == 'tag_release' and mode == 'probe':
-            line(e['name'], 'tag_release', repo, 'probe', e.get('version_command', ''), e.get('version_regex', ''), tier)
+            line(e['name'], 'tag_release', repo, 'probe', e.get('version_command', ''), e.get('version_regex', ''), tier, e.get('latest_source', ''))
         else:
             # Unrecognized kind/mode: pass it through verbatim so the bash
             # dispatch reports the REAL kind/mode (e.g. a known kind with a bad
@@ -344,7 +351,7 @@ PY
     echo "  ? upstreams.json / known_marketplaces.json parse failed (python3 error) — carried-upstreams class UNCHECKED."
     incomplete=1
   else
-    while IFS=$'\x1f' read -r name kind repo mode v1 v2 tier; do
+    while IFS=$'\x1f' read -r name kind repo mode v1 v2 tier latest_src; do
       [ -n "$name" ] || continue
       tier_note=""
       if [ -n "$tier" ]; then tier_note="  [$tier]"; fi
@@ -504,15 +511,35 @@ PY
             echo "  $name: ? tag_release mode '$mode' unknown — UNCHECKED (fix scripts/upstreams.json)"
             incomplete=1; continue
           fi
-          tags_raw="$(gh api "repos/$repo/tags?per_page=100" --jq '.[].name' 2>/dev/null)"; api_rc=$?
-          if [ "$api_rc" -ne 0 ] || [ -z "$tags_raw" ]; then
-            echo "  $name: ? true upstream unreachable ($repo tags) — UNCHECKED"
+          if [ "$latest_src" = "release" ]; then
+            # Non-monotonic tags: a stale higher-semver tag (e.g. graphify's
+            # v1.0.0, cut months before the current v0.9.x line) would make
+            # `sort -V` pick a phantom "latest" and report a permanent false
+            # BEHIND. Opt into the maintainer's own latest-non-prerelease
+            # designation (the Releases API), which reflects real recency.
+            latest="$(gh api "repos/$repo/releases/latest" --jq '.tag_name' 2>/dev/null)"; api_rc=$?
+            if [ "$api_rc" -ne 0 ] || ! printf '%s' "$latest" | grep -qE '^v?[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+              echo "  $name: ? no parseable latest release on $repo (latest_source=release) — UNCHECKED"
+              incomplete=1; continue
+            fi
+          elif [ -n "$latest_src" ]; then
+            # Only an empty latest_source means "default: highest stable tag". Any
+            # other non-empty value is a typo (e.g. "releases") that would silently
+            # fall into tag mode and re-introduce the phantom-drift this option
+            # exists to prevent — mark it UNCHECKED, never guess.
+            echo "  $name: ? unknown latest_source '$latest_src' — UNCHECKED (use 'release' or omit; fix scripts/upstreams.json)"
             incomplete=1; continue
-          fi
-          latest="$(printf '%s\n' "$tags_raw" | grep -E '^v?[0-9]+\.[0-9]+(\.[0-9]+)?$' | sort -V | tail -1)"
-          if [ -z "$latest" ]; then
-            echo "  $name: ? no stable version tags found on $repo — UNCHECKED"
-            incomplete=1; continue
+          else
+            tags_raw="$(gh api "repos/$repo/tags?per_page=100" --jq '.[].name' 2>/dev/null)"; api_rc=$?
+            if [ "$api_rc" -ne 0 ] || [ -z "$tags_raw" ]; then
+              echo "  $name: ? true upstream unreachable ($repo tags) — UNCHECKED"
+              incomplete=1; continue
+            fi
+            latest="$(printf '%s\n' "$tags_raw" | grep -E '^v?[0-9]+\.[0-9]+(\.[0-9]+)?$' | sort -V | tail -1)"
+            if [ -z "$latest" ]; then
+              echo "  $name: ? no stable version tags found on $repo — UNCHECKED"
+              incomplete=1; continue
+            fi
           fi
           # Normalize leading 'v' on both sides before comparing.
           norm_local="${local_ver#v}"

--- a/scripts/ci/fork-drift-issue.sh
+++ b/scripts/ci/fork-drift-issue.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# scripts/ci/fork-drift-issue.sh — maintain ONE consolidated upstream-drift
+# tracking issue from the nightly fork-drift workflow (HIMMEL-1046).
+#
+# The drift guard (scripts/check-plugin-drift.sh) reports via an EXIT CODE:
+#   0 = every tracked upstream CURRENT
+#   2 = DRIFT (at least one fork/pin is behind upstream)
+#   3 = INCOMPLETE (a check could not complete — expected in CI, where the
+#       probe/checkout registry entries have no local install)
+# This script turns that code into issue state, refreshing a single issue in
+# place (keyed by the `fork-drift` label) rather than opening a new one per run:
+#   rc 2 -> open the issue if absent, else refresh its body + add a "still
+#           drifting" comment.
+#   rc 0 -> if an issue is open, comment "cleared" and close it.
+#   rc 3 (or anything else) -> leave existing issue state untouched (an
+#           incomplete run must never open OR close — it proved nothing).
+#
+# Usage:  fork-drift-issue.sh <guard-exit-code> <report-file>
+# Env:
+#   GH_TOKEN / GITHUB_TOKEN  gh auth (issues:write) — supplied by the workflow.
+#   DRIFT_ISSUE_LABEL        marker label (default: fork-drift).
+#   DRIFT_ISSUE_TITLE        issue title (default below) — stable across runs.
+#   DRY_RUN=1                print the gh commands instead of running them
+#                            (used by the test harness; no network, no auth).
+set -uo pipefail
+
+RC="${1:-}"
+REPORT="${2:-}"
+LABEL="${DRIFT_ISSUE_LABEL:-fork-drift}"
+TITLE="${DRIFT_ISSUE_TITLE:-Upstream fork drift detected (nightly fork-drift)}"
+
+if [ -z "$RC" ] || [ -z "$REPORT" ]; then
+  echo "usage: fork-drift-issue.sh <guard-exit-code> <report-file>" >&2
+  exit 2
+fi
+if [ ! -f "$REPORT" ]; then
+  echo "fork-drift-issue: report file not found: $REPORT" >&2
+  exit 2
+fi
+
+# DRY_RUN prints the command instead of executing — lets the test harness
+# assert behaviour with no gh, no auth, no network.
+run() {
+  if [ "${DRY_RUN:-0}" = "1" ]; then
+    printf 'DRY: %s\n' "$*"
+    return 0
+  fi
+  "$@"
+}
+
+# UTC stamp — plain `date` (this runs in CI / a shell, not a Workflow script).
+now() { date -u +'%Y-%m-%d %H:%M UTC' 2>/dev/null || echo "unknown-time"; }
+
+# Newest open issue carrying the marker label. Prints the number (empty when
+# there is none) on a SUCCESSFUL lookup; returns nonzero when the lookup itself
+# fails (network/auth) so callers can distinguish "no issue" from "don't know" —
+# a swallowed failure would let the rc=2 branch open a DUPLICATE when an issue
+# already exists but the query transiently failed (breaks the one-issue contract).
+find_open_issue() {
+  if [ "${DRY_RUN:-0}" = "1" ]; then
+    # Test hook: simulate a failed gh lookup (returns nonzero, no output).
+    [ "${DRY_RUN_LOOKUP_FAIL:-0}" = "1" ] && return 1
+    printf '%s' "${DRY_RUN_OPEN_ISSUE:-}"
+    return 0
+  fi
+  local out rc
+  out="$(gh issue list --label "$LABEL" --state open --limit 1 \
+    --json number --jq '.[0].number // empty' 2>/dev/null)"; rc=$?
+  [ "$rc" -eq 0 ] || return 1
+  printf '%s' "$out"
+}
+
+build_body() {
+  local body_file="$1"
+  {
+    echo "**Automated upstream-drift report** — maintained in place by the nightly"
+    echo "\`fork-drift\` workflow (HIMMEL-1046). Do not open duplicates; this issue is"
+    echo "refreshed each run and auto-closed when drift clears."
+    echo ""
+    echo "_Last drift detected: $(now)._"
+    echo ""
+    echo "Guard output:"
+    echo ''
+    echo '```'
+    cat "$REPORT"
+    echo '```'
+    echo ""
+    echo "To resolve: re-sync the named fork onto its newer upstream, bump the pin"
+    echo "(and \`synced_base\` in \`scripts/upstreams.json\`), then this issue closes"
+    echo "on the next nightly run."
+  } > "$body_file"
+}
+
+case "$RC" in
+  2)
+    # A failed lookup (not "no issue") must NOT fall through to `gh issue create`
+    # — that would open a duplicate when an issue already exists. Bail loudly; the
+    # workflow step goes red so the transient failure is visible, and the next
+    # nightly retries.
+    if ! num="$(find_open_issue)"; then
+      echo "fork-drift: could not query existing issues (gh lookup failed) — not creating/refreshing to avoid a duplicate. Retrying next run." >&2
+      exit 1
+    fi
+    # Propagate EVERY mutation failure (mut=1) so a failed create/edit turns the
+    # workflow step RED — a silent green run that failed to open the drift issue
+    # would hide real drift. Cleanup runs before the exit either way.
+    mut=0
+    # Ensure the marker label exists (idempotent). --force updates an existing
+    # label rather than erroring, so a re-run never fails here.
+    run gh label create "$LABEL" --color B60205 \
+        --description "Nightly upstream fork-drift tracking (HIMMEL-1046)" --force || mut=1
+    body_file="$(mktemp)"
+    build_body "$body_file"
+    if [ -n "$num" ]; then
+      echo "fork-drift: refreshing existing issue #$num"
+      run gh issue edit "$num" --body-file "$body_file" || mut=1
+      run gh issue comment "$num" --body "Still drifting as of $(now)." || mut=1
+    else
+      echo "fork-drift: opening new consolidated drift issue"
+      run gh issue create --title "$TITLE" --label "$LABEL" --body-file "$body_file" || mut=1
+    fi
+    rm -f "$body_file"
+    if [ "$mut" -ne 0 ]; then
+      echo "fork-drift: an issue mutation failed (see above) — failing so the drift is not silently green." >&2
+      exit 1
+    fi
+    ;;
+  0)
+    # A failed lookup here means we can't verify/close a possibly-open drift
+    # issue — propagate it (red) for consistency with the rc=2 path rather than
+    # exiting green on an unverified reconciliation. The next run retries.
+    if ! num="$(find_open_issue)"; then
+      echo "fork-drift: all current, but could not query existing issues (gh lookup failed) — failing so the unresolved reconciliation is visible. Retries next run." >&2
+      exit 1
+    fi
+    if [ -n "$num" ]; then
+      echo "fork-drift: drift cleared — closing issue #$num"
+      mut=0
+      run gh issue comment "$num" --body "Drift cleared as of $(now) — all tracked upstreams current. Closing." || mut=1
+      run gh issue close "$num" || mut=1
+      if [ "$mut" -ne 0 ]; then
+        echo "fork-drift: failed to close the drift issue (see above) — it will retry next run." >&2
+        exit 1
+      fi
+    else
+      echo "fork-drift: all current, no open drift issue — nothing to do."
+    fi
+    ;;
+  3)
+    # INCOMPLETE — a documented, benign steady state in CI (the probe/checkout
+    # registry entries have no local install). Proved nothing about drift, so
+    # leave issue state as-is and exit 0.
+    echo "fork-drift: guard exit 3 (incomplete — expected in CI) — leaving issue state unchanged."
+    ;;
+  *)
+    # Any OTHER code (1 usage error, 127 not-found, a crash) is NOT the guard's
+    # documented 0/2/3 contract — the guard is broken. Fail (red) rather than
+    # exit green, so a broken nightly is visible instead of silently passing.
+    echo "fork-drift: guard exited $RC (unexpected — not the documented 0/2/3; crash/usage error?) — failing so a broken guard is not silently green." >&2
+    exit 1
+    ;;
+esac

--- a/scripts/ci/test-fork-drift-issue.sh
+++ b/scripts/ci/test-fork-drift-issue.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/ci/fork-drift-issue.sh (HIMMEL-1046). Uses DRY_RUN=1
+# so no gh, no auth, no network — asserts the issue-state decisions per guard
+# exit code from the emitted DRY: gh command lines.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/ci/fork-drift-issue.sh"
+fails=0
+ok() { echo "ok - $1"; }
+bad() { echo "FAIL - $1" >&2; fails=$((fails + 1)); }
+
+REP="$(mktemp)"; printf 'graphify: BEHIND (v0.9.16)\n' >"$REP"
+
+# has/hasnt: assert a substring is present / absent in captured output.
+has()   { if printf '%s' "$2" | grep -q "$1"; then ok "$3"; else bad "$3; out: $2"; fi; }
+hasnt() { if printf '%s' "$2" | grep -q "$1"; then bad "$3; out: $2"; else ok "$3"; fi; }
+
+# 1. Syntax.
+if bash -n "$SCRIPT"; then ok "syntax (bash -n)"; else bad "syntax"; fi
+
+# 2. Bad args -> usage exit 2.
+bash "$SCRIPT" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ]; then ok "no args -> exit 2"; else bad "no args exit=$rc (expected 2)"; fi
+bash "$SCRIPT" 2 /no/such/file >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 2 ]; then ok "missing report file -> exit 2"; else bad "missing report exit=$rc (expected 2)"; fi
+
+# 3. rc=2, no existing issue -> create (never edit/close).
+out="$(DRY_RUN=1 DRY_RUN_OPEN_ISSUE="" bash "$SCRIPT" 2 "$REP" 2>&1)"
+has 'DRY: gh issue create' "$out" "rc2/no-issue -> creates"
+has 'DRY: gh label create' "$out" "rc2 ensures marker label exists"
+hasnt 'gh issue edit' "$out" "rc2/no-issue does not edit"
+hasnt 'gh issue close' "$out" "rc2 never closes"
+
+# 4. rc=2, existing issue #42 -> edit + comment, never create.
+out="$(DRY_RUN=1 DRY_RUN_OPEN_ISSUE="42" bash "$SCRIPT" 2 "$REP" 2>&1)"
+has 'DRY: gh issue edit 42' "$out" "rc2/existing -> edits #42 (refresh in place)"
+has 'DRY: gh issue comment 42' "$out" "rc2/existing -> adds still-drifting comment"
+hasnt 'gh issue create' "$out" "rc2/existing never creates a duplicate"
+
+# 5. rc=0, existing issue #42 -> comment + close.
+out="$(DRY_RUN=1 DRY_RUN_OPEN_ISSUE="42" bash "$SCRIPT" 0 "$REP" 2>&1)"
+has 'DRY: gh issue close 42' "$out" "rc0/existing -> closes #42"
+hasnt 'gh issue create' "$out" "rc0 never creates"
+
+# 6. rc=0, no existing issue -> nothing.
+out="$(DRY_RUN=1 DRY_RUN_OPEN_ISSUE="" bash "$SCRIPT" 0 "$REP" 2>&1)"
+hasnt 'DRY: gh issue ' "$out" "rc0/no-issue -> no gh issue mutation"
+
+# 7. rc=3 (incomplete, documented) -> leave state unchanged, exit 0.
+out="$(DRY_RUN=1 DRY_RUN_OPEN_ISSUE="42" bash "$SCRIPT" 3 "$REP" 2>&1)"; rc=$?
+hasnt 'DRY: gh issue ' "$out" "rc3 -> issue state unchanged (proved nothing)"
+if [ "$rc" -eq 0 ]; then ok "rc3 -> exit 0 (benign incomplete)"; else bad "rc3 exit=$rc (expected 0)"; fi
+
+# 7b. Any OTHER guard exit (crash/127/usage) is NOT the 0/2/3 contract -> fail
+#     (red), never a silent-green no-op that hides a broken guard.
+out="$(DRY_RUN=1 DRY_RUN_OPEN_ISSUE="42" bash "$SCRIPT" 127 "$REP" 2>&1)"; rc=$?
+if [ "$rc" -eq 1 ]; then ok "rc127 (unexpected) -> exit 1 (broken guard is visible)"; else bad "rc127 exit=$rc (expected 1)"; fi
+hasnt 'DRY: gh issue ' "$out" "rc127 -> no issue mutation"
+
+# 8. Lookup failure (gh issue list errored) must NOT be treated as "no issue".
+#    rc=2 + failed lookup -> bail (exit 1), never create a duplicate.
+out="$(DRY_RUN=1 DRY_RUN_LOOKUP_FAIL=1 bash "$SCRIPT" 2 "$REP" 2>&1)"; rc=$?
+if [ "$rc" -eq 1 ]; then ok "rc2 + lookup-failure -> exit 1 (bail)"; else bad "rc2 + lookup-failure exit=$rc (expected 1)"; fi
+hasnt 'DRY: gh issue create' "$out" "rc2 + lookup-failure never creates (no duplicate)"
+#    rc=0 + failed lookup -> propagate (exit 1) for consistency, never close blindly.
+out="$(DRY_RUN=1 DRY_RUN_LOOKUP_FAIL=1 bash "$SCRIPT" 0 "$REP" 2>&1)"; rc=$?
+if [ "$rc" -eq 1 ]; then ok "rc0 + lookup-failure -> exit 1 (propagate)"; else bad "rc0 + lookup-failure exit=$rc (expected 1)"; fi
+hasnt 'DRY: gh issue close' "$out" "rc0 + lookup-failure never closes blindly"
+
+rm -f "$REP"
+echo ""
+if [ "$fails" -ne 0 ]; then echo "$fails check(s) failed."; exit 1; fi
+echo "all checks passed."

--- a/scripts/test-check-plugin-drift.sh
+++ b/scripts/test-check-plugin-drift.sh
@@ -92,6 +92,23 @@ if [ "$(pick "$(printf 'v1.9.1\nv1.9.2\nv1.9.2-alpha\nv1.8.1\n')")" = "v1.9.2" ]
 if [ "$(pick "$(printf 'v1.9.2\nv1.9.3\n')")" = "v1.9.3" ]; then ok "stable-tag select: newer stable wins"; else bad "newer stable not selected"; fi
 if [ -z "$(pick "$(printf 'v1.9.2-alpha\nv1.9.3-rc1\n')")" ]; then ok "stable-tag select: all-prerelease -> empty (drives the UNCHECKED path)"; else bad "all-prerelease should select nothing, got '$(pick "$(printf 'v1.9.2-alpha\nv1.9.3-rc1\n')")'"; fi
 
+# 3d. The real upstreams.json registers the two SHA-pinned lib forks (HIMMEL-1046)
+#     against their TRUE upstreams — graphify via latest_source=release (its tags
+#     are non-monotonic: a stale v1.0.0 predates the current v0.9.x line), qmd via
+#     the default highest-tag path.
+REG="$ROOT/scripts/upstreams.json"
+if python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$REG" >/dev/null 2>&1; then ok "upstreams.json is valid JSON"; else bad "upstreams.json is not valid JSON"; fi
+reg_probe="$(python3 - "$REG" <<'PY' 2>/dev/null | tr -d '\r'
+import json,sys
+d=json.load(open(sys.argv[1]))
+for e in d.get("entries",[]):
+    if e.get("name") in ("graphify","qmd"):
+        print("|".join([e.get("name",""), e.get("tracked_repo",""), e.get("kind",""), e.get("mode",""), e.get("latest_source","")]))
+PY
+)"
+if printf '%s\n' "$reg_probe" | grep -q 'graphify|Graphify-Labs/graphify|tag_release|base|release'; then ok "graphify entry -> true upstream Graphify-Labs, tag_release/base, latest_source=release"; else bad "graphify registry entry wrong/missing: $(printf '%s' "$reg_probe" | grep graphify)"; fi
+if printf '%s\n' "$reg_probe" | grep -q 'qmd|tobi/qmd|tag_release|base'; then ok "qmd entry -> true upstream tobi/qmd, tag_release/base"; else bad "qmd registry entry wrong/missing: $(printf '%s' "$reg_probe" | grep '^qmd')"; fi
+
 # 4. End-to-end: the script runs to completion with a sane exit code —
 #    0 (all current / fail-open), 2 (drift), or 3 (incomplete). Anything else
 #    (1, 127, crash) fails.
@@ -534,6 +551,74 @@ if printf '%s' "$w10_out" | grep 'timedprobe-tool' | grep -q 'probe timed out (1
 if printf '%s' "$w10_out" | grep -qE '^  timedprobe-tool: (CURRENT|BEHIND)'; then bad "timeout-path hanging probe: entry read CURRENT/BEHIND instead of UNCHECKED (partial pre-hang output was parsed)"; else ok "timeout-path hanging probe: entry never read CURRENT/BEHIND"; fi
 if [ "$w10_rc" -eq 3 ]; then ok "timeout-path hanging probe run exits 3 (incomplete)"; else bad "timeout-path hanging probe run rc=$w10_rc; expected 3"; fi
 rm -rf "$W10"
+
+# 11. latest_source=release (HIMMEL-1046): for a NON-MONOTONIC-tag upstream, the
+#     guard must read the maintainer's latest NON-prerelease via the Releases API,
+#     NOT the highest semver tag (a stale higher tag would be a phantom latest).
+#     The stub serves BOTH a stale-higher tag (v1.0.0) and the real release
+#     (v0.9.16); the release-mode entry compares against v0.9.16, while the default
+#     tag-mode control against the SAME repo picks the stale v1.0.0 — proving the
+#     opt-in changes the source.
+W11="$(mktemp -d)"; mkdir -p "$W11/bin"
+cat > "$W11/bin/gh" <<'GH'
+#!/usr/bin/env bash
+[ "$1" = auth ] && [ "$2" = status ] && exit 0
+case "$*" in
+  *"/releases/latest"*) printf 'v0.9.16\n'; exit 0 ;;
+  *"/tags"*) printf 'v1.0.0\nv0.9.16\nv0.9.13\n'; exit 0 ;;
+esac
+exit 0
+GH
+chmod +x "$W11/bin/gh"
+cat > "$W11/reg-release.json" <<'JSON'
+{"entries":[
+ {"name":"nonmono-rel","kind":"tag_release","mode":"base","tracked_repo":"owner/nonmono","synced_base":"0.9.13","latest_source":"release","tier":"A"}
+]}
+JSON
+cat > "$W11/reg-tag.json" <<'JSON'
+{"entries":[
+ {"name":"nonmono-tag","kind":"tag_release","mode":"base","tracked_repo":"owner/nonmono","synced_base":"0.9.13","tier":"A"}
+]}
+JSON
+printf '{"plugins":[]}' >"$W11/empty_mjson.json"; printf '{}' >"$W11/empty_ups.json"
+rel_out="$(PATH="$W11/bin:$PATH" DRIFT_REGISTRY="$W11/reg-release.json" DRIFT_KNOWN_MARKETPLACES=/dev/null DRIFT_MJSON="$W11/empty_mjson.json" DRIFT_UPSTREAMS="$W11/empty_ups.json" bash "$SCRIPT" 2>&1)"
+tag_out="$(PATH="$W11/bin:$PATH" DRIFT_REGISTRY="$W11/reg-tag.json" DRIFT_KNOWN_MARKETPLACES=/dev/null DRIFT_MJSON="$W11/empty_mjson.json" DRIFT_UPSTREAMS="$W11/empty_ups.json" bash "$SCRIPT" 2>&1)"
+if printf '%s' "$rel_out" | grep 'nonmono-rel' | grep -q 'v0.9.16'; then ok "latest_source=release compares against Releases API (v0.9.16)"; else bad "release-mode did not use releases/latest; $(printf '%s' "$rel_out" | grep nonmono-rel)"; fi
+if printf '%s' "$rel_out" | grep 'nonmono-rel' | grep -q 'v1.0.0'; then bad "release-mode leaked the stale v1.0.0 tag"; else ok "latest_source=release ignores the stale v1.0.0 highest tag"; fi
+if printf '%s' "$tag_out" | grep 'nonmono-tag' | grep -q 'v1.0.0'; then ok "default tag-mode control picks the highest tag v1.0.0 — confirms the opt-in changes the source"; else bad "tag-mode control did not pick v1.0.0; $(printf '%s' "$tag_out" | grep nonmono-tag)"; fi
+# releases/latest unreachable -> UNCHECKED (never a phantom compare).
+cat > "$W11/bin/gh" <<'GH'
+#!/usr/bin/env bash
+[ "$1" = auth ] && [ "$2" = status ] && exit 0
+case "$*" in
+  *"/releases/latest"*) exit 1 ;;
+esac
+exit 0
+GH
+chmod +x "$W11/bin/gh"
+unreach_out="$(PATH="$W11/bin:$PATH" DRIFT_REGISTRY="$W11/reg-release.json" DRIFT_KNOWN_MARKETPLACES=/dev/null DRIFT_MJSON="$W11/empty_mjson.json" DRIFT_UPSTREAMS="$W11/empty_ups.json" bash "$SCRIPT" 2>&1)"; unreach_rc=$?
+if printf '%s' "$unreach_out" | grep 'nonmono-rel' | grep -q 'UNCHECKED'; then ok "latest_source=release: no latest release -> UNCHECKED"; else bad "release-mode unreachable not UNCHECKED; $(printf '%s' "$unreach_out" | grep nonmono-rel)"; fi
+if [ "$unreach_rc" -eq 3 ]; then ok "release-mode unreachable run exits 3 (incomplete)"; else bad "release-mode unreachable rc=$unreach_rc; expected 3"; fi
+# An UNKNOWN latest_source (typo like "releases") must be UNCHECKED, never a
+# silent fall-through to tag mode (which would re-introduce the phantom drift).
+cat > "$W11/bin/gh" <<'GH'
+#!/usr/bin/env bash
+[ "$1" = auth ] && [ "$2" = status ] && exit 0
+case "$*" in
+  *"/tags"*) printf 'v1.0.0\nv0.9.16\n'; exit 0 ;;
+esac
+exit 0
+GH
+chmod +x "$W11/bin/gh"
+cat > "$W11/reg-bad.json" <<'JSON'
+{"entries":[
+ {"name":"bad-src","kind":"tag_release","mode":"base","tracked_repo":"owner/nonmono","synced_base":"0.9.13","latest_source":"releases","tier":"A"}
+]}
+JSON
+bad_out="$(PATH="$W11/bin:$PATH" DRIFT_REGISTRY="$W11/reg-bad.json" DRIFT_KNOWN_MARKETPLACES=/dev/null DRIFT_MJSON="$W11/empty_mjson.json" DRIFT_UPSTREAMS="$W11/empty_ups.json" bash "$SCRIPT" 2>&1)"; bad_rc=$?
+if printf '%s' "$bad_out" | grep 'bad-src' | grep -q "unknown latest_source"; then ok "unknown latest_source -> UNCHECKED (not silent tag-mode)"; else bad "unknown latest_source not UNCHECKED; $(printf '%s' "$bad_out" | grep bad-src)"; fi
+if printf '%s' "$bad_out" | grep -qE '^  bad-src: (CURRENT|BEHIND)'; then bad "unknown latest_source fell through to a tag-mode verdict"; else ok "unknown latest_source never produced a CURRENT/BEHIND verdict"; fi
+rm -rf "$W11"
 
 echo ""
 if [ "$fails" -ne 0 ]; then echo "$fails check(s) failed."; exit 1; fi

--- a/scripts/upstreams.json
+++ b/scripts/upstreams.json
@@ -47,6 +47,25 @@
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+[0-9A-Za-z.-]*",
       "tier": "A",
       "note": "Installed CLI at ~/.local/bin/twitter (consumed by the telegram clipper). Tier A (proactive). UNCHECKED if twitter absent / --version yields no parseable version."
+    },
+    {
+      "name": "graphify",
+      "kind": "tag_release",
+      "mode": "base",
+      "tracked_repo": "Graphify-Labs/graphify",
+      "synced_base": "0.9.13",
+      "latest_source": "release",
+      "tier": "A",
+      "note": "SHA-pinned lib fork yotamleo/graphify (pin in scripts/lib/graphify-bin.sh, HIMMEL-891; adoption verdict HIMMEL-621). tracked_repo is the TRUE upstream (Graphify-Labs), not the fork — a fork-HEAD compare would only catch fork-vs-pin drift, never upstream advance (same false-negative class as claude-statusline). synced_base = the upstream release the fork pin (v0.9.13-himmel.1) carries. latest_source=release because upstream tags are NON-MONOTONIC: a stale v1.0.0 (2026-04) predates the current v0.9.x line, so highest-semver-tag would report a permanent phantom BEHIND; the Releases API returns the real latest (v0.9.16). BEHIND here means: rebase the fork onto the newer upstream release, promote mcp->core dep, re-tag v<new>-himmel.1, bump the graphify-bin.sh pin, then bump synced_base here."
+    },
+    {
+      "name": "qmd",
+      "kind": "tag_release",
+      "mode": "base",
+      "tracked_repo": "tobi/qmd",
+      "synced_base": "2.5.3",
+      "tier": "B",
+      "note": "SHA-pinned lib fork yotamleo/qmd (pin in scripts/lib/qmd-bin.sh; the additive-delta audit was previously the MANUAL step named in the header). tracked_repo is the TRUE upstream (tobi/qmd). synced_base = the highest upstream STABLE tag the fork carries (fork package.json reads 2.6.3, ahead of upstream's released tags, so this reads CURRENT until upstream tags a version > synced_base). Tier B (reactive) — expected to read BEHIND once upstream cuts 2.5.4+, that IS the signal to re-audit the fork delta."
     }
   ]
 }


### PR DESCRIPTION
A nightly guard that detects when the tracked forks drift from their upstreams
and files an issue:

- `.github/workflows/fork-drift.yml`
- `scripts/ci/fork-drift-issue.sh` (+ test)
- `scripts/check-plugin-drift.sh` (+ test) and `scripts/upstreams.json` extended
  to cover the graphify + qmd forks

Propagated from private himmel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nightly monitoring for upstream fork drift.
  * Automatically creates, updates, or closes a consolidated tracking issue based on detected drift.
  * Added tracking for Graphify and QMD upstream releases.
  * Improved version checks for projects with non-monotonic tags by using release information when available.

* **Bug Fixes**
  * Prevents incomplete or unexpected checks from being incorrectly reported as current or behind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->