### PR TITLE
docs: arm-resume dedup is per-handover, not prefix-wide — correct the runbooks

### DIFF
--- a/.agents/skills/handover-arm-resume/SKILL.md
+++ b/.agents/skills/handover-arm-resume/SKILL.md
@@ -7,7 +7,7 @@ description: Arm the OS scheduler to relaunch claude at a given time with a give
 
 When the user asks to arm a scheduled resume, run:
 
-    bash scripts/handover/arm-resume.sh --time <HH:MM|smart|auto> --handover <path> [--force] [--dry-run]
+    bash scripts/handover/arm-resume.sh --time <HH:MM|smart|auto> --handover <path> [--force] [--dedup-any] [--dry-run]
 
 `--time smart` (prefer) reads the usage cache and picks the throughput-maximizing
 slot; `auto` waits for the next cap reset; `HH:MM` is explicit local time.

--- a/.agents/skills/handover-arm-resume/SKILL.md
+++ b/.agents/skills/handover-arm-resume/SKILL.md
@@ -11,7 +11,18 @@ When the user asks to arm a scheduled resume, run:
 
 `--time smart` (prefer) reads the usage cache and picks the throughput-maximizing
 slot; `auto` waits for the next cap reset; `HH:MM` is explicit local time.
-Dedup-guarded: refuses (rc=3) if a `HIMMEL-Resume-*` job exists (use `--force` to
-replace). This shells the SANCTIONED arm path — never hand-roll `schtasks`/`at`
+Dedup is PER-HANDOVER, not prefix-wide: it refuses (rc=3) only when a resume job
+for THIS SAME handover is already scheduled (`--force` replaces the matched
+job). Arming a DIFFERENT handover while another is queued SUCCEEDS —
+independent tickets are meant to run concurrently, so never serialise them
+or `--force` over one to queue the other. "Same handover" means the same
+*derived task name*, a sanitized form of the path as typed (HIMMEL-1304):
+pass the path the same way each time, and note that two distinct paths
+differing only in stripped punctuation can collide into one identity,
+producing a spurious rc=3 whose `--force` would replace the OTHER
+handover's slot — so check the named job before forcing.
+`--dedup-any` opts into the broad "any existing slot blocks" mode the
+unattended auto-arm watchdogs use. This shells the SANCTIONED arm path —
+never hand-roll `schtasks`/`at`
 (blocked by block-rogue-claude-schedule). See
 `.claude/commands/handover-arm-resume.md` for the time sentinels + exit codes.

--- a/.claude/commands/handover-arm-resume.md
+++ b/.claude/commands/handover-arm-resume.md
@@ -1,12 +1,15 @@
 ---
 description: Arm the OS scheduler to relaunch claude at the given time with the given handover. Dedup-guarded. Direct schtasks/at invoke. HIMMEL-122.
