### PR TITLE
feat(HIMMEL-1250): outbound Telegram session status + notification hooks (Increment 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,6 +182,17 @@ JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian tenant cloud id (
 # TELEGRAM_CHAT_ID=            # chat id the nudge relays to (bridged from this .env)
 # TELEGRAM_BOT_TOKEN=          # only needed here for the nudge relay; the bridge/poller keeps its own copy
 
+# Outbound Telegram session status (HIMMEL-1250 Increment 1, opt-in). The
+# SessionEnd hook (telegram-session-end.sh) and Notification hook
+# (telegram-notification.sh) relay a CONCISE status to this GROUP chat id when
+# set -- unset/blank is a SILENT no-op (nothing sent). Bridged from this .env
+# like TELEGRAM_CHAT_ID above; the bot token is resolved separately from the
+# existing bridge/poller token file (~/.claude/channels/telegram/.env,
+# TELEGRAM_ENV override) -- do NOT set TELEGRAM_BOT_TOKEN here for this
+# feature. Never sends session content for a repo whose name matches "salus"
+# (the medical vault) -- see scripts/telegram/session-status.ts.
+# TELEGRAM_GROUP_CHAT_ID=
+
 # --- Code review / pr-check critic panel (HIMMEL-558) ---
 # Operator's opt-in critic profile for /pr-check. AUTHORITATIVE for the panel's
 # tier filter when set (an agent can no longer scope the panel down by hand).

--- a/marketplace/plugins/himmel-ops/hooks/hooks.json
+++ b/marketplace/plugins/himmel-ops/hooks/hooks.json
@@ -125,6 +125,24 @@
             "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/jira-nudge-on-end.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; fi'"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/telegram-session-end.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; fi'"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'h=\"$CLAUDE_PROJECT_DIR/scripts/hooks/telegram-notification.sh\"; if [ -f \"$h\" ]; then exec bash \"$h\"; fi'"
+          }
+        ]
       }
     ]
   }

--- a/scripts/hooks/telegram-notification.sh
+++ b/scripts/hooks/telegram-notification.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# telegram-notification.sh — Claude Code Notification hook (HIMMEL-1250 Increment 1).
+#
+# Fires when Claude Code needs the operator's attention while unattended
+# (a permission prompt, an idle-wait timeout, an AskUserQuestion / elicitation
+# dialog). Fire-and-forget by contract (exit code ignored) — this hook mirrors
+# that posture and additionally detaches so it never adds latency before the
+# operator-facing prompt renders.
+#
+# Silent no-op (hard requirement): TELEGRAM_GROUP_CHAT_ID unset/blank -> exit
+# 0, nothing sent.
+#
+# Salus/PHI guard: if the session's repo NAME matches /salus/i, the
+# notification message text is NEVER forwarded to the relay (cleared before
+# it leaves this process). session-status.ts re-applies the same check on the
+# repo name it receives (defense-in-depth, not the only guard).
+#
+# Wiring: himmel-ops plugin hooks.json Notification (exec-if-exists) — see
+# marketplace/plugins/CLAUDE.md; .claude/settings.json is NOT touched.
+#
+# No .ps1 twin — same rationale as telegram-session-end.sh / jira-nudge-on-end.sh.
+
+set +e
+set -u 2>/dev/null || true
+trap 'exit 0' EXIT
+
+if [ "${1:-}" != "__himmel_detached" ]; then
+    PAYLOAD=""
+    if [ -t 0 ]; then :; else PAYLOAD="$(cat 2>/dev/null || true)"; fi
+    [ -n "$PAYLOAD" ] || exit 0
+    _tmp="$(mktemp "${TMPDIR:-/tmp}/telegram-notification-payload.XXXXXX" 2>/dev/null)" || exit 0
+    printf '%s' "$PAYLOAD" > "$_tmp" 2>/dev/null || { rm -f "$_tmp"; exit 0; }
+    _dlib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/detach.sh"
+    if [ -r "$_dlib" ]; then
+        # shellcheck source=/dev/null
+        . "$_dlib"
+        detach_run bash "${BASH_SOURCE[0]}" __himmel_detached "$_tmp"
+    else
+        rm -f "$_tmp"
+    fi
+    exit 0
+fi
+
+# === Detached child: the real work (parent already returned 0) ==============
+
+PAYLOAD="$(cat "${2:-}" 2>/dev/null || true)"
+rm -f "${2:-}" 2>/dev/null || true
+
+HOOK_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib"
+ROOT="$(cd "$HOOK_LIB/.." && pwd)"
+# shellcheck source=/dev/null
+[ -r "$HOOK_LIB/detach.sh" ] && . "$HOOK_LIB/detach.sh"
+
+command -v jq  >/dev/null 2>&1 || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+command -v bun >/dev/null 2>&1 || exit 0
+
+[ -n "$PAYLOAD" ] || exit 0
+printf '%s' "$PAYLOAD" | jq -e . >/dev/null 2>&1 || exit 0
+
+SESSION_CWD="$(printf '%s' "$PAYLOAD" | jq -r '.cwd // empty')"
+NOTIFICATION_TYPE="$(printf '%s' "$PAYLOAD" | jq -r '.notification_type // empty')"
+MESSAGE="$(printf '%s' "$PAYLOAD" | jq -r '.message // empty')"
+[ -n "$SESSION_CWD" ] || exit 0
+[ -d "$SESSION_CWD" ] || exit 0
+
+# --- Resolve the session repo's .env root (worktree-safe, like the jira CLI) -
+ENV_ROOT="$( cd "$SESSION_CWD" 2>/dev/null && cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd )"
+[ -n "$ENV_ROOT" ] || ENV_ROOT="$SESSION_CWD"
+
+if [ -r "$HOOK_LIB/load-dotenv.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$HOOK_LIB/load-dotenv.sh"
+    load_dotenv --root "$ENV_ROOT" TELEGRAM_GROUP_CHAT_ID 2>/dev/null || true
+fi
+
+# --- Silent no-op gate: unset/blank TELEGRAM_GROUP_CHAT_ID -------------------
+[ -n "${TELEGRAM_GROUP_CHAT_ID:-}" ] || exit 0
+
+# --- repo name (read-only; never `git fetch`) --------------------------------
+REMOTE_URL="$(git -C "$SESSION_CWD" remote get-url origin 2>/dev/null || true)"
+if [ -n "$REMOTE_URL" ]; then
+    REPO_NAME="$(basename "$REMOTE_URL" .git)"
+else
+    REPO_NAME="$(basename "$SESSION_CWD")"
+fi
+[ -n "$REPO_NAME" ] || REPO_NAME="unknown-repo"
+
+# --- Salus/PHI guard: never forward the notification message for salus ------
+case "$(printf '%s' "$REPO_NAME" | tr '[:upper:]' '[:lower:]')" in
+    *salus*) MESSAGE="" ;;
+esac
+
+# --- Relay via session-status.ts (reuses sendMessage — never reinvents the
+# HTTP client). Detached so it never delays the operator-facing prompt.
+detach_run env \
+    TG_REPO_NAME="$REPO_NAME" TG_NOTIFICATION_TYPE="$NOTIFICATION_TYPE" TG_MESSAGE="$MESSAGE" \
+    TELEGRAM_GROUP_CHAT_ID="$TELEGRAM_GROUP_CHAT_ID" \
+    bun run "$ROOT/scripts/telegram/session-status.ts" notification
+
+exit 0

