### PR TITLE
fix(telegram): resolve Git Bash explicitly + read the bridge .env the docs point at

### DIFF
--- a/.claude/commands/cr-public.md
+++ b/.claude/commands/cr-public.md
@@ -17,9 +17,14 @@ are the structural exfil gate), `gh pr create`, and CR fix-pushes. Before ANY
 fix-push, leak-scan the outgoing delta first:
 `git -C <wt> diff origin/main...HEAD > <tmp>.patch && bash scripts/propagate-public.sh scan <tmp>.patch`
 — a finding blocks the push. The **public squash-merge stays human-authorized**:
-report PR-ready (URL + short head SHA + the ready-to-send `/mergepub <pr> <sha7>`
+report PR-ready (URL + short head SHA + the ready-to-send `/mergepub <pr> <sha12>`
 line + the PR URL for the GitHub-UI fallback) and STOP. Never run `gh pr merge` on
-the public repo yourself.
+the public repo yourself. **`sha12`, never `sha7`** — `router.ts`'s MERGEPUB regex
+requires `[0-9a-f]{12,40}`, so a 7-hex line fails the match and never reaches the
+auto-merge path — it falls through to ordinary chat, with no refusal to read back
+(HIMMEL-1270; the floor was raised from 7 in
+HIMMEL-1213 because a 7-hex prefix is grindable at ~2^28 and an agent can push to
+the public branch).
 
 ## 1. Resolve the target
 
@@ -111,7 +116,8 @@ code; trust the final `check-ci: verdict exit=N` line printed on stdout.)
   CR-clean + CI-green. **STOP here** and report PR-ready to the operator (do NOT
   merge): PR URL + short head SHA + the check-ci verdict + the diff-identity
   verdict (where the bounded-wait named-private-ref path ran) + the ready-to-send
