### PR TITLE
fix(claudex): [HIMMEL-1037] robust to transient codex OAuth refresh gap (pre-launch auth preflight)

### DIFF
--- a/scripts/claude-codex
+++ b/scripts/claude-codex
@@ -75,10 +75,17 @@ fi
 
 RESEED=0
 FORCE=0
+PREFLIGHT_ONLY=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --reseed) RESEED=1; shift ;;
     --force)  FORCE=1;  shift ;;
+    # HIMMEL-1037: cheap auth/liveness probe for the background dispatcher's
+    # PRE-LAUNCH backoff — run the proxy preflight and exit (0=healthy,
+    # 2=unavailable) WITHOUT launching a worker, so spawn-claudex can wait out
+    # the transient 503 auth_unavailable OAuth-refresh gap before it ever spins
+    # a worker (and never re-runs one, which could duplicate side effects).
+    --preflight-only) PREFLIGHT_ONLY=1; shift ;;
     *) break ;;
   esac
 done
@@ -472,7 +479,10 @@ seed_with_lock() {
   rmdir "$LOCK" 2>/dev/null || echo "claude-codex: WARNING - failed to release seed lock $LOCK (not empty or busy); it self-heals via stale steal after ${SEED_LOCK_STALE}s but concurrent launches wait/time out until then." >&2
 }
 
-if [ ! -f "$CONFIG_DIR/.seeded" ] || [ "$RESEED" -eq 1 ] || config_seed_stale; then
+# HIMMEL-1037: a --preflight-only probe never launches claude, so it needs no
+# seeded config dir — skip the (potentially heavy) seed entirely to keep the
+# per-dispatch auth probe cheap.
+if [ "$PREFLIGHT_ONLY" -ne 1 ] && { [ ! -f "$CONFIG_DIR/.seeded" ] || [ "$RESEED" -eq 1 ] || config_seed_stale; }; then
   seed_with_lock
 fi
 
@@ -502,6 +512,61 @@ case "$proxy_hostport" in
     ;;
 esac
 
+# HIMMEL-1037 auth-gap probe (--preflight-only): detect the transient
+# 503 auth_unavailable OAuth-refresh gap by exercising the REAL upstream codex
+# provider. /v1/models is served from CLIProxyAPI's model REGISTRY and stays 200
+# during the gap (codex-adv CR — a registry GET is blind to upstream OAuth
+# readiness), so the probe makes a minimal 1-token /v1/messages call (the lane's
+# actual Anthropic-shaped transport) and classifies ONLY a confirmed 503 /
+# auth_unavailable as retryable. Exit 2 = gap (dispatcher backs off); exit 0 =
+# healthy OR any non-gap status (let the real run surface a genuine config
+# error). Key via `-K -` (curl config on stdin), never argv (CR HIMMEL-979).
+if [ "$PREFLIGHT_ONLY" -eq 1 ]; then
+  # NO test seam here (coderabbit CR): an env-driven stand-in for the probe result
+  # would let ambient/inherited env fake this auth gate. Tests drive the REAL curl
+  # against a controlled loopback endpoint via CODEX_PROXY_BASE_URL instead.
+  if ! command -v curl >/dev/null 2>&1; then
+    # The background gate FAILS CLOSED without curl (codex-adv CR): it cannot
+    # verify the proxy/auth, so reporting healthy would let the unattended
+    # dispatcher launch a worker blind and recreate the exact startup failure.
+    # exit 21 (fatal) → probeClaudexAuth "fatal" → the dispatcher aborts before
+    # any worktree. (The regular launch preflight below keeps its fail-open
+    # warning — a human is watching an interactive launch.)
+    echo "claude-codex: --preflight-only needs curl to verify codex auth — refusing to report healthy without it (fatal)." >&2
+    exit 21
+  fi
+  probe_out="$(printf 'header "Authorization: Bearer %s"\n' "$CLIPROXY_API_KEY" \
+    | curl -s -w '\n%{http_code}' -m 8 --noproxy '*' -K - \
+      -H 'content-type: application/json' -H 'anthropic-version: 2023-06-01' \
+      -d '{"model":"'"$CODEX_MODEL"'","max_tokens":1,"messages":[{"role":"user","content":"ping"}]}' \
+      "$CODEX_PROXY_BASE_URL/v1/messages" 2>/dev/null)"
+  curl_rc=$?   # curl's OWN exit — a nonzero rc means the transfer FAILED
+  probe_code="${probe_out##*$'\n'}"   # last line = %{http_code} (000 on connect failure)
+  # Transport-status guard (codex-adv CR): trust %{http_code} ONLY when curl
+  # itself succeeded. A partial/stalled 200 (headers arrive, then the body times
+  # out or truncates) prints "200" yet exits nonzero (e.g. 28 = timeout) — that
+  # is NOT healthy. A nonzero curl rc is a transport failure → transient (retry).
+  # We control the curl invocation (validated loopback URL, no user args), so the
+  # deterministic-config curl rc's do not occur at runtime; all nonzero = transient.
+  if [ "$curl_rc" -ne 0 ]; then exit 20; fi
+  # Three DISTINCT outcomes so the caller never confuses them (HIMMEL-1037,
+  # codex-adv CR): exit 0 = auth healthy (any 2xx); exit 20 = TRANSIENT and
+  # retry-worthy — the 503/auth_unavailable refresh gap PLUS other momentary
+  # failures that clear on their own (000 transport/proxy-restart, 429 rate
+  # limit, any 5xx gateway hiccup); exit 21 = a DETERMINISTIC failure that a
+  # retry cannot fix (4xx auth/config — 400/401/403/404…) → the caller ABORTS
+  # before minting a worktree. A non-2xx must NEVER read as healthy.
+  case "$probe_code" in
+    2??) exit 0 ;;              # any 2xx = upstream healthy
+    429|5??|000) exit 20 ;;     # rate-limit / any 5xx / transport failure = transient
+    *)
+      case "$probe_out" in
+        *auth_unavailable*) exit 20 ;;   # the gap can arrive with a non-5xx status too
+        *) exit 21 ;;                    # deterministic 4xx (400/401/403/404…) = fatal
+      esac ;;
+  esac
+fi
+
 # Proxy preflight: the lane is dead without a running cli-proxy-api. Advisory
 # curl absence (fail-open with a warning); a refused/timed-out proxy is fatal.
 # The Authorization header travels via `-K -` (curl config on stdin), never the
@@ -513,6 +578,9 @@ if command -v curl >/dev/null 2>&1; then
     exit 2
   fi
 else
+  # curl absent: cannot probe. For --preflight-only fail OPEN (exit 0) so the
+  # dispatcher still proceeds — mirrors the launch path's curl-absent skip.
+  [ "$PREFLIGHT_ONLY" -eq 1 ] && exit 0
   echo "claude-codex: WARNING - curl not found; skipping proxy reachability preflight." >&2
 fi
 

--- a/scripts/claude-codex.ps1
+++ b/scripts/claude-codex.ps1
@@ -99,11 +99,15 @@ if ([string]::IsNullOrEmpty($key)) {
 # --- flags lead, rest passes to claude verbatim ------------------------------
 $Reseed = $false
 $Force  = $false
+# HIMMEL-1037: --preflight-only mirrors the bash twin — a cheap auth/liveness
+# probe (0=healthy, 2=unavailable) that exits without launching a worker.
+$PreflightOnly = $false
 $ClaudeArgs = [System.Collections.Generic.List[string]]::new()
 $leading = $true
 foreach ($a in $args) {
   if ($leading -and ($a -ieq '-Reseed' -or $a -ieq '--reseed')) { $Reseed = $true; continue }
   if ($leading -and ($a -ieq '-Force'  -or $a -ieq '--force'))  { $Force  = $true; continue }
+  if ($leading -and ($a -ieq '-PreflightOnly' -or $a -ieq '--preflight-only')) { $PreflightOnly = $true; continue }
   $leading = $false
   $ClaudeArgs.Add($a)
 }
@@ -573,7 +577,8 @@ function Invoke-SeedWithLock {
   }
 }
 
