### PR TITLE
fix(cr): [HIMMEL-1221] load Z.ai key from .env + merge local critic overlay + minerva paid-fallback

### DIFF
--- a/marketplace/plugins/himmel-ops/skills/minerva/SKILL.md
+++ b/marketplace/plugins/himmel-ops/skills/minerva/SKILL.md
@@ -71,8 +71,11 @@ Resolve paths from the himmel checkout (minerva runs inside it):
 ```bash
 REPO="$(git rev-parse --show-toplevel)"; CR="$REPO/scripts/cr"
 CHARTER="$REPO/marketplace/plugins/himmel-ops/skills/minerva/panel-charter.md"
-# 1. Enumerate the free critic rows:
-node -e 'JSON.parse(require("fs").readFileSync(process.argv[1])).panel.filter(r=>r.tier==="free").forEach(r=>console.log(r.slug+"\t"+r.model))' "$CR/critics.json"
+# 1. Enumerate the advisory critic rows (free-preferred; if the registry has NO
+#    free rows, fall back to the PAID rows rather than an empty panel — an empty
+#    advisory panel silently degrades minerva to claude-only, HIMMEL-1221 G3).
+#    Reads the UNIVERSAL critics.json (adopter-neutral), NOT the operator overlay.
+bash "$CR/advisory-rows.sh" "$CR/critics.json"
 # 2. Per row, critique the spec artifact (dead row exits non-zero → FAIL OPEN, note + continue):
 #    bash "$CR/artifact-critic.sh" --artifact <spec-file> --charter "$CHARTER" --model <model> --slug <slug>
 ```
@@ -109,7 +112,8 @@ contents into the subagent prompt verbatim (no inline second copy — same
 HIMMEL-195 rule as Stage 2).
 
 **⚑ fork-1 ADVISORY panel lane** — mirror Stage 2's lane on the PLAN artifact:
-same free-row enumeration + fail-open + Claude-adjudicates-and-gates, but with
+same `advisory-rows.sh` enumeration (free-preferred, paid-fallback; HIMMEL-1221
+G3) + fail-open + Claude-adjudicates-and-gates, but with
 `--artifact <plan-file> --charter "$REPO/marketplace/plugins/himmel-ops/skills/minerva/plan-charter.md"`
 and the ledger records segmented as `--artifact plan`
 (`cr-scores.sh --artifact plan` reports them). The Claude plan-critic remains the

--- a/scripts/cr/advisory-rows.sh
+++ b/scripts/cr/advisory-rows.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# advisory-rows.sh — enumerate advisory critic rows for the minerva panel lanes.
+#
+# Prefer FREE rows (a cost-free cross-model second opinion); if the registry has
+# NO free rows, fall back to PAID rows rather than an empty panel (HIMMEL-1221
+# G3 — an empty advisory panel silently degrades minerva to claude-only, losing
+# the whole point of the cross-model lane; the paid spend is worth it when free
+# is unavailable). The Claude critic remains the GATE; this panel stays advisory.
+#
+# Prints "slug<TAB>model" per selected row (nothing when the registry is empty
+# or unreadable — the caller treats an empty enumeration as a no-op panel).
+# Arg 1: path to a critics registry JSON (default: the sibling critics.json).
+#
+# Deliberately reads the UNIVERSAL critics.json, not the operator's local overlay
+# — the advisory panel must be adopter-neutral and reproducible, independent of
+# one account's exhausted-quota drops or per-account model swaps. That asymmetry
+# from the CR panel (which is the operator's own gate and honors their overlay)
+# is intentional. Bash 3.2 safe.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REG="${1:-$SCRIPT_DIR/critics.json}"
+
+REG="$REG" node -e '
+  const fs = require("fs");
+  let panel = [];
+  try { panel = JSON.parse(fs.readFileSync(process.env.REG, "utf8")).panel || []; }
+  catch (e) { panel = []; }
+  const rows = panel.filter(r => r && typeof r === "object");
+  const free = rows.filter(r => r.tier === "free");
+  const chosen = free.length ? free : rows.filter(r => r.tier === "paid");
+  const out = chosen.filter(r => r.slug && r.model).map(r => r.slug + "\t" + r.model).join("\n");
+  // Trailing newline when non-empty so naive line-readers never drop the last
+  // row (matches the per-row newline of the console.log enumeration this replaces).
+  process.stdout.write(out ? out + "\n" : "");
+'

