### PR TITLE
fix: leg-16 wave — graphify corpus feedback-loop kill, guardrail-block status --json, qmd ship-index stop sweep

### DIFF
--- a/docs/internals/lane-calibration.md
+++ b/docs/internals/lane-calibration.md
@@ -51,9 +51,11 @@ silently drifts (the HIMMEL-1021 class) — this table is deliberately thin.
 
 `quota bank` reflects the `quota.bank` field in `lanes.json`; a lane without
 one is **dashboard-omitted** from the quota exporter (HIMMEL-1000) — that's a
-registry fact, not a doc gap.
+registry fact, not a doc gap. `cost-optimal context window` is exactly that —
+NOT a hard ceiling: larger inputs remain possible past it at higher cost (e.g.
+2× billing past 272k on the codex-quota lanes), per the registry's own wording.
 
-| Lane (`lanes.json` id) | Class | Default effort convention | Context ceiling | Quota bank | Calibration status |
+| Lane (`lanes.json` id) | Class | Default effort convention | Cost-optimal context window | Quota bank | Calibration status |
 |---|---|---|---|---|---|
 | `glm` — GLM lane (spawn-glm.ts) | impl | small-context discipline — chunk big plans | 1M | glm (flat-rate overflow, not per-token) | calibrated |
 | `glm-subagent` — GLM inline subagent | impl | same as `glm`, inline in-session dispatch | 1M | glm | calibrated |

--- a/docs/internals/lane-calibration.md
+++ b/docs/internals/lane-calibration.md
@@ -32,11 +32,42 @@ is data.
 | Fable 5 | judgment, taste — hardest calls; escalation target | scale to the item (operator 2026-07-08, un-capped): medium default; high for substantial judgment work — not just the hardest; xhigh for the hardest |
 
 Beyond the Claude tiers the fleet includes machine-specific impl/critic/bulk
-lanes (paid/optional — they exist only where the operator configured them).
+lanes (paid/optional — they exist only where the operator configured them). See
+[Non-Claude lane calibration](#non-claude-lane-calibration) below.
 
 Labels above mirror `scripts/lanes/lanes.json`, which is authoritative. When a
 tier's underlying model ships a new generation, update `lanes.json` first and
 this table follows — never the reverse.
+
+## Non-Claude lane calibration
+
+Every lane `scripts/lanes/lanes.json` registers gets a row here. The columns
+are the **invariant** calibration facts (class, effort convention, context
+ceiling, cost/quota posture, calibration status) — not the full description,
+chokepoint invocation, or roster detail, which stay in `lanes.json` (data) and
+[`tooling-catalog.md`](../tooling-catalog.md#other-delegation-lane-dispatch-chokepoints-scriptslaneslanesjson-registry-himmel-689)
+(dispatch shape). Restating that prose here would create a second copy that
+silently drifts (the HIMMEL-1021 class) — this table is deliberately thin.
+
+`quota bank` reflects the `quota.bank` field in `lanes.json`; a lane without
+one is **dashboard-omitted** from the quota exporter (HIMMEL-1000) — that's a
+registry fact, not a doc gap.
+
+| Lane (`lanes.json` id) | Class | Default effort convention | Context ceiling | Quota bank | Calibration status |
+|---|---|---|---|---|---|
+| `glm` — GLM lane (spawn-glm.ts) | impl | small-context discipline — chunk big plans | 1M | glm (flat-rate overflow, not per-token) | calibrated |
+| `glm-subagent` — GLM inline subagent | impl | same as `glm`, inline in-session dispatch | 1M | glm | calibrated |
+| `claudex` — claudex lane (claude-codex over CLIProxyAPI) | impl | launcher default `high`; `xhigh` rare; never `ultra`/`max` | 272k (2× bill past) | codex | calibrated (HIMMEL-1001/1002) |
+| `hermes-critics` — hermes free critics (qwen3coder) | critic | — (critic pass, not effort-tiered) | unverified/varies | none (dashboard-omitted) | calibrated — CR panel only (`/pr-check`) |
+| `codex` (paid, via hermes) | critic | — (critic pass) | 272k | none (dashboard-omitted); opt-in `CR_PROFILE=paid` | calibrated — CR escalation / second opinions only |
+| `copilot-cli` — GitHub Copilot CLI (free tier) | bulk | small tasks; model tier is mini-class unless the caller overrides the auto pin | unverified/varies | none (dashboard-omitted); 2,000 completions/mo bank | **not calibrated yet** — worker-spawn-matrix row UNVERIFIED (live smoke pending eval); route only for free chores / second opinions, and only through the `dispatch-copilot.sh` chokepoint |
+| `hermes-oneshot` — hermes one-shot dispatch | impl | no internal timeout — caller wraps | unverified/varies | none (dashboard-omitted) | calibrated — live-proven spawn path |
+| `codex-exec` — codex CLI sandbox | impl | well-scoped chunks; job registry is per-workspace | 272k | codex | calibrated (HIMMEL-741) |
+| `codex-wsl` — codex WSL lane | impl | well-scoped chunks; brief via `--brief-file` | 272k | codex | calibrated (HIMMEL-999) |
+| `antigravity-cli` — Antigravity CLI (Google AI Plus) | bulk | simple tasks; `--output-format` drift seen on Windows builds | unverified/varies | none (dashboard-omitted); free AI-Plus bank | **not calibrated yet** — roster + quota shape TO VERIFY at eval (HIMMEL-772); parity/guards UNVERIFIED (permission flags only, no hook surface); egress-DENIED for vault corpora, himmel-code only; route only for free-bank chores / second opinions |
+| `ollama-local` — ollama (local models) | bulk | slow, small tasks | unverified/varies | none (dashboard-omitted); free, local wall-clock | calibrated — zero-egress guarantee is structural; the only salus-eligible backend |
+| `openrouter-free` — OpenRouter free models | bulk | simple tasks only; rate-limited | unverified/varies | none (dashboard-omitted) | **not calibrated yet** — parity/guards UNVERIFIED pending eval; probe live availability before routing, route only for simple free-tier chores |
+| `ollama-cloud` — Ollama Cloud (free tier) | bulk | simple tasks; free-bank caps | unverified/varies | none (dashboard-omitted) | **not calibrated yet** — parity/guards UNVERIFIED pending eval; egresses to ollama.com, an undeclared egress-matrix provider — vault corpora default-DENY (himmel-code only) until the operator declares a cell; route only for free-bank chores on non-vault corpora |
 
 ## Effort calibration
 

--- a/docs/tooling-catalog.md
+++ b/docs/tooling-catalog.md
@@ -600,13 +600,18 @@ proxy.
 model and `env.ANTHROPIC_*`, refreshed by the shared `CLAUDE_LANE_*` reseed and
 lock knobs, and never copies credentials or history.
 
-**Prerequisite:** install a CLIProxyAPI release binary from
-`github.com/router-for-me/CLIProxyAPI`, write `~/.cli-proxy-api/config.yaml` with
-`host: "127.0.0.1"` (the default empty host binds ALL interfaces — that would
-LAN-expose the OAuth-wrapped endpoint), `port: 8317`, and an `api-keys` entry
-matching `CLIPROXY_API_KEY`, run `cli-proxy-api --codex-login` once to complete
-browser OAuth, and keep the proxy running while the lane is in use. This is subscription OAuth re-exposure; the
-ToS-risk posture is operator-accepted for HIMMEL-979.
+**Prerequisite:** the CLIProxyAPI binary is **not on PATH** — it's installed to
+`~/.cli-proxy-api/cli-proxy-api.exe` and driven through the per-host bring-up
+script, never invoked bare. Run `.\scripts\setup\cli-proxy-lane.ps1 -Install`
+(downloads the pinned release, writes `~/.cli-proxy-api/config.yaml` with
+`host: "127.0.0.1"` — the default empty host binds ALL interfaces, which would
+LAN-expose the OAuth-wrapped endpoint — and `port: 8317`), then `-Login` (device-code
+OAuth, no local browser needed) and `-Register` (windowless logon task, starts it
+now). An `api-keys` entry in `config.yaml` must match `CLIPROXY_API_KEY`. Full
+per-host checksheet + re-login recovery (device-flow re-auth when the codex token
+invalidates): [`docs/setup/cli-proxy-lane.md`](setup/cli-proxy-lane.md). This is
+subscription OAuth re-exposure; the ToS-risk posture is operator-accepted for
+HIMMEL-979.
 
 **Coexistence:** plain `claude` (Anthropic subscription, `~/.claude`, native
 OAuth) and `claude-codex` run side by side, even concurrently, because the lane's
@@ -872,6 +877,31 @@ monitor-orphan trap: a silently-dead monitor stranded the parent session ~4h,
 the `glm-subagent` lane in `scripts/lanes/lanes.json` (same `ZAI_API_KEY` probe as
 the `glm` lane). Reuses spawn-glm's worktree isolation + guard chain verbatim (no
 new fence surface). Red-path test: `scripts/hooks/test-glm-subagent-path.sh`.
+
+---
+
+## Other delegation-lane dispatch chokepoints (`scripts/lanes/lanes.json` registry, HIMMEL-689)
+
+The lanes below are registered in `scripts/lanes/lanes.json` (the `/lanes`
+source of truth) but don't otherwise get a full write-up in this file — their
+`bestFor` field in the registry IS the authoritative description (effort,
+traps, roster caveats); restating that prose here would just create a second
+copy that drifts (HIMMEL-1021 class; see also
+[`lane-calibration.md`](internals/lane-calibration.md#non-claude-lane-calibration)).
+What's pinned here is the **exact dispatch shape** — several of these lanes
+enforce a wrapper chokepoint, and calling the underlying binary bare is either
+wrong (not on PATH) or bypasses the wrapper's guards (hook-blocked).
+
+| Lane (`lanes.json` id) | Dispatch — never call the bare binary/underlying CLI directly where a chokepoint is named |
+|---|---|
+| GitHub Copilot CLI (`copilot-cli`, HIMMEL-772) | `bash scripts/copilot/dispatch-copilot.sh --worktree <wt> <args>` — enforces allow-list passthrough, worktree containment, granular grants |
+| hermes one-shot (`hermes-oneshot`) | `bash scripts/hermes/dispatch-trusted.sh <args>` (trusted-engine writes) or `scripts/hermes/invoke.sh` (untrusted default `todo` toolset) — the `/pr-check`-internal `hermes-critics`/`codex(paid)` critic lanes route through this same chokepoint; see the CR Scripts section below |
+| codex CLI sandbox (`codex-exec`, HIMMEL-741) | `bash scripts/codex/dispatch-codex-exec.sh --worktree <wt> <args>` — ACL preflight fail-closed, `gpt-5.5` pin |
+| codex WSL lane (`codex-wsl`, HIMMEL-999) | `bash scripts/codex/dispatch-codex-wsl.sh --distro <name> --clone <in-distro-abs-path> [--brief-file <path>] [args...]` — raw `wsl ... codex exec` is hook-blocked |
+| Antigravity CLI (`antigravity-cli`) | `agy -p <prompt>` (headless; PATH-installed CLI, no repo wrapper — permission flags only, no hook surface today) |
+| ollama, local (`ollama-local`) | `ollama run <model>` — bare model name only; zero-egress guarantee is structural (cloud requires the explicit `-cloud` suffix) |
+| Ollama Cloud (`ollama-cloud`) | `ollama run <model>-cloud` — same CLI, opt-in cloud suffix; content egresses to ollama.com |
+| OpenRouter free models (`openrouter-free`) | `OPENROUTER_API_KEY`-gated API calls, not a CLI dispatch; `scripts/openrouter/free-watch.sh` (below) watches catalog churn, it does not dispatch work |
 
 ---
 

--- a/scripts/graphify/refresh-graph-map.sh
+++ b/scripts/graphify/refresh-graph-map.sh
@@ -51,7 +51,31 @@ while [ $# -gt 0 ]; do
     --name) NAME="${2:-}"; shift 2 ;;
     --corpus-root) CORPUS_ROOT="${2:-}"; shift 2 ;;
     --backend) BACKEND="${2:-}"; shift 2 ;;
-    --maps-dir) MAPS_DIR="${2:-}"; shift 2 ;;
+    # HIMMEL-1415 CR follow-up rounds 2-4 (codex-1-r2, codex-adv-3,
+    # CodeRabbit App): trim trailing slash(es) at parse time -- a raw
+    # "--maps-dir /vault/60-Maps/" (or "//") propagated unmodified made the
+    # HIMMEL-1415 exclusion patterns become "./60-Maps//graph/*", which
+    # find's -path matcher never matches against the real
+    # "./60-Maps/graph/..." path -- the exclusion silently no-ops and
+    # derived pages leak back into the corpus. Looped, not a single `%/`, so
+    # it closes MULTIPLE trailing slashes too (round-3 panel flagged the
+    # single-trim as incomplete). Trimmed here (not just at the exclusion
+    # site, matching CORPUS_ROOT_TRIMMED there) so every downstream use --
+    # the exclusion AND the OUT_NOTE publish path below, which would
+    # otherwise get the same double slash -- sees the same clean value.
+    #
+    # Guarded with `[ -n "${MAPS_DIR%/}" ]` (CodeRabbit App, round 4): a bare
+    # `--maps-dir /` would otherwise be stripped to the EMPTY string (each
+    # iteration removes the one slash, `%/` on "" is a no-op, loop exits with
+    # nothing left) -- silently losing the maps dir entirely for every
+    # downstream use, including the `[ -z "$MAPS_DIR" ]` usage-check at line
+    # ~64, which would then wrongly reject a technically-valid (if absurd)
+    # root maps-dir as a missing flag. The guard stops stripping once only
+    # the bare "/" remains, so root is preserved as "/" instead of "".
+    --maps-dir)
+      MAPS_DIR="${2:-}"
+      while [ -n "${MAPS_DIR%/}" ] && [ "${MAPS_DIR%/}" != "$MAPS_DIR" ]; do MAPS_DIR="${MAPS_DIR%/}"; done
+      shift 2 ;;
     --title) TITLE="${2:-}"; shift 2 ;;
     --slug) SLUG="${2:-}"; shift 2 ;;
     --corpus-tag) CORPUS_TAG="${2:-}"; shift 2 ;;
@@ -557,7 +581,101 @@ if [ "$DO_UPDATE" -eq 1 ]; then
   # Both corpora are 100% regular files today (luna 15,239 / himmel 9,114, zero
   # dirs or symlinks named *.md), so this is a no-op on current data and a guard
   # against a silently-wrong corpus later.
-  ( cd "$CORPUS_ROOT" && find . -type f -name '*.md' -not -path './graphify-out/*' -print0 \
+  #
+  # HIMMEL-1415: also exclude graphify's OWN published derived pages --
+  # <maps-dir>/graph/* (the per-node/community notes graphify mints there) and
+  # <maps-dir>/<slug>.md (the curated MOC this script's own publish step,
+  # below, writes). Extracting the graph's own published output back into the
+  # graph is a feedback loop: a leg-14 luna regen found these derived pages
+  # dense enough to blow a rate-limited backend's per-chunk output cap
+  # (bisect-retry storms, depth-3 partials, outright-skipped chunks -- ALL
+  # from 60-Maps/graph sources). Computed via a plain bash prefix match, NOT
+  # a python3 round-trip: --corpus-root and --maps-dir are always constructed
+  # by the SAME caller in the SAME invocation (e.g. graphmap-cadence.sh builds
+  # both from one $VAULT), so they already share syntactic path form --
+  # handing them to a SEPARATE native python3.exe process for
+  # os.path.relpath instead invites MSYS's own argv-to-Windows-path
+  # translation, which was observed (HIMMEL-1415 CR follow-up test) to
+  # resolve the two strings to DIFFERENT drive roots for a maps-dir
+  # containing "[", silently disabling the exclusion -- strictly worse than
+  # the drive-letter mismatch a python3 round-trip was meant to guard
+  # against. When --maps-dir isn't actually a subdirectory of --corpus-root
+  # there's nothing under the corpus to exclude and this stays empty (a
+  # no-op below). Only "graph/" and the slug MOC are excluded -- a
+  # hand-authored, non-derived note living directly under maps-dir is real
+  # corpus content and still gets extracted.
+  MAPS_EXCL_REL=""
+  CORPUS_ROOT_TRIMMED="${CORPUS_ROOT%/}"
+  case "$MAPS_DIR" in
+    "$CORPUS_ROOT_TRIMMED"/*) MAPS_EXCL_REL="${MAPS_DIR#"$CORPUS_ROOT_TRIMMED"/}" ;;
+    "$CORPUS_ROOT_TRIMMED") MAPS_EXCL_REL="." ;;
+  esac
+  # HIMMEL-1415 CR follow-up round 3 (codex-adv-3): strip any LEADING
+  # slash(es) left on MAPS_EXCL_REL after the prefix-strip above. A caller
+  # that builds --maps-dir by naive concatenation against a --corpus-root
+  # that ALREADY ends in "/" (e.g. graphmap-cadence.sh accepting
+  # `--vault /vault/` and constructing maps-dir as `$VAULT/60-Maps` ->
+  # "/vault//60-Maps") leaves an internal double slash that --maps-dir's own
+  # trailing-slash trim above never sees (it isn't a TRAILING slash on
+  # --maps-dir itself). The case's prefix-strip only consumes ONE "/" as
+  # part of the "$CORPUS_ROOT_TRIMMED/" match, so MAPS_EXCL_REL is left as
+  # e.g. "/60-Maps" -- MAPS_EXCL_PREFIX would then become ".//60-Maps", and
+  # find's -path matcher never matches that literal double slash against a
+  # real "./60-Maps/..." target, silently no-opping the exclusion. Looped so
+  # it also closes multiple leading slashes, not just one.
+  #
+  # NOT given the round-4 "preserve a bare all-slash value" guard the
+  # --maps-dir parse-time trim above got (CodeRabbit App asked us to verify,
+  # not blanket-apply): unlike --maps-dir, this value can never legitimately
+  # be reduced to "all slashes" here. --maps-dir's OWN trailing-slash trim
+  # (above, already guarded) runs first and strips every trailing slash off
+  # the raw flag value before this case statement ever sees it, so the only
+  # way MAPS_EXCL_REL could still be all-slashes at this point is if
+  # --corpus-root itself is the filesystem root ("/", so
+  # CORPUS_ROOT_TRIMMED="") AND --maps-dir is also "/" -- a corpus-root of
+  # "/" is already nonsensical on unrelated grounds (the corpus-copy below
+  # would try to walk the entire filesystem for *.md) and is not a
+  # configuration any of these CR rounds have tried to harden, so adding
+  # branching here for a state that can't arise from any real caller would
+  # be speculative complexity, not a fix. And unlike the --maps-dir case
+  # (where losing "/" silently trips the UNRELATED `-z "$MAPS_DIR"`
+  # usage-check), an empty MAPS_EXCL_REL here just disables this one
+  # exclusion (`[ -n "$MAPS_EXCL_REL" ]` below) -- a narrower, already-inert
+  # failure mode given the corpus-root-is-"/" precondition, not an
+  # equivalent-but-different bug worth mirroring the guard for.
+  while [ "${MAPS_EXCL_REL#/}" != "$MAPS_EXCL_REL" ]; do MAPS_EXCL_REL="${MAPS_EXCL_REL#/}"; done
+  #
+  # HIMMEL-1415 CR follow-up (glm panel + codex-adv-1): $MAPS_EXCL_PREFIX and
+  # $SLUG land inside `find -path` PATTERN arguments, where *, ?, and [ are
+  # fnmatch wildcard syntax even though the arguments are shell-quoted --
+  # shell quoting only stops the SHELL from globbing them; find's own -path
+  # matcher still interprets them as wildcards. A maps-dir or slug containing
+  # one of these (e.g. "60-[Maps]") would fail to match its OWN literal path
+  # -- its derived pages re-enter the corpus, reopening the feedback loop --
+  # and a stray "*"/"?" could over-match unrelated siblings, silently
+  # excluding legitimate notes. Escape backslash FIRST so a backslash
+  # inserted by a later replacement isn't itself re-escaped by a subsequent
+  # pass. Only the computed PREFIX/SLUG are escaped -- the literal "/graph/*"
+  # suffix's trailing "*" stays an intentional wildcard, and the pre-existing
+  # graphify-out/* exclusion (a fixed literal with no wildcard chars) is
+  # untouched.
+  _find_glob_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\*/\\*}"
+    s="${s//\?/\\?}"
+    s="${s//\[/\\[}"
+    printf '%s' "$s"
+  }
+  CORPUS_FIND_EXCLUDES=(-not -path './graphify-out/*')
+  if [ -n "$MAPS_EXCL_REL" ]; then
+    MAPS_EXCL_PREFIX="./$MAPS_EXCL_REL"
+    [ "$MAPS_EXCL_REL" = "." ] && MAPS_EXCL_PREFIX="."
+    MAPS_EXCL_PREFIX_ESC="$(_find_glob_escape "$MAPS_EXCL_PREFIX")"
+    SLUG_ESC="$(_find_glob_escape "$SLUG")"
+    CORPUS_FIND_EXCLUDES+=(-not -path "$MAPS_EXCL_PREFIX_ESC/graph/*" -not -path "$MAPS_EXCL_PREFIX_ESC/$SLUG_ESC.md")
+  fi
+  ( cd "$CORPUS_ROOT" && find . -type f -name '*.md' "${CORPUS_FIND_EXCLUDES[@]}" -print0 \
       | tar --null -T - -cf - ) | ( cd "$SCRATCH" && tar -xf - ) \
     || { echo "refresh-graph-map: corpus scan/copy failed (see find/tar output above)" >&2; exit 1; }
   # HIMMEL-1097: graphify's semantic cache is corpus-relative and content-keyed,

--- a/scripts/graphify/test-refresh-graph-map.sh
+++ b/scripts/graphify/test-refresh-graph-map.sh
@@ -1494,5 +1494,292 @@ echo "$out" | grep -q "structleaktoken" \
   && pass "T26b nothing promoted under \$CORPUS_ROOT on a structural-field leak" \
   || fail "T26b leaking refresh still promoted into \$CORPUS_ROOT/graphify-out"
 
+# --- T27 (HIMMEL-1415): corpus-copy excludes graphify's own published
+# derived pages -- <maps-dir>/graph/* (per-node/community notes graphify
+# mints there) and <maps-dir>/<slug>.md (the curated MOC this script's own
+# publish step writes) -- from the extraction corpus, closing the feedback
+# loop where graphify's own output gets re-extracted into itself. A
+# legitimate, hand-authored note living directly under maps-dir (not under
+# graph/, not the MOC) must still reach the corpus -- this isn't "exclude all
+# of maps-dir wholesale". The stub snapshots what the corpus-copy actually
+# staged into the scratch dir before writing its own output. ---
+EXCLBIN="$WS/exclbin"; mkdir -p "$EXCLBIN"
+cat > "$EXCLBIN/graphify" <<STUB
+#!/usr/bin/env bash
+target=""
+if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
+if [ "\$1" != "cluster-only" ]; then
+  ( cd "\$target" && find . -type f -name '*.md' | sort ) > "$WS/excl-scratch-listing.txt"
+fi
+mkdir -p "\$target/graphify-out"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
+cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
+$REPORT_FIXTURE
+RPT
+exit 0
+STUB
+chmod +x "$EXCLBIN/graphify"
+EXCLCORPUS="$WS/exclcorpus"; EXCLMAPS="$EXCLCORPUS/60-Maps"
+mkdir -p "$EXCLCORPUS/notes" "$EXCLMAPS/graph"
+printf '# n\ncontent\n' > "$EXCLCORPUS/notes/n.md"
+printf '# derived node note\nminted by graphify\n' > "$EXCLMAPS/graph/some-node.md"
+printf '# Legit Maps Note\nhand-authored, not graphify output\n' > "$EXCLMAPS/legit-note.md"
+# Pre-seed the MOC this run's OWN publish step will (re)write -- simulates a
+# prior run's published output already sitting in the vault when the NEXT
+# refresh's corpus-copy runs.
+printf '# stale MOC from a prior run\n' > "$EXCLMAPS/excl-map.md"
+out=$( GRAPHIFY_MAP_BIN="$EXCLBIN/graphify" PATH="$EXCLBIN:$PATH" \
+  bash "$SCRIPT" --name excltest --corpus-root "$EXCLCORPUS" --backend deepseek \
+  --maps-dir "$EXCLMAPS" --title "Excl Map" --slug excl-map --corpus-tag excl 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] || fail "T27 run exit 0 (got $rc): $out"
+if grep -qF "60-Maps/graph/some-node.md" "$WS/excl-scratch-listing.txt" 2>/dev/null; then
+  fail "T27 derived-page note (maps-dir/graph/*) leaked into the extraction corpus"
+else
+  pass "T27 derived-page note (maps-dir/graph/*) excluded from the extraction corpus"
+fi
+if grep -qF "60-Maps/excl-map.md" "$WS/excl-scratch-listing.txt" 2>/dev/null; then
+  fail "T27 the corpus's own published MOC (maps-dir/slug.md) leaked into the extraction corpus"
+else
+  pass "T27 the corpus's own published MOC (maps-dir/slug.md) excluded from the extraction corpus"
+fi
+if grep -qF "60-Maps/legit-note.md" "$WS/excl-scratch-listing.txt" 2>/dev/null; then
+  pass "T27 a hand-authored maps-dir note (not under graph/, not the MOC) still reaches the corpus"
+else
+  fail "T27 over-excluded: a legitimate maps-dir note was dropped from the corpus"
+fi
+
+# --- T28 (HIMMEL-1415 CR follow-up, codex-adv-1): the computed maps-prefix
+# and slug land inside `find -path` PATTERN arguments, where *, ?, and [ are
+# fnmatch wildcard syntax even though the arguments are shell-quoted -- shell
+# quoting only stops the SHELL from globbing them; find's own matcher still
+# treats them as wildcards. A maps-dir/slug containing one of these could
+# either (a) fail to match its OWN literal path (its derived pages re-enter
+# the corpus, reopening the feedback loop T27 just closed) or (b) over-match
+# an unrelated sibling (silently dropping real content). Uses a maps-dir
+# literally named "60-[Maps]" (the CR's own example) and a slug containing
+# "[v2]" -- both real, valid filename characters (unlike a literal "*", which
+# a native Win32 file API refuses even though MSYS/bash can create one --
+# tried, and publish-graph-map.mjs's write ENOENT'd on it -- so "[" "]" alone
+# carries this regression without depending on Windows/MSYS path-translation
+# quirks). ---
+EXCL2BIN="$WS/excl2bin"; mkdir -p "$EXCL2BIN"
+cat > "$EXCL2BIN/graphify" <<STUB
+#!/usr/bin/env bash
+target=""
+if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
+if [ "\$1" != "cluster-only" ]; then
+  ( cd "\$target" && find . -type f -name '*.md' | sort ) > "$WS/excl2-scratch-listing.txt"
+fi
+mkdir -p "\$target/graphify-out"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
+cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
+$REPORT_FIXTURE
+RPT
+exit 0
+STUB
+chmod +x "$EXCL2BIN/graphify"
+EXCL2CORPUS="$WS/excl2corpus"
+EXCL2MAPS="$EXCL2CORPUS/60-[Maps]"
+EXCL2SLUG='map-[v2]-note'
+mkdir -p "$EXCL2CORPUS/notes" "$EXCL2MAPS/graph"
+printf '# n\ncontent\n' > "$EXCL2CORPUS/notes/n.md"
+# The derived page + the MOC this run's own publish step will (re)write --
+# both must be EXCLUDED (the "under-match" direction: escaping must not
+# break the exclusion on its own metachar-laden literal path). Unescaped,
+# the bracket class "[Maps]" matches exactly ONE char from {M,a,p,s} -- it
+# can never match the literal 6-char "[Maps]" substring in the real dirname,
+# so without the fix these would leak straight back into the corpus.
+printf '# derived node note\nminted by graphify\n' > "$EXCL2MAPS/graph/some-node.md"
+printf '# stale MOC from a prior run\n' > "$EXCL2MAPS/$EXCL2SLUG.md"
+# A sibling maps-dir named "60-M" -- exactly what the UNESCAPED bracket class
+# "[Maps]" (one char from {M,a,p,s}) would ALSO match -- carrying its own
+# unrelated graph/ page. Proves no over-match spillover into a
+# similarly-named sibling once escaped (the "over-match" direction).
+mkdir -p "$EXCL2CORPUS/60-M/graph"
+printf '# unrelated sibling page\nnot derived from THIS maps-dir\n' > "$EXCL2CORPUS/60-M/graph/sibling.md"
+# A file directly under the real maps-dir whose name is exactly what the
+# UNESCAPED slug pattern "map-[v2]-note.md" ([v2] -> one char from {v,2})
+# would also match -- "map-v-note.md" -- must survive as real corpus
+# content, not get swept up by an over-permissive class.
+printf '# unrelated note\nresembles the slug pattern, is not the MOC\n' > "$EXCL2MAPS/map-v-note.md"
+out=$( GRAPHIFY_MAP_BIN="$EXCL2BIN/graphify" PATH="$EXCL2BIN:$PATH" \
+  bash "$SCRIPT" --name excl2test --corpus-root "$EXCL2CORPUS" --backend deepseek \
+  --maps-dir "$EXCL2MAPS" --title "Excl2 Map" --slug "$EXCL2SLUG" --corpus-tag excl2 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] || fail "T28 run exit 0 (got $rc): $out"
+if grep -qF "60-[Maps]/graph/some-node.md" "$WS/excl2-scratch-listing.txt" 2>/dev/null; then
+  fail "T28 derived-page under a metachar-laden maps-dir leaked into the corpus (escaping broke the exclusion)"
+else
+  pass "T28 derived-page under a metachar-laden maps-dir still excluded"
+fi
+if grep -qF "60-[Maps]/map-[v2]-note.md" "$WS/excl2-scratch-listing.txt" 2>/dev/null; then
+  fail "T28 the MOC under a metachar-laden slug leaked into the corpus (escaping broke the exclusion)"
+else
+  pass "T28 the MOC under a metachar-laden slug still excluded"
+fi
+if grep -qF "60-M/graph/sibling.md" "$WS/excl2-scratch-listing.txt" 2>/dev/null; then
+  pass "T28 a similarly-named sibling maps-dir's page still reaches the corpus (no bracket-class over-match)"
+else
+  fail "T28 over-matched: an unrelated sibling maps-dir's page was wrongly excluded"
+fi
+if grep -qF "60-[Maps]/map-v-note.md" "$WS/excl2-scratch-listing.txt" 2>/dev/null; then
+  pass "T28 a note resembling the slug pattern still reaches the corpus (no bracket-class over-match)"
+else
+  fail "T28 over-matched: a legitimate note resembling the slug pattern was wrongly excluded"
+fi
+
+# --- T29 (HIMMEL-1415 CR follow-up round 2, codex-1-r2): a trailing slash on
+# --maps-dir must not defeat the exclusion. Passed raw, "$MAPS_DIR" ends with
+# "/" and the exclusion pattern becomes "./60-Maps//graph/*" -- find's -path
+# matcher never matches that against the real "./60-Maps/graph/..." path, so
+# the derived page silently leaks back into the corpus (the exact feedback
+# loop T27 exists to close). Same fixture shape as T27, just with a trailing
+# slash on --maps-dir. ---
+EXCL3BIN="$WS/excl3bin"; mkdir -p "$EXCL3BIN"
+cat > "$EXCL3BIN/graphify" <<STUB
+#!/usr/bin/env bash
+target=""
+if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
+if [ "\$1" != "cluster-only" ]; then
+  ( cd "\$target" && find . -type f -name '*.md' | sort ) > "$WS/excl3-scratch-listing.txt"
+fi
+mkdir -p "\$target/graphify-out"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
+cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
+$REPORT_FIXTURE
+RPT
+exit 0
+STUB
+chmod +x "$EXCL3BIN/graphify"
+EXCL3CORPUS="$WS/excl3corpus"; EXCL3MAPS="$EXCL3CORPUS/60-Maps"
+mkdir -p "$EXCL3CORPUS/notes" "$EXCL3MAPS/graph"
+printf '# n\ncontent\n' > "$EXCL3CORPUS/notes/n.md"
+printf '# derived node note\nminted by graphify\n' > "$EXCL3MAPS/graph/some-node.md"
+printf '# stale MOC from a prior run\n' > "$EXCL3MAPS/excl3-map.md"
+out=$( GRAPHIFY_MAP_BIN="$EXCL3BIN/graphify" PATH="$EXCL3BIN:$PATH" \
+  bash "$SCRIPT" --name excl3test --corpus-root "$EXCL3CORPUS" --backend deepseek \
+  --maps-dir "$EXCL3MAPS/" --title "Excl3 Map" --slug excl3-map --corpus-tag excl3 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] || fail "T29 run exit 0 (got $rc): $out"
+if grep -qF "60-Maps/graph/some-node.md" "$WS/excl3-scratch-listing.txt" 2>/dev/null; then
+  fail "T29 derived-page leaked into the corpus with a trailing-slash --maps-dir (double-slash pattern no-op)"
+else
+  pass "T29 derived-page still excluded with a trailing-slash --maps-dir"
+fi
+if grep -qF "60-Maps/excl3-map.md" "$WS/excl3-scratch-listing.txt" 2>/dev/null; then
+  fail "T29 the MOC leaked into the corpus with a trailing-slash --maps-dir (double-slash pattern no-op)"
+else
+  pass "T29 the MOC still excluded with a trailing-slash --maps-dir"
+fi
+# CodeRabbit App follow-up: a bare `[ -f ]` here would pass even if publish
+# never ran at all (the pre-seeded stale MOC from setup, above, already
+# satisfies existence). Assert the stale sentinel is GONE -- proof the
+# publish step actually rewrote the file at the trimmed path, not proof of
+# nothing.
+if [ -f "$EXCL3MAPS/excl3-map.md" ] && ! grep -qF "stale MOC from a prior run" "$EXCL3MAPS/excl3-map.md" 2>/dev/null; then
+  pass "T29 MOC republished (stale sentinel replaced) without a double slash in its path"
+else
+  fail "T29 MOC not republished at the expected (trimmed) path (missing, or still the stale sentinel)"
+fi
+
+# --- T30a (HIMMEL-1415 CR follow-up round 3, codex-adv-3): a CALLER-generated
+# internal double slash must not defeat the exclusion. graphmap-cadence.sh
+# accepts a --vault value that may itself end in "/" and constructs
+# --maps-dir as "$VAULT/60-Maps" by naive concatenation -- if $VAULT already
+# ends in "/", that produces an internal double slash the --maps-dir-only
+# trailing-slash trim (T29) never sees (it isn't a trailing slash on
+# --maps-dir itself; --corpus-root ends in "/", --maps-dir does not). Mirrors
+# the exact repro: --corpus-root "$vault/" --maps-dir "$vault//60-Maps". ---
+EXCL4BIN="$WS/excl4bin"; mkdir -p "$EXCL4BIN"
+cat > "$EXCL4BIN/graphify" <<STUB
+#!/usr/bin/env bash
+target=""
+if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
+if [ "\$1" != "cluster-only" ]; then
+  ( cd "\$target" && find . -type f -name '*.md' | sort ) > "$WS/excl4-scratch-listing.txt"
+fi
+mkdir -p "\$target/graphify-out"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
+cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
+$REPORT_FIXTURE
+RPT
+exit 0
+STUB
+chmod +x "$EXCL4BIN/graphify"
+CADENCE_VAULT="$WS/cadence-vault"
+mkdir -p "$CADENCE_VAULT/notes" "$CADENCE_VAULT/60-Maps/graph"
+printf '# n\ncontent\n' > "$CADENCE_VAULT/notes/n.md"
+printf '# derived node note\nminted by graphify\n' > "$CADENCE_VAULT/60-Maps/graph/some-node.md"
+printf '# stale MOC from a prior run\n' > "$CADENCE_VAULT/60-Maps/excl4-map.md"
+printf '# Legit Maps Note\nhand-authored, not graphify output\n' > "$CADENCE_VAULT/60-Maps/legit-note.md"
+CADENCE_VAULT_TS="$CADENCE_VAULT/"          # mimics `--vault /vault/`
+CADENCE_MAPS_ARG="$CADENCE_VAULT_TS/60-Maps" # mimics `$VAULT/60-Maps` -> internal "//"
+out=$( GRAPHIFY_MAP_BIN="$EXCL4BIN/graphify" PATH="$EXCL4BIN:$PATH" \
+  bash "$SCRIPT" --name excl4test --corpus-root "$CADENCE_VAULT_TS" --backend deepseek \
+  --maps-dir "$CADENCE_MAPS_ARG" --title "Excl4 Map" --slug excl4-map --corpus-tag excl4 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] || fail "T30a run exit 0 (got $rc): $out"
+if grep -qF "60-Maps/graph/some-node.md" "$WS/excl4-scratch-listing.txt" 2>/dev/null; then
+  fail "T30a derived-page leaked into the corpus via a cadence-generated internal double slash"
+else
+  pass "T30a derived-page still excluded via a cadence-generated internal double slash"
+fi
+if grep -qF "60-Maps/excl4-map.md" "$WS/excl4-scratch-listing.txt" 2>/dev/null; then
+  fail "T30a the MOC leaked into the corpus via a cadence-generated internal double slash"
+else
+  pass "T30a the MOC still excluded via a cadence-generated internal double slash"
+fi
+if grep -qF "60-Maps/legit-note.md" "$WS/excl4-scratch-listing.txt" 2>/dev/null; then
+  pass "T30a a hand-authored maps-dir note still reaches the corpus despite the internal double slash"
+else
+  fail "T30a over-excluded: a legitimate maps-dir note was dropped from the corpus"
+fi
+
+# --- T30b (HIMMEL-1415 CR follow-up round 3): a DOUBLE trailing slash on
+# --maps-dir (e.g. "60-Maps//") must be fully trimmed, not just one of the
+# two -- pins that the trailing-slash trim is a loop, not a single `%/`. ---
+EXCL5BIN="$WS/excl5bin"; mkdir -p "$EXCL5BIN"
+cat > "$EXCL5BIN/graphify" <<STUB
+#!/usr/bin/env bash
+target=""
+if [ "\$1" = "cluster-only" ]; then target="\$2"; else target="\$1"; fi
+if [ "\$1" != "cluster-only" ]; then
+  ( cd "\$target" && find . -type f -name '*.md' | sort ) > "$WS/excl5-scratch-listing.txt"
+fi
+mkdir -p "\$target/graphify-out"
+printf '{"nodes":[],"links":[]}' > "\$target/graphify-out/graph.json"
+cat > "\$target/graphify-out/GRAPH_REPORT.md" <<'RPT'
+$REPORT_FIXTURE
+RPT
+exit 0
+STUB
+chmod +x "$EXCL5BIN/graphify"
+EXCL5CORPUS="$WS/excl5corpus"; EXCL5MAPS="$EXCL5CORPUS/60-Maps"
+mkdir -p "$EXCL5CORPUS/notes" "$EXCL5MAPS/graph"
+printf '# n\ncontent\n' > "$EXCL5CORPUS/notes/n.md"
+printf '# derived node note\nminted by graphify\n' > "$EXCL5MAPS/graph/some-node.md"
+printf '# stale MOC from a prior run\n' > "$EXCL5MAPS/excl5-map.md"
+out=$( GRAPHIFY_MAP_BIN="$EXCL5BIN/graphify" PATH="$EXCL5BIN:$PATH" \
+  bash "$SCRIPT" --name excl5test --corpus-root "$EXCL5CORPUS" --backend deepseek \
+  --maps-dir "$EXCL5MAPS//" --title "Excl5 Map" --slug excl5-map --corpus-tag excl5 2>&1 ); rc=$?
+[ "$rc" -eq 0 ] || fail "T30b run exit 0 (got $rc): $out"
+if grep -qF "60-Maps/graph/some-node.md" "$WS/excl5-scratch-listing.txt" 2>/dev/null; then
+  fail "T30b derived-page leaked into the corpus with a double-trailing-slash --maps-dir"
+else
+  pass "T30b derived-page still excluded with a double-trailing-slash --maps-dir"
+fi
+if grep -qF "60-Maps/excl5-map.md" "$WS/excl5-scratch-listing.txt" 2>/dev/null; then
+  fail "T30b the MOC leaked into the corpus with a double-trailing-slash --maps-dir"
+else
+  pass "T30b the MOC still excluded with a double-trailing-slash --maps-dir"
+fi
+# CodeRabbit App follow-up: a bare `[ -f ]` here would pass even if publish
+# never ran at all (the pre-seeded stale MOC from setup, above, already
+# satisfies existence). Assert the stale sentinel is GONE -- proof the
+# publish step actually rewrote the file at the fully-trimmed path, not
+# proof of nothing.
+if [ -f "$EXCL5MAPS/excl5-map.md" ] && ! grep -qF "stale MOC from a prior run" "$EXCL5MAPS/excl5-map.md" 2>/dev/null; then
+  pass "T30b MOC republished (stale sentinel replaced) without a lingering double slash in its path"
+else
+  fail "T30b MOC not republished at the expected (fully-trimmed) path (missing, or still the stale sentinel)"
+fi
+
 if [ "$FAILS" -ne 0 ]; then echo "$FAILS FAILURES"; exit 1; fi
 echo "ALL PASS"

