### PR TITLE
chore(HIMMEL-1498): bump graphify 0.9.32 + cli-proxy-api 7.2.115 (fork-drift #518)

### DIFF
--- a/scripts/lib/graphify-bin.sh
+++ b/scripts/lib/graphify-bin.sh
@@ -50,7 +50,7 @@
 # (HIMMEL-891) -- without carrying a fork. A pin bump is a reviewed change to this
 # line, paired with `synced_base` in scripts/upstreams.json so the nightly
 # fork-drift guard stays truthful.
-_graphify_version() { printf '%s\n' "${GRAPHIFY_VERSION:-0.9.31}"; }
+_graphify_version() { printf '%s\n' "${GRAPHIFY_VERSION:-0.9.32}"; }
 _graphify_pypi_name() { printf '%s\n' "graphifyy"; }
 # The `uv tool install` package spec: `graphifyy==<version>`.
 _graphify_pinned_source() { printf '%s==%s\n' "$(_graphify_pypi_name)" "$(_graphify_version)"; }

--- a/scripts/setup/cli-proxy-lane.ps1
+++ b/scripts/setup/cli-proxy-lane.ps1
@@ -62,7 +62,7 @@ $Exe     = Join-Path $Dir 'cli-proxy-api.exe'
 $Cfg     = Join-Path $Dir 'config.yaml'
 $ApiKey  = 'himmel-local-claudex'   # local proxy token; must match config.yaml api-keys
 $Port    = 8317
-$Version = '7.2.113'
+$Version = '7.2.115'
 $Release = "https://github.com/router-for-me/CLIProxyAPI/releases/download/v$Version/CLIProxyAPI_${Version}_windows_amd64.zip"
 
 function Test-OAuth {

--- a/scripts/upstreams.json
+++ b/scripts/upstreams.json
@@ -139,7 +139,7 @@
       "kind": "tag_release",
       "mode": "base",
       "tracked_repo": "Graphify-Labs/graphify",
-      "synced_base": "0.9.31",
+      "synced_base": "0.9.32",
       "latest_source": "release",
       "version_pin": { "file": "scripts/lib/graphify-bin.sh", "template": "GRAPHIFY_VERSION:-{version}" },
       "tier": "A",
@@ -150,10 +150,10 @@
       "kind": "tag_release",
       "mode": "base",
       "tracked_repo": "router-for-me/CLIProxyAPI",
-      "synced_base": "7.2.113",
+      "synced_base": "7.2.115",
       "version_pin": { "file": "scripts/setup/cli-proxy-lane.ps1", "template": "$Version = '{version}'" },
       "tier": "A",
-      "note": "CLIProxyAPI codex-lane proxy (HOST process on 127.0.0.1:8317; installed + run by scripts/setup/cli-proxy-lane.ps1). Added to the nightly drift machinery (HIMMEL-1451) so a new upstream release SURFACES as a drift finding instead of needing manual surgery: v7.2.77 threw ~3-min bursts of instant upstream 502s every ~25 min that killed codex-adv renders (Claude Code retries 502s but the companion's render turn does not), and the validated fix was a manual swap to v7.2.113 -- both legs completed clean that night. AUTO-BUMP policy is deliberately SURFACE-ONLY and matches the existing rows' conservatism: apply-drift-bump.sh moves the in-repo pin literal ($Version in cli-proxy-lane.ps1) and synced_base TOGETHER, but NOTHING here restarts the running proxy -- bumping the pin does NOT swap a live instance. The drift leg lands the pin bump as a PR, and the operator runs cli-proxy-lane.ps1 -Install + -Restart (HIMMEL-1451 lifecycle verbs) to actually roll the host. Default tag-mode (highest stable tag, prereleases excluded -- CLIProxyAPI tags are monotonic, so no latest_source override is needed); synced_base lacks the leading 'v' but the guard normalizes both sides before comparing (v7.2.113 tag == 7.2.113 base). tracked_repo is the TRUE upstream (router-for-me/CLIProxyAPI)."
+      "note": "CLIProxyAPI codex-lane proxy (HOST process on 127.0.0.1:8317; installed + run by scripts/setup/cli-proxy-lane.ps1). Added to the nightly drift machinery (HIMMEL-1451) so a new upstream release SURFACES as a drift finding instead of needing manual surgery: v7.2.77 threw ~3-min bursts of instant upstream 502s every ~25 min that killed codex-adv renders (Claude Code retries 502s but the companion's render turn does not), and the validated fix was a manual swap to v7.2.113 -- both legs completed clean that night. AUTO-BUMP policy is deliberately SURFACE-ONLY and matches the existing rows' conservatism: apply-drift-bump.sh moves the in-repo pin literal ($Version in cli-proxy-lane.ps1) and synced_base TOGETHER, but NOTHING here restarts the running proxy -- bumping the pin does NOT swap a live instance. The drift leg lands the pin bump as a PR, and the operator runs cli-proxy-lane.ps1 -Install + -Restart (HIMMEL-1451 lifecycle verbs) to actually roll the host. Default tag-mode (highest stable tag, prereleases excluded -- CLIProxyAPI tags are monotonic, so no latest_source override is needed); synced_base lacks the leading 'v' but the guard normalizes both sides before comparing (v7.2.115 tag == 7.2.115 base). tracked_repo is the TRUE upstream (router-for-me/CLIProxyAPI)."
     },
     {
       "name": "qmd",


### PR DESCRIPTION
## Summary
Nightly drift-fix cadence payload (HIMMEL-1498) — closes the fork-drift loop for #518:
- **graphify** pin 0.9.31 → 0.9.32 (`scripts/lib/graphify-bin.sh` + `synced_base` in `scripts/upstreams.json`)
- **cli-proxy-api** pin 7.2.113 → 7.2.115 (`scripts/setup/cli-proxy-lane.ps1` + `synced_base`)

Both halves applied mechanically by `scripts/upstreams/apply-drift-bump.sh` (downgrade-refusing, byte-restoring; pin literal + `synced_base` move together) and re-verified `CURRENT` by `check-plugin-drift.sh`.

Surface-only policy: the bump does not roll a live proxy instance — the operator runs `cli-proxy-lane.ps1 -Install` + `-Restart` to swap the host binary.

## Test plan
- `scripts/upstreams/test-apply-drift-bump.sh` — all checks passed
- `scripts/lib/test-graphify-bin.sh` — 115 passed / 0 failed
- `scripts/setup/test-cli-proxy-lane.ps1` — 65 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
