### PR TITLE
fix(mergeable): compute PR merge conflict locally via git merge-tree

### DIFF
--- a/.claude/commands/handover-pr-merge.md
+++ b/.claude/commands/handover-pr-merge.md
@@ -33,8 +33,6 @@ Environment:
 - `GH_CMD=<cmd>` — override the gh binary (tests use `echo`).
 - `GH_ADMIN_MERGE_OK=1` — authorize the `--admin` fallback on a
   non-cosmetic plain-merge failure (default off).
-- `PR_MERGE_POLL_ATTEMPTS` / `PR_MERGE_POLL_INTERVAL` — mergeability-poll
-  tuning (HIMMEL-179; defaults 5 / 3s).
 
 Exit codes:
 - `0` merged (or no PR found — nothing to do)

--- a/scripts/handover/pr-merge.sh
+++ b/scripts/handover/pr-merge.sh
@@ -36,23 +36,19 @@
 #   GH_ADMIN_MERGE_OK        When `1`, authorizes the `--admin` fallback on a
 #                            non-cosmetic plain-merge failure (GitHub only).
 #                            Default off. The github backend reads this directly.
-#   PR_MERGE_POLL_ATTEMPTS   Mergeability-poll attempts (HIMMEL-179). Default 5.
-#   PR_MERGE_POLL_INTERVAL   Seconds slept between poll attempts. Default 3.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Forge-dispatch seam: forge_pr_find_open / forge_pr_mergeable / forge_pr_merge
 # route to the github or bitbucket backend per the repo's origin (HIMMEL-326).
 # The admin-fallback + cosmetic-branch-delete handling lives in the github
-# backend (gh_forge_pr_merge); this script orchestrates find → poll → merge.
+# backend (gh_forge_pr_merge); this script orchestrates find → check → merge.
 # shellcheck source=../lib/forge.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/../lib/forge.sh"
 
 # GH_ADMIN_MERGE_OK is consumed by the github backend (gh_forge_pr_merge) — it
 # reads the env var directly, so this script no longer normalizes it.
-POLL_ATTEMPTS="${PR_MERGE_POLL_ATTEMPTS:-5}"
-POLL_INTERVAL="${PR_MERGE_POLL_INTERVAL:-3}"
 DRY_RUN=0
 
 usage() {
@@ -126,9 +122,8 @@ fi
 
 # HIMMEL-936: CR merge gate on the same predicate as the PreToolUse hook, so
 # machines without the plugin hook still get the gate on this path. Placed
-# before the mergeability poll so a CR-blocked merge fails fast (exit 5)
-# instead of burning the 5x3s poll (plan-critic #7). GitHub-only: cr_merge_gate
-# resolves via gh; the bitbucket forge skips it.
+# before the mergeability check so a CR-blocked merge fails fast (exit 5).
+# GitHub-only: cr_merge_gate resolves via gh; the bitbucket forge skips it.
 vetted_head=""
 if [ "$forge" = "github" ]; then
     # HIMMEL-1058 (TOCTOU): capture the head we are about to vet, and bind the
@@ -160,7 +155,7 @@ if [ "$forge" = "github" ]; then
     # HIMMEL-1043: CI-green gate, same predicate as the PreToolUse hook's
     # second gate, so machines without the plugin hook still require green CI
     # on this path. Runs AFTER the CR gate (exit 5) and before the
-    # mergeability poll; a CI-blocked merge fails fast (exit 6). pr-merge passes
+    # mergeability check; a CI-blocked merge fails fast (exit 6). pr-merge passes
     # only the PR number (no --repo): a selector that fails to resolve is a
     # plain fail-open rc=3 here — no cwd-branch re-anchor (this path already
     # knows its PR via forge_pr_find_open).
@@ -176,44 +171,24 @@ if [ "$forge" = "github" ]; then
     fi
 fi
 
-# Bounded poll for mergeability to settle before merging (HIMMEL-179 sharp#1) —
-# GitHub only. This is the SECOND stage of the two-stage UNKNOWN handling: the
-# pre-push gate (scripts/hooks/check-pr-mergeable.sh, HIMMEL-136) lets
-# `mergeable: UNKNOWN` pass through because GitHub hasn't finished computing
-# mergeability right after a push; that pass-through can leave the real merge
-# below to fail, so we wait for `mergeable` to settle:
-#   MERGEABLE       -> proceed to merge.
+# Deterministic mergeability check before merging (HIMMEL-1232) — GitHub only.
+# forge_pr_mergeable now computes the conflict LOCALLY via `git merge-tree`
+# (github backend), so there is no async GitHub `mergeable` field to wait on: the
+# old bounded poll (HIMMEL-179, 5x3s) is gone — a single read decides.
 #   CONFLICTING     -> fail fast (exit 4); a conflict won't self-resolve.
-#   UNKNOWN / empty -> retry after a short sleep; if attempts exhaust while still
-#                      unsettled, fall through to the merge attempt (preserve the
-#                      pre-check's pass-through behavior — don't hard-fail). A
-#                      transient view-query failure surfaces as empty here too.
-# Bitbucket Cloud has no mergeable field (forge_pr_mergeable returns UNKNOWN), so
-# the poll is pointless there — the 400 at merge time is the only conflict signal
-# (spec §5.1), surfaced by forge_pr_merge. Skip the poll entirely for bitbucket.
+#   MERGEABLE       -> proceed to merge.
+#   UNKNOWN / empty -> a tooling gap (git < 2.38, refs unavailable, no PR view).
+#                      Fail OPEN and proceed — the merge still fails loudly if it
+#                      truly conflicts, and hard-blocking on a tool gap is worse.
+# Bitbucket Cloud has no pre-merge mergeable signal (forge_pr_mergeable returns
+# UNKNOWN), so this is skipped there — the 400 at merge time is the only conflict
+# signal (spec §5.1), surfaced by forge_pr_merge.
 if [ "$forge" = "github" ]; then
-    attempt=1
-    while [ "$attempt" -le "$POLL_ATTEMPTS" ]; do
-        mergeable=$(forge_pr_mergeable "$pr_num")
-        case "$mergeable" in
-            MERGEABLE)
-                break
-                ;;
-            CONFLICTING)
-                echo "ERR pr-merge: PR #$pr_num is CONFLICTING — resolve conflicts before merging. Refusing." >&2
-                exit 4
-                ;;
-            *)
-                # UNKNOWN (or empty/unexpected): still computing or a transient
-                # view failure. Retry after a sleep; never sleep after the last.
-                if [ "$attempt" -lt "$POLL_ATTEMPTS" ]; then
-                    echo "pr-merge: PR #$pr_num mergeable=${mergeable:-<empty>} (attempt $attempt/$POLL_ATTEMPTS) — waiting ${POLL_INTERVAL}s" >&2
-                    sleep "$POLL_INTERVAL"
-                fi
-                ;;
-        esac
-        attempt=$((attempt + 1))
-    done
+    mergeable=$(forge_pr_mergeable "$pr_num")
+    if [ "$mergeable" = "CONFLICTING" ]; then
+        echo "ERR pr-merge: PR #$pr_num is CONFLICTING — resolve conflicts before merging. Refusing." >&2
+        exit 4
+    fi
 fi
 
 # Squash-merge via the forge seam. The github backend does a PLAIN squash first