--- a/scripts/himmelctl/bin.js
+++ b/scripts/himmelctl/bin.js
@@ -2110,9 +2110,13 @@ async function cmdEnsure(args) {
       // CR fix (HIMMEL-1100 round 6, CodeRabbit App PR #1500 thread #4):
       // this branch used to push the blocker UNCONDITIONALLY, without ever
       // probing the item's actual state — so a full-offboard-only item that
-      // is PERMANENTLY degraded (e.g. guardrail-block-global, which per
-      // this ticket's own round-3 fix never reaches 'present' from status
-      // output alone) wedged EVERY `ensure` run the moment a profile change
+      // is PERMANENTLY degraded (e.g. guardrail-block-global, which through
+      // this ticket's own round-3 fix could never reach 'present' from
+      // status output alone — HIMMEL-1418 later gave it a `status --json`
+      // verb rich enough to confirm a genuine full install, so it is no
+      // longer an example of a permanently-degraded item, but the general
+      // shape still applies to any probe that structurally can't confirm
+      // 'present') wedged EVERY `ensure` run the moment a profile change
       // put it in towardDisabled, with no way to ever clear it (there is no
       // unwire descriptor to run — full-offboard-only items don't have one
       // by definition). Only a genuinely 'present' item blocks (the

--- a/scripts/himmelctl/lib/probes.js
+++ b/scripts/himmelctl/lib/probes.js
@@ -937,65 +937,219 @@ function probeCmdCadenceArmed(item, ctx) {
 // has its own drift check in himmel-update.sh (report_guardrail_block) but
 // zero manifest presence. Spawns node directly with an ARGV ARRAY (not
 // `bash -c` + string command) — no shell involved at all, so there is no
-// quoting/interpolation surface to get wrong in the first place. Parses the
-// script's own `guardrail-mode=<mode> node-resolves=<yes|no>` stdout (the
-// same status line report_guardrail_block already prints) rather than
-// re-implementing detectMode()/nodeResolves() a second way.
-//   mode=project              -> 'absent' (never armed globally — the
-//                                ordinary default; global mode is an explicit
-//                                `setup-hooks.sh --guardrail-mode global` opt-in,
-//                                never part of the automatic install path).
-//   mode=global, resolves=yes -> 'present'.
-//   mode=global, resolves=no  -> 'degraded' (armed but the baked node path
-//                                rotted — exactly the drift report_guardrail_
-//                                block itself exists to catch).
-//   anything else (nonzero exit, unparseable stdout) -> 'degraded'.
+// quoting/interpolation surface to get wrong in the first place.
+//
+// HIMMEL-1418: uses the richer `status --json` verb (guardrail-block.mjs's
+// statusDetail() contract) instead of the plain `guardrail-mode=<mode>
+// node-resolves=<yes|no>` text line the probe used through HIMMEL-1100. The
+// plain line only ever proves "at least one owned hook exists and ITS node
+// path resolves" (detectMode()'s `.some()` over every group, nodeResolves()'s
+// first-match return) — a 1-of-3 partial install (only one of the three
+// GUARDRAILS wired, the other two missing or pointing at dead paths) was
+// INDISTINGUISHABLE from a complete one, so every mode=global reading had to
+// map to 'degraded' (round 3, codex-adv-1) — 'present' was structurally
+// unreachable. `status --json` enumerates each expected hook's own presence,
+// ACTUAL matcher, and bash/node/wrapper/script resolution (`complete` is
+// true only when ALL of that holds for every hook), so this probe can now
+// trust a genuine full install the way handover-dir/qmd-index already trust
+// THEIR CLI's own richer output.
+//
+// CR fixes (same ticket, codex adversarial pass on 68c0b82c):
+//   codex-adv-1: statusDetail() used to report each hook's EXPECTED matcher
+//     (from GUARDRAILS) rather than the ACTUAL configured one — a settings.json
+//     where all 3 owned hooks were moved into a single `Bash` matcher group
+//     (so block-edit-on-main.sh never fires on Edit/Write, block-read-secrets
+//     never fires on PowerShell/Read/Grep) still read complete:true. Fixed by
+//     surfacing the actual matcher + an exact-match matcherMatches flag;
+//     complete now requires matcherMatches on every hook too.
+//   codex-adv-2: the baked GUARDRAIL_BASH path was parsed and then discarded
+//     — a nonexistent bash executable (the wrapper fails closed on this at
+//     runtime) still read complete:true, since only node/wrapper/script were
+//     checked. Fixed by surfacing bashPath/bashResolves; complete now
+//     requires bashResolves on every hook too.
+//   codex-adv-3 (round 3): the *Resolves fields used fs.existsSync(), which
+//     accepts a DIRECTORY (or, for node/bash, a non-executable file) as
+//     "resolves" — reproduced complete:true with a baked path pointing at a
+//     plain directory. Fixed in guardrail-block.mjs's isReadableFile()/
+//     isRunnableExecutable() (isFile() + access() mode check); see that
+//     file's contract comment for the Windows X_OK caveat.
+//   codex-adv-4 (round 3): statusDetail() only ever looked at the FIRST
+//     owned entry per basename — a second, dead-pathed duplicate (the exact
+//     drift state installData()'s own dedup step exists to clean up) was
+//     invisible, so a valid-plus-dead-duplicate pair still read
+//     complete:true even though the duplicate can independently fire and
+//     fail closed at runtime. Fixed by enumerating every owned entry
+//     (entryCount, duplicates[]); complete now requires entryCount === 1.
+//   codex-adv-5 (round 4): ownership was decided by substring-searching the
+//     WHOLE command string for the guardrail's basename, while the parser
+//     independently took the first three quoted args and ignored anything
+//     after them — reproduced: a command whose real script arg is a decoy
+//     (e.g. "claude-stub.sh") with the guardrail's basename sitting ONLY in
+//     a trailing shell comment still read complete:true, while the real
+//     protection was never wired. Fixed in guardrail-block.mjs by binding
+//     ownership to the PARSED command's structure: the whole string must
+//     match the exact generated shape (4 quoted segments, nothing
+//     trailing) AND the parsed script arg's basename must equal the
+//     guardrail's basename exactly (path.basename(), never a substring
+//     check) — a decoy is now not owned by ANY guardrail at all (reads
+//     present:false/entryCount:0, identical to "never wired"; see that
+//     file's contract comment for why "not owned" was chosen over "owned
+//     but flagged").
+//   codex-adv-7 (companion finding "basename-only ownership lets a
+//     same-named no-op file elsewhere pass" is tracked in HIMMEL-1422,
+//     linked to this ticket: binding wrapper/script identity beyond
+//     basename needs a trust-anchor decision — realpath vs
+//     content-integrity vs configurable HIMMEL_REPO anchor): round 4's anchored
+//     GENERATED_COMMAND_RE correctly rejects a true decoy, but it ALSO made
+//     an entry with the SAME wrapper/script identity plus a trailing extra
+//     token invisible entirely — yet guardrail-skip-in-himmel.js reads only
+//     process.argv[2] and ignores anything after it, so Claude Code still
+//     executes such an entry identically to a canonical one. A dead-pathed
+//     duplicate wired in this shape reopened round 3's own blind spot
+//     (entryCount stayed 1, complete:true) through a different command
+//     shape. Fixed via a bounded, NON-substring structural test
+//     (referencesGuardrailIdentity(): every quoted segment's
+//     path.basename() checked against WRAPPER/the guardrail's basename,
+//     never String#includes over the whole string — a comment-only mention
+//     still correctly reads as a decoy, no regression on codex-adv-5) that
+//     surfaces this as its own `nonCanonicalCount`/`nonCanonical` anomaly,
+//     distinct from both a decoy (present:false) and a canonical duplicate
+//     (entryCount > 1); complete now also requires nonCanonicalCount === 0.
+//   SCOPE: this probe attests the FULL GENERATED COMMAND IDENTITY —
+//     presence, resolution, matcher, uniqueness, and shape — of the
+//     CONFIGURED wiring. It does not attempt deeper runtime proof
+//     (executing the hook chain, node/bash version checks,
+//     ACL/trust-anchor analysis — tracked in HIMMEL-1422 — or semantic
+//     equivalence of a differently-formed command); those belong to
+//     follow-up tickets against the contract, not this probe.
+//   mode=project    -> 'absent' (never armed globally — the ordinary
+//                      default; global mode is an explicit `setup-hooks.sh
+//                      --guardrail-mode global` opt-in, never part of the
+//                      automatic install path).
+//   mode=global,
+//   complete=true   -> 'present' (every GUARDRAILS hook has EXACTLY ONE
+//                      owned entry, no non-canonical duplicates reference
+//                      its identity, its ACTUAL matcher exactly matches
+//                      what it needs for full tool coverage, and its
+//                      bash/node/wrapper/script paths are all usable).
+//   mode=global,
+//   complete=false  -> 'degraded', detail names exactly which hook(s) are
+//                      missing, duplicated (canonical or non-canonical),
+//                      matcher-mismatched, or have an unusable path
+//                      (partial install, duplicate/anomalous wiring, a
+//                      hand-edited matcher, or a genuinely fully-armed
+//                      install that rotted).
+//   anything else (nonzero exit, unparseable JSON, missing mode/hooks
+//   fields) -> 'degraded'.
 function probeGuardrailBlockStatus(item, ctx) {
   const scriptPath = path.resolve(ctx.repoRoot, item.probe.script);
-  const r = spawnProbeSync(process.execPath, [scriptPath, 'status'], { env: ctx.env || process.env, encoding: 'utf8' });
+  const r = spawnProbeSync(process.execPath, [scriptPath, 'status', '--json'], { env: ctx.env || process.env, encoding: 'utf8' });
   if (r.timedOut) return { actual: 'degraded', detail: 'cmd:guardrail_block_status probe timed out after 10s' };
   if (r.error) return { actual: 'degraded', detail: `spawn error: ${r.error.message}` };
   if (r.status !== 0) {
     const stderr = (r.stderr || '').trim();
-    return { actual: 'degraded', detail: `guardrail-block.mjs status exited rc=${r.status}${stderr ? `: ${stderr}` : ''}` };
+    return { actual: 'degraded', detail: `guardrail-block.mjs status --json exited rc=${r.status}${stderr ? `: ${stderr}` : ''}` };
   }
   const out = (r.stdout || '').trim();
-  const modeMatch = out.match(/guardrail-mode=(\S+)/);
-  const resolvesMatch = out.match(/node-resolves=(\S+)/);
-  if (!modeMatch) return { actual: 'degraded', detail: `guardrail-block.mjs status produced unparseable output: ${out || '(empty)'}` };
-  const mode = modeMatch[1];
-  if (mode !== 'global') return { actual: 'absent', detail: out };
-  // CR fix (HIMMEL-1100 round 2, glm-3): a MISSING node-resolves field is
-  // not proof of resolution — it used to fall through to 'present' (the
-  // `resolves === 'no'` check is simply false for null). An absent field
-  // means the script's output shape changed/broke, which is a wiring
-  // problem, not a confirmed-working global-mode install.
-  if (!resolvesMatch) return { actual: 'degraded', detail: `${out} — missing 'node-resolves' field in guardrail-block.mjs status output` };
-  if (resolvesMatch[1] === 'no') return { actual: 'degraded', detail: `${out} — global mode armed but the baked node path no longer resolves` };
-  // CR fix (HIMMEL-1100 round 3, codex-adv-1, bounded to status output
-  // alone — no rewrite of guardrail-block.mjs, no reading settings.json
-  // around it): guardrail-block.mjs's own `status` verb declares
-  // mode=global whenever ANY owned hook exists at all (detectMode: `.some`
-  // over every group — one hit is enough) and derives node-resolves from
-  // ONLY the FIRST owned hook it iterates to (nodeResolves returns inside
-  // its loop on first match). It never counts or enumerates the 3 expected
-  // guardrail hooks (auto-approve-safe-bash.sh / block-edit-on-main.sh /
-  // block-read-secrets.sh — GUARDRAILS in guardrail-block.mjs). So
-  // "mode=global, node-resolves=yes" proves only "at least one guardrail
-  // hook is wired and ITS OWN node path resolves" — a partial install (1 of
-  // 3 wired, the other two missing or pointing at dead paths) is
-  // INDISTINGUISHABLE from a complete one using this output alone; status
-  // exposes no per-hook data to deepen against (self-verified: this file's
-  // own tests construct exactly that 1-hook fixture and it read 'present'
-  // before this fix). 'present' therefore claims MORE than status output
-  // can honestly attest, so it is never reached from a real armed reading —
-  // every mode=global case reads 'degraded' until guardrail-block.mjs grows
-  // a richer verb (e.g. `status --json` enumerating each expected hook's
-  // own resolution), which would let this branch trust a genuine "all 3
-  // present and resolving" answer the way handover-dir/qmd-index already
-  // trust THEIR CLI's own richer output. Filed as a follow-up rather than
-  // built here (bounded scope for this round).
-  return { actual: 'degraded', detail: `${out} — global mode armed, but guardrail-block.mjs's status verb cannot confirm all 3 guardrail hooks are wired (only that at least one is, and its own node path resolves); a richer status verb is needed to verify completeness` };
+  let parsed;
+  try {
+    parsed = JSON.parse(out);
+  } catch (_e) {
+    return { actual: 'degraded', detail: `guardrail-block.mjs status --json produced unparseable output: ${out || '(empty)'}` };
+  }
+  // CR fix (codex-1-r6, round 6): Array.isArray([]) is true — without a
+  // non-empty check, a malformed/truncated {mode:"global",complete:true,
+  // hooks:[]} would sail past this guard and straight into the
+  // `complete === true` branch below, trusted as 'present' despite
+  // attesting ZERO guardrails. `hooks.length > 0` is the strictest check
+  // available without duplicating guardrail-block.mjs's own GUARDRAILS
+  // count here: hardcoding "3" (or requiring the .mjs's ESM export into
+  // this CommonJS file) would itself be a second, driftable copy of that
+  // knowledge — a non-empty array is the honest floor a CONSUMER can assert
+  // without owning the producer's vocabulary.
+  if (!parsed || typeof parsed.mode !== 'string' || !Array.isArray(parsed.hooks) || parsed.hooks.length === 0) {
+    return { actual: 'degraded', detail: `guardrail-block.mjs status --json missing expected 'mode'/'hooks' fields: ${out || '(empty)'}` };
+  }
+  if (parsed.mode !== 'global') return { actual: 'absent', detail: `guardrail-mode=${parsed.mode}` };
+  // CR fix (codex-1-r7, round 7 — third raise of this shape check, each
+  // stricter): round 6 closed the empty-array case, but a TRUNCATED payload
+  // — complete:true with only 1 hook object, that one object itself fully
+  // healthy — still sailed through on parsed.complete alone. RECOMPUTE
+  // completeness from the entries themselves rather than trusting the
+  // producer's own summary flag: every entry must independently satisfy the
+  // same fields the contract defines completeness by (present, matcherMatches,
+  // bashResolves, nodeResolves, wrapperResolves, scriptResolves, entryCount
+  // === 1, nonCanonicalCount === 0). 'present' now requires parsed.complete
+  // === true AND this recomputed value to AGREE — a payload whose entries
+  // contradict its own complete flag is untrustworthy, not present.
+  //
+  // ACCEPTED FLOOR (documented, not fixed here — HIMMEL-1422 territory):
+  // this still cannot catch an INTERNALLY CONSISTENT truncated array —
+  // e.g. complete:true with exactly 1 well-formed, fully-healthy hook
+  // object, when the real contract enumerates 3. Detecting "too few
+  // entries" requires knowing the EXPECTED count, which only the producer
+  // (guardrail-block.mjs's own GUARDRAILS array) owns; asserting a count
+  // here (hardcoded "3", or a `>1` guess) would be exactly the kind of
+  // producer-vocabulary duplication round 6 already rejected, and a real
+  // producer always emits its full fixed-order set regardless — this probe
+  // takes the floor: a non-empty, internally-self-consistent payload is
+  // trusted, and the count-verification gap stays deferred to HIMMEL-1422's
+  // trust-anchor work.
+  const guardrailEntryIsFullyValid = (h) => Boolean(h)
+    && h.present === true
+    && h.entryCount === 1
+    && (h.nonCanonicalCount || 0) === 0
+    && h.matcherMatches === true
+    && h.bashResolves === true
+    && h.nodeResolves === true
+    && h.wrapperResolves === true
+    && h.scriptResolves === true;
+  const recomputedComplete = parsed.hooks.every(guardrailEntryIsFullyValid);
+  if (parsed.complete === true) {
+    if (!recomputedComplete) {
+      return { actual: 'degraded', detail: `guardrail-block.mjs status --json declares complete=true but its own hooks[] entries do not all independently support it — self-contradictory payload, not trusted: ${out}` };
+    }
+    return { actual: 'present', detail: `guardrail-mode=global — all ${parsed.hooks.length} guardrail hooks present, correctly matched, and resolving` };
+  }
+  // complete !== true: name exactly which hook(s) fall short, rather than
+  // just saying "incomplete" — the whole point of the richer verb is to let
+  // an operator (or `himmelctl doctor`) act on a specific broken hook.
+  const problems = parsed.hooks
+    .filter((h) => !(h && h.present && h.entryCount === 1 && (h.nonCanonicalCount || 0) === 0
+      && h.matcherMatches && h.bashResolves && h.nodeResolves && h.wrapperResolves && h.scriptResolves))
+    .map((h) => {
+      // CR fix (codex-adv-7): even a hook with NO canonical entry at all can
+      // still have a runtime-relevant non-canonical one wired (same
+      // wrapper/script identity, non-generated shape) — "missing" alone
+      // would understate that, so it's named here too, not just below when
+      // a canonical entry is also present.
+      if (!h || !h.present) {
+        const label = `${h && h.basename ? h.basename : '?'}: missing`;
+        if (h && typeof h.nonCanonicalCount === 'number' && h.nonCanonicalCount > 0) {
+          return `${label} (canonical entry absent, but ${h.nonCanonicalCount} non-canonical entr${h.nonCanonicalCount === 1 ? 'y' : 'ies'} referencing this guardrail's identity ${h.nonCanonicalCount === 1 ? 'is' : 'are'} still wired and runtime-relevant)`;
+        }
+        return label;
+      }
+      const reasons = [];
+      // CR fix (codex-adv-4): a duplicate owned entry is a problem in its own
+      // right, independent of whether the FIRST-FOUND one is fully valid — a
+      // dead-pathed duplicate is still independently wired and can fail
+      // closed at runtime, so it's named even when the primary entry alone
+      // would otherwise pass every other check.
+      if (typeof h.entryCount === 'number' && h.entryCount > 1) reasons.push(`${h.entryCount} duplicate entries wired (expected exactly 1)`);
+      // CR fix (codex-adv-7): a non-canonical entry (same wrapper/script
+      // identity, non-generated shape — e.g. a trailing extra token) is
+      // still runtime-relevant (guardrail-skip-in-himmel.js only reads
+      // argv[2]) even though it's excluded from entryCount, so it must be
+      // named independently of whether the canonical entry alone is valid.
+      if (typeof h.nonCanonicalCount === 'number' && h.nonCanonicalCount > 0) reasons.push(`${h.nonCanonicalCount} non-canonical entr${h.nonCanonicalCount === 1 ? 'y' : 'ies'} reference this guardrail's identity outside the generated shape (still runtime-relevant)`);
+      if (!h.matcherMatches) reasons.push(`matcher mismatch (configured '${h.matcher}', expected '${h.expectedMatcher}')`);
+      const broken = ['bash', 'node', 'wrapper', 'script'].filter((part) => !h[`${part}Resolves`]);
+      if (broken.length > 0) reasons.push(`${broken.join('/')} path does not resolve`);
+      return `${h.basename}: ${reasons.join('; ')}`;
+    });
+  const summary = problems.length > 0 ? problems.join('; ') : 'guardrail-block.mjs status --json reports complete=false with no per-hook gap identified';
+  return { actual: 'degraded', detail: `guardrail-mode=global but incomplete — ${summary}` };
 }
 
 // ── dispatch ─────────────────────────────────────────────────────────────

--- a/scripts/himmelctl/lib/probes.js
+++ b/scripts/himmelctl/lib/probes.js
@@ -996,30 +996,46 @@ function probeCmdCadenceArmed(item, ctx) {
 //     file's contract comment for why "not owned" was chosen over "owned
 //     but flagged").
 //   codex-adv-7 (companion finding "basename-only ownership lets a
-//     same-named no-op file elsewhere pass" is tracked in HIMMEL-1422,
-//     linked to this ticket: binding wrapper/script identity beyond
-//     basename needs a trust-anchor decision — realpath vs
-//     content-integrity vs configurable HIMMEL_REPO anchor): round 4's anchored
-//     GENERATED_COMMAND_RE correctly rejects a true decoy, but it ALSO made
-//     an entry with the SAME wrapper/script identity plus a trailing extra
-//     token invisible entirely — yet guardrail-skip-in-himmel.js reads only
-//     process.argv[2] and ignores anything after it, so Claude Code still
-//     executes such an entry identically to a canonical one. A dead-pathed
-//     duplicate wired in this shape reopened round 3's own blind spot
-//     (entryCount stayed 1, complete:true) through a different command
-//     shape. Fixed via a bounded, NON-substring structural test
-//     (referencesGuardrailIdentity(): every quoted segment's
-//     path.basename() checked against WRAPPER/the guardrail's basename,
-//     never String#includes over the whole string — a comment-only mention
-//     still correctly reads as a decoy, no regression on codex-adv-5) that
-//     surfaces this as its own `nonCanonicalCount`/`nonCanonical` anomaly,
-//     distinct from both a decoy (present:false) and a canonical duplicate
-//     (entryCount > 1); complete now also requires nonCanonicalCount === 0.
+//     same-named no-op file elsewhere pass", tracked as HIMMEL-1422): round
+//     4's anchored GENERATED_COMMAND_RE correctly rejects a true decoy, but
+//     it ALSO made an entry with the SAME wrapper/script identity plus a
+//     trailing extra token invisible entirely — yet guardrail-skip-in-
+//     himmel.js reads only process.argv[2] and ignores anything after it,
+//     so Claude Code still executes such an entry identically to a
+//     canonical one. A dead-pathed duplicate wired in this shape reopened
+//     round 3's own blind spot (entryCount stayed 1, complete:true) through
+//     a different command shape. Fixed via a bounded, NON-substring
+//     structural test (referencesGuardrailIdentity(): every quoted
+//     segment's path.basename() checked against WRAPPER/the guardrail's
+//     basename, never String#includes over the whole string — a
+//     comment-only mention still correctly reads as a decoy, no regression
+//     on codex-adv-5) that surfaces this as its own
+//     `nonCanonicalCount`/`nonCanonical` anomaly, distinct from both a
+//     decoy (present:false) and a canonical duplicate (entryCount > 1);
+//     complete now also requires nonCanonicalCount === 0.
+//   HIMMEL-1422 (trust anchor, resolving codex-adv-7's own companion
+//     finding above): basename-only ownership meant a settings.json
+//     referencing a same-named file in a WRONG directory (a stale/moved
+//     checkout, or an unrelated no-op stub with the right filename) still
+//     read present:true/resolves:true — "present" attested wiring, not
+//     that the wired file IS the real himmel copy. guardrail-block.mjs's
+//     statusDetail() now realpath-compares the configured wrapper/script
+//     paths against a resolved trust anchor (HIMMEL_REPO env, else the
+//     running guardrail-block.mjs's own checkout) via
+//     wrapperMatchesAnchor/scriptMatchesAnchor; a mismatch never flips
+//     present:false (ownership stays basename-only, per codex-adv-5) but
+//     DOES force complete:false, with anchorWrapperPath/anchorScriptPath
+//     naming the anchor precisely. Separately, wrapperResolves/
+//     scriptResolves now also require non-trivial content
+//     (isSaneContentFile()) — a truncated/empty file at an otherwise-
+//     correct, even anchor-matching, path no longer reads resolves:true
+//     either. This probe's recompute (guardrailEntryIsFullyValid below) and
+//     its `problems` naming were extended in lockstep — see both below.
 //   SCOPE: this probe attests the FULL GENERATED COMMAND IDENTITY —
-//     presence, resolution, matcher, uniqueness, and shape — of the
-//     CONFIGURED wiring. It does not attempt deeper runtime proof
-//     (executing the hook chain, node/bash version checks,
-//     ACL/trust-anchor analysis — tracked in HIMMEL-1422 — or semantic
+//     presence, resolution, matcher, uniqueness, shape, AND trust-anchor
+//     identity — of the CONFIGURED wiring. It does not attempt deeper
+//     runtime proof (executing the hook chain, node/bash version checks,
+//     full content hashing beyond the cheap sanity floor, or semantic
 //     equivalence of a differently-formed command); those belong to
 //     follow-up tickets against the contract, not this probe.
 //   mode=project    -> 'absent' (never armed globally — the ordinary
@@ -1083,18 +1099,23 @@ function probeGuardrailBlockStatus(item, ctx) {
   // === true AND this recomputed value to AGREE — a payload whose entries
   // contradict its own complete flag is untrustworthy, not present.
   //
-  // ACCEPTED FLOOR (documented, not fixed here — HIMMEL-1422 territory):
-  // this still cannot catch an INTERNALLY CONSISTENT truncated array —
-  // e.g. complete:true with exactly 1 well-formed, fully-healthy hook
-  // object, when the real contract enumerates 3. Detecting "too few
-  // entries" requires knowing the EXPECTED count, which only the producer
-  // (guardrail-block.mjs's own GUARDRAILS array) owns; asserting a count
-  // here (hardcoded "3", or a `>1` guess) would be exactly the kind of
-  // producer-vocabulary duplication round 6 already rejected, and a real
-  // producer always emits its full fixed-order set regardless — this probe
-  // takes the floor: a non-empty, internally-self-consistent payload is
-  // trusted, and the count-verification gap stays deferred to HIMMEL-1422's
-  // trust-anchor work.
+  // ACCEPTED FLOOR (documented, not fixed here — out of HIMMEL-1422's
+  // trust-anchor scope, a distinct residual gap): this still cannot catch
+  // an INTERNALLY CONSISTENT truncated array — e.g. complete:true with
+  // exactly 1 well-formed, fully-healthy hook object, when the real
+  // contract enumerates 3. Detecting "too few entries" requires knowing the
+  // EXPECTED count, which only the producer (guardrail-block.mjs's own
+  // GUARDRAILS array) owns; asserting a count here (hardcoded "3", or a
+  // `>1` guess) would be exactly the kind of producer-vocabulary
+  // duplication round 6 already rejected, and a real producer always emits
+  // its full fixed-order set regardless — this probe takes the floor: a
+  // non-empty, internally-self-consistent payload is trusted.
+  //
+  // HIMMEL-1422: also requires wrapperMatchesAnchor/scriptMatchesAnchor —
+  // an entry whose configured wrapper/script paths do NOT match the trust
+  // anchor's own scripts/hooks/ copies (a same-basename file wired from a
+  // wrong/stale checkout) must not independently recompute as valid either,
+  // even if every other field on it looks healthy.
   const guardrailEntryIsFullyValid = (h) => Boolean(h)
     && h.present === true
     && h.entryCount === 1
@@ -1103,7 +1124,9 @@ function probeGuardrailBlockStatus(item, ctx) {
     && h.bashResolves === true
     && h.nodeResolves === true
     && h.wrapperResolves === true
-    && h.scriptResolves === true;
+    && h.scriptResolves === true
+    && h.wrapperMatchesAnchor === true
+    && h.scriptMatchesAnchor === true;
   const recomputedComplete = parsed.hooks.every(guardrailEntryIsFullyValid);
   if (parsed.complete === true) {
     if (!recomputedComplete) {
@@ -1116,7 +1139,8 @@ function probeGuardrailBlockStatus(item, ctx) {
   // an operator (or `himmelctl doctor`) act on a specific broken hook.
   const problems = parsed.hooks
     .filter((h) => !(h && h.present && h.entryCount === 1 && (h.nonCanonicalCount || 0) === 0
-      && h.matcherMatches && h.bashResolves && h.nodeResolves && h.wrapperResolves && h.scriptResolves))
+      && h.matcherMatches && h.bashResolves && h.nodeResolves && h.wrapperResolves && h.scriptResolves
+      && h.wrapperMatchesAnchor && h.scriptMatchesAnchor))
     .map((h) => {
       // CR fix (codex-adv-7): even a hook with NO canonical entry at all can
       // still have a runtime-relevant non-canonical one wired (same
@@ -1146,6 +1170,15 @@ function probeGuardrailBlockStatus(item, ctx) {
       if (!h.matcherMatches) reasons.push(`matcher mismatch (configured '${h.matcher}', expected '${h.expectedMatcher}')`);
       const broken = ['bash', 'node', 'wrapper', 'script'].filter((part) => !h[`${part}Resolves`]);
       if (broken.length > 0) reasons.push(`${broken.join('/')} path does not resolve`);
+      // HIMMEL-1422: a wrapper/script that resolves but is NOT the trust
+      // anchor's own copy (same basename, wrong/stale checkout) is a
+      // distinct problem from "does not resolve" — name it with the exact
+      // anchor path expected, so an operator can see precisely which
+      // checkout the wiring should point at.
+      const anchorMismatches = [];
+      if (h.wrapperMatchesAnchor === false) anchorMismatches.push(`wrapper (expected ${h.anchorWrapperPath})`);
+      if (h.scriptMatchesAnchor === false) anchorMismatches.push(`script (expected ${h.anchorScriptPath})`);
+      if (anchorMismatches.length > 0) reasons.push(`does not match trust anchor: ${anchorMismatches.join(', ')}`);
       return `${h.basename}: ${reasons.join('; ')}`;
     });
   const summary = problems.length > 0 ? problems.join('; ') : 'guardrail-block.mjs status --json reports complete=false with no per-hook gap identified';

--- a/scripts/himmelctl/test/test-wizard-ensure-disable.sh
+++ b/scripts/himmelctl/test/test-wizard-ensure-disable.sh
@@ -99,9 +99,10 @@
 #      of permanently blocking every ensure the way a 'present' item still
 #      does — the removal gate used to push ANY non-absent probe as an
 #      unconditional blocker, wedging a probe that can structurally never
-#      confirm 'present' (e.g. guardrail-block-global) forever, with no
-#      unwire descriptor to ever converge it. Asserted across TWO
-#      consecutive runs (not a one-shot fluke).
+#      confirm 'present' (e.g. guardrail-block-global, before its HIMMEL-1418
+#      `status --json` verb) forever, with no unwire descriptor to ever
+#      converge it. Asserted across TWO consecutive runs (not a one-shot
+#      fluke).
 
 set -euo pipefail
 
@@ -1290,9 +1291,10 @@ echo "ok: case o — the TRANSITIVE reverse walk STOPS at an absent undesired in
 # 'absent') must NOT block/abort an `ensure` run the way a 'present' one
 # does — the toward-disabled removal gate used to push ANY non-absent probe
 # as an unconditional blocker, so a probe that structurally can never
-# confirm 'present' from status output alone (e.g. guardrail-block-global)
-# wedged EVERY run permanently, with no unwire descriptor to ever converge
-# it. The fix probes the item first: 'present' still blocks (case b, above,
+# confirm 'present' from status output alone (e.g. guardrail-block-global,
+# before its HIMMEL-1418 `status --json` verb) wedged EVERY run permanently,
+# with no unwire descriptor to ever converge it. The fix probes the item
+# first: 'present' still blocks (case b, above,
 # unchanged); 'degraded' logs an ADVISORY line instead and the run PROCEEDS
 # (exit 0); 'absent' needs no note. Reuses the settings-hooks probe shape
 # from case c (1/3 himmel PreToolUse markers -> 'degraded', never 'present'

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -1659,7 +1659,15 @@ echo "ok: cmd:guardrail_block_status — a partial (1-of-3) install reads degrad
 # when EVERY GUARDRAILS hook is present, its ACTUAL matcher exactly matches
 # what it needs for full tool coverage, and bash/node/wrapper/script paths
 # ALL resolve — so a genuinely fully-armed machine now reads present instead
-# of being permanently bounded to degraded.
+# of being permanently bounded to degraded. HIMMEL-1422: this fixture bakes
+# wrapper/script paths under $repo_root_w, so its ctx.env below PINS
+# HIMMEL_REPO to that same $repo_root_w — hermetic against whatever
+# HIMMEL_REPO the ambient shell running this suite happens to carry (a real
+# operator machine auto-sets it in ~/.claude/settings.json, typically
+# pointing at the PRIMARY checkout, not necessarily this worktree); without
+# the pin, guardrail-block.mjs's trust-anchor check would compare this
+# fixture's baked paths against a DIFFERENT checkout and read a false
+# anchor mismatch.
 gb_settings_full="$work/gb-settings-full/.claude"; mkdir -p "$gb_settings_full"
 "$node_bin" -e "
 const fs = require('fs');
@@ -1680,14 +1688,91 @@ const { runProbe } = require('$probes_lib_w');
 const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
 const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
 const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user',
-  env: Object.assign({}, process.env, { CLAUDE_USER_SETTINGS: '$(winpath "$gb_settings_full")/settings.json' }) };
+  env: Object.assign({}, process.env, { CLAUDE_USER_SETTINGS: '$(winpath "$gb_settings_full")/settings.json', HIMMEL_REPO: '$repo_root_w' }) };
 console.log(JSON.stringify(runProbe(item, ctx)));
 ")
 echo "$outGBf" | jq -e '.actual == "present"' >/dev/null \
-  || fail "cmd:guardrail_block_status: a genuine 3-of-3 install (every hook wired under its correct matcher, bash/node/wrapper/script all resolving) must read present: (got: $outGBf)"
+  || fail "cmd:guardrail_block_status: a genuine 3-of-3 install (every hook wired under its correct matcher, bash/node/wrapper/script all resolving, HIMMEL-1422 trust anchor matching) must read present: (got: $outGBf)"
 echo "$outGBf" | jq -e '.detail | contains("3 guardrail hooks present, correctly matched, and resolving")' >/dev/null \
   || fail "cmd:guardrail_block_status present detail should confirm all 3 hooks (got: $outGBf)"
 echo "ok: cmd:guardrail_block_status — a genuine full (3-of-3) install now reads present via status --json"
+
+# ── HIMMEL-1422: same-basename, WRONG-checkout wiring → degraded, never
+# present, even though every other check (basename ownership, matcher,
+# bash/node/wrapper/script resolution) is genuinely fine. This is the
+# ticket's motivating scenario: a stale/moved checkout (or an unrelated
+# same-named stub elsewhere) that ownsGuardrail()'s basename-only identity
+# check alone cannot distinguish from the real thing. auto-approve-safe-
+# bash.sh's wrapper+script here live under a SEPARATE, real, non-empty
+# checkout ($gb_wrong_checkout) — not $repo_root_w, the pinned trust
+# anchor — so the probe must flag it, not the wrapper/script *Resolves
+# checks (which stay true: the files genuinely exist and are readable). ───
+gb_wrong_checkout="$work/gb-wrong-checkout"; mkdir -p "$gb_wrong_checkout/scripts/hooks"
+: > "$gb_wrong_checkout/scripts/hooks/guardrail-skip-in-himmel.js"
+printf '// real content, not a truncated stub\n' > "$gb_wrong_checkout/scripts/hooks/guardrail-skip-in-himmel.js"
+printf '# real content, not a truncated stub\n' > "$gb_wrong_checkout/scripts/hooks/auto-approve-safe-bash.sh"
+gb_settings_wrong_checkout="$work/gb-settings-wrong-checkout/.claude"; mkdir -p "$gb_settings_wrong_checkout"
+"$node_bin" -e "
+const fs = require('fs');
+const nodePath = '$(winpath "$gb_node_stub")';
+const bashPath = '$(winpath "$gb_bash_stub")';
+const wrongRepo = '$(winpath "$gb_wrong_checkout")';
+const command = 'GUARDRAIL_BASH=' + JSON.stringify(bashPath) + ' ' + JSON.stringify(nodePath) + ' ' + JSON.stringify(wrongRepo + '/scripts/hooks/guardrail-skip-in-himmel.js') + ' ' + JSON.stringify(wrongRepo + '/scripts/hooks/auto-approve-safe-bash.sh');
+const settings = { hooks: { PreToolUse: [ { matcher: 'Bash', hooks: [ { type: 'command', command } ] } ] } };
+fs.writeFileSync('$(winpath "$gb_settings_wrong_checkout")/settings.json', JSON.stringify(settings, null, 2));
+"
+outGBwc=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user',
+  env: Object.assign({}, process.env, { CLAUDE_USER_SETTINGS: '$(winpath "$gb_settings_wrong_checkout")/settings.json', HIMMEL_REPO: '$repo_root_w' }) };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outGBwc" | jq -e '.actual == "degraded"' >/dev/null \
+  || fail "cmd:guardrail_block_status: a same-basename wrapper/script wired from a WRONG checkout (not the pinned trust anchor) must read degraded, never present (HIMMEL-1422): (got: $outGBwc)"
+echo "$outGBwc" | jq -e '.detail | contains("does not match trust anchor")' >/dev/null \
+  || fail "cmd:guardrail_block_status wrong-checkout detail should name the trust-anchor mismatch (got: $outGBwc)"
+echo "ok: cmd:guardrail_block_status — same-basename wiring from a wrong checkout reads degraded with the trust-anchor mismatch named, never present (HIMMEL-1422)"
+
+# ── HIMMEL-1422: correct-checkout, correct path, but a TRUNCATED (empty)
+# script file → degraded, never present. Uses its OWN fake anchor checkout
+# ($gb_truncated_anchor, HIMMEL_REPO pinned to it) rather than truncating a
+# file under the real $repo_root_w scripts/hooks/ (which would break this
+# very test run's own guardrail wiring) — the wrapper/script paths baked
+# into settings.json live UNDER that anchor, so wrapperMatchesAnchor/
+# scriptMatchesAnchor stay true (this is NOT the wrong-checkout case above);
+# only the script's CONTENT is a no-op, exactly the empty-guardrail-skip-
+# in-himmel.js scenario from the ticket's motivating report. ───────────────
+gb_truncated_anchor="$work/gb-truncated-anchor"; mkdir -p "$gb_truncated_anchor/scripts/hooks"
+printf '// real content, not a truncated stub\n' > "$gb_truncated_anchor/scripts/hooks/guardrail-skip-in-himmel.js"
+: > "$gb_truncated_anchor/scripts/hooks/auto-approve-safe-bash.sh"
+gb_settings_empty_script="$work/gb-settings-empty-script/.claude"; mkdir -p "$gb_settings_empty_script"
+"$node_bin" -e "
+const fs = require('fs');
+const nodePath = '$(winpath "$gb_node_stub")';
+const bashPath = '$(winpath "$gb_bash_stub")';
+const anchorRepo = '$(winpath "$gb_truncated_anchor")';
+const wrapper = anchorRepo + '/scripts/hooks/guardrail-skip-in-himmel.js';
+const command = 'GUARDRAIL_BASH=' + JSON.stringify(bashPath) + ' ' + JSON.stringify(nodePath) + ' ' + JSON.stringify(wrapper) + ' ' + JSON.stringify(anchorRepo + '/scripts/hooks/auto-approve-safe-bash.sh');
+const settings = { hooks: { PreToolUse: [ { matcher: 'Bash', hooks: [ { type: 'command', command } ] } ] } };
+fs.writeFileSync('$(winpath "$gb_settings_empty_script")/settings.json', JSON.stringify(settings, null, 2));
+"
+outGBes=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user',
+  env: Object.assign({}, process.env, { CLAUDE_USER_SETTINGS: '$(winpath "$gb_settings_empty_script")/settings.json', HIMMEL_REPO: '$(winpath "$gb_truncated_anchor")' }) };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outGBes" | jq -e '.actual == "degraded"' >/dev/null \
+  || fail "cmd:guardrail_block_status: an anchor-matching but EMPTY script file must read degraded, never present (HIMMEL-1422 truncation floor): (got: $outGBes)"
+echo "$outGBes" | jq -e '.detail | contains("does not match trust anchor") | not' >/dev/null \
+  || fail "cmd:guardrail_block_status empty-script detail should be a content problem, NOT an anchor mismatch — the path IS the anchor's own copy (got: $outGBes)"
+echo "$outGBes" | jq -e '.detail | contains("script")' >/dev/null \
+  || fail "cmd:guardrail_block_status empty-script detail should name script as the broken part (got: $outGBes)"
+echo "ok: cmd:guardrail_block_status — an anchor-matching but empty (truncated) script file reads degraded, never present (HIMMEL-1422 content-sanity floor)"
 
 # ── codex-adv-1: all 3 hooks wired, every path resolving, but under the
 # WRONG matcher (all 3 crammed into a single 'Bash' group) → degraded, never
@@ -2052,17 +2137,21 @@ echo "ok: cmd:guardrail_block_status degraded when mode=global, complete=true, b
 # nothing recomputed completeness FROM the entries. The probe now requires
 # parsed.complete AND an independent per-entry recomputation to AGREE. ────
 
-# Case 1 (the accepted floor, DOCUMENTED not fixed — HIMMEL-1422 territory):
-# a non-empty, INTERNALLY CONSISTENT array with only 1 (of the real 3) hook
-# objects, that one fully healthy — complete:true and the recomputation over
-# the given entries agree (both say "healthy"), so this reads present. This
-# is the accepted limit: detecting "too few entries" needs the EXPECTED
-# count, which only the producer owns; asserting a count here would
-# duplicate producer vocabulary the same way round 6 already rejected.
+# Case 1 (the accepted floor, DOCUMENTED not fixed — a residual gap distinct
+# from HIMMEL-1422's trust-anchor scope, which this fixture's payload now
+# also satisfies via wrapperMatchesAnchor/scriptMatchesAnchor: true): a
+# non-empty, INTERNALLY CONSISTENT array with only 1 (of the real 3) hook
+# objects, that one fully healthy (including anchor-matching) — complete:true
+# and the recomputation over the given entries agree (both say "healthy"),
+# so this reads present. This is the accepted limit: detecting "too few
+# entries" needs the EXPECTED count, which only the producer owns; asserting
+# a count here would duplicate producer vocabulary the same way round 6
+# already rejected.
 gb_truncated_dir="$work/gb-truncated"; mkdir -p "$gb_truncated_dir/scripts/hooks"
 cat > "$gb_truncated_dir/scripts/hooks/guardrail-block.mjs" <<'JS'
 process.stdout.write(JSON.stringify({
   mode: 'global',
+  anchor: { repo: '/fake/repo', source: 'HIMMEL_REPO' },
   complete: true,
   hooks: [
     {
@@ -2071,7 +2160,9 @@ process.stdout.write(JSON.stringify({
       bashPath: '/fake/bash', bashResolves: true,
       nodePath: '/fake/node', nodeResolves: true,
       wrapperPath: '/fake/wrapper.js', wrapperResolves: true,
+      anchorWrapperPath: '/fake/repo/scripts/hooks/guardrail-skip-in-himmel.js', wrapperMatchesAnchor: true,
       scriptPath: '/fake/script.sh', scriptResolves: true,
+      anchorScriptPath: '/fake/repo/scripts/hooks/auto-approve-safe-bash.sh', scriptMatchesAnchor: true,
       duplicates: [], nonCanonicalCount: 0, nonCanonical: [],
     },
   ],

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -1591,22 +1591,49 @@ console.log(JSON.stringify(runProbe(item, ctx)));
 echo "$outGCp" | jq -e '.actual == "present"' >/dev/null || fail "cmd:cadence_armed (graphmap-cadence) present via GRAPHMAP_BAT_DIR: (got: $outGCp)"
 echo "ok: cmd:cadence_armed envVar wiring — codex-sweep-cadence/graphmap-cadence each route to their OWN dir"
 
-# ── cmd:guardrail_block_status (guardrail-block-global) — HIMMEL-1100 ───────
-# CR fix (round 3, codex-adv-1): guardrail-block.mjs's status verb declares
-# mode=global off ANY single owned hook (detectMode: `.some`) and derives
-# node-resolves from only the FIRST owned hook it iterates to — it never
-# enumerates all 3 expected guardrail hooks. This fixture is DELIBERATELY a
-# 1-of-3 partial install (only auto-approve-safe-bash.sh wired) — exactly
-# what used to false-green as 'present' before this round's fix. Bounded to
-# what status output alone can attest: 'present' is unreachable through this
-# data source (see the probe's own comment) until guardrail-block.mjs grows
-# a richer verb — every mode=global reading is 'degraded'.
-gb_node_stub="$work/gb-node-stub"; : > "$gb_node_stub"
+# ── cmd:guardrail_block_status (guardrail-block-global) — HIMMEL-1100/1418 ──
+# HIMMEL-1418: guardrail-block.mjs grew a `status --json` verb enumerating
+# all 3 expected GUARDRAILS hooks with per-hook presence + node/wrapper/
+# script resolution, and the probe now consumes it instead of the plain
+# `guardrail-mode=<mode> node-resolves=<yes|no>` text line (which only ever
+# proved "at least one owned hook exists and ITS node path resolves" —
+# detectMode()'s `.some()`, nodeResolves()'s first-match return). This
+# fixture is DELIBERATELY a 1-of-3 partial install (only auto-approve-safe-
+# bash.sh wired, and even that one hook's wrapper/script paths are FAKE
+# /x/... paths that don't resolve) — exactly what used to false-green as
+# 'present' pre-HIMMEL-1100, and what the round-3 fix could only bound to
+# 'degraded' for lack of per-hook data. It must still read degraded — the
+# genuine 'present' path is proven separately below (full-install fixture).
+gb_node_stub="$work/gb-node-stub"; : > "$gb_node_stub"; chmod +x "$gb_node_stub"
+# A REAL, RUNNABLE stub file for the baked bash path too (CR fix, codex-adv-2
+# then codex-adv-3): every fixture below that hardcoded the literal string
+# "/bin/bash" was a POSIX-only path that never resolves on native Windows
+# (fs.existsSync('/bin/bash') is false here) — harmless before bashResolves
+# existed, but now feeds directly into `complete`. `chmod +x` on both stubs
+# (round 3, codex-adv-3): the new node/bash usability check requires X_OK —
+# a POSIX CI run would otherwise fail the full-install fixture below on a
+# plain non-executable stub file (Windows' X_OK is a no-op, so this was
+# masked here, but not on POSIX).
+gb_bash_stub="$work/gb-bash-stub"; : > "$gb_bash_stub"; chmod +x "$gb_bash_stub"
 gb_settings_present="$work/gb-settings-present/.claude"; mkdir -p "$gb_settings_present"
+# CR fix (glm-2-r6, round 6): this fixture used to hardcode the literal
+# string "/bin/bash" for GUARDRAIL_BASH — which RESOLVES on POSIX (ubuntu
+# CI has a real /bin/bash) but never resolves on native Windows. The
+# assertion below names the EXACT combination of broken parts
+# ("bash/wrapper/script"), so a platform where bash happens to resolve
+# would drop the "bash/" prefix and string-mismatch — red on the public
+# mirror's ubuntu shell-unit job while staying green here. Fixed by baking
+# a DELIBERATELY dead bash path instead (this fixture already wants
+# everything about the one wired hook to be broken, so a genuinely
+# nonexistent bash path is thematically consistent, not just a workaround):
+# now bashResolves is false on EVERY platform, and the asserted detail
+# string is identical everywhere.
+gb_dead_bash_present="$(winpath "$work")/nonexistent-bash-for-partial-install"
 "$node_bin" -e "
 const fs = require('fs');
 const nodePath = '$(winpath "$gb_node_stub")';
-const command = 'GUARDRAIL_BASH=\"/bin/bash\" ' + JSON.stringify(nodePath) + ' \"/x/scripts/hooks/guardrail-skip-in-himmel.js\" \"/x/scripts/hooks/auto-approve-safe-bash.sh\"';
+const deadBashPath = '$gb_dead_bash_present';
+const command = 'GUARDRAIL_BASH=' + JSON.stringify(deadBashPath) + ' ' + JSON.stringify(nodePath) + ' \"/x/scripts/hooks/guardrail-skip-in-himmel.js\" \"/x/scripts/hooks/auto-approve-safe-bash.sh\"';
 const settings = { hooks: { PreToolUse: [ { matcher: 'Bash', hooks: [ { type: 'command', command } ] } ] } };
 fs.writeFileSync('$(winpath "$gb_settings_present")/settings.json', JSON.stringify(settings, null, 2));
 "
@@ -1619,10 +1646,314 @@ const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user
 console.log(JSON.stringify(runProbe(item, ctx)));
 ")
 echo "$outGBp" | jq -e '.actual == "degraded"' >/dev/null \
-  || fail "cmd:guardrail_block_status: a 1-of-3-hooks partial install (mode=global, node-resolves=yes for the one wired hook) must read degraded, NEVER present (status output cannot attest all 3 hooks): (got: $outGBp)"
-echo "$outGBp" | jq -e '.detail | contains("cannot confirm all 3")' >/dev/null \
-  || fail "cmd:guardrail_block_status partial-install detail should explain the status-verb limitation (got: $outGBp)"
-echo "ok: cmd:guardrail_block_status — a partial (1-of-3) install reads degraded, never a false present"
+  || fail "cmd:guardrail_block_status: a 1-of-3-hooks partial install (mode=global, node-resolves=yes for the one wired hook, but its bash/wrapper/script paths are fake) must read degraded, NEVER present: (got: $outGBp)"
+echo "$outGBp" | jq -e '.detail | contains("block-edit-on-main.sh: missing")' >/dev/null \
+  || fail "cmd:guardrail_block_status partial-install detail should name the missing hooks (got: $outGBp)"
+echo "$outGBp" | jq -e '.detail | contains("auto-approve-safe-bash.sh: bash/wrapper/script path does not resolve")' >/dev/null \
+  || fail "cmd:guardrail_block_status partial-install detail should name the wired hook's own broken paths, including its (now deliberately dead, platform-invariant) bash path (got: $outGBp)"
+echo "ok: cmd:guardrail_block_status — a partial (1-of-3) install reads degraded, never a false present, with per-hook detail"
+
+# ── full (3-of-3) install, every hook's matcher CORRECT and every path
+# (bash/node/wrapper/script) genuinely resolving → present ─────────────────
+# HIMMEL-1418's whole point: `complete` in status --json can only be true
+# when EVERY GUARDRAILS hook is present, its ACTUAL matcher exactly matches
+# what it needs for full tool coverage, and bash/node/wrapper/script paths
+# ALL resolve — so a genuinely fully-armed machine now reads present instead
+# of being permanently bounded to degraded.
+gb_settings_full="$work/gb-settings-full/.claude"; mkdir -p "$gb_settings_full"
+"$node_bin" -e "
+const fs = require('fs');
+const nodePath = '$(winpath "$gb_node_stub")';
+const bashPath = '$(winpath "$gb_bash_stub")';
+const repoRoot = '$repo_root_w';
+const basenames = ['auto-approve-safe-bash.sh', 'block-edit-on-main.sh', 'block-read-secrets.sh'];
+const matchers = { 'auto-approve-safe-bash.sh': 'Bash', 'block-edit-on-main.sh': 'Edit|Write|MultiEdit|NotebookEdit', 'block-read-secrets.sh': 'Bash|PowerShell|Read|Grep' };
+const wrapper = repoRoot + '/scripts/hooks/guardrail-skip-in-himmel.js';
+const groups = basenames.map((basename) => ({
+  matcher: matchers[basename],
+  hooks: [ { type: 'command', command: 'GUARDRAIL_BASH=' + JSON.stringify(bashPath) + ' ' + JSON.stringify(nodePath) + ' ' + JSON.stringify(wrapper) + ' ' + JSON.stringify(repoRoot + '/scripts/hooks/' + basename) } ],
+}));
+fs.writeFileSync('$(winpath "$gb_settings_full")/settings.json', JSON.stringify({ hooks: { PreToolUse: groups } }, null, 2));
+"
+outGBf=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user',
+  env: Object.assign({}, process.env, { CLAUDE_USER_SETTINGS: '$(winpath "$gb_settings_full")/settings.json' }) };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outGBf" | jq -e '.actual == "present"' >/dev/null \
+  || fail "cmd:guardrail_block_status: a genuine 3-of-3 install (every hook wired under its correct matcher, bash/node/wrapper/script all resolving) must read present: (got: $outGBf)"
+echo "$outGBf" | jq -e '.detail | contains("3 guardrail hooks present, correctly matched, and resolving")' >/dev/null \
+  || fail "cmd:guardrail_block_status present detail should confirm all 3 hooks (got: $outGBf)"
+echo "ok: cmd:guardrail_block_status — a genuine full (3-of-3) install now reads present via status --json"
+
+# ── codex-adv-1: all 3 hooks wired, every path resolving, but under the
+# WRONG matcher (all 3 crammed into a single 'Bash' group) → degraded, never
+# present. Without this check, block-edit-on-main.sh would never fire on
+# Edit/Write/MultiEdit/NotebookEdit and block-read-secrets.sh would never
+# fire on PowerShell/Read/Grep, while status --json still claimed complete. ─
+gb_settings_bad_matcher="$work/gb-settings-bad-matcher/.claude"; mkdir -p "$gb_settings_bad_matcher"
+"$node_bin" -e "
+const fs = require('fs');
+const nodePath = '$(winpath "$gb_node_stub")';
+const bashPath = '$(winpath "$gb_bash_stub")';
+const repoRoot = '$repo_root_w';
+const basenames = ['auto-approve-safe-bash.sh', 'block-edit-on-main.sh', 'block-read-secrets.sh'];
+const wrapper = repoRoot + '/scripts/hooks/guardrail-skip-in-himmel.js';
+const hooks = basenames.map((basename) => ({ type: 'command', command: 'GUARDRAIL_BASH=' + JSON.stringify(bashPath) + ' ' + JSON.stringify(nodePath) + ' ' + JSON.stringify(wrapper) + ' ' + JSON.stringify(repoRoot + '/scripts/hooks/' + basename) }));
+fs.writeFileSync('$(winpath "$gb_settings_bad_matcher")/settings.json', JSON.stringify({ hooks: { PreToolUse: [ { matcher: 'Bash', hooks } ] } }, null, 2));
+"
+outGBm=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user',
+  env: Object.assign({}, process.env, { CLAUDE_USER_SETTINGS: '$(winpath "$gb_settings_bad_matcher")/settings.json' }) };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outGBm" | jq -e '.actual == "degraded"' >/dev/null \
+  || fail "cmd:guardrail_block_status: all 3 hooks wired, every path resolving, but under the WRONG matcher must read degraded, never present (codex-adv-1): (got: $outGBm)"
+echo "$outGBm" | jq -e '.detail | contains("matcher mismatch")' >/dev/null \
+  || fail "cmd:guardrail_block_status wrong-matcher detail should name the matcher mismatch (got: $outGBm)"
+echo "$outGBm" | jq -e '.detail | contains("block-edit-on-main.sh")' >/dev/null \
+  || fail "cmd:guardrail_block_status wrong-matcher detail should name block-edit-on-main.sh specifically (got: $outGBm)"
+echo "ok: cmd:guardrail_block_status — all-paths-resolving under the WRONG matcher reads degraded, never present (codex-adv-1)"
+
+# ── codex-adv-2: all 3 hooks wired under their CORRECT matcher, node/
+# wrapper/script all resolving, but the baked GUARDRAIL_BASH executable is
+# missing → degraded, never present. The wrapper fails closed on a missing
+# bash at runtime; a status --json that ignored bash would claim complete
+# while the guardrail is machine-wide broken. ──────────────────────────────
+gb_settings_dead_bash="$work/gb-settings-dead-bash/.claude"; mkdir -p "$gb_settings_dead_bash"
+"$node_bin" -e "
+const fs = require('fs');
+const nodePath = '$(winpath "$gb_node_stub")';
+const repoRoot = '$repo_root_w';
+const basenames = ['auto-approve-safe-bash.sh', 'block-edit-on-main.sh', 'block-read-secrets.sh'];
+const matchers = { 'auto-approve-safe-bash.sh': 'Bash', 'block-edit-on-main.sh': 'Edit|Write|MultiEdit|NotebookEdit', 'block-read-secrets.sh': 'Bash|PowerShell|Read|Grep' };
+const wrapper = repoRoot + '/scripts/hooks/guardrail-skip-in-himmel.js';
+const deadBash = repoRoot + '/scripts/hooks/NONEXISTENT-bash.exe';
+const groups = basenames.map((basename) => ({
+  matcher: matchers[basename],
+  hooks: [ { type: 'command', command: 'GUARDRAIL_BASH=' + JSON.stringify(deadBash) + ' ' + JSON.stringify(nodePath) + ' ' + JSON.stringify(wrapper) + ' ' + JSON.stringify(repoRoot + '/scripts/hooks/' + basename) } ],
+}));
+fs.writeFileSync('$(winpath "$gb_settings_dead_bash")/settings.json', JSON.stringify({ hooks: { PreToolUse: groups } }, null, 2));
+"
+outGBb=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user',
+  env: Object.assign({}, process.env, { CLAUDE_USER_SETTINGS: '$(winpath "$gb_settings_dead_bash")/settings.json' }) };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outGBb" | jq -e '.actual == "degraded"' >/dev/null \
+  || fail "cmd:guardrail_block_status: all 3 hooks correctly wired but the baked bash executable is missing must read degraded, never present (codex-adv-2): (got: $outGBb)"
+echo "$outGBb" | jq -e '.detail | contains("bash")' >/dev/null \
+  || fail "cmd:guardrail_block_status dead-bash detail should name bash as unresolved (got: $outGBb)"
+echo "$outGBb" | jq -e '.detail | contains("path does not resolve")' >/dev/null \
+  || fail "cmd:guardrail_block_status dead-bash detail should say the path does not resolve (got: $outGBb)"
+echo "ok: cmd:guardrail_block_status — a genuinely wired install with a dead baked bash path reads degraded, never present (codex-adv-2)"
+
+# ── codex-adv-3 (round 3): fs.existsSync() alone accepts a DIRECTORY as
+# "resolves" — all 3 hooks wired, matcher correct, but the baked node path
+# is a DIRECTORY (not a file) → degraded, never present, even though
+# fs.existsSync() on that path would return true. ──────────────────────────
+gb_node_dir="$work/gb-node-is-a-directory"; mkdir -p "$gb_node_dir"
+gb_settings_node_dir="$work/gb-settings-node-dir/.claude"; mkdir -p "$gb_settings_node_dir"
+"$node_bin" -e "
+const fs = require('fs');
+const nodePath = '$(winpath "$gb_node_dir")';
+const bashPath = '$(winpath "$gb_bash_stub")';
+const repoRoot = '$repo_root_w';
+const basenames = ['auto-approve-safe-bash.sh', 'block-edit-on-main.sh', 'block-read-secrets.sh'];
+const matchers = { 'auto-approve-safe-bash.sh': 'Bash', 'block-edit-on-main.sh': 'Edit|Write|MultiEdit|NotebookEdit', 'block-read-secrets.sh': 'Bash|PowerShell|Read|Grep' };
+const wrapper = repoRoot + '/scripts/hooks/guardrail-skip-in-himmel.js';
+const groups = basenames.map((basename) => ({
+  matcher: matchers[basename],
+  hooks: [ { type: 'command', command: 'GUARDRAIL_BASH=' + JSON.stringify(bashPath) + ' ' + JSON.stringify(nodePath) + ' ' + JSON.stringify(wrapper) + ' ' + JSON.stringify(repoRoot + '/scripts/hooks/' + basename) } ],
+}));
+fs.writeFileSync('$(winpath "$gb_settings_node_dir")/settings.json', JSON.stringify({ hooks: { PreToolUse: groups } }, null, 2));
+"
+outGBnd=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user',
+  env: Object.assign({}, process.env, { CLAUDE_USER_SETTINGS: '$(winpath "$gb_settings_node_dir")/settings.json' }) };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outGBnd" | jq -e '.actual == "degraded"' >/dev/null \
+  || fail "cmd:guardrail_block_status: a DIRECTORY at the baked node path must read degraded, never present, even though fs.existsSync() would call it present (codex-adv-3): (got: $outGBnd)"
+echo "$outGBnd" | jq -e '.detail | contains("node")' >/dev/null \
+  || fail "cmd:guardrail_block_status directory-at-node-path detail should name node as unresolved (got: $outGBnd)"
+echo "ok: cmd:guardrail_block_status — a DIRECTORY at the baked node path reads degraded, never present (codex-adv-3)"
+
+# ── codex-adv-4 (round 3): duplicate owned entries per basename were
+# invisible past the first match — 6 configured entries (one valid + one
+# dead-node duplicate per guardrail) used to report only the 3 valid ones
+# and read complete:true, even though the dead duplicate is still
+# independently wired and can fail closed at runtime. ──────────────────────
+gb_dup_dead_node="$work/gb-dup-dead-node"
+gb_settings_dup="$work/gb-settings-dup/.claude"; mkdir -p "$gb_settings_dup"
+"$node_bin" -e "
+const fs = require('fs');
+const nodePath = '$(winpath "$gb_node_stub")';
+const deadNodePath = '$(winpath "$gb_dup_dead_node")';
+const bashPath = '$(winpath "$gb_bash_stub")';
+const repoRoot = '$repo_root_w';
+const basenames = ['auto-approve-safe-bash.sh', 'block-edit-on-main.sh', 'block-read-secrets.sh'];
+const matchers = { 'auto-approve-safe-bash.sh': 'Bash', 'block-edit-on-main.sh': 'Edit|Write|MultiEdit|NotebookEdit', 'block-read-secrets.sh': 'Bash|PowerShell|Read|Grep' };
+const wrapper = repoRoot + '/scripts/hooks/guardrail-skip-in-himmel.js';
+const cmdFor = (node, basename) => 'GUARDRAIL_BASH=' + JSON.stringify(bashPath) + ' ' + JSON.stringify(node) + ' ' + JSON.stringify(wrapper) + ' ' + JSON.stringify(repoRoot + '/scripts/hooks/' + basename);
+// ONE valid group per guardrail (the genuine install) PLUS one extra group
+// per guardrail wired to a dead node path — 6 owned entries total, exactly
+// the reproduced shape.
+const validGroups = basenames.map((basename) => ({ matcher: matchers[basename], hooks: [ { type: 'command', command: cmdFor(nodePath, basename) } ] }));
+const dupGroups = basenames.map((basename) => ({ matcher: matchers[basename], hooks: [ { type: 'command', command: cmdFor(deadNodePath, basename) } ] }));
+fs.writeFileSync('$(winpath "$gb_settings_dup")/settings.json', JSON.stringify({ hooks: { PreToolUse: [ ...validGroups, ...dupGroups ] } }, null, 2));
+"
+outGBdup=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user',
+  env: Object.assign({}, process.env, { CLAUDE_USER_SETTINGS: '$(winpath "$gb_settings_dup")/settings.json' }) };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outGBdup" | jq -e '.actual == "degraded"' >/dev/null \
+  || fail "cmd:guardrail_block_status: a valid entry PLUS a dead-node duplicate per guardrail (6 entries total) must read degraded, never present (codex-adv-4): (got: $outGBdup)"
+echo "$outGBdup" | jq -e '.detail | contains("duplicate entries wired")' >/dev/null \
+  || fail "cmd:guardrail_block_status duplicate-entry detail should name the duplication (got: $outGBdup)"
+echo "ok: cmd:guardrail_block_status — a valid entry plus a dead-node duplicate per guardrail reads degraded, never present (codex-adv-4)"
+
+# ── codex-adv-5 (round 4): ownership by whole-string substring search let a
+# DECOY command through — the real (4th quoted) script arg for all 3 groups
+# is a stub file, and each guardrail's actual basename appears ONLY in a
+# trailing shell comment. The pre-fix isOwnedHook()/parseOwnedCommand() pair
+# would have reported this as "owned, script resolves" per guardrail. Fixed
+# semantic: NOT owned by any guardrail at all (present:false/entryCount:0 —
+# reads identically to "never wired"), so this must read degraded (mode
+# still reads global off the decoy — detectMode()'s loose match is
+# unchanged/out of scope — but no guardrail has a genuine owned entry). ────
+gb_decoy_script="$work/gb-decoy-script.sh"; : > "$gb_decoy_script"
+gb_settings_decoy="$work/gb-settings-decoy/.claude"; mkdir -p "$gb_settings_decoy"
+"$node_bin" -e "
+const fs = require('fs');
+const nodePath = '$(winpath "$gb_node_stub")';
+const bashPath = '$(winpath "$gb_bash_stub")';
+const decoyScript = '$(winpath "$gb_decoy_script")';
+const repoRoot = '$repo_root_w';
+const basenames = ['auto-approve-safe-bash.sh', 'block-edit-on-main.sh', 'block-read-secrets.sh'];
+const matchers = { 'auto-approve-safe-bash.sh': 'Bash', 'block-edit-on-main.sh': 'Edit|Write|MultiEdit|NotebookEdit', 'block-read-secrets.sh': 'Bash|PowerShell|Read|Grep' };
+const wrapper = repoRoot + '/scripts/hooks/guardrail-skip-in-himmel.js';
+// Real script arg is the SAME decoy for all 3; the guardrail's own basename
+// sits ONLY in a trailing comment — no quoted-argument parse ever sees it.
+const groups = basenames.map((basename) => ({
+  matcher: matchers[basename],
+  hooks: [ { type: 'command', command: 'GUARDRAIL_BASH=' + JSON.stringify(bashPath) + ' ' + JSON.stringify(nodePath) + ' ' + JSON.stringify(wrapper) + ' ' + JSON.stringify(decoyScript) + ' # ' + basename } ],
+}));
+fs.writeFileSync('$(winpath "$gb_settings_decoy")/settings.json', JSON.stringify({ hooks: { PreToolUse: groups } }, null, 2));
+"
+outGBdecoy=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user',
+  env: Object.assign({}, process.env, { CLAUDE_USER_SETTINGS: '$(winpath "$gb_settings_decoy")/settings.json' }) };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outGBdecoy" | jq -e '.actual == "degraded"' >/dev/null \
+  || fail "cmd:guardrail_block_status: a decoy script arg with the real basename only in a trailing comment must read degraded, never present (codex-adv-5): (got: $outGBdecoy)"
+echo "$outGBdecoy" | jq -e '.detail | contains("auto-approve-safe-bash.sh: missing")' >/dev/null \
+  || fail "cmd:guardrail_block_status decoy detail should report the guardrail as missing (not owned by a comment mention) (got: $outGBdecoy)"
+echo "$outGBdecoy" | jq -e '.detail | contains("block-edit-on-main.sh: missing")' >/dev/null \
+  || fail "cmd:guardrail_block_status decoy detail should report block-edit-on-main.sh as missing too (got: $outGBdecoy)"
+echo "$outGBdecoy" | jq -e '.detail | contains("block-read-secrets.sh: missing")' >/dev/null \
+  || fail "cmd:guardrail_block_status decoy detail should report block-read-secrets.sh as missing too (got: $outGBdecoy)"
+echo "ok: cmd:guardrail_block_status — a decoy script with the real guardrail basename only in a trailing comment reads degraded (not owned by any guardrail), never present (codex-adv-5)"
+
+# ── codex-adv-7 (round 5): a canonical (fully valid) entry for all 3
+# guardrails PLUS a SAME-IDENTITY duplicate with a TRAILING EXTRA ARGUMENT
+# on auto-approve-safe-bash.sh — guardrail-skip-in-himmel.js reads only
+# process.argv[2] (the script path) and ignores anything after it, so this
+# duplicate is RUNTIME-RELEVANT (Claude still executes it identically to
+# the canonical one), not a decoy. Round 4's anchored regex alone would make
+# it invisible entirely (entryCount would stay 1, complete:true) even
+# though it's wired with a DEAD node path — reopening round 3's own blind
+# spot via a different command shape. Must read degraded, never present. ──
+gb_noncanon_dead_node="$work/gb-noncanon-dead-node"
+gb_settings_noncanon="$work/gb-settings-noncanon/.claude"; mkdir -p "$gb_settings_noncanon"
+"$node_bin" -e "
+const fs = require('fs');
+const nodePath = '$(winpath "$gb_node_stub")';
+const deadNodePath = '$(winpath "$gb_noncanon_dead_node")';
+const bashPath = '$(winpath "$gb_bash_stub")';
+const repoRoot = '$repo_root_w';
+const basenames = ['auto-approve-safe-bash.sh', 'block-edit-on-main.sh', 'block-read-secrets.sh'];
+const matchers = { 'auto-approve-safe-bash.sh': 'Bash', 'block-edit-on-main.sh': 'Edit|Write|MultiEdit|NotebookEdit', 'block-read-secrets.sh': 'Bash|PowerShell|Read|Grep' };
+const wrapper = repoRoot + '/scripts/hooks/guardrail-skip-in-himmel.js';
+const cmdFor = (node, basename, trailing) => 'GUARDRAIL_BASH=' + JSON.stringify(bashPath) + ' ' + JSON.stringify(node) + ' ' + JSON.stringify(wrapper) + ' ' + JSON.stringify(repoRoot + '/scripts/hooks/' + basename) + (trailing ? ' \"extra-trailing-arg\"' : '');
+// ONE canonical, fully-valid entry per guardrail, PLUS a non-canonical
+// (trailing-arg) duplicate on auto-approve-safe-bash.sh alone, wired to a
+// dead node path.
+const canonicalGroups = basenames.map((basename) => ({ matcher: matchers[basename], hooks: [ { type: 'command', command: cmdFor(nodePath, basename, false) } ] }));
+const noncanonGroup = { matcher: 'Bash', hooks: [ { type: 'command', command: cmdFor(deadNodePath, 'auto-approve-safe-bash.sh', true) } ] };
+fs.writeFileSync('$(winpath "$gb_settings_noncanon")/settings.json', JSON.stringify({ hooks: { PreToolUse: [ ...canonicalGroups, noncanonGroup ] } }, null, 2));
+"
+outGBnc=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user',
+  env: Object.assign({}, process.env, { CLAUDE_USER_SETTINGS: '$(winpath "$gb_settings_noncanon")/settings.json' }) };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outGBnc" | jq -e '.actual == "degraded"' >/dev/null \
+  || fail "cmd:guardrail_block_status: a canonical entry PLUS a same-identity trailing-arg duplicate must read degraded, never present (codex-adv-7): (got: $outGBnc)"
+echo "$outGBnc" | jq -e '.detail | contains("non-canonical entr")' >/dev/null \
+  || fail "cmd:guardrail_block_status non-canonical-duplicate detail should name the anomaly (got: $outGBnc)"
+echo "$outGBnc" | jq -e '.detail | contains("auto-approve-safe-bash.sh")' >/dev/null \
+  || fail "cmd:guardrail_block_status non-canonical-duplicate detail should name auto-approve-safe-bash.sh specifically (got: $outGBnc)"
+echo "ok: cmd:guardrail_block_status — a canonical entry plus a same-identity trailing-arg duplicate reads degraded, never present (codex-adv-7)"
+
+# ── full install but the WRAPPER itself has rotted (a moved/deleted himmel
+# checkout — exactly the drift class report_guardrail_block exists to
+# catch) → degraded, never present, even though all 3 hooks are wired. ────
+gb_settings_dead_wrapper="$work/gb-settings-dead-wrapper/.claude"; mkdir -p "$gb_settings_dead_wrapper"
+"$node_bin" -e "
+const fs = require('fs');
+const nodePath = '$(winpath "$gb_node_stub")';
+const repoRoot = '$repo_root_w';
+const basenames = ['auto-approve-safe-bash.sh', 'block-edit-on-main.sh', 'block-read-secrets.sh'];
+const matchers = { 'auto-approve-safe-bash.sh': 'Bash', 'block-edit-on-main.sh': 'Edit|Write|MultiEdit|NotebookEdit', 'block-read-secrets.sh': 'Bash|PowerShell|Read|Grep' };
+// Basename stays 'guardrail-skip-in-himmel.js' (isOwnedHook matches on that
+// substring) but lives under a directory that doesn't exist — the file
+// itself does not resolve.
+const wrapper = repoRoot + '/scripts/hooks/NONEXISTENT-DIR/guardrail-skip-in-himmel.js';
+const groups = basenames.map((basename) => ({
+  matcher: matchers[basename],
+  hooks: [ { type: 'command', command: 'GUARDRAIL_BASH=\"/bin/bash\" ' + JSON.stringify(nodePath) + ' ' + JSON.stringify(wrapper) + ' ' + JSON.stringify(repoRoot + '/scripts/hooks/' + basename) } ],
+}));
+fs.writeFileSync('$(winpath "$gb_settings_dead_wrapper")/settings.json', JSON.stringify({ hooks: { PreToolUse: groups } }, null, 2));
+"
+outGBw=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user',
+  env: Object.assign({}, process.env, { CLAUDE_USER_SETTINGS: '$(winpath "$gb_settings_dead_wrapper")/settings.json' }) };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outGBw" | jq -e '.actual == "degraded"' >/dev/null \
+  || fail "cmd:guardrail_block_status: all 3 hooks wired but the shared wrapper path is dead must read degraded, not present: (got: $outGBw)"
+echo "$outGBw" | jq -e '.detail | contains("wrapper")' >/dev/null \
+  || fail "cmd:guardrail_block_status dead-wrapper detail should name the wrapper as unresolved (got: $outGBw)"
+echo "$outGBw" | jq -e '.detail | contains("path does not resolve")' >/dev/null \
+  || fail "cmd:guardrail_block_status dead-wrapper detail should say the path does not resolve (got: $outGBw)"
+echo "ok: cmd:guardrail_block_status — a rotted wrapper path on an otherwise-3-of-3 install reads degraded, never present"
 
 gb_settings_absent="$work/gb-settings-absent"; mkdir -p "$gb_settings_absent"
 outGBa=$("$node_bin" -e "
@@ -1652,7 +1983,7 @@ const ctx = { repoRoot: '$repo_root_w', targetPath: '$repo_root_w', scope: 'user
 console.log(JSON.stringify(runProbe(item, ctx)));
 ")
 echo "$outGBd" | jq -e '.actual == "degraded"' >/dev/null || fail "cmd:guardrail_block_status degraded (global mode, node path rotted): (got: $outGBd)"
-echo "$outGBd" | jq -e '.detail | contains("no longer resolves")' >/dev/null || fail "cmd:guardrail_block_status degraded detail should say node no longer resolves (got: $outGBd)"
+echo "$outGBd" | jq -e '.detail | contains("path does not resolve")' >/dev/null || fail "cmd:guardrail_block_status degraded detail should say a path no longer resolves (got: $outGBd)"
 
 gb_bad_script_dir="$work/gb-bad-script"; mkdir -p "$gb_bad_script_dir/scripts/hooks"
 cat > "$gb_bad_script_dir/scripts/hooks/guardrail-block.mjs" <<'JS'
@@ -1668,14 +1999,14 @@ console.log(JSON.stringify(runProbe(item, ctx)));
 echo "$outGBu" | jq -e '.actual == "degraded"' >/dev/null || fail "cmd:guardrail_block_status degraded (unparseable output): (got: $outGBu)"
 echo "$outGBu" | jq -e '.detail | contains("unparseable")' >/dev/null || fail "cmd:guardrail_block_status unparseable-output detail should name it (got: $outGBu)"
 
-# CR fix (HIMMEL-1100 round 2, glm-3): mode=global but node-resolves is
-# MISSING entirely (distinct from the unparseable case above — mode itself
-# IS present/parseable here) used to fall through to 'present', since
-# `resolves === 'no'` is simply false for a missing field. A missing field is
-# not proof of resolution.
+# HIMMEL-1418: mode is valid JSON and present, but the 'hooks' array is
+# MISSING entirely (a wiring/shape break in guardrail-block.mjs's own
+# output, distinct from the plain-unparseable case above) — must NOT be
+# treated as a confirmed install; same "missing field is not proof" stance
+# as HIMMEL-1100 round 2's node-resolves check, now against the richer verb.
 gb_missing_field_dir="$work/gb-missing-field"; mkdir -p "$gb_missing_field_dir/scripts/hooks"
 cat > "$gb_missing_field_dir/scripts/hooks/guardrail-block.mjs" <<'JS'
-process.stdout.write('guardrail-mode=global\n');
+process.stdout.write(JSON.stringify({ mode: 'global' }) + '\n');
 JS
 outGBmf=$("$node_bin" -e "
 const { runProbe } = require('$probes_lib_w');
@@ -1685,10 +2016,111 @@ const ctx = { repoRoot: '$(winpath "$gb_missing_field_dir")', targetPath: '$repo
 console.log(JSON.stringify(runProbe(item, ctx)));
 ")
 echo "$outGBmf" | jq -e '.actual == "degraded"' >/dev/null \
-  || fail "cmd:guardrail_block_status degraded (mode=global but node-resolves field missing — must NOT fall through to present): (got: $outGBmf)"
-echo "$outGBmf" | jq -e '.detail | contains("missing")' >/dev/null \
-  || fail "cmd:guardrail_block_status missing-field detail should name it (got: $outGBmf)"
-echo "ok: cmd:guardrail_block_status degraded when mode=global but node-resolves is missing from the output"
+  || fail "cmd:guardrail_block_status degraded (mode=global but 'hooks' array missing — must NOT fall through to present): (got: $outGBmf)"
+echo "$outGBmf" | jq -e '.detail | contains("missing expected")' >/dev/null \
+  || fail "cmd:guardrail_block_status missing-hooks-field detail should name it (got: $outGBmf)"
+echo "ok: cmd:guardrail_block_status degraded when mode=global but the 'hooks' array is missing from status --json output"
+
+# CR fix (codex-1-r6, round 6): mode=global, complete=TRUE, but 'hooks' is a
+# genuinely present, well-typed EMPTY array. Array.isArray([]) is true, so
+# without an explicit non-empty check this would sail straight past the
+# shape guard and into the `complete === true` branch, trusted as 'present'
+# despite attesting ZERO guardrails — a malformed/truncated producer output
+# read as a clean, complete install. Raised as a suggestion in round 2,
+# re-raised as Important in round 6.
+gb_empty_hooks_dir="$work/gb-empty-hooks"; mkdir -p "$gb_empty_hooks_dir/scripts/hooks"
+cat > "$gb_empty_hooks_dir/scripts/hooks/guardrail-block.mjs" <<'JS'
+process.stdout.write(JSON.stringify({ mode: 'global', complete: true, hooks: [] }) + '\n');
+JS
+outGBeh=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
+const ctx = { repoRoot: '$(winpath "$gb_empty_hooks_dir")', targetPath: '$repo_root_w', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outGBeh" | jq -e '.actual == "degraded"' >/dev/null \
+  || fail "cmd:guardrail_block_status degraded (mode=global, complete=true, but hooks=[] — must NOT be trusted as present): (got: $outGBeh)"
+echo "$outGBeh" | jq -e '.detail | contains("missing expected")' >/dev/null \
+  || fail "cmd:guardrail_block_status empty-hooks-array detail should name the shape problem (got: $outGBeh)"
+echo "ok: cmd:guardrail_block_status degraded when mode=global, complete=true, but the 'hooks' array is empty (codex-1-r6)"
+
+# ── codex-1-r7 (round 7 — third raise, each stricter): round 6 closed the
+# EMPTY hooks[] case, but a TRUNCATED payload — complete:true with FEWER
+# hook objects than the real contract enumerates, that one object itself
+# fully healthy — still sailed through on parsed.complete alone, since
+# nothing recomputed completeness FROM the entries. The probe now requires
+# parsed.complete AND an independent per-entry recomputation to AGREE. ────
+
+# Case 1 (the accepted floor, DOCUMENTED not fixed — HIMMEL-1422 territory):
+# a non-empty, INTERNALLY CONSISTENT array with only 1 (of the real 3) hook
+# objects, that one fully healthy — complete:true and the recomputation over
+# the given entries agree (both say "healthy"), so this reads present. This
+# is the accepted limit: detecting "too few entries" needs the EXPECTED
+# count, which only the producer owns; asserting a count here would
+# duplicate producer vocabulary the same way round 6 already rejected.
+gb_truncated_dir="$work/gb-truncated"; mkdir -p "$gb_truncated_dir/scripts/hooks"
+cat > "$gb_truncated_dir/scripts/hooks/guardrail-block.mjs" <<'JS'
+process.stdout.write(JSON.stringify({
+  mode: 'global',
+  complete: true,
+  hooks: [
+    {
+      basename: 'auto-approve-safe-bash.sh', matcher: 'Bash', expectedMatcher: 'Bash', matcherMatches: true,
+      present: true, entryCount: 1,
+      bashPath: '/fake/bash', bashResolves: true,
+      nodePath: '/fake/node', nodeResolves: true,
+      wrapperPath: '/fake/wrapper.js', wrapperResolves: true,
+      scriptPath: '/fake/script.sh', scriptResolves: true,
+      duplicates: [], nonCanonicalCount: 0, nonCanonical: [],
+    },
+  ],
+}) + '\n');
+JS
+outGBtr=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
+const ctx = { repoRoot: '$(winpath "$gb_truncated_dir")', targetPath: '$repo_root_w', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outGBtr" | jq -e '.actual == "present"' >/dev/null \
+  || fail "cmd:guardrail_block_status: an internally-consistent TRUNCATED payload (1 of 3 real hooks, that one fully healthy) reads present under the documented floor (got: $outGBtr)"
+echo "ok: cmd:guardrail_block_status — an internally-consistent truncated payload (fewer entries than the real contract, all healthy) reads present under the documented accepted floor (codex-1-r7, case 1)"
+
+# Case 2 (the NON-NEGOTIABLE case): complete:true, but the ONE hook entry's
+# OWN fields say it is NOT healthy (wrapperResolves:false) — the payload
+# contradicts itself. Must read degraded, never present.
+gb_contradiction_dir="$work/gb-contradiction"; mkdir -p "$gb_contradiction_dir/scripts/hooks"
+cat > "$gb_contradiction_dir/scripts/hooks/guardrail-block.mjs" <<'JS'
+process.stdout.write(JSON.stringify({
+  mode: 'global',
+  complete: true,
+  hooks: [
+    {
+      basename: 'auto-approve-safe-bash.sh', matcher: 'Bash', expectedMatcher: 'Bash', matcherMatches: true,
+      present: true, entryCount: 1,
+      bashPath: '/fake/bash', bashResolves: true,
+      nodePath: '/fake/node', nodeResolves: true,
+      wrapperPath: '/fake/wrapper.js', wrapperResolves: false,
+      scriptPath: '/fake/script.sh', scriptResolves: true,
+      duplicates: [], nonCanonicalCount: 0, nonCanonical: [],
+    },
+  ],
+}) + '\n');
+JS
+outGBcon=$("$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'guardrail-block-global');
+const ctx = { repoRoot: '$(winpath "$gb_contradiction_dir")', targetPath: '$repo_root_w', scope: 'user', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+echo "$outGBcon" | jq -e '.actual == "degraded"' >/dev/null \
+  || fail "cmd:guardrail_block_status: complete=true with an entry whose OWN fields say it is unhealthy (wrapperResolves:false) is self-contradictory and must read degraded, never present (got: $outGBcon)"
+echo "$outGBcon" | jq -e '.detail | contains("self-contradictory")' >/dev/null \
+  || fail "cmd:guardrail_block_status self-contradictory-payload detail should name it as such (got: $outGBcon)"
+echo "ok: cmd:guardrail_block_status — complete=true contradicted by its own hooks[] entry reads degraded, never present (codex-1-r7, case 2, non-negotiable)"
 
 gb_bad_exit_dir="$work/gb-bad-exit"; mkdir -p "$gb_bad_exit_dir/scripts/hooks"
 cat > "$gb_bad_exit_dir/scripts/hooks/guardrail-block.mjs" <<'JS'
@@ -1704,7 +2136,7 @@ console.log(JSON.stringify(runProbe(item, ctx)));
 ")
 echo "$outGBe" | jq -e '.actual == "degraded"' >/dev/null || fail "cmd:guardrail_block_status degraded (script exits nonzero): (got: $outGBe)"
 echo "$outGBe" | jq -e '.detail | contains("rc=2")' >/dev/null || fail "cmd:guardrail_block_status nonzero-exit detail should name the rc (got: $outGBe)"
-echo "ok: cmd:guardrail_block_status (guardrail-block-global) absent/degraded (rotted node path / unparseable output / nonzero exit) — 'present' is unreachable from status output alone, see the partial-install case above"
+echo "ok: cmd:guardrail_block_status (guardrail-block-global) absent/degraded (rotted node path / unparseable output / missing hooks field / nonzero exit) — 'present' is reserved for the genuine full-install case proven above"
 # SKIP NOTE: a spawn-error path (process.execPath itself unresolvable) is not
 # exercised — this probe spawns by ABSOLUTE execPath, never a bash/PATH
 # lookup for node, so the r.error branch has no realistic trigger here (unlike

--- a/scripts/hooks/guardrail-block.mjs
+++ b/scripts/hooks/guardrail-block.mjs
@@ -517,8 +517,11 @@ function resolveOwnedEntry(info, guardrail, anchor) {
 //                            // (entryCount === 1), that entry's ACTUAL
 //                            // matcher exactly equals expectedMatcher, its
 //                            // bash/node/wrapper/script paths are all
-//                            // USABLE (see below), AND its wrapper/script
-//                            // both match the anchor. false otherwise.
+//                            // USABLE (see below), its wrapper/script
+//                            // both match the anchor, AND it has ZERO
+//                            // runtime-relevant NON-CANONICAL duplicate
+//                            // entries (nonCanonicalCount === 0).
+//                            // false otherwise.
 //     "hooks": [
 //       {
 //         "basename": string,        // e.g. "auto-approve-safe-bash.sh"

--- a/scripts/hooks/guardrail-block.mjs
+++ b/scripts/hooks/guardrail-block.mjs
@@ -30,6 +30,8 @@ function parseArgs(argv) {
       if (i + 1 >= argv.length) throw new Error(`${arg} requires a value`);
       args[arg.slice(2)] = argv[i + 1];
       i += 1;
+    } else if (arg === '--json') {
+      args.json = true;
     } else {
       args._.push(arg);
     }
@@ -184,13 +186,376 @@ function nodeResolves(data) {
   return false;
 }
 
+// commandFor() bakes EXACTLY `GUARDRAIL_BASH="<bash>" "<node>" "<wrapper>"
+// "<script>"` — four double-quoted segments, nothing before or after. This
+// is the inverse, but STRICT (CR fix, codex-adv-5): the `$` anchor requires
+// the match to consume the WHOLE command string, so a trailing shell
+// comment or any extra token after the 4th quoted segment fails the match
+// entirely (returns null) rather than being silently ignored. Contrast with
+// the pre-fix parseOwnedCommand(), which took the first three quoted
+// segments off `rest` via matchAll and never checked what followed them —
+// reproduced: a command whose real script arg is a decoy (e.g.
+// "claude-stub.sh") with the guardrail's actual basename sitting in a
+// trailing `# comment` still parsed "successfully" into 3 args, since the
+// comment text was simply never looked at.
+const GENERATED_COMMAND_RE = /^GUARDRAIL_BASH="([^"]*)"\s+"([^"]*)"\s+"([^"]*)"\s+"([^"]*)"\s*$/;
+
+function parseGeneratedCommand(hook) {
+  if (!hook || hook.type !== 'command' || typeof hook.command !== 'string') return null;
+  const match = hook.command.match(GENERATED_COMMAND_RE);
+  if (!match) return null;
+  const [, bashPath, nodePath, wrapperPath, scriptPath] = match;
+  return { bashPath, nodePath, wrapperPath, scriptPath };
+}
+
+// CR fix (codex-adv-5): ownership is IDENTITY, not mention. The pre-fix
+// isOwnedHook() substring-searched the WHOLE command string for `basename`
+// — matching a guardrail's name anywhere, including inside an inert
+// trailing comment, while the actual (4th quoted) script argument pointed
+// somewhere else entirely. This checks the PARSED wrapper/script paths'
+// basenames against the expected constants exactly (path.basename(), never
+// String#includes()) — a decoy command whose real script arg doesn't match
+// `guardrail.basename` is not owned by this guardrail, full stop, no matter
+// what a comment elsewhere in the string claims.
+function ownsGuardrail(parsed, guardrail) {
+  return Boolean(parsed)
+    && path.basename(parsed.wrapperPath) === WRAPPER
+    && path.basename(parsed.scriptPath) === guardrail.basename;
+}
+
+// Returns { hook, matcher, parsed } for EVERY owned entry matching
+// `guardrail` (order = hookGroups() traversal order), keeping each entry's
+// ENCLOSING group matcher alongside the hook itself — unlike isOwnedHook()
+// above (used by installData()/removeData() for CLEANUP, where a loose
+// substring match is the correct, DELIBERATE behavior: catching any
+// hand-edited/stale hook that merely mentions the wrapper is a feature
+// there, not a bug) — and unlike an earlier round's singular
+// findOwnedHookInfo(), which returned only the FIRST match (CR fix,
+// codex-adv-4: installData()'s own dedup step — "remove EVERY existing
+// owned hook for this guardrail" — exists precisely because duplicate owned
+// entries for the same basename are a real drift state; a second,
+// dead-pathed duplicate is invisible to a probe that only ever looks at the
+// first hit, even though it can still independently fire and fail closed at
+// runtime). This is the STRICT counterpart used ONLY by the status --json
+// attestation contract below — never by installData()/removeData(), whose
+// loose cleanup semantics are unchanged and out of scope for this ticket.
+function findGuardrailEntries(data, guardrail) {
+  const found = [];
+  for (const group of hookGroups(data)) {
+    if (!Array.isArray(group.hooks)) continue;
+    for (const hook of group.hooks) {
+      const parsed = parseGeneratedCommand(hook);
+      if (ownsGuardrail(parsed, guardrail)) found.push({ hook, matcher: group.matcher, parsed });
+    }
+  }
+  return found;
+}
+
+// CR fix (codex-adv-7, round 5): round 4's ANCHORED GENERATED_COMMAND_RE
+// correctly rejects a TRUE decoy (wrong script identity, real basename only
+// in an inert trailing comment) — but it also makes an entry with the SAME
+// wrapper/script identity plus a trailing extra token/comment invisible
+// entirely, not merely "not canonical". That's wrong: guardrail-skip-in-
+// himmel.js reads only process.argv[2] (the script path) and ignores
+// anything after it, so Claude Code still executes such an entry
+// identically to a canonical one — it is RUNTIME-RELEVANT. A duplicate
+// wired in this shape with a dead node/bash path would fail closed on
+// matching tool calls while sitting completely outside this contract's
+// enumeration (entryCount would stay 1, complete:true), reopening exactly
+// the blind spot round 3's duplicate detection was built to close, just
+// through a different command shape.
+//
+// This is the BOUNDED structural test for "references our identity without
+// being canonical": extract every double-quoted segment in the command
+// (regardless of position — no `^`/`$` anchor, no fixed arg count) and
+// check whether ANY of them, taken as a whole quoted VALUE and reduced with
+// path.basename(), equals WRAPPER, and ANY (possibly a different one)
+// equals guardrail.basename. This is deliberately NOT the old whole-string
+// substring search (String#includes over the entire command) that codex-
+// adv-5 fixed: a basename sitting in an unquoted trailing `# comment` is
+// never captured by the quote-extraction regex at all, so it still reads as
+// a decoy/not-owned, exactly preserving round 4's fix. Only an ACTUAL
+// quoted path argument whose basename matches counts.
+function referencesGuardrailIdentity(hook, guardrail) {
+  if (!hook || hook.type !== 'command' || typeof hook.command !== 'string') return false;
+  const quoted = [...hook.command.matchAll(/"([^"]*)"/g)].map((m) => m[1]);
+  const hasWrapper = quoted.some((q) => path.basename(q) === WRAPPER);
+  const hasScript = quoted.some((q) => path.basename(q) === guardrail.basename);
+  return hasWrapper && hasScript;
+}
+
+// Returns { hook, matcher } for every hook that references `guardrail`'s
+// identity (wrapper + script basenames, as quoted arguments) but did NOT
+// match the canonical generated shape in findGuardrailEntries() — i.e. the
+// tier-2 "runtime-relevant but non-attestable" anomaly this fix exists to
+// surface. A hook already counted as canonical is excluded here (it would
+// otherwise be double-counted as its own anomaly, since a canonical command
+// trivially also "references" its own identity).
+function findNonCanonicalEntries(data, guardrail) {
+  const found = [];
+  for (const group of hookGroups(data)) {
+    if (!Array.isArray(group.hooks)) continue;
+    for (const hook of group.hooks) {
+      if (ownsGuardrail(parseGeneratedCommand(hook), guardrail)) continue;
+      if (referencesGuardrailIdentity(hook, guardrail)) found.push({ hook, matcher: group.matcher });
+    }
+  }
+  return found;
+}
+
+// CR fix (codex-adv-3): fs.existsSync() alone accepts a DIRECTORY, an
+// unreadable file, or (for node/bash) a non-executable file as "resolves" —
+// reproduced complete:true with a baked path pointing at a plain directory.
+// isFile() is the load-bearing, fully portable check (a directory always
+// fails it, on every platform); the accessSync() mode check layers on top
+// but is a WEAK signal on Windows specifically — fs.accessSync(path, X_OK)
+// on Windows has no real executable-bit concept and behaves like F_OK (just
+// existence), confirmed empirically here, so it does not actually catch a
+// non-executable regular file on Windows the way it does on POSIX. isFile()
+// is what does the real work cross-platform; the mode check is included
+// because it's free, harmless, and is the meaningful check on POSIX.
+function isReadableFile(p) {
+  let stat;
+  try {
+    stat = fs.statSync(p);
+  } catch (_e) {
+    return false;
+  }
+  if (!stat.isFile()) return false;
+  try {
+    fs.accessSync(p, fs.constants.R_OK);
+  } catch (_e) {
+    return false;
+  }
+  return true;
+}
+
+function isRunnableExecutable(p) {
+  if (!isReadableFile(p)) return false;
+  try {
+    fs.accessSync(p, fs.constants.X_OK);
+  } catch (_e) {
+    return false;
+  }
+  return true;
+}
+
+// Resolves ONE owned entry ({ hook, matcher, parsed } from
+// findGuardrailEntries — `parsed` is already strictly matched, so no null
+// check is needed here) into its status --json shape (everything but
+// basename/present/entryCount, which the caller already knows). Shared by
+// the "primary" (first-found) entry and every entry in `duplicates`, so
+// both are checked identically.
+function resolveOwnedEntry(info, guardrail) {
+  return {
+    matcher: info.matcher ?? null,
+    matcherMatches: (info.matcher ?? null) === guardrail.matcher,
+    bashPath: info.parsed.bashPath,
+    bashResolves: isRunnableExecutable(info.parsed.bashPath),
+    nodePath: info.parsed.nodePath,
+    nodeResolves: isRunnableExecutable(info.parsed.nodePath),
+    wrapperPath: info.parsed.wrapperPath,
+    wrapperResolves: isReadableFile(info.parsed.wrapperPath),
+    scriptPath: info.parsed.scriptPath,
+    scriptResolves: isReadableFile(info.parsed.scriptPath),
+  };
+}
+
+// `status --json` contract (HIMMEL-1418, extended by CR fixes codex-adv-1/2,
+// then codex-adv-3/4, then codex-adv-5): a STABLE, machine-readable
+// enumeration of every EXPECTED guardrail hook (GUARDRAILS, in that fixed
+// order), each with its own presence + matcher + usability detail — unlike
+// the plain `status` verb below (kept byte-for-byte unchanged: himmel-
+// update.sh's report_guardrail_block parses it), which only ever proves "at
+// least one owned hook exists and ITS node path resolves" (detectMode()'s
+// `.some()`, nodeResolves()'s first-match return). SCOPE (fixed as of
+// codex-adv-3/4/5, round 4): this contract attests the FULL GENERATED
+// COMMAND IDENTITY — presence, resolution, matcher, uniqueness, and shape —
+// of the configured hook wiring. It does NOT execute the hook chain, check
+// node/bash versions, reason about ACLs beyond isFile()+access(), or judge
+// semantic equivalence of a differently-FORMED-but-still-correct command;
+// that is explicitly out of scope for this ticket (a deeper runtime-proof
+// contract, if ever wanted, is a follow-up ticket, not an extension here).
+//
+// Ownership semantics (CR fix, codex-adv-5, refined by codex-adv-7 — round
+// 5): "owned by guardrail X" (canonical, drives entryCount/present/paths)
+// means the ENTIRE command string parses as EXACTLY the generated shape
+// (GENERATED_COMMAND_RE — 4 quoted segments, nothing trailing) AND the
+// parsed script arg's basename === X's basename. A command that merely
+// MENTIONS X's basename somewhere (e.g. in an unquoted trailing `# comment`)
+// while its real (4th quoted) script arg points elsewhere is a TRUE DECOY —
+// not owned by X, or by ANY guardrail — it reads present:false/entryCount:0
+// for every GUARDRAILS entry, i.e. plain "missing", the same as if nothing
+// were wired at all. This was the deliberately chosen semantic for decoys
+// (over "owned but flagged"): the contract's job is to attest whether the
+// REAL protection is wired, and a decoy is not real protection — "missing"
+// is the most conservative, fail-closed characterization.
+//
+// BUT (codex-adv-7): a command whose wrapper/script ARE X's real identity —
+// each appearing as an actual quoted argument, not a comment — that merely
+// fails the canonical anchored shape (e.g. a trailing extra token/comment
+// AFTER the 4th quoted segment) is NOT a decoy: guardrail-skip-in-himmel.js
+// reads only process.argv[2] (the script path) and ignores anything after
+// it, so Claude Code still executes this entry identically to a canonical
+// one. Silently treating it as "missing" (round 4's blanket answer) would
+// hide a genuinely runtime-relevant duplicate — reopening exactly the
+// round-3 blind spot this ticket already closed once, just via a different
+// command shape. `nonCanonicalCount`/`nonCanonical` (below) surface this as
+// its own tracked anomaly, distinct from both a decoy (not referenced at
+// all) and a canonical duplicate (entryCount, round 3): it FORCES
+// complete:false for the affected guardrail even when the canonical entry
+// alone would otherwise be perfectly valid, because an ignored-but-still-
+// wired duplicate with a dead node/bash path can still fail closed on a
+// matching real tool call.
+//
+// A decoy sitting in an otherwise mode=global settings.json (detectMode()
+// still uses the intentionally loose isOwnedHook() below, so mode can read
+// "global" off a decoy alone) simply yields entryCount:0/nonCanonicalCount:0
+// for every real guardrail, so `complete` still correctly reads false and
+// the probe's detail still correctly says "<basename>: missing" — never a
+// false "present". Shape:
+//   {
+//     "mode": "global" | "project",
+//     "complete": boolean,  // true iff mode === "global" AND every hook
+//                            // below has EXACTLY ONE owned entry
+//                            // (entryCount === 1), that entry's ACTUAL
+//                            // matcher exactly equals expectedMatcher, and
+//                            // its bash/node/wrapper/script paths are all
+//                            // USABLE (see below). false otherwise.
+//     "hooks": [
+//       {
+//         "basename": string,        // e.g. "auto-approve-safe-bash.sh"
+//         "matcher": string|null,    // the FIRST-FOUND owned entry's ACTUAL
+//                                    // PreToolUse matcher (null if absent)
+//         "expectedMatcher": string, // the matcher this hook NEEDS for full
+//                                    // tool coverage (GUARDRAILS' own value)
+//         "matcherMatches": boolean, // matcher === expectedMatcher, EXACT
+//                                    // string equality — a looser "does
+//                                    // matcher cover expectedMatcher's tool
+//                                    // set" check would need to parse both
+//                                    // as alternation regexes and reason
+//                                    // about set containment; exact-match is
+//                                    // the simplest rule that can never
+//                                    // silently under-verify coverage, at
+//                                    // the cost of flagging a hand-authored
+//                                    // matcher that's a harmless superset
+//                                    // as non-compliant too (acceptable: an
+//                                    // operator who wants to relax this
+//                                    // should re-run setup-hooks, not craft
+//                                    // one by hand).
+//         "present": boolean,        // >= 1 owned hook entry exists for this basename
+//         "entryCount": number,      // TOTAL owned entries found for this
+//                                    // basename (CR fix, codex-adv-4:
+//                                    // installData()'s own dedup step
+//                                    // proves duplicate owned entries are a
+//                                    // real drift state — a dead-pathed
+//                                    // duplicate is still independently
+//                                    // wired and can fail closed at
+//                                    // runtime, so `complete` requires
+//                                    // EXACTLY 1, not merely >= 1)
+//         "bashPath": string|null,   // FIRST-FOUND entry's fields below —
+//         "bashResolves": boolean,   // ADDITIONAL entries (if entryCount > 1)
+//         "nodePath": string|null,   // are in `duplicates`, same shape as
+//         "nodeResolves": boolean,   // this block minus basename/present/
+//         "wrapperPath": string|null,// entryCount/duplicates itself.
+//         "wrapperResolves": boolean,
+//         "scriptPath": string|null,
+//         "scriptResolves": boolean, // *Resolves fields (CR fix, codex-adv-3):
+//                                    // "usable", not merely fs.existsSync().
+//                                    // wrapper/script (passed as ARGUMENTS to
+//                                    // node/bash, never exec'd directly) need
+//                                    // only be a regular, READABLE file.
+//                                    // node/bash (spawned as the executable
+//                                    // itself) additionally need X_OK. isFile()
+//                                    // is the load-bearing, fully portable
+//                                    // check — it is what actually rejects a
+//                                    // DIRECTORY, which fs.existsSync() alone
+//                                    // accepted (the reproduced false-green).
+//                                    // The X_OK layer is a WEAK signal on
+//                                    // Windows specifically: fs.accessSync
+//                                    // (path, X_OK) has no real executable-bit
+//                                    // concept there and behaves like F_OK
+//                                    // (existence only, confirmed empirically)
+//                                    // — so a non-executable-but-readable file
+//                                    // baked as the node/bash path will NOT
+//                                    // be caught on Windows, only on POSIX.
+//         "duplicates": [ /* same per-entry shape as above, one per
+//                            ADDITIONAL owned entry beyond the first-found;
+//                            [] when entryCount <= 1 */ ],
+//         "nonCanonicalCount": number, // CR fix, codex-adv-7 (round 5):
+//                                    // commands that reference THIS
+//                                    // guardrail's wrapper+script identity
+//                                    // as actual quoted arguments (not a
+//                                    // comment mention — see
+//                                    // referencesGuardrailIdentity()) but
+//                                    // fail the canonical anchored shape
+//                                    // (e.g. a trailing extra token). These
+//                                    // are RUNTIME-RELEVANT (the wrapper
+//                                    // only reads argv[2] and ignores the
+//                                    // rest) yet excluded from entryCount —
+//                                    // `complete` requires this to be 0.
+//         "nonCanonical": [ /* { matcher, command } per anomaly above;
+//                              [] when nonCanonicalCount is 0 */ ]
+//       },
+//       ... one entry per GUARDRAILS item, in GUARDRAILS order (stable) ...
+//     ]
+//   }
+// Field names/order and hook order are fixed once shipped — this is a probe
+// contract (scripts/himmelctl/lib/probes.js's cmd:guardrail_block_status).
+export function statusDetail(data) {
+  const mode = detectMode(data);
+  const hooks = GUARDRAILS.map((guardrail) => {
+    const found = findGuardrailEntries(data, guardrail);
+    const nonCanonical = findNonCanonicalEntries(data, guardrail);
+    const entry = {
+      basename: guardrail.basename,
+      matcher: null,
+      expectedMatcher: guardrail.matcher,
+      matcherMatches: false,
+      present: found.length > 0,
+      entryCount: found.length,
+      bashPath: null,
+      bashResolves: false,
+      nodePath: null,
+      nodeResolves: false,
+      wrapperPath: null,
+      wrapperResolves: false,
+      scriptPath: null,
+      scriptResolves: false,
+      duplicates: [],
+      nonCanonicalCount: nonCanonical.length,
+      nonCanonical: nonCanonical.map((info) => ({ matcher: info.matcher ?? null, command: info.hook.command })),
+    };
+    if (found.length > 0) {
+      const primary = resolveOwnedEntry(found[0], guardrail);
+      entry.matcher = primary.matcher;
+      entry.matcherMatches = primary.matcherMatches;
+      entry.bashPath = primary.bashPath;
+      entry.bashResolves = primary.bashResolves;
+      entry.nodePath = primary.nodePath;
+      entry.nodeResolves = primary.nodeResolves;
+      entry.wrapperPath = primary.wrapperPath;
+      entry.wrapperResolves = primary.wrapperResolves;
+      entry.scriptPath = primary.scriptPath;
+      entry.scriptResolves = primary.scriptResolves;
+      entry.duplicates = found.slice(1).map((info) => resolveOwnedEntry(info, guardrail));
+    }
+    return entry;
+  });
+  const complete = mode === 'global' && hooks.every((h) => (
+    h.entryCount === 1 && h.nonCanonicalCount === 0
+      && h.matcherMatches && h.bashResolves && h.nodeResolves && h.wrapperResolves && h.scriptResolves
+  ));
+  return { mode, complete, hooks };
+}
+
 function run(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   const command = args._[0];
   const file = settingsPath();
 
   if (!['detect', 'install', 'remove', 'status', 'global', 'project'].includes(command)) {
-    throw new Error('usage: guardrail-block.mjs detect|install|remove|status|global|project [--node ABS --bash ABS] [--stamp VALUE]');
+    throw new Error('usage: guardrail-block.mjs detect|install|remove|status|global|project [--node ABS --bash ABS] [--stamp VALUE] [--json]');
   }
 
   const { text, data } = readSettings(file);
@@ -201,7 +566,11 @@ function run(argv = process.argv.slice(2)) {
   }
 
   if (command === 'status') {
-    process.stdout.write(`guardrail-mode=${detectMode(data)} node-resolves=${nodeResolves(data) ? 'yes' : 'no'}\n`);
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(statusDetail(data))}\n`);
+    } else {
+      process.stdout.write(`guardrail-mode=${detectMode(data)} node-resolves=${nodeResolves(data) ? 'yes' : 'no'}\n`);
+    }
     return;
   }
 

--- a/scripts/hooks/guardrail-block.mjs
+++ b/scripts/hooks/guardrail-block.mjs
@@ -14,8 +14,29 @@ export const GUARDRAILS = [
   { basename: 'block-read-secrets.sh', matcher: 'Bash|PowerShell|Read|Grep' },
 ];
 
+// HIMMEL-1422: single source of truth for the guardrail-block "trust
+// anchor" — the himmel checkout whose scripts/hooks/ copies of the wrapper
+// + guardrail scripts are treated as authoritative. HIMMEL_REPO (env), when
+// set, names it explicitly (multi-checkout installs, e.g. a global install
+// pointing at a non-default clone); otherwise it falls back to the checkout
+// this guardrail-block.mjs is itself running from (self-checkout —
+// import.meta.url, not cwd, so it's correct regardless of invocation dir).
+// install()/global bake the anchor's own scripts/hooks/ paths into the
+// generated command (repoRoot() below); statusDetail()'s status --json
+// reuses the SAME anchor to realpath-compare whatever is ACTUALLY wired
+// against it, so drift (settings.json baked from a different/stale
+// checkout, or a same-basename file dropped in an unrelated directory) is
+// detectable even though ownsGuardrail() stays basename-only by design
+// (codex-adv-5) — the anchor check is a SEPARATE, additive signal, not a
+// change to ownership semantics.
+function resolveAnchor() {
+  const envRepo = process.env.HIMMEL_REPO;
+  if (envRepo) return { repo: path.resolve(envRepo), source: 'HIMMEL_REPO' };
+  return { repo: path.resolve(path.join(MODULE_DIR, '..', '..')), source: 'self-checkout' };
+}
+
 function repoRoot() {
-  return path.resolve(process.env.HIMMEL_REPO || path.join(MODULE_DIR, '..', '..'));
+  return resolveAnchor().repo;
 }
 
 function settingsPath() {
@@ -340,13 +361,56 @@ function isRunnableExecutable(p) {
   return true;
 }
 
+// HIMMEL-1422: cheap content-sanity floor for the wrapper/script files —
+// isReadableFile() alone accepts a truncated-to-zero-bytes (or
+// whitespace-only) file sitting at an otherwise-correct path, which is
+// exactly the "no-op guardrail" shape from the ticket's motivating scenario
+// (an empty guardrail-skip-in-himmel.js). Deliberately cheap (a content
+// check, not a real JS/bash parse or a hash) per the approved design —
+// "full hashing only if it falls out naturally", and it didn't here.
+function isSaneContentFile(p) {
+  if (!isReadableFile(p)) return false;
+  try {
+    return fs.readFileSync(p, 'utf8').trim().length > 0;
+  } catch (_e) {
+    return false;
+  }
+}
+
+// HIMMEL-1422: realpath-compare a configured (parsed) path against the
+// trust anchor's expected copy. realpathSync resolves symlinks AND
+// normalizes OS-reported case, so two paths naming the SAME file compare
+// equal even if written with different separators/casing; a path that
+// doesn't exist can't be realpath'd (ENOENT), so this falls back to a plain
+// path.resolve() normalization — cheap, and the *Resolves fields already
+// flag a nonexistent path as broken on their own, so a fallback-only
+// mismatch there is never the ONLY signal. Windows path comparison is
+// case-insensitive; POSIX stays case-sensitive.
+function resolvedPath(p) {
+  try {
+    return fs.realpathSync(p);
+  } catch (_e) {
+    return path.resolve(p);
+  }
+}
+
+function pathsMatchAnchor(configuredPath, anchorPath) {
+  const a = resolvedPath(configuredPath);
+  const b = resolvedPath(anchorPath);
+  return process.platform === 'win32' ? a.toLowerCase() === b.toLowerCase() : a === b;
+}
+
 // Resolves ONE owned entry ({ hook, matcher, parsed } from
 // findGuardrailEntries — `parsed` is already strictly matched, so no null
 // check is needed here) into its status --json shape (everything but
 // basename/present/entryCount, which the caller already knows). Shared by
 // the "primary" (first-found) entry and every entry in `duplicates`, so
-// both are checked identically.
-function resolveOwnedEntry(info, guardrail) {
+// both are checked identically. `anchor` is statusDetail()'s single
+// resolveAnchor() result (HIMMEL-1422), threaded through rather than
+// re-resolved per entry.
+function resolveOwnedEntry(info, guardrail, anchor) {
+  const anchorWrapperPath = path.join(anchor.repo, 'scripts', 'hooks', WRAPPER);
+  const anchorScriptPath = path.join(anchor.repo, 'scripts', 'hooks', guardrail.basename);
   return {
     matcher: info.matcher ?? null,
     matcherMatches: (info.matcher ?? null) === guardrail.matcher,
@@ -355,9 +419,13 @@ function resolveOwnedEntry(info, guardrail) {
     nodePath: info.parsed.nodePath,
     nodeResolves: isRunnableExecutable(info.parsed.nodePath),
     wrapperPath: info.parsed.wrapperPath,
-    wrapperResolves: isReadableFile(info.parsed.wrapperPath),
+    wrapperResolves: isSaneContentFile(info.parsed.wrapperPath),
+    anchorWrapperPath,
+    wrapperMatchesAnchor: pathsMatchAnchor(info.parsed.wrapperPath, anchorWrapperPath),
     scriptPath: info.parsed.scriptPath,
-    scriptResolves: isReadableFile(info.parsed.scriptPath),
+    scriptResolves: isSaneContentFile(info.parsed.scriptPath),
+    anchorScriptPath,
+    scriptMatchesAnchor: pathsMatchAnchor(info.parsed.scriptPath, anchorScriptPath),
   };
 }
 
@@ -413,15 +481,44 @@ function resolveOwnedEntry(info, guardrail) {
 // "global" off a decoy alone) simply yields entryCount:0/nonCanonicalCount:0
 // for every real guardrail, so `complete` still correctly reads false and
 // the probe's detail still correctly says "<basename>: missing" — never a
-// false "present". Shape:
+// false "present".
+//
+// HIMMEL-1422 (trust anchor + content-sanity floor, companion finding to
+// codex-adv-5/7): basename-only ownership means a settings.json referencing
+// a same-named file in a WRONG directory (a stale/moved checkout, or an
+// unrelated no-op stub) passed every prior check — "present" attested
+// wiring, not that the wired file IS the real himmel copy. Two additive
+// fixes, neither changing ownership semantics (still basename-only, per
+// codex-adv-5's deliberate choice):
+//   1. `anchor` (top-level, resolveAnchor()): HIMMEL_REPO env when set,
+//      else the checkout guardrail-block.mjs is itself running from
+//      (self-checkout, import.meta.url-derived). The SAME anchor
+//      install()/global already bake paths from (repoRoot() === anchor.repo).
+//   2. Per-hook anchorWrapperPath/wrapperMatchesAnchor and
+//      anchorScriptPath/scriptMatchesAnchor: realpath-compare the
+//      CONFIGURED wrapper/script paths against the anchor's own
+//      scripts/hooks/ copies (pathsMatchAnchor()). A mismatch never flips
+//      present:false (ownership is unchanged) but DOES force
+//      complete:false — the affected hook reads present:true,
+//      *MatchesAnchor:false, so a consumer can name the anchor precisely
+//      instead of a bare "missing".
+// Separately, *Resolves (wrapperResolves/scriptResolves) now also requires
+// non-trivial content (isSaneContentFile(), not just isReadableFile()) — a
+// truncated-to-zero-bytes or whitespace-only file at an otherwise-correct
+// (even anchor-matching) path is a no-op guardrail and must not read
+// resolves:true either. Shape:
 //   {
 //     "mode": "global" | "project",
+//     "anchor": { "repo": string, "source": "HIMMEL_REPO" | "self-checkout" },
+//                            // the trust anchor statusDetail() itself
+//                            // resolved for THIS run (see above).
 //     "complete": boolean,  // true iff mode === "global" AND every hook
 //                            // below has EXACTLY ONE owned entry
 //                            // (entryCount === 1), that entry's ACTUAL
-//                            // matcher exactly equals expectedMatcher, and
-//                            // its bash/node/wrapper/script paths are all
-//                            // USABLE (see below). false otherwise.
+//                            // matcher exactly equals expectedMatcher, its
+//                            // bash/node/wrapper/script paths are all
+//                            // USABLE (see below), AND its wrapper/script
+//                            // both match the anchor. false otherwise.
 //     "hooks": [
 //       {
 //         "basename": string,        // e.g. "auto-approve-safe-bash.sh"
@@ -459,12 +556,28 @@ function resolveOwnedEntry(info, guardrail) {
 //         "nodeResolves": boolean,   // this block minus basename/present/
 //         "wrapperPath": string|null,// entryCount/duplicates itself.
 //         "wrapperResolves": boolean,
+//         "anchorWrapperPath": string, // HIMMEL-1422: the anchor's own
+//                                    // scripts/hooks/<WRAPPER> path — shown
+//                                    // even when the hook is absent, so a
+//                                    // consumer always knows where the
+//                                    // anchor's copy WOULD be.
+//         "wrapperMatchesAnchor": boolean, // HIMMEL-1422: realpath-compare
+//                                    // (pathsMatchAnchor()) wrapperPath
+//                                    // against anchorWrapperPath. false for
+//                                    // an absent hook (no wrapperPath to
+//                                    // compare).
 //         "scriptPath": string|null,
-//         "scriptResolves": boolean, // *Resolves fields (CR fix, codex-adv-3):
-//                                    // "usable", not merely fs.existsSync().
+//         "scriptResolves": boolean, // *Resolves fields (CR fix, codex-adv-3,
+//                                    // extended HIMMEL-1422): "usable", not
+//                                    // merely fs.existsSync().
 //                                    // wrapper/script (passed as ARGUMENTS to
 //                                    // node/bash, never exec'd directly) need
-//                                    // only be a regular, READABLE file.
+//                                    // to be a regular, READABLE file WITH
+//                                    // non-trivial content (isSaneContentFile()
+//                                    // — HIMMEL-1422: a zero-byte or
+//                                    // whitespace-only file at an otherwise-
+//                                    // correct path is a no-op guardrail and
+//                                    // must not read resolves:true).
 //                                    // node/bash (spawned as the executable
 //                                    // itself) additionally need X_OK. isFile()
 //                                    // is the load-bearing, fully portable
@@ -479,6 +592,12 @@ function resolveOwnedEntry(info, guardrail) {
 //                                    // — so a non-executable-but-readable file
 //                                    // baked as the node/bash path will NOT
 //                                    // be caught on Windows, only on POSIX.
+//         "anchorScriptPath": string, // HIMMEL-1422: the anchor's own
+//                                    // scripts/hooks/<basename> path —
+//                                    // same shown-even-when-absent rule as
+//                                    // anchorWrapperPath.
+//         "scriptMatchesAnchor": boolean, // HIMMEL-1422: same as
+//                                    // wrapperMatchesAnchor, for scriptPath.
 //         "duplicates": [ /* same per-entry shape as above, one per
 //                            ADDITIONAL owned entry beyond the first-found;
 //                            [] when entryCount <= 1 */ ],
@@ -504,6 +623,7 @@ function resolveOwnedEntry(info, guardrail) {
 // contract (scripts/himmelctl/lib/probes.js's cmd:guardrail_block_status).
 export function statusDetail(data) {
   const mode = detectMode(data);
+  const anchor = resolveAnchor();
   const hooks = GUARDRAILS.map((guardrail) => {
     const found = findGuardrailEntries(data, guardrail);
     const nonCanonical = findNonCanonicalEntries(data, guardrail);
@@ -520,14 +640,18 @@ export function statusDetail(data) {
       nodeResolves: false,
       wrapperPath: null,
       wrapperResolves: false,
+      anchorWrapperPath: path.join(anchor.repo, 'scripts', 'hooks', WRAPPER),
+      wrapperMatchesAnchor: false,
       scriptPath: null,
       scriptResolves: false,
+      anchorScriptPath: path.join(anchor.repo, 'scripts', 'hooks', guardrail.basename),
+      scriptMatchesAnchor: false,
       duplicates: [],
       nonCanonicalCount: nonCanonical.length,
       nonCanonical: nonCanonical.map((info) => ({ matcher: info.matcher ?? null, command: info.hook.command })),
     };
     if (found.length > 0) {
-      const primary = resolveOwnedEntry(found[0], guardrail);
+      const primary = resolveOwnedEntry(found[0], guardrail, anchor);
       entry.matcher = primary.matcher;
       entry.matcherMatches = primary.matcherMatches;
       entry.bashPath = primary.bashPath;
@@ -536,17 +660,20 @@ export function statusDetail(data) {
       entry.nodeResolves = primary.nodeResolves;
       entry.wrapperPath = primary.wrapperPath;
       entry.wrapperResolves = primary.wrapperResolves;
+      entry.wrapperMatchesAnchor = primary.wrapperMatchesAnchor;
       entry.scriptPath = primary.scriptPath;
       entry.scriptResolves = primary.scriptResolves;
-      entry.duplicates = found.slice(1).map((info) => resolveOwnedEntry(info, guardrail));
+      entry.scriptMatchesAnchor = primary.scriptMatchesAnchor;
+      entry.duplicates = found.slice(1).map((info) => resolveOwnedEntry(info, guardrail, anchor));
     }
     return entry;
   });
   const complete = mode === 'global' && hooks.every((h) => (
     h.entryCount === 1 && h.nonCanonicalCount === 0
       && h.matcherMatches && h.bashResolves && h.nodeResolves && h.wrapperResolves && h.scriptResolves
+      && h.wrapperMatchesAnchor && h.scriptMatchesAnchor
   ));
-  return { mode, complete, hooks };
+  return { mode, anchor, complete, hooks };
 }
 
 function run(argv = process.argv.slice(2)) {

--- a/scripts/hooks/guardrail-block.test.mjs
+++ b/scripts/hooks/guardrail-block.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, statSync, unlinkSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -37,6 +37,18 @@ function run(args, ctx, opts = {}) {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
   });
+}
+
+// HIMMEL-1422: every other helper in this file pins HIMMEL_REPO to ctx.repo
+// (the fixture's own scratch checkout), so the anchor is always
+// deterministic in those tests. This variant deliberately DROPS it (even
+// if the outer test-runner process happens to have HIMMEL_REPO set) to
+// exercise the self-checkout fallback — resolveAnchor() must fall back to
+// the checkout this guardrail-block.mjs is itself running from.
+function runNoAnchorEnv(args, ctx) {
+  const env = { ...process.env, CLAUDE_USER_SETTINGS: ctx.settings };
+  delete env.HIMMEL_REPO;
+  return execFileSync(process.execPath, [MODULE, ...args], { env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
 }
 
 function runCode(args, ctx) {
@@ -669,4 +681,127 @@ test('plain status output is unchanged by the --json addition (himmel-update.sh 
   install(ctx);
 
   assert.equal(run(['status'], ctx), 'guardrail-mode=global node-resolves=yes\n');
+});
+
+// ── trust anchor (HIMMEL-1422) ──────────────────────────────────────────────
+// Companion finding to codex-adv-5/7: ownsGuardrail() is deliberately
+// basename-only (a settings.json referencing a same-named file passes
+// ownership regardless of WHERE that file lives), so a stale/moved checkout
+// — or an unrelated same-named no-op stub — previously still read
+// present:true/*Resolves:true. These tests cover the two additive gates
+// this ticket adds: (1) realpath-compare the configured wrapper/script
+// against a resolved trust anchor (HIMMEL_REPO env, else self-checkout),
+// and (2) a cheap content-sanity floor so a truncated/empty file at an
+// otherwise-correct (even anchor-matching) path still can't read resolves.
+
+test('status --json: with HIMMEL_REPO set, anchor.source is "HIMMEL_REPO" and anchor.repo is the resolved env value', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  assert.equal(out.anchor.source, 'HIMMEL_REPO');
+  assert.equal(out.anchor.repo, resolve(ctx.repo));
+});
+
+test('status --json: with HIMMEL_REPO unset, anchor falls back to self-checkout — the running guardrail-block.mjs\'s own two-levels-up repo root', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+
+  const out = JSON.parse(runNoAnchorEnv(['status', '--json'], ctx));
+
+  assert.equal(out.anchor.source, 'self-checkout');
+  assert.equal(out.anchor.repo, resolve(HERE, '..', '..'));
+});
+
+test('status --json: an install() run reports wrapperMatchesAnchor/scriptMatchesAnchor=true on every hook (the anchor it baked from is the anchor status reads back)', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+  writeHookStubs(ctx);
+  install(ctx);
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  for (const hook of out.hooks) {
+    assert.equal(hook.wrapperMatchesAnchor, true);
+    assert.equal(hook.scriptMatchesAnchor, true);
+    assert.equal(hook.anchorScriptPath, join(resolve(ctx.repo), 'scripts', 'hooks', hook.basename));
+  }
+});
+
+test('status --json: same-basename wiring from a WRONG (non-anchor) checkout reports present=true but *MatchesAnchor=false, and forces complete=false (HIMMEL-1422 same-basename no-op)', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+  writeHookStubs(ctx);
+  install(ctx);
+
+  // Simulate a stale/global install pointing at a DIFFERENT, otherwise-real
+  // checkout: same basenames (wrapper + auto-approve-safe-bash.sh), real
+  // non-empty content, but under a directory that is NOT ctx.repo (the
+  // pinned trust anchor).
+  const otherRepo = join(ctx.dir, 'other-checkout');
+  mkdirSync(join(otherRepo, 'scripts', 'hooks'), { recursive: true });
+  writeFileSync(join(otherRepo, 'scripts', 'hooks', 'guardrail-skip-in-himmel.js'), '// real content, not empty\n');
+  writeFileSync(join(otherRepo, 'scripts', 'hooks', 'auto-approve-safe-bash.sh'), '# real content, not empty\n');
+
+  const data = readJson(ctx.settings);
+  for (const group of data.hooks.PreToolUse) {
+    group.hooks = group.hooks.filter((hook) => !hook.command?.includes('auto-approve-safe-bash.sh'));
+  }
+  data.hooks.PreToolUse.push({
+    matcher: 'Bash',
+    hooks: [{ type: 'command', command: ownedCommand({ ctx: { repo: otherRepo }, basename: 'auto-approve-safe-bash.sh' }) }],
+  });
+  writeJson(ctx.settings, data);
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+  const hook = out.hooks.find((h) => h.basename === 'auto-approve-safe-bash.sh');
+
+  assert.equal(hook.present, true, 'basename ownership is unchanged (codex-adv-5) — still counted as owned');
+  assert.equal(hook.entryCount, 1);
+  assert.equal(hook.wrapperResolves, true, 'the wrong-checkout wrapper is a real, non-empty, readable file');
+  assert.equal(hook.scriptResolves, true, 'the wrong-checkout script is a real, non-empty, readable file');
+  assert.equal(hook.wrapperMatchesAnchor, false, 'wrapper is NOT the anchor\'s own copy');
+  assert.equal(hook.scriptMatchesAnchor, false, 'script is NOT the anchor\'s own copy');
+  assert.equal(hook.anchorScriptPath, join(resolve(ctx.repo), 'scripts', 'hooks', 'auto-approve-safe-bash.sh'), 'anchorScriptPath names the TRUE anchor, not the wrong-checkout path');
+  assert.equal(out.complete, false, 'a same-basename wrong-checkout script must never read complete');
+  // The other two guardrails are untouched by this — still anchor-matching.
+  for (const other of ['block-edit-on-main.sh', 'block-read-secrets.sh']) {
+    const otherHook = out.hooks.find((h) => h.basename === other);
+    assert.equal(otherHook.wrapperMatchesAnchor, true);
+    assert.equal(otherHook.scriptMatchesAnchor, true);
+  }
+});
+
+test('status --json: a ZERO-BYTE script file at the CORRECT (anchor-matching) path reports scriptResolves=false, not present-with-a-no-op (HIMMEL-1422 truncation floor)', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+  writeHookStubs(ctx);
+  install(ctx);
+  // Truncate in place — same path, same anchor, only the CONTENT changes.
+  writeFileSync(join(ctx.repo, 'scripts', 'hooks', 'auto-approve-safe-bash.sh'), '');
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+  const hook = out.hooks.find((h) => h.basename === 'auto-approve-safe-bash.sh');
+
+  assert.equal(hook.present, true);
+  assert.equal(hook.scriptMatchesAnchor, true, 'the path IS the anchor\'s own copy — only the content is a no-op');
+  assert.equal(hook.scriptResolves, false, 'a zero-byte file must never read as a resolving/usable script');
+  assert.equal(out.complete, false);
+});
+
+test('status --json: a WHITESPACE-ONLY (near-empty) wrapper file at the correct path reports wrapperResolves=false (content-sanity floor is not just a size-zero check)', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+  writeHookStubs(ctx);
+  install(ctx);
+  writeFileSync(join(ctx.repo, 'scripts', 'hooks', 'guardrail-skip-in-himmel.js'), '   \n\n\t\n');
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  assert.equal(out.complete, false);
+  for (const hook of out.hooks) {
+    assert.equal(hook.wrapperMatchesAnchor, true, 'the shared wrapper path is still the anchor\'s own copy');
+    assert.equal(hook.wrapperResolves, false, 'a whitespace-only file must never read as a resolving/usable wrapper');
+  }
 });

--- a/scripts/hooks/guardrail-block.test.mjs
+++ b/scripts/hooks/guardrail-block.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, statSync, unlinkSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -71,6 +71,25 @@ function foreignHooks(data) {
 
 function install(ctx, stamp = '1000') {
   return run(['install', '--node', NODE, '--bash', BASH, '--stamp', stamp], ctx);
+}
+
+// Creates stub files under <repo>/scripts/hooks/ so a baked wrapper/script
+// path in a status --json fixture actually resolves (fs.existsSync) instead
+// of pointing at a directory that was mkdir'd but never populated.
+function writeHookStubs(ctx, { wrapper = true, basenames = GUARDS.map(([basename]) => basename) } = {}) {
+  const hooksDir = join(ctx.repo, 'scripts', 'hooks');
+  if (wrapper) writeFileSync(join(hooksDir, 'guardrail-skip-in-himmel.js'), '// stub\n');
+  for (const basename of basenames) {
+    writeFileSync(join(hooksDir, basename), '# stub\n');
+  }
+}
+
+// Mirrors guardrail-block.mjs's own commandFor() so a fixture can hand-craft
+// exactly one owned hook without going through install().
+function ownedCommand({ ctx, basename, nodePath = NODE, bashPath = BASH }) {
+  const wrapper = join(ctx.repo, 'scripts', 'hooks', 'guardrail-skip-in-himmel.js');
+  const script = join(ctx.repo, 'scripts', 'hooks', basename);
+  return `GUARDRAIL_BASH=${JSON.stringify(bashPath)} ${JSON.stringify(nodePath)} ${JSON.stringify(wrapper)} ${JSON.stringify(script)}`;
 }
 
 function assertThreeWrapped(data) {
@@ -251,4 +270,403 @@ test('global and project aliases install and remove for setup-hooks', () => {
   assert.equal(run(['detect'], ctx), 'global\n');
   run(['project', '--stamp', 'project'], ctx);
   assert.equal(run(['detect'], ctx), 'project\n');
+});
+
+// ── status --json (HIMMEL-1418) ─────────────────────────────────────────────
+
+test('status --json after a full install reports complete=true with all three hooks present and resolving', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+  writeHookStubs(ctx);
+
+  install(ctx);
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  assert.equal(out.mode, 'global');
+  assert.equal(out.complete, true);
+  assert.equal(out.hooks.length, 3);
+  GUARDS.forEach(([basename, matcher], i) => {
+    const hook = out.hooks[i];
+    assert.equal(hook.basename, basename, 'hooks[] stays in GUARDRAILS order');
+    assert.equal(hook.matcher, matcher);
+    assert.equal(hook.expectedMatcher, matcher);
+    assert.equal(hook.matcherMatches, true);
+    assert.equal(hook.present, true);
+    assert.equal(hook.entryCount, 1);
+    assert.deepEqual(hook.duplicates, []);
+    assert.equal(hook.bashResolves, true);
+    assert.equal(hook.nodeResolves, true);
+    assert.equal(hook.wrapperResolves, true);
+    assert.equal(hook.scriptResolves, true);
+  });
+});
+
+// ── matcher + bash completeness (CR fix, codex-adv-1/2 on 68c0b82c) ────────
+
+test('status --json reports the ACTUAL configured matcher, not the expected one, and complete=false on a matcher mismatch', () => {
+  const ctx = work();
+  writeHookStubs(ctx);
+  // All 3 owned hooks wired under a single 'Bash' matcher group — exactly
+  // the codex-adv-1 repro: paths all resolve, but block-edit-on-main.sh
+  // (needs Edit|Write|MultiEdit|NotebookEdit) and block-read-secrets.sh
+  // (needs Bash|PowerShell|Read|Grep) would never fire on their real tools.
+  writeJson(ctx.settings, {
+    hooks: {
+      PreToolUse: [
+        {
+          matcher: 'Bash',
+          hooks: GUARDS.map(([basename]) => ({ type: 'command', command: ownedCommand({ ctx, basename }) })),
+        },
+      ],
+    },
+  });
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  assert.equal(out.mode, 'global');
+  assert.equal(out.complete, false, 'a coverage-breaking matcher must never read complete');
+  const byBasename = Object.fromEntries(out.hooks.map((hook) => [hook.basename, hook]));
+  // auto-approve-safe-bash.sh's OWN expected matcher genuinely IS 'Bash', so
+  // this one hook matches by coincidence — proves the check isn't just
+  // "matcher is falsy".
+  assert.equal(byBasename['auto-approve-safe-bash.sh'].matcher, 'Bash');
+  assert.equal(byBasename['auto-approve-safe-bash.sh'].expectedMatcher, 'Bash');
+  assert.equal(byBasename['auto-approve-safe-bash.sh'].matcherMatches, true);
+  assert.equal(byBasename['block-edit-on-main.sh'].matcher, 'Bash');
+  assert.equal(byBasename['block-edit-on-main.sh'].expectedMatcher, 'Edit|Write|MultiEdit|NotebookEdit');
+  assert.equal(byBasename['block-edit-on-main.sh'].matcherMatches, false);
+  assert.equal(byBasename['block-read-secrets.sh'].matcher, 'Bash');
+  assert.equal(byBasename['block-read-secrets.sh'].expectedMatcher, 'Bash|PowerShell|Read|Grep');
+  assert.equal(byBasename['block-read-secrets.sh'].matcherMatches, false);
+  // Paths all still resolve — proves the false complete is caused ONLY by
+  // the matcher check, not incidental path breakage.
+  for (const hook of out.hooks) {
+    assert.equal(hook.present, true);
+    assert.equal(hook.bashResolves, true);
+    assert.equal(hook.nodeResolves, true);
+    assert.equal(hook.wrapperResolves, true);
+    assert.equal(hook.scriptResolves, true);
+  }
+});
+
+test('status --json with a dead baked bash path reports bashResolves=false on every hook and complete=false', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+  writeHookStubs(ctx);
+  const deadBash = join(ctx.dir, 'nonexistent-bash.exe');
+
+  run(['install', '--node', NODE, '--bash', deadBash, '--stamp', 'deadbash'], ctx);
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  assert.equal(out.mode, 'global');
+  assert.equal(out.complete, false, 'a missing baked bash executable must never read complete (the wrapper fails closed on it)');
+  for (const hook of out.hooks) {
+    assert.equal(hook.present, true);
+    // baked paths round-trip through settings.json with backslashes doubled
+    // (JSON.stringify() bakes the command text once inside commandFor(),
+    // then the whole settings object is serialized a second time) — collapse
+    // before comparing, same as every other JSON-quoted arg in this file.
+    assert.equal(hook.bashPath.replace(/\\\\/g, '\\'), deadBash);
+    assert.equal(hook.bashResolves, false);
+    // Node/wrapper/script are unaffected by the bash breakage — proves the
+    // false complete is caused ONLY by the bash check.
+    assert.equal(hook.nodeResolves, true);
+    assert.equal(hook.wrapperResolves, true);
+    assert.equal(hook.scriptResolves, true);
+  }
+});
+
+// ── usability + duplicate-entry completeness (CR fix, codex-adv-3/4, round 3
+// on 9112bfe9) ───────────────────────────────────────────────────────────
+
+test('status --json with a DIRECTORY at the wrapper path reports wrapperResolves=false, not merely "exists" (complete=false)', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+  writeHookStubs(ctx);
+  install(ctx);
+  // fs.existsSync() alone accepts a directory — replace the wrapper file
+  // with a directory of the SAME name to reproduce codex-adv-3 exactly.
+  unlinkSync(join(ctx.repo, 'scripts', 'hooks', 'guardrail-skip-in-himmel.js'));
+  mkdirSync(join(ctx.repo, 'scripts', 'hooks', 'guardrail-skip-in-himmel.js'));
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  assert.equal(out.complete, false, 'a directory must never be reported as a usable wrapper path');
+  for (const hook of out.hooks) {
+    assert.equal(hook.wrapperResolves, false);
+    // node/script are unaffected — proves the false complete is caused ONLY
+    // by the directory-vs-file distinction, not incidental breakage.
+    assert.equal(hook.nodeResolves, true);
+    assert.equal(hook.scriptResolves, true);
+  }
+});
+
+test('status --json with a DIRECTORY at the baked node path reports nodeResolves=false, not merely "exists" (complete=false)', () => {
+  const ctx = work();
+  writeHookStubs(ctx);
+  const nodeDir = join(ctx.dir, 'node-is-actually-a-dir');
+  mkdirSync(nodeDir);
+  writeJson(ctx.settings, {
+    hooks: {
+      PreToolUse: [
+        { matcher: 'Bash', hooks: [{ type: 'command', command: ownedCommand({ ctx, basename: 'auto-approve-safe-bash.sh', nodePath: nodeDir }) }] },
+      ],
+    },
+  });
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+  const hook = out.hooks.find((h) => h.basename === 'auto-approve-safe-bash.sh');
+
+  assert.equal(out.complete, false);
+  assert.equal(hook.nodeResolves, false, 'a directory must never be reported as a runnable node path');
+});
+
+// Windows' fs.accessSync(path, X_OK) has no real executable-bit concept and
+// behaves like F_OK (existence only) — confirmed empirically and documented
+// in the contract comment — so a non-executable-but-readable file is NOT
+// distinguishable from a runnable one there. This case is only meaningful on
+// POSIX; the directory tests above already cover the portable, load-bearing
+// part of the codex-adv-3 fix (isFile()) on every platform.
+test('status --json with a non-executable (but readable) baked node path reports nodeResolves=false', { skip: process.platform === 'win32' ? "X_OK is a no-op on Windows (see guardrail-block.mjs's status --json contract comment) — not meaningfully testable here" : false }, () => {
+  const ctx = work();
+  writeHookStubs(ctx);
+  const nonExecNode = join(ctx.dir, 'non-exec-node');
+  writeFileSync(nonExecNode, '#!/bin/sh\n');
+  chmodSync(nonExecNode, 0o644); // readable, deliberately NOT executable
+  writeJson(ctx.settings, {
+    hooks: {
+      PreToolUse: [
+        { matcher: 'Bash', hooks: [{ type: 'command', command: ownedCommand({ ctx, basename: 'auto-approve-safe-bash.sh', nodePath: nonExecNode }) }] },
+      ],
+    },
+  });
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+  const hook = out.hooks.find((h) => h.basename === 'auto-approve-safe-bash.sh');
+
+  assert.equal(out.complete, false);
+  assert.equal(hook.nodeResolves, false, 'a non-executable file must never be reported as a runnable node path');
+});
+
+test('status --json with a valid entry PLUS a dead-node duplicate for the same hook reports entryCount=2, the duplicate in `duplicates`, and complete=false', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+  writeHookStubs(ctx);
+  install(ctx);
+
+  // Add a SECOND owned entry for auto-approve-safe-bash.sh with a dead node
+  // path, alongside the valid one install() already wrote — installData()'s
+  // own dedup step ("remove EVERY existing owned hook for this guardrail")
+  // exists precisely because this drift state occurs in practice; a probe
+  // that only looks at the first match can't see the dead duplicate, even
+  // though it is still independently wired and can fail closed at runtime.
+  const data = readJson(ctx.settings);
+  const deadNode = join(ctx.dir, 'nonexistent-node-duplicate');
+  data.hooks.PreToolUse.push({
+    matcher: 'Bash',
+    hooks: [{ type: 'command', command: ownedCommand({ ctx, basename: 'auto-approve-safe-bash.sh', nodePath: deadNode }) }],
+  });
+  writeJson(ctx.settings, data);
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  assert.equal(out.complete, false, 'a duplicate owned entry must block complete even though the FIRST-FOUND one is fully valid');
+  const hook = out.hooks.find((h) => h.basename === 'auto-approve-safe-bash.sh');
+  assert.equal(hook.present, true);
+  assert.equal(hook.entryCount, 2);
+  // The primary (first-found = originally-installed) entry stays valid.
+  assert.equal(hook.nodeResolves, true);
+  assert.equal(hook.duplicates.length, 1);
+  assert.equal(hook.duplicates[0].nodeResolves, false, 'the dead duplicate is surfaced in duplicates[], not silently dropped');
+  // The other two guardrails are untouched (still exactly 1 entry each) —
+  // proves the duplicate detection is per-basename, not a global flag.
+  for (const other of ['block-edit-on-main.sh', 'block-read-secrets.sh']) {
+    assert.equal(out.hooks.find((h) => h.basename === other).entryCount, 1);
+  }
+});
+
+// ── decoy / identity ownership (CR fix, codex-adv-5, round 4 on 9d1b24a5) ──
+
+test('status --json: real script arg is a decoy (claude-stub.sh) with each guardrail basename ONLY in a trailing comment — none are counted as owned (present=false, entryCount=0), complete=false', () => {
+  const ctx = work();
+  writeHookStubs(ctx);
+  const wrapper = join(ctx.repo, 'scripts', 'hooks', 'guardrail-skip-in-himmel.js');
+  const decoyScript = join(ctx.repo, 'scripts', 'hooks', 'claude-stub.sh');
+  writeFileSync(decoyScript, '#!/bin/sh\nexit 0\n');
+
+  writeJson(ctx.settings, {
+    hooks: {
+      PreToolUse: GUARDS.map(([basename, matcher]) => ({
+        matcher,
+        hooks: [{
+          type: 'command',
+          // The pre-fix isOwnedHook()/parseOwnedCommand() would have called
+          // this "owned by <basename>, script=claude-stub.sh, resolves=true"
+          // — the real (4th quoted) script arg is the decoy; the guardrail's
+          // actual basename appears ONLY in a trailing shell comment that no
+          // quoted-argument parse ever inspected. Exactly the reviewer's
+          // reproduced scenario.
+          command: `GUARDRAIL_BASH=${JSON.stringify(BASH)} ${JSON.stringify(NODE)} ${JSON.stringify(wrapper)} ${JSON.stringify(decoyScript)} # ${basename}`,
+        }],
+      })),
+    },
+  });
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  // detectMode() (the plain, intentionally loose `status` line's engine)
+  // still substring-matches WRAPPER and reads mode=global off the decoy —
+  // that engine is unchanged/out of scope here. The point of this fix is
+  // that the STRICT --json attestation must not be fooled by it: every
+  // guardrail still correctly reads not-owned, so complete stays false.
+  assert.equal(out.mode, 'global');
+  assert.equal(out.complete, false, 'a decoy command must never read complete, even with a real guardrail basename in a trailing comment');
+  for (const hook of out.hooks) {
+    assert.equal(hook.present, false, `${hook.basename} must NOT be counted as owned by a decoy that merely mentions it in a comment — chosen semantic: not owned at all, reads identically to "never wired"`);
+    assert.equal(hook.entryCount, 0);
+    assert.deepEqual(hook.duplicates, []);
+    assert.equal(hook.matcher, null);
+    assert.equal(hook.nodePath, null, 'a non-owned hook reports no path data at all, not the decoy\'s paths');
+    // codex-adv-7 regression guard: a comment-only mention must NOT be
+    // picked up by the bounded quoted-argument identity test either — it's
+    // a true decoy in BOTH tiers, not merely "non-canonical".
+    assert.equal(hook.nonCanonicalCount, 0);
+    assert.deepEqual(hook.nonCanonical, []);
+  }
+});
+
+// ── non-canonical (same-identity, non-generated-shape) duplicates
+// (CR fix, codex-adv-7, round 5 on 07a7ae10) ────────────────────────────────
+
+test('status --json: canonical entry PLUS a same-identity duplicate with a TRAILING EXTRA ARGUMENT — reports nonCanonicalCount=1, forces complete=false (round-3 blind spot reopened via a different shape)', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+  writeHookStubs(ctx);
+  install(ctx); // the canonical, fully-valid entry for all 3 guardrails.
+
+  // guardrail-skip-in-himmel.js reads only process.argv[2] — a trailing
+  // extra token after the (correct) script arg is silently ignored at
+  // runtime, so this duplicate is NOT a decoy: it references the REAL
+  // wrapper/script identity, just in a non-canonical shape (GENERATED_
+  // COMMAND_RE's `$` anchor rejects it, but Claude still executes it).
+  // Give it a DEAD node path — exactly the "still fails closed on a
+  // matching tool call" risk this fix exists to surface.
+  const data = readJson(ctx.settings);
+  const deadNode = join(ctx.dir, 'nonexistent-node-noncanonical');
+  const wrapper = join(ctx.repo, 'scripts', 'hooks', 'guardrail-skip-in-himmel.js');
+  const script = join(ctx.repo, 'scripts', 'hooks', 'auto-approve-safe-bash.sh');
+  data.hooks.PreToolUse.push({
+    matcher: 'Bash',
+    hooks: [{
+      type: 'command',
+      command: `GUARDRAIL_BASH=${JSON.stringify(BASH)} ${JSON.stringify(deadNode)} ${JSON.stringify(wrapper)} ${JSON.stringify(script)} "extra-trailing-arg"`,
+    }],
+  });
+  writeJson(ctx.settings, data);
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  assert.equal(out.complete, false, 'a same-identity non-canonical duplicate must force complete=false, even though the canonical entry alone is fully valid');
+  const hook = out.hooks.find((h) => h.basename === 'auto-approve-safe-bash.sh');
+  // The canonical entry is untouched — still exactly 1, still fully valid.
+  assert.equal(hook.present, true);
+  assert.equal(hook.entryCount, 1);
+  assert.equal(hook.nodeResolves, true);
+  assert.deepEqual(hook.duplicates, []);
+  // The non-canonical anomaly is surfaced, not silently dropped.
+  assert.equal(hook.nonCanonicalCount, 1);
+  assert.equal(hook.nonCanonical.length, 1);
+  assert.equal(hook.nonCanonical[0].matcher, 'Bash');
+  assert.ok(hook.nonCanonical[0].command.includes('extra-trailing-arg'));
+  // The other two guardrails are untouched.
+  for (const other of ['block-edit-on-main.sh', 'block-read-secrets.sh']) {
+    const otherHook = out.hooks.find((h) => h.basename === other);
+    assert.equal(otherHook.entryCount, 1);
+    assert.equal(otherHook.nonCanonicalCount, 0);
+  }
+});
+
+test('status --json with no owned hooks reports mode=project, complete=false, every hook absent', () => {
+  const ctx = work();
+  writeJson(ctx.settings, realShapedFixture());
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  assert.equal(out.mode, 'project');
+  assert.equal(out.complete, false);
+  assert.equal(out.hooks.length, 3);
+  for (const hook of out.hooks) {
+    assert.equal(hook.present, false);
+    assert.equal(hook.nodePath, null);
+  }
+});
+
+test('status --json partial install (one of three hooks wired) reports complete=false with the missing hooks named', () => {
+  const ctx = work();
+  writeHookStubs(ctx);
+  writeJson(ctx.settings, {
+    hooks: {
+      PreToolUse: [
+        { matcher: 'Bash', hooks: [{ type: 'command', command: ownedCommand({ ctx, basename: 'auto-approve-safe-bash.sh' }) }] },
+      ],
+    },
+  });
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  assert.equal(out.mode, 'global');
+  assert.equal(out.complete, false);
+  const byBasename = Object.fromEntries(out.hooks.map((hook) => [hook.basename, hook]));
+  assert.equal(byBasename['auto-approve-safe-bash.sh'].present, true);
+  assert.equal(byBasename['auto-approve-safe-bash.sh'].nodeResolves, true);
+  assert.equal(byBasename['auto-approve-safe-bash.sh'].wrapperResolves, true);
+  assert.equal(byBasename['auto-approve-safe-bash.sh'].scriptResolves, true);
+  assert.equal(byBasename['block-edit-on-main.sh'].present, false);
+  assert.equal(byBasename['block-read-secrets.sh'].present, false);
+});
+
+test('status --json with a dead wrapper path reports wrapperResolves=false on every hook and complete=false', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+  writeHookStubs(ctx);
+  install(ctx);
+  // Simulate a rotted wrapper path post-install (e.g. a moved/deleted himmel checkout).
+  unlinkSync(join(ctx.repo, 'scripts', 'hooks', 'guardrail-skip-in-himmel.js'));
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  assert.equal(out.mode, 'global');
+  assert.equal(out.complete, false);
+  for (const hook of out.hooks) {
+    assert.equal(hook.present, true);
+    assert.equal(hook.nodeResolves, true);
+    assert.equal(hook.wrapperResolves, false);
+    assert.equal(hook.scriptResolves, true);
+  }
+});
+
+test('status --json with a dead script path on one hook reports that hook alone as unresolved', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+  writeHookStubs(ctx);
+  install(ctx);
+  // Simulate one guardrail script disappearing while the other two stay intact.
+  unlinkSync(join(ctx.repo, 'scripts', 'hooks', 'block-edit-on-main.sh'));
+
+  const out = JSON.parse(run(['status', '--json'], ctx));
+
+  assert.equal(out.complete, false);
+  const byBasename = Object.fromEntries(out.hooks.map((hook) => [hook.basename, hook]));
+  assert.equal(byBasename['block-edit-on-main.sh'].scriptResolves, false);
+  assert.equal(byBasename['auto-approve-safe-bash.sh'].scriptResolves, true);
+  assert.equal(byBasename['block-read-secrets.sh'].scriptResolves, true);
+});
+
+test('plain status output is unchanged by the --json addition (himmel-update.sh parses this line)', () => {
+  const ctx = work();
+  writeJson(ctx.settings, {});
+  writeHookStubs(ctx);
+  install(ctx);
+
+  assert.equal(run(['status'], ctx), 'guardrail-mode=global node-resolves=yes\n');
 });

