### PR TITLE
fix: collection-scope the qmd MCP carve-out on the GLM/hermes lanes (fail-closed)

### DIFF
--- a/scripts/hermes/assets/parity_guard.py
+++ b/scripts/hermes/assets/parity_guard.py
@@ -591,6 +591,69 @@ def terminal_external_write_reason(cmd_norm: str):
     return None
 
 
+# --- qmd MCP collection fence (HIMMEL-1239) ---------------------------------
+# v1 allow-list: ONLY the "himmel" collection (non-sensitive, repo-local
+# docs). qmd indexes salus (a PHI medical vault) alongside himmel/luna/
+# luna-curated with NO built-in isolation, so a blanket allow of the qmd MCP
+# tools would let an untrusted engine egress PHI via the qmd MCP path even
+# though the PHI/data-egress fence above hard-denies salus by file path.
+# Widening this list (e.g. adding luna-curated) is a SEPARATE named operator
+# decision — do not add collections here without one.
+QMD_ALLOWED_COLLECTIONS = {"himmel"}
+
+# qmd's findDocument() resolver (qmd src/store.ts) falls back to matching a
+# bare/relative filename or a #docid against EVERY collection in turn when no
+# `qmd://<collection>/` scheme is given — such an input cannot be positively
+# attributed to one collection from the tool-call JSON alone, so only the
+# fully-qualified qmd://himmel/... virtual-path form is accepted.
+QMD_HIMMEL_SCOPED = re.compile(r"^\s*qmd://himmel/")
+
+
+def qmd_scope_reason(tool: str, args: dict):
+    """Return a block reason if this qmd MCP call (tool startswith
+    'mcp__plugin_qmd_qmd__') is not positively scoped to the v1 allow-listed
+    collection, else None (allow)."""
+    if tool == "mcp__plugin_qmd_qmd__query":
+        collections = args.get("collections")
+        if not isinstance(collections, list) or not collections:
+            return ("qmd query with no 'collections' filter is unscoped "
+                    "(falls back to the store's default collections, which "
+                    "may include salus) — pass collections=[\"himmel\"] "
+                    "(HIMMEL-1239).")
+        # isinstance-guard each entry — a non-string entry (e.g. a dict) makes
+        # `c not in <set-of-str>` raise TypeError, which would otherwise reach
+        # the outer fail-closed catch-all (main()'s try/except) instead of
+        # denying with a specific, documented reason (CR round 1, HIMMEL-1239).
+        bad = [c for c in collections
+               if not isinstance(c, str) or c not in QMD_ALLOWED_COLLECTIONS]
+        if bad:
+            return (f"qmd query is scoped to the 'himmel' collection only "
+                     f"(v1 allow-list, HIMMEL-1239); saw: {bad}.")
+        return None
+    if tool == "mcp__plugin_qmd_qmd__get":
+        file_arg = args.get("file")
+        if not isinstance(file_arg, str) or not QMD_HIMMEL_SCOPED.match(file_arg):
+            return ("qmd get requires a fully-qualified qmd://himmel/... path "
+                     "(v1 allow-list, HIMMEL-1239) — bare paths and #docids "
+                     "are cross-collection-ambiguous and denied fail-closed.")
+        return None
+    if tool == "mcp__plugin_qmd_qmd__multi_get":
+        pattern = args.get("pattern")
+        if not isinstance(pattern, str) or not pattern:
+            return ("qmd multi_get requires a qmd://himmel/... pattern "
+                     "(HIMMEL-1239).")
+        segs = [s.strip() for s in pattern.split(",")]
+        if not all(QMD_HIMMEL_SCOPED.match(s) for s in segs):
+            return ("qmd multi_get requires every segment to be a fully-"
+                     "qualified qmd://himmel/... path/glob (v1 allow-list, "
+                     "HIMMEL-1239).")
+        return None
+    # status (no scoping input) and any other/future qmd tool: scope cannot
+    # be positively determined from the tool-call JSON -> deny fail-closed.
+    return (f"qmd tool '{tool}' has no collection-scoping input this guard "
+            f"can verify — denied fail-closed (HIMMEL-1239).")
+
+
 def main() -> None:
     payload = json.load(sys.stdin)
     tool = payload.get("tool_name", "")
