### PR TITLE
fix: wave 2g — sweep client-liveness hardening, pwsh absolute-path launch, deferred-nits batch

### DIFF
--- a/scripts/cleanup/sweep-codex-orphans.ps1
+++ b/scripts/cleanup/sweep-codex-orphans.ps1
@@ -11,8 +11,8 @@
 # reusable sweep.
 #
 # THE TEST (client-side pipe-token liveness - the VALIDATED signal):
-#   A broker tree is LIVE  iff  some claude.exe or ChatGPT.exe process exists
-#   whose command line references the same `cxc-<token>-codex-app-server` pipe
+#   A broker tree is LIVE  iff  any process OUTSIDE every broker tree has a
+#   command line that references the same `cxc-<token>-codex-app-server` pipe
 #   (that is the client still holding it). Otherwise the tree is an ORPHAN.
 #
 #   Two signals are DELIBERATELY NOT used, because they are documented false
@@ -23,8 +23,8 @@
 #       by dead-parent alone reaps live, in-use trees. Do NOT do it.
 #     * A codex.exe descendant is NOT sufficient. codex.exe lives INSIDE the
 #       broker tree; it is present whether or not a client is still attached, so
-#       it can never distinguish live from orphan. Only the OUTSIDE client
-#       (claude.exe / ChatGPT.exe) holding the pipe can.
+#       it can never distinguish live from orphan. Only an OUTSIDE process
+#       holding the pipe can; its image name is not part of the signal.
 #   This tool is the complement of scripts/codex/reap-mcp-fleet.ps1: that one
 #   reaps MCP FLEETS under a dead app-server via codex-lineage fingerprints;
 #   this one reaps the BROKER TREES themselves via the client-pipe test.
@@ -33,9 +33,10 @@
 #   1. Enumerate node.exe processes whose CommandLine matches
 #      `app-server-broker.mjs serve --endpoint pipe:\\.\pipe\cxc-<token>-codex-app-server`;
 #      capture the cxc token per broker.
-#   2. Collect the set of tokens held by LIVE clients = every claude.exe /
-#      ChatGPT.exe whose CommandLine references a `cxc-<token>-codex-app-server`
-#      pipe. A broker whose token is NOT in that set is an ORPHAN.
+#   2. Build the union of every broker tree, then collect the set of tokens
+#      referenced by any process OUTSIDE that union. Excluding all broker roots
+#      and descendants prevents their own pipe arguments from self-marking live.
+#      A broker whose token is NOT in that set is an ORPHAN.
 #   3. For each orphan broker, walk descendants via CIM Win32_Process
 #      ParentProcessId (child map built once) to collect the full tree
 #      (broker + all descendants).
@@ -46,9 +47,10 @@
 #      insensitive) is in the allow set below AND its live StartTime matches
 #      the enumeration snapshot's CreationDate - PID-reuse safety against
 #      recycling into an unrelated image AND into another allow-listed image.
-#      -Kill REFUSES to run (exit 1) when any client's CommandLine is not
-#      visible to the caller (elevation/session gap) - an invisible client
-#      may hold a pipe, so every orphan verdict is then unverifiable.
+#      -Kill REFUSES to run (exit 1) when any plausible outside client image
+#      (claude.exe, ChatGPT.exe, node.exe, bun.exe) has no visible CommandLine.
+#      Cross-session processes of unrelated names are routinely invisible and
+#      do not disable the sweep.
 #   5. -Kill also removes stale `$env:TEMP\cxc-<token>\broker.pid` files whose
 #      token belonged to a swept tree AND whose broker was confirmed stopped.
 #   Allow set (name-verified kill): node, cmd, bash, codex, conhost, pwsh,
@@ -110,12 +112,14 @@ function Test-IsCodexAppServerBroker {
   return ($null -ne (Get-CxcToken -CommandLine $cl))
 }
 
-# Client = the outside holder of the pipe (claude desktop / codex desktop app).
-function Test-IsCodexAppServerClient {
+# Plausible outside-client IMAGE for the degraded-visibility fail-safe. This is
+# deliberately broader than the original desktop-only set because detached
+# codex-companion renders are node.exe clients (HIMMEL-1467). It is NOT the
+# liveness classifier: every visible outside-tree process is searched by token.
+function Test-IsPlausibleCodexAppServerClient {
   param([Parameter(Mandatory)]$Proc)
   if (-not $Proc.Name) { return $false }
-  $n = $Proc.Name
-  return ($n -ieq 'claude.exe') -or ($n -ieq 'ChatGPT.exe')
+  return @('claude.exe','ChatGPT.exe','node.exe','bun.exe') -contains [string]$Proc.Name
 }
 
 # Best-effort cwd LABEL for the table (purely cosmetic, never gates a decision).
@@ -133,31 +137,41 @@ function Get-BrokerCwd {
   return '(unknown)'
 }
 
-# Tokens currently held by at least one live client (claude.exe / ChatGPT.exe).
+# Tokens referenced by at least one visible process OUTSIDE every broker tree.
+# Image names are irrelevant to liveness: detached codex-companion node.exe is
+# a real client. The exclusion is essential because each broker's own argv and
+# its codex.exe descendants can reference the token after the real client dies.
 function Get-LiveClientTokens {
-  param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs)
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [Parameter(Mandatory)]$BrokerTreePids
+  )
   $set = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
   foreach ($p in $Procs) {
-    if (-not (Test-IsCodexAppServerClient -Proc $p)) { continue }
+    if ($BrokerTreePids.Contains([int]$p.ProcessId)) { continue }
     foreach ($t in (Get-CxcTokens -CommandLine ([string]$p.CommandLine))) { [void]$set.Add($t) }
   }
   return , ([string[]]@($set))
 }
 
 # Pure classification: the orphan brokers in $Procs - brokers whose token no
-# live client holds. Each returned record carries BrokerPid, Token, Cwd.
-# Records expose ProcessId, ParentProcessId, Name, CommandLine (WorkingSetSize
-# optional). Dead-parent and codex.exe-descendant are INTENTIONALLY ignored
-# (documented false signals) - only the client-pipe test decides.
+# outside-tree process references. Each returned record carries BrokerPid,
+# Token, Cwd. The broker-tree union is built once and excludes roots plus all
+# descendants before tokens are collected. Dead-parent and codex.exe-descendant
+# remain INTENTIONALLY ignored (documented false signals).
 function Get-CodexOrphanBrokers {
-  param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs)
-  $liveTokens = Get-LiveClientTokens -Procs $Procs
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [AllowNull()]$BrokerTreePids = $null
+  )
+  if ($null -eq $BrokerTreePids) { $BrokerTreePids = Get-CodexBrokerTreePids -Procs $Procs }
+  $liveTokens = Get-LiveClientTokens -Procs $Procs -BrokerTreePids $BrokerTreePids
   $out = New-Object System.Collections.ArrayList
   foreach ($p in $Procs) {
     if (-not (Test-IsCodexAppServerBroker -Proc $p)) { continue }
     $tok = Get-CxcToken -CommandLine ([string]$p.CommandLine)
     if ($null -eq $tok) { continue }
-    if ($liveTokens -contains $tok) { continue }   # a client still holds it -> LIVE
+    if ($liveTokens -contains $tok) { continue }   # an outside client still holds it -> LIVE
     [void]$out.Add([pscustomobject]@{
       BrokerPid = [int]$p.ProcessId
       Token     = [string]$tok
@@ -165,6 +179,25 @@ function Get-CodexOrphanBrokers {
     })
   }
   return $out.ToArray()
+}
+
+# Build the child + creation-time maps once when several broker roots must be
+# walked against the same process snapshot. Get-DescendantPids still builds its
+# own index when called directly, preserving the public pure-helper seam.
+function Get-ProcessTreeIndex {
+  param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs)
+  $created = @{}
+  $byParent = @{}
+  foreach ($p in $Procs) {
+    if ($p.PSObject.Properties['CreationDate'] -and $null -ne $p.CreationDate) {
+      $created[[string]$p.ProcessId] = [datetime]$p.CreationDate
+    }
+    if ($null -eq $p.ParentProcessId) { continue }
+    $key = [string]$p.ParentProcessId
+    if (-not $byParent.ContainsKey($key)) { $byParent[$key] = New-Object System.Collections.ArrayList }
+    [void]$byParent[$key].Add([int]$p.ProcessId)
+  }
+  return [pscustomobject]@{ Created = $created; ByParent = $byParent }
 }
 
 # Pure descendant walk. Returns every LIVE pid in $Procs reachable from $RootPid
