### PR TITLE
fix: two fail-open guards that never actually guarded

### DIFF
--- a/.claude/commands/cr-public.md
+++ b/.claude/commands/cr-public.md
@@ -175,8 +175,8 @@ while [ "$(date +%s)" -lt "$deadline" ] && [ "$iter" -lt "$max_iter" ]; do
     # head + zero reviews — indistinguishable from "no fresh review" — and would
     # then let the wait expire straight into the operator-merge fallback on what
     # was really an auth/network error.
-    head=$(gh pr view "$pr" --repo "$REPO" --json headRefSha -q .headRefSha) \
-        || { echo "cr-public: cannot evaluate — gh pr view (headRefSha) failed"; exit 2; }
+    head=$(gh pr view "$pr" --repo "$REPO" --json headRefOid -q .headRefOid) \
+        || { echo "cr-public: cannot evaluate — gh pr view (headRefOid) failed"; exit 2; }
     [ -n "$head" ] || { echo "cr-public: cannot evaluate — empty head sha"; exit 2; }
     # fresh review at the CURRENT head? (CodeRabbit posts a review whose commit == head)
     reviewed=$(gh pr view "$pr" --repo "$REPO" --json reviews \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,15 @@ repos:
         pass_filenames: true
         stages: [pre-commit]
 
+      - id: gh-json-fields
+        name: Validate gh --json field names against gh's own list (HIMMEL-1288)
+        language: system
+        entry: bash scripts/hooks/check-gh-json-fields.sh
+        pass_filenames: true
+        files: '\.(md|sh|bash|ts|js|mjs|cjs)$'
+        exclude: '^(archive/|.*/node_modules/)'
+        stages: [pre-commit]
+
       - id: no-headless-claude
         name: Block headless claude (-p / --print / --bg) introductions (HIMMEL-128)
         language: system

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -22,6 +22,16 @@ Stages currently wired:
 - **MCP plugin enforcement (pre-commit):** mcp-plugin-refs (blocks commits
   referencing Atlassian MCP Jira tools that have a himmel-jira plugin
   equivalent — see `block-backend-tier.sh` below).
+- **`gh --json` field-name guard (pre-commit):** gh-json-fields (every
+  literal `gh <sub> … --json a,b,c` in staged markdown/shell/ts/js is
+  checked against the field list `gh <sub> --json __bogus__` prints —
+  offline, no API call). A typo'd field makes `gh` exit 1, which callers
+  report as a generic "cannot evaluate", so the guarded path silently
+  never runs: that is how `/cr-public`'s HIMMEL-1202 bounded wait shipped
+  polling the nonexistent `headRefSha` (HIMMEL-1288). Non-literal
+  field lists (`--json "$FIELDS"`) and subcommands with no `--json`
+  support are skipped; a missing `gh` skips the gate loudly rather than
+  blocking the commit.
 - **Headless-claude gate (pre-commit):** no-headless-claude (blocks new
   `claude -p` / `claude --print` / `claude --bg` introductions unless
   the call has a `# headless-claude-ok: <reason>` marker on the same or

--- a/plugins/himmel-gh/package-lock.json
+++ b/plugins/himmel-gh/package-lock.json
@@ -901,9 +901,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -958,9 +958,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -978,7 +978,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/plugins/himmel-jira/package-lock.json
+++ b/plugins/himmel-jira/package-lock.json
@@ -901,9 +901,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -958,9 +958,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -978,7 +978,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/scripts/bitbucket/package-lock.json
+++ b/scripts/bitbucket/package-lock.json
@@ -1281,9 +1281,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1356,9 +1356,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -1376,7 +1376,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/scripts/ci-orchestrator/package-lock.json
+++ b/scripts/ci-orchestrator/package-lock.json
@@ -8,6 +8,9 @@
       "name": "ci-orchestrator",
       "version": "0.1.0",
       "license": "MIT",
+      "bin": {
+        "ci-orchestrator": "dist/index.js"
+      },
       "devDependencies": {
         "@types/node": "^26.1.0",
         "typescript": "^6.0.3",
@@ -913,9 +916,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -973,9 +976,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -993,7 +996,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/scripts/himmel-run/package-lock.json
+++ b/scripts/himmel-run/package-lock.json
@@ -1321,9 +1321,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1378,9 +1378,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -1398,7 +1398,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/scripts/hooks/check-gh-json-fields.sh
+++ b/scripts/hooks/check-gh-json-fields.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Pre-commit gate (pre-commit framework, not Claude PreToolUse).
+#
+# Validates every literal `gh <cmd> <sub> ... --json a,b,c` field list in
+# staged content against the field names `gh` itself advertises. A typo'd
+# field is invisible until the command runs live: `gh` exits 1 with
+# "Unknown JSON field", which a caller's fail-closed guard reports as a
+# generic "cannot evaluate" — indistinguishable from an auth/network
+# blip. That is how HIMMEL-1288 shipped: /cr-public's HIMMEL-1202
+# bounded-wait polled `--json headRefSha` (the real field is
+# headRefOid), so the wait could never run a single iteration, and the
+# operator-merge fallback it guards was unreachable precisely when a
+# public PR needed it.
+#
+# Enumeration is offline: `gh <sub> --json __bogus__` prints
+# "Available fields:" plus the list to stderr with no API call, so this
+# gate adds no network dependency and works on a plane.
+#
+# Deliberately narrow — only LITERAL field lists are checked. Anything
+# carrying `$`, backticks or command substitution is skipped rather than
+# guessed at; this gate exists to catch typos, not to evaluate shell.
+#
+# Exit codes:
+#   0 — clean, or gh unavailable (lint, not a security gate: skip loudly)
+#   1 — at least one unknown field name in a staged file
+set -uo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "check-gh-json-fields: gh not on PATH — skipping" >&2
+    exit 0
+fi
+
+# pre-commit passes staged filenames as argv (pass_filenames: true). Fall
+# back to a diff so always_run / manual invocation works too.
+files=("$@")
+if [ "${#files[@]}" -eq 0 ]; then
+    # bash 3.2-safe (macOS): no mapfile.
+    while IFS= read -r _line; do files+=("$_line"); done < <(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)
+fi
+[ "${#files[@]}" -eq 0 ] && exit 0
+
+# Cache of resolved field lists, keyed by subcommand. bash 3.2 has no
+# associative arrays (see scripts/hooks/CLAUDE.md), so this is a flat
+# "\nkey\tf1 f2 f3" string searched with a literal match.
+CACHE=""
+
+# Sets FIELDS_OUT to the space-delimited valid fields for a `gh`
+# subcommand, or empty if the subcommand does not support --json at all
+# (then we skip it: an unsupported --json is a different bug class, and
+# guessing here would emit noise on every `gh api --jq` style call).
+#
+# Result goes through a global rather than stdout on purpose: `$(...)`
+# would run this in a subshell and throw away every CACHE write, so the
+# cache would silently never hit and each matched line would respawn gh.
+FIELDS_OUT=""
+fields_for() {
+    _sub="$1"
+    FIELDS_OUT=""
+    _hit=$(printf '%s' "$CACHE" | grep -F "	$_sub	" 2>/dev/null | head -1)
+    if [ -n "$_hit" ]; then
+        FIELDS_OUT="${_hit#*"	$_sub	"}"
+        return 0
+    fi
+    # shellcheck disable=SC2086  # $_sub is a validated [a-z-]+ token list
+    _raw=$(gh $_sub --json __himmel_probe__ 2>&1 >/dev/null)
+    case "$_raw" in
+        *"Available fields:"*) : ;;
+        *) CACHE="$CACHE
+	$_sub	"; return 0 ;;
+    esac
+    _list=$(printf '%s\n' "$_raw" \
+        | sed -n '/Available fields:/,$p' \
+        | sed '1d' \
+        | tr -d '\r' \
+        | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
+        | grep -E '^[A-Za-z][A-Za-z0-9_]*$' \
+        | tr '\n' ' ')
+    CACHE="$CACHE
+	$_sub	$_list"
+    FIELDS_OUT="$_list"
+}
+
+violations=""
+for f in "${files[@]}"; do
+    [ -f "$f" ] || continue
+    # Skip this gate and its own test — both embed deliberately-bogus
+    # field names as fixtures. Match repo-relative paths, not basenames,
+    # so a file dropped elsewhere cannot inherit the exemption.
+    case "$f" in
+        scripts/hooks/check-gh-json-fields.sh|scripts/hooks/test-check-gh-json-fields.sh) continue ;;
+    esac
+
+    while IFS= read -r hit; do
+        [ -n "$hit" ] || continue
+        lineno=${hit%%:*}
+        text=${hit#*:}
+        # Subcommand = the leading run of bare lowercase words after `gh`.
+        # Stopping at the first non-word token drops flags, quoted args and
+        # `"$pr"`-style expansions without having to enumerate shell syntax.
+        sub=$(printf '%s' "$text" \
+            | sed -E 's/.*(^|[^A-Za-z0-9_-])gh[[:space:]]+//' \
+            | sed -E 's/^([a-z][a-z-]*( [a-z][a-z-]*)*).*/\1/')
+        # Only well-formed subcommand words; anything else is not ours.
+        printf '%s' "$sub" | grep -qE '^[a-z][a-z-]*( [a-z][a-z-]*)*$' || continue
+        csv=$(printf '%s' "$text" | sed -E 's/.*--json[[:space:]]+//' | sed -E 's/[^A-Za-z0-9_,].*//')
+        [ -n "$csv" ] || continue
+
+        fields_for "$sub"
+        valid="$FIELDS_OUT"
+        # Empty => subcommand does not support --json; not this gate's business.
+        [ -n "$valid" ] || continue
+
+        for fld in $(printf '%s' "$csv" | tr ',' ' '); do
+            [ -n "$fld" ] || continue
+            case " $valid " in
+                *" $fld "*) : ;;
+                *) violations="$violations
+  $f:$lineno: gh $sub --json … unknown field \"$fld\"" ;;
+            esac
+        done
+    done < <(grep -nE '(^|[^A-Za-z0-9_-])gh[[:space:]]+[a-z][a-z-]*([[:space:]]+[a-z][a-z-]*)*[^|;&]*--json[[:space:]]+[A-Za-z][A-Za-z0-9_,]*' -- "$f" 2>/dev/null || true)
+done
+
+[ -n "$violations" ] || exit 0
+
+{
+    echo "⛔ check-gh-json-fields: staged file(s) pass field names \`gh\` does not know."
+    echo "$violations"
+    echo
+    echo "gh exits 1 on an unknown field, which callers report as a generic"
+    echo "\"cannot evaluate\" — so the typo hides as a transient failure and the"
+    echo "guarded path silently never runs (HIMMEL-1288)."
+    echo "List the real names with:  gh <subcommand> --json __bogus__"
+} >&2
+exit 1

