### PR TITLE
feat(fleet-lane): spawn --help guard, per-critic CR timeout, Telegram session status (HIMMEL-1241)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,6 +182,17 @@ JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian tenant cloud id (
 # TELEGRAM_CHAT_ID=            # chat id the nudge relays to (bridged from this .env)
 # TELEGRAM_BOT_TOKEN=          # only needed here for the nudge relay; the bridge/poller keeps its own copy
 
+# Outbound Telegram session status (HIMMEL-1250 Increment 1, opt-in). The
+# SessionEnd hook (telegram-session-end.sh) and Notification hook
+# (telegram-notification.sh) relay a CONCISE status to this GROUP chat id when
+# set -- unset/blank is a SILENT no-op (nothing sent). Bridged from this .env
+# like TELEGRAM_CHAT_ID above; the bot token is resolved separately from the
+# existing bridge/poller token file (~/.claude/channels/telegram/.env,
+# TELEGRAM_ENV override) -- do NOT set TELEGRAM_BOT_TOKEN here for this
+# feature. Never sends session content for a repo whose name matches "salus"
+# (the medical vault) -- see scripts/telegram/session-status.ts.
+# TELEGRAM_GROUP_CHAT_ID=
+
 # --- Code review / pr-check critic panel (HIMMEL-558) ---
 # Operator's opt-in critic profile for /pr-check. AUTHORITATIVE for the panel's
 # tier filter when set (an agent can no longer scope the panel down by hand).

--- a/marketplace/plugins/himmel-ops/hooks/hooks.json
+++ b/marketplace/plugins/himmel-ops/hooks/hooks.json
@@ -125,6 +125,24 @@
             "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/jira-nudge-on-end.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; fi'"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/telegram-session-end.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; fi'"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/telegram-notification.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; fi'"
+          }
+        ]
       }
     ]
   }

--- a/scripts/cr/critic-panel.sh
+++ b/scripts/cr/critic-panel.sh
@@ -21,6 +21,9 @@
 #          nothing — 150 clipped their occasional slow reasoning. 240 gives headroom
 #          while still bounding a genuinely hung provider. Lower it for a faster gate.
 #          Requires GNU coreutils 'timeout'; gracefully degrades without it.
+#          A registry row's OPTIONAL "timeout_secs" (HIMMEL-1245) overrides this
+#          shared default for that ONE member only — e.g. the glm row needs more
+#          headroom than codex on a large diff. Invalid/absent -> this default.
 #      CRITIC_PARALLEL — set to 1 to run critics concurrently (default 0 = sequential).
 #          Output is byte-identical to sequential: results merged in registry order.
 set -uo pipefail
@@ -141,6 +144,25 @@ else
     echo "critic-panel.sh: CRITIC_TIMEOUT_SECS=$CRITIC_TIMEOUT_SECS invalid, using 240" >&2
     CRITIC_TIMEOUT_SECS="240"
 fi
+
+# _resolve_member_timeout <slug> <raw_timeout_secs> (HIMMEL-1245)
+# Echoes the effective per-member timeout: the row's OPT-IN timeout_secs when
+# it is a positive integer (Bash 3.2 safe via expr, same check as
+# CRITIC_TIMEOUT_SECS above), else the shared CRITIC_TIMEOUT_SECS default —
+# with a stderr note when a present value was invalid, so a typo'd registry
+# row degrades instead of failing closed.
+_resolve_member_timeout() {
+    _rmt_slug="$1"
+    _rmt_raw="$2"
+    if [ -n "$_rmt_raw" ]; then
+        if expr "$_rmt_raw" : '^[0-9][0-9]*$' > /dev/null 2>&1 && [ "$_rmt_raw" -gt 0 ]; then
+            echo "$_rmt_raw"
+            return
+        fi
+        echo "critic-panel.sh: row $_rmt_slug timeout_secs=$_rmt_raw invalid, using shared default (${CRITIC_TIMEOUT_SECS}s)" >&2
+    fi
+    echo "$CRITIC_TIMEOUT_SECS"
+}
 
 # Validate CRITIC_PARALLEL
 CRITIC_PARALLEL="${CRITIC_PARALLEL:-0}"
@@ -334,12 +356,17 @@ rows="$(REG="$REG" TIER_FILTER="$TIER_FILTER" node -e '
     // candidate chain (e.g. all OpenRouter free models) any failure on one
     // candidate is reason enough to try the next. "-" (unset) keeps the
     // HIMMEL-729 exhaustion-only default for every other row.
