### PR TITLE
feat(hooks): CI-green pre-merge guard

### DIFF
--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -342,6 +342,48 @@ Paired artifacts: `scripts/lib/cr-merge-gate.sh` (predicate),
 `scripts/lib/test-cr-merge-gate.sh` and
 `scripts/hooks/test-block-unresolved-cr-merge.sh` (smoke suites).
 
+### CI-green merge gate (HIMMEL-1043)
+
+Runs on the SAME `gh pr merge` path as the CodeRabbit gate above, one step
+after it: blocks the merge while the target PR's **head SHA is not green** —
+any **non-CodeRabbit** check-run with a red conclusion (`failure`,
+`timed_out`, `cancelled`, `action_required`, `startup_failure`, `stale`) or
+still pending (`status != completed`), or a combined commit **status** of
+`failure`/`error` (or `pending` with ≥1 status). It also **fail-CLOSED-blocks**
+when the head has **>100 check-runs** (more than the single API page can
+certify — a failing/pending run may sit on an unread page 2; same page-limit
+stance as `cr-merge-gate`, HIMMEL-980). This repo has **no branch
+protection**, so GitHub will not otherwise block a merge over red/pending
+CI — this gate is the structural "ready to merge ⇒ green" enforcement
+(operator rule 2026-07-15; HIMMEL-195 structural > instructional; the
+green-gate HIMMEL-1042's true auto-merge needs). CodeRabbit check-runs are
+excluded here on purpose — the CR gate above owns CodeRabbit (threads + the
+in_progress/zombie override, HIMMEL-936/980), so this gate never
+double-blocks nor false-blocks on a hung CodeRabbit run.
+
+The signal is `ci_green_gate <pr-selector> [<owner/repo>]` from
+`scripts/lib/ci-green-gate.sh`. It is wired into **the same
+`block-unresolved-cr-merge.sh` PreToolUse hook** (reuses that hook's
+adversarially-hardened selector extraction; a block prints
+`block-red-ci-merge: …` to stderr and exits 2) AND into
+`scripts/handover/pr-merge.sh` before its mergeability poll (a block there
+exits `pr-merge.sh` with code **6**, distinct from the CR gate's 5 and a real
+merge failure's 4).
+
+**Fail-OPEN posture:** deny ONLY on positive red/pending evidence. `gh`/`jq`
+missing, `gh pr view` failure, API/parse error, and a genuinely **checkless
+PR** (zero check-runs AND zero commit statuses) all exit 0 with a
+``ci-green-gate: degraded (<why>) - failing open`` stderr note — never a
+false block on a repo/branch with no CI.
+
+**Bypass:** `CI_MERGE_GATE_OK=1` in the LAUNCHING shell (independent of the
+CR gate's `CR_MERGE_GATE_OK`; NOT coupled to `CR_PROFILE`).
+
+Paired artifacts: `scripts/lib/ci-green-gate.sh` (predicate),
+`scripts/lib/test-ci-green-gate.sh` and the shared
+`scripts/hooks/test-block-unresolved-cr-merge.sh` /
+`scripts/handover/test-pr-merge.sh` (smoke suites).
+
 ### `block-lesson-enforcement-writes.sh` — lesson-loop write-fence (HIMMEL-767)
 
 Fires on `Edit|Write|MultiEdit|NotebookEdit|Bash|PowerShell`, but only when

--- a/scripts/handover/pr-merge.sh
+++ b/scripts/handover/pr-merge.sh
@@ -24,6 +24,7 @@
 #   3  not on a handover/* branch (refuses)
 #   4  gh pr merge failed
 #   5  blocked by the CR merge gate (unresolved CodeRabbit remarks - HIMMEL-936)
+#   6  blocked by the CI-green merge gate (head SHA not green - HIMMEL-1043)
 #
 # Environment overrides:
 #   FORGE / GH_CMD / BITBUCKET_CMD   Forge-seam overrides (HIMMEL-326). The PR
@@ -135,6 +136,23 @@ if [ "$forge" = "github" ]; then
         if [ "$_gate_rc" = "2" ]; then
             echo "pr-merge: CR gate: $_gate_reason" >&2
             exit 5
+        fi
+    fi
+    # HIMMEL-1043: CI-green gate, same predicate as the PreToolUse hook's
+    # second gate, so machines without the plugin hook still require green CI
+    # on this path. Runs AFTER the CR gate (exit 5) and before the
+    # mergeability poll; a CI-blocked merge fails fast (exit 6). pr-merge passes
+    # only the PR number (no --repo): a selector that fails to resolve is a
+    # plain fail-open rc=3 here — no cwd-branch re-anchor (this path already
+    # knows its PR via forge_pr_find_open).
+    # shellcheck disable=SC1091
+    if . "$SCRIPT_DIR/../lib/ci-green-gate.sh" 2>/dev/null; then
+        _ci_reason=""
+        _ci_rc=0
+        _ci_reason=$(ci_green_gate "$pr_num") || _ci_rc=$?
+        if [ "$_ci_rc" = "2" ]; then
+            echo "pr-merge: CI gate: $_ci_reason" >&2
+            exit 6
         fi
     fi
 fi

--- a/scripts/handover/test-pr-merge.sh
+++ b/scripts/handover/test-pr-merge.sh
@@ -65,7 +65,9 @@ case "$verb" in
         # cr_merge_gate proceeds to its graphql arm; otherwise echo non-JSON
         # so the gate degrades + fails open (existing cases stay green).
         if printf ' %s ' "$@" | grep -q 'headRefOid'; then
-            if [ "${STUB_CR_BLOCK:-0}" = "1" ]; then
+            # STUB_CR_BLOCK=1 arms the CR gate; STUB_CI_BLOCK=1 arms the CI gate
+            # (both need parseable metadata to resolve the head SHA).
+            if [ "${STUB_CR_BLOCK:-0}" = "1" ] || [ "${STUB_CI_BLOCK:-0}" = "1" ]; then
                 echo '{"number":42,"headRefOid":"abc123","url":"https://github.com/o/r/pull/42"}'
             else
                 echo "${STUB_VIEW_MERGEABLE:-MERGEABLE}"
@@ -107,15 +109,32 @@ case "$verb" in
         echo "merged"
         ;;
     "api graphql")
-        # HIMMEL-936 CR-gate reviewThreads query: one unresolved coderabbitai
-        # thread (fixture copied from test-cr-merge-gate.sh).
-        echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}'
+        # CR-gate reviewThreads query. STUB_CI_BLOCK=1 needs the CR gate to PASS
+        # (resolved coderabbit threads) so the CI gate is reached; otherwise one
+        # unresolved coderabbitai thread arms the CR block (fixture from
+        # test-cr-merge-gate.sh).
+        if [ "${STUB_CI_BLOCK:-0}" = "1" ]; then
+            echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":true,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}'
+        else
+            echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"comments":{"nodes":[{"author":{"login":"coderabbitai"}}]}}]}}}}}'
+        fi
         ;;
     "api repos"*)
