### PR TITLE
feat: qmd index ship transport — build local, RECEIVE remote

### DIFF
--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -1119,6 +1119,64 @@ signalled it. Same runner/scheduler split as the graphify pair above.
 
 ---
 
+## qmd index ship transport (`scripts/luna/ship-index*`, HIMMEL-1275)
+
+Build the search index LOCALLY, ship the artifact to a machine that cannot build
+its own. Measured 2026-07-25: win2 embeds at ~5 docs/min vs ~256 docs/min
+locally (50x), so an in-place reindex there was projected at **~17 hours** and
+was killed mid-run. It RECEIVES, never builds. Consumes HIMMEL-568's runner —
+ship AFTER a successful local reindex, not on a blind clock.
+
+- `scripts/luna/prepare-ship-index.mjs` — builds the shippable artifact.
+  Consistent copy via SQLite's **backup API** (not a file copy, so it is safe
+  while the local daemon is live), collection reconcile, **vec0 orphan GC**,
+  VACUUM, then a self-check. Node rather than Python because the index carries a
+  vec0 virtual table and Python's stdlib `sqlite3` cannot load vec0 on these
+  boxes. Two facts it depends on, both verified against the live index:
+  `vectors_vec.hash_seq == hash || '_' || seq` (underscore), and a vec0
+  `TEXT PRIMARY KEY` **replaces rowid** so deletes must key on `hash_seq`.
+  FTS needs no separate step — the `documents_ad` trigger cascades the
+  `documents` delete into `documents_fts` (hand-deleting from that contentless
+  fts5 table would corrupt it). Content is SHARED across collections
+  (`luna-curated` indexes a subset of the luna vault), so orphan cleanup is
+  "referenced by NO surviving document", never "belonged to a dropped
+  collection". The source index is opened READONLY and never modified.
+- `scripts/luna/ship-index-remote.ps1` — the RECEIVER half, copied over and run
+  there. Daemon fence (the daemon is **bun**, not node — a node-only filter both
+  misses it and matches dozens of unrelated processes), swap via a `.preship`
+  copy that is **reaped on success and failure**, **WMI-parented restart**
+  (`Invoke-CimMethod Win32_Process Create` — a child of the ssh session dies with
+  the connection), then verify. It is a FILE rather than an inline command
+  because a nested `\"` inside `ssh host 'powershell -Command "…"'` breaks cmd
+  parsing.
+- `scripts/luna/ship-index.sh` — the orchestrator: reindex → resolve the
+  receiver's collection set → prepare → upload → run the receiver script →
+  ship the graph. Distinct exit codes per stage (3 reindex / 4 prepare /
+  5 upload / 6 receiver / 7 graph) so a failure says which half broke and
+  whether anything reached the receiver.
+
+**Reconcile policy: ship-only-what-the-RECEIVER-configures.** Its own
+`qmd collection list` is the authority, so the ship can never create an orphan
+collection there; and it REFUSES outright if the receiver expects a collection
+the source lacks, rather than silently shipping an index missing it.
+**Verify fails LOUD** if vectors lag lex after the swap — that is the exact
+state win2 was found in (lex-current at 14,803 docs while thousands of vectors
+were missing, answering semantic queries off the gap in silence).
+
+The graphify graph rides the same transport; **HIMMEL-1129 owns publishing** —
+this moves the machine-to-machine leg only and never generates a graph.
+
+Hermetic tests: `test-prepare-ship-index.sh` (33 assertions against REAL fixture
+databases with real vec0 tables — reconcile, shared-content retention, orphan
+GC including pre-existing ghost rows, FTS trigger cascade; skips cleanly when
+better-sqlite3/vec0 are absent) and `test-ship-index.sh` (37 assertions —
+argument handling, preflight, dry-run, per-stage failure attribution, and the
+"a failed local build ships NOTHING" ordering guarantee, all against stubbed
+ssh/scp/node). Neither needs a second machine; the actual swap is deliberately
+never a CI test.
+
+---
+
 ## Codex Cleanup Cadence (`scripts/cleanup/`, HIMMEL-892)
 
 Windows-only scheduled cleanup for orphaned codex processes and stale MCP fleet.

