### PR TITLE
chore: daily qmd reindex cadence (update + embed + completeness assert)

### DIFF
--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -1078,6 +1078,47 @@ view into the vault — the bridge between the derived graph and the KB.
 
 ---
 
+## qmd reindex cadence (`scripts/luna/qmd-*.sh`, HIMMEL-568)
+
+Keeps the qmd search index from going silently stale. The index once sat 5 days
+stale (luna `lastUpdated` 2026-06-22 with `needsEmbedding: 0`) while notes
+written that week were simply not searchable — every qmd-backed workflow
+(compounding, ingest, synthesis, recall) answered off a stale index and nothing
+signalled it. Same runner/scheduler split as the graphify pair above.
+
+- `scripts/luna/qmd-reindex.sh` — the RUNNER. `qmd update` (re-index changed
+  files) then `qmd embed` (generate missing vectors), then a COMPLETENESS ASSERT:
+  a second `qmd embed` that must report "All content hashes already have
+  embeddings". That assert is the point — `qmd embed` has a session cap
+  (`--timeout`, default 30 min), and a run that hits it exits 0 having embedded
+  only PART of the pending set, leaving vectors lagging lex: the same silently-
+  wrong state with a fresher timestamp. Distinct exit codes (3 update failed,
+  4 embed failed, 5 embed incomplete) so a scheduler log says which half broke.
+  Scope is ALL configured collections — `qmd update`/`qmd embed` default to
+  everything and take `-c` only to NARROW, so nothing is hardcoded and a
+  collection added later needs no edit. `--qmd-bin` pins the executable (the
+  scheduler fires with a minimal PATH that lacks bun's bin dir); `--dry-run`
+  previews. Does NOT fence the qmd MCP daemon. What was actually observed
+  (2026-07-25): with the daemon running, a full `qmd update` + `qmd embed`
+  completed without error and the daemon was still serving on the same PID
+  afterwards. That is a process-survival + no-error observation, NOT a
+  concurrency proof — nothing exercised reads racing the writes. It is the
+  basis for not fencing today; if a fence is ever needed it belongs in the
+  runner, not the scheduler. Hermetic test `test-qmd-reindex.sh` (stubs qmd).
+- `scripts/luna/qmd-cadence.sh` — the scheduler that arms it. Deterministic-script
+  shape (the graphmap sibling, NOT a pipeline-cadence leg): no claude session, no
+  NUL stdin, no `--settings` fragment, so HIMMEL-128 does not apply at all.
+  `arm`/`status`/`disarm` register ONE daily task, `HIMMEL-Qmd-Reindex`
+  (default 05:00 local — AFTER the pipeline legs that WRITE to the vault
+  (Harvest 02:00, Synthesize 03:00, Health 04:00) so the reindex picks up what
+  they wrote instead of racing them, and clear of the graphmap slots 13:00/13:20).
+  A full local refresh measured 16s + 24s, so daily is cheap. schtasks (Windows,
+  StartWhenAvailable + IgnoreNew XML) / crontab (POSIX); dedup-guarded; hermetic
+  test `test-qmd-cadence.sh`. Arming is an operator flip, never auto-armed:
+  `bash scripts/luna/qmd-cadence.sh arm` (`--time` / `--force` / `--dry-run`).
+
+---
+
 ## Codex Cleanup Cadence (`scripts/cleanup/`, HIMMEL-892)
 
 Windows-only scheduled cleanup for orphaned codex processes and stale MCP fleet.

--- a/scripts/himmel-doctor.sh
+++ b/scripts/himmel-doctor.sh
@@ -346,6 +346,7 @@ check_c8() {
 pipeline-cadence|${PIPELINE_BAT_DIR:-$uh/.claude/pipeline-cadence}|bash scripts/luna/pipeline-cadence.sh arm --force
 codex-sweep-cadence|${SWEEP_BAT_DIR:-$uh/.claude/codex-sweep-cadence}|bash scripts/cleanup/codex-sweep-cadence.sh arm --force
 graphmap-cadence|${GRAPHMAP_BAT_DIR:-$uh/.claude/graphmap-cadence}|bash scripts/luna/graphmap-cadence.sh arm --force
+qmd-cadence|${QMD_CADENCE_BAT_DIR:-$uh/.claude/qmd-cadence}|bash scripts/luna/qmd-cadence.sh arm --force
 EOF
     if [ "$saw_any" -eq 0 ]; then
         emit OK C8-cadence "no armed cadence runners (skipped)"

--- a/scripts/himmel-update.sh
+++ b/scripts/himmel-update.sh
@@ -314,6 +314,7 @@ report_cadence_stale() {
 pipeline-cadence|${PIPELINE_BAT_DIR:-$uh/.claude/pipeline-cadence}|bash scripts/luna/pipeline-cadence.sh arm --force
 codex-sweep-cadence|${SWEEP_BAT_DIR:-$uh/.claude/codex-sweep-cadence}|bash scripts/cleanup/codex-sweep-cadence.sh arm --force
 graphmap-cadence|${GRAPHMAP_BAT_DIR:-$uh/.claude/graphmap-cadence}|bash scripts/luna/graphmap-cadence.sh arm --force
+qmd-cadence|${QMD_CADENCE_BAT_DIR:-$uh/.claude/qmd-cadence}|bash scripts/luna/qmd-cadence.sh arm --force
 EOF
     return 0
 }

--- a/scripts/lib/cadence-format.sh
+++ b/scripts/lib/cadence-format.sh
@@ -43,7 +43,7 @@ CADENCE_FORMAT_MARKER="himmel-cadence-runner-format:"
 # Basename registry for generated cadence runners. Keep explicit: a stray
 # foreign *.bat/*.sh in a runner dir must not poison the staleness probe.
 # shellcheck disable=SC2034  # consumed by cadence_runner_stamp callers/tests
-CADENCE_RUNNER_BASENAMES="pipeline-harvest pipeline-synthesize pipeline-health codex-sweep graphmap-luna graphmap-himmel"
+CADENCE_RUNNER_BASENAMES="pipeline-harvest pipeline-synthesize pipeline-health codex-sweep graphmap-luna graphmap-himmel qmd-reindex"
 
 # cadence_user_home
 # The runner homes the EMITTERS write under key off resolve_user_home

--- a/scripts/luna/qmd-cadence.sh
+++ b/scripts/luna/qmd-cadence.sh
@@ -1,0 +1,968 @@
+#!/usr/bin/env bash
+# qmd-cadence.sh — arm/status/disarm the recurring qmd reindex cadence
+# (HIMMEL-568).
+#
+# WHY: the qmd index goes stale SILENTLY. During HIMMEL-564 Phase A the luna
+# collection sat five days stale (lastUpdated 2026-06-22, needsEmbedding 0) while
+# notes written that week were simply not searchable — every qmd-backed workflow
+# answered off a stale index and nothing signalled it. scripts/luna/qmd-reindex.sh
+# is the RUNNER that refreshes it (`qmd update` + `qmd embed` + a completeness
+# assert); what was missing is the scheduler. This is that layer: one daily
+# OS-scheduler task that fires the runner off-peak.
+#
+# DESIGN: modelled on the sibling graphmap-cadence.sh (HIMMEL-829), NOT on
+# pipeline-cadence.sh. pipeline-cadence fires interactive `claude "<prompt>" < NUL`
+# bounded sessions, each wired with a --settings auto-approve fragment. THIS
+# scheduler fires a DETERMINISTIC SCRIPT — `bash <himmel>/scripts/luna/
+# qmd-reindex.sh --qmd-bin <qmd>` — so it has NO claude SESSION, NO NUL-stdin, NO
+# settings fragment and NO auto-approve hook. `qmd update` / `qmd embed` are plain
+# CLI calls, so the deterministic shape is the correct precedent.
+#
+# HIMMEL-128 (headless-claude billing) does NOT apply here, not even indirectly.
+# The graphmap sibling carries that caveat because its graphify backend shells the
+# `claude` CLI underneath; nothing in the qmd path invokes claude at all.
+#
+# ONE task is registered:
+#   HIMMEL-Qmd-Reindex   daily (default 05:00 local)
+#       bash <himmel>/scripts/luna/qmd-reindex.sh --qmd-bin <qmd>
+#
+# WHY 05:00 LOCAL: it lands AFTER the whole pipeline-cadence chain has finished
+# writing to the vault (HIMMEL-Pipeline-Harvest 02:00, -Synthesize 03:00,
+# -Health 04:00), so the reindex actually picks up what those legs just wrote
+# instead of racing them — a reindex scheduled before them would index the
+# previous day's vault. It is also clear of the graphmap slots (13:00 / 13:20)
+# and the 17:00 codex orphan sweep. Cost basis for daily: a full local refresh
+# measured 2026-07-25 ran in 16s (update) + 24s (embed) — daily is cheap, and
+# daily is what bounds the observed five-day staleness to under 24h.
+#
+# WHY THE qmd BINARY IS PINNED AT ARM TIME: schtasks and cron fire with a MINIMAL
+# PATH that does not carry the bun bin dir where qmd installs (~/.bun/bin here).
+# Resolving it HERE, at arm time, is what makes the failure visible — otherwise
+# the arm "succeeds" and every unattended fire dies in a log nobody reads. The
+# resolved ABSOLUTE path is passed to the runner as --qmd-bin. Unlike the
+# graphmap sibling (which must PATH-prepend, because graphify spawns `claude`
+# itself), we invoke qmd directly, so passing the path is both simpler and
+# stricter. Verified 2026-07-25: qmd runs correctly under a bare
+# PATH=C:\Windows\system32, so no PATH surgery is needed.
+#
+# OPERATOR FLIP: this NEVER auto-arms. `arm` registers the task only when
+# explicitly invoked, exactly like graphmap-cadence — arming is the operator's
+# decision, not a side effect of installing the harness.
+#
+# Usage:
+#   bash scripts/luna/qmd-cadence.sh arm [--time HH:MM] [--force] [--dry-run]
+#   bash scripts/luna/qmd-cadence.sh status
+#   bash scripts/luna/qmd-cadence.sh disarm [--dry-run]
+#
+# Test seams (used by test-qmd-cadence.sh):
+#   QMD_CADENCE_SCHTASKS  — command invoked instead of `schtasks` (Windows)
+#   QMD_CADENCE_CRONTAB   — command invoked instead of `crontab` (POSIX)
+#   QMD_CADENCE_BAT_DIR   — where the persistent runner (.bat/.sh) lives
+#
+# Exit codes (mirrors graphmap-cadence.sh / pipeline-cadence.sh):
+#   0  done (armed / status printed / disarmed / dry-run)
+#   1  usage / input error
+#   2  env unusable (no schtasks/crontab; unknown platform; runner or qmd
+#      missing; query tool errored)
+#   3  dedup block — a HIMMEL-Qmd-* task is already armed; use --force
+#   4  scheduler invocation failed (/create, /delete, crontab rewrite,
+#      path conversion)
+set -euo pipefail
+
+TASK_PREFIX="HIMMEL-Qmd-"
+TASK_REINDEX="${TASK_PREFIX}Reindex"
+SCHTASKS_BIN="${QMD_CADENCE_SCHTASKS:-schtasks}"
+CRONTAB_BIN="${QMD_CADENCE_CRONTAB:-crontab}"
+
+# Cross-platform user-home resolution (mirrors graphmap-cadence's, HIMMEL-645).
+# On Windows Git-Bash $HOME can be the MSYS home (/home/<user>) while Claude
+# Code's config (~/.claude) lives under the Windows user profile, so prefer
+# USERPROFILE via cygpath BEFORE $HOME. POSIX hosts have USERPROFILE unset and
+# fall straight through to $HOME. /tmp is the last-resort floor.
+resolve_user_home() {
+    if [ -n "${USERPROFILE:-}" ] && command -v cygpath >/dev/null 2>&1; then
+        cygpath -u "$USERPROFILE" 2>/dev/null || printf '%s' "$USERPROFILE"
+    else
+        printf '%s' "${HOME:-${USERPROFILE:-/tmp}}"
+    fi
+}
+
+# Persistent runner home (.bat on Windows, .sh on POSIX) — NOT mktemp: this task
+# recurs daily and %TEMP% / /tmp are subject to cleanup sweeps that would
+# silently kill the cadence (same rationale as the sibling cadences' BAT_DIR).
+BAT_DIR="${QMD_CADENCE_BAT_DIR:-$(resolve_user_home)/.claude/qmd-cadence}"
+
+# Resolve the himmel root from this script's own location (scripts/luna/..), so
+# the runner fires the shipped qmd-reindex.sh by absolute path.
+HIMMEL_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)"
+REINDEX_SCRIPT="$HIMMEL_ROOT/scripts/luna/qmd-reindex.sh"
+
+# Runner-format version stamp (HIMMEL-588): emit_bat / emit_runner stamp
+# CADENCE_RUNNER_FORMAT_VERSION into the runner so a stale-format armed cadence
+# is detectable. Shared lib, same as the sibling cadences.
+# shellcheck source=../lib/cadence-format.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/../lib/cadence-format.sh"
+
+# Off-peak default (see the header for the 05:00 rationale).
+REINDEX_TIME="05:00"
+FORCE=0
+DRY_RUN=0
+# Set when a --force arm has actually DELETED a previously armed task, so a
+# subsequent create failure can tell the operator the machine is now unarmed.
+REPLACED_EXISTING=0
+
+# Resolved by validate_arm_inputs: the absolute qmd executable handed to the
+# runner as --qmd-bin. See the header for why this is pinned at arm time.
+QMD_BIN=""
+
+usage() {
+    cat <<'EOF'
+Usage: qmd-cadence.sh <arm|status|disarm> [flags]
+
+Arm the OS scheduler with the recurring qmd reindex cadence (HIMMEL-568):
+one daily `qmd update` + `qmd embed` + completeness assert over ALL
+configured collections, fired as a DETERMINISTIC script
+(bash qmd-reindex.sh ...) — NO claude session.
+
+Subcommands:
+  arm      Register the daily task. Dedup-guarded: refuses (rc=3) if a
+           HIMMEL-Qmd-* task already exists; --force replaces.
+  status   Show whether the cadence is armed (+ next run time + run log).
+  disarm   Remove the task (idempotent; rc=0 if nothing was armed).
+
+Flags (arm only, except --dry-run):
+  --time <HH:MM>  Daily reindex time, 24h local (default 05:00)
+  --force         Replace an existing HIMMEL-Qmd-* task
+  --dry-run       Print what would happen, touch nothing
+                  (honored by arm AND disarm)
+
+WHY 05:00 local: it runs AFTER the pipeline-cadence legs that WRITE to the
+vault (Harvest 02:00, Synthesize 03:00, Health 04:00), so the reindex picks
+up what they wrote rather than racing them; and it is clear of the graphmap
+slots (13:00/13:20). A full refresh measured 16s + 24s, so daily is cheap.
+
+Collection scope is ALL configured collections — `qmd update` / `qmd embed`
+default to everything and take -c only to narrow, so nothing is hardcoded
+here and a collection added later needs no edit.
+
+This never auto-arms: arming is an explicit operator flip, and disarm is
+always available:
+    bash scripts/luna/qmd-cadence.sh disarm
+EOF
+}
+
+SUBCMD="${1:-}"
+if [ -z "$SUBCMD" ]; then
+    echo "ERR qmd-cadence: subcommand required (arm|status|disarm)" >&2
+    usage >&2
+    exit 1
+fi
+shift
+case "$SUBCMD" in
+    arm|status|disarm) ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+        echo "ERR qmd-cadence: unknown subcommand: $SUBCMD" >&2
+        usage >&2
+        exit 1
+        ;;
+esac
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --time)
+            # Demand a real operand: a trailing `--time` would otherwise make
+            # `shift 2` fail under set -e and exit with no message at all.
+            if [ $# -lt 2 ]; then
+                echo "ERR qmd-cadence: --time requires a value (HH:MM)" >&2
+                usage >&2
+                exit 1
+            fi
+            REINDEX_TIME="$2"; shift 2 ;;
+        --time=*)   REINDEX_TIME="${1#--time=}"; shift ;;
+        --force)    FORCE=1; shift ;;
+        --dry-run)  DRY_RUN=1; shift ;;
+        -h|--help)  usage; exit 0 ;;
+        *)
+            echo "ERR qmd-cadence: unknown arg: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Platform detect (same matrix as the sibling cadences).
+case "${OSTYPE:-$(uname -s 2>/dev/null || echo unknown)}" in
+    msys*|cygwin*|win32*|MINGW*) PLATFORM=windows ;;
+    linux*|Linux*)               PLATFORM=linux ;;
+    darwin*|Darwin*)             PLATFORM=macos ;;
+    *)                           PLATFORM=unknown ;;
+esac
+case "$PLATFORM" in
+    windows)
+        command -v "$SCHTASKS_BIN" >/dev/null 2>&1 || {
+            echo "ERR qmd-cadence: '$SCHTASKS_BIN' not on PATH (required on Windows)" >&2
+            exit 2
+        }
+        ;;
+    linux|macos)
+        command -v "$CRONTAB_BIN" >/dev/null 2>&1 || {
+            echo "ERR qmd-cadence: '$CRONTAB_BIN' not on PATH (required on $PLATFORM)" >&2
+            exit 2
+        }
+        ;;
+    *)
+        echo "ERR qmd-cadence: unsupported platform (OSTYPE=${OSTYPE:-})" >&2
+        echo "    Supported: Windows (schtasks), Linux/macOS (crontab)" >&2
+        exit 2
+        ;;
+esac
+
+# MSYS_NO_PATHCONV=1 per call: without it gitbash mangles /query, /create etc.
+# into Windows-rooted paths before schtasks sees them.
+run_schtasks() { MSYS_NO_PATHCONV=1 "$SCHTASKS_BIN" "$@"; }
+
+# Escape CMD metacharacters for values interpolated into the .bat (same order as
+# the sibling cadences' cmd_escape) so a path containing legal-but-hostile chars
+# (% & ^ are valid in Windows dirnames) can't inject commands at fire time.
+cmd_escape() {
+    local s="$1"
+    s="${s//\"/\\\"}"
+    s="${s//%/%%}"
+    s="${s//^/^^}"
+    s="${s//&/^&}"
+    s="${s//</^<}"
+    s="${s//>/^>}"
+    s="${s//|/^|}"
+    printf '%s' "$s"
+}
+
+# Dedup listing: every scheduled task named HIMMEL-Qmd-*. Fail-CLOSED if the
+# query tool itself errors (mirrors the sibling cadences' list_existing).
+list_existing() {
+    local err_file out rc
+    err_file=$(mktemp -t qmd-cadence.err.XXXXXX)
+    set +e
+    out=$(run_schtasks /query /fo CSV /nh 2>"$err_file")
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+        # Fail-CLOSED: any nonzero rc is fatal UNLESS it matches the one trusted
+        # empty-scheduler signature — rc=1 with EMPTY stderr (schtasks returns
+        # rc=1 on a completely empty scheduler; real errors carry stderr).
+        if [ "$rc" -ne 1 ] || [ -s "$err_file" ]; then
+            echo "ERR qmd-cadence: schtasks /query failed (rc=$rc) — refusing to treat as empty scheduler:" >&2
+            cat "$err_file" >&2
+            rm -f "$err_file"
+            exit 2
+        fi
+    fi
+    rm -f "$err_file"
+    # shellcheck disable=SC1003  # strips both quote and the literal backslash schtasks prefixes task names with
+    printf '%s\n' "$out" \
+        | grep -o '"\\\?HIMMEL-Qmd-[^"]*"' 2>/dev/null \
+        | tr -d '"\\' \
+        | sort -u || true
+}
+
+delete_task() {
+    local name="$1" err_file
+    err_file=$(mktemp -t qmd-cadence.err.XXXXXX)
+    if run_schtasks /delete /tn "$name" /f >/dev/null 2>"$err_file"; then
+        rm -f "$err_file"
+        echo "qmd-cadence: deleted scheduled task: $name"
+    else
+        echo "ERR qmd-cadence: schtasks /delete $name failed:" >&2
+        cat "$err_file" >&2
+        rm -f "$err_file"
+        exit 4
+    fi
+}
+
+# Known not-found stderr signatures for `/query /tn <name>` (mirrors the sibling
+# cadences). Real schtasks always emits one of these on a missing task, so rc=1
+# WITHOUT a match (silent rc=1 included) is a real query failure.
+NOT_FOUND_RE='The system cannot find the file specified|The specified task name .* does not exist'
+
+# query_one <name>: rc 0 = armed (QUERY_OUT set), rc 1 = trusted not-found,
+# rc 2 = query failed (stderr already printed).
+QUERY_OUT=""
+query_one() {
+    local name="$1" rc err_file
+    err_file=$(mktemp -t qmd-cadence.err.XXXXXX)
+    set +e
+    QUERY_OUT=$(run_schtasks /query /tn "$name" /fo LIST 2>"$err_file")
+    rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+        rm -f "$err_file"
+        return 0
+    fi
+    if [ "$rc" -eq 1 ] && grep -qiE "$NOT_FOUND_RE" "$err_file"; then
+        rm -f "$err_file"
+        return 1
+    fi
+    echo "ERR qmd-cadence: schtasks /query /tn $name failed (rc=$rc) — refusing to treat as 'not armed':" >&2
+    cat "$err_file" >&2
+    echo "    If this is a localized 'task does not exist' message, the task may simply" >&2
+    echo "    not be armed. Verify / remove manually:" >&2
+    echo "        schtasks /query /tn $name" >&2
+    echo "        schtasks /delete /tn $name /f" >&2
+    rm -f "$err_file"
+    return 2
+}
+
+task_summary() {
+    case "$1" in
+        "$TASK_REINDEX") printf ' -> qmd-reindex (update + embed, all collections, daily)' ;;
+    esac
+}
+
+status_one() {
+    local name="$1" next qrc=0
+    query_one "$name" || qrc=$?
+    case "$qrc" in
+        0)
+            next=$(printf '%s\n' "$QUERY_OUT" | grep -i 'Next Run Time' | head -1 \
+                | sed 's/^[^:]*:[[:space:]]*//' || true)
+            echo "ARMED      $name${next:+ (next run: $next)}$(task_summary "$name")"
+            ;;
+        1)  echo "not armed  $name$(task_summary "$name")" ;;
+        *)
+            echo "QUERY ERR  $name (see stderr above)"
+            return 2
+            ;;
+    esac
+}
+
+# Surface fire-time evidence: the runner writes its output to a .log next to
+# itself (rotated per fire), so "armed but never succeeding" is visible here.
+status_log() {
+    local log="$1" mtime last
+    if [ -f "$log" ]; then
+        mtime=$(date -r "$log" '+%Y-%m-%d %H:%M' 2>/dev/null \
+            || stat -f '%Sm' -t '%Y-%m-%d %H:%M' "$log" 2>/dev/null \
+            || echo '?')
+        last=$(tail -n 1 "$log" 2>/dev/null | tr -d '\r' || true)
+        echo "  run log    $log (last write: $mtime)"
+        if [ -n "$last" ]; then
+            echo "             last line: $last"
+        fi
+    elif [ -f "$log.prev" ]; then
+        echo "  run log    $log (rotated — see .log.prev; no run since last rotation)"
+    else
+        echo "  run log    $log (absent — task has not fired yet)"
+    fi
+    if [ -f "$log.prev" ]; then
+        # Same macOS-compatible fallback chain as the primary log above: BSD
+        # `date` has no -r, so without the `stat -f` leg this would always
+        # print '?' on macOS while the primary log resolved fine.
+        mtime=$(date -r "$log.prev" '+%Y-%m-%d %H:%M' 2>/dev/null \
+            || stat -f '%Sm' -t '%Y-%m-%d %H:%M' "$log.prev" 2>/dev/null \
+            || echo '?')
+        last=$(tail -n 1 "$log.prev" 2>/dev/null | tr -d '\r' || true)
+        echo "  prev log   $log.prev (last write: $mtime)"
+        if [ -n "$last" ]; then
+            echo "             last line: $last"
+        fi
+    fi
+}
+
+cmd_status() {
+    local status_rc=0
+    echo "qmd-cadence status:"
+    status_one "$TASK_REINDEX" || status_rc=2
+    status_log "$BAT_DIR/qmd-reindex.log"
+    return "$status_rc"
+}
+
+# Disarm every HIMMEL-Qmd-* task, not just the canonical TASK_REINDEX name.
+# `arm`'s dedup guard blocks on the PREFIX (list_existing), so a disarm that
+# only knew the exact name could leave an operator wedged: arm refuses with
+# "already armed", disarm answers "nothing armed", and nothing short of a manual
+# schtasks /delete breaks the tie. The POSIX path already disarms by prefix
+# (cron_existing greps TASK_PREFIX) — this brings the Windows path in line.
+# list_existing is fail-CLOSED, so a broken /query still exits 2 here rather
+# than reporting a false no-op.
+cmd_disarm() {
+    local found=0 existing name
+    existing=$(list_existing)
+    while IFS= read -r name; do
+        [ -z "$name" ] && continue
+        found=1
+        if [ "$DRY_RUN" -eq 1 ]; then
+            echo "DRY qmd-cadence: would delete $name"
+        else
+            delete_task "$name"
+        fi
+    done <<< "$existing"
+    if [ "$DRY_RUN" -eq 0 ]; then
+        rm -f "$BAT_DIR/qmd-reindex.bat"
+    fi
+    if [ "$found" -eq 0 ]; then
+        echo "qmd-cadence: nothing armed — disarm is a no-op"
+    elif [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRY qmd-cadence: no changes made"
+    else
+        echo "qmd-cadence: cadence disarmed"
+    fi
+}
+
+# Emit the .bat body: stamp the format version, rotate the run log (one prior run
+# kept as .log.prev), stamp the fire time, cd into the himmel root (a failing cd
+# aborts + is logged instead of firing from the wrong CWD), then fire bash +
+# qmd-reindex.sh with stdout+stderr captured to the rotating log. NO claude
+# SESSION, NO stdin redirect: the runner IS the payload. No PATH surgery either —
+# the qmd path is passed to the runner explicitly (see the header).
+emit_bat() {
+    local himmel_win_esc="$1" payload="$2" log_win_esc="$3"
+    printf 'rem %s %s\r\n' "$CADENCE_FORMAT_MARKER" "$CADENCE_RUNNER_FORMAT_VERSION"
+    printf 'if exist "%s" move /y "%s" "%s.prev" > NUL 2>&1\r\n' "$log_win_esc" "$log_win_esc" "$log_win_esc"
+    printf 'echo [fired %%DATE%% %%TIME%%] >> "%s" 2>&1\r\n' "$log_win_esc"
+    printf 'cd /d "%s" >> "%s" 2>&1 || exit /b 1\r\n' "$himmel_win_esc" "$log_win_esc"
+    printf '%s >> "%s" 2>&1\r\n' "$payload" "$log_win_esc"
+}
+
+# --- schtasks task XML (StartWhenAvailable) --------------------------------
+#
+# schtasks /create has no flag for StartWhenAvailable ("run as soon as possible
+# after a missed scheduled start"), so a daily 05:00 run is SILENTLY SKIPPED if
+# the machine was off/asleep at 05:00 — which for a staleness-prevention cadence
+# is the whole failure mode returning. The only CLI route is `schtasks /create
+# /xml`; we keep the .bat as the Exec Command and wrap it in XML carrying
+# StartWhenAvailable=true (same approach as the sibling cadences, HIMMEL-362).
+
+# Escape the three XML-significant characters for element-body text (the Exec
+# <Command> path — a BAT_DIR path may legally contain `&`). `&` first so the `&`
+# in the &lt;/&gt; entities isn't re-escaped. sed (not bash ${//}) for a
+# version-independent literal-ampersand replacement.
+xml_escape() {
+    printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
+schedule_daily_xml() {
+    printf '      <ScheduleByDay>\n        <DaysInterval>1</DaysInterval>\n      </ScheduleByDay>'
+}
+
+# Emit the task XML: a CalendarTrigger at the given local time, daily schedule,
+# StartWhenAvailable=true, and the .bat runner as the Exec Command. StartBoundary
+# date is a fixed past sentinel — the schedule fragment (not the date) governs
+# firing. MultipleInstancesPolicy=IgnoreNew is what keeps the cadence from
+# overlapping ITSELF (qmd-reindex.sh takes no lock of its own by design).
+# Declared UTF-16 (what schtasks /create /xml expects) but the bytes are plain
+# ASCII — keep it ASCII-only (a non-ASCII byte would need a real UTF-16LE +BOM
+# file; declaring UTF-8 is rejected on Win11).
+emit_task_xml() {
+    local command_raw="$1" start_time="$2" schedule_xml="$3" command
+    command=$(xml_escape "$command_raw")
+    cat <<XML
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>himmel qmd-cadence (HIMMEL-568)</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <CalendarTrigger>
+      <StartBoundary>2020-01-01T${start_time}:00</StartBoundary>
+      <Enabled>true</Enabled>
+${schedule_xml}
+    </CalendarTrigger>
+  </Triggers>
+  <Settings>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <Enabled>true</Enabled>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>${command}</Command>
+    </Exec>
+  </Actions>
+</Task>
+XML
+}
+
+# Create the task from an XML definition (so StartWhenAvailable applies).
+# Self-contained error handling; returns the schtasks rc so callers keep the
+# failure flow.
+schtasks_create_xml() {
+    local name="$1" schedule_xml="$2" start_time="$3" bat_win="$4" err_file="$5"
+    local xml_file xml_win rc
+    if ! xml_file=$(mktemp -t qmd-cadence.xml.XXXXXX 2>"$err_file"); then
+        return 1
+    fi
+    emit_task_xml "$bat_win" "$start_time" "$schedule_xml" > "$xml_file"
+    if ! xml_win=$(cygpath -w "$xml_file" 2>"$err_file"); then
+        rm -f "$xml_file"
+        return 1
+    fi
+    set +e
+    run_schtasks /create /tn "$name" /xml "$xml_win" /f 2>"$err_file"
+    rc=$?
+    set -e
+    rm -f "$xml_file"
+    return "$rc"
+}
+
+# Input validation shared by the schtasks and cron arm paths.
+validate_arm_inputs() {
+    if ! [[ "$REINDEX_TIME" =~ ^([01][0-9]|2[0-3]):[0-5][0-9]$ ]]; then
+        echo "ERR qmd-cadence: --time must be HH:MM (24h), got: $REINDEX_TIME" >&2
+        exit 1
+    fi
+    if [ ! -f "$REINDEX_SCRIPT" ]; then
+        echo "ERR qmd-cadence: qmd-reindex.sh not found at $REINDEX_SCRIPT" >&2
+        exit 2
+    fi
+    # FAIL FAST on a missing `qmd`. The scheduler fires with a MINIMAL PATH that
+    # does not carry qmd's bin dir (bun installs to ~/.bun/bin), so this must
+    # resolve HERE — without it the arm "succeeds" and the first unattended fire
+    # dies in a log nobody reads. The resolved absolute path is handed to the
+    # runner as --qmd-bin.
+    if ! QMD_BIN=$(command -v qmd 2>/dev/null); then
+        {
+            echo "ERR qmd-cadence: 'qmd' not on PATH at arm time, but the cadence runs it at fire time."
+            echo "    The scheduler fires with a minimal PATH, so this must resolve HERE — arming now"
+            echo "    would produce a cadence that fails on every fire. Install qmd (or put it on PATH)"
+            echo "    and re-arm."
+        } >&2
+        exit 2
+    fi
+    # `command -v` resolves more than on-PATH executables: a shell FUNCTION or
+    # ALIAS resolves to its own name/definition, and a relative PATH entry
+    # resolves to a relative path. Either would be meaningless in a runner that
+    # has cd'd elsewhere under a different PATH — the exact failure this check
+    # exists to prevent (same guard the graphmap sibling applies to `claude`).
+    # Demand a real, absolute, executable file (Windows: the `.exe` an MSYS -x
+    # test still accepts behind an extensionless path).
+    case "$QMD_BIN" in
+        /*|[A-Za-z]:[/\\]*) : ;;
+        *)
+            echo "ERR qmd-cadence: 'qmd' resolved to a non-absolute path ('$QMD_BIN') — a shell function/alias or a relative PATH entry cannot be pinned into a scheduled runner. Install qmd on PATH as a real executable and re-arm." >&2
+            exit 2 ;;
+    esac
+    if [ ! -f "$QMD_BIN" ] || [ ! -x "$QMD_BIN" ]; then
+        echo "ERR qmd-cadence: 'qmd' resolved to '$QMD_BIN', which is not an executable file — refusing to pin it into a scheduled runner." >&2
+        exit 2
+    fi
+}
+
+cmd_arm() {
+    validate_arm_inputs
+
+    # Resolve bash to an absolute Windows path so the .bat invokes the Git-Bash
+    # interpreter directly — NOT the bare `bash` that resolves to the WSL
+    # System32 stub in a fresh cmd.exe.
+    local bash_posix bash_win
+    if ! bash_posix=$(command -v bash 2>/dev/null); then
+        echo "ERR qmd-cadence: 'bash' not on PATH at arm time" >&2
+        exit 2
+    fi
+    command -v cygpath >/dev/null 2>&1 || {
+        echo "ERR qmd-cadence: cygpath not on PATH; cannot convert paths for schtasks" >&2
+        exit 2
+    }
+    if ! bash_win=$(cygpath -w "$bash_posix" 2>&1); then
+        echo "ERR qmd-cadence: cygpath -w failed for bash path: $bash_win" >&2
+        exit 4
+    fi
+
+    # bash consumes these paths (POSIX/mixed C:/ form via cygpath -m, which
+    # Git-Bash reads); the himmel cd target is a Windows path.
+    local script_mixed qmd_mixed himmel_win
+    if ! script_mixed=$(cygpath -m "$REINDEX_SCRIPT" 2>&1); then
+        echo "ERR qmd-cadence: cygpath -m failed for reindex script: $script_mixed" >&2
+        exit 4
+    fi
+    if ! qmd_mixed=$(cygpath -m "$QMD_BIN" 2>&1); then
+        echo "ERR qmd-cadence: cygpath -m failed for qmd path: $qmd_mixed" >&2
+        exit 4
+    fi
+    if ! himmel_win=$(cygpath -w "$HIMMEL_ROOT" 2>&1); then
+        echo "ERR qmd-cadence: cygpath -w failed for himmel root: $himmel_win" >&2
+        exit 4
+    fi
+
+    # Dedup guard — never double-register the cadence.
+    local existing
+    existing=$(list_existing)
+    if [ -n "$existing" ]; then
+        if [ "$FORCE" -eq 1 ]; then
+            echo "qmd-cadence: --force set; replacing existing task(s):" >&2
+            local marker
+            while IFS= read -r marker; do
+                [ -z "$marker" ] && continue
+                echo "  $marker" >&2
+                if [ "$DRY_RUN" -eq 0 ]; then
+                    delete_task "$marker"
+                    # Track that the OLD cadence is already gone, so a later
+                    # create failure can say so plainly (see the exit-4 path).
+                    REPLACED_EXISTING=1
+                else
+                    echo "DRY qmd-cadence: would delete $marker"
+                fi
+            done <<< "$existing"
+        else
+            {
+                echo "ERR qmd-cadence: HIMMEL-Qmd-* task(s) already armed:"
+                printf '%s\n' "$existing" | sed 's/^/    /'
+                echo ""
+                echo "Dedup safeguard — re-run with --force to replace, or inspect with:"
+                echo "    bash scripts/luna/qmd-cadence.sh status"
+            } >&2
+            exit 3
+        fi
+    fi
+
+    # cmd-escape EVERY path value interpolated into the .bat payload — the bash
+    # interpreter path included. It is the least likely of the three to contain
+    # a cmd metacharacter (typically C:\Program Files\Git\bin\bash.exe), but
+    # "unlikely" is not "escaped": a `%` anywhere in the resolved path would be
+    # expanded by cmd.exe at fire time instead of taken literally, and leaving
+    # one of three interpolated values unescaped is the kind of asymmetry that
+    # reads as intentional later. (The graphmap sibling leaves its bash path
+    # raw; this is a deliberate divergence, not a copy miss.)
+    local bash_win_esc script_esc qmd_esc himmel_win_esc
+    bash_win_esc=$(cmd_escape "$bash_win")
+    script_esc=$(cmd_escape "$script_mixed")
+    qmd_esc=$(cmd_escape "$qmd_mixed")
+    himmel_win_esc=$(cmd_escape "$himmel_win")
+
+    local payload
+    payload="\"$bash_win_esc\" \"$script_esc\" --qmd-bin \"$qmd_esc\""
+
+    local bat="$BAT_DIR/qmd-reindex.bat"
+
+    # Fire-time run log lives next to the .bat (cmd-escaped for the `>>` target).
+    local bat_dir_win log_esc
+    if ! bat_dir_win=$(cygpath -w "$BAT_DIR" 2>&1); then
+        echo "ERR qmd-cadence: cygpath -w failed for bat dir: $bat_dir_win" >&2
+        exit 4
+    fi
+    log_esc=$(cmd_escape "$bat_dir_win\\qmd-reindex.log")
+
+    # The .bat runner is the task's Exec Command. cygpath -w is a pure string
+    # transform (the .bat need not exist yet), so resolve the win path before the
+    # dry-run preview too.
+    local bat_win
+    if ! bat_win=$(cygpath -w "$bat" 2>&1); then
+        echo "ERR qmd-cadence: cygpath -w failed: $bat_win" >&2
+        exit 4
+    fi
+
+    local sched
+    sched=$(schedule_daily_xml)
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRY qmd-cadence: would write $bat:"
+        emit_bat "$himmel_win_esc" "$payload" "$log_esc" | sed 's/^/    /'
+        echo "DRY qmd-cadence: would schtasks /create /tn $TASK_REINDEX /xml <daily $REINDEX_TIME, StartWhenAvailable=true> /f"
+        emit_task_xml "$bat_win" "$REINDEX_TIME" "$sched" | sed 's/^/    /'
+        echo "qmd-cadence: dry-run complete (no changes made)"
+        return 0
+    fi
+
+    mkdir -p "$BAT_DIR"
+    # Stage the .bat and promote (mv) it only after schtasks /create succeeds —
+    # the same discipline the POSIX path already applies to its runner. Writing
+    # it in place first would let a failed create (exit 4) leave the runner file
+    # carrying the NEW config while the scheduler does not have the new task: a
+    # silent half-state, and under --force the OLD task is already deleted by
+    # then. The task XML still references the FINAL $bat path, so promotion is
+    # what makes the pair consistent. Staged file is cleaned on both paths.
+    local tmp_bat="$bat.tmp.$$"
+    emit_bat "$himmel_win_esc" "$payload" "$log_esc" > "$tmp_bat"
+
+    local err_file
+    err_file=$(mktemp -t qmd-cadence.err.XXXXXX)
+    if ! schtasks_create_xml "$TASK_REINDEX" "$sched" "$REINDEX_TIME" "$bat_win" "$err_file"; then
+        echo "ERR qmd-cadence: schtasks /create $TASK_REINDEX failed:" >&2
+        cat "$err_file" >&2
+        rm -f "$err_file" "$tmp_bat"
+        echo "    existing runner .bat left untouched" >&2
+        # Under --force the OLD task was already deleted above, so this failure
+        # leaves the machine with NO cadence armed. Say so plainly: the .bat
+        # line alone reads as "nothing changed", which is the opposite of true.
+        if [ "$REPLACED_EXISTING" -eq 1 ]; then
+            echo "    WARNING: --force already removed the previously armed task, and this" >&2
+            echo "    create failed — NO qmd cadence is armed right now. Re-run:" >&2
+            echo "        bash scripts/luna/qmd-cadence.sh arm" >&2
+        fi
+        exit 4
+    fi
+    if [ -s "$err_file" ]; then cat "$err_file" >&2; fi
+    rm -f "$err_file"
+    mv -f "$tmp_bat" "$bat"
+
+    cat <<EOF
+
+================================================================
+  QMD REINDEX CADENCE ARMED (HIMMEL-568)
+  $TASK_REINDEX  daily $REINDEX_TIME  -> qmd update + qmd embed
+  Scope:  all configured qmd collections
+  qmd:    $QMD_BIN
+  Himmel: $HIMMEL_ROOT
+  Runner .bat: $BAT_DIR
+
+  The task fires bash + qmd-reindex.sh directly (no claude session).
+  StartWhenAvailable=true: a run missed because the PC was off/asleep
+  fires when the PC is next on. Disarm anytime with:
+      bash scripts/luna/qmd-cadence.sh disarm
+================================================================
+EOF
+}
+
+# --- POSIX (cron) implementation -------------------------------------------
+#
+# Same arm/status/disarm contract as the schtasks path, against the user
+# crontab. The runner .sh mirrors the .bat: log rotation, fire stamp,
+# cd-into-himmel, then bash + qmd-reindex.sh.
+
+CRON_RUNNER="$BAT_DIR/qmd-reindex.sh"
+
+# Shell-quote a value for a cron command line (mirrors the sibling cadences'
+# cron_escape): printf %q survives the /bin/sh re-parse; the extra % -> \% pass
+# is cron(5) syntax. Control characters are rejected (rc=2).
+cron_escape() {
+    if printf '%s' "$1" | grep -qP '[[:cntrl:]]' 2>/dev/null \
+       || printf '%s' "$1" | LC_ALL=C grep -q $'[\x01-\x1f\x7f]'; then
+        echo "ERR qmd-cadence: cron_escape: argument contains control characters — rejected" >&2
+        return 2
+    fi
+    local s
+    s=$(printf '%q' "$1")
+    printf '%s' "${s//%/\\%}"
+}
+
+# Read the current crontab into CRON_TAB. Fail-CLOSED like list_existing.
+CRON_TAB=""
+cron_read() {
+    local err_file rc
+    err_file=$(mktemp -t qmd-cadence.err.XXXXXX)
+    set +e
+    CRON_TAB=$(LC_ALL=C "$CRONTAB_BIN" -l 2>"$err_file")
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+        if [ "$rc" -eq 1 ] && { [ ! -s "$err_file" ] || grep -qi 'no crontab' "$err_file"; }; then
+            CRON_TAB=""
+        else
+            echo "ERR qmd-cadence: crontab -l failed (rc=$rc) — refusing to treat as empty crontab:" >&2
+            cat "$err_file" >&2
+            echo "    Non-vixie crons (busybox, Solaris) phrase 'no crontab yet' differently;" >&2
+            echo "    if that is what tripped this, install an empty crontab to unblock:" >&2
+            echo "        crontab - </dev/null" >&2
+            rm -f "$err_file"
+            exit 2
+        fi
+    fi
+    rm -f "$err_file"
+}
+
+# Install a new crontab from the given file. Returns 4 on failure; the rejected
+# tab is kept for forensics.
+cron_install() {
+    local tab_file="$1" err_file
+    err_file=$(mktemp -t qmd-cadence.err.XXXXXX)
+    if ! "$CRONTAB_BIN" - < "$tab_file" 2>"$err_file"; then
+        echo "ERR qmd-cadence: crontab install failed:" >&2
+        cat "$err_file" >&2
+        rm -f "$err_file"
+        echo "    rejected crontab left at: $tab_file" >&2
+        return 4
+    fi
+    rm -f "$err_file" "$tab_file"
+}
+
+# Marker-tagged cadence lines in the current CRON_TAB (empty if none).
+cron_existing() {
+    printf '%s\n' "$CRON_TAB" | grep -F "$TASK_PREFIX" || true
+}
+
+# Emit the runner .sh body: stamp the format version, rotate the run log, stamp
+# the fire time, cd into the himmel root, then fire the payload with output
+# captured to the log. No PATH prepend is needed — unlike the graphmap sibling
+# (whose graphify backend spawns `claude` and therefore needs it discoverable),
+# we hand qmd's absolute path to the runner as --qmd-bin.
+# shellcheck disable=SC2016  # single-quoted $log/$(date)/_rc are emitted literally for the runner's own /bin/sh
+emit_runner() {
+    local name="$1" payload="$2" q_log="$3" q_himmel="$4"
+    printf '#!/bin/sh\n'
+    printf '# %s runner — generated by qmd-cadence.sh arm (HIMMEL-568)\n' "$name"
+    printf '# %s %s\n' "$CADENCE_FORMAT_MARKER" "$CADENCE_RUNNER_FORMAT_VERSION"
+    printf 'log=%s\n' "$q_log"
+    printf 'if [ -f "$log" ]; then\n'
+    printf '    mv -f "$log" "$log.prev" || echo "[rotation failed: mv $log -> $log.prev]" >> "$log" 2>&1\n'
+    printf 'fi\n'
+    printf '{\n'
+    printf '    echo "[fired $(date '\''+%%Y-%%m-%%d %%H:%%M:%%S'\'')]"\n'
+    printf '    cd %s || exit 1\n' "$q_himmel"
+    printf '    _rc=0; %s || _rc=$?\n' "$payload"
+    printf '    echo "[exit rc=$_rc]"\n'
+    printf '} >> "$log" 2>&1\n'
+    # PROPAGATE the runner's exit code (CR finding [codex-1]). Without this the
+    # script's status is that of the final `echo` inside the block — i.e. ALWAYS
+    # 0 — so cron (and anything else keyed on exit status) reports success after
+    # a failed reindex. That is precisely the silent-failure shape this ticket
+    # exists to eliminate, and it also made the two runner formats disagree: the
+    # .bat path already propagates, because its last line IS the payload.
+    # Deliberate divergence from the graphmap sibling, which swallows it too.
+    printf 'exit "$_rc"\n'
+}
+
+cron_status() {
+    cron_read
+    echo "qmd-cadence status:"
+    local entry sched
+    entry=$(printf '%s\n' "$CRON_TAB" | grep -F "# $TASK_REINDEX" | head -1 || true)
+    if [ -n "$entry" ]; then
+        sched=$(printf '%s' "$entry" | awk '{print $1, $2, $3, $4, $5}')
+        echo "ARMED      $TASK_REINDEX (cron: $sched)$(task_summary "$TASK_REINDEX")"
+    else
+        echo "not armed  $TASK_REINDEX$(task_summary "$TASK_REINDEX")"
+    fi
+    status_log "$BAT_DIR/qmd-reindex.log"
+}
+
+cron_disarm() {
+    cron_read
+    local existing
+    existing=$(cron_existing)
+    if [ -z "$existing" ]; then
+        if [ "$DRY_RUN" -eq 0 ]; then
+            rm -f "$CRON_RUNNER"
+        fi
+        echo "qmd-cadence: nothing armed — disarm is a no-op"
+        return 0
+    fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+        local line
+        while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            echo "DRY qmd-cadence: would remove crontab entry: $line"
+        done <<< "$existing"
+        echo "DRY qmd-cadence: no changes made"
+        return 0
+    fi
+    local newtab
+    newtab=$(mktemp -t qmd-cadence.cron.XXXXXX)
+    printf '%s\n' "$CRON_TAB" | grep -vF "$TASK_PREFIX" > "$newtab" || true
+    # Install must succeed BEFORE the runner is removed — a failed install leaves
+    # the entry live and it must keep pointing at an existing runner.
+    cron_install "$newtab" || exit 4
+    rm -f "$CRON_RUNNER"
+    echo "qmd-cadence: cadence disarmed"
+}
+
+cron_arm() {
+    validate_arm_inputs
+
+    # Resolve bash to an absolute path so the runner doesn't depend on cron's
+    # minimal PATH.
+    local bash_bin
+    if ! bash_bin=$(command -v bash 2>/dev/null); then
+        echo "ERR qmd-cadence: 'bash' not on PATH at arm time" >&2
+        exit 2
+    fi
+
+    # Dedup guard — never double-register the cadence.
+    cron_read
+    local existing
+    existing=$(cron_existing)
+    if [ -n "$existing" ]; then
+        if [ "$FORCE" -eq 1 ]; then
+            echo "qmd-cadence: --force set; replacing existing cadence entry:" >&2
+            local line
+            while IFS= read -r line; do
+                [ -z "$line" ] && continue
+                if [ "$DRY_RUN" -eq 0 ]; then
+                    echo "  $line" >&2
+                else
+                    echo "DRY qmd-cadence: would remove crontab entry: $line"
+                fi
+            done <<< "$existing"
+        else
+            {
+                echo "ERR qmd-cadence: HIMMEL-Qmd-* crontab entr(ies) already armed:"
+                printf '%s\n' "$existing" | sed 's/^/    /'
+                echo ""
+                echo "Dedup safeguard — re-run with --force to replace, or inspect with:"
+                echo "    bash scripts/luna/qmd-cadence.sh status"
+            } >&2
+            exit 3
+        fi
+    fi
+
+    local q_bash q_script q_qmd q_himmel q_log
+    q_bash=$(printf '%q' "$bash_bin")
+    q_script=$(printf '%q' "$REINDEX_SCRIPT")
+    q_qmd=$(printf '%q' "$QMD_BIN")
+    q_himmel=$(printf '%q' "$HIMMEL_ROOT")
+    q_log=$(printf '%q' "$BAT_DIR/qmd-reindex.log")
+
+    local payload
+    payload="$q_bash $q_script --qmd-bin $q_qmd"
+
+    local hh mm
+    hh="${REINDEX_TIME%:*}"; mm="${REINDEX_TIME#*:}"
+    local q_runner entry
+    q_runner=$(cron_escape "$CRON_RUNNER")
+    entry="$mm $hh * * * $q_runner # $TASK_REINDEX"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRY qmd-cadence: would write $CRON_RUNNER:"
+        emit_runner "$TASK_REINDEX" "$payload" "$q_log" "$q_himmel" | sed 's/^/    /'
+        echo "DRY qmd-cadence: would add crontab entry:"
+        echo "    $entry"
+        echo "qmd-cadence: dry-run complete (no changes made)"
+        return 0
+    fi
+
+    mkdir -p "$BAT_DIR"
+    # Stage the runner at a temp path and promote (mv) it only after the crontab
+    # install succeeds: writing it in place first would let a failed install
+    # (exit 4) leave the OLD crontab live while the runner file already carries
+    # the NEW config — a silent half-state under --force re-arm.
+    local tmp_runner="$CRON_RUNNER.tmp.$$"
+    emit_runner "$TASK_REINDEX" "$payload" "$q_log" "$q_himmel" > "$tmp_runner"
+    chmod +x "$tmp_runner"
+
+    # Single atomic rewrite: everything that isn't ours, then our entry.
+    local newtab
+    newtab=$(mktemp -t qmd-cadence.cron.XXXXXX)
+    {
+        if [ -n "$CRON_TAB" ]; then
+            printf '%s\n' "$CRON_TAB" | grep -vF "$TASK_PREFIX" || true
+        fi
+        printf '%s\n' "$entry"
+    } > "$newtab"
+    if ! cron_install "$newtab"; then
+        rm -f "$tmp_runner"
+        echo "    existing runner file left untouched" >&2
+        exit 4
+    fi
+    mv -f "$tmp_runner" "$CRON_RUNNER"
+
+    cat <<EOF
+
+================================================================
+  QMD REINDEX CADENCE ARMED (HIMMEL-568, cron)
+  $TASK_REINDEX  daily $REINDEX_TIME  -> qmd update + qmd embed
+  Scope:  all configured qmd collections
+  qmd:    $QMD_BIN
+  Himmel: $HIMMEL_ROOT
+  Runner .sh: $BAT_DIR
+
+  The entry fires bash + qmd-reindex.sh directly (no claude session).
+  Disarm anytime:
+      bash scripts/luna/qmd-cadence.sh disarm
+================================================================
+EOF
+}
+
+case "$SUBCMD" in
+    arm)    if [ "$PLATFORM" = "windows" ]; then cmd_arm;    else cron_arm;    fi ;;
+    status) if [ "$PLATFORM" = "windows" ]; then cmd_status; else cron_status; fi ;;
+    disarm) if [ "$PLATFORM" = "windows" ]; then cmd_disarm; else cron_disarm; fi ;;
+esac

--- a/scripts/luna/qmd-reindex.sh
+++ b/scripts/luna/qmd-reindex.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# qmd-reindex.sh — deterministic qmd index refresh: `qmd update` then
+# `qmd embed`, then a completeness assert (HIMMEL-568).
+#
+# WHY: the qmd index goes stale SILENTLY. Observed during HIMMEL-564 Phase A —
+# `qmd status` reported luna lastUpdated 2026-06-22 with needsEmbedding: 0 for
+# five days, so notes written 2026-06-27 were simply not searchable, and every
+# qmd-backed workflow (compounding, ingest, synthesis, recall) answered off a
+# stale index without signalling anything. This script is the RUNNER that fixes
+# that; scripts/luna/qmd-cadence.sh is the scheduler that fires it daily.
+#
+# The split is deliberate and mirrors the graphify precedent (HIMMEL-825/829):
+# refresh-graph-map.sh is the runner, graphmap-cadence.sh the arm layer. Keeping
+# them separate is what lets HIMMEL-1275's ship transport invoke the SAME build
+# step on demand ("ship after a successful local reindex") without re-entering a
+# scheduler.
+#
+# DESIGN: this is a DETERMINISTIC SCRIPT, not a claude session. `qmd update` and
+# `qmd embed` are plain CLI calls, so there is no bounded-session shape here — no
+# NUL stdin, no --settings auto-approve fragment, no claude invocation at all.
+# HIMMEL-128 (headless-claude billing) therefore does not apply: nothing in this
+# path shells `claude`, unlike refresh-graph-map.sh whose graphify backend does.
+#
+# WHY A SECOND `qmd embed` (the completeness assert): `qmd embed` has a session
+# cap (--timeout, default 30 minutes). A run that hits the cap exits having
+# embedded only PART of the pending set, leaving vectors lagging the lex index —
+# which is the EXACT silently-wrong state this ticket exists to eliminate, just
+# with a fresher timestamp on it. So after embedding we call `qmd embed` again:
+# when the set is genuinely complete it is a no-op that prints
+# "All content hashes already have embeddings" and costs ~1s. Anything else means
+# vectors are still pending and we fail LOUD (rc=5) instead of reporting success.
+#
+# DAEMON SAFETY: a resident `qmd mcp` daemon (the qmd-mcp-daemon scheduled task,
+# plus any MCP client holding the index) may be live while this runs. This runner
+# does NOT fence (stop/start) the daemon.
+#
+# Be precise about the evidence for that, because "verified safe" is a bigger
+# claim than what was actually measured. OBSERVED on 2026-07-25: with the daemon
+# up (PID 26420 @ localhost:8181), a full `qmd update` + `qmd embed` completed
+# without error, and the daemon was still serving on the SAME PID afterwards.
+# That is process survival + no error — it is NOT a concurrency proof: nothing
+# exercised MCP reads racing these writes, and SQLite-level read consistency
+# under concurrent access was not tested. It is enough to justify not fencing by
+# default; it is not enough to call the combination proven. If a fence is ever
+# needed, it belongs HERE, in the runner — not in the scheduler.
+#
+# COLLECTION SCOPE: all configured collections. Both `qmd update` and `qmd embed`
+# default to every collection and take `-c <name>` only to NARROW, so the bare
+# calls below are the "everything qmd knows about" scope by construction. That is
+# deliberately not a hardcoded list — a collection added later is picked up with
+# no edit here. (Local carries 4 today: himmel, luna, salus, luna-curated.)
+#
+# CONCURRENCY: no lock. The scheduled task is registered with
+# MultipleInstancesPolicy=IgnoreNew, so the cadence cannot overlap ITSELF; an
+# on-demand run racing a scheduled one is left to qmd's own SQLite locking, the
+# same bet graphmap-cadence makes. Cost basis for why overlap is unlikely: a full
+# local refresh measured 2026-07-25 took 16s (update) + 24s (embed, 457 chunks /
+# 81 docs) — a daily run has ~24h of headroom.
+#
+# Usage:
+#   bash scripts/luna/qmd-reindex.sh [--qmd-bin PATH] [--dry-run]
+#
+#   --qmd-bin PATH   Absolute path to the qmd executable. Default: resolved from
+#                    PATH. The cadence passes this explicitly, because schtasks
+#                    and cron fire with a MINIMAL PATH that does not carry the
+#                    bun bin dir where qmd installs.
+#   --dry-run        Print the two commands that would run, execute neither.
+#
+# Exit codes:
+#   0  index refreshed and verified complete
+#   1  usage / input error
+#   2  qmd executable not found or not usable
+#   3  `qmd update` failed
+#   4  `qmd embed` failed
+#   5  embed INCOMPLETE — vectors still pending after the embed pass
+set -euo pipefail
+
+QMD_BIN=""
+DRY_RUN=0
+
+usage() {
+    cat <<'EOF'
+Usage: qmd-reindex.sh [--qmd-bin PATH] [--dry-run]
+
+Refresh the qmd index across ALL configured collections: `qmd update`
+(re-index changed files) then `qmd embed` (generate missing vectors),
+then assert the embed actually finished.
+
+Flags:
+  --qmd-bin <PATH>  Absolute path to the qmd executable (default: from PATH).
+                    Schedulers fire with a minimal PATH that lacks qmd's bin
+                    dir, so the cadence always passes this explicitly.
+  --dry-run         Print what would run; execute nothing.
+
+Exit: 0 ok | 1 usage | 2 qmd unusable | 3 update failed | 4 embed failed
+      5 embed incomplete (vectors still pending)
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --qmd-bin)
+            # Demand a real operand. Without this, a trailing `--qmd-bin` makes
+            # `shift 2` fail under set -e and the script dies with no message,
+            # and `--qmd-bin --dry-run` silently swallows the next FLAG as the
+            # path (surfacing later as a confusing "not an executable file").
+            # An EXPLICITLY EMPTY operand is rejected too: `--qmd-bin ""` would
+            # otherwise leave QMD_BIN empty and fall through to PATH resolution,
+            # silently ignoring the flag the caller deliberately passed.
+            if [ $# -lt 2 ] || [ -z "$2" ] || [ "${2#-}" != "$2" ]; then
+                echo "ERR qmd-reindex: --qmd-bin requires an absolute path operand" >&2
+                usage >&2
+                exit 1
+            fi
+            QMD_BIN="$2"; shift 2 ;;
+        --qmd-bin=*)
+            QMD_BIN="${1#--qmd-bin=}"
+            if [ -z "$QMD_BIN" ]; then
+                echo "ERR qmd-reindex: --qmd-bin requires an absolute path operand" >&2
+                usage >&2
+                exit 1
+            fi
+            shift ;;
+        --dry-run)   DRY_RUN=1; shift ;;
+        -h|--help)   usage; exit 0 ;;
+        *)
+            echo "ERR qmd-reindex: unknown arg: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Resolve qmd. An explicit --qmd-bin wins; otherwise fall back to PATH so an
+# operator running this by hand needs no flag.
+if [ -z "$QMD_BIN" ]; then
+    if ! QMD_BIN=$(command -v qmd 2>/dev/null); then
+        {
+            echo "ERR qmd-reindex: 'qmd' not found on PATH and --qmd-bin was not given."
+            echo "    Install qmd, or pass the absolute path: --qmd-bin /path/to/qmd"
+        } >&2
+        exit 2
+    fi
+fi
+
+# Demand a real, absolute, executable file — the same discipline graphmap-cadence
+# applies to the `claude` it pins. `command -v` also resolves shell FUNCTIONS and
+# ALIASES (to their own name) and relative PATH entries (to a relative path);
+# either would be meaningless once a scheduled runner has cd'd elsewhere under a
+# different PATH. Windows note: `command -v qmd` yields an extensionless path
+# that MSYS resolves to qmd.exe, and -f/-x accept it.
+case "$QMD_BIN" in
+    /*|[A-Za-z]:[/\\]*) : ;;
+    *)
+        echo "ERR qmd-reindex: qmd resolved to a non-absolute path ('$QMD_BIN') — a shell function/alias or relative PATH entry cannot be used from a scheduled runner." >&2
+        exit 2
+        ;;
+esac
+if [ ! -f "$QMD_BIN" ] || [ ! -x "$QMD_BIN" ]; then
+    echo "ERR qmd-reindex: qmd path '$QMD_BIN' is not an executable file." >&2
+    exit 2
+fi
+
+stamp() { date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo '?'; }
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo "DRY qmd-reindex: would run: $QMD_BIN update"
+    echo "DRY qmd-reindex: would run: $QMD_BIN embed"
+    echo "DRY qmd-reindex: would re-run: $QMD_BIN embed   (completeness assert)"
+    echo "qmd-reindex: dry-run complete (no changes made)"
+    exit 0
+fi
+
+echo "qmd-reindex: start $(stamp) (qmd: $QMD_BIN)"
+
+# --- 1. re-index changed files across every configured collection -----------
+echo "qmd-reindex: [1/3] qmd update"
+if ! "$QMD_BIN" update; then
+    echo "ERR qmd-reindex: 'qmd update' failed — index NOT refreshed." >&2
+    exit 3
+fi
+
+# --- 2. embed whatever the update left without vectors ----------------------
+echo "qmd-reindex: [2/3] qmd embed"
+if ! "$QMD_BIN" embed; then
+    echo "ERR qmd-reindex: 'qmd embed' failed — lex index is fresh but vectors are NOT." >&2
+    exit 4
+fi
+
+# --- 3. completeness assert (see the header for why this is not optional) ---
+# A no-op embed prints "All content hashes already have embeddings". Match the
+# ASCII substring only: the real line is prefixed with a UTF-8 check mark, and
+# this output is read under the OEM codepage when the cadence fires from cmd.exe.
+echo "qmd-reindex: [3/3] verifying embed completeness"
+VERIFY_OUT=""
+VERIFY_RC=0
+VERIFY_OUT=$("$QMD_BIN" embed 2>&1) || VERIFY_RC=$?
+if [ "$VERIFY_RC" -ne 0 ]; then
+    echo "ERR qmd-reindex: completeness re-check ('qmd embed') failed (rc=$VERIFY_RC):" >&2
+    printf '%s\n' "$VERIFY_OUT" >&2
+    exit 4
+fi
+# Match with a HERE-STRING, not `printf … | grep -q` (HIMMEL-1115, same class
+# already fixed in check-security-reviewed.sh). Under `set -o pipefail`, grep -q
+# exits early on a match, printf takes SIGPIPE (141), and pipefail surfaces 141
+# as the pipeline status — so a SUCCESSFUL match reads as a failure once the
+# output is large enough to not fit the pipe buffer. Here that inversion would
+# report "embed INCOMPLETE" (rc=5) on a fully COMPLETE embed: a loud false alarm
+# in the exact check that exists to prevent silent wrongness.
+if ! grep -qF -- 'All content hashes already have embeddings' <<<"$VERIFY_OUT"; then
+    {
+        echo "ERR qmd-reindex: embed INCOMPLETE — content hashes still need vectors after the embed pass."
+        echo "    Vectors are lagging the lex index, which is the silently-stale state this"
+        echo "    runner exists to prevent. Most likely cause: 'qmd embed' hit its session"
+        echo "    cap (--timeout, default 30 min). Re-run this script, or embed by hand:"
+        echo "        $QMD_BIN embed --timeout 0"
+        echo "    Verifier output was:"
+        printf '%s\n' "$VERIFY_OUT" | sed 's/^/        /'
+    } >&2
+    exit 5
+fi
+
+echo "qmd-reindex: OK $(stamp) — index refreshed, all content hashes embedded"

--- a/scripts/luna/test-qmd-cadence.sh
+++ b/scripts/luna/test-qmd-cadence.sh
@@ -1,0 +1,834 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/luna/qmd-cadence.sh (HIMMEL-568).
+#
+# ONE daily cadence task is armed: HIMMEL-Qmd-Reindex (daily 05:00 ->
+# qmd-reindex.sh --qmd-bin <qmd>). Like the graphmap sibling — and unlike
+# pipeline-cadence — the runner fires a DETERMINISTIC script, NOT a claude
+# session, so there is no --settings fragment, no NUL stdin and no auto-approve
+# hook to assert; the suite asserts their ABSENCE instead.
+#
+# Strategy (hermetic — mirrors test-graphmap-cadence.sh): replace the scheduler
+# with a fake — schtasks via the QMD_CADENCE_SCHTASKS seam (records /create XML
+# and simulates /query and /delete from a state dir), crontab via the
+# QMD_CADENCE_CRONTAB seam (a state-file crontab supporting -l and - install);
+# point QMD_CADENCE_BAT_DIR at a temp dir so the runner (.bat/.sh) is
+# inspectable; put a fake `bash` first on PATH so arm resolves the stub, never
+# the real interpreter. HOME/USERPROFILE point at the temp dir so nothing
+# touches the real user profile. The cron suite runs on EVERY platform (the
+# POSIX path is forced with an OSTYPE override); the schtasks suite stays
+# Windows-only (cmd_arm needs cygpath).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/qmd-cadence.sh"
+
+PASS=0
+FAIL=0
+TMP_ROOT=""
+
+# shellcheck disable=SC2329,SC2317
+cleanup() {
+    if [ -n "$TMP_ROOT" ] && [ -d "$TMP_ROOT" ]; then
+        rm -rf "$TMP_ROOT" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; if [ $# -ge 2 ]; then printf '    %s\n' "$2"; fi; FAIL=$((FAIL+1)); }
+# Match with a HERE-STRING, not `printf … | grep -q` (HIMMEL-1115). Under the
+# `set -o pipefail` in force here, grep -q exits early on a match, printf takes
+# SIGPIPE (141), and pipefail surfaces 141 as the pipeline status — so a
+# SUCCESSFUL match reads as a FAILURE as soon as the haystack outgrows the pipe
+# buffer. This suite asserts against whole runner-file bodies, so it is the one
+# most likely to grow into that trap.
+assert_contains() {
+    local name="$1" needle="$2" haystack="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then pass "$name"; else fail "$name" "missing: $needle"; fi
+}
+assert_not_contains() {
+    local name="$1" needle="$2" haystack="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then fail "$name" "unexpected: $needle"; else pass "$name"; fi
+}
+assert_rc() {
+    local name="$1" want="$2" got="$3"
+    if [ "$got" = "$want" ]; then pass "$name"; else fail "$name" "expected rc=$want, got rc=$got"; fi
+}
+summary() {
+    echo
+    echo "===================================="
+    echo "test summary: $PASS passed, $FAIL failed"
+    echo "===================================="
+    [ "$FAIL" -gt 0 ] && exit 1 || exit 0
+}
+
+TMP_ROOT=$(mktemp -d)
+if command -v cygpath >/dev/null 2>&1; then TMP_ROOT=$(cygpath -m "$TMP_ROOT"); fi
+
+# Shared fixtures ------------------------------------------------------------
+
+# The interpreter that runs the script under test. Resolved BEFORE the fake bash
+# below shadows PATH: `env PATH=... bash` would exec the FAKE via the NEW PATH,
+# and on Linux the fake's own `#!/usr/bin/env bash` shebang re-resolves to itself
+# -> infinite exec loop -> the suite hangs to the CI timeout.
+REAL_BASH="$(command -v bash)"
+
+# Fake bash on PATH (arm resolves it via `command -v bash`). A no-op stub is
+# enough — the tests assert runner TEXT, they never fire the runner. Shebang is
+# /bin/sh (absolute) so the stub can never shebang-recurse into itself.
+mkdir -p "$TMP_ROOT/bin"
+printf '#!/bin/sh\nexit 0\n' > "$TMP_ROOT/bin/bash"
+chmod +x "$TMP_ROOT/bin/bash"
+
+# Fake `qmd` on PATH: arm resolves it via `command -v qmd` and FAILS FAST when
+# absent, because the scheduler fires with a minimal PATH that does not carry
+# qmd's bin dir (bun installs to ~/.bun/bin). A stub keeps the suite
+# deterministic on machines with and without a real qmd installed; like the bash
+# stub it is never fired, only resolved.
+#
+# It lives in its OWN dir, entered on PATH in POSIX form, for the same two
+# reasons the graphmap sibling's claude stub does: (1) TMP_ROOT is cygpath -m'd
+# (C:/... mixed form) and Git-Bash cannot resolve a PATH entry in that form — a
+# stub in `bin` is INVISIBLE on Windows, so the arm would silently resolve the
+# operator's REAL installed qmd and the runner assertions below would pin a
+# machine-specific path; (2) adding a POSIX entry for `bin` itself would newly
+# expose the fake `bash` on Windows, changing what the suite bakes into its
+# runners.
+QMD_BIN_DIR="$TMP_ROOT/qmd-bin"
+mkdir -p "$QMD_BIN_DIR"
+printf '#!/bin/sh\nexit 0\n' > "$QMD_BIN_DIR/qmd"
+chmod +x "$QMD_BIN_DIR/qmd"
+QMD_BIN_DIR_PATH="$QMD_BIN_DIR"
+if command -v cygpath >/dev/null 2>&1; then
+    QMD_BIN_DIR_PATH=$(cygpath -u "$QMD_BIN_DIR")
+fi
+# EVERY invocation that reaches `arm` must carry $QMD_BIN_DIR_PATH on PATH — arm
+# fail-fasts when `qmd` is absent. Omitting it would NOT fail on a dev box that
+# happens to have qmd installed: the inherited $PATH tail satisfies the probe by
+# ACCIDENT, so the suite goes green locally and dies on a clean CI runner with
+# rc=2. The stub keeps the suite hermetic — a test's result must never depend on
+# what the operator has installed.
+
+# A PATH with the real system dirs (arm needs dirname/sed/mktemp) but with EVERY
+# dir carrying a real `qmd` filtered out — the fail-fast probe below must not be
+# satisfied by an installed qmd. Filtering the real PATH beats replacing it: a
+# bare stub dir strips coreutils and the script dies rc=127 on `dirname` before
+# it ever reaches the check under test.
+PATH_NOQMD=""
+_oldifs=$IFS; IFS=:
+for _d in $PATH; do
+    [ -n "$_d" ] || continue
+    if [ -x "$_d/qmd" ] || [ -x "$_d/qmd.exe" ] || [ -x "$_d/qmd.cmd" ]; then continue; fi
+    PATH_NOQMD="${PATH_NOQMD:+$PATH_NOQMD:}$_d"
+done
+IFS=$_oldifs
+
+# Hermeticity: point HOME **and USERPROFILE** at the temp dir so a stray BAT_DIR
+# default (should the seam ever be dropped) can't land under the real user
+# profile. USERPROFILE is the load-bearing one on Windows: resolve_user_home
+# prefers it (via cygpath) BEFORE $HOME, so redirecting HOME alone would leave
+# the probe pointing at the operator's actual profile on exactly the platform
+# this cadence primarily runs on.
+export HOME="$TMP_ROOT/home"
+mkdir -p "$HOME"
+export USERPROFILE="$HOME"
+
+# The himmel root the runner cds into is this script's ../.. (same resolution
+# qmd-cadence.sh uses for HIMMEL_ROOT).
+HIMMEL_ROOT_EXP="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ============================================================================
+# xml_escape unit — the one non-trivial string transform. Pure + platform-
+# agnostic, so it runs on EVERY platform: extract the function and call it.
+# ============================================================================
+echo "TEST: xml_escape escapes & < > with & ordered first"
+xesc=$( { sed -n '/^xml_escape()/,/^}/p' "$SCRIPT"; echo "xml_escape 'a & b < c > d'"; } | bash )
+assert_contains "xml_escape produces well-formed entities (& first)" "a &amp; b &lt; c &gt; d" "$xesc"
+assert_not_contains "xml_escape leaves no bare ampersand" "a & b" "$xesc"
+
+# ============================================================================
+# POSIX (cron) suite. Runs on EVERY platform: the cron code path is forced via
+# an OSTYPE override + the QMD_CADENCE_CRONTAB seam.
+# ============================================================================
+
+CSTATE="$TMP_ROOT/cron-state"
+mkdir -p "$CSTATE"
+
+# Fake crontab: persists the installed tab at $CSTATE/crontab. Mimics real
+# crontab signatures: -l with no tab prints "no crontab for <user>" + rc=1;
+# `crontab -` installs from stdin. Failure seams: $CSTATE/fail-list,
+# $CSTATE/fail-write. Shebang MUST be /bin/sh (absolute, POSIX body):
+# `#!/usr/bin/env bash` would resolve the no-op fake `bash` stub via the
+# prepended PATH on Linux, turning every crontab call into a silent no-op.
+FAKE_CRONTAB="$TMP_ROOT/crontab-fake.sh"
+cat >"$FAKE_CRONTAB" <<FAKE
+#!/bin/sh
+CSTATE="$CSTATE"
+FAKE
+cat >>"$FAKE_CRONTAB" <<'FAKE'
+case "${1:-}" in
+    -l)
+        if [ -e "$CSTATE/fail-list" ]; then
+            echo "crontab: must be privileged to use -l" >&2
+            exit 1
+        fi
+        if [ -f "$CSTATE/crontab" ]; then
+            cat "$CSTATE/crontab"
+        else
+            echo "no crontab for fakeuser" >&2
+            exit 1
+        fi
+        ;;
+    -)
+        if [ -e "$CSTATE/fail-write" ]; then
+            echo "crontab: error writing new crontab" >&2
+            exit 1
+        fi
+        cat > "$CSTATE/crontab"
+        ;;
+    *)
+        echo "crontab-fake: unsupported argv: $*" >&2
+        exit 64
+        ;;
+esac
+FAKE
+chmod +x "$FAKE_CRONTAB"
+
+CRON_DIR="$TMP_ROOT/cron-runners"
+
+run_cron() {
+    env OSTYPE=linux-gnu QMD_CADENCE_CRONTAB="$FAKE_CRONTAB" \
+        QMD_CADENCE_BAT_DIR="$CRON_DIR" PATH="$TMP_ROOT/bin:$QMD_BIN_DIR_PATH:$PATH" \
+        "$REAL_BASH" "$SCRIPT" "$@"
+}
+
+# Test C0: usage errors -------------------------------------------------------
+
+echo "TEST: missing / unknown subcommand rejected"
+rc=0; out=$(run_cron 2>&1) || rc=$?
+assert_rc "no subcommand -> rc 1" 1 "$rc"
+rc=0; out=$(run_cron frobnicate 2>&1) || rc=$?
+assert_rc "unknown subcommand -> rc 1" 1 "$rc"
+rc=0; out=$(run_cron arm --nope 2>&1) || rc=$?
+assert_rc "unknown flag -> rc 1" 1 "$rc"
+
+# Test C1: status with no crontab installed ----------------------------------
+
+echo "TEST: cron status with no crontab installed"
+out=$(run_cron status)
+assert_contains "cron reindex not armed" "not armed  HIMMEL-Qmd-Reindex" "$out"
+assert_contains "status names the scope" "all collections" "$out"
+
+# Test C2: shared validation wired into the cron path ------------------------
+
+echo "TEST: cron arm rejects invalid --time (shared validation)"
+rc=0; out=$(run_cron arm --time 24:61 2>&1) || rc=$?
+assert_rc "cron bad --time -> rc 1" 1 "$rc"
+rc=0; out=$(run_cron arm --time 5:00 2>&1) || rc=$?
+assert_rc "cron --time without leading zero -> rc 1" 1 "$rc"
+rc=0; out=$(run_cron arm --time 25:00 2>&1) || rc=$?
+assert_rc "cron out-of-range --time -> rc 1" 1 "$rc"
+# A trailing `--time` must produce a MESSAGE + rc 1, not a silent set -e death
+# on the failing `shift 2`.
+rc=0; out=$(run_cron arm --time 2>&1) || rc=$?
+assert_rc "cron trailing --time -> rc 1" 1 "$rc"
+assert_contains "trailing --time explains itself" "--time requires a value" "$out"
+
+# Test C3: arm fails fast when `qmd` is absent -------------------------------
+#
+# The cadence runs qmd at fire time under the scheduler's minimal PATH. Arming
+# on a machine without it would "succeed" and then die on every unattended fire,
+# in a log nobody reads. PATH is REPLACED (not prepended) so a really-installed
+# qmd cannot satisfy the probe here.
+
+echo "TEST: cron arm fails fast when qmd is not on PATH"
+rc=0; out=$(env OSTYPE=linux-gnu QMD_CADENCE_CRONTAB="$FAKE_CRONTAB" \
+    QMD_CADENCE_BAT_DIR="$CRON_DIR" PATH="$PATH_NOQMD" \
+    "$REAL_BASH" "$SCRIPT" arm 2>&1) || rc=$?
+assert_rc "cron arm without qmd -> rc 2" 2 "$rc"
+assert_contains "missing-qmd error names the CLI" "'qmd' not on PATH at arm time" "$out"
+if [ ! -f "$CSTATE/crontab" ] && [ ! -d "$CRON_DIR" ]; then
+    pass "failed arm installed nothing"
+else
+    fail "failed arm left state behind" "$(ls -a "$CRON_DIR" 2>/dev/null; cat "$CSTATE/crontab" 2>/dev/null)"
+fi
+
+# Test C4: arm --dry-run touches nothing --------------------------------------
+
+echo "TEST: cron arm --dry-run prints plan, installs nothing"
+out=$(run_cron arm --dry-run)
+assert_contains "dry-run daily entry at 05:00" "00 05 * * *" "$out"
+assert_contains "dry-run marker" "# HIMMEL-Qmd-Reindex" "$out"
+assert_contains "dry-run fires qmd-reindex.sh" "qmd-reindex.sh" "$out"
+assert_contains "dry-run pins the qmd binary" "--qmd-bin" "$out"
+if [ ! -f "$CSTATE/crontab" ]; then
+    pass "dry-run installed no crontab"
+else
+    fail "dry-run installed a crontab" "$(cat "$CSTATE/crontab")"
+fi
+if [ ! -d "$CRON_DIR" ]; then
+    pass "dry-run wrote no runner .sh"
+else
+    fail "dry-run wrote runners" "$(ls "$CRON_DIR")"
+fi
+
+# Test C5: arm installs a marker-tagged entry, preserves unrelated lines ------
+
+echo "TEST: cron arm installs the entry with defaults, preserves unrelated lines"
+printf '5 5 * * * /usr/bin/true # keep-me\n' > "$CSTATE/crontab"
+out=$(run_cron arm)
+assert_contains "cron arm banner" "QMD REINDEX CADENCE ARMED" "$out"
+tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
+assert_contains "daily entry 05:00" "00 05 * * *" "$tab"
+assert_contains "entry marker-tagged" "# HIMMEL-Qmd-Reindex" "$tab"
+assert_contains "entry fires the runner" "qmd-reindex.sh" "$tab"
+assert_contains "unrelated entry preserved" "keep-me" "$tab"
+if [ -x "$CRON_DIR/qmd-reindex.sh" ]; then
+    pass "runner .sh written + executable"
+else
+    fail "runner .sh missing or not executable" "$(ls -l "$CRON_DIR" 2>/dev/null || true)"
+fi
+
+# Test C6: the runner .sh fires qmd-reindex.sh with the right arguments -------
+
+echo "TEST: runner .sh fires bash qmd-reindex.sh (deterministic, no claude)"
+runner=$(cat "$CRON_DIR/qmd-reindex.sh" 2>/dev/null || echo MISSING)
+# The sh runner embeds paths via printf %q (backslash-escapes); strip the
+# escapes before multi-word / path asserts.
+runner_plain=${runner//\\/}
+assert_contains "runner stamps the format version (HIMMEL-588)" "# himmel-cadence-runner-format: 4" "$runner"
+assert_contains "runner fires qmd-reindex.sh" "qmd-reindex.sh" "$runner_plain"
+assert_contains "runner points at the SHIPPED reindex script" \
+    "$HIMMEL_ROOT_EXP/scripts/luna/qmd-reindex.sh" "$runner_plain"
+# The qmd path must be PINNED into the runner: cron fires with a minimal PATH
+# that lacks qmd's bin dir, so a runner relying on PATH lookup dies on every
+# fire. Assert the stub's absolute path specifically — not just the flag — so a
+# regression to bare `qmd` fails here.
+# Assert the POSIX-form path: `command -v qmd` resolves through the POSIX PATH
+# entry, so on Windows the runner carries /c/... not the mixed C:/... form.
+assert_contains "runner pins the resolved qmd absolute path" \
+    "--qmd-bin $QMD_BIN_DIR_PATH/qmd" "$runner_plain"
+assert_contains "runner cds into himmel root" "cd $HIMMEL_ROOT_EXP" "$runner_plain"
+# shellcheck disable=SC2016  # literal $log needles — the runner expands them at fire time
+assert_contains "runner rotates the log" 'mv -f "$log" "$log.prev"' "$runner"
+assert_contains "runner stamps every fire" '[fired' "$runner"
+# shellcheck disable=SC2016
+assert_contains "runner captures output to log" '>> "$log" 2>&1' "$runner"
+# shellcheck disable=SC2016
+assert_contains "runner records the exit rc" 'echo "[exit rc=$_rc]"' "$runner"
+# Deterministic-script shape: NONE of the bounded-claude-session markers.
+assert_not_contains "runner has no --settings (not a claude session)" "--settings" "$runner"
+assert_not_contains "runner has no bounded-claude stdin marker" "< /dev/null" "$runner"
+assert_not_contains "runner never narrows collections with -c" "-c " "$runner"
+
+# Test C6b: the runner PROPAGATES the payload's exit code ------------------------
+#
+# Behavioural, not textual: rewrite the generated runner's payload to a known
+# failing/succeeding command and FIRE it, asserting the script's own exit status.
+# Without the trailing `exit "$_rc"` the runner's status is that of the final
+# `echo` inside the redirect block — always 0 — so cron reports success after a
+# failed reindex, which is the silent-failure shape this whole ticket is about.
+
+echo "TEST: generated cron runner propagates the payload exit code"
+runner_src=$(cat "$CRON_DIR/qmd-reindex.sh")
+probe_dir="$TMP_ROOT/rc-probe"
+mkdir -p "$probe_dir"
+# Swap the payload line for a parameterised exit, keeping every other line
+# (log rotation, fire stamp, cd, the exit propagation) byte-identical.
+for want_rc in 0 5; do
+    # `@` delimiter, NOT `|`: the replacements contain `||`, which sed would
+    # read as the closing delimiter followed by garbage.
+    printf '%s\n' "$runner_src" \
+        | sed "s@^    _rc=0; .*@    _rc=0; (exit $want_rc) || _rc=\$?@" \
+        | sed "s@^    cd .*@    cd . || exit 1@" \
+        > "$probe_dir/runner-$want_rc.sh"
+    chmod +x "$probe_dir/runner-$want_rc.sh"
+    # If the runner's payload line ever changes shape, the sed matches NOTHING
+    # and the probe silently fires the REAL reindex payload instead — which
+    # would quietly pass the rc=0 case and make this test meaningless. Assert
+    # the substitution actually landed rather than trusting it.
+    if ! grep -qF "(exit $want_rc) ||" "$probe_dir/runner-$want_rc.sh"; then
+        fail "rc-probe payload substitution matched nothing" \
+            "runner payload line shape changed; update the sed expression"
+        continue
+    fi
+    got_rc=0
+    "$REAL_BASH" "$probe_dir/runner-$want_rc.sh" >/dev/null 2>&1 || got_rc=$?
+    assert_rc "runner exits $want_rc when the payload exits $want_rc" "$want_rc" "$got_rc"
+done
+
+# Test C7: status after arm ----------------------------------------------------
+
+echo "TEST: cron status reflects the armed entry"
+out=$(run_cron status)
+assert_contains "cron reindex armed" "ARMED      HIMMEL-Qmd-Reindex" "$out"
+assert_contains "cron status surfaces run log state" "run log" "$out"
+
+# Test C8: re-arm without --force -> dedup block -------------------------------
+
+echo "TEST: cron re-arm without --force blocked (rc 3)"
+rc=0; out=$(run_cron arm 2>&1) || rc=$?
+assert_rc "cron dedup block rc 3" 3 "$rc"
+assert_contains "cron dedup message names the existing entry" "HIMMEL-Qmd-Reindex" "$out"
+if [ "$(grep -c 'HIMMEL-Qmd-' "$CSTATE/crontab")" -eq 1 ]; then
+    pass "no duplicate entry after blocked re-arm (idempotent)"
+else
+    fail "entry count changed on blocked re-arm" "$(cat "$CSTATE/crontab")"
+fi
+
+# Test C9: re-arm --force with an override --------------------------------------
+
+echo "TEST: cron re-arm --force applies the --time override"
+out=$(run_cron arm --force --time 01:15 2>&1)
+tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
+assert_contains "cron daily override" "15 01 * * *" "$tab"
+assert_not_contains "old 05:00 entry replaced" "00 05 * * *" "$tab"
+assert_contains "unrelated entry survives --force re-arm" "keep-me" "$tab"
+if [ "$(grep -c 'HIMMEL-Qmd-' "$CSTATE/crontab")" -eq 1 ]; then
+    pass "still exactly one entry after --force re-arm"
+else
+    fail "duplicate entries after --force re-arm" "$(cat "$CSTATE/crontab")"
+fi
+
+# Test C10: dry-run disarm prints the DRY tail, touches nothing -----------------
+
+echo "TEST: cron dry-run disarm prints DRY tail, touches nothing"
+out=$(run_cron disarm --dry-run)
+assert_contains "cron dry disarm lists removals" "would remove crontab entry" "$out"
+assert_contains "cron dry disarm closing summary" "no changes made" "$out"
+if [ "$(grep -c 'HIMMEL-Qmd-' "$CSTATE/crontab")" -eq 1 ]; then
+    pass "dry-run disarm removed no entries"
+else
+    fail "dry-run disarm changed crontab state" "$(cat "$CSTATE/crontab")"
+fi
+if [ -f "$CRON_DIR/qmd-reindex.sh" ]; then
+    pass "dry-run disarm kept the runner .sh"
+else
+    fail "dry-run disarm deleted the runner .sh"
+fi
+
+# Test C11: disarm + idempotent second disarm ------------------------------------
+
+echo "TEST: cron disarm removes the entry + runner, keeps unrelated lines"
+out=$(run_cron disarm)
+assert_contains "cron disarm reports" "cadence disarmed" "$out"
+tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
+assert_not_contains "cadence entry removed" "HIMMEL-Qmd-" "$tab"
+assert_contains "unrelated entry survives disarm" "keep-me" "$tab"
+if [ ! -f "$CRON_DIR/qmd-reindex.sh" ]; then
+    pass "runner .sh removed"
+else
+    fail "runner .sh left after disarm"
+fi
+rc=0; out=$(run_cron disarm) || rc=$?
+assert_rc "cron second disarm rc 0" 0 "$rc"
+assert_contains "cron second disarm is a no-op" "no-op" "$out"
+
+# Test C12: failing crontab -l is fail-CLOSED -------------------------------------
+
+echo "TEST: cron arm/status/disarm with failing crontab -l exit 2"
+touch "$CSTATE/fail-list"
+rc=0; out=$(run_cron arm 2>&1) || rc=$?
+assert_rc "cron fail-closed arm rc 2" 2 "$rc"
+assert_contains "cron arm failure surfaces stderr" "must be privileged" "$out"
+rc=0; out=$(run_cron status 2>&1) || rc=$?
+assert_rc "cron fail-closed status rc 2" 2 "$rc"
+rm -f "$CSTATE/fail-list"
+out=$(run_cron arm)
+touch "$CSTATE/fail-list"
+rc=0; out=$(run_cron disarm 2>&1) || rc=$?
+assert_rc "cron fail-closed disarm rc 2" 2 "$rc"
+assert_not_contains "no false no-op on failing crontab -l" "no-op" "$out"
+if [ -f "$CRON_DIR/qmd-reindex.sh" ]; then
+    pass "runner .sh NOT deleted on crontab -l failure"
+else
+    fail "runner .sh deleted despite crontab -l failure"
+fi
+rm -f "$CSTATE/fail-list"
+run_cron disarm >/dev/null
+
+# Test C13: crontab install failure -> rc 4 ---------------------------------------
+
+echo "TEST: cron arm with failing crontab install exits 4"
+touch "$CSTATE/fail-write"
+rc=0; out=$(run_cron arm 2>&1) || rc=$?
+assert_rc "cron install failure rc 4" 4 "$rc"
+assert_contains "cron install failure surfaces stderr" "error writing new crontab" "$out"
+if ! grep -q 'HIMMEL-Qmd-' "$CSTATE/crontab" 2>/dev/null; then
+    pass "no cadence entry installed on write failure"
+else
+    fail "cadence entry installed despite write failure" "$(cat "$CSTATE/crontab")"
+fi
+if [ ! -f "$CRON_DIR/qmd-reindex.sh" ]; then
+    pass "no runner promoted to its final path on write failure"
+else
+    fail "runner left despite write failure" "$(ls "$CRON_DIR" 2>/dev/null || true)"
+fi
+if ! compgen -G "$CRON_DIR/*.tmp.*" >/dev/null; then
+    pass "no staged .tmp runner litter on write failure"
+else
+    fail "staged .tmp runner litter left" "$(ls "$CRON_DIR")"
+fi
+rm -f "$CSTATE/fail-write"
+run_cron disarm >/dev/null
+
+# Test C14: --force re-arm with failing install leaves NO half-state --------------
+
+echo "TEST: cron --force re-arm with failing install keeps the old runner + entry"
+out=$(run_cron arm --time 05:00)
+touch "$CSTATE/fail-write"
+rc=0; out=$(run_cron arm --force --time 06:30 2>&1) || rc=$?
+assert_rc "cron force re-arm install failure rc 4" 4 "$rc"
+if ! compgen -G "$CRON_DIR/*.tmp.*" >/dev/null; then
+    pass "no staged .tmp runner litter after failed --force re-arm"
+else
+    fail "staged .tmp runner litter left" "$(ls "$CRON_DIR")"
+fi
+tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
+assert_contains "old 05:00 entry still armed after failed --force re-arm" "00 05 * * *" "$tab"
+assert_not_contains "new 06:30 entry NOT installed" "30 06 * * *" "$tab"
+rm -f "$CSTATE/fail-write"
+run_cron disarm >/dev/null
+
+# Test C15: disarm with failing install keeps entry + runner ----------------------
+
+echo "TEST: cron disarm with failing crontab install exits 4, keeps entry + runner"
+out=$(run_cron arm)
+touch "$CSTATE/fail-write"
+rc=0; out=$(run_cron disarm 2>&1) || rc=$?
+assert_rc "cron disarm install failure rc 4" 4 "$rc"
+assert_contains "disarm install failure surfaces stderr" "error writing new crontab" "$out"
+if [ "$(grep -c 'HIMMEL-Qmd-' "$CSTATE/crontab")" -eq 1 ]; then
+    pass "entry still in crontab after failed disarm install"
+else
+    fail "entry lost despite failed disarm install" "$(cat "$CSTATE/crontab")"
+fi
+if [ -f "$CRON_DIR/qmd-reindex.sh" ]; then
+    pass "runner .sh NOT deleted on failed disarm install"
+else
+    fail "runner .sh deleted despite failed disarm install"
+fi
+rm -f "$CSTATE/fail-write"
+run_cron disarm >/dev/null
+
+# Test C16: hostile-but-legal runner dir can't inject -----------------------------
+
+echo "TEST: cron entry + runner escape a hostile runner dir"
+EVIL_DIR="$TMP_ROOT/cr%on rnr"
+out=$(env OSTYPE=linux-gnu QMD_CADENCE_CRONTAB="$FAKE_CRONTAB" \
+    QMD_CADENCE_BAT_DIR="$EVIL_DIR" PATH="$TMP_ROOT/bin:$QMD_BIN_DIR_PATH:$PATH" \
+    "$REAL_BASH" "$SCRIPT" arm)
+tab=$(cat "$CSTATE/crontab" 2>/dev/null || echo MISSING)
+assert_contains "percent cron-escaped in entry (\\%)" 'cr\%on' "$tab"
+assert_contains "space %q-escaped in entry" 'cr\%on\ rnr' "$tab"
+env OSTYPE=linux-gnu QMD_CADENCE_CRONTAB="$FAKE_CRONTAB" \
+    QMD_CADENCE_BAT_DIR="$EVIL_DIR" PATH="$TMP_ROOT/bin:$QMD_BIN_DIR_PATH:$PATH" \
+    "$REAL_BASH" "$SCRIPT" disarm >/dev/null
+
+# Test C17: unknown platform exits 2 ----------------------------------------------
+
+echo "TEST: unknown platform (OSTYPE=beos) exits 2"
+rc=0; out=$(env OSTYPE=beos bash "$SCRIPT" status 2>&1) || rc=$?
+assert_rc "unknown platform rc 2" 2 "$rc"
+assert_contains "unknown platform message" "unsupported platform" "$out"
+
+# ============================================================================
+# schtasks suite — Windows-only (cmd_arm needs cygpath; the cron suite above
+# already exercised the POSIX path on this platform).
+# ============================================================================
+
+case "${OSTYPE:-$(uname -s 2>/dev/null || echo unknown)}" in
+    msys*|cygwin*|win32*|MINGW*) : ;;
+    *)
+        echo "SKIP: schtasks suite (Windows-only — needs cygpath/schtasks shapes)"
+        summary
+        ;;
+esac
+
+STATE="$TMP_ROOT/state"
+mkdir -p "$STATE/tasks"
+
+# Fake schtasks: persists tasks as files under $STATE/tasks/<name> (content =
+# the created XML, for assertions). Shebang is the pre-resolved REAL bash (the
+# body needs bash arrays) — an env-bash shebang would resolve the no-op fake
+# `bash` stub via the prepended PATH.
+FAKE_SCHTASKS="$TMP_ROOT/schtasks-fake.sh"
+cat >"$FAKE_SCHTASKS" <<FAKE
+#!$REAL_BASH
+STATE="$STATE"
+FAKE
+cat >>"$FAKE_SCHTASKS" <<'FAKE'
+tn=""; mode=""; xmlpath=""
+args=("$@")
+i=0
+while [ $i -lt ${#args[@]} ]; do
+    case "${args[$i]}" in
+        /create|/delete|/query) mode="${args[$i]}" ;;
+        /tn) i=$((i+1)); tn="${args[$i]}" ;;
+        /xml) i=$((i+1)); xmlpath="${args[$i]}" ;;
+    esac
+    i=$((i+1))
+done
+case "$mode" in
+    /create)
+        if [ -e "$STATE/fail-create-$tn" ]; then
+            echo "ERROR: Access is denied." >&2
+            exit 1
+        fi
+        if [ -n "$xmlpath" ]; then
+            xml_posix=$(cygpath -u "$xmlpath" 2>/dev/null || echo "$xmlpath")
+            cat "$xml_posix" > "$STATE/tasks/$tn"
+        else
+            printf '%s\n' "$*" > "$STATE/tasks/$tn"
+        fi
+        echo "SUCCESS: The scheduled task \"$tn\" has successfully been created."
+        ;;
+    /delete)
+        if [ -f "$STATE/tasks/$tn" ]; then rm -f "$STATE/tasks/$tn"; exit 0; else exit 1; fi
+        ;;
+    /query)
+        if [ -e "$STATE/fail-query" ]; then
+            echo "ERROR: Access is denied." >&2
+            exit 1
+        fi
+        if [ -n "$tn" ]; then
+            if [ -f "$STATE/tasks/$tn" ]; then
+                printf 'TaskName:      \\%s\nNext Run Time: 7/26/2026 5:00:00 AM\n' "$tn"
+                exit 0
+            fi
+            echo "ERROR: The system cannot find the file specified." >&2
+            exit 1
+        fi
+        found=0
+        for f in "$STATE/tasks"/*; do
+            [ -e "$f" ] || continue
+            found=1
+            printf '"\\%s","7/26/2026 5:00:00 AM","Ready"\n' "$(basename "$f")"
+        done
+        [ "$found" -eq 1 ] || exit 1
+        ;;
+    *) exit 1 ;;
+esac
+FAKE
+chmod +x "$FAKE_SCHTASKS"
+
+BAT_DIR="$TMP_ROOT/bats"
+
+run_qc() {
+    QMD_CADENCE_SCHTASKS="$FAKE_SCHTASKS" QMD_CADENCE_BAT_DIR="$BAT_DIR" \
+        PATH="$TMP_ROOT/bin:$QMD_BIN_DIR_PATH:$PATH" "$REAL_BASH" "$SCRIPT" "$@"
+}
+
+# Test W1: status on an empty scheduler --------------------------------------
+
+echo "TEST: schtasks status with nothing armed"
+out=$(run_qc status)
+assert_contains "reindex not armed" "not armed  HIMMEL-Qmd-Reindex" "$out"
+
+# Test W2: arm --dry-run registers nothing -----------------------------------
+
+echo "TEST: schtasks arm --dry-run prints plan, registers nothing"
+out=$(run_qc arm --dry-run)
+assert_contains "dry-run create line" "/tn HIMMEL-Qmd-Reindex /xml" "$out"
+assert_contains "dry-run XML has StartWhenAvailable" "<StartWhenAvailable>true</StartWhenAvailable>" "$out"
+assert_contains "dry-run XML daily schedule" "<ScheduleByDay>" "$out"
+assert_contains "dry-run default time" "T05:00:00" "$out"
+assert_contains "dry-run fires qmd-reindex.sh" "qmd-reindex.sh" "$out"
+if [ -z "$(ls -A "$STATE/tasks" 2>/dev/null)" ]; then
+    pass "dry-run registered no tasks"
+else
+    fail "dry-run registered tasks" "$(ls "$STATE/tasks")"
+fi
+if [ ! -d "$BAT_DIR" ]; then
+    pass "dry-run wrote no .bat"
+else
+    fail "dry-run wrote a .bat" "$(ls "$BAT_DIR")"
+fi
+
+# Test W3: arm registers the daily task --------------------------------------
+
+echo "TEST: schtasks arm registers HIMMEL-Qmd-Reindex daily 05:00"
+out=$(run_qc arm)
+assert_contains "arm banner" "QMD REINDEX CADENCE ARMED" "$out"
+task_xml=$(cat "$STATE/tasks/HIMMEL-Qmd-Reindex" 2>/dev/null || echo MISSING)
+assert_contains "daily schedule (XML)" "<ScheduleByDay>" "$task_xml"
+assert_contains "default time (XML)" "T05:00:00" "$task_xml"
+assert_contains "XML StartWhenAvailable" "<StartWhenAvailable>true</StartWhenAvailable>" "$task_xml"
+# IgnoreNew is what keeps the cadence from overlapping itself — qmd-reindex.sh
+# deliberately takes no lock of its own, so this is the only serialization.
+assert_contains "XML IgnoreNew (no self-overlap)" "<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>" "$task_xml"
+assert_contains "XML names the ticket" "HIMMEL-568" "$task_xml"
+assert_contains "Exec points at the runner bat" "qmd-reindex.bat" "$task_xml"
+
+# Test W4: the .bat fires qmd-reindex.sh with the right arguments -------------
+
+echo "TEST: .bat runner fires bash qmd-reindex.sh (deterministic, no claude)"
+bat=$(cat "$BAT_DIR/qmd-reindex.bat" 2>/dev/null || echo MISSING)
+assert_contains "bat stamps the format version (HIMMEL-588)" "rem himmel-cadence-runner-format: 4" "$bat"
+assert_contains "bat cds into himmel root" 'cd /d "' "$bat"
+assert_contains "bat fires qmd-reindex.sh" "qmd-reindex.sh" "$bat"
+assert_contains "bat pins the resolved qmd absolute path" "--qmd-bin \"$QMD_BIN_DIR/qmd\"" "$bat"
+assert_contains "bat appends run log" 'qmd-reindex.log" 2>&1' "$bat"
+assert_contains "bat rotates the log before firing" 'move /y' "$bat"
+assert_contains "bat stamps every fire" 'echo [fired %DATE% %TIME%]' "$bat"
+assert_not_contains "bat has no --settings (not a claude session)" "--settings" "$bat"
+assert_not_contains "bat has no bounded-claude stdin marker" "< NUL" "$bat"
+assert_not_contains "bat never narrows collections with -c" " -c " "$bat"
+
+# Test W5: status after arm ---------------------------------------------------
+
+echo "TEST: schtasks status reflects the armed task"
+out=$(run_qc status)
+assert_contains "reindex armed" "ARMED      HIMMEL-Qmd-Reindex" "$out"
+assert_contains "status shows next run time" "next run:" "$out"
+assert_contains "status surfaces run log state" "run log" "$out"
+
+# Test W6: re-arm without --force -> dedup block ------------------------------
+
+echo "TEST: schtasks re-arm without --force blocked (rc 3)"
+rc=0; out=$(run_qc arm 2>&1) || rc=$?
+assert_rc "dedup block rc 3" 3 "$rc"
+assert_contains "dedup message names the existing task" "HIMMEL-Qmd-Reindex" "$out"
+if [ "$(find "$STATE/tasks" -mindepth 1 | wc -l)" -eq 1 ]; then
+    pass "no duplicate task after blocked re-arm (idempotent)"
+else
+    fail "task count changed on blocked re-arm" "$(ls "$STATE/tasks")"
+fi
+
+# Test W7: re-arm --force applies the override --------------------------------
+
+echo "TEST: schtasks re-arm --force applies the --time override"
+out=$(run_qc arm --force --time 01:15 2>&1)
+task_xml=$(cat "$STATE/tasks/HIMMEL-Qmd-Reindex" 2>/dev/null || echo MISSING)
+assert_contains "override time (XML)" "T01:15:00" "$task_xml"
+assert_not_contains "old default time replaced" "T05:00:00" "$task_xml"
+if [ "$(find "$STATE/tasks" -mindepth 1 | wc -l)" -eq 1 ]; then
+    pass "still exactly one task after --force re-arm"
+else
+    fail "duplicate tasks after --force re-arm" "$(ls "$STATE/tasks")"
+fi
+
+# Test W8: schtasks /create failure -> rc 4 -----------------------------------
+
+echo "TEST: schtasks create failure exits 4"
+run_qc disarm >/dev/null
+touch "$STATE/fail-create-HIMMEL-Qmd-Reindex"
+rc=0; out=$(run_qc arm 2>&1) || rc=$?
+assert_rc "create failure rc 4" 4 "$rc"
+assert_contains "create failure surfaces stderr" "Access is denied" "$out"
+if [ -z "$(ls -A "$STATE/tasks" 2>/dev/null)" ]; then
+    pass "no task registered on create failure"
+else
+    fail "task registered despite create failure" "$(ls "$STATE/tasks")"
+fi
+rm -f "$STATE/fail-create-HIMMEL-Qmd-Reindex"
+
+# Test W8b: failed --force re-arm leaves the OLD .bat untouched -----------------
+#
+# Mirrors the POSIX C14 case. Writing the .bat in place before schtasks /create
+# would leave the runner carrying the NEW config while the scheduler has no new
+# task — and under --force the OLD task is already gone by then.
+
+echo "TEST: schtasks --force re-arm with failing create keeps the old .bat"
+out=$(run_qc arm --time 05:00)
+old_bat=$(cat "$BAT_DIR/qmd-reindex.bat")
+touch "$STATE/fail-create-HIMMEL-Qmd-Reindex"
+rc=0; out=$(run_qc arm --force --time 06:30 2>&1) || rc=$?
+assert_rc "force re-arm create failure rc 4" 4 "$rc"
+new_bat=$(cat "$BAT_DIR/qmd-reindex.bat" 2>/dev/null || echo MISSING)
+if [ "$new_bat" = "$old_bat" ]; then
+    pass "old .bat byte-identical after failed --force re-arm"
+else
+    fail "old .bat was overwritten despite failed create"
+fi
+if ! compgen -G "$BAT_DIR/*.tmp.*" >/dev/null; then
+    pass "no staged .tmp .bat litter after failed create"
+else
+    fail "staged .tmp .bat litter left" "$(ls "$BAT_DIR")"
+fi
+# --force already deleted the old task before the create failed, so the machine
+# is now UNARMED. The message must say that outright — "runner .bat left
+# untouched" alone reads as "nothing changed", the opposite of the truth.
+assert_contains "failed --force create warns the machine is now unarmed" \
+    "NO qmd cadence is armed right now" "$out"
+if [ -z "$(ls -A "$STATE/tasks" 2>/dev/null)" ]; then
+    pass "and the scheduler really is empty (warning is accurate)"
+else
+    fail "warning claims unarmed but a task remains" "$(ls "$STATE/tasks")"
+fi
+rm -f "$STATE/fail-create-HIMMEL-Qmd-Reindex"
+run_qc disarm >/dev/null
+
+# Test W8c: disarm removes EVERY HIMMEL-Qmd-* task, not just the canonical name --
+#
+# `arm`'s dedup guard blocks on the PREFIX, so a disarm that only knew the exact
+# name would wedge the operator: arm refuses "already armed", disarm answers
+# "nothing armed". The POSIX path already disarms by prefix.
+
+echo "TEST: schtasks disarm removes every HIMMEL-Qmd-* task (prefix, not exact name)"
+out=$(run_qc arm)
+printf 'stray task\n' > "$STATE/tasks/HIMMEL-Qmd-Stray"
+rc=0; out=$(run_qc arm 2>&1) || rc=$?
+assert_rc "arm dedup-blocks on the stray prefix task" 3 "$rc"
+out=$(run_qc disarm)
+if [ ! -f "$STATE/tasks/HIMMEL-Qmd-Stray" ] && [ ! -f "$STATE/tasks/HIMMEL-Qmd-Reindex" ]; then
+    pass "disarm removed BOTH the canonical and the stray prefix task"
+else
+    fail "disarm left a prefix task behind" "$(ls "$STATE/tasks" 2>/dev/null)"
+fi
+rc=0; out=$(run_qc arm 2>&1) || rc=$?
+assert_rc "arm works again after a full disarm (no wedge)" 0 "$rc"
+run_qc disarm >/dev/null
+
+# Test W9: failing /query is fail-CLOSED --------------------------------------
+
+echo "TEST: schtasks failing /query is fail-closed (rc 2)"
+out=$(run_qc arm)
+touch "$STATE/fail-query"
+rc=0; out=$(run_qc status 2>&1) || rc=$?
+assert_rc "fail-closed status rc 2" 2 "$rc"
+# Match the STATUS LINE shape, not the bare phrase: the fail-closed error itself
+# legitimately reads "refusing to treat as 'not armed'", so a bare needle would
+# match the very message that proves the guard worked.
+assert_not_contains "no false 'not armed' status line on query failure" \
+    "not armed  HIMMEL-Qmd-Reindex" "$out"
+assert_contains "query failure is reported as such" "QUERY ERR" "$out"
+rc=0; out=$(run_qc disarm 2>&1) || rc=$?
+assert_rc "fail-closed disarm rc 2" 2 "$rc"
+assert_not_contains "no false no-op on query failure" "no-op" "$out"
+rm -f "$STATE/fail-query"
+
+# Test W10: disarm + idempotent second disarm ---------------------------------
+
+echo "TEST: schtasks disarm removes the task + .bat, second disarm is a no-op"
+out=$(run_qc disarm)
+assert_contains "disarm reports" "cadence disarmed" "$out"
+if [ -z "$(ls -A "$STATE/tasks" 2>/dev/null)" ]; then
+    pass "task removed"
+else
+    fail "task left after disarm" "$(ls "$STATE/tasks")"
+fi
+if [ ! -f "$BAT_DIR/qmd-reindex.bat" ]; then
+    pass ".bat runner removed"
+else
+    fail ".bat runner left after disarm"
+fi
+rc=0; out=$(run_qc disarm) || rc=$?
+assert_rc "second disarm rc 0" 0 "$rc"
+assert_contains "second disarm is a no-op" "no-op" "$out"
+
+# Test W11: dry-run disarm touches nothing ------------------------------------
+
+echo "TEST: schtasks dry-run disarm prints DRY tail, touches nothing"
+out=$(run_qc arm)
+out=$(run_qc disarm --dry-run)
+assert_contains "dry disarm lists the deletion" "would delete HIMMEL-Qmd-Reindex" "$out"
+assert_contains "dry disarm closing summary" "no changes made" "$out"
+if [ -f "$STATE/tasks/HIMMEL-Qmd-Reindex" ] && [ -f "$BAT_DIR/qmd-reindex.bat" ]; then
+    pass "dry-run disarm left task + .bat in place"
+else
+    fail "dry-run disarm mutated state"
+fi
+run_qc disarm >/dev/null
+
+summary

--- a/scripts/luna/test-qmd-reindex.sh
+++ b/scripts/luna/test-qmd-reindex.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/luna/qmd-reindex.sh (HIMMEL-568).
+#
+# The runner is a deterministic two-step (`qmd update` then `qmd embed`) plus a
+# completeness assert (a second `qmd embed` that must report the all-clear).
+# Everything here is exercised against a FAKE qmd, so the suite is hermetic:
+# it needs no real qmd, no index, no network, and runs identically on CI's bare
+# Linux runner and on the Windows box (mirrors the fixture discipline in
+# test-graphmap-cadence.sh).
+#
+# The fake records every invocation to a call log, which is what lets us assert
+# ORDER (update before embed) and COUNT (dry-run invokes nothing; the happy path
+# embeds twice — once for real, once to verify).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/qmd-reindex.sh"
+
+PASS=0
+FAIL=0
+TMP_ROOT=""
+
+# shellcheck disable=SC2329,SC2317
+cleanup() {
+    if [ -n "$TMP_ROOT" ] && [ -d "$TMP_ROOT" ]; then
+        rm -rf "$TMP_ROOT" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; if [ $# -ge 2 ]; then printf '    %s\n' "$2"; fi; FAIL=$((FAIL+1)); }
+# Match with a HERE-STRING, not `printf … | grep -q` (HIMMEL-1115). Under the
+# `set -o pipefail` in force here, grep -q exits early on a match, printf takes
+# SIGPIPE (141), and pipefail surfaces 141 as the pipeline status — so a
+# SUCCESSFUL match reads as a FAILURE as soon as the haystack outgrows the pipe
+# buffer. Today's haystacks are small enough to fit, which is exactly what makes
+# it a latent trap: the suite would start failing on genuine matches only once a
+# runner/output grew, and the failure would look like a real regression.
+assert_contains() {
+    local name="$1" needle="$2" haystack="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then pass "$name"; else fail "$name" "missing: $needle"; fi
+}
+assert_not_contains() {
+    local name="$1" needle="$2" haystack="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then fail "$name" "unexpected: $needle"; else pass "$name"; fi
+}
+assert_rc() {
+    local name="$1" want="$2" got="$3"
+    if [ "$got" = "$want" ]; then pass "$name"; else fail "$name" "expected rc=$want, got rc=$got"; fi
+}
+summary() {
+    echo
+    echo "===================================="
+    echo "test summary: $PASS passed, $FAIL failed"
+    echo "===================================="
+    [ "$FAIL" -gt 0 ] && exit 1 || exit 0
+}
+
+TMP_ROOT=$(mktemp -d)
+STATE="$TMP_ROOT/state"
+mkdir -p "$STATE"
+
+# --- the fake qmd -----------------------------------------------------------
+#
+# Behaviour is driven by marker files in $STATE, so each test sets up the exact
+# qmd behaviour it needs. Shebang is /bin/sh (ABSOLUTE, POSIX body) — an
+# `#!/usr/bin/env bash` shebang would be re-resolved through a shadowed PATH,
+# the failure mode documented at length in test-graphmap-cadence.sh.
+#
+# Markers:
+#   fail-update   `qmd update` exits nonzero
+#   fail-embed    the FIRST `qmd embed` exits nonzero
+#   fail-verify   the SECOND `qmd embed` (the completeness assert) exits nonzero
+#   incomplete    every `qmd embed` reports work remaining (never the all-clear)
+#   did-work      the first embed reports it embedded chunks (the realistic
+#                 happy path); the verify pass still reports the all-clear
+FAKE_QMD="$TMP_ROOT/qmd"
+cat >"$FAKE_QMD" <<FAKE
+#!/bin/sh
+STATE="$STATE"
+FAKE
+cat >>"$FAKE_QMD" <<'FAKE'
+printf '%s\n' "$*" >> "$STATE/calls"
+case "${1:-}" in
+    update)
+        if [ -e "$STATE/fail-update" ]; then
+            echo "qmd: update exploded" >&2
+            exit 7
+        fi
+        echo "Indexed: 45 new, 22 updated, 14119 unchanged, 20 removed"
+        echo "4 collections updated."
+        ;;
+    embed)
+        # `grep -c` PRINTS "0" and exits 1 when there are no matches, so a
+        # `|| echo 0` fallback would emit a SECOND zero and make n="0\n0" —
+        # which then blows up the numeric tests below with "integer expression
+        # expected". Swallow grep's status instead, and floor an empty result
+        # (file absent) to 0.
+        n=$(grep -c '^embed' "$STATE/calls" 2>/dev/null || :)
+        [ -n "$n" ] || n=0
+        if [ -e "$STATE/fail-embed" ] && [ "$n" -eq 1 ]; then
+            echo "qmd: embed exploded" >&2
+            exit 9
+        fi
+        if [ -e "$STATE/fail-verify" ] && [ "$n" -ge 2 ]; then
+            echo "qmd: verify embed exploded" >&2
+            exit 9
+        fi
+        if [ -e "$STATE/incomplete" ]; then
+            echo "Embedded 100 chunks from 20 documents in 5s"
+            exit 0
+        fi
+        if [ -e "$STATE/did-work" ] && [ "$n" -eq 1 ]; then
+            echo "Embedded 457 chunks from 81 documents in 22s"
+            exit 0
+        fi
+        echo "All content hashes already have embeddings."
+        ;;
+    *)
+        echo "qmd-fake: unsupported argv: $*" >&2
+        exit 64
+        ;;
+esac
+FAKE
+chmod +x "$FAKE_QMD"
+
+reset_state() {
+    rm -f "$STATE"/* 2>/dev/null || true
+    : > "$STATE/calls"
+}
+
+calls() { cat "$STATE/calls" 2>/dev/null || true; }
+
+# A PATH with every dir carrying a real `qmd` filtered out — the not-found probe
+# must not be satisfied by an operator's actually-installed qmd. Filtering the
+# real PATH beats replacing it: a bare stub dir strips coreutils and the script
+# dies on `date`/`grep` before reaching the check under test (the lesson baked
+# into test-graphmap-cadence.sh's PATH_NOCLAUDE).
+PATH_NOQMD=""
+_oldifs=$IFS; IFS=:
+for _d in $PATH; do
+    [ -n "$_d" ] || continue
+    if [ -x "$_d/qmd" ] || [ -x "$_d/qmd.exe" ] || [ -x "$_d/qmd.cmd" ]; then continue; fi
+    PATH_NOQMD="${PATH_NOQMD:+$PATH_NOQMD:}$_d"
+done
+IFS=$_oldifs
+
+# ============================================================================
+# Argument handling
+# ============================================================================
+
+echo "TEST: --help exits 0 and documents the exit codes"
+rc=0; out=$(bash "$SCRIPT" --help 2>&1) || rc=$?
+assert_rc "--help rc 0" 0 "$rc"
+assert_contains "--help documents --qmd-bin" "--qmd-bin" "$out"
+assert_contains "--help documents the incomplete-embed code" "5 embed incomplete" "$out"
+
+echo "TEST: unknown arg exits 1"
+rc=0; out=$(bash "$SCRIPT" --nope 2>&1) || rc=$?
+assert_rc "unknown arg rc 1" 1 "$rc"
+assert_contains "unknown arg names the offender" "unknown arg: --nope" "$out"
+
+echo "TEST: --qmd-bin with no operand exits 1 with a message (not a silent set -e death)"
+rc=0; out=$(bash "$SCRIPT" --qmd-bin 2>&1) || rc=$?
+assert_rc "trailing --qmd-bin rc 1" 1 "$rc"
+assert_contains "trailing --qmd-bin explains itself" "requires an absolute path operand" "$out"
+
+echo "TEST: --qmd-bin swallowing the NEXT FLAG is refused"
+rc=0; out=$(bash "$SCRIPT" --qmd-bin --dry-run 2>&1) || rc=$?
+assert_rc "--qmd-bin --dry-run rc 1" 1 "$rc"
+assert_contains "flag-as-operand explains itself" "requires an absolute path operand" "$out"
+
+echo "TEST: an EXPLICITLY EMPTY --qmd-bin operand is refused (not silently PATH-resolved)"
+# `--qmd-bin ""` must not quietly fall through to PATH resolution — that ignores
+# the flag the caller deliberately passed.
+rc=0; out=$(bash "$SCRIPT" --qmd-bin "" 2>&1) || rc=$?
+assert_rc "empty --qmd-bin operand rc 1" 1 "$rc"
+assert_contains "empty operand explains itself" "requires an absolute path operand" "$out"
+rc=0; out=$(bash "$SCRIPT" --qmd-bin= 2>&1) || rc=$?
+assert_rc "empty --qmd-bin=VALUE rc 1" 1 "$rc"
+
+echo "TEST: qmd not found (absent from PATH, no --qmd-bin) exits 2"
+rc=0; out=$(env PATH="$PATH_NOQMD" bash "$SCRIPT" 2>&1) || rc=$?
+assert_rc "missing qmd rc 2" 2 "$rc"
+assert_contains "missing-qmd error is actionable" "not found on PATH" "$out"
+
+echo "TEST: --qmd-bin pointing at a non-existent file exits 2"
+rc=0; out=$(bash "$SCRIPT" --qmd-bin "$TMP_ROOT/no-such-qmd" 2>&1) || rc=$?
+assert_rc "bad --qmd-bin rc 2" 2 "$rc"
+assert_contains "bad --qmd-bin says not executable" "is not an executable file" "$out"
+
+echo "TEST: a RELATIVE --qmd-bin is refused (rc 2)"
+# A relative path is meaningless once a scheduled runner has cd'd elsewhere —
+# the same class the sibling cadence guards against for `claude`.
+rc=0; out=$(bash "$SCRIPT" --qmd-bin "./qmd" 2>&1) || rc=$?
+assert_rc "relative --qmd-bin rc 2" 2 "$rc"
+assert_contains "relative --qmd-bin explains why" "non-absolute path" "$out"
+
+echo "TEST: --qmd-bin=VALUE form is accepted"
+reset_state
+rc=0; out=$(bash "$SCRIPT" "--qmd-bin=$FAKE_QMD" --dry-run 2>&1) || rc=$?
+assert_rc "--qmd-bin=VALUE rc 0" 0 "$rc"
+assert_contains "--qmd-bin=VALUE resolves the fake" "$FAKE_QMD" "$out"
+
+# ============================================================================
+# --dry-run executes nothing
+# ============================================================================
+
+echo "TEST: --dry-run prints the plan and invokes qmd zero times"
+reset_state
+rc=0; out=$(bash "$SCRIPT" --qmd-bin "$FAKE_QMD" --dry-run 2>&1) || rc=$?
+assert_rc "dry-run rc 0" 0 "$rc"
+assert_contains "dry-run previews update" "would run: $FAKE_QMD update" "$out"
+assert_contains "dry-run previews embed" "would run: $FAKE_QMD embed" "$out"
+assert_contains "dry-run previews the completeness assert" "completeness assert" "$out"
+if [ ! -s "$STATE/calls" ]; then
+    pass "dry-run invoked qmd zero times"
+else
+    fail "dry-run invoked qmd" "$(calls)"
+fi
+
+# ============================================================================
+# Happy path
+# ============================================================================
+
+echo "TEST: happy path runs update, then embed, then the verify embed"
+reset_state
+touch "$STATE/did-work"
+rc=0; out=$(bash "$SCRIPT" --qmd-bin "$FAKE_QMD" 2>&1) || rc=$?
+assert_rc "happy path rc 0" 0 "$rc"
+assert_contains "reports success" "index refreshed, all content hashes embedded" "$out"
+assert_contains "step 1 labelled" "[1/3] qmd update" "$out"
+assert_contains "step 2 labelled" "[2/3] qmd embed" "$out"
+assert_contains "step 3 labelled" "[3/3] verifying embed completeness" "$out"
+# Order + count: exactly `update`, then `embed`, then `embed`.
+got_calls=$(calls | tr '\n' ',')
+if [ "$got_calls" = "update,embed,embed," ]; then
+    pass "call sequence is update -> embed -> embed(verify)"
+else
+    fail "wrong call sequence" "got: $got_calls"
+fi
+
+echo "TEST: happy path passes NO -c flag (all collections is the default scope)"
+# Collection scope is deliberately not hardcoded: `qmd update`/`qmd embed`
+# default to every configured collection and take -c only to NARROW, so a
+# collection added later must be picked up with no edit to the runner.
+assert_not_contains "no -c narrowing on any call" "-c " "$(calls)"
+
+echo "TEST: an already-complete index (no embedding work) still succeeds"
+reset_state
+rc=0; out=$(bash "$SCRIPT" --qmd-bin "$FAKE_QMD" 2>&1) || rc=$?
+assert_rc "no-op embed rc 0" 0 "$rc"
+assert_contains "still reports success" "index refreshed" "$out"
+
+echo "TEST: qmd resolved from PATH when --qmd-bin is omitted"
+reset_state
+touch "$STATE/did-work"
+rc=0; out=$(env PATH="$TMP_ROOT:$PATH" bash "$SCRIPT" 2>&1) || rc=$?
+assert_rc "PATH-resolved qmd rc 0" 0 "$rc"
+assert_contains "banner names the resolved qmd" "$FAKE_QMD" "$out"
+
+# ============================================================================
+# Failure paths — each must be LOUD and carry its own exit code
+# ============================================================================
+
+echo "TEST: 'qmd update' failure exits 3 and never embeds"
+reset_state
+touch "$STATE/fail-update"
+rc=0; out=$(bash "$SCRIPT" --qmd-bin "$FAKE_QMD" 2>&1) || rc=$?
+assert_rc "update failure rc 3" 3 "$rc"
+assert_contains "update failure is explicit" "'qmd update' failed" "$out"
+assert_contains "update failure surfaces qmd stderr" "update exploded" "$out"
+assert_not_contains "no embed attempted after a failed update" "embed" "$(calls)"
+
+echo "TEST: 'qmd embed' failure exits 4 and says vectors are stale"
+reset_state
+touch "$STATE/fail-embed"
+rc=0; out=$(bash "$SCRIPT" --qmd-bin "$FAKE_QMD" 2>&1) || rc=$?
+assert_rc "embed failure rc 4" 4 "$rc"
+assert_contains "embed failure names the half-state" "lex index is fresh but vectors are NOT" "$out"
+
+echo "TEST: an INCOMPLETE embed exits 5 (this is the whole point of HIMMEL-568)"
+# A `qmd embed` that hits its session cap exits 0 having embedded only PART of
+# the pending set. Without the completeness assert the cadence would report
+# success while vectors lag lex — the silently-stale state the ticket exists to
+# eliminate, just with a fresher timestamp on it.
+reset_state
+touch "$STATE/incomplete"
+rc=0; out=$(bash "$SCRIPT" --qmd-bin "$FAKE_QMD" 2>&1) || rc=$?
+assert_rc "incomplete embed rc 5" 5 "$rc"
+assert_contains "incomplete embed is named as such" "embed INCOMPLETE" "$out"
+assert_contains "incomplete embed explains the likely cause" "session" "$out"
+assert_contains "incomplete embed offers the manual escape" "embed --timeout 0" "$out"
+assert_not_contains "incomplete embed never claims success" "index refreshed, all content hashes embedded" "$out"
+
+echo "TEST: a failing verify pass exits 4 (not silently treated as complete)"
+reset_state
+touch "$STATE/fail-verify"
+rc=0; out=$(bash "$SCRIPT" --qmd-bin "$FAKE_QMD" 2>&1) || rc=$?
+assert_rc "verify failure rc 4" 4 "$rc"
+assert_contains "verify failure is explicit" "completeness re-check" "$out"
+assert_not_contains "verify failure never claims success" "index refreshed, all content hashes embedded" "$out"
+
+summary

--- a/scripts/test-himmel-doctor.sh
+++ b/scripts/test-himmel-doctor.sh
@@ -19,10 +19,14 @@ unset OLLAMA_NO_CLOUD
 
 # Hermeticity (HIMMEL-969): C8's runner-home defaults resolve via
 # cadence_user_home (USERPROFILE via cygpath on Windows) — per-case HOME
-# redirection does NOT cover that, so pin all three seams to empty dirs
-# globally; C8 cases override them per-case.
+# redirection does NOT cover that, so pin all four seams to empty dirs
+# globally; C8 cases override them per-case. EVERY seam in C8's table must be
+# pinned here: an unpinned one falls through to the operator's REAL
+# ~/.claude/<cadence> dir, so an armed cadence on the dev box would leak into
+# the "no armed cadence runners" and "no false nudges" cases (HIMMEL-568 added
+# the qmd seam).
 C8_EMPTY="$(mktemp -d)"
-export PIPELINE_BAT_DIR="$C8_EMPTY/pipeline" SWEEP_BAT_DIR="$C8_EMPTY/sweep" GRAPHMAP_BAT_DIR="$C8_EMPTY/graphmap"
+export PIPELINE_BAT_DIR="$C8_EMPTY/pipeline" SWEEP_BAT_DIR="$C8_EMPTY/sweep" GRAPHMAP_BAT_DIR="$C8_EMPTY/graphmap" QMD_CADENCE_BAT_DIR="$C8_EMPTY/qmd"
 
 failures=0
 pass() { printf '  PASS  %s\n' "$1"; }
@@ -394,6 +398,22 @@ out="$(RESOLVE_NODE_PROBE_DIRS="$FAKENODE" PIPELINE_BAT_DIR="$t/pipeline-empty" 
 if printf '%s' "$out" | grep -q 'WARN C8-cadence: graphmap-cadence runners are stale' \
     && printf '%s' "$out" | grep -q 'bash scripts/luna/graphmap-cadence.sh arm --force'; then
     pass "C8 -> WARN (stale graphmap runner)"
+else
+    fail "C8 -> $(printf '%s' "$out" | grep C8)"
+fi
+rm -rf "$t"
+
+echo "== C8: stale qmd runner -> WARN + qmd re-arm hint =="
+t="$(mktemp -d)"; mkdir -p "$t/claude" "$t/qmd"; write_settings "$t/claude" "$WRAPPER"
+printf '#!/bin/sh\n# himmel-cadence-runner-format: %s\necho old qmd\n' "$STALE_CADENCE_VER" > "$t/qmd/qmd-reindex.sh"
+out="$(RESOLVE_NODE_PROBE_DIRS="$FAKENODE" PIPELINE_BAT_DIR="$t/pipeline-empty" \
+    SWEEP_BAT_DIR="$t/sweep-empty" GRAPHMAP_BAT_DIR="$t/graphmap-empty" \
+    QMD_CADENCE_BAT_DIR="$t/qmd" \
+    DOCTOR_MCP_PLUGINS_GLOB="$t/none/*.mcp.json" CLAUDE_DIR="$t/claude" HOME="$t/home" \
+    bash "$DOC" --no-color 2>&1)"
+if printf '%s' "$out" | grep -q 'WARN C8-cadence: qmd-cadence runners are stale' \
+    && printf '%s' "$out" | grep -q 'bash scripts/luna/qmd-cadence.sh arm --force'; then
+    pass "C8 -> WARN (stale qmd runner)"
 else
     fail "C8 -> $(printf '%s' "$out" | grep C8)"
 fi


### PR DESCRIPTION
## What

A daily **qmd reindex cadence** so the search index stops going silently stale — a runner + scheduler pair, modelled on the existing graphify cadence.

- **`scripts/luna/qmd-reindex.sh`** — the RUNNER: `qmd update` → `qmd embed` → a **completeness assert**.
- **`scripts/luna/qmd-cadence.sh`** — the SCHEDULER: `arm` / `status` / `disarm` for one daily task, default **05:00** local.

**Nothing here arms anything.** Arming is an explicit operator action, and single-machine adopters take on no new obligation.

## Why

The index goes stale **silently**. A collection can sit days stale while notes written that week are simply not searchable — and every qmd-backed workflow (ingest, synthesis, recall) answers off the stale index with nothing signalling it.

## The completeness assert (the part that matters)

`qmd embed` has a session cap (`--timeout`, default 30 min). A run that hits the cap **exits 0** having embedded only PART of the pending set — leaving vectors lagging the lex index, which is the *same silently-wrong state*, just with a fresher timestamp on it.

So after embedding, the runner calls `qmd embed` again: when the set is genuinely complete it is a no-op reporting the all-clear (~1s). Anything else fails **loud** (rc=5).

Distinct exit codes so an unattended log says which half broke: `3` update failed, `4` embed failed, `5` embed incomplete.

## Design notes

**Deterministic-script shape.** No agent session, no stdin redirect, no settings fragment — `qmd update` / `qmd embed` are plain CLI calls, so the scheduler fires a script directly.

**Why 05:00.** It lands *after* the vault-writing pipeline legs (02:00 / 03:00 / 04:00), so the reindex picks up what they wrote instead of racing them; a slot before them would index the previous day's vault. `--time HH:MM` overrides.

**Collection scope is everything qmd knows about.** Both subcommands default to all collections and take `-c` only to NARROW, so the bare calls are the full scope by construction — a collection added later needs no edit here.

**The qmd binary is pinned at arm time.** Schedulers fire with a minimal PATH that need not carry qmd's bin dir, so `arm` resolves it up front and fails fast if absent — otherwise the arm "succeeds" and every unattended fire dies in a log nobody reads.

**No daemon fence, and the evidence is scoped precisely.** With a resident qmd MCP daemon up, a full `update` + `embed` completed without error and the daemon was still serving on the same PID afterwards. That is process survival plus absence of error — **not** a concurrency proof; nothing exercised reads racing the writes. Enough to justify not fencing by default; if a fence is ever needed it belongs in the runner, not the scheduler.

**StartWhenAvailable / IgnoreNew.** A run missed because the machine was off fires when it is next on (otherwise a staleness-prevention cadence silently skips exactly when it is needed), and the task cannot overlap itself.

## Tests

| Suite | Assertions |
|---|---|
| `scripts/luna/test-qmd-reindex.sh` | 50 |
| `scripts/luna/test-qmd-cadence.sh` | 141 |

Both **hermetic** — they stub `qmd`/`bash`/`schtasks`/`crontab`, so they need no real qmd, no index and no network. The cron suite runs on every platform (POSIX path forced via an `OSTYPE` override); the schtasks suite is Windows-only. shellcheck clean.

Coverage includes the failure paths that matter: update-fails-never-embeds, embed-fails, **incomplete-embed→rc5**, verify-pass-fails, missing/empty/flag-shaped `--qmd-bin`, arm fail-fast when `qmd` is off PATH, dedup and idempotent double-arm, fail-closed `crontab -l` / task query, no-half-state on a failed `--force` re-arm (both platforms), and a **behavioural** probe that fires the generated runner and asserts its exit code propagates.

## Try it

```bash
bash scripts/luna/qmd-cadence.sh status          # not armed
bash scripts/luna/qmd-cadence.sh arm --dry-run   # preview, touches nothing
bash scripts/luna/qmd-reindex.sh --dry-run       # preview the two qmd calls
```