-        # HIMMEL-936 CR-gate check-runs query: completed CodeRabbit check-run.
-        # Not reached when the threads arm already blocks, but stubbed for
-        # completeness / the in-flight arm.
-        echo '{"check_runs":[{"name":"CodeRabbit","status":"completed","conclusion":"success"}]}'
+        # check-runs vs combined-status, distinguished by the URL tail. The CR
+        # gate queries check-runs (CodeRabbit only); the CI gate queries both.
+        # STUB_CI_BLOCK=1 returns a FAILED non-CodeRabbit check-run so the CI
+        # gate blocks while the CR gate still passes.
+        if printf ' %s ' "$@" | grep -q 'check-runs'; then
+            if [ "${STUB_CI_BLOCK:-0}" = "1" ]; then
+                echo '{"check_runs":[{"name":"CodeRabbit","status":"completed","conclusion":"success"},{"name":"tests","status":"completed","conclusion":"failure"}]}'
+            else
+                echo '{"check_runs":[{"name":"CodeRabbit","status":"completed","conclusion":"success"}]}'
+            fi
+        elif printf ' %s ' "$@" | grep -q '/status'; then
+            echo '{"state":"success","total_count":1,"statuses":[{"context":"ci","state":"success"}]}'
+        else
+            echo '{}'
+        fi
         ;;
     *) ;;
 esac
@@ -271,6 +290,17 @@ if STUB_CR_BLOCK=1 \
     run_case "handover/x-slug" 5 "CR-gate block exits 5 before poll"; then
     assert_log_lacks "pr merge" "CR-gate block does not attempt merge"
     assert_err_has    "CR gate" "CR-gate block reports CR gate on stderr"
+fi
+
+# --- HIMMEL-1043: CI-green gate blocks AFTER the CR gate (exit 6) ---
+# STUB_CI_BLOCK=1: CR gate passes (resolved coderabbit threads + a completed
+# CodeRabbit check-run), but a non-CodeRabbit check-run ("tests") failed, so
+# ci_green_gate blocks. Runs AFTER the CR gate (exit 5) and BEFORE the
+# mergeability poll, so neither the poll's pr view nor `gh pr merge` is reached.
+if STUB_CI_BLOCK=1 \
+    run_case "handover/x-slug" 6 "CI-gate block exits 6 before poll"; then
+    assert_log_lacks "pr merge" "CI-gate block does not attempt merge"
+    assert_err_has    "CI gate" "CI-gate block reports CI gate on stderr"
 fi
 
 # --- summary ---