--- a/scripts/luna/prepare-ship-index.mjs
+++ b/scripts/luna/prepare-ship-index.mjs
@@ -266,7 +266,8 @@ stats.vec0 = vec0Used;
 const count = (sql) => db.prepare(sql).get().c;
 stats.before = {
   collections: count('select count(*) c from store_collections'),
-  documents: count('select count(*) c from documents'),
+  // WHERE active = 1 -- see the SAME predicate on stats.after below for why.
+  documents: count('select count(*) c from documents where active = 1'),
   content: count('select count(*) c from content'),
   contentVectors: count('select count(*) c from content_vectors'),
   vectors: count('select count(*) c from vectors_vec'),
@@ -329,7 +330,15 @@ try {
 
 stats.after = {
   collections: count('select count(*) c from store_collections'),
-  documents: count('select count(*) c from documents'),
+  // WHERE active = 1 -- matches qmd's own `qmd status` count EXACTLY (its
+  // "Total: N files indexed" is `SELECT COUNT(*) FROM documents WHERE
+  // active = 1`, verified against the qmd fork source). A bare COUNT(*) here
+  // counts soft-deleted rows too, so this staged count and the receiver's
+  // post-swap qmd status were comparing different predicates -- not different
+  // data -- and a swap that fully succeeded (vectors matched, nothing
+  // pending) died on a doc-count "mismatch" that was really just inactive
+  // rows the receiver's own count already excludes (HIMMEL-1416).
+  documents: count('select count(*) c from documents where active = 1'),
   content: count('select count(*) c from content'),
   contentVectors: count('select count(*) c from content_vectors'),
   vectors: count('select count(*) c from vectors_vec'),

--- a/scripts/luna/ship-index-remote.ps1
+++ b/scripts/luna/ship-index-remote.ps1
@@ -26,7 +26,15 @@
 #   2  daemon stop failed
 #   3  swap failed (previous index left in place)
 #   4  daemon restart failed (index WAS swapped -- say so loudly)
-#   5  post-swap verify failed (vectors lag lex, or qmd unusable)
+#   5  post-swap verify failed (doc/vector counts lag or mismatch, or qmd
+#      unusable -- see Get-ShipVerdict)
+#   6  index shipped + verified OK, but the HTTP-singleton MCP daemon restore
+#      FAILED after the stop sweep (round 4 [codex-adv-6]). The PRIMARY
+#      contract (swap + plain daemon + verify) succeeded; only the auxiliary
+#      HTTP surface (port 8181) may still be down -- surfaced loudly rather
+#      than silently reporting a clean 0 while unattended automation gets no
+#      signal. Never returned when a PRIMARY stage (2/3/4/5) already failed --
+#      that code always wins; restore failure only ever escalates a success.
 
 [CmdletBinding()]
 param(
@@ -34,6 +42,7 @@ param(
     [Parameter(Mandatory = $true)][string]$Target,   # live index path to replace
     [int]$ExpectDocs = -1,                            # from the sender's stats
     [int]$ExpectVectors = -1,
+    [string]$EnsureScript = '',                       # ensure-qmd-daemon.ps1, uploaded alongside (HIMMEL-1416)
     [switch]$NoRestart                                # leave the daemon down (debug)
 )
 
@@ -66,6 +75,188 @@ function Start-QmdDaemon {
     return $r.ProcessId
 }
 
+# Decides whether a process is one of the qmd-hosting shapes the stop sweep
+# must reap (HIMMEL-1416). Pulled out as its own function so the matching
+# logic is unit-testable without a live process list.
+#
+# qmd.exe is matched on NAME ALONE, unconditionally, BEFORE the CommandLine
+# guard below -- no false-positive risk, since any process literally named
+# qmd.exe is the daemon. This matters because Get-CimInstance Win32_Process
+# commonly returns a NULL CommandLine for an other-session/elevated process
+# (access denied to read it) -- exactly the Services-session qmd.exe this fix
+# exists to catch (CR [codex-1]). A CommandLine-dependent check would let that
+# process evade the sweep on a hardened/elevated receiver. bun.exe and
+# node.exe carry no such guarantee (bun.exe also hosts unrelated daemons;
+# node.exe is scoped to qmd.js specifically -- a bare 'qmd' substring would
+# also catch dozens of unrelated node.exe processes on this box), so they
+# still require the CommandLine match.
+function Test-IsQmdHostProcess {
+    param([string]$Name, [string]$CommandLine)
+    if ($Name -eq 'qmd.exe') { return $true }
+    if (-not $CommandLine) { return $false }
+    if ($Name -eq 'node.exe') { return $CommandLine -match 'qmd\.js' }
+    return $CommandLine -match 'qmd'
+}
+
+# Decides whether a STOPPED process was the HIMMEL-592 HTTP-singleton MCP
+# daemon (round-2 CR [codex-adv-2], verified against the qmd fork source):
+# ensure-qmd-daemon.ps1 always launches it as exactly `qmd mcp --http
+# --daemon`. Matched on CommandLine alone, not process name -- that daemon can
+# be bun-hosted (bun + the global qmd.js) or node-hosted (a PATH shim), and
+# `--http` is the one substring both forms share that the plain `mcp
+# --keep-models` daemon Start-QmdDaemon relaunches never carries.
+function Test-IsHttpDaemonProcess {
+    param([string]$CommandLine)
+    return [bool]($CommandLine -and $CommandLine -match '--http')
+}
+
+# Re-invokes the idempotent ensure-qmd-daemon.ps1 to restore the HTTP-singleton
+# MCP daemon after the stop sweep (round 3 [codex-adv-3]/[codex-adv-4],
+# verified). UNCONDITIONAL on purpose: round 2 gated this on
+# Test-IsHttpDaemonProcess classifying a stopped process's CommandLine, but a
+# qmd.exe swept on NAME ALONE (round 1, precisely BECAUSE its CommandLine can
+# be null/access-denied on an elevated/other-session process) can BE the HTTP
+# daemon with no CommandLine available to classify it by -- so the
+# classification-gated restore could silently skip exactly the case round 1
+# exists to catch, leaving port 8181 down with rc still 0. ensure-qmd-daemon.ps1
+# is idempotent (probes 8181 first, short-circuits if already alive) and
+# self-resolving, so calling it whenever ANYTHING was stopped -- even just the
+# plain daemon -- converges on the right state without needing to classify
+# what was killed. Test-IsHttpDaemonProcess and the stopped_http_daemon /
+# stopped_before_failure_http_daemon emits stay for OBSERVABILITY only; they
+# no longer gate this call.
+#
+# MUST be called from EVERY post-sweep exit path (round 4 [codex-adv-5]) --
+# success, the stop-failure catch, the swap-failure recovery, AND both
+# daemon-restart-failure branches -- see Complete-PostSweepFailure below,
+# which every Fail() after the sweep now routes through so this can never be
+# skipped by a return path that forgot to call it.
+#
+# Invoked as a genuinely SEPARATE `powershell` process (not `&`-sourced
+# in-process): ensure-qmd-daemon.ps1 calls `exit` on both its success and
+# failure paths, which would tear down THIS script's own process if run in
+# the same session.
+#
+# Always Emits 'http_daemon_restored' (yes / FAILED / skipped-no-ensure-script
+# / not-needed) so the caller's log states plainly what happened, and sets
+# $script:EnsureRestoreFailed (round 4 [codex-adv-6]) so the SUCCESS path can
+# turn an actual FAILED restore into exit code 6 instead of silently reporting
+# 0 -- unattended automation otherwise gets no signal that port 8181 is down.
+# A plain script-scoped variable, not a function return value: Emit itself
+# calls Write-Output, so a caller capturing this function's own return stream
+# (`$x = Invoke-EnsureRestore ...`) would get an ARRAY mixing the emitted
+# strings with any explicit return value, not a clean boolean -- the
+# script-scoped flag sidesteps that entirely.
+#
+# 'not-needed' (StoppedCount <= 0) does NOT set the flag: nothing was stopped,
+# so there is nothing to have failed to restore. 'skipped-no-ensure-script'
+# NOW DOES set the flag (round 5 [codex-adv-9], verified): something WAS
+# stopped, and with no ensure script to run, a null-CommandLine qmd.exe (round
+# 1 -- exactly the shape that cannot be classified as HTTP-shaped or not) can
+# leave port 8181 down while this used to read as a clean, unremarkable
+# skip -- a ship that swapped, restarted the plain daemon, and verified would
+# still exit 0 with the HTTP surface silently unconfirmed. A non-empty
+# -EnsureScript that resolves to nothing is now caught earlier and fails fast
+# pre-sweep (see the pre-sweep validation block); this branch is what is left
+# for a genuinely EMPTY -EnsureScript (the standalone/debug invocation) --
+# absence with zero stops still reads as fine ('not-needed' above), it is only
+# absence WITH something stopped that now escalates.
+function Invoke-EnsureRestore {
+    param([string]$EnsureScript, [int]$StoppedCount)
+    $script:EnsureRestoreFailed = $false
+    if ($StoppedCount -le 0) {
+        Emit 'http_daemon_restored' 'not-needed'
+        return
+    }
+    if (-not ($EnsureScript -and (Test-Path -LiteralPath $EnsureScript))) {
+        Emit 'http_daemon_restored' 'skipped-no-ensure-script'
+        $script:EnsureRestoreFailed = $true
+        return
+    }
+    $ensureRc = 1
+    try {
+        & powershell -NoProfile -ExecutionPolicy Bypass -File $EnsureScript
+        $ensureRc = $LASTEXITCODE
+    } catch {
+        $ensureRc = 1
+    }
+    if ($ensureRc -eq 0) {
+        Emit 'http_daemon_restored' 'yes'
+    } else {
+        Emit 'http_daemon_restored' 'FAILED'
+        $script:EnsureRestoreFailed = $true
+    }
+}
+
+# Centralizes recovery-before-exit so it can never be skipped (round 4
+# [codex-adv-5]/[codex-adv-7]): EVERY Fail() called after the stop sweep has
+# started routes through here first. Restores the PLAIN daemon (best-effort,
+# via Start-QmdDaemon) when -AlsoRestartPlainDaemon is passed -- the
+# stop-failure catch never attempted this before (a stopped plain daemon was
+# left down on a failed deploy, [codex-adv-7]) -- then ALWAYS restores the
+# HTTP daemon (via Invoke-EnsureRestore, unconditional per its own comment),
+# then calls Fail with the ORIGINAL code and message. The pre-determined
+# $Code always wins regardless of what recovery does or does not manage to
+# fix here -- a restore failure never masks or changes an already-decided
+# primary-stage failure (2/3/4); it only ever escalates a SUCCESS (handled
+# separately, at the bottom of the script, via $script:EnsureRestoreFailed).
+#
+# -AlsoRestartPlainDaemon is omitted at the daemon-restart-failure call sites
+# (rc 4): the plain form just failed there, moments ago, in the same code --
+# retrying it again immediately is not what round 4 asked for and adds no
+# value without backoff logic that would be scope creep here.
+function Complete-PostSweepFailure {
+    param(
+        [int]$Code,
+        [string]$Msg,
+        [string]$EnsureScript,
+        [int]$StoppedCount,
+        [switch]$NoRestart,
+        [switch]$AlsoRestartPlainDaemon
+    )
+    if (-not $NoRestart) {
+        if ($AlsoRestartPlainDaemon -and $StoppedCount -gt 0) {
+            $backPid = $null
+            try { $backPid = Start-QmdDaemon } catch { }
+            Emit 'restarted_after_failure' $(if ($backPid) { $backPid } else { 'FAILED' })
+        }
+        Invoke-EnsureRestore -EnsureScript $EnsureScript -StoppedCount $StoppedCount
+    }
+    Fail $Code $Msg
+}
+
+# Decides the post-swap verify outcome from already-parsed counts (HIMMEL-1416).
+# Pulled out as its own function so the pass/fail boundary is unit-testable
+# without a live qmd process. Returns @{ FailCode; FailMsg }: FailCode 0 means
+# the ship is verified; a non-zero FailCode is handed straight to Fail().
+#
+# Doc count is a HARD failure again, same as vectors/pending (round-2 CR
+# [codex-adv-1], verified against the qmd fork source): the live 14844-vs-15189
+# anomaly was a PREDICATE mismatch, not a genuine method/scope difference --
+# `qmd status`'s "Total: N files indexed" is `SELECT COUNT(*) FROM documents
+# WHERE active = 1` (src/cli/qmd.ts), while prepare-ship-index.mjs staged its
+# count with a bare COUNT(*) that also counted soft-deleted rows. Now that the
+# sender counts with the SAME active=1 predicate (prepare-ship-index.mjs), a
+# swapped-in index and the receiver's own status read of it MUST agree exactly
+# -- no legitimate mismatch source remains, so tolerating one here would just
+# be hiding a real transport bug.
+function Get-ShipVerdict {
+    param($Docs, $Vecs, $Pending, $ExpectDocs, $ExpectVectors)
+    if ($null -eq $Docs -or $null -eq $Vecs) {
+        return @{ FailCode = 5; FailMsg = 'could not parse doc/vector counts from qmd status -- refusing to call the ship verified.' }
+    }
+    if ($Pending -gt 0) {
+        return @{ FailCode = 5; FailMsg = "$Pending content hash(es) still need embedding after the swap -- vectors LAG lex. This is the silent-wrong state the ship exists to eliminate; the shipped artifact was not fully embedded at the source." }
+    }
+    if ($ExpectVectors -ge 0 -and $Vecs -ne $ExpectVectors) {
+        return @{ FailCode = 5; FailMsg = "vector count mismatch: receiver reports $Vecs, sender shipped $ExpectVectors" }
+    }
+    if ($ExpectDocs -ge 0 -and $Docs -ne $ExpectDocs) {
+        return @{ FailCode = 5; FailMsg = "document count mismatch: receiver reports $Docs, sender shipped $ExpectDocs" }
+    }
+    return @{ FailCode = 0; FailMsg = '' }
+}
+
 if (-not (Test-Path -LiteralPath $Staged)) { Fail 1 "staged index not found: $Staged" }
 $stagedSize = (Get-Item -LiteralPath $Staged).Length
 # A truncated/partial upload is the failure mode that would otherwise be
@@ -74,44 +265,21 @@ $stagedSize = (Get-Item -LiteralPath $Staged).Length
 if ($stagedSize -lt 50MB) { Fail 1 "staged index is implausibly small ($stagedSize bytes) -- refusing to swap in a likely-truncated upload" }
 Emit 'staged_bytes' $stagedSize
 
-# --- 1. Stop the qmd daemon --------------------------------------------------
-# The daemon is BUN, not node. A node-only filter both misses it and matches
-# dozens of unrelated processes (this box runs ~40 node.exe). Match on the
-# executable AND require the command line to mention qmd, so an unrelated bun
-# process is left alone.
-$stopped = @()
-try {
-    # -ErrorAction Stop, NOT SilentlyContinue: a FAILED enumeration would
-    # otherwise be indistinguishable from "no daemon is running", and we would
-    # go on to swap a file the daemon still holds open.
-    $procs = Get-CimInstance Win32_Process -Filter "Name = 'bun.exe'" -ErrorAction Stop
-    foreach ($p in $procs) {
-        if ($p.CommandLine -and $p.CommandLine -match 'qmd') {
-            Stop-Process -Id $p.ProcessId -Force -ErrorAction Stop
-            $stopped += $p.ProcessId
-        }
-    }
-} catch {
-    # Report what we DID stop before failing. A partial stop otherwise leaves the
-    # operator unable to tell whether a daemon needs restarting by hand.
-    Emit 'stopped_before_failure' ($(if ($stopped.Count) { $stopped -join ',' } else { 'none' }))
-    Fail 2 "failed to stop the qmd daemon: $($_.Exception.Message)"
-}
-Emit 'stopped_pids' ($(if ($stopped.Count) { $stopped -join ',' } else { 'none' }))
-
-# Give the OS a moment to release the file handles before the swap; a swap
-# against a still-mapped SQLite file fails with a sharing violation.
-if ($stopped.Count -gt 0) { Start-Sleep -Seconds 3 }
-
-# --- 2. Swap ------------------------------------------------------------------
-# The previous index moves aside to .preship FIRST, so a failed move-in can be
-# rolled back. It is REAPED below on success and on failure -- two stale copies
-# (365MB + 221MB) once sat here for days.
+# --- 0. Pre-sweep validation --------------------------------------------------
+# Moved here from just before the swap (round 5 [codex-adv-8], verified): these
+# used to sit BETWEEN the stop sweep and the swap and call Fail directly. A
+# failure there exits after daemons were already stopped, with no recovery
+# attempted at all -- the exact gap Complete-PostSweepFailure exists to close.
+# Nothing here depends on anything the sweep produces (only $Staged/$Target,
+# both already known from the parameters), so moving it BEFORE the sweep is
+# strictly better: nothing has been stopped yet, so a plain Fail is correct
+# and the "should this restore first" question does not even arise.
 $preship = "$Target.preship"
-# Refuse a self-swap BEFORE anything moves. If -Staged resolves to the live
-# index (or to the recovery copy), the move sequence would shuffle a file onto
-# itself and could destroy the only copy. Compare normalized full paths, since
-# the two can be spelled differently and still be the same file.
+# Refuse a self-swap BEFORE anything moves (and before anything is stopped).
+# If -Staged resolves to the live index (or to the recovery copy), the move
+# sequence would shuffle a file onto itself and could destroy the only copy.
+# Compare normalized full paths, since the two can be spelled differently and
+# still be the same file.
 $normStaged = [System.IO.Path]::GetFullPath($Staged)
 $normTarget = [System.IO.Path]::GetFullPath($Target)
 $normPreship = [System.IO.Path]::GetFullPath($preship)
@@ -121,6 +289,90 @@ if ($normStaged -ieq $normTarget) {
 if ($normStaged -ieq $normPreship) {
     Fail 1 "staged index is the recovery copy ($normPreship) -- refusing to swap, this would destroy the rollback"
 }
+# Round 5 [codex-adv-9], optional per the coordinator: fail FAST, pre-sweep,
+# when the sender says it uploaded an ensure script (-EnsureScript non-empty)
+# but the path does not actually resolve -- a config mistake caught before any
+# daemon is touched, rather than discovered only via a degraded rc 6 after a
+# full swap. An EMPTY -EnsureScript (the standalone/debug invocation with none
+# uploaded) is legitimate and deliberately NOT validated here -- only a
+# NON-EMPTY one that resolves to nothing.
+if ($EnsureScript -and -not (Test-Path -LiteralPath $EnsureScript)) {
+    Fail 1 "ensure script not found at $EnsureScript (the sender said it uploaded one) -- refusing to proceed with a restore path that cannot work"
+}
+
+# --- 1. Stop the qmd daemon --------------------------------------------------
+# THREE distinct process shapes can independently hold the index file open
+# (HIMMEL-1416, live on win2: a bun.exe-only filter left two of these running
+# through four straight ship failures -- each rc=6 "file being used by another
+# process", stopped_pids=none every time -- until both were killed by hand
+# over ssh):
+#   - bun.exe running the plain daemon Start-QmdDaemon (below) launches.
+#   - qmd.exe -- a compiled/shimmed qmd binary. A Name='bun.exe' filter never
+#     matches this by name, in ANY Windows session (one holder was found
+#     running in the Services session).
+#   - node.exe running .../qmd.js mcp|--daemon -- the HIMMEL-592
+#     HTTP-singleton MCP daemon (port 8181), resident by design and started
+#     independently of this script (ensure-qmd-daemon.ps1/.sh). It is
+#     NODE-hosted, not bun, so the bun-only filter misses it too.
+# The node.exe match is scoped to command lines mentioning qmd.js specifically,
+# not a bare 'qmd' substring -- an unscoped node filter would also catch
+# dozens of unrelated node.exe processes (this box runs ~40).
+#
+# The HTTP-singleton daemon can be among these, and Start-QmdDaemon's own
+# restart below only relaunches the plain `mcp --keep-models` form (a
+# DIFFERENT, non-HTTP invocation), so stopping it here without restoring it
+# would leave the receiver's HTTP MCP surface down until the next
+# SessionStart-hook/logon fires -- not prompt on an unattended receiver.
+# $stoppedHttpDaemon is tracked below for OBSERVABILITY (round 2 [codex-adv-2])
+# but no longer GATES the restore (round 3 [codex-adv-3]/[codex-adv-4]):
+# Invoke-EnsureRestore below runs unconditionally whenever anything was
+# stopped, because a qmd.exe swept on name alone can have a null CommandLine
+# (round 1) with nothing left to classify it by -- a classification-gated
+# restore could silently miss exactly that case.
+$stopped = @()
+$stoppedHttpDaemon = $false
+$script:EnsureRestoreFailed = $false   # set by Invoke-EnsureRestore; consulted at the success-path exit (round 4 [codex-adv-6])
+try {
+    # -ErrorAction Stop, NOT SilentlyContinue: a FAILED enumeration would
+    # otherwise be indistinguishable from "no daemon is running", and we would
+    # go on to swap a file the daemon still holds open.
+    $procs = Get-CimInstance Win32_Process `
+        -Filter "Name = 'bun.exe' OR Name = 'qmd.exe' OR Name = 'node.exe'" -ErrorAction Stop
+    foreach ($p in $procs) {
+        if (Test-IsQmdHostProcess -Name $p.Name -CommandLine $p.CommandLine) {
+            Stop-Process -Id $p.ProcessId -Force -ErrorAction Stop
+            $stopped += $p.ProcessId
+            if (Test-IsHttpDaemonProcess -CommandLine $p.CommandLine) { $stoppedHttpDaemon = $true }
+        }
+    }
+} catch {
+    # Report what we DID stop before failing. A partial stop otherwise leaves the
+    # operator unable to tell whether a daemon needs restarting by hand -- and,
+    # honestly, whether that includes the HTTP daemon specifically (round 2
+    # [codex-adv-2], observability only). A stop failure here means the swap
+    # never happens and this script exits before reaching the success path's
+    # restore, so Complete-PostSweepFailure recovers BOTH daemon forms here too
+    # (round 4 [codex-adv-7]: the plain form was never restarted on this path
+    # before, taking search offline on a failed deploy) -- whatever WAS stopped
+    # before the enumeration failed still needs both, or it is left down with
+    # no restore attempted at all.
+    Emit 'stopped_before_failure' ($(if ($stopped.Count) { $stopped -join ',' } else { 'none' }))
+    Emit 'stopped_before_failure_http_daemon' $(if ($stoppedHttpDaemon) { 'yes' } else { 'no' })
+    Complete-PostSweepFailure -Code 2 -Msg "failed to stop the qmd daemon: $($_.Exception.Message)" `
+        -EnsureScript $EnsureScript -StoppedCount $stopped.Count -NoRestart:$NoRestart -AlsoRestartPlainDaemon
+}
+Emit 'stopped_pids' ($(if ($stopped.Count) { $stopped -join ',' } else { 'none' }))
+Emit 'stopped_http_daemon' $(if ($stoppedHttpDaemon) { 'yes' } else { 'no' })
+
+# Give the OS a moment to release the file handles before the swap; a swap
+# against a still-mapped SQLite file fails with a sharing violation.
+if ($stopped.Count -gt 0) { Start-Sleep -Seconds 3 }
+
+# --- 2. Swap ------------------------------------------------------------------
+# The previous index moves aside to .preship FIRST, so a failed move-in can be
+# rolled back. It is REAPED below on success and on failure -- two stale copies
+# (365MB + 221MB) once sat here for days. $preship + the self-swap guards moved
+# BEFORE the stop sweep (round 5 [codex-adv-8]) -- see that block for why.
 $rolledBack = $false
 try {
     if (Test-Path -LiteralPath $preship) { Remove-Item -LiteralPath $preship -Force }
@@ -153,14 +405,12 @@ try {
     # We stopped the daemon before the swap. Bailing out now without restarting
     # would leave the receiver with its ORIGINAL index restored but its search
     # service DOWN -- a failed ship silently taking the machine offline for
-    # search, which is worse than the failed ship itself. Restart before exiting
-    # (best effort, and reported either way).
-    if (-not $NoRestart -and $stopped.Count -gt 0) {
-        $backPid = $null
-        try { $backPid = Start-QmdDaemon } catch { }
-        Emit 'restarted_after_failure' $(if ($backPid) { $backPid } else { 'FAILED' })
-    }
-    Fail 3 "swap failed: $($_.Exception.Message)"
+    # search, which is worse than the failed ship itself. Complete-PostSweepFailure
+    # restores BOTH daemon forms before exiting (best effort, and reported
+    # either way) -- a failed, rolled-back ship must not leave the receiver's
+    # MCP endpoint down any more than a successful one would.
+    Complete-PostSweepFailure -Code 3 -Msg "swap failed: $($_.Exception.Message)" `
+        -EnsureScript $EnsureScript -StoppedCount $stopped.Count -NoRestart:$NoRestart -AlsoRestartPlainDaemon
 }
 Emit 'swapped' 'yes'
 
@@ -184,12 +434,31 @@ try {
 if (-not $NoRestart) {
     try {
         $newPid = Start-QmdDaemon
-        if (-not $newPid) { Fail 4 'could not restart the qmd daemon (qmd missing from PATH, or Win32_Process Create failed) -- index WAS swapped' }
+        # Round 4 [codex-adv-5]: both branches below used to call Fail 4
+        # directly, whose exit terminates BEFORE the HTTP-daemon restore
+        # further down ever ran -- an HTTP daemon killed by the sweep stayed
+        # down with no restore attempt whatsoever if the PLAIN daemon also
+        # failed to come back. Complete-PostSweepFailure runs that restore
+        # first. No -AlsoRestartPlainDaemon here: the plain form just failed,
+        # moments ago, in this same block.
+        if (-not $newPid) {
+            Complete-PostSweepFailure -Code 4 -Msg 'could not restart the qmd daemon (qmd missing from PATH, or Win32_Process Create failed) -- index WAS swapped' `
+                -EnsureScript $EnsureScript -StoppedCount $stopped.Count
+        }
         Emit 'restarted_pid' $newPid
     } catch {
-        Fail 4 "daemon restart failed (index WAS swapped): $($_.Exception.Message)"
+        Complete-PostSweepFailure -Code 4 -Msg "daemon restart failed (index WAS swapped): $($_.Exception.Message)" `
+            -EnsureScript $EnsureScript -StoppedCount $stopped.Count
     }
     Start-Sleep -Seconds 3
+
+    # Restore the HTTP-singleton MCP daemon (round 2 [codex-adv-2] /
+    # round 3 [codex-adv-3]/[codex-adv-4]): Start-QmdDaemon above only
+    # relaunches the plain `mcp --keep-models` form, which never listens on
+    # HTTP. See Invoke-EnsureRestore's own comment for why this call is
+    # UNCONDITIONAL on $stopped.Count rather than gated on classifying which
+    # stopped process was the HTTP daemon.
+    Invoke-EnsureRestore -EnsureScript $EnsureScript -StoppedCount $stopped.Count
 } else {
     Emit 'restarted_pid' 'skipped'
 }
@@ -226,18 +495,19 @@ Emit 'docs' $(if ($null -ne $docs) { $docs } else { 'unparsed' })
 Emit 'vectors' $(if ($null -ne $vecs) { $vecs } else { 'unparsed' })
 Emit 'pending' $pending
 
-if ($null -eq $docs -or $null -eq $vecs) {
-    Fail 5 "could not parse doc/vector counts from qmd status -- refusing to call the ship verified.`n$statusText"
-}
-if ($pending -gt 0) {
-    Fail 5 "$pending content hash(es) still need embedding after the swap -- vectors LAG lex. This is the silent-wrong state the ship exists to eliminate; the shipped artifact was not fully embedded at the source."
-}
-if ($ExpectVectors -ge 0 -and $vecs -ne $ExpectVectors) {
-    Fail 5 "vector count mismatch: receiver reports $vecs, sender shipped $ExpectVectors"
-}
-if ($ExpectDocs -ge 0 -and $docs -ne $ExpectDocs) {
-    Fail 5 "document count mismatch: receiver reports $docs, sender shipped $ExpectDocs"
+$verdict = Get-ShipVerdict -Docs $docs -Vecs $vecs -Pending $pending -ExpectDocs $ExpectDocs -ExpectVectors $ExpectVectors
+if ($verdict.FailCode -ne 0) {
+    Fail $verdict.FailCode "$($verdict.FailMsg)`n$statusText"
 }
 
 Emit 'verified' 'ok'
+# Round 4 [codex-adv-6], coordinator-overridden: the index shipped and
+# verified cleanly (rc 0 was always correct for THAT), but if the HTTP-daemon
+# restore actually failed, exit 6 instead of silently reporting a clean 0 --
+# unattended automation gets no other signal that port 8181 may be down.
+# $script:EnsureRestoreFailed stays $false (its initial value) when
+# -NoRestart skipped the restore entirely, so that mode is unaffected.
+if ($script:EnsureRestoreFailed) {
+    Fail 6 'index shipped and verified OK, but the HTTP-singleton MCP daemon restore FAILED after the stop sweep -- port 8181 may still be down. See the http_daemon_restored line above.'
+}
 exit 0

--- a/scripts/luna/ship-index.sh
+++ b/scripts/luna/ship-index.sh
@@ -65,9 +65,20 @@
 #   4  prepare/staging failed — nothing shipped
 #   5  upload failed          — receiver untouched
 #   6  receiver-side failure  (see its SHIP-REMOTE output; it reports whether the
-#                              index was swapped before failing)
+#                              index was swapped before failing). NOTE: this is
+#                              a SEPARATE numbering space from the receiver's
+#                              OWN internal exit codes (ship-index-remote.ps1's
+#                              rc 6 means something entirely different — see
+#                              rc 8 below); this script's die-6 fires for ANY
+#                              receiver rc except that one specific case.
 #   7  graph leg failed       (index shipped OK — reported separately, non-fatal
 #                              to the index result but a non-zero overall exit)
+#   8  index shipped + verified OK, but the receiver's HTTP-singleton MCP
+#      daemon restore FAILED (HIMMEL-1416 round 4 [codex-adv-6]) — the
+#      transport succeeded (receiver rc 6), so the graph leg still RUNS; this
+#      exit fires AFTER it completes, so a graph-leg failure (7) is reported
+#      instead when both happened (7 is more code-specific; the restore
+#      failure was already printed as a WARN either way).
 set -euo pipefail
 
 HOST="win2"
@@ -86,6 +97,10 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REINDEX_SCRIPT="$HERE/qmd-reindex.sh"
 PREPARE_SCRIPT="$HERE/prepare-ship-index.mjs"
 REMOTE_SCRIPT="$HERE/ship-index-remote.ps1"
+# Uploaded alongside REMOTE_SCRIPT and invoked BY it (never sourced in-process
+# -- see ship-index-remote.ps1's own comment on why) to restore the HTTP-
+# singleton MCP daemon if the stop sweep killed one (HIMMEL-1416 round 2).
+ENSURE_SCRIPT="$HERE/../qmd/ensure-qmd-daemon.ps1"
 
 LOCAL_INDEX="${QMD_INDEX_PATH:-$HOME/.cache/qmd/index.sqlite}"
 LOCAL_GRAPH="${GRAPHIFY_GRAPH_PATH:-$HOME/.graphify/global-graph.json}"
@@ -118,7 +133,7 @@ can never create an orphan collection there; and it refuses outright if the
 receiver expects a collection the source does not have.
 
 Exit: 0 ok | 1 usage | 2 prereq | 3 reindex | 4 prepare | 5 upload
-      6 receiver | 7 graph leg
+      6 receiver | 7 graph leg | 8 shipped+verified but HTTP restore failed
 EOF
 }
 
@@ -196,6 +211,7 @@ for tool in ssh scp node; do
 done
 [ -f "$PREPARE_SCRIPT" ] || die 2 "prepare-ship-index.mjs not found at $PREPARE_SCRIPT"
 [ -f "$REMOTE_SCRIPT" ]  || die 2 "ship-index-remote.ps1 not found at $REMOTE_SCRIPT"
+[ -f "$ENSURE_SCRIPT" ]  || die 2 "ensure-qmd-daemon.ps1 not found at $ENSURE_SCRIPT"
 [ "$DO_REINDEX" -eq 0 ] || [ -f "$REINDEX_SCRIPT" ] || die 2 "qmd-reindex.sh not found at $REINDEX_SCRIPT"
 # The index-EXISTS check deliberately does NOT run here. On a first-ever run the
 # reindex step is what CREATES the index, so demanding it up front would fail
@@ -319,6 +335,7 @@ if [ "$DRY_RUN" -eq 1 ]; then
     say "  would run         : node $PREPARE_SCRIPT --src $LOCAL_INDEX --out <staging> --collections <set>"
     say "  would upload      : <staging> -> $HOST:$REMOTE_TMP/qmd-index.incoming.sqlite"
     say "  would upload      : $REMOTE_SCRIPT -> $HOST:$REMOTE_TMP/ship-index-remote.ps1"
+    say "  would upload      : $ENSURE_SCRIPT -> $HOST:$REMOTE_TMP/ensure-qmd-daemon.ps1"
     say "  would run THERE   : ship-index-remote.ps1 (daemon fence -> swap -> WMI restart -> verify -> reap)"
     say "dry-run complete (no changes made)"
     exit 0
@@ -390,6 +407,7 @@ say "[4/5] uploading to $HOST"
 RUN_TAG="$$-$(date +%s 2>/dev/null || echo 0)"
 REMOTE_STAGED="$REMOTE_TMP/qmd-index.incoming.$RUN_TAG.sqlite"
 REMOTE_PS1="$REMOTE_TMP/ship-index-remote.$RUN_TAG.ps1"
+REMOTE_ENSURE="$REMOTE_TMP/ensure-qmd-daemon.$RUN_TAG.ps1"
 scp -q "$STAGING" "$HOST:$REMOTE_STAGED" || die 5 "upload of the index failed — receiver untouched"
 if ! scp -q "$REMOTE_SCRIPT" "$HOST:$REMOTE_PS1"; then
     # The INDEX upload already succeeded, so a ~400MB staged file is sitting on
@@ -399,6 +417,14 @@ if ! scp -q "$REMOTE_SCRIPT" "$HOST:$REMOTE_PS1"; then
     ssh "$HOST" "cmd /c del /q \"${REMOTE_STAGED//\//\\}\"" >/dev/null 2>&1 || true
     die 5 "upload of the receiver script failed — receiver untouched (staged index reaped)"
 fi
+# ensure-qmd-daemon.ps1 lets ship-index-remote.ps1 restore the HTTP-singleton
+# MCP daemon if its stop sweep kills one (HIMMEL-1416 round 2). Same reap
+# discipline as the receiver script upload above.
+if ! scp -q "$ENSURE_SCRIPT" "$HOST:$REMOTE_ENSURE"; then
+    # shellcheck disable=SC2029  # client-side expansion is intended (paths resolved here)
+    ssh "$HOST" "cmd /c del /q \"${REMOTE_STAGED//\//\\}\" \"${REMOTE_PS1//\//\\}\"" >/dev/null 2>&1 || true
+    die 5 "upload of ensure-qmd-daemon.ps1 failed — receiver untouched (staged index + receiver script reaped)"
+fi
 
 # --- 5. receive (fence -> swap -> restart -> verify -> reap) -----------------
 say "[5/5] running the receiver-side swap on $HOST"
@@ -407,18 +433,37 @@ say "[5/5] running the receiver-side swap on $HOST"
 remote_rc=0
 # shellcheck disable=SC2029  # client-side expansion is INTENDED: the paths and
 # counts are resolved HERE and baked into the command the receiver runs.
-ssh "$HOST" "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS1\" -Staged \"$REMOTE_STAGED\" -Target \"$REMOTE_INDEX\" -ExpectDocs $SHIP_DOCS -ExpectVectors $SHIP_VECS" || remote_rc=$?
+ssh "$HOST" "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REMOTE_PS1\" -Staged \"$REMOTE_STAGED\" -Target \"$REMOTE_INDEX\" -ExpectDocs $SHIP_DOCS -ExpectVectors $SHIP_VECS -EnsureScript \"$REMOTE_ENSURE\"" || remote_rc=$?
+
+# Receiver rc 6: the PRIMARY contract (swap + plain daemon + verify) fully
+# succeeded on the receiver -- only its secondary, best-effort HTTP-singleton
+# MCP daemon restore failed (HIMMEL-1416 round 4 [codex-adv-6]). Transport is
+# genuinely verified, so this is NOT "receiver-side ship failed": clean up and
+# proceed exactly like a normal success, but remember to surface it loudly and
+# exit non-zero at the very end -- unattended automation must not see a clean
+# 0 while port 8181 may still be down. Do NOT `die` here: that would skip the
+# graph leg below, which is gated on a verified index ship and this one is --
+# recreating the exact blocked-graph-leg bug HIMMEL-1416 round 2 already fixed
+# once for a different reason.
+http_restore_failed=0
+if [ "$remote_rc" -eq 6 ]; then
+    http_restore_failed=1
+    echo "WARN ship-index: receiver's HTTP-singleton MCP daemon restore FAILED after the stop sweep -- the index itself shipped and verified. Check port 8181 on $HOST; the receiver's SHIP-REMOTE output above has the details." >&2
+    remote_rc=0
+fi
+
 if [ "$remote_rc" -ne 0 ]; then
     # Best-effort: do not leave this run's per-invocation artifacts behind on the
     # receiver. A failed swap already left its own state; the uploads are ours.
     # shellcheck disable=SC2029  # client-side expansion is intended (paths resolved here)
-    ssh "$HOST" "cmd /c del /q \"${REMOTE_STAGED//\//\\}\" \"${REMOTE_PS1//\//\\}\"" >/dev/null 2>&1 || true
+    ssh "$HOST" "cmd /c del /q \"${REMOTE_STAGED//\//\\}\" \"${REMOTE_PS1//\//\\}\" \"${REMOTE_ENSURE//\//\\}\"" >/dev/null 2>&1 || true
     die 6 "receiver-side ship failed (rc=$remote_rc). Its SHIP-REMOTE output above states whether the index was swapped before the failure."
 fi
 # On success the receiver consumed the staged index (it was MOVED into place);
-# only our copy of the script needs reaping.
-# shellcheck disable=SC2029  # client-side expansion is intended (path resolved here)
-ssh "$HOST" "cmd /c del /q \"${REMOTE_PS1//\//\\}\"" >/dev/null 2>&1 || true
+# our copies of the two scripts still need reaping (ensure-qmd-daemon.ps1 is
+# invoked in place, never moved).
+# shellcheck disable=SC2029  # client-side expansion is intended (paths resolved here)
+ssh "$HOST" "cmd /c del /q \"${REMOTE_PS1//\//\\}\" \"${REMOTE_ENSURE//\//\\}\"" >/dev/null 2>&1 || true
 
 say "index shipped + verified on $HOST (${SHIP_DOCS} docs / ${SHIP_VECS} vectors)"
 
@@ -441,4 +486,14 @@ if [ "$DO_GRAPH" -eq 1 ]; then
     fi
 fi
 
-exit "$graph_rc"
+# Final status (HIMMEL-1416 round 4 [codex-adv-6]): a graph-leg failure keeps
+# its own specific code (7) even when the HTTP restore ALSO failed -- the WARN
+# above already printed that regardless of which code wins, so nothing is
+# silently lost; 7 is simply the more specific of the two when both are true.
+if [ "$graph_rc" -ne 0 ]; then
+    exit "$graph_rc"
+fi
+if [ "$http_restore_failed" -eq 1 ]; then
+    exit 8
+fi
+exit 0

--- a/scripts/luna/test-ship-index.sh
+++ b/scripts/luna/test-ship-index.sh
@@ -852,6 +852,100 @@ else
         printf 'New-Item -ItemType File -Force -Path $env:SENTINEL_PATH | Out-Null\nexit 0\n' > "$1"
     }
 
+    # The separator PowerShell actually splits $env:PATH on for THIS OS:
+    # ';' under real Windows PowerShell (Git-Bash/MSYS), ':' under pwsh on
+    # Linux/macOS. A hardcoded ';' on non-Windows collapses the whole
+    # prepended entry into ONE bogus path segment -- the directory inside it
+    # is never resolved at all, regardless of what stub lives there.
+    ps_path_sep() {
+        case "$(uname -s)" in
+            MINGW*|MSYS*|CYGWIN*) printf ';' ;;
+            *) printf ':' ;;
+        esac
+    }
+
+    # Emits a `$env:PATH = "..."` line prepending one or more directories
+    # ahead of the inherited PATH, using the OS-appropriate separator so the
+    # generated probe resolves stubs on both real Windows PowerShell and pwsh
+    # on Linux.
+    ps_prepend_path_line() {
+        local sep joined d w
+        sep="$(ps_path_sep)"
+        joined=""
+        for d in "$@"; do
+            [ -z "$d" ] && continue
+            w="$(winpath "$d")"
+            joined="${joined}${w}${sep}"
+        done
+        # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
+        printf '$env:PATH = "%s" + $env:PATH\n' "$joined"
+    }
+
+    # Fake `qmd status`, resolvable as a bare `qmd` on PATH. Real Windows
+    # PowerShell resolves an extensionless command through PATHEXT, so a
+    # .cmd batch file works there -- but pwsh on non-Windows does NOT do
+    # PATHEXT-style resolution: it needs a file literally named `qmd`,
+    # executable, with a shebang. Without this, `& qmd status` throws
+    # CommandNotFoundException on Linux (measured: exactly the "qmd status
+    # failed after swap: The term 'qmd' is not recognized" failure on the
+    # ubuntu CI runner).
+    make_qmd_stub() {
+        local dir="$1"
+        mkdir -p "$dir"
+        case "$(uname -s)" in
+            MINGW*|MSYS*|CYGWIN*)
+                {
+                    printf '@echo off\r\n'
+                    printf 'echo QMD Status\r\n'
+                    printf 'echo.\r\n'
+                    printf 'echo Documents\r\n'
+                    printf 'echo   Total:    100 files indexed\r\n'
+                    printf 'echo   Vectors:  100 embedded\r\n'
+                    printf 'exit /b 0\r\n'
+                } > "$dir/qmd.cmd"
+                ;;
+            *)
+                {
+                    printf '#!/bin/sh\n'
+                    printf 'echo "QMD Status"\n'
+                    printf 'echo\n'
+                    printf 'echo "Documents"\n'
+                    printf 'echo "  Total:    100 files indexed"\n'
+                    printf 'echo "  Vectors:  100 embedded"\n'
+                    printf 'exit 0\n'
+                } > "$dir/qmd"
+                chmod +x "$dir/qmd"
+                ;;
+        esac
+    }
+
+    # Fake `powershell`, forwarding to $PS_BIN. ship-index-remote.ps1's
+    # Invoke-EnsureRestore hardcodes a literal `powershell` invocation to
+    # relaunch the ensure script as a genuinely separate process -- correct
+    # on the real receiver (win2, real Windows PowerShell 5.1), but
+    # `powershell` does not exist at all on the Linux CI runner (only
+    # `pwsh`), so that call throws CommandNotFoundException and the ensure
+    # script body never runs (measured: SHIP-REMOTE: http_daemon_restored=
+    # FAILED, and the sentinel file the ensure script writes never appears).
+    # A same-named forwarding shim makes the hardcoded name resolve without
+    # touching the CR-certified receiver script. Windows-only, real
+    # `powershell` already resolves there -- and, measured, real Windows
+    # PowerShell's own command resolution picks an extensionless same-named
+    # PATH entry over the real powershell.exe rather than skipping it, so
+    # shadowing it on Windows would break the real interpreter instead of
+    # leaving it alone. PSSHIM_DIR stays empty (never prepended -- see
+    # ps_prepend_path_line's blank-arg skip) on Windows.
+    PSSHIM_DIR=""
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*) ;;
+        *)
+            PSSHIM_DIR="$TMP_ROOT/psshim"
+            mkdir -p "$PSSHIM_DIR"
+            { printf '#!/bin/sh\nexec "%s" "$@"\n' "$PS_BIN"; } > "$PSSHIM_DIR/powershell"
+            chmod +x "$PSSHIM_DIR/powershell"
+            ;;
+    esac
+
     # ---- (a) sweep-stopped-something + a genuine success path ----------------
     # The fullest form: also fakes `qmd status` on PATH so the run completes
     # with a real rc 0, proving the restore fires on an ACTUAL successful ship,