--- a/scripts/cr/critic-panel.sh
+++ b/scripts/cr/critic-panel.sh
@@ -29,19 +29,83 @@ export LC_ALL
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CFP="${CRITIC_FIRST_PASS:-$SCRIPT_DIR/critic-first-pass.sh}"
-# Registry resolution (HIMMEL-727 operator-vs-universal split): CRITICS_JSON env
-# (tests/CI) > critics.local.json (gitignored per-operator overlay — carries
-# ACCOUNT state like exhausted free quotas / upgraded models, so the shipped
-# registry stays adopter-neutral) > critics.json (universal defaults).
+INVOKE="${CRITIC_INVOKE:-$SCRIPT_DIR/../hermes/invoke.sh}"
+
+# Registry resolution (HIMMEL-727 split + HIMMEL-1221 merge). CRITICS_JSON env
+# (tests/CI) wins outright. Otherwise critics.json is the BASE and
+# critics.local.json (gitignored per-operator overlay — ACCOUNT state like
+# exhausted free quotas / upgraded models) is MERGED per-slug ON TOP: a local row
+# OVERRIDES or APPENDS by slug, and a local row with "drop":true REMOVES the base
+# row of that slug. Merge (not the pre-1221 wholesale replace) so a stale overlay
+# can no longer silently mask a shipped critic — the glm row HIMMEL-1096 added
+# lived only in critics.json and an overlay predating it dropped it. Test hooks:
+# CRITICS_BASE_JSON / CRITICS_LOCAL_JSON override the two merge inputs.
+_MERGED_REG=""
+_REG_BASE="${CRITICS_BASE_JSON:-$SCRIPT_DIR/critics.json}"
+_REG_LOCAL="${CRITICS_LOCAL_JSON:-$SCRIPT_DIR/critics.local.json}"
 if [ -n "${CRITICS_JSON:-}" ]; then
     REG="$CRITICS_JSON"
-elif [ -f "$SCRIPT_DIR/critics.local.json" ]; then
-    REG="$SCRIPT_DIR/critics.local.json"
-    echo "critic-panel.sh: using operator-local registry critics.local.json" >&2
+elif [ -f "$_REG_LOCAL" ]; then
+    _MERGED_REG="$(mktemp -t critics-merged.XXXXXX)" || _MERGED_REG=""
+    # Early EXIT trap so the validation / arg-parse error exits below can't leak the
+    # merged temp file. The --check and main traps RE-INCLUDE this rm because a
+    # later `trap ... EXIT` REPLACES (not extends) an earlier one.
+    [ -n "$_MERGED_REG" ] && trap 'rm -f "$_MERGED_REG"' EXIT
+    if [ -n "$_MERGED_REG" ] && MERGE_BASE="$_REG_BASE" MERGE_LOCAL="$_REG_LOCAL" node -e '
+        const fs = require("fs");
+        const rd = p => { try { const j = JSON.parse(fs.readFileSync(p, "utf8"));
+            return Array.isArray(j.panel) ? j.panel : []; } catch (e) { return null; } };
+        const base = rd(process.env.MERGE_BASE), local = rd(process.env.MERGE_LOCAL);
+        if (base === null && local === null) process.exit(7);   // both unreadable
+        const bp = base || [], lp = local || [];
+        const drop = new Set(), over = new Map();               // local rows by slug
+        for (const r of lp) { if (r && typeof r === "object" && typeof r.slug === "string") {
+            if (r.drop === true) drop.add(r.slug); else over.set(r.slug, r); } }
+        const out = [], seen = new Set();
+        for (const r of bp) {                                   // base order first
+            if (!r || typeof r !== "object" || typeof r.slug !== "string") { out.push(r); continue; }
+            if (drop.has(r.slug)) { seen.add(r.slug); continue; }
+            out.push(over.has(r.slug) ? over.get(r.slug) : r);  // local override wins
+            seen.add(r.slug);
+        }
+        for (const r of lp) {                                   // local-only appends
+            if (!r || typeof r !== "object" || typeof r.slug !== "string") continue;
+            if (r.drop === true || seen.has(r.slug)) continue;
+            out.push(r); seen.add(r.slug);
+        }
+        process.stdout.write(JSON.stringify({ panel: out }));
+    ' > "$_MERGED_REG" 2>/dev/null; then
+        REG="$_MERGED_REG"
+        echo "critic-panel.sh: merged critics.local.json over critics.json" >&2
+    else
+        # Fail-open to the pre-1221 behavior: local overlay verbatim.
+        echo "critic-panel.sh: overlay merge failed — using critics.local.json verbatim" >&2
+        rm -f "$_MERGED_REG"; _MERGED_REG=""; REG="$_REG_LOCAL"
+    fi
 else
