### PR TITLE
fix: leg-12 wave — dependabot bumps, codex-adv background harvest, review-contract taxonomy, graphify promote fence

### DIFF
--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -112,6 +112,70 @@ Steps:
 
 3. **Cross-model finding passes (critic panel, codex, CodeRabbit), then adjudication (HIMMEL-178, HIMMEL-270, HIMMEL-415, HIMMEL-926).**
 
+   **Step 3 kickoff — background-launch the codex adversarial pass first, harvest in step 3.1 (HIMMEL-1407).** Root cause of 28 lifetime `/pr-check` timeouts: the codex companion's `adversarial-review --wait` is HEALTHY at kill time — it emits its verdict, then runs the repo's test suites to verify before finalizing, and the old foreground `CRITIC_TIMEOUT_SECS*2` timebox killed it mid-verification on every test-heavy diff, burning OpenAI quota for zero collected signal each time. The companion parses `--background` for `adversarial-review` but `handleReviewCommand` always runs foreground regardless (the flag is dead — not fixable here, the companion is not vendored in this repo). Fix at the runbook level instead: LAUNCH the pass as a real OS background job here, before the critic panel fence below even starts, so its wall-clock overlaps the panel instead of stacking after it; step 3.1 below HARVESTS it with a bounded additional wait after the panel finishes, so the common case adds ~zero wall-clock over the panel alone. Gate + resolution are identical to step 3.1's own (CR_PROFILE=none skip, companion-absent skip with the same one-line message, HIMMEL-741c glob resolution — never `ls`, the `cygpath -m` conversion). This fence is independent of every other fence in this runbook, so it re-resolves `$db` + `CR_PROFILE` itself:
+
+   ```bash
+   db=$(. scripts/guardrails/lib.sh 2>/dev/null && default_branch || echo main)
+   . scripts/lib/load-dotenv.sh; load_dotenv CR_PROFILE || true
+   export CR_PROFILE
+   branch=$(git branch --show-current)
+   git_dir=$(git rev-parse --git-common-dir)
+   # Branch-scoped under the SHARED git-common-dir, same convention as
+   # cr-pending/cr-prior-blocking (HIMMEL-1219) — concurrent /pr-check runs on
+   # different branches must not collide on one file. mkdir -p the parent
+   # because a branch name contains '/' (e.g. fix/himmel-1407-...).
+   codex_out="${git_dir}/codex-adv-out/${branch}"
+   codex_pid_file="${codex_out}.pid"
+   codex_rc_file="${codex_out}.rc"
+   # Companion stderr goes to its OWN sibling file, not merged into
+   # $codex_out (glm-3, CR round 2, HIMMEL-1407): findings capture must stay
+   # stdout-only, or diagnostic chatter on an otherwise-successful run gets
+   # forwarded to adjudication as review output. Preserved (not deleted) by
+   # the harvest fence below for debugging — the old `2>/dev/null` discard is
+   # exactly what hid this ticket's root cause for 28 runs.
+   codex_err_file="${codex_out}.err"
+   mkdir -p "$(dirname "$codex_out")"
+   # Overwrite per run — no unbounded growth, and a stale pid/rc/err from a
+   # PRIOR run on this branch can never be mistaken for this run's job.
+   rm -f "$codex_pid_file" "$codex_rc_file"; : > "$codex_out"; : > "$codex_err_file"
+   # Resolve via bash glob, NOT `ls` (HIMMEL-741c: Git Bash `ls` classify suffix
+   # `*` on executables corrupts the path). Last glob match = highest lexical.
+   companion=""
+   for _c in "$HOME/.claude/plugins/cache/openai-codex/codex/"*/scripts/codex-companion.mjs; do
+       [ -f "$_c" ] && companion="$_c"
+   done
+   # Windows node mangles an MSYS /c/... path into C:\c\... — hand it a native
+   # (mixed-form) path when cygpath exists; POSIX systems pass through unchanged.
+   if [ -n "$companion" ] && command -v cygpath >/dev/null 2>&1; then
+       companion=$(cygpath -m "$companion")
+   fi
+   if [ "${CR_PROFILE:-}" = "none" ]; then
+       : # claude-only — codex adversarial pass also skipped under none (step 3.1's harvest skips too).
+   elif [ -z "$companion" ]; then
+       echo "codex adversarial pass skipped (codex not configured)"
+   else
+       # A real OS background job, NOT `timeout`-wrapped (that would just
+       # reintroduce the foreground timebox one level up — the exact thing
+       # this restructure removes). The pid file records NODE's own pid,
+       # written from INSIDE the wrapper subshell — not the wrapper's $!:
+       # signaling a bash wrapper does not propagate to its running child, so
+       # a wrapper-pid kill on the timeout path would leave node alive and
+       # orphaned, still consuming quota (the exact cost HIMMEL-1407 exists
+       # to stop; also the Windows grandchild-kill trap). The wrapper lingers
+       # only to write node's exit status to $codex_rc_file after node exits,
+       # so step 3.1's harvest — a separate bash fence with no job-table link
+       # back to this one — can tell "still running" apart from "ran and
+       # failed" using only the pid + rc files on disk.
+       ( node "$companion" adversarial-review --wait --base "$db" >"$codex_out" 2>"$codex_err_file" &
+         _node_pid=$!
+         echo "$_node_pid" > "$codex_pid_file"
+         wait "$_node_pid"
+         echo $? > "$codex_rc_file" ) &
+       disown 2>/dev/null || true
+       echo "codex adversarial pass launched in background — harvested in step 3.1 after the critic panel (HIMMEL-1407)"
+   fi
+   ```
+
    **Step 3.0 — critic panel first-pass (decimal substep, runs BEFORE any Agent dispatch):**
 
    `/pr-check` runs the cross-model panel (~2min — bounded by the 240 s per-member `CRITIC_TIMEOUT_SECS`, but ONLY when the `timeout` binary is present; without it each member runs unbounded — see step 3.0's hang-protection note) by **default**. Control via `CR_PROFILE`.
@@ -223,50 +287,82 @@ Steps:
    forwarded to agents — append them directly to the aggregate
    `## Suggestions` section in step 3's output (step 7 files them).
 
-   **Step 3.1 — codex adversarial-review pass (decimal substep, runs AFTER the critic panel, still before any Agent dispatch; HIMMEL-694).** An ADDITIONAL pre-merge cross-model pass of the paid/pair tier: the codex companion's `adversarial-review` mode. It is **availability-gated** — it consumes the operator's OpenAI usage bank, so it runs ONLY when codex is configured and silently skips (one-line note, never an error) otherwise, mirroring how the paid codex critic is gated in `critics.json` / the `CR_PROFILE=paid` lane. Like the panel, this pass is **fail-open**: absence, timeout, or error degrades to claude-only and never blocks the gate.
+   **Step 3.1 — codex adversarial-review pass: harvest (decimal substep, runs AFTER the critic panel, still before any Agent dispatch; HIMMEL-694, HIMMEL-1407).** The pass itself was already LAUNCHED as a background job in the step-3 kickoff fence above — this substep HARVESTS it. It is **availability-gated** — it consumes the operator's OpenAI usage bank, so it runs ONLY when codex is configured (the kickoff fence's skip note already covers the unconfigured case), mirroring how the paid codex critic is gated in `critics.json` / the `CR_PROFILE=paid` lane. Like the panel, this pass is **fail-open**: absence, timeout, or error degrades to claude-only and never blocks the gate.
 