--- a/scripts/handover/test-pr-merge.sh
+++ b/scripts/handover/test-pr-merge.sh
@@ -23,13 +23,14 @@ fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1" >&2; }
 #   STUB_ADMIN_FAIL=1  : `gh pr merge` WITH --admin exits 1.
 #   STUB_COSMETIC=1    : `gh pr merge` exits 1 with the cosmetic
 #                        "branch is already used by worktree" error.
-#   STUB_VIEW_FAIL=1   : `gh pr view` (mergeability poll) exits 1 — simulates
-#                        a transient gh/network failure (HIMMEL-179).
-#   STUB_VIEW_MERGEABLE: value `gh pr view` prints for `.mergeable`. Default
-#                        MERGEABLE. Set CONFLICTING / UNKNOWN to drive the poll.
-#   STUB_VIEW_UNKNOWN_THEN=N : first N `gh pr view` calls print UNKNOWN, then
-#                        MERGEABLE — exercises the retry-then-settle path. Uses
-#                        a counter file at $GH_VIEW_COUNT.
+#   SETUP_MERGE_CONFLICT=1 : build a real add/add conflict between the branch
+#                        and main so the HIMMEL-1232 local merge-tree check
+#                        returns CONFLICTING.
+#   STUB_MERGE_UNKNOWN=1 : the base+head read reports a head SHA not present
+#                        locally, so the check cannot verify it -> UNKNOWN
+#                        (fail-open tooling-gap path).
+#   STUB_MERGE_VIEW_FAIL=1 : `gh pr view --json baseRefName,headRefOid` exits 1
+#                        — a transient gh/network failure (fail-open path).
 # After the run, $LAST_GH_LOG holds the path to the recorded gh argv log so
 # callers can assert on --admin presence/absence.
 LAST_GH_LOG=""
@@ -58,12 +59,27 @@ case "$verb" in
         echo "42"
         ;;
     "pr view")
