### PR TITLE
chore: bump graphify pin 0.9.22 -> 0.9.23

### DIFF
--- a/scripts/lib/graphify-bin.sh
+++ b/scripts/lib/graphify-bin.sh
@@ -45,7 +45,7 @@
 # (HIMMEL-891) -- without carrying a fork. A pin bump is a reviewed change to this
 # line, paired with `synced_base` in scripts/upstreams.json so the nightly
 # fork-drift guard stays truthful.
-_graphify_version() { printf '%s\n' "${GRAPHIFY_VERSION:-0.9.22}"; }
+_graphify_version() { printf '%s\n' "${GRAPHIFY_VERSION:-0.9.23}"; }
 _graphify_pypi_name() { printf '%s\n' "graphifyy"; }
 # The `uv tool install` package spec: `graphifyy==<version>`.
 _graphify_pinned_source() { printf '%s==%s\n' "$(_graphify_pypi_name)" "$(_graphify_version)"; }

--- a/scripts/upstreams.json
+++ b/scripts/upstreams.json
@@ -44,7 +44,7 @@
       "kind": "tag_release",
       "mode": "base",
       "tracked_repo": "Graphify-Labs/graphify",
-      "synced_base": "0.9.22",
+      "synced_base": "0.9.23",
       "latest_source": "release",
       "tier": "A",
       "note": "Upstream PyPI graphifyy, version-pinned in scripts/lib/graphify-bin.sh (_graphify_version). DE-FORKED from yotamleo/graphify in HIMMEL-1048 / issue #469: the fork carried ZERO delta over upstream (its only purpose — declaring the mcp dep, which upstream keeps optional — is handled by the `--with mcp` install flag), so himmel tracks upstream directly. tracked_repo is the TRUE upstream (Graphify-Labs). synced_base = the pinned upstream release. latest_source=release because upstream tags are NON-MONOTONIC: a stale v1.0.0 (2026-04) predates the current v0.9.x line, so highest-semver-tag would report a permanent phantom BEHIND; the Releases API returns the real latest. BEHIND here means: bump _graphify_version in graphify-bin.sh to the new release AND bump synced_base here (a reviewed one-line pair — no fork rebase)."


### PR DESCRIPTION
## What

Bump the pinned graphify version `0.9.22` → `0.9.23` (upstream `Graphify-Labs/graphify` latest release, tagged 2026-07-21, one patch ahead).

- `scripts/lib/graphify-bin.sh` — `_graphify_version()` default `0.9.22` → `0.9.23`
- `scripts/upstreams.json` — graphify `synced_base` `"0.9.22"` → `"0.9.23"`

## Why

Clears the nightly fork-drift `BEHIND` signal against upstream. Closes #491.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Graphify version to 0.9.23.
  * Updated upstream version tracking to reflect the new release baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->