### PR TITLE
feat(cr): narrow disproved review classes, lint the mechanical ones

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -78,5 +78,65 @@ reviews:
         the same directory. Only when that same-named .sh counterpart exists,
         flag behavioral drift between the pair rather than style differences;
         standalone .ps1 files (no .sh twin) carry no parity requirement.
+    # ── Disproved-class scope narrowings (CR-learnings tuning, 2026-07-28) ──
+    # Each entry narrows a rule to where it is RIGHT; none is a mute.
+    - path: "scripts/**/*.sh"
+      instructions: >-
+        Handover-root resolution: the rule "source scripts/lib/handover-path.sh
+        and call handover_root instead of hardcoding the path" applies to any
+        script that reads or writes handover state at runtime, test scripts
+        included. Do not flag: scripts/lib/handover-path.sh itself (it is the
+        resolver and legitimately constructs "$repo_root/handovers"), a
+        test-*.sh file that redirects HANDOVER_DIR (or equivalent) to a temp
+        fixture before touching handover state, hooks/guards that merely
+        pattern-match the string "handovers/" in paths, or comments/prose. DO
+        flag a runtime read or write of a literal ./handovers/ or
+        "$repo_root/handovers" path in a script that bypasses the resolver —
+        including a test-*.sh that touches a real/default handover root
+        instead of a redirected fixture.
+    - path: "scripts/**/*.sh"
+      instructions: >-
+        House style is `set -uo pipefail` WITHOUT errexit; the repo's shell-lint
+        gate flags `set -e` itself as a defect (errexit leaks into sourcing
+        shells). In a file whose prologue does not enable errexit, never raise
+        errexit-interaction findings — claims that an `&&` list, `a && b || c`,
+        or an unguarded command "aborts the script" or "silently bypasses set
+        -e" have no premise, and short-circuit lists with explicit
+        `|| { …; exit N; }` handling are the intended error style. Errexit
+        findings are valid only in a file that itself sets -e/-o errexit, and
+        only where a non-zero exit is genuinely masked with a behavioral
+        consequence.
+    - path: "scripts/**/*.sh"
+      instructions: >-
+        Bash test brackets ([ x -gt y ], [ x -eq y ]) parse operands as
+        DECIMAL — leading zeros (e.g. `date +%m` yielding "08") never trigger
+        octal interpretation there. Raise octal-interpretation findings only in
+        arithmetic contexts ($(( )), (( )), let) where a leading-zero-capable
+        operand is not already normalized via the repo's $((10#$var)) idiom.
+    - path: "scripts/**/test-*.sh"
+      instructions: >-
+        Bare `wait` (no PID) in these test harnesses is deliberate: they spawn
+        background stubs and assert outcomes via marker files and captured
+        output, not via wait's exit status. Do not flag bare `wait` here for
+        discarding per-job exit codes or waiting on unintended jobs.
+    - path: "scripts/**/*.sh"
+      instructions: >-
+        `rm -f` on a quoted single-file temp/marker/lock path — typically in a
+        `trap '…' EXIT` cleanup — is the intended idempotent idiom; the target
+        legitimately may not exist, and that is not a masked error. Do not flag
+        it for missing existence checks or suppressed failures. Still flag:
+        recursive deletion of any variable-built path that could be empty or
+        unset, unquoted expansions in rm arguments, or deletion targets outside
+        the script's own temp/marker files.
+    - path: "docs/**/*.md"
+      instructions: >-
+        Paths like <state-repo>/handovers/…, $HANDOVER_DIR, <handover-root>/…,
+        handovers/<USER_SLUG>/…, and C:/Users/<you>/… are parameterized
+        references to the READER'S OWN machine or private handover state repo
+        (configured via /handover-setup) — deliberately not resolvable inside
+        this repository. Do not flag them as broken links or private-repo
+        leaks. DO flag a literal operator-specific path (a real username in an
+        absolute path) or a link to a specific private repository — those are
+        genuine leaks (precedent: HIMMEL-1352 scrubbed one from fixtures).
 chat:
   auto_reply: true

--- a/scripts/lint/shell-lint.sh
+++ b/scripts/lint/shell-lint.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # shell-lint.sh — Pre-emptive advisory shell lint (HIMMEL-478, C4).
 #
