### PR TITLE
fix: teach the Telegram operator floor about anonymous group admins

### DIFF
--- a/scripts/observability/install-stack.ps1
+++ b/scripts/observability/install-stack.ps1
@@ -258,10 +258,11 @@ Register-LogonTask `
   -WorkingDirectory $grafanaHome `
   -StartupDelay 'PT3M'
 
+# HIMMEL-1161: disable the 'service' collector — it leaks kernel handles (paged pool) every scrape.
 Register-LogonTask `
   -TaskName 'himmel-observability-windows-exporter' `
   -Execute $windowsExporterExe `
-  -Arguments "--web.listen-address=127.0.0.1:9182" `
+  -Arguments "--web.listen-address=127.0.0.1:9182 --collectors.disabled=service" `
   -WorkingDirectory $stateRoot
 
 Register-LogonTask `

--- a/scripts/observability/install-stack.ps1
+++ b/scripts/observability/install-stack.ps1
@@ -258,11 +258,10 @@ Register-LogonTask `
   -WorkingDirectory $grafanaHome `
   -StartupDelay 'PT3M'
 
-# HIMMEL-1161: disable the 'service' collector — it leaks kernel handles (paged pool) every scrape.
 Register-LogonTask `
   -TaskName 'himmel-observability-windows-exporter' `
   -Execute $windowsExporterExe `
-  -Arguments "--web.listen-address=127.0.0.1:9182 --collectors.disabled=service" `
+  -Arguments "--web.listen-address=127.0.0.1:9182" `
   -WorkingDirectory $stateRoot
 
 Register-LogonTask `

--- a/scripts/telegram/README.md
+++ b/scripts/telegram/README.md
@@ -135,6 +135,72 @@ replies route back to that chat — the operator DM is untouched. Ticket verbs
 replies go to whichever chat FIRST created that session. Non-allowed groups
 fail closed.
 
+### Posting with "Remain anonymous" on (HIMMEL-1358)
+
+When a group ADMIN posts with Telegram's **Remain anonymous** switch on, Telegram
+strips the real sender and substitutes the fixed `GroupAnonymousBot` id
+`1087968824`. Your own id never reaches the bridge, so the triage **operator
+floor** (which keeps an operator message out of the cheap-triage drop path) can
+never match it — your messages get classified `ignore`/`ack` and are dropped
+permanently, with only a `[poller] triage ignore: dropped (never enqueued)` line
+in `supervisor.log` to show for it. That is not a bridge outage; the bridge is
+healthy and discarding the messages.
+
+Opt the group in per-group — allow-listing alone deliberately does **not** do
+this:
+
+```json
+"groups": { "-1009999999": { "trustAnonymousAdmins": true } }
+```
+
+**What you are trusting.** The anonymous id is shared by EVERY admin of that
+chat, so this says "any admin here may speak as me". Set it only where you
+control the admin list.
+
+Be precise about what the flag does and does not change, because the honest
+answer is not "triage only":
+
+- It does **not** grant any new capability. Allow-listing the group already lets
+  every member submit work to the bridge (see the trust warning below), and
+  `run-prompt.md` frames pending messages as the operator's requests regardless
+  of who sent them (tracked as HIMMEL-1359). What the flag changes is narrower
+  than "gets answered": an opted-in group's anonymous posts are guaranteed to be
+  **enqueued** rather than subject to the classifier's ignore/ack verdict.
+  Ordinary group messages stay fully triaged, and an enqueued message still waits
+  if that session is already running — enqueue is the guarantee, not an immediate
+  run. The verdict it bypasses was never a security boundary either: the triage
+  gate is a cost filter and is fail-open (a classifier error returns spawn-high).
+- It is **not** wired into the `/arm` auto-command surface. An anonymous `/arm`
+  is refused by `autoGate.authorize` and falls through to ordinary chat, because
+  an anonymous post cannot distinguish you from a co-admin.
+
+**If the group also has a per-group `allowFrom`, the flag alone is not enough.**
+A non-empty per-group `allowFrom` restricts senders at INGEST — before any
+triage runs — and the substituted `1087968824` is not your real id, so an
+anonymous post is rejected there and the floor never sees it. That rejection is
+correct (the restriction is deliberate and this flag must not quietly undo it),
+but it means a restrictively-configured group still loses anonymous posts
+silently. To admit them, add `1087968824` to that group's `allowFrom` as well:
+
+```json
+"groups": { "-1009999999": { "allowFrom": ["<your-id>", "1087968824"], "trustAnonymousAdmins": true } }
+```
+
+Understand what that costs: the id is shared, so listing it admits the anonymous
+posts of **every** admin of that chat — the same trust statement
+`trustAnonymousAdmins` makes, now also at the ingest gate. If you are not willing
+to make it, the alternative is to turn "Remain anonymous" off for that group.
+
+**Deploying it:** `access.json` is read at poller startup, so the flag takes
+effect only after a bridge restart —
+`pwsh -File scripts/telegram/restart-bridge.ps1`. Verify with a real post from
+that group: `supervisor.log` should show
+`[poller] triage <verdict> → spawn-low (operator floor) for group_<chat_id>`, or
+no triage line at all if the classifier already said spawn. A fresh
+`dropped (never enqueued)` line means the flag did not take — check that the
+chat_id key matches exactly (including the leading `-`) and that the restart
+actually reloaded.
+
 **Trust warning:** allowing a group trusts EVERY member of it — any member
 can drive the bridge: chat text spawns bounded claude runs (prompt-injection
 risk), and `work on <TICKET>` / `stop <TICKET>` verbs dispatch/halt ticket

