### PR TITLE
docs(HIMMEL-1267): configuration doc follow-ups + js-yaml bump (HIMMEL-1268)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,9 +96,10 @@ JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian tenant cloud id (
 #   scripts/cr/critic-panel.sh -- prefer ZAI_API_KEY)
 # OMNIROUTE_API_KEY=your_omniroute_key_here # claude-routed launcher
 # CLIPROXY_API_KEY=your_cliproxy_key_here   # claudex lane (scripts/claude-codex)
-#   The launcher bridges it from THIS .env via load_dotenv --root, pinned to the
-#   himmel checkout -- so it works from any CWD (never settings.json, per the
-#   block note above). The value must match an `api-keys` entry in
+#   TOOL-LOADED like the other launcher keys in this block: the launcher reads
+#   it from THIS .env via load_dotenv --root, pinned to the himmel checkout --
+#   so it works from any CWD; a live-env value wins (never settings.json, per
+#   the block note above). The value must match an `api-keys` entry in
 #   ~/.cli-proxy-api/config.yaml (the local cli-proxy-api the lane talks to);
 #   see the error text in scripts/claude-codex if the lane refuses to start.
 # Launcher tuning (LIVE env of the shell running the launcher; NOT read from

--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,9 @@
 #      injects that block into every session). A value sitting ONLY in this .env
 #      is never seen by most of them. (Exceptions, bridged from .env by
 #      scripts/lib/load-dotenv.sh: HANDOVER_DIR and USER_SLUG always; CR_PROFILE
-#      + CR_CLAUDE_AGENTS by /pr-check itself (HIMMEL-558/926); and the SessionStart/SessionEnd hooks
+#      + CR_CLAUDE_AGENTS by /pr-check itself (HIMMEL-558/926);
+#      CR_REQUIRE_CROSS_MODEL by scripts/cr/clear-cr-marker.sh (HIMMEL-1237);
+#      HIMMEL_UPDATE_AUTOSTASH by scripts/himmel-update.sh (HIMMEL-1205); and the SessionStart/SessionEnd hooks
 #      read the HIMMEL_INITIATIVE* set, HIMMEL_WHERE_ARE_WE +
 #      HIMMEL_WHERE_ARE_WE_STALE_HOURS (NOT the statusline-only _ROLLUP_TTL /
 #      _SEG_TIMEOUT knobs -- those are live-env only), HIMMEL_DOC_FRESHNESS,
@@ -28,6 +30,15 @@
 #   set in the shell that LAUNCHES claude and are never read from this file --
 #   inventoried in the SESSION-ONLY section near the bottom so every operator
 #   flag is discoverable in one place.
+#
+#   NOT listed on purpose (test seams / advanced overrides, not operator knobs):
+#   CODERABBIT_BIN + CODERABBIT_WSL (scripts/cr/coderabbit-review.sh test seams)
+#   and HIMMEL_STATUSLINE_SEGMENT (scripts/where-are-we/statusline.sh test seam);
+#   QMD_FORK_REPO / QMD_FORK_REF / QMD_FORK_MIN_VERSION (qmd fork pin overrides
+#   -- the certified defaults in scripts/lib/qmd-bin.sh ARE the point);
+#   CR_STATUS_CONTEXT (renames the commit-status context scripts/lib/cr-signal.sh
+#   reads, default "CodeRabbit"); HIMMEL_DOCTOR_ISSUE_REPO (flag-equivalent:
+#   /himmel-doctor --repo).
 #
 # setup.sh / adopt.sh AUTO-SET HIMMEL_REPO for you (it is the himmel clone path,
 # which the installer knows) into ~/.claude/settings.json. Run setup/adopt with
@@ -84,6 +95,12 @@ JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian tenant cloud id (
 #   (legacy alias spellings GLM_API_KEY / Z_AI_API_KEY are still accepted by
 #   scripts/cr/critic-panel.sh -- prefer ZAI_API_KEY)
 # OMNIROUTE_API_KEY=your_omniroute_key_here # claude-routed launcher
+# CLIPROXY_API_KEY=your_cliproxy_key_here   # claudex lane (scripts/claude-codex)
+#   The launcher bridges it from THIS .env via load_dotenv --root, pinned to the
+#   himmel checkout -- so it works from any CWD (never settings.json, per the
+#   block note above). The value must match an `api-keys` entry in
+#   ~/.cli-proxy-api/config.yaml (the local cli-proxy-api the lane talks to);
+#   see the error text in scripts/claude-codex if the lane refuses to start.
 # Launcher tuning (LIVE env of the shell running the launcher; NOT read from
 # this file):
 #   GLM_MODEL / GLM_CONTEXT_WINDOW   claude-glm model + context pin (default glm-5.2 / 1M)
@@ -99,7 +116,8 @@ JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian tenant cloud id (
 
 # === SECTION: PROCESS-ENV ===  read from the LIVE env -- EXPORT these (shell or
 #     ~/.claude/settings.json "env" {}); a value ONLY in .env is NOT read, except
-#     the load-dotenv-bridged vars (HANDOVER_DIR, USER_SLUG, CR_PROFILE, CR_CLAUDE_AGENTS, and the
+#     the load-dotenv-bridged vars (HANDOVER_DIR, USER_SLUG, CR_PROFILE,
+#     CR_CLAUDE_AGENTS, CR_REQUIRE_CROSS_MODEL, and the
 #     HIMMEL_INITIATIVE* / HIMMEL_WHERE_ARE_WE(+_STALE_HOURS) /
 #     HIMMEL_DOC_FRESHNESS / HIMMEL_WORKTREE_NUDGE / HIMMEL_JIRA_NUDGE /
 #     HIMMEL_UPDATE_AUTOSTASH set)
@@ -217,6 +235,19 @@ JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian tenant cloud id (
 # e.g. after the CodeRabbit trial lapses). Bridged from this .env by /pr-check
 # like CR_PROFILE; a live-env value wins.
 # CR_CLAUDE_AGENTS=1
+# Opt-in cross-model floor (HIMMEL-1237). Default OFF: when every external
+# critic lane is ABSENT, /pr-check's own claude-only diff review is the floor
+# and the CR marker clears on it. Set 1 to make that floor INSUFFICIENT:
+# scripts/cr/clear-cr-marker.sh gate 3b then also requires >=1 non-Claude
+# critic (codex/glm/CodeRabbit) "avail ... ok" at the SHA before the marker
+# clears. BRIDGED from this .env by clear-cr-marker.sh itself (load_dotenv);
+# a live-env value wins.
+# CR_REQUIRE_CROSS_MODEL=1
+# Public-mirror pin (LIVE env only -- read where the public merge chokepoints
+# run: scripts/merge-public-on-green.sh, the Telegram /mergepub path, and
+# /cr-public). Default yotamleo/Himmel -- set to YOUR public mirror when using
+# the public propagation flow.
+# CR_PUBLIC_REPO=owner/name
 # Panel tuning (LIVE env only -- NOT bridged from this file):
 #   CRITIC_TIMEOUT_SECS=240   per-critic wall-clock timeout (default 240, HIMMEL-558)
 #   CRITIC_PARALLEL=1         run panel members concurrently (default 0 = sequential)
@@ -256,7 +287,9 @@ JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian tenant cloud id (
 # Luna vault root for end-session-wiki capture (global default). The SessionEnd
 # hook writes a note per session into <vault>/sessions/. Unset -> ~/Documents/luna.
 # A per-repo .claude/end-session-wiki.json "vault_path" overrides this for that
-# repo. NOT bridged -- a value in .env is ignored; EXPORT it. See
+# repo. NOT bridged for this hook (or any other consumer) -- EXPORT it. Sole
+# exception: scripts/himmel-update.sh bridges LUNA_VAULT_PATH from this .env
+# for its luna-template upgrade step, so `himmelctl update` sees it. See
 # docs/luna/end-session-wiki.md ("Choosing the target vault").
 # LUNA_VAULT_PATH=/c/path/to/your/obsidian-vault
 # End-session-wiki opt-out: 0/false disables the SessionEnd capture hook.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -320,16 +320,24 @@ Minimum config: nothing is strictly required — `USER_SLUG` is recommended
 only if you use Jira. Everything else in this section is opt-in.
 
 The tables below organize every operator-meaningful knob by what it controls.
-"Set in" uses: `.env` (tool-loaded), `.env†` (bridged exception — `.env`
-works), `env` (live environment: export, or `settings.json` `"env"` block),
-`shell` (launching shell only), `own .env` (the external tool's file).
+"Set in" uses: `.env` (tool-loaded), `.env` (bridged), `env` (live
+environment: export, or `settings.json` `"env"` block), `shell` (launching
+shell only), `own .env` (the external tool's file).
+
+`.env` (bridged) marks the exceptions to the PROCESS-ENV trap: the reader is
+a script that consumes the **live environment**, but it explicitly bridges
+that key from the primary checkout's `.env` via `scripts/lib/load-dotenv.sh`
+before reading — so a value sitting only in `.env` IS picked up, while a
+live-env value (shell export or `settings.json` `"env"`) still wins. The
+bridged set is inventoried in [`.env.example`](../.env.example)'s header, and
+each bridged var's own comment there names its bridging reader.
 
 **Identity, handover, Jira & forge**
 
 | Knob | Default | Set in | Read by |
 |---|---|---|---|
-| `USER_SLUG` | slugified `git user.name` | `.env†` | handover bucket + worktree naming (`scripts/lib/user-slug.sh`) |
-| `HANDOVER_DIR` | inline `<repo>/handovers/` | `.env†` | `scripts/lib/handover-path.sh` — external handover state repo (Mode B) |
+| `USER_SLUG` | slugified `git user.name` | `.env` (bridged) | handover bucket + worktree naming (`scripts/lib/user-slug.sh`) |
+| `HANDOVER_DIR` | inline `<repo>/handovers/` | `.env` (bridged) | `scripts/lib/handover-path.sh` — external handover state repo (Mode B) |
 | `HANDOVER_DIRECT_MAIN` / `HANDOVER_PR_AUTO` / `HANDOVER_PR_BASE` | branched-PR flow ON | env | handover PR flow (`.claude/commands/handover-pr-open.md`) |
 | `JIRA_BASE_URL` / `JIRA_EMAIL` / `JIRA_API_TOKEN` / `JIRA_PROJECT_KEY` | — | `.env` | the Jira CLI (`scripts/jira/`); these four are all it needs — no cloud ID |
 | `JIRA_PROJECTS`, `JIRA_BOARD_ID`, `JIRA_SEVERITY_FIELD`, `JIRA_CLOUD_ID` | optional | `.env` | Jira CLI extras; `JIRA_CLOUD_ID` only for the optional Atlassian MCP |
@@ -341,9 +349,9 @@ works), `env` (live environment: export, or `settings.json` `"env"` block),
 
 | Knob | Default | Set in | Effect |
 |---|---|---|---|
-| `CR_PROFILE` | unset (see Effect) | `.env†` | which critic tier `/pr-check` runs. `none` = claude-only, panel skipped — the guaranteed no-external-spend setting. Unset → tier `free`, which (with no free critic row in `scripts/cr/critics.json` today) falls back to the paid codex anchor *where that lane is configured* — a lane without its key/CLI can't run and fails open. Note: a lane key configured for *any* purpose (e.g. `CLIPROXY_API_KEY` for claudex delegation) makes the paid anchor runnable — set `CR_PROFILE=none` if you want delegation without paid review critics |
-| `CR_CLAUDE_AGENTS` | OFF | `.env†` | opt-in Claude-agent reviewer fan-out inside `/pr-check` |
-| `CR_REQUIRE_CROSS_MODEL` | OFF | env | require ≥1 non-Claude critic verdict before the CR marker clears |
+| `CR_PROFILE` | unset (see Effect) | `.env` (bridged) | which critic tier `/pr-check` runs. `none` = claude-only, panel skipped — the guaranteed no-external-spend setting. Unset → tier `free`, which (with no free critic row in `scripts/cr/critics.json` today) falls back to the paid codex anchor *where that lane is configured*. A lane without its key/CLI can't run and fails open — open onto the **mandatory claude-only floor**, never onto "no review": when every cross-model critic is absent or produced nothing, `/pr-check` performs the full diff review itself and the gate still requires that recorded review to clear (`scripts/cr/critic-panel.sh` exit contract — all critics failed → caller falls back claude-only; the backstop + HIMMEL-1224 hatch invariants live in `.claude/commands/pr-check.md` step 3.5). So "no codex" = a Claude self-review, not zero CR. The fail-open is for **absent** lanes only — a lane that *ran* and errored records `unavailable`, and if that failed attempt is the sole evidence at the HEAD the gate stays closed (`scripts/cr/clear-cr-marker.sh` exit 14). To make the Claude-alone floor *insufficient*, set `CR_REQUIRE_CROSS_MODEL` (two rows down). Note: a lane key configured for *any* purpose (e.g. `CLIPROXY_API_KEY` for claudex delegation) makes the paid anchor runnable — set `CR_PROFILE=none` if you want delegation without paid review critics |
+| `CR_CLAUDE_AGENTS` | OFF | `.env` (bridged) | opt-in Claude-agent reviewer fan-out inside `/pr-check` |
+| `CR_REQUIRE_CROSS_MODEL` | OFF | `.env` (bridged) | opt-in cross-model floor (HIMMEL-1237): require ≥1 non-Claude critic `avail … ok` at the SHA before the CR marker clears — makes the claude-only floor above insufficient. Bridged from `.env` by `scripts/cr/clear-cr-marker.sh` itself (gate 3b); a live-env value wins |
 | `CRITIC_TIMEOUT_SECS` / `CRITIC_PARALLEL` / `CRITIC_PANEL_TIERS` / `CR_TRIVIALITY_OVERRIDE` / `CODERABBIT_TIMEOUT_SECS` / `CR_USAGE_LOG` | 240s / sequential / `free` / heuristic / 900s / off | env | panel cost/scope tuning (`scripts/cr/critic-panel.sh`, `.claude/commands/pr-check.md`) |
 | `scripts/cr/critics.local.json` | — | file (gitignored) | per-machine critic overlay; `"drop": true` removes a base row |
 | `ARMAUTOMERGE` | OFF | env | arms `merge-on-green.sh` (private auto-merge — full condition list in [§3.3](#33-merge--publish-gates)) |
@@ -375,8 +383,8 @@ default subset:
 
 | Knob | Default | Set in | Effect |
 |---|---|---|---|
-| `HIMMEL_INITIATIVE` | OFF | `.env†` | interactive-profile leg set (above) |
-| `HIMMEL_OVERNIGHT` + `HIMMEL_INITIATIVE_OVERNIGHT` | OFF | `.env†` | switches to the overnight profile + its leg set |
+| `HIMMEL_INITIATIVE` | OFF | `.env` (bridged) | interactive-profile leg set (above) |
+| `HIMMEL_OVERNIGHT` + `HIMMEL_INITIATIVE_OVERNIGHT` | OFF | `.env` (bridged) | switches to the overnight profile + its leg set |
 | `OVERNIGHT_PROJECT` / `OVERNIGHT_STATUS` / `OVERNIGHT_LIMIT` / `OVERNIGHT_PRIORITY` | `HIMMEL` / `To Do,In Progress` / 5 / `key-desc` | env | `/overnight-shift` ticket-plan defaults (`scripts/overnight/build-plan.sh`) |
 | `OVERNIGHT_STOP_DIR` | `~/.claude` | env | where the `/stop` halt marker lives (`scripts/overnight/stop-marker.sh`) |
 
@@ -428,31 +436,31 @@ change; token and access config live *outside* the repo):
 | `BRIDGE_ROOT` | `~/.claude/handover/bridge` | env | bridge session-state root |
 | `CR_PUBLIC_REPO` | `yotamleo/Himmel` | env | the pinned public repo `/mergepub` may merge into |
 | `TELEGRAM_OWN_POLLER` / `HIMMEL_MCP_TELEGRAM` | OFF | shell | opt a Claude session into the vendored telegram plugin (poll-owner / send-only). Never run both the plugin poller and the bun bridge — one `getUpdates` consumer per token |
-| `TELEGRAM_CHAT_ID` / `TELEGRAM_GROUP_CHAT_ID` | unset (silent no-op) | `.env†` | targets for the opt-in jira-nudge and session-status relays |
+| `TELEGRAM_CHAT_ID` / `TELEGRAM_GROUP_CHAT_ID` | unset (silent no-op) | `.env` (bridged) | targets for the opt-in jira-nudge and session-status relays |
 
 **Session nudges & ambient context** (all advisory, all default-OFF except
 the statusline segment):
 
 | Knob | Default | Set in | Effect |
 |---|---|---|---|
-| `HIMMEL_WHERE_ARE_WE` | ON for the statusline segment, OFF for the SessionStart inject (split polarity — noted in `.env.example`) | `.env†` | repo-state digest surfacing |
-| `HIMMEL_WHERE_ARE_WE_STALE_HOURS` / `_ROLLUP_TTL` / `_SEG_TIMEOUT` | 6h / 900s / 5s | `.env†` / env / env | staleness + refresh tuning |
-| `HIMMEL_DOC_FRESHNESS` | OFF | `.env†` | doc-freshness advisories (`advise,session,morning` subset) |
-| `HIMMEL_WORKTREE_NUDGE` / `HIMMEL_JIRA_NUDGE` | OFF | `.env†` | worktree-before-edit nudge / "you never touched Jira" SessionEnd relay |
+| `HIMMEL_WHERE_ARE_WE` | ON for the statusline segment, OFF for the SessionStart inject (split polarity — noted in `.env.example`) | `.env` (bridged) | repo-state digest surfacing |
+| `HIMMEL_WHERE_ARE_WE_STALE_HOURS` / `_ROLLUP_TTL` / `_SEG_TIMEOUT` | 6h / 900s / 5s | `.env` (bridged) / env / env | staleness + refresh tuning |
+| `HIMMEL_DOC_FRESHNESS` | OFF | `.env` (bridged) | doc-freshness advisories (`advise,session,morning` subset) |
+| `HIMMEL_WORKTREE_NUDGE` / `HIMMEL_JIRA_NUDGE` | OFF | `.env` (bridged) | worktree-before-edit nudge / "you never touched Jira" SessionEnd relay |
 | `UPDATE_CHECK_INTERVAL` | 4h | env | SessionStart update-check throttle |
 
 **Vault & misc**
 
 | Knob | Default | Set in | Effect |
 |---|---|---|---|
-| `LUNA_VAULT_PATH` | `~/Documents/luna` | env (not bridged) | which vault the luna tooling targets |
+| `LUNA_VAULT_PATH` | `~/Documents/luna` | env (bridged for one reader only: `/himmel-update`'s luna-template step, `scripts/himmel-update.sh`) | which vault the luna tooling targets |
 | `CLAUDE_END_SESSION_WIKI` | unset | env | `0` disables the SessionEnd vault capture hook |
 | `OBSIDIAN_API_KEY` | unset (on-disk fallback works) | `.env` | Obsidian REST plugin access |
 | `PERPLEXITY_API_KEY` / `XAI_API_KEY` / `DASHSCOPE_API_KEY` | blank = feature off | `.env` | research/x-read skills, fleet-control providers |
 | `SKILL_INDEX_DIR`, `SKILL_TELEMETRY_DISABLE`/`_DIR` | `~/.claude/skill-index` / on | env / shell | skill index + telemetry |
 | `ubuntu_vm_user`/`ubuntu_vm_pass`, `windows_vm_user`/`windows_vm_pass` | — | `.env` | test-VM credentials (deliberately lower-case names) |
 | `HIMMEL_REPO` | auto-resolved | env | pin the himmel checkout used by `/himmel-update` and the hooks' `.env` bridge |
-| `HIMMEL_UPDATE_AUTOSTASH` | OFF | `.env†` | let `/himmel-update` stash a dirty checkout |
+| `HIMMEL_UPDATE_AUTOSTASH` | OFF | `.env` (bridged) | let `/himmel-update` stash a dirty checkout |
 
 ### 4.2 Claude Code settings & hooks
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -453,7 +453,7 @@ the statusline segment):
 
 | Knob | Default | Set in | Effect |
 |---|---|---|---|
-| `LUNA_VAULT_PATH` | `~/Documents/luna` | env (bridged for one reader only: `/himmel-update`'s luna-template step, `scripts/himmel-update.sh`) | which vault the luna tooling targets |
+| `LUNA_VAULT_PATH` | `~/Documents/luna` | env | which vault the luna tooling targets. Exception: `/himmel-update`'s luna-template step (`scripts/himmel-update.sh`) bridges it from `.env` — every other reader needs a live-env value |
 | `CLAUDE_END_SESSION_WIKI` | unset | env | `0` disables the SessionEnd vault capture hook |
 | `OBSIDIAN_API_KEY` | unset (on-disk fallback works) | `.env` | Obsidian REST plugin access |
 | `PERPLEXITY_API_KEY` / `XAI_API_KEY` / `DASHSCOPE_API_KEY` | blank = feature off | `.env` | research/x-read skills, fleet-control providers |

--- a/marketplace/plugins/obsidian-triage/tools/package-lock.json
+++ b/marketplace/plugins/obsidian-triage/tools/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "5.2.1",
+        "js-yaml": "5.2.2",
         "playwright": "1.61.1"
       },
       "engines": {
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "funding": [
         {
           "type": "github",

--- a/marketplace/plugins/obsidian-triage/tools/package.json
+++ b/marketplace/plugins/obsidian-triage/tools/package.json
@@ -21,7 +21,7 @@
     "score:judge-prep": "bun follow-list-score.mjs judge-prep"
   },
   "dependencies": {
-    "js-yaml": "5.2.1",
+    "js-yaml": "5.2.2",
     "playwright": "1.61.1"
   }
 }


### PR DESCRIPTION
## Summary

Propagates two private merges:

**HIMMEL-1267** (priv #1383) — follow-ups to the canonical configuration doc (#514):
- `docs/configuration.md`: the bridged-key marker is now `` `.env` (bridged) `` (the in-span `.env†` read as a typo), with a legend paragraph stating the real mechanism — PROCESS-ENV class, bridged from the primary checkout's `.env` by `scripts/lib/load-dotenv.sh`, live env wins. The `CR_PROFILE` row now states the mandatory claude-only review floor (an unconfigured lane fails open onto a full Claude self-review, never "no review") and distinguishes absence from attempted-but-failed; `CR_REQUIRE_CROSS_MODEL` reconciled to the bridged set-in class per `clear-cr-marker.sh:175`; `LUNA_VAULT_PATH`'s single bridged reader (`scripts/himmel-update.sh` luna-template step) documented.
- `.env.example`: `CLIPROXY_API_KEY`, `CR_REQUIRE_CROSS_MODEL`, `CR_PUBLIC_REPO` added with consumer citations; deliberately excluded test-seam/override vars named in the header so the "complete" claim stays honest; header bridged lists reconciled.

**HIMMEL-1268** (priv #1382) — `js-yaml` 5.2.1 → 5.2.2 in `marketplace/plugins/obsidian-triage/tools` (GHSA-pm4m-ph32-ghv5, HIGH, exponential parsing DoS; the advisory blocked the repo-wide pre-push npm-audit gate).

## Verification

- Every doc claim carries file:line backing; two adversarial verify sub-agents attempted refutation of each claim (one refutation found and fixed — the LUNA_VAULT_PATH bridging contradiction).
- Private CR clean at both heads (critic panel codex+glm, codex adversarial, CodeRabbit CLI).
- `bash scripts/hooks/check-npm-audit.sh` passes post-bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified configuration guidance for environment variables, including which settings are bridged into operational scripts.
  - Added details about cross-model review requirements, configuration availability, fallback behavior, and gate conditions.
  - Expanded notes for the offload-lane API key and clarified vault path usage and exceptions.
  - Updated configuration tables for identity, handover, initiative, Telegram, relay, and review settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->