-        # HIMMEL-936 CR-gate metadata call is `gh pr view <sel> --json
-        # number,headRefOid,url`; the mergeability poll is `gh pr view <pr>
-        # --json mergeable`. Distinguish by the requested --json fields.
-        # STUB_CR_BLOCK=1 answers the metadata call with parseable JSON so
-        # cr_merge_gate proceeds to its graphql arm; otherwise echo non-JSON
-        # so the gate degrades + fails open (existing cases stay green).
+        # Three distinct `gh pr view` shapes reach this stub — matched by the
+        # requested --json fields (order matters; the first two also contain
+        # headRefOid, so the mergeability check must be matched FIRST):
+        #   1. HIMMEL-1232 mergeability check: --json baseRefName,headRefOid --jq
+        #   2. HIMMEL-1058 head-SHA bind read: --json headRefOid --jq .headRefOid
+        #   3. HIMMEL-936 CR-gate metadata:    --json number,headRefOid,url (no --jq)
+        if printf ' %s ' "$@" | grep -q 'baseRefName'; then
+            # forge_pr_mergeable (github) reads base+head, then computes the
+            # conflict LOCALLY with git merge-tree. Emit "<base> <headoid>":
+            #   STUB_MERGE_VIEW_FAIL=1 -> gh error (backend fails open -> proceed)
+            #   STUB_MERGE_UNKNOWN=1   -> a head SHA not present locally (backend
+            #                             cannot verify it -> UNKNOWN -> proceed)
+            #   default                -> the real current-branch tip, so
+            #                             merge-tree runs against real commits
+            #                             (clean by default; SETUP_MERGE_CONFLICT
+            #                             built a conflicting head).
+            [ "${STUB_MERGE_VIEW_FAIL:-0}" = "1" ] && { echo "gh: could not resolve PR" >&2; exit 1; }
+            [ "${STUB_MERGE_UNKNOWN:-0}" = "1" ] && { echo "main deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"; exit 0; }
+            echo "main $(git rev-parse HEAD)"
+            exit 0
+        fi
         if printf ' %s ' "$@" | grep -q 'headRefOid'; then
             # STUB_CR_BLOCK=1 arms the CR gate; STUB_CI_BLOCK=1 arms the CI gate
             # (both need parseable metadata to resolve the head SHA).
@@ -80,28 +96,11 @@ case "$verb" in
             elif [ "${STUB_CR_BLOCK:-0}" = "1" ] || [ "${STUB_CI_BLOCK:-0}" = "1" ] || [ "${STUB_ALL_GREEN:-0}" = "1" ]; then
                 echo '{"number":42,"headRefOid":"abc123","url":"https://github.com/o/r/pull/42"}'
             else
-                echo "${STUB_VIEW_MERGEABLE:-MERGEABLE}"
+                # Non-JSON so cr_merge_gate degrades + fails open (existing cases
+                # without STUB_CR_BLOCK/CI_BLOCK/ALL_GREEN stay green).
+                echo "degraded-non-json"
             fi
             exit 0
-        fi
-        # Mergeability poll (HIMMEL-179). pr-merge calls:
-        #   gh pr view <pr> --json mergeable --jq '.mergeable'
-        if [ "${STUB_VIEW_FAIL:-0}" = "1" ]; then
-            echo "gh: could not resolve PR" >&2
-            exit 1
-        fi
-        if [ "${STUB_VIEW_UNKNOWN_THEN:-0}" != "0" ]; then
-            n=0
-            [ -f "$GH_VIEW_COUNT" ] && n=$(cat "$GH_VIEW_COUNT")
-            n=$((n + 1))
-            echo "$n" > "$GH_VIEW_COUNT"
-            if [ "$n" -le "$STUB_VIEW_UNKNOWN_THEN" ]; then
-                echo "UNKNOWN"
-            else
-                echo "MERGEABLE"
-            fi
-        else
-            echo "${STUB_VIEW_MERGEABLE:-MERGEABLE}"
         fi
         ;;
     "pr merge")
@@ -169,14 +168,25 @@ STUB
         git config user.email t@t.t
         git config user.name t
         git commit -q --allow-empty -m init
+        # HIMMEL-1232: the github mergeability check resolves the base as
+        # origin/main (absent — no fetch) then local `main`, so a `main` ref
+        # must exist at the base for git merge-tree to run.
+        git branch -M main
         git checkout -q -b "$branch" 2>/dev/null || git checkout -q "$branch"
+        # SETUP_MERGE_CONFLICT=1: build a real add/add conflict between this
+        # branch and main so forge_pr_mergeable returns CONFLICTING.
+        if [ "${SETUP_MERGE_CONFLICT:-0}" = "1" ]; then
+            printf 'theirs\n' > cf; git add cf; git commit -q -m theirs
+            git checkout -q main
+            printf 'ours\n' > cf; git add cf; git commit -q -m ours
+            git checkout -q "$branch"
+        fi
         # Forge seam (HIMMEL-326): pr-merge resolves the forge from origin. A
         # github origin selects the github backend, which reproduces the exact
         # `gh pr merge` shapes (incl. --admin fallback) these asserts expect.
         git remote add origin https://github.com/test/test.git
-        GH_LOG="$ghlog" GH_VIEW_COUNT="$tmp/view.count" \
+        GH_LOG="$ghlog" \
             PATH="$tmp/bin:$PATH" GH_CMD=gh \
-            PR_MERGE_POLL_INTERVAL="${PR_MERGE_POLL_INTERVAL:-0}" \
             bash "$PR_MERGE" "$@" >"$tmp/out" 2>"$tmp/err"
     )
     local rc=$?
@@ -268,48 +278,45 @@ STUB_LIST_FAIL=1 \
     run_case "handover/x-slug" 4 "gh pr list failure exits 4 (not silent no-op)"
 assert_log_lacks "pr merge" "no merge attempted when PR state is unknown"
 
-# --- mergeability poll (HIMMEL-179 sharp#1) ---
+# --- deterministic mergeability check (HIMMEL-1232, local git merge-tree) ---
+# The old bounded poll (HIMMEL-179) is gone: forge_pr_mergeable now computes the
+# conflict locally in one shot. The check reads base+head via
+# `gh pr view <n> --json baseRefName,headRefOid` and runs git merge-tree.
 