-if ((-not (Test-Path -LiteralPath (Join-Path $ConfigDir '.seeded'))) -or $Reseed -or (Test-ConfigSeedStale)) {
+# HIMMEL-1037: a --preflight-only probe never launches claude, so skip seeding.
+if ((-not $PreflightOnly) -and ((-not (Test-Path -LiteralPath (Join-Path $ConfigDir '.seeded'))) -or $Reseed -or (Test-ConfigSeedStale))) {
   Invoke-SeedWithLock
 }
 
@@ -598,6 +603,36 @@ if (-not $isLoopback) {
   [Console]::Error.WriteLine("claude-codex: WARNING - non-loopback proxy ($proxyHostPort) under CLAUDE_CODEX_REMOTE_PROXY_OK=1. Key + session content WILL leave this machine.")
 }
 
+# HIMMEL-1037 auth-gap probe (--preflight-only): detect the transient
+# 503 auth_unavailable OAuth-refresh gap by exercising the REAL upstream codex
+# provider. /v1/models is served from CLIProxyAPI's model REGISTRY and stays 200
+# during the gap (codex-adv CR), so probe a minimal 1-token /v1/messages call
+# (the lane's Anthropic-shaped transport) and classify ONLY a confirmed 503 /
+# auth_unavailable as retryable. exit 2 = gap; exit 0 = healthy or any non-gap
+# status (let the real run surface a genuine error). Mirrors the bash twin.
+if ($PreflightOnly) {
+  try {
+    $body = '{"model":"' + $CodexModel + '","max_tokens":1,"messages":[{"role":"user","content":"ping"}]}'
+    Invoke-WebRequest -UseBasicParsing -TimeoutSec 8 -NoProxy -Method Post `
+      -Headers @{Authorization="Bearer $key"; 'content-type'='application/json'; 'anthropic-version'='2023-06-01'} `
+      -Body $body -Uri "$CodexProxyBaseUrl/v1/messages" | Out-Null
+    exit 0   # any 2xx = upstream healthy (Invoke-WebRequest throws on non-2xx)
+  } catch {
+    # Three DISTINCT outcomes (HIMMEL-1037, codex-adv CR), mirroring the bash
+    # twin: exit 20 = TRANSIENT (auth_unavailable gap, 429 rate-limit, any 5xx,
+    # OR a connection failure with no response = proxy restart); exit 21 =
+    # DETERMINISTIC 4xx (400/401/403/404…) a retry cannot fix → the caller ABORTS.
+    # A non-2xx never reads healthy (Invoke-WebRequest throws on non-2xx).
+    $resp = $_.Exception.Response
+    $code = $null; if ($resp) { try { $code = [int]$resp.StatusCode } catch { } }
+    if (("$_" -match 'auth_unavailable')) { exit 20 }
+    if ($code -eq 429) { exit 20 }
+    if ($null -ne $code -and $code -ge 500 -and $code -le 599) { exit 20 }  # any 5xx = transient
+    if ($null -eq $code) { exit 20 }                                        # no response = transport failure = transient
+    exit 21   # deterministic 4xx = fatal
+  }
+}
+
 # --- proxy preflight ---------------------------------------------------------
 # The lane is dead without a running cli-proxy-api; a refused/timed-out proxy is fatal.
 try {
@@ -609,6 +644,8 @@ try {
   [Console]::Error.WriteLine("claude-codex: proxy not reachable at $CodexProxyBaseUrl — start cli-proxy-api (and complete --codex-login) first. See docs/tooling-catalog.md#claude-codex.")
   exit 2
 }
+# Probe healthy — the dispatcher may now spin the worker (this run does not).
+if ($PreflightOnly) { exit 0 }
 
 # --- launch: env contract mirrors the bash `exec env … claude "$@"` -----------
 # The CLAUDE_CODE_*/ENABLE_TOOL_SEARCH values follow the field-tested claudex

--- a/scripts/telegram/spawn-claudex.test.ts
+++ b/scripts/telegram/spawn-claudex.test.ts
@@ -12,6 +12,7 @@ import {
   planClaudexSharedSpawn,
   gitBranchExists,
   gitIsDirty,
+  revalidateSharedWorktree,
   runClaudexSharedDispatch,
   parseClaudexArgs,
   codexBankLogPath,
@@ -20,6 +21,11 @@ import {
   parsePct,
   evaluateCodexBankPreflight,
   detectClaudexCap,
+  parseAuthRetryDelaysMs,
+  probeClaudexAuth,
+  runAuthPreflightWithBackoff,
+  DEFAULT_AUTH_RETRY_DELAYS_MS,
+  CLAUDEX_PREFLIGHT_GAP_EXIT,
   claudexLauncherPath,
   buildClaudexRunArgs,
   claudexChildEnv,
@@ -242,6 +248,72 @@ test("runClaudexSharedDispatch: acquires under lane 'codex' (not 'glm'), restore
   } finally { rmSync(repo, { recursive: true, force: true }); }
 });
 
+test("revalidateSharedWorktree: fresh worktree (needsWorktreeAdd) -> ok when the mapping is still absent, never checks dirtiness", () => {
+  let dirtyChecked = 0;
+  const r = revalidateSharedWorktree({ needsWorktreeAdd: true, branch: "feat/x", worktree: "/wt", worktreeOf: () => null, isDirty: () => { dirtyChecked++; return true; } });
+  expect(r.ok).toBe(true);
+  expect(dirtyChecked).toBe(0); // a to-be-created worktree has nothing to check dirty
+});
+
+test("revalidateSharedWorktree: needsWorktreeAdd but a concurrent dispatch already created the mapping -> refuse (no duplicate worktree add) (codex/coderabbit CR)", () => {
+  const r = revalidateSharedWorktree({ needsWorktreeAdd: true, branch: "feat/x", worktree: "/repo/.claude/worktrees/claudex+feat-x", worktreeOf: () => ({ path: "/repo/.claude/worktrees/claudex+feat-x", isPrimary: false }), isDirty: () => false });
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.reason).toContain("concurrent dispatch");
+});
+
+test("revalidateSharedWorktree: branch switched/recreated under the lock -> refuse (would commit to the wrong branch)", () => {
+  // branch no longer maps to any worktree
+  const gone = revalidateSharedWorktree({ needsWorktreeAdd: false, branch: "feat/x", worktree: "/repo/.claude/worktrees/feat+x", worktreeOf: () => null, isDirty: () => false });
+  expect(gone.ok).toBe(false);
+  if (!gone.ok) expect(gone.reason).toContain("changed under the lock");
+  // branch now maps to a DIFFERENT worktree path
+  const moved = revalidateSharedWorktree({ needsWorktreeAdd: false, branch: "feat/x", worktree: "/repo/.claude/worktrees/feat+x", worktreeOf: () => ({ path: "/repo/.claude/worktrees/other", isPrimary: false }), isDirty: () => false });
+  expect(moved.ok).toBe(false);
+  // branch now checked out in the PRIMARY checkout
+  const primary = revalidateSharedWorktree({ needsWorktreeAdd: false, branch: "feat/x", worktree: "/repo/.claude/worktrees/feat+x", worktreeOf: () => ({ path: "/repo", isPrimary: true }), isDirty: () => false });
+  expect(primary.ok).toBe(false);
+});
+
+test("revalidateSharedWorktree: same worktree but DIRTY -> refuse; same worktree + clean -> ok (path-separator tolerant)", () => {
+  const dirty = revalidateSharedWorktree({ needsWorktreeAdd: false, branch: "feat/x", worktree: "/repo/.claude/worktrees/feat+x", worktreeOf: () => ({ path: "/repo/.claude/worktrees/feat+x", isPrimary: false }), isDirty: () => true });
+  expect(dirty.ok).toBe(false);
+  if (!dirty.ok) expect(dirty.reason).toContain("dirty");
+  // Windows backslash path from git worktree list still matches the join()ed worktree
+  const okWin = revalidateSharedWorktree({ needsWorktreeAdd: false, branch: "feat/x", worktree: "C:\\repo\\.claude\\worktrees\\feat+x", worktreeOf: () => ({ path: "C:/repo/.claude/worktrees/feat+x", isPrimary: false }), isDirty: () => false });
+  expect(okWin.ok).toBe(true);
+});
+
+test("runClaudexSharedDispatch: revalidateClean refusal short-circuits (runBody never runs) and RELEASES the lock (codex-adv CR)", async () => {
+  const { repo, wt } = makeSharedRepo();
+  try {
+    let ranBody = false;
+    const res = await runClaudexSharedDispatch({
+      repoDir: repo, worktree: wt, branch: "feat/live-pr", needsWorktreeAdd: false, lockScript: LOCK_SCRIPT,
+      gitAdd: () => {}, runBody: async () => { ranBody = true; return 0; },
+      revalidateClean: () => ({ ok: false as const, reason: "worktree went dirty under the lock" }),
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("dirty");
+    expect(ranBody).toBe(false);                     // body never ran on stale/dirty state
+    expect(lockStatus(repo, "feat/live-pr")).toBe("free"); // lock released via the finally
+  } finally { rmSync(repo, { recursive: true, force: true }); }
+});
+
+test("runClaudexSharedDispatch: revalidateClean ok -> proceeds normally (runBody runs)", async () => {
+  const { repo, wt } = makeSharedRepo();
+  try {
+    let ranBody = false;
+    const res = await runClaudexSharedDispatch({
+      repoDir: repo, worktree: wt, branch: "feat/live-pr", needsWorktreeAdd: false, lockScript: LOCK_SCRIPT,
+      gitAdd: () => {}, runBody: async () => { ranBody = true; return 0; },
+      revalidateClean: () => ({ ok: true as const }),
+    });
+    expect(res.ok).toBe(true);
+    expect(ranBody).toBe(true); // ok revalidation lets the body run
+    expect(lockStatus(repo, "feat/live-pr")).toBe("free");
+  } finally { rmSync(repo, { recursive: true, force: true }); }
+});
+
 test("runClaudexSharedDispatch: owner.json records lane 'codex'", async () => {
   const { repo, wt } = makeSharedRepo();
   try {
@@ -321,6 +393,27 @@ test("parseClaudexArgs table: valid flags / positional-only / NaN timeout / trai
   const force = parseClaudexArgs(["p", "--force"]);
   expect(force.ok).toBe(true);
   expect((force as any).args.force).toBe(true);
+});
+
+test("parseClaudexArgs: --skip-auth-preflight is an EXPLICIT per-invocation flag, default false (codex-adv CR)", () => {
+  const off = parseClaudexArgs(["do x"]);
+  expect(off.ok).toBe(true);
+  if (off.ok) expect(off.args.skipAuthPreflight).toBe(false);
+  const on = parseClaudexArgs(["do x", "--skip-auth-preflight"]);
+  expect(on.ok).toBe(true);
+  if (on.ok) { expect(on.args.skipAuthPreflight).toBe(true); expect(on.args.task).toBe("do x"); }
+});
+
+test("no AMBIENT env can bypass or fake the auth gate — the only override is the explicit flag (source-text guard, codex-adv CR)", () => {
+  const src = readFileSync("scripts/telegram/spawn-claudex.ts", "utf8");
+  // the env bypass is GONE: a stale/inherited var must not silently disable the gate
+  expect(src.includes("CLAUDEX_SKIP_AUTH_PREFLIGHT")).toBe(false);
+  // the override is the parsed CLI flag, and it warns loudly
+  expect(src.includes("if (skipAuthPreflight)")).toBe(true);
+  expect(/--skip-auth-preflight given[\s\S]*?DISABLED/.test(src)).toBe(true);
+  // and the launcher carries no fake-response seam either
+  const bash = readFileSync("scripts/claude-codex", "utf8");
+  expect(bash.includes("CLAUDEX_PREFLIGHT_FAKE")).toBe(false);
 });
 
 test("parseClaudexArgs: --branch and --name are mutually exclusive", () => {
@@ -433,6 +526,259 @@ test("detectClaudexCap: generic sentinels match, unrelated text does not", () =>
   expect(detectClaudexCap("some other error")).toBe(false);
   expect(detectClaudexCap("")).toBe(false);
 });
+
+// --- pre-launch auth preflight (HIMMEL-1037) ----------------------------------
+
+test("parseAuthRetryDelaysMs: default fallback / custom seconds->ms / invalid / empty / trailing comma", () => {
+  const fb = DEFAULT_AUTH_RETRY_DELAYS_MS;
+  expect(parseAuthRetryDelaysMs(undefined, fb)).toEqual(fb);
+  expect(parseAuthRetryDelaysMs("", fb)).toEqual(fb);
+  expect(parseAuthRetryDelaysMs("   ", fb)).toEqual(fb);
+  expect(parseAuthRetryDelaysMs("1,2,3", fb)).toEqual([1000, 2000, 3000]);
+  expect(parseAuthRetryDelaysMs("0,0", fb)).toEqual(fb); // all-zero schedule -> fallback (0 budget can't probe; coderabbit CR)
+  expect(parseAuthRetryDelaysMs("0", fb)).toEqual(fb);   // single zero likewise
+  expect(parseAuthRetryDelaysMs("0,5", fb)).toEqual([0, 5000]); // a zero mixed with a real delay is fine (nonzero total)
+  expect(parseAuthRetryDelaysMs("1.5", fb)).toEqual([1500]);
+  expect(parseAuthRetryDelaysMs("5, 10 ,15", fb)).toEqual([5000, 10000, 15000]); // whitespace trimmed
+  expect(parseAuthRetryDelaysMs("15,,30", fb)).toEqual([15000, 30000]); // empty token dropped
+  expect(parseAuthRetryDelaysMs("nope", fb)).toEqual(fb); // non-numeric -> fallback
+  expect(parseAuthRetryDelaysMs("10,-5", fb)).toEqual(fb); // negative -> fallback
+  expect(parseAuthRetryDelaysMs("1e308", fb)).toEqual(fb); // finite secs overflows ms to Infinity -> fallback (coderabbit CR)
+  // setTimeout signed-32-bit cap (codex-adv CR): a single value past the cap falls back
+  expect(parseAuthRetryDelaysMs("999999999", fb)).toEqual(fb);            // ~1e9 s -> 1e12 ms > timer cap -> fallback
+  // aggregate + attempt caps (codex-adv r9): total <= 180s and <= 8 delays, else fallback
+  expect(parseAuthRetryDelaysMs("60,60,60", fb)).toEqual([60000, 60000, 60000]); // 180s exactly = allowed
+  expect(parseAuthRetryDelaysMs("60,60,61", fb)).toEqual(fb);                    // 181s > 3min aggregate -> fallback
+  expect(parseAuthRetryDelaysMs("2147483.647", fb)).toEqual(fb);                 // ~25-day single sleep: under timer cap but over aggregate -> fallback
+  expect(parseAuthRetryDelaysMs("1,1,1,1,1,1,1,1", fb)).toEqual([1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000]); // 8 delays = allowed
+  expect(parseAuthRetryDelaysMs("1,1,1,1,1,1,1,1,1", fb)).toEqual(fb);           // 9 delays > MAX_AUTH_RETRY_ATTEMPTS -> fallback
+});
+
+test("runAuthPreflightWithBackoff: a healthy first probe returns ready immediately, never sleeps", async () => {
+  let probes = 0; const slept: number[] = [];
+  const r = await runAuthPreflightWithBackoff(
+    () => { probes++; return "ok"; },
+    { delaysMs: [1, 2, 3], sleep: async (ms) => { slept.push(ms); }, log: () => {} },
+  );
+  expect(r).toEqual({ ready: true, fatal: false, attempts: 1 });
+  expect(probes).toBe(1);
+  expect(slept).toEqual([]);
+});
+
+test("runAuthPreflightWithBackoff: unavailable-then-ok backs off then proceeds (worker spawns only after auth is healthy)", async () => {
+  let probes = 0; const slept: number[] = []; const logs: string[] = [];
+  const r = await runAuthPreflightWithBackoff(
+    () => { probes++; return probes < 3 ? "unavailable" : "ok"; },
+    { delaysMs: [15000, 45000, 120000], sleep: async (ms) => { slept.push(ms); }, log: (m) => logs.push(m) },
+  );
+  expect(r).toEqual({ ready: true, fatal: false, attempts: 3 });
+  expect(probes).toBe(3);
+  expect(slept).toEqual([15000, 45000]); // backed off twice before the 3rd probe went ok
+  expect(logs[0]).toContain("auth unavailable");
+});
+
+test("runAuthPreflightWithBackoff: persistent unavailability returns not-ready after the whole schedule (caller refuses)", async () => {
+  let probes = 0; const slept: number[] = []; const logs: string[] = [];
+  const r = await runAuthPreflightWithBackoff(
+    () => { probes++; return "unavailable"; },
+    { delaysMs: [1, 2, 3], sleep: async (ms) => { slept.push(ms); }, log: (m) => logs.push(m), now: () => 0 }, // frozen clock: full budget available
+  );
+  expect(r).toEqual({ ready: false, fatal: false, attempts: 4 }); // initial + 3 backoffs
+  expect(probes).toBe(4);
+  expect(slept).toEqual([1, 2, 3]); // the whole schedule, in order
+  expect(logs[logs.length - 1]).toContain("refusing");
+});
+
+test("runAuthPreflightWithBackoff: worst case runs the FULL schedule (n+1 attempts, every delay intact) and never exceeds the deadline (codex-adv + coderabbit CR)", async () => {
+  // A pure clock advanced by BOTH the sleep (its wait) and the probe (its full
+  // clamped timeout) — worst case: every probe burns its whole budget and the gap
+  // persists. The deadline reserves a probe allowance, so the advertised schedule
+  // still runs end-to-end AND elapsed never passes the (honest) bound.
+  let clock = 0;
+  const now = () => clock;                                          // pure read
+  const slept: number[] = [];
+  const probe = (t: number) => { expect(t).toBeGreaterThanOrEqual(0); clock += t; return "unavailable" as const; };
+  const sleep = async (ms: number) => { clock += ms; slept.push(ms); };
+  const delaysMs = [10_000, 20_000, 30_000];
+  const r = await runAuthPreflightWithBackoff(probe, { delaysMs, sleep, now });
+  expect(r.ready).toBe(false);
+  expect(r.fatal).toBe(false);
+  expect(r.attempts).toBe(delaysMs.length + 1); // 4 attempts — the final wait IS followed by a probe
+  expect(slept).toEqual(delaysMs);              // every configured delay ran in full, none truncated
+  // honest hard bound: Σdelays + (n+1) probe allowance
+  expect(clock).toBeLessThanOrEqual(60_000 + 4 * 12_000);
+});
+
+test("runAuthPreflightWithBackoff: recovery on the LAST probe (after the final delay) is still detected", async () => {
+  let probes = 0;
+  const r = await runAuthPreflightWithBackoff(
+    () => { probes++; return probes < 4 ? "unavailable" : "ok"; }, // healthy only on the 4th (post-final-delay) probe
+    { delaysMs: [10_000, 20_000, 30_000], sleep: async () => {}, now: () => 0 },
+  );
+  expect(r).toEqual({ ready: true, fatal: false, attempts: 4 });
+});
+
+test("runAuthPreflightWithBackoff: a FATAL probe returns immediately (no backoff, no doomed worker) — first probe and mid-loop", async () => {
+  // fatal on the very first probe -> abort at once
+  let probes = 0; const slept: number[] = [];
+  const r = await runAuthPreflightWithBackoff(
+    () => { probes++; return "fatal"; },
+    { delaysMs: [1, 2, 3], sleep: async (ms) => { slept.push(ms); } },
+  );
+  expect(r).toEqual({ ready: false, fatal: true, attempts: 1 });
+  expect(probes).toBe(1);
+  expect(slept).toEqual([]);
+  // unavailable then fatal -> abort on the 2nd probe, one backoff only
+  let probes2 = 0; const slept2: number[] = [];
+  const r2 = await runAuthPreflightWithBackoff(
+    () => { probes2++; return probes2 === 1 ? "unavailable" : "fatal"; },
+    { delaysMs: [5, 6, 7], sleep: async (ms) => { slept2.push(ms); } },
+  );
+  expect(r2).toEqual({ ready: false, fatal: true, attempts: 2 });
+  expect(slept2).toEqual([5]);
+});
+
+test("probeClaudexAuth: exit 0 -> ok, exit 20 (gap) -> unavailable, exit 2/other (permanent) -> fatal", () => {
+  // A hermetic fake launcher at <repoRoot>/scripts/claude-codex controlled by an env var.
+  const repoRoot = mkdtempSync(join(tmpdir(), "cxprobe-"));
+  try {
+    mkdirSync(join(repoRoot, "scripts"), { recursive: true });
+    writeFileSync(join(repoRoot, "scripts", "claude-codex"), '#!/usr/bin/env bash\nexit "${FAKE_PREFLIGHT_RC:-0}"\n');
+    const withRc = (rc: string, fn: () => void) => { const prev = process.env.FAKE_PREFLIGHT_RC; process.env.FAKE_PREFLIGHT_RC = rc; try { fn(); } finally { if (prev === undefined) delete process.env.FAKE_PREFLIGHT_RC; else process.env.FAKE_PREFLIGHT_RC = prev; } };
+    withRc("0", () => expect(probeClaudexAuth(repoRoot, repoRoot)).toBe("ok"));
+    withRc(String(CLAUDEX_PREFLIGHT_GAP_EXIT), () => expect(probeClaudexAuth(repoRoot, repoRoot)).toBe("unavailable")); // 20 = transient gap
+    withRc("2", () => expect(probeClaudexAuth(repoRoot, repoRoot)).toBe("fatal")); // missing-key = permanent
+    withRc("5", () => expect(probeClaudexAuth(repoRoot, repoRoot)).toBe("fatal")); // any other nonzero = permanent
+  } finally { rmSync(repoRoot, { recursive: true, force: true }); }
+});
+
+test("probeClaudexAuth: a probe that exceeds the per-probe timeout is KILLED and read as transient, never fatal (codex/coderabbit CR)", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "cxprobe-to-"));
+  try {
+    mkdirSync(join(repoRoot, "scripts"), { recursive: true });
+    writeFileSync(join(repoRoot, "scripts", "claude-codex"), '#!/usr/bin/env bash\nsleep 30\n'); // hangs well past the cap
+    const t = Date.now();
+    const r = probeClaudexAuth(repoRoot, repoRoot, 800); // 0.8s hard cap
+    expect(Date.now() - t).toBeLessThan(5000);           // killed promptly, not after 30s
+    expect(r).toBe("unavailable");                       // timed-out probe = transient, not fatal
+  } finally { rmSync(repoRoot, { recursive: true, force: true }); }
+}, 15_000);
+
+test("auth preflight wiring: main() probes with backoff BEFORE the plan + worktree, refuses on !ready, revalidates the shared worktree (source-text pins)", () => {
+  const src = readFileSync("scripts/telegram/spawn-claudex.ts", "utf8");
+  expect(src.includes("runAuthPreflightWithBackoff((t) => probeClaudexAuth(")).toBe(true);
+  expect(src.includes("parseAuthRetryDelaysMs(process.env.CLAUDEX_AUTH_RETRY_DELAYS")).toBe(true);
+  // the worker itself runs exactly once — no retry wrapper around runClaudexSession
+  expect(src.includes("run: runClaudexSession")).toBe(true);
+  const preIdx = src.indexOf("runAuthPreflightWithBackoff((t) => probeClaudexAuth("); // the CALL in main, not the definition
+  const planIdx = src.indexOf("planClaudexSharedSpawn(absCwd");
+  const wtIdx = src.indexOf('"worktree", "add"');
+  expect(preIdx).toBeGreaterThan(-1);
+  // side-effect-free plan validation runs BEFORE the (billable) auth probe, and
+  // the probe runs BEFORE any worktree mutation (codex-adv CR: a deterministic
+  // local refusal must fail fast, never behind an auth probe)
+  expect(planIdx).toBeGreaterThan(-1);
+  expect(planIdx).toBeLessThan(preIdx);
+  expect(preIdx).toBeLessThan(wtIdx);
+  // refuse (abort) on !ready — covers BOTH pf.fatal (permanent) and exhausted transient
+  const notReadyIdx = src.indexOf("if (!pf.ready)");
+  expect(notReadyIdx).toBeGreaterThan(-1);
+  expect(notReadyIdx).toBeLessThan(wtIdx);
+  // the reused shared worktree is re-validated (identity + cleanliness) under the lock (codex-adv CR)
+  expect(src.includes("revalidateClean:")).toBe(true);
+  expect(src.includes("revalidateSharedWorktree({")).toBe(true);
+});
+
+test("claude-codex --preflight-only probes /v1/messages (NOT the registry) and exits before exec claude (launcher source pins)", () => {
+  const bash = readFileSync("scripts/claude-codex", "utf8");
+  expect(bash.includes("--preflight-only) PREFLIGHT_ONLY=1")).toBe(true);
+  // the probe hits the real upstream transport, not the gap-blind registry
+  expect(bash.includes('"$CODEX_PROXY_BASE_URL/v1/messages"')).toBe(true);
+  // transient statuses (429/5xx/000/auth_unavailable) map to the DEDICATED retry code 20; 4xx -> fatal 21
+  expect(bash.includes("429|5??|000) exit 20 ;;")).toBe(true);
+  expect(bash.includes("*auth_unavailable*) exit 20")).toBe(true);
+  expect(bash.includes("*) exit 21 ;;")).toBe(true);
+  expect(CLAUDEX_PREFLIGHT_GAP_EXIT).toBe(20); // TS + launcher agree on the gap code
+  // the probe block sits before exec claude, and seeding is skipped for a probe
+  const probeIdx = bash.indexOf('if [ "$PREFLIGHT_ONLY" -eq 1 ]; then');
+  const execIdx = bash.indexOf('exec claude "$@"');
+  expect(probeIdx).toBeGreaterThan(-1);
+  expect(probeIdx).toBeLessThan(execIdx);
+  expect(bash.includes('[ "$PREFLIGHT_ONLY" -ne 1 ] &&')).toBe(true); // seeding skip
+  // NO production test seam: ambient env must never be able to fake the auth gate (coderabbit CR)
+  expect(bash.includes("CLAUDEX_PREFLIGHT_FAKE_HTTP")).toBe(false);
+  expect(bash.includes("CLAUDEX_PREFLIGHT_FAKE_CURL_RC")).toBe(false);
+  expect(bash.includes("CLAUDEX_PREFLIGHT_ASSUME_NO_CURL")).toBe(false);
+  const ps1 = readFileSync("scripts/claude-codex.ps1", "utf8");
+  expect(ps1.includes('/v1/messages')).toBe(true);
+  expect(ps1.includes("if ($PreflightOnly) {")).toBe(true);
+  // .ps1 classifier mirrors the bash three-way outcome (codex-adv CR)
+  expect(ps1.includes("exit 20")).toBe(true);
+  expect(ps1.includes("exit 21")).toBe(true);
+});
+
+test("claude-codex --preflight-only classifies REAL HTTP responses: 2xx->0, 503/auth_unavailable/429/5xx->20, 4xx->21, connect-fail->20 (live loopback endpoint, no production seam)", async () => {
+  // Drives the launcher's REAL curl against a controlled loopback server — no
+  // env stand-in for the probe result (a production seam would let ambient env
+  // fake this auth gate; coderabbit CR). Loopback keeps the trust-boundary check
+  // happy. A missing key would exit 2 first, so pass a dummy CLIPROXY_API_KEY.
+  let status = 200, body = '{"ok":true}';
+  const server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response(body, { status }) });
+  const base = `http://127.0.0.1:${server.port}`;
+  // ASYNC spawn (not spawnSync): spawnSync blocks this process's event loop, so
+  // the in-process Bun.serve above could never answer curl — every probe would
+  // time out and read transient. Await the child instead.
+  const run = async (s: number, b: string, urlOverride?: string): Promise<number> => {
+    status = s; body = b;
+    const p = Bun.spawn(["bash", "scripts/claude-codex", "--preflight-only"], {
+      cwd: process.cwd(),
+      env: { ...process.env, CLIPROXY_API_KEY: "test-key", CODEX_PROXY_BASE_URL: urlOverride ?? base } as Record<string, string>,
+      stdout: "pipe", stderr: "pipe",
+    });
+    return await p.exited;
+  };
+  try {
+    expect(await run(200, '{"ok":true}')).toBe(0);                    // 2xx healthy
+    expect(await run(204, "")).toBe(0);                               // any 2xx
+    expect(await run(503, "auth_unavailable")).toBe(20);              // the gap
+    expect(await run(500, '{"type":"auth_unavailable"}')).toBe(20);   // gap by body
+    expect(await run(500, "internal error")).toBe(20);                // any 5xx = transient
+    expect(await run(502, "bad gateway")).toBe(20);                   // 5xx transient
+    expect(await run(429, "slow down")).toBe(20);                     // rate limit = transient
+    expect(await run(400, "bad request")).toBe(21);                   // deterministic 4xx = fatal
+    expect(await run(401, "invalid api key")).toBe(21);               // bad key = fatal
+    expect(await run(403, "forbidden")).toBe(21);                     // fatal
+    expect(await run(404, "not found")).toBe(21);                     // fatal
+    // transport failure: nothing listening on this loopback port -> curl rc!=0,
+    // http_code 000 -> transient, never healthy (codex-adv r9/r10). Bind an
+    // ephemeral port and release it rather than assuming a fixed one is free —
+    // a squatter on a hardcoded port would make this nondeterministic (coderabbit).
+    const dead = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("") });
+    const deadPort = dead.port;
+    dead.stop(true);
+    expect(await run(200, "x", `http://127.0.0.1:${deadPort}`)).toBe(20);
+  } finally { server.stop(true); }
+}, 60_000); // sequential bash spawns are slow on Windows — well past bun-test's 5s default
+
+test("claude-codex --preflight-only: a stalled body (200 headers, then hang) is NOT healthy — curl transport rc wins (coderabbit/codex-adv r10)", async () => {
+  // The launcher's curl uses -m 8; a server that sends a 200 then never finishes
+  // the body makes curl exit 28 (timeout) while %{http_code} still reads 200.
+  // The transport-status guard must classify that transient (20), never 0.
+  const server = Bun.serve({
+    port: 0, hostname: "127.0.0.1",
+    fetch: () => new Response(new ReadableStream({ start() { /* headers sent; body never completes */ } }), { status: 200 }),
+  });
+  try {
+    // async spawn — spawnSync would block the loop and stall the server for the
+    // WRONG reason, making this pass without exercising the partial-200 path
+    const p = Bun.spawn(["bash", "scripts/claude-codex", "--preflight-only"], {
+      cwd: process.cwd(),
+      env: { ...process.env, CLIPROXY_API_KEY: "test-key", CODEX_PROXY_BASE_URL: `http://127.0.0.1:${server.port}` } as Record<string, string>,
+      stdout: "pipe", stderr: "pipe",
+    });
+    expect(await p.exited).toBe(20); // partial 200 + curl rc 28 -> transient, NOT healthy
+  } finally { server.stop(true); }
+}, 30_000);
 
 // --- dispatch-command construction (D1: through claude-codex, no ANTHROPIC_*) ---
 