--- a/scripts/telegram/gate.test.ts
+++ b/scripts/telegram/gate.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { isAllowed, isGroupAllowed, vaultForChat } from "./gate";
+import { GROUP_ANONYMOUS_BOT_ID, isAllowed, isGroupAllowed, isOperatorIdentity, vaultForChat } from "./gate";
 
 // Real access.json shape (~/.claude/channels/telegram/access.json):
 //   { "dmPolicy": "allowlist", "allowFrom": ["1000000001"], "groups": {}, "pending": {} }
@@ -61,6 +61,98 @@ test("isGroupAllowed: empty/missing per-group allowFrom admits any member; requi
   // parse entities, so requireMention has no effect here
   expect(isGroupAllowed({ groups: { "-50": { allowFrom: [] } } }, -50, 999)).toBe(true);
   expect(isGroupAllowed({ groups: { "-50": { requireMention: true } } }, -50, 999)).toBe(true);
+});
+
+// --- operator identity, including anonymous group admins (HIMMEL-1358) ---
+// When a group admin posts with "Remain anonymous" on, Telegram replaces the
+// sender with the fixed GroupAnonymousBot id, so the operator's real id never
+// reaches us and a raw allowFrom comparison can never match. Measured live:
+// every message from the affected group carried 1087968824, while the same
+// sender's DMs carried their real id. Fixtures below are synthetic.
+
+const OPTED_IN = { allowFrom: ["1000000001"], groups: { "-1009999999": { trustAnonymousAdmins: true } } };
+
+test("isOperatorIdentity: the anonymous-admin id is operator in an opted-in group (HIMMEL-1358)", () => {
+  expect(isOperatorIdentity(OPTED_IN, 1000000001, -1009999999)).toBe(true);              // named post
+  expect(isOperatorIdentity(OPTED_IN, GROUP_ANONYMOUS_BOT_ID, -1009999999)).toBe(true);  // anonymous post
+  expect(isOperatorIdentity(OPTED_IN, "1087968824", "-1009999999")).toBe(true);          // string ids too
+});
+
+// The codex adversarial CR's finding, pinned: the anonymous id is shared by
+// EVERY admin of the chat, so allow-listing a group (which only means "ingest
+// this chat") must NOT by itself promote its admins to operator. The opt-in is
+// what says that out loud, per group.
+test("isOperatorIdentity: allow-listing alone does NOT trust anonymous admins (HIMMEL-1358)", () => {
+  const noOptIn = { allowFrom: ["1000000001"], groups: { "-1009999999": {} } };
+  expect(isOperatorIdentity(noOptIn, GROUP_ANONYMOUS_BOT_ID, -1009999999)).toBe(false);
+  expect(isOperatorIdentity(noOptIn, 1000000001, -1009999999)).toBe(true);   // named post is unaffected
+  // an explicit false is the same as absent
+  const optedOut = { allowFrom: ["1000000001"], groups: { "-1009999999": { trustAnonymousAdmins: false } } };
+  expect(isOperatorIdentity(optedOut, GROUP_ANONYMOUS_BOT_ID, -1009999999)).toBe(false);
+});
+
+// Telegram's sender_chat is the authoritative "which chat does this post
+// represent". Where it is supplied it must BE the destination chat, so the floor
+// no longer rests on inferring that 1087968824 here means an admin of here.
+// Absent is permitted on purpose — see the note on isOperatorIdentity.
+test("isOperatorIdentity: a mismatched sender_chat is refused; matching and absent pass (HIMMEL-1358)", () => {
+  expect(isOperatorIdentity(OPTED_IN, GROUP_ANONYMOUS_BOT_ID, -1009999999, -1009999999)).toBe(true);   // matches
+  expect(isOperatorIdentity(OPTED_IN, GROUP_ANONYMOUS_BOT_ID, -1009999999, "-1009999999")).toBe(true); // string form
+  expect(isOperatorIdentity(OPTED_IN, GROUP_ANONYMOUS_BOT_ID, -1009999999, -777)).toBe(false);         // some OTHER chat
+  expect(isOperatorIdentity(OPTED_IN, GROUP_ANONYMOUS_BOT_ID, -1009999999, undefined)).toBe(true);     // absent → allowed
+  expect(isOperatorIdentity(OPTED_IN, GROUP_ANONYMOUS_BOT_ID, -1009999999, null)).toBe(true);          // null → allowed
+  // the named-identity path is unaffected by sender_chat entirely
+  expect(isOperatorIdentity(OPTED_IN, 1000000001, -1009999999, -777)).toBe(true);
+});
+
+test("isOperatorIdentity: the anonymous-admin id is NOT operator outside its opted-in group (HIMMEL-1358)", () => {
+  expect(isOperatorIdentity(OPTED_IN, GROUP_ANONYMOUS_BOT_ID, -50)).toBe(false);            // unlisted group
+  expect(isOperatorIdentity(OPTED_IN, GROUP_ANONYMOUS_BOT_ID, 1087968824)).toBe(false);     // positive chat_id (DM)
+  expect(isOperatorIdentity(OPTED_IN, 9, -1009999999)).toBe(false);                      // ordinary member
+});
+
+// The narrower gate wins, deliberately: trustAnonymousAdmins must not quietly
+// undo a per-group allowFrom the operator set on purpose. The consequence — such
+// a group keeps losing anonymous posts (they are rejected at INGEST by
+// makeAllow, before triage) unless 1087968824 is added to that allowFrom too —
+// is a real trap and is documented in README.md rather than papered over here.
+test("isOperatorIdentity: a per-group allowFrom that excludes the anon id keeps it out (HIMMEL-1358)", () => {
+  const access = { allowFrom: ["5"], groups: { "-50": { allowFrom: ["9"], trustAnonymousAdmins: true } } };
+  expect(isOperatorIdentity(access, GROUP_ANONYMOUS_BOT_ID, -50)).toBe(false);
+  expect(isOperatorIdentity(access, 9, -50)).toBe(false);   // per-group member is not the operator (HIMMEL-1296)
+  expect(isOperatorIdentity(access, 5, -50)).toBe(true);    // global allowFrom identity still wins
+  // ...and listing the anon id in that allowFrom is what admits it (the README's escape hatch)
+  const listed = { allowFrom: ["5"], groups: { "-50": { allowFrom: ["9", "1087968824"], trustAnonymousAdmins: true } } };
+  expect(isOperatorIdentity(listed, GROUP_ANONYMOUS_BOT_ID, -50)).toBe(true);
+});
+
+// The anonymous branch is a SUBSTITUTION rule — "Telegram replaced the
+// operator's id" — so it is meaningless where no operator identity is
+// configured at all. With an empty/absent global allowFrom nobody is the
+// operator, and the anon id must not become one by default.
+// A globally-listed anonymous id must not short-circuit past the group-scoped
+// guards (CodeRabbit CR). The id is not a person, so globally it means nothing —
+// and this misconfiguration is one indentation level away from the per-group
+// allowFrom entry the README now recommends.
+test("isOperatorIdentity: the anon id in the GLOBAL allowFrom grants nothing (HIMMEL-1358)", () => {
+  const misconfigured = { allowFrom: ["1000000001", "1087968824"], groups: { "-50": {} } };
+  expect(isOperatorIdentity(misconfigured, GROUP_ANONYMOUS_BOT_ID, -50)).toBe(false);        // no group opt-in
+  expect(isOperatorIdentity(misconfigured, GROUP_ANONYMOUS_BOT_ID, 12345)).toBe(false);      // and not in a DM
+  expect(isOperatorIdentity(misconfigured, GROUP_ANONYMOUS_BOT_ID, -1)).toBe(false);         // nor an unlisted group
+  // it still cannot skip sender_chat once a group DOES opt in
+  const optedIn = { allowFrom: ["1000000001", "1087968824"], groups: { "-50": { trustAnonymousAdmins: true } } };
+  expect(isOperatorIdentity(optedIn, GROUP_ANONYMOUS_BOT_ID, -50, -777)).toBe(false);
+  expect(isOperatorIdentity(optedIn, GROUP_ANONYMOUS_BOT_ID, -50, -50)).toBe(true);
+  // and a real operator id in the global allowFrom is unaffected
+  expect(isOperatorIdentity(misconfigured, 1000000001, -50)).toBe(true);
+});
+
+test("isOperatorIdentity: fails closed when no operator identity is configured (HIMMEL-1358)", () => {
+  expect(isOperatorIdentity({}, GROUP_ANONYMOUS_BOT_ID, -50)).toBe(false);
+  expect(isOperatorIdentity({ groups: { "-50": { trustAnonymousAdmins: true } } }, GROUP_ANONYMOUS_BOT_ID, -50)).toBe(false);
+  expect(isOperatorIdentity({ allowFrom: [], groups: { "-50": { trustAnonymousAdmins: true } } }, GROUP_ANONYMOUS_BOT_ID, -50)).toBe(false);
+  expect(isOperatorIdentity(null as any, 5, -50)).toBe(false);
+  expect(isOperatorIdentity(undefined as any, GROUP_ANONYMOUS_BOT_ID, -50)).toBe(false);
 });
 
 // --- per-group vault routing (HIMMEL-321) ---