+    // Field 8 = TIMEOUT_SECS (HIMMEL-1245): OPT-IN per row. Overrides the
+    // shared CRITIC_TIMEOUT_SECS wall-clock budget for THIS member only
+    // (e.g. glm needs more headroom than codex on a large diff). "-" (unset)
+    // -> the shared default; bash validates positivity (see
+    // _resolve_member_timeout), same as CRITIC_TIMEOUT_SECS itself.
     process.stdout.write(p.map(r => {
       let chain = Array.isArray(r.fallback_models) ? r.fallback_models
                 : (r.fallback_model ? [r.fallback_model] : []);
       chain = chain.filter(m => typeof m === "string" && m.length);
       const fb = chain.length ? chain.join(",") : "-";
-      return r.slug + "\t" + r.model + "\t" + (r.perspective || "-") + "\t" + fb + "\t" + (r.route_provider || "-") + "\t" + (r.fallback_trigger || "-") + "\t" + (r.fallback_provider || "-");
+      return r.slug + "\t" + r.model + "\t" + (r.perspective || "-") + "\t" + fb + "\t" + (r.route_provider || "-") + "\t" + (r.fallback_trigger || "-") + "\t" + (r.fallback_provider || "-") + "\t" + (r.timeout_secs || "-");
     }).join("\n"));
   } catch (e) {
     process.exit(7);
@@ -368,7 +395,7 @@ if [ -z "${rows:-}" ]; then
             echo "critic-panel.sh: registry $REG parse failed unexpectedly (rc=${rows_rc:-0}) — anchor-only ($ANCHOR_SLUG)" >&2
             ;;
     esac
-    rows="${ANCHOR_SLUG}	${ANCHOR_MODEL}	-	-	${ANCHOR_PROVIDER}	-	-"
+    rows="${ANCHOR_SLUG}	${ANCHOR_MODEL}	-	-	${ANCHOR_PROVIDER}	-	-	-"
 fi
 
 # Write diff to a temp file so each member can read it via stdin redirect
@@ -484,6 +511,11 @@ _run_cfp_member() {
 #      requiring a quota-exhaustion signature match. Opt-in per row so the
 #      HIMMEL-729 "don't mask a dead primary lane" contract stays the DEFAULT
 #      for rows that don't set it ("" = exhaustion-signature-only, unchanged).
+# $10 = the RESOLVED per-member timeout in seconds for this slug (HIMMEL-1245):
+#      the row's timeout_secs when valid, else the shared CRITIC_TIMEOUT_SECS
+#      default — already resolved by _resolve_member_timeout at the call site,
+#      so this is used here only for accurate "unavailable (timeout Ns)"
+#      reporting and the fallback-chain seat budget. Unset -> CRITIC_TIMEOUT_SECS.
 # ---------------------------------------------------------------------------
 process_member() {
     _pm_slug="$1"
@@ -498,6 +530,7 @@ process_member() {
     # possibly cross-provider) per the HIMMEL-729 registry contract.
     _pm_fb_provider="${8:-}"
     _pm_trigger="${9:-}"
+    _pm_timeout="${10:-$CRITIC_TIMEOUT_SECS}"
     if [ -n "$_pm_model" ]; then
         _pm_avail="panel-availability: $_pm_slug ok responding-model($_pm_model)"
     else
@@ -534,7 +567,7 @@ process_member() {
     fi
 
     if [ "$_pm_is_timeout" -eq 1 ] && [ "$_pm_do_fallback" -eq 0 ]; then
-        echo "panel-availability: $_pm_slug unavailable (timeout ${CRITIC_TIMEOUT_SECS}s)" >&2
+        echo "panel-availability: $_pm_slug unavailable (timeout ${_pm_timeout}s)" >&2
         return
     fi
     if [ "$_pm_rc" -ne 0 ]; then
@@ -554,12 +587,12 @@ process_member() {
             # stack N full timeouts (observed 240s hangs on free tiers would
             # otherwise block a seat ~4x240s in sequential mode). Each attempt
             # gets the REMAINING budget via the _run_cfp_member override.
-            _fb_deadline=$((SECONDS + CRITIC_TIMEOUT_SECS))
+            _fb_deadline=$((SECONDS + _pm_timeout))
             for _fb_model in $_pm_fallback; do
                 [ -n "$_fb_model" ] || continue
                 _fb_remaining=$((_fb_deadline - SECONDS))
                 if [ "$_fb_remaining" -le 0 ]; then
-                    echo "panel-availability: $_pm_slug fallback-chain budget exhausted (${CRITIC_TIMEOUT_SECS}s) — remaining candidates skipped" >&2
+                    echo "panel-availability: $_pm_slug fallback-chain budget exhausted (${_pm_timeout}s) — remaining candidates skipped" >&2
                     break
                 fi
                 _RM_TIMEOUT_SECS="$_fb_remaining"
@@ -589,7 +622,7 @@ process_member() {
             unset _RM_TIMEOUT_SECS
             if [ "$_fb_success" -ne 1 ]; then
                 if [ "$_pm_is_timeout" -eq 1 ]; then
-                    echo "panel-availability: $_pm_slug unavailable (timeout ${CRITIC_TIMEOUT_SECS}s)" >&2
+                    echo "panel-availability: $_pm_slug unavailable (timeout ${_pm_timeout}s)" >&2
                 else
                     echo "panel-availability: $_pm_slug unavailable (rc=$_pm_rc)" >&2
                 fi
@@ -689,7 +722,7 @@ if [ "$CRITIC_PARALLEL" = "0" ]; then
     _seq_out="$(mktemp -t critic-panel-seq.XXXXXX)"
     _seq_err="$(mktemp -t critic-panel-seq-err.XXXXXX)"
 
-    while IFS="	" read -r slug model perspective fallback_chain row_provider fallback_trigger fb_provider; do
+    while IFS="	" read -r slug model perspective fallback_chain row_provider fallback_trigger fb_provider row_timeout; do
         [ -n "$slug" ] || continue
         # Map the "-" empty-field placeholder back to "" (see the registry
         # emission above — plain empty fields collapse under tab-IFS).
@@ -698,13 +731,18 @@ if [ "$CRITIC_PARALLEL" = "0" ]; then
         [ "$row_provider" = "-" ] && row_provider=""
         [ "$fallback_trigger" = "-" ] && fallback_trigger=""
         [ "$fb_provider" = "-" ] && fb_provider=""
+        [ "$row_timeout" = "-" ] && row_timeout=""
         total=$((total + 1))
+
+        # Per-member timeout override (HIMMEL-1245): the row's timeout_secs
+        # when valid, else the shared CRITIC_TIMEOUT_SECS default.
+        member_timeout="$(_resolve_member_timeout "$slug" "$row_timeout")"
 
         # Run this member (with per-member timeout if available). --provider ""
         # is a no-op in critic-first-pass.sh, so it is passed unconditionally.
         if [ -n "$perspective" ]; then
             if [ -n "$_TIMEOUT_BIN" ]; then
-                "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$_seq_out" 2>"$_seq_err"
+                "$_TIMEOUT_BIN" -k 5 "$member_timeout" bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$_seq_out" 2>"$_seq_err"
                 rc=$?
             else
                 bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$_seq_out" 2>"$_seq_err"
@@ -712,7 +750,7 @@ if [ "$CRITIC_PARALLEL" = "0" ]; then
             fi
         else
             if [ -n "$_TIMEOUT_BIN" ]; then
-                "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" < "$tmp" > "$_seq_out" 2>"$_seq_err"
+                "$_TIMEOUT_BIN" -k 5 "$member_timeout" bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" < "$tmp" > "$_seq_out" 2>"$_seq_err"
                 rc=$?
             else
                 bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" < "$tmp" > "$_seq_out" 2>"$_seq_err"
@@ -720,7 +758,7 @@ if [ "$CRITIC_PARALLEL" = "0" ]; then
             fi
         fi
 
-        process_member "$slug" "$_seq_out" "$rc" "$_seq_err" "$fallback_chain" "$perspective" "$model" "$fb_provider" "$fallback_trigger"
+        process_member "$slug" "$_seq_out" "$rc" "$_seq_err" "$fallback_chain" "$perspective" "$model" "$fb_provider" "$fallback_trigger" "$member_timeout"
 
     done << ROWSEOF
 $rows
@@ -734,7 +772,7 @@ else
 
     # Launch each member indexed by position i (i=0,1,2,...)
     i=0
-    while IFS="	" read -r slug model perspective fallback_chain row_provider fallback_trigger fb_provider; do
+    while IFS="	" read -r slug model perspective fallback_chain row_provider fallback_trigger fb_provider row_timeout; do
         [ -n "$slug" ] || continue
         # Map the "-" empty-field placeholder back to "" (see the registry
         # emission above — plain empty fields collapse under tab-IFS).
@@ -743,7 +781,11 @@ else
         [ "$row_provider" = "-" ] && row_provider=""
         [ "$fallback_trigger" = "-" ] && fallback_trigger=""
         [ "$fb_provider" = "-" ] && fb_provider=""
+        [ "$row_timeout" = "-" ] && row_timeout=""
         total=$((total + 1))
+        # Per-member timeout override (HIMMEL-1245): the row's timeout_secs
+        # when valid, else the shared CRITIC_TIMEOUT_SECS default.
+        member_timeout="$(_resolve_member_timeout "$slug" "$row_timeout")"
         # Write slug and model so the result loop can recover them
         printf '%s' "$slug"  > "$outdir/$i.slug"
         printf '%s' "$model" > "$outdir/$i.model"
@@ -754,10 +796,11 @@ else
         printf '%s' "$fallback_chain"  > "$outdir/$i.fb"
         printf '%s' "$fallback_trigger" > "$outdir/$i.trigger"
         printf '%s' "$fb_provider"      > "$outdir/$i.fbprov"
+        printf '%s' "$member_timeout"   > "$outdir/$i.timeout"
         (
             if [ -n "$perspective" ]; then
                 if [ -n "$_TIMEOUT_BIN" ]; then
-                    "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
+                    "$_TIMEOUT_BIN" -k 5 "$member_timeout" bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
                     echo $? > "$outdir/$i.rc"
                 else
                     bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" --perspective-file "$SCRIPT_DIR/$perspective" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
@@ -765,7 +808,7 @@ else
                 fi
             else
                 if [ -n "$_TIMEOUT_BIN" ]; then
-                    "$_TIMEOUT_BIN" -k 5 "$CRITIC_TIMEOUT_SECS" bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
+                    "$_TIMEOUT_BIN" -k 5 "$member_timeout" bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
                     echo $? > "$outdir/$i.rc"
                 else
                     bash "$CFP" --model "$model" --provider "$row_provider" --slug "$slug" < "$tmp" > "$outdir/$i.out" 2>"$outdir/$i.err"
@@ -795,6 +838,8 @@ ROWSEOF
         read -r trig_val < "$outdir/$i.trigger" 2>/dev/null || true
         fbprov_val=""
         read -r fbprov_val < "$outdir/$i.fbprov" 2>/dev/null || true
+        timeout_val=""
+        read -r timeout_val < "$outdir/$i.timeout" 2>/dev/null || true
         # Note: if .rc is absent (subshell received a signal during the .out write,
         # e.g. outer timeout SIGKILLs mid-run before the echo $? line runs),
         # rc_val stays at its initialized 1 → process_member treats the member as
@@ -802,7 +847,7 @@ ROWSEOF
         # process_member sees zero findings and counts the member as responded.
         model_val=""
         read -r model_val < "$outdir/$i.model" 2>/dev/null || true
-        process_member "$slug" "$outdir/$i.out" "$rc_val" "$outdir/$i.err" "$fb_val" "$persp_val" "$model_val" "$fbprov_val" "$trig_val"
+        process_member "$slug" "$outdir/$i.out" "$rc_val" "$outdir/$i.err" "$fb_val" "$persp_val" "$model_val" "$fbprov_val" "$trig_val" "$timeout_val"
         i=$((i + 1))
     done
 fi

--- a/scripts/cr/critics.json
+++ b/scripts/cr/critics.json
@@ -2,6 +2,6 @@
   "_compliance": "panel/router lanes default to per-token keys; a subscription lane is otherwise launcher-only (ToS restricts it to officially supported tools). EXCEPTION (operator-authorized 2026-07-17, HIMMEL-1096): the existing Z.ai Coding-Plan key MAY back the `glm` critic row below — the operator accepted the ToS trade-off to drop codex as the panel's single point of failure. Scope: this key + this one read-only critic row only; do NOT generalize to other subscription lanes or to router/impl dispatch without a fresh operator decision.",
   "panel": [
     { "slug": "codex",      "model": "gpt-5.5",                             "provider": "openai-codex", "tier": "paid" },
-    { "slug": "glm",        "model": "glm-5.2",                             "provider": "zai",          "tier": "paid", "route_provider": "glm" }
+    { "slug": "glm",        "model": "glm-5.2",                             "provider": "zai",          "tier": "paid", "route_provider": "glm", "timeout_secs": 450 }
   ]
 }

--- a/scripts/cr/test-critic-panel.sh
+++ b/scripts/cr/test-critic-panel.sh
@@ -212,10 +212,56 @@ if command -v timeout > /dev/null 2>&1; then
     check_contains "J1: hung member timeout in stderr" "$stderr_j" "unavailable (timeout 2s)"
     check_contains "J1: hung member slug in stderr" "$stderr_j" "hang-critic"
     check "J1: all-hang -> exit 1" "$j_rc" "1"
+
+    # Test J2 (HIMMEL-1245): a row's OPT-IN timeout_secs governs even when the
+    # shared CRITIC_TIMEOUT_SECS default is much larger — proves the per-row
+    # value actually threads through the timeout wrap, not just gets parsed.
+    HANG_OVERRIDE_JSON="$tmp/critics-hang-override.json"
+    printf '%s\n' '{"panel":[{"slug":"hang-critic2","model":"fake/hang2","provider":"test","tier":"free","timeout_secs":1}]}' > "$HANG_OVERRIDE_JSON"
+
+    j2_case() {
+        j2_rc=0
+        stderr_j2="$(printf '%s' "$DIFF" | CRITIC_TIMEOUT_SECS=20 CRITICS_JSON="$HANG_OVERRIDE_JSON" CRITIC_FIRST_PASS="$STUB_HANG" \
+            timeout 20 bash "$PANEL" 2>&1 >/dev/null)" || j2_rc=$?
+        printf '%s' "$stderr_j2" | grep -qF "unavailable (timeout 1s)" \
+            && printf '%s' "$stderr_j2" | grep -qF "hang-critic2" \
+            && [ "$j2_rc" = "1" ]
+    }
+    retry_once j2_case
+
+    check_contains "J2: row timeout_secs overrides shared default (1s, not 20s)" "$stderr_j2" "unavailable (timeout 1s)"
+    check_contains "J2: overridden member slug in stderr" "$stderr_j2" "hang-critic2"
+    check "J2: all-hang (override) -> exit 1" "$j2_rc" "1"
+
+    # Test J3 (HIMMEL-1245): an INVALID timeout_secs (non-numeric) must NOT fail
+    # the row — it falls back to the shared CRITIC_TIMEOUT_SECS default, with a
+    # stderr note (mirrors the existing CRITIC_TIMEOUT_SECS-itself validation).
+    HANG_BAD_JSON="$tmp/critics-hang-bad.json"
+    printf '%s\n' '{"panel":[{"slug":"hang-critic3","model":"fake/hang3","provider":"test","tier":"free","timeout_secs":"nope"}]}' > "$HANG_BAD_JSON"
+
+    j3_case() {
+        j3_rc=0
+        stderr_j3="$(printf '%s' "$DIFF" | CRITIC_TIMEOUT_SECS=2 CRITICS_JSON="$HANG_BAD_JSON" CRITIC_FIRST_PASS="$STUB_HANG" \
+            timeout 20 bash "$PANEL" 2>&1 >/dev/null)" || j3_rc=$?
+        printf '%s' "$stderr_j3" | grep -qF "unavailable (timeout 2s)" \
+            && printf '%s' "$stderr_j3" | grep -qF "hang-critic3" \
+            && [ "$j3_rc" = "1" ]
+    }
+    retry_once j3_case
+
+    check_contains "J3: invalid timeout_secs falls back to shared default (2s)" "$stderr_j3" "unavailable (timeout 2s)"
+    check_contains "J3: invalid timeout_secs logs a warning" "$stderr_j3" "timeout_secs=nope invalid, using shared default"
+    check "J3: all-hang (invalid override) -> exit 1" "$j3_rc" "1"
 else
     echo "ok - J1: SKIP (no timeout binary)"
     echo "ok - J1: SKIP (no timeout binary)"
     echo "ok - J1: SKIP (no timeout binary)"
+    echo "ok - J2: SKIP (no timeout binary)"
+    echo "ok - J2: SKIP (no timeout binary)"
+    echo "ok - J2: SKIP (no timeout binary)"
+    echo "ok - J3: SKIP (no timeout binary)"
+    echo "ok - J3: SKIP (no timeout binary)"
+    echo "ok - J3: SKIP (no timeout binary)"
 fi
 
 # Tests K1+K2+K3: parallel mode (CRITIC_PARALLEL=1)

--- a/scripts/hooks/telegram-notification.sh
+++ b/scripts/hooks/telegram-notification.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# telegram-notification.sh — Claude Code Notification hook (HIMMEL-1250 Increment 1).
+#
+# Fires when Claude Code needs the operator's attention while unattended
+# (a permission prompt, an idle-wait timeout, an AskUserQuestion / elicitation
+# dialog). Fire-and-forget by contract (exit code ignored) — this hook mirrors
+# that posture and additionally detaches so it never adds latency before the
+# operator-facing prompt renders.
+#
+# Silent no-op (hard requirement): TELEGRAM_GROUP_CHAT_ID unset/blank -> exit
+# 0, nothing sent.
+#
+# Salus/PHI guard: if the session's repo NAME matches /salus/i, the
+# notification message text is NEVER forwarded to the relay (cleared before
+# it leaves this process). session-status.ts re-applies the same check on the
+# repo name it receives (defense-in-depth, not the only guard).
+#
+# Wiring: himmel-ops plugin hooks.json Notification (exec-if-exists) — see
+# marketplace/plugins/CLAUDE.md; .claude/settings.json is NOT touched.
+#
+# No .ps1 twin — same rationale as telegram-session-end.sh / jira-nudge-on-end.sh.
+
+set +e
+set -u 2>/dev/null || true
+trap 'exit 0' EXIT
+
+if [ "${1:-}" != "__himmel_detached" ]; then
+    PAYLOAD=""
+    if [ -t 0 ]; then :; else PAYLOAD="$(cat 2>/dev/null || true)"; fi
+    [ -n "$PAYLOAD" ] || exit 0
+    _tmp="$(mktemp "${TMPDIR:-/tmp}/telegram-notification-payload.XXXXXX" 2>/dev/null)" || exit 0
+    printf '%s' "$PAYLOAD" > "$_tmp" 2>/dev/null || { rm -f "$_tmp"; exit 0; }
+    _dlib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/detach.sh"
+    if [ -r "$_dlib" ]; then
+        # shellcheck source=/dev/null
+        . "$_dlib"
+        detach_run bash "${BASH_SOURCE[0]}" __himmel_detached "$_tmp"
+    else
+        rm -f "$_tmp"
+    fi
+    exit 0
+fi
+
+# === Detached child: the real work (parent already returned 0) ==============
+
+PAYLOAD="$(cat "${2:-}" 2>/dev/null || true)"
+rm -f "${2:-}" 2>/dev/null || true
+
+HOOK_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib"
+ROOT="$(cd "$HOOK_LIB/.." && pwd)"
+# shellcheck source=/dev/null
+[ -r "$HOOK_LIB/detach.sh" ] && . "$HOOK_LIB/detach.sh"
+
+command -v jq  >/dev/null 2>&1 || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+command -v bun >/dev/null 2>&1 || exit 0
+
+[ -n "$PAYLOAD" ] || exit 0
+printf '%s' "$PAYLOAD" | jq -e . >/dev/null 2>&1 || exit 0
+
+SESSION_CWD="$(printf '%s' "$PAYLOAD" | jq -r '.cwd // empty')"
+NOTIFICATION_TYPE="$(printf '%s' "$PAYLOAD" | jq -r '.notification_type // empty')"
+MESSAGE="$(printf '%s' "$PAYLOAD" | jq -r '.message // empty')"
+[ -n "$SESSION_CWD" ] || exit 0
+[ -d "$SESSION_CWD" ] || exit 0
+
+# --- Resolve the session repo's .env root (worktree-safe, like the jira CLI) -
+ENV_ROOT="$( cd "$SESSION_CWD" 2>/dev/null && cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd )"
+[ -n "$ENV_ROOT" ] || ENV_ROOT="$SESSION_CWD"
+
+if [ -r "$HOOK_LIB/load-dotenv.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$HOOK_LIB/load-dotenv.sh"
+    load_dotenv --root "$ENV_ROOT" TELEGRAM_GROUP_CHAT_ID 2>/dev/null || true
+fi
+
+# --- Silent no-op gate: unset/blank TELEGRAM_GROUP_CHAT_ID -------------------
+[ -n "${TELEGRAM_GROUP_CHAT_ID:-}" ] || exit 0
+
+# --- repo name (read-only; never `git fetch`) --------------------------------
+REMOTE_URL="$(git -C "$SESSION_CWD" remote get-url origin 2>/dev/null || true)"
+if [ -n "$REMOTE_URL" ]; then
+    REPO_NAME="$(basename "$REMOTE_URL" .git)"
+else
+    REPO_NAME="$(basename "$SESSION_CWD")"
+fi
+[ -n "$REPO_NAME" ] || REPO_NAME="unknown-repo"
+
+# --- Salus/PHI guard: never forward the notification message for salus ------
+case "$(printf '%s' "$REPO_NAME" | tr '[:upper:]' '[:lower:]')" in
+    *salus*) MESSAGE="" ;;
+esac
+
+# --- Relay via session-status.ts (reuses sendMessage — never reinvents the
+# HTTP client). Detached so it never delays the operator-facing prompt.
+detach_run env \
+    TG_REPO_NAME="$REPO_NAME" TG_NOTIFICATION_TYPE="$NOTIFICATION_TYPE" TG_MESSAGE="$MESSAGE" \
+    TELEGRAM_GROUP_CHAT_ID="$TELEGRAM_GROUP_CHAT_ID" \
+    bun run "$ROOT/scripts/telegram/session-status.ts" notification
+
+exit 0

--- a/scripts/hooks/telegram-session-end.sh
+++ b/scripts/hooks/telegram-session-end.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# telegram-session-end.sh — Claude Code SessionEnd hook (HIMMEL-1250 Increment 1).
+#
+# Fires once per session (SessionEnd, NOT per-turn Stop — Stop fires on every
+# assistant turn and can block session flow via exit code 2; SessionEnd is
+# fire-and-forget and matches this repo's existing "notify operator at session
+# end" convention alongside end-session-wiki.sh / jira-nudge-on-end.sh /
+# refresh-where-are-we-on-end.sh). Composes a CONCISE status (repo/branch, a
+# best-effort last-assistant summary, any /mergepub line) and relays it to the
+# operator's Telegram GROUP via TELEGRAM_GROUP_CHAT_ID + the existing
+# sendMessage() HTTP client (scripts/telegram/telegram-api.ts, via
+# scripts/telegram/session-status.ts) — never reinvents the HTTP client.
+#
+# Silent no-op (hard requirement): TELEGRAM_GROUP_CHAT_ID unset/blank -> exit
+# 0, nothing sent. Never errors, never blocks session teardown — same failure
+# posture as every other SessionEnd hook in this repo.
+#
+# Salus/PHI guard: if the session's repo NAME matches /salus/i (the operator's
+# medical vault/repo), transcript content (last-assistant text) is NEVER READ
+# at all — the guard trips BEFORE extraction, not after, so no PHI-shaped text
+# ever leaves this process. session-status.ts re-applies the same check on the
+# repo name it receives (defense-in-depth, not the only guard).
+#
+# Wiring: himmel-ops plugin hooks.json SessionEnd (exec-if-exists) — see
+# marketplace/plugins/CLAUDE.md; .claude/settings.json is NOT touched (editing
+# it directly is a guarded self-mod).
+#
+# This hook runs under bash on every platform (no .ps1 twin — same rationale
+# as jira-nudge-on-end.sh: it does no OS-specific path work, so Git Bash on
+# Windows runs this file directly).
+#
+# Full-body detach pattern: HIMMEL-661 (extends HIMMEL-636/623). Even the
+# gate-off fast path costs real process-spawn time on Windows Git Bash, which
+# loses the race against Claude Code's SessionEnd teardown — so the ENTIRE
+# body (payload parse, dotenv load, transcript scan, relay) runs in a detached
+# child; the parent returns ~instantly.
+
+set +e
+set -u 2>/dev/null || true
+trap 'exit 0' EXIT
+
+if [ "${1:-}" != "__himmel_detached" ]; then
+    PAYLOAD=""
+    if [ -t 0 ]; then :; else PAYLOAD="$(cat 2>/dev/null || true)"; fi
+    [ -n "$PAYLOAD" ] || exit 0
+    _tmp="$(mktemp "${TMPDIR:-/tmp}/telegram-session-end-payload.XXXXXX" 2>/dev/null)" || exit 0
+    printf '%s' "$PAYLOAD" > "$_tmp" 2>/dev/null || { rm -f "$_tmp"; exit 0; }
+    _dlib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/detach.sh"
+    if [ -r "$_dlib" ]; then
+        # shellcheck source=/dev/null
+        . "$_dlib"
+        detach_run bash "${BASH_SOURCE[0]}" __himmel_detached "$_tmp"
+    else
+        rm -f "$_tmp"
+    fi
+    exit 0
+fi
+
+# === Detached child: the real work (parent already returned 0) ==============
+
+PAYLOAD="$(cat "${2:-}" 2>/dev/null || true)"
+rm -f "${2:-}" 2>/dev/null || true
+
+HOOK_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib"
+ROOT="$(cd "$HOOK_LIB/.." && pwd)"
+# shellcheck source=/dev/null
+[ -r "$HOOK_LIB/detach.sh" ] && . "$HOOK_LIB/detach.sh"
+
+command -v jq  >/dev/null 2>&1 || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+command -v bun >/dev/null 2>&1 || exit 0
+
+[ -n "$PAYLOAD" ] || exit 0
+printf '%s' "$PAYLOAD" | jq -e . >/dev/null 2>&1 || exit 0
+
+SESSION_CWD="$(printf '%s' "$PAYLOAD" | jq -r '.cwd // empty')"
+TRANSCRIPT_PATH="$(printf '%s' "$PAYLOAD" | jq -r '.transcript_path // empty')"
+REASON="$(printf '%s' "$PAYLOAD" | jq -r '.reason // "other"')"
+[ -n "$SESSION_CWD" ] || exit 0
+[ -d "$SESSION_CWD" ] || exit 0
+
+# --- Resolve the session repo's .env root (worktree-safe, like the jira CLI) -
+# The gitignored .env lives in the PRIMARY checkout, not the worktree.
+ENV_ROOT="$( cd "$SESSION_CWD" 2>/dev/null && cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd )"
+[ -n "$ENV_ROOT" ] || ENV_ROOT="$SESSION_CWD"
+
+if [ -r "$HOOK_LIB/load-dotenv.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$HOOK_LIB/load-dotenv.sh"
+    load_dotenv --root "$ENV_ROOT" TELEGRAM_GROUP_CHAT_ID 2>/dev/null || true
+fi
+
+# --- Silent no-op gate: unset/blank TELEGRAM_GROUP_CHAT_ID -------------------
+[ -n "${TELEGRAM_GROUP_CHAT_ID:-}" ] || exit 0
+
+# --- repo name / branch (read-only; never `git fetch`) ----------------------
+REMOTE_URL="$(git -C "$SESSION_CWD" remote get-url origin 2>/dev/null || true)"
+if [ -n "$REMOTE_URL" ]; then
+    REPO_NAME="$(basename "$REMOTE_URL" .git)"
+else
+    REPO_NAME="$(basename "$SESSION_CWD")"
+fi
+[ -n "$REPO_NAME" ] || REPO_NAME="unknown-repo"
+BRANCH="$(git -C "$SESSION_CWD" branch --show-current 2>/dev/null || true)"
+
+# --- Salus/PHI guard: trips BEFORE any transcript content is read -----------
+IS_SALUS=0
+case "$(printf '%s' "$REPO_NAME" | tr '[:upper:]' '[:lower:]')" in
+    *salus*) IS_SALUS=1 ;;
+esac
+
+LAST_ASSISTANT=""
+MERGEPUB_LINE=""
+if [ "$IS_SALUS" = "0" ] && [ -n "$TRANSCRIPT_PATH" ] && [ -r "$TRANSCRIPT_PATH" ]; then
+    # Single lightweight jq scan for the LAST assistant text turn (HIMMEL-636
+    # style single-pass extraction — deliberately NOT the full 4-scan
+    # session-transcript.sh lib; a concise status doesn't need it).
+    LAST_ASSISTANT="$(jq -r 'select(.type=="assistant") | .message.content[]? | select(.type=="text") | .text' "$TRANSCRIPT_PATH" 2>/dev/null | tail -1)"
+    # Best-effort /mergepub line, if the operator issued one this session.
+    MERGEPUB_LINE="$(grep -o '/mergepub[^"\\]*' "$TRANSCRIPT_PATH" 2>/dev/null | tail -1)"
+fi
+
+# --- Relay via session-status.ts (reuses sendMessage — never reinvents the
+# HTTP client). Detached again: the network call must not risk being reaped
+# before it completes (same double-detach pattern as jira-nudge-on-end.sh's
+# relay_nudge()).
+detach_run env \
+    TG_REPO_NAME="$REPO_NAME" TG_BRANCH="$BRANCH" TG_REASON="$REASON" \
+    TG_LAST_ASSISTANT="$LAST_ASSISTANT" TG_MERGEPUB_LINE="$MERGEPUB_LINE" \
+    TELEGRAM_GROUP_CHAT_ID="$TELEGRAM_GROUP_CHAT_ID" \
+    bun run "$ROOT/scripts/telegram/session-status.ts" sessionend
+
+exit 0

--- a/scripts/hooks/test-telegram-notification.sh
+++ b/scripts/hooks/test-telegram-notification.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Hermetic smoke test for scripts/hooks/telegram-notification.sh (HIMMEL-1250).
+#
+# Builds a throwaway git repo, drives the hook in CHILD MODE
+# (`__himmel_detached <payload-file>`) with a stub `bun` on PATH, and asserts:
+# (1) TELEGRAM_GROUP_CHAT_ID unset -> silent no-op, bun never invoked;
+# (2) TELEGRAM_GROUP_CHAT_ID set -> bun invoked with the "notification" arg +
+# the composed TG_* env; (3) a salus-named repo still relays a status but
+# NEVER forwards the notification message text.
+#
+# Usage: bash scripts/hooks/test-telegram-notification.sh
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$HOOK_DIR/telegram-notification.sh"
+
+FAILED=0
+PASSED=0
+pass() { echo "PASS $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "FAIL $1"; FAILED=$((FAILED + 1)); }
+
+ROOT_TMP="$(mktemp -d)"
+trap 'rm -rf "$ROOT_TMP"' EXIT
+
+STUB_DIR="$ROOT_TMP/stubs"
+mkdir -p "$STUB_DIR"
+BUN_LOG="$ROOT_TMP/bun-invocations.log"
+BUN_ARGS="$ROOT_TMP/bun-args.log"
+cat > "$STUB_DIR/bun" <<EOF
+#!/usr/bin/env bash
+echo called >> "$BUN_LOG"
+{
+    printf 'ARGS=%s\n' "\$*"
+    printf 'TG_REPO_NAME=%s\n' "\${TG_REPO_NAME:-}"
+    printf 'TG_NOTIFICATION_TYPE=%s\n' "\${TG_NOTIFICATION_TYPE:-}"
+    printf 'TG_MESSAGE=%s\n' "\${TG_MESSAGE:-}"
+} >> "$BUN_ARGS"
+exit 0
+EOF
+chmod +x "$STUB_DIR/bun"
+
+build_case() {
+    # args: <repo_name>
+    local name="$1"
+    CASE_REPO="$(mktemp -d "$ROOT_TMP/${name}.XXXXXX")"
+    git -C "$CASE_REPO" init -q
+    git -C "$CASE_REPO" config core.hooksPath /dev/null
+    git -C "$CASE_REPO" config commit.gpgsign false
+    git -C "$CASE_REPO" config user.email t@t.t
+    git -C "$CASE_REPO" config user.name tester
+    git -C "$CASE_REPO" remote add origin "https://github.com/acme/${name}.git"
+    echo x > "$CASE_REPO/f.txt"
+    git -C "$CASE_REPO" add f.txt
+    git -C "$CASE_REPO" commit -q --no-verify -m init
+
+    CASE_PAYLOAD="$(printf '{"cwd":"%s","notification_type":"permission_prompt","message":"Bash(rm -rf tmp) needs approval"}' "$CASE_REPO")"
+}
+
+run_hook() {
+    local chat_id="$1" wait_secs="$2"
+    rm -f "$BUN_LOG" "$BUN_ARGS"
+    local pf
+    pf="$(mktemp "$ROOT_TMP/payload.XXXXXX")"
+    printf '%s' "$CASE_PAYLOAD" > "$pf"
+    if [ -n "$chat_id" ]; then
+        env PATH="$STUB_DIR:$PATH" TELEGRAM_GROUP_CHAT_ID="$chat_id" \
+            bash "$HOOK" __himmel_detached "$pf" >/dev/null 2>&1
+    else
+        env -u TELEGRAM_GROUP_CHAT_ID PATH="$STUB_DIR:$PATH" \
+            bash "$HOOK" __himmel_detached "$pf" >/dev/null 2>&1
+    fi
+    local w=0
+    while [ ! -f "$BUN_LOG" ] && [ "$w" -lt "$wait_secs" ]; do sleep 1; w=$((w + 1)); done
+}
+
+# 1. Unset TELEGRAM_GROUP_CHAT_ID -> silent no-op, bun never invoked.
+build_case "himmel"
+run_hook "" 2
+if [ ! -f "$BUN_LOG" ]; then pass "unset chat id: bun never invoked (silent no-op)"; else fail "unset chat id: bun never invoked (silent no-op)"; fi
+
+# 2. Set TELEGRAM_GROUP_CHAT_ID -> bun invoked with notification + composed env.
+build_case "himmel"
+run_hook "-1001234" 5
+if [ -f "$BUN_LOG" ] && [ "$(grep -c . "$BUN_LOG")" = "1" ]; then pass "set chat id: bun invoked exactly once"; else fail "set chat id: bun invoked exactly once"; fi
+if grep -q 'ARGS=run .*session-status\.ts notification' "$BUN_ARGS" 2>/dev/null; then
+    pass "bun invoked with the 'notification' arg"
+else
+    fail "bun invoked with the 'notification' arg (got: $(cat "$BUN_ARGS" 2>/dev/null))"
+fi
+if grep -q '^TG_NOTIFICATION_TYPE=permission_prompt$' "$BUN_ARGS" 2>/dev/null; then pass "TG_NOTIFICATION_TYPE passed through"; else fail "TG_NOTIFICATION_TYPE passed through"; fi
+if grep -q '^TG_MESSAGE=Bash(rm -rf tmp) needs approval$' "$BUN_ARGS" 2>/dev/null; then
+    pass "TG_MESSAGE passed through"
+else
+    fail "TG_MESSAGE passed through (got: $(cat "$BUN_ARGS" 2>/dev/null))"
+fi
+
+# 3. Salus-named repo -> TG_MESSAGE cleared (never forwards notification text),
+#    but the status still relays.
+build_case "salus-vault"
+run_hook "-1001234" 5
+if [ -f "$BUN_LOG" ]; then pass "salus repo: bun still invoked (status still relays, redacted downstream)"; else fail "salus repo: bun still invoked"; fi
+if grep -q '^TG_MESSAGE=$' "$BUN_ARGS" 2>/dev/null; then
+    pass "salus repo: TG_MESSAGE cleared (notification text never forwarded)"
+else
+    fail "salus repo: TG_MESSAGE cleared (got: $(cat "$BUN_ARGS" 2>/dev/null))"
+fi
+
+echo "---"
+echo "PASSED=$PASSED FAILED=$FAILED"
+[ "$FAILED" -eq 0 ]

--- a/scripts/hooks/test-telegram-session-end.sh
+++ b/scripts/hooks/test-telegram-session-end.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Hermetic smoke test for scripts/hooks/telegram-session-end.sh (HIMMEL-1250).
+#
+# Builds a throwaway git repo + transcript, drives the hook in CHILD MODE
+# (`__himmel_detached <payload-file>`, same seam test-jira-nudge-on-end.sh
+# uses) with a stub `bun` on PATH, and asserts: (1) TELEGRAM_GROUP_CHAT_ID
+# unset -> silent no-op, bun never invoked; (2) TELEGRAM_GROUP_CHAT_ID set ->
+# bun invoked with the "sessionend" arg + the composed TG_* env, including the
+# transcript-extracted last-assistant text; (3) a salus-named repo still
+# relays a status but NEVER forwards transcript content (TG_LAST_ASSISTANT
+# stays empty — the guard trips before extraction, not after).
+#
+# The detach primitive itself (setsid/disown branches) is covered by
+# scripts/lib/test-detach.sh; this test only asserts the hook's own contract.
+#
+# Usage: bash scripts/hooks/test-telegram-session-end.sh
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$HOOK_DIR/telegram-session-end.sh"
+
+FAILED=0
+PASSED=0
+pass() { echo "PASS $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "FAIL $1"; FAILED=$((FAILED + 1)); }
+
+ROOT_TMP="$(mktemp -d)"
+trap 'rm -rf "$ROOT_TMP"' EXIT
+
+STUB_DIR="$ROOT_TMP/stubs"
+mkdir -p "$STUB_DIR"
+BUN_LOG="$ROOT_TMP/bun-invocations.log"
+BUN_ARGS="$ROOT_TMP/bun-args.log"
+cat > "$STUB_DIR/bun" <<EOF
+#!/usr/bin/env bash
+echo called >> "$BUN_LOG"
+{
+    printf 'ARGS=%s\n' "\$*"
+    printf 'TG_REPO_NAME=%s\n' "\${TG_REPO_NAME:-}"
+    printf 'TG_BRANCH=%s\n' "\${TG_BRANCH:-}"
+    printf 'TG_LAST_ASSISTANT=%s\n' "\${TG_LAST_ASSISTANT:-}"
+} >> "$BUN_ARGS"
+exit 0
+EOF
+chmod +x "$STUB_DIR/bun"
+
+# ---- case builder -----------------------------------------------------------
+# Globals set by build_case: CASE_REPO, CASE_PAYLOAD
+build_case() {
+    # args: <repo_name>
+    local name="$1"
+    CASE_REPO="$(mktemp -d "$ROOT_TMP/${name}.XXXXXX")"
+    git -C "$CASE_REPO" init -q
+    git -C "$CASE_REPO" config core.hooksPath /dev/null
+    git -C "$CASE_REPO" config commit.gpgsign false
+    git -C "$CASE_REPO" config user.email t@t.t
+    git -C "$CASE_REPO" config user.name tester
+    git -C "$CASE_REPO" remote add origin "https://github.com/acme/${name}.git"
+    echo x > "$CASE_REPO/f.txt"
+    git -C "$CASE_REPO" add f.txt
+    git -C "$CASE_REPO" commit -q --no-verify -m init
+
+    local tx="$CASE_REPO/transcript.jsonl"
+    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"Implemented the feature."}]}}\n' > "$tx"
+
+    CASE_PAYLOAD="$(printf '{"cwd":"%s","transcript_path":"%s","reason":"other"}' "$CASE_REPO" "$tx")"
+}
+
+# ---- run helper --------------------------------------------------------------
+# run_hook <chat_id or empty> <wait_secs> — drives child mode, waits up to
+# <wait_secs> for the detached relay to fire (or gives up).
+run_hook() {
+    local chat_id="$1" wait_secs="$2"
+    rm -f "$BUN_LOG" "$BUN_ARGS"
+    local pf
+    pf="$(mktemp "$ROOT_TMP/payload.XXXXXX")"
+    printf '%s' "$CASE_PAYLOAD" > "$pf"
+    if [ -n "$chat_id" ]; then
+        env PATH="$STUB_DIR:$PATH" TELEGRAM_GROUP_CHAT_ID="$chat_id" \
+            bash "$HOOK" __himmel_detached "$pf" >/dev/null 2>&1
+    else
+        env -u TELEGRAM_GROUP_CHAT_ID PATH="$STUB_DIR:$PATH" \
+            bash "$HOOK" __himmel_detached "$pf" >/dev/null 2>&1
+    fi
+    local w=0
+    while [ ! -f "$BUN_LOG" ] && [ "$w" -lt "$wait_secs" ]; do sleep 1; w=$((w + 1)); done
+}
+
+# 1. Unset TELEGRAM_GROUP_CHAT_ID -> silent no-op, bun never invoked.
+build_case "himmel"
+run_hook "" 2
+if [ ! -f "$BUN_LOG" ]; then pass "unset chat id: bun never invoked (silent no-op)"; else fail "unset chat id: bun never invoked (silent no-op)"; fi
+
+# 2. Set TELEGRAM_GROUP_CHAT_ID -> bun invoked with sessionend + composed env.
+build_case "himmel"
+run_hook "-1001234" 5
+if [ -f "$BUN_LOG" ] && [ "$(grep -c . "$BUN_LOG")" = "1" ]; then pass "set chat id: bun invoked exactly once"; else fail "set chat id: bun invoked exactly once"; fi
+if grep -q 'ARGS=run .*session-status\.ts sessionend' "$BUN_ARGS" 2>/dev/null; then
+    pass "bun invoked with the 'sessionend' arg"
+else
+    fail "bun invoked with the 'sessionend' arg (got: $(cat "$BUN_ARGS" 2>/dev/null))"
+fi
+if grep -q '^TG_REPO_NAME=himmel$' "$BUN_ARGS" 2>/dev/null; then pass "TG_REPO_NAME passed through"; else fail "TG_REPO_NAME passed through"; fi
+if grep -q '^TG_LAST_ASSISTANT=Implemented the feature\.$' "$BUN_ARGS" 2>/dev/null; then
+    pass "TG_LAST_ASSISTANT extracted from the transcript"
+else
+    fail "TG_LAST_ASSISTANT extracted from the transcript (got: $(cat "$BUN_ARGS" 2>/dev/null))"
+fi
+
+# 3. Salus-named repo -> TG_LAST_ASSISTANT stays empty (never reads transcript
+#    content), but the status still relays (redaction happens downstream, not
+#    by silently dropping the whole session-end status).
+build_case "salus-vault"
+run_hook "-1001234" 5
+if [ -f "$BUN_LOG" ]; then pass "salus repo: bun still invoked (status still relays, redacted downstream)"; else fail "salus repo: bun still invoked"; fi
+if grep -q '^TG_LAST_ASSISTANT=$' "$BUN_ARGS" 2>/dev/null; then
+    pass "salus repo: TG_LAST_ASSISTANT never populated (transcript content never read)"
+else
+    fail "salus repo: TG_LAST_ASSISTANT never populated (got: $(cat "$BUN_ARGS" 2>/dev/null))"
+fi
+
+echo "---"
+echo "PASSED=$PASSED FAILED=$FAILED"
+[ "$FAILED" -eq 0 ]

--- a/scripts/telegram/session-status.test.ts
+++ b/scripts/telegram/session-status.test.ts
@@ -1,0 +1,166 @@
+// scripts/telegram/session-status.test.ts — HIMMEL-1250 Increment 1.
+// Hermetic: no real network send (sendAlert is injected, same pattern as
+// luna-sync-alert.test.ts's checkLunaSync tests), no real token file read —
+// main()'s I/O path is never exercised here.
+import { expect, test } from "bun:test";
+import {
+  isSalusRepo,
+  composeSessionEndStatus,
+  composeNotificationStatus,
+  runSessionEndStatus,
+  runNotificationStatus,
+} from "./session-status";
+
+// --- (a) status composition -------------------------------------------------
+
+test("composeSessionEndStatus: includes repo, branch, summary, and mergepub line", () => {
+  const text = composeSessionEndStatus({
+    repoName: "himmel",
+    branch: "feat/himmel-1250-telegram-status",
+    reason: "other",
+    lastAssistant: "Implemented the outbound status hooks.",
+    mergepubLine: "/mergepub 1358 abc1234",
+  });
+  expect(text).toContain("himmel");
+  expect(text).toContain("feat/himmel-1250-telegram-status");
+  expect(text).toContain("Implemented the outbound status hooks.");
+  expect(text).toContain("/mergepub 1358 abc1234");
+});
+
+test("composeSessionEndStatus: omits empty summary/mergepub lines cleanly (concise, no blank lines)", () => {
+  const text = composeSessionEndStatus({ repoName: "himmel", branch: "main" });
+  expect(text).toContain("himmel");
+  expect(text.split("\n").length).toBe(1);
+});
+
+test("composeNotificationStatus: includes repo, type, and message", () => {
+  const text = composeNotificationStatus({
+    repoName: "himmel",
+    notificationType: "permission_prompt",
+    message: "Bash(rm -rf tmp) needs approval",
+  });
+  expect(text).toContain("himmel");
+  expect(text).toContain("permission_prompt");
+  expect(text).toContain("Bash(rm -rf tmp) needs approval");
+});
+
+test("truncate is applied to long content so the status stays CONCISE", () => {
+  const long = "x".repeat(5000);
+  const text = composeSessionEndStatus({ repoName: "himmel", lastAssistant: long });
+  expect(text.length).toBeLessThan(1000);
+  expect(text).toContain("…");
+});
+
+// --- (b) graceful silent no-op when TELEGRAM_GROUP_CHAT_ID is unset --------
+
+test("runSessionEndStatus: chatId null -> skip-no-chat, sendAlert never called (silent no-op)", async () => {
+  let called = false;
+  const outcome = await runSessionEndStatus({
+    chatId: null,
+    repoName: "himmel",
+    branch: "main",
+    lastAssistant: "did stuff",
+    sendAlert: async () => { called = true; return true; },
+    log: () => {},
+  });
+  expect(outcome).toBe("skip-no-chat");
+  expect(called).toBe(false);
+});
+
+test("runNotificationStatus: chatId null -> skip-no-chat, sendAlert never called (silent no-op)", async () => {
+  let called = false;
+  const outcome = await runNotificationStatus({
+    chatId: null,
+    repoName: "himmel",
+    notificationType: "idle_prompt",
+    message: "waiting on you",
+    sendAlert: async () => { called = true; return true; },
+    log: () => {},
+  });
+  expect(outcome).toBe("skip-no-chat");
+  expect(called).toBe(false);
+});
+
+test("runSessionEndStatus: chatId present -> composes + sends, returns sent", async () => {
+  const sent: string[] = [];
+  const outcome = await runSessionEndStatus({
+    chatId: 123,
+    repoName: "himmel",
+    branch: "main",
+    lastAssistant: "did stuff",
+    sendAlert: async (text) => { sent.push(text); return true; },
+  });
+  expect(outcome).toBe("sent");
+  expect(sent).toHaveLength(1);
+});
+
+test("runSessionEndStatus: sendAlert failure (Telegram drop) -> undelivered, never throws", async () => {
+  const outcome = await runSessionEndStatus({
+    chatId: 123,
+    repoName: "himmel",
+    sendAlert: async () => false,
+  });
+  expect(outcome).toBe("undelivered");
+});
+
+// --- (c) PHI / salus exclusion ----------------------------------------------
+
+test("isSalusRepo: matches salus (any case, as a substring) and does not match unrelated names", () => {
+  expect(isSalusRepo("salus")).toBe(true);
+  expect(isSalusRepo("Salus")).toBe(true);
+  expect(isSalusRepo("my-SALUS-vault")).toBe(true);
+  expect(isSalusRepo("himmel")).toBe(false);
+  expect(isSalusRepo("luna")).toBe(false);
+  expect(isSalusRepo(undefined)).toBe(false);
+});
+
+test("composeSessionEndStatus: salus repo NEVER includes the last-assistant text, even if passed in", () => {
+  const phiLooking = "Patient reports elevated blood pressure, medication X 20mg.";
+  const text = composeSessionEndStatus({
+    repoName: "salus",
+    branch: "main",
+    lastAssistant: phiLooking,
+    mergepubLine: "/mergepub 1 abc",
+  });
+  expect(text).not.toContain(phiLooking);
+  expect(text).not.toContain("/mergepub");
+  expect(text.toLowerCase()).toContain("redacted");
+});
+
+test("composeNotificationStatus: salus repo NEVER includes the notification message", () => {
+  const phiLooking = "Confirm dosage change for patient record #4471?";
+  const text = composeNotificationStatus({
+    repoName: "salus-vault",
+    notificationType: "permission_prompt",
+    message: phiLooking,
+  });
+  expect(text).not.toContain(phiLooking);
+  expect(text.toLowerCase()).toContain("redacted");
+});
+
+test("runSessionEndStatus: salus repo still sends a status (chat configured) but the delivered text is redacted", async () => {
+  const phiLooking = "diagnosis: hypertension";
+  const sent: string[] = [];
+  const outcome = await runSessionEndStatus({
+    chatId: 123,
+    repoName: "salus",
+    lastAssistant: phiLooking,
+    sendAlert: async (text) => { sent.push(text); return true; },
+  });
+  expect(outcome).toBe("sent");
+  expect(sent[0]).not.toContain(phiLooking);
+});
+
+test("runNotificationStatus: salus repo still sends a status but the delivered text is redacted", async () => {
+  const phiLooking = "lab result flagged abnormal";
+  const sent: string[] = [];
+  const outcome = await runNotificationStatus({
+    chatId: 123,
+    repoName: "salus",
+    notificationType: "permission_prompt",
+    message: phiLooking,
+    sendAlert: async (text) => { sent.push(text); return true; },
+  });
+  expect(outcome).toBe("sent");
+  expect(sent[0]).not.toContain(phiLooking);
+});

--- a/scripts/telegram/session-status.ts
+++ b/scripts/telegram/session-status.ts
@@ -1,0 +1,182 @@
+// scripts/telegram/session-status.ts — HIMMEL-1250 Increment 1: outbound
+// Telegram session status.
+//
+// Composes a CONCISE status message for two Claude Code hook events —
+// SessionEnd ("this session concluded") and Notification (permission prompt /
+// idle-wait / AskUserQuestion) — and relays it to the operator's Telegram
+// GROUP via the existing sendMessage() HTTP client
+// (scripts/telegram/telegram-api.ts). Never reinvents the HTTP client; never
+// reads/logs the raw bot token anywhere except handing it to sendMessage.
+//
+// Why SessionEnd, not Stop: Stop fires per assistant turn (repeatedly, can
+// block session flow via exit code 2) — SessionEnd fires exactly once per
+// session, is fire-and-forget, and matches this repo's existing "notify
+// operator at session end" convention (end-session-wiki.sh /
+// jira-nudge-on-end.sh / refresh-where-are-we-on-end.sh, all wired via the
+// himmel-ops plugin hooks.json SessionEnd array).
+//
+// Salus/PHI guard: a repo whose name matches /salus/i (the operator's
+// medical vault/repo — see docs/internals memory: "salus = medical vault")
+// NEVER has session content (last-assistant text, notification message)
+// included in the composed status — only a generic, content-free line. The
+// calling bash hooks additionally short-circuit BEFORE extracting any
+// transcript content for a salus repo, so this check is defense-in-depth,
+// not the only guard.
+//
+// Silent no-op: when no group chat id is configured (TELEGRAM_GROUP_CHAT_ID
+// unset/blank/non-numeric), runSessionEndStatus/runNotificationStatus return
+// "skip-no-chat" WITHOUT calling sendAlert — the hook's silent-no-op
+// contract (never error, never block, never send).
+//
+// Pattern mirrors scripts/observability/luna-sync-alert.ts: pure, injectable
+// core functions (unit-testable, no network/env/fs access) + a thin main()
+// that does the real I/O — never exercised by tests.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { sendMessage, redactChatId } from "./telegram-api";
+
+export function isSalusRepo(repoName: string | undefined): boolean {
+  return /salus/i.test(repoName ?? "");
+}
+
+export function truncate(s: string | undefined, max: number): string {
+  const t = (s ?? "").trim();
+  if (t.length <= max) return t;
+  return t.slice(0, max - 1).trimEnd() + "…";
+}
+
+const SUMMARY_MAX = 400;
+
+export function composeSessionEndStatus(input: {
+  repoName: string;
+  branch?: string;
+  reason?: string;
+  lastAssistant?: string;
+  mergepubLine?: string;
+}): string {
+  const { repoName, branch, reason } = input;
+  if (isSalusRepo(repoName)) {
+    return `🏁 ${repoName} session ended — content redacted (salus/medical vault)`;
+  }
+  const lines = [`🏁 ${repoName}${branch ? ` (${branch})` : ""} session ended${reason && reason !== "other" ? ` — ${reason}` : ""}`];
+  const summary = truncate(input.lastAssistant, SUMMARY_MAX);
+  if (summary) lines.push(summary);
+  const mergepub = truncate(input.mergepubLine, 200);
+  if (mergepub) lines.push(mergepub);
+  return lines.join("\n");
+}
+
+export function composeNotificationStatus(input: {
+  repoName: string;
+  notificationType?: string;
+  message?: string;
+}): string {
+  const { repoName, notificationType } = input;
+  if (isSalusRepo(repoName)) {
+    return `🔔 ${repoName}: ${notificationType || "notification"} — content redacted (salus/medical vault)`;
+  }
+  const msg = truncate(input.message, SUMMARY_MAX);
+  return `🔔 ${repoName}: ${notificationType || "notification"}${msg ? ` — ${msg}` : ""}`;
+}
+
+export type SendFn = (text: string) => Promise<boolean>;
+export type StatusOutcome = "sent" | "skip-no-chat" | "undelivered";
+
+export async function runSessionEndStatus(opts: {
+  chatId: number | null;
+  repoName: string;
+  branch?: string;
+  reason?: string;
+  lastAssistant?: string;
+  mergepubLine?: string;
+  sendAlert: SendFn;
+  log?: (msg: string) => void;
+}): Promise<StatusOutcome> {
+  const log = opts.log ?? ((m: string) => console.error(m));
+  if (opts.chatId === null) {
+    log("telegram-session-status: no TELEGRAM_GROUP_CHAT_ID configured — silent no-op");
+    return "skip-no-chat";
+  }
+  const text = composeSessionEndStatus(opts);
+  const delivered = await opts.sendAlert(text);
+  return delivered ? "sent" : "undelivered";
+}
+
+export async function runNotificationStatus(opts: {
+  chatId: number | null;
+  repoName: string;
+  notificationType?: string;
+  message?: string;
+  sendAlert: SendFn;
+  log?: (msg: string) => void;
+}): Promise<StatusOutcome> {
+  const log = opts.log ?? ((m: string) => console.error(m));
+  if (opts.chatId === null) {
+    log("telegram-session-status: no TELEGRAM_GROUP_CHAT_ID configured — silent no-op");
+    return "skip-no-chat";
+  }
+  const text = composeNotificationStatus(opts);
+  const delivered = await opts.sendAlert(text);
+  return delivered ? "sent" : "undelivered";
+}
+
+// ── real I/O (main-only; never exercised by tests) ──────────────────────────
+
+// Bot token: SAME resolution the bridge/poller and luna-sync-alert.ts use —
+// ~/.claude/channels/telegram/.env's TELEGRAM_BOT_TOKEN, overridable via
+// TELEGRAM_ENV. Never logged — only handed to sendMessage's request body.
+function loadToken(env: Record<string, string | undefined>): string {
+  const envPath = env.TELEGRAM_ENV ?? join(homedir(), ".claude", "channels", "telegram", ".env");
+  const txt = readFileSync(envPath, "utf8");
+  const m = txt.match(/^TELEGRAM_BOT_TOKEN\s*=\s*(.+)$/m);
+  if (!m) throw new Error("TELEGRAM_BOT_TOKEN not found in " + envPath);
+  return m[1].trim();
+}
+
+function resolveChatId(env: Record<string, string | undefined>): number | null {
+  const raw = (env.TELEGRAM_GROUP_CHAT_ID ?? "").trim();
+  if (!raw || !/^-?\d+$/.test(raw)) return null;
+  return Number(raw);
+}
+
+async function main(): Promise<void> {
+  const env = process.env;
+  const eventType = process.argv[2]; // "sessionend" | "notification"
+  const chatId = resolveChatId(env);
+  const repoName = env.TG_REPO_NAME || "unknown-repo";
+
+  const sendAlert: SendFn = async (text) => {
+    if (chatId === null) return false;
+    const token = loadToken(env);
+    return sendMessage(token, chatId, text);
+  };
+
+  const result =
+    eventType === "notification"
+      ? await runNotificationStatus({
+          chatId,
+          repoName,
+          notificationType: env.TG_NOTIFICATION_TYPE,
+          message: env.TG_MESSAGE,
+          sendAlert,
+        })
+      : await runSessionEndStatus({
+          chatId,
+          repoName,
+          branch: env.TG_BRANCH,
+          reason: env.TG_REASON,
+          lastAssistant: env.TG_LAST_ASSISTANT,
+          mergepubLine: env.TG_MERGEPUB_LINE,
+          sendAlert,
+        });
+
+  if (result === "undelivered") {
+    console.error(`telegram-session-status: ${eventType || "sessionend"} status not delivered (chat=${chatId !== null ? redactChatId(chatId) : "none"})`);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((e) => { console.error(`telegram-session-status: fatal: ${e instanceof Error ? e.message : String(e)}`); });
+}

--- a/scripts/telegram/spawn-claudex.test.ts
+++ b/scripts/telegram/spawn-claudex.test.ts
@@ -998,3 +998,44 @@ test("runSharedDispatch releases the lock via a finally (wiring pin)", () => {
   const src = readFileSync("scripts/telegram/spawn-claudex.ts", "utf8");
   expect(/finally\s*\{[\s\S]*?"release", p\.repoDir, p\.branch/.test(src)).toBe(true);
 });
+
+// --- HIMMEL-1225: --help/-h short-circuits BEFORE any side effect ---
+// (isHelpFlag itself is lane-agnostic and unit-tested in spawn-glm.test.ts —
+// spawn-claudex imports it verbatim so both lanes share one definition and
+// can't drift apart; these pins wire it into THIS lane's main().)
+
+test("main() imports isHelpFlag from spawn-glm and checks it BEFORE parseClaudexArgs / any side effect (wiring pin)", () => {
+  const src = readFileSync("scripts/telegram/spawn-claudex.ts", "utf8");
+  expect(/import \{[^}]*\bisHelpFlag\b[^}]*\} from "\.\/spawn-glm"/.test(src)).toBe(true);
+  const helpIdx = src.indexOf("isHelpFlag(rawArgv)");
+  const parseIdx = src.indexOf("parseClaudexArgs(rawArgv)");
+  const wtIdx = src.indexOf('"worktree", "add"');
+  const bankIdx = src.indexOf("fetchCodexWeeklyUsedPercent(homedir())");
+  expect(helpIdx).toBeGreaterThan(-1);
+  expect(parseIdx).toBeGreaterThan(-1);
+  expect(helpIdx).toBeLessThan(parseIdx);   // help checked before parseClaudexArgs even runs
+  expect(helpIdx).toBeLessThan(wtIdx);
+  expect(helpIdx).toBeLessThan(bankIdx);
+  expect(/if \(isHelpFlag\(rawArgv\)\) \{ console\.log\(usage\); process\.exit\(0\); \}/.test(src)).toBe(true);
+});
+
+test("spawn-claudex --help / -h: real CLI invocation prints usage, exits 0, and returns fast (no worktree/dispatch side effects)", () => {
+  for (const flag of ["--help", "-h"]) {
+    const r = Bun.spawnSync(["bun", "scripts/telegram/spawn-claudex.ts", flag], {
+      cwd: resolve("."), stdout: "pipe", stderr: "pipe", timeout: 10_000,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.toString()).toMatch(/usage: spawn-claudex/);
+    expect(r.stdout.toString()).not.toContain("session-dir:");
+  }
+});
+
+test("parseClaudexArgs: a bare unrecognized flag is a usage refusal, not swallowed as the task (HIMMEL-1225)", () => {
+  const typo = parseClaudexArgs(["--tiemout-mins", "45", "real task"]);
+  expect(typo.ok).toBe(false);
+  expect((typo as any).error).toMatch(/unrecognized flag "--tiemout-mins"/);
+  // a bogus flag AFTER a valid positional is still refused (fail-closed)
+  expect(parseClaudexArgs(["do it", "--bogus"]).ok).toBe(false);
+  // recognized flags + a normal positional still parse fine
+  expect(parseClaudexArgs(["do it", "--cwd", "/repo"]).ok).toBe(true);
+});

--- a/scripts/telegram/spawn-claudex.ts
+++ b/scripts/telegram/spawn-claudex.ts
@@ -25,7 +25,7 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawn } from "bun";
 import { REPO_ROOT, killTree, detectContentFilter, type PermissionMode } from "./run";
-import { transcriptDirFor, poisonPushUrl, preflightWindowCheck, measureOverheadChars, finalMeta, POISON_SENTINEL, resolveProfileSettings, teardownMintedWorktree, DEFAULT_LANE_PROFILE, mintRetaskNonce, composeRetaskBlock } from "./spawn-glm";
+import { transcriptDirFor, poisonPushUrl, preflightWindowCheck, measureOverheadChars, finalMeta, POISON_SENTINEL, resolveProfileSettings, teardownMintedWorktree, DEFAULT_LANE_PROFILE, mintRetaskNonce, composeRetaskBlock, isHelpFlag } from "./spawn-glm";
 // HIMMEL-1040 plugin profiles: same per-dispatch lean-profile injection as the
 // GLM lane. spawn-claudex dispatches through scripts/claude-codex, which already
 // screens + forwards --settings — so the resolved payload just rides its argv.
@@ -256,6 +256,10 @@ export function parseClaudexArgs(argv: string[]): { ok: true; args: ClaudexParse
     else if (a === "--skip-auth-preflight") skipAuthPreflight = true;
     else if (a === "--profile") { const v = argv[++i]; if (v === undefined) return { ok: false, error: "--profile requires a value" }; profile = v; }
     else if (a === "--add-plugins") { const v = argv[++i]; if (v === undefined) return { ok: false, error: "--add-plugins requires a value" }; addPlugins.push(...parseAddPlugins(v)); }
+    // HIMMEL-1225: a bare unrecognized flag (--help/-h already short-circuit in
+    // main) is a mistyped/unsupported option, NOT a task — fail closed rather
+    // than dispatch a real worker to reason about the literal flag string.
+    else if (a.startsWith("-")) return { ok: false, error: `unrecognized flag "${a}" (--help for usage)` };
     else if (task === undefined) task = a;
   }
   if (branch !== undefined && name !== undefined) return { ok: false, error: "--branch and --name are mutually exclusive (shared mode derives the slug from the branch)" };
@@ -680,14 +684,18 @@ export async function runClaudexSharedDispatch(p: {
 
 // ── main ─────────────────────────────────────────────────────────────────
 //
-// Exit codes: 1 = uncaught error (main().catch) · 2 = a refusal (usage, bank
-// preflight, himmel-checkout / shared-branch plan, window preflight, --effort
+// Exit codes: 0 = --help/-h (usage printed to stdout, HIMMEL-1225) · 1 =
+// uncaught error (main().catch) · 2 = a refusal (usage, bank preflight,
+// himmel-checkout / shared-branch plan, window preflight, --effort
 // max/ultra) · 4 = shared-branch-lock acquire failure (parity with spawn-glm;
 // there is no exit-3 GLM-guard equivalent here — claude-codex owns PHI/egress
 // guarding itself, D1).
 async function main(): Promise<void> {
-  const parsed = parseClaudexArgs(process.argv.slice(2));
   const usage = "usage: spawn-claudex <prompt> [--cwd <dir>] [--name <slug>] [--branch <existing-branch>] [--timeout-mins <n>] [--permission-mode bypassPermissions] [--effort low|medium|high|xhigh] [--profile <name>] [--add-plugins a@m,b@m] [--force] [--skip-auth-preflight]";
+  const rawArgv = process.argv.slice(2);
+  // HIMMEL-1225: help short-circuit — before parseClaudexArgs, before any side effect.
+  if (isHelpFlag(rawArgv)) { console.log(usage); process.exit(0); }
+  const parsed = parseClaudexArgs(rawArgv);
   if (!parsed.ok) { console.error(`spawn-claudex: ${parsed.error}`); console.error(usage); process.exit(2); }
   const { task, cwd, name, branch: branchArg, timeoutMins, permMode, effort, force, skipAuthPreflight, profile, addPlugins } = parsed.args;
   if (!task) { console.error(usage); process.exit(2); }

--- a/scripts/telegram/spawn-glm.test.ts
+++ b/scripts/telegram/spawn-glm.test.ts
@@ -34,6 +34,7 @@ import {
   DEFAULT_LANE_PROFILE,
   mintRetaskNonce,
   composeRetaskBlock,
+  isHelpFlag,
   type CapGuardDeps,
 } from "./spawn-glm";
 import type { SettingsConflict } from "./glm-env";
@@ -738,6 +739,63 @@ test("parseArgs table: valid flags / positional-only / NaN timeout / trailing fl
 
   const trailingTimeout = parseArgs(["p", "--timeout-mins"]);
   expect(trailingTimeout.ok).toBe(false);
+});
+
+// --- HIMMEL-1225: --help/-h short-circuits BEFORE any side effect ---
+
+test("isHelpFlag: detects --help and -h anywhere in argv; a normal prompt is untouched", () => {
+  expect(isHelpFlag(["--help"])).toBe(true);
+  expect(isHelpFlag(["-h"])).toBe(true);
+  expect(isHelpFlag(["do the thing", "--help"])).toBe(true);
+  expect(isHelpFlag(["--cwd", "/repo", "-h"])).toBe(true);
+  expect(isHelpFlag(["do the thing"])).toBe(false);
+  expect(isHelpFlag([])).toBe(false);
+  expect(isHelpFlag(["--cwd", "/repo", "--name", "task1"])).toBe(false);
+});
+
+test("main() checks isHelpFlag BEFORE parseArgs and before any side effect (worktree add, ZAI preflight) — wiring pin", () => {
+  const src = readFileSync("scripts/telegram/spawn-glm.ts", "utf8");
+  const helpIdx = src.indexOf("isHelpFlag(rawArgv)");
+  const parseIdx = src.indexOf("parseArgs(rawArgv)");
+  const wtIdx = src.indexOf('"worktree", "add"');
+  const zaiIdx = src.indexOf("buildGlmEnv(REPO_ROOT)");
+  expect(helpIdx).toBeGreaterThan(-1);
+  expect(parseIdx).toBeGreaterThan(-1);
+  expect(helpIdx).toBeLessThan(parseIdx);   // help checked before parseArgs even runs
+  expect(helpIdx).toBeLessThan(wtIdx);
+  expect(helpIdx).toBeLessThan(zaiIdx);
+  // the help branch exits 0 to stdout — distinct from the exit-2 usage-error path
+  expect(/if \(isHelpFlag\(rawArgv\)\) \{ console\.log\(usage\); process\.exit\(0\); \}/.test(src)).toBe(true);
+});
+
+test("spawn-glm --help / -h: real CLI invocation prints usage, exits 0, and returns fast (no worktree/dispatch side effects)", () => {
+  for (const flag of ["--help", "-h"]) {
+    const r = Bun.spawnSync(["bun", "scripts/telegram/spawn-glm.ts", flag], {
+      cwd: resolve("."), stdout: "pipe", stderr: "pipe", timeout: 10_000,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.toString()).toMatch(/usage: spawn-glm/);
+    // no orphan worktree/branch minted before the short-circuit
+    expect(r.stdout.toString()).not.toContain("session-dir:");
+  }
+});
+
+test("spawn-glm with only --help as the sole arg does NOT fall through to the missing-prompt usage-error path (exit 0, not exit 2)", () => {
+  const r = Bun.spawnSync(["bun", "scripts/telegram/spawn-glm.ts", "--help"], {
+    cwd: resolve("."), stdout: "pipe", stderr: "pipe", timeout: 10_000,
+  });
+  expect(r.exitCode).toBe(0);
+  expect(r.stderr.toString()).toBe("");
+});
+
+test("parseArgs: a bare unrecognized flag is a usage refusal, not swallowed as the task (HIMMEL-1225)", () => {
+  const typo = parseArgs(["--tiemout-mins", "45", "real task"]);
+  expect(typo.ok).toBe(false);
+  expect((typo as any).error).toMatch(/unrecognized flag "--tiemout-mins"/);
+  // a bogus flag AFTER a valid positional is still refused (fail-closed)
+  expect(parseArgs(["do it", "--bogus"]).ok).toBe(false);
+  // recognized flags + a normal positional still parse fine
+  expect(parseArgs(["do it", "--cwd", "/repo"]).ok).toBe(true);
 });
 
 // --- HIMMEL-1040: --profile / --add-plugins parsing + resolution ---

--- a/scripts/telegram/spawn-glm.ts
+++ b/scripts/telegram/spawn-glm.ts
@@ -410,6 +410,19 @@ export function gitIsDirty(worktreePath: string): boolean {
   return r.stdout.toString().trim().length > 0;
 }
 
+// HIMMEL-1225: --help/-h must short-circuit BEFORE any side effect (worktree
+// add, branch mint, meta.json write, dispatch). A bare `--help`/`-h` was
+// previously parsed as the TASK POSITIONAL by parseArgs below (no recognized
+// flag matches it), so it silently became the prompt and dispatched a REAL
+// unattended worker — burning ~3x quota and leaving an orphan worktree.
+// Checked on the RAW argv, before parseArgs runs, so --help/-h ANYWHERE in the
+// invocation short-circuits regardless of what else was passed. Lane-agnostic:
+// spawn-claudex.ts imports this so both lanes share one definition (twins
+// can't drift apart).
+export function isHelpFlag(argv: string[]): boolean {
+  return argv.includes("--help") || argv.includes("-h");
+}
+
 export type ParsedArgs = { task?: string; cwd: string; name?: string; branch?: string; timeoutMins?: number; permMode?: PermissionMode; armOnCap: boolean; grants: GrantSpec[]; autonomous: boolean; carryFrom?: string; context?: "big" | "small"; profile: string; addPlugins: string[] };
 // Pure + validated: a value-taking flag with no value, or a non-positive /
 // non-finite --timeout-mins, is a USAGE REFUSAL (main → exit 2) — NOT a silent
@@ -456,6 +469,10 @@ export function parseArgs(argv: string[]): { ok: true; args: ParsedArgs } | { ok
     else if (a === "--context") { const v = argv[++i]; if (v === undefined) return { ok: false, error: "--context requires a value" }; if (v !== "big" && v !== "small") return { ok: false, error: `--context must be big or small (got "${v}")` }; context = v; }
     else if (a === "--profile") { const v = argv[++i]; if (v === undefined) return { ok: false, error: "--profile requires a value" }; profile = v; }
     else if (a === "--add-plugins") { const v = argv[++i]; if (v === undefined) return { ok: false, error: "--add-plugins requires a value" }; addPlugins.push(...parseAddPlugins(v)); }
+    // HIMMEL-1225: a bare unrecognized flag (--help/-h already short-circuit in
+    // main) is a mistyped/unsupported option, NOT a task — fail closed rather
+    // than dispatch a real worker to reason about the literal flag string.
+    else if (a.startsWith("-")) return { ok: false, error: `unrecognized flag "${a}" (--help for usage)` };
     else if (task === undefined) task = a;
   }
   // HIMMEL-800: --branch and --name are mutually exclusive — shared mode
@@ -668,8 +685,11 @@ export async function runSharedDispatch(p: {
 }
 
 async function main(): Promise<void> {
-  const parsed = parseArgs(process.argv.slice(2));
   const usage = "usage: spawn-glm <prompt> [--cwd <dir>] [--name <slug>] [--branch <existing-branch>] [--timeout-mins <n>] [--permission-mode bypassPermissions] [--context big|small] [--profile <name>] [--add-plugins a@m,b@m]";
+  const rawArgv = process.argv.slice(2);
+  // HIMMEL-1225: help short-circuit — before parseArgs, before any side effect.
+  if (isHelpFlag(rawArgv)) { console.log(usage); process.exit(0); }
+  const parsed = parseArgs(rawArgv);
   if (!parsed.ok) { console.error(`spawn-glm: ${parsed.error}`); console.error(usage); process.exit(2); }
   const { task, cwd, name, branch: branchArg, timeoutMins, permMode, armOnCap, grants, autonomous, carryFrom, context, profile, addPlugins } = parsed.args;
   if (!task) { console.error(usage); process.exit(2); }

--- a/scripts/telegram/telegram-api.ts
+++ b/scripts/telegram/telegram-api.ts
@@ -21,7 +21,7 @@ export async function sendChatAction(token: string, chat_id: number, f: F = fetc
 // and these logs get captured into session notes committed to a vault. For
 // longer ids, keeps the last 2 digits so repeated failures for the same chat
 // can still be correlated without exposing the raw id.
-const redactChatId = (chat_id: number): string => {
+export const redactChatId = (chat_id: number): string => {
   const digits = String(chat_id).replace(/^-/, "");
   return digits.length > 2 ? `***${digits.slice(-2)}` : "***";
 };


### PR DESCRIPTION
## Fleet-lane batch (HIMMEL-1241) — 3 changes

- **HIMMEL-1225** — `spawn-glm`/`spawn-claudex`: a bare `--help`/`-h` (or any
  unrecognized `--flag`) was parsed as the task positional and dispatched a real
  worker (quota burn + orphan worktree). Now short-circuits to usage on the raw
  argv before any side effect; a shared `isHelpFlag()` keeps the twins from
  drifting, and `parseArgs`/`parseClaudexArgs` fail closed on bare flags.
- **HIMMEL-1245** — CR critic panel: rows gain an optional `timeout_secs` that
  overrides the shared `CRITIC_TIMEOUT_SECS` for that member only (Bash-3.2-safe
  validation, degrades to the shared default on an invalid value); threaded
  through the sequential + parallel paths and the fallback-chain deadline.
- **HIMMEL-1250** — outbound Telegram session status (Increment 1): `SessionEnd`
  + `Notification` hooks relay a concise status / pending prompt to a configured
  group via the existing `sendMessage` client. Silent no-op when unset;
  full-body-detach so it never blocks teardown; two-layer `/salus/i` PHI
  exclusion (guard trips before any transcript read).

Each was reviewed by a cross-model critic panel (codex, + glm where available)
before merge to the source repo.

Platforms tested: gitbash, windows · Security reviewed: manual