--- a/scripts/telegram/spawn-claudex.ts
+++ b/scripts/telegram/spawn-claudex.ts
@@ -165,10 +165,43 @@ export function gitIsDirty(worktreePath: string): boolean {
   return r.stdout.toString().trim().length > 0;
 }
 
+// Under-the-lock revalidation of a REUSED shared worktree (HIMMEL-1037,
+// codex-adv CR). The plan's pre-lock checks can go stale between then and lock
+// acquisition — the worktree could be switched to another branch, recreated, or
+// dirtied by a concurrent worker. Re-resolve identity + cleanliness so the
+// worker never commits onto the WRONG branch or another worker's mixed state:
+//   - fresh worktree (needsWorktreeAdd) ⇒ nothing to revalidate, ok.
+//   - the branch must still map to the SAME non-primary worktree path.
+//   - that worktree must be clean.
+// Deps injected (worktreeOf/isDirty) so it is unit-tested without real git.
+export function revalidateSharedWorktree(deps: {
+  needsWorktreeAdd: boolean; branch: string; worktree: string;
+  worktreeOf: (b: string) => { path: string; isPrimary: boolean } | null;
+  isDirty: (p: string) => boolean;
+}): { ok: true } | { ok: false; reason: string } {
+  const norm = (p: string) => p.replace(/\\/g, "/").replace(/\/$/, "");
+  const wtNow = deps.worktreeOf(deps.branch);
+  if (deps.needsWorktreeAdd) {
+    // Planned to CREATE the worktree — but under the lock a concurrent dispatch
+    // may have created the branch→worktree mapping during the backoff; a second
+    // `git worktree add` would then fail. Refuse cleanly instead (codex-adv/
+    // coderabbit CR). Absent mapping ⇒ ours to create, proceed.
+    if (wtNow) return { ok: false, reason: `spawn-claudex: worktree for ${deps.branch} was created by a concurrent dispatch during the preflight (now ${wtNow.path}) — refusing the duplicate worktree-add; re-dispatch (HIMMEL-1037).` };
+    return { ok: true };
+  }
+  if (!wtNow || wtNow.isPrimary || norm(wtNow.path) !== norm(deps.worktree)) {
+    return { ok: false, reason: `spawn-claudex: shared worktree for ${deps.branch} changed under the lock (no longer the expected non-primary worktree ${deps.worktree}) — refusing before launch (a worker could commit to the wrong branch); re-dispatch (HIMMEL-1037).` };
+  }
+  if (deps.isDirty(deps.worktree)) {
+    return { ok: false, reason: `spawn-claudex: reused worktree ${deps.worktree} became dirty before the lock (a concurrent shared worker left uncommitted changes) — refusing rather than commit onto mixed state; commit/stash there and re-dispatch (HIMMEL-1037).` };
+  }
+  return { ok: true };
+}
+
 // ── args parsing ──────────────────────────────────────────────────────────
 
 export type EffortLevel = "low" | "medium" | "high" | "xhigh";
