### PR TITLE
fix(triage-clips): default terminal branch for unmapped clip types

### DIFF
--- a/marketplace/plugins/obsidian-triage/commands/triage-clips.md
+++ b/marketplace/plugins/obsidian-triage/commands/triage-clips.md
@@ -171,7 +171,7 @@ The flag (and its `harvest_flag_detail:` sibling) is never written or cleared by
   - `tweet` → Folder Map `idea` entry, else `<vault>/Ideas/` if it exists, else `<vault>/00-Inbox/`. Cross-suggest a `<vault>/20-Areas/<author>.md` link target if the author has a known person note.
   - `reddit` → Folder Map `discussion`/`resource` entry, else `<vault>/30-Resources/`
   - `newsletter` → Folder Map `newsletter`/`resource` entry, else `<vault>/30-Resources/`
-  - **Unknown `type:`**: log `⊘ <clip> — skipped (phase-6-promotion): unknown type "<type>", no promotion mapping`. Do NOT mark `processed: true` for this clip — let the user inspect.
+  - **Any other `type:` (default — terminal; never halts).** No type-specific mapping. Resolve the promotion target to the Folder Map `resource` entry if present, else `<vault>/30-Resources/` (the same generic bucket `reddit`/`newsletter` fall back to). Annotate the `## Promotion candidate` exactly like a mapped type, with the **Rationale** noting it is a generic default the operator should re-route on promotion (e.g. `no type-specific mapping for "<type>"; generic default — re-route on promotion`). Then continue to Phase 7 + Phase 8 like any mapped type — including the Phase 8 step-0 `ig_media_pending` hold, which still applies to un-enriched instagram clips. This is the closed-mapping guard: no `type:` value falls through to a silent skip, so a newly-introduced type (e.g. `instagram`, `note`) reaches `_evidence/` instead of re-running phases 1–5 forever.
 
 - Write a `## Promotion candidate` section at the end of the clip body (append, do not replace any user content above it):
   ```markdown


### PR DESCRIPTION
## triage-clips: default terminal branch for unmapped clip types

### Problem
`triage-clips` Phase 6 mapped only `youtube / research / article / tweet / reddit / newsletter` to a promotion target. Its last branch **halted** on any other type — logging `no promotion mapping` and never marking `processed: true`. So `type: instagram` and `type: note` clips re-ran phases 1–5 on every triage pass forever, never draining to `Clippings/_evidence/`.

### Root observation
Phase 6 only *annotates an advisory* promotion suggestion — clips are never auto-moved there. The real terminal move is Phase 8 → `_evidence/`, whose `evidence_kind` (`tools/lib/evidence-kind.mjs`) is already a **closed set with a `misc` fallback**. The terminal machinery already handled any type; only Phase 6's open, halting branch blocked the path.

### Fix
Replace the halting unknown-type branch with a **default terminal branch**: any unmapped `type:` resolves to a generic promotion target (Folder Map `resource`, else `<vault>/30-Resources/`) and continues to Phase 7 + Phase 8 like a mapped type. **Closed by construction** — the next unknown type also drains; no per-type allowlist that would silently drop it. One-line prose change; the six mapped bullets, the promotion-candidate template, the logging enum, and Phase 8 (incl. the `ig_media_pending` hold) are untouched.

### Verification
Traced the previously-stuck clips (`instagram`, `note`) through the revised Phase 6: each reaches the default branch → Phase 7 (`processed: true`) → Phase 8 → `_evidence/` with `evidence_kind: [misc]`, none re-enter the removed silent-skip branch.

Ref: HIMMEL-1139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the triage runbook to route unrecognized clip types to the generic Resources location.
  * Added guidance identifying these items as promotion candidates requiring manual rerouting.
  * Ensured unrecognized types continue through later triage phases, including evidence-move hold handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->