-# (a) MERGEABLE immediately => merges after a single poll.
-if STUB_VIEW_MERGEABLE=MERGEABLE \
-    run_case "handover/x-slug" 0 "poll: MERGEABLE merges"; then
-    assert_log_has "pr view 42 --json mergeable" "poll queried mergeability"
-    assert_log_has "pr merge 42 --squash"        "MERGEABLE proceeds to merge"
+# (a) clean branch (merge-tree MERGEABLE) => proceeds to merge.
+if run_case "handover/x-slug" 0 "check: MERGEABLE merges"; then
+    assert_log_has "pr view 42 --json baseRefName,headRefOid" "check queried base+head refs"
+    assert_log_has "pr merge 42 --squash"                     "MERGEABLE proceeds to merge"
 fi
 
-# (b) UNKNOWN twice then MERGEABLE => merges after the poll settles.
-if STUB_VIEW_UNKNOWN_THEN=2 \
-    run_case "handover/x-slug" 0 "poll: UNKNOWN-then-MERGEABLE merges"; then
-    assert_log_has "pr merge 42 --squash" "settled UNKNOWN proceeds to merge"
-fi
-
-# (c) CONFLICTING => exit 4, no merge attempted.
-if STUB_VIEW_MERGEABLE=CONFLICTING \
-    run_case "handover/x-slug" 4 "poll: CONFLICTING exits 4"; then
+# (b) real conflict (merge-tree CONFLICTING) => exit 4, no merge attempted.
+if SETUP_MERGE_CONFLICT=1 \
+    run_case "handover/x-slug" 4 "check: CONFLICTING exits 4"; then
     assert_log_lacks "pr merge" "CONFLICTING does not attempt merge"
 fi
 
-# (d) UNKNOWN never settles (attempts exhausted) => falls through to merge.
-if STUB_VIEW_MERGEABLE=UNKNOWN PR_MERGE_POLL_ATTEMPTS=3 \
-    run_case "handover/x-slug" 0 "poll: UNKNOWN exhausted falls through to merge"; then
-    assert_log_has "pr merge 42 --squash" "exhausted UNKNOWN still attempts merge"
+# (c) UNKNOWN (head SHA not resolvable locally — a tooling gap) => fails OPEN
+#     and falls through to merge (never hard-block on a tool gap).
+if STUB_MERGE_UNKNOWN=1 \
+    run_case "handover/x-slug" 0 "check: UNKNOWN fails open to merge"; then
+    assert_log_has "pr merge 42 --squash" "UNKNOWN still attempts merge"
 fi
 
-# (e) gh pr view itself fails => skips poll, falls through to merge.
-if STUB_VIEW_FAIL=1 \
-    run_case "handover/x-slug" 0 "poll: gh pr view failure falls through to merge"; then
+# (d) gh pr view (base+head read) itself fails => empty verdict => fails OPEN.
+if STUB_MERGE_VIEW_FAIL=1 \
+    run_case "handover/x-slug" 0 "check: gh view failure falls through to merge"; then
     assert_log_has "pr merge 42 --squash" "view failure still attempts merge"
 fi
 
-# --- HIMMEL-936: CR merge gate blocks before the poll (exit 5) ---
+# --- HIMMEL-936: CR merge gate blocks before the mergeability check (exit 5) ---
 # STUB_CR_BLOCK=1 arms the gate's pr-view metadata arm + the graphql arm so
 # cr_merge_gate positively confirms an unresolved coderabbitai thread. The
-# gate runs BEFORE the mergeability poll, so neither the poll's pr view nor
+# gate runs BEFORE the mergeability check, so neither the check's pr view nor
 # `gh pr merge` is reached. Existing cases above stay green by design: their
 # stub returns non-JSON for the gate's pr-view (headRefOid branch, STUB_CR_BLOCK
 # unset), so cr_merge_gate degrades and fails open (plan-critic #4).
 if STUB_CR_BLOCK=1 \
-    run_case "handover/x-slug" 5 "CR-gate block exits 5 before poll"; then
+    run_case "handover/x-slug" 5 "CR-gate block exits 5 before check"; then
     assert_log_lacks "pr merge" "CR-gate block does not attempt merge"
     assert_err_has    "CR gate" "CR-gate block reports CR gate on stderr"
 fi
@@ -318,9 +325,9 @@ fi
 # STUB_CI_BLOCK=1: CR gate passes (resolved coderabbit threads + a completed
 # CodeRabbit check-run), but a non-CodeRabbit check-run ("tests") failed, so
 # ci_green_gate blocks. Runs AFTER the CR gate (exit 5) and BEFORE the
-# mergeability poll, so neither the poll's pr view nor `gh pr merge` is reached.
+# mergeability check, so neither the check's pr view nor `gh pr merge` is reached.
 if STUB_CI_BLOCK=1 \
-    run_case "handover/x-slug" 6 "CI-gate block exits 6 before poll"; then
+    run_case "handover/x-slug" 6 "CI-gate block exits 6 before check"; then
     assert_log_lacks "pr merge" "CI-gate block does not attempt merge"
     assert_err_has    "CI gate" "CI-gate block reports CI gate on stderr"
 fi