--- a/scripts/hooks/block-unresolved-cr-merge.sh
+++ b/scripts/hooks/block-unresolved-cr-merge.sh
@@ -1,22 +1,31 @@
 #!/usr/bin/env bash
 # PreToolUse hook: block-unresolved-cr-merge.sh
 #
-# Blocks `gh pr merge` while the PR has unresolved CodeRabbit review threads
-# or a CodeRabbit check-run still running on the head SHA (HIMMEL-936), except
-# a proven old zombie backed by success status + zero unresolved threads (HIMMEL-980;
-# operator rule 2026-07-11: never merge over unresolved CodeRabbit remarks).
+# Blocks `gh pr merge` on TWO independent gates, run in order:
+#   1. CR gate (HIMMEL-936): unresolved CodeRabbit review threads or a
+#      CodeRabbit check-run still running on the head SHA (except a proven old
+#      zombie backed by success status + zero unresolved threads, HIMMEL-980;
+#      operator rule 2026-07-11: never merge over unresolved CodeRabbit remarks).
+#   2. CI-green gate (HIMMEL-1043): the PR's head SHA must have green overall
+#      CI — no failing/pending check-run, no failing/pending combined status.
+#      This repo has NO branch protection, so GitHub will not otherwise block a
+#      merge over red/pending CI (operator rule: "ready to merge" requires green).
 # Sibling of check-cr-marker-on-pr-create.sh / block-merged-pr-commit.sh.
 #
 # Exit: 0 allow (incl. every fail-open path), 2 block (stderr shown to model).
-# Bypass: CR_MERGE_GATE_OK=1 in the LAUNCHING shell. CR_PROFILE=none skips.
+# Bypass: CR_MERGE_GATE_OK=1 and/or CI_MERGE_GATE_OK=1 in the LAUNCHING shell
+# (each gates its own check independently). CR_PROFILE=none skips the CR gate.
 set -uo pipefail
 # NOT set -e: fail-open hook, must never abort on a sub-call's rc 1.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-[ "${CR_MERGE_GATE_OK:-0}" = "1" ] && exit 0
-[ "${CR_PROFILE:-}" = "none" ] && exit 0
-
+# The CR-gate bypasses (CR_MERGE_GATE_OK=1 / CR_PROFILE=none) are handled
+# INSIDE cr_merge_gate (self-bypass → rc 0), NOT with an early exit here — an
+# early `exit 0` would also skip the independent CI-green gate below, letting a
+# red/pending-CI merge through whenever a CR bypass is set (CodeRabbit, #1230).
+# The CI gate has its OWN bypass (CI_MERGE_GATE_OK=1) inside ci_green_gate. So
+# both gates are always reached; each self-bypasses its own check.
 command -v jq >/dev/null 2>&1 || exit 0   # cannot parse stdin: fail open
 
 payload=$(cat) || exit 0
@@ -140,6 +149,31 @@ if [ "$rc" = "3" ] && [ -n "$cwd_branch" ]; then
 fi
 if [ "$rc" = "2" ]; then
     echo "block-unresolved-cr-merge: $reason" >&2
+    exit 2
+fi
+
+# ── CI-green merge gate (HIMMEL-1043) — runs SECOND, after the CR gate ──
+# Same extracted selector ($sel)/$repo + rc=3 re-anchor pattern as the CR gate
+# above; the CI gate is independent (its own bypass CI_MERGE_GATE_OK=1) and
+# never coupled to CR_PROFILE. A guard bug must NEVER block a legit merge, so
+# every unresolvable/degraded path fails open (rc 0/3) inside ci_green_gate.
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/ci-green-gate.sh" 2>/dev/null || exit 0
+
+ci_reason=""
+ci_rc=0
+ci_reason=$(ci_green_gate "$sel" "$repo") || ci_rc=$?
+if [ "$ci_rc" = "3" ] && [ -n "$cwd_branch" ]; then
+    # Mirror the CR gate's re-anchor: the extracted token did not resolve to a
+    # PR, so retry once on the cwd branch (in the cwd repo) so ordinary CLI
+    # syntax cannot dodge the gate; if this also fails, ci_green_gate fails open.
+    if [ "$cwd_branch" != "$sel" ] || [ -n "$repo" ]; then
+        ci_rc=0
+        ci_reason=$(ci_green_gate "$cwd_branch" "") || ci_rc=$?
+    fi
+fi
+if [ "$ci_rc" = "2" ]; then
+    echo "block-red-ci-merge: $ci_reason" >&2
     exit 2
 fi
 exit 0