-# Runs shellcheck + a UTF-8 BOM check + an errexit-leak check on shell files
-# BEFORE the commit attempt, so the autonomous loop fixes issues instead of
-# bouncing off the real pre-commit gate mid-run. The authoritative gate
-# (.pre-commit-config.yaml) stays the source of truth and is UNCHANGED — this is
-# additive and runs earlier. Advisory: it reports findings and exits non-zero if
-# any are found; it never modifies files.
+# Runs shellcheck plus advisory byte/regex portability checks (BOM incl. *.ps1,
+# errexit leak, POSIX-ERE classes, mktemp template, bash-3.2 constructs, GNU-only
+# flags, echo -e/-n) BEFORE the commit attempt, so the autonomous loop fixes
+# issues instead of bouncing off the real pre-commit gate mid-run. The
+# authoritative gate (.pre-commit-config.yaml) stays the source of truth and is
+# UNCHANGED — this is additive and runs earlier. Advisory: it reports findings
+# and exits non-zero if any are found; it never modifies files.
 #
 # Usage:
 #   bash scripts/lint/shell-lint.sh [FILE...]   # lint the named shell files
@@ -14,10 +15,20 @@
 #   bash scripts/lint/shell-lint.sh --help
 #
 # Checks:
-#   [BOM]        UTF-8 byte-order mark at file start (breaks the shebang; SC1082).
-#   [errexit]    `set -e` / `-eu` / `-euo` / `-o errexit` — errexit leaks into a
-#                sourcing shell; himmel convention is `set -uo pipefail`.
-#   [shellcheck] the same linter the pre-commit gate runs (when installed).
+#   [BOM]         UTF-8 byte-order mark at file start (breaks the shebang; SC1082).
+#                 Runs on shell AND *.ps1 files — a BOM breaks PowerShell too.
+#   [errexit]     `set -e` / `-eu` / `-euo` / `-o errexit` — errexit leaks into a
+#                 sourcing shell; himmel convention is `set -uo pipefail`.
+#   [shellcheck]  the same linter the pre-commit gate runs (when installed).
+#   [regex-class] \s / \d / \w in a grep -E / egrep / sed -E / sed -e pattern —
+#                 POSIX ERE has no such classes (they match a literal letter).
+#   [mktemp]      `mktemp` / `mktemp -d` with no template arg (BSD/macOS needs one).
+#   [bash32]      bash 4+ constructs (declare -A, mapfile/readarray, ${var,,}/
+#                 ${var^^}, |&, &>>) — not 3.2-safe, the macOS default.
+#   [gnu-flag]    GNU-only flags (sed -i no-suffix, date -d, readlink -f, grep -P,
+#                 stat -c) without a same-line BSD fallback; exempt via
+#                 `# gnu-ok: <reason>` (mirrors the repo's headless-claude-ok hatch).
+#   [echo-e]      `echo -e` / `echo -n` — non-portable; use printf.
 #
 # Exit: 0 = clean, 1 = findings, 2 = usage error.
 # bash 3.2-safe; shellcheck-clean; cross-platform (Git Bash / macOS / Linux).
@@ -43,6 +54,81 @@ _is_shell_file() {
     esac
     return 1
 }
