### PR TITLE
feat: wave 2h — gate evidence + guardrail hardening (HIMMEL-1465/1472/1473/1475/1482/1483)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@
 #      scripts/lib/load-dotenv.sh: HANDOVER_DIR and USER_SLUG always; CR_PROFILE
 #      + CR_CLAUDE_AGENTS by /pr-check itself (HIMMEL-558/926);
 #      CR_REQUIRE_CROSS_MODEL by scripts/cr/clear-cr-marker.sh (HIMMEL-1237);
+#      TICKET_ID_REQUIRED / TICKET_ID_PATTERN / TICKET_ID_EXEMPT_AUTHORS plus
+#      JIRA_PROJECT_KEY by the commit-msg/public-propagation gates (HIMMEL-1483);
 #      HIMMEL_UPDATE_AUTOSTASH by scripts/himmel-update.sh (HIMMEL-1205); and the SessionStart/SessionEnd hooks
 #      read the HIMMEL_INITIATIVE* set, HIMMEL_WHERE_ARE_WE +
 #      HIMMEL_WHERE_ARE_WE_STALE_HOURS (NOT the statusline-only _ROLLUP_TTL /
@@ -61,6 +63,14 @@ JIRA_API_TOKEN=your_api_token_here                # id.atlassian.com/manage-prof
 # Example value -- replace with YOUR Jira project key (e.g. ACME).
 JIRA_PROJECT_KEY=HIMMEL                            # default project for jira ops
 JIRA_CLOUD_ID=<your-cloud-id>                      # Atlassian tenant cloud id (REST / MCP); from admin.atlassian.com or the getAccessibleAtlassianResources API
+# Ticket traceability gate (HIMMEL-1483). Default OFF for adopters: uncomment to
+# require every non-exempt commit to reference JIRA_PROJECT_KEY-N. This repo turns
+# it ON in checked-in CI config. For a non-Jira tracker, also set a portable ERE
+# such as '#[0-9]+'. Merge/revert commits and the comma-list of bot authors are
+# exempt; override the list rather than editing gate code.
+# TICKET_ID_REQUIRED=1
+# TICKET_ID_PATTERN=#[0-9]+
+# TICKET_ID_EXEMPT_AUTHORS=dependabot[bot],dependabot
 # Optional: extra projects whose metadata /jira-init caches (comma-list).
 # Defaults to JIRA_PROJECT_KEY alone. himmel itself tracks HIMMEL + LUNA.
 # JIRA_PROJECTS=HIMMEL,LUNA

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,16 @@ jobs:
       - uses: actions/checkout@v7
       - run: bash scripts/ci/check-no-secrets.sh
 
-  # Commit-message governance (HIMMEL-594): every commit in the PR range must be
-  # conventional + (if a HIMMEL- ticket is present) well-formed. Reuses the local
+  # Commit-message governance (HIMMEL-594/1483): every non-exempt commit in the
+  # PR range must be conventional and ticket-traceable. Reuses the local
   # commit-msg gate (scripts/hooks/check-commit-msg.sh) over the range so CI and
   # the author-time hook agree. fetch-depth: 0 → full history for the range walk.
   commit-lint:
     runs-on: ubuntu-latest
+    env:
+      TICKET_ID_REQUIRED: '1'
+      JIRA_PROJECT_KEY: HIMMEL
+      TICKET_ID_TRUSTED_AUTHOR: ${{ github.event.pull_request.user.login }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -252,7 +252,7 @@ repos:
         stages: [pre-push]
 
       - id: conventional-commit-msg
-        name: Conventional commit message + optional HIMMEL-N
+        name: Conventional commit message + ticket ID (strict when TICKET_ID_REQUIRED=1, HIMMEL-1483)
         language: system
         entry: bash scripts/hooks/check-commit-msg.sh
         pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,12 +76,13 @@ operator's user-scope `~/.claude/CLAUDE.md`. Use judgement on trivial tasks.
 ### Git workflow
 - All feature work in git worktrees. Never commit directly to main.
 - All changes via PR. No direct pushes to main. PRs need ≥1 approval before merge.
-- Conventional commits; the `commit-msg` gate validates the shape plus an
-  optional `HIMMEL-N` ticket ID.
-- **Every private-repo PR carries a Jira ticket** (operator, 2026-07-16).
-  Retro-filing is fine — the ticket may be created after the work started —
-  but the PR must reference one (title and/or commits) before merge. Search
-  Jira first; extend an existing ticket rather than re-filing.
+- Conventional commits; the `commit-msg` + CI range gates require a ticket ID
+  for every non-exempt commit (`JIRA_PROJECT_KEY-N`, or `TICKET_ID_PATTERN`).
+- **Every private and public PR carries a ticket** (operator, 2026-07-16;
+  structurally enforced by HIMMEL-1483). Retro-filing is fine — the ticket may
+  be created after the work started — but commit/public-propagation gates block
+  untraceable changes. Search Jira first; extend an existing ticket rather than
+  re-filing.
 - Pre-push gates need attestation trailers (`Platforms tested: <os>` on
   shell/script diffs; `Security reviewed: <token>` on non-docs code) in the
   **FIRST commit** after genuinely testing + reviewing. Recovery when a gate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,12 +38,13 @@ operator's user-scope `~/.claude/CLAUDE.md`. Use judgement on trivial tasks.
 ### Git workflow
 - All feature work in git worktrees. Never commit directly to main.
 - All changes via PR. No direct pushes to main. PRs need ≥1 approval before merge.
-- Conventional commits; the `commit-msg` gate validates the shape plus an
-  optional `HIMMEL-N` ticket ID.
-- **Every private-repo PR carries a Jira ticket** (operator, 2026-07-16).
-  Retro-filing is fine — the ticket may be created after the work started —
-  but the PR must reference one (title and/or commits) before merge. Search
-  Jira first; extend an existing ticket rather than re-filing.
+- Conventional commits; the `commit-msg` + CI range gates require a ticket ID
+  for every non-exempt commit (`JIRA_PROJECT_KEY-N`, or `TICKET_ID_PATTERN`).
+- **Every private and public PR carries a ticket** (operator, 2026-07-16;
+  structurally enforced by HIMMEL-1483). Retro-filing is fine — the ticket may
+  be created after the work started — but commit/public-propagation gates block
+  untraceable changes. Search Jira first; extend an existing ticket rather than
+  re-filing.
 - Pre-push gates need attestation trailers (`Platforms tested: <os>` on
   shell/script diffs; `Security reviewed: <token>` on non-docs code) in the
   **FIRST commit** after genuinely testing + reviewing. Recovery when a gate

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -237,7 +237,7 @@ tries to close.
 | `worktree-isolation`, `merged-branch-check`, `hookspath-misconfig`, `lockfile-integrity`, `artifact-leakage`, `uv-lock-integrity`, `pip-hashes`, `mcp-plugin-refs` | pre-commit | HARD | fix the finding (`--no-verify` only) |
 | drift guards (`doc-guard`, `agents-md-fresh`, `lanes-inventory-guard`, `hud-drift`, `telegram-fork-drift`, `template-himmel-plugins`) | pre-commit (most carry no `stages:` pin, so today they fire at every installed stage, push included) | HARD | fix the finding |
 | `no-headless-claude` / `no-headless-gemini` (billing rule, HIMMEL-128) | pre-commit | HARD | `# headless-claude-ok: <reason>` marker on/above the line; docs paths exempt (`scripts/hooks/check-no-headless-claude.sh`) |
-| `conventional-commit-msg` — `type(scope): [HIMMEL-N ]msg` | commit-msg | HARD | fix the message (merge/fixup/revert exempt) |
+| `conventional-commit-msg` — conventional shape + strict ticket traceability when `TICKET_ID_REQUIRED=1` | commit-msg | HARD | fix the message; merge/revert and `TICKET_ID_EXEMPT_AUTHORS` exempt (fixup/squash skip shape only) |
 | `no-push-to-main` | pre-push | HARD | none — work through a PR |
 | `npm-audit` / `npm-licenses` / `npm-audit-signatures` | pre-push | HARD | fix the dependency |
 | `no-force-push` | pre-push | HARD for `main`; advisory elsewhere | `SKIP_FORCE_PUSH_GATE=1` silences the non-main warning only |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,10 +22,10 @@ keep that working at any team size.
    `type ∈ feat|fix|chore|docs|refactor|test`. The orchestrator
    enforces this.
 
-3. **Commit format:** conventional commits with optional ticket key.
+3. **Commit format:** conventional commits with a required ticket key in this repo.
 
-   ```
-   type(scope): [HIMMEL-N ]message
+   ```text
+   type(scope): HIMMEL-N message
 
    Optional longer body...
 
@@ -33,7 +33,10 @@ keep that working at any team size.
    Co-Authored-By: ...
    ```
 
-   `scripts/hooks/check-commit-msg.sh` validates the format on `commit-msg`.
+   `scripts/hooks/check-commit-msg.sh` validates the format on `commit-msg`;
+   CI rechecks every PR commit with `TICKET_ID_REQUIRED=1`. Adopters default to
+   ticket-optional and can opt in via `.env` using `JIRA_PROJECT_KEY`, or set a
+   custom `TICKET_ID_PATTERN` for another tracker.
 
    The `Co-Authored-By: Claude` trailer is emitted by Claude Code itself, not
    by any himmel script. To turn it off, set the `attribution` key in your

--- a/docs/daily-loop.md
+++ b/docs/daily-loop.md
@@ -111,7 +111,7 @@ git commit -m "docs: [HIMMEL-289] toy change for daily-loop walkthrough"
 The **commit-msg gate** (`check-commit-msg.sh`) runs and validates:
 
 ```
-Pattern:  type[(scope)][!]: [HIMMEL-N ]message
+Pattern:  type[(scope)][!]: [HIMMEL-N] message
 Types:    feat fix chore docs refactor test style perf ci build revert
 ```
 
@@ -121,14 +121,14 @@ If you get the format wrong you see:
 COMMIT REJECTED: message does not match conventional commit format.
 
   Required:  type(scope): message
-  Optional:  type(scope): HIMMEL-N message
+  Ticket:    required only when TICKET_ID_REQUIRED=1
 
   Types: feat fix chore docs refactor test style perf ci build revert
 
   Examples:
-    feat(auth): add JWT validation
+    feat(auth): HIMMEL-22 add JWT validation
     fix(api): HIMMEL-23 correct status code on 404
-    chore: update dependencies
+    chore: HIMMEL-24 update dependencies
 
   Got: my bad message
 ```
@@ -330,7 +330,7 @@ gh pr create …                  # 7. open PR
 |---|---|---|
 | `block-edit-on-main` | PreToolUse (Edit/Write) | Blocks edits in primary worktree while on main |
 | `check-cr-marker-on-pr-create` | PreToolUse (Bash) | Blocks `gh pr create` while a CR marker exists |
-| `conventional-commit-msg` | commit-msg | Validates `type[(scope)]: [HIMMEL-N ]message` |
+| `conventional-commit-msg` | commit-msg | Validates conventional shape and required ticket traceability in this repo |
 | `code-review-before-push` | pre-push | Writes CR marker for non-docs changes |
 | `platforms-tested` | pre-push | Requires `Platforms tested:` trailer on shell/script diffs |
 | `security-reviewed` | pre-push | Requires `Security reviewed:` trailer on non-docs code |

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -64,8 +64,14 @@ Stages currently wired:
   every `package.json` under `scripts/` needs a tracked, in-sync sibling
   lockfile), uv-lock-integrity, pip-hashes (requirements*.txt must use
   --generate-hashes).
-- **Commit-msg:** conventional-commit-msg (validates conventional format +
-  optional HIMMEL-N).
+- **Commit-msg / PR traceability (HIMMEL-1483):** conventional-commit-msg
+  validates conventional format and, when `TICKET_ID_REQUIRED=1`, requires a
+  ticket matching `TICKET_ID_PATTERN` or the derived `JIRA_PROJECT_KEY-N` form.
+  The gate defaults OFF for adopters; this repo enables it in checked-in CI
+  config. Merge/revert commits and the configurable comma-list
+  `TICKET_ID_EXEMPT_AUTHORS` (default `dependabot[bot],dependabot`) are exempt.
+  `propagate-public.sh ship/reship` defaults the same policy ON and checks the PR
+  title and/or commit file before any push or PR creation.
 - **Doc-guard (pre-commit + pre-push, himmel-dev only):** check-doc-guard
   (blocks ADDING a command/skill file without a matching update to
   `docs/commands-catalog.md`; gated behind `.himmel-dev` marker so adopters
@@ -1685,7 +1691,11 @@ A ticket (`^[A-Z][A-Z0-9]+-[0-9]+$`) resolves to a resume handover under
 `handover_root` (case-insensitive, `specs/` excluded, `type: handover` preferred,
 ambiguity refused — never silently picked); a path must exist and resolve **under**
 `handover_root`. The bridge shells `auto-action.sh` → `arm-resume.sh` (per-handover
-dedup; no `--force`/`--dedup-any` remotely).
+dedup; no `--force`/`--dedup-any` remotely). An explicit `at HH:MM` rides
+`--long-gap` — a HUMAN typing a far time on Telegram IS the explicit choice the
+HIMMEL-1475 long-gap guard exists to force (the guard targets the orchestrator
+silently defaulting to a far park, not a typed one); `smart`/`auto` keep the bare
+call (the guard exempts those sentinels by design).
 
 **Activation flag — `TELEGRAM_AUTO_ACTIONS` (default OFF, operator-only).** A per-op
 enable-list whose grammar **mirrors `HIMMEL_INITIATIVE`** (so users learn one

--- a/marketplace/plugins/himmel-ops/skills/vm/SKILL.md
+++ b/marketplace/plugins/himmel-ops/skills/vm/SKILL.md
@@ -37,7 +37,7 @@ python scripts/lib/vmsdk.py <vm> <verb>
 Full usage line from the script:
 
 ```
-usage: vmsdk.py <vm> <up|down|snapshot NAME|restore NAME|baseline NAME|clone [REF]|provision|e2e|push FILE [DEST]|trigger HANDOVER [--at TIME] [--cwd DIR] [--timeout N]>
+usage: vmsdk.py <vm> <up|down|snapshot NAME|restore NAME|baseline NAME|clone [REF]|provision|e2e|push FILE [DEST]|trigger HANDOVER [--at TIME] [--cwd DIR] [--long-gap] [--timeout N]>
 ```
 
 | Verb | What it does |
@@ -51,7 +51,7 @@ usage: vmsdk.py <vm> <up|down|snapshot NAME|restore NAME|baseline NAME|clone [RE
 | `provision` | Run the per-OS provisioner (`ubuntu-vm-setup.py` or `windows-vm-setup.py`) |
 | `e2e` | Run the install/uninstall symmetry e2e against an Ubuntu VM (delegates to `scripts/test-install-symmetry-vm.sh`) |
 | `push FILE [DEST]` | Copy one host file to the guest via SFTP (`DEST` defaults to `~/handover-inbox/<name>`; `.env*` files refused) |
-| `trigger HANDOVER [--at TIME] [--cwd DIR] [--timeout N]` | Fire a claude session ON the guest from a host handover file (HIMMEL-835): pushes the handover, then either drives an immediate bounded session (default) or, with `--at`, arms the guest's own `arm-resume.sh` (at/atd backend). `--cwd` defaults to `~/Documents/github/himmel-private` (the ubuntu_new layout, verified 2026-07-09). Single-writer: do not trigger a ticket another writer owns |
+| `trigger HANDOVER [--at TIME] [--cwd DIR] [--long-gap] [--timeout N]` | Fire a claude session ON the guest from a host handover file (HIMMEL-835): pushes the handover, then either drives an immediate bounded session (default) or, with `--at`, arms the guest's own `arm-resume.sh` (at/atd backend). `--cwd` defaults to the guest's private-checkout path under `~/Documents/github/` (the ubuntu_new layout, verified 2026-07-09). `--long-gap` (HIMMEL-1475) forwards arm-resume's `--long-gap` so a far `--at TIME` (>60 min out) is not refused (rc 9) by the long-gap guard; only valid with `--at`. Single-writer: do not trigger a ticket another writer owns |
 
 **All invocations must be from the primary checkout** (not a worktree) — the
 SDK resolves `.env` via `git rev-parse --git-common-dir`; worktrees lack `.env`.

--- a/scripts/check-ci.sh
+++ b/scripts/check-ci.sh
@@ -240,6 +240,12 @@ if [ "$CR_ARMED" -eq 1 ]; then
     # shellcheck source=scripts/lib/cr-body-findings.sh
     # shellcheck disable=SC1091  # sourced at runtime; checked standalone by pre-commit
     . "$(cd "$(dirname "$0")" && pwd)/lib/cr-body-findings.sh"
+    # The CR-ledger evidence reader (HIMMEL-1465): tells cr_signal_gate below
+    # whether a CLEAN critic panel carried the gate at the head, so a
+    # rate-limited CodeRabbit App need not block when the panel already reviewed.
+    # shellcheck source=scripts/lib/cr-ledger-evidence.sh
+    # shellcheck disable=SC1091  # sourced at runtime; checked standalone by pre-commit
+    . "$(cd "$(dirname "$0")" && pwd)/lib/cr-ledger-evidence.sh"
 fi
 
 pr_checks() {
@@ -510,6 +516,35 @@ cr_signal_gate() {
             # from a clean review, and this gate certified exit 0 on a PR nobody
             # had looked at (reproduced on PR #1429, 2026-07-27). Actionable
             # rather than merely closed: the operator's next move is one comment.
+            #
+            # HIMMEL-1465: cr_signal_state collapses EVERY decline wording to
+            # `skipped`, but only the RATE-LIMITED one is panel-carriable. Read
+            # the description and, when (and ONLY when) it is the rate-limit
+            # shape, consult the CR ledger the same way clear-cr-marker.sh does:
+            # a CLEAN critic panel (>=1 `avail ... ok`, no blocking finding) at
+            # THIS head carries the gate (operator standing rule), so the
+            # rate-limited App does not fail the verdict. Any other skip wording
+            # — auto-reviews-disabled, or a decline CodeRabbit invents later —
+            # keeps failing closed exactly as before. Evidence-gated and
+            # fail-closed: no clean panel => current exit-2 behaviour stands.
+            local rl_desc rl_low rl_panel
+            if rl_desc=$(cr_signal_description "$owner" "$repo" "$head0"); then
+                rl_low=$(printf '%s' "$rl_desc" | tr '[:upper:]' '[:lower:]')
+            else
+                echo "check-ci: CodeRabbit SKIPPED the review on head $head0 of PR #$num and its description could not be read to tell rate-limiting from a disabled review — cannot evaluate the panel-carried allowance; re-run. If this repo has no CodeRabbit, set CR_PROFILE=none." >&2
+                exit 2
+            fi
+            # Rate-limit vocabulary (mirrors cr-signal.sh's _CRS_SKIP_RE
+            # `rate.?limit` arm): "rate limit" / "rate-limit" / "ratelimit".
+            case "$rl_low" in
+                *rate?limit*|*ratelimit*)
+                    if rl_panel=$(cr_ledger_carries_gate "$head0"); then
+                        echo "check-ci: CodeRabbit is rate-limited on head $head0 of PR #$num; the critic panel carries the gate ($rl_panel) — not failing the verdict on the App (HIMMEL-1465)."
+                        return 0
+                    fi
+                    echo "check-ci: CodeRabbit is rate-limited on head $head0 of PR #$num and the critic panel did NOT carry the gate at this head (ledger: $rl_panel) — a rate-limited App with no clean panel is not a green one. Wait for the App's limit to reset, or run /pr-check on this HEAD so a panel reviews it. Bypass: CR_APP=0 (or CR_PROFILE=none)." >&2
+                    exit 2 ;;
+            esac
             echo "check-ci: CodeRabbit SKIPPED the review on head $head0 of PR #$num — it posted state=success, but its description does not say the review completed. A DECLINED review is not a clean one. Known causes: automatic reviews are disabled on this repo (trigger one with a '@coderabbitai review' comment, wait for it to conclude, then re-run), or CodeRabbit is RATE LIMITED (HIMMEL-1354 — wait for the limit to reset; do NOT re-trigger in a loop, and note the CLI lane 'bash scripts/cr/coderabbit-review.sh --branch <b> --base main' is a separate, independently-limited path). If CodeRabbit has simply renamed its success wording, widen the allow-list for one run with CR_OK_DESC_RE='^(review completed|no review changes requested|<new wording>)\$' — CR_OK_DESC_RE REPLACES the default, so carry BOTH default alternatives or you narrow it instead of widening it, and KEEP the ^(...)\$ anchors or a decline description merely containing one of these phrases (e.g. 'No review completed') passes as clean again (HIMMEL-1354 R2). If this repo has no CodeRabbit, set CR_PROFILE=none." >&2
             exit 2 ;;
         *)

--- a/scripts/ci/check-commit-range.sh
+++ b/scripts/ci/check-commit-range.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 # check-commit-range.sh — lint every commit message in a range against the
-# project's conventional-commit gate (scripts/hooks/check-commit-msg.sh) PLUS a
-# malformed-HIMMEL-ticket check, so a PR can't merge non-conventional or
-# bad-ticket commits (HIMMEL-594).
+# project's conventional-commit + ticket gate (scripts/hooks/check-commit-msg.sh),
+# so a PR can't merge non-conventional or untraceable commits (HIMMEL-594/1483).
 #
-# Local parity: the commit-msg hook already runs check-commit-msg.sh per commit
-# at author time. This re-checks the WHOLE PR range in CI (covering commits
-# authored where the local hook was bypassed) and ADDITIONALLY rejects a
-# present-but-malformed `HIMMEL-` ref — which the shared hook treats as prose.
-# CI being slightly stricter than the local gate is intentional (the operator
-# wants CI to FAIL on commit/ticket issues).
+# Local parity: the commit-msg hook runs check-commit-msg.sh per commit at author
+# time. This re-checks the WHOLE PR range in CI (covering commits authored where
+# the local hook was bypassed). Bot exemptions require both the trusted PR author
+# supplied by CI and each commit's author metadata to match the exemption list.
 #
 # Usage:
 #   check-commit-range.sh [<base-ref-or-sha>]
@@ -51,7 +48,12 @@ fi
 # otherwise reach here and `rev-list` would error — DON'T swallow it to an empty
 # "nothing to lint" pass. A genuinely empty range (base == HEAD) exits rev-list 0
 # with no output and is handled below.
-if ! commits="$(git rev-list "$BASE..HEAD" 2>/dev/null)"; then
+# --no-merges (HIMMEL-1483 CR1): the hook's merge exemption is live-MERGE_HEAD
+# only, so a HISTORICAL merge commit in the range would be validated as an
+# ordinary message and fail. Parent count is the unfakeable merge signal — a
+# message SHAPED like a merge still has one parent and is still validated —
+# so skipping real merges here keeps the r2 anti-spoof hardening intact.
+if ! commits="$(git rev-list --no-merges "$BASE..HEAD" 2>/dev/null)"; then
   echo "ERR commit-range: cannot walk range $BASE..HEAD (unresolvable base?)" >&2
   exit 2
 fi
@@ -65,19 +67,13 @@ tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
 for sha in $commits; do
   subject="$(git log -1 --format='%s' "$sha")"
+  author="$(git log -1 --format='%an' "$sha")"
   git log -1 --format='%B' "$sha" > "$tmp"
-  if ! bash "$CHECK_MSG" "$tmp" >/dev/null 2>&1; then
-    echo "FAIL ${sha} non-conventional: ${subject}"
+  if ! TICKET_ID_AUTHOR="$author" TICKET_ID_TRUSTED_AUTHOR="${TICKET_ID_TRUSTED_AUTHOR:-}" \
+      bash "$CHECK_MSG" "$tmp" >/dev/null 2>&1; then
+    echo "FAIL ${sha} commit-message gate: ${subject}"
     fails=$((fails + 1))
-    continue
   fi
-  # A HIMMEL- ref in the ticket position MUST be HIMMEL-<digits> (the shared
-  # hook silently treats a malformed ref as message text).
-  body="${subject#*: }"
-  case "$body" in
-    HIMMEL-[0-9]*) : ;;
-    HIMMEL-*) echo "FAIL ${sha} malformed HIMMEL- ticket: ${subject}"; fails=$((fails + 1)) ;;
-  esac
 done
 
 if [ "$fails" -gt 0 ]; then

--- a/scripts/ci/test-check-commit-range.sh
+++ b/scripts/ci/test-check-commit-range.sh
@@ -32,10 +32,11 @@ mkrepo() {
     for m in "$@"; do git -C "$d" commit -q --allow-empty -m "$m"; done
 }
 
-run_cr() { # <repo-dir> -> runs check-commit-range against <base>..HEAD
+run_cr() { # <repo-dir> -> runs strict check-commit-range against <base>..HEAD
     local d="$1" base
     base="$(cat "$d/.base")"
-    ( cd "$d" && bash "$CR" "$base" 2>&1 )
+    ( cd "$d" && TICKET_ID_REQUIRED=1 JIRA_PROJECT_KEY=HIMMEL \
+        TICKET_ID_TRUSTED_AUTHOR="${TICKET_ID_TRUSTED_AUTHOR:-}" bash "$CR" "$base" 2>&1 )
 }
 
 # --- one bad (non-conventional) commit -> rc1 + surfaces it ---
@@ -46,11 +47,33 @@ if [ "$rc" -eq 1 ]; then pass "non-conventional -> rc1"; else fail "expected rc1
 if grepq "$out" 'broken commit no type'; then pass "surfaces offending subject"; else fail "no offending subject: $out"; fi
 rm -rf "$t"
 
-# --- all-clean range -> rc0 ---
+# --- all-clean ticketed range -> rc0 ---
 t="$(mktemp -d)"
-mkrepo "$t" "fix(api): HIMMEL-2 ok" "chore: tidy"
+mkrepo "$t" "fix(api): HIMMEL-2 ok" "chore: HIMMEL-3 tidy"
 out="$(run_cr "$t")"; rc=$?
 if [ "$rc" -eq 0 ]; then pass "clean range -> rc0"; else fail "expected rc0, got $rc: $out"; fi
+rm -rf "$t"
+
+# --- a REAL merge commit in the range is skipped (HIMMEL-1483 CR1) ---
+# The hook's merge exemption is live-MERGE_HEAD only, so the range gate must
+# skip historical merges structurally (--no-merges; parent count >= 2).
+t="$(mktemp -d -t himmel-commit-range.XXXXXX)"
+mkrepo "$t" "fix(api): HIMMEL-2 ok"
+git -C "$t" checkout -q -b side
+git -C "$t" commit -q --allow-empty -m "feat(y): HIMMEL-4 side work"
+git -C "$t" checkout -q -
+git -C "$t" merge -q --no-ff --no-edit side
+out="$(run_cr "$t")"; rc=$?
+if [ "$rc" -eq 0 ]; then pass "range containing a real merge commit -> rc0"; else fail "expected rc0, got $rc: $out"; fi
+rm -rf "$t"
+
+# --- ...but a merge-SHAPED message with ONE parent is still validated ---
+# Parent count is the unfakeable signal: a hand-typed "Merge branch ..." subject
+# on an ordinary commit gets no skip and fails the gate (anti-spoof, r2 intent).
+t="$(mktemp -d -t himmel-commit-range.XXXXXX)"
+mkrepo "$t" "Merge branch 'fake' into main"
+out="$(run_cr "$t")"; rc=$?
+if [ "$rc" -eq 1 ]; then pass "merge-shaped single-parent commit still fails"; else fail "expected rc1, got $rc: $out"; fi
 rm -rf "$t"
 
 # --- malformed HIMMEL- ticket -> rc1 + named ---
@@ -59,6 +82,38 @@ mkrepo "$t" "feat(x): HIMMEL-abc malformed ticket"
 out="$(run_cr "$t")"; rc=$?
 if [ "$rc" -eq 1 ]; then pass "malformed ticket -> rc1"; else fail "expected rc1, got $rc: $out"; fi
 if grepq "$out" -i 'malformed'; then pass "names malformed ticket"; else fail "no malformed msg: $out"; fi
+rm -rf "$t"
+
+# --- conventional but ticketless commit -> rc1 ---
+t="$(mktemp -d -t himmel-commit-range.XXXXXX)"
+mkrepo "$t" "chore: ticket omitted"
+out="$(run_cr "$t")"; rc=$?
+if [ "$rc" -eq 1 ]; then pass "ticketless strict commit -> rc1"; else fail "expected rc1, got $rc: $out"; fi
+rm -rf "$t"
+
+# --- spoofed dependabot commit metadata is not enough without a trusted PR author ---
+t="$(mktemp -d -t himmel-commit-range.XXXXXX)"
+mkrepo "$t"
+git -C "$t" -c user.name='dependabot[bot]' -c user.email='bot@example.invalid' \
+  commit -q --allow-empty -m "chore: bump dependency"
+out="$(run_cr "$t")"; rc=$?
+if [ "$rc" -eq 1 ]; then pass "bot metadata without trusted author -> rc1"; else fail "expected rc1, got $rc: $out"; fi
+rm -rf "$t"
+
+# --- trusted bot PR author still needs bot-authored commit metadata ---
+t="$(mktemp -d -t himmel-commit-range.XXXXXX)"
+mkrepo "$t" "chore: bump dependency"
+out="$(TICKET_ID_TRUSTED_AUTHOR='dependabot[bot]' run_cr "$t")"; rc=$?
+if [ "$rc" -eq 1 ]; then pass "trusted bot with human commit author -> rc1"; else fail "expected rc1, got $rc: $out"; fi
+rm -rf "$t"
+
+# --- trusted bot PR author plus bot commit metadata is exempt ---
+t="$(mktemp -d -t himmel-commit-range.XXXXXX)"
+mkrepo "$t"
+git -C "$t" -c user.name='dependabot[bot]' -c user.email='bot@example.invalid' \
+  commit -q --allow-empty -m "chore: bump dependency"
+out="$(TICKET_ID_TRUSTED_AUTHOR='dependabot[bot]' run_cr "$t")"; rc=$?
+if [ "$rc" -eq 0 ]; then pass "trusted bot and bot commit author -> rc0"; else fail "expected rc0, got $rc: $out"; fi
 rm -rf "$t"
 
 # --- unresolvable base ref -> rc2 (cannot evaluate the range) ---

--- a/scripts/claude-codex
+++ b/scripts/claude-codex
@@ -52,9 +52,14 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # CLIPROXY key; CWD-resolution would exit 2 despite himmel/.env holding the key.
 # CLAUDE_CODEX_DOTENV_ROOT (test hook) overrides that root so hermetic tests
 # never read the real himmel .env — same production code path either way.
+# HIMMEL-1482: when this launcher is invoked from a linked worktree copy of
+# itself (e.g. a dispatch whose REPO_ROOT resolved to a worktree), $HERE/.. is a
+# worktree root with no .env — _load_dotenv_primary_for falls back to the primary
+# checkout so the key is still found. Same pin-to-the-launcher's-repo contract,
+# just primary-aware; the CWD repo is still never trusted.
 if [ -z "${CLIPROXY_API_KEY-}" ] && [ -f "$HERE/lib/load-dotenv.sh" ]; then
   . "$HERE/lib/load-dotenv.sh"
-  load_dotenv --root "${CLAUDE_CODEX_DOTENV_ROOT:-$HERE/..}" CLIPROXY_API_KEY
+  load_dotenv --root "$(_load_dotenv_primary_for "${CLAUDE_CODEX_DOTENV_ROOT:-$HERE/..}")" CLIPROXY_API_KEY
   # load_dotenv leaves surrounding quotes literal (the shared lib does not strip
   # them); drop ONE matching surrounding quote pair so a `.env` value written as
   # CLIPROXY_API_KEY="…" doesn't send the quotes to the API. bash 3.2-safe.

--- a/scripts/claude-codex.ps1
+++ b/scripts/claude-codex.ps1
@@ -85,9 +85,48 @@ function Get-DotenvKey {
   return $null
 }
 
+# HIMMEL-1482 (twin of bash _load_dotenv_primary_for in lib/load-dotenv.sh):
+# resolve the .env-bearing root for a candidate dir. <dir>/.env present → <dir>.
+# Else if <dir> is a linked git worktree → the PRIMARY checkout (parent of
+# git-common-dir) when its .env exists, with ONE advisory to stderr (a launcher
+# invoked from a worktree copy of itself has <parent> = a worktree root with no
+# .env). Otherwise → <dir> unchanged (the missing-key path below applies).
+function Resolve-DotenvPrimary {
+  param([string]$Dir)
+  if (Test-Path -LiteralPath (Join-Path $Dir '.env')) { return $Dir }
+  try {
+    $common = & git -C $Dir rev-parse --git-common-dir 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $common) { return $Dir }
+    $dirAbs = (Resolve-Path -LiteralPath $Dir -ErrorAction Stop).Path
+    # HIMMEL-1482 R2: restrict the fallback to GENUINE linked-worktree ROOTS.
+    # r1 gated only on `primary != candidate`, so a NESTED dir inside any
+    # checkout (e.g. <worktree>/scripts) resolved common-dir to the real .git
+    # and silently loaded the operator's .env — breaking the hermetic override.
+    # Guard 1: candidate must BE its checkout root (show-toplevel == $dirAbs).
+    # Guard 2: checkout must be genuinely LINKED — git-dir differs from
+    # git-common-dir (equal = primary checkout → nothing to fall back from).
+    # Compare canonicalized paths case-insensitively (NTFS is case-insensitive).
+    $toplevel = & git -C $Dir rev-parse --show-toplevel 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $toplevel) { return $Dir }
+    $toplevelAbs = (Resolve-Path -LiteralPath $toplevel -ErrorAction Stop).Path
+    if (-not ($toplevelAbs -ieq $dirAbs)) { return $Dir }
+    $gitdir = & git -C $Dir rev-parse --git-dir 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $gitdir -or $gitdir -eq $common) { return $Dir }
+    # git may print a path relative to $Dir; root it before resolving '..'.
+    $commonFull = if ([System.IO.Path]::IsPathRooted($common)) { $common } else { Join-Path $Dir $common }
+    $primary = (Resolve-Path -LiteralPath (Join-Path $commonFull '..') -ErrorAction Stop).Path
+    if ($primary -ne $dirAbs -and (Test-Path -LiteralPath (Join-Path $primary '.env'))) {
+      [Console]::Error.WriteLine("claude-codex: .env absent under worktree '$dirAbs' — reading the primary checkout's .env at '$primary'.")
+      return $primary
+    }
+  } catch { }
+  return $Dir
+}
+
 $key = $env:CLIPROXY_API_KEY
 if ([string]::IsNullOrEmpty($key)) {
   $root = if ($env:CLAUDE_CODEX_DOTENV_ROOT) { $env:CLAUDE_CODEX_DOTENV_ROOT } else { Split-Path -Parent $PSScriptRoot }
+  $root = Resolve-DotenvPrimary -Dir $root
   $key = Get-DotenvKey -Root $root -Name 'CLIPROXY_API_KEY'
 }
 

--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -50,6 +50,13 @@
 #                      (with --dedup-any, any existing HIMMEL-Resume job).
 #                      Default refuses (rc=3) — explicit opt-in only.
 #                      Also bypasses the time-collision check (HIMMEL-407).
+#   --long-gap         Sanction an explicit HH:MM more than 60 min out
+#                      (HIMMEL-1475). Default REFUSES (rc=9) a far park so a
+#                      long wait is an explicit choice, not a silent default
+#                      (ALWAYS-CONTINUE: an orchestrator leg arms <=30-60 min
+#                      out while work remains). Automated safety arms
+#                      (ARM_RESUME_SAFETY_ARM=1) and the smart/auto sentinels
+#                      are exempt.
 #   --dedup-any        Dedup against ANY HIMMEL-Resume job, not just this
 #                      handover's (HIMMEL-340 safety-arm semantics).
 #   --dry-run          Print what would be scheduled, touch nothing.
@@ -61,6 +68,11 @@
 #                           that trigger a WARN (default 5). An exact-minute
 #                           match always refuses (rc=6) unless --force.
 #   ARM_COLLISION_WINDOW    Test seam: overrides COLLISION_WINDOW_MINUTES.
+#   ARM_RESUME_SAFETY_ARM   Internal signal (=1) marking an automated
+#                           machine-wide SAFETY arm (auto-arm-on-cap.sh,
+#                           spawn-glm cap-respawn) so the HIMMEL-1475 long-gap
+#                           guard exempts it. NOT a public flag: set only by
+#                           the in-repo automated callers in their child env.
 #   ARM_NAME_TEMPLATE       Naming template for the derived session identity
 #                           (HIMMEL-716): placeholders {ticket} {slug}
 #                           {session}. Unset = the built-in ticket-first
@@ -94,6 +106,11 @@
 #      this script also prunes ITS OWN host's prior records for the same
 #      handover on every re-arm, so neither a fired arm nor a superseded
 #      re-arm blocks a later cross-host arm forever.
+#   9  long-gap refused — an explicit --time HH:MM more than 60 min out
+#      without --long-gap (HIMMEL-1475). Pass --long-gap to sanction an
+#      overnight/idle wait, or pick a nearer --time. Automated safety arms
+#      (ARM_RESUME_SAFETY_ARM=1) are exempt; smart/auto sentinels are exempt
+#      by design.
 set -euo pipefail
 
 RESUME_TIME=""
@@ -106,6 +123,7 @@ DEDUP_ANY=0
 WORKTREE_BRANCH=""
 WSL_DISTRO=""
 AUTOMERGE=0
+LONG_GAP=0
 
 # Local HH:MM from an epoch (armored python3 — portable, no GNU `date -d`;
 # capture via file so a wedged Store stub can't hang the $() call sites).
