### PR TITLE
fix(HIMMEL-1253): batch-clear 6 deferred-CR issues (#1149 #1130 #1129 #1128 #1127)

### DIFF
--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -732,12 +732,12 @@ Steps:
    ```bash
    threads_rc=2  # default: unknown = blocking; every path below overwrites it
    pr_rc=0
-   pr_lookup=$(gh pr view --json number -q .number 2>&1) || pr_rc=$?
+   pr_lookup=$(gh pr list --state open --head "$branch" --json number --jq '.[0].number' 2>&1) || pr_rc=$?
    if [ "$pr_rc" -ne 0 ]; then
-       case "$pr_lookup" in
-           *"no pull requests"*|*"no open pull"*) echo "4.8: no PR yet — thread gate skipped (re-applies after gh pr create; /check-ci enforces it at merge time)"; threads_rc=0 ;;
-           *) echo "4.8: gh pr view failed ($pr_lookup) — thread state UNKNOWN, treat as BLOCKING" >&2; threads_rc=2 ;;
-       esac
+       echo "4.8: gh pr list failed ($pr_lookup) — thread state UNKNOWN, treat as BLOCKING" >&2
+   elif [ -z "$pr_lookup" ]; then
+       echo "4.8: no PR yet — thread gate skipped (re-applies after gh pr create; /check-ci enforces it at merge time)"
+       threads_rc=0
    else
        threads_rc=0
        bash scripts/check-ci.sh --threads-only || threads_rc=$?

--- a/scripts/himmelctl/bin.js
+++ b/scripts/himmelctl/bin.js
@@ -83,6 +83,7 @@ commands:
 
 options:
   --from-profile <path>  install non-interactively from a saved profile cache
+  --default-scope <s>    install question default: project|user (answer remains confirmable)
   --advanced             reserved: surface advanced options (parsed, not yet honored)
   --dry-run              print the derived plan/actions without executing
   --items <a,b>          status/ensure: scope the run to these item ids (comma list)
@@ -101,7 +102,7 @@ options:
 // each option (so passing the DEFAULT value explicitly is never flagged —
 // only a genuinely-set option outside the whitelist is).
 const ALLOWED_OPTIONS = {
-  install: ['fromProfile', 'advanced', 'dryRun'],
+  install: ['fromProfile', 'defaultScope', 'advanced', 'dryRun'],
   uninstall: ['dryRun'],
   update: ['dryRun'],
   status: ['items', 'json'],
@@ -133,12 +134,12 @@ const DEPS_VERB_ALLOWED_OPTIONS = {
   upgrade: ['dryRun', 'yes', 'withModels'],
 };
 const OPTION_FLAGS = {
-  fromProfile: '--from-profile', advanced: '--advanced', dryRun: '--dry-run',
+  fromProfile: '--from-profile', defaultScope: '--default-scope', advanced: '--advanced', dryRun: '--dry-run',
   items: '--items', json: '--json', profile: '--profile', yes: '--yes',
   withModels: '--with-models',
 };
 const OPTION_DEFAULTS = {
-  fromProfile: null, advanced: false, dryRun: false, items: null, json: false, profile: null, yes: false,
+  fromProfile: null, defaultScope: null, advanced: false, dryRun: false, items: null, json: false, profile: null, yes: false,
   withModels: false,
 };
 
@@ -150,6 +151,7 @@ function parseArgs(argv) {
   const args = {
     subcommand: null,
     fromProfile: null, // reserved (T0: parse only)
+    defaultScope: null, // install question default: project|user (null = project)
     advanced: false,   // reserved (T0: parse only)
     dryRun: false,
     items: null,       // status/ensure: --items comma list (null = no filter)
@@ -295,6 +297,14 @@ function parseArgs(argv) {
           return args;
         }
         break;
+      case '--default-scope':
+        args.defaultScope = argv[++i];
+        if (['project', 'user'].indexOf(args.defaultScope) === -1) {
+          console.error(`himmelctl: --default-scope must be one of project|user (got ${args.defaultScope})`);
+          process.exitCode = 2;
+          return args;
+        }
+        break;
       case '--advanced':
         args.advanced = true;
         break;
@@ -433,10 +443,11 @@ function isInteractive(args) {
 // win32: winget takes ONE exact package id per invocation — `winget install
 // jq python3 npm` is a single search QUERY, not multiple packages, and bare
 // tool names are not winget ids. Map each hard-gate tool to its documented
-// id (mirrors scripts/machine-setup/win11.ps1's per-tool installs). bash is
-// never installed through this map (self-install paradox, special-cased
-// below); it ships with Git.Git anyway.
+// id (mirrors scripts/machine-setup/win11.ps1's per-tool installs). Git.Git
+// supplies both git and Git Bash, so a clean Windows machine can install bash
+// through cmd without the old bash self-install paradox.
 const WINGET_IDS = {
+  bash: 'Git.Git',
   git: 'Git.Git',
   jq: 'jqlang.jq',
   python3: 'Python.Python.3.12',
@@ -444,15 +455,15 @@ const WINGET_IDS = {
   npm: 'OpenJS.NodeJS.LTS',
 };
 
-// Run one package-manager line via `bash -c` (bash is guaranteed present at
-// every call site — the bash-missing paradox is special-cased before this is
-// reached) and log a launch failure or nonzero exit instead of swallowing it.
-// The bash-wrap keeps the call testable with an extensionless stub on every
-// OS. Every line is assembled from fixed vocabulary — never user input — so
-// interpolating into a shell line carries no injection risk.
+// Run one package-manager line and log a launch failure or nonzero exit
+// instead of swallowing it. Windows uses cmd directly so the clean-machine
+// winget path does not depend on Git Bash already being installed; posix keeps
+// bash -c. Every line is fixed vocabulary — never user input.
 function runInstallerLine(line) {
   console.error(`himmelctl: running: ${line}`);
-  const r = spawnSync(resolveBash(), ['-c', line], { stdio: 'inherit' });
+  const r = process.platform === 'win32'
+    ? spawnSync(process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', line], { stdio: 'inherit' })
+    : spawnSync(resolveBash(), ['-c', line], { stdio: 'inherit' });
   if (r.error) console.error(`himmelctl: failed to launch installer: ${r.error.message}`);
   if (typeof r.status === 'number' && r.status !== 0) console.error(`himmelctl: installer exited ${r.status}`);
 }
@@ -461,24 +472,24 @@ function runInstallerLine(line) {
 // darwin/linux: ONE brew/apt invocation for the whole list. win32: one
 // `winget install --id <ID> -e` per tool (see WINGET_IDS); a tool with no
 // mapped id gets a manual-install pointer instead of a doomed bare-name
-// query. bash CAN itself be the missing tool, and shelling out via `bash -c`
-// to install bash is a paradox (nothing to shell out THROUGH) — that case
-// prints a platform-appropriate pointer and skips the spawn entirely.
+// query. On posix, bash cannot shell out to install itself; Windows avoids
+// that paradox by running winget through cmd and mapping bash to Git.Git.
 function installMissing(missing) {
-  if (missing.indexOf('bash') !== -1) {
+  if (process.platform !== 'win32' && missing.indexOf('bash') !== -1) {
     console.error('himmelctl: bash itself is missing and cannot be self-installed via a bash shell-out.');
-    console.error(process.platform === 'win32'
-      ? '  install Git for Windows (Git Bash) or enable WSL, then re-run himmelctl.'
-      : '  install bash via your platform package manager, then re-run himmelctl.');
+    console.error('  install bash via your platform package manager, then re-run himmelctl.');
     return;
   }
   if (process.platform === 'win32') {
+    const installedIds = [];
     for (const tool of missing) {
       const id = WINGET_IDS[tool];
       if (!id) {
         console.error(`himmelctl: no winget id known for '${tool}' — install it manually, then re-run himmelctl.`);
         continue;
       }
+      if (installedIds.indexOf(id) !== -1) continue;
+      installedIds.push(id);
       runInstallerLine(`winget install --id ${id} -e`);
     }
     return;
@@ -664,7 +675,7 @@ async function askPath(ask, prompt, defaultVal) {
 }
 
 // Walk all questions interactively and return the answer object.
-async function askQuestions() {
+async function askQuestions(defaultScope) {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: false });
   const ask = makeAsk(rl);
 
@@ -674,9 +685,10 @@ async function askQuestions() {
   const role = await askEnum(ask, `? role [adopter|contributor] (default: ${det.role})\n> `, ['adopter', 'contributor'], det.role);
 
   // 2. scope — adopter only. Contributor never asks (setup.sh is user-scope).
-  let scope = 'project';
+  const scopeDefault = defaultScope || 'project';
+  let scope = scopeDefault;
   if (role === 'adopter') {
-    scope = await askEnum(ask, '? scope [project|user] (default: project)\n> ', ['project', 'user'], 'project');
+    scope = await askEnum(ask, `? scope [project|user] (default: ${scopeDefault})\n> `, ['project', 'user'], scopeDefault);
   }
 
   // 3. vault. T2 collects mode+path only (non-luna->luna conversion is O1,
@@ -704,10 +716,10 @@ async function askQuestions() {
 
 // All-default answers (no prompts) for --dry-run previews. Still prints the
 // role reasoning line so the preview shows what would happen.
-function defaultAnswers() {
+function defaultAnswers(defaultScope) {
   const det = detectRole();
   console.log(`detected: ${det.reason}`);
-  return buildAnswers(det.role, det.role === 'contributor' ? 'user' : 'project', 'none', '', 'inline', '', 'lean');
+  return buildAnswers(det.role, det.role === 'contributor' ? 'user' : (defaultScope || 'project'), 'none', '', 'inline', '', 'lean');
 }
 
 // ── T3: answer schema + cache ────────────────────────────────────────────────
@@ -845,6 +857,32 @@ function settingsPathForScope(scope) {
   return path.join(process.cwd(), '.claude', 'settings.json');
 }
 
+// Fail before the install/wire/plugin steps when their target settings file
+// cannot be written. Existing files are checked directly; for a not-yet-created
+// file, check the nearest existing parent that would need to create it.
+function settingsTargetsWritable(answers) {
+  const targets = [settingsPathForScope(answers.scope)];
+  if (answers.pluginSet === 'full') targets.push(settingsPathForScope('user'));
+  for (const target of targets.filter((p, i, all) => all.indexOf(p) === i)) {
+    let probe = target;
+    while (!fs.existsSync(probe)) {
+      const parent = path.dirname(probe);
+      if (parent === probe) break;
+      probe = parent;
+    }
+    try {
+      if (probe === target && !fs.statSync(probe).isFile()) throw new Error('target is not a regular file');
+      if (probe !== target && !fs.statSync(probe).isDirectory()) throw new Error('parent is not a directory');
+      fs.accessSync(probe, fs.constants.W_OK);
+    } catch (e) {
+      const code = e && e.code ? ` (${e.code})` : '';
+      console.error(`himmelctl: target settings.json is not writable: ${target}${code}`);
+      return false;
+    }
+  }
+  return true;
+}
+
 // T5b STAMPED plan (locked O1): wire env.LUNA_VAULT_PATH into the
 // scope-appropriate settings.json, THEN run luna-upgrade-all.sh apply against
 // the vault. Backup is built into apply itself (its own BACKUP\t<path> line,
@@ -956,50 +994,24 @@ function writeHandoverDir(p) {
   return true;
 }
 
-// T4.5 pluginSet=full: the DOCUMENTED per-plugin enable table (HIMMEL-816,
-// docs/setup/new-machine.md § "Claude Code Plugins" — "Turn any of these
-// back on with one command"). Hardcoded to match that table EXACTLY rather
-// than derived from docs/setup/settings-template.json's `enabledPlugins`:
-// the JSON additionally disables `qmd@qmd` (the served fork is `qmd@himmel`;
-// enabling the upstream registration too would duplicate/conflict with it),
-// which the doc's curated table deliberately omits — so "every false entry"
-// is not the same set as "the documented enable path." Every install is
-// --scope user, matching the doc literally (this is independent of the
-// adopter's own --scope answer, which only applies to adopt.sh's core
-// profile).
-//
-// HIMMEL-755 A4: the CANONICAL copy of this list now also lives at
-// scripts/machine-setup/full-plugin-enable.json (a shared data file other
-// consumers, e.g. a future install-plugins.sh mode, can read without
-// depending on bin.js). This const is intentionally kept INLINE rather than
-// read from that file at runtime — every derive/bootstrap hermetic test
-// fixture builds its OWN minimal HIMMELCTL_REPO_ROOT tree with only the
-// files each case needs, and making pluginSet=full's dry-run preview do a
-// fresh fs read would require every such fixture to also carry the JSON
-// file, which is invasive and unrelated to what those suites cover. Instead
-// test-wizard-install-engine.sh asserts this const and the JSON file's
-// `plugins` array stay byte-identical, so any future drift between them is
-// CI-caught rather than silent.
-const FULL_PLUGIN_ENABLE = [
-  { spec: 'github@claude-plugins-official' },
-  { spec: 'feature-dev@claude-plugins-official' },
-  { spec: 'plugin-dev@claude-plugins-official' },
-  { spec: 'code-review@claude-plugins-official' },
-  { spec: 'ralph-loop@claude-plugins-official' },
-  { spec: 'pyright-lsp@claude-plugins-official' },
-  { spec: 'agent-sdk-dev@claude-plugins-official' },
-  { spec: 'claude-code-setup@claude-plugins-official' },
-  { spec: 'code-simplifier@claude-plugins-official' },
-  { spec: 'commit-commands@claude-plugins-official' },
-  { spec: 'playground@claude-plugins-official' },
-  { spec: 'skill-creator@claude-plugins-official' },
-  { spec: 'obsidian@obsidian-skills', marketplaceAdd: 'kepano/obsidian-skills' },
-  { spec: 'caveman@caveman', marketplaceAdd: 'JuliusBrussee/caveman' },
-];
+// T4.5 pluginSet=full: load the canonical documented enable table from data,
+// rather than keeping a second inline copy that can drift. This is deliberately
+// separate from settings-template.json's broader enabledPlugins map: qmd@qmd
+// must stay excluded because himmel serves qmd@himmel instead. Every install is
+// --scope user, independent of the adopter's core-install scope answer.
+let fullPluginEnableCache = null;
+function fullPluginEnable() {
+  if (fullPluginEnableCache !== null) return fullPluginEnableCache;
+  const dataPath = path.join(repoRoot(), 'scripts', 'machine-setup', 'full-plugin-enable.json');
+  const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  if (!Array.isArray(data.plugins)) throw new Error(`invalid full plugin data: ${dataPath}`);
+  fullPluginEnableCache = data.plugins;
+  return fullPluginEnableCache;
+}
 
 function fullPluginEnableCommands() {
   const cmds = [];
-  for (const p of FULL_PLUGIN_ENABLE) {
+  for (const p of fullPluginEnable()) {
     if (p.marketplaceAdd) cmds.push(['claude', 'plugin', 'marketplace', 'add', p.marketplaceAdd]);
     cmds.push(['claude', 'plugin', 'install', p.spec, '--scope', 'user']);
   }
@@ -1137,6 +1149,7 @@ async function runPlan(answers, args) {
         return 0;
       }
     }
+    if (!settingsTargetsWritable(answers)) return 1;
     if (!applyHandoverStep(answers)) return 1;
     const wireRc = runSpawn(plan.wire);
     if (wireRc !== 0) return wireRc;
@@ -1170,6 +1183,11 @@ async function runPlan(answers, args) {
       return 0;
     }
   }
+
+  // Fail before any installer/wire/plugin mutation when the relevant target
+  // settings.json cannot be written, so EACCES is actionable rather than a raw
+  // downstream script error.
+  if (!settingsTargetsWritable(answers)) return 1;
 
   // T4.5: handover.mode=external → persist HANDOVER_DIR before the install.
   // inline → no-op (adopt.sh's/setup.sh's own inline handovers/ default).
@@ -1225,10 +1243,10 @@ async function cmdInstall(args) {
   if (profileAnswers) {
     answers = profileAnswers;
   } else if (shouldPrompt(args)) {
-    answers = await askQuestions();
+    answers = await askQuestions(args.defaultScope);
     writeCache(answers);
   } else if (args.dryRun) {
-    answers = defaultAnswers();
+    answers = defaultAnswers(args.defaultScope);
   } else {
     console.error('himmelctl: non-interactive install requires --from-profile <path>');
     console.error('  (or set HIMMELCTL_INTERACTIVE=1 to answer prompts interactively)');
@@ -2617,10 +2635,11 @@ async function cmdScope(args) {
 // no behavior yet (nothing to toggle).
 const INITIATIVE_LEGS = ['execute', 'prcheck', 'pr', 'ticket', 'merge', 'public', 'handover'];
 
-// The plugin names `hooks.plugin.<name>` accepts — derived from
-// FULL_PLUGIN_ENABLE (single source of truth, T4.5's own pluginSet=full
-// table) rather than a second hand-maintained list.
-const HOOK_PLUGIN_NAMES = FULL_PLUGIN_ENABLE.map((p) => p.spec.split('@')[0]);
+// The plugin names `hooks.plugin.<name>` accepts — derived lazily from the
+// canonical pluginSet=full data rather than a second hand-maintained list.
+function hookPluginNames() {
+  return fullPluginEnable().map((p) => p.spec.split('@')[0]);
+}
 
 function envFilePath() {
   return path.join(repoRoot(), '.env');
@@ -2898,8 +2917,8 @@ function cmdConfigSetHook(hookPath, onOff, args) {
   }
   if (hookPath.length === 2 && hookPath[0] === 'plugin') {
     const name = hookPath[1];
-    if (HOOK_PLUGIN_NAMES.indexOf(name) === -1) {
-      console.error(`himmelctl: unknown plugin '${name}' (known: ${HOOK_PLUGIN_NAMES.join(', ')})`);
+    if (hookPluginNames().indexOf(name) === -1) {
+      console.error(`himmelctl: unknown plugin '${name}' (known: ${hookPluginNames().join(', ')})`);
       return 2;
     }
     const verb = onOff === 'on' ? 'enable' : 'disable';
@@ -2972,8 +2991,8 @@ function cmdConfigGet(pathParts) {
     // what CodeRabbit flagged (an "instructions, not current value" get), so all
     // `get hooks*` paths reject with rc 2 + guidance on where the real state
     // lives. (`config set hooks.plugin.<name>` still performs the real toggle.)
-    if (rest.length === 2 && rest[0] === 'plugin' && HOOK_PLUGIN_NAMES.indexOf(rest[1]) === -1) {
-      console.error(`himmelctl: config get: unknown plugin '${rest[1]}' (known: ${HOOK_PLUGIN_NAMES.join(', ')})`);
+    if (rest.length === 2 && rest[0] === 'plugin' && hookPluginNames().indexOf(rest[1]) === -1) {
+      console.error(`himmelctl: config get: unknown plugin '${rest[1]}' (known: ${hookPluginNames().join(', ')})`);
       return 2;
     }
     const validShape = rest.length === 0
@@ -2985,7 +3004,7 @@ function cmdConfigGet(pathParts) {
     }
     console.error('himmelctl: config get does not report hook state — hooks are not a readable config value.');
     console.error('  hooks.improveOnSubmit: launching-shell env var — check IMPROVE_ON_SUBMIT in the shell that launches claude.');
-    console.error(`  hooks.plugin.<name>: claude-owned — run 'claude plugin list' for actual enabled state (known: ${HOOK_PLUGIN_NAMES.join(', ')}).`);
+    console.error(`  hooks.plugin.<name>: claude-owned — run 'claude plugin list' for actual enabled state (known: ${hookPluginNames().join(', ')}).`);
     return 2;
   }
   console.error(`himmelctl: unknown config path: ${pathParts.join('.')}`);
@@ -3048,7 +3067,7 @@ async function cmdConfigInteractive(args) {
     if (category === 'hooks') {
       const target = await askPath(
         ask,
-        `? hook target ('improveOnSubmit' or 'plugin.<name>'; known plugins: ${HOOK_PLUGIN_NAMES.join(', ')}) (blank to cancel)\n> `,
+        `? hook target ('improveOnSubmit' or 'plugin.<name>'; known plugins: ${hookPluginNames().join(', ')}) (blank to cancel)\n> `,
         '',
       );
       if (!target) continue;

--- a/scripts/himmelctl/bootstrap.ps1
+++ b/scripts/himmelctl/bootstrap.ps1
@@ -9,13 +9,15 @@
 #
 # Usage (-ExecutionPolicy Bypass: a clean machine's default policy is
 # Restricted, which refuses -File outright):
-#   powershell -ExecutionPolicy Bypass -File scripts/himmelctl/bootstrap.ps1 [-DryRun]
+#   powershell -ExecutionPolicy Bypass -File scripts/himmelctl/bootstrap.ps1 [-DryRun] [-DefaultScope project|user]
 #
 # HIMMELCTL_REPO_ROOT overrides where bin.js is looked up (same seam bin.js
 # itself honors) so a hermetic test can point the hand-off at a stub.
 
 param(
-  [switch]$DryRun
+  [switch]$DryRun,
+  [ValidateSet('project', 'user')]
+  [string]$DefaultScope = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -27,7 +29,13 @@ if (-not $repoRoot) {
 }
 $binJs = Join-Path $repoRoot 'scripts\himmelctl\bin.js'
 
-$handoffCmd = "node `"$binJs`" install"
+$handoffArgs = @($binJs, 'install')
+$rerunArg = ''
+if ($DefaultScope) {
+  $handoffArgs += @('--default-scope', $DefaultScope)
+  $rerunArg = " -DefaultScope $DefaultScope"
+}
+$handoffCmd = "node `"$binJs`" " + (($handoffArgs | Select-Object -Skip 1) -join ' ')
 $installPlan = 'winget install --id OpenJS.NodeJS.LTS -e'
 
 function Test-NodePresent {
@@ -38,7 +46,7 @@ if (Test-NodePresent) {
   # node-present short-circuit: straight to the hand-off, no install step.
   Write-Output "bootstrap: node found -- handing off to: $handoffCmd"
   if ($DryRun) { exit 0 }
-  & node $binJs install
+  & node @handoffArgs
   exit $LASTEXITCODE
 }
 
@@ -57,7 +65,7 @@ Write-Output "bootstrap: bun not installed (optional -- needed later for qmd/tel
 
 if (Test-NodePresent) {
   Write-Output "bootstrap: node installed -- handing off to: $handoffCmd"
-  & node $binJs install
+  & node @handoffArgs
   exit $LASTEXITCODE
 }
 
@@ -74,5 +82,5 @@ if ($wingetExit -ne 0) {
 # PATH-refresh trap (Draft-A §6): winget SUCCEEDED but the fresh install's PATH
 # edit is invisible to this process. Print the ONE re-run line rather than
 # chaining blindly.
-Write-Output "bootstrap: node installed but not resolvable in this shell -- open a new terminal and re-run: powershell -ExecutionPolicy Bypass -File `"$scriptDir\bootstrap.ps1`""
+Write-Output "bootstrap: node installed but not resolvable in this shell -- open a new terminal and re-run: powershell -ExecutionPolicy Bypass -File `"$scriptDir\bootstrap.ps1`"$rerunArg"
 exit 1

--- a/scripts/himmelctl/bootstrap.sh
+++ b/scripts/himmelctl/bootstrap.sh
@@ -9,7 +9,7 @@
 # bootstrap.ps1 instead (winget).
 #
 # Usage:
-#   bash scripts/himmelctl/bootstrap.sh [--dry-run]
+#   bash scripts/himmelctl/bootstrap.sh [--dry-run] [--default-scope project|user]
 #
 # HIMMELCTL_REPO_ROOT overrides where bin.js is looked up (same seam bin.js
 # itself honors) so a hermetic test can point the hand-off at a stub.
@@ -21,14 +21,26 @@ repo_root="${HIMMELCTL_REPO_ROOT:-$(cd -- "$script_dir/../.." && pwd)}"
 bin_js="$repo_root/scripts/himmelctl/bin.js"
 
 dry_run=0
-for arg in "$@"; do
-  case "$arg" in
-    --dry-run) dry_run=1 ;;
-    *) echo "bootstrap: unknown argument: $arg" >&2; exit 2 ;;
+default_scope=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run) dry_run=1; shift ;;
+    --default-scope)
+      default_scope="${2:-}"
+      case "$default_scope" in project|user) ;; *) echo "bootstrap: --default-scope must be project or user" >&2; exit 2 ;; esac
+      shift 2
+      ;;
+    *) echo "bootstrap: unknown argument: $1" >&2; exit 2 ;;
   esac
 done
 
-handoff_cmd="node \"$bin_js\" install"
+handoff_args=(install)
+rerun_args=""
+if [ -n "$default_scope" ]; then
+  handoff_args+=(--default-scope "$default_scope")
+  rerun_args=" --default-scope $default_scope"
+fi
+handoff_cmd="node \"$bin_js\" ${handoff_args[*]}"
 
 # install_plan — the package-manager line for this platform. darwin: brew
 # (node+bun both brew-installable); everything else (linux, and any posix
@@ -75,7 +87,7 @@ if command -v node >/dev/null 2>&1; then
   # node-present short-circuit: straight to the hand-off, no install step.
   echo "bootstrap: node found -- handing off to: $handoff_cmd"
   [ "$dry_run" -eq 1 ] && exit 0
-  exec node "$bin_js" install
+  exec node "$bin_js" "${handoff_args[@]}"
 fi
 
 plan="$(install_plan)"
@@ -91,10 +103,10 @@ note_bun_optional
 
 if command -v node >/dev/null 2>&1; then
   echo "bootstrap: node installed -- handing off to: $handoff_cmd"
-  exec node "$bin_js" install
+  exec node "$bin_js" "${handoff_args[@]}"
 fi
 
 # PATH-refresh trap (Draft-A §6): the fresh install's PATH edit is invisible
 # to this process. Print the ONE re-run line rather than chaining blindly.
-echo "bootstrap: node installed but not resolvable in this shell -- open a new terminal and re-run: bash \"$script_dir/bootstrap.sh\"" >&2
+echo "bootstrap: node installed but not resolvable in this shell -- open a new terminal and re-run: bash \"$script_dir/bootstrap.sh\"$rerun_args" >&2
 exit 1

--- a/scripts/himmelctl/test/test-wizard-bootstrap.sh
+++ b/scripts/himmelctl/test/test-wizard-bootstrap.sh
@@ -148,15 +148,15 @@ cA=$(build_path "$stubA" uname node -- )
 fixtureA="$work/shA-fixture"; build_bin_js_fixture "$fixtureA"
 set +e
 out=$(PATH="$cA" HIMMELCTL_REPO_ROOT="$(winpath "$fixtureA")" \
-      "$bash_bin" "$bootstrap_sh" 2>&1); rc=$?
+      "$bash_bin" "$bootstrap_sh" --default-scope user 2>&1); rc=$?
 set -e
 [ "$rc" -eq 0 ] || fail "caseA(sh): node-present should exit 0 (got rc=$rc): $out"
 printf '%s' "$out" | grep -q 'node found' \
   || fail "caseA(sh): expected the node-found hand-off message (got: $out)"
 [ -f "$fixtureA/scripts/himmelctl/bin-js-calls.log" ] \
   || fail "caseA(sh): expected bin.js to be invoked (out: $out)"
-grep -q 'install' "$fixtureA/scripts/himmelctl/bin-js-calls.log" \
-  || fail "caseA(sh): expected bin.js invoked with the 'install' arg"
+grep -q '^bin.js: install --default-scope user$' "$fixtureA/scripts/himmelctl/bin-js-calls.log" \
+  || fail "caseA(sh): expected bin.js invoked with 'install --default-scope user'"
 [ -f "$stubA/install-calls.log" ] \
   && fail "caseA(sh): node-present short-circuit must NOT invoke the platform installer"
 echo "ok: caseA(sh) node present -> short-circuits straight to hand-off, installer never invoked"
@@ -314,6 +314,7 @@ elif command -v pwsh >/dev/null 2>&1; then
   pwsh_bin=$(command -v pwsh)
 fi
 win_host=0
+# WSL reports uname=Linux, so this intentionally false-skips the Windows-only .ps1 stubs there.
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*) win_host=1 ;;
 esac
@@ -329,13 +330,15 @@ else
   fixtureA2="$work/psA-fixture"; build_bin_js_fixture "$fixtureA2"
   set +e
   out=$(PATH="$stubA2:$PATH" HIMMELCTL_REPO_ROOT="$(winpath "$fixtureA2")" \
-        "$pwsh_bin" -NoProfile -File "$(winpath "$bootstrap_ps1")" 2>&1); rc=$?
+        "$pwsh_bin" -NoProfile -File "$(winpath "$bootstrap_ps1")" -DefaultScope user 2>&1); rc=$?
   set -e
   [ "$rc" -eq 0 ] || fail "caseA(ps1): node-present should exit 0 (got rc=$rc): $out"
   printf '%s' "$out" | grep -q 'node found' \
     || fail "caseA(ps1): expected the node-found hand-off message (got: $out)"
   [ -f "$fixtureA2/scripts/himmelctl/bin-js-calls.log" ] \
     || fail "caseA(ps1): expected bin.js to be invoked (out: $out)"
+  grep -q '^bin.js: install --default-scope user$' "$fixtureA2/scripts/himmelctl/bin-js-calls.log" \
+    || fail "caseA(ps1): expected bin.js invoked with 'install --default-scope user'"
   [ -f "$stubA2/install-calls.log" ] \
     && fail "caseA(ps1): node-present short-circuit must NOT invoke winget"
   echo "ok: caseA(ps1) node present -> short-circuits straight to hand-off, winget never invoked"

--- a/scripts/himmelctl/test/test-wizard-config.sh
+++ b/scripts/himmelctl/test/test-wizard-config.sh
@@ -76,10 +76,11 @@ winpath() {
 # repo's own .env / scripts/lanes/*.json.
 build_fixture() {
   local _d="$1"
-  mkdir -p "$_d/scripts/lib" "$_d/scripts/lanes"
+  mkdir -p "$_d/scripts/lib" "$_d/scripts/lanes" "$_d/scripts/machine-setup"
   cp "$repo_root/scripts/lib/set-env-var.sh" "$_d/scripts/lib/set-env-var.sh"
   cp "$repo_root/scripts/lanes/set-lane-override.mjs" "$_d/scripts/lanes/set-lane-override.mjs"
   cp "$repo_root/scripts/lanes/lanes.json" "$_d/scripts/lanes/lanes.json"
+  cp "$repo_root/scripts/machine-setup/full-plugin-enable.json" "$_d/scripts/machine-setup/full-plugin-enable.json"
 }
 
 run_cfg() {

--- a/scripts/himmelctl/test/test-wizard-derive.sh
+++ b/scripts/himmelctl/test/test-wizard-derive.sh
@@ -133,7 +133,8 @@ JSON
 # "surface the BACKUP line" behavior is exercised without a real apply.
 build_fixture() {
   local _d="$1"
-  mkdir -p "$_d/scripts/handover" "$_d/scripts/lib"
+  mkdir -p "$_d/scripts/handover" "$_d/scripts/lib" "$_d/scripts/machine-setup"
+  cp "$repo_root/scripts/machine-setup/full-plugin-enable.json" "$_d/scripts/machine-setup/full-plugin-enable.json"
   cat > "$_d/scripts/adopt.sh" <<STUB
 #!/usr/bin/env bash
 printf 'adopt.sh: %s\n' "\$*" >> "$_d/adopt-calls.log"
@@ -794,5 +795,47 @@ printf '%s' "$out" | grep -q '^DRY: claude plugin install github@claude-plugins-
 printf '%s' "$out" | grep -qE 'derived:.*adopt\.sh --profile all --scope project --luna-target' \
   || fail "caseK: expected the --profile all --luna-target derived line (got: $out)"
 echo "ok: caseK --dry-run (full + external + default-template combo) -> zero mutation, DRY previews only"
+
+# ── Case U: EACCES settings pre-check fails friendly before wire/plugin ──────
+stubU="$work/caseU"; mkdir -p "$stubU"
+cU=$(build_path "$stubU" bash git jq python3 npm -- )
+hU="$work/hU"; mkdir -p "$hU/.claude"
+settingsU="$hU/.claude/settings.json"; printf '{}\n' > "$settingsU"
+fixtureU="$work/caseU-fixture"; build_fixture "$fixtureU"
+vaultU="$work/caseU-vault"; stamp_vault "$vaultU"
+cacheU="$work/caseU-profile.json"
+write_cache "$cacheU" adopter user existing "$(winpath "$vaultU")" inline "" lean
+denyU="$work/deny-settings-write.js"
+cat > "$denyU" <<'JS'
+const fs = require('fs');
+const path = require('path');
+const realAccessSync = fs.accessSync;
+fs.accessSync = function (p, mode) {
+  if (path.resolve(String(p)) === path.resolve(process.env.DENY_SETTINGS_PATH)) {
+    const err = new Error('simulated permission denied');
+    err.code = 'EACCES';
+    throw err;
+  }
+  return realAccessSync.call(fs, p, mode);
+};
+JS
+set +e
+out=$(PATH="$cU" HOME="$hU" HIMMELCTL_INTERACTIVE=0 \
+      HIMMELCTL_REPO_ROOT="$(winpath "$fixtureU")" \
+      DENY_SETTINGS_PATH="$(winpath "$settingsU")" \
+      NODE_OPTIONS="--require=$(winpath "$denyU")" \
+      "$node_bin" "$wizard" install --from-profile "$(winpath "$cacheU")" \
+      </dev/null 2>&1); rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "caseU: simulated EACCES should fail before wiring (got rc=0): $out"
+printf '%s' "$out" | grep -q 'target settings.json is not writable' \
+  || fail "caseU: expected the friendly settings writability diagnostic (got: $out)"
+printf '%s' "$out" | grep -q 'EACCES' \
+  || fail "caseU: expected the EACCES code in the diagnostic (got: $out)"
+[ -f "$fixtureU/wire-luna-vault-calls.log" ] \
+  && fail "caseU: EACCES pre-check must abort before wire-luna-vault.sh"
+[ -f "$fixtureU/luna-upgrade-all-calls.log" ] \
+  && fail "caseU: EACCES pre-check must abort before luna-upgrade-all.sh"
+echo "ok: caseU simulated settings EACCES -> friendly fail before wire/plugin steps"
 
 echo "PASS"

--- a/scripts/himmelctl/test/test-wizard-install-engine.sh
+++ b/scripts/himmelctl/test/test-wizard-install-engine.sh
@@ -31,11 +31,9 @@
 #      NON-default --scope project still runs its HIMMEL_RECONCILE_PLUGINS
 #      lean-floor reconcile step — proving the `plugins` install type's
 #      delegation to it is behavior-preserving, not a capability regression.
-#   g. plugin-spec canonicalization drift check: bin.js's inline
-#      FULL_PLUGIN_ENABLE table stays byte-identical to the canonical
-#      scripts/machine-setup/full-plugin-enable.json `plugins` array (kept
-#      inline rather than read from the file at runtime — see bin.js's own
-#      comment — so this test is what actually keeps the two from drifting).
+#   g. plugin-spec canonicalization: bin.js has no inline FULL_PLUGIN_ENABLE
+#      duplicate and loads scripts/machine-setup/full-plugin-enable.json; the
+#      data file carries the expected 14 unique plugin specs.
 #   h. a signal-terminated primitive (r.signal set, r.status null — a real
 #      OS signal kill does not reliably surface via Node's spawnSync.signal
 #      field on Windows, verified empirically; a child_process.spawnSync
@@ -338,35 +336,19 @@ else
   echo "ok: case f — install-plugins.sh at a non-default --scope project still runs its lean-floor reconcile (orchestrator preserved)"
 fi
 
-# ── case g: plugin-spec canonicalization drift check ───────────────────────
+# ── case g: plugin-spec canonicalization has one runtime source ─────────────
 wizard="$repo_root/scripts/himmelctl/bin.js"
 plugin_json="$repo_root/scripts/machine-setup/full-plugin-enable.json"
 [ -f "$wizard" ] || { echo "FAIL: $wizard not found" >&2; exit 1; }
 [ -f "$plugin_json" ] || { echo "FAIL: $plugin_json not found" >&2; exit 1; }
-WIZARD_PATH="$(winpath "$wizard")"
-PLUGIN_JSON_PATH="$(winpath "$plugin_json")"
-export WIZARD_PATH PLUGIN_JSON_PATH
-outG=$("$node_bin" -e "
-const fs = require('fs');
-const src = fs.readFileSync(process.env.WIZARD_PATH, 'utf8');
-const m = src.match(/const FULL_PLUGIN_ENABLE = (\[[\s\S]*?\n\]);/);
-if (!m) { console.log(JSON.stringify({ error: 'FULL_PLUGIN_ENABLE const not found in bin.js' })); process.exit(0); }
-// Safe JS-literal -> JSON transform (NOT eval): the const is a plain array of
-// { spec, marketplaceAdd? } object literals with single-quoted string values
-// and bare (unquoted) keys — quote the two known keys, swap quote style, and
-// drop the trailing comma before the closing bracket, then JSON.parse it.
-const jsonish = m[1]
-  .replace(/'/g, '\"')
-  .replace(/\b(spec|marketplaceAdd)\b\s*:/g, '\"\$1\":')
-  .replace(/,(\s*\])/g, '\$1');
-const inline = JSON.parse(jsonish);
-const fromFile = JSON.parse(fs.readFileSync(process.env.PLUGIN_JSON_PATH, 'utf8')).plugins;
-console.log(JSON.stringify({ inline, fromFile }));
-")
-echo "$outG" | jq -e '.error == null' >/dev/null || fail "case g: could not extract FULL_PLUGIN_ENABLE from bin.js (got: $outG)"
-echo "$outG" | jq -e '.inline == .fromFile' >/dev/null \
-  || fail "case g: bin.js's inline FULL_PLUGIN_ENABLE has drifted from scripts/machine-setup/full-plugin-enable.json (got: $outG)"
-echo "ok: case g — bin.js's inline FULL_PLUGIN_ENABLE stays byte-identical to the canonical full-plugin-enable.json"
+grep -q 'const FULL_PLUGIN_ENABLE = ' "$wizard" \
+  && fail "case g: bin.js must not keep an inline FULL_PLUGIN_ENABLE duplicate"
+grep -q "full-plugin-enable.json" "$wizard" \
+  || fail "case g: bin.js must load the canonical full-plugin-enable.json"
+outG=$(jq -c '{count:(.plugins|length), unique:(.plugins|map(.spec)|unique|length), valid:(.plugins|all(.spec|type == "string" and length > 0))}' "$plugin_json")
+echo "$outG" | jq -e '.count == 14 and .unique == 14 and .valid == true' >/dev/null \
+  || fail "case g: full-plugin-enable.json must carry 14 unique valid plugin specs (got: $outG)"
+echo "ok: case g — bin.js loads the canonical full-plugin-enable.json; no inline duplicate remains"
 
 # ── case h: a signal-terminated primitive lands in failed[], never ran[] ───
 # child_process.spawnSync is monkey-patched to return the exact

--- a/scripts/himmelctl/test/test-wizard-preflight.sh
+++ b/scripts/himmelctl/test/test-wizard-preflight.sh
@@ -13,6 +13,8 @@
 #      stub that logs its argv and creates the missing tool -> answering `y`
 #      triggers exactly ONE pkg-mgr call and the re-check reaches
 #      `preflight OK`.
+#   3b. Windows only: missing bash + git installs Git.Git exactly once through
+#      cmd/winget, then the re-check sees both tools (clean-machine path).
 #   4. interactive, missing jq, stdin closed BEFORE any answer at the
 #      "Install missing tools now?" confirm -> declines safely (CR r1 FIX 8:
 #      the confirm used to hang forever on EOF-before-answer; it now uses the
@@ -102,17 +104,22 @@ log3="$work/case3-pkgmgr.log"
 # The wizard invokes a platform-specific package manager; stub whichever one it
 # will reach so the same case is hermetic on win32/darwin/linux.
 case "$(uname -s)" in
-  MINGW*|MSYS*|CYGWIN*) pkgmgr='winget' ;;
-  Darwin)              pkgmgr='brew' ;;
-  Linux)               pkgmgr='sudo' ;;
-  *) fail "case3: unsupported platform $(uname -s)" ;;
-esac
-# The stub logs its argv (so the test can count calls) and fabricates each named
-# missing tool inside the stub dir, so the wizard's re-check finds it. The
-# winget branch receives `install --id <ID> -e` (CR r2: one exact package id
-# per invocation, never a bare-name query), so ids map back to tool names;
-# apt/brew still receive bare tool names.
-cat > "$stub3/$pkgmgr" <<STUB
+  MINGW*|MSYS*|CYGWIN*)
+    pkgmgr='winget.cmd'
+    jq_src=$(cygpath -w "$(command -v jq)")
+    stub3_win=$(cygpath -w "$stub3")
+    log3_win=$(cygpath -w "$log3")
+    cat > "$stub3/$pkgmgr" <<STUB
+@echo off
+echo called: %*>>"$log3_win"
+copy /Y "$jq_src" "$stub3_win\jq.exe" >nul
+exit /b 0
+STUB
+    ;;
+  Darwin|Linux)
+    if [ "$(uname -s)" = "Darwin" ]; then pkgmgr='brew'; else pkgmgr='sudo'; fi
+    # The posix stub fabricates each named missing tool so the re-check finds it.
+    cat > "$stub3/$pkgmgr" <<STUB
 #!/usr/bin/env bash
 echo "called: \$*" >> "$log3"
 for a in "\$@"; do
@@ -128,7 +135,10 @@ for a in "\$@"; do
 done
 exit 0
 STUB
-chmod +x "$stub3/$pkgmgr"
+    chmod +x "$stub3/$pkgmgr"
+    ;;
+  *) fail "case3: unsupported platform $(uname -s)" ;;
+esac
 c3path=$(build_path "$stub3" bash git python3 npm -- jq)
 PATH="$c3path" command -v jq >/dev/null 2>&1 \
   && fail "case3 sanity: jq should be absent before the install offer"
@@ -147,6 +157,45 @@ calls=0
 printf '%s' "$out" | grep -q 'preflight OK' \
   || fail "case3: recheck should reach preflight OK (got: $out)"
 echo "ok: case3 interactive -> exactly 1 $pkgmgr call + recheck passes -> preflight OK"
+
+# ── Case 3b: Windows clean machine installs Git.Git once for bash + git ─────
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    stub3b="$work/case3b"; mkdir -p "$stub3b"
+    log3b="$work/case3b-pkgmgr.log"
+    bash_src=$(cygpath -w "$(command -v bash)")
+    git_src=$(cygpath -w "$(command -v git)")
+    stub3b_win=$(cygpath -w "$stub3b")
+    log3b_win=$(cygpath -w "$log3b")
+    cat > "$stub3b/winget.cmd" <<STUB
+@echo off
+echo called: %*>>"$log3b_win"
+copy /Y "$bash_src" "$stub3b_win\bash.exe" >nul
+copy /Y "$git_src" "$stub3b_win\git.exe" >nul
+exit /b 0
+STUB
+    c3bpath=$(build_path "$stub3b" jq python3 npm -- bash git)
+    PATH="$c3bpath" command -v bash >/dev/null 2>&1 \
+      && fail "case3b sanity: bash should be absent before the install offer"
+    PATH="$c3bpath" command -v git >/dev/null 2>&1 \
+      && fail "case3b sanity: git should be absent before the install offer"
+    h3b="$work/h3b"; mkdir -p "$h3b"
+    set +e
+    out=$(PATH="$c3bpath" HOME="$h3b" HIMMELCTL_INTERACTIVE=1 \
+          "$node_bin" "$wizard" install <<<"y" 2>&1); rc=$?
+    set -e
+    [ "$rc" -eq 0 ] || fail "case3b: Git.Git install+recheck should reach preflight OK (got rc=$rc): $out"
+    calls=$(wc -l < "$log3b")
+    [ "$calls" = "1" ] \
+      || fail "case3b: bash + git must deduplicate to one Git.Git install (got $calls): $(cat "$log3b")"
+    grep -q 'Git.Git' "$log3b" \
+      || fail "case3b: the one winget call must install Git.Git (got: $(cat "$log3b"))"
+    printf '%s' "$out" | grep -q 'preflight OK' \
+      || fail "case3b: recheck should reach preflight OK (got: $out)"
+    echo "ok: case3b Windows missing bash + git -> one cmd/winget Git.Git install + recheck passes"
+    ;;
+  *) echo "SKIP: case3b Windows clean-machine Git.Git path (non-Windows host)" ;;
+esac
 
 # ── Case 4: interactive, closed stdin at the install confirm -> no hang ────
 # CR r1 FIX 8 made the confirm EOF-safe so a closed stdin declines instead of

--- a/scripts/himmelctl/test/test-wizard-questions.sh
+++ b/scripts/himmelctl/test/test-wizard-questions.sh
@@ -24,6 +24,8 @@
 #      the fresh clone) -> ADOPTER default, scope asked, and the accepted
 #      defaults derive adopt.sh with the vault flags honored — never
 #      setup.sh.
+#   8. --default-scope user changes only the adopter scope question's default;
+#      accepting it still prints the plan normally and preserves confirmation.
 # Covers (T3):
 #   5. interactive run writes the cache; --from-profile on it reproduces the
 #      same answer JSON with ZERO prompts.
@@ -352,5 +354,31 @@ printf '%s' "$out" | grep -q 'case7-luna' \
 printf '%s' "$out" | grep '^derived:' | grep -q 'setup\.sh' \
   && fail "case7: an official-clone adopter must never derive setup.sh (got: $out)"
 echo "ok: case7 himmel origin without .himmel-dev -> adopter default, scope asked, adopt.sh derived with vault flags"
+
+# ── Case 8: explicit user-scope hint changes the confirmable default only ────
+stub8="$work/case8"; mkdir -p "$stub8"
+c8path=$(build_path "$stub8" bash jq python3 npm -- )
+make_git_stub "$stub8" "https://github.com/someone/other-repo.git"
+h8="$work/h8"; mkdir -p "$h8"
+set +e
+out=$(PATH="$c8path" HOME="$h8" HIMMELCTL_INTERACTIVE=1 \
+      "$node_bin" "$wizard" install --dry-run --default-scope user 2>&1 <<INPUT
+
+
+none
+inline
+lean
+INPUT
+)
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "case8: user-scope hint run should succeed (got rc=$rc): $out"
+printf '%s' "$out" | grep -qF '? scope [project|user] (default: user)' \
+  || fail "case8: scope question should display user as its default (got: $out)"
+printf '%s' "$out" | grep -q '"scope": "user"' \
+  || fail "case8: accepting the scope default should record user (got: $out)"
+printf '%s' "$out" | grep -qE 'derived:.*adopt\.sh --profile core --scope user$' \
+  || fail "case8: accepted hint should derive the normal user-scope plan (got: $out)"
+echo "ok: case8 --default-scope user -> confirmable scope default=user + normal derived plan"
 
 echo "PASS"

--- a/scripts/machine-setup/full-plugin-enable.json
+++ b/scripts/machine-setup/full-plugin-enable.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Canonical pluginSet=full enable table (HIMMEL-816, HIMMEL-755 A4). Single source of truth for scripts/himmelctl/bin.js's FULL_PLUGIN_ENABLE — the documented per-plugin enable list from docs/setup/new-machine.md's Claude Code Plugins section. Every install is --scope user. Extracted so this list has ONE canonical home instead of living inline in bin.js (HIMMEL-755 A4 plugin-spec canonicalization); scripts/machine-setup/install-plugins.sh is a SEPARATE, template-driven orchestrator (docs/setup/settings-template.json's enabledPlugins) and is intentionally NOT re-pointed at this file — the two lists serve different purposes (this is a fixed pluginSet=full bonus list; install-plugins.sh installs whatever a scope's settings-template flags true) and collapsing them would be a functional change, not a list extraction.",
+  "_comment": "Canonical pluginSet=full enable table (HIMMEL-816, HIMMEL-755 A4). scripts/himmelctl/bin.js loads this file at runtime; every install is --scope user. scripts/machine-setup/install-plugins.sh remains a separate template-driven orchestrator over docs/setup/settings-template.json because that broader enabledPlugins map serves a different purpose.",
   "plugins": [
     { "spec": "github@claude-plugins-official" },
     { "spec": "feature-dev@claude-plugins-official" },

--- a/scripts/machine-setup/test-ubuntu-settings-jq.sh
+++ b/scripts/machine-setup/test-ubuntu-settings-jq.sh
@@ -85,9 +85,11 @@ else
 fi
 # The NOTICE alone is not the contract: assert the executable delegation
 # statement too, so removing the exec while keeping the NOTICE fails
-# (codex-adv finding, HIMMEL-934 CR round).
+# (codex-adv finding, HIMMEL-934 CR round). The optional trailing
+# `--default-scope <scope>` is the HIMMEL-1253 user-scope default hint the
+# machine-setup shims pass (#1130) — allowed, but the exec must still be real.
 # shellcheck disable=SC2016  # single quotes intentional: $HIMMEL_PATH is ubuntu.sh's variable
-if grep -qE -- '^[[:space:]]*(HIMMELCTL_REPO_ROOT="\$HIMMEL_PATH"[[:space:]]+)?exec[[:space:]]+bash[[:space:]]+"\$HIMMEL_PATH/scripts/himmelctl/bootstrap\.sh"[[:space:]]*$' "$ubuntu_sh"; then
+if grep -qE -- '^[[:space:]]*(HIMMELCTL_REPO_ROOT="\$HIMMEL_PATH"[[:space:]]+)?exec[[:space:]]+bash[[:space:]]+"\$HIMMEL_PATH/scripts/himmelctl/bootstrap\.sh"([[:space:]]+--default-scope[[:space:]]+[A-Za-z]+)?[[:space:]]*$' "$ubuntu_sh"; then
     assert_pass "ubuntu.sh execs himmelctl bootstrap.sh (delegation is real, HIMMEL-887)"
 else
     assert_fail "ubuntu.sh does not exec himmelctl bootstrap.sh (NOTICE without delegation)"

--- a/scripts/machine-setup/test-ubuntu-shim.sh
+++ b/scripts/machine-setup/test-ubuntu-shim.sh
@@ -83,10 +83,11 @@ EOF
 
 cat > "$stub_bin/git" <<'EOF'
 #!/usr/bin/env bash
+echo "GIT:$*"
 if [ "$1" = "clone" ]; then
   target="$*"
   target="${target##* }"
-  mkdir -p "$target/scripts/hooks" "$target/scripts/himmelctl" "$target/scripts/lib"
+  mkdir -p "$target/.git" "$target/scripts/hooks" "$target/scripts/himmelctl" "$target/scripts/lib"
   cat > "$target/scripts/hooks/check-hookspath.sh" <<'INNER'
 #!/usr/bin/env bash
 echo "STUB:check-hookspath"
@@ -178,7 +179,10 @@ bootstrap_pwd=$(grep '^BOOTSTRAP:pwd ' "$log" | head -1 | sed 's/^BOOTSTRAP:pwd 
 [ -n "$bootstrap_pwd" ] || { cat "$log" >&2; fail "caseB: no BOOTSTRAP:pwd marker found (log above)"; }
 [ "$bootstrap_pwd" = "$expected_pwd" ] \
   || fail "caseB: bootstrap must be invoked with cwd=\$HIMMEL_PATH ($expected_pwd), got: $bootstrap_pwd"
-echo "ok: caseB provisioning ($provision_line) < notice ($notice_line) < delegated bootstrap ($bootstrap_line), cwd=\$HIMMEL_PATH"
+bootstrap_args=$(grep '^BOOTSTRAP:invoked ' "$log" | head -1 | sed 's/^BOOTSTRAP:invoked //')
+[ "$bootstrap_args" = "--default-scope user" ] \
+  || fail "caseB: machine-restore delegation must hint user scope, got: $bootstrap_args"
+echo "ok: caseB provisioning ($provision_line) < notice ($notice_line) < delegated bootstrap ($bootstrap_line), cwd=\$HIMMEL_PATH, default scope=user"
 
 # HIMMEL-985: the shim must reconcile the rtk hook (bare `rtk hook claude`
 # from `rtk init -g --auto-patch` → the rtk-hook-guard wrapper) AFTER the
@@ -203,6 +207,19 @@ reconcile_args=$(grep '^STUB:reconcile-rtk-hook ' "$log" | head -1 | sed 's/^STU
 [ "$reconcile_args" = "$tmp_home/.claude/settings.json $expected_pwd" ] \
   || fail "caseB: reconcile-rtk-hook args must be '<settings.json> <himmel-path>', got: $reconcile_args"
 echo "ok: caseB reconcile-rtk-hook ($reconcile_line) < bootstrap ($bootstrap_line), args OK"
+
+# ── Case D: re-run reuses the existing clone and fetches it ─────────────────
+logD="$work/run-rerun.log"
+set +e
+HOME="$tmp_home" PATH="$stub_bin:$PATH" bash "$target" >"$logD" 2>&1
+run_rcD=$?
+set -e
+[ "$run_rcD" -eq 0 ] || { cat "$logD" >&2; fail "caseD: re-run should succeed against the existing clone (rc=$run_rcD)"; }
+grep -q "^GIT:-C $expected_pwd fetch --all --prune$" "$logD" \
+  || { cat "$logD" >&2; fail "caseD: re-run must fetch/reuse the existing clone"; }
+grep -q '^GIT:clone ' "$logD" \
+  && fail "caseD: re-run must not clone over the existing checkout"
+echo "ok: caseD existing clone -> fetch --all --prune + reuse, no second clone"
 
 # ── Case C: --luna-remote -> fail-closed BEFORE any provisioning ───────────
 # Reuses the Case B stub environment (same stub PATH + temp HOME) so a

--- a/scripts/machine-setup/test-win11-shim.ps1
+++ b/scripts/machine-setup/test-win11-shim.ps1
@@ -124,4 +124,10 @@ if ($source -match 'NOTE: -LunaRemote was passed') {
 }
 Write-Output "ok: caseC -LunaRemote fail-closed guard (offset $($guardMatch.Index)) sits before provisioning (offset $firstProvisionIdx); silent-drop NOTE gone"
 
+# ── Case D: machine-restore delegation explicitly defaults scope to user ─────
+if ($source -notmatch [regex]::Escape("-DefaultScope user")) {
+    Fail "caseD: delegated bootstrap must carry '-DefaultScope user'"
+}
+Write-Output "ok: caseD delegated bootstrap carries the explicit user-scope default hint"
+
 Write-Output "PASS"

--- a/scripts/machine-setup/ubuntu.sh
+++ b/scripts/machine-setup/ubuntu.sh
@@ -103,7 +103,18 @@ rtk --version
 
 step "Clone himmel repo"
 mkdir -p "$(dirname "$HIMMEL_PATH")"
-git clone https://github.com/yotamleo/himmel.git "$HIMMEL_PATH"
+if [ -d "$HIMMEL_PATH/.git" ]; then
+  # Idempotent re-run: fetch AND fast-forward the checked-out branch to its
+  # upstream — a bare fetch updates refs only, leaving the working tree (and the
+  # bootstrap.sh this script exec's below) STALE, so the re-run would provision
+  # from old code. --ff-only never clobbers a diverged/dirty/detached operator
+  # clone: it fails, we note it, and reuse the existing checkout.
+  git -C "$HIMMEL_PATH" fetch --all --prune
+  git -C "$HIMMEL_PATH" merge --ff-only '@{u}' 2>/dev/null \
+    || echo "  note: himmel clone not fast-forward-updatable (diverged/dirty/detached HEAD) — reusing the existing checkout; update it manually if a newer himmel is needed" >&2
+else
+  git clone https://github.com/yotamleo/himmel.git "$HIMMEL_PATH"
+fi
 cd "$HIMMEL_PATH"
 
 # HIMMEL-105: gate the clone for core.hooksPath misconfiguration BEFORE any
@@ -161,13 +172,13 @@ step "Delegate himmel/luna wiring to himmelctl bootstrap (HIMMEL-887)"
 # handling is needed here.)
 #
 # CR r4: delegate FROM the himmel clone, not from wherever the operator
-# launched this shim. The wizard's role/scope inference reads the CWD's git
-# origin, and scope=project wires .claude into the CWD — delegating from the
-# launch directory would target the WRONG repo. cd (not a subshell) because
+# launched this shim. The wizard's role inference reads the CWD's git origin;
+# the explicit user-scope hint below fits this machine-restore flow while the
+# interactive question + plan/confirm remain unchanged. cd (not a subshell) because
 # the exec below replaces this process. The wizard is interactive by design:
 # an unattended/non-TTY run fails loud with remediation (documented posture);
 # this cd only guarantees that when it DOES run, its inference targets the
 # himmel clone deterministically.
 echo "NOTICE: himmel/luna wiring in this script is soft-deprecated (HIMMEL-887) -- delegating to himmelctl bootstrap. Hard-remove deferred to HIMMEL-755."
 cd "$HIMMEL_PATH"
-HIMMELCTL_REPO_ROOT="$HIMMEL_PATH" exec bash "$HIMMEL_PATH/scripts/himmelctl/bootstrap.sh"
+HIMMELCTL_REPO_ROOT="$HIMMEL_PATH" exec bash "$HIMMEL_PATH/scripts/himmelctl/bootstrap.sh" --default-scope user

--- a/scripts/machine-setup/win11.ps1
+++ b/scripts/machine-setup/win11.ps1
@@ -204,9 +204,9 @@ Write-Step "Delegate himmel/luna wiring to himmelctl bootstrap (HIMMEL-887)"
 # remote-vault handling is needed here.)
 #
 # CR r4: delegate FROM the himmel clone, not from wherever the operator
-# launched this shim. The wizard's role/scope inference reads the CWD's git
-# origin, and scope=project wires .claude into the CWD — delegating from the
-# launch directory would target the WRONG repo. The wizard is interactive by
+# launched this shim. The wizard's role inference reads the CWD's git origin;
+# the explicit user-scope hint below fits this machine-restore flow while the
+# interactive question + plan/confirm remain unchanged. The wizard is interactive by
 # design: an unattended/non-TTY run fails loud with remediation (documented
 # posture); this Set-Location only guarantees that when it DOES run, its
 # inference targets the himmel clone deterministically.
@@ -215,5 +215,5 @@ Set-Location $HimmelPath
 # Pin HIMMELCTL_REPO_ROOT to this clone so a stale inherited value can't
 # redirect the bootstrap hand-off at a different repo's bin.js (HIMMEL-935 / CR #1126).
 $env:HIMMELCTL_REPO_ROOT = $HimmelPath
-& (Join-Path $HimmelPath 'scripts\himmelctl\bootstrap.ps1')
+& (Join-Path $HimmelPath 'scripts\himmelctl\bootstrap.ps1') -DefaultScope user
 exit $LASTEXITCODE


### PR DESCRIPTION
## Summary
Batch-clears 6 actionable deferred-CodeRabbit GitHub issues in one PR (follow-up to HIMMEL-1251, which fixed 23 and skipped 7). HIMMEL-1253.

| Issue | Fix |
|---|---|
| **#1149** | `pr-check.md` step 4.8 — machine-readable `gh pr list --state open --head` no-PR detection (empty success = no PR) instead of error-string parsing |
| **#1129a** | `himmelctl/bin.js` — `FULL_PLUGIN_ENABLE` loads from `machine-setup/full-plugin-enable.json` via a cached `fullPluginEnable()` instead of a drift-prone second inline array |
| **#1129b** | himmelctl — EACCES writability pre-check on `settings.json` before plugin-enable/wire steps (friendly failure) |
| **#1130a** | `machine-setup/{ubuntu.sh,win11.ps1}` — delegate to the wizard with an explicit user-scope default hint |
| **#1130b** | `test-wizard-bootstrap.sh` — comment the WSL-bash Windows-host false-skip |
| **#1128** | `himmelctl/bootstrap.ps1` — winget-when-bash-missing spawns the installer via cmd directly (no bash dependency on a clean Windows machine) |
| **#1127** | `machine-setup/ubuntu.sh` — idempotent himmel clone (clone-if-absent, else fetch **+ `--ff-only` update of the working tree** so a re-run provisions from current code, never clobbering a diverged/dirty clone) |

**Not changed:** #1290 needs no edit — `enforcement.md` already documents the nested-`${…}` quote-masking exception (the finding predates that wording); closed already-resolved. #1035 closed won't-fix (optional insurance test).

## Test plan
- himmelctl `test-wizard-{bootstrap,config,derive,preflight,questions,install-engine}` + `machine-setup/test-ubuntu-shim.sh` + `test-win11-shim.ps1` — all green on Windows (incl. the new EACCES, user-scope-hint, and winget-fail-closed cases). shellcheck clean.
- Cross-model `/pr-check`: the panel caught that #1127's first cut fetched but left the working tree stale → fixed to `--ff-only` update; re-review clean (the one remaining Important was a pre-existing pre-existing winget-PATH observation at `bin.js:493`, blame-confirmed outside this diff + deliberate per HIMMEL-935 → disproved).

Implementation drafted on the claudex lane (gpt-5.6-sol), reviewed + verified + completed by the parent session.