+
+# Like _is_shell_file but also admits *.ps1 (the [BOM] check covers PowerShell
+# too). The shell-specific checks below still gate on _is_shell_file, so a .ps1
+# only ever reaches [BOM].
+_is_lint_target() {
+    case "$1" in
+        *.ps1) return 0 ;;
+    esac
+    _is_shell_file "$1"
+}
+
+# Print "lineno: line" for every non-comment line in file $1 matching ERE $2.
+# Full-line comments are excluded so a construct merely NAMED in a doc comment
+# — e.g. "# bash 3.2-safe: no mapfile" — is not a false positive. (Inline
+# comments and heredoc/string bodies can still match; these checks are advisory.)
+_grep_hits() {
+    grep -nE "$2" -- "$1" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#' || true
+}
+
+# Append one "  [tag] line N: text — hint" per "lineno: line" entry in $2, and
+# bump file_issues once if any. Empty $2 is a no-op. file_report/file_issues are
+# the caller's loop-scoped accumulators (not local here).
+_report_hits() {
+    # $1=tag  $2=hits (lineno:line lines)  $3=hint
+    [ -n "$2" ] || return 0
+    local _ln _rest
+    while IFS=: read -r _ln _rest; do
+        [ -n "$_ln" ] || continue
+        file_report="${file_report}  [$1] line $_ln: $_rest — $3"$'\n'
+    done <<EOF
+$2
+EOF
+    file_issues=$((file_issues + 1))
+}
+
+# True if line $2 (1-indexed) of file $1 carries a `# gnu-ok: <reason>` marker,
+# on that line or the line immediately above — mirrors the repo's
+# `headless-claude-ok` opt-in pattern (scripts/hooks/check-no-headless-claude.sh).
+_has_gnu_ok() {
+    local file="$1" line_no="$2"
+    sed -n "${line_no}p" "$file" 2>/dev/null | grep -q 'gnu-ok' && return 0
+    if [ "$line_no" -gt 1 ]; then
+        sed -n "$((line_no - 1))p" "$file" 2>/dev/null | grep -q 'gnu-ok' && return 0
+    fi
+    return 1
+}
+
+# ── Advisory portability patterns (CR-learnings tuning, HIMMEL-1315, 2026-07-28)
+# POSIX ERE throughout (no \s/\d/\w, no PCRE); bash 3.2-safe. Lines are scanned
+# as-is (full-line comments excluded by _grep_hits); a construct inside a heredoc
+# body or quoted string may still match — these checks are advisory, never a gate.
+
+# grep -E / egrep / sed -E / sed -e invocation; check 1 then looks for a PCRE
+# class escape (\s \d \w) on the same line.
+REGEX_CLASS_CMD='(^|[^[:alnum:]_-])(grep[[:space:]]+-[A-Za-z]*E|egrep|sed[[:space:]]+(-[A-Za-z]*E|-[A-Za-z]*e))'
+PCRE_CLASS='\\[sdw]'
+
+# mktemp / mktemp -d with NO template arg (next token is a shell terminator or
+# end-of-line, not a path). Templated forms (mktemp x.XXXX, mktemp "$x",
+# mktemp -d -t p) skip — a following quote opens a template argument, so '"' is
+# intentionally NOT a terminator; the close-paren ')' still covers "$(mktemp)".
+MKTEMP_NOARG='(^|[^[:alnum:]_-])mktemp([[:space:]]+-[A-Za-z]+)*[[:space:]]*($|\)|\||&|;)'
+
+# bash 4+ constructs. |& and &>> are matched only in operator position
+# (whitespace-bounded) so the same tokens inside a regex char-class or quoted
+# string ([;|&()], "&>>") are not false positives.
+BASH32='(^|[^[:alnum:]_])(declare[[:space:]]+-[A-Za-z]*A[A-Za-z]*|mapfile|readarray)([^[:alnum:]_]|$)|\$\{[A-Za-z_][A-Za-z0-9_]*,,|\$\{[A-Za-z_][A-Za-z0-9_]*\^\^|[[:space:]]\|&[[:space:]]|[[:space:]]&>>'
+
+# GNU-only flags. Portable code pairs them with a BSD alt on the same line
+# (stat -f for stat -c, date -[vrj] for date -d); check 5 excludes those, then
+# honors '# gnu-ok:'.
+GNU_FLAG_PAT='(^|[^[:alnum:]_-])(sed[[:space:]]+-i([[:space:]]|$)|date[[:space:]]+(-d|--date)|readlink[[:space:]]+-f|grep[[:space:]]+-[A-Za-z]*P|stat[[:space:]]+(-c|--format))'
+
+# echo -e / echo -n (and combined short flags such as -ne / -en).
+ECHO_FLAG='(^|[^[:alnum:]_-])echo[[:space:]]+-[A-Za-z]*[en][A-Za-z]*'
 
 STAGED=0
 EXPLICIT=0         # 1 once any explicit file path is given
@@ -73,7 +159,7 @@ if [ "$STAGED" -eq 1 ]; then
         [ -n "$_f" ] || continue
         _abs="$_root/$_f"
         [ -f "$_abs" ] || continue
-        _is_shell_file "$_abs" && FILES="$FILES$_abs"$'\n'
+        _is_lint_target "$_abs" && FILES="$FILES$_abs"$'\n'
     done <<EOF
 $_staged
 EOF
@@ -101,13 +187,17 @@ while IFS= read -r f; do
     file_issues=0
     file_report=""
 