--- a/scripts/telegram/gate.ts
+++ b/scripts/telegram/gate.ts
@@ -13,7 +13,11 @@ import { homedir } from "node:os";
 // vault (HIMMEL-321): an absolute Obsidian-vault path a document/PDF sent to
 // this chat is filed into. A group-level vault overrides the top-level
 // defaultVault (see vaultForChat).
-export type GroupPolicy = { requireMention?: boolean; allowFrom?: string[]; vault?: string };
+// trustAnonymousAdmins (HIMMEL-1358): opt in to treating this group's ANONYMOUS
+// posts as the operator's for the triage floor. Off by default and per-group,
+// because the anonymous sender id is shared by every admin of the chat — see
+// isOperatorIdentity.
+export type GroupPolicy = { requireMention?: boolean; allowFrom?: string[]; vault?: string; trustAnonymousAdmins?: boolean };
 export type Access = { dmPolicy?: string; allowFrom?: string[]; groups?: Record<string, GroupPolicy>; defaultVault?: string };
 
 // Pure predicate. Fails CLOSED: missing/empty/malformed allowlist → false.
@@ -33,6 +37,63 @@ export function isGroupAllowed(access: Access | null | undefined, chatId: number
   const perGroup = groups[String(chatId)]?.allowFrom;
   if (Array.isArray(perGroup) && perGroup.length > 0) return fromId != null && perGroup.includes(String(fromId));
   return true;
+}
+
+// Telegram's fixed GroupAnonymousBot id. When a group ADMIN posts with "Remain
+// anonymous" enabled, Telegram strips the real sender and substitutes this id
+// for every such message; it is a documented platform constant, not an account
+// anyone can sign in as. A non-admin cannot post anonymously, so inside a given
+// chat this id means exactly "an admin of this chat".
+export const GROUP_ANONYMOUS_BOT_ID = 1087968824;
+
+// Is this sender the OPERATOR, for the purposes of the triage operator floor
+// (poller.ts handleInbound)? Two ways to be:
+//   1. the global allowFrom identity — unchanged HIMMEL-1296 semantics;
+//   2. the anonymous-admin substitute id, in a group that has OPTED IN via
+//      `trustAnonymousAdmins`.
+// (2) exists because the operator posts in his own groups with "Remain
+// anonymous" on, so his real id NEVER reaches us and (1) can never match — his
+// messages were classified `ignore` and permanently dropped (HIMMEL-1358).
+//
+// Why the explicit per-group opt-in rather than "any allow-listed group" (codex
+// adversarial CR): the anonymous id is shared by EVERY admin of the chat, so in
+// a multi-admin group mere allow-listing would silently promote all of them.
+// Allow-listing means "ingest this chat's messages"; it does not mean "every
+// admin here speaks for me". `trustAnonymousAdmins: true` is the operator
+// saying the second part out loud, per group. It stacks ON TOP of the other
+// conditions, never replaces them — the chat must still be a negative-id,
+// allow-listed group, and there must still be a configured operator identity,
+// since the anon branch is a SUBSTITUTION rule and an empty allowFrom leaves
+// no one for it to be substituting for.
+//
+// This governs the triage floor ONLY. It is deliberately NOT wired into
+// autoGate.authorize: the floor's worst case is spawning on chatter, whereas
+// /arm grants powers, and an anonymous post cannot distinguish the operator
+// from any other admin of that group even with the opt-in set.
+// senderChatId: Telegram's `sender_chat` — for an on-behalf-of-chat message,
+// the chat the post actually represents. When Telegram supplies it, the
+// anonymous branch REQUIRES it to be the destination chat, so the floor rests on
+// Telegram's own authoritative identity rather than on inferring "1087968824
+// here must mean an admin of here" (codex adversarial CR).
+// Absent (`undefined`/`null`) does NOT block: these fields come from Telegram's
+// servers, not the client, so an attacker cannot suppress one — while REQUIRING
+// it would silently re-break the exact drop this ticket exists to fix on any
+// update shape that legitimately omits it. Present-and-mismatched is the only
+// case that can be an impersonation, and it is the case this rejects.
+export function isOperatorIdentity(access: Access | null | undefined, fromId: number | string, chatId: number | string, senderChatId?: number | string | null): boolean {
+  // The anonymous id NEVER wins via the global allowFrom (CodeRabbit CR). It is
+  // not a person, so globally it means nothing — and letting it short-circuit
+  // here would grant operator status in ANY chat, skipping every group-scoped
+  // guard below. Reachable by a plausible misconfiguration now that the README
+  // tells operators to put 1087968824 in a group's allowFrom: putting it in the
+  // TOP-LEVEL allowFrom instead is one indentation level away.
+  const isAnonymous = String(fromId) === String(GROUP_ANONYMOUS_BOT_ID);
+  if (!isAnonymous) return isAllowed(access, fromId);
+  const allow = access?.allowFrom;
+  if (!Array.isArray(allow) || allow.length === 0) return false;
+  if (access?.groups?.[String(chatId)]?.trustAnonymousAdmins !== true) return false;
+  if (senderChatId != null && String(senderChatId) !== String(chatId)) return false;
+  return Number(chatId) < 0 && isGroupAllowed(access, chatId, fromId);
 }
 
 // Resolve the vault a document sent to `chatId` is filed into (HIMMEL-321):