--- a/scripts/hooks/test-block-unresolved-cr-merge.sh
+++ b/scripts/hooks/test-block-unresolved-cr-merge.sh
@@ -32,6 +32,11 @@ case "$1 $2" in
     case "$GH_STUB_MODE" in
       inflight|zombie|zombie-unresolved|zombie-no-status|zombie-status-error|zombie-paged|zombie-nopageinfo) echo '{"check_runs":[{"name":"CodeRabbit","status":"in_progress","started_at":"2000-01-01T00:00:00Z","conclusion":null}]}' ;;
       young) echo "{\"check_runs\":[{\"name\":\"CodeRabbit\",\"status\":\"in_progress\",\"started_at\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"conclusion\":null}]}" ;;
+      # HIMMEL-1043 CI-gate cases: a completed CodeRabbit run keeps the CR gate
+      # green (it only looks at CodeRabbit); a non-CodeRabbit run carries the
+      # red/green signal only the CI gate reads.
+      ci-red)   echo '{"check_runs":[{"name":"CodeRabbit","status":"completed","conclusion":"success"},{"name":"tests","status":"completed","conclusion":"failure"}]}' ;;
+      ci-green) echo '{"check_runs":[{"name":"CodeRabbit","status":"completed","conclusion":"success"},{"name":"tests","status":"completed","conclusion":"success"}]}' ;;
       *)        echo '{"check_runs":[{"name":"CodeRabbit","status":"completed","conclusion":"success"}]}' ;;
     esac ;;
   "api repos/o/r/commits/abc123/status")
@@ -39,6 +44,7 @@ case "$1 $2" in
       zombie|zombie-unresolved|zombie-paged|zombie-nopageinfo) echo '{"statuses":[{"context":"CodeRabbit","state":"success"}]}' ;;
       zombie-status-error) exit 1 ;;
       zombie-no-status) echo '{"statuses":[]}' ;;
+      ci-green) echo '{"state":"success","total_count":1,"statuses":[{"context":"ci","state":"success"}]}' ;;
       *) echo '{"statuses":[{"context":"CodeRabbit","state":"pending"}]}' ;;
     esac ;;
   *) echo '{}' ;;
@@ -77,6 +83,17 @@ GH_STUB_MODE=zombie-paged t zombie-paged-threads-blocks 2 Bash "gh pr merge 42 -
 GH_STUB_MODE=zombie-nopageinfo t zombie-nopageinfo-blocks 2 Bash "gh pr merge 42 --squash"
 GH_STUB_MODE=other-author t other-author-thread-allows 0 Bash "gh pr merge 42 --squash"
 CR_ZOMBIE_CHECKRUN_MINS=090 GH_STUB_MODE=zombie t zombie-leading-zero-mins-allows 0 Bash "gh pr merge 42 --squash"
+# ── HIMMEL-1043: CI-green gate runs SECOND (after the CR gate) ──
+# ci-red: CR gate passes (resolved CodeRabbit thread + completed CodeRabbit
+# check-run), but a non-CodeRabbit check-run ("tests") failed -> CI gate
+# blocks. ci-green: every check-run green -> merge allowed.
+GH_STUB_MODE=ci-red   t merge-over-red-ci-blocks    2 Bash "gh pr merge 42 --squash"
+GH_STUB_MODE=ci-green t merge-over-green-ci-allows  0 Bash "gh pr merge 42 --squash"
+# CodeRabbit #1230: a CR-gate bypass must NOT disable the independent CI gate.
+# A red-CI merge with CR_MERGE_GATE_OK=1 (or CR_PROFILE=none) is STILL blocked
+# by the CI gate. (Under the old top early-exit these returned 0 — the bug.)
+CR_MERGE_GATE_OK=1 GH_STUB_MODE=ci-red t cr-bypass-still-ci-blocks      2 Bash "gh pr merge 42 --squash"
+CR_PROFILE=none    GH_STUB_MODE=ci-red t cr-profile-none-still-ci-blocks 2 Bash "gh pr merge 42 --squash"
 GH_STUB_MODE=unresolved t non-merge-passthrough          0 Bash "gh pr view 42"
 GH_STUB_MODE=unresolved t string-literal-passthrough     0 Bash "echo \\\"gh pr merge 42\\\""
 GH_STUB_MODE=unresolved t powershell-payload-blocks      2 PowerShell "gh pr merge 42 --squash"
@@ -105,6 +122,8 @@ for pt in non-merge-passthrough string-literal-passthrough quoted-merge-text-pas
 done
 # block reason surfaces on stderr (hook contract: stderr shown to model+user)
 grep -qi "unresolved" "$TMP/err-merge-with-unresolved-blocks" || { echo "FAIL stderr reason missing"; fail=$((fail+1)); }
