### PR TITLE
fix: disable the windows_exporter service collector

### DIFF
--- a/scripts/observability/install-stack.ps1
+++ b/scripts/observability/install-stack.ps1
@@ -258,10 +258,11 @@ Register-LogonTask `
   -WorkingDirectory $grafanaHome `
   -StartupDelay 'PT3M'
 
+# HIMMEL-1161: disable the 'service' collector — it leaks kernel handles (paged pool) every scrape.
 Register-LogonTask `
   -TaskName 'himmel-observability-windows-exporter' `
   -Execute $windowsExporterExe `
-  -Arguments "--web.listen-address=127.0.0.1:9182" `
+  -Arguments "--web.listen-address=127.0.0.1:9182 --collectors.disabled=service" `
   -WorkingDirectory $stateRoot
 
 Register-LogonTask `


### PR DESCRIPTION
## What

Adds `--collectors.disabled=service` to the `himmel-observability-windows-exporter` logon task.

## Why

windows_exporter's `service` collector leaks **kernel handles into the paged pool** on every scrape. At the default scrape interval this accumulates steadily, and the pool is reclaimed only by restarting the host — restarting the exporter alone does not release it.

This is the same pathology class as the Dell/AWCC WMI pollers: a periodic WMI-backed enumerator that does not release what it opens.

## Scope

One line, one file. The service-state series is the only thing lost; every other collector is unaffected.

## Verification

Confirmed live on the affected machine — the exporter runs with the flag and holds a flat ~525 handles / ~20 MB, so it is no longer a contributor on that host.