--- a/scripts/telegram/poller.test.ts
+++ b/scripts/telegram/poller.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { readNewLines, readMeta, writeMeta, ensureSession, appendLine, sessionDir } from "./bus";
 import { ingestUpdates, loadOffset, handleInbound, handleAutoCommand, replyViaOutbox, runAndSettle, reconcile, flushOutboxes, isRetryDue, peekPending, commitPending, makeRunFn, makeAllow, makeDispatcher, makeFetchVoice, sweepStuckRunning, signalTyping, guarded, deliverAllPending, sweepAttachments, resolveRetentionMs, noticeText, parseBridgeEnv, loadBridgeEnv, bridgeEnvOrigin, makeRestart, makeBurstCoalescer, intervalEnvMs, windowEnvMs, handleBatch, RESTART_WATCHDOG_MS, type FetchImageFn } from "./poller";
 import { readFile, writeFile, mkdir, utimes } from "node:fs/promises";
-import { isAllowed, vaultForChat } from "./gate";
+import { GROUP_ANONYMOUS_BOT_ID, isAllowed, isOperatorIdentity, vaultForChat } from "./gate";
 import { describeEnabledOps, KNOWN_OPS } from "./auto-action";
 import type { TriageVerdict } from "./triage";
 
@@ -718,6 +718,95 @@ test("operator floor keys on GLOBAL allowFrom: a per-group allowFrom member is s
   await handleInbound(rOp, { from:5, chat_id:-50, text:"try again.." },
     async (s:string) => { opRan.push(s); }, undefined, ignoreTriage, isOperator);
   expect(opRan).toEqual(["group_-50"]);                // operator: floored, never dropped
+});
+
+// HIMMEL-1358 — an operator posting in a group with "Remain anonymous" enabled
+// has GroupAnonymousBot substituted for their real id, so a floor keyed on raw
+// from.id could never match. The links were classified `ignore` and hit the
+// PERMANENT drop with only a supervisor.log line to show for it. Composes the
+// REAL production predicate (what main() passes), not a mock — the wiring is the
+// thing that was wrong. Ids below are synthetic.
+test("an anonymous group admin reaches the spawn floor, not the drop path (HIMMEL-1358)", async () => {
+  const access = { allowFrom: ["1000000001"], groups: { "-1009999999": { trustAnonymousAdmins: true } } };
+  const isOperator = (from: number, chat_id: number) => isOperatorIdentity(access, from, chat_id);
+  const ignoreTriage = async (): Promise<TriageVerdict> => "ignore";
+
+  const r = root(); const ran: string[] = [];
+  await handleInbound(r, { from: GROUP_ANONYMOUS_BOT_ID, chat_id: -1009999999, text: "https://example.com/a" },
+    async (s: string) => { ran.push(s); }, undefined, ignoreTriage, isOperator);
+
+  expect(ran).toEqual(["group_-1009999999"]);
+  expect((await peekPending(r, "group_-1009999999")).count).toBe(1);   // durable, not dropped
+});
+
+// End-to-end, ingest → handler (codex adversarial CR asked for exactly this):
+// Telegram's sender_chat says which chat an on-behalf-of-chat post represents.
+// A post carrying the anonymous sender id but a sender_chat that is NOT the
+// destination chat is a different trust principal and must stay triaged — and
+// the check is only reachable if ingest actually PRESERVES the field, which is
+// why this drives the real ingestUpdates rather than hand-building the message.
+test("ingest preserves sender_chat, and a mismatched one is not floored (HIMMEL-1358)", async () => {
+  const access = { allowFrom: ["1000000001"], groups: { "-1009999999": { trustAnonymousAdmins: true } } };
+  const isOperator = (from: number, chat_id: number, sender_chat?: number) => isOperatorIdentity(access, from, chat_id, sender_chat);
+  const ignoreTriage = async (): Promise<TriageVerdict> => "ignore";
+
+  const r = root();
+  await ingestUpdates(r, [
+    { update_id: 1, message: { chat: { id: -1009999999 }, from: { id: GROUP_ANONYMOUS_BOT_ID },
+                               sender_chat: { id: -1009999999 }, text: "genuine anonymous admin post" } },
+    { update_id: 2, message: { chat: { id: -1009999999 }, from: { id: GROUP_ANONYMOUS_BOT_ID },
+                               sender_chat: { id: -777 }, text: "on behalf of some OTHER chat" } },
+  ], allowAll);
+  const lines = await readNewLines(join(r, "inbound.jsonl"), join(r, "inbound.jsonl.cursor"));
+  expect(lines.length).toBe(2);
+  expect(lines[0].sender_chat).toBe(-1009999999);   // preserved, not merely used as the fromId fallback
+  expect(lines[1].sender_chat).toBe(-777);
+
+  const ran: string[] = [];
+  for (const l of lines) {
+    await handleInbound(root(), { from: l.from, chat_id: l.chat_id, text: l.text, ts: l.ts, sender_chat: l.sender_chat },
+      async (s: string) => { ran.push(`${l.update_id}:${s}`); }, undefined, ignoreTriage, isOperator);
+  }
+  expect(ran).toEqual(["1:group_-1009999999"]);     // matching floored; mismatched dropped
+});
+
+// sender_chat is spread into all FOUR ingest branches, and the media ones append
+// their record only AFTER the download settles (`{ ...rec, ...path }`), so the
+// field survives by construction rather than by an explicit copy. Pin the two
+// that go through that post-download finalization (panel CR glm-1) — the plain
+// text path is covered above, and voice shares the ready.push shape.
+test("ingest preserves sender_chat through the post-download media branches (HIMMEL-1358)", async () => {
+  const r = root();
+  const fetchDoc = async () => "/tmp/att/1.pdf";
+  const fetchImg: FetchImageFn = async () => "/tmp/att/2.jpg";
+  await ingestUpdates(r, [
+    { update_id: 1, message: { chat: { id: -1009999999 }, from: { id: GROUP_ANONYMOUS_BOT_ID },
+                               sender_chat: { id: -1009999999 }, caption: "a pdf",
+                               document: { file_id: "d1", file_name: "x.pdf" } } },
+    { update_id: 2, message: { chat: { id: -1009999999 }, from: { id: GROUP_ANONYMOUS_BOT_ID },
+                               sender_chat: { id: -1009999999 }, caption: "a photo",
+                               photo: [{ file_id: "p1" }] } },
+  ], allowAll, undefined, fetchImg, fetchDoc);
+  const lines = await readNewLines(join(r, "inbound.jsonl"), join(r, "inbound.jsonl.cursor"));
+  expect(lines.length).toBe(2);
+  expect(lines.map((l) => l.sender_chat)).toEqual([-1009999999, -1009999999]);
+});
+
+// The scope guard on the rescue above: the anon id only means "an admin of THIS
+// group" where the operator opted that group in. Anywhere else it is an unknown
+// sender and stays fully triaged, so the floor cannot be reached by posting
+// anonymously in an arbitrary chat.
+test("the anonymous-admin id is still triaged in a non-opted-in group (HIMMEL-1358)", async () => {
+  const access = { allowFrom: ["1000000001"], groups: { "-1009999999": { trustAnonymousAdmins: true } } };
+  const isOperator = (from: number, chat_id: number) => isOperatorIdentity(access, from, chat_id);
+
+  const r = root(); const ran: string[] = [];
+  await handleInbound(r, { from: GROUP_ANONYMOUS_BOT_ID, chat_id: -50, text: "lol nice" },
+    async (s: string) => { ran.push(s); }, undefined,
+    async (): Promise<TriageVerdict> => "ignore", isOperator);
+
+  expect(ran).toEqual([]);
+  expect(await readMeta(r, "group_-50")).toBeNull();
 });
 
 // A dispatch failure happens AFTER the message is durable, so it must not

