### PR TITLE
fix(HIMMEL-1225): spawn-glm/claudex --help + bare-flag short-circuit before dispatch

### DIFF
--- a/scripts/telegram/spawn-claudex.test.ts
+++ b/scripts/telegram/spawn-claudex.test.ts
@@ -998,3 +998,44 @@ test("runSharedDispatch releases the lock via a finally (wiring pin)", () => {
   const src = readFileSync("scripts/telegram/spawn-claudex.ts", "utf8");
   expect(/finally\s*\{[\s\S]*?"release", p\.repoDir, p\.branch/.test(src)).toBe(true);
 });
+
+// --- HIMMEL-1225: --help/-h short-circuits BEFORE any side effect ---
+// (isHelpFlag itself is lane-agnostic and unit-tested in spawn-glm.test.ts —
+// spawn-claudex imports it verbatim so both lanes share one definition and
+// can't drift apart; these pins wire it into THIS lane's main().)
+
+test("main() imports isHelpFlag from spawn-glm and checks it BEFORE parseClaudexArgs / any side effect (wiring pin)", () => {
+  const src = readFileSync("scripts/telegram/spawn-claudex.ts", "utf8");
+  expect(/import \{[^}]*\bisHelpFlag\b[^}]*\} from "\.\/spawn-glm"/.test(src)).toBe(true);
+  const helpIdx = src.indexOf("isHelpFlag(rawArgv)");
+  const parseIdx = src.indexOf("parseClaudexArgs(rawArgv)");
+  const wtIdx = src.indexOf('"worktree", "add"');
+  const bankIdx = src.indexOf("fetchCodexWeeklyUsedPercent(homedir())");
+  expect(helpIdx).toBeGreaterThan(-1);
+  expect(parseIdx).toBeGreaterThan(-1);
+  expect(helpIdx).toBeLessThan(parseIdx);   // help checked before parseClaudexArgs even runs
+  expect(helpIdx).toBeLessThan(wtIdx);
+  expect(helpIdx).toBeLessThan(bankIdx);
+  expect(/if \(isHelpFlag\(rawArgv\)\) \{ console\.log\(usage\); process\.exit\(0\); \}/.test(src)).toBe(true);
+});
+
+test("spawn-claudex --help / -h: real CLI invocation prints usage, exits 0, and returns fast (no worktree/dispatch side effects)", () => {
+  for (const flag of ["--help", "-h"]) {
+    const r = Bun.spawnSync(["bun", "scripts/telegram/spawn-claudex.ts", flag], {
+      cwd: resolve("."), stdout: "pipe", stderr: "pipe", timeout: 10_000,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.toString()).toMatch(/usage: spawn-claudex/);
+    expect(r.stdout.toString()).not.toContain("session-dir:");
+  }
+});
+
+test("parseClaudexArgs: a bare unrecognized flag is a usage refusal, not swallowed as the task (HIMMEL-1225)", () => {
+  const typo = parseClaudexArgs(["--tiemout-mins", "45", "real task"]);
+  expect(typo.ok).toBe(false);
+  expect((typo as any).error).toMatch(/unrecognized flag "--tiemout-mins"/);
+  // a bogus flag AFTER a valid positional is still refused (fail-closed)
+  expect(parseClaudexArgs(["do it", "--bogus"]).ok).toBe(false);
+  // recognized flags + a normal positional still parse fine
+  expect(parseClaudexArgs(["do it", "--cwd", "/repo"]).ok).toBe(true);
+});

--- a/scripts/telegram/spawn-claudex.ts
+++ b/scripts/telegram/spawn-claudex.ts
@@ -25,7 +25,7 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawn } from "bun";
 import { REPO_ROOT, killTree, detectContentFilter, type PermissionMode } from "./run";
-import { transcriptDirFor, poisonPushUrl, preflightWindowCheck, measureOverheadChars, finalMeta, POISON_SENTINEL, resolveProfileSettings, teardownMintedWorktree, DEFAULT_LANE_PROFILE, mintRetaskNonce, composeRetaskBlock } from "./spawn-glm";
+import { transcriptDirFor, poisonPushUrl, preflightWindowCheck, measureOverheadChars, finalMeta, POISON_SENTINEL, resolveProfileSettings, teardownMintedWorktree, DEFAULT_LANE_PROFILE, mintRetaskNonce, composeRetaskBlock, isHelpFlag } from "./spawn-glm";
 // HIMMEL-1040 plugin profiles: same per-dispatch lean-profile injection as the
 // GLM lane. spawn-claudex dispatches through scripts/claude-codex, which already
 // screens + forwards --settings — so the resolved payload just rides its argv.