-export type ClaudexParsedArgs = { task?: string; cwd: string; name?: string; branch?: string; timeoutMins?: number; permMode?: PermissionMode; effort?: EffortLevel; force: boolean };
+export type ClaudexParsedArgs = { task?: string; cwd: string; name?: string; branch?: string; timeoutMins?: number; permMode?: PermissionMode; effort?: EffortLevel; force: boolean; skipAuthPreflight: boolean };
 
 // Pure + validated, mirrors spawn-glm's parseArgs (a value-taking flag with no
 // value, or a non-positive/non-finite --timeout-mins, is a usage refusal).
@@ -184,6 +217,7 @@ export function parseClaudexArgs(argv: string[]): { ok: true; args: ClaudexParse
   let permMode: PermissionMode | undefined;
   let effort: EffortLevel | undefined;
   let force = false;
+  let skipAuthPreflight = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--cwd") { const v = argv[++i]; if (v === undefined) return { ok: false, error: "--cwd requires a value" }; cwd = v; }
@@ -205,10 +239,14 @@ export function parseClaudexArgs(argv: string[]): { ok: true; args: ClaudexParse
       effort = v;
     }
     else if (a === "--force") force = true;
+    // Auth-preflight override is an EXPLICIT per-invocation flag, never an env
+    // var: an ambient/inherited setting must not be able to silently disable the
+    // fail-closed auth gate and restore the original startup failure (codex-adv CR).
+    else if (a === "--skip-auth-preflight") skipAuthPreflight = true;
     else if (task === undefined) task = a;
   }
   if (branch !== undefined && name !== undefined) return { ok: false, error: "--branch and --name are mutually exclusive (shared mode derives the slug from the branch)" };