-    REG="$SCRIPT_DIR/critics.json"
+    REG="$_REG_BASE"
 fi
-INVOKE="${CRITIC_INVOKE:-$SCRIPT_DIR/../hermes/invoke.sh}"
+
+# HIMMEL-1221: load the Z.ai critic credential from the primary checkout's .env so
+# the paid glm panel row (provider zai / route_provider glm, HIMMEL-1096)
+# authenticates with NO manual env export — but ONLY when the resolved registry
+# actually contains a Z.ai critic (a "zai"/"glm" provider, route_provider, or
+# slug). load_dotenv forks a subshell per .env line (≈1.5s on Git Bash over a
+# large .env), so gating on need keeps that cost off every free-only / glm-less
+# panel run (the common path). load_dotenv sets a key ONLY when currently UNSET
+# (a live env value wins) and never sources/logs the .env — it extracts only the
+# requested KEY= lines (block-read-secrets safe). Scoped to the CR panel per the
+# HIMMEL-1096 Z.ai-key compliance note; deliberately NOT loaded at the hermes
+# chokepoint (invoke.sh stays auth-agnostic, HIMMEL-278). load_dotenv exports each
+# key it sets, so the child critic-first-pass.sh -> invoke.sh processes inherit it.
+if grep -Eq '"(zai|glm)"' "$REG" 2>/dev/null; then
+    # shellcheck source=../lib/load-dotenv.sh
+    # shellcheck disable=SC1091
+    . "$SCRIPT_DIR/../lib/load-dotenv.sh" 2>/dev/null || true
+    if command -v load_dotenv >/dev/null 2>&1; then
+        load_dotenv GLM_API_KEY ZAI_API_KEY Z_AI_API_KEY 2>/dev/null || true
+    fi
+fi
 
 # Effective tier resolution (HIMMEL-558). CR_PROFILE is AUTHORITATIVE when set —
 # it is the operator's opt-in profile (loaded from .env, exported by /pr-check).
@@ -132,7 +196,7 @@ if [ "$CHECK_MODE" = "1" ]; then
     fi
 
     check_prompt="$(mktemp -t critic-panel-check.XXXXXX)"
-    trap 'rm -f "$check_prompt"' EXIT
+    trap 'rm -f "$check_prompt"; [ -n "$_MERGED_REG" ] && rm -f "$_MERGED_REG"' EXIT
     printf '%s' 'Reply with exactly: ok' > "$check_prompt"
 
     check_failed="0"
@@ -156,6 +220,7 @@ $check_rows
 CHECKROWSEOF
 
     rm -f "$check_prompt"
+    [ -n "$_MERGED_REG" ] && rm -f "$_MERGED_REG"   # normal --check path (trap is disarmed next)
     trap - EXIT
     [ "$check_failed" -eq 0 ] || exit 1
     exit 0
@@ -311,7 +376,7 @@ tmp="$(mktemp -t critic-panel.XXXXXX)"
 _seq_out=""
 _seq_err=""
 outdir=""
-trap 'rm -f "$tmp"; [ -n "$_seq_out" ] && rm -f "$_seq_out"; [ -n "${_seq_err:-}" ] && rm -f "$_seq_err"; [ -n "$outdir" ] && rm -rf "$outdir"' EXIT
+trap 'rm -f "$tmp"; [ -n "$_seq_out" ] && rm -f "$_seq_out"; [ -n "${_seq_err:-}" ] && rm -f "$_seq_err"; [ -n "$outdir" ] && rm -rf "$outdir"; [ -n "$_MERGED_REG" ] && rm -f "$_MERGED_REG"' EXIT
 printf '%s' "$diff_in" > "$tmp"
 
 # Run each panel member; collect per-member output and renumber globally.