-argument-hint: --time <HH:MM|smart|auto> --handover <path> [--force] [--dry-run]
+argument-hint: --time <HH:MM|smart|auto> --handover <path> [--force] [--dedup-any] [--dry-run]
 ---
 
 Actually create the scheduled relaunch (not just print the command — for the print-only flavor see `scripts/handover/schedule-resume.sh`). Wraps the platform scheduler (`schtasks` on Windows, `at` or `crontab` on POSIX) directly — does NOT shell out to `schedule-resume.sh` (whose stdout mixes prose with commands and isn't safe to `bash -c`).
 
 ## Guarantees
-- **Dedup safeguard:** refuses (rc=3) if a `HIMMEL-Resume-*` job already exists. Pass `--force` to delete + replace.
+- **Dedup safeguard is PER-HANDOVER (HIMMEL-340), not prefix-wide:** it refuses (rc=3) only when a resume job for *this same handover* is already scheduled — matched on the handover-derived `$TASK_NAME`, not on the `HIMMEL-Resume-` prefix. Pass `--force` to delete + replace (a `--force` replace is scoped to this handover's job; sibling slots survive). **Distinct handovers arm concurrently by design** — N tickets each get their own slot, so you never have to serialise two independent tickets or `--force` over one to queue the other. `--dedup-any` opts back into the broad "defer to ANY existing resume slot" semantics; that is the unattended auto-arm watchdog's safety-arm mode, not the operator path. **Caveats (HIMMEL-1304) — the identity is a *sanitized, uncanonicalized* form of the `--handover` path, so it is lossy in both directions:**
+  - *Same file, two spellings → two slots.* The path is used as you typed it, so `x.md` vs `./x.md` vs an absolute path vs a symlink read as different handovers. Pass the path consistently — preferably absolute.
+  - *Two files, one identity → a false dedup block.* Sanitization strips every character outside `[:alnum:]_-`, so genuinely distinct paths can collapse together (`.../a+b.md` and `.../ab.md` both reduce to `…abmd`). The second arm is then refused rc=3 as a "duplicate", and `--force` would replace the *other* handover's slot. Rare, but it is why the per-handover guarantee below is "matched on the derived name", not "provably one slot per file".
+- **Time collision, not dedup, is what guards the clock (HIMMEL-407) — and only on some backends:** arming a *different* handover at the exact minute another `HIMMEL-*` task fires refuses rc=6; within `COLLISION_WINDOW_MINUTES` (default 5) it only WARNs and proceeds. **This holds for `schtasks` (Windows) and `crontab` only.** The POSIX `at` queue is deliberately NOT inspected — `atq` exposes no per-job fire time in a portably parseable form (`arm-resume.sh:1351-1354`) — so on a Linux host with `atd` running, where arms go to `at`, two handovers can be armed for the same minute with **no rc=6 and no WARN**. Treat collision detection as best-effort there. `--force` bypasses both — and so does **`--dedup-any`, which downgrades even an exact-minute collision to a WARN** and proceeds, because an unattended watchdog arm must never refuse. Past `ARM_MAX_SLOTS` (default 4) concurrent slots you get a soft WARN — never a block. Note `--dedup-any --force` is the one genuinely destructive combination: its dedup scope matches *every* resume job, so `--force` deletes them all, not just one — **and the deletion runs first**, before the rc 7 / rc 8 refusals and before the replacement is scheduled, so a failure after that point leaves you with no arm at all and no rollback (HIMMEL-1304 tracks making this transactional).
 - **Fail-closed:** if the dedup listing itself errors (schtasks denied, atd down), the script exits rc=2 rather than silently arming a duplicate.
 - **POSIX dedup that actually works:** the `at` job body includes `# HIMMEL-Resume-<task_name>` as a comment line so `atq + at -c | grep` finds it. (v1 omitted this marker; dedup was dead.)
 - **Windows path correctness:** the .bat indirection is written via `mktemp` and the path converted with `cygpath -w` for `schtasks`. (v1 emitted `%TEMP%\...` which bash left literal.)
@@ -37,7 +40,7 @@ Common invocations:
 - `/handover-arm-resume --time auto --handover handovers/<USER_SLUG>/himmel/standalones/HIMMEL-44-windows-install-test/next-session.md --force`
 - `/handover-arm-resume --time 14:00 --handover handovers/<USER_SLUG>/status.md --dry-run`
 
-Exit codes: 0 armed, 1 usage error, 2 env unusable, 3 dedup block, 4 scheduler failed.
+Exit codes: 0 armed, 1 usage error, 2 env unusable (includes a fail-closed dedup-listing error), 3 dedup block (same handover; or any slot under `--dedup-any`), 4 scheduler failed, 5 `--channels` refused while the bun Telegram bridge is live, 6 exact-minute time collision, 7 the handover's queue lock is FRESH (a session is live on it), 8 this handover already has a PENDING arm on another host.
 
 **Scope:** This is the *arm* half of HIMMEL-122; `smart` (HIMMEL-204) is the
 usage-aware *detect* heuristic wired into the arm path.

--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -1522,8 +1522,27 @@ if [ -n "$existing" ]; then
                 echo "    $marker"
             done <<< "$existing"
             echo ""
-            echo "Dedup safeguard — never want two claude sessions cron-relaunched"
-            echo "for the same handover. To replace, re-run with --force. Inspect:"
+            # Scope-accurate reason (HIMMEL-1297): the default per-handover scope
+            # and the --dedup-any broad scope refuse for DIFFERENT reasons, and a
+            # single "same handover" blurb misdescribes the broad one — the same
+            # doc-overstates-the-guard drift this ticket fixed in the runbooks.
+            if [ "$DEDUP_SCOPE" = task ]; then
+                echo "Dedup safeguard — never want two claude sessions cron-relaunched"
+                echo "for the SAME handover. A DIFFERENT handover normally"
+                echo "arms concurrently with no flag at all. To replace, use --force."
+                echo "The match is on the DERIVED task name, which strips punctuation"
+                echo "(HIMMEL-1304), so two distinct paths can collide — CONFIRM the job"
+                echo "above is really this handover's, before --force replaces it. Inspect:"
+            else
+                echo "--dedup-any safety-arm semantics — defer to whatever resume slot is"
+                echo "already queued, whichever handover it points at. To arm this handover"
+                echo "alongside it, drop --dedup-any. Adding --force in THIS scope"
+                echo "deletes EVERY job listed above, not just one — sibling"
+                echo "relaunches included. That deletion happens FIRST, before the"
+                echo "remaining refusals and before the new job is scheduled, so a"
+                echo "later failure can leave you with NO arm at all and no rollback"
+                echo "(HIMMEL-1304). Inspect:"
+            fi
             case "$PLATFORM" in
                 windows) echo "    schtasks /query /tn \"<task-name>\"" ;;
                 *)       echo "    atq && at -c <job-id>   (or: crontab -l)" ;;

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -922,6 +922,10 @@ out=$(TMPDIR="$TMP" SCHED_DB="$DB26" SCHED_DB_DIR="$DB26D" PATH="$STATEFUL_STUB:
 rc=$?
 assert_rc "T26b same handover re-arm still blocks (rc 3)" 3 "$rc"
 assert_contains "T26b dedup ERR text preserved" "already scheduled" "$out"
+# HIMMEL-1297: the refusal must state the scope it actually enforces. A blurb
+# that reads prefix-wide taught the operator to serialise independent tickets.
+assert_contains "T26b refusal names the SAME-handover scope" "for the SAME handover" "$out"
+assert_contains "T26b refusal says a different handover needs no flag" "arms concurrently with" "$out"
 if [ "$(count_slots "$DB26" "$DB26D")" = "1" ]; then
     echo "PASS T26c same-handover dedup keeps exactly one slot"
 else
@@ -963,6 +967,13 @@ out=$(TMPDIR="$TMP" SCHED_DB="$DB28" SCHED_DB_DIR="$DB28D" PATH="$STATEFUL_STUB:
 rc=$?
 assert_rc "T28a --dedup-any distinct handover blocks when any slot exists (rc 3)" 3 "$rc"
 assert_contains "T28a dedup ERR text preserved" "already scheduled" "$out"
+# HIMMEL-1297: the broad scope refuses for a DIFFERENT reason than the default
+# per-handover scope, so it must not claim the slot is the same handover's.
+assert_contains "T28a refusal names the --dedup-any scope" "--dedup-any safety-arm semantics" "$out"
+assert_not_contains "T28a refusal does not claim same-handover" "for the SAME handover" "$out"
+# The refusal must warn that --force in THIS scope is multi-delete (T28d proves
+# it actually is) — reading it as "replace that one job" costs sibling arms.
+assert_contains "T28a refusal warns --force here is multi-delete" "deletes EVERY" "$out"
 # Sanity: WITHOUT --dedup-any the same distinct arm would succeed (T25 proves
 # this), so the rc 3 here is the flag's doing, not a stuck scheduler.
 if [ "$(count_slots "$DB28" "$DB28D")" = "1" ]; then
@@ -978,6 +989,53 @@ out=$(TMPDIR="$TMP" SCHED_DB="$DB28E" SCHED_DB_DIR="$DB28ED" PATH="$STATEFUL_STU
     bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dedup-any 2>&1)
 rc=$?
 assert_rc "T28c --dedup-any on empty scheduler arms (rc 0)" 0 "$rc"
+
+# T28d (HIMMEL-1297): --dedup-any --force is the one genuinely DESTRUCTIVE
+# combination. Its dedup scope matches EVERY resume job, so the --force replace
+# loop deletes them all — two queued sibling arms collapse to the single new
+# one. Pin that here so the refusal message's multi-delete warning (T28a) stays
+# tied to real behaviour, and so a future scoping change to the --force path
+# can't silently pass. Contrast T30: WITHOUT --dedup-any, --force is scoped to
+# the arming handover and sibling slots survive.
+#
+# CHARACTERIZATION, NOT ENDORSEMENT (HIMMEL-1304). This pins what the code
+# does TODAY so the warning text can't drift from it — it does not bless the
+# design. The deletion happens BEFORE the rc 7 queue-lock check, the rc 8
+# cross-host registry check, and schedule_arm itself, so an arm that deletes
+# and THEN exits 7/8 (or fails to schedule) leaves the siblings destroyed with
+# no replacement and no rollback. That non-transactional ordering is a real
+# pre-existing defect tracked in HIMMEL-1304; when it is fixed, this test
+# should be re-pointed at the new (transactional) contract rather than kept as
+# a guarantee that multi-delete stays unconditional.
+DB28F="$TMP/db28f.tasks"; DB28FD="$TMP/db28f.atdir"; : > "$DB28F"; mkdir -p "$DB28FD"
+HO_F1=$(make_handover "$WORK_REPO")
+HO_F2=$(make_handover "$WORK_REPO")
+HO_F3=$(make_handover "$WORK_REPO")
+# Seed the two siblings at DISTINCT minutes. They only need to coexist, not to
+# share a minute, and giving them their own slots keeps this test independent of
+# whether the backend under test implements exact-minute collision detection
+# (HIMMEL-407): on one that does, same-minute seeds would refuse rc=6 and the
+# test would fail during setup, before it ever exercised --dedup-any --force.
+TMPDIR="$TMP" SCHED_DB="$DB28F" SCHED_DB_DIR="$DB28FD" PATH="$STATEFUL_STUB:$PATH" \
+    bash "$ARM" --time "23:57" --handover "$HO_F1" >/dev/null 2>&1
+TMPDIR="$TMP" SCHED_DB="$DB28F" SCHED_DB_DIR="$DB28FD" PATH="$STATEFUL_STUB:$PATH" \
+    bash "$ARM" --time "23:58" --handover "$HO_F2" >/dev/null 2>&1
+if [ "$(count_slots "$DB28F" "$DB28FD")" = "2" ]; then
+    echo "PASS T28d two sibling slots queued before the --dedup-any --force arm"
+else
+    echo "FAIL T28d expected 2 slots before force, got $(count_slots "$DB28F" "$DB28FD")"
+    FAILED=$((FAILED + 1))
+fi
+out=$(TMPDIR="$TMP" SCHED_DB="$DB28F" SCHED_DB_DIR="$DB28FD" PATH="$STATEFUL_STUB:$PATH" \
+    bash "$ARM" --time "$FUTURE_TIME" --handover "$HO_F3" --dedup-any --force 2>&1)
+rc=$?
+assert_rc "T28d --dedup-any --force arms (rc 0)" 0 "$rc"
+if [ "$(count_slots "$DB28F" "$DB28FD")" = "1" ]; then
+    echo "PASS T28d --dedup-any --force deleted BOTH siblings (1 slot remains)"
+else
+    echo "FAIL T28d expected 1 slot after --dedup-any --force, got $(count_slots "$DB28F" "$DB28FD")"
+    FAILED=$((FAILED + 1))
+fi
 
 # ---------------------------------------------------------------------------
 # T29: soft slot cap (HIMMEL-340 decision: WARN, never block). With

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -1026,6 +1026,15 @@ else
     echo "FAIL T28d expected 2 slots before force, got $(count_slots "$DB28F" "$DB28FD")"
     FAILED=$((FAILED + 1))
 fi
+_slot_ids() {   # echo one HIMMEL-Resume-* identity per recorded slot
+    case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
+        msys*|cygwin*|win32*|MINGW*) grep -ho 'HIMMEL-Resume-[^[:space:]"]*' "$DB28F" 2>/dev/null || true ;;
+        *) grep -rho 'HIMMEL-Resume-[^[:space:]"]*' "$DB28FD" 2>/dev/null || true ;;
+    esac
+}
+# Snapshot the two siblings' identities BEFORE the force, so the post-check can
+# prove the survivor is the new arm rather than one of them.
+_ids_before=$(_slot_ids | sort -u)
 out=$(TMPDIR="$TMP" SCHED_DB="$DB28F" SCHED_DB_DIR="$DB28FD" PATH="$STATEFUL_STUB:$PATH" \
     bash "$ARM" --time "$FUTURE_TIME" --handover "$HO_F3" --dedup-any --force 2>&1)
 rc=$?
