### PR TITLE
feat: make review spend visible and review records correctable

### DIFF
--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -697,6 +697,52 @@ Steps:
    The ledger is deduped on `(head, finding_id)` for findings and `(head, model)`
    for avail records, so re-running `/pr-check` on the same HEAD is safe.
 
+   **Record the head the finding was RAISED AGAINST (HIMMEL-1294).** `--head`
+   is the SHA the critic reviewed, not the SHA that fixes it. Keying a finding
+   onto the fixing head makes gate 4 block a commit that already resolved it,
+   and the fix then requires an `amend` (below). On the `/cr-public` path,
+   where the public review lands against an earlier head than the private
+   commit carrying the fix, this is easy to get wrong — take the head from the
+   review, not from `git rev-parse HEAD`.
+
+   **A genuinely out-of-scope blocking finding is DEFERRED, never downgraded
+   (HIMMEL-1294).** When a `crit`/`imp` finding is real but out-of-diff,
+   pre-existing, or out-of-scope for this branch, do NOT record it as `sug` and
+   do NOT claim `disproved` — both are false, and the gate used to leave no
+   other mechanical exit. File a ticket and record the truth:
+   ```bash
+   bash scripts/cr/ledger-append.sh finding \
+       --branch "$branch" --head "$head" \
+       --model "<slug>" --id "<slug>-N" --severity imp \
+       --file <file> --line <line> \
+       --verdict deferred --deferred-to HIMMEL-<n> \
+       --reason "<why it is out of scope for this branch>"
+   ```
+   Gate 4 accepts a deferral ONLY with both the ticket key and the reason — a
+   bare `deferred` still blocks, so this is a truthful third exit, not a free
+   pass. The deferral is printed and audit-logged when the marker clears.
+
+   **Correcting a record: `amend`, never a re-append (HIMMEL-1294).** Findings
+   dedup on `(head, finding_id)`, so re-appending with different content writes
+   nothing. That used to exit 0 silently — the caller believed the severity was
+   fixed while the gate kept reading the original — and it wedged the
+   HIMMEL-1291 loop twice. It is now a loud non-zero pointing here:
+   ```bash
+   bash scripts/cr/ledger-append.sh amend \
+       --head <head-the-finding-is-CURRENTLY-recorded-at> --id "<slug>-N" \
+       --set severity=sug --reason "<why the original record was wrong>"
+   # or re-key a mis-keyed finding onto the head it was raised against:
+   #   --set head=<raised-against-sha>
+   # or defer it after the fact — `--set reason=` is required and is NOT the
+   # same field as `--reason` (which says why the RECORD was wrong; the gate
+   # reads the FINDING's reason):
+   #   --set verdict=deferred --set deferred_to=HIMMEL-<n> --set reason="<why out of scope>"
+   ```
+   `amend` APPENDS a supersede record — the ledger stays append-only and the
+   correction is itself auditable. It refuses non-zero when no matching finding
+   exists, so it can never report success without writing. Never hand-edit
+   `.git/cr-critic-scores.jsonl`.
+
 4.6. **Handover CR-findings capture (HIMMEL-416 F2 / C2) — runs alongside 4.5; best-effort, single-writer for the `## CR Findings` section, graceful skip when there is no active handover item.** Mirrors the panel findings into the current work-item's `reviewer-notes.md` so CR results survive the session (the F1 ledger is machine state; this is the human-readable trail surfaced on resume).
 
    Resolve the active item ONCE; skip the whole block (no error) if there is none:

--- a/scripts/cr/clear-cr-marker.sh
+++ b/scripts/cr/clear-cr-marker.sh
@@ -25,7 +25,11 @@
 #      NON-claude — a single-model Claude self-review floor is not sufficient in
 #      this setup. Default off (adopter-portable HIMMEL-1224 floor). Else refuse.
 #   4. The ledger records NO blocking finding at that SHA (severity crit|imp
-#      whose verdict is anything other than `disproved`).
+#      whose verdict is anything other than `disproved` or a TRACKED `deferred`).
+#      `amend` supersede records are applied before this is judged, so a
+#      correction (wrong severity, wrong head) actually takes effect; a
+#      `deferred` verdict clears ONLY with a ticket key AND a reason, so a bare
+#      "deferred" is still blocking (HIMMEL-1294).
 #   5. POST-PR ONLY: when a PR already exists for the branch, its head commit
 #      must BE the certified SHA, and check-ci.sh must also return 0 (CI green +
 #      all review threads resolved + no changes-requested). check-ci evaluates
@@ -242,10 +246,49 @@ verdict=$(LEDGER="$ledger" FULL_SHA="$tip" node -e '
   // or corrupted while an avail-ok line stays readable, the gate would clear
   // the marker without ever evaluating that finding. An unreadable ledger is
   // an unknown verdict, and unknown must never mean clean.
-  let responders = 0, nonClaudeResponders = 0, blocking = [], malformed = 0;
+  let responders = 0, nonClaudeResponders = 0, blocking = [], malformed = 0, deferred = [], applied = [];
+  // AMENDS (HIMMEL-1294). The ledger is append-only, so a correction arrives as
+  // a supersede record rather than an edited line. Collect them FIRST, keyed by
+  // each finding by its ORIGINAL (head, finding_id, artifact, perspective), and
+  // apply them before any finding is judged. NOTE: no apostrophes, backticks or
+  // dollar-braces anywhere in this node block — it is single-quoted for the
+  // shell, so an apostrophe ends the quote and every line after it becomes
+  // shell syntax. Without this pass the ledger could
+  // record a correction that the gate never sees - which is the same
+  // caller-thinks-it-worked failure the amend verb exists to end.
+  // Later amends win per key; a set.head then re-keys the finding, so atHead
+  // below evaluates it against the head it was actually raised at.
+  //
+  // SEP is U+001F (unit separator), built with String.fromCharCode so no raw
+  // control byte ever sits in this file. A PRINTABLE delimiter is the real
+  // hazard codex-2/glm-4 pointed at: it can occur inside a field, so two
+  // different tuples could flatten to one key and an amend could land on the
+  // wrong finding. U+001F cannot appear in a sha, slug, artifact or perspective.
+  const SEP = String.fromCharCode(31);
+  const amends = new Map();
+  for (const l of lines) {
+      let a;
+      try { a = JSON.parse(l); } catch { continue; }   // counted below in the main pass
+      if (a.kind !== "amend" || !a.set || typeof a.set !== "object") continue;
+      const k = [a.target_head, a.finding_id, a.artifact || "diff", a.perspective || "off"].join(SEP);
+      amends.set(k, Object.assign({}, amends.get(k) || {}, a.set));
+  }
   for (const l of lines) {
       let o;
       try { o = JSON.parse(l); } catch { malformed++; continue; }
+      if (o.kind === "amend") continue;   // metadata, not a verdict record
+      if (o.kind === "finding") {
+          const k = [o.head, o.finding_id, o.artifact || "diff", o.perspective || "off"].join(SEP);
+          if (amends.has(k)) {
+              // Report every amend the gate ACTS on. An amend can move a
+              // finding off this SHA or change its severity, i.e. it can be the
+              // reason the gate cleared - so applying one silently would make
+              // the decisive evidence the one thing the transcript does not
+              // show. Reported whether or not the finding ends up blocking.
+              applied.push((o.finding_id || "?") + JSON.stringify(amends.get(k)));
+              o = Object.assign({}, o, amends.get(k));
+          }
+      }
       if (!atHead(o)) continue;
       if (o.kind === "avail" && o.status === "ok") {
           responders++;
@@ -267,6 +310,20 @@ verdict=$(LEDGER="$ledger" FULL_SHA="$tip" node -e '
       }
       if (o.kind === "finding" && (o.severity === "crit" || o.severity === "imp")
           && o.verdict !== "disproved") {
+          // DEFERRAL (HIMMEL-1294). Before this, an honestly-recorded
+          // out-of-diff / pre-existing crit|imp had exactly two mechanical
+          // exits: downgrade it to sug, or claim disproved. Both are false, so
+          // the gate pushed an honest session toward mis-recording - and a
+          // single such record wedged a branch permanently.
+          // A deferral is accepted ONLY when it is TRACKED: verdict deferred
+          // AND a ticket key AND a stated reason. A bare "deferred" stays
+          // blocking, so this is a third truthful exit, not a free pass.
+          const ticket = typeof o.deferred_to === "string" ? o.deferred_to.trim() : "";
+          const why = typeof o.reason === "string" ? o.reason.trim() : "";
+          if (o.verdict === "deferred" && /^[A-Z][A-Z0-9]*-[0-9]+$/.test(ticket) && why) {
+              deferred.push((o.finding_id || "?") + "->" + ticket);
+              continue;
+          }
           // String concat, not a template literal: a dollar-brace inside this
           // single-quoted node block trips shellcheck SC2016, and the quotes
           // must stay single so the shell never expands the JS.
@@ -274,7 +331,7 @@ verdict=$(LEDGER="$ledger" FULL_SHA="$tip" node -e '
               (o.verdict || "no-verdict") + ")");
       }
   }
-  console.log(JSON.stringify({ responders, nonClaudeResponders, blocking, malformed }));
+  console.log(JSON.stringify({ responders, nonClaudeResponders, blocking, malformed, deferred, applied }));
 ' 2>/dev/null)
 if [ -z "$verdict" ]; then
     echo "clear-cr-marker: could not read the CR ledger at $ledger — refusing (cannot certify the review)." >&2
@@ -285,6 +342,16 @@ responders=$(printf '%s' "$verdict" | node -e 'let s="";process.stdin.on("data",
 non_claude_responders=$(printf '%s' "$verdict" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).nonClaudeResponders))' 2>/dev/null)
 blocking=$(printf '%s' "$verdict" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).blocking.join(" ")))' 2>/dev/null)
 malformed=$(printf '%s' "$verdict" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).malformed))' 2>/dev/null)
+deferred=$(printf '%s' "$verdict" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log((JSON.parse(s).deferred||[]).join(" ")))' 2>/dev/null)
+applied_amends=$(printf '%s' "$verdict" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log((JSON.parse(s).applied||[]).join(" ")))' 2>/dev/null)
+# Say what was amended BEFORE reporting the verdict it produced. An amend can be
+# the reason the gate cleared (it can re-key a blocking finding off this SHA, or
+# lower its severity), so it must never be the one piece of decisive evidence
+# the transcript omits.
+if [ -n "$applied_amends" ]; then
+    echo "clear-cr-marker: applied amend(s) at ${tip:0:8}: $applied_amends" >&2
+    audit "AMENDS branch=$branch sha=$tip applied=$applied_amends"
+fi
 
 # Malformed ledger lines => the verdict is UNKNOWN. Refuse (coderabbit).
 if [ "${malformed:-0}" -gt 0 ]; then
@@ -319,8 +386,19 @@ fi
 # 4. Blocking findings recorded at this SHA.
 if [ -n "$blocking" ]; then
     echo "clear-cr-marker: blocking finding(s) recorded at ${tip:0:8}: $blocking — address them, resolve the threads, re-run /pr-check." >&2
+    echo "  If a finding is genuinely out-of-diff / pre-existing / out-of-scope, DEFER it to a ticket instead of downgrading or disproving it (HIMMEL-1294):" >&2
+    # `--set reason=` is NOT redundant with `--reason` (glm-3): the gate reads
+    # the FINDING's reason, while --reason documents why the RECORD was wrong.
+    # Omitting it leaves the deferral rejected for a missing reason, i.e. this
+    # very hint would send the reader into a dead end.
+    echo "    scripts/cr/ledger-append.sh amend --head $tip --id <finding-id> --set verdict=deferred --set deferred_to=<TICKET> --set reason=\"<why it is out of scope here>\" --reason \"deferred after review\"" >&2
     audit "REFUSED reason=blocking-findings branch=$branch sha=$tip findings=$blocking"
     exit 15
+fi
+# Deferrals are not silent: they cleared the gate, so say so and name the tickets.
+if [ -n "$deferred" ]; then
+    echo "clear-cr-marker: deferred finding(s) at ${tip:0:8} (tracked, not blocking): $deferred" >&2
+    audit "DEFERRED branch=$branch sha=$tip findings=$deferred"
 fi
 
 # 5. Post-PR / pre-merge gate — when a PR already exists, the review threads and

--- a/scripts/cr/cr-scores.sh
+++ b/scripts/cr/cr-scores.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
 # scripts/cr/cr-scores.sh — per-critic agreed/availability scorecard (HIMMEL-415)
 # Usage: cr-scores.sh [--window N] [--artifact kind] [--perspective on|off]
+#        cr-scores.sh --by-branch [<branch>]
 # Reads CR_LEDGER (default: $(git rev-parse --git-common-dir)/cr-critic-scores.jsonl)
 # and prints a per-model table plus drop advice.
+#
+# --by-branch (HIMMEL-1299): per-PR review SPEND. Every other table here is
+# per-model and cumulative, so "what did this PR cost the scarce reviewer?" was
+# unanswerable — the fix-then-re-review loop has no budget, no termination
+# policy, and no way to see the budget is nearly gone. #523 ran twelve rounds
+# before anyone could say how many CodeRabbit calls that had been.
+#
+# It needs no new record kind. `avail` already carries branch + model and is
+# written once per (head, model); every round produces a new head, so the ROW
+# COUNT for a (branch, model) pair IS the number of calls that lane made on
+# that PR, and the distinct heads are the rounds. Measurement only: it sets no
+# budget and blocks nothing — you cannot budget what you cannot yet measure.
 set -uo pipefail
 
 # ── Named threshold constants (referenced by test-cr-scores.sh) ────────────
@@ -11,12 +24,20 @@ CR_SCORES_MIN_N="${CR_SCORES_MIN_N:-10}"
 WINDOW=20
 FILTER_ARTIFACT=""
 FILTER_PERSPECTIVE=""
+BY_BRANCH=0
+BRANCH_FILTER=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --window) [ $# -ge 2 ] || { echo "cr-scores.sh: --window requires an argument" >&2; exit 2; }; WINDOW="$2"; shift 2;;
     --artifact) [ $# -ge 2 ] || { echo "cr-scores.sh: --artifact requires an argument" >&2; exit 2; }; FILTER_ARTIFACT="$2"; shift 2;;
     --perspective) [ $# -ge 2 ] || { echo "cr-scores.sh: --perspective requires an argument" >&2; exit 2; }; FILTER_PERSPECTIVE="$2"; shift 2;;
+    --by-branch)
+      BY_BRANCH=1; shift
+      # Optional positional branch. Do NOT swallow a following flag.
+      if [ $# -gt 0 ]; then
+        case "$1" in -*) ;; *) BRANCH_FILTER="$1"; shift ;; esac
+      fi ;;
     *) echo "cr-scores.sh: unknown option $1" >&2; exit 2;;
   esac
 done
@@ -25,6 +46,75 @@ ledger="${CR_LEDGER:-$(git rev-parse --git-common-dir 2>/dev/null)/cr-critic-sco
 
 if [ ! -f "$ledger" ] || [ ! -s "$ledger" ]; then
   echo "no critic scores recorded yet (ledger: $ledger)"
+  exit 0
+fi
+
+if [ "$BY_BRANCH" = "1" ]; then
+  # shellcheck disable=SC2016  # the $-refs below are JS inside a single-quoted node script, not shell
+  LEDGER="$ledger" BRANCH_FILTER="$BRANCH_FILTER" node -e '
+const fs = require("fs");
+const ledger = process.env.LEDGER;
+const only   = process.env.BRANCH_FILTER || "";
+const records = [];
+for (const l of fs.readFileSync(ledger, "utf8").split("\n").filter(Boolean)) {
+  try { records.push(JSON.parse(l)); } catch (_) { /* skip malformed */ }
+}
+// calls[branch][model] = {ok, unavailable, est_total}; heads[branch] = Set
+const calls = {}, heads = {}, findings = {};
+for (const r of records) {
+  const b = r.branch;
+  if (!b) continue;                       // pre-branch records: not attributable
+  if (only && b !== only) continue;
+  if (r.head) { (heads[b] = heads[b] || new Set()).add(r.head); }
+  if (r.kind === "avail" && r.model) {
+    const m = ((calls[b] = calls[b] || {})[r.model] =
+               calls[b][r.model] || { ok:0, unavailable:0, est_total:0 });
+    if (r.status === "ok") m.ok++; else m.unavailable++;
+  } else if (r.kind === "usage" && r.model) {
+    const m = ((calls[b] = calls[b] || {})[r.model] =
+               calls[b][r.model] || { ok:0, unavailable:0, est_total:0 });
+    m.est_total += Number(r.est_total_tokens) || 0;
+  } else if (r.kind === "finding") {
+    findings[b] = (findings[b] || 0) + 1;
+  }
+}
+const branches = Object.keys(calls).sort();
+if (!branches.length) {
+  console.log(only ? ("no review spend recorded for branch " + only)
+                   : "no branch-attributed review spend recorded yet");
+  process.exit(0);
+}
+const W = [34, 16, 7, 7, 8, 11];
+const row = cells => cells.map((c,i)=>String(c).padEnd(W[i])).join("  ");
+console.log("=== Review spend per branch (HIMMEL-1299) ===");
+console.log("A call is one avail record = one (head, model) pair. Rounds are distinct heads.");
+console.log("");
+console.log(row(["branch","model","calls","failed","rounds","est_tokens"]));
+console.log(W.map(w=>"-".repeat(w)).join("  "));
+let worst = null;
+for (const b of branches) {
+  const rounds = heads[b] ? heads[b].size : 0;
+  const models = Object.keys(calls[b]).sort();
+  let first = true, branchCalls = 0;
+  for (const m of models) {
+    const c = calls[b][m];
+    branchCalls += c.ok + c.unavailable;
+    console.log(row([first ? b : "", m, c.ok + c.unavailable, c.unavailable,
+                     first ? rounds : "", c.est_total || ""]));
+    first = false;
+  }
+  // Per-branch summary as prose, not a table row: findings and rounds are
+  // branch-level facts and would sit under the wrong column headers.
+  console.log("    -> " + rounds + " round(s), " + branchCalls + " critic call(s), "
+              + (findings[b] || 0) + " finding(s) recorded");
+  if (!worst || branchCalls > worst.calls) worst = { b, calls: branchCalls, rounds };
+}
+if (!only && worst) {
+  console.log("");
+  console.log("Most expensive branch: " + worst.b + " — " + worst.calls
+              + " critic call(s) across " + worst.rounds + " round(s).");
+}
+'
   exit 0
 fi
 

--- a/scripts/cr/ledger-append.sh
+++ b/scripts/cr/ledger-append.sh
@@ -10,12 +10,33 @@
 # WHY a critic was down. Additive + back-compat: omitted -> the fields are
 # ABSENT from the JSON (never emitted as empty strings), so every pre-existing
 # caller and the dedup key (unchanged) are byte-for-byte unaffected.
+# --deferred-to (HIMMEL-1294): an honestly-recorded crit/imp finding that is
+# out-of-diff / pre-existing / out-of-scope used to have only two mechanical
+# exits at clear-cr-marker gate 4 — downgrade it to `sug`, or claim `disproved`.
+# Both are lies, so the gate actively pushed an honest session toward
+# mis-recording. `--verdict deferred --deferred-to <TICKET> --reason <text>`
+# is the third, truthful exit: the finding stands, it is tracked, and the
+# branch proceeds. The gate REQUIRES both the ticket key and the reason, so a
+# bare "deferred" cannot become a free pass.
+#
+# `amend` (HIMMEL-1294): the ledger is append-only and had no way to correct a
+# record. A finding logged at the wrong severity or keyed to the wrong head
+# permanently wedged a branch — clear-cr-marker refuses, the CR-marker hook
+# hard-blocks `gh pr create`, and the session cannot fix it (a ledger-rewrite
+# script is classifier-denied as gate tampering; Edit is refused because the
+# ledger lives under the PRIMARY checkout's .git/). It cost the HIMMEL-1291
+# loop two full rounds and an operator-authorised hand-edit of the JSONL.
+# `amend` appends a SUPERSEDE record rather than rewriting a line, so the
+# ledger stays append-only and the correction is itself auditable.
 set -uo pipefail
 kind="${1:-}"; shift || true
-[ "$kind" = "finding" ] || [ "$kind" = "avail" ] || [ "$kind" = "usage" ] || { echo "ledger-append.sh: kind must be finding|avail|usage" >&2; exit 2; }
+case "$kind" in
+  finding|avail|usage|amend) ;;
+  *) echo "ledger-append.sh: kind must be finding|avail|usage|amend" >&2; exit 2;;
+esac
 
 branch="" head="" model="" responding_model="" id="" severity="" file="" line="" verdict="" status="" artifact="diff" perspective="off"
-prompt_chars="" response_chars="" reason="" detail=""
+prompt_chars="" response_chars="" reason="" detail="" deferred_to="" set_pairs=""
 while [ $# -gt 0 ]; do case "$1" in
   --branch) branch="$2"; shift 2;; --head) head="$2"; shift 2;;
   --model) model="$2"; shift 2;; --responding-model) responding_model="$2"; shift 2;;
@@ -26,11 +47,95 @@ while [ $# -gt 0 ]; do case "$1" in
   --artifact) artifact="$2"; shift 2;; --perspective) perspective="$2"; shift 2;;
   --prompt-chars) prompt_chars="$2"; shift 2;; --response-chars) response_chars="$2"; shift 2;;
   --reason) reason="$2"; shift 2;; --detail) detail="$2"; shift 2;;
+  --deferred-to) deferred_to="$2"; shift 2;;
+  --set) set_pairs="$set_pairs$2"$'\n'; shift 2;;
   *) echo "ledger-append.sh: unknown $1" >&2; exit 2;;
 esac; done
 
 case "$artifact" in diff|spec|plan) ;; *) echo "ledger-append.sh: --artifact must be diff|spec|plan" >&2; exit 2;; esac
 case "$perspective" in on|off) ;; *) echo "ledger-append.sh: --perspective must be on|off" >&2; exit 2;; esac