--- a/scripts/cr/test-advisory-rows.sh
+++ b/scripts/cr/test-advisory-rows.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# scripts/cr/test-advisory-rows.sh — guard for HIMMEL-1221 G3: the minerva
+# advisory panel enumeration prefers FREE rows but falls back to PAID rows when
+# the registry has NO free rows (instead of an empty panel → claude-only). Tests
+# the real helper minerva calls, so a regression in it (or in the behavior) is
+# caught. Hermetic, bash 3.2 safe.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+HELPER="$HERE/advisory-rows.sh"
+tmp="$(mktemp -d)"
+# shellcheck disable=SC2064
+trap "rm -rf $tmp" EXIT
+fails=0
+
+check() {
+    if [ "$2" = "$3" ]; then echo "ok - $1"; else
+        echo "FAIL - $1: got [$2] want [$3]"; fails=$((fails + 1)); fi
+}
+
+# Paid-only registry → paid rows enumerated (the real himmel case: codex+glm).
+printf '%s' '{"panel":[
+  {"slug":"codex","model":"gpt-5.5","tier":"paid"},
+  {"slug":"glm","model":"glm-5.2","tier":"paid"}]}' > "$tmp/paid.json"
+out_paid="$(bash "$HELPER" "$tmp/paid.json")"
+check "paid-only: codex enumerated" "$(printf '%s\n' "$out_paid" | grep -c '^codex	gpt-5.5$')" "1"
+check "paid-only: glm enumerated"   "$(printf '%s\n' "$out_paid" | grep -c '^glm	glm-5.2$')" "1"
+check "paid-only: exactly 2 rows"   "$(printf '%s\n' "$out_paid" | grep -c '	')" "2"
+
+# Registry WITH a free row → only the free row(s), paid suppressed.
+printf '%s' '{"panel":[
+  {"slug":"codex","model":"gpt-5.5","tier":"paid"},
+  {"slug":"glm","model":"glm-5.2","tier":"paid"},
+  {"slug":"freebie","model":"m/free","tier":"free"}]}' > "$tmp/mixed.json"
+out_mixed="$(bash "$HELPER" "$tmp/mixed.json")"
+check "free-present: free row enumerated"  "$(printf '%s\n' "$out_mixed" | grep -c '^freebie	m/free$')" "1"
+check "free-present: paid codex suppressed" "$(printf '%s\n' "$out_mixed" | grep -c 'codex')" "0"
+check "free-present: paid glm suppressed"   "$(printf '%s\n' "$out_mixed" | grep -c 'glm')" "0"
+
+# Empty / unreadable registry → empty output (no crash).
+printf '%s' '{"panel":[]}' > "$tmp/empty.json"
+out_empty="$(bash "$HELPER" "$tmp/empty.json")"
+check "empty registry: no rows" "$(printf '%s' "$out_empty" | wc -c | tr -d '[:space:]')" "0"
+
+if [ "$fails" -eq 0 ]; then
+    echo "ALL PASS"
+else
+    echo "$fails FAILED"
+    exit 1
+fi