-   Gate, checked FIRST:
-   - `CR_PROFILE=none` → skip (none = instant claude-only; the codex adversarial pass is ALSO skipped under none).
-   - codex companion absent → print one line `codex adversarial pass skipped (codex not configured)` and continue. Do NOT hardcode the version segment in the path (brittle — `1.0.5` drifts on plugin update); the fence below resolves the installed copy with a **bash glob loop, never `ls`** (HIMMEL-741c: Git Bash `ls` appends a classify `*` to executables, corrupting the captured path into `…codex-companion.mjs*` → `MODULE_NOT_FOUND` → silent rc=1). Glob order is lexical, so the last match is "highest lexical", not strictly highest semver — revisit only if a `1.0.10`-vs-`1.0.5` ordering bite appears. On Windows the MSYS `/c/…` form must also be converted to a native path before it reaches `node` (which reads `/c/…` as `C:\c\…`) — hence the `cygpath -m` step.
-
-   The pass (~3min typical), timeboxed at `CRITIC_TIMEOUT_SECS*2` (≈480s — twice the per-member panel budget; the adversarial run is a single heavier call). Each bash fence in this runbook is independent, so re-resolve `$db` + `CR_PROFILE`:
+   **Harvest budget (HIMMEL-1407 — replaces the old foreground `CRITIC_TIMEOUT_SECS*2` timebox that caused 28 lifetime timeouts).** After the panel completes, poll for the backgrounded process's exit up to `CRITIC_TIMEOUT_SECS*2` MORE seconds (≈480s default — the same per-pass budget the old foreground timebox used, now measured from harvest-start instead of launch-start). Net time available to the review is panel-wall-clock + ≈480s (typically 12–20min total), with ~zero added wall-clock in the common case where the review finishes during or shortly after the panel. If the process is still alive once that budget is exhausted, kill it and record a timeout — the same fail-open outcome as before, just far less likely to fire on a healthy review still running its post-verdict test-suite verification. Each bash fence in this runbook is independent, so re-resolve `$db` + `CR_PROFILE` and the branch-scoped pid/rc/output files the kickoff fence wrote:
    ```bash
    db=$(. scripts/guardrails/lib.sh 2>/dev/null && default_branch || echo main)
    . scripts/lib/load-dotenv.sh; load_dotenv CR_PROFILE || true
    export CR_PROFILE
+   branch=$(git branch --show-current)
+   git_dir=$(git rev-parse --git-common-dir)
+   codex_out="${git_dir}/codex-adv-out/${branch}"
+   codex_pid_file="${codex_out}.pid"
+   codex_rc_file="${codex_out}.rc"
+   codex_err_file="${codex_out}.err"  # companion stderr, kept for debugging — see kickoff fence (glm-3, CR round 2)
    codex_findings=""; codex_rc=0
-   # Resolve via bash glob, NOT `ls` (HIMMEL-741c: Git Bash `ls` classify suffix
-   # `*` on executables corrupts the path). Last glob match = highest lexical.
-   companion=""
-   for _c in "$HOME/.claude/plugins/cache/openai-codex/codex/"*/scripts/codex-companion.mjs; do
-       [ -f "$_c" ] && companion="$_c"
-   done
-   # Windows node mangles an MSYS /c/... path into C:\c\... — hand it a native
-   # (mixed-form) path when cygpath exists; POSIX systems pass through unchanged.
-   if [ -n "$companion" ] && command -v cygpath >/dev/null 2>&1; then
-       companion=$(cygpath -m "$companion")
-   fi
    if [ "${CR_PROFILE:-}" = "none" ]; then
-       : # claude-only — codex adversarial pass also skipped under none.
-   elif [ -z "$companion" ]; then
-       echo "codex adversarial pass skipped (codex not configured)"
+       : # claude-only — codex adversarial pass also skipped under none (kickoff fence never launched a job).
+   elif [ ! -s "$codex_pid_file" ]; then
+       # No job was launched — companion was absent at kickoff time (already
+       # reported there with "codex adversarial pass skipped (codex not
+       # configured)").
+       : # nothing to harvest.
    else
+       codex_pid=$(cat "$codex_pid_file")
        # 10# forces base 10: `$(( ))` reads a LEADING ZERO as octal, so
        # CRITIC_TIMEOUT_SECS=08 would die here with "value too great for base",
-       # leave codex_to empty, and surface as "codex adversarial pass failed" —
-       # a wrong cause for a value that looks perfectly configured. Same fix
-       # critic-panel.sh applies to its own copy of this variable.
+       # leave codex_to empty, and surface as a wrong cause for a value that
+       # looks perfectly configured. Same fix critic-panel.sh applies to its
+       # own copy of this variable.
        codex_to=$(( 10#${CRITIC_TIMEOUT_SECS:-240} * 2 ))
-       if command -v timeout >/dev/null 2>&1; then
-           codex_findings=$(timeout -k 5 "$codex_to" node "$companion" adversarial-review --wait --base "$db" 2>/dev/null) || codex_rc=$?
+       # Bounded poll loop, NOT `timeout` (Windows note, HIMMEL-1407): `timeout`
+       # cannot wrap an already-detached background PID, and a poll loop
+       # degrades gracefully on any host regardless of whether `timeout` is
+       # installed — unlike the old foreground fence's `command -v timeout`
+       # branch, this harvest needs no such fallback.
+       waited=0
+       while kill -0 "$codex_pid" 2>/dev/null; do
+           [ "$waited" -ge "$codex_to" ] && break
+           sleep 5
+           waited=$((waited + 5))
+       done
+       if kill -0 "$codex_pid" 2>/dev/null; then
+           # Still running after the bounded additional wait — kill it and
+           # record a timeout, same fail-open outcome as the old rc=124/137 case.
+           kill "$codex_pid" 2>/dev/null; sleep 1; kill -9 "$codex_pid" 2>/dev/null
+           echo "codex adversarial pass timed out (>${codex_to}s after the panel finished; stderr: $codex_err_file) — continuing without it" >&2
+           codex_findings=""; codex_rc=124
        else
-           codex_findings=$(node "$companion" adversarial-review --wait --base "$db" 2>/dev/null) || codex_rc=$?
+           # Node has exited (kill -0 above just failed), but the wrapper
+           # subshell writes $codex_rc_file a BEAT LATER — after `wait
+           # "$_node_pid"` returns — so a genuinely successful run landing in
+           # that window must not be discarded as "no recorded status"
+           # (codex-1, CR round 2, HIMMEL-1407: this was a real race, not a
+           # theoretical one). Poll briefly for the rc file to appear before
+           # falling through to the fail-open no-status branch.
+           rc_wait=0
+           while [ ! -s "$codex_rc_file" ] && [ "$rc_wait" -lt 10 ]; do
+               sleep 1
+               rc_wait=$((rc_wait + 1))
+           done
+           if [ -s "$codex_rc_file" ]; then
+               codex_rc=$(cat "$codex_rc_file")
+               case "$codex_rc" in
+                   0) codex_findings=$(cat "$codex_out" 2>/dev/null) ;;  # success — findings (if any) captured
+                   *) echo "codex adversarial pass failed (rc=$codex_rc; stderr: $codex_err_file) — continuing without it" >&2; codex_findings="" ;;
+               esac
+           else
+               # rc file genuinely never appeared (killed pre-write, or a
+               # crash) — same fail-open "continuing without it" outcome.
+               echo "codex adversarial pass exited without a recorded status (waited ${rc_wait}s; stderr: $codex_err_file) — continuing without it" >&2
+               codex_findings=""; codex_rc=1
+           fi
        fi
-       case "$codex_rc" in
-           0) ;;  # success — findings (if any) captured
-           124|137) echo "codex adversarial pass timed out — continuing without it"; codex_findings="" ;;
-           *) echo "codex adversarial pass failed (rc=$codex_rc) — continuing without it" >&2; codex_findings="" ;;
-       esac
+       # $codex_err_file is intentionally NOT removed here (glm-3, CR round 2)
+       # — companion stderr stays on disk for debugging; only pid/rc, whose
+       # job is done once harvested, are cleaned up.
+       rm -f "$codex_pid_file" "$codex_rc_file"
    fi
    # Surface findings (if any) so they flow into the step-3 adjudication prepend.
    [ -n "$codex_findings" ] && printf '%s\n' "$codex_findings"