--- a/scripts/luna/prepare-ship-index.mjs
+++ b/scripts/luna/prepare-ship-index.mjs
@@ -1,0 +1,422 @@
+#!/usr/bin/env node
+// prepare-ship-index.mjs — build a shippable qmd index snapshot for a RECEIVING
+// machine: consistent copy -> collection reconcile -> vec0 orphan GC -> VACUUM
+// -> stats (HIMMEL-1275).
+//
+// WHY THIS EXISTS: win2 cannot BUILD its own search substrate. Measured
+// 2026-07-25: it embeds at ~5 docs/min vs ~256 docs/min locally (50x), so an
+// in-place reindex there was projected at ~17 HOURS and was killed mid-run. The
+// only workable shape is build-local / ship-the-artifact. This script is the
+// "prepare the artifact" half; scripts/luna/ship-index.sh is the transport.
+//
+// WHY NODE AND NOT PYTHON/sqlite3-CLI: the index carries a vec0 virtual table
+// (`vectors_vec`). Python's stdlib sqlite3 CANNOT load the vec0 extension on
+// these boxes (`no such module: vec0`), and the sqlite3 CLI is not guaranteed to
+// have it either. node + better-sqlite3 + vec0.dll via db.loadExtension() is the
+// path that works, so the GC lives here rather than in the shell script.
+//
+// ---------------------------------------------------------------------------
+// The four facts this script is built on (all verified against the live index
+// on 2026-07-25 — do not re-derive them by guessing):
+//
+//   1. SCHEMA
+//        store_collections(name PK, path, pattern, ...)
+//        documents(id PK, collection, path, title, hash, ..., active)
+//        content(hash PK, doc, created_at)
+//        content_vectors(hash, seq PK, pos, model, ...)
+//        vectors_vec USING vec0(hash_seq TEXT PRIMARY KEY, embedding float[768])
+//
+//   2. vectors_vec.hash_seq == hash + "_" + seq  (UNDERSCORE separator).
+//      Sampled: "46b47b19…cc8ebf_0", "…_1". The GC predicate depends on this
+//      exact shape; a wrong separator silently deletes EVERY vector.
+//
+//   3. `hash_seq TEXT PRIMARY KEY` REPLACES rowid in a vec0 table. So
+//      `DELETE FROM vectors_vec WHERE rowid = ?` fails with
+//      "no such column: rowid" — deletions MUST key on hash_seq.
+//
+//   4. FTS IS HANDLED BY A TRIGGER, NOT BY US. `documents_ad` is an
+//      AFTER DELETE trigger on documents that deletes the matching
+//      documents_fts row. So deleting documents cascades to FTS for free.
+//      Do NOT hand-delete from documents_fts (it is a contentless fts5 table —
+//      manual deletes corrupt it), and do NOT skip the documents delete
+//      thinking FTS needs separate handling.
+//
+// CONTENT IS SHARED ACROSS COLLECTIONS. `luna-curated` indexes a SUBSET of the
+// same luna vault, so a content hash can be referenced by documents in more
+// than one collection. Orphan cleanup is therefore "referenced by NO surviving
+// document", never "belonged to a dropped collection" — the latter would delete
+// content that a kept collection still needs.
+//
+// SAFETY: the source index is opened READONLY and is never modified. All
+// mutation happens on the copy. The copy is made with SQLite's own backup API
+// (better-sqlite3 db.backup), NOT a filesystem copy, so it is consistent even
+// while the local qmd MCP daemon is live.
+//
+// Usage:
+//   node prepare-ship-index.mjs --src <index.sqlite> --out <staging.sqlite> \
+//        --collections himmel,luna [--vec0 <path>] [--json]
+//
+// Exit codes:
+//   0  staging index built + verified self-consistent
+//   1  usage / input error
+//   2  dependency unusable (better-sqlite3 or vec0 not loadable)
+//   3  source index unreadable / unexpected schema
+//   4  reconcile or GC failed
+//   5  post-build self-check failed (staging index is internally inconsistent)
+
+import { existsSync, mkdirSync, renameSync, rmSync, statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { homedir } from 'node:os';
+
+const require = createRequire(import.meta.url);
+
+function die(code, msg) {
+  process.stderr.write(`ERR prepare-ship-index: ${msg}\n`);
+  process.exit(code);
+}
+
+// --- args -------------------------------------------------------------------
+const args = process.argv.slice(2);
+let src = '', out = '', collectionsArg = null, vec0Path = '', asJson = false;
+for (let i = 0; i < args.length; i++) {
+  const a = args[i];
+  const need = (name) => {
+    const v = args[i + 1];
+    if (v === undefined || v.startsWith('--')) die(1, `${name} requires a value`);
+    i++;
+    return v;
+  };
+  switch (a) {
+    case '--src': src = need('--src'); break;
+    case '--out': out = need('--out'); break;
+    case '--collections': collectionsArg = need('--collections'); break;
+    case '--vec0': vec0Path = need('--vec0'); break;
+    case '--json': asJson = true; break;
+    case '-h': case '--help':
+      process.stdout.write(
+        'Usage: prepare-ship-index.mjs --src <index.sqlite> --out <staging.sqlite> ' +
+        '--collections a,b [--vec0 <vec0.dll>] [--json]\n');
+      process.exit(0);
+    default: die(1, `unknown arg: ${a}`);
+  }
+}
+if (!src || !out) die(1, '--src and --out are required');
+if (collectionsArg === null) die(1, '--collections is required (the RECEIVING machine\'s set)');
+
+// An empty --collections would reconcile the shipped index down to nothing,
+// which is a plausible typo/shell-expansion accident and never a real intent.
+const keep = collectionsArg.split(',').map(s => s.trim()).filter(Boolean);
+if (keep.length === 0) die(1, '--collections resolved to an empty set — refusing to ship an empty index');
+
+src = resolve(src);
+out = resolve(out);
+if (!existsSync(src)) die(3, `source index not found: ${src}`);
+if (src === out) die(1, 'refusing to use the same path for --src and --out');
+
+// --- dependencies -----------------------------------------------------------
+// better-sqlite3 is not a dependency of this repo; it comes from the qmd fork
+// checkout that scripts/lib/qmd-bin.sh manages. Probe the known locations
+// rather than assuming a global install.
+const bs3Candidates = [
+  process.env.HIMMEL_BETTER_SQLITE3,
+  `${homedir()}/.himmel/qmd-fork/node_modules/better-sqlite3`,
+  `${homedir()}/Documents/github/qmd/node_modules/better-sqlite3`,
+].filter(Boolean);
+
+let Database = null, bs3Used = '';
+for (const c of bs3Candidates) {
+  try { Database = require(c); bs3Used = c; break; } catch { /* try next */ }
+}
+if (!Database) {
+  die(2, 'better-sqlite3 not found. Looked in:\n' + bs3Candidates.map(c => `    ${c}`).join('\n') +
+         '\n    Set HIMMEL_BETTER_SQLITE3 to its directory, or install the qmd fork.');
+}
+
+// sqlite-vec ships a per-platform package with a per-platform library name, so
+// a Windows-only candidate list would make every POSIX host look like "vec0
+// unavailable" even with it installed. Cover the three platforms explicitly.
+const vec0Pkgs = process.platform === 'win32'
+  ? [['sqlite-vec-windows-x64', 'vec0.dll']]
+  : process.platform === 'darwin'
+    ? [['sqlite-vec-darwin-arm64', 'vec0.dylib'], ['sqlite-vec-darwin-x64', 'vec0.dylib']]
+    : [['sqlite-vec-linux-x64', 'vec0.so'], ['sqlite-vec-linux-arm64', 'vec0.so']];
+const vec0Roots = [
+  `${homedir()}/.himmel/qmd-fork/node_modules`,
+  `${homedir()}/Documents/github/qmd/node_modules`,
+  `${homedir()}/.bun/install/global/node_modules`,
+];
+const vec0Candidates = [
+  vec0Path,
+  process.env.HIMMEL_VEC0,
+  ...vec0Roots.flatMap(r => vec0Pkgs.map(([pkg, lib]) => `${r}/${pkg}/${lib}`)),
+].filter(Boolean);
+
+function loadVec0(db) {
+  for (const c of vec0Candidates) {
+    if (!existsSync(c)) continue;
+    try { db.loadExtension(c); return c; } catch { /* try next */ }
+  }
+  return null;
+}
+
+// --- build ------------------------------------------------------------------
+const stats = { src, out, keptCollections: keep, bs3: bs3Used };
+
+mkdirSync(dirname(out), { recursive: true });
+
+// Build at a unique sibling path and PROMOTE to --out only after every step
+// (reconcile, GC, VACUUM, self-check) has succeeded. Deleting/overwriting --out
+// up front would destroy a previous good artifact the moment anything failed,
+// leaving the operator with neither the old one nor a usable new one — and a
+// half-written file at exactly the path the transport is about to upload. Same
+// staged-then-promoted discipline the cadence emitters use for their runners.
+const workPath = `${out}.building.${process.pid}`;
+let promoted = false;
+// SQLite writes -wal and -shm SIDECARS next to the database. They must be
+// cleaned up and replaced together with the main file: a stale -wal left beside
+// a NEW database is not just litter, it is a journal belonging to a DIFFERENT
+// database sitting where SQLite will look for one.
+const sidecars = (p) => [`${p}-wal`, `${p}-shm`];
+const rmQuiet = (p) => { try { if (existsSync(p)) rmSync(p, { force: true }); } catch { /* best effort */ } };
+const discardWork = () => {
+  if (!promoted) {
+    rmQuiet(workPath);
+    for (const s of sidecars(workPath)) rmQuiet(s);
+  }
+};
+process.on('exit', discardWork);
+
+let source;
+try {
+  source = new Database(src, { readonly: true });
+} catch (e) {
+  die(3, `cannot open source index readonly: ${e.message}`);
+}
+
+// Schema sanity BEFORE touching anything: a qmd index that does not look like
+// the one this script was written against must not be silently "reconciled".
+const tables = new Set(
+  source.prepare("select name from sqlite_master where type in ('table','view')").all().map(r => r.name));
+for (const t of ['store_collections', 'documents', 'content', 'content_vectors', 'vectors_vec', 'documents_fts']) {
+  if (!tables.has(t)) {
+    source.close();
+    die(3, `source index is missing the '${t}' table — schema is not what this script expects. ` +
+           'Re-verify the schema before shipping (see the header).');
+  }
+}
+
+// The FTS cascade is an ASSUMPTION this script depends on, so verify it rather
+// than trust it. We deliberately do NOT touch documents_fts: correctness relies
+// entirely on the documents_ad AFTER DELETE trigger removing the matching FTS
+// row. If a qmd version ever drops or renames that trigger, the reconcile would
+// still "succeed" and silently ship an index whose full-text search returns
+// documents that are no longer in it — a wrong-answer failure with no error.
+// Refuse instead.
+const hasAd = source.prepare(
+  "select count(*) c from sqlite_master where type='trigger' and name='documents_ad'").get().c;
+if (!hasAd) {
+  source.close();
+  die(3, "source index has no 'documents_ad' trigger. This script relies on it to cascade " +
+         'document deletes into documents_fts, and never deletes from that (contentless) FTS ' +
+         'table itself. Without the trigger the shipped index would full-text-match deleted ' +
+         'documents. Refusing to ship.');
+}
+
+const srcCollections = source.prepare('select name from store_collections order by name').all().map(r => r.name);
+stats.sourceCollections = srcCollections;
+
+// Refuse to invent collections on the receiver. If the receiver asks for a
+// collection the source does not have, the ship would silently deliver an
+// index missing it — better to fail here and let the operator decide.
+const missing = keep.filter(k => !srcCollections.includes(k));
+if (missing.length) {
+  source.close();
+  die(1, `receiver expects collection(s) the SOURCE does not have: ${missing.join(', ')}\n` +
+         `    source has: ${srcCollections.join(', ')}\n` +
+         '    Refusing to ship an index that silently omits them.');
+}
+
+stats.droppedCollections = srcCollections.filter(c => !keep.includes(c));
+
+try {
+  await source.backup(workPath);
+} catch (e) {
+  source.close();
+  die(3, `SQLite backup to staging failed: ${e.message}`);
+}
+source.close();
+
+let db;
+try {
+  db = new Database(workPath);
+} catch (e) {
+  die(3, `cannot open staging index: ${e.message}`);
+}
+
+const vec0Used = loadVec0(db);
+if (!vec0Used) {
+  db.close();
+  die(2, 'could not load the vec0 extension. Looked in:\n' + vec0Candidates.map(c => `    ${c}`).join('\n') +
+         '\n    vec0 is REQUIRED: vectors_vec is a vec0 virtual table, and its orphan rows ' +
+         'cannot be deleted without it. Set HIMMEL_VEC0 or pass --vec0.');
+}
+stats.vec0 = vec0Used;
+
+const count = (sql) => db.prepare(sql).get().c;
+stats.before = {
+  collections: count('select count(*) c from store_collections'),
+  documents: count('select count(*) c from documents'),
+  content: count('select count(*) c from content'),
+  contentVectors: count('select count(*) c from content_vectors'),
+  vectors: count('select count(*) c from vectors_vec'),
+};
+
+const placeholders = keep.map(() => '?').join(',');
+try {
+  db.exec('BEGIN');
+  // 1. Drop documents outside the receiver's set. The documents_ad trigger
+  //    cascades each delete into documents_fts, so FTS needs no separate step
+  //    (and must not get one — it is a contentless fts5 table).
+  db.prepare(`DELETE FROM documents WHERE collection NOT IN (${placeholders})`).run(...keep);
+  // 2. Drop the collection rows themselves, so the receiver never sees an
+  //    orphan collection it does not configure.
+  db.prepare(`DELETE FROM store_collections WHERE name NOT IN (${placeholders})`).run(...keep);
+  // 3. Content is SHARED across collections (luna-curated indexes a subset of
+  //    the luna vault), so drop only what NO surviving document references.
+  //
+  //    NOT EXISTS, NOT `NOT IN` — this is a correctness requirement, not style.
+  //    SQL `x NOT IN (subquery)` evaluates to NULL (not TRUE) for every row as
+  //    soon as the subquery yields a single NULL, so ONE document with a NULL
+  //    hash silently deletes NOTHING. Verified: with one NULL hash present,
+  //    the NOT IN form finds 0 orphans where NOT EXISTS correctly finds 1.
+  //    documents.hash has no NOT NULL constraint, so this is reachable — and it
+  //    would ship a bloated index while the self-check below (which used the
+  //    same predicate) reported it clean.
+  db.prepare(
+    'DELETE FROM content WHERE NOT EXISTS (SELECT 1 FROM documents d WHERE d.hash = content.hash)').run();
+  // 4. Vector metadata follows content. Same NULL-safety reasoning.
+  db.prepare(
+    'DELETE FROM content_vectors WHERE NOT EXISTS (SELECT 1 FROM content c WHERE c.hash = content_vectors.hash)').run();
+  // 5. vec0 orphan GC. These rows NEVER self-clean (22,895 were GC'd by hand on
+  //    2026-07-23). Key on hash_seq — a vec0 TEXT PRIMARY KEY replaces rowid,
+  //    so a rowid predicate errors outright.
+  //    NOT EXISTS here TOO. This is the same NULL trap as steps 3-4 and it is
+  //    easy to miss because the subquery looks like a computed string rather
+  //    than a column: `hash || '_' || seq` is NULL whenever EITHER operand is
+  //    NULL, so one such row makes `hash_seq NOT IN (...)` NULL for every row
+  //    and the orphan GC deletes nothing — silently, with the convergence
+  //    self-check below then failing for a reason that points elsewhere.
+  db.prepare(
+    'DELETE FROM vectors_vec WHERE NOT EXISTS (' +
+    "SELECT 1 FROM content_vectors cv WHERE cv.hash IS NOT NULL AND cv.seq IS NOT NULL " +
+    "AND cv.hash || '_' || cv.seq = vectors_vec.hash_seq)").run();
+  db.exec('COMMIT');
+} catch (e) {
+  try { db.exec('ROLLBACK'); } catch { /* already rolled back */ }
+  db.close();
+  die(4, `reconcile/GC failed: ${e.message}`);
+}
+
+// VACUUM outside the transaction — reclaims the space the deletes freed, which
+// is the difference between shipping ~440MB and shipping the pre-strip size.
+try {
+  db.exec('VACUUM');
+} catch (e) {
+  db.close();
+  die(4, `VACUUM failed: ${e.message}`);
+}
+
+stats.after = {
+  collections: count('select count(*) c from store_collections'),
+  documents: count('select count(*) c from documents'),
+  content: count('select count(*) c from content'),
+  contentVectors: count('select count(*) c from content_vectors'),
+  vectors: count('select count(*) c from vectors_vec'),
+};
+
+// --- self-check: never hand the transport a known-inconsistent artifact ------
+// This is the local half of "verify, don't assume". The remote half (does the
+// receiver actually report these numbers afterwards) lives in ship-index.sh.
+const problems = [];
+// Absolute equality is deliberate here, NOT a before/after delta comparison (a
+// CR suggestion this rejects): post-GC, EVERY vec0 row must have a matching
+// content_vectors row and vice versa — that is the whole invariant. A delta
+// check would pass an index that merely removed as many orphans as it gained,
+// which is exactly the silently-wrong shape this script exists to prevent. The
+// orphans fixture proves equality is reachable from a source that starts unequal.
+if (stats.after.vectors !== stats.after.contentVectors) {
+  problems.push(
+    `vec0 rows (${stats.after.vectors}) != content_vectors rows (${stats.after.contentVectors}) — ` +
+    'orphan GC did not converge. If these differ, the hash_seq separator assumption ' +
+    "(hash + '_' + seq) is probably wrong for this qmd version.");
+}
+const strayDocs = db.prepare(
+  `select count(*) c from documents where collection not in (${placeholders})`).get(...keep).c;
+if (strayDocs !== 0) problems.push(`${strayDocs} document(s) outside the kept collections survived`);
+const strayCols = db.prepare(
+  `select count(*) c from store_collections where name not in (${placeholders})`).get(...keep).c;
+if (strayCols !== 0) problems.push(`${strayCols} collection row(s) outside the kept set survived`);
+// NOT EXISTS here too — with the NOT IN form this check would report zero
+// orphans for the very same NULL-hash reason that caused them, confirming a
+// broken reconcile as clean.
+const orphanContent = count(
+  'select count(*) c from content where not exists (select 1 from documents d where d.hash = content.hash)');
+if (orphanContent !== 0) problems.push(`${orphanContent} orphan content row(s) survived`);
+
+stats.sizeBytes = statSync(workPath).size;
+db.close();
+
+if (problems.length) {
+  process.stderr.write('ERR prepare-ship-index: staging index failed its self-check:\n');
+  for (const p of problems) process.stderr.write(`    - ${p}\n`);
+  process.stderr.write('    Refusing to hand a known-inconsistent index to the transport.\n');
+  if (asJson) process.stdout.write(JSON.stringify({ ...stats, ok: false, problems }) + '\n');
+  // process.exitCode, NOT process.exit(5): an immediate exit can truncate a
+  // stdout write that has not flushed yet, and the JSON above is exactly what a
+  // caller parses to learn WHY the build failed. Setting the code lets node
+  // drain and exit naturally. The exit hook still discards the work file (and
+  // its sidecars), so a failed build leaves any previous --out artifact intact.
+  process.exitCode = 5;
+} else {
+
+// PROMOTE: everything succeeded, so the verified artifact becomes --out. Only
+// now is any previous artifact at that path replaced.
+try {
+  // renameSync alone for the MAIN file — no rmSync first. fs.renameSync
+  // atomically REPLACES an existing destination (Windows included, Node 10+),
+  // so pre-deleting only opens a window where a failing rename leaves the
+  // operator with neither the old artifact nor the new one.
+  renameSync(workPath, out);
+  promoted = true;
+  // The sidecars are NOT covered by that atomic replace. Any -wal/-shm left
+  // beside the OLD artifact now belongs to a database that no longer exists at
+  // this path; SQLite would find it and try to use it. Remove those, then move
+  // ours across if the build produced any (a clean close usually checkpoints
+  // them away, so their absence is normal).
+  for (const s of sidecars(out)) rmQuiet(s);
+  for (const s of sidecars(workPath)) {
+    if (existsSync(s)) {
+      try { renameSync(s, s.replace(workPath, out)); } catch { rmQuiet(s); }
+    }
+  }
+} catch (e) {
+  die(4, `could not promote the verified staging index to ${out}: ${e.message}`);
+}
+
+if (asJson) {
+  process.stdout.write(JSON.stringify({ ...stats, ok: true }) + '\n');
+} else {
+  const mb = (n) => (n / 1024 / 1024).toFixed(1) + 'MB';
+  process.stdout.write(
+    `prepare-ship-index: OK\n` +
+    `  kept collections : ${keep.join(', ')}\n` +
+    `  dropped          : ${stats.droppedCollections.join(', ') || '(none)'}\n` +
+    `  documents        : ${stats.before.documents} -> ${stats.after.documents}\n` +
+    `  content          : ${stats.before.content} -> ${stats.after.content}\n` +
+    `  content_vectors  : ${stats.before.contentVectors} -> ${stats.after.contentVectors}\n` +
+    `  vectors_vec      : ${stats.before.vectors} -> ${stats.after.vectors}\n` +
+    `  staging size     : ${mb(stats.sizeBytes)}\n` +
+    `  staging path     : ${out}\n`);
+  }
+}

--- a/scripts/luna/ship-index-remote.ps1
+++ b/scripts/luna/ship-index-remote.ps1
@@ -1,0 +1,243 @@
+# ASCII-ONLY, deliberately. This file is UTF-8 on disk, but Windows PowerShell
+# 5.1 reads a BOM-less script using the ANSI codepage: a UTF-8 em dash
+# (E2 80 94) decodes to the three chars a-circumflex, euro, and RIGHT DOUBLE
+# QUOTATION MARK -- and PowerShell accepts that curly quote AS A STRING
+# DELIMITER. One em dash inside a double-quoted string therefore desyncs every
+# quote after it and the whole script fails to parse. Verified: 18 em dashes
+# produced 4 parse errors and the receiver would not have run at all. Same rule
+# the cadence emitters already follow for their .bat files. Keep it ASCII.
+#
+# ship-index-remote.ps1 -- the RECEIVER half of the qmd index ship (HIMMEL-1275).
+#
+# Runs ON the receiving machine (win2). scripts/luna/ship-index.sh copies this
+# file over alongside the staged index and invokes it. It is a FILE, not an
+# inline `ssh host 'powershell -Command "..."'` string, on purpose: the quoting
+# that survives Git-Bash -> ssh -> cmd.exe -> powershell is
+# `ssh host 'powershell -NoProfile -Command "..."'` and a nested `\"` inside
+# that breaks cmd parsing outright. Anything with real logic in it therefore
+# belongs in a script file, not in the command line.
+#
+# Contract: prints one `SHIP-REMOTE: <key>=<value>` line per step so the caller
+# can parse a machine-readable result, and exits non-zero on any failure.
+#
+# Exit codes:
+#   0  swapped + daemon restarted + verified
+#   1  usage / staged file missing or implausible
+#   2  daemon stop failed
+#   3  swap failed (previous index left in place)
+#   4  daemon restart failed (index WAS swapped -- say so loudly)
+#   5  post-swap verify failed (vectors lag lex, or qmd unusable)
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Staged,   # incoming index (already uploaded)
+    [Parameter(Mandatory = $true)][string]$Target,   # live index path to replace
+    [int]$ExpectDocs = -1,                            # from the sender's stats
+    [int]$ExpectVectors = -1,
+    [switch]$NoRestart                                # leave the daemon down (debug)
+)
+
+$ErrorActionPreference = 'Stop'
+function Emit($k, $v) { Write-Output "SHIP-REMOTE: $k=$v" }
+
+# Write to stderr DIRECTLY, not via Write-Error (CR finding [codex-1], verified
+# by hand). Under $ErrorActionPreference='Stop', Write-Error raises a
+# TERMINATING error, so the following `exit $code` never runs and the script
+# dies with PowerShell's generic status 1 instead. That silently collapses every
+# stage-specific code in the contract above into "1" -- and the distinction it
+# destroys is the one that matters most after a failure: 3 means the index was
+# NOT swapped, 4 means it WAS. Measured: the Write-Error form exits 1 where this
+# form exits 5. A terminating error would also be swallowed by the enclosing
+# try/catch blocks below and re-reported as the wrong stage.
+function Fail($code, $msg) {
+    [Console]::Error.WriteLine("ship-index-remote: $msg")
+    exit $code
+}
+
+# Bring the qmd daemon back up, WMI-parented so it outlives the ssh session.
+# Returns the new PID, or $null. Used BOTH on the success path and on the
+# swap-failure path -- a failed ship must not leave the receiver's search
+# service DOWN just because the swap did not happen (CR finding [codex-1]).
+function Start-QmdDaemon {
+    $qmd = (Get-Command qmd -ErrorAction SilentlyContinue).Source
+    if (-not $qmd) { return $null }
+    $r = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{ CommandLine = "`"$qmd`" mcp --keep-models" }
+    if ($r.ReturnValue -ne 0) { return $null }
+    return $r.ProcessId
+}
+
+if (-not (Test-Path -LiteralPath $Staged)) { Fail 1 "staged index not found: $Staged" }
+$stagedSize = (Get-Item -LiteralPath $Staged).Length
+# A truncated/partial upload is the failure mode that would otherwise be
+# discovered only by a broken search days later. 50MB is far below any real
+# index and far above any plausible stub.
+if ($stagedSize -lt 50MB) { Fail 1 "staged index is implausibly small ($stagedSize bytes) -- refusing to swap in a likely-truncated upload" }
+Emit 'staged_bytes' $stagedSize
+
+# --- 1. Stop the qmd daemon --------------------------------------------------
+# The daemon is BUN, not node. A node-only filter both misses it and matches
+# dozens of unrelated processes (this box runs ~40 node.exe). Match on the
+# executable AND require the command line to mention qmd, so an unrelated bun
+# process is left alone.
+$stopped = @()
+try {
+    # -ErrorAction Stop, NOT SilentlyContinue: a FAILED enumeration would
+    # otherwise be indistinguishable from "no daemon is running", and we would
+    # go on to swap a file the daemon still holds open.
+    $procs = Get-CimInstance Win32_Process -Filter "Name = 'bun.exe'" -ErrorAction Stop
+    foreach ($p in $procs) {
+        if ($p.CommandLine -and $p.CommandLine -match 'qmd') {
+            Stop-Process -Id $p.ProcessId -Force -ErrorAction Stop
+            $stopped += $p.ProcessId
+        }
+    }
+} catch {
+    # Report what we DID stop before failing. A partial stop otherwise leaves the
+    # operator unable to tell whether a daemon needs restarting by hand.
+    Emit 'stopped_before_failure' ($(if ($stopped.Count) { $stopped -join ',' } else { 'none' }))
+    Fail 2 "failed to stop the qmd daemon: $($_.Exception.Message)"
+}
+Emit 'stopped_pids' ($(if ($stopped.Count) { $stopped -join ',' } else { 'none' }))
+
+# Give the OS a moment to release the file handles before the swap; a swap
+# against a still-mapped SQLite file fails with a sharing violation.
+if ($stopped.Count -gt 0) { Start-Sleep -Seconds 3 }
+
+# --- 2. Swap ------------------------------------------------------------------
+# The previous index moves aside to .preship FIRST, so a failed move-in can be
+# rolled back. It is REAPED below on success and on failure -- two stale copies
+# (365MB + 221MB) once sat here for days.
+$preship = "$Target.preship"
+# Refuse a self-swap BEFORE anything moves. If -Staged resolves to the live
+# index (or to the recovery copy), the move sequence would shuffle a file onto
+# itself and could destroy the only copy. Compare normalized full paths, since
+# the two can be spelled differently and still be the same file.
+$normStaged = [System.IO.Path]::GetFullPath($Staged)
+$normTarget = [System.IO.Path]::GetFullPath($Target)
+$normPreship = [System.IO.Path]::GetFullPath($preship)
+if ($normStaged -ieq $normTarget) {
+    Fail 1 "staged index and target are the same file ($normTarget) -- refusing to swap a file onto itself"
+}
+if ($normStaged -ieq $normPreship) {
+    Fail 1 "staged index is the recovery copy ($normPreship) -- refusing to swap, this would destroy the rollback"
+}
+$rolledBack = $false
+try {
+    if (Test-Path -LiteralPath $preship) { Remove-Item -LiteralPath $preship -Force }
+    if (Test-Path -LiteralPath $Target) { Move-Item -LiteralPath $Target -Destination $preship -Force }
+    # Retire the OUTGOING index's -wal/-shm sidecars. Moving only the main file
+    # would leave journals belonging to the PREVIOUS database sitting exactly
+    # where SQLite looks for the new one's -- it would attach them to the freshly
+    # shipped index. The uploaded file arrives as a single artifact with no
+    # sidecars of its own (prepare-ship-index checkpoints on close), so removing
+    # is right here; there is nothing to carry across.
+    foreach ($sfx in @('-wal', '-shm')) {
+        $side = "$Target$sfx"
+        if (Test-Path -LiteralPath $side) { Remove-Item -LiteralPath $side -Force }
+    }
+    Move-Item -LiteralPath $Staged -Destination $Target -Force
+} catch {
+    # Put the old index back rather than leaving the machine with none.
+    try {
+        if ((Test-Path -LiteralPath $preship) -and -not (Test-Path -LiteralPath $Target)) {
+            Move-Item -LiteralPath $preship -Destination $Target -Force
+            $rolledBack = $true
+        }
+    } catch {
+        # Surface it. A silently-swallowed rollback failure is the difference
+        # between "the swap failed, your old index is back" and "the swap failed
+        # and the machine now has NO index" -- the operator must be told which.
+        Write-Warning "ROLLBACK FAILED -- the receiver may have no index at ${Target}: $($_.Exception.Message)"
+    }
+    Emit 'rolled_back' $rolledBack
+    # We stopped the daemon before the swap. Bailing out now without restarting
+    # would leave the receiver with its ORIGINAL index restored but its search
+    # service DOWN -- a failed ship silently taking the machine offline for
+    # search, which is worse than the failed ship itself. Restart before exiting
+    # (best effort, and reported either way).
+    if (-not $NoRestart -and $stopped.Count -gt 0) {
+        $backPid = $null
+        try { $backPid = Start-QmdDaemon } catch { }
+        Emit 'restarted_after_failure' $(if ($backPid) { $backPid } else { 'FAILED' })
+    }
+    Fail 3 "swap failed: $($_.Exception.Message)"
+}
+Emit 'swapped' 'yes'
+
+# Reap the pre-ship copy immediately on the success path. Keeping it "just in
+# case" is exactly how the stale copies accumulated.
+# Report what ACTUALLY happened: an unconditional 'yes' here would mask a
+# failed delete and re-create the stale-copy problem this reap exists to solve,
+# while the caller's log claimed it was handled.
+try {
+    if (Test-Path -LiteralPath $preship) { Remove-Item -LiteralPath $preship -Force }
+    Emit 'preship_reaped' 'yes'
+} catch {
+    Write-Warning "could not remove the pre-ship index at ${preship}: $($_.Exception.Message)"
+    Emit 'preship_reaped' 'no'
+}
+
+# --- 3. Restart the daemon, WMI-parented -------------------------------------
+# Invoke-CimMethod Win32_Process Create, NOT Start-Process: a child of the ssh
+# session dies with the connection, so the daemon would silently vanish the
+# moment the ship script disconnects.
+if (-not $NoRestart) {
+    try {
+        $newPid = Start-QmdDaemon
+        if (-not $newPid) { Fail 4 'could not restart the qmd daemon (qmd missing from PATH, or Win32_Process Create failed) -- index WAS swapped' }
+        Emit 'restarted_pid' $newPid
+    } catch {
+        Fail 4 "daemon restart failed (index WAS swapped): $($_.Exception.Message)"
+    }
+    Start-Sleep -Seconds 3
+} else {
+    Emit 'restarted_pid' 'skipped'
+}
+
+# --- 4. Verify -- fail LOUD if vectors lag lex --------------------------------
+# This is the check that exists because win2 sat at 14,803 lex docs with ~5,200
+# vectors missing and answered semantic queries off that gap in silence.
+$statusText = ''
+# Drop to 'Continue' around the NATIVE call. Under 'Stop', anything qmd writes
+# to stderr -- including harmless progress noise -- is promoted to a TERMINATING
+# error by the `2>&1` merge, so a perfectly healthy status would abort the
+# verification on a machine whose index was just replaced. We still want the
+# stderr text (it goes into the failure message), hence the merge; we just do
+# not want its mere presence to be fatal. $LASTEXITCODE below is the real signal.
+$prevEap = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try { $statusText = (& qmd status 2>&1 | Out-String) }
+catch { $ErrorActionPreference = $prevEap; Fail 5 "qmd status failed after swap: $($_.Exception.Message)" }
+$ErrorActionPreference = $prevEap
+# A native command's NON-ZERO EXIT does not throw, so the catch above never sees
+# it. Without this check a failing `qmd status` would fall through to the regex
+# parse, find nothing, and be reported as "could not parse" -- misdiagnosing a
+# broken qmd as a format change, on a machine whose index was just replaced.
+if ($LASTEXITCODE -ne 0) {
+    Fail 5 "qmd status exited $LASTEXITCODE after the swap -- the receiver's qmd is not usable.`n$statusText"
+}
+
+$docs = $null; $vecs = $null; $pending = 0
+if ($statusText -match 'Total:\s+(\d+)\s+files indexed') { $docs = [int]$Matches[1] }
+if ($statusText -match 'Vectors:\s+(\d+)\s+embedded') { $vecs = [int]$Matches[1] }
+if ($statusText -match 'Pending:\s+(\d+)\s+need embedding') { $pending = [int]$Matches[1] }
+
+Emit 'docs' $(if ($null -ne $docs) { $docs } else { 'unparsed' })
+Emit 'vectors' $(if ($null -ne $vecs) { $vecs } else { 'unparsed' })
+Emit 'pending' $pending
+
+if ($null -eq $docs -or $null -eq $vecs) {
+    Fail 5 "could not parse doc/vector counts from qmd status -- refusing to call the ship verified.`n$statusText"
+}
+if ($pending -gt 0) {
+    Fail 5 "$pending content hash(es) still need embedding after the swap -- vectors LAG lex. This is the silent-wrong state the ship exists to eliminate; the shipped artifact was not fully embedded at the source."
+}
+if ($ExpectVectors -ge 0 -and $vecs -ne $ExpectVectors) {
+    Fail 5 "vector count mismatch: receiver reports $vecs, sender shipped $ExpectVectors"
+}
+if ($ExpectDocs -ge 0 -and $docs -ne $ExpectDocs) {
+    Fail 5 "document count mismatch: receiver reports $docs, sender shipped $ExpectDocs"
+}
+
+Emit 'verified' 'ok'
+exit 0

--- a/scripts/luna/ship-index.sh
+++ b/scripts/luna/ship-index.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# ship-index.sh — build the qmd search index LOCALLY and ship the artifact to a
+# receiving machine (HIMMEL-1275).
+#
+# WHY: the receiver cannot BUILD its own substrate. Measured 2026-07-25, win2
+# embeds at ~5 docs/min vs ~256 docs/min locally (50x), so an in-place reindex
+# there was projected at ~17 HOURS and was killed mid-run. Any design that has
+# the receiver run `qmd embed` over the corpus is wrong. It RECEIVES, never
+# builds. Today the index and the graphify graph only reach it when a human
+# remembers to copy a file; this is that transport.
+#
+# SHAPE: a deterministic script, like scripts/luna/qmd-reindex.sh and
+# scripts/graphify/refresh-graph-map.sh — no claude session, no NUL stdin, no
+# settings fragment. HIMMEL-128 does not apply.
+#
+# THREE PARTS, each in the place it belongs:
+#   1. build     — scripts/luna/qmd-reindex.sh (HIMMEL-568). Reused, not
+#                  reimplemented: the ticket says ship AFTER a successful local
+#                  reindex, not on a blind clock. --no-reindex skips it.
+#   2. prepare   — scripts/luna/prepare-ship-index.mjs. Consistent copy via
+#                  SQLite's backup API, collection reconcile, vec0 orphan GC,
+#                  VACUUM, self-check. Node because Python's stdlib sqlite3
+#                  cannot load vec0 on these boxes.
+#   3. receive   — scripts/luna/ship-index-remote.ps1, copied over and run
+#                  THERE: daemon fence, swap, WMI-parented restart, verify,
+#                  .preship reap.
+#
+# COLLECTION RECONCILE POLICY: ship-only-what-the-RECEIVER-configures. The
+# receiver's own `qmd collection list` is the authority, so the ship can never
+# create an orphan collection there. It also never silently drops one the
+# receiver expects: prepare-ship-index.mjs REFUSES if the receiver asks for a
+# collection the source lacks. The local index is never modified.
+#
+# WHY NOT INLINE THE REMOTE LOGIC: the quoting that survives Git-Bash -> ssh ->
+# cmd.exe -> powershell is `ssh host 'powershell -NoProfile -Command "..."'`,
+# and a nested `\"` inside that breaks cmd parsing. So anything with real logic
+# goes over as a FILE and is invoked, rather than being escaped into a one-liner.
+#
+# GRAPH: ~/.graphify/global-graph.json rides the same transport (last hand-ported
+# 2026-07-13). This moves the machine-to-machine leg ONLY — HIMMEL-1129 owns
+# publishing the tracked graph, and nothing here reimplements that.
+#
+# Usage:
+#   bash scripts/luna/ship-index.sh [--host <ssh-host>] [--no-reindex]
+#       [--collections a,b] [--no-graph] [--keep-staging] [--dry-run]
+#
+#   --host <h>          ssh host to ship to            (default: win2)
+#   --no-reindex        skip the local qmd-reindex step (ship what exists)
+#   --collections a,b   override the receiver's set    (default: ask the receiver)
+#   --no-graph          do not ship the graphify graph
+#   --keep-staging      keep the local staging copy for inspection
+#   --dry-run           print the plan; build nothing, copy nothing, change nothing
+#
+# Exit codes:
+#   0  shipped + verified
+#   1  usage / input error
+#   2  local prerequisite unusable (ssh/scp/node/reindex/prepare script missing)
+#   3  local reindex failed  — nothing shipped
+#   4  prepare/staging failed — nothing shipped
+#   5  upload failed          — receiver untouched
+#   6  receiver-side failure  (see its SHIP-REMOTE output; it reports whether the
+#                              index was swapped before failing)
+#   7  graph leg failed       (index shipped OK — reported separately, non-fatal
+#                              to the index result but a non-zero overall exit)
+set -euo pipefail
+
+HOST="win2"
+DO_REINDEX=1
+DO_GRAPH=1
+KEEP_STAGING=0
+DRY_RUN=0
+COLLECTIONS=""
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REINDEX_SCRIPT="$HERE/qmd-reindex.sh"
+PREPARE_SCRIPT="$HERE/prepare-ship-index.mjs"
+REMOTE_SCRIPT="$HERE/ship-index-remote.ps1"
+
+LOCAL_INDEX="${QMD_INDEX_PATH:-$HOME/.cache/qmd/index.sqlite}"
+LOCAL_GRAPH="${GRAPHIFY_GRAPH_PATH:-$HOME/.graphify/global-graph.json}"
+# Remote paths are DERIVED from the receiver's own profile at run time, never
+# hardcoded. An absolute C:/Users/<name>/... default would (a) tie the script to
+# one operator's account, so it simply would not work for anyone else, and (b)
+# bake a personal home path into a file that propagates to the public repo.
+# Each is overridable for a non-standard layout.
+REMOTE_HOME=""                              # resolved in preflight (see below)
+REMOTE_INDEX="${SHIP_REMOTE_INDEX:-}"
+REMOTE_GRAPH="${SHIP_REMOTE_GRAPH:-}"
+REMOTE_TMP="${SHIP_REMOTE_TMP:-}"
+
+usage() {
+    cat <<'EOF'
+Usage: ship-index.sh [--host <ssh-host>] [--no-reindex] [--collections a,b]
+                     [--no-graph] [--keep-staging] [--dry-run]
+
+Build the qmd index LOCALLY and ship the artifact to a receiving machine that
+is too slow to build its own (win2 embeds ~50x slower; an in-place reindex
+there was measured at ~17 hours).
+
+The receiver's own `qmd collection list` decides what is shipped, so the ship
+can never create an orphan collection there; and it refuses outright if the
+receiver expects a collection the source does not have.
+
+Exit: 0 ok | 1 usage | 2 prereq | 3 reindex | 4 prepare | 5 upload
+      6 receiver | 7 graph leg
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --host)
+            if [ $# -lt 2 ] || [ -z "$2" ]; then
+                echo "ERR ship-index: --host requires a value" >&2; exit 1
+            fi
+            HOST="$2"; shift 2 ;;
+        --host=*)        HOST="${1#--host=}"; shift ;;
+        --collections)
+            if [ $# -lt 2 ] || [ -z "$2" ]; then
+                echo "ERR ship-index: --collections requires a value" >&2; exit 1
+            fi
+            COLLECTIONS="$2"; shift 2 ;;
+        --collections=*) COLLECTIONS="${1#--collections=}"; shift ;;
+        --no-reindex)    DO_REINDEX=0; shift ;;
+        --no-graph)      DO_GRAPH=0; shift ;;
+        --keep-staging)  KEEP_STAGING=1; shift ;;
+        --dry-run)       DRY_RUN=1; shift ;;
+        -h|--help)       usage; exit 0 ;;
+        *)
+            echo "ERR ship-index: unknown arg: $1" >&2
+            usage >&2
+            exit 1 ;;
+    esac
+done
+[ -n "$HOST" ] || { echo "ERR ship-index: --host resolved to empty" >&2; exit 1; }
+
+say() { printf 'ship-index: %s\n' "$*"; }
+die() { local c="$1"; shift; printf 'ERR ship-index: %s\n' "$*" >&2; exit "$c"; }
+
+# --- staging + cleanup -------------------------------------------------------
+# The staging copy is reaped on EVERY exit path, success or failure. Stale
+# pre-ship copies (365MB + 221MB) once sat on the receiver for days; the local
+# side must not repeat that.
+STAGING=""
+# shellcheck disable=SC2329,SC2317
+cleanup() {
+    if [ -n "$STAGING" ] && [ -f "$STAGING" ] && [ "$KEEP_STAGING" -eq 0 ]; then
+        rm -f "$STAGING" 2>/dev/null || true
+    elif [ -n "$STAGING" ] && [ -f "$STAGING" ]; then
+        printf 'ship-index: staging kept at %s (--keep-staging)\n' "$STAGING"
+    fi
+}
+trap cleanup EXIT
+
+# --- preflight ---------------------------------------------------------------
+for tool in ssh scp node; do
+    command -v "$tool" >/dev/null 2>&1 || die 2 "'$tool' not on PATH (required)"
+done
+[ -f "$PREPARE_SCRIPT" ] || die 2 "prepare-ship-index.mjs not found at $PREPARE_SCRIPT"
+[ -f "$REMOTE_SCRIPT" ]  || die 2 "ship-index-remote.ps1 not found at $REMOTE_SCRIPT"
+[ "$DO_REINDEX" -eq 0 ] || [ -f "$REINDEX_SCRIPT" ] || die 2 "qmd-reindex.sh not found at $REINDEX_SCRIPT"
+# The index-EXISTS check deliberately does NOT run here. On a first-ever run the
+# reindex step is what CREATES the index, so demanding it up front would fail
+# preflight on exactly the case the reindex exists to handle. With --no-reindex
+# there is nothing that could create it, so the check applies immediately.
+if [ "$DO_REINDEX" -eq 0 ] && [ ! -f "$LOCAL_INDEX" ]; then
+    die 2 "local qmd index not found at $LOCAL_INDEX and --no-reindex was given (set QMD_INDEX_PATH, or drop --no-reindex to build it)"
+fi
+
+# --- receiver's collection set ----------------------------------------------
+# The RECEIVER is the authority on what it carries (ship-only-what-it-configures).
+# An explicit --collections overrides, for the case where the receiver's qmd is
+# down and the operator knows the intended set.
+# Ask the RECEIVER where its own profile is, and derive the paths from that.
+# Forward slashes throughout: they are what PowerShell, scp targets and the
+# receiver script all accept, and they avoid a second layer of backslash
+# escaping through ssh.
+resolve_remote_paths() {
+    if [ -n "$REMOTE_INDEX" ] && [ -n "$REMOTE_GRAPH" ] && [ -n "$REMOTE_TMP" ]; then
+        return 0   # fully overridden by the caller; nothing to resolve
+    fi
+    # `|| true`: under `set -o pipefail` a failing ssh makes the whole pipeline
+    # fail, and `set -e` would abort the script right here with rc=1 — before the
+    # explicit, explanatory die below could run. Swallow the status and let the
+    # emptiness check produce the real diagnosis and exit code.
+    REMOTE_HOME="$(ssh "$HOST" 'powershell -NoProfile -Command "$env:USERPROFILE"' 2>/dev/null \
+        | tr -d '\r' | head -1 | sed 's|\\|/|g' || true)"
+    if [ -z "$REMOTE_HOME" ]; then
+        die 2 "could not resolve the remote user profile on '$HOST' (ssh or powershell unavailable there). Set SHIP_REMOTE_INDEX / SHIP_REMOTE_GRAPH / SHIP_REMOTE_TMP to override."
+    fi
+    REMOTE_INDEX="${REMOTE_INDEX:-$REMOTE_HOME/.cache/qmd/index.sqlite}"
+    REMOTE_GRAPH="${REMOTE_GRAPH:-$REMOTE_HOME/.graphify/global-graph.json}"
+    REMOTE_TMP="${REMOTE_TMP:-$REMOTE_HOME/AppData/Local/Temp}"
+}
+
+remote_collections() {
+    ssh "$HOST" 'qmd collection list' 2>/dev/null \
+        | sed 's/\r$//' \
+        | awk '{print $1}' \
+        | grep -E '^[A-Za-z0-9._-]+$' \
+        | sort -u \
+        | paste -sd, - || true
+}
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    say "DRY RUN — nothing will be built, copied, or changed"
+    say "  host              : $HOST"
+    say "  local index       : $LOCAL_INDEX"
+    # Report the EXPLICIT override when one is set, rather than always claiming
+    # the value will be derived — a dry-run that misreports its own plan is
+    # worse than no dry-run. (And no backslash before the apostrophe: inside
+    # double quotes `\'` is not an escape, it prints a literal backslash.)
+    if [ -n "$REMOTE_INDEX" ]; then
+        say "  remote index      : $REMOTE_INDEX (SHIP_REMOTE_INDEX override)"
+    else
+        say "  remote index      : (derived from the receiver's USERPROFILE at run time)"
+    fi
+    say "  reindex first     : $([ "$DO_REINDEX" -eq 1 ] && echo yes || echo no)"
+    say "  ship graph        : $([ "$DO_GRAPH" -eq 1 ] && echo yes || echo no)"
+    if [ -n "$COLLECTIONS" ]; then
+        say "  collections       : $COLLECTIONS (explicit override)"
+    else
+        say "  collections       : (would query the receiver's 'qmd collection list')"
+    fi
+    say "  would run         : $REINDEX_SCRIPT"
+    say "  would run         : node $PREPARE_SCRIPT --src $LOCAL_INDEX --out <staging> --collections <set>"
+    say "  would upload      : <staging> -> $HOST:$REMOTE_TMP/qmd-index.incoming.sqlite"
+    say "  would upload      : $REMOTE_SCRIPT -> $HOST:$REMOTE_TMP/ship-index-remote.ps1"
+    say "  would run THERE   : ship-index-remote.ps1 (daemon fence -> swap -> WMI restart -> verify -> reap)"
+    say "dry-run complete (no changes made)"
+    exit 0
+fi
+
+# --- 1. build local ----------------------------------------------------------
+if [ "$DO_REINDEX" -eq 1 ]; then
+    say "[1/5] local reindex (qmd-reindex.sh)"
+    bash "$REINDEX_SCRIPT" || die 3 "local reindex failed — NOTHING shipped (the receiver keeps its current index)"
+else
+    say "[1/5] local reindex SKIPPED (--no-reindex) — shipping the index as it stands"
+fi
+# Now the index must exist, whether it was just built or was already there.
+[ -f "$LOCAL_INDEX" ] || die 3 "local qmd index still not present at $LOCAL_INDEX after the build step — NOTHING shipped"
+
+# --- 2. resolve the receiver's collection set --------------------------------
+say "[2/5] resolving the receiver's paths + collection set"
+resolve_remote_paths
+say "      receiver index: $REMOTE_INDEX"
+if [ -z "$COLLECTIONS" ]; then
+    COLLECTIONS="$(remote_collections)"
+    [ -n "$COLLECTIONS" ] || die 2 \
+        "could not read '$HOST' collections (ssh or qmd unavailable there). Pass --collections explicitly if you know the intended set."
+    say "      receiver configures: $COLLECTIONS"
+else
+    say "      using explicit override: $COLLECTIONS"
+fi
+
+# --- 3. prepare the artifact -------------------------------------------------
+say "[3/5] preparing the shippable artifact (reconcile + vec0 GC + VACUUM)"
+STAGING="$(mktemp -t qmd-ship.XXXXXX)"
+rm -f "$STAGING"
+STAGING="$STAGING.sqlite"
+
+PREP_JSON=""
+PREP_JSON="$(node "$PREPARE_SCRIPT" --src "$LOCAL_INDEX" --out "$STAGING" --collections "$COLLECTIONS" --json)" \
+    || die 4 "prepare-ship-index failed — NOTHING shipped"
+
+SHIP_DOCS="$(printf '%s' "$PREP_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(String(JSON.parse(s).after.documents))}catch{process.stdout.write("-1")}})')"
+SHIP_VECS="$(printf '%s' "$PREP_JSON" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(String(JSON.parse(s).after.vectors))}catch{process.stdout.write("-1")}})')"
+
+# A parse failure must NOT sail through as a usable count. The receiver treats a
+# NEGATIVE expectation as "skip this check", so an unparsed "-1" would silently
+# DISABLE the post-swap doc/vector verification — turning the one guard against
+# shipping a wrong index into a no-op, quietly. Demand plain non-negative
+# integers and fail the prepare stage instead.
+case "$SHIP_DOCS" in ''|*[!0-9]*) die 4 "prepare-ship-index returned an unusable document count ('$SHIP_DOCS') — refusing to ship with the post-swap verification disabled" ;; esac
+case "$SHIP_VECS" in ''|*[!0-9]*) die 4 "prepare-ship-index returned an unusable vector count ('$SHIP_VECS') — refusing to ship with the post-swap verification disabled" ;; esac
+say "      staged: ${SHIP_DOCS} documents / ${SHIP_VECS} vectors"
+
+# --- 4. upload ---------------------------------------------------------------
+say "[4/5] uploading to $HOST"
+# PER-INVOCATION remote paths. Fixed names would have two concurrent ships
+# overwriting each other's upload mid-flight — and the loser would swap in a
+# file that is half the other run's index. $$ plus the epoch is enough to
+# separate runs; the receiver script removes its own staged file when it swaps.
+RUN_TAG="$$-$(date +%s 2>/dev/null || echo 0)"
+REMOTE_STAGED="$REMOTE_TMP/qmd-index.incoming.$RUN_TAG.sqlite"
+REMOTE_PS1="$REMOTE_TMP/ship-index-remote.$RUN_TAG.ps1"
+scp -q "$STAGING" "$HOST:$REMOTE_STAGED" || die 5 "upload of the index failed — receiver untouched"
+if ! scp -q "$REMOTE_SCRIPT" "$HOST:$REMOTE_PS1"; then
+    # The INDEX upload already succeeded, so a ~400MB staged file is sitting on
+    # the receiver with nothing left to consume it. Reap it rather than leaving
+    # the exact stale-copy litter this transport is meant to stop producing.
+    # shellcheck disable=SC2029  # client-side expansion is intended (path resolved here)
+    ssh "$HOST" "cmd /c del /q \"${REMOTE_STAGED//\//\\}\"" >/dev/null 2>&1 || true
+    die 5 "upload of the receiver script failed — receiver untouched (staged index reaped)"
+fi
+
+# --- 5. receive (fence -> swap -> restart -> verify -> reap) -----------------
+say "[5/5] running the receiver-side swap on $HOST"
+# Single-quoted OUTER, double-quoted INNER — the one quoting shape that survives
+# Git-Bash -> ssh -> cmd.exe -> powershell. No nested \" anywhere.
+remote_rc=0
+# shellcheck disable=SC2029  # client-side expansion is INTENDED: the paths and
+# counts are resolved HERE and baked into the command the receiver runs.
+ssh "$HOST" "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS1\" -Staged \"$REMOTE_STAGED\" -Target \"$REMOTE_INDEX\" -ExpectDocs $SHIP_DOCS -ExpectVectors $SHIP_VECS" || remote_rc=$?
+if [ "$remote_rc" -ne 0 ]; then
+    # Best-effort: do not leave this run's per-invocation artifacts behind on the
+    # receiver. A failed swap already left its own state; the uploads are ours.
+    # shellcheck disable=SC2029  # client-side expansion is intended (paths resolved here)
+    ssh "$HOST" "cmd /c del /q \"${REMOTE_STAGED//\//\\}\" \"${REMOTE_PS1//\//\\}\"" >/dev/null 2>&1 || true
+    die 6 "receiver-side ship failed (rc=$remote_rc). Its SHIP-REMOTE output above states whether the index was swapped before the failure."
+fi
+# On success the receiver consumed the staged index (it was MOVED into place);
+# only our copy of the script needs reaping.
+# shellcheck disable=SC2029  # client-side expansion is intended (path resolved here)
+ssh "$HOST" "cmd /c del /q \"${REMOTE_PS1//\//\\}\"" >/dev/null 2>&1 || true
+
+say "index shipped + verified on $HOST (${SHIP_DOCS} docs / ${SHIP_VECS} vectors)"
+
+# --- graph leg ---------------------------------------------------------------
+# Transport only. HIMMEL-1129 owns publishing the tracked graph; this never
+# generates or publishes one, it moves whatever already exists.
+graph_rc=0
+if [ "$DO_GRAPH" -eq 1 ]; then
+    if [ -f "$LOCAL_GRAPH" ]; then
+        say "shipping the graphify graph ($(wc -c < "$LOCAL_GRAPH" | tr -d ' ') bytes)"
+        ssh "$HOST" 'powershell -NoProfile -Command "New-Item -ItemType Directory -Force -Path $env:USERPROFILE\.graphify | Out-Null"' >/dev/null 2>&1 || true
+        if scp -q "$LOCAL_GRAPH" "$HOST:$REMOTE_GRAPH"; then
+            say "graph shipped"
+        else
+            echo "WARN ship-index: graph upload failed (the INDEX shipped fine)" >&2
+            graph_rc=7
+        fi
+    else
+        say "no local graph at $LOCAL_GRAPH — graph leg skipped"
+    fi
+fi
+
+exit "$graph_rc"