--- a/scripts/hooks/telegram-session-end.sh
+++ b/scripts/hooks/telegram-session-end.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# telegram-session-end.sh — Claude Code SessionEnd hook (HIMMEL-1250 Increment 1).
+#
+# Fires once per session (SessionEnd, NOT per-turn Stop — Stop fires on every
+# assistant turn and can block session flow via exit code 2; SessionEnd is
+# fire-and-forget and matches this repo's existing "notify operator at session
+# end" convention alongside end-session-wiki.sh / jira-nudge-on-end.sh /
+# refresh-where-are-we-on-end.sh). Composes a CONCISE status (repo/branch, a
+# best-effort last-assistant summary, any /mergepub line) and relays it to the
+# operator's Telegram GROUP via TELEGRAM_GROUP_CHAT_ID + the existing
+# sendMessage() HTTP client (scripts/telegram/telegram-api.ts, via
+# scripts/telegram/session-status.ts) — never reinvents the HTTP client.
+#
+# Silent no-op (hard requirement): TELEGRAM_GROUP_CHAT_ID unset/blank -> exit
+# 0, nothing sent. Never errors, never blocks session teardown — same failure
+# posture as every other SessionEnd hook in this repo.
+#
+# Salus/PHI guard: if the session's repo NAME matches /salus/i (the operator's
+# medical vault/repo), transcript content (last-assistant text) is NEVER READ
+# at all — the guard trips BEFORE extraction, not after, so no PHI-shaped text
+# ever leaves this process. session-status.ts re-applies the same check on the
+# repo name it receives (defense-in-depth, not the only guard).
+#
+# Wiring: himmel-ops plugin hooks.json SessionEnd (exec-if-exists) — see
+# marketplace/plugins/CLAUDE.md; .claude/settings.json is NOT touched (editing
+# it directly is a guarded self-mod).
+#
+# This hook runs under bash on every platform (no .ps1 twin — same rationale
+# as jira-nudge-on-end.sh: it does no OS-specific path work, so Git Bash on
+# Windows runs this file directly).
+#
+# Full-body detach pattern: HIMMEL-661 (extends HIMMEL-636/623). Even the
+# gate-off fast path costs real process-spawn time on Windows Git Bash, which
+# loses the race against Claude Code's SessionEnd teardown — so the ENTIRE
+# body (payload parse, dotenv load, transcript scan, relay) runs in a detached
+# child; the parent returns ~instantly.
+
+set +e
+set -u 2>/dev/null || true
+trap 'exit 0' EXIT
+
+if [ "${1:-}" != "__himmel_detached" ]; then
+    PAYLOAD=""
+    if [ -t 0 ]; then :; else PAYLOAD="$(cat 2>/dev/null || true)"; fi
+    [ -n "$PAYLOAD" ] || exit 0
+    _tmp="$(mktemp "${TMPDIR:-/tmp}/telegram-session-end-payload.XXXXXX" 2>/dev/null)" || exit 0
+    printf '%s' "$PAYLOAD" > "$_tmp" 2>/dev/null || { rm -f "$_tmp"; exit 0; }
+    _dlib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/detach.sh"
+    if [ -r "$_dlib" ]; then
+        # shellcheck source=/dev/null
+        . "$_dlib"
+        detach_run bash "${BASH_SOURCE[0]}" __himmel_detached "$_tmp"
+    else
+        rm -f "$_tmp"
+    fi
+    exit 0
+fi
+
+# === Detached child: the real work (parent already returned 0) ==============
+
+PAYLOAD="$(cat "${2:-}" 2>/dev/null || true)"
+rm -f "${2:-}" 2>/dev/null || true
+
+HOOK_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib"
+ROOT="$(cd "$HOOK_LIB/.." && pwd)"
+# shellcheck source=/dev/null
+[ -r "$HOOK_LIB/detach.sh" ] && . "$HOOK_LIB/detach.sh"
+
+command -v jq  >/dev/null 2>&1 || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+command -v bun >/dev/null 2>&1 || exit 0
+
+[ -n "$PAYLOAD" ] || exit 0
+printf '%s' "$PAYLOAD" | jq -e . >/dev/null 2>&1 || exit 0
+
+SESSION_CWD="$(printf '%s' "$PAYLOAD" | jq -r '.cwd // empty')"
+TRANSCRIPT_PATH="$(printf '%s' "$PAYLOAD" | jq -r '.transcript_path // empty')"
+REASON="$(printf '%s' "$PAYLOAD" | jq -r '.reason // "other"')"
+[ -n "$SESSION_CWD" ] || exit 0
+[ -d "$SESSION_CWD" ] || exit 0
+
+# --- Resolve the session repo's .env root (worktree-safe, like the jira CLI) -
+# The gitignored .env lives in the PRIMARY checkout, not the worktree.
+ENV_ROOT="$( cd "$SESSION_CWD" 2>/dev/null && cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd )"
+[ -n "$ENV_ROOT" ] || ENV_ROOT="$SESSION_CWD"
+
+if [ -r "$HOOK_LIB/load-dotenv.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$HOOK_LIB/load-dotenv.sh"
+    load_dotenv --root "$ENV_ROOT" TELEGRAM_GROUP_CHAT_ID 2>/dev/null || true
+fi
+
+# --- Silent no-op gate: unset/blank TELEGRAM_GROUP_CHAT_ID -------------------
+[ -n "${TELEGRAM_GROUP_CHAT_ID:-}" ] || exit 0
+
+# --- repo name / branch (read-only; never `git fetch`) ----------------------
+REMOTE_URL="$(git -C "$SESSION_CWD" remote get-url origin 2>/dev/null || true)"
+if [ -n "$REMOTE_URL" ]; then
+    REPO_NAME="$(basename "$REMOTE_URL" .git)"
+else
+    REPO_NAME="$(basename "$SESSION_CWD")"
+fi
+[ -n "$REPO_NAME" ] || REPO_NAME="unknown-repo"
+BRANCH="$(git -C "$SESSION_CWD" branch --show-current 2>/dev/null || true)"
+
+# --- Salus/PHI guard: trips BEFORE any transcript content is read -----------
+IS_SALUS=0
+case "$(printf '%s' "$REPO_NAME" | tr '[:upper:]' '[:lower:]')" in
+    *salus*) IS_SALUS=1 ;;
+esac
+
+LAST_ASSISTANT=""
+MERGEPUB_LINE=""
+if [ "$IS_SALUS" = "0" ] && [ -n "$TRANSCRIPT_PATH" ] && [ -r "$TRANSCRIPT_PATH" ]; then
+    # Single lightweight jq scan for the LAST assistant text turn (HIMMEL-636
+    # style single-pass extraction — deliberately NOT the full 4-scan
+    # session-transcript.sh lib; a concise status doesn't need it).
+    LAST_ASSISTANT="$(jq -r 'select(.type=="assistant") | .message.content[]? | select(.type=="text") | .text' "$TRANSCRIPT_PATH" 2>/dev/null | tail -1)"
+    # Best-effort /mergepub line, if the operator issued one this session.
+    MERGEPUB_LINE="$(grep -o '/mergepub[^"\\]*' "$TRANSCRIPT_PATH" 2>/dev/null | tail -1)"
+fi
+
+# --- Relay via session-status.ts (reuses sendMessage — never reinvents the
+# HTTP client). Detached again: the network call must not risk being reaped
+# before it completes (same double-detach pattern as jira-nudge-on-end.sh's
+# relay_nudge()).
+detach_run env \
+    TG_REPO_NAME="$REPO_NAME" TG_BRANCH="$BRANCH" TG_REASON="$REASON" \
+    TG_LAST_ASSISTANT="$LAST_ASSISTANT" TG_MERGEPUB_LINE="$MERGEPUB_LINE" \
+    TELEGRAM_GROUP_CHAT_ID="$TELEGRAM_GROUP_CHAT_ID" \
+    bun run "$ROOT/scripts/telegram/session-status.ts" sessionend
+
+exit 0