@@ -280,7 +376,7 @@ Steps:
    # candidate and a `- [low] …` line as a Suggestion, which is never a
    # blocker and needs no verdict for conservation.)
    ```
-   (`timeout` absent degrades to unbounded — same graceful-degrade convention as `critic-panel.sh`; the run still fails open on any non-zero / empty result. `--base "$db"` is the runbook's default-branch var from step 3.0.)
+   (`--base "$db"` at launch is the runbook's default-branch var from step 3.0's sibling resolution above; the harvest fence itself needs no `timeout` binary — see the poll-loop note in the fence.)
 
    **Findings merge (HIMMEL-694):** the pass's Critical/Important findings are BLOCKING CANDIDATES exactly like panel `[<slug>-N]` findings, tagged `[codex-adv-N]`. Merge them into the SAME adjudication flow:
    - Forwarded under the cross-model adjudication directive below alongside the panel findings (slug `codex-adv`); the mandatory adjudicator (the session itself by default; the `code-reviewer` agent under `CR_CLAUDE_AGENTS=1` — step 3.5) renders a `VERDICT [codex-adv-N] = …` on each (the generic `[<slug>-N]` machinery in step 4 and the adjudicator note below treat `codex-adv` as the slug, so codex findings are never orphaned).

--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -150,6 +150,7 @@ Steps:
        companion=$(cygpath -m "$companion")
    fi
    if [ "${CR_PROFILE:-}" = "none" ]; then
+       echo "claude-only (CR_PROFILE=none) — codex adversarial pass not launched"
        : # claude-only — codex adversarial pass also skipped under none (step 3.1's harvest skips too).
    elif [ -z "$companion" ]; then
        echo "codex adversarial pass skipped (codex not configured)"
@@ -315,7 +316,14 @@ Steps:
        # leave codex_to empty, and surface as a wrong cause for a value that
        # looks perfectly configured. Same fix critic-panel.sh applies to its
        # own copy of this variable.
-       codex_to=$(( 10#${CRITIC_TIMEOUT_SECS:-240} * 2 ))
+       # Normalize BEFORE the 10# arithmetic: a non-numeric value (e.g. "abc")
+       # dies the `$(( ))` outright, and a negative or zero value yields an
+       # instant timeout — neither matches the documented contract
+       # (critic-panel.sh falls back to 240 on the same bad-value cases).
+       codex_timeout=${CRITIC_TIMEOUT_SECS:-240}
+       case "$codex_timeout" in ''|*[!0-9]*) codex_timeout=240 ;; esac
+       [ "$codex_timeout" -gt 0 ] || codex_timeout=240
+       codex_to=$(( 10#$codex_timeout * 2 ))
        # Bounded poll loop, NOT `timeout` (Windows note, HIMMEL-1407): `timeout`
        # cannot wrap an already-detached background PID, and a poll loop
        # degrades gracefully on any host regardless of whether `timeout` is
@@ -330,6 +338,14 @@ Steps:
        if kill -0 "$codex_pid" 2>/dev/null; then
            # Still running after the bounded additional wait — kill it and
            # record a timeout, same fail-open outcome as the old rc=124/137 case.
+           # Prefer a Windows tree-kill: plain `kill "$codex_pid"` reaches node
+           # but not the subprocesses the companion spawns (test suites) —
+           # double-slash `//PID`/`//T`/`//F` guards against MSYS path-mangling
+           # rewriting a leading `/` into a path. Full portable process-group
+           # kill is HIMMEL-1409; the POSIX kill chain stays as the fallback.
+           if command -v taskkill >/dev/null 2>&1; then
+               taskkill //PID "$codex_pid" //T //F 2>/dev/null
+           fi
            kill "$codex_pid" 2>/dev/null; sleep 1; kill -9 "$codex_pid" 2>/dev/null
            echo "codex adversarial pass timed out (>${codex_to}s after the panel finished; stderr: $codex_err_file) — continuing without it" >&2
            codex_findings=""; codex_rc=124

--- a/marketplace/plugins/claude-hud/VENDORED.manifest
+++ b/marketplace/plugins/claude-hud/VENDORED.manifest
@@ -264,7 +264,7 @@ d0098b6e0c0a40876fb033bf3970ab688fd83f37  dist/utils/truncate.js.map
 1a09e382e7a248007be2da37e750114c8065ece1  dist/version.d.ts.map
 54444685d064ba09e3afd66124497394c737ec3d  dist/version.js
 e527e286a9eae26d52e32fd5a7751b47225d7512  dist/version.js.map
-f25de1fa0c2c92be2964bfd98f8d0be049ce6341  package-lock.json
+4d889ed031aabf6c564ae695e64bbe06f300faef  package-lock.json
 e048d5031bb8fe194a090bba9992f6317d9200a0  package.json
 ae323f37c223573fbbe914b4713a349400dfe1e5  scripts/clean-dist.mjs
 a9fba8d0ca539fc6828ff1589ca0b7f9c75d0bdb  src/auth.ts

--- a/marketplace/plugins/claude-hud/VENDORED.md
+++ b/marketplace/plugins/claude-hud/VENDORED.md
@@ -16,7 +16,7 @@ fork_repo:            https://github.com/yotamleo/claude-hud   # public fork (HI
 upstream_repo:        https://github.com/jarrodwatts/claude-hud
 pinned_commit:        e39bafc6d778d61f41592eced53f8aa58bf5239c  # post-v0.6.0 main HEAD (jj status indicators #685; HIMMEL-1254)
 pinned_upstream_tree: 4fcbfe47ab8780e1b11c2ddb36c18be1b24a371f  # git tree of pinned_commit (provenance)
