### PR TITLE
fix(himmel-1235): x-media provenance splice + --repair-provenance (traversal + substring hardened)

### DIFF
--- a/marketplace/plugins/obsidian-triage/tests/test-x-media-enrich.sh
+++ b/marketplace/plugins/obsidian-triage/tests/test-x-media-enrich.sh
@@ -621,6 +621,294 @@ assert "inbox same.md -> _media/same-7001/" ok "$a"
 [ -d "$VX/Clippings/_media/same-7002" ] && a=ok || a=no
 assert "_done same.md -> _media/same-7002/ (distinct, no collision)" ok "$a"
 
+# --- Test 15: _splice_crawled preserves x-media provenance when splicing into
+# an EXISTING ## Crawled content section from an earlier fxtwitter pass
+# (HIMMEL-1235). Before the fix, the existing-section branch started at the
+# first ### heading and dropped the <!-- media-enriched ... via x-media -->
+# comment, so --apply-digest's provenance guard refused every such clip.
+echo "Test 15: _splice_crawled preserves provenance into an EXISTING crawled section (HIMMEL-1235)"
+emit_gallery_dl 1.jpg
+SP="$tmp/vault-splice"; mkdir -p "$SP/Clippings"
+cat > "$SP/Clippings/clip.md" <<EOF
+---
+title: "splice existing"
+source: "https://x.com/someuser/status/2001"
+type: tweet
+---
+# splice existing
+$IMAGE_MEDIA
+
+## Crawled content
+<!-- enriched 2026-07-01 via fxtwitter -->
+
+Some prior fxtwitter crawled text.
+
+## Source
+[link](https://x.com/someuser/status/2001)
+EOF
+run_tool "$SP" >"$tmp/splice.out" 2>"$tmp/splice.err"
+assert "splice run exit 0" 0 "$?"
+today="$(date +%Y-%m-%d)"
+grep -qF "<!-- media-enriched $today via x-media -->" "$SP/Clippings/clip.md" && a=ok || a=no
+assert "x-media provenance comment present after splice into existing section" ok "$a"
+grep -qF "Some prior fxtwitter crawled text." "$SP/Clippings/clip.md" && a=ok || a=no
+assert "prior fxtwitter content preserved" ok "$a"
+prov_line="$(grep -n 'media-enriched' "$SP/Clippings/clip.md" | head -1 | cut -d: -f1)"
+marker_line="$(grep -n 'slides-pending-digest' "$SP/Clippings/clip.md" | head -1 | cut -d: -f1)"
+if [ -n "$prov_line" ] && [ -n "$marker_line" ] && [ "$prov_line" -lt "$marker_line" ]; then a=ok; else a=no; fi
+assert "provenance precedes pending marker" ok "$a"
+printf 'Slide 1: repaired splice digest.\n' > "$tmp/splice-digest.txt"
+run_tool --apply-digest "$SP/Clippings/clip.md" --digest-file "$tmp/splice-digest.txt" >"$tmp/splice-apply.out" 2>"$tmp/splice-apply.err"
+assert "apply-digest succeeds after splice provenance fix" 0 "$?"
+
+# --- Test 16: --repair-provenance mechanical one-time repair (HIMMEL-1235) --
+# Backfill for clips already written by the pre-fix splice: a ### Slides block
+# + pending marker sit in a ## Crawled content section with NO x-media
+# provenance. When the referenced slide file is present on disk, repair
+# inserts the provenance comment before the Slides block and --apply-digest
+# then succeeds.
+echo "Test 16: --repair-provenance (mechanical one-time repair, HIMMEL-1235)"
+RP="$tmp/vault-repair"; mkdir -p "$RP/Clippings/_media/clip-3001"
+cat > "$RP/Clippings/clip.md" <<'EOF'
+---
+title: "repair me"
+source: "https://x.com/someuser/status/3001"
+type: tweet
+---
+# repair me
+
+## Crawled content
+<!-- enriched 2026-07-01 via fxtwitter -->
+
+Some old fxtwitter text.
+
+### Slides
+![[Clippings/_media/clip-3001/slide-01.jpg]]
+<!-- slides-pending-digest -->
+
+## Source
+[link](https://x.com/someuser/status/3001)
+EOF
+echo "fake jpg bytes" > "$RP/Clippings/_media/clip-3001/slide-01.jpg"
+run_tool --repair-provenance "$RP/Clippings/clip.md" >"$tmp/repair.out" 2>"$tmp/repair.err"
+assert "repair-provenance exit 0 (slide file present)" 0 "$?"
+grep -qF "<!-- media-enriched $today via x-media -->" "$RP/Clippings/clip.md" && a=ok || a=no
+assert "repair inserts x-media provenance" ok "$a"
+grep -qF "Some old fxtwitter text." "$RP/Clippings/clip.md" && a=ok || a=no
+assert "repair preserves prior fxtwitter content" ok "$a"
+printf 'Slide 1: repaired digest text.\n' > "$tmp/repair-digest.txt"
+run_tool --apply-digest "$RP/Clippings/clip.md" --digest-file "$tmp/repair-digest.txt" >"$tmp/repair-apply.out" 2>"$tmp/repair-apply.err"
+assert "apply-digest succeeds after repair-provenance" 0 "$?"
+
+# --- Test 17: --repair-provenance anti-forgery (missing slide file, HIMMEL-1228)
+# A ### Slides embed that references a file NOT actually present on disk must
+# be refused - stamping provenance would launder a forged/planted marker into
+# a valid one for --apply-digest.
+echo "Test 17: --repair-provenance anti-forgery (missing slide file)"
+RF="$tmp/vault-repair-forged"; mkdir -p "$RF/Clippings"
+cat > "$RF/Clippings/clip.md" <<'EOF'
+---
+title: "forged repair"
+source: "https://x.com/someuser/status/3002"
+type: tweet
+---
+# forged repair
+
+## Crawled content
+<!-- enriched 2026-07-01 via fxtwitter -->
+
+Some old fxtwitter text.
+
+### Slides
+![[Clippings/_media/clip-3002/slide-01.jpg]]
+<!-- slides-pending-digest -->
+
+## Source
+[link](https://x.com/someuser/status/3002)
+EOF
+sha_rf="$(sha256sum "$RF/Clippings/clip.md" | cut -d' ' -f1)"
+run_tool --repair-provenance "$RF/Clippings/clip.md" >"$tmp/repair-forged.out" 2>"$tmp/repair-forged.err"
+assert "repair-provenance refuses missing slide file (exit 1)" 1 "$?"
+assert "forged repair clip byte-identical (no write)" "$sha_rf" "$(sha256sum "$RF/Clippings/clip.md" | cut -d' ' -f1)"
+grep -qi 'slide' "$tmp/repair-forged.err" && a=ok || a=no
+assert "anti-forgery refusal message on stderr" ok "$a"
+
+# --- Test 18: --repair-provenance path-traversal containment (codex-adv) ----
+# The Slides embed regex accepts any suffix after Clippings/_media/, so a
+# crafted ../ embed could resolve (following .. and symlinks) to a real file
+# OUTSIDE _media and satisfy the "slide exists" anti-forgery gate, laundering
+# forged provenance. The containment check must resolve each embed and require
+# it stays UNDER Clippings/_media/ - a traversal to a real out-of-_media file
+# is refused, exit 1, no write.
+echo "Test 18: --repair-provenance refuses path-traversal embed (codex-adv)"
+RT="$tmp/vault-repair-traversal"; mkdir -p "$RT/Clippings/_media"
+echo "a real file outside _media" > "$RT/secret.txt"
+cat > "$RT/Clippings/clip.md" <<'EOF'
+---
+title: "traversal repair"
+source: "https://x.com/someuser/status/3003"
+type: tweet
+---
+# traversal repair
+
+## Crawled content
+<!-- enriched 2026-07-01 via fxtwitter -->
+
+Some old fxtwitter text.
+
+### Slides
+![[Clippings/_media/../../secret.txt]]
+<!-- slides-pending-digest -->
+
+## Source
+[link](https://x.com/someuser/status/3003)
+EOF
+sha_rt="$(sha256sum "$RT/Clippings/clip.md" | cut -d' ' -f1)"
+run_tool --repair-provenance "$RT/Clippings/clip.md" >"$tmp/repair-trav.out" 2>"$tmp/repair-trav.err"
+assert "repair-provenance refuses ../ traversal embed (exit 1)" 1 "$?"
+assert "traversal repair clip byte-identical (no write)" "$sha_rt" "$(sha256sum "$RT/Clippings/clip.md" | cut -d' ' -f1)"
+grep -qF "<!-- media-enriched" "$RT/Clippings/clip.md" && a=no || a=ok
+assert "no x-media provenance stamped on traversal embed" ok "$a"
+
+# --- Test 19: untrusted crawled prose containing the literal "via x-media -->"
+# substring must NOT be mistaken for real provenance (codex-adv HIMMEL-1235).
+# Before the anchored-regex fix, a bare substring match in _splice_crawled
+# suppressed the real provenance insert (permanently stranding the clip's
+# digest) and --apply-digest's own substring guard would also be fooled.
+echo "Test 19: untrusted prose substring 'via x-media -->' does not defeat anchored provenance detection (codex-adv)"
+emit_gallery_dl 1.jpg
+SB="$tmp/vault-substring"; mkdir -p "$SB/Clippings"
+cat > "$SB/Clippings/clip.md" <<EOF
+---
+title: "substring defeat attempt"
+source: "https://x.com/someuser/status/2002"
+type: tweet
+---
+# substring defeat attempt
+$IMAGE_MEDIA
+
+## Crawled content
+<!-- enriched 2026-07-01 via fxtwitter -->
+
+Some tweet text mentioning via x-media --> inline.
+
+## Source
+[link](https://x.com/someuser/status/2002)
+EOF
+run_tool "$SB" >"$tmp/substring.out" 2>"$tmp/substring.err"
+assert "substring-defeat run exit 0" 0 "$?"
+today="$(date +%Y-%m-%d)"
+grep -qE "^<!-- media-enriched .* via x-media -->" "$SB/Clippings/clip.md" && a=ok || a=no
+assert "anchored provenance line present despite untrusted substring in prose" ok "$a"
+printf 'Slide 1: substring-defeat digest.\n' > "$tmp/substring-digest.txt"
+run_tool --apply-digest "$SB/Clippings/clip.md" --digest-file "$tmp/substring-digest.txt" >"$tmp/substring-apply.out" 2>"$tmp/substring-apply.err"
+assert "apply-digest succeeds with anchored provenance recognized" 0 "$?"
+
+# --- Test 20: --repair-provenance marker must be INSIDE the ### Slides block --
+# The applicability guard counts the pending marker as an anchored line within
+# the ### Slides block, NOT anywhere in the ## Crawled content section
+# (CodeRabbit). A marker planted elsewhere in the section (here, before the
+# Slides block) must NOT qualify the clip for repair - even though a real slide
+# file is present, so it is the marker guard (not the embed guard) that refuses.
+echo "Test 20: --repair-provenance refuses a pending marker outside the ### Slides block (CodeRabbit)"
+RM="$tmp/vault-repair-marker"; mkdir -p "$RM/Clippings/_media/clip-3004"
+echo "fake jpg bytes" > "$RM/Clippings/_media/clip-3004/slide-01.jpg"
+cat > "$RM/Clippings/clip.md" <<'EOF'
+---
+title: "marker outside slides"
+source: "https://x.com/someuser/status/3004"
+type: tweet
+---
+# marker outside slides
+
+## Crawled content
+<!-- enriched 2026-07-01 via fxtwitter -->
+<!-- slides-pending-digest -->
+
+Some old fxtwitter text.
+
+### Slides
+![[Clippings/_media/clip-3004/slide-01.jpg]]
+
+## Source
+[link](https://x.com/someuser/status/3004)
+EOF
+sha_rm="$(sha256sum "$RM/Clippings/clip.md" | cut -d' ' -f1)"
+run_tool --repair-provenance "$RM/Clippings/clip.md" >"$tmp/repair-marker.out" 2>"$tmp/repair-marker.err"
+assert "repair-provenance refuses marker outside ### Slides (exit 1)" 1 "$?"
+assert "marker-outside repair clip byte-identical (no write)" "$sha_rm" "$(sha256sum "$RM/Clippings/clip.md" | cut -d' ' -f1)"
+grep -qF "<!-- media-enriched" "$RM/Clippings/clip.md" && a=no || a=ok
+assert "no x-media provenance stamped when marker is outside Slides" ok "$a"
+
+# --- Test 21: --repair-provenance marker in a LATER sibling ### subsection ----
+# slides_block is bounded to the ### Slides subsection (up to the next ##/###
+# heading), so a marker in a following ### subsection (e.g. ### Transcript) is
+# NOT counted as inside Slides (codex). A real slide is present, so it is the
+# marker guard - not the embed guard - that refuses.
+echo "Test 21: --repair-provenance refuses a marker in a later sibling ### subsection (codex)"
+RS="$tmp/vault-repair-sibling"; mkdir -p "$RS/Clippings/_media/clip-3005"
+echo "fake jpg bytes" > "$RS/Clippings/_media/clip-3005/slide-01.jpg"
+cat > "$RS/Clippings/clip.md" <<'EOF'
+---
+title: "marker in sibling subsection"
+source: "https://x.com/someuser/status/3005"
+type: tweet
+---
+# marker in sibling subsection
+
+## Crawled content
+<!-- enriched 2026-07-01 via fxtwitter -->
+
+### Slides
+![[Clippings/_media/clip-3005/slide-01.jpg]]
+
+### Transcript
+<!-- slides-pending-digest -->
+
+## Source
+[link](https://x.com/someuser/status/3005)
+EOF
+sha_rs="$(sha256sum "$RS/Clippings/clip.md" | cut -d' ' -f1)"
+run_tool --repair-provenance "$RS/Clippings/clip.md" >"$tmp/repair-sibling.out" 2>"$tmp/repair-sibling.err"
+assert "repair-provenance refuses marker in later ### subsection (exit 1)" 1 "$?"
+assert "sibling-subsection repair clip byte-identical (no write)" "$sha_rs" "$(sha256sum "$RS/Clippings/clip.md" | cut -d' ' -f1)"
+grep -qF "<!-- media-enriched" "$RS/Clippings/clip.md" && a=no || a=ok
+assert "no x-media provenance stamped when marker is in a sibling subsection" ok "$a"
+
+# --- Test 22: --repair-provenance requires the EXACT ### Slides heading -------
+# `^### Slides\b` accepted decorated headings like `### Slides are attached` or
+# `### Slides<!-- x -->`; the anchored `^### Slides[ \t]*$` rejects them, so a
+# crafted heading (with a valid embed + marker) can't pass the repair gate
+# (CodeRabbit, Major/Security). Real slide present -> it's the heading match, not
+# the embed guard, that refuses.
+echo "Test 22: --repair-provenance rejects a decorated ### Slides heading (CodeRabbit)"
+RH="$tmp/vault-repair-heading"; mkdir -p "$RH/Clippings/_media/clip-3006"
+echo "fake jpg bytes" > "$RH/Clippings/_media/clip-3006/slide-01.jpg"
+cat > "$RH/Clippings/clip.md" <<'EOF'
+---
+title: "decorated slides heading"
+source: "https://x.com/someuser/status/3006"
+type: tweet
+---
+# decorated slides heading
+
+## Crawled content
+<!-- enriched 2026-07-01 via fxtwitter -->
+
+### Slides are attached
+![[Clippings/_media/clip-3006/slide-01.jpg]]
+<!-- slides-pending-digest -->
+
+## Source
+[link](https://x.com/someuser/status/3006)
+EOF
+sha_rh="$(sha256sum "$RH/Clippings/clip.md" | cut -d' ' -f1)"
+run_tool --repair-provenance "$RH/Clippings/clip.md" >"$tmp/repair-heading.out" 2>"$tmp/repair-heading.err"
+assert "repair-provenance rejects decorated ### Slides heading (exit 1)" 1 "$?"
+assert "decorated-heading repair clip byte-identical (no write)" "$sha_rh" "$(sha256sum "$RH/Clippings/clip.md" | cut -d' ' -f1)"
+grep -qF "<!-- media-enriched" "$RH/Clippings/clip.md" && a=no || a=ok
+assert "no x-media provenance stamped on decorated ### Slides heading" ok "$a"
+
 # --- Test 14: doc-contract -------------------------------------------------
 echo "Test 14: /x-media-enrich runbook + catalog + README doc-contract"
 CMD="$SCRIPT_DIR/../commands/x-media-enrich.md"

--- a/marketplace/plugins/obsidian-triage/tools/x-media-fetch.py
+++ b/marketplace/plugins/obsidian-triage/tools/x-media-fetch.py
@@ -54,6 +54,12 @@ if hasattr(sys.stdout, "reconfigure"):
     sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
 TODAY = datetime.date.today().isoformat()
+# Anchored provenance detector (codex-adv HIMMEL-1235): a real x-media
+# provenance comment occupies its own line. A bare substring match (e.g.
+# "via x-media -->" anywhere in the text) is defeatable by untrusted
+# crawled/tweet prose that happens to contain that literal string, so every
+# provenance-detection site shares THIS anchored full-line check instead.
+PROV_RE = re.compile(r"(?m)^<!-- media-enriched \S+ via x-media -->[ \t]*$")
 RATE_LIMIT_S = 0 if os.environ.get("X_MEDIA_NO_SLEEP") else 10
 DEFAULT_LIMIT = 10
 SLIDE_CAP = 20
@@ -638,6 +644,18 @@ def _splice_crawled(body: str, section: str) -> str:
         head, after = body[:cut], body[cut:]
         h3 = re.search(r"(?m)^### ", section)
         blocks = (section[h3.start():] if h3 else section).rstrip("\n")
+        # HIMMEL-1235: starting `blocks` at the first ### heading drops
+        # render_crawled's <!-- media-enriched ... via x-media --> provenance
+        # comment (it lives BEFORE the first ###). An existing section from an
+        # earlier fxtwitter pass carries no such comment, so the spliced-in
+        # ### Slides + pending marker would land with no x-media provenance and
+        # the --apply-digest guard would refuse forever. Prepend it here -
+        # unless the existing section already has x-media provenance (a
+        # same-tool re-run), which must not duplicate the comment. Detection is
+        # the anchored PROV_RE (codex-adv): a bare "via x-media -->" substring
+        # buried in untrusted crawled prose no longer counts as real provenance.
+        if not PROV_RE.search(body[m.start():cut]):
+            blocks = f"<!-- media-enriched {TODAY} via x-media -->\n\n" + blocks
         sep = "" if head.endswith("\n\n") else ("\n" if head.endswith("\n") else "\n\n")
         return head + sep + blocks + "\n" + after
     src = re.search(r"(?m)^## Source\b", body)
@@ -744,6 +762,7 @@ def parse_args(argv):
     ap.add_argument("--whisper-model", default=DEFAULT_WHISPER_MODEL)
     ap.add_argument("--apply-digest", type=Path, default=None, metavar="CLIP")
     ap.add_argument("--digest-file", type=Path, default=None, metavar="FILE")
+    ap.add_argument("--repair-provenance", type=Path, default=None, metavar="CLIP")
     ap.add_argument("--flag-screen", type=Path, default=None, metavar="CLIP")
     ap.add_argument("--detail", default=None, metavar="DETAIL")
     return ap.parse_args(argv)
@@ -947,18 +966,18 @@ def run_apply_digest(clip: Path, digest_file: Path) -> int:
         print("x-media-fetch --apply-digest: expected exactly one pending "
               "marker; found %d" % body.count(marker), file=sys.stderr)
         return 1
-    # Provenance guard (codex-adv HIMMEL-1226, partial): the pending marker must
+    # Provenance guard (codex-adv HIMMEL-1226/1235): the pending marker must
     # sit inside a tool-written x-media ## Crawled content section - proven by
-    # the "via x-media" provenance comment that render_crawled always emits and
-    # the marker following it. A bare marker planted in attacker-controlled clip
-    # prose (or a clip that merely mentions the literal string) is refused, so
-    # the applier never treats forged/accidental markers as workflow control.
+    # an ANCHORED, full-line "via x-media" provenance comment (PROV_RE) that
+    # render_crawled always emits, with the marker following it. A bare marker
+    # planted in attacker-controlled clip prose (or a clip whose crawled prose
+    # merely CONTAINS the literal substring, mid-line) is refused, so the
+    # applier never treats forged/accidental markers as workflow control.
     # NOT unforgeable (an attacker who copies the whole crawled block still
     # passes) - the full per-run-nonce + media-path-ownership fix spanning BOTH
     # media rungs is HIMMEL-1228; this raises the bar cheaply for now.
-    prov = body.find("<!-- media-enriched")
-    prov_end = body.find("via x-media -->", prov) if prov >= 0 else -1
-    if prov < 0 or prov_end < 0 or body.index(marker) < prov_end:
+    prov_m = PROV_RE.search(body)
+    if prov_m is None or body.index(marker) < prov_m.end():
         print("x-media-fetch --apply-digest: pending marker is not inside an "
               "x-media crawled section (no 'via x-media' provenance before it); "
               "refusing", file=sys.stderr)
@@ -992,6 +1011,137 @@ def run_apply_digest(clip: Path, digest_file: Path) -> int:
               "reverted", file=sys.stderr)
         return 3
     print(f"OK apply-digest {clip.name}: 1 ### Slide digest H3 added, marker stripped")
+    return 0
+
+
+def _vault_root_from_clip(clip: Path) -> Path:
+    """Vault root = the directory above the clip's Clippings/ ancestor (the
+    clip lives at <vault>/Clippings/..., possibly nested under a pool like
+    _done/2026-05/). Walk parents rather than assume a fixed depth."""
+    for p in clip.resolve().parents:
+        if p.name == "Clippings":
+            return p.parent
+    return clip.resolve().parent
+
+
+def run_repair_provenance(clip: Path) -> int:
+    """One-time mechanical repair (HIMMEL-1235) for clips already written by
+    the pre-fix _splice_crawled: a ### Slides block + exactly one
+    <!-- slides-pending-digest --> marker were spliced into a PRE-EXISTING
+    ## Crawled content section (e.g. from an earlier fxtwitter pass) with NO
+    <!-- media-enriched ... via x-media --> provenance comment, so
+    --apply-digest's provenance guard refuses them forever. Not applicable
+    (exit 1, no write) when there is no ## Crawled content section, no
+    ### Slides block + exactly one pending marker inside it, or the section
+    already carries x-media provenance.
+
+    Anti-forgery (HIMMEL-1228): BEFORE stamping provenance, every
+    ![[Clippings/_media/<slug>/slide-NN.jpg]] embed in the ### Slides block
+    must resolve to a file that actually exists on disk (relative to the
+    vault root derived from the clip's own path) - a bare Slides block with no
+    embeds, or an embed pointing at a missing file, is refused. This prevents
+    laundering a forged/planted marker into one --apply-digest will accept.
+
+    Scoped-G-3: a reconstruction check (removing exactly the inserted
+    provenance text reproduces the pre-write body byte-for-byte) plus fm_raw
+    hash immutability, mirroring run_apply_digest. Reverts on any violation.
+    Exit 0 repaired, 1 usage/not-applicable, 3 G-3 failure."""
+    if not clip.is_file():
+        print("x-media-fetch --repair-provenance: clip not found: %s" % clip,
+              file=sys.stderr)
+        return 1
+    text, has_crlf = read_clip(clip)
+    _fm, fm_raw, body, present = parse_frontmatter(text)
+    if not present:
+        print("x-media-fetch --repair-provenance: no frontmatter",
+              file=sys.stderr)
+        return 1
+    m = re.search(r"(?m)^## Crawled content\b", body)
+    if not m:
+        print("x-media-fetch --repair-provenance: no ## Crawled content "
+              "section; not applicable", file=sys.stderr)
+        return 1
+    rest = body[m.end():]
+    nxt = re.search(r"(?m)^## (?!Crawled content)", rest)
+    sec_end = m.end() + (nxt.start() if nxt else len(rest))
+    section = body[m.start():sec_end]
+    marker = "<!-- slides-pending-digest -->"
+    marker_re = re.compile(r"(?m)^" + re.escape(marker) + r"[ \t]*$")
+    slides_m = re.search(r"(?m)^### Slides[ \t]*$", section)
+    # HIMMEL-1235 (CodeRabbit/codex): the pending marker must sit INSIDE the
+    # ### Slides block as its own anchored line, not merely somewhere in the
+    # ## Crawled content section - a marker planted elsewhere in the section, in
+    # a LATER sibling ### subsection, or mid-line in prose must not qualify a
+    # clip for provenance repair. Bound slides_block to the ### Slides subsection
+    # (up to the next ## / ### heading), so the marker AND embed checks below are
+    # scoped to Slides alone.
+    if slides_m:
+        after_slides = section[slides_m.end():]
+        nxt_h = re.search(r"(?m)^#{2,3} ", after_slides)
+        slides_end = slides_m.end() + (nxt_h.start() if nxt_h else len(after_slides))
+        slides_block = section[slides_m.start():slides_end]
+    else:
+        slides_block = ""
+    if not slides_m or len(marker_re.findall(slides_block)) != 1:
+        print("x-media-fetch --repair-provenance: no ### Slides block + "
+              "exactly one pending marker line in the ### Slides block; not "
+              "applicable", file=sys.stderr)
+        return 1
+    if PROV_RE.search(section):
+        print("x-media-fetch --repair-provenance: section already carries "
+              "x-media provenance; not applicable", file=sys.stderr)
+        return 1
+    embeds = re.findall(r"(?m)^!\[\[(Clippings/_media/[^\]]+?)\]\]$",
+                        slides_block)
+    vault_root = _vault_root_from_clip(clip)
+    media_root = (vault_root / "Clippings" / "_media").resolve()
+
+    def _contained_slide(embed: str) -> bool:
+        # Anti-forgery containment (HIMMEL-1235 / codex-adv): the embed regex
+        # accepts any suffix after Clippings/_media/, so a crafted ../ (or
+        # symlink) embed could otherwise resolve to an arbitrary existing file
+        # (e.g. .../Windows/win.ini) and satisfy the "slide exists" gate,
+        # laundering forged provenance. Resolve the path (following .. and
+        # symlinks) and require it stays UNDER Clippings/_media/ AND is a real
+        # file. (Binding a slide to the clip's own status id stays HIMMEL-1228.)
+        try:
+            p = (vault_root / embed).resolve()
+        except (OSError, RuntimeError):
+            return False
+        return p.is_relative_to(media_root) and p.is_file()
+
+    missing = [e for e in embeds if not _contained_slide(e)]
+    if not embeds or missing:
+        print("x-media-fetch --repair-provenance: refusing - referenced "
+              "slide file(s) missing on disk: %s"
+              % (", ".join(missing) if missing else "(no slide embeds found)"),
+              file=sys.stderr)
+        return 1
+    slides_abs = m.start() + slides_m.start()
+    before, after = body[:slides_abs], body[slides_abs:]
+    sep = "" if before.endswith("\n\n") else ("\n" if before.endswith("\n") else "\n\n")
+    prov = f"<!-- media-enriched {TODAY} via x-media -->"
+    inserted = sep + prov + "\n\n"
+    new_body = before + inserted + after
+    # Scoped-G-3: removing exactly the inserted text must reproduce the
+    # baseline body byte-for-byte (proves nothing outside it changed).
+    reconstructed = new_body.replace(inserted, "", 1)
+    if reconstructed != body:
+        print("x-media-fetch --repair-provenance: scoped-G-3 reconstruction "
+              "mismatch; refusing", file=sys.stderr)
+        return 3
+    new_text = f"---\n{fm_raw}\n---\n{new_body}"
+    write_clip(clip, new_text, has_crlf)
+    disk, _ = read_clip(clip)
+    _dfm, dfm_raw, dbody, dpresent = parse_frontmatter(disk)
+    ok = dpresent and dbody == new_body and _sha(dfm_raw) == _sha(fm_raw)
+    if not ok:
+        write_clip(clip, text, has_crlf)   # revert
+        print("x-media-fetch --repair-provenance: post-write verify failed; "
+              "reverted", file=sys.stderr)
+        return 3
+    print(f"OK repair-provenance {clip.name}: x-media provenance inserted "
+          f"before ### Slides")
     return 0
 
 
@@ -1035,6 +1185,8 @@ def main():
     args = parse_args(sys.argv[1:])
     if args.apply_digest is not None:
         sys.exit(run_apply_digest(args.apply_digest, args.digest_file))
+    if args.repair_provenance is not None:
+        sys.exit(run_repair_provenance(args.repair_provenance))
     if args.flag_screen is not None:
         sys.exit(run_flag_screen(args.flag_screen, args.detail))
     if args.vault is None or not args.vault.is_dir():


### PR DESCRIPTION
## HIMMEL-1235 — x-media provenance splice fix + `--repair-provenance`

Fixes the `_splice_crawled` provenance-drop bug in the X media-enrichment
rung and adds a one-time `--repair-provenance` backfill mode, plus two
security hardenings surfaced by an adversarial review pass.

### What changed
1. **Splice provenance drop (the core bug).** `_splice_crawled` dropped the
   `<!-- media-enriched … via x-media -->` provenance comment when upserting a
   `### Slides` block into a **pre-existing** `## Crawled content` section,
   because the block scan started at the first `###`. Clips then landed with
   no x-media provenance and `--apply-digest`'s guard refused them forever.
   Provenance is now prepended when the existing section lacks it (no dup on
   same-tool re-run).
2. **New `--repair-provenance <clip>`.** Mechanical one-time repair for
   already-written clips; anti-forgery gated (a `### Slides` embed must resolve
   to a real on-disk file), scoped-G-3, frontmatter-immutable, revert-on-fail.
3. **Path-traversal / symlink containment.** The repair anti-forgery gate used
   `is_file()`, which follows `../` and symlinks — a crafted embed could
   resolve to any existing file outside `_media`. Each embed must now resolve
   **under** `Clippings/_media/` **and** be a real file.
4. **Anchored provenance detection.** Replaced bare `"via x-media -->"`
   substring matching (at three sites) with one shared anchored full-line
   regex, so untrusted crawled prose can neither suppress a real provenance
   insert nor be mistaken for provenance.

### Tests
`marketplace/plugins/obsidian-triage/tests/test-x-media-enrich.sh` — added
coverage for splice behavior, successful/blocked repair, spoofing attempts,
missing/traversal slide embeds, and strict marker placement.