-  `/mergepub <pr> <sha7>` line + the GitHub-UI fallback link. The printed
+  `/mergepub <pr> <sha12>` line (**12+ hex — a 7-hex SHA silently classifies as
+  chat**, see §intro) + the GitHub-UI fallback link. The printed
   `gh pr merge` command is kept only as the operator's terminal alternative:
   ```bash
   gh pr merge <pr> --squash --admin --repo <REPO>   # operator's terminal alternative

--- a/.env.example
+++ b/.env.example
@@ -429,10 +429,28 @@ ALIBABA_DASHSCOPE_BASE_URL=  # DashScope native endpoint (e.g. https://dashscope
 
 # --- Telegram bridge ---
 # The POLLER's TELEGRAM_BOT_TOKEN lives in ~/.claude/channels/telegram/.env
-# (scaffolded by scripts/setup/onboard-telegram.{sh,ps1}). Operator flags read
-# by the POLLER process (set where the poller runs; restart to apply):
-#   TELEGRAM_AUTO_ACTIONS=arm    enable privileged auto-commands (default: all OFF;
-#                                grammar mirrors HIMMEL_INITIATIVE, HIMMEL-424)
+# (scaffolded by scripts/setup/onboard-telegram.{sh,ps1}) and is read from THAT
+# FILE ONLY -- a TELEGRAM_BOT_TOKEN in the process env never overrides it. That is
+# deliberate: the jira-nudge relay below reads a TELEGRAM_BOT_TOKEN from THIS repo
+# .env, and it is usually a DIFFERENT bot; if the process env could win, launching
+# the bridge from a shell that had sourced this file would authenticate the poller
+# as the relay bot (deaf bridge, or two consumers racing one getUpdates offset).
+#
+# TELEGRAM_AUTO_ACTIONS is read from that SAME bridge file, or from the poller's
+# process env (which wins). Every other flag below is process-env ONLY.
+# Restart the bridge to apply either way.
+#   TELEGRAM_AUTO_ACTIONS=arm-resume        enable privileged auto-commands.
+#                                Default: all OFF. Grammar mirrors HIMMEL_INITIATIVE
+#                                (HIMMEL-424). Valid op names are EXACTLY:
+#                                  arm-resume     -> /arm
+#                                  merge-public   -> /mergepub
+#                                Anything else is dropped, so `=arm` (no `-resume`)
+#                                enables NOTHING -- the poller now warns loudly at
+#                                startup when a configured value parses to no ops.
+#                                `=1`/`all`/`on`/`yes` enable arm-resume but NEVER
+#                                merge-public: the public squash-merge is
+#                                EXPLICIT_ONLY and must be named
+#                                (`=merge-public` or `=arm-resume,merge-public`).
 #   TELEGRAM_CLAUDE_MODEL=opus   model pin for bridge-spawned bounded runs
 #                                (default opus; never inherits the operator default)
 # NOTE: the HIMMEL_JIRA_NUDGE SessionEnd relay does NOT read the poller's env --

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -443,7 +443,7 @@ change; token and access config live *outside* the repo):
 |---|---|---|---|
 | `TELEGRAM_BOT_TOKEN` | — | `~/.claude/channels/telegram/.env` (path override `TELEGRAM_ENV`) | bot auth. A *separate* copy in the repo `.env` feeds only the opt-in jira-nudge / session-status relays |
 | `access.json` (`TELEGRAM_ACCESS_PATH`) | — | `~/.claude/channels/telegram/access.json` | the allowlist: `allowFrom` (DM senders), `groups` (chat-id keys), per-group `allowFrom`/`vault`, `defaultVault`. Fails closed |
-| `TELEGRAM_AUTO_ACTIONS` | OFF | own .env | enables `/arm` (`arm-resume`) and `/mergepub` (`merge-public`) per-op; `merge-public` must be named explicitly — `all` never enables it |
+| `TELEGRAM_AUTO_ACTIONS` | OFF | bridge .env *or* process env (process wins) | enables `/arm` (`arm-resume`) and `/mergepub` (`merge-public`) per-op; `merge-public` must be named explicitly — `all` never enables it. Op names are exactly `arm-resume` / `merge-public`; the whole-value aliases `1`/`all`/`on`/`yes` enable `arm-resume` only, and any other unrecognised token parses to nothing (the poller warns at startup, naming the dropped tokens) |
 | `TELEGRAM_CLAUDE_MODEL` | `opus` | own .env | model pin for bounded bridge runs (never inherits your default) |
 | `TELEGRAM_MAX_CONCURRENT_RUNS` / `TELEGRAM_RETRY_MS` / `TELEGRAM_MAX_RETRIES` / `RUN_TIMEOUT_MS` | 2 / 15min / 3 / 30min | own .env | run concurrency/retry/deadline |
 | `TELEGRAM_TRIAGE` (+ `_MODEL`, `_PROVIDER`, `_TIMEOUT_MS`) | on (`deepseek-v4-flash`) | own .env | cheap group-message triage classifier; `TELEGRAM_TRIAGE=off` disables |
@@ -578,7 +578,7 @@ tables; this is the layer level.)
 | Recurring vault cadence | `scripts/luna/pipeline-cadence.sh disarm` | OS scheduler |
 | An overnight run in flight | `/stop` (graceful, marker-based; `--hard` also stops subagents) | marker file |
 | Telegram bridge | never started unless you start it; stop: `bun --cwd scripts/telegram supervisor.ts --kill`; remove the optional logon task: `pwsh -File scripts/telegram/install-logon-task.ps1 -Remove` | process / scheduler |
-| Telegram privileged ops | leave/unset `TELEGRAM_AUTO_ACTIONS` (default OFF; `merge-public` needs explicit naming even then) | bridge env |
+| Telegram privileged ops | default OFF — but there are now TWO sources, so "unset it" is not enough: clear/empty `TELEGRAM_AUTO_ACTIONS` in the bridge `.env` **and** unset any process override. For one run without editing the file, launch the bridge with `TELEGRAM_AUTO_ACTIONS=` (defined-but-empty beats the file). (`merge-public` needs explicit naming even when enabled) | bridge .env *or* process env (process wins) |
 | An external lane | `node scripts/lanes/set-lane-override.mjs <lane> never`, or unset its API key / remove its CLI from PATH | machine |
 | Lane config auto-reseed | `CLAUDE_LANE_AUTO_RESEED=0` | launching shell |
 | External CR critics | `CR_PROFILE=none` (claude-only review, no external spend) | `.env` / shell |

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -1401,8 +1401,18 @@ aliases do NOT enable it — it requires being NAMED explicitly (`=merge-public`
 cannot silently inherit the merge capability** (HIMMEL-1213 CR). The enable-all
 aliases turn on every *non-EXPLICIT_ONLY* known op. The dispatch-table keys
 (`OPS`/`KNOWN_OPS` in `auto-action.ts`) are the closed op allow-list, re-asserted in
-`auto-action.sh`; `EXPLICIT_ONLY_OPS` is the privileged subset the alias skips. Set it in the bridge's
-launching env + restart the bridge to activate.
+`auto-action.sh`; `EXPLICIT_ONLY_OPS` is the privileged subset the alias skips.
+
+**Where to set `TELEGRAM_AUTO_ACTIONS` (HIMMEL-1270)** — the flag; `EXPLICIT_ONLY_OPS`
+above is a code-defined constant, not an operator setting. Either the bridge's own
+`~/.claude/channels/telegram/.env` (the file that already holds
+`TELEGRAM_BOT_TOKEN`) or the poller's launching env — a real process env var wins
+over the file. Restart the bridge to apply either way. Until HIMMEL-1270 the
+poller read this key from `process.env` ONLY while the docs pointed at the file,
+so a correctly-edited `.env` enabled nothing and `/mergepub` silently routed as
+chat. A configured value that parses to zero ops (e.g. `arm` instead of
+`arm-resume`) now logs a startup WARNING naming the unrecognised tokens, so
+"I enabled it and nothing happened" is no longer indistinguishable from "it's off".
 
 **Guards (fail-closed):**
 - **Operator-identity** — an auto-command runs only when the SENDER is the allowlisted

--- a/docs/internals/environment-gotchas.md
+++ b/docs/internals/environment-gotchas.md
@@ -32,6 +32,28 @@ fallback path. Operator hand-off commands that call bash on Windows must use the
 full Git Bash path `& "C:\Program Files\Git\bin\bash.exe" …`. (This is the same
 stub Codex's hook wrapper has to skip — see `harness-compat.md`.)
 
+**It bites long-running child processes too, and there it is silent.** A
+`spawn(["bash", "<abs-script>"])` from Node/Bun resolves `bash` through the
+*spawning process's* PATH — which for a daemon is whatever its launcher had, not
+your interactive shell's. The telegram bridge's supervisor is started by the
+`HimmelTelegramBridge` scheduled task under `pwsh -NoProfile`, whose PATH puts
+System32 ahead of `Git\bin`, so every `bash` the poller spawned hit the stub and
+exited 127 (HIMMEL-1279). Two things make this hard to see:
+
+- **POSIX-ifying the path does not help.** The stub eats the backslashes during
+  the WSL argv translation, so the error text reads
+  `/bin/bash: C:UsersyotamDocuments…: No such file or directory` and looks like a
+  quoting bug — but it exits 127 on `C:/…` too. Resolve the *interpreter*, not
+  the argument.
+- **Reproducing it from an interactive shell misleads you**, because that PATH
+  usually has `Git\bin` first. Probe with the stub named explicitly
+  (`C:\Windows\System32\bash.exe`), or read the daemon's own log.
+
+TS/JS side: use the shared `resolveBash()` / `BASH_BIN` in
+`scripts/telegram/run.ts` (candidates first, `git.exe`-derived root next, PATH
+last minus `system32`/`windowsapps`) rather than a literal `"bash"`. Shell side
+has `cygpath`; the `.ps1` side has the snippet above.
+
 ## Windows WSL / Docker resource budget
 
 WSL2 and Docker Desktop share the Windows host's CPU, memory, disk IO, and page

--- a/scripts/telegram/README.md
+++ b/scripts/telegram/README.md
@@ -166,6 +166,58 @@ allowlist edit.
 — plain message ingested, bounded run replied INTO the group, DM untouched;
 an allowlisted channel — first post surfaced its id via the gated-out log,
 allowlisted + restarted, posts then processed with replies into the channel.
+
+## Privileged auto-commands — `/arm` and `/mergepub` (default OFF)
+
+Two commands are executed by the TRUSTED bridge itself rather than by a spawned
+Claude session — the agent is never in the trust path:
+
+| Command | Op name | What it does |
+|---|---|---|
+| `/arm <ticket-or-path> [at HH:MM\|auto\|smart]` | `arm-resume` | schedules a resume session via `arm-resume.sh` (time defaults to `smart`) |
+| `/mergepub <pr> <sha12>` | `merge-public` | SHA-bound squash-merge of a PUBLIC propagation PR |
+
+**Both ship disabled.** Enable per-op with `TELEGRAM_AUTO_ACTIONS`, read from the
+bridge's own `~/.claude/channels/telegram/.env` (the file that already holds
+`TELEGRAM_BOT_TOKEN`) **or** the poller's process env — a process env var wins.
+Restart the bridge to apply.
+
+`TELEGRAM_AUTO_ACTIONS` is the *only* key that takes a process override.
+`TELEGRAM_BOT_TOKEN` is read from that file and nowhere else, because the repo
+`.env` holds a different bot's token for the jira-nudge relay.
+
+```ini
+# ~/.claude/channels/telegram/.env
+TELEGRAM_AUTO_ACTIONS=arm-resume,merge-public
+```
+
+Rules worth knowing before you edit that line:
+
+- The op names are exactly `arm-resume` and `merge-public`. Unknown tokens are
+  dropped, so `TELEGRAM_AUTO_ACTIONS=arm` enables **nothing** — the poller now
+  logs a startup `WARNING: … enables NOTHING` naming the bad tokens (HIMMEL-1270;
+  before that it was silent and indistinguishable from "off").
+- `=1`/`all`/`on`/`yes` enable `arm-resume` but **never** `merge-public`. The
+  public merge is `EXPLICIT_ONLY` — it must be named, so an operator running `=1`
+  cannot silently inherit the capability.
+- `/mergepub` needs a **12+ hex** SHA (`[0-9a-f]{12,40}`). A 7-hex one fails the
+  router regex and reads as ordinary chat.
+- Launching the bridge with `TELEGRAM_AUTO_ACTIONS=` (defined but empty) is the
+  one-run kill switch: an explicitly empty process value beats the file, so it
+  turns file-enabled ops off without editing anything.
+- A disabled or unmatched auto-command is not an error: it never enters the
+  auto-action path, it routes as normal chat. Diagnosing a `/mergepub` that did
+  not merge: if it produced no merge AND no refusal message, check the three
+  points above (enabled? named explicitly? 12+ hex?). If it produced a refusal —
+  `not-green`, `head-moved`, `no-open-pr` — it DID match and the chokepoint
+  declined; `auto-action-audit.log` records which, one line per attempt.
+- Guards are unconditional and fail-closed: operator-only sender, typed (not a
+  caption), not forwarded, whole-message match. Every attempt — executed or
+  refused — appends one line to `~/.claude/handover/bridge/auto-action-audit.log`.
+
+Semantics + threat model: [`docs/internals/enforcement.md`](../../docs/internals/enforcement.md).
+Where each knob is set: [`docs/configuration.md`](../../docs/configuration.md).
+
 ## Group triage (HIMMEL-721)
 
 Plain group/channel chat is fronted by a cheap classifier before the bridge

--- a/scripts/telegram/auto-action.test.ts
+++ b/scripts/telegram/auto-action.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-  OPS, KNOWN_OPS, parseEnabledOps, isExecutableAutoCommand,
+  OPS, KNOWN_OPS, parseEnabledOps, describeEnabledOps, isExecutableAutoCommand,
   dispatchAutoAction, formatAuditLine, appendAuditLine, type AuditFields,
 } from "./auto-action";
 import type { Route } from "./router";
@@ -167,4 +167,64 @@ test("appendAuditLine appends a line and swallows a write failure (best-effort)"
   // injected writer that rejects → swallowed, no throw (best-effort contract)
   const boom = appendAuditLine(dir, { write: async () => { throw new Error("disk full"); } });
   await expect(boom(base)).resolves.toBeUndefined();
+});
+
+// --- describeEnabledOps: configured-but-inert must SAY so (HIMMEL-1270) ---
+
+test("describeEnabledOps: a value that enables ops returns no warning", () => {
+  expect(describeEnabledOps("arm-resume", KNOWN_OPS)).toEqual({ ops: new Set(["arm-resume"]) });
+  expect(describeEnabledOps("arm-resume,merge-public", KNOWN_OPS).warning).toBeUndefined();
+  expect(describeEnabledOps("1", KNOWN_OPS).warning).toBeUndefined();
+});
+
+test("describeEnabledOps: deliberately-off values are silent, not warnings", () => {
+  for (const off of [undefined, "", "  ", "0", "off", "no", "false", "OFF"]) {
+    const { ops, warning } = describeEnabledOps(off, KNOWN_OPS);
+    expect(ops.size).toBe(0);
+    expect(warning).toBeUndefined();
+  }
+});
+
+test("describeEnabledOps: the shipped .env.example typo warns and names the bad token (HIMMEL-1270)", () => {
+  // `arm` is what .env.example taught; KNOWN_OPS has `arm-resume`. It parsed to
+  // the empty set and the poller logged NOTHING — indistinguishable from "off",
+  // which is why the misconfiguration survived four days.
+  const { ops, warning } = describeEnabledOps("arm", KNOWN_OPS);
+  expect(ops.size).toBe(0);
+  expect(warning).toContain("enables NOTHING");
+  expect(warning).toContain("arm");
+  expect(warning).toContain("arm-resume");
+  expect(warning).toContain("merge-public");
+});
+
+test("describeEnabledOps: warns on an all-unknown list and reports every bad token", () => {
+  const { ops, warning } = describeEnabledOps("arm, mergepub", KNOWN_OPS);
+  expect(ops.size).toBe(0);
+  expect(warning).toContain("arm");
+  expect(warning).toContain("mergepub");
+});
+
+test("describeEnabledOps: a partially-valid list enables what it can AND names the dropped token", () => {
+  // glm CR: /arm works, the "auto-actions enabled:" line looks healthy, and
+  // /mergepub stays inert with no explanation — this ticket's failure in a quieter costume.
+  const { ops, warning } = describeEnabledOps("arm-resume,mergepublic", KNOWN_OPS);
+  expect(ops).toEqual(new Set(["arm-resume"]));
+  expect(warning).toContain("DROPPED");
+  expect(warning).toContain("mergepublic");
+});
+
+test("describeEnabledOps: the warning states the EXPLICIT_ONLY rule (merge-public is not covered by =1)", () => {
+  // The second half of the 1270 doc defect: `=1` looks like "enable everything"
+  // but never turns on merge-public, and nothing said so.
+  expect(describeEnabledOps("1", KNOWN_OPS).ops.has("merge-public")).toBe(false);
+  expect(describeEnabledOps("arm", KNOWN_OPS).warning).toContain("named explicitly");
+});
+
+test("describeEnabledOps: the whole-value enable-all aliases are never treated as op tokens", () => {
+  // `1` is not in KNOWN_OPS, but it is an alias, not a typo — warning it would be noise.
+  for (const alias of ["1", "all", "on", "yes", "true", "ALL"]) {
+    const { ops, warning } = describeEnabledOps(alias, KNOWN_OPS);
+    expect(ops).toEqual(new Set(["arm-resume"]));
+    expect(warning).toBeUndefined();
+  }
 });

--- a/scripts/telegram/auto-action.ts
+++ b/scripts/telegram/auto-action.ts
@@ -48,6 +48,40 @@ export function parseEnabledOps(raw: string | undefined, knownOps: Set<string>):
   return out;
 }
 
+// Whole-value aliases. Both parse to a deliberate outcome and carry no op-name
+// list, so there are no tokens to validate and nothing to warn about.
+const OFF_ALIASES = new Set(["", "0", "off", "no", "false"]);
+const ON_ALIASES = new Set(["1", "all", "on", "yes", "true"]);
+
+// describeEnabledOps (HIMMEL-1270) — the startup line(s) for TELEGRAM_AUTO_ACTIONS.
+// The failure this exists for: the shipped `.env.example` taught
+// `TELEGRAM_AUTO_ACTIONS=arm`, which is not a token in KNOWN_OPS (`arm-resume` is),
+// so it parsed to the EMPTY set and enabled nothing — and the poller only logged
+// when the set was NON-empty, making "I enabled it and nothing happened"
+// indistinguishable from "it's off". A configured-but-inert value now says so, and
+// names the tokens it did not recognise.
+export function describeEnabledOps(raw: string | undefined, knownOps: Set<string>): { ops: Set<string>; warning?: string } {
+  const ops = parseEnabledOps(raw, knownOps);
+  const v = (raw ?? "").trim().toLowerCase();
+  if (OFF_ALIASES.has(v) || ON_ALIASES.has(v)) return { ops };
+  const unknown = v.split(",").map((t) => t.trim()).filter((t) => t && !knownOps.has(t));
+  // A PARTIALLY valid list warns too: `arm-resume,mergepublic` enables /arm, so the
+  // "auto-actions enabled:" line looks healthy while /mergepub stays inert with no
+  // explanation — the same puzzle in a quieter costume.
+  if (ops.size > 0 && unknown.length === 0) return { ops };
+  const tail =
+    `Valid ops: ${[...knownOps].join(", ")}` +
+    ` (${[...EXPLICIT_ONLY_OPS].join(", ")} must be named explicitly — the =1/all/on/yes aliases never enable them).`;
+  const dropped = unknown.length ? ` unrecognised token(s): ${unknown.join(", ")}.` : "";
+  return {
+    ops,
+    warning:
+      ops.size === 0
+        ? `TELEGRAM_AUTO_ACTIONS="${raw}" enables NOTHING —${dropped || " no valid op names in it."} ${tail}`
+        : `TELEGRAM_AUTO_ACTIONS="${raw}" enabled ${[...ops].join(",")} but DROPPED${dropped} ${tail}`,
+  };
+}
+
 // The injection-test seam (pure). An auto-command executes ONLY when it is a typed
 // (caption === false), non-forwarded (forwarded === false) auto route. Strict `=== false`
 // so an unknown/undefined flag refuses rather than fail-open — this is THE security

--- a/scripts/telegram/poller.test.ts
+++ b/scripts/telegram/poller.test.ts
@@ -3,9 +3,10 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readNewLines, readMeta, writeMeta, ensureSession, appendLine, sessionDir } from "./bus";
-import { ingestUpdates, loadOffset, handleInbound, handleAutoCommand, replyViaOutbox, runAndSettle, reconcile, flushOutboxes, isRetryDue, peekPending, commitPending, makeRunFn, makeAllow, makeDispatcher, makeFetchVoice, sweepStuckRunning, signalTyping, guarded, deliverAllPending, sweepAttachments, resolveRetentionMs, noticeText, type FetchImageFn } from "./poller";
+import { ingestUpdates, loadOffset, handleInbound, handleAutoCommand, replyViaOutbox, runAndSettle, reconcile, flushOutboxes, isRetryDue, peekPending, commitPending, makeRunFn, makeAllow, makeDispatcher, makeFetchVoice, sweepStuckRunning, signalTyping, guarded, deliverAllPending, sweepAttachments, resolveRetentionMs, noticeText, parseBridgeEnv, loadBridgeEnv, bridgeEnvOrigin, type FetchImageFn } from "./poller";
 import { readFile, writeFile, mkdir, utimes } from "node:fs/promises";
 import { isAllowed, vaultForChat } from "./gate";
+import { describeEnabledOps, KNOWN_OPS } from "./auto-action";
 import type { TriageVerdict } from "./triage";
 
 const root = () => mkdtempSync(join(tmpdir(), "poller-"));
@@ -1593,4 +1594,197 @@ test("makeRunFn: an empty-string vault normalizes to null (repoCwd, no bypass) �
   await makeRunFn(r, "/repo", spy, 5000, undefined, 3, () => "")("E");   // blank vault
   expect(calls[0].cwd).toBe("/repo");                   // not "" — normalized
   expect(calls[0].mode).toBeUndefined();                // no bypass for a falsy vault
+});
+
+// --- bridge config file: TELEGRAM_AUTO_ACTIONS is read from it (HIMMEL-1270) ---
+
+test("parseBridgeEnv reads both keys, ignores comments, and strips surrounding quotes", () => {
+  const parsed = parseBridgeEnv([
+    "# TELEGRAM_AUTO_ACTIONS=commented-out-must-not-win",
+    "TELEGRAM_BOT_TOKEN=123:abc",
+    'TELEGRAM_AUTO_ACTIONS="arm-resume,merge-public"',
+    "UNRELATED=x",
+  ].join("\n"));
+  expect(parsed.TELEGRAM_BOT_TOKEN).toBe("123:abc");
+  expect(parsed.TELEGRAM_AUTO_ACTIONS).toBe("arm-resume,merge-public");
+});
+
+test("parseBridgeEnv tolerates spacing, single quotes and a missing key", () => {
+  const parsed = parseBridgeEnv("TELEGRAM_BOT_TOKEN =  '9:z' \n");
+  expect(parsed.TELEGRAM_BOT_TOKEN).toBe("9:z");
+  expect(parsed.TELEGRAM_AUTO_ACTIONS).toBeUndefined();
+});
+
+test("loadBridgeEnv reads TELEGRAM_AUTO_ACTIONS from the file the docs point at (HIMMEL-1270)", async () => {
+  // The bug: the poller read this key from process.env ONLY, so the operator's
+  // correctly-edited bridge config enabled nothing and /mergepub routed as chat.
+  const dir = mkdtempSync(join(tmpdir(), "bridgecfg-"));
+  const cfg = join(dir, "bridge-config");
+  await writeFile(cfg, "TELEGRAM_BOT_TOKEN=1:tok\nTELEGRAM_AUTO_ACTIONS=arm-resume,merge-public\n");
+  const prevPath = process.env.TELEGRAM_ENV;
+  const prevOps = process.env.TELEGRAM_AUTO_ACTIONS;
+  process.env.TELEGRAM_ENV = cfg;
+  delete process.env.TELEGRAM_AUTO_ACTIONS;
+  try {
+    const env = await loadBridgeEnv();
+    expect(env.TELEGRAM_BOT_TOKEN).toBe("1:tok");
+    expect(env.TELEGRAM_AUTO_ACTIONS).toBe("arm-resume,merge-public");
+    expect(env.path).toBe(cfg);
+  } finally {
+    if (prevPath === undefined) delete process.env.TELEGRAM_ENV; else process.env.TELEGRAM_ENV = prevPath;
+    if (prevOps !== undefined) process.env.TELEGRAM_AUTO_ACTIONS = prevOps;
+  }
+});
+
+test("loadBridgeEnv: a real process env var WINS over the file (launching shell is the narrower scope)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "bridgecfg-"));
+  const cfg = join(dir, "bridge-config");
+  await writeFile(cfg, "TELEGRAM_BOT_TOKEN=1:fromfile\nTELEGRAM_AUTO_ACTIONS=arm-resume\n");
+  const prevPath = process.env.TELEGRAM_ENV;
+  const prevOps = process.env.TELEGRAM_AUTO_ACTIONS;
+  process.env.TELEGRAM_ENV = cfg;
+  process.env.TELEGRAM_AUTO_ACTIONS = "merge-public";
+  try {
+    const env = await loadBridgeEnv();
+    expect(env.TELEGRAM_AUTO_ACTIONS).toBe("merge-public");
+    expect(env.TELEGRAM_BOT_TOKEN).toBe("1:fromfile");   // not set in process env → file wins
+  } finally {
+    if (prevPath === undefined) delete process.env.TELEGRAM_ENV; else process.env.TELEGRAM_ENV = prevPath;
+    if (prevOps === undefined) delete process.env.TELEGRAM_AUTO_ACTIONS; else process.env.TELEGRAM_AUTO_ACTIONS = prevOps;
+  }
+});
+
+test("loadBridgeEnv still throws when no token is resolvable anywhere", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "bridgecfg-"));
+  const cfg = join(dir, "bridge-config");
+  await writeFile(cfg, "TELEGRAM_AUTO_ACTIONS=arm-resume\n");
+  const prevPath = process.env.TELEGRAM_ENV;
+  const prevTok = process.env.TELEGRAM_BOT_TOKEN;
+  process.env.TELEGRAM_ENV = cfg;
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  try {
+    await expect(loadBridgeEnv()).rejects.toThrow("TELEGRAM_BOT_TOKEN not found");
+  } finally {
+    if (prevPath === undefined) delete process.env.TELEGRAM_ENV; else process.env.TELEGRAM_ENV = prevPath;
+    if (prevTok !== undefined) process.env.TELEGRAM_BOT_TOKEN = prevTok;
+  }
+});
+
+test("loadBridgeEnv: an EMPTY process TELEGRAM_AUTO_ACTIONS disables file-enabled ops (kill switch)", async () => {
+  // `TELEGRAM_AUTO_ACTIONS=` in the launching shell is how the operator turns
+  // privileged ops off for one run. Treating it as "unset" would leave the
+  // file's merge-public enabled — a fail-OPEN on the privileged direction.
+  const dir = mkdtempSync(join(tmpdir(), "bridgecfg-"));
+  const cfg = join(dir, "bridge-config");
+  await writeFile(cfg, "TELEGRAM_BOT_TOKEN=1:tok\nTELEGRAM_AUTO_ACTIONS=arm-resume,merge-public\n");
+  const prevPath = process.env.TELEGRAM_ENV;
+  const prevOps = process.env.TELEGRAM_AUTO_ACTIONS;
+  process.env.TELEGRAM_ENV = cfg;
+  process.env.TELEGRAM_AUTO_ACTIONS = "";
+  try {
+    const env = await loadBridgeEnv();
+    expect(env.TELEGRAM_AUTO_ACTIONS).toBe("");
+    expect(describeEnabledOps(env.TELEGRAM_AUTO_ACTIONS, KNOWN_OPS).ops.size).toBe(0);
+    expect(env.TELEGRAM_BOT_TOKEN).toBe("1:tok");   // token untouched by the kill switch
+  } finally {
+    if (prevPath === undefined) delete process.env.TELEGRAM_ENV; else process.env.TELEGRAM_ENV = prevPath;
+    if (prevOps === undefined) delete process.env.TELEGRAM_AUTO_ACTIONS; else process.env.TELEGRAM_AUTO_ACTIONS = prevOps;
+  }
+});
+
+test("loadBridgeEnv: NO process TELEGRAM_BOT_TOKEN can override the bridge file's (HIMMEL-1270 CR)", async () => {
+  // The token is FILE-ONLY, as loadToken() always was. This repo runs a SECOND
+  // bot: the HIMMEL_JIRA_NUDGE SessionEnd relay reads TELEGRAM_BOT_TOKEN from the
+  // repo .env. If the process env could win, launching the bridge from a shell
+  // that had sourced that file would authenticate the poller AS THE RELAY BOT —
+  // a deaf bridge, or two consumers racing the same getUpdates offset.
+  const dir = mkdtempSync(join(tmpdir(), "bridgecfg-"));
+  const cfg = join(dir, "bridge-config");
+  await writeFile(cfg, "TELEGRAM_BOT_TOKEN=1:bridgebot\n");
+  const prevPath = process.env.TELEGRAM_ENV;
+  const prevTok = process.env.TELEGRAM_BOT_TOKEN;
+  process.env.TELEGRAM_ENV = cfg;
+  try {
+    for (const intruder of ["9:relaybot", ""]) {
+      process.env.TELEGRAM_BOT_TOKEN = intruder;
+      const env = await loadBridgeEnv();
+      expect(env.TELEGRAM_BOT_TOKEN).toBe("1:bridgebot");
+      expect(env.source.TELEGRAM_BOT_TOKEN).toBe("file");
+    }
+  } finally {
+    if (prevPath === undefined) delete process.env.TELEGRAM_ENV; else process.env.TELEGRAM_ENV = prevPath;
+    if (prevTok === undefined) delete process.env.TELEGRAM_BOT_TOKEN; else process.env.TELEGRAM_BOT_TOKEN = prevTok;
+  }
+});
+
+test("parseBridgeEnv: an empty scaffold placeholder never masks a later real token (HIMMEL-1270 CR)", async () => {
+  // scripts/setup/onboard-telegram.{sh,ps1} writes a literal `TELEGRAM_BOT_TOKEN=`
+  // placeholder. An operator who APPENDED the real token has a working bridge;
+  // first-match-wins would resolve the empty line and abort startup on upgrade.
+  // Same rule as scripts/lib/load-dotenv.sh: FIRST NON-EMPTY assignment wins.
+  const parsed = parseBridgeEnv([
+    "# Telegram bot token for the himmel bun bridge",
+    "TELEGRAM_BOT_TOKEN=",
+    "TELEGRAM_BOT_TOKEN=1:real",
+  ].join("\n"));
+  expect(parsed.TELEGRAM_BOT_TOKEN).toBe("1:real");
+  // …and the reverse arrangement (real first) is unchanged.
+  expect(parseBridgeEnv("TELEGRAM_BOT_TOKEN=1:real\nTELEGRAM_BOT_TOKEN=\n").TELEGRAM_BOT_TOKEN).toBe("1:real");
+  // A key whose ONLY assignment is empty still resolves to "" — meaningful for
+  // TELEGRAM_AUTO_ACTIONS (explicitly off), and a throw for the token.
+  expect(parseBridgeEnv("TELEGRAM_AUTO_ACTIONS=\n").TELEGRAM_AUTO_ACTIONS).toBe("");
+});
+
+test("loadBridgeEnv tracks provenance so a warning points at the right place (HIMMEL-1270 CR)", async () => {
+  // A typo'd PROCESS value that was reported as "read from <file>" would send the
+  // operator to edit the file; after restart the process value wins again and
+  // /mergepub is still dead.
+  const dir = mkdtempSync(join(tmpdir(), "bridgecfg-"));
+  const cfg = join(dir, "bridge-config");
+  await writeFile(cfg, "TELEGRAM_BOT_TOKEN=1:tok\nTELEGRAM_AUTO_ACTIONS=arm-resume\n");
+  const prevPath = process.env.TELEGRAM_ENV;
+  const prevOps = process.env.TELEGRAM_AUTO_ACTIONS;
+  process.env.TELEGRAM_ENV = cfg;
+  try {
+    delete process.env.TELEGRAM_AUTO_ACTIONS;
+    const fromFile = await loadBridgeEnv();
+    expect(fromFile.source.TELEGRAM_AUTO_ACTIONS).toBe("file");
+    expect(bridgeEnvOrigin(fromFile, "TELEGRAM_AUTO_ACTIONS")).toBe(cfg);
+
+    process.env.TELEGRAM_AUTO_ACTIONS = "arm";        // the typo, in the process env
+    const fromProc = await loadBridgeEnv();
+    expect(fromProc.source.TELEGRAM_AUTO_ACTIONS).toBe("process env");
+    expect(bridgeEnvOrigin(fromProc, "TELEGRAM_AUTO_ACTIONS")).toContain("process env");
+    expect(bridgeEnvOrigin(fromProc, "TELEGRAM_AUTO_ACTIONS")).not.toContain(cfg);
+    expect(describeEnabledOps(fromProc.TELEGRAM_AUTO_ACTIONS, KNOWN_OPS).warning).toContain("enables NOTHING");
+    // the token still came from the file — provenance is per-key, not global
+    expect(bridgeEnvOrigin(fromProc, "TELEGRAM_BOT_TOKEN")).toBe(cfg);
+  } finally {
+    if (prevPath === undefined) delete process.env.TELEGRAM_ENV; else process.env.TELEGRAM_ENV = prevPath;
+    if (prevOps === undefined) delete process.env.TELEGRAM_AUTO_ACTIONS; else process.env.TELEGRAM_AUTO_ACTIONS = prevOps;
+  }
+});
+
+test("parseBridgeEnv: a later TELEGRAM_AUTO_ACTIONS assignment REVOKES an earlier one (HIMMEL-1270 CR)", async () => {
+  // Opposite rule from the token, deliberately. This is a CAPABILITY flag: with
+  // first-wins, an operator who appended `off` under an existing
+  // `merge-public` line would still have a live public-merge capability while
+  // believing they revoked it. Last-wins fails toward LESS capability, and reads
+  // the way an operator scanning the file top-to-bottom expects.
+  const revoke = (second: string) =>
+    parseBridgeEnv(`TELEGRAM_AUTO_ACTIONS=arm-resume,merge-public\nTELEGRAM_AUTO_ACTIONS=${second}\n`).TELEGRAM_AUTO_ACTIONS;
+  expect(revoke("")).toBe("");                      // appended empty  -> off
+  expect(revoke("off")).toBe("off");                // appended off    -> off
+  expect(revoke("arm-resume")).toBe("arm-resume");  // narrowed        -> no merge-public
+  for (const v of ["", "off", "arm-resume"])
+    expect(describeEnabledOps(revoke(v), KNOWN_OPS).ops.has("merge-public")).toBe(false);
+  // …while the token keeps first-non-empty in the SAME file, unaffected.
+  const both = parseBridgeEnv([
+    "TELEGRAM_BOT_TOKEN=",
+    "TELEGRAM_BOT_TOKEN=1:real",
+    "TELEGRAM_AUTO_ACTIONS=merge-public",
+    "TELEGRAM_AUTO_ACTIONS=",
+  ].join("\n"));
+  expect(both.TELEGRAM_BOT_TOKEN).toBe("1:real");
+  expect(both.TELEGRAM_AUTO_ACTIONS).toBe("");
 });

--- a/scripts/telegram/poller.ts
+++ b/scripts/telegram/poller.ts
@@ -3,10 +3,10 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { appendLine, atomicWrite, bridgeRoot, ensureSession, readMeta, writeMeta, sessionDir, readNewLines, truncateFullyConsumed, type Meta } from "./bus";
 import { classify, type Route } from "./router";
-import { dispatchAutoAction, parseEnabledOps, KNOWN_OPS, appendAuditLine, type RunScriptFn, type AuditFields } from "./auto-action";
+import { dispatchAutoAction, describeEnabledOps, KNOWN_OPS, appendAuditLine, type RunScriptFn, type AuditFields } from "./auto-action";
 import { getUpdates, sendMessage, sendChatAction, getFile, downloadFile } from "./telegram-api";
 import { isAllowed, isGroupAllowed, loadAccess, vaultForChat, type Access } from "./gate";
-import { runSession, buildPrompt, type BusPaths, type PermissionMode } from "./run";
+import { runSession, buildPrompt, BASH_BIN, type BusPaths, type PermissionMode } from "./run";
 import { classifyForSpawn, type TriageVerdict, type TriageModelOverride } from "./triage";
 import { transcribe } from "./transcribe";
 
@@ -788,12 +788,118 @@ export async function sweepAttachments(dir: string, maxAgeMs: number = ATTACHMEN
   return removed;
 }
 
-async function loadToken(): Promise<string> {
+// Bridge config file (HIMMEL-1270). Until now the ONLY key ever read out of
+// ~/.claude/channels/telegram/.env was TELEGRAM_BOT_TOKEN, while the shipped docs
+// told operators to set TELEGRAM_AUTO_ACTIONS there too — so a correctly-edited
+// .env enabled nothing and `/mergepub` silently routed as chat, twice. Every
+// other knob is still process.env-only and stays that way; these two keys are the
+// ones the docs point at the file for.
+//
+// The parsed values are returned as an explicit config object and NOT merged into
+// process.env: the auto-action child inherits the poller env wholesale (see
+// runScript below), and widening that surface from a config file is not something
+// this ticket needs.
+export const BRIDGE_ENV_KEYS = ["TELEGRAM_BOT_TOKEN", "TELEGRAM_AUTO_ACTIONS"] as const;
+export type BridgeEnvKey = (typeof BRIDGE_ENV_KEYS)[number];
+
+// Strips ONE layer of matching surrounding quotes. dotenv-style files quote
+// values routinely, and an unstripped `"arm-resume"` is not a known op token —
+// it would parse to the empty set, which is the exact silent-nothing this ticket
+// exists to kill.
+function unquote(v: string): string {
+  const m = v.match(/^(['"])(.*)\1$/);
+  return m ? m[2] : v;
+}
+
+// Duplicate-key precedence, line by line. The two keys need OPPOSITE rules, and
+// picking one for both is wrong in a way that bites:
+//
+//   TELEGRAM_BOT_TOKEN — FIRST NON-EMPTY wins (the rule
+//     scripts/lib/load-dotenv.sh:62-76 already implements). onboard-telegram.{sh,ps1}
+//     scaffolds a literal empty `TELEGRAM_BOT_TOKEN=` placeholder, so an operator who
+//     APPENDED the real token instead of editing the placeholder has a working bridge
+//     today; letting the empty first line win would abort startup and take the whole
+//     bridge down on upgrade. An empty assignment must never mask a real one.
+//
+//   TELEGRAM_AUTO_ACTIONS — LAST assignment wins, empty included. This is a
+//     CAPABILITY flag, so the failure that matters is the opposite one: with
+//     first-wins, `TELEGRAM_AUTO_ACTIONS=merge-public` followed by an appended
+//     ``, `off`, or narrower value would leave the public-merge capability live
+//     while the operator believes they revoked it. Editing by appending is exactly
+//     the habit the token rule above accommodates, so duplicates are realistic.
+//     Last-wins makes the file behave the way an operator reading it top-to-bottom
+//     expects, and fails toward LESS capability.
+const LAST_ASSIGNMENT_WINS: ReadonlySet<BridgeEnvKey> = new Set<BridgeEnvKey>(["TELEGRAM_AUTO_ACTIONS"]);
+
+export function parseBridgeEnv(txt: string): Partial<Record<BridgeEnvKey, string>> {
+  const out: Partial<Record<BridgeEnvKey, string>> = {};
+  const known = new Set<string>(BRIDGE_ENV_KEYS);
+  for (const raw of txt.split("\n")) {
+    const line = raw.replace(/\r$/, "");
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim() as BridgeEnvKey;
+    if (!known.has(key)) continue;
+    const val = unquote(line.slice(eq + 1).trim());
+    // first-non-empty keys: a value that already won is never replaced
+    if (!LAST_ASSIGNMENT_WINS.has(key) && out[key]) continue;
+    out[key] = val;
+  }
+  return out;
+}
+
+// A real process env var still WINS over the file — the launching shell is the
+// more specific scope, and that is the precedence the rest of the bridge assumes.
+//
+// Only TELEGRAM_AUTO_ACTIONS accepts a process-env override. TELEGRAM_BOT_TOKEN is
+// deliberately FILE-ONLY, exactly as loadToken() was before HIMMEL-1270.
+//
+// The reason is specific, not conservatism: this repo runs a SECOND bot. The
+// HIMMEL_JIRA_NUDGE SessionEnd relay reads `TELEGRAM_BOT_TOKEN` from the repo
+// `.env` (see the jira-nudge block in .env.example), which is a different
+// credential from the poller's. Letting the process env win would mean that
+// launching the bridge from any shell that had sourced the repo `.env`
+// authenticates the poller AS THE RELAY BOT — a deaf bridge, or two consumers
+// competing for the same getUpdates offset, depending on which token it grabbed.
+// The dedicated bridge file is the only correct source for that credential.
+//
+// For TELEGRAM_AUTO_ACTIONS the override is the point, and an EMPTY value counts:
+// `TELEGRAM_AUTO_ACTIONS=` in the launching shell is the one-run kill switch, so
+// treating it as "unset" would leave the file's `merge-public` live — a fail-OPEN
+// on the privileged direction.
+const PROCESS_OVERRIDABLE: ReadonlySet<BridgeEnvKey> = new Set<BridgeEnvKey>(["TELEGRAM_AUTO_ACTIONS"]);
+
+// `source` records WHERE each effective value came from, so a startup warning can
+// point the operator at the thing they actually have to edit. Reporting the file
+// path for a value the process env supplied would send them to fix the wrong
+// place — they would edit the file, restart, and the process value would win again.
+export type BridgeEnvSource = "process env" | "file";
+export type LoadedBridgeEnv = Partial<Record<BridgeEnvKey, string>> & {
+  path: string;
+  source: Partial<Record<BridgeEnvKey, BridgeEnvSource>>;
+};
+
+export async function loadBridgeEnv(): Promise<LoadedBridgeEnv> {
   const envPath = process.env.TELEGRAM_ENV ?? join(homedir(), ".claude", "channels", "telegram", ".env");
-  const txt = await readFile(envPath, "utf8");
-  const m = txt.match(/^TELEGRAM_BOT_TOKEN\s*=\s*(.+)$/m);
-  if (!m) throw new Error("TELEGRAM_BOT_TOKEN not found in " + envPath);
-  return m[1].trim();
+  const fromFile = parseBridgeEnv(await readFile(envPath, "utf8"));
+  const merged: Partial<Record<BridgeEnvKey, string>> = { ...fromFile };
+  const source: Partial<Record<BridgeEnvKey, BridgeEnvSource>> = {};
+  for (const key of BRIDGE_ENV_KEYS) if (fromFile[key] !== undefined) source[key] = "file";
+  for (const key of BRIDGE_ENV_KEYS) {
+    if (!PROCESS_OVERRIDABLE.has(key)) continue;
+    const live = process.env[key];
+    if (live === undefined) continue;
+    merged[key] = live;          // "" included — the kill switch
+    source[key] = "process env";
+  }
+  if (!merged.TELEGRAM_BOT_TOKEN) throw new Error("TELEGRAM_BOT_TOKEN not found in " + envPath);
+  return { ...merged, path: envPath, source };
+}
+
+// Where to tell the operator to go for a given key's EFFECTIVE value.
+export function bridgeEnvOrigin(env: LoadedBridgeEnv, key: BridgeEnvKey): string {
+  return env.source[key] === "process env" ? "the poller's process env" : env.path;
 }
 
 async function sessionsList(root: string): Promise<string[]> {
@@ -819,7 +925,8 @@ export async function replyViaOutbox(root: string, chat_id: number, text: string
 export async function main(): Promise<void> {
   const root = bridgeRoot();
   const repoCwd = process.env.HIMMEL_REPO ?? process.cwd();
-  const token = await loadToken();
+  const bridgeEnv = await loadBridgeEnv();
+  const token = bridgeEnv.TELEGRAM_BOT_TOKEN!;
   const access = await loadAccess();
   const allow = makeAllow(access);
   // cap/transient/giveup/blocked notice (HIMMEL-260/263/353): poller-side direct
@@ -891,14 +998,20 @@ export async function main(): Promise<void> {
   // never into env. We strip only TELEGRAM_BOT_TOKEN (+ TELEGRAM_OWN_POLLER) — the one
   // credential the arm path demonstrably never needs (fix M3). The arm runs
   // FIRE-AND-FORGET (autoFire) so a slow `--time smart` arm never stalls the ingest loop.
-  const enabledOps = parseEnabledOps(process.env.TELEGRAM_AUTO_ACTIONS, KNOWN_OPS);
+  // Read from the bridge .env (with a real process env var still winning) —
+  // HIMMEL-1270: this used to be process.env ONLY, so the documented .env location
+  // was inert. The describe* wrapper also makes a configured-but-inert value say so
+  // at startup instead of looking identical to "off".
+  const { ops: enabledOps, warning: autoActionsWarning } =
+    describeEnabledOps(bridgeEnv.TELEGRAM_AUTO_ACTIONS, KNOWN_OPS);
   if (enabledOps.size > 0) console.error(`[poller] auto-actions enabled: ${[...enabledOps].join(",")}`);
+  if (autoActionsWarning) console.error(`[poller] WARNING: ${autoActionsWarning} (set in ${bridgeEnvOrigin(bridgeEnv, "TELEGRAM_AUTO_ACTIONS")})`);
   const autoScript = join(import.meta.dir, "auto-action.sh");
   const runScript: RunScriptFn = async (op, arg, time) => {
     const env: Record<string, string> = { ...process.env } as Record<string, string>;
     delete env.TELEGRAM_BOT_TOKEN;
     delete env.TELEGRAM_OWN_POLLER;
-    const p = Bun.spawn(["bash", autoScript, op, arg, time], { cwd: repoCwd, env, stdout: "pipe", stderr: "pipe" });
+    const p = Bun.spawn([BASH_BIN, autoScript, op, arg, time], { cwd: repoCwd, env, stdout: "pipe", stderr: "pipe" });
     const [stdout, stderr, code] = await Promise.all([
       new Response(p.stdout).text(),
       new Response(p.stderr).text(),

--- a/scripts/telegram/run.ts
+++ b/scripts/telegram/run.ts
@@ -1,5 +1,7 @@
 import { spawn } from "bun";
 import { buildGlmEnv, GLM_MODEL_ALIAS } from "./glm-env";
+import { existsSync } from "node:fs";
+import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 // Bounded-run spawn helper. Runs an INTERACTIVE `claude "<prompt>"` with stdin
@@ -45,6 +47,45 @@ export function buildRunArgs(prompt: string, permissionMode?: PermissionMode, mo
 // fileURLToPath is the cross-platform form — new URL(...).pathname yields a
 // broken leading-slash path on Windows (/C:/Users/...). Exported for the test.
 export const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+// BASH_BIN (HIMMEL-1279): every `bash <abs-script>` the bridge spawns must name
+// Git Bash by absolute path. A bare "bash" resolves through the spawning
+// process's PATH, and the supervisor is launched by the HimmelTelegramBridge
+// schtask under `pwsh -NoProfile`, whose PATH has System32 ahead of Git\bin —
+// so "bash" lands on the WSL stub C:\Windows\System32\bash.exe. That stub sees
+// no C: drive at all: it exits 127 on BOTH `C:\...` (backslashes eaten by the
+// WSL argv translation, hence the "C:UsersyotamDocuments..." in supervisor.log)
+// and `C:/...`. POSIX-ifying the path does NOT help — resolving the interpreter
+// does. Same candidate order as scripts/setup-hooks.sh, preflight-sim.sh and
+// scripts/ci-orchestrator/tests/*.ts; see docs/internals/environment-gotchas.md.
+const WIN_BASH_CANDIDATES = ["C:/Program Files/Git/bin/bash.exe", "C:/Program Files (x86)/Git/bin/bash.exe"];
+export function resolveBash(): string {
+  if (process.platform !== "win32") return "bash";
+  // Derive from git.exe too — <GitRoot>/cmd/git.exe => <GitRoot>/bin/bash.exe —
+  // so a non-default Git install location still resolves.
+  const candidates = [...WIN_BASH_CANDIDATES];
+  const gitExe = Bun.which("git");
+  if (gitExe) candidates.push(dirname(dirname(gitExe.replace(/\\/g, "/"))) + "/bin/bash.exe");
+  for (const c of candidates) if (existsSync(c)) return c;
+  // PATH fallback, minus the two known stub locations.
+  const pathBash = Bun.which("bash");
+  if (pathBash && !/system32|windowsapps/i.test(pathBash)) return pathBash;
+  // Nothing safe found. Returning the bare "bash" here would re-introduce the
+  // exact defect this function exists to prevent: spawn would resolve it
+  // through PATH straight back to the WSL stub, which "runs" and exits 127 —
+  // silent, and indistinguishable from a script bug. Return the canonical Git
+  // Bash path instead, which on this machine does NOT exist: spawn then fails
+  // ENOENT naming the interpreter we actually require. Loud beats invisible.
+  // Not a throw — run.ts is imported for far more than bash spawning, and
+  // taking the whole poller down at module load over a missing classifier
+  // dependency trades a narrow failure for a total one.
+  console.error(
+    `[bridge] no usable Git Bash found (checked ${candidates.join(", ")} and PATH minus the WSL stub); ` +
+      `every bash child will fail ENOENT until Git for Windows is installed`,
+  );
+  return WIN_BASH_CANDIDATES[0];
+}
+export const BASH_BIN = resolveBash();
 
 // glmChildEnv (HIMMEL-654): the GLM lane's child env — the current process env
 // with the GLM block (buildGlmEnv) merged over it, and TELEGRAM_OWN_POLLER

--- a/scripts/telegram/spawn-claudex.test.ts
+++ b/scripts/telegram/spawn-claudex.test.ts
@@ -31,6 +31,7 @@ import {
   claudexChildEnv,
   executeClaudexRun,
 } from "./spawn-claudex";
+import { BASH_BIN } from "./run";
 
 // --- claudexSessionRoot ------------------------------------------------------
 
@@ -746,7 +747,7 @@ test("claude-codex --preflight-only classifies REAL HTTP responses: 2xx->0, 503/
   // time out and read transient. Await the child instead.
   const run = async (s: number, b: string, urlOverride?: string): Promise<number> => {
     status = s; body = b;
-    const p = Bun.spawn(["bash", "scripts/claude-codex", "--preflight-only"], {
+    const p = Bun.spawn([BASH_BIN, "scripts/claude-codex", "--preflight-only"], {
       cwd: process.cwd(),
       env: { ...process.env, CLIPROXY_API_KEY: "test-key", CODEX_PROXY_BASE_URL: urlOverride ?? base } as Record<string, string>,
       stdout: "pipe", stderr: "pipe",
@@ -787,7 +788,7 @@ test("claude-codex --preflight-only: a stalled body (200 headers, then hang) is 
   try {
     // async spawn — spawnSync would block the loop and stall the server for the
     // WRONG reason, making this pass without exercising the partial-200 path
-    const p = Bun.spawn(["bash", "scripts/claude-codex", "--preflight-only"], {
+    const p = Bun.spawn([BASH_BIN, "scripts/claude-codex", "--preflight-only"], {
       cwd: process.cwd(),
       env: { ...process.env, CLIPROXY_API_KEY: "test-key", CODEX_PROXY_BASE_URL: `http://127.0.0.1:${server.port}` } as Record<string, string>,
       stdout: "pipe", stderr: "pipe",