--- a/scripts/hooks/check-pr-mergeable.sh
+++ b/scripts/hooks/check-pr-mergeable.sh
@@ -13,9 +13,11 @@
 # - Skips on a protected default (main OR master — HIMMEL-297) / detached
 #   HEAD (no PR ever opens for the default branch; detached pushes have no
 #   head ref to query).
-# - Queries `gh pr view --head <branch> --json mergeable`. When no PR
-#   exists, exits 0 (nothing to gate on).
-# - Refuses (exit 1) when `mergeable` is `CONFLICTING`. Surfaces the
+# - Asks forge_pr_mergeable for the branch's open PR. On GitHub that now
+#   computes the conflict LOCALLY via `git merge-tree` (HIMMEL-1232) rather
+#   than reading GitHub's flaky async `mergeable` field. When no PR exists,
+#   exits 0 (nothing to gate on).
+# - Refuses (exit 1) when the verdict is `CONFLICTING`. Surfaces the
 #   PR URL + the gh command to inspect.
 # - Falls back to exit 0 (best-effort) when gh CLI is missing or
 #   unauthenticated — a hard refuse would block pushes whenever the
@@ -88,15 +90,11 @@ EOF
         exit 1
         ;;
     MERGEABLE|UNKNOWN|*)
-        # MERGEABLE: clearly OK. UNKNOWN: not computed yet (GitHub) or no
-        # pre-merge signal (Bitbucket) — let it through; the merge gate blocks
-        # again at merge time if it's actually conflicting. Anything else:
-        # be lenient.
-        #
-        # Two-stage UNKNOWN handling (HIMMEL-179): this pre-push pass-through
-        # is stage 1. Stage 2 is the bounded mergeability poll in
-        # scripts/handover/pr-merge.sh, which waits for UNKNOWN to settle to
-        # MERGEABLE/CONFLICTING before the real merge.
+        # MERGEABLE: clearly OK. UNKNOWN: a tooling gap (git < 2.38, base/head
+        # refs unavailable — GitHub) or no pre-merge signal (Bitbucket). Let it
+        # through best-effort — the merge gate (scripts/handover/pr-merge.sh)
+        # runs the same local check again and blocks at merge time if it is
+        # actually conflicting. Anything else: be lenient.
         exit 0
         ;;
 esac

--- a/scripts/hooks/test-check-pr-mergeable.sh
+++ b/scripts/hooks/test-check-pr-mergeable.sh
@@ -36,6 +36,12 @@ assert_rc() {
 TMP_ROOT=$(mktemp -d); if command -v cygpath >/dev/null 2>&1; then TMP_ROOT=$(cygpath -m "$TMP_ROOT"); fi
 
 # Fake gh: behavior driven by FAKE_GH_* env.
+#
+# HIMMEL-1232: forge_pr_mergeable (github) now reads only base+head refs from gh
+# and computes the conflict LOCALLY via `git merge-tree`. So the fake emits
+# "<base> <headoid>" (a synchronous field read), and the test drives a clean vs
+# conflicting verdict by pointing FAKE_GH_HEAD at a real clean / conflicting
+# commit in the repo below — not by returning a mocked mergeable string.
 FAKE_GH="$TMP_ROOT/gh-fake.sh"
 cat >"$FAKE_GH" <<'FAKE'
 #!/usr/bin/env bash
@@ -46,12 +52,12 @@ case "$1 $2" in
     "pr view")
         if [ "${FAKE_GH_NO_PR:-0}" = "1" ]; then
             # gh pr view exits non-zero with no stdout when no PR exists; the
-            # forge backend's `|| true` turns that into an empty mergeable.
+            # forge backend's `|| return 0` turns that into an empty verdict.
             exit 1
         fi
-        # forge_pr_mergeable calls `gh pr view <branch> --json mergeable --jq
-        # .mergeable`, so gh emits just the bare status value.
-        printf '%s\n' "${FAKE_GH_MERGEABLE:-MERGEABLE}"
+        # forge_pr_mergeable calls `gh pr view <branch> --json
+        # baseRefName,headRefOid --jq ...`, so gh emits "<base> <headoid>".
+        printf '%s %s\n' "${FAKE_GH_BASE:-main}" "${FAKE_GH_HEAD:?FAKE_GH_HEAD unset}"
         exit 0
         ;;
 esac
@@ -59,18 +65,32 @@ exit 0
 FAKE
 chmod +x "$FAKE_GH"
 