-  return { ok: true, args: { task, cwd, name, branch, timeoutMins, permMode, effort, force } };
+  return { ok: true, args: { task, cwd, name, branch, timeoutMins, permMode, effort, force, skipAuthPreflight } };
 }
 
 // ── codex weekly bank preflight (HIMMEL-1003 D4) ────────────────────────────
@@ -316,6 +354,162 @@ export function detectClaudexCap(output: string): boolean {
   return CLAUDEX_CAP_SENTINELS.some((r) => r.test(output));
 }
 
+// ── transient codex OAuth refresh-gap PRE-LAUNCH preflight (HIMMEL-1037) ────
+//
+// The CLIProxyAPI codex gateway (127.0.0.1:8317) returns 503 auth_unavailable
+// during the ~seconds window while the codex OAuth *access* token is
+// mid-refresh — a transient ~1h-lapse window, NOT a dead credential. A
+// BACKGROUND dispatch that starts up inside that window dies immediately; the
+// proven 2026-07-15 incident was 3 back-to-back immediate retries all landing
+// in the SAME gap (an interactive retry a minute later worked, because the
+// human waited).
+//
+// We fix this BEFORE launching the worker — never by re-running one. `probe`
+// runs `claude-codex --preflight-only` (the launcher's OWN authed 1-token
+// /v1/messages check — the registry /v1/models stays 200 during the gap, so it
+// must exercise the real upstream; exits 0=healthy / 20=transient-retry /
+// 21=fatal WITHOUT spinning a worker) and is retried with backoff until auth is
+// healthy or fatal/exhausted; only then does the caller mint
+// the worktree and spawn the worker, exactly once. A worker's allowed side
+// effects (Jira writes, outbox appends — see the worker prompt) can therefore
+// never be duplicated by a re-run: post-hoc "did the worker do work?" inference
+// is unsound (codex-adv CR), so a pre-execution auth signal is the only safe
+// gate. It also avoids minting a worktree for a doomed run. Interactive
+// cc-codex needs none of this — its human provides the retry delay — so this
+// lives only in the background dispatcher; claude-codex still owns the authed
+// call (the probe just asks it), keeping the D1 trust boundary intact.
+
+// Backoff schedule between preflight probe attempts: 10s/20s/30s (=60s total).
+// The refresh gap is a ~seconds window, so a modest schedule catches the common
+// case; a gap that outlasts the whole schedule hits the refuse-on-exhaustion
+// path (main), not an ever-longer wait. The total is deliberately BOUNDED and
+// small because the preflight runs in the FOREGROUND before the worker — a
+// long backoff plus a multi-minute worker could exceed a caller's foreground
+// dispatch budget (codex-adv CR). Immediate (0-delay) retries are futile (the
+// gap outlasts them). Overridable via CLAUDEX_AUTH_RETRY_DELAYS (comma-separated
+// SECONDS); an empty/invalid value falls back (parsePct style).
+export const DEFAULT_AUTH_RETRY_DELAYS_MS = [10_000, 20_000, 30_000];
+export function parseAuthRetryDelaysMs(raw: string | undefined, fallbackMs: number[]): number[] {
+  const s = raw?.trim();
+  if (s === undefined || s === "") return fallbackMs;
+  const toks = s.split(",").map((t) => t.trim()).filter((t) => t !== "");
+  if (toks.length === 0) return fallbackMs;
+  const secs = toks.map((t) => Number(t));
+  if (secs.some((n) => !Number.isFinite(n) || n < 0)) return fallbackMs;
+  const ms = secs.map((n) => Math.round(n * 1000));
+  // Reject an absurd schedule rather than defeat the backoff (both CR):
+  //  - 1e308 s overflows to Infinity once scaled to ms (coderabbit);
+  //  - a finite value past Bun/Node's signed-32-bit setTimeout cap
+  //    (2147483647 ms) is silently reset to ~1ms → immediate retry (codex-adv);
+  //  - too many attempts, OR an aggregate that exceeds the bounded FOREGROUND
+  //    deadline, would strand the invoking parent (codex-adv: a per-value cap
+  //    alone still allows a ~25-day single sleep). Require a safe integer within
+  //    the timer cap, at most MAX_AUTH_RETRY_ATTEMPTS delays, summing within
+  //    MAX_TOTAL_BACKOFF_MS — else fall back to the small default.
+  if (ms.some((n) => !Number.isSafeInteger(n) || n > MAX_TIMER_MS)) return fallbackMs;
+  if (ms.length > MAX_AUTH_RETRY_ATTEMPTS) return fallbackMs;
+  const totalMs = ms.reduce((a, b) => a + b, 0);
+  // An all-zero schedule (e.g. "0,0") has budgetMs 0 → the deadline is `now()`,
+  // so the very first probe gets a 0ms timeout and the loop breaks before any
+  // re-probe: zero effective retries AND a killed first probe. Immediate retries
+  // are documented futile anyway, so fall back to the real default (coderabbit CR).
+  if (totalMs === 0 || totalMs > MAX_TOTAL_BACKOFF_MS) return fallbackMs;
+  return ms;
+}
+// Bun/Node setTimeout delay is a signed 32-bit int; a larger value fires ~immediately.
+export const MAX_TIMER_MS = 2_147_483_647;
+// The preflight runs in the FOREGROUND before the worker, so its total wall-clock
+// is hard-bounded: at most 8 backoff delays summing to ≤3 min, even under an
+// operator override (codex-adv CR — otherwise a single huge delay strands the parent).
+export const MAX_AUTH_RETRY_ATTEMPTS = 8;
+export const MAX_TOTAL_BACKOFF_MS = 180_000;
+
+// Dedicated launcher exit code for the transient codex OAuth-refresh gap
+// (claude-codex --preflight-only). Keeps the retry from ever firing on a
+// PERMANENT error (missing key = the launcher's early exit 2, egress refusal =
+// 3, etc.), which would otherwise waste the whole backoff then launch a doomed
+// worker (codex-adv CR). Keep in sync with scripts/claude-codex{,.ps1}.
+export const CLAUDEX_PREFLIGHT_GAP_EXIT = 20;
+// Hard per-probe wall-clock cap so ONE synchronous probe can never blow the
+// preflight's absolute deadline (codex/coderabbit CR: spawnSync is not
+// cancellable, so bound it at the source). Comfortably above the launcher's own
+// curl -m 8 plus bash/guard overhead; a probe killed at this cap is transient.
+export const PROBE_TIMEOUT_MS = 12_000;
+export type AuthProbeResult = "ok" | "unavailable" | "fatal";
+
+// Run the launcher's --preflight-only auth probe (no worker spawned). The
+// launcher exercises the REAL upstream provider (a 1-token /v1/messages call),
+// so this distinguishes:
+//   exit 0                        ⇒ "ok"        (auth healthy, or a non-gap
+//                                                 status the real run surfaces)
+//   exit CLAUDEX_PREFLIGHT_GAP_EXIT⇒ "unavailable" (transient 503 refresh gap → retry)
+//   any other nonzero             ⇒ "fatal"     (missing key / config / egress
+//                                                 refusal — permanent; abort, do
+//                                                 NOT retry or mint a worktree)
+// A probe KILLED at PROBE_TIMEOUT_MS (spawnSync timeout → exitCode null +
+// signalCode) is TRANSIENT, not fatal — the gate couldn't complete, so retry
+// within the deadline rather than abort. TELEGRAM_OWN_POLLER is stripped
+// (claudexChildEnv) so the probe never adopts poller ownership.
+export function probeClaudexAuth(repoRoot: string, cwd: string, timeoutMs: number = PROBE_TIMEOUT_MS): AuthProbeResult {
+  const launcherPath = claudexLauncherPath(repoRoot);
+  const r = Bun.spawnSync(["bash", launcherPath, "--preflight-only"], { cwd, stdout: "pipe", stderr: "pipe", env: claudexChildEnv(process.env) as Record<string, string>, timeout: timeoutMs });
+  if (r.exitCode === null || r.signalCode != null) return "unavailable"; // killed / timed out
+  if (r.exitCode === 0) return "ok";
+  if (r.exitCode === CLAUDEX_PREFLIGHT_GAP_EXIT) return "unavailable";
+  return "fatal";
+}
+
+// Poll the auth probe with backoff BEFORE any worktree side-effect. Returns as
+// soon as the probe is decisive:
+//   {ready:true}              — auth healthy, spin the worker.
+//   {fatal:true}             — a permanent config error; the caller aborts
+//                              WITHOUT minting a worktree (no doomed run, no
+//                              wasted backoff).
+//   {ready:false,fatal:false}— still the transient gap after the whole schedule:
+//                              REFUSED by the caller (don't launch into a known
+//                              outage).
+// An ABSOLUTE wall-clock deadline (start + Σdelays) bounds the WHOLE preflight —
+// sleeps AND synchronous probe time — so it can NEVER exceed the budget (codex-adv
+// CR: a per-delay cap alone ignored probe latency, and even a hard per-probe cap
+// let the FINAL probe overshoot). Each backoff AND each probe timeout is clamped
+// to the budget remaining at that instant, and the loop stops the moment the
+// budget is spent — total elapsed ≤ deadline. `probe` receives its clamped
+// timeout (ms); `probe`/`sleep`/`now` are injected so tests never spawn or wait.
+export async function runAuthPreflightWithBackoff(
+  probe: (timeoutMs: number) => AuthProbeResult,
+  deps: { delaysMs: number[]; sleep: (ms: number) => Promise<void>; log?: (m: string) => void; now?: () => number },
+): Promise<{ ready: boolean; fatal: boolean; attempts: number }> {
+  const now = deps.now ?? (() => Date.now());
+  const budgetMs = deps.delaysMs.reduce((a, b) => a + b, 0);
+  // The deadline covers the configured SLEEPS **plus** a probe allowance — one
+  // bounded probe per attempt (n delays ⇒ n+1 attempts). Without the allowance
+  // probe time eats the sleep budget, silently truncating the last delay and
+  // dropping the final probe, so recovery after the last wait is undetectable
+  // and the advertised schedule never runs (coderabbit CR). Worst-case foreground
+  // is therefore Σdelays + (n+1)·PROBE_TIMEOUT_MS — larger, but honest and hard.
+  const probeAllowanceMs = (deps.delaysMs.length + 1) * PROBE_TIMEOUT_MS;
+  const deadline = now() + budgetMs + probeAllowanceMs;
+  const probeBudget = () => Math.min(PROBE_TIMEOUT_MS, Math.max(0, deadline - now()));
+  let res = probe(probeBudget());
+  let attempts = 1;
+  if (res === "ok") return { ready: true, fatal: false, attempts };
+  if (res === "fatal") return { ready: false, fatal: true, attempts };
+  for (let i = 0; i < deps.delaysMs.length; i++) {
+    const remaining = deadline - now();
+    if (remaining <= 0) break; // out of the foreground budget (probes consumed it)
+    const wait = Math.min(deps.delaysMs[i], remaining);
+    deps.log?.(`spawn-claudex: codex auth unavailable (503 refresh gap?) on preflight ${i + 1}/${deps.delaysMs.length + 1}; backing off ${Math.round(wait / 1000)}s before re-probing (HIMMEL-1037)`);
+    await deps.sleep(wait);
+    if (deadline - now() <= 0) break; // budget spent by the sleep — do NOT probe past the deadline
+    res = probe(probeBudget());
+    attempts++;
+    if (res === "ok") return { ready: true, fatal: false, attempts };
+    if (res === "fatal") return { ready: false, fatal: true, attempts };
+  }
+  deps.log?.(`spawn-claudex: codex auth still unavailable after ${attempts} preflight attempt(s) across the ${Math.round(budgetMs / 1000)}s backoff schedule — refusing (likely a real outage, not the transient gap) (HIMMEL-1037)`);
+  return { ready: false, fatal: false, attempts };
+}
+
 // ── dispatch through scripts/claude-codex (D1) ──────────────────────────────
 
 // REPO_ROOT is derived from run.ts's OWN file location (see run.ts) —
