### PR TITLE
feat(graphify): glm extraction backend + GRAPHIFY_MAX_CONCURRENCY throttle knob

### DIFF
--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -1045,7 +1045,20 @@ view into the vault — the bridge between the derived graph and the KB.
 - **Cost + cadence:** a full ecosystem sync is ~$2 (measured 2026-07-09);
   `--update` is a fraction of that, so a **daily** off-peak run is affordable.
   Schedule per corpus (example, Git Bash on Windows via schtasks or cron):
-  `bash scripts/graphify/refresh-graph-map.sh --name luna --corpus-root <vault> --maps-dir <vault>/60-Maps --title "Graphify Luna Vault Map" --slug graphify-luna-map --corpus-tag luna`.
+  `bash scripts/graphify/refresh-graph-map.sh --name luna --corpus-root <vault> --backend glm --maps-dir <vault>/60-Maps --title "Graphify Luna Vault Map" --slug graphify-luna-map --corpus-tag luna`
+  (`--backend glm` is the ratified luna extraction provider — zai-glm, allow+log on
+  luna-personal, HIMMEL-1096/1122; it auto-routes to graphify's `claude` backend at
+  the Z.ai Anthropic-compatible endpoint using `ZAI_API_KEY` from `.env`, so no
+  hand-set `ANTHROPIC_*` env is needed).
+  **Throttle knob (`GRAPHIFY_MAX_CONCURRENCY`, default 6):** concurrency 6
+  overshoots Z.ai's request limit — `--backend glm` 429s (`rate_limit_error`
+  1302) on most chunks and the regen fails. `GRAPHIFY_MAX_CONCURRENCY=1`
+  serializes the extraction + cluster-only LLM calls, which eases request
+  pressure but is NOT true rate-limiting (no pacing/backoff) and cannot beat a
+  hard per-key quota — an exhausted quota 429s even serialized (observed
+  2026-07-21: chunk 1 failed at concurrency 1). Band-aid for the full-extraction
+  cost; the durable fix (seed graphify's semantic cache so a regen is a small
+  incremental, not a 255-chunk full run) is HIMMEL-1097.
   Model: the derived graph.json + full report stay repo-local (gitignored,
   regenerable); only the curated MOC is committed to the vault, so each refresh
   shows the map's drift as a small git diff.

--- a/scripts/graphify/refresh-graph-map.sh
+++ b/scripts/graphify/refresh-graph-map.sh
@@ -63,9 +63,70 @@ done
 if [ -z "$NAME" ] || [ -z "$CORPUS_ROOT" ] || [ -z "$MAPS_DIR" ] || [ -z "$TITLE" ] || [ -z "$SLUG" ]; then usage; fi
 [ -d "$CORPUS_ROOT" ] || { echo "refresh-graph-map: corpus root not found: $CORPUS_ROOT" >&2; exit 1; }
 
+# GLM (Z.ai) alias (HIMMEL-1048). graphify has NO native `glm` backend — GLM is
+# reached via graphify's `claude` backend pointed at Z.ai's Anthropic-compatible
+# endpoint. The egress matrix + fence already classify `--backend glm` as the
+# ratified zai-glm provider (luna-personal extraction = allow+log, HIMMEL-1096/1122),
+# so make `--backend glm` a single-flag process instead of hand-setting ANTHROPIC_*
+# env each run: it remaps to `--backend claude` + ANTHROPIC_BASE_URL=<z.ai> +
+# ANTHROPIC_MODEL=glm-5.2 + ANTHROPIC_API_KEY=<ZAI_API_KEY, loaded from .env, never
+# printed>. A live ANTHROPIC_* env still wins (only fills gaps).
+case "$BACKEND" in
+  glm|zai-glm)
+    BACKEND="claude"
+    : "${ANTHROPIC_BASE_URL:=https://api.z.ai/api/anthropic}"
+    : "${ANTHROPIC_MODEL:=glm-5.2}"
+    if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+      # shellcheck source=../lib/load-dotenv.sh
+      # shellcheck disable=SC1091
+      if . "$(dirname "$0")/../lib/load-dotenv.sh" 2>/dev/null && load_dotenv ZAI_API_KEY 2>/dev/null && [ -n "${ZAI_API_KEY:-}" ]; then
+        ANTHROPIC_API_KEY="$ZAI_API_KEY"
+      else
+        echo "refresh-graph-map: --backend glm needs ZAI_API_KEY (in the primary checkout's .env) or ANTHROPIC_API_KEY set." >&2
+        exit 1
+      fi
+    fi
+    export ANTHROPIC_BASE_URL ANTHROPIC_MODEL ANTHROPIC_API_KEY
+    echo "refresh-graph-map: --backend glm -> claude backend @ $ANTHROPIC_BASE_URL (model $ANTHROPIC_MODEL)" >&2
+    ;;
+esac
+
 GRAPHIFY_MAP="${GRAPHIFY_MAP_BIN:-graphify}"   # test hook: stub graphify
 # graphify is only needed for the extraction path — --no-update publishes from
 # an existing report and must not require it (CR: code-reviewer).
