### PR TITLE
chore: bump graphify pin 0.9.23 -> 0.9.25 (closes #511)

### DIFF
--- a/scripts/lib/graphify-bin.sh
+++ b/scripts/lib/graphify-bin.sh
@@ -3,7 +3,12 @@
 #
 # Resolver for the graphify CLI. graphify is a knowledge-graph tool distributed
 # via PyPI as `graphifyy` (binary name `graphify`, upstream Graphify-Labs/graphify,
-# MIT). This resolver installs it from PyPI pinned to a specific version via
+# Apache-2.0 as of v0.9.25 -- MIT through v0.9.24; upstream keeps the historical MIT
+# text in LICENSE-MIT for pre-relicense contributions and references it from NOTICE).
+# himmel neither vendors nor redistributes graphify -- `uv tool install` fetches it
+# from PyPI onto the operator's own machine -- so the relicense carries no bundled-
+# notice obligation here; it is a pin-review fact, not a compliance gate.
+# This resolver installs it from PyPI pinned to a specific version via
 # `uv tool install --with mcp graphifyy==<version>`. uv tool installs are already
 # self-isolating (their own venv + a shim in uv's tool bin dir), so — unlike
 # scripts/lib/qmd-bin.sh's bun-global junction — there is no separate PATH-provider
@@ -45,7 +50,7 @@
 # (HIMMEL-891) -- without carrying a fork. A pin bump is a reviewed change to this
 # line, paired with `synced_base` in scripts/upstreams.json so the nightly
 # fork-drift guard stays truthful.
-_graphify_version() { printf '%s\n' "${GRAPHIFY_VERSION:-0.9.23}"; }
+_graphify_version() { printf '%s\n' "${GRAPHIFY_VERSION:-0.9.25}"; }
 _graphify_pypi_name() { printf '%s\n' "graphifyy"; }
 # The `uv tool install` package spec: `graphifyy==<version>`.
 _graphify_pinned_source() { printf '%s==%s\n' "$(_graphify_pypi_name)" "$(_graphify_version)"; }

--- a/scripts/upstreams.json
+++ b/scripts/upstreams.json
@@ -44,7 +44,7 @@
       "kind": "tag_release",
       "mode": "base",
       "tracked_repo": "Graphify-Labs/graphify",
-      "synced_base": "0.9.23",
+      "synced_base": "0.9.25",
       "latest_source": "release",
       "tier": "A",
       "note": "Upstream PyPI graphifyy, version-pinned in scripts/lib/graphify-bin.sh (_graphify_version). DE-FORKED from yotamleo/graphify in HIMMEL-1048 / issue #469: the fork carried ZERO delta over upstream (its only purpose — declaring the mcp dep, which upstream keeps optional — is handled by the `--with mcp` install flag), so himmel tracks upstream directly. tracked_repo is the TRUE upstream (Graphify-Labs). synced_base = the pinned upstream release. latest_source=release because upstream tags are NON-MONOTONIC: a stale v1.0.0 (2026-04) predates the current v0.9.x line, so highest-semver-tag would report a permanent phantom BEHIND; the Releases API returns the real latest. BEHIND here means: bump _graphify_version in graphify-bin.sh to the new release AND bump synced_base here (a reviewed one-line pair — no fork rebase)."


### PR DESCRIPTION
## What

Bump the pinned graphify version `0.9.23` → `0.9.25` (upstream `Graphify-Labs/graphify` current release, published 2026-07-22), plus a header-comment license correction.

- `scripts/lib/graphify-bin.sh` — `_graphify_version()` default `0.9.23` → `0.9.25`
- `scripts/upstreams.json` — graphify `synced_base` `"0.9.23"` → `"0.9.25"`
- `scripts/lib/graphify-bin.sh` (comment-only) — the header's `MIT` parenthetical → Apache-2.0 as of v0.9.25, with the redistribution-scope note

The first two lines are the reviewed pair documented in the `graphify-bin.sh` header (`BEHIND` = bump `_graphify_version` **and** `synced_base`). No fork rebase — graphify is de-forked and tracks upstream PyPI directly.

## Why

Clears the nightly fork-drift `BEHIND` signal — closes #511, which auto-closes on the next nightly run once this lands.

`latest_source=release` stays load-bearing: upstream tags are non-monotonic (a stale `v1.0.0` from 2026-04 predates the current v0.9.x line), so the Releases API — not highest-semver-tag — is the source of truth.

## License note

The cross-model review pass flagged the header's `MIT` claim as stale at the new pin. Verified against PyPI metadata: `graphifyy` 0.9.24 is MIT; 0.9.25 declares `license_expression: Apache-2.0` with `license_files: [LICENSE, LICENSE-MIT, NOTICE]`, and the upstream v0.9.25 release notes state the relicense explicitly (MIT text retained in `LICENSE-MIT` for pre-relicense contributions). The relicense landed exactly at 0.9.25.

Scope: himmel neither vendors nor redistributes graphify — `uv tool install` fetches it from PyPI onto the operator's own machine — so no bundled-notice obligation arises here.

## Verification

- `scripts/lib/test-graphify-bin.sh` 70/0 pass
- `scripts/test-check-plugin-drift.sh` all checks passed
- `scripts/upstreams.json` valid JSON
- real `check-plugin-drift.sh` now reads `graphify: CURRENT (installed 0.9.25 = Graphify-Labs/graphify latest tag)`

Closes #511