@@ -600,11 +663,16 @@ def main() -> None:
     # 731). himmel's CC PreToolUse hooks do NOT load under hermes, so an MCP tool
     # call would reach the engine UNFENCED — a real external-write surface on the
     # default lane. Blanket-deny every mcp__* tool EXCEPT the read-only qmd
-    # knowledge-base carve-out (mirrors block-glm-external-writes.sh). This fires
-    # unconditionally on this cloud profile (both engines); the matcher extension
-    # in wire_parity_guard.py is what makes the guard see mcp__* tools at all.
+    # knowledge-base carve-out (mirrors block-glm-external-writes.sh), which is
+    # itself COLLECTION-SCOPED to the "himmel" v1 allow-list (HIMMEL-1239 — see
+    # qmd_scope_reason() above). This fires unconditionally on this cloud
+    # profile (both engines); the matcher extension in wire_parity_guard.py is
+    # what makes the guard see mcp__* tools at all.
     if tool.startswith("mcp__"):
         if tool.startswith("mcp__plugin_qmd_qmd__"):
+            reason = qmd_scope_reason(tool, args)
+            if reason:
+                block(reason)
             allow()
         block(f"MCP tool '{tool}' is refused under hermes — the MCP/backend "
               "surface is an unfenced external-write path on this cloud "

--- a/scripts/hermes/test-parity-guard.sh
+++ b/scripts/hermes/test-parity-guard.sh
@@ -271,8 +271,27 @@ echo "== parity_guard: block-backend-tier / MCP fence parity (HIMMEL-731) =="
 g "mcp github tool refused"    block '{"tool_name":"mcp__plugin_github_github__create_pull_request","tool_input":{}}'
 g "mcp vercel tool refused"    block '{"tool_name":"mcp__plugin_vercel_vercel__deploy_to_vercel","tool_input":{}}'
 g "mcp bare tool refused"      block '{"tool_name":"mcp__whatever__do","tool_input":{}}'
-g "mcp qmd KB carve-out allowed"    allow '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{}}'
-g "mcp qmd KB get carve-out allowed" allow '{"tool_name":"mcp__plugin_qmd_qmd__get","tool_input":{}}'
+# qmd MCP collection fence (HIMMEL-1239): the KB carve-out is COLLECTION-
+# SCOPED to "himmel" only — qmd indexes salus (PHI vault) with no built-in
+# isolation, so an unscoped call must deny fail-closed.
+g "mcp qmd query unscoped refused"       block '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{}}'
+g "mcp qmd query scoped himmel allowed"  allow '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{"collections":["himmel"]}}'
+g "mcp qmd query scoped salus refused"   block '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{"collections":["salus"]}}'
+g "mcp qmd query scoped luna refused"    block '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{"collections":["luna"]}}'
+g "mcp qmd query mixed himmel+salus refused" block '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{"collections":["himmel","salus"]}}'
+g "mcp qmd query empty collections refused" block '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{"collections":[]}}'
+g "mcp qmd get scoped himmel allowed"    allow '{"tool_name":"mcp__plugin_qmd_qmd__get","tool_input":{"file":"qmd://himmel/README.md"}}'
+g "mcp qmd get scoped salus refused"     block '{"tool_name":"mcp__plugin_qmd_qmd__get","tool_input":{"file":"qmd://salus/patient.md"}}'
+g "mcp qmd get bare filename refused"    block '{"tool_name":"mcp__plugin_qmd_qmd__get","tool_input":{"file":"README.md"}}'
+g "mcp qmd get docid refused"            block '{"tool_name":"mcp__plugin_qmd_qmd__get","tool_input":{"file":"#abc123"}}'
+g "mcp qmd multi_get scoped himmel allowed" allow '{"tool_name":"mcp__plugin_qmd_qmd__multi_get","tool_input":{"pattern":"qmd://himmel/*.md"}}'
+g "mcp qmd multi_get mixed scoped+unscoped refused" block '{"tool_name":"mcp__plugin_qmd_qmd__multi_get","tool_input":{"pattern":"qmd://himmel/a.md,notes.md"}}'
+g "mcp qmd multi_get luna referenced refused" block '{"tool_name":"mcp__plugin_qmd_qmd__multi_get","tool_input":{"pattern":"qmd://luna/*.md"}}'
+g "mcp qmd status refused (no scoping input)" block '{"tool_name":"mcp__plugin_qmd_qmd__status","tool_input":{}}'
+# CR round 1 (codex-1): a non-string collections entry (e.g. a dict) must not
+# crash the guard via `c not in <set-of-str>` raising TypeError — it must
+# deny fail-closed like any other non-"himmel" entry.
+g "mcp qmd query non-string collections entry refused (no crash)" block '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{"collections":[{"x":1}]}}'
 
 echo "== parity_guard: fail-closed on malformed payload =="
 g "malformed json" block 'NOT JSON'

--- a/scripts/hooks/block-glm-external-writes.sh
+++ b/scripts/hooks/block-glm-external-writes.sh
@@ -18,7 +18,8 @@
 #
 # Blocked on-lane:
 #   - ALL mcp__* tools EXCEPT the qmd KB carve-out (v1 chores are repo-local;
-#     blanket beats a verb list; qmd KB reads are operator-allowed, see below)
+#     blanket beats a verb list; qmd KB reads are operator-allowed, COLLECTION-
+#     SCOPED to "himmel" only — see below)
 #   - git push; git remote set-url; git config …url (tripwire un-poisoning)
 #   - the gh CLI EXCEPT the carve-out below — pr create/merge/edit/review/
 #     comment/ready, api, repo, release, gist, … stay blocked (parent-session
@@ -32,7 +33,25 @@
 #     Jira history + recoverable, so GLM workers may update status/comments and
 #     file followup tickets. Atlassian MCP stays blocked (mcp__* below) — Jira
 #     routing is CLI-first (block-backend-tier enforces that in every session).
-#   - the qmd KB (mcp__plugin_qmd_qmd__* tools): read-only knowledge-base access.
+#   - the qmd KB (mcp__plugin_qmd_qmd__* tools): read-only knowledge-base
+#     access, COLLECTION-SCOPED (HIMMEL-1239). qmd indexes salus (a PHI medical
+#     vault) alongside himmel/luna/luna-curated with NO built-in isolation, so
+#     a blanket allow would let the GLM lane egress PHI to api.z.ai via the qmd
+#     MCP path even though egress-matrix.json hard-denies salus by file path.
+#     v1 allow-list = {himmel} ONLY (widening it, e.g. adding luna-curated, is
+#     a SEPARATE named operator decision):
+#       - `query`: allowed only when tool_input.collections is a non-empty
+#         array whose every entry is "himmel" — an absent/empty collections
+#         filter falls back to the store's default collections (unknown from
+#         the tool-call JSON, may include salus) and is denied as unscoped.
+#       - `get` / `multi_get`: allowed only when every file/pattern segment is
+#         a fully-qualified `qmd://himmel/...` virtual path. qmd's resolver
+#         falls back to matching a bare/relative filename or a #docid against
+#         EVERY collection in turn, so anything short of the qmd://<collection>
+#         scheme cannot be positively attributed to one collection and is
+#         denied fail-closed.
+#       - `status` (and any other/future qmd tool): has no collection-scoping
+#         input at all, so it is denied fail-closed too.
 #   - gh issue <anything> (full issue surface — reads AND writes; cr-deferred
 #     followups are gh issues, audited in GitHub + recoverable), plus read-only
 #     PR/CI context: `gh pr view|diff|checks|status|list`, `gh run
@@ -103,8 +122,85 @@ deny() {
     exit 2
 }
 
+# qmd MCP collection fence (HIMMEL-1239). v1 allow-list: ONLY the "himmel"
+# collection (non-sensitive, repo-local docs). Widening this list (e.g. adding
+# luna-curated) is a SEPARATE named operator decision — do not add collections
+# here without one. `qmd_himmel_scoped "<value>"` -> 0 iff the value is a
+# fully-qualified qmd://himmel/... virtual path (see header comment above for
+# why bare/relative paths and #docids are rejected instead of allowed).
+qmd_himmel_scoped() {
+    # Whole-STRING prefix match (CR round 5, HIMMEL-1239) — NOT grep's
+    # per-line match. grep -qE '^...' anchors at the start of EACH LINE, so a
+    # value with an embedded newline where any line starts with
+    # qmd://himmel/ (e.g. "qmd://salus/x\nqmd://himmel/y") passed even though
+    # the value itself starts with salus. Python's re.match (no MULTILINE)
+    # anchors at the actual string start; this replicates that exactly via
+    # parameter expansion (bash 3.2-safe, no grep/sed) — strip leading
+    # whitespace, then a plain glob-prefix case match.
+    _q="$1"
+    _q="${_q#"${_q%%[![:space:]]*}"}"   # strip leading whitespace (\s* in the regex)
+    case "$_q" in qmd://himmel/*) return 0 ;; *) return 1 ;; esac
+}
+
 case "$tool" in
-    mcp__plugin_qmd_qmd__*) exit 0 ;; # KB search/read — operator-allowed (audited-lane policy 2026-07-03)
+    mcp__plugin_qmd_qmd__query)
+        # Single authoritative jq validation (CodeRabbit PR #1353, HIMMEL-1239)
+        # — do NOT round-trip collections through shell lines: the earlier
+        # extract + `[ -z ]` + `grep -vxF` form let collections:["himmel",""]
+        # through, because the empty entry collapses out of the newline-joined
+        # jq -r output and command-substitution trailing-newline stripping, so
+        # `qmd_bad` ended up empty and the deny never fired (an empty-string
+        # collection can mean "all collections" to qmd — a PHI-egress path).
+        # This one check subsumes: non-array (was CR round 1 codex-2),
+        # unscoped/empty array, AND any non-"himmel"/blank entry — matches the
+        # Python qmd_scope_reason() query branch exactly.
+        if ! printf '%s' "$input" | jq -e '(.tool_input.collections) | (type=="array") and (length>0) and (all(.=="himmel"))' >/dev/null 2>&1; then
+            deny "qmd query 'collections' must be a non-empty JSON array of only \"himmel\" on the GLM lane (HIMMEL-1239) — no blank/other entries."
+        fi
+        exit 0
+        ;;
+    mcp__plugin_qmd_qmd__get)
+        qmd_file=$(printf '%s' "$input" | jq -r '.tool_input.file // empty' 2>/dev/null || true)
+        if [ -z "$qmd_file" ] || ! qmd_himmel_scoped "$qmd_file"; then
+            deny "qmd get on the GLM lane requires a fully-qualified qmd://himmel/... path (v1 allow-list, HIMMEL-1239) — bare paths and #docids are cross-collection-ambiguous and denied fail-closed."
+        fi
+        exit 0
+        ;;
+    mcp__plugin_qmd_qmd__multi_get)
+        qmd_pattern=$(printf '%s' "$input" | jq -r '.tool_input.pattern // empty' 2>/dev/null || true)
+        if [ -z "$qmd_pattern" ]; then
+            deny "qmd multi_get on the GLM lane requires a qmd://himmel/... pattern (HIMMEL-1239)."
+        fi
+        # Root-cause fix (CR round 4, HIMMEL-1239): this is the 4th finding
+        # rooted in the same mismatch — bash word-splitting (the prior
+        # `IFS=',' for qmd_seg in $qmd_pattern` loop) DROPS empty
+        # comma-separated fields, so a trailing comma ("a.md,"), a leading
+        # comma (",a.md"), and adjacent commas ("a,,b") all lost their empty
+        # segment and passed despite containing one. Rather than patch the
+        # split mechanism again, replace it: awk -F',' preserves empty fields
+        # (NF counts them), making this PROVABLY equivalent to the Python
+        # qmd_scope_reason() multi_get branch (`[s.strip() for s in
+        # pattern.split(",")]` + a full-match check on every segment, denying
+        # on any empty/non-"qmd://himmel/" segment). No IFS/set -f/for-loop
+        # left to diverge from Python's split semantics.
+        if ! printf '%s' "$qmd_pattern" | awk -F',' '{
+                if (NF==0) exit 1
+                for (i=1;i<=NF;i++) {
+                    s=$i
+                    gsub(/^[[:space:]]+|[[:space:]]+$/,"",s)
+                    if (s !~ /^qmd:\/\/himmel\//) exit 1
+                }
+            }'; then
+            deny "qmd multi_get on the GLM lane requires a non-empty comma list where EVERY segment is a fully-qualified qmd://himmel/... path (HIMMEL-1239) — no empty/blank segments."
+        fi
+        exit 0
+        ;;
+    mcp__plugin_qmd_qmd__*)
+        # status (no scoping input) and any other/future qmd tool: scope
+        # cannot be positively determined from the tool-call JSON -> deny
+        # fail-closed (HIMMEL-1239).
+        deny "qmd tool '$tool' has no collection-scoping input the GLM lane can verify — denied fail-closed (HIMMEL-1239)."
+        ;;
     mcp__*) deny "MCP tool '$tool' is blocked on the GLM lane." ;;
     Bash|PowerShell) ;;
     *) exit 0 ;;