+
+# Extraction/labeling concurrency knob (HIMMEL-1097 mitigation). --max-concurrency
+# caps only how many requests are IN FLIGHT at once — it is not true rate-limiting
+# (no pacing/backoff between sequential requests), so it reduces request pressure
+# but cannot beat a hard per-key quota. The default 6 overshoots a rate-limited
+# backend badly — `--backend glm` (Z.ai) 429s (rate_limit_error code 1302) on most
+# chunks at 6. Lowering it (e.g. GRAPHIFY_MAX_CONCURRENCY=1) eases the pressure and
+# is worth trying, but is NOT guaranteed to complete: an exhausted/hard request
+# quota 429s even serialized (observed 2026-07-21 — chunk 1 failed at concurrency 1
+# with ~33s spacing). Applies to BOTH the --update extraction and the cluster-only
+# labeling pass (both make backend LLM calls against the same limit). Must be a
+# positive integer; anything else (including an explicitly-empty value) fails loud.
+# Band-aid — the durable fix (seed graphify's semantic cache so the regen is a
+# small incremental, not a full 255-chunk extraction) is HIMMEL-1097.
+# `-6` (unset-only default), NOT `:-6`: an explicitly-empty value stays empty and
+# is caught by the validation below, rather than silently defaulting to 6.
+# The default stays 6 (not glm-lowered): this script's DEFAULT backend is
+# claude-cli (line 45), which is unaffected — lowering the default would 6x-slow
+# every non-glm regen for no gain. glm callers pass the knob explicitly, and a
+# lower value would not rescue glm anyway when the request quota is exhausted
+# (it 429s even serialized, as above). Wiring a throttled default into the glm
+# cadence is a separate concern, out of scope for this knob.
+GRAPHIFY_MAX_CONCURRENCY="${GRAPHIFY_MAX_CONCURRENCY-6}"
+# Validate ONLY on the extraction path (DO_UPDATE=1): the knob feeds the
+# --update + cluster-only graphify calls, which a --no-update publish-only run
+# never makes — so an invalid value is irrelevant there and must not fail an
+# unrelated republish (CR: codex-1).
+if [ "$DO_UPDATE" -eq 1 ]; then
+  case "$GRAPHIFY_MAX_CONCURRENCY" in
+    ''|*[!0-9]*) echo "refresh-graph-map: GRAPHIFY_MAX_CONCURRENCY must be a positive integer (got '$GRAPHIFY_MAX_CONCURRENCY')" >&2; exit 1 ;;
+  esac
+  [ "$GRAPHIFY_MAX_CONCURRENCY" -ge 1 ] || { echo "refresh-graph-map: GRAPHIFY_MAX_CONCURRENCY must be >= 1 (got '$GRAPHIFY_MAX_CONCURRENCY')" >&2; exit 1; }
+fi
 
 # Off-peak advisory (DeepSeek peak-valley UTC 1-4 + 6-10 = 2x). Advisory only —
 # a scheduler should aim off-peak; we never hard-refuse (an operator may run ad hoc).
@@ -437,8 +498,8 @@ if [ "$DO_UPDATE" -eq 1 ]; then
   # tripped the gate by containing the literal flag, so the marker would only
   # have been suppressing itself.) The real control for what those nested calls
   # can reach is the reroute-selector clearing above + the egress fence.