--- a/scripts/hooks/test-telegram-notification.sh
+++ b/scripts/hooks/test-telegram-notification.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Hermetic smoke test for scripts/hooks/telegram-notification.sh (HIMMEL-1250).
+#
+# Builds a throwaway git repo, drives the hook in CHILD MODE
+# (`__himmel_detached <payload-file>`) with a stub `bun` on PATH, and asserts:
+# (1) TELEGRAM_GROUP_CHAT_ID unset -> silent no-op, bun never invoked;
+# (2) TELEGRAM_GROUP_CHAT_ID set -> bun invoked with the "notification" arg +
+# the composed TG_* env; (3) a salus-named repo still relays a status but
+# NEVER forwards the notification message text.
+#
+# Usage: bash scripts/hooks/test-telegram-notification.sh
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$HOOK_DIR/telegram-notification.sh"
+
+FAILED=0
+PASSED=0
+pass() { echo "PASS $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "FAIL $1"; FAILED=$((FAILED + 1)); }
+
+ROOT_TMP="$(mktemp -d)"
+trap 'rm -rf "$ROOT_TMP"' EXIT
+
+STUB_DIR="$ROOT_TMP/stubs"
+mkdir -p "$STUB_DIR"
+BUN_LOG="$ROOT_TMP/bun-invocations.log"
+BUN_ARGS="$ROOT_TMP/bun-args.log"
+cat > "$STUB_DIR/bun" <<EOF
+#!/usr/bin/env bash
+echo called >> "$BUN_LOG"
+{
+    printf 'ARGS=%s\n' "\$*"
+    printf 'TG_REPO_NAME=%s\n' "\${TG_REPO_NAME:-}"
+    printf 'TG_NOTIFICATION_TYPE=%s\n' "\${TG_NOTIFICATION_TYPE:-}"
+    printf 'TG_MESSAGE=%s\n' "\${TG_MESSAGE:-}"
+} >> "$BUN_ARGS"
+exit 0
+EOF
+chmod +x "$STUB_DIR/bun"
+
+build_case() {
+    # args: <repo_name>
+    local name="$1"
+    CASE_REPO="$(mktemp -d "$ROOT_TMP/${name}.XXXXXX")"
+    git -C "$CASE_REPO" init -q
+    git -C "$CASE_REPO" config core.hooksPath /dev/null
+    git -C "$CASE_REPO" config commit.gpgsign false
+    git -C "$CASE_REPO" config user.email t@t.t
+    git -C "$CASE_REPO" config user.name tester
+    git -C "$CASE_REPO" remote add origin "https://github.com/acme/${name}.git"
+    echo x > "$CASE_REPO/f.txt"
+    git -C "$CASE_REPO" add f.txt
+    git -C "$CASE_REPO" commit -q --no-verify -m init
+
+    CASE_PAYLOAD="$(printf '{"cwd":"%s","notification_type":"permission_prompt","message":"Bash(rm -rf tmp) needs approval"}' "$CASE_REPO")"
+}
+
+run_hook() {
+    local chat_id="$1" wait_secs="$2"
+    rm -f "$BUN_LOG" "$BUN_ARGS"
+    local pf
+    pf="$(mktemp "$ROOT_TMP/payload.XXXXXX")"
+    printf '%s' "$CASE_PAYLOAD" > "$pf"
+    if [ -n "$chat_id" ]; then
+        env PATH="$STUB_DIR:$PATH" TELEGRAM_GROUP_CHAT_ID="$chat_id" \
+            bash "$HOOK" __himmel_detached "$pf" >/dev/null 2>&1
+    else
+        env -u TELEGRAM_GROUP_CHAT_ID PATH="$STUB_DIR:$PATH" \
+            bash "$HOOK" __himmel_detached "$pf" >/dev/null 2>&1
+    fi
+    local w=0
+    while [ ! -f "$BUN_LOG" ] && [ "$w" -lt "$wait_secs" ]; do sleep 1; w=$((w + 1)); done
+}
+
+# 1. Unset TELEGRAM_GROUP_CHAT_ID -> silent no-op, bun never invoked.
+build_case "himmel"
+run_hook "" 2
+if [ ! -f "$BUN_LOG" ]; then pass "unset chat id: bun never invoked (silent no-op)"; else fail "unset chat id: bun never invoked (silent no-op)"; fi
+
+# 2. Set TELEGRAM_GROUP_CHAT_ID -> bun invoked with notification + composed env.
+build_case "himmel"
+run_hook "-1001234" 5
+if [ -f "$BUN_LOG" ] && [ "$(grep -c . "$BUN_LOG")" = "1" ]; then pass "set chat id: bun invoked exactly once"; else fail "set chat id: bun invoked exactly once"; fi
+if grep -q 'ARGS=run .*session-status\.ts notification' "$BUN_ARGS" 2>/dev/null; then
+    pass "bun invoked with the 'notification' arg"
+else
+    fail "bun invoked with the 'notification' arg (got: $(cat "$BUN_ARGS" 2>/dev/null))"
+fi
+if grep -q '^TG_NOTIFICATION_TYPE=permission_prompt$' "$BUN_ARGS" 2>/dev/null; then pass "TG_NOTIFICATION_TYPE passed through"; else fail "TG_NOTIFICATION_TYPE passed through"; fi
+if grep -q '^TG_MESSAGE=Bash(rm -rf tmp) needs approval$' "$BUN_ARGS" 2>/dev/null; then
+    pass "TG_MESSAGE passed through"
+else
+    fail "TG_MESSAGE passed through (got: $(cat "$BUN_ARGS" 2>/dev/null))"
+fi
+
+# 3. Salus-named repo -> TG_MESSAGE cleared (never forwards notification text),
+#    but the status still relays.
+build_case "salus-vault"
+run_hook "-1001234" 5
+if [ -f "$BUN_LOG" ]; then pass "salus repo: bun still invoked (status still relays, redacted downstream)"; else fail "salus repo: bun still invoked"; fi
+if grep -q '^TG_MESSAGE=$' "$BUN_ARGS" 2>/dev/null; then
+    pass "salus repo: TG_MESSAGE cleared (notification text never forwarded)"
+else
+    fail "salus repo: TG_MESSAGE cleared (got: $(cat "$BUN_ARGS" 2>/dev/null))"
+fi
+
+echo "---"
+echo "PASSED=$PASSED FAILED=$FAILED"
+[ "$FAILED" -eq 0 ]

--- a/scripts/hooks/test-telegram-session-end.sh
+++ b/scripts/hooks/test-telegram-session-end.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Hermetic smoke test for scripts/hooks/telegram-session-end.sh (HIMMEL-1250).
+#
+# Builds a throwaway git repo + transcript, drives the hook in CHILD MODE
+# (`__himmel_detached <payload-file>`, same seam test-jira-nudge-on-end.sh
+# uses) with a stub `bun` on PATH, and asserts: (1) TELEGRAM_GROUP_CHAT_ID
+# unset -> silent no-op, bun never invoked; (2) TELEGRAM_GROUP_CHAT_ID set ->
+# bun invoked with the "sessionend" arg + the composed TG_* env, including the
+# transcript-extracted last-assistant text; (3) a salus-named repo still
+# relays a status but NEVER forwards transcript content (TG_LAST_ASSISTANT
+# stays empty — the guard trips before extraction, not after).
+#
+# The detach primitive itself (setsid/disown branches) is covered by
+# scripts/lib/test-detach.sh; this test only asserts the hook's own contract.
+#
+# Usage: bash scripts/hooks/test-telegram-session-end.sh
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$HOOK_DIR/telegram-session-end.sh"
+
+FAILED=0
+PASSED=0
+pass() { echo "PASS $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "FAIL $1"; FAILED=$((FAILED + 1)); }
+
+ROOT_TMP="$(mktemp -d)"
+trap 'rm -rf "$ROOT_TMP"' EXIT
+
+STUB_DIR="$ROOT_TMP/stubs"
+mkdir -p "$STUB_DIR"
+BUN_LOG="$ROOT_TMP/bun-invocations.log"
+BUN_ARGS="$ROOT_TMP/bun-args.log"
+cat > "$STUB_DIR/bun" <<EOF
+#!/usr/bin/env bash
+echo called >> "$BUN_LOG"
+{
+    printf 'ARGS=%s\n' "\$*"
+    printf 'TG_REPO_NAME=%s\n' "\${TG_REPO_NAME:-}"
+    printf 'TG_BRANCH=%s\n' "\${TG_BRANCH:-}"
+    printf 'TG_LAST_ASSISTANT=%s\n' "\${TG_LAST_ASSISTANT:-}"
+} >> "$BUN_ARGS"
+exit 0
+EOF
+chmod +x "$STUB_DIR/bun"
+
+# ---- case builder -----------------------------------------------------------
+# Globals set by build_case: CASE_REPO, CASE_PAYLOAD
+build_case() {
+    # args: <repo_name>
+    local name="$1"
+    CASE_REPO="$(mktemp -d "$ROOT_TMP/${name}.XXXXXX")"
+    git -C "$CASE_REPO" init -q
+    git -C "$CASE_REPO" config core.hooksPath /dev/null
+    git -C "$CASE_REPO" config commit.gpgsign false
+    git -C "$CASE_REPO" config user.email t@t.t
+    git -C "$CASE_REPO" config user.name tester
+    git -C "$CASE_REPO" remote add origin "https://github.com/acme/${name}.git"
+    echo x > "$CASE_REPO/f.txt"
+    git -C "$CASE_REPO" add f.txt
+    git -C "$CASE_REPO" commit -q --no-verify -m init
+
+    local tx="$CASE_REPO/transcript.jsonl"
+    printf '{"type":"assistant","message":{"content":[{"type":"text","text":"Implemented the feature."}]}}\n' > "$tx"
+
+    CASE_PAYLOAD="$(printf '{"cwd":"%s","transcript_path":"%s","reason":"other"}' "$CASE_REPO" "$tx")"
+}
+
+# ---- run helper --------------------------------------------------------------
+# run_hook <chat_id or empty> <wait_secs> — drives child mode, waits up to
+# <wait_secs> for the detached relay to fire (or gives up).
+run_hook() {
+    local chat_id="$1" wait_secs="$2"
+    rm -f "$BUN_LOG" "$BUN_ARGS"
+    local pf
+    pf="$(mktemp "$ROOT_TMP/payload.XXXXXX")"
+    printf '%s' "$CASE_PAYLOAD" > "$pf"
+    if [ -n "$chat_id" ]; then
+        env PATH="$STUB_DIR:$PATH" TELEGRAM_GROUP_CHAT_ID="$chat_id" \
+            bash "$HOOK" __himmel_detached "$pf" >/dev/null 2>&1
+    else
+        env -u TELEGRAM_GROUP_CHAT_ID PATH="$STUB_DIR:$PATH" \
+            bash "$HOOK" __himmel_detached "$pf" >/dev/null 2>&1
+    fi
+    local w=0
+    while [ ! -f "$BUN_LOG" ] && [ "$w" -lt "$wait_secs" ]; do sleep 1; w=$((w + 1)); done
+}
+
+# 1. Unset TELEGRAM_GROUP_CHAT_ID -> silent no-op, bun never invoked.
+build_case "himmel"
+run_hook "" 2
+if [ ! -f "$BUN_LOG" ]; then pass "unset chat id: bun never invoked (silent no-op)"; else fail "unset chat id: bun never invoked (silent no-op)"; fi
+
+# 2. Set TELEGRAM_GROUP_CHAT_ID -> bun invoked with sessionend + composed env.
+build_case "himmel"
+run_hook "-1001234" 5
+if [ -f "$BUN_LOG" ] && [ "$(grep -c . "$BUN_LOG")" = "1" ]; then pass "set chat id: bun invoked exactly once"; else fail "set chat id: bun invoked exactly once"; fi
+if grep -q 'ARGS=run .*session-status\.ts sessionend' "$BUN_ARGS" 2>/dev/null; then
+    pass "bun invoked with the 'sessionend' arg"
+else
+    fail "bun invoked with the 'sessionend' arg (got: $(cat "$BUN_ARGS" 2>/dev/null))"
+fi
+if grep -q '^TG_REPO_NAME=himmel$' "$BUN_ARGS" 2>/dev/null; then pass "TG_REPO_NAME passed through"; else fail "TG_REPO_NAME passed through"; fi
+if grep -q '^TG_LAST_ASSISTANT=Implemented the feature\.$' "$BUN_ARGS" 2>/dev/null; then
+    pass "TG_LAST_ASSISTANT extracted from the transcript"
+else
+    fail "TG_LAST_ASSISTANT extracted from the transcript (got: $(cat "$BUN_ARGS" 2>/dev/null))"
+fi
+
+# 3. Salus-named repo -> TG_LAST_ASSISTANT stays empty (never reads transcript
+#    content), but the status still relays (redaction happens downstream, not
+#    by silently dropping the whole session-end status).
+build_case "salus-vault"
+run_hook "-1001234" 5
+if [ -f "$BUN_LOG" ]; then pass "salus repo: bun still invoked (status still relays, redacted downstream)"; else fail "salus repo: bun still invoked"; fi
+if grep -q '^TG_LAST_ASSISTANT=$' "$BUN_ARGS" 2>/dev/null; then
+    pass "salus repo: TG_LAST_ASSISTANT never populated (transcript content never read)"
+else
+    fail "salus repo: TG_LAST_ASSISTANT never populated (got: $(cat "$BUN_ARGS" 2>/dev/null))"
+fi
+
+echo "---"
+echo "PASSED=$PASSED FAILED=$FAILED"
+[ "$FAILED" -eq 0 ]

--- a/scripts/telegram/session-status.test.ts
+++ b/scripts/telegram/session-status.test.ts
@@ -1,0 +1,166 @@
+// scripts/telegram/session-status.test.ts — HIMMEL-1250 Increment 1.
+// Hermetic: no real network send (sendAlert is injected, same pattern as
+// luna-sync-alert.test.ts's checkLunaSync tests), no real token file read —
+// main()'s I/O path is never exercised here.
+import { expect, test } from "bun:test";
+import {
+  isSalusRepo,
+  composeSessionEndStatus,
+  composeNotificationStatus,
+  runSessionEndStatus,
+  runNotificationStatus,
+} from "./session-status";
+
+// --- (a) status composition -------------------------------------------------
+
+test("composeSessionEndStatus: includes repo, branch, summary, and mergepub line", () => {
+  const text = composeSessionEndStatus({
+    repoName: "himmel",
+    branch: "feat/himmel-1250-telegram-status",
+    reason: "other",
+    lastAssistant: "Implemented the outbound status hooks.",
+    mergepubLine: "/mergepub 1358 abc1234",
+  });
+  expect(text).toContain("himmel");
+  expect(text).toContain("feat/himmel-1250-telegram-status");
+  expect(text).toContain("Implemented the outbound status hooks.");
+  expect(text).toContain("/mergepub 1358 abc1234");
+});
+
+test("composeSessionEndStatus: omits empty summary/mergepub lines cleanly (concise, no blank lines)", () => {
+  const text = composeSessionEndStatus({ repoName: "himmel", branch: "main" });
+  expect(text).toContain("himmel");
+  expect(text.split("\n").length).toBe(1);
+});
+
+test("composeNotificationStatus: includes repo, type, and message", () => {
+  const text = composeNotificationStatus({
+    repoName: "himmel",
+    notificationType: "permission_prompt",
+    message: "Bash(rm -rf tmp) needs approval",
+  });
+  expect(text).toContain("himmel");
+  expect(text).toContain("permission_prompt");
+  expect(text).toContain("Bash(rm -rf tmp) needs approval");
+});
+
+test("truncate is applied to long content so the status stays CONCISE", () => {
+  const long = "x".repeat(5000);
+  const text = composeSessionEndStatus({ repoName: "himmel", lastAssistant: long });
+  expect(text.length).toBeLessThan(1000);
+  expect(text).toContain("…");
+});
+
+// --- (b) graceful silent no-op when TELEGRAM_GROUP_CHAT_ID is unset --------
+
+test("runSessionEndStatus: chatId null -> skip-no-chat, sendAlert never called (silent no-op)", async () => {
+  let called = false;
+  const outcome = await runSessionEndStatus({
+    chatId: null,
+    repoName: "himmel",
+    branch: "main",
+    lastAssistant: "did stuff",
+    sendAlert: async () => { called = true; return true; },
+    log: () => {},
+  });
+  expect(outcome).toBe("skip-no-chat");
+  expect(called).toBe(false);
+});
+
+test("runNotificationStatus: chatId null -> skip-no-chat, sendAlert never called (silent no-op)", async () => {
+  let called = false;
+  const outcome = await runNotificationStatus({
+    chatId: null,
+    repoName: "himmel",
+    notificationType: "idle_prompt",
+    message: "waiting on you",
+    sendAlert: async () => { called = true; return true; },
+    log: () => {},
+  });
+  expect(outcome).toBe("skip-no-chat");
+  expect(called).toBe(false);
+});
+
+test("runSessionEndStatus: chatId present -> composes + sends, returns sent", async () => {
+  const sent: string[] = [];
+  const outcome = await runSessionEndStatus({
+    chatId: 123,
+    repoName: "himmel",
+    branch: "main",
+    lastAssistant: "did stuff",
+    sendAlert: async (text) => { sent.push(text); return true; },
+  });
+  expect(outcome).toBe("sent");
+  expect(sent).toHaveLength(1);
+});
+
+test("runSessionEndStatus: sendAlert failure (Telegram drop) -> undelivered, never throws", async () => {
+  const outcome = await runSessionEndStatus({
+    chatId: 123,
+    repoName: "himmel",
+    sendAlert: async () => false,
+  });
+  expect(outcome).toBe("undelivered");
+});
+
+// --- (c) PHI / salus exclusion ----------------------------------------------
+
+test("isSalusRepo: matches salus (any case, as a substring) and does not match unrelated names", () => {
+  expect(isSalusRepo("salus")).toBe(true);
+  expect(isSalusRepo("Salus")).toBe(true);
+  expect(isSalusRepo("my-SALUS-vault")).toBe(true);
+  expect(isSalusRepo("himmel")).toBe(false);
+  expect(isSalusRepo("luna")).toBe(false);
+  expect(isSalusRepo(undefined)).toBe(false);
+});
+
+test("composeSessionEndStatus: salus repo NEVER includes the last-assistant text, even if passed in", () => {
+  const phiLooking = "Patient reports elevated blood pressure, medication X 20mg.";
+  const text = composeSessionEndStatus({
+    repoName: "salus",
+    branch: "main",
+    lastAssistant: phiLooking,
+    mergepubLine: "/mergepub 1 abc",
+  });
+  expect(text).not.toContain(phiLooking);
+  expect(text).not.toContain("/mergepub");
+  expect(text.toLowerCase()).toContain("redacted");
+});
+
+test("composeNotificationStatus: salus repo NEVER includes the notification message", () => {
+  const phiLooking = "Confirm dosage change for patient record #4471?";
+  const text = composeNotificationStatus({
+    repoName: "salus-vault",
+    notificationType: "permission_prompt",
+    message: phiLooking,
+  });
+  expect(text).not.toContain(phiLooking);
+  expect(text.toLowerCase()).toContain("redacted");
+});
+
+test("runSessionEndStatus: salus repo still sends a status (chat configured) but the delivered text is redacted", async () => {
+  const phiLooking = "diagnosis: hypertension";
+  const sent: string[] = [];
+  const outcome = await runSessionEndStatus({
+    chatId: 123,
+    repoName: "salus",
+    lastAssistant: phiLooking,
+    sendAlert: async (text) => { sent.push(text); return true; },
+  });
+  expect(outcome).toBe("sent");
+  expect(sent[0]).not.toContain(phiLooking);
+});
+
+test("runNotificationStatus: salus repo still sends a status but the delivered text is redacted", async () => {
+  const phiLooking = "lab result flagged abnormal";
+  const sent: string[] = [];
+  const outcome = await runNotificationStatus({
+    chatId: 123,
+    repoName: "salus",
+    notificationType: "permission_prompt",
+    message: phiLooking,
+    sendAlert: async (text) => { sent.push(text); return true; },
+  });
+  expect(outcome).toBe("sent");
+  expect(sent[0]).not.toContain(phiLooking);
+});

--- a/scripts/telegram/session-status.ts
+++ b/scripts/telegram/session-status.ts
@@ -1,0 +1,182 @@
+// scripts/telegram/session-status.ts — HIMMEL-1250 Increment 1: outbound
+// Telegram session status.
+//
+// Composes a CONCISE status message for two Claude Code hook events —
+// SessionEnd ("this session concluded") and Notification (permission prompt /
+// idle-wait / AskUserQuestion) — and relays it to the operator's Telegram
+// GROUP via the existing sendMessage() HTTP client
+// (scripts/telegram/telegram-api.ts). Never reinvents the HTTP client; never
+// reads/logs the raw bot token anywhere except handing it to sendMessage.
+//
+// Why SessionEnd, not Stop: Stop fires per assistant turn (repeatedly, can
+// block session flow via exit code 2) — SessionEnd fires exactly once per
+// session, is fire-and-forget, and matches this repo's existing "notify
+// operator at session end" convention (end-session-wiki.sh /
+// jira-nudge-on-end.sh / refresh-where-are-we-on-end.sh, all wired via the
+// himmel-ops plugin hooks.json SessionEnd array).
+//
+// Salus/PHI guard: a repo whose name matches /salus/i (the operator's
+// medical vault/repo — see docs/internals memory: "salus = medical vault")
+// NEVER has session content (last-assistant text, notification message)
+// included in the composed status — only a generic, content-free line. The
+// calling bash hooks additionally short-circuit BEFORE extracting any
+// transcript content for a salus repo, so this check is defense-in-depth,
+// not the only guard.
+//
+// Silent no-op: when no group chat id is configured (TELEGRAM_GROUP_CHAT_ID
+// unset/blank/non-numeric), runSessionEndStatus/runNotificationStatus return
+// "skip-no-chat" WITHOUT calling sendAlert — the hook's silent-no-op
+// contract (never error, never block, never send).
+//
+// Pattern mirrors scripts/observability/luna-sync-alert.ts: pure, injectable
+// core functions (unit-testable, no network/env/fs access) + a thin main()
+// that does the real I/O — never exercised by tests.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { sendMessage, redactChatId } from "./telegram-api";
+
+export function isSalusRepo(repoName: string | undefined): boolean {
+  return /salus/i.test(repoName ?? "");
+}
+
+export function truncate(s: string | undefined, max: number): string {
+  const t = (s ?? "").trim();
+  if (t.length <= max) return t;
+  return t.slice(0, max - 1).trimEnd() + "…";
+}
+
+const SUMMARY_MAX = 400;
+
+export function composeSessionEndStatus(input: {
+  repoName: string;
+  branch?: string;
+  reason?: string;
+  lastAssistant?: string;
+  mergepubLine?: string;
+}): string {
+  const { repoName, branch, reason } = input;
+  if (isSalusRepo(repoName)) {
+    return `🏁 ${repoName} session ended — content redacted (salus/medical vault)`;
+  }
+  const lines = [`🏁 ${repoName}${branch ? ` (${branch})` : ""} session ended${reason && reason !== "other" ? ` — ${reason}` : ""}`];
+  const summary = truncate(input.lastAssistant, SUMMARY_MAX);
+  if (summary) lines.push(summary);
+  const mergepub = truncate(input.mergepubLine, 200);
+  if (mergepub) lines.push(mergepub);
+  return lines.join("\n");
+}
+
+export function composeNotificationStatus(input: {
+  repoName: string;
+  notificationType?: string;
+  message?: string;
+}): string {
+  const { repoName, notificationType } = input;
+  if (isSalusRepo(repoName)) {
+    return `🔔 ${repoName}: ${notificationType || "notification"} — content redacted (salus/medical vault)`;
+  }
+  const msg = truncate(input.message, SUMMARY_MAX);
+  return `🔔 ${repoName}: ${notificationType || "notification"}${msg ? ` — ${msg}` : ""}`;
+}
+
+export type SendFn = (text: string) => Promise<boolean>;
+export type StatusOutcome = "sent" | "skip-no-chat" | "undelivered";
+
+export async function runSessionEndStatus(opts: {
+  chatId: number | null;
+  repoName: string;
+  branch?: string;
+  reason?: string;
+  lastAssistant?: string;
+  mergepubLine?: string;
+  sendAlert: SendFn;
+  log?: (msg: string) => void;
+}): Promise<StatusOutcome> {
+  const log = opts.log ?? ((m: string) => console.error(m));
+  if (opts.chatId === null) {
+    log("telegram-session-status: no TELEGRAM_GROUP_CHAT_ID configured — silent no-op");
+    return "skip-no-chat";
+  }
+  const text = composeSessionEndStatus(opts);
+  const delivered = await opts.sendAlert(text);
+  return delivered ? "sent" : "undelivered";
+}
+
+export async function runNotificationStatus(opts: {
+  chatId: number | null;
+  repoName: string;
+  notificationType?: string;
+  message?: string;
+  sendAlert: SendFn;
+  log?: (msg: string) => void;
+}): Promise<StatusOutcome> {
+  const log = opts.log ?? ((m: string) => console.error(m));
+  if (opts.chatId === null) {
+    log("telegram-session-status: no TELEGRAM_GROUP_CHAT_ID configured — silent no-op");
+    return "skip-no-chat";
+  }
+  const text = composeNotificationStatus(opts);
+  const delivered = await opts.sendAlert(text);
+  return delivered ? "sent" : "undelivered";
+}
+
+// ── real I/O (main-only; never exercised by tests) ──────────────────────────
+
+// Bot token: SAME resolution the bridge/poller and luna-sync-alert.ts use —
+// ~/.claude/channels/telegram/.env's TELEGRAM_BOT_TOKEN, overridable via
+// TELEGRAM_ENV. Never logged — only handed to sendMessage's request body.
+function loadToken(env: Record<string, string | undefined>): string {
+  const envPath = env.TELEGRAM_ENV ?? join(homedir(), ".claude", "channels", "telegram", ".env");
+  const txt = readFileSync(envPath, "utf8");
+  const m = txt.match(/^TELEGRAM_BOT_TOKEN\s*=\s*(.+)$/m);
+  if (!m) throw new Error("TELEGRAM_BOT_TOKEN not found in " + envPath);
+  return m[1].trim();
+}
+
+function resolveChatId(env: Record<string, string | undefined>): number | null {
+  const raw = (env.TELEGRAM_GROUP_CHAT_ID ?? "").trim();
+  if (!raw || !/^-?\d+$/.test(raw)) return null;
+  return Number(raw);
+}
+
+async function main(): Promise<void> {
+  const env = process.env;
+  const eventType = process.argv[2]; // "sessionend" | "notification"
+  const chatId = resolveChatId(env);
+  const repoName = env.TG_REPO_NAME || "unknown-repo";
+
+  const sendAlert: SendFn = async (text) => {
+    if (chatId === null) return false;
+    const token = loadToken(env);
+    return sendMessage(token, chatId, text);
+  };
+
+  const result =
+    eventType === "notification"
+      ? await runNotificationStatus({
+          chatId,
+          repoName,
+          notificationType: env.TG_NOTIFICATION_TYPE,
+          message: env.TG_MESSAGE,
+          sendAlert,
+        })
+      : await runSessionEndStatus({
+          chatId,
+          repoName,
+          branch: env.TG_BRANCH,
+          reason: env.TG_REASON,
+          lastAssistant: env.TG_LAST_ASSISTANT,
+          mergepubLine: env.TG_MERGEPUB_LINE,
+          sendAlert,
+        });
+
+  if (result === "undelivered") {
+    console.error(`telegram-session-status: ${eventType || "sessionend"} status not delivered (chat=${chatId !== null ? redactChatId(chatId) : "none"})`);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((e) => { console.error(`telegram-session-status: fatal: ${e instanceof Error ? e.message : String(e)}`); });
+}

--- a/scripts/telegram/telegram-api.ts
+++ b/scripts/telegram/telegram-api.ts
@@ -21,7 +21,7 @@ export async function sendChatAction(token: string, chat_id: number, f: F = fetc
 // and these logs get captured into session notes committed to a vault. For
 // longer ids, keeps the last 2 digits so repeated failures for the same chat
 // can still be correlated without exposing the raw id.
-const redactChatId = (chat_id: number): string => {
+export const redactChatId = (chat_id: number): string => {
   const digits = String(chat_id).replace(/^-/, "");
   return digits.length > 2 ? `***${digits.slice(-2)}` : "***";
 };


### PR DESCRIPTION
## Outbound Telegram session status + notification hooks (HIMMEL-1250, Increment 1)

Route every session's **end status** and every **request-for-input** to the
operator's Telegram group for remote visibility. Increment 1 (outbound) only;
the inbound reply loop is deferred.

### What's here
- `telegram-session-end.sh` (SessionEnd) + `telegram-notification.sh` (Notification) — full-body detach so they never block teardown (HIMMEL-661).
- `session-status.ts` — pure compose+send core + a thin `main()`; reuses `telegram-api.ts` `sendMessage` + `redactChatId` (never reinvents the client, never logs the token).
- Config `TELEGRAM_GROUP_CHAT_ID` (documented in `.env.example`); **silent no-op** when unset/blank/non-numeric. The bot token resolves separately from the existing bridge/poller token file (`TELEGRAM_ENV` override), never from this `.env`.

### Design
Uses **SessionEnd** (fires once per session, fire-and-forget) rather than a per-turn `Stop` hook, matching the existing himmel SessionEnd convention. `.claude/settings.json` is not touched.

### PHI guard (two layers)
The bash hook trips on a `salus` repo name **before** reading any transcript content, and `session-status.ts` re-applies the same check — a salus session sends only a content-free line.

### Tests
session-status (13) + telegram-api (12) + hook smoke tests, shellcheck clean.
