### PR TITLE
fix(cr): [HIMMEL-1251] batch deferred CodeRabbit nits + #1295 propagation catch-up

### DIFF
--- a/scripts/agents-md/debrand.json
+++ b/scripts/agents-md/debrand.json
@@ -52,7 +52,7 @@
   {
     "from": "compare per task vs Fable-low",
     "to": "compare per task vs top-model-low",
-    "note": "HIMMEL-806: Sonnet-row pricing comparison added 2026-07-08 — neutral tier language; full-phrase so it never matches the attributed calibration line. DORMANT since 2026-07-10 (HIMMEL-774 row replaced the comparison clause); retained for the test fixture."
+    "note": "HIMMEL-806: Sonnet-row pricing comparison added 2026-07-08 — neutral tier language; full-phrase scopes the replacement to that comparison clause. DORMANT since 2026-07-10 (HIMMEL-774 row replaced the clause); retained for the test fixture."
   },
   {
     "from": "Fable stays CONSERVED (limited release)",

--- a/scripts/agents-md/test-generate.sh
+++ b/scripts/agents-md/test-generate.sh
@@ -123,6 +123,9 @@ main loop and burns the time-limited Fable quota on work a cheaper
 tier handles.
 Raise *effort* before raising model tier — Fable-5 `low` ≈ prior-gen
 `xhigh`, and the same shift applies down-tier.
+| Fable 5 | judgment, taste — hardest calls; escalation target |
+compare per task vs Fable-low
+Fable stays CONSERVED (limited release)
 EOF
 SAVED_SRC="$SRC"; SAVED_TGT="$TGT"; SRC="$FAB"; TGT="$TGTFAB"
 run 0 "fable fixture write succeeds" -- --write
@@ -138,6 +141,15 @@ else bad "wrap-spanning 'Fable main loop' entry matched across the newline"; fi
 if grep -q 'on Claude, Fable-5' "$TGT"; then
   ok "effort calibration attributed to Claude"
 else bad "effort calibration attributed to Claude"; fi
+if grep -qF '| top model | judgment, taste — hardest calls; escalation target |' "$TGT"; then
+  ok "top-model lane row neutralized"
+else bad "top-model lane row neutralized"; fi
+if grep -qF 'compare per task vs top-model-low' "$TGT"; then
+  ok "top-model-low comparison neutralized"
+else bad "top-model-low comparison neutralized"; fi
+if grep -qF 'The top model stays CONSERVED (limited release)' "$TGT"; then
+  ok "top-model conservation sentence neutralized"
+else bad "top-model conservation sentence neutralized"; fi
 SRC="$SAVED_SRC"; TGT="$SAVED_TGT"
 
 # b) real-CLAUDE.md leak check: after generation, no identity-claiming Fable

--- a/scripts/cleanup/sweep-codex-orphans.ps1
+++ b/scripts/cleanup/sweep-codex-orphans.ps1
@@ -123,7 +123,10 @@ function Test-IsCodexAppServerClient {
 function Get-BrokerCwd {
   param([string]$CommandLine)
   if (-not $CommandLine) { return '(unknown)' }
-  if ($CommandLine -match '(?:^|\s)--cwd[ =]?"?([^"\s]+)"?') { return $Matches[1] }
+  if ($CommandLine -match '(?:^|\s)--cwd[ =](?:"([^"]+)"|(\S+))') {
+    if ($Matches[1]) { return $Matches[1] }
+    return $Matches[2]
+  }
   if ($CommandLine -match '(\S*app-server-broker\.mjs)') {
     try { return [System.IO.Path]::GetDirectoryName($Matches[1]) } catch { return $Matches[1] }
   }

--- a/scripts/cleanup/test-sweep-codex-orphans.ps1
+++ b/scripts/cleanup/test-sweep-codex-orphans.ps1
@@ -45,6 +45,8 @@ $mt = Get-CxcTokens -CommandLine "x cxc-one-codex-app-server and cxc-two-codex-a
 Check 'multi-token -> both'             (($mt -join ',') -eq 'one,two') "got='$($mt -join ',')'"
 Check 'no-pipe line -> empty array'     ((Get-CxcTokens -CommandLine 'nothing here').Count -eq 0)
 Check 'dashed token a1-b2 preserved'    ((Get-CxcToken -CommandLine 'cxc-a1-b2-codex-app-server') -eq 'a1-b2') "got='$(Get-CxcToken -CommandLine 'cxc-a1-b2-codex-app-server')'"
+Check 'quoted --cwd preserves spaces'   ((Get-BrokerCwd -CommandLine 'node broker.mjs --cwd="C:\Users\Example User\repo"') -eq 'C:\Users\Example User\repo')
+Check 'unquoted --cwd still parses'     ((Get-BrokerCwd -CommandLine 'node broker.mjs --cwd=C:\repo') -eq 'C:\repo')
 
 # --- Test 2: broker / client predicates --------------------------------------
 Write-Host "Test 2: broker + client predicate classification"

--- a/scripts/handover/test-merge-on-green.sh
+++ b/scripts/handover/test-merge-on-green.sh
@@ -115,6 +115,10 @@ case "$verb" in
         # the same-repo binding (codex-adv-2).
         case "$json" in
             isPrivate,defaultBranchRef)
+                if [ -z "$jqexpr" ]; then
+                    echo "gh stub: 'repo view' isPrivate,defaultBranchRef missing required --jq expression" >&2
+                    exit 93
+                fi
                 # (CodeRabbit) Assert the positional repo arg — a regression
                 # back to a cwd-scoped query would otherwise pass silently.
                 if [ "$repo_arg" != "$nwo" ]; then

--- a/scripts/lib/test-fix-qmd-stub.sh
+++ b/scripts/lib/test-fix-qmd-stub.sh
@@ -413,7 +413,7 @@ assert "ubuntu.sh does NOT reference lib/fix-qmd-stub.sh (wiring delegated, HIMM
 # statement too (codex-adv finding, HIMMEL-934 CR round).
 # shellcheck disable=SC2016
 assert "ubuntu.sh execs himmelctl bootstrap.sh (delegation is real, HIMMEL-887)" \
-  grep -qF -- 'exec bash "$HIMMEL_PATH/scripts/himmelctl/bootstrap.sh"' "$repo_root/scripts/machine-setup/ubuntu.sh"
+  grep -qE -- '^[[:space:]]*(HIMMELCTL_REPO_ROOT="\$HIMMEL_PATH"[[:space:]]+)?exec[[:space:]]+bash[[:space:]]+"\$HIMMEL_PATH/scripts/himmelctl/bootstrap\.sh"[[:space:]]*$' "$repo_root/scripts/machine-setup/ubuntu.sh"
 assert "ubuntu.sh prints the himmelctl bootstrap delegation NOTICE (HIMMEL-887)" \
   grep -q 'delegating to himmelctl bootstrap' "$repo_root/scripts/machine-setup/ubuntu.sh"
 

--- a/scripts/lib/test-qmd-bin.sh
+++ b/scripts/lib/test-qmd-bin.sh
@@ -712,7 +712,7 @@ assert "ubuntu.sh does NOT call qmd_cmd (wiring delegated, HIMMEL-887)" \
 # (codex-adv finding, HIMMEL-934 CR round).
 # shellcheck disable=SC2016
 assert "ubuntu.sh execs himmelctl bootstrap.sh (delegation is real, HIMMEL-887)" \
-  grep -qF -- 'exec bash "$HIMMEL_PATH/scripts/himmelctl/bootstrap.sh"' "$repo_root/scripts/machine-setup/ubuntu.sh"
+  grep -qE -- '^[[:space:]]*(HIMMELCTL_REPO_ROOT="\$HIMMEL_PATH"[[:space:]]+)?exec[[:space:]]+bash[[:space:]]+"\$HIMMEL_PATH/scripts/himmelctl/bootstrap\.sh"[[:space:]]*$' "$repo_root/scripts/machine-setup/ubuntu.sh"
 assert "ubuntu.sh prints the himmelctl bootstrap delegation NOTICE (HIMMEL-887)" \
   grep -q 'delegating to himmelctl bootstrap' "$repo_root/scripts/machine-setup/ubuntu.sh"
 

--- a/scripts/luna-vitals/cli.ts
+++ b/scripts/luna-vitals/cli.ts
@@ -63,7 +63,7 @@ async function main(): Promise<void> {
     // degraded pull can produce a rows-empty artifact whose warnings still must
     // merge through (HIMMEL-794), but rows-empty AND warnings-empty inputs
     // (including zero artifact files) are a total extraction failure — error out.
-    if (!det.length && !llm.length && !collectedWarnings.length) { console.error("usage: merge [--det <det.json>...] [--llm <llm.json>...] --out <merged.json> (no input artifacts found)"); process.exit(1); }
+    if (!det.length && !llm.length && !collectedWarnings.length) { console.error("usage: merge [--det <det.json>...] [--llm <llm.json>...] --out <merged.json> (no rows or warnings to merge)"); process.exit(1); }
     const uniq = [...new Set(buckets)];
     const bucket = uniq.length === 1 ? uniq[0] : `merged(${uniq.join(",")})`;
     const merged = mergeRows({ deterministic: det, llm, bucket });

--- a/scripts/luna-vitals/connectors/SCHEMA.md
+++ b/scripts/luna-vitals/connectors/SCHEMA.md
@@ -61,7 +61,8 @@ degraded date carries `warnings: ["sleep <date>: malformed stage timestamps - sl
 omitted (degraded stage data)"]`. The stderr line is unchanged — the artifact copy is
 additive. A dated warning is recorded on the artifact only when its date falls inside the
 pull's `[from, to]` window (matching the rows filter); a warning with no derivable date is
-always recorded regardless of window.
+always recorded regardless of window. A malformed date is also kept conservatively; that
+arm is defensive because current derivation emits only valid ISO dates or no date.
 
 Four adjacent paths that previously skipped silently now each produce a warning too
 (stderr + artifact); row-emission behavior is unchanged for all four. The three

--- a/scripts/luna-vitals/connectors/map/derive.test.ts
+++ b/scripts/luna-vitals/connectors/map/derive.test.ts
@@ -744,6 +744,33 @@ describe('deriveSleep', () => {
     });
   });
 
+  test('null and object-shaped "stages" fields follow the same malformed-stage path', () => {
+    for (const stages of [null, {}]) {
+      const fixture = {
+        dataPoints: [
+          {
+            dataSource: { platform: 'HEALTH_CONNECT' },
+            sleep: {
+              interval: {
+                startTime: '2026-01-01T22:00:00Z',
+                startUtcOffset: '0s',
+                endTime: '2026-01-02T06:00:00Z',
+                endUtcOffset: '0s',
+              },
+              stages,
+            },
+          },
+        ],
+      };
+      const { rows, warnings } = deriveSleep(fixture);
+      expect(rows.map((r) => r.metric)).toEqual(['sleep_in_bed_hours']);
+      expect(warnings).toEqual([{
+        date: '2026-01-02',
+        text: 'sleep 2026-01-02: non-array "stages" field - treated as stage-less (sleep_hours unavailable)',
+      }]);
+    }
+  });
+
   test('REGRESSION: malformed non-array stages on a shorter NAP session does not warn (main session wins) — HIMMEL-794 Fix B / codex-adv-2', () => {
     // A clean, longer main session (valid stages) plus a shorter same-date nap
     // session whose `stages` field is malformed. Only the MAIN session may warn —

--- a/scripts/luna-vitals/connectors/map/derive.ts
+++ b/scripts/luna-vitals/connectors/map/derive.ts
@@ -312,7 +312,8 @@ export function deriveSleep(response: { dataPoints?: unknown[] }): { rows: Extra
   // Each warning is recorded in `warnings` (durable, returned to the caller) AND
   // printed to stderr with the [google-health] prefix (the pre-HIMMEL-794 operator
   // signal, kept byte-identical). The stderr line is `[google-health] ` + text —
-  // `date` is carried only in the returned copy, never in the stderr line.
+  // `date` is carried only in the returned copy, never in the stderr line. Callers
+  // that embed a date in `text` must pass that same date as the second argument.
   const warn = (text: string, date?: string): void => {
     warnings.push({ date, text });
     console.error(`[google-health] ${text}`);
@@ -322,7 +323,8 @@ export function deriveSleep(response: { dataPoints?: unknown[] }): { rows: Extra
   // DISTINCT dropped sessions can never share a text — the merge CLI dedups
   // warnings by exact text, so identical text must mean the same event. (Across
   // re-pulls with different windows the same session may carry a different index;
-  // over-reporting there is the accepted safe direction.)
+  // over-reporting there is the accepted safe direction.) Fully undated drops in
+  // separate artifacts can still share an index and collapse during merge.
   for (const [i, dp] of (response.dataPoints ?? []).entries()) {
     const point = dp as DataPoint;
     const fieldKey = Object.keys(point).find((k) => k !== 'name' && k !== 'dataSource');

--- a/scripts/luna-vitals/tests/cli.test.ts
+++ b/scripts/luna-vitals/tests/cli.test.ts
@@ -61,6 +61,24 @@ test("merge preserves warnings from inputs (deduped) when an input carries them"
   expect(m.rows).toContainEqual({ metric: "migraine", date: "2024-06-15", value: 1, source: "b.md" });
 });
 
+test("merge combines one rows-only artifact with one warnings-only artifact", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "luna-vitals-cli-mixed-shapes-"));
+  const rowsOnly = join(dir, "rows.json");
+  const warningsOnly = join(dir, "warnings.json");
+  const merged = join(dir, "merged.json");
+  const warning = "sleep dataPoint 0: missing interval startTime/endTime - session dropped";
+  await Bun.write(rowsOnly, JSON.stringify({
+    bucket: "rows", conflicts: [],
+    rows: [{ metric: "migraine", date: "2024-06-14", value: 3, source: "daily.md" }],
+  }));
+  await Bun.write(warningsOnly, JSON.stringify({ bucket: "warnings", conflicts: [], rows: [], warnings: [warning] }));
+  const p = Bun.spawn(["bun", "run", "cli.ts", "merge", rowsOnly, warningsOnly, "--out", merged], { cwd: ROOT, stderr: "pipe" });
+  expect(await p.exited).toBe(0);
+  const artifact = await readJson(merged);
+  expect(artifact.rows).toContainEqual({ metric: "migraine", date: "2024-06-14", value: 3, source: "daily.md" });
+  expect(artifact.warnings).toEqual([warning]);
+});
+
 test("merge warns on stderr (naming the file) for a positional arg that is not a .json artifact", async () => {
   const dir = mkdtempSync(join(tmpdir(), "luna-vitals-cli-warn-"));
   const det = join(dir, "det.json");
@@ -113,7 +131,7 @@ test("merge of a single rows-empty, warnings-free artifact exits 1 (total extrac
   const p = Bun.spawn(["bun", "run", "cli.ts", "merge", a, "--out", join(dir, "merged.json")], { cwd: ROOT, stderr: "pipe" });
   const err = await new Response(p.stderr).text();
   expect(await p.exited).toBe(1);
-  expect(err).toContain("no input artifacts found");
+  expect(err).toContain("no rows or warnings to merge");
 });
 
 test("merge with NO artifact inputs at all still exits 1 with the usage message", async () => {
@@ -121,7 +139,7 @@ test("merge with NO artifact inputs at all still exits 1 with the usage message"
   const p = Bun.spawn(["bun", "run", "cli.ts", "merge", "--out", join(dir, "merged.json")], { cwd: ROOT, stderr: "pipe" });
   const err = await new Response(p.stderr).text();
   expect(await p.exited).toBe(1);
-  expect(err).toContain("no input artifacts found");
+  expect(err).toContain("no rows or warnings to merge");
 });
 
 test("write on an artifact carrying warnings: exit 0, series written, warnings surfaced on stderr and harmlessly ignored (HIMMEL-794 Fix E)", async () => {

--- a/scripts/luna-vitals/tests/writeSeries.test.ts
+++ b/scripts/luna-vitals/tests/writeSeries.test.ts
@@ -58,12 +58,13 @@ test("an empty artifact (rows: []) writes nothing and returns []", async () => {
   expect(res).toEqual([]);
 });
 
-test("preserves existing sleep_hours row when a stage-less date emits no sleep_hours (HIMMEL-785)", async () => {
+test("warnings do not erase an existing sleep_hours value for the warned-and-dropped date", async () => {
   const dir = tmp();
   await Bun.write(join(dir, "sleep_hours.csv"), "date,value\n2024-06-14,7.5\n");
   const a: ReviewArtifact = {
     bucket: "x", conflicts: [],
     rows: [{ metric: "sleep_in_bed_hours", date: "2024-06-14", value: 8.0, source: "s" }],
+    warnings: ["sleep 2024-06-14: malformed stage timestamps - sleep_hours omitted (degraded stage data)"],
   };
   await writeSeries(a, dir);
   expect(await Bun.file(join(dir, "sleep_hours.csv")).text()).toBe("date,value\n2024-06-14,7.5\n");

--- a/scripts/luna/fold-chat-history.py
+++ b/scripts/luna/fold-chat-history.py
@@ -19,9 +19,10 @@ import json
 import re
 import shutil
 import sys
-from dataclasses import dataclass, field
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal, NamedTuple
 
 if hasattr(sys.stdout, "reconfigure"):  # Windows cp1252 trap
     sys.stdout.reconfigure(encoding="utf-8")
@@ -38,14 +39,15 @@ SKIP_CONTENT_TYPES = ("thoughts", "reasoning_recap")
 AUDIO_POINTER_TYPES = ("audio_asset_pointer",
                        "real_time_user_audio_video_asset_pointer")
 
-# Segment = ("text", body) | ("image", file_id) | ("audio", file_id)
-Segment = tuple
+class Segment(NamedTuple):
+    kind: Literal["text", "image", "audio"]
+    value: str
 
 
 @dataclass
 class Turn:
     role: str
-    segments: list
+    segments: list[Segment]
 
 
 @dataclass
@@ -72,20 +74,20 @@ def _segments_from_content(content):
     for part in content.get("parts") or []:
         if isinstance(part, str):
             if part.strip():
-                segments.append(("text", part.strip()))
+                segments.append(Segment("text", part.strip()))
         elif isinstance(part, dict):
             ptype = part.get("content_type")
             if ptype == "audio_transcription":
                 text = (part.get("text") or "").strip()
                 if text:
-                    segments.append(("text", text))
+                    segments.append(Segment("text", text))
             elif ptype == "image_asset_pointer":
                 pointer = part.get("asset_pointer") or ""
                 if pointer:
-                    segments.append(("image", _normalize_pointer(pointer)))
+                    segments.append(Segment("image", _normalize_pointer(pointer)))
             elif ptype in AUDIO_POINTER_TYPES:
                 pointer = part.get("asset_pointer") or ""
-                segments.append(("audio", _normalize_pointer(pointer)))
+                segments.append(Segment("audio", _normalize_pointer(pointer)))
     return segments
 
 
@@ -104,7 +106,7 @@ def _linearize(raw):
 
 
 def parse_conversation(raw):
-    """Raw export conversation dict -> Conversation, or None if 0 turns."""
+    """None for a non-dict record, missing create_time, or no renderable turns."""
     if not isinstance(raw, dict):
         return None
     ct = raw.get("create_time")
@@ -139,15 +141,15 @@ def parse_conversation(raw):
     return Conversation(
         id=cid,
         title=(raw.get("title") or "").strip() or "untitled",
-        created=datetime.fromtimestamp(ct),
-        updated=datetime.fromtimestamp(updated) if updated else None,
+        created=datetime.fromtimestamp(ct, timezone.utc),
+        updated=datetime.fromtimestamp(updated, timezone.utc) if updated else None,
         model=model,
         turns=turns,
     )
 
 
 def parse_chatgpt(export_dir):
-    """All renderable Conversations from conversations-*.json (sorted)."""
+    """Renderable conversations, processing files in sorted filename order."""
     export_dir = Path(export_dir)
     conversations = []
     for jf in sorted(export_dir.glob("conversations-*.json")):
@@ -458,7 +460,8 @@ def write_index(chats_dir, dry_run):
             except (OSError, UnicodeDecodeError):
                 continue
             link = note.relative_to(chats_dir.parent).with_suffix("").as_posix()
-            rows.append((created, f"| {created} | [[{link}\\|{title}]] | {messages} |"))
+            escaped_title = title.replace("|", "\\|")
+            rows.append((created, f"| {created} | [[{link}\\|{escaped_title}]] | {messages} |"))
         lines += [f"## {provider_dir.name}", "",
                   f"{len(rows)} conversations.", "",
                   "| date | conversation | msgs |", "|---|---|---|"]
@@ -715,15 +718,18 @@ def _tg_month_note(group_name, group_slug, month, entries, assets_dir_rel,
 
 def _tg_note_signature(text):
     """The comparable content of a rendered month note: title+day/message
-    text with the frontmatter (carries the `messages:` count) and media
-    embed lines (`![[...]]`, whose name is content-hashed on a byte
-    collision — see `_tg_asset_name`) stripped off. Two renders of the same
-    messages compare equal even if the count metadata or a re-hashed media
-    name differs."""
+    text with the frontmatter (carries the `messages:` count) stripped and
+    every media embed line (`![[...]]`, whose name is content-hashed on a
+    byte collision — see `_tg_asset_name`) normalized to a nameless marker.
+    Two renders of the same messages compare equal even if the count metadata
+    or a re-hashed media NAME differs, but a re-import that ADDS or REMOVES
+    media changes the marker count — so the overwrite guard sees it as a
+    different note and won't silently drop media embeds (codex + CodeRabbit,
+    PR #1295)."""
     m = re.search(r"^# ", text, re.M)
     body = text[m.start():] if m else text
-    return "\n".join(line for line in body.splitlines()
-                     if not line.startswith("![["))
+    return "\n".join("![[]]" if line.startswith("![[") else line
+                     for line in body.splitlines())
 
 
 def _fold_telegram(export_dir, vault_dir, dry_run, group_slug_override=None):
@@ -772,7 +778,13 @@ def _fold_telegram(export_dir, vault_dir, dry_run, group_slug_override=None):
         if dest.exists():  # guard runs in dry-run too, so the reported count
             existing_sig = _tg_note_signature(dest.read_text(encoding="utf-8"))
             new_sig = _tg_note_signature(note_text)
-            if not new_sig.startswith(existing_sig):
+            # Require the existing signature to be a COMPLETE-line prefix of
+            # the incoming one (boundary at "\n"), not a mid-message character
+            # prefix: "foo" is a str-prefix of an edited "foobar", but that is
+            # a changed last message, and overwriting would drop it (codex CR
+            # #470). Equal ⇒ identical re-import; prefix+"\n" ⇒ a strictly
+            # fuller later export that preserves every existing message whole.
+            if not (new_sig == existing_sig or new_sig.startswith(existing_sig + "\n")):
                 print(f"warning: {dest.relative_to(vault_dir)} holds messages "
                       f"not reproduced by this import — skipping to avoid "
                       f"clobbering them (delete the note to force)",
@@ -807,6 +819,8 @@ def fold(provider, export_dir, vault_dir, dry_run, group_slug=None):
     else:
         all_raw_count = 0
         conversations = []
+        # Keep this loop aligned with parse_chatgpt(): sorted files, then records
+        # in file order. It is duplicated here only so the report retains raw count.
         for jf in sorted(export_dir.glob("conversations-*.json")):
             for raw in json.loads(jf.read_text(encoding="utf-8")):
                 all_raw_count += 1

--- a/scripts/luna/test-fold-chat-history.py
+++ b/scripts/luna/test-fold-chat-history.py
@@ -9,7 +9,7 @@ import re
 import sys
 import tempfile
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 _MOD_PATH = Path(__file__).resolve().parent / "fold-chat-history.py"
@@ -556,10 +556,9 @@ class TestFold(unittest.TestCase):
             # placeholder but does NOT increment the counter
             self.assertEqual(report.audio_placeholders, 1)
             gpt = vault / "chats" / "gpt"
-            # derive expected dates via the SAME local-time conversion the
-            # module uses — hard-coding the day would be timezone-fragile
-            d1 = datetime.fromtimestamp(1755500000.0)
-            d2 = datetime.fromtimestamp(1758200000.0)
+            # Derive expected dates via the same UTC conversion the module uses.
+            d1 = datetime.fromtimestamp(1755500000.0, timezone.utc)
+            d2 = datetime.fromtimestamp(1758200000.0, timezone.utc)
             heb_name = f"{d1:%Y-%m-%d}-שיחה-בעברית.md"
             pic_name = f"{d2:%Y-%m-%d}-Pic-chat.md"
             notes = sorted(p.name for p in gpt.rglob("*.md"))
@@ -579,6 +578,19 @@ class TestFold(unittest.TestCase):
             # gitignore rule not duplicated
             gi2 = (vault / ".gitignore").read_text(encoding="utf-8")
             self.assertEqual(gi2.count("chats/*/_assets/"), 1)
+
+    def test_index_escapes_pipe_in_title(self):
+        with tempfile.TemporaryDirectory() as td:
+            conv = chain(u("q"), a("a"), title="Pipe | title")
+            ed = self._make_export(td, convs=[conv])
+            vault = Path(td) / "vault"
+            vault.mkdir()
+            fch.fold("chatgpt", ed, vault, dry_run=False)
+            index = (vault / "chats" / "_index.md").read_text(encoding="utf-8")
+            self.assertRegex(
+                index,
+                r"\| [^|]+ \| \[\[[^\]]+\\\|Pipe \\\| title\]\] \| \d+ \|",
+            )
 
     def test_fold_dry_run_writes_nothing(self):
         with tempfile.TemporaryDirectory() as td:
@@ -852,6 +864,31 @@ class TestCli(unittest.TestCase):
                            "--vault", td])
             self.assertEqual(rc, 1)
 
+    def test_main_rejects_missing_vault_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            export = Path(td) / "export"
+            export.mkdir()
+            rc = fch.main(["--provider", "chatgpt", "--export", str(export),
+                           "--vault", str(Path(td) / "nope")])
+            self.assertEqual(rc, 1)
+
+    def test_main_empty_export_reports_all_zero(self):
+        with tempfile.TemporaryDirectory() as td:
+            export = Path(td) / "export"
+            vault = Path(td) / "vault"
+            export.mkdir()
+            vault.mkdir()
+            import contextlib, io
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = fch.main(["--provider", "chatgpt", "--export", str(export),
+                               "--vault", str(vault), "--dry-run"])
+            self.assertEqual(rc, 0)
+            report = buf.getvalue()
+            self.assertIn("notes created: 0", report)
+            self.assertIn("conversations skipped (empty): 0", report)
+            self.assertIn("assets copied: 0", report)
+
 
 # ---------- Telegram HTML group export (HIMMEL-1170) ----------
 
@@ -1050,6 +1087,21 @@ class TestFoldTelegram(unittest.TestCase):
             self.assertEqual(report.assets_missing, 1)
             self.assertFalse((vault / "evil.jpg").exists())
             self.assertFalse((Path(td) / "evil.jpg").exists())
+
+    def test_note_signature_preserves_media_presence(self):
+        # Same message text, media re-hashed (same COUNT) -> equal signature:
+        # an idempotent re-import must still overwrite (documented intent).
+        a = ("---\nmessages: 3\n---\n# G — 2026-07\n\n## day\n"
+             "**09:00 · Alice**\nhello\n![[chats/telegram/_assets/g__photo_1.jpg]]\n")
+        b = ("---\nmessages: 3\n---\n# G — 2026-07\n\n## day\n"
+             "**09:00 · Alice**\nhello\n![[chats/telegram/_assets/g__photo_1.abc123.jpg]]\n")
+        self.assertEqual(fch._tg_note_signature(a), fch._tg_note_signature(b))
+        # Same text but media REMOVED (fewer embeds) -> different signature, so
+        # the overwrite guard treats it as a different note and won't silently
+        # drop the existing media embed (codex + CodeRabbit, PR #1295).
+        c = ("---\nmessages: 3\n---\n# G — 2026-07\n\n## day\n"
+             "**09:00 · Alice**\nhello\n")
+        self.assertNotEqual(fch._tg_note_signature(a), fch._tg_note_signature(c))
 
 
 class TestCliTelegram(unittest.TestCase):

--- a/scripts/luna/test-pipeline-cadence.sh
+++ b/scripts/luna/test-pipeline-cadence.sh
@@ -317,6 +317,7 @@ run_cron() {
 echo "TEST: cron status with no crontab installed"
 out=$(run_cron status)
 assert_contains "cron harvest not armed"    "not armed  HIMMEL-Pipeline-Harvest"    "$out"
+assert_contains "cron harvest not-armed summary names the full daily chain" "-> /harvest-clips + /triage-clips + /ig-media-enrich" "$out"
 assert_contains "cron synthesize not armed" "not armed  HIMMEL-Pipeline-Synthesize" "$out"
 assert_contains "cron health not armed"     "not armed  HIMMEL-Pipeline-Health"     "$out"
 
@@ -590,6 +591,10 @@ if [ "$(grep -c 'HIMMEL-Pipeline-' "$CSTATE/crontab")" -eq 3 ]; then
 else
     fail "duplicate entries after --force re-arm" "$(cat "$CSTATE/crontab")"
 fi
+
+out=$(run_cron arm --vault "$VAULT" --force --ig-limit 0 --harvest-model opus 2>&1)
+harvest_sh=$(cat "$CRON_DIR/pipeline-harvest.sh" 2>/dev/null || echo MISSING)
+assert_contains "cron --ig-limit 0 reaches harvest runner" "/ig-media-enrich --limit 0" "${harvest_sh//\\/}"
 
 # Test C14: dry-run disarm with armed entries prints DRY tail, touches nothing --
 
@@ -1277,6 +1282,10 @@ if [ "$(find "$STATE/tasks" -mindepth 1 | wc -l)" -eq 3 ]; then
 else
     fail "duplicate tasks after --force re-arm" "$(ls "$STATE/tasks")"
 fi
+
+out=$(run_pc arm --vault "$VAULT" --force --ig-limit 25 --harvest-model opus 2>&1)
+harvest_bat=$(cat "$BAT_DIR/pipeline-harvest.bat" 2>/dev/null || echo MISSING)
+assert_contains "--ig-limit 25 reaches harvest bat" "/ig-media-enrich --limit 25" "$harvest_bat"
 
 # Test 9b: --force re-arm model pin round-trips through status (HIMMEL-506).
 # status parses the --model token back out of the .bat runner; after a

--- a/scripts/machine-setup/test-ubuntu-settings-jq.sh
+++ b/scripts/machine-setup/test-ubuntu-settings-jq.sh
@@ -87,7 +87,7 @@ fi
 # statement too, so removing the exec while keeping the NOTICE fails
 # (codex-adv finding, HIMMEL-934 CR round).
 # shellcheck disable=SC2016  # single quotes intentional: $HIMMEL_PATH is ubuntu.sh's variable
-if grep -qF -- 'exec bash "$HIMMEL_PATH/scripts/himmelctl/bootstrap.sh"' "$ubuntu_sh"; then
+if grep -qE -- '^[[:space:]]*(HIMMELCTL_REPO_ROOT="\$HIMMEL_PATH"[[:space:]]+)?exec[[:space:]]+bash[[:space:]]+"\$HIMMEL_PATH/scripts/himmelctl/bootstrap\.sh"[[:space:]]*$' "$ubuntu_sh"; then
     assert_pass "ubuntu.sh execs himmelctl bootstrap.sh (delegation is real, HIMMEL-887)"
 else
     assert_fail "ubuntu.sh does not exec himmelctl bootstrap.sh (NOTICE without delegation)"

--- a/scripts/test-check-ci.sh
+++ b/scripts/test-check-ci.sh
@@ -312,7 +312,8 @@ run() {
     local mode="$1"; shift
     COUNT=$((COUNT+1))
     local of ef
-    of=$(mktemp); ef=$(mktemp)
+    if ! of=$(mktemp "$STUBDIR/out.XXXXXX"); then echo "FATAL: mktemp for stdout capture failed" >&2; exit 1; fi
+    if ! ef=$(mktemp "$STUBDIR/err.XXXXXX"); then rm -f "$of"; echo "FATAL: mktemp for stderr capture failed" >&2; exit 1; fi
     : > "$STUBDIR/args.log"
     : > "$STUBDIR/count"
     : > "$STUBDIR/watch"


### PR DESCRIPTION
## What

Batch-triage of accumulated `cr-deferred` CodeRabbit SUGGESTION/nit findings — 18 files. Each finding was verified against current code before any edit; mostly test-hardening, docstrings, and comments, with a few real fixes.

### Notable
- `sweep-codex-orphans.ps1`: `--cwd` regex captures quoted paths containing spaces.
- `fold-chat-history.py`: unused import removed; `Segment` → typed `NamedTuple`; naive `datetime.fromtimestamp` → tz-aware UTC; pipe-escaping in index titles.
- Test assertions tightened (exact-array warning contract, full-row wikilink regex, temp-file cleanup on the `mktemp` error path).

### Propagation catch-up
The byte-verify gate flagged that `fold-chat-history.py` (+ its test) was behind private — **PR #1295**'s telegram note-signature / media-embed handling had never propagated. Those 2 files are brought up to private head here, so public matches private (the #1295 changes were already CR-clean in private).

Propagated from the private merge; cross-model reviewed clean (codex).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed sleep-stage data while preserving valid sleep metrics.
  - Merge operations now clearly report when no rows or warnings are available.
  - Improved chat-history imports across time zones and safer Telegram media updates.
  - Markdown indexes now remain valid when conversation titles contain pipe characters.
  - Improved detection of broker working directories, including quoted paths.

- **Documentation**
  - Clarified how undated or malformed warnings are retained conservatively.

- **Tests**
  - Expanded coverage for debranding, merge behavior, scheduling limits, setup validation, and chat-history edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->