-# tmp repo on a non-main branch
+# tmp repo on a non-main branch, with real clean + conflicting branches so
+# `git merge-tree` produces a genuine verdict.
 REPO="$TMP_ROOT/repo"
 git init -q --initial-branch=main "$REPO" 2>/dev/null || git init -q "$REPO"
 (
     cd "$REPO" || exit 99
-    git -c user.email=t@test.com -c user.name=test commit -q --allow-empty -m "init"
+    git config user.email t@test.com; git config user.name test
+    printf 'a\nb\nc\n' > f; git add f; git commit -q -m "init"
     git branch -m main 2>/dev/null || true
-    git checkout -q -b feat/test
+    # clean branch: adds an unrelated file — no overlap with main.
+    git checkout -q -b feat/clean
+    echo x > g; git add g; git commit -q -m clean
+    # conflict branch off init changes line 2; main then changes the same line.
+    git checkout -q -b feat/conflict main
+    printf 'a\nTHEIRS\nc\n' > f; git add f; git commit -q -m theirs
+    git checkout -q main
+    printf 'a\nOURS\nc\n' > f; git add f; git commit -q -m ours
+    # feat/test is the branch under test (the hook reads its NAME); its own
+    # content is irrelevant — the fake injects the head commit to check.
+    git checkout -q -b feat/test main
     # Forge seam (HIMMEL-326): the hook resolves the forge from origin; a github
     # origin selects the github backend (gh pr view via the GH_CMD stub).
     git remote add origin https://github.com/test/test.git
 )
+CLEAN_OID=$(git -C "$REPO" rev-parse feat/clean)
+CONFLICT_OID=$(git -C "$REPO" rev-parse feat/conflict)
 
 # The forge github backend invokes "${GH_CMD}" by its absolute path (no PATH
 # lookup, no word-split), so GH_CMD must be a single executable — point it at
@@ -120,28 +140,28 @@ rc=0
 out=$(export FAKE_GH_NO_PR=1; run 2>&1) || rc=$?
 assert_rc "no-pr rc=0" "0" "$rc"
 
-# Test 4: MERGEABLE -> exit 0 -----------------------------------------
-echo "TEST: PR MERGEABLE -> exit 0"
+# Test 4: clean branch -> MERGEABLE -> exit 0 -------------------------
+echo "TEST: clean branch (merge-tree MERGEABLE) -> exit 0"
 rc=0
 # shellcheck disable=SC2030,SC2031
-out=$(export FAKE_GH_MERGEABLE=MERGEABLE; run 2>&1) || rc=$?
+out=$(export FAKE_GH_HEAD="$CLEAN_OID"; run 2>&1) || rc=$?
 assert_rc "mergeable rc=0" "0" "$rc"
 
-# Test 5: CONFLICTING -> exit 1 ---------------------------------------
-echo "TEST: PR CONFLICTING -> exit 1 + helpful stderr"
+# Test 5: conflicting branch -> CONFLICTING -> exit 1 -----------------
+echo "TEST: conflicting branch (merge-tree CONFLICTING) -> exit 1 + helpful stderr"
 rc=0
 # shellcheck disable=SC2030,SC2031
-out=$(export FAKE_GH_MERGEABLE=CONFLICTING; run 2>&1) || rc=$?
+out=$(export FAKE_GH_HEAD="$CONFLICT_OID"; run 2>&1) || rc=$?
 assert_rc "conflicting rc=1" "1" "$rc"
 assert_contains "stderr mentions CONFLICTING" "CONFLICTING state" "$out"
 assert_contains "stderr suggests inspect"     "gh pr view"        "$out"
 assert_contains "stderr names bypass var"     "SKIP_PR_MERGEABLE"  "$out"
 
 # Test 6: SKIP_PR_MERGEABLE=1 short-circuits --------------------------
-echo "TEST: SKIP_PR_MERGEABLE=1 short-circuits even on CONFLICTING"
+echo "TEST: SKIP_PR_MERGEABLE=1 short-circuits even on a conflicting branch"
 rc=0
 # shellcheck disable=SC2030,SC2031
-out=$(export SKIP_PR_MERGEABLE=1 FAKE_GH_MERGEABLE=CONFLICTING; run 2>&1) || rc=$?
+out=$(export SKIP_PR_MERGEABLE=1 FAKE_GH_HEAD="$CONFLICT_OID"; run 2>&1) || rc=$?
 assert_rc "skip rc=0" "0" "$rc"
 assert_contains "stderr explains skip" "SKIP_PR_MERGEABLE=1" "$out"
 
@@ -152,7 +172,7 @@ out=$(
     # shellcheck disable=SC2030,SC2031,SC2164
     cd "$REPO" || exit 99
     # shellcheck disable=SC2030,SC2031
-    export GH_CMD="$FAKE_GH"
+    export GH_CMD="$FAKE_GH" FAKE_GH_HEAD="$CLEAN_OID"
     printf 'a b c d\ne f g h\n' | bash "$HOOK" 2>&1
 ) || rc=$?
 assert_rc "multi-line stdin rc=0" "0" "$rc"

--- a/scripts/lib/forge-github.sh
+++ b/scripts/lib/forge-github.sh
@@ -43,10 +43,62 @@ gh_forge_pr_set_body() {
     _gh pr edit "$number" --body "$body"
 }
 
