### PR TITLE
docs(HIMMEL-1249): luna-second-brain template _CLAUDE.md — Golden-Rule save + graph-integrity invariant

### DIFF
--- a/templates/luna-second-brain/_CLAUDE.md
+++ b/templates/luna-second-brain/_CLAUDE.md
@@ -34,6 +34,11 @@ knowledge.
    decision, or concept uses `[[wikilinks]]`.
 7. **Confidence levels** — Mark claims as
    `stated | high | medium | speculation`.
+8. **Preserve the graph** — never break a `[[wikilink]]`. When you move
+   or rename a note, rewrite every inbound link so none dangle (a
+   relocation skill like `/archive-clips` does this on move; a manual
+   move must do the same by hand). Ask before any restructuring that
+   relinks many notes at once.
 
 ---
 
@@ -91,6 +96,10 @@ Claude should auto-save the following **without asking**:
 - Tasks assigned or committed to → `10-Projects/` relevant note
 - Knowledge learned → `30-Resources/` appropriate subfolder
 - Dev/work sessions → today's daily note + project note
+- A substantial Claude output worth reusing (research brief, synthesis,
+  strategy doc) → save it as a file, don't leave it in chat. Route per
+  the Folder Map (synthesis/concept → `30-Resources/`; cross-topic map →
+  `60-Maps/`).
 
 Claude should **ask before saving**:
 - Anything touching finances or private personal data


### PR DESCRIPTION
## What

Adds two rules to the adopter-facing vault skeleton `templates/luna-second-brain/_CLAUDE.md`:

- **Section 0, rule 8 — Preserve the graph:** never break a `[[wikilink]]`; rewrite inbound links on move/rename so none dangle; ask before any restructuring that relinks many notes. Makes the previously tooling-implicit invariant explicit.
- **Auto-Save Rules — Golden Rule:** save a substantial reusable Claude output (research brief, synthesis, strategy doc) as a file rather than leaving it in chat; route per the Folder Map.

## Why

Review of two @Degen_calls_sol X posts on the Obsidian-as-Claude-memory pattern. The vault skeleton already implements a more advanced version of everything both posts recommend; these were the only two ideas the operating manual did not state explicitly. Deliberately **not** adopting the posts' "never edit archive files" — wrong for a PARA vault (archive = inactive, not immutable).

9-line additive docs change, no code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI guidance to preserve wikilink references when notes are moved or renamed.
  * Added safeguards requiring confirmation before large-scale note restructuring.
  * Clarified that substantial, reusable AI-generated content should be saved in the appropriate resource or map folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->