+# HIMMEL-1043: the CI gate's block surfaces with its own prefix on stderr
+grep -q "block-red-ci-merge" "$TMP/err-merge-over-red-ci-blocks" || { echo "FAIL ci-block stderr reason missing"; fail=$((fail+1)); }
 grep -q "zombie check-run override:.*commit status=success + 0 unresolved threads.*HIMMEL-980" "$TMP/err-zombie-review-allows" || { echo "FAIL zombie override line missing"; fail=$((fail+1)); }
 
 echo "pass=$pass fail=$fail"

--- a/scripts/lib/ci-green-gate.sh
+++ b/scripts/lib/ci-green-gate.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# ci-green-gate.sh — shared predicate for the HIMMEL-1043 CI-green merge gate.
+#
+# ci_green_gate <pr-selector> [<owner/repo>]
+#   rc 0 = allow; rc 2 = block, one-line reason on stdout.
+#   rc 3 = allow, but the SELECTOR did not resolve to a PR (gh pr view failed)
+#          — callers that extracted the selector heuristically (the PreToolUse
+#          hook) should retry once with a better-anchored selector (the cwd
+#          branch) so quoted/mis-tokenized selectors cannot dodge the gate
+#          (same re-anchor contract as cr_merge_gate, HIMMEL-936). Top-level
+#          consumers treat any non-2 rc as allow.
+#   Deny ONLY on positive evidence: a NON-GREEN CI state on the PR's head SHA
+#   among NON-CodeRabbit check-runs — either a check-run with a RED conclusion
+#   (failure, timed_out, cancelled, action_required, startup_failure, stale), a
+#   check-run still PENDING (status != completed) — or a combined commit status
+#   of failure (or pending with >=1 status, evaluated in full). CodeRabbit
+#   check-runs are EXCLUDED (the CR gate, HIMMEL-936/980, owns CodeRabbit; this
+#   gate owns the tests/lint/build CI the repo otherwise has no guard for — see
+#   brief WHY "a red or still-running non-CodeRabbit check", and it keeps a hung
+#   CodeRabbit check-run from false-blocking here). This repo has NO branch
+#   protection, so GitHub will not otherwise block `gh pr merge` over red/pending
+#   CI (HIMMEL-1043). EVERYTHING else (gh/jq missing, gh pr view failure, API
+#   error, parse failure, a check-less PR with zero check-runs AND zero statuses)
+#   fails OPEN (rc 0/3) with a "ci-green-gate: degraded (...) - failing open"
+#   stderr note. CI_MERGE_GATE_OK=1 skips the gate entirely (rc 0). NOT coupled
+#   to CR_PROFILE (the CI gate is independent of the CodeRabbit gate).
+#
+# Sourceable from hooks and scripts: uses only `return`, never `exit`;
+# does not toggle set -e. bash 3.2-safe. Each `jq` command substitution is
+# made set -e-safe with a trailing `|| true` inside the subshell so that a
+# caller running `set -e` (pr-merge.sh) does not abort on a jq parse failure
+# (a parse failure is a normal fail-open input here, not a hard error).
+# HIMMEL-1043. Mirrors scripts/lib/cr-merge-gate.sh in structure + conventions.
+
+_cig_degrade() { echo "ci-green-gate: degraded ($*) - failing open" >&2; }
+
+ci_green_gate() {
+    [ "${CI_MERGE_GATE_OK:-0}" = "1" ] && return 0
+
+    local sel="${1:-}" repo="${2:-}"
+    if [ -z "$sel" ]; then _cig_degrade "no PR selector"; return 0; fi
+    command -v gh >/dev/null 2>&1 || { _cig_degrade "gh not on PATH"; return 0; }
+    command -v jq >/dev/null 2>&1 || { _cig_degrade "jq not on PATH"; return 0; }
+
+    local meta url num head owner name
+    if [ -n "$repo" ]; then
+        meta=$(gh pr view "$sel" --repo "$repo" --json number,headRefOid,url 2>/dev/null) || { _cig_degrade "gh pr view failed (selector '$sel' unresolvable)"; return 3; }
+    else
+        meta=$(gh pr view "$sel" --json number,headRefOid,url 2>/dev/null) || { _cig_degrade "gh pr view failed (selector '$sel' unresolvable)"; return 3; }
+    fi
+    num=$(printf '%s' "$meta" | jq -r '.number // empty' 2>/dev/null || true)
+    head=$(printf '%s' "$meta" | jq -r '.headRefOid // empty' 2>/dev/null || true)
+    url=$(printf '%s' "$meta" | jq -r '.url // empty' 2>/dev/null || true)
+    if [ -z "$num" ] || [ -z "$head" ] || [ -z "$url" ]; then _cig_degrade "pr metadata incomplete"; return 0; fi
+    # url shape: https://github.com/OWNER/NAME/pull/N
+    owner=$(printf '%s' "$url" | sed -n 's|^https://[^/]*/\([^/]*\)/.*|\1|p')
+    name=$(printf '%s' "$url"  | sed -n 's|^https://[^/]*/[^/]*/\([^/]*\)/.*|\1|p')
+    if [ -z "$owner" ] || [ -z "$name" ]; then _cig_degrade "cannot parse owner/name from $url"; return 0; fi
+
+    # 1) check-runs on the head SHA. RED conclusions block; PENDING (status !=
+    # completed) block. GREEN = success/neutral/skipped (or any non-RED
+    # conclusion on a completed run — block ONLY on positive evidence).
+    #
+    # Layering with the CR gate (HIMMEL-936): CodeRabbit check-runs are the CR
+    # gate's domain (it owns CodeRabbit threads + the in_progress/zombie
+    # override, HIMMEL-980). The CI gate evaluates NON-CodeRabbit check-runs
+    # only — the tests/lint/build CI this repo otherwise has no guard for
+    # (brief WHY: "a red or still-running non-CodeRabbit check"). This also
+    # keeps a hung CodeRabbit check-run (a known CodeRabbit quirk the zombie
+    # override exists for) from false-blocking here. The combined commit STATUS
+    # below is still evaluated in full (it is the overall aggregate).
+    local runs runs_count red red_names pending
+    runs=$(gh api "repos/$owner/$name/commits/$head/check-runs?per_page=100" 2>/dev/null) || { _cig_degrade "check-runs query failed"; return 0; }
+    # runs_count (ALL check-runs, incl. CodeRabbit) doubles as the parse canary
+    # AND feeds the checkless-PR check: a CodeRabbit-only repo has runs_count>0
+    # so it is NOT noisy-"checkless"; its non-CodeRabbit CI is vacuously green.
+    runs_count=$(printf '%s' "$runs" | jq -r '.check_runs | length' 2>/dev/null || true)
+    if [ -z "$runs_count" ]; then _cig_degrade "check-runs parse failed"; return 0; fi
+    # >100 check-runs: this single page cannot certify green — a failing or
+    # pending run may sit on an unread page 2. A merge SAFETY gate must not pass
+    # on that uncertainty, so BLOCK (fail-closed on the page limit, same stance
+    # as cr-merge-gate's thread paging, HIMMEL-980). `.total_count` is the total
+    # across all pages; the `.check_runs` array is capped at per_page=100.
+    runs_total=$(printf '%s' "$runs" | jq -r '.total_count // 0' 2>/dev/null || true)
+    if [ -z "$runs_total" ]; then _cig_degrade "check-runs total_count parse failed"; return 0; fi
+    if [ "${runs_total:-0}" -gt "${runs_count:-0}" ] 2>/dev/null; then
+        echo "BLOCK: PR #$num head $head has $runs_total check-runs (> one page of $runs_count) — cannot certify CI green from a single page. Bypass: CI_MERGE_GATE_OK=1."
+        return 2
+    fi
+    red=$(printf '%s' "$runs" | jq -r \
+        '[.check_runs[]? | select(.name!="CodeRabbit") | select(.conclusion=="failure" or .conclusion=="timed_out" or .conclusion=="cancelled" or .conclusion=="action_required" or .conclusion=="startup_failure" or .conclusion=="stale")] | length' \
+        2>/dev/null || true)
+    if [ -z "$red" ]; then _cig_degrade "check-runs parse failed (red)"; return 0; fi
+    if [ "$red" -gt 0 ] 2>/dev/null; then
+        red_names=$(printf '%s' "$runs" | jq -r \
+            '[.check_runs[]? | select(.name!="CodeRabbit") | select(.conclusion=="failure" or .conclusion=="timed_out" or .conclusion=="cancelled" or .conclusion=="action_required" or .conclusion=="startup_failure" or .conclusion=="stale") | .name // "?"] | join(", ")' \
+            2>/dev/null || true)
+        echo "BLOCK: PR #$num head $head has failing checks [${red_names:-?}] — CI not green. Bypass: CI_MERGE_GATE_OK=1."
+        return 2
+    fi
+    pending=$(printf '%s' "$runs" | jq -r \
+        '[.check_runs[]? | select(.name!="CodeRabbit") | select(.status!="completed")] | length' \
+        2>/dev/null || true)
+    if [ -z "$pending" ]; then _cig_degrade "check-runs parse failed (pending)"; return 0; fi
+    if [ "$pending" -gt 0 ] 2>/dev/null; then
+        echo "BLOCK: PR #$num head $head has $pending check(s) still running — wait for green. Bypass: CI_MERGE_GATE_OK=1."
+        return 2
+    fi
+
+    # 2) combined commit status on the head SHA. Block on .state=="failure",
+    # or .state=="pending" with >=1 status (total_count>0). "success"/empty is
+    # ok. This catches legacy status contexts not surfaced as check-runs.
+    # Parse total_count FIRST as the parse-failure canary: a valid payload
+    # yields a number (0 for a status-less commit); a jq parse failure yields
+    # empty (degrade, fail open).
+    local statuses state total
+    statuses=$(gh api "repos/$owner/$name/commits/$head/status" 2>/dev/null) || { _cig_degrade "status query failed"; return 0; }
+    total=$(printf '%s' "$statuses" | jq -r '.total_count // 0' 2>/dev/null || true)
+    if [ -z "$total" ]; then _cig_degrade "status parse failed"; return 0; fi
+    state=$(printf '%s' "$statuses" | jq -r '.state // empty' 2>/dev/null || true)
+    if [ "$state" = "failure" ] || [ "$state" = "error" ]; then
+        echo "BLOCK: PR #$num head $head has a $state commit status — CI not green. Bypass: CI_MERGE_GATE_OK=1."
+        return 2
+    fi
+    if [ "$state" = "pending" ] && [ "${total:-0}" -gt 0 ] 2>/dev/null; then
+        echo "BLOCK: PR #$num head $head has $total pending commit status(es) — wait for green. Bypass: CI_MERGE_GATE_OK=1."
+        return 2
+    fi
+
+    # 3) No red/pending evidence. A PR with ZERO check-runs AND zero commit
+    # statuses is checkless (no CI configured for the repo/branch) — fail open
+    # with a note, do NOT block (operator rule: block ONLY on positive evidence).
+    if [ "$runs_count" -eq 0 ] 2>/dev/null && [ "$total" -eq 0 ] 2>/dev/null; then
+        _cig_degrade "no check-runs and no commit statuses on head $head (checkless PR?)"
+        return 0
+    fi
+    return 0
+}

