### PR TITLE
docs(glm-offload): update propagation step to the ship model

### DIFF
--- a/docs/glm-offload.md
+++ b/docs/glm-offload.md
@@ -393,7 +393,7 @@ wait   # each prints its 3-line inspect contract (session-dir / transcript-dir /
 #   1. inspect meta.json + outbox.jsonl + run.log
 #   2. review glm/<slug> diff through the CR loop  → fix findings
 #   3. attestation-commit → push → /pr-check → gh pr create → merge
-#   4. propagate-public prep → operator/validator ships
+#   4. propagate-public ship → /cr-public to PR-ready → human /mergepub authorizes (HIMMEL-1213)
 #   5. CR ledger append (ledger-append.sh, main thread only; cr-scores.sh reads)
 ```
 


### PR DESCRIPTION
Refresh the GLM-offload flow comment (step 4) from the old
"prep -> operator ships" public-propagation framing to the current
ship model: the agent ships end-to-end via `propagate-public.sh ship`,
babysits `/cr-public` to PR-ready, and the public squash-merge stays
human-authorized via `/mergepub`.

Docs-only, one line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the batch fan-out workflow, including the `/cr-public` preparation stage and final human approval via `/mergepub`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->