### PR TITLE
leg-13 wave: adopter installs, lane trust, template safety, telegram + status hardening

### DIFF
--- a/.agents/skills/pr-check/SKILL.md
+++ b/.agents/skills/pr-check/SKILL.md
@@ -91,7 +91,26 @@ timeout (`CODERABBIT_TIMEOUT_SECS`, default 900s).
     [ -n "$coderabbit_avail" ] && printf '%s\n' "$coderabbit_avail" >&2
     case "$coderabbit_rc" in
         0) ;;  # review completed — findings (possibly none) captured
-        3) echo "coderabbit pass skipped (CLI not configured)" ;;  # capability-absent → fail-open
+        3)
+            # CLI absent. For an App-less repo this IS the pre-CI CodeRabbit
+            # signal (HIMMEL-1164) — reuse cr_app_configured (HIMMEL-1125)
+            # rather than a new probe, so the message escalates only when
+            # nothing will actually review this PR. Guard the source
+            # (codex-1, CR round 3): a missing helper must degrade to the
+            # generic skip message, never break the handler itself
+            # (fail-open).
+            if [ ! -f scripts/lib/cr-available.sh ]; then
+                echo "coderabbit pass skipped (CLI not configured)"
+            else
+                # shellcheck source=scripts/lib/cr-available.sh
+                . scripts/lib/cr-available.sh
+                if cr_app_configured; then
+                    echo "coderabbit pass skipped (CLI not configured) — the CodeRabbit App is armed for this repo, so CI still reviews this PR"
+                else
+                    echo "coderabbit pass skipped (CLI not configured) AND the CodeRabbit App is not armed here — this PR will ship with NO CodeRabbit signal. Install the CLI for the sanctioned pre-CI path (docs/internals/enforcement.md#coderabbit-pre-ci-path--app-present-vs-app-absent-himmel-1164), or arm the App with \`git config --local himmel.coderabbit true\` if one is installed." >&2
+                fi
+            fi
+            ;;  # capability-absent → fail-open
         *) echo "coderabbit pass failed (rc=$coderabbit_rc) — run attempted but did not complete; marker will be RETAINED (fail-closed)" >&2; coderabbit_findings=""; coderabbit_run_failed=1 ;;
     esac
     rm -f "$cr_tmp"

--- a/.claude/commands/himmel-update.md
+++ b/.claude/commands/himmel-update.md
@@ -1,5 +1,5 @@
 ---
-description: Update this himmel checkout (harness) — six-item dependency chain (pull, marketplace, jira CLI dist, qmd fork, hermes, luna template) with per-item status + abort-on-first-failure, plus five best-effort advisory steps (codex re-sanitize, statusLine re-wire, plugin gap report, plugin-set reconcile, cadence/guardrail drift checks). `himmelctl update` runs the same engine. autoUpdate does NOT deliver the checkout (git pull) or the core hooks/slash-commands — it only re-syncs installed plugins from the on-disk dir. A configured LUNA_VAULT_PATH is already refreshed by step 6 of this chain; use /luna-upgrade only for an explicit Luna-only run, and /himmel-update-all for multi-vault workflows.
+description: Update this himmel checkout (harness) — six-item dependency chain (pull, marketplace, jira CLI dist, qmd fork, hermes, luna template) with per-item status + abort-on-first-failure, plus seven best-effort advisory steps (codex re-sanitize, statusLine re-wire, graphify pin sync, plugin gap report, plugin-set reconcile, cadence/guardrail drift checks, dependency-readiness check). `himmelctl update` runs the same engine. autoUpdate does NOT deliver the checkout (git pull) or the core hooks/slash-commands — it only re-syncs installed plugins from the on-disk dir. A configured LUNA_VAULT_PATH is already refreshed by step 6 of this chain; use /luna-upgrade only for an explicit Luna-only run, and /himmel-update-all for multi-vault workflows.
 ---
 
 Updates an existing himmel install. **`git pull` is the only thing that
@@ -32,17 +32,25 @@ the chain** — later items report `not-attempted`, the table still prints, and
 the script exits non-zero.
 
 After the chain (win or lose — these never abort and always run, restoring
-their pre-existing best-effort behavior even on a chain failure) come five
+their pre-existing best-effort behavior even on a chain failure) come seven
 advisory steps: a **codex plugin re-sync + hooks.json re-sanitize**
-(HIMMEL-742), a **statusLine hud re-wire** (HIMMEL-718), a **plugin
-install-state report** — `marketplace update` only re-syncs plugins that are
-*already installed*, so it can't tell you a himmel-marketplace plugin is
-missing, or is being served from a non-`@himmel` marketplace whose
-`autoUpdate` shadows the himmel SHA pin (HIMMEL-434; the report prints the
-`claude plugin install …@himmel` / migrate commands for any gap) — a **lean
-plugin-set reconcile** (HIMMEL-1032, warn-only unless
-`HIMMEL_RECONCILE_PLUGINS=1`), and stale **cadence-runner** / **guardrail-mode
-block** drift checks.
+(HIMMEL-742), a **statusLine hud re-wire** (HIMMEL-718), a **graphify pin
+sync** (HIMMEL-1048) — rolls an EXISTING `uv`-managed graphify install
+forward to the pinned version, so a pin bump in this checkout actually
+reaches the machine (`git pull` alone only updates the resolver script, not
+the installed tool); it reinstalls graphify via `uv` when the pinned version
+differs, skips cleanly when `uv` or the install is absent, and never aborts
+the chain on failure — a **plugin install-state report** — `marketplace
+update` only re-syncs plugins that are *already installed*, so it can't tell
+you a himmel-marketplace plugin is missing, or is being served from a
+non-`@himmel` marketplace whose `autoUpdate` shadows the himmel SHA pin
+(HIMMEL-434; the report prints the `claude plugin install …@himmel` /
+migrate commands for any gap) — a **lean plugin-set reconcile** (HIMMEL-1032,
+warn-only unless `HIMMEL_RECONCILE_PLUGINS=1`), stale **cadence-runner** /
+**guardrail-mode block** drift checks, and a **dependency-readiness check**
+(HIMMEL-1393) — surfaces an enabled skill missing its declared API key, or
+an enabled+keyed skill whose docs still mark its toolkit disabled
+(presence-only, no key values read).
 
 This command can run from **any directory** (HIMMEL-459), so first resolve the
 himmel checkout using the same checkout-resolution order as

--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -509,7 +509,26 @@ Steps:
        coderabbit_avail=$(grep '^panel-availability:' "$cr_tmp" || true)
        case "$coderabbit_rc" in
            0) ;;  # review completed — findings (possibly none) captured
-           3) echo "coderabbit pass skipped (CLI not configured)" ;;
+           3)
+               # CLI absent. For an App-less repo this CLI pass is the ONLY
+               # pre-CI CodeRabbit signal (HIMMEL-1164) — reuse cr-available.sh's
+               # cr_app_configured (HIMMEL-1125) rather than inventing another
+               # probe, so the message escalates only when it's actually true
+               # that nothing will review this PR. Guard the source (codex-1,
+               # CR round 3): a missing helper must degrade to the generic skip
+               # message, never break the handler itself (fail-open).
+               if [ ! -f scripts/lib/cr-available.sh ]; then
+                   echo "coderabbit pass skipped (CLI not configured)"
+               else
+                   # shellcheck source=scripts/lib/cr-available.sh
+                   . scripts/lib/cr-available.sh
+                   if cr_app_configured; then
+                       echo "coderabbit pass skipped (CLI not configured) — the CodeRabbit App is armed for this repo, so CI still reviews this PR"
+                   else
+                       echo "coderabbit pass skipped (CLI not configured) AND the CodeRabbit App is not armed here — this PR will ship with NO CodeRabbit signal. Install the CLI for the sanctioned pre-CI path (docs/internals/enforcement.md#coderabbit-pre-ci-path--app-present-vs-app-absent-himmel-1164), or arm the App with \`git config --local himmel.coderabbit true\` if one is installed." >&2
+                   fi
+               fi
+               ;;
            4) echo "coderabbit pass RATE-LIMITED/quota-exhausted (rc=4) — retry later; recording unavailable (a rate-limited reviewer is a MISSING signal, NOT clean)" >&2 ;;
            *) echo "coderabbit pass failed (rc=$coderabbit_rc) — continuing without it" >&2; coderabbit_findings="" ;;
        esac

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,14 @@ repos:
         always_run: true
         pass_filenames: false
 
+      - id: template-version
+        name: template content change requires metadata.version bump (himmel-dev only, HIMMEL-524)
+        entry: bash scripts/hooks/check-template-version.sh
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-commit]
+
       - id: agents-md-fresh
         name: AGENTS.md must be regenerated from CLAUDE.md (himmel-dev only)
         entry: bash scripts/hooks/check-agents-md-fresh.sh
@@ -222,6 +230,14 @@ repos:
       - id: doc-guard-push
         name: command/skill added requires catalog update (pre-push range)
         entry: bash scripts/hooks/check-doc-guard.sh --pre-push
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: template-version-push
+        name: template content change requires metadata.version bump (pre-push range, HIMMEL-524)
+        entry: bash scripts/hooks/check-template-version.sh --pre-push
         language: system
         always_run: true
         pass_filenames: false

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -745,6 +745,36 @@ Paired artifacts: `scripts/lib/cr-merge-gate.sh` (predicate),
 construction), `scripts/lib/test-cr-merge-gate.sh` and
 `scripts/hooks/test-block-unresolved-cr-merge.sh` (smoke suites).
 
+### CodeRabbit pre-CI path — App-present vs App-absent (HIMMEL-1164)
+
+CodeRabbit has two independent surfaces (also documented at the top of
+`scripts/lib/cr-available.sh`), and each covers a *different* adopter:
+
+- **App present (armed via HIMMEL-1125 above)** — reviews the PR in CI, after
+  `gh pr create`. That review is what the merge gates above key off of. This is
+  the **CI-side** path.
+- **App absent** — no App means no CI-side review, ever, on this repo. The
+  **sanctioned pre-CI path** is the CodeRabbit CLI wrapper,
+  `scripts/cr/coderabbit-review.sh`, run as part of `/pr-check` (step 3.2 phase
+  B in `.claude/commands/pr-check.md`) before the PR ever opens.
+
+**`/pr-check` already runs the CLI pass by default, regardless of App
+presence** — an App-less repo gets CodeRabbit signal from the CLI leg with no
+extra setup. What HIMMEL-1164 adds is *degrading loudly* when that pass is
+unavailable too (`coderabbit-review.sh` rc 3 — CLI not on PATH and, on
+Windows, WSL not opted into via `CODERABBIT_ALLOW_WSL`): the step reuses
+`cr_app_configured` from `scripts/lib/cr-available.sh` (HIMMEL-1125's
+availability probe — never a second, invented probe) to tell whether CI will
+still catch this PR. When the App **is** armed, the CLI-absent message stays
+quiet (CI covers it). When the App is **not** armed, the message escalates to
+say the PR is shipping with **no CodeRabbit signal at all**, and points at
+installing the CLI or arming the App.
+
+The reverse case — an App-present repo running the CLI pass too — is
+intentional duplicate coverage, not a bug; an operator who wants to avoid
+spending a second CodeRabbit call against the same rate-limited account sets
+`CODERABBIT_CLI_DISABLE=1` (documented in `coderabbit-review.sh`).
+
 ### CI-green merge gate (HIMMEL-1043)
 
 Runs on the SAME `gh pr merge` path as the CodeRabbit gate above, one step

--- a/marketplace/plugins/CLAUDE.md
+++ b/marketplace/plugins/CLAUDE.md
@@ -38,6 +38,13 @@ marketplace (`obsidian@obsidian-skills`).
   `scripts/jira/` deps, so raw `bun test` here starts RED ("Cannot find module
   '@modelcontextprotocol/sdk/…'") and masks real regressions; the helper
   `bun install`s first so the baseline is GREEN.
+- **A command mirrored in both `.claude/commands/<name>.md` and a plugin's
+  `commands/<name>.md` (himmel-ops' `himmel-update.md` /
+  `himmel-update-all.md` — kept in both places on purpose, HIMMEL-459: the
+  project copy is the bootstrap path when the plugin isn't installed yet, the
+  plugin copy is what makes it reachable from any cwd) needs BOTH edited
+  together.** They drifted once (HIMMEL-459) when only the project copy kept
+  getting updated — diff the two before committing a change to either.
 
 ## Reference
 - Tooling catalog (what each plugin does):

--- a/marketplace/plugins/handover/skills/handover/references/init-register.md
+++ b/marketplace/plugins/handover/skills/handover/references/init-register.md
@@ -37,7 +37,7 @@ state repo (e.g. `<state-repo>`); it is always the operator-chosen location. The
 |---|---|---|
 | `name` | repo-root basename, slugged | non-empty, kebab-case, ≤30 chars, unique in registry |
 | `path` | canonical `parent(git -C $cwd rev-parse --git-common-dir)` | abs path, exists, is a git repo |
-| `user` | slugged `git -C <path> config user.name` (fallback `$USER`) | non-empty, kebab-case |
+| `user` | resolved via `scripts/lib/user-slug.sh`'s `user_slug` (HIMMEL-145 — `$USER_SLUG` env, then forge username, then slugged `git config user.name`); ask via `AskUserQuestion` if it cannot be resolved (HIMMEL-839 — do NOT fall back to the raw `$USER` OS account name, which on a fresh/shared machine is a generic login like `osboxes`, not the operator's identity) | non-empty, kebab-case |
 | `aliases` | `[name]` | optional, kebab-case list |
 | `keywords` | `[]` | optional, free-text list |
 | `branch_prefix` | `handover/` | optional, must end with `/`; used by worktree gate for `<branch_prefix><slug>`. Scopes **handover-mutation** branches (`new-epic`, `new-task`, `new-standalone`, `end-session`, `update-status`) — distinct from general feature-branch prefixes used by `/worktree.sh` (CLAUDE.md `type/slug` convention) |

