### PR TITLE
refactor(dispatch): drop feature-dev:code-architect fallback, rely on Plan/minerva

### DIFF
--- a/.agents/skills/cavecrew/SKILL.md
+++ b/.agents/skills/cavecrew/SKILL.md
@@ -20,7 +20,7 @@ Cavecrew = three subagent presets that emit caveman output. Same job as Anthropi
 | "Where is X defined / what calls Y / list uses of Z" | `cavecrew-investigator` |
 | Same but you also want suggestions/architecture commentary | `Explore` (vanilla) |
 | Surgical edit, ≤2 files, scope obvious | `cavecrew-builder` |
-| New feature / 3+ files / cross-cutting refactor | Main thread or `feature-dev:code-architect` |
+| New feature / 3+ files / cross-cutting refactor | Main thread or the built-in `Plan` agent |
 | Review diff, branch, or file for bugs | `cavecrew-reviewer` |
 | Deep code review with rationale + alternatives | `Code Reviewer` (vanilla) |
 | One-line answer you already know | Main thread, no subagent |

--- a/.claude/commands/overnight-shift.md
+++ b/.claude/commands/overnight-shift.md
@@ -46,8 +46,8 @@ dispatch step from `docs/handover/overnight-mode.md`.
    in parallel (single message, multiple Agent tool calls):
 
    - `description`: `Implement <KEY>` (3-5 words).
-   - `subagent_type`: `general-purpose` (or `feature-dev:feature-dev`
-     for larger features — pick based on ticket type/scope).
+   - `subagent_type`: `general-purpose` (the default). For architecture-heavy
+     tickets, run the built-in `Plan` agent first to design the implementation plan.
    - `isolation`: `worktree` (each subagent gets its own copy of the
      repo on the target branch).
    - `prompt`: The subagent prompt from the plan + the standard

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -431,7 +431,7 @@ exits 2.
 
 **Decision shape:** a dispatch is only DENY-eligible when BOTH
 `subagent_type` is in the allow-list {`general-purpose`, `claude`,
-`feature-dev:code-architect`} AND `model` is in {`sonnet`, `opus`, `fable`,
+`Plan`} AND `model` is in {`sonnet`, `opus`, `fable`,
 absent/empty}. An absent/empty `model` is DENY-eligible per the HIMMEL-972
 operator ruling: an unnamed dispatch inherits the parent loop.
 `model == haiku` always allows regardless of shape. Beyond the allow-list
@@ -473,7 +473,7 @@ prefix does not reach the hook process).
 `block-docker-privesc`); live only after `/himmel-update` (marketplace
 re-sync) + a fresh session.
 
-Spec: `scripts/hooks/test-guard-implementor-dispatch.sh` (22 test cases, 40
+Spec: `scripts/hooks/test-guard-implementor-dispatch.sh` (24 test cases, 43
 assertions).
 
 ### `block-glm-external-writes.sh` — GLM-lane external-write deny (HIMMEL-654)

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -617,7 +617,7 @@ chokepoint above, and returns final `meta.json` status + the worker branch +
 failure) — the parent owns review + merge. **`guard-implementor-dispatch`
 (HIMMEL-920) orthogonality:** that hook gates an ALLOW-LIST of
 implementor-shaped `subagent_type`s (`general-purpose`, `claude`,
-`feature-dev:code-architect`) against the Claude 5-hour bank;
+`Plan`) against the Claude 5-hour bank;
 `claudex-subagent` is not in that list (exactly like `glm-subagent`) and
 spends the codex weekly bank instead — the two guards deliberately don't
 overlap. The codex-lane cost control is the bank preflight above, not

--- a/marketplace/plugins/himmel-ops/agents/claudex-subagent.md
+++ b/marketplace/plugins/himmel-ops/agents/claudex-subagent.md
@@ -14,7 +14,7 @@ have Bash only — by design.
 
 `guard-implementor-dispatch` (the 5-hour-Claude-bank cost guard on Agent
 dispatches, HIMMEL-920) gates an ALLOW-LIST of implementor-shaped