@@ -1034,6 +1043,21 @@ if [ "$(count_slots "$DB28F" "$DB28FD")" = "1" ]; then
     echo "PASS T28d --dedup-any --force deleted BOTH siblings (1 slot remains)"
 else
     echo "FAIL T28d expected 1 slot after --dedup-any --force, got $(count_slots "$DB28F" "$DB28FD")"
+    FAILED=$((FAILED + 1))
+fi
+# Cardinality alone is not enough: a regression that deleted ONE sibling and then
+# failed to create the replacement also leaves exactly one slot. Assert the
+# surviving slot is the NEW one — its identity must differ from both siblings'
+# (captured above, before the force). Compares the recorded HIMMEL-Resume-*
+# identities rather than re-deriving the task name here, so this stays correct
+# if the name composition ever changes.
+_ids_after=$(_slot_ids | sort -u)
+_surviving=$(printf '%s\n' "$_ids_after" | grep -c . || true)
+if [ "$_surviving" = "1" ] && [ -n "$_ids_before" ] \
+   && ! printf '%s\n' "$_ids_before" | grep -qxF "$_ids_after"; then
+    echo "PASS T28d the surviving slot is the NEW arm, not a leftover sibling"
+else
+    echo "FAIL T28d surviving slot identity wrong (before='$(printf '%s' "$_ids_before" | tr '\n' ',')' after='$(printf '%s' "$_ids_after" | tr '\n' ',')')"
     FAILED=$((FAILED + 1))
 fi
 


