### PR TITLE
chore(security): allowlist local proxy token in luna gitleaks template

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -20,7 +20,18 @@ description = "Telegram bot API token"
 regex = '''[0-9]{8,10}:[A-Za-z0-9_-]{35}'''
 
 [allowlist]
-description = "Vendored third-party Obsidian plugin bundles (minified upstream code)"
+description = "Vendored third-party Obsidian plugin bundles + the known-benign local-proxy test token"
 paths = [
   '''templates/luna-second-brain/\.obsidian/plugins/''',
+]
+# The luna template's gitleaks regression test embeds the loopback-only local
+# CLIProxyAPI token (Authorization Bearer) plus a deliberate suffixed near-miss
+# as FIXTURES, proving the template allowlist lets the exact constant through
+# but blocks a near-miss. That token is a documented, loopback-only shared
+# constant checked into himmel (scripts/setup/cli-proxy-lane.ps1), not a
+# credential. Scope the exception to those exact constants (anchored) rather
+# than path-allowlisting the whole test file, so real secrets in it are still
+# scanned (CR #1239). Anchored ^…$ avoids the substring-bypass hole (HIMMEL-1055).
+regexes = [
+  '''^himmel-local-claudex(-extra)?$''',
 ]

--- a/templates/luna-second-brain/.gitleaks.toml
+++ b/templates/luna-second-brain/.gitleaks.toml
@@ -11,7 +11,18 @@
 useDefault = true
 
 [allowlist]
-description = "Vendored third-party Obsidian plugin bundles (minified upstream code)"
+description = "Vendored plugin bundles + known-benign local loopback proxy token"
 paths = [
   '''\.obsidian/plugins/''',
+]
+# The end-session-wiki hook captures session bash verbatim, so probes against
+# the local CLIProxyAPI gateway (127.0.0.1:8317) land in sessions/*.md as
+# `curl -H "Authorization: Bearer himmel-local-claudex"`. That token is a
+# documented, loopback-only, shared constant checked into himmel itself
+# (scripts/setup/cli-proxy-lane.ps1), not a credential. Suppress the generic
+# curl-auth-header false positive for this one literal only. Anchored (^…$)
+# so it suppresses ONLY the exact constant — a prefixed/suffixed bearer
+# credential (himmel-local-claudex-<real-secret>) is still caught.
+regexes = [
+  '''^himmel-local-claudex$''',
 ]

--- a/templates/luna-second-brain/scripts/test-vault-git.sh
+++ b/templates/luna-second-brain/scripts/test-vault-git.sh
@@ -184,6 +184,29 @@ else
   assert_eq "D5 planted key NOT in committed tree" "0" \
     "$(git_in "$VC" ls-tree -r HEAD --name-only | grep -c 'leak\.md' || true)"
 
+  # D6-D9 — regression test for the local-proxy allowlist entry (HIMMEL-1055):
+  # the anchored regex (`^himmel-local-claudex$`) in .gitleaks.toml must let
+  # the exact constant through but still block a suffixed near-miss, guarding
+  # the anti-bypass rationale documented there.
+  rm -f "$VC/30-Resources/leak.md"
+  printf 'curl -H "Authorization: Bearer himmel-local-claudex"\n' >"$VC/30-Resources/proxy-token.md"
+  (cd "$VC" && LUNA_VAULT_AUTOSYNC=1 bash "$VC/scripts/vault-autosync.sh") >/dev/null 2>&1
+  assert_ok "D6 allowlisted local-proxy token: autosync commits (exit 0)" "$?"
+  assert_eq "D7 allowlisted token IS in committed tree" "1" \
+    "$(git_in "$VC" ls-tree -r HEAD --name-only | grep -c 'proxy-token\.md' || true)"
+
+  d8_before=$(git_in "$VC" rev-parse HEAD)
+  printf 'curl -H "Authorization: Bearer himmel-local-claudex-extra"\n' >"$VC/30-Resources/proxy-token-extra.md"
+  # Capture the output so the block can be attributed to the SECRET SCANNER, not
+  # an unrelated hook/setup failure that also exits non-zero (CR #1239). autosync
+  # runs `git commit` without muting the hooks, so gitleaks' own "leaks found"
+  # reaches this stream on a real secret block.
+  d8_out=$( (cd "$VC" && LUNA_VAULT_AUTOSYNC=1 bash "$VC/scripts/vault-autosync.sh") 2>&1 ); d8_rc=$?
+  assert_nz "D8 near-miss token (suffixed) still blocked (non-zero)" "$d8_rc"
+  printf '%s\n' "$d8_out" | grep -qiE 'gitleaks|leaks found'
+  assert_ok "D8b near-miss block attributable to gitleaks (secret scan)" "$?"
+  assert_eq "D9 near-miss token NOT in committed tree" "$d8_before" "$(git_in "$VC" rev-parse HEAD)"
+
   # =========================================================================
   # Phase E — clone-with-remote (no marker, PAST unborn HEAD): autosync must
   # ensure .single-writer itself so its on-main commit clears worktree-isolation


### PR DESCRIPTION
Adds an anchored allowlist entry to the bundled luna gitleaks template so the
local-proxy bearer-token pattern captured in session notes does not trip a
false-positive secret block on push.

- `templates/luna-second-brain/.gitleaks.toml`

Propagated from private himmel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated secret-scanning configuration to avoid flagging a known local-only development token in vendored plugin files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->