### PR TITLE
chore(ci): enable setup-node npm caching (node-suites + security-scan)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: scripts/${{ matrix.pkg }}/package-lock.json
       - run: npm ci
         working-directory: scripts/${{ matrix.pkg }}
       - run: npm test
@@ -126,6 +128,8 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
       - uses: oven-sh/setup-bun@v2
 
       # gitleaks: pinned to the SAME version as the pre-commit hook


### PR DESCRIPTION
## What

Enable `actions/setup-node` built-in npm caching on the two CI jobs that install
npm dependencies fresh every run:

- **`node-suites`** (matrix): `cache: 'npm'` with a per-leg key
  (`cache-dependency-path: scripts/${{ matrix.pkg }}/package-lock.json`).
- **`security-scan`**: `cache: 'npm'` with `cache-dependency-path: '**/package-lock.json'`.

## Why

Both jobs re-downloaded every dependency from the npm registry on every run.
setup-node caches `~/.npm` (the download cache), keyed on the lockfile hash.

## Safety

Behavior-neutral: only the download cache is cached (never `node_modules`), and
`npm ci` still verifies each package's integrity hash against the lockfile.