-`subagent_type`s (`general-purpose`, `claude`, `feature-dev:code-architect`)
+`subagent_type`s (`general-purpose`, `claude`, `Plan`)
 with an empty/sonnet/opus/fable model. This agent's `subagent_type` —
 `himmel-ops:claudex-subagent` — is NOT in that list, so dispatching it never
 trips HIMMEL-920, exactly like `himmel-ops:glm-subagent`. That is correct,

--- a/scripts/hooks/guard-implementor-dispatch.sh
+++ b/scripts/hooks/guard-implementor-dispatch.sh
@@ -26,7 +26,7 @@
 #   5. DENY-tier eligibility is an ALLOW-LIST of known-expensive implementor
 #      shapes (critic Q2 — a deny-list would false-block future reviewer
 #      agent types): subagent_type in {general-purpose, claude,
-#      feature-dev:code-architect} AND model in {sonnet, opus, fable, absent/
+#      Plan} AND model in {sonnet, opus, fable, absent/
 #      empty}. An absent/empty model IS DENY-eligible (HIMMEL-972 operator
 #      ruling 2026-07-12: an unnamed dispatch inherits the parent loop — the
 #      exact expensive shape this guard exists for; supersedes the original
@@ -117,7 +117,7 @@ model_lc=$(printf '%s' "$model" | tr '[:upper:]' '[:lower:]')
 # (critic Q2: a deny-list would false-block future reviewer agent types).
 subagent_in_set=0
 case "$subagent_type" in
-    general-purpose|claude|feature-dev:code-architect) subagent_in_set=1 ;;
+    general-purpose|claude|Plan) subagent_in_set=1 ;;
 esac
 model_in_set=0
 case "$model_lc" in

--- a/scripts/hooks/test-guard-implementor-dispatch.sh
+++ b/scripts/hooks/test-guard-implementor-dispatch.sh
@@ -229,6 +229,21 @@ printf '{"five_hour":{"utilization":85,"resets_at":"%s"}}' "$(date -u -d "@$(( $
 RC18=$(run_hook t18 "$(payload_full general-purpose sonnet 'implement the fix')"     IMPL_GUARD_CACHE_PATH="$CACHE18")
 assert_rc "T18 fractional-ISO future resets_at rc (deny)" 2 "$RC18"
 
+# T19/T20 (HIMMEL-1045): the DENY allow-list swapped feature-dev:code-architect
+# → the built-in Plan agent. At util=85 + sonnet + impl prompt:
+#   - feature-dev:code-architect is NO LONGER in-set → not hard-deny (rc=0).
+#   - Plan IS in-set → hard-deny (rc=2), same shape as T1's general-purpose.
+CACHE19="$TMP/cache19.json"; mkcache "$CACHE19" 85
+RC19=$(run_hook t19 "$(payload_full feature-dev:code-architect sonnet 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE19")
+assert_rc "T19 feature-dev:code-architect removed-from-set rc (allow)" 0 "$RC19"
+
+CACHE20="$TMP/cache20.json"; mkcache "$CACHE20" 85
+RC20=$(run_hook t20 "$(payload_full Plan sonnet 'implement the fix')" \
+    IMPL_GUARD_CACHE_PATH="$CACHE20")
+assert_rc "T20 Plan in-set hard-deny rc" 2 "$RC20"
+assert_contains "T20 Plan in-set deny stderr names glm-subagent" "glm-subagent" "$(cat "$TMP/err-t20")"
+
 echo ""
 echo "Results: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Drops the legacy `feature-dev:code-architect` fallback lane:

- `scripts/hooks/guard-implementor-dispatch.sh` (+ test) no longer references it
- doc/skill references updated (enforcement.md, tooling-catalog.md,
  overnight-shift command, cavecrew + claudex-subagent skills)

Planning now relies on the Plan agent / minerva pipeline.

Propagated from private himmel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent dispatch guidance to standardize general-purpose agents and use the built-in Plan agent for architecture-heavy work.
  * Revised tooling and enforcement documentation to reflect the updated dispatch rules.

* **Bug Fixes**
  * Updated dispatch enforcement so Plan-based implementor requests receive the correct bank-based blocking behavior.

* **Tests**
  * Added coverage confirming Plan requests are blocked appropriately while the former architecture agent remains allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->