--- a/scripts/cr/test-critic-panel-registry.sh
+++ b/scripts/cr/test-critic-panel-registry.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# scripts/cr/test-critic-panel-registry.sh — regression guards for HIMMEL-1221:
+#   T1  the Z.ai critic credential is loaded from the primary checkout's .env and
+#       reaches the dispatched critic (credential-path guard).
+#   T2  critics.local.json MERGES per-slug over critics.json (override / append /
+#       drop-tombstone), instead of wholesale replacement.
+#   T3  CRITICS_JSON env still wins outright (no merge) — the tests/CI contract.
+# Hermetic: no network, no real key, bash 3.2 safe. Uses a stub critic (via
+# CRITIC_FIRST_PASS) that records what it was dispatched with; no hermes call.
+set -uo pipefail
+
+# Clear ambient tier controls so the panel's tier filter is deterministic
+# (.env often exports CR_PROFILE); each case sets what it needs explicitly.
+unset CR_PROFILE CRITIC_PANEL_TIERS CR_TRIVIALITY_OVERRIDE 2>/dev/null || true
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PANEL="$HERE/critic-panel.sh"
+tmp="$(mktemp -d)"
+# shellcheck disable=SC2064
+trap "rm -rf $tmp" EXIT
+fails=0
+
+check() {
+    if [ "$2" = "$3" ]; then echo "ok - $1"; else
+        echo "FAIL - $1: got [$2] want [$3]"; fails=$((fails + 1)); fi
+}
+
+# A stub critic: records "slug=<slug> model=<model> zai=<ZAI_API_KEY or MISSING>"
+# to $PANEL_TEST_LOG, then emits a valid empty findings block so the panel counts
+# it as responded. Ignores stdin (the diff).
+STUB="$tmp/stub.sh"
+cat > "$STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+slug=""; model=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --slug)  slug="$2";  shift 2 ;;
+        --model) model="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+printf 'slug=%s model=%s zai=%s\n' "$slug" "$model" "${ZAI_API_KEY:-MISSING}" >> "$PANEL_TEST_LOG"
+printf '# %s First-Pass Review\n\n## Critical Issues (0 found)\n\n## Important Issues (0 found)\n\n## Suggestions (0 found)\n' "$slug"
+STUBEOF
+chmod +x "$STUB"
+
+DIFF='diff --git a/foo.sh b/foo.sh
+index 0000000..1111111 100644
+--- a/foo.sh
++++ b/foo.sh
+@@ -1,2 +1,4 @@
+ line
++added one
++added two
++added three'
+
+# ---------------------------------------------------------------------------
+# T1 — credential path: .env ZAI_API_KEY reaches the dispatched critic, with NO
+# manual export and CWD inside a throwaway git repo (load_dotenv resolves .env
+# via `git rev-parse --git-common-dir` of CWD). The sentinel value proves the
+# panel read THIS .env, not himmel's.
+# ---------------------------------------------------------------------------
+repo="$tmp/repo"
+mkdir -p "$repo"
+( cd "$repo" && git init -q )
+SENTINEL="sentinel-zai-9f3a7c"
+printf 'ZAI_API_KEY=%s\n' "$SENTINEL" > "$repo/.env"
+printf '%s' '{"panel":[{"slug":"glm","model":"glm-5.2","provider":"zai","tier":"free","route_provider":"glm"}]}' > "$tmp/t1-reg.json"
+LOG1="$tmp/t1.log"; : > "$LOG1"
+# Unset every alias so load_dotenv actually loads from the temp .env.
+( cd "$repo" && env -u ZAI_API_KEY -u GLM_API_KEY -u Z_AI_API_KEY -u CR_PROFILE -u CRITIC_PANEL_TIERS \
+    PANEL_TEST_LOG="$LOG1" CRITICS_JSON="$tmp/t1-reg.json" CRITIC_FIRST_PASS="$STUB" \
+    bash "$PANEL" >/dev/null 2>&1 <<< "$DIFF" )
+check "T1: glm critic was dispatched"                 "$(grep -c 'slug=glm ' "$LOG1")" "1"
+check "T1: .env ZAI_API_KEY reached the critic env"   "$(grep -c "zai=$SENTINEL" "$LOG1")" "1"
+check "T1: credential was NOT missing"                "$(grep -c 'zai=MISSING' "$LOG1")" "0"
+
+# ---------------------------------------------------------------------------
+# T2 — merge semantics: BASE {glm, dup(base), keepme} + LOCAL {dup(local override),
+# lagunaor(append), keepme drop:true}. Expect dispatched: glm (base), dup (LOCAL
+# model), lagunaor (append); keepme dropped. CR_TRIVIALITY_OVERRIDE=full so the
+# triviality gate cannot strip the paid tier and confound the glm assertion.
+# ---------------------------------------------------------------------------
+printf '%s' '{"panel":[
+  {"slug":"glm","model":"glm-5.2","provider":"zai","tier":"paid","route_provider":"glm"},
+  {"slug":"dup","model":"base/dup","provider":"test","tier":"paid"},
+  {"slug":"keepme","model":"base/keepme","provider":"test","tier":"paid"}]}' > "$tmp/t2-base.json"
+printf '%s' '{"panel":[
+  {"slug":"dup","model":"local/dup","provider":"test","tier":"paid"},
+  {"slug":"lagunaor","model":"free/laguna","provider":"test","tier":"free"},
+  {"slug":"keepme","drop":true}]}' > "$tmp/t2-local.json"
+LOG2="$tmp/t2.log"; : > "$LOG2"
+env -u CRITICS_JSON \
+    PANEL_TEST_LOG="$LOG2" CR_PROFILE="free,paid" CR_TRIVIALITY_OVERRIDE=full \
+    CRITICS_BASE_JSON="$tmp/t2-base.json" CRITICS_LOCAL_JSON="$tmp/t2-local.json" \
+    CRITIC_FIRST_PASS="$STUB" bash "$PANEL" >/dev/null 2>&1 <<< "$DIFF"
+check "T2: glm restored from base (core regression)"  "$(grep -c 'slug=glm '      "$LOG2")" "1"
+check "T2: local-only row appended (lagunaor)"        "$(grep -c 'slug=lagunaor ' "$LOG2")" "1"
+check "T2: overridden slug dispatched exactly once"   "$(grep -c 'slug=dup '      "$LOG2")" "1"
+check "T2: override used the LOCAL model"              "$(grep -c 'model=local/dup' "$LOG2")" "1"
+check "T2: base model NOT dispatched for override"    "$(grep -c 'model=base/dup'  "$LOG2")" "0"
+check "T2: drop-tombstone removed the base row"       "$(grep -c 'slug=keepme '    "$LOG2")" "0"
+
+# ---------------------------------------------------------------------------
+# T3 — CRITICS_JSON wins outright: merge is bypassed even when a local overlay is
+# pointed at a different fixture.
+# ---------------------------------------------------------------------------
+printf '%s' '{"panel":[{"slug":"onlyme","model":"m/only","provider":"test","tier":"free"}]}' > "$tmp/t3-json.json"
+printf '%s' '{"panel":[{"slug":"other","model":"m/other","provider":"test","tier":"free"}]}' > "$tmp/t3-local.json"
+LOG3="$tmp/t3.log"; : > "$LOG3"
+env -u CR_PROFILE -u CRITIC_PANEL_TIERS \
+    PANEL_TEST_LOG="$LOG3" CRITICS_JSON="$tmp/t3-json.json" CRITICS_LOCAL_JSON="$tmp/t3-local.json" \
+    CRITIC_FIRST_PASS="$STUB" bash "$PANEL" >/dev/null 2>&1 <<< "$DIFF"
+check "T3: CRITICS_JSON row dispatched"                "$(grep -c 'slug=onlyme ' "$LOG3")" "1"
+check "T3: local overlay NOT merged (CRITICS_JSON wins)" "$(grep -c 'slug=other ' "$LOG3")" "0"
+
+if [ "$fails" -eq 0 ]; then
+    echo "ALL PASS"
+else
+    echo "$fails FAILED"
+    exit 1
+fi

