### PR TITLE
fix(telegram): never triage away an operator message; tell the classifier what its verdicts actually do

### DIFF
--- a/scripts/telegram/bus.ts
+++ b/scripts/telegram/bus.ts
@@ -68,7 +68,13 @@ export async function truncateFullyConsumed(file: string, cursorFile: string): P
   return true;
 }
 // reader tracks a byte offset in <file>.cursor; parses only '\n'-terminated lines.
-export async function readNewLines(file: string, cursorFile: string): Promise<any[]> {
+// Generic in the record shape (HIMMEL-1296 CR glm-1) so a caller can NAME what
+// it is reading — the poller reads Inbound from inbound.jsonl, sessions read
+// their own inbox shape — instead of casting `any[]` at the call site. Defaults
+// to `any`, so every existing caller is unchanged. The parse itself stays
+// unchecked: these are JSON lines off disk, and T is the caller's assertion
+// about them, not a validation.
+export async function readNewLines<T = any>(file: string, cursorFile: string): Promise<T[]> {
   let start = 0;
   try { start = Number(await readFile(cursorFile, "utf8")) || 0; } catch {}
   let buf = "";

--- a/scripts/telegram/poller.test.ts
+++ b/scripts/telegram/poller.test.ts
@@ -1,9 +1,9 @@
-import { expect, test } from "bun:test";
+import { beforeEach, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readNewLines, readMeta, writeMeta, ensureSession, appendLine, sessionDir } from "./bus";
-import { ingestUpdates, loadOffset, handleInbound, handleAutoCommand, replyViaOutbox, runAndSettle, reconcile, flushOutboxes, isRetryDue, peekPending, commitPending, makeRunFn, makeAllow, makeDispatcher, makeFetchVoice, sweepStuckRunning, signalTyping, guarded, deliverAllPending, sweepAttachments, resolveRetentionMs, noticeText, parseBridgeEnv, loadBridgeEnv, bridgeEnvOrigin, makeRestart, makeBurstCoalescer, intervalEnvMs, windowEnvMs, RESTART_WATCHDOG_MS, type FetchImageFn } from "./poller";
+import { ingestUpdates, loadOffset, handleInbound, handleAutoCommand, replyViaOutbox, runAndSettle, reconcile, flushOutboxes, isRetryDue, peekPending, commitPending, makeRunFn, makeAllow, makeDispatcher, makeFetchVoice, sweepStuckRunning, signalTyping, guarded, deliverAllPending, sweepAttachments, resolveRetentionMs, noticeText, parseBridgeEnv, loadBridgeEnv, bridgeEnvOrigin, makeRestart, makeBurstCoalescer, intervalEnvMs, windowEnvMs, handleBatch, RESTART_WATCHDOG_MS, type FetchImageFn } from "./poller";
 import { readFile, writeFile, mkdir, utimes } from "node:fs/promises";
 import { isAllowed, vaultForChat } from "./gate";
 import { describeEnabledOps, KNOWN_OPS } from "./auto-action";
@@ -12,6 +12,16 @@ import type { TriageVerdict } from "./triage";
 const root = () => mkdtempSync(join(tmpdir(), "poller-"));
 const allowAll = () => true;
 const spawnHighTriage = async (): Promise<TriageVerdict> => "spawn-high";
+
+// The triage gate is skipped entirely when TELEGRAM_TRIAGE=off — and that is a
+// real User env var on the operator's box while a triage incident is mitigated
+// (HIMMEL-1296). Inherited, it made every triage test below silently pass-through
+// and still report green. Clear it so the suite tests the code, not the host.
+// beforeEACH, not beforeAll (panel CR codex-1): the kill switch is exactly the
+// kind of state a test sets and could fail to restore, and a once-per-file clear
+// would let that leak forward and silently disable triage for every later test —
+// re-creating the false-green this guard exists to prevent. Per-test is cheap.
+beforeEach(() => { delete process.env.TELEGRAM_TRIAGE; });
 
 // --- retry cap + run.log (HIMMEL-262/263) ---
 
@@ -547,6 +557,204 @@ test("group chat spawn-low triage passes haiku as the run model override", async
     async (): Promise<TriageVerdict> => "spawn-low");
 
   expect(ran).toEqual([{ session: "group_-50", modelOverride: "haiku" }]);
+});
+
+// --- operator is never triaged away (HIMMEL-1296) ---
+// The incident: with the classifier live on Windows for the first time
+// (HIMMEL-1279 fixed the bash-path bug that had fail-opened it), ordinary
+// operator questions in the himmel-ops group classified as ignore/ack and were
+// dropped PERMANENTLY — including `why didn't we got an answer on last messagE?`,
+// the complaint about the message the same bug had already eaten. HIMMEL-721's
+// purpose was cutting resource spam in SHARED groups, never filtering the
+// operator, so an operator message floors to spawn-low instead of dropping.
+
+test("operator group message triaged `ignore` is floored to spawn-low, never dropped (HIMMEL-1296)", async () => {
+  const r = root(); const ran: any[] = [];
+  await handleInbound(r, { from:5, chat_id:-50, text:"try again.." },
+    async (session:string, modelOverride?: string) => { ran.push({ session, modelOverride }); },
+    undefined,
+    async (): Promise<TriageVerdict> => "ignore",
+    (fromId) => fromId === 5);
+
+  expect(ran).toEqual([{ session: "group_-50", modelOverride: "haiku" }]);
+  // and it is durably enqueued, so a crash before the run still replays it
+  expect((await peekPending(r, "group_-50")).count).toBe(1);
+});
+
+test("operator group message triaged `ack` is floored to spawn-low, never dropped (HIMMEL-1296)", async () => {
+  const r = root(); const ran: any[] = [];
+  await handleInbound(r, { from:5, chat_id:-50, text:"why didn't we got an answer on last messagE?" },
+    async (session:string, modelOverride?: string) => { ran.push({ session, modelOverride }); },
+    undefined,
+    async (): Promise<TriageVerdict> => "ack",
+    (fromId) => fromId === 5);
+
+  expect(ran).toEqual([{ session: "group_-50", modelOverride: "haiku" }]);
+  expect((await peekPending(r, "group_-50")).count).toBe(1);
+});
+
+// The floor is a FLOOR, not an override: it lifts ignore/ack to spawn-low and
+// leaves every verdict at or above it alone, so the classifier keeps deciding
+// cheap-vs-full model for the operator exactly as before.
+test("operator exemption is a floor: spawn-high keeps the full model (HIMMEL-1296)", async () => {
+  const r = root(); const ran: any[] = [];
+  await handleInbound(r, { from:5, chat_id:-50, text:"rewrite the retry cap" },
+    async (session:string, modelOverride?: string) => { ran.push({ session, modelOverride }); },
+    undefined,
+    async (): Promise<TriageVerdict> => "spawn-high",
+    (fromId) => fromId === 5);
+
+  expect(ran).toEqual([{ session: "group_-50", modelOverride: undefined }]);
+});
+
+// HIMMEL-721 must still do its job: a NON-operator member of a shared group is
+// triaged exactly as before, so the exemption did not neuter the spam gate.
+test("non-operator group chatter is still dropped when the exemption is wired (HIMMEL-1296)", async () => {
+  const r = root(); const ran: string[] = [];
+  await handleInbound(r, { from:9, chat_id:-50, text:"lol nice" },
+    async (s:string) => { ran.push(s); },
+    undefined,
+    async (): Promise<TriageVerdict> => "ignore",
+    (fromId) => fromId === 5);
+
+  expect(ran).toEqual([]);
+  expect(await readMeta(r, "group_-50")).toBeNull();
+});
+
+// The batch is already marked consumed by readNewLines before any of it is
+// handled, so a record that throws used to kill the poller and take every LATER
+// record with it — permanently. That is how an operator message could be lost
+// without ever reaching the floor above. (The remaining crash window between the
+// cursor commit and the inbox append is HIMMEL-1302, not closed here.)
+const inbound = (text: string, update_id: number, from = 5) =>
+  ({ from, chat_id: -50, text, ts: 0, update_id, forwarded: false, caption: false });
+
+test("handleBatch isolates a throwing record so later records still land (HIMMEL-1296)", async () => {
+  const handled: string[] = [];
+  await handleBatch(
+    [inbound("poison", 1, 9), inbound("try again..", 2), inbound("status?", 3)],
+    async (rec) => { if (rec.text === "poison") throw new Error("EPERM: writeMeta exploded"); handled.push(rec.text); },
+  );
+
+  // the throw is contained: both operator messages behind it are still handled
+  expect(handled).toEqual(["try again..", "status?"]);
+});
+
+// Containing the throw must not make the loss QUIET — that would swap a loud
+// crash-loop for a healthy-looking bridge that silently eats messages, which is
+// the exact signature HIMMEL-1296 exists to kill.
+test("handleBatch notifies on a dropped record, keyed by update_id (HIMMEL-1296)", async () => {
+  const drops: number[] = [];
+  await handleBatch(
+    [inbound("poison", 42), inbound("fine", 43)],
+    async (rec) => { if (rec.text === "poison") throw new Error("EISDIR"); },
+    (rec) => { drops.push(rec.update_id); },
+  );
+
+  expect(drops).toEqual([42]);
+});
+
+// The notice can fail on its own (Telegram down, chat gone). That must not
+// abort the batch and strand the records queued behind the failed one.
+test("handleBatch survives an onDrop that itself throws (HIMMEL-1296)", async () => {
+  const handled: string[] = [];
+  await handleBatch(
+    [inbound("poison", 1), inbound("later", 2)],
+    async (rec) => { if (rec.text === "poison") throw new Error("EISDIR"); handled.push(rec.text); },
+    () => { throw new Error("send failed too"); },
+  );
+
+  expect(handled).toEqual(["later"]);
+});
+
+// The notice goes over the network, and sendMessage honours Telegram's uncapped
+// retry_after. If handleBatch awaited it, ONE rate-limited chat would stall every
+// later record of a batch the cursor has already consumed — and a restart while
+// blocked would lose them permanently. onDrop is fire-and-forget by signature,
+// so a notifier that never settles cannot hold the loop.
+test("a drop notifier that never settles does not stall later records (HIMMEL-1296)", async () => {
+  const handled: string[] = [];
+  await handleBatch(
+    [inbound("poison", 1), inbound("later", 2), inbound("later still", 3)],
+    async (rec) => { if (rec.text === "poison") throw new Error("EPERM"); handled.push(rec.text); },
+    // RETURNED, not merely constructed (CR coderabbit-1): discarding it made the
+    // callback return undefined immediately, so the test proved nothing about
+    // awaiting. Returning it from a void-typed callback is exactly the shape a
+    // real async notifier has, and is what makes this a regression test.
+    () => new Promise<void>(() => {}),   // never settles; must not be awaited
+  );
+
+  expect(handled).toEqual(["later", "later still"]);
+});
+
+test("handleBatch handles every record when none throw (HIMMEL-1296)", async () => {
+  const handled: string[] = [];
+  await handleBatch(
+    [inbound("a", 1), inbound("b", 2)],
+    async (rec) => { handled.push(rec.text); },
+  );
+
+  expect(handled).toEqual(["a", "b"]);
+});
+
+// The tests above inject a mock isOperator, which proves the FLOOR but not the
+// production WIRING (panel CR glm-2). This one composes the real predicate —
+// `(from) => isAllowed(access, from)`, exactly what main() passes — against an
+// access.json shape where the two identities differ, so the claim that the floor
+// keys on the GLOBAL allowFrom (and not on group membership) is actually tested.
+test("operator floor keys on GLOBAL allowFrom: a per-group allowFrom member is still triaged (HIMMEL-1296)", async () => {
+  // 5 is the operator; 9 is merely allowed to post in group -50
+  const access = { allowFrom: ["5"], groups: { "-50": { allowFrom: ["9"] } } };
+  const isOperator = (from: number) => isAllowed(access, from);
+  const ignoreTriage = async (): Promise<TriageVerdict> => "ignore";
+
+  const rMember = root(); const memberRan: string[] = [];
+  await handleInbound(rMember, { from:9, chat_id:-50, text:"lol nice" },
+    async (s:string) => { memberRan.push(s); }, undefined, ignoreTriage, isOperator);
+  expect(memberRan).toEqual([]);                       // group member: dropped, gate keeps its teeth
+  expect(await readMeta(rMember, "group_-50")).toBeNull();
+
+  const rOp = root(); const opRan: string[] = [];
+  await handleInbound(rOp, { from:5, chat_id:-50, text:"try again.." },
+    async (s:string) => { opRan.push(s); }, undefined, ignoreTriage, isOperator);
+  expect(opRan).toEqual(["group_-50"]);                // operator: floored, never dropped
+});
+
+// A dispatch failure happens AFTER the message is durable, so it must not
+// escape handleInbound — handleBatch would label it "could not be queued" and
+// tell the operator to resend an already-enqueued message (CR coderabbit-1).
+// Reachable via TELEGRAM_BATCH_QUIET_MS=0, where the coalescer awaits dispatch.
+test("a dispatch failure after the inbox append does not escape handleInbound (HIMMEL-1296)", async () => {
+  const r = root();
+  let threw = false;
+  try {
+    await handleInbound(r, { from:5, chat_id:-50, text:"try again.." },
+      async () => { throw new Error("dispatch exploded"); },
+      undefined,
+      async (): Promise<TriageVerdict> => "spawn-high");
+  } catch { threw = true; }
+
+  expect(threw).toBe(false);
+  // and the message really is durable, so deliverAllPending can re-serve it
+  expect((await peekPending(r, "group_-50")).count).toBe(1);
+});
+
+// The poller must tell the classifier the SAME sender role the floor uses —
+// otherwise a group member could be classified under operator framing (CR
+// codex-adv-1), or the operator under shared-group framing.
+test("the sender role handleInbound passes to triage matches the floor's (HIMMEL-1296)", async () => {
+  const seen: Array<boolean | undefined> = [];
+  const recordingTriage = async (_t: string, _s?: string, fromOperator?: boolean): Promise<TriageVerdict> => {
+    seen.push(fromOperator); return "spawn-high";
+  };
+  const isOperator = (from: number) => from === 5;
+
+  await handleInbound(root(), { from:5, chat_id:-50, text:"try again.." },
+    async () => {}, undefined, recordingTriage, isOperator);
+  await handleInbound(root(), { from:9, chat_id:-50, text:"lol nice" },
+    async () => {}, undefined, recordingTriage, isOperator);
+
+  expect(seen).toEqual([true, false]);
 });
 
 test("DM chat bypasses cheap triage", async () => {

--- a/scripts/telegram/poller.ts
+++ b/scripts/telegram/poller.ts
@@ -261,7 +261,17 @@ export async function ingestUpdates(root: string, updates: any[], allow: AllowFn
 
 export type DeliveredMsg = { from: number; chat_id: number; text: string; ts?: number; forwarded?: boolean; caption?: boolean; image_path?: string; document_path?: string; document_name?: string };
 export type RunFn = (session: string, modelOverride?: TriageModelOverride) => Promise<void>;
-export type TriageFn = (text: string, sessionLabel?: string) => Promise<TriageVerdict>;
+// fromOperator selects the classifier's prompt framing (HIMMEL-1296 CR
+// codex-adv-1) — operator framing must not be told to a shared group's ordinary
+// members, whose chatter is what HIMMEL-721 exists to filter.
+export type TriageFn = (text: string, sessionLabel?: string, fromOperator?: boolean) => Promise<TriageVerdict>;
+// Is this sender the operator (the GLOBAL allowFrom identity — the same one
+// AutoGate.authorize uses), as opposed to some other member of a shared group?
+// Kept a separate dep from AutoGate rather than reusing its authorize: the
+// triage floor below is what keeps an operator message out of the drop path,
+// and it must not silently die if the /arm surface is ever disabled or rewired
+// (HIMMEL-1296).
+export type OperatorFn = (fromId: number) => boolean;
 
 // Auto-command gate (HIMMEL-424 B2). `fire` is FIRE-AND-FORGET so a slow arm never
 // blocks the ingest loop; `enabledOps` is parsed from TELEGRAM_AUTO_ACTIONS (empty by
@@ -277,7 +287,9 @@ export type AutoGate = { enabledOps: Set<string>; authorize: (from: number, chat
 
 // Single-threaded dispatch: the poller calls handleInbound serially, so the
 // "status === running" in-flight check needs no atomic CAS.
-export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn, auto?: AutoGate, triage: TriageFn = (text, sessionLabel) => classifyForSpawn(text, { sessionLabel })): Promise<void> {
+// isOperator defaults to "nobody is the operator" so every existing caller keeps
+// the pure HIMMEL-721 behaviour; main() is the one production wiring.
+export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn, auto?: AutoGate, triage: TriageFn = (text, sessionLabel, fromOperator) => classifyForSpawn(text, { sessionLabel, fromOperator }), isOperator: OperatorFn = () => false): Promise<void> {
   const route = classify(msg.text);
   // control verbs act directly; minimal handling for v2.2 (status/sessions/stop)
   if (route.kind === "control") {
@@ -317,8 +329,33 @@ export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn,
   // fail-open (any error → spawn-high) so a real failure still enqueues + spawns.
   let modelOverride: TriageModelOverride | undefined;
   if (msg.chat_id < 0 && (route.kind === "chat" || route.kind === "auto") && process.env.TELEGRAM_TRIAGE !== "off") {
-    const verdict = await triage(msg.text, session);
-    switch (verdict) {
+    // Resolved ONCE and used for both the classifier's framing and the floor —
+    // they must agree on who the sender is.
+    const fromOperator = isOperator(msg.from);
+    const verdict = await triage(msg.text, session, fromOperator);
+    // OPERATOR FLOOR (HIMMEL-1296). The drop above is for shared-group CHATTER;
+    // HIMMEL-721 exists to cut resource spam, never to filter the operator. When
+    // the sender IS the operator this is a message addressed to the agent, so an
+    // ignore/ack is a misclassification that costs the message with no trace —
+    // exactly the incident: `try again..` and `didn't understand the cosmetic
+    // item…` classified `ignore`, and `why didn't we got an answer on last
+    // messagE?` classified `ack`, i.e. the complaint about the drop was eaten by
+    // the same drop. Floored, not overridden: verdicts at or above spawn-low are
+    // untouched, so the classifier still picks cheap-vs-full model as before.
+    // SCOPE, precisely: this removes the TRIAGE drop. It does not make ingest
+    // crash-durable — `readNewLines` commits inbound.jsonl.cursor for the whole
+    // batch before this handler runs, so a crash between that commit and the
+    // inbox append below still loses the record. That window is pre-existing and
+    // applies to every message, not just floored ones; closing it is a per-record
+    // peek/ack redesign tracked as HIMMEL-1302 (found by the codex CR pass here).
+    // Logged when it fires (panel CR glm-1): a rescue is exactly as invisible as
+    // the drop it replaces, and "why did this spawn?" is the question the next
+    // triage misclassification will be debugged from. Same stream as the drop
+    // line below, so the supervisor log shows both sides of the gate.
+    const operatorFloor = fromOperator && (verdict === "ignore" || verdict === "ack");
+    const floored: TriageVerdict = operatorFloor ? "spawn-low" : verdict;
+    if (operatorFloor) console.error(`[poller] triage ${verdict} → spawn-low (operator floor) for ${session}`);
+    switch (floored) {
       case "ignore":
       case "ack":
         console.error(`[poller] triage ${verdict}: dropped (never enqueued) for ${session}`);
@@ -331,7 +368,7 @@ export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn,
       // exhaustive (mirrors noticeText): a future 5th verdict is a compile error,
       // not a silent fall-through that spawns untriaged.
       default:
-        return ((_: never) => { throw new Error(`unhandled triage verdict: ${String(_)}`); })(verdict);
+        return ((_: never) => { throw new Error(`unhandled triage verdict: ${String(_)}`); })(floored);
     }
   }
   const { created } = await ensureSession(root, session);
@@ -347,7 +384,21 @@ export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn,
   }
   const line = route.kind === "followup" ? route.text : msg.text;
   await appendLine(join(sessionDir(root, session), "inbox.jsonl"), JSON.stringify({ text: line, from: msg.from, ts: msg.ts ?? 0, ...(msg.image_path ? { image_path: msg.image_path } : {}), ...(msg.document_path ? { document_path: msg.document_path, document_name: msg.document_name } : {}) }));
-  if (meta.status === "idle" || meta.status === "done") await run(session, modelOverride);
+  // Everything above this line can throw BEFORE the append, and handleBatch's
+  // drop notice ("could not be queued — please resend") is truthful for those.
+  // The dispatch below is AFTER the message is durable, so its failure must not
+  // escape wearing that label (CR coderabbit-1): telling the operator to resend
+  // an already-enqueued message manufactures a duplicate. Reachable, not
+  // theoretical — with TELEGRAM_BATCH_QUIET_MS=0 the coalescer awaits dispatch
+  // inline, so a rejection propagates straight out of here. deliverAllPending
+  // is the existing recovery path for exactly this: the line is in the inbox.
+  if (meta.status === "idle" || meta.status === "done") {
+    try {
+      await run(session, modelOverride);
+    } catch (e) {
+      console.error(`[poller] dispatch after enqueue failed for ${session} — message is durable, deliverAllPending will re-serve it: ${e}`);
+    }
+  }
 }
 
 // Map the auto-action.sh exit code to an audit result label. OP-AWARE
@@ -626,6 +677,56 @@ export async function reconcile(root: string, isAlive: (pid: number) => boolean)
     const m = await readMeta(root, s);
     if (m && m.status === "running" && (m.last_run_pid == null || !isAlive(m.last_run_pid))) {
       await writeMeta(root, s, { ...m, status: "idle", last_run_pid: null });
+    }
+  }
+}
+
+// Drive ONE ingest batch, isolating each record (HIMMEL-1296 CR, codex-adv-1).
+// readNewLines has ALREADY advanced inbound.jsonl.cursor for the whole batch by
+// the time these records are handled, so a throw escaping this loop did double
+// damage: it killed the poller (the main loop wraps only getUpdates in a catch)
+// AND took every LATER record of that batch with it — permanently, because the
+// cursor says they were consumed. Those later records include operator messages
+// that never reached the triage floor, which is the exact loss this ticket
+// exists to close. handleInbound's own I/O is the reachable thrower here
+// (ensureSession / writeMeta / appendLine — EPERM, ENOSPC, EISDIR); triage
+// itself is fail-open. Losing ONE record loudly beats losing the rest silently.
+// This does NOT make ingest durable: the window between the cursor commit and
+// the inbox append remains, and closing it needs per-record peek/ack — HIMMEL-1302.
+// onDrop makes the drop VISIBLE instead of merely survivable (CR round 4).
+// Containing the throw traded a loud crash-loop for a quiet one: before, a
+// persistent session-storage fault killed the poller over and over, which at
+// least LOOKED broken; contained, it would consume and discard batch after batch
+// while the bridge looked healthy — the precise failure signature this ticket
+// exists to kill. So a drop tells the chat it happened. main() wires onDrop to a
+// DIRECT Telegram send rather than the session outbox, precisely so the notice
+// shares no state with the I/O whose failure it is reporting. onDrop's own
+// failure is caught and logged: a notice that cannot be delivered must not
+// abort the batch and strand the records behind it.
+// onDrop is FIRE-AND-FORGET BY SIGNATURE — it returns void and is never awaited
+// (CR codex-adv-1 round 7). The notice goes over the network, and sendMessage
+// retries up to 5x honouring Telegram's UNCAPPED retry_after; awaiting it here
+// would let one rate-limited chat stall every later record in a batch the cursor
+// has already consumed, and a restart while blocked would lose them for good.
+// Declaring it void puts that guarantee in the seam instead of in the caller's
+// good behaviour: a notifier that never settles cannot block the loop, because
+// the loop does not wait for it. Same reason AutoGate.fire is fire-and-forget.
+export async function handleBatch(
+  fresh: Inbound[],
+  handle: (rec: Inbound) => Promise<void>,
+  onDrop?: (rec: Inbound, err: unknown) => void,
+): Promise<void> {
+  for (const rec of fresh) {
+    try {
+      await handle(rec);
+    } catch (e) {
+      // update_id is the replay key (CR round 4): without it the log names no
+      // specific message, so a post-mortem cannot tell WHICH message was lost.
+      console.error(`[poller] handleInbound failed for update ${rec.update_id} chat ${rec.chat_id} — record dropped, batch continues: ${e}`);
+      if (onDrop) {
+        try { onDrop(rec, e); }
+        catch (e2) { console.error(`[poller] drop notice could not be raised for update ${rec.update_id}: ${e2}`); }
+      }
     }
   }
 }
@@ -1481,13 +1582,50 @@ export async function main(): Promise<void> {
     let updates: any[] = [];
     try { updates = await getUpdates(token, offset, 30); } catch (e) { console.error("[poller] getUpdates failed: " + e); await Bun.sleep(1000); continue; }
     await ingestUpdates(root, updates, allow, fetchImage, fetchVoice, fetchDoc, notifyDocFail);
-    const fresh = await readNewLines(join(root, "inbound.jsonl"), join(root, "inbound.jsonl.cursor"));
+    const fresh = await readNewLines<Inbound>(join(root, "inbound.jsonl"), join(root, "inbound.jsonl.cursor"));
+    // Per-BATCH, so it resets every poll tick: a chat whose fault persists is
+    // re-notified on the next batch rather than silenced for the session.
+    const notifiedChats = new Set<number>();
     // dispatch (not runFn) everywhere: runs fire WITHOUT blocking this loop —
     // ingest keeps polling while bounded children work (HIMMEL-246)
     // coalesce (not dispatch): each inbound RECORDS intent, so a same-tick burst
     // is one run even before the quiet window elapses — the intra-tick race the
     // ticket calls near-free to close (HIMMEL-1273).
-    for (const i of fresh) await handleInbound(root, { from: i.from, chat_id: i.chat_id, text: i.text, ts: i.ts, forwarded: i.forwarded, caption: i.caption, image_path: i.image_path, document_path: i.document_path, document_name: i.document_name }, coalesce, autoGate);
+    // isOperator = global allowFrom identity only (HIMMEL-1296): a per-group
+    // allowFrom member is an ordinary group member and stays fully triaged.
+    // handleBatch, not a bare for-await: one record's I/O failure must not take
+    // the rest of the already-consumed batch with it (HIMMEL-1296 CR).
+    await handleBatch(
+      fresh,
+      (i) => handleInbound(root, { from: i.from, chat_id: i.chat_id, text: i.text, ts: i.ts, forwarded: i.forwarded, caption: i.caption, image_path: i.image_path, document_path: i.document_path, document_name: i.document_name }, coalesce, autoGate, undefined, (from) => isAllowed(access, from)),
+      // sendMessage, NOT replyViaOutbox (CR codex-adv-1 round 6): the outbox is
+      // written INTO the same session directory whose failure caused the drop,
+      // so on an unwritable session it fails too — and the bridge would then eat
+      // that chat's messages indefinitely with nothing but supervisor.log to show
+      // for it, staying alive because the root inbound log is still fine. A
+      // direct send shares no state with the session, so the one failure that
+      // matters most is exactly the one it can still report.
+      (i) => {
+        // ONE notice per chat per batch (CR coderabbit-2). The failure this
+        // reports is usually per-SESSION and persistent — an unwritable session
+        // directory fails for every message to that chat — so a naive
+        // notice-per-record turns a broken chat into a burst of identical alerts,
+        // which is the resource spam HIMMEL-721 exists to prevent, aimed at the
+        // operator. Every dropped record is still logged individually below.
+        if (notifiedChats.has(i.chat_id)) {
+          console.error(`[poller] drop notice suppressed (chat already notified this batch) for update ${i.update_id} chat ${i.chat_id}`);
+          return;
+        }
+        notifiedChats.add(i.chat_id);
+        // The boolean IS the error channel: sendMessage returns false on a
+        // permanent 4xx, a transport failure, or exhausted retries rather than
+        // throwing (telegram-api.ts), so ignoring it would let the visibility
+        // guarantee fail silently — the exact shape of this whole ticket.
+        void sendMessage(token, i.chat_id, `⚠️ Your last message could not be queued (update ${i.update_id}) and was NOT answered — please resend. Details in supervisor.log.`)
+          .then((ok) => { if (!ok) console.error(`[poller] drop notice UNDELIVERED for update ${i.update_id} chat ${i.chat_id} — this log is now the only record of the drop`); })
+          .catch((e) => { console.error(`[poller] drop notice threw for update ${i.update_id}: ${e}`); });
+      },
+    );
     await deliverAllPending(root, dispatch, new Date(), () => sessionsList(root), coalesce.isHolding);
     await sweepStuckRunning(root, dispatch.isInFlight, () => sessionsList(root));
   }

--- a/scripts/telegram/triage.test.ts
+++ b/scripts/telegram/triage.test.ts
@@ -64,6 +64,66 @@ test("classifyForSpawn spawns a real non-WSL bash against an existing script (HI
   expect(resolveBash()).toBe(BASH_BIN);
 });
 
+// HIMMEL-1296. The prompt handed the classifier a bare message: no statement of
+// what the group IS, and — the part that actually caused the loss — no statement
+// that `ack` DISCARDS the message. `ack` reads as "send an acknowledgement", so
+// the model picked it for messages it had understood were addressed to the
+// agent, and the poller threw them away. Both halves are asserted here; the
+// measured verdict shift they produce is recorded above triagePrompt().
+test("triage prompt frames the channel AND names each verdict's effect (HIMMEL-1296)", async () => {
+  let prompt = "";
+  await classifyForSpawn("try again..", {
+    invoke: async (_args, input) => { prompt = input; return "spawn-low"; },
+    timeoutMs: 1000,
+    fromOperator: true,
+  });
+
+  expect(prompt).toContain("from the human operator");
+  expect(prompt).toContain("follow-up is still a request");
+  // the drop verdicts must both be described as discarding — `ack` especially,
+  // whose token name otherwise promises the opposite of what it does
+  expect(prompt).toContain("ignore: silently discarded");
+  expect(prompt).toContain("ack: ALSO silently discarded");
+  expect(prompt).toContain("try again..");
+  // the four-token answer contract must survive the added framing
+  expect(prompt).toContain("exactly one token: ignore, ack, spawn-low, or spawn-high");
+});
+
+// The operator framing must go ONLY where it is true (CR codex-adv-1). A bare
+// group allowlist admits every member, so telling the classifier "this is from
+// the operator" for an ordinary member would widen the very spam gate
+// HIMMEL-721 exists to keep — and the branch's own measurements show framing
+// moves verdicts, so this is not a harmless inaccuracy.
+test("a NON-operator gets shared-group framing, never the operator framing (HIMMEL-1296)", async () => {
+  let prompt = "";
+  await classifyForSpawn("lol nice", {
+    invoke: async (_args, input) => { prompt = input; return "ack"; },
+    timeoutMs: 1000,
+    fromOperator: false,
+  });
+
+  expect(prompt).not.toContain("from the human operator");
+  expect(prompt).not.toContain("follow-up is still a request");
+  expect(prompt).toContain("NOT from the operator");
+  expect(prompt).toContain("ordinary chatter");
+  // the ROLE-NEUTRAL half — what the verdicts actually do — is still told to
+  // everyone, because that is what stops `ack` reading as "acknowledge"
+  expect(prompt).toContain("ack: ALSO silently discarded");
+});
+
+// Absence of the flag must fall to the SAFE side: an unwired caller gets the
+// shared-group framing, never the operator's.
+test("triage prompt defaults to shared-group framing when the role is unset (HIMMEL-1296)", async () => {
+  let prompt = "";
+  await classifyForSpawn("hello", {
+    invoke: async (_args, input) => { prompt = input; return "ack"; },
+    timeoutMs: 1000,
+  });
+
+  expect(prompt).not.toContain("from the human operator");
+  expect(prompt).toContain("NOT from the operator");
+});
+
 test("classifyForSpawn fails open on classifier timeout", async () => {
   const verdict = await classifyForSpawn("hello", {
     invoke: async () => {

--- a/scripts/telegram/triage.ts
+++ b/scripts/telegram/triage.ts
@@ -9,7 +9,10 @@ export type TriageVerdict = "ignore" | "ack" | "spawn-low" | "spawn-high";
 // fall-through to the default model.
 export type TriageModelOverride = "haiku";
 export type TriageInvokeFn = (args: string[], prompt: string) => Promise<string>;
-export type TriageDeps = { invoke?: TriageInvokeFn; timeoutMs?: number; sessionLabel?: string };
+// fromOperator (HIMMEL-1296 CR codex-adv-1): the sender's ROLE, which selects
+// the prompt framing. Defaults false — the conservative side: an unwired caller
+// gets the shared-group framing, never the operator one.
+export type TriageDeps = { invoke?: TriageInvokeFn; timeoutMs?: number; sessionLabel?: string; fromOperator?: boolean };
 
 const VERDICTS = new Set<TriageVerdict>(["ignore", "ack", "spawn-low", "spawn-high"]);
 const DEFAULT_TIMEOUT_MS = 20_000;
@@ -28,9 +31,61 @@ function resolveTimeoutMs(): number {
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TIMEOUT_MS;
 }
 
-function triagePrompt(text: string): string {
+// HIMMEL-1296. Two things were wrong with the bare-message prompt.
+//
+// 1. It never said what the group IS, so a terse follow-up (`try again..`,
+//    `Status?`) was indistinguishable from idle chatter.
+// 2. `ack` LIES about its effect. To a classifier the token reads "send an
+//    acknowledgement"; at the poller it means the same as `ignore` — silently
+//    discarded, nobody ever sees it. So the model picked the label whose name
+//    matched its intent and unknowingly chose the drop.
+//
+// Naming each verdict's consequence is what actually moves messages out of the
+// drop set. Measured against the three texts the incident lost, via the live
+// classifier (deepseek-v4-flash):
+//
+//   prompt                     try again..   …upgrraded whispper?   why didn't we got an answer
+//   bare (before)              ignore        ignore                 ack
+//   + channel framing only     ack           ack                    ack        ← still dropped
+//   + verdict EFFECTS (this)   spawn-low     spawn-low              spawn-low  ← answered
+//
+// and genuine chatter (`lol nice`, `haha 😂`, `ok`) still classifies `ack`, so
+// the HIMMEL-721 spam gate keeps its teeth.
+//
+// Deliberately stateless — no conversation history: the poller's triage gate
+// runs BEFORE the enqueue precisely so it needs no session I/O.
+function triagePrompt(text: string, fromOperator: boolean): string {
   return [
     "Classify this Telegram group message for whether it needs an agent spawn.",
+    // ROLE-SPLIT (CR codex-adv-1). The framing was originally sent to EVERY
+    // sender, which told the classifier "most traffic is the operator" even for
+    // an ordinary member of a shared group — a bare group allowlist admits every
+    // member. Measured chatter still classified `ack` under it, so no promotion
+    // was observed, but asserting something false about the sender to widen a
+    // spam gate is the wrong shape regardless: HIMMEL-721 exists to filter
+    // exactly those members. The operator framing now goes only where it is true.
+    ...(fromOperator
+      ? ["This message is from the human operator the agent works for: it is an",
+         "instruction or a question addressed to the agent, and a terse or",
+         "context-free follow-up is still a request."]
+      // Deliberately says "not from the operator" rather than "from another
+      // member": anonymous CHANNEL posts also land here (ingest falls their
+      // `from` back to sender_chat, a channel id that is never in allowFrom), and
+      // a broadcast post is not a group member. Their handling is unchanged from
+      // before this ticket — no exemption existed for anyone — so this is
+      // accuracy, not a behaviour change. Recognising an operator posting under a
+      // channel identity would need a trusted-channel policy; not in scope here.
+      : ["This message is a shared-group post and is NOT from the operator.",
+         "Most such traffic is ordinary chatter that needs no agent at all."]),
+    // Role-NEUTRAL, and the half that actually did the work: the verdict labels
+    // lie about their effect to anyone who has not been told otherwise.
+    "The verdict decides what HAPPENS to the message:",
+    "- ignore: silently discarded, nobody ever sees it. Group noise only.",
+    "- ack: ALSO silently discarded — no acknowledgement is sent. Use it only for",
+    "  messages that need no response at all.",
+    "- spawn-low: answered by a small cheap model. Use for anything addressed to",
+    "  the agent that is simple, terse, or a follow-up.",
+    "- spawn-high: answered by the full model. Use for real work or hard questions.",
     "Answer with exactly one token: ignore, ack, spawn-low, or spawn-high.",
     "Message:",
     text,
@@ -93,7 +148,7 @@ export async function classifyForSpawn(text: string, deps: TriageDeps = {}): Pro
   const label = deps.sessionLabel ?? "unknown-session";
 
   try {
-    const prompt = triagePrompt(text);
+    const prompt = triagePrompt(text, deps.fromOperator === true);
     const output = deps.invoke
       ? await invokeWithTimeout(deps.invoke(args, prompt), timeoutMs)
       : await defaultInvoke(args, prompt, timeoutMs);


### PR DESCRIPTION
The cheap triage gate that filters shared-group spam was dropping the **operator's own messages**. `ignore`/`ack` is a *permanent* drop at the poller — nothing written to the session inbox, the consumed cursor never moves, so a later delivery sweep has nothing to resurrect. The bridge went silent and looked dead for over an hour. One of the dropped messages was the operator asking why the previous one had gone unanswered.

## Two root causes

**1. The gate had no notion of sender.** It exists to cut resource spam in *shared groups*, never to filter the operator. An operator message whose verdict is `ignore`/`ack` is now floored to `spawn-low` instead of dropped. It is a floor, not an override — `spawn-high` still gets the full model, so the classifier keeps choosing cheap-vs-full exactly as before.

**2. The prompt lied about its own verdicts.** `ack` reads as "send an acknowledgement"; at the poller it means *silently discarded*. So the model picked the label that matched its intent and unknowingly chose the drop. Naming each verdict's actual consequence is what moves messages out of the drop set — measured on the live classifier:

| prompt | `try again..` | a two-part question | `why didn't we got an answer` |
|---|---|---|---|
| bare (before) | `ignore` | `ignore` | `ack` |
| + channel framing only | `ack` | `ack` | `ack` — still dropped |
| + verdict **effects** | `spawn-low` | `spawn-high` | `spawn-low` — answered |

Ordinary chatter (`lol nice`, `ok`, `thanks!`) still classifies `ack`/`ignore`, so the spam gate keeps its teeth. The operator framing is sent **only** to the operator: a bare group allowlist admits every member, so asserting "this is from the operator" for an ordinary member would widen the very gate this filter exists to keep.

## Ingest batch hardening

The inbound cursor is advanced for the *whole batch* before any record is handled, and the main loop caught only the update fetch. So a throw out of the handler killed the poller **and** took every later record of that already-consumed batch with it, permanently — including operator messages that never reached the new floor. An exception is far more reachable than a crash here: the handler's own I/O can throw `EPERM`/`ENOSPC`/`EISDIR`, and only the classifier is fail-open.

Records are now isolated, and a drop is **announced** rather than merely survived — containing the throw would otherwise trade a loud crash-loop for a healthy-looking bridge that quietly eats messages, which is the exact signature this fix exists to kill. The notice goes over a direct send rather than the session outbox, so it does not fail for the same reason the drop did; it is fire-and-forget by signature, so a rate-limited notice cannot stall the records behind it; and it is deduped per chat per batch so a persistently broken chat does not produce an alert storm.

## Known limit, unchanged here

The cursor commits before the message is durable, so a crash in that window still loses a record. Closing it needs per-record peek/ack plus `update_id` dedup — a redesign of the ingest durability contract for *all* messages, deliberately not folded into an incident fix.

## Tests

226 pass across the poller, triage, bus, gate and router suites, including regressions for the floor, the role-split framing, batch isolation, the drop notice, and a notifier that never settles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Operator messages are no longer silently discarded during triage.
  * Operator messages are classified with the correct context and priority.
  * A failed message dispatch no longer causes the message to be lost.
  * Errors processing one incoming message no longer prevent later messages from being handled.
  * Dropped messages now produce a direct warning, with duplicate warnings suppressed within the same batch.

* **Reliability**
  * Improved handling of notification failures and stalled message processing so polling continues normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->