### PR DESCRIPTION
## Summary

The `/handover-arm-resume` runbook and its skill twin both claimed `arm-resume.sh` *"refuses (rc=3) if a `HIMMEL-Resume-*` job already exists"*. That has been false since per-handover dedup landed — dedup keys on the handover-derived `$TASK_NAME`, so **distinct handovers arm concurrently** and only a same-handover re-arm refuses.

The overstated doc had a real cost: a session read it, believed it over the code, and needlessly serialised two independent tickets that could have run in parallel. A doc that overstates a guard is worse than no doc.

This was filed as a code bug. Verification first showed the code was already correct, so the fix is the documentation — plus one message correction and tests that keep the two from drifting apart again.

## Actual behaviour (already covered by the existing suite)

| scenario | behaviour |
|---|---|
| SAME handover already armed | **rc 3** refusal naming the job |
| SAME handover + `--force` | replaces, **scoped to that job** — siblings survive |
| DIFFERENT handover already armed | **proceeds, rc 0** — no flag needed |
| `--dedup-any` + any slot | rc 3 (the unattended watchdog's safety-arm mode) |
| dedup listing errors | **rc 2, fail-closed** |

No dedup behaviour changed in this PR.

## Changes

- **Both runbooks** — state the per-handover scope, document `--dedup-any`, separate time-collision from dedup, and complete the exit-code list (5/6/7/8 were undocumented).
- **`arm-resume.sh`** — the rc-3 refusal reason is now scope-accurate; the `--dedup-any` path was printing the "same handover" blurb, the same drift in miniature. Header text unchanged.
- **`test-arm-resume.sh`** — each scope must state its own reason, and a new case pins that `--dedup-any --force` deletes *every* queued sibling.

## Limits now documented rather than papered over

Review surfaced three real properties of the identity scheme the old text implied away. None are changed here; all are now stated so the runbooks stop promising more than the code delivers:

1. **The task name derives from the handover path as typed.** Aliases (`x.md` vs `./x.md` vs a symlink vs case variants) read as different handovers and arm two slots; conversely the sanitizer strips punctuation, so two distinct paths can collapse into one identity and produce a spurious rc 3 whose `--force` would replace the *other* handover's slot.
2. **`--dedup-any --force` deletes first.** The deletion runs before the remaining refusals and before the replacement is scheduled, so a later failure can leave no arm at all and no rollback. The refusal message and runbook now say so.
3. **Exact-minute collision detection covers `schtasks` and `crontab` only.** The POSIX `at` queue is deliberately not inspected — `atq` exposes no portably parseable per-job fire time — so on a Linux host using `at`, two handovers can take the same minute with no refusal and no warning.

The new multi-delete test is labelled a **characterization test, not an endorsement**, and should be re-pointed at a transactional contract if the replace path is ever made failure-safe.

## Testing

- `scripts/handover/test-arm-resume.sh` — **295 passing, 0 failing** (up from 291), 1 environment-specific skip.
- `scripts/handover/test-arm-resume-proxy.sh` — passing.
- `shellcheck -S warning` clean on both changed shell files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that resume-job deduplication is scoped per handover, while other handovers can be queued concurrently.
  * Documented `--dedup-any` opt-in behavior, `--force` replacement/deletion risks, identity-collision edge cases, timing/collision handling, and expanded exit-code meanings (rc 5–8).
  * Added guidance to inspect the matched job before using force replacement.
* **Bug Fixes**
  * Improved refusal and warning messages to accurately reflect the enforced deduplication scope and potential multi-job deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->