-    # [BOM] — first three bytes EF BB BF. No 2>/dev/null: a genuine od/head
-    # failure should surface, not be absorbed into a false "no BOM".
+    # [BOM] — first three bytes EF BB BF. Runs on shell AND *.ps1 (a BOM breaks
+    # PowerShell too). No 2>/dev/null: a genuine od/head failure should surface,
+    # not be absorbed into a false "no BOM".
     first3="$(head -c 3 "$f" | od -An -tx1 | tr -d ' \n')"
     if [ "$first3" = "efbbbf" ]; then
         file_report="$file_report  [BOM] UTF-8 byte-order mark at file start — strip it (breaks shebang; shellcheck SC1082)"$'\n'
         file_issues=$((file_issues + 1))
     fi
+
+    # The remaining checks are shell-specific; a .ps1 only reached [BOM] above.
+    if _is_shell_file "$f"; then
 
     # [errexit] — set -e / -eu / -euo / -o errexit in the prologue. A real
     # errexit directive sits at file top, before any heredoc; `set -e` text inside
@@ -131,6 +221,69 @@ EOF
             file_issues=$((file_issues + 1))
         fi
     fi
+
+    # Advisory portability checks (CR-learnings tuning). These define their own
+    # patterns/tags/hints as DATA, so this linter's own source — and its test
+    # suite's fixtures/assertions, which embed the same patterns/tags on
+    # purpose — would flag itself (the BASH32 pattern mentions `mapfile`; the
+    # echo-e hint says `echo -e`). Skip them for these two files only —
+    # BOM/errexit/shellcheck still run on both. This mirrors
+    # check-no-headless-claude exempting its own pattern-documenting file.
+    case "$f" in
+        *scripts/lint/shell-lint.sh|*scripts/lint/test-shell-lint.sh) _skip_advisory=1 ;;
+        *) _skip_advisory=0 ;;
+    esac
+    if [ "$_skip_advisory" -eq 0 ]; then
+
+    # [regex-class] — \s / \d / \w are PCRE/GNU extensions; in a grep -E / egrep
+    # / sed -E / sed -e pattern they match a literal letter, not a character
+    # class (POSIX ERE has none).
+    _rc="$(_grep_hits "$f" "$REGEX_CLASS_CMD" | grep -E "$PCRE_CLASS")"
+    _report_hits regex-class "$_rc" \
+        "POSIX ERE has no \s/\d/\w (matches a literal letter); use [[:space:]]/[[:digit:]]/[[:alnum:]]"
+
+    # [mktemp] — GNU mktemp works with no template arg; BSD/macOS requires one.
+    _mt="$(_grep_hits "$f" "$MKTEMP_NOARG")"
+    _report_hits mktemp "$_mt" \
+        "BSD/macOS mktemp needs a template arg (e.g. mktemp -d -t prefix.XXXXXX)"
+
+    # [bash32] — bash 4+ constructs; macOS ships bash 3.2.
+    _b32="$(_grep_hits "$f" "$BASH32")"
+    _report_hits bash32 "$_b32" \
+        "bash 4+ construct, not 3.2-safe (macOS default) — see repo house style"
+
+    # [echo-e] — echo -e/-n behaviour varies by shell/build; printf is portable.
+    _echo="$(_grep_hits "$f" "$ECHO_FLAG")"
+    _report_hits echo-e "$_echo" \
+        "echo -e/-n is non-portable; use printf"
+
+    # [gnu-flag] — GNU-only flags (sed -i no-suffix, date -d, readlink -f, grep
+    # -P, stat -c). Lines that already pair the GNU form with its BSD alternative
+    # on the same line (stat -f for stat -c, date -[vrj] for date -d) are the
+    # intended portable idiom and are dropped; the rest may be exempted with
+    # `# gnu-ok: <reason>` (same-line or line above).
+    _gf="$(grep -nE "$GNU_FLAG_PAT" -- "$f" 2>/dev/null \
+        | grep -vE '^[0-9]+:[[:space:]]*#' \
+        | grep -vE 'stat[[:space:]]+-f|date[[:space:]]+-[vrj]' || true)"
+    if [ -n "$_gf" ]; then
+        _gf_report=""
+        while IFS=: read -r _gln _grest; do
+            [ -n "$_gln" ] || continue
+            if ! _has_gnu_ok "$f" "$_gln"; then
+                _gf_report="${_gf_report}  [gnu-flag] line $_gln: $_grest — GNU-only flag, not portable to BSD/macOS; add a BSD fallback or '# gnu-ok: <reason>'"$'\n'
+            fi
+        done <<EOF
+$_gf
+EOF
+        if [ -n "$_gf_report" ]; then
+            file_report="${file_report}${_gf_report}"
+            file_issues=$((file_issues + 1))
+        fi
+    fi
+
+    fi   # end advisory checks (_skip_advisory)
+
+    fi   # end shell-specific checks (gate on _is_shell_file; .ps1 hit only [BOM])
 
     if [ "$file_issues" -gt 0 ]; then
         ISSUE_FILES=$((ISSUE_FILES + 1))