--- a/scripts/hooks/test-block-glm-external-writes.sh
+++ b/scripts/hooks/test-block-glm-external-writes.sh
@@ -101,8 +101,62 @@ assert_rc "glm gh pr checks (allowed)"     0 "$(run_case "$(j_bash 'gh pr checks
 assert_rc "glm gh pr list (allowed)"       0 "$(run_case "$(j_bash 'gh pr list')" "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm gh run list (allowed)"      0 "$(run_case "$(j_bash 'gh run list')" "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm gh run watch (allowed)"     0 "$(run_case "$(j_bash 'gh run watch 123')" "ANTHROPIC_BASE_URL=$GLM_URL")"
-# qmd KB reads are operator-allowed on-lane (carve-out before the blanket mcp deny).
-assert_rc "glm mcp qmd read (allowed)"   0 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+# qmd KB reads are operator-allowed on-lane (carve-out before the blanket mcp
+# deny), but COLLECTION-SCOPED to "himmel" only (HIMMEL-1239) — an unscoped
+# query (no collections filter) could hit salus (PHI vault) and must deny.
+assert_rc "glm mcp qmd query unscoped (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp qmd query scoped himmel (allowed)" 0 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{"collections":["himmel"]}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp qmd query scoped salus (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{"collections":["salus"]}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp qmd query scoped luna (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{"collections":["luna"]}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp qmd query mixed himmel+salus (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{"collections":["himmel","salus"]}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp qmd query empty collections array (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{"collections":[]}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+# CR round 1 (codex-2): collections must be a JSON ARRAY — an object's VALUES
+# must not satisfy the allow-list via `.[]` (e.g. {"x":"himmel"} must deny,
+# matching the Python-side isinstance(collections, list) contract).
+assert_rc "glm mcp qmd query collections object not array (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{"collections":{"x":"himmel"}}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+# CodeRabbit PR #1353: himmel + a BLANK entry must still deny — the earlier
+# extract+grep-vxF shell round-trip let this through because the empty jq -r
+# line collapsed out via command-substitution trailing-newline stripping.
+assert_rc "glm mcp qmd query himmel+blank entry (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{"collections":["himmel",""]}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+# get/multi_get: only a fully-qualified qmd://himmel/... path is positively
+# scoped; bare paths and #docids are cross-collection-ambiguous (deny).
+assert_rc "glm mcp qmd get scoped himmel (allowed)" 0 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__get","tool_input":{"file":"qmd://himmel/README.md"}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp qmd get scoped salus (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__get","tool_input":{"file":"qmd://salus/patient.md"}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp qmd get bare filename unscoped (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__get","tool_input":{"file":"README.md"}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp qmd get docid unscoped (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__get","tool_input":{"file":"#abc123"}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+# CR round 5 (codex-1 r5): qmd_himmel_scoped was grep-based (per-LINE match),
+# so a value with an embedded newline where any line starts with
+# qmd://himmel/ passed even though the value itself starts with salus. It
+# must be a whole-STRING prefix check (matches Python re.match, no MULTILINE).
+QMD_NEWLINE_FILE="$(jq -n --arg file "$(printf 'qmd://salus/secret\nqmd://himmel/x')" '{tool_name:"mcp__plugin_qmd_qmd__get",tool_input:{file:$file}}')"
+assert_rc "glm mcp qmd get salus-then-himmel via newline (denied)" 2 "$(run_case "$QMD_NEWLINE_FILE" "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp qmd multi_get scoped himmel (allowed)" 0 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__multi_get","tool_input":{"pattern":"qmd://himmel/*.md"}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp qmd multi_get mixed scoped+unscoped (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__multi_get","tool_input":{"pattern":"qmd://himmel/a.md,notes.md"}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp qmd multi_get luna referenced (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__multi_get","tool_input":{"pattern":"qmd://luna/*.md"}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+# CR round 1 (glm-3): under nullglob, a glob-bearing non-himmel segment that
+# matches no file must still DENY. The awk-based validation (CR round 4)
+# never does pathname expansion at all, so this stays denied unconditionally
+# regardless of nullglob — kept as a regression pin.
+assert_rc "glm mcp qmd multi_get salus glob under nullglob (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__multi_get","tool_input":{"pattern":"qmd://salus/*.md"}}' "ANTHROPIC_BASE_URL=$GLM_URL" "BASHOPTS=nullglob")"
+# CR round 2 (codex-1 r2): a pattern of only empty comma-separated segments
+# (",") must deny. Originally guarded by an explicit zero-iteration counter;
+# now covered directly by the awk validation's NF==0 / empty-field checks
+# (CR round 4) — kept as a regression pin.
+assert_rc "glm mcp qmd multi_get comma-only pattern (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__multi_get","tool_input":{"pattern":","}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+# CR round 4 (codex-1 r4) — ROOT CAUSE: bash word-splitting DROPS empty
+# comma-separated fields, so a trailing/leading/adjacent-comma pattern lost
+# its empty segment and was wrongly allowed despite containing one. The awk
+# -F',' replacement preserves empty fields (NF counts them), matching
+# Python's `pattern.split(",")` exactly — these three must all deny.
+assert_rc "glm mcp qmd multi_get trailing comma (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__multi_get","tool_input":{"pattern":"qmd://himmel/a.md,"}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp qmd multi_get leading comma (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__multi_get","tool_input":{"pattern":",qmd://himmel/a.md"}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+assert_rc "glm mcp qmd multi_get adjacent commas (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__multi_get","tool_input":{"pattern":"qmd://himmel/a.md,,qmd://himmel/b.md"}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+# status has no scoping input at all -> denied fail-closed.
+assert_rc "glm mcp qmd status (denied)" 2 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__status","tool_input":{}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
+# off-lane: qmd fence does not apply — the pre-existing off-lane mcp allow
+# case above ("off-lane mcp tool") already covers an unscoped qmd call
+# reaching this hook when ANTHROPIC_BASE_URL is not the GLM lane.
+assert_rc "off-lane mcp qmd query unscoped (allowed, off-lane)" 0 "$(run_case '{"tool_name":"mcp__plugin_qmd_qmd__query","tool_input":{}}')"
 assert_rc "glm Read tool ignored"        0 "$(run_case '{"tool_name":"Read","tool_input":{"file_path":"x"}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm empty command"            0 "$(run_case '{"tool_name":"Bash","tool_input":{}}' "ANTHROPIC_BASE_URL=$GLM_URL")"
 assert_rc "glm multi-line prose push"    0 "$(run_case "$(j_bash "$(printf 'git commit -m "notes\nabout git push etiquette"')")" "ANTHROPIC_BASE_URL=$GLM_URL")"
@@ -201,7 +255,7 @@ fi
 # Total-count guard: every assert_rc increments CASES; a drift here means a case
 # was silently dropped (or an early exit skipped the tail) even though nothing
 # FAILED. Update EXPECTED_CASES deliberately when adding/removing a case.
-EXPECTED_CASES=82
+EXPECTED_CASES=104
 if [ "$CASES" -ne "$EXPECTED_CASES" ]; then
     echo "CASE-COUNT MISMATCH — ran $CASES, expected $EXPECTED_CASES"
     exit 1


### PR DESCRIPTION
## Collection-scope the qmd MCP carve-out (fail-closed)

The qmd MCP carve-out on the GLM/hermes lanes allowed the entire
`mcp__plugin_qmd_qmd__*` surface with **no collection scoping** — a query
(or an unscoped default) could reach any indexed collection.

Make it collection-aware and **fail-closed** in both guards, kept in sync:
- **query** — require a non-empty JSON array of only allow-listed collections (validated directly in `jq`).
- **get / multi_get** — require fully-qualified `qmd://<allowed>/` paths; `multi_get` uses `awk -F','` (preserving empty comma fields) instead of shell word-splitting; the path check is a whole-string prefix match.
- **status** and any unknown qmd tool — denied (no scoping input to verify).

The bash validators were verified equivalent to the Python guard across the empty-array, blank-entry, object-not-array, `nullglob`, empty-segment, trailing/leading/adjacent-comma, and embedded-newline edge cases. Regression tests included for each.