-vendored_tree_hash:   4476fb2597f49a065c60c5b93144fb4d7c2678a213c95f48f9f92a639441f1bb  # sha256 over VENDORED.manifest
+vendored_tree_hash:   208ec6f9fcb092cdb11957200d13f4341d74e5d235e9a1e6b85085b48237b04c  # sha256 over VENDORED.manifest
 vendored_at:          2026-07-21
 ```
 
@@ -125,7 +125,9 @@ protected: editing it without bumping the pin trips the guard.
   bump can land here WITHOUT a re-vendor, and the vendored tree then legitimately
   differs from `pinned_upstream_tree` by those hunks. Landed so far:
   `brace-expansion` 5.0.6 → 5.0.7 (dev-only transitive, PR #1374 /
-  `a386a624`, re-recorded in HIMMEL-1262). Dependabot does NOT run
+  `a386a624`, re-recorded in HIMMEL-1262); `brace-expansion` 5.0.7 → 5.0.9
+  (dev-only transitive via minimatch `^5.0.2`, dependabot alert #26,
+  HIMMEL-1408). Dependabot does NOT run
   `check-hud-drift.sh --write`, so each such bump needs a follow-up pin re-record
   commit (`--write`, then commit `VENDORED.md` + `VENDORED.manifest`) or every
   contributor commit trips the pre-commit drift gate. `pinned_commit` /

--- a/marketplace/plugins/claude-hud/package-lock.json
+++ b/marketplace/plugins/claude-hud/package-lock.json
@@ -433,16 +433,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/c8": {

--- a/marketplace/plugins/pr-review-toolkit-himmel/agents/code-reviewer.md
+++ b/marketplace/plugins/pr-review-toolkit-himmel/agents/code-reviewer.md
@@ -109,7 +109,7 @@ absent, downgrade — the finding is too speculative for Critical.
 
 ## Output Format
 
-Start by listing what you're reviewing. For each high-confidence issue provide:
+Start by listing what you're reviewing. For every finding you report — regardless of confidence — provide:
 
 - Clear description and confidence score
 - File path and line number
@@ -117,8 +117,8 @@ Start by listing what you're reviewing. For each high-confidence issue provide:
 - Concrete fix suggestion
 - **For Critical findings:** include a one-line verify-before-critical attestation: `verified: <cited-content> found at <file:line>` OR `verified-via-context: <surrounding-content> found at <file:line>` (refactor-edge-case).
 
-Group issues by severity (Critical: 91-100, Important: 80-90).
+Group issues by severity (Critical: 91-100, Important: 80-90, Suggestion: below 80). Per HIMMEL-1405, the Suggestion group is not optional — it is where the Issue Confidence Scoring section's mandate to report every finding, including 51-75, actually lands in the output.
 
-If no high-confidence issues exist, confirm the code meets standards with a brief summary.
+If zero findings exist across all three severities, confirm the code meets standards with a brief summary.
 
-Be thorough but filter aggressively - quality over quantity. Focus on issues that truly matter.
+Be thorough. Weight your attention toward the issues that truly matter, but never filter a real finding out of the report — lower-confidence and minor findings land as Suggestions, not on the cutting-room floor (HIMMEL-1405).

--- a/marketplace/plugins/pr-review-toolkit-himmel/agents/code-reviewer.md
+++ b/marketplace/plugins/pr-review-toolkit-himmel/agents/code-reviewer.md
@@ -95,7 +95,7 @@ debating whether the reviewer is right or wrong rather than fixing
 real bugs.
 
 **This rule applies ONLY to Critical (91-100) findings.** Important
-(80-89) and below findings do not require verbatim verification —
+(76-90) and below findings do not require verbatim verification —
 those tiers tolerate some inference and pattern-matching. Critical
 findings block PRs; they must be verified.
 
@@ -117,7 +117,7 @@ Start by listing what you're reviewing. For every finding you report — regardl
 - Concrete fix suggestion
 - **For Critical findings:** include a one-line verify-before-critical attestation: `verified: <cited-content> found at <file:line>` OR `verified-via-context: <surrounding-content> found at <file:line>` (refactor-edge-case).
 
-Group issues by severity (Critical: 91-100, Important: 80-90, Suggestion: below 80). Per HIMMEL-1405, the Suggestion group is not optional — it is where the Issue Confidence Scoring section's mandate to report every finding, including 51-75, actually lands in the output.
+Group issues by severity (Critical: 91-100, Important: 76-90, Suggestion: below 76). Per HIMMEL-1405, the Suggestion group is not optional — it is where the Issue Confidence Scoring section's mandate to report every finding, including 51-75, actually lands in the output.
 
 If zero findings exist across all three severities, confirm the code meets standards with a brief summary.
 

--- a/scripts/cr/critic-first-pass.sh
+++ b/scripts/cr/critic-first-pass.sh
@@ -229,7 +229,7 @@ if [ "$artifact_mode" -eq 1 ]; then
 - Replace N with the exact bullet count under that heading (0 is allowed; then put no bullets under it).
 - Every bullet MUST end with a [<file>#<heading>] citation naming a section heading that exists in the artifact.
 - Number IDs sequentially across all sections.
-- Critical = certain bug / security / data-loss. Important = likely bug or risky pattern. Suggestion = style / cleanup.
+- Critical = certain bug / security / data-loss. Important = likely bug or risky pattern. Suggestion = style / cleanup, OR a minor / lower-confidence functional or security finding that doesn't clear Important (HIMMEL-1405) — Suggestion is not limited to cosmetic issues.
 - DO NOT INVENT FINDINGS. Every bullet must cite something that is actually in the artifact. A fabricated finding is worse than a missed one, and an empty review is acceptable when the artifact is genuinely clean.
 - But do NOT withhold a real finding because it is minor or because you are unsure it will be acted on. Report it as a Suggestion. Filtering happens in a LATER pass (the merge gates on Critical + Important; the rest is auto-filed as deferred issues) — a finding you omit here is destroyed, not filtered.
 - When uncertain between two severities, pick the LOWER — downgrade, do not drop.
@@ -259,7 +259,7 @@ else
 - Replace N with the exact bullet count under that heading (0 is allowed; then put no bullets under it).
 - Every bullet MUST end with a [<file>:<line>] citation pointing into the diff (new-file line numbers).
 - Number IDs sequentially across all sections.
-- Critical = certain bug / security / data-loss. Important = likely bug or risky pattern. Suggestion = style / cleanup.
+- Critical = certain bug / security / data-loss. Important = likely bug or risky pattern. Suggestion = style / cleanup, OR a minor / lower-confidence functional or security finding that doesn't clear Important (HIMMEL-1405) — Suggestion is not limited to cosmetic issues.
 - DO NOT INVENT FINDINGS. Every bullet must cite something that is actually in the diff. A fabricated finding is worse than a missed one, and an empty review is acceptable when the diff is genuinely clean.
 - But do NOT withhold a real finding because it is minor or because you are unsure it will be acted on. Report it as a Suggestion. Filtering happens in a LATER pass (the merge gates on Critical + Important; the rest is auto-filed as deferred issues) — a finding you omit here is destroyed, not filtered.
 - When uncertain between two severities, pick the LOWER — downgrade, do not drop.

--- a/scripts/graphify/refresh-graph-map.sh
+++ b/scripts/graphify/refresh-graph-map.sh
@@ -284,6 +284,86 @@ _promote_lock_acquire() {
   done
 }
 
+# _scratch_cleanup -- EXIT-trap cleanup for the owned $SCRATCH subdir
+# (HIMMEL-1406). Previously this was a bare `rm -rf "$SCRATCH"`, which ran
+# on EVERY exit including a promote-refusal (host-path guard, a missing
+# scratch artifact, a failed sideline cache mv, ...) AFTER the paid
+# extraction had already completed -- discarding the only copy of a full,
+# possibly $2+ extraction (the 2026-07-30 luna/glm regen: 14,569 nodes,
+# 16.7M tokens in) with no way to inspect what tripped the refusal. On a
+# FAILURE exit where the extraction actually produced a
+# $SCRATCH/graphify-out/graph.json, quarantine that dir (graph.json,
+# GRAPH_REPORT.md, semantic cache, markers -- the "paid" artifact) to a
+# sibling path instead of deleting it, so it survives for inspection/reuse;
+# only the disposable corpus md copy under $SCRATCH is then removed. A
+# SUCCESS exit already rm -rf's $SCRATCH eagerly before this trap fires (see
+# "eager clean on success" below), and a failure BEFORE extraction produced
+# anything (graphify not on PATH, corpus scan/copy failure, graphify
+# --update itself failing with no output, ...) has nothing worth quarantining
+# -- both fall through to the original unconditional rm -rf, unchanged.
+_scratch_cleanup() {
+  local rc=$?
+  if [ "$rc" -ne 0 ] && [ -d "$SCRATCH/graphify-out" ] && [ -f "$SCRATCH/graphify-out/graph.json" ]; then
+    local qdir="${SCRATCH}.quarantine"
+    rm -rf "$qdir" 2>/dev/null || true
+    if mv "$SCRATCH/graphify-out" "$qdir" 2>/dev/null; then
+      echo "refresh-graph-map: promote did not complete -- preserved the extracted graphify-out (graph.json, GRAPH_REPORT.md, semantic cache) at $qdir for inspection/reuse; nothing under $CORPUS_ROOT was touched" >&2
+    else
+      echo "refresh-graph-map: WARN promote did not complete AND quarantining $SCRATCH/graphify-out to $qdir failed -- the extracted artifact may be lost on cleanup" >&2
+    fi
+  fi
+  rm -rf "$SCRATCH" 2>/dev/null || true
+}
+
+# _graph_structural_fields <graph.json> <out_txt> -- HIMMEL-1406. Extracts
+# ONLY the structural fields graphify itself writes as artifact structure
+# (node id/source_file/source_url; link source/target/source_file; hyperedge
+# id/source_file/member node ids -- per graph.json's actual schema) into a
+# flat text file, so the host-path guard below can scan JUST that instead of
+# the full graph.json. Deliberately EXCLUDED: `label` (and anything derived
+# from it) -- for an extracted markdown corpus this can be a free-text
+# excerpt (e.g. a `file_type: rationale` node's docstring/summary) that
+# legitimately QUOTES a Windows path in prose; the luna vault routinely does
+# (handover specs quoting C:\Users\...). The artifact lands in the PRIVATE
+# vault, not a public repo, so a content-borne host path there is not a leak
+# (policy decision, HIMMEL-1406) -- only a path graphify wrote into the
+# artifact's own STRUCTURE is.
+# jq is preferred (matches this repo's `command -v jq` convention used
+# throughout scripts/); python3 is the fallback and is UNCONDITIONALLY
+# available whenever this runs (the DO_UPDATE=1 preflight above already
+# requires it), so the fallback is never a real degrade on this path.
+# Returns the extractor's exit status; a non-zero rc means the scan below
+# must fail closed (same "leak SCAN FAILED" convention as a grep scan error).
+_graph_structural_fields() {
+  local graph_json="$1" out_txt="$2"
+  if command -v jq >/dev/null 2>&1; then
+    jq -r '
+      ((.nodes // [])[]      | "node id=\(.id // "") source_file=\(.source_file // "") source_url=\(.source_url // "")"),
+      ((.links // [])[]      | "link source=\(.source // "") target=\(.target // "") source_file=\(.source_file // "")"),
+      ((.hyperedges // [])[] | "hyperedge id=\(.id // "") source_file=\(.source_file // "") nodes=\(((.nodes // []) | join(",")))")
+    ' "$graph_json" > "$out_txt" 2>/dev/null
+    return $?
+  fi
+  python3 - "$graph_json" > "$out_txt" 2>/dev/null <<'PYEOF'
+import json, sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception:
+    sys.exit(1)
+def s(v):
+    return "" if v is None else str(v)
+for n in data.get("nodes") or []:
+    print("node id=%s source_file=%s source_url=%s" % (s(n.get("id")), s(n.get("source_file")), s(n.get("source_url"))))
+for l in data.get("links") or []:
+    print("link source=%s target=%s source_file=%s" % (s(l.get("source")), s(l.get("target")), s(l.get("source_file"))))
+for h in data.get("hyperedges") or []:
+    nodes_field = ",".join(s(x) for x in (h.get("nodes") or []))
+    print("hyperedge id=%s source_file=%s nodes=%s" % (s(h.get("id")), s(h.get("source_file")), nodes_field))
+PYEOF
+  return $?
+}
+
 if [ "$DO_UPDATE" -eq 1 ]; then
   command -v "$GRAPHIFY_MAP" >/dev/null 2>&1 || { echo "refresh-graph-map: '$GRAPHIFY_MAP' not on PATH (needed for --update; use --no-update to publish from an existing report)" >&2; exit 2; }
   # F3 (HIMMEL-907): python3 writes the freshness manifest (see stamp step
@@ -301,7 +381,10 @@ if [ "$DO_UPDATE" -eq 1 ]; then
   rm -rf "$SCRATCH"; mkdir -p "$SCRATCH"
   # Clean the owned subdir on ANY exit — a graphify/cluster-only failure (exit 2)
   # otherwise leaks it (CR suggestion). Scoped to the PID-owned dir only.
-  trap 'rm -rf "$SCRATCH" 2>/dev/null || true; _promote_stage_cleanup; _promote_lock_release' EXIT
+  # _scratch_cleanup (HIMMEL-1406) quarantines the extracted graphify-out
+  # instead of deleting it when the exit is a FAILURE and extraction had
+  # already produced one — see its definition above.
+  trap '_scratch_cleanup; _promote_stage_cleanup; _promote_lock_release' EXIT
   # pull-before-regenerate (HIMMEL-1050): refresh the corpus from its remote
   # before copying to scratch, so the graph reflects the latest pushed state, not
   # a stale local checkout. Best-effort + advisory: a miss regenerates from the
@@ -711,6 +794,22 @@ if [ "$DO_UPDATE" -eq 1 ]; then
     # previously $OUT_DIR/graph.json) can itself carry the corpus/home path
     # -- error messages below print only the filename, never the full path.
     leak_artifact_name="${leak_artifact##*/}"
+    scan_target="$leak_artifact"
+    scan_target_note=""
+    if [ "$leak_artifact" = "$SCRATCH_GRAPH" ]; then
+      # HIMMEL-1406: scope graph.json's scan to STRUCTURAL fields only,
+      # instead of the full raw JSON text -- see _graph_structural_fields
+      # above for the field list + why (a vault note's content-borne host
+      # path, e.g. a rationale/summary quoting C:\Users\..., is
+      # policy-allowed here; a path graphify wrote into the artifact's own
+      # structure is not).
+      scan_target="$SCRATCH/.graph-structural-fields.$$"
+      if ! _graph_structural_fields "$SCRATCH_GRAPH" "$scan_target"; then
+        echo "refresh-graph-map: REFUSING to promote -- leak SCAN FAILED for $leak_artifact_name (could not extract structural fields for the scoped host-path scan)" >&2
+        exit 2
+      fi
+      scan_target_note=" (structural field; line number refers to the scoped extract, not the raw file -- see the quarantined copy for the full artifact)"
+    fi
     # -m1: grep stops after its OWN first match (rc 0 hit / rc 1 miss) -- no
     # pipe to `head`, so no SIGPIPE. Under `set -o pipefail` (line 30), a
     # `grep | head -n 1` pipeline where grep gets SIGPIPE'd by head closing
@@ -734,11 +833,11 @@ if [ "$DO_UPDATE" -eq 1 ]; then
     # error message depends on and makes a real leak's detectability
     # unpredictable on adversarial/binary content. Force text mode instead
     # -- both artifacts are supposed to be text (a report is markdown, the
-    # graph is JSON), so treating a NUL as just another byte is correct
-    # here, not a workaround.
+    # graph is JSON -- or, for graph.json, a flat text extract of it), so
+    # treating a NUL as just another byte is correct here, not a workaround.
     leak_line=""
     grep_rc=0
-    leak_line="$(grep -a -m1 -inE "$leak_pattern" "$leak_artifact")" || grep_rc=$?
+    leak_line="$(grep -a -m1 -inE "$leak_pattern" "$scan_target")" || grep_rc=$?
     if [ "$grep_rc" -eq 0 ]; then
       # HIMMEL-1134 CR follow-up: do NOT echo $leak_line -- it's the matched
       # grep line, i.e. it CONTAINS the leaked host path. Printing it here
@@ -747,7 +846,17 @@ if [ "$DO_UPDATE" -eq 1 ]; then
       # output). Report only the file NAME + the line NUMBER (grep's own
       # "N:..." prefix, stripped at the first colon).
       leak_line_number="${leak_line%%:*}"
-      echo "refresh-graph-map: REFUSING to promote -- host path detected in $leak_artifact_name at line $leak_line_number" >&2
+      # HIMMEL-1406: save a FEW lines of context around the match into the
+      # scratch graphify-out, so it travels with the quarantine copy
+      # _scratch_cleanup preserves on this refusal (see its definition
+      # above) -- for offline inspection only. This file DOES contain the
+      # leaked path (that's the point), so -- same rule as $leak_line above
+      # -- it must never be echoed to stdout/stderr here.
+      leak_context_file="$SCRATCH_OUT/.leak-context-${leak_artifact_name}.txt"
+      leak_ctx_start=$(( leak_line_number > 2 ? leak_line_number - 2 : 1 ))
+      leak_ctx_end=$(( leak_line_number + 2 ))
+      sed -n "${leak_ctx_start},${leak_ctx_end}p" "$scan_target" > "$leak_context_file" 2>/dev/null || true
+      echo "refresh-graph-map: REFUSING to promote -- host path detected in $leak_artifact_name at line $leak_line_number${scan_target_note} (context saved to graphify-out/${leak_context_file##*/} in the quarantined copy -- not printed here to avoid leaking the path into logs)" >&2
       exit 2
     elif [ "$grep_rc" -gt 1 ]; then
       echo "refresh-graph-map: REFUSING to promote -- leak SCAN FAILED for $leak_artifact_name (grep rc=$grep_rc)" >&2

--- a/scripts/graphify/refresh-graph-map.sh
+++ b/scripts/graphify/refresh-graph-map.sh
@@ -339,7 +339,7 @@ _graph_structural_fields() {
   if command -v jq >/dev/null 2>&1; then
     jq -r '
       ((.nodes // [])[]      | "node id=\(.id // "") source_file=\(.source_file // "") source_url=\(.source_url // "")"),
-      ((.links // [])[]      | "link source=\(.source // "") target=\(.target // "") source_file=\(.source_file // "")"),
+      ((((.links // []) + (.edges // []))[]) | "link source=\(.source // "") target=\(.target // "") source_file=\(.source_file // "")"),
       ((.hyperedges // [])[] | "hyperedge id=\(.id // "") source_file=\(.source_file // "") nodes=\(((.nodes // []) | join(",")))")
     ' "$graph_json" > "$out_txt" 2>/dev/null
     return $?
@@ -355,7 +355,7 @@ def s(v):
     return "" if v is None else str(v)
 for n in data.get("nodes") or []:
     print("node id=%s source_file=%s source_url=%s" % (s(n.get("id")), s(n.get("source_file")), s(n.get("source_url"))))
-for l in data.get("links") or []:
+for l in (data.get("links") or []) + (data.get("edges") or []):
     print("link source=%s target=%s source_file=%s" % (s(l.get("source")), s(l.get("target")), s(l.get("source_file"))))
 for h in data.get("hyperedges") or []:
     nodes_field = ",".join(s(x) for x in (h.get("nodes") or []))

--- a/scripts/graphify/test-refresh-graph-map-lock.sh
+++ b/scripts/graphify/test-refresh-graph-map-lock.sh
@@ -51,7 +51,7 @@ make_stub() {
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[],"gen":"$gen"}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[],"gen":"$gen"}' > "\$target/graphify-out/graph.json"
 cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
 $content
 RPT

--- a/scripts/graphify/test-refresh-graph-map.sh
+++ b/scripts/graphify/test-refresh-graph-map.sh
@@ -11,6 +11,14 @@ pass() { echo "  ok: $1"; }
 fail() { echo "  FAIL: $1"; FAILS=$((FAILS+1)); }
 
 WS="$(mktemp -d)"; trap 'rm -rf "$WS"' EXIT
+# HIMMEL-1406: scope the default scratch parent to $WS. Most tests below
+# don't pass --scratch, so refresh-graph-map.sh falls back to
+# ${TMPDIR:-/tmp} -- and a promote-refusal now quarantines the extracted
+# graphify-out there (see _scratch_cleanup) instead of deleting it. Without
+# this, every leak/refusal test in this file would leave a quarantine dir
+# behind in the REAL system temp dir on every run. Scoping TMPDIR to $WS
+# keeps them inside the hermetic workspace this file's own EXIT trap sweeps.
+export TMPDIR="$WS/tmp"; mkdir -p "$TMPDIR"
 CORPUS="$WS/vault"; mkdir -p "$CORPUS/notes"; printf '# n\ncontent\n' > "$CORPUS/notes/a.md"
 MAPS="$WS/vault/60-Maps"; mkdir -p "$MAPS"
 
@@ -636,14 +644,20 @@ out=$( GRAPHIFY_MAP_BIN="$MULTIBIN/graphify" PATH="$MULTIBIN:$PATH" \
 # alternatives added in Part B are still worth keeping (explicit,
 # defense-in-depth against a future edit that narrows/removes the bare
 # alternative), but this test is NOT a red/green differentiator for Part B
-# the way T12 is for Part A -- it stays green on both sides of that change. ---
+# the way T12 is for Part A -- it stays green on both sides of that change.
+# HIMMEL-1406: the leaked value now sits on `source_file` rather than the
+# synthetic `path` key this fixture originally used -- the guard's graph.json
+# scan is now scoped to STRUCTURAL fields only (id/source_file/source_url/
+# source/target, per graphify's real schema), so a leak has to live on one of
+# those field names to still be caught; `source_file` is real schema, `path`
+# is not. ---
 JSONBIN="$WS/jsonbin"; mkdir -p "$JSONBIN"
 cat > "$JSONBIN/graphify" <<'STUB'
 #!/usr/bin/env bash
 target=""
 if [ "$1" = "cluster-only" ]; then target="$2"; else target="$1"; fi
 mkdir -p "$target/graphify-out"
-printf '{"nodes":[{"id":"n1","path":"C:\\\\Users\\\\leaker\\\\AppData\\\\Local\\\\Temp\\\\case"}],"edges":[]}' \
+printf '{"nodes":[{"id":"n1","source_file":"C:\\\\Users\\\\leaker\\\\AppData\\\\Local\\\\Temp\\\\case"}],"edges":[]}' \
   > "$target/graphify-out/graph.json"
 printf '# Graph Report - X  (2026-07-17)\n\n## Summary\n- 1 nodes . 0 edges . 1 communities (1 shown)\n' \
   > "$target/graphify-out/GRAPH_REPORT.md"
@@ -1350,6 +1364,135 @@ NOCACHEOUT="$NOCACHECORPUS/graphify-out"
   || fail "T24 graph.json missing after a cache-less refresh: $out"
 [ ! -e "$NOCACHEOUT/cache" ] && pass "T24 stale cache removed when scratch produced none" \
   || fail "T24 stale \$OUT_DIR/cache survived a refresh that produced no staged cache (should be removed)"
+
+# --- T25 (HIMMEL-1406, defect 1): a promote-refusal must PRESERVE the
+# extracted scratch graphify-out instead of the EXIT trap deleting it --
+# the real 2026-07-30 luna/glm incident spent a full extraction (14,569
+# nodes, 16.7M tokens in) only to have the refusal's cleanup discard the
+# only copy, leaving the offending line unverifiable. Reuses a T11-style
+# report-body leak (sentinel graph.json content + a leaking GRAPH_REPORT.md)
+# and asserts: (a) the refusal message names a quarantine path, (b) that
+# path exists and holds the promoted-would-be graph.json + GRAPH_REPORT.md
+# (the paid artifact, byte-identical to what extraction produced) plus a
+# semantic-cache marker (HIMMEL-1406: "keep any semantic cache reusable for
+# the next run"), (c) a non-printed context snippet file also landed there,
+# and (d) the leaked host path itself never appears in stdout/stderr (same
+# redaction rule as T11/T20 -- the quarantine message must not itself leak
+# the secret it's preserving). ---
+QBIN="$WS/qbin"; mkdir -p "$QBIN"
+cat > "$QBIN/graphify" <<'STUB'
+#!/usr/bin/env bash
+target=""
+if [ "$1" = "cluster-only" ]; then target="$2"; else target="$1"; fi
+mkdir -p "$target/graphify-out/cache"
+printf 'SENTINEL-PAID-EXTRACTION-CACHE' > "$target/graphify-out/cache/semantic.cache"
+printf '{"nodes":[{"id":"sentinel-node"}],"edges":[]}' > "$target/graphify-out/graph.json"
+{
+  printf '# Graph Report - X  (2026-07-17)\n\n'
+  printf '## Summary\n- 42 nodes . 30 edges . 5 communities (5 shown)\n\n'
+  printf '## God Nodes (most connected - your core abstractions)\n'
+  printf '1. `C:/Users/quarantoken/AppData/Local/Temp/case` - 9 edges\n\n'
+  printf '## Communities (5 total)\n\n### Community 0 - "Alpha"\nCohesion: 0.06\nNodes (20): a, b (+18 more)\n'
+} > "$target/graphify-out/GRAPH_REPORT.md"
+exit 0
+STUB
+chmod +x "$QBIN/graphify"
+QCORPUS="$WS/qcorpus"; QMAPS="$WS/qmaps"; mkdir -p "$QCORPUS/notes" "$QMAPS"
+printf '# n\ncontent\n' > "$QCORPUS/notes/n.md"
+out=$( GRAPHIFY_MAP_BIN="$QBIN/graphify" PATH="$QBIN:$PATH" \
+  bash "$SCRIPT" --name quarantest --corpus-root "$QCORPUS" --backend deepseek \
+  --maps-dir "$QMAPS" --title "Q Map" --slug q-map --corpus-tag q 2>&1 ); rc=$?
+[ "$rc" -eq 2 ] && pass "T25 leaking refresh still fails loudly (rc=2)" \
+  || fail "T25 leaking refresh should fail loudly with rc=2 (got $rc): $out"
+qdir=$(printf '%s\n' "$out" | grep -oE '/[^ ]*\.quarantine' | head -n1)
+[ -n "$qdir" ] && pass "T25 refusal message names a quarantine path" \
+  || fail "T25 refusal message should name a quarantine path: $out"
+[ -n "$qdir" ] && [ -d "$qdir" ] && pass "T25 quarantine path exists as a directory" \
+  || fail "T25 quarantine path missing/not a directory: $qdir"
+[ -n "$qdir" ] && grep -q "sentinel-node" "$qdir/graph.json" 2>/dev/null \
+  && pass "T25 quarantined graph.json preserves the paid extraction" \
+  || fail "T25 quarantined graph.json missing/does not match the extracted artifact"
+[ -n "$qdir" ] && [ -f "$qdir/GRAPH_REPORT.md" ] \
+  && pass "T25 quarantined GRAPH_REPORT.md preserved" \
+  || fail "T25 quarantined GRAPH_REPORT.md missing"
+[ -n "$qdir" ] && grep -q "SENTINEL-PAID-EXTRACTION-CACHE" "$qdir/cache/semantic.cache" 2>/dev/null \
+  && pass "T25 quarantined semantic cache preserved (reusable for the next run)" \
+  || fail "T25 quarantined semantic cache missing"
+[ -n "$qdir" ] && [ -f "$qdir/.leak-context-GRAPH_REPORT.md.txt" ] \
+  && pass "T25 leak context snippet saved into the quarantine copy" \
+  || fail "T25 leak context snippet file missing from quarantine copy"
+echo "$out" | grep -q "quarantoken" \
+  && fail "T25 refusal/quarantine message exposes the rejected host path: $out" \
+  || pass "T25 refusal/quarantine message redacts the rejected host path"
+[ -e "$QCORPUS/graphify-out/graph.json" ] \
+  && fail "T25 leaking refresh still promoted into \$CORPUS_ROOT/graphify-out" \
+  || pass "T25 nothing promoted under \$CORPUS_ROOT on a leaking refresh"
+
+# --- T26 (HIMMEL-1406, defect 2): graph.json's host-path scan is scoped to
+# STRUCTURAL fields only. Two halves against the SAME node shape (id/label/
+# source_file), differing only in WHICH field carries the host path:
+# (a) the path lives only in `label` (a content/summary field a vault note's
+#     extracted text can legitimately carry, e.g. a rationale quoting
+#     C:\Users\...) -- must PROMOTE normally (rc 0), and the promoted
+#     graph.json still carries that content verbatim (scoping the SCAN, not
+#     redacting the artifact);
+# (b) the path lives on `source_file` (a structural field graphify itself
+#     writes) -- must still REFUSE (rc 2), proving the scoping didn't
+#     collaterally blind the guard to a real structural leak. ---
+CONTENTBIN="$WS/contentbin"; mkdir -p "$CONTENTBIN"
+cat > "$CONTENTBIN/graphify" <<'STUB'
+#!/usr/bin/env bash
+target=""
+if [ "$1" = "cluster-only" ]; then target="$2"; else target="$1"; fi
+mkdir -p "$target/graphify-out"
+printf '{"nodes":[{"id":"n1","label":"See C:\\\\Users\\\\labelleaktoken\\\\notes.md for details","source_file":"notes/a.md"}],"edges":[]}' \
+  > "$target/graphify-out/graph.json"
+printf '# Graph Report - X  (2026-07-17)\n\n## Summary\n- 1 nodes . 0 edges . 1 communities (1 shown)\n' \
+  > "$target/graphify-out/GRAPH_REPORT.md"
+exit 0
+STUB
+chmod +x "$CONTENTBIN/graphify"
+CONTENTCORPUS="$WS/contentcorpus"; CONTENTMAPS="$WS/contentmaps"; mkdir -p "$CONTENTCORPUS/notes" "$CONTENTMAPS"
+printf '# n\ncontent\n' > "$CONTENTCORPUS/notes/n.md"
+out=$( GRAPHIFY_MAP_BIN="$CONTENTBIN/graphify" PATH="$CONTENTBIN:$PATH" \
+  bash "$SCRIPT" --name contenttest --corpus-root "$CONTENTCORPUS" --backend deepseek \
+  --maps-dir "$CONTENTMAPS" --title "Content Map" --slug content-map --corpus-tag content 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] && pass "T26a host path ONLY in a content field (label) promotes normally (rc=0)" \
+  || fail "T26a content-only host path should promote (got rc=$rc): $out"
+[ -f "$CONTENTMAPS/content-map.md" ] && pass "T26a MOC published despite the content-borne host path" \
+  || fail "T26a MOC not published: $out"
+grep -q "labelleaktoken" "$CONTENTCORPUS/graphify-out/graph.json" 2>/dev/null \
+  && pass "T26a promoted graph.json still carries the content verbatim (scan scoped, artifact untouched)" \
+  || fail "T26a promoted graph.json lost the content-borne text"
+
+STRUCTBIN="$WS/structbin"; mkdir -p "$STRUCTBIN"
+cat > "$STRUCTBIN/graphify" <<'STUB'
+#!/usr/bin/env bash
+target=""
+if [ "$1" = "cluster-only" ]; then target="$2"; else target="$1"; fi
+mkdir -p "$target/graphify-out"
+printf '{"nodes":[{"id":"n1","label":"a perfectly ordinary node","source_file":"C:\\\\Users\\\\structleaktoken\\\\notes.md"}],"edges":[]}' \
+  > "$target/graphify-out/graph.json"
+printf '# Graph Report - X  (2026-07-17)\n\n## Summary\n- 1 nodes . 0 edges . 1 communities (1 shown)\n' \
+  > "$target/graphify-out/GRAPH_REPORT.md"
+exit 0
+STUB
+chmod +x "$STRUCTBIN/graphify"
+STRUCTCORPUS="$WS/structcorpus"; STRUCTMAPS="$WS/structmaps"; mkdir -p "$STRUCTCORPUS/notes" "$STRUCTMAPS"
+printf '# n\ncontent\n' > "$STRUCTCORPUS/notes/n.md"
+out=$( GRAPHIFY_MAP_BIN="$STRUCTBIN/graphify" PATH="$STRUCTBIN:$PATH" \
+  bash "$SCRIPT" --name structtest --corpus-root "$STRUCTCORPUS" --backend deepseek \
+  --maps-dir "$STRUCTMAPS" --title "Struct Map" --slug struct-map --corpus-tag struct 2>&1 ); rc=$?
+[ "$rc" -eq 2 ] && pass "T26b host path in a structural field (source_file) still refuses (rc=2)" \
+  || fail "T26b structural-field host path should still refuse (got rc=$rc): $out"
+echo "$out" | grep -q "graph.json" \
+  && pass "T26b error names graph.json as the offending artifact" || fail "T26b error should name graph.json: $out"
+echo "$out" | grep -q "structleaktoken" \
+  && fail "T26b error output exposes the rejected host path: $out" \
+  || pass "T26b error output redacts the rejected host path"
+[ ! -e "$STRUCTCORPUS/graphify-out/graph.json" ] \
+  && pass "T26b nothing promoted under \$CORPUS_ROOT on a structural-field leak" \
+  || fail "T26b leaking refresh still promoted into \$CORPUS_ROOT/graphify-out"
 
 if [ "$FAILS" -ne 0 ]; then echo "$FAILS FAILURES"; exit 1; fi
 echo "ALL PASS"

--- a/scripts/graphify/test-refresh-graph-map.sh
+++ b/scripts/graphify/test-refresh-graph-map.sh
@@ -53,7 +53,7 @@ cat > "$BIN/graphify" <<STUB
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
 $REPORT_FIXTURE
 RPT
@@ -100,7 +100,7 @@ printf '%s\n' "\$@" >> "$BACKEND_LOG"
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
 $REPORT_FIXTURE
 RPT
@@ -247,7 +247,7 @@ cat > "$EBIN/graphify" <<STUB
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
 $REPORT_FIXTURE
 RPT
@@ -304,7 +304,7 @@ cat > "$PBIN/graphify" <<STUB
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
 $REPORT_FIXTURE
 RPT
@@ -341,7 +341,7 @@ cat > "$GBIN/graphify" <<STUB
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 printf '# Graph Report - X\ntotally unparseable garbage body - no recognizable sections at all\n' > "\$target/graphify-out/GRAPH_REPORT.md"
 exit 0
 STUB
@@ -483,7 +483,7 @@ done
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
 $REPORT_FIXTURE
 RPT
@@ -517,7 +517,7 @@ cat > "$LEAKBIN/graphify" <<STUB
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 winpath="C:/Users/testop/AppData/Local/Temp/\$(basename "\$target")"
 {
   printf '# Graph Report - %s  (2026-07-17)\n\n' "\$winpath"
@@ -562,7 +562,7 @@ cat > "$GUARDBIN/graphify" <<STUB
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 {
   printf '# Graph Report - X  (2026-07-17)\n\n'
   printf '## Summary\n- 42 nodes . 30 edges . 5 communities (5 shown)\n\n'
@@ -610,7 +610,7 @@ cat > "$MULTIBIN/graphify" <<'STUB'
 target=""
 if [ "$1" = "cluster-only" ]; then target="$2"; else target="$1"; fi
 mkdir -p "$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "$target/graphify-out/graph.json"
 {
   printf '# Graph Report - X  (2026-07-17)\n'
   i=1
@@ -657,7 +657,7 @@ cat > "$JSONBIN/graphify" <<'STUB'
 target=""
 if [ "$1" = "cluster-only" ]; then target="$2"; else target="$1"; fi
 mkdir -p "$target/graphify-out"
-printf '{"nodes":[{"id":"n1","source_file":"C:\\\\Users\\\\leaker\\\\AppData\\\\Local\\\\Temp\\\\case"}],"edges":[]}' \
+printf '{"nodes":[{"id":"n1","source_file":"C:\\\\Users\\\\leaker\\\\AppData\\\\Local\\\\Temp\\\\case"}],"links":[]}' \
   > "$target/graphify-out/graph.json"
 printf '# Graph Report - X  (2026-07-17)\n\n## Summary\n- 1 nodes . 0 edges . 1 communities (1 shown)\n' \
   > "$target/graphify-out/GRAPH_REPORT.md"
@@ -712,7 +712,7 @@ cat > "$FPBIN/graphify" <<STUB
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
 $FP_REPORT_FIXTURE
 RPT
@@ -752,7 +752,7 @@ cat > "$TPBIN/graphify" <<STUB
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
 $TP_REPORT_FIXTURE
 RPT
@@ -800,7 +800,7 @@ cat > "$SCANBIN/graphify" <<STUB
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
 $REPORT_FIXTURE
 RPT
@@ -848,7 +848,7 @@ cat > "$AWKBIN/graphify" <<STUB
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
 $REPORT_FIXTURE
 RPT
@@ -906,7 +906,7 @@ cat > "$PRIORBIN/graphify" <<STUB
 target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 {
   printf '# Graph Report - X  (2026-07-17)\n\n'
   printf '## Summary\n- 42 nodes . 30 edges . 5 communities (5 shown)\n\n'
@@ -1016,7 +1016,7 @@ cat > "$BADHDRBIN/graphify" <<'STUB'
 target=""
 if [ "$1" = "cluster-only" ]; then target="$2"; else target="$1"; fi
 mkdir -p "$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "$target/graphify-out/graph.json"
 printf 'Totally Different Header Format\nnot a graphify report at all\n' > "$target/graphify-out/GRAPH_REPORT.md"
 exit 0
 STUB
@@ -1073,7 +1073,7 @@ cat > "$NULBIN/graphify" <<'STUB'
 target=""
 if [ "$1" = "cluster-only" ]; then target="$2"; else target="$1"; fi
 mkdir -p "$target/graphify-out"
-printf '{"nodes":[],"edges":[]}' > "$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "$target/graphify-out/graph.json"
 {
   printf '# Graph Report - X\n\nsome text'
   printf '\0'
@@ -1225,7 +1225,7 @@ if [ "\$1" != "cluster-only" ]; then
 else
   rm -f "\$target/graphify-out/.graphify_analysis.json"
 fi
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
 $REPORT_FIXTURE
 RPT
@@ -1297,7 +1297,7 @@ target=""
 if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
 mkdir -p "\$target/graphify-out/cache"
 printf 'STAGED' > "\$target/graphify-out/cache/staged.marker"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
 $REPORT_FIXTURE
 RPT
@@ -1342,7 +1342,7 @@ mkdir -p "\$target/graphify-out"
 # The refresh produced NO semantic cache: drop whatever the runner seeded into
 # scratch and write none back.
 rm -rf "\$target/graphify-out/cache"
-printf '{"nodes":[],"edges":[]}' > "\$target/graphify-out/graph.json"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
 cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
 $REPORT_FIXTURE
 RPT
@@ -1386,7 +1386,7 @@ target=""
 if [ "$1" = "cluster-only" ]; then target="$2"; else target="$1"; fi
 mkdir -p "$target/graphify-out/cache"
 printf 'SENTINEL-PAID-EXTRACTION-CACHE' > "$target/graphify-out/cache/semantic.cache"
-printf '{"nodes":[{"id":"sentinel-node"}],"edges":[]}' > "$target/graphify-out/graph.json"
+printf '{"nodes":[{"id":"sentinel-node"}],"links":[]}' > "$target/graphify-out/graph.json"
 {
   printf '# Graph Report - X  (2026-07-17)\n\n'
   printf '## Summary\n- 42 nodes . 30 edges . 5 communities (5 shown)\n\n'
@@ -1445,7 +1445,7 @@ cat > "$CONTENTBIN/graphify" <<'STUB'
 target=""
 if [ "$1" = "cluster-only" ]; then target="$2"; else target="$1"; fi
 mkdir -p "$target/graphify-out"
-printf '{"nodes":[{"id":"n1","label":"See C:\\\\Users\\\\labelleaktoken\\\\notes.md for details","source_file":"notes/a.md"}],"edges":[]}' \
+printf '{"nodes":[{"id":"n1","label":"See C:\\\\Users\\\\labelleaktoken\\\\notes.md for details","source_file":"notes/a.md"}],"links":[]}' \
   > "$target/graphify-out/graph.json"
 printf '# Graph Report - X  (2026-07-17)\n\n## Summary\n- 1 nodes . 0 edges . 1 communities (1 shown)\n' \
   > "$target/graphify-out/GRAPH_REPORT.md"
@@ -1471,7 +1471,7 @@ cat > "$STRUCTBIN/graphify" <<'STUB'
 target=""
 if [ "$1" = "cluster-only" ]; then target="$2"; else target="$1"; fi
 mkdir -p "$target/graphify-out"
-printf '{"nodes":[{"id":"n1","label":"a perfectly ordinary node","source_file":"C:\\\\Users\\\\structleaktoken\\\\notes.md"}],"edges":[]}' \
+printf '{"nodes":[{"id":"n1","label":"a perfectly ordinary node","source_file":"C:\\\\Users\\\\structleaktoken\\\\notes.md"}],"links":[]}' \
   > "$target/graphify-out/graph.json"
 printf '# Graph Report - X  (2026-07-17)\n\n## Summary\n- 1 nodes . 0 edges . 1 communities (1 shown)\n' \
   > "$target/graphify-out/GRAPH_REPORT.md"

--- a/scripts/jira/package-lock.json
+++ b/scripts/jira/package-lock.json
@@ -57,12 +57,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -76,12 +76,12 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",


### PR DESCRIPTION
## Summary
Leg-12 wave: four private merges propagated together (private range `433dbb12..a1314280`).

| Private PR | Ticket | Change |
|---|---|---|
| #1482 | HIMMEL-1408 | Dependabot: brace-expansion → 5.0.9 (HIGH DoS) in claude-hud, @hono/node-server → 2.0.12 (MED path traversal) in scripts/jira. Lockfile-only + documented VENDORED re-pin. |
| #1483 | HIMMEL-1407 | codex adversarial-review runs as a background job (launched before the critic panel, harvested after) — replaces the foreground 480s timebox that killed 28 healthy reviews mid-verification. |
| #1484 | HIMMEL-1405 | Review prompt contracts now require reporting every finding; minor / lower-confidence findings land as Suggestions. Parser surfaces verified byte-identical. |
| #1485 | HIMMEL-1406 | graphify promote fence: quarantine the paid artifact on refusal (was: EXIT-trap delete) + host-path scan scoped to structural fields (content-borne quoted paths no longer block). |

## Verification carried from the private gates
- Panels (codex gpt-5.5 + glm-5.2, 2/2 responders on every round): all Critical/Important candidates either fixed or disproved with cited evidence; final rounds clean on every branch.
- Tests: claude-hud plugin suite identical to pre-bump baseline; scripts/jira vitest 214/214 + tsc clean; graphify suites T1–T26 green incl. new quarantine/structural-scope coverage; taxonomy suites all pass.
- `npm audit`: 0 vulnerabilities in both touched packages post-bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved graph refresh safeguards by detecting host-path leaks in structural graph data and preventing unsafe publication.
  - Preserved refused or failed graph outputs in quarantine for easier inspection, while redacting sensitive paths from logs.
  - Expanded coverage for graph leak detection, quarantine handling, and safe promotion behavior.

- **Documentation**
  - Clarified review guidance to report findings across all severity levels with actionable details.
  - Updated pull request checking instructions for more reliable background analysis and timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->