+
+# A deferral is only honest if it is TRACKED. Validate the ticket key here so a
+# typo cannot silently produce a deferral the gate then rejects for reasons the
+# caller has to reverse-engineer.
+#
+# grep -E, NOT a case glob (codex-1). A shell glob is not a regex: in
+# `[A-Z][A-Z0-9]*-[0-9]*` the trailing `*` means ANY characters, not "more
+# digits", so `HI-1x` matches here and is then rejected by the gate's real
+# anchored regex — the exact split-validation this check exists to prevent.
+# One definition, shared with clear-cr-marker gate 4.
+valid_ticket() { printf '%s' "$1" | grep -qE '^[A-Z][A-Z0-9]*-[0-9]+$'; }
+if [ -n "$deferred_to" ] && ! valid_ticket "$deferred_to"; then
+  echo "ledger-append.sh: --deferred-to must be a ticket key like HIMMEL-1294 (got '$deferred_to')" >&2
+  exit 2
+fi
+
+if [ "$kind" = "amend" ]; then
+  amend_usage="usage: ledger-append.sh amend --head <sha> --id <finding-id> --set <key>=<value> [--set ...] --reason <text> [--artifact <a>] [--perspective <p>]"
+  [ -n "$head" ] || { echo "ledger-append.sh: amend requires --head (the head the finding is CURRENTLY recorded at). $amend_usage" >&2; exit 2; }
+  [ -n "$id" ]   || { echo "ledger-append.sh: amend requires --id. $amend_usage" >&2; exit 2; }
+  [ -n "$set_pairs" ] || { echo "ledger-append.sh: amend requires at least one --set <key>=<value>. $amend_usage" >&2; exit 2; }
+  # A correction without a stated reason is indistinguishable from tampering.
+  [ -n "$reason" ] || { echo "ledger-append.sh: amend requires --reason (why the original record was wrong). $amend_usage" >&2; exit 2; }
+  while IFS= read -r _pair; do
+    [ -n "$_pair" ] || continue
+    case "$_pair" in
+      # `reason` is amendable (glm-3). Gate 4 accepts a deferral only when the
+      # FINDING carries a reason, and an amend's own --reason documents why the
+      # RECORD was wrong — a different field. Without this key, the deferral
+      # path clear-cr-marker itself recommends is a dead end for any finding
+      # originally recorded without a reason, which is most of them.
+      severity=*|head=*|verdict=*|deferred_to=*|reason=*|file=*|line=*) ;;
+      *=*) echo "ledger-append.sh: amend cannot set '${_pair%%=*}' (allowed: severity, head, verdict, deferred_to, reason, file, line)" >&2; exit 2;;
+      *)   echo "ledger-append.sh: --set expects <key>=<value> (got '$_pair')" >&2; exit 2;;
+    esac
+    # Same eager validation as --deferred-to (glm-5): otherwise a typo'd ticket
+    # is only caught at gate time, on the path this verb exists to unblock.
+    #
+    # severity/verdict are validated too (codex-1). Gate 4 blocks on
+    # `severity in (crit, imp)`, so a typo like `severity=suq` matches NEITHER
+    # and silently makes a blocking finding non-blocking — a fail-OPEN on the
+    # one verb that can change a gate verdict. (Verdict typos already fail
+    # closed: anything unrecognised is neither `disproved` nor a valid
+    # `deferred`, so it keeps blocking. Validated anyway, so a typo is a clear
+    # error instead of a silently-ignored amend.)
+    #
+    # Scope: the AMEND surface only. The `finding` verb has always accepted
+    # free-form severity strings and existing callers/tests rely on that;
+    # tightening it is a separate, wider change.
+    case "$_pair" in
+      deferred_to=*)
+        if ! valid_ticket "${_pair#deferred_to=}"; then
+          echo "ledger-append.sh: --set deferred_to= must be a ticket key like HIMMEL-1294 (got '${_pair#deferred_to=}')" >&2
+          exit 2
+        fi ;;
+      severity=*)
+        case "${_pair#severity=}" in
+          crit|imp|sug) ;;
+          *) echo "ledger-append.sh: --set severity= must be crit|imp|sug (got '${_pair#severity=}') — an unrecognised severity is not blocking, so a typo here would silently clear the gate" >&2; exit 2;;
+        esac ;;
+      verdict=*)
+        case "${_pair#verdict=}" in
+          agreed|disproved|conflict|unaddressed|deferred) ;;
+          *) echo "ledger-append.sh: --set verdict= must be agreed|disproved|conflict|unaddressed|deferred (got '${_pair#verdict=}')" >&2; exit 2;;
+        esac ;;
+      head=*)
+        # Re-keying is the point of this key (a finding mis-keyed onto the head
+        # that FIXES it must be movable to the head it was RAISED against), so
+        # the value cannot be constrained to one sha. What it CAN be constrained
+        # to is the shape gate 4 will actually accept: clear-cr-marker's isHex
+        # takes 7-40 hex chars and silently ignores anything else. Validating a
+        # narrower shape here than the gate consumes is the split-validation
+        # trap codex-1 already caught once on --deferred-to — so the two agree
+        # exactly. Without this, `--set head=HEAD~1` re-keys a blocking finding
+        # into nowhere and gate 4 fails OPEN.
+        if ! printf '%s' "${_pair#head=}" | grep -qE '^[0-9a-fA-F]{7,40}$'; then
+          echo "ledger-append.sh: --set head= must be a 7-40 char hex sha (got '${_pair#head=}') — anything else is not recognised as a head by the gate, so the finding would silently vanish from it" >&2
+          exit 2
+        fi ;;
+    esac
+  done <<< "$set_pairs"
+fi
 
 # --detail scrub (HIMMEL-1176): provider error bodies (rate-limit/auth/etc.
 # messages) can echo request fragments or credentials. Lightweight, anchored
@@ -59,17 +164,93 @@ ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 KIND="$kind" BRANCH="$branch" HEAD_="$head" MODEL="$model" RESPONDING_MODEL="$responding_model" ID="$id" SEV="$severity" \
 FILE="$file" LINE="$line" VERDICT="$verdict" STATUS="$status" \
 PROMPT_CHARS="$prompt_chars" RESPONSE_CHARS="$response_chars" TS="$ts" LEDGER="$ledger" ARTIFACT="$artifact" PERSPECTIVE="$perspective" \
-REASON="$reason" DETAIL="$detail" node -e '
+REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" SET_PAIRS="$set_pairs" node -e '
   const fs=require("fs"), e=process.env;
   const led=e.LEDGER;
   const existing=fs.existsSync(led)?fs.readFileSync(led,"utf8").split("\n").filter(Boolean):[];
+  const key=(o)=>o.kind==="finding"&&o.head===e.HEAD_&&o.finding_id===e.ID
+      &&(o.artifact||"diff")===e.ARTIFACT&&(o.perspective||"off")===e.PERSPECTIVE;
+
+  // AMEND: append a supersede record pointing at an EXISTING finding. It never
+  // rewrites a line - the ledger stays append-only, and the correction is
+  // itself auditable. Refuses loudly when there is nothing to amend: a silent
+  // success here would recreate the exact failure this verb exists to fix
+  // (caller sees 0, record unchanged, gate still refuses).
+  if(e.KIND==="amend"){
+    const parsed=existing.map(l=>{try{return JSON.parse(l);}catch{return null;}}).filter(Boolean);
+    // Resolve through PRIOR amends (codex-1 round 4). A re-key leaves the
+    // original finding row untouched (append-only), so after moving a finding
+    // A -> B the row still reads A while the ledger EFFECTIVELY places it at B.
+    // Matching only the raw row would then reject an amend aimed at B - the
+    // head the operator can actually see - on the one path they reach when they
+    // are already stuck. Match either the original row or its effective state;
+    // the emitted record still keys on the ORIGINAL head, so the reader in
+    // clear-cr-marker needs no matching logic of its own.
+    const SEP=String.fromCharCode(31);
+    const prior=new Map();
+    for(const a of parsed){
+      if(a.kind!=="amend"||!a.set||typeof a.set!=="object") continue;
+      const k=[a.target_head,a.finding_id,a.artifact||"diff",a.perspective||"off"].join(SEP);
+      prior.set(k,Object.assign({},prior.get(k)||{},a.set));
+    }
+    const effective=(o)=>{
+      const k=[o.head,o.finding_id,o.artifact||"diff",o.perspective||"off"].join(SEP);
+      return prior.has(k)?Object.assign({},o,prior.get(k)):o;
+    };
+    const findings=parsed.filter(o=>o.kind==="finding");
+    const target=findings.filter(o=>key(o)||key(effective(o))).pop();
+    if(!target){
+      process.stderr.write("ledger-append.sh: amend found NO finding "+e.ID+" at head "+e.HEAD_
+        +" (artifact="+e.ARTIFACT+" perspective="+e.PERSPECTIVE+") - nothing amended.\n"
+        +"  Amend targets the head the finding sits at - either the one it was originally\n"
+        +"  recorded at, or the one a previous amend moved it to - never the one you want\n"
+        +"  it moved to next.\n");
+      process.exit(3);
+    }
+    const set={};
+    for(const p of (e.SET_PAIRS||"").split("\n").filter(Boolean)){
+      const i=p.indexOf("=");
+      let v=p.slice(i+1);
+      const k=p.slice(0,i);
+      if(k==="line") v=Number(v)||v;
+      set[k]=v;
+    }
+    const rec={kind:"amend",ts:e.TS,branch:e.BRANCH,target_head:target.head,finding_id:e.ID,
+               artifact:e.ARTIFACT,perspective:e.PERSPECTIVE,set,reason:e.REASON};
+    fs.appendFileSync(led, JSON.stringify(rec)+"\n");
+    process.stderr.write("ledger-append.sh: amended "+e.ID+" at "+e.HEAD_.slice(0,8)+" -> "
+      +JSON.stringify(set)+"\n");
+    process.exit(0);
+  }
+
   let rec, dup;
   if(e.KIND==="finding"){
     rec={kind:"finding",ts:e.TS,branch:e.BRANCH,head:e.HEAD_,model:e.MODEL,finding_id:e.ID,severity:e.SEV,file:e.FILE,line:Number(e.LINE)||e.LINE,verdict:e.VERDICT,artifact:e.ARTIFACT,perspective:e.PERSPECTIVE};
     if(e.RESPONDING_MODEL) rec.responding_model=e.RESPONDING_MODEL;
     if(e.REASON) rec.reason=e.REASON;
     if(e.DETAIL) rec.detail=e.DETAIL;
-    dup=existing.some(l=>{try{const o=JSON.parse(l);return o.kind==="finding"&&o.head===e.HEAD_&&o.finding_id===e.ID&&(o.artifact||"diff")===e.ARTIFACT&&(o.perspective||"off")===e.PERSPECTIVE;}catch{return false;}});
+    if(e.DEFERRED_TO) rec.deferred_to=e.DEFERRED_TO;
+    // A re-append that CHANGES the record is the wedge this ticket is about:
+    // the old code hit the dedup key, wrote nothing, and exited 0, so the
+    // caller believed the severity had been corrected while the gate kept
+    // reading the original. Identical content is still a quiet success (re-
+    // running /pr-check on the same head must stay idempotent); DIFFERING
+    // content is now a loud refusal that names the sanctioned fix.
+    const prior=existing.map(l=>{try{return JSON.parse(l);}catch{return null;}})
+                        .filter(Boolean).filter(key).pop();
+    if(prior){
+      const norm=(o)=>{const c={...o}; delete c.ts; return JSON.stringify(Object.keys(c).sort().map(k=>[k,c[k]]));};
+      if(norm(prior)!==norm(rec)){
+        process.stderr.write("ledger-append.sh: finding "+e.ID+" is ALREADY recorded at head "+e.HEAD_
+          +" with different content - NOTHING was written (the ledger dedups on head+finding_id).\n"
+          +"  Correct it with the amend verb, which appends an auditable supersede record:\n"
+          +"    ledger-append.sh amend --head "+e.HEAD_+" --id "+e.ID
+          +" --set <key>=<value> --reason \"<why>\"\n");
+        process.exit(3);
+      }
+      process.exit(0);
+    }
+    dup=false;
   } else if(e.KIND==="usage"){
     // chars/4 token estimate (hermes does not expose real usage via the one-shot
     // chokepoint — HIMMEL-485). The /4 lives here so it is computed in ONE place.
@@ -87,6 +268,16 @@ REASON="$reason" DETAIL="$detail" node -e '
     if(e.DETAIL) rec.detail=e.DETAIL;
     dup=existing.some(l=>{try{const o=JSON.parse(l);return o.kind==="avail"&&o.head===e.HEAD_&&o.model===e.MODEL&&(o.artifact||"diff")===e.ARTIFACT&&(o.perspective||"off")===e.PERSPECTIVE;}catch{return false;}});
   }
-  if(dup) process.exit(0);
+  // avail/usage keep the quiet-dedup contract: /pr-check re-runs them on the
+  // same head as a matter of course, and turning that into an error would
+  // break every existing caller. They are still not SILENT - the note says
+  // plainly that nothing was written, which is what the incident actually
+  // turned on. Only the finding kind (the record gate 4 blocks on) refuses a
+  // conflicting rewrite, above.
+  if(dup){
+    process.stderr.write("ledger-append.sh: "+e.KIND+" record for "+e.MODEL+" at head "
+      +String(e.HEAD_).slice(0,8)+" already exists - nothing written (dedup on head+model).\n");
+    process.exit(0);
+  }
   fs.appendFileSync(led, JSON.stringify(rec)+"\n");
 '

--- a/scripts/cr/test-clear-cr-marker.sh
+++ b/scripts/cr/test-clear-cr-marker.sh
@@ -571,6 +571,115 @@ stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
 run_clear "$tmp" 0 "disproved crit is not blocking → exit 0"
 rm -rf "$tmp"
 
+# 6a-1. HIMMEL-1294 — an `amend` supersede record is APPLIED before gate 4
+# judges. Incident 1: a blocking imp recorded honestly wedged the branch, and
+# re-appending at a lower severity silently no-op'd, so the only escapes were a
+# hand-edit of the JSONL or an operator. The amend must actually take effect
+# here, or the verb is theatre.
+make_repo
+write_marker "$tmp" "$sha"
+write_ledger "$tmp" "$(avail_ok "${sha:0:8}")" "$(finding "${sha:0:8}" imp agreed)" \
+  "$(printf '{"kind":"amend","target_head":"%s","finding_id":"codex-1","artifact":"diff","perspective":"off","set":{"severity":"sug"},"reason":"out of diff"}' "${sha:0:8}")"
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 0 "amend severity imp->sug unblocks gate 4 → exit 0"
+rm -rf "$tmp"
+
+# 6a-2. Incident 2: the finding was keyed to the head that FIXES it instead of
+# the head it was raised against. An amend that re-keys `head` must move the
+# finding OFF this head entirely.
+make_repo
+write_marker "$tmp" "$sha"
+write_ledger "$tmp" "$(avail_ok "${sha:0:8}")" "$(finding "${sha:0:8}" imp agreed)" \
+  "$(printf '{"kind":"amend","target_head":"%s","finding_id":"codex-1","artifact":"diff","perspective":"off","set":{"head":"deadbeef"},"reason":"raised against deadbeef, mis-keyed"}' "${sha:0:8}")"
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 0 "amend re-keying head moves the finding off this SHA → exit 0"
+rm -rf "$tmp"
+
+# 6a-3. An amend must not be a universal unblock: one that leaves the finding
+# blocking still blocks.
+make_repo
+write_marker "$tmp" "$sha"
+write_ledger "$tmp" "$(avail_ok "${sha:0:8}")" "$(finding "${sha:0:8}" imp agreed)" \
+  "$(printf '{"kind":"amend","target_head":"%s","finding_id":"codex-1","artifact":"diff","perspective":"off","set":{"file":"b.sh"},"reason":"wrong file"}' "${sha:0:8}")"
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 15 "an amend that does not clear the finding still blocks → exit 15"
+rm -rf "$tmp"
+
+# 6a-4. An amend record is metadata, not review evidence — it must never count
+# toward the gate-3 responder floor.
+make_repo
+write_marker "$tmp" "$sha"
+write_ledger "$tmp" "$(printf '{"kind":"amend","target_head":"%s","finding_id":"codex-1","artifact":"diff","perspective":"off","set":{"severity":"sug"},"reason":"x"}' "${sha:0:8}")"
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 14 "an amend alone is not a responder → exit 14"
+rm -rf "$tmp"
+
+# 6c. HIMMEL-1294 — a TRACKED deferral clears gate 4. Before this the only
+# mechanical exits for an honest out-of-diff crit|imp were a downgrade to sug or
+# a false `disproved`, so the gate pushed an honest session toward mis-recording.
+deferred_finding() { printf '{"kind":"finding","head":"%s","model":"codex","finding_id":"codex-1","severity":"imp","file":"a.sh","line":1,"verdict":"deferred","deferred_to":"%s","reason":"%s"}' "$1" "$2" "$3"; }
+make_repo
+write_marker "$tmp" "$sha"
+write_ledger "$tmp" "$(avail_ok "${sha:0:8}")" "$(deferred_finding "${sha:0:8}" HIMMEL-1293 "pre-existing, already public")"
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 0 "tracked deferral (ticket + reason) is not blocking → exit 0"
+rm -rf "$tmp"
+
+# 6d. …but a deferral is only honest if it is TRACKED. A bare `deferred`, or one
+# missing either half of the evidence, must STILL block — otherwise the verdict
+# is just a cheaper lie than `disproved`.
+make_repo
+write_marker "$tmp" "$sha"
+write_ledger "$tmp" "$(avail_ok "${sha:0:8}")" "$(finding "${sha:0:8}" imp deferred)"
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 15 "bare deferred with no ticket still blocks → exit 15"
+rm -rf "$tmp"
+
+make_repo
+write_marker "$tmp" "$sha"
+write_ledger "$tmp" "$(avail_ok "${sha:0:8}")" "$(deferred_finding "${sha:0:8}" HIMMEL-1293 "")"
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 15 "deferral with a ticket but no reason still blocks → exit 15"
+rm -rf "$tmp"
+
+make_repo
+write_marker "$tmp" "$sha"
+write_ledger "$tmp" "$(deferred_finding "${sha:0:8}" "not-a-ticket" "why")" "$(avail_ok "${sha:0:8}")"
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 15 "deferral with a malformed ticket key still blocks → exit 15"
+rm -rf "$tmp"
+
+# 6e. glm-3 — deferring an ALREADY-RECORDED finding through amend must actually
+# clear gate 4. The gate reads the FINDING-level reason, so an amend that sets
+# only verdict+ticket leaves it blocking; this is the end-to-end shape the
+# gate's own error message prints, so if it does not work the hint is a trap.
+make_repo
+write_marker "$tmp" "$sha"
+write_ledger "$tmp" "$(avail_ok "${sha:0:8}")" "$(finding "${sha:0:8}" imp agreed)" \
+  "$(printf '{"kind":"amend","target_head":"%s","finding_id":"codex-1","artifact":"diff","perspective":"off","set":{"verdict":"deferred","deferred_to":"HIMMEL-1293","reason":"pre-existing, already public"},"reason":"deferred after review"}' "${sha:0:8}")"
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 0 "amend to a TRACKED deferral clears gate 4 → exit 0"
+rm -rf "$tmp"
+
+# …and the half-done version must NOT clear: verdict+ticket with no
+# finding-level reason is exactly the dead end glm-3 found.
+make_repo
+write_marker "$tmp" "$sha"
+write_ledger "$tmp" "$(avail_ok "${sha:0:8}")" "$(finding "${sha:0:8}" imp agreed)" \
+  "$(printf '{"kind":"amend","target_head":"%s","finding_id":"codex-1","artifact":"diff","perspective":"off","set":{"verdict":"deferred","deferred_to":"HIMMEL-1293"},"reason":"deferred after review"}' "${sha:0:8}")"
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 15 "amend deferral without a finding-level reason still blocks → exit 15"
+rm -rf "$tmp"
+
+# 6f. codex-1 — the ticket-key check must be an anchored regex, not a glob.
+# `HI-1x` passes a `[A-Z][A-Z0-9]*-[0-9]*` glob and must still block here.
+make_repo
+write_marker "$tmp" "$sha"
+write_ledger "$tmp" "$(avail_ok "${sha:0:8}")" "$(deferred_finding "${sha:0:8}" "HI-1x" "why")"
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 15 "ticket key with a trailing non-digit still blocks → exit 15"
+rm -rf "$tmp"
+
 # 6b. A Suggestion never blocks.
 make_repo
 write_marker "$tmp" "$sha"

--- a/scripts/cr/test-cr-scores.sh
+++ b/scripts/cr/test-cr-scores.sh
@@ -207,5 +207,52 @@ echo '{"kind":"avail","ts":"2026-03-01T00:00:00Z","branch":"b","head":"EH1","mod
 empty_reason_out="$(CR_LEDGER="$L7" bash "$CS" 2>&1)"
 not_contains "empty-string reason does not trigger breakdown section" "$empty_reason_out" "Unavailability breakdown"
 
+# ── HIMMEL-1299: --by-branch review spend ──────────────────────────────────
+# The claim under test: a call is one `avail` record = one (head, model) pair,
+# and rounds are the distinct heads. A branch reviewed over 3 rounds by 2 lanes
+# therefore cost 6 calls — the number that was unanswerable before, and the
+# reason a fix-then-re-review loop could run twelve rounds unnoticed.
+LB="$tmp/by-branch.jsonl"
+{
+  for h in BH1 BH2 BH3; do
+    echo '{"kind":"avail","ts":"2026-04-01T00:00:00Z","branch":"feat/costly","head":"'"$h"'","model":"coderabbit","status":"ok"}'
+    echo '{"kind":"avail","ts":"2026-04-01T00:00:00Z","branch":"feat/costly","head":"'"$h"'","model":"codex","status":"ok"}'
+  done
+  echo '{"kind":"avail","ts":"2026-04-01T00:00:00Z","branch":"feat/cheap","head":"CH1","model":"codex","status":"unavailable","reason":"timeout"}'
+  echo '{"kind":"finding","ts":"2026-04-01T00:00:00Z","branch":"feat/costly","head":"BH1","model":"codex","finding_id":"codex-1","severity":"imp","file":"f","line":1,"verdict":"agreed"}'
+  echo '{"kind":"usage","ts":"2026-04-01T00:00:00Z","branch":"feat/costly","head":"BH1","model":"codex","est_total_tokens":4242}'
+} > "$LB"
+bb_out="$(CR_LEDGER="$LB" bash "$CS" --by-branch 2>&1)"
+contains "by-branch reports the costly branch" "$bb_out" "feat/costly"
+contains "by-branch counts one call per (head, model)" "$bb_out" "3 round(s), 6 critic call(s), 1 finding(s) recorded"
+contains "by-branch counts a FAILED call as spend too" "$bb_out" "1 round(s), 1 critic call(s), 0 finding(s) recorded"
+contains "by-branch carries the token estimate" "$bb_out" "4242"
+contains "by-branch names the most expensive branch" "$bb_out" "Most expensive branch: feat/costly"
+
+# A branch filter scopes the report and drops the cross-branch superlative.
+bb_one="$(CR_LEDGER="$LB" bash "$CS" --by-branch feat/cheap 2>&1)"
+contains "branch filter keeps the requested branch" "$bb_one" "feat/cheap"
+not_contains "branch filter excludes other branches" "$bb_one" "feat/costly"
+not_contains "branch filter drops the cross-branch superlative" "$bb_one" "Most expensive branch"
+
+# An unknown branch is an explicit no-data message, not an empty table.
+bb_none="$(CR_LEDGER="$LB" bash "$CS" --by-branch feat/does-not-exist 2>&1)"
+contains "unknown branch says so" "$bb_none" "no review spend recorded for branch feat/does-not-exist"
+
+# --by-branch must not swallow a following FLAG as its optional branch arg.
+bb_flag="$(CR_LEDGER="$LB" bash "$CS" --by-branch --window 5 2>&1)"
+contains "--by-branch does not eat a following flag" "$bb_flag" "feat/costly"
+
+# Records predating the branch field are not attributable and must be skipped,
+# not bucketed under a phantom branch.
+LBN="$tmp/by-branch-nobranch.jsonl"
+echo '{"kind":"avail","ts":"2026-04-01T00:00:00Z","head":"NH1","model":"codex","status":"ok"}' > "$LBN"
+bb_nb="$(CR_LEDGER="$LBN" bash "$CS" --by-branch 2>&1)"
+contains "branch-less records are not attributed" "$bb_nb" "no branch-attributed review spend recorded yet"
+
+# The default report must not gain the new section.
+base_out="$(CR_LEDGER="$L" bash "$CS" 2>&1)"
+not_contains "default output does not gain the spend table" "$base_out" "Review spend per branch"
+
 # ── Final ──────────────────────────────────────────────────────────────────
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/cr/test-ledger-append.sh
+++ b/scripts/cr/test-ledger-append.sh
@@ -135,4 +135,105 @@ _tg_id="123456789"; _tg_sec="AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsawX"
 CR_LEDGER="$LR" bash "$LA" avail --branch b --head RH9 --model m --status unavailable --reason http-4xx --detail "telegram token ${_tg_id}:${_tg_sec} leaked"
 check "detail scrubs a telegram-bot-token shape" "$(contains_json_detail RH9 "${_tg_id}:${_tg_sec}")" "false"
 