-  "$GRAPHIFY_MAP" "$SCRATCH" --update --backend "$BACKEND" --max-concurrency 6 --api-timeout 300 >&2 || { echo "refresh-graph-map: graphify --update failed" >&2; exit 2; }
-  "$GRAPHIFY_MAP" cluster-only "$SCRATCH" --backend "$BACKEND" >&2 || { echo "refresh-graph-map: cluster-only failed" >&2; exit 2; }
+  "$GRAPHIFY_MAP" "$SCRATCH" --update --backend "$BACKEND" --max-concurrency "$GRAPHIFY_MAX_CONCURRENCY" --api-timeout 300 >&2 || { echo "refresh-graph-map: graphify --update failed" >&2; exit 2; }
+  "$GRAPHIFY_MAP" cluster-only "$SCRATCH" --backend "$BACKEND" --max-concurrency "$GRAPHIFY_MAX_CONCURRENCY" >&2 || { echo "refresh-graph-map: cluster-only failed" >&2; exit 2; }
   # HIMMEL-907: stamp freshness artifacts so the companion guard
   # check-graph-freshness.sh can VERIFY this graph (not "fresh by age" only).
   # Source-of-truth for shape is the guard's parser: manifest.json = flat

--- a/scripts/graphify/test-refresh-graph-map.sh
+++ b/scripts/graphify/test-refresh-graph-map.sh
@@ -37,6 +37,11 @@ BIN="$WS/bin"; mkdir -p "$BIN"
 cat > "$BIN/graphify" <<STUB
 #!/usr/bin/env bash
 # args: either "<path> --update ..." or "cluster-only <path> ..."
+# When GRAPHIFY_CALL_LOG is set, append the full arg line of every invocation
+# (one per line) so a test can assert what flags reached graphify (T21 uses this
+# to verify GRAPHIFY_MAX_CONCURRENCY is wired to --max-concurrency, and that an
+# invalid value fails BEFORE any extraction call).
+[ -n "\$GRAPHIFY_CALL_LOG" ] && printf '%s\n' "\$*" >> "\$GRAPHIFY_CALL_LOG"
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
@@ -1078,6 +1083,83 @@ echo "$out" | grep -q "Binary file" \
 echo "$out" | grep -q "nulleak" \
   && fail "T20 error output exposes the rejected host path: $out" \
   || pass "T20 error output redacts the rejected host path"