@@ -113,7 +131,7 @@ _epoch_hhmm() { py_armor_capture -c 'import sys,datetime; print(datetime.datetim
 
 usage() {
     cat <<'EOF'
-Usage: arm-resume.sh --time <HH:MM> --handover <path> [--wsl-distro <name>] [--force] [--dedup-any] [--dry-run] [--automerge]
+Usage: arm-resume.sh --time <HH:MM> --handover <path> [--wsl-distro <name>] [--force] [--long-gap] [--dedup-any] [--dry-run] [--automerge]
 
 Arms the OS scheduler to relaunch claude at the given time with a
 resume prompt referencing the given handover file. Dedup-guarded
@@ -169,6 +187,11 @@ Optional:
                      interpreted as an in-distro path.
   --force            Replace the existing same-handover HIMMEL-Resume job;
                      also bypasses the time-collision check (HIMMEL-407).
+  --long-gap         Sanction an explicit --time HH:MM more than 60 min out
+                     (HIMMEL-1475). Default REFUSES (rc=9) a far park so a long
+                     wait is an explicit choice (ALWAYS-CONTINUE: arm <=30-60
+                     min out while work remains). Safety arms
+                     (ARM_RESUME_SAFETY_ARM=1) and smart/auto are exempt.
   --dedup-any        Dedup against ANY HIMMEL-Resume job, not just this
                      handover's: arm only if NO resume slot exists at all.
                      The safety-arm semantics the auto-arm watchdogs use so
@@ -188,6 +211,11 @@ Env:
                           fire time that trigger a near-collision WARN (default
                           5). An exact-minute overlap always refuses (rc=6)
                           unless --force. Set ARM_COLLISION_WINDOW in tests.
+  ARM_RESUME_SAFETY_ARM   Internal signal (=1) marking an automated
+                          machine-wide SAFETY arm (auto-arm-on-cap.sh,
+                          spawn-glm cap-respawn) so the HIMMEL-1475 long-gap
+                          guard exempts it. NOT a public flag — set only by the
+                          in-repo automated callers in their child env.
   ARM_NAME_TEMPLATE       Template for the derived session identity
                           (HIMMEL-716). Placeholders: {ticket} (inferred key),
                           {slug} (worktree/handover name-half), {session}
@@ -232,6 +260,7 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         --force)       FORCE=1; shift ;;
+        --long-gap)    LONG_GAP=1; shift ;;
         --dedup-any)   DEDUP_ANY=1; shift ;;
         --dry-run)     DRY_RUN=1; shift ;;
         --automerge)   AUTOMERGE=1; shift ;;
@@ -522,13 +551,55 @@ now = datetime.now().astimezone()
 cand = now.replace(hour=hh, minute=mm, second=0, microsecond=0)
 if cand <= now:          # time already passed today -> tomorrow
     cand += timedelta(days=1)
-print(int(cand.timestamp()), cand.strftime("%H:%M"), cand.strftime("%m/%d/%Y"), cand.strftime("%Y%m%d%H%M"))
+print(int(cand.timestamp()), cand.strftime("%H:%M"), cand.strftime("%m/%d/%Y"), cand.strftime("%Y%m%d%H%M"), int((cand - now).total_seconds()))
 ' "$RESUME_TIME" || {
             echo "ERR arm-resume: could not resolve --time $RESUME_TIME to an epoch (python3 failed/timed out)" >&2
             exit 2
         }
-        read -r TARGET_EPOCH RESUME_TIME START_DATE AT_STAMP <<<"$PY_ARMOR_OUT"
+        # 5th field is the gap in RAW SECONDS (HIMMEL-1475 CR-fix): a floored-
+        # to-minutes value made 60m01s-60m59s read as 60 and slip past a
+        # >60min check. The guard compares gap_sec > 3600 directly.
+        read -r TARGET_EPOCH RESUME_TIME START_DATE AT_STAMP _GAP_SEC <<<"$PY_ARMOR_OUT"
         _SCHED_FIELDS_DERIVED=1
+        # HIMMEL-1475 long-gap guard. An explicit HH:MM work arm parked more
+        # than 60 min out is a deliberate choice, not a default: the
+        # ALWAYS-CONTINUE directive says an orchestrator leg should arm
+        # <=30-60 min out while work remains (the original failure was a leg
+        # parking the chain 4 HOURS on operator-blocked items while
+        # independent work sat idle). Refuse (rc=9) unless the operator owns
+        # the choice with --long-gap (mirrors the --force dedup override).
+        # The gap is compared in RAW SECONDS (>3600), not floored minutes: a
+        # //60 floor made 60m01s-60m59s read as 60 and slip past a >60 check.
+        #
+        # EXEMPT — these are NOT explicit work-arm choices, so the guard does
+        # not target them:
+        #   * ARM_RESUME_SAFETY_ARM=1 marks an automated machine-wide SAFETY
+        #     arm (auto-arm-on-cap.sh's stale-cache escalation + spawn-glm's
+        #     cap-respawn both set it in their child env; those callers arm at
+        #     a multi-hour cap reset and cannot pass --long-gap). This is a
+        #     dedicated internal signal, NOT a public flag: --dedup-any is a
+        #     dedup-scope knob any caller can add, so it must NOT bypass the
+        #     guard (a far arm with only --dedup-any is still refused — LG5b).
+        #   * smart/auto are system-computed sentinels resolved in their own
+        #     branches above and never reach this HH:MM arm.
+        # Only an explicit per-handover work arm (the orchestrator's
+        # --time HH:MM) is guarded.
+        # The exemption is an EXACT string compare on literal "1" (CR-fix):
+        # a numeric `-ne 1` treats a non-numeric ambient value (e.g. "yes",
+        # "true", garbage) as a FAILED expression whose non-zero return makes
+        # the whole && chain false and SKIPS the refusal — the guard silently
+        # drops. Anything other than the literal "1" (unset, "0", junk) → the
+        # guard applies. See also the launch-body unset that prevents this var
+        # leaking into a resumed session (HIMMEL-1475).
+        if [ "${_GAP_SEC:-0}" -gt 3600 ] && [ "$LONG_GAP" -eq 0 ] && [ "${ARM_RESUME_SAFETY_ARM:-}" != "1" ]; then
+            _gh=$(( _GAP_SEC / 3600 )); _gm=$(( (_GAP_SEC % 3600) / 60 ))
+            {
+                echo "WARN arm-resume: arming ${_gh}h${_gm}m out ($RESUME_TIME) — is the queue actually empty? ALWAYS-CONTINUE directive says arm <=30-60 min while work remains."
+                echo "    Refusing without --long-gap (rc=9). A longer park is fine for an overnight/idle"
+                echo "    wait but must be an explicit choice — re-run with --long-gap, or pick a nearer --time."
+            } >&2
+            exit 9
+        fi
         ;;
 esac
 
@@ -2221,13 +2292,17 @@ _crontab_schedule() {
     # whatever env cron happened to run it under. `&&`, not `;`, so a failed
     # unset (should never happen) can't fall through to an ungated claude
     # launch outside the entry's `cd ... && $tail` gate.
-    local tail="unset ARMAUTOMERGE CR_MERGE_GATE_OK && ${q_automerge}claude ${q_name}$q_prompt $q_channels"
+    # HIMMEL-1475: also unset ARM_RESUME_SAFETY_ARM — a crontab entry fired by
+    # an automated safety arm (auto-arm-on-cap/spawn-glm set the var in their
+    # child env) must NOT hand the long-gap exemption to the resumed session,
+    # or a later far HH:MM arm it makes silently bypasses the guard.
+    local tail="unset ARMAUTOMERGE CR_MERGE_GATE_OK ARM_RESUME_SAFETY_ARM && ${q_automerge}claude ${q_name}$q_prompt $q_channels"
     if [ "$HEADROOM_PROXY_ACTIVE" -eq 1 ]; then
         local q_hb q_log q_curl
         q_hb=$(printf '%q' "$HEADROOM_BIN")
         q_log=$(printf '%q' "$HOME/.headroom-proxy.log")
         q_curl=$(printf '%q' "$HEADROOM_CURL")
-        tail="{ unset ARMAUTOMERGE CR_MERGE_GATE_OK; $q_curl -s -m 5 http://127.0.0.1:$HEADROOM_PROXY_PORT/livez >/dev/null 2>&1 || { $q_hb proxy --port $HEADROOM_PROXY_PORT >> $q_log 2>&1 & sleep 3; }; if $q_curl -s -m 5 http://127.0.0.1:$HEADROOM_PROXY_PORT/livez >/dev/null 2>&1; then echo \"\$(date) arm=$TASK_NAME mode=proxied\" >> $q_log; ANTHROPIC_BASE_URL=http://127.0.0.1:$HEADROOM_PROXY_PORT HEADROOM_OFFLINE=1 ${q_automerge}claude ${q_name}$q_prompt $q_channels; else echo \"\$(date) arm=$TASK_NAME mode=bare-fallback\" >> $q_log; ${q_automerge}claude ${q_name}$q_prompt $q_channels; fi; }"
+        tail="{ unset ARMAUTOMERGE CR_MERGE_GATE_OK ARM_RESUME_SAFETY_ARM; $q_curl -s -m 5 http://127.0.0.1:$HEADROOM_PROXY_PORT/livez >/dev/null 2>&1 || { $q_hb proxy --port $HEADROOM_PROXY_PORT >> $q_log 2>&1 & sleep 3; }; if $q_curl -s -m 5 http://127.0.0.1:$HEADROOM_PROXY_PORT/livez >/dev/null 2>&1; then echo \"\$(date) arm=$TASK_NAME mode=proxied\" >> $q_log; ANTHROPIC_BASE_URL=http://127.0.0.1:$HEADROOM_PROXY_PORT HEADROOM_OFFLINE=1 ${q_automerge}claude ${q_name}$q_prompt $q_channels; else echo \"\$(date) arm=$TASK_NAME mode=bare-fallback\" >> $q_log; ${q_automerge}claude ${q_name}$q_prompt $q_channels; fi; }"
     fi
     local q_flow_lib q_task q_note
     q_flow_lib=$(printf '%q' "$SCRIPT_DIR/../lib/flow-run-ledger.sh")
@@ -2479,8 +2554,10 @@ schedule_arm() {
                 # HIMMEL-1382 fix round: unset both vars first (defense against
                 # ambient carryover), THEN conditionally re-grant via the
                 # per-command prefix — same always-clear contract as the
-                # Windows/at/crontab launch bodies below.
-                wsl_command="cd $q_cwd && unset ARMAUTOMERGE CR_MERGE_GATE_OK && ${q_automerge}claude$q_name $q_prompt$q_channels"
+                # Windows/at/crontab launch bodies below. HIMMEL-1475: the same
+                # unset also drops ARM_RESUME_SAFETY_ARM so the resumed in-distro
+                # session does not inherit a leaked long-gap exemption.
+                wsl_command="cd $q_cwd && unset ARMAUTOMERGE CR_MERGE_GATE_OK ARM_RESUME_SAFETY_ARM && ${q_automerge}claude$q_name $q_prompt$q_channels"
                 # The composed command sits INSIDE the .bat line's double
                 # quotes, where CMD treats ^ as a LITERAL character —
                 # caret-escaping here reaches bash verbatim and shatters the
@@ -2660,8 +2737,13 @@ schedule_arm() {
                     # ambient ARMAUTOMERGE/CR_MERGE_GATE_OK through from
                     # whatever launched it -- the emitted text enforces its
                     # own contract regardless of ambient env.
+                    # HIMMEL-1475: clear ARM_RESUME_SAFETY_ARM too, for the same
+                    # reason and by symmetry with the POSIX launch bodies — the
+                    # fired .bat session must not inherit a leaked long-gap
+                    # exemption from the submitting safety-arm env.
                     printf 'set "ARMAUTOMERGE="\r\n'
                     printf 'set "CR_MERGE_GATE_OK="\r\n'
+                    printf 'set "ARM_RESUME_SAFETY_ARM="\r\n'
                     if [ "$AUTOMERGE" -eq 1 ]; then
                         printf 'set "ARMAUTOMERGE=1"\r\n'
                         printf 'set "CR_MERGE_GATE_OK=1"\r\n'
@@ -2954,15 +3036,20 @@ schedule_arm() {
                 # even when THIS arm's generated text sets neither. Unset both
                 # unconditionally as the first line of the job body so the
                 # emitted text — not the ambient env it was submitted from —
-                # is what governs.
-                local launch_lines="unset ARMAUTOMERGE CR_MERGE_GATE_OK
+                # is what governs. HIMMEL-1475: the same line also unsets
+                # ARM_RESUME_SAFETY_ARM — on Linux `at` snapshots the submitter
+                # env, so without this the RESUMED claude session inherits the
+                # sticky long-gap exemption from the safety arm that scheduled
+                # it, and every later far HH:MM arm it makes silently bypasses
+                # the guard.
+                local launch_lines="unset ARMAUTOMERGE CR_MERGE_GATE_OK ARM_RESUME_SAFETY_ARM
 ${q_automerge}claude ${q_name}$q_prompt $q_channels"
                 if [ "$HEADROOM_PROXY_ACTIVE" -eq 1 ]; then
                     local q_hb q_log q_curl
                     q_hb=$(printf '%q' "$HEADROOM_BIN")
                     q_log=$(printf '%q' "$HOME/.headroom-proxy.log")
                     q_curl=$(printf '%q' "$HEADROOM_CURL")
-                    launch_lines="unset ARMAUTOMERGE CR_MERGE_GATE_OK
+                    launch_lines="unset ARMAUTOMERGE CR_MERGE_GATE_OK ARM_RESUME_SAFETY_ARM
 $q_curl -s -m 5 http://127.0.0.1:$HEADROOM_PROXY_PORT/livez >/dev/null 2>&1 || { $q_hb proxy --port $HEADROOM_PROXY_PORT >> $q_log 2>&1 & sleep 3; }
 if $q_curl -s -m 5 http://127.0.0.1:$HEADROOM_PROXY_PORT/livez >/dev/null 2>&1; then
     echo \"\$(date) arm=$TASK_NAME mode=proxied\" >> $q_log
@@ -3072,7 +3159,7 @@ fi
 # Telemetry (HIMMEL-236): a successful arm IS the re-launch signal the
 # measure-during protocol wants — one append, after the dry-run gate so
 # --dry-run keeps its "touch nothing" contract.
-telemetry_emit handover-arm-resume armed "time=$RESUME_TIME" "force=$FORCE"
+telemetry_emit handover-arm-resume armed "time=$RESUME_TIME" "force=$FORCE" "long_gap=$LONG_GAP"
 
 # HIMMEL-856: record this arm in the cross-machine arms registry, same
 # dry-run gate as telemetry above. Best-effort -- a registry write failure

--- a/scripts/handover/test-arm-resume-identity.sh
+++ b/scripts/handover/test-arm-resume-identity.sh
@@ -91,7 +91,9 @@ WORK_REPO="$TMP/work-repo"
 mkdir -p "$WORK_REPO"
 git init -q "$WORK_REPO"
 
-FUTURE_TIME="23:59"
+# A near future time keeps these identity/transaction fixtures inside the
+# HIMMEL-1475 explicit-HH:MM long-gap limit.
+FUTURE_TIME=$(python3 -c 'import datetime; print((datetime.datetime.now()+datetime.timedelta(minutes=30)).strftime("%H:%M"))')
 FAILED=0
 
 # --- assertions -------------------------------------------------------------

--- a/scripts/handover/test-arm-resume-long-gap.sh
+++ b/scripts/handover/test-arm-resume-long-gap.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# HIMMEL-1475 long-gap guard twin for scripts/handover/arm-resume.sh.
+#
+# arm-resume now REFUSES (rc=9) an explicit --time HH:MM more than 60 min out
+# unless --long-gap sanctions the park (the ALWAYS-CONTINUE directive: an
+# orchestrator leg arms <=30-60 min out while work remains). This twin covers
+# the gap arithmetic (incl. the midnight wrap), the refusal path, the
+# --long-gap pass-through, the <=60 min silent path, the ARM_RESUME_SAFETY_ARM=1
+# safety-arm exemption (auto-arm-on-cap.sh's stale-cache escalation + spawn-glm
+# cap-respawn arm at a multi-hour cap reset and cannot pass --long-gap;
+# --dedup-any alone does NOT exempt — LG5b), the raw-seconds gap floor (LG7),
+# and the long_gap audit field.
+#
+# Kept SEPARATE from the (large) test-arm-resume.sh, same rationale as the
+# identity/proxy/queue-lock twins. Uses --dry-run throughout so no real
+# scheduler jobs are created, EXCEPT the audit-field cases (LG6a/LG6b) which
+# need a real (stubbed) arm so the telemetry "armed" record is emitted.
+set -uo pipefail
+
+ARM="$(cd "$(dirname "$0")" && pwd)/arm-resume.sh"
+[ -x "$ARM" ] || chmod +x "$ARM"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Hermetic shields — same set test-arm-resume.sh uses so the assertions below
+# are not skewed by the operator's shell.
+export SKILL_TELEMETRY_DIR="$TMP/telemetry-default"
+unset SKILL_TELEMETRY_DISABLE 2>/dev/null || true
+unset ARM_NAME_TEMPLATE 2>/dev/null || true
+unset RESUME_SLOT_THRESHOLD 2>/dev/null || true
+export WORKSPACE_TRUST_CONFIG="$TMP/claude-trust.json"
+export HIMMEL_FLOW_RUNS_LEDGER="$TMP/flow-runs.jsonl"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+assert_rc() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS $label (rc=$actual)"
+    else
+        echo "FAIL $label — expected rc=$expected, got rc=$actual"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    case "$haystack" in
+        *"$needle"*) echo "PASS $label" ;;
+        *) echo "FAIL $label — output missing: $needle"; FAILED=$((FAILED + 1)) ;;
+    esac
+}
+
+assert_not_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    case "$haystack" in
+        *"$needle"*) echo "FAIL $label — output unexpectedly contains: $needle"; FAILED=$((FAILED + 1)) ;;
+        *) echo "PASS $label" ;;
+    esac
+}
+
+FAILED=0
+
+# ---------------------------------------------------------------------------
+# Fixture setup (mirrors test-arm-resume.sh)
+# ---------------------------------------------------------------------------
+WORK_REPO="$TMP/work-repo"
+mkdir -p "$WORK_REPO"
+git init -q "$WORK_REPO"
+
+HANDOVER_DIR="$TMP/statedocs/handovers"
+mkdir -p "$HANDOVER_DIR"
+git init -q "$TMP/statedocs"
+
+make_handover() {
+    local cwd_val="${1:-}"
+    local path="$HANDOVER_DIR/handover-$RANDOM.md"
+    {
+        printf -- '---\n'
+        printf 'session_kind: test\n'
+        [ -n "$cwd_val" ] && printf 'resume_cwd: %s\n' "$cwd_val"
+        printf -- '---\n'
+        printf '# Test handover\n'
+    } > "$path"
+    printf '%s' "$path"
+}
+
+# Empty-scheduler stub (the SCHED_STUB_T17 pattern): every backend exits 0
+# with no jobs, so list_existing / dedup never blocks and the guard is the
+# only thing under test.
+SCHED_STUB="$TMP/sched-stub"
+mkdir -p "$SCHED_STUB"
+cat > "$SCHED_STUB/schtasks" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$SCHED_STUB/atq" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$SCHED_STUB/at" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$SCHED_STUB/powershell" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$SCHED_STUB/schtasks" "$SCHED_STUB/atq" "$SCHED_STUB/at" "$SCHED_STUB/powershell"
+
+# Armed stub (the ARMED_STUB pattern): a non-dry-run arm completes on any
+# platform without touching the real scheduler, so the "armed" telemetry
+# record is emitted. TMPDIR pinned so a windows .bat lands under $TMP.
+ARMED_STUB="$TMP/armed-stub"
+mkdir -p "$ARMED_STUB"
+cat > "$ARMED_STUB/schtasks" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$ARMED_STUB/atq" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$ARMED_STUB/at" <<'EOF'
+#!/usr/bin/env bash
+cat > /dev/null
+exit 0
+EOF
+cat > "$ARMED_STUB/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$ARMED_STUB/powershell" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$ARMED_STUB/schtasks" "$ARMED_STUB/atq" "$ARMED_STUB/at" "$ARMED_STUB/claude" "$ARMED_STUB/powershell"
+
+# Gap fixtures, computed relative to real now (the guard's `now` is captured
+# a fraction of a second later, so the gaps below hold for this fast twin):
+#   FAR    ~3h out  -> gap ~180 min  (>60 -> refused without --long-gap)
+#   NEAR   ~5m out  -> gap ~5 min    (<=60 -> silent)
+#   WRAP   ~10m AGO -> rolls to tomorrow -> gap ~1430 min (midnight wrap, MUST
+#                     be a large POSITIVE gap, never negative: a broken wrap
+#                     would yield ~-10 min -> <=60 -> not refused -> LG4 fails)
+FAR_HHMM=$(python3 -c 'import datetime; print((datetime.datetime.now()+datetime.timedelta(hours=3)).strftime("%H:%M"))')
+NEAR_HHMM=$(python3 -c 'import datetime; print((datetime.datetime.now()+datetime.timedelta(minutes=5)).strftime("%H:%M"))')
+WRAP_HHMM=$(python3 -c 'import datetime; print((datetime.datetime.now()-datetime.timedelta(minutes=10)).strftime("%H:%M"))')
+
+# ---------------------------------------------------------------------------
+# LG1: gap > 60 min, no --long-gap -> REFUSED (rc 9) + the loud WARN.
+# ---------------------------------------------------------------------------
+HO=$(make_handover "$WORK_REPO")
+out=$(PATH="$SCHED_STUB:$PATH" bash "$ARM" --time "$FAR_HHMM" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "LG1 far HH:MM refused without --long-gap (rc 9)" 9 "$rc"
+assert_contains "LG1 WARN asks if the queue is empty" "is the queue actually empty" "$out"
+assert_contains "LG1 WARN cites the ALWAYS-CONTINUE directive" "ALWAYS-CONTINUE" "$out"
+assert_contains "LG1 WARN names the --long-gap escape" "--long-gap" "$out"
+assert_contains "LG1 WARN reports the gap as NhMm out" "m out" "$out"
+assert_contains "LG1 WARN names the requested time" "out ($FAR_HHMM)" "$out"
+
+# ---------------------------------------------------------------------------
+# LG2: gap <= 60 min -> SILENT, unchanged behavior (rc 0, no WARN).
+# ---------------------------------------------------------------------------
+HO=$(make_handover "$WORK_REPO")
+out=$(PATH="$SCHED_STUB:$PATH" bash "$ARM" --time "$NEAR_HHMM" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "LG2 near HH:MM proceeds silently (rc 0)" 0 "$rc"
+assert_not_contains "LG2 no long-gap WARN on a near arm" "is the queue actually empty" "$out"
+assert_not_contains "LG2 no rc-9 refusal text on a near arm" "rc=9" "$out"
+
+# ---------------------------------------------------------------------------
+# LG3: --long-gap sanctions a far park -> proceeds (rc 0, no WARN).
+# ---------------------------------------------------------------------------
+HO=$(make_handover "$WORK_REPO")
+out=$(PATH="$SCHED_STUB:$PATH" bash "$ARM" --time "$FAR_HHMM" --handover "$HO" --long-gap --dry-run 2>&1)
+rc=$?
+assert_rc "LG3 far HH:MM + --long-gap proceeds (rc 0)" 0 "$rc"
+assert_not_contains "LG3 no refusal under --long-gap" "is the queue actually empty" "$out"
+assert_not_contains "LG3 no rc-9 refusal text under --long-gap" "rc=9" "$out"
+
+# ---------------------------------------------------------------------------
+# LG4: midnight wrap — a time ~10 min AGO rolls to tomorrow, so the gap is a
+#      large POSITIVE value (~1430 min) and the arm is REFUSED. A broken wrap
+#      (no +1 day) would compute a ~-10 min gap -> <=60 -> NOT refused, failing
+#      this case. This is the "550 min, not negative" correctness guard.
+# ---------------------------------------------------------------------------
+HO=$(make_handover "$WORK_REPO")
+out=$(PATH="$SCHED_STUB:$PATH" bash "$ARM" --time "$WRAP_HHMM" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "LG4 past-time wrap refused (positive gap, rc 9)" 9 "$rc"
+assert_contains "LG4 wrap refusal still cites the directive" "ALWAYS-CONTINUE" "$out"
+
+# ---------------------------------------------------------------------------
+# LG5: ARM_RESUME_SAFETY_ARM=1 (automated safety arm) is EXEMPT — a far HH:MM
+#      proceeds without --long-gap. auto-arm-on-cap.sh's stale-cache escalation
+#      and spawn-glm's cap-respawn arm at a multi-hour cap reset under this env
+#      var and cannot pass --long-gap, so the guard must not block it.
+# ---------------------------------------------------------------------------
+HO=$(make_handover "$WORK_REPO")
+out=$(PATH="$SCHED_STUB:$PATH" ARM_RESUME_SAFETY_ARM=1 bash "$ARM" --time "$FAR_HHMM" --handover "$HO" --dedup-any --dry-run 2>&1)
+rc=$?
+assert_rc "LG5 ARM_RESUME_SAFETY_ARM=1 far arm exempt from the guard (rc 0)" 0 "$rc"
+assert_not_contains "LG5 no refusal on a safety-arm env" "is the queue actually empty" "$out"
+
+# ---------------------------------------------------------------------------
+# LG5b: --dedup-any ALONE (no ARM_RESUME_SAFETY_ARM) does NOT bypass the guard
+#       (HIMMEL-1475 CR-fix): --dedup-any is a public dedup-scope flag any
+#       caller can add, not a provenance signal. A far arm with only
+#       --dedup-any is REFUSED just like a bare far arm.
+# ---------------------------------------------------------------------------
+HO=$(make_handover "$WORK_REPO")
+out=$(PATH="$SCHED_STUB:$PATH" bash "$ARM" --time "$FAR_HHMM" --handover "$HO" --dedup-any --dry-run 2>&1)
+rc=$?
+assert_rc "LG5b --dedup-any alone no longer bypasses the guard (rc 9)" 9 "$rc"
+assert_contains "LG5b refusal still cites the directive" "ALWAYS-CONTINUE" "$out"
+
+# ---------------------------------------------------------------------------
+# LG7: the gap compares RAW SECONDS (>3600), not floored minutes. A time ~61
+#      min out lands the true gap in [3601, 3660]s — ALWAYS over 3600 (refused),
+#      yet the old `//60` floor rounded 3601-3659s down to 60 min and let it
+#      pass.
+# ---------------------------------------------------------------------------
+# Rollover-safe edge (HIMMEL-1475 CR-fix): EDGE_HHMM is computed here in a
+# SEPARATE process from arm-resume's own now-capture. The gap arm-resume sees
+# is 3660 - now.seconds - lag (lag = the wall time between this capture and
+# arm-resume's). The prior comment's "no flaky split across the 3600 boundary"
+# was wrong: when this fixture lands in the last few seconds of a minute,
+# now.seconds + lag crosses 60, the gap dips to <= 3600, and the expected rc=9
+# flakes. Wait past the minute boundary whenever now is within a few seconds of
+# rolling over so now.seconds is small and the gap stays in (3600, 3660) with
+# margin for the cross-process lag.
+_now_sec=$(python3 -c 'import datetime; print(datetime.datetime.now().second)')
+if [ "$_now_sec" -ge 55 ]; then
+    sleep $((61 - _now_sec))
+fi
+HO=$(make_handover "$WORK_REPO")
+EDGE_HHMM=$(python3 -c 'import datetime; print((datetime.datetime.now()+datetime.timedelta(minutes=61)).strftime("%H:%M"))')
+unset _now_sec
+out=$(PATH="$SCHED_STUB:$PATH" bash "$ARM" --time "$EDGE_HHMM" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "LG7 ~61 min out ([3601,3660]s) refused under raw-seconds floor (rc 9)" 9 "$rc"
+
+# ---------------------------------------------------------------------------
+# LG6a: the long_gap audit field — a far arm WITH --long-gap records the
+#       explicit choice in the "armed" telemetry line (long_gap=1).
+# ---------------------------------------------------------------------------
+HO=$(make_handover "$WORK_REPO")
+TELE_LG6A="$TMP/tel-lg6a"
+out=$(TMPDIR="$TMP" PATH="$ARMED_STUB:$PATH" SKILL_TELEMETRY_DIR="$TELE_LG6A" \
+    bash "$ARM" --time "$FAR_HHMM" --handover "$HO" --long-gap 2>&1)
+rc=$?
+assert_rc "LG6a far arm + --long-gap arms (rc 0)" 0 "$rc"
+TLOG="$TELE_LG6A/skill-usage.jsonl"
+if [ -f "$TLOG" ] && [ "$(wc -l < "$TLOG" | tr -d ' ')" = "1" ]; then
+    echo "PASS LG6a exactly one telemetry record"
+else
+    echo "FAIL LG6a expected exactly one telemetry line ($TLOG)"
+    FAILED=$((FAILED + 1))
+fi
+tline=$(tail -1 "$TLOG" 2>/dev/null || true)
+assert_contains "LG6a record names the event" '"event":"armed"' "$tline"
+assert_contains "LG6a record marks the explicit long-gap choice" '"long_gap":"1"' "$tline"
+
+# ---------------------------------------------------------------------------
+# LG6b: a NEAR arm (no --long-gap) records long_gap=0 — the ledger
+#       distinguishes an explicit long park from a normal near arm.
+# ---------------------------------------------------------------------------
+HO=$(make_handover "$WORK_REPO")
+TELE_LG6B="$TMP/tel-lg6b"
+out=$(TMPDIR="$TMP" PATH="$ARMED_STUB:$PATH" SKILL_TELEMETRY_DIR="$TELE_LG6B" \
+    bash "$ARM" --time "$NEAR_HHMM" --handover "$HO" 2>&1)
+rc=$?
+assert_rc "LG6b near arm arms (rc 0)" 0 "$rc"
+TLOG="$TELE_LG6B/skill-usage.jsonl"
+tline=$(tail -1 "$TLOG" 2>/dev/null || true)
+assert_contains "LG6b record names the event" '"event":"armed"' "$tline"
+assert_contains "LG6b near arm records long_gap=0" '"long_gap":"0"' "$tline"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+if [ "$FAILED" -gt 0 ]; then
+    echo "---"
+    echo "FAIL $FAILED case(s)"
+    exit 1
+fi
+echo "---"
+echo "PASS all cases"
+exit 0

--- a/scripts/handover/test-arm-resume-proxy.sh
+++ b/scripts/handover/test-arm-resume-proxy.sh
@@ -73,7 +73,9 @@ git init -q "$WORK_REPO"
 HANDOVER_DIR="$TMP/statedocs/handovers"
 mkdir -p "$HANDOVER_DIR"
 git init -q "$TMP/statedocs"
-FUTURE_TIME="23:59"
+# A near future time keeps these proxy fixtures inside the HIMMEL-1475
+# explicit-HH:MM long-gap limit.
+FUTURE_TIME=$(python3 -c 'import datetime; print((datetime.datetime.now()+datetime.timedelta(minutes=30)).strftime("%H:%M"))')
 
 make_handover() {
     local path="$HANDOVER_DIR/handover-$RANDOM.md"

--- a/scripts/handover/test-arm-resume-queue-lock.sh
+++ b/scripts/handover/test-arm-resume-queue-lock.sh
@@ -30,7 +30,9 @@ export SKILL_TELEMETRY_DIR="$TMP/telemetry"
 export WORKSPACE_TRUST_CONFIG="$TMP/claude-trust.json"
 unset QUEUE_LOCK_TAKEOVER QUEUE_LOCK_TTL_SECONDS ARM_DUP_OK 2>/dev/null || true
 
-FUTURE_TIME="23:59"
+# A near future time keeps these queue-lock fixtures inside the HIMMEL-1475
+# explicit-HH:MM long-gap limit.
+FUTURE_TIME=$(python3 -c 'import datetime; print((datetime.datetime.now()+datetime.timedelta(minutes=30)).strftime("%H:%M"))')
 HO="$HANDOVER_DIR/HIMMEL-856-test/next-session-1.md"
 mkdir -p "$(dirname "$HO")"
 printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 test handover\n' > "$HO"

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -93,8 +93,13 @@ HANDOVER_DIR="$TMP/statedocs/handovers"
 mkdir -p "$HANDOVER_DIR"
 git init -q "$TMP/statedocs"
 
-# A fixed time in the future (HH:MM format) — just needs to parse.
-FUTURE_TIME="23:59"
+# A NEAR future time (HH:MM, <=60 min out) so the HIMMEL-1475 long-gap guard
+# stays silent for every fixture below that just needs a valid future HH:MM.
+# Computed once (a hermetic shell suite finishes well inside the 30-min
+# window). Tests that deliberately arm FAR — T8 tomorrow-roll, T28d seeds,
+# T33-T36/N6 collision probes, the macOS multislot sibling — carry their own
+# far times + --long-gap.
+FUTURE_TIME=$(python3 -c 'import datetime; print((datetime.datetime.now()+datetime.timedelta(minutes=30)).strftime("%H:%M"))')
 
 # ---------------------------------------------------------------------------
 # Helper: write a minimal handover file and return its path via stdout.
@@ -288,7 +293,7 @@ assert_not_contains "T7 no discoverability warning for CRLF handover" "no --cwd 
 HO=$(make_handover "$WORK_REPO")
 PAST_HHMM=$(python3 -c 'import datetime; print((datetime.datetime.now()-datetime.timedelta(minutes=2)).strftime("%H:%M"))')
 # HIMMEL-966: host `at` must not be a dependency; pin the posix backend with the stub.
-out=$(PATH="$SCHED_STUB_T17:$PATH" bash "$ARM" --time "$PAST_HHMM" --handover "$HO" --force --dry-run 2>&1)
+out=$(PATH="$SCHED_STUB_T17:$PATH" bash "$ARM" --time "$PAST_HHMM" --handover "$HO" --long-gap --force --dry-run 2>&1)
 rc=$?
 assert_rc "T8 past --time exits 0 (force+dry)" 0 "$rc"
 case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
@@ -1053,9 +1058,9 @@ HO_F3=$(make_handover "$WORK_REPO")
 # (HIMMEL-407): on one that does, same-minute seeds would refuse rc=6 and the
 # test would fail during setup, before it ever exercised --dedup-any --force.
 TMPDIR="$TMP" SCHED_DB="$DB28F" SCHED_DB_DIR="$DB28FD" PATH="$STATEFUL_STUB:$PATH" \
-    bash "$ARM" --time "23:57" --handover "$HO_F1" >/dev/null 2>&1
+    bash "$ARM" --time "23:57" --handover "$HO_F1" --long-gap >/dev/null 2>&1
 TMPDIR="$TMP" SCHED_DB="$DB28F" SCHED_DB_DIR="$DB28FD" PATH="$STATEFUL_STUB:$PATH" \
-    bash "$ARM" --time "23:58" --handover "$HO_F2" >/dev/null 2>&1
+    bash "$ARM" --time "23:58" --handover "$HO_F2" --long-gap >/dev/null 2>&1
 if [ "$(count_slots "$DB28F" "$DB28FD")" = "2" ]; then
     echo "PASS T28d two sibling slots queued before the --dedup-any --force arm"
 else
@@ -1305,6 +1310,34 @@ case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
 esac
 
 # ---------------------------------------------------------------------------
+# T38: ARM_RESUME_SAFETY_ARM sticky-exemption clear (HIMMEL-1475 CR-fix). The
+#      automated safety callers (auto-arm-on-cap.sh, spawn-glm) set
+#      ARM_RESUME_SAFETY_ARM=1 in their child env so the long-gap guard exempts
+#      their multi-hour cap-reset arm. On Linux `at` snapshots the submitter
+#      env, so WITHOUT a clear in the launch body the RESUMED claude session
+#      inherits =1 and every later far HH:MM arm it makes silently bypasses the
+#      guard. Every generated launch body must CLEAR ARM_RESUME_SAFETY_ARM
+#      alongside ARMAUTOMERGE/CR_MERGE_GATE_OK — the exemption is for THIS
+#      safety arm only, never a property the resumed session keeps. Mirrors how
+#      the ARMAUTOMERGE unset is tested (T33b/c).
+# ---------------------------------------------------------------------------
+HO=$(make_handover "$WORK_REPO")
+out=$(PATH="$SCHED_STUB_T17:$PATH" ARM_RESUME_SAFETY_ARM=1 \
+    bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dedup-any --dry-run 2>&1)
+rc=$?
+assert_rc "T38 safety-arm dry-run exits 0" 0 "$rc"
+case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
+    msys*|cygwin*|win32*|MINGW*)
+        assert_contains "T38 .bat CLEARS ARM_RESUME_SAFETY_ARM (sticky-exemption)" 'set "ARM_RESUME_SAFETY_ARM="' "$out"
+        ;;
+    *)
+        assert_contains "T38 launch body unsets ARM_RESUME_SAFETY_ARM (sticky-exemption)" "unset ARMAUTOMERGE CR_MERGE_GATE_OK ARM_RESUME_SAFETY_ARM" "$out"
+        ;;
+esac
+# The exemption VALUE is never granted to the resumed session — only cleared.
+assert_not_contains "T38 body does not grant ARM_RESUME_SAFETY_ARM=1" "ARM_RESUME_SAFETY_ARM=1" "$out"
+
+# ---------------------------------------------------------------------------
 # W1-W5: --worktree isolation for code arms (HIMMEL-387)
 # ---------------------------------------------------------------------------
 # W1: --worktree dry-run computes the type+slug path, resumes there, pre-trusts it.
@@ -1408,7 +1441,7 @@ DB33=$(_collision_db); DB33D=$(_collision_dbdir); : > "$DB33"; mkdir -p "$DB33D"
 HO=$(make_handover "$WORK_REPO")
 out=$(TMPDIR="$TMP" SCHED_DB="$DB33" SCHED_DB_DIR="$DB33D" PATH="$STATEFUL_STUB:$PATH" \
     ARM_COLLISION_CANDIDATES="$(printf 'HIMMEL-Pipeline-Harvest\t02:00')" \
-    bash "$ARM" --time "02:00" --handover "$HO" --dry-run 2>&1)
+    bash "$ARM" --time "02:00" --handover "$HO" --long-gap --dry-run 2>&1)
 rc=$?
 assert_rc "T33 exact collision refuses (rc 6)" 6 "$rc"
 assert_contains "T33 ERR names the collision" "time collision" "$out"
@@ -1425,7 +1458,7 @@ DB34=$(_collision_db); DB34D=$(_collision_dbdir); : > "$DB34"; mkdir -p "$DB34D"
 HO=$(make_handover "$WORK_REPO")
 out=$(TMPDIR="$TMP" SCHED_DB="$DB34" SCHED_DB_DIR="$DB34D" PATH="$STATEFUL_STUB:$PATH" \
     ARM_COLLISION_CANDIDATES="$(printf 'HIMMEL-Pipeline-Harvest\t02:00')" \
-    bash "$ARM" --time "02:03" --handover "$HO" --dry-run 2>&1)
+    bash "$ARM" --time "02:03" --handover "$HO" --long-gap --dry-run 2>&1)
 rc=$?
 assert_rc "T34 near collision still exits 0 (warn-only)" 0 "$rc"
 assert_contains "T34 WARN printed for near collision" "WARN arm-resume: near time collision" "$out"
@@ -1440,7 +1473,7 @@ DB35=$(_collision_db); DB35D=$(_collision_dbdir); : > "$DB35"; mkdir -p "$DB35D"
 HO=$(make_handover "$WORK_REPO")
 out=$(TMPDIR="$TMP" SCHED_DB="$DB35" SCHED_DB_DIR="$DB35D" PATH="$STATEFUL_STUB:$PATH" \
     ARM_COLLISION_CANDIDATES="$(printf 'HIMMEL-Pipeline-Harvest\t02:00')" \
-    bash "$ARM" --time "02:10" --handover "$HO" --dry-run 2>&1)
+    bash "$ARM" --time "02:10" --handover "$HO" --long-gap --dry-run 2>&1)
 rc=$?
 assert_rc "T35 outside window exits 0 silently" 0 "$rc"
 assert_not_contains "T35 no collision warn outside window" "collision" "$out"
