### PR TITLE
fix(handover): make the --time smart bank wall configurable (RESUME_SLOT_THRESHOLD)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -282,6 +282,19 @@ JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian tenant cloud id (
 #                            {ticket} {slug} {session}
 #   HIMMEL_HEADROOM_PROXY=1  route armed relaunches through the local headroom
 #                            Anthropic-API proxy (resolved once at arm time)
+# The TWO bank walls (HIMMEL-1271) -- both default to 90%, both LIVE env, and
+# they are INDEPENDENT: raise BOTH to move the effective wall.
+#   AUTO_ARM_THRESHOLD=90    wall 1 -- utilization % at which the auto-arm
+#                            watchdog trips and arms a resume
+#                            (scripts/hooks/auto-arm-on-cap.sh)
+#   RESUME_SLOT_THRESHOLD=90 wall 2 -- utilization % at which `--time smart`
+#                            counts a window as exhausted and parks the resume
+#                            at that window's reset instead of relaunching ASAP
+#                            (scripts/handover/resume-slot.sh). Must be 0-100;
+#                            a non-numeric OR out-of-range value falls back to
+#                            90 silently (a 970 typo would otherwise read every
+#                            window as headroom and relaunch into a walled
+#                            bank); an explicit --threshold flag wins
 # /overnight-shift ticket-selection defaults (LIVE env):
 #   OVERNIGHT_PROJECT=HIMMEL   OVERNIGHT_STATUS="To Do,In Progress"
 #   OVERNIGHT_LIMIT=5          OVERNIGHT_PRIORITY=key-desc

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -400,8 +400,24 @@ default subset:
 | `ARM_DUP_OK` / `QUEUE_LOCK_TAKEOVER` | unset | shell | override cross-machine duplicate-arm / fresh-queue-lock refusals |
 | `HIMMEL_HEADROOM_PROXY` | OFF | env | route the armed relaunch through a local headroom API proxy |
 | `AUTO_ARM_DISABLE` / `AUTO_ARM_SUBAGENT_DISABLE` | OFF (watchdogs armed) | shell | kill switches for the cap watchdogs (`scripts/hooks/auto-arm-on-cap.sh`, `auto-arm-on-subagent-cap.sh`) |
-| `AUTO_ARM_THRESHOLD` (+ `AUTO_ARM_CHECK_INTERVAL`, `AUTO_ARM_CACHE`, `AUTO_ARM_STATE_DIR`, `AUTO_ARM_MAX_ARM_FAILURES`, `AUTO_ARM_STALE_*`, `AUTO_ARM_BIN`) | 90% (60s, …) | env | watchdog tuning |
+| `AUTO_ARM_THRESHOLD` (+ `AUTO_ARM_CHECK_INTERVAL`, `AUTO_ARM_CACHE`, `AUTO_ARM_STATE_DIR`, `AUTO_ARM_MAX_ARM_FAILURES`, `AUTO_ARM_STALE_*`, `AUTO_ARM_BIN`) | 90% (60s, …) | env | watchdog tuning — **bank wall 1**, see below |
+| `RESUME_SLOT_THRESHOLD` | 90% | env | **bank wall 2**: utilization at/above which `--time smart` treats a window as exhausted (`scripts/handover/resume-slot.sh`) — an explicit `--threshold` still wins; must be 0-100, and a non-numeric or out-of-range value falls back to 90 silently (a `970` typo would otherwise read every window as headroom) |
 | Recurring vault cadence | — | `scripts/luna/pipeline-cadence.sh arm` | daily harvest/synthesize + weekly health runs, per-leg cheap model pins, `HIMMEL-Pipeline-*` dedup |
+
+**The two bank walls are INDEPENDENT** (HIMMEL-1271). Both default to 90% and
+both must be raised to move the effective wall:
+
+- `AUTO_ARM_THRESHOLD` decides **when the watchdog trips** — the utilization at
+  which `auto-arm-on-cap.sh` writes a snapshot and arms a resume.
+- `RESUME_SLOT_THRESHOLD` decides **where that resume is parked** —
+  `resume-slot.sh` (the `--time smart` resolver, used by the armed watchdog,
+  the Telegram bridge, and every manual `arm-resume.sh --time smart`) counts a
+  window at/above it as exhausted and waits for its reset instead of relaunching
+  ASAP.
+
+Raising only the first still parks the resume at the window reset; raising only
+the second still trips the watchdog at 90%. Both are **process env** — a value
+written only into `.env` is not read (`load-dotenv.sh` bridges neither).
 
 **Lanes & delegation**
 

--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -347,6 +347,12 @@ case "$RESUME_TIME" in
         # genuinely abandoned cache (>1h) still errors out. SLOT_MAX_AGE
         # overrides for tests / tighter freshness; RESUME_SLOT_CACHE injects a
         # fixture cache (test seam — keeps the smart path end-to-end testable).
+        # The THRESHOLD is deliberately NOT in _slot_args (HIMMEL-1271):
+        # resume-slot.sh runs as a plain child of this process, so a
+        # RESUME_SLOT_THRESHOLD set in the environment already reaches it —
+        # including down the auto-arm-on-cap.sh -> arm-resume -> resume-slot
+        # chain. Forwarding it as a flag would be a redundant second copy of
+        # the same knob (and a second place for its default to drift).
         _slot_args=(--max-age "${SLOT_MAX_AGE:-3600}")
         [ -n "${RESUME_SLOT_CACHE:-}" ] && _slot_args+=(--cache "$RESUME_SLOT_CACHE")
         # One --emit all call (epoch<TAB>hhmm<TAB>reason) — avoids a second,

--- a/scripts/handover/resume-slot.sh
+++ b/scripts/handover/resume-slot.sh
@@ -29,7 +29,15 @@
 #
 # Optional:
 #   --threshold <pct>   Utilization at/above which a window counts as
-#                       exhausted. Default 90.
+#                       exhausted. Must be 0-100. Default 90. Env override:
+#                       RESUME_SLOT_THRESHOLD (HIMMEL-1271) — an explicit
+#                       flag still wins; a non-numeric OR out-of-range env
+#                       value falls back to the default instead of erroring
+#                       (an out-of-range FLAG errors). This is the
+#                       SECOND, independent bank wall: the auto-arm watchdog
+#                       has its own AUTO_ARM_THRESHOLD (scripts/hooks/
+#                       auto-arm-on-cap.sh) and raising one does NOT raise
+#                       the other.
 #   --buffer-min <min>  Minutes from now for the ASAP slot. Default 4.
 #   --cache <path>      Override cache path.
 #   --max-age <s>       Refuse if cache older than <s>s. Default 300. 0 skips.
@@ -49,7 +57,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/../lib/py-armor.sh"
 
-THRESHOLD=90
+# Shipped default stays 90 (HIMMEL-1271): the threshold is how much runway is
+# left to write a handover before the bank walls, so the conservative value is
+# the right default for adopters. An operator who wants a tighter wall sets
+# RESUME_SLOT_THRESHOLD in their environment (and, separately,
+# AUTO_ARM_THRESHOLD for the watchdog wall — the two are independent).
+THRESHOLD_DEFAULT=90
+THRESHOLD="${RESUME_SLOT_THRESHOLD:-$THRESHOLD_DEFAULT}"
+THRESHOLD_FROM_ENV=1   # cleared by an explicit --threshold flag below
 BUFFER_MIN=4
 CACHE_PATH="/tmp/claude/statusline-usage-cache.json"
 MAX_AGE_SEC=300
@@ -64,20 +79,44 @@ Usage: resume-slot.sh [--threshold <pct>] [--buffer-min <min>]
 Reads the claude-statusline usage cache and prints the best relaunch slot:
 ASAP (now + buffer) when the bank has headroom, else the latest reset of any
 exhausted window. Default emit: HH:MM 24h local.
+
+Threshold must be 0-100; default 90. Override with RESUME_SLOT_THRESHOLD in the
+environment (an explicit --threshold wins; a non-numeric or out-of-range env
+value falls back to 90). The auto-arm watchdog's AUTO_ARM_THRESHOLD is a
+SEPARATE wall — raising one does not raise the other.
 EOF
+}
+
+# A two-arg option given with no value would reach `shift 2` with one arg left;
+# that returns nonzero and `set -e` kills the script with rc 1 and NO message —
+# so arm-resume's relay prints an EMPTY error, the exact failure this script's
+# error contract exists to prevent (see the rc relay at the bottom). Fail with
+# a usage line instead. Called as `_need_val "$@"`, so $1 is the option and $2
+# its value, if any.
+# A following token that is itself an option (`--threshold --emit epoch`) is a
+# missing value too: it would be swallowed as the value, and the REAL next arg
+# then fails as "unknown arg", pointing at the wrong token. No option here takes
+# a value that starts with `--`, so rejecting that shape is safe.
+_need_val() {
+    if [ $# -lt 2 ]; then
+        echo "ERR resume-slot: $1 needs a value" >&2; usage >&2; exit 1
+    fi
+    case "$2" in
+        --*) echo "ERR resume-slot: $1 needs a value (got the option '$2')" >&2; usage >&2; exit 1 ;;
+    esac
 }
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --threshold)    THRESHOLD="${2:-}"; shift 2 ;;
-        --threshold=*)  THRESHOLD="${1#--threshold=}"; shift ;;
-        --buffer-min)   BUFFER_MIN="${2:-}"; shift 2 ;;
+        --threshold)    _need_val "$@"; THRESHOLD="$2"; THRESHOLD_FROM_ENV=0; shift 2 ;;
+        --threshold=*)  THRESHOLD="${1#--threshold=}"; THRESHOLD_FROM_ENV=0; shift ;;
+        --buffer-min)   _need_val "$@"; BUFFER_MIN="$2"; shift 2 ;;
         --buffer-min=*) BUFFER_MIN="${1#--buffer-min=}"; shift ;;
