### PR TITLE
docs: trim the always-loaded context surface + close the debrand-coverage hole

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,13 @@ repos:
         always_run: true
         pass_filenames: false
 
+      - id: debrand-coverage
+        name: every debrand rule still matches CLAUDE.md (himmel-dev only)
+        entry: bash scripts/hooks/check-debrand-coverage.sh
+        language: system
+        always_run: true
+        pass_filenames: false
+
       - id: lanes-inventory-guard
         name: lane inventory stays out of CLAUDE.md prose (HIMMEL-689, himmel-dev only)
         entry: bash scripts/hooks/check-lanes-inventory.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,26 +47,16 @@ exists to make Claude's behavior *structurally* safe and repeatable
 rather than relying on it to remember prose. Positioning — the
 [Tier 3-4 maturity stance](README.md#who-is-this-for--tier-3-4-on-the-maturity-ladder)
 and the [Camp 2 memory architecture](README.md#memory-architecture--camp-2-a-context-substrate-not-a-backend)
-— lives in `README.md`.
-
-This file is **state, not a prompt**: repo memory of why/map/rules/
-workflows, kept short on purpose. Reference detail lives in
-`docs/internals/` (linked below) so it loads only when needed. Every
-line here is paid for in every session — if a rule isn't session-time
-relevant, it belongs in a doc, not here.
+— lives in `README.md`. Reference detail lives in `docs/internals/`.
 
 ## MAP
 
-- `scripts/` — shell tooling (worktrees, guardrails, handover, jira, hooks).
-- `scripts/jira/dist/index.js` — the Jira CLI (prefer over Atlassian MCP).
-- `.claude/settings.json` — hooks (UserPromptSubmit, PreToolUse) + permissions.
-- `.pre-commit-config.yaml` — pre-commit/commit-msg/pre-push gates (source of truth).
-- `marketplace/plugins/` — vendored + forked plugins (handover, pr-review-toolkit-himmel, …).
-- `docs/internals/` — extracted reference (enforcement, handover-system, jira-plugin, stuck-playbook).
-- `docs/setup/`, `docs/luna/`, `docs/security-review.md` — setup, luna guides, security.
-- Subdir `CLAUDE.md` (scripts/jira, scripts/handover, scripts/hooks,
-  marketplace/plugins) — subtree-local dev conventions, loaded only when
-  working there. This file stays cross-project invariants.
+Layout is discoverable (`ls`); only the non-obvious matters here.
+`scripts/jira/dist/index.js` is the Jira CLI — an untracked build artifact,
+which is why the invocation rule below exists. Subdir `CLAUDE.md`
+(`scripts/jira`, `scripts/handover`, `scripts/hooks`, `marketplace/plugins`)
+carries subtree-local dev conventions; this file stays cross-project
+invariants.
 
 ## RULES
 
@@ -86,9 +76,8 @@ operator's user-scope `~/.claude/CLAUDE.md`. Use judgement on trivial tasks.
 ### Git workflow
 - All feature work in git worktrees. Never commit directly to main.
 - All changes via PR. No direct pushes to main. PRs need ≥1 approval before merge.
-- Conventional commits: `type(scope): [HIMMEL-N ]message` where type ∈
-  `feat|fix|chore|docs|refactor|test`. Ticket ID optional per commit, validated
-  if present.
+- Conventional commits; the `commit-msg` gate validates the shape plus an
+  optional `HIMMEL-N` ticket ID.
 - **Every private-repo PR carries a Jira ticket** (operator, 2026-07-16).
   Retro-filing is fine — the ticket may be created after the work started —
   but the PR must reference one (title and/or commits) before merge. Search
@@ -116,14 +105,11 @@ denial recovery: `himmel-ops:stuck-playbook` skill.
 
 ### Claude invocation billing (HIMMEL-128)
 Headless invocations (`claude -p`/`--print`/`--bg`/Agent SDK; same for
-gemini-cli, HIMMEL-157) bill to a separate bucket (announced **2026-06-15**;
-**currently PAUSED** by Anthropic as of 2026-06-21 — preference kept because
-the split is volatile and may re-activate). Scripts here prefer interactive
-`claude "$prompt"`. The
-`no-headless-claude`/`no-headless-gemini` pre-commit gates block new
-headless calls unless marked `# headless-claude-ok: <reason>` /
+gemini-cli) bill to a separate bucket, so scripts here prefer interactive
+`claude "$prompt"`. The `no-headless-claude`/`no-headless-gemini` pre-commit
+gates block new headless calls unless marked `# headless-claude-ok: <reason>` /
 `# headless-gemini-ok: <reason>` on the call line or the line above.
-Detail + exempt paths: [`docs/internals/enforcement.md`](docs/internals/enforcement.md#claude-invocation-billing-himmel-128).
+Current status, dates + exempt paths: [`docs/internals/enforcement.md`](docs/internals/enforcement.md#claude-invocation-billing-himmel-128).
 
 ### Bash command shape (HIMMEL-203)
 Native permission matcher bails + PROMPTS on `$var`/`$(…)`/backticks/compound
@@ -133,62 +119,54 @@ what `auto-approve-safe-bash` does/doesn't cover: `himmel-ops:stuck-playbook`
 skill / [`docs/internals/stuck-playbook.md`](docs/internals/stuck-playbook.md).
 
 ### Subagent policy — delegation & escalation (HIMMEL-166/688)
-<!-- FABLE-WINDOW: HIMMEL-688 hybrid — Opus 4.8 default parent, Fable-5 escalation-only.
-     On loss of Fable access, drop the top-model table row, the escalation paragraph,
-     AND the Fable effort-calibration lines (the former Sonnet-comparison clause was
-     superseded by the HIMMEL-774 calibration row, 2026-07-10); the dispatch-naming
-     paragraph SURVIVES a revert (Opus original in HIMMEL-282).
-     Markers documentary; text between them is live prose — revert = REPLACE it. -->
-**The higher your tier, the more you delegate.** Push the work down;
-keep your own context for judgment. Hand any self-contained subtask to
-a subagent and keep working while it runs. Brief every child: the
-context, the why, what done looks like — it starts blank and inherits
-nothing. Route by lane. The Claude tiers are always present; their
-*semantics* (what each tier is for) are invariant:
+<!-- FABLE-WINDOW: HIMMEL-688 hybrid — Opus default parent, Fable-5 escalation-only.
+     The tier table, effort calibration and cost posture now live in
+     docs/internals/lane-calibration.md (moved HIMMEL-480). On loss of Fable
+     access, revert THERE: drop the top-model table row, the escalation-shape
+     section, and the Fable effort lines. In CLAUDE.md only the Fable mention in
+     the tier-semantics sentence and the escalation sentence need dropping; the
+     dispatch-naming and floor paragraphs SURVIVE a revert (Opus original in
+     HIMMEL-282). Both of those mentions are debranded out of AGENTS.md by
+     debrand.json, so the generated file needs no revert of its own.
+     Markers documentary; text between them is live prose. -->
+**Delegate what is genuinely independent and sizeable — and only that.**
+Don't delegate work you'd finish in a handful of tool calls, and never spawn a
+subagent to verify or double-check your own work; current models over-delegate
+and over-verify by default, and both multiply cost without improving the result.
+When you do delegate, brief every child: the context, the why, what done looks
+like — it starts blank and inherits nothing. Keep spawn counts low.
 
-| Lane | Best for | Effort / notes |
-|---|---|---|
-| Haiku | bulk mechanical (never delegates further) | low |
-| Sonnet 5 | scoped research; **default implementor for well-specified impl briefs (intro $2/$10 through 2026-08-31 — recalibrate Sep: HIMMEL-774)** | medium default; high for multi-file/long briefs — raise effort before Opus |
-| Opus 4.8 | multi-step reasoning; **default parent/orchestrator** | xhigh default for orchestration; scale DOWN (high/medium) for lighter parenting or scoped impl |
-| top model | judgment, taste — hardest calls; escalation target | scale to the item (operator 2026-07-08, un-capped): medium default; **high for substantial judgment work — not just the hardest**; xhigh for the hardest |
+Tier semantics are invariant: Haiku = bulk mechanical; Sonnet 5 = scoped
+research and default implementor for well-specified briefs; Opus = multi-step
+reasoning and default parent/orchestrator; the top model = judgment and taste, the
+escalation target. Query the live inventory with **`/lanes`** — never route to a
+lane it doesn't list. Tier/effort/cost detail:
+[`docs/internals/lane-calibration.md`](docs/internals/lane-calibration.md).
 
-Beyond the Claude tiers the fleet includes machine-specific impl/critic/
-bulk lanes (paid/optional — they exist only where the operator configured
-them). Query the live set with **`/lanes`** (derived from
-`scripts/lanes/lanes.json` + machine state, HIMMEL-689) — never route to a
-lane `/lanes` doesn't list. The tier semantics above are invariant; the
-inventory is data.
+**Escalation over top-down:** the parent needn't be the top model — an Opus
+parent spawns a top-model child for the one hard call, when `/lanes` lists that
+tier; where it doesn't, stay at the highest listed tier rather than routing to
+an absent lane. Work above your tier? Return it — don't burn tokens on it.
 
-**Escalation over top-down:** the parent doesn't have to be the top
-model — the Opus parent spawns a top-model child for the one hard call;
-the child answers and returns. Top-model-as-parent only by operator
-choice — it then delegates EVERY implementation chunk to a cheaper
-lane and owns planning/judgment/final synthesis; inline impl on a
-top-tier parent is the anti-pattern (sole exception: ONE trivial
-CR-fix faster to apply than to re-brief — per PR, not per round;
-from the second CR round on, batch remaining findings to a worker
-lane in shared-branch mode, HIMMEL-1216). Work above your tier?
-Return it — don't burn tokens on it.
+**Use the top-tier lane as parent only by operator choice.** It then delegates
+every implementation chunk downward.
 
-**Every dispatch names an explicit model** — an unnamed dispatch
-inherits the parent loop and burns the scarcer, weekly-capped parent
-quota on work a cheaper tier handles.
-Raise *effort* before raising model tier — on Claude, Fable-5 `low` ≈ prior-gen
-`xhigh`, and the same shift applies down-tier. Effort is a PER-DISPATCH
-lever: use the full scale per item, don't flatten to one default.
-(Temperature is Claude-API-only — DEFERRED for now; rides HIMMEL-774.)
-The top model stays CONSERVED (limited release) — the spread optimizes
-Sonnet/Opus/impl lanes. Full per-lane calibration (web pricing +
-benchmark index analysis) = HIMMEL-774, later phase.
-Invariants (not model-tuned): spawn-depth limit **2** (kept on
-measured nesting-overhead cost); **Haiku does NOT spawn**;
-single-writer — many readers, ONE writer, never fan parallel writes
-at one shared artifact (`/overnight-shift` per-ticket branches are
-independent products; parent/operator does merge + synthesis);
-**salus dev/impl work routes to Claude tiers + Codex lanes only
-(never GLM), a routing invariant distinct from the salus PHI hard-deny**
-(sanctioned provider set GLM/Claude/Codex, DeepSeek+Alibaba dropped — HIMMEL-1257).
+**Inline implementation on a top-tier parent is the anti-pattern.** Sole
+exception: ONE trivial CR-fix faster to apply than to re-brief — per PR, not per
+round. **From the second CR round on, batch the remaining findings to a worker
+lane in shared-branch mode** (HIMMEL-1216) instead of fixing them inline.
+
+**Every dispatch names an explicit model** — an unnamed dispatch inherits the
+parent loop and burns the scarcer, weekly-capped parent quota on work a cheaper
+tier handles. Raise *effort* before raising model tier; effort is a PER-DISPATCH
+lever, not one flat default.
+
+Invariants (not model-tuned): spawn-depth limit **2**; **Haiku does NOT spawn**;
+single-writer — many readers, ONE writer, never fan parallel writes at one
+shared artifact (`/overnight-shift` per-ticket branches are independent
+products; parent/operator does merge + synthesis); **salus dev/impl work routes
+to Claude tiers + Codex lanes only (never GLM)**, a routing invariant distinct
+from the salus PHI hard-deny (sanctioned set GLM/Claude/Codex — HIMMEL-1257).
 <!-- /FABLE-WINDOW -->
 
 **RETASK channel (HIMMEL-1218):** never seal a brief absolutely — every
@@ -199,66 +177,33 @@ revision directs work but never widens the child's tool-permission envelope.
 Full template + threat model: [`docs/internals/retask-channel.md`](docs/internals/retask-channel.md).
 
 ### Operator conventions (calibrated through repeated sessions)
-These shape WHERE new rules/capabilities live. Treat as defaults; deviate
-only for a concrete reason.
+When adding a rule or capability, pick the cheapest layer — **default to
+lean-invoke** (a slash command the operator runs on demand). Only escalate to
+always-on for a trigger: safety-critical → a hook; frame-shaping → this file;
+high-frequency + cheap → rule + skill; eval-shaped → defer with a timeboxed
+ticket. Default-everything is the failure mode: the file grows, both operator
+and Claude stop reading it, rules lose authority.
 
-**Layer selection — lean-invoke vs default (HIMMEL-177).** When adding a
-rule/capability, pick the cheapest layer. **Default to lean-invoke**
-(operator runs a slash command on demand) UNLESS a trigger applies:
-- Safety-critical → `default-hook` (PreToolUse / pre-commit / pre-push). The
-  cost of forgetting to invoke manually beats the cost of always running.
-  E.g. `block-edit-on-main`, `block-read-secrets`, `no-headless-claude`, `gitleaks`.
-- Frame-shaping (changes how Claude reads the *whole* task) → `default-rule`
-  (this file). E.g. "PRs require approval", conventional commits, "prefer plugin over MCP".
-- High frequency × low marginal cost → `default-rule + installed skill`.
-  E.g. `/handover`, `/clean`, `/worktree`.
-- Eval-shaped ("read X, decide, write ADR", no ship-code) → `defer`: file a
-  timeboxed ticket, close Won't Do on expiry. Do NOT install as always-on.
+**Structural > instructional.** Track the drift count per instructional rule.
+First drift is signal; on the **second**, escalate to structural (hook, gate,
+classifier, dispatcher guard) — not to stronger prose. Prose does not enforce.
 
-Default-everything is the failure mode — more always-on rules without a
-trigger above creates drift: the file grows, both operator and Claude stop
-reading it, rules lose authority. Lean-invoke keeps the cost on the
-operator's side, which is the right side: the operator knows when a rule
-applies; Claude does not.
+Full frame + worked escalation examples:
+[`docs/internals/context-architecture.md`](docs/internals/context-architecture.md).
 
-**Enforcement strength — structural > instructional (HIMMEL-195).** Track
-the **drift count** per instructional rule. First drift is signal; on the
-**second** drift escalate to structural (PreToolUse hook, pre-commit/
-pre-push gate, classifier, dispatcher guard) — don't wait for the third, by
-then the rule has lost authority and Claude is rationalising bypasses.
-Prose does not enforce. `default-rule` is a fine first layer, but its next
-layer after drift is structural, not "stronger prose." (Worked escalation
-examples — MCP-jira, headless-billing, edit-on-main, secrets-reads — and the
-per-layer example set: [`docs/internals/enforcement.md`](docs/internals/enforcement.md#operator-conventions--worked-examples).)
+### Where artifacts land (HIMMEL-138 / HIMMEL-409)
+- **Reference docs operators consume** → the owning repo's `docs/`
+  (himmel luna docs → `docs/luna/`; plugin specs → `plugins/<plugin>/README.md`).
+  The vendored template `templates/luna-second-brain/` is OSS-quality — it is the
+  source that propagates to the public `luna-brain` repo.
+- **Internal specs, plans, decision records** → the state repo bucket
+  `<state-repo>/handovers/<USER_SLUG>/<repo-bucket>/specs/<type>/`, **never**
+  himmel `docs/` (reference + OSS-public only). Cross-repo source of truth is
+  the handover skill, which loads in any repo unlike this project-scoped file.
+- **Vault content** (clips, notes, daily entries) → stays in luna.
 
-### Luna-area docs convention (HIMMEL-138, locked 2026-05-25)
-Three tiers for luna-touching artifacts:
-1. **Reference docs operators consume** (guides, runbooks, architecture) →
-   the relevant repo's `docs/` (himmel luna docs → `himmel/docs/luna/`;
-   luna → `luna/docs/`; the vendored vault template →
-   `himmel/templates/luna-second-brain/docs/`, OSS-quality from day 1 because it
-   propagates to the separate public `luna-brain` repo — it is the source, not
-   the publish target itself; plugin specs stay in
-   `plugins/<plugin>/README.md`).
-2. **Personal-state work artifacts** (handovers, work/decision logs,
-   journal-style decision records, next-session-resume) →
-   `<state-repo>/handovers/<USER_SLUG>/<repo-bucket>/` (cross-cutting → `…/cross/`).
-3. **Vault content** (clips, notes, daily entries) → unchanged, stays in luna.
-
-Author new luna-touching reference docs in `docs/luna/`; author
-journal-style decision records under the appropriate <state-repo> bucket.
-
-**Internal specs/plans → state repo, not himmel `docs/` (HIMMEL-409).** Design
-docs, implementation plans, and decision records are work artifacts → the
-state bucket `<state-repo>/handovers/<USER_SLUG>/<repo-bucket>/specs/<type>/`
-(subfolders `design/`, `plan/`, …; extensible). They never live in himmel
-`docs/` (reference + OSS-public only). Cross-repo source of truth = the
-**handover skill** (loaded in any repo, unlike this project-scoped file);
-existing `docs/specs/` files migrate per-ticket.
-
-**Luna recent context (HIMMEL-254):** read `~/Documents/luna/hot.md` (if present)
-first for recent vault context (~500-word Tier-2 hot cache) before crawling luna
-`index.md`.
+**Luna recent context:** read `~/Documents/luna/hot.md` (if present) before
+crawling luna `index.md` — it's a ~500-word hot cache.
 
 ### Memory recall — the index routes, it does not store (HIMMEL-570)
 The always-loaded `MEMORY.md` index carries **routing lines, not bodies**. On a
@@ -269,42 +214,29 @@ before improvising** — that read is the primary path. qmd the substrate
 (it searches everything while looking scoped). A qmd miss is **not** evidence a
 fact is absent.
 
-### graphify — retrieval routing (HIMMEL-621)
-graphify is the knowledge-graph CLI over vaults/docs (entity/relation
-extraction + graph queries). One flow, three organs: **qmd finds content,
-graphify explains structure, tokensave serves symbol-level code ops.**
-Route by question shape:
-- Content lookup ("where is X discussed") → **qmd**, first hop.
-- Structure/neighborhood ("what clusters around X", "what does this epic
-  touch") → `graphify query` / `graphify explain`; whole-architecture
-  review → `GRAPH_REPORT.md` (graphify ≤0.9.18 has no `wiki` command; at
-  >5000 nodes `graph.html` is skipped — use `graphify tree` for a viz).
-- Symbol-level code ops → **tokensave**; graphify = architecture/community
-  views + all non-code. (headroom, if ever adopted post-H4 gate
-  (HIMMEL-622), = context-window management only — not retrieval.)
-- Cross-file "how is A related to B" → `graphify query` each + join
-  in-head, or qmd. **Never `graphify path`** — node IDs are file-scoped
-  (same entity in two files = two disconnected nodes), so cross-file path
-  traversal is structurally broken.
-Graph refresh is lean-invoke (`graphify <corpus-copy> --update`), never a
-hook. Extraction backends are governed by the egress matrix
-(`scripts/guardrails/egress-matrix.json` — HIMMEL-766, lands via PR #985);
-extraction runs on scratchpad copies, never live vaults.
+### Retrieval routing (HIMMEL-621)
+Three organs: **qmd finds content, graphify explains structure, tokensave
+serves symbol-level code ops.** Content lookup → qmd, first hop. Structure or
+neighborhood → `graphify query` / `graphify explain`. Symbol-level code →
+tokensave.
+
+Traps: **never `graphify path`** — node IDs are file-scoped, so the same entity
+in two files is two disconnected nodes and cross-file traversal is structurally
+broken (join `graphify query` results in-head instead). Extraction runs on
+scratchpad copies, **never live vaults**, and its backends are governed by
+`scripts/guardrails/egress-matrix.json`. Graph refresh is lean-invoke
+(`graphify <corpus-copy> --update`), never a hook.
 
 ## WORKFLOWS
 
 ### Worktree commands (one orchestrator, `scripts/clean-garden.sh`)
-- **`/worktree <branch>`** — create only. Branch must be `type/slug`
-  (`feat|fix|chore|docs|refactor|test`).
-- **`/clean`** — prune merged-PR worktrees only.
-- **`/clean_garden <branch>`** — prune AND create in one shot.
+`/worktree` (create), `/clean` (prune merged), `/clean_garden` (both). Branch
+must be `type/slug` (`feat|fix|chore|docs|refactor|test`). Superseded, don't
+use: `/new-worktree`, `/clean_gone`.
 
-Pick by intent: fresh feature = `/worktree`, prune cycle = `/clean`,
-both = `/clean_garden`. (Superseded, don't use: `/new-worktree`, `/clean_gone`.)
-`/worktree` (via `scripts/_new-worktree.sh`) refuses to create a worktree for
-a branch whose PR is already MERGED (bypass: `REUSE_MERGED_BRANCH_OK=1`).
-`/himmel-doctor` C7 flags lingering worktrees on merged-PR branches as a
-read-only diagnostic (points to `/clean`; no `--fix`; HIMMEL-512).
+Non-obvious: `/worktree` refuses a branch whose PR is already MERGED (bypass:
+`REUSE_MERGED_BRANCH_OK=1`), and `/himmel-doctor` C7 flags lingering merged-PR
+worktrees read-only (points to `/clean`; no `--fix`).
 
 ### Handover
 All personal handover state is centralized in your handover state repo
@@ -325,17 +257,14 @@ Autonomous end-to-end execution of a well-scoped ticket: see
 
 ## ENFORCEMENT (runs automatically)
 
-himmel enforces structurally, not by prose: PreToolUse hooks (safe-bash
-auto-approve; the edit-on-main / read-secrets / backend-tier / CR-marker /
-jira-compound-write / unresolved-CR-merge / merged-PR-commit / docker-privesc /
-rogue-schedule / rogue-codex-wsl guards; `guard-implementor-dispatch` cost guard; the cap-arm
-hooks), a PostToolUse cap-arm hook, **pre-commit/commit-msg/pre-push gates**
-(source of truth `.pre-commit-config.yaml`), and an opt-in `SessionStart` hook (`inject-initiative.sh`
-`HIMMEL_INITIATIVE`, default OFF); `improve-on-submit.sh` is a
-`UserPromptSubmit` hook wired only in the Codex lane
-(`.codex/hooks.json`), not `.claude/settings.json`. The full per-hook behaviour, the
-gate list, the guardrail matrix, the Telegram `/arm` surface, and billing
+himmel enforces structurally, not by prose: PreToolUse/PostToolUse hooks plus
+**pre-commit/commit-msg/pre-push gates**. The live inventory is
+`.claude/settings.json` and `.pre-commit-config.yaml` — read those, not a list
+here (an enumeration in this file drifts silently, HIMMEL-1021). Per-hook
+behaviour, the guardrail matrix, the Telegram `/arm` surface, and billing
 detail: [`docs/internals/enforcement.md`](docs/internals/enforcement.md).
+Note `improve-on-submit.sh` is wired only in the Codex lane
+(`.codex/hooks.json`), not `.claude/settings.json`.
 
 **Session-critical (kept inline — needed at a glance):** hook bypass = a session
 env var set in the LAUNCHING shell (e.g. `EDIT_ON_MAIN_OK=1 claude`); a per-call
@@ -347,16 +276,17 @@ stay protected. Required environment (HIMMEL-123):
 
 ## REFERENCE INDEX
 
-- [`docs/internals/context-architecture.md`](docs/internals/context-architecture.md) — the lean-surface doctrine: where knowledge lives (4 rules, layering model, the nesting trap, memory-as-map). The anchor for the HIMMEL-177/195 frame above.
-- [`docs/internals/enforcement.md`](docs/internals/enforcement.md) — pre-commit + all hooks + guardrails + billing detail.
-- [`docs/internals/handover-system.md`](docs/internals/handover-system.md) — full handover system + user-slug resolution.
-- [`docs/internals/jira-plugin.md`](docs/internals/jira-plugin.md) — Jira plugin↔MCP op mapping.
-- [`docs/operator-conventions.md`](docs/operator-conventions.md) — durable operator working-habits (jira CLI invocation, CR/merge habits, upstream-contribution gating, arming/chaining, clips-are-pointers) consolidated from per-user auto-memory (HIMMEL-179 sharp #5).
-- [`docs/internals/stuck-playbook.md`](docs/internals/stuck-playbook.md) — guardrail-recovery escape-hatches (surfaced load-on-trigger by the `himmel-ops:stuck-playbook` skill on a denial/friction symptom).
-- [`docs/tool-adoption/rubric.md`](docs/tool-adoption/rubric.md) — the decision method every community-tool eval runs through (goal/KPI, trust-posture tiers, ADOPT/PILOT/REJECT, measurement protocol).
-- [`docs/tooling-catalog.md`](docs/tooling-catalog.md) — all tools/scripts/plugins in active use.
-- [`docs/commands-catalog.md`](docs/commands-catalog.md) — project-local slash commands (`.claude/commands/`).
+- [`docs/internals/context-architecture.md`](docs/internals/context-architecture.md) — lean-surface doctrine; anchors the layer-selection frame above.
+- [`docs/internals/enforcement.md`](docs/internals/enforcement.md) — hooks, gates, guardrails, billing.
+- [`docs/internals/handover-system.md`](docs/internals/handover-system.md) — handover system + user-slug resolution.
+- [`docs/internals/jira-plugin.md`](docs/internals/jira-plugin.md) — Jira op↔MCP mapping.
+- [`docs/internals/lane-calibration.md`](docs/internals/lane-calibration.md) — tier table, effort calibration, cost posture.
+- [`docs/internals/stuck-playbook.md`](docs/internals/stuck-playbook.md) — guardrail-recovery escape-hatches.
+- [`docs/internals/harness-compat.md`](docs/internals/harness-compat.md) — himmel under Codex / other harnesses.
+- [`docs/internals/environment-gotchas.md`](docs/internals/environment-gotchas.md) — Windows / Git-Bash / content-filter traps.
+- [`docs/internals/retask-channel.md`](docs/internals/retask-channel.md) — RETASK threat model + brief template.
+- [`docs/operator-conventions.md`](docs/operator-conventions.md) — durable operator working-habits.
+- [`docs/tool-adoption/rubric.md`](docs/tool-adoption/rubric.md) — the community-tool eval method.
+- [`docs/tooling-catalog.md`](docs/tooling-catalog.md) — tools/scripts/plugins in active use.
+- [`docs/commands-catalog.md`](docs/commands-catalog.md) — project-local slash commands.
 - [`docs/setup/new-machine.md`](docs/setup/new-machine.md) — fresh-machine setup.
-- [`docs/internals/harness-compat.md`](docs/internals/harness-compat.md) — running himmel under Codex / other harnesses (compat matrix + port/guard/accept decisions, HIMMEL-470).
-- [`docs/internals/environment-gotchas.md`](docs/internals/environment-gotchas.md) — Windows / Git-Bash / Bash-tool / content-filter environment traps (generic, adopter-facing).
-- [`docs/internals/retask-channel.md`](docs/internals/retask-channel.md) — RETASK channel: threat model, dispatch-brief template, honest-fallback discipline for re-tasking a live subagent (HIMMEL-1218); the PreToolUse guard is HELD for second-drift escalation (HIMMEL-195).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,26 +9,16 @@ exists to make Claude's behavior *structurally* safe and repeatable
 rather than relying on it to remember prose. Positioning — the
 [Tier 3-4 maturity stance](README.md#who-is-this-for--tier-3-4-on-the-maturity-ladder)
 and the [Camp 2 memory architecture](README.md#memory-architecture--camp-2-a-context-substrate-not-a-backend)
-— lives in `README.md`.
-
-This file is **state, not a prompt**: repo memory of why/map/rules/
-workflows, kept short on purpose. Reference detail lives in
-`docs/internals/` (linked below) so it loads only when needed. Every
-line here is paid for in every session — if a rule isn't session-time
-relevant, it belongs in a doc, not here.
+— lives in `README.md`. Reference detail lives in `docs/internals/`.
 
 ## MAP
 
-- `scripts/` — shell tooling (worktrees, guardrails, handover, jira, hooks).
-- `scripts/jira/dist/index.js` — the Jira CLI (prefer over Atlassian MCP).
-- `.claude/settings.json` — hooks (UserPromptSubmit, PreToolUse) + permissions.
-- `.pre-commit-config.yaml` — pre-commit/commit-msg/pre-push gates (source of truth).
-- `marketplace/plugins/` — vendored + forked plugins (handover, pr-review-toolkit-himmel, …).
-- `docs/internals/` — extracted reference (enforcement, handover-system, jira-plugin, stuck-playbook).
-- `docs/setup/`, `docs/luna/`, `docs/security-review.md` — setup, luna guides, security.
-- Subdir `CLAUDE.md` (scripts/jira, scripts/handover, scripts/hooks,
-  marketplace/plugins) — subtree-local dev conventions, loaded only when
-  working there. This file stays cross-project invariants.
+Layout is discoverable (`ls`); only the non-obvious matters here.
+`scripts/jira/dist/index.js` is the Jira CLI — an untracked build artifact,
+which is why the invocation rule below exists. Subdir `CLAUDE.md`
+(`scripts/jira`, `scripts/handover`, `scripts/hooks`, `marketplace/plugins`)
+carries subtree-local dev conventions; this file stays cross-project
+invariants.
 
 ## RULES
 
@@ -48,9 +38,8 @@ operator's user-scope `~/.claude/CLAUDE.md`. Use judgement on trivial tasks.
 ### Git workflow
 - All feature work in git worktrees. Never commit directly to main.
 - All changes via PR. No direct pushes to main. PRs need ≥1 approval before merge.
-- Conventional commits: `type(scope): [HIMMEL-N ]message` where type ∈
-  `feat|fix|chore|docs|refactor|test`. Ticket ID optional per commit, validated
-  if present.
+- Conventional commits; the `commit-msg` gate validates the shape plus an
+  optional `HIMMEL-N` ticket ID.
 - **Every private-repo PR carries a Jira ticket** (operator, 2026-07-16).
   Retro-filing is fine — the ticket may be created after the work started —
   but the PR must reference one (title and/or commits) before merge. Search
@@ -78,14 +67,11 @@ denial recovery: `himmel-ops:stuck-playbook` skill.
 
 ### Claude invocation billing (HIMMEL-128)
 Headless invocations (`claude -p`/`--print`/`--bg`/Agent SDK; same for
-gemini-cli, HIMMEL-157) bill to a separate bucket (announced **2026-06-15**;
-**currently PAUSED** by Anthropic as of 2026-06-21 — preference kept because
-the split is volatile and may re-activate). Scripts here prefer interactive
-`claude "$prompt"`. The
-`no-headless-claude`/`no-headless-gemini` pre-commit gates block new
-headless calls unless marked `# headless-claude-ok: <reason>` /
+gemini-cli) bill to a separate bucket, so scripts here prefer interactive
+`claude "$prompt"`. The `no-headless-claude`/`no-headless-gemini` pre-commit
+gates block new headless calls unless marked `# headless-claude-ok: <reason>` /
 `# headless-gemini-ok: <reason>` on the call line or the line above.
-Detail + exempt paths: [`docs/internals/enforcement.md`](docs/internals/enforcement.md#claude-invocation-billing-himmel-128).
+Current status, dates + exempt paths: [`docs/internals/enforcement.md`](docs/internals/enforcement.md#claude-invocation-billing-himmel-128).
 
 ### Bash command shape (HIMMEL-203)
 Native permission matcher bails + PROMPTS on `$var`/`$(…)`/backticks/compound
@@ -95,62 +81,54 @@ what `auto-approve-safe-bash` does/doesn't cover: `himmel-ops:stuck-playbook`
 skill / [`docs/internals/stuck-playbook.md`](docs/internals/stuck-playbook.md).
 
 ### Subagent policy — delegation & escalation (HIMMEL-166/688)
-<!-- FABLE-WINDOW: HIMMEL-688 hybrid — Opus 4.8 default parent, Fable-5 escalation-only.
-     On loss of Fable access, drop the top-model table row, the escalation paragraph,
-     AND the Fable effort-calibration lines (the former Sonnet-comparison clause was
-     superseded by the HIMMEL-774 calibration row, 2026-07-10); the dispatch-naming
-     paragraph SURVIVES a revert (Opus original in HIMMEL-282).
-     Markers documentary; text between them is live prose — revert = REPLACE it. -->
-**The higher your tier, the more you delegate.** Push the work down;
-keep your own context for judgment. Hand any self-contained subtask to
-a subagent and keep working while it runs. Brief every child: the
-context, the why, what done looks like — it starts blank and inherits
-nothing. Route by lane. The Claude tiers are always present; their
-*semantics* (what each tier is for) are invariant:
+<!-- FABLE-WINDOW: HIMMEL-688 hybrid — Opus default parent, Fable-5 escalation-only.
+     The tier table, effort calibration and cost posture now live in
+     docs/internals/lane-calibration.md (moved HIMMEL-480). On loss of Fable
+     access, revert THERE: drop the top-model table row, the escalation-shape
+     section, and the Fable effort lines. In CLAUDE.md only the Fable mention in
+     the tier-semantics sentence and the escalation sentence need dropping; the
+     dispatch-naming and floor paragraphs SURVIVE a revert (Opus original in
+     HIMMEL-282). Both of those mentions are debranded out of AGENTS.md by
+     debrand.json, so the generated file needs no revert of its own.
+     Markers documentary; text between them is live prose. -->
+**Delegate what is genuinely independent and sizeable — and only that.**
+Don't delegate work you'd finish in a handful of tool calls, and never spawn a
+subagent to verify or double-check your own work; current models over-delegate
+and over-verify by default, and both multiply cost without improving the result.
+When you do delegate, brief every child: the context, the why, what done looks
+like — it starts blank and inherits nothing. Keep spawn counts low.
 
-| Lane | Best for | Effort / notes |
-|---|---|---|
-| Haiku | bulk mechanical (never delegates further) | low |
-| Sonnet 5 | scoped research; **default implementor for well-specified impl briefs (intro $2/$10 through 2026-08-31 — recalibrate Sep: HIMMEL-774)** | medium default; high for multi-file/long briefs — raise effort before Opus |
-| Opus 4.8 | multi-step reasoning; **default parent/orchestrator** | xhigh default for orchestration; scale DOWN (high/medium) for lighter parenting or scoped impl |
-| Fable 5 | judgment, taste — hardest calls; escalation target | scale to the item (operator 2026-07-08, un-capped): medium default; **high for substantial judgment work — not just the hardest**; xhigh for the hardest |
+Tier semantics are invariant: Haiku = bulk mechanical; Sonnet 5 = scoped
+research and default implementor for well-specified briefs; Opus = multi-step
+reasoning and default parent/orchestrator; Fable 5 = judgment and taste, the
+escalation target. Query the live inventory with **`/lanes`** — never route to a
+lane it doesn't list. Tier/effort/cost detail:
+[`docs/internals/lane-calibration.md`](docs/internals/lane-calibration.md).
 
-Beyond the Claude tiers the fleet includes machine-specific impl/critic/
-bulk lanes (paid/optional — they exist only where the operator configured
-them). Query the live set with **`/lanes`** (derived from
-`scripts/lanes/lanes.json` + machine state, HIMMEL-689) — never route to a
-lane `/lanes` doesn't list. The tier semantics above are invariant; the
-inventory is data.
+**Escalation over top-down:** the parent needn't be the top model — an Opus
+parent spawns a Fable child for the one hard call, when `/lanes` lists that
+tier; where it doesn't, stay at the highest listed tier rather than routing to
+an absent lane. Work above your tier? Return it — don't burn tokens on it.
 
-**Escalation over top-down:** the parent doesn't have to be the top
-model — the Opus parent spawns a Fable child for the one hard call;
-the child answers and returns. Fable-as-parent only by operator
-choice — it then delegates EVERY implementation chunk to a cheaper
-lane and owns planning/judgment/final synthesis; inline impl on a
-top-tier parent is the anti-pattern (sole exception: ONE trivial
-CR-fix faster to apply than to re-brief — per PR, not per round;
-from the second CR round on, batch remaining findings to a worker
-lane in shared-branch mode, HIMMEL-1216). Work above your tier?
-Return it — don't burn tokens on it.
+**Use the top-tier lane as parent only by operator choice.** It then delegates
+every implementation chunk downward.
 
-**Every dispatch names an explicit model** — an unnamed dispatch
-inherits the parent loop and burns the scarcer, weekly-capped parent
-quota on work a cheaper tier handles.
-Raise *effort* before raising model tier — Fable-5 `low` ≈ prior-gen
-`xhigh`, and the same shift applies down-tier. Effort is a PER-DISPATCH
-lever: use the full scale per item, don't flatten to one default.
-(Temperature is Claude-API-only — DEFERRED for now; rides HIMMEL-774.)
-Fable stays CONSERVED (limited release) — the spread optimizes
-Sonnet/Opus/impl lanes. Full per-lane calibration (web pricing +
-benchmark index analysis) = HIMMEL-774, later phase.
-Invariants (not model-tuned): spawn-depth limit **2** (kept on
-measured nesting-overhead cost); **Haiku does NOT spawn**;
-single-writer — many readers, ONE writer, never fan parallel writes
-at one shared artifact (`/overnight-shift` per-ticket branches are
-independent products; parent/operator does merge + synthesis);
-**salus dev/impl work routes to Claude tiers + Codex lanes only
-(never GLM), a routing invariant distinct from the salus PHI hard-deny**
-(sanctioned provider set GLM/Claude/Codex, DeepSeek+Alibaba dropped — HIMMEL-1257).
+**Inline implementation on a top-tier parent is the anti-pattern.** Sole
+exception: ONE trivial CR-fix faster to apply than to re-brief — per PR, not per
+round. **From the second CR round on, batch the remaining findings to a worker
+lane in shared-branch mode** (HIMMEL-1216) instead of fixing them inline.
+
+**Every dispatch names an explicit model** — an unnamed dispatch inherits the
+parent loop and burns the scarcer, weekly-capped parent quota on work a cheaper
+tier handles. Raise *effort* before raising model tier; effort is a PER-DISPATCH
+lever, not one flat default.
+
+Invariants (not model-tuned): spawn-depth limit **2**; **Haiku does NOT spawn**;
+single-writer — many readers, ONE writer, never fan parallel writes at one
+shared artifact (`/overnight-shift` per-ticket branches are independent
+products; parent/operator does merge + synthesis); **salus dev/impl work routes
+to Claude tiers + Codex lanes only (never GLM)**, a routing invariant distinct
+from the salus PHI hard-deny (sanctioned set GLM/Claude/Codex — HIMMEL-1257).
 <!-- /FABLE-WINDOW -->
 
 **RETASK channel (HIMMEL-1218):** never seal a brief absolutely — every
@@ -161,66 +139,33 @@ revision directs work but never widens the child's tool-permission envelope.
 Full template + threat model: [`docs/internals/retask-channel.md`](docs/internals/retask-channel.md).
 
 ### Operator conventions (calibrated through repeated sessions)
-These shape WHERE new rules/capabilities live. Treat as defaults; deviate
-only for a concrete reason.
+When adding a rule or capability, pick the cheapest layer — **default to
+lean-invoke** (a slash command the operator runs on demand). Only escalate to
+always-on for a trigger: safety-critical → a hook; frame-shaping → this file;
+high-frequency + cheap → rule + skill; eval-shaped → defer with a timeboxed
+ticket. Default-everything is the failure mode: the file grows, both operator
+and Claude stop reading it, rules lose authority.
 
-**Layer selection — lean-invoke vs default (HIMMEL-177).** When adding a
-rule/capability, pick the cheapest layer. **Default to lean-invoke**
-(operator runs a slash command on demand) UNLESS a trigger applies:
-- Safety-critical → `default-hook` (PreToolUse / pre-commit / pre-push). The
-  cost of forgetting to invoke manually beats the cost of always running.
-  E.g. `block-edit-on-main`, `block-read-secrets`, `no-headless-claude`, `gitleaks`.
-- Frame-shaping (changes how Claude reads the *whole* task) → `default-rule`
-  (this file). E.g. "PRs require approval", conventional commits, "prefer plugin over MCP".
-- High frequency × low marginal cost → `default-rule + installed skill`.
-  E.g. `/handover`, `/clean`, `/worktree`.
-- Eval-shaped ("read X, decide, write ADR", no ship-code) → `defer`: file a
-  timeboxed ticket, close Won't Do on expiry. Do NOT install as always-on.
+**Structural > instructional.** Track the drift count per instructional rule.
+First drift is signal; on the **second**, escalate to structural (hook, gate,
+classifier, dispatcher guard) — not to stronger prose. Prose does not enforce.
 
-Default-everything is the failure mode — more always-on rules without a
-trigger above creates drift: the file grows, both operator and Claude stop
-reading it, rules lose authority. Lean-invoke keeps the cost on the
-operator's side, which is the right side: the operator knows when a rule
-applies; Claude does not.
+Full frame + worked escalation examples:
+[`docs/internals/context-architecture.md`](docs/internals/context-architecture.md).
 
-**Enforcement strength — structural > instructional (HIMMEL-195).** Track
-the **drift count** per instructional rule. First drift is signal; on the
-**second** drift escalate to structural (PreToolUse hook, pre-commit/
-pre-push gate, classifier, dispatcher guard) — don't wait for the third, by
-then the rule has lost authority and Claude is rationalising bypasses.
-Prose does not enforce. `default-rule` is a fine first layer, but its next
-layer after drift is structural, not "stronger prose." (Worked escalation
-examples — MCP-jira, headless-billing, edit-on-main, secrets-reads — and the
-per-layer example set: [`docs/internals/enforcement.md`](docs/internals/enforcement.md#operator-conventions--worked-examples).)
+### Where artifacts land (HIMMEL-138 / HIMMEL-409)
+- **Reference docs operators consume** → the owning repo's `docs/`
+  (himmel luna docs → `docs/luna/`; plugin specs → `plugins/<plugin>/README.md`).
+  The vendored template `templates/luna-second-brain/` is OSS-quality — it is the
+  source that propagates to the public `luna-brain` repo.
+- **Internal specs, plans, decision records** → the state repo bucket
+  `<state-repo>/handovers/<USER_SLUG>/<repo-bucket>/specs/<type>/`, **never**
+  himmel `docs/` (reference + OSS-public only). Cross-repo source of truth is
+  the handover skill, which loads in any repo unlike this project-scoped file.
+- **Vault content** (clips, notes, daily entries) → stays in luna.
 
-### Luna-area docs convention (HIMMEL-138, locked 2026-05-25)
-Three tiers for luna-touching artifacts:
-1. **Reference docs operators consume** (guides, runbooks, architecture) →
-   the relevant repo's `docs/` (himmel luna docs → `himmel/docs/luna/`;
-   luna → `luna/docs/`; the vendored vault template →
-   `himmel/templates/luna-second-brain/docs/`, OSS-quality from day 1 because it
-   propagates to the separate public `luna-brain` repo — it is the source, not
-   the publish target itself; plugin specs stay in
-   `plugins/<plugin>/README.md`).
-2. **Personal-state work artifacts** (handovers, work/decision logs,
-   journal-style decision records, next-session-resume) →
-   `<state-repo>/handovers/<USER_SLUG>/<repo-bucket>/` (cross-cutting → `…/cross/`).
-3. **Vault content** (clips, notes, daily entries) → unchanged, stays in luna.
-
-Author new luna-touching reference docs in `docs/luna/`; author
-journal-style decision records under the appropriate <state-repo> bucket.
-
-**Internal specs/plans → state repo, not himmel `docs/` (HIMMEL-409).** Design
-docs, implementation plans, and decision records are work artifacts → the
-state bucket `<state-repo>/handovers/<USER_SLUG>/<repo-bucket>/specs/<type>/`
-(subfolders `design/`, `plan/`, …; extensible). They never live in himmel
-`docs/` (reference + OSS-public only). Cross-repo source of truth = the
-**handover skill** (loaded in any repo, unlike this project-scoped file);
-existing `docs/specs/` files migrate per-ticket.
-
-**Luna recent context (HIMMEL-254):** read `~/Documents/luna/hot.md` (if present)
-first for recent vault context (~500-word Tier-2 hot cache) before crawling luna
-`index.md`.
+**Luna recent context:** read `~/Documents/luna/hot.md` (if present) before
+crawling luna `index.md` — it's a ~500-word hot cache.
 
 ### Memory recall — the index routes, it does not store (HIMMEL-570)
 The always-loaded `MEMORY.md` index carries **routing lines, not bodies**. On a
@@ -231,42 +176,29 @@ before improvising** — that read is the primary path. qmd the substrate
 (it searches everything while looking scoped). A qmd miss is **not** evidence a
 fact is absent.
 
-### graphify — retrieval routing (HIMMEL-621)
-graphify is the knowledge-graph CLI over vaults/docs (entity/relation
-extraction + graph queries). One flow, three organs: **qmd finds content,
-graphify explains structure, tokensave serves symbol-level code ops.**
-Route by question shape:
-- Content lookup ("where is X discussed") → **qmd**, first hop.
-- Structure/neighborhood ("what clusters around X", "what does this epic
-  touch") → `graphify query` / `graphify explain`; whole-architecture
-  review → `GRAPH_REPORT.md` (graphify ≤0.9.18 has no `wiki` command; at
-  >5000 nodes `graph.html` is skipped — use `graphify tree` for a viz).
-- Symbol-level code ops → **tokensave**; graphify = architecture/community
-  views + all non-code. (headroom, if ever adopted post-H4 gate
-  (HIMMEL-622), = context-window management only — not retrieval.)
-- Cross-file "how is A related to B" → `graphify query` each + join
-  in-head, or qmd. **Never `graphify path`** — node IDs are file-scoped
-  (same entity in two files = two disconnected nodes), so cross-file path
-  traversal is structurally broken.
-Graph refresh is lean-invoke (`graphify <corpus-copy> --update`), never a
-hook. Extraction backends are governed by the egress matrix
-(`scripts/guardrails/egress-matrix.json` — HIMMEL-766, lands via PR #985);
-extraction runs on scratchpad copies, never live vaults.
+### Retrieval routing (HIMMEL-621)
+Three organs: **qmd finds content, graphify explains structure, tokensave
+serves symbol-level code ops.** Content lookup → qmd, first hop. Structure or
+neighborhood → `graphify query` / `graphify explain`. Symbol-level code →
+tokensave.
+
+Traps: **never `graphify path`** — node IDs are file-scoped, so the same entity
+in two files is two disconnected nodes and cross-file traversal is structurally
+broken (join `graphify query` results in-head instead). Extraction runs on
+scratchpad copies, **never live vaults**, and its backends are governed by
+`scripts/guardrails/egress-matrix.json`. Graph refresh is lean-invoke
+(`graphify <corpus-copy> --update`), never a hook.
 
 ## WORKFLOWS
 
 ### Worktree commands (one orchestrator, `scripts/clean-garden.sh`)
-- **`/worktree <branch>`** — create only. Branch must be `type/slug`
-  (`feat|fix|chore|docs|refactor|test`).
-- **`/clean`** — prune merged-PR worktrees only.
-- **`/clean_garden <branch>`** — prune AND create in one shot.
+`/worktree` (create), `/clean` (prune merged), `/clean_garden` (both). Branch
+must be `type/slug` (`feat|fix|chore|docs|refactor|test`). Superseded, don't
+use: `/new-worktree`, `/clean_gone`.
 
-Pick by intent: fresh feature = `/worktree`, prune cycle = `/clean`,
-both = `/clean_garden`. (Superseded, don't use: `/new-worktree`, `/clean_gone`.)
-`/worktree` (via `scripts/_new-worktree.sh`) refuses to create a worktree for
-a branch whose PR is already MERGED (bypass: `REUSE_MERGED_BRANCH_OK=1`).
-`/himmel-doctor` C7 flags lingering worktrees on merged-PR branches as a
-read-only diagnostic (points to `/clean`; no `--fix`; HIMMEL-512).
+Non-obvious: `/worktree` refuses a branch whose PR is already MERGED (bypass:
+`REUSE_MERGED_BRANCH_OK=1`), and `/himmel-doctor` C7 flags lingering merged-PR
+worktrees read-only (points to `/clean`; no `--fix`).
 
 ### Handover
 All personal handover state is centralized in your handover state repo
@@ -287,17 +219,14 @@ Autonomous end-to-end execution of a well-scoped ticket: see
 
 ## ENFORCEMENT (runs automatically)
 
-himmel enforces structurally, not by prose: PreToolUse hooks (safe-bash
-auto-approve; the edit-on-main / read-secrets / backend-tier / CR-marker /
-jira-compound-write / unresolved-CR-merge / merged-PR-commit / docker-privesc /
-rogue-schedule / rogue-codex-wsl guards; `guard-implementor-dispatch` cost guard; the cap-arm
-hooks), a PostToolUse cap-arm hook, **pre-commit/commit-msg/pre-push gates**
-(source of truth `.pre-commit-config.yaml`), and an opt-in `SessionStart` hook (`inject-initiative.sh`
-`HIMMEL_INITIATIVE`, default OFF); `improve-on-submit.sh` is a
-`UserPromptSubmit` hook wired only in the Codex lane
-(`.codex/hooks.json`), not `.claude/settings.json`. The full per-hook behaviour, the
-gate list, the guardrail matrix, the Telegram `/arm` surface, and billing
+himmel enforces structurally, not by prose: PreToolUse/PostToolUse hooks plus
+**pre-commit/commit-msg/pre-push gates**. The live inventory is
+`.claude/settings.json` and `.pre-commit-config.yaml` — read those, not a list
+here (an enumeration in this file drifts silently, HIMMEL-1021). Per-hook
+behaviour, the guardrail matrix, the Telegram `/arm` surface, and billing
 detail: [`docs/internals/enforcement.md`](docs/internals/enforcement.md).
+Note `improve-on-submit.sh` is wired only in the Codex lane
+(`.codex/hooks.json`), not `.claude/settings.json`.
 
 **Session-critical (kept inline — needed at a glance):** hook bypass = a session
 env var set in the LAUNCHING shell (e.g. `EDIT_ON_MAIN_OK=1 claude`); a per-call
@@ -309,16 +238,17 @@ stay protected. Required environment (HIMMEL-123):
 
 ## REFERENCE INDEX
 
-- [`docs/internals/context-architecture.md`](docs/internals/context-architecture.md) — the lean-surface doctrine: where knowledge lives (4 rules, layering model, the nesting trap, memory-as-map). The anchor for the HIMMEL-177/195 frame above.
-- [`docs/internals/enforcement.md`](docs/internals/enforcement.md) — pre-commit + all hooks + guardrails + billing detail.
-- [`docs/internals/handover-system.md`](docs/internals/handover-system.md) — full handover system + user-slug resolution.
-- [`docs/internals/jira-plugin.md`](docs/internals/jira-plugin.md) — Jira plugin↔MCP op mapping.
-- [`docs/operator-conventions.md`](docs/operator-conventions.md) — durable operator working-habits (jira CLI invocation, CR/merge habits, upstream-contribution gating, arming/chaining, clips-are-pointers) consolidated from per-user auto-memory (HIMMEL-179 sharp #5).
-- [`docs/internals/stuck-playbook.md`](docs/internals/stuck-playbook.md) — guardrail-recovery escape-hatches (surfaced load-on-trigger by the `himmel-ops:stuck-playbook` skill on a denial/friction symptom).
-- [`docs/tool-adoption/rubric.md`](docs/tool-adoption/rubric.md) — the decision method every community-tool eval runs through (goal/KPI, trust-posture tiers, ADOPT/PILOT/REJECT, measurement protocol).
-- [`docs/tooling-catalog.md`](docs/tooling-catalog.md) — all tools/scripts/plugins in active use.
-- [`docs/commands-catalog.md`](docs/commands-catalog.md) — project-local slash commands (`.claude/commands/`).
+- [`docs/internals/context-architecture.md`](docs/internals/context-architecture.md) — lean-surface doctrine; anchors the layer-selection frame above.
+- [`docs/internals/enforcement.md`](docs/internals/enforcement.md) — hooks, gates, guardrails, billing.
+- [`docs/internals/handover-system.md`](docs/internals/handover-system.md) — handover system + user-slug resolution.
+- [`docs/internals/jira-plugin.md`](docs/internals/jira-plugin.md) — Jira op↔MCP mapping.
+- [`docs/internals/lane-calibration.md`](docs/internals/lane-calibration.md) — tier table, effort calibration, cost posture.
+- [`docs/internals/stuck-playbook.md`](docs/internals/stuck-playbook.md) — guardrail-recovery escape-hatches.
+- [`docs/internals/harness-compat.md`](docs/internals/harness-compat.md) — himmel under Codex / other harnesses.
+- [`docs/internals/environment-gotchas.md`](docs/internals/environment-gotchas.md) — Windows / Git-Bash / content-filter traps.
+- [`docs/internals/retask-channel.md`](docs/internals/retask-channel.md) — RETASK threat model + brief template.
+- [`docs/operator-conventions.md`](docs/operator-conventions.md) — durable operator working-habits.
+- [`docs/tool-adoption/rubric.md`](docs/tool-adoption/rubric.md) — the community-tool eval method.
+- [`docs/tooling-catalog.md`](docs/tooling-catalog.md) — tools/scripts/plugins in active use.
+- [`docs/commands-catalog.md`](docs/commands-catalog.md) — project-local slash commands.
 - [`docs/setup/new-machine.md`](docs/setup/new-machine.md) — fresh-machine setup.
-- [`docs/internals/harness-compat.md`](docs/internals/harness-compat.md) — running himmel under Codex / other harnesses (compat matrix + port/guard/accept decisions, HIMMEL-470).
-- [`docs/internals/environment-gotchas.md`](docs/internals/environment-gotchas.md) — Windows / Git-Bash / Bash-tool / content-filter environment traps (generic, adopter-facing).
-- [`docs/internals/retask-channel.md`](docs/internals/retask-channel.md) — RETASK channel: threat model, dispatch-brief template, honest-fallback discipline for re-tasking a live subagent (HIMMEL-1218); the PreToolUse guard is HELD for second-drift escalation (HIMMEL-195).

--- a/docs/internals/context-architecture.md
+++ b/docs/internals/context-architecture.md
@@ -98,11 +98,42 @@ Three guards keep retrieval honest:
   chaining ~24 gotchas at ~61 chars each **is** the store — the exact thing this
   section forbids. The doctrine was right; the implementation had drifted from it.
 
-## Where the canonical pieces live
+## Layer selection — lean-invoke vs default (HIMMEL-177)
 
-- **Layer-selection frame** (lean-invoke vs default-rule vs default-hook vs
-  defer) + **structural > instructional** escalation → [`CLAUDE.md`](../../CLAUDE.md)
-  (HIMMEL-177 / HIMMEL-195).
+When adding a rule or capability, pick the cheapest layer. **Default to
+lean-invoke** (the operator runs a slash command on demand) UNLESS a trigger
+applies:
+
+- **Safety-critical** → `default-hook` (PreToolUse / pre-commit / pre-push). The
+  cost of forgetting to invoke manually beats the cost of always running.
+  E.g. `block-edit-on-main`, `block-read-secrets`, `no-headless-claude`, `gitleaks`.
+- **Frame-shaping** (changes how Claude reads the *whole* task) → `default-rule`
+  (root `CLAUDE.md`). E.g. "PRs require approval", conventional commits,
+  "prefer plugin over MCP".
+- **High frequency × low marginal cost** → `default-rule` + installed skill.
+  E.g. `/handover`, `/clean`, `/worktree`.
+- **Eval-shaped** ("read X, decide, write ADR", no ship-code) → `defer`: file a
+  timeboxed ticket, close Won't Do on expiry. Do NOT install as always-on.
+
+Default-everything is the failure mode — more always-on rules without a trigger
+above creates drift: the file grows, both operator and Claude stop reading it,
+rules lose authority. Lean-invoke keeps the cost on the operator's side, which
+is the right side: the operator knows when a rule applies; Claude does not.
+
+## Enforcement strength — structural > instructional (HIMMEL-195)
+
+Track the **drift count** per instructional rule. First drift is signal; on the
+**second** drift escalate to structural (PreToolUse hook, pre-commit/pre-push
+gate, classifier, dispatcher guard) — don't wait for the third, by then the rule
+has lost authority and Claude is rationalising bypasses. Prose does not enforce.
+`default-rule` is a fine first layer, but its next layer after drift is
+structural, not "stronger prose."
+
+Worked escalation examples (MCP-jira, headless-billing, edit-on-main,
+secrets-reads) + the per-layer example set:
+[`enforcement.md`](enforcement.md#operator-conventions--worked-examples).
+
+## Where the canonical pieces live
 - **The habits** (no operational rules in the root, verify universal claims,
   generic example names, specs live in the state repo, memory staleness
   frontmatter) → [`operator-conventions.md`](../operator-conventions.md#memory--claudemd-hygiene).

--- a/docs/internals/lane-calibration.md
+++ b/docs/internals/lane-calibration.md
@@ -1,0 +1,87 @@
+# Lane calibration — tiers, effort, and cost
+
+> **If you are not a Claude session, read this as an inventory, not an identity.**
+> The model names below (Haiku, Sonnet, Opus, Fable) name LANES this operator can
+> dispatch work to — they do not describe you, and a Claude-family fact stated
+> here (effort equivalences, quota posture) is not a fact about your own model.
+> Route only to what `/lanes` lists on this machine. `AGENTS.md` is debranded for
+> non-Claude harnesses (`scripts/agents-md/debrand.json`); this file is reference
+> detail linked from it and is deliberately NOT rewritten, so the orientation is
+> stated here instead (HIMMEL-559 / HIMMEL-480).
+
+Reference detail for the delegation policy. The **directives** (name an explicit
+model, raise effort before tier, spawn-depth 2, Haiku does not spawn,
+single-writer, the salus provider restriction) stay resident in
+[`CLAUDE.md`](../../CLAUDE.md) — a directive behind a lookup is a dead directive
+(see [`context-architecture.md`](context-architecture.md#memory-as-a-map-not-a-backend)).
+What lives here is the fact-shaped part: which lane suits which work, and how to
+set effort.
+
+The live per-machine inventory is **`/lanes`** (derived from
+`scripts/lanes/lanes.json` + machine state, HIMMEL-689). Never route to a lane
+`/lanes` does not list. The tier semantics below are invariant; the inventory
+is data.
+
+## Tier semantics
+
+| Lane | Best for | Effort / notes |
+|---|---|---|
+| Haiku | bulk mechanical (never delegates further) | low |
+| Sonnet 5 | scoped research; default implementor for well-specified impl briefs | medium default; high for multi-file/long briefs — raise effort before reaching for Opus |
+| Opus 4.8 | multi-step reasoning; default parent/orchestrator | xhigh for orchestration; scale DOWN (high/medium) for lighter parenting or scoped impl |
+| Fable 5 | judgment, taste — hardest calls; escalation target | scale to the item (operator 2026-07-08, un-capped): medium default; high for substantial judgment work — not just the hardest; xhigh for the hardest |
+
+Beyond the Claude tiers the fleet includes machine-specific impl/critic/bulk
+lanes (paid/optional — they exist only where the operator configured them).
+
+Labels above mirror `scripts/lanes/lanes.json`, which is authoritative. When a
+tier's underlying model ships a new generation, update `lanes.json` first and
+this table follows — never the reverse.
+
+## Effort calibration
+
+Effort is a **per-dispatch** lever — use the full scale per item, do not flatten
+to one default. Raise effort before raising model tier: Fable-5 `low` ≈
+prior-gen `xhigh`, and the same shift applies down-tier.
+
+Anthropic's published **Claude Opus 5** prompting guidance — cited here as the
+newest available guidance for the Opus family, not as a claim that the Opus lane
+above already runs Opus 5 — is to use `low` and `medium` liberally as the
+primary control for token cost and latency wherever quality holds, and to step
+up to `xhigh` only for demanding coding and agentic work. Effort defaults
+carried over from a prior model should be re-swept against real evals rather
+than assumed — that sweep is HIMMEL-774, which is also where the lane's own
+model generation gets revisited.
+
+Temperature is Claude-API-only — deferred; rides HIMMEL-774.
+
+## Cost posture
+
+Fable stays **conserved** (limited release) — the spread optimizes
+Sonnet/Opus/impl lanes. Sonnet 5 carried introductory pricing ($2 per
+million input tokens / $10 per million output tokens) through 2026-08-31;
+recalibrate in September against Anthropic's published pricing (HIMMEL-774).
+
+Pricing and per-lane benchmark analysis are volatile: treat any figure here as
+needing revalidation before it drives a routing decision.
+
+## Escalation shape
+
+The parent does not have to be the top model — an Opus parent spawns a Fable
+child for the one hard call; the child answers and returns. The top-tier
+parent-selection restriction and its downward-delegation rule are **directives
+and stay resident in [`CLAUDE.md`](../../CLAUDE.md)** — a directive behind a
+lookup is a dead directive. What belongs here is the rationale: Fable is
+limited-release and conserved; when it is the parent, its role is planning,
+judgment, and final synthesis while every implementation chunk goes to a lower
+lane. The delegation floor in [`CLAUDE.md`](../../CLAUDE.md) still applies: work
+finishable in a handful of tool calls stays with the parent, and verification
+is never delegated.
+
+The inline-implementation anti-pattern, its single per-PR exception, and the
+second-round batching rule are **directives and stay resident in
+[`CLAUDE.md`](../../CLAUDE.md)** — a directive behind a lookup is a dead
+directive. What belongs here is the rationale: batching exists because CR rounds
+are where a top-tier parent quietly burns its scarce weekly quota on mechanical
+edits, and because a worker lane on a shared branch can absorb several findings
+per dispatch instead of one round-trip each.

--- a/scripts/agents-md/debrand.json
+++ b/scripts/agents-md/debrand.json
@@ -2,66 +2,83 @@
   {
     "from": "the Skill tool",
     "to": "your skill-invocation mechanism",
-    "note": "Claude-Code tool name -> behavioral. Full-phrase ('the X tool') so it only matches unambiguous tool references, never factual prose."
+    "dormant": true,
+    "note": "Claude-Code tool name -> behavioral. Full-phrase ('the X tool') so it only matches unambiguous tool references, never factual prose. DORMANT: phrase not in live CLAUDE.md; retained for the test-generate.sh fixture."
   },
   {
     "from": "the Agent tool",
     "to": "your subagent-dispatch mechanism",
-    "note": "Full-phrase only; deliberately does NOT match bare 'Agent tool' which appears inside a factual hook description in CLAUDE.md."
+    "dormant": true,
+    "note": "Full-phrase only; deliberately does NOT match bare 'Agent tool' which appears inside a factual hook description in CLAUDE.md. DORMANT: phrase not in live CLAUDE.md; retained for the test fixture."
   },
   {
     "from": "the Bash tool",
     "to": "your shell-execution mechanism",
-    "note": "Full-phrase tool reference -> behavioral text."
+    "dormant": true,
+    "note": "Full-phrase tool reference -> behavioral text. DORMANT: phrase not in live CLAUDE.md; retained for the test fixture."
   },
   {
     "from": "the **Fable main thread**",
     "to": "the **main thread**",
+    "dormant": true,
     "note": "HIMMEL-559: identity claim — a Codex/GPT session must not read itself as the Fable main thread. DORMANT since HIMMEL-688 (phrase no longer in live CLAUDE.md); retained because the test-generate.sh fixture exercises it. Fable mentions in FABLE-WINDOW provenance comments stay (documentary, not identity)."
   },
   {
     "from": "inherits the Fable\nmain loop",
     "to": "inherits the main\nloop",
+    "dormant": true,
     "note": "HIMMEL-559: spans CLAUDE.md's hard wrap — embedded newline load-bearing. DORMANT since HIMMEL-688; retained for the test fixture."
   },
   {
     "from": "the time-limited Fable quota",
     "to": "the time-limited top-tier quota",
+    "dormant": true,
     "note": "HIMMEL-559: quota claim — neutral tier language. DORMANT since HIMMEL-688; retained for the test fixture."
   },
   {
     "from": "Fable-5 `low` ≈ prior-gen\n`xhigh`",
     "to": "on Claude, Fable-5 `low` ≈ prior-gen\n`xhigh`",
-    "note": "HIMMEL-559: the effort calibration is a Claude-family fact (false for GPT) — attribute it instead of asserting it about the reading model. Embedded newline matches CLAUDE.md's wrap, same caveat as above."
+    "dormant": true,
+    "note": "HIMMEL-559: the effort calibration is a Claude-family fact (false for GPT) — attribute it instead of asserting it about the reading model. DORMANT since HIMMEL-480: the calibration prose moved to docs/internals/lane-calibration.md, which carries its own non-Claude reader note. Retained for the test fixture."
   },
   {
     "from": "| Fable 5 | judgment, taste — hardest calls; escalation target |",
     "to": "| top model | judgment, taste — hardest calls; escalation target |",
-    "note": "HIMMEL-688 lane table row — neutral tier language for non-Claude drivers; table rows never wrap so the full-cell match is stable. Re-matched after the 2026-07-08 effort-calibration rewording dropped 'the ~10%' (HIMMEL-806)."
+    "dormant": true,
+    "note": "HIMMEL-688 lane table row — neutral tier language for non-Claude drivers. DORMANT since HIMMEL-480: the tier table moved to docs/internals/lane-calibration.md, which is NOT debranded (this transform only covers CLAUDE.md -> AGENTS.md); that doc carries an explicit non-Claude reader note instead. Retained for the test fixture."
   },
   {
     "from": "spawns a Fable child",
     "to": "spawns a top-model child",
-    "note": "HIMMEL-688 escalation prose — routing fact, neutralized so a GPT/Codex driver doesn't read a Claude-only dispatch as an instruction it can execute."
+    "note": "HIMMEL-688 escalation prose — routing fact, neutralized so a GPT/Codex driver doesn't read a Claude-only dispatch as an instruction it can execute. LIVE — keep this string intact when editing the escalation paragraph."
+  },
+  {
+    "from": "Fable 5 = judgment and taste, the\nescalation target",
+    "to": "the top model = judgment and taste, the\nescalation target",
+    "note": "HIMMEL-480: the condensed tier-semantics sentence that replaced the lane table in CLAUDE.md — same neutralization the table row (now dormant) provided. LIVE. Embedded newline matches CLAUDE.md's hard wrap; re-check this rule if that paragraph is rewrapped."
   },
   {
     "from": "Fable-as-parent",
     "to": "Top-model-as-parent",
-    "note": "HIMMEL-688 escalation prose — same neutralization."
+    "dormant": true,
+    "note": "HIMMEL-688 escalation prose — same neutralization. DORMANT since HIMMEL-480: the escalation-shape prose moved to docs/internals/lane-calibration.md, which carries its own non-Claude reader note. Retained for the test fixture."
   },
   {
     "from": "compare per task vs Fable-low",
     "to": "compare per task vs top-model-low",
+    "dormant": true,
     "note": "HIMMEL-806: Sonnet-row pricing comparison added 2026-07-08 — neutral tier language; full-phrase scopes the replacement to that comparison clause. DORMANT since 2026-07-10 (HIMMEL-774 row replaced the clause); retained for the test fixture."
   },
   {
     "from": "Fable stays CONSERVED (limited release)",
     "to": "The top model stays CONSERVED (limited release)",
-    "note": "HIMMEL-806: conservation note added 2026-07-08 — sentence-initial, single line, so the full-phrase match is stable."
+    "dormant": true,
+    "note": "HIMMEL-806: conservation note added 2026-07-08. DORMANT since HIMMEL-480: the cost-posture prose moved to docs/internals/lane-calibration.md, which carries its own non-Claude reader note. Retained for the test fixture."
   },
   {
     "from": "a Sonnet/Opus/Fable implementor-shaped Agent dispatch",
     "to": "a Sonnet/Opus/top-model implementor-shaped Agent dispatch",
-    "note": "HIMMEL-920: guard-implementor-dispatch hook description in the ENFORCEMENT section — neutral tier language, same pattern as the Fable-5 lane-table row."
+    "dormant": true,
+    "note": "HIMMEL-920: guard-implementor-dispatch hook description in the ENFORCEMENT section — neutral tier language, same pattern as the Fable-5 lane-table row. DORMANT: the ENFORCEMENT hook enumeration was replaced by a pointer in HIMMEL-480; retained for the test fixture."
   }
 ]

--- a/scripts/agents-md/generate.mjs
+++ b/scripts/agents-md/generate.mjs
@@ -51,15 +51,101 @@ function build() {
   let table;
   try { table = JSON.parse(readFileSync(DEBRAND, 'utf8')); }
   catch (e) { die(2, `agents-md: cannot evaluate — debrand table is not valid JSON: ${e.message}`); }
+  if (!Array.isArray(table)) {
+    die(2, `agents-md: cannot evaluate — debrand table must be a JSON array, got ${typeof table}.`);
+  }
+  // Coverage validation (HIMMEL-480). `split/join` silently no-ops when `from`
+  // is absent, so a CLAUDE.md edit that moves or rewrites debranded text turns
+  // its rule into a dead no-op with NO signal — the transform quietly stops
+  // protecting that string. Every rule must therefore either match, or declare
+  // `"dormant": true` with a `note` saying why. An unmatched, undeclared rule is
+  // a hard error: structural, not a warning nobody reads (HIMMEL-195).
+  const orphans = [];
+  const revived = [];
+  const seenFrom = new Set();
   for (const entry of table) {
-    const { from, to } = entry;
-    // Skip malformed entries: a non-string/empty `from` would either no-op or
-    // (empty string) corrupt the body by inserting `to` between every char.
-    if (typeof from !== 'string' || from === '' || typeof to !== 'string') {
-      process.stderr.write(`agents-md: skipping malformed debrand entry: ${JSON.stringify(entry)}\n`);
-      continue;
+    // Validate the entry SHAPE before destructuring — `const {…} = null` throws
+    // a raw TypeError instead of the structured cannot-evaluate message.
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      die(2, `agents-md: cannot evaluate — malformed debrand entry (expected an object):\n` +
+             `         ${JSON.stringify(entry)}`);
     }
+    const { from, to, dormant } = entry;
+    // Malformed entries are FATAL, not skipped. A non-string/empty `from` would
+    // either no-op or (empty string) corrupt the body by inserting `to` between
+    // every char — and a skipped entry never reaches the orphan calculation
+    // below, so a one-character schema typo would silently disable a live
+    // neutralization rule while BOTH gates still went green. Fail closed.
+    if (typeof from !== 'string' || from === '' || typeof to !== 'string') {
+      die(2, `agents-md: cannot evaluate — malformed debrand entry ` +
+             `(needs a non-empty string "from" and a string "to"):\n` +
+             `         ${JSON.stringify(entry)}`);
+    }
+    if (to === from) {
+      die(2, `agents-md: cannot evaluate — debrand entry maps "from" to itself:\n` +
+             `         ${JSON.stringify(entry)}\n` +
+             `         This performs no substitution and therefore protects nothing.`);
+    }
+    if (seenFrom.has(from)) {
+      die(2, `agents-md: cannot evaluate — duplicate debrand "from" value:\n` +
+             `         ${JSON.stringify(entry)}\n` +
+             `         Each source string may appear only once in the ordered mapping table.`);
+    }
+    seenFrom.add(from);
+    // A `dormant` flag suppresses the coverage error below, so it must carry its
+    // own justification — an unexplained dormant rule is the same silent drift
+    // the coverage check exists to surface, just opted out of.
+    if (dormant === true && (typeof entry.note !== 'string' || entry.note.trim() === '')) {
+      die(2, `agents-md: cannot evaluate — debrand entry is marked "dormant": true but has no "note" ` +
+             `explaining why:\n         · ${JSON.stringify(from)}\n` +
+             `         Record where the content went, so the rule can be revived or deleted later.`);
+    }
+    // Match against the ORIGINAL body, not the progressively rewritten text:
+    // an earlier rule's replacement can destroy a later rule's `from` (false
+    // orphan) or synthesize one (false revival). Coverage is a question about
+    // the SOURCE, so it must be asked of the source.
+    const matched = body.includes(from);
+    if (!matched && dormant !== true) orphans.push(from);
+    if (matched && dormant === true) revived.push(from);
+    const before = debranded;
     debranded = debranded.split(from).join(to);
+    if (matched && debranded === before) {
+      die(2, `agents-md: cannot evaluate — live debrand entry produced no substitution:\n` +
+             `         ${JSON.stringify(entry)}\n` +
+             `         An earlier rule consumed its source text, so this mapping silently protects nothing.`);
+    }
+  }
+  if (revived.length) {
+    const msg = `${revived.length} debrand rule(s) marked "dormant": true now MATCH again:\n` +
+      revived.map((f) => `         · ${JSON.stringify(f)}`).join('\n') + '\n' +
+      `         Drop their "dormant" flag. While the flag stays, the rule is exempt\n` +
+      `         from orphan detection — so a later rewrite of that phrase would go\n` +
+      `         unnoticed, which is the exact silent drift this check exists to stop.`;
+    // Fatal under enforcement, advisory otherwise: a dormant flag left on a live
+    // rule quietly re-opens the fail-open path for every future edit.
+    if (process.env.AGENTS_MD_ENFORCE_COVERAGE === '1') {
+      die(2, `agents-md: cannot evaluate — ${msg}`);
+    }
+    process.stderr.write(`agents-md: NOTE — ${msg}\n`);
+  }
+  // Coverage enforcement is OPT-IN, because this generator legitimately runs
+  // against partial sources: the freshness hooks regenerate from a staged temp
+  // copy, and both test suites build stub fixtures containing none of the live
+  // phrases. Making it unconditional fails all of those spuriously; keying it
+  // on "does SOURCE look like the canonical CLAUDE.md" fails the opposite way —
+  // the freshness hook's temp copy never matches, so the check would be dead in
+  // the one path that gates a commit.
+  //
+  // Instead the dedicated pre-commit gate (scripts/hooks/check-debrand-coverage.sh)
+  // sets AGENTS_MD_ENFORCE_COVERAGE=1 and points SOURCE at the real staged
+  // CLAUDE.md. One job per caller; the gate is what makes this structural.
+  if (orphans.length && process.env.AGENTS_MD_ENFORCE_COVERAGE === '1') {
+    die(2, `agents-md: cannot evaluate — ${orphans.length} debrand rule(s) no longer match ${SOURCE}:\n` +
+           orphans.map((f) => `         · ${JSON.stringify(f)}`).join('\n') + '\n' +
+           `         A rule that matches nothing is a silent no-op: the string it protected\n` +
+           `         is either gone or moved OUT of CLAUDE.md (and is therefore no longer\n` +
+           `         debranded anywhere). Either restore the text, or mark the rule\n` +
+           `         "dormant": true with a "note" recording where the content went.`);
   }
 
   // Assemble: preamble, exactly one blank line, then the (debranded) body. LF, single trailing newline.

--- a/scripts/agents-md/test-generate.sh
+++ b/scripts/agents-md/test-generate.sh
@@ -210,6 +210,78 @@ if sed 's/on Claude, Fable-5//g' "$broken_stripped" | grep -q 'Fable'; then
 else bad "leak check fires on a rewrap-broken entry (red path)"; fi
 SRC="$SAVED_SRC"; TGT="$SAVED_TGT"
 
+# ---- 10. debrand coverage enforcement (HIMMEL-480) ------------------------
+# Coverage is OPT-IN (AGENTS_MD_ENFORCE_COVERAGE=1) and enforced by the
+# dedicated gate scripts/hooks/check-debrand-coverage.sh. It must fire on ANY
+# source the gate hands it — including a staged temp copy, which is what
+# check-agents-md-fresh.sh generates from. Keying enforcement on "SOURCE looks
+# like the canonical CLAUDE.md" would leave it dead in exactly that path
+# (codex-adv finding, CR round 4).
+COVSRC="$TMP/staged-copy/CLAUDE.md"; mkdir -p "$TMP/staged-copy"
+# A source containing NONE of the live debrand phrases -> every live rule orphaned.
+printf '# Staged copy\n\nNo branded phrases here at all.\n' > "$COVSRC"
+AGENTS_MD_ENFORCE_COVERAGE=1 \
+AGENTS_MD_SOURCE="$COVSRC" AGENTS_MD_TARGET="$TMP/AGENTS-cov.md" \
+  AGENTS_MD_PREAMBLE="$PREAMBLE" AGENTS_MD_DEBRAND="$SCRIPT_DIR/debrand.json" \
+  node "$GEN" --write >"$TMP/out" 2>"$TMP/err"
+covrc=$?
+if [ "$covrc" -eq 2 ]; then
+  ok "coverage fires on a staged temp copy when enforced (rc=2)"
+else bad "coverage fires on a staged temp copy when enforced (rc=$covrc, want 2); stderr: $(cat "$TMP/err")"; fi
+if grep -q 'no longer match' "$TMP/err"; then
+  ok "coverage error names the dead rules"
+else bad "coverage error names the dead rules"; fi
+# Without the opt-in, the same partial source must generate cleanly — that is
+# what keeps the freshness hook and both fixture suites working.
+AGENTS_MD_SOURCE="$COVSRC" AGENTS_MD_TARGET="$TMP/AGENTS-cov.md" \
+  AGENTS_MD_PREAMBLE="$PREAMBLE" AGENTS_MD_DEBRAND="$SCRIPT_DIR/debrand.json" \
+  node "$GEN" --write >"$TMP/out" 2>"$TMP/err"
+nooptrc=$?
+if [ "$nooptrc" -eq 0 ]; then ok "partial source generates cleanly without the opt-in"
+else bad "partial source generates cleanly without the opt-in (rc=$nooptrc); stderr: $(cat "$TMP/err")"; fi
+# The real CLAUDE.md must PASS coverage — this is the live-repo assertion.
+AGENTS_MD_ENFORCE_COVERAGE=1 \
+AGENTS_MD_SOURCE="$SCRIPT_DIR/../../CLAUDE.md" AGENTS_MD_TARGET="$TMP/AGENTS-live.md" \
+  AGENTS_MD_PREAMBLE="$PREAMBLE" AGENTS_MD_DEBRAND="$SCRIPT_DIR/debrand.json" \
+  node "$GEN" --write >"$TMP/out" 2>"$TMP/err"
+livercv=$?
+if [ "$livercv" -eq 0 ]; then ok "live CLAUDE.md passes debrand coverage"
+else bad "live CLAUDE.md passes debrand coverage (rc=$livercv); stderr: $(cat "$TMP/err")"; fi
+# Malformed entries must be FATAL, not skipped (codex-adv + coderabbit, round 5).
+# A skipped entry never reaches the orphan calculation, so a one-character schema
+# typo would silently disable a live rule while both gates stayed green. Each
+# case is checked WITHOUT the coverage opt-in, proving the guard is unconditional.
+malformed_case() {
+  local desc="$1" json="$2" want="$3"
+  local f="$TMP/debrand-malformed.json"
+  printf '%s\n' "$json" > "$f"
+  AGENTS_MD_SOURCE="$COVSRC" AGENTS_MD_TARGET="$TMP/AGENTS-cov.md" \
+    AGENTS_MD_PREAMBLE="$PREAMBLE" AGENTS_MD_DEBRAND="$f" \
+    node "$GEN" --write >"$TMP/out" 2>"$TMP/err"
+  local mrc=$?
+  if [ "$mrc" -eq "$want" ]; then ok "$desc"
+  else bad "$desc (rc=$mrc, want $want)"; fi
+}
+malformed_case "missing 'from' is fatal"      '[{"to":"x"}]'                       2
+malformed_case "empty 'from' is fatal"        '[{"from":"","to":"x"}]'             2
+malformed_case "non-string 'from' is fatal"   '[{"from":123,"to":"x"}]'            2
+malformed_case "missing 'to' is fatal"        '[{"from":"spawns a Fable child"}]'  2
+malformed_case "null 'to' is fatal"           '[{"from":"a","to":null}]'           2
+malformed_case "same 'from' and 'to' is fatal" '[{"from":"a","to":"a"}]'            2
+malformed_case "duplicate 'from' is fatal"    '[{"from":"duplicate-phrase","to":"x"},{"from":"duplicate-phrase","to":"y"}]' 2
+malformed_case "an earlier overlapping rule cannot consume a live source" '[{"from":"branded phrases","to":"neutral text"},{"from":"branded","to":"generic"}]' 2
+malformed_case "non-array table is fatal"     '{"from":"a","to":"b"}'              2
+
+# A dormant rule with no note is rejected — independent of the coverage opt-in.
+NONOTE="$TMP/debrand-nonote.json"
+printf '[{"from":"zzz-absent-phrase","to":"x","dormant":true}]\n' > "$NONOTE"
+AGENTS_MD_SOURCE="$COVSRC" AGENTS_MD_TARGET="$TMP/AGENTS-cov.md" \
+  AGENTS_MD_PREAMBLE="$PREAMBLE" AGENTS_MD_DEBRAND="$NONOTE" \
+  node "$GEN" --write >"$TMP/out" 2>"$TMP/err"
+nonotercv=$?
+if [ "$nonotercv" -eq 2 ]; then ok "dormant rule without a note is rejected"
+else bad "dormant rule without a note is rejected (rc=$nonotercv)"; fi
+
 # ---- summary --------------------------------------------------------------
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/hooks/check-debrand-coverage.sh
+++ b/scripts/hooks/check-debrand-coverage.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# HIMMEL-480 — every debrand rule must still match the staged CLAUDE.md.
+#
+# generate.mjs debrands via `split(from).join(to)`, which silently no-ops when
+# `from` is absent. So a CLAUDE.md edit that moves, rewraps, or rewrites a
+# debranded phrase turns its rule into a dead no-op with NO signal: the string
+# it protected stops being neutralized, and the AGENTS.md freshness guard does
+# not notice (it compares generated output to generated output — both sides
+# regenerate together, so both are equally wrong).
+#
+# This gate closes that. It runs the generator with coverage enforcement ON
+# against the STAGED CLAUDE.md, so an unmatched rule that has not declared
+# `"dormant": true` (with a note) blocks the commit.
+#
+# Deliberately SEPARATE from check-agents-md-fresh.sh: that hook regenerates
+# from a staged temp copy and its own tests use stub fixtures, so coverage can
+# neither be always-on there nor path-detected (the temp copy never matches the
+# canonical path — which is exactly how an earlier attempt left the check dead
+# in the only path that gates a commit).
+#
+# Exit: 0 covered / not applicable · 1 an orphaned rule · 2 cannot evaluate.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GEN="$SCRIPT_DIR/../agents-md/generate.mjs"
+
+# himmel-dev only: adopters who vendored the repo do not maintain debrand.json.
+# Use the shared resolver, NOT a bare [ -f "$REPO_ROOT/.himmel-dev" ] — the
+# marker is gitignored and lives in the PRIMARY checkout, so a naive test
+# silently no-ops in every worktree (i.e. in exactly the place feature work
+# happens). Mirrors check-agents-md-fresh.sh.
+# shellcheck source=scripts/guardrails/lib.sh
+# shellcheck disable=SC1091
+. "$REPO_ROOT/scripts/guardrails/lib.sh"
+rc=0; is_himmel_dev_repo || rc=$?
+# `if`, not `[ … ] && exit 0` — under errexit a false test makes the compound
+# return 1 and kills the script with a bogus failure.
+if [ "$rc" -eq 1 ]; then exit 0; fi   # not a himmel-dev checkout → no-op
+if [ ! -f "$GEN" ]; then echo "→ debrand-coverage: generator missing — fail-closed" >&2; exit 2; fi
+
+# Only relevant when the repo-root CLAUDE.md or debrand table is staged. A git
+# failure here is NOT "nothing staged" — suppressing it with `|| true` would
+# turn an unreadable index into a silent pass, which is the opposite of
+# fail-closed. Parse name-status fields exactly; substring matches would also
+# fire for unrelated paths such as templates/luna-second-brain/_CLAUDE.md.
+if ! staged="$(git diff --cached --name-status 2>/dev/null)"; then
+    echo "→ debrand-coverage: cannot inspect staged paths — fail-closed" >&2; exit 2
+fi
+relevant=0
+refuse=0
+while IFS=$'\t' read -r status old_path new_path; do
+    case "$old_path" in
+      CLAUDE.md|scripts/agents-md/debrand.json)
+        relevant=1
+        case "$status" in D|R[0-9]*) refuse=1 ;; esac
+        ;;
+    esac
+    case "$status" in
+      R[0-9]*)
+        case "$new_path" in
+          CLAUDE.md|scripts/agents-md/debrand.json) relevant=1; refuse=1 ;;
+        esac
+        ;;
+    esac
+done < <(printf '%s\n' "$staged")
+if [ "$relevant" -eq 0 ]; then exit 0; fi
+
+# A staged DELETION or RENAME of either input is not something to validate
+# around — the fallbacks below would happily check HEAD's copy and pass a commit
+# that removes or relocates the file. For rename records both old and new paths
+# matter: moving an input out or replacing one by moving another file in must
+# fail closed.
+if [ "$refuse" -eq 1 ]; then
+    echo "→ debrand-coverage: CLAUDE.md or debrand.json is staged for DELETION/RENAME — fail-closed" >&2
+    exit 2
+fi
+
+tmpd="$(mktemp -d)"
+trap 'rm -rf "$tmpd"' EXIT
+
+# Validate the STAGED content, not the working tree — the commit is what ships.
+if ! git show ":CLAUDE.md" > "$tmpd/CLAUDE.md" 2>/dev/null; then
+    # CLAUDE.md not staged (only debrand.json was) — validate against HEAD's copy.
+    if ! git show "HEAD:CLAUDE.md" > "$tmpd/CLAUDE.md" 2>/dev/null; then
+        echo "→ debrand-coverage: no CLAUDE.md in index or HEAD — fail-closed" >&2; exit 2
+    fi
+fi
+# Same rule as CLAUDE.md above: validate COMMITTED state, never the working
+# tree. Falling back to $SCRIPT_DIR/../agents-md/debrand.json would let an
+# unstaged edit of the mapping decide whether the staged commit passes.
+deb="$tmpd/debrand.json"
+if ! git show ":scripts/agents-md/debrand.json" > "$deb" 2>/dev/null; then
+    if ! git show "HEAD:scripts/agents-md/debrand.json" > "$deb" 2>/dev/null; then
+        echo "→ debrand-coverage: no debrand.json in index or HEAD — fail-closed" >&2
+        exit 2
+    fi
+fi
+
+# `if` exempts the call from errexit while still capturing its status — no
+# set +e/-e toggling, so every other command in this script stays fail-closed.
+#
+# The branches must be `then rc=0; else rc=$?`, NOT `if ! cmd; then rc=$?`:
+# `!` negates the status BEFORE the branch runs, so inside `then` $? is 0 and
+# rc would always be 0 — a gate that reports success for every failure. That
+# exact inversion shipped briefly and both CR lanes flagged it; the hook-level
+# regression test (test-check-debrand-coverage.sh) exists to keep it dead.
+if AGENTS_MD_ENFORCE_COVERAGE=1 \
+   AGENTS_MD_SOURCE="$tmpd/CLAUDE.md" AGENTS_MD_TARGET="$tmpd/AGENTS.md" \
+   AGENTS_MD_PREAMBLE="$SCRIPT_DIR/../agents-md/preamble.md" \
+   AGENTS_MD_DEBRAND="$deb" node "$GEN" --write >/dev/null 2>"$tmpd/err"; then
+    rc=0
+else
+    rc=$?
+fi
+cat "$tmpd/err" >&2 || true
+
+# generate.mjs signals EVERY cannot-evaluate condition with exit 2 — an orphaned
+# rule, a malformed entry, a non-array table, an @include. Only the first is a
+# "you broke coverage" finding (our exit 1); the rest are genuine cannot-evaluate
+# (our exit 2). The statuses do not distinguish them, so key off the message.
+if [ "$rc" -eq 2 ] && ! grep -q 'no longer match' "$tmpd/err"; then
+    echo "→ debrand-coverage: generator cannot evaluate (see message above) — fail-closed" >&2
+    exit 2
+fi
+
+case "$rc" in
+  0) exit 0 ;;
+  2) cat >&2 <<'EOF'
+⛔ debrand-coverage: a debrand rule no longer matches the staged CLAUDE.md
+   (see the generator message above).
+
+   Why it matters: the replacement is a literal split/join, so a rule that
+   matches nothing silently protects nothing — the phrase it was neutralizing
+   now reaches AGENTS.md (or moved out of CLAUDE.md entirely and is no longer
+   debranded anywhere). Non-Claude harnesses read that file.
+
+   Fix one of:
+     1. Restore/rewrap the phrase in CLAUDE.md so the rule matches again.
+     2. Update the rule's "from" to the new wording.
+     3. If the content moved out on purpose, mark the rule
+        "dormant": true with a "note" saying where it went — and make sure
+        the new home carries its own non-Claude reader note.
+EOF
+     exit 1 ;;
+  *) echo "→ debrand-coverage: generator exited $rc — fail-closed" >&2; exit 2 ;;
+esac

--- a/scripts/hooks/test-check-debrand-coverage.sh
+++ b/scripts/hooks/test-check-debrand-coverage.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/hooks/check-debrand-coverage.sh (HIMMEL-480).
+#
+# WHY THIS FILE EXISTS: the generator suite (scripts/agents-md/test-generate.sh)
+# only exercises generate.mjs. The hook WRAPPER around it was untested, and a
+# status-capture inversion (`if ! cmd; then rc=$?`, which leaves rc=0 because
+# `!` negates before the branch) shipped briefly and made the gate report
+# success for every failure. Unit tests could not have caught that. These cases
+# drive the hook itself and assert its exit code.
+#
+# The hook runs IN PLACE from the real tree (it resolves the generator and
+# guardrails/lib.sh via its own SCRIPT_DIR); only the GIT REPO is a tempdir.
+#
+# shellcheck disable=SC2034  # R/SCRIPT used inside eval'd test body strings
+# shellcheck disable=SC2016  # single-quoted test bodies intentionally contain $
+# shellcheck disable=SC2317  # fixture fns called indirectly via eval
+# shellcheck disable=SC2329  # same as SC2317 in newer shellcheck
+set -uo pipefail
+
+HOOKS="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HOOKS/check-debrand-coverage.sh"
+REAL_CLAUDE="$HOOKS/../../CLAUDE.md"
+REAL_DEBRAND="$HOOKS/../agents-md/debrand.json"
+
+# A throwaway repo whose CLAUDE.md is a COPY of the real one, so the real
+# debrand table's live rules genuinely match — the baseline must be green.
+setup_repo() {
+  R=$(mktemp -d); git -C "$R" init -q
+  git -C "$R" config user.email t@t; git -C "$R" config user.name t
+  : > "$R/.himmel-dev"
+  mkdir -p "$R/scripts/agents-md"
+  cp "$REAL_CLAUDE" "$R/CLAUDE.md"
+  cp "$REAL_DEBRAND" "$R/scripts/agents-md/debrand.json"
+  git -C "$R" add CLAUDE.md scripts/agents-md/debrand.json
+  git -C "$R" commit -qm init
+}
+
+expect_rc() { local want=$1; shift; local rc=0; "$@" || rc=$?; [ "$rc" -eq "$want" ]; }
+
+_failures=0
+run_test() {
+  local name="$1" body="$2"; local rc=0
+  ( eval "$body" ) 2>/dev/null || rc=$?
+  if [ "$rc" -eq 0 ]; then printf '  PASS  %s\n' "$name"
+  else printf '  FAIL  %s (subshell rc=%s)\n' "$name" "$rc"; _failures=$((_failures + 1)); fi
+}
+
+run_test "no-op without .himmel-dev marker (rc=0)" '
+  setup_repo; cd "$R"; rm -f .himmel-dev;
+  printf "\nx\n" >> CLAUDE.md; git add CLAUDE.md;
+  expect_rc 0 bash "$SCRIPT"
+'
+
+run_test "no-op when neither input is staged (rc=0)" '
+  setup_repo; cd "$R"; echo hi > other.txt; git add other.txt;
+  expect_rc 0 bash "$SCRIPT"
+'
+
+run_test "no-op for unrelated path containing CLAUDE.md (rc=0)" '
+  setup_repo; cd "$R"; mkdir -p templates/luna-second-brain;
+  echo hi > templates/luna-second-brain/_CLAUDE.md;
+  git add templates/luna-second-brain/_CLAUDE.md;
+  expect_rc 0 bash "$SCRIPT"
+'
+
+run_test "green: staged CLAUDE.md keeps every live rule matching (rc=0)" '
+  setup_repo; cd "$R";
+  printf "\nAn unrelated new rule.\n" >> CLAUDE.md; git add CLAUDE.md;
+  expect_rc 0 bash "$SCRIPT"
+'
+
+# THE regression case for the fail-open inversion: break a LIVE rule and require
+# a nonzero exit. With `if ! cmd; then rc=$?` this returned 0.
+run_test "blocks when a live debrand rule is orphaned (rc=1)" '
+  setup_repo; cd "$R";
+  # No sed -i: that is GNU-only and this suite must run on macOS bash 3.2 too.
+  sed "s/spawns a Fable child/spawns a Fable offspring/" CLAUDE.md > CLAUDE.tmp;
+  mv CLAUDE.tmp CLAUDE.md;
+  git add CLAUDE.md;
+  expect_rc 1 bash "$SCRIPT"
+'
+
+# A dormant rule whose phrase reappears must fail closed under enforcement:
+# leaving the flag on exempts that rule from orphan detection forever after.
+run_test "blocks a revived dormant rule (rc=2)" '
+  setup_repo; cd "$R";
+  printf "%s\n" "[{\"from\":\"spawns a Fable child\",\"to\":\"spawns a top-model child\",\"dormant\":true,\"note\":\"deliberately stale flag\"}]" \
+    > scripts/agents-md/debrand.json;
+  git add scripts/agents-md/debrand.json;
+  expect_rc 2 bash "$SCRIPT"
+'
+
+# The hook must judge COMMITTED state — an unstaged debrand.json edit must not
+# change the verdict.
+run_test "ignores an unstaged debrand.json edit (rc=0)" '
+  setup_repo; cd "$R";
+  printf "\nAn unrelated new rule.\n" >> CLAUDE.md; git add CLAUDE.md;
+  printf "%s\n" "[{\"from\":\"zzz-never-present\",\"to\":\"x\"}]" > scripts/agents-md/debrand.json;
+  expect_rc 0 bash "$SCRIPT"
+'
+
+run_test "blocks a staged DELETION of CLAUDE.md (rc=2)" '
+  setup_repo; cd "$R"; git rm --cached -q CLAUDE.md;
+  expect_rc 2 bash "$SCRIPT"
+'
+
+run_test "blocks a staged RENAME of CLAUDE.md (rc=2)" '
+  setup_repo; cd "$R"; git mv CLAUDE.md CLAUDE.renamed.md;
+  expect_rc 2 bash "$SCRIPT"
+'
+
+run_test "malformed staged debrand.json is fatal (rc=2)" '
+  setup_repo; cd "$R";
+  printf "[{\"to\":\"x\"}]\n" > scripts/agents-md/debrand.json;
+  git add scripts/agents-md/debrand.json;
+  expect_rc 2 bash "$SCRIPT"
+'
+
+run_test "staged no-op debrand mapping is fatal (rc=2)" '
+  setup_repo; cd "$R";
+  printf "%s\n" "[{\"from\":\"spawns a Fable child\",\"to\":\"spawns a Fable child\"}]" \
+    > scripts/agents-md/debrand.json;
+  git add scripts/agents-md/debrand.json;
+  expect_rc 2 bash "$SCRIPT"
+'
+
+run_test "staged duplicate-from debrand mapping is fatal (rc=2)" '
+  setup_repo; cd "$R";
+  printf "%s\n" "[{\"from\":\"duplicate-phrase\",\"to\":\"x\"},{\"from\":\"duplicate-phrase\",\"to\":\"y\"}]" \
+    > scripts/agents-md/debrand.json;
+  git add scripts/agents-md/debrand.json;
+  expect_rc 2 bash "$SCRIPT"
+'
+
+run_test "non-array staged debrand.json is fatal (rc=2)" '
+  setup_repo; cd "$R";
+  printf "{\"from\":\"a\",\"to\":\"b\"}\n" > scripts/agents-md/debrand.json;
+  git add scripts/agents-md/debrand.json;
+  expect_rc 2 bash "$SCRIPT"
+'
+
+if [ "$_failures" -eq 0 ]; then echo "OK: all cases passed"; exit 0
+else echo "FAIL: $_failures case(s) failed"; exit 1; fi

--- a/scripts/hooks/test-check-debrand-coverage.sh
+++ b/scripts/hooks/test-check-debrand-coverage.sh
@@ -40,7 +40,12 @@ expect_rc() { local want=$1; shift; local rc=0; "$@" || rc=$?; [ "$rc" -eq "$wan
 _failures=0
 run_test() {
   local name="$1" body="$2"; local rc=0
-  ( eval "$body" ) 2>/dev/null || rc=$?
+  # The EXIT trap runs INSIDE the per-test subshell, where setup_repo's $R is
+  # set — each case makes exactly one throwaway repo, so one trap cleans it.
+  # Without this a 13-case run leaves 13 mktemp -d git repos behind, and they
+  # accumulate across runs. `${R:-}` keeps it a harmless no-op if a case exits
+  # before setup_repo runs.
+  ( trap 'rm -rf "${R:-}"' EXIT; eval "$body" ) 2>/dev/null || rc=$?
   if [ "$rc" -eq 0 ]; then printf '  PASS  %s\n' "$name"
   else printf '  FAIL  %s (subshell rc=%s)\n' "$name" "$rc"; _failures=$((_failures + 1)); fi
 }


### PR DESCRIPTION
Applies Anthropic's [Claude 5 context-engineering guidance](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models) and the [Prompting Claude Opus 5](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5) doc to the harness's own always-loaded surface.

**`CLAUDE.md` / `AGENTS.md`: 20,965 → ~15,300 chars** (~1.4k est. tokens saved every session).

## What was cut, and why it was safe

Each line removed is either derivable from the repo or already enforced by a gate that speaks at the moment of violation — which is progressive disclosure in its purest form:

| Cut | Recoverable from |
|---|---|
| MAP directory listing | `ls` |
| ENFORCEMENT hook enumeration | `.claude/settings.json` + `.pre-commit-config.yaml` (the inline list had already drifted to 11-vs-16) |
| Conventional-commit format spec | the `commit-msg` gate rejects and explains |
| Billing announcement dates/status | `docs/internals/enforcement.md` |
| Worktree "pick by intent" prose | command descriptions, already resident |
| REFERENCE INDEX descriptions | `ls docs/internals/` |

## What moved to lazy loading

- Tier table, effort calibration, cost posture, escalation rationale → **new `docs/internals/lane-calibration.md`**
- Layer-selection frame + escalation doctrine → `docs/internals/context-architecture.md`, which previously pointed *back* at `CLAUDE.md` for these. The circular reference is now resolved in the right direction.

## What deliberately stayed

Every directive and every gotcha. `context-architecture.md` states the constraint that governed this split — *"the model does not query for a rule it does not know it is violating, so a directive behind a query is dead"* — so only fact-shaped reference moved. Two review rounds caught exactly this failure: directives that had been moved out of view. Both restored.

## Delegation floor (Opus 5 guidance)

Anthropic's Opus 5 doc reports the model over-delegates and over-verifies by default. Added: *don't delegate work you'd finish in a handful of tool calls, and never spawn a subagent to verify your own work.*

## New gate: `debrand-coverage`

`scripts/agents-md/debrand.json` had **only 1 of 13 rules still matching** — 8 were already dead. `split(from).join(to)` no-ops silently, so a rename quietly disables a debranding mapping and nothing complains. The new pre-commit gate (`scripts/hooks/check-debrand-coverage.sh`, 13-case test suite in `scripts/hooks/test-check-debrand-coverage.sh`) fails when a mapping stops matching.

## Verification

- `bash scripts/agents-md/test-generate.sh`
- `bash scripts/hooks/test-check-debrand-coverage.sh` (13 cases)
- Reviewed across 12 review rounds on two independent reviewer lanes; 25 findings, 22 fixed, 3 declined with rationale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational guidance for routing, escalation, enforcement, worktrees, and artifact handling.
  * Added documentation describing layer selection, enforcement strength, and model-lane calibration.

* **Bug Fixes**
  * Improved validation to detect invalid, duplicate, outdated, or conflicting debranding rules before changes are accepted.
  * Added safeguards to prevent documentation and debranding rules from becoming inconsistent.

* **Tests**
  * Added comprehensive coverage for debranding validation and commit-time enforcement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->