--- a/scripts/cr/test-critic-panel.sh
+++ b/scripts/cr/test-critic-panel.sh
@@ -508,17 +508,22 @@ check "PV2: provider metadata alone does NOT thread --provider <name>" "$(grep -
 printf '%s' "$DIFF" | CRITICS_JSON="$tmp/does-not-exist.json" CRITIC_FIRST_PASS="$CAPTURE_STUB" bash "$PANEL" >/dev/null 2>&1
 check "PV3: anchor-only fallback threads --provider ANCHOR_PROVIDER" "$(grep -c -- "--provider $ANCHOR_PROVIDER" "$CAPTURE_FILE")" "1"
 
-# Test O: operator-local registry overlay (HIMMEL-727). critics.local.json next
-# to the panel wins over critics.json; CRITICS_JSON env wins over both. Run a
-# COPY of the panel from a tmp dir so the repo tree is never polluted with a
-# local overlay file (concurrent sessions share this checkout).
+# Test O: operator-local registry overlay (HIMMEL-727 + HIMMEL-1221 merge).
+# critics.local.json next to the panel is now MERGED per-slug OVER critics.json
+# (was: wholesale replacement) — a local-only slug appends, a base-only slug
+# survives; CRITICS_JSON env still wins over both (no merge). Run a COPY of the
+# panel from a tmp dir so the repo tree is never polluted with a local overlay
+# file (concurrent sessions share this checkout).
 mkdir -p "$tmp/panelcopy"
 cp "$PANEL" "$tmp/panelcopy/critic-panel.sh"
 printf '%s' '{"panel":[{"slug":"repodefault","model":"fake/repo","provider":"test","tier":"free"}]}' > "$tmp/panelcopy/critics.json"
 printf '%s' '{"panel":[{"slug":"localoverlay","model":"fake/local","provider":"test","tier":"free"}]}' > "$tmp/panelcopy/critics.local.json"
 stderr_l="$(printf '%s' "$DIFF" | CRITIC_FIRST_PASS="$CAPTURE_STUB" bash "$tmp/panelcopy/critic-panel.sh" 2>&1 >/dev/null)"
 check "O1: local overlay used when present" "$(printf '%s\n' "$stderr_l" | grep -cF 'panel-availability: localoverlay')" "1"