@@ -256,6 +256,10 @@ export function parseClaudexArgs(argv: string[]): { ok: true; args: ClaudexParse
     else if (a === "--skip-auth-preflight") skipAuthPreflight = true;
     else if (a === "--profile") { const v = argv[++i]; if (v === undefined) return { ok: false, error: "--profile requires a value" }; profile = v; }
     else if (a === "--add-plugins") { const v = argv[++i]; if (v === undefined) return { ok: false, error: "--add-plugins requires a value" }; addPlugins.push(...parseAddPlugins(v)); }
+    // HIMMEL-1225: a bare unrecognized flag (--help/-h already short-circuit in
+    // main) is a mistyped/unsupported option, NOT a task — fail closed rather
+    // than dispatch a real worker to reason about the literal flag string.
+    else if (a.startsWith("-")) return { ok: false, error: `unrecognized flag "${a}" (--help for usage)` };
     else if (task === undefined) task = a;
   }
   if (branch !== undefined && name !== undefined) return { ok: false, error: "--branch and --name are mutually exclusive (shared mode derives the slug from the branch)" };
@@ -680,14 +684,18 @@ export async function runClaudexSharedDispatch(p: {
 
 // ── main ─────────────────────────────────────────────────────────────────
 //
-// Exit codes: 1 = uncaught error (main().catch) · 2 = a refusal (usage, bank
-// preflight, himmel-checkout / shared-branch plan, window preflight, --effort
+// Exit codes: 0 = --help/-h (usage printed to stdout, HIMMEL-1225) · 1 =
+// uncaught error (main().catch) · 2 = a refusal (usage, bank preflight,
+// himmel-checkout / shared-branch plan, window preflight, --effort
 // max/ultra) · 4 = shared-branch-lock acquire failure (parity with spawn-glm;
 // there is no exit-3 GLM-guard equivalent here — claude-codex owns PHI/egress
 // guarding itself, D1).
 async function main(): Promise<void> {
-  const parsed = parseClaudexArgs(process.argv.slice(2));
   const usage = "usage: spawn-claudex <prompt> [--cwd <dir>] [--name <slug>] [--branch <existing-branch>] [--timeout-mins <n>] [--permission-mode bypassPermissions] [--effort low|medium|high|xhigh] [--profile <name>] [--add-plugins a@m,b@m] [--force] [--skip-auth-preflight]";
+  const rawArgv = process.argv.slice(2);
+  // HIMMEL-1225: help short-circuit — before parseClaudexArgs, before any side effect.
+  if (isHelpFlag(rawArgv)) { console.log(usage); process.exit(0); }
+  const parsed = parseClaudexArgs(rawArgv);
   if (!parsed.ok) { console.error(`spawn-claudex: ${parsed.error}`); console.error(usage); process.exit(2); }
   const { task, cwd, name, branch: branchArg, timeoutMins, permMode, effort, force, skipAuthPreflight, profile, addPlugins } = parsed.args;
   if (!task) { console.error(usage); process.exit(2); }

--- a/scripts/telegram/spawn-glm.test.ts
+++ b/scripts/telegram/spawn-glm.test.ts
@@ -34,6 +34,7 @@ import {
   DEFAULT_LANE_PROFILE,
   mintRetaskNonce,
   composeRetaskBlock,
+  isHelpFlag,
   type CapGuardDeps,
 } from "./spawn-glm";
 import type { SettingsConflict } from "./glm-env";
@@ -738,6 +739,63 @@ test("parseArgs table: valid flags / positional-only / NaN timeout / trailing fl
 
   const trailingTimeout = parseArgs(["p", "--timeout-mins"]);
   expect(trailingTimeout.ok).toBe(false);
+});
+
+// --- HIMMEL-1225: --help/-h short-circuits BEFORE any side effect ---
+
+test("isHelpFlag: detects --help and -h anywhere in argv; a normal prompt is untouched", () => {
+  expect(isHelpFlag(["--help"])).toBe(true);
+  expect(isHelpFlag(["-h"])).toBe(true);
+  expect(isHelpFlag(["do the thing", "--help"])).toBe(true);
+  expect(isHelpFlag(["--cwd", "/repo", "-h"])).toBe(true);
+  expect(isHelpFlag(["do the thing"])).toBe(false);
+  expect(isHelpFlag([])).toBe(false);
+  expect(isHelpFlag(["--cwd", "/repo", "--name", "task1"])).toBe(false);
+});
+
+test("main() checks isHelpFlag BEFORE parseArgs and before any side effect (worktree add, ZAI preflight) — wiring pin", () => {
+  const src = readFileSync("scripts/telegram/spawn-glm.ts", "utf8");
+  const helpIdx = src.indexOf("isHelpFlag(rawArgv)");
+  const parseIdx = src.indexOf("parseArgs(rawArgv)");
+  const wtIdx = src.indexOf('"worktree", "add"');
+  const zaiIdx = src.indexOf("buildGlmEnv(REPO_ROOT)");
+  expect(helpIdx).toBeGreaterThan(-1);
+  expect(parseIdx).toBeGreaterThan(-1);
+  expect(helpIdx).toBeLessThan(parseIdx);   // help checked before parseArgs even runs
+  expect(helpIdx).toBeLessThan(wtIdx);
+  expect(helpIdx).toBeLessThan(zaiIdx);
+  // the help branch exits 0 to stdout — distinct from the exit-2 usage-error path
+  expect(/if \(isHelpFlag\(rawArgv\)\) \{ console\.log\(usage\); process\.exit\(0\); \}/.test(src)).toBe(true);
+});
+
+test("spawn-glm --help / -h: real CLI invocation prints usage, exits 0, and returns fast (no worktree/dispatch side effects)", () => {
+  for (const flag of ["--help", "-h"]) {
+    const r = Bun.spawnSync(["bun", "scripts/telegram/spawn-glm.ts", flag], {
+      cwd: resolve("."), stdout: "pipe", stderr: "pipe", timeout: 10_000,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.toString()).toMatch(/usage: spawn-glm/);
+    // no orphan worktree/branch minted before the short-circuit
+    expect(r.stdout.toString()).not.toContain("session-dir:");
+  }
+});
+
+test("spawn-glm with only --help as the sole arg does NOT fall through to the missing-prompt usage-error path (exit 0, not exit 2)", () => {
+  const r = Bun.spawnSync(["bun", "scripts/telegram/spawn-glm.ts", "--help"], {
+    cwd: resolve("."), stdout: "pipe", stderr: "pipe", timeout: 10_000,
+  });
+  expect(r.exitCode).toBe(0);
+  expect(r.stderr.toString()).toBe("");
+});
+
+test("parseArgs: a bare unrecognized flag is a usage refusal, not swallowed as the task (HIMMEL-1225)", () => {
+  const typo = parseArgs(["--tiemout-mins", "45", "real task"]);
+  expect(typo.ok).toBe(false);
+  expect((typo as any).error).toMatch(/unrecognized flag "--tiemout-mins"/);
+  // a bogus flag AFTER a valid positional is still refused (fail-closed)
+  expect(parseArgs(["do it", "--bogus"]).ok).toBe(false);
+  // recognized flags + a normal positional still parse fine
+  expect(parseArgs(["do it", "--cwd", "/repo"]).ok).toBe(true);
 });
 
 // --- HIMMEL-1040: --profile / --add-plugins parsing + resolution ---

--- a/scripts/telegram/spawn-glm.ts
+++ b/scripts/telegram/spawn-glm.ts
@@ -410,6 +410,19 @@ export function gitIsDirty(worktreePath: string): boolean {
   return r.stdout.toString().trim().length > 0;
 }
 
+// HIMMEL-1225: --help/-h must short-circuit BEFORE any side effect (worktree
+// add, branch mint, meta.json write, dispatch). A bare `--help`/`-h` was
+// previously parsed as the TASK POSITIONAL by parseArgs below (no recognized
+// flag matches it), so it silently became the prompt and dispatched a REAL
+// unattended worker — burning ~3x quota and leaving an orphan worktree.
+// Checked on the RAW argv, before parseArgs runs, so --help/-h ANYWHERE in the
+// invocation short-circuits regardless of what else was passed. Lane-agnostic:
+// spawn-claudex.ts imports this so both lanes share one definition (twins
+// can't drift apart).
+export function isHelpFlag(argv: string[]): boolean {
+  return argv.includes("--help") || argv.includes("-h");
+}
+
 export type ParsedArgs = { task?: string; cwd: string; name?: string; branch?: string; timeoutMins?: number; permMode?: PermissionMode; armOnCap: boolean; grants: GrantSpec[]; autonomous: boolean; carryFrom?: string; context?: "big" | "small"; profile: string; addPlugins: string[] };
 // Pure + validated: a value-taking flag with no value, or a non-positive /
 // non-finite --timeout-mins, is a USAGE REFUSAL (main → exit 2) — NOT a silent
@@ -456,6 +469,10 @@ export function parseArgs(argv: string[]): { ok: true; args: ParsedArgs } | { ok
     else if (a === "--context") { const v = argv[++i]; if (v === undefined) return { ok: false, error: "--context requires a value" }; if (v !== "big" && v !== "small") return { ok: false, error: `--context must be big or small (got "${v}")` }; context = v; }
     else if (a === "--profile") { const v = argv[++i]; if (v === undefined) return { ok: false, error: "--profile requires a value" }; profile = v; }
     else if (a === "--add-plugins") { const v = argv[++i]; if (v === undefined) return { ok: false, error: "--add-plugins requires a value" }; addPlugins.push(...parseAddPlugins(v)); }
+    // HIMMEL-1225: a bare unrecognized flag (--help/-h already short-circuit in
+    // main) is a mistyped/unsupported option, NOT a task — fail closed rather
+    // than dispatch a real worker to reason about the literal flag string.
+    else if (a.startsWith("-")) return { ok: false, error: `unrecognized flag "${a}" (--help for usage)` };
     else if (task === undefined) task = a;
   }
   // HIMMEL-800: --branch and --name are mutually exclusive — shared mode
@@ -668,8 +685,11 @@ export async function runSharedDispatch(p: {
 }
 
 async function main(): Promise<void> {
-  const parsed = parseArgs(process.argv.slice(2));
   const usage = "usage: spawn-glm <prompt> [--cwd <dir>] [--name <slug>] [--branch <existing-branch>] [--timeout-mins <n>] [--permission-mode bypassPermissions] [--context big|small] [--profile <name>] [--add-plugins a@m,b@m]";
+  const rawArgv = process.argv.slice(2);
+  // HIMMEL-1225: help short-circuit — before parseArgs, before any side effect.
+  if (isHelpFlag(rawArgv)) { console.log(usage); process.exit(0); }
+  const parsed = parseArgs(rawArgv);
   if (!parsed.ok) { console.error(`spawn-glm: ${parsed.error}`); console.error(usage); process.exit(2); }
   const { task, cwd, name, branch: branchArg, timeoutMins, permMode, armOnCap, grants, autonomous, carryFrom, context, profile, addPlugins } = parsed.args;
   if (!task) { console.error(usage); process.exit(2); }


### PR DESCRIPTION
## `--help`/bare-flag short-circuit before dispatch (HIMMEL-1225)

A bare `--help`/`-h` (and any unrecognized `--flag`) fell through to the task
positional and dispatched a **real unattended worker** — quota burn + orphan
worktrees, exit 0 so nothing surfaced it.

### Fix
- Shared `isHelpFlag()` (spawn-claudex imports the one definition so the twins can't drift): prints usage + exits 0 on the RAW argv, **before** `parseArgs` and any side effect (worktree add, branch mint, dispatch).
- `parseArgs`/`parseClaudexArgs` now **fail closed** on any other bare `-`-prefixed token instead of swallowing it as the task — a mistyped/unsupported flag is never a valid brief.

### Tests
Unit pins for `isHelpFlag`, real-CLI `--help`/`-h` round-trips, and the bare-flag refusal, in both twins. (The pre-existing Windows git-worktree suites, HIMMEL-1112, are untouched.)