-# echo MERGEABLE | CONFLICTING | UNKNOWN (or empty on gh error). args: NUMBER
+# echo MERGEABLE | CONFLICTING | UNKNOWN, or empty when no PR exists. args: REF
+# (a branch name or PR number — whatever `gh pr view` accepts).
+#
+# HIMMEL-1232: computes the merge conflict LOCALLY with `git merge-tree
+# --write-tree` (Git 2.38+) instead of reading GitHub's async `mergeable` field,
+# which is flaky/slow and returns UNKNOWN right after a push (HIMMEL-136/179).
+# Only the PR's base+head refs are read from GitHub, via a SYNCHRONOUS `gh pr
+# view` (baseRefName/headRefOid are stored fields, not async-computed); the merge
+# itself is then computed offline:
+#     merge-tree exit 0  -> clean     -> MERGEABLE
+#     merge-tree exit 1  -> conflicts -> CONFLICTING
+#     anything else      -> git error -> UNKNOWN
+# Every missing precondition (no PR, gh error, unresolvable base/head, git < 2.38)
+# degrades to empty/UNKNOWN so callers FAIL OPEN — a tooling gap must never
+# hard-block a push or a merge.
+#
+# A missing ref makes `git merge-tree` ALSO exit 1 (indistinguishable from a real
+# conflict), so base and head are `git rev-parse --verify`'d first; merge-tree
+# runs only when both are confirmed present, making exit 1 mean "genuine
+# conflict" unambiguously.
 gh_forge_pr_mergeable() {
-    local number="$1"
-    _gh pr view "$number" --json mergeable --jq '.mergeable' 2>/dev/null || true
+    local ref="$1"
+    local meta base_name head_oid
+    # Synchronous metadata read — NOT the async `mergeable` field. `|| return 0`
+    # turns a "no PR" / gh error into empty output (callers treat it as "no PR").
+    meta=$(_gh pr view "$ref" --json baseRefName,headRefOid \
+              --jq '.baseRefName + " " + .headRefOid' 2>/dev/null) || return 0
+    [ -z "$meta" ] && return 0
+    base_name=${meta%% *}
+    head_oid=${meta##* }
+    if [ -z "$base_name" ] || [ -z "$head_oid" ] || [ "$base_name" = "$head_oid" ]; then
+        echo "UNKNOWN"; return 0
+    fi
+
+    # Resolve the base commit locally WITHOUT fetching (the point is an offline,
+    # non-hanging check): prefer the remote-tracking ref, fall back to a local
+    # branch of the same name. Unresolvable -> fail open.
+    local base_commit
+    base_commit=$(git rev-parse --verify --quiet "refs/remotes/origin/$base_name^{commit}") \
+        || base_commit=$(git rev-parse --verify --quiet "$base_name^{commit}") \
+        || { echo "UNKNOWN"; return 0; }
+
+    # The head commit must be present locally (it is this branch's tip after a
+    # push). Absent -> fail open rather than guess.
+    git rev-parse --verify --quiet "$head_oid^{commit}" >/dev/null \
+        || { echo "UNKNOWN"; return 0; }
+
+    # git merge-tree --write-tree (Git 2.38+): 0 clean, 1 conflicts, else error.
+    # With both refs verified above, exit 1 unambiguously means a real conflict.
+    local rc=0
+    git merge-tree --write-tree "$base_commit" "$head_oid" >/dev/null 2>&1 || rc=$?
+    case "$rc" in
+        0) echo "MERGEABLE" ;;
+        1) echo "CONFLICTING" ;;
+        *) echo "UNKNOWN" ;;   # git < 2.38 usage error, or merge could not complete
+    esac
 }
 
 # count merged PRs whose source branch is BRANCH (clean-garden prune signal).

--- a/scripts/lib/test-forge.sh
+++ b/scripts/lib/test-forge.sh
@@ -94,6 +94,58 @@ assert_eq "gh pr_create url"    "https://github.com/owner/repo/pull/9" "$(FORGE=
 assert_eq "gh pr_has_merged"    "2" "$(FORGE=github GH_CMD="$GH_STUB" forge_pr_has_merged feat/x)"
 assert_eq "gh issue_create url" "https://github.com/owner/repo/issues/5" "$(FORGE=github GH_CMD="$GH_STUB" forge_issue_create owner/repo "A nit" "Fix it." cr-deferred)"
 
