### PR TITLE
fix(luna): _tg_note_signature — preserve literal embed text

### DIFF
--- a/scripts/luna/fold-chat-history.py
+++ b/scripts/luna/fold-chat-history.py
@@ -719,8 +719,8 @@ def _tg_month_note(group_name, group_slug, month, entries, assets_dir_rel,
 def _tg_note_signature(text):
     """The comparable content of a rendered month note: title+day/message
     text with the frontmatter (carries the `messages:` count) stripped and
-    every media embed line (`![[...]]`, whose name is content-hashed on a
-    byte collision — see `_tg_asset_name`) normalized to a nameless marker.
+    every generated Telegram asset embed line (whose name is content-hashed
+    on a byte collision — see `_tg_asset_name`) normalized to a nameless marker.
     Two renders of the same messages compare equal even if the count metadata
     or a re-hashed media NAME differs, but a re-import that ADDS or REMOVES
     media changes the marker count — so the overwrite guard sees it as a
@@ -728,7 +728,8 @@ def _tg_note_signature(text):
     PR #1295)."""
     m = re.search(r"^# ", text, re.M)
     body = text[m.start():] if m else text
-    return "\n".join("![[]]" if line.startswith("![[") else line
+    media_prefix = "![[chats/telegram/_assets/"
+    return "\n".join("![[]]" if line.startswith(media_prefix) else line
                      for line in body.splitlines())
 
 

--- a/scripts/luna/test-fold-chat-history.py
+++ b/scripts/luna/test-fold-chat-history.py
@@ -1088,6 +1088,13 @@ class TestFoldTelegram(unittest.TestCase):
             self.assertFalse((vault / "evil.jpg").exists())
             self.assertFalse((Path(td) / "evil.jpg").exists())
 
+    def test_note_signature_preserves_literal_embeds(self):
+        a = ("---\nmessages: 3\n---\n# G — 2026-07\n\n## day\n"
+             "**09:00 · Alice**\n![[literal-a]]\n")
+        b = ("---\nmessages: 3\n---\n# G — 2026-07\n\n## day\n"
+             "**09:00 · Alice**\n![[literal-b]]\n")
+        self.assertNotEqual(fch._tg_note_signature(a), fch._tg_note_signature(b))
+
     def test_note_signature_preserves_media_presence(self):
         # Same message text, media re-hashed (same COUNT) -> equal signature:
         # an idempotent re-import must still overwrite (documented intent).


### PR DESCRIPTION
## What

`_tg_note_signature()` (the telegram month-note overwrite guard) normalized **every** line starting with `![[` to `![[]]`. A note body can contain *literal* user `![[...]]` text, not just generated asset embeds — so an existing note whose literal `![[A]]` differed from a new import's `![[B]]` compared **equal**, and the guard could silently clobber the changed content.

## Fix

Scope normalization to the generated asset-embed prefix `![[chats/telegram/_assets/` only, so literal `![[…]]` body text affects the signature (a real change is detected → guard skips → no clobber). Generated asset re-hashes still normalize equal. Adds a regression test.

`python scripts/luna/test-fold-chat-history.py` → 77 tests OK. Cross-model reviewed clean (codex + glm).
