### PR TITLE
fix(himmel-ops): [HIMMEL-1250] bump plugin version 0.4.0->0.4.1

### DIFF
--- a/marketplace/plugins/himmel-ops/.claude-plugin/plugin.json
+++ b/marketplace/plugins/himmel-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "himmel-ops",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Harness-meta operational skills for himmel. Load-on-trigger guardrail-recovery playbook (stuck-playbook) that surfaces escape-hatches when an auto-mode write is denied, a Bash command falls through to the classifier, a permission prompt hangs, or a pre-push gate fails — so operational/troubleshooting rules stay out of the always-on root CLAUDE.md (HIMMEL-211). Plus the minerva pipeline skill (/minerva): brainstorm→critic→spec→critic→plan with adversarial critic loops between stages (HIMMEL-428); and memory-compound (/memory-compound): lean-invoke compaction of the per-project auto-memory into qmd-searchable luna/himmel reference notes with a findability gate (HIMMEL-569).",
   "author": {
     "name": "yotamleo"


### PR DESCRIPTION
## What

Bump the `himmel-ops` plugin version `0.4.0 → 0.4.1` (manifest-only).

## Why

The SessionEnd `telegram-session-end.sh` hook was added to himmel-ops `hooks.json`
without bumping the plugin version. The Claude Code plugin cache is keyed by version
(`~/.claude/plugins/cache/<mkt>/<plugin>/<version>/`), and `claude plugin marketplace update`
does not re-copy content into an existing version dir — so on any harness that already
cached `0.4.0`, the new SessionEnd hook never landed. Bumping to `0.4.1` changes the cache
key so a normal marketplace update propagates the hook to every machine.