@@ -417,12 +611,19 @@ export async function executeClaudexRun(deps: {
 export async function runClaudexSharedDispatch(p: {
   repoDir: string; worktree: string; branch: string; needsWorktreeAdd: boolean;
   lockScript: string; gitAdd: () => void; runBody: () => Promise<number>;
+  // codex-adv CR: re-validate the reused worktree AFTER the lock. The plan's
+  // pre-lock cleanliness check can go stale — another shared worker may run
+  // (and leave uncommitted changes) between it and this acquire. Called right
+  // after acquire, before gitAdd/poison; returns ok:false to refuse (the finally
+  // still releases the lock). Absent ⇒ skipped (own-mode / tests).
+  revalidateClean?: () => { ok: true } | { ok: false; reason: string };
 }): Promise<{ ok: true; code: number } | { ok: false; reason: string }> {
   const acquire = Bun.spawnSync(["bash", p.lockScript, "acquire", p.repoDir, p.branch, "codex"], { stdout: "pipe", stderr: "pipe" });
   if (acquire.exitCode !== 0) return { ok: false, reason: acquire.stderr.toString().trim() || `spawn-claudex: shared-branch-lock acquire failed (rc=${acquire.exitCode})` };
   let priorPushUrl: string | undefined;
   let poisoned = false;
   try {
+    if (p.revalidateClean) { const rv = p.revalidateClean(); if (!rv.ok) return rv; } // stale-clean guard, lock released in finally
     if (p.needsWorktreeAdd) p.gitAdd(); // NO -b: an existing branch, never minted here
     const priorRes = Bun.spawnSync(["git", "-C", p.worktree, "config", "--worktree", "--get", "remote.origin.pushurl"], { stdout: "pipe", stderr: "pipe" });
     if (priorRes.exitCode === 0) {
@@ -465,9 +666,9 @@ export async function runClaudexSharedDispatch(p: {
 // guarding itself, D1).
 async function main(): Promise<void> {
   const parsed = parseClaudexArgs(process.argv.slice(2));
-  const usage = "usage: spawn-claudex <prompt> [--cwd <dir>] [--name <slug>] [--branch <existing-branch>] [--timeout-mins <n>] [--permission-mode bypassPermissions] [--effort low|medium|high|xhigh] [--force]";
+  const usage = "usage: spawn-claudex <prompt> [--cwd <dir>] [--name <slug>] [--branch <existing-branch>] [--timeout-mins <n>] [--permission-mode bypassPermissions] [--effort low|medium|high|xhigh] [--force] [--skip-auth-preflight]";
   if (!parsed.ok) { console.error(`spawn-claudex: ${parsed.error}`); console.error(usage); process.exit(2); }
-  const { task, cwd, name, branch: branchArg, timeoutMins, permMode, effort, force } = parsed.args;
+  const { task, cwd, name, branch: branchArg, timeoutMins, permMode, effort, force, skipAuthPreflight } = parsed.args;
   if (!task) { console.error(usage); process.exit(2); }
   const absCwd = resolve(cwd);
 
@@ -512,6 +713,33 @@ async function main(): Promise<void> {
   const pre = preflightWindowCheck({ briefChars: briefText.length, overheadChars, windowTokens: CLAUDEX_WINDOW_TOKENS });
   if (!pre.ok) { console.error(pre.reason); process.exit(2); }
 
+  // Auth preflight (HIMMEL-1037): wait out a transient codex OAuth-refresh gap
+  // (503 auth_unavailable) BEFORE any worktree side-effect but AFTER all the
+  // side-effect-free local validation (bank/plan/window) — so a deterministic
+  // refusal (bad branch, dirty/primary/trunk worktree, brief-too-big) fails
+  // FAST and locally, never wasting billable probes or masking itself behind an
+  // auth failure (codex-adv CR). The shared-worktree race a long backoff could
+  // open is handled under the lock by runClaudexSharedDispatch.revalidateClean.
+  // REFUSES (no worktree, no worker) on `!ready` — BOTH a permanent failure
+  // (pf.fatal) AND an exhausted transient gap. The probe is claude-codex's own
+  // authed check, so no key is handled here (D1). The ONLY override is the
+  // EXPLICIT per-invocation --skip-auth-preflight flag, never an env var: an
+  // ambient/inherited setting that silently disabled this gate would restore the
+  // exact unattended startup failure this branch fixes (codex-adv CR).
+  if (skipAuthPreflight) {
+    console.error("spawn-claudex: WARNING - --skip-auth-preflight given: the codex auth gate is DISABLED for this dispatch. The worker may launch straight into a 503 refresh gap / invalid auth, die at startup, and strand a worktree (HIMMEL-1037).");
+  } else {
+    const preflightDelaysMs = parseAuthRetryDelaysMs(process.env.CLAUDEX_AUTH_RETRY_DELAYS, DEFAULT_AUTH_RETRY_DELAYS_MS);
+    const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+    const pf = await runAuthPreflightWithBackoff((t) => probeClaudexAuth(REPO_ROOT, absCwd, t), { delaysMs: preflightDelaysMs, sleep, log: (m) => console.error(m) });
+    if (!pf.ready) {
+      console.error(pf.fatal
+        ? "spawn-claudex: codex auth preflight reports a PERMANENT failure (missing/invalid CLIPROXY_API_KEY, a deterministic auth 4xx like 401/403, curl unavailable, or a config/egress refusal — NOT a transient 5xx/timeout, which is retried) — aborting before any worktree; fix the claude-codex config, then re-dispatch (HIMMEL-1037)."
+        : "spawn-claudex: codex auth still unavailable (503 refresh gap / transient 5xx/timeout) after the full backoff budget — refusing rather than launch into a known-doomed auth state (would reproduce the failure and strand a worktree); re-dispatch once the gateway recovers (HIMMEL-1037).");
+      process.exit(2);
+    }
+  }
+
   const g = (args: string[]) => { const r = Bun.spawnSync(["git", "-C", absCwd, ...args], { stdout: "pipe", stderr: "pipe" }); if (r.exitCode !== 0) throw new Error(`git ${args[0]} failed: ${r.stderr.toString()}`); };
 
   // The run body (mkdir sessionDir through executeClaudexRun) is IDENTICAL
@@ -530,6 +758,10 @@ async function main(): Promise<void> {
     const prompt = composeClaudexPointerPrompt(briefPath);
     if (timeoutMins !== undefined) process.env.RUN_TIMEOUT_MS = String(timeoutMins * 60 * 1000);
 
+    // The worker runs EXACTLY ONCE — the transient codex OAuth gap is waited out
+    // by the pre-launch auth preflight in main() (HIMMEL-1037), never by
+    // re-running a worker (which could duplicate the worker's allowed side
+    // effects). No retry wrapper here.
     const { code } = await executeClaudexRun({ run: runClaudexSession, prompt, worktree, permMode, effort, repoRoot: REPO_ROOT, sessionDir, metaPath, runningMeta });
     return code;
   };
@@ -544,7 +776,17 @@ async function main(): Promise<void> {
     // CLAUDE.md Subagent policy). Lock acquired AFTER guards pass, BEFORE any
     // worktree mutation, released in a finally on every catchable exit path.
     const lockScript = join(REPO_ROOT, "scripts", "lib", "shared-branch-lock.sh");
-    const shared = await runClaudexSharedDispatch({ repoDir: absCwd, worktree, branch, needsWorktreeAdd, lockScript, gitAdd: () => g(["worktree", "add", worktree, branch]), runBody });
+    const shared = await runClaudexSharedDispatch({
+      repoDir: absCwd, worktree, branch, needsWorktreeAdd, lockScript,
+      gitAdd: () => g(["worktree", "add", worktree, branch]), runBody,
+      // codex-adv CR: re-resolve the REUSED worktree's identity + cleanliness
+      // under the lock (branch could be switched/dirtied since the plan).
+      revalidateClean: () => revalidateSharedWorktree({
+        needsWorktreeAdd, branch, worktree,
+        worktreeOf: (b) => gitWorktreeOf(absCwd, b),
+        isDirty: (p) => gitIsDirty(p),
+      }),
+    });
     if (!shared.ok) { console.error(shared.reason); process.exit(4); }
     code = shared.code;
   }


### PR DESCRIPTION
Makes the claudex lane robust to the transient codex OAuth refresh gap.

**Approach:** a pre-launch auth preflight rather than a worker retry. `claude-codex --preflight-only` performs a 1-token authed `/v1/messages` probe and exits `0` healthy / `20` transient / `21` fatal. `spawn-claudex` probes with a bounded backoff after all side-effect-free validation, then spawns the worker **exactly once** — a retry could duplicate the worker's Jira/outbox writes. It refuses before creating a worktree on a fatal or exhausted-transient result.

Notes:
- The registry `/v1/models` endpoint stays 200 during the refresh gap, so it is blind to it — the probe deliberately hits `/v1/messages`.
- No ambient env may fake or disable the gate; only an explicit `--skip-auth-preflight` flag, which warns loudly.

**Verification:** 79 tests pass, `bash -n` clean, shellcheck clean, CodeRabbit review completed with 0 findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional authentication preflight check before launching Codex work.
  - Added `--preflight-only` mode to check proxy and upstream availability without starting a worker.
  - Added bounded retries for temporary authentication or service failures.
  - Added `--skip-auth-preflight` for explicit per-run bypassing, with a warning.
  - Added shared-worktree validation to prevent dispatch when mappings, branches, or files are stale or inconsistent.

- **Bug Fixes**
  - Prevented launches when shared worktrees are concurrently reused, modified, or incorrectly mapped.
  - Improved handling of timeout, rate-limit, and upstream service failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->