### PR TITLE
feat(doctor): detect pushed branches with no PR, and report chain health

### DIFF
--- a/scripts/lib/orphan-branches.sh
+++ b/scripts/lib/orphan-branches.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+# orphan-branches.sh — detect pushed branches with no PR + report chain health.
+# (HIMMEL-1325 chunk C — the lean-invoke branch→PR orphan guard.)
+#
+# THE INVARIANT (the durable signal, not session liveness):
+#   Every branch on origin must have a PR. A branch WITH a PR survives its
+#   session; one WITHOUT one depends on a process staying alive. A resident
+#   claude.exe is not evidence work is progressing, and an exited session is
+#   not evidence work finished — so this keys off branch+PR pairing, never
+#   process liveness.
+#
+# HOW IT AVOIDS THE FALSE-POSITIVE TRAP (HIMMEL-1325): a global
+#   `gh pr list --state all --limit 1000` is TRUNCATED past ~999 refs, so a
+#   "is my branch in that list" membership test flags every older branch as
+#   orphaned — 81 false positives on 2026-07-28. This lib NEVER issues a
+#   headless `gh pr list`: it queries PER-BRANCH (`gh pr list --head <branch>`),
+#   scoped to one branch so it is bounded and never truncated by the global
+#   cap. Candidates are narrowed locally first (pure git) by a date window +
+#   protected-name exclude + count cap, and EVERY bound is stated in the output
+#   (silent truncation reads as "covered everything" — the exact failure this
+#   guard exists to fix). After a SQUASH merge the source branch still reads
+#   ahead of main, so `ahead=N` is NOT used as an unmerged signal — PR STATE
+#   (none/open/merged) is the signal, queried per-branch.
+#
+# CHAIN HEALTH — five states, the furthest stage a branch reached:
+#   pushed     on origin, NO pr  (the orphan — the failure class)        [WARN]
+#   pr         open pr, ci not green                                        [info]
+#   ci-green   open pr, all checks passing                                  [info]
+#   merged     merged pr (propagation not confirmed)                       [info]
+#   propagated merged pr whose squash commit reached the public clone       [info]
+#   (closed — a branch whose only pr was closed-unmerged; abandoned work,
+#    reported as a truncated chain, never an orphan.)
+# A branch still on origin is by definition not fully shipped: the merge flow
+# deletes the source branch on success, so `propagated` self-removes. A scan of
+# current origin branches therefore surfaces the TRUNCATED chains.
+#
+# Sourced by check_c17 (scripts/himmel-doctor.sh); also directly runnable for
+# an ad-hoc scan (`bash scripts/lib/orphan-branches.sh`).
+#
+# Seams (test overrides — same shape as scripts/lib/branch-shipped.sh):
+#   FORGE=github              bypass origin detection (forge seam)
+#   GH_CMD=<path>             override the `gh` binary for the per-branch pr query
+#   OB_CI_CMD=<path>          override `gh pr checks` (ci enrichment; defaults to gh)
+#   ORPHAN_BRANCH_DAYS=N      date window in days (default 30)
+#   ORPHAN_BRANCH_MAX=N       cap on branches scanned (default 50)
+#   ORPHAN_BRANCH_IGNORE=     space-separated glob patterns to always skip
+#   ORPHAN_BRANCH_TIMEOUT=N   per-call gh timeout seconds (default 15)
+#   ORPHAN_BRANCH_FETCH=1     `git fetch origin` before scanning (default off)
+#   ORPHAN_PUBLIC_CLONE=<dir> public clone dir (propagated state; maintainer only)
+#   OB_PRIMARY=<dir>          primary repo dir (dual-mode run only)
+#
+# DO NOT add set -e / set -euo pipefail at file scope — this is a sourced
+# library; that would leak into the sourcing shell. Guard internally.
+
+_OB_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/forge.sh
+# shellcheck disable=SC1091
+. "$_OB_LIB_DIR/forge.sh"
+
+_ob_timeout_cmd() {
+    if command -v timeout >/dev/null 2>&1; then printf 'timeout'
+    elif command -v gtimeout >/dev/null 2>&1; then printf 'gtimeout'; fi
+}
+
+# _ob_bounded <secs> <outfile> <primary> <cmd...> — portable per-call timeout for
+# hosts with NO `timeout`/`gtimeout` (stock macOS ships bash 3.2 + BSD coreutils,
+# no GNU timeout). Runs <cmd> from <primary>, stdout to <outfile> + stderr
+# discarded (same capture shape as the `timeout` branch), bounded to <secs>
+# wall-clock. Returns the child's exit status on normal completion, or 124 on
+# timeout (GNU `timeout`'s convention — both call sites already map any non-zero
+# rc to uncertain/pending, so 124 lands correctly and consistently with the
+# timeout-binary path).
+#
+# Why this exists (HIMMEL-1325): _ob_timeout_cmd returns empty when no timeout
+# binary is present, and without this fallback _ob_gh_list / _ob_ci_state run `gh`
+# UNBOUNDED — a hung call hangs the whole scan with no ceiling, on a lib whose
+# whole point is to be bounded by ORPHAN_BRANCH_TIMEOUT.
+#
+# Design notes:
+#   * Whole body runs in a `set +m` subshell so the background `&` never emits
+#     `[n] PID` / `Done` job-control noise, even if the sourcing shell is
+#     interactive; `set +m` is scoped to the subshell and never touches the
+#     caller. (Every real call site is a non-interactive script, where job
+#     control is already off — this is belt-and-suspenders.)
+#   * `exec` replaces the launcher subshell with <cmd>, so $! is <cmd>'s own PID
+#     and SIGTERM hits it directly. gh is a single binary with no child tree, so
+#     this leaves nothing orphaned. (A command that itself spawns long-lived
+#     children could orphan those — best-effort, the same limitation GNU
+#     `timeout` has without a process-group kill, which its own `-k` does not
+#     widen; not a concern for the gh callee here.)
+#   * Output to a FILE, not $( ): a surviving process cannot hold a command
+#     substitution's pipe open (the same reason _ob_gh_list uses mktemp).
+#   * Bash 3.2-safe: no `wait -n` (4.3+), no mapfile (4.0+), no coproc. Polls
+#     with `kill -0` (non-blocking liveness) at 1s granularity, so the bound is
+#     <secs> rounded up by at most ~1s — the same budget the `timeout` path uses.
+_ob_bounded() {
+    local secs="$1" outfile="$2" primary="$3"; shift 3
+    (
+        set +m
+        ( cd "$primary" && exec "$@" ) >"$outfile" 2>/dev/null &
+        local pid=$! rc="" i=0
+        while [ "$i" -lt "$secs" ]; do
+            # SIGZERO liveness check: succeeds only while the child lives, so this
+            # never blocks on a running child.
+            if ! kill -0 "$pid" 2>/dev/null; then
+                wait "$pid" 2>/dev/null; rc=$?        # reap + capture real status
+                break
+            fi
+            sleep 1
+            i=$((i + 1))
+        done
+        if [ -z "$rc" ]; then
+            # Loop exhausted => child outlived the budget. Kill + reap (no zombie,
+            # no lingering proc); SIGKILL escalation if SIGTERM is ignored. If it
+            # died during the final sleep, kill -0 fails and we skip to the reap,
+            # still reported as a timeout — it did not finish inside the window.
+            if kill -0 "$pid" 2>/dev/null; then
+                kill "$pid" 2>/dev/null
+                sleep 1
+                kill -9 "$pid" 2>/dev/null
+            fi
+            wait "$pid" 2>/dev/null
+            rc=124
+        fi
+        exit "$rc"
+    )
+}
+
+# Is the forge github? (gh orphan scan is a github concern; bitbucket uses a
+# different flow — see himmel-doctor C4.) Sourced forge_detect honors FORGE.
+_ob_forge_ok() {
+    local f
+    f="$(cd "$1" 2>/dev/null && forge_detect 2>/dev/null)" || return 1
+    [ "$f" = github ]
+}
+
+_ob_fetch() {
+    local tcmd; tcmd="$(_ob_timeout_cmd)"
+    if [ -n "$tcmd" ]; then
+        "$tcmd" 60 git -C "$1" fetch origin --prune >/dev/null 2>&1
+    else
+        # Same bound as the `timeout` path above. This else-branch previously ran
+        # the fetch UNBOUNDED, which is the third instance of the defect fixed at
+        # _ob_gh_list and _ob_ci_state — a network fetch is the likeliest of the
+        # three to hang, so leaving it out would have shipped a bounded-scan
+        # guarantee with a hole in it.
+        _ob_bounded 60 /dev/null "$1" git fetch origin --prune
+    fi
+}
+
+# _ob_gh_list <primary_dir> <branch> — query THIS branch's PRs from the target
+# repo (per-branch, never global). Sets globals _ob_out (tsv rows) and _ob_rc
+# (0 = query succeeded).
+#   rc 0 + empty   -> 0 PRs. Confirmed by a SECOND query before it is reported
+#                     as an orphan — an empty rc=0 response is also what a
+#                     transient forge hiccup looks like (see orphan_branch_scan).
+#   rc != 0        -> forge unreachable (uncertain — never a false orphan)
+_ob_gh_list() {
+    local primary="$1" branch="$2" secs="${ORPHAN_BRANCH_TIMEOUT:-15}" tcmd tmp
+    tcmd="$(_ob_timeout_cmd)"
+    # Capture to a FILE, not a command substitution. `timeout` signals only the
+    # direct child, so a surviving GRANDCHILD keeps the substitution's pipe open
+    # and `$( … )` blocks for the grandchild's full lifetime — the timeout then
+    # bounds nothing (observed on Git Bash / Windows: a 1s timeout took 39s).
+    # Reading a regular file cannot block that way, so the bound actually holds.
+    # mktemp, NOT a predictable "$$-$RANDOM" path: this file is opened with `>`,
+    # so a guessable name in a shared /tmp lets an attacker pre-plant a symlink
+    # and clobber any file the running user can write (codex-1).
+    tmp=$(mktemp -t ob-gh.XXXXXX) || { _ob_out=""; _ob_rc=1; return 0; }
+    # The query is ALWAYS scoped with --head <branch> — a headless `gh pr list`
+    # is the truncation root cause (see file header). T14 STATIC asserts this.
+    if [ -n "$tcmd" ]; then
+        (cd "$primary" && "$tcmd" -k 2 "$secs" "${GH_CMD:-gh}" pr list --head "$branch" \
+            --state all --limit 100 --json number,state,mergeCommit \
+            --jq '.[] | [.number, .state, (.mergeCommit.oid // "-")] | @tsv') \
+            >"$tmp" 2>/dev/null
+        _ob_rc=$?
+    else
+        # No `timeout` binary (stock macOS / minimal containers): the portable
+        # _ob_bounded runner enforces the same ORPHAN_BRANCH_TIMEOUT budget so a
+        # hung gh cannot hang the scan unbounded (HIMMEL-1325).
+        _ob_bounded "$secs" "$tmp" "$primary" "${GH_CMD:-gh}" pr list --head "$branch" \
+            --state all --limit 100 --json number,state,mergeCommit \
+            --jq '.[] | [.number, .state, (.mergeCommit.oid // "-")] | @tsv'
+        _ob_rc=$?
+    fi
+    _ob_out="$(cat "$tmp" 2>/dev/null)"
+    rm -f "$tmp"
+}
+
+# _ob_ci_state <primary_dir> <pr_number> -> echoes green|none|pending|failed
+# (best-effort; never affects the orphan/merged determination — only enriches
+# an open-pr branch). gh documents rc=8 for pending checks. rc=1 is AMBIGUOUS:
+# `gh pr checks` exits 1 for BOTH a genuinely red check AND "no checks reported"
+# (cli/cli#9390, #9682, #7401 — upstream has repeatedly declined to change it),
+# and Actions is OFF on this private repo, so "no checks" is the COMMON case. rc=1
+# is therefore resolved by INSPECTING the captured output, not the exit code alone:
+# empty/whitespace-only output, or gh's "no checks" message, => none; any
+# check-row content => failed. Other non-zero exits stay pending (conservative).
+_ob_ci_state() {
+    local primary="$1" num="$2" secs="${ORPHAN_BRANCH_TIMEOUT:-15}" tcmd out rc tmp
+    tcmd="$(_ob_timeout_cmd)"
+    # Same grandchild-holds-the-pipe reason as _ob_gh_list: capture to a file.
+    # mktemp for the same symlink-clobbering reason as _ob_gh_list (codex-1).
+    tmp=$(mktemp -t ob-ci.XXXXXX) || { printf 'pending'; return; }
+    if [ -n "$tcmd" ]; then
+        (cd "$primary" && "$tcmd" -k 2 "$secs" "${OB_CI_CMD:-${GH_CMD:-gh}}" pr checks "$num") >"$tmp" 2>/dev/null; rc=$?
+    else
+        # Same portable bound as _ob_gh_list when no `timeout` binary exists (HIMMEL-1325).
+        _ob_bounded "$secs" "$tmp" "$primary" "${OB_CI_CMD:-${GH_CMD:-gh}}" pr checks "$num"; rc=$?
+    fi
+    out="$(cat "$tmp" 2>/dev/null)"; rm -f "$tmp"
+    if [ "$rc" -eq 8 ]; then printf 'pending'; return; fi
+    if [ "$rc" -eq 1 ]; then
+        # Resolve the rc=1 ambiguity by OUTPUT, not exit code alone (see header).
+        # gh's no-checks message goes to stderr (captured to /dev/null), so the
+        # common no-checks case leaves $out empty/whitespace-only => none. The
+        # literal "no checks" message is matched too, for gh builds that print it
+        # to stdout (anchored to a line start so a check whose NAME contains those
+        # words is not misread). Anything else is a real checks table => failed.
+        if [ -z "${out//[[:space:]]/}" ]; then printf 'none'; return; fi
+        if printf '%s\n' "$out" | grep -qiE '^[[:space:]]*no checks'; then printf 'none'; return; fi
+        printf 'failed'; return
+    fi
+    if [ "$rc" -ne 0 ]; then printf 'pending'; return; fi
+    if [ -z "$out" ]; then printf 'none'; return; fi
+    printf 'green'
+}
+
+# _ob_is_propagated <merge_oid> <public_clone> -> rc 0 if the squash commit is
+# present in the public clone's object db. Conservative: squash→squash rewrites
+# the SHA, so this resolves `propagated` only when the commit was copied
+# verbatim; otherwise the branch stays `merged` (repo-level propagation truth
+# is owned by himmel-doctor C10 / propagation-drift, not re-derived here).
+_ob_is_propagated() {
+    local oid="$1" pub="$2"
+    [ -n "$oid" ] && [ "$oid" != "-" ] && [ -n "$pub" ] && [ -d "$pub" ] \
+        && git -C "$pub" cat-file -e "$oid" >/dev/null 2>&1
+}
+
+# _ob_is_ignored <name> -> rc 0 if the branch should be skipped.
+_ob_is_ignored() {
+    local n="$1" pat
+    case "$n" in
+        ""|main|master|HEAD|dev|develop) return 0 ;;
+    esac
+    [ -n "$_ob_default" ] && [ "$n" = "$_ob_default" ] && return 0
+    for pat in $_ob_ignore_globs; do          # intentional unquote: word-split globs
+        # shellcheck disable=SC2254  # $pat MUST glob here — these are user-supplied
+        # patterns (e.g. 'renovate/*'); quoting would match them literally.
+        case "$n" in $pat) return 0 ;; esac
+    done
+    return 1
+}
+
+# _ob_classify <primary_dir> <branch> — consumes _ob_out/_ob_rc, prints one result line.
+_ob_classify() {
+    local primary="$1" branch="$2"
+    if [ "$_ob_rc" -ne 0 ]; then
+        printf 'uncertain: %s (forge unreachable)\n' "$branch"; return
+    fi
+    local has_any=0 merged_oid="" open_num="" has_closed=0 num state oid
+    while IFS="$(printf '\t')" read -r num state oid; do
+        [ -n "$num" ] || continue
+        has_any=1
+        case "$state" in
+            MERGED) [ -n "$merged_oid" ] || merged_oid="${oid:--}" ;;
+            OPEN)   open_num="$num" ;;
+            CLOSED) has_closed=1 ;;
+        esac
+    done <<EOF
+$_ob_out
+EOF
+    if [ "$has_any" -eq 0 ]; then
+        printf 'ORPHAN %s\n' "$branch"; return
+    fi
+    if [ -n "$merged_oid" ]; then
+        if _ob_is_propagated "$merged_oid" "$_ob_public"; then
+            printf 'chain: propagated %s\n' "$branch"
+        else
+            printf 'chain: merged %s\n' "$branch"
+        fi
+        return
+    fi
+    if [ -n "$open_num" ]; then
+        local ci; ci="$(_ob_ci_state "$primary" "$open_num")"
+        if [ "$ci" = green ]; then
+            printf 'chain: ci-green %s (pr #%s)\n' "$branch" "$open_num"
+        else
+            printf 'chain: pr %s (pr #%s, ci=%s)\n' "$branch" "$open_num" "$ci"
+        fi
+        return
+    fi
+    if [ "$has_closed" -eq 1 ]; then
+        printf 'chain: closed %s\n' "$branch"; return
+    fi
+    printf 'uncertain: %s (unrecognized pr states)\n' "$branch"
+}
+
+# orphan_branch_scan <primary_dir> — print the scan report to stdout.
+# Always returns 0 once a scan ran (callers parse stdout). Never a false orphan
+# on forge outage (those print `uncertain:`).
+orphan_branch_scan() {
+    local primary="${1:-${OB_PRIMARY:-}}"
+    [ -n "$primary" ] || primary="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    if [ -z "$primary" ] || [ ! -d "$primary" ]; then
+        echo "orphan-branches: no git repo to scan (skipped)"
+        return 0
+    fi
+    if ! _ob_forge_ok "$primary"; then
+        echo "orphan-branches: skipped (forge not github; gh orphan scan is a github concern)"
+        return 0
+    fi
+
+    # Base-10 force: a leading-zero value (e.g. "08") is parsed as OCTAL in the
+    # $(( )) cutoff below ("value too great for base" -> scan aborts; verified on
+    # 2026-07-28). Same $((10#$var)) idiom as scripts/check-ci.sh. `max` needs
+    # none: it is only ever used in a [ -ge ] test (decimal), never in $(( ))
+    # (HIMMEL-1325). The cutoff re-applies 10# as defense-in-depth at the one
+    # arithmetic site the value actually reaches.
+    local days="${ORPHAN_BRANCH_DAYS:-30}"
+    days=$((10#$days))
+    local max="${ORPHAN_BRANCH_MAX:-50}"
+    _ob_public="${ORPHAN_PUBLIC_CLONE:-}"
+    _ob_default="$(git -C "$primary" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
+    _ob_ignore_globs="${ORPHAN_BRANCH_IGNORE:-}"
+
+    local fetched="no"
+    if [ "${ORPHAN_BRANCH_FETCH:-0}" = "1" ]; then
+        _ob_fetch "$primary" && fetched="yes"
+    fi
+
+    # Narrow the candidate set LOCALLY first (pure git) so the per-branch gh
+    # call count stays small (a per-branch loop over ALL remote branches times
+    # out past ~2 min). Date window keeps it to recent activity; every bound is
+    # stated in the header below.
+    #
+    # The ref list is sorted NEWEST-FIRST (`--sort=-committerdate`) because the
+    # `max` cap truncates it. git's default order is by REFNAME, so an
+    # alphabetical cap would silently drop the most recently pushed branches —
+    # precisely the ones most likely to be live orphans, and the exact class this
+    # guard exists to catch (codex-2).
+    local cutoff now
+    now="$(date +%s)"
+    cutoff=$(( now - 10#$days * 86400 ))
+    local candidates=() name cdate n=0
+    while IFS=' ' read -r name cdate; do
+        [ -n "$name" ] || continue
+        case "$name" in origin/*) name="${name#origin/}" ;; *) continue ;; esac
+        _ob_is_ignored "$name" && continue
+        # empty/non-numeric committerdate -> include (fail-safe toward scanning)
+        case "$cdate" in ''|*[!0-9]*) cdate="$cutoff" ;; esac
+        [ "$cdate" -ge "$cutoff" ] || continue
+        candidates+=("$name")
+        n=$((n + 1))
+        [ "$n" -ge "$max" ] && break
+    done <<EOF
+$(git -C "$primary" for-each-ref --sort=-committerdate --format='%(refname:short) %(committerdate:unix)' refs/remotes/origin/ 2>/dev/null)
+EOF
+
+    local ig="main|master|HEAD|dev|develop"
+    [ -n "$_ob_default" ] && ig="$ig|$_ob_default"
+    [ -n "$_ob_ignore_globs" ] && ig="$ig $_ob_ignore_globs"
+    printf "orphan-branches: scanning %d candidate(s) window=%dd max=%d per-branch-limit=100 ignore='%s' fetch=%s\n" \
+        "${#candidates[@]}" "$days" "$max" "$ig" "$fetched"
+
+    if [ "${#candidates[@]}" -eq 0 ]; then
+        echo "orphan-branches: no candidate remote branches in window (refs as of last fetch; set ORPHAN_BRANCH_FETCH=1 to refresh)"
+        return 0
+    fi
+
+    local b
+    for b in "${candidates[@]}"; do
+        _ob_gh_list "$primary" "$b"
+        # CONFIRM an empty result before it becomes an ORPHAN claim. rc=0 with
+        # no rows is the orphan signal, but it is ALSO what a transient forge
+        # hiccup looks like: on 2026-07-28 `gh pr list --head` returned rc=0 and
+        # empty for fix/himmel-1315-revert-duplicate-switch, whose PR #1442 was
+        # in fact MERGED — a re-query returned it. That is a false ORPHAN from
+        # the very call this guard treats as authoritative, so query twice and
+        # only claim ORPHAN when both agree. A noisy guard gets ignored, which
+        # is how this failure class survived unnoticed in the first place.
+        if [ "$_ob_rc" -eq 0 ] && [ -z "$_ob_out" ]; then
+            _ob_gh_list "$primary" "$b"
+        fi
+        _ob_classify "$primary" "$b"
+    done
+    return 0
+}
+
+# ── dual-mode: run directly for an ad-hoc scan ────────────────────────────────
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    _ob_primary="${OB_PRIMARY:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+    _ob_report="$(orphan_branch_scan "$_ob_primary" 2>&1)"
+    printf '%s\n' "$_ob_report"
+    if printf '%s\n' "$_ob_report" | grep -q '^ORPHAN '; then exit 1; fi
+    exit 0
+fi

--- a/scripts/lib/test-orphan-branches.sh
+++ b/scripts/lib/test-orphan-branches.sh
@@ -1,0 +1,606 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016  # single-quoted `$…` is deliberate throughout: these
+# printf lines EMIT shell source into the GH_CMD stub files, so the expansions
+# must survive verbatim and be evaluated when the stub runs, not when it is written.
+# test-orphan-branches.sh — self-contained tests for orphan_branch_scan.
+#
+# Usage: bash scripts/lib/test-orphan-branches.sh
+# Exit:  0 = all pass, 1 = one or more failures.
+#
+# Strategy (mirrors test-branch-shipped.sh): build real temp git repos with
+# refs/remotes/origin/<branch>, write GH_CMD stub scripts, export FORGE=github
+# + GH_CMD=<stub>, source orphan-branches.sh, call orphan_branch_scan, assert
+# on stdout.  The per-branch gh call shape the lib issues is:
+#   gh pr list --head <branch> --state all --limit 100 \
+#       --json number,state,mergeCommit --jq '.[]|[.number,.state,(.mergeCommit.oid//"-")]|@tsv'
+# so a stub matches on $4 (the --head value).  The CI call (open PRs only) is:
+#   gh pr checks <number>      (rc 0 => green, rc 1 => failed, rc 8 => pending)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── temp dir setup ────────────────────────────────────────────────────────────
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+# A fake "primary" git dir: forge_detect (FORGE=github) needs a real-ish repo.
+PRIMARY_DIR="$TMPDIR_ROOT/primary"
+mkdir -p "$PRIMARY_DIR/.git"
+
+# now in epoch seconds (portable: no external `date -d`).
+now=$(date +%s)
+
+# ── test harness ──────────────────────────────────────────────────────────────
+_pass=0
+_fail=0
+pass() { printf '  PASS  %s\n' "$1"; _pass=$(( _pass + 1 )); }
+fail() { printf '  FAIL  %s\n' "$1"; _fail=$(( _fail + 1 )); }
+
+# mk_repo <dir> — init a minimal git repo + one commit (on main) so refs work.
+# Disables the operator's global core.hooksPath pre-commit + commit.gpgsign so
+# each `git commit` is fast + hermetic (the global hook adds ~5-10s/commit on
+# the dev box and has nothing to do with the unit under test).
+mk_repo() {
+    local d="$1"
+    mkdir -p "$d"
+    git -C "$d" init -q
+    git -C "$d" config user.email t@t
+    git -C "$d" config user.name t
+    git -C "$d" config core.autocrlf false
+    mkdir -p "$d/.nohooks"
+    git -C "$d" config core.hooksPath "$d/.nohooks"
+    git -C "$d" config commit.gpgsign false
+    printf 'init\n' > "$d/README.md"
+    git -C "$d" add README.md
+    git -C "$d" commit -q -m "init"
+    git -C "$d" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || true
+}
+
+# mk_remote_branch <repo> <name> <days_ago> — empty commit dated N days ago,
+# then point refs/remotes/origin/<name> at it.  git accepts a raw epoch + tz.
+mk_remote_branch() {
+    local repo="$1" name="$2" days="$3"
+    local epoch=$(( now - days * 86400 ))
+    GIT_AUTHOR_DATE="$epoch +0000" GIT_COMMITTER_DATE="$epoch +0000" \
+        git -C "$repo" commit -q --allow-empty -m "c $name"
+    git -C "$repo" update-ref "refs/remotes/origin/$name" HEAD
+}
+
+# point origin/main at HEAD (the first commit) so the default branch is present.
+mk_origin_main() {
+    git -C "$1" update-ref refs/remotes/origin/main HEAD
+}
+
+# write a GH_CMD stub.  args: stub_path <lines...>  (each line is `echo`-able sh).
+write_stub() {
+    local stub_path="$1"; shift
+    { printf '%s\n' '#!/usr/bin/env bash'; printf '%s\n' "$@"; } > "$stub_path"
+    chmod +x "$stub_path"
+}
+
+# A stub that returns PR rows only for --head <named> branches.  It also writes
+# a sentinel if it is EVER called WITHOUT --head (a global/headless list call) —
+# that sentinel is the 81-false-positive-regression proof.  $1=pr $2=list
+# $3=--head $4=<branch> ...  so $4 is the head branch.
+# $1 = sentinel-file path, $2 = an associative word<branch>->rows encoding:
+#   "BRANCH1:NUM:STATE:OID BRANCH2:..." (space separated; rows tab-joined).
+make_head_stub() {
+    local stub_path="$1" sentinel="$2"; shift 2
+    {
+        printf '%s\n' '#!/usr/bin/env bash'
+        printf 'sent=%q\n' "$sentinel"
+        printf '%s\n' 'if [ "$3" != "--head" ]; then touch "$sent"; exit 0; fi'
+        printf '%s\n' 'b="$4"'
+        printf '%s\n' 'case "$b" in'
+        local spec
+        for spec in "$@"; do
+            # spec = BRANCH:NUM:STATE:OID   (OID optional, default "-")
+            local br num state oid rest   # `rest` was leaking to global scope (glm-5)
+            br="${spec%%:*}"; rest="${spec#*:}"
+            num="${rest%%:*}"; rest="${rest#*:}"
+            state="${rest%%:*}"; oid="${rest#*:}"
+            [ "$oid" = "$state" ] && oid="-"
+            printf '  %q) printf "%%s\\t%%s\\t%%s\\n" %s %s %s ;;\n' "$br" "$num" "$state" "$oid"
+        done
+        printf '%s\n' 'esac'
+    } > "$stub_path"
+    chmod +x "$stub_path"
+}
+
+# Source the library under test.  RED before orphan-branches.sh exists.
+OB_LIB="$SCRIPT_DIR/orphan-branches.sh"
+# Distinguish MISSING from BROKEN (HIMMEL-1325): a single `. … 2>/dev/null` test
+# returned non-zero for BOTH a missing file and one that exists but failed to
+# source, so a genuine syntax error in the lib masqueraded as "not found" and hid
+# the real cause. Check existence first; on a present-but-failing source, surface
+# the actual error instead of swallowing it.
+if [ ! -f "$OB_LIB" ]; then
+    echo "SKIP: $OB_LIB not found — tests would all fail with a source error."
+    echo "      Create scripts/lib/orphan-branches.sh, then re-run this test."
+    exit 1
+fi
+# shellcheck source=scripts/lib/orphan-branches.sh
+# shellcheck disable=SC1091
+if ! . "$OB_LIB" 2>"$TMPDIR_ROOT/ob-src.err"; then
+    echo "FAIL: $OB_LIB exists but failed to source (syntax error? bad dependency?)."
+    sed 's/^/      /' "$TMPDIR_ROOT/ob-src.err" 2>/dev/null
+    exit 1
+fi
+
+# count_orphans <scan_output>
+count_orphans() { printf '%s\n' "$1" | grep -c '^ORPHAN ' || true; }
+# has_orphan <scan_output> <branch>
+has_orphan() { printf '%s\n' "$1" | grep -qF "ORPHAN $2"; }
+# (has_chain removed — it was never called and was broken anyway: it used $1 as
+# BOTH the scan output and the state pattern, ignoring $2/$3, so it would have
+# silently returned false for every caller. chain_state_of is the working
+# equivalent and is what the assertions actually use. codex-3 / glm-4.)
+# chain_state_of <scan_output> <branch> -> echoes the chain state for that branch
+chain_state_of() { printf '%s\n' "$1" | awk -v b="$2" '$1=="chain:" && $3==b {print $2; exit}'; }
+
+# ── T1: branch with NO PR -> ORPHAN -------------------------------------------
+t="$TMPDIR_ROOT/t1"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/orphan" 1
+stub="$TMPDIR_ROOT/gh-t1"
+write_stub "$stub" 'exit 0'   # empty stdout for every --head call => 0 PRs
+export FORGE=github GH_CMD="$stub" ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if has_orphan "$out" "feat/orphan"; then pass "T1: no-PR branch -> ORPHAN"; else fail "T1: expected ORPHAN feat/orphan; got: $(printf '%s\n' "$out" | grep -E '^(ORPHAN|chain:|orphan-branches:)' | head)"; fi
+unset GH_CMD FORGE ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T2: branch with an OPEN PR -> NOT orphan (chain: pr) ----------------------
+t="$TMPDIR_ROOT/t2"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/open" 1
+stub="$TMPDIR_ROOT/gh-t2"
+make_head_stub "$stub" "$TMPDIR_ROOT/sent-t2" "feat/open:42:OPEN:-"
+# CI call for the open PR: `gh pr checks 42` -> rc 1 WITH a failing check row
+# (a genuine red check — distinct from the no-checks rc=1 exercised in T20/T21,
+# which must read as ci=none). This shared stub is reused by T3/T4/T10/T11/T13/T18
+# as a generic "not green" CI; a failing row keeps all of those correct.
+{ printf '%s\n' '#!/usr/bin/env bash'; printf '%s\n' 'echo -e "CI\t\tfail"'; printf '%s\n' 'exit 1'; } > "$TMPDIR_ROOT/ci-no"
+chmod +x "$TMPDIR_ROOT/ci-no"
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$TMPDIR_ROOT/ci-no" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if ! has_orphan "$out" "feat/open" && printf '%s\n' "$out" | grep -q '^chain: pr .*ci=failed'; then
+    pass "T2: open-PR branch + failed CI -> chain: pr, ci=failed (not orphan)"
+else
+    fail "T2: expected chain: pr feat/open with ci=failed, no ORPHAN; got: $(printf '%s\n' "$out" | grep -E '^(ORPHAN|chain:)' )"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T3: branch with a MERGED PR -> NOT orphan (chain: merged) -----------------
+t="$TMPDIR_ROOT/t3"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/merged" 2
+stub="$TMPDIR_ROOT/gh-t3"
+make_head_stub "$stub" "$TMPDIR_ROOT/sent-t3" "feat/merged:7:MERGED:abc123"
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$TMPDIR_ROOT/ci-no" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50 ORPHAN_PUBLIC_CLONE=""
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if ! has_orphan "$out" "feat/merged" && printf '%s\n' "$out" | grep -q '^chain: merged '; then
+    pass "T3: merged-PR branch -> chain: merged (not orphan)"
+else
+    fail "T3: expected chain: merged feat/merged; got: $(printf '%s\n' "$out" | grep -E '^(ORPHAN|chain:)')"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX ORPHAN_PUBLIC_CLONE
+
+# ── T4: THE 81-FALSE-POSITIVE REGRESSION TEST --------------------------------
+# A branch that HAS a PR must NOT be reported orphan even when a GLOBAL list is
+# truncated.  The lib must query per-branch (--head), never a headless list.
+# Proof shape: the stub touches a sentinel on any headless (no --head) call; a
+# correct lib never makes one, so the sentinel stays absent AND the has-PR
+# branch is classified from its per-head truth.
+t="$TMPDIR_ROOT/t4"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/has-pr" 1
+mk_remote_branch "$t/rep" "feat/really-orphan" 1
+sent="$TMPDIR_ROOT/sent-t4"; rm -f "$sent"
+stub="$TMPDIR_ROOT/gh-t4"
+make_head_stub "$stub" "$sent" "feat/has-pr:99:OPEN:-"
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$TMPDIR_ROOT/ci-no" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if has_orphan "$out" "feat/really-orphan" && ! has_orphan "$out" "feat/has-pr" && [ ! -f "$sent" ]; then
+    pass "T4: has-PR branch NOT orphan + no headless gh call (per-branch only)"
+else
+    fail "T4: per-branch isolation failed — orphan=$(printf '%s' "$out" | grep -c '^ORPHAN '), sentinel=$([ -f "$sent" ] && echo present || echo absent)"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T5: protected branch (main) is excluded -----------------------------------
+t="$TMPDIR_ROOT/t5"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "main" 1      # a stray origin/main-like ref is ignored
+mk_remote_branch "$t/rep" "feat/x" 1
+stub="$TMPDIR_ROOT/gh-t5"
+write_stub "$stub" 'exit 0'
+export FORGE=github GH_CMD="$stub" ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if has_orphan "$out" "feat/x" && ! printf '%s\n' "$out" | grep -qE '^(ORPHAN|chain:) main( |$)'; then
+    pass "T5: 'main' excluded from scan"
+else
+    fail "T5: main leaked into scan: $(printf '%s\n' "$out" | grep -E 'main')"
+fi
+unset GH_CMD FORGE ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T6: ORPHAN_BRANCH_IGNORE glob excludes a branch --------------------------
+t="$TMPDIR_ROOT/t6"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "renovate/deps" 1
+mk_remote_branch "$t/rep" "feat/y" 1
+stub="$TMPDIR_ROOT/gh-t6"
+write_stub "$stub" 'exit 0'
+export FORGE=github GH_CMD="$stub" ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50 \
+    ORPHAN_BRANCH_IGNORE='renovate/*'
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if has_orphan "$out" "feat/y" && ! printf '%s\n' "$out" | grep -q 'renovate/deps'; then
+    pass "T6: ORPHAN_BRANCH_IGNORE glob excludes renovate/*"
+else
+    fail "T6: ignore glob failed: $(printf '%s\n' "$out" | grep -E 'renovate|feat/y')"
+fi
+unset GH_CMD FORGE ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX ORPHAN_BRANCH_IGNORE
+
+# ── T7: date window bounds old branches out (and the bound is STATED) --------
+t="$TMPDIR_ROOT/t7"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/recent" 5
+mk_remote_branch "$t/rep" "feat/old" 200
+stub="$TMPDIR_ROOT/gh-t7"
+write_stub "$stub" 'exit 0'
+export FORGE=github GH_CMD="$stub" ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if has_orphan "$out" "feat/recent" && ! printf '%s\n' "$out" | grep -q 'feat/old' \
+   && printf '%s\n' "$out" | grep -q 'window=30'; then
+    pass "T7: window=30 bounds old branch out + bound stated"
+else
+    fail "T7: window bounding failed: $(printf '%s\n' "$out" | grep -E 'feat/old|feat/recent|window=')"
+fi
+unset GH_CMD FORGE ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T8: forge unreachable (gh exits non-zero) -> uncertain, no false orphan --
+t="$TMPDIR_ROOT/t8"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/q" 1
+stub="$TMPDIR_ROOT/gh-t8"
+write_stub "$stub" 'exit 1'   # every gh call fails (unauthed/offline shape)
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$stub" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if ! has_orphan "$out" "feat/q" && printf '%s\n' "$out" | grep -q '^uncertain:'; then
+    pass "T8: forge-error -> uncertain (no false orphan)"
+else
+    fail "T8: expected uncertain feat/q, no ORPHAN; got: $(printf '%s\n' "$out" | grep -E '^(ORPHAN|uncertain:)')"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T9: per-branch gh timeout -> uncertain, wall-clock bounded ---------------
+if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
+    t="$TMPDIR_ROOT/t9"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+    mk_remote_branch "$t/rep" "feat/slow" 1
+    stub="$TMPDIR_ROOT/gh-t9"
+    write_stub "$stub" 'sleep 30' 'exit 0'
+    export FORGE=github GH_CMD="$stub" OB_CI_CMD="$stub" \
+        ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50 ORPHAN_BRANCH_TIMEOUT=1
+    _ts=$(date +%s)
+    out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+    _te=$(date +%s); _el=$(( _te - _ts ))
+    if ! has_orphan "$out" "feat/slow" && printf '%s\n' "$out" | grep -q '^uncertain:' && [ "$_el" -lt 10 ]; then
+        pass "T9: slow gh -> uncertain, bounded (${_el}s < 10s)"
+    else
+        fail "T9: timeout handling failed (el=${_el}s): $(printf '%s\n' "$out" | grep -E '^(ORPHAN|uncertain:)')"
+    fi
+    unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX ORPHAN_BRANCH_TIMEOUT
+else
+    pass "T9: timeout case skipped (no timeout/gtimeout binary)"
+fi
+
+# ── T10: mixed repo — only the orphan is flagged; others get chain labels ----
+t="$TMPDIR_ROOT/t10"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/orphan2" 1
+mk_remote_branch "$t/rep" "feat/open2" 1
+mk_remote_branch "$t/rep" "feat/merged2" 2
+stub="$TMPDIR_ROOT/gh-t10"
+make_head_stub "$stub" "$TMPDIR_ROOT/sent-t10" \
+    "feat/open2:55:OPEN:-" "feat/merged2:66:MERGED:oid66"
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$TMPDIR_ROOT/ci-no" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50 ORPHAN_PUBLIC_CLONE=""
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+_n=$(count_orphans "$out")
+if [ "$_n" = "1" ] && has_orphan "$out" "feat/orphan2" \
+   && printf '%s\n' "$out" | grep -q '^chain: pr .*feat/open2' \
+   && printf '%s\n' "$out" | grep -q '^chain: merged .*feat/merged2'; then
+    pass "T10: mixed repo — 1 orphan + correct chain labels"
+else
+    fail "T10: mixed classification wrong (orphans=$_n): $(printf '%s\n' "$out" | grep -E '^(ORPHAN|chain:)')"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX ORPHAN_PUBLIC_CLONE
+
+# ── T11: propagated — merged PR whose mergeCommit is in the public clone -----
+t="$TMPDIR_ROOT/t11"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/prop" 2
+# A public clone whose history contains the mergeCommit oid.
+pub="$t/pub"; mk_repo "$pub"
+GIT_AUTHOR_DATE="$((now - 86400)) +0000" GIT_COMMITTER_DATE="$((now - 86400)) +0000" \
+    git -C "$pub" commit -q --allow-empty -m "squash for feat/prop"
+oid="$(git -C "$pub" rev-parse HEAD)"
+stub="$TMPDIR_ROOT/gh-t11"
+make_head_stub "$stub" "$TMPDIR_ROOT/sent-t11" "feat/prop:77:MERGED:$oid"
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$TMPDIR_ROOT/ci-no" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50 ORPHAN_PUBLIC_CLONE="$pub"
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if printf '%s\n' "$out" | grep -q '^chain: propagated .*feat/prop'; then
+    pass "T11: merged + mergeCommit in public clone -> propagated"
+else
+    fail "T11: expected propagated; got: $(printf '%s\n' "$out" | grep -E '^chain:')"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX ORPHAN_PUBLIC_CLONE
+
+# ── T12: ci-green — open PR whose `gh pr checks` exits 0 (all green) ---------
+t="$TMPDIR_ROOT/t12"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/green" 1
+stub="$TMPDIR_ROOT/gh-t12"
+make_head_stub "$stub" "$TMPDIR_ROOT/sent-t12" "feat/green:88:OPEN:-"
+ci_yes="$TMPDIR_ROOT/ci-yes"
+{ printf '%s\n' '#!/usr/bin/env bash'; printf '%s\n' 'echo -e "CI\t\tpass"'; printf '%s\n' 'exit 0'; } > "$ci_yes"; chmod +x "$ci_yes"
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$ci_yes" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if printf '%s\n' "$out" | grep -q '^chain: ci-green .*feat/green'; then
+    pass "T12: open PR + green CI -> ci-green"
+else
+    fail "T12: expected ci-green; got: $(printf '%s\n' "$out" | grep -E '^chain:')"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T13: closed-only PR -> abandoned, NOT orphan, NOT merged -----------------
+t="$TMPDIR_ROOT/t13"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/closed" 1
+stub="$TMPDIR_ROOT/gh-t13"
+make_head_stub "$stub" "$TMPDIR_ROOT/sent-t13" "feat/closed:33:CLOSED:-"
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$TMPDIR_ROOT/ci-no" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if ! has_orphan "$out" "feat/closed" && printf '%s\n' "$out" | grep -q '^chain: closed .*feat/closed'; then
+    pass "T13: closed-only PR -> chain: closed (abandoned, not orphan)"
+else
+    fail "T13: expected chain: closed; got: $(printf '%s\n' "$out" | grep -E '^(ORPHAN|chain:)')"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T14: STSTATIC — lib never issues a headless `gh pr list` -----------------
+# A headless (no --head) `gh pr list --state all` is the truncation trap root
+# cause.  Grep the lib source for the pattern and reject it.
+_lib_src="$OB_LIB"
+# Strip comment lines BEFORE the check: the lib's header deliberately quotes the
+# anti-pattern (`gh pr list --state all --limit 1000`) to document the trap, and
+# matching that prose is a false positive on the test's own documentation.
+if grep -vE '^[[:space:]]*#' "$_lib_src" | grep -E 'pr list' | grep -qv -- '--head'; then
+    fail "T14 STATIC: lib issues a headless 'gh pr list' (truncation-trap root cause)"
+else
+    pass "T14 STATIC: every 'gh pr list' in the lib carries --head (no global membership test)"
+fi
+
+# ── T16: transient empty response must NOT become a false ORPHAN -------------
+# Observed 2026-07-28: `gh pr list --head fix/himmel-1315-revert-duplicate-switch`
+# returned rc=0 and EMPTY for a branch whose PR #1442 was MERGED; a re-query
+# returned it.  An empty rc=0 is indistinguishable from a genuine no-PR result,
+# so the scan must confirm with a second query before claiming ORPHAN.  This
+# stub is empty on its FIRST --head call and returns the merged PR thereafter.
+t="$TMPDIR_ROOT/t16"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "fix/flaky" 1
+stub="$TMPDIR_ROOT/gh-t16"; ctr="$TMPDIR_ROOT/t16-calls"
+{
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf 'ctr=%q\n' "$ctr"
+    printf '%s\n' 'if [ "$3" != "--head" ]; then exit 0; fi'
+    printf '%s\n' 'n=0; [ -f "$ctr" ] && n=$(cat "$ctr")'
+    printf '%s\n' 'n=$((n + 1)); printf "%s" "$n" > "$ctr"'
+    printf '%s\n' 'if [ "$n" -le 1 ]; then exit 0; fi'   # first call: transient empty
+    printf '%s\n' 'printf "%s\t%s\t%s\n" 1442 MERGED -'
+} > "$stub"
+chmod +x "$stub"
+export FORGE=github GH_CMD="$stub" ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if ! has_orphan "$out" "fix/flaky" && [ "$(chain_state_of "$out" "fix/flaky")" = "merged" ]; then
+    pass "T16: transient empty rc=0 re-queried -> chain: merged (no false ORPHAN)"
+else
+    fail "T16: transient empty became a false verdict; got: $(printf '%s\n' "$out" | grep -E '^(ORPHAN|chain:|uncertain:)')"
+fi
+unset GH_CMD FORGE ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T15: dual-mode — running the lib as a script prints a report + exits 1 on orphan
+t="$TMPDIR_ROOT/t15"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/orphan3" 1
+stub="$TMPDIR_ROOT/gh-t15"; write_stub "$stub" 'exit 0'
+out="$(FORGE=github GH_CMD="$stub" ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50 \
+    OB_PRIMARY="$t/rep" bash "$OB_LIB" 2>/dev/null)"; rc=$?
+if [ "$rc" -ne 0 ] && printf '%s\n' "$out" | grep -q '^ORPHAN feat/orphan3'; then
+    pass "T15: dual-mode run -> report + non-zero exit on orphan"
+else
+    fail "T15: dual-mode failed (rc=$rc): $(printf '%s\n' "$out" | grep -E '^(ORPHAN|orphan-branches:)' | head -3)"
+fi
+unset GH_CMD FORGE ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T17: forge calls use the target repo, not the ambient cwd -----------------
+t="$TMPDIR_ROOT/t17"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "fix/scoped" 1
+mkdir -p "$t/elsewhere"
+sent="$TMPDIR_ROOT/sent-t17"; rm -f "$sent"
+stub="$TMPDIR_ROOT/gh-t17"
+{
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf 'expected=%q\n' "$t/rep"
+    printf 'sent=%q\n' "$sent"
+    printf '%s\n' 'if [ "$PWD" != "$expected" ]; then touch "$sent"; exit 1; fi'
+    printf '%s\n' 'if [ "$1" = pr ] && [ "$2" = list ] && [ "$3" = --head ] && [ "$4" = fix/scoped ]; then'
+    printf '%s\n' '    printf "%s\t%s\t%s\n" 117 OPEN -; exit 0'
+    printf '%s\n' 'fi'
+    printf '%s\n' 'if [ "$1" = pr ] && [ "$2" = checks ] && [ "$3" = 117 ]; then'
+    printf '%s\n' '    printf "CI\t\tpass\n"; exit 0'
+    printf '%s\n' 'fi'
+    printf '%s\n' 'touch "$sent"; exit 1'
+} > "$stub"
+chmod +x "$stub"
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$stub" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(cd "$t/elsewhere" && orphan_branch_scan "$t/rep" 2>/dev/null)"
+if [ ! -f "$sent" ] && [ "$(chain_state_of "$out" "fix/scoped")" = "ci-green" ]; then
+    pass "T17: PR + CI lookups run from target repo when ambient cwd differs"
+else
+    fail "T17: forge lookup used ambient cwd or wrong args: $(printf '%s\n' "$out" | grep -E '^(ORPHAN|chain:|uncertain:)')"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T18: generated stub matches pattern metacharacters literally --------------
+t="$TMPDIR_ROOT/t18"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "fix/a)b" 1
+stub="$TMPDIR_ROOT/gh-t18"
+make_head_stub "$stub" "$TMPDIR_ROOT/sent-t18" "fix/a)b:118:OPEN:-"
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$TMPDIR_ROOT/ci-no" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if ! has_orphan "$out" "fix/a)b" && [ "$(chain_state_of "$out" "fix/a)b")" = "pr" ]; then
+    pass "T18: generated stub matches metacharacter branch fix/a)b literally"
+else
+    fail "T18: metacharacter branch was misclassified: $(printf '%s\n' "$out" | grep -E '^(ORPHAN|chain:|uncertain:)')"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T19: pending checks remain distinct from failed checks --------------------
+t="$TMPDIR_ROOT/t19"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/pending" 1
+stub="$TMPDIR_ROOT/gh-t19"
+make_head_stub "$stub" "$TMPDIR_ROOT/sent-t19" "feat/pending:119:OPEN:-"
+ci_pending="$TMPDIR_ROOT/ci-pending"
+{ printf '%s\n' '#!/usr/bin/env bash'; printf '%s\n' 'exit 8'; } > "$ci_pending"; chmod +x "$ci_pending"
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$ci_pending" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if printf '%s\n' "$out" | grep -q '^chain: pr .*feat/pending.*ci=pending'; then
+    pass "T19: open PR + pending CI -> chain: pr, ci=pending"
+else
+    fail "T19: expected ci=pending; got: $(printf '%s\n' "$out" | grep -E '^chain:')"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T20: rc=1 with NO checks output -> ci=none (HIMMEL-1325) -------------------
+# `gh pr checks` exits 1 for BOTH a red check AND "no checks reported"
+# (cli/cli#9390, #9682, #7401 — upstream has declined to change it). Actions is
+# OFF on this private repo, so "no checks" is the COMMON private-PR state. The
+# no-checks message goes to stderr (the lib captures stderr to /dev/null), so the
+# realistic stub leaves stdout EMPTY on a rc=1: that must read `none`, not `failed`.
+t="$TMPDIR_ROOT/t20"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/nochecks" 1
+stub="$TMPDIR_ROOT/gh-t20"
+make_head_stub "$stub" "$TMPDIR_ROOT/sent-t20" "feat/nochecks:201:OPEN:-"
+ci_none="$TMPDIR_ROOT/ci-none"
+{ printf '%s\n' '#!/usr/bin/env bash'; printf '%s\n' 'exit 1'; } > "$ci_none"; chmod +x "$ci_none"
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$ci_none" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if ! has_orphan "$out" "feat/nochecks" && printf '%s\n' "$out" | grep -q '^chain: pr .*feat/nochecks.*ci=none'; then
+    pass "T20: rc=1 + empty output (no checks) -> ci=none (not failed)"
+else
+    fail "T20: expected ci=none for no-checks rc=1; got: $(printf '%s\n' "$out" | grep -E '^(ORPHAN|chain:|uncertain:)')"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T21: rc=1 with gh's "no checks" message ON STDOUT -> ci=none (HIMMEL-1325) -
+# Defensive: some gh builds print "no checks reported" to STDOUT (not stderr),
+# so $out is non-empty on a no-checks rc=1. The discriminator must still read it
+# as `none` by matching the message, never treat the non-empty rc=1 as `failed`.
+t="$TMPDIR_ROOT/t21"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/nomsg" 1
+stub="$TMPDIR_ROOT/gh-t21"
+make_head_stub "$stub" "$TMPDIR_ROOT/sent-t21" "feat/nomsg:202:OPEN:-"
+ci_nomsg="$TMPDIR_ROOT/ci-nomsg"
+{ printf '%s\n' '#!/usr/bin/env bash'; printf '%s\n' 'echo "no checks reported"'; printf '%s\n' 'exit 1'; } > "$ci_nomsg"; chmod +x "$ci_nomsg"
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$ci_nomsg" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+if ! has_orphan "$out" "feat/nomsg" && printf '%s\n' "$out" | grep -q '^chain: pr .*feat/nomsg.*ci=none'; then
+    pass "T21: rc=1 + 'no checks reported' on stdout -> ci=none (matched by message)"
+else
+    fail "T21: expected ci=none for no-checks message; got: $(printf '%s\n' "$out" | grep -E '^(ORPHAN|chain:|uncertain:)')"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T22: leading-zero ORPHAN_BRANCH_DAYS must not parse as octal (HIMMEL-1325) -
+# $(( )) parses a leading-zero value as OCTAL, so "08" is an error ("value too
+# great for base") and the scan ABORTS (verified pre-fix: line 266 error, exit 1,
+# empty stdout). Base-10 normalization (10#$days) must let a config like 08 scan.
+t="$TMPDIR_ROOT/t22"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/oct" 1
+stub="$TMPDIR_ROOT/gh-t22"
+write_stub "$stub" 'exit 0'
+export FORGE=github GH_CMD="$stub" ORPHAN_BRANCH_DAYS=08 ORPHAN_BRANCH_MAX=50
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+# window=8d (not 08d) + the orphan surfaced => days was read base-10, not octal.
+if has_orphan "$out" "feat/oct" && printf '%s\n' "$out" | grep -q 'window=8d'; then
+    pass "T22: ORPHAN_BRANCH_DAYS=08 parsed base-10 (window=8d, orphan found)"
+else
+    fail "T22: leading-zero days misparsed as octal: $(printf '%s\n' "$out" | grep -E '^(ORPHAN|chain:|orphan-branches:)' | head)"
+fi
+unset GH_CMD FORGE ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX
+
+# ── T23: no `timeout` binary -> scan still bounds gh via _ob_bounded (HIMMEL-1325)
+# Stock macOS / minimal containers have no GNU timeout, so _ob_timeout_cmd returns
+# empty and the scan must fall back to the portable _ob_bounded runner rather than
+# run gh UNBOUNDED. Override the detector to SIMULATE that host (no pgrep needed —
+# the stub records its own PID via $$ and we kill -0 it), point gh at a stub that
+# hangs (exec sleep 30 so $! IS the sleep, killable with no orphan), and assert:
+# bounded (< the stub's 30s) + uncertain (timeout => rc!=0 => uncertain) + no
+# false ORPHAN + the hung child is reaped (not lingering).
+t="$TMPDIR_ROOT/t23"; mk_repo "$t/rep"; mk_origin_main "$t/rep"
+mk_remote_branch "$t/rep" "feat/slow2" 1
+stub="$TMPDIR_ROOT/gh-t23"
+# exec sleep 30 => the stub process becomes sleep, so $! is sleep's PID and the
+# SIGTERM hits it directly (mirrors real gh, a single binary with no child tree).
+write_stub "$stub" "echo \$\$ > '$TMPDIR_ROOT/t23-pid'" 'exec sleep 30'
+_orig_tcmd="$(declare -f _ob_timeout_cmd)"    # save real detector, restore after
+_ob_timeout_cmd() { :; }                       # simulate "no timeout/gtimeout"
+export FORGE=github GH_CMD="$stub" OB_CI_CMD="$stub" \
+    ORPHAN_BRANCH_DAYS=30 ORPHAN_BRANCH_MAX=50 ORPHAN_BRANCH_TIMEOUT=1
+_ts=$(date +%s)
+out="$(orphan_branch_scan "$t/rep" 2>/dev/null)"
+_te=$(date +%s); _el=$(( _te - _ts ))
+_spid="$(cat "$TMPDIR_ROOT/t23-pid" 2>/dev/null)"
+_left=0; kill -0 "$_spid" 2>/dev/null && _left=1
+eval "$_orig_tcmd"                             # restore the real _ob_timeout_cmd
+if ! has_orphan "$out" "feat/slow2" && printf '%s\n' "$out" | grep -q '^uncertain:' \
+   && [ "$_el" -lt 10 ] && [ "$_left" = 0 ]; then
+    pass "T23: no-timeout-binary fallback bounded (${_el}s<10s) -> uncertain, child reaped"
+else
+    fail "T23: portable fallback failed (el=${_el}s, leftover=$_left): $(printf '%s\n' "$out" | grep -E '^(ORPHAN|uncertain:)' | head)"
+fi
+unset GH_CMD FORGE OB_CI_CMD ORPHAN_BRANCH_DAYS ORPHAN_BRANCH_MAX ORPHAN_BRANCH_TIMEOUT
+
+# ── T24: _ob_bounded normal path -> real rc + stdout captured + NO noise --------
+# The fast (non-timeout) path must return the child's real exit status, capture
+# its stdout, and emit no job-control `[n] PID`/Done chatter. We capture the
+# FUNCTION's stderr (where any such noise would surface) and assert it is empty.
+_btmp="$TMPDIR_ROOT/ob-bnd.out"; _berr="$TMPDIR_ROOT/ob-bnd.err"
+_ob_bounded 3 "$_btmp" "$TMPDIR_ROOT" sh -c 'printf "ok\n"; exit 0' 2>"$_berr"
+_rc=$?
+if [ "$_rc" = 0 ] && [ "$(cat "$_btmp")" = ok ] && [ ! -s "$_berr" ]; then
+    pass "T24: _ob_bounded fast path -> rc=0, stdout captured, no job-control noise"
+else
+    fail "T24: fast path wrong (rc=$_rc, out=$(cat "$_btmp" 2>/dev/null), err=$(cat "$_berr" 2>/dev/null))"
+fi
+
+# ── T25: shared ci-no stub is chmod +x'd (HIMMEL-1325) -------------------------
+# The ci-no stub (shared as OB_CI_CMD by T2/T3/T4/T10/T11/T13/T18) was the SOLE
+# stub written without `chmod +x` (every other stub at lines 78/107/328/459/481/501
+# has it). On Linux/macOS a non-executable OB_CI_CMD returns 126 (not 1), so
+# _ob_ci_state takes the rc!=0 -> pending branch instead of the rc==1 branch and
+# those 7 tests silently stop testing what they claim. Git Bash/MSYS EXECUTES
+# non-executable scripts AND reports `test -x` true AND `stat` mode 755 for them,
+# so the behavioral tests + a [ -x ] guard all pass here regardless — exactly why
+# this bug shipped unnoticed on Windows. This guard reads the test's OWN source
+# for the chmod line: a text check no MSYS permissiveness can mask, so it fails
+# the moment the chmod is dropped, on EVERY OS (it FAILED pre-fix).
+if grep -qE 'chmod[[:space:]]+\+x.*ci-no' "$0"; then
+    pass "T25: shared ci-no stub is chmod +x'd (no 126 on Linux/macOS)"
+else
+    fail "T25: ci-no stub missing chmod +x — returns 126 (not 1) on Linux/macOS"
+fi
+
+# ── summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $_pass passed, $_fail failed"
+[ "$_fail" -eq 0 ]


### PR DESCRIPTION
## What

A new library, `scripts/lib/orphan-branches.sh`, plus its suite. It scans the branches currently on `origin` and reports how far each one actually got:

| state | meaning | level |
|---|---|---|
| `pushed` | on origin, **no PR** — the orphan, the failure class | WARN |
| `pr` | open PR, CI not green | info |
| `ci-green` | open PR, all checks passing | info |
| `merged` | merged PR, propagation not confirmed | info |
| `propagated` | merged PR whose squash commit reached the public clone | info |

(`closed` — a branch whose only PR was closed unmerged — is reported as a truncated chain, never as an orphan. Abandoned work is a different thing from lost work.)

Sourced by the doctor check; also runnable directly for an ad-hoc scan.

## Why

The durable signal that work survived its session is **branch↔PR pairing**, not process liveness. A branch with a PR outlives the session that made it; a branch without one depends on a process staying alive. A resident agent process is not evidence work is progressing, and an exited one is not evidence it finished — so this keys off pairing and never off process state.

Because the merge flow deletes the source branch on success, a branch still sitting on `origin` is by definition not fully shipped. A scan of current origin branches is therefore exactly the set of truncated chains, with no extra bookkeeping.

## The false-positive trap this is built around

The obvious implementation is one global `gh pr list --state all --limit 1000` plus a membership test. That is wrong, and wrong in a way that looks like it works:

- the listing **truncates past ~999 refs**
- so every older branch falls out of the list
- so every older branch reads as orphaned

Measured, that produced **81 false positives**.

This library never issues a headless global `gh pr list`. It queries **per branch** (`gh pr list --head <branch>`), which is bounded by construction and cannot be truncated by the global cap. Candidates are narrowed locally first with pure git — date window, protected-name exclude, count cap — and **every bound is stated in the output**, because silent truncation reads as "covered everything," which is the precise failure this guard exists to catch.

One related correctness note: after a squash merge the source branch still reads ahead of main, so `ahead=N` is deliberately **not** used as an unmerged signal. PR state (none / open / merged) is the signal.

## Scope

Two new files. No existing file is touched.

## Verification

`scripts/lib/test-orphan-branches.sh` — **25 passed / 0 failed**.

Review found three real defects, all fixed here:

1. **Octal parse.** `ORPHAN_BRANCH_DAYS` reached arithmetic without base-10 normalisation, so a zero-padded value would be read as octal.
2. **Unbounded timeout wrapper.** The wrapper stopped bounding when neither `timeout` nor `gtimeout` is installed — i.e. it silently gave up on exactly the systems that lack the tool. Three call sites needed the bound, not two; the third was the network fetch, which is the one that most needs it. Shipping two of three would have advertised a bounded scan while the network call stayed unbounded.
3. **Test blind spot.** A test could not distinguish a *missing* library from one that *failed to source*.

### One deliberate test-design choice

The executable-bit guard is a **static source-text** check, not a runtime assertion. On Git Bash / MSYS the filesystem masks executability at every layer — non-executable scripts still run, `test -x` returns true, `stat` reports 755 — so no runtime assertion can fail on Windows. A runtime test here would pass for the wrong reason rather than verify anything.