+
+# --- T21: GRAPHIFY_MAX_CONCURRENCY knob (HIMMEL-1097 throttle) ---
+# Invalid values fail LOUD (rc=1) before any extraction, rather than silently
+# reverting to a concurrency that 429s the rate-limited backend.
+# GRAPHIFY_CALL_LOG lets the stub record every graphify invocation, so these
+# tests can assert an invalid value fails BEFORE any extraction call (empty log),
+# and a valid value wires --max-concurrency into both graphify subcommands.
+t21log="$WS/t21-calls.log"; : > "$t21log"
+out=$( GRAPHIFY_CALL_LOG="$t21log" GRAPHIFY_MAX_CONCURRENCY=abc bash "$SCRIPT" --name luna --corpus-root "$CORPUS" --backend deepseek \
+  --maps-dir "$MAPS" --title "T" --slug graphify-luna-map --corpus-tag luna 2>&1 ); rc=$?
+[ "$rc" -eq 1 ] && pass "T21a non-numeric GRAPHIFY_MAX_CONCURRENCY rejected (rc=1)" \
+  || fail "T21a non-numeric GRAPHIFY_MAX_CONCURRENCY should fail rc=1 (got $rc): $out"
+echo "$out" | grep -q "GRAPHIFY_MAX_CONCURRENCY must be a positive integer" \
+  && pass "T21a error names the invalid knob" \
+  || fail "T21a error should name GRAPHIFY_MAX_CONCURRENCY: $out"
+[ ! -s "$t21log" ] && pass "T21a invalid value fails before any extraction call" \
+  || fail "T21a extraction ran on an invalid value: $(cat "$t21log")"
+# Assert rc=1 AND the concurrency-validation message (not just any rc=1), so an
+# unrelated early failure cannot pass these. Zero and empty hit different
+# branches ("must be >= 1" vs "must be a positive integer") — assert the common
+# `GRAPHIFY_MAX_CONCURRENCY must be` prefix both emit.
+: > "$t21log"
+out=$( GRAPHIFY_CALL_LOG="$t21log" GRAPHIFY_MAX_CONCURRENCY=0 bash "$SCRIPT" --name luna --corpus-root "$CORPUS" --backend deepseek \
+  --maps-dir "$MAPS" --title "T" --slug graphify-luna-map --corpus-tag luna 2>&1 ); rc=$?
+{ [ "$rc" -eq 1 ] && echo "$out" | grep -q "GRAPHIFY_MAX_CONCURRENCY must be"; } \
+  && pass "T21b zero GRAPHIFY_MAX_CONCURRENCY rejected (rc=1 + validation msg)" \
+  || fail "T21b zero GRAPHIFY_MAX_CONCURRENCY should fail rc=1 with the validation msg (got $rc): $out"
+[ ! -s "$t21log" ] && pass "T21b zero value fails before any extraction call" \
+  || fail "T21b extraction ran on a zero value: $(cat "$t21log")"
+# Explicitly-empty value fails loud too (unset-only `-6` default preserves it
+# for the validation instead of silently defaulting to 6).
+: > "$t21log"
+out=$( GRAPHIFY_CALL_LOG="$t21log" GRAPHIFY_MAX_CONCURRENCY='' bash "$SCRIPT" --name luna --corpus-root "$CORPUS" --backend deepseek \
+  --maps-dir "$MAPS" --title "T" --slug graphify-luna-map --corpus-tag luna 2>&1 ); rc=$?
+{ [ "$rc" -eq 1 ] && echo "$out" | grep -q "GRAPHIFY_MAX_CONCURRENCY must be"; } \
+  && pass "T21b2 explicitly-empty GRAPHIFY_MAX_CONCURRENCY rejected (rc=1 + validation msg)" \
+  || fail "T21b2 empty GRAPHIFY_MAX_CONCURRENCY should fail rc=1 with the validation msg (got $rc): $out"
+[ ! -s "$t21log" ] && pass "T21b2 empty value fails before any extraction call" \
+  || fail "T21b2 extraction ran on an empty value: $(cat "$t21log")"
+# Negative value: the leading '-' is a non-digit, so it hits the same
+# positive-integer branch as T21a and fails before extraction.
+: > "$t21log"
+out=$( GRAPHIFY_CALL_LOG="$t21log" GRAPHIFY_MAX_CONCURRENCY=-1 bash "$SCRIPT" --name luna --corpus-root "$CORPUS" --backend deepseek \
+  --maps-dir "$MAPS" --title "T" --slug graphify-luna-map --corpus-tag luna 2>&1 ); rc=$?
+{ [ "$rc" -eq 1 ] && echo "$out" | grep -q "GRAPHIFY_MAX_CONCURRENCY must be"; } \
+  && pass "T21b3 negative GRAPHIFY_MAX_CONCURRENCY rejected (rc=1 + validation msg)" \
+  || fail "T21b3 negative GRAPHIFY_MAX_CONCURRENCY should fail rc=1 with the validation msg (got $rc): $out"
+[ ! -s "$t21log" ] && pass "T21b3 negative value fails before any extraction call" \
+  || fail "T21b3 extraction ran on a negative value: $(cat "$t21log")"
+# A valid non-default value still drives the full path to a published MOC AND
+# reaches BOTH graphify subcommands as --max-concurrency (the wiring this change
+# adds — verified via the stub call-log, since GRAPHIFY_MAP_BIN is a stub).
+T21MAPS="$WS/t21maps"; mkdir -p "$T21MAPS"; : > "$t21log"
+out=$( GRAPHIFY_CALL_LOG="$t21log" GRAPHIFY_MAX_CONCURRENCY=3 bash "$SCRIPT" --name luna --corpus-root "$CORPUS" --backend deepseek \
+  --maps-dir "$T21MAPS" --title "T" --slug graphify-luna-map --corpus-tag luna 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] && [ -f "$T21MAPS/graphify-luna-map.md" ] \
+  && pass "T21c valid non-default GRAPHIFY_MAX_CONCURRENCY still publishes (rc=0)" \
+  || fail "T21c valid GRAPHIFY_MAX_CONCURRENCY=3 should publish (rc=$rc): $out"
+# Require TWO distinct call records — one --update, one cluster-only — each with
+# --max-concurrency 3, and reject any single record combining both (guards against
+# a future stub logging both phases on one line masking a half-wired change).
+awk '
+  /--update/ && /cluster-only/ { combined=1 }
+  /--update/ && /--max-concurrency 3( |$)/ { update=1 }
+  /cluster-only/ && /--max-concurrency 3( |$)/ { cluster=1 }
+  END { exit !((update && cluster) && !combined) }
+' "$t21log" \
+  && pass "T21c both graphify subprocesses received --max-concurrency 3 (distinct records)" \
+  || fail "T21c concurrency propagation not verified on two distinct records: $(cat "$t21log")"
+# T21d: --no-update (publish-only) never makes the extraction/cluster-only calls,
+# so an invalid throttle value is irrelevant and must NOT trip the validation
+# (the run may still fail later for other reasons, but never on the throttle msg).
+out=$( GRAPHIFY_MAX_CONCURRENCY=abc bash "$SCRIPT" --name luna --corpus-root "$CORPUS" --backend deepseek \
+  --maps-dir "$MAPS" --title "T" --slug graphify-luna-map --corpus-tag luna --no-update 2>&1 ); rc=$?
+echo "$out" | grep -q "GRAPHIFY_MAX_CONCURRENCY must be" \
+  && fail "T21d --no-update wrongly validated the irrelevant throttle value: $out" \
+  || pass "T21d --no-update skips throttle validation (invalid value tolerated on publish-only path)"
 
 if [ "$FAILS" -ne 0 ]; then echo "$FAILS FAILURES"; exit 1; fi
 echo "ALL PASS"