@@ -861,16 +955,7 @@ else
     make_staged "$STAGED_A"
     printf 'old-index' > "$TARGET_A"
     ENSURE_A="$TMP_ROOT/ensure-a.ps1"; make_fake_ensure "$ENSURE_A"
-    FAKEBIN_A="$TMP_ROOT/fakebin-a"; mkdir -p "$FAKEBIN_A"
-    {
-        printf '@echo off\r\n'
-        printf 'echo QMD Status\r\n'
-        printf 'echo.\r\n'
-        printf 'echo Documents\r\n'
-        printf 'echo   Total:    100 files indexed\r\n'
-        printf 'echo   Vectors:  100 embedded\r\n'
-        printf 'exit /b 0\r\n'
-    } > "$FAKEBIN_A/qmd.cmd"
+    FAKEBIN_A="$TMP_ROOT/fakebin-a"; make_qmd_stub "$FAKEBIN_A"
     PROBE_A="$TMP_ROOT/wiring-success-probe.ps1"
     cat > "$PROBE_A" <<'PROBE_A_EOF'
 function Get-CimInstance {
@@ -891,8 +976,7 @@ function Get-Command {
 }
 PROBE_A_EOF
     {
-        # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
-        printf '$env:PATH = "%s;" + $env:PATH\n' "$(winpath "$FAKEBIN_A")"
+        ps_prepend_path_line "$FAKEBIN_A" "$PSSHIM_DIR"
         # shellcheck disable=SC2016  # PowerShell syntax, same reason as above
         printf '$env:SENTINEL_PATH = "%s"\n' "$(winpath "$SENT_A")"
         # `&`, NOT dot-source (`.`): a dot-sourced script's `exit` inside a
@@ -946,6 +1030,7 @@ function Get-Command {
 }
 PROBE_B_EOF
     {
+        ps_prepend_path_line "$PSSHIM_DIR"
         # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
         printf '$env:SENTINEL_PATH = "%s"\n' "$(winpath "$SENT_B")"
         # `&`, not dot-source -- see the comment on the (a) probe for why.
@@ -996,6 +1081,7 @@ function Get-Command {
 }
 PROBE_C_EOF
     {
+        ps_prepend_path_line "$PSSHIM_DIR"
         # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
         printf '$env:SENTINEL_PATH = "%s"\n' "$(winpath "$SENT_C")"
         # `&`, not dot-source -- see the comment on the (a) probe for why.
@@ -1039,6 +1125,7 @@ function Get-Command {
 }
 PROBE_D_EOF
     {
+        ps_prepend_path_line "$PSSHIM_DIR"
         # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
         printf '$env:SENTINEL_PATH = "%s"\n' "$(winpath "$SENT_D")"
         printf '& "%s" -Staged "%s" -Target "%s" -EnsureScript "%s"\n' \
@@ -1081,6 +1168,7 @@ function Get-Command {
 }
 PROBE_E_EOF
     {
+        ps_prepend_path_line "$PSSHIM_DIR"
         # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
         printf '$env:SENTINEL_PATH = "%s"\n' "$(winpath "$SENT_E")"
         printf '& "%s" -Staged "%s" -Target "%s" -EnsureScript "%s"\n' \
@@ -1107,16 +1195,7 @@ PROBE_E_EOF
     ENSURE_F="$TMP_ROOT/ensure-f.ps1"
     # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
     printf 'New-Item -ItemType File -Force -Path $env:SENTINEL_PATH | Out-Null\nexit 1\n' > "$ENSURE_F"
-    FAKEBIN_F="$TMP_ROOT/fakebin-f"; mkdir -p "$FAKEBIN_F"
-    {
-        printf '@echo off\r\n'
-        printf 'echo QMD Status\r\n'
-        printf 'echo.\r\n'
-        printf 'echo Documents\r\n'
-        printf 'echo   Total:    100 files indexed\r\n'
-        printf 'echo   Vectors:  100 embedded\r\n'
-        printf 'exit /b 0\r\n'
-    } > "$FAKEBIN_F/qmd.cmd"
+    FAKEBIN_F="$TMP_ROOT/fakebin-f"; make_qmd_stub "$FAKEBIN_F"
     PROBE_F="$TMP_ROOT/wiring-restorefail-probe.ps1"
     cat > "$PROBE_F" <<'PROBE_F_EOF'
 function Get-CimInstance {
@@ -1137,8 +1216,7 @@ function Get-Command {
 }
 PROBE_F_EOF
     {
-        # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
-        printf '$env:PATH = "%s;" + $env:PATH\n' "$(winpath "$FAKEBIN_F")"
+        ps_prepend_path_line "$FAKEBIN_F" "$PSSHIM_DIR"
         # shellcheck disable=SC2016  # PowerShell syntax, same reason as above
         printf '$env:SENTINEL_PATH = "%s"\n' "$(winpath "$SENT_F")"
         printf '& "%s" -Staged "%s" -Target "%s" -EnsureScript "%s" -ExpectDocs 100 -ExpectVectors 100\n' \
@@ -1199,16 +1277,7 @@ PROBE_G_EOF
     STAGED_H="$TMP_ROOT/staged-h.sqlite"; TARGET_H="$TMP_ROOT/target-h.sqlite"
     make_staged "$STAGED_H"
     printf 'old-index' > "$TARGET_H"
-    FAKEBIN_H="$TMP_ROOT/fakebin-h"; mkdir -p "$FAKEBIN_H"
-    {
-        printf '@echo off\r\n'
-        printf 'echo QMD Status\r\n'
-        printf 'echo.\r\n'
-        printf 'echo Documents\r\n'
-        printf 'echo   Total:    100 files indexed\r\n'
-        printf 'echo   Vectors:  100 embedded\r\n'
-        printf 'exit /b 0\r\n'
-    } > "$FAKEBIN_H/qmd.cmd"
+    FAKEBIN_H="$TMP_ROOT/fakebin-h"; make_qmd_stub "$FAKEBIN_H"
     PROBE_H="$TMP_ROOT/wiring-noensure-probe.ps1"
     cat > "$PROBE_H" <<'PROBE_H_EOF'
 function Get-CimInstance {
@@ -1229,8 +1298,7 @@ function Get-Command {
 }
 PROBE_H_EOF
     {
-        # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
-        printf '$env:PATH = "%s;" + $env:PATH\n' "$(winpath "$FAKEBIN_H")"
+        ps_prepend_path_line "$FAKEBIN_H"
         # No -EnsureScript at all -- exercises the parameter's own empty default.
         printf '& "%s" -Staged "%s" -Target "%s" -ExpectDocs 100 -ExpectVectors 100\n' \
             "$(winpath "$REAL_REMOTE_SCRIPT")" "$(winpath "$STAGED_H")" "$(winpath "$TARGET_H")"

--- a/scripts/luna/test-ship-index.sh
+++ b/scripts/luna/test-ship-index.sh
@@ -113,6 +113,15 @@ case "$*" in
       # matches the PER-INVOCATION name (ship-index-remote.<tag>.ps1), not a
       # fixed one — the orchestrator uniquifies remote paths per run.
       if [ -e "$STATE/remote-fail" ]; then echo "SHIP-REMOTE: swapped=no" >&2; exit 5; fi
+      # rc 6 (HIMMEL-1416 round 4): the PRIMARY receiver contract (swap +
+      # plain daemon + verify) fully succeeded -- only the HTTP-singleton
+      # daemon restore failed. Distinct from remote-fail above (a genuine
+      # transport failure, rc 5).
+      if [ -e "$STATE/remote-http-restore-fail" ]; then
+          echo "SHIP-REMOTE: verified=ok"
+          echo "SHIP-REMOTE: http_daemon_restored=FAILED" >&2
+          exit 6
+      fi
       echo "SHIP-REMOTE: verified=ok" ;;
 esac
 exit 0'
@@ -217,6 +226,12 @@ mkdir -p "$SANDBOX"
 cp "$SCRIPT" "$SANDBOX/ship-index.sh"
 cp "$SCRIPT_DIR/prepare-ship-index.mjs" "$SANDBOX/"
 cp "$SCRIPT_DIR/ship-index-remote.ps1" "$SANDBOX/"
+# ship-index.sh also resolves ensure-qmd-daemon.ps1 from ../qmd relative to its
+# OWN directory (HIMMEL-1416 round 2) -- mirror that sibling layout here too,
+# or the preflight existence check dies rc 2 before reaching anything this
+# sandbox exists to exercise.
+mkdir -p "$SANDBOX/../qmd"
+cp "$SCRIPT_DIR/../qmd/ensure-qmd-daemon.ps1" "$SANDBOX/../qmd/"
 printf '#!/bin/sh\necho "reindex exploded" >&2\nexit 3\n' > "$SANDBOX/qmd-reindex.sh"
 chmod +x "$SANDBOX/qmd-reindex.sh"
 rc=0; out=$(env PATH="$BIN:$PATH" QMD_INDEX_PATH="$FAKE_INDEX" \
@@ -461,6 +476,10 @@ assert_contains "passed that set to prepare" "--collections himmel,luna" "$(call
 assert_contains "uploaded the index" "scp " "$(calls)"
 assert_contains "ran the receiver script" "ship-index-remote.ps1" "$(calls)"
 assert_contains "reports the shipped counts" "14782 docs / 50698 vectors" "$out"
+# HIMMEL-1416 round 2: ensure-qmd-daemon.ps1 rides along so the receiver can
+# restore the HTTP-singleton MCP daemon if the stop sweep kills it.
+assert_contains "uploaded ensure-qmd-daemon.ps1 alongside the receiver script" "ensure-qmd-daemon" "$(calls)"
+assert_contains "passed -EnsureScript to the receiver invocation" "-EnsureScript" "$(calls)"
 
 echo "TEST: remote paths are DERIVED from the receiver, never hardcoded"
 # A baked C:/Users/<name>/... default would tie the script to one operator's
@@ -556,6 +575,27 @@ assert_rc "receiver failure rc 6" 6 "$rc"
 assert_contains "points at the receiver's own output" "SHIP-REMOTE" "$out"
 
 # ============================================================================
+echo "TEST: receiver rc 6 (HTTP restore failed) still runs the graph leg and exits 8 (HIMMEL-1416 round 4 [codex-adv-6])"
+# ============================================================================
+# The receiver's PRIMARY contract (swap + plain daemon + verify) succeeded --
+# only its secondary HTTP-daemon restore failed. This must NOT take the
+# generic die-6 "receiver-side ship failed" path above (that would skip the
+# graph leg entirely, recreating the exact blocked-graph-leg bug this ticket
+# already fixed once for a different reason) -- it must run the graph leg
+# normally and THEN exit non-zero (8) so unattended automation still gets a
+# signal, rather than a silent, misleadingly clean 0.
+reset_calls
+touch "$STATE/remote-http-restore-fail"
+REAL_GRAPH="$TMP_ROOT/real-graph-for-rc6-test.json"
+printf '{"nodes":[]}' > "$REAL_GRAPH"
+rc=0; out=$(env PATH="$BIN:$PATH" QMD_INDEX_PATH="$FAKE_INDEX" GRAPHIFY_GRAPH_PATH="$REAL_GRAPH" \
+    "$REAL_BASH" "$SCRIPT" --no-reindex 2>&1) || rc=$?
+assert_rc "receiver rc 6 -> sender exits 8 (not 0, not the generic die-6)" 8 "$rc"
+assert_contains "warns loudly about the HTTP restore failure" "HTTP-singleton MCP daemon restore FAILED" "$out"
+assert_contains "the graph leg actually ran (shipped the real graph file)" "graph shipped" "$out"
+assert_not_contains "did NOT take the generic die-6 receiver-failure path" "receiver-side ship failed" "$out"
+
+# ============================================================================
 echo "TEST: the receiver script's Fail() preserves its stage-specific exit code"
 # ============================================================================
 # Regression pin for CR finding [codex-1]. ship-index-remote.ps1 runs under
@@ -622,6 +662,587 @@ else
         "$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$PS_PROBE" >/dev/null 2>&1 || ps_rc=$?
         assert_rc "Fail 5 really exits 5 (not collapsed to 1)" 5 "$ps_rc"
     fi
+fi
+
+# ============================================================================
+echo "TEST: Test-IsQmdHostProcess matches all qmd-hosting process shapes (HIMMEL-1416)"
+# ============================================================================
+# Regression pin for the live stop-sweep miss: a bun.exe-only filter left a
+# compiled qmd.exe and a node-hosted qmd.js MCP daemon running through four
+# straight ship failures (rc=6 "file being used by another process",
+# stopped_pids=none every time; two holders had to be killed by hand over
+# ssh). Extract the REAL function (so this cannot drift from it) and probe it
+# against every shape the sweep must now catch, plus the shapes it must still
+# leave alone.
+if [ -z "$PS_BIN" ]; then
+    echo "  SKIP: no powershell/pwsh on this host (Test-IsQmdHostProcess check)"
+else
+    HOST_PROBE="$TMP_ROOT/qmdhost-probe.ps1"
+    {
+        sed -n '/^function Test-IsQmdHostProcess/,/^}/p' "$SCRIPT_DIR/ship-index-remote.ps1"
+        cat <<'HOST_EOF'
+$cases = @(
+    @{ Name = 'bun.exe';  Cmd = '"C:\Users\op\.bun\bin\qmd.exe" mcp --keep-models'; Want = $true;  Label = 'bun.exe launching a qmd.exe command line' }
+    @{ Name = 'bun.exe';  Cmd = '"C:\Users\op\.bun\bin\bun.exe" run --cwd C:\plugins\luna-correlate\0.2.0 --shell=bun --silent start'; Want = $false; Label = 'unrelated bun.exe (luna-correlate)' }
+    @{ Name = 'qmd.exe';  Cmd = '"C:\Users\op\.bun\bin\qmd.exe" mcp --keep-models'; Want = $true;  Label = 'qmd.exe compiled binary (HIMMEL-1416, invisible to a bun.exe-only filter)' }
+    @{ Name = 'qmd.exe';  Cmd = $null; Want = $true;  Label = 'qmd.exe with no visible command line -- access-denied to an elevated/other-session process, exactly the Services-session case (CR codex-1)' }
+    @{ Name = 'node.exe'; Cmd = 'node "C:\Users\op\.bun\install\global\node_modules\@tobilu\qmd\dist\cli\qmd.js" mcp --http --daemon'; Want = $true;  Label = 'node-hosted qmd.js HTTP-singleton daemon (HIMMEL-592)' }
+    @{ Name = 'node.exe'; Cmd = 'node C:\some\other\app\server.js --port 3000'; Want = $false; Label = 'unrelated node.exe' }
+    @{ Name = 'node.exe'; Cmd = $null; Want = $false; Label = 'node.exe with no command line -- the null guard still applies to non-qmd.exe shapes' }
+)
+$failed = $false
+foreach ($c in $cases) {
+    $got = Test-IsQmdHostProcess -Name $c.Name -CommandLine $c.Cmd
+    if ($got -ne $c.Want) {
+        Write-Output "MISMATCH: $($c.Label) -> got $got, want $($c.Want)"
+        $failed = $true
+    }
+}
+if ($failed) { exit 1 } else { exit 0 }
+HOST_EOF
+    } > "$HOST_PROBE"
+    if ! grep -q 'function Test-IsQmdHostProcess' "$HOST_PROBE"; then
+        fail "could not extract Test-IsQmdHostProcess from ship-index-remote.ps1" "the function shape changed; update this test"
+    else
+        host_rc=0
+        host_out=$("$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$HOST_PROBE" 2>&1) || host_rc=$?
+        assert_rc "Test-IsQmdHostProcess matches every qmd-hosting shape and only those" 0 "$host_rc"
+        [ "$host_rc" -eq 0 ] || printf '    %s\n' "$host_out"
+    fi
+fi
+
+# ============================================================================
+echo "TEST: Test-IsHttpDaemonProcess flags the HTTP-singleton daemon shape (HIMMEL-1416 round 2)"
+# ============================================================================
+# Round-2 CR [codex-adv-2], verified: Start-QmdDaemon's own restart relaunches
+# only the plain `mcp --keep-models` form, never the HIMMEL-592 HTTP-singleton
+# daemon (`mcp --http --daemon`). This function decides whether a STOPPED
+# process was that HTTP daemon, so the restart step knows to restore it via
+# ensure-qmd-daemon.ps1. Matched on CommandLine alone (not process name): the
+# daemon can be bun- or node-hosted, but ensure-qmd-daemon.ps1 always launches
+# it with `--http`, which the plain daemon's command line never carries.
+if [ -z "$PS_BIN" ]; then
+    echo "  SKIP: no powershell/pwsh on this host (Test-IsHttpDaemonProcess check)"
+else
+    HTTP_PROBE="$TMP_ROOT/httpdaemon-probe.ps1"
+    {
+        sed -n '/^function Test-IsHttpDaemonProcess/,/^}/p' "$SCRIPT_DIR/ship-index-remote.ps1"
+        cat <<'HTTP_EOF'
+$cases = @(
+    @{ Cmd = '"C:\Users\op\.bun\bin\qmd.exe" mcp --http --daemon'; Want = $true;  Label = 'qmd.exe HTTP-singleton daemon' }
+    @{ Cmd = 'node "C:\Users\op\.bun\install\global\node_modules\@tobilu\qmd\dist\cli\qmd.js" mcp --http --daemon'; Want = $true;  Label = 'node-hosted qmd.js HTTP-singleton daemon' }
+    @{ Cmd = '"C:\Users\op\.bun\bin\qmd.exe" mcp --keep-models'; Want = $false; Label = 'the plain stdio daemon Start-QmdDaemon itself relaunches' }
+    @{ Cmd = $null; Want = $false; Label = 'no command line at all' }
+)
+$failed = $false
+foreach ($c in $cases) {
+    $got = Test-IsHttpDaemonProcess -CommandLine $c.Cmd
+    if ($got -ne $c.Want) {
+        Write-Output "MISMATCH: $($c.Label) -> got $got, want $($c.Want)"
+        $failed = $true
+    }
+}
+if ($failed) { exit 1 } else { exit 0 }
+HTTP_EOF
+    } > "$HTTP_PROBE"
+    if ! grep -q 'function Test-IsHttpDaemonProcess' "$HTTP_PROBE"; then
+        fail "could not extract Test-IsHttpDaemonProcess from ship-index-remote.ps1" "the function shape changed; update this test"
+    else
+        http_rc=0
+        http_out=$("$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$HTTP_PROBE" 2>&1) || http_rc=$?
+        assert_rc "Test-IsHttpDaemonProcess flags --http command lines and only those" 0 "$http_rc"
+        [ "$http_rc" -eq 0 ] || printf '    %s\n' "$http_out"
+    fi
+fi
+
+# ============================================================================
+echo "TEST: Get-ShipVerdict fails on any doc-count mismatch (HIMMEL-1416 round 2)"
+# ============================================================================
+# Round-2 CR [codex-adv-1], verified against the qmd fork source: the live
+# false-fail (receiver docs 14844 != sender-staged docs 15189, despite vectors
+# 52967==52967 and pending 0) was a PREDICATE mismatch -- qmd status counts
+# `WHERE active = 1`, prepare-ship-index.mjs staged a bare COUNT(*). Now that
+# the sender counts with the same active=1 predicate, a genuine post-swap
+# mismatch means something is actually wrong, so it goes back to being a HARD
+# failure -- same as an unparseable count. The 14844/15189 regression values
+# are asserted FATAL here: the fix for the live incident is the sender
+# predicate change (prepare-ship-index.mjs), not tolerance in this function.
+if [ -z "$PS_BIN" ]; then
+    echo "  SKIP: no powershell/pwsh on this host (Get-ShipVerdict check)"
+else
+    VERDICT_PROBE="$TMP_ROOT/verdict-probe.ps1"
+    {
+        sed -n '/^function Get-ShipVerdict/,/^}/p' "$SCRIPT_DIR/ship-index-remote.ps1"
+        cat <<'VERDICT_EOF'
+function Check($label, $got, $wantFailCode) {
+    if ($got.FailCode -ne $wantFailCode) {
+        Write-Output "MISMATCH: $label -> FailCode=$($got.FailCode) (want FailCode=$wantFailCode)"
+        return $false
+    }
+    return $true
+}
+$ok = $true
+if (-not (Check 'unparsed vectors is fatal' (Get-ShipVerdict -Docs 100 -Vecs $null -Pending 0 -ExpectDocs -1 -ExpectVectors -1) 5)) { $ok = $false }
+if (-not (Check 'unparsed docs is fatal' (Get-ShipVerdict -Docs $null -Vecs 100 -Pending 0 -ExpectDocs -1 -ExpectVectors -1) 5)) { $ok = $false }
+if (-not (Check 'pending>0 is fatal' (Get-ShipVerdict -Docs 100 -Vecs 100 -Pending 3 -ExpectDocs -1 -ExpectVectors -1) 5)) { $ok = $false }
+if (-not (Check 'vector count mismatch is fatal' (Get-ShipVerdict -Docs 100 -Vecs 90 -Pending 0 -ExpectDocs -1 -ExpectVectors 100) 5)) { $ok = $false }
+if (-not (Check 'doc count mismatch is fatal' (Get-ShipVerdict -Docs 90 -Vecs 100 -Pending 0 -ExpectDocs 100 -ExpectVectors -1) 5)) { $ok = $false }
+if (-not (Check 'live regression (14844 vs 15189) is now FATAL, not tolerated' (Get-ShipVerdict -Docs 14844 -Vecs 52967 -Pending 0 -ExpectDocs 15189 -ExpectVectors 52967) 5)) { $ok = $false }
+if (-not (Check 'same-predicate counts equal -> clean verify' (Get-ShipVerdict -Docs 100 -Vecs 100 -Pending 0 -ExpectDocs 100 -ExpectVectors 100) 0)) { $ok = $false }
+if ($ok) { exit 0 } else { exit 1 }
+VERDICT_EOF
+    } > "$VERDICT_PROBE"
+    if ! grep -q 'function Get-ShipVerdict' "$VERDICT_PROBE"; then
+        fail "could not extract Get-ShipVerdict from ship-index-remote.ps1" "the function shape changed; update this test"
+    else
+        verdict_rc=0
+        verdict_out=$("$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$VERDICT_PROBE" 2>&1) || verdict_rc=$?
+        assert_rc "Get-ShipVerdict: doc/vector count mismatches and unparseable counts are all hard failures" 0 "$verdict_rc"
+        [ "$verdict_rc" -eq 0 ] || printf '    %s\n' "$verdict_out"
+    fi
+fi
+
+# ============================================================================
+echo "TEST: Invoke-EnsureRestore is wired into every post-sweep exit path (HIMMEL-1416 round 3)"
+# ============================================================================
+# Round-3 [codex-adv-3]/[codex-adv-4]: the restore must be UNCONDITIONAL and
+# run on every post-sweep exit, not gated on classifying what was stopped, and
+# not just on the happy path. These drive the REAL ship-index-remote.ps1
+# end-to-end -- dot-sourced verbatim, so its own functions run unmodified, no
+# sed extraction and no drift risk -- with the WMI/process cmdlets it calls
+# fault-injected via function shadowing (Get-CimInstance, Stop-Process,
+# Invoke-CimMethod, Get-Command). Fixture-level fault injection throughout;
+# never a live process, a real qmd binary, or a real bun/node daemon.
+if [ -z "$PS_BIN" ]; then
+    echo "  SKIP: no powershell/pwsh on this host (Invoke-EnsureRestore wiring check)"
+else
+    REAL_REMOTE_SCRIPT="$SCRIPT_DIR/ship-index-remote.ps1"
+
+    # Git-Bash auto-translates a POSIX path to its Windows form ONLY when the
+    # path is its OWN whole argv token on a command line handed to a native
+    # (non-MSYS) process -- which is why `-File "$SOME_PROBE"` elsewhere in
+    # this suite just works. It does NOT reach into a path written as literal
+    # TEXT inside a generated .ps1 file's CONTENT: PowerShell's own parser
+    # reads that text directly, with zero Git-Bash involvement, so a bare
+    # "/c/Users/..." or "/tmp/..." string there is parsed as a literal
+    # (nonexistent) path and fails with CommandNotFoundException /
+    # DirectoryNotFoundException. Every path embedded INSIDE a probe file
+    # below (dot-source args, $env:SENTINEL_PATH, the $env:PATH prepend, and
+    # the -Command string in make_staged) needs this explicit conversion;
+    # bash-side operations (mkdir, printf >, rm -f, [ -f ]) keep using the
+    # original bash-native path throughout -- both spellings name the
+    # identical file, bash just needs its own.
+    winpath() {
+        local w
+        w="$(cygpath -w "$1" 2>/dev/null)"
+        if [ -n "$w" ]; then printf '%s' "$w" | tr "\\\\" "/"; else printf '%s' "$1"; fi
+    }
+
+    # A staged index must exist and be >=50MB to pass ship-index-remote.ps1's
+    # own truncation guard -- write one for real rather than special-casing
+    # that guard, so these tests exercise it too instead of routing around it.
+    make_staged() {
+        "$PS_BIN" -NoProfile -ExecutionPolicy Bypass -Command \
+            "[System.IO.File]::WriteAllBytes('$(winpath "$1")', (New-Object byte[] 52428800))"
+    }
+    # Shared fake ensure-script body: touches $env:SENTINEL_PATH and exits 0 --
+    # standing in for the real ensure-qmd-daemon.ps1 without starting anything.
+    make_fake_ensure() {
+        # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
+        printf 'New-Item -ItemType File -Force -Path $env:SENTINEL_PATH | Out-Null\nexit 0\n' > "$1"
+    }
+
+    # ---- (a) sweep-stopped-something + a genuine success path ----------------
+    # The fullest form: also fakes `qmd status` on PATH so the run completes
+    # with a real rc 0, proving the restore fires on an ACTUAL successful ship,
+    # not just on a path that happens to call the function.
+    SENT_A="$TMP_ROOT/sentinel-a.txt"; rm -f "$SENT_A"
+    STAGED_A="$TMP_ROOT/staged-a.sqlite"; TARGET_A="$TMP_ROOT/target-a.sqlite"
+    make_staged "$STAGED_A"
+    printf 'old-index' > "$TARGET_A"
+    ENSURE_A="$TMP_ROOT/ensure-a.ps1"; make_fake_ensure "$ENSURE_A"
+    FAKEBIN_A="$TMP_ROOT/fakebin-a"; mkdir -p "$FAKEBIN_A"
+    {
+        printf '@echo off\r\n'
+        printf 'echo QMD Status\r\n'
+        printf 'echo.\r\n'
+        printf 'echo Documents\r\n'
+        printf 'echo   Total:    100 files indexed\r\n'
+        printf 'echo   Vectors:  100 embedded\r\n'
+        printf 'exit /b 0\r\n'
+    } > "$FAKEBIN_A/qmd.cmd"
+    PROBE_A="$TMP_ROOT/wiring-success-probe.ps1"
+    cat > "$PROBE_A" <<'PROBE_A_EOF'
+function Get-CimInstance {
+    param($ClassName, [string]$Filter, $ErrorAction)
+    return @([pscustomobject]@{ Name = 'qmd.exe'; ProcessId = 4242; CommandLine = '"C:\fake\qmd.exe" mcp --keep-models' })
+}
+function Stop-Process {
+    param($Id, [switch]$Force, $ErrorAction)
+}
+function Invoke-CimMethod {
+    param($ClassName, $MethodName, $Arguments)
+    return [pscustomobject]@{ ReturnValue = 0; ProcessId = 9999 }
+}
+function Get-Command {
+    param($Name, $ErrorAction)
+    if ($Name -eq 'qmd') { return [pscustomobject]@{ Source = 'qmd' } }
+    return $null
+}
+PROBE_A_EOF
+    {
+        # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
+        printf '$env:PATH = "%s;" + $env:PATH\n' "$(winpath "$FAKEBIN_A")"
+        # shellcheck disable=SC2016  # PowerShell syntax, same reason as above
+        printf '$env:SENTINEL_PATH = "%s"\n' "$(winpath "$SENT_A")"
+        # `&`, NOT dot-source (`.`): a dot-sourced script's `exit` inside a
+        # FUNCTION (Fail(), here) does not propagate as this WRAPPER's own
+        # process exit code -- measured empirically, it comes back 0 every
+        # time regardless of the real code. `&` runs it as a child script
+        # invocation instead: its `exit N` sets $LASTEXITCODE correctly in
+        # the caller, while fake functions defined above (Get-CimInstance
+        # etc.) remain visible to it via normal PowerShell scope inheritance.
+        printf '& "%s" -Staged "%s" -Target "%s" -EnsureScript "%s" -ExpectDocs 100 -ExpectVectors 100\n' \
+            "$(winpath "$REAL_REMOTE_SCRIPT")" "$(winpath "$STAGED_A")" "$(winpath "$TARGET_A")" "$(winpath "$ENSURE_A")"
+        # shellcheck disable=SC2016  # PowerShell syntax, same reason as above
+        printf 'exit $LASTEXITCODE\n'
+    } >> "$PROBE_A"
+    a_rc=0
+    a_out=$("$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$PROBE_A" 2>&1) || a_rc=$?
+    assert_rc "(a) success path: the real script exits 0 (transport verified)" 0 "$a_rc"
+    [ "$a_rc" -eq 0 ] || printf '    %s\n' "$a_out"
+    if [ -f "$SENT_A" ]; then pass "(a) success path: Invoke-EnsureRestore actually ran the ensure script"; else fail "(a) success path: ensure script never ran"; fi
+
+    # ---- (b) stop-failure AFTER a first successful stop -----------------------
+    # Two qualifying processes; the first Stop-Process succeeds ($stopped
+    # becomes non-empty), the second throws -- landing in the stop-sweep's own
+    # catch with $stopped.Count -gt 0, before any swap is attempted.
+    SENT_B="$TMP_ROOT/sentinel-b.txt"; rm -f "$SENT_B"
+    STAGED_B="$TMP_ROOT/staged-b.sqlite"; TARGET_B="$TMP_ROOT/target-b.sqlite"
+    make_staged "$STAGED_B"
+    printf 'old-index' > "$TARGET_B"
+    ENSURE_B="$TMP_ROOT/ensure-b.ps1"; make_fake_ensure "$ENSURE_B"
+    PROBE_B="$TMP_ROOT/wiring-stopfail-probe.ps1"
+    cat > "$PROBE_B" <<'PROBE_B_EOF'
+function Get-CimInstance {
+    param($ClassName, [string]$Filter, $ErrorAction)
+    return @(
+        [pscustomobject]@{ Name = 'qmd.exe'; ProcessId = 4242; CommandLine = $null },
+        [pscustomobject]@{ Name = 'qmd.exe'; ProcessId = 4243; CommandLine = $null }
+    )
+}
+function Stop-Process {
+    param($Id, [switch]$Force, $ErrorAction)
+    if ($Id -eq 4243) { throw 'Access is denied' }
+}
+function Invoke-CimMethod {
+    param($ClassName, $MethodName, $Arguments)
+    return [pscustomobject]@{ ReturnValue = 0; ProcessId = 9999 }
+}
+function Get-Command {
+    param($Name, $ErrorAction)
+    if ($Name -eq 'qmd') { return [pscustomobject]@{ Source = 'qmd' } }
+    return $null
+}
+PROBE_B_EOF
+    {
+        # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
+        printf '$env:SENTINEL_PATH = "%s"\n' "$(winpath "$SENT_B")"
+        # `&`, not dot-source -- see the comment on the (a) probe for why.
+        printf '& "%s" -Staged "%s" -Target "%s" -EnsureScript "%s"\n' \
+            "$(winpath "$REAL_REMOTE_SCRIPT")" "$(winpath "$STAGED_B")" "$(winpath "$TARGET_B")" "$(winpath "$ENSURE_B")"
+        # shellcheck disable=SC2016  # PowerShell syntax, same reason as above
+        printf 'exit $LASTEXITCODE\n'
+    } >> "$PROBE_B"
+    b_rc=0
+    b_out=$("$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$PROBE_B" 2>&1) || b_rc=$?
+    assert_rc "(b) stop-failure after a partial stop: exits 2" 2 "$b_rc"
+    [ "$b_rc" -eq 2 ] || printf '    %s\n' "$b_out"
+    if [ -f "$SENT_B" ]; then pass "(b) stop-failure: Invoke-EnsureRestore ran before Fail 2"; else fail "(b) stop-failure: ensure script never ran"; fi
+    # Round 4 [codex-adv-7]: this catch never attempted the PLAIN daemon form
+    # before, leaving a stopped plain daemon down on a failed deploy. The fake
+    # Invoke-CimMethod above (used by Start-QmdDaemon) reports success, so
+    # Complete-PostSweepFailure's -AlsoRestartPlainDaemon attempt should Emit
+    # a real PID here, not skip straight to the HTTP restore alone.
+    assert_contains "(b) stop-failure: the PLAIN daemon restart was also attempted" "restarted_after_failure=9999" "$b_out"
+
+    # ---- (c) swap-failure recovery ---------------------------------------------
+    # The stop sweep succeeds cleanly ($stopped.Count -gt 0); the swap itself
+    # fails because $Target's parent directory does not exist, so Move-Item
+    # into it throws -- a genuine filesystem failure, not a faked cmdlet --
+    # landing in the swap catch's rollback/restart-best-effort block.
+    SENT_C="$TMP_ROOT/sentinel-c.txt"; rm -f "$SENT_C"
+    STAGED_C="$TMP_ROOT/staged-c.sqlite"
+    make_staged "$STAGED_C"
+    TARGET_C="$TMP_ROOT/nonexistent-dir-c/target.sqlite"
+    ENSURE_C="$TMP_ROOT/ensure-c.ps1"; make_fake_ensure "$ENSURE_C"
+    PROBE_C="$TMP_ROOT/wiring-swapfail-probe.ps1"
+    cat > "$PROBE_C" <<'PROBE_C_EOF'
+function Get-CimInstance {
+    param($ClassName, [string]$Filter, $ErrorAction)
+    return @([pscustomobject]@{ Name = 'qmd.exe'; ProcessId = 5000; CommandLine = $null })
+}
+function Stop-Process {
+    param($Id, [switch]$Force, $ErrorAction)
+}
+function Invoke-CimMethod {
+    param($ClassName, $MethodName, $Arguments)
+    return [pscustomobject]@{ ReturnValue = 0; ProcessId = 9999 }
+}
+function Get-Command {
+    param($Name, $ErrorAction)
+    if ($Name -eq 'qmd') { return [pscustomobject]@{ Source = 'qmd' } }
+    return $null
+}
+PROBE_C_EOF
+    {
+        # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
+        printf '$env:SENTINEL_PATH = "%s"\n' "$(winpath "$SENT_C")"
+        # `&`, not dot-source -- see the comment on the (a) probe for why.
+        printf '& "%s" -Staged "%s" -Target "%s" -EnsureScript "%s"\n' \
+            "$(winpath "$REAL_REMOTE_SCRIPT")" "$(winpath "$STAGED_C")" "$(winpath "$TARGET_C")" "$(winpath "$ENSURE_C")"
+        # shellcheck disable=SC2016  # PowerShell syntax, same reason as above
+        printf 'exit $LASTEXITCODE\n'
+    } >> "$PROBE_C"
+    c_rc=0
+    c_out=$("$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$PROBE_C" 2>&1) || c_rc=$?
+    assert_rc "(c) swap-failure recovery: exits 3" 3 "$c_rc"
+    [ "$c_rc" -eq 3 ] || printf '    %s\n' "$c_out"
+    if [ -f "$SENT_C" ]; then pass "(c) swap-failure: Invoke-EnsureRestore ran during rollback recovery"; else fail "(c) swap-failure: ensure script never ran"; fi
+
+    # ---- (d) Start-QmdDaemon returns null (round 4 [codex-adv-5]) -------------
+    # The stop sweep and swap both succeed; the restart's Start-QmdDaemon
+    # returns $null (Get-Command finds no qmd), landing in the `if (-not
+    # $newPid)` branch that used to call Fail 4 directly -- BEFORE the HTTP
+    # restore further down ever ran.
+    SENT_D="$TMP_ROOT/sentinel-d.txt"; rm -f "$SENT_D"
+    STAGED_D="$TMP_ROOT/staged-d.sqlite"; TARGET_D="$TMP_ROOT/target-d.sqlite"
+    make_staged "$STAGED_D"
+    printf 'old-index' > "$TARGET_D"
+    ENSURE_D="$TMP_ROOT/ensure-d.ps1"; make_fake_ensure "$ENSURE_D"
+    PROBE_D="$TMP_ROOT/wiring-restartnull-probe.ps1"
+    cat > "$PROBE_D" <<'PROBE_D_EOF'
+function Get-CimInstance {
+    param($ClassName, [string]$Filter, $ErrorAction)
+    return @([pscustomobject]@{ Name = 'qmd.exe'; ProcessId = 6000; CommandLine = $null })
+}
+function Stop-Process {
+    param($Id, [switch]$Force, $ErrorAction)
+}
+function Invoke-CimMethod {
+    param($ClassName, $MethodName, $Arguments)
+    return [pscustomobject]@{ ReturnValue = 0; ProcessId = 9999 }
+}
+function Get-Command {
+    param($Name, $ErrorAction)
+    return $null
+}
+PROBE_D_EOF
+    {
+        # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
+        printf '$env:SENTINEL_PATH = "%s"\n' "$(winpath "$SENT_D")"
+        printf '& "%s" -Staged "%s" -Target "%s" -EnsureScript "%s"\n' \
+            "$(winpath "$REAL_REMOTE_SCRIPT")" "$(winpath "$STAGED_D")" "$(winpath "$TARGET_D")" "$(winpath "$ENSURE_D")"
+        # shellcheck disable=SC2016  # PowerShell syntax, same reason as above
+        printf 'exit $LASTEXITCODE\n'
+    } >> "$PROBE_D"
+    d_rc=0
+    d_out=$("$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$PROBE_D" 2>&1) || d_rc=$?
+    assert_rc "(d) Start-QmdDaemon returns null: exits 4" 4 "$d_rc"
+    [ "$d_rc" -eq 4 ] || printf '    %s\n' "$d_out"
+    if [ -f "$SENT_D" ]; then pass "(d) restart-returns-null: Invoke-EnsureRestore still ran before Fail 4"; else fail "(d) restart-returns-null: ensure script never ran"; fi
+
+    # ---- (e) Start-QmdDaemon throws (round 4 [codex-adv-5]) --------------------
+    # Same shape as (d), but Get-Command resolves qmd fine and Invoke-CimMethod
+    # (the WMI process-create call inside Start-QmdDaemon) throws instead --
+    # the OTHER branch that used to call Fail 4 directly.
+    SENT_E="$TMP_ROOT/sentinel-e.txt"; rm -f "$SENT_E"
+    STAGED_E="$TMP_ROOT/staged-e.sqlite"; TARGET_E="$TMP_ROOT/target-e.sqlite"
+    make_staged "$STAGED_E"
+    printf 'old-index' > "$TARGET_E"
+    ENSURE_E="$TMP_ROOT/ensure-e.ps1"; make_fake_ensure "$ENSURE_E"
+    PROBE_E="$TMP_ROOT/wiring-restartthrow-probe.ps1"
+    cat > "$PROBE_E" <<'PROBE_E_EOF'
+function Get-CimInstance {
+    param($ClassName, [string]$Filter, $ErrorAction)
+    return @([pscustomobject]@{ Name = 'qmd.exe'; ProcessId = 7000; CommandLine = $null })
+}
+function Stop-Process {
+    param($Id, [switch]$Force, $ErrorAction)
+}
+function Invoke-CimMethod {
+    param($ClassName, $MethodName, $Arguments)
+    throw 'WMI create failed'
+}
+function Get-Command {
+    param($Name, $ErrorAction)
+    if ($Name -eq 'qmd') { return [pscustomobject]@{ Source = 'qmd' } }
+    return $null
+}
+PROBE_E_EOF
+    {
+        # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
+        printf '$env:SENTINEL_PATH = "%s"\n' "$(winpath "$SENT_E")"
+        printf '& "%s" -Staged "%s" -Target "%s" -EnsureScript "%s"\n' \
+            "$(winpath "$REAL_REMOTE_SCRIPT")" "$(winpath "$STAGED_E")" "$(winpath "$TARGET_E")" "$(winpath "$ENSURE_E")"
+        # shellcheck disable=SC2016  # PowerShell syntax, same reason as above
+        printf 'exit $LASTEXITCODE\n'
+    } >> "$PROBE_E"
+    e_rc=0
+    e_out=$("$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$PROBE_E" 2>&1) || e_rc=$?
+    assert_rc "(e) Start-QmdDaemon throws: exits 4" 4 "$e_rc"
+    [ "$e_rc" -eq 4 ] || printf '    %s\n' "$e_out"
+    if [ -f "$SENT_E" ]; then pass "(e) restart-throws: Invoke-EnsureRestore still ran before Fail 4"; else fail "(e) restart-throws: ensure script never ran"; fi
+
+    # ---- (f) restore FAILS after an otherwise-full success (round 4 [codex-adv-6]) --
+    # The fullest form again (fakes `qmd status` too, like (a)), but this time
+    # the ensure script itself touches the sentinel THEN exits 1 -- proving it
+    # was genuinely invoked and failed, not merely skipped. The transport
+    # verified cleanly; only the auxiliary HTTP-daemon restore failed, so this
+    # must exit 6, not 0.
+    SENT_F="$TMP_ROOT/sentinel-f.txt"; rm -f "$SENT_F"
+    STAGED_F="$TMP_ROOT/staged-f.sqlite"; TARGET_F="$TMP_ROOT/target-f.sqlite"
+    make_staged "$STAGED_F"
+    printf 'old-index' > "$TARGET_F"
+    ENSURE_F="$TMP_ROOT/ensure-f.ps1"
+    # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
+    printf 'New-Item -ItemType File -Force -Path $env:SENTINEL_PATH | Out-Null\nexit 1\n' > "$ENSURE_F"
+    FAKEBIN_F="$TMP_ROOT/fakebin-f"; mkdir -p "$FAKEBIN_F"
+    {
+        printf '@echo off\r\n'
+        printf 'echo QMD Status\r\n'
+        printf 'echo.\r\n'
+        printf 'echo Documents\r\n'
+        printf 'echo   Total:    100 files indexed\r\n'
+        printf 'echo   Vectors:  100 embedded\r\n'
+        printf 'exit /b 0\r\n'
+    } > "$FAKEBIN_F/qmd.cmd"
+    PROBE_F="$TMP_ROOT/wiring-restorefail-probe.ps1"
+    cat > "$PROBE_F" <<'PROBE_F_EOF'
+function Get-CimInstance {
+    param($ClassName, [string]$Filter, $ErrorAction)
+    return @([pscustomobject]@{ Name = 'qmd.exe'; ProcessId = 8000; CommandLine = '"C:\fake\qmd.exe" mcp --keep-models' })
+}
+function Stop-Process {
+    param($Id, [switch]$Force, $ErrorAction)
+}
+function Invoke-CimMethod {
+    param($ClassName, $MethodName, $Arguments)
+    return [pscustomobject]@{ ReturnValue = 0; ProcessId = 9999 }
+}
+function Get-Command {
+    param($Name, $ErrorAction)
+    if ($Name -eq 'qmd') { return [pscustomobject]@{ Source = 'qmd' } }
+    return $null
+}
+PROBE_F_EOF
+    {
+        # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
+        printf '$env:PATH = "%s;" + $env:PATH\n' "$(winpath "$FAKEBIN_F")"
+        # shellcheck disable=SC2016  # PowerShell syntax, same reason as above
+        printf '$env:SENTINEL_PATH = "%s"\n' "$(winpath "$SENT_F")"
+        printf '& "%s" -Staged "%s" -Target "%s" -EnsureScript "%s" -ExpectDocs 100 -ExpectVectors 100\n' \
+            "$(winpath "$REAL_REMOTE_SCRIPT")" "$(winpath "$STAGED_F")" "$(winpath "$TARGET_F")" "$(winpath "$ENSURE_F")"
+        # shellcheck disable=SC2016  # PowerShell syntax, same reason as above
+        printf 'exit $LASTEXITCODE\n'
+    } >> "$PROBE_F"
+    f_rc=0
+    f_out=$("$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$PROBE_F" 2>&1) || f_rc=$?
+    assert_rc "(f) restore failure after a full successful verify: exits 6" 6 "$f_rc"
+    [ "$f_rc" -eq 6 ] || printf '    %s\n' "$f_out"
+    if [ -f "$SENT_F" ]; then pass "(f) restore failure: the ensure script actually ran (and reported failure)"; else fail "(f) restore failure: ensure script never ran at all"; fi
+    assert_contains "(f) restore failure: the verify stage itself still reported ok" "verified=ok" "$f_out"
+
+    # ---- (g) self-swap validation now fails PRE-SWEEP (round 5 [codex-adv-8]) --
+    # Moved before the stop sweep entirely -- a collision must exit 1 WITHOUT
+    # ever touching a process. Fakes that THROW if called prove this: reaching
+    # them would land in the sweep's own catch (Complete-PostSweepFailure
+    # -Code 2), producing rc 2, not rc 1 -- so asserting exactly rc 1 already
+    # proves the sweep was never reached, and "the restore question vanishes"
+    # as the finding puts it: nothing was ever stopped, so nothing needs
+    # restoring, so a plain Fail 1 is correct.
+    SENT_G="$TMP_ROOT/sentinel-g.txt"; rm -f "$SENT_G"
+    STAGED_G="$TMP_ROOT/staged-g.sqlite"
+    make_staged "$STAGED_G"
+    ENSURE_G="$TMP_ROOT/ensure-g.ps1"; make_fake_ensure "$ENSURE_G"
+    PROBE_G="$TMP_ROOT/wiring-selfswap-probe.ps1"
+    cat > "$PROBE_G" <<'PROBE_G_EOF'
+function Get-CimInstance { throw 'the stop sweep must never run for a self-swap collision' }
+function Stop-Process { throw 'the stop sweep must never run for a self-swap collision' }
+function Invoke-CimMethod { throw 'Start-QmdDaemon must never run for a self-swap collision' }
+function Get-Command { throw 'Start-QmdDaemon must never run for a self-swap collision' }
+PROBE_G_EOF
+    {
+        # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
+        printf '$env:SENTINEL_PATH = "%s"\n' "$(winpath "$SENT_G")"
+        # -Target IS -Staged: the exact self-swap collision.
+        printf '& "%s" -Staged "%s" -Target "%s" -EnsureScript "%s"\n' \
+            "$(winpath "$REAL_REMOTE_SCRIPT")" "$(winpath "$STAGED_G")" "$(winpath "$STAGED_G")" "$(winpath "$ENSURE_G")"
+        # shellcheck disable=SC2016  # PowerShell syntax, same reason as above
+        printf 'exit $LASTEXITCODE\n'
+    } >> "$PROBE_G"
+    g_rc=0
+    g_out=$("$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$PROBE_G" 2>&1) || g_rc=$?
+    assert_rc "(g) self-swap collision fails pre-sweep: exits 1, not 2" 1 "$g_rc"
+    [ "$g_rc" -eq 1 ] || printf '    %s\n' "$g_out"
+    assert_contains "(g) self-swap: names the collision" "refusing to swap a file onto itself" "$g_out"
+    if [ -f "$SENT_G" ]; then fail "(g) self-swap: recovery ran even though nothing was ever stopped" "$g_out"; else pass "(g) self-swap: no restore attempted (correctly -- nothing was stopped)"; fi
+
+    # ---- (h) stopped>0 + missing ensure script -> rc 6, not 0 (round 5 [codex-adv-9]) --
+    # The full genuine-success harness (like (a)/(f)), but -EnsureScript is
+    # omitted entirely -- the legitimate standalone/debug invocation the
+    # receiver script's own default ('') supports. Something WAS stopped, so
+    # Invoke-EnsureRestore's skipped-no-ensure-script branch must now set
+    # EnsureRestoreFailed: a null-CommandLine qmd.exe cannot be classified
+    # either way, so a receiver with no ensure script genuinely cannot confirm
+    # the HTTP surface came back, and this must not silently read as success.
+    STAGED_H="$TMP_ROOT/staged-h.sqlite"; TARGET_H="$TMP_ROOT/target-h.sqlite"
+    make_staged "$STAGED_H"
+    printf 'old-index' > "$TARGET_H"
+    FAKEBIN_H="$TMP_ROOT/fakebin-h"; mkdir -p "$FAKEBIN_H"
+    {
+        printf '@echo off\r\n'
+        printf 'echo QMD Status\r\n'
+        printf 'echo.\r\n'
+        printf 'echo Documents\r\n'
+        printf 'echo   Total:    100 files indexed\r\n'
+        printf 'echo   Vectors:  100 embedded\r\n'
+        printf 'exit /b 0\r\n'
+    } > "$FAKEBIN_H/qmd.cmd"
+    PROBE_H="$TMP_ROOT/wiring-noensure-probe.ps1"
+    cat > "$PROBE_H" <<'PROBE_H_EOF'
+function Get-CimInstance {
+    param($ClassName, [string]$Filter, $ErrorAction)
+    return @([pscustomobject]@{ Name = 'qmd.exe'; ProcessId = 9001; CommandLine = $null })
+}
+function Stop-Process {
+    param($Id, [switch]$Force, $ErrorAction)
+}
+function Invoke-CimMethod {
+    param($ClassName, $MethodName, $Arguments)
+    return [pscustomobject]@{ ReturnValue = 0; ProcessId = 9999 }
+}
+function Get-Command {
+    param($Name, $ErrorAction)
+    if ($Name -eq 'qmd') { return [pscustomobject]@{ Source = 'qmd' } }
+    return $null
+}
+PROBE_H_EOF
+    {
+        # shellcheck disable=SC2016  # PowerShell syntax -- must stay literal until the .ps1 file is parsed, not expand as bash now
+        printf '$env:PATH = "%s;" + $env:PATH\n' "$(winpath "$FAKEBIN_H")"
+        # No -EnsureScript at all -- exercises the parameter's own empty default.
+        printf '& "%s" -Staged "%s" -Target "%s" -ExpectDocs 100 -ExpectVectors 100\n' \
+            "$(winpath "$REAL_REMOTE_SCRIPT")" "$(winpath "$STAGED_H")" "$(winpath "$TARGET_H")"
+        # shellcheck disable=SC2016  # PowerShell syntax, same reason as above
+        printf 'exit $LASTEXITCODE\n'
+    } >> "$PROBE_H"
+    h_rc=0
+    h_out=$("$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$PROBE_H" 2>&1) || h_rc=$?
+    assert_rc "(h) stopped>0 + no ensure script: exits 6, not 0" 6 "$h_rc"
+    [ "$h_rc" -eq 6 ] || printf '    %s\n' "$h_out"
+    assert_contains "(h) reports skipped-no-ensure-script" "http_daemon_restored=skipped-no-ensure-script" "$h_out"
+    assert_contains "(h) the verify stage itself still reported ok" "verified=ok" "$h_out"
 fi
 
 summary


### PR DESCRIPTION
## Summary

Leg-16 propagation wave (three private merges):

- **graphify corpus exclusion** — the maps-dir `graph/` output and the slug
  MOC are excluded from the extraction corpus, killing the feedback loop
  where graphify re-ingested its own generated artifacts. Exclusion matching
  is hardened against slashes/metacharacters in slugs.
- **guardrail-block `status --json`** — a per-hook attestation contract with
  an honest `present` probe: a hook is only reported present when the probe
  actually proves it, never inferred.
- **qmd ship-index receiver hardening** — full stop sweep on shutdown,
  same-predicate document verification, and an honest recovery matrix
  (no recovery path claims success it can't prove).

## Verification

- Shipped via the propagation helper: fail-closed leak scan + byte-verify
  against the private range.
- All suites green on the private PRs before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph publishing for maps paths with trailing, duplicate, or special characters.
  * Prevented derived graph pages and published maps from being copied into source content.
  * Improved guardrail installation validation and index shipment recovery.

* **Enhancements**
  * Added structured guardrail status reporting and clearer diagnostics.
  * Improved shipment verification, cleanup, process detection, and daemon restoration warnings.

* **Documentation**
  * Updated lane calibration guidance and tooling setup instructions.
  * Documented delegation workflows and required command-line wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->