-        --cache)        CACHE_PATH="${2:-}"; shift 2 ;;
+        --cache)        _need_val "$@"; CACHE_PATH="$2"; shift 2 ;;
         --cache=*)      CACHE_PATH="${1#--cache=}"; shift ;;
-        --max-age)      MAX_AGE_SEC="${2:-}"; shift 2 ;;
+        --max-age)      _need_val "$@"; MAX_AGE_SEC="$2"; shift 2 ;;
         --max-age=*)    MAX_AGE_SEC="${1#--max-age=}"; shift ;;
-        --emit)         EMIT="${2:-}"; shift 2 ;;
+        --emit)         _need_val "$@"; EMIT="$2"; shift 2 ;;
         --emit=*)       EMIT="${1#--emit=}"; shift ;;
         -h|--help)      usage; exit 0 ;;
         *) echo "ERR resume-slot: unknown arg: $1" >&2; usage >&2; exit 1 ;;
@@ -87,8 +126,24 @@ done
 case "$EMIT" in hhmm|epoch|iso|reason|all) ;; *)
     echo "ERR resume-slot: --emit must be hhmm|epoch|iso|reason|all, got: $EMIT" >&2; exit 1 ;;
 esac
-if ! [[ "$THRESHOLD" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
-    echo "ERR resume-slot: --threshold must be numeric, got: $THRESHOLD" >&2; exit 1
+# Numeric AND in range 0-100. The range check is not pedantry: a
+# syntactically-numeric but out-of-range value — `RESUME_SLOT_THRESHOLD=970`,
+# a fat-finger for 97 — makes every window's 0-100% utilization compare as
+# headroom, so `--time smart` picks ASAP and relaunches straight back into a
+# walled bank. As an env var that misconfiguration is PERSISTENT: it would
+# apply silently to every arm, including the auto-arm watchdog's, which is
+# exactly when parking at the reset matters. awk does the compare because the
+# threshold may be fractional and bash arithmetic is integer-only.
+if ! [[ "$THRESHOLD" =~ ^[0-9]+(\.[0-9]+)?$ ]] \
+   || ! awk -v t="$THRESHOLD" 'BEGIN { exit !(t >= 0 && t <= 100) }'; then
+    if [ "$THRESHOLD_FROM_ENV" -eq 1 ]; then
+        # A typo'd RESUME_SLOT_THRESHOLD must not break the resume-critical
+        # path — fall back silently to the shipped default, mirroring the
+        # auto-arm-on-cap.sh:186 contract. An explicit FLAG typo still errors.
+        THRESHOLD="$THRESHOLD_DEFAULT"
+    else
+        echo "ERR resume-slot: --threshold must be a number in 0-100, got: $THRESHOLD" >&2; exit 1
+    fi
 fi
 if ! [[ "$BUFFER_MIN" =~ ^[0-9]+$ ]]; then
     echo "ERR resume-slot: --buffer-min must be a non-negative integer, got: $BUFFER_MIN" >&2; exit 1

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -27,6 +27,11 @@ unset SKILL_TELEMETRY_DISABLE 2>/dev/null || true
 # ARM_NAME_TEMPLATE would skew every derived-name assertion below (N/S cases);
 # S8/S9 set it per-call.
 unset ARM_NAME_TEMPLATE 2>/dev/null || true
+# Slot-threshold shield (HIMMEL-1271): the --time smart cases assert against
+# the SHIPPED default wall, and an operator shell exporting
+# RESUME_SLOT_THRESHOLD reaches resume-slot.sh through this script. T9c sets
+# it per-call.
+unset RESUME_SLOT_THRESHOLD 2>/dev/null || true
 # Global workspace-trust shield (HIMMEL-386): arm-resume now pre-trusts the
 # resolved cwd in ~/.claude.json. The non-dry-run arm cases below (T14-T20
 # bridge/channel checks, dedup-any) would otherwise write the operator's real
@@ -313,6 +318,32 @@ case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
     *)
         assert_contains "T9 smart flows an at -t stamp" "at -t " "$out" ;;
 esac
+
+# ---------------------------------------------------------------------------
+# T9b/T9c: RESUME_SLOT_THRESHOLD reaches resume-slot.sh THROUGH arm-resume
+#     (HIMMEL-1271). arm-resume deliberately does not forward a --threshold
+#     flag — the child process inherits the environment — so this is the
+#     end-to-end proof of that contract. One 95% seven_day fixture: EXHAUSTED
+#     under the shipped 90 default (park at the reset), HEADROOM under an
+#     operator-set 97 (ASAP).
+# ---------------------------------------------------------------------------
+HO=$(make_handover "$WORK_REPO")
+BUSY_CACHE="$TMP/usage-95.json"
+printf '{"five_hour":{"utilization":10.0,"resets_at":"%s"},"seven_day":{"utilization":95.0,"resets_at":"%s"}}' \
+    "$FIVE_RESET" "$SEVEN_RESET" > "$BUSY_CACHE"
+out=$(RESUME_SLOT_CACHE="$BUSY_CACHE" SLOT_MAX_AGE=0 PATH="$SCHED_STUB_T17:$PATH" \
+    bash "$ARM" --time smart --handover "$HO" --force --dry-run 2>&1)
+rc=$?
+assert_rc "T9b default wall exits 0" 0 "$rc"
+assert_contains "T9b 95% is exhausted under the shipped 90 default" "wait for seven-day reset" "$out"
+
+HO=$(make_handover "$WORK_REPO")
+out=$(RESUME_SLOT_THRESHOLD=97 RESUME_SLOT_CACHE="$BUSY_CACHE" SLOT_MAX_AGE=0 PATH="$SCHED_STUB_T17:$PATH" \
+    bash "$ARM" --time smart --handover "$HO" --force --dry-run 2>&1)
+rc=$?
+assert_rc "T9c env-97 wall exits 0" 0 "$rc"
+assert_contains "T9c RESUME_SLOT_THRESHOLD=97 reaches the child -> ASAP" "bank free" "$out"
+assert_contains "T9c child applied the env threshold, not 90" "< 97%" "$out"
 
 # ---------------------------------------------------------------------------
 # T10: --time smart with an exhausted-but-null-reset cache fails loud (rc 1

--- a/scripts/handover/test-resume-slot.sh
+++ b/scripts/handover/test-resume-slot.sh
@@ -6,6 +6,11 @@ set -uo pipefail
 SLOT="$(cd "$(dirname "$0")" && pwd)/resume-slot.sh"
 [ -x "$SLOT" ] || chmod +x "$SLOT"
 
+# Hermetic run (HIMMEL-1271): the operator may have RESUME_SLOT_THRESHOLD
+# exported. Every case below asserts against the SHIPPED default unless it sets
+# the var itself, so clear it for the whole suite.
+unset RESUME_SLOT_THRESHOLD
+
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 FAILED=0
@@ -222,6 +227,128 @@ printf '{"five_hour":{"utilization":10.0,"resets_at":%s},"seven_day":{"utilizati
 out=$(bash "$SLOT" --cache "$TMP/epochnum.json" --max-age 0 --emit reason 2>&1); rc=$?
 assert_rc "T16b numeric resets_at exits 0" 0 "$rc"
 assert_contains "T16b waits for seven-day reset" "wait for seven-day reset" "$out"
+
+# ---------------------------------------------------------------------------
+# T17: RESUME_SLOT_THRESHOLD env override (HIMMEL-1271). The --time smart wall
+#      used to be hardcoded at 90, so an operator who considers a 95% bank
+#      usable still got parked at the window reset. Four contracts:
+#      env honoured / explicit flag beats env / bad env falls back silently /
+#      bad flag still errors.
+# ---------------------------------------------------------------------------
+# Default (no env, no flag): 95% counts as exhausted -> wait for the reset.
+mk_cache "$TMP/at95.json" 10.0 "$(iso_in 9000)" 95.0 "$(iso_in 200000)"
+out=$(bash "$SLOT" --cache "$TMP/at95.json" --max-age 0 --emit reason 2>&1); rc=$?
+assert_rc "T17 default threshold exits 0" 0 "$rc"
+assert_contains "T17 default (90) treats 95% as exhausted" "wait for seven-day reset" "$out"
+assert_contains "T17 default threshold is 90 in the reason" ">= 90%" "$out"
+
+# Env override 97: the same 95% cache now has headroom -> ASAP.
+out=$(RESUME_SLOT_THRESHOLD=97 bash "$SLOT" --cache "$TMP/at95.json" --max-age 0 --emit reason 2>&1); rc=$?
+assert_rc "T17b env override exits 0" 0 "$rc"
+assert_contains "T17b env 97 makes 95% headroom -> ASAP" "bank free" "$out"
+assert_contains "T17b reason reports the env threshold" "< 97%" "$out"
+
+# ...and 98% is still exhausted under the same env value.
+mk_cache "$TMP/at98.json" 10.0 "$(iso_in 9000)" 98.0 "$(iso_in 200000)"
+out=$(RESUME_SLOT_THRESHOLD=97 bash "$SLOT" --cache "$TMP/at98.json" --max-age 0 --emit reason 2>&1); rc=$?
+assert_rc "T17c env-97 exhausted path exits 0" 0 "$rc"
+assert_contains "T17c env 97 still treats 98% as exhausted" "wait for seven-day reset" "$out"
+
+# Explicit --threshold WINS over the env var.
+out=$(RESUME_SLOT_THRESHOLD=97 bash "$SLOT" --cache "$TMP/at95.json" --max-age 0 --threshold 90 --emit reason 2>&1); rc=$?
+assert_rc "T17d explicit --threshold exits 0" 0 "$rc"
+assert_contains "T17d explicit --threshold beats the env var" "wait for seven-day reset" "$out"
+assert_contains "T17d flag value (90) is the one applied" ">= 90%" "$out"
+
+# A typo'd env value falls back to the shipped default SILENTLY — this sits on
+# the resume-critical path (auto-arm -> arm-resume -> resume-slot), so it must
+# not error the way a bad FLAG does. Mirrors auto-arm-on-cap.sh:186.
+err=$(RESUME_SLOT_THRESHOLD=ninetyseven bash "$SLOT" --cache "$TMP/at95.json" --max-age 0 --emit reason 2>&1 >"$TMP/t17e-out"); rc=$?
+assert_rc "T17e non-numeric env exits 0 (no crash)" 0 "$rc"
+assert_contains "T17e non-numeric env falls back to 90" ">= 90%" "$(cat "$TMP/t17e-out")"
+assert_not_contains "T17e fallback is silent (no ERR line)" "ERR resume-slot" "$err"
+# Multi-dot and empty are the same class of typo — same rc-0 + silent contract
+# as T17e, asserted explicitly so a future regression that starts ERRing on one
+# of these shapes cannot hide behind the fallback-reason check alone.
+err=$(RESUME_SLOT_THRESHOLD=9..7 bash "$SLOT" --cache "$TMP/at95.json" --max-age 0 --emit reason 2>&1 >"$TMP/t17f-out"); rc=$?
+assert_rc "T17f multi-dot env exits 0 (no crash)" 0 "$rc"
+assert_contains "T17f multi-dot env falls back to 90" ">= 90%" "$(cat "$TMP/t17f-out")"
+assert_not_contains "T17f fallback is silent (no ERR line)" "ERR resume-slot" "$err"
+err=$(RESUME_SLOT_THRESHOLD='' bash "$SLOT" --cache "$TMP/at95.json" --max-age 0 --emit reason 2>&1 >"$TMP/t17g-out"); rc=$?
+assert_rc "T17g empty env exits 0 (no crash)" 0 "$rc"
+assert_contains "T17g empty env falls back to 90" ">= 90%" "$(cat "$TMP/t17g-out")"
+assert_not_contains "T17g fallback is silent (no ERR line)" "ERR resume-slot" "$err"
+
+# A bad --threshold FLAG still errors loudly, even with a valid env value set —
+# loudly meaning a diagnostic on stderr, not just a nonzero rc.
+err=$(RESUME_SLOT_THRESHOLD=97 bash "$SLOT" --threshold abc --cache "$TMP/at95.json" --max-age 0 2>&1 >/dev/null); rc=$?
+assert_rc "T17h bad --threshold flag still exits 1 under a valid env" 1 "$rc"
+assert_contains "T17h bad --threshold flag reports the value it rejected" "ERR resume-slot: --threshold must be a number in 0-100, got: abc" "$err"
+
+# ---------------------------------------------------------------------------
+# T18: RANGE guard (codex-adv, HIMMEL-1271). A syntactically-numeric but
+#      out-of-range value — 970, the fat-finger for 97 — would make every
+#      window's 0-100% utilization compare as headroom, so `--time smart`
+#      would pick ASAP and relaunch straight back into a walled bank. As an
+#      env var that misconfiguration PERSISTS across every arm, so it must be
+#      caught, not trusted.
+# ---------------------------------------------------------------------------
+err=$(RESUME_SLOT_THRESHOLD=970 bash "$SLOT" --cache "$TMP/at95.json" --max-age 0 --emit reason 2>&1 >"$TMP/t18-out"); rc=$?
+assert_rc "T18 out-of-range env exits 0 (no crash)" 0 "$rc"
+assert_contains "T18 out-of-range env falls back to 90 (not treated as headroom)" ">= 90%" "$(cat "$TMP/t18-out")"
+assert_not_contains "T18 env fallback is silent (no ERR line)" "ERR resume-slot" "$err"
+# The 95% window must still be EXHAUSTED — proving 970 never reached the compare.
+assert_contains "T18 95% still parks at the reset under a 970 typo" "wait for seven-day reset" "$(cat "$TMP/t18-out")"
+
+# An out-of-range explicit FLAG errors loudly (rc 1), like any other bad flag.
+err=$(bash "$SLOT" --threshold 101 --cache "$TMP/at95.json" --max-age 0 --emit reason 2>&1); rc=$?
+assert_rc "T18b --threshold 101 exits 1" 1 "$rc"
+assert_contains "T18b surfaces the 0-100 range in the error" "must be a number in 0-100" "$err"
+
+# Boundaries stay VALID: 0 and 100 are legal thresholds.
+out=$(bash "$SLOT" --threshold 100 --cache "$TMP/at95.json" --max-age 0 --emit reason 2>&1); rc=$?
+assert_rc "T18c --threshold 100 is valid" 0 "$rc"
+assert_contains "T18c at 100 a 95% window has headroom" "bank free" "$out"
+out=$(bash "$SLOT" --threshold 0 --cache "$TMP/at95.json" --max-age 0 --emit reason 2>&1); rc=$?
+assert_rc "T18d --threshold 0 is valid" 0 "$rc"
+assert_contains "T18d at 0 every window is exhausted" "wait for seven-day reset" "$out"
+
+# ...and the SAME boundaries via the env path — the range guard must ACCEPT
+# 0/100 there too, not quietly fall back to 90 (which would still produce a
+# plausible-looking slot and hide the bug).
+out=$(RESUME_SLOT_THRESHOLD=100 bash "$SLOT" --cache "$TMP/at95.json" --max-age 0 --emit reason 2>&1); rc=$?
+assert_rc "T18e env threshold 100 is valid" 0 "$rc"
+assert_contains "T18e env 100 leaves a 95% window with headroom" "bank free" "$out"
+assert_contains "T18e env 100 was applied, not the 90 fallback" "< 100%" "$out"
+out=$(RESUME_SLOT_THRESHOLD=0 bash "$SLOT" --cache "$TMP/at95.json" --max-age 0 --emit reason 2>&1); rc=$?
+assert_rc "T18f env threshold 0 is valid" 0 "$rc"
+assert_contains "T18f env 0 exhausts every window" "wait for seven-day reset" "$out"
+assert_contains "T18f env 0 was applied, not the 90 fallback" ">= 0%" "$out"
+
+# ---------------------------------------------------------------------------
+# T19: a two-arg option with NO value must fail with a MESSAGE, not silently
+#      (CodeRabbit). `shift 2` with one arg left returns nonzero, and under
+#      `set -e` that killed the script with rc 1 and empty stderr — which
+#      arm-resume then relayed as an empty error, the exact shape this
+#      script's "the block OWNS its error reporting" contract forbids.
+# ---------------------------------------------------------------------------
+for _opt in --threshold --buffer-min --cache --max-age --emit; do
+    err=$(bash "$SLOT" "$_opt" 2>&1 >/dev/null); rc=$?
+    assert_rc "T19 $_opt with no value exits 1" 1 "$rc"
+    assert_contains "T19 $_opt with no value says so" "ERR resume-slot: $_opt needs a value" "$err"
+done
+# The =VALUE form is unaffected, and a present-but-invalid value still takes the
+# normal validation path (a message about the VALUE, not about a missing one).
+err=$(bash "$SLOT" --threshold=abc --cache "$TMP/at95.json" --max-age 0 2>&1 >/dev/null); rc=$?
+assert_rc "T19b --threshold=abc exits 1" 1 "$rc"
+assert_contains "T19b --threshold=abc is a value error, not a missing-value error" "must be a number in 0-100" "$err"
+
+# A following OPTION is a missing value too — otherwise it is swallowed as the
+# value and the error points at the wrong (next) token.
+err=$(bash "$SLOT" --threshold --emit epoch 2>&1 >/dev/null); rc=$?
+assert_rc "T19c --threshold followed by an option exits 1" 1 "$rc"
+assert_contains "T19c blames the option, not the token after it" "--threshold needs a value (got the option '--emit')" "$err"
+assert_not_contains "T19c does not misreport the next arg as unknown" "unknown arg: epoch" "$err"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/hooks/auto-arm-on-cap.sh
+++ b/scripts/hooks/auto-arm-on-cap.sh
@@ -88,7 +88,12 @@
 #
 # Env knobs (all optional):
 #   AUTO_ARM_DISABLE=1          kill switch (set in the launching shell)
-#   AUTO_ARM_THRESHOLD          utilization % that trips the arm (default 90)
+#   AUTO_ARM_THRESHOLD          utilization % that trips the arm (default 90).
+#                               INDEPENDENT of the slot-resolution wall
+#                               RESUME_SLOT_THRESHOLD (resume-slot.sh, also
+#                               default 90), which decides ASAP-vs-wait once
+#                               this hook has tripped. Raising one does NOT
+#                               raise the other — set both (HIMMEL-1271).
 #   AUTO_ARM_CACHE              usage-cache path override
 #   AUTO_ARM_STATE_DIR          throttle/fired marker dir (default /tmp/claude)
 #   AUTO_ARM_CHECK_INTERVAL     seconds between real checks (default 60)


### PR DESCRIPTION
fix(handover): make the --time smart bank wall configurable

There were two independent 90% bank walls and only one was tunable. The
auto-arm watchdog's AUTO_ARM_THRESHOLD decides WHEN a resume is armed and was
already env-tunable; resume-slot.sh's THRESHOLD decides WHERE that resume is
parked and was a hardcoded literal. A --threshold flag existed but nothing
passed it and there was no env override, so every `--time smart` arm was pinned
at 90 regardless of the watchdog setting — parking the resume at the window
reset even when the operator considers that bank usable.

- resume-slot.sh: THRESHOLD="${RESUME_SLOT_THRESHOLD:-90}". An explicit
  --threshold still wins; a bad env value falls back to the default silently
  (this is the resume-critical path — an env typo must not break arming),
  mirroring the auto-arm-on-cap.sh contract; a bad flag still errors.
- arm-resume.sh: no flag pass-through by design (comment only) — resume-slot
  runs as a plain child, so the env var already reaches it down the whole
  auto-arm -> arm-resume -> resume-slot chain.
- auto-arm-on-cap.sh: header note that the two walls are independent.

Shipped default stays 90: the threshold is how much runway is left to write a
handover before the bank walls, so the conservative value is right for
adopters. Operators who want a tighter wall set both env vars.

Hardening found in review:
- Range guard 0-100. A syntactically-numeric but out-of-range value (970, the
  fat-finger for 97) made every window's 0-100% utilization read as headroom,
  so --time smart picked ASAP and relaunched into a walled bank — silently, on
  every arm, since the env var persists.
- All five two-arg options read "${2:-}" then `shift 2`; with the value missing
  that returned nonzero and `set -e` killed the script with rc 1 and EMPTY
  stderr, so arm-resume relayed an empty error. Now a clear usage line. A
  following option counts as a missing value too.

Docs: docs/configuration.md gains the RESUME_SLOT_THRESHOLD row plus a "the two
bank walls are INDEPENDENT" block; .env.example lists both keys together. Both
are process env — load-dotenv.sh bridges neither.

Tests: test-resume-slot.sh 83/83 (T17 env override, T18 range guard, T19
missing-value); test-arm-resume.sh gains T9b/T9c proving the env var reaches
resume-slot through arm-resume end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable utilization thresholds for automatic arming and resume-slot scheduling.
  - Resume-slot thresholds can be set through the environment, support fractional values from 0–100, and allow explicit command-line overrides.
  - Invalid environment values safely fall back to the default 90% threshold.

- **Bug Fixes**
  - Improved validation for missing or invalid command-line option values.
  - Clarified that automatic-arm and resume-slot thresholds operate independently.

- **Documentation**
  - Updated configuration and command help text with threshold behavior, defaults, and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->