@@ -804,12 +805,12 @@ test("claudexLauncherPath joins repoRoot + scripts/claude-codex", () => {
 
 test("buildClaudexRunArgs: invokes bash <launcher> --permission-mode <mode> <prompt> when permMode is set", () => {
   const { cmd } = buildClaudexRunArgs("/repo/scripts/claude-codex", "read the brief", "bypassPermissions");
-  expect(cmd).toEqual(["bash", "/repo/scripts/claude-codex", "--permission-mode", "bypassPermissions", "read the brief"]);
+  expect(cmd).toEqual([BASH_BIN, "/repo/scripts/claude-codex", "--permission-mode", "bypassPermissions", "read the brief"]);
 });
 
 test("buildClaudexRunArgs: omits --permission-mode when unset — bash <launcher> <prompt>", () => {
   const { cmd } = buildClaudexRunArgs("/repo/scripts/claude-codex", "read the brief");
-  expect(cmd).toEqual(["bash", "/repo/scripts/claude-codex", "read the brief"]);
+  expect(cmd).toEqual([BASH_BIN, "/repo/scripts/claude-codex", "read the brief"]);
 });
 
 test("buildClaudexRunArgs: NEVER includes a --model flag (claude-codex pins the model itself)", () => {
@@ -822,10 +823,10 @@ test("buildClaudexRunArgs: NEVER includes a --model flag (claude-codex pins the 
 test("buildClaudexRunArgs: injects --settings before the prompt when set; omits it otherwise", () => {
   const s = '{"enabledPlugins":{"qmd@himmel":true}}';
   expect(buildClaudexRunArgs("/repo/scripts/claude-codex", "go", undefined, s).cmd)
-    .toEqual(["bash", "/repo/scripts/claude-codex", "--settings", s, "go"]);
+    .toEqual([BASH_BIN, "/repo/scripts/claude-codex", "--settings", s, "go"]);
   // co-present with --permission-mode: both precede the prompt, settings last
   expect(buildClaudexRunArgs("/repo/scripts/claude-codex", "go", "bypassPermissions", s).cmd)
-    .toEqual(["bash", "/repo/scripts/claude-codex", "--permission-mode", "bypassPermissions", "--settings", s, "go"]);
+    .toEqual([BASH_BIN, "/repo/scripts/claude-codex", "--permission-mode", "bypassPermissions", "--settings", s, "go"]);
   expect(buildClaudexRunArgs("/repo/scripts/claude-codex", "go").cmd).not.toContain("--settings");
 });
 

--- a/scripts/telegram/spawn-claudex.ts
+++ b/scripts/telegram/spawn-claudex.ts
@@ -24,7 +24,7 @@ import { existsSync, mkdirSync, writeFileSync, appendFileSync, statSync, openSyn
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawn } from "bun";
-import { REPO_ROOT, killTree, detectContentFilter, type PermissionMode } from "./run";
+import { BASH_BIN, REPO_ROOT, killTree, detectContentFilter, type PermissionMode } from "./run";
 import { transcriptDirFor, poisonPushUrl, preflightWindowCheck, measureOverheadChars, finalMeta, POISON_SENTINEL, resolveProfileSettings, teardownMintedWorktree, DEFAULT_LANE_PROFILE, mintRetaskNonce, composeRetaskBlock, isHelpFlag } from "./spawn-glm";
 // HIMMEL-1040 plugin profiles: same per-dispatch lean-profile injection as the
 // GLM lane. spawn-claudex dispatches through scripts/claude-codex, which already
@@ -469,7 +469,7 @@ export type AuthProbeResult = "ok" | "unavailable" | "fatal";
 // (claudexChildEnv) so the probe never adopts poller ownership.
 export function probeClaudexAuth(repoRoot: string, cwd: string, timeoutMs: number = PROBE_TIMEOUT_MS): AuthProbeResult {
   const launcherPath = claudexLauncherPath(repoRoot);
-  const r = Bun.spawnSync(["bash", launcherPath, "--preflight-only"], { cwd, stdout: "pipe", stderr: "pipe", env: claudexChildEnv(process.env) as Record<string, string>, timeout: timeoutMs });
+  const r = Bun.spawnSync([BASH_BIN, launcherPath, "--preflight-only"], { cwd, stdout: "pipe", stderr: "pipe", env: claudexChildEnv(process.env) as Record<string, string>, timeout: timeoutMs });
   if (r.exitCode === null || r.signalCode != null) return "unavailable"; // killed / timed out
   if (r.exitCode === 0) return "ok";
   if (r.exitCode === CLAUDEX_PREFLIGHT_GAP_EXIT) return "unavailable";
@@ -547,7 +547,7 @@ export function claudexLauncherPath(repoRoot: string): string {
 // claude-codex screens it (env-injection) then forwards it to claude. Omitted
 // (operator profile) => no flag. Placed before the prompt, after --permission-mode.
 export function buildClaudexRunArgs(launcherPath: string, prompt: string, permMode?: PermissionMode, settings?: string): { cmd: string[] } {
-  const cmd = ["bash", launcherPath];
+  const cmd = [BASH_BIN, launcherPath];
   if (permMode) cmd.push("--permission-mode", permMode);
   if (settings) cmd.push("--settings", settings);
   cmd.push(prompt);
@@ -643,7 +643,7 @@ export async function runClaudexSharedDispatch(p: {
   // still releases the lock). Absent ⇒ skipped (own-mode / tests).
   revalidateClean?: () => { ok: true } | { ok: false; reason: string };
 }): Promise<{ ok: true; code: number } | { ok: false; reason: string }> {
-  const acquire = Bun.spawnSync(["bash", p.lockScript, "acquire", p.repoDir, p.branch, "codex"], { stdout: "pipe", stderr: "pipe" });
+  const acquire = Bun.spawnSync([BASH_BIN, p.lockScript, "acquire", p.repoDir, p.branch, "codex"], { stdout: "pipe", stderr: "pipe" });
   if (acquire.exitCode !== 0) return { ok: false, reason: acquire.stderr.toString().trim() || `spawn-claudex: shared-branch-lock acquire failed (rc=${acquire.exitCode})` };
   let priorPushUrl: string | undefined;
   let poisoned = false;
@@ -673,7 +673,7 @@ export async function runClaudexSharedDispatch(p: {
       console.error(`spawn-claudex: WARNING - pushurl restore threw (${String((e as any)?.message ?? e)}); ${p.worktree} may stay push-poisoned`);
     } finally {
       try {
-        const rel = Bun.spawnSync(["bash", p.lockScript, "release", p.repoDir, p.branch], { stdout: "pipe", stderr: "pipe" });
+        const rel = Bun.spawnSync([BASH_BIN, p.lockScript, "release", p.repoDir, p.branch], { stdout: "pipe", stderr: "pipe" });
         if (rel.exitCode !== 0) console.error(`spawn-claudex: WARNING - shared-branch-lock release failed (rc=${rel.exitCode}); the lock for ${p.branch} may stay held: ${rel.stderr.toString().trim()}`);
       } catch (e) {
         console.error(`spawn-claudex: WARNING - shared-branch-lock release threw (${String((e as any)?.message ?? e)}); the lock for ${p.branch} may stay held`);

--- a/scripts/telegram/spawn-glm.test.ts
+++ b/scripts/telegram/spawn-glm.test.ts
@@ -37,6 +37,7 @@ import {
   isHelpFlag,
   type CapGuardDeps,
 } from "./spawn-glm";
+import { BASH_BIN } from "./run";
 import type { SettingsConflict } from "./glm-env";
 import { composeGrantLine, nextGrantId, classifyShape, authorityGate, composeEscalationForRefusedGrant } from "./grants";
 
@@ -1234,7 +1235,7 @@ test("parseArgs arm flags", () => {
 
 test("buildArmArgv matches arm-resume's documented flag contract", () => {
   const a = buildArmArgv("C:/repo", "04:10", "C:/sess/respawn-handover.md");
-  expect(a[0]).toBe("bash");
+  expect(a[0]).toBe(BASH_BIN);
   expect(a[1]).toContain("arm-resume.sh");
   expect(a.slice(2)).toEqual(["--dedup-any", "--time", "04:10", "--handover", "C:/sess/respawn-handover.md"]);
 });

--- a/scripts/telegram/spawn-glm.ts
+++ b/scripts/telegram/spawn-glm.ts
@@ -8,7 +8,7 @@ import { existsSync, mkdirSync, writeFileSync, appendFileSync, readFileSync, sta
 import { randomBytes } from "node:crypto";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { runSession, REPO_ROOT, detectGlmCap, type PermissionMode, type GlmCapWindow } from "./run";
+import { runSession, BASH_BIN, REPO_ROOT, detectGlmCap, type PermissionMode, type GlmCapWindow } from "./run";
 import { checkGlmGuards } from "./glm-guard";
 import { buildGlmEnv, findSettingsConflicts, formatConflict, fetchGlmUsage, readZaiKey, glmContextPreset, type SettingsConflict, type GlmUsage } from "./glm-env";
 import { appendQuotaGauge, buildGlmRow, isGlmPeak } from "./quota-gauge";
@@ -618,7 +618,7 @@ export async function runSharedDispatch(p: {
   repoDir: string; worktree: string; branch: string; needsWorktreeAdd: boolean;
   lockScript: string; gitAdd: () => void; runBody: () => Promise<number>;
 }): Promise<{ ok: true; code: number } | { ok: false; reason: string }> {
-  const acquire = Bun.spawnSync(["bash", p.lockScript, "acquire", p.repoDir, p.branch, "glm"], { stdout: "pipe", stderr: "pipe" });
+  const acquire = Bun.spawnSync([BASH_BIN, p.lockScript, "acquire", p.repoDir, p.branch, "glm"], { stdout: "pipe", stderr: "pipe" });
   if (acquire.exitCode !== 0) return { ok: false, reason: acquire.stderr.toString().trim() || `spawn-glm: shared-branch-lock acquire failed (rc=${acquire.exitCode})` };
   let priorPushUrl: string | undefined;
   // CR round 2 F5: only true once poisonPushUrl has actually completed — gates
@@ -675,7 +675,7 @@ export async function runSharedDispatch(p: {
       console.error(`spawn-glm: WARNING - pushurl restore threw (${String((e as any)?.message ?? e)}); ${p.worktree} may stay push-poisoned`);
     } finally {
       try {
-        const rel = Bun.spawnSync(["bash", p.lockScript, "release", p.repoDir, p.branch], { stdout: "pipe", stderr: "pipe" });
+        const rel = Bun.spawnSync([BASH_BIN, p.lockScript, "release", p.repoDir, p.branch], { stdout: "pipe", stderr: "pipe" });
         if (rel.exitCode !== 0) console.error(`spawn-glm: WARNING - shared-branch-lock release failed (rc=${rel.exitCode}); the lock for ${p.branch} may stay held: ${rel.stderr.toString().trim()}`);
       } catch (e) {
         console.error(`spawn-glm: WARNING - shared-branch-lock release threw (${String((e as any)?.message ?? e)}); the lock for ${p.branch} may stay held`);
@@ -992,7 +992,7 @@ export type CapGuardDeps = {
 // argv builder for the real arm invoker — pure so the flag contract
 // (--dedup-any --time <HH:MM> --handover <path>) is unit-asserted.
 export function buildArmArgv(repoRoot: string, hhmm: string, handoverPath: string): string[] {
-  return ["bash", join(repoRoot, "scripts", "handover", "arm-resume.sh"), "--dedup-any", "--time", hhmm, "--handover", handoverPath];
+  return [BASH_BIN, join(repoRoot, "scripts", "handover", "arm-resume.sh"), "--dedup-any", "--time", hhmm, "--handover", handoverPath];
 }
 
 // Preflight warn (spec (c)): warn-only — a heuristic-threshold refusal would

--- a/scripts/telegram/triage.test.ts
+++ b/scripts/telegram/triage.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "bun:test";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { classifyForSpawn, parseTriageVerdict, type TriageVerdict } from "./triage";
-import { REPO_ROOT } from "./run";
+import { BASH_BIN, REPO_ROOT, resolveBash } from "./run";
 
 test("parseTriageVerdict accepts the four strict single-token verdicts", () => {
   for (const verdict of ["ignore", "ack", "spawn-low", "spawn-high"] as TriageVerdict[]) {
@@ -28,9 +29,39 @@ test("classifyForSpawn shells through the cheap classifier and parses its verdic
 
   expect(verdict).toBe("spawn-low");
   expect(calls).toHaveLength(1);
-  expect(calls[0].args).toEqual(["bash", join(REPO_ROOT, "scripts", "hermes", "invoke.sh"), "--model", "deepseek-v4-flash", "--provider", "deepseek"]);
+  expect(calls[0].args).toEqual([BASH_BIN, join(REPO_ROOT, "scripts", "hermes", "invoke.sh"), "--model", "deepseek-v4-flash", "--provider", "deepseek"]);
   expect(calls[0].input).toContain("ship this?");
   expect(calls[0].input).not.toContain("chat_id");
+});
+
+// HIMMEL-1279 regression. The classifier was dead on 100% of messages because
+// argv[0] was a bare "bash": under the poller's PATH that resolves to the WSL
+// System32 stub, which cannot see ANY C: path (it exits 127 on both `C:\...`
+// and `C:/...`, so POSIX-ifying argv[1] would not have helped) — and
+// classifyForSpawn fails open to spawn-high, so the breakage was invisible.
+// Asserted on the CONSTRUCTED argv rather than on a live spawn so it runs on
+// every platform: the interpreter must exist and must not be the stub, and the
+// script path must resolve.
+test("classifyForSpawn spawns a real non-WSL bash against an existing script (HIMMEL-1279)", async () => {
+  const calls: any[] = [];
+  await classifyForSpawn("hi", { invoke: async (args) => { calls.push(args); return "ack"; }, timeoutMs: 1000 });
+
+  const [interpreter, script] = calls[0];
+  expect(interpreter).not.toMatch(/system32|windowsapps/i);
+  expect(existsSync(script)).toBe(true);
+  if (process.platform === "win32") {
+    // Windows must name the interpreter ABSOLUTELY. That is the whole contract:
+    // any PATH-resolved name can land on the stub, so resolveBash() never
+    // returns one here — not even as a last-resort fallback (it returns the
+    // canonical Git Bash path, so a machine without it fails ENOENT loudly
+    // rather than 127 silently). Asserting the shape, not existence, keeps this
+    // true on a Windows box that has no Git Bash installed.
+    expect(interpreter).not.toBe("bash");
+    expect(interpreter).toMatch(/^[A-Za-z]:[\\/]/);
+  } else {
+    expect(interpreter).toBe("bash");
+  }
+  expect(resolveBash()).toBe(BASH_BIN);
 });
 
 test("classifyForSpawn fails open on classifier timeout", async () => {

--- a/scripts/telegram/triage.ts
+++ b/scripts/telegram/triage.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { join } from "node:path";
-import { REPO_ROOT, killTree } from "./run";
+import { BASH_BIN, REPO_ROOT, killTree } from "./run";
 
 export type TriageVerdict = "ignore" | "ack" | "spawn-low" | "spawn-high";
 // The only model the triage seam ever injects is the spawn-low haiku override
@@ -84,7 +84,10 @@ export async function classifyForSpawn(text: string, deps: TriageDeps = {}): Pro
   const model = process.env.TELEGRAM_TRIAGE_MODEL?.trim() || "deepseek-v4-flash";
   const provider = process.env.TELEGRAM_TRIAGE_PROVIDER?.trim() || "deepseek";
   // Absolute path: the poller's cwd is not guaranteed to be the repo root.
-  const args = ["bash", join(REPO_ROOT, "scripts", "hermes", "invoke.sh"), "--model", model, "--provider", provider];
+  // BASH_BIN, not a bare "bash" (HIMMEL-1279): under the poller's PATH a bare
+  // "bash" hit the WSL System32 stub, which exits 127 on any C: path — so the
+  // classifier fail-opened to spawn-high on 100% of messages, invisibly.
+  const args = [BASH_BIN, join(REPO_ROOT, "scripts", "hermes", "invoke.sh"), "--model", model, "--provider", provider];
   // deps.timeoutMs (tests) wins; otherwise the env-tunable deadline.
   const timeoutMs = deps.timeoutMs ?? resolveTimeoutMs();
   const label = deps.sessionLabel ?? "unknown-session";


### PR DESCRIPTION
Two silent failures in the Telegram bridge, plus the doc defects that hid them.

## 1. The triage classifier was dead 100% of the time on Windows

`supervisor.log` was a wall of:

```
[telegram-triage] fail-open: Error: triage exited 127:
  /bin/bash: C:UsersDocumentsscriptshermesinvoke.sh: No such file or directory
```

`classifyForSpawn` catches and returns `spawn-high`, so nothing looked broken —
messages were still answered. But the whole point of the tier is to route
`ignore` / `ack` / `spawn-low` away from a full session, and with the classifier
dead every inbound message, including one-word acks, spawned a full-model run.

**The eaten backslashes are a red herring.** They point at the path; the defect is
`argv[0]`. A bare `"bash"` resolves through the *spawning process's* PATH, and the
bridge supervisor is started by a scheduled task under `pwsh -NoProfile`, whose
PATH puts System32 ahead of `Git\bin`. So `bash` was the WSL stub. Probed
directly:

| interpreter | argument | result |
|---|---|---|
| Git Bash | `C:\…\invoke.sh` | rc 0 |
| Git Bash | `C:/…/invoke.sh` | rc 0 |
| `C:\Windows\System32\bash.exe` | `C:\…\invoke.sh` | rc **127** |
| `C:\Windows\System32\bash.exe` | `C:/…/invoke.sh` | rc **127** |

The stub sees no `C:` drive at all, so POSIX-ifying the argument would have
changed nothing — the interpreter has to be resolved. Adds
`resolveBash()`/`BASH_BIN` (the candidate order already used in
`setup-hooks.sh`, `preflight-sim.sh` and the ci-orchestrator tests) and applies it
to every production `bash <abs-script>` spawn in the bridge, since they all run
under that PATH and all had the same latent break.

On Windows the resolver never falls back to a bare `"bash"`: with no safe
interpreter found it returns the canonical Git Bash path, which does not exist on
such a machine, so spawn fails ENOENT naming what is required instead of exiting
127 silently. Loud beats invisible.

Live smoke, real classifier: `"ok"` → `ignore`, a real request → `spawn-low`.
Both were `spawn-high` before.

## 2. `TELEGRAM_AUTO_ACTIONS` was never read from the bridge `.env`

`loadToken()` was the only reader of that file and extracted exactly one key,
while the enable-list came from `process.env` alone. A correctly-edited `.env`
therefore enabled nothing, and the privileged ops stayed inert with no error.

`loadToken()` → `loadBridgeEnv()` parses the file once for both keys. The two keys
take deliberately **opposite** precedence rules, because they fail in opposite
directions:

| | `TELEGRAM_BOT_TOKEN` | `TELEGRAM_AUTO_ACTIONS` |
|---|---|---|
| Process-env override | refused — file only | wins, **including an empty value** (the one-run kill switch) |
| Duplicate keys in file | first NON-EMPTY wins | LAST wins |
| Why | onboarding scaffolds an empty placeholder; first-match-wins would abort startup for anyone who appended their token | it is a capability flag — an appended `off` must revoke |

A configured value that parses to zero ops, or that silently drops a token from a
partially-valid list, now logs a startup warning naming what was not recognised
and which source the effective value came from. Silent-empty is what made the
original misconfiguration invisible for days.

## 3. Docs

The same class of defect in six places, the sharpest being a `<sha7>` in the
public-merge authorization instructions where the router requires 12+ hex — so the
command that *generates* the authorization line generated one that falls through
to chat. Also: two config-reference rows that disagreed with each other about
where the flag lives, a propagation runbook that documented the authorization step
without mentioning the op is default-OFF, and a bridge README with no coverage of
the privileged ops at all.

## Review

Six CR rounds across the two changes. Four of the findings were defects in the
fixes themselves — including a process-env override that would have authenticated
the poller as a *different bot*, and a parse change that would have aborted
startup on upgrade for a plausible `.env` layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