--- a/scripts/lint/test-shell-lint.sh
+++ b/scripts/lint/test-shell-lint.sh
@@ -12,6 +12,13 @@
 #   5. --help             : exits 0 and prints usage
 #   6. errexit variants   : set -eu / set -euo / set -o errexit all flagged;
 #                          set -uo pipefail / set -o pipefail NOT flagged
+# 7-10. heredoc-body set -e, --staged-from-subdir, missing-file exit 2, set -Ee.
+# 11-17. CR-learnings advisory checks (HIMMEL-1315, 2026-07-28): regex-class,
+#        mktemp template, bash32 constructs, echo-e, gnu-flag (+BSD-fallback
+#        exclusion + gnu-ok exemption), BOM covers .ps1, --staged admits .ps1.
+#  18. self-check (HIMMEL-1355): shell-lint reports no findings against this
+#      suite's own file (its fixtures/assertions are exempted from advisory
+#      checks the same way shell-lint.sh exempts its own source).
 #
 # Exit: 0 all passed, 1 any failed. bash 3.2-safe; shellcheck-clean.
 
@@ -226,6 +233,151 @@ if [ "$EC10" -eq 1 ] && printf '%s' "$OUT10" | grep -qF errexit; then
     pass "set -Ee flagged as errexit"
 else
     fail "set -Ee should be flagged" "$OUT10"