--- a/scripts/hooks/test-check-gh-json-fields.sh
+++ b/scripts/hooks/test-check-gh-json-fields.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/hooks/check-gh-json-fields.sh (HIMMEL-1288).
+#
+# The regression this locks: `gh pr view --json headRefSha` (no such
+# field) must FAIL LOUDLY here at commit time, instead of shipping and
+# surfacing later as a generic "cannot evaluate" that hides a guarded
+# path never running.
+#
+# Uses a `gh` stub on PATH so the suite is hermetic — no real gh, no
+# network, and the field lists are fixed rather than tracking whatever
+# gh version the machine happens to have.
+#
+# File-scoped: the test cases are single-quoted shell FIXTURES fed to the
+# gate as file content. Their `$pr` / `$FIELDS` must stay literal — one
+# of the cases exists precisely to prove an unexpanded `--json "$FIELDS"`
+# is skipped — so SC2016 is the intended shape here, not a bug.
+# shellcheck disable=SC2016
+set -uo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+GATE="$HERE/check-gh-json-fields.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+# --- gh stub -------------------------------------------------------------
+# Mirrors real gh: an unknown field goes to STDERR as "Unknown JSON field"
+# + "Available fields:" + an indented list, exit 1. `gh api` supports no
+# --json at all, so it must not print a field list.
+mkdir -p "$TMP/bin"
+cat >"$TMP/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+[ -n "${GH_CALL_LOG:-}" ] && echo "$1 $2" >>"$GH_CALL_LOG"
+sub="$1 $2"
+case "$sub" in
+    "pr view"|"pr list")
+        echo 'Unknown JSON field: "x"' >&2
+        echo 'Available fields:' >&2
+        printf '  %s\n' baseRefName headRefName headRefOid number reviews state url >&2
+        exit 1 ;;
+    "repo view")
+        echo 'Unknown JSON field: "x"' >&2
+        echo 'Available fields:' >&2
+        printf '  %s\n' isPrivate nameWithOwner >&2
+        exit 1 ;;
+    *)
+        echo 'unknown command' >&2
+        exit 1 ;;
+esac
+STUB
+chmod +x "$TMP/bin/gh"
+export PATH="$TMP/bin:$PATH"
+
+check() {
+    # check <name> <expected-rc> <file-content>
+    name="$1"; want="$2"; body="$3"
+    f="$TMP/case.md"
+    printf '%s\n' "$body" >"$f"
+    out=$(cd "$TMP" && bash "$GATE" case.md 2>&1)
+    got=$?
+    if [ "$got" -eq "$want" ]; then
+        echo "ok   — $name"
+        pass=$((pass + 1))
+    else
+        echo "FAIL — $name (want rc=$want, got rc=$got)"
+        printf '%s\n' "$out" | sed 's/^/       /'
+        fail=$((fail + 1))
+    fi
+}
+
+# The actual HIMMEL-1288 bug, verbatim in shape.
+check "headRefSha is rejected" 1 \
+    '    head=$(gh pr view "$pr" --repo "$REPO" --json headRefSha -q .headRefSha)'
+
+# The fix must pass.
+check "headRefOid is accepted" 0 \
+    '    head=$(gh pr view "$pr" --repo "$REPO" --json headRefOid -q .headRefOid)'
+
+# Multi-field CSV: one bad name among good ones still fails.
+check "bad field inside a CSV is rejected" 1 \
+    'gh pr list --head "$b" --state open --json number,headRefSha'
+
+check "all-good CSV is accepted" 0 \
+    'gh pr list --head "$b" --state open --json number,headRefOid'
+
+# Field sets are per-subcommand: a valid `pr view` field is not a valid
+# `repo view` field, and the gate must not pool them.
+check "field valid elsewhere is rejected for this subcommand" 1 \
+    'gh repo view --json headRefOid'
+
+check "correct subcommand field is accepted" 0 \
+    'gh repo view --json nameWithOwner,isPrivate'
+
+# Subcommands with no --json support are not this gate's business.
+check "subcommand without --json support is skipped" 0 \
+    'gh api graphql --json whatever'
+
+# Non-literal field lists are skipped rather than guessed at.
+check "variable field list is skipped" 0 \
+    'gh pr view --json "$FIELDS"'
+
+# A file with no gh calls at all is trivially clean.
+check "unrelated file is clean" 0 \
+    'nothing to see here'
+
+# Missing gh must skip (rc 0), not block every commit on a lint. Invoke
+# bash by absolute path — the emptied PATH cannot resolve `bash` itself.
+BASH_ABS=$(command -v bash)
+printf '%s\n' 'gh pr view --json headRefSha' >"$TMP/case.md"
+out=$(cd "$TMP" && PATH="/nonexistent" "$BASH_ABS" "$GATE" case.md 2>&1); got=$?
+if [ "$got" -eq 0 ] && printf '%s' "$out" | grep -q 'skipping'; then
+    echo "ok   — missing gh skips loudly"
+    pass=$((pass + 1))
+else
+    echo "FAIL — missing gh should skip with rc=0 (got rc=$got)"
+    fail=$((fail + 1))
+fi
+
+# The gate and its own test carry bogus fields as fixtures — they must be
+# exempt by repo-relative path, or this suite could never be committed.
+mkdir -p "$TMP/scripts/hooks"
+printf '%s\n' 'gh pr view --json headRefSha' >"$TMP/scripts/hooks/check-gh-json-fields.sh"
+cp "$TMP/scripts/hooks/check-gh-json-fields.sh" "$TMP/scripts/hooks/test-check-gh-json-fields.sh"
+if (cd "$TMP" && bash "$GATE" scripts/hooks/check-gh-json-fields.sh scripts/hooks/test-check-gh-json-fields.sh >/dev/null 2>&1); then
+    echo "ok   — gate + its test are self-exempt"
+    pass=$((pass + 1))
+else
+    echo "FAIL — gate + its test should be self-exempt"
+    fail=$((fail + 1))
+fi
+
+# The per-subcommand field list is cached, so gh is probed ONCE per
+# distinct subcommand no matter how many lines reference it. Returning
+# the list through `$(fields_for …)` instead of a global would run the
+# function in a subshell and discard every cache write — the cache would
+# look present in the source and never hit.
+printf '%s\n' \
+    'gh pr view --json headRefOid' \
+    'gh pr view --json number' \
+    'gh pr view --json state' \
+    'gh repo view --json isPrivate' >"$TMP/case.md"
+: >"$TMP/gh.log"
+(cd "$TMP" && GH_CALL_LOG="$TMP/gh.log" bash "$GATE" case.md >/dev/null 2>&1)
+probes=$(sort -u "$TMP/gh.log" | wc -l | tr -d ' ')
+calls=$(wc -l <"$TMP/gh.log" | tr -d ' ')
+if [ "$calls" -eq "$probes" ] && [ "$calls" -eq 2 ]; then
+    echo "ok   — field lists are cached (one gh probe per subcommand)"
+    pass=$((pass + 1))
+else
+    echo "FAIL — expected 2 gh probes (pr view, repo view), got $calls"
+    fail=$((fail + 1))
+fi
+
+echo
+echo "check-gh-json-fields: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/jira/package-lock.json
+++ b/scripts/jira/package-lock.json
@@ -2002,9 +2002,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2147,9 +2147,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2167,7 +2167,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/scripts/lib/graphify-bin.sh
+++ b/scripts/lib/graphify-bin.sh
@@ -720,7 +720,57 @@ graphify_update() {
       return 0
     fi
   else
-    echo "  note: cannot probe for graphify-mcp holders on this platform — proceeding; the post-install verify below is the safety net."
+    # FAIL CLOSED when the probe cannot run (HIMMEL-1293). "Could not tell"
+    # is not "clear", and this arm gates a DESTRUCTIVE step: `uv tool install
+    # --force` removes the old entry points BEFORE replacing the tool dir, so
+    # if a holder is in fact live the host goes from "graphify works" to
+    # "graphify broken". The old wording called the post-install verify a
+    # "safety net", but _graphify_binary_ok only DETECTS that state — it does
+    # not repair it, and by then the entry points are already gone.
+    #
+    # The asymmetry decides it. Proceeding wrongly costs a broken install that
+    # needs every Claude Code session closed plus a manual reinstall; declining
+    # wrongly costs an unadvanced pin on an install that KEEPS WORKING, with
+    # both remedies printed right here. This is also the contract the rest of
+    # this file already keeps: _graphify_version_lt returns "not lower" on any
+    # parse failure ("never clobber on uncertainty"), and _graphify_mcp_holders
+    # documents itself as a guard that "must fail CLOSED". This caller was the
+    # one place that read its rc 1 as permission to proceed.
+    #
+    # Retrying the install on verify failure — the other candidate fix — does
+    # not address this case: the reason the install failed is a holder that is
+    # still live on the retry, so attempt two fails identically, after the
+    # entry points are already gone.
+    #
+    # GRAPHIFY_UNPROBED_OK=1 is the escape hatch for a host that legitimately
+    # cannot probe (no pwsh/powershell on Windows; neither pgrep nor ps on a
+    # slim POSIX image). Without it, fail-closed would mean such a host never
+    # updates again — the same silent permanent staleness the Windows
+    # self-match bug caused (HIMMEL-1274) — so the default is safe and the
+    # operator keeps an explicit, one-line way out.
+    if [ "${GRAPHIFY_UNPROBED_OK:-}" = "1" ]; then
+      echo "  note: cannot probe for graphify-mcp holders on this platform — proceeding anyway (GRAPHIFY_UNPROBED_OK=1). If a graphify-mcp is live this reinstall can leave graphify BROKEN; the post-install verify reports that but cannot repair it." >&2
+    else
+      {
+        echo "  SKIP: cannot probe for graphify-mcp holders on this platform — NOT attempting the reinstall."
+        echo "        graphify stays at v${installed:-?} and KEEPS WORKING; the pin has NOT advanced to $pin."
+        echo "        A probe that cannot run does not mean the machine is clear. If a graphify-mcp"
+        echo "        IS live, uv would delete the old entry points and then fail to replace the"
+        echo "        locked directory, leaving graphify broken (HIMMEL-1274/1293)."
+        echo "        To advance the pin, either close the Claude Code sessions holding graphify-mcp"
+        echo "        (each live session spawns one) and install by hand:"
+        echo "            uv tool install --force --with mcp '$spec'"
+        echo "        or, on a host that genuinely cannot probe, re-run with the override:"
+        echo "            GRAPHIFY_UNPROBED_OK=1 <this command>"
+      } >&2
+      # Same as the holders>0 skip: a working uv-managed install is left in
+      # place and we return 0, so the WSL store link must be shared here too.
+      graphify_wsl_share_store
+      # rc 0 for the same reason as that skip — nothing failed and nothing is
+      # broken. A nonzero would draw himmel-update's generic "failed
+      # (non-fatal)" warning on top of a deliberate, healthy decline.
+      return 0
+    fi
   fi
 
   echo "  graphify ${installed:-?} -> $pin (uv reinstall at pin, extras='${extras:-none}')..."

--- a/scripts/lib/test-graphify-bin.sh
+++ b/scripts/lib/test-graphify-bin.sh
@@ -645,7 +645,14 @@ gs_broken=$(grep -c 'BROKEN' <<<"$out" || true)   # counted, not negated in a su
 assert "install-failed-binary-survives: does NOT cry BROKEN" [ "$gs_broken" = 0 ]
 assert "install-failed-binary-survives: the install was actually attempted" grep -qE 'tool install --force --with mcp graphifyy' "$gs_log"
 
-echo "[test-graphify-bin] graphify_update: unprobeable platform -> proceeds, verify-after is the net"
+# --- HIMMEL-1293: an UNPROBEABLE host must fail CLOSED ----------------------
+# The probe returns rc 1 for "this platform offers no probe" — NOT for "the
+# machine is clear". Until HIMMEL-1293 the caller conflated the two and ran
+# `uv tool install --force` anyway, which is the destructive step: uv removes
+# the old entry points before replacing the tool dir, so an unprobeable host
+# with a live holder went from working graphify to broken graphify. The
+# post-install verify only reports that state; it cannot undo it.
+echo "[test-graphify-bin] graphify_update: unprobeable platform -> SKIP (fail closed), no install attempted"
 gp_home="$tmpdir/gup-probe"; mkdir -p "$gp_home"
 gp_tools="$tmpdir/gup-probe-tools"; mkdir -p "$gp_tools/graphifyy"
 printf 'requirements = [{ name = "graphifyy" }]\n' > "$gp_tools/graphifyy/uv-receipt.toml"
@@ -656,9 +663,59 @@ gp_log="$tmpdir/gup-probe-log"; : > "$gp_log"
 out=$(HOME="$gp_home" PATH="$gp_bin:$stub_dir/bin:$base_path" UV_TOOL_DIR="$gp_tools" UV_LIST_FILE="$gp_list" \
       UV_BIN_DIR="$gp_bin" UV_LOG="$gp_log" GRAPHIFY_MCP_HOLDERS=unavailable \
       bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_update; echo "RC=$?"' 2>&1)
-assert "unprobeable: rc 0" grep -q '^RC=0$' <<<"$out"
+# rc 0 for the same reason as the holders>0 skip: a deliberate, healthy decline
+# on a still-working install, not a failure worth himmel-update's generic warning.
+assert "unprobeable: rc 0 (a deliberate skip is not a failure)" grep -q '^RC=0$' <<<"$out"
 assert "unprobeable: says it cannot probe" grep -q 'cannot probe for graphify-mcp holders' <<<"$out"
-assert "unprobeable: still performs the install" grep -qE 'tool install --force --with mcp graphifyy' "$gp_log"
+assert "unprobeable: announces a SKIP" grep -q 'SKIP: cannot probe' <<<"$out"
+assert "unprobeable: states graphify KEEPS WORKING" grep -q 'KEEPS WORKING' <<<"$out"
+assert "unprobeable: says the pin did NOT advance" grep -q 'has NOT advanced' <<<"$out"
+# THE POINT: no uv install ran, so the entry points were never removed.
+# shellcheck disable=SC2016
+assert "unprobeable: NO uv install attempted (this is the whole fix)" \
+  bash -c '! grep -q "tool install" "$1"' _ "$gp_log"
+# Both remedies must be printed — fail-closed is only acceptable because the
+# operator is told exactly how to get unstuck. A silent decline would recreate
+# the permanent-staleness failure of the HIMMEL-1274 Windows self-match bug.
+assert "unprobeable: gives the manual install command" \
+  grep -qE "uv tool install --force --with mcp 'graphifyy==[0-9][^']*'" <<<"$out"
+assert "unprobeable: names the GRAPHIFY_UNPROBED_OK override" grep -q 'GRAPHIFY_UNPROBED_OK=1' <<<"$out"
+
+echo "[test-graphify-bin] graphify_update: unprobeable + GRAPHIFY_UNPROBED_OK=1 -> proceeds anyway"
+gpo_home="$tmpdir/gup-probe-ok"; mkdir -p "$gpo_home"
+gpo_tools="$tmpdir/gup-probe-ok-tools"; mkdir -p "$gpo_tools/graphifyy"
+printf 'requirements = [{ name = "graphifyy" }]\n' > "$gpo_tools/graphifyy/uv-receipt.toml"
+gpo_list="$tmpdir/gup-probe-ok-list"; printf 'graphifyy v0.0.1\n' > "$gpo_list"
+gpo_bin="$tmpdir/gup-probe-ok-bin"; mkdir -p "$gpo_bin"
+printf '#!/usr/bin/env bash\necho x\n' > "$gpo_bin/graphify"; chmod +x "$gpo_bin/graphify"
+gpo_log="$tmpdir/gup-probe-ok-log"; : > "$gpo_log"
+out=$(HOME="$gpo_home" PATH="$gpo_bin:$stub_dir/bin:$base_path" UV_TOOL_DIR="$gpo_tools" UV_LIST_FILE="$gpo_list" \
+      UV_BIN_DIR="$gpo_bin" UV_LOG="$gpo_log" GRAPHIFY_MCP_HOLDERS=unavailable GRAPHIFY_UNPROBED_OK=1 \
+      bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_update; echo "RC=$?"' 2>&1)
+assert "unprobeable+override: rc 0" grep -q '^RC=0$' <<<"$out"
+assert "unprobeable+override: performs the install" grep -qE 'tool install --force --with mcp graphifyy' "$gpo_log"
+# The override must not be silent — the operator opted into a real risk.
+assert "unprobeable+override: still warns the install can leave graphify BROKEN" \
+  grep -q 'can leave graphify BROKEN' <<<"$out"
+
+# A live holder still wins over the override: the override says "I cannot
+# probe", not "ignore a probe that came back positive". Anything else would let
+# one env var disable the guard outright.
+echo "[test-graphify-bin] graphify_update: holders>0 + GRAPHIFY_UNPROBED_OK=1 -> still SKIPs"
+gpv_home="$tmpdir/gup-probe-veto"; mkdir -p "$gpv_home"
+gpv_tools="$tmpdir/gup-probe-veto-tools"; mkdir -p "$gpv_tools/graphifyy"
+printf 'requirements = [{ name = "graphifyy" }]\n' > "$gpv_tools/graphifyy/uv-receipt.toml"
+gpv_list="$tmpdir/gup-probe-veto-list"; printf 'graphifyy v0.0.1\n' > "$gpv_list"
+gpv_bin="$tmpdir/gup-probe-veto-bin"; mkdir -p "$gpv_bin"
+printf '#!/usr/bin/env bash\necho x\n' > "$gpv_bin/graphify"; chmod +x "$gpv_bin/graphify"
+gpv_log="$tmpdir/gup-probe-veto-log"; : > "$gpv_log"
+out=$(HOME="$gpv_home" PATH="$gpv_bin:$stub_dir/bin:$base_path" UV_TOOL_DIR="$gpv_tools" UV_LIST_FILE="$gpv_list" \
+      UV_BIN_DIR="$gpv_bin" UV_LOG="$gpv_log" GRAPHIFY_MCP_HOLDERS=2 GRAPHIFY_UNPROBED_OK=1 \
+      bash -c '. "'"$SCRIPT_DIR"'/graphify-bin.sh"; graphify_update; echo "RC=$?"' 2>&1)
+assert "holders+override: still reports the holder SKIP" grep -q 'SKIP: 2 graphify-mcp process' <<<"$out"
+# shellcheck disable=SC2016
+assert "holders+override: NO uv install attempted" \
+  bash -c '! grep -q "tool install" "$1"' _ "$gpv_log"
 
 echo "[test-graphify-bin] graphify_update: uv graphifyy AHEAD of pin -> left as-is, no install (CR codex-1: never downgrade/clobber)"
 gua_home="$tmpdir/gup-ahead"; mkdir -p "$gua_home"


### PR DESCRIPTION
Two fail-open guards that never actually guarded, plus a gate that makes the first class of bug catchable, plus a dependency refresh.

Both bugs share a shape: **a probe that could not answer was read as an answer**, so the guard it fed silently stopped guarding.

## 1. `cr-public`'s bounded wait never ran

The bounded-wait loop polled `gh pr view --json headRefSha`. There is no such `gh` field — the real name is `headRefOid` — so `gh` exited 1 on the first iteration and the loop's fail-closed guard reported `cannot evaluate`. The wait never executed once, and the operator-merge fallback it gates was unreachable precisely when a public PR's App refused to re-review.

This was worked around by hand through every round of one long public PR chain before the cause was found, so it is measured, not theoretical.

## 2. New `check-gh-json-fields` pre-commit gate

A typo in a `--json` field list is invisible until the command runs live, and then it surfaces as a generic "cannot evaluate" that reads exactly like an auth or network blip. Nothing in the repo could have caught it.

The gate validates every **literal** `gh <sub> … --json a,b,c` in staged markdown/shell/ts/js against the field list `gh` itself advertises:

- **Offline** — `gh <sub> --json __bogus__` prints the valid field list with no API call, so the gate adds no network dependency.
- **Per-subcommand** — a field valid for `pr view` is rejected for `repo view`; the lists are never pooled.
- **Narrow on purpose** — non-literal lists (`--json "$FIELDS"`) and subcommands with no `--json` support are skipped rather than guessed at. This catches typos; it does not evaluate shell.
- **Lint, not a security gate** — a missing `gh` skips loudly (rc 0) instead of blocking every commit.

Ships with its own test suite.

## 3. graphify holder probe: rc 1 meant "could not tell", the caller read it as "clear"

`_graphify_mcp_holders` returns rc 1 for *this platform offers no probe*. `graphify_update` treated that identically to a zero holder count and ran `uv tool install --force` anyway.

That is the destructive step: `uv` removes the old distribution's entry points **before** replacing the tool dir, so on an unprobeable host with a live `graphify-mcp` the machine goes from *graphify works* to *graphify broken*. The post-install verify only **detects** that state — by the time it runs, the entry points are already gone.

It was also an internal inconsistency: `_graphify_version_lt` already returns *not lower* on any parse failure ("never clobber on uncertainty"), and `_graphify_mcp_holders` documents itself as a guard that "must fail CLOSED". This caller was the single place reading its rc 1 as permission to proceed.

The asymmetry settles it:

| | wrong decision | cost |
|---|---|---|
| fail open | proceeded with a live holder | broken install; close every session + manual reinstall |
| fail closed | declined on a clear machine | pin not advanced; graphify **keeps working**; both remedies printed |

`GRAPHIFY_UNPROBED_OK=1` is the escape hatch, printed alongside the manual `uv tool install` line in the decline message. It covers *"I cannot probe"*, **not** *"ignore a probe that came back positive"* — a `holders>0` result still declines with the override set, and there is a test for exactly that.

## 4. Dependencies

`postcss` 8.5.16 → 8.5.23 across the six workspaces that pin it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request review detection to correctly identify reviews for the current commit.
  * Prevented potentially unsafe Graphify reinstalls when system state cannot be verified.
  * Added an explicit override for operators who want to proceed despite unverifiable conditions.

* **New Features**
  * Added validation for GitHub CLI JSON field names during pre-commit checks.

* **Documentation**
  * Documented the new GitHub CLI validation and Graphify safety behavior.

* **Tests**
  * Added coverage for validation, caching, skip behavior, and protected reinstall scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->