--- a/scripts/luna/test-prepare-ship-index.sh
+++ b/scripts/luna/test-prepare-ship-index.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+# Tests for scripts/luna/prepare-ship-index.mjs (HIMMEL-1275).
+#
+# Builds REAL fixture qmd-shaped SQLite databases (schema + the documents_ad FTS
+# trigger + a vec0 virtual table) and runs the real script against them, so the
+# reconcile rules and the vec0 orphan GC are exercised for real rather than
+# asserted textually. Needs NO second machine and NO network — the transport
+# half is not touched here.
+#
+# SKIPS (cleanly, rc 0) when better-sqlite3 or vec0 cannot be loaded on this
+# host: those come from the qmd fork checkout, not from this repo, so a bare CI
+# runner legitimately lacks them. A skip prints why — it never reads as a pass
+# of assertions that did not run.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/prepare-ship-index.mjs"
+
+PASS=0
+FAIL=0
+TMP_ROOT=""
+
+# shellcheck disable=SC2329,SC2317
+cleanup() {
+    if [ -n "$TMP_ROOT" ] && [ -d "$TMP_ROOT" ]; then
+        rm -rf "$TMP_ROOT" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; if [ $# -ge 2 ]; then printf '    %s\n' "$2"; fi; FAIL=$((FAIL+1)); }
+assert_eq() {
+    local name="$1" want="$2" got="$3"
+    if [ "$want" = "$got" ]; then pass "$name"; else fail "$name" "expected '$want', got '$got'"; fi
+}
+assert_contains() {
+    local name="$1" needle="$2" haystack="$3"
+    # here-string, not `printf | grep -q` (HIMMEL-1115 pipefail false-negative)
+    if grep -qF -- "$needle" <<<"$haystack"; then pass "$name"; else fail "$name" "missing: $needle"; fi
+}
+assert_rc() {
+    local name="$1" want="$2" got="$3"
+    if [ "$got" = "$want" ]; then pass "$name"; else fail "$name" "expected rc=$want, got rc=$got"; fi
+}
+summary() {
+    echo
+    echo "===================================="
+    echo "test summary: $PASS passed, $FAIL failed"
+    echo "===================================="
+    [ "$FAIL" -gt 0 ] && exit 1 || exit 0
+}
+
+command -v node >/dev/null 2>&1 || { echo "SKIP: node not on PATH"; exit 0; }
+
+TMP_ROOT=$(mktemp -d)
+
+# --- dependency probe --------------------------------------------------------
+# Resolve better-sqlite3 + vec0 the SAME way the script under test does, so a
+# skip here means the script genuinely cannot run on this host.
+PROBE="$TMP_ROOT/probe.mjs"
+cat >"$PROBE" <<'PROBE_EOF'
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+const require = createRequire(import.meta.url);
+const bs3 = [process.env.HIMMEL_BETTER_SQLITE3,
+  `${homedir()}/.himmel/qmd-fork/node_modules/better-sqlite3`,
+  `${homedir()}/Documents/github/qmd/node_modules/better-sqlite3`].filter(Boolean);
+let D = null, used = '';
+for (const c of bs3) { try { D = require(c); used = c; break; } catch {} }
+if (!D) { console.log('NO_BS3'); process.exit(0); }
+// Per-platform sqlite-vec package + library name, mirroring the script under
+// test. A Windows-only list makes every POSIX host report "vec0 unavailable".
+const pkgs = process.platform === 'win32' ? [['sqlite-vec-windows-x64','vec0.dll']]
+  : process.platform === 'darwin' ? [['sqlite-vec-darwin-arm64','vec0.dylib'],['sqlite-vec-darwin-x64','vec0.dylib']]
+  : [['sqlite-vec-linux-x64','vec0.so'],['sqlite-vec-linux-arm64','vec0.so']];
+const roots = [`${homedir()}/.himmel/qmd-fork/node_modules`,
+  `${homedir()}/Documents/github/qmd/node_modules`,
+  `${homedir()}/.bun/install/global/node_modules`];
+const vecs = [process.env.HIMMEL_VEC0, ...roots.flatMap(r=>pkgs.map(([k,l])=>`${r}/${k}/${l}`))].filter(Boolean);
+const db = new D(':memory:');
+let ok = '';
+for (const c of vecs) { if (!existsSync(c)) continue; try { db.loadExtension(c); ok = c; break; } catch {} }
+db.close();
+console.log(ok ? 'OK ' + used + ' ' + ok : 'NO_VEC0');
+PROBE_EOF
+probe_out="$(node "$PROBE" 2>&1 || true)"
+case "$probe_out" in
+    NO_BS3*)  echo "SKIP: better-sqlite3 unavailable on this host (qmd fork not installed) — $probe_out"; exit 0 ;;
+    NO_VEC0*) echo "SKIP: vec0 extension unavailable on this host — $probe_out"; exit 0 ;;
+    OK*)      echo "deps OK: $probe_out" ;;
+    *)        echo "SKIP: dependency probe inconclusive: $probe_out"; exit 0 ;;
+esac
+
+# --- fixture builder ---------------------------------------------------------
+# Mirrors the real qmd schema closely enough to exercise every rule under test:
+# the documents_ad FTS trigger, content shared across collections, and a vec0
+# table keyed by "<hash>_<seq>".
+MKFIX="$TMP_ROOT/mkfix.mjs"
+cat >"$MKFIX" <<'FIX_EOF'
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+const require = createRequire(import.meta.url);
+const out = process.argv[2];
+const mode = process.argv[3] || 'normal';
+const bs3 = [process.env.HIMMEL_BETTER_SQLITE3,
+  `${homedir()}/.himmel/qmd-fork/node_modules/better-sqlite3`,
+  `${homedir()}/Documents/github/qmd/node_modules/better-sqlite3`].filter(Boolean);
+let D = null; for (const c of bs3) { try { D = require(c); break; } catch {} }
+// Per-platform sqlite-vec package + library name, mirroring the script under
+// test. A Windows-only list makes every POSIX host report "vec0 unavailable".
+const pkgs = process.platform === 'win32' ? [['sqlite-vec-windows-x64','vec0.dll']]
+  : process.platform === 'darwin' ? [['sqlite-vec-darwin-arm64','vec0.dylib'],['sqlite-vec-darwin-x64','vec0.dylib']]
+  : [['sqlite-vec-linux-x64','vec0.so'],['sqlite-vec-linux-arm64','vec0.so']];
+const roots = [`${homedir()}/.himmel/qmd-fork/node_modules`,
+  `${homedir()}/Documents/github/qmd/node_modules`,
+  `${homedir()}/.bun/install/global/node_modules`];
+const vecs = [process.env.HIMMEL_VEC0, ...roots.flatMap(r=>pkgs.map(([k,l])=>`${r}/${k}/${l}`))].filter(Boolean);
+const db = new D(out);
+for (const c of vecs) { if (existsSync(c)) { try { db.loadExtension(c); break; } catch {} } }
+
+db.exec(`
+CREATE TABLE store_collections(name TEXT PRIMARY KEY, path TEXT, pattern TEXT,
+  ignore_patterns TEXT, include_by_default INTEGER, update_command TEXT, context TEXT);
+CREATE TABLE documents(id INTEGER PRIMARY KEY, collection TEXT, path TEXT, title TEXT,
+  hash TEXT, created_at TEXT, modified_at TEXT, active INTEGER, disk_mtime TEXT);
+CREATE TABLE content(hash TEXT PRIMARY KEY, doc TEXT, created_at TEXT);
+CREATE TABLE content_vectors(hash TEXT, seq INTEGER, pos INTEGER, model TEXT,
+  embedded_at TEXT, embed_fingerprint TEXT, total_chunks INTEGER, PRIMARY KEY(hash, seq));
+CREATE VIRTUAL TABLE documents_fts USING fts5(filepath, title, body, tokenize='porter unicode61');
+CREATE VIRTUAL TABLE vectors_vec USING vec0(hash_seq TEXT PRIMARY KEY, embedding float[4] distance_metric=cosine);
+CREATE TRIGGER documents_ai AFTER INSERT ON documents WHEN new.active = 1 BEGIN
+  INSERT INTO documents_fts(rowid, filepath, title, body)
+  SELECT new.id, new.collection || '/' || new.path, new.title,
+         (SELECT doc FROM content WHERE hash = new.hash) WHERE new.active = 1;
+END;
+CREATE TRIGGER documents_ad AFTER DELETE ON documents BEGIN
+  DELETE FROM documents_fts WHERE rowid = old.id;
+END;
+`);
+
+const cols = ['himmel', 'luna', 'salus', 'luna-curated'];
+const insCol = db.prepare('INSERT INTO store_collections(name,path,pattern) VALUES (?,?,?)');
+for (const c of cols) insCol.run(c, '/x/' + c, '**/*.md');
+
+const insContent = db.prepare('INSERT OR IGNORE INTO content(hash,doc,created_at) VALUES (?,?,?)');
+const insDoc = db.prepare('INSERT INTO documents(id,collection,path,title,hash,active) VALUES (?,?,?,?,?,1)');
+const insCV = db.prepare('INSERT INTO content_vectors(hash,seq,pos,model,total_chunks) VALUES (?,?,?,?,?)');
+const insVec = db.prepare('INSERT INTO vectors_vec(hash_seq, embedding) VALUES (?, ?)');
+const emb = () => new Float32Array([0.1, 0.2, 0.3, 0.4]);
+
+// h_shared is referenced by BOTH luna and luna-curated — the shared-content
+// case that a naive "delete content of dropped collections" would break.
+let id = 1;
+const rows = [
+  ['himmel', 'a.md', 'h_himmel'],
+  ['luna', 'b.md', 'h_shared'],
+  ['luna-curated', 'b.md', 'h_shared'],
+  ['salus', 'c.md', 'h_salus'],
+  ['luna-curated', 'd.md', 'h_curated_only'],
+];
+for (const [col, path, hash] of rows) {
+  insContent.run(hash, 'body of ' + hash, '2026-01-01');
+  insDoc.run(id++, col, path, 'T ' + path, hash);
+}
+for (const hash of ['h_himmel', 'h_shared', 'h_salus', 'h_curated_only']) {
+  for (let s = 0; s < 2; s++) {
+    insCV.run(hash, s, s, 'm', 2);
+    insVec.run(hash + '_' + s, emb());
+  }
+}
+
+if (mode === 'nullhash') {
+  // ONE document row with a NULL hash. Under the old `NOT IN (SELECT hash FROM
+  // documents)` predicate this makes the whole orphan-content delete evaluate to
+  // NULL for every row — deleting NOTHING — and the self-check used the same
+  // predicate, so it reported clean. A single NULL silently disabled the entire
+  // orphan cleanup while claiming success.
+  insDoc.run(id++, 'luna', 'nullish.md', 'T nullish', null);
+}
+
+if (mode === 'orphans') {
+  // Pre-existing vec0 orphans with NO content_vectors row — the 22,895-row
+  // situation that was GC'd by hand on 2026-07-23. These must be gone after.
+  for (let s = 0; s < 3; s++) insVec.run('h_ghost_' + s, emb());
+}
+db.close();
+console.log('fixture written: ' + out + ' (' + mode + ')');
+FIX_EOF
+
+mkfix() { node "$MKFIX" "$1" "${2:-normal}" >/dev/null; }
+q() {
+  node -e '
+  const {createRequire}=require("module");const req=createRequire(process.cwd()+"/x.js");
+  const os=require("os");
+  const cands=[process.env.HIMMEL_BETTER_SQLITE3,
+    os.homedir()+"/.himmel/qmd-fork/node_modules/better-sqlite3",
+    os.homedir()+"/Documents/github/qmd/node_modules/better-sqlite3"].filter(Boolean);
+  let D=null;for(const c of cands){try{D=req(c);break;}catch{}}
+  const fs=require("fs");
+  const pkgs=process.platform==="win32"?[["sqlite-vec-windows-x64","vec0.dll"]]
+    :process.platform==="darwin"?[["sqlite-vec-darwin-arm64","vec0.dylib"],["sqlite-vec-darwin-x64","vec0.dylib"]]
+    :[["sqlite-vec-linux-x64","vec0.so"],["sqlite-vec-linux-arm64","vec0.so"]];
+  const roots=[os.homedir()+"/.himmel/qmd-fork/node_modules",
+    os.homedir()+"/Documents/github/qmd/node_modules",
+    os.homedir()+"/.bun/install/global/node_modules"];
+  const vecs=[process.env.HIMMEL_VEC0].concat(...roots.map(r=>pkgs.map(kl=>r+"/"+kl[0]+"/"+kl[1]))).filter(Boolean);
+  const db=new D(process.argv[1],{readonly:true});
+  for(const c of vecs){if(fs.existsSync(c)){try{db.loadExtension(c);break;}catch{}}}
+  process.stdout.write(String(db.prepare(process.argv[2]).get().c));
+  db.close();' "$1" "$2"
+}
+
+SRC="$TMP_ROOT/src.sqlite"
+OUT="$TMP_ROOT/out.sqlite"
+
+# ============================================================================
+echo "TEST: argument handling"
+# ============================================================================
+rc=0; out=$(node "$SCRIPT" --help 2>&1) || rc=$?
+assert_rc "--help rc 0" 0 "$rc"
+rc=0; out=$(node "$SCRIPT" --src x 2>&1) || rc=$?
+assert_rc "missing --out rc 1" 1 "$rc"
+rc=0; out=$(node "$SCRIPT" --src x --out y 2>&1) || rc=$?
+assert_rc "missing --collections rc 1" 1 "$rc"
+assert_contains "missing --collections explains itself" "--collections is required" "$out"
+mkfix "$SRC"
+# An empty set would reconcile the shipped index down to nothing — a plausible
+# shell-expansion accident, never a real intent.
+rc=0; out=$(node "$SCRIPT" --src "$SRC" --out "$OUT" --collections "" 2>&1) || rc=$?
+assert_rc "empty --collections rc 1" 1 "$rc"
+assert_contains "empty set refused loudly" "refusing to ship an empty index" "$out"
+rc=0; out=$(node "$SCRIPT" --src "$SRC" --out "$SRC" --collections luna 2>&1) || rc=$?
+assert_rc "same src and out rc 1" 1 "$rc"
+rc=0; out=$(node "$SCRIPT" --src "$TMP_ROOT/nope.sqlite" --out "$OUT" --collections luna 2>&1) || rc=$?
+assert_rc "missing source rc 3" 3 "$rc"
+
+# ============================================================================
+echo "TEST: refuses a collection the SOURCE does not have"
+# ============================================================================
+# Silently shipping an index missing a collection the receiver expects is the
+# "orphan/absent collection" failure the reconcile policy exists to prevent.
+rc=0; out=$(node "$SCRIPT" --src "$SRC" --out "$OUT" --collections himmel,nosuch 2>&1) || rc=$?
+assert_rc "unknown receiver collection rc 1" 1 "$rc"
+assert_contains "names the missing collection" "nosuch" "$out"
+assert_contains "refuses rather than silently omitting" "silently omits" "$out"
+
+# ============================================================================
+echo "TEST: reconcile keeps only the receiver's collections"
+# ============================================================================
+rm -f "$OUT"
+rc=0; out=$(node "$SCRIPT" --src "$SRC" --out "$OUT" --collections himmel,luna 2>&1) || rc=$?
+assert_rc "reconcile rc 0" 0 "$rc"
+assert_eq "store_collections reduced to 2" "2" "$(q "$OUT" 'select count(*) c from store_collections')"
+assert_eq "only kept-collection documents survive" "0" \
+    "$(q "$OUT" "select count(*) c from documents where collection not in ('himmel','luna')")"
+assert_eq "kept documents present" "2" "$(q "$OUT" 'select count(*) c from documents')"
+# The source must never be touched.
+assert_eq "SOURCE still has all 4 collections" "4" "$(q "$SRC" 'select count(*) c from store_collections')"
+assert_eq "SOURCE still has all 5 documents" "5" "$(q "$SRC" 'select count(*) c from documents')"
+
+# ============================================================================
+echo "TEST: content SHARED across collections is retained"
+# ============================================================================
+# h_shared is referenced by luna (kept) AND luna-curated (dropped). Deleting
+# content by dropped-collection would remove it and break luna's search.
+assert_eq "shared content retained" "1" "$(q "$OUT" "select count(*) c from content where hash='h_shared'")"
+assert_eq "curated-only content dropped" "0" "$(q "$OUT" "select count(*) c from content where hash='h_curated_only'")"
+assert_eq "salus content dropped" "0" "$(q "$OUT" "select count(*) c from content where hash='h_salus'")"
+assert_eq "no orphan content at all" "0" \
+    "$(q "$OUT" 'select count(*) c from content where hash not in (select hash from documents)')"
+
+# ============================================================================
+echo "TEST: vec0 orphan GC (the rows that never self-clean)"
+# ============================================================================
+assert_eq "vectors_vec == content_vectors after GC" \
+    "$(q "$OUT" 'select count(*) c from content_vectors')" \
+    "$(q "$OUT" 'select count(*) c from vectors_vec')"
+assert_eq "dropped-collection vectors gone" "0" \
+    "$(q "$OUT" "select count(*) c from vectors_vec where hash_seq like 'h_salus%'")"
+assert_eq "kept vectors survive" "4" \
+    "$(q "$OUT" "select count(*) c from vectors_vec where hash_seq like 'h_himmel%' or hash_seq like 'h_shared%'")"
+
+echo "TEST: PRE-EXISTING vec0 orphans are collected too"
+SRC2="$TMP_ROOT/src-orphans.sqlite"
+OUT2="$TMP_ROOT/out-orphans.sqlite"
+mkfix "$SRC2" orphans
+assert_eq "fixture really has the ghost rows" "3" \
+    "$(q "$SRC2" "select count(*) c from vectors_vec where hash_seq like 'h_ghost%'")"
+rc=0; out=$(node "$SCRIPT" --src "$SRC2" --out "$OUT2" --collections himmel,luna 2>&1) || rc=$?
+assert_rc "orphan fixture rc 0" 0 "$rc"
+assert_eq "ghost vec0 rows collected" "0" \
+    "$(q "$OUT2" "select count(*) c from vectors_vec where hash_seq like 'h_ghost%'")"
+assert_eq "vectors_vec == content_vectors (orphan fixture)" \
+    "$(q "$OUT2" 'select count(*) c from content_vectors')" \
+    "$(q "$OUT2" 'select count(*) c from vectors_vec')"
+
+# ============================================================================
+echo "TEST: FTS follows the documents delete via the trigger"
+# ============================================================================
+# documents_ad cascades; the script must NOT hand-delete from the contentless
+# fts5 table. If this drifts, the receiver searches deleted docs.
+assert_eq "fts rows match surviving active documents" \
+    "$(q "$OUT" 'select count(*) c from documents where active=1')" \
+    "$(q "$OUT" 'select count(*) c from documents_fts')"
+
+# ============================================================================
+echo "TEST: --json emits machine-readable stats the transport consumes"
+# ============================================================================
+rm -f "$OUT"
+# Capture rc explicitly (suite convention): under `set -e` an unguarded failure
+# here would abort the whole run silently instead of reporting a FAIL.
+rc=0; json=$(node "$SCRIPT" --src "$SRC" --out "$OUT" --collections himmel,luna --json 2>/dev/null) || rc=$?
+assert_rc "--json rc 0" 0 "$rc"
+assert_contains "json reports ok" '"ok":true' "$json"
+assert_contains "json carries after.documents" '"documents"' "$json"
+assert_contains "json names dropped collections" 'salus' "$json"
+rc=0; docs=$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(String(JSON.parse(s).after.documents)))' <<<"$json") || rc=$?
+assert_rc "json parse rc 0" 0 "$rc"
+assert_eq "json after.documents parses to 2" "2" "$docs"
+
+# ============================================================================
+echo "TEST: a NULL document hash does not disable orphan cleanup (NOT EXISTS)"
+# ============================================================================
+# Regression pin for CR finding [glm-4]. `x NOT IN (subquery)` yields NULL — not
+# TRUE — for every row once the subquery contains a single NULL, so ONE document
+# with a NULL hash silently deleted no orphan content at all, and the self-check
+# (same predicate) reported it clean. NOT EXISTS is NULL-safe.
+SRC_NULL="$TMP_ROOT/src-nullhash.sqlite"
+OUT_NULL="$TMP_ROOT/out-nullhash.sqlite"
+mkfix "$SRC_NULL" nullhash
+rc=0; out=$(node "$SCRIPT" --src "$SRC_NULL" --out "$OUT_NULL" --collections himmel,luna 2>&1) || rc=$?
+assert_rc "null-hash fixture rc 0" 0 "$rc"
+# salus/luna-curated-only content must STILL be gone despite the NULL row.
+assert_eq "orphan cleanup still ran with a NULL hash present" "0" \
+    "$(q "$OUT_NULL" "select count(*) c from content where hash='h_salus'")"
+assert_eq "no orphan content survives (NULL-safe predicate)" "0" \
+    "$(q "$OUT_NULL" 'select count(*) c from content where not exists (select 1 from documents d where d.hash = content.hash)')"
+assert_eq "vectors still converge with a NULL hash present" \
+    "$(q "$OUT_NULL" 'select count(*) c from content_vectors')" \
+    "$(q "$OUT_NULL" 'select count(*) c from vectors_vec')"
+
+# ============================================================================
+echo "TEST: refuses a source whose documents_ad FTS trigger is missing"
+# ============================================================================
+# The whole FTS story rests on that trigger cascading document deletes. Without
+# it the reconcile still "succeeds" and ships an index that full-text-matches
+# documents it no longer contains — a wrong ANSWER with no error anywhere.
+SRC_NOTRIG="$TMP_ROOT/src-notrigger.sqlite"
+cp "$SRC" "$SRC_NOTRIG"
+rc=0; node -e '
+const {createRequire}=require("module");const req=createRequire(process.cwd()+"/x.js");
+const os=require("os");
+const cands=[process.env.HIMMEL_BETTER_SQLITE3,
+  os.homedir()+"/.himmel/qmd-fork/node_modules/better-sqlite3",
+  os.homedir()+"/Documents/github/qmd/node_modules/better-sqlite3"].filter(Boolean);
+let D=null;for(const c of cands){try{D=req(c);break;}catch{}}
+const fs=require("fs");
+// Load vec0 before touching a DB that CONTAINS a vec0 virtual table — without
+// it SQLite can refuse on schema access, and this helper would fail for a
+// reason unrelated to what the test is checking.
+const pkgs=process.platform==="win32"?[["sqlite-vec-windows-x64","vec0.dll"]]
+  :process.platform==="darwin"?[["sqlite-vec-darwin-arm64","vec0.dylib"],["sqlite-vec-darwin-x64","vec0.dylib"]]
+  :[["sqlite-vec-linux-x64","vec0.so"],["sqlite-vec-linux-arm64","vec0.so"]];
+const roots=[os.homedir()+"/.himmel/qmd-fork/node_modules",
+  os.homedir()+"/Documents/github/qmd/node_modules",
+  os.homedir()+"/.bun/install/global/node_modules"];
+const vecs=[process.env.HIMMEL_VEC0].concat(...roots.map(r=>pkgs.map(kl=>r+"/"+kl[0]+"/"+kl[1]))).filter(Boolean);
+const db=new D(process.argv[1]);
+for(const c of vecs){if(fs.existsSync(c)){try{db.loadExtension(c);break;}catch{}}}
+db.exec("DROP TRIGGER documents_ad"); db.close();' "$SRC_NOTRIG" || rc=$?
+assert_rc "fixture trigger dropped" 0 "$rc"
+rc=0; out=$(node "$SCRIPT" --src "$SRC_NOTRIG" --out "$TMP_ROOT/out-notrig.sqlite" --collections himmel,luna 2>&1) || rc=$?
+assert_rc "missing documents_ad trigger rc 3" 3 "$rc"
+assert_contains "names the missing trigger" "documents_ad" "$out"
+if [ ! -f "$TMP_ROOT/out-notrig.sqlite" ]; then
+    pass "no artifact produced when the trigger is missing"
+else
+    fail "produced an artifact despite the missing trigger"
+fi
+
+# ============================================================================
+echo "TEST: a FAILED build leaves any previous --out artifact intact"
+# ============================================================================
+# The artifact is built at a sibling work path and promoted only after the
+# self-check passes, so a failure must not destroy a good previous artifact
+# (nor leave a half-written file at the path the transport uploads).
+PREV="$TMP_ROOT/prev-out.sqlite"
+rc=0; node "$SCRIPT" --src "$SRC" --out "$PREV" --collections himmel,luna >/dev/null 2>&1 || rc=$?
+assert_rc "seed a good previous artifact" 0 "$rc"
+prev_sum="$(wc -c < "$PREV" | tr -d ' ')"
+rc=0; node "$SCRIPT" --src "$SRC_NOTRIG" --out "$PREV" --collections himmel,luna >/dev/null 2>&1 || rc=$?
+assert_rc "failing build rc 3" 3 "$rc"
+assert_eq "previous artifact untouched after a failed build" "$prev_sum" "$(wc -c < "$PREV" | tr -d ' ')"
+if ! compgen -G "$PREV.building.*" >/dev/null; then
+    pass "no .building work file left behind"
+else
+    fail "work file litter left" "$(ls "$TMP_ROOT")"
+fi
+
+summary