--- a/marketplace/plugins/himmel-ops/.claude-plugin/plugin.json
+++ b/marketplace/plugins/himmel-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "himmel-ops",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Harness-meta operational skills for himmel. Load-on-trigger guardrail-recovery playbook (stuck-playbook) that surfaces escape-hatches when an auto-mode write is denied, a Bash command falls through to the classifier, a permission prompt hangs, or a pre-push gate fails — so operational/troubleshooting rules stay out of the always-on root CLAUDE.md (HIMMEL-211). Plus the minerva pipeline skill (/minerva): brainstorm→critic→spec→critic→plan with adversarial critic loops between stages (HIMMEL-428); and memory-compound (/memory-compound): lean-invoke compaction of the per-project auto-memory into qmd-searchable luna/himmel reference notes with a findability gate (HIMMEL-569).",
   "author": {
     "name": "yotamleo"

--- a/marketplace/plugins/himmel-ops/commands/himmel-update.md
+++ b/marketplace/plugins/himmel-ops/commands/himmel-update.md
@@ -1,24 +1,56 @@
 ---
-description: Update this himmel checkout (harness) — git pull + marketplace re-sync + hermes junior-tier update. autoUpdate does NOT deliver himmel updates. For the luna vault, use /luna-upgrade; for both at once, /himmel-update-all.
+description: Update this himmel checkout (harness) — six-item dependency chain (pull, marketplace, jira CLI dist, qmd fork, hermes, luna template) with per-item status + abort-on-first-failure, plus seven best-effort advisory steps (codex re-sanitize, statusLine re-wire, graphify pin sync, plugin gap report, plugin-set reconcile, cadence/guardrail drift checks, dependency-readiness check). `himmelctl update` runs the same engine. autoUpdate does NOT deliver the checkout (git pull) or the core hooks/slash-commands — it only re-syncs installed plugins from the on-disk dir. A configured LUNA_VAULT_PATH is already refreshed by step 6 of this chain; use /luna-upgrade only for an explicit Luna-only run, and /himmel-update-all for multi-vault workflows.
 ---
 
 Updates an existing himmel install. **`git pull` is the only thing that
 delivers a himmel update** — the marketplace is registered from a local
 `directory` source, so Claude Code's `autoUpdate` only re-syncs plugins from
 the on-disk dir; and the core hooks + slash commands aren't plugins at all.
-Full model: `docs/setup/updating.md` in the himmel checkout.
+Full model: `docs/setup/updating.md` in the himmel checkout. `node
+scripts/himmelctl/bin.js update` (or `himmelctl update` if wired) is a thin
+front-end that shells out to the exact same `scripts/himmel-update.sh` engine
+described below, so the two entry points never drift.
 
-Does four steps: fast-forward pull of this checkout,
+In **apply mode** (no `--check`), refuses to run against a **dirty checkout**
+(uncommitted changes) up front — commit or stash first, then re-run. (The
+read-only `--check` mode does not reject a dirty tree.) To update through
+deliberately-kept local tracked diffs (e.g. locally-installed skills), set
+`HIMMEL_UPDATE_AUTOSTASH=1` per-invocation to autostash them around the pull
+(HIMMEL-1197). On a clean tree it runs
+a **six-item dependency chain, in order**: (1) `git pull --ff-only` of this checkout, (2)
 `claude plugin marketplace update himmel` to refresh plugins from the
-freshly-pulled dir, a **hermes junior-tier update** (HIMMEL-426 — hermes is a
-separate editable git checkout *outside* this repo, so `git pull` here never
-touches it; this pulls + reinstalls it, skipping cleanly when hermes isn't
-installed), then a **plugin install-state report** — `marketplace update` only
-re-syncs plugins that are *already installed*, so it can't tell you a
-himmel-marketplace plugin is missing, or is being served from a non-`@himmel`
-marketplace whose `autoUpdate` shadows the himmel SHA pin (HIMMEL-434). The
-report prints the `claude plugin install …@himmel` / migrate commands for any
-gap.
+freshly-pulled dir, (3) a **jira CLI dist rebuild** (`scripts/jira/dist` is
+gitignored, so a pull that touches the jira TypeScript source needs a
+rebuild to take effect), (4) a **qmd fork update** (qmd ships from a
+himmel-pinned fork outside this checkout), (5) a **hermes junior-tier
+update** (HIMMEL-426 — hermes is a separate editable git checkout *outside*
+this repo, so `git pull` here never touches it; this pulls + reinstalls it),
+and (6) a **luna template upgrade** (`LUNA_VAULT_PATH`, content-preserving).
+Each item reports one of `updated` / `up-to-date` / `skipped` / `failed` /
+`not-attempted` in a closing status table. The **first genuine failure aborts
+the chain** — later items report `not-attempted`, the table still prints, and
+the script exits non-zero.
+
+After the chain (win or lose — these never abort and always run, restoring
+their pre-existing best-effort behavior even on a chain failure) come seven
+advisory steps: a **codex plugin re-sync + hooks.json re-sanitize**
+(HIMMEL-742), a **statusLine hud re-wire** (HIMMEL-718), a **graphify pin
+sync** (HIMMEL-1048) — rolls an EXISTING `uv`-managed graphify install
+forward to the pinned version, so a pin bump in this checkout actually
+reaches the machine (`git pull` alone only updates the resolver script, not
+the installed tool); it reinstalls graphify via `uv` when the pinned version
+differs, skips cleanly when `uv` or the install is absent, and never aborts
+the chain on failure — a **plugin install-state report** — `marketplace
+update` only re-syncs plugins that are *already installed*, so it can't tell
+you a himmel-marketplace plugin is missing, or is being served from a
+non-`@himmel` marketplace whose `autoUpdate` shadows the himmel SHA pin
+(HIMMEL-434; the report prints the `claude plugin install …@himmel` /
+migrate commands for any gap) — a **lean plugin-set reconcile** (HIMMEL-1032,
+warn-only unless `HIMMEL_RECONCILE_PLUGINS=1`), stale **cadence-runner** /
+**guardrail-mode block** drift checks, and a **dependency-readiness check**
+(HIMMEL-1393) — surfaces an enabled skill missing its declared API key, or
+an enabled+keyed skill whose docs still mark its toolkit disabled
+(presence-only, no key values read).
 
 This command can run from **any directory** (HIMMEL-459), so first resolve the
 himmel checkout using the same checkout-resolution order as
@@ -38,9 +70,11 @@ fi
 [ -f "$REPO/scripts/himmel-update.sh" ] || { echo "ERR: cannot locate himmel checkout — set HIMMEL_REPO to your himmel clone" >&2; exit 1; }
 
 # Then run ONE of:
-bash "$REPO/scripts/himmel-update.sh"                 # pull + re-sync + gap report
+bash "$REPO/scripts/himmel-update.sh"                 # six-item chain + advisory steps
 bash "$REPO/scripts/himmel-update.sh" --check         # report only (behind/ahead + gaps), no pull
 bash "$REPO/scripts/himmel-update.sh" --plugins-check # just the plugin gap report, no git
+# equivalent entry point:
+node "$REPO/scripts/himmelctl/bin.js" update          # same engine, thin wrapper
 ```
 
 After it finishes: hooks are live immediately; **restart any running Claude

--- a/scripts/adopt.ps1
+++ b/scripts/adopt.ps1
@@ -221,6 +221,63 @@ function Wire-LunaVaultPath([string]$Dest) {
     if ($LASTEXITCODE -ne 0) { throw "wire-luna-vault failed (exit $LASTEXITCODE)" }
 }
 
+# env.HANDOVER_DIR — seed the handover state root at the scaffolded luna vault
+# (HIMMEL-839). Without this, a fresh adopter's handover state silently
+# defaults to the inline <repo-root>/handovers/ stub. Creates <Dest>/handovers
+# so Mode B resolves cleanly out of the box. Sibling of Wire-LunaVaultPath;
+# $Dest = the scaffolded vault dir.
+function Wire-HandoverDirLuna([string]$Dest) {
+    $hdir = Join-Path $Dest 'handovers'
+    $settings = if ($Scope -eq 'project') {
+        Join-Path $Target '.claude\settings.json'
+    } else {
+        Join-Path $HOME '.claude\settings.json'
+    }
+
+    # PRESERVE an operator-selected HANDOVER_DIR (HIMMEL-839 CR round-2): a
+    # routine re-adopt must reproduce state, never silently reset it.
+    # /handover-setup is documented as "the only place the state-root location
+    # is chosen interactively" -- adopt.ps1 must not become a second, silent
+    # place that overrides that choice. Two places it could already live:
+    #   1. This settings.json's own env.HANDOVER_DIR (a prior adopt run).
+    #   2. The primary checkout's .env (set-handover-dir.sh / Mode B -- the
+    #      actual file /handover-setup writes to). settings.json env takes
+    #      PROCESS-ENV precedence over .env, so writing here would silently
+    #      SHADOW that choice even though the .env file itself stayed
+    #      untouched. Same rationale as the .sh twin.
+    if (Test-Path $settings) {
+        $existing = $null
+        try {
+            $existingCfg = Get-Content $settings -Raw | ConvertFrom-Json
+            $existing = $existingCfg.env.HANDOVER_DIR
+        } catch {
+            $existing = $null
+        }
+        if ($existing) {
+            Write-Host "  env.HANDOVER_DIR already set in $settings ($existing) — leaving it (re-adopt reproduces, never resets; HIMMEL-839)"
+            return
+        }
+    }
+    $envFile = Join-Path $HimmelRoot '.env'
+    if ((Test-Path $envFile) -and (Select-String -Path $envFile -Pattern '^\s*HANDOVER_DIR=' -Quiet)) {
+        Write-Host "  HANDOVER_DIR already set in $envFile (via /handover-setup) — leaving it, not wiring env.HANDOVER_DIR into $settings (HIMMEL-839)"
+        return
+    }
+
+    if ($DryRun) {
+        Write-Host "DRY: mkdir -p $hdir"
+        Write-Host "DRY: wire env.HANDOVER_DIR → $settings (handover dir: $hdir)"
+        return
+    }
+    New-Item -ItemType Directory -Force -Path $hdir | Out-Null
+    # Canonicalize to an absolute path (HIMMEL-839 CR round-2): a relative
+    # -LunaTarget would otherwise persist a CWD-dependent relative path.
+    $hdir = (Resolve-Path $hdir).Path
+    $whd = Join-Path $HimmelRoot 'scripts\lib\wire-handover-dir.ps1'
+    & pwsh -NoProfile -File $whd -SettingsPath $settings -HandoverDir $hdir
+    if ($LASTEXITCODE -ne 0) { throw "wire-handover-dir failed (exit $LASTEXITCODE)" }
+}
+
 # -FillEnv (HIMMEL-453): fill the himmel clone's .env via the bash fill-env.sh.
 # Targets $HimmelRoot\.env for BOTH scopes (adopt copies hooks, never the Jira
 # CLI, so an adopted repo always uses the clone's CLI reading $HimmelRoot\.env).
@@ -629,6 +686,8 @@ function Do-Luna([string]$Dest) {
     # Persist the vault path UNCONDITIONALLY — a re-run over an existing scaffold
     # must still wire a previously-unwired install (HIMMEL-458).
     Wire-LunaVaultPath $Dest
+    # Seed HANDOVER_DIR the same way, same reasoning (HIMMEL-839).
+    Wire-HandoverDirLuna $Dest
     # G5 (HIMMEL-752): register the scaffolded vault as a qmd collection so it
     # is queryable immediately. Skip + note when qmd/bun unavailable; WARN-not-fail.
     # For -Profile all, Do-Core (-> Wire-QmdCore) has already installed qmd; for

--- a/scripts/adopt.sh
+++ b/scripts/adopt.sh
@@ -246,6 +246,61 @@ wire_luna_vault_path() {
   bash "$HIMMEL_ROOT/scripts/lib/wire-luna-vault.sh" "$settings" "$dest"
 }
 
+# env.HANDOVER_DIR — seed the handover state root at the scaffolded luna vault
+# (HIMMEL-839). Without this, a fresh adopter's handover state silently
+# defaults to the inline <repo-root>/handovers/ stub and the operator has to
+# discover + set HANDOVER_DIR by hand (observed on a fresh ubuntu_new install
+# with no prior state). Creates <dest>/handovers/ so Mode B resolves cleanly
+# out of the box (handover_root's pure resolver fails closed on a missing
+# dir — scripts/lib/handover-path.sh). Sibling of wire_luna_vault_path; $1 =
+# the scaffolded vault dir.
+wire_handover_dir_luna() {
+  local dest="$1" hdir settings envfile existing
+  hdir="$dest/handovers"
+  if [[ "$SCOPE" == "project" ]]; then
+    settings="$TARGET/.claude/settings.json"
+  else
+    settings="$HOME/.claude/settings.json"
+  fi
+  # PRESERVE an operator-selected HANDOVER_DIR (HIMMEL-839 CR round-2): a
+  # routine re-adopt must reproduce state, never silently reset it.
+  # /handover-setup is documented as "the only place the state-root location
+  # is chosen interactively" (handover-setup.md) — adopt.sh must not become a
+  # second, silent place that overrides that choice. Two places it could
+  # already live:
+  #   1. This settings.json's own env.HANDOVER_DIR (a prior adopt run).
+  #   2. The primary checkout's .env (set-handover-dir.sh / Mode B — the
+  #      actual file /handover-setup writes to). settings.json env takes
+  #      PROCESS-ENV precedence over .env (scripts/lib/load-dotenv.sh only
+  #      fills currently-unset vars), so writing here would silently SHADOW
+  #      that choice even though the .env file itself stayed untouched.
+  if [[ -f "$settings" ]] && command -v jq >/dev/null 2>&1; then
+    existing="$(jq -r '.env.HANDOVER_DIR // empty' "$settings" 2>/dev/null || true)"
+    if [[ -n "$existing" ]]; then
+      echo "  env.HANDOVER_DIR already set in $settings ($existing) — leaving it (re-adopt reproduces, never resets; HIMMEL-839)"
+      return
+    fi
+  fi
+  envfile="$HIMMEL_ROOT/.env"
+  if [[ -f "$envfile" ]] && grep -qE '^[[:space:]]*HANDOVER_DIR=' "$envfile"; then
+    echo "  HANDOVER_DIR already set in $envfile (via /handover-setup) — leaving it, not wiring env.HANDOVER_DIR into $settings (HIMMEL-839)"
+    return
+  fi
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "DRY: mkdir -p $hdir"
+    echo "DRY: wire env.HANDOVER_DIR → $settings (handover dir: $hdir)"
+    return
+  fi
+  mkdir -p "$hdir"
+  # Canonicalize to an absolute path (HIMMEL-839 CR round-2): a relative
+  # --luna-target would otherwise persist a CWD-dependent relative path into
+  # settings.json, resolving against whatever CWD a later session happens to
+  # launch from. Same idiom scripts/handover/set-handover-dir.sh already uses.
+  # shellcheck disable=SC1003  # '\\' is a literal backslash for tr, not a quote escape
+  hdir="$(cd "$hdir" && pwd | tr '\\' '/')"
+  bash "$HIMMEL_ROOT/scripts/lib/wire-handover-dir.sh" "$settings" "$hdir"
+}
+
 # --fill-env (HIMMEL-453): fill the himmel clone's .env. We target
 # $HIMMEL_ROOT/.env (NOT $TARGET/.env) for BOTH scopes because adopt copies only
 # portable hooks — never the Jira CLI — so an adopted repo always invokes
@@ -434,6 +489,8 @@ do_luna() {
   # Persist the vault path UNCONDITIONALLY — a re-run over an existing scaffold
   # (skipped copy above) must still wire a previously-unwired install (HIMMEL-458).
   wire_luna_vault_path "$dest"
+  # Seed HANDOVER_DIR the same way, same reasoning (HIMMEL-839).
+  wire_handover_dir_luna "$dest"
   # G5 (HIMMEL-752): register the scaffolded vault as a qmd collection so it is
   # queryable immediately. Skip + note when qmd/bun unavailable; WARN-not-fail.
   # For --profile all, do_core (→ wire_qmd_core) has already installed qmd; for

--- a/scripts/clean-garden.sh
+++ b/scripts/clean-garden.sh
@@ -4,10 +4,9 @@
 # Usage:
 #   ./scripts/clean-garden.sh [branch-name] [flags]
 #
-# Prune phase: removes any non-primary worktree whose branch has a merged PR
-# (preferred signal: the forge seam's merged-PR query — GitHub or Bitbucket,
-# HIMMEL-326) or is marked [gone] in `git branch -v` (fallback when the forge
-# CLI is unavailable).
+# Prune phase: removes any non-primary worktree whose branch tip exactly matches
+# the recorded head of a merged PR. After pruning, every kept worktree is
+# accounted for and origin's unmerged remote branches are classified.
 #
 # Create phase: when branch-name supplied, delegates to scripts/_new-worktree.sh
 # after the prune.
@@ -22,6 +21,7 @@
 #   --no-prune           Skip the prune phase; just create.
 #   --no-install         Forwarded to _new-worktree.sh.
 #   --dry-run            Show what would happen, do nothing.
+#   --include-puborigin  Also account for puborigin's remote branches.
 #   --verbose, -v        Stream subprocess output.
 #   -h, --help           Print usage.
 set -euo pipefail
@@ -44,6 +44,7 @@ Flags:
   --no-prune            Skip prune; only create.
   --no-install          Forward to _new-worktree.sh (skip jira install).
   --dry-run             Show plan; do nothing.
+  --include-puborigin   Also report unmerged branches from puborigin.
   --verbose, -v         Stream subprocess output.
   -h, --help            This message.
 
@@ -65,14 +66,16 @@ PRUNE_ONLY=0
 NO_PRUNE=0
 NO_INSTALL=0
 DRY_RUN=0
+INCLUDE_PUBORIGIN=0
 VERBOSE=0
 while [ $# -gt 0 ]; do
     case "$1" in
         --prune-only) PRUNE_ONLY=1; shift ;;
         --no-prune)   NO_PRUNE=1; shift ;;
         --no-install) NO_INSTALL=1; shift ;;
-        --dry-run)    DRY_RUN=1; shift ;;
-        --verbose|-v) VERBOSE=1; shift ;;
+        --dry-run)           DRY_RUN=1; shift ;;
+        --include-puborigin) INCLUDE_PUBORIGIN=1; shift ;;
+        --verbose|-v)        VERBOSE=1; shift ;;
         -h|--help)    print_help ;;
         -*)           echo "Unknown flag: $1" >&2; usage_err ;;
         *)
@@ -119,34 +122,169 @@ if FORGE_KIND=$(forge_in_primary forge_detect 2>/dev/null) && forge_in_primary f
     HAVE_FORGE=1
     FORGE_NWO=$(forge_in_primary forge_repo_nwo 2>/dev/null || true)
     if [ -n "$FORGE_NWO" ]; then
-        log "clean-garden: $FORGE_KIND CLI available — using merged-PR signal (repo: $FORGE_NWO)"
+        log "clean-garden: $FORGE_KIND CLI available (repo: $FORGE_NWO)"
     else
-        log "clean-garden: $FORGE_KIND CLI available but repo lookup failed — queries use the origin's repo"
+        log "clean-garden: $FORGE_KIND CLI available but repo lookup failed"
     fi
 else
-    log "clean-garden: forge CLI unavailable — falling back to [gone] tracking"
+    log "clean-garden: forge CLI unavailable — PR accounting unknown; worktrees are kept"
 fi
 
-# Return 0 if the branch has a merged PR (or is [gone] in fallback mode).
-# Returns 1 (do-not-prune) on any error so transient failures are safe.
+# GitHub accounting cache. One paginated API walk per repository replaces the
+# old per-worktree PR queries and records the PR head SHA needed to distinguish
+# a squash-merged branch from post-merge commits on the same branch.
+ORIGIN_NWO="$FORGE_NWO"
+ORIGIN_PR_CACHE=""
+ORIGIN_PR_CACHE_OK=0
+PUBORIGIN_NWO=""
+PUBORIGIN_PR_CACHE=""
+PUBORIGIN_PR_CACHE_OK=0
+
+# KNOWN LIMITATION: rows key on head.repo.full_name == nwo, so a PR opened
+# from a fork (head repo != base repo) is filtered out even though its base
+# is this repo. Local worktree/remote-tracking branches are pushed straight
+# to origin on this private repo, so a fork PR would only coincidentally
+# share a branch name with one of them — rare enough here not to warrant the
+# extra base.repo.full_name plumbing + matching-rule complexity. Revisit if
+# this repo starts taking fork PRs.
+fetch_github_pr_cache() {
+    local nwo="$1"
+    forge_in_primary _gh api --paginate "repos/$nwo/pulls?state=all&per_page=100" \
+        --jq '.[] | [(.head.repo.full_name // ""), .head.ref, (if .state == "open" then "open" elif .merged_at != null then "merged" else "closed" end), .head.sha] | @tsv'
+}
+
+github_nwo_from_remote() {
+    local remote="$1" url path
+    url=$(git -C "$PRIMARY_WORKTREE" remote get-url "$remote" 2>/dev/null) || return 1
+    case "$url" in
+        https://github.com/*|http://github.com/*) path="${url#*github.com/}" ;;
+        git@github.com:*) path="${url#git@github.com:}" ;;
+        ssh://git@github.com/*) path="${url#ssh://git@github.com/}" ;;
+        *) return 1 ;;
+    esac
+    path="${path%.git}"
+    path="${path%/}"
+    case "$path" in
+        */*) printf '%s\n' "$path" ;;
+        *) return 1 ;;
+    esac
+}
+
+if [ "$HAVE_FORGE" -eq 1 ] && [ "$FORGE_KIND" = "github" ]; then
+    if [ -z "$ORIGIN_NWO" ]; then
+        # forge_repo_nwo (gh repo view) failed — fall back to parsing origin's
+        # remote URL directly rather than silently degrading accounting.
+        if ORIGIN_NWO=$(github_nwo_from_remote origin); then
+            log "clean-garden: origin repo lookup recovered from remote URL: $ORIGIN_NWO"
+        fi
+    fi
+    if [ -n "$ORIGIN_NWO" ]; then
+        if ORIGIN_PR_CACHE=$(fetch_github_pr_cache "$ORIGIN_NWO" 2>/dev/null); then
+            ORIGIN_PR_CACHE_OK=1
+        else
+            echo "WARN clean-garden: GitHub PR cache failed for origin — accounting will keep uncertain work" >&2
+        fi
+    else
+        echo "WARN clean-garden: could not determine origin's GitHub repo (gh repo view + remote URL parse both failed) — PR accounting degraded to unknown for origin" >&2
+    fi
+fi
+if [ "$INCLUDE_PUBORIGIN" -eq 1 ]; then
+    if ! git -C "$PRIMARY_WORKTREE" remote get-url puborigin >/dev/null 2>&1; then
+        echo "WARN clean-garden: --include-puborigin requested but no puborigin remote exists" >&2
+    elif PUBORIGIN_NWO=$(github_nwo_from_remote puborigin); then
+        if PUBORIGIN_PR_CACHE=$(fetch_github_pr_cache "$PUBORIGIN_NWO" 2>/dev/null); then
+            PUBORIGIN_PR_CACHE_OK=1
+        else
+            echo "WARN clean-garden: GitHub PR cache failed for puborigin — accounting will keep uncertain work" >&2
+        fi
+    else
+        echo "WARN clean-garden: puborigin is not a GitHub remote — PR accounting unavailable" >&2
+    fi
+fi
+
+# Sets PR_STATE and PR_HEAD_MATCH for a branch tip. PR_STATE is one of
+# open/merged/closed/none when the cache is authoritative, or unknown when the
+# forge could not be queried. A merged PR wins over a closed PR, but an open PR
+# wins over both. Among merged PRs, an exact recorded head match is remembered.
+resolve_pr_state() {
+    local remote="$1" branch="$2" tip="$3"
+    local cache cache_ok nwo row_repo row_branch row_state row_sha
+    local saw_closed=0 saw_merged=0 exact_merged=0
+    PR_STATE="unknown"
+    PR_HEAD_MATCH=0
+
+    case "$remote" in
+        origin)
+            cache="$ORIGIN_PR_CACHE"
+            cache_ok="$ORIGIN_PR_CACHE_OK"
+            nwo="$ORIGIN_NWO"
+            ;;
+        puborigin)
+            cache="$PUBORIGIN_PR_CACHE"
+            cache_ok="$PUBORIGIN_PR_CACHE_OK"
+            nwo="$PUBORIGIN_NWO"
+            ;;
+        *) return 0 ;;
+    esac
+    [ "$cache_ok" -eq 1 ] || return 0
+
+    PR_STATE="none"
+    while IFS=$'\t' read -r row_repo row_branch row_state row_sha; do
+        [ -n "$row_branch" ] || continue
+        [ "$row_repo" = "$nwo" ] || continue
+        [ "$row_branch" = "$branch" ] || continue
+        case "$row_state" in
+            open)
+                PR_STATE="open"
+                return 0
+                ;;
+            merged)
+                saw_merged=1
+                [ "$row_sha" = "$tip" ] && exact_merged=1
+                ;;
+            closed)
+                saw_closed=1
+                ;;
+        esac
+    done <<EOF
+$cache
+EOF
+    if [ "$saw_merged" -eq 1 ]; then
+        PR_STATE="merged"
+        PR_HEAD_MATCH="$exact_merged"
+    elif [ "$saw_closed" -eq 1 ]; then
+        PR_STATE="closed"
+    fi
+}
+
+# Return 0 only when the current branch tip exactly matches the recorded head
+# of a merged PR. A mere "this branch once had a merged PR" signal is unsafe:
+# commits may have been added after the squash merge (the HIMMEL-1410 loss mode).
+#
+# The cached-listing accounting above (ORIGIN_PR_CACHE) is GitHub-only. On a
+# non-github forge, fall back to the forge-agnostic per-branch signal the
+# cache replaced (forge_pr_has_merged) so pruning keeps working — accounting
+# rows still show pr-state=unknown there, but that is a display-only gap, not
+# a stuck-worktree regression.
+NON_GITHUB_PRUNE_DEGRADED_WARNED=0
 is_branch_mergeable_for_prune() {
-    local branch="$1"
-    if [ "$HAVE_FORGE" -eq 1 ]; then
+    local branch="$1" tip
+    tip=$(git -C "$PRIMARY_WORKTREE" rev-parse --verify "refs/heads/$branch^{commit}" 2>/dev/null) || return 1
+    if [ "$HAVE_FORGE" -eq 1 ] && [ "$FORGE_KIND" != "github" ]; then
+        if [ "$NON_GITHUB_PRUNE_DEGRADED_WARNED" -eq 0 ]; then
+            echo "WARN clean-garden: $FORGE_KIND PR accounting is degraded (pr-state=unknown for kept worktrees) — prune decisions fall back to the legacy per-branch merged-PR check" >&2
+            NON_GITHUB_PRUNE_DEGRADED_WARNED=1
+        fi
         local count
         if ! count=$(forge_in_primary forge_pr_has_merged "$branch" 2>/dev/null); then
             echo "WARN clean-garden: forge PR query failed for $branch — treating as not-mergeable (worktree kept)" >&2
             return 1
         fi
-        # The test exit code is intentionally the function's return value.
         [ "${count:-0}" -gt 0 ]
         return
     fi
-    # Fallback: parse `git branch -v` for [gone]. Assumes the worktree branch
-    # also exists in the primary repo's branch list — true for branches
-    # created via scripts/_new-worktree.sh (always created from primary).
-    git -C "$PRIMARY_WORKTREE" branch -v 2>/dev/null \
-        | sed 's/^[+* ]//' \
-        | awk -v b="$branch" '$1 == b && /\[gone\]/ { found=1 } END { exit !found }'
+    resolve_pr_state origin "$branch" "$tip"
+    [ "$PR_STATE" = "merged" ] && [ "$PR_HEAD_MATCH" -eq 1 ]
 }
 
 # Is an untracked path a known, discardable stray? (HIMMEL-431)
@@ -257,6 +395,220 @@ human_kib() {
             printf "%.1f%s", value, unit[idx]
         }
     }'
+}
+
+MAIN_REF=""
+if git -C "$PRIMARY_WORKTREE" rev-parse --verify --quiet refs/remotes/origin/main >/dev/null; then
+    MAIN_REF="refs/remotes/origin/main"
+elif git -C "$PRIMARY_WORKTREE" rev-parse --verify --quiet refs/heads/main >/dev/null; then
+    MAIN_REF="refs/heads/main"
+fi
+
+last_commit_age() {
+    local tip="$1" committed now elapsed
+    committed=$(git -C "$PRIMARY_WORKTREE" show -s --format=%ct "$tip" 2>/dev/null) || {
+        printf '?'; return 0;
+    }
+    now=$(date +%s)
+    elapsed=$((now - committed))
+    [ "$elapsed" -lt 0 ] && elapsed=0
+    if [ "$elapsed" -ge 86400 ]; then
+        printf '%dd' "$((elapsed / 86400))"
+    elif [ "$elapsed" -ge 3600 ]; then
+        printf '%dh' "$((elapsed / 3600))"
+    else
+        printf '%dm' "$((elapsed / 60))"
+    fi
+}
+
+scan_worktree_counts() {
+    local wt="$1" status_line status_output
+    WT_SCAN_OK=1
+    WT_DIRTY_COUNT=0
+    WT_UNTRACKED_COUNT=0
+    if ! status_output=$(git -C "$wt" status --porcelain --untracked-files=all 2>/dev/null); then
+        WT_SCAN_OK=0
+        return 0
+    fi
+    while IFS= read -r status_line; do
+        [ -n "$status_line" ] || continue
+        case "$status_line" in
+            "?? "*) WT_UNTRACKED_COUNT=$((WT_UNTRACKED_COUNT+1)) ;;
+            *)       WT_DIRTY_COUNT=$((WT_DIRTY_COUNT+1)) ;;
+        esac
+    done <<EOF
+$status_output
+EOF
+}
+
+commits_not_on_main() {
+    local tip="$1"
+    if [ -z "$MAIN_REF" ]; then
+        printf '?'
+        return 0
+    fi
+    git -C "$PRIMARY_WORKTREE" rev-list --count "$MAIN_REF..$tip" 2>/dev/null || printf '?'
+}
+
+LOCAL_KEPT=0
+LOCAL_UNKNOWN=0
+report_kept_worktree() {
+    local wt="$1" branch="$2" tip="$3" locked="$4"
+    local branch_label ahead age verdict why wt_norm
+    LOCAL_KEPT=$((LOCAL_KEPT+1))
+    branch_label="$branch"
+    [ -n "$branch_label" ] || branch_label="(detached:${tip:0:12})"
+    ahead=$(commits_not_on_main "$tip")
+    age=$(last_commit_age "$tip")
+    scan_worktree_counts "$wt"
+    wt_norm=$(cd "$wt" 2>/dev/null && pwd || echo "$wt")
+
+    if [ "$WT_SCAN_OK" -eq 0 ]; then
+        PR_STATE="unknown"
+        verdict="UNKNOWN"
+        why="working-tree scan failed"
+    elif [ $((WT_DIRTY_COUNT + WT_UNTRACKED_COUNT)) -gt 0 ]; then
+        if [ -n "$branch" ]; then
+            resolve_pr_state origin "$branch" "$tip"
+        else
+            PR_STATE="none"
+        fi
+        verdict="PARKED-WIP"
+        why="working tree is not clean"
+    elif [ "$wt_norm" = "$PRIMARY_WORKTREE" ]; then
+        if [ -n "$branch" ]; then
+            resolve_pr_state origin "$branch" "$tip"
+        else
+            PR_STATE="none"
+        fi
+        verdict="ACTIVE"
+        why="primary worktree"
+    elif [ -z "$branch" ]; then
+        PR_STATE="none"
+        if [ "$ahead" = "0" ]; then
+            verdict="SUPERSEDED"
+            why="detached tip is already on main"
+        else
+            verdict="UNKNOWN"
+            why="detached tip has commits not on main"
+        fi
+    else
+        resolve_pr_state origin "$branch" "$tip"
+        case "$PR_STATE:$PR_HEAD_MATCH:$ahead" in
+            open:*)
+                verdict="ACTIVE"
+                why="open PR"
+                ;;
+            merged:1:*)
+                verdict="SUPERSEDED"
+                why="tip matches merged PR head"
+                ;;
+            merged:0:*)
+                verdict="UNKNOWN"
+                why="branch tip differs from merged PR head"
+                ;;
+            *:*:0)
+                verdict="SUPERSEDED"
+                why="tip is already on main"
+                ;;
+            closed:*)
+                verdict="UNKNOWN"
+                why="closed PR left commits off main"
+                ;;
+            none:*)
+                verdict="UNKNOWN"
+                why="no PR for commits off main"
+                ;;
+            *)
+                verdict="UNKNOWN"
+                why="PR state could not be resolved"
+                ;;
+        esac
+    fi
+    [ "$locked" -eq 0 ] || why="$why; worktree locked"
+    [ "$verdict" != "UNKNOWN" ] || LOCAL_UNKNOWN=$((LOCAL_UNKNOWN+1))
+    printf 'KEEP clean-garden: branch=%s pr=%s commits-not-main=%s dirty=%s untracked=%s age=%s verdict=%s why=%s path=%s\n' \
+        "$branch_label" "$PR_STATE" "$ahead" "$WT_DIRTY_COUNT" "$WT_UNTRACKED_COUNT" \
+        "$age" "$verdict" "$why" "$wt"
+}
+
+report_kept_worktrees() {
+    local wt="" branch="" tip="" locked=0 line
+    while IFS= read -r line; do
+        case "$line" in
+            "worktree "*)
+                if [ -n "$wt" ]; then
+                    report_kept_worktree "$wt" "$branch" "$tip" "$locked"
+                fi
+                wt="${line#worktree }"
+                branch=""
+                tip=""
+                locked=0
+                ;;
+            "HEAD "*)
+                tip="${line#HEAD }"
+                ;;
+            "branch refs/heads/"*)
+                branch="${line#branch refs/heads/}"
+                ;;
+            "locked"*)
+                locked=1
+                ;;
+            "")
+                if [ -n "$wt" ]; then
+                    report_kept_worktree "$wt" "$branch" "$tip" "$locked"
+                    wt=""
+                fi
+                ;;
+        esac
+    done < <(git -C "$PRIMARY_WORKTREE" worktree list --porcelain)
+    if [ -n "$wt" ]; then
+        report_kept_worktree "$wt" "$branch" "$tip" "$locked"
+    fi
+}
+
+REMOTE_MERGED_CLEAN=0
+REMOTE_TIP_DIFFERS=0
+REMOTE_CLOSED_UNMERGED=0
+REMOTE_NO_PR=0
+REMOTE_UNKNOWN=0
+report_remote_orphans() {
+    local remote="$1" branch tip category
+    git -C "$PRIMARY_WORKTREE" remote get-url "$remote" >/dev/null 2>&1 || return 0
+    while IFS=' ' read -r branch tip; do
+        [ -n "$branch" ] || continue
+        [ "$branch" != "HEAD" ] || continue
+        if [ -n "$MAIN_REF" ] && git -C "$PRIMARY_WORKTREE" merge-base --is-ancestor "$tip" "$MAIN_REF" 2>/dev/null; then
+            continue
+        fi
+        resolve_pr_state "$remote" "$branch" "$tip"
+        [ "$PR_STATE" != "open" ] || continue
+        case "$PR_STATE:$PR_HEAD_MATCH" in
+            merged:1)
+                category="MERGED-CLEAN"
+                REMOTE_MERGED_CLEAN=$((REMOTE_MERGED_CLEAN+1))
+                ;;
+            merged:0)
+                category="TIP-DIFFERS"
+                REMOTE_TIP_DIFFERS=$((REMOTE_TIP_DIFFERS+1))
+                ;;
+            closed:*)
+                category="CLOSED-UNMERGED"
+                REMOTE_CLOSED_UNMERGED=$((REMOTE_CLOSED_UNMERGED+1))
+                ;;
+            none:*)
+                category="NO-PR"
+                REMOTE_NO_PR=$((REMOTE_NO_PR+1))
+                ;;
+            *)
+                category="UNKNOWN"
+                REMOTE_UNKNOWN=$((REMOTE_UNKNOWN+1))
+                ;;
+        esac
+        printf 'REMOTE clean-garden: remote=%s branch=%s pr=%s category=%s tip=%s\n' \
+            "$remote" "$branch" "$PR_STATE" "$category" "${tip:0:12}"
+    done < <(git -C "$PRIMARY_WORKTREE" for-each-ref \
+        --format='%(refname:strip=3) %(objectname)' "refs/remotes/$remote")
 }
 
 PRUNED=0
@@ -470,6 +822,19 @@ if [ "$NO_PRUNE" -eq 0 ]; then
             fi
         done < <(find "$CR_DIR" -type f 2>/dev/null | sort)
         echo "clean-garden: cr-pending sweep — $CR_SWEPT swept, $CR_KEPT kept (branch exists), $CR_NOTED kept (open PR)"
+    fi
+
+    echo "clean-garden: full accounting — kept worktrees"
+    report_kept_worktrees
+    echo "clean-garden: full accounting — remote orphans"
+    report_remote_orphans origin
+    if [ "$INCLUDE_PUBORIGIN" -eq 1 ]; then
+        report_remote_orphans puborigin
+    fi
+    echo "clean-garden: accounting summary — $LOCAL_KEPT kept worktrees; $REMOTE_MERGED_CLEAN MERGED-CLEAN, $REMOTE_TIP_DIFFERS TIP-DIFFERS, $REMOTE_CLOSED_UNMERGED CLOSED-UNMERGED, $REMOTE_NO_PR NO-PR"
+    ACCOUNTING_UNKNOWN=$((LOCAL_UNKNOWN + REMOTE_UNKNOWN))
+    if [ "$ACCOUNTING_UNKNOWN" -gt 0 ] || [ "$REMOTE_TIP_DIFFERS" -gt 0 ] || [ "$REMOTE_NO_PR" -gt 0 ]; then
+        echo "ALERT clean-garden: attention required — $ACCOUNTING_UNKNOWN UNKNOWN, $REMOTE_TIP_DIFFERS TIP-DIFFERS, $REMOTE_NO_PR NO-PR"
     fi
 fi
 

--- a/scripts/cleanup/test-codex-sweep-cadence.sh
+++ b/scripts/cleanup/test-codex-sweep-cadence.sh
@@ -342,6 +342,24 @@ assert_contains "bat carries the resolved pwsh path" "$fake_pwsh_win" "$bat"
 for what in --settings "< NUL" "< /dev/null"; do
     assert_not_contains "bat has no claude-session marker ($what)" "$what" "$bat"
 done
+# Folded in from former FIX 1c/1d blocks (HIMMEL-1324): both exercised this
+# exact same successful-default-arm scenario (reset_state; run_sc arm) with
+# no state divergence from T1 above, so they are the same code path -- merged
+# into T1's single arm call instead of re-arming twice more.
+if ls "$BAT_DIR"/.codex-sweep.bat.* >/dev/null 2>&1; then
+    fail "temp runner file left behind after success" "$(ls "$BAT_DIR"/.codex-sweep.bat.* 2>/dev/null)"
+else
+    pass "no temp runner file left behind after success (FIX 1c)"
+fi
+if [ -f "$STATE/create-time-runner-probe.bat" ]; then
+    pass "runner was readable at its final path at /create time (publish-before-create ordering holds, FIX 1d)"
+else
+    fail "runner NOT readable at its final path at /create time -- publish-before-create ordering broken"
+fi
+probe=$(cat "$STATE/create-time-runner-probe.bat" 2>/dev/null || echo MISSING)
+assert_contains "create-time probe carries the full new runner content (sweep payload)" "sweep-codex-orphans.ps1" "$probe"
+assert_contains "create-time probe carries the full new runner content (reap payload)" "reap-mcp-fleet.ps1" "$probe"
+assert_contains "create-time probe carries the format-version stamp (proves COMPLETE content, not partial)" "himmel-cadence-runner-format: 7" "$probe"
 
 echo "TEST: created XML carries InteractiveToken/LeastPrivilege + default 09:00 (T1b)"
 xml=$(cat "$STATE/tasks/HIMMEL-CodexOrphanSweep" 2>/dev/null || echo MISSING)
@@ -371,10 +389,14 @@ assert_contains "Repetition is the FIRST child of CalendarTrigger (canonical ord
 # 12 invocations and pushed the suite past the cap: green standalone, rc=124
 # under the runner. Coverage is chosen per distinct CODE PATH, not per value:
 #   * one accepted non-default value, via the `=` form (covers value handling AND
-#     the equals-form parse; the space form is covered by the reject cases below)
+#     the equals-form parse; the space form is covered by the reject case below)
 #   * 0, the only value that changes the emitted SHAPE (no <Repetition>)
 #   * the default (4) is already asserted in T1b, so it is not re-armed here
-#   * three rejects, one per regex branch: out-of-range, non-numeric, empty
+#   * one reject (HIMMEL-1324): codex-sweep-cadence.sh validates --repeat-hours
+#     with a SINGLE regex line (`^([0-9]|1[0-9]|2[0-3])$`), so an out-of-range,
+#     a non-numeric, and an empty value all fail the exact same branch with the
+#     exact same message -- three inputs, one code path. Kept the out-of-range
+#     case (24); dropped abc/'' as same-branch duplicates.
 #   * arm-only enforcement on ONE subcommand — status and disarm share a single
 #     guard, and --time already covers both for that code path
 echo "TEST: --repeat-hours (HIMMEL-1309 gap 6)"
@@ -387,18 +409,16 @@ run_sc arm --repeat-hours 0 >/dev/null
 xml=$(cat "$STATE/tasks/HIMMEL-CodexOrphanSweep" 2>/dev/null || echo MISSING)
 assert_not_contains "--repeat-hours 0 emits NO Repetition (daily-only, pre-1309 shape)" "<Repetition>" "$xml"
 assert_contains "--repeat-hours 0 still emits the daily schedule" "<ScheduleByDay>" "$xml"
-# Rejects run BEFORE the platform gate and never reach schtasks, so they are the
-# cheap cases — one per regex branch.
-for bad in 24 abc ''; do
-    reset_state
-    rc=0; out=$(run_sc arm --repeat-hours "$bad" 2>&1) || rc=$?
-    assert_rc "--repeat-hours '$bad' rejected -> rc 1" 1 "$rc"
-    if [ ! -f "$STATE/calls.log" ]; then
-        pass "--repeat-hours '$bad' touched no schtasks"
-    else
-        fail "--repeat-hours '$bad' reached schtasks" "$(cat "$STATE/calls.log")"
-    fi
-done
+# Reject runs BEFORE the platform gate and never reaches schtasks, so it is a
+# cheap case -- one representative input for the single regex branch.
+reset_state
+rc=0; out=$(run_sc arm --repeat-hours 24 2>&1) || rc=$?
+assert_rc "--repeat-hours '24' rejected -> rc 1" 1 "$rc"
+if [ ! -f "$STATE/calls.log" ]; then
+    pass "--repeat-hours '24' touched no schtasks"
+else
+    fail "--repeat-hours '24' reached schtasks" "$(cat "$STATE/calls.log")"
+fi
 reset_state
 rc=0; out=$(run_sc arm --repeat-hours 2>&1) || rc=$?
 assert_rc "--repeat-hours with no value -> rc 1 (not a raw bash shift error)" 1 "$rc"
@@ -508,6 +528,11 @@ rm -f "$STATE/verify-epoch"
 
 echo "TEST: post-arm verify NEXTRUN-NONE answer rolls back, rc 4 (T3)"
 reset_state
+# Sentinel pre-existing .bat folded in from former FIX 1b (HIMMEL-1324): same
+# NEXTRUN-NONE rollback scenario, so the sentinel-replacement check is added
+# to this arm call instead of re-arming from scratch a second time.
+mkdir -p "$BAT_DIR"
+printf 'SENTINEL-PRE-EXISTING-BAT\r\n' > "$BAT_DIR/codex-sweep.bat"
 touch "$STATE/verify-nextrun-none"
 rc=0; out=$(run_sc arm 2>&1) || rc=$?
 assert_rc "post-arm verify NEXTRUN-NONE -> rc 4" 4 "$rc"
@@ -519,6 +544,14 @@ fi
 deleted=$(cat "$STATE/deleted.log" 2>/dev/null || echo MISSING)
 assert_contains "rollback recorded a /delete call" "HIMMEL-CodexOrphanSweep" "$deleted"
 assert_contains "rollback NOTE names the --force re-arm recovery command (FIX B)" "re-arm with: bash scripts/cleanup/codex-sweep-cadence.sh arm" "$out"
+bat_after=$(cat "$BAT_DIR/codex-sweep.bat" 2>/dev/null || echo MISSING)
+assert_not_contains "pre-existing sentinel .bat is GONE after NEXTRUN-NONE rollback (publish happens before /create now, FIX 1b)" "SENTINEL-PRE-EXISTING-BAT" "$bat_after"
+assert_contains "bat holds the COMPLETE new runner content after NEXTRUN-NONE rollback (inert without the deleted task, FIX 1b)" "sweep-codex-orphans.ps1" "$bat_after"
+if ls "$BAT_DIR"/.codex-sweep.bat.* >/dev/null 2>&1; then
+    fail "temp runner file left behind after NEXTRUN-NONE rollback" "$(ls "$BAT_DIR"/.codex-sweep.bat.* 2>/dev/null)"
+else
+    pass "no temp runner file left behind after NEXTRUN-NONE rollback (FIX 1b)"
+fi
 rm -f "$STATE/verify-nextrun-none"
 
 # Test T3b: probe failure fails OPEN -- arm stands, rc 0, WARN present -------
@@ -559,48 +592,11 @@ else
 fi
 rm -f "$STATE/fail-create"
 
-echo "TEST: atomic runner publication -- NEXTRUN-NONE rollback deletes the task but still leaves the published COMPLETE new .bat (not the old sentinel), no temp left (FIX 1b, round-3 reorder)"
-reset_state
-mkdir -p "$BAT_DIR"
-printf 'SENTINEL-PRE-EXISTING-BAT\r\n' > "$BAT_DIR/codex-sweep.bat"
-touch "$STATE/verify-nextrun-none"
-rc=0; out=$(run_sc arm 2>&1) || rc=$?
-assert_rc "arm with NEXTRUN-NONE rollback -> rc 4" 4 "$rc"
-bat_after=$(cat "$BAT_DIR/codex-sweep.bat" 2>/dev/null || echo MISSING)
-assert_not_contains "pre-existing sentinel .bat is GONE after NEXTRUN-NONE rollback (publish happens before /create now)" "SENTINEL-PRE-EXISTING-BAT" "$bat_after"
-assert_contains "bat holds the COMPLETE new runner content after NEXTRUN-NONE rollback (inert without the deleted task)" "sweep-codex-orphans.ps1" "$bat_after"
-if ls "$BAT_DIR"/.codex-sweep.bat.* >/dev/null 2>&1; then
-    fail "temp runner file left behind after NEXTRUN-NONE rollback" "$(ls "$BAT_DIR"/.codex-sweep.bat.* 2>/dev/null)"
-else
-    pass "no temp runner file left behind after NEXTRUN-NONE rollback"
-fi
-rm -f "$STATE/verify-nextrun-none"
-
-echo "TEST: atomic runner publication -- success path publishes new .bat content, no temp left (FIX 1c)"
-reset_state
-rc=0; out=$(run_sc arm 2>&1) || rc=$?
-assert_rc "arm success -> rc 0" 0 "$rc"
-bat=$(cat "$BAT_DIR/codex-sweep.bat" 2>/dev/null || echo MISSING)
-assert_contains "published .bat holds new runner content" "sweep-codex-orphans.ps1" "$bat"
-if ls "$BAT_DIR"/.codex-sweep.bat.* >/dev/null 2>&1; then
-    fail "temp runner file left behind after success" "$(ls "$BAT_DIR"/.codex-sweep.bat.* 2>/dev/null)"
-else
-    pass "no temp runner file left behind after success"
-fi
-
-echo "TEST: immediate-fire regression -- the runner is fully published and readable at its FINAL path AT /create TIME, before the task can possibly exist (FIX 1d, round-3 CR fix, HIMMEL-892)"
-reset_state
-rc=0; out=$(run_sc arm 2>&1) || rc=$?
-assert_rc "arm success -> rc 0" 0 "$rc"
-if [ -f "$STATE/create-time-runner-probe.bat" ]; then
-    pass "runner was readable at its final path at /create time (publish-before-create ordering holds)"
-else
-    fail "runner NOT readable at its final path at /create time -- publish-before-create ordering broken"
-fi
-probe=$(cat "$STATE/create-time-runner-probe.bat" 2>/dev/null || echo MISSING)
-assert_contains "create-time probe carries the full new runner content (sweep payload)" "sweep-codex-orphans.ps1" "$probe"
-assert_contains "create-time probe carries the full new runner content (reap payload)" "reap-mcp-fleet.ps1" "$probe"
-assert_contains "create-time probe carries the format-version stamp (proves COMPLETE content, not partial)" "himmel-cadence-runner-format: 7" "$probe"
+# FIX 1b (NEXTRUN-NONE rollback sentinel-replacement check) folded into T3
+# above -- same rollback scenario, same arm call (HIMMEL-1324).
+# FIX 1c (success-path publish) and FIX 1d (immediate-fire create-time probe)
+# used to re-arm from a clean state here to check exactly what T1's own
+# successful default arm already produces -- folded into T1 above (HIMMEL-1324).
 
 # Test T6: --dry-run touches nothing ------------------------------------------
 
@@ -644,8 +640,6 @@ assert_contains "LOG assignment is the real dir, fully quoted (% doubled, & ^ ve
     "$EVIL_LOG_EXPECTED" "$evil_bat"
 assert_not_contains "no caret-escaped ampersand" '^&' "$evil_bat"
 assert_not_contains "no doubled caret" '^^' "$evil_bat"
-env SWEEP_SCHTASKS="$FAKE_SCHTASKS" SWEEP_BAT_DIR="$EVIL_DIR" SWEEP_PWSH="$FAKE_PWSH" \
-    SWEEP_HIMMEL_ROOT="$FIXTURE_ROOT" HOME="$HOME" "$REAL_BASH" "$SCRIPT" arm >/dev/null 2>&1 || true
 
 # Test T7b: no pwsh/powershell resolvable -> rc 2 -----------------------------
 
@@ -722,11 +716,19 @@ echo "TEST: second arm without --force -> rc 3, no new /create recorded (T10)"
 reset_state
 run_sc arm >/dev/null
 creates_before=$(grep -c '^/create ' "$STATE/calls.log" 2>/dev/null || true)
+deletes_before=$(grep -c '^/delete ' "$STATE/calls.log" 2>/dev/null || true)
 rc=0; out=$(run_sc arm 2>&1) || rc=$?
 assert_rc "second arm without --force -> rc 3" 3 "$rc"
 assert_contains "dedup message names the task" "HIMMEL-CodexOrphanSweep" "$out"
 creates_after=$(grep -c '^/create ' "$STATE/calls.log" 2>/dev/null || true)
 assert_rc "no new /create call recorded" "$creates_before" "$creates_after"
+deletes_after=$(grep -c '^/delete ' "$STATE/calls.log" 2>/dev/null || true)
+# T11b (HIMMEL-1324 CR round): this /delete check was T11b's ONE unique
+# assertion -- a regression where the dedup path deletes the armed task
+# before returning rc=3 would pass every other T10 check while silently
+# disarming the cadence. Restored here (same arm call, no extra spawn)
+# instead of re-adding the full duplicate re-arm sequence.
+assert_rc "dedup block makes no /delete call" "$deletes_before" "$deletes_after"
 
 echo "TEST: arm --force replaces create-only, NO /delete (transactional --force, FIX B / codex-adv-2, T11)"
 : > "$STATE/calls.log"
@@ -743,40 +745,18 @@ else
     fail "arm --force /create call missing /f" "$(cat "$STATE/calls.log")"
 fi
 
-echo "TEST: dedup unchanged -- plain arm still rc 3 when already armed; arm --force proceeds create-only (T11b)"
-reset_state
-run_sc arm >/dev/null
-: > "$STATE/calls.log"
-rc=0; out=$(run_sc arm 2>&1) || rc=$?
-assert_rc "plain arm against an already-armed task -> rc 3 (dedup unchanged)" 3 "$rc"
-calls_after_plain=$(cat "$STATE/calls.log" 2>/dev/null || echo "")
-assert_not_contains "plain arm dedup block makes no /create call" "/create " "$calls_after_plain"
-assert_not_contains "plain arm dedup block makes no /delete call" "/delete " "$calls_after_plain"
-: > "$STATE/calls.log"
-rc=0; out=$(run_sc arm --force 2>&1) || rc=$?
-assert_rc "arm --force against an already-armed task -> rc 0 (proceeds)" 0 "$rc"
-calls_after_force=$(cat "$STATE/calls.log" 2>/dev/null || echo "")
-assert_not_contains "arm --force still makes no /delete call" "/delete " "$calls_after_force"
-assert_contains "arm --force makes exactly the /create call" "/create /tn HIMMEL-CodexOrphanSweep /xml" "$calls_after_force"
+# T11b (HIMMEL-1324): dropped. It re-ran the identical dedup-reject-then-force-
+# succeed sequence from a second fresh arm, asserting the same two outcomes
+# T10 (dedup rejects, no /create) and T11 (--force proceeds, no /delete, one
+# /create) already assert on the SAME code paths -- three full arm/query/force
+# invocations for zero net-new coverage.
 
-# Test T12: disarm removes task + idempotency ----------------------------------
-
-echo "TEST: disarm removes task; disarm again -> rc 0 idempotent (T12)"
-reset_state
-run_sc arm >/dev/null
-rc=0; out=$(run_sc disarm 2>&1) || rc=$?
-assert_rc "disarm -> rc 0" 0 "$rc"
-assert_contains "disarm reports removal" "disarmed" "$out"
-if [ ! -f "$STATE/tasks/HIMMEL-CodexOrphanSweep" ]; then
-    pass "disarm deleted the task"
-else
-    fail "disarm left the task behind"
-fi
-rc=0; out=$(run_sc disarm 2>&1) || rc=$?
-assert_rc "second disarm -> rc 0 idempotent" 0 "$rc"
-assert_contains "second disarm -> no-op message" "nothing armed" "$out"
-
-# Test T12b: disarm --dry-run while armed touches nothing --------------------
+# Test T12 / T12b: disarm --dry-run, then real disarm + idempotency -----------
+#
+# One arm shared across both (HIMMEL-1324): T12b's dry-run-while-armed
+# assertions don't mutate anything (that's the point of the test), so they run
+# FIRST against the still-armed state, then T12's real disarm + idempotent
+# second disarm consume the same arm without re-arming from scratch.
 
 echo "TEST: disarm --dry-run while armed -> rc 0, no /delete, .bat still present (T12b)"
 reset_state
@@ -796,6 +776,19 @@ if [ -f "$STATE/tasks/HIMMEL-CodexOrphanSweep" ]; then
 else
     fail "disarm --dry-run removed the task"
 fi
+
+echo "TEST: disarm removes task; disarm again -> rc 0 idempotent (T12)"
+rc=0; out=$(run_sc disarm 2>&1) || rc=$?
+assert_rc "disarm -> rc 0" 0 "$rc"
+assert_contains "disarm reports removal" "disarmed" "$out"
+if [ ! -f "$STATE/tasks/HIMMEL-CodexOrphanSweep" ]; then
+    pass "disarm deleted the task"
+else
+    fail "disarm left the task behind"
+fi
+rc=0; out=$(run_sc disarm 2>&1) || rc=$?
+assert_rc "second disarm -> rc 0 idempotent" 0 "$rc"
+assert_contains "second disarm -> no-op message" "nothing armed" "$out"
 
 # Test T13: not-found stderr classification fails CLOSED on unrelated error --
 

--- a/scripts/himmelctl/bin.js
+++ b/scripts/himmelctl/bin.js
@@ -1518,8 +1518,16 @@ async function cmdStatus(args) {
 
   const state = stateLib.load();
   const existedBefore = Boolean(state.targets[targetKey]);
-  stateLib.ensureTarget(state, manifest, cachedAnswers);
-  if (!existedBefore) stateLib.save(state);
+  const itemCountBefore = existedBefore ? Object.keys(state.targets[targetKey].items).length : 0;
+  const target = stateLib.ensureTarget(state, manifest, cachedAnswers);
+  // HIMMEL-1017: persist not only a brand-new derive but also a migration —
+  // ensureTarget() now backfills manifest items an EXISTING target was
+  // missing (a manifest update since the target was last derived). Without
+  // this, the migrated items would live only in-memory for this one run and
+  // never make it into state.json, so the very next `status` invocation
+  // would silently re-migrate them (harmless, but the on-disk artifact would
+  // never catch up).
+  if (!existedBefore || Object.keys(target.items).length !== itemCountBefore) stateLib.save(state);
 
   const report = statusReportLib.statusReport({
     manifest, scope, targetPath: baseTargetPath, answers: cachedAnswers, itemIds: args.items,
@@ -1606,8 +1614,13 @@ async function cmdEnsure(args) {
   // reconciled bookkeeping immediately is correct and intentionally kept.
   const state = stateLib.load();
   const existedBefore = Boolean(state.targets[targetKey]);
+  const itemCountBefore = existedBefore ? Object.keys(state.targets[targetKey].items).length : 0;
   let target = stateLib.ensureTarget(state, manifest, cachedAnswers);
-  let stateChanged = !existedBefore;
+  // HIMMEL-1017: ensureTarget() can now also MIGRATE an existing target (add
+  // manifest items it was missing) — count that as a state change too, same
+  // as a brand-new derive, so the migrated items get persisted rather than
+  // silently staying in-memory-only for this one run.
+  let stateChanged = !existedBefore || Object.keys(target.items).length !== itemCountBefore;
 
   // Step 0: reconcile FIRST whenever --profile is explicitly supplied —
   // CR fix: NOT only when it differs from the target's stored profile. A

--- a/scripts/himmelctl/lib/probes.js
+++ b/scripts/himmelctl/lib/probes.js
@@ -250,19 +250,50 @@ function probeQmdIndex(item, ctx) {
 
 // ── mcp-registered ───────────────────────────────────────────────────────
 
+// CR fix (HIMMEL-1017 CR round): SCOPE-AWARE file resolution. Claude Code's
+// own `claude mcp add -s <scope>` writes to a DIFFERENT config file per
+// scope (graphify-bin.sh's graphify_register_mcp() comment + docs/setup/
+// new-machine.md: project scope -> a COMMITTED <target>/.mcp.json;
+// user/local scope -> the personal ~/.claude.json) — this probe used to read
+// ~/.claude.json UNCONDITIONALLY, so a correctly-registered project-scope
+// server (graphify-mcp AND tokensave-mcp both carry scopes:["project",
+// "user"]) always read absent. Both files share the same
+// `{"mcpServers": {...}}` shape, so the parse/lookup logic below is scope-
+// agnostic; only the path differs.
+function mcpConfigPath(ctx) {
+  if (ctx.scope === 'project') return path.join(ctx.targetPath, '.mcp.json');
+  return path.join((ctx.env && ctx.env.HOME) || os.homedir(), '.claude.json');
+}
+
 function probeMcpRegistered(item, ctx) {
-  const filePath = path.join((ctx.env && ctx.env.HOME) || os.homedir(), '.claude.json');
+  const filePath = mcpConfigPath(ctx);
   let data;
   try {
     data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch (_e) {
-    return { actual: 'absent', detail: `cannot read/parse ${filePath}` };
+  } catch (e) {
+    // configError: true (CR fix, HIMMEL-1017 round) marks a genuinely BROKEN
+    // config — unreadable for a reason other than "it doesn't exist yet", or
+    // present-but-unparseable — as opposed to a clean, expected absence. A
+    // MISSING file (ENOENT) is the ordinary, common case for project-scope
+    // .mcp.json specifically (a committed file that only exists once
+    // SOMETHING has been registered at project scope — most projects never
+    // have one) — that is exactly "never opted in", not an error, so it does
+    // NOT get configError. Any other read failure (permission denied) or a
+    // present-but-unparseable file DOES: a consumer that wants to treat
+    // "genuinely never opted in" differently from "the config is broken"
+    // (status-report.js's graphify-mcp opt-in downgrade) needs this signal;
+    // every other existing caller ignores the extra field (additive, not a
+    // breaking change to the {actual, detail} contract).
+    if (e && e.code === 'ENOENT') {
+      return { actual: 'absent', detail: `${filePath} does not exist` };
+    }
+    return { actual: 'absent', detail: `cannot read/parse ${filePath}`, configError: true };
   }
   // A valid-JSON but non-object root (null, array, string) has no mcpServers —
-  // guard before dereferencing so a malformed ~/.claude.json reads absent
-  // rather than throwing out of the whole status sweep.
+  // guard before dereferencing so a malformed config reads absent rather
+  // than throwing out of the whole status sweep.
   if (data === null || typeof data !== 'object' || Array.isArray(data)) {
-    return { actual: 'absent', detail: `unexpected JSON shape in ${filePath}` };
+    return { actual: 'absent', detail: `unexpected JSON shape in ${filePath}`, configError: true };
   }
   const server = item.probe.server;
   if (data.mcpServers && Object.prototype.hasOwnProperty.call(data.mcpServers, server)) {

--- a/scripts/himmelctl/lib/state.js
+++ b/scripts/himmelctl/lib/state.js
@@ -89,14 +89,66 @@ function deriveTarget(manifest, cachedAnswers) {
   return { profile, scope, items, lastEnsured: null };
 }
 
+// Backfill any manifest item IDs an existing target entry doesn't yet carry
+// (HIMMEL-1017): ensureTarget's derive-if-missing path only ever runs ONCE,
+// on a target's first-ever encounter — a manifest item added to
+// scripts/install/manifest.json AFTER that point never gets an `items` entry
+// on an already-existing target, so it reads `entry === undefined` in
+// statusReport (desired:false, "not enabled for this target") forever, on
+// every future run, until the target is deleted and re-derived from scratch.
+// This is the missing state-schema migration: for each manifest item the
+// target's `items` map doesn't yet carry, derive its `enabled` flag with the
+// SAME pure membership rule deriveTarget() uses (the handover-wiring
+// exception included). Every item already present in `target.items` is left
+// completely untouched — enabled flags, overrides, all of it. Mutates
+// `target.items` in place; returns true if anything was added, so a caller
+// can decide whether the mutation needs persisting.
+//
+// CR fix (HIMMEL-1017 CR round): scope membership is checked against
+// cachedAnswers.scope — the AUTHORITATIVE invocation scope (the exact value
+// ensureTarget() used to compute the target's own key) — never
+// `target.scope`. `target.scope` is a persisted, independently-editable
+// copy of that same fact (same class of drift risk as `lastEnsured`/
+// `overrides` above, or `target.scope` vs the invocation scope in
+// cmdEnsure's own Step 0 comment on reconcileTarget): a state.json entry
+// keyed under a project path but whose persisted `.scope` field somehow read
+// "user" (hand-edit, schema drift) used to backfill every project-only new
+// item disabled — and, once backfilled, `ensureTarget`'s own
+// `if (target.items[item.id]) continue` guard means that wrong value is
+// never revisited on a later run. `target.profile`, in contrast, genuinely
+// CAN diverge intentionally from a fresh derive (an explicit `ensure
+// --profile` reconcile) — that one is still read from the persisted target,
+// matching this function's "existing item state is never second-guessed"
+// contract.
+function migrateTargetItems(target, manifest, cachedAnswers) {
+  const scope = cachedAnswers.scope;
+  let changed = false;
+  for (const item of manifest.items) {
+    if (target.items[item.id]) continue;
+    let enabled = item.profiles.includes(target.profile) && item.scopes.includes(scope);
+    if (item.id === 'handover-wiring') {
+      enabled = Boolean(cachedAnswers.handover) && cachedAnswers.handover.mode !== 'none';
+    }
+    target.items[item.id] = { enabled, overrides: {} };
+    changed = true;
+  }
+  return changed;
+}
+
 // Add the derived entry for this target if missing; return the (possibly
-// pre-existing) entry either way. Never overwrites an existing entry — a
-// target that already has state is left alone (re-deriving/repairing belongs
-// to a later reconcile path, not this first-run seam).
+// pre-existing) entry either way. An existing entry is never re-derived —
+// its profile/scope and every already-tracked item's enabled/overrides are
+// left alone (re-deriving/repairing those belongs to reconcileTarget(), not
+// this first-run seam) — but it IS migrated: any manifest item ID missing
+// from its `items` map gets backfilled via migrateTargetItems() above, so an
+// existing target never silently loses visibility into a newly-added
+// manifest item.
 function ensureTarget(state, manifest, cachedAnswers) {
   const key = targetKeyForScope(cachedAnswers.scope);
   if (!state.targets[key]) {
     state.targets[key] = deriveTarget(manifest, cachedAnswers);
+  } else {
+    migrateTargetItems(state.targets[key], manifest, cachedAnswers);
   }
   return state.targets[key];
 }
@@ -154,4 +206,4 @@ function reconcileTarget(state, manifest, cachedAnswers, { profile, scope }) {
   return entry;
 }
 
-module.exports = { load, save, deriveTarget, ensureTarget, reconcileTarget };
+module.exports = { load, save, deriveTarget, ensureTarget, reconcileTarget, migrateTargetItems };

--- a/scripts/himmelctl/lib/status-report.js
+++ b/scripts/himmelctl/lib/status-report.js
@@ -124,6 +124,36 @@ function statusReport({ manifest, scope, targetPath, answers, itemIds, state: pa
       // never lays this file) — that is the intended "does THIS project
       // carry the gate" semantic, not a broken install; say so plainly.
       if (item.id === 'pre-commit-hooks') detail = 'no .pre-commit-config.yaml in this project';
+      // CR follow-up (HIMMEL-1017, HIMMEL-1012 review): graphify-mcp carries
+      // profiles:["luna","all"] like any other luna-profile item, so every
+      // luna/all target reads it desired:true — but registering the
+      // graphify MCP server is a genuinely OPT-IN, manual step (adopt.sh's
+      // --with-graphify flag / `claude mcp add graphify`; adopt.sh's own
+      // wire_graphify_core() comment: "unlike qmd, graphify is NOT wired by
+      // default"), and unlike qmd-binary/qmd-index it carries no `install`
+      // descriptor of its own for `ensure` to converge — it is HINT-only
+      // (see cmdEnsure's towardEnabled/hints split). Demanding it
+      // unconditionally therefore produced a false red for every luna/all
+      // operator who simply never opted in. Downgrade to n/a (informational)
+      // instead of red: it is still probed every run (desired stays true),
+      // so an operator who DOES register the MCP server still sees it flip
+      // green — this only silences the alarm for the "never opted in" case.
+      //
+      // CR fix (HIMMEL-1017 CR round): only for a CLEAN absence —
+      // probeMcpRegistered's 'absent' also covers an unreadable/unparseable
+      // or malformed-shape config (probe.configError:true), which is NOT
+      // "never opted in", it's a broken config that may well have LOST a
+      // real registration (e.g. ~/.claude.json got corrupted after the
+      // operator genuinely ran --with-graphify). That case must stay on the
+      // standard red path with probe.detail intact, not get silently
+      // swallowed into the same friendly opt-in message. And even for the
+      // clean-absence case, the underlying probe diagnostic is APPENDED
+      // rather than discarded, so the n/a row still names exactly which
+      // file/server was checked.
+      if (item.id === 'graphify-mcp' && !probe.configError) {
+        severity = 'n/a';
+        detail = `${probe.detail} — opt-in (adopt.sh --with-graphify / claude mcp add graphify)`;
+      }
     }
     results.push({ id: item.id, kind: item.kind, desired: true, actual: probe.actual, severity, detail });
   }

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -22,8 +22,13 @@
 #   cmd:has_qmd    qmd-binary, via a stubbed `qmd` on PATH.
 #   qmd-index      present (all 4 collections) / degraded (2 of 4) / absent
 #                  (no qmd on PATH).
-#   mcp-registered tokensave-mcp present / server missing / file missing,
-#                  resolving .claude.json from ctx.env.HOME.
+#   mcp-registered tokensave-mcp present / server missing / file missing
+#                  (ENOENT, clean) / malformed JSON / unexpected shape
+#                  (the latter two carry configError:true), resolving
+#                  .claude.json from ctx.env.HOME; plus graphify-mcp
+#                  scope-awareness — project scope resolves <targetPath>/
+#                  .mcp.json, user scope resolves ~/.claude.json, no
+#                  cross-scope bleed (HIMMEL-1017 CR round).
 #   handover-dir   handover-wiring — HANDOVER_DIR set (ctx.env pass-through,
 #                  not process.env mutation) / unset with a non-repo cwd.
 #   dep            single-cmd (rtk) and the win32/posix platform union
@@ -394,7 +399,7 @@ console.log(JSON.stringify(runProbe(item, ctx)));
 echo "$outQIa" | jq -e '.actual == "absent"' >/dev/null || fail "qmd-index absent (no qmd on PATH): (got: $outQIa)"
 echo "ok: qmd-index present/degraded/absent"
 
-# ── mcp-registered: present / server missing / file missing ───────────────
+# ── mcp-registered: present / server missing / file missing / malformed ────
 mcp_present_home="$work/mcp-present-home"; mkdir -p "$mcp_present_home"
 printf '{"mcpServers":{"tokensave":{"command":"tokensave-mcp"}}}' > "$mcp_present_home/.claude.json"
 mcp_server_missing_home="$work/mcp-server-missing-home"; mkdir -p "$mcp_server_missing_home"
@@ -402,6 +407,12 @@ printf '{"mcpServers":{"graphify":{"command":"graphify-mcp"}}}' > "$mcp_server_m
 mcp_file_missing_home="$work/mcp-file-missing-home"; mkdir -p "$mcp_file_missing_home"
 mcp_null_root_home="$work/mcp-null-root-home"; mkdir -p "$mcp_null_root_home"
 printf 'null' > "$mcp_null_root_home/.claude.json"
+# CR fix (HIMMEL-1017 CR round): a present-but-UNPARSEABLE config is a
+# genuinely different case from a MISSING one — both used to read identically
+# (actual:absent, generic "cannot read/parse" detail); configError now
+# distinguishes them (see probes.js's probeMcpRegistered).
+mcp_malformed_json_home="$work/mcp-malformed-json-home"; mkdir -p "$mcp_malformed_json_home"
+printf '{not valid json' > "$mcp_malformed_json_home/.claude.json"
 
 outMCP=$("$node_bin" -e "
 const { runProbe } = require('$probes_lib_w');
@@ -416,15 +427,52 @@ console.log(JSON.stringify([
   probeHome('$(winpath "$mcp_server_missing_home")'),
   probeHome('$(winpath "$mcp_file_missing_home")'),
   probeHome('$(winpath "$mcp_null_root_home")'),
+  probeHome('$(winpath "$mcp_malformed_json_home")'),
 ]));
 ")
-echo "$outMCP" | jq -e '.[0].actual == "present" and .[1].actual == "absent" and .[2].actual == "absent" and .[3].actual == "absent"' >/dev/null \
-  || fail "mcp-registered present/server-missing/file-missing/null-root: (got: $outMCP)"
-echo "$outMCP" | jq -e '.[2].detail | contains("cannot read/parse")' >/dev/null \
-  || fail "mcp-registered file-missing detail should report cannot read/parse (got: $outMCP)"
+echo "$outMCP" | jq -e '.[0].actual == "present" and .[1].actual == "absent" and .[2].actual == "absent" and .[3].actual == "absent" and .[4].actual == "absent"' >/dev/null \
+  || fail "mcp-registered present/server-missing/file-missing/null-root/malformed: (got: $outMCP)"
+echo "$outMCP" | jq -e '.[2].detail | contains("does not exist")' >/dev/null \
+  || fail "mcp-registered file-missing (ENOENT) detail should report 'does not exist' (got: $outMCP)"
 echo "$outMCP" | jq -e '.[3].detail | contains("unexpected JSON shape")' >/dev/null \
   || fail "mcp-registered null-root detail should report unexpected JSON shape (got: $outMCP)"
-echo "ok: mcp-registered (tokensave-mcp) present/server-missing/file-missing/null-root via ctx.env.HOME"
+echo "$outMCP" | jq -e '.[4].detail | contains("cannot read/parse")' >/dev/null \
+  || fail "mcp-registered malformed-JSON detail should report cannot read/parse (got: $outMCP)"
+# CR fix (HIMMEL-1017 CR round): configError distinguishes a genuinely BROKEN
+# config (malformed JSON, unexpected shape) from a clean absence (present-
+# but-server-missing, OR the file simply doesn't exist yet — ENOENT is the
+# ORDINARY case for project-scope .mcp.json, never an error by itself).
+echo "$outMCP" | jq -e '(.[0].configError // false) == false and (.[1].configError // false) == false and (.[2].configError // false) == false' >/dev/null \
+  || fail "mcp-registered present/server-missing/file-missing (ENOENT) should carry NO configError (got: $outMCP)"
+echo "$outMCP" | jq -e '.[3].configError == true and .[4].configError == true' >/dev/null \
+  || fail "mcp-registered null-root/malformed-JSON should carry configError:true (got: $outMCP)"
+echo "ok: mcp-registered (tokensave-mcp) present/server-missing/file-missing/null-root/malformed via ctx.env.HOME, configError distinguishes broken config from clean absence"
+
+# ── mcp-registered: scope-aware file resolution (CR fix, HIMMEL-1017 round) ─
+# project scope reads <targetPath>/.mcp.json, NOT ~/.claude.json — proven in
+# both directions: a project-scope registration in .mcp.json reads present
+# even with a DIFFERENT server registered in ~/.claude.json (never bleeds
+# across scopes), and a user-scope-only registration is correctly invisible
+# to a project-scope probe.
+mcp_project_target="$work/mcp-project-target"; mkdir -p "$mcp_project_target"
+printf '{"mcpServers":{"graphify":{"command":"graphify-mcp"}}}' > "$mcp_project_target/.mcp.json"
+mcp_scope_home="$work/mcp-scope-home"; mkdir -p "$mcp_scope_home"
+printf '{"mcpServers":{"tokensave":{"command":"tokensave-mcp"}}}' > "$mcp_scope_home/.claude.json"
+
+outScope=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const graphifyItem = manifest.items.find((i) => i.id === 'graphify-mcp');
+const env = Object.assign({}, process.env, { HOME: '$(winpath "$mcp_scope_home")' });
+const projectHit = runProbe(graphifyItem, { repoRoot: '$repo_root_w', targetPath: '$(winpath "$mcp_project_target")', scope: 'project', env });
+const userMiss = runProbe(graphifyItem, { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user', env });
+console.log(JSON.stringify({ projectHit, userMiss }));
+")
+echo "$outScope" | jq -e '.projectHit.actual == "present"' >/dev/null \
+  || fail "mcp-registered project-scope should read <targetPath>/.mcp.json, not ~/.claude.json (got: $outScope)"
+echo "$outScope" | jq -e '.userMiss.actual == "absent"' >/dev/null \
+  || fail "mcp-registered user-scope probe for graphify should NOT see the project-scope .mcp.json registration (got: $outScope)"
+echo "ok: mcp-registered is scope-aware — project scope resolves .mcp.json, user scope resolves ~/.claude.json, never cross-bleeding"
 
 # ── handover-dir (handover-wiring) ──────────────────────────────────────────
 hd_present_dir="$work/hd-present-handoverdir"; mkdir -p "$hd_present_dir"

--- a/scripts/himmelctl/test/test-wizard-state.sh
+++ b/scripts/himmelctl/test/test-wizard-state.sh
@@ -142,4 +142,135 @@ cmp -s "$work/state-save1.json" "$statePathC" \
   || fail "caseC: state.json should round-trip byte-identically across two saves"
 echo "ok: caseC write->read round-trips byte-stably across two saves"
 
+# ── Case D (HIMMEL-1017): ensureTarget() migrates a PRE-CHANGE existing
+# target — it backfills manifest items the target's persisted `items` map
+# doesn't yet carry (simulating a manifest that gained items after this
+# target was first derived, e.g. an install predating this repo's most
+# recent `himmel-update`), leaving every already-tracked item's enabled flag
+# and overrides byte-for-byte untouched. ─────────────────────────────────────
+caseD_dir="$work/caseD-target"; mkdir -p "$caseD_dir"
+homeD="$work/homeD"; mkdir -p "$homeD"
+cacheD="$work/cacheD"
+
+outD=$(cd "$caseD_dir" && HOME="$homeD" HIMMELCTL_CACHE_DIR="$(winpath "$cacheD")" "$node_bin" -e "
+const state = require('$state_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const answers = {
+  role: 'adopter', tier: 'standard', scope: 'project',
+  vault: { mode: 'default-template', path: '~/vault' },
+  handover: { mode: 'external', path: '~/h' },
+  pluginSet: 'lean', lanes: [], alwaysOn: false,
+};
+
+// Simulate a PRE-CHANGE state.json: derive against an OLDER manifest missing
+// two real items (one that should end up enabled:true under this target's
+// profile/scope — 'qmd-binary' — and one that should end up enabled:false —
+// 'pre-commit-hooks', scope:['project'] only under profiles core/all, and
+// this target's profile is 'all' from vault.mode default-template — wait,
+// pre-commit-hooks IS profiles:['core','all'] so it WOULD be true; pick a
+// genuinely-false one instead: a user-scope-only item under a project-scope
+// target reads false regardless of profile).
+const oldManifest = { schemaVersion: manifest.schemaVersion, harness: manifest.harness,
+  items: manifest.items.filter((i) => i.id !== 'qmd-binary' && i.id !== 'graphify') };
+if (oldManifest.items.length === manifest.items.length) throw new Error('fixture drift: expected the real manifest to still carry qmd-binary + graphify');
+
+let s = state.load();
+const preChange = state.ensureTarget(s, oldManifest, answers);
+if (preChange.items['qmd-binary']) throw new Error('fixture drift: qmd-binary should be ABSENT from the pre-change derive');
+if (preChange.items['graphify']) throw new Error('fixture drift: graphify should be ABSENT from the pre-change derive');
+// Hand-set an override + a non-default enabled flag on an item that DOES
+// survive the migration untouched — proves migration never re-derives
+// already-tracked items.
+preChange.items['pre-commit-hooks'].overrides = { note: 'pre-change-override' };
+preChange.items['pre-commit-hooks'].enabled = false; // deliberately wrong vs. a fresh derive, to prove it survives verbatim
+state.save(s);
+
+const before = JSON.parse(JSON.stringify(s));
+
+// Now ensureTarget against the CURRENT (full) manifest — the 'upgrade'.
+const migrated = state.ensureTarget(s, manifest, answers);
+state.save(s);
+
+console.log(JSON.stringify({ before, after: s, migrated }));
+")
+
+echo "$outD" | jq -e '.migrated.items["qmd-binary"].enabled == true' >/dev/null \
+  || fail "caseD: migrated qmd-binary should be backfilled enabled:true under profile 'all' (got: $outD)"
+echo "ok: caseD — qmd-binary backfilled enabled:true"
+
+# graphify is scope:["user"] only; this target is scope 'project', so its
+# backfilled membership check (scopes.includes('project')) reads false —
+# asserted explicitly so the migration's per-item rule (not just presence) is
+# exercised in both directions.
+echo "$outD" | jq -e '.migrated.items["graphify"].enabled == false' >/dev/null \
+  || fail "caseD: migrated graphify (scope:user-only) should backfill enabled:false under a project-scope target (got: $outD)"
+echo "ok: caseD — ensureTarget backfills missing manifest items (qmd-binary:true, graphify:false) into an existing target"
+
+echo "$outD" | jq -e '.migrated.items["pre-commit-hooks"].enabled == false and .migrated.items["pre-commit-hooks"].overrides == {"note":"pre-change-override"}' >/dev/null \
+  || fail "caseD: an already-tracked item (pre-commit-hooks) must survive migration byte-for-byte unchanged (got: $outD)"
+echo "ok: caseD — an already-tracked item's enabled flag + overrides survive migration untouched"
+
+migratedCount=$(echo "$outD" | jq '.migrated.items | keys | length')
+manifestCount=$(jq '.items | length' "$manifest_path")
+[ "$migratedCount" -eq "$manifestCount" ] || fail "caseD: migrated target should carry ALL $manifestCount manifest item ids (got $migratedCount)"
+echo "ok: caseD — migrated target carries every manifest item id"
+
+echo "$outD" | jq -e '.after.targets | to_entries[0].value.items["qmd-binary"].enabled == true' >/dev/null \
+  || fail "caseD: the migration should round-trip through save() (got: $outD)"
+echo "ok: caseD — migration round-trips through save()/load()"
+
+# ── Case E (HIMMEL-1017 CR round): migration membership must key off the
+# AUTHORITATIVE invocation scope (cachedAnswers.scope — the same value that
+# picked which target entry we're even operating on), NEVER the target's own
+# PERSISTED `.scope` field, which can independently drift (a hand-edit, a
+# pre-schema-fix state file — the same class of defect `lastEnsured`/
+# `overrides` already guard against). Repro: a project-scope target whose
+# persisted `.scope` somehow reads "user" gains a project-ONLY item after an
+# upgrade — the item must still backfill enabled:true (project scope really
+# is desired here), not enabled:false (what a naive read of the stale
+# persisted scope would produce, forever, since the item-exists guard skips
+# it on every later run once wrongly backfilled). ─────────────────────────
+caseE_dir="$work/caseE-target"; mkdir -p "$caseE_dir"
+homeE="$work/homeE"; mkdir -p "$homeE"
+cacheE="$work/cacheE"
+
+outE=$(cd "$caseE_dir" && HOME="$homeE" HIMMELCTL_CACHE_DIR="$(winpath "$cacheE")" "$node_bin" -e "
+const state = require('$state_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const answers = {
+  role: 'adopter', tier: 'standard', scope: 'project',
+  vault: { mode: 'none', path: '' },
+  handover: { mode: 'none', path: '' },
+  pluginSet: 'lean', lanes: [], alwaysOn: false,
+};
+
+// PRE-CHANGE state: derive against a manifest missing pre-commit-hooks
+// (scopes:['project'], profiles:['core','all'] — desired under THIS
+// target's real profile 'core' + authoritative scope 'project').
+const oldManifest = { schemaVersion: manifest.schemaVersion, harness: manifest.harness,
+  items: manifest.items.filter((i) => i.id !== 'pre-commit-hooks') };
+if (oldManifest.items.length === manifest.items.length) throw new Error('fixture drift: expected the real manifest to still carry pre-commit-hooks');
+
+let s = state.load();
+const key = state.ensureTarget(s, oldManifest, answers) && Object.keys(s.targets)[0];
+if (s.targets[key].items['pre-commit-hooks']) throw new Error('fixture drift: pre-commit-hooks should be ABSENT from the pre-change derive');
+if (s.targets[key].scope !== 'project') throw new Error('fixture drift: freshly-derived scope should be project before corruption');
+
+// Corrupt the PERSISTED .scope field only — cachedAnswers.scope (what
+// ensureTarget uses to pick this very target key) stays 'project'
+// throughout; only the target's own redundant copy drifts.
+s.targets[key].scope = 'user';
+state.save(s);
+
+// The 'upgrade': ensureTarget against the CURRENT (full) manifest.
+const migrated = state.ensureTarget(s, manifest, answers);
+state.save(s);
+
+console.log(JSON.stringify({ migrated }));
+")
+
+echo "$outE" | jq -e '.migrated.items["pre-commit-hooks"].enabled == true' >/dev/null \
+  || fail "caseE: a project-only item backfilled under a target with a STALE persisted scope:'user' must still key off the AUTHORITATIVE invocation scope 'project' (got: $outE)"
+echo "ok: caseE — migration membership uses the authoritative invocation scope, never a stale persisted target.scope"
+
 echo "PASS"

--- a/scripts/himmelctl/test/test-wizard-status-upgrade.sh
+++ b/scripts/himmelctl/test/test-wizard-status-upgrade.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# test-wizard-status-upgrade.sh — hermetic tests for HIMMEL-1017 (CR
+# follow-up from HIMMEL-1012): himmelctl `status` must reconcile new
+# manifest items into an EXISTING state.json, and stop false-redding
+# opt-in tools. Mirrors sibling test-wizard-status-*.sh conventions: a fake
+# HOME + HIMMELCTL_CACHE_DIR + HIMMELCTL_REPO_ROOT fixture, node launched by
+# absolute path, winpath for node.exe's MSYS-path blindness.
+#
+# Covers:
+#   a. UPGRADE: a target's state.json was derived against an OLDER manifest
+#      missing an item ('pre-commit-hooks') that a later himmel-update's
+#      manifest.json gained. Re-running `status` against the CURRENT
+#      (full) manifest — simulating that update — must (1) surface the
+#      previously-invisible item in the report instead of silently omitting
+#      it, with its genuinely-derived desired/severity (not a stale
+#      n/a-forever), and (2) persist that migration into state.json so the
+#      NEXT run doesn't need to re-migrate it, while leaving every
+#      already-tracked item's state byte-for-byte untouched.
+#   b. OPT-IN: graphify-mcp carries profiles:["luna","all"] like any other
+#      luna-profile item, so a luna/all target reads it desired:true even
+#      though registering it is a genuinely opt-in, manual step (adopt.sh's
+#      --with-graphify). Absent -> severity n/a (informational), not red.
+#      Present (registered in ~/.claude.json) -> severity green, same as
+#      any other item — the fix only silences the "never opted in" alarm,
+#      it does not stop tracking the item.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+wizard="$repo_root/scripts/himmelctl/bin.js"
+manifest_path="$repo_root/scripts/install/manifest.json"
+[ -f "$wizard" ] || { echo "FAIL: $wizard not found" >&2; exit 1; }
+[ -f "$manifest_path" ] || { echo "FAIL: $manifest_path not found" >&2; exit 1; }
+command -v node >/dev/null 2>&1 || { echo "FAIL: node required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "FAIL: jq required" >&2; exit 1; }
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+node_bin=$(command -v node)
+
+work=$(mktemp -d)
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT
+
+# winpath <path> — echo <path> unchanged on posix, or its Windows form on
+# git-bash/MSYS/Cygwin (node.exe misresolves MSYS /tmp-style paths).
+winpath() {
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) cygpath -m "$1" 2>/dev/null || printf '%s' "$1" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+# write_cache <path> <role> <scope> <vault-mode> <vault-path> <handover-mode>
+#             <handover-path> <plugin-set> — a minimal valid Draft-A profile
+#             (same shape sibling test-wizard-status-cmd.sh's write_cache).
+write_cache() {
+  cat > "$1" <<JSON
+{"role":"$2","tier":"standard","scope":"$3","vault":{"mode":"$4","path":"$5"},"handover":{"mode":"$6","path":"$7"},"pluginSet":"$8","lanes":[],"alwaysOn":false}
+JSON
+}
+
+# ══════════════════════════════════════════════════════════════════════════
+# case (a): UPGRADE — a manifest item gained after the target was derived
+# ══════════════════════════════════════════════════════════════════════════
+
+fixtureRepoA="$work/repoA"
+mkdir -p "$fixtureRepoA/scripts/install"
+fixtureRepoA_w="$(winpath "$fixtureRepoA")"
+
+targetA="$work/targetA"; mkdir -p "$targetA/.claude"
+# Deliberately no .pre-commit-config.yaml — pre-commit-hooks reads absent
+# once it's visible at all.
+
+homeA="$work/homeA"; mkdir -p "$homeA"
+cacheA="$work/cacheA"; mkdir -p "$cacheA"
+cacheA_w="$(winpath "$cacheA")"
+
+# profile 'core' (vault.mode:none), scope 'project' — pre-commit-hooks
+# (profiles:["core","all"], scopes:["project"]) is desired under this
+# target.
+write_cache "$cacheA/install-profile.json" adopter project none "" inline "" lean
+
+# ── OLD manifest: the real manifest minus pre-commit-hooks — simulates the
+# state.json this target would have derived BEFORE a himmel-update added it
+# (this is a fixture device: pre-commit-hooks is a real, long-standing item;
+# the point is only that SOME item the target's persisted state predates).
+"$node_bin" -e "
+const fs = require('fs');
+const m = JSON.parse(fs.readFileSync('$(winpath "$manifest_path")', 'utf8'));
+m.items = m.items.filter((i) => i.id !== 'pre-commit-hooks');
+fs.writeFileSync('$fixtureRepoA_w/scripts/install/manifest.json', JSON.stringify(m, null, 2) + '\n');
+" || fail "case a setup: failed to write the OLD (item-short) fixture manifest"
+
+# ── seed run: status against the OLD (item-short) manifest derives + saves
+# a target entry that never carries pre-commit-hooks at all.
+( cd "$targetA" && HIMMELCTL_REPO_ROOT="$fixtureRepoA_w" HIMMELCTL_CACHE_DIR="$cacheA_w" HOME="$homeA" \
+    "$node_bin" "$wizard" status --json >/dev/null ) \
+  || fail "case a setup: seed status run (old manifest) failed"
+
+targetKeyA=$(jq -r '.targets | keys[0]' "$cacheA/state.json")
+if [ -z "$targetKeyA" ] || [ "$targetKeyA" = "null" ]; then
+  fail "case a setup: state.json has no derived target key"
+fi
+jq -e --arg k "$targetKeyA" '.targets[$k].items | has("pre-commit-hooks") | not' "$cacheA/state.json" >/dev/null \
+  || fail "case a setup: fixture drift — pre-change state.json should NOT carry pre-commit-hooks yet (got: $(cat "$cacheA/state.json"))"
+echo "ok: case a (setup) — seed state.json derived against the OLD manifest never carries pre-commit-hooks"
+
+# Snapshot another item's enabled flag from the pre-migration state, to
+# prove the migration below leaves it untouched.
+wiringBefore=$(jq -e --arg k "$targetKeyA" '.targets[$k].items["wiring-pretooluse"].enabled' "$cacheA/state.json")
+
+# ── the "upgrade": swap in the REAL (current, full) manifest and re-run
+# status — this is the exact scenario a himmel-update delivers.
+cp "$manifest_path" "$fixtureRepoA/scripts/install/manifest.json"
+
+outA=$( cd "$targetA" && HIMMELCTL_REPO_ROOT="$fixtureRepoA_w" HIMMELCTL_CACHE_DIR="$cacheA_w" HOME="$homeA" \
+    "$node_bin" "$wizard" status --json ) \
+  || fail "case a: post-upgrade status run failed"
+
+echo "$outA" | jq -e '.items[] | select(.id=="pre-commit-hooks")' >/dev/null \
+  || fail "case a: pre-commit-hooks must now appear in the status report (got: $outA)"
+echo "$outA" | jq -e '.items[] | select(.id=="pre-commit-hooks") | .desired == true' >/dev/null \
+  || fail "case a: pre-commit-hooks should read desired:true under profile core/scope project (got: $outA)"
+echo "$outA" | jq -e '.items[] | select(.id=="pre-commit-hooks") | .severity == "red"' >/dev/null \
+  || fail "case a: pre-commit-hooks should be ACTIVELY PROBED (severity red — no .pre-commit-config.yaml here), not silently n/a (got: $outA)"
+echo "ok: case a — a manifest item gained after the target's last derive is surfaced (probed, not silently n/a) on the very next status run"
+
+jq -e --arg k "$targetKeyA" '.targets[$k].items | has("pre-commit-hooks")' "$cacheA/state.json" >/dev/null \
+  || fail "case a: the migration should be PERSISTED into state.json (got: $(cat "$cacheA/state.json"))"
+echo "ok: case a — the migration is persisted into state.json (not just reported in-memory for this one run)"
+
+wiringAfter=$(jq -e --arg k "$targetKeyA" '.targets[$k].items["wiring-pretooluse"].enabled' "$cacheA/state.json")
+[ "$wiringBefore" = "$wiringAfter" ] \
+  || fail "case a: an already-tracked item's enabled flag must survive the migration unchanged (before=$wiringBefore after=$wiringAfter)"
+echo "ok: case a — an already-tracked item's state survives the migration unchanged"
+
+# ── a second post-upgrade run performs zero further state.json writes
+# (migration is idempotent — nothing left to backfill). ─────────────────────
+before2=$(sha256sum "$cacheA/state.json")
+( cd "$targetA" && HIMMELCTL_REPO_ROOT="$fixtureRepoA_w" HIMMELCTL_CACHE_DIR="$cacheA_w" HOME="$homeA" \
+    "$node_bin" "$wizard" status --json >/dev/null ) || fail "case a: second post-upgrade run failed"
+after2=$(sha256sum "$cacheA/state.json")
+[ "$before2" = "$after2" ] || fail "case a: a second run against an already-migrated target should write nothing further to state.json"
+echo "ok: case a — a second run against an already-migrated target is a zero-write no-op"
+
+# ══════════════════════════════════════════════════════════════════════════
+# case (b): OPT-IN — graphify-mcp reads n/a (not red) when CLEANLY never
+# registered, still reads green once it IS registered, and — CR fix
+# (HIMMEL-1017 round) — stays red (not silently swallowed to n/a) when its
+# config is genuinely broken rather than just never-opted-in. This target is
+# scope 'project', so graphify-mcp's registration lives in <targetB>/
+# .mcp.json (CR fix: probeMcpRegistered is now scope-aware — see
+# probes.js's mcpConfigPath()); the original version of this test wrote to
+# ~/.claude.json instead, which happened to pass only because the probe used
+# to ignore scope entirely.
+# ══════════════════════════════════════════════════════════════════════════
+
+fixtureRepoB="$work/repoB"
+mkdir -p "$fixtureRepoB/scripts/install"
+cp "$manifest_path" "$fixtureRepoB/scripts/install/manifest.json"
+fixtureRepoB_w="$(winpath "$fixtureRepoB")"
+
+targetB="$work/targetB"; mkdir -p "$targetB/.claude"
+homeB="$work/homeB"; mkdir -p "$homeB"
+cacheB="$work/cacheB"; mkdir -p "$cacheB"
+cacheB_w="$(winpath "$cacheB")"
+
+# profile 'all' (vault.mode:default-template), scope 'project' — graphify-mcp
+# (profiles:["luna","all"], scopes:["project","user"]) is desired:true here.
+vaultB="$work/vault"
+write_cache "$cacheB/install-profile.json" adopter project default-template "$(winpath "$vaultB")" inline "" lean
+
+runStatusB() {
+  ( cd "$targetB" && HIMMELCTL_REPO_ROOT="$fixtureRepoB_w" HIMMELCTL_CACHE_DIR="$cacheB_w" HOME="$homeB" \
+      "$node_bin" "$wizard" status --items graphify-mcp --json )
+}
+
+# ── absent: no <targetB>/.mcp.json at all (project scope) -> severity n/a,
+# not red, desired stays true (still actively tracked, just not alarmed).
+# ENOENT is the ORDINARY case here — most projects never commit a .mcp.json
+# at all — so this is a CLEAN absence, not a config error.
+outB1=$(runStatusB) || fail "case b: status run (graphify-mcp absent) failed"
+echo "$outB1" | jq -e '.items[0].desired == true' >/dev/null \
+  || fail "case b: graphify-mcp should read desired:true under profile 'all' (got: $outB1)"
+echo "$outB1" | jq -e '.items[0].severity == "n/a"' >/dev/null \
+  || fail "case b: graphify-mcp absent should read severity n/a (informational, opt-in), not red (got: $outB1)"
+echo "$outB1" | jq -e '.items[0].detail | test("opt-in"; "i")' >/dev/null \
+  || fail "case b: graphify-mcp's n/a detail should name it as opt-in (got: $outB1)"
+# CR fix (HIMMEL-1017 round): the n/a row must PRESERVE the underlying probe
+# diagnostic (which file/condition was actually checked), not just the
+# friendly opt-in framing — proves the fix doesn't discard information.
+echo "$outB1" | jq -e '.items[0].detail | test("does not exist")' >/dev/null \
+  || fail "case b: graphify-mcp's n/a detail should still name the underlying probe diagnostic (got: $outB1)"
+echo "$outB1" | jq -e '.summary.red == 0' >/dev/null \
+  || fail "case b: graphify-mcp absent must not count toward summary.red (got: $outB1)"
+echo "ok: case b — graphify-mcp cleanly absent (never opted in) reads n/a, not a false red, and keeps its diagnostic detail"
+
+# ── malformed config (CR fix, HIMMEL-1017 round): .mcp.json EXISTS but is
+# unparseable — a lost/corrupted registration, NOT "never opted in". Must
+# stay on the standard red path with the RAW probe diagnostic, never the
+# friendly opt-in message (which would hide a genuine regression).
+printf '{not valid json' > "$targetB/.mcp.json"
+outB2=$(runStatusB) || fail "case b: status run (graphify-mcp malformed config) failed"
+echo "$outB2" | jq -e '.items[0].severity == "red"' >/dev/null \
+  || fail "case b: graphify-mcp with an unparseable .mcp.json must stay red, not be swallowed into n/a (got: $outB2)"
+echo "$outB2" | jq -e '.items[0].detail | test("cannot read/parse")' >/dev/null \
+  || fail "case b: graphify-mcp's red detail (malformed config) should carry the RAW probe diagnostic (got: $outB2)"
+echo "$outB2" | jq -e '.items[0].detail | test("opt-in"; "i") | not' >/dev/null \
+  || fail "case b: a broken config must NOT read the friendly opt-in message (got: $outB2)"
+echo "$outB2" | jq -e '.summary.red == 1' >/dev/null \
+  || fail "case b: a broken graphify-mcp config must count toward summary.red (got: $outB2)"
+echo "ok: case b — a malformed graphify-mcp config stays red with its raw diagnostic, never silently downgraded"
+
+# ── present: register it in <targetB>/.mcp.json -> severity green, same as
+# any other present item — the fix must not stop tracking it once it IS
+# there, and project scope must resolve .mcp.json (not ~/.claude.json).
+printf '{"mcpServers":{"graphify":{"command":"graphify-mcp"}}}' > "$targetB/.mcp.json"
+outB3=$(runStatusB) || fail "case b: status run (graphify-mcp present) failed"
+echo "$outB3" | jq -e '.items[0].severity == "green"' >/dev/null \
+  || fail "case b: graphify-mcp registered in <targetB>/.mcp.json (project scope) should read green (got: $outB3)"
+echo "ok: case b — graphify-mcp registered (project-scope .mcp.json) reads green, same as any other present desired item"
+
+echo "PASS"

--- a/scripts/hooks/check-template-version.sh
+++ b/scripts/hooks/check-template-version.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Template-version gate (HIMMEL-524): a commit/push that changes any
+# template-OWNED file under templates/luna-second-brain/ MUST also bump the
+# template's marketplace.json metadata.version — the stamp scripts/upgrade.sh
+# compares against each vault's .vault-template.json. A content change with no
+# bump ships "already current" and strands the change for every stamped vault,
+# the 449/501/521 failure mode this closes structurally (HIMMEL-195).
+#
+# "Owned" = the upgrade.sh classifier's propagated-content classes
+# (overwrite | threeway | jsonmerge); skip-class files (skip / skipexists /
+# report — .vault-template.json, plugin assets, user content) do NOT fire. See
+# owned_class() below: it is DERIVED FROM and MUST STAY IN SYNC WITH classify()
+# in templates/luna-second-brain/scripts/upgrade.sh (the single source of truth
+# — the case arms are copied verbatim so this gate tracks the classifier, not a
+# hand-maintained second list).
+#
+# himmel-contributor-only (gated by the .himmel-dev marker), like doc-guard.
+# pre-commit = staged set; --pre-push = push range.
+# rc: 0 pass | 1 violation | 2 cannot-evaluate.
+# Skips (exit 0) when jq is unavailable (mirrors check-template-himmel-plugins.sh
+# — a missing optional tool must not block every contributor commit).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ "${TEMPLATE_VERSION_FORCE_ERR:-0}" = "1" ]; then
+    echo "→ template-version: TEMPLATE_VERSION_FORCE_ERR=1 — forced cannot-evaluate" >&2; exit 2
+fi
+# shellcheck disable=SC1091
+if ! . "$SCRIPT_DIR/../guardrails/lib.sh" 2>/dev/null; then
+    echo "→ template-version: cannot source guardrails/lib.sh — fail-closed" >&2; exit 2
+fi
+rc=0; is_himmel_dev_repo || rc=$?
+[ "$rc" -eq 2 ] && { echo "→ template-version: cannot resolve repo root — fail-closed" >&2; exit 2; }
+[ "$rc" -eq 1 ] && exit 0   # not a contributor checkout → no-op
+if [ "${TEMPLATE_VERSION_OK:-0}" = "1" ]; then
+    echo "→ template-version: TEMPLATE_VERSION_OK=1 — skipping (verify the bump manually)" >&2; exit 0
+fi
+
+TEMPLATE_ROOT="templates/luna-second-brain"
+MP_REL="marketplace/.claude-plugin/marketplace.json"
+MP_REPO="$TEMPLATE_ROOT/$MP_REL"
+
+# No early "$TEMPLATE_ROOT absent -> exit 0" short-circuit here on purpose: a
+# WORKING-TREE dir check run before the diff is inspected would bypass the
+# gate on exactly the case it exists to catch — deleting the entire template
+# dir in this commit/range (HIMMEL-524 CR round 3). The owned-files collection
+# below is diff-driven (git diff --name-only / --cached), so it still catches
+# deletions even though the dir is now gone from the working tree; a checkout
+# that genuinely never had the template (nothing touched under TEMPLATE_ROOT
+# either) falls through to the owned_list emptiness check and exits 0 there.
+
+# jq reads metadata.version out of git blobs (staged index, HEAD, range base).
+command -v jq >/dev/null 2>&1 || { echo "→ template-version: jq not on PATH — skipping (verify the bump manually)" >&2; exit 0; }
+
+# owned_class <rel> — print the upgrade.sh classifier class for a path RELATIVE
+# to the template root. Copied verbatim from classify() in upgrade.sh so it stays
+# structurally tied to the classifier; keep the two in sync. Owned (gate fires)
+# = overwrite | threeway | jsonmerge; the rest are user-content / review-only.
+owned_class() {
+    case "$1" in
+        _CLAUDE.md)                                   echo threeway ;;
+        _Templates/*.md)                              echo report ;;
+        .obsidian/community-plugins.json)             echo jsonmerge ;;
+        .obsidian/plugins/*/data.json)                echo skipexists ;;
+        .obsidian/plugins/*/main.js|.obsidian/plugins/*/manifest.json|.obsidian/plugins/*/styles.css) echo skipexists ;;
+        .obsidian/PLUGINS-SETUP.md)                   echo overwrite ;;
+        .obsidian/app.json|.obsidian/appearance.json|.obsidian/graph.json|.obsidian/core-plugins.json) echo overwrite ;;
+        scripts/*)                                    echo overwrite ;;
+        docs/*)                                       echo overwrite ;;
+        .pre-commit-config.yaml)                      echo overwrite ;;
+        marketplace/.claude-plugin/marketplace.json)  echo overwrite ;;
+        .env.example|.gitignore|.gitattributes|.gitleaks.toml|README.md) echo overwrite ;;
+        *)                                            echo skip ;;
+    esac
+}
+
+# version_at <ref-path> — print metadata.version of the template marketplace.json
+# at a git ref path (":<path>" = staged index, "HEAD:<path>", "<base>:<path>").
+# Prints empty when the blob is absent at that ref or has no metadata.version.
+version_at() {
+    git show "$1" 2>/dev/null | jq -r '.metadata.version // empty' 2>/dev/null | tr -d '\r' || true
+}
+
+mode="${1:-pre-commit}"
+if [ "$mode" = "--pre-push" ]; then
+    db=$(default_branch)
+    # On the default branch itself, or a detached HEAD: no feature-branch range
+    # to check (mirrors check-doc-guard.sh).
+    cur=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
+    if [ "$cur" = "HEAD" ] || is_on_main; then
+        echo "→ template-version: no feature-branch range (detached/default) — skipping" >&2; exit 0
+    fi
+    # Offline seam (mirrors check-doc-guard.sh): skip the fetch under NO_FETCH,
+    # and on a known-offline clone with no resolvable base, SKIP loudly rather
+    # than hard-block a legit offline push. A FAILED fetch (network blip, etc.)
+    # is different: falling through would silently compare against a STALE
+    # local origin/$db, which can carry an upstream version bump the branch
+    # never earned — fail-closed instead (HIMMEL-524 CR round 5).
+    if [ "${TEMPLATE_VERSION_NO_FETCH:-0}" != "1" ]; then
+        git fetch -q origin "$db" 2>/dev/null || { echo "→ template-version: git fetch origin/$db failed — fail-closed (bypass: TEMPLATE_VERSION_NO_FETCH=1)" >&2; exit 2; }
+    fi
+    base=""
+    if git rev-parse --verify --quiet "origin/$db" >/dev/null; then base="origin/$db"
+    elif git rev-parse --verify --quiet "$db" >/dev/null; then base="$db"
+    elif [ "${TEMPLATE_VERSION_NO_FETCH:-0}" = "1" ]; then
+        echo "→ template-version: no base + NO_FETCH — skipping (verify the bump manually)" >&2; exit 0
+    else echo "→ template-version: no diff base after fetch — fail-closed" >&2; exit 2; fi
+    # --no-renames: name-only rename detection would report only the
+    # destination path for a moved owned file, so the deleted source is never
+    # classified and a rename-out-of-template silently escapes the gate
+    # (HIMMEL-524 CR round 4). Force delete+add so both sides surface.
+    # A FAILED diff must fail-closed too, not fall through as an empty
+    # touched set — `|| true` here would turn "git couldn't evaluate the
+    # range" into a silent pass (HIMMEL-524 CR round 5).
+    if ! touched=$(git diff --no-renames --name-only "$base...HEAD" 2>/dev/null); then
+        echo "→ template-version: cannot collect pre-push changes — fail-closed" >&2; exit 2
+    fi
+    cur_v="$(version_at "HEAD:$MP_REPO")"
+    # prev_v must be read at the MERGE-BASE, not the base tip: the touched set
+    # above is a three-dot diff (merge-base...HEAD), so the version comparison
+    # has to match that same base or a post-split bump on main's tip falsely
+    # clears a branch that never bumped (HIMMEL-524 CR).
+    mb=$(git merge-base "$base" HEAD 2>/dev/null) || { echo "→ template-version: cannot resolve merge-base — fail-closed" >&2; exit 2; }
+    prev_v="$(version_at "$mb:$MP_REPO")"
+else
+    # --no-renames: same rationale as the pre-push branch above — force
+    # delete+add so a renamed owned file surfaces both sides. Fail-closed on
+    # a diff failure too (HIMMEL-524 CR round 5) — see the pre-push branch.
+    if ! touched=$(git diff --no-renames --cached --name-only); then
+        echo "→ template-version: cannot collect staged changes — fail-closed" >&2; exit 2
+    fi
+    cur_v="$(version_at ":$MP_REPO")"
+    prev_v="$(version_at "HEAD:$MP_REPO")"
+fi
+
+# Collect the owned template files among the touched set. bash 3.2-safe
+# (while-read over a heredoc, no assoc arrays).
+owned=""
+while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    case "$f" in
+        "$TEMPLATE_ROOT"/*) rel="${f#"$TEMPLATE_ROOT"/}" ;;
+        *) continue ;;
+    esac
+    case "$(owned_class "$rel")" in
+        overwrite|threeway|jsonmerge) owned="${owned}${f}"$'\n' ;;
+    esac
+done <<EOF
+$touched
+EOF
+
+owned_list="$(printf '%s' "$owned" | sed '/^$/d')"
+[ -n "$owned_list" ] || exit 0
+
+# A bump = the metadata.version value differs across the change set (staged vs
+# HEAD for pre-commit; HEAD vs base for pre-push). String compare, not semver:
+# the gap this closes is "version UNCHANGED while content shipped", and a plain
+# inequality is portable (no sort -V) and catches exactly that.
+if [ -n "$cur_v" ] && [ "$cur_v" != "$prev_v" ]; then
+    exit 0
+fi
+
+cat >&2 <<EOF
+⛔ template-version: template-OWNED content changed without bumping the template version.
+$(printf '%s\n' "$owned_list" | sed 's/^/     /')
+
+   marketplace.json metadata.version is the stamp /luna-upgrade compares against each
+   vault's .vault-template.json: a content change with no bump reports "already current"
+   and strands the change for every stamped vault (HIMMEL-449/501/521/524). Bump
+   metadata.version in $MP_REPO within THIS change set.
+
+   Bypass (per-session env, not a prefix):  TEMPLATE_VERSION_OK=1 git commit ...
+EOF
+exit 1

--- a/scripts/hooks/test-template-version.sh
+++ b/scripts/hooks/test-template-version.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/hooks/check-template-version.sh (HIMMEL-524).
+#
+# Builds throwaway git repos, exercises each rc case, asserts exact rc.
+# Usage: bash scripts/hooks/test-template-version.sh
+#
+# Exit 0 if all cases pass, 1 otherwise.
+#
+# shellcheck disable=SC2034  # SCRIPT/ORIGIN/R/MP used inside eval'd test bodies
+# shellcheck disable=SC2016  # single-quoted test body strings intentionally contain $
+# shellcheck disable=SC2317  # fixture fns called indirectly via eval inside run_test
+# shellcheck disable=SC2329  # same as SC2317 (alias in newer shellcheck versions)
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Shared fixture helpers
+# ---------------------------------------------------------------------------
+
+HOOKS="$(cd "$(dirname "$0")" && pwd)"
+# Run the script IN PLACE from the real tree (mirrors test-doc-guard.sh): it
+# resolves guardrails/lib.sh via its own SCRIPT_DIR; only the GIT REPO is a
+# tempdir, so `cd "$R"` is all that's needed.
+SCRIPT="$HOOKS/check-template-version.sh"
+MP="templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json"
+# upgrade.sh's classify() is the single source of truth owned_class() copies
+# its case arms from verbatim (see check-template-version.sh header) — run
+# from the real repo tree (not a fixture repo), same as SCRIPT.
+UPGRADE_SH="$HOOKS/../../templates/luna-second-brain/scripts/upgrade.sh"
+
+# mk_market <path> <version> — write a minimal valid marketplace.json.
+mk_market() { mkdir -p "$(dirname "$1")"; printf '{"name":"luna-brain","metadata":{"version":"%s"},"plugins":[]}\n' "$2" > "$1"; }
+
+# extract_case_arms <file> <fn> — print just the `pattern) body ;;` lines of
+# a shell function's `case "$1" in ... esac` block (trimmed, comment/wrapper
+# lines excluded), so a diff between two copies ignores cosmetic reflow.
+extract_case_arms() {
+  awk -v fn="$2" '
+    $0 == fn"() {" { infn=1 }
+    infn && /^}/ { exit }
+    infn && /esac/ { exit }
+    infn && index($0, "case \"$1\" in") { incase=1; next }
+    infn && incase && $0 !~ /^[[:space:]]*#/ && $0 !~ /^[[:space:]]*$/ { print }
+  ' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+# setup_repo: temp git repo WITH the .himmel-dev marker. Explicit mktemp
+# template (not a bare `mktemp -d`): BSD mktemp on macOS requires one for -d.
+setup_repo() {
+  R=$(mktemp -d -t tv-test-repo.XXXXXX); git -C "$R" init -q
+  git -C "$R" config user.email t@t; git -C "$R" config user.name t
+  : > "$R/.himmel-dev"
+}
+setup_repo_no_marker() { setup_repo; rm -f "$R/.himmel-dev"; }
+
+# setup_repo_with_origin: seeds marketplace.json on main + a bare origin for
+# pre-push base resolution (mirrors test-doc-guard.sh's setup_repo_with_origin).
+setup_repo_with_origin() {
+  setup_repo
+  mk_market "$R/$MP" 0.1.0
+  git -C "$R" add "$MP"; git -C "$R" commit -qm "seed market"
+  ORIGIN=$(mktemp -d -t tv-test-origin.XXXXXX); git -C "$ORIGIN" init -q --bare
+  git -C "$R" remote add origin "$ORIGIN"
+  git -C "$R" branch -M main
+  git -C "$R" push -q origin main
+}
+
+expect_rc() { local want=$1; shift; local rc=0; "$@" || rc=$?; [ "$rc" -eq "$want" ]; }
+
+# ---------------------------------------------------------------------------
+# run_test harness (modeled on test-doc-guard.sh pass/fail accounting)
+# ---------------------------------------------------------------------------
+
+_failures=0
+
+run_test() {
+  local name="$1" body="$2"
+  local rc=0 errfile
+  errfile=$(mktemp)
+  # Run each test body in a subshell so cd/R don't leak between cases.
+  ( eval "$body" ) 2>"$errfile" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    printf '  PASS  %s\n' "$name"
+  else
+    printf '  FAIL  %s (subshell rc=%s)\n' "$name" "$rc"
+    sed 's/^/        /' "$errfile"
+    _failures=$((_failures + 1))
+  fi
+  rm -f "$errfile"
+}
+
+# ---------------------------------------------------------------------------
+# Test cases — assert EXACT rc with expect_rc.
+# ---------------------------------------------------------------------------
+
+# Required contract: template file + no bump -> fail.
+run_test "blocks owned content (docs/) without bump (rc=1)" '
+  setup_repo; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  mkdir -p templates/luna-second-brain/docs; : > templates/luna-second-brain/docs/foo.md;
+  git add templates/luna-second-brain/docs/foo.md;
+  expect_rc 1 bash "$SCRIPT"
+'
+
+# Required contract: template file + bump -> pass.
+run_test "passes owned content WITH version bump (rc=0)" '
+  setup_repo; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  mkdir -p templates/luna-second-brain/docs; : > templates/luna-second-brain/docs/foo.md;
+  mk_market "$MP" 0.2.0; git add templates/luna-second-brain/docs/foo.md "$MP";
+  expect_rc 0 bash "$SCRIPT"
+'
+
+# Required contract: skip-class file alone -> pass (skipexists plugin asset, HIMMEL-525).
+run_test "skipexists plugin asset alone passes (rc=0)" '
+  setup_repo; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  mkdir -p templates/luna-second-brain/.obsidian/plugins/foo;
+  : > templates/luna-second-brain/.obsidian/plugins/foo/main.js;
+  git add templates/luna-second-brain/.obsidian/plugins/foo/main.js;
+  expect_rc 0 bash "$SCRIPT"
+'
+
+# Required contract: skip-class catch-all (user content) alone -> pass.
+run_test "user-content (skip catch-all) alone passes (rc=0)" '
+  setup_repo; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  : > templates/luna-second-brain/Some-User-Note.md;
+  git add templates/luna-second-brain/Some-User-Note.md;
+  expect_rc 0 bash "$SCRIPT"
+'
+
+# Required contract: non-template change -> pass.
+run_test "non-template change passes (rc=0)" '
+  setup_repo; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  : > README-ROOT.md; git add README-ROOT.md;
+  expect_rc 0 bash "$SCRIPT"
+'
+
+# Deletion of a single owned file, staged, without a bump -> fail. The gate is
+# diff-driven, not working-tree-driven, so a deletion must be caught the same
+# as an addition/modification (HIMMEL-524 CR round 3).
+run_test "blocks staged deletion of owned content without bump (rc=1)" '
+  setup_repo; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  mkdir -p templates/luna-second-brain/docs; : > templates/luna-second-brain/docs/foo.md;
+  git add templates/luna-second-brain/docs/foo.md; git commit -qm "add doc";
+  git rm -q templates/luna-second-brain/docs/foo.md;
+  expect_rc 1 bash "$SCRIPT"
+'
+
+# Deletion of the ENTIRE template dir (including marketplace.json itself),
+# without a bump -> fail. The pre-fix early "$TEMPLATE_ROOT absent -> exit 0"
+# working-tree check would have bypassed this entirely (the bug this closes).
+run_test "blocks deletion of the ENTIRE template dir without bump (rc=1)" '
+  setup_repo; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  mkdir -p templates/luna-second-brain/docs; : > templates/luna-second-brain/docs/foo.md;
+  git add templates/luna-second-brain/docs/foo.md; git commit -qm "add doc";
+  git rm -rq templates/luna-second-brain;
+  expect_rc 1 bash "$SCRIPT"
+'
+
+# Structural: no-op without .himmel-dev marker.
+run_test "no-op without .himmel-dev marker (rc=0)" '
+  setup_repo_no_marker; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  mkdir -p templates/luna-second-brain/docs; : > templates/luna-second-brain/docs/foo.md; git add templates/luna-second-brain/docs/foo.md;
+  expect_rc 0 bash "$SCRIPT"
+'
+
+# Structural: bypass seam.
+run_test "TEMPLATE_VERSION_OK=1 bypasses (rc=0)" '
+  setup_repo; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  mkdir -p templates/luna-second-brain/docs; : > templates/luna-second-brain/docs/foo.md; git add templates/luna-second-brain/docs/foo.md;
+  expect_rc 0 env TEMPLATE_VERSION_OK=1 bash "$SCRIPT"
+'
+
+# Structural: force-err seam.
+run_test "TEMPLATE_VERSION_FORCE_ERR=1 exits 2" '
+  setup_repo; cd "$R"; expect_rc 2 env TEMPLATE_VERSION_FORCE_ERR=1 bash "$SCRIPT"
+'
+
+# marketplace.json itself is owned: a description change without a bump -> fail.
+run_test "marketplace.json description change without bump fails (rc=1)" '
+  setup_repo; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  printf "%s\n" "{\"name\":\"luna-brain\",\"metadata\":{\"description\":\"x\",\"version\":\"0.1.0\"},\"plugins\":[]}" > "$MP";
+  git add "$MP";
+  expect_rc 1 bash "$SCRIPT"
+'
+
+# A pure version bump alone (no other content) passes.
+run_test "pure version bump alone passes (rc=0)" '
+  setup_repo; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  mk_market "$MP" 0.2.0; git add "$MP";
+  expect_rc 0 bash "$SCRIPT"
+'
+
+# threeway class (_CLAUDE.md) without bump -> fail.
+run_test "_CLAUDE.md (threeway) change without bump fails (rc=1)" '
+  setup_repo; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  : > templates/luna-second-brain/_CLAUDE.md; git add templates/luna-second-brain/_CLAUDE.md;
+  expect_rc 1 bash "$SCRIPT"
+'
+
+# jsonmerge class (community-plugins.json) without bump -> fail.
+run_test "community-plugins.json (jsonmerge) change without bump fails (rc=1)" '
+  setup_repo; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  mkdir -p templates/luna-second-brain/.obsidian; : > templates/luna-second-brain/.obsidian/community-plugins.json;
+  git add templates/luna-second-brain/.obsidian/community-plugins.json;
+  expect_rc 1 bash "$SCRIPT"
+'
+
+# pre-push: bump in a later commit of the range -> pass.
+run_test "pre-push passes when version bumped in a later commit (rc=0)" '
+  setup_repo_with_origin; cd "$R"; git checkout -qb feat/x;
+  mkdir -p templates/luna-second-brain/docs; : > templates/luna-second-brain/docs/foo.md;
+  git add .; git commit -qm "content";
+  mk_market "$MP" 0.2.0; git add "$MP"; git commit -qm "bump";
+  expect_rc 0 env TEMPLATE_VERSION_NO_FETCH=1 bash "$SCRIPT" --pre-push
+'
+
+# pre-push: range never bumps -> fail.
+run_test "pre-push blocks when range never bumps (rc=1)" '
+  setup_repo_with_origin; cd "$R"; git checkout -qb feat/y;
+  mkdir -p templates/luna-second-brain/docs; : > templates/luna-second-brain/docs/foo.md;
+  git add .; git commit -qm "content";
+  expect_rc 1 env TEMPLATE_VERSION_NO_FETCH=1 bash "$SCRIPT" --pre-push
+'
+
+# pre-push: main bumps AFTER the branch split, branch itself never bumps ->
+# must still fail. prev_v has to compare at the MERGE-BASE, not the current
+# main tip, or the main-side bump falsely clears the branch (HIMMEL-524 CR).
+run_test "pre-push blocks when main bumps after split but branch never bumps (rc=1)" '
+  setup_repo_with_origin; cd "$R"; git checkout -qb feat/z;
+  mkdir -p templates/luna-second-brain/docs; : > templates/luna-second-brain/docs/foo.md;
+  git add .; git commit -qm "content";
+  git checkout -q main; mk_market "$MP" 0.2.0; git add "$MP"; git commit -qm "main bump";
+  git push -q origin main; git checkout -q feat/z;
+  expect_rc 1 env TEMPLATE_VERSION_NO_FETCH=1 bash "$SCRIPT" --pre-push
+'
+
+# Renaming an owned file OUT of the template dir without a bump -> fail.
+# name-only diff honors rename detection by default, which would report only
+# the destination (untracked, non-owned) path and never classify the deleted
+# source -- --no-renames forces delete+add so both sides surface. Explicitly
+# set diff.renames=true so the fixture proves the flag matters rather than
+# happening to pass under an unconfigured default (HIMMEL-524 CR round 4).
+run_test "blocks rename of owned file OUT of template dir without bump (rc=1)" '
+  setup_repo; cd "$R"; git config diff.renames true;
+  mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  mkdir -p templates/luna-second-brain/docs;
+  printf "same content on both sides of the rename, long enough to be detected\n" > templates/luna-second-brain/docs/foo.md;
+  git add templates/luna-second-brain/docs/foo.md; git commit -qm "add doc";
+  git mv templates/luna-second-brain/docs/foo.md moved-foo.md;
+  expect_rc 1 bash "$SCRIPT"
+'
+
+# Source parity: owned_class() must stay case-arm-identical to upgrade.sh's
+# classify() (the single source of truth these arms are copied from
+# verbatim, per the header comment) -- an upstream classify() edit that isn't
+# mirrored here should break THIS test, not silently under/over-fire the gate.
+run_test "owned_class() case arms match upgrade.sh classify() (source parity)" '
+  a=$(extract_case_arms "$SCRIPT" owned_class);
+  b=$(extract_case_arms "$UPGRADE_SH" classify);
+  [ -n "$a" ] && [ "$a" = "$b" ]
+'
+
+# extract_case_arms must skip comment-only and blank lines INSIDE the case
+# block -- a comment added to one copy but not the other must not false-fail
+# the parity test above. Synthetic fixtures (not the real source files), so
+# this is independent of whether the two real functions currently carry
+# comments (HIMMEL-524 CR round 5).
+run_test "extract_case_arms filters comments/blanks inside the case block" '
+  f1=$(mktemp -t tv-test-arms1.XXXXXX);
+  f2=$(mktemp -t tv-test-arms2.XXXXXX);
+  printf "foo() {\n    case \"\$1\" in\n        # a comment only one copy has\n        a) echo x ;;\n\n        b) echo y ;;\n    esac\n}\n" > "$f1";
+  printf "bar() {\n    case \"\$1\" in\n        a) echo x ;;\n        b) echo y ;;\n    esac\n}\n" > "$f2";
+  a=$(extract_case_arms "$f1" foo);
+  b=$(extract_case_arms "$f2" bar);
+  [ -n "$a" ] && [ "$a" = "$b" ]
+'
+
+# pre-push: a FAILED fetch (network blip etc.) without NO_FETCH must fail
+# closed, not silently fall back to a stale local origin/$db that could carry
+# an upstream bump the branch never earned (HIMMEL-524 CR round 5).
+run_test "pre-push fails closed when fetch fails without NO_FETCH (rc=2)" '
+  setup_repo_with_origin; cd "$R"; git checkout -qb feat/fetchfail;
+  git remote set-url origin "$R/does-not-exist";
+  expect_rc 2 bash "$SCRIPT" --pre-push
+'
+
+# pre-commit: a diff that git genuinely CANNOT compute must fail closed, not
+# fall through as an empty touched set (which would exit 0). Corrupt the
+# index so `git diff --cached` itself fails (HIMMEL-524 CR round 5).
+run_test "pre-commit fails closed when the staged diff cannot be computed (rc=2)" '
+  setup_repo; cd "$R"; mk_market "$MP" 0.1.0; git add "$MP"; git commit -qm seed;
+  mkdir -p templates/luna-second-brain/docs; : > templates/luna-second-brain/docs/foo.md;
+  git add templates/luna-second-brain/docs/foo.md;
+  printf "garbage-not-an-index" > .git/index;
+  expect_rc 2 bash "$SCRIPT"
+'
+
+# pre-push: same contract for the range diff -- corrupt HEAD'"'"'s commit
+# object so `git diff $base...HEAD` itself fails, must fail closed (HIMMEL-524
+# CR round 5).
+run_test "pre-push fails closed when the range diff cannot be computed (rc=2)" '
+  setup_repo_with_origin; cd "$R"; git checkout -qb feat/corrupt;
+  mkdir -p templates/luna-second-brain/docs; : > templates/luna-second-brain/docs/foo.md;
+  git add .; git commit -qm "content";
+  head_sha=$(git rev-parse HEAD);
+  rm -f ".git/objects/${head_sha:0:2}/${head_sha:2}";
+  expect_rc 2 env TEMPLATE_VERSION_NO_FETCH=1 bash "$SCRIPT" --pre-push
+'
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+if [ "$_failures" -eq 0 ]; then
+  echo "OK: all cases passed"
+  exit 0
+else
+  echo "FAIL: $_failures case(s) failed"
+  exit 1
+fi

--- a/scripts/lib/test-unwire-singlekey.ps1
+++ b/scripts/lib/test-unwire-singlekey.ps1
@@ -1,7 +1,8 @@
 # test-unwire-singlekey.ps1 -- committed PS test for the single-key unwire helpers
-# (unwire-statusline.ps1, unwire-himmel-repo.ps1, unwire-luna-vault.ps1; SC6).
-# Plus a .sh/.ps1 byte-parity assertion (both libs normalize through `jq --indent 2`,
-# so identical input must yield identical output). Run:
+# (unwire-statusline.ps1, unwire-himmel-repo.ps1, unwire-luna-vault.ps1,
+# unwire-handover-dir.ps1; SC6 + HIMMEL-839). Plus a .sh/.ps1 byte-parity
+# assertion (both libs normalize through `jq --indent 2`, so identical input
+# must yield identical output). Run:
 #   pwsh -File test-unwire-singlekey.ps1
 
 $ErrorActionPreference = 'Stop'
@@ -9,6 +10,7 @@ $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 . (Join-Path $here 'unwire-statusline.ps1')
 . (Join-Path $here 'unwire-himmel-repo.ps1')
 . (Join-Path $here 'unwire-luna-vault.ps1')
+. (Join-Path $here 'unwire-handover-dir.ps1')
 $fails = 0
 function Check($name, $got, $want) {
     if ("$got" -eq "$want") { Write-Host "ok - $name" }
@@ -68,6 +70,13 @@ Remove-LunaVault -SettingsPath $s | Out-Null
 Check 'LUNA_VAULT_PATH removed' (JqVal $s '.env.LUNA_VAULT_PATH // "ABSENT"') 'ABSENT'
 Check 'HIMMEL_REPO kept'        (JqVal $s '.env.HIMMEL_REPO') 'C:/h'
 
+# 5b. handover-dir (HIMMEL-839): removes key, preserves siblings.
+$s = Join-Path $td 'hd1.json'
+'{"env":{"HANDOVER_DIR":"C:/v/handovers","HIMMEL_REPO":"C:/h"}}' | Set-Content $s -Encoding utf8
+Remove-HandoverDir -SettingsPath $s | Out-Null
+Check 'HANDOVER_DIR removed'     (JqVal $s '.env.HANDOVER_DIR // "ABSENT"') 'ABSENT'
+Check 'HIMMEL_REPO kept (hd)'    (JqVal $s '.env.HIMMEL_REPO') 'C:/h'
+
 # 6. shared invariants: absent file -> no-op; invalid JSON refused.
 $missing = Join-Path $td 'missing.json'
 Remove-HimmelRepo -SettingsPath $missing | Out-Null
@@ -87,6 +96,7 @@ if ($gitBash) {
     $pairs = @(
         @{ ps = { param($p) Remove-HimmelRepo -SettingsPath $p }; sh = 'unwire-himmel-repo.sh'; json = '{"env":{"HIMMEL_REPO":"C:/h","HIMMEL_INITIATIVE":"all"}}' },
         @{ ps = { param($p) Remove-LunaVault -SettingsPath $p };  sh = 'unwire-luna-vault.sh';  json = '{"env":{"LUNA_VAULT_PATH":"C:/v","K":"1"}}' },
+        @{ ps = { param($p) Remove-HandoverDir -SettingsPath $p }; sh = 'unwire-handover-dir.sh'; json = '{"env":{"HANDOVER_DIR":"C:/v/handovers","K":"1"}}' },
         @{ ps = { param($p) Remove-Statusline -SettingsPath $p }; sh = 'unwire-statusline.sh';  json = '{"statusLine":{"type":"command","command":"bash \"C:/h/scripts/statusline/bin/statusline.sh\""},"env":{"X":"1"}}' }
     )
     foreach ($pair in $pairs) {

--- a/scripts/lib/test-unwire-singlekey.sh
+++ b/scripts/lib/test-unwire-singlekey.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2015
 # test-unwire-singlekey.sh -- hermetic tests for the single-key unwire helpers
-# (unwire-statusline.sh, unwire-himmel-repo.sh, unwire-luna-vault.sh; SC6). Each:
-# removes only its key/stanza, preserves siblings, idempotent, absent -> no-op,
-# refuses invalid JSON. statusLine removal is conditional (himmel binary only).
+# (unwire-statusline.sh, unwire-himmel-repo.sh, unwire-luna-vault.sh,
+# unwire-handover-dir.sh; SC6 + HIMMEL-839). Each: removes only its
+# key/stanza, preserves siblings, idempotent, absent -> no-op, refuses
+# invalid JSON. statusLine removal is conditional (himmel binary only).
 set -u
 here="$(cd "$(dirname "$0")" && pwd)"
 sl="$here/unwire-statusline.sh"
 hr="$here/unwire-himmel-repo.sh"
 lv="$here/unwire-luna-vault.sh"
+hd="$here/unwire-handover-dir.sh"
 fails=0
 check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
 td="$(mktemp -d)"
@@ -74,8 +76,16 @@ bash "$lv" "$s" >/dev/null
 check "LUNA_VAULT_PATH removed"  "$(jq -r '.env.LUNA_VAULT_PATH // "ABSENT"' "$s")" "ABSENT"
 check "HIMMEL_REPO kept"         "$(jq -r '.env.HIMMEL_REPO' "$s")" "C:/h"
 
-# ── shared invariants for all three ─────────────────────────────────────────
-for h in "$sl" "$hr" "$lv"; do
+# ── unwire-handover-dir (HIMMEL-839) ────────────────────────────────────────
+# 6. removes HANDOVER_DIR, preserves sibling env keys.
+s="$td/hd1.json"
+printf '%s' '{"env":{"HANDOVER_DIR":"C:/v/handovers","HIMMEL_REPO":"C:/h"}}' > "$s"
+bash "$hd" "$s" >/dev/null
+check "HANDOVER_DIR removed"     "$(jq -r '.env.HANDOVER_DIR // "ABSENT"' "$s")" "ABSENT"
+check "HIMMEL_REPO kept (hd)"    "$(jq -r '.env.HIMMEL_REPO' "$s")" "C:/h"
+
+# ── shared invariants for all four ──────────────────────────────────────────
+for h in "$sl" "$hr" "$lv" "$hd"; do
   n="$(basename "$h")"
   # absent file -> rc 0, not created.
   m="$td/missing-$n.json"

--- a/scripts/lib/test-wire-handover-dir.ps1
+++ b/scripts/lib/test-wire-handover-dir.ps1
@@ -1,0 +1,101 @@
+# test-wire-handover-dir.ps1 -- committed PS test for wire-handover-dir.ps1
+# (HIMMEL-839). Mirrors test-wire-luna-vault.ps1's shape (its own .env merge
+# is genuinely new logic, and clobbering a sibling key is the highest-risk
+# failure on the operator's primary platform, so it gets a real assertion, not
+# parity-by-inspection). No case-8 "seam" test here: unlike LUNA_VAULT_PATH
+# (consumed by vault-resolve.ps1), handover_root() has no PowerShell
+# consumer -- it is read directly from the process env by bash-only handover
+# tooling (scripts/lib/handover-path.sh). The final block is the cross-twin
+# parity check: feed the same input to wire-handover-dir.sh (via Git Bash) and
+# .ps1 and assert byte-identical .env.HANDOVER_DIR (skipped if bash absent).
+# Run: pwsh -File test-wire-handover-dir.ps1
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$wire = Join-Path $here 'wire-handover-dir.ps1'
+$fails = 0
+function Check($name, $got, $want) {
+    if ($got -eq $want) { Write-Host "ok - $name" }
+    else { Write-Host "FAIL - ${name}: [$got]!=[$want]"; $script:fails++ }
+}
+
+$td = Join-Path ([System.IO.Path]::GetTempPath()) ("wirehd-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force $td | Out-Null
+
+# 1. existing sibling env key preserved + HANDOVER_DIR added.
+$s1 = Join-Path $td 's1.json'
+'{"statusLine":{"type":"command"},"env":{"HIMMEL_REPO":"C:/himmel"}}' | Set-Content $s1 -Encoding utf8
+& pwsh -NoProfile -File $wire -SettingsPath $s1 -HandoverDir 'C:/Documents/luna/handovers' | Out-Null
+$c1 = Get-Content $s1 -Raw | ConvertFrom-Json
+Check 'sibling env key preserved' $c1.env.HIMMEL_REPO 'C:/himmel'
+Check 'top-level key preserved'   $c1.statusLine.type 'command'
+Check 'HANDOVER_DIR added'        $c1.env.HANDOVER_DIR 'C:/Documents/luna/handovers'
+
+# 2. missing file -> created with env.HANDOVER_DIR.
+$s2 = Join-Path $td 's2.json'
+& pwsh -NoProfile -File $wire -SettingsPath $s2 -HandoverDir 'C:/Documents/luna/handovers' | Out-Null
+$c2 = Get-Content $s2 -Raw | ConvertFrom-Json
+Check 'create on missing file' $c2.env.HANDOVER_DIR 'C:/Documents/luna/handovers'
+
+# 3. backslash -> forward-slashed.
+$s3 = Join-Path $td 's3.json'
+& pwsh -NoProfile -File $wire -SettingsPath $s3 -HandoverDir 'C:\Users\me\Documents\luna\handovers' | Out-Null
+$c3 = Get-Content $s3 -Raw | ConvertFrom-Json
+Check 'backslash forward-slashed' $c3.env.HANDOVER_DIR 'C:/Users/me/Documents/luna/handovers'
+
+# 4. invalid JSON -> exit 1, file unchanged.
+$s4 = Join-Path $td 's4.json'
+'not json {' | Set-Content $s4 -Encoding utf8
+& pwsh -NoProfile -File $wire -SettingsPath $s4 -HandoverDir 'C:/Documents/luna/handovers' 2>$null | Out-Null
+if ($LASTEXITCODE -eq 0) { Write-Host 'FAIL: invalid JSON not refused'; $fails++ }
+else { Write-Host 'ok - refuses invalid JSON' }
+Check 'invalid file unchanged' ((Get-Content $s4 -Raw).Trim()) 'not json {'
+
+# 5. last-write-wins: re-run with a DIFFERENT target overwrites, keeps sibling.
+# (Callers -- adopt.ps1's Wire-HandoverDirLuna -- are expected to check for an
+# existing value BEFORE calling this; the wire script itself stays a dumb,
+# unconditional setter, same division of labor as wire-luna-vault.ps1.)
+$s5 = Join-Path $td 's5.json'
+'{"env":{"HANDOVER_DIR":"C:/Documents/luna-old/handovers","KEEP":"x"}}' | Set-Content $s5 -Encoding utf8
+& pwsh -NoProfile -File $wire -SettingsPath $s5 -HandoverDir 'C:/Documents/luna-new/handovers' | Out-Null
+$c5 = Get-Content $s5 -Raw | ConvertFrom-Json
+Check 'last-write-wins overwrite' $c5.env.HANDOVER_DIR 'C:/Documents/luna-new/handovers'
+Check 'overwrite keeps sibling'   $c5.env.KEEP 'x'
+
+# 6. idempotent -> second run identical bytes (PS serializer path).
+$s6 = Join-Path $td 's6.json'
+& pwsh -NoProfile -File $wire -SettingsPath $s6 -HandoverDir 'C:/Documents/luna/handovers' | Out-Null
+$h6a = Get-Content $s6 -Raw
+& pwsh -NoProfile -File $wire -SettingsPath $s6 -HandoverDir 'C:/Documents/luna/handovers' | Out-Null
+Check 'idempotent re-run' (Get-Content $s6 -Raw) $h6a
+
+# 7. whitespace-only file -> treated as {}, not refused.
+$s7 = Join-Path $td 's7.json'
+"   `n" | Set-Content $s7 -Encoding utf8
+& pwsh -NoProfile -File $wire -SettingsPath $s7 -HandoverDir 'C:/Documents/luna/handovers' | Out-Null
+$c7 = Get-Content $s7 -Raw | ConvertFrom-Json
+Check 'whitespace file -> created' $c7.env.HANDOVER_DIR 'C:/Documents/luna/handovers'
+
+# 8. cross-twin parity: same backslash input to .sh (Git Bash) and .ps1 must
+#    yield byte-identical .env.HANDOVER_DIR. Skip cleanly if no Git Bash.
+$gitBash = 'C:\Program Files\Git\bin\bash.exe'
+if (-not (Test-Path $gitBash)) {
+    $bc = Get-Command bash -ErrorAction SilentlyContinue
+    $gitBash = if ($bc -and $bc.Source -notmatch 'System32') { $bc.Source } else { $null }
+}
+if ($gitBash) {
+    $shWire = (Join-Path $here 'wire-handover-dir.sh').Replace('\', '/')
+    $pIn = 'C:\Users\me\Documents\luna\handovers'
+    $shOut = (Join-Path $td 'parity_sh.json').Replace('\', '/')
+    $psOut = Join-Path $td 'parity_ps.json'
+    & $gitBash $shWire $shOut $pIn | Out-Null
+    & pwsh -NoProfile -File $wire -SettingsPath $psOut -HandoverDir $pIn | Out-Null
+    $shVal = (Get-Content $shOut -Raw | ConvertFrom-Json).env.HANDOVER_DIR
+    $psVal = (Get-Content $psOut -Raw | ConvertFrom-Json).env.HANDOVER_DIR
+    Check 'cross-twin .sh/.ps1 parity (HANDOVER_DIR)' $psVal $shVal
+} else {
+    Write-Host 'skip - cross-twin parity (Git Bash not found)'
+}
+
+Remove-Item -Recurse -Force $td
+if ($fails -eq 0) { Write-Host 'ALL PASS' } else { Write-Host "$fails FAILED"; exit 1 }

--- a/scripts/lib/test-wire-handover-dir.sh
+++ b/scripts/lib/test-wire-handover-dir.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015
+# test-wire-handover-dir.sh -- hermetic tests for wire-handover-dir.sh (HIMMEL-839).
+# Verifies the settings.json .env.HANDOVER_DIR merge: create, preserve
+# siblings, forward-slash, refuse invalid JSON, idempotent, last-adopt-wins
+# overwrite, plus the seam into handover_root() (scripts/lib/handover-path.sh)
+# reading HANDOVER_DIR straight from the process env.
+set -u
+here="$(cd "$(dirname "$0")" && pwd)"
+wire="$here/wire-handover-dir.sh"
+fails=0
+check(){ [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+
+td="$(mktemp -d)"
+
+# 1. missing file -> creates {"env":{"HANDOVER_DIR":"C:/Documents/luna/handovers"}}.
+s1="$td/s1.json"
+bash "$wire" "$s1" "C:/Documents/luna/handovers" >/dev/null
+check "create on missing file" "$(jq -r '.env.HANDOVER_DIR' "$s1")" "C:/Documents/luna/handovers"
+
+# 2. existing siblings preserved.
+s2="$td/s2.json"
+printf '%s' '{"statusLine":{"type":"command"},"env":{"HIMMEL_REPO":"C:/himmel"}}' > "$s2"
+bash "$wire" "$s2" "C:/Documents/luna/handovers" >/dev/null
+check "sibling env key preserved" "$(jq -r '.env.HIMMEL_REPO' "$s2")" "C:/himmel"
+check "top-level key preserved"   "$(jq -r '.statusLine.type' "$s2")" "command"
+check "HANDOVER_DIR added"        "$(jq -r '.env.HANDOVER_DIR' "$s2")" "C:/Documents/luna/handovers"
+
+# 3. backslash path arg -> stored forward-slashed.
+s3="$td/s3.json"
+bash "$wire" "$s3" 'C:\Users\me\Documents\luna\handovers' >/dev/null
+check "backslash forward-slashed" "$(jq -r '.env.HANDOVER_DIR' "$s3")" "C:/Users/me/Documents/luna/handovers"
+
+# 4. invalid JSON -> rc != 0, file unchanged.
+s4="$td/s4.json"
+printf '%s' 'not json {' > "$s4"
+if bash "$wire" "$s4" "C:/Documents/luna/handovers" >/dev/null 2>&1; then
+  echo "FAIL: invalid JSON not refused"; fails=$((fails+1))
+else
+  echo "ok - refuses invalid JSON"
+fi
+check "invalid file unchanged" "$(cat "$s4")" "not json {"
+
+# 5. idempotent -> second run identical bytes.
+s5="$td/s5.json"
+bash "$wire" "$s5" "C:/Documents/luna/handovers" >/dev/null
+h5a="$(cat "$s5")"
+bash "$wire" "$s5" "C:/Documents/luna/handovers" >/dev/null
+check "idempotent re-run" "$(cat "$s5")" "$h5a"
+
+# 6. last-adopt-wins: re-run with a DIFFERENT target overwrites, keeps sibling.
+s6="$td/s6.json"
+printf '%s' '{"env":{"HANDOVER_DIR":"C:/Documents/luna-old/handovers","KEEP":"x"}}' > "$s6"
+bash "$wire" "$s6" "C:/Documents/luna-new/handovers" >/dev/null
+check "last-adopt-wins overwrite" "$(jq -r '.env.HANDOVER_DIR' "$s6")" "C:/Documents/luna-new/handovers"
+check "overwrite keeps sibling"   "$(jq -r '.env.KEEP' "$s6")" "x"
+
+# 7. empty / whitespace-only file -> treated as {}, not refused as invalid JSON.
+s7="$td/s7.json"
+printf '   \n' > "$s7"
+bash "$wire" "$s7" "C:/Documents/luna/handovers" >/dev/null
+check "whitespace file -> created" "$(jq -r '.env.HANDOVER_DIR' "$s7")" "C:/Documents/luna/handovers"
+
+# 8. SEAM (HIMMEL-839): what wire-handover-dir writes into settings.json .env is
+#    exactly what handover_root() (scripts/lib/handover-path.sh) reads straight
+#    from the process env — Claude Code applies a settings.json "env" block to
+#    the process env at session start. This test makes that hop explicit: wire
+#    a real, existing dir, export the wired value the same way, and assert
+#    handover_root() resolves it (Mode B) instead of falling through to the
+#    inline <repo-root>/handovers default.
+s8dir="$td/vault8/handovers"
+mkdir -p "$s8dir"
+s8="$td/s8.json"
+bash "$wire" "$s8" "$s8dir" >/dev/null
+wired8="$(jq -r '.env.HANDOVER_DIR' "$s8")"
+# shellcheck disable=SC1091  # sourced at runtime; linted standalone by pre-commit
+. "$here/handover-path.sh"
+prev_hd="${HANDOVER_DIR-__UNSET__}"   # save/restore
+export HANDOVER_DIR="$wired8"
+got8="$(handover_root)"
+expected8="$(cd "$s8dir" && pwd)"
+check "seam: settings.json env -> handover_root() Mode B" "$got8" "$expected8"
+
+if [ "$prev_hd" = "__UNSET__" ]; then unset HANDOVER_DIR; else export HANDOVER_DIR="$prev_hd"; fi
+
+rm -rf "$td"
+[ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/lib/unwire-handover-dir.ps1
+++ b/scripts/lib/unwire-handover-dir.ps1
@@ -1,0 +1,31 @@
+# unwire-handover-dir.ps1 -- PowerShell counterpart of unwire-handover-dir.sh.
+# Removes env.HANDOVER_DIR from a Claude Code settings.json; all other env keys
+# are preserved; an env object left empty is pruned. Shells out to jq for byte-parity.
+#
+#   Remove-HandoverDir -SettingsPath <path>
+# Direct:  pwsh -File unwire-handover-dir.ps1 -SettingsPath <path>
+
+[CmdletBinding()]
+param([string]$SettingsPath)
+
+function Remove-HandoverDir {
+    param([Parameter(Mandatory = $true)][string]$SettingsPath)
+    if (-not (Get-Command jq -ErrorAction SilentlyContinue)) { throw "unwire-handover-dir: jq required" }
+    if (-not (Test-Path $SettingsPath)) { return }
+    $raw = Get-Content $SettingsPath -Raw
+    if ([string]::IsNullOrWhiteSpace($raw)) { return }
+    $raw | jq -e . > $null 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "unwire-handover-dir: $SettingsPath is not valid JSON -- refusing to modify" }
+    $filter = 'del(.env.HANDOVER_DIR) | if (has("env") and (.env == {})) then del(.env) else . end'
+    $out = $raw | jq --indent 2 $filter
+    if ($LASTEXITCODE -ne 0) { throw "unwire-handover-dir: jq transform failed" }
+    $tmp = "$SettingsPath.unwirehd.tmp"
+    # UTF-8 without BOM (HIMMEL-365/408): Set-Content -Encoding utf8 BOMs on PS 5.1.
+    [System.IO.File]::WriteAllText($tmp, ($out -join "`n") + "`n")
+    Move-Item -Path $tmp -Destination $SettingsPath -Force
+    Write-Host "  removed env.HANDOVER_DIR (if present) -> $SettingsPath"
+}
+
+if ($SettingsPath) {
+    try { Remove-HandoverDir -SettingsPath $SettingsPath } catch { Write-Error $_; exit 1 }
+}

--- a/scripts/lib/unwire-handover-dir.sh
+++ b/scripts/lib/unwire-handover-dir.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# unwire-handover-dir.sh -- remove env.HANDOVER_DIR from a Claude Code
+# settings.json (the inverse of wire-handover-dir.sh; HIMMEL install/uninstall
+# symmetry). Written by `adopt --profile luna/all`, so this matters for
+# luna-scaffolded installs. All other env keys are preserved; an env object
+# left empty is pruned.
+#
+# Usage:
+#   bash unwire-handover-dir.sh <settings-json-path>
+#
+# Idempotent (absent key / absent file -> no-op), atomic (temp file + mv),
+# refuses invalid JSON, preserves all sibling keys. Requires jq. Source it to
+# call unwire_handover_dir directly, or invoke via bash.
+set -euo pipefail
+
+unwire_handover_dir() {
+  local settings="$1"
+  command -v jq >/dev/null 2>&1 || { echo "unwire-handover-dir: jq required" >&2; return 1; }
+  [ -f "$settings" ] || return 0
+  local base
+  base=$(cat "$settings")
+  [ -z "$(printf '%s' "$base" | tr -d '[:space:]')" ] && return 0
+  if ! printf '%s' "$base" | jq -e . >/dev/null 2>&1; then
+    echo "unwire-handover-dir: $settings is not valid JSON -- refusing to modify" >&2
+    return 1
+  fi
+  printf '%s' "$base" | jq '
+    del(.env.HANDOVER_DIR)
+    | if (has("env") and (.env == {})) then del(.env) else . end
+  ' > "$settings.unwirehd.tmp" && mv "$settings.unwirehd.tmp" "$settings"
+  echo "  removed env.HANDOVER_DIR (if present) -> $settings"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  [ "$#" -eq 1 ] || { echo "usage: unwire-handover-dir.sh <settings-json-path>" >&2; exit 2; }
+  unwire_handover_dir "$1"
+fi

--- a/scripts/lib/wire-handover-dir.ps1
+++ b/scripts/lib/wire-handover-dir.ps1
@@ -1,0 +1,81 @@
+# wire-handover-dir.ps1 -- PowerShell counterpart of wire-handover-dir.sh
+# (HIMMEL-839). Sets .env.HANDOVER_DIR in a Claude Code settings.json to the
+# handover state root. Sibling of wire-luna-vault.ps1 -- same shape, but a
+# different key. MERGES into the existing .env object (preserving
+# LUNA_VAULT_PATH / HIMMEL_REPO and any other env keys) instead of replacing a
+# single top-level object.
+#
+# Dot-source to get Set-HandoverDir, or invoke directly:
+#   pwsh -File wire-handover-dir.ps1 -SettingsPath <path> -HandoverDir <path>
+#
+# Idempotent, atomic (temp + move), non-destructive (other keys preserved; file
+# + parent dir created if absent). Normalizes JSON through `jq --indent 2` when
+# jq is on PATH (matches the luna-vault twin), else falls back to ConvertTo-Json.
+
+[CmdletBinding()]
+param(
+    [string]$SettingsPath,
+    [string]$HandoverDir
+)
+
+function Set-HandoverDir {
+    param(
+        [Parameter(Mandatory = $true)] [string]$SettingsPath,
+        [Parameter(Mandatory = $true)] [string]$HandoverDir
+    )
+
+    # Forward-slash so the stored value is a valid Git-Bash path even when a
+    # caller passes a Windows backslash path.
+    $hdirFwd = $HandoverDir.Replace('\', '/')
+
+    if (Test-Path $SettingsPath) {
+        $raw = Get-Content $SettingsPath -Raw
+        if ([string]::IsNullOrWhiteSpace($raw)) {
+            $cfg = [pscustomobject]@{}
+        } else {
+            try {
+                $cfg = $raw | ConvertFrom-Json
+            } catch {
+                # Throw (not Write-Error+return): the entry point converts this to
+                # `exit 1` so `-File` callers see a non-zero code, matching the
+                # bash twin's `return 1`.
+                throw "wire-handover-dir: $SettingsPath is not valid JSON -- refusing to overwrite"
+            }
+        }
+    } else {
+        $dir = Split-Path $SettingsPath
+        if ($dir) { New-Item -ItemType Directory -Force $dir | Out-Null }
+        $cfg = [pscustomobject]@{}
+    }
+
+    # Ensure an .env object exists, then set/replace only the HANDOVER_DIR
+    # member (all sibling env keys preserved).
+    if (-not $cfg.PSObject.Properties['env'] -or $null -eq $cfg.env) {
+        $cfg | Add-Member -NotePropertyName env -NotePropertyValue ([pscustomobject]@{}) -Force
+    }
+    if ($cfg.env.PSObject.Properties['HANDOVER_DIR']) {
+        $cfg.env.HANDOVER_DIR = $hdirFwd
+    } else {
+        $cfg.env | Add-Member -NotePropertyName HANDOVER_DIR -NotePropertyValue $hdirFwd -Force
+    }
+
+    $json = $cfg | ConvertTo-Json -Depth 20
+    if (Get-Command jq -ErrorAction SilentlyContinue) {
+        $normalized = $json | jq --indent 2 .
+        if ($LASTEXITCODE -eq 0 -and $normalized) { $json = $normalized -join "`n" }
+    }
+    Set-Content -Path "$SettingsPath.new" -Value $json -Encoding utf8
+    Move-Item -Path "$SettingsPath.new" -Destination $SettingsPath -Force
+    Write-Host "  set env.HANDOVER_DIR -> $SettingsPath"
+}
+
+# Direct invocation (both args supplied) runs the function. Dot-sourcing with no
+# args just defines it.
+if ($SettingsPath -and $HandoverDir) {
+    try {
+        Set-HandoverDir -SettingsPath $SettingsPath -HandoverDir $HandoverDir
+    } catch {
+        Write-Error $_
+        exit 1
+    }
+}

--- a/scripts/lib/wire-handover-dir.sh
+++ b/scripts/lib/wire-handover-dir.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# wire-handover-dir.sh -- set env.HANDOVER_DIR in a Claude Code settings.json
+# to the handover state root (HIMMEL-839). handover_root()
+# (scripts/lib/handover-path.sh) reads HANDOVER_DIR straight from the process
+# env, so wiring it into settings.json's env stanza makes Mode B (external
+# state repo) resolve correctly for every session under this scope, without a
+# manual .env edit or shell export. adopt.sh calls this after scaffolding the
+# luna vault (--profile luna|all) so a fresh adopter's handover state lands in
+# the vault instead of silently defaulting to the inline <repo-root>/handovers/
+# stub (observed on a fresh ubuntu_new install with no prior state, HIMMEL-839
+# defect 2). Sibling of wire-luna-vault.sh -- same shape, different key.
+#
+# Usage:
+#   bash wire-handover-dir.sh <settings-json-path> <handover-dir>
+#
+# Sets:
+#   .env.HANDOVER_DIR = "<handover-dir forward-slashed>"   (all other .env keys
+#   preserved -- LUNA_VAULT_PATH / HIMMEL_REPO etc. are never clobbered).
+#
+# Idempotent (re-setting the same value is a no-op), atomic (temp file + mv),
+# non-destructive (other keys preserved; file + parent dir created if absent).
+# Requires jq. Source it to call wire_handover_dir directly, or invoke via bash
+# (the BASH_SOURCE guard below supports both).
+set -euo pipefail
+
+wire_handover_dir() {
+  local settings="$1" hdir="$2"
+  command -v jq >/dev/null 2>&1 || { echo "wire-handover-dir: jq required" >&2; return 1; }
+
+  # Forward-slash the path so the stored value is a valid Git-Bash path even
+  # when a caller passes a Windows backslash path.
+  local hdir_fwd="${hdir//\\//}"
+
+  mkdir -p "$(dirname "$settings")"
+  local base="{}"
+  if [ -s "$settings" ]; then
+    base=$(cat "$settings")
+    # An empty / whitespace-only file -> treat as {} (jq would choke on it).
+    # A non-empty but INVALID file -> refuse, rather than clobber data.
+    if [ -z "$(printf '%s' "$base" | tr -d '[:space:]')" ]; then
+      base="{}"
+    elif ! printf '%s' "$base" | jq -e . >/dev/null 2>&1; then
+      echo "wire-handover-dir: $settings is not valid JSON -- refusing to overwrite" >&2
+      return 1
+    fi
+  fi
+
+  printf '%s' "$base" | jq --arg hdir "$hdir_fwd" \
+    '.env = ((.env // {}) + { HANDOVER_DIR: $hdir })' \
+    > "$settings.handoverdir.tmp" && mv "$settings.handoverdir.tmp" "$settings"
+  echo "  set env.HANDOVER_DIR -> $settings"
+}
+
+# Allow both `source wire-handover-dir.sh` (to call wire_handover_dir directly)
+# and direct invocation `bash wire-handover-dir.sh <settings> <handover-dir>`.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  if [ "$#" -ne 2 ]; then
+    echo "usage: wire-handover-dir.sh <settings-json-path> <handover-dir>" >&2
+    exit 2
+  fi
+  wire_handover_dir "$1" "$2"
+fi

--- a/scripts/telegram/log-timestamp.test.ts
+++ b/scripts/telegram/log-timestamp.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+import { installTimestampedLogging } from "./log-timestamp";
+
+const ISO_PREFIX = /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\]$/;
+
+test("installTimestampedLogging prepends an ISO-8601 timestamp arg to log + error, preserving the original args", () => {
+  const logCalls: unknown[][] = [];
+  const errorCalls: unknown[][] = [];
+  // A fake target, not the real console — this must not touch global state
+  // (other test files share the process and would leak the wrap otherwise).
+  const target = {
+    log: (...args: unknown[]) => { logCalls.push(args); },
+    error: (...args: unknown[]) => { errorCalls.push(args); },
+  };
+  installTimestampedLogging(target as unknown as Console);
+  target.log("[poller] hello", 42);
+  target.error("[poller] boom");
+
+  expect(logCalls).toHaveLength(1);
+  expect(String(logCalls[0][0])).toMatch(ISO_PREFIX);
+  expect(logCalls[0].slice(1)).toEqual(["[poller] hello", 42]);
+
+  expect(errorCalls).toHaveLength(1);
+  expect(String(errorCalls[0][0])).toMatch(ISO_PREFIX);
+  expect(errorCalls[0].slice(1)).toEqual(["[poller] boom"]);
+});
+
+test("installTimestampedLogging does not touch the real global console (opt-in target only)", () => {
+  const originalLog = console.log;
+  const originalError = console.error;
+  const target = { log: () => {}, error: () => {} };
+  installTimestampedLogging(target as unknown as Console);
+  expect(console.log).toBe(originalLog);
+  expect(console.error).toBe(originalError);
+});

--- a/scripts/telegram/log-timestamp.ts
+++ b/scripts/telegram/log-timestamp.ts
@@ -1,0 +1,19 @@
+// Timestamp every console.log/console.error line (HIMMEL-1401). supervisor.log
+// carries none today: restart-bridge.ps1 launches `bun supervisor.ts > log 2>&1`,
+// and supervisor.ts spawns poller.ts with stdout/stderr "inherit" — both write
+// raw console output straight into that redirected file. A Telegram-API-side
+// outage (e.g. a Bad Gateway storm) then shows up as a bare run of identical
+// lines with no way to tell when it started, how long it lasted, or when it
+// ended short of correlating file mtimes with run logs (2026-07-30 incident).
+//
+// Wraps `target.log`/`target.error` in place, prefixing an ISO-8601 timestamp
+// arg ahead of the caller's own args — so every existing call site (across this
+// file and everything it imports, in-process) gets a timestamp with no change at
+// the call site itself. `target` defaults to the real `console`; tests pass a
+// fake object so this is verifiable without mutating global state.
+export function installTimestampedLogging(target: Pick<Console, "log" | "error"> = console): void {
+  const rawLog = target.log.bind(target);
+  const rawError = target.error.bind(target);
+  target.log = ((...args: unknown[]) => rawLog(`[${new Date().toISOString()}]`, ...args)) as Console["log"];
+  target.error = ((...args: unknown[]) => rawError(`[${new Date().toISOString()}]`, ...args)) as Console["error"];
+}

--- a/scripts/telegram/poller.test.ts
+++ b/scripts/telegram/poller.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readNewLines, readMeta, writeMeta, ensureSession, appendLine, sessionDir } from "./bus";
-import { ingestUpdates, loadOffset, handleInbound, handleAutoCommand, replyViaOutbox, runAndSettle, reconcile, flushOutboxes, isRetryDue, peekPending, commitPending, makeRunFn, makeAllow, makeDispatcher, makeFetchVoice, sweepStuckRunning, signalTyping, guarded, deliverAllPending, sweepAttachments, resolveRetentionMs, noticeText, parseBridgeEnv, loadBridgeEnv, bridgeEnvOrigin, makeRestart, makeBurstCoalescer, intervalEnvMs, windowEnvMs, handleBatch, RESTART_WATCHDOG_MS, type FetchImageFn } from "./poller";
+import { ingestUpdates, loadOffset, handleInbound, handleAutoCommand, replyViaOutbox, runAndSettle, reconcile, flushOutboxes, isRetryDue, peekPending, commitPending, makeRunFn, makeAllow, makeDispatcher, makeFetchVoice, sweepStuckRunning, signalTyping, guarded, deliverAllPending, sweepAttachments, resolveRetentionMs, noticeText, parseBridgeEnv, loadBridgeEnv, bridgeEnvOrigin, makeRestart, makeBurstCoalescer, intervalEnvMs, windowEnvMs, handleBatch, RESTART_WATCHDOG_MS, getUpdatesBackoffMs, shouldAlertOutage, OUTAGE_ALERT_AFTER_MS, type FetchImageFn } from "./poller";
 import { readFile, writeFile, mkdir, utimes } from "node:fs/promises";
 import { GROUP_ANONYMOUS_BOT_ID, isAllowed, isOperatorIdentity, vaultForChat } from "./gate";
 import { describeEnabledOps, KNOWN_OPS } from "./auto-action";
@@ -2753,4 +2753,31 @@ test("one session's dispatch failure does not abort the flush of others", async 
   await c.flushDue(now);                   // must not reject
   expect(runs).toEqual(["fine"]);          // the healthy session still went
   expect(c.isHolding("boom")).toBe(false); // and the failed hold was released
+});
+
+// --- getUpdates outage backoff + prolonged-outage alert (HIMMEL-1401) ---
+
+test("getUpdatesBackoffMs: 0 failures = no backoff; grows 1s -> 2s -> 4s ... capped at 30s", () => {
+  expect(getUpdatesBackoffMs(0)).toBe(0);
+  expect(getUpdatesBackoffMs(1)).toBe(1000);
+  expect(getUpdatesBackoffMs(2)).toBe(2000);
+  expect(getUpdatesBackoffMs(3)).toBe(4000);
+  expect(getUpdatesBackoffMs(4)).toBe(8000);
+  expect(getUpdatesBackoffMs(5)).toBe(16000);
+  expect(getUpdatesBackoffMs(6)).toBe(30000);   // 32s would-be value clamps to the cap
+  expect(getUpdatesBackoffMs(20)).toBe(30000);  // stays capped, never grows unbounded
+});
+
+test("shouldAlertOutage: silent before the threshold, fires once at it, then re-fires only after a full interval", () => {
+  const start = 1_000_000;
+  // Before threshold — never alerts, first-alert or repeat.
+  expect(shouldAlertOutage(start, start, null)).toBe(false);
+  expect(shouldAlertOutage(start + OUTAGE_ALERT_AFTER_MS - 1, start, null)).toBe(false);
+  // Crosses the threshold — first alert fires.
+  expect(shouldAlertOutage(start + OUTAGE_ALERT_AFTER_MS, start, null)).toBe(true);
+  // Right after a first alert, does not immediately re-fire.
+  const firstAlertAt = start + OUTAGE_ALERT_AFTER_MS;
+  expect(shouldAlertOutage(firstAlertAt + 1000, start, firstAlertAt)).toBe(false);
+  // A full interval after the last alert, it re-fires (still ongoing).
+  expect(shouldAlertOutage(firstAlertAt + OUTAGE_ALERT_AFTER_MS, start, firstAlertAt)).toBe(true);
 });

--- a/scripts/telegram/poller.ts
+++ b/scripts/telegram/poller.ts
@@ -5,6 +5,7 @@ import { appendLine, atomicWrite, bridgeRoot, ensureSession, readMeta, writeMeta
 import { classify, type Route } from "./router";
 import { dispatchAutoAction, describeEnabledOps, KNOWN_OPS, appendAuditLine, type RunScriptFn, type AuditFields } from "./auto-action";
 import { getUpdates, sendMessage, sendChatAction, getFile, downloadFile } from "./telegram-api";
+import { installTimestampedLogging } from "./log-timestamp";
 import { isAllowed, isGroupAllowed, isOperatorIdentity, loadAccess, vaultForChat, type Access } from "./gate";
 import { runSession, buildPrompt, BASH_BIN, type BusPaths, type PermissionMode } from "./run";
 import { classifyForSpawn, type TriageVerdict, type TriageModelOverride } from "./triage";
@@ -1445,7 +1446,42 @@ export async function replyViaOutbox(root: string, chat_id: number, text: string
   await appendLine(join(sessionDir(root, session), "outbox.jsonl"), JSON.stringify({ text }));
 }
 
+// --- getUpdates outage handling (HIMMEL-1401) ---
+// Before this, a non-ok getUpdates response (e.g. a Telegram-API-side Bad
+// Gateway storm) returned [] silently and the main loop's catch — the ONLY
+// place that slept — was never reached, so the loop re-hit the API every tick
+// with zero delay for as long as the outage lasted. getUpdates now throws on
+// non-ok (telegram-api.ts), routing it through the same catch as a network
+// error; these two pure helpers decide how long to back off and when a
+// still-ongoing outage is loud enough to need a log marker.
+
+// Grows 1s -> 2s -> 4s ... capped at 30s across consecutive getUpdates
+// failures; the caller resets to 0 on the next successful call, so a healthy
+// poll never carries residual delay from a past outage.
+export function getUpdatesBackoffMs(consecutiveFails: number): number {
+  if (consecutiveFails <= 0) return 0;
+  return Math.min(30_000, 1000 * 2 ** (consecutiveFails - 1));
+}
+
+// How long getUpdates has to be failing continuously before the outage is
+// worth a loud log line (constant, not env-tunable — this is a fixed
+// observability threshold, not an operator-facing knob).
+export const OUTAGE_ALERT_AFTER_MS = 5 * 60 * 1000;
+
+// Pure + testable without real timers. `outageStartedAt` is the ms timestamp of
+// the first consecutive failure in the current episode; `lastAlertAt` is null
+// until the first alert fires. True once the outage has run >= OUTAGE_ALERT_AFTER_MS
+// AND (no alert has fired yet OR a full interval has passed since the last one) —
+// so a stuck outage keeps re-announcing itself at a bounded rate (a later reader
+// can see it was still down, not just that it once was) instead of alerting once
+// and going silent for the rest of the outage.
+export function shouldAlertOutage(now: number, outageStartedAt: number, lastAlertAt: number | null): boolean {
+  if (now - outageStartedAt < OUTAGE_ALERT_AFTER_MS) return false;
+  return lastAlertAt === null || now - lastAlertAt >= OUTAGE_ALERT_AFTER_MS;
+}
+
 export async function main(): Promise<void> {
+  installTimestampedLogging();
   const root = bridgeRoot();
   const repoCwd = process.env.HIMMEL_REPO ?? process.cwd();
   const bridgeEnv = await loadBridgeEnv();
@@ -1586,10 +1622,40 @@ export async function main(): Promise<void> {
   const FLUSH_MS = intervalEnvMs(process.env.TELEGRAM_FLUSH_MS, 1000);
   const flushTimer = setInterval(guarded(() => flushOutboxes(root, send)), FLUSH_MS);
   if (typeof flushTimer.unref === "function") flushTimer.unref();
+  // Outage tracking across loop iterations (HIMMEL-1401): consecutive getUpdates
+  // failures drive the backoff, outageStartedAt/lastOutageAlertAt drive the
+  // rate-limited log marker. All three reset together on the next clean call.
+  let pollFails = 0;
+  let outageStartedAt: number | null = null;
+  let lastOutageAlertAt: number | null = null;
   for (;;) {
     const offset = await loadOffset(root);
     let updates: any[] = [];
-    try { updates = await getUpdates(token, offset, 30); } catch (e) { console.error("[poller] getUpdates failed: " + e); await Bun.sleep(1000); continue; }
+    try {
+      updates = await getUpdates(token, offset, 30);
+      if (outageStartedAt !== null) {
+        const downSec = Math.round((Date.now() - outageStartedAt) / 1000);
+        console.error(`[poller] getUpdates recovered after ${pollFails} consecutive failure(s) — outage ran ~${downSec}s (started ${new Date(outageStartedAt).toISOString()})`);
+      }
+      pollFails = 0; outageStartedAt = null; lastOutageAlertAt = null;
+    } catch (e) {
+      pollFails++;
+      if (outageStartedAt === null) outageStartedAt = Date.now();
+      const backoffMs = getUpdatesBackoffMs(pollFails);
+      console.error(`[poller] getUpdates failed (consecutive=${pollFails}, backoff=${backoffMs}ms): ${e}`);
+      if (shouldAlertOutage(Date.now(), outageStartedAt, lastOutageAlertAt)) {
+        lastOutageAlertAt = Date.now();
+        const downMin = Math.round((Date.now() - outageStartedAt) / 60000);
+        // Log-only (HIMMEL-1401): no non-Telegram operator-alert path (e.g. a
+        // PushNotification/hermes hook) exists in this repo to raise this on —
+        // and Telegram itself is exactly what's down, so this can't alert
+        // through it either. The recovery line above closes the span for a
+        // later reader of this (now timestamped) log.
+        console.error(`[poller] *** PROLONGED OUTAGE: getUpdates has been failing continuously since ${new Date(outageStartedAt).toISOString()} (~${downMin}min) ***`);
+      }
+      await Bun.sleep(backoffMs);
+      continue;
+    }
     await ingestUpdates(root, updates, allow, fetchImage, fetchVoice, fetchDoc, notifyDocFail);
     const fresh = await readNewLines<Inbound>(join(root, "inbound.jsonl"), join(root, "inbound.jsonl.cursor"));
     // Per-BATCH, so it resets every poll tick: a chat whose fault persists is

--- a/scripts/telegram/spawn-claudex.test.ts
+++ b/scripts/telegram/spawn-claudex.test.ts
@@ -34,6 +34,21 @@ import {
 } from "./spawn-claudex";
 import { BASH_BIN } from "./run";
 
+// HIMMEL-1096 (codex-adv round 2): runClaudexSharedDispatch now trust-seeds
+// UNCONDITIONALLY (needsWorktreeAdd true or false), so every test below that
+// exercises it would otherwise read/rewrite the OPERATOR'S REAL ~/.claude.json
+// on every dispatch — slow (JSON parse/stringify of a live, 100KB+ file,
+// pushing already-borderline Windows subprocess timing over Bun's 5s default
+// test timeout — observed as spurious "lock release failed (rc=null)" +
+// EBUSY-on-cleanup once the timeout kills the process mid-dispatch) AND a
+// real side effect (leaves throwaway temp-worktree paths trusted in the
+// operator's live config forever). Point every ensureWorkspaceTrust call in
+// this file's tests at a scratch config instead. TRUST_WRITE_JITTER_MS=0
+// drops the (up to 500ms) launch-race jitter — the dedicated jitter behavior
+// is exercised by scripts/lib/test-ensure-workspace-trust.sh, not here.
+process.env.WORKSPACE_TRUST_CONFIG = join(tmpdir(), `spawn-claudex-test-trust-${process.pid}.json`);
+process.env.TRUST_WRITE_JITTER_MS = "0";
+
 // --- claudexSessionRoot ------------------------------------------------------
 
 test("claudexSessionRoot is OUTSIDE the poller's sessions/ tree and distinct from the GLM sessions root", () => {
@@ -288,6 +303,29 @@ test("runClaudexSharedDispatch: acquires under lane 'codex' (not 'glm'), restore
     expect(run(["config", "--worktree", "--get", "remote.origin.pushurl"], wt).stdout.toString().trim()).toBe("git@example.com:orig/repo.git");
     expect(lockStatus(repo, "feat/live-pr")).toBe("free");
   } finally { rmSync(repo, { recursive: true, force: true }); }
+});
+
+test("runClaudexSharedDispatch (HIMMEL-1096, codex-adv round): needsWorktreeAdd:false (REUSED worktree, gitAdd never called) still gets trust-seeded", async () => {
+  const { repo, wt } = makeSharedRepo();
+  const trustCfg = join(tmpdir(), `trust-reuse-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+  const prevCfg = process.env.WORKSPACE_TRUST_CONFIG;
+  process.env.WORKSPACE_TRUST_CONFIG = trustCfg;
+  try {
+    const res = await runClaudexSharedDispatch({
+      repoDir: repo, worktree: wt, branch: "feat/live-pr", needsWorktreeAdd: false, lockScript: LOCK_SCRIPT,
+      gitAdd: () => { throw new Error("gitAdd must NOT be called when needsWorktreeAdd is false"); },
+      runBody: async () => 0,
+    });
+    expect(res.ok).toBe(true);
+    const cfg = JSON.parse(readFileSync(trustCfg, "utf8"));
+    const keys = Object.keys(cfg.projects ?? {});
+    expect(keys.length).toBe(1);
+    expect(cfg.projects[keys[0]].hasTrustDialogAccepted).toBe(true);
+  } finally {
+    if (prevCfg === undefined) delete process.env.WORKSPACE_TRUST_CONFIG; else process.env.WORKSPACE_TRUST_CONFIG = prevCfg;
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(trustCfg, { force: true });
+  }
 });
 
 test("revalidateSharedWorktree: fresh worktree (needsWorktreeAdd) -> ok when the mapping is still absent, never checks dirtiness", () => {
@@ -1040,9 +1078,14 @@ test("own-branch (flag-less) path mints its own branch with -b, no shared lock (
 
 test("shared-branch lock is acquired BEFORE any worktree mutation (wiring pin)", () => {
   const src = readFileSync("scripts/telegram/spawn-claudex.ts", "utf8");
+  // acquire → worktree add → trust-seed (HIMMEL-1096, unconditional) → poison
   const acquireIdx = src.indexOf('"acquire", p.repoDir, p.branch, "codex"');
-  const addIdx = src.indexOf("if (p.needsWorktreeAdd) p.gitAdd()");
+  const addIdx = src.indexOf("if (p.needsWorktreeAdd) p.gitAdd();");
+  const trustIdx = src.indexOf("ensureWorkspaceTrust(p.worktree);");
   const poisonIdx = src.indexOf("poisonPushUrl(p.repoDir, p.worktree)");
+  expect(trustIdx).toBeGreaterThan(-1);
+  expect(acquireIdx).toBeLessThan(trustIdx);    // lock before trust-seed
+  expect(addIdx).toBeLessThan(trustIdx);        // worktree add before trust-seed
   expect(acquireIdx).toBeGreaterThan(-1);
   expect(acquireIdx).toBeLessThan(addIdx);
   expect(acquireIdx).toBeLessThan(poisonIdx);

--- a/scripts/telegram/spawn-claudex.ts
+++ b/scripts/telegram/spawn-claudex.ts
@@ -25,7 +25,7 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawn } from "bun";
 import { BASH_BIN, REPO_ROOT, killTree, detectContentFilter, type PermissionMode } from "./run";
-import { transcriptDirFor, poisonPushUrl, preflightWindowCheck, measureOverheadChars, finalMeta, POISON_SENTINEL, resolveProfileSettings, teardownMintedWorktree, DEFAULT_LANE_PROFILE, mintRetaskNonce, composeRetaskBlock, composeBashShapeWarning, composeOutboxWriteHint, composeWorkerSettings, refuseBypassPermissions, refuseUnknownPermissionMode, isHelpFlag } from "./spawn-glm";
+import { transcriptDirFor, poisonPushUrl, ensureWorkspaceTrust, preflightWindowCheck, measureOverheadChars, finalMeta, POISON_SENTINEL, resolveProfileSettings, teardownMintedWorktree, DEFAULT_LANE_PROFILE, mintRetaskNonce, composeRetaskBlock, composeBashShapeWarning, composeOutboxWriteHint, composeWorkerSettings, refuseBypassPermissions, refuseUnknownPermissionMode, isHelpFlag } from "./spawn-glm";
 // HIMMEL-1040 plugin profiles: same per-dispatch lean-profile injection as the
 // GLM lane. spawn-claudex dispatches through scripts/claude-codex, which already
 // screens + forwards --settings — so the resolved payload just rides its argv.
@@ -681,6 +681,10 @@ export async function runClaudexSharedDispatch(p: {
   try {
     if (p.revalidateClean) { const rv = p.revalidateClean(); if (!rv.ok) return rv; } // stale-clean guard, lock released in finally
     if (p.needsWorktreeAdd) p.gitAdd(); // NO -b: an existing branch, never minted here
+    // Unconditional (codex-adv, HIMMEL-1096 CR round): a REUSED managed
+    // worktree (needsWorktreeAdd=false) from a pre-change or failed dispatch
+    // may never have been trust-seeded — seeding is idempotent, so cover both.
+    ensureWorkspaceTrust(p.worktree);
     const priorRes = Bun.spawnSync(["git", "-C", p.worktree, "config", "--worktree", "--get", "remote.origin.pushurl"], { stdout: "pipe", stderr: "pipe" });
     if (priorRes.exitCode === 0) {
       const got = priorRes.stdout.toString().trim();
@@ -873,6 +877,7 @@ async function main(): Promise<void> {
   let code: number;
   if (!sharedMode) {
     g(["worktree", "add", worktree, "-b", branch]);
+    ensureWorkspaceTrust(worktree);
     poisonPushUrl(absCwd, worktree);
     // HIMMEL-1094: this dispatch MINTED both the worktree and the branch (-b), so
     // it owns them until the worker starts. Teardown is passed ONLY here — shared

--- a/scripts/telegram/spawn-glm.test.ts
+++ b/scripts/telegram/spawn-glm.test.ts
@@ -13,6 +13,7 @@ import {
   transcriptDirFor,
   glmSessionRoot,
   poisonPushUrl,
+  ensureWorkspaceTrust,
   planSpawn,
   planSharedSpawn,
   gitBranchExists,
@@ -46,6 +47,23 @@ import {
 import { BASH_BIN } from "./run";
 import type { SettingsConflict } from "./glm-env";
 import { composeGrantLine, nextGrantId, classifyShape, authorityGate, composeEscalationForRefusedGrant } from "./grants";
+
+// HIMMEL-1096 (codex-adv round 2): runSharedDispatch now trust-seeds
+// UNCONDITIONALLY (needsWorktreeAdd true or false), so every test below that
+// exercises it would otherwise read/rewrite the OPERATOR'S REAL ~/.claude.json
+// on every dispatch — slow (JSON parse/stringify of a live, 100KB+ file,
+// pushing already-borderline Windows subprocess timing over Bun's 5s default
+// test timeout — observed as spurious "lock release failed (rc=null)" +
+// EBUSY-on-cleanup once the timeout kills the process mid-dispatch) AND a
+// real side effect (leaves throwaway temp-worktree paths trusted in the
+// operator's live config forever). Point every ensureWorkspaceTrust call in
+// this file's tests at a scratch config instead. TRUST_WRITE_JITTER_MS=0
+// drops the (up to 500ms) launch-race jitter — the dedicated jitter behavior
+// is exercised by scripts/lib/test-ensure-workspace-trust.sh, not here.
+// (My own HIMMEL-1096 test below layers its OWN scoped override/restore on
+// top of this default for its byte-exact assertion — both compose cleanly.)
+process.env.WORKSPACE_TRUST_CONFIG = join(tmpdir(), `spawn-glm-test-trust-${process.pid}.json`);
+process.env.TRUST_WRITE_JITTER_MS = "0";
 
 test("session root is OUTSIDE the poller's sessions/ tree", () => {
   const root = glmSessionRoot();
@@ -206,14 +224,19 @@ test("main() writes shared_branch into runningMeta only in shared mode (wiring p
 
 test("shared-branch lock is acquired BEFORE any worktree mutation, and main() guards before dispatching (wiring pin)", () => {
   const src = readFileSync("scripts/telegram/spawn-glm.ts", "utf8");
-  // acquire → worktree add → poison ordering inside runSharedDispatch
+  // acquire → worktree add → trust-seed (HIMMEL-1096, unconditional) → poison
+  // ordering inside runSharedDispatch
   const acquireIdx = src.indexOf('"acquire", p.repoDir, p.branch, "glm"');
-  const addIdx = src.indexOf("if (p.needsWorktreeAdd) p.gitAdd()");
+  const addIdx = src.indexOf("if (p.needsWorktreeAdd) p.gitAdd();");
+  const trustIdx = src.indexOf("ensureWorkspaceTrust(p.worktree);");
   const poisonIdx = src.indexOf("poisonPushUrl(p.repoDir, p.worktree)");
   expect(acquireIdx).toBeGreaterThan(-1);
   expect(addIdx).toBeGreaterThan(-1);
+  expect(trustIdx).toBeGreaterThan(-1);
   expect(poisonIdx).toBeGreaterThan(-1);
   expect(acquireIdx).toBeLessThan(addIdx);      // lock before worktree add
+  expect(acquireIdx).toBeLessThan(trustIdx);    // lock before trust-seed
+  expect(addIdx).toBeLessThan(trustIdx);        // worktree add before trust-seed
   expect(acquireIdx).toBeLessThan(poisonIdx);   // lock before poison
   // main() runs the GLM guard before it dispatches into the shared lifecycle
   const guardIdx = src.indexOf("checkGlmGuards(worktree)");
@@ -368,6 +391,55 @@ test("runSharedDispatch (I7): needsWorktreeAdd:true invokes gitAdd exactly once 
     expect(adds).toBe(1);
     expect(lockStatus(repo, "feat/live-pr")).toBe("free");
   } finally { rmSync(repo, { recursive: true, force: true }); }
+});
+
+test("runSharedDispatch (HIMMEL-1096): needsWorktreeAdd:true pre-trusts the worktree via ensure-workspace-trust.sh", async () => {
+  const { repo, wt } = makeSharedRepo();
+  const trustCfg = join(tmpdir(), `trust-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+  const prevCfg = process.env.WORKSPACE_TRUST_CONFIG;
+  const prevJitter = process.env.TRUST_WRITE_JITTER_MS;
+  process.env.WORKSPACE_TRUST_CONFIG = trustCfg;
+  process.env.TRUST_WRITE_JITTER_MS = "0"; // no launch-race jitter needed for a single call
+  try {
+    const res = await runSharedDispatch({ repoDir: repo, worktree: wt, branch: "feat/live-pr", needsWorktreeAdd: true, lockScript: LOCK_SCRIPT, gitAdd: () => {}, runBody: async () => 0 });
+    expect(res.ok).toBe(true);
+    const cfg = JSON.parse(readFileSync(trustCfg, "utf8"));
+    const keys = Object.keys(cfg.projects ?? {});
+    expect(keys.length).toBe(1);
+    expect(cfg.projects[keys[0]].hasTrustDialogAccepted).toBe(true);
+  } finally {
+    if (prevCfg === undefined) delete process.env.WORKSPACE_TRUST_CONFIG; else process.env.WORKSPACE_TRUST_CONFIG = prevCfg;
+    if (prevJitter === undefined) delete process.env.TRUST_WRITE_JITTER_MS; else process.env.TRUST_WRITE_JITTER_MS = prevJitter;
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(trustCfg, { force: true });
+  }
+});
+
+test("ensureWorkspaceTrust is non-fatal: a bad dir never throws, just warns", () => {
+  expect(() => ensureWorkspaceTrust(join(tmpdir(), "himmel-no-such-dir-1096"))).not.toThrow();
+});
+
+test("runSharedDispatch (HIMMEL-1096, codex-adv round): needsWorktreeAdd:false (REUSED worktree, gitAdd never called) still gets trust-seeded", async () => {
+  const { repo, wt } = makeSharedRepo();
+  const trustCfg = join(tmpdir(), `trust-reuse-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+  const prevCfg = process.env.WORKSPACE_TRUST_CONFIG;
+  process.env.WORKSPACE_TRUST_CONFIG = trustCfg;
+  try {
+    const res = await runSharedDispatch({
+      repoDir: repo, worktree: wt, branch: "feat/live-pr", needsWorktreeAdd: false, lockScript: LOCK_SCRIPT,
+      gitAdd: () => { throw new Error("gitAdd must NOT be called when needsWorktreeAdd is false"); },
+      runBody: async () => 0,
+    });
+    expect(res.ok).toBe(true);
+    const cfg = JSON.parse(readFileSync(trustCfg, "utf8"));
+    const keys = Object.keys(cfg.projects ?? {});
+    expect(keys.length).toBe(1);
+    expect(cfg.projects[keys[0]].hasTrustDialogAccepted).toBe(true);
+  } finally {
+    if (prevCfg === undefined) delete process.env.WORKSPACE_TRUST_CONFIG; else process.env.WORKSPACE_TRUST_CONFIG = prevCfg;
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(trustCfg, { force: true });
+  }
 });
 
 // --- gitIsDirty / gitBranchExists (CR round 2 F1): the REAL git-probe

--- a/scripts/telegram/spawn-glm.ts
+++ b/scripts/telegram/spawn-glm.ts
@@ -442,6 +442,31 @@ export function poisonPushUrl(repoRoot: string, worktree: string): void {
   g(["config", "--worktree", "remote.origin.pushurl", POISON_SENTINEL], worktree);
 }
 
+// HIMMEL-1096: pre-trust a freshly-created worktree in Claude Code's config
+// (~/.claude.json) so the spawned worker's `claude` launch does not stall on
+// the interactive workspace-trust prompt — an unattended GLM/claudex dispatch
+// has no human present to answer it. Delegates to the shared helper
+// (scripts/lib/ensure-workspace-trust.sh, HIMMEL-386), already used by
+// arm-resume.sh and vmsdk.py for the same reason. Exported (mirrors
+// poisonPushUrl) so the claudex lane reuses it as-is. Non-fatal by the
+// helper's own contract (documented there: any nonzero exit is warn-and-
+// continue, never abort) — a trust pre-seed failure must never block a spawn.
+export function ensureWorkspaceTrust(worktree: string): void {
+  const script = join(REPO_ROOT, "scripts", "lib", "ensure-workspace-trust.sh");
+  try {
+    // env: process.env (CR-round finding, this ticket): Bun.spawnSync's default
+    // env is a snapshot from process start, NOT live process.env at call time —
+    // a runtime override (WORKSPACE_TRUST_CONFIG/TRUST_WRITE_JITTER_MS, the
+    // helper's own test seams) would silently miss the child without this.
+    const r = Bun.spawnSync([BASH_BIN, script, worktree], { stdout: "pipe", stderr: "pipe", env: process.env });
+    if (r.exitCode !== 0) {
+      console.error(`spawn-glm: WARNING - workspace-trust pre-seed failed for ${worktree} (rc=${r.exitCode}); spawn continues, first launch may prompt to trust the folder: ${r.stderr.toString().trim()}`);
+    }
+  } catch (e) {
+    console.error(`spawn-glm: WARNING - workspace-trust pre-seed threw (${String((e as any)?.message ?? e)}); spawn continues, first launch may prompt to trust the folder`);
+  }
+}
+
 export type SpawnPlan = { ok: true; slug: string; worktree: string; branch: string; warnings: SettingsConflict[] } | { ok: false; reason: string };
 // Pure decision logic — deps injected so every refusal branch is testable.
 export function planSpawn(
@@ -849,6 +874,10 @@ export async function runSharedDispatch(p: {
   let poisoned = false;
   try {
     if (p.needsWorktreeAdd) p.gitAdd(); // NO -b: an existing branch, never minted here
+    // Unconditional (codex-adv, HIMMEL-1096 CR round): a REUSED managed
+    // worktree (needsWorktreeAdd=false) from a pre-change or failed dispatch
+    // may never have been trust-seeded — seeding is idempotent, so cover both.
+    ensureWorkspaceTrust(p.worktree);
     // Capture any pre-existing per-worktree pushurl immediately before
     // poisoning so the finally can restore exactly what was there. Crash-
     // recovery constraint (I2): a prior shared-mode run that crashed between
@@ -1105,6 +1134,7 @@ async function main(): Promise<void> {
   let code: number;
   if (!sharedMode) {
     g(["worktree", "add", worktree, "-b", branch]);
+    ensureWorkspaceTrust(worktree);
     poisonPushUrl(absCwd, worktree);
     // HIMMEL-1094: this dispatch MINTED both the worktree and the branch (-b), so
     // it owns them until the worker starts. Teardown is passed ONLY here — shared

--- a/scripts/telegram/supervisor.ts
+++ b/scripts/telegram/supervisor.ts
@@ -2,6 +2,7 @@ import { spawn } from "bun";
 import { mkdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { bridgeRoot } from "./bus";
+import { installTimestampedLogging } from "./log-timestamp";
 
 export function breakerTrips(consecutiveImmediateFails: number, maxFails: number): boolean {
   return consecutiveImmediateFails >= maxFails;
@@ -106,6 +107,7 @@ export function killBridge(killFn: (pid: number) => void = (pid) => process.kill
 }
 
 async function main(): Promise<void> {
+  installTimestampedLogging();   // HIMMEL-1401: every supervisor.log line gets an ISO timestamp
   if (process.argv.includes("--kill")) { process.exit(killBridge()); }
   writePidfile({ supervisor: process.pid, poller: null });
   let fails = 0;

--- a/scripts/telegram/telegram-api.test.ts
+++ b/scripts/telegram/telegram-api.test.ts
@@ -22,6 +22,38 @@ test("getUpdates returns [] on a malformed ok:true with no result array (no thro
   const r = await getUpdates("TOKEN", 0, 30, fakeFetch as any);
   expect(r).toEqual([]);
 });
+test("getUpdates THROWS on a non-ok response (HIMMEL-1401) so the poller's catch can back off instead of hot-looping", async () => {
+  const fakeFetch = async () => new Response(JSON.stringify({ ok: false, description: "Bad Gateway" }), { status: 502 });
+  await expect(getUpdates("TOKEN", 0, 30, fakeFetch as any)).rejects.toThrow(/Bad Gateway/);
+});
+test("getUpdates non-ok error falls back to the HTTP status when description is absent", async () => {
+  const fakeFetch = async () => new Response(JSON.stringify({ ok: false }), { status: 502 });
+  await expect(getUpdates("TOKEN", 0, 30, fakeFetch as any)).rejects.toThrow(/502/);
+});
+test("getUpdates aborts a stalled request within its client-side deadline (HIMMEL-1401 CR round 2) — a transport that never resolves must still REJECT, not hang forever, so the poller's catch/backoff fires", async () => {
+  // Models a stuck transport: the fetch promise never resolves on its own, only
+  // rejecting when the AbortSignal getUpdates wires up actually fires — exactly
+  // what a real fetch implementation does under an AbortSignal (this is the same
+  // contract getFile/downloadFile already rely on for FILE_FETCH_TIMEOUT_MS).
+  // `timeout=0` and a 20ms abortMarginMs keep the deadline (0*1000+20=20ms) tiny
+  // so the test doesn't wait out a real long-poll window.
+  const stallForever = (_url: string, init?: { signal?: AbortSignal }) =>
+    new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(new Error("The operation was aborted.")));
+    });
+  const start = Date.now();
+  await expect(getUpdates("TOKEN", 0, 0, stallForever as any, 20)).rejects.toThrow();
+  expect(Date.now() - start).toBeLessThan(2000);   // rejected via the 20ms deadline, not left hanging
+});
+test("getUpdates passes an AbortSignal to fetch so a stalled request CAN be aborted (wiring pin)", async () => {
+  let sawSignal: AbortSignal | undefined;
+  const fakeFetch = async (_url: string, init?: { signal?: AbortSignal }) => {
+    sawSignal = init?.signal;
+    return new Response(JSON.stringify({ ok: true, result: [] }));
+  };
+  await getUpdates("TOKEN", 0, 30, fakeFetch as any);
+  expect(sawSignal).toBeInstanceOf(AbortSignal);
+});
 test("sendMessage honors 429 retry_after then succeeds", async () => {
   let n = 0; const sleeps: number[] = [];
   const fakeFetch = async () => { n++;

--- a/scripts/telegram/telegram-api.ts
+++ b/scripts/telegram/telegram-api.ts
@@ -2,10 +2,33 @@ import { writeFile } from "node:fs/promises";
 
 const API = (t: string, m: string) => `https://api.telegram.org/bot${t}/${m}`;
 type F = typeof fetch;
-export async function getUpdates(token: string, offset: number, timeout = 30, f: F = fetch): Promise<any[]> {
-  const res = await f(API(token, "getUpdates") + `?offset=${offset}&timeout=${timeout}`);
+// A non-ok response (HIMMEL-1401 — e.g. a Telegram-API-side Bad Gateway storm)
+// THROWS instead of returning []. poller.ts's main loop already wraps getUpdates
+// in a try/catch for network errors; folding the API-level failure into that same
+// path lets it back off instead of hot-looping with zero delay, which is what a
+// silent [] used to produce. An ok:true call still never throws (below) — that
+// path stays fail-open for a malformed result array.
+//
+// Client-side abort deadline (HIMMEL-1401 CR round 2 — codex adversarial pass).
+// `timeout` above is only a QUERY PARAMETER telling Telegram how long to hold the
+// connection open server-side; it does NOT bound the fetch itself. Without a
+// client-side abort, a stalled transport (or a response whose body never
+// completes) left `await f(...)` / `await res.json()` pending forever — no
+// reject, so the catch/backoff above (and the HIMMEL-1401 outage marker) never
+// fired, and the bridge went silently deaf while the process stayed alive and
+// the supervisor saw nothing wrong. The deadline is set slightly LONGER than the
+// server-side long-poll timeout, so a healthy long poll — which returns at or
+// before `timeout` seconds, whether from an update arriving or Telegram's own
+// timeout — is never cut short. Per the WHATWG fetch spec, aborting a signal
+// aborts BOTH the in-flight request and, once headers have arrived, the response
+// body stream, so this one signal covers res.json() too — the same pattern
+// getFile/downloadFile below already use for FILE_FETCH_TIMEOUT_MS.
+const GETUPDATES_ABORT_MARGIN_MS = 10_000;
+export async function getUpdates(token: string, offset: number, timeout = 30, f: F = fetch, abortMarginMs = GETUPDATES_ABORT_MARGIN_MS): Promise<any[]> {
+  const res = await f(API(token, "getUpdates") + `?offset=${offset}&timeout=${timeout}`,
+    { signal: AbortSignal.timeout(timeout * 1000 + abortMarginMs) });
   const j: any = await res.json();
-  if (!j.ok) { console.error(`[telegram] getUpdates not ok: ${j.description ?? res.status}`); return []; }
+  if (!j.ok) throw new Error(`getUpdates not ok: ${j.description ?? res.status}`);
   return j.result ?? [];   // tolerate a malformed ok:true with no result array (never throw downstream)
 }
 // Best-effort "typing…" indicator (HIMMEL-260). No retries, failures swallowed —

--- a/scripts/test-adopt.sh
+++ b/scripts/test-adopt.sh
@@ -54,10 +54,26 @@ if [ -e "$real_jira_node_modules" ]; then
   node_modules_backup="$work/node_modules-backup"
   mv "$real_jira_node_modules" "$node_modules_backup"
 fi
+# HIMMEL-839 CR round-2: the repo-.env-preserve scenario below temporarily
+# writes a HANDOVER_DIR= line into THIS repo's real .env ($HIMMEL_ROOT is
+# resolved by adopt.sh from its own script path — not overridable via HOME —
+# so there is no fake-checkout stand-in for it). Declared here, set only at
+# the point of mutation, and restored unconditionally in cleanup() — same
+# backup-then-trap-restore shape as the jira dist/node_modules pair above, so
+# a `fail()` (which exits immediately) mid-scenario can never strand a
+# mutated .env in the real worktree.
+real_env="$repo_root/.env"
+env_backup=""
+env_mutated=0
 cleanup() {
   rm -rf "$real_jira_dist" "$real_jira_node_modules"
   if [ -n "$dist_backup" ]; then mv "$dist_backup" "$real_jira_dist"; fi
   if [ -n "$node_modules_backup" ]; then mv "$node_modules_backup" "$real_jira_node_modules"; fi
+  if [ -n "$env_backup" ]; then
+    mv "$env_backup" "$real_env"
+  elif [ "$env_mutated" -eq 1 ]; then
+    rm -f "$real_env"
+  fi
   rm -rf "$work"
 }
 trap cleanup EXIT
@@ -221,6 +237,60 @@ lv=$(jq -r '.env.LUNA_VAULT_PATH' "$vault/.claude/settings.json" 2>/dev/null)
 [ "$lv" = "$(norm "$vault")" ] || fail "luna/project did not persist LUNA_VAULT_PATH ([$lv] != [$(norm "$vault")])"
 echo "ok: luna scaffolds the vault + persists LUNA_VAULT_PATH (project scope)"
 
+# HIMMEL-839: luna profile also seeds HANDOVER_DIR at <vault>/handovers so a
+# fresh adopter's handover state doesn't silently default to the inline
+# <repo-root>/handovers stub.
+hd=$(jq -r '.env.HANDOVER_DIR' "$vault/.claude/settings.json" 2>/dev/null)
+[ "$hd" = "$(norm "$vault/handovers")" ] || fail "luna/project did not persist HANDOVER_DIR ([$hd] != [$(norm "$vault/handovers")])"
+[ -d "$vault/handovers" ] || fail "luna/project did not create <vault>/handovers"
+echo "ok: luna scaffolds the vault + persists HANDOVER_DIR (project scope)"
+
+# ── 4b. HIMMEL-839 CR round-2: PRESERVE an existing settings.json HANDOVER_DIR ──
+# A routine re-adopt must reproduce state, never silently reset an
+# operator-selected root (own settings.json env.HANDOVER_DIR from a prior
+# /handover-setup or adopt run).
+preserve_vault="$work/preserve-vault"
+preserve_target="$work/preserve-target"; mkdir -p "$preserve_target/.claude"
+printf '%s' '{"env":{"HANDOVER_DIR":"/some/operator/chosen/handovers"}}' > "$preserve_target/.claude/settings.json"
+out=$(HOME="$base_home" bash "$adopt" --profile luna --target "$preserve_target" --luna-target "$preserve_vault" 2>&1)
+hd=$(jq -r '.env.HANDOVER_DIR' "$preserve_target/.claude/settings.json" 2>/dev/null)
+[ "$hd" = "/some/operator/chosen/handovers" ] || fail "HIMMEL-839 preserve: existing settings.json HANDOVER_DIR was overwritten ([$hd])"
+printf '%s' "$out" | grep -q 'leaving it' || fail "HIMMEL-839 preserve: missing the leaving-it message (got: $out)"
+echo "ok: HIMMEL-839 preserves an existing settings.json env.HANDOVER_DIR (re-adopt reproduces, not resets)"
+
+# ── 4c. HIMMEL-839 CR round-2: PRESERVE an existing repo .env HANDOVER_DIR ──
+# The other place HANDOVER_DIR can already live: the primary checkout's own
+# .env (set-handover-dir.sh / Mode B — what /handover-setup actually writes).
+# settings.json env takes PROCESS-ENV precedence over .env, so writing it here
+# would silently shadow that choice even with the .env file itself untouched.
+if [ -f "$real_env" ]; then
+  env_backup="$work/env-backup"
+  mv "$real_env" "$env_backup"
+fi
+printf 'HANDOVER_DIR=/some/dotenv/handovers\n' > "$real_env"
+env_mutated=1
+preserve_vault2="$work/preserve-vault2"
+preserve_target2="$work/preserve-target2"; mkdir -p "$preserve_target2"
+out=$(HOME="$base_home" bash "$adopt" --profile luna --target "$preserve_target2" --luna-target "$preserve_vault2" 2>&1)
+if [ -n "$env_backup" ]; then mv "$env_backup" "$real_env"; env_backup=""; else rm -f "$real_env"; fi
+env_mutated=0
+hd=$(jq -r '.env.HANDOVER_DIR // "ABSENT"' "$preserve_target2/.claude/settings.json" 2>/dev/null)
+[ "$hd" = "ABSENT" ] || fail "HIMMEL-839 preserve: .env-configured HANDOVER_DIR was shadowed by a settings.json write ([$hd])"
+printf '%s' "$out" | grep -q 'via /handover-setup' || fail "HIMMEL-839 preserve: missing the .env-preserve message (got: $out)"
+echo "ok: HIMMEL-839 preserves an existing repo .env HANDOVER_DIR (does not shadow it via settings.json)"
+
+# ── 4d. HIMMEL-839 CR round-2: canonicalize a relative --luna-target ────────
+# A relative --luna-target must not persist a CWD-dependent relative path.
+relhome="$work/relhome"; mkdir -p "$relhome"
+relbase="$work/relbase"; mkdir -p "$relbase"
+( cd "$relbase" && HOME="$relhome" bash "$adopt" --profile luna --luna-target "rel-vault" >/dev/null )
+relsettings="$relbase/.claude/settings.json"
+hd=$(jq -r '.env.HANDOVER_DIR' "$relsettings" 2>/dev/null)
+expected_rel="$(norm "$relbase/rel-vault/handovers")"
+[ "$hd" = "$expected_rel" ] || fail "HIMMEL-839 canonicalize: relative --luna-target persisted a wrong/non-canonical HANDOVER_DIR ([$hd] != [$expected_rel])"
+case "$hd" in /*|[A-Za-z]:/*) : ;; *) fail "HIMMEL-839 canonicalize: HANDOVER_DIR is not absolute: $hd" ;; esac
+echo "ok: HIMMEL-839 canonicalizes a relative --luna-target to an absolute HANDOVER_DIR"
+
 # ── 6. all — core→--target, vault→--luna-target (no leak) ────────────────────
 allrepo="$work/allrepo"; allvault="$work/allvault"; mkdir -p "$allrepo"
 HOME="$base_home" bash "$adopt" --profile all --scope project --target "$allrepo" --luna-target "$allvault" >/dev/null
@@ -230,7 +300,12 @@ HOME="$base_home" bash "$adopt" --profile all --scope project --target "$allrepo
 # F1 (HIMMEL-458): project scope wires LUNA_VAULT_PATH=$allvault into $allrepo/.claude.
 lv=$(jq -r '.env.LUNA_VAULT_PATH' "$allrepo/.claude/settings.json" 2>/dev/null)
 [ "$lv" = "$(norm "$allvault")" ] || fail "all/project did not persist LUNA_VAULT_PATH ([$lv] != [$(norm "$allvault")])"
-echo "ok: all routes core→--target, vault→--luna-target (no leak) + persists LUNA_VAULT_PATH"
+# HIMMEL-839: same for HANDOVER_DIR=$allvault/handovers — this is the exact
+# --profile all repro shape from the ticket (VM adopter needed HANDOVER_DIR
+# set manually; adopt.sh should seed it).
+hd=$(jq -r '.env.HANDOVER_DIR' "$allrepo/.claude/settings.json" 2>/dev/null)
+[ "$hd" = "$(norm "$allvault/handovers")" ] || fail "all/project did not persist HANDOVER_DIR ([$hd] != [$(norm "$allvault/handovers")])"
+echo "ok: all routes core→--target, vault→--luna-target (no leak) + persists LUNA_VAULT_PATH + HANDOVER_DIR"
 
 # ── 7. core/user idempotency (re-run into populated ~/.claude keeps 3) ────────
 HOME="$home" bash "$adopt" --profile core --scope user --target "$work/ignored" >/dev/null
@@ -244,6 +319,11 @@ HOME="$fh" bash "$adopt" --profile all --scope user --target "$work/ign-a" --lun
 got=$(jq -r '.env.LUNA_VAULT_PATH' "$fh/.claude/settings.json")
 [ "$got" = "$(norm "$fv")" ] || fail "F1-SC1(a) all/user: LUNA_VAULT_PATH=[$got] != [$(norm "$fv")]"
 echo "ok: F1-SC1(a) all/user --luna-target persists LUNA_VAULT_PATH"
+# HIMMEL-839: this is the literal ticket repro shape (`adopt.sh --profile all
+# --scope user --luna-target ...`) — HANDOVER_DIR must land in ~/.claude too.
+got=$(jq -r '.env.HANDOVER_DIR' "$fh/.claude/settings.json")
+[ "$got" = "$(norm "$fv/handovers")" ] || fail "HIMMEL-839 all/user: HANDOVER_DIR=[$got] != [$(norm "$fv/handovers")]"
+echo "ok: HIMMEL-839 all/user --luna-target persists HANDOVER_DIR"
 
 # 8b. F1-SC1(b): luna/user --target -> env.LUNA_VAULT_PATH in ~/.claude.
 fh2="$work/f1b-home"; mkdir -p "$fh2"; fv2="$work/f1b-vault"
@@ -330,6 +410,10 @@ printf '%s' "$out" | grep -q 'DRY: qmd_install'      || fail "dry-run missing qm
 printf '%s' "$out" | grep -q 'DRY: qmd pull'         || fail "dry-run missing qmd pull DRY line"
 printf '%s' "$out" | grep -q 'DRY: qmd_register_collection .* himmel$' || fail "dry-run missing himmel register DRY line"
 printf '%s' "$out" | grep -q 'DRY: qmd_register_collection .* luna$'   || fail "dry-run missing luna register DRY line"
+# HIMMEL-839: dry-run must also report the HANDOVER_DIR seed step (no mkdir,
+# no settings.json write — mirrors the mkdir-then-wire pair as DRY lines).
+printf '%s' "$out" | grep -q 'DRY: mkdir -p .*/qvault/handovers$' || fail "dry-run missing HANDOVER_DIR mkdir DRY line"
+printf '%s' "$out" | grep -q 'DRY: wire env.HANDOVER_DIR' || fail "dry-run missing HANDOVER_DIR wire DRY line"
 printf '%s' "$out" | grep -q 'Wiring graphify (opt-in' || fail "dry-run --with-graphify missing the graphify wiring banner"
 printf '%s' "$out" | grep -q 'DRY: graphify_install'   || fail "dry-run --with-graphify missing graphify_install DRY line"
 # HIMMEL-1047: --with-graphify also registers the MCP server at the adopt scope

--- a/scripts/test-clean-garden-accounting.sh
+++ b/scripts/test-clean-garden-accounting.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Hermetic coverage for clean-garden full accounting (HIMMEL-1410): every kept
+# worktree gets a what+why row, squash-merged tips are compared to the recorded
+# PR head, and remote-only branches are classified from one cached PR listing.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLEAN_GARDEN="$SCRIPT_DIR/clean-garden.sh"
+
+PASS=0
+FAIL=0
+TMP_ROOT=""
+
+# shellcheck disable=SC2317,SC2329  # invoked indirectly by the EXIT trap
+cleanup() {
+    if [ -n "$TMP_ROOT" ] && [ -d "$TMP_ROOT" ]; then
+        rm -rf "$TMP_ROOT" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; if [ $# -ge 2 ]; then printf '    %s\n' "$2"; fi; FAIL=$((FAIL+1)); }
+
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/himmel-clean-accounting.XXXXXX")
+TMP_ROOT_UNIX="$TMP_ROOT"
+if command -v cygpath >/dev/null 2>&1; then
+    TMP_ROOT=$(cygpath -m "$TMP_ROOT")
+fi
+REPO="$TMP_ROOT/repo"
+git init -q --initial-branch=main "$REPO" 2>/dev/null || {
+    git init -q "$REPO"
+    git -C "$REPO" symbolic-ref HEAD refs/heads/main || true
+}
+git -C "$REPO" config user.email t@test.com
+git -C "$REPO" config user.name t
+printf 'base\n' > "$REPO/README"
+git -C "$REPO" add README
+git -C "$REPO" commit -q -m "base"
+git -C "$REPO" branch -m main 2>/dev/null || true
+git -C "$REPO" remote add origin https://github.com/owner/repo.git
+git -C "$REPO" remote add puborigin https://github.com/public/repo.git
+MAIN_SHA=$(git -C "$REPO" rev-parse main)
+git -C "$REPO" update-ref refs/remotes/origin/main "$MAIN_SHA"
+git -C "$REPO" update-ref refs/remotes/puborigin/main "$MAIN_SHA"
+
+mk_wt_commit() {
+    local name="$1" branch="$2" wt
+    wt="$TMP_ROOT/$name"
+    git -C "$REPO" worktree add -q "$wt" -b "$branch" >/dev/null 2>&1
+    printf '%s\n' "$branch" > "$wt/${name}.txt"
+    git -C "$wt" add "${name}.txt"
+    git -C "$wt" commit -q -m "$branch"
+    printf '%s\n' "$wt"
+}
+
+WT_OPEN=$(mk_wt_commit wt-open feat/open)
+OPEN_SHA=$(git -C "$WT_OPEN" rev-parse HEAD)
+WT_MERGED=$(mk_wt_commit wt-merged feat/merged-clean)
+MERGED_SHA=$(git -C "$WT_MERGED" rev-parse HEAD)
+WT_POST=$(mk_wt_commit wt-post feat/post-merge)
+POST_MERGED_SHA=$(git -C "$WT_POST" rev-parse HEAD)
+printf 'after merge\n' >> "$WT_POST/wt-post.txt"
+git -C "$WT_POST" commit -q -am "post merge work"
+WT_PARKED=$(mk_wt_commit wt-parked feat/parked)
+PARKED_SHA=$(git -C "$WT_PARKED" rev-parse HEAD)
+printf 'untracked work\n' > "$WT_PARKED/notes.txt"
+mk_wt_commit wt-none feat/no-pr >/dev/null
+WT_DETACHED="$TMP_ROOT/wt-detached"
+git -C "$REPO" worktree add -q --detach "$WT_DETACHED" main >/dev/null 2>&1
+printf 'detached work\n' > "$WT_DETACHED/detached.txt"
+git -C "$WT_DETACHED" add detached.txt
+git -C "$WT_DETACHED" commit -q -m "detached work"
+DETACHED_SHA=$(git -C "$WT_DETACHED" rev-parse HEAD)
+
+# Remote-only tips. commit-tree avoids creating local branches/worktrees for
+# these fixtures while still producing real commits for merge-base checks.
+TREE=$(git -C "$REPO" rev-parse "main^{tree}")
+REMOTE_MERGED=$(printf 'remote merged\n' | git -C "$REPO" commit-tree "$TREE" -p "$MAIN_SHA")
+REMOTE_OLD=$(printf 'remote old\n' | git -C "$REPO" commit-tree "$TREE" -p "$MAIN_SHA")
+REMOTE_NEW=$(printf 'remote new\n' | git -C "$REPO" commit-tree "$TREE" -p "$REMOTE_OLD")
+REMOTE_CLOSED=$(printf 'remote closed\n' | git -C "$REPO" commit-tree "$TREE" -p "$MAIN_SHA")
+REMOTE_NONE=$(printf 'remote none\n' | git -C "$REPO" commit-tree "$TREE" -p "$MAIN_SHA")
+REMOTE_OPEN=$(printf 'remote open\n' | git -C "$REPO" commit-tree "$TREE" -p "$MAIN_SHA")
+REMOTE_PUBLIC=$(printf 'remote public\n' | git -C "$REPO" commit-tree "$TREE" -p "$MAIN_SHA")
+git -C "$REPO" update-ref refs/remotes/origin/chore/merged-clean "$REMOTE_MERGED"
+git -C "$REPO" update-ref refs/remotes/origin/chore/post-merge "$REMOTE_NEW"
+git -C "$REPO" update-ref refs/remotes/origin/chore/closed "$REMOTE_CLOSED"
+git -C "$REPO" update-ref refs/remotes/origin/chore/no-pr "$REMOTE_NONE"
+git -C "$REPO" update-ref refs/remotes/origin/chore/open "$REMOTE_OPEN"
+git -C "$REPO" update-ref refs/remotes/puborigin/chore/public-no-pr "$REMOTE_PUBLIC"
+
+GH_ROWS_ORIGIN="$TMP_ROOT_UNIX/origin.tsv"
+GH_ROWS_PUBLIC="$TMP_ROOT_UNIX/public.tsv"
+GH_CALLS="$TMP_ROOT_UNIX/gh-calls"
+{
+    printf 'owner/repo\tfeat/open\topen\t%s\n' "$OPEN_SHA"
+    printf 'owner/repo\tfeat/merged-clean\tmerged\t%s\n' "$MERGED_SHA"
+    printf 'owner/repo\tfeat/post-merge\tmerged\t%s\n' "$POST_MERGED_SHA"
+    printf 'owner/repo\tfeat/parked\tmerged\t%s\n' "$PARKED_SHA"
+    printf 'owner/repo\tchore/merged-clean\tmerged\t%s\n' "$REMOTE_MERGED"
+    printf 'owner/repo\tchore/post-merge\tmerged\t%s\n' "$REMOTE_OLD"
+    printf 'owner/repo\tchore/closed\tclosed\t%s\n' "$REMOTE_CLOSED"
+    printf 'owner/repo\tchore/open\topen\t%s\n' "$REMOTE_OPEN"
+} > "$GH_ROWS_ORIGIN"
+: > "$GH_ROWS_PUBLIC"
+: > "$GH_CALLS"
+
+STUB_DIR="$TMP_ROOT_UNIX/bin"
+mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+if echo "$args" | grep -q "auth status"; then exit 0; fi
+if echo "$args" | grep -q "repo view"; then echo "owner/repo"; exit 0; fi
+if echo "$args" | grep -q "api --paginate repos/owner/repo/pulls"; then
+    printf 'origin\n' >> "$GH_CALLS"
+    cat "$GH_ROWS_ORIGIN"
+    exit 0
+fi
+if echo "$args" | grep -q "api --paginate repos/public/repo/pulls"; then
+    printf 'puborigin\n' >> "$GH_CALLS"
+    cat "$GH_ROWS_PUBLIC"
+    exit 0
+fi
+if echo "$args" | grep -q -- "--state open"; then exit 0; fi
+exit 0
+STUB
+chmod +x "$STUB_DIR/gh"
+
+run_clean() {
+    (
+        export PATH="${STUB_DIR}:${PATH}"
+        export GH_ROWS_ORIGIN GH_ROWS_PUBLIC GH_CALLS
+        cd "$REPO" || exit 1
+        bash "$CLEAN_GARDEN" --prune-only "$@" 2>&1
+    )
+}
+
+assert_line() {
+    local name="$1" output="$2" first="$3" second="${4:-}"
+    if printf '%s\n' "$output" | grep -F "$first" | grep -Fq "$second"; then
+        pass "$name"
+    else
+        fail "$name" "$output"
+    fi
+}
+
+echo "RUN A: origin accounting"
+out=$(run_clean)
+
+if [ ! -d "$WT_MERGED" ]; then
+    pass "exact merged PR head is pruned"
+else
+    fail "exact merged PR head was kept" "$out"
+fi
+if [ -d "$WT_POST" ]; then
+    pass "post-merge branch tip is kept"
+else
+    fail "post-merge branch tip was wrongly pruned" "$out"
+fi
+
+assert_line "open worktree is ACTIVE" "$out" "branch=feat/open pr=open" "verdict=ACTIVE"
+assert_line "post-merge worktree is UNKNOWN" "$out" "branch=feat/post-merge pr=merged" "verdict=UNKNOWN"
+assert_line "post-merge why names tip mismatch" "$out" "branch=feat/post-merge" "why=branch tip differs from merged PR head"
+assert_line "dirty merged worktree is PARKED-WIP" "$out" "branch=feat/parked pr=merged" "untracked=1"
+assert_line "dirty merged worktree verdict" "$out" "branch=feat/parked pr=merged" "verdict=PARKED-WIP"
+assert_line "no-PR worktree is explicit UNKNOWN" "$out" "branch=feat/no-pr pr=none" "verdict=UNKNOWN"
+assert_line "detached worktree is accounted" "$out" "branch=(detached:${DETACHED_SHA:0:12})" "verdict=UNKNOWN"
+
+keep_count=$(printf '%s\n' "$out" | grep -c '^KEEP clean-garden:')
+if [ "$keep_count" -eq 6 ]; then
+    pass "every one of 6 kept worktrees has one accounting row"
+else
+    fail "expected 6 kept-worktree rows, got $keep_count" "$out"
+fi
+
+assert_line "remote merged head is MERGED-CLEAN" "$out" "remote=origin branch=chore/merged-clean" "category=MERGED-CLEAN"
+assert_line "remote post-merge tip is TIP-DIFFERS" "$out" "remote=origin branch=chore/post-merge" "category=TIP-DIFFERS"
+assert_line "remote closed PR is CLOSED-UNMERGED" "$out" "remote=origin branch=chore/closed" "category=CLOSED-UNMERGED"
+assert_line "remote branch without PR is NO-PR" "$out" "remote=origin branch=chore/no-pr" "category=NO-PR"
+if printf '%s\n' "$out" | grep -Fq "remote=origin branch=chore/open"; then
+    fail "open-PR remote branch should not be an orphan row" "$out"
+else
+    pass "open-PR remote branch is excluded from orphan rows"
+fi
+assert_line "loud summary counts risk classes" "$out" "ALERT clean-garden: attention required" "TIP-DIFFERS, 1 NO-PR"
+
+origin_calls=$(grep -c '^origin$' "$GH_CALLS")
+if [ "$origin_calls" -eq 1 ]; then
+    pass "origin PRs fetched once for the whole run"
+else
+    fail "expected one origin PR API call, got $origin_calls" "$out"
+fi
+if printf '%s\n' "$out" | grep -Fq "remote=puborigin"; then
+    fail "puborigin was reported without the opt-in flag" "$out"
+else
+    pass "puborigin is disabled by default"
+fi
+
+echo "RUN B: puborigin opt-in"
+pub_out=$(run_clean --include-puborigin)
+assert_line "puborigin opt-in reports remote orphan" "$pub_out" "remote=puborigin branch=chore/public-no-pr" "category=NO-PR"
+pub_calls=$(grep -c '^puborigin$' "$GH_CALLS")
+if [ "$pub_calls" -eq 1 ]; then
+    pass "puborigin PRs fetched once when requested"
+else
+    fail "expected one puborigin PR API call, got $pub_calls" "$pub_out"
+fi
+
+echo
+echo "===================================="
+echo "test summary: $PASS passed, $FAIL failed"
+echo "===================================="
+if [ "$FAIL" -gt 0 ]; then exit 1; fi
+exit 0

--- a/scripts/test-clean-prune-strays.sh
+++ b/scripts/test-clean-prune-strays.sh
@@ -53,6 +53,12 @@ cat > "$STUB_DIR/gh" <<'STUB'
 args="$*"
 if echo "$args" | grep -q "auth status"; then exit 0; fi
 if echo "$args" | grep -q "repo view"; then echo "owner/repo"; exit 0; fi
+if echo "$args" | grep -q "api --paginate repos/owner/repo/pulls"; then
+    while IFS=' ' read -r branch sha; do
+        printf 'owner/repo\t%s\tmerged\t%s\n' "$branch" "$sha"
+    done < <(git for-each-ref --format='%(refname:short) %(objectname)' refs/heads/feat)
+    exit 0
+fi
 if echo "$args" | grep -q -- "--state merged"; then echo "1"; exit 0; fi
 if echo "$args" | grep -q -- "--state open"; then exit 0; fi
 exit 0

--- a/scripts/test-uninstall.ps1
+++ b/scripts/test-uninstall.ps1
@@ -21,7 +21,15 @@ $script:Failed = 0
 $Cli = Join-Path $PSScriptRoot 'uninstall.ps1'
 
 function Assert-Rc {
-    param([string]$Label, [int]$Expected, [int]$Actual)
+    # HIMMEL-839 CR round-2: [int]-typed Expected/Actual made every non-numeric
+    # call in the SC6 settings-unwire block (e.g. 'statusLine removed' 'null'
+    # ...) throw a non-terminating ParameterBindingArgumentTransformation
+    # error -- PowerShell writes it to the error stream and silently skips
+    # the call (no PASS/FAIL, no $script:Failed increment), so ~12 assertions
+    # (incl. the file-diff checks at the end) were never actually evaluated
+    # and the suite still reported ALL PASS. [string] compares correctly for
+    # both the genuine rc callers (0/1/2 as strings) and these value callers.
+    param([string]$Label, [string]$Expected, [string]$Actual)
     if ($Actual -eq $Expected) {
         Write-Host "PASS $Label (rc=$Actual)"
     } else {
@@ -341,7 +349,7 @@ function Unregister-ScheduledTask {
         @'
 {
   "statusLine": {"type":"command","command":"bash \"C:/h/scripts/statusline/bin/statusline.sh\""},
-  "env": {"HIMMEL_REPO":"C:/h","LUNA_VAULT_PATH":"C:/v","KEEP_ME":"1"},
+  "env": {"HIMMEL_REPO":"C:/h","LUNA_VAULT_PATH":"C:/v","HANDOVER_DIR":"C:/v/handovers","KEEP_ME":"1"},
   "hooks": {
     "PreToolUse": [
       {"matcher":"Bash","hooks":[
@@ -374,6 +382,7 @@ function Unregister-ScheduledTask {
     Assert-Rc 'statusLine removed'      'null' (JqU '.statusLine // "null"')
     Assert-Rc 'HIMMEL_REPO removed'     'null' (JqU '.env.HIMMEL_REPO // "null"')
     Assert-Rc 'LUNA_VAULT_PATH removed' 'null' (JqU '.env.LUNA_VAULT_PATH // "null"')
+    Assert-Rc 'HANDOVER_DIR removed'    'null' (JqU '.env.HANDOVER_DIR // "null"')
     Assert-Rc 'non-himmel env kept'     '1'    (JqU '.env.KEEP_ME')
     Assert-Rc 'UNIVERSAL hook removed'  '0'    (JqU '[.hooks.PreToolUse[].hooks[].command|select(test("auto-approve-safe-bash"))]|length')
     Assert-Rc 'rtk guard preserved'     '1'    (JqU '[.hooks.PreToolUse[].hooks[].command|select(test("rtk-hook-guard"))]|length')

--- a/scripts/test-uninstall.sh
+++ b/scripts/test-uninstall.sh
@@ -417,7 +417,7 @@ seed_settings() {
   cat > "$HIMMEL_USER_SETTINGS" <<'JSON'
 {
   "statusLine": {"type":"command","command":"bash \"C:/h/scripts/statusline/bin/statusline.sh\""},
-  "env": {"HIMMEL_REPO":"C:/h","LUNA_VAULT_PATH":"C:/v","KEEP_ME":"1"},
+  "env": {"HIMMEL_REPO":"C:/h","LUNA_VAULT_PATH":"C:/v","HANDOVER_DIR":"C:/v/handovers","KEEP_ME":"1"},
   "hooks": {
     "PreToolUse": [
       {"matcher":"Bash","hooks":[
@@ -447,6 +447,7 @@ assert_has "[6/6] banner present" "[6/6] Unwiring" "$out"
 assert_rc "statusLine removed"      "null"   "$(jq -r '.statusLine // "null"' "$HIMMEL_USER_SETTINGS")"
 assert_rc "HIMMEL_REPO removed"     "null"   "$(jq -r '.env.HIMMEL_REPO // "null"' "$HIMMEL_USER_SETTINGS")"
 assert_rc "LUNA_VAULT_PATH removed" "null"   "$(jq -r '.env.LUNA_VAULT_PATH // "null"' "$HIMMEL_USER_SETTINGS")"
+assert_rc "HANDOVER_DIR removed"    "null"   "$(jq -r '.env.HANDOVER_DIR // "null"' "$HIMMEL_USER_SETTINGS")"
 assert_rc "non-himmel env kept"     "1"      "$(jq -r '.env.KEEP_ME' "$HIMMEL_USER_SETTINGS")"
 assert_rc "UNIVERSAL hook removed"  "0"      "$(jq -r '[.hooks.PreToolUse[].hooks[].command|select(test("auto-approve-safe-bash"))]|length' "$HIMMEL_USER_SETTINGS")"
 assert_rc "rtk guard preserved"     "1"      "$(jq -r '[.hooks.PreToolUse[].hooks[].command|select(test("rtk-hook-guard"))]|length' "$HIMMEL_USER_SETTINGS")"

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -8,7 +8,8 @@
 #   [4/6] uninstall Claude plugins + marketplaces (uninstall-plugins.ps1)
 #   [5/6] uninstall git hooks (pre-commit/pre-push/commit-msg)
 #   [6/6] unwire ~/.claude/settings.json (statusLine, env.HIMMEL_REPO,
-#         env.LUNA_VAULT_PATH, the UNIVERSAL hooks — what setup.ps1/adopt wired)
+#         env.LUNA_VAULT_PATH, env.HANDOVER_DIR, the UNIVERSAL hooks — what
+#         setup.ps1/adopt wired)
 #
 # Destructive. Fail-closed: without -Yes an interactive run prompts; a
 # non-interactive run aborts (rc=2). -DryRun prints actions only.
@@ -80,7 +81,7 @@ if (-not $SkipHooks) {
 }
 if (-not $SkipSettings) {
     Write-Host "  6. unwire ~/.claude/settings.json (statusLine, HIMMEL_REPO,"
-    Write-Host "     LUNA_VAULT_PATH, UNIVERSAL hooks -- non-himmel keys untouched)"
+    Write-Host "     LUNA_VAULT_PATH, HANDOVER_DIR, UNIVERSAL hooks -- non-himmel keys untouched)"
 } else {
     Write-Host "  6. keep ~/.claude/settings.json wiring (-SkipSettings)"
 }
@@ -302,20 +303,21 @@ Write-Host ""
 
 # --- [6/6] unwire user-scope settings.json (HIMMEL-460) ----------------------
 # Symmetric inverse of setup.ps1 [9/10] + adopt -Scope user: remove the
-# statusLine, env.HIMMEL_REPO, env.LUNA_VAULT_PATH, and the UNIVERSAL hooks.
-# Each helper removes ONLY its own key/stanza (refuses invalid JSON, preserves
-# every non-himmel key). The single-key helpers have no dry-run flag, so -DryRun
-# is gated here; unwire-pretooluse-hooks has its own switch.
-Write-Host "[6/6] Unwiring ~/.claude/settings.json (statusLine, HIMMEL_REPO, LUNA_VAULT_PATH, hooks)..."
+# statusLine, env.HIMMEL_REPO, env.LUNA_VAULT_PATH, env.HANDOVER_DIR
+# (HIMMEL-839), and the UNIVERSAL hooks. Each helper removes ONLY its own
+# key/stanza (refuses invalid JSON, preserves every non-himmel key). The
+# single-key helpers have no dry-run flag, so -DryRun is gated here;
+# unwire-pretooluse-hooks has its own switch.
+Write-Host "[6/6] Unwiring ~/.claude/settings.json (statusLine, HIMMEL_REPO, LUNA_VAULT_PATH, HANDOVER_DIR, hooks)..."
 if ($SkipSettings) {
     Write-Host "  kept (-SkipSettings)."
 } elseif (-not (Test-Path $UserSettings)) {
     Write-Host "  no $UserSettings -- nothing to unwire."
 } elseif ($DryRun) {
-    Write-Host "DRY: unwire statusLine (himmel), env.HIMMEL_REPO, env.LUNA_VAULT_PATH from $UserSettings"
+    Write-Host "DRY: unwire statusLine (himmel), env.HIMMEL_REPO, env.LUNA_VAULT_PATH, env.HANDOVER_DIR from $UserSettings"
     & pwsh -NoProfile -File (Join-Path $RepoRoot 'scripts\lib\unwire-pretooluse-hooks.ps1') -SettingsPath $UserSettings -DryRun
 } else {
-    foreach ($u in @('unwire-statusline', 'unwire-himmel-repo', 'unwire-luna-vault')) {
+    foreach ($u in @('unwire-statusline', 'unwire-himmel-repo', 'unwire-luna-vault', 'unwire-handover-dir')) {
         & pwsh -NoProfile -File (Join-Path $RepoRoot "scripts\lib\$u.ps1") -SettingsPath $UserSettings
         if ($LASTEXITCODE -ne 0) {
             Write-Host "  WARN: $u reported a problem; setup-state may remain." -ForegroundColor Yellow

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -11,7 +11,8 @@
 #         (machine-setup/uninstall-plugins.sh — user-scope, affects all repos)
 #   [5/6] uninstall git hooks (pre-commit/pre-push/commit-msg)
 #   [6/6] unwire ~/.claude/settings.json (statusLine, env.HIMMEL_REPO,
-#         env.LUNA_VAULT_PATH, the UNIVERSAL hooks — what setup.sh/adopt wired)
+#         env.LUNA_VAULT_PATH, env.HANDOVER_DIR, the UNIVERSAL hooks — what
+#         setup.sh/adopt wired)
 #
 # Destructive. Fail-closed: without --yes an interactive run prompts; a
 # non-interactive run aborts (rc=2). --dry-run prints every action without
@@ -124,7 +125,7 @@ else
 fi
 if [ "$SKIP_SETTINGS" -eq 0 ]; then
   echo "  6. unwire ~/.claude/settings.json (statusLine, HIMMEL_REPO,"
-  echo "     LUNA_VAULT_PATH, UNIVERSAL hooks — non-himmel keys untouched)"
+  echo "     LUNA_VAULT_PATH, HANDOVER_DIR, UNIVERSAL hooks — non-himmel keys untouched)"
 else
   echo "  6. keep ~/.claude/settings.json wiring (--skip-settings)"
 fi
@@ -363,11 +364,12 @@ echo ""
 
 # --- [6/6] unwire user-scope settings.json (HIMMEL-460) ----------------------
 # Symmetric inverse of setup.sh [9/10] + adopt --scope user: remove the
-# statusLine, env.HIMMEL_REPO, env.LUNA_VAULT_PATH, and the UNIVERSAL hooks that
-# himmel wired into ~/.claude/settings.json. Each helper removes ONLY its own
-# key/stanza (refuses invalid JSON, preserves every non-himmel key: rtk guard,
-# the operator's own hooks, MCP config). --dry-run flows through to each.
-echo "[6/6] Unwiring ~/.claude/settings.json (statusLine, HIMMEL_REPO, LUNA_VAULT_PATH, hooks)..."
+# statusLine, env.HIMMEL_REPO, env.LUNA_VAULT_PATH, env.HANDOVER_DIR
+# (HIMMEL-839), and the UNIVERSAL hooks that himmel wired into
+# ~/.claude/settings.json. Each helper removes ONLY its own key/stanza
+# (refuses invalid JSON, preserves every non-himmel key: rtk guard, the
+# operator's own hooks, MCP config). --dry-run flows through to each.
+echo "[6/6] Unwiring ~/.claude/settings.json (statusLine, HIMMEL_REPO, LUNA_VAULT_PATH, HANDOVER_DIR, hooks)..."
 _user_settings="$USER_SETTINGS"
 if [ "$SKIP_SETTINGS" -eq 1 ]; then
   echo "  kept (--skip-settings)."
@@ -376,11 +378,11 @@ elif [ ! -f "$_user_settings" ]; then
 elif [ "$DRY_RUN" -eq 1 ]; then
   # The single-key unwire helpers have no dry-run flag, so gate at this level to
   # keep --dry-run a true no-op (SC6). unwire-pretooluse-hooks has its own flag.
-  echo "DRY: unwire statusLine (himmel), env.HIMMEL_REPO, env.LUNA_VAULT_PATH from $_user_settings"
+  echo "DRY: unwire statusLine (himmel), env.HIMMEL_REPO, env.LUNA_VAULT_PATH, env.HANDOVER_DIR from $_user_settings"
   bash "$REPO_ROOT/scripts/lib/unwire-pretooluse-hooks.sh" "$_user_settings" 1 \
     || echo "  WARN: unwire-pretooluse-hooks dry-run reported a problem." >&2
 else
-  for _unwire in unwire-statusline unwire-himmel-repo unwire-luna-vault; do
+  for _unwire in unwire-statusline unwire-himmel-repo unwire-luna-vault unwire-handover-dir; do
     if ! bash "$REPO_ROOT/scripts/lib/$_unwire.sh" "$_user_settings"; then
       echo "  WARN: $_unwire reported a problem; setup-state may remain." >&2
     fi

--- a/templates/luna-second-brain/scripts/test-upgrade.sh
+++ b/templates/luna-second-brain/scripts/test-upgrade.sh
@@ -432,5 +432,44 @@ assert_eq "T27 multi-hunk does not advance the stamp" "0.1.0" "$got_ver"
 # A conflict must also exit non-zero.
 if [ "$rc" -ne 0 ]; then pass "T27 multi-hunk conflict exits non-zero"; else fail "T27 multi-hunk conflict exits non-zero" "rc=0"; fi
 
+# ---------------------------------------------------------------------------
+# T28 (HIMMEL-525): bundled plugin assets (main.js, manifest.json, styles.css
+# under .obsidian/plugins/*/) are FIRST-POPULATION ONLY (skipexists), never
+# overwrite. A vault whose installed plugin is NEWER than the template bundle
+# must NOT be downgraded (live incident: obsidian-local-rest-api 4.1.3 -> 4.0.1,
+# qmd-as-md-obsidian 0.4.3 -> 0.3.4). data.json is already skipexists (T4); the
+# three asset files now match it.
+#   (a) downgrade protection — a newer installed plugin is left byte-identical.
+#   (b) first-population — an ABSENT plugin is still seeded from the bundle.
+T="$TMP/t28-tmpl"; V="$TMP/t28-vault"; make_template "$T" "1.0.0"
+mkdir -p "$V/.obsidian/plugins/obsidian-local-rest-api"; stamp_vault "$V" "0.1.0"
+# Template BUNDLES the plugin at an OLDER version (4.0.1).
+mkdir -p "$T/.obsidian/plugins/obsidian-local-rest-api"
+printf '{"id":"obsidian-local-rest-api","version":"4.0.1"}\n' > "$T/.obsidian/plugins/obsidian-local-rest-api/manifest.json"
+printf 'TEMPLATE-MAIN-JS-4.0.1\n'                              > "$T/.obsidian/plugins/obsidian-local-rest-api/main.js"
+printf 'TEMPLATE-STYLES-4.0.1\n'                               > "$T/.obsidian/plugins/obsidian-local-rest-api/styles.css"
+# Vault has the SAME plugin at a NEWER version (4.1.3) the adopter self-updated to.
+printf '{"id":"obsidian-local-rest-api","version":"4.1.3"}\n' > "$V/.obsidian/plugins/obsidian-local-rest-api/manifest.json"
+printf 'VAULT-MAIN-JS-4.1.3\n'                                 > "$V/.obsidian/plugins/obsidian-local-rest-api/main.js"
+printf 'VAULT-STYLES-4.1.3\n'                                  > "$V/.obsidian/plugins/obsidian-local-rest-api/styles.css"
+m_before=$(sha_of "$V/.obsidian/plugins/obsidian-local-rest-api/manifest.json")
+j_before=$(sha_of "$V/.obsidian/plugins/obsidian-local-rest-api/main.js")
+s_before=$(sha_of "$V/.obsidian/plugins/obsidian-local-rest-api/styles.css")
+run_upgrade --yes >/dev/null 2>&1
+assert_eq "T28 newer manifest.json NOT downgraded" "$m_before" "$(sha_of "$V/.obsidian/plugins/obsidian-local-rest-api/manifest.json")"
+assert_eq "T28 newer main.js NOT downgraded"       "$j_before" "$(sha_of "$V/.obsidian/plugins/obsidian-local-rest-api/main.js")"
+assert_eq "T28 newer styles.css NOT downgraded"    "$s_before" "$(sha_of "$V/.obsidian/plugins/obsidian-local-rest-api/styles.css")"
+# (b) first-population: a fresh vault with the plugin ABSENT must still be seeded.
+# NOTE: run_upgrade() closes over $V, so call upgrade.sh directly for the $V2
+# vault (same pattern T11/T16 use for a non-default vault dir).
+V2="$TMP/t28-vault-fp"; mkdir -p "$V2"; stamp_vault "$V2" "0.1.0"
+# Precondition (CR): the fixture must actually be plugin-absent, or (b) stops
+# covering first-population without failing.
+test ! -e "$V2/.obsidian/plugins/obsidian-local-rest-api"
+bash "$UPGRADE" --template-dir "$T" --vault-dir "$V2" --yes >/dev/null 2>&1
+assert_eq "T28 first-population seeds absent manifest.json" "$(sha_of "$T/.obsidian/plugins/obsidian-local-rest-api/manifest.json")" "$(sha_of "$V2/.obsidian/plugins/obsidian-local-rest-api/manifest.json")"
+assert_eq "T28 first-population seeds absent main.js"       "$(sha_of "$T/.obsidian/plugins/obsidian-local-rest-api/main.js")"       "$(sha_of "$V2/.obsidian/plugins/obsidian-local-rest-api/main.js")"
+assert_eq "T28 first-population seeds absent styles.css"    "$(sha_of "$T/.obsidian/plugins/obsidian-local-rest-api/styles.css")"    "$(sha_of "$V2/.obsidian/plugins/obsidian-local-rest-api/styles.css")"
+
 echo
 if [ "$FAILED" -eq 0 ]; then echo "All upgrade tests passed."; else echo "$FAILED test(s) failed."; exit 1; fi

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -238,7 +238,7 @@ classify() {
         _Templates/*.md)                              echo report ;;
         .obsidian/community-plugins.json)             echo jsonmerge ;;
         .obsidian/plugins/*/data.json)                echo skipexists ;;
-        .obsidian/plugins/*/main.js|.obsidian/plugins/*/manifest.json|.obsidian/plugins/*/styles.css) echo overwrite ;;
+        .obsidian/plugins/*/main.js|.obsidian/plugins/*/manifest.json|.obsidian/plugins/*/styles.css) echo skipexists ;;
         .obsidian/PLUGINS-SETUP.md)                   echo overwrite ;;
         .obsidian/app.json|.obsidian/appearance.json|.obsidian/graph.json|.obsidian/core-plugins.json) echo overwrite ;;
         scripts/*)                                    echo overwrite ;;


### PR DESCRIPTION
## Leg-13 wave (2026-07-31)

Propagates 12 private merges. Every PR was cross-model panel-gated (codex gpt-5.5 + glm-5.2, CR_REQUIRE_CROSS_MODEL) with a codex adversarial pass per branch; every Critical/Important candidate was fixed, evidence-disproved, or deferred with a ticket (HIMMEL-1411 trust-file race, HIMMEL-1412 plugin-dir atomicity, HIMMEL-1413 clean-garden hardening residuals).

### Highlights
- **Adopter experience**: fresh-install defects root-caused on the ubuntu_new VM (user-slug fallback bypass; HANDOVER_DIR never seeded) — fixed with preserve-on-re-adopt semantics per the migration standing (re-install reproduces, never resets). `/luna-upgrade` stops downgrading self-updated Obsidian plugins.
- **Lane reliability (HIMMEL-1096 line)**: spawned worktrees are pre-trusted (fresh AND reused), so unattended GLM/claudex dispatches no longer wedge on the trust prompt.
- **Telegram bridge**: the recurring "stopped responding" class — timestamped supervisor log, exponential backoff on non-ok getUpdates, prolonged-outage markers, and a client-side abort deadline on the long poll (a stalled transport previously hung the poller silently forever).
- **Truthful status**: himmelctl reconciles newly-added manifest items into existing installs; MCP probes are scope-aware (project `.mcp.json` vs user config — pre-existing bug fixed for all consumers).
- **Structural safety**: template content changes now require a version bump (pre-commit gate, merge-base-compared, deletion/rename safe); clean-garden accounts for every kept worktree and sweeps remote orphans — no silent keeps (born from this leg's loss audit, which recovered real stranded work).
- **Leak-scan policy change (operator-visible)**: the template leak seed narrowed from bare `luna-brain` (already-public branding) to the private locator `yotamleo/luna-brain`, with a one-time live-denylist migration — required for the template carve-out to ship at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