+# ── HIMMEL-1294: conflicting re-append + the amend verb ─────────────────────
+# The wedge this ticket is about: re-appending a finding with a LOWER severity
+# hit the dedup key, wrote nothing, and exited 0. The caller believed the
+# record was corrected; the gate kept reading the original and kept refusing.
+AM="$tmp/amend.jsonl"; : > "$AM"
+CR_LEDGER="$AM" bash "$LA" finding --branch b --head AH1 --model codex-adv --id codex-adv-1 --severity imp --file f --line 3 --verdict agreed
+
+CR_LEDGER="$AM" bash "$LA" finding --branch b --head AH1 --model codex-adv --id codex-adv-1 --severity sug --file f --line 3 --verdict agreed 2>"$tmp/conflict.err"
+check "conflicting re-append exits non-zero (was a silent 0)" "$?" "3"
+check "conflicting re-append wrote NOTHING" "$(wc -l < "$AM" | tr -d ' ')" "1"
+check "conflicting re-append names the amend verb" "$(grep -c 'amend --head' "$tmp/conflict.err")" "1"
+check "conflicting re-append says nothing was written" "$(grep -c 'NOTHING was written' "$tmp/conflict.err")" "1"
+
+# An IDENTICAL re-append must stay a quiet success — /pr-check re-runs on the
+# same head as a matter of course, and idempotency is a real feature.
+CR_LEDGER="$AM" bash "$LA" finding --branch b --head AH1 --model codex-adv --id codex-adv-1 --severity imp --file f --line 3 --verdict agreed
+check "identical re-append still exits 0 (idempotent)" "$?" "0"
+check "identical re-append adds no line" "$(wc -l < "$AM" | tr -d ' ')" "1"
+
+# amend appends a SUPERSEDE record; it never rewrites the original line.
+CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id codex-adv-1 --set severity=sug --reason "out of diff, pre-existing, already public"
+check "amend exits 0" "$?" "0"
+check "amend APPENDS rather than rewriting" "$(wc -l < "$AM" | tr -d ' ')" "2"
+check "the original finding line is untouched" "$(L="$AM" node -e 'const o=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).find(r=>r.kind==="finding");console.log(o.severity)')" "imp"
+check "amend records the target + the set" "$(L="$AM" node -e 'const o=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).find(r=>r.kind==="amend");console.log(o.target_head+","+o.finding_id+","+o.set.severity)')" "AH1,codex-adv-1,sug"
+check "amend records the reason" "$(L="$AM" node -e 'const o=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).find(r=>r.kind==="amend");console.log(o.reason)')" "out of diff, pre-existing, already public"
+
+# The whole point of the verb: it must NEVER report success without writing.
+CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id no-such-finding --set severity=sug --reason x 2>"$tmp/noop.err"
+check "amend with no target exits non-zero" "$?" "3"
+check "amend with no target says nothing was amended" "$(grep -c 'nothing amended' "$tmp/noop.err")" "1"
+check "amend with no target wrote no line" "$(wc -l < "$AM" | tr -d ' ')" "2"
+
+# A correction with no stated reason is indistinguishable from tampering.
+CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id codex-adv-1 --set severity=sug 2>/dev/null
+check "amend requires --reason" "$?" "2"
+CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id codex-adv-1 --reason x 2>/dev/null
+check "amend requires at least one --set" "$?" "2"
+CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id codex-adv-1 --set model=evil --reason x 2>/dev/null
+check "amend refuses to set a non-amendable key" "$?" "2"
+
+# Incident 2: the finding was keyed to the head that FIXES it instead of the
+# head it was raised against. amend can re-key it.
+CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id codex-adv-1 --set head=deadbeef --reason "raised against deadbeef, mis-keyed onto the fixing head"
+check "amend can re-key the head" "$(L="$AM" node -e 'const rs=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).filter(r=>r.kind==="amend");console.log(rs[rs.length-1].set.head)')" "deadbeef"
+
+# codex-1 round 3: a re-key to something the gate cannot recognise as a head
+# makes the finding vanish from gate 4 entirely - fail OPEN. Validate exactly
+# the shape the gate consumes (isHex: 7-40 hex chars), no narrower, no wider.
+CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id codex-adv-1 --set head=HEAD~1 --reason x 2>/dev/null
+check "amend rejects a non-sha head (would silently unblock)" "$?" "2"
+CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id codex-adv-1 --set head=abc123 --reason x 2>/dev/null
+check "amend rejects a too-short head" "$?" "2"
+
+# codex-1 round 4: after a re-key, the original row still reads the OLD head
+# (append-only), so a second amend aimed at the NEW head - the only head an
+# operator can see in the effective state - must still resolve. Otherwise the
+# recovery path breaks exactly when it is being used to recover.
+CR_LEDGER="$AM" bash "$LA" amend --head deadbeef --id codex-adv-1 --set severity=sug --reason "second amend, aimed at the re-keyed head"
+check "amend resolves a finding through a prior re-key" "$?" "0"
+check "the follow-up amend still keys on the ORIGINAL head" "$(L="$AM" node -e 'const rs=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).filter(r=>r.kind==="amend");console.log(rs[rs.length-1].target_head)')" "AH1"
+
+# ── HIMMEL-1294: the deferral field ─────────────────────────────────────────
+CR_LEDGER="$AM" bash "$LA" finding --branch b --head AH3 --model glm --id glm-1 --severity imp --file f --line 1 --verdict deferred --deferred-to HIMMEL-1293 --reason "pre-existing, already public"
+check "finding stores deferred_to" "$(L="$AM" node -e 'const o=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).find(r=>r.head==="AH3");console.log(o.verdict+","+o.deferred_to)')" "deferred,HIMMEL-1293"
+CR_LEDGER="$AM" bash "$LA" finding --branch b --head AH4 --model glm --id glm-2 --severity imp --file f --line 1 --verdict deferred --deferred-to "not a ticket" 2>/dev/null
+check "a malformed --deferred-to is rejected" "$?" "2"
+
+# codex-1: the validator was a shell GLOB, not a regex. In `[A-Z][A-Z0-9]*-[0-9]*`
+# the trailing `*` means ANY characters, so HI-1x passed here and was then
+# rejected by the gate's anchored regex — split validation, the exact trap that
+# makes a deferral fail late and opaquely.
+CR_LEDGER="$AM" bash "$LA" finding --branch b --head AH5 --model glm --id glm-3 --severity imp --file f --line 1 --verdict deferred --deferred-to "HI-1x" --reason r 2>/dev/null
+check "ticket key with a trailing non-digit is rejected (glob-vs-regex)" "$?" "2"
+CR_LEDGER="$AM" bash "$LA" finding --branch b --head AH5 --model glm --id glm-3 --severity imp --file f --line 1 --verdict deferred --deferred-to "himmel-1" --reason r 2>/dev/null
+check "lowercase ticket key is rejected" "$?" "2"
+CR_LEDGER="$AM" bash "$LA" finding --branch b --head AH6 --model glm --id glm-4 --severity imp --file f --line 1 --verdict deferred --deferred-to "HI-1" --reason r
+check "a minimal well-formed ticket key is accepted" "$?" "0"
+
+# codex-1: gate 4 blocks on severity IN (crit, imp), so a typo matches neither
+# and would silently unblock. The one verb that can change a gate verdict must
+# not fail OPEN on a fat finger.
+CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id codex-adv-1 --set severity=suq --reason x 2>/dev/null
+check "amend rejects a typo'd severity (would silently unblock)" "$?" "2"
+CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id codex-adv-1 --set severity=imp --reason x
+check "amend accepts a valid severity" "$?" "0"
+CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id codex-adv-1 --set verdict=disprovd --reason x 2>/dev/null
+check "amend rejects a typo'd verdict" "$?" "2"
+
+# glm-5: --set deferred_to= must get the SAME eager validation, or a typo is
+# only caught at gate time — on the very path amend exists to unblock.
+CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id codex-adv-1 --set deferred_to=nope --reason x 2>/dev/null
+check "amend --set deferred_to= validates the ticket key too" "$?" "2"
+
+# glm-3: the gate reads the FINDING's reason, so `reason` must be amendable —
+# otherwise deferring an already-recorded finding (the documented recovery) is a
+# dead end for any finding logged without one.
+CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id codex-adv-1 --set reason="out of scope for this branch" --reason "deferring after review"
+check "amend can set the finding-level reason" "$?" "0"
+check "amend --set reason lands in set, not on the amend reason" "$(L="$AM" node -e 'const rs=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).filter(r=>r.kind==="amend");const r=rs[rs.length-1];console.log(r.set.reason+"|"+r.reason)')" "out of scope for this branch|deferring after review"
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/hooks/refresh-statusline-caches-periodic.sh
+++ b/scripts/hooks/refresh-statusline-caches-periodic.sh
@@ -128,21 +128,117 @@ if command -v rebuild_all_sessions_index >/dev/null 2>&1 \
     index_file="$econ_dir/cache-${window_id}-index.json"
     lock="${index_file}.lock"
     mkdir -p "$econ_dir" 2>/dev/null || true
+    # Releases the economics lock. The owner-pid marker lives INSIDE the lock
+    # dir so `mkdir` stays the atomic acquire and a lock created by the legacy
+    # bar (which writes no marker) is still a plain empty dir it can rmdir.
+    _econ_release_lock() {
+        rm -f "$lock/owner.pid" "$lock/heartbeat" 2>/dev/null || true
+        # `rmdir` only removes an EMPTY dir, so any entry this function does not
+        # know about — a marker written by a future version, an editor swapfile,
+        # a filesystem turd — makes the release silently fail and wedges the
+        # refresh for every later session (the reaper below would keep finding a
+        # lock it just declined to remove). Fall back to a recursive remove: by
+        # the time this runs the lock is either OURS or has been positively
+        # confirmed dead, so there is no live owner to pull the rug from under.
+        # Narrowly scoped — "$lock" is always "$index_file.lock" under $econ_dir.
+        rmdir "$lock" 2>/dev/null || rm -rf "$lock" 2>/dev/null || true
+    }
+    # Spawn-free lock heartbeat (HIMMEL-1300). Passed to the rebuild via the
+    # `command -v _hud_rb_heartbeat` seam in all-sessions-index.sh, which calls
+    # it once per transcript. `printf` + redirect are builtins — no touch(1)
+    # fork in the per-file hot path. It stamps a SEPARATE file rather than
+    # re-writing owner.pid, so a concurrent reaper can never catch the pid
+    # marker mid-truncate and mistake this live owner for a marker-less lock.
+    # shellcheck disable=SC2317,SC2329  # invoked indirectly, from the sourced
+    # lib's `command -v _hud_rb_heartbeat` seam — never called by name here.
+    _hud_rb_heartbeat() {
+        printf '%s\n' "$$" > "$lock/heartbeat" 2>/dev/null || true
+    }
+    # Kill-path cleanup: release the lock AND drop the temps this pass left
+    # behind — the rebuild's mktemps (registered by the lib in
+    # $_HUD_RB_TMPFILES) plus the two `.$$.tmp` staging files the atomic
+    # publish uses. The lib is SOURCED, so `$$` is this process and the staging
+    # names match (HIMMEL-1300 R3-4).
+    _econ_cleanup() {
+        rm -f "${index_file}.$$.tmp" "${cache_file}.$$.tmp" 2>/dev/null || true
+        command -v _hud_rb_rmtemps >/dev/null 2>&1 && _hud_rb_rmtemps
+        _econ_release_lock
+    }
+    # The SIGNAL path must EXIT; cleaning up is not enough. A bash INT/TERM
+    # trap RESUMES the interrupted script once the handler returns — it does
+    # not terminate. Demonstrated directly: a script trapping TERM with a
+    # cleanup-only handler ran its cleanup on the signal and then continued to
+    # the last line. So a cleanup-only signal trap here released the lock and
+    # deleted the pass's temps while rebuild_all_sessions_index was STILL
+    # running — leaving the checkpoint writer publishing through temps that no
+    # longer exist, and (the real damage) leaving the lock free so the next
+    # session's refresher could acquire it and write the same cache/index
+    # concurrently. That is precisely the double-writer the lock exists to
+    # prevent, reached BY the kill that is the normal termination mode here.
+    # Exit 0, not 128+signo: hooks in this repo fail CLOSED (a non-zero exit
+    # blocks the action), and this one is a cache-warmer whose documented
+    # contract is that it never blocks the session. Disarm EXIT first so the
+    # cleanup does not run a second time on the way out.
+    # shellcheck disable=SC2317,SC2329  # invoked indirectly, via the trap below.
+    _econ_signal_exit() {
+        _econ_cleanup
+        trap - EXIT
+        exit 0
+    }
   if ! _cache_fresh "$cache_file" "${HIMMEL_STATUSLINE_REFRESH_TTL:-30}"; then
-    # Clear a stale lock left by a crashed rebuild so refresh can't wedge.
+    # Reap a leaked lock. HIMMEL-1300 R3-4: a hook timeout-kill never reaches
+    # the release below, and while the index heals a kill is the NORMAL
+    # termination mode — so with only the 300s age threshold EVERY overrun
+    # leaked the lock and any session started within the next 5 minutes skipped
+    # the refresh entirely. The lock now records its owner PID: an owner that is
+    # gone means the lock is dead, reap it immediately. The 300s age threshold
+    # is KEPT as the fallback — it covers a lock with no pid marker (the legacy
+    # bar's own mkdir-lock, so the two refreshers still interoperate) and the
+    # pathological PID-reuse case where a dead owner's number is live again.
     if [ -d "$lock" ]; then
-        lock_mtime=$(stat -c %Y "$lock" 2>/dev/null || stat -f %m "$lock" 2>/dev/null || echo 0)
-        if [ "$(( $(date +%s) - lock_mtime ))" -gt 300 ]; then
-            rmdir "$lock" 2>/dev/null || true
+        lock_stale=0
+        lock_pid=""
+        # The -f guard is load-bearing: a failing `<` redirect is reported by
+        # the SHELL, so its own `2>/dev/null` cannot suppress the message — and
+        # a marker-less legacy-bar lock is the normal case, not an error.
+        [ -f "$lock/owner.pid" ] && lock_pid=$(tr -dc '0-9' < "$lock/owner.pid" 2>/dev/null)
+        if [ -n "$lock_pid" ] && ! kill -0 "$lock_pid" 2>/dev/null; then
+            lock_stale=1
+        else
+            # Either no pid marker (a legacy-bar lock) or a LIVE pid. The age
+            # test alone was wrong for the live case: a genuine owner grinding
+            # through a slow rebuild crosses 300s and was reaped out from under
+            # itself, so a second refresher then ran concurrently on the same
+            # cache files. A live owner now re-stamps $lock/heartbeat once per
+            # transcript, so measure THAT when it exists — a fresh heartbeat
+            # proves the owner is still working, while an alive-but-silent pid
+            # is a recycled PID number sitting on a dead lock and still ages
+            # out. The lock dir's own mtime stays the fallback: it covers the
+            # marker-less legacy lock and an owner killed before its first
+            # heartbeat.
+            lock_ref="$lock"
+            [ -f "$lock/heartbeat" ] && lock_ref="$lock/heartbeat"
+            lock_mtime=$(stat -c %Y "$lock_ref" 2>/dev/null || stat -f %m "$lock_ref" 2>/dev/null || echo 0)
+            [ "$(( $(date +%s) - lock_mtime ))" -gt 300 ] && lock_stale=1
         fi
+        [ "$lock_stale" -eq 1 ] && _econ_release_lock
     fi
     if mkdir "$lock" 2>/dev/null; then
+        printf '%s\n' "$$" > "$lock/owner.pid" 2>/dev/null || true
+        # SIGKILL cannot be trapped — that path is covered by the dead-owner
+        # reap above; these traps cover SIGTERM/SIGINT and any early exit.
+        # INT/TERM route through _econ_signal_exit (which EXITS) rather than
+        # sharing the EXIT handler — see that function for why a cleanup-only
+        # signal trap kept the rebuild running past its own lock release.
+        trap '_econ_cleanup' EXIT
+        trap '_econ_signal_exit' INT TERM
         if [ "$window_id" = "all-stats" ]; then
             rebuild_all_sessions_index "$proj_root" "$cache_file" "$index_file"
         else
             rebuild_all_sessions_index "$proj_root" "$cache_file" "$index_file" "$window_start" "$window_end"
         fi
-        rmdir "$lock" 2>/dev/null || true
+        trap - EXIT INT TERM
+        _econ_cleanup
     fi
   fi
 fi

--- a/scripts/hooks/test-refresh-statusline-caches.sh
+++ b/scripts/hooks/test-refresh-statusline-caches.sh
@@ -152,6 +152,148 @@ else
     fail "main branch -> rc=$rc rollup_called=$([ -f "$rollup_marker" ] && echo yes || echo no)"
 fi
 
+# ── Cases 3.1-3.3: economics lock reaping (HIMMEL-1300) ─────────────────────
+# All three drive the reaper through the SAME discriminator: if the lock is
+# reaped, the hook acquires it and writes cache-all-stats.json; if it is not,
+# the hook skips the refresh entirely and no cache appears. TTL=0 forces past
+# the freshness gate so the reaper is always reached.
+#
+# Ages the lock dir past the 300s staleness threshold. Returns 1 when this
+# platform's touch(1) cannot set an explicit mtime, so a case can skip rather
+# than assert on a setup that never happened.
+# `touch -d @epoch` is GNU-only, so on a stock macOS this returned 1 and cases
+# 3.1/3.2 SKIPped permanently — silently dropping coverage of the heartbeat-vs-age
+# reaper logic on one of the three declared platforms. Falls back to the POSIX
+# `-t` form via `date -r`, the same pair lib/all-sessions-index.sh already uses to
+# build its `find -newer` reference (~324-326). Still returns 1 when NEITHER form
+# works, so a case can skip rather than assert on a setup that never happened.
+_age_lock() {
+    local _when=$(( $(date +%s) - 600 ))
+    touch -d "@$_when" "$1" 2>/dev/null \
+        || touch -t "$(date -r "$_when" +%Y%m%d%H%M.%S 2>/dev/null)" "$1" 2>/dev/null
+}
+
+run_hook_econ() {  # $1 = econ dir
+    CLAUDE_PROJECTS_DIR="$PROJ" CLAUDE_ALL_SESSIONS_CACHE_DIR="$1" \
+        HIMMEL_STATUSLINE_REFRESH_TTL=0 \
+        HIMMEL_WHERE_ARE_WE_ROLLUP_DIR="$ROLLDIR" HIMMEL_WHERE_ARE_WE_ROLLUP_CMD="bash $rollup_stub" \
+        bash "$HOOK" --cwd "$GITDIR" </dev/null >/dev/null 2>&1
+}
+
+# 3.1 — a LIVE owner whose heartbeat is fresh must SURVIVE, even though the lock
+# dir itself is older than the 300s threshold. This is the regression the
+# heartbeat exists for: before it, a genuine rebuild running longer than 300s
+# was reaped out from under itself and a second refresher ran concurrently on
+# the same cache files. $$ is this test process — unambiguously alive.
+ECON_HB="$TMP/econ-hb"; mkdir -p "$ECON_HB"
+LOCK_HB="$ECON_HB/cache-all-stats-index.json.lock"
+mkdir -p "$LOCK_HB"
+printf '%s\n' "$$" > "$LOCK_HB/owner.pid"
+printf '%s\n' "$$" > "$LOCK_HB/heartbeat"     # fresh: written just now
+if ! _age_lock "$LOCK_HB"; then
+    echo "SKIP live-owner heartbeat -> touch(1) cannot set an explicit mtime here"
+else
+    run_hook_econ "$ECON_HB"
+    if [ -d "$LOCK_HB" ] && [ ! -f "$ECON_HB/cache-all-stats.json" ]; then
+        pass "live owner + fresh heartbeat -> lock NOT reaped, refresh skipped"
+    else
+        fail "live owner + fresh heartbeat -> lock reaped (lock=$([ -d "$LOCK_HB" ] && echo kept || echo gone), cache=$([ -f "$ECON_HB/cache-all-stats.json" ] && echo written || echo none))"
+    fi
+fi
+
+# 3.2 — an alive PID with a STALE heartbeat is a recycled PID number sitting on
+# a dead lock (a real owner would have re-stamped it), so the age fallback must
+# still reap it. Without this the 3.1 fix would wedge the refresh forever.
+ECON_ST="$TMP/econ-stale"; mkdir -p "$ECON_ST"
+LOCK_ST="$ECON_ST/cache-all-stats-index.json.lock"
+mkdir -p "$LOCK_ST"
+printf '%s\n' "$$" > "$LOCK_ST/owner.pid"
+printf '%s\n' "$$" > "$LOCK_ST/heartbeat"
+if ! _age_lock "$LOCK_ST/heartbeat" || ! _age_lock "$LOCK_ST"; then
+    echo "SKIP recycled-pid stale heartbeat -> touch(1) cannot set an explicit mtime here"
+else
+    run_hook_econ "$ECON_ST"
+    if [ -f "$ECON_ST/cache-all-stats.json" ]; then
+        pass "alive pid + stale heartbeat -> reaped by the age fallback, refresh ran"
+    else
+        fail "alive pid + stale heartbeat -> not reaped, refresh never ran"
+    fi
+fi
+
+# 3.3 — release must survive an UNEXPECTED entry in the lock dir. `rmdir` only
+# removes an empty dir, so a stray file made the release silently fail and
+# wedged every later session. Uses a dead owner pid so the reap path (not the
+# acquire path) does the removal.
+ECON_FR="$TMP/econ-force"; mkdir -p "$ECON_FR"
+LOCK_FR="$ECON_FR/cache-all-stats-index.json.lock"
+mkdir -p "$LOCK_FR"
+( exit 0 ) & dead_pid=$!; wait "$dead_pid" 2>/dev/null
+printf '%s\n' "$dead_pid" > "$LOCK_FR/owner.pid"
+printf '%s\n' 'stray marker from some future version' > "$LOCK_FR/unexpected-entry"
+if kill -0 "$dead_pid" 2>/dev/null; then
+    echo "SKIP force-release -> reaped pid $dead_pid is somehow still alive (pid reuse)"
+else
+    run_hook_econ "$ECON_FR"
+    if [ -f "$ECON_FR/cache-all-stats.json" ]; then
+        pass "dead owner + stray lock entry -> force-release reaped it, refresh ran"
+    else
+        fail "dead owner + stray lock entry -> rmdir-only release wedged the refresh"
+    fi
+fi
+
+# 3.4 — a SIGTERM mid-rebuild must TERMINATE the hook, not merely clean up.
+# A bash INT/TERM trap RESUMES the interrupted script when the handler returns,
+# so a cleanup-only signal trap released the lock and deleted the pass's temps
+# while rebuild_all_sessions_index kept running — a second refresher could then
+# acquire the lock and write the same cache/index concurrently. Killing is the
+# NORMAL termination mode for this hook (the SessionStart timeout), so this is
+# the common path, not a corner case. A slow-jq PATH shim makes the rebuild long
+# enough to signal mid-pass; the assertion is that the process is GONE shortly
+# after the TERM, which fails if the trap only cleans up.
+ECON_SIG="$TMP/econ-sig"; mkdir -p "$ECON_SIG"
+SIGPROJ="$TMP/sigprojects"; mkdir -p "$SIGPROJ"
+for n in 1 2 3 4 5 6 7 8; do
+    mkdir -p "$SIGPROJ/s$n"
+    printf '%s\n' '{"type":"assistant","message":{"usage":{"cache_read_input_tokens":1000}}}' > "$SIGPROJ/s$n/t.jsonl"
+done
+SLOWJQ="$TMP/slowjq"; mkdir -p "$SLOWJQ"
+REAL_JQ=$(command -v jq)
+cat > "$SLOWJQ/jq" <<SIGJQ
+#!/usr/bin/env bash
+sleep 1
+exec "$REAL_JQ" "\$@"
+SIGJQ
+chmod +x "$SLOWJQ/jq"
+SIGLOCK="$ECON_SIG/cache-all-stats-index.json.lock"
+CLAUDE_PROJECTS_DIR="$SIGPROJ" CLAUDE_ALL_SESSIONS_CACHE_DIR="$ECON_SIG" \
+    HIMMEL_STATUSLINE_REFRESH_TTL=0 PATH="$SLOWJQ:$PATH" \
+    HIMMEL_WHERE_ARE_WE_ROLLUP_DIR="$ROLLDIR" HIMMEL_WHERE_ARE_WE_ROLLUP_CMD="bash $rollup_stub" \
+    bash "$HOOK" --cwd "$GITDIR" </dev/null >/dev/null 2>&1 &
+sig_pid=$!
+# Wait for the rebuild to actually be under way (lock acquired), bounded.
+waited=0
+while [ ! -d "$SIGLOCK" ] && [ "$waited" -lt 100 ]; do sleep 0.1; waited=$((waited + 1)); done
+if [ ! -d "$SIGLOCK" ]; then
+    echo "SKIP signal-exit -> hook never acquired the lock within 10s (cannot stage the scenario)"
+    kill -TERM "$sig_pid" 2>/dev/null; wait "$sig_pid" 2>/dev/null
+else
+    kill -TERM "$sig_pid" 2>/dev/null
+    # Poll for death rather than `wait` — `wait` would block until the process
+    # ends either way and could not distinguish "exited on the signal" from
+    # "ran the whole rebuild to completion", which is the entire distinction.
+    gone=0
+    for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+        kill -0 "$sig_pid" 2>/dev/null || { gone=1; break; }
+        sleep 0.2
+    done
+    wait "$sig_pid" 2>/dev/null
+    if [ "$gone" -eq 1 ]; then
+        pass "SIGTERM mid-rebuild -> hook exited on the signal (did not resume the rebuild past its own lock release)"
+    else
+        fail "SIGTERM mid-rebuild -> hook still running 3s after TERM; the signal trap cleaned up but did not exit"
+    fi
+fi
+
 # ── Case 4: static no-spawn — the hook itself carries no detached-fork pattern
 strip_comments() { sed -E 's/^[[:space:]]*#.*//; s/([[:space:]])#.*/\1/' "$1"; }
 if [ -z "$(strip_comments "$HOOK" | grep -nE '&[[:space:]]*disown|\([^)]*&[[:space:]]*\)|[^&>|]&[[:space:]]*$' || true)" ]; then