@@ -177,29 +210,23 @@ function Get-CodexOrphanBrokers {
 # would sweep it in. The canonical filter is creation-time ordering: a real
 # child can never be OLDER than its parent, while a stale-PPID impostor
 # predates the recycled pid it points at. A claimed child older than its
-# claimed parent (2s tolerance, matching Test-ProcessStartMatches) is
-# skipped; either CreationDate missing keeps the link (fail-open to the
-# pre-existing PPID-only level - the orphan CLASSIFICATION is still gated by
-# the client-pipe test, and the kill loop's name + identity gates run per
-# pid regardless).
+# claimed parent (2s tolerance, matching Test-ProcessStartMatches) is skipped.
+#
+# The default kill-tree walk keeps an edge when either CreationDate is missing
+# (fail-open for orphan-descendant completeness); the downstream name + process
+# identity gates still protect every kill. -VerifiedEdgesOnly instead drops
+# such unverifiable edges (fail-closed for broker-tree evidence suppression),
+# so an outside client with a stale PPID cannot be hidden from liveness.
 function Get-DescendantPids {
   param(
     [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
-    [Parameter(Mandatory)][int]$RootPid
+    [Parameter(Mandatory)][int]$RootPid,
+    [AllowNull()]$TreeIndex = $null,
+    [switch]$VerifiedEdgesOnly
   )
-  $created = @{}
-  foreach ($p in $Procs) {
-    if ($p.PSObject.Properties['CreationDate'] -and $null -ne $p.CreationDate) {
-      $created[[string]$p.ProcessId] = [datetime]$p.CreationDate
-    }
-  }
-  $byParent = @{}
-  foreach ($p in $Procs) {
-    if ($null -eq $p.ParentProcessId) { continue }
-    $key = [string]$p.ParentProcessId
-    if (-not $byParent.ContainsKey($key)) { $byParent[$key] = New-Object System.Collections.ArrayList }
-    [void]$byParent[$key].Add([int]$p.ProcessId)
-  }
+  if ($null -eq $TreeIndex) { $TreeIndex = Get-ProcessTreeIndex -Procs $Procs }
+  $created = $TreeIndex.Created
+  $byParent = $TreeIndex.ByParent
   $result = New-Object System.Collections.ArrayList
   $queue = New-Object System.Collections.Generic.Queue[int]
   $queue.Enqueue($RootPid)
@@ -221,8 +248,21 @@ function Get-DescendantPids {
       if ($seen.ContainsKey($childKey)) { continue }   # pid-reuse cycle guard
       # Creation-time ordering (codex round 4): a claimed child measurably
       # OLDER than its claimed parent is a stale-PPID impostor, not kin.
-      if ($created.ContainsKey($childKey) -and $created.ContainsKey($curKey)) {
-        if (($created[$curKey] - $created[$childKey]).TotalSeconds -gt 2) { continue }
+      $hasChildCreated = $created.ContainsKey($childKey)
+      $hasParentCreated = $created.ContainsKey($curKey)
+      if ($VerifiedEdgesOnly -and (-not $hasChildCreated -or -not $hasParentCreated)) { continue }
+      if ($hasChildCreated -and $hasParentCreated) {
+        # Both timestamps come from the SAME CIM snapshot, so a real child is
+        # never older than its parent at all - the 2s tolerance exists for the
+        # CROSS-read comparisons (Test-ProcessStartMatches, snapshot vs live).
+        # The verified walk therefore rejects ANY older-than-parent child
+        # (codex-adv r2: a stale PPID recycled within the 2s window would
+        # otherwise read as verified kin and suppress client evidence); the
+        # kill-tree walk keeps the lenient cross-read-shaped tolerance.
+        $gap = ($created[$curKey] - $created[$childKey]).TotalSeconds
+        if ($VerifiedEdgesOnly) {
+          if ($gap -gt 0) { continue }
+        } elseif ($gap -gt 2) { continue }
       }
       $seen[$childKey] = $true
       [void]$result.Add($child)
@@ -232,12 +272,35 @@ function Get-DescendantPids {
   return $result.ToArray()
 }
 
+# Union of every broker root + VERIFIED descendant pid in the snapshot. A
+# process inside ANY broker tree cannot be client evidence for ANY token, but an
+# unverifiable edge must fail closed here: suppressing a real outside client's
+# evidence could make its live broker look orphaned. Cross-tree references with
+# verified ancestry remain excluded. The process-tree index is built once and
+# reused for every root.
+function Get-CodexBrokerTreePids {
+  param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs)
+  $set = New-Object System.Collections.Generic.HashSet[int]
+  $treeIndex = Get-ProcessTreeIndex -Procs $Procs
+  foreach ($p in $Procs) {
+    if (-not (Test-IsCodexAppServerBroker -Proc $p)) { continue }
+    [void]$set.Add([int]$p.ProcessId)
+    foreach ($procId in (Get-DescendantPids -Procs $Procs -RootPid ([int]$p.ProcessId) -TreeIndex $treeIndex -VerifiedEdgesOnly)) {
+      [void]$set.Add([int]$procId)
+    }
+  }
+  return , $set
+}
+
 # Headline pure classifier the brief asks for: given a synthetic proc table,
 # return one object per orphan tree - { BrokerPid, Token, Cwd, TreePids (broker
 # + descendants), TreeProcCount }. Testable end-to-end without real processes.
 function Get-CodexOrphanTrees {
-  param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs)
-  $orphans = @(Get-CodexOrphanBrokers -Procs $Procs)
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [AllowNull()]$BrokerTreePids = $null
+  )
+  $orphans = @(Get-CodexOrphanBrokers -Procs $Procs -BrokerTreePids $BrokerTreePids)
   $out = New-Object System.Collections.ArrayList
   foreach ($o in $orphans) {
     $desc = @(Get-DescendantPids -Procs $Procs -RootPid $o.BrokerPid)
@@ -300,17 +363,24 @@ function Test-CxcTokenPathSafe {
 
 # Degraded-visibility probe (silent-failure CR): WMI returns an EMPTY
 # CommandLine for a process the caller lacks rights to inspect (cross-
-# elevation / cross-session). If that hits a CLIENT (claude.exe /
-# ChatGPT.exe), its token silently drops out of the live-token set and its
-# broker tree misclassifies as ORPHAN - the exact wrong-kill this tool must
-# never make, invisible in the report. Returns the pids of clients whose
-# CommandLine is not visible; ANY entry means orphan classifications are
-# unverifiable (the caller warns on dry run and refuses -Kill).
+# elevation / cross-session). If that hits a plausible OUTSIDE client image
+# (claude.exe, ChatGPT.exe, node.exe, bun.exe), its token could silently drop
+# out of the live-token set and a broker could misclassify as ORPHAN.
+#
+# Do NOT gate on every invisible process: unrelated cross-session / SYSTEM
+# processes routinely hide CommandLine from a non-elevated sweep, which would
+# disable -Kill permanently. Processes inside any broker tree are also excluded;
+# descendants are known non-client false signals even when their argv is hidden.
 function Get-BlindClientPids {
-  param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs)
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [AllowNull()]$BrokerTreePids = $null
+  )
+  if ($null -eq $BrokerTreePids) { $BrokerTreePids = Get-CodexBrokerTreePids -Procs $Procs }
   $out = New-Object System.Collections.ArrayList
   foreach ($p in $Procs) {
-    if (-not (Test-IsCodexAppServerClient -Proc $p)) { continue }
+    if ($BrokerTreePids.Contains([int]$p.ProcessId)) { continue }
+    if (-not (Test-IsPlausibleCodexAppServerClient -Proc $p)) { continue }
     if ([string]::IsNullOrEmpty([string]$p.CommandLine)) { [void]$out.Add([int]$p.ProcessId) }
   }
   return , ($out.ToArray())
@@ -369,7 +439,10 @@ try {
   exit 1
 }
 
-$trees = @(Get-CodexOrphanTrees -Procs $records)
+# Build the broker-tree exclusion union once for both liveness classification
+# and the blind-client gate; no process inside any tree can be client evidence.
+$brokerTreePids = Get-CodexBrokerTreePids -Procs $records
+$trees = @(Get-CodexOrphanTrees -Procs $records -BrokerTreePids $brokerTreePids)
 
 # byPid lookup for working-set summation + name-verified kill.
 $byPid = @{}
@@ -406,17 +479,21 @@ $totalMB = [math]::Round((($rows | Measure-Object -Property TreeWSMB -Sum).Sum),
 $flatPids = ($trees | ForEach-Object { $_.TreePids } | Sort-Object -Unique)
 
 Write-Host ("[sweep-codex-orphans] {0} orphaned broker tree(s), {1} proc(s), ~{2} MB:" -f $trees.Count, $totalProcs, $totalMB)
+foreach ($t in $trees) {
+  Write-Host ("[sweep-codex-orphans] orphan evidence: token cxc-{0}-codex-app-server; no visible outside-broker-tree process command line referenced it." -f $t.Token)
+}
 $rows | Format-Table -AutoSize | Out-String -Width 200 | Write-Host
 Write-Host ("[sweep-codex-orphans] flat PID list ({0}): {1}" -f $flatPids.Count, ($flatPids -join ', '))
 
-# Blind-client gate (silent-failure CR): a client whose CommandLine WMI hides
-# from us may be holding a pipe we cannot see, so every ORPHAN verdict above is
-# suspect. Warn always; refuse -Kill (report stays useful, nothing is stopped).
+# Blind-client gate (silent-failure CR): a plausible outside client whose
+# CommandLine WMI hides may hold a pipe we cannot see, so every ORPHAN verdict
+# above is suspect. Warn always; refuse -Kill (report stays useful, nothing is
+# stopped). The broker-tree union excludes hidden descendants from this gate.
 # NB: NO @() wrap on the call (HIMMEL-930) - Get-BlindClientPids returns via
 # unary comma so the array survives raw assignment (wrapping it in @() would
 # re-box an EMPTY result into a 1-element wrapper, permanently tripping this
 # gate: Count=1 even with zero blind clients).
-$blindClients = Get-BlindClientPids -Procs $records
+$blindClients = Get-BlindClientPids -Procs $records -BrokerTreePids $brokerTreePids
 if ($blindClients.Count -gt 0) {
   Write-Warning ("[sweep-codex-orphans] client pid(s) {0} have no visible CommandLine (elevation/session gap) - the client-liveness signal is unreliable; orphan classifications above may be WRONG." -f ($blindClients -join ', '))
 }
@@ -428,7 +505,7 @@ if (-not $Kill) {
 }
 
 if ($blindClients.Count -gt 0) {
-  Write-Warning "[sweep-codex-orphans] refusing -Kill while client command lines are invisible - re-run from a context that can see every claude.exe/ChatGPT.exe command line (e.g. the same elevation as the clients)."
+  Write-Warning "[sweep-codex-orphans] refusing -Kill while plausible outside client command lines are invisible - re-run from a context that can see claude.exe/ChatGPT.exe/node.exe/bun.exe clients (e.g. the same elevation as the clients)."
   exit 1
 }
 

--- a/scripts/cleanup/test-sweep-codex-orphans.ps1
+++ b/scripts/cleanup/test-sweep-codex-orphans.ps1
@@ -22,6 +22,9 @@ function Check([string]$Name, [bool]$Ok, [string]$Detail = '') { if ($Ok) { Pass
 function Rec($procId, $parentId, $name, $cl) {
   [pscustomobject]@{ ProcessId = $procId; ParentProcessId = $parentId; Name = $name; CommandLine = $cl }
 }
+function RecT($procId, $parentId, $name, $cl, $created) {
+  [pscustomobject]@{ ProcessId = $procId; ParentProcessId = $parentId; Name = $name; CommandLine = $cl; CreationDate = $created }
+}
 
 # Fixture command lines derive from the running user's profile dir (no literal
 # home paths in source - the propagation leak scan fail-closes on them).
@@ -30,8 +33,8 @@ function BrokerLine($token) {
   "node $UserHome\.claude\plugins\cache\openai-codex\codex\1.0.5\scripts\app-server-broker.mjs serve --endpoint pipe:\\.\pipe\cxc-$token-codex-app-server"
 }
 function ClientRef($token) {
-  # A client (claude.exe / ChatGPT.exe) connects to the broker's named pipe;
-  # its command line carries the same pipe-name fragment.
+  # Any outside client connects to the broker's named pipe; its command line
+  # carries the same pipe-name fragment regardless of image name.
   "claude-code.exe --mcp-endpoint \\.\pipe\cxc-$token-codex-app-server --session xyz"
 }
 
@@ -55,38 +58,46 @@ Check 'plain node NOT a broker'         (-not (Test-IsCodexAppServerBroker -Proc
 Check 'broker.mjs without serve NOT broker' (-not (Test-IsCodexAppServerBroker -Proc (Rec 1 0 'node.exe' "node x\app-server-broker.mjs")))
 Check 'broker.mjs without pipe NOT broker'  (-not (Test-IsCodexAppServerBroker -Proc (Rec 1 0 'node.exe' "node x\app-server-broker.mjs serve --endpoint elsewhere")))
 Check 'non-node NOT a broker'           (-not (Test-IsCodexAppServerBroker -Proc (Rec 1 0 'python.exe' $bl)))
-Check 'claude.exe is a client'          (Test-IsCodexAppServerClient -Proc (Rec 2 0 'claude.exe' 'anything'))
-Check 'ChatGPT.exe is a client'         (Test-IsCodexAppServerClient -Proc (Rec 2 0 'ChatGPT.exe' 'anything'))
-Check 'node.exe NOT a client'           (-not (Test-IsCodexAppServerClient -Proc (Rec 2 0 'node.exe' 'anything')))
-Check 'codex.exe NOT a client (lives in-tree)' (-not (Test-IsCodexAppServerClient -Proc (Rec 2 0 'codex.exe' 'anything')))
+Check 'claude.exe plausible blind client'  (Test-IsPlausibleCodexAppServerClient -Proc (Rec 2 0 'claude.exe' 'anything'))
+Check 'ChatGPT.exe plausible blind client' (Test-IsPlausibleCodexAppServerClient -Proc (Rec 2 0 'ChatGPT.exe' 'anything'))
+Check 'node.exe plausible blind client'    (Test-IsPlausibleCodexAppServerClient -Proc (Rec 2 0 'node.exe' 'anything'))
+Check 'bun.exe plausible blind client'     (Test-IsPlausibleCodexAppServerClient -Proc (Rec 2 0 'bun.exe' 'anything'))
+Check 'codex.exe NOT plausible outside client' (-not (Test-IsPlausibleCodexAppServerClient -Proc (Rec 2 0 'codex.exe' 'anything')))
 
 # --- Test 3: live/orphan classification on a synthetic table -----------------
-# The four guards the algorithm hinges on:
-#   (a) live  = client holds the token           -> NOT orphan
-#   (b) orphan = no client holds the token       -> orphan
-#   (c) dead-parent is a FALSE signal            -> client holding wins, NOT orphan
-#   (d) codex.exe descendant is NOT sufficient   -> still orphan with no client
-Write-Host "Test 3: live/orphan classification (client-pipe test; dead-parent + codex.exe guards)"
+# The five guards the algorithm hinges on:
+#   (a) live  = outside process holds token      -> NOT orphan
+#   (b) orphan = no outside process holds token  -> orphan
+#   (c) dead-parent is a FALSE signal            -> outside holder wins, NOT orphan
+#   (d) broker/descendant token refs are FALSE   -> still orphan
+#   (e) detached companion node holds token      -> NOT orphan (HIMMEL-1467 repro)
+Write-Host "Test 3: live/orphan classification (outside-tree pipe test; self/descendant guards)"
+$tClass = Get-Date '2026-07-11 01:00:00'
 $procs = @(
   # (a) LIVE: broker 100 token aaa111, client 110 holds aaa111.
   (Rec 100 1   'node.exe'   (BrokerLine 'aaa111'))
   (Rec 110 1   'claude.exe' (ClientRef 'aaa111'))   # holds the pipe -> broker LIVE
 
   # (b) ORPHAN: broker 200 token bbb222, NO client holds bbb222.
-  (Rec 200 1   'node.exe'   (BrokerLine 'bbb222'))
-  (Rec 201 200 'codex.exe'  'codex.exe app-server') # in-tree, irrelevant to liveness
-  (Rec 202 200 'node.exe'   'node mcp-fleet.js')    # in-tree descendant
+  (RecT 200 1   'node.exe'   (BrokerLine 'bbb222') $tClass)
+  (RecT 201 200 'codex.exe'  'codex.exe app-server' ($tClass.AddSeconds(1))) # in-tree, irrelevant to liveness
+  (RecT 202 200 'node.exe'   'node mcp-fleet.js'    ($tClass.AddSeconds(2))) # in-tree descendant
 
   # (c) dead-parent FALSE SIGNAL: broker 300 has DEAD parent (999 absent) BUT
   #     client 310 holds ccc333 -> MUST be LIVE (dead-parent must not reap it).
   (Rec 300 999 'node.exe'   (BrokerLine 'ccc333'))
   (Rec 310 1   'ChatGPT.exe' (ClientRef 'ccc333'))  # holds the pipe -> LIVE despite dead parent
 
-  # (d) codex.exe-descendant NOT sufficient: broker 400 token ddd444 has a
-  #     codex.exe descendant but NO outside client -> MUST be ORPHAN.
-  (Rec 400 1   'node.exe'   (BrokerLine 'ddd444'))
-  (Rec 401 400 'codex.exe'  'codex.exe app-server') # in-tree, cannot mark live
-  (Rec 402 401 'node.exe'   'node mcp.js')           # grandchild
+  # (d) self/descendant references are NOT sufficient: both the broker argv
+  #     and its codex.exe child carry ddd444, but no OUTSIDE process does.
+  (RecT 400 1   'node.exe'   (BrokerLine 'ddd444') $tClass)
+  (RecT 401 400 'codex.exe'  (ClientRef 'ddd444')  ($tClass.AddSeconds(1))) # in-tree token ref -> ignored
+  (RecT 402 401 'node.exe'   'node mcp.js'         ($tClass.AddSeconds(2))) # grandchild
+
+  # (e) HIMMEL-1467 exact repro: detached codex-companion node.exe is outside
+  #     the broker tree and holds eee555 -> broker MUST be LIVE.
+  (Rec 600 1   'node.exe'   (BrokerLine 'eee555'))
+  (Rec 610 1   'node.exe'   ("node codex-companion.mjs adversarial-review " + (ClientRef 'eee555')))
 
   # Non-broker node must never be a candidate.
   (Rec 500 1   'node.exe'   'node playwright-mcp.js')
@@ -97,7 +108,41 @@ $obPids = @($orphanBrokers | ForEach-Object { $_.BrokerPid } | Sort-Object)
 Check 'orphan brokers = {200,400}'     (($obPids -join ',') -eq '200,400') "got=$($obPids -join ',')"
 Check 'live broker 100 excluded'       (-not ($obPids -contains 100))
 Check 'dead-parent-but-held 300 excluded' (-not ($obPids -contains 300))
+Check 'self/descendant-only broker 400 stays orphan' ($obPids -contains 400)
+Check 'standalone companion node keeps 600 live' (-not ($obPids -contains 600))
 Check 'non-broker node 500 excluded'   (-not ($obPids -contains 500))
+
+# Exclusion is the union of ALL broker trees, not just the tree being judged:
+# a descendant under one broker that mentions another token is still internal
+# fleet evidence and must not keep the other broker alive.
+$crossTreeProcs = @(
+  (RecT 650 1   'node.exe'  (BrokerLine 'left11')  $tClass)
+  (RecT 651 650 'node.exe'  (ClientRef 'right22') ($tClass.AddSeconds(1)))
+  (RecT 660 1   'node.exe'  (BrokerLine 'right22') $tClass)
+)
+$crossTreeOrphans = @((Get-CodexOrphanBrokers -Procs $crossTreeProcs) | ForEach-Object { $_.BrokerPid } | Sort-Object)
+Check 'cross-tree token reference cannot mark broker live' (($crossTreeOrphans -join ',') -eq '650,660') "got=$($crossTreeOrphans -join ',')"
+
+# A detached outside client can retain a stale PPID after its real parent dies.
+# If its CreationDate is unavailable, exclusion membership must fail closed:
+# do not follow the unverifiable edge, so its visible token still proves LIVE.
+$staleClientProcs = @(
+  (RecT 670 1   'node.exe' (BrokerLine 'stale67') $tClass)
+  (Rec  671 670 'node.exe' (ClientRef 'stale67'))
+)
+$staleClientOrphans = @((Get-CodexOrphanBrokers -Procs $staleClientProcs) | ForEach-Object { $_.BrokerPid })
+Check 'undated stale-PPID outside token-holder keeps broker live' (-not ($staleClientOrphans -contains 670)) "got=$($staleClientOrphans -join ',')"
+
+# codex-adv r2: a stale PPID recycled into a broker created within the OLD 2s
+# tolerance window must not read as verified kin. The client (681) is 1 second
+# OLDER than the broker (680) its stale PPID points at - strict same-snapshot
+# ordering drops the edge, so its token still proves the broker LIVE.
+$narrowStaleProcs = @(
+  (RecT 680 1   'node.exe' (BrokerLine 'stale68') $tClass)
+  (RecT 681 680 'node.exe' (ClientRef 'stale68') ($tClass.AddSeconds(-1)))
+)
+$narrowStaleOrphans = @((Get-CodexOrphanBrokers -Procs $narrowStaleProcs) | ForEach-Object { $_.BrokerPid })
+Check '1s-older stale-PPID client still proves broker live (strict verified ordering)' (-not ($narrowStaleOrphans -contains 680)) "got=$($narrowStaleOrphans -join ',')"
 
 # --- Test 4: orphan TREE composition (broker + descendants) ------------------
 Write-Host "Test 4: orphan tree = broker pid + full descendant walk"
@@ -159,10 +204,7 @@ Check 'cycle: peer listed exactly once'    ((@($cycDesc | Where-Object { $_ -eq 
 # Stale-PPID impostor (codex CR round 4): an unrelated process whose recorded
 # PPID was recycled into a tree pid is OLDER than its claimed parent - the
 # creation-time ordering filter must drop it, keep real (younger) children,
-# and fail open when a CreationDate is missing.
-function RecT($procId, $parentId, $name, $cl, $created) {
-  [pscustomobject]@{ ProcessId = $procId; ParentProcessId = $parentId; Name = $name; CommandLine = $cl; CreationDate = $created }
-}
+# and fail open when a CreationDate is missing for the kill-tree walk.
 $tWalk = Get-Date '2026-07-11 03:00:00'
 $ppidProcs = @(
   (RecT 730 1   'node.exe'   'walk-root'      $tWalk)
@@ -173,7 +215,9 @@ $ppidProcs = @(
 $ppidDesc = @(Get-DescendantPids -Procs $ppidProcs -RootPid 730)
 Check 'younger real child kept'        ($ppidDesc -contains 731) "got=$($ppidDesc -join ',')"
 Check 'stale-PPID impostor excluded'   (-not ($ppidDesc -contains 732)) "got=$($ppidDesc -join ',')"
-Check 'undated child kept (fail-open)' ($ppidDesc -contains 733) "got=$($ppidDesc -join ',')"
+Check 'kill-tree keeps undated child (fail-open)' ($ppidDesc -contains 733) "got=$($ppidDesc -join ',')"
+$verifiedPpidDesc = @(Get-DescendantPids -Procs $ppidProcs -RootPid 730 -VerifiedEdgesOnly)
+Check 'exclusion walk drops undated edge (fail-closed)' (-not ($verifiedPpidDesc -contains 733)) "got=$($verifiedPpidDesc -join ',')"
 
 # --- Test 6: name allow-list filtering (kill-safety) -------------------------
 Write-Host "Test 6: name allow-list (PID-reuse safety gate)"
@@ -213,19 +257,28 @@ Check 'empty token NOT safe'           (-not (Test-CxcTokenPathSafe -Token ''))
 
 # --- Test 6c: blind-client visibility probe (silent-failure CR) --------------
 Write-Host "Test 6c: Get-BlindClientPids (degraded CommandLine visibility)"
+$tVis = Get-Date '2026-07-11 04:00:00'
 $visProcs = @(
-  (Rec 900 1 'claude.exe'  '')                       # client, INVISIBLE cmdline -> blind
-  (Rec 901 1 'claude.exe'  (ClientRef 'tok9'))       # client, visible -> not blind
-  (Rec 902 1 'ChatGPT.exe' $null)                    # client, null cmdline -> blind
-  (Rec 903 1 'node.exe'    '')                       # NOT a client -> ignored
+  (Rec 900 1   'claude.exe'  '')                       # plausible outside client, blind
+  (Rec 901 1   'claude.exe'  (ClientRef 'tok9'))       # plausible client, visible
+  (Rec 902 1   'ChatGPT.exe' $null)                    # plausible outside client, blind
+  (Rec 903 1   'node.exe'    '')                       # detached companion could be client -> blind
+  (Rec 904 1   'bun.exe'     $null)                    # plausible outside client, blind
+  (Rec 905 1   'svchost.exe' '')                       # unrelated hidden SYSTEM proc -> ignored
+  (RecT 920 1   'node.exe'    (BrokerLine 'blindtree') $tVis)
+  (RecT 921 920 'node.exe'    '' ($tVis.AddSeconds(1))) # verified hidden broker descendant -> ignored
+  (Rec  922 920 'node.exe'    '')                       # undated stale PPID -> outside, blind
 )
 # Raw assignment, no @() wrap / no pipe on the call itself: the function
 # returns via unary comma (same contract as Get-CxcTokens - see the note at
 # its call site) so the array survives assignment as ONE object.
 $blindRaw = Get-BlindClientPids -Procs $visProcs
 $blind = @($blindRaw | Sort-Object)
-Check 'blind clients = {900,902}'      (($blind -join ',') -eq '900,902') "got=$($blind -join ',')"
-$noBlind = Get-BlindClientPids -Procs @( (Rec 901 1 'claude.exe' (ClientRef 'tok9')) )
+Check 'blind outside clients = {900,902,903,904,922}' (($blind -join ',') -eq '900,902,903,904,922') "got=$($blind -join ',')"
+Check 'verified hidden broker descendant 921 excluded' (-not ($blind -contains 921)) "got=$($blind -join ',')"
+Check 'undated stale-PPID plausible client 922 stays blind' ($blind -contains 922) "got=$($blind -join ',')"
+Check 'unrelated hidden svchost 905 ignored' (-not ($blind -contains 905)) "got=$($blind -join ',')"
+$noBlind = Get-BlindClientPids -Procs @( (Rec 901 1 'node.exe' (ClientRef 'tok9')) )
 Check 'all-visible -> empty'           ($noBlind.Count -eq 0) "got count=$($noBlind.Count)"
 
 # --- Test 6d: caller-path @() wrap regression (HIMMEL-930) -------------------

--- a/scripts/himmelctl/bin.js
+++ b/scripts/himmelctl/bin.js
@@ -1286,7 +1286,18 @@ async function printContributorProfile(answers, derived, dryRun) {
     // buildReport() is third-party-shaped and could reject with null/undefined
     // (a non-Error rejection), in which case reading e.message would itself
     // throw and re-escape as exit 1 — the exact abort the guard exists to prevent.
-    console.error(`himmelctl: WARN: contributor dev profile unavailable (${e?.message ?? String(e)}) — profile report skipped; install is unaffected`);
+    // HIMMEL-1476: stringifying the rejection is the last throw site — coercing
+    // a {message: Symbol()} or Object.create(null) (no toString) rejection would
+    // throw, re-escaping as exit 1. Build the detail via a template inside its
+    // own try/catch (a template always yields a string when it doesn't throw, so
+    // the console.error below can never throw); fall back to a constant.
+    let detail;
+    try {
+      detail = `${e?.message ?? String(e)}`;
+    } catch (_e) {
+      detail = 'unformattable error';
+    }
+    console.error(`himmelctl: WARN: contributor dev profile unavailable (${detail}) — profile report skipped; install is unaffected`);
     return;
   }
   for (const line of contributorProfileLib.reportLines(report, { dryRun, derived })) {

--- a/scripts/himmelctl/bin.js
+++ b/scripts/himmelctl/bin.js
@@ -1282,7 +1282,11 @@ async function printContributorProfile(answers, derived, dryRun) {
       platform: process.platform,
     });
   } catch (e) {
-    console.error(`himmelctl: WARN: contributor dev profile unavailable (${e.message}) — profile report skipped; install is unaffected`);
+    // HIMMEL-1466 made this non-gating; HIMMEL-1468 hardens the catch itself:
+    // buildReport() is third-party-shaped and could reject with null/undefined
+    // (a non-Error rejection), in which case reading e.message would itself
+    // throw and re-escape as exit 1 — the exact abort the guard exists to prevent.
+    console.error(`himmelctl: WARN: contributor dev profile unavailable (${e?.message ?? String(e)}) — profile report skipped; install is unaffected`);
     return;
   }
   for (const line of contributorProfileLib.reportLines(report, { dryRun, derived })) {

--- a/scripts/hooks/guardrail-block.mjs
+++ b/scripts/hooks/guardrail-block.mjs
@@ -424,13 +424,21 @@ function resolveCommonDir(gitDir) {
   }
 }
 
+// The ref/HEAD OID predicates accept 40-hex (sha1) OR 64-hex (sha256), matching
+// readObject via hashAlgoForOid (HIMMEL-1468): the fallback ref/HEAD parser
+// hardcoded-tested only {40}, so a sha256 repo (objectFormat=sha256) degraded to
+// reference-unavailable whenever the git subprocess was unavailable — an
+// internal inconsistency with r10's sha256 object support. This repo is sha1,
+// so this is consistency, not a live bug. Exported for direct unit tests; a full
+// sha256 round-trip is not exercisable end-to-end (the loose/tree readers stay
+// sha1), so the predicate is the testable seam.
 function readPackedRef(commonDir, ref) {
   try {
     const lines = fs.readFileSync(path.join(commonDir, 'packed-refs'), 'utf8').split(/\r?\n/);
     for (const line of lines) {
       if (!line || line.startsWith('#') || line.startsWith('^')) continue;
       const [oid, name] = line.split(' ');
-      if (name === ref && /^[0-9a-f]{40}$/.test(oid)) return oid;
+      if (name === ref && hashAlgoForOid(oid)) return oid;
     }
   } catch (_e) {
     // packed-refs is optional.
@@ -438,20 +446,20 @@ function readPackedRef(commonDir, ref) {
   return null;
 }
 
-function readHeadOid(gitDir, commonDir) {
+export function readHeadOid(gitDir, commonDir) {
   let head;
   try {
     head = fs.readFileSync(path.join(gitDir, 'HEAD'), 'utf8').trim();
   } catch (_e) {
     return null;
   }
-  if (/^[0-9a-f]{40}$/.test(head)) return head;
+  if (hashAlgoForOid(head)) return head;
   const match = head.match(/^ref:\s*(.+)$/);
   if (!match) return null;
   const ref = match[1];
   try {
     const oid = fs.readFileSync(path.join(commonDir, ref), 'utf8').trim();
-    if (/^[0-9a-f]{40}$/.test(oid)) return oid;
+    if (hashAlgoForOid(oid)) return oid;
   } catch (_e) {
     return readPackedRef(commonDir, ref);
   }

--- a/scripts/hooks/guardrail-block.test.mjs
+++ b/scripts/hooks/guardrail-block.test.mjs
@@ -7,7 +7,7 @@ import { tmpdir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import zlib from 'node:zlib';
-import { install as installStatusData, statusDetail, sanitizedGitEnv, findPackOffset, readObject, applyDelta } from './guardrail-block.mjs';
+import { install as installStatusData, statusDetail, sanitizedGitEnv, findPackOffset, readObject, applyDelta, readHeadOid } from './guardrail-block.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const MODULE = join(HERE, 'guardrail-block.mjs');
@@ -1588,4 +1588,57 @@ test('readObject: a correct pack/idx pair still resolves (no false-degrade from 
 
   assert.deepEqual(readObject(commonDir, oidA), { type: 'blob', body: Buffer.from('AAA') });
   assert.deepEqual(readObject(commonDir, oidB), { type: 'blob', body: Buffer.from('BBBBB') });
+});
+
+// HIMMEL-1468: the manual ref/HEAD fallback parser (used when the git subprocess
+// is unavailable) used to accept only 40-hex sha1 OIDs, degrading a sha256 repo
+// even though readObject supports sha256. readHeadOid must now accept 40- OR
+// 64-hex detached OIDs, and a ref: pointing at a loose ref or a packed-ref.
+const HEAD_SHA1 = '0123456789abcdef0123456789abcdef01234567';
+const HEAD_SHA256 = '0123456789abcdef'.repeat(4); // 64 hex chars
+
+function buildHeadFixture({ head, looseRef, packedRef } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'gblock-head-'));
+  const gitDir = join(dir, 'git');
+  mkdirSync(gitDir, { recursive: true });
+  writeFileSync(join(gitDir, 'HEAD'), head);
+  if (looseRef) {
+    const [refName, oid] = looseRef;
+    const refPath = join(gitDir, ...refName.split('/'));
+    mkdirSync(dirname(refPath), { recursive: true });
+    writeFileSync(refPath, `${oid}\n`);
+  }
+  if (packedRef) {
+    writeFileSync(join(gitDir, 'packed-refs'), `${packedRef[1]} ${packedRef[0]}\n`);
+  }
+  return { dir, gitDir };
+}
+
+function dropOnExit(dir) {
+  process.on('exit', () => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort tmp cleanup */ } });
+}
+
+test('readHeadOid: accepts a 64-hex sha256 detached HEAD and still rejects non-hex (HIMMEL-1468)', () => {
+  const sha256 = buildHeadFixture({ head: `${HEAD_SHA256}\n` });
+  dropOnExit(sha256.dir);
+  assert.equal(readHeadOid(sha256.gitDir, sha256.gitDir), HEAD_SHA256, '64-hex sha256 detached HEAD must resolve');
+
+  const sha1 = buildHeadFixture({ head: `${HEAD_SHA1}\n` });
+  dropOnExit(sha1.dir);
+  assert.equal(readHeadOid(sha1.gitDir, sha1.gitDir), HEAD_SHA1, '40-hex sha1 detached HEAD still resolves (control)');
+
+  const junk = buildHeadFixture({ head: 'not-an-oid\n' });
+  dropOnExit(junk.dir);
+  assert.equal(readHeadOid(junk.gitDir, junk.gitDir), null, 'non-hex HEAD is rejected');
+});
+
+test('readHeadOid: follows ref: to a 64-hex sha256 loose ref and to packed-refs (HIMMEL-1468)', () => {
+  const loose = buildHeadFixture({ head: 'ref: refs/heads/main\n', looseRef: ['refs/heads/main', HEAD_SHA256] });
+  dropOnExit(loose.dir);
+  assert.equal(readHeadOid(loose.gitDir, loose.gitDir), HEAD_SHA256, 'loose ref carrying a sha256 oid resolves');
+
+  // No loose ref → readHeadOid falls through to readPackedRef.
+  const packed = buildHeadFixture({ head: 'ref: refs/heads/main\n', packedRef: ['refs/heads/main', HEAD_SHA256] });
+  dropOnExit(packed.dir);
+  assert.equal(readHeadOid(packed.gitDir, packed.gitDir), HEAD_SHA256, 'packed-ref carrying a sha256 oid resolves');
 });

--- a/scripts/luna/fetch-health.py
+++ b/scripts/luna/fetch-health.py
@@ -323,6 +323,23 @@ def primary_repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
+def _clean_dotenv_value(raw: str) -> str:
+    # Normalize a dotenv value (HIMMEL-1468): the prior raw value.strip() left
+    # BITBUCKET_API_TOKEN="secret" holding literal quotes, so Basic auth failed
+    # on any non-cron path where no shell pre-sources the file, and an inline
+    # `# comment` was kept on the value. Strip MATCHED surrounding single or
+    # double quotes (an unmatched opening quote is left verbatim — don't guess
+    # where it closes), then drop a trailing unquoted inline comment: a `#`
+    # preceded by whitespace, mirroring python-dotenv so a bare mid-token `#`
+    # (KEY=a#b) is preserved and a quoted value keeps the `#` inside its quotes.
+    value = raw.strip()
+    if value and value[0] in ('"', "'"):
+        close = value.find(value[0], 1)
+        if close != -1:
+            return value[1:close]
+    return re.sub(r"\s+#.*", "", value)
+
+
 def load_repo_env(env: dict[str, str], repo_root: Path) -> dict[str, str]:
     loaded = dict(env)
     env_file = repo_root / ".env"
@@ -334,7 +351,7 @@ def load_repo_env(env: dict[str, str], repo_root: Path) -> dict[str, str]:
             if not stripped or stripped.startswith("#") or "=" not in stripped:
                 continue
             key, value = stripped.split("=", 1)
-            loaded.setdefault(key.strip(), value.strip())
+            loaded.setdefault(key.strip(), _clean_dotenv_value(value))
     except OSError:
         pass
     return loaded
@@ -370,7 +387,10 @@ def probe_firecrawl(env: dict[str, str], http: Callable[..., HttpResult]) -> Pro
     api_key = env.get("FIRECRAWL_API_KEY", "").strip()
     if not api_key:
         return ProbeResult("auth-or-cookie-expired", "Firecrawl API key missing")
-    base_url = env.get("FIRECRAWL_BASE_URL", "").strip().rstrip("/") or "https://api.firecrawl.dev"
+    # Normalize the base (HIMMEL-1468): rstrip("/") alone left a FIRECRAWL_BASE_URL
+    # set WITH a /v2 suffix composing /v2/v2/scrape. Drop a trailing /v2 (then any
+    # newly-exposed slash) before appending the /v2 path ourselves.
+    base_url = re.sub(r"/v2$", "", env.get("FIRECRAWL_BASE_URL", "").strip().rstrip("/")) or "https://api.firecrawl.dev"
     url = env.get("FETCH_HEALTH_FIRECRAWL_URL", DEFAULT_URLS["firecrawl"])
     payload = json.dumps({"url": url, "formats": ["markdown"]}).encode()
     api_host = (urllib.parse.urlparse(base_url).hostname or "").lower()

--- a/scripts/luna/fetch-health.py
+++ b/scripts/luna/fetch-health.py
@@ -332,11 +332,17 @@ def _clean_dotenv_value(raw: str) -> str:
     # where it closes), then drop a trailing unquoted inline comment: a `#`
     # preceded by whitespace, mirroring python-dotenv so a bare mid-token `#`
     # (KEY=a#b) is preserved and a quoted value keeps the `#` inside its quotes.
+    # HIMMEL-1476: scan for the first UNESCAPED closing quote (prev char not a
+    # backslash) so an embedded `\"` no longer counts as the delimiter — the
+    # prior value.find(value[0], 1) truncated `"abc\"def"` to `abc\`. A full
+    # escape parser is out of scope, so `\\"` (escaped backslash, then the real
+    # closing quote) still reads as escaped and over-runs — accepted here.
     value = raw.strip()
     if value and value[0] in ('"', "'"):
-        close = value.find(value[0], 1)
-        if close != -1:
-            return value[1:close]
+        quote = value[0]
+        for close in range(1, len(value)):
+            if value[close] == quote and value[close - 1] != "\\":
+                return value[1:close]
     return re.sub(r"\s+#.*", "", value)
 
 

--- a/scripts/luna/test_fetch_health.py
+++ b/scripts/luna/test_fetch_health.py
@@ -216,6 +216,7 @@ class FetchHealthTests(unittest.TestCase):
         # bare mid-token `#` (kept), and an unmatched opening quote (verbatim).
         clean = fetch_health._clean_dotenv_value
         self.assertEqual(clean('"secret"'), "secret")
+        self.assertEqual(clean(r'"abc\"def"'), r'abc\"def')  # HIMMEL-1476: escaped quote is not the delimiter
         self.assertEqual(clean("'secret'"), "secret")
         self.assertEqual(clean('"value" # trailing comment'), "value")
         self.assertEqual(clean("tok_abc # scoped to fetch-health"), "tok_abc")
@@ -257,9 +258,10 @@ class FetchHealthTests(unittest.TestCase):
             "https://api.firecrawl.dev/",
         ):
             seen = {}
-            http = lambda url, **kwargs: seen.update(url=url) or fetch_health.HttpResult(
-                200, b'{"success":true,"data":{"markdown":"x"}}'
-            )
+
+            def http(url, **kwargs):
+                seen.update(url=url)
+                return fetch_health.HttpResult(200, b'{"success":true,"data":{"markdown":"x"}}')
             result = fetch_health.probe_firecrawl({"FIRECRAWL_API_KEY": "secret", "FIRECRAWL_BASE_URL": base_url}, http)
             self.assertEqual(result.status, "ok", base_url)
             self.assertEqual(seen["url"], "https://api.firecrawl.dev/v2/scrape", base_url)

--- a/scripts/luna/test_fetch_health.py
+++ b/scripts/luna/test_fetch_health.py
@@ -208,6 +208,32 @@ class FetchHealthTests(unittest.TestCase):
             self.assertTrue(seen["headers"]["Authorization"].startswith("Basic "))
             self.assertNotIn("token", seen["headers"]["Authorization"])
 
+    def test_load_repo_env_strips_quotes_and_inline_comments(self):
+        # HIMMEL-1468: a raw value.strip() left a quoted dotenv value holding
+        # its literal quotes (Basic auth then fails on non-cron paths) and kept
+        # an inline `# comment` on the value. Covered: double + single quoted
+        # values, a quoted value with a trailing comment, an inline comment, a
+        # bare mid-token `#` (kept), and an unmatched opening quote (verbatim).
+        clean = fetch_health._clean_dotenv_value
+        self.assertEqual(clean('"secret"'), "secret")
+        self.assertEqual(clean("'secret'"), "secret")
+        self.assertEqual(clean('"value" # trailing comment'), "value")
+        self.assertEqual(clean("tok_abc # scoped to fetch-health"), "tok_abc")
+        self.assertEqual(clean("a#b"), "a#b")  # no whitespace before # → kept
+        self.assertEqual(clean('"unmatched'), '"unmatched')  # leave unmatched alone
+        # End-to-end via load_repo_env: a quoted token + inline comment parse
+        # to the bare secret, and a leading export stays part of an unquoted value.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".env").write_text(
+                'BITBUCKET_API_TOKEN="quoted-secret"  # operator-injected\n'
+                "BITBUCKET_EMAIL=ops@example.com # noqa\n",
+                encoding="utf-8",
+            )
+            loaded = fetch_health.load_repo_env({}, root)
+            self.assertEqual(loaded["BITBUCKET_API_TOKEN"], "quoted-secret")
+            self.assertEqual(loaded["BITBUCKET_EMAIL"], "ops@example.com")
+
     def test_firecrawl_uses_v2_scrape_and_validates_markdown(self):
         seen = {}
 
@@ -220,6 +246,23 @@ class FetchHealthTests(unittest.TestCase):
         self.assertEqual(result.status, "ok")
         self.assertEqual(seen["url"], "https://api.firecrawl.dev/v2/scrape")
         self.assertEqual(json.loads(seen["data"]), {"url": "https://example.com/", "formats": ["markdown"]})
+
+    def test_firecrawl_normalizes_base_url_with_v2_suffix(self):
+        # HIMMEL-1468: a FIRECRAWL_BASE_URL set WITH a /v2 suffix (or a trailing
+        # slash) used to compose /v2/v2/scrape. Each variant must collapse to the
+        # single canonical /v2 path.
+        for base_url in (
+            "https://api.firecrawl.dev/v2",
+            "https://api.firecrawl.dev/v2/",
+            "https://api.firecrawl.dev/",
+        ):
+            seen = {}
+            http = lambda url, **kwargs: seen.update(url=url) or fetch_health.HttpResult(
+                200, b'{"success":true,"data":{"markdown":"x"}}'
+            )
+            result = fetch_health.probe_firecrawl({"FIRECRAWL_API_KEY": "secret", "FIRECRAWL_BASE_URL": base_url}, http)
+            self.assertEqual(result.status, "ok", base_url)
+            self.assertEqual(seen["url"], "https://api.firecrawl.dev/v2/scrape", base_url)
 
     def test_redirect_handler_strips_auth_off_scope(self):
         handler = fetch_health.AuthScopedRedirectHandler({"www.reddit.com"})

--- a/scripts/setup/cli-proxy-lane.ps1
+++ b/scripts/setup/cli-proxy-lane.ps1
@@ -154,16 +154,20 @@ if ($Install) {
     $VerStamp = Join-Path $Dir 'cli-proxy-api.version'
     $installedVer = if (Test-Path $VerStamp) { (Get-Content $VerStamp -ErrorAction SilentlyContinue | Select-Object -First 1) } else { $null }
     if ((-not (Test-Path $Exe)) -or ($installedVer -ne $Version)) {
+        # Windows locks a running exe - the pinned swap cannot land over a live
+        # instance, so a combined -Install -Restart (or -Install -Stop) stops the
+        # proxy in THIS invocation and the later $Restart/$Stop block then finds
+        # nothing to stop (HIMMEL-1451 r3). The stop is DEFERRED until just before
+        # Copy-Item (HIMMEL-1468): it used to run BEFORE the download, so a
+        # download/extract failure left the proxy DOWN until manual recovery. Now
+        # the temp download/extract resolves first and the running instance is
+        # touched only once the new binary is staged, shrinking the downtime
+        # window to the Copy-Item itself; any failure above this point leaves the
+        # old binary serving.
+        $stopForSwap = $false
         if ((Test-Path $Exe) -and (Get-ProxyProcess)) {
-            # Windows locks a running exe - the pinned swap cannot land over a
-            # live instance. A combined -Install -Restart (or -Install -Stop)
-            # can stop the proxy in THIS invocation instead of failing, so the
-            # documented pin-roll shape works as one sequence (HIMMEL-1451 r3);
-            # the later $Restart/$Stop block then finds nothing to stop.
             if ($Restart -or $Stop) {
-                Assert-BounceSafe   # -Force still overrides the live-client refusal
-                Write-Host "stopping cli-proxy-api to roll the pinned binary ..."
-                Stop-ProxyInstance | Out-Null
+                $stopForSwap = $true
             } else {
                 # Standalone -Install: refuse loudly with the working order
                 # instead of failing later on an opaque Copy-Item lock error.
@@ -182,6 +186,11 @@ if ($Install) {
             Expand-Archive -Force $zip $tmp
             $src = Get-ChildItem -Recurse $tmp -Filter 'cli-proxy-api.exe' | Select-Object -First 1 -ExpandProperty FullName
             if (-not $src) { throw "cli-proxy-api.exe not found in release archive" }
+            if ($stopForSwap) {
+                Assert-BounceSafe   # -Force still overrides the live-client refusal
+                Write-Host "stopping cli-proxy-api to roll the pinned binary ..."
+                Stop-ProxyInstance | Out-Null
+            }
             Copy-Item $src $Exe -Force
             Set-Content -Path $VerStamp -Value $Version
             Write-Host "installed binary: $Exe (v$Version)"

--- a/scripts/test-claude-glm.ps1
+++ b/scripts/test-claude-glm.ps1
@@ -599,8 +599,12 @@ try {
   $env:MOCK_ENV_OUT           = $ChildEnv
   $env:MOCK_ARGV_OUT          = $ArgvOut
   $env:PATH = $BIN + [IO.Path]::PathSeparator + $OrigEnv['PATH']
-  $pa = Start-Process pwsh -ArgumentList @('-NoProfile', '-File', $Launcher) -WorkingDirectory $WORK -PassThru
-  $pb = Start-Process pwsh -ArgumentList @('-NoProfile', '-File', $Launcher) -WorkingDirectory $WORK -PassThru
+  # HIMMEL-1426: resolve pwsh by absolute path so Start-Process doesn't fall
+  # back to ShellExecute bare-name resolution (the "how do you want to open
+  # this file?" picker). Same idiom as the $PwshDir line at the top of the file.
+  $pwshPath = (Get-Command pwsh -ErrorAction Stop).Source
+  $pa = Start-Process $pwshPath -ArgumentList @('-NoProfile', '-File', $Launcher) -WorkingDirectory $WORK -PassThru
+  $pb = Start-Process $pwshPath -ArgumentList @('-NoProfile', '-File', $Launcher) -WorkingDirectory $WORK -PassThru
   $pa.WaitForExit(); $pb.WaitForExit()
   if ($pa.ExitCode -eq 0 -and $pb.ExitCode -eq 0) { Pass 'both concurrent launches exit 0' } else { Fail "concurrent launches exit A=$($pa.ExitCode) B=$($pb.ExitCode)" }
   if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-glm\.seeded')) { Pass 'concurrent seed left a sentinel' } else { Fail 'concurrent seed left no sentinel' }

--- a/scripts/test-claude-routed.ps1
+++ b/scripts/test-claude-routed.ps1
@@ -497,8 +497,12 @@ try {
   $env:MOCK_ARGV_OUT             = $ArgvOut
   Remove-Item Env:OMNIROUTE_PORT -ErrorAction SilentlyContinue
   $env:PATH = $BIN + [IO.Path]::PathSeparator + $OrigEnv['PATH']
-  $pa = Start-Process pwsh -ArgumentList @('-NoProfile', '-File', $Launcher) -WorkingDirectory $WORK -PassThru
-  $pb = Start-Process pwsh -ArgumentList @('-NoProfile', '-File', $Launcher) -WorkingDirectory $WORK -PassThru
+  # HIMMEL-1426: resolve pwsh by absolute path so Start-Process doesn't fall
+  # back to ShellExecute bare-name resolution (the "how do you want to open
+  # this file?" picker). Same idiom as the $PwshDir line at the top of the file.
+  $pwshPath = (Get-Command pwsh -ErrorAction Stop).Source
+  $pa = Start-Process $pwshPath -ArgumentList @('-NoProfile', '-File', $Launcher) -WorkingDirectory $WORK -PassThru
+  $pb = Start-Process $pwshPath -ArgumentList @('-NoProfile', '-File', $Launcher) -WorkingDirectory $WORK -PassThru
   $pa.WaitForExit(); $pb.WaitForExit()
   if ($pa.ExitCode -eq 0 -and $pb.ExitCode -eq 0) { Pass 'both concurrent launches exit 0' } else { Fail "concurrent launches exit A=$($pa.ExitCode) B=$($pb.ExitCode)" }
   if (Test-Path -LiteralPath (Join-Path $FAKEHOME '.claude-routed\.seeded')) { Pass 'concurrent seed left a sentinel' } else { Fail 'concurrent seed left no sentinel' }


### PR DESCRIPTION
## Wave 2g — public propagation

One ship carrying the full private wave-2g batch (3 PRs):

| Ticket | What | Private PR |
|---|---|---|
| HIMMEL-1467 | CodexOrphanSweep client-liveness hardening (name-agnostic outside-tree signal, verified-edges-only exclusion walk with strict older-than-parent snapshot rejection, plausible-client-image blind gate, orphan negative-evidence logging) | #1538 |
| HIMMEL-1426 | Start-Process pwsh via absolute path ((Get-Command pwsh).Source) — removes the two in-repo ShellExecute bare-name instances | #1537 |
| HIMMEL-1468 | deferred-nits batch (fetch-health .env quoting + firecrawl base URL, guardrail sha256 ref parse, cli-proxy download-before-stop ordering, contributor-profile catch) | #1536 |

Every PR passed the cross-model CR matrix (codex + glm panel, codex-adv where infrastructure allowed — the 1467 branch went three gate rounds; the residual pipe-ownership design is tracked privately as HIMMEL-1474). All suites parent-verified on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup safety by detecting more client types and preventing termination when hidden or detached processes may still be active.
  * Improved contributor profile error handling so installation continues when unexpected error values are reported.
  * Fixed repository health checks for quoted environment values, inline comments, and Firecrawl URLs ending in `/v2`.
  * Improved Git compatibility for both SHA-1 and SHA-256 repositories.
* **Improvements**
  * Reduced proxy downtime during pinned binary updates by validating downloads before replacing the running executable.
  * Improved reliability of concurrent launcher tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->