--- a/scripts/himmel-update.sh
+++ b/scripts/himmel-update.sh
@@ -685,6 +685,12 @@ run_hermes_step() {
 #    safe because upgrade.sh's own contract never destroys user content.
 update_luna_template() {
     local mode="$1"   # check | apply
+    # Load LUNA_VAULT_PATH from the primary checkout's .env when it is not
+    # already in the process env (a live shell env var still wins — load_dotenv
+    # only fills the gap). Without this, `himmelctl update` run from a shell that
+    # never exported LUNA_VAULT_PATH silently skipped the luna-template upgrade
+    # even though it was configured in .env (operator report 2026-07-21).
+    load_dotenv LUNA_VAULT_PATH 2>/dev/null || true
     local vault="${LUNA_VAULT_PATH:-}"
     local template="$ROOT/templates/luna-second-brain"
     local upgrade="$template/scripts/upgrade.sh"


### PR DESCRIPTION
## What

Two related changes to the graphify refresh tooling (`scripts/graphify/refresh-graph-map.sh`):

**1. `--backend glm` alias.** Reach a GLM/Z.ai extraction through graphify's `claude`
backend pointed at the Anthropic-compatible endpoint, so `--backend glm` is a single
flag instead of hand-setting `ANTHROPIC_*` env each run. `himmel-update.sh` also loads
`LUNA_VAULT_PATH` from `.env` when it isn't already exported, so a configured
luna-template upgrade isn't silently skipped.

**2. `GRAPHIFY_MAX_CONCURRENCY` throttle knob (default 6).** Wired to `--max-concurrency`
on both the `--update` extraction and the `cluster-only` labeling pass, so a rate-limited
backend can be serialized (`GRAPHIFY_MAX_CONCURRENCY=1`).

## Notes

- `--max-concurrency` caps in-flight requests only — it is not true rate-limiting and
  cannot beat a hard per-key quota, so the throttle is a mitigation, not a guarantee.
- Default stays 6 (the default backend, `claude-cli`, is unaffected); throttled callers
  pass the knob explicitly.
- The throttle value is validated as a positive integer, scoped to the extraction path
  so a `--no-update` publish-only run never fails on an irrelevant value.
- Documented in `docs/tooling-catalog.md`; `test-refresh-graph-map.sh` T21 covers
  invalid/empty/negative reject, fail-before-extraction, valid passthrough, and that both
  graphify subcommands receive `--max-concurrency`.