+fi
+
+# ---------------------------------------------------------------------------
+# Cases 11-17: CR-learnings advisory portability checks (HIMMEL-1315, 2026-07-28).
+# ---------------------------------------------------------------------------
+
+# Case 11: [regex-class] — \s/\d/\w in a grep -E pattern is flagged; a POSIX
+# class ([[:space:]]) is not.
+printf '\nCase 11: regex-class detection\n'
+RC_BAD="$TMP_ROOT/rc_bad.sh"
+cat > "$RC_BAD" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+grep -E '\s+' file
+EOF
+OUT11="$(bash "$LINT" "$RC_BAD" 2>&1)"
+if printf '%s' "$OUT11" | grep -qF '[regex-class]'; then pass "regex-class flags \\s in grep -E"; else fail "regex-class should flag \\s" "$OUT11"; fi
+RC_GOOD="$TMP_ROOT/rc_good.sh"
+cat > "$RC_GOOD" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+grep -E '[[:space:]]+' file
+EOF
+OUT11b="$(bash "$LINT" "$RC_GOOD" 2>&1)"
+if printf '%s' "$OUT11b" | grep -qF '[regex-class]'; then fail "regex-class false positive on POSIX class" "$OUT11b"; else pass "regex-class ignores POSIX [[:space:]]"; fi
+
+# Case 12: [mktemp] — no-template mktemp/-d is flagged; a templated form is not.
+printf '\nCase 12: mktemp template detection\n'
+MT_BAD="$TMP_ROOT/mt_bad.sh"
+cat > "$MT_BAD" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+d="$(mktemp -d)"
+EOF
+OUT12="$(bash "$LINT" "$MT_BAD" 2>&1)"
+if printf '%s' "$OUT12" | grep -qF '[mktemp]'; then pass "mktemp flags no-template mktemp -d"; else fail "mktemp should flag no-template" "$OUT12"; fi
+MT_GOOD="$TMP_ROOT/mt_good.sh"
+cat > "$MT_GOOD" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+d="$(mktemp -d -t prefix.XXXXXX)"
+EOF
+OUT12b="$(bash "$LINT" "$MT_GOOD" 2>&1)"
+if printf '%s' "$OUT12b" | grep -qF '[mktemp]'; then fail "mktemp false positive on templated form" "$OUT12b"; else pass "mktemp ignores templated form"; fi
+
+# Case 13: [bash32] — declare -A is flagged.
+printf '\nCase 13: bash32 detection\n'
+B32="$TMP_ROOT/b32.sh"
+cat > "$B32" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+declare -A seen
+EOF
+OUT13="$(bash "$LINT" "$B32" 2>&1)"
+if printf '%s' "$OUT13" | grep -qF '[bash32]'; then pass "bash32 flags declare -A"; else fail "bash32 should flag declare -A" "$OUT13"; fi
+
+# Case 14: [echo-e] — echo -e is flagged.
+printf '\nCase 14: echo-e detection\n'
+EFLAG="$TMP_ROOT/eflag.sh"
+cat > "$EFLAG" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+echo -e "hi"
+EOF
+OUT14="$(bash "$LINT" "$EFLAG" 2>&1)"
+if printf '%s' "$OUT14" | grep -qF '[echo-e]'; then pass "echo-e flags echo -e"; else fail "echo-e should flag echo -e" "$OUT14"; fi
+
+# Case 15: [gnu-flag] — grep -P flagged; GNU||BSD portable idiom not; gnu-ok
+# marker (preceding line) exempts.
+printf '\nCase 15: gnu-flag detection + BSD-fallback + gnu-ok exemption\n'
+GF_BAD="$TMP_ROOT/gf_bad.sh"
+cat > "$GF_BAD" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+echo "$x" | grep -oP '"id"'
+EOF
+OUT15="$(bash "$LINT" "$GF_BAD" 2>&1)"
+if printf '%s' "$OUT15" | grep -qF '[gnu-flag]'; then pass "gnu-flag flags grep -P"; else fail "gnu-flag should flag grep -P" "$OUT15"; fi
+GF_FB="$TMP_ROOT/gf_fb.sh"
+cat > "$GF_FB" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+mt=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f")
+EOF
+OUT15b="$(bash "$LINT" "$GF_FB" 2>&1)"
+if printf '%s' "$OUT15b" | grep -qF '[gnu-flag]'; then fail "gnu-flag false positive on GNU||BSD fallback" "$OUT15b"; else pass "gnu-flag ignores GNU||BSD portable idiom"; fi
+GF_OK="$TMP_ROOT/gf_ok.sh"
+cat > "$GF_OK" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+# gnu-ok: JSON extraction needs PCRE
+echo "$x" | grep -oP '"id"'
+EOF
+OUT15c="$(bash "$LINT" "$GF_OK" 2>&1)"
+if printf '%s' "$OUT15c" | grep -qF '[gnu-flag]'; then fail "gnu-ok marker did not exempt grep -P" "$OUT15c"; else pass "gnu-ok marker exempts grep -P"; fi
+
+# Case 16: [BOM] covers *.ps1, and a .ps1 runs NO shell-specific check.
+printf '\nCase 16: BOM covers .ps1; .ps1 skips shell checks\n'
+PS1="$TMP_ROOT/thing.ps1"
+_write_bom_file "$PS1" <<'EOF'
+Write-Output "hi"
+EOF
+OUT16="$(bash "$LINT" "$PS1" 2>&1)"
+if printf '%s' "$OUT16" | grep -qF '[BOM]'; then pass "BOM detected in .ps1"; else fail "BOM should be detected in .ps1" "$OUT16"; fi
+if printf '%s' "$OUT16" | grep -qE '\[(errexit|shellcheck|regex-class|mktemp|bash32|gnu-flag|echo-e)\]'; then
+    fail ".ps1 ran a shell-specific check" "$OUT16"
+else
+    pass ".ps1 reaches [BOM] only"
+fi
+
+# Case 17: --staged lints a staged .ps1 (BOM) — the gathering admits *.ps1.
+printf '\nCase 17: --staged lints a staged .ps1\n'
+REPO2="$TMP_ROOT/repo2"
+mkdir -p "$REPO2"
+(
+    cd "$REPO2" || exit 1
+    git init -q
+    git config user.email t@t.t
+    git config user.name t
+    printf '\xEF\xBB\xBF' > staged.ps1
+    printf 'Write-Output hi\n' >> staged.ps1
+    git add staged.ps1
+)
+OUT17="$(cd "$REPO2" && bash "$LINT" --staged 2>&1)"
+if printf '%s' "$OUT17" | grep -qF 'staged.ps1' && printf '%s' "$OUT17" | grep -qF '[BOM]'; then
+    pass "--staged detects BOM in staged .ps1"
+else
+    fail "--staged should lint a staged .ps1 BOM" "$OUT17"
+fi
+
+# Case 18: shell-lint reports no findings against its own test file
+# (HIMMEL-1355) — this suite's fixtures/assertions embed the same
+# patterns/tags/hints as DATA (e.g. Case 12's `mktemp -d`, Case 16's grep
+# alternation naming every advisory tag), so shell-lint exempts
+# scripts/lint/test-shell-lint.sh from advisory checks alongside its own
+# source. Guard that exemption directly against the real file on disk.
+# ---------------------------------------------------------------------------
+printf '\nCase 18: shell-lint has no findings on its own test file\n'
+SELF="$SCRIPT_DIR/test-shell-lint.sh"
+OUT18="$(bash "$LINT" "$SELF" 2>&1)"; EC18=$?
+if [ "$EC18" -eq 0 ]; then pass "shell-lint exits 0 on test-shell-lint.sh"; else fail "expected exit 0, got $EC18" "$OUT18"; fi
+if printf '%s' "$OUT18" | grep -qE '\[(regex-class|mktemp|bash32|gnu-flag|echo-e)\]'; then
+    fail "shell-lint should not report advisory findings on its own test file" "$OUT18"
+else
+    pass "no advisory findings on test-shell-lint.sh"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two halves of one idea — stop paying attention twice for the same finding.