@@ -1452,7 +1485,7 @@ DB36=$(_collision_db); DB36D=$(_collision_dbdir); : > "$DB36"; mkdir -p "$DB36D"
 HO=$(make_handover "$WORK_REPO")
 out=$(TMPDIR="$TMP" SCHED_DB="$DB36" SCHED_DB_DIR="$DB36D" PATH="$STATEFUL_STUB:$PATH" \
     ARM_COLLISION_CANDIDATES="$(printf 'HIMMEL-Pipeline-Harvest\t02:00')" \
-    bash "$ARM" --time "02:00" --handover "$HO" --force --dry-run 2>&1)
+    bash "$ARM" --time "02:00" --handover "$HO" --long-gap --force --dry-run 2>&1)
 rc=$?
 assert_rc "T36 --force bypasses exact collision (rc 0)" 0 "$rc"
 assert_not_contains "T36 no ERR on --force collision bypass" "ERR arm-resume: time collision" "$out"
@@ -1461,11 +1494,17 @@ assert_contains "T36 --force emits override WARN" "WARN arm-resume: --force: ign
 # ---------------------------------------------------------------------------
 # T37: --dedup-any (unattended watchdog) exact collision → WARN-ONLY (rc=0),
 #      never refuses. Ensures unattended watchdog arms always succeed even when
-#      another HIMMEL-* task fires at the same time.
+#      another HIMMEL-* task fires at the same time. ARM_RESUME_SAFETY_ARM=1 is
+#      the watchdog's guard-exemption signal (HIMMEL-1475 CR-fix: --dedup-any
+#      is dedup-scope only and no longer bypasses the long-gap guard, so a real
+#      safety arm — auto-arm-on-cap.sh — sets this env var; this simulation
+#      mirrors it). The collision check's own --dedup-any warn-only behavior is
+#      what T37 actually asserts; the env var just gets it past the guard.
 # ---------------------------------------------------------------------------
 DB37=$(_collision_db); DB37D=$(_collision_dbdir); : > "$DB37"; mkdir -p "$DB37D"
 HO=$(make_handover "$WORK_REPO")
 out=$(TMPDIR="$TMP" SCHED_DB="$DB37" SCHED_DB_DIR="$DB37D" PATH="$STATEFUL_STUB:$PATH" \
+    ARM_RESUME_SAFETY_ARM=1 \
     ARM_COLLISION_CANDIDATES="$(printf 'HIMMEL-Pipeline-Harvest\t02:00')" \
     bash "$ARM" --time "02:00" --handover "$HO" --dedup-any --dry-run 2>&1)
 rc=$?
@@ -1542,7 +1581,7 @@ DBN6=$(_collision_db); DBN6D=$(_collision_dbdir); : > "$DBN6"; mkdir -p "$DBN6D"
 HO=$(make_handover_titled "Resume: HIMMEL-540 collision case")
 out=$(TMPDIR="$TMP" SCHED_DB="$DBN6" SCHED_DB_DIR="$DBN6D" PATH="$STATEFUL_STUB:$PATH" \
     ARM_COLLISION_CANDIDATES="$(printf 'HIMMEL-Pipeline-Harvest\t02:00')" \
-    bash "$ARM" --time "02:00" --handover "$HO" --dry-run 2>&1)
+    bash "$ARM" --time "02:00" --handover "$HO" --long-gap --dry-run 2>&1)
 rc=$?
 assert_rc "N6 collision still HARD-REFUSES with a ticket-prefixed name (rc 6)" 6 "$rc"
 assert_contains "N6 ERR names the collision" "time collision" "$out"
@@ -1855,7 +1894,7 @@ if [ "$n" -eq 1 ]; then echo "PASS macOS --force keeps single entry"; else echo 
 # advisory collision check has nothing to flag.
 a_line="$(grep 'HIMMEL-Resume-' "$CRON_STORE" | head -1)"
 MAC_HO2="$(make_handover "$WORK_REPO")"
-mac_env bash "$ARM" --time "23:58" --handover "$MAC_HO2" >/dev/null 2>&1   # arm sibling B
+mac_env bash "$ARM" --time "23:58" --handover "$MAC_HO2" --long-gap >/dev/null 2>&1   # arm sibling B
 n="$(grep -c 'HIMMEL-Resume-' "$CRON_STORE" 2>/dev/null)" || n=0
 if [ "$n" -eq 2 ]; then echo "PASS macOS two distinct handovers coexist"; else echo "FAIL macOS expected 2 slots, got $n"; FAILED=$((FAILED+1)); fi
 b_line="$(grep -vF "$a_line" "$CRON_STORE" | grep 'HIMMEL-Resume-' | head -1)"
@@ -2019,8 +2058,10 @@ assert_contains "T-wsl body uses unquoted distro + login shell" 'wsl.exe -d ubun
 assert_not_contains "T-wsl body never quotes the -d value" 'wsl.exe -d "' "$out"
 # HIMMEL-1382 fix round: the launch body now unsets ARMAUTOMERGE/
 # CR_MERGE_GATE_OK unconditionally between cd and claude (always-clear
-# contract — see arm-resume.sh's schedule_arm WSL branch comment).
-assert_contains "T-wsl body has in-distro cd+unset+claude" "cd '$WSL_CWD' && unset ARMAUTOMERGE CR_MERGE_GATE_OK && claude" "$out"
+# contract — see arm-resume.sh's schedule_arm WSL branch comment). HIMMEL-1475:
+# the same unset also drops ARM_RESUME_SAFETY_ARM so a resumed in-distro session
+# does not inherit a leaked long-gap exemption.
+assert_contains "T-wsl body has in-distro cd+unset+claude" "cd '$WSL_CWD' && unset ARMAUTOMERGE CR_MERGE_GATE_OK ARM_RESUME_SAFETY_ARM && claude" "$out"
 assert_not_contains "T-wsl no caret escapes inside CMD quotes" '^&' "$out"
 assert_contains "T-wsl prompt precedes channels" "'load $WSL_HO overnight mode' --channels 'plugin:test@local'" "$out"
 assert_not_contains "T-wsl body drops Windows cd" "cd /d" "$out"

--- a/scripts/hooks/auto-arm-on-cap.sh
+++ b/scripts/hooks/auto-arm-on-cap.sh
@@ -517,12 +517,16 @@ PY
     # --dedup-any (HIMMEL-340): this is a machine-wide SAFETY arm, not a
     # per-handover work arm — it must defer to ANY queued resume so a wedged
     # cache across concurrent sessions can never fan out duplicate relaunches.
+    # ARM_RESUME_SAFETY_ARM=1 (HIMMEL-1475): the env var is the guard-exemption
+    # signal (a multi-hour cap-reset park is this arm's whole point), set in
+    # the child env. --dedup-any stays dedup-scope only — it is a public flag
+    # any caller can add, so it must NOT bypass the long-gap guard.
     # HIMMEL-1382: automerge is per-arm opt-in — this automatic re-arm never
     # forwards --automerge, by design (fail-closed policy: a cap re-arm is
     # not the arm that asked). arm-resume.sh's own always-clear-first fix
     # backstops this even if the ambient env carried a grant.
     warn "automerge grant NOT carried across automatic re-arm (per-arm opt-in, HIMMEL-1382)"
-    arm_out=$(bash "$ARM_BIN" --dedup-any --time "$slot_hhmm" --handover "$snapshot" 2>&1)
+    arm_out=$(ARM_RESUME_SAFETY_ARM=1 bash "$ARM_BIN" --dedup-any --time "$slot_hhmm" --handover "$snapshot" 2>&1)
     arm_rc=$?
     set -e
     case "$arm_rc" in
@@ -806,12 +810,17 @@ set +e
 # safety arm must defer to ANY queued resume (operator/supervisor/sibling
 # session) so concurrent sessions hitting the cap never double-book the
 # scheduler. Per-handover multislot is for explicit work arms, not this.
+# ARM_RESUME_SAFETY_ARM=1 (HIMMEL-1475): the env var is the guard-exemption
+# signal (--time smart is exempt anyway, but the explicit-HH:MM stale-cache
+# escalation path above sets it too; set here for parity + so a future
+# change to a far explicit HH:MM stays exempt). --dedup-any stays dedup-scope
+# only — a public flag any caller can add must NOT bypass the long-gap guard.
 # HIMMEL-1382: automerge is per-arm opt-in — this automatic re-arm never
 # forwards --automerge, by design (fail-closed policy: a cap re-arm is not
 # the arm that asked). arm-resume.sh's own always-clear-first fix backstops
 # this even if the ambient env carried a grant.
 warn "automerge grant NOT carried across automatic re-arm (per-arm opt-in, HIMMEL-1382)"
-arm_out=$(bash "$ARM_BIN" --dedup-any --time smart --handover "$snapshot" 2>&1)
+arm_out=$(ARM_RESUME_SAFETY_ARM=1 bash "$ARM_BIN" --dedup-any --time smart --handover "$snapshot" 2>&1)
 arm_rc=$?
 set -e
 

--- a/scripts/hooks/check-commit-msg.ps1
+++ b/scripts/hooks/check-commit-msg.ps1
@@ -13,32 +13,128 @@ if (-not $CommitMsgFile -or -not (Test-Path $CommitMsgFile)) {
 
 $msg = Get-Content $CommitMsgFile -Raw
 
-# Skip merge commits
-$gitDir = git rev-parse --git-dir 2>$null
-if (Test-Path (Join-Path $gitDir "MERGE_HEAD")) { exit 0 }
+function Import-TicketConfig {
+    $commonDir = & git rev-parse --git-common-dir 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $commonDir) { return }
+    if (-not [System.IO.Path]::IsPathRooted($commonDir)) {
+        $commonDir = Join-Path (Get-Location) $commonDir
+    }
+    $root = [System.IO.Path]::GetFullPath((Join-Path $commonDir '..'))
+    $envFile = Join-Path $root '.env'
+    if (-not (Test-Path -LiteralPath $envFile)) { return }
 
-# Skip fixup/squash/revert
-$firstLine = ($msg -split "`n")[0]
-if ($firstLine -match '^(fixup!|squash!|revert!|Revert|Merge)') { exit 0 }
+    $wanted = @('TICKET_ID_REQUIRED','TICKET_ID_PATTERN','TICKET_ID_EXEMPT_AUTHORS','JIRA_PROJECT_KEY')
+    foreach ($line in Get-Content -LiteralPath $envFile) {
+        $trimmed = $line.Trim().TrimEnd("`r")
+        if (-not $trimmed -or $trimmed.StartsWith('#') -or -not $trimmed.Contains('=')) { continue }
+        $separator = $trimmed.IndexOf('=')
+        $key = $trimmed.Substring(0, $separator).Trim()
+        if ($wanted -notcontains $key) { continue }
+        if ([string]::IsNullOrEmpty([System.Environment]::GetEnvironmentVariable($key, 'Process'))) {
+            $value = $trimmed.Substring($separator + 1).Trim()
+            [System.Environment]::SetEnvironmentVariable($key, $value, 'Process')
+        }
+    }
+}
+
+Import-TicketConfig
+
+# Skip real merge commits. MERGE_HEAD exists while Git is composing the commit.
+$mergeHead = & git rev-parse -q --verify MERGE_HEAD 2>$null
+if ($LASTEXITCODE -eq 0 -and $mergeHead) { exit 0 }
+
+$firstLine = (($msg -split "`n")[0]).TrimEnd("`r")
+
+# Git-generated revert commits are exempt from both checks. fixup/squash retain
+# their generated shape, but strict mode still requires the referenced ticket.
+# HIMMEL-1483 CR1: the reverted hash must resolve to a real commit object
+# (git cat-file -e <hash>^{commit}); a revert-shaped MESSAGE alone is not
+# enough, or a hand-typed revert with a fabricated hash bypasses both checks.
+# On resolution failure fall through to normal validation.
+$generatedRevert = $false
+if ($firstLine -match '^Revert ".+"$') {
+    if ($msg -match '(?m)^This reverts commit (?<hash>[0-9a-fA-F]{40}|[0-9a-fA-F]{64})\.$') {
+        $revertedHash = $Matches['hash']
+        & git cat-file -e "$revertedHash^{commit}" 2>$null
+        if ($LASTEXITCODE -eq 0) { $generatedRevert = $true }
+    }
+}
+if ($generatedRevert) { exit 0 }
+$skipConventional = $firstLine -match '^(fixup!|squash!)'
+
+# Skip empty or comment-only messages.
+$meaningful = ($msg -split "`r?`n") | Where-Object { $_ -notmatch '^#' -and $_ -match '\S' }
+if (-not $meaningful) { exit 0 }
 
 # Validate conventional commit
-$pattern = '^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?!?:\s+(HIMMEL-\d+\s+)?\S.+'
-if ($firstLine -notmatch $pattern) {
+$pattern = '^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?!?:\s+\S.+'
+if (-not $skipConventional -and $firstLine -notmatch $pattern) {
     Write-Host ""
     Write-Host "COMMIT REJECTED: message does not match conventional commit format."
     Write-Host ""
     Write-Host "  Required:  type(scope): message"
-    Write-Host "  Optional:  type(scope): HIMMEL-N message"
+    Write-Host "  Ticket:    required only when TICKET_ID_REQUIRED=1"
     Write-Host ""
     Write-Host "  Types: feat fix chore docs refactor test style perf ci build revert"
     Write-Host ""
     Write-Host "  Examples:"
     Write-Host "    feat(auth): add JWT validation"
-    Write-Host "    fix(api): HIMMEL-23 correct status code on 404"
+    Write-Host "    fix(api): PROJECT-23 correct status code on 404"
     Write-Host "    chore: update dependencies"
     Write-Host ""
     Write-Host "  Got: $firstLine"
     Write-Host ""
+    exit 1
+}
+
+$requiredValue = if ($env:TICKET_ID_REQUIRED) { $env:TICKET_ID_REQUIRED } else { '0' }
+switch -Regex ($requiredValue) {
+    '^(|0|false|off|no)$' { exit 0 }
+    '^(1|true|on|yes)$'   { break }
+    default {
+        Write-Error "COMMIT REJECTED: invalid TICKET_ID_REQUIRED='$requiredValue'. Use 1/true/on/yes or 0/false/off/no."
+        exit 1
+    }
+}
+
+$authorName = $env:TICKET_ID_AUTHOR
+if (-not $authorName) { $authorName = $env:GIT_AUTHOR_NAME }
+if (-not $authorName) {
+    $authorIdent = & git var GIT_AUTHOR_IDENT 2>$null
+    if ($authorIdent -match '^(.*?)\s+<') { $authorName = $Matches[1] }
+}
+$exemptAuthors = if ($env:TICKET_ID_EXEMPT_AUTHORS) { $env:TICKET_ID_EXEMPT_AUTHORS } else { 'dependabot[bot],dependabot' }
+$trustedAuthor = [System.Environment]::GetEnvironmentVariable('TICKET_ID_TRUSTED_AUTHOR', 'Process')
+$trustedAuthorSet = $null -ne $trustedAuthor
+$authorExempt = $false
+$trustedAuthorExempt = $false
+foreach ($exemptAuthor in ($exemptAuthors -split ',')) {
+    $candidate = $exemptAuthor.Trim()
+    if ($candidate -and $candidate.Equals($authorName, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $authorExempt = $true
+    }
+    if ($candidate -and $trustedAuthor -and $candidate.Equals($trustedAuthor, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $trustedAuthorExempt = $true
+    }
+}
+if ($authorExempt -and (-not $trustedAuthorSet -or $trustedAuthorExempt)) { exit 0 }
+
+$ticketPattern = $env:TICKET_ID_PATTERN
+if (-not $ticketPattern -and $env:JIRA_PROJECT_KEY) {
+    $ticketPattern = [regex]::Escape($env:JIRA_PROJECT_KEY) + '-\d+'
+}
+if (-not $ticketPattern) {
+    Write-Error "COMMIT REJECTED: TICKET_ID_REQUIRED=1 but no ticket pattern is configured.`n  Set JIRA_PROJECT_KEY (for PROJECT-N) or TICKET_ID_PATTERN (for another ticket system)."
+    exit 1
+}
+
+try {
+    if ($msg -notmatch $ticketPattern) {
+        Write-Error "COMMIT REJECTED: TICKET_ID_REQUIRED=1 but no ticket reference matched: $ticketPattern`n  Merge commits, revert commits, and TICKET_ID_EXEMPT_AUTHORS are exempt."
+        exit 1
+    }
+} catch {
+    Write-Error "COMMIT REJECTED: invalid TICKET_ID_PATTERN regex: $ticketPattern"
     exit 1
 }
 

--- a/scripts/hooks/check-commit-msg.sh
+++ b/scripts/hooks/check-commit-msg.sh
@@ -1,52 +1,139 @@
 #!/usr/bin/env bash
 # Validates commit message format.
 # Required: conventional commit  type[(scope)]: message
-# Optional: HIMMEL-N ticket ID after the colon+space
-# Skips:    merge commits, fixup/squash commits, revert commits
+# Strict mode (TICKET_ID_REQUIRED=1): message must reference the configured ticket.
+# Skips: merge commits and revert commits. fixup/squash skip only the shape check.
 
 COMMIT_MSG_FILE="${1}"
 COMMIT_MSG=$(cat "${COMMIT_MSG_FILE}")
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Skip merge commits
-if [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
+# Load ticket configuration from the primary checkout's .env. Live env wins.
+# shellcheck source=../lib/load-dotenv.sh
+# shellcheck disable=SC1091
+if . "$SCRIPT_DIR/../lib/load-dotenv.sh" 2>/dev/null; then
+  load_dotenv TICKET_ID_REQUIRED TICKET_ID_PATTERN TICKET_ID_EXEMPT_AUTHORS JIRA_PROJECT_KEY || true
+fi
+
+# Skip real merge commits. MERGE_HEAD exists while Git is composing the commit.
+if git rev-parse -q --verify MERGE_HEAD >/dev/null 2>&1; then
   exit 0
 fi
 
-# Skip fixup/squash/revert generated messages
-case "${COMMIT_MSG}" in
-  fixup!*|squash!*|revert!*|Revert*|Merge*)
-    exit 0
-    ;;
+FIRST_LINE=$(printf '%s\n' "${COMMIT_MSG}" | head -1)
+
+# Git-generated revert commits are exempt from both checks. fixup/squash retain
+# their generated shape, but strict mode still requires the referenced ticket.
+# HIMMEL-1483 CR1: the reverted hash must resolve to a real commit object
+# (git cat-file -e <hash>^{commit}); a revert-shaped MESSAGE alone is not
+# enough, or a hand-typed revert with a fabricated hash bypasses both the
+# conventional-format and the strict ticket check. On resolution failure fall
+# through to normal validation — never hard-reject on resolution alone (a
+# genuine revert under shallow history still deserves a verdict, not an opaque
+# deny).
+if printf '%s\n' "${FIRST_LINE}" | grep -Eq '^Revert ".+"$'; then
+  REVERT_LINE=$(printf '%s\n' "${COMMIT_MSG}" | grep -E '^This reverts commit ([0-9a-fA-F]{40}|[0-9a-fA-F]{64})\.$' | head -1)
+  if [ -n "${REVERT_LINE}" ]; then
+    REVERTED_HASH="${REVERT_LINE#This reverts commit }"
+    REVERTED_HASH="${REVERTED_HASH%.}"
+    if git cat-file -e "${REVERTED_HASH}^{commit}" >/dev/null 2>&1; then
+      exit 0
+    fi
+  fi
+fi
+case "${FIRST_LINE}" in
+  fixup!*|squash!*) SKIP_CONVENTIONAL=1 ;;
+  *) SKIP_CONVENTIONAL=0 ;;
 esac
 
 # Skip empty or comment-only messages
-STRIPPED=$(echo "${COMMIT_MSG}" | sed '/^#/d' | sed '/^[[:space:]]*$/d')
+STRIPPED=$(printf '%s\n' "${COMMIT_MSG}" | sed '/^#/d' | sed '/^[[:space:]]*$/d')
 if [ -z "${STRIPPED}" ]; then
   exit 0
 fi
 
-FIRST_LINE=$(echo "${COMMIT_MSG}" | head -1)
-
-# Pattern: type[(scope)][!]: [HIMMEL-N ]message
+# Pattern: type[(scope)][!]: message
 # type: feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert
-CONVENTIONAL_RE='^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?!?:[[:space:]]+(HIMMEL-[0-9]+[[:space:]]+)?[^[:space:]].+'
+CONVENTIONAL_RE='^(feat|fix|chore|docs|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?!?:[[:space:]]+[^[:space:]].+'
 
-if ! echo "${FIRST_LINE}" | grep -Eq "${CONVENTIONAL_RE}"; then
+if [ "${SKIP_CONVENTIONAL}" -eq 0 ] && ! printf '%s\n' "${FIRST_LINE}" | grep -Eq "${CONVENTIONAL_RE}"; then
   echo ""
   echo "COMMIT REJECTED: message does not match conventional commit format."
   echo ""
   echo "  Required:  type(scope): message"
-  echo "  Optional:  type(scope): HIMMEL-N message"
+  echo "  Ticket:    required only when TICKET_ID_REQUIRED=1"
   echo ""
   echo "  Types: feat fix chore docs refactor test style perf ci build revert"
   echo ""
   echo "  Examples:"
   echo "    feat(auth): add JWT validation"
-  echo "    fix(api): HIMMEL-23 correct status code on 404"
+  echo "    fix(api): PROJECT-23 correct status code on 404"
   echo "    chore: update dependencies"
   echo ""
   echo "  Got: ${FIRST_LINE}"
   echo ""
+  exit 1
+fi
+
+case "${TICKET_ID_REQUIRED:-0}" in
+  ''|0|false|FALSE|off|OFF|no|NO) exit 0 ;;
+  1|true|TRUE|on|ON|yes|YES) ;;
+  *)
+    echo "COMMIT REJECTED: invalid TICKET_ID_REQUIRED='${TICKET_ID_REQUIRED}'. Use 1/true/on/yes or 0/false/off/no." >&2
+    exit 1
+    ;;
+esac
+
+AUTHOR_NAME="${TICKET_ID_AUTHOR:-${GIT_AUTHOR_NAME:-}}"
+if [ -z "${AUTHOR_NAME}" ]; then
+  AUTHOR_IDENT=$(git var GIT_AUTHOR_IDENT 2>/dev/null || true)
+  AUTHOR_NAME=${AUTHOR_IDENT%% <*}
+fi
+EXEMPT_AUTHORS="${TICKET_ID_EXEMPT_AUTHORS:-dependabot[bot],dependabot}"
+AUTHOR_EXEMPT=0
+TRUSTED_AUTHOR_EXEMPT=0
+OLD_IFS=$IFS
+IFS=','
+# HIMMEL-1483 CR2: the unquoted expansion below is deliberate (field split on
+# IFS) but must not ALSO pathname-expand — `dependabot[bot]` is a glob, and a
+# file like `dependabotb` in the repo root would replace it and silently break
+# the exemption. Globbing off for the split, restored right after.
+set -f
+for EXEMPT_AUTHOR in $EXEMPT_AUTHORS; do
+  EXEMPT_AUTHOR=$(printf '%s' "$EXEMPT_AUTHOR" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  if [ -n "$EXEMPT_AUTHOR" ] && [ "$(printf '%s' "$AUTHOR_NAME" | tr '[:upper:]' '[:lower:]')" = "$(printf '%s' "$EXEMPT_AUTHOR" | tr '[:upper:]' '[:lower:]')" ]; then
+    AUTHOR_EXEMPT=1
+  fi
+  if [ -n "$EXEMPT_AUTHOR" ] && [ -n "${TICKET_ID_TRUSTED_AUTHOR:-}" ] && [ "$(printf '%s' "$TICKET_ID_TRUSTED_AUTHOR" | tr '[:upper:]' '[:lower:]')" = "$(printf '%s' "$EXEMPT_AUTHOR" | tr '[:upper:]' '[:lower:]')" ]; then
+    TRUSTED_AUTHOR_EXEMPT=1
+  fi
+done
+set +f
+IFS=$OLD_IFS
+if [ "$AUTHOR_EXEMPT" -eq 1 ] && { [ -z "${TICKET_ID_TRUSTED_AUTHOR+x}" ] || [ "$TRUSTED_AUTHOR_EXEMPT" -eq 1 ]; }; then
+  exit 0
+fi
+
+TICKET_PATTERN="${TICKET_ID_PATTERN:-}"
+if [ -z "${TICKET_PATTERN}" ] && [ -n "${JIRA_PROJECT_KEY:-}" ]; then
+  ESCAPED_PROJECT_KEY=$(printf '%s' "${JIRA_PROJECT_KEY}" | sed 's/[][\\.^$*+?(){}|]/\\&/g')
+  TICKET_PATTERN="${ESCAPED_PROJECT_KEY}-[0-9]+"
+fi
+if [ -z "${TICKET_PATTERN}" ]; then
+  echo "COMMIT REJECTED: TICKET_ID_REQUIRED=1 but no ticket pattern is configured." >&2
+  echo "  Set JIRA_PROJECT_KEY (for PROJECT-N) or TICKET_ID_PATTERN (for another ticket system)." >&2
+  exit 1
+fi
+
+printf '%s\n' "${COMMIT_MSG}" | grep -Eq "${TICKET_PATTERN}"
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  if [ "$rc" -eq 2 ]; then
+    echo "COMMIT REJECTED: invalid TICKET_ID_PATTERN regex: ${TICKET_PATTERN}" >&2
+  else
+    echo "COMMIT REJECTED: TICKET_ID_REQUIRED=1 but no ticket reference matched: ${TICKET_PATTERN}" >&2
+    echo "  Merge commits, revert commits, and TICKET_ID_EXEMPT_AUTHORS are exempt." >&2
+  fi
   exit 1
 fi
 

--- a/scripts/hooks/guardrail-block.mjs
+++ b/scripts/hooks/guardrail-block.mjs
@@ -424,6 +424,243 @@ function resolveCommonDir(gitDir) {
   }
 }
 
+// HIMMEL-1472 (R4): the authoritative object-format width is the repository's
+// CONFIGURED format, NOT the HEAD/ref oid's own length. A crafted/corrupt DB in
+// a DEFAULT (sha1) repo whose HEAD ref carries a 64-hex oid with a fully
+// self-consistent sha256 commit→tree→blob chain passes every r3 width+rehash
+// check (the HEAD oid pinned width 32 and the foreign chain agreed) while git
+// itself rejects the repo (extensions.objectFormat says sha1); the mirror holds
+// for a configured sha256 repo with a 40-hex chain. Read the common dir's
+// config for [extensions] objectFormat and return the byte width it implies:
+// sha256 → 32, absent/sha1 → 20 (git's default). Fail CLOSED on a present-but-
+// unreadable config or an unrecognized value — degrade, never guess the width.
+// A MISSING config file is the healthy default (no objectFormat override → sha1),
+// matching git; any OTHER read error (permissions/I/O on a present file) degrades.
+//
+// HIMMEL-1472 (R5): apply git's FULL repository-format validation, not just the
+// objectFormat value. R4 read objectFormat and derived a width but skipped the
+// rules git uses to ACCEPT that config, so configs git REFUSES still yielded a
+// width and a healthy attestation: objectFormat=sha256 with
+// core.repositoryformatversion 0 (git: "repo version is 0, but v1-only extension
+// found"), repositoryformatversion > 1 (git: "Expected git repo version <= 1"),
+// an unknown extensions.* key (git: "unknown repository extension found"), or a
+// valueless objectFormat (git: "invalid value for 'extensions.objectformat'").
+// Mirror git's documented rule set and degrade on every config git itself rejects.
+// git's documented extension keys (Documentation/technical/repository-version.txt
+// + setup.c): the extensions.* keys git HONORS at repositoryformatversion >= 1. A
+// key outside this set is one git refuses outright ("unknown repository extension
+// found"), so attesting integrity against it would diverge from git. Keep this in
+// sync with git's current known set.
+const KNOWN_GIT_EXTENSIONS = new Set([
+  'objectformat',
+  'refstorage',
+  'worktreeconfig',
+  'preciousobjects',
+  'partialclone',
+  'compatobjectformat',
+]);
+
+// HIMMEL-1472 (R6): a known KEY is necessary but not sufficient — git also
+// validates each extension's VALUE and refuses the repo on a bad one ("invalid
+// value for 'extensions.<name>'"). R5 only checked the key set, so e.g.
+// refStorage=bogus attested healthy against a config git rejects. Mirror git's
+// accepted value sets: refStorage / compatObjectFormat take git's lowercase
+// canonical tokens (case-SENSITIVE, like git); worktreeConfig / preciousObjects
+// are git booleans (the literals below, case-INsensitive; a BARE key parses as
+// true); partialClone is any non-empty remote name. objectFormat is validated
+// by the width derivation below, not this table. A value outside its key's set
+// degrades — never attest against a config git refuses.
+const GIT_EXTENSION_VALUES = {
+  refstorage: ['files', 'reftable'],
+  compatobjectformat: ['sha1', 'sha256'],
+  worktreeconfig: 'bool',
+  preciousobjects: 'bool',
+  partialclone: 'nonempty',
+};
+// git config_bool accepts exactly these literals (case-insensitive). A bare
+// valueless variable (no `=`) is boolean true to git — the parse loop maps that
+// to 'true' before this table sees it.
+const GIT_BOOL_LITERALS = new Set(['true', 'false', 'yes', 'no', 'on', 'off', '1', '0']);
+// true iff `raw` is a value git accepts for extension `key`. objectFormat (and
+// any unconstrained key) is unconstrained here — objectFormat is normalized to
+// {sha1,sha256} by the width derivation.
+function validExtensionValue(key, raw) {
+  const spec = GIT_EXTENSION_VALUES[key];
+  if (!spec) return true;
+  const v = raw.trim().replace(/^"|"$/g, '');
+  if (spec === 'bool') return GIT_BOOL_LITERALS.has(v.toLowerCase());
+  if (spec === 'nonempty') return v.length > 0;
+  return spec.includes(v); // case-sensitive canonical token
+}
+// HIMMEL-1472 (R9): a STRICT value whitelist for the kv grammar. git's config
+// value grammar is broad (escapes, line continuations, mid-value comment
+// starts, ...) and chasing it exactly is a bottomless source of "looser than
+// git" findings. The invariant needs only one direction — never attest against
+// a config git REFUSES — so accept only the conservative shape every real
+// default config satisfies and degrade on EVERYTHING else. Two shapes pass:
+//   - bare value: no `"`, no `\`, no `;`/`#` (git reads ; and # as comment
+//     starts only outside quotes; rather than model that, refuse them), OR
+//   - fully quoted: optional surrounding whitespace then `"..."` with no `\`
+//     and no `"` inside.
+// Anything else — unbalanced/embedded quotes, any backslash (escapes and line
+// continuations), trailing garbage after a closing quote — fails. This is
+// fail-closed: a value git would ACCEPT but this refuses is safe (the
+// guardrail reports width-unavailable and degrades gracefully). `v` is the raw
+// text captured after `key =` (leading whitespace already consumed by the kv
+// regex).
+function valueIsWellFormed(v) {
+  if (!v.includes('"') && !v.includes('\\') && !v.includes(';') && !v.includes('#')) return true;
+  return /^\s*"[^"\\]*"\s*$/.test(v);
+}
+function configuredObjectByteWidth(commonDir) {
+  let text;
+  try {
+    text = fs.readFileSync(path.join(commonDir, 'config'), 'utf8');
+  } catch (e) {
+    return e.code === 'ENOENT' ? 20 : null;
+  }
+  let section = null; // bare section in scope, or null (outside / subsectioned)
+  let version = 0; // core.repositoryformatversion — git's default is 0
+  let versionMalformed = false;
+  let malformed = false; // a [core]/[extensions] line git's parser would reject
+  const extensions = new Map(); // [extensions] keys (lowercased) → raw value
+  // HIMMEL-1472 (R9) — CLOSURE RULE for the config-grammar class. This parser
+  // accepts ONLY the strict subset below (headers, key grammar, and the value
+  // whitelist in valueIsWellFormed); every shape outside it degrades. The
+  // invariant is one-directional: NEVER attest a width against a config git
+  // REFUSES. Degrading on a config git would ACCEPT is safe and by-design (the
+  // fallback reports width-unavailable; the guardrail degrades gracefully).
+  // So a future "parser is looser than git" finding must demonstrate a config
+  // this WHITELIST ACCEPTS while git REJECTS it (a fail-open); "git accepts but
+  // we degrade" is fail-closed and OUT OF SCOPE — that sentence is the decline
+  // template for future re-raises.
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#') || line.startsWith(';')) continue;
+    const sec = line.match(/^\[([^\]]*)\]$/);
+    if (sec) {
+      // HIMMEL-1472 (R8): mirror git's config header grammar (Documentation/config.txt).
+      // Git accepts exactly two header forms — a bare `[name]` (name = alnum, `-`,
+      // `.`) or a subsection `[name "sub"]` (whitespace then a DOUBLE-QUOTED
+      // subsection, escapes \\ and \"). A header that looks like one but matches
+      // neither (e.g. an unquoted second word like `[bad section]`) makes git reject
+      // the whole file ("bad config line"), so degrade rather than silently scope it
+      // out and attest a width against a config git refuses.
+      const bareHeader = sec[1].match(/^([A-Za-z0-9.-]+)$/);
+      const subHeader = sec[1].match(/^([A-Za-z0-9.-]+)[ \t]+"((?:[^"\\\n]|\\.)*)"$/);
+      if (bareHeader) {
+        // HIMMEL-1472 (R11): the bare-header grammar admits dots, so git's legacy
+        // dotted subsection syntax `[name.sub]` lands here too. Git reads those keys
+        // as `<name>.<sub>.*`; for `[extensions.x]` that is `extensions.x.*`, which
+        // git refuses as an unknown extension at repositoryformatversion >= 1 — a
+        // config this whitelist ACCEPTS while git REJECTS it (the R9 closure rule's
+        // own fail-open), so degrade rather than silently scope it out and attest.
+        // Dotted `[core.x]` (and any other dotted section) is consistently IGNORED
+        // by both git's repo-format validation and this parser — extensions.* is the
+        // only divergence, so this guard is extensions-only. Case-insensitive (match
+        // lowercased); covers `[extensions.x]`, `[EXTENSIONS.X]`, `[extensions.]`.
+        const name = bareHeader[1].toLowerCase();
+        if (name.startsWith('extensions.')) malformed = true;
+        else section = name;
+      } else if (subHeader) {
+        // HIMMEL-1472 (R10): git reads `[extensions "x"]` keys as `extensions.x.*` and
+        // refuses them as unknown extensions at repositoryformatversion >= 1; at v0 any
+        // extension present is already a degrade. No real repo carries subsectioned
+        // extensions — degrade, never attest. `[core "x"]` and other subsections stay
+        // scoped out (they play no part in repo-format validation). Section names are
+        // case-insensitive in git config, so compare lowercased.
+        if (subHeader[1].toLowerCase() === 'extensions') malformed = true;
+        else section = null; // a subsectioned header (e.g. [remote "origin"]) is not the bare scope
+      } else {
+        malformed = true;
+      }
+      continue;
+    }
+    // git rejects the ENTIRE config file on a line its parser can't read, in
+    // ANY section ("bad config line N in file .git/config") — so shape-validate
+    // every line; only the SEMANTIC capture below is scoped to the bare
+    // [core]/[extensions] sections.
+    // HIMMEL-1472 (R8): a git variable name starts with a letter and allows only
+    // alnum + `-` (no leading digit/dot, no embedded dot). The key patterns below
+    // use that grammar so a key git rejects (9key, .key, key.sub) degrades instead
+    // of attesting against a config git refuses.
+    if (!section) {
+      // Subsectioned (e.g. [remote "origin"]) or pre-section scope: a kv or
+      // bare line is fine here in SHAPE; the VALUE is still whitelist-checked
+      // (R9) so a value git refuses degrades even out of scope, and anything
+      // else still chokes git's parser.
+      const oosKv = line.match(/^([A-Za-z][A-Za-z0-9-]*)\s*=\s*(.*)$/);
+      if (oosKv) {
+        if (!valueIsWellFormed(oosKv[2])) malformed = true;
+      } else if (!/^[A-Za-z][A-Za-z0-9-]*$/.test(line)) {
+        malformed = true;
+      }
+      continue;
+    }
+    const kv = line.match(/^([A-Za-z][A-Za-z0-9-]*)\s*=\s*(.*)$/);
+    if (kv) {
+      const key = kv[1].toLowerCase();
+      // R9: whitelist the value shape before any semantic capture, so a value
+      // git refuses (unclosed quote, escape, trailing garbage) degrades even
+      // under [core]/[extensions], where R6 only validated known extension keys.
+      if (!valueIsWellFormed(kv[2])) {
+        malformed = true;
+        continue;
+      }
+      if (section === 'core' && key === 'repositoryformatversion') {
+        const v = kv[2].trim();
+        if (/^\d+$/.test(v)) version = Number(v);
+        else versionMalformed = true;
+      } else if (section === 'extensions') {
+        // Capture every extensions.* key so an unknown one degrades below — git
+        // refuses an unknown extension outright at repositoryformatversion >= 1.
+        extensions.set(key, kv[2]);
+      }
+      continue;
+    }
+    // BARE key (no `=`): git parses a valueless variable as boolean true. For an
+    // extensions.* key this is its =true form — a known boolean extension stays
+    // valid (validated below); an unknown one still degrades on the key check.
+    // R9: under [core], a valueless `repositoryformatversion` is a key git reads
+    // as an integer — a valueless int key is one git rejects, so degrade.
+    const bare = line.match(/^([A-Za-z][A-Za-z0-9-]*)$/);
+    if (bare) {
+      const bkey = bare[1].toLowerCase();
+      if (section === 'extensions') extensions.set(bkey, 'true');
+      else if (section === 'core' && bkey === 'repositoryformatversion') versionMalformed = true;
+      continue;
+    }
+    // Neither `key = value` nor a bare `key`: a config line git would choke on.
+    malformed = true;
+  }
+  if (malformed) return null; // a line git's parser rejects, anywhere in the file
+  if (versionMalformed) return null; // non-numeric repositoryformatversion → degrade
+  if (version > 1) return null; // git: "Expected git repo version <= 1"
+  // Extensions are honored ONLY at repositoryformatversion >= 1. Any extension
+  // present at version 0 is malformed (a real repo is v0 with NO extensions, or
+  // v1+ WITH them); git refuses known v1-only extensions here ("repo version is
+  // 0, but v1-only extension found"). Degrade fail-closed rather than guess.
+  if (version === 0) return extensions.size > 0 ? null : 20;
+  // version === 1: extensions honored, but every key must be one git recognizes —
+  // an unknown one makes git refuse the repo outright.
+  for (const key of extensions.keys()) {
+    if (!KNOWN_GIT_EXTENSIONS.has(key)) return null;
+  }
+  // git also constrains each extension's VALUE — a value it refuses ("invalid
+  // value for 'extensions.<name>'") makes it refuse the repo, so degrade.
+  for (const [key, raw] of extensions) {
+    if (!validExtensionValue(key, raw)) return null;
+  }
+  if (!extensions.has('objectformat')) return 20; // no override → git default sha1
+  // git config values may be quoted; strip one layer. Lowercased because the
+  // only canonical forms are sha1/sha256 — anything else (incl. a valueless
+  // entry) degrades.
+  const objectFormat = extensions.get('objectformat').trim().replace(/^"|"$/g, '').toLowerCase();
+  if (objectFormat === 'sha256') return 32;
+  if (objectFormat === 'sha1') return 20;
+  return null; // unrecognized / valueless objectFormat → degrade, never guess
+}
+
 // The ref/HEAD OID predicates accept 40-hex (sha1) OR 64-hex (sha256), matching
 // readObject via hashAlgoForOid (HIMMEL-1468): the fallback ref/HEAD parser
 // hardcoded-tested only {40}, so a sha256 repo (objectFormat=sha256) degraded to