--- a/scripts/luna/test-ship-index.sh
+++ b/scripts/luna/test-ship-index.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+# Tests for scripts/luna/ship-index.sh (HIMMEL-1275).
+#
+# Covers everything reachable WITHOUT a second machine: argument handling,
+# preflight refusals, the dry-run plan, and the "nothing ships when the local
+# build fails" ordering guarantee. Deliberately does NOT test the actual
+# swap/fence/restart — that mutates a remote machine's live index, so it must
+# never be a CI test (the ticket says so explicitly).
+#
+# Strategy: stub `ssh`, `scp`, `node` and the reindex runner on PATH so the
+# script's ORDER OF OPERATIONS and its refusals are observable via a call log,
+# with no network and no real qmd.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/ship-index.sh"
+
+PASS=0
+FAIL=0
+TMP_ROOT=""
+
+# shellcheck disable=SC2329,SC2317
+cleanup() {
+    if [ -n "$TMP_ROOT" ] && [ -d "$TMP_ROOT" ]; then
+        rm -rf "$TMP_ROOT" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; if [ $# -ge 2 ]; then printf '    %s\n' "$2"; fi; FAIL=$((FAIL+1)); }
+assert_contains() {
+    local name="$1" needle="$2" haystack="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then pass "$name"; else fail "$name" "missing: $needle"; fi
+}
+assert_not_contains() {
+    local name="$1" needle="$2" haystack="$3"
+    if grep -qF -- "$needle" <<<"$haystack"; then fail "$name" "unexpected: $needle"; else pass "$name"; fi
+}
+assert_rc() {
+    local name="$1" want="$2" got="$3"
+    if [ "$got" = "$want" ]; then pass "$name"; else fail "$name" "expected rc=$want, got rc=$got"; fi
+}
+summary() {
+    echo
+    echo "===================================="
+    echo "test summary: $PASS passed, $FAIL failed"
+    echo "===================================="
+    [ "$FAIL" -gt 0 ] && exit 1 || exit 0
+}
+
+REAL_BASH="$(command -v bash)"
+# Resolve the REAL node BEFORE the stub dir shadows PATH. The stub falls back to
+# the real interpreter for the tiny inline JSON programs the script pipes
+# through node — and `env node` there would re-resolve through the shadowed
+# PATH straight back into the stub, an infinite exec loop that hangs the suite
+# to the CI timeout (the same shape test-graphmap-cadence.sh documents for bash).
+REAL_NODE="$(command -v node 2>/dev/null || true)"
+[ -n "$REAL_NODE" ] || { echo "SKIP: node not on PATH"; exit 0; }
+TMP_ROOT=$(mktemp -d)
+BIN="$TMP_ROOT/bin"
+STATE="$TMP_ROOT/state"
+mkdir -p "$BIN" "$STATE"
+: > "$STATE/calls"
+
+# --- stubs -------------------------------------------------------------------
+# All /bin/sh with an ABSOLUTE shebang so a shadowed PATH can never make one
+# re-resolve into another stub.
+# shellcheck disable=SC2016  # stub BODIES are deliberately literal: `$*`, `$STATE`
+# and friends must reach the generated stub unexpanded, to be evaluated when the
+# stub RUNS, not when this suite writes it.
+mk_stub() {
+    local name="$1" body="$2"
+    { printf '#!/bin/sh\nSTATE="%s"\n' "$STATE"; printf '%s\n' "$body"; } > "$BIN/$name"
+    chmod +x "$BIN/$name"
+}
+
+# ssh: records argv; `qmd collection list` answers with the receiver's set.
+# shellcheck disable=SC2016  # literal body — expands when the STUB runs, not now
+mk_stub ssh '
+printf "ssh %s\n" "$*" >> "$STATE/calls"
+if [ -e "$STATE/ssh-fail" ]; then exit 255; fi
+case "$*" in
+  *USERPROFILE*)
+      # The receiver reports where its OWN profile lives; ship-index derives the
+      # remote index/graph/tmp paths from it rather than hardcoding a home dir.
+      # Backslashes + CR on purpose: that is what real PowerShell over ssh emits.
+      if [ -e "$STATE/no-remote-home" ]; then exit 1; fi
+      printf "C:\\\\Users\\\\fakeuser\r\n" ;;
+  *"qmd collection list"*)
+      if [ -e "$STATE/no-remote-collections" ]; then exit 1; fi
+      echo "himmel"; echo "luna" ;;
+  *"cmd /c del"*)
+      # per-run artifact cleanup — always succeeds, never the ship result
+      exit 0 ;;
+  *ship-index-remote*)
+      # matches the PER-INVOCATION name (ship-index-remote.<tag>.ps1), not a
+      # fixed one — the orchestrator uniquifies remote paths per run.
+      if [ -e "$STATE/remote-fail" ]; then echo "SHIP-REMOTE: swapped=no" >&2; exit 5; fi
+      echo "SHIP-REMOTE: verified=ok" ;;
+esac
+exit 0'
+
+# shellcheck disable=SC2016  # literal body — expands when the STUB runs, not now
+mk_stub scp '
+printf "scp %s\n" "$*" >> "$STATE/calls"
+if [ -e "$STATE/scp-fail" ]; then exit 1; fi
+exit 0'
+
+# node: stands in for prepare-ship-index.mjs. Emits the --json shape the
+# orchestrator parses, and still behaves as a real node for the tiny inline
+# JSON-extraction programs the script pipes through it.
+{ printf '#!/bin/sh\nSTATE="%s"\nREAL_NODE="%s"\n' "$STATE" "$REAL_NODE"; cat <<'NODE_EOF'
+case "$*" in
+  *prepare-ship-index.mjs*)
+      printf "node-prepare %s\n" "$*" >> "$STATE/calls"
+      if [ -e "$STATE/prepare-fail" ]; then echo "prepare exploded" >&2; exit 4; fi
+      if [ -e "$STATE/prepare-badjson" ]; then echo "not json at all"; exit 0; fi
+      # create the staging file the orchestrator expects to upload
+      prev=""
+      for a in "$@"; do
+          if [ "$prev" = "--out" ]; then : > "$a"; fi
+          prev="$a"
+      done
+      echo '{"ok":true,"after":{"documents":14782,"vectors":50698}}'
+      exit 0 ;;
+esac
+# ABSOLUTE path, never `env node` — see the REAL_NODE comment above.
+exec "$REAL_NODE" "$@"
+NODE_EOF
+} > "$BIN/node"
+chmod +x "$BIN/node"
+
+FAKE_INDEX="$TMP_ROOT/index.sqlite"
+printf 'not-a-real-index' > "$FAKE_INDEX"
+
+run_ship() {
+    env PATH="$BIN:$PATH" QMD_INDEX_PATH="$FAKE_INDEX" GRAPHIFY_GRAPH_PATH="$TMP_ROOT/nograph.json" \
+        "$REAL_BASH" "$SCRIPT" "$@"
+}
+# Clear EVERY behaviour marker, not just the *-fail ones — a leftover marker
+# silently changes the next test's meaning (and did: prepare-badjson leaked into
+# three later cases and made them fail for the wrong reason).
+reset_calls() {
+    : > "$STATE/calls"
+    rm -f "$STATE"/*-fail "$STATE/no-remote-collections" "$STATE/no-remote-home" "$STATE/prepare-badjson" 2>/dev/null || true
+}
+calls() { cat "$STATE/calls" 2>/dev/null || true; }
+
+# ============================================================================
+echo "TEST: argument handling"
+# ============================================================================
+rc=0; out=$(run_ship --help 2>&1) || rc=$?
+assert_rc "--help rc 0" 0 "$rc"
+assert_contains "--help documents the exit codes" "6 receiver" "$out"
+rc=0; out=$(run_ship --nope 2>&1) || rc=$?
+assert_rc "unknown arg rc 1" 1 "$rc"
+rc=0; out=$(run_ship --host 2>&1) || rc=$?
+assert_rc "trailing --host rc 1" 1 "$rc"
+assert_contains "trailing --host explains itself" "--host requires a value" "$out"
+rc=0; out=$(run_ship --collections 2>&1) || rc=$?
+assert_rc "trailing --collections rc 1" 1 "$rc"
+
+# ============================================================================
+echo "TEST: preflight refuses a missing local index"
+# ============================================================================
+rc=0; out=$(env PATH="$BIN:$PATH" QMD_INDEX_PATH="$TMP_ROOT/absent.sqlite" \
+    "$REAL_BASH" "$SCRIPT" --no-reindex 2>&1) || rc=$?
+assert_rc "missing local index rc 2" 2 "$rc"
+assert_contains "names the missing index" "local qmd index not found" "$out"
+
+# ============================================================================
+echo "TEST: --dry-run plans everything and touches nothing"
+# ============================================================================
+reset_calls
+rc=0; out=$(run_ship --dry-run 2>&1) || rc=$?
+assert_rc "dry-run rc 0" 0 "$rc"
+assert_contains "dry-run names the host" "host              : win2" "$out"
+assert_contains "dry-run says the remote index is derived" "derived from the receiver's USERPROFILE" "$out"
+assert_not_contains "dry-run does not print a stray backslash-apostrophe" "receiver\\'s" "$out"
+assert_contains "dry-run mentions the reconcile query" "qmd collection list" "$out"
+assert_contains "dry-run mentions the receiver script" "ship-index-remote.ps1" "$out"
+assert_contains "dry-run names the fence/swap/verify order" "daemon fence -> swap -> WMI restart -> verify -> reap" "$out"
+if [ ! -s "$STATE/calls" ]; then
+    pass "dry-run made no ssh/scp/node calls at all"
+else
+    fail "dry-run performed calls" "$(calls)"
+fi
+
+# ============================================================================
+echo "TEST: a failed local reindex ships NOTHING"
+# ============================================================================
+# Ordering guarantee: the receiver must keep its current index rather than
+# receive a half-built one.
+reset_calls
+# ship-index.sh resolves its siblings from its OWN directory, so a copy of it
+# into a temp dir alongside a FAILING qmd-reindex.sh exercises the real code
+# path with no patching of the script under test.
+SANDBOX="$TMP_ROOT/sandbox"
+mkdir -p "$SANDBOX"
+cp "$SCRIPT" "$SANDBOX/ship-index.sh"
+cp "$SCRIPT_DIR/prepare-ship-index.mjs" "$SANDBOX/"
+cp "$SCRIPT_DIR/ship-index-remote.ps1" "$SANDBOX/"
+printf '#!/bin/sh\necho "reindex exploded" >&2\nexit 3\n' > "$SANDBOX/qmd-reindex.sh"
+chmod +x "$SANDBOX/qmd-reindex.sh"
+rc=0; out=$(env PATH="$BIN:$PATH" QMD_INDEX_PATH="$FAKE_INDEX" \
+    "$REAL_BASH" "$SANDBOX/ship-index.sh" --no-graph 2>&1) || rc=$?
+assert_rc "failed reindex rc 3" 3 "$rc"
+assert_contains "says nothing was shipped" "NOTHING shipped" "$out"
+assert_not_contains "no upload attempted after a failed reindex" "scp " "$(calls)"
+
+# ============================================================================
+echo "TEST: the RECEIVER decides the collection set"
+# ============================================================================
+reset_calls
+rc=0; out=$(run_ship --no-reindex --no-graph 2>&1) || rc=$?
+assert_rc "happy path rc 0" 0 "$rc"
+assert_contains "queried the receiver's collections" "qmd collection list" "$(calls)"
+assert_contains "reports what the receiver configures" "receiver configures: himmel,luna" "$out"
+assert_contains "passed that set to prepare" "--collections himmel,luna" "$(calls)"
+assert_contains "uploaded the index" "scp " "$(calls)"
+assert_contains "ran the receiver script" "ship-index-remote.ps1" "$(calls)"
+assert_contains "reports the shipped counts" "14782 docs / 50698 vectors" "$out"
+
+echo "TEST: remote paths are DERIVED from the receiver, never hardcoded"
+# A baked C:/Users/<name>/... default would tie the script to one operator's
+# account AND put a personal home path into a file that propagates publicly.
+reset_calls
+rc=0; out=$(run_ship --no-reindex --no-graph 2>&1) || rc=$?
+assert_rc "derived-paths happy path rc 0" 0 "$rc"
+assert_contains "asked the receiver for its profile" "USERPROFILE" "$(calls)"
+assert_contains "derived the index path from it" "C:/Users/fakeuser/.cache/qmd/index.sqlite" "$out"
+if LC_ALL=C grep -qE 'C:/Users/[A-Za-z0-9._-]+/' "$SCRIPT"; then
+    fail "ship-index.sh still contains a hardcoded home path" "derive it from the receiver instead"
+else
+    pass "ship-index.sh has no hardcoded home path"
+fi
+
+echo "TEST: an unreadable receiver profile is fatal, not a silent default"
+reset_calls
+touch "$STATE/no-remote-home"
+rc=0; out=$(run_ship --no-reindex --no-graph 2>&1) || rc=$?
+assert_rc "unresolvable remote home rc 2" 2 "$rc"
+assert_contains "names the override env vars" "SHIP_REMOTE_INDEX" "$out"
+assert_not_contains "nothing uploaded without resolved paths" "scp " "$(calls)"
+
+echo "TEST: dry-run reports an explicit override, not the derived placeholder"
+# A dry-run that misreports its own plan is worse than no dry-run.
+reset_calls
+rc=0; out=$(env PATH="$BIN:$PATH" QMD_INDEX_PATH="$FAKE_INDEX" \
+    GRAPHIFY_GRAPH_PATH="$TMP_ROOT/nograph.json" SHIP_REMOTE_INDEX="D:/idx/index.sqlite" \
+    "$REAL_BASH" "$SCRIPT" --dry-run 2>&1) || rc=$?
+assert_rc "dry-run with override rc 0" 0 "$rc"
+assert_contains "dry-run shows the override value" "D:/idx/index.sqlite" "$out"
+assert_contains "dry-run labels it an override" "SHIP_REMOTE_INDEX override" "$out"
+assert_not_contains "dry-run does not claim it will be derived" "derived from the receiver's" "$out"
+
+echo "TEST: SHIP_REMOTE_* overrides skip the receiver query entirely"
+reset_calls
+rc=0; out=$(env PATH="$BIN:$PATH" QMD_INDEX_PATH="$FAKE_INDEX" \
+    GRAPHIFY_GRAPH_PATH="$TMP_ROOT/nograph.json" \
+    SHIP_REMOTE_INDEX="D:/idx/index.sqlite" SHIP_REMOTE_GRAPH="D:/idx/graph.json" \
+    SHIP_REMOTE_TMP="D:/tmp" \
+    "$REAL_BASH" "$SCRIPT" --no-reindex --no-graph 2>&1) || rc=$?
+assert_rc "explicit remote overrides rc 0" 0 "$rc"
+assert_contains "used the override index path" "D:/idx/index.sqlite" "$out"
+assert_not_contains "did NOT query the receiver profile" "USERPROFILE" "$(calls)"
+
+echo "TEST: --collections overrides the receiver query"
+reset_calls
+rc=0; out=$(run_ship --no-reindex --no-graph --collections himmel 2>&1) || rc=$?
+assert_rc "override rc 0" 0 "$rc"
+assert_contains "reports the override" "explicit override: himmel" "$out"
+assert_not_contains "did NOT query the receiver" "qmd collection list" "$(calls)"
+
+echo "TEST: an unreadable receiver collection set is fatal, not a silent default"
+reset_calls
+touch "$STATE/no-remote-collections"
+rc=0; out=$(run_ship --no-reindex --no-graph 2>&1) || rc=$?
+assert_rc "unreadable receiver set rc 2" 2 "$rc"
+assert_contains "suggests the explicit override" "--collections" "$out"
+assert_not_contains "nothing uploaded" "scp " "$(calls)"
+
+# ============================================================================
+echo "TEST: failures are attributed to the right stage"
+# ============================================================================
+reset_calls
+touch "$STATE/prepare-fail"
+rc=0; out=$(run_ship --no-reindex --no-graph 2>&1) || rc=$?
+assert_rc "prepare failure rc 4" 4 "$rc"
+assert_contains "prepare failure says nothing shipped" "NOTHING shipped" "$out"
+assert_not_contains "no upload after a failed prepare" "scp " "$(calls)"
+
+echo "TEST: unparseable prepare metadata does NOT silently disable verification"
+# The receiver treats a NEGATIVE expectation as "skip this check", so an
+# unparsed count sailing through as -1 would quietly turn the post-swap
+# doc/vector verification into a no-op — the ship would report success while
+# having verified nothing.
+reset_calls
+touch "$STATE/prepare-badjson"
+rc=0; out=$(run_ship --no-reindex --no-graph 2>&1) || rc=$?
+assert_rc "unparseable counts rc 4" 4 "$rc"
+assert_contains "explains the verification would be disabled" "verification disabled" "$out"
+assert_not_contains "nothing uploaded on unusable counts" "scp " "$(calls)"
+
+reset_calls
+touch "$STATE/scp-fail"
+rc=0; out=$(run_ship --no-reindex --no-graph 2>&1) || rc=$?
+assert_rc "upload failure rc 5" 5 "$rc"
+assert_contains "upload failure says the receiver is untouched" "receiver untouched" "$out"
+
+reset_calls
+touch "$STATE/remote-fail"
+rc=0; out=$(run_ship --no-reindex --no-graph 2>&1) || rc=$?
+assert_rc "receiver failure rc 6" 6 "$rc"
+assert_contains "points at the receiver's own output" "SHIP-REMOTE" "$out"
+
+# ============================================================================
+echo "TEST: the receiver script's Fail() preserves its stage-specific exit code"
+# ============================================================================
+# Regression pin for CR finding [codex-1]. ship-index-remote.ps1 runs under
+# $ErrorActionPreference='Stop', where Write-Error raises a TERMINATING error —
+# so a `Write-Error ...; exit $code` Fail() never reaches the exit and the
+# script dies with PowerShell's generic status 1. That collapses every documented
+# stage code into "1", destroying the distinction that matters most after a
+# failure: 3 = index NOT swapped vs 4 = index WAS swapped.
+#
+# Extract the REAL Fail() from the shipped script (so this cannot drift from it)
+# and assert a non-1 code survives. Skipped where powershell is unavailable.
+# ============================================================================
+echo "TEST: the receiver script is ASCII-only and PARSES"
+# ============================================================================
+# Both halves of a real bug. The file is UTF-8, but Windows PowerShell 5.1 reads
+# a BOM-less script with the ANSI codepage: a UTF-8 em dash (E2 80 94) decodes
+# to three chars ending in U+201D RIGHT DOUBLE QUOTATION MARK — which PowerShell
+# accepts AS A STRING DELIMITER. One em dash inside a double-quoted string
+# desyncs every quote after it. Measured: 18 em dashes produced 4 parse errors,
+# i.e. the receiver would not have run on win2 AT ALL. Assert both the byte-level
+# rule (cheap, runs everywhere) and a real parse (where powershell exists).
+if LC_ALL=C grep -qP '[^\x00-\x7F]' "$SCRIPT_DIR/ship-index-remote.ps1" 2>/dev/null; then
+    fail "receiver script contains non-ASCII bytes" \
+        "PowerShell 5.1 mis-decodes them under the ANSI codepage; keep this file ASCII-only"
+else
+    pass "receiver script is ASCII-only"
+fi
+
+PS_BIN="$(command -v powershell 2>/dev/null || command -v pwsh 2>/dev/null || true)"
+if [ -n "$PS_BIN" ]; then
+    PARSE_PROBE="$TMP_ROOT/parse-probe.ps1"
+    cat >"$PARSE_PROBE" <<'PARSE_EOF'
+param([Parameter(Mandatory=$true)][string]$Path)
+$errs = $null
+[void][System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path $Path).Path, [ref]$null, [ref]$errs)
+if ($errs -and $errs.Count -gt 0) {
+    foreach ($e in $errs) { Write-Output ("line " + $e.Extent.StartLineNumber + ": " + $e.Message) }
+    exit 1
+}
+exit 0
+PARSE_EOF
+    parse_rc=0
+    parse_out=$("$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$PARSE_PROBE" -Path "$SCRIPT_DIR/ship-index-remote.ps1" 2>&1) || parse_rc=$?
+    assert_rc "receiver script parses with 0 errors" 0 "$parse_rc"
+    [ "$parse_rc" -eq 0 ] || printf '    %s\n' "$parse_out"
+fi
+
+
+if [ -z "$PS_BIN" ]; then
+    echo "  SKIP: no powershell/pwsh on this host (receiver-script check)"
+else
+    PS_PROBE="$TMP_ROOT/fail-probe.ps1"
+    {
+        # shellcheck disable=SC2016  # PowerShell variable, must stay literal
+        echo '$ErrorActionPreference = "Stop"'
+        # the Fail() body as actually shipped
+        sed -n '/^function Fail(/,/^}/p' "$SCRIPT_DIR/ship-index-remote.ps1"
+        echo 'Fail 5 "probe"'
+    } > "$PS_PROBE"
+    if ! grep -q 'function Fail(' "$PS_PROBE"; then
+        fail "could not extract Fail() from ship-index-remote.ps1" "the function shape changed; update this test"
+    else
+        ps_rc=0
+        "$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$PS_PROBE" >/dev/null 2>&1 || ps_rc=$?
+        assert_rc "Fail 5 really exits 5 (not collapsed to 1)" 5 "$ps_rc"
+    fi
+fi
+
+summary


### PR DESCRIPTION
## What

The **local-build → remote-receive transport** for the qmd search index, for a setup where one machine is far slower than the other. Three parts:

- **`scripts/luna/prepare-ship-index.mjs`** — builds the shippable artifact: consistent copy → collection reconcile → vec0 orphan GC → VACUUM → self-check.
- **`scripts/luna/ship-index-remote.ps1`** — the RECEIVER half, copied over and run there: daemon fence → swap → WMI-parented restart → verify → `.preship` reap.
- **`scripts/luna/ship-index.sh`** — the orchestrator, reusing the qmd-reindex runner for the build step.

Opt-in and manual: nothing here is scheduled, and a single-machine setup takes on no new obligation.

## Why

A slow secondary cannot practically BUILD its own search substrate. Measured on this setup: **~5 docs/min vs ~256 docs/min locally (50x)**, so an in-place reindex there was projected at **~17 hours** and had to be killed mid-run. It has to RECEIVE — and until now the index arrived only when a human remembered to copy a file.

## Verified on a real 447MB index, not just fixtures

| | before | after |
|---|---|---|
| documents | 17,382 | 14,782 |
| content_vectors | 74,917 | 50,698 |
| vectors_vec | 74,917 | **50,698** |
| size | 447 MB | 396 MB |

23 seconds, and the vec0 GC **converged exactly**. The artifact was then reopened and checked for usability rather than mere self-consistency: collections correctly reduced, **active documents == FTS rows**, FTS and vec0 queries both returning real hits, `pragma integrity_check` → `ok`.

## Schema facts this depends on — verified, not assumed

Recorded in the file headers so the next reader doesn't re-derive them:

- `vectors_vec.hash_seq` is `hash || '_' || seq` (**underscore**). A wrong separator silently deletes every vector.
- A vec0 `TEXT PRIMARY KEY` **replaces rowid**, so deletes must key on `hash_seq` — `WHERE rowid = ?` errors outright.
- **FTS needs no separate step**: the `documents_ad` trigger cascades the `documents` delete into `documents_fts`. Hand-deleting from that contentless fts5 table would corrupt it; skipping the cascade would ship stale FTS. The preflight now **requires** that trigger rather than trusting it.
- **Content is SHARED across collections** (a curated collection can index a subset of the same vault), so orphan cleanup means "referenced by NO surviving document", never "belonged to a dropped collection".
- Every orphan predicate uses **`NOT EXISTS`, not `NOT IN`**: SQL `NOT IN` yields NULL for every row once its subquery contains a single NULL, so one NULL hash would silently delete nothing at all — while a self-check written with the same predicate would report it clean.

## Policies

**Reconcile: ship-only-what-the-RECEIVER-configures.** The receiver's own collection list is the authority, so the ship can never create an orphan collection there; and it refuses outright if the receiver expects a collection the source lacks, rather than silently shipping without it. The source index is opened READONLY and never modified.

**Verify fails LOUD** if vectors lag lex after the swap. The `.preship` copy is reaped on success AND failure. The daemon filter matches **bun**, not node — a node-only filter both misses the daemon and matches dozens of unrelated processes. Restart is **WMI-parented**, because a child of the ssh session dies with the connection.

The receiver logic is a **`.ps1` file** rather than an inline ssh one-liner, because a nested escaped quote inside `ssh host 'powershell -Command "…"'` breaks cmd parsing. That file is **ASCII-only on purpose**: Windows PowerShell reads a BOM-less script with the ANSI codepage, where a UTF-8 em dash decodes to a sequence ending in a curly quote that PowerShell accepts *as a string delimiter* — one em dash inside a string desyncs every quote after it and the script fails to parse.

## Tests — 90 assertions, no second machine required

| Suite | Assertions |
|---|---|
| `test-prepare-ship-index.sh` | 47 |
| `test-ship-index.sh` | 43 |

The prepare suite builds **real** fixture databases with real vec0 tables and a real `documents_ad` trigger, exercising reconcile, shared-content retention, orphan GC (including pre-existing ghost rows), the FTS cascade, a NULL-hash fixture, the missing-trigger refusal, and that a failed build leaves any previous artifact byte-identical. It skips cleanly with a printed reason where better-sqlite3/vec0 are unavailable.

The ship suite stubs ssh/scp/node and covers argument handling, preflight, the dry-run plan, per-stage failure attribution, the "a failed local build ships NOTHING" ordering guarantee, and two pins on the receiver script (ASCII-only, plus a real PowerShell parse).

**The actual swap is deliberately never a CI test** — it mutates a remote machine's live index.

## Try it

```bash
bash scripts/luna/ship-index.sh --dry-run    # prints the full plan, changes nothing
```