1. `.coderabbit.yaml` path instructions gain scope **narrowings** for finding classes that have been raised and disproved repeatedly.
2. `scripts/lint/shell-lint.sh` gains mechanical checks for the classes a linter can decide locally: bare `mktemp` without a template, GNU-only flags, regex classes that are GNU extensions, bash 4 constructs in files that must stay 3.2-safe, and `echo -e`.

## Why

A reviewer that re-raises a class already shown to be wrong costs a round trip every time, and the cost lands on whoever is holding the branch.

The worked example is the octal claim: `[ "$x" -gt 8 ]` is base-10 in POSIX test, so flagging it as octal-sensitive is wrong. It is `$(( ))` that is octal-sensitive — a real class, a different one. Narrowing the first does not touch the second.

The split is deliberate. A **narrowing** suppresses a class the reviewer gets wrong. A **lint check** catches a class that is mechanically decidable and therefore should never have needed a reviewer's attention in the first place. Neither is a mute — nothing here stops a genuine finding from being raised.

## Scope

Three files: `.coderabbit.yaml`, `scripts/lint/shell-lint.sh`, `scripts/lint/test-shell-lint.sh`.

`shell-lint.sh` is **advisory**. It is not wired into `.pre-commit-config.yaml`, so it blocks nothing today; run it directly.

Two exemptions are worth calling out, because both were tightened during review rather than written this way:

- The **handover-root exemption** started as a blanket `test-*.sh` filename match. Too broad — it would exempt a test that touches a real handover root. It is now a *behavioural* condition: exempt only where the test redirects the handover directory to a temporary fixture.
- The **linter's self-exemption** (it must not flag the pattern strings in its own source) now also covers its own test suite, which was otherwise flagged for containing tag names inside assertions. BOM, errexit and shellcheck deliberately still run on it.

## Verification

| Check | Result |
|---|---|
| `scripts/lint/test-shell-lint.sh` | 39 passed / 0 failed, exit 0 |
| Non-vacuity (revert `shell-lint.sh`, keep tests) | 37 passed / **2 failed**, exit 1 |
| Restore | back to 39 / 0, exit 0 |
| `shell-lint.sh` on its own source | clean |
| `shell-lint.sh` on its own test file | clean |
| `.coderabbit.yaml` | parses |

The non-vacuity step matters here: a lint test suite is easy to write so that it passes whether or not the checks exist. Reverting only the implementation and watching exactly the new assertions fail is what shows these tests are load-bearing.

## Known residual

Measured, not hypothetical: enabling the new checks flags a large share of the existing tracked shell files, with `mktemp` the bulk of it. That backlog needs scoping to changed lines or a deliberate sweep — which is precisely why this lands **advisory** rather than gating. Turning it on as a gate today would block essentially every commit.

## Review note

One suggestion was recorded rather than actioned: `_has_gnu_ok` accepts any `gnu-ok` substring on the command or the preceding line, so a stray token could suppress a portability finding without the intended `# gnu-ok: <reason>` marker. Fair point about escape-hatch precision, but it is a suggestion on a surface that blocks nothing today, and tightening it would have widened this change. Noted here so it is not lost.