--- a/scripts/statusline/bin/statusline.sh
+++ b/scripts/statusline/bin/statusline.sh
@@ -469,6 +469,63 @@ if [ "$extra_enabled" = "true" ] && [ -n "$usage_data" ]; then
 fi
 
 # ── Cache metrics functions ──────────────────────────────
+# ── Dual-logging dedup, shared jq prelude (HIMMEL-1300) ─────────────────────
+# Claude Code writes the same API response into the transcript 2-3 times, so a
+# naive per-row sum over-counts 1.9x-3.3x. Mirrors claude-hud transcript.ts
+# (457-490): primary key message.id (non-empty string <= 128 chars) against a
+# bounded FIFO seen-set (cap 4096, evict-oldest); a row with a missing/invalid
+# id falls back to its usage fingerprint vs the IMMEDIATELY PREVIOUS row and
+# counts only on change; the fallback key resets on EVERY non-assistant /
+# non-usage row. That reset is why the scan runs over the UNFILTERED row
+# stream — pre-filtering destroys adjacency and would merge two distinct
+# id-less messages. foreach (a reduce that also emits), never group_by /
+# unique_by: those reorder the stream, which the consecutive fingerprint
+# cannot survive. dedup_usage emits one compact {t,r,w,i,o} record per COUNTED
+# message; sum4 folds them into [reads, writes, inputs, outputs]. A WINDOWED
+# caller filters the winners on .t between the two — dedup first, then window;
+# UNWINDOWED callers apply no timestamp filter at all (rows legitimately carry
+# no .timestamp, and filtering them would zero the total).
+_HUD_DEDUP_JQ='
+def normcount:
+  if type != "number" then 0
+  elif (isnan or isinfinite) then 0
+  else (floor as $f | if $f < 0 then 0 else $f end)
+  end;
+def normid:
+  if (type == "string") and (length > 0) and (length <= 128) then . else null end;
+def fp:
+  [.input_tokens, .output_tokens, .cache_creation_input_tokens, .cache_read_input_tokens]
+  | map(if . == null then "null" else tostring end) | join("|");
+def dedup_usage:
+  [ foreach .[] as $msg (
+      { seen: {}, queue: [], lastKey: null, hit: false };
+      if ($msg.type == "assistant") and ($msg.message.usage != null) then
+        ($msg.message.id | normid) as $mid
+        | if $mid != null then
+            ( if (.seen[$mid] // false) then .hit = false
+              else ( if (.queue | length) >= 4096
+                     then (.queue[0]) as $old | .seen |= del(.[$old]) | .queue |= .[1:]
+                     else . end )
+                   | .seen[$mid] = true | .queue += [$mid] | .hit = true
+              end )
+            | .lastKey = null
+          else
+            ($msg.message.usage | fp) as $f
+            | .hit = ($f != .lastKey) | .lastKey = $f
+          end
+      else .hit = false | .lastKey = null
+      end;
+      if .hit then
+        { t: ($msg.timestamp // ""),
+          r: ($msg.message.usage.cache_read_input_tokens     | normcount),
+          w: ($msg.message.usage.cache_creation_input_tokens | normcount),
+          i: ($msg.message.usage.input_tokens                | normcount),
+          o: ($msg.message.usage.output_tokens               | normcount) }
+      else empty end ) ];
+def sum4:
+  [ ([.[].r] | add // 0), ([.[].w] | add // 0),
+    ([.[].i] | add // 0), ([.[].o] | add // 0) ];
+'
 format_tokens() {
     local n="${1:-0}"
     [[ "$n" =~ ^[0-9]+$ ]] || n=0
@@ -561,32 +618,34 @@ format_ttl_line() {
     fi
 }
 # Reads session cache stats from transcript JSONL.
-# Sets: sess_reads sess_writes sess_inputs last_5m_iso last_1h_iso
+# Sets: sess_reads sess_writes sess_inputs sess_outputs last_5m_iso last_1h_iso
 read_session_cache_stats() {
     local transcript="$1"
-    sess_reads=0; sess_writes=0; sess_inputs=0; last_5m_iso=""; last_1h_iso=""
+    sess_reads=0; sess_writes=0; sess_inputs=0; sess_outputs=0; last_5m_iso=""; last_1h_iso=""
     [ -z "$transcript" ] || [ ! -f "$transcript" ] && return
 
     # One jq pass joining on US \x1f (was a slurp + 5 echo|jq extractions;
     # HIMMEL-612). US is non-whitespace so `read` preserves empty timestamp
     # fields instead of coalescing them (a tab IFS would shift columns when
     # last_5m is empty but last_1h is set).
+    # The four token sums are DEDUPED (_HUD_DEDUP_JQ, HIMMEL-1300) and, being an
+    # unwindowed site, carry no timestamp filter. The two TTL timestamps stay on
+    # the raw row stream — "the last write of tier X" is unaffected by dedup.
     local stats US=$'\037'
-    stats=$(jq -rs --arg sep "$US" '[
-        ([.[] | select(.type == "assistant") | .message.usage.cache_read_input_tokens   // 0] | add // 0),
-        ([.[] | select(.type == "assistant") | .message.usage.cache_creation_input_tokens // 0] | add // 0),
-        ([.[] | select(.type == "assistant") | .message.usage.input_tokens              // 0] | add // 0),
-        ([.[] | select(.type == "assistant" and ((.message.usage.cache_creation.ephemeral_5m_input_tokens // 0) > 0))] | last | .timestamp // ""),
-        ([.[] | select(.type == "assistant" and ((.message.usage.cache_creation.ephemeral_1h_input_tokens // 0) > 0))] | last | .timestamp // "")
-    ] | map(tostring) | join($sep)' "$transcript" 2>/dev/null) || return
+    stats=$(jq -rs --arg sep "$US" "$_HUD_DEDUP_JQ"'
+        ((dedup_usage | sum4) + [
+            ([.[] | select(.type == "assistant" and ((.message.usage.cache_creation.ephemeral_5m_input_tokens // 0) > 0))] | last | .timestamp // ""),
+            ([.[] | select(.type == "assistant" and ((.message.usage.cache_creation.ephemeral_1h_input_tokens // 0) > 0))] | last | .timestamp // "")
+        ]) | map(tostring) | join($sep)' "$transcript" 2>/dev/null) || return
     [ -n "$stats" ] || return
 
-    IFS="$US" read -r sess_reads sess_writes sess_inputs last_5m_iso last_1h_iso <<EOF
+    IFS="$US" read -r sess_reads sess_writes sess_inputs sess_outputs last_5m_iso last_1h_iso <<EOF
 $stats
 EOF
-    [ -n "$sess_reads" ]  || sess_reads=0
-    [ -n "$sess_writes" ] || sess_writes=0
-    [ -n "$sess_inputs" ] || sess_inputs=0
+    [ -n "$sess_reads" ]   || sess_reads=0
+    [ -n "$sess_writes" ]  || sess_writes=0
+    [ -n "$sess_inputs" ]  || sess_inputs=0
+    [ -n "$sess_outputs" ] || sess_outputs=0
 }
 # Resolves the bottom cache-row aggregation window for a period. Sets, in the
 # CALLER's scope: window_id, window_start (inclusive epoch), window_end
@@ -634,6 +693,132 @@ resolve_window() {
             ;;
     esac
 }
+# Removes every temp file the current rebuild pass registered in
+# $_HUD_RB_TMPFILES (newline-separated; empty entries skipped) and clears the
+# register. Called on every exit path of rebuild_all_sessions_index — and, per
+# HIMMEL-1300 R3-4, ALSO from the periodic hook's kill-path trap, because a hook
+# timeout-kill never reaches the rebuild's own cleanup and would otherwise leave
+# three mktemps per killed pass behind (kills are the NORMAL termination mode
+# while the index heals).
+_hud_rb_rmtemps() {
+    local _t
+    [ -n "${_HUD_RB_TMPFILES:-}" ] || return 0
+    while IFS= read -r _t; do
+        [ -n "$_t" ] && rm -f "$_t" 2>/dev/null
+    done <<EOF
+$_HUD_RB_TMPFILES
+EOF
+    _HUD_RB_TMPFILES=""
+    return 0
+}
+# Assembles + atomically publishes BOTH the per-file index ($2) and the totals
+# cache ($1) from the CALLER's $recomputed via the caller's $tmp_old/$tmp_all/
+# $tmp_rc transport (bash dynamic scoping — those strings run to hundreds of KB
+# and must never cross an argv boundary).
+# Args: $1=cache_file  $2=index_file  $3=ref_file ("" when none).
+#
+# HIMMEL-1300 R3-5: hoisted out of rebuild_all_sessions_index's tail so it can
+# run every N files as a CHECKPOINT, not only once at the end. A pass killed by
+# the hook timeout previously wrote NOTHING, so on a history whose full scan
+# cannot finish inside the timeout, progress was zero forever. It publishes BOTH
+# files on purpose: an index-only checkpoint would leave the totals (and
+# `pending`) frozen exactly while the index churns. Mid-pass totals are as valid
+# as terminal ones — the reduce carries $oldidx forward for unprocessed files.
+#
+# HIMMEL-1300 R3-1: after each publish the index mtime is pinned BACK to the
+# pass-start reference. The next pass's recompute set is `find -newer
+# "$index_file"`, so an advancing mtime would make a file that is (a) already
+# v-current, (b) modified during this pass and (c) not yet reached when the pass
+# is killed invisible to every later pass — neither -newer, nor missing, nor
+# stale-schema — freezing it at its pre-modification sums indefinitely. Pinning
+# is conservative: such a file is merely re-scanned once.
+# shellcheck disable=SC2154  # $recomputed/$tmp_old/$tmp_all/$tmp_rc are the
+# caller's locals, visible here by bash dynamic scoping (see above).
+_hud_write_index_checkpoint() {
+    local cache_file="$1" index_file="$2" ref_file="$3"
+    local out tmp
+    printf '%s' "$recomputed" > "$tmp_rc"
+
+    # Entry schema v2 (HIMMEL-1300): { reads, writes, inputs, outputs, v }
+    # (+ `attempts` while a file is failing). `outputs` rides THIS bump on
+    # purpose — adding it later would force a v3 and a second full re-migration.
+    # `pending` (R3-5 / §3.5) counts the work still owed: paths with no entry at
+    # all, plus carried entries whose `v` is not current — EXCLUDING the v:-1
+    # permanently-parked failures, which is what lets the composer's `all~`
+    # marker eventually disappear.
+    out=$(jq -n --rawfile old "$tmp_old" --rawfile allp "$tmp_all" --rawfile recomp "$tmp_rc" '
+        2 as $schema
+        | 3 as $maxattempts
+        | ($old | fromjson? // {}) as $oldidx
+        | ($recomp | split("\n") | map(select(length > 0) | split("\t"))
+            | map(if (length >= 5)
+                  then { key: .[0], value: { ok: true,
+                                             reads:   (.[1] | tonumber? // 0),
+                                             writes:  (.[2] | tonumber? // 0),
+                                             inputs:  (.[3] | tonumber? // 0),
+                                             outputs: (.[4] | tonumber? // 0) } }
+                  else { key: .[0], value: { ok: false } }
+                  end)
+            | from_entries) as $rc
+        | ($allp | split("\n") | map(select(length > 0))) as $files
+        | reduce $files[] as $p
+            ({ index: {}, reads: 0, writes: 0, inputs: 0, outputs: 0, pending: 0 };
+             ($oldidx[$p] // null) as $o
+             | ($rc[$p] // null) as $r
+             | (if $r == null then
+                  # Untouched this pass: carry the old entry (and its v) forward.
+                  (if $o == null then null
+                   else { reads:   ($o.reads   // 0), writes:  ($o.writes  // 0),
+                          inputs:  ($o.inputs  // 0), outputs: ($o.outputs // 0),
+                          v: ($o.v // 1) }
+                        + (if ($o.attempts // 0) > 0 then { attempts: $o.attempts } else {} end)
+                   end)
+                elif ($r.ok) then
+                  # Success: stamp the current schema, clear any attempt count.
+                  { reads: $r.reads, writes: $r.writes, inputs: $r.inputs,
+                    outputs: $r.outputs, v: $schema }
+                else
+                  # Failure sentinel: old sums (zeros if never indexed), one more
+                  # attempt, and NO current v — so the known-set filter keeps
+                  # retrying it. After $maxattempts consecutive failures park it
+                  # at v:-1: known (never re-enters the recompute set) but flagged.
+                  { reads:   ($o.reads   // 0), writes:  ($o.writes  // 0),
+                    inputs:  ($o.inputs  // 0), outputs: ($o.outputs // 0),
+                    attempts: (($o.attempts // 0) + 1) }
+                  | if .attempts >= $maxattempts then . + { v: -1 } else . end
+                end) as $e
+             | if $e == null then .pending += 1
+               else .index[$p] = $e
+                  | .reads   += $e.reads
+                  | .writes  += $e.writes
+                  | .inputs  += $e.inputs
+                  | .outputs += $e.outputs
+                  | (($e.v // 1) as $ev
+                     | if $ev == $schema or $ev == -1 then . else .pending += 1 end)
+               end)' 2>/dev/null)
+    [ -z "$out" ] && return 0
+
+    # Atomic tmp+mv so a concurrent reader never sees a torn file.
+    tmp="${index_file}.$$.tmp"
+    if echo "$out" | jq -c '.index' > "$tmp" 2>/dev/null; then
+        if mv -f "$tmp" "$index_file" 2>/dev/null; then
+            # R3-1 mtime pin — see the header. Best-effort: a touch(1) without
+            # -r just leaves the natural (later) mtime, i.e. today's behaviour.
+            [ -n "$ref_file" ] && touch -r "$ref_file" "$index_file" 2>/dev/null
+        else
+            rm -f "$tmp" 2>/dev/null
+        fi
+    else
+        rm -f "$tmp" 2>/dev/null
+    fi
+    tmp="${cache_file}.$$.tmp"
+    if echo "$out" | jq -c '{ reads, writes, inputs, outputs, pending }' > "$tmp" 2>/dev/null; then
+        mv -f "$tmp" "$cache_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    else
+        rm -f "$tmp" 2>/dev/null
+    fi
+    return 0
+}
 # Rebuilds the all-sessions cache incrementally. Sets nothing; writes totals
 # to $2 (cache_file) and a per-file sums index to $3 (index_file), atomically.
 # Optional $4/$5 (win_start/win_end epochs) switch on WINDOWED mode: files whose
@@ -661,16 +846,28 @@ resolve_window() {
 rebuild_all_sessions_index() {
     local proj_root="$1" cache_file="$2" index_file="$3"
     local win_start="${4:-}" win_end="${5:-}"
-    local old_index all_paths recompute_paths recomputed out
-    local tmp_old tmp_all tmp_rc tmp
+    local old_index all_paths recompute_paths recomputed ref_file
+    local tmp_old tmp_all tmp_rc
 
     old_index=$(cat "$index_file" 2>/dev/null)
     echo "$old_index" | jq -e 'type == "object"' >/dev/null 2>&1 || old_index='{}'
 
+    # HIMMEL-1300 R3-1: the pass-start mtime reference, touched into existence
+    # BEFORE the first `find` below. _hud_write_index_checkpoint pins
+    # $index_file back to it after every publish — see that function's header
+    # for why an advancing index mtime silently freezes files modified mid-pass.
+    # Registered in $_HUD_RB_TMPFILES so a caller killed mid-pass (the periodic
+    # hook's timeout) can still reap it.
+    ref_file=$(mktemp 2>/dev/null) || ref_file=""
+    _HUD_RB_TMPFILES="$ref_file"
+
     # Current transcripts (one dir level down). `find` streams paths, so this
     # never hits the argv limit the glob did.
     all_paths=$(find "$proj_root" -mindepth 2 -maxdepth 2 -name '*.jsonl' 2>/dev/null)
-    [ -z "$all_paths" ] && return
+    if [ -z "$all_paths" ]; then
+        _hud_rb_rmtemps
+        return 0
+    fi
 
     # Windowed mode: drop files whose mtime predates the window start — none of
     # their messages can fall in [start,end), so this only bounds the scan, it
@@ -699,7 +896,10 @@ rebuild_all_sessions_index() {
         # list: the per-message jq still yields a correct windowed sum, only the
         # scan is unbounded — a slow-but-correct render beats a 0.
         [ -n "$_ref" ] && rm -f "$_ref" 2>/dev/null
-        [ -z "$all_paths" ] && return
+        if [ -z "$all_paths" ]; then
+            _hud_rb_rmtemps
+            return 0
+        fi
     fi
 
     # Files to recompute: those modified since the last index write (so the
@@ -714,114 +914,162 @@ rebuild_all_sessions_index() {
     # history whose cold full-scan never completed, the "all" row then reflects
     # only the handful of files that happened to be the active transcript at a
     # render (observed: 6 of 1812 files → a stuck, implausibly-low total).
-    # The backfill is BOUNDED per rebuild (default 400, override
-    # HIMMEL_STATUSLINE_BACKFILL_MAX) so a single refresh can't exceed the
-    # stale-lock reaper window on a huge back-catalogue; the index grows
-    # monotonically (a backfilled file's mtime predates the new index write, so
-    # it is carried forward, not re-scanned), so the aggregate heals over
-    # successive renders. Cold start (no index) is unchanged — it already scans
-    # every file — so this only affects the incremental path.
+    # The backfill is BOUNDED per rebuild (override
+    # HIMMEL_STATUSLINE_BACKFILL_MAX); the index grows monotonically (a
+    # backfilled file's mtime predates the new index write, so it is carried
+    # forward, not re-scanned), so the aggregate heals over successive passes.
+    # HIMMEL-1300 §3.4 retunes the default 400 -> 50: at a measured 71ms/file
+    # that is ~3.5s, ~35% of a 10s hook, where 400 was 28.4s (2.8x over) and
+    # therefore never completed. With checkpointing this is a latency knob, not
+    # a correctness one.
+    #
+    # HIMMEL-1300 §3.4 also bounds COLD START: the recompute set starts EMPTY
+    # (it used to be `$all_paths`, unbounded), and the backfill below is hoisted
+    # OUT of the `-f "$index_file"` guard so it runs unconditionally. The old
+    # cold scan could not finish inside the hook timeout, was killed, wrote
+    # nothing, and so left the next pass cold too — a permanent 0. Cold start is
+    # now simply "empty index + BACKFILL_MAX files per pass".
+    recompute_paths=""
     if [ -f "$index_file" ]; then
         recompute_paths=$(find "$proj_root" -mindepth 2 -maxdepth 2 -name '*.jsonl' -newer "$index_file" 2>/dev/null)
-        local backfill_max="${HIMMEL_STATUSLINE_BACKFILL_MAX:-400}"
-        case "$backfill_max" in ''|*[!0-9]*) backfill_max=400 ;; esac
-        if [ "$backfill_max" -gt 0 ]; then
-            local tmp_known missing
-            tmp_known=$(mktemp 2>/dev/null) || tmp_known=""
-            if [ -n "$tmp_known" ]; then
-                # Known = paths already in the index. Any all_paths entry not in
-                # it is a never-scanned historical file → backfill up to N.
-                printf '%s\n' "$old_index" | jq -r 'keys[]?' 2>/dev/null \
-                    | LC_ALL=C sort -u > "$tmp_known"
-                missing=$(printf '%s\n' "$all_paths" | grep -v '^$' | LC_ALL=C sort -u \
-                    | LC_ALL=C comm -23 - "$tmp_known" | head -n "$backfill_max")
-                rm -f "$tmp_known" 2>/dev/null
-                if [ -n "$missing" ]; then
-                    recompute_paths=$(printf '%s\n%s' "$recompute_paths" "$missing" \
-                        | grep -v '^$' | LC_ALL=C sort -u)
-                fi
+    fi
+    local backfill_max="${HIMMEL_STATUSLINE_BACKFILL_MAX:-50}"
+    case "$backfill_max" in ''|*[!0-9]*) backfill_max=50 ;; esac
+    if [ "$backfill_max" -gt 0 ]; then
+        local tmp_known missing
+        tmp_known=$(mktemp 2>/dev/null) || tmp_known=""
+        # Registered like every other mktemp in this function: the jq/sort/comm
+        # window below is long enough to be killed through, and a timeout-kill
+        # IS the normal termination mode while the index heals — so the inline
+        # `rm -f` after the pipeline is not sufficient on its own.
+        [ -n "$tmp_known" ] && _HUD_RB_TMPFILES="$ref_file
+$tmp_known"
+        if [ -n "$tmp_known" ]; then
+            # Known = paths already in the index AT THE CURRENT SCHEMA.
+            # HIMMEL-1300 stamps `v` INSIDE each entry value (so `keys[]` is
+            # never polluted): v=2 = deduped accounting, v=-1 = a file that
+            # failed to parse N times running (permanently parked). Anything
+            # else — a pre-dedup v=1 entry, or a failure sentinel with no v —
+            # is deliberately NOT known, so `comm -23` classifies it as
+            # missing and it re-enters the SAME bounded backfill machinery.
+            # That one query line is the whole re-migration.
+            # `tr -d` strips CR: a native-Windows jq (jq-1.8.2 via winget)
+            # writes CRLF, and unlike a single-line `$(…)` — where bash eats
+            # the trailing \r\n — a multi-line pipeline keeps a \r on EVERY
+            # line. `comm -23` then matches nothing, so every path looks
+            # missing and the backfill re-scans BACKFILL_MAX files every
+            # pass forever. Pre-existing (the old `keys[]?` had it too) and
+            # invisible because "recompute everything" is merely slow, not
+            # wrong — but it would make the schema filter above a no-op.
+            printf '%s\n' "$old_index" \
+                | jq -r 'to_entries[]?
+                         | (.value | if type == "object" then (.v // 1) else 1 end) as $v
+                         | select($v == 2 or $v == -1) | .key' 2>/dev/null \
+                | tr -d '\r' | LC_ALL=C sort -u > "$tmp_known"
+            missing=$(printf '%s\n' "$all_paths" | grep -v '^$' | LC_ALL=C sort -u \
+                | LC_ALL=C comm -23 - "$tmp_known" | head -n "$backfill_max")
+            rm -f "$tmp_known" 2>/dev/null
+            if [ -n "$missing" ]; then
+                recompute_paths=$(printf '%s\n%s' "$recompute_paths" "$missing" \
+                    | grep -v '^$' | LC_ALL=C sort -u)
             fi
         fi
-    else
-        recompute_paths="$all_paths"
     fi
 
-    # Recompute changed files one at a time → path<TAB>reads<TAB>writes<TAB>inputs.
-    # Cheap in steady state (usually just the active transcript).
+    # Assemble/publish transport. Created BEFORE the recompute loop (it used to
+    # sit after it) because the loop now CHECKPOINTS through
+    # _hud_write_index_checkpoint every N files, and each checkpoint re-runs the
+    # assemble jq over these same three files. Everything large flows through
+    # them, never through jq args.
+    tmp_old=$(mktemp 2>/dev/null) || tmp_old=""
+    tmp_all=$(mktemp 2>/dev/null) || tmp_all=""
+    tmp_rc=$(mktemp  2>/dev/null) || tmp_rc=""
+    _HUD_RB_TMPFILES="$ref_file
+$tmp_old
+$tmp_all
+$tmp_rc"
+    if [ -z "$tmp_old" ] || [ -z "$tmp_all" ] || [ -z "$tmp_rc" ]; then
+        _hud_rb_rmtemps
+        return 0
+    fi
+    printf '%s'   "$old_index" > "$tmp_old"
+    printf '%s\n' "$all_paths" > "$tmp_all"
+
+    # Recompute changed files one at a time →
+    # path<TAB>reads<TAB>writes<TAB>inputs<TAB>outputs (5 fields), or the
+    # 2-field failure sentinel path<TAB>FAIL. Cheap in steady state (usually
+    # just the active transcript).
+    #
+    # CHECKPOINT every $ckpt_every files (HIMMEL-1300 R3-5, override
+    # HIMMEL_STATUSLINE_CHECKPOINT_EVERY): the pass is normally terminated by
+    # the hook's timeout kill, and a single terminal `mv` meant such a pass
+    # persisted NOTHING. Checkpointing makes progress monotonic regardless of
+    # how the budget compares to the timeout.
     recomputed=""
     if [ -n "$recompute_paths" ]; then
-        local fpath sums line
+        local fpath sums line ckpt_every processed
+        ckpt_every="${HIMMEL_STATUSLINE_CHECKPOINT_EVERY:-25}"
+        case "$ckpt_every" in ''|*[!0-9]*) ckpt_every=25 ;; esac
+        processed=0
         while IFS= read -r fpath; do
             [ -z "$fpath" ] && continue
+            # LIVENESS HEARTBEAT (HIMMEL-1300). A caller holding a lock over
+            # this rebuild — scripts/hooks/refresh-statusline-caches-periodic.sh
+            # — defines _hud_rb_heartbeat to re-stamp its lock. Without it a pass
+            # that legitimately runs past that reaper's age threshold looks
+            # exactly like a leaked lock and gets reaped out from under itself,
+            # letting a second refresher start on top of the first. Called
+            # per-file rather than per-checkpoint on purpose: a pass with fewer
+            # files than $ckpt_every never checkpoints at all, so a
+            # checkpoint-only heartbeat would go quiet in precisely the
+            # slow-and-few case the reap protects against. The contract on the
+            # callback is that it must be SPAWN-FREE (builtin write, no touch(1))
+            # — this runs once per file inside the hot path. Optional by design:
+            # the legacy bar defines no such function and the `command -v` guard
+            # makes it a no-op there.
+            command -v _hud_rb_heartbeat >/dev/null 2>&1 && _hud_rb_heartbeat
             if [ -n "$win_start" ]; then
-                # Windowed: keep only assistant messages whose timestamp falls
-                # in [win_start, win_end). Fractional ".000Z" is stripped before
+                # Windowed: dedup over the FULL row stream FIRST (the
+                # consecutive-fingerprint fallback needs the original row
+                # adjacency; filtering first would fuse two distinct id-less
+                # messages), then keep the winners whose timestamp falls in
+                # [win_start, win_end). Fractional ".000Z" is stripped before
                 # fromdateiso8601; an unparseable timestamp → -1 → excluded.
                 sums=$(jq -rs --argjson s "$win_start" --argjson e "$win_end" \
-                    '[ .[] | select(.type == "assistant")
-                           | ((.timestamp // "") | sub("\\.[0-9]+Z$";"Z") | fromdateiso8601? // -1) as $te
-                           | select($te >= $s and $te < $e) ]
-                     | [ ([.[] | .message.usage.cache_read_input_tokens   // 0] | add // 0),
-                         ([.[] | .message.usage.cache_creation_input_tokens // 0] | add // 0),
-                         ([.[] | .message.usage.input_tokens               // 0] | add // 0)
-                       ] | @tsv' "$fpath" 2>/dev/null)
+                    "$_HUD_DEDUP_JQ"' dedup_usage
+                     | map(select((.t | sub("\\.[0-9]+Z$";"Z") | fromdateiso8601? // -1) as $te
+                                  | $te >= $s and $te < $e))
+                     | sum4 | @tsv' "$fpath" 2>/dev/null)
             else
-                sums=$(jq -rs '[ ([.[] | select(.type == "assistant") | .message.usage.cache_read_input_tokens   // 0] | add // 0),
-                                 ([.[] | select(.type == "assistant") | .message.usage.cache_creation_input_tokens // 0] | add // 0),
-                                 ([.[] | select(.type == "assistant") | .message.usage.input_tokens               // 0] | add // 0)
-                               ] | @tsv' "$fpath" 2>/dev/null)
+                # Unwindowed: dedup ONLY, no timestamp filter. Rows here
+                # legitimately carry no `.timestamp`, and a winner-filter would
+                # silently drop every one of them (→ a 0 total).
+                sums=$(jq -rs "$_HUD_DEDUP_JQ"' dedup_usage | sum4 | @tsv' "$fpath" 2>/dev/null)
             fi
-            [ -z "$sums" ] && sums=$(printf '0\t0\t0')
+            # jq failure (corrupt/oversized file, or a torn read of the live
+            # transcript mid-append) → a SENTINEL row, never a zero row: a zero
+            # entry OVERRIDES the carried-forward value and drags the aggregate
+            # below true. The assemble below carries the old sums and bumps
+            # `attempts` instead; `attempts` resets on the next success.
+            [ -z "$sums" ] && sums="FAIL"
             line=$(printf '%s\t%s' "$fpath" "$sums")
             recomputed="${recomputed}${line}"$'\n'
+            processed=$(( processed + 1 ))
+            if [ "$ckpt_every" -gt 0 ] && [ $(( processed % ckpt_every )) -eq 0 ]; then
+                _hud_write_index_checkpoint "$cache_file" "$index_file" "$ref_file"
+            fi
         done <<EOF
 $recompute_paths
 EOF
     fi
 
-    # Assemble the new index (recomputed entries override carried-forward ones,
-    # deleted files drop out because we only iterate current paths) and the
-    # totals. Everything large goes through temp files, never jq args.
-    tmp_old=$(mktemp 2>/dev/null) || return
-    tmp_all=$(mktemp 2>/dev/null) || { rm -f "$tmp_old"; return; }
-    tmp_rc=$(mktemp  2>/dev/null) || { rm -f "$tmp_old" "$tmp_all"; return; }
-    printf '%s'   "$old_index"   > "$tmp_old"
-    printf '%s\n' "$all_paths"   > "$tmp_all"
-    printf '%s'   "$recomputed"  > "$tmp_rc"
-
-    out=$(jq -n --rawfile old "$tmp_old" --rawfile allp "$tmp_all" --rawfile recomp "$tmp_rc" '
-        ($old | fromjson? // {}) as $oldidx
-        | ($recomp | split("\n") | map(select(length > 0) | split("\t"))
-            | map({ key: .[0], value: { reads:  (.[1] | tonumber? // 0),
-                                        writes: (.[2] | tonumber? // 0),
-                                        inputs: (.[3] | tonumber? // 0) } })
-            | from_entries) as $rc
-        | ($allp | split("\n") | map(select(length > 0))) as $files
-        | reduce $files[] as $p
-            ({ index: {}, reads: 0, writes: 0, inputs: 0 };
-             ($rc[$p] // $oldidx[$p] // null) as $e
-             | if $e == null then .
-               else .index[$p] = { reads: $e.reads, writes: $e.writes, inputs: $e.inputs }
-                  | .reads  += $e.reads
-                  | .writes += $e.writes
-                  | .inputs += $e.inputs
-               end)' 2>/dev/null)
-    rm -f "$tmp_old" "$tmp_all" "$tmp_rc"
-    [ -z "$out" ] && return
-
-    # Atomic tmp+mv so a concurrent reader never sees a torn file.
-    tmp="${index_file}.$$.tmp"
-    if echo "$out" | jq -c '.index' > "$tmp" 2>/dev/null; then
-        mv -f "$tmp" "$index_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
-    else
-        rm -f "$tmp" 2>/dev/null
-    fi
-    tmp="${cache_file}.$$.tmp"
-    if echo "$out" | jq -c '{ reads, writes, inputs }' > "$tmp" 2>/dev/null; then
-        mv -f "$tmp" "$cache_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
-    else
-        rm -f "$tmp" 2>/dev/null
-    fi
+    # Final publish. Also the ONLY publish when nothing was recomputed —
+    # deletions and carried-forward entries still have to reach the index and
+    # the totals — and the one that lands the tail of a chunk shorter than
+    # $ckpt_every.
+    _hud_write_index_checkpoint "$cache_file" "$index_file" "$ref_file"
+    _hud_rb_rmtemps
+    return 0
 }
 # Returns all-sessions cache totals, refreshing via a single locked background
 # rebuild (30s throttle). Sets: all_reads all_writes all_inputs
@@ -891,7 +1139,7 @@ EOF
 build_cache_lines() {
     local transcript_path="$1" model_id="$2" session_cost="${3:-}"
     local read_savings_rate write_overhead_rate
-    local sess_reads sess_writes sess_inputs last_5m_iso last_1h_iso
+    local sess_reads sess_writes sess_inputs sess_outputs last_5m_iso last_1h_iso
     local all_reads all_writes all_inputs
     local cache_ttl_str cache_ttl_pct
     cache_lines=""

--- a/scripts/statusline/hud-custom-lines.sh
+++ b/scripts/statusline/hud-custom-lines.sh
@@ -14,7 +14,9 @@
 # (§Decisions render-native-map — CUSTOM set):
 #   1. where-are-we  : ⎇ <KEY>[ 📋][ <ledger-status>][ · <EPIC> <done>/<total>]
 #   2. session econ  : session  r:<r>  w:<w>  hit:<h>%  net <±>$<n>
-#   3. all-sessions  : <all|week|month>  r:<r>  w:<w>  hit:<h>%  net <±>$<n>
+#   3. all-sessions  : <all[~]|week|month>  r:<r>  w:<w>  hit:<h>%  net <±>$<n>
+#                      (the `~` is the HIMMEL-1300 healing marker — see §3.5)
+#   4. token volume  : total  cache:<read+creation>  used:<in+read+creation+out>
 # hud renders natively (so we do NOT emit): model/ctx/git/duration/effort,
 # 5h/7d usage, credits (balance_label), prompt-cache countdown, session cost.
 #
@@ -100,26 +102,82 @@ get_model_savings_rate() {
     read_savings_rate=$(awk  -v i="$input_price" -v r="$cache_read_price"  'BEGIN{printf "%.8f",(i-r)/1000000}')
     write_overhead_rate=$(awk -v w="$cache_write_price" -v i="$input_price" 'BEGIN{printf "%.8f",(w-i)/1000000}')
 }
+# ── Dual-logging dedup, shared jq prelude (HIMMEL-1300) ─────────────────────
+# Claude Code writes the same API response into the transcript 2-3 times, so a
+# naive per-row sum over-counts 1.9x-3.3x. Mirrors claude-hud transcript.ts
+# (457-490): primary key message.id (non-empty string <= 128 chars) against a
+# bounded FIFO seen-set (cap 4096, evict-oldest); a row with a missing/invalid
+# id falls back to its usage fingerprint vs the IMMEDIATELY PREVIOUS row and
+# counts only on change; the fallback key resets on EVERY non-assistant /
+# non-usage row. That reset is why the scan runs over the UNFILTERED row
+# stream — pre-filtering destroys adjacency and would merge two distinct
+# id-less messages. foreach (a reduce that also emits), never group_by /
+# unique_by: those reorder the stream, which the consecutive fingerprint
+# cannot survive. dedup_usage emits one compact {t,r,w,i,o} record per COUNTED
+# message; sum4 folds them into [reads, writes, inputs, outputs]. A WINDOWED
+# caller filters the winners on .t between the two — dedup first, then window;
+# UNWINDOWED callers apply no timestamp filter at all (rows legitimately carry
+# no .timestamp, and filtering them would zero the total).
+_HUD_DEDUP_JQ='
+def normcount:
+  if type != "number" then 0
+  elif (isnan or isinfinite) then 0
+  else (floor as $f | if $f < 0 then 0 else $f end)
+  end;
+def normid:
+  if (type == "string") and (length > 0) and (length <= 128) then . else null end;
+def fp:
+  [.input_tokens, .output_tokens, .cache_creation_input_tokens, .cache_read_input_tokens]
+  | map(if . == null then "null" else tostring end) | join("|");
+def dedup_usage:
+  [ foreach .[] as $msg (
+      { seen: {}, queue: [], lastKey: null, hit: false };
+      if ($msg.type == "assistant") and ($msg.message.usage != null) then
+        ($msg.message.id | normid) as $mid
+        | if $mid != null then
+            ( if (.seen[$mid] // false) then .hit = false
+              else ( if (.queue | length) >= 4096
+                     then (.queue[0]) as $old | .seen |= del(.[$old]) | .queue |= .[1:]
+                     else . end )
+                   | .seen[$mid] = true | .queue += [$mid] | .hit = true
+              end )
+            | .lastKey = null
+          else
+            ($msg.message.usage | fp) as $f
+            | .hit = ($f != .lastKey) | .lastKey = $f
+          end
+      else .hit = false | .lastKey = null
+      end;
+      if .hit then
+        { t: ($msg.timestamp // ""),
+          r: ($msg.message.usage.cache_read_input_tokens     | normcount),
+          w: ($msg.message.usage.cache_creation_input_tokens | normcount),
+          i: ($msg.message.usage.input_tokens                | normcount),
+          o: ($msg.message.usage.output_tokens               | normcount) }
+      else empty end ) ];
+def sum4:
+  [ ([.[].r] | add // 0), ([.[].w] | add // 0),
+    ([.[].i] | add // 0), ([.[].o] | add // 0) ];
+'
 # Reads session cache stats from transcript JSONL. Sets: sess_reads sess_writes
-# sess_inputs (last_5m/last_1h timestamps are the TTL lines' concern — hud
-# native promptCache — so we do NOT read them here).
+# sess_inputs sess_outputs (last_5m/last_1h timestamps are the TTL lines'
+# concern — hud native promptCache — so we do NOT read them here).
+# Deduped per _HUD_DEDUP_JQ; UNWINDOWED, so no timestamp filter.
 read_session_cache_stats() {
     local transcript="$1"
-    sess_reads=0; sess_writes=0; sess_inputs=0
+    sess_reads=0; sess_writes=0; sess_inputs=0; sess_outputs=0
     [ -z "$transcript" ] || [ ! -f "$transcript" ] && return
     local stats US=$'\037'
-    stats=$(jq -rs --arg sep "$US" '[
-        ([.[] | select(.type == "assistant") | .message.usage.cache_read_input_tokens   // 0] | add // 0),
-        ([.[] | select(.type == "assistant") | .message.usage.cache_creation_input_tokens // 0] | add // 0),
-        ([.[] | select(.type == "assistant") | .message.usage.input_tokens              // 0] | add // 0)
-    ] | map(tostring) | join($sep)' "$transcript" 2>/dev/null) || return
+    stats=$(jq -rs --arg sep "$US" "$_HUD_DEDUP_JQ"'
+        (dedup_usage | sum4) | map(tostring) | join($sep)' "$transcript" 2>/dev/null) || return
     [ -n "$stats" ] || return
-    IFS="$US" read -r sess_reads sess_writes sess_inputs <<EOF
+    IFS="$US" read -r sess_reads sess_writes sess_inputs sess_outputs <<EOF
 $stats
 EOF
-    [ -n "$sess_reads" ]  || sess_reads=0
-    [ -n "$sess_writes" ] || sess_writes=0
-    [ -n "$sess_inputs" ] || sess_inputs=0
+    [ -n "$sess_reads" ]   || sess_reads=0
+    [ -n "$sess_writes" ]  || sess_writes=0
+    [ -n "$sess_inputs" ]  || sess_inputs=0
+    [ -n "$sess_outputs" ] || sess_outputs=0
 }
 # Formats one economics row (plain text). Args: $1=label $2=reads $3=writes
 # $4=inputs. Uses the model rates already set by get_model_savings_rate.
@@ -137,6 +195,28 @@ format_econ_line() {
     # Pad the label to 7 cols (= "session") so the r: columns of the session and
     # all-sessions rows align, matching the legacy bar's 9-col label gutter.
     printf '%-7s  r:%s  w:%s  hit:%s%%  net %s$%s' "$label" "$r_fmt" "$w_fmt" "$hit" "$sign" "$abs"
+}
+# Formats the token-volume row (plain text) for the ACTIVE all-sessions window.
+# Args: $1=reads $2=writes $3=inputs $4=outputs.
+#   total cache = cache_read + cache_creation
+#   total used  = input + cache_read + cache_creation + output
+# (HIMMEL-1300 §3.6, operator-requested.) It lands on its OWN row rather than
+# extending the session / all rows: both of those are pinned as regression nets
+# — test-hud-composer-parity.sh case 3 is END-ANCHORED on the all row, and
+# test/golden-all-row.txt is a byte-exact capture of the legacy bar's two rows —
+# and neither should be moved for a display addition. Same 7-col `%-7s` gutter
+# as format_econ_line, so `cache:` lines up under the rows' `r:`.
+format_totals_line() {
+    local reads="$1" writes="$2" inputs="$3" outputs="$4"
+    local total_cache total_used
+    [[ "$reads"   =~ ^[0-9]+$ ]] || reads=0
+    [[ "$writes"  =~ ^[0-9]+$ ]] || writes=0
+    [[ "$inputs"  =~ ^[0-9]+$ ]] || inputs=0
+    [[ "$outputs" =~ ^[0-9]+$ ]] || outputs=0
+    total_cache=$(( reads + writes ))
+    total_used=$(( inputs + reads + writes + outputs ))
+    printf '%-7s  cache:%s  used:%s' "total" \
+        "$(format_tokens "$total_cache")" "$(format_tokens "$total_used")"
 }
 
 lines=""
@@ -220,7 +300,7 @@ append "$(format_econ_line "session" "$sess_reads" "$sess_writes" "$sess_inputs"
 # shellcheck source=scripts/statusline/lib/all-sessions-index.sh
 . "$SD/lib/all-sessions-index.sh" 2>/dev/null || true
 period="${HIMMEL_STATUSLINE_PERIOD:-all}"
-all_reads=0 all_writes=0 all_inputs=0 all_label="all"
+all_reads=0 all_writes=0 all_inputs=0 all_outputs=0 all_pending=0 all_label="all"
 if command -v resolve_window >/dev/null 2>&1; then
     # resolve_window sets window_id (+ window_start/window_end, unused on the
     # read path — only the hook's rebuild needs the bounds).
@@ -229,18 +309,55 @@ if command -v resolve_window >/dev/null 2>&1; then
     case "$period" in week) all_label="week" ;; month) all_label="month" ;; *) all_label="all" ;; esac
     all_cache="${CLAUDE_ALL_SESSIONS_CACHE_DIR:-/tmp/claude}/cache-${window_id}.json"
     if [ -f "$all_cache" ]; then
-        joined="$(jq -r '[(.reads // 0),(.writes // 0),(.inputs // 0)] | map(tostring) | join("")' "$all_cache" 2>/dev/null || true)"
+        # `.outputs` and `.pending` are NEW reads (HIMMEL-1300) — the pre-1300 jq
+        # selected reads/writes/inputs only. `outputs` feeds the total-used
+        # figure on the totals row; `pending` drives the `all~` healing marker.
+        # Both are `// 0`, so a cache written by an older producer still parses.
+        # The US (\037) separator comes in via --arg rather than a literal
+        # control byte in the program text.
+        us=$'\037'
+        joined="$(jq -r --arg sep "$us" '[(.reads // 0),(.writes // 0),(.inputs // 0),(.outputs // 0),(.pending // 0)] | map(tostring) | join($sep)' "$all_cache" 2>/dev/null || true)"
         if [ -n "$joined" ]; then
-            IFS=$'\037' read -r all_reads all_writes all_inputs <<EOF
+            IFS="$us" read -r all_reads all_writes all_inputs all_outputs all_pending <<EOF
 $joined
 EOF
         fi
     fi
 fi
-[ -n "$all_reads" ]  || all_reads=0
-[ -n "$all_writes" ] || all_writes=0
-[ -n "$all_inputs" ] || all_inputs=0
-append "$(format_econ_line "$all_label" "$all_reads" "$all_writes" "$all_inputs")"
+# Numeric guards, not merely non-empty ones: every one of these five feeds an
+# arithmetic context downstream (format_econ_line / format_totals_line, and the
+# `-gt 0` test below). A cache written by hand, truncated mid-write, or carrying
+# a jq-stringified float ("1e+30") would otherwise reach `$(( ))` as a syntax
+# error under `set -u`-adjacent strictness. Clamp anything non-integral to 0 —
+# a 0 row is a visibly-wrong number the operator can act on; a broken composer
+# takes the whole statusline down.
+#
+# Matched on the RAW value, never `${x:-0}`: the default would expand an empty
+# var to the literal "0", which matches NEITHER pattern, so the assignment is
+# skipped and the variable stays empty — the exact case the guard exists for.
+# All five are initialised above, so there is no unbound-variable exposure.
+case "$all_reads"   in ''|*[!0-9]*) all_reads=0   ;; esac
+case "$all_writes"  in ''|*[!0-9]*) all_writes=0  ;; esac
+case "$all_inputs"  in ''|*[!0-9]*) all_inputs=0  ;; esac
+case "$all_outputs" in ''|*[!0-9]*) all_outputs=0 ;; esac
+case "$all_pending" in ''|*[!0-9]*) all_pending=0 ;; esac
+
+# HIMMEL-1300 §3.5: while the index still owes work — transcripts it has never
+# indexed, plus carried entries at a stale schema, EXCLUDING the permanently
+# parked v:-1 failures — the `all` row is still MOVING, so it renders as `all~`.
+# The tilde vanishes permanently at pending == 0. `all~` is 4 cols and still
+# fits format_econ_line's 7-col `%-7s` gutter, so nothing realigns. Gated to the
+# `all` period on purpose (spec OQ4): week/month indexes rotate and self-heal
+# within <=7/<=31 days. The legacy bar deliberately gets NO marker — it never
+# renders post-cutover and its row uses a different 9-col gutter.
+all_row_label="$all_label"
+if [ "$all_label" = "all" ] && [ "$all_pending" -gt 0 ]; then
+    all_row_label="all~"
+fi
+append "$(format_econ_line "$all_row_label" "$all_reads" "$all_writes" "$all_inputs")"
+
+# ── Line 4: token volume — total cache / total used (HIMMEL-1300 §3.6) ───────
+append "$(format_totals_line "$all_reads" "$all_writes" "$all_inputs" "$all_outputs")"
 
 printf '%s\n' "$lines"
 exit 0

--- a/scripts/statusline/lib/all-sessions-index.sh
+++ b/scripts/statusline/lib/all-sessions-index.sh
@@ -19,6 +19,67 @@
 [ -n "${_ALL_SESSIONS_INDEX_SH:-}" ] && return 0
 _ALL_SESSIONS_INDEX_SH=1
 
+# ── Dual-logging dedup, shared jq prelude (HIMMEL-1300) ─────────────────────
+# Claude Code writes the same API response into the transcript 2-3 times, so a
+# naive per-row sum over-counts 1.9x-3.3x. Mirrors claude-hud transcript.ts
+# (457-490): primary key message.id (non-empty string <= 128 chars) against a
+# bounded FIFO seen-set (cap 4096, evict-oldest); a row with a missing/invalid
+# id falls back to its usage fingerprint vs the IMMEDIATELY PREVIOUS row and
+# counts only on change; the fallback key resets on EVERY non-assistant /
+# non-usage row. That reset is why the scan runs over the UNFILTERED row
+# stream — pre-filtering destroys adjacency and would merge two distinct
+# id-less messages. foreach (a reduce that also emits), never group_by /
+# unique_by: those reorder the stream, which the consecutive fingerprint
+# cannot survive. dedup_usage emits one compact {t,r,w,i,o} record per COUNTED
+# message; sum4 folds them into [reads, writes, inputs, outputs]. A WINDOWED
+# caller filters the winners on .t between the two — dedup first, then window;
+# UNWINDOWED callers apply no timestamp filter at all (rows legitimately carry
+# no .timestamp, and filtering them would zero the total).
+# Kept byte-identical with the copies in bin/statusline.sh and
+# hud-custom-lines.sh (same "do NOT diverge" invariant as the two functions
+# below, which test-all-sessions-index-parity.sh enforces by byte-diff).
+_HUD_DEDUP_JQ='
+def normcount:
+  if type != "number" then 0
+  elif (isnan or isinfinite) then 0
+  else (floor as $f | if $f < 0 then 0 else $f end)
+  end;
+def normid:
+  if (type == "string") and (length > 0) and (length <= 128) then . else null end;
+def fp:
+  [.input_tokens, .output_tokens, .cache_creation_input_tokens, .cache_read_input_tokens]
+  | map(if . == null then "null" else tostring end) | join("|");
+def dedup_usage:
+  [ foreach .[] as $msg (
+      { seen: {}, queue: [], lastKey: null, hit: false };
+      if ($msg.type == "assistant") and ($msg.message.usage != null) then
+        ($msg.message.id | normid) as $mid
+        | if $mid != null then
+            ( if (.seen[$mid] // false) then .hit = false
+              else ( if (.queue | length) >= 4096
+                     then (.queue[0]) as $old | .seen |= del(.[$old]) | .queue |= .[1:]
+                     else . end )
+                   | .seen[$mid] = true | .queue += [$mid] | .hit = true
+              end )
+            | .lastKey = null
+          else
+            ($msg.message.usage | fp) as $f
+            | .hit = ($f != .lastKey) | .lastKey = $f
+          end
+      else .hit = false | .lastKey = null
+      end;
+      if .hit then
+        { t: ($msg.timestamp // ""),
+          r: ($msg.message.usage.cache_read_input_tokens     | normcount),
+          w: ($msg.message.usage.cache_creation_input_tokens | normcount),
+          i: ($msg.message.usage.input_tokens                | normcount),
+          o: ($msg.message.usage.output_tokens               | normcount) }
+      else empty end ) ];
+def sum4:
+  [ ([.[].r] | add // 0), ([.[].w] | add // 0),
+    ([.[].i] | add // 0), ([.[].o] | add // 0) ];
+'
+
 # Resolves the bottom cache-row aggregation window for a period. Sets, in the
 # CALLER's scope: window_id, window_start (inclusive epoch), window_end
 # (exclusive epoch).
@@ -68,6 +129,132 @@ resolve_window() {
     esac
 }
 
+# Removes every temp file the current rebuild pass registered in
+# $_HUD_RB_TMPFILES (newline-separated; empty entries skipped) and clears the
+# register. Called on every exit path of rebuild_all_sessions_index — and, per
+# HIMMEL-1300 R3-4, ALSO from the periodic hook's kill-path trap, because a hook
+# timeout-kill never reaches the rebuild's own cleanup and would otherwise leave
+# three mktemps per killed pass behind (kills are the NORMAL termination mode
+# while the index heals).
+_hud_rb_rmtemps() {
+    local _t
+    [ -n "${_HUD_RB_TMPFILES:-}" ] || return 0
+    while IFS= read -r _t; do
+        [ -n "$_t" ] && rm -f "$_t" 2>/dev/null
+    done <<EOF
+$_HUD_RB_TMPFILES
+EOF
+    _HUD_RB_TMPFILES=""
+    return 0
+}
+# Assembles + atomically publishes BOTH the per-file index ($2) and the totals
+# cache ($1) from the CALLER's $recomputed via the caller's $tmp_old/$tmp_all/
+# $tmp_rc transport (bash dynamic scoping — those strings run to hundreds of KB
+# and must never cross an argv boundary).
+# Args: $1=cache_file  $2=index_file  $3=ref_file ("" when none).
+#
+# HIMMEL-1300 R3-5: hoisted out of rebuild_all_sessions_index's tail so it can
+# run every N files as a CHECKPOINT, not only once at the end. A pass killed by
+# the hook timeout previously wrote NOTHING, so on a history whose full scan
+# cannot finish inside the timeout, progress was zero forever. It publishes BOTH
+# files on purpose: an index-only checkpoint would leave the totals (and
+# `pending`) frozen exactly while the index churns. Mid-pass totals are as valid
+# as terminal ones — the reduce carries $oldidx forward for unprocessed files.
+#
+# HIMMEL-1300 R3-1: after each publish the index mtime is pinned BACK to the
+# pass-start reference. The next pass's recompute set is `find -newer
+# "$index_file"`, so an advancing mtime would make a file that is (a) already
+# v-current, (b) modified during this pass and (c) not yet reached when the pass
+# is killed invisible to every later pass — neither -newer, nor missing, nor
+# stale-schema — freezing it at its pre-modification sums indefinitely. Pinning
+# is conservative: such a file is merely re-scanned once.
+# shellcheck disable=SC2154  # $recomputed/$tmp_old/$tmp_all/$tmp_rc are the
+# caller's locals, visible here by bash dynamic scoping (see above).
+_hud_write_index_checkpoint() {
+    local cache_file="$1" index_file="$2" ref_file="$3"
+    local out tmp
+    printf '%s' "$recomputed" > "$tmp_rc"
+
+    # Entry schema v2 (HIMMEL-1300): { reads, writes, inputs, outputs, v }
+    # (+ `attempts` while a file is failing). `outputs` rides THIS bump on
+    # purpose — adding it later would force a v3 and a second full re-migration.
+    # `pending` (R3-5 / §3.5) counts the work still owed: paths with no entry at
+    # all, plus carried entries whose `v` is not current — EXCLUDING the v:-1
+    # permanently-parked failures, which is what lets the composer's `all~`
+    # marker eventually disappear.
+    out=$(jq -n --rawfile old "$tmp_old" --rawfile allp "$tmp_all" --rawfile recomp "$tmp_rc" '
+        2 as $schema
+        | 3 as $maxattempts
+        | ($old | fromjson? // {}) as $oldidx
+        | ($recomp | split("\n") | map(select(length > 0) | split("\t"))
+            | map(if (length >= 5)
+                  then { key: .[0], value: { ok: true,
+                                             reads:   (.[1] | tonumber? // 0),
+                                             writes:  (.[2] | tonumber? // 0),
+                                             inputs:  (.[3] | tonumber? // 0),
+                                             outputs: (.[4] | tonumber? // 0) } }
+                  else { key: .[0], value: { ok: false } }
+                  end)
+            | from_entries) as $rc
+        | ($allp | split("\n") | map(select(length > 0))) as $files
+        | reduce $files[] as $p
+            ({ index: {}, reads: 0, writes: 0, inputs: 0, outputs: 0, pending: 0 };
+             ($oldidx[$p] // null) as $o
+             | ($rc[$p] // null) as $r
+             | (if $r == null then
+                  # Untouched this pass: carry the old entry (and its v) forward.
+                  (if $o == null then null
+                   else { reads:   ($o.reads   // 0), writes:  ($o.writes  // 0),
+                          inputs:  ($o.inputs  // 0), outputs: ($o.outputs // 0),
+                          v: ($o.v // 1) }
+                        + (if ($o.attempts // 0) > 0 then { attempts: $o.attempts } else {} end)
+                   end)
+                elif ($r.ok) then
+                  # Success: stamp the current schema, clear any attempt count.
+                  { reads: $r.reads, writes: $r.writes, inputs: $r.inputs,
+                    outputs: $r.outputs, v: $schema }
+                else
+                  # Failure sentinel: old sums (zeros if never indexed), one more
+                  # attempt, and NO current v — so the known-set filter keeps
+                  # retrying it. After $maxattempts consecutive failures park it
+                  # at v:-1: known (never re-enters the recompute set) but flagged.
+                  { reads:   ($o.reads   // 0), writes:  ($o.writes  // 0),
+                    inputs:  ($o.inputs  // 0), outputs: ($o.outputs // 0),
+                    attempts: (($o.attempts // 0) + 1) }
+                  | if .attempts >= $maxattempts then . + { v: -1 } else . end
+                end) as $e
+             | if $e == null then .pending += 1
+               else .index[$p] = $e
+                  | .reads   += $e.reads
+                  | .writes  += $e.writes
+                  | .inputs  += $e.inputs
+                  | .outputs += $e.outputs
+                  | (($e.v // 1) as $ev
+                     | if $ev == $schema or $ev == -1 then . else .pending += 1 end)
+               end)' 2>/dev/null)
+    [ -z "$out" ] && return 0
+
+    # Atomic tmp+mv so a concurrent reader never sees a torn file.
+    tmp="${index_file}.$$.tmp"
+    if echo "$out" | jq -c '.index' > "$tmp" 2>/dev/null; then
+        if mv -f "$tmp" "$index_file" 2>/dev/null; then
+            # R3-1 mtime pin — see the header. Best-effort: a touch(1) without
+            # -r just leaves the natural (later) mtime, i.e. today's behaviour.
+            [ -n "$ref_file" ] && touch -r "$ref_file" "$index_file" 2>/dev/null
+        else
+            rm -f "$tmp" 2>/dev/null
+        fi
+    else
+        rm -f "$tmp" 2>/dev/null
+    fi
+    tmp="${cache_file}.$$.tmp"
+    if echo "$out" | jq -c '{ reads, writes, inputs, outputs, pending }' > "$tmp" 2>/dev/null; then
+        mv -f "$tmp" "$cache_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+    else
+        rm -f "$tmp" 2>/dev/null
+    fi
+    return 0
+}
 # Rebuilds the all-sessions cache incrementally. Sets nothing; writes totals
 # to $2 (cache_file) and a per-file sums index to $3 (index_file), atomically.
 # Optional $4/$5 (win_start/win_end epochs) switch on WINDOWED mode: files whose
@@ -95,16 +282,28 @@ resolve_window() {
 rebuild_all_sessions_index() {
     local proj_root="$1" cache_file="$2" index_file="$3"
     local win_start="${4:-}" win_end="${5:-}"
-    local old_index all_paths recompute_paths recomputed out
-    local tmp_old tmp_all tmp_rc tmp
+    local old_index all_paths recompute_paths recomputed ref_file
+    local tmp_old tmp_all tmp_rc
 
     old_index=$(cat "$index_file" 2>/dev/null)
     echo "$old_index" | jq -e 'type == "object"' >/dev/null 2>&1 || old_index='{}'
 
+    # HIMMEL-1300 R3-1: the pass-start mtime reference, touched into existence
+    # BEFORE the first `find` below. _hud_write_index_checkpoint pins
+    # $index_file back to it after every publish — see that function's header
+    # for why an advancing index mtime silently freezes files modified mid-pass.
+    # Registered in $_HUD_RB_TMPFILES so a caller killed mid-pass (the periodic
+    # hook's timeout) can still reap it.
+    ref_file=$(mktemp 2>/dev/null) || ref_file=""
+    _HUD_RB_TMPFILES="$ref_file"
+
     # Current transcripts (one dir level down). `find` streams paths, so this
     # never hits the argv limit the glob did.
     all_paths=$(find "$proj_root" -mindepth 2 -maxdepth 2 -name '*.jsonl' 2>/dev/null)
-    [ -z "$all_paths" ] && return
+    if [ -z "$all_paths" ]; then
+        _hud_rb_rmtemps
+        return 0
+    fi
 
     # Windowed mode: drop files whose mtime predates the window start — none of
     # their messages can fall in [start,end), so this only bounds the scan, it
@@ -133,7 +332,10 @@ rebuild_all_sessions_index() {
         # list: the per-message jq still yields a correct windowed sum, only the
         # scan is unbounded — a slow-but-correct render beats a 0.
         [ -n "$_ref" ] && rm -f "$_ref" 2>/dev/null
-        [ -z "$all_paths" ] && return
+        if [ -z "$all_paths" ]; then
+            _hud_rb_rmtemps
+            return 0
+        fi
     fi
 
     # Files to recompute: those modified since the last index write (so the
@@ -148,112 +350,160 @@ rebuild_all_sessions_index() {
     # history whose cold full-scan never completed, the "all" row then reflects
     # only the handful of files that happened to be the active transcript at a
     # render (observed: 6 of 1812 files → a stuck, implausibly-low total).
-    # The backfill is BOUNDED per rebuild (default 400, override
-    # HIMMEL_STATUSLINE_BACKFILL_MAX) so a single refresh can't exceed the
-    # stale-lock reaper window on a huge back-catalogue; the index grows
-    # monotonically (a backfilled file's mtime predates the new index write, so
-    # it is carried forward, not re-scanned), so the aggregate heals over
-    # successive renders. Cold start (no index) is unchanged — it already scans
-    # every file — so this only affects the incremental path.
+    # The backfill is BOUNDED per rebuild (override
+    # HIMMEL_STATUSLINE_BACKFILL_MAX); the index grows monotonically (a
+    # backfilled file's mtime predates the new index write, so it is carried
+    # forward, not re-scanned), so the aggregate heals over successive passes.
+    # HIMMEL-1300 §3.4 retunes the default 400 -> 50: at a measured 71ms/file
+    # that is ~3.5s, ~35% of a 10s hook, where 400 was 28.4s (2.8x over) and
+    # therefore never completed. With checkpointing this is a latency knob, not
+    # a correctness one.
+    #
+    # HIMMEL-1300 §3.4 also bounds COLD START: the recompute set starts EMPTY
+    # (it used to be `$all_paths`, unbounded), and the backfill below is hoisted
+    # OUT of the `-f "$index_file"` guard so it runs unconditionally. The old
+    # cold scan could not finish inside the hook timeout, was killed, wrote
+    # nothing, and so left the next pass cold too — a permanent 0. Cold start is
+    # now simply "empty index + BACKFILL_MAX files per pass".
+    recompute_paths=""
     if [ -f "$index_file" ]; then
         recompute_paths=$(find "$proj_root" -mindepth 2 -maxdepth 2 -name '*.jsonl' -newer "$index_file" 2>/dev/null)
-        local backfill_max="${HIMMEL_STATUSLINE_BACKFILL_MAX:-400}"
-        case "$backfill_max" in ''|*[!0-9]*) backfill_max=400 ;; esac
-        if [ "$backfill_max" -gt 0 ]; then
-            local tmp_known missing
-            tmp_known=$(mktemp 2>/dev/null) || tmp_known=""
-            if [ -n "$tmp_known" ]; then
-                # Known = paths already in the index. Any all_paths entry not in
-                # it is a never-scanned historical file → backfill up to N.
-                printf '%s\n' "$old_index" | jq -r 'keys[]?' 2>/dev/null \
-                    | LC_ALL=C sort -u > "$tmp_known"
-                missing=$(printf '%s\n' "$all_paths" | grep -v '^$' | LC_ALL=C sort -u \
-                    | LC_ALL=C comm -23 - "$tmp_known" | head -n "$backfill_max")
-                rm -f "$tmp_known" 2>/dev/null
-                if [ -n "$missing" ]; then
-                    recompute_paths=$(printf '%s\n%s' "$recompute_paths" "$missing" \
-                        | grep -v '^$' | LC_ALL=C sort -u)
-                fi
+    fi
+    local backfill_max="${HIMMEL_STATUSLINE_BACKFILL_MAX:-50}"
+    case "$backfill_max" in ''|*[!0-9]*) backfill_max=50 ;; esac
+    if [ "$backfill_max" -gt 0 ]; then
+        local tmp_known missing
+        tmp_known=$(mktemp 2>/dev/null) || tmp_known=""
+        # Registered like every other mktemp in this function: the jq/sort/comm
+        # window below is long enough to be killed through, and a timeout-kill
+        # IS the normal termination mode while the index heals — so the inline
+        # `rm -f` after the pipeline is not sufficient on its own.
+        [ -n "$tmp_known" ] && _HUD_RB_TMPFILES="$ref_file
+$tmp_known"
+        if [ -n "$tmp_known" ]; then
+            # Known = paths already in the index AT THE CURRENT SCHEMA.
+            # HIMMEL-1300 stamps `v` INSIDE each entry value (so `keys[]` is
+            # never polluted): v=2 = deduped accounting, v=-1 = a file that
+            # failed to parse N times running (permanently parked). Anything
+            # else — a pre-dedup v=1 entry, or a failure sentinel with no v —
+            # is deliberately NOT known, so `comm -23` classifies it as
+            # missing and it re-enters the SAME bounded backfill machinery.
+            # That one query line is the whole re-migration.
+            # `tr -d` strips CR: a native-Windows jq (jq-1.8.2 via winget)
+            # writes CRLF, and unlike a single-line `$(…)` — where bash eats
+            # the trailing \r\n — a multi-line pipeline keeps a \r on EVERY
+            # line. `comm -23` then matches nothing, so every path looks
+            # missing and the backfill re-scans BACKFILL_MAX files every
+            # pass forever. Pre-existing (the old `keys[]?` had it too) and
+            # invisible because "recompute everything" is merely slow, not
+            # wrong — but it would make the schema filter above a no-op.
+            printf '%s\n' "$old_index" \
+                | jq -r 'to_entries[]?
+                         | (.value | if type == "object" then (.v // 1) else 1 end) as $v
+                         | select($v == 2 or $v == -1) | .key' 2>/dev/null \
+                | tr -d '\r' | LC_ALL=C sort -u > "$tmp_known"
+            missing=$(printf '%s\n' "$all_paths" | grep -v '^$' | LC_ALL=C sort -u \
+                | LC_ALL=C comm -23 - "$tmp_known" | head -n "$backfill_max")
+            rm -f "$tmp_known" 2>/dev/null
+            if [ -n "$missing" ]; then
+                recompute_paths=$(printf '%s\n%s' "$recompute_paths" "$missing" \
+                    | grep -v '^$' | LC_ALL=C sort -u)
             fi
         fi
-    else
-        recompute_paths="$all_paths"
     fi
 
-    # Recompute changed files one at a time → path<TAB>reads<TAB>writes<TAB>inputs.
-    # Cheap in steady state (usually just the active transcript).
+    # Assemble/publish transport. Created BEFORE the recompute loop (it used to
+    # sit after it) because the loop now CHECKPOINTS through
+    # _hud_write_index_checkpoint every N files, and each checkpoint re-runs the
+    # assemble jq over these same three files. Everything large flows through
+    # them, never through jq args.
+    tmp_old=$(mktemp 2>/dev/null) || tmp_old=""
+    tmp_all=$(mktemp 2>/dev/null) || tmp_all=""
+    tmp_rc=$(mktemp  2>/dev/null) || tmp_rc=""
+    _HUD_RB_TMPFILES="$ref_file
+$tmp_old
+$tmp_all
+$tmp_rc"
+    if [ -z "$tmp_old" ] || [ -z "$tmp_all" ] || [ -z "$tmp_rc" ]; then
+        _hud_rb_rmtemps
+        return 0
+    fi
+    printf '%s'   "$old_index" > "$tmp_old"
+    printf '%s\n' "$all_paths" > "$tmp_all"
+
+    # Recompute changed files one at a time →
+    # path<TAB>reads<TAB>writes<TAB>inputs<TAB>outputs (5 fields), or the
+    # 2-field failure sentinel path<TAB>FAIL. Cheap in steady state (usually
+    # just the active transcript).
+    #
+    # CHECKPOINT every $ckpt_every files (HIMMEL-1300 R3-5, override
+    # HIMMEL_STATUSLINE_CHECKPOINT_EVERY): the pass is normally terminated by
+    # the hook's timeout kill, and a single terminal `mv` meant such a pass
+    # persisted NOTHING. Checkpointing makes progress monotonic regardless of
+    # how the budget compares to the timeout.
     recomputed=""
     if [ -n "$recompute_paths" ]; then
-        local fpath sums line
+        local fpath sums line ckpt_every processed
+        ckpt_every="${HIMMEL_STATUSLINE_CHECKPOINT_EVERY:-25}"
+        case "$ckpt_every" in ''|*[!0-9]*) ckpt_every=25 ;; esac
+        processed=0
         while IFS= read -r fpath; do
             [ -z "$fpath" ] && continue
+            # LIVENESS HEARTBEAT (HIMMEL-1300). A caller holding a lock over
+            # this rebuild — scripts/hooks/refresh-statusline-caches-periodic.sh
+            # — defines _hud_rb_heartbeat to re-stamp its lock. Without it a pass
+            # that legitimately runs past that reaper's age threshold looks
+            # exactly like a leaked lock and gets reaped out from under itself,
+            # letting a second refresher start on top of the first. Called
+            # per-file rather than per-checkpoint on purpose: a pass with fewer
+            # files than $ckpt_every never checkpoints at all, so a
+            # checkpoint-only heartbeat would go quiet in precisely the
+            # slow-and-few case the reap protects against. The contract on the
+            # callback is that it must be SPAWN-FREE (builtin write, no touch(1))
+            # — this runs once per file inside the hot path. Optional by design:
+            # the legacy bar defines no such function and the `command -v` guard
+            # makes it a no-op there.
+            command -v _hud_rb_heartbeat >/dev/null 2>&1 && _hud_rb_heartbeat
             if [ -n "$win_start" ]; then
-                # Windowed: keep only assistant messages whose timestamp falls
-                # in [win_start, win_end). Fractional ".000Z" is stripped before
+                # Windowed: dedup over the FULL row stream FIRST (the
+                # consecutive-fingerprint fallback needs the original row
+                # adjacency; filtering first would fuse two distinct id-less
+                # messages), then keep the winners whose timestamp falls in
+                # [win_start, win_end). Fractional ".000Z" is stripped before
                 # fromdateiso8601; an unparseable timestamp → -1 → excluded.
                 sums=$(jq -rs --argjson s "$win_start" --argjson e "$win_end" \
-                    '[ .[] | select(.type == "assistant")
-                           | ((.timestamp // "") | sub("\\.[0-9]+Z$";"Z") | fromdateiso8601? // -1) as $te
-                           | select($te >= $s and $te < $e) ]
-                     | [ ([.[] | .message.usage.cache_read_input_tokens   // 0] | add // 0),
-                         ([.[] | .message.usage.cache_creation_input_tokens // 0] | add // 0),
-                         ([.[] | .message.usage.input_tokens               // 0] | add // 0)
-                       ] | @tsv' "$fpath" 2>/dev/null)
+                    "$_HUD_DEDUP_JQ"' dedup_usage
+                     | map(select((.t | sub("\\.[0-9]+Z$";"Z") | fromdateiso8601? // -1) as $te
+                                  | $te >= $s and $te < $e))
+                     | sum4 | @tsv' "$fpath" 2>/dev/null)
             else
-                sums=$(jq -rs '[ ([.[] | select(.type == "assistant") | .message.usage.cache_read_input_tokens   // 0] | add // 0),
-                                 ([.[] | select(.type == "assistant") | .message.usage.cache_creation_input_tokens // 0] | add // 0),
-                                 ([.[] | select(.type == "assistant") | .message.usage.input_tokens               // 0] | add // 0)
-                               ] | @tsv' "$fpath" 2>/dev/null)
+                # Unwindowed: dedup ONLY, no timestamp filter. Rows here
+                # legitimately carry no `.timestamp`, and a winner-filter would
+                # silently drop every one of them (→ a 0 total).
+                sums=$(jq -rs "$_HUD_DEDUP_JQ"' dedup_usage | sum4 | @tsv' "$fpath" 2>/dev/null)
             fi
-            [ -z "$sums" ] && sums=$(printf '0\t0\t0')
+            # jq failure (corrupt/oversized file, or a torn read of the live
+            # transcript mid-append) → a SENTINEL row, never a zero row: a zero
+            # entry OVERRIDES the carried-forward value and drags the aggregate
+            # below true. The assemble below carries the old sums and bumps
+            # `attempts` instead; `attempts` resets on the next success.
+            [ -z "$sums" ] && sums="FAIL"
             line=$(printf '%s\t%s' "$fpath" "$sums")
             recomputed="${recomputed}${line}"$'\n'
+            processed=$(( processed + 1 ))
+            if [ "$ckpt_every" -gt 0 ] && [ $(( processed % ckpt_every )) -eq 0 ]; then
+                _hud_write_index_checkpoint "$cache_file" "$index_file" "$ref_file"
+            fi
         done <<EOF
 $recompute_paths
 EOF
     fi
 
-    # Assemble the new index (recomputed entries override carried-forward ones,
-    # deleted files drop out because we only iterate current paths) and the
-    # totals. Everything large goes through temp files, never jq args.
-    tmp_old=$(mktemp 2>/dev/null) || return
-    tmp_all=$(mktemp 2>/dev/null) || { rm -f "$tmp_old"; return; }
-    tmp_rc=$(mktemp  2>/dev/null) || { rm -f "$tmp_old" "$tmp_all"; return; }
-    printf '%s'   "$old_index"   > "$tmp_old"
-    printf '%s\n' "$all_paths"   > "$tmp_all"
-    printf '%s'   "$recomputed"  > "$tmp_rc"
-
-    out=$(jq -n --rawfile old "$tmp_old" --rawfile allp "$tmp_all" --rawfile recomp "$tmp_rc" '
-        ($old | fromjson? // {}) as $oldidx
-        | ($recomp | split("\n") | map(select(length > 0) | split("\t"))
-            | map({ key: .[0], value: { reads:  (.[1] | tonumber? // 0),
-                                        writes: (.[2] | tonumber? // 0),
-                                        inputs: (.[3] | tonumber? // 0) } })
-            | from_entries) as $rc
-        | ($allp | split("\n") | map(select(length > 0))) as $files
-        | reduce $files[] as $p
-            ({ index: {}, reads: 0, writes: 0, inputs: 0 };
-             ($rc[$p] // $oldidx[$p] // null) as $e
-             | if $e == null then .
-               else .index[$p] = { reads: $e.reads, writes: $e.writes, inputs: $e.inputs }
-                  | .reads  += $e.reads
-                  | .writes += $e.writes
-                  | .inputs += $e.inputs
-               end)' 2>/dev/null)
-    rm -f "$tmp_old" "$tmp_all" "$tmp_rc"
-    [ -z "$out" ] && return
-
-    # Atomic tmp+mv so a concurrent reader never sees a torn file.
-    tmp="${index_file}.$$.tmp"
-    if echo "$out" | jq -c '.index' > "$tmp" 2>/dev/null; then
-        mv -f "$tmp" "$index_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
-    else
-        rm -f "$tmp" 2>/dev/null
-    fi
-    tmp="${cache_file}.$$.tmp"
-    if echo "$out" | jq -c '{ reads, writes, inputs }' > "$tmp" 2>/dev/null; then
-        mv -f "$tmp" "$cache_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null
-    else
-        rm -f "$tmp" 2>/dev/null
-    fi
+    # Final publish. Also the ONLY publish when nothing was recomputed —
+    # deletions and carried-forward entries still have to reach the index and
+    # the totals — and the one that lands the tail of a chunk shorter than
+    # $ckpt_every.
+    _hud_write_index_checkpoint "$cache_file" "$index_file" "$ref_file"
+    _hud_rb_rmtemps
+    return 0
 }

--- a/scripts/statusline/test-all-sessions-index-parity.sh
+++ b/scripts/statusline/test-all-sessions-index-parity.sh
@@ -11,6 +11,7 @@ set -uo pipefail
 DIR="$(cd "$(dirname "$0")" && pwd)"
 LIB="$DIR/lib/all-sessions-index.sh"
 LEGACY="$DIR/bin/statusline.sh"
+COMPOSER="$DIR/hud-custom-lines.sh"
 
 FAILED=0; PASSED=0
 pass() { echo "PASS $1"; PASSED=$((PASSED + 1)); }
@@ -21,6 +22,11 @@ trap 'rm -rf "$TMP"' EXIT
 
 # Extract a top-level function body (def line .. its column-0 closing brace).
 extract_fn() { sed -n "/^$1() {/,/^}/p" "$2"; }
+
+# Extract a top-level single-quoted heredoc-style assignment
+# (`NAME='` .. the lone closing `'`). Used for the shared jq program below,
+# which is a VARIABLE, not a function, so extract_fn cannot reach it.
+extract_var() { sed -n "/^$1='/,/^'\$/p" "$2"; }
 
 # ── Case 1: resolve_window byte-identical between lib and legacy ─────────────
 lib_rw="$TMP/lib-rw"; leg_rw="$TMP/leg-rw"
@@ -44,7 +50,52 @@ else
     diff -u "$leg_rb" "$lib_rb" | head -40
 fi
 
-# ── Case 3: windowed rebuild through the lib (the else-branch path) ──────────
+# ── Cases 3-4: the rebuild's HELPERS byte-identical (glm-2, HIMMEL-1300) ─────
+# _hud_write_index_checkpoint and _hud_rb_rmtemps are duplicated into the
+# legacy bar under the SAME "do NOT diverge" invariant as the two functions
+# above, but nothing enforced it — and they are not incidental: the checkpoint
+# writer owns the atomic publish AND the R3-1 index-mtime pinning, so a drifted
+# copy silently changes which files the NEXT pass considers stale. The temp
+# reaper is the kill-path cleanup the periodic hook calls by name. Same
+# structural enforcement, one case each.
+for _fn in _hud_write_index_checkpoint _hud_rb_rmtemps; do
+    _lib_h="$TMP/lib-$_fn"; _leg_h="$TMP/leg-$_fn"
+    extract_fn "$_fn" "$LIB"    > "$_lib_h"
+    extract_fn "$_fn" "$LEGACY" > "$_leg_h"
+    if [ -s "$_lib_h" ] && [ -s "$_leg_h" ] && diff -u "$_leg_h" "$_lib_h" >/dev/null 2>&1; then
+        pass "$_fn byte-identical (lib == legacy)"
+    else
+        fail "$_fn DIVERGED (lib vs legacy):"
+        diff -u "$_leg_h" "$_lib_h" | head -40
+    fi
+done
+
+# ── Cases 5-6: _HUD_DEDUP_JQ byte-identical across ALL THREE copies ──────────
+# The dedup jq program is the actual accounting rule (HIMMEL-1300): if the
+# composer's copy drifts from the rebuild's, the `session` row and the `all` row
+# start counting the SAME transcripts differently and the discrepancy is
+# invisible — both rows still render, just with numbers that no longer agree.
+# It lives in three files (lib, legacy bar, composer) and is a variable, so the
+# two function diffs above never covered it. Same structural enforcement, one
+# case per pair against the lib as the reference copy.
+lib_jq="$TMP/lib-jq"
+extract_var _HUD_DEDUP_JQ "$LIB" > "$lib_jq"
+if [ ! -s "$lib_jq" ]; then
+    fail "_HUD_DEDUP_JQ not extractable from the lib (extractor or definition changed shape)"
+fi
+for _pair in "legacy:$LEGACY" "composer:$COMPOSER"; do
+    _name="${_pair%%:*}"; _file="${_pair#*:}"
+    _out="$TMP/$_name-jq"
+    extract_var _HUD_DEDUP_JQ "$_file" > "$_out"
+    if [ -s "$lib_jq" ] && [ -s "$_out" ] && diff -u "$_out" "$lib_jq" >/dev/null 2>&1; then
+        pass "_HUD_DEDUP_JQ byte-identical (lib == $_name)"
+    else
+        fail "_HUD_DEDUP_JQ DIVERGED (lib vs $_name):"
+        diff -u "$_out" "$lib_jq" | head -40
+    fi
+done
+
+# ── Case 7: windowed rebuild through the lib (the else-branch path) ──────────
 # Drive rebuild_all_sessions_index in WINDOWED mode directly and assert only the
 # in-window assistant messages are summed (the fromdateiso8601 timestamp filter).
 # shellcheck source=scripts/statusline/lib/all-sessions-index.sh disable=SC1091

--- a/scripts/statusline/test-hud-composer-parity.sh
+++ b/scripts/statusline/test-hud-composer-parity.sh
@@ -72,9 +72,27 @@ stdin_json="$(printf '{"model":{"id":"claude-opus-4-8"},"transcript_path":"%s","
 
 run_composer() {
     # $@ = extra env assignments already exported by caller.
+    #
+    # The segment timeout is pinned WELL above the 3s production default on
+    # purpose. The composer runs the WAW segment under `timeout` and fails open
+    # to an empty line when it overruns — correct on the render path, but it
+    # turns the two WAW cases below into a measurement of machine speed: on a
+    # loaded box (e.g. immediately after test/test_cache.sh, which spawns jq
+    # several hundred times) the ~1s segment crosses 3s and both cases fail with
+    # no WAW line at all. Verified by forcing the mechanism directly:
+    # HIMMEL_WHERE_ARE_WE_SEG_TIMEOUT=1 reproduces exactly that 2-failure
+    # signature. These cases assert composer/segment PARITY, so the segment must
+    # be allowed to finish; the timeout's own fail-open behaviour is not what is
+    # under test here.
+    #
+    # Pinned UNCONDITIONALLY, not `${VAR:-30}`: honouring an inherited value let
+    # an ambient 1 or 3 in the caller's environment silently reintroduce the very
+    # missing-segment flake this pin exists to remove, turning a parity assertion
+    # back into a machine-speed one. A hermetic test sets its own preconditions.
     printf '%s' "$stdin_json" | \
         HIMMEL_WHERE_ARE_WE_ROLLUP_DIR="$ROLLDIR" HANDOVER_DIR="$HROOT" \
         CLAUDE_ALL_SESSIONS_CACHE_DIR="$ECON_DIR" \
+        HIMMEL_WHERE_ARE_WE_SEG_TIMEOUT=30 \
         bash "$COMPOSER" 2>/dev/null
 }
 
@@ -100,7 +118,15 @@ fi
 if [ -n "$key" ]; then
     seg_line="$(printf '%s' "$stdin_json" | HIMMEL_WHERE_ARE_WE_ROLLUP_DIR="$ROLLDIR" HANDOVER_DIR="$HROOT" \
                 bash "$SEGMENT" --cwd "$WT" 2>/dev/null)"
-    if [ -n "$seg_line" ] && printf '%s\n' "$out" | grep -qF "$seg_line"; then
+    # LC_ALL=C is load-bearing, not decoration. The segment line carries 📋
+    # (U+1F4CB), a 4-byte astral-plane character, and GNU grep 3.0 — what
+    # Git-Bash/MSYS ships — fails to match an astral character through `-F` when
+    # the locale is UTF-8 (en_GB.UTF-8 here): the identical byte sequence is
+    # reported as absent. Verified in isolation: the same needle matches under
+    # LC_ALL=C and does not under LC_ALL=en_GB.UTF-8, while `⎇` (3-byte) and the
+    # ASCII parts match under both. This test compares BYTES for a byte-identity
+    # claim, so the C locale is also the semantically correct choice.
+    if [ -n "$seg_line" ] && printf '%s\n' "$out" | LC_ALL=C grep -qF "$seg_line"; then
         pass "WAW parity -> composer emits the segment line verbatim ('$seg_line')"
     else
         fail "WAW parity -> seg='$seg_line' not found in composer out"

--- a/scripts/statusline/test/test_cache.sh
+++ b/scripts/statusline/test/test_cache.sh
@@ -4,6 +4,47 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATUSLINE="$SCRIPT_DIR/../bin/statusline.sh"
 
+# ── HIMMEL-1300 R3-8: save/restore the LIVE all-sessions caches ───────────
+# This suite repeatedly overwrites/removes /tmp/claude/cache-all-stats.json
+# (and its -index.json sibling) as fixtures throughout the file below —
+# read_all_sessions_cache_stats (bin/statusline.sh) hardcodes /tmp/claude, so
+# there is no cache-dir seam to redirect through. Left unguarded, a local
+# full-suite run destroys the operator's real historical totals. Mirrors the
+# restore_usage_cache trap further down (same technique, same file).
+ALLSTATS_CACHE=/tmp/claude/cache-all-stats.json
+ALLSTATS_INDEX=/tmp/claude/cache-all-stats-index.json
+ALLSTATS_CACHE_BACKUP=$(mktemp)
+ALLSTATS_INDEX_BACKUP=$(mktemp)
+ALLSTATS_CACHE_HAD_FILE=false
+ALLSTATS_INDEX_HAD_FILE=false
+mkdir -p /tmp/claude 2>/dev/null || true
+if [ -f "$ALLSTATS_CACHE" ]; then
+    ALLSTATS_CACHE_HAD_FILE=true
+    cp "$ALLSTATS_CACHE" "$ALLSTATS_CACHE_BACKUP"
+fi
+if [ -f "$ALLSTATS_INDEX" ]; then
+    ALLSTATS_INDEX_HAD_FILE=true
+    cp "$ALLSTATS_INDEX" "$ALLSTATS_INDEX_BACKUP"
+fi
+# Presence flag (not -s), same reasoning as restore_usage_cache: an originally
+# absent file must come back absent, not as an empty file.
+restore_allstats_cache() {
+    if $ALLSTATS_CACHE_HAD_FILE; then
+        mv -f "$ALLSTATS_CACHE_BACKUP" "$ALLSTATS_CACHE"
+    else
+        rm -f "$ALLSTATS_CACHE_BACKUP" "$ALLSTATS_CACHE"
+    fi
+    if $ALLSTATS_INDEX_HAD_FILE; then
+        mv -f "$ALLSTATS_INDEX_BACKUP" "$ALLSTATS_INDEX"
+    else
+        rm -f "$ALLSTATS_INDEX_BACKUP" "$ALLSTATS_INDEX"
+    fi
+}
+# Set NOW so an early failure (before the usage-cache trap below is installed)
+# still restores; the usage-cache trap installation further down replaces this
+# with a combined trap that runs both restores.
+trap restore_allstats_cache EXIT
+
 # ── Inline deps from original script ──────────────────────
 iso_to_epoch() {
     local iso_str="$1"
@@ -418,7 +459,10 @@ restore_usage_cache() {
     fi
     rm -f "$SL_ERR"
 }
-trap restore_usage_cache EXIT
+# Combined trap: both restores must run on exit (a single EXIT trap slot
+# replaces, not adds — chain explicitly rather than losing the R3-8 restore
+# installed above).
+trap 'restore_usage_cache; restore_allstats_cache' EXIT
 
 run_statusline() {  # $1 = stdin payload; stderr kept for FAIL output
     printf '%s' "$1" | bash "$STATUSLINE" >/dev/null 2>"$SL_ERR" || true
@@ -681,6 +725,393 @@ echo "$plain_lbl" | grep -q "r:6k" \
     || { echo "FAIL: month windowed totals missing in: $plain_lbl"; FAIL=$(( FAIL + 1 )); }
 rm -f /tmp/claude/cache-month-202606.json
 rm -rf "$TMPDIR_LBL"
+
+# ── HIMMEL-1300: dedup by message.id (duplicate collapsed, distinct summed) ──
+# Claude Code dual/triple-logs the same API response into the transcript; a
+# naive per-row sum over-counts 1.9x-3.3x (spec §1.1). rebuild_all_sessions_index
+# must count each message.id once, but still sum genuinely distinct messages.
+TMPDIR_DEDUP=$(mktemp -d)
+DEDUP_PROJ="$TMPDIR_DEDUP/.claude/projects"; mkdir -p "$DEDUP_PROJ/p"
+cat > "$DEDUP_PROJ/p/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"id":"m1","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":100,"cache_read_input_tokens":200}}}
+{"type":"assistant","message":{"id":"m1","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":100,"cache_read_input_tokens":200}}}
+{"type":"assistant","message":{"id":"m1","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":100,"cache_read_input_tokens":200}}}
+{"type":"assistant","message":{"id":"m2","usage":{"input_tokens":20,"output_tokens":8,"cache_creation_input_tokens":300,"cache_read_input_tokens":400}}}
+EOF
+DEDUP_CACHE="$TMPDIR_DEDUP/cache.json"; DEDUP_INDEX="$TMPDIR_DEDUP/index.json"
+rebuild_all_sessions_index "$DEDUP_PROJ" "$DEDUP_CACHE" "$DEDUP_INDEX" || true
+assert_eq "dedup by message.id: reads (m1 once + m2, not m1 x3)" "$(jq -r '.reads'   "$DEDUP_CACHE" 2>/dev/null)" "600"
+assert_eq "dedup by message.id: writes (m1 once + m2)"          "$(jq -r '.writes'  "$DEDUP_CACHE" 2>/dev/null)" "400"
+assert_eq "dedup by message.id: inputs (m1 once + m2)"          "$(jq -r '.inputs'  "$DEDUP_CACHE" 2>/dev/null)" "30"
+assert_eq "dedup by message.id: outputs (m1 once + m2)"         "$(jq -r '.outputs' "$DEDUP_CACHE" 2>/dev/null)" "13"
+rm -rf "$TMPDIR_DEDUP"
+
+# ── HIMMEL-1300: id-less consecutive-fingerprint fallback + reset ────────────
+# No fixture here carries message.id, so dedup falls back to comparing usage
+# fingerprints against the IMMEDIATELY PREVIOUS row: identical-consecutive is
+# skipped, a change counts, and the key RESETS on every non-assistant row (so
+# two distinct id-less messages separated by a user row do NOT fuse into one).
+# usage A: input=1 output=2 write=10 read=20 ; usage B: input=3 output=4 write=30 read=40
+# Sequence: A, A(dup->skip), user(reset), A(post-reset->count again), B(count), B(dup->skip)
+# Expected: 2xA + 1xB -> reads=20+20+40=80 writes=10+10+30=50 inputs=1+1+3=5 outputs=2+2+4=8
+TMPDIR_FP=$(mktemp -d)
+FP_PROJ="$TMPDIR_FP/.claude/projects"; mkdir -p "$FP_PROJ/p"
+cat > "$FP_PROJ/p/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"usage":{"input_tokens":1,"output_tokens":2,"cache_creation_input_tokens":10,"cache_read_input_tokens":20}}}
+{"type":"assistant","message":{"usage":{"input_tokens":1,"output_tokens":2,"cache_creation_input_tokens":10,"cache_read_input_tokens":20}}}
+{"type":"user","message":{"content":"reset here"}}
+{"type":"assistant","message":{"usage":{"input_tokens":1,"output_tokens":2,"cache_creation_input_tokens":10,"cache_read_input_tokens":20}}}
+{"type":"assistant","message":{"usage":{"input_tokens":3,"output_tokens":4,"cache_creation_input_tokens":30,"cache_read_input_tokens":40}}}
+{"type":"assistant","message":{"usage":{"input_tokens":3,"output_tokens":4,"cache_creation_input_tokens":30,"cache_read_input_tokens":40}}}
+EOF
+FP_CACHE="$TMPDIR_FP/cache.json"; FP_INDEX="$TMPDIR_FP/index.json"
+rebuild_all_sessions_index "$FP_PROJ" "$FP_CACHE" "$FP_INDEX" || true
+assert_eq "id-less fallback: reads (2xA + 1xB, dups skipped, reset across user row)"  "$(jq -r '.reads'   "$FP_CACHE" 2>/dev/null)" "80"
+assert_eq "id-less fallback: writes"                                                  "$(jq -r '.writes'  "$FP_CACHE" 2>/dev/null)" "50"
+assert_eq "id-less fallback: inputs"                                                  "$(jq -r '.inputs'  "$FP_CACHE" 2>/dev/null)" "5"
+assert_eq "id-less fallback: outputs"                                                 "$(jq -r '.outputs' "$FP_CACHE" 2>/dev/null)" "8"
+rm -rf "$TMPDIR_FP"
+
+# ── HIMMEL-1300: normalization (non-number / null / negative / fractional) ──
+# normcount: non-number -> 0; null -> 0; negative -> clamped to 0; fractional
+# -> floor.
+TMPDIR_NORM=$(mktemp -d)
+NORM_PROJ="$TMPDIR_NORM/.claude/projects"; mkdir -p "$NORM_PROJ/p"
+cat > "$NORM_PROJ/p/s.jsonl" <<'EOF'
+{"type":"assistant","message":{"id":"norm1","usage":{"input_tokens":"abc","output_tokens":null,"cache_creation_input_tokens":-50,"cache_read_input_tokens":12.7}}}
+EOF
+NORM_CACHE="$TMPDIR_NORM/cache.json"; NORM_INDEX="$TMPDIR_NORM/index.json"
+rebuild_all_sessions_index "$NORM_PROJ" "$NORM_CACHE" "$NORM_INDEX" || true
+assert_eq "normalization: fractional 12.7 reads floors to 12" "$(jq -r '.reads'   "$NORM_CACHE" 2>/dev/null)" "12"
+assert_eq "normalization: negative -50 writes clamps to 0"    "$(jq -r '.writes'  "$NORM_CACHE" 2>/dev/null)" "0"
+assert_eq "normalization: non-number \"abc\" inputs -> 0"     "$(jq -r '.inputs'  "$NORM_CACHE" 2>/dev/null)" "0"
+assert_eq "normalization: null outputs -> 0"                  "$(jq -r '.outputs' "$NORM_CACHE" 2>/dev/null)" "0"
+rm -rf "$TMPDIR_NORM"
+
+# ── HIMMEL-1300 R3-2/§3.3: v2 entry carried forward untouched; a stale/v-less
+# entry re-enters the recompute set ──────────────────────────────────────────
+# fileA (v=2, known) and fileB (v stripped, simulating a pre-dedup/stale
+# entry) both get their CONTENT changed on disk while their mtime is reset to
+# its pre-change value (so neither is `-newer` than the index). fileA — known
+# and unchanged per the index — must be carried forward exactly as indexed,
+# ignoring the new bytes. fileB — not "known" (no current v) — must re-enter
+# recompute via the backfill missing-set regardless of mtime, and pick up its
+# new content.
+TMPDIR_V2=$(mktemp -d)
+V2_PROJ="$TMPDIR_V2/.claude/projects"; mkdir -p "$V2_PROJ/pa" "$V2_PROJ/pb"
+cat > "$V2_PROJ/pa/fileA.jsonl" <<'EOF'
+{"type":"assistant","message":{"id":"va1","usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":100,"cache_read_input_tokens":111}}}
+EOF
+cat > "$V2_PROJ/pb/fileB.jsonl" <<'EOF'
+{"type":"assistant","message":{"id":"vb1","usage":{"input_tokens":2,"output_tokens":2,"cache_creation_input_tokens":200,"cache_read_input_tokens":222}}}
+EOF
+V2_CACHE="$TMPDIR_V2/cache.json"; V2_INDEX="$TMPDIR_V2/index.json"
+sleep 1
+rebuild_all_sessions_index "$V2_PROJ" "$V2_CACHE" "$V2_INDEX" || true
+assert_eq "v2 seed: fileA indexed at reads=111, v=2" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("fileA.jsonl")) | "\(.value.reads)/\(.value.v)"' "$V2_INDEX" 2>/dev/null)" "111/2"
+
+# Strip fileB's v stamp — simulates a pre-dedup v1 entry / stale carry.
+# Matched via endswith() baked into the jq PROGRAM TEXT, not --arg: this
+# machine's jq is a native Windows binary, and MSYS/Git-Bash auto-translates
+# a POSIX-look `--arg` value (e.g. "/tmp/tmp.XXX/...") into a Windows path
+# before jq ever sees it, so an exact-match `.[$p]` silently misses (verified:
+# `jq -n --arg p "/tmp/x" '$p'` prints "C:/Users/.../Temp/x"). endswith() on a
+# literal in the program itself is immune to that argv mangling.
+jq 'to_entries | map(if (.key | endswith("fileB.jsonl")) then .value |= del(.v) else . end) | from_entries' \
+    "$V2_INDEX" > "$V2_INDEX.tmp" && mv "$V2_INDEX.tmp" "$V2_INDEX"
+sleep 1
+
+FA_REF="$TMPDIR_V2/famref"; touch -r "$V2_PROJ/pa/fileA.jsonl" "$FA_REF"
+echo '{"type":"assistant","message":{"id":"va2","usage":{"input_tokens":9,"output_tokens":9,"cache_creation_input_tokens":900,"cache_read_input_tokens":999}}}' > "$V2_PROJ/pa/fileA.jsonl"
+touch -r "$FA_REF" "$V2_PROJ/pa/fileA.jsonl"
+
+FB_REF="$TMPDIR_V2/fbref"; touch -r "$V2_PROJ/pb/fileB.jsonl" "$FB_REF"
+echo '{"type":"assistant","message":{"id":"vb2","usage":{"input_tokens":8,"output_tokens":8,"cache_creation_input_tokens":800,"cache_read_input_tokens":888}}}' > "$V2_PROJ/pb/fileB.jsonl"
+touch -r "$FB_REF" "$V2_PROJ/pb/fileB.jsonl"
+
+rebuild_all_sessions_index "$V2_PROJ" "$V2_CACHE" "$V2_INDEX" || true
+assert_eq "v2 entry carried forward UNTOUCHED (fileA reads stay 111, bytes on disk changed to 999 but ignored)" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("fileA.jsonl")) | .value.reads' "$V2_INDEX" 2>/dev/null)" "111"
+assert_eq "stale/v-less entry RE-ENTERS recompute (fileB reads now 888, re-read despite unchanged mtime)" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("fileB.jsonl")) | .value.reads' "$V2_INDEX" 2>/dev/null)" "888"
+assert_eq "re-entered entry stamped current v=2 on success" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("fileB.jsonl")) | .value.v' "$V2_INDEX" 2>/dev/null)" "2"
+rm -rf "$TMPDIR_V2"
+
+# ── HIMMEL-1300 R3-3: jq failure -> sentinel (never a zero), attempts count,
+# reset-on-success, and v:-1 parking after 3 consecutive failures ───────────
+TMPDIR_FAIL=$(mktemp -d)
+FAIL_PROJ="$TMPDIR_FAIL/.claude/projects"; mkdir -p "$FAIL_PROJ/p"
+FAIL_FILE="$FAIL_PROJ/p/flaky.jsonl"
+echo '{"type":"assistant","message":{"id":"good1","usage":{"input_tokens":5,"output_tokens":5,"cache_creation_input_tokens":50,"cache_read_input_tokens":100}}}' > "$FAIL_FILE"
+FAIL_CACHE="$TMPDIR_FAIL/cache.json"; FAIL_INDEX="$TMPDIR_FAIL/index.json"
+sleep 1
+rebuild_all_sessions_index "$FAIL_PROJ" "$FAIL_CACHE" "$FAIL_INDEX" || true
+assert_eq "pre-failure: good sums indexed (reads=100)" "$(jq -r '.reads' "$FAIL_CACHE" 2>/dev/null)" "100"
+
+# Corrupt the file (invalid JSON -> jq -rs fails, empty stdout) and touch it
+# newer so it enters this pass's recompute set via -newer.
+sleep 1
+printf 'not json{{{\n' > "$FAIL_FILE"
+rebuild_all_sessions_index "$FAIL_PROJ" "$FAIL_CACHE" "$FAIL_INDEX" || true
+assert_eq "jq-failure sentinel: aggregate does NOT dip (still 100, not 0)" \
+    "$(jq -r '.reads' "$FAIL_CACHE" 2>/dev/null)" "100"
+assert_eq "jq-failure sentinel: attempts=1 after first failure" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("flaky.jsonl")) | .value.attempts' "$FAIL_INDEX" 2>/dev/null)" "1"
+assert_eq "jq-failure sentinel: no current v (keeps retrying via the missing-set)" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("flaky.jsonl")) | .value.v' "$FAIL_INDEX" 2>/dev/null)" "null"
+
+# Second consecutive failure — picked up via the backfill missing-set this
+# time (the entry has no v, so it is not "known" regardless of mtime).
+rebuild_all_sessions_index "$FAIL_PROJ" "$FAIL_CACHE" "$FAIL_INDEX" || true
+assert_eq "jq-failure sentinel: attempts=2 (second consecutive failure)" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("flaky.jsonl")) | .value.attempts' "$FAIL_INDEX" 2>/dev/null)" "2"
+assert_eq "jq-failure sentinel: still carries the old sums at attempts=2 (no dip)" \
+    "$(jq -r '.reads' "$FAIL_CACHE" 2>/dev/null)" "100"
+
+# Third consecutive failure -> parked at v:-1 (excluded from pending).
+rebuild_all_sessions_index "$FAIL_PROJ" "$FAIL_CACHE" "$FAIL_INDEX" || true
+assert_eq "jq-failure: 3rd consecutive failure parks v:-1" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("flaky.jsonl")) | .value.v' "$FAIL_INDEX" 2>/dev/null)" "-1"
+assert_eq "jq-failure: parked entry excluded from pending" \
+    "$(jq -r '.pending' "$FAIL_CACHE" 2>/dev/null)" "0"
+rm -rf "$TMPDIR_FAIL"
+
+# ── Reset-on-success: a failing file that later recovers clears `attempts` ──
+TMPDIR_RESET=$(mktemp -d)
+RESET_PROJ="$TMPDIR_RESET/.claude/projects"; mkdir -p "$RESET_PROJ/p"
+RESET_FILE="$RESET_PROJ/p/flaky2.jsonl"
+echo '{"type":"assistant","message":{"id":"r1","usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":10,"cache_read_input_tokens":20}}}' > "$RESET_FILE"
+RESET_CACHE="$TMPDIR_RESET/cache.json"; RESET_INDEX="$TMPDIR_RESET/index.json"
+sleep 1
+rebuild_all_sessions_index "$RESET_PROJ" "$RESET_CACHE" "$RESET_INDEX" || true
+sleep 1
+printf 'not json{{{\n' > "$RESET_FILE"
+rebuild_all_sessions_index "$RESET_PROJ" "$RESET_CACHE" "$RESET_INDEX" || true
+assert_eq "reset-on-success setup: attempts=1 before recovery" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("flaky2.jsonl")) | .value.attempts' "$RESET_INDEX" 2>/dev/null)" "1"
+sleep 1
+echo '{"type":"assistant","message":{"id":"r2","usage":{"input_tokens":2,"output_tokens":2,"cache_creation_input_tokens":20,"cache_read_input_tokens":40}}}' > "$RESET_FILE"
+rebuild_all_sessions_index "$RESET_PROJ" "$RESET_CACHE" "$RESET_INDEX" || true
+assert_eq "reset-on-success: attempts cleared after a success" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("flaky2.jsonl")) | .value.attempts' "$RESET_INDEX" 2>/dev/null)" "null"
+assert_eq "reset-on-success: v stamped current (2) on success" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("flaky2.jsonl")) | .value.v' "$RESET_INDEX" 2>/dev/null)" "2"
+assert_eq "reset-on-success: sums reflect the NEW post-recovery content (40, not the old 20)" \
+    "$(jq -r '.reads' "$RESET_CACHE" 2>/dev/null)" "40"
+rm -rf "$TMPDIR_RESET"
+
+# ── HIMMEL-1300 R3-5: checkpointing — a pass killed mid-run still persists
+# completed entries (the §1.6 fix: before checkpointing, a killed pass wrote
+# NOTHING, so a history whose scan never finishes inside the hook timeout made
+# ZERO progress forever). A "slow jq" (a PATH-shadowed jq wrapper that adds a
+# fixed delay before delegating to the real binary) turns the normally-instant
+# per-file/per-checkpoint jq calls into a long enough pass to reliably
+# interrupt with `timeout -s TERM`. Assertions are RANGE-based, not exact
+# counts: which file the kill lands on is a real race — the invariant under
+# test is "some but not all persisted, and a follow-up pass heals the rest".
+CACHE_FUNCS_FILE=$(mktemp)
+sed -n '/^# ── Cache metrics functions/,/^# ── End cache metrics functions/p' "$STATUSLINE" > "$CACHE_FUNCS_FILE"
+
+TMPDIR_CKPT=$(mktemp -d)
+CKPT_PROJ="$TMPDIR_CKPT/.claude/projects"; mkdir -p "$CKPT_PROJ"
+for n in 1 2 3; do
+    mkdir -p "$CKPT_PROJ/p$n"
+    echo '{"type":"assistant","message":{"id":"ckid'"$n"'","usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":1,"cache_read_input_tokens":'"$((n*1000))"'}}}' > "$CKPT_PROJ/p$n/f.jsonl"
+done
+CKPT_CACHE="$TMPDIR_CKPT/cache.json"; CKPT_INDEX="$TMPDIR_CKPT/index.json"
+
+SLOWJQ_DIR=$(mktemp -d)
+REAL_JQ_BIN=$(command -v jq)
+cat > "$SLOWJQ_DIR/jq" <<SLOWEOF
+#!/usr/bin/env bash
+sleep 0.5
+exec "$REAL_JQ_BIN" "\$@"
+SLOWEOF
+chmod +x "$SLOWJQ_DIR/jq"
+
+# `timeout`'s own exit status is 124 on a genuine kill — that IS the expected,
+# successful outcome here, not a script error. Left unguarded under this
+# file's `set -e`, a bare 124 aborts the WHOLE suite immediately (no further
+# tests run, no "Results:" line, and the abort's 124 becomes the file's own
+# exit code) — exactly the bug a prior run of this test hit. `|| true` makes
+# the expected-nonzero outcome non-fatal. `--kill-after=3` is a hard backstop:
+# this platform's signal delivery to a process chain that has exec'd into a
+# native-Windows binary (jq.exe) has been observed to lag well past a bare
+# `-s TERM`'s deadline, so escalate to an unmaskable SIGKILL 3s later rather
+# than risk an orphaned process lingering (and burning CPU / racing shared
+# fixtures) long after this test itself has moved on.
+#
+# `timeout` is GNU coreutils, NOT POSIX: a stock macOS has neither it nor
+# (without Homebrew coreutils) its `gtimeout` alias. Resolve whichever exists
+# and SKIP the two kill assertions when neither does — an absent tool is not a
+# product defect, and hard-failing on it would make this suite red on any
+# machine that cannot run the scenario at all. The heal assertions below do NOT
+# depend on the kill and still run either way.
+CKPT_TIMEOUT_BIN=""
+for _cand in timeout gtimeout; do
+    if command -v "$_cand" >/dev/null 2>&1; then CKPT_TIMEOUT_BIN="$_cand"; break; fi
+done
+if [ -z "$CKPT_TIMEOUT_BIN" ]; then
+    echo "SKIP: checkpoint survives a kill -> neither timeout(1) nor gtimeout(1) available"
+else
+HIMMEL_STATUSLINE_CHECKPOINT_EVERY=1 PATH="$SLOWJQ_DIR:$PATH" \
+    "$CKPT_TIMEOUT_BIN" --kill-after=3 -s TERM 7 bash -c '. "$1"; rebuild_all_sessions_index "$2" "$3" "$4"' _ \
+    "$CACHE_FUNCS_FILE" "$CKPT_PROJ" "$CKPT_CACHE" "$CKPT_INDEX" >/dev/null 2>&1 || true
+CKPT_KILLED_COUNT=$(jq -r 'length' "$CKPT_INDEX" 2>/dev/null); [ -n "$CKPT_KILLED_COUNT" ] || CKPT_KILLED_COUNT=0
+CKPT_KILLED_READS=$(jq -r '.reads // 0' "$CKPT_CACHE" 2>/dev/null); [ -n "$CKPT_KILLED_READS" ] || CKPT_KILLED_READS=0
+# The invariant is PROGRESS PERSISTED, not "the kill landed mid-pass". Whether
+# 7s is long enough to finish all 3 slow-jq files is a property of the host, not
+# of the code under test: on a fast box the pass completes and persists all 3 —
+# still a correct outcome, and failing it would make this a machine-speed
+# assertion. A count of 0 remains the real regression (the pre-checkpoint
+# behaviour: a killed pass wrote NOTHING).
+if [ "$CKPT_KILLED_COUNT" -gt 0 ] 2>/dev/null && [ "$CKPT_KILLED_COUNT" -le 3 ] 2>/dev/null; then
+    if [ "$CKPT_KILLED_COUNT" -eq 3 ]; then
+        echo "PASS: checkpoint survives a kill -> pass ran to completion, all 3 files persisted (reads=$CKPT_KILLED_READS)"; PASS=$(( PASS + 1 ))
+    else
+        echo "PASS: checkpoint survives a kill -> partial progress persisted ($CKPT_KILLED_COUNT/3 files, reads=$CKPT_KILLED_READS)"; PASS=$(( PASS + 1 ))
+    fi
+else
+    echo "FAIL: checkpoint survives a kill -> expected 1-3 of 3 files persisted, got count='$CKPT_KILLED_COUNT'"; FAIL=$(( FAIL + 1 ))
+fi
+if [ "$CKPT_KILLED_READS" -gt 0 ] 2>/dev/null && [ "$CKPT_KILLED_READS" -le 6000 ] 2>/dev/null; then
+    echo "PASS: checkpoint survives a kill -> totals persisted (reads=$CKPT_KILLED_READS, not the pre-checkpoint 0)"; PASS=$(( PASS + 1 ))
+else
+    echo "FAIL: checkpoint survives a kill -> reads should be in (0,6000], got $CKPT_KILLED_READS"; FAIL=$(( FAIL + 1 ))
+fi
+fi
+
+# A follow-up pass (ordinary/unthrottled jq) must heal the rest.
+rebuild_all_sessions_index "$CKPT_PROJ" "$CKPT_CACHE" "$CKPT_INDEX" || true
+assert_eq "checkpoint heal: index has all 3 files after a follow-up pass" \
+    "$(jq -r 'length' "$CKPT_INDEX" 2>/dev/null)" "3"
+assert_eq "checkpoint heal: totals reach the full sum (1000+2000+3000)" \
+    "$(jq -r '.reads' "$CKPT_CACHE" 2>/dev/null)" "6000"
+assert_eq "checkpoint heal: pending reaches 0" \
+    "$(jq -r '.pending' "$CKPT_CACHE" 2>/dev/null)" "0"
+rm -rf "$TMPDIR_CKPT" "$SLOWJQ_DIR"
+
+# ── HIMMEL-1300 R3-1 (CRITICAL) — mtime pinning ──────────────────────────────
+# The next pass's recompute set is `find -newer "$index_file"`, keyed on the
+# index's mtime. Without pinning, a checkpoint's `mv` would advance that mtime
+# mid-pass, so a file that is (a) already known/v-current, (b) modified DURING
+# the pass (after recompute_paths was fixed, before the pass reaches it), and
+# (c) not yet reached when the pass ends, becomes invisible FOREVER afterward:
+# not -newer (checkpoint mtime raced past it), not missing (already known),
+# not stale-schema. This drives _hud_write_index_checkpoint directly (its
+# caller-scope vars, via bash dynamic scoping — the same contract
+# rebuild_all_sessions_index itself relies on) to model "a checkpoint fires
+# mid-pass" deterministically, without racing a real timeout/kill.
+TMPDIR_PIN=$(mktemp -d)
+PIN_PROJ="$TMPDIR_PIN/.claude/projects"; mkdir -p "$PIN_PROJ/proj-a"
+echo '{"type":"assistant","message":{"id":"pinA1","usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":10,"cache_read_input_tokens":500}}}' > "$PIN_PROJ/proj-a/fileA.jsonl"
+PIN_CACHE="$TMPDIR_PIN/cache.json"; PIN_INDEX="$TMPDIR_PIN/index.json"
+rebuild_all_sessions_index "$PIN_PROJ" "$PIN_CACHE" "$PIN_INDEX" || true
+assert_eq "mtime-pin setup: fileA seeded at reads=500" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("fileA.jsonl")) | .value.reads' "$PIN_INDEX" 2>/dev/null)" "500"
+
+sleep 1
+# The pass-start reference, exactly as rebuild_all_sessions_index creates one.
+PIN_REF=$(mktemp)
+sleep 1
+# fileA "modified during the pass": new content + a fresh mtime, strictly
+# AFTER the pass-start ref above — the file the (simulated) pass hasn't
+# reached yet when a checkpoint fires.
+echo '{"type":"assistant","message":{"id":"pinA2","usage":{"input_tokens":2,"output_tokens":2,"cache_creation_input_tokens":20,"cache_read_input_tokens":999}}}' > "$PIN_PROJ/proj-a/fileA.jsonl"
+
+# Drive ONE checkpoint publish as if it fired mid-pass having recomputed
+# NOTHING yet (fileA not reached): $recomputed empty, carrying the old index
+# forward untouched — exactly rebuild_all_sessions_index's own transport
+# contract ($recomputed/$tmp_old/$tmp_all/$tmp_rc read from the CALLER's scope).
+recomputed=""
+tmp_old=$(mktemp); tmp_all=$(mktemp); tmp_rc=$(mktemp)
+printf '%s' "$(cat "$PIN_INDEX")" > "$tmp_old"
+printf '%s\n' "$PIN_PROJ/proj-a/fileA.jsonl" > "$tmp_all"
+_hud_write_index_checkpoint "$PIN_CACHE" "$PIN_INDEX" "$PIN_REF"
+
+PIN_IDX_MTIME=$(stat -c %Y "$PIN_INDEX" 2>/dev/null || stat -f %m "$PIN_INDEX" 2>/dev/null)
+PIN_FILEA_MTIME=$(stat -c %Y "$PIN_PROJ/proj-a/fileA.jsonl" 2>/dev/null || stat -f %m "$PIN_PROJ/proj-a/fileA.jsonl" 2>/dev/null)
+if [ "$PIN_IDX_MTIME" -lt "$PIN_FILEA_MTIME" ] 2>/dev/null; then
+    echo "PASS: mtime pin -> checkpoint publish did NOT advance index mtime past fileA's mid-pass edit ($PIN_IDX_MTIME < $PIN_FILEA_MTIME)"; PASS=$(( PASS + 1 ))
+else
+    echo "FAIL: mtime pin -> index mtime ($PIN_IDX_MTIME) is not older than fileA's ($PIN_FILEA_MTIME); a later pass's -newer check would miss it forever"; FAIL=$(( FAIL + 1 ))
+fi
+assert_eq "mtime pin: fileA carried forward untouched by the mid-pass checkpoint (still 500)" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("fileA.jsonl")) | .value.reads' "$PIN_INDEX" 2>/dev/null)" "500"
+
+# The critical end-to-end proof: the NEXT real pass must see fileA as -newer
+# (thanks to the pin) and pick up its NEW content — not stay frozen forever,
+# which is exactly the failure mode R3-1 describes without the pin.
+rebuild_all_sessions_index "$PIN_PROJ" "$PIN_CACHE" "$PIN_INDEX" || true
+assert_eq "mtime pin: NEXT pass re-scans fileA and picks up the NEW content (999, not still 500)" \
+    "$(jq -r 'to_entries[] | select(.key|endswith("fileA.jsonl")) | .value.reads' "$PIN_INDEX" 2>/dev/null)" "999"
+rm -f "$PIN_REF" "$tmp_old" "$tmp_all" "$tmp_rc" "$CACHE_FUNCS_FILE"
+rm -rf "$TMPDIR_PIN"
+
+# ── HIMMEL-1300 §3.4: cold start recomputes a BOUNDED slice, not all paths ──
+# Cold start (no index_file yet) used to scan every path unbounded (§1.4's
+# "live hole" — a wiped /tmp/claude then meant every pass tried all files, was
+# killed, wrote nothing, so the next pass was cold too: permanent 0). The fix
+# bounds even the FIRST pass to HIMMEL_STATUSLINE_BACKFILL_MAX, healing over
+# successive passes — and `pending` (§3.5) must decrease monotonically to 0
+# as those passes land.
+TMPDIR_COLD=$(mktemp -d)
+COLD_PROJ="$TMPDIR_COLD/.claude/projects"; mkdir -p "$COLD_PROJ"
+for n in 1 2 3 4 5; do
+    mkdir -p "$COLD_PROJ/p$n"
+    echo '{"type":"assistant","message":{"id":"cold'"$n"'","usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":1,"cache_read_input_tokens":'"$((n*100))"'}}}' > "$COLD_PROJ/p$n/f.jsonl"
+done
+COLD_CACHE="$TMPDIR_COLD/cache.json"; COLD_INDEX="$TMPDIR_COLD/index.json"
+HIMMEL_STATUSLINE_BACKFILL_MAX=2 rebuild_all_sessions_index "$COLD_PROJ" "$COLD_CACHE" "$COLD_INDEX" || true
+assert_eq "cold start pass 1: bounded to BACKFILL_MAX (2 of 5 files), not all paths" \
+    "$(jq -r 'length' "$COLD_INDEX" 2>/dev/null)" "2"
+assert_eq "cold start pass 1: pending = 3 remaining unindexed files" \
+    "$(jq -r '.pending' "$COLD_CACHE" 2>/dev/null)" "3"
+
+HIMMEL_STATUSLINE_BACKFILL_MAX=2 rebuild_all_sessions_index "$COLD_PROJ" "$COLD_CACHE" "$COLD_INDEX" || true
+assert_eq "cold start pass 2: another bounded slice (4 of 5 total)" \
+    "$(jq -r 'length' "$COLD_INDEX" 2>/dev/null)" "4"
+assert_eq "cold start pass 2: pending decreases monotonically (3 -> 1)" \
+    "$(jq -r '.pending' "$COLD_CACHE" 2>/dev/null)" "1"
+
+HIMMEL_STATUSLINE_BACKFILL_MAX=2 rebuild_all_sessions_index "$COLD_PROJ" "$COLD_CACHE" "$COLD_INDEX" || true
+assert_eq "cold start pass 3: fully healed (5 of 5), never scanned all-at-once" \
+    "$(jq -r 'length' "$COLD_INDEX" 2>/dev/null)" "5"
+assert_eq "cold start pass 3: pending reaches 0" \
+    "$(jq -r '.pending' "$COLD_CACHE" 2>/dev/null)" "0"
+rm -rf "$TMPDIR_COLD"
+
+# ── HIMMEL-1300: CRLF — the known-set pipeline classifies an already-known
+# path as NOT missing ────────────────────────────────────────────────────────
+# The backfill's known-set query pipes jq output through `sort -u` / `comm
+# -23`; a native-Windows jq emits CRLF line endings, and without `tr -d '\r'`
+# every line keeps a trailing \r that `comm -23` never matches against the
+# CR-less `find` output — so EVERY known path looks "missing" and gets
+# needlessly re-scanned every pass. This machine's jq is exactly that
+# CRLF-emitting build (verified: jq -r '.a' | xxd shows a trailing 0d0a), so
+# this test exercises the real bug class, not just its logic in the abstract.
+TMPDIR_CRLF=$(mktemp -d)
+CRLF_PROJ="$TMPDIR_CRLF/.claude/projects"; mkdir -p "$CRLF_PROJ/p"
+CRLF_FILE="$CRLF_PROJ/p/f.jsonl"
+echo '{"type":"assistant","message":{"id":"crlf1","usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":1,"cache_read_input_tokens":123}}}' > "$CRLF_FILE"
+CRLF_CACHE="$TMPDIR_CRLF/cache.json"; CRLF_INDEX="$TMPDIR_CRLF/index.json"
+sleep 1
+rebuild_all_sessions_index "$CRLF_PROJ" "$CRLF_CACHE" "$CRLF_INDEX" || true
+assert_eq "CRLF setup: file indexed at v=2, reads=123" "$(jq -r '.reads' "$CRLF_CACHE" 2>/dev/null)" "123"
+
+# Modify content but PRESERVE the old (pre-index) mtime — not -newer. A known
+# (v=2) path must classify as NOT missing regardless.
+CRLF_REF=$(mktemp); touch -r "$CRLF_FILE" "$CRLF_REF"
+echo '{"type":"assistant","message":{"id":"crlf2","usage":{"input_tokens":9,"output_tokens":9,"cache_creation_input_tokens":9,"cache_read_input_tokens":999}}}' > "$CRLF_FILE"
+touch -r "$CRLF_REF" "$CRLF_FILE"
+rm -f "$CRLF_REF"
+
+rebuild_all_sessions_index "$CRLF_PROJ" "$CRLF_CACHE" "$CRLF_INDEX" || true
+assert_eq "CRLF: known v=2 path classified as NOT missing (sums stay 123, not needlessly re-scanned to 999)" \
+    "$(jq -r '.reads' "$CRLF_CACHE" 2>/dev/null)" "123"
+rm -rf "$TMPDIR_CRLF"
 
 echo ""; echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Three changes to the CR ledger and the statusline economics layer. Common theme: the review loop could not see what it was spending, and could not correct what it had recorded.

## 1. Economics dedup — the HUD over-counted by 1.84x

The statusline economics rows over-counted cache and input tokens because the bash layer never deduped Claude Code's dual-logged assistant messages. Measured inflation on a real transcript: **1.84x** — the `all` row read `r:35.2B` against a true ~19B.

The vendored TS renderer already deduped by `message.id`; the bash layer never got the equivalent fix.

Historical figures are **re-migrated**, not just corrected going forward — past numbers had to become right, which is what forced a re-migration design rather than a one-line patch.

## 2. `amend` — one mis-recorded finding could wedge a branch permanently

The CR ledger was append-only with no way to correct a record, and the gate had no category for a finding that is *real but out of scope*. Together, a single mis-recorded finding could wedge a branch with no sanctioned way for the session to fix it: the marker-clearing step refuses, the marker hook hard-blocks PR creation, a ledger-rewrite script reads as gate tampering, and direct editing is refused because the ledger lives under the primary checkout's `.git/`.

Corrections now arrive as an **appended supersede record**, so the ledger stays append-only and the correction is itself auditable. The marker-clearing step applies amends before judging, so a correction actually takes effect. It resolves a target *through* prior amends — a re-key leaves the original row reading the old head, so after moving a finding A→B the only head an operator can see is B, and rejecting that would be a dead end.

Plus a tracked deferral category for findings that are genuine but out of scope, so they are recorded rather than silently dropped or forced.

## 3. `cr-scores --by-branch` — attribute review spend per branch

The fix-then-re-review loop treats a shared, rate-limited, slowly-renewing resource as if it were free. One PR ran **twelve rounds** before anyone could say how many review calls that had been, because every table in `cr-scores.sh` is per-model and cumulative.

No new record kind was needed. The availability record already carries `branch` + `model` and is written once per `(head, model)`, and every round produces a new head — so the **row count for a `(branch, model)` pair is the number of calls that lane made on that PR**, and the distinct heads are the rounds.

This ships **the measurement leg only**. The other legs each encode a *policy*, which is the operator's to choose; they are written up as recommendations instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branch-level review-spend reporting, including calls, rounds, failures, and estimated tokens.
  * Added support for tracking and deferring out-of-scope review findings with required tickets and reasons.
  * Statusline now displays expanded cache and token totals, including outputs and pending rebuild status.

* **Bug Fixes**
  * Improved transcript deduplication to prevent inflated usage totals.
  * Cache indexes now recover more reliably from interruptions, failures, stale locks, and partial rebuilds.
  * Review gates now apply finding corrections accurately and reject incomplete deferrals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->