--- a/scripts/lib/test-ci-green-gate.sh
+++ b/scripts/lib/test-ci-green-gate.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Tests for scripts/lib/ci-green-gate.sh (HIMMEL-1043). Hermetic: gh is stubbed.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+export HOME="$TMP/home"; mkdir -p "$HOME"
+
+# ── stub gh ──────────────────────────────────────────────────────────────────
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$*" >> "${GH_STUB_LOG:?}"
+case "${GH_STUB_MODE:?}" in
+  error) exit 1 ;;   # gh pr view itself fails -> rc=3 selector-unresolvable
+esac
+case "$1 $2" in
+  "pr view")
+    echo '{"number":42,"headRefOid":"abc123","url":"https://github.com/o/r/pull/42"}' ;;
+  "api repos/o/r/commits/abc123/check-runs"*)
+    case "$GH_STUB_MODE" in
+      api-error)    exit 1 ;;                                  # downstream API fail -> rc=0 fail-open
+      red-run)     echo '{"check_runs":[{"name":"CI Build","status":"completed","conclusion":"failure"}]}' ;;
+      pending-run) echo '{"check_runs":[{"name":"CI Lint","status":"in_progress","conclusion":null}]}' ;;
+      many-runs)   echo '{"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}],"total_count":150}' ;;
+      checkless)   echo '{"check_runs":[]}' ;;
+      *)           echo '{"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}' ;;
+    esac ;;
+  "api repos/o/r/commits/abc123/status")
+    case "$GH_STUB_MODE" in
+      red-status) echo '{"state":"failure","total_count":1,"statuses":[{"context":"ci/legacy","state":"failure"}]}' ;;
+      pend-status) echo '{"state":"pending","total_count":2,"statuses":[{"context":"ci/a","state":"pending"},{"context":"ci/b","state":"pending"}]}' ;;
+      error-status) echo '{"state":"error","total_count":1,"statuses":[{"context":"ci/legacy","state":"error"}]}' ;;
+      checkless)  echo '{"state":"","total_count":0,"statuses":[]}' ;;
+      *)          echo '{"state":"success","total_count":1,"statuses":[{"context":"ci/legacy","state":"success"}]}' ;;
+    esac ;;
+  *) echo '{}' ;;
+esac
+EOF
+chmod +x "$TMP/bin/gh"
+export PATH="$TMP/bin:$PATH"
+
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/ci-green-gate.sh"
+
+pass=0; fail=0
+t() { # t <name> <expected-rc> — runs ci_green_gate 42 o/r with current env
+  local name="$1" want="$2" rc=0
+  export GH_STUB_LOG="$TMP/calls-$name.log"; : > "$GH_STUB_LOG"
+  ci_green_gate 42 o/r >"$TMP/out-$name" 2>"$TMP/err-$name" || rc=$?
+  if [ "$rc" = "$want" ]; then pass=$((pass+1)); echo "ok   $name"
+  else fail=$((fail+1)); echo "FAIL $name (rc=$rc want=$want)"; sed 's/^/  err: /' "$TMP/err-$name"; fi
+}
+
+GH_STUB_MODE=clean         t all-green-allows 0
+GH_STUB_MODE=red-run       t failing-checkrun-blocks 2
+GH_STUB_MODE=pending-run   t pending-checkrun-blocks 2
+GH_STUB_MODE=red-status    t status-failure-blocks 2
+GH_STUB_MODE=pend-status   t status-pending-blocks 2
+GH_STUB_MODE=error-status  t status-error-blocks 2          # codex-1: combined status 'error' must block
+GH_STUB_MODE=many-runs     t over-100-checkruns-blocks 2    # codex-2: >100 check-runs can't certify green -> block
+GH_STUB_MODE=checkless     t checkless-pr-allows 0
+# pr view itself fails -> rc=3 (selector unresolvable; still an allow, but lets
+# the hook retry with a better anchor — mirrors cr_merge_gate, codex-1)
+GH_STUB_MODE=error         t gh-pr-view-fails-rc3 3
+# pr view succeeds, downstream check-runs API fails -> plain rc=0 fail-open
+GH_STUB_MODE=api-error     t api-error-fails-open 0
+
+# bypass env short-circuits BEFORE any gh call (independent of CR_PROFILE)
+GH_STUB_MODE=red-run CI_MERGE_GATE_OK=1 t bypass-env-allows 0
+[ -s "$TMP/calls-bypass-env-allows.log" ] && { echo "FAIL bypass called gh"; fail=$((fail+1)); }
+unset CI_MERGE_GATE_OK
+# CR_PROFILE must NOT affect the CI gate (it is independent of the CodeRabbit gate)
+GH_STUB_MODE=red-run CR_PROFILE=none t cr-profile-none-still-blocks 2
+unset CR_PROFILE
+
+# block reasons land on stdout
+grep -qi "failing checks" "$TMP/out-failing-checkrun-blocks" || { echo "FAIL block reason missing (red-run)"; fail=$((fail+1)); }
+grep -qi "still running" "$TMP/out-pending-checkrun-blocks" || { echo "FAIL block reason missing (pending-run)"; fail=$((fail+1)); }
+grep -qi "commit status" "$TMP/out-status-failure-blocks" || { echo "FAIL block reason missing (red-status)"; fail=$((fail+1)); }
+# degradation notes land on stderr on the fail-open shapes
+grep -qi "degraded" "$TMP/err-gh-pr-view-fails-rc3" || { echo "FAIL degradation note missing (rc3)"; fail=$((fail+1)); }
+grep -qi "degraded" "$TMP/err-api-error-fails-open" || { echo "FAIL degradation note missing (rc0)"; fail=$((fail+1)); }
+grep -qi "degraded" "$TMP/err-checkless-pr-allows" || { echo "FAIL degradation note missing (checkless)"; fail=$((fail+1)); }
+# a real-green head is a SILENT pass (no degrade noise)
+[ ! -s "$TMP/err-all-green-allows" ] || { echo "FAIL all-green emitted stderr"; cat "$TMP/err-all-green-allows"; fail=$((fail+1)); }
+
+# head-SHA binding: the gate must query check-runs + status on the head SHA
+# from `gh pr view` (abc123), proving it binds to the head, not a stale ref.
+grep -q "commits/abc123/check-runs" "$TMP/calls-all-green-allows.log" || { echo "FAIL head-SHA not bound (check-runs)"; fail=$((fail+1)); }
+grep -q "commits/abc123/status"      "$TMP/calls-all-green-allows.log" || { echo "FAIL head-SHA not bound (status)"; fail=$((fail+1)); }
+
+echo "pass=$pass fail=$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
A pre-merge guard that refuses to merge a PR until CI is green on its head SHA:

- new `scripts/lib/ci-green-gate.sh` (+ `test-ci-green-gate.sh`)
- wired into `scripts/handover/pr-merge.sh` and the
  `block-unresolved-cr-merge.sh` hook
- `docs/internals/enforcement.md` documents the gate

Propagated from private himmel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CI-green merge gate that prevents pull requests from merging when non-CodeRabbit checks or commit statuses indicate failing or pending CI.
  * Added a dedicated CI gate bypass option for exceptional cases.
  * Added clear merge-blocking and degraded-status messages.

* **Documentation**
  * Documented the CI-green merge gate, its behavior, ordering, bypass option, and failure conditions.

* **Tests**
  * Added coverage for failing, pending, green, bypass, and degraded CI scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->