### PR TITLE
fix: /end-session-wiki-setup GLOBAL wires ~/.claude/settings.json, not the repo .env

### DIFF
--- a/.claude/commands/end-session-wiki-setup.md
+++ b/.claude/commands/end-session-wiki-setup.md
@@ -7,7 +7,7 @@ Point the `end-session-wiki` SessionEnd hook (`scripts/hooks/end-session-wiki.{s
 
 1. per-repo `.claude/end-session-wiki.json` **`vault_path`** (absolute)
 2. per-repo `.claude/end-session-wiki.json` **`vault`** NAME → operator registry `~/.claude/luna-vaults.json` → else convention `~/Documents/<name>` (must contain an `.obsidian/` marker)
-3. global **`LUNA_VAULT_PATH`** env
+3. global **`LUNA_VAULT_PATH`** env — read from the **live process environment**, so it must come from `~/.claude/settings.json`'s `env` block or your shell profile. The repo-root `.env` is **not** bridged for this hook; a value written there is never seen.
 4. default — the `luna` entry in `~/.claude/luna-vaults.json` if present, else **`~/Documents/luna`**
 
 A leading `~/` is expanded. An invalid/unresolvable `vault` name, or a config that isn't a valid JSON object, **fails closed** (skips the capture, never misroutes). Full options + examples: [`docs/luna/end-session-wiki.md`](../../docs/luna/end-session-wiki.md) ("Choosing the target vault").
@@ -19,7 +19,7 @@ Run this from the **code repo** whose sessions you want captured. Be idempotent 
 1. **Ask how to target the vault** — three choices:
    - **BY-NAME (recommended, distributable)** — best when the config is committed/shared (the same repo on another machine still works). You configure a *name*; each machine resolves it to a path. Go to step 2a.
    - **BY-PATH (this repo, absolute)** — a concrete absolute path for *this* repo only. Machine-specific, so don't commit it if the repo is shared. Go to step 2b.
-   - **GLOBAL (every repo)** — your default vault for all repos via `LUNA_VAULT_PATH`. Go to step 2c.
+   - **GLOBAL (every repo)** — your default vault for all repos via `LUNA_VAULT_PATH`, persisted in `~/.claude/settings.json`'s `env` block. Go to step 2c.
 
 2a. **By name.**
    - Ask for the **vault name** (e.g. `salus`). Validate: 1–64 chars, `[A-Za-z0-9._-]`, must start alphanumeric, no `/` or `..`. Reject otherwise.
@@ -29,7 +29,44 @@ Run this from the **code repo** whose sessions you want captured. Be idempotent 
 
 2b. **By path (this repo only).** Ask for the absolute path (default `~/Documents/luna`); expand a leading `~/`; validate the dir exists and contains `.obsidian/` — if not, report and stop. Merge `"vault_path": "<path>"` into `.claude/end-session-wiki.json`, preserving existing keys: `jq '. + {vault_path: $p}' --arg p "<path>"`. Create as `{ "vault_path": "<path>" }` if absent.
 
-2c. **Global.** Ask for the absolute path (default `~/Documents/luna`); expand + validate as in 2b. Write `LUNA_VAULT_PATH=<path>` to the repo-root `.env`: replace an existing `LUNA_VAULT_PATH=` line (commented or not) or append. Don't disturb other keys.
+2c. **Global.** Ask for the absolute path (default `~/Documents/luna`); expand + validate as in 2b. Persist the **expanded** path as `env.LUNA_VAULT_PATH` in the user settings file `~/.claude/settings.json` — that is the process-env mechanism the resolver reads (step 3 above). Do **not** write it to the repo-root `.env`: that file is not bridged for this hook, so the hook would never see it (`.env.example` says so, and it's the wrong scope anyway — `.env` is per-repo, this tier is every repo).
+
+   Use the existing helper rather than hand-editing the JSON — it is idempotent, atomic (temp + `mv`), and preserves every other key (`HIMMEL_REPO`, `statusLine`, …); it refuses to overwrite a settings file that isn't valid JSON. Resolve the himmel checkout first, since this command runs from *your* code repo:
+
+   ```bash
+   # Resolve the himmel checkout: $HIMMEL_REPO -> canonical install paths -> error.
+   # NOTE: deliberately NO `git rev-parse --show-toplevel` fallback, unlike
+   # /himmel-update's otherwise-identical resolver. This command is documented as
+   # run from ARBITRARY code repos, so accepting the current repo as the himmel
+   # checkout merely because it contains scripts/lib/wire-luna-vault.sh would let
+   # a hostile clone supply the script we then execute — with ~/.claude/settings.json
+   # as its argument. Trusted locations only; fail closed.
+   REPO="${HIMMEL_REPO:-}"
+   if [ -z "$REPO" ] || [ ! -f "$REPO/scripts/lib/wire-luna-vault.sh" ]; then
+     REPO=""
+     for c in "$HOME/Documents/github/himmel" "$HOME/Documents/github/Himmel" "$HOME/github/himmel" "$HOME/github/Himmel"; do
+       [ -f "$c/scripts/lib/wire-luna-vault.sh" ] && { REPO="$c"; break; }
+     done
+   fi
+   [ -n "$REPO" ] && [ -f "$REPO/scripts/lib/wire-luna-vault.sh" ] || { echo "ERR: cannot locate himmel checkout — set HIMMEL_REPO to your himmel clone" >&2; exit 1; }
+
+   # Persist a DRIVE-QUALIFIED path on Windows. Git Bash expands ~/Documents/luna
+   # to the MSYS form /c/Users/…, which the PowerShell SessionEnd hook resolves
+   # under \c\Users\… (Join-Path reads a leading / as the current drive root) —
+   # capture would land in the wrong place or fail. cygpath -m converts
+   # /c/Users/… -> C:/Users/…; it is absent on POSIX, where the path passes through.
+   vault="<expanded-path>"
+   case "$vault" in
+     /*) command -v cygpath >/dev/null 2>&1 && vault="$(cygpath -m "$vault")" ;;
+   esac
+   bash "$REPO/scripts/lib/wire-luna-vault.sh" "$HOME/.claude/settings.json" "$vault"
+   ```
+
+   PowerShell twin (same contract, and already native — PowerShell never produces an MSYS path): `pwsh -File "$REPO/scripts/lib/wire-luna-vault.ps1" -SettingsPath "$HOME/.claude/settings.json" -VaultPath "<expanded-path>"`.
+
+   A `settings.json` `env` block is applied at **session start**, so say plainly that the value takes effect for **new** sessions — the current session keeps whatever vault it started with. (For a one-off in the current shell, `export LUNA_VAULT_PATH=<path>` before launching `claude`.)
+
+   **Legacy `.env` cleanup — tell the operator, don't go read the file.** An earlier version of this step wrote `LUNA_VAULT_PATH=` into the repo-root `.env`. That line is inert for the capture hook, but it is NOT inert everywhere: `/himmel-update`'s luna-template step still bridges the key from `.env`, and a bridged value only loses to a value already live in the environment. So a **standalone** `himmelctl update` from a plain shell (no Claude session, nothing exporting the new value) would upgrade the OLD vault. Advise removing or updating that stale line. Do not grep for it yourself — the `block-read-secrets` guard hard-blocks any Bash command whose text contains a `.env` path.
 
 3. **Confirm the REST API key is discoverable.** The hook delivers notes via the Obsidian Local REST API when a key is available, and falls back to writing on disk otherwise. Check whether either:
    - `OBSIDIAN_API_KEY` is set in the environment, OR
@@ -37,6 +74,6 @@ Run this from the **code repo** whose sessions you want captured. Be idempotent 
 
    If neither is found, warn that REST delivery won't work until they install/enable the Local REST API plugin and set `OBSIDIAN_API_KEY` — but note the **on-disk fallback still captures notes without it** (Obsidian picks up file changes automatically).
 
-4. **Report.** State exactly what you wrote (which file, which key/line), which precedence tier now wins for this repo, and the absolute vault path sessions will land in. For BY-NAME, show both the repo `vault` key and how the name resolved (registry entry or `~/Documents/<name>` convention).
+4. **Report.** State exactly what you wrote (which file, which key), which precedence tier now wins for this repo, and the absolute vault path sessions will land in. For BY-NAME, show both the repo `vault` key and how the name resolved (registry entry or `~/Documents/<name>` convention). For GLOBAL, name `~/.claude/settings.json` → `env.LUNA_VAULT_PATH` and repeat the **new sessions only** caveat.
 
 Keep it tight. Ask the targeting question, validate, write, confirm — nothing more.

--- a/.claude/commands/end-session-wiki-setup.md
+++ b/.claude/commands/end-session-wiki-setup.md
@@ -64,7 +64,7 @@ Run this from the **code repo** whose sessions you want captured. Be idempotent 
 
    PowerShell twin (same contract, and already native — PowerShell never produces an MSYS path): `pwsh -File "$REPO/scripts/lib/wire-luna-vault.ps1" -SettingsPath "$HOME/.claude/settings.json" -VaultPath "<expanded-path>"`.
 
-   A `settings.json` `env` block is applied at **session start**, so say plainly that the value takes effect for **new** sessions — the current session keeps whatever vault it started with. (For a one-off in the current shell, `export LUNA_VAULT_PATH=<path>` before launching `claude`.)
+   A `settings.json` `env` block is applied at **session start**, so say plainly that the value takes effect for **new** sessions — the current session keeps whatever vault it started with. (For a one-off in the current shell, `export LUNA_VAULT_PATH=<path>` before launching `claude` — same drive-qualified requirement on Windows, so `export LUNA_VAULT_PATH="$(cygpath -m ~/Documents/luna)"`, not the bare `~/…` form.)
 
    **Legacy `.env` cleanup — tell the operator, don't go read the file.** An earlier version of this step wrote `LUNA_VAULT_PATH=` into the repo-root `.env`. That line is inert for the capture hook, but it is NOT inert everywhere: `/himmel-update`'s luna-template step still bridges the key from `.env`, and a bridged value only loses to a value already live in the environment. So a **standalone** `himmelctl update` from a plain shell (no Claude session, nothing exporting the new value) would upgrade the OLD vault. Advise removing or updating that stale line. Do not grep for it yourself — the `block-read-secrets` guard hard-blocks any Bash command whose text contains a `.env` path.
 

--- a/.env.example
+++ b/.env.example
@@ -291,7 +291,9 @@ JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian tenant cloud id (
 # repo. NOT bridged for this hook (or any other consumer) -- set it in
 # ~/.claude/settings.json's "env" block (what /end-session-wiki-setup and
 # scripts/adopt.sh write, via scripts/lib/wire-luna-vault.{sh,ps1}) or EXPORT it
-# from your shell profile. Sole exception: scripts/himmel-update.sh bridges
+# from your shell profile. On Windows use the DRIVE-QUALIFIED form (C:/...) in
+# EITHER case -- a Git-Bash /c/... value makes the PowerShell hook resolve the
+# vault under \c\Users\...; convert with cygpath -m. Sole exception: scripts/himmel-update.sh bridges
 # LUNA_VAULT_PATH from this .env for its luna-template upgrade step, so
 # `himmelctl update` sees it. Because of that exception, a STALE value left
 # here after moving to settings.json is not inert -- a standalone

--- a/.env.example
+++ b/.env.example
@@ -288,9 +288,15 @@ JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian tenant cloud id (
 # Luna vault root for end-session-wiki capture (global default). The SessionEnd
 # hook writes a note per session into <vault>/sessions/. Unset -> ~/Documents/luna.
 # A per-repo .claude/end-session-wiki.json "vault_path" overrides this for that
-# repo. NOT bridged for this hook (or any other consumer) -- EXPORT it. Sole
-# exception: scripts/himmel-update.sh bridges LUNA_VAULT_PATH from this .env
-# for its luna-template upgrade step, so `himmelctl update` sees it. See
+# repo. NOT bridged for this hook (or any other consumer) -- set it in
+# ~/.claude/settings.json's "env" block (what /end-session-wiki-setup and
+# scripts/adopt.sh write, via scripts/lib/wire-luna-vault.{sh,ps1}) or EXPORT it
+# from your shell profile. Sole exception: scripts/himmel-update.sh bridges
+# LUNA_VAULT_PATH from this .env for its luna-template upgrade step, so
+# `himmelctl update` sees it. Because of that exception, a STALE value left
+# here after moving to settings.json is not inert -- a standalone
+# `himmelctl update` (no live value exported) would upgrade the OLD vault.
+# Keep the two in sync, or leave this key unset. See
 # docs/luna/end-session-wiki.md ("Choosing the target vault").
 # LUNA_VAULT_PATH=/c/path/to/your/obsidian-vault
 # End-session-wiki opt-out: 0/false disables the SessionEnd capture hook.

--- a/docs/commands-catalog.md
+++ b/docs/commands-catalog.md
@@ -77,7 +77,7 @@ and their rows are paraphrased one-liners rather than verbatim frontmatter
 | /retitle | Infer a himmel-canonical session name (TICKET-ID + meaningful name) from the current branch and print a ready-to-paste built-in /rename line. |
 | /overnight-shift | Auto-dispatch N tickets from Jira as parallel subagents — emits plan + confirms before fanout (HIMMEL-134). |
 | /pipeline-cadence | Arm/inspect/remove the recurring clip-pipeline cadence (daily /harvest-clips + /triage-clips, daily /synthesize-clips + /archive-clips, weekly /obsidian-health) via schtasks (Windows) or cron (POSIX), interactive-claude shaped with per-leg --model pins. Dedup-guarded. HIMMEL-255/265/357/506. |
-| /end-session-wiki-setup | Configure which Obsidian vault the end-session-wiki hook captures sessions into — writes LUNA_VAULT_PATH (global) or .claude/end-session-wiki.json vault_path (this repo only). |
+| /end-session-wiki-setup | Configure which Obsidian vault the end-session-wiki hook captures sessions into — writes env.LUNA_VAULT_PATH into ~/.claude/settings.json (global) or the .claude/end-session-wiki.json vault or vault_path key (this repo only). |
 | /stop | Graceful-halt marker for in-progress /overnight-shift sessions (HIMMEL-137). |
 
 ## Prompt / discovery

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -453,7 +453,7 @@ the statusline segment):
 
 | Knob | Default | Set in | Effect |
 |---|---|---|---|
-| `LUNA_VAULT_PATH` | `~/Documents/luna` | env | which vault the luna tooling targets. Exception: `/himmel-update`'s luna-template step (`scripts/himmel-update.sh`) bridges it from `.env` — every other reader needs a live-env value |
+| `LUNA_VAULT_PATH` | `~/Documents/luna` | env (`~/.claude/settings.json` `env` block, or your shell profile) | which vault the luna tooling targets. `/end-session-wiki-setup` and `scripts/adopt.sh` persist it via `scripts/lib/wire-luna-vault.{sh,ps1}`. Exception: `/himmel-update`'s luna-template step (`scripts/himmel-update.sh`) bridges it from `.env` — every other reader needs a live-env value |
 | `CLAUDE_END_SESSION_WIKI` | unset | env | `0` disables the SessionEnd vault capture hook |
 | `OBSIDIAN_API_KEY` | unset (on-disk fallback works) | `.env` | Obsidian REST plugin access |
 | `PERPLEXITY_API_KEY` / `XAI_API_KEY` / `DASHSCOPE_API_KEY` | blank = feature off | `.env` | research/x-read skills, fleet-control providers |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -453,7 +453,7 @@ the statusline segment):
 
 | Knob | Default | Set in | Effect |
 |---|---|---|---|
-| `LUNA_VAULT_PATH` | `~/Documents/luna` | env (`~/.claude/settings.json` `env` block, or your shell profile) | which vault the luna tooling targets. `/end-session-wiki-setup` and `scripts/adopt.sh` persist it via `scripts/lib/wire-luna-vault.{sh,ps1}`. Exception: `/himmel-update`'s luna-template step (`scripts/himmel-update.sh`) bridges it from `.env` — every other reader needs a live-env value |
+| `LUNA_VAULT_PATH` | `~/Documents/luna` | env (`~/.claude/settings.json` `env` block, or your shell profile) | which vault the luna tooling targets. `/end-session-wiki-setup` and `scripts/adopt.sh` persist it via `scripts/lib/wire-luna-vault.{sh,ps1}`. On Windows the value must be drive-qualified (`C:/…`) however it is set — a Git-Bash `/c/…` value resolves under `\c\Users\…` in the PowerShell hook; convert with `cygpath -m`. Exception: `/himmel-update`'s luna-template step (`scripts/himmel-update.sh`) bridges it from `.env` — every other reader needs a live-env value |
 | `CLAUDE_END_SESSION_WIKI` | unset | env | `0` disables the SessionEnd vault capture hook |
 | `OBSIDIAN_API_KEY` | unset (on-disk fallback works) | `.env` | Obsidian REST plugin access |
 | `PERPLEXITY_API_KEY` / `XAI_API_KEY` / `DASHSCOPE_API_KEY` | blank = feature off | `.env` | research/x-read skills, fleet-control providers |

--- a/docs/luna/end-session-wiki.md
+++ b/docs/luna/end-session-wiki.md
@@ -175,7 +175,7 @@ Your vault almost certainly does not live where the operator's does, and you may
 
 1. **`vault_path` in `.claude/end-session-wiki.json`** (per-repo, absolute path) — the most specific, highest priority. An absolute path is machine-specific, so prefer `vault` (below) for anything you commit and share.
 2. **`vault` name in `.claude/end-session-wiki.json`** (per-repo, **distributable**) — a vault *name* instead of a path, so the same committed config works on every machine. Resolved per-machine: first the operator registry `~/.claude/luna-vaults.json`, else the convention `~/Documents/<name>`. The convention target must be a real vault (contain an `.obsidian/` folder); a name that resolves to no real vault — or fails validation (1–64 chars, must match `[A-Za-z0-9._-]`, start alphanumeric, no `/` or `..`) — **skips the capture rather than misrouting it** (logged as `skipped: vault …`). A config file that exists but is **not valid JSON** also skips (fail-closed) rather than falling through to the default, so a malformed config can't silently leak a sensitive repo's sessions into the general vault.
-3. **`LUNA_VAULT_PATH` environment variable** (global) — your default vault for everything that doesn't override it per-repo. Set it in your shell profile or your `.env` (see `.env.example`).
+3. **`LUNA_VAULT_PATH` environment variable** (global) — your default vault for everything that doesn't override it per-repo. The hook reads the **live process environment**, so set it in `~/.claude/settings.json`'s `env` block (what `/end-session-wiki-setup` and `scripts/adopt.sh` write, via `scripts/lib/wire-luna-vault.{sh,ps1}`) or export it from your shell profile. Putting it in the repo-root `.env` does **nothing** for this hook — that key is not bridged (see `.env.example`). A `settings.json` `env` value is applied at session start, so it takes effect for **new** sessions.
 4. **Built-in default** — the `luna` vault: the `luna` entry in `~/.claude/luna-vaults.json` if you have one, else the `~/Documents/luna` (`$HOME`/`$USERPROFILE`) convention. The bare convention is honored **only when it is a real vault** (contains an `.obsidian/` folder), so a stock luna install works with zero config. With no configured vault **and** no real `~/Documents/luna`, the hook **skips** (logged `skipped: vault unresolved …`) rather than materializing a phantom vault for someone who never set luna up (HIMMEL-590). An explicit `luna` registry entry is honored as-is (no existence check), like `vault_path`.
 
 `vault_path` configures a path (renaming/moving the vault means updating that path). `vault` configures a name and each machine resolves the path — so the same committed value works everywhere: an operator either follows the `~/Documents/<name>` convention (zero extra config) or maps the name in their registry.
@@ -198,9 +198,20 @@ Your vault almost certainly does not live where the operator's does, and you may
 { "vaults": { "salus": "~/Documents/salus" } }
 ```
 
+```json
+// ~/.claude/settings.json — global default vault for all repos (process env,
+// applied at session start). Store the DRIVE-QUALIFIED form on Windows (C:/…),
+// never the Git-Bash MSYS form (/c/…) — the PowerShell hook resolves a leading
+// / under the current drive root. ~/Documents/my-vault expands to the MSYS form
+// under Git Bash, so pipe it through cygpath -m (a no-op absent on POSIX):
+//   bash scripts/lib/wire-luna-vault.sh ~/.claude/settings.json \
+//     "$(cygpath -m ~/Documents/my-vault 2>/dev/null || echo ~/Documents/my-vault)"
+{ "env": { "LUNA_VAULT_PATH": "C:/Users/me/Documents/my-vault" } }
+```
+
 ```bash
-# .env or shell profile — global default vault for all repos
-LUNA_VAULT_PATH="$HOME/Documents/my-vault"
+# …or export it from your shell profile before launching claude (NOT the repo .env)
+export LUNA_VAULT_PATH="$HOME/Documents/my-vault"
 ```
 
 ## Logs

--- a/docs/luna/end-session-wiki.md
+++ b/docs/luna/end-session-wiki.md
@@ -175,7 +175,7 @@ Your vault almost certainly does not live where the operator's does, and you may
 
 1. **`vault_path` in `.claude/end-session-wiki.json`** (per-repo, absolute path) — the most specific, highest priority. An absolute path is machine-specific, so prefer `vault` (below) for anything you commit and share.
 2. **`vault` name in `.claude/end-session-wiki.json`** (per-repo, **distributable**) — a vault *name* instead of a path, so the same committed config works on every machine. Resolved per-machine: first the operator registry `~/.claude/luna-vaults.json`, else the convention `~/Documents/<name>`. The convention target must be a real vault (contain an `.obsidian/` folder); a name that resolves to no real vault — or fails validation (1–64 chars, must match `[A-Za-z0-9._-]`, start alphanumeric, no `/` or `..`) — **skips the capture rather than misrouting it** (logged as `skipped: vault …`). A config file that exists but is **not valid JSON** also skips (fail-closed) rather than falling through to the default, so a malformed config can't silently leak a sensitive repo's sessions into the general vault.
-3. **`LUNA_VAULT_PATH` environment variable** (global) — your default vault for everything that doesn't override it per-repo. The hook reads the **live process environment**, so set it in `~/.claude/settings.json`'s `env` block (what `/end-session-wiki-setup` and `scripts/adopt.sh` write, via `scripts/lib/wire-luna-vault.{sh,ps1}`) or export it from your shell profile. Putting it in the repo-root `.env` does **nothing** for this hook — that key is not bridged (see `.env.example`). A `settings.json` `env` value is applied at session start, so it takes effect for **new** sessions.
+3. **`LUNA_VAULT_PATH` environment variable** (global) — your default vault for everything that doesn't override it per-repo. The hook reads the **live process environment**, so set it in `~/.claude/settings.json`'s `env` block (what `/end-session-wiki-setup` and `scripts/adopt.sh` write, via `scripts/lib/wire-luna-vault.{sh,ps1}`) or export it from your shell profile — on Windows always as a drive-qualified `C:/…` path, never the Git-Bash `/c/…` form (see the note under the examples below). Putting it in the repo-root `.env` does **nothing** for this hook — that key is not bridged (see `.env.example`). A `settings.json` `env` value is applied at session start, so it takes effect for **new** sessions.
 4. **Built-in default** — the `luna` vault: the `luna` entry in `~/.claude/luna-vaults.json` if you have one, else the `~/Documents/luna` (`$HOME`/`$USERPROFILE`) convention. The bare convention is honored **only when it is a real vault** (contains an `.obsidian/` folder), so a stock luna install works with zero config. With no configured vault **and** no real `~/Documents/luna`, the hook **skips** (logged `skipped: vault unresolved …`) rather than materializing a phantom vault for someone who never set luna up (HIMMEL-590). An explicit `luna` registry entry is honored as-is (no existence check), like `vault_path`.
 
 `vault_path` configures a path (renaming/moving the vault means updating that path). `vault` configures a name and each machine resolves the path — so the same committed value works everywhere: an operator either follows the `~/Documents/<name>` convention (zero extra config) or maps the name in their registry.
@@ -200,18 +200,19 @@ Your vault almost certainly does not live where the operator's does, and you may
 
 ```json
 // ~/.claude/settings.json — global default vault for all repos (process env,
-// applied at session start). Store the DRIVE-QUALIFIED form on Windows (C:/…),
-// never the Git-Bash MSYS form (/c/…) — the PowerShell hook resolves a leading
-// / under the current drive root. ~/Documents/my-vault expands to the MSYS form
-// under Git Bash, so pipe it through cygpath -m (a no-op absent on POSIX):
-//   bash scripts/lib/wire-luna-vault.sh ~/.claude/settings.json \
-//     "$(cygpath -m ~/Documents/my-vault 2>/dev/null || echo ~/Documents/my-vault)"
+// applied at session start)
 { "env": { "LUNA_VAULT_PATH": "C:/Users/me/Documents/my-vault" } }
 ```
 
+**Windows: use the drive-qualified form (`C:/…`), never the Git-Bash MSYS form (`/c/…`)** — the PowerShell hook resolves a leading `/` under the current drive root, so an MSYS value sends captures to `\c\Users\…`. `~/Documents/my-vault` expands to the MSYS form under Git Bash, so pipe it through `cygpath -m` (absent on POSIX, where the path passes through unchanged). This applies to **every** way you set the variable — the helper, and a direct export alike:
+
 ```bash
+# write it into ~/.claude/settings.json with the helper (recommended)
+bash scripts/lib/wire-luna-vault.sh ~/.claude/settings.json \
+  "$(cygpath -m ~/Documents/my-vault 2>/dev/null || echo ~/Documents/my-vault)"
+
 # …or export it from your shell profile before launching claude (NOT the repo .env)
-export LUNA_VAULT_PATH="$HOME/Documents/my-vault"
+export LUNA_VAULT_PATH="$(cygpath -m ~/Documents/my-vault 2>/dev/null || echo ~/Documents/my-vault)"
 ```
 
 ## Logs

--- a/scripts/lib/test-wire-luna-vault.ps1
+++ b/scripts/lib/test-wire-luna-vault.ps1
@@ -70,7 +70,33 @@ $s7 = Join-Path $td 's7.json'
 $c7 = Get-Content $s7 -Raw | ConvertFrom-Json
 Check 'whitespace file -> created' $c7.env.LUNA_VAULT_PATH 'C:/Documents/luna'
 
-# 8. F1-SC4 cross-twin parity: same backslash input to .sh (Git Bash) and .ps1
+# 8. SEAM (HIMMEL-1269): what wire-luna-vault writes into settings.json .env is
+#    exactly what the end-session-wiki resolver consumes at step 3. Claude Code
+#    applies a settings.json "env" block to the process env at session start;
+#    this test makes that hop explicitly (read the key back, set it in the
+#    process env) and then asserts Resolve-VaultRoot returns the wired path with
+#    an EMPTY config and registry -- i.e. /end-session-wiki-setup's GLOBAL tier
+#    actually reaches the hook. Mirrors case 8 of the .sh twin. The .sh twin
+#    additionally carries a case 9 (MSYS /c/... input normalized via cygpath -m,
+#    per /end-session-wiki-setup step 2c); there is deliberately no twin here --
+#    PowerShell never produces an MSYS path, so its inputs are already
+#    drive-qualified and case 8 is the whole story on this side.
+$s8 = Join-Path $td 's8.json'
+& pwsh -NoProfile -File $wire -SettingsPath $s8 -VaultPath 'C:\Users\me\Documents\luna' | Out-Null
+$wired = (Get-Content $s8 -Raw | ConvertFrom-Json).env.LUNA_VAULT_PATH
+$cfg8 = Join-Path $td 'cfg8.json'; '{}' | Set-Content $cfg8 -Encoding utf8
+$reg8 = Join-Path $td 'reg8.json'; '{"vaults":{}}' | Set-Content $reg8 -Encoding utf8
+. (Join-Path $here 'vault-resolve.ps1')
+$prevLvp = $env:LUNA_VAULT_PATH
+$env:LUNA_VAULT_PATH = $wired
+try { $got8 = Resolve-VaultRoot -ConfigPath $cfg8 -RegistryPath $reg8 }
+finally {
+    if ($null -eq $prevLvp) { Remove-Item Env:LUNA_VAULT_PATH -ErrorAction SilentlyContinue }
+    else { $env:LUNA_VAULT_PATH = $prevLvp }
+}
+Check 'seam: settings.json env -> resolver step 3' $got8 'C:/Users/me/Documents/luna'
+
+# 9. F1-SC4 cross-twin parity: same backslash input to .sh (Git Bash) and .ps1
 #    must yield byte-identical .env.LUNA_VAULT_PATH. Skip cleanly if no Git Bash.
 $gitBash = 'C:\Program Files\Git\bin\bash.exe'
 if (-not (Test-Path $gitBash)) {

--- a/scripts/lib/test-wire-luna-vault.sh
+++ b/scripts/lib/test-wire-luna-vault.sh
@@ -63,5 +63,46 @@ printf '   \n' > "$s7"
 bash "$wire" "$s7" "C:/Documents/luna" >/dev/null
 check "whitespace file -> created" "$(jq -r '.env.LUNA_VAULT_PATH' "$s7")" "C:/Documents/luna"
 
+# 8. SEAM (HIMMEL-1269): what wire-luna-vault writes into settings.json .env is
+#    exactly what the end-session-wiki resolver consumes at step 3. Claude Code
+#    applies a settings.json "env" block to the process env at session start;
+#    this test makes that hop explicitly (read the key back, export it) and then
+#    asserts resolve_vault_root returns the wired path with an EMPTY config and
+#    registry -- i.e. /end-session-wiki-setup's GLOBAL tier actually reaches the
+#    hook. A backslash input also proves the forward-slashing survives the seam.
+s8="$td/s8.json"
+bash "$wire" "$s8" 'C:\Users\me\Documents\luna' >/dev/null
+wired="$(jq -r '.env.LUNA_VAULT_PATH' "$s8")"
+cfg8="$td/cfg8.json"; printf '%s' '{}' > "$cfg8"
+reg8="$td/reg8.json"; printf '%s' '{"vaults":{}}' > "$reg8"
+# shellcheck disable=SC1091  # sourced at runtime; linted standalone by pre-commit
+. "$here/vault-resolve.sh"
+prev_lvp="${LUNA_VAULT_PATH-__UNSET__}"   # save/restore, like the .ps1 twin
+export LUNA_VAULT_PATH="$wired"
+got8="$(resolve_vault_root "$cfg8" "$reg8")"
+check "seam: settings.json env -> resolver step 3" "$got8" "C:/Users/me/Documents/luna"
+
+# 9. SEAM, MSYS form (HIMMEL-1269 / codex-adv): Git Bash expands the documented
+#    default ~/Documents/luna to /c/Users/..., which the PowerShell hook would
+#    resolve under \c\Users\... . /end-session-wiki-setup step 2c therefore runs
+#    `cygpath -m` before calling the helper; this asserts that prescribed
+#    conversion yields a drive-qualified value the resolver hands back intact.
+#    Skips cleanly off Windows, where cygpath does not exist (and MSYS paths
+#    are the native form anyway). No .ps1 twin: PowerShell never produces an
+#    MSYS path, so its inputs are already drive-qualified (covered by case 8).
+if command -v cygpath >/dev/null 2>&1; then
+  s9="$td/s9.json"
+  msys_in='/c/Users/me/Documents/luna'
+  bash "$wire" "$s9" "$(cygpath -m "$msys_in")" >/dev/null
+  wired9="$(jq -r '.env.LUNA_VAULT_PATH' "$s9")"
+  export LUNA_VAULT_PATH="$wired9"
+  got9="$(resolve_vault_root "$cfg8" "$reg8")"
+  check "seam: MSYS input -> drive-qualified via cygpath -m" "$got9" "C:/Users/me/Documents/luna"
+else
+  echo "skip - MSYS seam (cygpath not found)"
+fi
+
+if [ "$prev_lvp" = "__UNSET__" ]; then unset LUNA_VAULT_PATH; else export LUNA_VAULT_PATH="$prev_lvp"; fi
+
 rm -rf "$td"
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
## The bug

`/end-session-wiki-setup`'s **GLOBAL** tier wrote `LUNA_VAULT_PATH=<path>` into the repo-root `.env`, but the SessionEnd capture hook's vault resolvers read **only the process environment** (`scripts/lib/vault-resolve.sh` step 3 / `vault-resolve.ps1` step 3), and `LUNA_VAULT_PATH` is not a bridged key for that hook — `.env.example` said so explicitly. So the command contradicted the repo's own documented contract: anyone following the supported workflow configured a value its own consumer never saw, and sessions silently landed in the default/registry vault (or capture was skipped).

## The fix

Persist the value where the hook actually reads it, reusing the already-tested helper rather than hand-rolling JSON edits.

- **Step 2c** now calls `scripts/lib/wire-luna-vault.{sh,ps1}` against `~/.claude/settings.json` — idempotent, atomic, preserves every other key. The header precedence list, the GLOBAL branch pointer, and the step-4 report wording all describe settings.json instead of `.env`. It notes the new-sessions-only caveat, since a `settings.json` `env` block is applied at session start.
- **Windows path form** — Git Bash expands the documented default `~/Documents/luna` to `/c/Users/…`, which the PowerShell hook resolves under `\c\Users\…`. Step 2c runs `cygpath -m` on a leading-`/` path before calling the helper (absent on POSIX → passthrough).
- **Trusted-locations-only helper resolution** — `$HIMMEL_REPO` (validated) → canonical install paths → fail closed. Deliberately **no** `git rev-parse --show-toplevel` fallback, unlike the otherwise-identical resolver in `/himmel-update`: this command is documented as run from arbitrary code repos, so accepting the current repo as the himmel checkout merely because it contains `scripts/lib/wire-luna-vault.sh` would let a hostile clone supply the script that then gets executed with `~/.claude/settings.json` as its argument. Commented inline so the divergence doesn't read as drift.

This also restores symmetry the rest of the harness already assumed: `uninstall.{sh,ps1}` unwire `env.LUNA_VAULT_PATH` **from `~/.claude/settings.json`**, and `adopt.sh` has wired it there since the vault-path wiring landed. The setup command was the outlier.

**Not** taken: bridging `LUNA_VAULT_PATH` through `load-dotenv.sh`. It would contradict `.env.example`, widen the bridged-key surface, and make the per-repo `.env` authoritative for an explicitly every-repo setting.

## Docs reconciled

`docs/luna/end-session-wiki.md` (precedence item 3 + a settings.json example), `.env.example`'s "NOT bridged" comment — which also now warns that a stale value there is *not* inert, since `/himmel-update`'s luna-template step still bridges the key, so a standalone `himmelctl update` would upgrade the OLD vault — `docs/configuration.md`'s `LUNA_VAULT_PATH` row, and `docs/commands-catalog.md`'s one-line description.

The resolver logic itself is untouched: tiers 1/2 still shadow the env var, and the phantom-vault guard at tier 4 is unchanged.

## Tests

The missing coverage was the **seam**, not step 3 itself — the `vault-resolve` suites already assert step 3 consumes `LUNA_VAULT_PATH`. Added to **both** twins: wire a path into a settings.json, read `env.LUNA_VAULT_PATH` back, put it in the process env (the hop Claude Code performs at session start), then assert the resolver returns exactly that path with an empty config + registry.

Discriminating, not trivially true — without the env hop the resolver falls through to the tier-4 default. The `.sh` twin carries an extra case for the MSYS → `cygpath -m` conversion; there is no `.ps1` twin for it because PowerShell never produces an MSYS path (noted in the file).

```
$ bash scripts/lib/test-wire-luna-vault.sh
... 13 cases ... ALL PASS      # incl. seam + MSYS seam
$ pwsh -NoProfile -File scripts/lib/test-wire-luna-vault.ps1
... 13 cases ... ALL PASS      # incl. seam + cross-twin parity
$ bash scripts/lib/test-vault-resolve.sh
ALL PASS
$ shellcheck scripts/lib/test-wire-luna-vault.sh   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how the end-session wiki determines its target vault.
  * Added guidance for configuring `LUNA_VAULT_PATH` through global settings or shell environment variables.
  * Documented Windows path handling, new-session behavior, and cleanup of outdated `.env` values.
  * Updated command and configuration references, including REST API key reporting guidance.

* **Tests**
  * Added coverage validating vault configuration wiring and path resolution across Windows and MSYS/Git Bash environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->