-check "O1: local overlay announced on stderr" "$(printf '%s\n' "$stderr_l" | grep -cF 'critics.local.json')" "1"
+# HIMMEL-1221: the base row is now MERGED IN (not masked by the overlay). Reverting
+# Change 2 to wholesale replacement makes this assertion fail — it guards the shift.
+check "O1: base row also merged in (HIMMEL-1221)" "$(printf '%s\n' "$stderr_l" | grep -cF 'panel-availability: repodefault')" "1"
+check "O1: overlay merge announced on stderr" "$(printf '%s\n' "$stderr_l" | grep -cF 'critics.local.json')" "1"
 stderr_l2="$(printf '%s' "$DIFF" | CRITICS_JSON="$tmp/panelcopy/critics.json" CRITIC_FIRST_PASS="$CAPTURE_STUB" bash "$tmp/panelcopy/critic-panel.sh" 2>&1 >/dev/null)"
 check "O2: CRITICS_JSON env wins over local overlay" "$(printf '%s\n' "$stderr_l2" | grep -cF 'panel-availability: repodefault')" "1"
 rm -f "$tmp/panelcopy/critics.local.json"


### PR DESCRIPTION
## HIMMEL-1221 — GLM critic reliability

Code-only re-projection of **private `main` `d65a9e86`** (private PR #1333). The paid **glm** critic silently dropped from `/pr-check`; three independent gaps are fixed.

### Fixes (all in `scripts/cr/`)
- **G1 credential:** `critic-panel.sh` now loads the Z.ai key from the repo-root `.env` (`GLM_API_KEY`/`ZAI_API_KEY`/`Z_AI_API_KEY`) — **only when the resolved registry contains a Z.ai critic** (`load_dotenv` forks a subshell per `.env` line, ~1.5s on Git Bash; gating keeps that off glm-less panel runs). `invoke.sh` stays auth-agnostic (HIMMEL-278); the key is never printed/logged.
- **G2 registry merge:** `critics.local.json` now MERGES per-slug over `critics.json` (override/append; `"drop":true` tombstone) instead of wholesale replacement, so a stale overlay can't mask a shipped critic. `CRITICS_JSON` still wins outright.
- **G3 minerva paid-fallback:** new `advisory-rows.sh` enumerates advisory critics free-preferred, paid-fallback (was free-only → empty panel → claude-only on a paid-only registry). Both minerva stages call it.

### Validation
- `critic-panel.sh --check --all-tiers` with `ZAI_API_KEY` unset → `codex ok` + `glm ok` (no manual export).
- Full panel on the diff → **2/2 critics responded**, 0 Critical/Important.

### Regression guards (each verified to FAIL when its change is reverted)
`test-critic-panel-registry.sh` (credential/merge/CRITICS_JSON-wins), `test-advisory-rows.sh` (paid fallback), `test-critic-panel.sh` Test O (base row merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advisory panels now prefer free critic entries and fall back to paid entries when no free options are available.
  * Local critic configuration can override, add, or remove entries from the default registry.
  * Required Z.ai/GLM credentials are loaded automatically when applicable.

* **Bug Fixes**
  * Prevented advisory panels from appearing empty when free critics are unavailable.
  * Improved handling of unreadable or invalid critic registries.

* **Tests**
  * Added coverage for advisory selection, registry overlays, credential loading, and configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->