+# ── github pr_mergeable: LOCAL git merge-tree, not GitHub's async field ───────
+# HIMMEL-1232: gh_forge_pr_mergeable reads only base+head refs from gh (a
+# synchronous field read, stubbed here) and computes the conflict locally with
+# `git merge-tree`. So this exercises a REAL merge against real commits, not a
+# mocked mergeable string.
+echo "TEST: github pr_mergeable computes conflicts locally (git merge-tree, HIMMEL-1232)"
+MREPO="$TMP_ROOT/mergerepo"
+git init -q -b main "$MREPO" 2>/dev/null || { git init -q "$MREPO"; git -C "$MREPO" checkout -q -b main; }
+git -C "$MREPO" config user.email t@t.t
+git -C "$MREPO" config user.name test
+printf 'a\nb\nc\n' > "$MREPO/f"; git -C "$MREPO" add f; git -C "$MREPO" commit -qm base
+# Clean branch: adds an unrelated file — no overlap with main.
+git -C "$MREPO" checkout -q -b feat/clean
+echo x > "$MREPO/g"; git -C "$MREPO" add g; git -C "$MREPO" commit -qm clean
+# Conflict branch off base changes line 2; main then changes the same line.
+git -C "$MREPO" checkout -q -b feat/conflict main
+printf 'a\nTHEIRS\nc\n' > "$MREPO/f"; git -C "$MREPO" add f; git -C "$MREPO" commit -qm theirs
+git -C "$MREPO" checkout -q main
+printf 'a\nOURS\nc\n' > "$MREPO/f"; git -C "$MREPO" add f; git -C "$MREPO" commit -qm ours
+CLEAN_OID=$(git -C "$MREPO" rev-parse feat/clean)
+CONFLICT_OID=$(git -C "$MREPO" rev-parse feat/conflict)
+
+# Stub gh: answer only the base+head metadata read. MT_HEAD selects which commit
+# is the PR head; MT_NOPR=1 simulates "no PR" (gh exits non-zero, empty stdout).
+MT_STUB="$TMP_ROOT/gh-mergetree.sh"
+cat >"$MT_STUB" <<'STUB'
+#!/usr/bin/env bash
+case "$* " in
+    *"pr view"*baseRefName*)
+        [ "${MT_NOPR:-0}" = "1" ] && exit 1
+        printf '%s %s\n' "${MT_BASE:-main}" "${MT_HEAD:?MT_HEAD unset}"
+        ;;
+    *) echo "stub: unhandled gh args: $*" >&2; exit 99 ;;
+esac
+STUB
+chmod +x "$MT_STUB"
+
+# merge-tree runs in cwd, so each call is made from inside MREPO.
+assert_eq "gh pr_mergeable MERGEABLE (clean branch)" "MERGEABLE" \
+    "$(cd "$MREPO" && FORGE=github GH_CMD="$MT_STUB" MT_HEAD="$CLEAN_OID" forge_pr_mergeable feat/clean)"
+assert_eq "gh pr_mergeable CONFLICTING (real overlap)" "CONFLICTING" \
+    "$(cd "$MREPO" && FORGE=github GH_CMD="$MT_STUB" MT_HEAD="$CONFLICT_OID" forge_pr_mergeable feat/conflict)"
+# No PR -> empty (callers treat empty as "nothing to gate on").
+assert_eq "gh pr_mergeable no-PR → empty" "" \
+    "$(cd "$MREPO" && FORGE=github GH_CMD="$MT_STUB" MT_NOPR=1 forge_pr_mergeable feat/x)"
+# Unresolvable head SHA -> UNKNOWN (fail open, never a false CONFLICTING).
+assert_eq "gh pr_mergeable unresolvable head → UNKNOWN" "UNKNOWN" \
+    "$(cd "$MREPO" && FORGE=github GH_CMD="$MT_STUB" MT_HEAD=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef forge_pr_mergeable feat/x)"
+# gh error (CLI missing) -> empty (fail open).
+assert_eq "gh pr_mergeable gh-error → empty" "" \
+    "$(cd "$MREPO" && FORGE=github GH_CMD=/no/such/gh forge_pr_mergeable feat/x)"
+
 # ── verb routing: bitbucket backend (BITBUCKET_CMD stub) ─────────────────────
 echo "TEST: bitbucket verbs route through BITBUCKET_CMD"
 BB_STUB="$TMP_ROOT/bb-stub.sh"


### PR DESCRIPTION
## Summary
Replace GitHub's async-computed `mergeable` field with a **deterministic local `git merge-tree --write-tree`** conflict check in the github forge backend.

GitHub computes `mergeable` lazily and returns `UNKNOWN` right after a push, which stalled the pre-push conflict gate and forced a bounded poll before merge. The local check is offline, immediate, and never hangs on GitHub.

## What changed
- **`scripts/lib/forge-github.sh`** — `gh_forge_pr_mergeable` reads only base+head refs via a synchronous `gh pr view --json baseRefName,headRefOid`, then runs `git merge-tree --write-tree`: exit `0`→`MERGEABLE`, `1`→`CONFLICTING`, else→`UNKNOWN`. Base+head are `git rev-parse --verify`'d **before** merge-tree, so a missing ref (also exit 1) is never mistaken for a real conflict.
- **`scripts/handover/pr-merge.sh`** — the mergeability poll is replaced by a single deterministic check.
- **`scripts/hooks/check-pr-mergeable.sh`** — no logic change; the seam contract is preserved, so the pre-push `CONFLICTING` hard-refuse is intact.
- Bitbucket backend untouched (still `UNKNOWN`, no pre-merge signal).

## Tool choice
`git merge-tree --write-tree` (Git 2.38+) over: legacy trivial merge-tree (always exits 0, no verdict), temp-worktree `git merge --no-commit` (mutates state), GraphQL `mergeStateStatus` (still async GitHub-side).

## Fail-open
Any tooling gap (no PR, gh error, unresolvable base/head, git < 2.38) degrades to `UNKNOWN`/empty — the check never hard-blocks a push or merge on a tool gap.

## Tests
Three shell suites exercise **real** local merges against real clean/conflicting branch pairs (not a mocked `mergeable` string); all green, shellcheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request merge checks by detecting conflicts locally and deterministically.
  * Merge attempts now stop immediately when a real conflict is detected.
  * Unavailable or inconclusive mergeability information no longer blocks otherwise valid merge attempts.
  * Updated merge validation and test coverage for clean, conflicting, missing, and failed pull request states.

* **Documentation**
  * Updated merge command and hook documentation to reflect the revised mergeability behavior and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->