### PR TITLE
fix: unblock post-/luna-upgrade vault commits (#510) + re-record the claude-hud vendored pin

### DIFF
--- a/marketplace/plugins/claude-hud/VENDORED.manifest
+++ b/marketplace/plugins/claude-hud/VENDORED.manifest
@@ -264,7 +264,7 @@ d0098b6e0c0a40876fb033bf3970ab688fd83f37  dist/utils/truncate.js.map
 1a09e382e7a248007be2da37e750114c8065ece1  dist/version.d.ts.map
 54444685d064ba09e3afd66124497394c737ec3d  dist/version.js
 e527e286a9eae26d52e32fd5a7751b47225d7512  dist/version.js.map
-3d7c8f988a52ceb965239c82799132e29aa37da1  package-lock.json
+f25de1fa0c2c92be2964bfd98f8d0be049ce6341  package-lock.json
 e048d5031bb8fe194a090bba9992f6317d9200a0  package.json
 ae323f37c223573fbbe914b4713a349400dfe1e5  scripts/clean-dist.mjs
 a9fba8d0ca539fc6828ff1589ca0b7f9c75d0bdb  src/auth.ts

--- a/marketplace/plugins/claude-hud/VENDORED.md
+++ b/marketplace/plugins/claude-hud/VENDORED.md
@@ -16,14 +16,17 @@ fork_repo:            https://github.com/yotamleo/claude-hud   # public fork (HI
 upstream_repo:        https://github.com/jarrodwatts/claude-hud
 pinned_commit:        e39bafc6d778d61f41592eced53f8aa58bf5239c  # post-v0.6.0 main HEAD (jj status indicators #685; HIMMEL-1254)
 pinned_upstream_tree: 4fcbfe47ab8780e1b11c2ddb36c18be1b24a371f  # git tree of pinned_commit (provenance)
-vendored_tree_hash:   3c99c19df13fc951e03bbe27b4824938cc4ae6e3648cb42f80766309ecd16fd6  # sha256 over VENDORED.manifest
+vendored_tree_hash:   4476fb2597f49a065c60c5b93144fb4d7c2678a213c95f48f9f92a639441f1bb  # sha256 over VENDORED.manifest
 vendored_at:          2026-07-21
 ```
 
 `pinned_commit` points at the **upstream** base `e39bafc` (post-v0.6.0 main
 HEAD); the vendored tree is that base **plus** himmel's `customLineCommand` delta
-(see **Fork delta**
-below), so `vendored_tree_hash` reflects that delta. `fork_repo`
+**plus** any dependabot lockfile bumps landed since the vendor (see **Fork
+delta**
+below), so `vendored_tree_hash` reflects those deltas — it is a
+self-consistency hash over the CURRENT tree, not a claim that the tree equals
+`pinned_upstream_tree`. `fork_repo`
 (`yotamleo/claude-hud`) is a public provenance mirror himmel does NOT install
 from (himmel vendors the tree directly), so keeping it in sync is optional — the
 drift guard gates on `vendored_tree_hash`, and the nightly upstream-drift guard
@@ -72,7 +75,8 @@ protected: editing it without bumping the pin trips the guard.
   `src/render/index.ts`; tests in `tests/custom-line-cmd.test.js`. himmel's own
   render logic (the where-are-we composer) stays in himmel `scripts/`, **not** in
   this fork — this fork carries only the generic capability. **This is now the
-  ONLY himmel delta** (see the re-vendor note below).
+  ONLY himmel SOURCE delta** (see the re-vendor note below) — the lockfile
+  additionally carries automated dependency bumps; see the dependabot bullet.
 
   > **Coexists with upstream's own `extra-cmd` (since v0.6.0):** upstream grew
   > `src/extra-cmd.ts`, gated by the SAME env `CLAUDE_HUD_ALLOW_EXTRA_CMD` but a
@@ -110,3 +114,48 @@ protected: editing it without bumping the pin trips the guard.
   `tests/custom-line-cmd.test.js` stays 6/6. The jj tests are inert where the `jj`
   binary is absent (skip); the only new Windows failures are EPERM on symlink
   fixtures in `tests/jj.test.js` (platform, not code).
+
+- **Dependabot SECURITY-update lockfile bumps (automated, on top of the pin):**
+  `.github/dependabot.yml` deliberately does NOT list
+  `/marketplace/plugins/claude-hud` — scheduled *version* updates are not wanted
+  on a vendored tree (they would drift it away from `pinned_commit` every week
+  and demand a re-record each time; the tree is meant to move on re-vendors).
+  Dependabot **security** updates are repo-level and alert-driven, though: they
+  fire on any lockfile GitHub detects, config directory or not. So a security
+  bump can land here WITHOUT a re-vendor, and the vendored tree then legitimately
+  differs from `pinned_upstream_tree` by those hunks. Landed so far:
+  `brace-expansion` 5.0.6 → 5.0.7 (dev-only transitive, PR #1374 /
+  `a386a624`, re-recorded in HIMMEL-1262). Dependabot does NOT run
+  `check-hud-drift.sh --write`, so each such bump needs a follow-up pin re-record
+  commit (`--write`, then commit `VENDORED.md` + `VENDORED.manifest`) or every
+  contributor commit trips the pre-commit drift gate. `pinned_commit` /
+  `pinned_upstream_tree` / `vendored_at` stay UNCHANGED for these — they record
+  the upstream base, and a bump is not a re-vendor.
+
+  **Re-vendor rule for these bumps — do NOT blindly take upstream's lockfile.**
+  A re-vendor supersedes a bump listed here ONLY when the incoming upstream
+  lockfile pins the same version or newer. If upstream is still behind (e.g.
+  upstream at `brace-expansion` 5.0.6 while the entry below records 5.0.7),
+  taking upstream's lockfile wholesale DOWNGRADES a patched dependency, and
+  re-recording the pin afterwards would bless that regression — the drift guard
+  hashes the tree for self-consistency and cannot tell a downgrade from any
+  other change. Re-apply the bump on top of the re-vendored tree instead
+  — lockfile-ONLY, so a dev-only transitive package does not become a direct
+  dependency:
+
+  ```sh
+  # in marketplace/plugins/claude-hud/
+  npm update <pkg> --package-lock-only --ignore-scripts
+  git diff --exit-code package.json   # MUST be unchanged
+  # then confirm the resolved version + integrity moved to the recorded floor
+  ```
+
+  (`npm install <pkg>@<ver>` is the WRONG tool here — it writes the package into
+  `package.json` `dependencies`, and the follow-up `--write` would bless that as
+  a vendored delta.) Then `--write`. Only strike an entry from the list once
+  upstream has actually caught up.
+
+  This rule is prose, not an enforced gate: `check-hud-drift.sh` hashes the tree
+  for self-consistency and has no notion of a version floor, so a re-vendor that
+  downgrades still passes if the reviewer misses it. Machine-enforcing the floor
+  is tracked separately (HIMMEL-1264).

--- a/templates/luna-second-brain/scripts/test-vault-git.sh
+++ b/templates/luna-second-brain/scripts/test-vault-git.sh
@@ -196,7 +196,12 @@ else
     "$(git_in "$VC" ls-tree -r HEAD --name-only | grep -c 'proxy-token\.md' || true)"
 
   d8_before=$(git_in "$VC" rev-parse HEAD)
-  printf 'curl -H "Authorization: Bearer himmel-local-claudex-extra"\n' >"$VC/30-Resources/proxy-token-extra.md"
+  # Keep the near-miss token OUT of the format string: inlined, this line is
+  # itself a curl-auth-header hit, and the vault's own .gitleaks.toml allowlists
+  # only the exact (anchored) constant — so the harness would block every
+  # post-/luna-upgrade vault commit (public issue #510). Passing it as a printf
+  # ARGUMENT writes byte-identical fixture content without tripping the rule.
+  printf 'curl -H "Authorization: Bearer %s"\n' 'himmel-local-claudex-extra' >"$VC/30-Resources/proxy-token-extra.md"
   # Capture the output so the block can be attributed to the SECRET SCANNER, not
   # an unrelated hook/setup failure that also exits non-zero (CR #1239). autosync
   # runs `git commit` without muting the hooks, so gitleaks' own "leaks found"


### PR DESCRIPTION
Two independent fixes, both surfaced from the public side.

## 1. `fix(HIMMEL-1263)` — closes #510

`templates/luna-second-brain` v0.3.0 ships `scripts/test-vault-git.sh`. Its D8 fixture
line inlined a full bearer header, and the template's own `.gitleaks.toml` allowlists
only the exact anchored constant (`^himmel-local-claudex$`) — so the **suffixed**
near-miss on line 199 was itself a `curl-auth-header` hit. Any vault that ran
`/luna-upgrade` to v0.3.0 then could not commit the upgrade: the `gitleaks` pre-commit
hook blocked on a template-owned file. Reported by @Goomal.

Fix: pass the token as a `printf` **argument** instead of inlining it in the format
string, plus a comment so a future edit does not re-inline the literal.

```diff
-  printf 'curl -H "Authorization: Bearer himmel-local-claudex-extra"\n' >"$VC/…"
+  printf 'curl -H "Authorization: Bearer %s"\n' 'himmel-local-claudex-extra' >"$VC/…"
```

Deliberately **not** the fix the issue proposes (allowlisting
`scripts/test-vault-git\.sh` in the template's `.gitleaks.toml`). That works, but it
blanket-exempts a 17 KB harness from secret scanning forever — and `.gitleaks.toml` is
WRITE-class in `upgrade.sh`, which is exactly why the reporter's local workaround is not
durable. Fixing the fixture needs no config change at all, so there is nothing for
`/luna-upgrade` to overwrite.

Verified A/B against the pinned gitleaks using the template's own `.gitleaks.toml`:
before = `leaks found: 1` at line 199, after = `no leaks found`. Generated fixture bytes
`cmp`-identical between the old and new `printf` forms, so D8 still asserts exactly what
it asserted before. `bash -n` clean. The anchored allowlist regex is unchanged.

## 2. `chore(HIMMEL-1262)` — vendored claude-hud pin re-record

Dependabot bumped `brace-expansion` 5.0.6 → 5.0.7 inside the vendored
`marketplace/plugins/claude-hud/package-lock.json`, but Dependabot does not run the
drift-guard re-record — so `VENDORED.manifest` + `VENDORED.md` kept the hashes from the
last re-vendor (upstream `e39bafc`) and every contributor commit tripped the local
`hud-drift` pre-commit gate.

Re-recorded via `check-hud-drift.sh --write`. The vendored tree is **not** reverted: the
bump is the desired state and the only delta vs the recorded pin. `pinned_commit` /
`pinned_upstream_tree` / `vendored_at` are untouched — a bump is not a re-vendor.

`VENDORED.md` also gains the provenance the drift exposed: dependabot lockfile bumps are
now a named delta class, `vendored_tree_hash` is documented as a self-consistency hash
(not a claim of equality with `pinned_upstream_tree`), and the re-vendor rule now forbids
taking an upstream lockfile that would **downgrade** a recorded security bump — with a
lockfile-only re-apply recipe (`npm update <pkg> --package-lock-only --ignore-scripts`,
`package.json` unchanged). Machine-enforcing that floor is tracked separately.

## Review

Both changes went through the full cross-model CR matrix: critic panel 2/2 responded
0/0/0, codex adversarial → approve, CodeRabbit → clean (the one `minor` CodeRabbit
finding on the manifest was disproved: it reports `package-lock.json` as dangling, but
the file is present and tracked at exactly the recorded hash).