--- a/scripts/telegram/poller.ts
+++ b/scripts/telegram/poller.ts
@@ -5,7 +5,7 @@ import { appendLine, atomicWrite, bridgeRoot, ensureSession, readMeta, writeMeta
 import { classify, type Route } from "./router";
 import { dispatchAutoAction, describeEnabledOps, KNOWN_OPS, appendAuditLine, type RunScriptFn, type AuditFields } from "./auto-action";
 import { getUpdates, sendMessage, sendChatAction, getFile, downloadFile } from "./telegram-api";
-import { isAllowed, isGroupAllowed, loadAccess, vaultForChat, type Access } from "./gate";
+import { isAllowed, isGroupAllowed, isOperatorIdentity, loadAccess, vaultForChat, type Access } from "./gate";
 import { runSession, buildPrompt, BASH_BIN, type BusPaths, type PermissionMode } from "./run";
 import { classifyForSpawn, type TriageVerdict, type TriageModelOverride } from "./triage";
 import { transcribe } from "./transcribe";
@@ -27,7 +27,7 @@ const RETRY_MS = Number(process.env.TELEGRAM_RETRY_MS ?? 15 * 60 * 1000);
 // present (the injection-refuse signal). `caption` = the text came from a media caption
 // or voice transcript, NOT a genuinely typed m.text. Both fail toward "not a typed
 // command" so an undefined-deserialized value can never fail OPEN.
-export type Inbound = { from: number; chat_id: number; text: string; ts: number; update_id: number; forwarded: boolean; caption: boolean; image_path?: string; document_path?: string; document_name?: string };
+export type Inbound = { from: number; chat_id: number; text: string; ts: number; update_id: number; sender_chat?: number; forwarded: boolean; caption: boolean; image_path?: string; document_path?: string; document_name?: string };
 export type AllowFn = (fromId: number, chatId: number) => boolean;
 // Downloads a photo by file_id, returns the local path (null on failure).
 export type FetchImageFn = (file_id: string, update_id: number) => Promise<string | null>;
@@ -160,6 +160,11 @@ export async function ingestUpdates(root: string, updates: any[], allow: AllowFn
     if (!hasText && !photo && !voice && !doc) continue;
     // channel posts have no `from` (anonymous) — fall back to sender_chat (the channel itself)
     const fromId = m.from?.id ?? m.sender_chat?.id ?? 0;
+    // PRESERVED, not just used as the fromId fallback (HIMMEL-1358, codex CR):
+    // for an on-behalf-of-chat message this is the chat Telegram says the post
+    // actually represents, and the anonymous-admin operator floor checks it
+    // against the destination chat. Undefined for an ordinary user post.
+    const senderChat = m.sender_chat?.id;
     if (!allow(fromId, chatId)) {                          // gated out (offset still advances below)
       // log non-DM rejects so the operator can discover a new group/channel chat_id
       if (chatId < 0) console.error(`[poller] gated out chat ${chatId} (add to groups in access.json to allow)`);
@@ -194,14 +199,14 @@ export async function ingestUpdates(root: string, updates: any[], allow: AllowFn
         text = (caption ? caption + "\n" : "") + "[voice transcript] " + transcript;
       }
       // caption:true — a voice transcript is never a typed command (auto-ineligible).
-      ready.push({ from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id, forwarded, caption: true });
+      ready.push({ from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id, forwarded, caption: true, ...(senderChat != null ? { sender_chat: senderChat } : {}) });
     } else if (doc && fetchDoc) {
       // Document (e.g. PDF) — same concurrent, time-bounded download as photos (HIMMEL-321).
       const docName = typeof doc.file_name === "string" ? doc.file_name : "file";
       text = caption || `[document: ${docName}]`;
       const downloadP = fetchDoc(doc.file_id, u.update_id, docName)
         .catch((e: unknown) => { console.error(`[poller] document download failed for update ${u.update_id}: ${e}`); return null; });
-      pendingDocs.push({ rec: { from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id, document_name: docName, forwarded, caption: true }, p: downloadP });
+      pendingDocs.push({ rec: { from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id, document_name: docName, forwarded, caption: true, ...(senderChat != null ? { sender_chat: senderChat } : {}) }, p: downloadP });
     } else if (photo && fetchImage) {
       // Start the download immediately (after allow gate) but do NOT await it here —
       // downloads run concurrently across the batch (HIMMEL-266); each one is
@@ -209,7 +214,7 @@ export async function ingestUpdates(root: string, updates: any[], allow: AllowFn
       text = caption || "[photo]";
       const downloadP = fetchImage(photo.file_id, u.update_id)
         .catch((e: unknown) => { console.error(`[poller] photo download failed for update ${u.update_id}: ${e}`); return null; });
-      pendingPhotos.push({ rec: { from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id, forwarded, caption: true }, p: downloadP });
+      pendingPhotos.push({ rec: { from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id, forwarded, caption: true, ...(senderChat != null ? { sender_chat: senderChat } : {}) }, p: downloadP });
     } else {
       // plain text, or photo/document with no fetch fn wired (forward caption text only)
       text = photo ? (caption || "[photo]")
@@ -217,7 +222,7 @@ export async function ingestUpdates(root: string, updates: any[], allow: AllowFn
            : m.text;
       // caption:true iff the text came from a media caption (photo/doc present), else it
       // is a genuinely typed m.text (caption:false) — the only auto-command-eligible shape.
-      ready.push({ from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id, forwarded, caption: !!(photo || doc) });
+      ready.push({ from: fromId, chat_id: chatId, text, ts: m.date ?? 0, update_id: u.update_id, forwarded, caption: !!(photo || doc), ...(senderChat != null ? { sender_chat: senderChat } : {}) });
     }
   }
   // Write all non-photo inbox entries.
@@ -259,7 +264,7 @@ export async function ingestUpdates(root: string, updates: any[], allow: AllowFn
   if (maxId >= offset) await saveOffset(root, maxId + 1);
 }
 
-export type DeliveredMsg = { from: number; chat_id: number; text: string; ts?: number; forwarded?: boolean; caption?: boolean; image_path?: string; document_path?: string; document_name?: string };
+export type DeliveredMsg = { from: number; chat_id: number; text: string; ts?: number; sender_chat?: number; forwarded?: boolean; caption?: boolean; image_path?: string; document_path?: string; document_name?: string };
 export type RunFn = (session: string, modelOverride?: TriageModelOverride) => Promise<void>;
 // fromOperator selects the classifier's prompt framing (HIMMEL-1296 CR
 // codex-adv-1) — operator framing must not be told to a shared group's ordinary
@@ -271,7 +276,11 @@ export type TriageFn = (text: string, sessionLabel?: string, fromOperator?: bool
 // triage floor below is what keeps an operator message out of the drop path,
 // and it must not silently die if the /arm surface is ever disabled or rewired
 // (HIMMEL-1296).
-export type OperatorFn = (fromId: number) => boolean;
+// Takes the CHAT as well as the sender (HIMMEL-1358): an anonymous group-admin
+// post carries GroupAnonymousBot instead of the operator's real id, so identity
+// there is only decidable relative to the chat it was posted in. See
+// gate.ts isOperatorIdentity for the rule.
+export type OperatorFn = (fromId: number, chatId: number, senderChatId?: number) => boolean;
 
 // Auto-command gate (HIMMEL-424 B2). `fire` is FIRE-AND-FORGET so a slow arm never
 // blocks the ingest loop; `enabledOps` is parsed from TELEGRAM_AUTO_ACTIONS (empty by
@@ -331,7 +340,7 @@ export async function handleInbound(root: string, msg: DeliveredMsg, run: RunFn,
   if (msg.chat_id < 0 && (route.kind === "chat" || route.kind === "auto") && process.env.TELEGRAM_TRIAGE !== "off") {
     // Resolved ONCE and used for both the classifier's framing and the floor —
     // they must agree on who the sender is.
-    const fromOperator = isOperator(msg.from);
+    const fromOperator = isOperator(msg.from, msg.chat_id, msg.sender_chat);
     const verdict = await triage(msg.text, session, fromOperator);
     // OPERATOR FLOOR (HIMMEL-1296). The drop above is for shared-group CHATTER;
     // HIMMEL-721 exists to cut resource spam, never to filter the operator. When
@@ -1591,13 +1600,16 @@ export async function main(): Promise<void> {
     // coalesce (not dispatch): each inbound RECORDS intent, so a same-tick burst
     // is one run even before the quiet window elapses — the intra-tick race the
     // ticket calls near-free to close (HIMMEL-1273).
-    // isOperator = global allowFrom identity only (HIMMEL-1296): a per-group
-    // allowFrom member is an ordinary group member and stays fully triaged.
+    // isOperator = global allowFrom identity (HIMMEL-1296): a per-group
+    // allowFrom member is an ordinary group member and stays fully triaged —
+    // plus the anonymous-admin substitute id in a group that opted in via
+    // `trustAnonymousAdmins` (HIMMEL-1358), which is the only form the
+    // operator's own posts take in a group he has "Remain anonymous" on for.
     // handleBatch, not a bare for-await: one record's I/O failure must not take
     // the rest of the already-consumed batch with it (HIMMEL-1296 CR).
     await handleBatch(
       fresh,
-      (i) => handleInbound(root, { from: i.from, chat_id: i.chat_id, text: i.text, ts: i.ts, forwarded: i.forwarded, caption: i.caption, image_path: i.image_path, document_path: i.document_path, document_name: i.document_name }, coalesce, autoGate, undefined, (from) => isAllowed(access, from)),
+      (i) => handleInbound(root, { from: i.from, chat_id: i.chat_id, text: i.text, ts: i.ts, sender_chat: i.sender_chat, forwarded: i.forwarded, caption: i.caption, image_path: i.image_path, document_path: i.document_path, document_name: i.document_name }, coalesce, autoGate, undefined, (from, chat_id, sender_chat) => isOperatorIdentity(access, from, chat_id, sender_chat)),
       // sendMessage, NOT replyViaOutbox (CR codex-adv-1 round 6): the outbox is
       // written INTO the same session directory whose failure caused the drop,
       // so on an unwritable session it fails too — and the bridge would then eat


### PR DESCRIPTION
fix: teach the Telegram operator floor about anonymous group admins

When a group admin posts with Telegram's "Remain anonymous" switch on, Telegram
strips the real sender and substitutes the fixed GroupAnonymousBot id
(1087968824). The triage operator floor compared that against access.json's
global allowFrom, never matched, and the classifier's `ignore` verdict on a bare
URL fell through to the PERMANENT drop in handleInbound — the message was never
enqueued and the only trace was one supervisor.log line. From the operator's
side this looks exactly like a dead bridge; the bridge is healthy and discarding
the messages.

isOperatorIdentity(access, fromId, chatId, senderChatId?) now recognises two
ways to be the operator: the global allowFrom identity (unchanged), or the
anonymous-admin substitute id under four stacked conditions — the group opted in
via the new per-group `trustAnonymousAdmins`, Telegram's sender_chat is the
destination chat, the chat_id is negative, and isGroupAllowed admits it.
OperatorFn grows the chat and sender-chat arguments, because an anonymous post is
only decidable relative to the chat it was posted in.

The opt-in is explicit and per-group on purpose: the anonymous id is shared by
every admin of a chat, so allow-listing (which means "ingest this chat") must not
by itself promote all of them. sender_chat is now preserved through ingest rather
than used only as a fallback for a missing from.id, so the anonymous branch rests
on Telegram's own authoritative identity instead of inferring one. Absent
sender_chat is permitted — those fields come from Telegram's servers, not the
client, so an attacker cannot suppress one, while requiring it would silently
re-break the very drop this fixes on any update shape that omits it. The
anonymous id also never resolves through the global allowFrom, where it would
skip every group-scoped guard.

Scoped to the triage floor only — deliberately not wired into the auto-command
authorization, since an anonymous post cannot distinguish the operator from a
co-admin.

README documents the symptom, the opt-in, what trusting it costs, the
interaction with a per-group allowFrom (which blocks the anonymous id at ingest,
before triage), and how to verify the deployment.

Regression fixtures were written against the pre-fix wiring first and reproduced
the incident's log line before passing: the anonymous-admin path reaching the
spawn floor via the real production predicate, the scope guard for a
non-opted-in group, the sender_chat mismatch driven end-to-end through the real
ingest, and sender_chat surviving the post-download media branches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for Telegram group admins posting with “Remain anonymous.”
  * Anonymous admin posts can now reach operator triage when explicitly enabled per group.
  * Preserved sender context for reliable identity checks, including media messages.

* **Documentation**
  * Added setup guidance, allow-list requirements, restart steps, and troubleshooting details for anonymous admin posts.

* **Bug Fixes**
  * Prevented eligible anonymous admin messages from being incorrectly dropped.
  * Rejected mismatched sender information and unconfigured anonymous identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->