@@ -467,7 +704,11 @@ export function readHeadOid(gitDir, commonDir) {
 }
 
 function readLooseObject(commonDir, oid) {
-  if (!/^[0-9a-f]{40}$/.test(oid)) return null;
+  // HIMMEL-1472: accept sha1 (40-hex) OR sha256 (64-hex) oids, keyed by
+  // hashAlgoForOid (matching readObject's rehash chokepoint) — a sha256 repo's
+  // loose objects live at objects/<2>/<62>, which the prior {40}-only guard
+  // rejected, dead-ending the fallback one layer below readHeadOid's fix.
+  if (!hashAlgoForOid(oid)) return null;
   const objectPath = path.join(commonDir, 'objects', oid.slice(0, 2), oid.slice(2));
   let inflated;
   try {
@@ -505,8 +746,9 @@ const PACK_IDX_MAGIC = [0xff, 0x74, 0x4f, 0x63]; // "\377tOc"
 const PACK_TYPE_NAMES = { 1: 'commit', 2: 'tree', 3: 'blob', 4: 'tag' };
 
 // Returns the oid's byte offset into its .pack, or null if the oid is absent.
-// A v2 idx is header(8) + fanout(256*4) + oid(total*20) + crc(total*4) +
-// offset(total*4) [+ large-offset] tables. A truncated/crafted idx can
+// A v2 idx is header(8) + fanout(256*4) + oid(total*<width>) + crc(total*4) +
+// offset(total*4) [+ large-offset] tables — <width> is 20 (sha1) or 32 (sha256),
+// keyed by the requested oid's format (HIMMEL-1472). A truncated/crafted idx can
 // advertise a fanout total or large-offset index that points past idx.length,
 // and the Buffer.compare/readUint32BE calls below then THROW ERR_OUT_OF_RANGE —
 // uncaught, that crashes status --json instead of returning
@@ -517,18 +759,23 @@ export function findPackOffset(idx, oidHex) {
   if (idx.length < 1032) return null; // header(8) + fanout(256*4) minimum
   if (idx[0] !== PACK_IDX_MAGIC[0] || idx[1] !== PACK_IDX_MAGIC[1] || idx[2] !== PACK_IDX_MAGIC[2] || idx[3] !== PACK_IDX_MAGIC[3]) return null;
   if (readUint32BE(idx, 4) !== 2) return null; // v2 idx only
+  // HIMMEL-1472: per-entry oid width is keyed by the repo object format — a sha1
+  // idx stores 20-byte oids, a sha256 (objectFormat=sha256) idx stores 32. The
+  // requested oid's hex length names it (oidByteWidth, matching hashAlgoForOid),
+  // so the request and the idx must agree; any other length is no match.
+  const width = oidByteWidth(oidHex);
+  if (!width) return null;
   const fanoutOff = 8;
   const total = readUint32BE(idx, fanoutOff + 255 * 4);
   if (total === 0) return null;
   const oidsOff = fanoutOff + 256 * 4;
-  const crcsOff = oidsOff + total * 20;
+  const crcsOff = oidsOff + total * width;
   const offsOff = crcsOff + total * 4;
   const largeOff = offsOff + total * 4;
   // Require the whole oid+crc+offset table span to fit before touching any of
   // it — an absurd fanout total (e.g. 0xffffffff in a 1032-byte idx) fails here.
   if (largeOff > idx.length) return null;
   const oid = Buffer.from(oidHex, 'hex');
-  if (oid.length !== 20) return null; // malformed hex oid → no match
   const firstByte = oid[0];
   const lo = firstByte === 0 ? 0 : readUint32BE(idx, fanoutOff + (firstByte - 1) * 4);
   const hi = readUint32BE(idx, fanoutOff + firstByte * 4);
@@ -539,7 +786,7 @@ export function findPackOffset(idx, oidHex) {
   let right = hi;
   while (left < right) {
     const mid = (left + right) >>> 1;
-    const cmp = idx.compare(oid, 0, 20, oidsOff + mid * 20, oidsOff + mid * 20 + 20);
+    const cmp = idx.compare(oid, 0, width, oidsOff + mid * width, oidsOff + mid * width + width);
     if (cmp === 0) {
       let off = readUint32BE(idx, offsOff + mid * 4);
       if (off & 0x80000000) {
@@ -668,7 +915,7 @@ export function applyDelta(base, delta) {
 // git itself caps delta depth (pack.depth default 50); 64 matches that posture.
 const MAX_DELTA_DEPTH = 64;
 
-function readPackEntry(commonDir, pack, idx, off, depth = 0, lookup) {
+function readPackEntry(commonDir, pack, idx, off, depth = 0, lookup, oidWidth) {
   if (depth > MAX_DELTA_DEPTH) return null;
   let b = pack[off];
   const type = (b >> 4) & 7;
@@ -696,16 +943,26 @@ function readPackEntry(commonDir, pack, idx, off, depth = 0, lookup) {
     if (!(negOff > 0) || negOff > off) return null; // 0 = self-reference loop; > off = out of range
     let delta;
     try { delta = zlib.inflateSync(pack.subarray(p)); } catch (_e) { return null; }
-    const base = readPackEntry(commonDir, pack, idx, off - negOff, depth + 1, lookup);
+    const base = readPackEntry(commonDir, pack, idx, off - negOff, depth + 1, lookup, oidWidth);
     if (!base) return null;
     const body = applyDelta(base.body, delta);
     return body ? { type: base.type, body } : null;
   }
-  if (type === 7) { // REF_DELTA: base named by the following 20-byte oid
-    const baseOid = pack.subarray(dataStart, dataStart + 20).toString('hex');
+  if (type === 7) { // REF_DELTA: base named by the following oid (20 bytes sha1, 32 sha256)
+    // HIMMEL-1472: the base-oid slice must be sized by the repo hash width, not a
+    // fixed 20. An objectFormat=sha256 pack carries a 32-byte base oid — a fixed
+    // 20 truncated it AND started the inflate 12 bytes inside the oid, so a
+    // sha256 REF_DELTA never resolved. `oidWidth` is derived from the requested
+    // oid (oidByteWidth in readPackedObject) the same way findPackOffset keys
+    // the idx; an unknown width can't size the oid, so degrade (fail-closed).
+    if (!oidWidth) return null;
+    const baseOid = pack.subarray(dataStart, dataStart + oidWidth).toString('hex');
     let delta;
-    try { delta = zlib.inflateSync(pack.subarray(dataStart + 20)); } catch (_e) { return null; }
-    const base = readObject(commonDir, baseOid, depth + 1, lookup); // cycle-checked via lookup.visited
+    try { delta = zlib.inflateSync(pack.subarray(dataStart + oidWidth)); } catch (_e) { return null; }
+    // HIMMEL-1472 (R3): thread the pinned width so a foreign-format REF_DELTA
+    // base (a mixed-format pack) is rejected at the readObject chokepoint rather
+    // than traversed into a false integrity attestation.
+    const base = readObject(commonDir, baseOid, depth + 1, lookup, oidWidth); // cycle-checked via lookup.visited
     if (!base) return null;
     const body = applyDelta(base.body, delta);
     return body ? { type: base.type, body } : null;
@@ -716,7 +973,7 @@ function readPackEntry(commonDir, pack, idx, off, depth = 0, lookup) {
   return typeName ? { type: typeName, body } : null;
 }
 
-function readPackedObject(commonDir, oid, depth = 0, lookup) {
+function readPackedObject(commonDir, oid, depth = 0, lookup, oidWidth) {
   let entries;
   try {
     entries = fs.readdirSync(path.join(commonDir, 'objects', 'pack'));
@@ -752,7 +1009,15 @@ function readPackedObject(commonDir, oid, depth = 0, lookup) {
     try {
       const off = findPackOffset(idx, oid);
       if (off === null) continue;
-      return readPackEntry(commonDir, pack, idx, off, depth, lookup);
+      // HIMMEL-1472: findPackOffset matched this oid against the idx, so its
+      // oidByteWidth (20 sha1 / 32 sha256) is the repo's hash width — thread it
+      // into readPackEntry so the REF_DELTA base oid is sized correctly (the same
+      // width source findPackOffset uses for the idx entries). R3: prefer the
+      // pinned width threaded from readObject (the repo's single object format);
+      // absent a pin (direct callers) derive it from the oid — both equal the
+      // oid's own width once readObject has rejected any mismatched request.
+      const width = oidWidth || oidByteWidth(oid);
+      return readPackEntry(commonDir, pack, idx, off, depth, lookup, width);
     } catch (_e) {
       continue;
     }
@@ -766,6 +1031,17 @@ function readPackedObject(commonDir, oid, depth = 0, lookup) {
 function hashAlgoForOid(oid) {
   if (oid.length === 40 && /^[0-9a-f]{40}$/.test(oid)) return 'sha1';
   if (oid.length === 64 && /^[0-9a-f]{64}$/.test(oid)) return 'sha256';
+  return null;
+}
+
+// Byte width of a git object id by its hex length (HIMMEL-1472): the companion
+// to hashAlgoForOid for the raw-byte readers below (pack-idx entries, tree
+// entries) that index oid BYTES rather than pick a hash algorithm — sha1 = 20,
+// sha256 = 32, else not a git oid. Function-declaration hoisting lets the
+// earlier findPackOffset and the findTreeEntry call site use it.
+function oidByteWidth(oid) {
+  if (oid.length === 40 && /^[0-9a-f]{40}$/.test(oid)) return 20;
+  if (oid.length === 64 && /^[0-9a-f]{64}$/.test(oid)) return 32;
   return null;
 }
 
@@ -787,12 +1063,21 @@ function computeGitOid(type, body, algo) {
 // caps it at MAX_DELTA_DEPTH but only after 64 wasted per-level pack
 // re-reads, so a repeat oid in one lookup degrades immediately, and each
 // pack file is read at most once per lookup (CodeRabbit on #1527).
-export function readObject(commonDir, oid, depth = 0, lookup) {
+export function readObject(commonDir, oid, depth = 0, lookup, oidWidth) {
   if (!lookup) lookup = { visited: new Set(), packCache: new Map() };
+  // HIMMEL-1472 (R3): when the caller pins a repo object-format width (threaded
+  // from readHeadBlob's HEAD/ref oid), reject any oid whose own width disagrees.
+  // Git forbids intermixing hash formats in one repository (hash-transition
+  // spec): a crafted/corrupt DB with a 40-hex sha1 commit naming a 64-hex sha256
+  // tree (or the mirror) would otherwise traverse and rehash green where
+  // `git show HEAD:<path>` rejects — a false integrity attestation on the
+  // git-unavailable fallback path. Without a pin (direct unit-test callers) the
+  // per-oid rehash below still self-validates each object.
+  if (oidWidth && oidByteWidth(oid) !== oidWidth) return null;
   if (lookup.visited.has(oid)) return null; // REF_DELTA cycle → degrade, don't loop
   lookup.visited.add(oid);
   const loose = readLooseObject(commonDir, oid);
-  const obj = loose || readPackedObject(commonDir, oid, depth, lookup);
+  const obj = loose || readPackedObject(commonDir, oid, depth, lookup, oidWidth);
   // Recompute the object id and compare to the request (HIMMEL-1427 r10): a
   // crafted/corrupt idx can map oid→offset at the WRONG object, and a tampered
   // loose file can sit at an oid-derived path whose content hashes elsewhere —
@@ -809,25 +1094,46 @@ export function readObject(commonDir, oid, depth = 0, lookup) {
   return obj;
 }
 
-function commitTreeOid(body) {
+function commitTreeOid(body, oidWidth) {
   const lineEnd = body.indexOf(10);
   const firstLine = body.subarray(0, lineEnd < 0 ? body.length : lineEnd).toString('utf8');
-  const match = firstLine.match(/^tree ([0-9a-f]{40})$/);
-  return match ? match[1] : null;
+  // HIMMEL-1472: accept sha1 (40-hex) OR sha256 (64-hex) tree oids, keyed
+  // consistently with hashAlgoForOid — a sha256 repo's commit carries a 64-hex
+  // tree line that the prior {40}-only regex silently dropped.
+  const match = firstLine.match(/^tree ([0-9a-f]{40}|[0-9a-f]{64})$/);
+  if (!match) return null;
+  // HIMMEL-1472 (R3): reject a tree oid whose width disagrees with the repo's
+  // pinned object format (threaded from readHeadBlob's HEAD/ref oid). Git
+  // forbids a sha1 commit naming a sha256 tree (and the mirror); without this a
+  // crafted/corrupt DB traversed into a false integrity attestation on the
+  // git-unavailable fallback path.
+  if (oidWidth && oidByteWidth(match[1]) !== oidWidth) return null;
+  return match[1];
 }
 
-function findTreeEntry(treeBody, name) {
+// HIMMEL-1472: a tree entry is "<mode> <name>\0<oid>" where the oid is 20 bytes
+// (sha1) or 32 (sha256). The nul+<width> advance and oid slice are keyed by
+// `oidWidth` — the tree's own oid width, passed by readHeadBlob's caller (a
+// tree object's entries carry oids of the repo's object format). The prior
+// hardcoded nul+21 walk silently truncated sha256 entry oids to their first 20
+// bytes and advanced past only 21, desynchronizing every subsequent entry.
+function findTreeEntry(treeBody, name, oidWidth) {
+  // HIMMEL-1472 (R3, panel glm-1): an undefined oidWidth made nul+1+oidWidth
+  // NaN, the oid subarray coerce to empty, and the loop index go NaN — silently
+  // wrong instead of null. The pinned width is threaded from readHeadBlob, but
+  // keep an explicit fail-closed guard matching the REF_DELTA arm regardless.
+  if (!oidWidth) return null;
   let i = 0;
   while (i < treeBody.length) {
     const space = treeBody.indexOf(32, i);
     if (space < 0) return null;
     const nul = treeBody.indexOf(0, space + 1);
-    if (nul < 0 || nul + 21 > treeBody.length) return null;
+    if (nul < 0 || nul + 1 + oidWidth > treeBody.length) return null;
     const mode = treeBody.subarray(i, space).toString('utf8');
     const entryName = treeBody.subarray(space + 1, nul).toString('utf8');
-    const oid = treeBody.subarray(nul + 1, nul + 21).toString('hex');
+    const oid = treeBody.subarray(nul + 1, nul + 1 + oidWidth).toString('hex');
     if (entryName === name) return { mode, oid };
-    i = nul + 21;
+    i = nul + 1 + oidWidth;
   }
   return null;
 }
@@ -880,7 +1186,7 @@ function readHeadBlobFromGit(repo, relativePath) {
   }
 }
 
-function readHeadBlob(repo, relativePath) {
+export function readHeadBlob(repo, relativePath) {
   const fromGit = readHeadBlobFromGit(repo, relativePath);
   if (fromGit) return fromGit;
   const gitDir = readGitDir(repo);
@@ -895,18 +1201,34 @@ function readHeadBlob(repo, relativePath) {
   const commonDir = resolveCommonDir(gitDir);
   const headOid = readHeadOid(gitDir, commonDir);
   if (!headOid) return { ok: false, reason: 'reference-unavailable' };
-  const commit = readObject(commonDir, headOid);
+  // HIMMEL-1472 (R4): pin the repo's object-format width from the CONFIGURED
+  // format (extensions.objectFormat in the common dir's config), NOT the HEAD/ref
+  // oid's own length — the HEAD oid is corrupt/attacker-controllable, the config
+  // is git's declared repo format. A crafted/corrupt default (sha1) repo whose
+  // HEAD ref carries a 64-hex oid with a fully self-consistent sha256 chain passes
+  // every r3 width+rehash check (the HEAD oid pinned width 32 and the chain
+  // agreed) while git itself rejects the repo (objectFormat says sha1); the mirror
+  // holds for a configured sha256 repo with a 40-hex chain. Derive the configured
+  // width (fail-closed), REJECT a HEAD oid whose width disagrees, and pin the
+  // CONFIGURED width into the traversal thread (readObject, commitTreeOid, the
+  // tree walk, readPackEntry's REF_DELTA arm) — every oid inside a repo shares its
+  // one object format (hash-transition spec), so a HEAD/oid disagreeing with the
+  // config is corrupt and degrades rather than attests.
+  const oidWidth = configuredObjectByteWidth(commonDir);
+  if (!oidWidth) return { ok: false, reason: 'reference-unavailable' };
+  if (oidByteWidth(headOid) !== oidWidth) return { ok: false, reason: 'reference-unavailable' };
+  const commit = readObject(commonDir, headOid, 0, undefined, oidWidth);
   if (!commit || commit.type !== 'commit') return { ok: false, reason: 'reference-unavailable' };
-  let treeOid = commitTreeOid(commit.body);
+  let treeOid = commitTreeOid(commit.body, oidWidth);
   if (!treeOid) return { ok: false, reason: 'reference-unavailable' };
   const parts = relativePath.split('/');
   for (let i = 0; i < parts.length; i += 1) {
-    const tree = readObject(commonDir, treeOid);
+    const tree = readObject(commonDir, treeOid, 0, undefined, oidWidth);
     if (!tree || tree.type !== 'tree') return { ok: false, reason: 'reference-unavailable' };
-    const entry = findTreeEntry(tree.body, parts[i]);
+    const entry = findTreeEntry(tree.body, parts[i], oidWidth);
     if (!entry) return { ok: false, reason: 'reference-unavailable' };
     if (i === parts.length - 1) {
-      const blob = readObject(commonDir, entry.oid);
+      const blob = readObject(commonDir, entry.oid, 0, undefined, oidWidth);
       if (!blob || blob.type !== 'blob') return { ok: false, reason: 'reference-unavailable' };
       return { ok: true, body: blob.body };
     }

--- a/scripts/hooks/guardrail-block.test.mjs
+++ b/scripts/hooks/guardrail-block.test.mjs
@@ -7,7 +7,7 @@ import { tmpdir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import zlib from 'node:zlib';
-import { install as installStatusData, statusDetail, sanitizedGitEnv, findPackOffset, readObject, applyDelta, readHeadOid } from './guardrail-block.mjs';
+import { install as installStatusData, statusDetail, sanitizedGitEnv, findPackOffset, readObject, readHeadBlob, applyDelta, readHeadOid } from './guardrail-block.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const MODULE = join(HERE, 'guardrail-block.mjs');
@@ -999,6 +999,39 @@ function buildPackedRepo(repo) {
   gitCmd(repo, ['prune-packed']);
 }
 
+// HIMMEL-1472: git must support objectFormat=sha256 (git 2.29+ compiled with
+// sha256) for the sha256 fallback tests. Probes by initting a throwaway sha256
+// repo; the suite skips if git or sha256 is unavailable.
+function sha256GitAvailable() {
+  if (!gitAvailable()) return false;
+  const dir = mkdtempSync(join(tmpdir(), 'gblock-sha256-probe-'));
+  try {
+    execFileSync('git', ['init', '-q', '--object-format=sha256'], { cwd: dir, stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' });
+    return true;
+  } catch (_e) {
+    return false;
+  } finally {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort probe cleanup */ }
+  }
+}
+
+// HIMMEL-1472: builds a REAL sha256 repo (git init --object-format=sha256) whose
+// HEAD tree is scripts/hooks/<files> (the on-disk copies writeRealHookCopies
+// wrote), then optionally repacks so the blobs live ONLY in objects/pack —
+// exercising the fallback's sha256 pack-idx reader (findPackOffset with 32-byte
+// entries) when git is forced off. Local `git repack -ad` emits OFS_DELTA
+// (format-agnostic, already handled), never REF_DELTA, so the pack path needs
+// no further width fix. Requires sha256-capable git (gate on sha256GitAvailable).
+function buildSha256Repo(repo, { repack = false } = {}) {
+  gitCmd(repo, ['init', '-q', '--object-format=sha256']);
+  gitCmd(repo, ['add', 'scripts/hooks']);
+  gitCmd(repo, ['commit', '-q', '-m', 'fixture']);
+  if (repack) {
+    gitCmd(repo, ['repack', '-q', '-a', '-d']);
+    gitCmd(repo, ['prune-packed']);
+  }
+}
+
 test('status --json: module checkout and declared HIMMEL_REPO divergence is surfaced while preserving declared-anchor verdicts', () => {
   const ctx = work();
   writeHookStubs(ctx);
@@ -1641,4 +1674,928 @@ test('readHeadOid: follows ref: to a 64-hex sha256 loose ref and to packed-refs 
   const packed = buildHeadFixture({ head: 'ref: refs/heads/main\n', packedRef: ['refs/heads/main', HEAD_SHA256] });
   dropOnExit(packed.dir);
   assert.equal(readHeadOid(packed.gitDir, packed.gitDir), HEAD_SHA256, 'packed-ref carrying a sha256 oid resolves');
+});
+
+// -- sha256 (objectFormat=sha256) full traversal (HIMMEL-1472) ------------------
+// HIMMEL-1468 aligned the ref/HEAD parser to accept 64-hex oids, but the
+// traversal dead-ended one layer deeper: readLooseObject, findPackOffset (20-
+// byte idx entries), commitTreeOid ({40}-only) and findTreeEntry (nul+21 walk)
+// stayed sha1-only, so a sha256 repo with git unavailable degraded to
+// reference-unavailable. These exercise the completed traversal end-to-end with
+// the git subprocess forced off (withNoGitOnPath): loose objects (the default
+// after a commit) and a repacked pack (exercising the 32-byte idx search).
+
+test('status --json: a sha256 loose-object fixture VERIFIES via the manual fallback when git is forced off (HIMMEL-1472)', {
+  skip: sha256GitAvailable() ? false : 'building the sha256 fixture needs a sha256-capable git (git init --object-format=sha256)',
+}, () => {
+  const ctx = work();
+  writeRealHookCopies(ctx);
+  buildSha256Repo(ctx.repo);
+  // Sanity: this really is a sha256 repo (64-hex commit oid, not 40).
+  assert.equal(gitCmd(ctx.repo, ['rev-parse', 'HEAD']).trim().length, 64);
+
+  const data = installedData(ctx);
+  const out = withNoGitOnPath(() => withDeclaredRepo(ctx.repo, () => statusDetail(data, { repoRoot: ctx.repo })));
+
+  assert.equal(out.contentIntegrityComplete, true, 'the manual fallback must VERIFY (not degrade) a sha256 repo via loose objects when git is unavailable');
+  for (const hook of out.hooks) {
+    assert.equal(hook.wrapperIntegrity.verdict, 'healthy');
+    assert.equal(hook.wrapperIntegrity.reason, 'matches-git-object');
+    assert.equal(hook.scriptIntegrity.verdict, 'healthy');
+    assert.equal(hook.scriptIntegrity.reason, 'matches-git-object');
+  }
+});
+
+test('status --json: a sha256 PACKED fixture (no loose objects) VERIFIES via the pack reader when git is forced off (HIMMEL-1472)', {
+  skip: sha256GitAvailable() ? false : 'building the sha256 fixture needs a sha256-capable git (git init --object-format=sha256)',
+}, () => {
+  const ctx = work();
+  writeRealHookCopies(ctx);
+  buildSha256Repo(ctx.repo, { repack: true });
+  assert.equal(gitCmd(ctx.repo, ['rev-parse', 'HEAD']).trim().length, 64);
+  // Sanity: the target objects are PACKED, not loose — otherwise the 32-byte
+  // idx search in findPackOffset is not exercised at all.
+  const looseDirs = readdirSync(join(ctx.repo, '.git', 'objects')).filter((e) => e !== 'pack' && e !== 'info');
+  assert.equal(looseDirs.length, 0, 'fixture must have no loose object dirs (repack -ad + prune-packed)');
+
+  const data = installedData(ctx);
+  const out = withNoGitOnPath(() => withDeclaredRepo(ctx.repo, () => statusDetail(data, { repoRoot: ctx.repo })));
+
+  assert.equal(out.contentIntegrityComplete, true, 'packed sha256 blobs must resolve through the pack reader (32-byte idx entries) when git is unavailable');
+  for (const hook of out.hooks) {
+    assert.equal(hook.wrapperIntegrity.verdict, 'healthy');
+    assert.equal(hook.wrapperIntegrity.reason, 'matches-git-object');
+    assert.equal(hook.scriptIntegrity.verdict, 'healthy');
+    assert.equal(hook.scriptIntegrity.reason, 'matches-git-object');
+  }
+});
+
+// -- sha256 REF_DELTA base-oid width (HIMMEL-1472) ----------------------------
+// The packed sha256 tests above exercise the 32-byte idx search, but the default
+// `git repack -ad` emits OFS_DELTA exclusively — so readPackEntry's REF_DELTA arm
+// (which read its base oid as a FIXED 20 bytes) was never hit for sha256. In an
+// objectFormat=sha256 pack the REF_DELTA base oid is 32 bytes, so the fixed-20
+// read truncated it AND started the inflate 12 bytes inside the oid, meaning a
+// sha256 REF_DELTA could never resolve. This forces REF_DELTA via
+// `repack.useDeltaBaseOffset=false` and asserts the manual fallback resolves the
+// delta-chained blob through its correctly-sized 32-byte base oid.
+
+// Builds a REAL sha256 repo whose pack is forced to emit REF_DELTA (not the
+// default OFS_DELTA) via `repack.useDeltaBaseOffset=false`. A few near-duplicate
+// blobs give git something to delta so the resulting pack actually contains
+// REF_DELTA entries (git skips delta-ing tiny/dissimilar objects). Requires
+// sha256-capable git (gate on sha256GitAvailable).
+function buildSha256RefDeltaRepo(repo) {
+  gitCmd(repo, ['init', '-q', '--object-format=sha256']);
+  const base = 'line\n'.repeat(200); // ~1 KiB: large enough that git bothers to delta
+  writeFileSync(join(repo, 'base.txt'), base);
+  writeFileSync(join(repo, 'derived.txt'), `${base}extra tail line\n`); // near-duplicate → delta'd onto base
+  writeFileSync(join(repo, 'third.txt'), `${base}another tail line\n`);
+  gitCmd(repo, ['add', '.']);
+  gitCmd(repo, ['commit', '-q', '-m', 'fixture']);
+  gitCmd(repo, ['-c', 'repack.useDeltaBaseOffset=false', 'repack', '-q', '-a', '-d']);
+  gitCmd(repo, ['prune-packed']);
+}
+
+// Recomputes a git object id with sha256 (the sha256 companion to the sha1
+// gitObjectId above) — lets the test map a resolved REF_DELTA target back to the
+// exact blob body it authored.
+function gitSha256Oid(type, body) {
+  return crypto.createHash('sha256').update(`${type} ${body.length}\0`, 'utf8').update(body).digest('hex');
+}
+
+// Returns the oids in <repo>'s single pack whose pack entry is a REF_DELTA (type
+// nibble 7). `git verify-pack -v` reports each object's offset and LOGICAL type
+// (blob/tree) plus a base-oid column for deltas, but does NOT distinguish
+// REF_DELTA from OFS_DELTA — only the pack's own type nibble at the entry offset
+// does. That distinction is exactly what proves the fixture emitted REF_DELTA
+// (repack.useDeltaBaseOffset=false) rather than the default OFS_DELTA, so this is
+// the non-vacuity seam: without it the test could pass against the unfixed code.
+function refDeltaTargetOids(repo) {
+  const packDir = join(repo, '.git', 'objects', 'pack');
+  const idxName = readdirSync(packDir).find((f) => f.endsWith('.idx'));
+  const idxPath = join(packDir, idxName);
+  const pack = readFileSync(`${idxPath.slice(0, -4)}.pack`);
+  const out = gitCmd(repo, ['verify-pack', '-v', idxPath]);
+  const oids = [];
+  for (const line of out.split('\n')) {
+    const c = line.trim().split(/\s+/);
+    // Object rows: "<64-hex oid> <type> <size> <packed> <offset> [<depth> <base-oid>]"
+    if (c.length >= 5 && /^[0-9a-f]{64}$/.test(c[0]) && ((pack[Number(c[4])] >> 4) & 7) === 7) {
+      oids.push(c[0]);
+    }
+  }
+  return oids;
+}
+
+test('readObject: a sha256 REF_DELTA target resolves via the 32-byte base oid when git is forced off (HIMMEL-1472)', {
+  skip: sha256GitAvailable() ? false : 'building the sha256 fixture needs a sha256-capable git (git init --object-format=sha256)',
+}, () => {
+  const ctx = work();
+  buildSha256RefDeltaRepo(ctx.repo);
+  assert.equal(gitCmd(ctx.repo, ['rev-parse', 'HEAD']).trim().length, 64, 'sanity: this is a sha256 repo (64-hex commit oid)');
+
+  // Non-vacuity: the pack must actually contain a REF_DELTA. The default repack
+  // emits OFS_DELTA only, so without this check the 32-byte base-oid read would
+  // never run and the test would pass against the unfixed (fixed-20) code.
+  const refDeltas = refDeltaTargetOids(ctx.repo);
+  assert.ok(refDeltas.length > 0, 'fixture must emit ≥1 REF_DELTA (repack.useDeltaBaseOffset=false) for this test to exercise the sha256 base-oid read');
+
+  // Known blob bodies keyed by their sha256 oid, so the resolved body can be
+  // checked exactly. readObject re-hashes (HIMMEL-1427 r10), so a non-null result
+  // already implies a body that matches the oid; this additionally asserts the
+  // authored bytes when the delta target is one of our blobs.
+  const base = 'line\n'.repeat(200);
+  const blobsByOid = {
+    [gitSha256Oid('blob', base)]: base,
+    [gitSha256Oid('blob', `${base}extra tail line\n`)]: `${base}extra tail line\n`,
+    [gitSha256Oid('blob', `${base}another tail line\n`)]: `${base}another tail line\n`,
+  };
+
+  withNoGitOnPath(() => {
+    for (const oid of refDeltas) {
+      // Pre-fix readPackEntry read 20 of the 32 base-oid bytes → a truncated base
+      // oid → readObject returned null (reference-unavailable). Sizing the base
+      // oid by the repo hash width makes the delta chain resolve.
+      const resolved = readObject(join(ctx.repo, '.git'), oid);
+      assert.ok(resolved, `sha256 REF_DELTA target ${oid.slice(0, 12)}… must resolve via its 32-byte base oid, not degrade`);
+      const expectedBody = blobsByOid[oid];
+      if (expectedBody !== undefined) {
+        assert.equal(resolved.type, 'blob');
+        assert.deepEqual(resolved.body, Buffer.from(expectedBody));
+      }
+    }
+  });
+});
+
+// -- mixed-format object DB rejection (HIMMEL-1472 R3) ------------------------
+// Adversarial review of the sha256 traversal found a real design gap: the hash
+// width was derived PER-OID (oidByteWidth on whatever oid was being read), so a
+// crafted/corrupt object DB — a 40-hex sha1 commit whose tree line names a
+// 64-hex sha256 oid (or the mirror) — traversed and rehashed green where
+// `git show HEAD:<path>` rejects. Git forbids intermixing object formats in one
+// repo (hash-transition spec), so on the git-unavailable fallback path that is a
+// FALSE integrity attestation. R3 pins the width ONCE from the HEAD/ref oid and
+// rejects any oid whose width disagrees. These build the mixed-format DB by hand
+// (git itself refuses to author it) as loose objects, planting the foreign tree
+// so it is independently readable — proving the degrade is the pin rejecting the
+// mix, not a missing/invalid object. No git / no sha256-capable git needed: the
+// fixtures are pure crypto+zlib loose objects, so these run on every machine.
+
+// Recomputes a git object id with either algo (the format-agnostic companion to
+// gitObjectId/gitSha256Oid above) — lets the mixed-format fixture author a valid
+// commit/tree/blob in either object format.
+function hashOid(type, body, algo) {
+  return crypto.createHash(algo).update(`${type} ${body.length}\0`, 'utf8').update(body).digest('hex');
+}
+
+// Writes a loose git object ("<type> <len>\0<body>", zlib-deflated) at the
+// oid-derived path objects/<2>/<rest> and returns its oid. Algo is 'sha1' or
+// 'sha256'. readObject re-hashes with hashAlgoForOid(oid), so a body written
+// under algo hashes back to its own oid and reads clean.
+function writeLoose(commonDir, type, body, algo) {
+  const oid = hashOid(type, body, algo);
+  const store = Buffer.concat([Buffer.from(`${type} ${body.length}\0`, 'utf8'), body]);
+  const objectPath = join(commonDir, 'objects', oid.slice(0, 2), oid.slice(2));
+  mkdirSync(dirname(objectPath), { recursive: true });
+  writeFileSync(objectPath, zlib.deflateSync(store));
+  return oid;
+}
+
+// A minimal valid commit body whose tree line names <treeOid>. readObject only
+// re-hashes the bytes and checks the type; commitTreeOid reads just the first
+// line, so this is enough to drive the fallback's commit→tree step.
+function commitBody(treeOid) {
+  return Buffer.from(
+    `tree ${treeOid}\nauthor g <g@example.invalid> 0 +0000\ncommitter g <g@example.invalid> 0 +0000\n\nfixture\n`,
+  );
+}
+
+// Builds a CORRUPT mixed-format object DB: a <commitAlgo> commit (sha1→40-hex,
+// sha256→64-hex) whose tree line names a tree oid of the OTHER format, with the
+// FULL foreign subtree (tree + a resolvable blob for hello.txt) actually present
+// and valid. Layout matches what readHeadBlob expects: <repo>/.git/{HEAD,objects/…}
+// (readGitDir finds .git, resolveCommonDir is a no-op without a commondir file).
+// The whole foreign subtree is independently resolvable via readObject (no pin),
+// so WITHOUT the R3 pin readHeadBlob traverses it end-to-end and returns
+// { ok: true } — a FALSE integrity attestation; WITH the pin it degrades. That
+// contrast is what makes these tests non-vacuous (they fail against the unfixed
+// per-oid-width code, which would report the mixed DB as healthy).
+function buildMixedFormatRepo({ commitAlgo }) {
+  const dir = mkdtempSync(join(tmpdir(), 'gblock-mixed-'));
+  const gitDir = join(dir, '.git');
+  const commonDir = gitDir;
+  mkdirSync(join(commonDir, 'objects'), { recursive: true });
+  const treeAlgo = commitAlgo === 'sha1' ? 'sha256' : 'sha1';
+  // A real foreign-format blob the tree entry resolves to, so the unfixed
+  // traversal reaches { ok: true } (false healthy) rather than degrading on a
+  // missing blob — the degrade must come from the pin, not an absent object.
+  const blobBody = Buffer.from('foreign-format blob body\n');
+  const blobOid = writeLoose(commonDir, 'blob', blobBody, treeAlgo);
+  const treeBody = Buffer.concat([Buffer.from('100644 hello.txt\0', 'utf8'), Buffer.from(blobOid, 'hex')]);
+  const treeOid = writeLoose(commonDir, 'tree', treeBody, treeAlgo);
+  const commitOid = writeLoose(commonDir, 'commit', commitBody(treeOid), commitAlgo);
+  writeFileSync(join(gitDir, 'HEAD'), `${commitOid}\n`);
+  return { dir, gitDir, commonDir, commitOid, treeOid, blobOid, commitAlgo, treeAlgo };
+}
+
+test('readObject: rejects an oid whose byte width disagrees with the pinned repo width (HIMMEL-1472 R3)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gblock-pin-'));
+  dropOnExit(dir);
+  const commonDir = join(dir, '.git');
+  mkdirSync(join(commonDir, 'objects'), { recursive: true });
+  const body = Buffer.from('AAA');
+  const oid = writeLoose(commonDir, 'blob', body, 'sha1');
+  // No pin (legacy 2-arg callers) and a matching pin both resolve; a foreign
+  // pin degrades fail-closed.
+  assert.deepEqual(readObject(commonDir, oid), { type: 'blob', body }, 'no pin: a sha1 blob still resolves (legacy callers)');
+  assert.deepEqual(readObject(commonDir, oid, 0, undefined, 20), { type: 'blob', body }, 'a sha1 pin matches a sha1 (40-hex) oid');
+  assert.equal(readObject(commonDir, oid, 0, undefined, 32), null, 'a sha256 pin must reject a sha1 (40-hex) oid');
+  // Mirror: a real sha256 blob rejected by a sha1 pin.
+  const oid256 = writeLoose(commonDir, 'blob', body, 'sha256');
+  assert.deepEqual(readObject(commonDir, oid256, 0, undefined, 32), { type: 'blob', body }, 'a sha256 pin matches a sha256 (64-hex) oid');
+  assert.equal(readObject(commonDir, oid256, 0, undefined, 20), null, 'a sha1 pin must reject a sha256 (64-hex) oid');
+});
+
+test('readHeadBlob: a sha1 commit naming a 64-hex (sha256) tree degrades as reference-unavailable (HIMMEL-1472 R3)', () => {
+  const fix = buildMixedFormatRepo({ commitAlgo: 'sha1' });
+  dropOnExit(fix.dir);
+  // Non-vacuity: the whole foreign sha256 subtree (tree + blob) is present and
+  // independently readable (no pin) — so without the R3 pin the traversal would
+  // follow commit→tree→blob and return { ok: true } (a false attestation). The
+  // degrade below is therefore the pin rejecting the mixed format, not a
+  // missing/invalid object.
+  assert.ok(readObject(fix.commonDir, fix.treeOid), 'the 64-hex sha256 tree must be independently readable (present + valid)');
+  assert.ok(readObject(fix.commonDir, fix.blobOid), 'the 64-hex sha256 blob must be independently readable (present + valid)');
+  assert.equal(fix.commitOid.length, 40, 'sanity: the commit oid is sha1 (40-hex), so the pin is width 20');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a sha1 commit naming a sha256 tree must degrade — git forbids the mixed format');
+});
+
+test('readHeadBlob: a sha256 commit naming a 40-hex (sha1) tree degrades — mirror case (HIMMEL-1472 R3)', () => {
+  const fix = buildMixedFormatRepo({ commitAlgo: 'sha256' });
+  dropOnExit(fix.dir);
+  // Non-vacuity (mirror): the whole foreign sha1 subtree is present and readable
+  // in isolation, so without the pin the traversal would return { ok: true }.
+  assert.ok(readObject(fix.commonDir, fix.treeOid), 'the foreign sha1 tree must be independently readable (present + valid)');
+  assert.ok(readObject(fix.commonDir, fix.blobOid), 'the foreign sha1 blob must be independently readable (present + valid)');
+  assert.equal(fix.commitOid.length, 64, 'sanity: the commit oid is sha256 (64-hex), so the pin is width 32');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a sha256 commit naming a sha1 tree must degrade — mirror mixed-format case');
+});
+
+// Positive control: the R3 pin must NOT reject a consistent single-format repo.
+// A hand-built sha1 commit→tree→blob for path hello.txt still resolves, proving
+// the pin rejects only MIXED formats, not valid same-format lookups (guards
+// against an over-broad pin silently degrading every healthy install).
+test('readHeadBlob: a consistent single-format (sha1) repo still resolves — no false degrade from the pin (HIMMEL-1472 R3)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gblock-single-'));
+  dropOnExit(dir);
+  const gitDir = join(dir, '.git');
+  const commonDir = gitDir;
+  mkdirSync(join(commonDir, 'objects'), { recursive: true });
+  const blobBody = Buffer.from('hello body\n');
+  const blobOid = writeLoose(commonDir, 'blob', blobBody, 'sha1');
+  const treeBody = Buffer.concat([Buffer.from('100644 hello.txt\0', 'utf8'), Buffer.from(blobOid, 'hex')]);
+  const treeOid = writeLoose(commonDir, 'tree', treeBody, 'sha1');
+  const commitOid = writeLoose(commonDir, 'commit', commitBody(treeOid), 'sha1');
+  writeFileSync(join(gitDir, 'HEAD'), `${commitOid}\n`);
+
+  const out = withNoGitOnPath(() => readHeadBlob(dir, 'hello.txt'));
+  assert.equal(out.ok, true, 'a consistent sha1 repo must resolve — the pin rejects only mixed formats');
+  assert.deepEqual(out.body, blobBody);
+});
+
+// -- config-anchored width rejection (HIMMEL-1472 R4) -------------------------
+// Adversarial review of R3 found the remaining real gap: the HEAD oid's OWN
+// length was the width source, so a crafted/corrupt DB in a DEFAULT (sha1) repo
+// whose HEAD ref carries a 64-hex oid with a FULLY self-consistent sha256
+// commit→tree→blob chain passed every r3 width+rehash check (HEAD pinned 32, the
+// chain agreed) while git itself rejects the repo (extensions.objectFormat is
+// absent → sha1); the mirror holds for a configured sha256 repo with a 40-hex
+// chain. R4 derives the width from the CONFIGURED format and rejects a HEAD oid
+// whose width disagrees. Unlike buildMixedFormatRepo (which mixes formats
+// WITHIN the objects), these keep the OBJECT chain internally consistent in ONE
+// format — so R3's HEAD-derived pin traversed it green (a false attestation);
+// the degrade must come from the config disagreeing with the HEAD oid, the R4
+// gap. No git / no sha256-capable git needed: pure crypto+zlib loose objects +
+// a hand-written config, so these run on every machine.
+
+// Builds a SELF-CONSISTENT single-format chain (commit→tree→blob for hello.txt,
+// all in `algo`) under <repo>/.git plus a config whose [extensions] objectFormat
+// is `configFormat`, or omitted when null (a default sha1 repo, exactly like a
+// real `git init` with no object-format override).
+function buildConfigMismatchRepo({ algo, configFormat }) {
+  const dir = mkdtempSync(join(tmpdir(), 'gblock-cfg-'));
+  const gitDir = join(dir, '.git');
+  const commonDir = gitDir;
+  mkdirSync(join(commonDir, 'objects'), { recursive: true });
+  const blobBody = Buffer.from('hello body\n');
+  const blobOid = writeLoose(commonDir, 'blob', blobBody, algo);
+  const treeBody = Buffer.concat([Buffer.from('100644 hello.txt\0', 'utf8'), Buffer.from(blobOid, 'hex')]);
+  const treeOid = writeLoose(commonDir, 'tree', treeBody, algo);
+  const commitOid = writeLoose(commonDir, 'commit', commitBody(treeOid), algo);
+  writeFileSync(join(gitDir, 'HEAD'), `${commitOid}\n`);
+  // A real default repo has no [extensions] section (objectFormat defaults to
+  // sha1); a configured sha256 repo is repositoryformatversion 1 + objectFormat
+  // = sha256 (git init --object-format=sha256). Hand-write exactly that.
+  writeFileSync(join(gitDir, 'config'), configFormat === null
+    ? '[core]\n\trepositoryformatversion = 0\n'
+    : `[core]\n\trepositoryformatversion = 1\n[extensions]\n\tobjectFormat = ${configFormat}\n`);
+  return { dir, gitDir, commonDir, commitOid, treeOid, blobOid, algo };
+}
+
+test('readHeadBlob: a self-consistent sha256 chain in a DEFAULT (sha1) repo degrades — config width rejects the 64-hex HEAD (HIMMEL-1472 R4)', () => {
+  // The R3 gap exactly: pinning width from the HEAD oid let a 64-hex HEAD pin
+  // width 32 and traverse a fully self-consistent sha256 chain green, attesting
+  // integrity where git rejects the repo (no extensions.objectFormat → sha1).
+  const fix = buildConfigMismatchRepo({ algo: 'sha256', configFormat: null });
+  dropOnExit(fix.dir);
+  assert.equal(fix.commitOid.length, 64, 'sanity: the chain is sha256 (64-hex HEAD)');
+  // Non-vacuity: the whole sha256 chain is independently resolvable (no pin) —
+  // so R3 (HEAD-pinned width 32) returned { ok: true }, a false attestation. The
+  // degrade must come from the config disagreeing with the HEAD oid, not a bad
+  // object. (Confirmed: against the r3 pin-from-HEAD code this resolves ok:true.)
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha256 commit must be independently readable (present + valid)');
+  assert.ok(readObject(fix.commonDir, fix.treeOid), 'the sha256 tree must be independently readable (present + valid)');
+  assert.ok(readObject(fix.commonDir, fix.blobOid), 'the sha256 blob must be independently readable (present + valid)');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a 64-hex HEAD in a default (sha1) repo must degrade — config width 20 ≠ HEAD width 32');
+});
+
+test('readHeadBlob: a self-consistent sha1 chain in a CONFIGURED sha256 repo degrades — mirror case (HIMMEL-1472 R4)', () => {
+  // Mirror: a configured sha256 repo (objectFormat=sha256) whose HEAD carries a
+  // 40-hex sha1 chain. R3 pinned width 20 from the HEAD and traversed the
+  // self-consistent sha1 chain green; R4 reads config width 32, rejects the
+  // 40-hex HEAD → degrade.
+  const fix = buildConfigMismatchRepo({ algo: 'sha1', configFormat: 'sha256' });
+  dropOnExit(fix.dir);
+  assert.equal(fix.commitOid.length, 40, 'sanity: the chain is sha1 (40-hex HEAD)');
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit must be independently readable (present + valid)');
+  assert.ok(readObject(fix.commonDir, fix.treeOid), 'the sha1 tree must be independently readable (present + valid)');
+  assert.ok(readObject(fix.commonDir, fix.blobOid), 'the sha1 blob must be independently readable (present + valid)');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a 40-hex HEAD in a sha256-configured repo must degrade — config width 32 ≠ HEAD width 20');
+});
+
+// -- repository-format validation (HIMMEL-1472 R5) ---------------------------
+// Adversarial review of R4: configuredObjectByteWidth read objectFormat and
+// returned a width but skipped the rules git uses to ACCEPT that config — so a
+// config git REJECTS still yielded a width and a healthy attestation. R5 mirrors
+// git's documented validation set (core.repositoryformatversion + the FULL
+// [extensions] section) and degrades on every config git refuses. Each negative
+// config is also run through REAL git (`git rev-parse --verify HEAD` non-zero),
+// gated on gitAvailable(), so the fallback is proven to match git, not a guess.
+// No sha256-capable git needed: every degrade below comes from the CONFIG, which
+// git validates before it touches objects, so a hand-written config over a
+// consistent object chain exercises it on every machine.
+
+// git rev-parse exit code for a repo; non-zero ⇒ git refuses it. Used to prove
+// each negative config is one REAL git rejects too (not just our guess).
+function gitRevParseHeadExit(repo) {
+  try {
+    execFileSync('git', ['-C', repo, 'rev-parse', '--verify', 'HEAD'], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' });
+    return 0;
+  } catch (e) {
+    return e.status ?? 1;
+  }
+}
+
+// Builds a self-consistent single-format chain under <repo>/.git plus an
+// arbitrary config text, so a repo-format test can pin exactly the config git
+// must refuse. The chain is internally consistent in `algo`, so a degrade must
+// come from the config, not a bad object (non-vacuous).
+function buildRepoFormatRepo({ algo, config }) {
+  const dir = mkdtempSync(join(tmpdir(), 'gblock-repofmt-'));
+  const gitDir = join(dir, '.git');
+  const commonDir = gitDir;
+  mkdirSync(join(commonDir, 'objects'), { recursive: true });
+  const blobBody = Buffer.from('hello body\n');
+  const blobOid = writeLoose(commonDir, 'blob', blobBody, algo);
+  const treeBody = Buffer.concat([Buffer.from('100644 hello.txt\0', 'utf8'), Buffer.from(blobOid, 'hex')]);
+  const treeOid = writeLoose(commonDir, 'tree', treeBody, algo);
+  const commitOid = writeLoose(commonDir, 'commit', commitBody(treeOid), algo);
+  writeFileSync(join(gitDir, 'HEAD'), `${commitOid}\n`);
+  writeFileSync(join(gitDir, 'config'), config);
+  return { dir, gitDir, commonDir, commitOid, treeOid, blobOid, algo };
+}
+
+test('readHeadBlob: objectFormat=sha256 with repositoryformatversion 0 degrades — git refuses the v1-only extension (HIMMEL-1472 R5)', () => {
+  // A real configured sha256 repo is repositoryformatversion 1 + objectFormat
+  // sha256 (git init --object-format=sha256); version 0 + an objectFormat
+  // extension is malformed and git refuses it ("repo version is 0, but v1-only
+  // extension found"). R4 returned width 32 here and attested integrity against a
+  // repo git rejects; R5 degrades. The chain is a consistent sha256 chain, so the
+  // degrade must come from the config, not the objects.
+  const cfg = '[core]\n\trepositoryformatversion = 0\n[extensions]\n\tobjectFormat = sha256\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha256', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha256 commit is independently readable — degrade is config-driven, not a bad object');
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse v0 + objectFormat (v1-only extension)');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'objectFormat=sha256 at repositoryformatversion 0 must degrade — git refuses the malformed config');
+});
+
+test('readHeadBlob: repositoryformatversion 1 with an unknown extension degrades — git refuses it outright (HIMMEL-1472 R5)', () => {
+  // At repositoryformatversion >= 1 git honors extensions but refuses any key it
+  // does not recognize ("unknown repository extension found"). R4 read only
+  // objectFormat and ignored every other key, so an unknown extension hid a
+  // config git rejects. A sha1 chain keeps the objects valid so the degrade is
+  // config-driven.
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[extensions]\n\tobjectFormat = sha1\n\tfrobnicate = yes\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse an unknown extensions.* key');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'an unknown extension at repositoryformatversion 1 must degrade — git refuses the repo');
+});
+
+test('readHeadBlob: a valueless objectFormat degrades — git rejects the empty value (HIMMEL-1472 R5)', () => {
+  // objectFormat = (no value) parses to an empty string; like any unrecognized
+  // value it degrades (R4's existing unrecognized-value path already covered it).
+  // Pinned here against real git ("invalid value for 'extensions.objectformat'")
+  // to lock the documented validation set.
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[extensions]\n\tobjectFormat =\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse a valueless objectFormat');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a valueless objectFormat must degrade — git rejects the empty value');
+});
+
+// Positive control: the validation must NOT reject a config git ACCEPTS. A real
+// configured sha256 repo (repositoryformatversion 1 + objectFormat sha256, only
+// known extensions) still resolves — R5 degrades only configs git refuses, never
+// a healthy one (guards against an over-broad pin silently degrading installs).
+test('readHeadBlob: a configured sha256 repo (repositoryformatversion 1 + only known extensions) still resolves — no false degrade (HIMMEL-1472 R5)', () => {
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[extensions]\n\tobjectFormat = sha256\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha256', config: cfg });
+  dropOnExit(fix.dir);
+  assert.equal(fix.commitOid.length, 64, 'sanity: the chain is sha256 (64-hex HEAD)');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, true, 'a configured sha256 repo with only known extensions must resolve — R5 degrades only configs git refuses');
+  assert.deepEqual(out.body, Buffer.from('hello body\n'));
+});
+
+// -- repository-format validation, value + bare-key gaps (HIMMEL-1472 R6) -------
+// Adversarial review of R5: the key-set check closed the "unknown extension"
+// hole, but two narrower gaps versus real git remained. (1) BARE extension keys
+// (no `=`) were DROPPED — git parses `[extensions]\nfrobnicate` as frobnicate=true
+// (an unknown extension → git REJECTS), but the parser required `=` and skipped
+// the line, attesting healthy. (2) Known-extension VALUES were not validated —
+// refStorage=bogus returned a width though git refuses it. R6 parses bare keys
+// as boolean true, validates known-extension values against git's accepted sets,
+// and degrades fail-closed on any [core]/[extensions] line that is neither
+// `key = value` nor a bare `key`. Every negative is also run through REAL git
+// (`git rev-parse --verify HEAD` non-zero), gated on gitAvailable(), so the
+// fallback is proven to match git, not a guess. The chain is a consistent sha1
+// (or sha256 for the positive control) chain, so a degrade is config-driven.
+
+test('readHeadBlob: a BARE unknown extension degrades — git parses a valueless var as true, then refuses it (HIMMEL-1472 R6)', () => {
+  // git config grammar treats a valueless variable (no `=`) as boolean true, so
+  // `[extensions]\nfrobnicate` is frobnicate=true — still an UNKNOWN extension,
+  // which git refuses outright. R5 required `=` and dropped the line, attesting
+  // healthy against a repo git rejects. A sha1 chain keeps the objects valid so
+  // the degrade is config-driven.
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[extensions]\n\tfrobnicate\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse a bare unknown extensions.* key');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a bare unknown extension must degrade — git parses it as =true then refuses the unknown key');
+});
+
+test('readHeadBlob: refStorage=bogus degrades — git refuses an invalid refStorage value (HIMMEL-1472 R6)', () => {
+  // refStorage is a known KEY, so R5's key-set check passed it; but its VALUE is
+  // constrained to {files, reftable}, and git refuses anything else ("invalid
+  // value for 'extensions.refstorage'"). A sha1 chain keeps the objects valid so
+  // the degrade is config-driven.
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[extensions]\n\trefStorage = bogus\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse refStorage=bogus');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'refStorage=bogus must degrade — git refuses the invalid value');
+});
+
+test('readHeadBlob: a malformed [extensions] line degrades — git refuses a bad config line (HIMMEL-1472 R6)', () => {
+  // A line that is neither `key = value` nor a bare `key` (here a name with a
+  // space) is one git's parser rejects ("bad config line"). R5 silently skipped
+  // such lines; R6 degrades fail-closed. The line carries no extension key, so
+  // without the malformed guard this config would resolve (no extension → sha1),
+  // making the degrade non-vacuously attributable to the bad line.
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[extensions]\n\tbad key\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse a bad config line');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a malformed [extensions] line must degrade — git refuses a bad config line');
+});
+
+test('readHeadBlob: a malformed line in a NON-relevant section degrades — git rejects the whole file (HIMMEL-1472 R6 panel)', () => {
+  // git errors "bad config line" for a syntactically invalid line ANYWHERE in
+  // the file, not only under [core]/[extensions]. R6 first flagged only the
+  // relevant sections, so a syntax error in e.g. [user] attested healthy where
+  // git refuses the repo outright. The config is otherwise fully valid sha1.
+  const cfg = '[core]\n\trepositoryformatversion = 0\n[user]\n\tbad name line\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse a bad config line in any section');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a malformed line outside [core]/[extensions] must degrade — git rejects the whole file');
+});
+
+// Positive control for the bare-key rule: a BARE KNOWN boolean extension behaves
+// as its =true form, which git ACCEPTS. worktreeConfig (bare) + objectFormat=sha256
+// at v1 is a real, healthy repo shape (`git init --object-format=sha256` + a
+// linked worktree) — the validation must NOT degrade it. The sha256 chain is
+// hand-built, so this exercises the manual fallback (no sha256-capable git
+// needed), exactly like the R5 sha256 positive control.
+test('readHeadBlob: a bare worktreeConfig + objectFormat=sha256 (v1) still resolves — a bare known boolean is =true, which git accepts (HIMMEL-1472 R6)', () => {
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[extensions]\n\tworktreeConfig\n\tobjectFormat = sha256\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha256', config: cfg });
+  dropOnExit(fix.dir);
+  assert.equal(fix.commitOid.length, 64, 'sanity: the chain is sha256 (64-hex HEAD)');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, true, 'a bare worktreeConfig (parsed as =true) with objectFormat=sha256 must resolve — git accepts this healthy config');
+  assert.deepEqual(out.body, Buffer.from('hello body\n'));
+});
+
+// Value-validation coverage: git refuses a boolean extension set to a non-bool
+// literal, and treats refStorage's value case-sensitively (only lowercase
+// files/reftable). Both pin the new value table against real git.
+test('readHeadBlob: a non-bool worktreeConfig value degrades — git refuses it as a bad boolean (HIMMEL-1472 R6)', () => {
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[extensions]\n\tworktreeConfig = notabool\n\tobjectFormat = sha1\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse worktreeConfig=notabool');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'worktreeConfig=notabool must degrade — git refuses a non-bool boolean value');
+});
+
+test('readHeadBlob: refStorage=Files (wrong case) degrades — git matches the value case-sensitively (HIMMEL-1472 R6)', () => {
+  // git accepts only the lowercase tokens files/reftable; Files/FILES are refused
+  // as invalid values. R6's value table matches case-sensitively to stay aligned
+  // with git rather than over-accepting a config git rejects.
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[extensions]\n\trefStorage = Files\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse refStorage=Files (case-sensitive)');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'refStorage=Files must degrade — git matches the refStorage value case-sensitively');
+});
+
+// -- repository-format validation, header + key grammar (HIMMEL-1472 R8) ------
+// Adversarial review of R6/R7: the malformed-line guard and the key-capture
+// regexes were looser than git's config grammar, leaving two fail-OPEN gaps. (1) A
+// header shaped like one but matching NEITHER accepted form — e.g. `[bad section]`
+// (an unquoted second word) — was silently scoped out (section = null) and the
+// file could still attest a width, though git rejects the whole file ("bad config
+// line"). (2) Key patterns accepted leading digits/dots and embedded dots (`9key`,
+// `.key`, `key.sub`) that git's variable-name grammar (alpha, then alnum + `-`)
+// refuses — again "bad config line". R8 mirrors git's header grammar (bare
+// `[name]` / subsection `[name "sub"]` with \\ and \" escapes) and tightens the key
+// grammar, so a config git rejects degrades. Each negative is pinned against REAL
+// git; positives prove the grammar does NOT over-degrade a healthy config. The
+// chain is a consistent sha1 (or sha256 for the positive control) chain, so a
+// degrade is config-driven.
+
+test('readHeadBlob: a header with an unquoted second word [bad section] degrades — git rejects the bad header (HIMMEL-1472 R8)', () => {
+  // `[bad section]` is neither a bare `[name]` nor a subsection `[name "sub"]` (no
+  // quotes around the second word), so git's parser rejects the whole file ("bad
+  // config line 1"). R6/R7 silently scoped any space-containing header out
+  // (section = null) and attested healthy; R8 degrades fail-closed. A sha1 chain
+  // keeps the objects valid so the degrade is config-driven.
+  const cfg = '[bad section]\n[core]\n\trepositoryformatversion = 0\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse a header with an unquoted second word');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'an unquoted-space header must degrade — git rejects the bad header');
+});
+
+test('readHeadBlob: a valid subsection [core "sub"] is scoped out — the file still resolves (HIMMEL-1472 R8)', () => {
+  // `[core "sub"]` is a well-formed subsection header; git accepts it, and the bare
+  // [core] scope git reads repositoryformatversion from is unaffected. R8 must NOT
+  // over-degrade this healthy shape: the subsection is scoped out (section = null)
+  // and a later bare [core] still reads version 0.
+  const cfg = '[core "sub"]\n\tfoo = bar\n[core]\n\trepositoryformatversion = 0\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, true, 'a valid subsection header must not over-degrade — the file still resolves');
+  assert.deepEqual(out.body, Buffer.from('hello body\n'));
+});
+
+test('readHeadBlob: a subsection header with an escaped quote [a "b\\"c"] is accepted — file still resolves (HIMMEL-1472 R8)', () => {
+  // git's subsection grammar allows \\ and \" escapes inside the quoted name, so
+  // `[a "b\"c"]` is well-formed and git accepts it. R8's subsection regex honors
+  // those escapes, so the header is scoped out (not flagged malformed) and the
+  // otherwise-valid sha1 config still resolves.
+  const cfg = '[a "b\\"c"]\n\tfoo = bar\n[core]\n\trepositoryformatversion = 0\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, true, 'an escaped-quote subsection header must be accepted — git accepts it');
+  assert.deepEqual(out.body, Buffer.from('hello body\n'));
+});
+
+test('readHeadBlob: a key starting with a digit (9key) under [core] degrades — git rejects the variable name (HIMMEL-1472 R8)', () => {
+  // git variable names must start with a letter (alnum + `-` after); `9key` is one
+  // git's parser rejects ("bad config line"), refusing the whole file. The prior
+  // key grammar `[A-Za-z0-9.-]+` accepted a leading digit and captured it, attesting
+  // healthy; R8 tightens to git's grammar and degrades. A sha1 chain keeps the
+  // objects valid so the degrade is config-driven.
+  const cfg = '[core]\n\trepositoryformatversion = 0\n\t9key = 1\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse a variable name starting with a digit');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a digit-leading key must degrade — git rejects the variable name');
+});
+
+test('readHeadBlob: keys git rejects (.key, key.sub) under a subsectioned scope degrade — git rejects the variable name (HIMMEL-1472 R8)', () => {
+  // Under a subsectioned scope (section = null) a key line is still shape-checked:
+  // git's variable-name grammar (alpha, then alnum + `-`) refuses a leading dot
+  // (`.key`) and an embedded dot (`key.sub`) — both "bad config line". The prior
+  // grammar `[A-Za-z0-9.-]+` accepted dots and attested healthy; R8 degrades. Each
+  // config is otherwise a valid sha1 repo, so the degrade is config-driven.
+  for (const badKey of ['.key = 1', 'key.sub = 1']) {
+    const cfg = `[remote "origin"]\n\t${badKey}\n[core]\n\trepositoryformatversion = 0\n`;
+    const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+    dropOnExit(fix.dir);
+    assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+    if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, `real git must refuse variable name: ${badKey}`);
+
+    const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+    assert.equal(out.ok, false, `${badKey} must degrade`);
+    assert.equal(out.reason, 'reference-unavailable', `${badKey} must degrade — git rejects the variable name`);
+  }
+});
+
+// -- repository-format validation, strict-value collapse (HIMMEL-1472 R9) ------
+// Adversarial review of R5-R8: each round found one more way configuredObjectByteWidth()
+// was LOOSER than git's config parser (version rules, extension values, line shapes,
+// headers, keys, now bare version + value quoting). Enumerating what git REJECTS is a
+// bottomless well. The invariant needs only one direction — NEVER attest against a
+// config git refuses — so R9 makes the parser STRICT-BY-WHITELIST and CLOSES the class:
+// accept only a conservative value shape every real default config satisfies (bare, or
+// fully quoted; no escapes, no line continuations, no mid-value comment chars, no
+// unbalanced/embedded quotes, no trailing garbage), degrade on everything else, and
+// also degrade on a valueless core.repositoryformatversion. A future "parser is looser
+// than git" finding must show a config THIS WHITELIST ACCEPTS while git REJECTS it
+// (fail-open); "git accepts but we degrade" is by-design fail-closed and out of scope.
+
+test('readHeadBlob: a valueless repositoryformatversion under [core] degrades — git rejects a valueless int key (HIMMEL-1472 R9)', () => {
+  // A bare `repositoryformatversion` (no `=`) under [core] parsed as boolean true to
+  // git, but git reads core.repositoryformatversion as an INTEGER — a valueless int key
+  // is one git rejects. R8's bare-key branch only captured [extensions] keys, so under
+  // [core] this was silently skipped (version stayed 0) and the file attested healthy;
+  // R9 sets versionMalformed and degrades. A sha1 chain keeps the objects valid so the
+  // degrade is config-driven.
+  const cfg = '[core]\n\trepositoryformatversion\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse a valueless repositoryformatversion');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a valueless repositoryformatversion must degrade — git rejects the valueless int key');
+});
+
+test('readHeadBlob: an unclosed quote in an extension value (objectFormat = "sha256) degrades (HIMMEL-1472 R9)', () => {
+  // `objectFormat = "sha256` has an opening quote with no closing quote; R6/R8 captured
+  // the value `(.*)`, stripped the leading quote, and attested while git rejects the
+  // file ("bad config line"). R9's value whitelist refuses an unbalanced quote, so the
+  // line degrades. A sha1 chain keeps the objects valid so the degrade is value-driven.
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[extensions]\n\tobjectFormat = "sha256\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse an unclosed quote in a value');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'an unclosed quote in a value must degrade — git rejects the bad config line');
+});
+
+test('readHeadBlob: trailing garbage after a closing quote (key = "a" x) degrades (HIMMEL-1472 R9)', () => {
+  // `somekey = "a" x` is a quoted value followed by trailing garbage; git parses the
+  // quoted "a" then chokes on ` x` ("bad config line"). The prior `(.*)` value capture
+  // accepted it and (for an unknown core key) attested healthy; R9's whitelist requires
+  // a quoted value to END at its closing quote, so the trailing text degrades. A sha1
+  // chain keeps the objects valid so the degrade is value-driven.
+  const cfg = '[core]\n\trepositoryformatversion = 0\n\tsomekey = "a" x\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+  if (gitAvailable()) assert.notEqual(gitRevParseHeadExit(fix.dir), 0, 'real git must refuse trailing garbage after a quoted value');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'trailing garbage after a quoted value must degrade — git rejects the bad config line');
+});
+
+test('readHeadBlob: a line-continuation backslash in an out-of-scope value (url = val\) degrades by construction (HIMMEL-1472 R9)', () => {
+  // A trailing `\` is git's line-continuation char — git would read the NEXT line as
+  // part of this value. R9 refuses ANY backslash in a value (escapes/continuations are
+  // out of the whitelist), so this degrades where git would continue the line. That is
+  // the documented fail-CLOSED case (git accepts/continues, we degrade), NOT pinned
+  // against real git — the assertion is solely that our parser degrades fail-closed.
+  const cfg = '[remote "origin"]\n\turl = val\\\n[core]\n\trepositoryformatversion = 0\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a backslash in a value must degrade by construction (fail-closed) — line continuations are outside the whitelist');
+});
+
+test('readHeadBlob: a clean quoted value (somekey = "quoted") resolves — the whitelist does not over-degrade (HIMMEL-1472 R9)', () => {
+  // Positive control for the value whitelist: a fully-quoted value with no escapes and
+  // no embedded quote is well-formed, so an unknown [core] key carrying one must NOT
+  // degrade. R9 refuses only shapes git's broad grammar could abuse; a plain quoted
+  // value is accepted and the otherwise-default sha1 repo still resolves.
+  const cfg = '[core]\n\trepositoryformatversion = 0\n\tsomekey = "quoted"\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, true, 'a clean quoted value must not over-degrade — the file still resolves');
+  assert.deepEqual(out.body, Buffer.from('hello body\n'));
+});
+
+test('readHeadBlob: a plain default-shape config resolves unchanged at sha1/20 (HIMMEL-1472 R9)', () => {
+  // Positive control for the whole grammar tightening: a plain default-style config
+  // (bare values, no quotes/escapes/comments) is entirely inside the R9 whitelist, so
+  // the strict parser must still derive sha1 (width 20) and resolve. Guards against the
+  // whitelist silently degrading a healthy install.
+  const cfg = '[core]\n\trepositoryformatversion = 0\n\tfilemode = false\n\tbare = false\n\tlogallrefupdates = true\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.equal(fix.commitOid.length, 40, 'sanity: the chain is sha1 (40-hex HEAD)');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, true, 'a plain default-shape config must resolve — R9 does not over-degrade a healthy config');
+  assert.deepEqual(out.body, Buffer.from('hello body\n'));
+});
+
+// -- repository-format validation, subsectioned extensions degrade (HIMMEL-1472 R10) -
+// Adversarial review (codex) of R8's subsection handling: a subsectioned header
+// `[extensions "x"]` was scoped out (section = null), so keys under it were only
+// shape-checked and never reached the extensions capture. But git surfaces those keys
+// as `extensions.x.*`, and its repository-format validation REFUSES an unknown
+// extension at repositoryformatversion >= 1 ("unknown repository extension found");
+// at v0 any extension present is already a degrade (R5). Net: `[extensions "x"]\nfoo = 1`
+// attested a width while git refuses the repo — a whitelist-accepts-git-rejects
+// fail-open, exactly what the R9 closure rule scopes IN. R10 special-cases the
+// subsection header: when the section NAME is `extensions` (case-insensitive — git
+// treats section names case-insensitively), flag malformed and degrade. `[core "x"]`
+// and other subsections stay scoped out (they play no part in repo-format validation).
+// This REVERSES R8's "a subsection [extensions "x"] is scoped out, file resolves"
+// expectation; that test is superseded by the cases below.
+
+test('readHeadBlob: a subsection [extensions "x"] with a key degrades — git reads its keys as extensions.x.* and refuses them (HIMMEL-1472 R10)', () => {
+  // `[extensions "x"]\n\tfoo = 1` at v1: git reads `foo` as extensions.x.foo, an
+  // unknown extension it refuses; R8 scoped the subsection out and attested, R10 flags
+  // the header malformed and degrades. A sha1 chain keeps the objects valid so the
+  // degrade is config-driven.
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[extensions "x"]\n\tfoo = 1\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a subsectioned [extensions "x"] must degrade — git refuses its keys as unknown extensions');
+});
+
+test('readHeadBlob: a subsection [EXTENSIONS "x"] (case variant) degrades — git section names are case-insensitive (HIMMEL-1472 R10)', () => {
+  // git config section names are case-insensitive, so `[EXTENSIONS "x"]` is the same
+  // section as `[extensions "x"]` and must degrade identically. R10 lowercases the
+  // captured section name before the extensions check. A sha1 chain keeps the objects
+  // valid so the degrade is config-driven.
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[EXTENSIONS "x"]\n\tfoo = 1\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a case-variant [EXTENSIONS "x"] must degrade — git matches section names case-insensitively');
+});
+
+test('readHeadBlob: a subsection [remote "origin"] with a key still resolves — R10 degrades only the extensions section (HIMMEL-1472 R10)', () => {
+  // Positive control: R10 special-cases ONLY the extensions section name. A subsection
+  // of any other section (here [remote "origin"]) is still scoped out and the otherwise-
+  // default sha1 repo still resolves — R10 must not over-degrade a healthy config that
+  // carries a normal remote.
+  const cfg = '[remote "origin"]\n\turl = https://example.com/repo.git\n[core]\n\trepositoryformatversion = 0\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, true, 'a non-extensions subsection must not over-degrade — the file still resolves');
+  assert.deepEqual(out.body, Buffer.from('hello body\n'));
+});
+
+// -- repository-format validation, dotted [extensions.x] headers degrade (HIMMEL-1472 R11) ----
+// Adversarial review (codex) of the bare-header grammar: `[A-Za-z0-9.-]+` admits dots, so
+// git's legacy dotted subsection syntax `[extensions.x]` matched the bare-header branch and
+// set section = "extensions.x" (neither core nor extensions). Its keys were then shape-checked
+// only and never reached the extensions capture, so the file attested a width. But git reads
+// `[extensions.x]` keys as `extensions.x.*` (the deprecated [section.subsection] form lowercases
+// the subsection) and refuses an unknown extension at repositoryformatversion >= 1 — the same
+// whitelist-accepts-git-rejects fail-open R10 closed for the quoted-subsection form. R11 flags
+// any bare header whose lowercased name starts with `extensions.` as malformed and degrades.
+// Dotted `[core.x]` (and other dotted sections) is consistently IGNORED by both git's repo-
+// format validation and this parser, so the guard stays extensions-only.
+
+test('readHeadBlob: a dotted [extensions.x] header with a key degrades — git reads its keys as extensions.x.* and refuses them (HIMMEL-1472 R11)', () => {
+  // `[extensions.x]\n\tfoo = 1` at v1: git reads `foo` as extensions.x.foo via the deprecated
+  // [section.subsection] syntax, an unknown extension it refuses; the bare-header grammar
+  // admitted the dot so R8 scoped it as "extensions.x" and attested, R11 flags the header
+  // malformed and degrades. A sha1 chain keeps the objects valid so the degrade is config-driven.
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[extensions.x]\n\tfoo = 1\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a dotted [extensions.x] header must degrade — git refuses its keys as unknown extensions');
+});
+
+test('readHeadBlob: a dotted [EXTENSIONS.X] header (case variant) degrades — git section names are case-insensitive (HIMMEL-1472 R11)', () => {
+  // git config section names are case-insensitive, so `[EXTENSIONS.X]` is the same section as
+  // `[extensions.x]` and must degrade identically. R11 lowercases the captured header name
+  // before the extensions-prefix check. A sha1 chain keeps the objects valid so the degrade
+  // is config-driven.
+  const cfg = '[core]\n\trepositoryformatversion = 1\n[EXTENSIONS.X]\n\tfoo = 1\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+  assert.ok(readObject(fix.commonDir, fix.commitOid), 'the sha1 commit is independently readable — degrade is config-driven, not a bad object');
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, false);
+  assert.equal(out.reason, 'reference-unavailable', 'a case-variant [EXTENSIONS.X] header must degrade — git matches section names case-insensitively');
+});
+
+test('readHeadBlob: a dotted [branch.master] header with a key still resolves — R11 degrades only the extensions section (HIMMEL-1472 R11)', () => {
+  // Positive control: R11 special-cases ONLY dotted extensions headers. A dotted header of any
+  // other section (here [branch.master]) is still scoped out and the otherwise-default sha1
+  // repo still resolves — R11 must not over-degrade a healthy config that carries a normal
+  // branch subsection written in the legacy dotted form.
+  const cfg = '[branch.master]\n\tremote = origin\n[core]\n\trepositoryformatversion = 0\n';
+  const fix = buildRepoFormatRepo({ algo: 'sha1', config: cfg });
+  dropOnExit(fix.dir);
+
+  const out = withNoGitOnPath(() => readHeadBlob(fix.dir, 'hello.txt'));
+  assert.equal(out.ok, true, 'a non-extensions dotted header must not over-degrade — the file still resolves');
+  assert.deepEqual(out.body, Buffer.from('hello body\n'));
 });

--- a/scripts/hooks/test-check-commit-msg.ps1
+++ b/scripts/hooks/test-check-commit-msg.ps1
@@ -1,0 +1,127 @@
+# Smoke test for scripts/hooks/check-commit-msg.ps1 (HIMMEL-1483).
+# PowerShell twin of test-check-commit-msg.sh.
+$ErrorActionPreference = 'Stop'
+$SCRIPT = Join-Path $PSScriptRoot 'check-commit-msg.ps1'
+$R = Join-Path ([System.IO.Path]::GetTempPath()) ('cm-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $R -Force | Out-Null
+& git -C $R init -q
+& git -C $R config user.email 't@t'
+& git -C $R config user.name 't'
+$MSG = Join-Path $R 'COMMIT_MSG'
+$script:failures = 0
+
+function Invoke-Gate {
+    param([string]$Message, [hashtable]$Env = @{})
+    Set-Content -LiteralPath $MSG -Value $Message -NoNewline
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = (Get-Command pwsh).Source
+    $psi.ArgumentList.Add('-NoProfile')
+    $psi.ArgumentList.Add('-NonInteractive')
+    $psi.ArgumentList.Add('-File')
+    $psi.ArgumentList.Add($SCRIPT)
+    $psi.ArgumentList.Add($MSG)
+    $psi.WorkingDirectory = $R
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.UseShellExecute = $false
+    foreach ($key in @('TICKET_ID_REQUIRED','TICKET_ID_PATTERN','TICKET_ID_EXEMPT_AUTHORS','TICKET_ID_AUTHOR','TICKET_ID_TRUSTED_AUTHOR','JIRA_PROJECT_KEY')) {
+        $psi.Environment.Remove($key)
+    }
+    foreach ($key in $Env.Keys) { $psi.Environment[$key] = $Env[$key] }
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    [void]$proc.StandardOutput.ReadToEnd()
+    [void]$proc.StandardError.ReadToEnd()
+    $proc.WaitForExit()
+    return $proc.ExitCode
+}
+
+function Expect-Rc {
+    param([string]$Name, [int]$Want, [string]$Message, [hashtable]$Env = @{})
+    $rc = Invoke-Gate -Message $Message -Env $Env
+    if ($rc -eq $Want) { Write-Host "  PASS  $Name" }
+    else { Write-Host "  FAIL  $Name (rc=$rc, want $Want)"; $script:failures++ }
+}
+
+try {
+    Expect-Rc 'default OFF keeps ticket optional' 0 'feat: add feature'
+    Expect-Rc 'malformed conventional commit still rejects' 1 'not conventional'
+    Expect-Rc 'strict Jira mode rejects missing ticket' 1 'feat: add feature' @{
+        TICKET_ID_REQUIRED = '1'; JIRA_PROJECT_KEY = 'ACME'
+    }
+    Expect-Rc 'strict Jira mode accepts PROJECT-N' 0 'feat: ACME-42 add feature' @{
+        TICKET_ID_REQUIRED = '1'; JIRA_PROJECT_KEY = 'ACME'
+    }
+    Expect-Rc 'custom regex supports no-Jira #N tickets' 0 'fix: close #73' @{
+        TICKET_ID_REQUIRED = '1'; TICKET_ID_PATTERN = '#[0-9]+'
+    }
+    Expect-Rc 'strict mode fails closed without any pattern' 1 'feat: add feature' @{
+        TICKET_ID_REQUIRED = '1'
+    }
+    Expect-Rc 'invalid custom regex fails closed' 1 'feat: [ add feature' @{
+        TICKET_ID_REQUIRED = '1'; TICKET_ID_PATTERN = '['
+    }
+    Expect-Rc 'fake merge subject is not exempt' 1 "Merge branch 'main'" @{
+        TICKET_ID_REQUIRED = '1'; JIRA_PROJECT_KEY = 'ACME'
+    }
+    Expect-Rc 'bare revert subject is not exempt' 1 'Revert "feat: add feature"' @{
+        TICKET_ID_REQUIRED = '1'; JIRA_PROJECT_KEY = 'ACME'
+    }
+    # HIMMEL-1483 CR1: revert exemption now requires the reverted hash to resolve
+    # to a real commit. Seed one and use its SHA for the positive case; a
+    # fabricated hash must fall through and be rejected in strict mode.
+    & git -C $R commit -q --allow-empty -m 'feat: add feature'
+    $revertedSha = (& git -C $R rev-parse HEAD).Trim()
+    Expect-Rc 'Git-generated revert of a real commit is exempt' 0 "Revert `"feat: add feature`"`n`nThis reverts commit $revertedSha." @{
+        TICKET_ID_REQUIRED = '1'
+    }
+    Expect-Rc 'fabricated-hash revert shape falls through and is rejected' 1 "Revert `"feat: add feature`"`n`nThis reverts commit 0123456789abcdef0123456789abcdef01234567." @{
+        TICKET_ID_REQUIRED = '1'; JIRA_PROJECT_KEY = 'ACME'
+    }
+
+    $baseBranch = (& git -C $R symbolic-ref --short HEAD).Trim()
+    Set-Content -LiteralPath (Join-Path $R 'file') -Value 'base' -NoNewline
+    & git -C $R add file
+    & git -C $R commit -q -m base
+    & git -C $R checkout -q -b side
+    Set-Content -LiteralPath (Join-Path $R 'file') -Value 'side' -NoNewline
+    & git -C $R commit -q -am side
+    & git -C $R checkout -q $baseBranch
+    Set-Content -LiteralPath (Join-Path $R 'file') -Value 'main' -NoNewline
+    & git -C $R commit -q -am main
+    & git -C $R merge side *> $null
+    Expect-Rc 'real merge is exempt' 0 "Merge branch 'side'" @{
+        TICKET_ID_REQUIRED = '1'
+    }
+    & git -C $R merge --abort
+
+    Expect-Rc 'dependabot author is exempt locally' 0 'chore: bump dependency' @{
+        TICKET_ID_REQUIRED = '1'; TICKET_ID_AUTHOR = 'dependabot[bot]'
+    }
+    Expect-Rc 'trusted human blocks spoofed bot author' 1 'chore: bump dependency' @{
+        TICKET_ID_REQUIRED = '1'; JIRA_PROJECT_KEY = 'ACME'; TICKET_ID_AUTHOR = 'dependabot[bot]'; TICKET_ID_TRUSTED_AUTHOR = 'human'
+    }
+    Expect-Rc 'trusted bot and bot author are exempt' 0 'chore: bump dependency' @{
+        TICKET_ID_REQUIRED = '1'; TICKET_ID_AUTHOR = 'dependabot[bot]'; TICKET_ID_TRUSTED_AUTHOR = 'dependabot[bot]'
+    }
+    Expect-Rc 'custom author exemption list is data-driven' 0 'chore: generated update' @{
+        TICKET_ID_REQUIRED = '1'; TICKET_ID_AUTHOR = 'release-bot'; TICKET_ID_EXEMPT_AUTHORS = 'release-bot'
+    }
+    Expect-Rc 'fixup without ticket rejects in strict mode' 1 'fixup! feat: add feature' @{
+        TICKET_ID_REQUIRED = '1'; JIRA_PROJECT_KEY = 'ACME'
+    }
+    Expect-Rc 'fixup carrying ticket passes strict mode' 0 'fixup! feat: ACME-42 add feature' @{
+        TICKET_ID_REQUIRED = '1'; JIRA_PROJECT_KEY = 'ACME'
+    }
+
+    "TICKET_ID_REQUIRED=1`nJIRA_PROJECT_KEY=ENVKEY`n" | Set-Content -LiteralPath (Join-Path $R '.env') -NoNewline
+    Expect-Rc 'primary .env supplies strict mode and Jira key' 0 'docs: ENVKEY-9 update docs'
+    Expect-Rc 'live env overrides the primary .env' 0 'docs: no ticket needed' @{
+        TICKET_ID_REQUIRED = '0'
+    }
+} finally {
+    Remove-Item -LiteralPath $R -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+if ($script:failures -eq 0) { Write-Host 'OK: all cases passed'; exit 0 }
+Write-Host "FAIL: $($script:failures) case(s) failed"
+exit 1

--- a/scripts/hooks/test-check-commit-msg.sh
+++ b/scripts/hooks/test-check-commit-msg.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/hooks/check-commit-msg.sh (HIMMEL-1483).
+# Exercises default-off compatibility, strict Jira/custom patterns, and exemptions.
+set -uo pipefail
+
+HOOKS="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HOOKS/check-commit-msg.sh"
+R=$(mktemp -d -t himmel-commit-msg.XXXXXX)
+trap 'rm -rf "$R"' EXIT
+git -C "$R" init -q
+git -C "$R" config user.email t@t
+git -C "$R" config user.name t
+MSG="$R/COMMIT_MSG"
+
+run_gate() {
+  local message="$1"
+  shift
+  printf '%s\n' "$message" > "$MSG"
+  ( cd "$R" && env -u TICKET_ID_REQUIRED -u TICKET_ID_PATTERN \
+      -u TICKET_ID_EXEMPT_AUTHORS -u TICKET_ID_AUTHOR -u TICKET_ID_TRUSTED_AUTHOR -u JIRA_PROJECT_KEY \
+      "$@" bash "$SCRIPT" "$MSG" )
+}
+
+failures=0
+expect_rc() {
+  local name="$1" want="$2" message="$3"
+  shift 3
+  local rc=0
+  run_gate "$message" "$@" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -eq "$want" ]; then
+    printf '  PASS  %s\n' "$name"
+  else
+    printf '  FAIL  %s (rc=%s, want %s)\n' "$name" "$rc" "$want"
+    failures=$((failures + 1))
+  fi
+}
+
+expect_rc "default OFF keeps ticket optional" 0 "feat: add feature"
+expect_rc "malformed conventional commit still rejects" 1 "not conventional"
+expect_rc "strict Jira mode rejects missing ticket" 1 "feat: add feature" \
+  TICKET_ID_REQUIRED=1 JIRA_PROJECT_KEY=ACME
+expect_rc "strict Jira mode accepts PROJECT-N" 0 "feat: ACME-42 add feature" \
+  TICKET_ID_REQUIRED=1 JIRA_PROJECT_KEY=ACME
+expect_rc "custom regex supports no-Jira #N tickets" 0 "fix: close #73" \
+  TICKET_ID_REQUIRED=1 'TICKET_ID_PATTERN=#[0-9]+'
+expect_rc "strict mode fails closed without any pattern" 1 "feat: add feature" \
+  TICKET_ID_REQUIRED=1
+expect_rc "invalid custom regex fails closed" 1 "feat: [ add feature" \
+  TICKET_ID_REQUIRED=1 'TICKET_ID_PATTERN=['
+expect_rc "fake merge subject is not exempt" 1 "Merge branch 'main'" \
+  TICKET_ID_REQUIRED=1 JIRA_PROJECT_KEY=ACME
+expect_rc "bare revert subject is not exempt" 1 'Revert "feat: add feature"' \
+  TICKET_ID_REQUIRED=1 JIRA_PROJECT_KEY=ACME
+# HIMMEL-1483 CR1: the revert exemption now requires the reverted hash to
+# resolve to a real commit (git cat-file -e). Seed one and use its SHA for the
+# positive case; a fabricated hash must fall through and be rejected in strict.
+git -C "$R" commit -q --allow-empty -m "feat: add feature"
+REVERTED_SHA=$(git -C "$R" rev-parse HEAD)
+expect_rc "Git-generated revert of a real commit is exempt" 0 \
+  "Revert \"feat: add feature\"
+
+This reverts commit ${REVERTED_SHA}." \
+  TICKET_ID_REQUIRED=1
+expect_rc "fabricated-hash revert shape falls through and is rejected" 1 \
+  $'Revert "feat: add feature"\n\nThis reverts commit 0123456789abcdef0123456789abcdef01234567.' \
+  TICKET_ID_REQUIRED=1 JIRA_PROJECT_KEY=ACME
+
+BASE_BRANCH=$(git -C "$R" symbolic-ref --short HEAD)
+printf 'base\n' > "$R/file"
+git -C "$R" add file
+git -C "$R" commit -q -m base
+git -C "$R" checkout -q -b side
+printf 'side\n' > "$R/file"
+git -C "$R" commit -q -am side
+git -C "$R" checkout -q "$BASE_BRANCH"
+printf 'main\n' > "$R/file"
+git -C "$R" commit -q -am main
+git -C "$R" merge side >/dev/null 2>&1 || true
+expect_rc "real merge is exempt" 0 "Merge branch 'side'" TICKET_ID_REQUIRED=1
+git -C "$R" merge --abort
+
+expect_rc "dependabot author is exempt locally" 0 "chore: bump dependency" \
+  TICKET_ID_REQUIRED=1 'TICKET_ID_AUTHOR=dependabot[bot]'
+expect_rc "trusted human blocks spoofed bot author" 1 "chore: bump dependency" \
+  TICKET_ID_REQUIRED=1 JIRA_PROJECT_KEY=ACME 'TICKET_ID_AUTHOR=dependabot[bot]' TICKET_ID_TRUSTED_AUTHOR=human
+expect_rc "trusted bot and bot author are exempt" 0 "chore: bump dependency" \
+  TICKET_ID_REQUIRED=1 'TICKET_ID_AUTHOR=dependabot[bot]' 'TICKET_ID_TRUSTED_AUTHOR=dependabot[bot]'
+expect_rc "custom author exemption list is data-driven" 0 "chore: generated update" \
+  TICKET_ID_REQUIRED=1 TICKET_ID_AUTHOR=release-bot TICKET_ID_EXEMPT_AUTHORS=release-bot
+# HIMMEL-1483 CR2: `dependabot[bot]` is a GLOB — a matching file in the hook's
+# cwd (e.g. `dependabotb`) used to pathname-expand the unquoted list expansion
+# and silently break the exemption. Globbing is now off around the split.
+touch "$R/dependabotb"
+expect_rc "glob-matching file in cwd does not break the bot exemption" 0 "chore: bump dependency" \
+  TICKET_ID_REQUIRED=1 'TICKET_ID_AUTHOR=dependabot[bot]'
+rm -f "$R/dependabotb"
+expect_rc "fixup without ticket rejects in strict mode" 1 "fixup! feat: add feature" \
+  TICKET_ID_REQUIRED=1 JIRA_PROJECT_KEY=ACME
+expect_rc "fixup carrying ticket passes strict mode" 0 "fixup! feat: ACME-42 add feature" \
+  TICKET_ID_REQUIRED=1 JIRA_PROJECT_KEY=ACME
+
+printf 'TICKET_ID_REQUIRED=1\nJIRA_PROJECT_KEY=ENVKEY\n' > "$R/.env"
+expect_rc "primary .env supplies strict mode and Jira key" 0 "docs: ENVKEY-9 update docs"
+expect_rc "live env overrides the primary .env" 0 "docs: no ticket needed" TICKET_ID_REQUIRED=0
+
+if [ "$failures" -eq 0 ]; then
+  echo "OK: all cases passed"
+  exit 0
+fi
+echo "FAIL: $failures case(s) failed"
+exit 1

--- a/scripts/lib/cr-ledger-evidence.sh
+++ b/scripts/lib/cr-ledger-evidence.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# cr-ledger-evidence.sh — does the CR critic panel carry the gate at this SHA?
+# (HIMMEL-1465.)
+#
+# WHY THIS EXISTS. CodeRabbit's App review is rate limited at times, and when it
+# is it posts state=success + description="Review rate limited" — a DECLINED
+# review that cr-signal.sh projects to state=skipped (HIMMEL-1354). Both the
+# certifier (check-ci.sh) and the merge hook (cr-merge-gate.sh, the CR gate
+# behind block-unresolved-cr-merge.sh) fail CLOSED on that, so a rate-limited
+# App blocks a merge even when the critic PANEL (codex+glm) had already reviewed
+# the exact head cleanly and recorded that in the CR ledger. The operator's
+# standing rule (stated 3x since 2026-07-30): when the App is rate-limited, a
+# CLEAN panel at the PR's CURRENT head + 0 unresolved threads carries the gate.
+#
+# This lib is the ONE reader for that evidence. The verdict it derives MIRRORS
+# scripts/cr/clear-cr-marker.sh gates 3-4 exactly — the same amend application,
+# the same atHead resolution (short SHAs resolved through git, never prefix
+# match), the same responder floor (>=1 `avail ... status=ok`), and the same
+# blocking definition (crit|imp whose verdict is neither `disproved` nor a
+# TRACKED `deferred`). clear-cr-marker is the reference; this is the same
+# evaluation factored for the two MERGE gates. A future unification would move
+# clear-cr-marker onto this reader too — left out of HIMMEL-1465 to keep that
+# change off the most-sensitive surface (clear-cr-marker is untouched here).
+#
+# Evidence-gated, fail-closed, NEVER a free pass: this only ANSWERS the question
+# "did the panel carry the gate at this head". The caller decides whether that
+# answer lets a rate-limited CodeRabbit skip stand, and ONLY ever asks it on the
+# rate-limited description (the sole skip wording that is panel-carriable). A
+# clean ledger never waves through an ABSENT, pending, failed, or
+# auto-reviews-disabled CodeRabbit review — those keep their current verdict.
+#
+# cr_ledger_carries_gate <full-sha>
+#   rc 0 = the panel CARRIES the gate at this SHA: >=1 responder recorded
+#          `avail ... status=ok` here AND no blocking finding AND no malformed
+#          ledger line. stdout: "carried responders=<N> models=<comma list>"
+#          (the responder models, for the merge-gate audit line).
+#   rc 1 = the panel does NOT carry the gate here, OR the evidence cannot be
+#          read reliably (no git dir / no node / ledger unreadable / malformed
+#          line / zero responders / a blocking finding). stdout: a short
+#          machine reason (no-git-dir|no-node|ledger-unreadable|malformed:N|
+#          no-responders|blocking:<ids>). The caller treats rc 1 uniformly as
+#          "evidence absent -> current verdict stands" (HIMMEL-1465): for
+#          check-ci that is exit 2, for cr-merge-gate it is rc 2 (block).
+#
+# GATE INTEGRITY (mirrors clear-cr-marker.sh / merge-on-green.sh): the ledger
+# path is FIXED at `<git-common-dir>/cr-critic-scores.jsonl` and is NOT
+# environment-overridable here. ledger-append.sh honors a CR_LEDGER override for
+# its WRITES, but this GATE must never read a caller-pointed ledger — that would
+# let a contaminated environment forge the evidence the carry depends on.
+# check-ci.sh / cr-merge-gate.sh / gh are likewise not overridable from here.
+#
+# Sourceable from check-ci.sh and cr-merge-gate.sh: uses only `return`, never
+# `exit`; does not toggle set -e. bash 3.2-safe.
+
+cr_ledger_carries_gate() {
+    local full_sha="${1:-}"
+
+    # Resolve the FIXED ledger location. Empty (no git dir) => cannot read
+    # evidence => not carried.
+    local git_dir
+    git_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+    if [ -z "$git_dir" ]; then
+        printf 'no-git-dir\n'; return 1
+    fi
+    local ledger="$git_dir/cr-critic-scores.jsonl"
+
+    # node reads + evaluates the ledger. Missing => cannot read => not carried.
+    command -v node >/dev/null 2>&1 || { printf 'no-node\n'; return 1; }
+
+    # The evaluation mirrors clear-cr-marker.sh gates 3-4 verbatim (amend
+    # application, atHead resolution, responder floor, blocking definition). The
+    # block is single-quoted for the shell, so NO apostrophes / backticks /
+    # dollar-braces may appear inside it (same constraint as clear-cr-marker's
+    # twin block). It emits a SPACE-delimited decision line the bash below
+    # parses with `case` (no jq/node second pass needed). carried=<0|1> is the
+    # verdict; responders=/models= ride along for the audit line on a carry,
+    # reason= names the refusal otherwise.
+    local line
+    line=$(LEDGER="$ledger" FULL_SHA="$full_sha" node -e '
+      const fs = require("fs"), e = process.env;
+      const lines = fs.existsSync(e.LEDGER)
+          ? fs.readFileSync(e.LEDGER, "utf8").split("\n").filter(Boolean) : [];
+      const cp = require("child_process");
+      // atHead: a ledger head is EVIDENCE — it must name this commit, not merely
+      // look like it. Prefix equality accepted any record whose head shared the
+      // first 7 chars, so a DIFFERENT commit with a colliding abbreviation
+      // satisfied the gate. /pr-check writes SHORT heads, so short-SHA support
+      // survives via RESOLVE-then-compare; an unresolvable or ambiguous
+      // abbreviation resolves to null and matches nothing.
+      const HEX = "0123456789abcdef";
+      const isHex = (s) => s.length >= 7 && s.length <= 40 &&
+          s.split("").every((c) => HEX.indexOf(c) >= 0);
+      const cache = new Map();
+      const resolve = (h) => {
+          if (!cache.has(h)) {
+              let full = null;
+              try {
+                  full = cp.execFileSync("git",
+                      ["rev-parse", "--verify", "--quiet", h + "^{commit}"],
+                      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+              } catch { full = null; }
+              cache.set(h, full || null);
+          }
+          return cache.get(h);
+      };
+      const atHead = (o) => {
+          const h = String(o.head || "");
+          // Exact string equality FIRST: a head identical to the one the caller
+          // asked about IS evidence at that head, hex-shaped or not. In
+          // production FULL_SHA is a full 40-hex oid, so any h equal to it is
+          // hex anyway and this ordering is semantically identical — it only
+          // lets hermetic suites use short stub heads. isHex then gates ONLY
+          // the resolve path, where prefix collisions are the actual risk.
+          if (e.FULL_SHA === h) return true;
+          if (!isHex(h)) return false;
+          return resolve(h) === e.FULL_SHA;
+      };
+      // A malformed record is a REFUSAL, not a skip: silently skipping
+      // unparseable lines fails OPEN (a blocking finding corrupted while an
+      // avail-ok line stays readable would clear the gate unevaluated). An
+      // unreadable ledger is an unknown verdict, and unknown is never clean.
+      let responders = 0, models = [], blocking = [], malformed = 0;
+      // AMENDS: the ledger is append-only, so a correction arrives as a
+      // supersede record. Collect them FIRST (keyed by the ORIGINAL tuple) and
+      // apply before any finding is judged, so a correction (wrong severity,
+      // wrong head) actually takes effect. Later amends win per key; a set.head
+      // re-keys the finding, so atHead evaluates it against its real head.
+      // SEP is U+001F (unit separator) via fromCharCode — no raw control byte
+      // in the file, and U+001F cannot occur in a sha/slug/artifact/perspective
+      // (so two tuples cannot flatten to one key and mis-route an amend).
+      const SEP = String.fromCharCode(31);
+      const amends = new Map();
+      for (const l of lines) {
+          let a;
+          try { a = JSON.parse(l); } catch { continue; }
+          if (a.kind !== "amend" || !a.set || typeof a.set !== "object") continue;
+          const k = [a.target_head, a.finding_id, a.artifact || "diff", a.perspective || "off"].join(SEP);
+          amends.set(k, Object.assign({}, amends.get(k) || {}, a.set));
+      }
+      for (const l of lines) {
+          let o;
+          try { o = JSON.parse(l); } catch { malformed++; continue; }
+          if (o.kind === "amend") continue;
+          if (o.kind === "finding") {
+              const k = [o.head, o.finding_id, o.artifact || "diff", o.perspective || "off"].join(SEP);
+              if (amends.has(k)) o = Object.assign({}, o, amends.get(k));
+          }
+          if (!atHead(o)) continue;
+          if (o.kind === "avail" && o.status === "ok") {
+              responders++;
+              const model = (typeof o.model === "string" ? o.model : "").trim();
+              if (model) models.push(model);
+          }
+          if (o.kind === "finding" && (o.severity === "crit" || o.severity === "imp")
+              && o.verdict !== "disproved") {
+              // DEFERRAL: accepted ONLY when TRACKED — verdict deferred AND a
+              // ticket key AND a reason. A bare "deferred" stays blocking (a
+              // third truthful exit, not a free pass).
+              const ticket = typeof o.deferred_to === "string" ? o.deferred_to.trim() : "";
+              const why = typeof o.reason === "string" ? o.reason.trim() : "";
+              if (o.verdict === "deferred" && /^[A-Z][A-Z0-9]*-[0-9]+$/.test(ticket) && why) {
+                  continue;
+              }
+              blocking.push((o.finding_id || "?") + "(" + o.severity + "," +
+                  (o.verdict || "no-verdict") + ")");
+          }
+      }
+      if (malformed > 0) {
+          process.stdout.write("carried=0 reason=malformed:" + malformed);
+      } else if (responders < 1) {
+          process.stdout.write("carried=0 reason=no-responders");
+      } else if (blocking.length > 0) {
+          process.stdout.write("carried=0 reason=blocking:" + blocking.join(","));
+      } else {
+          process.stdout.write("carried=1 responders=" + responders +
+              " models=" + (models.length ? models.join(",") : "?"));
+      }
+    ' 2>/dev/null) || line=""
+    if [ -z "$line" ]; then
+        printf 'ledger-unreadable\n'; return 1
+    fi
+
+    # Parse the decision line (key=value tokens). `case` anchors each token
+    # from its start, so carried= / reason= / responders= / models= never
+    # collide regardless of order.
+    local carried="" reason="" responders="" models="" tok
+    for tok in $line; do
+        case "$tok" in
+            carried=*)   carried=${tok#carried=} ;;
+            reason=*)    reason=${tok#reason=} ;;
+            responders=*) responders=${tok#responders=} ;;
+            models=*)    models=${tok#models=} ;;
+        esac
+    done
+    if [ "$carried" = "1" ]; then
+        printf 'carried responders=%s models=%s\n' "${responders:-?}" "${models:-?}"
+        return 0
+    fi
+    printf '%s\n' "${reason:-not-carried}"
+    return 1
+}

--- a/scripts/lib/cr-merge-gate.sh
+++ b/scripts/lib/cr-merge-gate.sh
@@ -60,6 +60,13 @@ _cmg_degrade() { echo "cr-merge-gate: degraded ($*) - failing open" >&2; }
 # shellcheck disable=SC1091  # sourced at runtime; checked standalone by pre-commit
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/cr-available.sh"
 
+# The CR-ledger evidence reader (HIMMEL-1465): tells the skipped arm below
+# whether a CLEAN critic panel carried the gate at the head, so a rate-limited
+# CodeRabbit App need not block a direct `gh pr merge` when the panel reviewed.
+# shellcheck source=scripts/lib/cr-ledger-evidence.sh
+# shellcheck disable=SC1091  # sourced at runtime; checked standalone by pre-commit
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/cr-ledger-evidence.sh"
+
 # _cmg_canon_nwo <value> — canonical lowercase "owner/name", rc 1 if <value> is
 # not one — as canonical "HOST/OWNER/NAME", host included. Two spellings would
 # otherwise smuggle a merge past the gate (coderabbit-9), because anything that
@@ -283,8 +290,36 @@ cr_merge_gate() {
                 # is rate limited. A declined review must not merge, for the
                 # same reason `absent` must not. Wording aligned with
                 # check-ci.sh's twin arm so both gates agree.
-                echo "BLOCK: CodeRabbit SKIPPED the review on head $head of PR #$num — it posted success, but its description does not say the review completed. A DECLINED review is not a clean one. Known causes: automatic reviews are disabled on this repo (trigger one with a '@coderabbitai review' comment, wait for it to conclude, then re-check), or CodeRabbit is RATE LIMITED (HIMMEL-1354 — wait for the limit to reset; do NOT re-trigger in a loop). If this repo has no CodeRabbit, set CR_PROFILE=none. Bypass: CR_MERGE_GATE_OK=1."
-                return 2 ;;
+                #
+                # HIMMEL-1465: ONLY the rate-limited decline is panel-carriable.
+                # When the description is the rate-limit shape, a CLEAN critic
+                # panel at this head carries the gate (operator standing rule) —
+                # the same ledger evidence clear-cr-marker.sh gates 3-4 read,
+                # evaluated by cr_ledger_carries_gate. A carried panel does NOT
+                # merge here outright: it falls through to the thread + body
+                # gates below exactly like a `success`, so "0 unresolved threads"
+                # still binds. A rate-limited App with no clean panel, or any
+                # other skip wording, keeps the BLOCK. Evidence is required for
+                # the exception, so a description/ledger we cannot read falls
+                # back to the block (the default for `skipped`), not a fail-open
+                # allow.
+                local rl_desc rl_low rl_panel
+                rl_desc=$(cr_signal_description "$owner" "$name" "$head" 2>/dev/null || true)
+                rl_low=$(printf '%s' "$rl_desc" | tr '[:upper:]' '[:lower:]')
+                case "$rl_low" in
+                    *rate?limit*|*ratelimit*) : ;;  # only rate-limit is panel-carriable
+                    *)
+                        echo "BLOCK: CodeRabbit SKIPPED the review on head $head of PR #$num — it posted success, but its description does not say the review completed. A DECLINED review is not a clean one. Known causes: automatic reviews are disabled on this repo (trigger one with a '@coderabbitai review' comment, wait for it to conclude, then re-check), or CodeRabbit is RATE LIMITED (HIMMEL-1354 — wait for the limit to reset; do NOT re-trigger in a loop). If this repo has no CodeRabbit, set CR_PROFILE=none. Bypass: CR_MERGE_GATE_OK=1."
+                        return 2 ;;
+                esac
+                if rl_panel=$(cr_ledger_carries_gate "$head"); then
+                    echo "ALLOW-note: CodeRabbit is rate-limited on head $head of PR #$num but the critic panel carries the gate ($rl_panel); the thread + body gates below still apply (HIMMEL-1465)." >&2
+                    # fall through to the thread + body gates (like a `success`)
+                else
+                    echo "BLOCK: CodeRabbit is rate-limited on head $head of PR #$num and the critic panel did NOT carry the gate at this head (ledger: $rl_panel) — a rate-limited App with no clean panel is not a clean one. Wait for the App's limit to reset, or run /pr-check on this HEAD so a panel reviews it. Bypass: CR_MERGE_GATE_OK=1."
+                    return 2
+                fi
+                ;;
             *)
                 # Fail CLOSED on an unrecognised state. This case had no
                 # catch-all, so a state cr-signal.sh learns to emit LATER would

--- a/scripts/lib/cr-signal.sh
+++ b/scripts/lib/cr-signal.sh
@@ -71,6 +71,15 @@
 #   which forks a subshell — a global set inside could never reach them.
 #   cr_signal_state is the thin wrapper for callers that only need the state.
 #
+# cr_signal_description <owner> <name> <sha>
+#   stdout: the CodeRabbit status DESCRIPTION on this SHA (empty when it carries
+#           none, or no CodeRabbit status exists). rc 0 = read ok (incl. empty);
+#           rc 1 = cannot evaluate. Same identity-matched query as the probe, so
+#           the description belongs to the status cr_signal_state classified.
+#           Added for HIMMEL-1465: a rate-limited skip and an auto-reviews-
+#           disabled skip both project to `skipped`, and only rate-limiting is
+#           panel-carriable — the gates need the description to tell them apart.
+#
 #   A SHA that does not exist returns `[]` with HTTP 200 on this endpoint, so it
 #   is indistinguishable from "no CodeRabbit status" and reports "absent". That
 #   conflation is safe in one direction only — every caller fails CLOSED on
@@ -188,6 +197,56 @@ cr_signal_state() {
     local probe
     probe=$(cr_signal_probe "$@") || return 1
     printf '%s\n' "${probe%% *}"
+}
+
+# cr_signal_description <owner> <name> <sha>
+#   stdout: CodeRabbit's status DESCRIPTION for this SHA (empty when the status
+#           carries no description, or no CodeRabbit status exists on the SHA).
+#   rc 0 = read ok (incl. an empty description); rc 1 = cannot evaluate (query
+#           or parse failure — the caller decides open/closed, this reader does
+#           not).
+#
+#   Reuses the SAME identity-matched /statuses LIST query as cr_signal_probe
+#   (first match = newest = current verdict), so the description this returns
+#   is the one belonging to the very status cr_signal_state classified — the
+#   ONE-reader invariant this file exists to hold.
+#
+#   HIMMEL-1465: cr_signal_state collapses every decline wording to a single
+#   `skipped` state (HIMMEL-1317/1354), so a caller cannot tell a RATE-LIMITED
+#   skip ("Review rate limited", which a clean critic PANEL may carry) from an
+#   auto-reviews-DISABLED skip ("Review skipped: ...", which nothing carries)
+#   from the state alone. This reader exposes the description so the MERGE
+#   gates can make that policy call themselves — it stays a NEUTRAL reader and
+#   owns no panel-carriable vocabulary (the rate-limit discrimination lives in
+#   check-ci.sh / cr-merge-gate.sh, where the merge verdict does).
+cr_signal_description() {
+    local owner="$1" name="$2" sha="$3"
+    local uid ctx
+    uid=$(cr_signal_bot_id)
+    ctx=$(cr_signal_context)
+
+    if [ -z "$owner" ] || [ -z "$name" ] || [ -z "$sha" ]; then return 1; fi
+    case "$uid" in ''|*[!0-9]*) return 1 ;; esac
+
+    local json
+    json=$(_crs_gh api "repos/$owner/$name/commits/$sha/statuses?per_page=100" 2>/dev/null) || return 1
+
+    # Same canary as cr_signal_probe: a valid payload is a JSON array (possibly
+    # empty); anything else is a query/parse failure (rc 1), distinct from a
+    # well-formed array whose CodeRabbit status simply carries no description.
+    local kind
+    kind=$(printf '%s' "$json" | jq -r 'if type=="array" then "array" else empty end' 2>/dev/null || true)
+    [ "$kind" = "array" ] || return 1
+
+    # First identity match (newest-first). An absent status yields "" — the
+    # caller only reaches this on state=skipped, where a status provably exists.
+    printf '%s\n' "$(printf '%s' "$json" | jq -r --arg ctx "$ctx" --argjson uid "$uid" '
+        [ .[]?
+          | select(.creator.id == $uid)
+          | select(.creator.type == "Bot")
+          | select(.context == $ctx)
+        ] | first | (.description // "")' 2>/dev/null || true)"
+    return 0
 }
 
 cr_signal_probe() {

--- a/scripts/lib/load-dotenv.sh
+++ b/scripts/lib/load-dotenv.sh
@@ -45,6 +45,62 @@ _load_dotenv_root() {
     ( cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd )
 }
 
+# _load_dotenv_primary_for <dir> (HIMMEL-1482) — resolve the .env-bearing root for
+# a CANDIDATE directory, for launchers that pin the .env to their OWN repo root via
+# `load_dotenv --root` (which deliberately bypasses _load_dotenv_root's CWD-based
+# resolution). The gitignored .env lives ONLY in the primary checkout and is never
+# copied into linked worktrees, so a launcher invoked from a worktree copy of itself
+# (its parent dir is a worktree root) finds no .env at <dir> and would exit 2.
+#   <dir>/.env present             → echo <dir> (already the .env-bearing root)
+#   <dir> is a linked git worktree → echo the PRIMARY checkout root (parent of
+#                                    `git rev-parse --git-common-dir`) when its
+#                                    .env exists; emit ONE advisory line to stderr
+#   otherwise                      → echo <dir> (caller's missing-.env path applies
+#                                    — load_dotenv then no-ops, rc 0)
+# Mirrors glm-env.ts mainCheckoutRoot() (HIMMEL-654) for the bash side. Returns the
+# path on stdout; the advisory is the helper's ONLY stderr output.
+_load_dotenv_primary_for() {  # $1 = candidate root dir
+    local dir="${1:-}" common primary dir_abs toplevel gitdir dir_phys
+    [ -n "$dir" ] || dir="$(_load_dotenv_root)"
+    [ -f "$dir/.env" ] && { printf '%s' "$dir"; return 0; }
+    dir_abs=$(cd "$dir" 2>/dev/null && pwd) || { printf '%s' "$dir"; return 0; }
+    # Resolve the primary only when <dir> is a linked worktree. cd into <dir>
+    # first so a relative --git-common-dir resolves against <dir> (not the shell
+    # cwd); an absolute path cd's equally well — `( cd "$common/.." && pwd )` is
+    # the same idiom _load_dotenv_root uses.
+    if common=$(cd "$dir" && git rev-parse --git-common-dir 2>/dev/null) && [ -n "$common" ]; then
+        primary=$(cd "$dir" && cd "$common/.." 2>/dev/null && pwd) || primary=""
+        # HIMMEL-1482 R2: restrict the fallback to GENUINE linked-worktree ROOTS.
+        # r1 gated only on `primary != candidate`, so ANY directory inside ANY
+        # checkout qualified — a hermetically pinned root like <worktree>/scripts
+        # (or <primary>/scripts) resolved common-dir to the real .git, differed
+        # from the candidate, and silently loaded the operator's .env, breaking
+        # the documented hermetic override. Two guards:
+        #  (1) the candidate must BE its checkout root: --show-toplevel (git's
+        #      resolved, physical form) == the candidate's physical path (pwd -P),
+        #      so a NESTED dir inside a worktree or the primary never qualifies;
+        #  (2) the checkout must be genuinely LINKED: --git-dir differs from
+        #      --git-common-dir (equal = primary checkout → nothing to fall back
+        #      FROM). Both resolve relative to <dir>, so the raw outputs compare.
+        dir_phys=$(cd "$dir" && pwd -P)
+        toplevel=$(cd "$dir" && git rev-parse --show-toplevel 2>/dev/null) || toplevel=""
+        # Re-resolve git's toplevel through bash cd+pwd -P so it lands in the
+        # same physical (MSYS on Windows) form as dir_phys — git for Windows
+        # prints a drive-letter path that never string-equals a bash pwd, and on
+        # macOS /tmp → /private/tmp must resolve identically on both sides.
+        [ -n "$toplevel" ] && toplevel=$(cd "$toplevel" 2>/dev/null && pwd -P)
+        gitdir=$(cd "$dir" && git rev-parse --git-dir 2>/dev/null) || gitdir=""
+        if [ -n "$primary" ] && [ -n "$toplevel" ] && [ "$toplevel" = "$dir_phys" ] \
+           && [ -n "$gitdir" ] && [ "$gitdir" != "$common" ] \
+           && [ "$primary" != "$dir_abs" ] && [ -f "$primary/.env" ]; then
+            echo "load-dotenv: .env absent under worktree '$dir_abs' — reading the primary checkout's .env at '$primary'." >&2
+            printf '%s' "$primary"
+            return 0
+        fi
+    fi
+    printf '%s' "$dir"
+}
+
 load_dotenv() {
     local root=""
     if [ "${1:-}" = "--root" ]; then

--- a/scripts/lib/test-cr-merge-gate.sh
+++ b/scripts/lib/test-cr-merge-gate.sh
@@ -65,6 +65,9 @@ case "$1 $2" in
       # CONTAINS skip-ish words must not block.
       cr-nearmiss) echo '[{"context":"CodeRabbit","state":"success","description":"No review changes requested","created_at":"2026-07-16T19:10:05Z","creator":{"id":136622811,"login":"coderabbitai[bot]","type":"Bot"}}]' ;;
       cr-failure) echo '[{"context":"CodeRabbit","state":"failure","created_at":"2026-07-16T19:10:05Z","creator":{"id":136622811,"login":"coderabbitai[bot]","type":"Bot"}}]' ;;
+      # HIMMEL-1465: the rate-limit decline — same skipped-state projection as
+      # cr-skipped, but the ONE wording a clean critic panel may carry.
+      cr-ratelimited) echo '[{"context":"CodeRabbit","state":"success","description":"Review rate limited","created_at":"2026-07-16T19:10:05Z","creator":{"id":136622811,"login":"coderabbitai[bot]","type":"Bot"}}]' ;;
       # An impostor: right context + right login, WRONG creator.id. The whole
       # point of HIMMEL-1058's identity match — display names are spoofable,
       # the bot's user id is not.
@@ -156,6 +159,17 @@ GH_STUB_MODE=cr-superseded t cr-status-superseded-pending-allows 0
 GH_STUB_MODE=cr-paged       t cr-status-page-limit-blocks 2
 # ...but a match ON the full page is the newest by construction -> allow.
 GH_STUB_MODE=cr-paged-found t cr-status-found-on-full-page-allows 0
+# HIMMEL-1465: a rate-limited decline with NO panel evidence in this repo's CR
+# ledger keeps the block — evidence-gated, never a free pass.
+GH_STUB_MODE=cr-ratelimited t cr-status-ratelimited-no-panel-blocks 2
+# ...and the SAME decline with a clean panel avail-ok recorded at the head is
+# panel-carried: it falls through to the thread + body gates (clean here) and
+# allows. Head "abc123" is 6 chars — below atHead's 7-char isHex floor — so it
+# matches ONLY by atHead's equality-first check, never by prefix resolution.
+printf '%s\n' '{"kind":"avail","ts":"2026-08-03T00:00:00Z","branch":"feat/x","head":"abc123","model":"codex","status":"ok","artifact":"diff","perspective":"off","responding_model":"gpt-5.5"}' > "$TMP/repo/.git/cr-critic-scores.jsonl"
+GH_STUB_MODE=cr-ratelimited t cr-status-ratelimited-panel-carried-allows 0
+# scrub the scratch ledger so no later case inherits the carry evidence
+rm -f "$TMP/repo/.git/cr-critic-scores.jsonl"
 
 # ORDER: the verdict must be read BEFORE the thread query (coderabbit-10).
 # Threads-first loses a race — snapshot threads (clean) -> CodeRabbit posts

--- a/scripts/lib/test-load-dotenv.sh
+++ b/scripts/lib/test-load-dotenv.sh
@@ -110,6 +110,77 @@ assert_eq "T13 --root non-clobbering" "live" "$got"
 out=$( cd "$NONGIT" && unset HIMMEL_INITIATIVE && load_dotenv --root "$NONGIT" HIMMEL_INITIATIVE; rc=$?; printf '%s|%s' "${HIMMEL_INITIATIVE:-<unset>}" "$rc" )
 assert_eq "T14 --root no .env no-op" "<unset>|0" "$out"
 
+# ── _load_dotenv_primary_for (HIMMEL-1482): primary-checkout fallback for a ───
+# pinned --root — the claude-codex path. A launcher invoked from a worktree copy
+# of itself has <parent> = worktree root (no .env); the helper resolves the
+# primary and reads .env there. canonicalize() compares paths by their resolved
+# form (avoids macOS /tmp → /private/tmp and drive-form mismatches).
+canon() { ( cd "$1" 2>/dev/null && pwd ); }
+PFREPO="$TMP/pf-repo"; mkdir -p "$PFREPO"; git -C "$PFREPO" init --quiet
+git -C "$PFREPO" config user.email t@example.com
+git -C "$PFREPO" config user.name tester
+git -C "$PFREPO" commit --allow-empty -q -m init
+printf 'CLIPROXY_API_KEY=pk-from-primary\n' > "$PFREPO/.env"   # gitleaks:allow
+PFWT="$TMP/pf-wt"
+git -C "$PFREPO" worktree add -q "$PFWT" -b pf-branch
+
+# T15: candidate is a linked worktree with NO .env → resolves the PRIMARY (which
+# has .env), and emits exactly ONE advisory line to stderr.
+root=$( _load_dotenv_primary_for "$PFWT" 2>/dev/null )
+assert_eq "T15 worktree → primary root" "$(canon "$PFREPO")" "$(canon "$root")"
+adv=$( _load_dotenv_primary_for "$PFWT" 2>&1 1>/dev/null )
+case "$adv" in *"reading the primary checkout's .env"*) echo "PASS T15 advisory emitted" ;; *) echo "FAIL T15 advisory — got: $adv"; FAILED=$((FAILED + 1)) ;; esac
+
+# T16: candidate is the primary (has .env) → returned unchanged, NO advisory.
+assert_eq "T16 primary unchanged" "$(canon "$PFREPO")" "$(canon "$(_load_dotenv_primary_for "$PFREPO" 2>/dev/null)")"
+adv=$( _load_dotenv_primary_for "$PFREPO" 2>&1 1>/dev/null )
+if [ -z "$adv" ]; then echo "PASS T16 no advisory on primary"; else echo "FAIL T16 advisory leaked: $adv"; FAILED=$((FAILED + 1)); fi
+
+# T17: both missing (worktree AND primary have no .env) → returns the candidate
+# unchanged, NO advisory (the caller's missing-.env path applies — load_dotenv
+# no-ops, the key stays unset, the launcher's own error message surfaces).
+rm -f "$PFREPO/.env"
+root=$( _load_dotenv_primary_for "$PFWT" 2>/dev/null )
+assert_eq "T17 both-missing returns candidate" "$(canon "$PFWT")" "$(canon "$root")"
+adv=$( _load_dotenv_primary_for "$PFWT" 2>&1 1>/dev/null )
+if [ -z "$adv" ]; then echo "PASS T17 no advisory on both-missing"; else echo "FAIL T17 advisory leaked: $adv"; FAILED=$((FAILED + 1)); fi
+printf 'CLIPROXY_API_KEY=pk-from-primary\n' > "$PFREPO/.env"   # gitleaks:allow  (restore for T18)
+
+# T18: integration — load_dotenv --root <helper-resolved worktree> finds the key
+# in the PRIMARY .env (exactly what claude-codex does). Run from the worktree's
+# own cwd to prove --root + helper reaches the primary regardless of CWD.
+got=$( cd "$PFWT" && unset CLIPROXY_API_KEY && load_dotenv --root "$(_load_dotenv_primary_for "$PFWT")" CLIPROXY_API_KEY && printf '%s' "${CLIPROXY_API_KEY:-<unset>}" )
+assert_eq "T18 load_dotenv via helper finds primary key" "pk-from-primary" "$got"
+
+# T19: a non-git candidate dir → returned unchanged (git fails, no fallback, no
+# advisory) — hermetic tests that pin the root to a temp dir are unaffected.
+PFNONGIT="$TMP/pf-nongit"; mkdir -p "$PFNONGIT"
+assert_eq "T19 non-git returns candidate" "$(canon "$PFNONGIT")" "$(canon "$(_load_dotenv_primary_for "$PFNONGIT" 2>/dev/null)")"
+adv=$( _load_dotenv_primary_for "$PFNONGIT" 2>&1 1>/dev/null )
+if [ -z "$adv" ]; then echo "PASS T19 no advisory on non-git"; else echo "FAIL T19 advisory leaked: $adv"; FAILED=$((FAILED + 1)); fi
+
+# T20 (HIMMEL-1482 R2): a NESTED dir INSIDE a worktree (NOT the worktree root)
+# must NOT read the primary .env. A hermetically pinned root like
+# <worktree>/scripts resolves common-dir to the real .git and (under r1) differed
+# from the candidate → silently loaded the operator's .env. The candidate is not
+# the checkout root, so the fallback must NOT fire (primary .env still present).
+PFWTNEST="$PFWT/nested"; mkdir -p "$PFWTNEST"
+root=$( _load_dotenv_primary_for "$PFWTNEST" 2>/dev/null )
+assert_eq "T20 nested-in-worktree returns candidate" "$(canon "$PFWTNEST")" "$(canon "$root")"
+adv=$( _load_dotenv_primary_for "$PFWTNEST" 2>&1 1>/dev/null )
+if [ -z "$adv" ]; then echo "PASS T20 no advisory on nested-in-worktree"; else echo "FAIL T20 advisory leaked: $adv"; FAILED=$((FAILED + 1)); fi
+
+# T21 (HIMMEL-1482 R2): a NESTED dir INSIDE the primary checkout must NOT fall
+# back either — git-dir == git-common-dir here (primary checkout), so there is no
+# linked worktree to fall back from, and the candidate is not the toplevel.
+PFPRIMNEST="$PFREPO/nested"; mkdir -p "$PFPRIMNEST"
+root=$( _load_dotenv_primary_for "$PFPRIMNEST" 2>/dev/null )
+assert_eq "T21 nested-in-primary returns candidate" "$(canon "$PFPRIMNEST")" "$(canon "$root")"
+adv=$( _load_dotenv_primary_for "$PFPRIMNEST" 2>&1 1>/dev/null )
+if [ -z "$adv" ]; then echo "PASS T21 no advisory on nested-in-primary"; else echo "FAIL T21 advisory leaked: $adv"; FAILED=$((FAILED + 1)); fi
+
+git -C "$PFREPO" worktree remove --force "$PFWT" 2>/dev/null || true
+
 echo
 if [ "$FAILED" -eq 0 ]; then
     echo "All load-dotenv tests passed."

--- a/scripts/lib/test-vmsdk.py
+++ b/scripts/lib/test-vmsdk.py
@@ -946,6 +946,34 @@ class TestTriggerClaude(unittest.TestCase):
         # stay live so a re-trigger cannot silently replace a pending job.
         self.assertNotIn("--force", joined)
 
+    def test_scheduled_long_gap_forwards_flag(self):
+        """HIMMEL-1475: long_gap=True appends --long-gap to the guest arm-resume
+        command so a far --at TIME does not trip the long-gap guard (rc 9)."""
+        vm = self._vm()
+        cmds = []
+        def fake_run(cmd, **kw):
+            cmds.append(cmd)
+            return (0, "armed")
+        with mock.patch.object(vm, "push_file",
+                               return_value="/home/u/handover-inbox/next-session-1.md"), \
+             mock.patch.object(vm, "run", side_effect=fake_run):
+            rc, out = vm.trigger_claude(str(self.local), when="22:30", long_gap=True)
+        self.assertEqual(rc, 0)
+        joined = "\n".join(cmds)
+        self.assertIn("--long-gap", joined)
+        self.assertIn("--time 22:30", joined)
+
+    def test_long_gap_requires_scheduled_arm(self):
+        """long_gap without a when= is meaningless (no scheduler is armed) and
+        must raise a clean VMError rather than silently ignore the flag — and
+        must do so before the handover is pushed to the guest."""
+        vm = self._vm()
+        with mock.patch.object(vm, "push_file") as pf:
+            with self.assertRaises(vmsdk.VMError) as cm:
+                vm.trigger_claude(str(self.local), long_gap=True)
+            pf.assert_not_called()  # rejected before the handover is pushed
+        self.assertIn("long_gap", str(cm.exception))
+
     def test_scheduled_without_cwd_omits_cwd_flag(self):
         """HIMMEL-835 CR finding 1: no explicit cwd -> --cwd must be ABSENT so
         arm-resume.sh's own priority (--cwd > resume_cwd: frontmatter >
@@ -1037,6 +1065,24 @@ class TestTriggerCLI(unittest.TestCase):
                              "--at", "22:30", "--cwd", "~/himmel", "--timeout", "60"])
         self.assertEqual(rc, 0)
         t.assert_called_once_with("h.md", when="22:30", cwd="~/himmel", timeout=60)
+
+    def test_trigger_parses_long_gap(self):
+        """HIMMEL-1475: the bare --long-gap flag parses to long_gap=True
+        alongside --at and flows through to trigger_claude."""
+        with self._env(), mock.patch.object(vmsdk, "_load_dotenv_into_env"), \
+             mock.patch.object(vmsdk.VM, "trigger_claude",
+                               return_value=(0, "armed")) as t:
+            rc = vmsdk.main(["ubuntu_new", "trigger", "h.md",
+                             "--at", "23:30", "--long-gap"])
+        self.assertEqual(rc, 0)
+        t.assert_called_once_with("h.md", when="23:30", long_gap=True)
+
+    def test_trigger_long_gap_without_at_exit_2(self):
+        """Rejection path: --long-gap only modifies a scheduled arm, so without
+        --at it is a usage error (exit 2), not a silent no-op."""
+        with self._env(), mock.patch.object(vmsdk, "_load_dotenv_into_env"):
+            rc = vmsdk.main(["ubuntu_new", "trigger", "h.md", "--long-gap"])
+        self.assertEqual(rc, 2)
 
     def test_trigger_propagates_drive_rc(self):
         with self._env(), mock.patch.object(vmsdk, "_load_dotenv_into_env"), \

--- a/scripts/lib/vmsdk.py
+++ b/scripts/lib/vmsdk.py
@@ -19,7 +19,7 @@ scripts/lib/load-dotenv.sh).
 CLI: python scripts/lib/vmsdk.py <vm> <up|down|snapshot NAME|restore NAME|
                                       baseline NAME|clone [REF]|provision|e2e|
                                       push FILE [DEST]|
-                                      trigger HANDOVER [--at TIME] [--cwd DIR] [--timeout N]>
+                                      trigger HANDOVER [--at TIME] [--cwd DIR] [--long-gap] [--timeout N]>
 """
 import hashlib
 import io
@@ -544,7 +544,8 @@ class VM:
         return absremote
 
     def trigger_claude(self, handover, cwd=None,
-                       when=None, timeout=600, inbox="~/handover-inbox"):
+                       when=None, timeout=600, inbox="~/handover-inbox",
+                       long_gap=False):
         """Fire a claude session ON the guest from a HOST handover file
         (HIMMEL-835 — the host->VM session-trigger seam).
 
@@ -572,8 +573,22 @@ class VM:
         The guest session runs on the guest's own claude login (its own quota)
         and commits with the guest's own credentials. Single-writer stays with
         the caller: do not trigger a ticket another writer owns.
+
+        long_gap (HIMMEL-1475): forward arm-resume.sh's --long-gap so a far
+          --at TIME (more than 60 min out) does not trip the long-gap guard
+          (rc 9). Only meaningful for a SCHEDULED arm (when is set); passing it
+          with when=None raises VMError rather than silently ignoring a flag
+          the caller believes is in effect.
         """
         locate_cwd = cwd if cwd is not None else "~/Documents/github/himmel-private"
+        # long_gap only modifies a SCHEDULED arm (when is set): it forwards
+        # arm-resume.sh's --long-gap past the HIMMEL-1475 long-gap guard. It is
+        # meaningless for an immediate drive (when=None -> drive_claude), so
+        # reject the combination loudly instead of silently no-op'ing a flag the
+        # caller thinks is in effect.
+        if long_gap and when is None:
+            raise VMError(
+                "trigger_claude: long_gap=True requires a scheduled arm (when=...)")
         self._safe_guest_path(locate_cwd, "trigger_claude: cwd")
         src = Path(handover).resolve()
         # Path(...).resolve() does not require existence — check explicitly so
@@ -618,6 +633,8 @@ class VM:
                f" --handover {shlex.quote(guest_handover)}")
         if cwd is not None:
             arm += f" --cwd {cwd}"
+        if long_gap:
+            arm += " --long-gap"
         try:
             rc, out = self.run(f"bash -lc {shlex.quote(arm)}", timeout=120)
         except Exception as e:
@@ -657,18 +674,26 @@ class VM:
 _USAGE = ("usage: vmsdk.py <vm> "
           "<up|down|snapshot NAME|restore NAME|baseline NAME|clone [REF]|provision|e2e|"
           "push FILE [DEST]|"
-          "trigger HANDOVER [--at TIME] [--cwd DIR] [--timeout N]>")
+          "trigger HANDOVER [--at TIME] [--cwd DIR] [--long-gap] [--timeout N]>")
 
 
 def _parse_trigger_args(rest):
-    """Parse `trigger HANDOVER [--at TIME] [--cwd DIR] [--timeout N]`.
+    """Parse `trigger HANDOVER [--at TIME] [--cwd DIR] [--long-gap] [--timeout N]`.
 
     Returns (handover, kwargs) or raises ValueError on a malformed flag.
+    --long-gap (HIMMEL-1475) is a bare flag (forwards arm-resume.sh's --long-gap
+    past the long-gap guard) and is only valid alongside --at; on its own it
+    raises ValueError so the CLI surfaces exit 2 rather than arming an immediate
+    drive with a meaningless flag.
     """
     handover, opts, kw = rest[0], rest[1:], {}
     i = 0
     while i < len(opts):
         flag = opts[i]
+        if flag == "--long-gap":
+            kw["long_gap"] = True
+            i += 1
+            continue
         if i + 1 >= len(opts):
             raise ValueError(f"missing value for {flag}")
         val = opts[i + 1]
@@ -681,6 +706,9 @@ def _parse_trigger_args(rest):
         else:
             raise ValueError(f"unknown flag {flag}")
         i += 2
+    if kw.get("long_gap") and "when" not in kw:
+        raise ValueError(
+            "--long-gap requires --at TIME (it modifies a scheduled arm only)")
     return handover, kw
 
 

--- a/scripts/setup/cli-proxy-lane.ps1
+++ b/scripts/setup/cli-proxy-lane.ps1
@@ -50,7 +50,9 @@ param(
     [switch]$Stop,
     [switch]$Restart,
     [switch]$Force,
-    [switch]$Verify
+    [switch]$Verify,
+    [Parameter(DontShow = $true)]
+    [switch]$AsLibrary
 )
 
 $ErrorActionPreference = 'Stop'
@@ -75,6 +77,9 @@ function Test-Running {
     # 200 = up + our key accepted; 401 = up but key rejected (still the proxy speaking HTTP).
     $c = Get-ProxyCode
     ($c -eq '200') -or ($c -eq '401')
+}
+function Test-Healthy {
+    (Get-ProxyCode) -eq '200'
 }
 function Assert-Exe {
     if (-not (Test-Path $Exe)) { throw "binary missing at $Exe - run with -Install first" }
@@ -143,8 +148,281 @@ function Start-ProxyBackground {
     }
 }
 
+function Wait-ProxyRunning([int]$TimeoutSeconds = 20, [switch]$RequireHealthy) {
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        $running = if ($RequireHealthy) { Test-Healthy } else { Test-Running }
+        if ($running) { return $true }
+        Start-Sleep -Milliseconds 500
+    }
+    return $false
+}
+
+# Serialize the read/swap/recovery window with a held exclusive file handle.
+# Process death releases the handle automatically; metadata is diagnostic only.
+$script:ProxyInstallLockPath = $null
+$script:ProxyInstallLockHandle = $null
+$script:ProxyInstallLockDetail = ''
+
+function Get-ProxyInstallLockHost {
+    if ($env:COMPUTERNAME) { return $env:COMPUTERNAME }
+    try { return [System.Net.Dns]::GetHostName() } catch { return 'unknown' }
+}
+
+function Remove-ProxyInstallLock {
+    if (-not $script:ProxyInstallLockHandle) { return }
+    try {
+        $script:ProxyInstallLockHandle.Dispose()
+    } catch { }
+    $script:ProxyInstallLockHandle = $null
+    Remove-Item -LiteralPath $script:ProxyInstallLockPath -Force -ErrorAction SilentlyContinue
+}
+
+function Write-ProxyInstallLockOwner([System.IO.FileStream]$Handle) {
+    try {
+        $metadata = "pid=$PID`nhost=$(Get-ProxyInstallLockHost)`nstarted=$([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())`n"
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($metadata)
+        $Handle.SetLength(0)
+        $Handle.Position = 0
+        $Handle.Write($bytes, 0, $bytes.Length)
+        $Handle.Flush()
+    } catch { }
+}
+
+function Enter-ProxyInstallLock([string]$Path) {
+    $script:ProxyInstallLockPath = $Path
+    $script:ProxyInstallLockHandle = $null
+    $script:ProxyInstallLockDetail = ''
+
+    try {
+        $script:ProxyInstallLockHandle = [System.IO.File]::Open(
+            $Path,
+            [System.IO.FileMode]::OpenOrCreate,
+            [System.IO.FileAccess]::ReadWrite,
+            [System.IO.FileShare]::None
+        )
+    } catch [System.IO.IOException] {
+        # FileShare.None makes owner metadata unreadable until the holder exits.
+        $script:ProxyInstallLockDetail = "another install already holds the lock (owner details unavailable while held) -- $Path"
+        return $false
+    } catch {
+        $script:ProxyInstallLockDetail = "could not acquire install lock at ${Path}: $($_.Exception.Message)"
+        return $false
+    }
+
+    Write-ProxyInstallLockOwner $script:ProxyInstallLockHandle
+    return $true
+}
+
+function Invoke-ProxyBinarySwap {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Destination,
+        [Parameter(Mandatory = $true)][string]$VersionStamp,
+        [Parameter(Mandatory = $true)][string]$PinnedVersion,
+        [switch]$StopForSwap,
+        [switch]$RestartAfterSwap
+    )
+
+    # Stage both the candidate and rollback material beside the destination so
+    # existing files can be replaced atomically on the same volume. Nothing
+    # running is stopped until the candidate has been copied and validated.
+    $swapId = [guid]::NewGuid().ToString('N')
+    $stagedExe = "$Destination.$swapId.new"
+    $rollbackExe = "$Destination.$swapId.rollback"
+    $stagedStamp = "$VersionStamp.$swapId.new"
+    $rollbackStamp = "$VersionStamp.$swapId.rollback"
+    $hadDestination = Test-Path -LiteralPath $Destination
+    $hadVersionStamp = Test-Path -LiteralPath $VersionStamp
+    $restartAfterFailure = [bool]($StopForSwap -or $RestartAfterSwap)
+    $swapAttempted = $false
+    $candidateStartAttempted = $false
+    $retainRollbackArtifacts = $false
+
+    try {
+        Copy-Item -LiteralPath $Source -Destination $stagedExe -Force
+        $stagedInfo = Get-Item -LiteralPath $stagedExe
+        if ($stagedInfo.Length -le 0) { throw "staged cli-proxy-api.exe is empty" }
+
+        if ($hadDestination) {
+            Copy-Item -LiteralPath $Destination -Destination $rollbackExe -Force
+        }
+        if ($hadVersionStamp) {
+            Copy-Item -LiteralPath $VersionStamp -Destination $rollbackStamp -Force
+        }
+
+        if ($StopForSwap) {
+            Assert-BounceSafe
+            Write-Host "stopping cli-proxy-api to roll the pinned binary ..."
+            Stop-ProxyInstance | Out-Null
+        }
+
+        $swapAttempted = $true
+        if ($hadDestination) {
+            [System.IO.File]::Replace($stagedExe, $Destination, [System.Management.Automation.Language.NullString]::Value)
+        } else {
+            Move-Item -LiteralPath $stagedExe -Destination $Destination -Force
+        }
+        Set-Content -LiteralPath $stagedStamp -Value $PinnedVersion
+        if ($hadVersionStamp) {
+            [System.IO.File]::Replace($stagedStamp, $VersionStamp, [System.Management.Automation.Language.NullString]::Value)
+        } else {
+            Move-Item -LiteralPath $stagedStamp -Destination $VersionStamp -Force
+        }
+
+        if ($RestartAfterSwap) {
+            Write-Host "relaunching proxy (windowless) ..."
+            $candidateStartAttempted = $true
+            Start-ProxyBackground
+            if (-not (Wait-ProxyRunning -RequireHealthy)) {
+                throw "candidate deployment failed: proxy did not come up healthy on 127.0.0.1:$Port within 20s"
+            }
+            Write-Host "proxy back up on 127.0.0.1:$Port."
+        }
+    } catch {
+        $installFailure = $_
+        $recoveryFailures = @()
+        $restorationFailed = $false
+
+        if ($candidateStartAttempted -and (Get-ProxyProcess)) {
+            try {
+                Stop-ProxyInstance | Out-Null
+            } catch {
+                $recoveryFailures += "candidate stop failed: $($_.Exception.Message)"
+            }
+        }
+        if ($swapAttempted) {
+            try {
+                if ($hadDestination) {
+                    if (-not (Test-Path -LiteralPath $rollbackExe)) {
+                        throw "rollback executable is missing: $rollbackExe"
+                    }
+                    if (Test-Path -LiteralPath $Destination) {
+                        [System.IO.File]::Replace($rollbackExe, $Destination, [System.Management.Automation.Language.NullString]::Value)
+                    } else {
+                        Move-Item -LiteralPath $rollbackExe -Destination $Destination -Force
+                    }
+                } else {
+                    Remove-Item -LiteralPath $Destination -Force -ErrorAction SilentlyContinue
+                }
+            } catch {
+                $restorationFailed = $true
+                $recoveryFailures += "executable rollback failed: $($_.Exception.Message)"
+            }
+
+            try {
+                if ($hadVersionStamp) {
+                    if (-not (Test-Path -LiteralPath $rollbackStamp)) {
+                        throw "rollback version stamp is missing: $rollbackStamp"
+                    }
+                    if (Test-Path -LiteralPath $VersionStamp) {
+                        [System.IO.File]::Replace($rollbackStamp, $VersionStamp, [System.Management.Automation.Language.NullString]::Value)
+                    } else {
+                        Move-Item -LiteralPath $rollbackStamp -Destination $VersionStamp -Force
+                    }
+                } else {
+                    Remove-Item -LiteralPath $VersionStamp -Force -ErrorAction SilentlyContinue
+                }
+            } catch {
+                $restorationFailed = $true
+                $stampRollbackFailure = $_.Exception.Message
+                try {
+                    if (Test-Path -LiteralPath $VersionStamp) {
+                        Remove-Item -LiteralPath $VersionStamp -Force -ErrorAction Stop
+                    }
+                    $recoveryFailures += "version stamp rollback failed: $stampRollbackFailure; live version stamp invalidated: $VersionStamp"
+                } catch {
+                    $recoveryFailures += "version stamp rollback failed: $stampRollbackFailure; live version stamp invalidation failed: $($_.Exception.Message)"
+                }
+            }
+        }
+
+        if ($restartAfterFailure -and -not (Get-ProxyProcess)) {
+            $destinationUsable = $false
+            try {
+                $destinationUsable = (Test-Path -LiteralPath $Destination) -and ((Get-Item -LiteralPath $Destination).Length -gt 0)
+            } catch {
+                $recoveryFailures += "could not validate executable before proxy restart: $($_.Exception.Message)"
+            }
+            if ($destinationUsable) {
+                try {
+                    Start-ProxyBackground
+                    if (-not (Wait-ProxyRunning -RequireHealthy)) {
+                        throw "proxy did not come up healthy on 127.0.0.1:$Port within 20s"
+                    }
+                } catch {
+                    $recoveryFailures += "proxy restart failed: $($_.Exception.Message)"
+                }
+            } else {
+                $recoveryFailures += "proxy restart skipped because no usable executable exists at $Destination"
+            }
+        }
+
+        if ($recoveryFailures.Count -gt 0) {
+            $message = "install failed: $($installFailure.Exception.Message); recovery failed: $($recoveryFailures -join '; ')"
+            if ($restorationFailed) {
+                $retainRollbackArtifacts = $true
+                $retainedPaths = @($rollbackExe, $rollbackStamp) | Where-Object { Test-Path -LiteralPath $_ }
+                if (@($retainedPaths).Count -gt 0) {
+                    $message += "; rollback artifacts retained: $($retainedPaths -join ', ')"
+                }
+            }
+            throw $message
+        }
+        throw $installFailure
+    } finally {
+        Remove-Item -LiteralPath $stagedExe, $stagedStamp -Force -ErrorAction SilentlyContinue
+        if (-not $retainRollbackArtifacts) {
+            Remove-Item -LiteralPath $rollbackExe, $rollbackStamp -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Install-ProxyBinary {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Destination,
+        [Parameter(Mandatory = $true)][string]$VersionStamp,
+        [Parameter(Mandatory = $true)][string]$PinnedVersion,
+        [switch]$StopForSwap,
+        [switch]$RestartAfterSwap
+    )
+
+    $lockPath = "$Destination.install.lock"
+    if (-not (Enter-ProxyInstallLock $lockPath)) {
+        $exception = [System.InvalidOperationException]::new("cli-proxy install refused: $script:ProxyInstallLockDetail")
+        $exception.Data['ExitCode'] = 3
+        throw $exception
+    }
+
+    try {
+        Invoke-ProxyBinarySwap @PSBoundParameters
+    } finally {
+        Remove-ProxyInstallLock
+    }
+}
+
+if ($AsLibrary) { return }
+
+$restartCompletedDuringInstall = $false
+
 if ($Install) {
     New-Item -ItemType Directory -Force $Dir | Out-Null
+    if (-not (Test-Path $Cfg)) {
+        # host 127.0.0.1 ONLY: the default empty host binds ALL interfaces, which
+        # would LAN-expose the OAuth-wrapped subscription endpoint.
+        $yaml = @"
+host: "127.0.0.1"
+port: $Port
+auth-dir: "~/.cli-proxy-api"
+api-keys:
+  - "$ApiKey"
+"@
+        [System.IO.File]::WriteAllText($Cfg, $yaml, (New-Object System.Text.UTF8Encoding $false))
+        Write-Host "wrote config: $Cfg"
+    } else {
+        Write-Host "config already present: $Cfg"
+    }
     # Version stamp makes -Install pin-aware (CR r1 codex-1, HIMMEL-1451): a
     # bare exe-exists check would skip the download forever, so bumping $Version
     # could never roll an existing install and the drift-row's documented
@@ -156,14 +434,15 @@ if ($Install) {
     if ((-not (Test-Path $Exe)) -or ($installedVer -ne $Version)) {
         # Windows locks a running exe - the pinned swap cannot land over a live
         # instance, so a combined -Install -Restart (or -Install -Stop) stops the
-        # proxy in THIS invocation and the later $Restart/$Stop block then finds
-        # nothing to stop (HIMMEL-1451 r3). The stop is DEFERRED until just before
-        # Copy-Item (HIMMEL-1468): it used to run BEFORE the download, so a
+        # proxy in THIS invocation. -Restart validates the candidate before the
+        # transaction ends; the later $Stop block finds nothing to stop. The stop
+        # is DEFERRED until just before
+        # the atomic swap (HIMMEL-1468): it used to run BEFORE the download, so a
         # download/extract failure left the proxy DOWN until manual recovery. Now
         # the temp download/extract resolves first and the running instance is
-        # touched only once the new binary is staged, shrinking the downtime
-        # window to the Copy-Item itself; any failure above this point leaves the
-        # old binary serving.
+        # touched only once the new binary and rollback copy are staged, shrinking
+        # the downtime window to the same-volume Move-Item; any failure above this
+        # point leaves the old binary serving.
         $stopForSwap = $false
         if ((Test-Path $Exe) -and (Get-ProxyProcess)) {
             if ($Restart -or $Stop) {
@@ -186,34 +465,23 @@ if ($Install) {
             Expand-Archive -Force $zip $tmp
             $src = Get-ChildItem -Recurse $tmp -Filter 'cli-proxy-api.exe' | Select-Object -First 1 -ExpandProperty FullName
             if (-not $src) { throw "cli-proxy-api.exe not found in release archive" }
-            if ($stopForSwap) {
-                Assert-BounceSafe   # -Force still overrides the live-client refusal
-                Write-Host "stopping cli-proxy-api to roll the pinned binary ..."
-                Stop-ProxyInstance | Out-Null
+            try {
+                $restartAfterSwap = [bool]$Restart
+                Install-ProxyBinary -Source $src -Destination $Exe -VersionStamp $VerStamp -PinnedVersion $Version -StopForSwap:$stopForSwap -RestartAfterSwap:$restartAfterSwap
+                $restartCompletedDuringInstall = $restartAfterSwap
+            } catch {
+                if ($_.Exception.Data['ExitCode'] -eq 3) {
+                    Write-Error $_.Exception.Message -ErrorAction Continue
+                    exit 3
+                }
+                throw
             }
-            Copy-Item $src $Exe -Force
-            Set-Content -Path $VerStamp -Value $Version
             Write-Host "installed binary: $Exe (v$Version)"
         } finally {
             Remove-Item -Recurse -Force $tmp, $zip -ErrorAction SilentlyContinue
         }
     } else {
         Write-Host "binary already present at pinned v${Version}: $Exe"
-    }
-    if (-not (Test-Path $Cfg)) {
-        # host 127.0.0.1 ONLY: the default empty host binds ALL interfaces, which
-        # would LAN-expose the OAuth-wrapped subscription endpoint.
-        $yaml = @"
-host: "127.0.0.1"
-port: $Port
-auth-dir: "~/.cli-proxy-api"
-api-keys:
-  - "$ApiKey"
-"@
-        [System.IO.File]::WriteAllText($Cfg, $yaml, (New-Object System.Text.UTF8Encoding $false))
-        Write-Host "wrote config: $Cfg"
-    } else {
-        Write-Host "config already present: $Cfg"
     }
 }
 
@@ -266,7 +534,7 @@ if ($Stop) {
     }
 }
 
-if ($Restart) {
+if ($Restart -and -not $restartCompletedDuringInstall) {
     Assert-Exe; Assert-Config
     Assert-BounceSafe
     if (Get-ProxyProcess) {
@@ -276,13 +544,7 @@ if ($Restart) {
     Write-Host "relaunching proxy (windowless) ..."
     Start-ProxyBackground
     # Verify /v1/models answers (200 = up + key accepted; 401 = up, key rejected).
-    $deadline = (Get-Date).AddSeconds(20)
-    $up = $false
-    while ((Get-Date) -lt $deadline) {
-        if (Test-Running) { $up = $true; break }
-        Start-Sleep -Milliseconds 500
-    }
-    if (-not $up) {
+    if (-not (Wait-ProxyRunning)) {
         throw "proxy did not come up on 127.0.0.1:$Port within 20s (run -Verify, or -Start in the foreground to see the error)"
     }
     Write-Host "proxy back up on 127.0.0.1:$Port."

--- a/scripts/setup/test-cli-proxy-lane.ps1
+++ b/scripts/setup/test-cli-proxy-lane.ps1
@@ -1,0 +1,331 @@
+# Hermetic swap/rollback tests for cli-proxy-lane.ps1 (HIMMEL-1473).
+# Dot-sources the helper without touching the live proxy, then replaces only the
+# lifecycle commands and targeted filesystem failure points used by the swap.
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Helper = Join-Path $ScriptDir 'cli-proxy-lane.ps1'
+foreach ($path in @($Helper, $MyInvocation.MyCommand.Path)) {
+    $tokens = $null
+    $parseErrors = $null
+    [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$tokens, [ref]$parseErrors) | Out-Null
+    if (@($parseErrors).Count -gt 0) { throw "PowerShell parser errors in ${path}: $($parseErrors -join '; ')" }
+}
+$script:Pass = 0
+$script:Fail = 0
+function Pass([string]$Name) { Write-Host "  PASS  $Name"; $script:Pass++ }
+function Fail([string]$Name, [string]$Detail = '') { Write-Host "  FAIL  $Name $Detail" -ForegroundColor Red; $script:Fail++ }
+function Check([string]$Name, [bool]$Ok, [string]$Detail = '') { if ($Ok) { Pass $Name } else { Fail $Name $Detail } }
+
+. $Helper -AsLibrary
+
+$script:ProxyRunning = $false
+$script:ProxyHealthy = $true
+$script:HealthProbeResults = @()
+$script:HealthProbeResultIndex = 0
+$script:HealthProbeCount = 0
+$script:StrictHealthProbeCount = 0
+$script:StopCount = 0
+$script:StartCount = 0
+$script:DestinationMoveCount = 0
+$script:TargetExe = ''
+$script:TargetStamp = ''
+$script:FailDestinationMove = $false
+$script:FailStampWrite = $false
+$script:LockRollbackStampOnFailure = $false
+$script:RollbackStampLock = $null
+$script:RollbackStampPath = ''
+
+function Assert-BounceSafe {}
+function Stop-ProxyInstance {
+    $script:StopCount++
+    $script:ProxyRunning = $false
+    return $true
+}
+function Get-ProxyProcess {
+    if ($script:ProxyRunning) { [pscustomobject]@{ Id = 1234 } }
+}
+function Start-ProxyBackground {
+    $script:StartCount++
+    $script:ProxyRunning = $true
+}
+function Wait-ProxyRunning {
+    param([int]$TimeoutSeconds = 20, [switch]$RequireHealthy)
+    $script:HealthProbeCount++
+    if ($RequireHealthy) { $script:StrictHealthProbeCount++ }
+    if ($script:HealthProbeResultIndex -lt @($script:HealthProbeResults).Count) {
+        $result = $script:HealthProbeResults[$script:HealthProbeResultIndex]
+        $script:HealthProbeResultIndex++
+        if ($result -is [string]) {
+            if ($RequireHealthy) { return $result -eq '200' }
+            return ($result -eq '200') -or ($result -eq '401')
+        }
+        return $result
+    }
+    return $script:ProxyHealthy
+}
+function Move-Item {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$LiteralPath,
+        [Parameter(Mandatory = $true)][string]$Destination,
+        [switch]$Force
+    )
+    if ($Destination -eq $script:TargetExe) {
+        $script:DestinationMoveCount++
+        if ($script:FailDestinationMove) {
+            throw 'simulated destination move failure'
+        }
+    }
+    Microsoft.PowerShell.Management\Move-Item -LiteralPath $LiteralPath -Destination $Destination -Force:$Force
+}
+function Set-Content {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$LiteralPath,
+        [Parameter(Mandatory = $true)][object]$Value
+    )
+    if ($script:FailStampWrite -and $LiteralPath[0].StartsWith("$($script:TargetStamp).")) {
+        if ($script:LockRollbackStampOnFailure) {
+            $rollbackStamp = @(Microsoft.PowerShell.Management\Get-ChildItem -LiteralPath (Split-Path -Parent $script:TargetStamp) |
+                Where-Object { $_.FullName.StartsWith("$($script:TargetStamp).") -and $_.Name.EndsWith('.rollback') }) |
+                Select-Object -First 1
+            if (-not $rollbackStamp) { throw 'could not find rollback stamp to lock' }
+            $script:RollbackStampPath = $rollbackStamp.FullName
+            $script:RollbackStampLock = [System.IO.File]::Open(
+                $script:RollbackStampPath,
+                [System.IO.FileMode]::Open,
+                [System.IO.FileAccess]::Read,
+                [System.IO.FileShare]::None
+            )
+        }
+        $script:FailStampWrite = $false
+        throw 'simulated version stamp failure'
+    }
+    Microsoft.PowerShell.Management\Set-Content -LiteralPath $LiteralPath -Value $Value
+}
+
+function New-Fixture([string]$Root, [string]$Name) {
+    $dir = Join-Path $Root $Name
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    $source = Join-Path $dir 'downloaded.exe'
+    $destination = Join-Path $dir 'cli-proxy-api.exe'
+    $versionStamp = Join-Path $dir 'cli-proxy-api.version'
+    [System.IO.File]::WriteAllText($source, 'new-binary')
+    [System.IO.File]::WriteAllText($destination, 'old-binary')
+    [System.IO.File]::WriteAllText($versionStamp, '7.2.112')
+    [pscustomobject]@{ Dir = $dir; Source = $source; Destination = $destination; VersionStamp = $versionStamp }
+}
+function Reset-Lifecycle([object]$Fixture) {
+    if ($script:RollbackStampLock) {
+        $script:RollbackStampLock.Dispose()
+        $script:RollbackStampLock = $null
+    }
+    $script:ProxyRunning = $true
+    $script:ProxyHealthy = $true
+    $script:HealthProbeResults = @()
+    $script:HealthProbeResultIndex = 0
+    $script:HealthProbeCount = 0
+    $script:StrictHealthProbeCount = 0
+    $script:StopCount = 0
+    $script:StartCount = 0
+    $script:DestinationMoveCount = 0
+    $script:TargetExe = $Fixture.Destination
+    $script:TargetStamp = $Fixture.VersionStamp
+    $script:FailDestinationMove = $false
+    $script:FailStampWrite = $false
+    $script:LockRollbackStampOnFailure = $false
+    $script:RollbackStampPath = ''
+}
+function Test-NoSwapArtifacts([string]$Dir) {
+    @((Get-ChildItem -LiteralPath $Dir | Where-Object { $_.Name -match '\.(new|rollback)$' })).Count -eq 0
+}
+
+$Tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("himmel-cli-proxy-swap-test-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $Tmp | Out-Null
+try {
+    Write-Host 'Test 1: first install moves staged files into absent destinations'
+    $fixture = New-Fixture $Tmp 'first-install'
+    Remove-Item -LiteralPath $fixture.Destination, $fixture.VersionStamp -Force
+    Reset-Lifecycle $fixture
+    Install-ProxyBinary -Source $fixture.Source -Destination $fixture.Destination -VersionStamp $fixture.VersionStamp -PinnedVersion '7.2.113'
+    Check 'first install writes the new binary' (([System.IO.File]::ReadAllText($fixture.Destination)) -eq 'new-binary')
+    Check 'first install writes the new version stamp' (([System.IO.File]::ReadAllText($fixture.VersionStamp)).Trim() -eq '7.2.113')
+    Check 'first install uses Move-Item for the absent executable' ($script:DestinationMoveCount -eq 1) "count=$script:DestinationMoveCount"
+    Check 'first-install artifacts cleaned' (Test-NoSwapArtifacts $fixture.Dir)
+    Check 'first-install lock released' (-not (Test-Path -LiteralPath "$($fixture.Destination).install.lock"))
+
+    Write-Host 'Test 2: an existing destination is replaced without Move-Item overwrite'
+    $fixture = New-Fixture $Tmp 'replace-existing'
+    Reset-Lifecycle $fixture
+    $script:FailDestinationMove = $true
+    Install-ProxyBinary -Source $fixture.Source -Destination $fixture.Destination -VersionStamp $fixture.VersionStamp -PinnedVersion '7.2.113'
+    Check 'replace path writes the new binary' (([System.IO.File]::ReadAllText($fixture.Destination)) -eq 'new-binary')
+    Check 'replace path writes the new version stamp' (([System.IO.File]::ReadAllText($fixture.VersionStamp)).Trim() -eq '7.2.113')
+    Check 'replace path does not Move-Item over the executable' ($script:DestinationMoveCount -eq 0) "count=$script:DestinationMoveCount"
+    Check 'replace-path artifacts cleaned' (Test-NoSwapArtifacts $fixture.Dir)
+
+    Write-Host 'Test 3: a healthy candidate is validated before rollback cleanup'
+    $fixture = New-Fixture $Tmp 'healthy-candidate'
+    Reset-Lifecycle $fixture
+    Install-ProxyBinary -Source $fixture.Source -Destination $fixture.Destination -VersionStamp $fixture.VersionStamp -PinnedVersion '7.2.113' -StopForSwap -RestartAfterSwap
+    Check 'healthy candidate stops the old proxy once' ($script:StopCount -eq 1) "count=$script:StopCount"
+    Check 'healthy candidate starts once' ($script:StartCount -eq 1) "count=$script:StartCount"
+    Check 'healthy candidate is probed once' ($script:HealthProbeCount -eq 1) "count=$script:HealthProbeCount"
+    Check 'healthy candidate remains running' $script:ProxyRunning
+    Check 'healthy candidate keeps the new binary' (([System.IO.File]::ReadAllText($fixture.Destination)) -eq 'new-binary')
+    Check 'healthy candidate keeps the new version stamp' (([System.IO.File]::ReadAllText($fixture.VersionStamp)).Trim() -eq '7.2.113')
+    Check 'healthy-candidate rollback artifacts cleaned' (Test-NoSwapArtifacts $fixture.Dir)
+
+    Write-Host 'Test 4: a candidate returning 401 restores and restarts the old proxy'
+    $fixture = New-Fixture $Tmp 'candidate-health-failure'
+    Reset-Lifecycle $fixture
+    $script:HealthProbeResults = @('401', '200')
+    $errorMessage = ''
+    try {
+        Install-ProxyBinary -Source $fixture.Source -Destination $fixture.Destination -VersionStamp $fixture.VersionStamp -PinnedVersion '7.2.113' -StopForSwap -RestartAfterSwap
+    } catch {
+        $errorMessage = $_.Exception.Message
+    }
+    Check '401 candidate deployment is rejected' ($errorMessage.Contains('candidate deployment failed:')) $errorMessage
+    Check 'failed candidate names the strict health timeout' ($errorMessage.Contains('proxy did not come up healthy on 127.0.0.1:8317 within 20s')) $errorMessage
+    Check 'old and candidate processes were each stopped' ($script:StopCount -eq 2) "count=$script:StopCount"
+    Check 'candidate and restored old proxy were each started' ($script:StartCount -eq 2) "count=$script:StartCount"
+    Check 'candidate and restored old proxy were each health-checked' ($script:HealthProbeCount -eq 2) "count=$script:HealthProbeCount"
+    Check 'candidate and recovery probes both require HTTP 200' ($script:StrictHealthProbeCount -eq 2) "count=$script:StrictHealthProbeCount"
+    Check 'old proxy reports running after candidate failure' $script:ProxyRunning
+    Check 'old binary restored after candidate failure' (([System.IO.File]::ReadAllText($fixture.Destination)) -eq 'old-binary')
+    Check 'old version restored after candidate failure' (([System.IO.File]::ReadAllText($fixture.VersionStamp)) -eq '7.2.112')
+    Check 'candidate-failure rollback artifacts consumed' (Test-NoSwapArtifacts $fixture.Dir)
+
+    Write-Host 'Test 5: a stamp failure restores both files and restarts the old proxy'
+    $fixture = New-Fixture $Tmp 'stamp-failure'
+    Reset-Lifecycle $fixture
+    $script:FailStampWrite = $true
+    $threw = $false
+    try {
+        Install-ProxyBinary -Source $fixture.Source -Destination $fixture.Destination -VersionStamp $fixture.VersionStamp -PinnedVersion '7.2.113' -StopForSwap
+    } catch {
+        $threw = $true
+    }
+    Check 'stamp failure is surfaced' $threw
+    Check 'proxy was stopped once for stamp failure' ($script:StopCount -eq 1) "count=$script:StopCount"
+    Check 'old proxy was restarted after executable restore' ($script:StartCount -eq 1) "count=$script:StartCount"
+    Check 'restarted proxy health was verified' ($script:HealthProbeCount -eq 1) "count=$script:HealthProbeCount"
+    Check 'proxy reports running after executable restore' $script:ProxyRunning
+    Check 'old binary restored after stamp failure' (([System.IO.File]::ReadAllText($fixture.Destination)) -eq 'old-binary')
+    Check 'old version stamp restored after stamp failure' (([System.IO.File]::ReadAllText($fixture.VersionStamp)) -eq '7.2.112')
+    Check 'stamp-failure artifacts cleaned' (Test-NoSwapArtifacts $fixture.Dir)
+
+    Write-Host 'Test 6: rollback failure retains the artifact, names it, and still restarts'
+    $fixture = New-Fixture $Tmp 'rollback-failure'
+    Reset-Lifecycle $fixture
+    $script:FailStampWrite = $true
+    $script:LockRollbackStampOnFailure = $true
+    $errorMessage = ''
+    try {
+        Install-ProxyBinary -Source $fixture.Source -Destination $fixture.Destination -VersionStamp $fixture.VersionStamp -PinnedVersion '7.2.113' -StopForSwap
+    } catch {
+        $errorMessage = $_.Exception.Message
+    }
+    $retainedRollback = @(Get-ChildItem -LiteralPath $fixture.Dir | Where-Object { $_.Name.EndsWith('.rollback') })
+    Check 'rollback failure is surfaced' ($errorMessage.Length -gt 0)
+    Check 'executable was restored before stamp rollback failed' (([System.IO.File]::ReadAllText($fixture.Destination)) -eq 'old-binary')
+    Check 'live stamp is removed after stamp rollback fails' (-not (Test-Path -LiteralPath $fixture.VersionStamp))
+    $installedVer = if (Test-Path -LiteralPath $fixture.VersionStamp) { Get-Content $fixture.VersionStamp | Select-Object -First 1 } else { $null }
+    $nextInstallNeeded = (-not (Test-Path -LiteralPath $fixture.Destination)) -or ($installedVer -ne '7.2.113')
+    Check 'missing live stamp prevents the next install from skipping' $nextInstallNeeded
+    Check 'stamp rollback error names live stamp invalidation' ($errorMessage.Contains("live version stamp invalidated: $($fixture.VersionStamp)")) $errorMessage
+    Check 'restart was attempted after executable restore' ($script:StartCount -eq 1) "count=$script:StartCount"
+    Check 'proxy reports running after partial rollback' $script:ProxyRunning
+    Check 'failed rollback artifact is retained' ($retainedRollback.Count -eq 1) "count=$($retainedRollback.Count)"
+    Check 'error names the retained rollback artifact' ($errorMessage.Contains($script:RollbackStampPath)) $errorMessage
+    Check 'only the rollback artifact remains staged' (@(Get-ChildItem -LiteralPath $fixture.Dir | Where-Object { $_.Name.EndsWith('.new') }).Count -eq 0)
+    $script:RollbackStampLock.Dispose()
+    $script:RollbackStampLock = $null
+
+    Write-Host 'Test 7: recovery reports a launch that never becomes healthy'
+    $fixture = New-Fixture $Tmp 'restart-health-failure'
+    Reset-Lifecycle $fixture
+    $script:FailStampWrite = $true
+    $script:ProxyHealthy = $false
+    $errorMessage = ''
+    try {
+        Install-ProxyBinary -Source $fixture.Source -Destination $fixture.Destination -VersionStamp $fixture.VersionStamp -PinnedVersion '7.2.113' -StopForSwap
+    } catch {
+        $errorMessage = $_.Exception.Message
+    }
+    Check 'failed recovery is surfaced' ($errorMessage.Contains('recovery failed:')) $errorMessage
+    Check 'failed recovery names the strict health timeout' ($errorMessage.Contains('proxy did not come up healthy on 127.0.0.1:8317 within 20s')) $errorMessage
+    Check 'recovery launch was attempted once' ($script:StartCount -eq 1) "count=$script:StartCount"
+    Check 'failed recovery was health-checked once' ($script:HealthProbeCount -eq 1) "count=$script:HealthProbeCount"
+    Check 'old binary remains restored after unhealthy restart' (([System.IO.File]::ReadAllText($fixture.Destination)) -eq 'old-binary')
+    Check 'old version remains restored after unhealthy restart' (([System.IO.File]::ReadAllText($fixture.VersionStamp)) -eq '7.2.112')
+    Check 'restart-health-failure artifacts cleaned' (Test-NoSwapArtifacts $fixture.Dir)
+    Check 'restart-health-failure lock released' (-not (Test-Path -LiteralPath "$($fixture.Destination).install.lock"))
+
+    Write-Host 'Test 8: a live install lock refuses overlap without altering completed files'
+    $fixture = New-Fixture $Tmp 'concurrent-install'
+    [System.IO.File]::WriteAllText($fixture.Destination, 'concurrent-completed-binary')
+    [System.IO.File]::WriteAllText($fixture.VersionStamp, '7.2.114')
+    Reset-Lifecycle $fixture
+    $lockPath = "$($fixture.Destination).install.lock"
+    $liveLock = [System.IO.File]::Open(
+        $lockPath,
+        [System.IO.FileMode]::OpenOrCreate,
+        [System.IO.FileAccess]::ReadWrite,
+        [System.IO.FileShare]::None
+    )
+    Write-ProxyInstallLockOwner $liveLock
+    $errorMessage = ''
+    $exitCode = $null
+    try {
+        Install-ProxyBinary -Source $fixture.Source -Destination $fixture.Destination -VersionStamp $fixture.VersionStamp -PinnedVersion '7.2.113' -StopForSwap
+    } catch {
+        $errorMessage = $_.Exception.Message
+        $exitCode = $_.Exception.Data['ExitCode']
+    }
+    Check 'overlapping install is refused' ($errorMessage.Contains('another install already holds the lock')) $errorMessage
+    Check 'lock refusal honestly omits unreadable owner fields' ($errorMessage.Contains('owner details unavailable while held')) $errorMessage
+    Check 'lock refusal carries distinct exit code 3' ($exitCode -eq 3) "exit=$exitCode"
+    Check 'completed binary is unchanged after refusal' (([System.IO.File]::ReadAllText($fixture.Destination)) -eq 'concurrent-completed-binary')
+    Check 'completed version is unchanged after refusal' (([System.IO.File]::ReadAllText($fixture.VersionStamp)) -eq '7.2.114')
+    Check 'lock refusal does not stop the proxy' ($script:StopCount -eq 0) "count=$script:StopCount"
+    Check 'contender does not remove the live lock' (Test-Path -LiteralPath $lockPath)
+    $liveLock.Dispose()
+    Remove-Item -LiteralPath $lockPath -Force
+
+    Write-Host 'Test 9: a released holder does not block the next install'
+    $fixture = New-Fixture $Tmp 'released-holder'
+    Reset-Lifecycle $fixture
+    $lockPath = "$($fixture.Destination).install.lock"
+    $deadHolder = [System.IO.File]::Open(
+        $lockPath,
+        [System.IO.FileMode]::OpenOrCreate,
+        [System.IO.FileAccess]::ReadWrite,
+        [System.IO.FileShare]::None
+    )
+    Write-ProxyInstallLockOwner $deadHolder
+    $deadHolder.Dispose()
+    Install-ProxyBinary -Source $fixture.Source -Destination $fixture.Destination -VersionStamp $fixture.VersionStamp -PinnedVersion '7.2.113'
+    Check 'released-holder install writes the new binary' (([System.IO.File]::ReadAllText($fixture.Destination)) -eq 'new-binary')
+    Check 'released-holder install writes the new version stamp' (([System.IO.File]::ReadAllText($fixture.VersionStamp)).Trim() -eq '7.2.113')
+    Check 'released-holder lock cleaned' (-not (Test-Path -LiteralPath $lockPath))
+
+    Write-Host 'Test 10: a leftover lock file without a holder does not wedge installs'
+    $fixture = New-Fixture $Tmp 'leftover-lock-file'
+    Reset-Lifecycle $fixture
+    $lockPath = "$($fixture.Destination).install.lock"
+    [System.IO.File]::WriteAllText($lockPath, '')
+    Install-ProxyBinary -Source $fixture.Source -Destination $fixture.Destination -VersionStamp $fixture.VersionStamp -PinnedVersion '7.2.113'
+    Check 'leftover-file install writes the new binary' (([System.IO.File]::ReadAllText($fixture.Destination)) -eq 'new-binary')
+    Check 'leftover-file install writes the new version stamp' (([System.IO.File]::ReadAllText($fixture.VersionStamp)).Trim() -eq '7.2.113')
+    Check 'leftover lock file cleaned' (-not (Test-Path -LiteralPath $lockPath))
+
+    Write-Host ""
+    Write-Host "test-cli-proxy-lane: $script:Pass passed, $script:Fail failed"
+    if ($script:Fail -gt 0) { exit 1 }
+} finally {
+    if ($script:RollbackStampLock) { $script:RollbackStampLock.Dispose() }
+    Remove-Item -LiteralPath $Tmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+exit 0

--- a/scripts/telegram/auto-action.sh
+++ b/scripts/telegram/auto-action.sh
@@ -165,14 +165,26 @@ echo "resolved=$(basename "$RESOLVED")"
 # Invoke arm-resume.sh with the resolved handover as the --handover VALUE. Strip the
 # bot token (and TELEGRAM_OWN_POLLER) from the child env (M3 — arm doesn't need them).
 # Default per-handover dedup; no --force, no --dedup-any (remote arms can't force/clobber).
+# HIMMEL-1475: an explicit HH:MM rides --long-gap — a HUMAN typing a far time on
+# Telegram IS the explicit choice the long-gap guard exists to force (the guard
+# targets the ORCHESTRATOR silently defaulting to a far park, not a typed one).
+# smart/auto are system-computed sentinels the guard exempts by design, so they
+# keep the bare call shape.
 ARM_CMD="${AUTO_ACTION_ARM_CMD:-bash $SCRIPT_DIR/../handover/arm-resume.sh}"
-# ARM_CMD is an intentional command+args split — word-splitting wanted.
+case "$TIME" in
+    smart|auto) ARM_LONG_GAP="" ;;
+    *)          ARM_LONG_GAP="--long-gap" ;;
+esac
+# ARM_CMD / ARM_LONG_GAP are an intentional command+args split — word-splitting wanted.
 # shellcheck disable=SC2086
-out=$(TELEGRAM_BOT_TOKEN="" TELEGRAM_OWN_POLLER="" $ARM_CMD --handover "$RESOLVED" --time "$TIME" 2>&1)
+out=$(TELEGRAM_BOT_TOKEN="" TELEGRAM_OWN_POLLER="" $ARM_CMD --handover "$RESOLVED" --time "$TIME" $ARM_LONG_GAP 2>&1)
 arm_rc=$?
 
 case "$arm_rc" in
     0) exit 0 ;;
     3) echo "ERR auto-action: already armed for $(basename "$RESOLVED")" >&2; exit 5 ;;
+    # rc=9 should not occur once --long-gap rides along on the HH:MM branch above,
+    # but keep the honest text if it ever does (mapped to the generic failure exit).
+    9) echo "ERR auto-action: arm-resume refused the long gap (rc=9): $(printf '%s' "$out" | tail -1)" >&2; exit 6 ;;
     *) echo "ERR auto-action: arm-resume failed (rc=$arm_rc): $(printf '%s' "$out" | tail -1)" >&2; exit 6 ;;
 esac

--- a/scripts/telegram/spawn-claudex.ts
+++ b/scripts/telegram/spawn-claudex.ts
@@ -564,8 +564,10 @@ export async function runAuthPreflightWithBackoff(
 // reliable when spawn-claudex.ts runs from the primary checkout (the common
 // case for a parent/orchestrator session, per the design brief's explicit
 // "resolved like run.ts's REPO_ROOT" instruction). A parent invoking this
-// script from a worktree copy of itself would need CLAUDE_CODEX_DOTENV_ROOT
-// set explicitly in its own env — out of v1 scope.
+// script from a worktree copy of itself resolves REPO_ROOT to that worktree;
+// claude-codex then self-heals its .env lookup via the worktree→primary fallback
+// (HIMMEL-1482, scripts/lib/load-dotenv.sh _load_dotenv_primary_for), so no
+// explicit CLAUDE_CODEX_DOTENV_ROOT is required for the key to resolve.
 export function claudexLauncherPath(repoRoot: string): string {
   return join(repoRoot, "scripts", "claude-codex");
 }

--- a/scripts/telegram/spawn-glm.test.ts
+++ b/scripts/telegram/spawn-glm.test.ts
@@ -28,6 +28,7 @@ import {
   composeRespawnHandover,
   applyCarryFrom,
   buildArmArgv,
+  buildArmEnv,
   formatUsageWarn,
   parseWarnPct,
   resolveProfileSettings,
@@ -1317,6 +1318,15 @@ test("buildArmArgv matches arm-resume's documented flag contract", () => {
   expect(a[0]).toBe(BASH_BIN);
   expect(a[1]).toContain("arm-resume.sh");
   expect(a.slice(2)).toEqual(["--dedup-any", "--time", "04:10", "--handover", "C:/sess/respawn-handover.md"]);
+});
+
+test("buildArmEnv marks the auto-arm as a safety arm (long-gap exempt, HIMMEL-1475)", () => {
+  // ARM_RESUME_SAFETY_ARM=1 is the guard-exemption signal (a multi-hour
+  // cap-reset park is the safety arm's whole point); --dedup-any in the argv
+  // stays dedup-scope only and must NOT bypass the guard. Spreads process.env
+  // so the live PATH/.env-sourced vars still reach the child.
+  const e = buildArmEnv();
+  expect(e.ARM_RESUME_SAFETY_ARM).toBe("1");
 });
 
 test("formatUsageWarn tiers", () => {

--- a/scripts/telegram/spawn-glm.ts
+++ b/scripts/telegram/spawn-glm.ts
@@ -1125,7 +1125,7 @@ async function main(): Promise<void> {
       // re-dispatches on the SAME lane profile (not the lane-impl default).
       profile, addPlugins,
       fetchUsage: () => fetchGlmUsage(readZaiKey(REPO_ROOT).key),
-      arm: (hhmm, snap) => Bun.spawnSync(buildArmArgv(REPO_ROOT, hhmm, snap), { stdout: "inherit", stderr: "inherit" }).exitCode ?? 1,
+      arm: (hhmm, snap) => Bun.spawnSync(buildArmArgv(REPO_ROOT, hhmm, snap), { stdout: "inherit", stderr: "inherit", env: buildArmEnv() }).exitCode ?? 1,
     };
     const { code } = await executeRun({ runSession, prompt, worktree, permMode, sessionDir, metaPath, runningMeta, capGuard, settings });
     return code;
@@ -1258,6 +1258,19 @@ export type CapGuardDeps = {
 // (--dedup-any --time <HH:MM> --handover <path>) is unit-asserted.
 export function buildArmArgv(repoRoot: string, hhmm: string, handoverPath: string): string[] {
   return [BASH_BIN, join(repoRoot, "scripts", "handover", "arm-resume.sh"), "--dedup-any", "--time", hhmm, "--handover", handoverPath];
+}
+
+// Child env for the auto-arm invoker: ARM_RESUME_SAFETY_ARM=1 marks this as an
+// automated machine-wide SAFETY arm (the cap-respawn watchdog) so arm-resume's
+// long-gap guard (HIMMEL-1475) exempts it — a multi-hour cap-reset park is the
+// safety arm's whole point, not an orchestrator's silent far default. Pure so
+// the env contract is unit-asserted (the --dedup-any argv stays dedup-scope
+// only and does NOT bypass the guard). Spreads process.env so a runtime
+// override + the live PATH/.env-sourced vars still reach the child (Bun's
+// default env is a process-START snapshot, not live process.env — same reason
+// ensureWorkspaceTrust passes env: process.env).
+export function buildArmEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, ARM_RESUME_SAFETY_ARM: "1" };
 }
 
 // Preflight warn (spec (c)): warn-only — a heuristic-threshold refusal would

--- a/scripts/telegram/test-auto-action.sh
+++ b/scripts/telegram/test-auto-action.sh
@@ -23,6 +23,10 @@ assert_contains() {
     local label="$1" needle="$2" haystack="$3"
     case "$haystack" in *"$needle"*) echo "PASS $label" ;; *) echo "FAIL $label — missing: $needle"; FAILED=$((FAILED + 1)) ;; esac
 }
+assert_not_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    case "$haystack" in *"$needle"*) echo "FAIL $label — unexpectedly contains: $needle"; FAILED=$((FAILED + 1)) ;; *) echo "PASS $label" ;; esac
+}
 FAILED=0
 
 # --- Fixtures -------------------------------------------------------------
@@ -88,6 +92,9 @@ assert_contains "T3 echoes resolved basename" "resolved=2026-06-20-himmel-777-re
 args=$(cat "$ARM_ARGS_FILE" 2>/dev/null)
 assert_contains "T3 arm got --handover resolved path" "2026-06-20-himmel-777-resume.md" "$args"
 assert_contains "T3 arm got --time smart" "--time smart" "$args"
+# smart is a system-computed sentinel the long-gap guard exempts by design, so
+# the Telegram path must NOT ride --long-gap on it (HIMMEL-1475).
+assert_not_contains "T3 smart does not ride --long-gap" "--long-gap" "$args"
 
 # --- T4: ticket only matched under specs/ → excluded → no handover --------
 out=$(run arm-resume HIMMEL-888 smart); rc=$?
@@ -115,7 +122,11 @@ assert_rc "T8 path outside handover_root rejected" 3 "$rc"
 INSIDE="$HANDOVER_DIR/yotam/himmel/2026-06-20-himmel-777-resume.md"
 out=$(run arm-resume "$INSIDE" 02:00); rc=$?
 assert_rc "T9 valid in-root path arms" 0 "$rc"
-assert_contains "T9 arm got --time 02:00" "--time 02:00" "$(cat "$ARM_ARGS_FILE")"
+args9=$(cat "$ARM_ARGS_FILE")
+assert_contains "T9 arm got --time 02:00" "--time 02:00" "$args9"
+# an explicit HH:MM typed on Telegram rides --long-gap — a HUMAN typing a far
+# time IS the explicit choice the long-gap guard exists to force (HIMMEL-1475).
+assert_contains "T9 explicit HH:MM rides --long-gap" "--long-gap" "$args9"
 
 # --- T10: arm-resume dedup (rc 3) → auto-action rc 5 (already armed) -------
 out=$(ARM_STUB_RC=3 run arm-resume HIMMEL-777 smart); rc=$?
@@ -124,6 +135,12 @@ assert_rc "T10 already-armed maps to rc 5" 5 "$rc"
 # --- T11: arm-resume other failure (rc 2) → auto-action rc 6 --------------
 out=$(ARM_STUB_RC=2 run arm-resume HIMMEL-777 smart); rc=$?
 assert_rc "T11 arm failure maps to rc 6" 6 "$rc"
+
+# --- T11b: arm-resume long-gap refusal (rc 9) → auto-action rc 6 ----------
+# Should not occur once --long-gap rides along on the HH:MM branch, but the
+# honest error text is kept if it does (HIMMEL-1475).
+out=$(ARM_STUB_RC=9 run arm-resume HIMMEL-777 smart); rc=$?
+assert_rc "T11b long-gap refusal (rc 9) maps to rc 6" 6 "$rc"
 
 # --- merge-public (HIMMEL-1213) --------------------------------------------
 # merge-public-on-green stub: records argv, exits with MERGE_STUB_RC (default 0).

--- a/scripts/test-check-ci.sh
+++ b/scripts/test-check-ci.sh
@@ -703,9 +703,27 @@ assert_rc 0 "34d skip-ish wording on a COMPLETED review does not block"
 unset CR_OK_DESC_RE CR_SKIP_DESC_RE
 
 run cr-ratelimited
-assert_rc 2 "34e rate-limited CodeRabbit review is not certifiable"
-assert_err_has "SKIPPED the review" "34e rate-limit reason surfaced"
-assert_err_has "RATE LIMITED" "34e names rate limiting as a known cause"
+assert_rc 2 "34e rate-limited CodeRabbit review with no panel evidence is not certifiable"
+assert_err_has "rate-limited" "34e rate-limit reason surfaced"
+assert_err_has "did NOT carry the gate" "34e names the missing panel evidence (HIMMEL-1465)"
+
+# 34e2 (HIMMEL-1465) — the SAME rate-limited decline, but a CLEAN critic panel
+# recorded at the head in the CR ledger: the panel carries the gate and the
+# verdict certifies. A SCRATCH repo pins the ledger — cr-ledger-evidence.sh
+# deliberately reads only <git-common-dir>/cr-critic-scores.jsonl of the CWD
+# repo (never an env-pointed path), so the real checkout's ledger must not
+# decide this case. Head "sha1" matches by exact string equality in atHead
+# (it is not hex, so it can never prefix-resolve to anything else).
+LEDGER_REPO=$(mktemp -d "$STUBDIR/ledgerrepo.XXXXXX")
+git -C "$LEDGER_REPO" init --quiet
+git -C "$LEDGER_REPO" -c user.email=t@t -c user.name=t commit --allow-empty -m seed --quiet --no-verify
+printf '%s\n' '{"kind":"avail","ts":"2026-08-03T00:00:00Z","branch":"feat/x","head":"sha1","model":"codex","status":"ok","artifact":"diff","perspective":"off","responding_model":"gpt-5.5"}' > "$LEDGER_REPO/.git/cr-critic-scores.jsonl"
+PRE_34E2_PWD=$PWD
+cd "$LEDGER_REPO" || { echo "FATAL: cannot cd to 34e2 scratch repo" >&2; exit 1; }
+run cr-ratelimited
+cd "$PRE_34E2_PWD" || { echo "FATAL: cannot cd back from 34e2 scratch repo" >&2; exit 1; }
+assert_rc 0 "34e2 rate-limited App with a clean panel at the head is panel-carried (HIMMEL-1465)"
+assert_out_has "the critic panel carries the gate" "34e2 carried-gate audit line surfaced"
 
 run cr-unknownword
 assert_rc 2 "34f an UNENUMERATED success wording fails closed, not open"
@@ -993,5 +1011,5 @@ fi
 
 echo
 echo "ran $COUNT cases; PASS=$PASS FAIL=$FAIL"
-if [ "$COUNT" -ne 66 ]; then echo "CASE-COUNT MISMATCH: ran $COUNT want 66"; exit 1; fi
+if [ "$COUNT" -ne 67 ]; then echo "CASE-COUNT MISMATCH: ran $COUNT want 67"; exit 1; fi
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Wave 2h — gate evidence + guardrail hardening

Public projection of everything merged to private main since `9ac88939`:

- **HIMMEL-1465** — when CodeRabbit's App declines with the rate-limit wording
  (and only that wording), a clean critic-panel record in the CR ledger at the
  exact head carries the gate. Evidence-gated and fail-closed: any other
  decline, or unreadable evidence, keeps today's behavior. New
  `scripts/lib/cr-ledger-evidence.sh` mirrors clear-cr-marker gates 3–4;
  `check-ci.sh` + `cr-merge-gate.sh` consume it; a carry never skips the
  thread/body gates.
- **HIMMEL-1475** — arm-resume long-gap guard: parking an arm further than 60
  minutes out requires an explicit `--long-gap` (fail-closed rc=9), with the
  Telegram explicit-HH:MM surface riding the flag by design and the automated
  safety-arm exemption de-publicized to an internal env that every launch body
  clears.
- **HIMMEL-1472** — the guardrail-block git-unavailable fallback handles
  sha256 repos end-to-end, and its repository-format validation is
  strict-by-whitelist: it can never attest a width against a config git
  refuses (headers, keys, values, quoted + dotted extensions subsections),
  with the closure rule documented in-code.
- **HIMMEL-1483** — every PR carries a ticket, structurally: strict
  commit-msg twins + CI range gate (`--no-merges`, revert exemption requires
  the reverted hash to resolve) + propagate-public backstop. Adopter-
  configurable (`TICKET_ID_PATTERN` / `TICKET_ID_REQUIRED`).
- **HIMMEL-1473 / HIMMEL-1482 / HIMMEL-1476 follow-ons** — atomic cli-proxy
  binary swap (File.Replace, held-handle lock, in-transaction health);
  worktree-cwd .env resolution restricted to genuine linked-worktree roots;
  public CR batch residue.

Every change passed the private gate stack (critic panel per head, adversarial
renders where applicable, parent-verified suites); the per-round evidence
lives in the private CR ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
