### PR TITLE
feat: [HIMMEL-1474][HIMMEL-1509] wave 2i — render liveness + lease protocol, panel carry, gate hermeticity (13 tickets)

### DIFF
--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -117,8 +117,23 @@ Steps:
    ```bash
    db=$(. scripts/guardrails/lib.sh 2>/dev/null && default_branch || echo main)
    . scripts/lib/load-dotenv.sh; load_dotenv CR_PROFILE || true
+   . scripts/lib/proc-tree.sh
    export CR_PROFILE
    branch=$(git branch --show-current)
+   # HIMMEL-1509 launch claim (subsumes HIMMEL-1496): one render per branch,
+   # coordinated through the render-lease registry instead of the retired :00
+   # launch window. This probe is the loud fast-path refusal; the ATOMIC claim
+   # lives inside run-codex-adversarial.sh (mkdir = the lock, taken before node
+   # spawns), so two kickoffs racing past this probe still cannot double-launch
+   # - the loser exits 75 with its own diagnostic. RENDER_LEASE_BRANCH is the
+   # launcher's opt-in.
+   # shellcheck source=scripts/lib/render-lease.sh
+   . scripts/lib/render-lease.sh
+   export RENDER_LEASE_BRANCH="$branch"
+   if [ -n "$branch" ] && ! render_lease_probe "$branch"; then
+       echo "codex adversarial kickoff BLOCKED: branch '$branch' holds a live render lease ($(render_lease_dir_for "$branch")) — a concurrent /pr-check render owns this branch (HIMMEL-1509); wait for it to finish, or adjudicate a stale lease via the sweep before retrying" >&2
+       exit 1
+   fi
    git_dir=$(git rev-parse --git-common-dir)
    # Branch-scoped under the SHARED git-common-dir, same convention as
    # cr-pending/cr-prior-blocking (HIMMEL-1219) — concurrent /pr-check runs on
@@ -126,7 +141,14 @@ Steps:
    # because a branch name contains '/' (e.g. fix/himmel-1407-...).
    codex_out="${git_dir}/codex-adv-out/${branch}"
    codex_pid_file="${codex_out}.pid"
+   codex_identity_file="${codex_pid_file}.identity"
+   codex_survivors_file="${codex_pid_file}.survivors"
+   codex_retry_pid_file="${codex_pid_file}.retry"
+   codex_retry_identity_file="${codex_retry_pid_file}.identity"
+   codex_retry_survivors_file="${codex_retry_pid_file}.survivors"
    codex_rc_file="${codex_out}.rc"
+   codex_cleanup_rc_file="${codex_pid_file}.cleanup-rc"
+   codex_retry_cleanup_rc_file="${codex_retry_pid_file}.cleanup-rc"
    # Companion stderr goes to its OWN sibling file, not merged into
    # $codex_out (glm-3, CR round 2, HIMMEL-1407): findings capture must stay
    # stdout-only, or diagnostic chatter on an otherwise-successful run gets
@@ -135,9 +157,103 @@ Steps:
    # exactly what hid this ticket's root cause for 28 runs.
    codex_err_file="${codex_out}.err"
    mkdir -p "$(dirname "$codex_out")"
-   # Overwrite per run — no unbounded growth, and a stale pid/rc/err from a
-   # PRIOR run on this branch can never be mistaken for this run's job.
-   rm -f "$codex_pid_file" "$codex_rc_file"; : > "$codex_out"; : > "$codex_err_file"
+   # HIMMEL-1474 r11 kickoff recovery start. Never overwrite a prior run's
+   # ownership handles. A completed clean record is stale and removable; an
+   # identity-verified leader or r14 survivor anchor is recovered; an active or
+   # unverifiable record blocks this kickoff with the handles intact.
+   recover_codex_survivor() {
+       local state_label="$1" survivor_pid="$2" survivor_identity="$3" identity_rc
+       if [ -z "$survivor_pid" ] || [ -z "$survivor_identity" ]; then
+           echo "codex adversarial kickoff BLOCKED: $state_label survivor record is malformed; manual recovery required" >&2
+           return 1
+       fi
+       identity_rc=0
+       proc_tree_process_identity_matches "$survivor_pid" "$survivor_identity" || identity_rc=$?
+       if [ "$identity_rc" -eq 1 ]; then
+           if proc_tree_process_alive "$survivor_pid"; then
+               echo "codex adversarial kickoff BLOCKED: $state_label survivor pid $survivor_pid has an identity mismatch; no signal sent" >&2
+               return 1
+           fi
+           return 0
+       fi
+       if [ "$identity_rc" -ne 0 ]; then
+           echo "codex adversarial kickoff BLOCKED: $state_label survivor pid $survivor_pid cannot be identity-verified (identity rc=$identity_rc); no signal sent" >&2
+           return 1
+       fi
+       kill -TERM "$survivor_pid" 2>/dev/null || true
+       sleep 1
+       identity_rc=0
+       proc_tree_process_identity_matches "$survivor_pid" "$survivor_identity" || identity_rc=$?
+       if [ "$identity_rc" -eq 0 ]; then
+           kill -KILL "$survivor_pid" 2>/dev/null || true
+           sleep 1
+           identity_rc=0
+           proc_tree_process_identity_matches "$survivor_pid" "$survivor_identity" || identity_rc=$?
+       fi
+       if [ "$identity_rc" -eq 1 ]; then
+           proc_tree_process_alive "$survivor_pid" || return 0
+       fi
+       echo "codex adversarial kickoff BLOCKED: $state_label survivor pid $survivor_pid remains live or unverifiable after recovery (identity rc=$identity_rc); preserve recovery sidecars" >&2
+       return 1
+   }
+   recover_codex_state() {
+       local state_label="$1" state_pid_file="$2" state_identity_file="${2}.identity" state_cleanup_rc_file="${2}.cleanup-rc" state_survivors_file="${2}.survivors"
+       local state_pid state_identity state_cleanup_rc identity_rc recovery_rc survivor_pid survivor_identity
+       [ -e "$state_pid_file" ] || { rm -f "$state_identity_file" "$state_cleanup_rc_file" "$state_survivors_file"; return 0; }
+       if [ ! -s "$state_pid_file" ] || [ ! -s "$state_identity_file" ]; then
+           echo "codex adversarial kickoff BLOCKED: $state_label ownership record is incomplete ($state_pid_file / $state_identity_file); refusing to overwrite it" >&2
+           return 1
+       fi
+       if [ ! -s "$state_cleanup_rc_file" ]; then
+           echo "codex adversarial kickoff BLOCKED: $state_label render is still active or cleanup status is missing; preserve $state_pid_file and $state_identity_file and recover it before retrying" >&2
+           return 1
+       fi
+       state_cleanup_rc=$(cat "$state_cleanup_rc_file")
+       if [ "$state_cleanup_rc" = "0" ]; then
+           rm -f "$state_pid_file" "$state_identity_file" "$state_cleanup_rc_file" "$state_survivors_file"
+           return 0
+       fi
+       state_pid=$(cat "$state_pid_file")
+       state_identity=$(cat "$state_identity_file")
+       identity_rc=0
+       proc_tree_process_identity_matches "$state_pid" "$state_identity" || identity_rc=$?
+       if [ "$identity_rc" -eq 1 ]; then
+           case "$state_cleanup_rc" in
+               1|2) ;;
+               *)
+                   echo "codex adversarial kickoff BLOCKED: $state_label cleanup rc=$state_cleanup_rc and launch identity no longer matches; no signal sent; preserve recovery sidecars" >&2
+                   return 1
+                   ;;
+           esac
+           if [ ! -e "$state_survivors_file" ]; then
+               echo "codex adversarial kickoff BLOCKED: $state_label cleanup rc=$state_cleanup_rc has a dead leader but no survivors sidecar (legacy pre-r14 record); manual recovery required before removing $state_pid_file / $state_identity_file / $state_cleanup_rc_file" >&2
+               return 1
+           fi
+           while IFS=$'\t' read -r survivor_pid survivor_identity || [ -n "$survivor_pid$survivor_identity" ]; do
+               recover_codex_survivor "$state_label" "$survivor_pid" "$survivor_identity" || return 1
+           done < "$state_survivors_file"
+           rm -f "$state_pid_file" "$state_identity_file" "$state_cleanup_rc_file" "$state_survivors_file"
+           echo "codex adversarial kickoff recovered prior $state_label render through survivor anchors" >&2
+           return 0
+       fi
+       if [ "$identity_rc" -ne 0 ]; then
+           echo "codex adversarial kickoff BLOCKED: $state_label cleanup rc=$state_cleanup_rc and launch identity cannot be verified (identity rc=$identity_rc); no signal sent; preserve recovery sidecars" >&2
+           return 1
+       fi
+       recovery_rc=0
+       proc_tree_terminate "$state_pid" 1 "$state_identity" || recovery_rc=$?
+       if [ "$recovery_rc" -ne 0 ]; then
+           echo "codex adversarial kickoff BLOCKED: $state_label recovery cleanup rc=$recovery_rc; preserve recovery sidecars" >&2
+           return 1
+       fi
+       rm -f "$state_pid_file" "$state_identity_file" "$state_cleanup_rc_file" "$state_survivors_file"
+       echo "codex adversarial kickoff recovered prior $state_label render pid/group $state_pid" >&2
+       return 0
+   }
+   recover_codex_state "primary" "$codex_pid_file" || exit 1
+   recover_codex_state "retry" "$codex_retry_pid_file" || exit 1
+   # HIMMEL-1474 r11 kickoff recovery end.
+   rm -f "$codex_rc_file" "$codex_cleanup_rc_file"; : > "$codex_out"; : > "$codex_err_file"
    # Resolve via bash glob, NOT `ls` (HIMMEL-741c: Git Bash `ls` classify suffix
    # `*` on executables corrupts the path). Last glob match = highest lexical.
    companion=""
@@ -157,8 +273,8 @@ Steps:
    else
        # A real OS background job, NOT `timeout`-wrapped (that would just
        # reintroduce the foreground timebox one level up — the exact thing
-       # this restructure removes). The pid file records NODE's own pid,
-       # written from INSIDE the wrapper subshell — not the wrapper's $!:
+       # this restructure removes). The shared launcher records NODE's own pid
+       # and starts its Layer B client-lease heartbeat — not the wrapper's $!:
        # signaling a bash wrapper does not propagate to its running child, so
        # a wrapper-pid kill on the timeout path would leave node alive and
        # orphaned, still consuming quota (the exact cost HIMMEL-1407 exists
@@ -167,10 +283,7 @@ Steps:
        # so step 3.1's harvest — a separate bash fence with no job-table link
        # back to this one — can tell "still running" apart from "ran and
        # failed" using only the pid + rc files on disk.
-       ( node "$companion" adversarial-review --wait --base "$db" >"$codex_out" 2>"$codex_err_file" &
-         _node_pid=$!
-         echo "$_node_pid" > "$codex_pid_file"
-         wait "$_node_pid"
+       ( bash scripts/cr/run-codex-adversarial.sh "$companion" "$db" "$codex_out" "$codex_err_file" "$codex_pid_file" 0 "$codex_cleanup_rc_file"
          echo $? > "$codex_rc_file" ) &
        disown 2>/dev/null || true
        echo "codex adversarial pass launched in background — harvested in step 3.1 after the critic panel (HIMMEL-1407)"
@@ -290,18 +403,26 @@ Steps:
 
    **Step 3.1 — codex adversarial-review pass: harvest (decimal substep, runs AFTER the critic panel, still before any Agent dispatch; HIMMEL-694, HIMMEL-1407).** The pass itself was already LAUNCHED as a background job in the step-3 kickoff fence above — this substep HARVESTS it. It is **availability-gated** — it consumes the operator's OpenAI usage bank, so it runs ONLY when codex is configured (the kickoff fence's skip note already covers the unconfigured case), mirroring how the paid codex critic is gated in `critics.json` / the `CR_PROFILE=paid` lane. Like the panel, this pass is **fail-open**: absence, timeout, or error degrades to claude-only and never blocks the gate.
 
-   **Completion sentinel (HIMMEL-1420 — rc=0 alone is NOT sufficient evidence of a clean pass.)** Observed 8x across HIMMEL-1420 under this same background-launch pattern: the companion node process exits rc=0 with EMPTY or truncated stdout and a truncated `.err` — no final verdict ever emitted (proven: the HIMMEL-1416 retry on one such diff came back needs-attention with two `[high]` findings the rc=0/empty run had silently dropped). The old fence here read rc=0 alone as success (`codex_findings=$(cat "$codex_out")`). The fence below classifies rc=0 via `scripts/cr/codex-adv-completion-check.sh` (tested — `scripts/cr/test-codex-adv-completion-check.sh`), which is the SINGLE SOURCE OF TRUTH for the completion contract — do not re-derive its logic or its assertion/step count here, both keep growing across CR rounds and any number quoted in this prose drifts stale immediately; see the script's own header comment for the current contract (a line-walk anchored to the real companion source at `scripts/lib/render.mjs`, not free-text search — the renderer's own parse-error/validation-error banners reuse the identical heading under rc=0 and can echo the model's raw output verbatim) and its test suite for the exhaustive fixture set. rc=0 that fails the script's check is treated as **UNAVAILABLE**, never clean, and gets ONE bounded synchronous retry (bounded by the same `$codex_timeout` the async kickoff used, with a `timeout -k` kill-after grace) before finalizing. The `.err` tail is captured for diagnostics only — a last line matching `Turn completion inferred` tells you the companion process itself believed it finished, distinct from an actually-killed mid-review process, but it never flips the unavailable verdict; the contract lives entirely in the tested script, not the companion's internal state.
+   **Completion sentinel (HIMMEL-1420 — rc=0 alone is NOT sufficient evidence of a clean pass.)** Observed 8x across HIMMEL-1420 under this same background-launch pattern: the companion node process exits rc=0 with EMPTY or truncated stdout and a truncated `.err` — no final verdict ever emitted (proven: the HIMMEL-1416 retry on one such diff came back needs-attention with two `[high]` findings the rc=0/empty run had silently dropped). The old fence here read rc=0 alone as success (`codex_findings=$(cat "$codex_out")`). The fence below classifies rc=0 via `scripts/cr/codex-adv-completion-check.sh` (tested — `scripts/cr/test-codex-adv-completion-check.sh`), which is the SINGLE SOURCE OF TRUTH for the completion contract — do not re-derive its logic or its assertion/step count here, both keep growing across CR rounds and any number quoted in this prose drifts stale immediately; see the script's own header comment for the current contract (a line-walk anchored to the real companion source at `scripts/lib/render.mjs`, not free-text search — the renderer's own parse-error/validation-error banners reuse the identical heading under rc=0 and can echo the model's raw output verbatim) and its test suite for the exhaustive fixture set. rc=0 that fails the script's check is treated as **UNAVAILABLE**, never clean, and gets ONE bounded synchronous retry (bounded by the same `$codex_timeout` the async kickoff used through the shared launcher, which owns and tree-kills the real node pid) before finalizing. The `.err` tail is captured for diagnostics only — a last line matching `Turn completion inferred` tells you the companion process itself believed it finished, distinct from an actually-killed mid-review process, but it never flips the unavailable verdict; the contract lives entirely in the tested script, not the companion's internal state.
 
    **Harvest budget (HIMMEL-1407 — replaces the old foreground `CRITIC_TIMEOUT_SECS*2` timebox that caused 28 lifetime timeouts).** After the panel completes, poll for the backgrounded process's exit up to `CRITIC_TIMEOUT_SECS*2` MORE seconds (≈480s default — the same per-pass budget the old foreground timebox used, now measured from harvest-start instead of launch-start). Net time available to the review is panel-wall-clock + ≈480s (typically 12–20min total), with ~zero added wall-clock in the common case where the review finishes during or shortly after the panel. If the process is still alive once that budget is exhausted, kill it and record a timeout — the same fail-open outcome as before, just far less likely to fire on a healthy review still running its post-verdict test-suite verification. Each bash fence in this runbook is independent, so re-resolve `$db` + `CR_PROFILE` and the branch-scoped pid/rc/output files the kickoff fence wrote:
    ```bash
    db=$(. scripts/guardrails/lib.sh 2>/dev/null && default_branch || echo main)
    . scripts/lib/load-dotenv.sh; load_dotenv CR_PROFILE || true
+   . scripts/lib/proc-tree.sh
    export CR_PROFILE
    branch=$(git branch --show-current)
+   # HIMMEL-1509: the bounded retry below re-invokes the shared launcher, so it
+   # must carry the branch launch claim too (the primary render's lease was
+   # released on its verified-clean exit before any retry can fire).
+   export RENDER_LEASE_BRANCH="$branch"
    git_dir=$(git rev-parse --git-common-dir)
    codex_out="${git_dir}/codex-adv-out/${branch}"
    codex_pid_file="${codex_out}.pid"
+   codex_identity_file="${codex_pid_file}.identity"
+   codex_survivors_file="${codex_pid_file}.survivors"
    codex_rc_file="${codex_out}.rc"
+   codex_cleanup_rc_file="${codex_pid_file}.cleanup-rc"
    codex_err_file="${codex_out}.err"  # companion stderr, kept for debugging — see kickoff fence (glm-3, CR round 2)
    codex_findings=""; codex_rc=0; codex_avail_status=""
    if [ "${CR_PROFILE:-}" = "none" ]; then
@@ -313,6 +434,7 @@ Steps:
        : # nothing to harvest.
    else
        codex_pid=$(cat "$codex_pid_file")
+       codex_identity=$(cat "$codex_identity_file" 2>/dev/null) || codex_identity=""
        # 10# forces base 10: `$(( ))` reads a LEADING ZERO as octal, so
        # CRITIC_TIMEOUT_SECS=08 would die here with "value too great for base",
        # leave codex_to empty, and surface as a wrong cause for a value that
@@ -326,35 +448,52 @@ Steps:
        case "$codex_timeout" in ''|*[!0-9]*) codex_timeout=240 ;; esac
        [ "$codex_timeout" -gt 0 ] || codex_timeout=240
        codex_to=$(( 10#$codex_timeout * 2 ))
-       # Bounded poll loop, NOT `timeout` (Windows note, HIMMEL-1407): `timeout`
-       # cannot wrap an already-detached background PID, and a poll loop
-       # degrades gracefully on any host regardless of whether `timeout` is
-       # installed — unlike the old foreground fence's `command -v timeout`
-       # branch, this harvest needs no such fallback.
+       # HIMMEL-1474 r4/r6b: rc is the first liveness fact. Only when no rc
+       # exists may the launch identity be probed; break only on a confirmed
+       # mismatch/exit, not when the identity probe is unavailable.
        waited=0
-       while kill -0 "$codex_pid" 2>/dev/null; do
+       while [ ! -s "$codex_rc_file" ]; do
+           identity_rc=0
+           proc_tree_process_identity_matches "$codex_pid" "$codex_identity" || identity_rc=$?
+           [ "$identity_rc" -eq 1 ] && break
            [ "$waited" -ge "$codex_to" ] && break
            sleep 5
            waited=$((waited + 5))
        done
-       if kill -0 "$codex_pid" 2>/dev/null; then
-           # Still running after the bounded additional wait — kill it and
-           # record a timeout, same fail-open outcome as the old rc=124/137 case.
-           # Prefer a Windows tree-kill: plain `kill "$codex_pid"` reaches node
-           # but not the subprocesses the companion spawns (test suites) —
-           # double-slash `//PID`/`//T`/`//F` guards against MSYS path-mangling
-           # rewriting a leading `/` into a path. Full portable process-group
-           # kill is HIMMEL-1409; the POSIX kill chain stays as the fallback.
-           if command -v taskkill >/dev/null 2>&1; then
-               taskkill //PID "$codex_pid" //T //F 2>/dev/null
+       harvest_timed_out=0
+       harvest_live_unreaped=0
+       harvest_survivors=0
+       harvest_cleanup_unverified=0
+       if [ ! -s "$codex_rc_file" ] && [ "$waited" -ge "$codex_to" ]; then
+           # Re-check rc FIRST immediately before the identity-guarded signal.
+           # proc_tree_terminate returns 2 without signaling when identity cannot
+           # be confirmed; rc 1 means escalated cleanup left survivors. Either
+           # outcome may still be live and needs its recovery sidecars.
+           if [ ! -s "$codex_rc_file" ]; then
+               proc_tree_terminate "$codex_pid" 1 "$codex_identity"
+               terminate_rc=$?
+               if [ "$terminate_rc" -eq 2 ]; then
+                   harvest_live_unreaped=1
+               else
+                   harvest_timed_out=1
+                   [ "$terminate_rc" -eq 1 ] && harvest_survivors=1
+               fi
            fi
-           kill "$codex_pid" 2>/dev/null; sleep 1; kill -9 "$codex_pid" 2>/dev/null
-           echo "codex adversarial pass timed out (>${codex_to}s after the panel finished; stderr: $codex_err_file) — continuing without it" >&2
+       fi
+       if [ "$harvest_live_unreaped" -eq 1 ]; then
+           echo "codex adversarial pass is live but unreaped: cleanup refused for pid/group $codex_pid (rc=2); preserving recovery sidecars $codex_pid_file and $codex_identity_file because no signal was sent — continuing without it" >&2
+           codex_findings=""; codex_rc=2; codex_avail_status="unavailable"
+       elif [ "$harvest_timed_out" -eq 1 ]; then
+           if [ "$harvest_survivors" -eq 1 ]; then
+               echo "codex adversarial pass timed out with survivors after escalated cleanup — sidecars preserved for recovery: $codex_pid_file and $codex_identity_file; continuing without it" >&2
+           else
+               echo "codex adversarial pass timed out (>${codex_to}s after the panel finished; stderr: $codex_err_file) — continuing without it" >&2
+           fi
            codex_findings=""; codex_rc=124; codex_avail_status="unavailable"
        else
-           # Node has exited (kill -0 above just failed), but the wrapper
-           # subshell writes $codex_rc_file a BEAT LATER — after `wait
-           # "$_node_pid"` returns — so a genuinely successful run landing in
+           # Node has exited (or its identity no longer matches), but the wrapper
+           # subshell writes $codex_rc_file a BEAT LATER — after the shared
+           # launcher's internal node wait returns — so a successful run landing in
            # that window must not be discarded as "no recorded status"
            # (codex-1, CR round 2, HIMMEL-1407: this was a real race, not a
            # theoretical one). Poll briefly for the rc file to appear before
@@ -401,48 +540,26 @@ Steps:
                                echo "codex adversarial pass retry skipped — companion path could not be re-resolved in this fence — recording unavailable" >&2
                                codex_findings=""; codex_avail_status="unavailable"
                            else
+                               codex_retry_pid_file="${codex_pid_file}.retry"
+                               codex_retry_identity_file="${codex_retry_pid_file}.identity"
+                               codex_retry_survivors_file="${codex_retry_pid_file}.survivors"
+                               codex_retry_cleanup_rc_file="${codex_retry_pid_file}.cleanup-rc"
+                               rm -f "$codex_retry_pid_file" "$codex_retry_identity_file" "$codex_retry_survivors_file" "$codex_retry_cleanup_rc_file"
                                : > "$codex_out"; : > "$codex_err_file"
-                               if command -v timeout >/dev/null 2>&1; then
-                                   # -k grace (CR round 2 [codex-adv-2], HIMMEL-1420):
-                                   # without it a SIGTERM-ignoring companion
-                                   # outlives the advertised bound and its
-                                   # child test-suite processes can survive
-                                   # node's own exit — same
-                                   # CRITIC_KILL_GRACE_SECS pattern
-                                   # critic-panel.sh already uses for every
-                                   # member timeout.
-                                   # $codex_timeout: raised 4x across CR rounds as
-                                   # "undefined here" and disproved each time —
-                                   # normalized once at the TOP of THIS SAME bash
-                                   # fence (~line 325, the `codex_timeout=${CRITIC_TIMEOUT_SECS:-240}` /
-                                   # `case ... esac` / `[ "$codex_timeout" -gt 0 ]`
-                                   # block), not the step-3 kickoff fence's. Fence
-                                   # delimiters (```bash … ```) prove this whole
-                                   # block from that normalization down through
-                                   # this retry is ONE continuous fence — if you're
-                                   # about to re-raise this, re-check the fence
-                                   # boundaries first, not just the line numbers.
-                                   timeout -k "${CRITIC_KILL_GRACE_SECS:-5}s" "${codex_timeout}s" node "$companion" adversarial-review --wait --base "$db" >"$codex_out" 2>"$codex_err_file"
-                                   codex_retry_rc=$?
+                               # Shared launcher owns the real node pid, starts the
+                               # Layer B client-lease heartbeat, and preserves the
+                               # existing bounded tree-kill behavior without relying
+                               # on an external timeout binary.
+                               bash scripts/cr/run-codex-adversarial.sh "$companion" "$db" "$codex_out" "$codex_err_file" "$codex_retry_pid_file" "$codex_timeout" "$codex_retry_cleanup_rc_file"
+                               codex_retry_rc=$?
+                               codex_retry_cleanup_rc=""
+                               if [ -s "$codex_retry_cleanup_rc_file" ]; then
+                                   codex_retry_cleanup_rc=$(cat "$codex_retry_cleanup_rc_file")
+                               fi
+                               if [ "$codex_retry_cleanup_rc" = "0" ]; then
+                                   rm -f "$codex_retry_pid_file" "$codex_retry_identity_file" "$codex_retry_survivors_file" "$codex_retry_cleanup_rc_file"
                                else
-                                   node "$companion" adversarial-review --wait --base "$db" >"$codex_out" 2>"$codex_err_file" &
-                                   codex_retry_pid=$!
-                                   codex_retry_waited=0
-                                   while kill -0 "$codex_retry_pid" 2>/dev/null; do
-                                       [ "$codex_retry_waited" -ge "$codex_timeout" ] && break
-                                       sleep 5
-                                       codex_retry_waited=$((codex_retry_waited + 5))
-                                   done
-                                   if kill -0 "$codex_retry_pid" 2>/dev/null; then
-                                       if command -v taskkill >/dev/null 2>&1; then
-                                           taskkill //PID "$codex_retry_pid" //T //F 2>/dev/null
-                                       fi
-                                       kill "$codex_retry_pid" 2>/dev/null; sleep 1; kill -9 "$codex_retry_pid" 2>/dev/null
-                                       codex_retry_rc=124
-                                   else
-                                       wait "$codex_retry_pid"
-                                       codex_retry_rc=$?
-                                   fi
+                                   echo "codex adversarial pass retry cleanup unverified (rc=${codex_retry_cleanup_rc:-missing}) — preserving recovery sidecars: $codex_retry_pid_file, $codex_retry_identity_file, and $codex_retry_survivors_file" >&2
                                fi
                                cac_retry_check=$(bash scripts/cr/codex-adv-completion-check.sh "$codex_retry_rc" "$codex_out" "$codex_err_file" 2>/dev/null)
                                if [ $? -eq 0 ]; then
@@ -469,10 +586,27 @@ Steps:
                codex_findings=""; codex_rc=1; codex_avail_status="unavailable"
            fi
        fi
+       # The launcher publishes cleanup independently because a nonzero companion
+       # rc remains the process exit status even when cleanup also failed.
+       harvest_cleanup_rc=""
+       if [ ! -s "$codex_rc_file" ]; then
+           harvest_cleanup_unverified=1
+           echo "codex adversarial pass launcher status missing — preserving recovery sidecars until both launcher and cleanup status are verified: $codex_pid_file and $codex_identity_file" >&2
+       else
+           if [ -s "$codex_cleanup_rc_file" ]; then
+               harvest_cleanup_rc=$(cat "$codex_cleanup_rc_file")
+           fi
+           if [ "$harvest_cleanup_rc" != "0" ]; then
+               harvest_cleanup_unverified=1
+               echo "codex adversarial pass cleanup unverified (rc=${harvest_cleanup_rc:-missing}) — preserving recovery sidecars: $codex_pid_file, $codex_identity_file, and $codex_survivors_file" >&2
+           fi
+       fi
        # $codex_err_file is intentionally NOT removed here (glm-3, CR round 2)
-       # — companion stderr stays on disk for debugging; only pid/rc, whose
-       # job is done once harvested, are cleaned up.
-       rm -f "$codex_pid_file" "$codex_rc_file"
+       # — companion stderr stays on disk for debugging. Jobs that may still be
+       # live keep their recovery handles; completed/terminated jobs are cleaned.
+       if [ "$harvest_live_unreaped" -eq 0 ] && [ "$harvest_survivors" -eq 0 ] && [ "$harvest_cleanup_unverified" -eq 0 ]; then
+           rm -f "$codex_pid_file" "$codex_identity_file" "$codex_survivors_file" "$codex_rc_file" "$codex_cleanup_rc_file"
+       fi
    fi
    # Surface findings (if any) so they flow into the step-3 adjudication prepend.
    [ -n "$codex_findings" ] && printf '%s\n' "$codex_findings"

--- a/scripts/check-ci.sh
+++ b/scripts/check-ci.sh
@@ -476,6 +476,23 @@ review_state_gate
 #
 # Runs AFTER the watch + settle so the normal registration race resolves itself
 # in the window that already exists; only a signal still missing by then fails.
+_cr_panel_carries_absent_signal() {
+    local absent_signal="$1"
+    if _cr_panel_evidence=$(cr_ledger_carries_gate "$head0"); then
+        case "$absent_signal" in
+            rate-limited)
+                # Preserve the HIMMEL-1465 audit line byte-for-byte.
+                echo "check-ci: CodeRabbit is rate-limited on head $head0 of PR #$num; the critic panel carries the gate ($_cr_panel_evidence) — not failing the verdict on the App (HIMMEL-1465)." ;;
+            review-object)
+                echo "check-ci: review object absent at head $head0 of PR #$num; threads resolved; panel carries — HIMMEL-1502/1506 ($_cr_panel_evidence)." ;;
+            *)
+                echo "check-ci: CodeRabbit $absent_signal on head $head0 of PR #$num; the critic panel carries the gate ($_cr_panel_evidence) — not failing the verdict on the absent App signal (HIMMEL-1506)." ;;
+        esac
+        return 0
+    fi
+    return 1
+}
+
 cr_signal_gate() {
     # Availability gate (HIMMEL-1125): no CodeRabbit App on this repo -> no-op.
     # Silent on purpose — an adopter without CodeRabbit must not notice that a
@@ -517,35 +534,33 @@ cr_signal_gate() {
             # had looked at (reproduced on PR #1429, 2026-07-27). Actionable
             # rather than merely closed: the operator's next move is one comment.
             #
-            # HIMMEL-1465: cr_signal_state collapses EVERY decline wording to
-            # `skipped`, but only the RATE-LIMITED one is panel-carriable. Read
-            # the description and, when (and ONLY when) it is the rate-limit
-            # shape, consult the CR ledger the same way clear-cr-marker.sh does:
-            # a CLEAN critic panel (>=1 `avail ... ok`, no blocking finding) at
-            # THIS head carries the gate (operator standing rule), so the
-            # rate-limited App does not fail the verdict. Any other skip wording
-            # — auto-reviews-disabled, or a decline CodeRabbit invents later —
-            # keeps failing closed exactly as before. Evidence-gated and
-            # fail-closed: no clean panel => current exit-2 behaviour stands.
-            local rl_desc rl_low rl_panel
-            if rl_desc=$(cr_signal_description "$owner" "$repo" "$head0"); then
-                rl_low=$(printf '%s' "$rl_desc" | tr '[:upper:]' '[:lower:]')
+            # HIMMEL-1506: every skip-classified description means the App's
+            # review signal is absent. A CLEAN critic panel (>=1 `avail ... ok`,
+            # no blocking finding) at THIS exact head carries each shape; absent
+            # or dirty evidence keeps the existing fail-closed verdict/message.
+            local skip_desc skip_low
+            if skip_desc=$(cr_signal_description "$owner" "$repo" "$head0"); then
+                skip_low=$(printf '%s' "$skip_desc" | tr '[:upper:]' '[:lower:]')
             else
+                if _cr_panel_carries_absent_signal "description is unreadable"; then return 0; fi
                 echo "check-ci: CodeRabbit SKIPPED the review on head $head0 of PR #$num and its description could not be read to tell rate-limiting from a disabled review — cannot evaluate the panel-carried allowance; re-run. If this repo has no CodeRabbit, set CR_PROFILE=none." >&2
                 exit 2
             fi
             # Rate-limit vocabulary (mirrors cr-signal.sh's _CRS_SKIP_RE
             # `rate.?limit` arm): "rate limit" / "rate-limit" / "ratelimit".
-            case "$rl_low" in
+            case "$skip_low" in
                 *rate?limit*|*ratelimit*)
-                    if rl_panel=$(cr_ledger_carries_gate "$head0"); then
-                        echo "check-ci: CodeRabbit is rate-limited on head $head0 of PR #$num; the critic panel carries the gate ($rl_panel) — not failing the verdict on the App (HIMMEL-1465)."
-                        return 0
-                    fi
-                    echo "check-ci: CodeRabbit is rate-limited on head $head0 of PR #$num and the critic panel did NOT carry the gate at this head (ledger: $rl_panel) — a rate-limited App with no clean panel is not a green one. Wait for the App's limit to reset, or run /pr-check on this HEAD so a panel reviews it. Bypass: CR_APP=0 (or CR_PROFILE=none)." >&2
+                    if _cr_panel_carries_absent_signal "rate-limited"; then return 0; fi
+                    echo "check-ci: CodeRabbit is rate-limited on head $head0 of PR #$num and the critic panel did NOT carry the gate at this head (ledger: $_cr_panel_evidence) — a rate-limited App with no clean panel is not a green one. Wait for the App's limit to reset, or run /pr-check on this HEAD so a panel reviews it. Bypass: CR_APP=0 (or CR_PROFILE=none)." >&2
                     exit 2 ;;
+                '')
+                    if _cr_panel_carries_absent_signal "description is absent"; then return 0; fi ;;
+                *automatic*reviews*disabled*)
+                    if _cr_panel_carries_absent_signal "reports automatic reviews are disabled"; then return 0; fi ;;
+                *)
+                    if _cr_panel_carries_absent_signal "posted skip-classified wording"; then return 0; fi ;;
             esac
-            echo "check-ci: CodeRabbit SKIPPED the review on head $head0 of PR #$num — it posted state=success, but its description does not say the review completed. A DECLINED review is not a clean one. Known causes: automatic reviews are disabled on this repo (trigger one with a '@coderabbitai review' comment, wait for it to conclude, then re-run), or CodeRabbit is RATE LIMITED (HIMMEL-1354 — wait for the limit to reset; do NOT re-trigger in a loop, and note the CLI lane 'bash scripts/cr/coderabbit-review.sh --branch <b> --base main' is a separate, independently-limited path). If CodeRabbit has simply renamed its success wording, widen the allow-list for one run with CR_OK_DESC_RE='^(review completed|no review changes requested|<new wording>)\$' — CR_OK_DESC_RE REPLACES the default, so carry BOTH default alternatives or you narrow it instead of widening it, and KEEP the ^(...)\$ anchors or a decline description merely containing one of these phrases (e.g. 'No review completed') passes as clean again (HIMMEL-1354 R2). If this repo has no CodeRabbit, set CR_PROFILE=none." >&2
+            echo "check-ci: CodeRabbit SKIPPED the review on head $head0 of PR #$num — it posted state=success, but its description does not say the review completed. A DECLINED review is not a clean one. Known causes: automatic reviews are disabled on this repo (trigger one with a '@coderabbitai review' comment, wait for it to conclude, then re-run), or CodeRabbit is RATE LIMITED (HIMMEL-1354 — wait for the limit to reset; do NOT re-trigger in a loop, and note the CLI lane 'bash scripts/cr/coderabbit-review.sh --branch <b> --base main' is a separate, independently-limited path). A clean exact-head critic panel carries every skip-classified state (HIMMEL-1506) — run /pr-check on this HEAD if no panel evidence exists yet. If CodeRabbit merely RENAMED its success wording (an OK review misclassified as a skip), widen the OK allow-list for one run with CR_OK_DESC_RE — keep both default alternatives and the ^(...)\$ anchors (HIMMEL-1354 R2); the knob does NOT apply to genuine skip wordings. If this repo has no CodeRabbit, set CR_PROFILE=none." >&2
             exit 2 ;;
         *)
             echo "check-ci: unrecognized CodeRabbit state '$state' on head $head0 — cannot evaluate the gate; re-run" >&2
@@ -685,6 +700,10 @@ cr_body_gate() {
     # full review. Default observers stay read-only and return rc 4; --escalate
     # opts into posting the command once and boundedly re-reading.
     if [ "$_cbg_prior_outside" -gt 0 ] && [ "$_cbg_head_reviews" -eq 0 ]; then
+        # review_state_gate already proved the thread set resolved immediately
+        # before this body read. Exact-head panel evidence may therefore carry
+        # this otherwise-only missing review-object signal (HIMMEL-1502/1506).
+        if [ "$_cbg_outside" -eq 0 ] && _cr_panel_carries_absent_signal "review-object"; then return 0; fi
         if [ "$ESCALATE" -eq 0 ]; then
             echo "check-ci: ${ctx}PR #$num had unresolved outside-diff findings at a prior head, but CodeRabbit's incremental pass posted no review object at current head $head0 — request @coderabbitai full review, then re-run" >&2
             exit 4

--- a/scripts/ci/run-shell-tests.sh
+++ b/scripts/ci/run-shell-tests.sh
@@ -151,8 +151,10 @@ gemini/test-invoke.sh                # needs the gemini-cli binary
 cr/test-hermes-critic.sh             # integration: needs the hermes runtime (no keys on CI) — VM e2e covers it
 handover/test-hop.sh                 # integration: needs a live 'claude' (--print relaunch) — VM e2e covers it
 handover/test-resume-armed.sh        # integration: needs the bun runtime + armed-resume flow — VM e2e covers it
+handover/test-arm-resume.sh          # timing-heavy Windows scheduler lifecycle suite exceeds the 180s hermetic runner cap; runnable individually, no VM e2e coverage
 luna/test-pipeline-cadence.sh        # integration: drives a live 'claude' (--settings fragment) — VM e2e covers it
 test-plugin-test.sh                  # integration: self-bootstraps a plugin's deps over npm/network — VM e2e covers it
+test-adopt.sh                        # timing-heavy full adoption matrix exceeds the 180s hermetic runner cap on Windows; runnable individually, no VM e2e coverage
 "
 
 # extra_skips accumulates paths added via --skip-extra flags.

--- a/scripts/ci/test-suite-concurrency.sh
+++ b/scripts/ci/test-suite-concurrency.sh
@@ -50,7 +50,7 @@ this_host() {
   printf '%s' "${HOSTNAME:-${COMPUTERNAME:-$(hostname 2>/dev/null || echo unknown)}}"
 }
 
-WORK=$(mktemp -d)
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/himmel-suite-concurrency.XXXXXX")
 trap 'rm -rf "$WORK"' EXIT
 
 # Each case gets a fresh sandbox + a lock path inside it.
@@ -547,6 +547,222 @@ if [ "$rc4" -eq 0 ]; then
   pass "SUITE_LOCK=0 -> runs despite a held lock"
 else
   fail "SUITE_LOCK=0 -> expected rc 0 got $rc4; output: $out4"
+fi
+
+# --------------------------------------------------------------------------
+# Case 4b -- an explicitly EMPTY expected identity refuses to signal.
+#
+# The timeout harvest can have a pid but no readable identity sidecar. That is
+# not enough authority to signal a possibly-recycled pid: rc 2 means the helper
+# sent neither its POSIX group/bare-pid signal nor the Windows fallback.
+# --------------------------------------------------------------------------
+echo "== Case 4b: empty identity refuses to signal =="
+empty_identity_result=$(
+  # shellcheck source=scripts/lib/proc-tree.sh
+  # shellcheck disable=SC1091  # runtime path; library is checked separately
+  . "$CI_DIR/../lib/proc-tree.sh"
+  signal_calls=0
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  kill() { signal_calls=$((signal_calls + 1)); }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  taskkill() { signal_calls=$((signal_calls + 1)); }
+  terminate_rc=0
+  proc_tree_terminate 4242 0 "" || terminate_rc=$?
+  printf '%s:%s\n' "$terminate_rc" "$signal_calls"
+)
+if [ "$empty_identity_result" = "2:0" ]; then
+  pass "empty identity -> rc 2, no signal sent"
+else
+  fail "empty identity -> expected rc 2 and zero signals, got $empty_identity_result"
+fi
+
+# --------------------------------------------------------------------------
+# Case 4c -- a guarded leader recycled during TERM grace is never targeted.
+#
+# The first identity check authorizes TERM for the original group. Before KILL,
+# the leader identity has changed: cleanup returns unverified without sending
+# KILL to either the recycled group id or the recycled bare pid.
+# --------------------------------------------------------------------------
+echo "== Case 4c: recycled guarded leader blocks KILL and bare-pid fallback =="
+recycled_identity_result=$(
+  # shellcheck source=scripts/lib/proc-tree.sh
+  # shellcheck disable=SC1091  # runtime path; library is checked separately
+  . "$CI_DIR/../lib/proc-tree.sh"
+  signal_log=''
+  identity_checks=0
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  proc_tree_process_identity_matches() {
+    identity_checks=$((identity_checks + 1))
+    [ "$identity_checks" -eq 1 ]
+  }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  proc_tree_group_alive() { return 0; }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  kill() { signal_log="${signal_log}${1}:${2},"; return 0; }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  sleep() { :; }
+  terminate_rc=0
+  proc_tree_terminate 4242 0 test-identity || terminate_rc=$?
+  printf '%s:%s\n' "$terminate_rc" "$signal_log"
+)
+if [ "$recycled_identity_result" = "2:-TERM:-4242," ]; then
+  pass "recycled guarded leader -> TERM only, rc 2, no KILL or bare-pid signal"
+else
+  fail "recycled guarded leader -> expected only group TERM then rc 2, got $recycled_identity_result"
+fi
+
+# A failed guarded group signal must not retry against the bare leader pid.
+guarded_fallback_result=$(
+  # shellcheck source=scripts/lib/proc-tree.sh
+  # shellcheck disable=SC1091  # runtime path; library is checked separately
+  . "$CI_DIR/../lib/proc-tree.sh"
+  signal_log=''
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  proc_tree_process_identity_matches() { return 0; }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  proc_tree_group_alive() { return 0; }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  kill() { signal_log="${signal_log}${1}:${2},"; return 1; }
+  terminate_rc=0
+  proc_tree_terminate 4242 0 test-identity || terminate_rc=$?
+  printf '%s:%s\n' "$terminate_rc" "$signal_log"
+)
+if [ "$guarded_fallback_result" = "2:-TERM:-4242," ]; then
+  pass "guarded group signal failure -> rc 2 without bare-pid fallback"
+else
+  fail "guarded group signal failure -> expected no bare-pid fallback, got $guarded_fallback_result"
+fi
+
+# A leader that exits during the grace does not revoke authority over member
+# identities captured before TERM. Escalate the still-matching child by pid,
+# never the now-unowned numeric group id.
+leader_exit_survivor_result=$(
+  # shellcheck source=scripts/lib/proc-tree.sh
+  # shellcheck disable=SC1091  # runtime path; library is checked separately
+  . "$CI_DIR/../lib/proc-tree.sh"
+  signal_log=''
+  leader_checks=0
+  alive_checks=0
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  proc_tree_group_members() { printf '%s\n' 4242 500; }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  proc_tree_process_identity() { printf 'identity-%s\n' "$1"; }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  proc_tree_process_identity_matches() {
+    if [ "$1" = "4242" ]; then
+      leader_checks=$((leader_checks + 1))
+      [ "$leader_checks" -eq 1 ]
+    else
+      [ "$1" = "500" ] && [ "$2" = "identity-500" ]
+    fi
+  }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  proc_tree_group_alive() {
+    alive_checks=$((alive_checks + 1))
+    [ "$alive_checks" -eq 1 ]
+  }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  kill() { signal_log="${signal_log}${1}:${2},"; return 0; }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_terminate
+  sleep() { :; }
+  terminate_rc=0
+  proc_tree_terminate 4242 0 identity-4242 || terminate_rc=$?
+  printf '%s:%s\n' "$terminate_rc" "$signal_log"
+)
+if [ "$leader_exit_survivor_result" = "0:-TERM:-4242,-KILL:500," ]; then
+  pass "guarded leader exit -> KILL only the identity-verified survivor, rc 0"
+else
+  fail "guarded leader exit -> expected group TERM then verified survivor KILL, got $leader_exit_survivor_result"
+fi
+
+# --------------------------------------------------------------------------
+# Case 4d -- leader-exit cleanup revalidates every observed member.
+#
+# The numeric group id has no surviving ownership anchor after leader exit.
+# Snapshot member identities, signal only identity-matching pids, and return rc 2
+# rather than group-KILLing or taskkilling a member whose identity changed.
+# --------------------------------------------------------------------------
+echo "== Case 4d: leader-exit group sweep verifies each member identity =="
+group_member_identity_result=$(
+  # shellcheck source=scripts/lib/proc-tree.sh
+  # shellcheck disable=SC1091  # runtime path; library is checked separately
+  . "$CI_DIR/../lib/proc-tree.sh"
+  signal_log=''
+  identity_checks=0
+  taskkill_calls=0
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_group_terminate
+  proc_tree_group_alive() { return 0; }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_group_terminate
+  proc_tree_group_members() { printf '%s\n' 500 501; }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_group_terminate
+  proc_tree_process_identity() { printf 'identity-%s\n' "$1"; }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_group_terminate
+  proc_tree_process_identity_matches() {
+    identity_checks=$((identity_checks + 1))
+    [ "$1" = "500" ]
+  }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_group_terminate
+  kill() { signal_log="${signal_log}${1}:${2},"; return 0; }
+  # shellcheck disable=SC2317,SC2329  # invoked indirectly by proc_tree_group_terminate
+  taskkill() { taskkill_calls=$((taskkill_calls + 1)); return 0; }
+  # shellcheck disable=SC2329  # invoked indirectly by proc_tree_group_terminate
+  sleep() { :; }
+  terminate_rc=0
+  proc_tree_group_terminate 4242 0 || terminate_rc=$?
+  printf '%s:%s:%s:%s\n' "$terminate_rc" "$identity_checks" "$signal_log" "$taskkill_calls"
+)
+if [ "$group_member_identity_result" = "2:4:-TERM:500,-KILL:500,:0" ]; then
+  pass "leader-exit sweep -> per-member TERM/KILL validation, rc 2, no blind fallback"
+else
+  fail "leader-exit sweep -> expected only verified pid signals and rc 2, got $group_member_identity_result"
+fi
+
+# --------------------------------------------------------------------------
+# Case 4e -- a guarded leader that exits on TERM must not strand an ignoring
+# descendant. The guarded helper snapshots member identities before TERM, then
+# escalates only the still-matching survivor after the leader identity is gone.
+# --------------------------------------------------------------------------
+echo "== Case 4e: guarded leader exit escalates verified survivors =="
+sb4e=$(new_sandbox)
+cat > "$sb4e/leader.sh" <<'SHEOF'
+#!/usr/bin/env bash
+node -e 'process.on("SIGTERM", () => {}); setInterval(() => {}, 1000)' &
+printf '%s\n' "$!" > "${HIMMEL_R13_CHILD_PID_FILE:?}"
+trap 'exit 0' TERM
+while :; do sleep 1; done
+SHEOF
+# shellcheck source=scripts/lib/proc-tree.sh
+# shellcheck disable=SC1091
+. "$CI_DIR/../lib/proc-tree.sh"
+set -m
+HIMMEL_R13_CHILD_PID_FILE="$sb4e/child.pid" bash "$sb4e/leader.sh" &
+leader4e=$!
+set +m
+waited4e=0
+while [ ! -s "$sb4e/child.pid" ] && kill -0 "$leader4e" 2>/dev/null && [ "$waited4e" -lt 50 ]; do
+  sleep 0.1
+  waited4e=$((waited4e + 1))
+done
+leader_identity4e=$(proc_tree_process_identity "$leader4e") || leader_identity4e=''
+terminate4e_rc=0
+proc_tree_terminate "$leader4e" 1 "$leader_identity4e" || terminate4e_rc=$?
+wait "$leader4e" 2>/dev/null || true
+child4e=$(cat "$sb4e/child.pid" 2>/dev/null || echo '')
+if [ "$terminate4e_rc" -eq 0 ]; then
+  pass "leader exits during TERM grace -> verified survivor cleanup returns rc 0"
+else
+  fail "leader exits during TERM grace -> expected cleanup rc 0 got $terminate4e_rc"
+fi
+if [ -n "$child4e" ] && ! kill -0 "$child4e" 2>/dev/null; then
+  pass "leader exits during TERM grace -> TERM-ignoring child is gone"
+else
+  fail "leader exits during TERM grace -> TERM-ignoring child survived (pid=${child4e:-missing})"
+  if [ -n "$child4e" ]; then
+    kill -9 "$child4e" 2>/dev/null || true
+    if command -v taskkill >/dev/null 2>&1; then
+      MSYS_NO_PATHCONV=1 taskkill /PID "$child4e" /T /F >/dev/null 2>&1 || true
+    fi
+  fi
 fi
 
 # --------------------------------------------------------------------------

--- a/scripts/cleanup/sweep-codex-orphans.ps1
+++ b/scripts/cleanup/sweep-codex-orphans.ps1
@@ -10,10 +10,12 @@
 # ~3.8 GB) were found and hand-killed on this Windows box. This tool is the
 # reusable sweep.
 #
-# THE TEST (client-side pipe-token liveness - the VALIDATED signal):
-#   A broker tree is LIVE  iff  any process OUTSIDE every broker tree has a
-#   command line that references the same `cxc-<token>-codex-app-server` pipe
-#   (that is the client still holding it). Otherwise the tree is an ORPHAN.
+# THE TEST (client-side liveness - validated pipe token + pr-check lease):
+#   A broker tree is LIVE iff either (a) a process OUTSIDE every broker tree has
+#   a command line referencing the same `cxc-<token>-codex-app-server` pipe, or
+#   (b) its TEMP directory has a fresh pr-check lease whose pid + StartTime
+#   identifies a live outside-tree process and whose cwd matches the broker.
+#   An unattributed outside-tree adversarial render defers the whole -Kill pass.
 #
 #   Two signals are DELIBERATELY NOT used, because they are documented false
 #   signals on this fleet (HIMMEL-718):
@@ -33,10 +35,11 @@
 #   1. Enumerate node.exe processes whose CommandLine matches
 #      `app-server-broker.mjs serve --endpoint pipe:\\.\pipe\cxc-<token>-codex-app-server`;
 #      capture the cxc token per broker.
-#   2. Build the union of every broker tree, then collect the set of tokens
-#      referenced by any process OUTSIDE that union. Excluding all broker roots
-#      and descendants prevents their own pipe arguments from self-marking live.
-#      A broker whose token is NOT in that set is an ORPHAN.
+#   2. Build the union of every broker tree, then collect outside-tree token
+#      references plus fresh per-tree client leases. Excluding all broker roots
+#      and descendants prevents their own arguments from self-marking live. An
+#      outside adversarial render not covered by a valid lease defers -Kill.
+#      A broker whose token has neither signal is an ORPHAN.
 #   3. For each orphan broker, walk descendants via CIM Win32_Process
 #      ParentProcessId (child map built once) to collect the full tree
 #      (broker + all descendants).
@@ -56,17 +59,51 @@
 #   Allow set (name-verified kill): node, cmd, bash, codex, conhost, pwsh,
 #   python, bun, uv, uvx, node_repl, mcp-obsidian, qmd, tokensave.
 #
+# RENDER-LEASE REGISTRY (HIMMEL-1509 - replaces the retired :00 launch-window
+# rule with dynamic coordination): before ANY kill, the sweep takes the
+# registry lock and reads the per-branch render leases that
+# run-codex-adversarial.sh acquires (see scripts/lib/render-lease.sh). A LIVE
+# lease (fresh heartbeat, or a leader pid whose snapshot creation time matches
+# the recorded win:<pid>:<startticks> identity) makes every broker tree in its
+# worktree - and every token its heartbeat recorded - UNTOUCHABLE regardless
+# of command-line visibility. An UNVERIFIABLE lease defers its trees
+# (fail-closed); only a confirmed-STALE lease leaves its trees as ordinary
+# candidates, still subject to every name/token/identity gate below. An
+# unreadable registry or unavailable lock refuses the kill pass outright.
+#
+# KILL-LEDGER (HIMMEL-1509): verified orphan pids the -Kill pass could NOT
+# stop (e.g. Stop-Process refusals such as the HIMMEL-1508 Session-0 gap) are
+# appended to an append-only JSONL ledger next to the registry. Later sweep
+# runs consume resolved entries; `-FromLedger` is the sanctioned orchestrator
+# consume path - it kills ONLY entries whose live process still matches the
+# recorded creation-time identity and the name allow set, and skips anything
+# a live/unverifiable lease protects.
+#
 # USAGE:
 #   pwsh -NoProfile -File scripts/cleanup/sweep-codex-orphans.ps1           # dry run (default): report orphan trees
-#   pwsh -NoProfile -File scripts/cleanup/sweep-codex-orphans.ps1 -Kill     # name-verified stop + stale broker.pid cleanup
+#   pwsh -NoProfile -File scripts/cleanup/sweep-codex-orphans.ps1 -Kill     # lease-validated name-verified stop + stale broker.pid cleanup
+#   pwsh -NoProfile -File scripts/cleanup/sweep-codex-orphans.ps1 -FromLedger        # list unconsumed kill-ledger entries (dry run)
+#   pwsh -NoProfile -File scripts/cleanup/sweep-codex-orphans.ps1 -FromLedger -Kill  # identity-verified ledger consume (orchestrator path)
+# -RegistryPath / -LedgerPath override the render-lease registry and ledger
+# locations (default: $env:RENDER_LEASE_DIR or
+# $env:USERPROFILE\.claude\handover\bridge\render-leases, ledger
+# kill-ledger.jsonl inside it).
 # Exit codes: 0 = nothing to sweep OR sweep done (prints count + estimated MB);
-#             1 = usage / enumeration error.
+#             1 = usage / enumeration error, or the render-lease registry
+#                 refused the kill pass (lock unavailable / unreadable).
 # Non-Windows: exits 0 with a message (the broker leak is a Windows-observed
 # pattern; the pure functions still dot-source-load for cross-platform tests).
 
-[CmdletBinding()]
+# PositionalBinding=$false (HIMMEL-1509): the string params below must never
+# swallow a stray positional argument - malformed argv keeps failing fast.
+[CmdletBinding(PositionalBinding = $false)]
 param(
   [switch]$Kill,
+  # HIMMEL-1509 orchestrator consume path: act on the kill-ledger instead of
+  # classifying; -Kill upgrades it from listing to identity-verified stopping.
+  [switch]$FromLedger,
+  [string]$RegistryPath,
+  [string]$LedgerPath,
   # Dot-source seam for the hermetic test: define the pure functions, then
   # return WITHOUT scanning the live process table or touching the OS.
   [switch]$AsLibrary
@@ -122,6 +159,35 @@ function Test-IsPlausibleCodexAppServerClient {
   return @('claude.exe','ChatGPT.exe','node.exe','bun.exe') -contains [string]$Proc.Name
 }
 
+# Render shape visible even when the companion argv does not carry its cxc token.
+# Any such process outside every broker tree is fail-safe evidence that attribution
+# may be incomplete, so -Kill defers the whole pass (Layer A, HIMMEL-1474).
+function Test-IsCodexAdversarialRender {
+  param([Parameter(Mandatory)]$Proc)
+  if (-not $Proc.Name -or $Proc.Name -ine 'node.exe') { return $false }
+  $cl = [string]$Proc.CommandLine
+  return ($cl -match 'codex-companion\.mjs' -and $cl -match '(?:^|\s)adversarial-review(?:\s|$)' -and $cl -match '(?:^|\s)--wait(?:\s|$)')
+}
+
+function Get-OutsideCodexAdversarialRenderPids {
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [AllowNull()]$BrokerTreePids = $null
+  )
+  if ($null -eq $BrokerTreePids) { $BrokerTreePids = Get-CodexBrokerTreePids -Procs $Procs }
+  $out = New-Object System.Collections.ArrayList
+  foreach ($p in $Procs) {
+    if ($BrokerTreePids.Contains([int]$p.ProcessId)) { continue }
+    if (Test-IsCodexAdversarialRender -Proc $p) { [void]$out.Add([int]$p.ProcessId) }
+  }
+  return , ($out.ToArray())
+}
+
+function Test-ShouldDeferCodexKill {
+  param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$OutsideRenderPids)
+  return ($OutsideRenderPids.Count -gt 0)
+}
+
 # Best-effort cwd LABEL for the table (purely cosmetic, never gates a decision).
 # Prefers an explicit --cwd, else derives the broker.mjs script directory.
 function Get-BrokerCwd {
@@ -135,6 +201,34 @@ function Get-BrokerCwd {
     try { return [System.IO.Path]::GetDirectoryName($Matches[1]) } catch { return $Matches[1] }
   }
   return '(unknown)'
+}
+
+# Lease attribution is deliberately stricter than the cosmetic table label:
+# only an explicit broker --cwd can bind a pr-check client lease to that tree.
+function Get-BrokerLeaseCwd {
+  param([string]$CommandLine)
+  if (-not $CommandLine) { return $null }
+  if ($CommandLine -match '(?:^|\s)--cwd[ =](?:"([^"]+)"|(\S+))') {
+    if ($Matches[1]) { return $Matches[1] }
+    return $Matches[2]
+  }
+  return $null
+}
+
+function Test-PathEquivalent {
+  param([AllowNull()][string]$Left, [AllowNull()][string]$Right)
+  if (-not $Left -or -not $Right) { return $false }
+  try {
+    $leftFull = [System.IO.Path]::GetFullPath($Left).TrimEnd([char[]]@('\','/'))
+    $rightFull = [System.IO.Path]::GetFullPath($Right).TrimEnd([char[]]@('\','/'))
+    return [string]::Equals($leftFull, $rightFull, [System.StringComparison]::OrdinalIgnoreCase)
+  } catch { return $false }
+}
+
+function Test-PathResolvable {
+  param([AllowNull()][string]$Path)
+  if (-not $Path) { return $false }
+  try { [void][System.IO.Path]::GetFullPath($Path); return $true } catch { return $false }
 }
 
 # Tokens referenced by at least one visible process OUTSIDE every broker tree.
@@ -154,6 +248,146 @@ function Get-LiveClientTokens {
   return , ([string[]]@($set))
 }
 
+# A lease is valid only while all identity signals agree: fresh heartbeat, an
+# explicit cwd matching the broker, and a live outside-tree pid whose snapshot
+# CreationDate matches the recorded StartTime. Missing identity data fails
+# closed (ignore the lease); a lease may only subtract from the kill set.
+function Test-LeaseProcessStartMatches {
+  param($SnapshotCreation, $LeaseStart)
+  if ($null -eq $SnapshotCreation -or $null -eq $LeaseStart) { return $false }
+  try {
+    $snapshotUtc = ([datetime]$SnapshotCreation).ToUniversalTime()
+    $leaseUtc = ([datetimeoffset]::Parse([string]$LeaseStart)).UtcDateTime
+    return ([math]::Abs(($snapshotUtc - $leaseUtc).TotalSeconds) -le 2)
+  } catch { return $false }
+}
+
+function Get-LiveClientLeaseEvidence {
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [Parameter(Mandatory)]$BrokerTreePids,
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$ClientLeases,
+    [datetime]$NowUtc = [datetime]::UtcNow,
+    [int]$LeaseTtlMinutes = 10
+  )
+  $out = New-Object System.Collections.ArrayList
+  $seen = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
+  if ($LeaseTtlMinutes -le 0) { return $out.ToArray() }
+
+  $byPid = @{}
+  foreach ($p in $Procs) { $byPid[[string]$p.ProcessId] = $p }
+  $brokersByToken = @{}
+  foreach ($p in $Procs) {
+    if (-not (Test-IsCodexAppServerBroker -Proc $p)) { continue }
+    $token = Get-CxcToken -CommandLine ([string]$p.CommandLine)
+    $cwd = Get-BrokerLeaseCwd -CommandLine ([string]$p.CommandLine)
+    if ($token -and $cwd) { $brokersByToken[[string]$token] = [string]$cwd }
+  }
+
+  foreach ($lease in $ClientLeases) {
+    $tokenProp = $lease.PSObject.Properties['Token']
+    $pidProp = $lease.PSObject.Properties['ClientPid']
+    $startProp = $lease.PSObject.Properties['ClientStartTime']
+    $cwdProp = $lease.PSObject.Properties['Cwd']
+    $heartbeatProp = $lease.PSObject.Properties['Heartbeat']
+    if (-not $tokenProp -or -not $pidProp -or -not $startProp -or -not $cwdProp -or -not $heartbeatProp) { continue }
+
+    $token = [string]$tokenProp.Value
+    if (-not $brokersByToken.ContainsKey($token)) { continue }
+    if (-not (Test-PathEquivalent -Left ([string]$cwdProp.Value) -Right ([string]$brokersByToken[$token]))) { continue }
+
+    $heartbeatUtc = $null
+    try { $heartbeatUtc = ([datetimeoffset]::Parse([string]$heartbeatProp.Value)).UtcDateTime } catch { continue }
+    $age = ($NowUtc.ToUniversalTime() - $heartbeatUtc).TotalMinutes
+    if ($age -lt 0 -or $age -gt $LeaseTtlMinutes) { continue }
+
+    $clientPid = 0
+    try { $clientPid = [int]$pidProp.Value } catch { continue }
+    if ($clientPid -le 0 -or $BrokerTreePids.Contains($clientPid)) { continue }
+    $client = $byPid[[string]$clientPid]
+    if ($null -eq $client) { continue }
+    $creationProp = $client.PSObject.Properties['CreationDate']
+    if (-not $creationProp) { continue }
+    if (-not (Test-LeaseProcessStartMatches -SnapshotCreation $creationProp.Value -LeaseStart $startProp.Value)) { continue }
+    $key = "$token|$clientPid"
+    if ($seen.Add($key)) {
+      [void]$out.Add([pscustomobject]@{
+        Token = $token; ClientPid = $clientPid; Cwd = [string]$cwdProp.Value
+      })
+    }
+  }
+  return $out.ToArray()
+}
+
+function Get-LiveClientLeaseTokens {
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [Parameter(Mandatory)]$BrokerTreePids,
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$ClientLeases,
+    [datetime]$NowUtc = [datetime]::UtcNow,
+    [int]$LeaseTtlMinutes = 10
+  )
+  $set = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($evidence in @(Get-LiveClientLeaseEvidence -Procs $Procs -BrokerTreePids $BrokerTreePids -ClientLeases $ClientLeases -NowUtc $NowUtc -LeaseTtlMinutes $LeaseTtlMinutes)) {
+    [void]$set.Add([string]$evidence.Token)
+  }
+  return , ([string[]]@($set))
+}
+
+# A render lease suppresses Layer A only when it covers EVERY broker in the
+# leased cwd. The writer scans once per heartbeat, so a broker born after that
+# scan is deliberately still ambiguous and must defer -Kill (HIMMEL-1474 r2).
+# HIMMEL-1474 r3: a broker without a resolvable explicit cwd is equally
+# ambiguous; no path signal proves it belongs outside the active render.
+function Get-UnattributedCodexAdversarialRenderPids {
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [AllowNull()]$BrokerTreePids = $null,
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$ClientLeases,
+    [datetime]$NowUtc = [datetime]::UtcNow,
+    [int]$LeaseTtlMinutes = 10
+  )
+  if ($null -eq $BrokerTreePids) { $BrokerTreePids = Get-CodexBrokerTreePids -Procs $Procs }
+  $outsideRenderPids = Get-OutsideCodexAdversarialRenderPids -Procs $Procs -BrokerTreePids $BrokerTreePids
+  $leaseEvidence = @(Get-LiveClientLeaseEvidence -Procs $Procs -BrokerTreePids $BrokerTreePids -ClientLeases $ClientLeases -NowUtc $NowUtc -LeaseTtlMinutes $LeaseTtlMinutes)
+  $brokers = @($Procs | Where-Object { Test-IsCodexAppServerBroker -Proc $_ })
+  $out = New-Object System.Collections.ArrayList
+
+  foreach ($renderPid in $outsideRenderPids) {
+    $renderEvidence = @($leaseEvidence | Where-Object { [int]$_.ClientPid -eq [int]$renderPid })
+    if ($renderEvidence.Count -eq 0) {
+      [void]$out.Add([int]$renderPid)
+      continue
+    }
+
+    $coveredTokens = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($evidence in $renderEvidence) { [void]$coveredTokens.Add([string]$evidence.Token) }
+    $hasUnleasedSameCwdBroker = $false
+    foreach ($broker in $brokers) {
+      $brokerCwd = Get-BrokerLeaseCwd -CommandLine ([string]$broker.CommandLine)
+      if (-not (Test-PathResolvable -Path $brokerCwd)) {
+        $hasUnleasedSameCwdBroker = $true
+        break
+      }
+      $sharesLeasedCwd = $false
+      foreach ($evidence in $renderEvidence) {
+        if (Test-PathEquivalent -Left $brokerCwd -Right ([string]$evidence.Cwd)) {
+          $sharesLeasedCwd = $true
+          break
+        }
+      }
+      if (-not $sharesLeasedCwd) { continue }
+      $brokerToken = Get-CxcToken -CommandLine ([string]$broker.CommandLine)
+      if (-not $coveredTokens.Contains([string]$brokerToken)) {
+        $hasUnleasedSameCwdBroker = $true
+        break
+      }
+    }
+    if ($hasUnleasedSameCwdBroker) { [void]$out.Add([int]$renderPid) }
+  }
+  return , ($out.ToArray())
+}
+
 # Pure classification: the orphan brokers in $Procs - brokers whose token no
 # outside-tree process references. Each returned record carries BrokerPid,
 # Token, Cwd. The broker-tree union is built once and excludes roots plus all
@@ -162,16 +396,20 @@ function Get-LiveClientTokens {
 function Get-CodexOrphanBrokers {
   param(
     [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
-    [AllowNull()]$BrokerTreePids = $null
+    [AllowNull()]$BrokerTreePids = $null,
+    [AllowEmptyCollection()][object[]]$ClientLeases = @(),
+    [datetime]$NowUtc = [datetime]::UtcNow
   )
   if ($null -eq $BrokerTreePids) { $BrokerTreePids = Get-CodexBrokerTreePids -Procs $Procs }
-  $liveTokens = Get-LiveClientTokens -Procs $Procs -BrokerTreePids $BrokerTreePids
+  $liveTokens = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($token in (Get-LiveClientTokens -Procs $Procs -BrokerTreePids $BrokerTreePids)) { [void]$liveTokens.Add($token) }
+  foreach ($token in (Get-LiveClientLeaseTokens -Procs $Procs -BrokerTreePids $BrokerTreePids -ClientLeases $ClientLeases -NowUtc $NowUtc)) { [void]$liveTokens.Add($token) }
   $out = New-Object System.Collections.ArrayList
   foreach ($p in $Procs) {
     if (-not (Test-IsCodexAppServerBroker -Proc $p)) { continue }
     $tok = Get-CxcToken -CommandLine ([string]$p.CommandLine)
     if ($null -eq $tok) { continue }
-    if ($liveTokens -contains $tok) { continue }   # an outside client still holds it -> LIVE
+    if ($liveTokens.Contains($tok)) { continue }   # an outside token reference or fresh client lease -> LIVE
     [void]$out.Add([pscustomobject]@{
       BrokerPid = [int]$p.ProcessId
       Token     = [string]$tok
@@ -298,9 +536,11 @@ function Get-CodexBrokerTreePids {
 function Get-CodexOrphanTrees {
   param(
     [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
-    [AllowNull()]$BrokerTreePids = $null
+    [AllowNull()]$BrokerTreePids = $null,
+    [AllowEmptyCollection()][object[]]$ClientLeases = @(),
+    [datetime]$NowUtc = [datetime]::UtcNow
   )
-  $orphans = @(Get-CodexOrphanBrokers -Procs $Procs -BrokerTreePids $BrokerTreePids)
+  $orphans = @(Get-CodexOrphanBrokers -Procs $Procs -BrokerTreePids $BrokerTreePids -ClientLeases $ClientLeases -NowUtc $NowUtc)
   $out = New-Object System.Collections.ArrayList
   foreach ($o in $orphans) {
     $desc = @(Get-DescendantPids -Procs $Procs -RootPid $o.BrokerPid)
@@ -361,6 +601,38 @@ function Test-CxcTokenPathSafe {
   return ($Token -match '^[A-Za-z0-9_-]+$')
 }
 
+# Best-effort filesystem reader for Layer B leases. Invalid JSON, unsafe tokens,
+# missing fields, and unreadable files are ignored; Get-LiveClientLeaseTokens
+# applies the freshness + identity + cwd gates before any lease becomes evidence.
+function Get-CodexClientLeases {
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [AllowNull()][string]$TempRoot
+  )
+  $out = New-Object System.Collections.ArrayList
+  if (-not $TempRoot -or -not (Test-Path -LiteralPath $TempRoot)) { return $out.ToArray() }
+  foreach ($p in $Procs) {
+    if (-not (Test-IsCodexAppServerBroker -Proc $p)) { continue }
+    $token = Get-CxcToken -CommandLine ([string]$p.CommandLine)
+    if (-not $token -or -not (Test-CxcTokenPathSafe -Token $token)) { continue }
+    $leaseDir = Join-Path $TempRoot "cxc-$token"
+    if (-not (Test-Path -LiteralPath $leaseDir)) { continue }
+    foreach ($file in @(Get-ChildItem -LiteralPath $leaseDir -Filter 'client-lease-*.json' -File -ErrorAction SilentlyContinue)) {
+      try {
+        $raw = Get-Content -LiteralPath $file.FullName -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        [void]$out.Add([pscustomobject]@{
+          Token           = [string]$token
+          ClientPid       = $raw.clientPid
+          ClientStartTime = $raw.clientStartTime
+          Cwd             = $raw.cwd
+          Heartbeat       = $raw.heartbeat
+        })
+      } catch { continue }
+    }
+  }
+  return $out.ToArray()
+}
+
 # Degraded-visibility probe (silent-failure CR): WMI returns an EMPTY
 # CommandLine for a process the caller lacks rights to inspect (cross-
 # elevation / cross-session). If that hits a plausible OUTSIDE client image
@@ -407,6 +679,473 @@ function Test-OnWindows {
   return [bool]$IsWindowsValue
 }
 
+# --- HIMMEL-1509: render-lease registry + kill-ledger helpers -----------------
+
+# Branch -> lease-dir slug, mirroring render-lease.sh's render_lease_slug
+# EXACTLY (HIMMEL-1509 r6, codex-2): [A-Za-z0-9._-] passes through; every
+# other UTF-8 BYTE becomes '+HH' (two uppercase hex; '/' -> +2F, '+' itself
+# -> +2B). '+' only ever starts a fixed-width escape, so the map is
+# injective - distinct branches can never share a lease dir. The sweep does
+# not slug branches today (it matches leases by record fields), but any
+# future PS consumer MUST use this and never re-derive the mapping.
+function Get-RenderLeaseSlug {
+  param([AllowNull()][AllowEmptyString()][string]$Branch)
+  if (-not $Branch) { return '' }
+  $sb = New-Object System.Text.StringBuilder
+  foreach ($b in [System.Text.Encoding]::UTF8.GetBytes($Branch)) {
+    $c = [string][char][int]$b
+    if ($c -cmatch '^[A-Za-z0-9._-]$') {
+      [void]$sb.Append($c)
+    } else {
+      [void]$sb.Append('+' + ([int]$b).ToString('X2'))
+    }
+  }
+  return $sb.ToString()
+}
+
+# Parse a proc-tree Windows identity string (`win:<pid>:<startticks>`) into its
+# parts, or $null for anything else (posix identities, malformed, empty).
+function Get-RenderLeaseIdentityParts {
+  param([AllowNull()][AllowEmptyString()][string]$Identity)
+  if (-not $Identity) { return $null }
+  if ($Identity -match '^win:(\d+):(\d+)$') {
+    try {
+      return [pscustomobject]@{ WinPid = [int]$Matches[1]; StartTicks = [long]$Matches[2] }
+    } catch { return $null }
+  }
+  return $null
+}
+
+# lease.record is KEY<TAB>VALUE, one pair per line (render-lease.sh writer).
+function ConvertFrom-RenderLeaseRecord {
+  param([AllowNull()][AllowEmptyCollection()][string[]]$Lines)
+  $map = @{}
+  foreach ($line in @($Lines)) {
+    if (-not $line) { continue }
+    $idx = ([string]$line).IndexOf("`t")
+    if ($idx -lt 1) { continue }
+    $map[([string]$line).Substring(0, $idx)] = ([string]$line).Substring($idx + 1)
+  }
+  return $map
+}
+
+# TTL parity with the bash launcher (HIMMEL-1509 r3, glm-4): render-lease.sh
+# honors RENDER_LEASE_TTL_SECS (default 600s), so the sweep resolves the SAME
+# env knob - raising the launcher TTL must never make a launcher-live lease
+# look sweep-stale. Non-numeric/non-positive values fall back to the default;
+# odd second counts round UP (sparing errs long, never short).
+function Get-RenderLeaseTtlMinutes {
+  param([AllowNull()][AllowEmptyString()][string]$EnvValue)
+  $secs = 600
+  if ($EnvValue -and $EnvValue -match '^\d+$') {
+    try {
+      $candidate = [int]$EnvValue
+      if ($candidate -gt 0) { $secs = $candidate }
+    } catch { }
+  }
+  return [int][math]::Ceiling($secs / 60.0)
+}
+
+# Lock stale-break parity (HIMMEL-1509 r5, glm-2): the bash twin honors
+# RENDER_LEASE_LOCK_STALE_SECS (default 600s, render-lease.sh), so the sweep
+# resolves the SAME knob for Lock-RenderLeaseRegistry's age break - a raised
+# env must never let the sweep age-break cross-space locks earlier than the
+# launcher expects. Identical conversion contract to the TTL resolver
+# (positive-int seconds, fall back on garbage/zero, round UP).
+function Get-RenderLeaseLockStaleMinutes {
+  param([AllowNull()][AllowEmptyString()][string]$EnvValue)
+  return (Get-RenderLeaseTtlMinutes -EnvValue $EnvValue)
+}
+
+# Freshness gate for SPARING (protective), so its skew posture deliberately
+# differs from the cxc client-lease validator: a FUTURE timestamp still reads
+# fresh here - clock skew must never enable a kill. Unparseable -> not fresh
+# (the lease then falls through to the leader-identity probe, not to a kill).
+function Test-RenderLeaseHeartbeatFresh {
+  param(
+    [AllowNull()][AllowEmptyString()][string]$HeartbeatText,
+    [datetime]$NowUtc = [datetime]::UtcNow,
+    [int]$TtlMinutes = 10
+  )
+  if (-not $HeartbeatText) { return $false }
+  $hb = $null
+  try { $hb = ([datetimeoffset]::Parse($HeartbeatText.Trim())).UtcDateTime } catch { return $false }
+  $age = ($NowUtc.ToUniversalTime() - $hb).TotalMinutes
+  return ($age -le $TtlMinutes)
+}
+
+# Classify one lease against the enumeration snapshot:
+#   live         = fresh heartbeat, OR recorded leader pid present in the
+#                  snapshot with a creation time matching the recorded start
+#                  ticks (2s tolerance, same anchor as Test-ProcessStartMatches),
+#                  OR a leaderless launch-phase record whose started_at is
+#                  still fresh (the launcher may not have bound yet), OR a
+#                  leader ABSENT from (or recycled within) the snapshot while
+#                  the record itself is still fresh - a lease bound AFTER this
+#                  snapshot has a leader the snapshot cannot contain, so
+#                  absence only proves death against a snapshot newer than the
+#                  launch (HIMMEL-1509 r6, codex-1);
+#   stale        = leader confirmed gone (absent from the snapshot or recycled
+#                  into a different creation time) AND the record is past the
+#                  TTL;
+#   unverifiable = unreadable record, or a leader whose identity cannot be
+#                  checked - fail-closed, the caller defers instead of killing.
+function Get-RenderLeaseDisposition {
+  param(
+    [Parameter(Mandatory)]$Lease,
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [datetime]$NowUtc = [datetime]::UtcNow,
+    [int]$TtlMinutes = 10
+  )
+  if ($Lease.PSObject.Properties['Unreadable'] -and $Lease.Unreadable) { return 'unverifiable' }
+  $heartbeatText = $null
+  if ($Lease.PSObject.Properties['Heartbeat']) { $heartbeatText = [string]$Lease.Heartbeat }
+  if (Test-RenderLeaseHeartbeatFresh -HeartbeatText $heartbeatText -NowUtc $NowUtc -TtlMinutes $TtlMinutes) { return 'live' }
+  $startedText = $null
+  if ($Lease.PSObject.Properties['StartedAt']) { $startedText = [string]$Lease.StartedAt }
+  $identity = $null
+  if ($Lease.PSObject.Properties['LeaderIdentity']) { $identity = [string]$Lease.LeaderIdentity }
+  $parts = Get-RenderLeaseIdentityParts -Identity $identity
+  if ($null -eq $parts) {
+    if (Test-RenderLeaseHeartbeatFresh -HeartbeatText $startedText -NowUtc $NowUtc -TtlMinutes $TtlMinutes) { return 'live' }
+    return 'unverifiable'
+  }
+  $leader = $null
+  foreach ($p in $Procs) {
+    if ([int]$p.ProcessId -eq $parts.WinPid) { $leader = $p; break }
+  }
+  if ($null -eq $leader) {
+    # r6 codex-1: a leader bound after the snapshot cannot appear in it. A
+    # fresh record (started_at inside the TTL; a fresh heartbeat already
+    # returned live above) keeps the lease LIVE; only absent + stale-record
+    # falls through to stale.
+    if (Test-RenderLeaseHeartbeatFresh -HeartbeatText $startedText -NowUtc $NowUtc -TtlMinutes $TtlMinutes) { return 'live' }
+    return 'stale'
+  }
+  $creationProp = $leader.PSObject.Properties['CreationDate']
+  if (-not $creationProp -or $null -eq $creationProp.Value) { return 'unverifiable' }
+  $creationTicks = $null
+  try { $creationTicks = ([datetime]$creationProp.Value).ToUniversalTime().Ticks } catch { return 'unverifiable' }
+  if ([math]::Abs(($creationTicks - $parts.StartTicks) / 10000000.0) -le 2) { return 'live' }
+  # Same cross-snapshot race as the absent-leader case: the snapshot pid may
+  # be a PRE-launch process whose pid the post-snapshot leader reused.
+  if (Test-RenderLeaseHeartbeatFresh -HeartbeatText $startedText -NowUtc $NowUtc -TtlMinutes $TtlMinutes) { return 'live' }
+  return 'stale'
+}
+
+function Get-RenderLeaseDispositions {
+  param(
+    [AllowEmptyCollection()][object[]]$Leases = @(),
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs,
+    [datetime]$NowUtc = [datetime]::UtcNow,
+    [int]$TtlMinutes = 10
+  )
+  $out = New-Object System.Collections.ArrayList
+  foreach ($lease in @($Leases)) {
+    [void]$out.Add([pscustomobject]@{
+      Lease = $lease
+      State = (Get-RenderLeaseDisposition -Lease $lease -Procs $Procs -NowUtc $NowUtc -TtlMinutes $TtlMinutes)
+    })
+  }
+  # No unary comma: callers consume via @(...) (Get-CodexOrphanTrees style).
+  return $out.ToArray()
+}
+
+# Map each orphan tree to a kill decision under the lease dispositions:
+#   spared   = a LIVE lease claims the tree (recorded token, or lease-strict
+#              broker --cwd equals the lease worktree) -> untouchable;
+#   deferred = an UNVERIFIABLE lease might claim it (cwd match, worktree-less
+#              unverifiable lease, or the tree's own cwd is unresolvable while
+#              any live/unverifiable lease exists - HIMMEL-1474 r3 ambiguity
+#              posture) -> not killed this pass;
+#   kill     = no lease claims it -> proceeds to the existing name + identity
+#              verified stop.
+function Select-RenderLeaseKillActions {
+  param(
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Trees,
+    [AllowEmptyCollection()][object[]]$Dispositions = @(),
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs
+  )
+  $byPid = @{}
+  foreach ($p in $Procs) { $byPid[[string]$p.ProcessId] = $p }
+  $liveTokens = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
+  $liveCwds = New-Object System.Collections.ArrayList
+  $unvCwds = New-Object System.Collections.ArrayList
+  $unvGlobal = $false
+  foreach ($d in @($Dispositions)) {
+    $lease = $d.Lease
+    $worktree = $null
+    if ($lease.PSObject.Properties['Worktree']) { $worktree = [string]$lease.Worktree }
+    if ($d.State -eq 'live') {
+      if ($lease.PSObject.Properties['Tokens']) {
+        foreach ($t in @($lease.Tokens)) { if ($t) { [void]$liveTokens.Add([string]$t) } }
+      }
+      if ($worktree) { [void]$liveCwds.Add($worktree) } else { $unvGlobal = $true }
+    } elseif ($d.State -eq 'unverifiable') {
+      if ($worktree) { [void]$unvCwds.Add($worktree) } else { $unvGlobal = $true }
+    }
+  }
+  $anyLeaseSignal = ($liveTokens.Count -gt 0 -or $liveCwds.Count -gt 0 -or $unvCwds.Count -gt 0 -or $unvGlobal)
+  $out = New-Object System.Collections.ArrayList
+  foreach ($t in @($Trees)) {
+    $action = 'kill'
+    $reason = ''
+    if ($liveTokens.Contains([string]$t.Token)) {
+      $action = 'spared'; $reason = 'live-lease-token'
+    } else {
+      $broker = $byPid[[string]$t.BrokerPid]
+      $brokerCwd = $null
+      if ($broker) { $brokerCwd = Get-BrokerLeaseCwd -CommandLine ([string]$broker.CommandLine) }
+      if (Test-PathResolvable -Path $brokerCwd) {
+        foreach ($c in $liveCwds) {
+          if (Test-PathEquivalent -Left $brokerCwd -Right ([string]$c)) { $action = 'spared'; $reason = 'live-lease-cwd'; break }
+        }
+        if ($action -eq 'kill') {
+          foreach ($c in $unvCwds) {
+            if (Test-PathEquivalent -Left $brokerCwd -Right ([string]$c)) { $action = 'deferred'; $reason = 'unverifiable-lease-cwd'; break }
+          }
+        }
+        if ($action -eq 'kill' -and $unvGlobal) { $action = 'deferred'; $reason = 'unverifiable-lease' }
+      } elseif ($anyLeaseSignal) {
+        $action = 'deferred'; $reason = 'unresolvable-broker-cwd'
+      }
+    }
+    [void]$out.Add([pscustomobject]@{ Tree = $t; Action = $action; Reason = $reason })
+  }
+  # No unary comma: callers consume via @(...) (Get-CodexOrphanTrees style).
+  return $out.ToArray()
+}
+
+# Replay-guard parity with the main pass (HIMMEL-1509 r2, codex-1): a lease
+# can protect a render by WORKTREE alone (its tokens file may not exist yet),
+# so -FromLedger must not kill just because the recorded token set is empty.
+# Protection = recorded tokens of live/unverifiable leases, PLUS the token of
+# every snapshot broker whose lease-strict --cwd matches a live/unverifiable
+# lease worktree, PLUS ambiguous brokers (unresolvable cwd) whenever any lease
+# signal exists; a worktree-less live/unverifiable lease protects everything.
+# AnySignal lets callers fail closed on entries that carry no token at all.
+function Get-RenderLeaseReplayGuard {
+  param(
+    [AllowEmptyCollection()][object[]]$Dispositions = @(),
+    [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Procs
+  )
+  $tokens = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
+  $cwds = New-Object System.Collections.ArrayList
+  $protectAll = $false
+  $anySignal = $false
+  foreach ($d in @($Dispositions)) {
+    if ($d.State -eq 'stale') { continue }
+    $anySignal = $true
+    $lease = $d.Lease
+    if ($lease.PSObject.Properties['Tokens']) {
+      foreach ($t in @($lease.Tokens)) { if ($t) { [void]$tokens.Add([string]$t) } }
+    }
+    $worktree = $null
+    if ($lease.PSObject.Properties['Worktree']) { $worktree = [string]$lease.Worktree }
+    if ($worktree) { [void]$cwds.Add($worktree) } else { $protectAll = $true }
+  }
+  if (-not $protectAll -and $anySignal) {
+    foreach ($p in @($Procs)) {
+      if (-not (Test-IsCodexAppServerBroker -Proc $p)) { continue }
+      $brokerToken = Get-CxcToken -CommandLine ([string]$p.CommandLine)
+      if (-not $brokerToken) { continue }
+      $brokerCwd = Get-BrokerLeaseCwd -CommandLine ([string]$p.CommandLine)
+      if (Test-PathResolvable -Path $brokerCwd) {
+        foreach ($c in $cwds) {
+          if (Test-PathEquivalent -Left $brokerCwd -Right ([string]$c)) { [void]$tokens.Add([string]$brokerToken); break }
+        }
+      } else {
+        # Same ambiguity posture as Select-RenderLeaseKillActions: a broker
+        # with no provable path binding is untouchable while any lease exists.
+        [void]$tokens.Add([string]$brokerToken)
+      }
+    }
+  }
+  return [pscustomobject]@{ Tokens = $tokens; ProtectAll = $protectAll; AnySignal = $anySignal }
+}
+
+# Ledger entries are keyed by pid + recorded creation time, so a `consumed`
+# record can only ever retire the exact process incarnation it names.
+function Get-KillLedgerEntryKey {
+  param([Parameter(Mandatory)]$Entry)
+  $entryPid = ''
+  $creation = ''
+  if ($Entry.PSObject.Properties['pid'] -and $null -ne $Entry.pid) { $entryPid = [string]$Entry.pid }
+  if ($Entry.PSObject.Properties['creation'] -and $null -ne $Entry.creation) { $creation = [string]$Entry.creation }
+  return "$entryPid|$creation"
+}
+
+# Parse the append-only JSONL kill-ledger: return the `kill-failed` entries not
+# yet retired by a matching `consumed` record. Malformed lines are skipped
+# (they can only ever hide evidence, never authorize a kill).
+function ConvertFrom-KillLedger {
+  param([AllowNull()][AllowEmptyCollection()][string[]]$Lines)
+  $consumed = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::Ordinal)
+  $entries = New-Object System.Collections.ArrayList
+  foreach ($line in @($Lines)) {
+    if (-not $line) { continue }
+    $o = $null
+    try { $o = $line | ConvertFrom-Json -ErrorAction Stop } catch { continue }
+    if ($null -eq $o -or -not $o.PSObject.Properties['type']) { continue }
+    switch ([string]$o.type) {
+      'consumed' { [void]$consumed.Add((Get-KillLedgerEntryKey -Entry $o)) }
+      'kill-failed' { [void]$entries.Add($o) }
+    }
+  }
+  $out = New-Object System.Collections.ArrayList
+  foreach ($e in $entries) {
+    if (-not $consumed.Contains((Get-KillLedgerEntryKey -Entry $e))) { [void]$out.Add($e) }
+  }
+  # No unary comma: callers consume via @(...) (Get-CodexOrphanTrees style).
+  return $out.ToArray()
+}
+
+# Judge a ledger entry against the LIVE process it names:
+#   match        = same creation time (2s) AND the live name is allow-listed
+#                  -> the recorded orphan incarnation, killable;
+#   recycled     = live creation time provably differs -> the orphan is gone,
+#                  the entry is consumable, the live process untouchable;
+#   unverifiable = missing/unreadable identity data on either side ->
+#                  fail-closed: never kill, never consume. STRICTER than
+#                  Test-ProcessStartMatches by design: a ledger kill is
+#                  elective, so a lost probe drops the kill, not the guard.
+function Get-KillLedgerEntryLiveState {
+  param(
+    [Parameter(Mandatory)]$Entry,
+    [AllowNull()][AllowEmptyString()][string]$LiveName,
+    [AllowNull()]$LiveStart
+  )
+  $creationProp = $Entry.PSObject.Properties['creation']
+  if (-not $creationProp -or -not $creationProp.Value) { return 'unverifiable' }
+  if ($null -eq $LiveStart) { return 'unverifiable' }
+  $recorded = $null
+  $live = $null
+  try {
+    # PS7 ConvertFrom-Json auto-converts ISO strings to [datetime] (Local
+    # kind); stringifying that and re-parsing shifts by the UTC offset, so
+    # branch on the actual representation instead of round-tripping.
+    if ($creationProp.Value -is [datetime]) {
+      $recorded = ([datetime]$creationProp.Value).ToUniversalTime()
+    } else {
+      $recorded = ([datetimeoffset]::Parse([string]$creationProp.Value)).UtcDateTime
+    }
+    $live = ([datetime]$LiveStart).ToUniversalTime()
+  } catch { return 'unverifiable' }
+  if ([math]::Abs(($live - $recorded).TotalSeconds) -gt 2) { return 'recycled' }
+  if (-not $LiveName -or -not (Test-ProcessNameAllowed -Name $LiveName)) { return 'unverifiable' }
+  return 'match'
+}
+
+# --- registry IO (invoked only by the production path / IO-aware tests) -------
+
+# Read every lease under the registry root. Per-lease read failures mark that
+# lease Unreadable (-> unverifiable downstream); a top-level enumeration
+# failure THROWS so the caller can refuse the kill pass.
+function Get-RenderLeaseRecords {
+  param([AllowNull()][AllowEmptyString()][string]$RegistryPath)
+  $out = New-Object System.Collections.ArrayList
+  # No unary comma on either return: callers consume via @(...).
+  if (-not $RegistryPath -or -not (Test-Path -LiteralPath $RegistryPath)) { return $out.ToArray() }
+  foreach ($dir in @(Get-ChildItem -LiteralPath $RegistryPath -Directory -Force -ErrorAction Stop)) {
+    if ($dir.Name.StartsWith('.')) { continue }
+    $rec = [ordered]@{
+      Name = $dir.Name; Path = $dir.FullName
+      Branch = $null; Worktree = $null; LeaderIdentity = $null; StartedAt = $null
+      Heartbeat = $null; Tokens = @(); Unreadable = $false
+    }
+    try {
+      $lines = @(Get-Content -LiteralPath (Join-Path $dir.FullName 'lease.record') -ErrorAction Stop)
+      $map = ConvertFrom-RenderLeaseRecord -Lines $lines
+      if ($map.ContainsKey('branch')) { $rec.Branch = $map['branch'] } else { $rec.Unreadable = $true }
+      if ($map.ContainsKey('worktree')) { $rec.Worktree = $map['worktree'] }
+      if ($map.ContainsKey('leader_identity')) { $rec.LeaderIdentity = $map['leader_identity'] }
+      if ($map.ContainsKey('started_at')) { $rec.StartedAt = $map['started_at'] }
+    } catch { $rec.Unreadable = $true }
+    try { $rec.Heartbeat = [string](Get-Content -LiteralPath (Join-Path $dir.FullName 'heartbeat') -Raw -ErrorAction Stop) } catch { }
+    try { $rec.Tokens = @(Get-Content -LiteralPath (Join-Path $dir.FullName 'tokens') -ErrorAction Stop | Where-Object { $_ }) } catch { $rec.Tokens = @() }
+    [void]$out.Add([pscustomobject]$rec)
+  }
+  return $out.ToArray()
+}
+
+# Registry mutex: mkdir of .registry.lock, mirroring render-lease.sh. Owner is
+# tagged `win:<pid>` here. Stale-break disposition (HIMMEL-1509 r4, matching
+# the bash twin): a same-space owner probed ALIVE is NEVER broken - not even
+# by age (a long kill pass or mid-claim launcher legitimately holds it;
+# contenders wait out their retries and the caller refuses); a same-space
+# owner probed DEAD is broken immediately; only a cross-space (`msys:`) or
+# unverifiable owner falls back to the AGE break, and each break logs which
+# disposition fired. Returns the lock path or $null when every attempt stayed
+# contended (caller must then refuse kills).
+function Lock-RenderLeaseRegistry {
+  param(
+    [Parameter(Mandatory)][string]$RegistryPath,
+    [int]$Attempts = 10,
+    [int]$DelayMs = 500,
+    [int]$StaleMinutes = 10
+  )
+  $lockPath = Join-Path $RegistryPath '.registry.lock'
+  for ($i = 0; $i -lt $Attempts; $i++) {
+    try {
+      [void](New-Item -ItemType Directory -Path $lockPath -ErrorAction Stop)
+      try { Set-Content -LiteralPath (Join-Path $lockPath 'owner.pid') -Value "win:$PID" } catch { }
+      return $lockPath
+    } catch { }
+    $stale = $false
+    $ownerLive = $false
+    $owner = $null
+    try { $owner = [string](Get-Content -LiteralPath (Join-Path $lockPath 'owner.pid') -Raw -ErrorAction Stop) } catch { }
+    if ($owner -and $owner.Trim() -match '^win:(\d+)$') {
+      try {
+        [void](Get-Process -Id ([int]$Matches[1]) -ErrorAction Stop)
+        $ownerLive = $true
+      } catch { $stale = $true }
+    }
+    if ($stale) {
+      Write-Host ('[sweep-codex-orphans] render-lease: breaking registry lock held by confirmed-dead owner ({0})' -f $owner.Trim())
+    } elseif (-not $ownerLive) {
+      # Cross-space or unverifiable owner: age is the only safe judge. A
+      # verified-live owner never reaches this branch.
+      try {
+        $age = ([datetime]::UtcNow - (Get-Item -LiteralPath $lockPath -Force -ErrorAction Stop).CreationTimeUtc).TotalMinutes
+        if ($age -gt $StaleMinutes) {
+          $stale = $true
+          $ownerLabel = '(unreadable)'
+          if ($owner) { $ownerLabel = $owner.Trim() }
+          Write-Host ('[sweep-codex-orphans] render-lease: age-breaking registry lock with cross-space/unverifiable owner ({0}, older than {1}min)' -f $ownerLabel, $StaleMinutes)
+        }
+      } catch { }
+    }
+    if ($stale) { Remove-Item -LiteralPath $lockPath -Recurse -Force -ErrorAction SilentlyContinue }
+    Start-Sleep -Milliseconds $DelayMs
+  }
+  return $null
+}
+
+# Owner-verified release (HIMMEL-1509 r7, codex-1; mirrors
+# render_lease_lock_release): remove the lock ONLY when its owner record
+# names this process - a former holder whose lock was broken must never
+# delete a successor's newly acquired lock. A mismatched or unreadable owner
+# leaves the lock (the dead-owner / age breaks self-heal it) and says so.
+function Unlock-RenderLeaseRegistry {
+  param([Parameter(Mandatory)][string]$LockPath)
+  if (-not (Test-Path -LiteralPath $LockPath)) { return }
+  $owner = $null
+  try { $owner = ([string](Get-Content -LiteralPath (Join-Path $LockPath 'owner.pid') -Raw -ErrorAction Stop)).Trim() } catch { }
+  if ($owner -ceq "win:$PID") {
+    Remove-Item -LiteralPath $LockPath -Recurse -Force -ErrorAction SilentlyContinue
+    return
+  }
+  $ownerLabel = '(unreadable)'
+  if ($owner) { $ownerLabel = $owner }
+  Write-Host ('[sweep-codex-orphans] render-lease: NOT releasing registry lock: owner record {0} is not this process (win:{1}) - it was re-acquired after a break; leaving it to its owner' -f $ownerLabel, $PID)
+}
+
+function Add-KillLedgerLine {
+  param([Parameter(Mandatory)][string]$Path, [Parameter(Mandatory)]$Object)
+  Add-Content -LiteralPath $Path -Value (ConvertTo-Json -Compress -InputObject $Object)
+}
+
 if ($AsLibrary) { return }
 
 # --- production path ---------------------------------------------------------
@@ -419,6 +1158,17 @@ if (-not (Test-OnWindows -IsWindowsValue $IsWindows -OsEnv $env:OS)) {
 }
 
 $ErrorActionPreference = 'Stop'
+
+# HIMMEL-1509: resolve the render-lease registry + kill-ledger locations once.
+$renderLeaseRegistry = $RegistryPath
+if (-not $renderLeaseRegistry) { $renderLeaseRegistry = [string]$env:RENDER_LEASE_DIR }
+if (-not $renderLeaseRegistry) { $renderLeaseRegistry = Join-Path ([string]$env:USERPROFILE) '.claude\handover\bridge\render-leases' }
+$killLedgerPath = $LedgerPath
+if (-not $killLedgerPath) { $killLedgerPath = Join-Path $renderLeaseRegistry 'kill-ledger.jsonl' }
+# Launcher TTL parity (r3 glm-4): one resolution, passed to every disposition.
+$renderLeaseTtl = Get-RenderLeaseTtlMinutes -EnvValue ([string]$env:RENDER_LEASE_TTL_SECS)
+# Launcher lock-stale parity (r5 glm-2): same, for the registry-lock age break.
+$renderLeaseLockStale = Get-RenderLeaseLockStaleMinutes -EnvValue ([string]$env:RENDER_LEASE_LOCK_STALE_SECS)
 
 try {
   $records = @(Get-CimInstance Win32_Process -ErrorAction Stop |
@@ -439,10 +1189,124 @@ try {
   exit 1
 }
 
-# Build the broker-tree exclusion union once for both liveness classification
-# and the blind-client gate; no process inside any tree can be client evidence.
+# --- HIMMEL-1509: -FromLedger, the sanctioned orchestrator consume path ------
+# Kills ONLY identity-verified unconsumed ledger entries: live process present,
+# creation time matching the recorded identity, name allow-listed, and not
+# protected by a live/unverifiable render lease. Without -Kill it only lists.
+if ($FromLedger) {
+  if (-not (Test-Path -LiteralPath $killLedgerPath)) {
+    Write-Host "[sweep-codex-orphans] kill-ledger: absent at $killLedgerPath - nothing to consume."
+    exit 0
+  }
+  $leaseLock = $null
+  if ($Kill) {
+    # HIMMEL-1509 r3 (codex-1): unconditional create+lock before any replay
+    # kill, same as the main kill path - a missing registry never skips the
+    # lock (a first concurrent render can create it mid-replay).
+    try { [void](New-Item -ItemType Directory -Force -Path $renderLeaseRegistry -ErrorAction Stop) } catch {
+      Write-Host "[sweep-codex-orphans] render-lease: outcome=refused reason=registry-unusable - no ledger entry was acted on."
+      exit 1
+    }
+    $leaseLock = Lock-RenderLeaseRegistry -RegistryPath $renderLeaseRegistry -StaleMinutes $renderLeaseLockStale
+    if (-not $leaseLock) {
+      Write-Host "[sweep-codex-orphans] render-lease: outcome=refused reason=lock-unavailable - no ledger entry was acted on."
+      exit 1
+    }
+  }
+  # try/finally holds the lock release (HIMMEL-1509 r2, glm-4 parity): an
+  # exception mid-replay must not strand the lock into the 10-min stale
+  # reclaim. PowerShell runs finally on `exit` too.
+  try {
+  $renderLeases = @()
+  if (Test-Path -LiteralPath $renderLeaseRegistry) {
+    try { $renderLeases = @(Get-RenderLeaseRecords -RegistryPath $renderLeaseRegistry) } catch {
+      Write-Host "[sweep-codex-orphans] render-lease: outcome=refused reason=registry-unreadable - no ledger entry was acted on."
+      exit 1
+    }
+  }
+  $dispositions = @(Get-RenderLeaseDispositions -Leases $renderLeases -Procs $records -TtlMinutes $renderLeaseTtl)
+  $replayGuard = Get-RenderLeaseReplayGuard -Dispositions $dispositions -Procs $records
+  $ledgerEntries = @()
+  try { $ledgerEntries = @(ConvertFrom-KillLedger -Lines @(Get-Content -LiteralPath $killLedgerPath -ErrorAction Stop)) } catch {
+    Write-Host "[sweep-codex-orphans] kill-ledger: outcome=refused reason=ledger-unreadable"
+    exit 1
+  }
+  $ledgerKilled = 0
+  $ledgerConsumed = 0
+  $ledgerSkipped = 0
+  foreach ($entry in $ledgerEntries) {
+    $entryPid = 0
+    try { $entryPid = [int]$entry.pid } catch { $ledgerSkipped++; continue }
+    if ($entryPid -le 0) { $ledgerSkipped++; continue }
+    $entryToken = ''
+    if ($entry.PSObject.Properties['token'] -and $null -ne $entry.token) { $entryToken = [string]$entry.token }
+    # Lease protection has main-pass parity (r2 codex-1): recorded or
+    # cwd-derived protected tokens, a protect-everything lease, or an entry
+    # with no token at all while any live/unverifiable lease exists.
+    if ($replayGuard.ProtectAll -or
+        ($entryToken -and $replayGuard.Tokens.Contains($entryToken)) -or
+        (-not $entryToken -and $replayGuard.AnySignal)) {
+      Write-Host "[sweep-codex-orphans] kill-ledger: pid=$entryPid token=$entryToken action=skipped reason=lease-protected"
+      $ledgerSkipped++
+      continue
+    }
+    $live = $null
+    try { $live = Get-Process -Id $entryPid -ErrorAction Stop } catch { $live = $null }
+    # Dry-run honesty (r3 codex-2): without -Kill nothing is appended, so the
+    # per-entry label and the summary both say "would-consume"/"would-kill".
+    $consumeLabel = 'consumed'
+    if (-not $Kill) { $consumeLabel = 'would-consume' }
+    if ($null -eq $live) {
+      if ($Kill) { Add-KillLedgerLine -Path $killLedgerPath -Object ([ordered]@{ type = 'consumed'; ts = [datetime]::UtcNow.ToString('o'); pid = $entryPid; creation = $entry.creation; reason = 'gone' }) }
+      Write-Host "[sweep-codex-orphans] kill-ledger: pid=$entryPid token=$entryToken action=$consumeLabel reason=gone"
+      $ledgerConsumed++
+      continue
+    }
+    $liveStart = $null
+    try { $liveStart = $live.StartTime } catch { $liveStart = $null }
+    $state = Get-KillLedgerEntryLiveState -Entry $entry -LiveName ([string]$live.ProcessName) -LiveStart $liveStart
+    if ($state -eq 'match') {
+      if ($Kill) {
+        try {
+          Stop-Process -Id $entryPid -Force -ErrorAction Stop
+          Add-KillLedgerLine -Path $killLedgerPath -Object ([ordered]@{ type = 'consumed'; ts = [datetime]::UtcNow.ToString('o'); pid = $entryPid; creation = $entry.creation; reason = 'swept' })
+          Write-Host "[sweep-codex-orphans] kill-ledger: pid=$entryPid token=$entryToken action=killed reason=identity-verified"
+          $ledgerKilled++
+        } catch {
+          Write-Warning "[sweep-codex-orphans] kill-ledger: pid=$entryPid could not be stopped: $_"
+          $ledgerSkipped++
+        }
+      } else {
+        Write-Host "[sweep-codex-orphans] kill-ledger: pid=$entryPid token=$entryToken action=would-kill reason=identity-verified"
+        $ledgerKilled++
+      }
+    } elseif ($state -eq 'recycled') {
+      if ($Kill) { Add-KillLedgerLine -Path $killLedgerPath -Object ([ordered]@{ type = 'consumed'; ts = [datetime]::UtcNow.ToString('o'); pid = $entryPid; creation = $entry.creation; reason = 'recycled' }) }
+      Write-Host "[sweep-codex-orphans] kill-ledger: pid=$entryPid token=$entryToken action=$consumeLabel reason=recycled"
+      $ledgerConsumed++
+    } else {
+      Write-Host "[sweep-codex-orphans] kill-ledger: pid=$entryPid token=$entryToken action=skipped reason=unverifiable"
+      $ledgerSkipped++
+    }
+  }
+  if ($Kill) {
+    Write-Host ("[sweep-codex-orphans] kill-ledger: {0} unconsumed entr(y/ies): {1} killed, {2} consumed, {3} skipped." -f $ledgerEntries.Count, $ledgerKilled, $ledgerConsumed, $ledgerSkipped)
+  } else {
+    Write-Host ("[sweep-codex-orphans] kill-ledger: {0} unconsumed entr(y/ies): would kill {1}, would consume {2}, {3} skipped (dry run - nothing written; re-run with -Kill)." -f $ledgerEntries.Count, $ledgerKilled, $ledgerConsumed, $ledgerSkipped)
+  }
+  exit 0
+  } finally {
+    if ($leaseLock) { Unlock-RenderLeaseRegistry -LockPath $leaseLock }
+  }
+}
+
+# Build the broker-tree exclusion union once for liveness classification, the
+# Layer A render gate, and the blind-client gate. Layer B leases are read only
+# from each broker token's TEMP directory, then validated against this snapshot.
 $brokerTreePids = Get-CodexBrokerTreePids -Procs $records
-$trees = @(Get-CodexOrphanTrees -Procs $records -BrokerTreePids $brokerTreePids)
+$clientLeases = @(Get-CodexClientLeases -Procs $records -TempRoot ([string]$env:TEMP))
+$trees = @(Get-CodexOrphanTrees -Procs $records -BrokerTreePids $brokerTreePids -ClientLeases $clientLeases)
+$outsideRenderPids = Get-UnattributedCodexAdversarialRenderPids -Procs $records -BrokerTreePids $brokerTreePids -ClientLeases $clientLeases
 
 # byPid lookup for working-set summation + name-verified kill.
 $byPid = @{}
@@ -497,10 +1361,41 @@ $blindClients = Get-BlindClientPids -Procs $records -BrokerTreePids $brokerTreeP
 if ($blindClients.Count -gt 0) {
   Write-Warning ("[sweep-codex-orphans] client pid(s) {0} have no visible CommandLine (elevation/session gap) - the client-liveness signal is unreliable; orphan classifications above may be WRONG." -f ($blindClients -join ', '))
 }
+if (Test-ShouldDeferCodexKill -OutsideRenderPids $outsideRenderPids) {
+  Write-Warning ("[sweep-codex-orphans] outside-broker-tree codex adversarial render pid(s) {0} are live but carry no attributable cxc token - Layer A will defer the entire -Kill pass." -f ($outsideRenderPids -join ', '))
+}
 
 if (-not $Kill) {
+  # HIMMEL-1509 report-only lease view (unlocked read; the -Kill pass re-reads
+  # authoritatively under the registry lock).
+  $renderLeases = @()
+  if (Test-Path -LiteralPath $renderLeaseRegistry) {
+    try { $renderLeases = @(Get-RenderLeaseRecords -RegistryPath $renderLeaseRegistry) } catch {
+      Write-Warning "[sweep-codex-orphans] render-lease: registry unreadable ($renderLeaseRegistry) - a -Kill run would refuse."
+    }
+  }
+  $renderDispositions = @(Get-RenderLeaseDispositions -Leases $renderLeases -Procs $records -TtlMinutes $renderLeaseTtl)
+  foreach ($d in $renderDispositions) {
+    Write-Host ('[sweep-codex-orphans] render-lease: name={0} state={1}' -f $d.Lease.Name, $d.State)
+  }
+  $killActions = @(Select-RenderLeaseKillActions -Trees $trees -Dispositions $renderDispositions -Procs $records)
+  $wouldKillTrees = New-Object System.Collections.ArrayList
+  foreach ($a in $killActions) {
+    if ($a.Action -eq 'kill') { [void]$wouldKillTrees.Add($a.Tree) }
+    else { Write-Host ('[sweep-codex-orphans] render-lease: token={0} broker={1} action={2} reason={3}' -f $a.Tree.Token, $a.Tree.BrokerPid, $a.Action, $a.Reason) }
+  }
+  # Report the KILLABLE subset distinctly (r3 glm-3): the candidate totals
+  # above include lease-spared/deferred trees a -Kill run would not touch.
+  $wouldKillPids = @($wouldKillTrees | ForEach-Object { $_.TreePids } | Sort-Object -Unique)
+  $wouldKillMB = 0
+  if ($wouldKillPids.Count -gt 0) { $wouldKillMB = Get-TreeWSMB -Pids ([int[]]$wouldKillPids) }
   Write-Host "[sweep-codex-orphans] dry run (default). Re-run with -Kill to name-verified-stop the above + clean stale broker.pid files."
-  Write-Host ("[sweep-codex-orphans] would sweep {0} tree(s), {1} proc(s), ~{2} MB." -f $trees.Count, $totalProcs, $totalMB)
+  Write-Host ("[sweep-codex-orphans] would sweep {0} of {1} tree(s) ({2} lease-spared/deferred): {3} proc(s), ~{4} MB in the killable subset (all candidates: {5} proc(s), ~{6} MB)." -f $wouldKillTrees.Count, $trees.Count, ($trees.Count - $wouldKillTrees.Count), $wouldKillPids.Count, $wouldKillMB, $totalProcs, $totalMB)
+  exit 0
+}
+
+if (Test-ShouldDeferCodexKill -OutsideRenderPids $outsideRenderPids) {
+  Write-Host "[sweep-codex-orphans] deferred -Kill: at least one outside-tree codex adversarial render is live; no process was stopped."
   exit 0
 }
 
@@ -508,6 +1403,56 @@ if ($blindClients.Count -gt 0) {
   Write-Warning "[sweep-codex-orphans] refusing -Kill while plausible outside client command lines are invisible - re-run from a context that can see claude.exe/ChatGPT.exe/node.exe/bun.exe clients (e.g. the same elevation as the clients)."
   exit 1
 }
+
+# HIMMEL-1509: authoritative render-lease read UNDER THE REGISTRY LOCK before
+# any kill. Live-lease trees are untouchable regardless of command-line
+# visibility; unverifiable leases defer their trees; an unavailable lock or
+# unreadable registry refuses the whole pass (fail-closed).
+$leaseLock = $null
+$renderLeases = @()
+# HIMMEL-1509 r3 (codex-1): the registry lock is UNCONDITIONAL before any
+# kill. "Registry absent" must never mean "skip the lock" - the first
+# concurrent render CREATES the registry and its lease after an existence
+# check would have passed, leaving the sweep killing with no authoritative
+# locked read. The sweep therefore creates the registry dir itself and locks
+# it; an EMPTY locked registry is the correct no-leases proof.
+try { [void](New-Item -ItemType Directory -Force -Path $renderLeaseRegistry -ErrorAction Stop) } catch {
+  Write-Host "[sweep-codex-orphans] render-lease: outcome=refused reason=registry-unusable - no process was stopped."
+  exit 1
+}
+$leaseLock = Lock-RenderLeaseRegistry -RegistryPath $renderLeaseRegistry -StaleMinutes $renderLeaseLockStale
+if (-not $leaseLock) {
+  Write-Host "[sweep-codex-orphans] render-lease: outcome=refused reason=lock-unavailable - no process was stopped."
+  exit 1
+}
+# try/finally holds the lock release (HIMMEL-1509 r2, glm-4): an exception
+# anywhere in the kill/ledger section must not strand the lock into the 10-min
+# stale reclaim. PowerShell runs finally on `exit` too. Body indentation is
+# left flat to keep the guarded region diffable.
+try {
+try { $renderLeases = @(Get-RenderLeaseRecords -RegistryPath $renderLeaseRegistry) } catch {
+  Write-Host "[sweep-codex-orphans] render-lease: outcome=refused reason=registry-unreadable - no process was stopped."
+  exit 1
+}
+$renderDispositions = @(Get-RenderLeaseDispositions -Leases $renderLeases -Procs $records -TtlMinutes $renderLeaseTtl)
+foreach ($d in $renderDispositions) {
+  Write-Host ('[sweep-codex-orphans] render-lease: name={0} state={1}' -f $d.Lease.Name, $d.State)
+}
+$killActions = @(Select-RenderLeaseKillActions -Trees $trees -Dispositions $renderDispositions -Procs $records)
+$killTrees = New-Object System.Collections.ArrayList
+foreach ($a in $killActions) {
+  if ($a.Action -eq 'kill') { [void]$killTrees.Add($a.Tree) }
+  else { Write-Host ('[sweep-codex-orphans] render-lease: token={0} broker={1} action={2} reason={3}' -f $a.Tree.Token, $a.Tree.BrokerPid, $a.Action, $a.Reason) }
+}
+$leaseExcludedTrees = $trees.Count - $killTrees.Count
+$killFlatPids = @($killTrees | ForEach-Object { $_.TreePids } | Sort-Object -Unique)
+# pid -> token map so a stop-failure can be led into the kill-ledger with its
+# tree identity attached.
+$pidTokenMap = @{}
+foreach ($t in $killTrees) {
+  foreach ($treePid in $t.TreePids) { $pidTokenMap[[string]$treePid] = [string]$t.Token }
+}
+$ledgerFailed = New-Object System.Collections.ArrayList
 
 # -Kill: name-verified stop. A pid is stopped ONLY if (a) its current
 # ProcessName is in the allow set AND (b) its live StartTime matches the
@@ -522,8 +1467,8 @@ $skippedGone = 0
 $killedPids = New-Object System.Collections.ArrayList
 $killedBrokerPids = New-Object System.Collections.Generic.HashSet[int]
 $brokerPidSet = New-Object System.Collections.Generic.HashSet[int]
-foreach ($t in $trees) { [void]$brokerPidSet.Add([int]$t.BrokerPid) }
-foreach ($procId in $flatPids) {
+foreach ($t in $killTrees) { [void]$brokerPidSet.Add([int]$t.BrokerPid) }
+foreach ($procId in $killFlatPids) {
   $rec = $byPid[[string]$procId]            # enumeration snapshot (identity anchor)
   $liveNow = $null
   try { $liveNow = Get-Process -Id $procId -ErrorAction Stop } catch { $liveNow = $null }
@@ -558,7 +1503,57 @@ foreach ($procId in $flatPids) {
     if ($brokerPidSet.Contains([int]$procId)) { [void]$killedBrokerPids.Add([int]$procId) }
   } catch {
     Write-Warning "[sweep-codex-orphans] could not stop pid $procId ('$curName'): $_"
+    # HIMMEL-1509: this pid passed every classification + name + identity gate
+    # and only the stop itself was refused (e.g. the HIMMEL-1508 Session-0
+    # elevation gap) - exactly the evidence the kill-ledger exists to carry.
+    $snapCreationIso = $null
+    if ($rec -and $rec.PSObject.Properties['CreationDate'] -and $null -ne $rec.CreationDate) {
+      try { $snapCreationIso = ([datetime]$rec.CreationDate).ToUniversalTime().ToString('o') } catch { $snapCreationIso = $null }
+    }
+    $failedToken = $null
+    if ($pidTokenMap.ContainsKey([string]$procId)) { $failedToken = $pidTokenMap[[string]$procId] }
+    [void]$ledgerFailed.Add([pscustomobject]@{ Pid = [int]$procId; Name = $curName; Creation = $snapCreationIso; Token = $failedToken })
   }
+}
+
+# HIMMEL-1509: append the verified-but-unstoppable pids to the kill-ledger and
+# retire (`consumed`) entries whose recorded process is confirmed gone.
+if ($ledgerFailed.Count -gt 0) {
+  try {
+    if (-not (Test-Path -LiteralPath $renderLeaseRegistry)) { [void](New-Item -ItemType Directory -Force -Path $renderLeaseRegistry) }
+    foreach ($f in $ledgerFailed) {
+      Add-KillLedgerLine -Path $killLedgerPath -Object ([ordered]@{
+        type = 'kill-failed'; ts = [datetime]::UtcNow.ToString('o')
+        token = $f.Token; pid = $f.Pid; name = $f.Name; creation = $f.Creation
+        reason = 'stop-failed'
+      })
+    }
+    Write-Host ("[sweep-codex-orphans] kill-ledger: appended {0} stop-failed entr(y/ies) to {1}" -f $ledgerFailed.Count, $killLedgerPath)
+  } catch {
+    Write-Warning "[sweep-codex-orphans] could not append to kill-ledger ($killLedgerPath): $_"
+  }
+}
+if (Test-Path -LiteralPath $killLedgerPath) {
+  try {
+    $ledgerRetired = 0
+    foreach ($entry in @(ConvertFrom-KillLedger -Lines @(Get-Content -LiteralPath $killLedgerPath -ErrorAction Stop))) {
+      $entryPid = 0
+      try { $entryPid = [int]$entry.pid } catch { continue }
+      if ($entryPid -le 0) { continue }
+      $entryGone = $false
+      try { [void](Get-Process -Id $entryPid -ErrorAction Stop) } catch { $entryGone = $true }
+      if ($entryGone) {
+        Add-KillLedgerLine -Path $killLedgerPath -Object ([ordered]@{ type = 'consumed'; ts = [datetime]::UtcNow.ToString('o'); pid = $entryPid; creation = $entry.creation; reason = 'gone' })
+        $ledgerRetired++
+      }
+    }
+    if ($ledgerRetired -gt 0) { Write-Host ("[sweep-codex-orphans] kill-ledger: consumed {0} resolved entr(y/ies)." -f $ledgerRetired) }
+  } catch {
+    Write-Warning "[sweep-codex-orphans] could not consume kill-ledger entries ($killLedgerPath): $_"
+  }
+}
+} finally {
+  if ($leaseLock) { Unlock-RenderLeaseRegistry -LockPath $leaseLock }
 }
 
 # Clean stale $env:TEMP\cxc-<token>\broker.pid files - ONLY for trees whose
@@ -590,8 +1585,8 @@ if ($tempRoot -and $sweptTokens.Count -gt 0 -and (Test-Path -LiteralPath $tempRo
 # candidate total stays as context so partial sweeps are visible at a glance.
 $reclaimedMB = 0
 if ($killedPids.Count -gt 0) { $reclaimedMB = Get-TreeWSMB -Pids ([int[]]$killedPids.ToArray()) }
-$sweepFailed = $flatPids.Count - $killed - $skippedGone - $skippedName - $skippedRecycled
-Write-Host ("[sweep-codex-orphans] {0} candidate tree(s): stopped {1} of {2} proc(s) ({3} name-skipped, {4} recycled-skipped, {5} already-gone, {6} stop-failed), removed {7} stale broker.pid file(s). ~{8} MB reclaimed (candidates totalled ~{9} MB)." `
-  -f $trees.Count, $killed, $flatPids.Count, $skippedName, $skippedRecycled, $skippedGone, $sweepFailed, $pidFilesRemoved, $reclaimedMB, $totalMB)
+$sweepFailed = $killFlatPids.Count - $killed - $skippedGone - $skippedName - $skippedRecycled
+Write-Host ("[sweep-codex-orphans] {0} candidate tree(s) ({1} lease-spared/deferred): stopped {2} of {3} proc(s) ({4} name-skipped, {5} recycled-skipped, {6} already-gone, {7} stop-failed), removed {8} stale broker.pid file(s). ~{9} MB reclaimed (candidates totalled ~{10} MB)." `
+  -f $trees.Count, $leaseExcludedTrees, $killed, $killFlatPids.Count, $skippedName, $skippedRecycled, $skippedGone, $sweepFailed, $pidFilesRemoved, $reclaimedMB, $totalMB)
 
 exit 0

--- a/scripts/cleanup/test-sweep-codex-orphans.ps1
+++ b/scripts/cleanup/test-sweep-codex-orphans.ps1
@@ -29,8 +29,10 @@ function RecT($procId, $parentId, $name, $cl, $created) {
 # Fixture command lines derive from the running user's profile dir (no literal
 # home paths in source - the propagation leak scan fail-closes on them).
 $UserHome = $env:USERPROFILE
-function BrokerLine($token) {
-  "node $UserHome\.claude\plugins\cache\openai-codex\codex\1.0.5\scripts\app-server-broker.mjs serve --endpoint pipe:\\.\pipe\cxc-$token-codex-app-server"
+function BrokerLine($token, $cwd = $null) {
+  $line = "node $UserHome\.claude\plugins\cache\openai-codex\codex\1.0.5\scripts\app-server-broker.mjs serve --endpoint pipe:\\.\pipe\cxc-$token-codex-app-server"
+  if ($cwd) { $line += " --cwd=`"$cwd`"" }
+  return $line
 }
 function ClientRef($token) {
   # Any outside client connects to the broker's named pipe; its command line
@@ -63,6 +65,22 @@ Check 'ChatGPT.exe plausible blind client' (Test-IsPlausibleCodexAppServerClient
 Check 'node.exe plausible blind client'    (Test-IsPlausibleCodexAppServerClient -Proc (Rec 2 0 'node.exe' 'anything'))
 Check 'bun.exe plausible blind client'     (Test-IsPlausibleCodexAppServerClient -Proc (Rec 2 0 'bun.exe' 'anything'))
 Check 'codex.exe NOT plausible outside client' (-not (Test-IsPlausibleCodexAppServerClient -Proc (Rec 2 0 'codex.exe' 'anything')))
+
+# --- Test 2b: Layer A outside-tree render defers the whole kill pass ---------
+Write-Host "Test 2b: outside-tree adversarial render deferral (HIMMEL-1474 Layer A)"
+$tRender = Get-Date '2026-08-02 01:00:00'
+$renderProcs = @(
+  (RecT 10 1  'node.exe' (BrokerLine 'render10') $tRender)
+  (RecT 11 10 'node.exe' 'node codex-companion.mjs adversarial-review --wait --base main' ($tRender.AddSeconds(1)))
+  (RecT 20 1  'node.exe' 'node codex-companion.mjs adversarial-review --wait --base main' ($tRender.AddSeconds(1)))
+  (RecT 21 1  'node.exe' 'node codex-companion.mjs adversarial-review --base main' ($tRender.AddSeconds(1)))
+)
+$outsideRenders = Get-OutsideCodexAdversarialRenderPids -Procs $renderProcs
+Check 'only outside-tree full render shape is returned' (($outsideRenders -join ',') -eq '20') "got=$($outsideRenders -join ',')"
+Check 'outside-tree render defers all kills' (Test-ShouldDeferCodexKill -OutsideRenderPids $outsideRenders)
+$noRenders = Get-OutsideCodexAdversarialRenderPids -Procs @( (Rec 30 1 'node.exe' 'node other.js') )
+Check 'no render leaves current kill behavior unchanged' (-not (Test-ShouldDeferCodexKill -OutsideRenderPids $noRenders))
+Check 'missing --wait is not render shape' (-not (Test-IsCodexAdversarialRender -Proc $renderProcs[3]))
 
 # --- Test 3: live/orphan classification on a synthetic table -----------------
 # The five guards the algorithm hinges on:
@@ -143,6 +161,100 @@ $narrowStaleProcs = @(
 )
 $narrowStaleOrphans = @((Get-CodexOrphanBrokers -Procs $narrowStaleProcs) | ForEach-Object { $_.BrokerPid })
 Check '1s-older stale-PPID client still proves broker live (strict verified ordering)' (-not ($narrowStaleOrphans -contains 680)) "got=$($narrowStaleOrphans -join ',')"
+
+# --- Test 3b: Layer B client leases protect only their attributed tree -------
+Write-Host "Test 3b: fresh pid+StartTime client leases (HIMMEL-1474 Layer B)"
+$leaseNow = [datetime]::Parse('2026-08-02T12:00:00Z').ToUniversalTime()
+$leaseStart = $leaseNow.AddMinutes(-2)
+$leaseProcs = @(
+  (RecT 1000 1 'node.exe' (BrokerLine 'lease-a' 'C:\repo-a') $leaseStart)
+  (RecT 2000 1 'node.exe' (BrokerLine 'lease-b' 'C:\repo-b') $leaseStart)
+  (RecT 1010 1 'node.exe' 'node codex-companion.mjs adversarial-review --wait --base main' $leaseStart)
+)
+$freshLease = [pscustomobject]@{
+  Token = 'lease-a'; ClientPid = 1010; ClientStartTime = $leaseStart.ToString('o')
+  Cwd = 'C:\repo-a'; Heartbeat = $leaseNow.AddMinutes(-1).ToString('o')
+}
+$freshLeaseOrphans = @((Get-CodexOrphanBrokers -Procs $leaseProcs -ClientLeases @($freshLease) -NowUtc $leaseNow) | ForEach-Object { $_.BrokerPid } | Sort-Object)
+Check 'fresh lease + live pid protects its tree' (-not ($freshLeaseOrphans -contains 1000)) "got=$($freshLeaseOrphans -join ',')"
+Check 'lease in one tree does not protect another' ($freshLeaseOrphans -contains 2000) "got=$($freshLeaseOrphans -join ',')"
+$leaseTreePids = Get-CodexBrokerTreePids -Procs $leaseProcs
+$unattributedFreshRenders = Get-UnattributedCodexAdversarialRenderPids -Procs $leaseProcs -BrokerTreePids $leaseTreePids -ClientLeases @($freshLease) -NowUtc $leaseNow
+Check 'fresh attributed render restores kill availability for other-cwd trees' (-not (Test-ShouldDeferCodexKill -OutsideRenderPids $unattributedFreshRenders))
+
+# HIMMEL-1474 r2 startup race: the writer leased an older same-cwd broker, then
+# a sibling broker appeared before the next heartbeat scan. The sibling remains
+# an orphan candidate, but Layer A must defer -Kill until its lease catches up.
+$raceProcs = @(
+  (RecT 3000 1 'node.exe' (BrokerLine 'lease-old' 'C:\repo-race') $leaseStart)
+  (RecT 3001 1 'node.exe' (BrokerLine 'lease-new' 'C:\repo-race') ($leaseStart.AddSeconds(30)))
+  (RecT 3010 1 'node.exe' 'node codex-companion.mjs adversarial-review --wait --base main' $leaseStart)
+)
+$raceLease = [pscustomobject]@{
+  Token = 'lease-old'; ClientPid = 3010; ClientStartTime = $leaseStart.ToString('o')
+  Cwd = 'C:\repo-race'; Heartbeat = $leaseNow.AddMinutes(-1).ToString('o')
+}
+$raceTreePids = Get-CodexBrokerTreePids -Procs $raceProcs
+$raceOrphans = @((Get-CodexOrphanBrokers -Procs $raceProcs -BrokerTreePids $raceTreePids -ClientLeases @($raceLease) -NowUtc $leaseNow) | ForEach-Object { $_.BrokerPid })
+$raceOutsideRenders = Get-UnattributedCodexAdversarialRenderPids -Procs $raceProcs -BrokerTreePids $raceTreePids -ClientLeases @($raceLease) -NowUtc $leaseNow
+Check 'new same-cwd broker remains unleased candidate' ($raceOrphans -contains 3001) "got=$($raceOrphans -join ',')"
+Check 'unleased same-cwd broker keeps Layer A deferral active' (Test-ShouldDeferCodexKill -OutsideRenderPids $raceOutsideRenders) "got=$($raceOutsideRenders -join ',')"
+
+# HIMMEL-1474 r3: an older explicitly-bound broker can be leased while a
+# sibling with no explicit cwd under the same render remains unattributable.
+# Unknown means unresolved, so Layer A must preserve the global safety defer.
+$unknownCwdProcs = @(
+  (RecT 3100 1 'node.exe' (BrokerLine 'lease-explicit' 'C:\repo-mixed') $leaseStart)
+  (RecT 3101 1 'node.exe' (BrokerLine 'lease-unknown') ($leaseStart.AddSeconds(30)))
+  (RecT 3110 1 'node.exe' 'node codex-companion.mjs adversarial-review --wait --base main' $leaseStart)
+)
+$unknownCwdLease = [pscustomobject]@{
+  Token = 'lease-explicit'; ClientPid = 3110; ClientStartTime = $leaseStart.ToString('o')
+  Cwd = 'C:\repo-mixed'; Heartbeat = $leaseNow.AddMinutes(-1).ToString('o')
+}
+$unknownCwdTreePids = Get-CodexBrokerTreePids -Procs $unknownCwdProcs
+$unknownCwdOrphans = @((Get-CodexOrphanBrokers -Procs $unknownCwdProcs -BrokerTreePids $unknownCwdTreePids -ClientLeases @($unknownCwdLease) -NowUtc $leaseNow) | ForEach-Object { $_.BrokerPid })
+$unknownCwdOutsideRenders = Get-UnattributedCodexAdversarialRenderPids -Procs $unknownCwdProcs -BrokerTreePids $unknownCwdTreePids -ClientLeases @($unknownCwdLease) -NowUtc $leaseNow
+Check 'missing-cwd broker remains unleased candidate' ($unknownCwdOrphans -contains 3101) "got=$($unknownCwdOrphans -join ',')"
+Check 'missing-cwd broker keeps Layer A deferral active' (Test-ShouldDeferCodexKill -OutsideRenderPids $unknownCwdOutsideRenders) "got=$($unknownCwdOutsideRenders -join ',')"
+
+$staleLease = $freshLease.PSObject.Copy()
+$staleLease.Heartbeat = $leaseNow.AddMinutes(-11).ToString('o')
+$staleLeaseOrphans = @((Get-CodexOrphanBrokers -Procs $leaseProcs -ClientLeases @($staleLease) -NowUtc $leaseNow) | ForEach-Object { $_.BrokerPid })
+Check 'stale lease older than TTL is ignored' ($staleLeaseOrphans -contains 1000) "got=$($staleLeaseOrphans -join ',')"
+$unattributedStaleRenders = Get-UnattributedCodexAdversarialRenderPids -Procs $leaseProcs -BrokerTreePids $leaseTreePids -ClientLeases @($staleLease) -NowUtc $leaseNow
+Check 'stale lease leaves Layer A global deferral active' (Test-ShouldDeferCodexKill -OutsideRenderPids $unattributedStaleRenders)
+
+$deadLease = $freshLease.PSObject.Copy()
+$deadLease.ClientPid = 9999
+$deadLeaseOrphans = @((Get-CodexOrphanBrokers -Procs $leaseProcs -ClientLeases @($deadLease) -NowUtc $leaseNow) | ForEach-Object { $_.BrokerPid })
+Check 'dead lease pid is ignored' ($deadLeaseOrphans -contains 1000) "got=$($deadLeaseOrphans -join ',')"
+
+$mismatchLease = $freshLease.PSObject.Copy()
+$mismatchLease.ClientStartTime = $leaseStart.AddMinutes(-5).ToString('o')
+$mismatchLeaseOrphans = @((Get-CodexOrphanBrokers -Procs $leaseProcs -ClientLeases @($mismatchLease) -NowUtc $leaseNow) | ForEach-Object { $_.BrokerPid })
+Check 'pid with mismatched StartTime is ignored' ($mismatchLeaseOrphans -contains 1000) "got=$($mismatchLeaseOrphans -join ',')"
+
+$wrongCwdLease = $freshLease.PSObject.Copy()
+$wrongCwdLease.Cwd = 'C:\repo-b'
+$wrongCwdLeaseOrphans = @((Get-CodexOrphanBrokers -Procs $leaseProcs -ClientLeases @($wrongCwdLease) -NowUtc $leaseNow) | ForEach-Object { $_.BrokerPid })
+Check 'cwd mismatch cannot attribute lease to token directory' ($wrongCwdLeaseOrphans -contains 1000) "got=$($wrongCwdLeaseOrphans -join ',')"
+
+# Filesystem seam: the token comes from the broker directory, never from JSON.
+$leaseTemp = Join-Path ([System.IO.Path]::GetTempPath()) ("himmel-1474-" + [guid]::NewGuid().ToString('N'))
+try {
+  $leaseDir = Join-Path $leaseTemp 'cxc-lease-a'
+  [void](New-Item -ItemType Directory -Path $leaseDir -Force)
+  $leaseJson = [ordered]@{
+    clientPid = 1010; clientStartTime = $leaseStart.ToString('o')
+    cwd = 'C:\repo-a'; heartbeat = $leaseNow.AddMinutes(-1).ToString('o')
+  } | ConvertTo-Json -Compress
+  Set-Content -LiteralPath (Join-Path $leaseDir 'client-lease-1010-test.json') -Value $leaseJson -Encoding UTF8
+  $loadedLeases = @(Get-CodexClientLeases -Procs $leaseProcs -TempRoot $leaseTemp)
+  Check 'filesystem lease reader binds directory token' ($loadedLeases.Count -eq 1 -and $loadedLeases[0].Token -eq 'lease-a') "count=$($loadedLeases.Count)"
+} finally {
+  Remove-Item -LiteralPath $leaseTemp -Recurse -Force -ErrorAction SilentlyContinue
+}
 
 # --- Test 4: orphan TREE composition (broker + descendants) ------------------
 Write-Host "Test 4: orphan tree = broker pid + full descendant walk"
@@ -304,6 +416,116 @@ Check 'production source: blindClients assignment is NOT @()-wrapped' `
   ($callerSrc -match '\$blindClients\s*=\s*Get-BlindClientPids' -and $callerSrc -notmatch '\$blindClients\s*=\s*@\(\s*Get-BlindClientPids') `
   'caller line regressed to the @() wrap'
 
+# --- Test 6e: pr-check uses one lease-aware launcher at both render sites ------
+Write-Host "Test 6e: pr-check launcher wiring (HIMMEL-1474 Layer B)"
+$RepoRoot = (Resolve-Path (Join-Path $ScriptDir '..\..')).Path
+$PrCheck = Join-Path $RepoRoot '.claude\commands\pr-check.md'
+$Runner = Join-Path $RepoRoot 'scripts\cr\run-codex-adversarial.sh'
+$LeaseWriter = Join-Path $RepoRoot 'scripts\cr\codex-render-client-lease.ps1'
+Check 'shared adversarial runner exists' (Test-Path -LiteralPath $Runner)
+Check 'PowerShell lease writer exists' (Test-Path -LiteralPath $LeaseWriter)
+$prCheckSrc = Get-Content -LiteralPath $PrCheck -Raw
+$runnerRefs = [regex]::Matches($prCheckSrc, 'bash scripts/cr/run-codex-adversarial\.sh').Count
+Check 'kickoff and retry both use shared runner' ($runnerRefs -eq 2) "got=$runnerRefs"
+$runnerSrc = Get-Content -LiteralPath $Runner -Raw
+Check 'runner starts client lease writer with translated client pid' `
+  ($runnerSrc -match 'codex-render-client-lease\.ps1' -and $runnerSrc -match '-ClientPid \"\$lease_client_pid\"')
+
+# --- Test 6f: execute the real writer and observe two heartbeats ---------------
+# Source-grep coverage missed the read-only `$PID` binder collision. This starts
+# a real node broker plus the real writer, then requires a write AND refresh so
+# the Layer B heartbeat path executes past identity binding (HIMMEL-1474 r2).
+Write-Host "Test 6f: lease writer executes and refreshes (HIMMEL-1474 r2)"
+$writerIsWindows = Test-OnWindows -IsWindowsValue (Get-Variable -Name IsWindows -ValueOnly -ErrorAction SilentlyContinue) -OsEnv $env:OS
+if (-not $writerIsWindows) {
+  Write-Host '  SKIP  lease writer execution test is Windows-only'
+} else {
+  $leaseToken = 'writer-r2-test'
+  $leaseTestDir = Join-Path ([string]$env:TEMP) "cxc-$leaseToken"
+  $brokerScript = Join-Path $leaseTestDir 'app-server-broker.mjs'
+  # HIMMEL-1509 r2 regression (glm-2 critical): -LeaseDir must survive the
+  # broker foreach. A local named $leaseDir case-insensitively CLOBBERED the
+  # param after the first token iteration, so the SECOND registry heartbeat
+  # landed in the cxc token dir and the registry lease starved past TTL.
+  # Running with >=1 broker token and requiring TWO registry heartbeats
+  # catches exactly that.
+  $registryLeaseDir = Join-Path ([string]$env:TEMP) ("h1509-r2-lease-" + [System.IO.Path]::GetRandomFileName())
+  $brokerProc = $null
+  $writerProc = $null
+  try {
+    [void](New-Item -ItemType Directory -Path $leaseTestDir -Force)
+    [void](New-Item -ItemType Directory -Path $registryLeaseDir -Force)
+    Set-Content -LiteralPath $brokerScript -Value 'setInterval(() => {}, 1000);' -Encoding UTF8
+    $nodePath = (Get-Command node -ErrorAction Stop).Source
+    $brokerArgs = "$brokerScript serve --endpoint `"pipe:\\.\pipe\cxc-$leaseToken-codex-app-server`" --cwd `"$RepoRoot`""
+    $brokerProc = Start-Process -FilePath $nodePath -ArgumentList $brokerArgs -WorkingDirectory $RepoRoot -NoNewWindow -PassThru
+    $writerArgs = "-NoProfile -ExecutionPolicy Bypass -File `"$LeaseWriter`" -ClientPid $PID -HeartbeatSeconds 1 -LeaseDir `"$registryLeaseDir`""
+    $writerProc = Start-Process -FilePath (Get-Process -Id $PID).Path -ArgumentList $writerArgs -WorkingDirectory $RepoRoot -NoNewWindow -PassThru
+
+    $leaseFile = $null
+    $writeDeadline = [datetime]::UtcNow.AddSeconds(10)
+    while (-not $leaseFile -and [datetime]::UtcNow -lt $writeDeadline) {
+      Start-Sleep -Milliseconds 250
+      $leaseFile = Get-ChildItem -LiteralPath $leaseTestDir -Filter 'client-lease-*.json' -File -ErrorAction SilentlyContinue | Select-Object -First 1
+    }
+    Check 'writer creates a lease file' ($null -ne $leaseFile)
+
+    $firstHeartbeat = $null
+    if ($leaseFile) {
+      try { $firstHeartbeat = (Get-Content -LiteralPath $leaseFile.FullName -Raw | ConvertFrom-Json).heartbeat } catch {}
+    }
+    $refreshedHeartbeat = $firstHeartbeat
+    $refreshDeadline = [datetime]::UtcNow.AddSeconds(10)
+    while ($firstHeartbeat -and $refreshedHeartbeat -eq $firstHeartbeat -and [datetime]::UtcNow -lt $refreshDeadline) {
+      Start-Sleep -Milliseconds 250
+      try { $refreshedHeartbeat = (Get-Content -LiteralPath $leaseFile.FullName -Raw | ConvertFrom-Json).heartbeat } catch {}
+    }
+    Check 'writer refreshes the heartbeat' ($firstHeartbeat -and $refreshedHeartbeat -ne $firstHeartbeat) "first=$firstHeartbeat refreshed=$refreshedHeartbeat"
+
+    # HIMMEL-1509 r2: BOTH iterations above wrote a cxc lease for the broker
+    # token, so with the $leaseDir collision the registry heartbeat would have
+    # stopped advancing after the first write. Require it to advance too.
+    $registryHbFile = Join-Path $registryLeaseDir 'heartbeat'
+    $firstRegistryHb = $null
+    $regDeadline = [datetime]::UtcNow.AddSeconds(10)
+    while (-not $firstRegistryHb -and [datetime]::UtcNow -lt $regDeadline) {
+      Start-Sleep -Milliseconds 250
+      try { $firstRegistryHb = [string](Get-Content -LiteralPath $registryHbFile -Raw -ErrorAction Stop) } catch {}
+    }
+    Check 'writer creates the registry heartbeat' ($null -ne $firstRegistryHb)
+    $refreshedRegistryHb = $firstRegistryHb
+    $regDeadline = [datetime]::UtcNow.AddSeconds(10)
+    while ($firstRegistryHb -and $refreshedRegistryHb -eq $firstRegistryHb -and [datetime]::UtcNow -lt $regDeadline) {
+      Start-Sleep -Milliseconds 250
+      try { $refreshedRegistryHb = [string](Get-Content -LiteralPath $registryHbFile -Raw -ErrorAction Stop) } catch {}
+    }
+    Check 'registry heartbeat advances across broker-token iterations (r2 collision)' `
+      ($firstRegistryHb -and $refreshedRegistryHb -ne $firstRegistryHb) "first=$firstRegistryHb refreshed=$refreshedRegistryHb"
+    $tokensFile = Join-Path $registryLeaseDir 'tokens'
+    $tokensContent = ''
+    try { $tokensContent = [string](Get-Content -LiteralPath $tokensFile -Raw -ErrorAction Stop) } catch {}
+    Check 'writer records the observed broker token on the lease' ($tokensContent -match [regex]::Escape($leaseToken)) "tokens=$tokensContent"
+    # And the registry writes must never leak into the cxc token dir (the
+    # collision's failure mode wrote `heartbeat`/`tokens` files there).
+    Check 'no registry files leak into the cxc token dir' `
+      (-not (Test-Path -LiteralPath (Join-Path $leaseTestDir 'heartbeat')) -and -not (Test-Path -LiteralPath (Join-Path $leaseTestDir 'tokens')))
+    # r9 codex-2: token protection ages out with reality - once the broker
+    # dies, the next EMPTY observation removes the tokens file instead of
+    # letting a stale token set keep protecting unrelated trees.
+    if ($brokerProc -and -not $brokerProc.HasExited) { Stop-Process -Id $brokerProc.Id -Force -ErrorAction SilentlyContinue }
+    $tokensGoneDeadline = [datetime]::UtcNow.AddSeconds(10)
+    while ((Test-Path -LiteralPath $tokensFile) -and [datetime]::UtcNow -lt $tokensGoneDeadline) {
+      Start-Sleep -Milliseconds 250
+    }
+    Check 'dead broker ages out the tokens file (r9)' (-not (Test-Path -LiteralPath $tokensFile))
+  } finally {
+    if ($writerProc -and -not $writerProc.HasExited) { Stop-Process -Id $writerProc.Id -Force -ErrorAction SilentlyContinue }
+    if ($brokerProc -and -not $brokerProc.HasExited) { Stop-Process -Id $brokerProc.Id -Force -ErrorAction SilentlyContinue }
+    Remove-Item -LiteralPath $leaseTestDir -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $registryLeaseDir -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
 # --- Test 7: malformed argv fails fast (no hang, no production execution) ----
 # PowerShell's parameter binder rejects unknown params / stray positionals
 # BEFORE the script body runs, so these never reach Get-CimInstance or any kill
@@ -349,6 +571,306 @@ Check 'undefined $IsWindows with a non-Windows OS env -> NOT Windows' `
   (-not (Test-OnWindows -IsWindowsValue $null -OsEnv 'Linux'))
 Check 'undefined $IsWindows with an EMPTY OS env -> NOT Windows (no blind assume)' `
   (-not (Test-OnWindows -IsWindowsValue $null -OsEnv ''))
+
+# --- Test 9: render-lease registry + kill-ledger (HIMMEL-1509) ---------------
+Write-Host "Test 9: render-lease dispositions, kill filtering, kill-ledger (HIMMEL-1509)"
+
+function LeaseRec($name, $worktree, $identity, $started, $heartbeat, $tokens, $unreadable) {
+  [pscustomobject]@{
+    Name = $name; Path = "X:\reg\$name"; Branch = $name; Worktree = $worktree
+    LeaderIdentity = $identity; StartedAt = $started; Heartbeat = $heartbeat
+    Tokens = $tokens; Unreadable = $unreadable
+  }
+}
+
+$nowUtc = [datetime]::SpecifyKind([datetime]'2026-08-03T12:00:00', [System.DateTimeKind]::Utc)
+$freshHb = '2026-08-03T11:55:00Z'
+$staleHb = '2026-08-03T10:00:00Z'
+$leaderStart = [datetime]::SpecifyKind([datetime]'2026-08-03T11:00:00', [System.DateTimeKind]::Utc)
+$leaderIdentity = "win:900:$($leaderStart.Ticks)"
+
+# Slug parity with render-lease.sh (r6 codex-2): identical +HH byte encoding,
+# same expected literals as test-render-lease.sh, so the twins can never
+# drift apart silently; the map is injective (aliasing branches diverge).
+Check 'slug: slash encodes to +2F'       ((Get-RenderLeaseSlug -Branch 'feat/himmel-1509-x') -ceq 'feat+2Fhimmel-1509-x')
+Check 'slug: literal plus escapes to +2B' ((Get-RenderLeaseSlug -Branch 'feat/a+b') -ceq 'feat+2Fa+2Bb')
+Check 'slug: aliasing branches stay distinct' ((Get-RenderLeaseSlug -Branch 'feat/a/b') -ceq 'feat+2Fa+2Fb')
+Check 'slug: hostile chars hex-encode per byte' ((Get-RenderLeaseSlug -Branch 'a b!c') -ceq 'a+20b+21c')
+Check 'slug: deterministic' ((Get-RenderLeaseSlug -Branch 'feat/a+b') -ceq (Get-RenderLeaseSlug -Branch 'feat/a+b'))
+
+# Identity-string parsing.
+$parts = Get-RenderLeaseIdentityParts -Identity 'win:123:456'
+Check 'win identity parses pid'    ($parts.WinPid -eq 123)
+Check 'win identity parses ticks'  ($parts.StartTicks -eq 456)
+Check 'posix identity -> $null'    ($null -eq (Get-RenderLeaseIdentityParts -Identity 'posix:Mon Aug 3 bash'))
+Check 'empty identity -> $null'    ($null -eq (Get-RenderLeaseIdentityParts -Identity ''))
+
+# lease.record parsing.
+$map = ConvertFrom-RenderLeaseRecord -Lines @("branch`tfeat/x", "worktree`tC:\repo\wt", 'garbage-no-tab', "status`trunning")
+Check 'record parses branch'   ($map['branch'] -eq 'feat/x')
+Check 'record parses worktree' ($map['worktree'] -eq 'C:\repo\wt')
+Check 'record skips tabless garbage' (-not $map.ContainsKey('garbage-no-tab'))
+
+# Heartbeat freshness (sparing gate: future skew reads FRESH, never a kill).
+Check 'fresh heartbeat is fresh'    (Test-RenderLeaseHeartbeatFresh -HeartbeatText $freshHb -NowUtc $nowUtc)
+Check 'stale heartbeat is not'      (-not (Test-RenderLeaseHeartbeatFresh -HeartbeatText $staleHb -NowUtc $nowUtc))
+Check 'future heartbeat reads fresh' (Test-RenderLeaseHeartbeatFresh -HeartbeatText '2026-08-03T12:30:00Z' -NowUtc $nowUtc)
+Check 'garbage heartbeat is not fresh' (-not (Test-RenderLeaseHeartbeatFresh -HeartbeatText 'not-a-time' -NowUtc $nowUtc))
+
+# Dispositions against a snapshot carrying the recorded leader.
+$leaseProcs = @(
+  (RecT 900 1 'node.exe' 'node codex-companion.mjs adversarial-review --wait --base main' $leaderStart)
+  (RecT 901 1 'node.exe' 'node other.js' ($leaderStart.AddSeconds(100)))
+  (Rec  902 1 'node.exe' 'node no-creation.js')
+)
+Check 'unreadable lease -> unverifiable' `
+  ((Get-RenderLeaseDisposition -Lease (LeaseRec 'l1' 'C:\repo\wtA' $leaderIdentity $staleHb $staleHb @() $true) -Procs $leaseProcs -NowUtc $nowUtc) -eq 'unverifiable')
+Check 'fresh heartbeat -> live' `
+  ((Get-RenderLeaseDisposition -Lease (LeaseRec 'l2' 'C:\repo\wtA' $leaderIdentity $staleHb $freshHb @() $false) -Procs $leaseProcs -NowUtc $nowUtc) -eq 'live')
+Check 'stale heartbeat + creation-matched leader -> live' `
+  ((Get-RenderLeaseDisposition -Lease (LeaseRec 'l3' 'C:\repo\wtA' $leaderIdentity $staleHb $staleHb @() $false) -Procs $leaseProcs -NowUtc $nowUtc) -eq 'live')
+Check 'stale heartbeat + absent leader -> stale' `
+  ((Get-RenderLeaseDisposition -Lease (LeaseRec 'l4' 'C:\repo\wtA' 'win:999:1' $staleHb $staleHb @() $false) -Procs $leaseProcs -NowUtc $nowUtc) -eq 'stale')
+Check 'stale heartbeat + recycled leader pid -> stale' `
+  ((Get-RenderLeaseDisposition -Lease (LeaseRec 'l5' 'C:\repo\wtA' "win:901:$($leaderStart.Ticks)" $staleHb $staleHb @() $false) -Procs $leaseProcs -NowUtc $nowUtc) -eq 'stale')
+Check 'leader without snapshot creation -> unverifiable' `
+  ((Get-RenderLeaseDisposition -Lease (LeaseRec 'l6' 'C:\repo\wtA' "win:902:$($leaderStart.Ticks)" $staleHb $staleHb @() $false) -Procs $leaseProcs -NowUtc $nowUtc) -eq 'unverifiable')
+Check 'leaderless record + fresh started_at -> live' `
+  ((Get-RenderLeaseDisposition -Lease (LeaseRec 'l7' 'C:\repo\wtA' '' $freshHb $null @() $false) -Procs $leaseProcs -NowUtc $nowUtc) -eq 'live')
+Check 'leaderless record + stale started_at -> unverifiable' `
+  ((Get-RenderLeaseDisposition -Lease (LeaseRec 'l8' 'C:\repo\wtA' '' $staleHb $null @() $false) -Procs $leaseProcs -NowUtc $nowUtc) -eq 'unverifiable')
+# r6 codex-1: a lease BOUND AFTER the snapshot has a leader the snapshot
+# cannot contain - absence (or a pre-launch recycled pid) plus a FRESH record
+# is live, not stale.
+Check 'post-snapshot leader (absent) + fresh started_at -> live' `
+  ((Get-RenderLeaseDisposition -Lease (LeaseRec 'l9' 'C:\repo\wtA' 'win:555:1' $freshHb $staleHb @() $false) -Procs $leaseProcs -NowUtc $nowUtc) -eq 'live')
+Check 'post-snapshot leader (recycled snapshot pid) + fresh started_at -> live' `
+  ((Get-RenderLeaseDisposition -Lease (LeaseRec 'l10' 'C:\repo\wtA' "win:901:$($leaderStart.Ticks)" $freshHb $staleHb @() $false) -Procs $leaseProcs -NowUtc $nowUtc) -eq 'live')
+
+# Kill filtering over classified orphan trees: three orphan brokers, one per
+# shape (leased cwd, other cwd, unresolvable cwd).
+$tKill = Get-Date '2026-08-03 01:00:00'
+$killProcs = @(
+  (RecT 700 1 'node.exe' (BrokerLine 'tokA' 'C:\repo\wtA') $tKill)
+  (RecT 710 1 'node.exe' (BrokerLine 'tokB' 'C:\repo\wtB') ($tKill.AddSeconds(1)))
+  (RecT 720 1 'node.exe' (BrokerLine 'tokC') ($tKill.AddSeconds(2)))
+)
+$killTrees = @(Get-CodexOrphanTrees -Procs $killProcs)
+Check 'kill fixture classifies three orphans' ($killTrees.Count -eq 3) "got=$($killTrees.Count)"
+
+function ActionFor($actions, $token) {
+  foreach ($a in @($actions)) { if ($a.Tree.Token -eq $token) { return "$($a.Action):$($a.Reason)" } }
+  return '(missing)'
+}
+
+$noLease = @(Select-RenderLeaseKillActions -Trees $killTrees -Dispositions @() -Procs $killProcs)
+Check 'no leases: every tree stays killable' ((@($noLease | Where-Object { $_.Action -eq 'kill' })).Count -eq 3)
+
+$dispLiveA = @(Get-RenderLeaseDispositions -Leases @((LeaseRec 'feat+a' 'C:\repo\wtA' $leaderIdentity $staleHb $freshHb @() $false)) -Procs $killProcs -NowUtc $nowUtc)
+$actLiveA = @(Select-RenderLeaseKillActions -Trees $killTrees -Dispositions $dispLiveA -Procs $killProcs)
+Check 'live lease spares its cwd tree'          ((ActionFor $actLiveA 'tokA') -eq 'spared:live-lease-cwd') "got=$(ActionFor $actLiveA 'tokA')"
+Check 'live lease leaves other cwd killable'    ((ActionFor $actLiveA 'tokB') -eq 'kill:')
+Check 'cwd-less broker defers under any lease'  ((ActionFor $actLiveA 'tokC') -eq 'deferred:unresolvable-broker-cwd')
+
+$dispToken = @(Get-RenderLeaseDispositions -Leases @((LeaseRec 'feat+x' 'C:\repo\wtX' $leaderIdentity $staleHb $freshHb @('tokB') $false)) -Procs $killProcs -NowUtc $nowUtc)
+$actToken = @(Select-RenderLeaseKillActions -Trees $killTrees -Dispositions $dispToken -Procs $killProcs)
+Check 'recorded token spares its tree regardless of cwd' ((ActionFor $actToken 'tokB') -eq 'spared:live-lease-token')
+Check 'token spare leaves unrelated cwd killable'        ((ActionFor $actToken 'tokA') -eq 'kill:')
+
+$dispUnvB = @(Get-RenderLeaseDispositions -Leases @((LeaseRec 'feat+b' 'C:\repo\wtB' $leaderIdentity $staleHb $staleHb @() $true)) -Procs $killProcs -NowUtc $nowUtc)
+$actUnvB = @(Select-RenderLeaseKillActions -Trees $killTrees -Dispositions $dispUnvB -Procs $killProcs)
+Check 'unverifiable lease defers its cwd tree'   ((ActionFor $actUnvB 'tokB') -eq 'deferred:unverifiable-lease-cwd')
+Check 'unverifiable lease leaves other cwd killable' ((ActionFor $actUnvB 'tokA') -eq 'kill:')
+
+$dispUnvGlobal = @(Get-RenderLeaseDispositions -Leases @((LeaseRec 'feat+g' $null $leaderIdentity $staleHb $staleHb @() $true)) -Procs $killProcs -NowUtc $nowUtc)
+$actUnvGlobal = @(Select-RenderLeaseKillActions -Trees $killTrees -Dispositions $dispUnvGlobal -Procs $killProcs)
+Check 'worktree-less unverifiable lease defers everything' ((@($actUnvGlobal | Where-Object { $_.Action -eq 'deferred' })).Count -eq 3)
+
+$dispStale = @(Get-RenderLeaseDispositions -Leases @((LeaseRec 'feat+s' 'C:\repo\wtA' 'win:999:1' $staleHb $staleHb @() $false)) -Procs $killProcs -NowUtc $nowUtc)
+$actStale = @(Select-RenderLeaseKillActions -Trees $killTrees -Dispositions $dispStale -Procs $killProcs)
+Check 'confirmed-stale lease leaves its cwd killable' ((ActionFor $actStale 'tokA') -eq 'kill:')
+
+# Kill-ledger parsing: consumed records retire by pid+creation; malformed
+# lines and unknown types are skipped.
+$c1 = '2026-08-03T09:00:00.0000000Z'
+$c2 = '2026-08-03T09:05:00.0000000Z'
+$ledgerLines = @(
+  ('{"type":"kill-failed","ts":"x","token":"tokA","pid":100,"name":"node","creation":"' + $c1 + '","reason":"stop-failed"}')
+  ('{"type":"kill-failed","ts":"x","token":"tokB","pid":101,"name":"node","creation":"' + $c2 + '","reason":"stop-failed"}')
+  ('{"type":"consumed","ts":"x","pid":100,"creation":"' + $c1 + '","reason":"swept"}')
+  'not json at all'
+  '{"type":"mystery","pid":5}'
+)
+$unconsumed = @(ConvertFrom-KillLedger -Lines $ledgerLines)
+Check 'ledger returns only unconsumed entries' ($unconsumed.Count -eq 1) "got=$($unconsumed.Count)"
+Check 'ledger keeps the unresolved pid'        ([int]$unconsumed[0].pid -eq 101)
+Check 'empty ledger parses to empty'           ((@(ConvertFrom-KillLedger -Lines @())).Count -eq 0)
+
+# Ledger entry vs live process: strict identity, fail-closed on any gap.
+$entry = $unconsumed[0]
+$entryCreationUtc = ([datetimeoffset]::Parse($c2)).UtcDateTime
+Check 'creation-matched allow-listed live -> match' `
+  ((Get-KillLedgerEntryLiveState -Entry $entry -LiveName 'node' -LiveStart $entryCreationUtc) -eq 'match')
+Check 'creation mismatch -> recycled' `
+  ((Get-KillLedgerEntryLiveState -Entry $entry -LiveName 'node' -LiveStart $entryCreationUtc.AddSeconds(100)) -eq 'recycled')
+Check 'missing live start -> unverifiable' `
+  ((Get-KillLedgerEntryLiveState -Entry $entry -LiveName 'node' -LiveStart $null) -eq 'unverifiable')
+Check 'disallowed live name -> unverifiable' `
+  ((Get-KillLedgerEntryLiveState -Entry $entry -LiveName 'explorer' -LiveStart $entryCreationUtc) -eq 'unverifiable')
+$noCreation = [pscustomobject]@{ type = 'kill-failed'; pid = 102; name = 'node' }
+Check 'entry without creation -> unverifiable' `
+  ((Get-KillLedgerEntryLiveState -Entry $noCreation -LiveName 'node' -LiveStart $entryCreationUtc) -eq 'unverifiable')
+
+# Replay guard (r2 codex-1): -FromLedger protection must match the main pass,
+# not just recorded tokens - a TOKENLESS live lease still protects its
+# worktree's brokers, and ambiguity fails closed.
+$guardNone = Get-RenderLeaseReplayGuard -Dispositions @() -Procs $killProcs
+Check 'replay guard: no leases -> no signal, nothing protected' `
+  (-not $guardNone.AnySignal -and -not $guardNone.ProtectAll -and $guardNone.Tokens.Count -eq 0)
+$dispTokenlessLive = @(Get-RenderLeaseDispositions -Leases @((LeaseRec 'feat+a' 'C:\repo\wtA' $leaderIdentity $staleHb $freshHb @() $false)) -Procs $killProcs -NowUtc $nowUtc)
+$guardTokenless = Get-RenderLeaseReplayGuard -Dispositions $dispTokenlessLive -Procs $killProcs
+Check 'replay guard: tokenless live lease protects its cwd broker token' `
+  ($guardTokenless.Tokens.Contains('tokA'))
+Check 'replay guard: tokenless live lease protects ambiguous cwd-less broker' `
+  ($guardTokenless.Tokens.Contains('tokC'))
+Check 'replay guard: tokenless live lease leaves other cwd token killable' `
+  (-not $guardTokenless.Tokens.Contains('tokB') -and -not $guardTokenless.ProtectAll -and $guardTokenless.AnySignal)
+$dispRecordedTok = @(Get-RenderLeaseDispositions -Leases @((LeaseRec 'feat+x' 'C:\repo\wtX' $leaderIdentity $staleHb $freshHb @('tokB') $false)) -Procs $killProcs -NowUtc $nowUtc)
+$guardRecorded = Get-RenderLeaseReplayGuard -Dispositions $dispRecordedTok -Procs $killProcs
+Check 'replay guard: recorded lease tokens stay protected' ($guardRecorded.Tokens.Contains('tokB'))
+$dispStaleOnly = @(Get-RenderLeaseDispositions -Leases @((LeaseRec 'feat+s' 'C:\repo\wtA' 'win:999:1' $staleHb $staleHb @() $false)) -Procs $killProcs -NowUtc $nowUtc)
+$guardStale = Get-RenderLeaseReplayGuard -Dispositions $dispStaleOnly -Procs $killProcs
+Check 'replay guard: confirmed-stale lease protects nothing' `
+  (-not $guardStale.AnySignal -and $guardStale.Tokens.Count -eq 0)
+$dispNoWorktree = @(Get-RenderLeaseDispositions -Leases @((LeaseRec 'feat+g' $null $leaderIdentity $staleHb $staleHb @() $true)) -Procs $killProcs -NowUtc $nowUtc)
+$guardNoWorktree = Get-RenderLeaseReplayGuard -Dispositions $dispNoWorktree -Procs $killProcs
+Check 'replay guard: worktree-less unverifiable lease protects everything' ($guardNoWorktree.ProtectAll)
+
+# TTL parity with the launcher (r3 glm-4): RENDER_LEASE_TTL_SECS resolves to
+# the sweep's freshness window; a heartbeat past the 10-min default but
+# inside a raised env TTL must stay LIVE.
+Check 'ttl resolver: unset -> 10min default'    ((Get-RenderLeaseTtlMinutes -EnvValue '') -eq 10)
+Check 'ttl resolver: 1800s -> 30min'            ((Get-RenderLeaseTtlMinutes -EnvValue '1800') -eq 30)
+Check 'ttl resolver: 90s rounds UP to 2min'     ((Get-RenderLeaseTtlMinutes -EnvValue '90') -eq 2)
+Check 'ttl resolver: garbage -> default'        ((Get-RenderLeaseTtlMinutes -EnvValue 'abc') -eq 10)
+Check 'ttl resolver: zero -> default'           ((Get-RenderLeaseTtlMinutes -EnvValue '0') -eq 10)
+$agedHb = '2026-08-03T11:40:00Z'   # 20 min before $nowUtc
+$agedLease = LeaseRec 'feat+aged' 'C:\repo\wtA' 'win:999:1' $agedHb $agedHb @() $false
+Check 'aged heartbeat under default TTL falls through (leader gone -> stale)' `
+  ((Get-RenderLeaseDisposition -Lease $agedLease -Procs $killProcs -NowUtc $nowUtc -TtlMinutes 10) -eq 'stale')
+Check 'aged heartbeat inside a raised env TTL stays live' `
+  ((Get-RenderLeaseDisposition -Lease $agedLease -Procs $killProcs -NowUtc $nowUtc -TtlMinutes (Get-RenderLeaseTtlMinutes -EnvValue '1800')) -eq 'live')
+
+# Unconditional lock (r3 codex-1): a registry ABSENT at sweep start is
+# created + locked, and a lease landing mid-pass is seen by the locked
+# re-read and spares its tree - "missing registry" never skips the lock.
+$lateReg = Join-Path ([System.IO.Path]::GetTempPath()) ("himmel-1509-late-" + [System.IO.Path]::GetRandomFileName())
+$lateLock = $null
+try {
+  [void](New-Item -ItemType Directory -Force -Path $lateReg)
+  $lateLock = Lock-RenderLeaseRegistry -RegistryPath $lateReg
+  Check 'unconditional lock acquires on a just-created empty registry' ($null -ne $lateLock)
+  $lateLease = Join-Path $lateReg 'feat+late'
+  [void](New-Item -ItemType Directory -Force -Path $lateLease)
+  Set-Content -LiteralPath (Join-Path $lateLease 'lease.record') -Value @("branch`tfeat/late", "worktree`tC:\repo\wtA", "leader_identity`t$leaderIdentity", "started_at`t$freshHb", "status`trunning")
+  Set-Content -LiteralPath (Join-Path $lateLease 'heartbeat') -Value $freshHb -NoNewline
+  $lateReads = @(Get-RenderLeaseRecords -RegistryPath $lateReg)
+  Check 'locked re-read sees the mid-pass lease' ($lateReads.Count -eq 1) "got=$($lateReads.Count)"
+  $lateDisp = @(Get-RenderLeaseDispositions -Leases $lateReads -Procs $killProcs -NowUtc $nowUtc)
+  $lateActions = @(Select-RenderLeaseKillActions -Trees $killTrees -Dispositions $lateDisp -Procs $killProcs)
+  Check 'mid-pass lease spares its tree under the lock' ((ActionFor $lateActions 'tokA') -eq 'spared:live-lease-cwd') "got=$(ActionFor $lateActions 'tokA')"
+} finally {
+  Remove-Item -LiteralPath $lateReg -Recurse -Force -ErrorAction SilentlyContinue
+}
+# Registry-lock stale-break disposition (r4 codex-1): a verified-live
+# same-space owner is NEVER broken (age included); a confirmed-dead owner
+# breaks immediately; cross-space keeps the age break.
+$lockReg = Join-Path ([System.IO.Path]::GetTempPath()) ("himmel-1509-lock-" + [System.IO.Path]::GetRandomFileName())
+try {
+  [void](New-Item -ItemType Directory -Force -Path $lockReg)
+  $lockDir = Join-Path $lockReg '.registry.lock'
+  [void](New-Item -ItemType Directory -Force -Path $lockDir)
+  Set-Content -LiteralPath (Join-Path $lockDir 'owner.pid') -Value "win:$PID"
+  (Get-Item -LiteralPath $lockDir -Force).CreationTimeUtc = [datetime]'2020-01-01'
+  $lockTry = Lock-RenderLeaseRegistry -RegistryPath $lockReg -Attempts 2 -DelayMs 10
+  Check 'aged lock with verified-live owner is never age-broken' ($null -eq $lockTry)
+  Check 'verified-live owner keeps its lock through contention' (Test-Path -LiteralPath $lockDir)
+  Set-Content -LiteralPath (Join-Path $lockDir 'owner.pid') -Value 'win:999999999'
+  (Get-Item -LiteralPath $lockDir -Force).CreationTimeUtc = [datetime]::UtcNow
+  $lockTry = Lock-RenderLeaseRegistry -RegistryPath $lockReg -Attempts 2 -DelayMs 10
+  Check 'young lock with confirmed-dead owner breaks immediately' ($null -ne $lockTry)
+  Remove-Item -LiteralPath $lockDir -Recurse -Force -ErrorAction SilentlyContinue
+  [void](New-Item -ItemType Directory -Force -Path $lockDir)
+  Set-Content -LiteralPath (Join-Path $lockDir 'owner.pid') -Value 'msys:123'
+  $lockTry = Lock-RenderLeaseRegistry -RegistryPath $lockReg -Attempts 2 -DelayMs 10
+  Check 'fresh cross-space owner is not broken' ($null -eq $lockTry)
+  (Get-Item -LiteralPath $lockDir -Force).CreationTimeUtc = [datetime]'2020-01-01'
+  $lockTry = Lock-RenderLeaseRegistry -RegistryPath $lockReg -Attempts 2 -DelayMs 10
+  Check 'aged cross-space owner is age-broken' ($null -ne $lockTry)
+  # Lock-stale env parity (r5 glm-2): RENDER_LEASE_LOCK_STALE_SECS resolves
+  # through the same conversion as the TTL knob, and a cross-space lock aged
+  # past the 10-min default but inside a raised env threshold is NOT broken.
+  Check 'lock-stale resolver: unset -> 10min default' ((Get-RenderLeaseLockStaleMinutes -EnvValue '') -eq 10)
+  Check 'lock-stale resolver: 1800s -> 30min'         ((Get-RenderLeaseLockStaleMinutes -EnvValue '1800') -eq 30)
+  Remove-Item -LiteralPath $lockDir -Recurse -Force -ErrorAction SilentlyContinue
+  [void](New-Item -ItemType Directory -Force -Path $lockDir)
+  Set-Content -LiteralPath (Join-Path $lockDir 'owner.pid') -Value 'msys:123'
+  (Get-Item -LiteralPath $lockDir -Force).CreationTimeUtc = [datetime]::UtcNow.AddMinutes(-20)
+  $lockTry = Lock-RenderLeaseRegistry -RegistryPath $lockReg -Attempts 2 -DelayMs 10 -StaleMinutes (Get-RenderLeaseLockStaleMinutes -EnvValue '1800')
+  Check '20min-aged cross-space lock survives a raised env threshold' ($null -eq $lockTry)
+  Check 'raised-threshold contention leaves the lock intact' (Test-Path -LiteralPath $lockDir)
+  $lockTry = Lock-RenderLeaseRegistry -RegistryPath $lockReg -Attempts 2 -DelayMs 10 -StaleMinutes (Get-RenderLeaseLockStaleMinutes -EnvValue '')
+  Check '20min-aged cross-space lock breaks under the default threshold' ($null -ne $lockTry)
+  # r7 codex-1: owner-verified release - a broken-then-superseded holder must
+  # never delete a successor's lock.
+  Remove-Item -LiteralPath $lockDir -Recurse -Force -ErrorAction SilentlyContinue
+  [void](New-Item -ItemType Directory -Force -Path $lockDir)
+  Set-Content -LiteralPath (Join-Path $lockDir 'owner.pid') -Value 'msys:123'
+  Unlock-RenderLeaseRegistry -LockPath $lockDir
+  Check 'unlock leaves a successor-owned lock intact' (Test-Path -LiteralPath $lockDir)
+  Set-Content -LiteralPath (Join-Path $lockDir 'owner.pid') -Value "win:$PID"
+  Unlock-RenderLeaseRegistry -LockPath $lockDir
+  Check 'unlock removes this process''s own lock' (-not (Test-Path -LiteralPath $lockDir))
+} finally {
+  Remove-Item -LiteralPath $lockReg -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$helperSource = Get-Content -LiteralPath $Helper -Raw
+Check 'both kill paths create the registry before locking' `
+  (([regex]::Matches($helperSource, [regex]::Escape('reason=registry-unusable'))).Count -eq 2)
+Check 'both production releases are owner-verified (r7)' `
+  (([regex]::Matches($helperSource, [regex]::Escape('Unlock-RenderLeaseRegistry -LockPath $leaseLock'))).Count -eq 2)
+Check 'FromLedger lock is no longer gated on registry existence' `
+  (-not ($helperSource -match '\$Kill\s+-and\s+\(Test-Path\s+-LiteralPath\s+\$renderLeaseRegistry\)'))
+Check 'main kill lock is no longer gated on registry existence' `
+  (-not ($helperSource -match 'Test-Path[^\r\n]*renderLeaseRegistry[^\r\n]*\{\s*\r?\n\s*\$leaseLock\s*=\s*Lock-'))
+
+# Registry IO reader: readable lease, unreadable lease, dotted dirs skipped.
+$regRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("himmel-1509-reg-" + [System.IO.Path]::GetRandomFileName())
+try {
+  $goodDir = Join-Path $regRoot 'feat+good'
+  [void](New-Item -ItemType Directory -Force -Path $goodDir)
+  Set-Content -LiteralPath (Join-Path $goodDir 'lease.record') -Value @("branch`tfeat/good", "worktree`tC:\repo\wtA", "leader_identity`t$leaderIdentity", "started_at`t$staleHb", "status`trunning")
+  Set-Content -LiteralPath (Join-Path $goodDir 'heartbeat') -Value $freshHb -NoNewline
+  Set-Content -LiteralPath (Join-Path $goodDir 'tokens') -Value @('tokA', 'tokB')
+  $badDir = Join-Path $regRoot 'feat+bad'
+  [void](New-Item -ItemType Directory -Force -Path $badDir)
+  [void](New-Item -ItemType Directory -Force -Path (Join-Path $regRoot '.registry.lock'))
+  $reads = @(Get-RenderLeaseRecords -RegistryPath $regRoot)
+  Check 'registry reader returns both leases, skips dotted dirs' ($reads.Count -eq 2) "got=$($reads.Count)"
+  $good = @($reads | Where-Object { $_.Name -eq 'feat+good' })[0]
+  $bad = @($reads | Where-Object { $_.Name -eq 'feat+bad' })[0]
+  Check 'readable lease carries branch'    ($good.Branch -eq 'feat/good')
+  Check 'readable lease carries worktree'  ($good.Worktree -eq 'C:\repo\wtA')
+  Check 'readable lease carries heartbeat' (([string]$good.Heartbeat).Trim() -eq $freshHb)
+  Check 'readable lease carries tokens'    ((@($good.Tokens) -join ',') -eq 'tokA,tokB')
+  Check 'recordless lease reads unreadable' ($bad.Unreadable)
+  Check 'unreadable lease disposes unverifiable' `
+    ((Get-RenderLeaseDisposition -Lease $bad -Procs $killProcs -NowUtc $nowUtc) -eq 'unverifiable')
+  Check 'absent registry reads empty' ((@(Get-RenderLeaseRecords -RegistryPath (Join-Path $regRoot 'nope'))).Count -eq 0)
+} finally {
+  Remove-Item -LiteralPath $regRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
 
 Write-Host "Results: $Pass passed, $Fail failed"
 if ($Fail -ne 0) { exit 1 }

--- a/scripts/cr/codex-render-client-lease.ps1
+++ b/scripts/cr/codex-render-client-lease.ps1
@@ -1,0 +1,148 @@
+# codex-render-client-lease.ps1 (HIMMEL-1474) - publish a short-lived client
+# lease while a pr-check codex adversarial render is alive. The sweep validates
+# every field independently; this writer is best-effort and fail-open.
+# HIMMEL-1509: when -LeaseDir names a render-lease registry entry (see
+# scripts/lib/render-lease.sh), each heartbeat iteration also refreshes that
+# lease's `heartbeat` file and records the cxc tokens observed for the render's
+# cwd in its `tokens` file - the sweep's strongest liveness signal, independent
+# of command-line visibility. Still best-effort: registry writes never affect
+# the cxc client-lease loop.
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)][int]$ClientPid,
+  [int]$HeartbeatSeconds = 60,
+  [string]$LeaseDir
+)
+
+$ErrorActionPreference = 'Stop'
+if ($HeartbeatSeconds -le 0) { exit 0 }
+$isWindowsHost = if (Get-Variable -Name IsWindows -ErrorAction SilentlyContinue) { [bool]$IsWindows } else { $env:OS -eq 'Windows_NT' }
+if (-not $isWindowsHost) { exit 0 }
+
+function Get-BrokerToken {
+  param([string]$CommandLine)
+  if ($CommandLine -match 'cxc-(\S+?)-codex-app-server') { return $Matches[1] }
+  return $null
+}
+
+function Get-BrokerCwd {
+  param([string]$CommandLine)
+  if ($CommandLine -match '(?:^|\s)--cwd[ =](?:"([^"]+)"|(\S+))') {
+    if ($Matches[1]) { return $Matches[1] }
+    return $Matches[2]
+  }
+  return $null
+}
+
+function Get-NormalizedPath {
+  param([string]$Path)
+  if (-not $Path) { return $null }
+  try { return [System.IO.Path]::GetFullPath($Path).TrimEnd([char[]]@('\','/')) } catch { return $null }
+}
+
+# `$PID` is a read-only automatic variable: the identity helper must never bind
+# that name or the heartbeat dies before its first write (HIMMEL-1474 r2).
+function Test-ClientIdentity {
+  param([int]$ClientProcessId, [datetime]$ExpectedStartUtc)
+  try {
+    $proc = Get-Process -Id $ClientProcessId -ErrorAction Stop
+    return ([math]::Abs(($proc.StartTime.ToUniversalTime() - $ExpectedStartUtc).TotalSeconds) -le 2)
+  } catch { return $false }
+}
+
+try {
+  $client = Get-Process -Id $ClientPid -ErrorAction Stop
+  $clientStartUtc = $client.StartTime.ToUniversalTime()
+  $clientStartText = $clientStartUtc.ToString('o')
+  $cwd = Get-NormalizedPath -Path ([string](Get-Location).ProviderPath)
+  if (-not $cwd) { exit 0 }
+} catch { exit 0 }
+
+$tempRoot = [string]$env:TEMP
+if (-not $tempRoot) { exit 0 }
+$leaseName = 'client-lease-{0}-{1}.json' -f $ClientPid, $clientStartUtc.Ticks
+$writtenPaths = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
+
+try {
+  while (Test-ClientIdentity -ClientProcessId $ClientPid -ExpectedStartUtc $clientStartUtc) {
+    $heartbeat = [datetime]::UtcNow.ToString('o')
+    # HIMMEL-1509: refresh the registry lease heartbeat FIRST, before the
+    # broker scan can fail - a live render must stay provably live even while
+    # its broker is not yet up or WMI is unavailable. Atomic tmp+move; the
+    # Test-Path guard never resurrects a released lease dir.
+    if ($LeaseDir -and (Test-Path -LiteralPath $LeaseDir)) {
+      $registryHbPath = Join-Path $LeaseDir 'heartbeat'
+      $registryHbTmp = "$registryHbPath.tmp-$PID"
+      try {
+        Set-Content -LiteralPath $registryHbTmp -Value $heartbeat -Encoding UTF8 -NoNewline
+        Move-Item -LiteralPath $registryHbTmp -Destination $registryHbPath -Force
+      } catch {
+        Remove-Item -LiteralPath $registryHbTmp -Force -ErrorAction SilentlyContinue
+      }
+    }
+    $leaseTokens = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
+    $brokers = @()
+    try {
+      $brokers = @(Get-CimInstance Win32_Process -ErrorAction Stop | Where-Object {
+        $_.Name -ieq 'node.exe' -and [string]$_.CommandLine -match 'app-server-broker\.mjs\s+serve'
+      })
+    } catch { $brokers = @() }
+
+    foreach ($broker in $brokers) {
+      $commandLine = [string]$broker.CommandLine
+      $token = Get-BrokerToken -CommandLine $commandLine
+      $brokerCwd = Get-NormalizedPath -Path (Get-BrokerCwd -CommandLine $commandLine)
+      if (-not $token -or $token -notmatch '^[A-Za-z0-9_-]+$') { continue }
+      if (-not [string]::Equals($cwd, $brokerCwd, [System.StringComparison]::OrdinalIgnoreCase)) { continue }
+      [void]$leaseTokens.Add($token)
+
+      # $tokenLeaseDir, NOT $leaseDir: PowerShell names are case-insensitive,
+      # so a local named $leaseDir would CLOBBER the -LeaseDir registry param
+      # after the first iteration and starve the registry heartbeat into the
+      # cxc token dir (HIMMEL-1509 r2 critical).
+      $tokenLeaseDir = Join-Path $tempRoot "cxc-$token"
+      if (-not (Test-Path -LiteralPath $tokenLeaseDir)) { continue }
+      $leasePath = Join-Path $tokenLeaseDir $leaseName
+      $tempPath = "$leasePath.tmp-$PID"
+      $payload = [ordered]@{
+        clientPid       = $ClientPid
+        clientStartTime = $clientStartText
+        cwd             = $cwd
+        heartbeat       = $heartbeat
+      } | ConvertTo-Json -Compress
+      try {
+        Set-Content -LiteralPath $tempPath -Value $payload -Encoding UTF8 -NoNewline
+        Move-Item -LiteralPath $tempPath -Destination $leasePath -Force
+        [void]$writtenPaths.Add($leasePath)
+      } catch {
+        Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue
+      }
+    }
+    # HIMMEL-1509 r9 (codex-2): the tokens file tracks EVERY observation, not
+    # just non-empty ones - a stale token set must never outlive its broker
+    # and keep protecting unrelated orphan trees. An empty scan removes the
+    # file, degrading token protection to the sweep's cwd-matching fallback
+    # (which follows reality), never to a dead broker's recorded token.
+    if ($LeaseDir -and (Test-Path -LiteralPath $LeaseDir)) {
+      $tokensPath = Join-Path $LeaseDir 'tokens'
+      if ($leaseTokens.Count -gt 0) {
+        $tokensTmp = "$tokensPath.tmp-$PID"
+        try {
+          Set-Content -LiteralPath $tokensTmp -Value (@($leaseTokens) -join "`n") -Encoding UTF8
+          Move-Item -LiteralPath $tokensTmp -Destination $tokensPath -Force
+        } catch {
+          Remove-Item -LiteralPath $tokensTmp -Force -ErrorAction SilentlyContinue
+        }
+      } else {
+        Remove-Item -LiteralPath $tokensPath -Force -ErrorAction SilentlyContinue
+      }
+    }
+    Start-Sleep -Seconds $HeartbeatSeconds
+  }
+} finally {
+  foreach ($leasePath in $writtenPaths) {
+    Remove-Item -LiteralPath $leasePath -Force -ErrorAction SilentlyContinue
+  }
+}
+
+exit 0

--- a/scripts/cr/critic-panel.sh
+++ b/scripts/cr/critic-panel.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 # scripts/cr/critic-panel.sh — run the free-cloud critic panel over a diff (HIMMEL-415).
-# Reads a unified diff on stdin, runs each registry critic in the CRITIC_PANEL_TIERS
-# set (default free) via critic-first-pass.sh, merges findings (global renumber, per-model slug IDs).
+# Reads a unified diff on stdin, or computes main...HEAD itself with
+# --worktree <path>, then runs each registry critic in the CRITIC_PANEL_TIERS set
+# (default free) via critic-first-pass.sh and merges findings (global renumber,
+# per-model slug IDs). The panel appends its own availability + raw-finding rows
+# to the CR ledger before it exits.
 # Stdout = merged findings block. Stderr = panel-availability lines.
-# Exit 0 = >=1 responded; 1 = all failed (caller -> claude-only). Bash 3.2-safe.
+# Exit 0 = >=1 responded; 1 = all failed (caller -> claude-only); 2 = usage;
+# 3 = invalid --worktree; 4 = --worktree diff is empty; 5 = git/ledger failure.
+# Bash 3.2-safe.
 # Env: CR_PROFILE — the operator's opt-in critic profile (from repo-root .env,
 #      exported by /pr-check). AUTHORITATIVE when set (HIMMEL-558): the panel
 #      derives its tier filter from it directly, so an agent running /pr-check
@@ -69,6 +74,21 @@ export LC_ALL
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CFP="${CRITIC_FIRST_PASS:-$SCRIPT_DIR/critic-first-pass.sh}"
 INVOKE="${CRITIC_INVOKE:-$SCRIPT_DIR/../hermes/invoke.sh}"
+LEDGER_APPEND="${CRITIC_LEDGER_APPEND:-$SCRIPT_DIR/ledger-append.sh}"
+
+usage() {
+    cat >&2 <<'USAGE'
+usage: critic-panel.sh [--worktree <path>] [--check [--all-tiers]]
+  stdin                    review the unified diff read from stdin (back-compat)
+  --worktree <path>        review `git -C <path> diff <base>...HEAD` (sanctioned)
+                           <base> = CR_BASE_BRANCH env, else the remote's default
+                           branch (refs/remotes/origin/HEAD), else main
+  --check [--all-tiers]    probe registry health without reviewing a diff
+exit 3: --worktree path is not a git worktree
+exit 4: --worktree <base>...HEAD diff is empty (review refused)
+exit 5: git metadata, diff computation, or CR-ledger persistence failed
+USAGE
+}
 
 # failure-classify.sh (HIMMEL-1176): sole owner of the quota-exhaustion
 # signature table (is_quota_exhaustion, ex-HIMMEL-729 _is_quota_exhaustion)
@@ -324,6 +344,7 @@ fi
 
 CHECK_MODE="0"
 CHECK_ALL_TIERS="0"
+WORKTREE=""
 while [ $# -gt 0 ]; do
     case "$1" in
         --check)
@@ -334,12 +355,28 @@ while [ $# -gt 0 ]; do
             CHECK_ALL_TIERS="1"
             shift
             ;;
+        --worktree)
+            if [ $# -lt 2 ] || [ -z "$2" ]; then
+                echo "critic-panel.sh: --worktree requires a path" >&2
+                usage
+                exit 2
+            fi
+            WORKTREE="$2"
+            shift 2
+            ;;
         *)
             echo "critic-panel.sh: unknown option $1" >&2
+            usage
             exit 2
             ;;
     esac
 done
+
+if [ "$CHECK_MODE" = "1" ] && [ -n "$WORKTREE" ]; then
+    echo "critic-panel.sh: --worktree cannot be combined with --check" >&2
+    usage
+    exit 2
+fi
 
 if [ "$CHECK_MODE" = "1" ]; then
     # Parse registry for a health probe: emit "slug<TAB>model<TAB>tier" for every row.
@@ -393,8 +430,123 @@ CHECKROWSEOF
     exit 0
 fi
 
-# Read diff from stdin and store it
-diff_in="$(cat)"
+# Resolve the reviewed repository + exact head before running any critic. The
+# --worktree path owns both the diff and the ledger location, so a stale caller
+# cwd cannot silently review/stamp a different checkout. Stdin mode deliberately
+# keeps its historical cwd-based repository context for back-compat.
+if [ -n "$WORKTREE" ]; then
+    _inside="$(git -C "$WORKTREE" rev-parse --is-inside-work-tree 2>/dev/null)" || _inside=""
+    if [ "$_inside" != "true" ]; then
+        echo "critic-panel.sh: --worktree path is not a git worktree: $WORKTREE" >&2
+        exit 3
+    fi
+    REVIEW_ROOT="$(git -C "$WORKTREE" rev-parse --show-toplevel 2>/dev/null)" || REVIEW_ROOT=""
+    if [ -z "$REVIEW_ROOT" ]; then
+        echo "critic-panel.sh: cannot resolve worktree root for: $WORKTREE" >&2
+        exit 3
+    fi
+    # Resolve the base branch instead of hardcoding `main` (HIMMEL-1494): a repo
+    # whose default branch is master/other always hit the empty-diff / diff-failed
+    # exits below. Order: an explicit CR_BASE_BRANCH override -> the remote's
+    # default branch (symbolic-ref of refs/remotes/origin/HEAD, with the
+    # refs/remotes/origin/ prefix stripped) -> main. The resolved name flows into
+    # the diff and every diagnostic so a non-main default branch works.
+    _base="${CR_BASE_BRANCH:-}"
+    _base_via_origin=0
+    if [ -z "$_base" ]; then
+        _oh="$(git -C "$REVIEW_ROOT" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null)" || _oh=""
+        case "$_oh" in
+            refs/remotes/origin/*) _base="${_oh#refs/remotes/origin/}"; _base_via_origin=1 ;;
+        esac
+        [ -n "$_base" ] || _base="main"
+    fi
+    # Re-resolve the bare name to a ref git can actually diff (HIMMEL-1494 r3).
+    # A clone or worktree that carries only origin/<name> (and never checked
+    # <name> out locally) fails on a bare name. An explicit CR_BASE_BRANCH
+    # override is honored VERBATIM (documented). Otherwise: prefer the bare LOCAL
+    # name when it verifies; else, for an origin/HEAD resolution, fall back to
+    # the REMOTE origin/<name> the symbolic-ref guaranteed exists. If neither
+    # verifies _base stays bare so the diff still fails loudly with the resolved
+    # name (preserving the documented exit-5 diagnostic).
+    # r4: verify refs/heads/<name> explicitly. A bare --verify <name> also
+    # matches a TAG named like the default branch, which then falsely satisfied
+    # this check and suppressed the origin/<name> fallback; qualifying the LOCAL
+    # branch ref means only a real branch satisfies it (HIMMEL-1494 r4).
+    if [ -z "${CR_BASE_BRANCH:-}" ]; then
+        if ! git -C "$REVIEW_ROOT" rev-parse --verify "refs/heads/$_base" >/dev/null 2>&1; then
+            if [ "$_base_via_origin" -eq 1 ]; then
+                _base="origin/$_base"
+            fi
+        fi
+    fi
+    # Capture the reviewed head ONCE (HIMMEL-1494 r4) and reuse it for BOTH the
+    # diff and the ledger stamp: a separate `git rev-parse HEAD` at stamp time
+    # could resolve a different commit if a concurrent commit lands between the
+    # two invocations, certifying a head that does not match the reviewed diff.
+    # The diagnostics still read "<base>...HEAD" (the operator-visible intent);
+    # $_head is that same HEAD, snapshotted here.
+    _head="$(git -C "$REVIEW_ROOT" rev-parse HEAD 2>/dev/null)" || _head=""
+    diff_in="$(git -C "$REVIEW_ROOT" diff "$_base...$_head")"
+    _diff_rc=$?
+    if [ "$_diff_rc" -ne 0 ]; then
+        echo "critic-panel.sh: git diff $_base...HEAD failed in $REVIEW_ROOT (rc=$_diff_rc)" >&2
+        exit 5
+    fi
+    if [ -z "$diff_in" ]; then
+        echo "critic-panel.sh: REFUSING empty --worktree diff (git -C $REVIEW_ROOT diff $_base...HEAD produced no output)" >&2
+        exit 4
+    fi
+else
+    diff_in="$(cat)"
+    REVIEW_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || REVIEW_ROOT=""
+    # Capture the head once for stamping coherence (HIMMEL-1494 r4): the stdin
+    # diff is not HEAD-derived, but REVIEW_HEAD must still name the exact commit
+    # under review, snapshotted here rather than re-resolved at stamp time.
+    _head=""
+    if [ -n "$REVIEW_ROOT" ]; then
+        _head="$(git -C "$REVIEW_ROOT" rev-parse HEAD 2>/dev/null)" || _head=""
+    fi
+    if [ -z "$REVIEW_ROOT" ]; then
+        # Back-compat (HIMMEL-1494): the stdin path used to work anywhere; it
+        # only needs a worktree to STAMP ledger rows. Run the review anyway,
+        # skip the self-append, and warn loudly. Review output and the exit code
+        # behave exactly as pre-change. _SKIP_LEDGER gates every ledger step
+        # below (head/branch resolution, ledger path, the final append).
+        echo "critic-panel.sh: stdin review outside a git worktree — CR-ledger self-append skipped" >&2
+        _SKIP_LEDGER=1
+        REVIEW_HEAD=""
+        REVIEW_BRANCH=""
+    fi
+fi
+
+# Ledger stamping needs a worktree; the stdin-outside-worktree path skips all
+# of it (HIMMEL-1494). REVIEW_HEAD/REVIEW_BRANCH/PANEL_LEDGER stay unset and the
+# final _append_panel_ledger call is gated on the same flag below.
+if [ "${_SKIP_LEDGER:-0}" != "1" ]; then
+    REVIEW_HEAD="$_head"
+    REVIEW_BRANCH="$(git -C "$REVIEW_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)" || REVIEW_BRANCH=""
+    if [ -z "$REVIEW_HEAD" ] || [ -z "$REVIEW_BRANCH" ]; then
+        echo "critic-panel.sh: cannot resolve reviewed head/branch in $REVIEW_ROOT" >&2
+        exit 5
+    fi
+    if [ -n "${CR_LEDGER:-}" ]; then
+        PANEL_LEDGER="$CR_LEDGER"
+    else
+        _common_dir="$(git -C "$REVIEW_ROOT" rev-parse --git-common-dir 2>/dev/null)" || _common_dir=""
+        if [ -z "$_common_dir" ]; then
+            echo "critic-panel.sh: cannot resolve git common dir for ledger in $REVIEW_ROOT" >&2
+            exit 5
+        fi
+        case "$_common_dir" in
+            /*|[A-Za-z]:/*) PANEL_LEDGER="$_common_dir/cr-critic-scores.jsonl" ;;
+            *) PANEL_LEDGER="$REVIEW_ROOT/$_common_dir/cr-critic-scores.jsonl" ;;
+        esac
+    fi
+    if [ ! -r "$LEDGER_APPEND" ]; then
+        echo "critic-panel.sh: ledger append helper is not readable: $LEDGER_APPEND" >&2
+        exit 5
+    fi
+fi
 
 # Triviality gate (HIMMEL-737): a diff classified 'trivial' skips the PAID tier
 # to save codex spend. Only fires when 'paid' is in the effective tier filter
@@ -548,7 +700,21 @@ tmp="$(mktemp -t critic-panel.XXXXXX)"
 _seq_out=""
 _seq_err=""
 outdir=""
-trap 'rm -f "$tmp"; [ -n "$_seq_out" ] && rm -f "$_seq_out"; [ -n "${_seq_err:-}" ] && rm -f "$_seq_err"; [ -n "$outdir" ] && rm -rf "$outdir"; [ -n "$_MERGED_REG" ] && rm -f "$_MERGED_REG"' EXIT
+# Ledger evidence spool (HIMMEL-1494 r3; per-member r4): subshell-safe
+# replacement for the old parent-scope STRING accumulators. The parallel path
+# runs each member's critic in a background subshell; if process_member is ever
+# moved into that subshell, parent-scope string accumulation would be silently
+# lost (a subshell forks a copy-on-write snapshot of the vars). Appending to
+# FILES instead survives the member boundary in BOTH sequential and parallel
+# modes, and _append_panel_ledger reads them at the end.
+# r4: ONE spool file PER MEMBER (avail.<slug> / finding.<slug>), not a single
+# shared file. A single-printf O_APPEND row is atomic-ish on POSIX but NOT
+# guaranteed on Windows/MSYS, so no two members ever append to the same file.
+# Each member writes only its own file (a member is processed once, so its own
+# file is never written concurrently); _append_panel_ledger globs them all, and
+# bash sorts pathname expansion so the read order is deterministic.
+PANEL_SPOOL_DIR="$(mktemp -d -t critic-panel-spool.XXXXXX)"
+trap 'rm -f "$tmp"; [ -n "$_seq_out" ] && rm -f "$_seq_out"; [ -n "${_seq_err:-}" ] && rm -f "$_seq_err"; [ -n "$outdir" ] && rm -rf "$outdir"; [ -n "${PANEL_SPOOL_DIR:-}" ] && rm -rf "$PANEL_SPOOL_DIR"; [ -n "$_MERGED_REG" ] && rm -f "$_MERGED_REG"' EXIT
 printf '%s' "$diff_in" > "$tmp"
 
 # Run each panel member; collect per-member output and renumber globally.
@@ -561,6 +727,67 @@ global_id=0
 agg_crit=""
 agg_imp=""
 agg_sug=""
+
+# Ledger accumulators live in per-member spool files under PANEL_SPOOL_DIR
+# (created above with $tmp — subshell-safe file spools, HIMMEL-1494 r3; one file
+# per member r4). Keep availability and findings structured rather than reparsing
+# stderr/stdout: availability has intermediate fallback-failed diagnostics that
+# are NOT terminal member outcomes, while findings must preserve the exact
+# reviewed head even if the orchestrator later commits a fix before judging them.
+
+_queue_avail() {
+    # Subshell-safe + per-member (HIMMEL-1494 r3/r4): append the row to THIS
+    # member's own avail spool file, not a parent-scope string or a shared file.
+    # A file append persists across a background-subshell member boundary (a
+    # string mutation would not); per-member files mean no shared-file concurrent
+    # append. $1 is the member slug (a registry kebab-case identifier, filesystem-
+    # safe); _append_panel_ledger globs avail.* at the end.
+    printf '%s\034%s\034%s\034%s\034%s\n' "$1" "$2" "${3:-}" "${4:-}" "${5:-}" \
+        >> "$PANEL_SPOOL_DIR/avail.$1"
+}
+
+_queue_finding() {
+    # Subshell-safe + per-member + symmetric set -u safety (HIMMEL-1494 r3/r4):
+    # see _queue_avail. The ${n:-} defaults mirror _queue_avail so a bare
+    # positional under set -u can never abort the append.
+    printf '%s\034%s\034%s\034%s\034%s\n' "$1" "$2" "${3:-}" "${4:-}" "${5:-}" \
+        >> "$PANEL_SPOOL_DIR/finding.$1"
+}
+
+_append_panel_ledger() {
+    _apl_failed=0
+    # Glob the per-member spool files (HIMMEL-1494 r4): bash sorts pathname
+    # expansion, so the read order is deterministic. [ -f ] guards the no-match
+    # case (a finding.* glob with no findings would otherwise be a literal
+    # pattern). set -- inside the loop reassigns positionals; the for-loop
+    # iterates a named var, so it is unaffected.
+    for _apl_spool in "$PANEL_SPOOL_DIR"/avail.*; do
+        [ -f "$_apl_spool" ] || continue
+        while IFS=$'\034' read -r _apl_model _apl_status _apl_responding _apl_reason _apl_detail; do
+            [ -n "$_apl_model" ] || continue
+            set -- avail --branch "$REVIEW_BRANCH" --head "$REVIEW_HEAD" \
+                --model "$_apl_model" --status "$_apl_status"
+            [ -n "$_apl_responding" ] && set -- "$@" --responding-model "$_apl_responding"
+            [ -n "$_apl_reason" ] && set -- "$@" --reason "$_apl_reason"
+            [ -n "$_apl_detail" ] && set -- "$@" --detail "$_apl_detail"
+            CR_LEDGER="$PANEL_LEDGER" bash "$LEDGER_APPEND" "$@" || _apl_failed=1
+        done < "$_apl_spool"
+    done
+
+    for _apl_spool in "$PANEL_SPOOL_DIR"/finding.*; do
+        [ -f "$_apl_spool" ] || continue
+        while IFS=$'\034' read -r _apl_model _apl_id _apl_severity _apl_file _apl_line; do
+            [ -n "$_apl_id" ] || continue
+            CR_LEDGER="$PANEL_LEDGER" bash "$LEDGER_APPEND" finding \
+                --branch "$REVIEW_BRANCH" --head "$REVIEW_HEAD" \
+                --model "$_apl_model" --id "$_apl_id" \
+                --severity "$_apl_severity" --file "$_apl_file" \
+                --line "$_apl_line" --verdict "" || _apl_failed=1
+        done < "$_apl_spool"
+    done
+
+    [ "$_apl_failed" -eq 0 ]
+}
 
 # ---------------------------------------------------------------------------
 # _is_quota_exhaustion <out_file> <err_file> (HIMMEL-729)
@@ -667,6 +894,7 @@ process_member() {
     else
         _pm_avail="panel-availability: $_pm_slug ok"
     fi
+    _pm_responding_model="$_pm_model"
     _fb_out=""
     _fb_err=""
 
@@ -699,6 +927,7 @@ process_member() {
 
     if [ "$_pm_is_timeout" -eq 1 ] && [ "$_pm_do_fallback" -eq 0 ]; then
         echo "panel-availability: $_pm_slug unavailable (timeout ${_pm_timeout}s) reason=timeout" >&2
+        _queue_avail "$_pm_slug" unavailable "" timeout ""
         return
     fi
     if [ "$_pm_rc" -ne 0 ]; then
@@ -750,6 +979,7 @@ process_member() {
                         echo "WARN critic-panel: $_pm_slug failed (rc=$_pm_rc) - fell back to $_fb_model" >&2
                     fi
                     _pm_avail="panel-availability: $_pm_slug fallback($_fb_model)"
+                    _pm_responding_model="$_fb_model"
                     _pm_out_file="$_fb_out"
                     _fb_success=1
                     break
@@ -776,16 +1006,19 @@ process_member() {
                 else
                     echo "panel-availability: $_pm_slug unavailable (rc=$_pm_rc) reason=$_pm_reason detail=fallback-chain exhausted" >&2
                 fi
+                _queue_avail "$_pm_slug" unavailable "" "$_pm_reason" "fallback-chain exhausted"
                 return
             fi
         else
             _pm_reason="$(classify_failure "$_pm_rc" "$_pm_out_file" "$_pm_err_file" 2>/dev/null)"
             [ -n "$_pm_reason" ] || _pm_reason="generic-rc-$_pm_rc"
             echo "panel-availability: $_pm_slug unavailable (rc=$_pm_rc) reason=$_pm_reason" >&2
+            _queue_avail "$_pm_slug" unavailable "" "$_pm_reason" ""
             return
         fi
     fi
     echo "$_pm_avail" >&2
+    _queue_avail "$_pm_slug" ok "$_pm_responding_model" "" ""
     responded=$((responded + 1))
 
     # Parse the member output sections and renumber bullets globally.
@@ -816,12 +1049,31 @@ process_member() {
                 max_id++
                 b = $0
                 # Renumber: replace the ID with slug-max_id
+                id = slug "-" max_id
                 if (b ~ /^- \[[^]]*\]:/) {
-                    sub(/^- \[[^]]*\]:/, "- [" slug "-" max_id "]:", b)
+                    sub(/^- \[[^]]*\]:/, "- [" id "]:", b)
                 } else {
-                    sub(/^- /, "- [" slug "-" max_id "]: ", b)
+                    sub(/^- /, "- [" id "]: ", b)
                 }
-                print sec "\t" b
+                loc = b
+                sub(/^.*\[/, "", loc)
+                sub(/\]$/, "", loc)
+                # A finding citation is a TRAILING "[file:line]" (the merged
+                # output bullet contract). When none is present the last bracket
+                # is the ID "[slug-K]" (no colon, and the bullet does not end
+                # with "]"), so loc carries finding text, not a path:line token.
+                # Emit empty file/line then (HIMMEL-1494): the ledger absent-
+                # value convention (file:""/line:""), not the malformed values
+                # the old unguarded parse produced from the ID bracket.
+                file = ""
+                line = ""
+                if (b ~ /\]$/ && loc ~ /:[0-9]+$/) {
+                    file = loc
+                    sub(/:[^:]*$/, "", file)
+                    line = loc
+                    sub(/^.*:/, "", line)
+                }
+                print sec "\t" b "\t" id "\t" file "\t" line
             }
             next
         }
@@ -835,6 +1087,19 @@ process_member() {
     if [ -n "$max_used" ] && [ "$max_used" -gt "$global_id" ] 2>/dev/null; then
         global_id=$max_used
     fi
+
+    while IFS=$'\t' read -r _pf_sec _pf_bullet _pf_id _pf_file _pf_line; do
+        [ -n "$_pf_id" ] || continue
+        case "$_pf_sec" in
+            1) _pf_severity="crit" ;;
+            2) _pf_severity="imp" ;;
+            3) _pf_severity="sug" ;;
+            *) continue ;;
+        esac
+        _queue_finding "$_pm_slug" "$_pf_id" "$_pf_severity" "$_pf_file" "$_pf_line"
+    done << PARSEDFINDINGSEOF
+$member_parsed
+PARSEDFINDINGSEOF
 
     # Accumulate by section
     crit_bullets="$(printf '%s\n' "$member_parsed" | awk -F'\t' '$1=="1"{print $2}')"
@@ -887,9 +1152,11 @@ if [ "$CRITIC_PARALLEL" = "0" ]; then
         if _panel_deadline_passed; then
             echo "critic-panel.sh: TOTAL panel deadline ${CRITIC_PANEL_TOTAL_TIMEOUT_SECS}s exceeded after ${total} member(s) — skipping the rest (raise CRITIC_PANEL_TOTAL_TIMEOUT_SECS)" >&2
             echo "panel-availability: $slug unavailable (panel-deadline) reason=panel-deadline" >&2
+            _queue_avail "$slug" unavailable "" panel-deadline ""
             while IFS="	" read -r _s _rest; do
                 [ -n "$_s" ] || continue
                 echo "panel-availability: $_s unavailable (panel-deadline) reason=panel-deadline" >&2
+                _queue_avail "$_s" unavailable "" panel-deadline ""
             done
             break
         fi
@@ -956,9 +1223,11 @@ else
         if _panel_deadline_passed; then
             echo "critic-panel.sh: TOTAL panel deadline ${CRITIC_PANEL_TOTAL_TIMEOUT_SECS}s exceeded after launching ${i} member(s) — not launching the rest (raise CRITIC_PANEL_TOTAL_TIMEOUT_SECS)" >&2
             echo "panel-availability: $slug unavailable (panel-deadline) reason=panel-deadline" >&2
+            _queue_avail "$slug" unavailable "" panel-deadline ""
             while IFS="	" read -r _s _rest; do
                 [ -n "$_s" ] || continue
                 echo "panel-availability: $_s unavailable (panel-deadline) reason=panel-deadline" >&2
+                _queue_avail "$_s" unavailable "" panel-deadline ""
             done
             break
         fi
@@ -1060,6 +1329,16 @@ printf '## Important Issues (%d found)\n' "$ni"
 printf '\n'
 printf '## Suggestions (%d found)\n' "$ns"
 [ -n "$agg_sug" ] && printf '%s\n' "$agg_sug"
+
+# The stdin-outside-worktree path skips certification (HIMMEL-1494): the review
+# was emitted, but with no worktree there is nothing to stamp, so a failed (or
+# skipped) append never overrides the review's own exit code.
+if [ "${_SKIP_LEDGER:-0}" != "1" ]; then
+    if ! _append_panel_ledger; then
+        echo "critic-panel.sh: CR-ledger append failed; review output was emitted but this run is NOT certified" >&2
+        exit 5
+    fi
+fi
 
 [ "$responded" -ge 1 ] || exit 1
 exit 0

--- a/scripts/cr/run-codex-adversarial.sh
+++ b/scripts/cr/run-codex-adversarial.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# run-codex-adversarial.sh (HIMMEL-1474) - launch the companion with an actual
+# node pid, start its Windows client-lease heartbeat, and optionally bound it.
+# Exit 125 means launch ownership could not be established or a successful
+# companion left process-group cleanup unverified; companion failures and the
+# timeout rc 124 keep their original status. Exit 75 means the branch launch
+# claim was REFUSED (HIMMEL-1509): when RENDER_LEASE_BRANCH is set in the
+# environment, this launcher acquires the per-branch render lease from the
+# scripts/lib/render-lease.sh registry before spawning node - a live or
+# unverifiable lease on the branch, lock contention, or an unusable registry
+# all refuse the launch instead of racing (fail-closed; closes the
+# HIMMEL-1496 same-branch TOCTOU). The lease is released ONLY when cleanup
+# verifies clean (cleanup rc 0); every other exit leaves the lease for the
+# sweep/orchestrator to adjudicate.
+set -u
+
+if [ "$#" -lt 4 ] || [ "$#" -gt 7 ]; then
+    echo "usage: run-codex-adversarial.sh <companion> <base> <stdout> <stderr> [pid-file] [timeout-seconds] [cleanup-rc-file]" >&2
+    exit 2
+fi
+
+companion=$1
+base=$2
+stdout_file=$3
+stderr_file=$4
+pid_file=${5:-}
+timeout_secs=${6:-0}
+cleanup_rc_file=${7:-}
+[ -n "$cleanup_rc_file" ] || cleanup_rc_file="${stdout_file}.cleanup-rc"
+case "$timeout_secs" in ''|*[!0-9]*) timeout_secs=0 ;; esac
+rm -f "$cleanup_rc_file"
+
+self_dir=$(cd "$(dirname "$0")" && pwd)
+lease_script="$self_dir/codex-render-client-lease.ps1"
+# shellcheck source=../lib/proc-tree.sh
+# shellcheck disable=SC1091
+. "$self_dir/../lib/proc-tree.sh"
+# shellcheck source=../lib/render-lease.sh
+# shellcheck disable=SC1091
+. "$self_dir/../lib/render-lease.sh"
+
+# HIMMEL-1509 launch claim: opt-in via RENDER_LEASE_BRANCH (pr-check exports
+# it). Acquired BEFORE node exists so two same-branch kickoffs race no further
+# than one atomic mkdir; released only from publish_cleanup_rc's verified-clean
+# path below.
+render_lease_branch=${RENDER_LEASE_BRANCH:-}
+lease_held=0
+if [ -n "$render_lease_branch" ]; then
+    launch_cwd=$(pwd)
+    if command -v cygpath >/dev/null 2>&1; then
+        launch_cwd=$(cygpath -m "$launch_cwd")
+    fi
+    claim_rc=0
+    render_lease_claim "$render_lease_branch" "$launch_cwd" || claim_rc=$?
+    if [ "$claim_rc" -ne 0 ]; then
+        echo "codex adversarial launch REFUSED: render lease for branch '$render_lease_branch' unavailable (claim rc=$claim_rc; registry $(render_lease_registry_dir)) - a live render owns this branch, the registry lock is contended, or the registry is unusable (HIMMEL-1509); no process was launched" >&2
+        exit 75
+    fi
+    lease_held=1
+fi
+
+node_pid=''
+node_identity=''
+ownership_published=0
+identity_file=''
+identity_tmp=''
+pid_tmp=''
+survivors_file=''
+survivors_tmp=''
+if [ -n "$pid_file" ]; then
+    identity_file="${pid_file}.identity"
+    identity_tmp="${identity_file}.tmp.$$"
+    pid_tmp="${pid_file}.tmp.$$"
+    survivors_file="${pid_file}.survivors"
+    survivors_tmp="${survivors_file}.tmp.$$"
+    rm -f "$pid_file" "$identity_file" "$identity_tmp" "$pid_tmp" "$survivors_file" "$survivors_tmp"
+fi
+
+publish_survivors() {
+    local members='' member member_identity snapshot_unverified=0
+    [ -n "$survivors_file" ] || return 0
+    : > "$survivors_tmp" || return 1
+    members=$(proc_tree_group_members "$node_pid") || snapshot_unverified=1
+    for member in $members; do
+        member_identity=$(proc_tree_process_identity "$member") || member_identity=''
+        if [ -z "$member_identity" ] || ! proc_tree_process_identity_matches "$member" "$member_identity"; then
+            snapshot_unverified=1
+            break
+        fi
+        if ! printf '%s\t%s\n' "$member" "$member_identity" >> "$survivors_tmp"; then
+            snapshot_unverified=1
+            break
+        fi
+    done
+    if [ "$snapshot_unverified" -ne 0 ] || ! mv -f "$survivors_tmp" "$survivors_file"; then
+        rm -f "$survivors_tmp" "$survivors_file"
+        echo "codex adversarial survivor snapshot unavailable for pid/group $node_pid: recovery sidecar not published" >&2
+        return 1
+    fi
+    return 0
+}
+
+publish_cleanup_rc() {
+    case "$1" in
+        1|2) publish_survivors || true ;;
+        0) [ -z "$survivors_file" ] || rm -f "$survivors_file" "$survivors_tmp" ;;
+    esac
+    # HIMMEL-1509: cleanup rc 0 is the ONLY verified-clean signal, so it is the
+    # only place the branch render lease may be released. Any other status
+    # leaves the lease as adjudication evidence for the sweep/orchestrator.
+    if [ "$lease_held" -eq 1 ]; then
+        if [ "$1" = "0" ]; then
+            render_lease_release "$render_lease_branch"
+        else
+            echo "codex adversarial render lease preserved for adjudication (cleanup rc=$1): $(render_lease_dir_for "$render_lease_branch")" >&2
+        fi
+    fi
+    printf '%s\n' "$1" > "$cleanup_rc_file"
+}
+
+publish_ownership_sidecars() {
+    [ -n "$pid_file" ] || return 1
+    [ -n "$node_pid" ] && [ -n "$node_identity" ] || return 1
+    if ! printf '%s\n' "$node_identity" > "$identity_tmp" || ! mv -f "$identity_tmp" "$identity_file" ||
+       ! printf '%s\n' "$node_pid" > "$pid_tmp" || ! mv -f "$pid_tmp" "$pid_file"; then
+        rm -f "$identity_tmp" "$pid_tmp" "$identity_file" "$pid_file"
+        return 1
+    fi
+    ownership_published=1
+    return 0
+}
+
+stop_node_tree() {
+    local leader_exited="${1:-0}" identity_rc=2 cleanup_rc
+    [ -n "$node_pid" ] || return 0
+    if [ "$leader_exited" = "1" ]; then
+        identity_rc=1
+    elif [ -n "$node_identity" ]; then
+        identity_rc=0
+        proc_tree_process_identity_matches "$node_pid" "$node_identity" || identity_rc=$?
+    fi
+    if [ "$identity_rc" -eq 0 ]; then
+        proc_tree_terminate "$node_pid" 1 "$node_identity"
+        cleanup_rc=$?
+    elif [ "$identity_rc" -eq 1 ]; then
+        # HIMMEL-1474 r4: after leader exit, sweep any observed launch-group
+        # survivors without ever signaling a bare, potentially-recycled leader pid.
+        proc_tree_group_terminate "$node_pid" 1
+        cleanup_rc=$?
+    else
+        echo "codex adversarial cleanup failed for pid/group $node_pid: identity probe unavailable; no signal sent" >&2
+        return 2
+    fi
+    if [ "$cleanup_rc" -ne 0 ]; then
+        echo "codex adversarial cleanup failed for pid/group $node_pid (rc=$cleanup_rc): processes may remain alive" >&2
+    fi
+    return "$cleanup_rc"
+}
+
+# shellcheck disable=SC2317,SC2329  # invoked by trap
+terminate_on_signal() {
+    local cleanup_rc=0 identity_attempt=0 candidate_identity=''
+    if [ -n "$node_pid" ] && [ -z "$node_identity" ]; then
+        # Before the launch identity is captured, this wrapper still exclusively
+        # owns the dedicated group. Sweep that observed group instead of refusing
+        # every signal for lack of the not-yet-published identity.
+        proc_tree_group_terminate "$node_pid" 1 || cleanup_rc=$?
+    else
+        stop_node_tree || cleanup_rc=$?
+    fi
+    publish_cleanup_rc "$cleanup_rc"
+    if [ "$cleanup_rc" -ne 0 ] && [ "$ownership_published" -eq 0 ]; then
+        # The initial handshake may have been interrupted before it captured the
+        # leader identity. Briefly retry against the still-observed leader, and
+        # publish recovery handles only after immediate identity revalidation.
+        while [ -z "$node_identity" ] && [ "$identity_attempt" -lt 5 ]; do
+            candidate_identity=$(proc_tree_process_identity "$node_pid") || candidate_identity=''
+            if [ -n "$candidate_identity" ] && proc_tree_process_identity_matches "$node_pid" "$candidate_identity"; then
+                node_identity=$candidate_identity
+                break
+            fi
+            identity_attempt=$((identity_attempt + 1))
+            sleep 0.1
+        done
+        if ! publish_ownership_sidecars; then
+            echo "codex adversarial signal cleanup UNRECOVERABLE for pid/group $node_pid (rc=$cleanup_rc): leader identity could not be reacquired; no recovery pid marker published" >&2
+        fi
+    fi
+    exit 143
+}
+trap terminate_on_signal HUP INT TERM
+
+# Job control gives the companion and every descendant a dedicated process
+# group on POSIX and Git Bash; proc_tree_terminate relies on this invariant.
+# HIMMEL-1474 r3/r11: async harvest receives the group leader only after a
+# required identity handshake has established ownership of that exact process.
+set -m
+node "$companion" adversarial-review --wait --base "$base" >"$stdout_file" 2>"$stderr_file" &
+node_pid=$!
+set +m
+identity_attempt=0
+while [ -z "$node_identity" ] && [ "$identity_attempt" -lt 20 ]; do
+    node_identity=$(proc_tree_process_identity "$node_pid") || node_identity=''
+    [ -n "$node_identity" ] && break
+    identity_attempt=$((identity_attempt + 1))
+    sleep 0.1
+done
+if [ -z "$node_identity" ]; then
+    cleanup_rc=0
+    proc_tree_group_terminate "$node_pid" 1 || cleanup_rc=$?
+    publish_cleanup_rc "$cleanup_rc"
+    if [ "$cleanup_rc" -eq 0 ]; then
+        wait "$node_pid" 2>/dev/null || true
+    fi
+    echo "codex adversarial launch unavailable for pid/group $node_pid: process identity could not be captured; owned group termination rc=$cleanup_rc; no pid published" >&2
+    exit 125
+fi
+if [ -n "$pid_file" ]; then
+    if ! publish_ownership_sidecars; then
+        cleanup_rc=0
+        proc_tree_group_terminate "$node_pid" 1 || cleanup_rc=$?
+        publish_cleanup_rc "$cleanup_rc"
+        if [ "$cleanup_rc" -eq 0 ]; then
+            wait "$node_pid" 2>/dev/null || true
+        fi
+        echo "codex adversarial launch unavailable for pid/group $node_pid: ownership sidecars could not be published atomically; owned group termination rc=$cleanup_rc" >&2
+        exit 125
+    fi
+fi
+
+lease_client_pid=$node_pid
+if proc_tree_is_windows; then
+    lease_client_pid=$(proc_tree_winpid "$node_pid")
+    case "$lease_client_pid" in ''|*[!0-9]*) lease_client_pid='' ;; esac
+fi
+
+# HIMMEL-1509: bind the identity-verified leader onto the held lease so the
+# sweep can verify liveness from the record alone (win:<pid>:<startticks>),
+# independent of command-line visibility. Best-effort: a failed bind keeps the
+# launch-phase record, which stays live via its own freshness anchor.
+if [ "$lease_held" -eq 1 ]; then
+    render_lease_bind "$render_lease_branch" "$node_pid" "$lease_client_pid" "$node_identity" ||
+        echo "codex adversarial render lease bind failed for branch '$render_lease_branch'; lease keeps its launch-phase record" >&2
+fi
+
+pwsh_bin=''
+for candidate in pwsh pwsh.exe powershell.exe powershell; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        pwsh_bin=$candidate
+        break
+    fi
+done
+if [ -n "$pwsh_bin" ] && [ -n "$lease_client_pid" ]; then
+    lease_arg=$lease_script
+    if command -v cygpath >/dev/null 2>&1; then
+        lease_arg=$(cygpath -m "$lease_script")
+    fi
+    if [ "$lease_held" -eq 1 ]; then
+        # The heartbeat writer also refreshes the registry lease (heartbeat +
+        # observed cxc tokens) so the sweep sees live proof without argv access.
+        lease_dir_path=$(render_lease_dir_for "$render_lease_branch")
+        if command -v cygpath >/dev/null 2>&1; then
+            lease_dir_path=$(cygpath -m "$lease_dir_path")
+        fi
+        "$pwsh_bin" -NoProfile -ExecutionPolicy Bypass -File "$lease_arg" -ClientPid "$lease_client_pid" -LeaseDir "$lease_dir_path" >/dev/null 2>&1 &
+    else
+        "$pwsh_bin" -NoProfile -ExecutionPolicy Bypass -File "$lease_arg" -ClientPid "$lease_client_pid" >/dev/null 2>&1 &
+    fi
+    disown 2>/dev/null || true
+fi
+
+if [ "$timeout_secs" -gt 0 ]; then
+    waited=0
+    while kill -0 "$node_pid" 2>/dev/null; do
+        if [ "$waited" -ge "$timeout_secs" ]; then
+            cleanup_rc=0
+            stop_node_tree || cleanup_rc=$?
+            publish_cleanup_rc "$cleanup_rc"
+            if [ "$cleanup_rc" -eq 0 ]; then
+                wait "$node_pid" 2>/dev/null || true
+            else
+                echo "codex adversarial timeout cleanup incomplete for pid/group $node_pid (rc=$cleanup_rc): skipping blocking wait; ownership sidecars preserved" >&2
+            fi
+            exit 124
+        fi
+        sleep 5
+        waited=$((waited + 5))
+    done
+fi
+
+wait "$node_pid"
+node_rc=$?
+# HIMMEL-1474 r4: leader exit is not group completion. Reap any stubborn
+# descendants before the wrapper publishes the companion rc to harvest.
+stop_node_tree 1
+cleanup_rc=$?
+publish_cleanup_rc "$cleanup_rc"
+[ "$node_rc" -ne 0 ] && exit "$node_rc"
+[ "$cleanup_rc" -eq 0 ] || exit 125
+exit 0

--- a/scripts/cr/test-clear-cr-marker.sh
+++ b/scripts/cr/test-clear-cr-marker.sh
@@ -8,6 +8,14 @@
 # fixed paths under the temp repo's own .git, exactly as the real ones resolve.
 set -uo pipefail
 
+# HIMMEL-1495 — an --automerge-armed launching shell carries ARMAUTOMERGE=1 +
+# CR_MERGE_GATE_OK=1 by design; an ambient value in the operator's shell must
+# not decide the result (the 34e/34f precedent in test-check-ci.sh,
+# generalized). clear-cr-marker.sh does not consult either var today, so this
+# is defense-in-depth for the day a sourced lib reads one — the canary case
+# below pins today's insensitivity.
+unset ARMAUTOMERGE CR_MERGE_GATE_OK
+
 # grepq <text> [grep-args...] — a `grep -q` test against <text> with NO
 # pipeline. printf/echo-into-`grep -q` is a trap under this file's
 # `set -o pipefail`: grep -q exits the instant it matches, the producer
@@ -959,6 +967,22 @@ if grepq "$help_out" 'set -uo pipefail'; then
 else
     pass
 fi
+
+# HIMMEL-1495 hermeticity canary. clear-cr-marker.sh does not consult the
+# armed-session bypass env (ARMAUTOMERGE/CR_MERGE_GATE_OK), so a block fixture
+# STILL blocks (exit 13, stale marker) with both exported into the suite's env
+# — pinning that insensitivity so a future change wiring either var into the
+# clear chokepoint fails HERE (clears an unreviewed marker) rather than failing
+# open. The startup unset above is the matching defense-in-depth.
+export ARMAUTOMERGE=1 CR_MERGE_GATE_OK=1
+make_repo
+write_marker "$tmp" "$sha"; write_ledger "$tmp" "$(avail_ok "${sha:0:8}")"
+(cd "$tmp" && echo x >> f.txt && git commit -qam "later work") >/dev/null 2>&1
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 13 "armed bypass env does not clear a stale marker (HIMMEL-1495)"
+if marker_exists "$tmp"; then pass; else fail "armed-env stale marker: marker must REMAIN"; fi
+rm -rf "$tmp"
+unset ARMAUTOMERGE CR_MERGE_GATE_OK
 
 echo
 echo "clear-cr-marker: $PASS passed, $FAIL failed"

--- a/scripts/cr/test-critic-panel-fallback.sh
+++ b/scripts/cr/test-critic-panel-fallback.sh
@@ -21,14 +21,21 @@ grepq() { local _t="$1"; shift; grep -q "$@" <<< "$_t"; }
 
 # Hermetic: the panel reads CR_PROFILE (HIMMEL-558). Clear ambient values so the
 # default free-tier path is used.
-unset CR_PROFILE CRITIC_PANEL_TIERS 2>/dev/null || true
+unset CR_PROFILE CRITIC_PANEL_TIERS CRITIC_LEDGER_APPEND CR_LEDGER \
+    CRITIC_FIRST_PASS CRITICS_JSON CRITIC_PARALLEL CRITIC_TIMEOUT_SECS \
+    CRITIC_PANEL_TOTAL_TIMEOUT_SECS CRITIC_PANEL_STARTED_AT \
+    CR_TRIVIALITY_OVERRIDE 2>/dev/null || true
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 PANEL="$HERE/critic-panel.sh"
-tmp="$(mktemp -d)"
+tmp="$(mktemp -d -t critic-panel-fallback-test.XXXXXX)"
 # shellcheck disable=SC2064
 trap "rm -rf $tmp" EXIT
 fails=0
+LEDGER_NOOP="$tmp/ledger-noop.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$LEDGER_NOOP"
+chmod +x "$LEDGER_NOOP"
+export CRITIC_LEDGER_APPEND="$LEDGER_NOOP"
 
 check() {
     if [ "$2" = "$3" ]; then

--- a/scripts/cr/test-critic-panel-registry.sh
+++ b/scripts/cr/test-critic-panel-registry.sh
@@ -11,14 +11,21 @@ set -uo pipefail
 
 # Clear ambient tier controls so the panel's tier filter is deterministic
 # (.env often exports CR_PROFILE); each case sets what it needs explicitly.
-unset CR_PROFILE CRITIC_PANEL_TIERS CR_TRIVIALITY_OVERRIDE 2>/dev/null || true
+unset CR_PROFILE CRITIC_PANEL_TIERS CR_TRIVIALITY_OVERRIDE \
+    CRITIC_LEDGER_APPEND CR_LEDGER CRITIC_FIRST_PASS CRITICS_JSON \
+    CRITIC_PARALLEL CRITIC_TIMEOUT_SECS CRITIC_PANEL_TOTAL_TIMEOUT_SECS \
+    CRITIC_PANEL_STARTED_AT 2>/dev/null || true
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 PANEL="$HERE/critic-panel.sh"
-tmp="$(mktemp -d)"
+tmp="$(mktemp -d -t critic-panel-registry-test.XXXXXX)"
 # shellcheck disable=SC2064
 trap "rm -rf $tmp" EXIT
 fails=0
+LEDGER_NOOP="$tmp/ledger-noop.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$LEDGER_NOOP"
+chmod +x "$LEDGER_NOOP"
+export CRITIC_LEDGER_APPEND="$LEDGER_NOOP"
 
 check() {
     if [ "$2" = "$3" ]; then echo "ok - $1"; else
@@ -62,7 +69,7 @@ index 0000000..1111111 100644
 # ---------------------------------------------------------------------------
 repo="$tmp/repo"
 mkdir -p "$repo"
-( cd "$repo" && git init -q )
+( cd "$repo" && git init -q && git -c user.name=test -c user.email=test@example.invalid commit -q --allow-empty -m init )
 SENTINEL="sentinel-zai-9f3a7c"
 printf 'ZAI_API_KEY=%s\n' "$SENTINEL" > "$repo/.env"
 printf '%s' '{"panel":[{"slug":"glm","model":"glm-5.2","provider":"zai","tier":"free","route_provider":"glm"}]}' > "$tmp/t1-reg.json"

--- a/scripts/cr/test-critic-panel-triviality.sh
+++ b/scripts/cr/test-critic-panel-triviality.sh
@@ -17,14 +17,21 @@ grepq() { local _t="$1"; shift; grep -q "$@" <<< "$_t"; }
 
 # Hermetic: the panel reads CR_PROFILE (HIMMEL-558). Clear ambient values; each
 # case sets CR_PROFILE explicitly.
-unset CR_PROFILE CRITIC_PANEL_TIERS CR_TRIVIALITY_OVERRIDE 2>/dev/null || true
+unset CR_PROFILE CRITIC_PANEL_TIERS CR_TRIVIALITY_OVERRIDE \
+    CRITIC_LEDGER_APPEND CR_LEDGER CRITIC_FIRST_PASS CRITICS_JSON \
+    CRITIC_PARALLEL CRITIC_TIMEOUT_SECS CRITIC_PANEL_TOTAL_TIMEOUT_SECS \
+    CRITIC_PANEL_STARTED_AT 2>/dev/null || true
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 PANEL="$HERE/critic-panel.sh"
-tmp="$(mktemp -d)"
+tmp="$(mktemp -d -t critic-panel-triviality-test.XXXXXX)"
 # shellcheck disable=SC2064
 trap "rm -rf $tmp" EXIT
 fails=0
+LEDGER_NOOP="$tmp/ledger-noop.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$LEDGER_NOOP"
+chmod +x "$LEDGER_NOOP"
+export CRITIC_LEDGER_APPEND="$LEDGER_NOOP"
 
 check() {
     if [ "$2" = "$3" ]; then

--- a/scripts/cr/test-critic-panel.sh
+++ b/scripts/cr/test-critic-panel.sh
@@ -16,14 +16,25 @@ grepq() { local _t="$1"; shift; grep -q "$@" <<< "$_t"; }
 # CRITIC_PANEL_TIERS — from the environment. Clear any ambient values so the
 # default-behaviour tests are not perturbed by the operator's shell (.env often
 # exports CR_PROFILE=free,paid). Each CR_PROFILE test below sets it explicitly.
-unset CR_PROFILE CRITIC_PANEL_TIERS 2>/dev/null || true
+unset CR_PROFILE CRITIC_PANEL_TIERS CRITIC_LEDGER_APPEND CR_LEDGER \
+    CRITIC_FIRST_PASS CRITICS_JSON CRITIC_PARALLEL CRITIC_TIMEOUT_SECS \
+    CRITIC_PANEL_TOTAL_TIMEOUT_SECS CRITIC_PANEL_STARTED_AT \
+    CR_TRIVIALITY_OVERRIDE 2>/dev/null || true
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 PANEL="$HERE/critic-panel.sh"
-tmp="$(mktemp -d)"
+tmp="$(mktemp -d -t critic-panel-test.XXXXXX)"
 # shellcheck disable=SC2064
 trap "rm -rf $tmp" EXIT
 fails=0
+
+# Most cases exercise panel behavior, not persistence; isolate them from the real
+# git-common-dir ledger and from each other's repeated finding IDs. Dedicated
+# ledger assertions below override this seam with the real helper.
+LEDGER_NOOP="$tmp/ledger-noop.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$LEDGER_NOOP"
+chmod +x "$LEDGER_NOOP"
+export CRITIC_LEDGER_APPEND="$LEDGER_NOOP"
 
 check() {
     if [ "$2" = "$3" ]; then
@@ -137,9 +148,382 @@ check "B: header 2/3" "$(printf '%s\n' "$out_b" | grep -cF '(2/3 critics respond
 printf '%s' "$DIFF" | CRITICS_JSON="$tmp/critics-allfail.json" CRITIC_FIRST_PASS="$STUB" bash "$PANEL" >/dev/null 2>&1
 check "C: all-fail -> exit 1" "$?" "1"
 
-# Test D: >=1 responds -> exit 0
+# Test D: >=1 responds -> exit 0 (the stdin shape remains supported).
 printf '%s' "$DIFF" | CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" bash "$PANEL" >/dev/null 2>&1
-check "D: >=1 responds -> exit 0" "$?" "0"
+check "D: stdin shape + >=1 responds -> exit 0" "$?" "0"
+
+# Test LA: the panel persists its OWN evidence through ledger-append.sh. One run
+# contains two responders + one unavailable member and four findings, so it
+# covers both availability statuses and empty raw verdicts without orchestrator
+# glue. Every row must carry the exact head that was reviewed.
+LEDGER_CASE="$tmp/panel-ledger.jsonl"
+: > "$LEDGER_CASE"
+CR_LEDGER="$LEDGER_CASE" CRITIC_LEDGER_APPEND="$HERE/ledger-append.sh" \
+    CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" \
+    bash "$PANEL" <<< "$DIFF" > "$tmp/ledger-out" 2> "$tmp/ledger-err"
+ledger_rc=$?
+reviewed_head="$(git rev-parse HEAD)"
+ledger_summary="$(python3 - "$LEDGER_CASE" "$reviewed_head" <<'PYEOF'
+import json, sys
+rows = [json.loads(line) for line in open(sys.argv[1]) if line.strip()]
+head = sys.argv[2]
+avail = [r for r in rows if r.get('kind') == 'avail']
+findings = [r for r in rows if r.get('kind') == 'finding']
+print('avail=' + str(len(avail)))
+print('ok=' + str(sum(r.get('status') == 'ok' for r in avail)))
+print('unavailable=' + str(sum(r.get('status') == 'unavailable' for r in avail)))
+print('unavailable-reason=' + ('yes' if any(r.get('model') == 'kimi' and r.get('reason') == 'generic-rc-1' for r in avail) else 'no'))
+print('all-head=' + ('yes' if rows and all(r.get('head') == head for r in rows) else 'no'))
+print('findings=' + str(len(findings)))
+print('empty-verdicts=' + ('yes' if findings and all(r.get('verdict') == '' for r in findings) else 'no'))
+print('models=' + ','.join(sorted(r.get('model', '') for r in avail)))
+PYEOF
+)"
+check "LA: panel succeeds while self-appending" "$ledger_rc" "0"
+check "LA: one availability row per member" "$(printf '%s\n' "$ledger_summary" | sed -n 's/^avail=//p')" "3"
+check "LA: responder availability rows are ok" "$(printf '%s\n' "$ledger_summary" | sed -n 's/^ok=//p')" "2"
+check "LA: failed member availability row is unavailable" "$(printf '%s\n' "$ledger_summary" | sed -n 's/^unavailable=//p')" "1"
+check "LA: unavailable row includes its classified reason" "$(printf '%s\n' "$ledger_summary" | sed -n 's/^unavailable-reason=//p')" "yes"
+check "LA: availability models are the registry slugs" "$(printf '%s\n' "$ledger_summary" | sed -n 's/^models=//p')" "gptoss,kimi,qwen3coder"
+check "LA: every row is stamped with the reviewed head" "$(printf '%s\n' "$ledger_summary" | sed -n 's/^all-head=//p')" "yes"
+check "LA: every emitted finding self-appended" "$(printf '%s\n' "$ledger_summary" | sed -n 's/^findings=//p')" "4"
+check "LA: raw finding verdicts are empty" "$(printf '%s\n' "$ledger_summary" | sed -n 's/^empty-verdicts=//p')" "yes"
+
+# Test LAP: parallel mode self-appends the SAME ledger evidence as sequential
+# (HIMMEL-1494 r3; per-member spool files r4). The evidence path flows through
+# PER-MEMBER spool files (avail.<slug>/finding.<slug>), one per member, not a
+# shared file; this is the regression guard. If process_member is ever moved
+# into a background subshell, each member's spool must still land every row —
+# assert the parallel ledger has the same avail/finding counts AND the same
+# per-member model sets (avail + findings) as the sequential run over the
+# identical fixture, so a lost per-member file can't hide behind a matching count.
+LAP_SEQ="$tmp/lap-seq.jsonl"; : > "$LAP_SEQ"
+LAP_PAR="$tmp/lap-par.jsonl"; : > "$LAP_PAR"
+CR_LEDGER="$LAP_SEQ" CRITIC_LEDGER_APPEND="$HERE/ledger-append.sh" \
+    CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" \
+    bash "$PANEL" <<< "$DIFF" > "$tmp/lap-seq-out" 2> "$tmp/lap-seq-err"
+CR_LEDGER="$LAP_PAR" CRITIC_LEDGER_APPEND="$HERE/ledger-append.sh" \
+    CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" \
+    CRITIC_PARALLEL=1 \
+    bash "$PANEL" <<< "$DIFF" > "$tmp/lap-par-out" 2> "$tmp/lap-par-err"
+lap_summary="$(python3 - "$LAP_SEQ" "$LAP_PAR" <<'PYEOF'
+import json, sys
+def shape(p):
+    rows = [json.loads(l) for l in open(p) if l.strip()]
+    a = [r for r in rows if r.get('kind') == 'avail']
+    f = [r for r in rows if r.get('kind') == 'finding']
+    return (len(a), len(f),
+            ','.join(sorted(r.get('model', '') for r in a)),
+            ','.join(sorted(r.get('model', '') for r in f)))
+sa, sf, sm, sfm = shape(sys.argv[1]); pa, pf, pm, pfm = shape(sys.argv[2])
+print('seq_avail=%d' % sa); print('seq_find=%d' % sf)
+print('par_avail=%d' % pa); print('par_find=%d' % pf)
+print('avail_same=%s' % (sa == pa)); print('find_same=%s' % (sf == pf))
+print('models_same=%s' % (sm == pm)); print('seq_models=%s' % sm)
+print('find_models_same=%s' % (sfm == pfm)); print('seq_find_models=%s' % sfm)
+PYEOF
+)"
+check "LAP: sequential avail rows (3)" "$(printf '%s\n' "$lap_summary" | sed -n 's/^seq_avail=//p')" "3"
+check "LAP: sequential finding rows (4)" "$(printf '%s\n' "$lap_summary" | sed -n 's/^seq_find=//p')" "4"
+check "LAP: parallel avail rows == sequential" "$(printf '%s\n' "$lap_summary" | sed -n 's/^avail_same=//p')" "True"
+check "LAP: parallel finding rows == sequential" "$(printf '%s\n' "$lap_summary" | sed -n 's/^find_same=//p')" "True"
+check "LAP: parallel avail model set == sequential" "$(printf '%s\n' "$lap_summary" | sed -n 's/^models_same=//p')" "True"
+check "LAP: parallel finding model set == sequential" "$(printf '%s\n' "$lap_summary" | sed -n 's/^find_models_same=//p')" "True"
+check "LAP: avail model set is the registry slugs" "$(printf '%s\n' "$lap_summary" | sed -n 's/^seq_models=//p')" "gptoss,kimi,qwen3coder"
+
+# Test WT: sanctioned --worktree mode computes main...HEAD itself. A real diff
+# runs and stamps that worktree's head; an empty diff and a non-worktree path
+# fail loudly with distinct documented exits.
+WT_REPO="$tmp/review-worktree"
+git init -q "$WT_REPO"
+git -C "$WT_REPO" checkout -q -b main
+git -C "$WT_REPO" config user.name test
+git -C "$WT_REPO" config user.email test@example.invalid
+printf 'base\n' > "$WT_REPO/review.txt"
+git -C "$WT_REPO" add review.txt
+git -C "$WT_REPO" commit -q -m base
+git -C "$WT_REPO" checkout -q -b feature
+printf 'changed\n' >> "$WT_REPO/review.txt"
+git -C "$WT_REPO" add review.txt
+git -C "$WT_REPO" commit -q -m feature
+wt_head="$(git -C "$WT_REPO" rev-parse HEAD)"
+WT_LEDGER="$tmp/worktree-ledger.jsonl"
+: > "$WT_LEDGER"
+CR_LEDGER="$WT_LEDGER" CRITIC_LEDGER_APPEND="$HERE/ledger-append.sh" \
+    CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" \
+    bash "$PANEL" --worktree "$WT_REPO" > "$tmp/wt-out" 2> "$tmp/wt-err"
+wt_rc=$?
+check "WT1: --worktree real main...HEAD diff runs" "$wt_rc" "0"
+check_contains "WT1: --worktree still emits panel output" "$(cat "$tmp/wt-out")" "# Critic Panel Review"
+check "WT1: ledger rows use the reviewed worktree head" \
+    "$(python3 - "$WT_LEDGER" "$wt_head" <<'PYEOF'
+import json, sys
+rows = [json.loads(line) for line in open(sys.argv[1]) if line.strip()]
+print('yes' if rows and all(r.get('head') == sys.argv[2] for r in rows) else 'no')
+PYEOF
+)" "yes"
+
+git -C "$WT_REPO" checkout -q main
+wt_empty_rc=0
+CR_LEDGER="$tmp/wt-empty-ledger.jsonl" CRITIC_LEDGER_APPEND="$HERE/ledger-append.sh" \
+    CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" \
+    bash "$PANEL" --worktree "$WT_REPO" > "$tmp/wt-empty-out" 2> "$tmp/wt-empty-err" || wt_empty_rc=$?
+check "WT2: empty --worktree diff uses distinct exit" "$wt_empty_rc" "4"
+check_contains "WT2: empty --worktree diff refusal is loud" "$(cat "$tmp/wt-empty-err")" "REFUSING empty --worktree diff"
+
+mkdir -p "$tmp/not-a-worktree"
+wt_bad_rc=0
+bash "$PANEL" --worktree "$tmp/not-a-worktree" > "$tmp/wt-bad-out" 2> "$tmp/wt-bad-err" || wt_bad_rc=$?
+check "WT3: non-worktree path uses distinct exit" "$wt_bad_rc" "3"
+check_contains "WT3: non-worktree refusal is explicit" "$(cat "$tmp/wt-bad-err")" "is not a git worktree"
+
+# ── HIMMEL-1494 r2: stdin graceful degrade, base-branch resolution, ──────────
+#    citation-less ledger rows. Three panel suggestions, parent premise-
+#    verified; each fix has its own fixture and touches only critic-panel.sh.
+
+# Test NWS: stdin review from a NON-worktree cwd degrades gracefully — the
+# review runs, a loud warning names the skipped self-append, NO ledger rows are
+# written, and the exit code matches pre-change behavior (the review's own 0/1,
+# not the old exit 5). Pre-fix this path exited 5; the worktree is only needed
+# to STAMP ledger rows.
+NWS_DIR="$tmp/non-worktree-cwd"
+mkdir -p "$NWS_DIR"
+NWS_LEDGER="$tmp/nws-ledger.jsonl"
+: > "$NWS_LEDGER"
+nws_rc=0
+( cd "$NWS_DIR" && printf '%s' "$DIFF" \
+    | CR_LEDGER="$NWS_LEDGER" CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" \
+      bash "$PANEL" > "$tmp/nws-out" 2> "$tmp/nws-err" ) || nws_rc=$?
+check "NWS: review runs from a non-worktree cwd (exit 0, was 5)" "$nws_rc" "0"
+check_contains "NWS: loud self-append-skipped warning" "$(cat "$tmp/nws-err")" "stdin review outside a git worktree"
+check_contains "NWS: warning names the skipped self-append" "$(cat "$tmp/nws-err")" "CR-ledger self-append skipped"
+check "NWS: merged review output still emitted" "$(grep -cF '# Critic Panel Review' "$tmp/nws-out")" "1"
+check "NWS: NO ledger rows written (self-append skipped)" "$(wc -l < "$NWS_LEDGER" | tr -d ' ')" "0"
+
+# Tests B1-B3: --worktree resolves the base branch instead of hardcoding main.
+# B1 — CR_BASE_BRANCH wins over origin/HEAD. Fixture: master base + feature
+# change, origin/HEAD -> master (valid). An override to a NONEXISTENT branch
+# must still win and produce the diff-failed exit naming the override, proving
+# origin/HEAD's master was never consulted.
+BR_REPO="$tmp/base-resolve-repo"
+git init -q "$BR_REPO"
+git -C "$BR_REPO" checkout -q -b master
+git -C "$BR_REPO" config user.name test
+git -C "$BR_REPO" config user.email test@example.invalid
+printf 'base\n' > "$BR_REPO/r.txt"
+git -C "$BR_REPO" add r.txt
+git -C "$BR_REPO" commit -q -m base
+# Point origin/HEAD at master so the override-only path is the discriminating one.
+git -C "$BR_REPO" update-ref refs/remotes/origin/master "$(git -C "$BR_REPO" rev-parse master)"
+git -C "$BR_REPO" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
+git -C "$BR_REPO" checkout -q -b feature
+printf 'change\n' >> "$BR_REPO/r.txt"
+git -C "$BR_REPO" add r.txt
+git -C "$BR_REPO" commit -q -m feature
+b1_rc=0
+CR_BASE_BRANCH=zzz-nope-override CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" \
+    bash "$PANEL" --worktree "$BR_REPO" > "$tmp/b1-out" 2> "$tmp/b1-err" || b1_rc=$?
+check "B1: CR_BASE_BRANCH override is honored (diff fails on the override, exit 5)" "$b1_rc" "5"
+check_contains "B1: failed diff names the OVERRIDE base, not origin/HEAD's master" "$(cat "$tmp/b1-err")" "diff zzz-nope-override...HEAD"
+
+# B2 — origin/HEAD fallback (no override). Same fixture; master is a real
+# branch, so diffing master...HEAD on feature runs and the panel succeeds —
+# proving origin/HEAD resolved to master (the old hardcoded `main` would have
+# failed, since this repo has no main branch).
+b2_rc=0
+CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" \
+    bash "$PANEL" --worktree "$BR_REPO" > "$tmp/b2-out" 2> "$tmp/b2-err" || b2_rc=$?
+check "B2: origin/HEAD fallback resolves master and the diff runs (exit 0)" "$b2_rc" "0"
+check_contains "B2: panel output emitted (diff against master ran)" "$(cat "$tmp/b2-out")" "# Critic Panel Review"
+
+# B3 — final fallback `main`. A repo with NO origin/HEAD and NO CR_BASE_BRANCH,
+# on a `trunk` base branch; there is no `main`, so the diff fails and the
+# message reveals the resolved base is `main` (not trunk).
+BR3_REPO="$tmp/base-resolve-main-fallback"
+git init -q "$BR3_REPO"
+git -C "$BR3_REPO" checkout -q -b trunk
+git -C "$BR3_REPO" config user.name test
+git -C "$BR3_REPO" config user.email test@example.invalid
+printf 'base\n' > "$BR3_REPO/r.txt"
+git -C "$BR3_REPO" add r.txt
+git -C "$BR3_REPO" commit -q -m base
+git -C "$BR3_REPO" checkout -q -b feature
+printf 'change\n' >> "$BR3_REPO/r.txt"
+git -C "$BR3_REPO" add r.txt
+git -C "$BR3_REPO" commit -q -m feature
+b3_rc=0
+CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" \
+    bash "$PANEL" --worktree "$BR3_REPO" > "$tmp/b3-out" 2> "$tmp/b3-err" || b3_rc=$?
+check "B3: no override + no origin/HEAD falls back to main (diff fails, exit 5)" "$b3_rc" "5"
+check_contains "B3: failed diff names the FINAL fallback base main" "$(cat "$tmp/b3-err")" "diff main...HEAD"
+
+# B4 — origin/HEAD base that exists ONLY as origin/<name> (no local branch).
+# A clone/worktree that never checked the default out locally carries no
+# refs/heads/<name>, so the bare name must NOT be diffed. The remote ref
+# origin/<name> (which origin/HEAD guaranteed exists) must be diffed instead
+# (HIMMEL-1494 r3). Without the fix the bare `develop` fails to resolve and the
+# panel exits 5; with it, origin/develop resolves and the diff runs.
+BR4_REPO="$tmp/base-resolve-origin-only"
+git init -q "$BR4_REPO"
+git -C "$BR4_REPO" checkout -q -b develop
+git -C "$BR4_REPO" config user.name test
+git -C "$BR4_REPO" config user.email test@example.invalid
+printf 'base\n' > "$BR4_REPO/r.txt"
+git -C "$BR4_REPO" add r.txt
+git -C "$BR4_REPO" commit -q -m base
+git -C "$BR4_REPO" update-ref refs/remotes/origin/develop "$(git -C "$BR4_REPO" rev-parse develop)"
+git -C "$BR4_REPO" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+git -C "$BR4_REPO" checkout -q -b feature
+printf 'change\n' >> "$BR4_REPO/r.txt"
+git -C "$BR4_REPO" add r.txt
+git -C "$BR4_REPO" commit -q -m feature
+git -C "$BR4_REPO" branch -D develop   # local develop GONE; only origin/develop remains
+b4_rc=0
+CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" \
+    bash "$PANEL" --worktree "$BR4_REPO" > "$tmp/b4-out" 2> "$tmp/b4-err" || b4_rc=$?
+check "B4: origin-only base diffs origin/<name> and runs (exit 0)" "$b4_rc" "0"
+check_contains "B4: panel output emitted (diff against origin/develop ran)" "$(cat "$tmp/b4-out")" "# Critic Panel Review"
+
+# B5 — when BOTH a local <name> and origin/<name> exist and origin/HEAD -> <name>,
+# the bare LOCAL name is used (it verifies), NOT the stale remote (HIMMEL-1494
+# r3). Discriminating proof: local develop is AHEAD of origin/develop by one
+# commit, so an origin/<name> three-dot diff would include that ancestral change
+# while a bare-local diff excludes it. The critic stub echoes a marker derived
+# from its stdin (the computed diff), so the merged output names which ref was
+# diffed.
+BR5_REPO="$tmp/base-resolve-local-verifies"
+git init -q "$BR5_REPO"
+git -C "$BR5_REPO" checkout -q -b develop
+git -C "$BR5_REPO" config user.name test
+git -C "$BR5_REPO" config user.email test@example.invalid
+printf 'base\n' > "$BR5_REPO/r.txt"
+git -C "$BR5_REPO" add r.txt
+git -C "$BR5_REPO" commit -q -m base
+git -C "$BR5_REPO" update-ref refs/remotes/origin/develop "$(git -C "$BR5_REPO" rev-parse develop)"
+git -C "$BR5_REPO" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+printf 'origin-only-ancestral-marker\n' >> "$BR5_REPO/r.txt"
+git -C "$BR5_REPO" add r.txt
+git -C "$BR5_REPO" commit -q -m advance-local-develop   # local develop now AHEAD of origin/develop
+git -C "$BR5_REPO" checkout -q -b feature
+printf 'feature-change\n' >> "$BR5_REPO/r.txt"
+git -C "$BR5_REPO" add r.txt
+git -C "$BR5_REPO" commit -q -m feature
+B5_STUB="$tmp/b5-cfp.sh"
+cat > "$B5_STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+# Discriminate which base ref was diffed. The ancestral marker is ADDED only
+# when origin/develop (C0) is the base; when bare local develop (C0a, which
+# already contains the marker) is the base the marker is mere context, so the
+# unified-diff ADDITION prefix '+origin-only-ancestral-marker' is present in the
+# origin/ diff and absent from the bare-local diff.
+input="$(cat)"
+if printf '%s' "$input" | grep -qF '+origin-only-ancestral-marker'; then
+    ref='ORIGIN-REF-USED'
+else
+    ref='LOCAL-REF-USED'
+fi
+printf '# gptoss First-Pass Review\n\n## Critical Issues (1 found)\n- [gptoss-1]: %s [r.txt:3]\n\n## Important Issues (0 found)\n\n## Suggestions (0 found)\n' "$ref"
+STUBEOF
+chmod +x "$B5_STUB"
+b5_rc=0
+CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$B5_STUB" \
+    bash "$PANEL" --worktree "$BR5_REPO" > "$tmp/b5-out" 2> "$tmp/b5-err" || b5_rc=$?
+check "B5: local-verifies base diffs bare local name and runs (exit 0)" "$b5_rc" "0"
+check_contains "B5: bare LOCAL name used (not stale origin/)" "$(cat "$tmp/b5-out")" "LOCAL-REF-USED"
+
+# B6 — tag shadowing (HIMMEL-1494 r4 Fix 2). A repo with NO local branch
+# <name>, but BOTH a TAG named <name> AND origin/<name>. r3's bare
+# `--verify "$_base"` matched the TAG, falsely satisfying the local-branch
+# check and suppressing the origin/<name> fallback; r4 verifies
+# refs/heads/<name> so only a real local branch satisfies it, the fallback
+# fires, and the diff uses origin/<name>.
+# Discriminator (mirrors B5): the tag sits one ancestral commit ABOVE
+# origin/<name> (a marker line), so an origin/<name> three-dot diff includes
+# the marker as an ADDITION while a tag-based diff (base = the tag commit,
+# which is HEAD's ancestor) does not. A stub inspecting its stdin names which
+# ref ran.
+BR6_REPO="$tmp/base-resolve-tag-shadow"
+git init -q "$BR6_REPO"
+git -C "$BR6_REPO" checkout -q -b develop
+git -C "$BR6_REPO" config user.name test
+git -C "$BR6_REPO" config user.email test@example.invalid
+printf 'base\n' > "$BR6_REPO/r.txt"
+git -C "$BR6_REPO" add r.txt
+git -C "$BR6_REPO" commit -q -m base                 # C0: origin/<name> base
+_b6_c0="$(git -C "$BR6_REPO" rev-parse HEAD)"
+printf 'tag-only-ancestral-marker\n' >> "$BR6_REPO/r.txt"
+git -C "$BR6_REPO" add r.txt
+git -C "$BR6_REPO" commit -q -m tagpoint              # C1: the TAG's commit
+git -C "$BR6_REPO" tag develop                        # tag <name> -> C1
+git -C "$BR6_REPO" update-ref refs/remotes/origin/develop "$_b6_c0"
+git -C "$BR6_REPO" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+git -C "$BR6_REPO" checkout -q -b feature            # feature from C1
+printf 'feature-change\n' >> "$BR6_REPO/r.txt"
+git -C "$BR6_REPO" add r.txt
+git -C "$BR6_REPO" commit -q -m feature
+git -C "$BR6_REPO" branch -D develop                 # local branch GONE; tag + origin/<name> remain
+B6_STUB="$tmp/b6-cfp.sh"
+cat > "$B6_STUB" <<'STUBEOF'
+#!/usr/bin/env bash
+# Discriminate which base ref was diffed. origin/develop (C0) as the base
+# includes the marker as an ADDITION (the marker is in C1, between C0 and
+# HEAD); the tag develop (C1) as the base is HEAD's ancestor, so the marker is
+# mere context and the '+...' addition is absent.
+input="$(cat)"
+if printf '%s' "$input" | grep -qF '+tag-only-ancestral-marker'; then
+    ref='ORIGIN-REF-USED'
+else
+    ref='TAG-REF-USED'
+fi
+printf '# gptoss First-Pass Review\n\n## Critical Issues (1 found)\n- [gptoss-1]: %s [r.txt:3]\n\n## Important Issues (0 found)\n\n## Suggestions (0 found)\n' "$ref"
+STUBEOF
+chmod +x "$B6_STUB"
+b6_rc=0
+CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$B6_STUB" \
+    bash "$PANEL" --worktree "$BR6_REPO" > "$tmp/b6-out" 2> "$tmp/b6-err" || b6_rc=$?
+check "B6: tag-shadowed base diffs origin/<name> and runs (exit 0)" "$b6_rc" "0"
+check_contains "B6: origin/<name> used (not the shadowing tag)" "$(cat "$tmp/b6-out")" "ORIGIN-REF-USED"
+
+# Test NC: a finding WITHOUT a trailing [file:line] citation must land in the
+# ledger with EMPTY file/line (the absent-value convention), not the malformed
+# values the old unguarded AWK parse produced from the ID bracket. Inline stub
+# so the test stays self-contained (stub-cfp.py is out of the file fence).
+NC_STUB="$tmp/nc-cfp.sh"
+cat > "$NC_STUB" <<'EOS'
+#!/usr/bin/env bash
+cat >/dev/null
+echo "# nc First-Pass Review"
+echo ""
+echo "## Critical Issues (1 found)"
+echo "- [nc-1]: global concern with no code location"
+echo ""
+echo "## Important Issues (0 found)"
+echo ""
+echo "## Suggestions (0 found)"
+EOS
+chmod +x "$NC_STUB"
+NC_JSON="$tmp/critics-nc.json"
+printf '%s' '{"panel":[{"slug":"nc","model":"fake/nc","provider":"test","tier":"free"}]}' > "$NC_JSON"
+NC_LEDGER="$tmp/nc-ledger.jsonl"
+: > "$NC_LEDGER"
+printf '%s' "$DIFF" | CR_LEDGER="$NC_LEDGER" CRITIC_LEDGER_APPEND="$HERE/ledger-append.sh" \
+    CRITICS_JSON="$NC_JSON" CRITIC_FIRST_PASS="$NC_STUB" bash "$PANEL" > "$tmp/nc-out" 2> "$tmp/nc-err"
+nc_fields="$(python3 - "$NC_LEDGER" <<'PYEOF'
+import json, sys
+rows = [json.loads(l) for l in open(sys.argv[1]) if l.strip()]
+f = [r for r in rows if r.get('kind') == 'finding']
+print('findings=' + str(len(f)))
+if f:
+    print('file=' + repr(f[0].get('file', '<MISSING>')))
+    print('line=' + repr(f[0].get('line', '<MISSING>')))
+else:
+    print('file=<no-finding>')
+    print('line=<no-finding>')
+PYEOF
+)"
+check "NC: citation-less finding self-appends (one finding row)" "$(printf '%s\n' "$nc_fields" | sed -n 's/^findings=//p')" "1"
+check "NC: citation-less finding has EMPTY file" "$(printf '%s\n' "$nc_fields" | sed -n 's/^file=//p')" "''"
+check "NC: citation-less finding has EMPTY line" "$(printf '%s\n' "$nc_fields" | sed -n 's/^line=//p')" "''"
 
 # Test E: missing registry -> anchor fallback
 stderr_e="$(printf '%s' "$DIFF" | CRITICS_JSON="$tmp/does-not-exist.json" CRITIC_FIRST_PASS="$STUB" bash "$PANEL" 2>&1 >/dev/null)"

--- a/scripts/cr/test-run-codex-adversarial.sh
+++ b/scripts/cr/test-run-codex-adversarial.sh
@@ -1,0 +1,947 @@
+#!/usr/bin/env bash
+# Execution tests for run-codex-adversarial.sh process cleanup and leases (HIMMEL-1474 r6).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RUNNER="$HERE/run-codex-adversarial.sh"
+PR_CHECK="$HERE/../../.claude/commands/pr-check.md"
+# shellcheck source=../lib/proc-tree.sh
+# shellcheck disable=SC1091
+. "$HERE/../lib/proc-tree.sh"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/himmel-run-codex-adversarial.XXXXXX")"
+fails=0
+unrelated_pid=''
+
+cleanup() {
+    if [ -n "$unrelated_pid" ]; then
+        kill -9 "$unrelated_pid" 2>/dev/null || true
+        wait "$unrelated_pid" 2>/dev/null || true
+    fi
+    if [ -s "$tmp/child.pid" ]; then
+        child_pid=$(cat "$tmp/child.pid")
+        kill -9 "$child_pid" 2>/dev/null || true
+        if command -v taskkill >/dev/null 2>&1; then
+            MSYS_NO_PATHCONV=1 taskkill /PID "$child_pid" /T /F >/dev/null 2>&1 || true
+        fi
+    fi
+    rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+check() {
+    if [ "$2" = "$3" ]; then
+        echo "ok - $1"
+    else
+        echo "FAIL - $1: got [$2] want [$3]"
+        fails=$((fails + 1))
+    fi
+}
+
+cat > "$tmp/stubborn-child.mjs" <<'JS'
+import fs from 'node:fs';
+const heartbeat = process.argv[2];
+process.on('SIGTERM', () => {});
+setInterval(() => fs.appendFileSync(heartbeat, 'x'), 100);
+JS
+
+cat > "$tmp/companion.mjs" <<'JS'
+import fs from 'node:fs';
+import { spawn } from 'node:child_process';
+const childScript = process.env.HIMMEL_R2_CHILD_SCRIPT;
+const childPidFile = process.env.HIMMEL_R2_CHILD_PID_FILE;
+const heartbeat = process.env.HIMMEL_R2_HEARTBEAT;
+const child = spawn(process.execPath, [childScript, heartbeat], { stdio: 'ignore' });
+fs.writeFileSync(childPidFile, String(child.pid));
+process.on('SIGTERM', () => {});
+setInterval(() => {}, 1000);
+JS
+
+cat > "$tmp/companion-exits.mjs" <<'JS'
+import fs from 'node:fs';
+import { spawn } from 'node:child_process';
+const childScript = process.env.HIMMEL_R2_CHILD_SCRIPT;
+const childPidFile = process.env.HIMMEL_R2_CHILD_PID_FILE;
+const heartbeat = process.env.HIMMEL_R2_HEARTBEAT;
+const child = spawn(process.execPath, [childScript, heartbeat], { stdio: 'ignore' });
+fs.writeFileSync(childPidFile, String(child.pid));
+child.unref();
+await new Promise(resolve => setTimeout(resolve, 2500));
+JS
+
+# HIMMEL-1474 r5: exercise the lease launch against a copied runner and a
+# proc-tree stub so both host branches are deterministic on every platform.
+mkdir -p "$tmp/lease-fixture/cr" "$tmp/lease-fixture/lib" "$tmp/lease-fixture/stub-bin"
+cp "$RUNNER" "$tmp/lease-fixture/cr/run-codex-adversarial.sh"
+# HIMMEL-1509: the runner sources the real render-lease lib; lease behavior
+# stays inert unless a test opts in via RENDER_LEASE_BRANCH.
+cp "$HERE/../lib/render-lease.sh" "$tmp/lease-fixture/lib/render-lease.sh"
+: > "$tmp/lease-fixture/cr/codex-render-client-lease.ps1"
+cat > "$tmp/lease-fixture/lib/proc-tree.sh" <<'SH'
+proc_tree_is_windows() {
+    [ "${HIMMEL_R5_WINDOWS:-0}" = "1" ]
+}
+proc_tree_winpid() {
+    printf '%s\n' "${HIMMEL_R5_WINPID:-}"
+}
+proc_tree_process_identity() {
+    if [ "${HIMMEL_R11_IDENTITY_UNAVAILABLE:-0}" = "1" ]; then
+        [ -z "${HIMMEL_R12_IDENTITY_PROBE_CALLED:-}" ] || printf x >> "$HIMMEL_R12_IDENTITY_PROBE_CALLED"
+        return 1
+    fi
+    printf '%s\n' test-identity
+}
+proc_tree_process_identity_matches() {
+    return "${HIMMEL_R6_IDENTITY_RC:-0}"
+}
+proc_tree_group_members() {
+    [ -z "${HIMMEL_R14_GROUP_MEMBERS:-}" ] || printf '%s\n' "$HIMMEL_R14_GROUP_MEMBERS"
+    return "${HIMMEL_R14_GROUP_MEMBERS_RC:-0}"
+}
+proc_tree_terminate() {
+    return "${HIMMEL_R6_TERMINATE_RC:-0}"
+}
+proc_tree_group_terminate() {
+    [ -z "${HIMMEL_R6_GROUP_TERMINATE_CALLED:-}" ] || : > "$HIMMEL_R6_GROUP_TERMINATE_CALLED"
+    if [ "${HIMMEL_R11_TERMINATE_REAL_GROUP:-0}" = "1" ]; then
+        kill -TERM -"$1" 2>/dev/null || kill -TERM "$1" 2>/dev/null || true
+    fi
+    return "${HIMMEL_R6_GROUP_TERMINATE_RC:-0}"
+}
+SH
+cat > "$tmp/lease-fixture/stub-bin/pwsh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${HIMMEL_R5_PWSH_ARGS:?}"
+SH
+chmod +x "$tmp/lease-fixture/stub-bin/pwsh"
+cat > "$tmp/lease-fixture/companion.mjs" <<'JS'
+await new Promise(resolve => setTimeout(resolve, 100));
+JS
+cat > "$tmp/lease-fixture/companion-lease.mjs" <<'JS'
+await new Promise(resolve => setTimeout(resolve, 3000));
+JS
+cat > "$tmp/lease-fixture/companion-delayed.mjs" <<'JS'
+await new Promise(resolve => setTimeout(resolve, 12000));
+JS
+cat > "$tmp/lease-fixture/companion-fails.mjs" <<'JS'
+process.exit(7);
+JS
+
+rm -f "$tmp/lease-windows.args" "$tmp/lease-windows.pid"
+runner_rc=0
+PATH="$tmp/lease-fixture/stub-bin:$PATH" \
+HIMMEL_R5_WINDOWS=1 \
+HIMMEL_R5_WINPID=424242 \
+HIMMEL_R5_PWSH_ARGS="$tmp/lease-windows.args" \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion-lease.mjs" main "$tmp/lease-windows.stdout" "$tmp/lease-windows.stderr" "$tmp/lease-windows.pid" || runner_rc=$?
+check "Windows lease runner exits 0" "$runner_rc" "0"
+check "Windows ownership pid sidecar is nonempty" "$(test -s "$tmp/lease-windows.pid" && echo nonempty || echo empty)" "nonempty"
+check "Windows ownership identity sidecar is nonempty" "$(test -s "$tmp/lease-windows.pid.identity" && echo nonempty || echo empty)" "nonempty"
+lease_pid=$(awk 'previous == "-ClientPid" { print; exit } { previous = $0 }' "$tmp/lease-windows.args" 2>/dev/null)
+check "Windows lease receives translated native pid" "$lease_pid" "424242"
+
+rm -f "$tmp/lease-posix.args" "$tmp/lease-posix.pid"
+runner_rc=0
+PATH="$tmp/lease-fixture/stub-bin:$PATH" \
+HIMMEL_R5_WINDOWS=0 \
+HIMMEL_R5_PWSH_ARGS="$tmp/lease-posix.args" \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion.mjs" main "$tmp/lease-posix.stdout" "$tmp/lease-posix.stderr" "$tmp/lease-posix.pid" || runner_rc=$?
+check "POSIX lease runner exits 0" "$runner_rc" "0"
+check "POSIX ownership pid sidecar is nonempty" "$(test -s "$tmp/lease-posix.pid" && echo nonempty || echo empty)" "nonempty"
+check "POSIX ownership identity sidecar is nonempty" "$(test -s "$tmp/lease-posix.pid.identity" && echo nonempty || echo empty)" "nonempty"
+lease_pid=$(awk 'previous == "-ClientPid" { print; exit } { previous = $0 }' "$tmp/lease-posix.args" 2>/dev/null)
+check "POSIX lease receives unchanged node pid" "$lease_pid" "$(cat "$tmp/lease-posix.pid")"
+
+rm -f "$tmp/lease-invalid.args" "$tmp/lease-invalid.pid"
+runner_rc=0
+PATH="$tmp/lease-fixture/stub-bin:$PATH" \
+HIMMEL_R5_WINDOWS=1 \
+HIMMEL_R5_WINPID=not-a-pid \
+HIMMEL_R5_PWSH_ARGS="$tmp/lease-invalid.args" \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion.mjs" main "$tmp/lease-invalid.stdout" "$tmp/lease-invalid.stderr" "$tmp/lease-invalid.pid" || runner_rc=$?
+check "invalid native pid runner exits 0" "$runner_rc" "0"
+check "invalid native pid skips lease writer" "$(test -e "$tmp/lease-invalid.args" && echo launched || echo skipped)" "skipped"
+
+# HIMMEL-1509: the branch render lease. RENDER_LEASE_BRANCH opts the launcher
+# into the registry: atomic claim before node spawns, release only on a
+# verified-clean exit, refusal (exit 75) on a held branch or unusable registry.
+reg1509="$tmp/reg-1509"
+rm -rf "$reg1509" "$tmp/lease-1509.pid"
+runner_rc=0
+RENDER_LEASE_DIR="$reg1509" RENDER_LEASE_BRANCH=feat/1509-clean \
+RENDER_LEASE_LOCK_ATTEMPTS=2 RENDER_LEASE_LOCK_DELAY_SECS=0 \
+HIMMEL_R5_WINDOWS=0 \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion.mjs" main "$tmp/lease-1509.stdout" "$tmp/lease-1509.stderr" "$tmp/lease-1509.pid" 2>"$tmp/lease-1509-runner.stderr" || runner_rc=$?
+check "leased clean run exits 0" "$runner_rc" "0"
+check "leased clean run creates the registry" "$(test -d "$reg1509" && echo present || echo absent)" "present"
+check "verified-clean exit releases the branch lease" "$(test -e "$reg1509/feat+2F1509-clean" && echo held || echo released)" "released"
+
+# The Windows heartbeat writer receives the lease dir so it can refresh the
+# registry heartbeat + tokens alongside the cxc client lease.
+rm -f "$tmp/lease-1509-win.args" "$tmp/lease-1509-win.pid"
+runner_rc=0
+PATH="$tmp/lease-fixture/stub-bin:$PATH" \
+RENDER_LEASE_DIR="$reg1509" RENDER_LEASE_BRANCH=feat/1509-win \
+RENDER_LEASE_LOCK_ATTEMPTS=2 RENDER_LEASE_LOCK_DELAY_SECS=0 \
+HIMMEL_R5_WINDOWS=1 \
+HIMMEL_R5_WINPID=424242 \
+HIMMEL_R5_PWSH_ARGS="$tmp/lease-1509-win.args" \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion-lease.mjs" main "$tmp/lease-1509-win.stdout" "$tmp/lease-1509-win.stderr" "$tmp/lease-1509-win.pid" || runner_rc=$?
+check "leased Windows runner exits 0" "$runner_rc" "0"
+lease_dir_arg=$(awk 'previous == "-LeaseDir" { print; exit } { previous = $0 }' "$tmp/lease-1509-win.args" 2>/dev/null)
+check "heartbeat writer receives the lease dir" "$(printf '%s\n' "$lease_dir_arg" | grep -Fc 'feat+2F1509-win')" "1"
+
+# Second launch on a branch holding a live lease refuses loudly, spawns
+# nothing, and preserves the holder's record (the HIMMEL-1496 TOCTOU closure).
+mkdir -p "$reg1509/feat+2F1509-held"
+printf 'branch\tfeat/1509-held\nworktree\t%s\nacquired_by\t999999\nstarted_at\t2026-01-01T00:00:00Z\nleader_pid\t424242\nleader_winpid\t424242\nleader_identity\ttest-identity\nstatus\trunning\n' \
+    "$tmp" > "$reg1509/feat+2F1509-held/lease.record"
+rm -f "$tmp/lease-1509-refused.stdout"
+runner_rc=0
+RENDER_LEASE_DIR="$reg1509" RENDER_LEASE_BRANCH=feat/1509-held \
+RENDER_LEASE_LOCK_ATTEMPTS=2 RENDER_LEASE_LOCK_DELAY_SECS=0 \
+HIMMEL_R6_IDENTITY_RC=0 \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion.mjs" main "$tmp/lease-1509-refused.stdout" "$tmp/lease-1509-refused.stderr" 2>"$tmp/lease-1509-refused-runner.stderr" || runner_rc=$?
+check "second launch on a held branch exits 75" "$runner_rc" "75"
+check "refused launch emits loud diagnostic" "$(grep -Fc 'launch REFUSED' "$tmp/lease-1509-refused-runner.stderr" 2>/dev/null)" "1"
+check "refused launch spawns no companion" "$(test -e "$tmp/lease-1509-refused.stdout" && echo spawned || echo refused)" "refused"
+check "refused launch preserves the holder record" "$(test -s "$reg1509/feat+2F1509-held/lease.record" && echo preserved || echo missing)" "preserved"
+
+# A stale lease with a CONFIRMED-dead leader is reclaimed by the next launch.
+mkdir -p "$reg1509/feat+2F1509-stale"
+printf 'branch\tfeat/1509-stale\nworktree\t%s\nacquired_by\t999999\nstarted_at\t2020-01-01T00:00:00Z\nleader_pid\t424243\nleader_winpid\t424243\nleader_identity\ttest-identity\nstatus\trunning\n' \
+    "$tmp" > "$reg1509/feat+2F1509-stale/lease.record"
+touch -t 202001010000 "$reg1509/feat+2F1509-stale/lease.record"
+runner_rc=0
+RENDER_LEASE_DIR="$reg1509" RENDER_LEASE_BRANCH=feat/1509-stale \
+RENDER_LEASE_LOCK_ATTEMPTS=2 RENDER_LEASE_LOCK_DELAY_SECS=0 \
+HIMMEL_R6_IDENTITY_RC=1 \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion.mjs" main "$tmp/lease-1509-stale.stdout" "$tmp/lease-1509-stale.stderr" 2>"$tmp/lease-1509-stale-runner.stderr" || runner_rc=$?
+check "stale-lease launch reclaims and exits 0" "$runner_rc" "0"
+check "stale-lease launch announces the reclaim" "$(grep -Fc 'reclaiming stale lease' "$tmp/lease-1509-stale-runner.stderr" 2>/dev/null)" "1"
+check "reclaimed lease is released on clean exit" "$(test -e "$reg1509/feat+2F1509-stale" && echo held || echo released)" "released"
+
+# An UNVERIFIED exit (cleanup rc nonzero) leaves the lease for adjudication.
+runner_rc=0
+RENDER_LEASE_DIR="$reg1509" RENDER_LEASE_BRANCH=feat/1509-dirty \
+RENDER_LEASE_LOCK_ATTEMPTS=2 RENDER_LEASE_LOCK_DELAY_SECS=0 \
+HIMMEL_R6_GROUP_TERMINATE_RC=1 \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion.mjs" main "$tmp/lease-1509-dirty.stdout" "$tmp/lease-1509-dirty.stderr" 2>"$tmp/lease-1509-dirty-runner.stderr" || runner_rc=$?
+check "unverified-cleanup leased run exits 125" "$runner_rc" "125"
+check "unverified exit preserves the lease" "$(test -s "$reg1509/feat+2F1509-dirty/lease.record" && echo preserved || echo released)" "preserved"
+check "preserved lease is announced for adjudication" "$(grep -Fc 'lease preserved for adjudication' "$tmp/lease-1509-dirty-runner.stderr" 2>/dev/null)" "1"
+
+# An unusable registry refuses the launch (fail-closed) instead of running
+# untracked.
+printf 'not a dir' > "$tmp/reg-blocker"
+runner_rc=0
+RENDER_LEASE_DIR="$tmp/reg-blocker/sub" RENDER_LEASE_BRANCH=feat/1509-broken \
+RENDER_LEASE_LOCK_ATTEMPTS=2 RENDER_LEASE_LOCK_DELAY_SECS=0 \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion.mjs" main "$tmp/lease-1509-broken.stdout" "$tmp/lease-1509-broken.stderr" 2>"$tmp/lease-1509-broken-runner.stderr" || runner_rc=$?
+check "unusable registry refuses the launch with 75" "$runner_rc" "75"
+check "unusable registry refusal is loud" "$(grep -Fc 'launch REFUSED' "$tmp/lease-1509-broken-runner.stderr" 2>/dev/null)" "1"
+
+# pr-check wiring: kickoff probe + both fences exporting the launch claim.
+# shellcheck disable=SC2016
+lease_export_wiring=$(grep -Fc 'export RENDER_LEASE_BRANCH="$branch"' "$PR_CHECK" 2>/dev/null)
+check "kickoff and harvest both export the launch claim" "$lease_export_wiring" "2"
+# shellcheck disable=SC2016
+lease_probe_wiring=$(grep -Fc 'render_lease_probe "$branch"' "$PR_CHECK" 2>/dev/null)
+check "kickoff pre-flights the branch lease probe" "$lease_probe_wiring" "1"
+lease_source_wiring=$(grep -Fc '. scripts/lib/render-lease.sh' "$PR_CHECK" 2>/dev/null)
+check "kickoff sources the render-lease lib" "$lease_source_wiring" "1"
+
+# HIMMEL-1474 r11: launch identity is a required ownership handshake. Persistent
+# INITIAL probe failure must terminate the still-owned group before returning,
+# and must never publish a pid without its identity anchor.
+rm -f "$tmp/initial-identity.pid" "$tmp/initial-identity.pid.identity" "$tmp/initial-identity-terminated"
+runner_rc=0
+HIMMEL_R11_IDENTITY_UNAVAILABLE=1 \
+HIMMEL_R11_TERMINATE_REAL_GROUP=1 \
+HIMMEL_R6_GROUP_TERMINATE_CALLED="$tmp/initial-identity-terminated" \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion-delayed.mjs" main "$tmp/initial-identity.stdout" "$tmp/initial-identity.stderr" "$tmp/initial-identity.pid" 2>"$tmp/initial-identity-runner.stderr" || runner_rc=$?
+check "initial identity failure returns unavailable" "$runner_rc" "125"
+check "initial identity failure terminates the owned group" "$(test -e "$tmp/initial-identity-terminated" && echo terminated || echo missed)" "terminated"
+check "initial identity failure publishes no pid" "$(test -e "$tmp/initial-identity.pid" && echo published || echo absent)" "absent"
+check "initial identity failure publishes no identity" "$(test -e "$tmp/initial-identity.pid.identity" && echo published || echo absent)" "absent"
+initial_identity_diagnostic=$(grep -Fc "process identity could not be captured" "$tmp/initial-identity-runner.stderr" 2>/dev/null)
+check "initial identity failure reports unavailable launch" "$initial_identity_diagnostic" "1"
+
+# HIMMEL-1474 r12: a signal during that identity retry window must either reap
+# the still-owned group or publish recovery handles before the wrapper exits.
+rm -f "$tmp/handshake-signal.pid" "$tmp/handshake-signal.pid.identity" "$tmp/handshake-signal.pid.cleanup-rc" "$tmp/handshake-signal-probed"
+HIMMEL_R11_IDENTITY_UNAVAILABLE=1 \
+HIMMEL_R12_IDENTITY_PROBE_CALLED="$tmp/handshake-signal-probed" \
+HIMMEL_R11_TERMINATE_REAL_GROUP=1 \
+HIMMEL_R6_GROUP_TERMINATE_RC=1 \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion-delayed.mjs" main "$tmp/handshake-signal.stdout" "$tmp/handshake-signal.stderr" "$tmp/handshake-signal.pid" 0 "$tmp/handshake-signal.pid.cleanup-rc" 2>"$tmp/handshake-signal-runner.stderr" &
+handshake_wrapper_pid=$!
+waited=0
+while [ ! -e "$tmp/handshake-signal-probed" ] && kill -0 "$handshake_wrapper_pid" 2>/dev/null && [ "$waited" -lt 50 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+done
+handshake_probes_before=$(wc -c < "$tmp/handshake-signal-probed" | tr -d ' ')
+kill -TERM "$handshake_wrapper_pid" 2>/dev/null || true
+handshake_signal_rc=0
+wait "$handshake_wrapper_pid" 2>/dev/null || handshake_signal_rc=$?
+handshake_probes_after=$(wc -c < "$tmp/handshake-signal-probed" | tr -d ' ')
+check "signal during identity handshake exits 143" "$handshake_signal_rc" "143"
+check "failed signal cleanup retries identity acquisition" "$([ "$handshake_probes_after" -gt "$handshake_probes_before" ] && echo retried || echo missed)" "retried"
+check "failed handshake identity reacquisition leaves no pid marker" "$(test -e "$tmp/handshake-signal.pid" && echo published || echo absent)" "absent"
+check "failed handshake identity reacquisition leaves no identity marker" "$(test -e "$tmp/handshake-signal.pid.identity" && echo published || echo absent)" "absent"
+check "unverified handshake signal publishes cleanup status" "$(cat "$tmp/handshake-signal.pid.cleanup-rc" 2>/dev/null)" "1"
+handshake_unrecoverable_diagnostic=$(grep -Fc "signal cleanup UNRECOVERABLE" "$tmp/handshake-signal-runner.stderr" 2>/dev/null)
+check "failed handshake identity reacquisition emits loud diagnostic" "$handshake_unrecoverable_diagnostic" "1"
+
+# HIMMEL-1474 r6: a cleanup primitive failure is separate from the companion
+# result. A clean companion cannot publish rc 0 while its group may survive.
+runner_rc=0
+HIMMEL_R6_GROUP_TERMINATE_RC=1 \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion.mjs" main "$tmp/cleanup.stdout" "$tmp/cleanup.stderr" 2>"$tmp/cleanup-runner.stderr" || runner_rc=$?
+check "cleanup failure after companion success exits 125" "$runner_rc" "125"
+cleanup_diagnostic=$(grep -Fc "codex adversarial cleanup failed for pid/group" "$tmp/cleanup-runner.stderr" 2>/dev/null)
+check "cleanup failure names the pid/group on stderr" "$cleanup_diagnostic" "1"
+
+rm -f "$tmp/group-terminate-called" "$tmp/identity-unavailable.pid" "$tmp/identity-unavailable.pid.identity"
+runner_rc=0
+identity_started=$SECONDS
+HIMMEL_R6_IDENTITY_RC=2 HIMMEL_R6_GROUP_TERMINATE_CALLED="$tmp/group-terminate-called" \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion-delayed.mjs" main "$tmp/identity-unavailable.stdout" "$tmp/identity-unavailable.stderr" "$tmp/identity-unavailable.pid" 1 2>"$tmp/identity-unavailable-runner.stderr" || runner_rc=$?
+identity_elapsed=$((SECONDS - identity_started))
+check "identity-unavailable timeout keeps rc 124" "$runner_rc" "124"
+check "identity-unavailable timeout skips blocking wait" "$([ "$identity_elapsed" -lt 10 ] && echo bounded || echo blocked)" "bounded"
+check "identity-unavailable cleanup sends no group signal" "$(test -e "$tmp/group-terminate-called" && echo signaled || echo skipped)" "skipped"
+check "identity-unavailable timeout preserves pid sidecar" "$(test -s "$tmp/identity-unavailable.pid" && echo preserved || echo missing)" "preserved"
+check "identity-unavailable timeout preserves identity sidecar" "$(test -s "$tmp/identity-unavailable.pid.identity" && echo preserved || echo missing)" "preserved"
+identity_cleanup_diagnostic=$(grep -Fc "identity probe unavailable; no signal sent" "$tmp/identity-unavailable-runner.stderr" 2>/dev/null)
+check "identity-unavailable cleanup emits diagnostic" "$identity_cleanup_diagnostic" "1"
+identity_wait_diagnostic=$(grep -Fc "timeout cleanup incomplete for pid/group" "$tmp/identity-unavailable-runner.stderr" 2>/dev/null)
+check "identity-unavailable timeout reports skipped blocking wait" "$identity_wait_diagnostic" "1"
+identity_unavailable_pid=$(cat "$tmp/identity-unavailable.pid")
+kill -9 "$identity_unavailable_pid" 2>/dev/null || true
+if command -v taskkill >/dev/null 2>&1; then
+    MSYS_NO_PATHCONV=1 taskkill /PID "$identity_unavailable_pid" /T /F >/dev/null 2>&1 || true
+fi
+
+runner_rc=0
+HIMMEL_R6_TERMINATE_RC=1 \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion-delayed.mjs" main "$tmp/cleanup-timeout.stdout" "$tmp/cleanup-timeout.stderr" "" 1 2>"$tmp/cleanup-timeout-runner.stderr" || runner_rc=$?
+check "timeout keeps rc 124 when cleanup fails" "$runner_rc" "124"
+timeout_cleanup_diagnostic=$(grep -Fc "codex adversarial cleanup failed for pid/group" "$tmp/cleanup-timeout-runner.stderr" 2>/dev/null)
+check "timeout cleanup failure still emits diagnostic" "$timeout_cleanup_diagnostic" "1"
+
+runner_rc=0
+HIMMEL_R2_CHILD_SCRIPT="$tmp/stubborn-child.mjs" \
+HIMMEL_R2_CHILD_PID_FILE="$tmp/child.pid" \
+HIMMEL_R2_HEARTBEAT="$tmp/heartbeat" \
+    bash "$RUNNER" "$tmp/companion.mjs" main "$tmp/stdout" "$tmp/stderr" "" 1 || runner_rc=$?
+check "timeout exits 124" "$runner_rc" "124"
+
+waited=0
+while [ ! -s "$tmp/heartbeat" ] && [ "$waited" -lt 20 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+done
+if [ -s "$tmp/heartbeat" ]; then
+    size_before=$(wc -c < "$tmp/heartbeat" | tr -d ' ')
+    sleep 2
+    size_after=$(wc -c < "$tmp/heartbeat" | tr -d ' ')
+    check "timeout stops stubborn descendants with the companion group" "$size_after" "$size_before"
+else
+    echo "FAIL - stubborn child never wrote its heartbeat"
+    fails=$((fails + 1))
+fi
+
+# HIMMEL-1474 r4: a successful leader exit is not group completion. The runner
+# must sweep stubborn descendants before returning the leader's rc.
+rm -f "$tmp/child.pid" "$tmp/heartbeat"
+runner_rc=0
+HIMMEL_R2_CHILD_SCRIPT="$tmp/stubborn-child.mjs" \
+HIMMEL_R2_CHILD_PID_FILE="$tmp/child.pid" \
+HIMMEL_R2_HEARTBEAT="$tmp/heartbeat" \
+    bash "$RUNNER" "$tmp/companion-exits.mjs" main "$tmp/stdout-exit" "$tmp/stderr-exit" || runner_rc=$?
+check "leader-exit companion preserves rc 0" "$runner_rc" "0"
+if [ -s "$tmp/heartbeat" ]; then
+    size_before=$(wc -c < "$tmp/heartbeat" | tr -d ' ')
+    sleep 2
+    size_after=$(wc -c < "$tmp/heartbeat" | tr -d ' ')
+    check "leader exit sweeps stubborn group descendants" "$size_after" "$size_before"
+else
+    echo "FAIL - leader-exit stubborn child never wrote its heartbeat"
+    fails=$((fails + 1))
+fi
+
+# HIMMEL-1474 r3: production uses the 5-argument async kickoff, then harvests
+# the recorded node group leader later. A taskkill stub makes any Windows-only
+# escape visible while the portable group kill must stop the stubborn child.
+rm -f "$tmp/child.pid" "$tmp/heartbeat" "$tmp/async.pid" "$tmp/async.rc" "$tmp/taskkill-called"
+mkdir -p "$tmp/stub-bin"
+cat > "$tmp/stub-bin/taskkill" <<'SH'
+#!/usr/bin/env bash
+: > "${HIMMEL_R3_TASKKILL_CALLED:?}"
+exit 127
+SH
+chmod +x "$tmp/stub-bin/taskkill"
+(
+    PATH="$tmp/stub-bin:$PATH" \
+    HIMMEL_R2_CHILD_SCRIPT="$tmp/stubborn-child.mjs" \
+    HIMMEL_R2_CHILD_PID_FILE="$tmp/child.pid" \
+    HIMMEL_R2_HEARTBEAT="$tmp/heartbeat" \
+    HIMMEL_R3_TASKKILL_CALLED="$tmp/taskkill-called" \
+        bash "$RUNNER" "$tmp/companion.mjs" main "$tmp/stdout-async" "$tmp/stderr-async" "$tmp/async.pid"
+    printf '%s\n' "$?" > "$tmp/async.rc"
+) &
+async_job=$!
+
+waited=0
+while { [ ! -s "$tmp/async.pid" ] || [ ! -s "$tmp/async.pid.identity" ] || [ ! -s "$tmp/heartbeat" ]; } && [ "$waited" -lt 50 ]; do
+    sleep 0.1
+    waited=$((waited + 1))
+done
+if [ -s "$tmp/async.pid" ] && [ -s "$tmp/async.pid.identity" ] && [ -s "$tmp/heartbeat" ]; then
+    async_pid=$(cat "$tmp/async.pid")
+    async_identity=$(cat "$tmp/async.pid.identity")
+    check "5-arg kickoff publishes matching process identity" "$(proc_tree_process_identity_matches "$async_pid" "$async_identity" && echo match || echo mismatch)" "match"
+    PATH="$tmp/stub-bin:$PATH" HIMMEL_R3_TASKKILL_CALLED="$tmp/taskkill-called" \
+        proc_tree_terminate "$async_pid" 1 "$async_identity" || true
+    wait "$async_job" 2>/dev/null || true
+    size_before=$(wc -c < "$tmp/heartbeat" | tr -d ' ')
+    sleep 2
+    size_after=$(wc -c < "$tmp/heartbeat" | tr -d ' ')
+    check "5-arg harvest stops stubborn descendants with the recorded group" "$size_after" "$size_before"
+    check "5-arg harvest does not need taskkill" "$(test -e "$tmp/taskkill-called" && echo called || echo absent)" "absent"
+else
+    echo "FAIL - 5-arg kickoff did not publish pid and child heartbeat"
+    fails=$((fails + 1))
+fi
+
+# HIMMEL-1474 r4: model the recycled-pid harvest case against the same guarded
+# primitive wired into pr-check. A mismatched anchor must return before signal.
+set -m
+sleep 30 &
+unrelated_pid=$!
+set +m
+unrelated_identity=$(proc_tree_process_identity "$unrelated_pid") || unrelated_identity=''
+guard_rc=0
+proc_tree_terminate "$unrelated_pid" 0 "${unrelated_identity}-recycled" || guard_rc=$?
+check "identity mismatch refuses to signal recycled pid" "$guard_rc" "2"
+check "identity-mismatched unrelated process remains alive" "$(kill -0 "$unrelated_pid" 2>/dev/null && echo alive || echo dead)" "alive"
+kill -9 "$unrelated_pid" 2>/dev/null || true
+wait "$unrelated_pid" 2>/dev/null || true
+unrelated_pid=''
+
+# HIMMEL-1474 r6: identity checks distinguish confirmed mismatch/exit from an
+# unavailable probe so harvest can wait through transient infrastructure gaps.
+identity_match_rc=0
+(
+    # shellcheck disable=SC2317,SC2329
+    proc_tree_is_windows() { return 1; }
+    # shellcheck disable=SC2317,SC2329
+    ps() { printf '%s\n' 'Mon Aug  3 00:00:00 2026 bash test-runner'; }
+    current_identity=$(proc_tree_process_identity "$$") || exit 9
+    proc_tree_process_identity_matches "$$" "$current_identity"
+) || identity_match_rc=$?
+check "identity probe returns 0 for a confirmed match" "$identity_match_rc" "0"
+
+identity_exit_rc=0
+(
+    # shellcheck disable=SC2317,SC2329
+    proc_tree_is_windows() { return 1; }
+    proc_tree_process_identity_matches 2147483647 "posix:gone"
+) || identity_exit_rc=$?
+check "identity probe returns 1 for a confirmed exit" "$identity_exit_rc" "1"
+
+identity_unavailable_rc=0
+(
+    # shellcheck disable=SC2317,SC2329
+    proc_tree_is_windows() { return 1; }
+    # shellcheck disable=SC2317,SC2329
+    ps() { return 1; }
+    proc_tree_process_identity_matches "$$" "posix:unavailable"
+) || identity_unavailable_rc=$?
+check "identity probe returns 2 when ps fails for a live pid" "$identity_unavailable_rc" "2"
+
+process_alive_rc=0
+proc_tree_process_alive "$$" || process_alive_rc=$?
+check "identity-free liveness probe confirms current shell" "$process_alive_rc" "0"
+process_gone_rc=0
+proc_tree_process_alive 2147483647 || process_gone_rc=$?
+check "identity-free liveness probe confirms absent pid" "$process_gone_rc" "1"
+
+# HIMMEL-1474 r6b: execute the production harvest loop with deterministic
+# identity and sleep stubs. An unavailable probe must consume the wait budget;
+# only a confirmed mismatch/exit may abandon the wait at waited=0.
+harvest_loop_extract_rc=0
+harvest_loop=$(awk '
+    /while \[ ! -s "\$codex_rc_file" \]; do/ { capture=1 }
+    capture {
+        sub(/^       /, "")
+        print
+        if ($0 == "done") { complete=1; exit }
+    }
+    END { if (!complete) exit 42 }
+' "$PR_CHECK") || harvest_loop_extract_rc=$?
+check "harvest-loop extractor reaches its terminating done" "$harvest_loop_extract_rc" "0"
+# shellcheck disable=SC2034,SC2317,SC2329
+harvest_unavailable_result=$(
+    codex_rc_file="$tmp/harvest-unavailable.rc"
+    codex_pid=424242
+    codex_identity=''
+    codex_to=5
+    waited=0
+    probe_count=0
+    proc_tree_process_identity_matches() {
+        probe_count=$((probe_count + 1))
+        return 2
+    }
+    sleep() { :; }
+    eval "$harvest_loop"
+    printf '%s:%s\n' "$probe_count" "$waited"
+)
+check "identity-unavailable harvest waits through waited=0" "$harvest_unavailable_result" "2:5"
+
+# shellcheck disable=SC2034,SC2317,SC2329
+harvest_mismatch_result=$(
+    codex_rc_file="$tmp/harvest-mismatch.rc"
+    codex_pid=424242
+    codex_identity='test-identity'
+    codex_to=5
+    waited=0
+    probe_count=0
+    proc_tree_process_identity_matches() {
+        probe_count=$((probe_count + 1))
+        return 1
+    }
+    sleep() { :; }
+    eval "$harvest_loop"
+    printf '%s:%s\n' "$probe_count" "$waited"
+)
+check "identity mismatch harvest breaks at waited=0" "$harvest_mismatch_result" "1:0"
+
+harvest_wiring=$(grep -Fc "proc_tree_terminate \"\$codex_pid\" 1 \"\$codex_identity\"" "$PR_CHECK" 2>/dev/null)
+check "production harvest passes launch identity to proc_tree_terminate" "$harvest_wiring" "1"
+identity_file_wiring=$(grep -Fc "codex_identity_file=\"\${codex_pid_file}.identity\"" "$PR_CHECK" 2>/dev/null)
+check "kickoff and harvest share the identity sidecar" "$identity_file_wiring" "2"
+survivors_file_wiring=$(grep -Fc "codex_survivors_file=\"\${codex_pid_file}.survivors\"" "$PR_CHECK" 2>/dev/null)
+check "kickoff and harvest share the survivor sidecar" "$survivors_file_wiring" "2"
+rc_first_wiring=$(grep -Fc "while [ ! -s \"\$codex_rc_file\" ]; do" "$PR_CHECK" 2>/dev/null)
+check "production harvest checks rc before identity probing" "$rc_first_wiring" "1"
+
+# HIMMEL-1474 r11/r12: execute the kickoff recovery fence. Cleanup status is
+# record-scoped, so a clean primary can be cleared independently of a failed
+# retry while an unverifiable record still blocks overwrite.
+kickoff_recovery_extract_rc=0
+kickoff_recovery_block=$(awk '
+    /HIMMEL-1474 r11 kickoff recovery start/ { capture=1; next }
+    /HIMMEL-1474 r11 kickoff recovery end/ {
+        if (capture) complete=1
+        exit
+    }
+    capture { sub(/^   /, ""); print }
+    END { if (!complete) exit 42 }
+' "$PR_CHECK") || kickoff_recovery_extract_rc=$?
+check "kickoff-recovery extractor reaches its end marker" "$kickoff_recovery_extract_rc" "0"
+handshake_next_kickoff_rc=0
+# shellcheck disable=SC2034,SC2317,SC2329
+(
+    codex_pid_file="$tmp/handshake-signal.pid"
+    codex_retry_pid_file="$tmp/handshake-signal-retry.pid"
+    proc_tree_process_identity_matches() { return 9; }
+    proc_tree_terminate() { return 9; }
+    eval "$kickoff_recovery_block"
+) 2>"$tmp/handshake-next-kickoff.stderr" || handshake_next_kickoff_rc=$?
+check "failed blank-identity recovery does not block the next kickoff" "$handshake_next_kickoff_rc" "0"
+check "next kickoff clears orphan cleanup status without a pid marker" "$(test -e "$tmp/handshake-signal.pid.cleanup-rc" && echo preserved || echo cleared)" "cleared"
+
+rm -f "$tmp/kickoff-primary.pid" "$tmp/kickoff-primary.pid.identity" "$tmp/kickoff-primary.pid.cleanup-rc" \
+      "$tmp/kickoff-retry.pid" "$tmp/kickoff-retry.pid.identity" "$tmp/kickoff-retry.pid.cleanup-rc"
+printf '%s\n' 424243 > "$tmp/kickoff-primary.pid"
+printf '%s\n' primary-identity > "$tmp/kickoff-primary.pid.identity"
+printf '%s\n' 0 > "$tmp/kickoff-primary.pid.cleanup-rc"
+printf '%s\n' 424244 > "$tmp/kickoff-retry.pid"
+printf '%s\n' retry-identity > "$tmp/kickoff-retry.pid.identity"
+printf '%s\n' 1 > "$tmp/kickoff-retry.pid.cleanup-rc"
+kickoff_mixed_rc=0
+# shellcheck disable=SC2034,SC2317,SC2329
+(
+    codex_pid_file="$tmp/kickoff-primary.pid"
+    codex_retry_pid_file="$tmp/kickoff-retry.pid"
+    proc_tree_process_identity_matches() { return 2; }
+    proc_tree_terminate() { return 9; }
+    eval "$kickoff_recovery_block"
+) 2>"$tmp/kickoff-mixed.stderr" || kickoff_mixed_rc=$?
+check "failed retry blocks kickoff after clean primary is cleared" "$kickoff_mixed_rc" "1"
+check "clean primary record is removed independently" "$(test -e "$tmp/kickoff-primary.pid" && echo preserved || echo cleared)" "cleared"
+check "clean primary cleanup status is removed independently" "$(test -e "$tmp/kickoff-primary.pid.cleanup-rc" && echo preserved || echo cleared)" "cleared"
+check "failed retry pid remains preserved" "$(test -s "$tmp/kickoff-retry.pid" && echo preserved || echo missing)" "preserved"
+check "failed retry cleanup status remains preserved" "$(cat "$tmp/kickoff-retry.pid.cleanup-rc" 2>/dev/null)" "1"
+
+kickoff_recover_rc=0
+# shellcheck disable=SC2034,SC2317,SC2329
+(
+    codex_pid_file="$tmp/kickoff-primary.pid"
+    codex_retry_pid_file="$tmp/kickoff-retry.pid"
+    proc_tree_process_identity_matches() { return 0; }
+    proc_tree_terminate() { return 0; }
+    eval "$kickoff_recovery_block"
+) 2>"$tmp/kickoff-recover.stderr" || kickoff_recover_rc=$?
+check "kickoff recovers prior retry ownership state" "$kickoff_recover_rc" "0"
+check "kickoff recovery clears retry pid sidecar" "$(test -e "$tmp/kickoff-retry.pid" && echo preserved || echo cleared)" "cleared"
+check "kickoff recovery clears retry identity sidecar" "$(test -e "$tmp/kickoff-retry.pid.identity" && echo preserved || echo cleared)" "cleared"
+check "kickoff recovery clears retry cleanup status" "$(test -e "$tmp/kickoff-retry.pid.cleanup-rc" && echo preserved || echo cleared)" "cleared"
+kickoff_recover_diagnostic=$(grep -Fc "recovered prior retry render" "$tmp/kickoff-recover.stderr" 2>/dev/null)
+check "kickoff recovery reports recovered retry" "$kickoff_recover_diagnostic" "1"
+
+printf '%s\n' 424245 > "$tmp/kickoff-primary.pid"
+printf '%s\n' primary-identity > "$tmp/kickoff-primary.pid.identity"
+printf '%s\n' 2 > "$tmp/kickoff-primary.pid.cleanup-rc"
+kickoff_block_rc=0
+# shellcheck disable=SC2034,SC2317,SC2329
+(
+    codex_pid_file="$tmp/kickoff-primary.pid"
+    codex_retry_pid_file="$tmp/kickoff-retry.pid"
+    proc_tree_process_identity_matches() { return 2; }
+    proc_tree_terminate() { return 9; }
+    eval "$kickoff_recovery_block"
+) 2>"$tmp/kickoff-block.stderr" || kickoff_block_rc=$?
+check "kickoff blocks unverifiable preserved state" "$kickoff_block_rc" "1"
+check "blocked kickoff preserves primary pid sidecar" "$(test -s "$tmp/kickoff-primary.pid" && echo preserved || echo missing)" "preserved"
+check "blocked kickoff preserves primary identity sidecar" "$(test -s "$tmp/kickoff-primary.pid.identity" && echo preserved || echo missing)" "preserved"
+check "blocked kickoff preserves primary cleanup status" "$(cat "$tmp/kickoff-primary.pid.cleanup-rc" 2>/dev/null)" "2"
+kickoff_block_diagnostic=$(grep -Fc "kickoff BLOCKED" "$tmp/kickoff-block.stderr" 2>/dev/null)
+check "blocked kickoff emits actionable diagnostic" "$kickoff_block_diagnostic" "1"
+
+# HIMMEL-1474 r14: once a failed cleanup record's leader exits, survivor
+# identities are the remaining recovery authority. Exercise both unverified
+# cleanup statuses through the launcher and the next kickoff fence.
+for survivor_cleanup_rc in 1 2; do
+    survivor_prefix="$tmp/survivor-anchor-$survivor_cleanup_rc"
+    rm -f "$survivor_prefix.pid" "$survivor_prefix.pid.identity" "$survivor_prefix.pid.cleanup-rc" "$survivor_prefix.pid.survivors" "$survivor_prefix-killed" "$survivor_prefix-signals"
+    runner_rc=0
+    HIMMEL_R6_GROUP_TERMINATE_RC="$survivor_cleanup_rc" HIMMEL_R14_GROUP_MEMBERS=5151 \
+        bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion.mjs" main "$survivor_prefix.stdout" "$survivor_prefix.stderr" "$survivor_prefix.pid" 0 "$survivor_prefix.pid.cleanup-rc" 2>"$survivor_prefix-runner.stderr" || runner_rc=$?
+    check "cleanup rc $survivor_cleanup_rc after leader exit remains unavailable" "$runner_rc" "125"
+    survivor_record=$(awk -F'\t' '{ print $1 ":" $2; exit }' "$survivor_prefix.pid.survivors" 2>/dev/null)
+    check "cleanup rc $survivor_cleanup_rc publishes survivor identity sidecar" "$survivor_record" "5151:test-identity"
+    survivor_leader_pid=$(cat "$survivor_prefix.pid")
+    survivor_recover_rc=0
+    # shellcheck disable=SC2034,SC2317,SC2329
+    (
+        codex_pid_file="$survivor_prefix.pid"
+        codex_retry_pid_file="$survivor_prefix-retry.pid"
+        proc_tree_process_identity_matches() {
+            if [ "$1" = "$survivor_leader_pid" ]; then
+                return 1
+            fi
+            if [ "$1" = "5151" ] && [ "$2" = "test-identity" ] && [ ! -e "$survivor_prefix-killed" ]; then
+                return 0
+            fi
+            return 1
+        }
+        proc_tree_process_alive() {
+            [ "$1" = "5151" ] && [ ! -e "$survivor_prefix-killed" ]
+        }
+        proc_tree_process_identity() { return 1; }
+        proc_tree_terminate() { return 9; }
+        kill() {
+            printf '%s:%s\n' "$1" "$2" >> "$survivor_prefix-signals"
+            [ "$1" != "-TERM" ] || : > "$survivor_prefix-killed"
+            return 0
+        }
+        sleep() { :; }
+        eval "$kickoff_recovery_block"
+    ) 2>"$survivor_prefix-recover.stderr" || survivor_recover_rc=$?
+    check "cleanup rc $survivor_cleanup_rc next kickoff recovers through survivor anchor" "$survivor_recover_rc" "0"
+    check "cleanup rc $survivor_cleanup_rc recovery signals verified survivor" "$(grep -Fc -- '-TERM:5151' "$survivor_prefix-signals" 2>/dev/null)" "1"
+    check "cleanup rc $survivor_cleanup_rc recovery clears survivor sidecar" "$(test -e "$survivor_prefix.pid.survivors" && echo preserved || echo cleared)" "cleared"
+done
+
+# An unavailable process-table snapshot must not publish an empty sidecar that
+# a later kickoff could mistake for definitive group absence.
+rm -f "$tmp/survivor-snapshot-failed.pid" "$tmp/survivor-snapshot-failed.pid.identity" "$tmp/survivor-snapshot-failed.pid.cleanup-rc" "$tmp/survivor-snapshot-failed.pid.survivors"
+runner_rc=0
+HIMMEL_R6_GROUP_TERMINATE_RC=1 HIMMEL_R14_GROUP_MEMBERS_RC=1 \
+    bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion.mjs" main "$tmp/survivor-snapshot-failed.stdout" "$tmp/survivor-snapshot-failed.stderr" "$tmp/survivor-snapshot-failed.pid" 0 "$tmp/survivor-snapshot-failed.pid.cleanup-rc" 2>"$tmp/survivor-snapshot-failed-runner.stderr" || runner_rc=$?
+check "unavailable survivor snapshot keeps cleanup unavailable" "$runner_rc" "125"
+check "unavailable survivor snapshot publishes no false-empty sidecar" "$(test -e "$tmp/survivor-snapshot-failed.pid.survivors" && echo published || echo absent)" "absent"
+check "unavailable survivor snapshot emits diagnostic" "$(grep -Fc 'survivor snapshot unavailable' "$tmp/survivor-snapshot-failed-runner.stderr" 2>/dev/null)" "1"
+
+# A complete r14 snapshot may name survivors that exited before the next
+# kickoff. Confirmed absence is definitive and clears the preserved record.
+printf '%s\n' 424250 > "$tmp/survivors-gone.pid"
+printf '%s\n' leader-identity > "$tmp/survivors-gone.pid.identity"
+printf '%s\n' 1 > "$tmp/survivors-gone.pid.cleanup-rc"
+printf '5152\ttest-identity\n' > "$tmp/survivors-gone.pid.survivors"
+survivors_gone_rc=0
+# shellcheck disable=SC2034,SC2317,SC2329
+(
+    codex_pid_file="$tmp/survivors-gone.pid"
+    codex_retry_pid_file="$tmp/survivors-gone-retry.pid"
+    proc_tree_process_identity_matches() { return 1; }
+    proc_tree_process_alive() { return 1; }
+    proc_tree_process_identity() { return 1; }
+    proc_tree_terminate() { return 9; }
+    kill() { return 9; }
+    eval "$kickoff_recovery_block"
+) 2>"$tmp/survivors-gone.stderr" || survivors_gone_rc=$?
+check "exited leader with all survivor anchors gone proceeds" "$survivors_gone_rc" "0"
+check "all-gone survivor recovery clears ownership record" "$(test -e "$tmp/survivors-gone.pid" && echo preserved || echo cleared)" "cleared"
+
+# A live pid with a different identity is not the recorded survivor and cannot
+# be signaled or silently treated as absence.
+printf '%s\n' 424251 > "$tmp/survivor-mismatch.pid"
+printf '%s\n' leader-identity > "$tmp/survivor-mismatch.pid.identity"
+printf '%s\n' 2 > "$tmp/survivor-mismatch.pid.cleanup-rc"
+printf '5153\ttest-identity\n' > "$tmp/survivor-mismatch.pid.survivors"
+survivor_mismatch_rc=0
+# shellcheck disable=SC2034,SC2317,SC2329
+(
+    codex_pid_file="$tmp/survivor-mismatch.pid"
+    codex_retry_pid_file="$tmp/survivor-mismatch-retry.pid"
+    proc_tree_process_identity_matches() { return 1; }
+    proc_tree_process_alive() { [ "$1" = "5153" ]; }
+    proc_tree_process_identity() {
+        [ "$1" != "5153" ] || printf '%s\n' recycled-identity
+    }
+    proc_tree_terminate() { return 9; }
+    kill() { return 9; }
+    eval "$kickoff_recovery_block"
+) 2>"$tmp/survivor-mismatch.stderr" || survivor_mismatch_rc=$?
+check "identity-mismatched survivor blocks kickoff" "$survivor_mismatch_rc" "1"
+check "identity-mismatched survivor record stays preserved" "$(test -s "$tmp/survivor-mismatch.pid.survivors" && echo preserved || echo missing)" "preserved"
+check "identity-mismatched survivor diagnostic names mismatch" "$(grep -Fc 'identity mismatch' "$tmp/survivor-mismatch.stderr" 2>/dev/null)" "1"
+
+# Pre-r14 failed records have no survivor anchors. Preserve the old fail-closed
+# manual path instead of guessing that a dead leader means an empty group.
+printf '%s\n' 424252 > "$tmp/legacy-record.pid"
+printf '%s\n' leader-identity > "$tmp/legacy-record.pid.identity"
+printf '%s\n' 1 > "$tmp/legacy-record.pid.cleanup-rc"
+rm -f "$tmp/legacy-record.pid.survivors"
+legacy_record_rc=0
+# shellcheck disable=SC2034,SC2317,SC2329
+(
+    codex_pid_file="$tmp/legacy-record.pid"
+    codex_retry_pid_file="$tmp/legacy-record-retry.pid"
+    proc_tree_process_identity_matches() { return 1; }
+    proc_tree_process_identity() { return 1; }
+    proc_tree_terminate() { return 9; }
+    eval "$kickoff_recovery_block"
+) 2>"$tmp/legacy-record.stderr" || legacy_record_rc=$?
+check "legacy failed record without survivor sidecar stays blocked" "$legacy_record_rc" "1"
+check "legacy failed record stays preserved" "$(test -s "$tmp/legacy-record.pid" && echo preserved || echo missing)" "preserved"
+check "legacy record diagnostic names manual recovery path" "$(grep -Fc 'legacy pre-r14 record); manual recovery required' "$tmp/legacy-record.stderr" 2>/dev/null)" "1"
+
+# HIMMEL-1474 r8: terminate rc 2 means no signal was sent. Execute the
+# production timeout-classification/cleanup block and prove its recovery
+# handles survive instead of being erased as though the render had exited.
+harvest_timeout_extract_rc=0
+harvest_timeout_block=$(awk '
+    /harvest_timed_out=0/ { capture=1 }
+    capture {
+        raw=$0
+        sub(/^       /, "")
+        print
+        if (raw ~ /^       if \[ "\$harvest_live_unreaped" -eq 0 \] && \[ "\$harvest_survivors" -eq 0 \] && \[ "\$harvest_cleanup_unverified" -eq 0 \]; then/) cleanup=1
+        else if (cleanup && raw == "       fi") { complete=1; exit }
+    }
+    END { if (!complete) exit 42 }
+' "$PR_CHECK") || harvest_timeout_extract_rc=$?
+check "harvest-timeout extractor reaches the cleanup block terminator" "$harvest_timeout_extract_rc" "0"
+printf '%s\n' 424242 > "$tmp/harvest-live.pid"
+printf '%s\n' test-identity > "$tmp/harvest-live.pid.identity"
+rm -f "$tmp/harvest-live.rc"
+# shellcheck disable=SC2034,SC2154,SC2317,SC2329
+harvest_live_result=$(
+    codex_pid=424242
+    codex_identity=test-identity
+    codex_pid_file="$tmp/harvest-live.pid"
+    codex_identity_file="$tmp/harvest-live.pid.identity"
+    codex_survivors_file="$tmp/harvest-live.pid.survivors"
+    codex_rc_file="$tmp/harvest-live.rc"
+    codex_err_file="$tmp/harvest-live.err"
+    codex_out="$tmp/harvest-live.out"
+    codex_to=5
+    waited=5
+    codex_findings=stale
+    codex_rc=0
+    codex_avail_status=''
+    proc_tree_terminate() { return 2; }
+    eval "$harvest_timeout_block" 2>"$tmp/harvest-live.stderr"
+    printf '%s:%s:%s:%s\n' "$harvest_live_unreaped" "$harvest_timed_out" "$codex_rc" "$codex_avail_status"
+)
+check "terminate-rc-2 harvest is live-but-unreaped" "$harvest_live_result" "1:0:2:unavailable"
+check "live-but-unreaped harvest preserves pid sidecar" "$(test -s "$tmp/harvest-live.pid" && echo preserved || echo missing)" "preserved"
+check "live-but-unreaped harvest preserves identity sidecar" "$(test -s "$tmp/harvest-live.pid.identity" && echo preserved || echo missing)" "preserved"
+harvest_live_diagnostic=$(grep -Fc "live but unreaped" "$tmp/harvest-live.stderr" 2>/dev/null)
+check "live-but-unreaped harvest reports distinct state" "$harvest_live_diagnostic" "1"
+harvest_preserve_diagnostic=$(grep -Fc "because no signal was sent" "$tmp/harvest-live.stderr" 2>/dev/null)
+check "live-but-unreaped harvest explains preserved handles" "$harvest_preserve_diagnostic" "1"
+
+# HIMMEL-1474 r9: terminate rc 1 means escalated cleanup left survivors. The
+# gate remains a timeout while its recovery handles stay available.
+printf '%s\n' 424243 > "$tmp/harvest-survivors.pid"
+printf '%s\n' test-identity > "$tmp/harvest-survivors.pid.identity"
+rm -f "$tmp/harvest-survivors.rc"
+# shellcheck disable=SC2034,SC2154,SC2317,SC2329
+harvest_survivors_result=$(
+    codex_pid=424243
+    codex_identity=test-identity
+    codex_pid_file="$tmp/harvest-survivors.pid"
+    codex_identity_file="$tmp/harvest-survivors.pid.identity"
+    codex_survivors_file="$tmp/harvest-survivors.pid.survivors"
+    codex_rc_file="$tmp/harvest-survivors.rc"
+    codex_err_file="$tmp/harvest-survivors.err"
+    codex_out="$tmp/harvest-survivors.out"
+    codex_to=5
+    waited=5
+    codex_findings=stale
+    codex_rc=0
+    codex_avail_status=''
+    proc_tree_terminate() { return 1; }
+    eval "$harvest_timeout_block" 2>"$tmp/harvest-survivors.stderr"
+    printf '%s:%s:%s:%s\n' "$harvest_live_unreaped" "$harvest_timed_out" "$codex_rc" "$codex_avail_status"
+)
+check "terminate-rc-1 harvest remains a timeout" "$harvest_survivors_result" "0:1:124:unavailable"
+check "terminate-rc-1 harvest preserves pid sidecar" "$(test -s "$tmp/harvest-survivors.pid" && echo preserved || echo missing)" "preserved"
+check "terminate-rc-1 harvest preserves identity sidecar" "$(test -s "$tmp/harvest-survivors.pid.identity" && echo preserved || echo missing)" "preserved"
+harvest_survivors_diagnostic=$(grep -Fc "survivors after escalated cleanup — sidecars preserved for recovery" "$tmp/harvest-survivors.stderr" 2>/dev/null)
+check "terminate-rc-1 harvest reports preserved recovery sidecars" "$harvest_survivors_diagnostic" "1"
+
+# HIMMEL-1474 r12: cleanup is removable only after BOTH launcher status and a
+# zero cleanup status exist. A killed-pre-write launcher and a late cleanup
+# publication each preserve the ownership handles.
+printf '%s\n' 424246 > "$tmp/harvest-no-rc.pid"
+printf '%s\n' test-identity > "$tmp/harvest-no-rc.pid.identity"
+printf '%s\n' 0 > "$tmp/harvest-no-rc.pid.cleanup-rc"
+rm -f "$tmp/harvest-no-rc.rc"
+# shellcheck disable=SC2034,SC2154,SC2317,SC2329
+harvest_no_rc_result=$(
+    codex_pid=424246
+    codex_identity=test-identity
+    codex_pid_file="$tmp/harvest-no-rc.pid"
+    codex_identity_file="$tmp/harvest-no-rc.pid.identity"
+    codex_survivors_file="$tmp/harvest-no-rc.pid.survivors"
+    codex_rc_file="$tmp/harvest-no-rc.rc"
+    codex_cleanup_rc_file="$tmp/harvest-no-rc.pid.cleanup-rc"
+    codex_err_file="$tmp/harvest-no-rc.err"
+    codex_out="$tmp/harvest-no-rc.out"
+    codex_to=5
+    waited=0
+    codex_findings=stale
+    codex_rc=0
+    codex_avail_status=''
+    sleep() { :; }
+    eval "$harvest_timeout_block" 2>"$tmp/harvest-no-rc.stderr"
+    printf '%s:%s:%s\n' "$harvest_cleanup_unverified" "$codex_rc" "$codex_avail_status"
+)
+check "missing launcher rc marks cleanup unverified" "$harvest_no_rc_result" "1:1:unavailable"
+check "missing launcher rc preserves pid sidecar" "$(test -s "$tmp/harvest-no-rc.pid" && echo preserved || echo missing)" "preserved"
+check "missing launcher rc preserves identity sidecar" "$(test -s "$tmp/harvest-no-rc.pid.identity" && echo preserved || echo missing)" "preserved"
+check "missing launcher rc preserves cleanup status" "$(cat "$tmp/harvest-no-rc.pid.cleanup-rc" 2>/dev/null)" "0"
+no_rc_diagnostic=$(grep -Fc "launcher status missing" "$tmp/harvest-no-rc.stderr" 2>/dev/null)
+check "missing launcher rc reports preserved handles" "$no_rc_diagnostic" "1"
+
+printf '%s\n' 424247 > "$tmp/harvest-late-cleanup.pid"
+printf '%s\n' test-identity > "$tmp/harvest-late-cleanup.pid.identity"
+printf '%s\n' 7 > "$tmp/harvest-late-cleanup.rc"
+rm -f "$tmp/harvest-late-cleanup.pid.cleanup-rc"
+# shellcheck disable=SC2034,SC2154
+harvest_late_cleanup_result=$(
+    codex_pid=424247
+    codex_identity=test-identity
+    codex_pid_file="$tmp/harvest-late-cleanup.pid"
+    codex_identity_file="$tmp/harvest-late-cleanup.pid.identity"
+    codex_survivors_file="$tmp/harvest-late-cleanup.pid.survivors"
+    codex_rc_file="$tmp/harvest-late-cleanup.rc"
+    codex_cleanup_rc_file="$tmp/harvest-late-cleanup.pid.cleanup-rc"
+    codex_err_file="$tmp/harvest-late-cleanup.err"
+    codex_out="$tmp/harvest-late-cleanup.out"
+    codex_to=5
+    waited=0
+    codex_findings=stale
+    codex_rc=0
+    codex_avail_status=''
+    eval "$harvest_timeout_block" 2>"$tmp/harvest-late-cleanup.stderr"
+    printf '%s:%s:%s\n' "$harvest_cleanup_unverified" "$codex_rc" "$codex_avail_status"
+)
+check "late cleanup status marks cleanup unverified" "$harvest_late_cleanup_result" "1:7:unavailable"
+check "late cleanup status preserves pid sidecar" "$(test -s "$tmp/harvest-late-cleanup.pid" && echo preserved || echo missing)" "preserved"
+check "late cleanup status preserves identity sidecar" "$(test -s "$tmp/harvest-late-cleanup.pid.identity" && echo preserved || echo missing)" "preserved"
+late_cleanup_diagnostic=$(grep -Fc "cleanup unverified (rc=missing)" "$tmp/harvest-late-cleanup.stderr" 2>/dev/null)
+check "late cleanup status reports missing cleanup rc" "$late_cleanup_diagnostic" "1"
+
+# HIMMEL-1474 r10/r12: the synchronous retry owns distinct recovery sidecars. Its
+# timeout status remains 124 while cleanup rc 1/2 and both handles survive.
+# shellcheck disable=SC2016
+retry_pid_wiring=$(grep -Fc 'codex_retry_pid_file="${codex_pid_file}.retry"' "$PR_CHECK" 2>/dev/null)
+check "kickoff and harvest share the dedicated retry pid sidecar" "$retry_pid_wiring" "2"
+# shellcheck disable=SC2016
+retry_survivors_wiring=$(grep -Fc 'codex_retry_survivors_file="${codex_retry_pid_file}.survivors"' "$PR_CHECK" 2>/dev/null)
+check "kickoff and harvest share the dedicated retry survivor sidecar" "$retry_survivors_wiring" "2"
+# shellcheck disable=SC2016
+retry_launcher_wiring=$(grep -Fc '"$codex_retry_pid_file" "$codex_timeout" "$codex_retry_cleanup_rc_file"' "$PR_CHECK" 2>/dev/null)
+check "production retry passes its pid and cleanup sidecars to the launcher" "$retry_launcher_wiring" "1"
+# shellcheck disable=SC2016
+primary_cleanup_wiring=$(grep -Fc 'codex_cleanup_rc_file="${codex_pid_file}.cleanup-rc"' "$PR_CHECK" 2>/dev/null)
+check "kickoff and harvest derive primary cleanup status from its pid record" "$primary_cleanup_wiring" "2"
+# shellcheck disable=SC2016
+retry_cleanup_wiring=$(grep -Fc 'codex_retry_cleanup_rc_file="${codex_retry_pid_file}.cleanup-rc"' "$PR_CHECK" 2>/dev/null)
+check "kickoff and harvest derive retry cleanup status from its pid record" "$retry_cleanup_wiring" "2"
+for retry_cleanup_rc in 1 2; do
+    rm -f "$tmp/retry-$retry_cleanup_rc.pid" "$tmp/retry-$retry_cleanup_rc.pid.identity" "$tmp/retry-$retry_cleanup_rc.pid.cleanup-rc"
+    runner_rc=0
+    HIMMEL_R6_TERMINATE_RC="$retry_cleanup_rc" \
+        bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion-delayed.mjs" main "$tmp/retry-$retry_cleanup_rc.stdout" "$tmp/retry-$retry_cleanup_rc.stderr" "$tmp/retry-$retry_cleanup_rc.pid" 1 "$tmp/retry-$retry_cleanup_rc.pid.cleanup-rc" 2>"$tmp/retry-$retry_cleanup_rc-runner.stderr" || runner_rc=$?
+    check "retry-shaped cleanup rc $retry_cleanup_rc keeps exit 124" "$runner_rc" "124"
+    check "retry-shaped cleanup rc $retry_cleanup_rc publishes record cleanup status" "$(cat "$tmp/retry-$retry_cleanup_rc.pid.cleanup-rc" 2>/dev/null)" "$retry_cleanup_rc"
+    check "retry-shaped cleanup rc $retry_cleanup_rc preserves pid sidecar" "$(test -s "$tmp/retry-$retry_cleanup_rc.pid" && echo preserved || echo missing)" "preserved"
+    check "retry-shaped cleanup rc $retry_cleanup_rc preserves identity sidecar" "$(test -s "$tmp/retry-$retry_cleanup_rc.pid.identity" && echo preserved || echo missing)" "preserved"
+    retry_pid=$(cat "$tmp/retry-$retry_cleanup_rc.pid")
+    kill -9 "$retry_pid" 2>/dev/null || true
+    if command -v taskkill >/dev/null 2>&1; then
+        MSYS_NO_PATHCONV=1 taskkill /PID "$retry_pid" /T /F >/dev/null 2>&1 || true
+    fi
+done
+
+# Companion failure keeps its own rc, while the independent cleanup status lets
+# harvest preserve recovery handles for cleanup rc 1/2 instead of deleting them.
+for companion_cleanup_rc in 1 2; do
+    companion_prefix="$tmp/companion-cleanup-$companion_cleanup_rc"
+    rm -f "$companion_prefix.pid" "$companion_prefix.pid.identity" "$companion_prefix.rc" "$companion_prefix.pid.cleanup-rc"
+    runner_rc=0
+    HIMMEL_R6_GROUP_TERMINATE_RC="$companion_cleanup_rc" \
+        bash "$tmp/lease-fixture/cr/run-codex-adversarial.sh" "$tmp/lease-fixture/companion-fails.mjs" main "$companion_prefix.stdout" "$companion_prefix.stderr" "$companion_prefix.pid" 0 "$companion_prefix.pid.cleanup-rc" 2>"$companion_prefix-runner.stderr" || runner_rc=$?
+    check "companion rc wins over cleanup rc $companion_cleanup_rc" "$runner_rc" "7"
+    check "companion failure publishes cleanup rc $companion_cleanup_rc" "$(cat "$companion_prefix.pid.cleanup-rc" 2>/dev/null)" "$companion_cleanup_rc"
+    printf '%s\n' "$runner_rc" > "$companion_prefix.rc"
+    # shellcheck disable=SC2034,SC2154
+    companion_harvest_result=$(
+        codex_pid=$(cat "$companion_prefix.pid")
+        codex_identity=$(cat "$companion_prefix.pid.identity")
+        codex_pid_file="$companion_prefix.pid"
+        codex_identity_file="$companion_prefix.pid.identity"
+        codex_survivors_file="$companion_prefix.pid.survivors"
+        codex_rc_file="$companion_prefix.rc"
+        codex_cleanup_rc_file="$companion_prefix.pid.cleanup-rc"
+        codex_err_file="$companion_prefix.stderr"
+        codex_out="$companion_prefix.stdout"
+        codex_to=5
+        waited=0
+        codex_findings=stale
+        codex_rc=0
+        codex_avail_status=''
+        eval "$harvest_timeout_block" 2>"$companion_prefix-harvest.stderr"
+        printf '%s:%s:%s\n' "$harvest_cleanup_unverified" "$codex_rc" "$codex_avail_status"
+    )
+    check "harvest sees companion cleanup rc $companion_cleanup_rc" "$companion_harvest_result" "1:7:unavailable"
+    check "companion cleanup rc $companion_cleanup_rc preserves pid sidecar" "$(test -s "$companion_prefix.pid" && echo preserved || echo missing)" "preserved"
+    check "companion cleanup rc $companion_cleanup_rc preserves identity sidecar" "$(test -s "$companion_prefix.pid.identity" && echo preserved || echo missing)" "preserved"
+    check "companion cleanup rc $companion_cleanup_rc preserves cleanup status" "$(cat "$companion_prefix.pid.cleanup-rc" 2>/dev/null)" "$companion_cleanup_rc"
+done
+
+if [ "$fails" -eq 0 ]; then
+    echo "ALL PASS"
+else
+    echo "$fails FAILED"
+    exit 1
+fi

--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -77,6 +77,9 @@
 #                           (HIMMEL-716): placeholders {ticket} {slug}
 #                           {session}. Unset = the built-in ticket-first
 #                           composition. See _compose_arm_name.
+#   ARM_WITH_LIVE_WORKERS   Exact value 1 bypasses the live lane-worker guard
+#                           with a loud warning. Use only when intentionally
+#                           killing in-flight workers at session exit.
 #
 # Exit codes:
 #   0  scheduler armed (or printed under --dry-run)
@@ -111,6 +114,10 @@
 #      overnight/idle wait, or pick a nearer --time. Automated safety arms
 #      (ARM_RESUME_SAFETY_ARM=1) are exempt; smart/auto sentinels are exempt
 #      by design.
+#   10 live workers refused — one or more GLM/claudex bridge rows are running
+#      with a live or unprobeable pid (HIMMEL-1463). Unprobeable fails closed as
+#      possibly alive. Wait for them or explicitly set ARM_WITH_LIVE_WORKERS=1
+#      to accept that session exit may kill them.
 set -euo pipefail
 
 RESUME_TIME=""
@@ -226,6 +233,9 @@ Env:
                           composition; e.g. '{slug}' for slug-only names. A
                           template that renders empty falls back to the plain
                           HIMMEL-Resume-<path> name with no -n.
+  ARM_WITH_LIVE_WORKERS   Exact value 1 bypasses the live lane-worker refusal
+                          with a loud warning. The armed session exit may kill
+                          those in-flight workers; wait for them by default.
 EOF
 }
 
@@ -280,6 +290,55 @@ if [ -z "$RESUME_TIME" ] || [ -z "$HANDOVER_PATH" ]; then
     exit 1
 fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# HIMMEL-1463: an unattended arm normally ends this Claude session, and the
+# harness then reaps its background task tree. Lane workers are children of
+# that tree, so arming while one is live silently kills it and can strand its
+# shared-branch lock. For a REAL arm, reconcile dead rows first and then fail
+# closed on every remaining running row whose pid is live or unprobeable. A
+# dry-run stays side-effect-free and skips the external worker census entirely.
+# ARM_WITH_LIVE_WORKERS=1 is deliberately loud: it accepts that data-loss risk,
+# rather than making a force-like flag easy to add accidentally.
+if [ "$DRY_RUN" -eq 0 ]; then
+    _WORKER_RECONCILER="$SCRIPT_DIR/reconcile-workers.sh"
+    if [ ! -f "$_WORKER_RECONCILER" ]; then
+        echo "ERR arm-resume: worker reconciler missing: $_WORKER_RECONCILER — refusing because live-worker state cannot be checked" >&2
+        exit 2
+    fi
+    set +e
+    bash "$_WORKER_RECONCILER"
+    _worker_reconcile_rc=$?
+    set -e
+    if [ "$_worker_reconcile_rc" -ne 0 ]; then
+        echo "ERR arm-resume: worker reconciliation failed (rc=$_worker_reconcile_rc) — refusing because live-worker state is uncertain" >&2
+        exit 2
+    fi
+    set +e
+    _live_workers=$(bash "$_WORKER_RECONCILER" --list-live)
+    _worker_list_rc=$?
+    set -e
+    if [ "$_worker_list_rc" -ne 0 ]; then
+        echo "ERR arm-resume: live-worker census failed (rc=$_worker_list_rc) — refusing to arm" >&2
+        exit 2
+    fi
+    if [ -n "$_live_workers" ]; then
+        if [ "${ARM_WITH_LIVE_WORKERS:-}" = "1" ]; then
+            {
+                echo "WARN arm-resume: ARM_WITH_LIVE_WORKERS=1 — arming despite live or unprobeable lane workers; exiting this session may kill them:"
+                printf '    %s\n' "${_live_workers//$'\n'/$'\n    '}"
+            } >&2
+        else
+            {
+                echo "ERR arm-resume: refusing to arm while lane workers are live or unprobeable (possibly alive) (rc=10):"
+                printf '    %s\n' "${_live_workers//$'\n'/$'\n    '}"
+                echo "    Wait for them to finish. Emergency override: ARM_WITH_LIVE_WORKERS=1"
+                echo "    (the armed session exit may kill those workers and orphan their work)."
+            } >&2
+            exit 10
+        fi
+    fi
+    unset _WORKER_RECONCILER _worker_reconcile_rc _worker_list_rc _live_workers
+fi
 
 # python3 hang armor (HIMMEL-249): the Windows Store python3 stub can wedge
 # (ignores SIGTERM, orphan child holds the $() pipe). The auto-arm-on-cap
@@ -3159,7 +3218,14 @@ fi
 # Telemetry (HIMMEL-236): a successful arm IS the re-launch signal the
 # measure-during protocol wants — one append, after the dry-run gate so
 # --dry-run keeps its "touch nothing" contract.
-telemetry_emit handover-arm-resume armed "time=$RESUME_TIME" "force=$FORCE" "long_gap=$LONG_GAP"
+# HIMMEL-1490: emit the MEASURED gap (raw seconds, the guard's canonical
+# unit — _GAP_SEC, deliberately not floored to minutes: the guard compares
+# >3600 directly because a //60 floor made 60m01s-60m59s read as 60). On the
+# Telegram HH:MM surface --long-gap rides every explicit arm (HIMMEL-1475),
+# so long_gap=1 alone can't tell a genuine >60-min park from a near arm in
+# the audit; gap_sec records how far out it actually is. Default 0 for the
+# smart/auto sentinel arms, which never derive _GAP_SEC (no measured park).
+telemetry_emit handover-arm-resume armed "time=$RESUME_TIME" "force=$FORCE" "long_gap=$LONG_GAP" "gap_sec=${_GAP_SEC:-0}"
 
 # HIMMEL-856: record this arm in the cross-machine arms registry, same
 # dry-run gate as telemetry above. Best-effort -- a registry write failure

--- a/scripts/handover/leg-timeline.sh
+++ b/scripts/handover/leg-timeline.sh
@@ -1,0 +1,493 @@
+#!/usr/bin/env bash
+# scripts/handover/leg-timeline.sh — HIMMEL-1485
+#
+# Reconstruct a per-leg critical-path timeline from data that already exists:
+#   - worker dispatches : ~/.claude/handover/bridge/{glm,claudex}-sessions/*/meta.json
+#                         (started_at = dispatch; meta.json mtime = exit/land stamp,
+#                          since NO meta.json carries an explicit end timestamp —
+#                          verified across every session; the file's mtime is the
+#                          instant status flipped to a terminal value).
+#   - gate renders      : <primary-checkout>/.git/cr-critic-scores.jsonl
+#                         (CR ledger; avail/finding rows carry ts + head + model).
+#   - chain-ledger stamps: the operator's luna chain-ledger markdown (some lines
+#                          carry an ISO timestamp + an event tag).
+#
+# All three sources are READ-ONLY. This script never writes any of them.
+#
+# Usage:
+#   scripts/handover/leg-timeline.sh <since-ts>
+#     <since-ts>  ISO-8601 lower bound. UTC is assumed when no offset is given,
+#                 so '2026-08-03T00:00' == '2026-08-03T00:00Z'. Events at or after
+#                 this instant are shown.
+#
+# Output:
+#   - A table, one row per event sorted by ts: ts · source · leg/branch · event ·
+#     delta-from-previous.
+#   - A summary block: total span, per-worker dispatch→land, gate-wait vs
+#     gate-run where derivable, and a one-line wall-clock summary
+#     (total leg time + % waiting).
+#
+# Source paths are env-overridable (see test-leg-timeline.sh):
+#   LEG_TIMELINE_WORKER_GLM, LEG_TIMELINE_WORKER_CLAUDEX,
+#   LEG_TIMELINE_CR_LEDGER, LEG_TIMELINE_CHAIN_LEDGER.
+#
+# Tooling: jq (JSONL field extraction) + node. node is the ONLY portable
+# ISO-8601-with-offset / sub-second / file-mtime reader across Git Bash (GNU
+# date) and macOS bash 3.2 (BSD date): `date -d` is GNU-only, `date -r` means
+# different things on GNU vs BSD, `stat -c/-f` flags differ, and jq's fromdate
+# rejects `+0200` offsets and sub-seconds. node is a hard repo dependency
+# (the Jira CLI, lanes, etc.), so leaning on it costs no new assumption.
+#
+# bash 3.2-safe (macOS ships 3.2): no mapfile, no associative arrays.
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults. $HOME is MSYS form (/c/Users/...) under Git Bash; the node helpers
+# normalize MSYS paths to Windows form because Node's fs rejects '/c/...'.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/load-dotenv.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/load-dotenv.sh"
+# shellcheck source=../lib/user-slug.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/user-slug.sh"
+# shellcheck source=../lib/handover-path.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/handover-path.sh"
+load_dotenv HANDOVER_DIR USER_SLUG
+
+glm_dir="${LEG_TIMELINE_WORKER_GLM:-$HOME/.claude/handover/bridge/glm-sessions}"
+claudex_dir="${LEG_TIMELINE_WORKER_CLAUDEX:-$HOME/.claude/handover/bridge/claudex-sessions}"
+if [ -n "${LEG_TIMELINE_CHAIN_LEDGER:-}" ]; then
+  chain_ledger="$LEG_TIMELINE_CHAIN_LEDGER"
+elif handover_base=$(handover_root 2>/dev/null) && handover_slug=$(user_slug 2>/dev/null); then
+  chain_ledger="$handover_base/$handover_slug/himmel/specs/plan/2026-07-28-chain-ledger.md"
+else
+  chain_ledger=""
+fi
+
+# The CR ledger lives under the PRIMARY checkout's .git, not the worktree's
+# (worktrees share the primary's .git via the common dir). An explicit env value
+# always wins.
+if [ -z "${LEG_TIMELINE_CR_LEDGER:-}" ]; then
+  common_dir=$(git rev-parse --git-common-dir 2>/dev/null || printf '.git')
+  # Treat both POSIX-absolute (/c/...) and Windows-drive-absolute (C:/...) as
+  # already absolute; git-common-dir returns the latter under Git for Windows.
+  case "$common_dir" in
+    /* | [A-Za-z]:/*) : ;;
+    *) common_dir="$PWD/$common_dir" ;;
+  esac
+  cr_ledger="$common_dir/cr-critic-scores.jsonl"
+else
+  cr_ledger="$LEG_TIMELINE_CR_LEDGER"
+fi
+
+# ---------------------------------------------------------------------------
+# usage
+# ---------------------------------------------------------------------------
+usage() {
+  cat >&2 <<EOF
+Usage: $0 <since-ts>
+
+Reconstruct a per-leg critical-path timeline (HIMMEL-1485).
+  <since-ts>  ISO-8601 lower bound (UTC assumed when no offset), e.g.
+              '2026-08-03T00:00'.
+
+Env overrides: LEG_TIMELINE_WORKER_GLM, LEG_TIMELINE_WORKER_CLAUDEX,
+               LEG_TIMELINE_CR_LEDGER, LEG_TIMELINE_CHAIN_LEDGER.
+EOF
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 1
+fi
+since_raw="$1"
+
+# ---------------------------------------------------------------------------
+# since-epoch: parse the lower bound once. Date-only input means UTC midnight;
+# append 'Z' to offset-less date-times so V8 does not read them as local time
+# (measured 4h off on an EDT host). Empty result => unparseable since-ts.
+# ---------------------------------------------------------------------------
+since_epoch=$(printf '%s' "$since_raw" | node -e '
+  const s = require("fs").readFileSync(0, "utf8").trim();
+  const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(s);
+  const hasOffset = /[Zz]$|[+-]\d{2}:?\d{2}$/.test(s);
+  const normalized = dateOnly ? s + "T00:00:00Z" : (hasOffset ? s : s + "Z");
+  const ms = Date.parse(normalized);
+  process.stdout.write(Number.isNaN(ms) ? "" : String(ms));
+')
+if [ -z "$since_epoch" ]; then
+  printf 'ERROR: could not parse since-ts [%s] as ISO-8601.\n' "$since_raw" >&2
+  usage
+  exit 1
+fi
+
+# Validate mktemp before using $tmp: `set` has no -e, so a failed mktemp -d
+# would leave $tmp empty (or a non-dir) and execution would continue into
+# "/raw.tsv". Fail loudly, and arm the cleanup trap only once $tmp is real.
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/leg-timeline.XXXXXX") || tmp=""
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  printf 'ERROR: mktemp -d failed (no temp dir created); aborting.\n' >&2
+  exit 1
+fi
+trap 'rm -rf "$tmp"' EXIT
+raw="$tmp/raw.tsv"          # all events, col1 = ISO ts (unsorted, unfiltered)
+allnorm="$tmp/allnorm.tsv"  # normalized ALL events (unfiltered) for summary pairing
+events="$tmp/events.tsv"    # normalized + since-filtered: the displayed table rows
+
+# ---------------------------------------------------------------------------
+# Collect raw events into $raw. Col layout: <iso-ts>\t<source>\t<leg>\t<event>.
+# Each source degrades gracefully: a missing/unreadable path is reported and
+# skipped, never fatal.
+# ---------------------------------------------------------------------------
+: > "$raw"
+
+# --- source 1: worker dispatches (node; needs meta.json parse + file mtime) ---
+# Emits a dispatch row per session (started_at) and, for terminal statuses, a
+# land row whose ts is the meta.json mtime (the status-flip instant). Paths are
+# MSYS-normalized because Git Bash hands node '/c/...' which Node fs rejects.
+gather_workers() {
+  node -e '
+    const fs = require("fs");
+    // win(): coerce any path form Git Bash may hand us into forward-slash Windows
+    // form, the one Node fs reliably accepts on Windows: MSYS '/c/...' -> 'C:/...',
+    // backslashes -> forward slashes, already-Windows passes through. Node fs
+    // rejects MSYS paths outright, so this normalization is load-bearing.
+    function win(p){
+      let q = p.replace(/\\/g, "/");
+      const m = q.match(/^\/([a-zA-Z])\/(.*)$/);
+      return m ? (m[1].toUpperCase() + ":/" + m[2]) : q;
+    }
+    // "blocked" is a real terminal status (content-filter) emitted by
+    // spawn-glm.ts finalMeta alongside done/timeout/failed/capped; without it a
+    // blocked session never gets a land row. "aborted" is NOT a finalMeta status.
+    const TERM = new Set(["done","timeout","failed","capped","blocked"]);
+    const dirs = process.argv.slice(1).map(win);
+    for (const d of dirs){
+      let names = [];
+      try { names = fs.readdirSync(d); } catch (e) { continue; }   // missing dir -> skip
+      for (const n of names){
+        const p = d.replace(/\/$/, "") + "/" + n + "/meta.json";
+        let j;
+        try { j = JSON.parse(fs.readFileSync(p, "utf8")); } catch (e) { continue; }  // bad json -> skip
+        if (!j.started_at) continue;
+        const leg = j.shared_branch || j.task_name || n;
+        const lane = j.lane || "?";
+        const st = j.status || "?";
+        process.stdout.write(j.started_at + "\tworker\t" + leg + "\tdispatch " + lane + " " + st + "\t" + n + "\n");
+        if (TERM.has(st)){
+          let iso;
+          try { iso = fs.statSync(p).mtime.toISOString(); } catch (e) { iso = ""; }
+          if (iso){
+            const rc = ("exit_code" in j) ? (" rc=" + j.exit_code) : "";
+            process.stdout.write(iso + "\tworker\t" + leg + "\tland " + st + rc + "\t" + n + "\n");
+          }
+        }
+      }
+    }
+  ' -- "$glm_dir" "$claudex_dir"
+}
+
+# --- source 2: gate renders (jq over the CR ledger JSONL) ---
+# One row per ledger record that carries a ts. leg/branch = branch@head; event
+# encodes kind + model (+ severity for findings) so the table is self-describing.
+gather_gate() {
+  [ -f "$cr_ledger" ] || return 0
+  jq -Rr '
+    fromjson? |
+    select(type == "object" and .ts) |
+    "\(.ts)\tgate\t\((.branch//"chain") + "@" + ((.head//"-")[0:7]))\t" +
+    ( if .kind == "avail"   then "avail "   + (.model//"")
+      elif .kind == "finding" then "finding " + (.model//"") + " " + (.severity//"")
+      elif .kind == "usage"  then "usage "   + (.model//"")
+      else                             (.kind//"?") + " " + (.model//"") end ) + "\t-"
+  ' "$cr_ledger" 2>/dev/null
+}
+
+# --- source 3: chain-ledger stamps (node; binary-tolerant, regex extraction) ---
+# The ledger is append-only markdown with non-UTF8 bytes; read as a buffer.
+# Only lines carrying an ISO timestamp become events; the event is the text
+# before the timestamp (the tag), whitespace-collapsed and capped.
+gather_ledger() {
+  [ -f "$chain_ledger" ] || return 0
+  node -e '
+    const fs = require("fs");
+    function win(p){
+      let q = p.replace(/\\/g, "/");
+      const m = q.match(/^\/([a-zA-Z])\/(.*)$/);
+      return m ? (m[1].toUpperCase() + ":/" + m[2]) : q;
+    }
+    const p = win(process.argv[1]);
+    let buf;
+    try { buf = fs.readFileSync(p); } catch (e) { process.exit(0); }   // missing -> skip
+    const text = buf.toString("utf8");                 // bad bytes -> replacement chars, ignored
+    // optional fractional seconds then an optional offset; without the
+    // (?:\.\d+)? clause a stamp like T13:40:00.5+02:00 captures truncated
+    // before ".5+02:00", silently stripping the offset (HIMMEL-1485 r7).
+    const RE = /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)/;
+    for (const line of text.split(/\r?\n/)){
+      const m = line.match(RE);
+      if (!m) continue;
+      let prefix = line.slice(0, m.index).trim().replace(/\s+/g, " ");
+      if (prefix.length > 40) prefix = prefix.slice(0, 37) + "...";
+      process.stdout.write(m[1] + "\tledger\tchain\t" + prefix + "\t-\n");
+    }
+  ' "$chain_ledger"
+}
+
+# Track which sources contributed (for the summary's gap report).
+w_glm=0; w_claudex=0; w_gate=0; w_ledger=0; w_gate_malformed=0
+[ -d "$glm_dir" ]     && w_glm=1
+[ -d "$claudex_dir" ] && w_claudex=1
+[ -f "$cr_ledger" ]   && w_gate=1
+[ -f "$chain_ledger" ] && w_ledger=1
+
+{ gather_workers; gather_gate; gather_ledger; } >> "$raw" 2>/dev/null
+if [ "$w_gate" -eq 1 ]; then
+  w_gate_malformed=$(jq -Rn '
+    reduce inputs as $line (0;
+      if $line == "" then .
+      else (try ($line | fromjson) catch null) as $row |
+        if $row == null or ($row | type) != "object" then . + 1 else . end
+      end)
+  ' "$cr_ledger" 2>/dev/null) || w_gate_malformed=0
+fi
+
+# ---------------------------------------------------------------------------
+# Normalize ALL events -> $allnorm (UNFILTERED): parse col1 ISO ts -> epoch ms,
+# drop rows that fail to parse, re-emit as epoch \t source \t leg \t event \t
+# session-id \t iso(seconds). Sorted numerically by epoch ascending. The since-ts
+# filter is applied separately (next block) to the DISPLAYED table rows only, so
+# the summary pairing below still sees dispatches that predate the window but
+# land inside it (HIMMEL-1485 r5 #1). One node pass over the whole file.
+# A trailing lowercase "z" is a valid offset designator (V8 accepts it; since_ts
+# does too): recognize z/Z case-insensitively so it is not re-suffixed into an
+# invalid "zZ" that Date.parse drops (HIMMEL-1485 r5 #2).
+# ---------------------------------------------------------------------------
+node -e '
+  const fs = require("fs");
+  const rows = [];
+  for (const line of fs.readFileSync(0, "utf8").split(/\r?\n/)){
+    if (line === "") continue;
+    const c = line.split("\t");
+    if (c.length < 5) continue;
+    // Offset-less stamps parse as HOST-local while since_epoch normalizes
+    // offset-less input to UTC — append Z so filtering and output agree. A
+    // trailing z/Z (case-insensitive) or numeric offset is an existing designator.
+    const ts = /[Zz]$|[+-]\d\d:?\d\d$/.test(c[0]) ? c[0] : c[0] + "Z";
+    const ms = Date.parse(ts);
+    if (Number.isNaN(ms)) continue;
+    const iso = new Date(ms).toISOString().replace(/\.\d{3}Z$/, "Z");
+    rows.push([ms, c[1], c[2], c[3], c[4], iso]);
+  }
+  rows.sort((a, b) => (a[0] - b[0]) || (a[1] < b[1] ? -1 : (a[1] > b[1] ? 1 : 0)));
+  for (const r of rows) process.stdout.write(r.join("\t") + "\n");
+' < "$raw" > "$allnorm"
+
+# Displayed table rows: events at/after since-ts only. $events is the table's
+# display contract (unchanged); the summary pairs over the unfiltered $allnorm.
+node -e '
+  const since = parseInt(process.argv[1], 10);   // epoch ms or NaN
+  for (const line of require("fs").readFileSync(0, "utf8").split(/\r?\n/)){
+    if (line === "") continue;
+    const ep = Number(line.split("\t")[0]);
+    if (Number.isNaN(since) || ep >= since) process.stdout.write(line + "\n");
+  }
+' "$since_epoch" < "$allnorm" > "$events"
+
+# ---------------------------------------------------------------------------
+# Helpers for the table + summary.
+# ---------------------------------------------------------------------------
+
+# fmtdur <ms> -> "+1h02m" / "+3m04s" / "+12s" / "+0s" (never negative in table).
+fmtdur() {
+  local ms=${1:-0}
+  [ "$ms" -lt 0 ] && ms=0
+  local s=$(( ms / 1000 ))
+  local h=$(( s / 3600 ))
+  local m=$(( (s % 3600) / 60 ))
+  local sec=$(( s % 60 ))
+  if [ "$h" -gt 0 ]; then printf '+%dh%02dm' "$h" "$m"
+  elif [ "$m" -gt 0 ]; then printf '+%dm%02ds' "$m" "$sec"
+  else printf '+%ds' "$sec"; fi
+}
+
+# compacts an ISO 'YYYY-MM-DDTHH:MM:SSZ' to 'MM-DD HH:MM:SS' for the table.
+compact_ts() { printf '%s' "${1#????-}" | sed 's/T/ /; s/Z$//'; }
+
+# truncate a field to width, adding an ellipsis.
+trunc() { local s="$1" w="${2:-28}"; local n=${#s}; if [ "$n" -gt "$w" ]; then printf '%s' "${s:0:$((w-1))}…"; else printf '%s' "$s"; fi; }
+
+# ---------------------------------------------------------------------------
+# Table.
+# ---------------------------------------------------------------------------
+event_count=$(wc -l < "$events" | tr -d ' ')
+
+echo
+echo "=== Leg timeline (since $(node -e 'process.stdout.write(new Date(Number(process.argv[1])).toISOString())' "$since_epoch")) ==="
+echo "events: $event_count"
+echo
+if [ "$event_count" -gt 0 ]; then
+  printf '%-15s  %-6s  %-28s  %-9s  %s\n' "TS(UTC)" "SOURCE" "LEG/BRANCH" "DELTA" "EVENT"
+  printf '%-15s  %-6s  %-28s  %-9s  %s\n' "-------" "------" "----------" "-----" "-----"
+  prev=""
+  while IFS=$'\t' read -r ep src leg ev _ ts; do
+    if [ -z "$prev" ]; then delta="-"; else delta=$(fmtdur $(( ep - prev ))); fi
+    printf '%-15s  %-6s  %-28s  %-9s  %s\n' "$(compact_ts "$ts")" "$src" "$(trunc "$leg" 28)" "$delta" "$(trunc "$ev" 60)"
+    prev="$ep"
+  done < "$events"
+else
+  echo "(no events in window)"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary block. Computed in one node pass over $events (it does the pairing
+# and interval-union arithmetic that bash 3.2 cannot do without awk).
+# ---------------------------------------------------------------------------
+echo
+echo "=== Summary ==="
+
+# Source-gap report: which configured sources were missing.
+gap=""
+[ "$w_glm" -eq 0 ]     && gap="${gap}  - worker(glm) dir missing: $glm_dir"$'\n'
+[ "$w_claudex" -eq 0 ] && gap="${gap}  - worker(claudex) dir missing: $claudex_dir"$'\n'
+[ "$w_gate" -eq 0 ]    && gap="${gap}  - CR ledger missing: $cr_ledger"$'\n'
+[ "$w_gate_malformed" -gt 0 ] && gap="${gap}  - CR ledger malformed rows skipped: $w_gate_malformed"$'\n'
+if [ "$w_ledger" -eq 0 ]; then
+  if [ -n "$chain_ledger" ]; then
+    gap="${gap}  - chain ledger missing: $chain_ledger"$'\n'
+  else
+    gap="${gap}  - chain ledger unresolved via handover_root"$'\n'
+  fi
+fi
+if [ -n "$gap" ]; then
+  echo "sources:"
+  printf '%s' "$gap"
+fi
+
+# SC2016: the single-quoted JS body uses template literals (${...}); bash must
+# NOT expand them — node receives them verbatim. Intentional, hence disabled.
+# shellcheck disable=SC2016
+node -e '
+  const fs = require("fs");
+  const since = parseInt(process.argv[1], 10);   // epoch ms (window lower bound)
+  const inWin = (ms) => Number.isNaN(since) || ms >= since;
+  // branch name = label with the appended "@<head>" suffix stripped. Split on
+  // the LAST '@' (the head is the trailing hex token) so a branch name that
+  // itself contains '@' is not truncated (HIMMEL-1485 r7).
+  const branch = (leg) => { const i = leg.lastIndexOf("@"); return i < 0 ? leg : leg.slice(0, i); };
+  const rows = [];
+  for (const line of fs.readFileSync(0, "utf8").split(/\r?\n/)){
+    if (line === "") continue;
+    const c = line.split("\t");
+    if (c.length < 6) continue;
+    rows.push({ ms: Number(c[0]), src: c[1], leg: c[2], ev: c[3], session: c[4], iso: c[5] });
+  }
+  const fmt = (ms) => {
+    let s = Math.floor(ms/1000), neg = s < 0; if (neg) s = -s;
+    const h = Math.floor(s/3600), m = Math.floor((s%3600)/60), sec = s%60;
+    let out = h>0 ? `${h}h${String(m).padStart(2,"0")}m` : (m>0 ? `${m}m${String(sec).padStart(2,"0")}s` : `${sec}s`);
+    return (neg?"-":"") + out;
+  };
+  // Window bounds come from IN-WINDOW rows (the displayed table). Pairing reads
+  // the unfiltered set so a pre-window dispatch that lands in-window is no longer
+  // dropped (HIMMEL-1485 r5 #1).
+  const win = rows.filter(r => inWin(r.ms));
+  if (win.length === 0){ process.stdout.write("(no events — nothing to summarize)\n"); process.exit(0); }
+
+  const min = win[0].ms, max = win[win.length-1].ms;
+  const span = max - min;
+
+  // Per-worker dispatch→land: pair by bridge session, never by shared branch.
+  const sessions = new Map();   // session -> { leg, disp:{ms,ev}, land:{ms,ev} }
+  for (const r of rows){
+    if (r.src !== "worker") continue;
+    const isDisp = r.ev.startsWith("dispatch");
+    const isLand = r.ev.startsWith("land");
+    if (!isDisp && !isLand) continue;
+    if (!sessions.has(r.session)) sessions.set(r.session, { leg: r.leg });
+    const o = sessions.get(r.session);
+    if (isDisp && !o.disp) o.disp = r;
+    if (isLand) o.land = r;
+  }
+
+  // Worker busy UNION (merge overlapping dispatch→land intervals) for % waiting.
+  // A pair contributes only when it LANDS in-window; its interval is clamped to
+  // the window so a pre-window dispatch counts only its in-window busy time.
+  const iv = [];
+  for (const o of sessions.values()){
+    if (!(o.disp && o.land && inWin(o.land.ms))) continue;
+    const a = Math.max(Math.min(o.disp.ms, o.land.ms), since);
+    const b = Math.min(Math.max(o.disp.ms, o.land.ms), max);
+    if (b >= a) iv.push([a, b]);
+  }
+  iv.sort((x,y) => x[0]-y[0]);
+  let union = 0;
+  if (iv.length){
+    let [lo, hi] = iv[0];
+    for (let i = 1; i < iv.length; i++){
+      const [a, b] = iv[i];
+      if (a <= hi) hi = Math.max(hi, b);
+      else { union += hi - lo; lo = a; hi = b; }
+    }
+    union += hi - lo;
+  }
+
+  // Per-branch gate run (last-first ts) + gate wait (first gate - dispatch of
+  // the same leg, when a worker dispatched that branch).
+  const gate = new Map();   // branch -> [firstMs, lastMs]
+  for (const r of rows){
+    if (r.src !== "gate" || !inWin(r.ms)) continue;
+    const br = branch(r.leg);
+    if (!gate.has(br)) gate.set(br, [r.ms, r.ms]);
+    else { const g = gate.get(br); g[0] = Math.min(g[0], r.ms); g[1] = Math.max(g[1], r.ms); }
+  }
+
+  // total span (event count = in-window rows, matching the displayed table)
+  process.stdout.write(`total span: ${fmt(span)}  (${win.length} events, ${min}..${max})\n`);
+
+  // per-worker dispatch->land. A session is shown when it lands in-window (its
+  // dispatch may predate the window — marked "dispatched pre-window") or was
+  // dispatched in-window and has not landed yet (still running).
+  process.stdout.write("\nworker dispatch→land:\n");
+  let anyWorker = false;
+  for (const [session, o] of sessions){
+    if (!o.disp) continue;
+    const landInWin = o.land && inWin(o.land.ms);
+    if (!landInWin && !inWin(o.disp.ms)) continue;   // nothing in-window for this session
+    anyWorker = true;
+    const tag = (o.disp.ms < since) ? " (dispatched pre-window)" : "";
+    const land = o.land ? `${fmt(o.land.ms - o.disp.ms)} (land ${o.land.ev.replace(/^land /,"")})${tag}` : "(never landed — still running or aborted)";
+    const label = `${o.leg} [${session}]`;
+    const name = label.length > 34 ? label.slice(0,33)+"…" : label;
+    process.stdout.write(`  ${name.padEnd(34)} ${land}\n`);
+  }
+  if (!anyWorker) process.stdout.write("  (no worker dispatches in window)\n");
+
+  // gate run per branch + derivable wait
+  process.stdout.write("\ngate run per branch (first→last critic event):\n");
+  if (gate.size === 0){
+    process.stdout.write("  (no gate events in window)\n");
+  } else {
+    // order branches by first-gate ts
+    const order = [...gate.entries()].sort((x,y) => x[1][0]-y[1][0]);
+    for (const [br, g] of order){
+      const run = fmt(g[1] - g[0]);
+      // wait = first gate - earliest worker dispatch of that same branch
+      let waitStr = "n/a";
+      let best = null;
+      for (const o of sessions.values()) if (o.disp && branch(o.leg) === br && (!best || o.disp.ms < best)) best = o.disp.ms;
+      if (best !== null) waitStr = fmt(g[0] - best);
+      const name = br.length > 34 ? br.slice(0,33)+"…" : br;
+      process.stdout.write(`  ${name.padEnd(34)} run=${run.padEnd(8)} wait-to-first=${waitStr}\n`);
+    }
+  }
+
+  // one-line wall-clock summary
+  const pctWaiting = span > 0 ? Math.max(0, Math.min(100, ((span - union) / span) * 100)) : 0;
+  process.stdout.write(`\nwall-clock: total ${fmt(span)}, worker-active ${fmt(union)} (${(100-pctWaiting).toFixed(0)}% of span), waiting ${pctWaiting.toFixed(0)}%\n`);
+' "$since_epoch" < "$allnorm"
+
+exit 0

--- a/scripts/handover/reconcile-workers.sh
+++ b/scripts/handover/reconcile-workers.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# reconcile-workers.sh -- reconcile offload-lane worker metadata after an
+# unclean dispatcher/session exit (HIMMEL-1463).
+#
+# A worker wrapper normally moves meta.json from status=running to a terminal
+# state. If the dispatching Claude session exits first, the wrapper and worker
+# can die together, leaving a false running row and (in shared-branch mode) a
+# stale writer lock. This helper marks only running rows whose recorded pid is
+# confirmed dead and whose metadata is older than the terminal-write grace
+# window as orphaned, preserving every other metadata field via an atomic JSON
+# rewrite. An unprobeable or still-settling row stays running and keeps its lock.
+# A shared lock is removed only when its own recorded holder pid is confirmed dead.
+#
+# Usage:
+#   bash scripts/handover/reconcile-workers.sh
+#   bash scripts/handover/reconcile-workers.sh --list-live
+#
+# Env:
+#   WORKER_BRIDGE_ROOT   Bridge root override (default: BRIDGE_ROOT, then
+#                        ~/.claude/handover/bridge).
+#   WORKER_PID_ALIVE_CMD Test seam: executable invoked as <cmd> <pid>; rc 0
+#                        means live, rc 1 confirmed dead, every other rc
+#                        unprobeable. Production probes both MSYS and native
+#                        Windows pid namespaces.
+#   RECONCILE_GRACE_SECS Minimum meta.json age before a confirmed-dead worker
+#                        may be orphaned (default: 120).
+#
+# Exit: 0 success/nothing to do; 2 malformed metadata or reconciliation error.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BRIDGE="${WORKER_BRIDGE_ROOT:-${BRIDGE_ROOT:-$HOME/.claude/handover/bridge}}"
+MODE="${1:-reconcile}"
+RECONCILE_GRACE_SECS="${RECONCILE_GRACE_SECS:-120}"
+
+case "$MODE" in
+    reconcile|--list-live) : ;;
+    -h|--help)
+        echo "usage: reconcile-workers.sh [--list-live]"
+        exit 0
+        ;;
+    *)
+        echo "ERR reconcile-workers: unknown arg: $MODE" >&2
+        exit 2
+        ;;
+esac
+
+case "$RECONCILE_GRACE_SECS" in
+    ''|*[!0-9]*)
+        echo "ERR reconcile-workers: RECONCILE_GRACE_SECS must be a non-negative integer" >&2
+        exit 2
+        ;;
+esac
+
+# worker_pid_alive <pid> -- rc 0 live, rc 1 confirmed dead, rc 2 unprobeable.
+# Bun reports native Windows pids; the shared-lock shell historically recorded
+# an MSYS pid. Checking both errs safely toward live if a number happens to exist
+# in both namespaces. Missing/failed census data must never authorize cleanup.
+worker_pid_alive() {
+    local pid="$1" out rc
+    case "$pid" in
+        ''|*[!0-9]*|0) return 2 ;;
+    esac
+
+    if [ -n "${WORKER_PID_ALIVE_CMD:-}" ]; then
+        "$WORKER_PID_ALIVE_CMD" "$pid"
+        rc=$?
+        case "$rc" in
+            0|1) return "$rc" ;;
+            *)
+                echo "WARN reconcile-workers: worker PID probe command failed for PID $pid (rc=$rc); liveness is unprobeable" >&2
+                return 2
+                ;;
+        esac
+    fi
+
+    if kill -0 "$pid" 2>/dev/null; then
+        return 0
+    fi
+
+    case "${OSTYPE:-$(uname -s 2>/dev/null || echo unknown)}" in
+        msys*|cygwin*|win32*|MINGW*)
+            if ! command -v tasklist >/dev/null 2>&1; then
+                echo "WARN reconcile-workers: tasklist unavailable for native PID $pid; liveness is unprobeable" >&2
+                return 2
+            fi
+            out=$(MSYS_NO_PATHCONV=1 tasklist /FO CSV /NH /FI "PID eq $pid" 2>&1)
+            rc=$?
+            if [ "$rc" -eq 0 ]; then
+                case "$out" in
+                    *\"$pid\"*) return 0 ;;
+                    *) return 1 ;;
+                esac
+            fi
+            echo "WARN reconcile-workers: tasklist failed for PID $pid (rc=$rc); liveness is unprobeable" >&2
+            return 2
+            ;;
+    esac
+    return 1
+}
+
+# _worker_meta_fields <meta.json> -- unit-separator-delimited fields. A
+# non-whitespace separator preserves empty shared_branch/repo_dir positions in
+# bash 3.2's read builtin.
+_worker_meta_fields() {
+    # shellcheck disable=SC2016  # JavaScript template literals, not shell expansion.
+    node -e '
+const fs = require("fs");
+const p = process.argv[1];
+let o;
+try { o = JSON.parse(fs.readFileSync(p, "utf8")); }
+catch (e) { console.error(`ERR reconcile-workers: cannot parse ${p}: ${e.message}`); process.exit(2); }
+const vals = [o.status, o.pid, o.shared_branch, o.repo_dir, o.lane, o.task_name];
+process.stdout.write(vals.map(v => v == null ? "" : String(v)).join("\x1f"));
+' "$1"
+}
+
+# _worker_meta_is_fresh <meta.json> -- rc 0 while the terminal writer may still
+# be settling, rc 1 once the grace window has elapsed, rc 2 on a stat error.
+_worker_meta_is_fresh() {
+    # shellcheck disable=SC2016  # JavaScript template literal, not shell expansion.
+    node -e '
+const fs = require("fs");
+const p = process.argv[1];
+const graceMs = Number(process.argv[2]) * 1000;
+try { process.exit(Date.now() - fs.statSync(p).mtimeMs <= graceMs ? 0 : 1); }
+catch (e) { console.error(`ERR reconcile-workers: cannot stat ${p}: ${e.message}`); process.exit(2); }
+' "$1" "$RECONCILE_GRACE_SECS"
+}
+
+# _worker_mark_orphaned <meta.json> <expected-pid> -- compare-and-rewrite. The
+# re-read prevents clobbering a terminal writer that won the race after census.
+_worker_mark_orphaned() {
+    # shellcheck disable=SC2016  # JavaScript template literals, not shell expansion.
+    node -e '
+const fs = require("fs");
+const p = process.argv[1];
+const expected = Number(process.argv[2]);
+let o;
+try { o = JSON.parse(fs.readFileSync(p, "utf8")); }
+catch (e) { console.error(`ERR reconcile-workers: cannot re-read ${p}: ${e.message}`); process.exit(2); }
+if (o.status !== "running" || Number(o.pid) !== expected) process.exit(3);
+o.status = "orphaned";
+const tmp = `${p}.tmp-reconcile-${process.pid}`;
+fs.writeFileSync(tmp, JSON.stringify(o, null, 2) + "\n");
+fs.renameSync(tmp, p);
+' "$1" "$2"
+}
+
+_worker_common_dir() {
+    local repo="$1" out
+    out=$(git -C "$repo" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || out=""
+    if [ -n "$out" ]; then
+        printf '%s\n' "$out"
+        return 0
+    fi
+    out=$(git -C "$repo" rev-parse --git-common-dir 2>/dev/null) || out=""
+    [ -n "$out" ] || return 1
+    case "$out" in
+        /*|[A-Za-z]:/*|[A-Za-z]:\\*) printf '%s\n' "$out" ;;
+        *) (cd "$repo" 2>/dev/null && cd "$out" 2>/dev/null && pwd -P) ;;
+    esac
+}
+
+_worker_lockdir() {
+    local repo="$1" branch="$2" common slug
+    common=$(_worker_common_dir "$repo") || return 1
+    slug=$(printf '%s' "$branch" | tr -c 'a-zA-Z0-9-' '-')
+    printf '%s/himmel-shared-branch/%s.lock\n' "$common" "$slug"
+}
+
+_worker_lock_owner_pid() {
+    node -e '
+const fs = require("fs");
+try {
+  const o = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  if (Number.isInteger(o.pid) && o.pid > 0) process.stdout.write(String(o.pid));
+} catch (_) {}
+' "$1"
+}
+
+# _worker_release_dead_lock <repo> <branch> -- atomically CLAIM the stale lock
+# directory by rename before deleting it. Once renamed, a new dispatcher may
+# acquire the original path and cannot be removed by this cleanup.
+_worker_release_dead_lock() {
+    local repo="$1" branch="$2" lockdir owner owner_now claimed rc
+    lockdir=$(_worker_lockdir "$repo" "$branch") || return 1
+    [ -d "$lockdir" ] || return 1
+    [ -f "$lockdir/owner.json" ] || return 1
+    owner=$(_worker_lock_owner_pid "$lockdir/owner.json")
+    [ -n "$owner" ] || return 1
+    worker_pid_alive "$owner"
+    rc=$?
+    [ "$rc" -eq 1 ] || return 1
+
+    # Re-read immediately before the atomic claim. The owner cannot change
+    # while the directory exists; acquire uses mkdir and cannot enter it.
+    owner_now=$(_worker_lock_owner_pid "$lockdir/owner.json")
+    [ "$owner_now" = "$owner" ] || return 1
+    claimed="${lockdir}.reconcile.$$"
+    if [ -e "$claimed" ]; then
+        echo "WARN reconcile-workers: stale-lock claim path already exists '$claimed'; left the lock in place" >&2
+        return 1
+    fi
+    if ! mv "$lockdir" "$claimed" 2>/dev/null; then
+        echo "WARN reconcile-workers: could not claim stale lock '$lockdir'; left it in place" >&2
+        return 1
+    fi
+    rm -rf "$claimed"
+    if [ -d "$claimed" ]; then
+        echo "WARN reconcile-workers: claimed stale lock '$claimed' could not be removed" >&2
+        return 1
+    fi
+    return 0
+}
+
+FAILED=0
+for lane_dir in "$BRIDGE/glm-sessions" "$BRIDGE/claudex-sessions"; do
+    for meta in "$lane_dir"/*/meta.json; do
+        [ -f "$meta" ] || continue
+        fields=$(_worker_meta_fields "$meta")
+        rc=$?
+        if [ "$rc" -ne 0 ]; then
+            FAILED=1
+            continue
+        fi
+        IFS=$'\x1f' read -r status pid branch repo_dir lane task_name <<< "$fields"
+        [ "$status" = "running" ] || continue
+
+        if worker_pid_alive "$pid"; then
+            if [ "$MODE" = "--list-live" ]; then
+                printf '%s task=%s pid=%s meta=%s\n' "${lane:-unknown}" "${task_name:-unknown}" "$pid" "$meta"
+            fi
+            continue
+        else
+            probe_rc=$?
+        fi
+        if [ "$probe_rc" -ne 1 ]; then
+            echo "WARN reconcile-workers: unprobeable ${lane:-unknown}/${task_name:-unknown} pid=${pid:-absent}; treating as possibly alive, leaving metadata and any shared lock untouched" >&2
+            if [ "$MODE" = "--list-live" ]; then
+                printf '%s task=%s pid=%s state=unprobeable meta=%s\n' "${lane:-unknown}" "${task_name:-unknown}" "${pid:-absent}" "$meta"
+            fi
+            continue
+        fi
+
+        if _worker_meta_is_fresh "$meta"; then
+            echo "WARN reconcile-workers: settling ${lane:-unknown}/${task_name:-unknown} pid=${pid:-absent}; meta.json is newer than the ${RECONCILE_GRACE_SECS}s grace, leaving metadata and any shared lock untouched" >&2
+            if [ "$MODE" = "--list-live" ]; then
+                printf '%s task=%s pid=%s state=settling meta=%s\n' "${lane:-unknown}" "${task_name:-unknown}" "${pid:-absent}" "$meta"
+            fi
+            continue
+        else
+            freshness_rc=$?
+        fi
+        if [ "$freshness_rc" -ne 1 ]; then
+            FAILED=1
+            continue
+        fi
+        [ "$MODE" = "reconcile" ] || continue
+
+        _worker_mark_orphaned "$meta" "$pid"
+        rc=$?
+        if [ "$rc" -eq 3 ]; then
+            continue
+        fi
+        if [ "$rc" -ne 0 ]; then
+            FAILED=1
+            continue
+        fi
+
+        summary="reconcile-workers: orphaned ${lane:-unknown}/${task_name:-unknown} pid=${pid:-0}"
+        if [ -n "$branch" ]; then
+            [ -n "$repo_dir" ] || repo_dir="$SCRIPT_DIR/../.."
+            if _worker_release_dead_lock "$repo_dir" "$branch"; then
+                summary="$summary; released shared lock $branch"
+            fi
+        fi
+        echo "$summary"
+    done
+done
+
+[ "$FAILED" -eq 0 ] || exit 2
+exit 0

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -709,6 +709,23 @@ assert_contains "T23 record names the skill" '"skill":"handover-arm-resume"' "$t
 assert_contains "T23 record names the event" '"event":"armed"' "$tline"
 assert_contains "T23 record carries time" "\"time\":\"$FUTURE_TIME\"" "$tline"
 assert_contains "T23 record carries force" '"force":"0"' "$tline"
+# HIMMEL-1490: the measured gap (raw seconds) is emitted alongside the
+# long_gap flag. FUTURE_TIME is now+30m, so a real positive integer (<3600)
+# is expected — present AND numeric, not an exact value (timing-dependent).
+assert_contains "T23 record carries gap_sec field" '"gap_sec":"' "$tline"
+_t23_gap=${tline#*\"gap_sec\":\"}; _t23_gap=${_t23_gap%%\"*}
+case "$_t23_gap" in
+    ''|0|*[!0-9]*)
+        # '0' is rejected too: an explicit arm 30m out MUST measure a nonzero
+        # gap — 0 is the unset-_GAP_SEC default and would mask that regression.
+        echo "FAIL T23 gap_sec not a strictly positive integer (got '$_t23_gap')"
+        FAILED=$((FAILED + 1))
+        ;;
+    *)
+        echo "PASS T23 gap_sec is a strictly positive integer ($_t23_gap)"
+        ;;
+esac
+unset _t23_gap
 
 # ---------------------------------------------------------------------------
 # T23b: scheduler-create FAILURE emits NO record (HIMMEL-236) — the

--- a/scripts/handover/test-leg-timeline.sh
+++ b/scripts/handover/test-leg-timeline.sh
@@ -1,0 +1,410 @@
+#!/usr/bin/env bash
+# scripts/handover/test-leg-timeline.sh — HIMMEL-1485
+#
+# Hermetic suite for scripts/handover/leg-timeline.sh. Builds FIXTURE copies of
+# each source (worker meta.json, CR ledger JSONL, chain-ledger md) under a temp
+# dir and points the script at them via its env overrides — the LIVE sources are
+# never touched. Covers: happy path, missing-source degradation, non-UTF8 ledger
+# line tolerated, plus since-ts filtering + arg/parse edge cases.
+#
+# Idiom follows scripts/cr/test-cr-scores.sh: set -uo pipefail, mktemp + trap,
+# check/contains/not_contains helpers, ALL PASS / <n> FAILED footer. Prints FULL
+# output and an explicit SUITE-EXIT=<rc> line (never tail/head).
+#
+# bash 3.2-safe (no mapfile/associative arrays). jq + node required.
+# shellcheck disable=SC2015  # A && B || C intentional in check()/contains()
+set -uo pipefail
+
+# grepq: a `grep -q` against a here-string with NO pipeline. printf|grep -q is a
+# trap under `set -o pipefail` (grep -q exits on first match -> SIGPIPE -> the
+# pipeline reports failed on a successful match). A here-string is not a pipeline
+# so the status is grep's alone. (HIMMEL-1430.)
+grepq() { local _t="$1"; shift; grep -q "$@" <<< "$_t"; }
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LT="$HERE/leg-timeline.sh"
+
+fails=0
+check()        { [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+contains()     { grepq "$2" -F "$3" && echo "ok - $1" || { echo "FAIL - $1: output does not contain [$3]"; fails=$((fails+1)); }; }
+matches()      { grepq "$2" -E "$3" && echo "ok - $1" || { echo "FAIL - $1: output does not match [$3]"; fails=$((fails+1)); }; }
+not_contains() { grepq "$2" -F "$3" && { echo "FAIL - $1: output must NOT contain [$3]"; fails=$((fails+1)); } || echo "ok - $1"; }
+ordered()      { case "$2" in *"$3"*"$4"*) echo "ok - $1" ;; *) echo "FAIL - $1: [$3] must precede [$4]"; fails=$((fails+1)) ;; esac; }
+
+# Fixture root under node's os.tmpdir() (Windows-form path), backslashes folded
+# to forward slashes so it is safe both in bash and in the script's node calls.
+# mktemp(1) under Git Bash returns an MSYS '/tmp/...' path with no drive letter,
+# which the script cannot normalize and Node fs rejects — hence node mkdtemp.
+ROOT=$(node -e 'const os=require("os"),fs=require("fs"),p=require("path"); process.stdout.write(fs.mkdtempSync(p.join(os.tmpdir(),"legtl-")).replace(/\\/g,"/"))')
+trap 'rm -rf "$ROOT"' EXIT
+mkdir -p "$ROOT/glm-sessions/glm-fix-1" "$ROOT/glm-sessions/glm-fix-2" \
+         "$ROOT/glm-sessions/glm-fix-4" "$ROOT/glm-sessions/glm-fix-0" \
+         "$ROOT/claudex-sessions/claudex-fix-3" \
+         "$ROOT/state/tester/himmel/specs/plan"
+
+# set_mtime <file> <ISO-ts>: stamp a fixture file's mtime to an exact instant,
+# independent of host TZ (node utimesSync takes epoch seconds). The script reads
+# the exit/land stamp from meta.json's mtime, so deterministic mtimes make the
+# dispatch->land durations assertable.
+set_mtime() {
+  node -e 'const fs=require("fs"); const t=Date.parse(process.argv[2])/1000; fs.utimesSync(process.argv[1], t, t)' "$1" "$2"
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures.
+# ---------------------------------------------------------------------------
+
+# worker glm-fix-1: done, dispatch 01:00:00Z, land 01:05:00Z -> 5m
+cat > "$ROOT/glm-sessions/glm-fix-1/meta.json" <<'EOF'
+{"status":"done","pid":111,"started_at":"2026-08-03T01:00:00Z","lane":"glm","task_name":"fix-1","exit_code":0,"timed_out":false}
+EOF
+set_mtime "$ROOT/glm-sessions/glm-fix-1/meta.json" "2026-08-03T01:05:00Z"
+
+# worker glm-fix-2: running, dispatch 01:10:00Z (never lands -> "still running")
+cat > "$ROOT/glm-sessions/glm-fix-2/meta.json" <<'EOF'
+{"status":"running","pid":222,"started_at":"2026-08-03T01:10:00Z","lane":"glm","task_name":"fix-2","last_output_at":"2026-08-03T01:11:00Z"}
+EOF
+
+# worker glm-fix-0: done but started BEFORE the since-ts window -> must be filtered out
+cat > "$ROOT/glm-sessions/glm-fix-0/meta.json" <<'EOF'
+{"status":"done","pid":444,"started_at":"2026-08-02T23:00:00Z","lane":"glm","task_name":"fix-0-prewindow","exit_code":0,"timed_out":false}
+EOF
+set_mtime "$ROOT/glm-sessions/glm-fix-0/meta.json" "2026-08-02T23:02:00Z"
+
+# worker claudex-fix-3: done, dispatch 02:00:00Z, land 02:08:00Z -> 8m, shared_branch
+cat > "$ROOT/claudex-sessions/claudex-fix-3/meta.json" <<'EOF'
+{"status":"done","pid":333,"started_at":"2026-08-03T02:00:00Z","lane":"codex","task_name":"claudex-fix-3","shared_branch":"claudex/fix-3","exit_code":0,"timed_out":false}
+EOF
+set_mtime "$ROOT/claudex-sessions/claudex-fix-3/meta.json" "2026-08-03T02:08:00Z"
+
+# worker glm-fix-4: blocked (content-filter), dispatch 02:05:00Z, land 02:06:00Z.
+# "blocked" is terminal in spawn-glm.ts finalMeta -> must produce a land row.
+cat > "$ROOT/glm-sessions/glm-fix-4/meta.json" <<'EOF'
+{"status":"blocked","pid":555,"started_at":"2026-08-03T02:05:00Z","lane":"glm","task_name":"fix-4","exit_code":0}
+EOF
+set_mtime "$ROOT/glm-sessions/glm-fix-4/meta.json" "2026-08-03T02:06:00Z"
+
+# CR ledger: two rounds of avail+finding on branch claudex/fix-3 @ head ABC1234
+cat > "$ROOT/cr-critic-scores.jsonl" <<'EOF'
+{"kind":"avail","ts":"2026-08-03T02:01:00Z","branch":"claudex/fix-3","head":"ABC1234","model":"codex","status":"ok"}
+{"kind":"avail","ts":"2026-08-03T02:01:30Z","branch":"claudex/fix-3","head":"ABC1234","model":"glm","status":"ok"}
+{"kind":"finding","ts":"2026-08-03T02:02:00Z","branch":"claudex/fix-3","head":"ABC1234","model":"codex","finding_id":"c1","severity":"imp","file":"f","line":1,"verdict":"agreed"}
+{"kind":"finding","ts":"2026-08-03T02:02:30Z"
+{"kind":"usage","ts":"2026-08-03T02:03:00Z","branch":"claudex/fix-3","head":"ABC1234","model":"glm"}
+EOF
+
+# chain ledger: header, two timestamped lines, one no-timestamp line (skipped),
+# then a line carrying a non-UTF8 byte (0xFF) in its prefix before the timestamp.
+cat > "$ROOT/chain-ledger.md" <<'EOF'
+# Chain ledger fixture
+BASELINE abc123 2026-08-03T01:30:00Z init
+NOTE this line has no timestamp and must be skipped
+TIE_FIRST 2026-08-03T02:20:00Z stable-one
+TIE_SECOND 2026-08-03T02:20:00Z stable-two
+PHASE_START P1 2026-08-03T02:30:00Z running
+EOF
+node -e 'const fs=require("fs"); const b=Buffer.concat([Buffer.from("WEIRD "),Buffer.from([255]),Buffer.from(" tag 2026-08-03T01:45:00Z binary-tolerated\n")]); fs.appendFileSync(process.argv[1], b);' "$ROOT/chain-ledger.md"
+
+cat > "$ROOT/state/tester/himmel/specs/plan/2026-07-28-chain-ledger.md" <<'EOF'
+RESOLVED_ROOT 2026-08-03T01:35:00Z via-handover-root
+EOF
+
+# Common env override prefix for the script.
+ENVOFF="LEG_TIMELINE_WORKER_GLM=$ROOT/glm-sessions LEG_TIMELINE_WORKER_CLAUDEX=$ROOT/claudex-sessions LEG_TIMELINE_CR_LEDGER=$ROOT/cr-critic-scores.jsonl LEG_TIMELINE_CHAIN_LEDGER=$ROOT/chain-ledger.md"
+
+# run_lt: invoke leg-timeline.sh against the full-source fixtures. $ENVOFF is
+# INTENTIONALLY word-split into env's VAR=val args — SC2086 disabled for that.
+# shellcheck disable=SC2086
+run_lt() { env $ENVOFF bash "$LT" "$@"; }
+
+# ===========================================================================
+# 1. Happy path — all three sources present, since 2026-08-03T00:00 (UTC).
+# ===========================================================================
+echo "--- 1. happy path ---"
+out=$(run_lt 2026-08-03T00:00 2>&1); rc=$?
+check "happy path exit 0" "$rc" "0"
+contains "worker dispatch row"            "$out" "dispatch glm done"
+contains "worker dispatch claudex(codex)" "$out" "dispatch codex done"
+contains "worker land row"                "$out" "land done rc=0"
+contains "blocked session gets a land row" "$out" "land blocked"
+contains "gate avail row"                 "$out" "avail codex"
+contains "gate finding row"               "$out" "finding codex imp"
+contains "gate row after torn JSONL line"  "$out" "usage glm"
+contains "reports torn CR ledger line"     "$out" "CR ledger malformed rows skipped: 1"
+contains "ledger BASELINE event"          "$out" "BASELINE"
+contains "ledger PHASE_START event"       "$out" "PHASE_START"
+ordered "equal timestamp/source rows retain input order" "$out" "TIE_FIRST" "TIE_SECOND"
+contains "summary total span"             "$out" "total span:"
+contains "fix-1 dispatch->land = 5m00s"   "$out" "5m00s"
+contains "fix-3 dispatch->land = 8m00s"   "$out" "8m00s"
+contains "gate run per branch names fix-3" "$out" "claudex/fix-3"
+# Bind the metric to the claudex/fix-3 branch on the SAME line: the duration-only
+# forms would pass if ANY branch showed 2m00s/1m00s. The summary prints one line per
+# branch ("<branch>... run=<d> wait-to-first=<d>"), so identity+metric co-occur there.
+matches "gate run for fix-3 = 2m00s"           "$out" 'claudex/fix-3.*run=2m00s'
+matches "gate wait-to-first for fix-3 = 1m00s" "$out" 'claudex/fix-3.*wait-to-first=1m00s'
+contains "wall-clock summary line"        "$out" "wall-clock:"
+contains "waiting percentage"             "$out" "waiting"
+contains "running worker flagged never-landed" "$out" "(never landed"
+# non-UTF8 ledger line was processed, not dropped/crashed:
+contains "non-UTF8 ledger line produced an event (01:45)" "$out" "08-03 01:45"
+# pre-window worker was filtered out by since-ts:
+not_contains "pre-window worker filtered out" "$out" "fix-0"
+# the no-timestamp ledger line did not become an event:
+not_contains "no-ts ledger line not emitted"  "$out" "must be skipped"
+
+# Resolve the default chain-ledger path through handover_root + USER_SLUG.
+echo "--- 1b. handover-root chain ledger resolution ---"
+out=$(env HANDOVER_DIR="$ROOT/state" USER_SLUG=tester \
+          LEG_TIMELINE_WORKER_GLM="$ROOT/glm-sessions" \
+          LEG_TIMELINE_WORKER_CLAUDEX="$ROOT/claudex-sessions" \
+          LEG_TIMELINE_CR_LEDGER="$ROOT/cr-critic-scores.jsonl" \
+          LEG_TIMELINE_CHAIN_LEDGER="" \
+      bash "$LT" 2026-08-03T00:00 2>&1); rc=$?
+check "handover-root resolution exit 0" "$rc" "0"
+contains "chain ledger resolved via handover_root" "$out" "RESOLVED_ROOT"
+
+# A failed pure resolution is a reported source gap, not a fatal error.
+echo "--- 1c. unresolved handover root degradation ---"
+out=$(env HANDOVER_DIR="$ROOT/no-state" USER_SLUG=tester \
+          LEG_TIMELINE_WORKER_GLM="$ROOT/glm-sessions" \
+          LEG_TIMELINE_WORKER_CLAUDEX="$ROOT/claudex-sessions" \
+          LEG_TIMELINE_CR_LEDGER="$ROOT/cr-critic-scores.jsonl" \
+          LEG_TIMELINE_CHAIN_LEDGER="" \
+      bash "$LT" 2026-08-03T00:00 2>&1); rc=$?
+check "unresolved handover root still exit 0" "$rc" "0"
+contains "reports unresolved chain ledger" "$out" "chain ledger unresolved via handover_root"
+
+# Re-dispatches onto one shared branch remain distinct dispatch→land sessions.
+echo "--- 1d. same-branch re-dispatch pairing ---"
+mkdir -p "$ROOT/redispatch-sessions/session-one" "$ROOT/redispatch-sessions/session-two"
+cat > "$ROOT/redispatch-sessions/session-one/meta.json" <<'EOF'
+{"status":"done","started_at":"2026-08-03T03:00:00Z","lane":"codex","task_name":"round-one","shared_branch":"fix/shared","exit_code":0}
+EOF
+set_mtime "$ROOT/redispatch-sessions/session-one/meta.json" "2026-08-03T03:03:00Z"
+cat > "$ROOT/redispatch-sessions/session-two/meta.json" <<'EOF'
+{"status":"done","started_at":"2026-08-03T04:00:00Z","lane":"codex","task_name":"round-two","shared_branch":"fix/shared","exit_code":0}
+EOF
+set_mtime "$ROOT/redispatch-sessions/session-two/meta.json" "2026-08-03T04:07:00Z"
+out=$(env LEG_TIMELINE_WORKER_GLM="$ROOT/no-glm" \
+          LEG_TIMELINE_WORKER_CLAUDEX="$ROOT/redispatch-sessions" \
+          LEG_TIMELINE_CR_LEDGER="$ROOT/no-cr.jsonl" \
+          LEG_TIMELINE_CHAIN_LEDGER="$ROOT/no-ledger.md" \
+      bash "$LT" 2026-08-03T00:00 2>&1); rc=$?
+check "same-branch re-dispatch exit 0" "$rc" "0"
+matches "first session pairs with its own land" "$out" 'fix/shared \[session-one\] +3m00s'
+matches "second session pairs with its own land" "$out" 'fix/shared \[session-two\] +7m00s'
+
+# mktemp -d failure (TMPDIR at a non-existent parent) must be fatal, not silently
+# continue with an empty $tmp into "/raw.tsv" (HIMMEL-1485 r4 #1). TMPDIR is the
+# script's only mktemp input, so pointing it at a path whose parent does not
+# exist is the cheap injection — no scaffolding required.
+echo "--- 1e. mktemp failure is fatal ---"
+out=$(env LEG_TIMELINE_WORKER_GLM="$ROOT/no-glm" \
+          LEG_TIMELINE_WORKER_CLAUDEX="$ROOT/no-claudex" \
+          LEG_TIMELINE_CR_LEDGER="$ROOT/no-cr.jsonl" \
+          LEG_TIMELINE_CHAIN_LEDGER="$ROOT/no-ledger.md" \
+          TMPDIR="$ROOT/nonexistent-tmpdir" \
+      bash "$LT" 2026-08-03T00:00 2>&1); rc=$?
+# Contract is "nonzero", not specifically 1 (the script's `exit 1` is incidental).
+if [ "$rc" -ne 0 ]; then
+  echo "ok - mktemp failure exits nonzero"
+else
+  echo "FAIL - mktemp failure exits nonzero: rc=$rc (expected nonzero)"; fails=$((fails+1))
+fi
+contains "mktemp failure error message" "$out" "mktemp -d failed"
+
+# ===========================================================================
+# 2. Missing-source degradation — CR ledger points at a nonexistent path.
+#    The script must report the gap and still run over worker + ledger sources.
+# ===========================================================================
+echo "--- 2. missing-source degradation ---"
+out=$(env LEG_TIMELINE_WORKER_GLM="$ROOT/glm-sessions" \
+          LEG_TIMELINE_WORKER_CLAUDEX="$ROOT/claudex-sessions" \
+          LEG_TIMELINE_CR_LEDGER="$ROOT/does-not-exist.jsonl" \
+          LEG_TIMELINE_CHAIN_LEDGER="$ROOT/chain-ledger.md" \
+      bash "$LT" 2026-08-03T00:00 2>&1); rc=$?
+check "missing source still exit 0" "$rc" "0"
+contains "reports missing CR ledger"   "$out" "CR ledger missing:"
+contains "worker source still works"   "$out" "dispatch glm done"
+contains "ledger source still works"   "$out" "BASELINE"
+not_contains "gate source absent"      "$out" "avail codex"
+
+# All three sources missing -> still exit 0, gap report lists all three, no crash.
+echo "--- 2b. all sources missing ---"
+out=$(env LEG_TIMELINE_WORKER_GLM="$ROOT/no-glm" \
+          LEG_TIMELINE_WORKER_CLAUDEX="$ROOT/no-claudex" \
+          LEG_TIMELINE_CR_LEDGER="$ROOT/no-cr.jsonl" \
+          LEG_TIMELINE_CHAIN_LEDGER="$ROOT/no-ledger.md" \
+      bash "$LT" 2026-08-03T00:00 2>&1); rc=$?
+check "all-missing still exit 0" "$rc" "0"
+contains "all-missing reports glm dir"    "$out" "worker(glm) dir missing"
+contains "all-missing reports claudex dir" "$out" "worker(claudex) dir missing"
+contains "all-missing reports CR ledger"  "$out" "CR ledger missing"
+contains "all-missing reports chain ledger" "$out" "chain ledger missing"
+contains "all-missing graceful empty msg" "$out" "no events in window"
+
+# ===========================================================================
+# 3. Non-UTF8 ledger line tolerated — a ledger whose ONLY timestamped line
+#    carries a 0xFF byte right before the timestamp still yields its event.
+# ===========================================================================
+echo "--- 3. non-UTF8 ledger line tolerated ---"
+mkdir -p "$ROOT/utf8-glm/u1"
+cat > "$ROOT/utf8-glm/u1/meta.json" <<'EOF'
+{"status":"done","pid":9,"started_at":"2026-08-03T01:40:00Z","lane":"glm","task_name":"u1","exit_code":0,"timed_out":false}
+EOF
+set_mtime "$ROOT/utf8-glm/u1/meta.json" "2026-08-03T01:41:00Z"
+printf '# utf8 ledger fixture\n' > "$ROOT/utf8-ledger.md"
+node -e 'const fs=require("fs"); const b=Buffer.concat([Buffer.from("ONLY "),Buffer.from([255,254]),Buffer.from(" line 2026-08-03T01:50:00Z survives\n")]); fs.appendFileSync(process.argv[1], b);' "$ROOT/utf8-ledger.md"
+out=$(env LEG_TIMELINE_WORKER_GLM="$ROOT/utf8-glm" \
+          LEG_TIMELINE_WORKER_CLAUDEX="$ROOT/no-claudex" \
+          LEG_TIMELINE_CR_LEDGER="$ROOT/no-cr.jsonl" \
+          LEG_TIMELINE_CHAIN_LEDGER="$ROOT/utf8-ledger.md" \
+      bash "$LT" 2026-08-03T00:00 2>&1); rc=$?
+check "non-utf8 ledger exit 0" "$rc" "0"
+contains "non-utf8 ledger event survives" "$out" "08-03 01:50"
+contains "non-utf8 ledger row content emitted" "$out" "ONLY �� line"
+
+# ===========================================================================
+# 4. Edge cases.
+# ===========================================================================
+echo "--- 4. edge cases ---"
+# No since-ts arg -> usage, non-zero exit.
+out=$(bash "$LT" 2>&1); rc=$?
+check "no-arg non-zero exit" "$rc" "1"
+contains "no-arg prints usage" "$out" "Usage:"
+# Unparseable since-ts -> error, non-zero exit.
+out=$(run_lt "not-a-date" 2>&1); rc=$?
+check "bad since-ts non-zero exit" "$rc" "1"
+contains "bad since-ts error" "$out" "could not parse"
+# Date-only since-ts means UTC midnight, not an invalid YYYY-MM-DDZ timestamp.
+out=$(run_lt 2026-08-03 2>&1); rc=$?
+check "date-only since-ts exit 0" "$rc" "0"
+contains "date-only since-ts includes post-midnight event" "$out" "fix-1"
+# Offset-less since-ts read as UTC, not local: 2026-08-03T00:00 (no Z) must match
+# the explicit-Z form (fix-1 @ 01:00:00Z is included in both; on a non-UTC host a
+# local-misread would push 00:00 PAST 01:00Z and filter fix-1 out).
+out_z=$(run_lt 2026-08-03T00:00Z 2>&1)
+out_noz=$(run_lt 2026-08-03T00:00 2>&1)
+if grepq "$out_z" -F "fix-1" && grepq "$out_noz" -F "fix-1"; then
+  echo "ok - offset-less since-ts treated as UTC (fix-1 in both)"
+else
+  echo "FAIL - offset-less since-ts treated as UTC (fix-1 in both)"; fails=$((fails+1))
+fi
+
+# ===========================================================================
+# 5. Pre-window dispatch pairing (HIMMEL-1485 r5 #1). A worker dispatched
+#    BEFORE since-ts that LANDS inside the window must still appear in the
+#    dispatch→land + worker-active summaries (marked "dispatched pre-window"),
+#    while its pre-window dispatch row stays out of the displayed table.
+# ===========================================================================
+echo "--- 5. pre-window dispatch pairing ---"
+mkdir -p "$ROOT/prewin-sessions/handed-over" "$ROOT/prewin-sessions/fresh"
+# handed-over: dispatched 2026-08-02T23:00:00Z (pre-window), lands 00:20:00Z.
+cat > "$ROOT/prewin-sessions/handed-over/meta.json" <<'EOF'
+{"status":"done","started_at":"2026-08-02T23:00:00Z","lane":"glm","task_name":"handed","exit_code":0}
+EOF
+set_mtime "$ROOT/prewin-sessions/handed-over/meta.json" "2026-08-03T00:20:00Z"
+# fresh: dispatched + landed fully in-window (bounds the window + baseline union).
+cat > "$ROOT/prewin-sessions/fresh/meta.json" <<'EOF'
+{"status":"done","started_at":"2026-08-03T01:00:00Z","lane":"glm","task_name":"fresh","exit_code":0}
+EOF
+set_mtime "$ROOT/prewin-sessions/fresh/meta.json" "2026-08-03T01:05:00Z"
+out=$(env LEG_TIMELINE_WORKER_GLM="$ROOT/prewin-sessions" \
+          LEG_TIMELINE_WORKER_CLAUDEX="$ROOT/no-claudex" \
+          LEG_TIMELINE_CR_LEDGER="$ROOT/no-cr.jsonl" \
+          LEG_TIMELINE_CHAIN_LEDGER="$ROOT/no-ledger.md" \
+      bash "$LT" 2026-08-03T00:00 2>&1); rc=$?
+check "pre-window pairing exit 0" "$rc" "0"
+contains "handed-over appears in dispatch->land" "$out" "handed-over"
+contains "handed-over full duration 1h20m" "$out" "1h20m"
+contains "handed-over marked dispatched pre-window" "$out" "(dispatched pre-window)"
+not_contains "pre-window dispatch row absent from table" "$out" "08-02 23:00"
+contains "handed-over in-window land shown in table" "$out" "08-03 00:20"
+# worker-active = handed-over in-window [00:00,00:20]=20m + fresh [01:00,01:05]=5m
+# = 25m. Without the fix handed-over is dropped entirely -> worker-active 5m00s.
+contains "worker-active includes handed-over (25m00s)" "$out" "worker-active 25m00s"
+
+# ===========================================================================
+# 6. Lowercase-z timestamp normalization (HIMMEL-1485 r5 #2). An event row
+#    whose ISO ts ends in a lowercase "z" must normalize to valid UTC, not be
+#    re-suffixed into an invalid "zZ" that Date.parse drops.
+# ===========================================================================
+echo "--- 6. lowercase-z normalization ---"
+mkdir -p "$ROOT/lowz-sessions/lowz-1"
+# started_at ends in lowercase "z"; its dispatch row must survive normalization.
+cat > "$ROOT/lowz-sessions/lowz-1/meta.json" <<'EOF'
+{"status":"done","started_at":"2026-08-03T01:00:00z","lane":"glm","task_name":"lowz","exit_code":0}
+EOF
+set_mtime "$ROOT/lowz-sessions/lowz-1/meta.json" "2026-08-03T01:05:00Z"
+out=$(env LEG_TIMELINE_WORKER_GLM="$ROOT/lowz-sessions" \
+          LEG_TIMELINE_WORKER_CLAUDEX="$ROOT/no-claudex" \
+          LEG_TIMELINE_CR_LEDGER="$ROOT/no-cr.jsonl" \
+          LEG_TIMELINE_CHAIN_LEDGER="$ROOT/no-ledger.md" \
+      bash "$LT" 2026-08-03T00:00 2>&1); rc=$?
+check "lowercase-z exit 0" "$rc" "0"
+# The lowercase-z dispatch at 01:00:00z normalizes to 01:00:00Z and is shown
+# (not dropped). Without the fix it became "...zZ" -> NaN -> the row vanished.
+contains "lowercase-z dispatch row shown (not dropped)" "$out" "08-03 01:00:00"
+# Pairing needs both dispatch + land; without the fix the dispatch dropped and
+# no dispatch->land duration would be emitted.
+# Bind the duration to the lowz worker identity + its land label on the SAME
+# dispatch->land row ("<leg> [<session>]  <dur> (land <status>)"): the bare
+# "5m00s" form would pass if ANY worker showed that duration.
+matches "lowercase-z worker pairs lowz [lowz-1] land 5m00s" "$out" 'lowz \[lowz-1\] +5m00s \(land'
+
+# ===========================================================================
+# 7. Fractional-second + explicit offset in a chain-ledger stamp (HIMMEL-1485
+#    r7 #1). A stamp like 2026-08-03T13:40:00.5+02:00 must keep its offset:
+#    without the (?:\.\d+)? clause the capture truncates before ".5+02:00",
+#    silently stripping the offset so r5 normalization misreads it as UTC.
+#    +02:00 -> 13:40:00.5 local == 11:40:00Z. Ledger-only run (no workers).
+# ===========================================================================
+echo "--- 7. fractional-second offset honored ---"
+printf '# fractional-second offset fixture\n' > "$ROOT/frac-ledger.md"
+printf 'FRAC_OFFSET 2026-08-03T13:40:00.5+02:00 honors-offset\n' >> "$ROOT/frac-ledger.md"
+out=$(env LEG_TIMELINE_WORKER_GLM="$ROOT/no-glm" \
+          LEG_TIMELINE_WORKER_CLAUDEX="$ROOT/no-claudex" \
+          LEG_TIMELINE_CR_LEDGER="$ROOT/no-cr.jsonl" \
+          LEG_TIMELINE_CHAIN_LEDGER="$ROOT/frac-ledger.md" \
+      bash "$LT" 2026-08-03T00:00 2>&1); rc=$?
+check "fractional-offset exit 0" "$rc" "0"
+contains "fractional-offset event shown (prefix survives)" "$out" "FRAC_OFFSET"
+# offset honored -> displayed at 11:40 UTC; stripped (bug) -> misread as 13:40 UTC.
+contains "offset honored -> 11:40 UTC" "$out" "08-03 11:40:00"
+not_contains "offset stripped misread as 13:40 UTC" "$out" "08-03 13:40:00"
+
+# ===========================================================================
+# 8. Gate branch containing '@' shown intact (HIMMEL-1485 r7 #2). The gate
+#    label is <branch>@<head-7>; the per-branch summary extracts the branch by
+#    splitting on the LAST '@' (the head suffix), so a branch name that itself
+#    contains '@' survives. Splitting on the FIRST '@' truncated it.
+# ===========================================================================
+echo "--- 8. gate branch containing '@' shown intact ---"
+cat > "$ROOT/at-cr.jsonl" <<'EOF'
+{"kind":"avail","ts":"2026-08-03T02:01:00Z","branch":"feat/x@y","head":"ABC1234","model":"codex","status":"ok"}
+{"kind":"finding","ts":"2026-08-03T02:02:00Z","branch":"feat/x@y","head":"ABC1234","model":"codex","finding_id":"c1","severity":"imp","file":"f","line":1,"verdict":"agreed"}
+EOF
+out=$(env LEG_TIMELINE_WORKER_GLM="$ROOT/no-glm" \
+          LEG_TIMELINE_WORKER_CLAUDEX="$ROOT/no-claudex" \
+          LEG_TIMELINE_CR_LEDGER="$ROOT/at-cr.jsonl" \
+          LEG_TIMELINE_CHAIN_LEDGER="$ROOT/no-ledger.md" \
+      bash "$LT" 2026-08-03T00:00 2>&1); rc=$?
+check "'@'-branch exit 0" "$rc" "0"
+contains "gate avail row for '@'-branch" "$out" "avail codex"
+# gate-run line prints the extracted branch name; with the fix the full
+# "feat/x@y" survives on the run= line (first-'@' split would truncate to "feat/x").
+matches "'@'-branch shown intact in gate run" "$out" 'feat/x@y.*run='
+
+# ===========================================================================
+# Footer.
+# ===========================================================================
+rc=0
+if [ "$fails" -eq 0 ]; then
+  echo "ALL PASS"
+else
+  echo "$fails FAILED"
+  rc=1
+fi
+echo "SUITE-EXIT=$rc"
+exit "$rc"

--- a/scripts/handover/test-merge-on-green.sh
+++ b/scripts/handover/test-merge-on-green.sh
@@ -8,6 +8,16 @@
 # --squash + --match-head-commit <certified-sha>.
 set -uo pipefail
 
+# HIMMEL-1495 — an --automerge-armed launching shell carries ARMAUTOMERGE=1 +
+# CR_MERGE_GATE_OK=1 by design; an ambient value in the operator's shell must
+# not decide the result (the 34e/34f precedent in test-check-ci.sh,
+# generalized). merge-on-green.sh gates on a truthy ARMAUTOMERGE
+# (merge-on-green.sh:153), so an ambient =1 would make the no-opt-in refusal
+# (case 1) read as opted-in. (Case 1's own inline `unset ARMAUTOMERGE` is
+# retained; this is the startup defense-in-depth + the CR_MERGE_GATE_OK scrub
+# for the day a sourced lib reads it.)
+unset ARMAUTOMERGE CR_MERGE_GATE_OK
+
 # grepq <text> [grep-args...] — a `grep -q` test against <text> with NO
 # pipeline. printf/echo-into-`grep -q` is a trap under this file's
 # `set -o pipefail`: grep -q exits the instant it matches, the producer
@@ -229,6 +239,18 @@ assert_state_requery() {
 
 echo "== merge-on-green.sh tests =="
 
+# HIMMEL-1495 hermeticity probe — when this suite re-execs itself under the
+# armed bypass env (see the guard at the end), short-circuit here. The startup
+# unset above must have already scrubbed the parent's exported ARMAUTOMERGE=1,
+# so the no-opt-in refusal STILL fires (exit 10). Exit 0 = scrub held; exit 1 =
+# ARMAUTOMERGE leaked and the wrapper read as opted-in (not exit 10). Relies on
+# the startup scrub (does NOT re-unset), so it guards THAT line. One run_mog.
+if [ "${HIMMEL_1495_SELF:-0}" = "1" ]; then
+    _probe_fail_before=$FAIL
+    STUB_NO_PR=1 run_mog 10 "armed-env scrubbed: no-opt-in still refuses"
+    [ "$FAIL" = "$_probe_fail_before" ] && exit 0 || exit 1
+fi
+
 # 1. No opt-in → refuse (exit 10). Unset in the PARENT shell (no subshell) so
 # pass()/fail() land in the top-level tally (coderabbit-1).
 unset ARMAUTOMERGE
@@ -437,6 +459,23 @@ if grepq "$help_out" 'set -uo pipefail'; then
     fail "--help leaks the 'set -uo pipefail' code line"
 else
     pass
+fi
+
+# HIMMEL-1495 hermeticity guard — prove the startup scrub holds. Re-run this
+# suite in a subprocess EXPORTING the exact armed bypass env an
+# --automerge-armed shell carries; the reinvoked copy's startup unset must
+# neutralize it, so its probe (no-opt-in still refuses) passes and it exits 0.
+# Remove the startup `unset ARMAUTOMERGE CR_MERGE_GATE_OK` and the reinvoked
+# copy instead reads ARMAUTOMERGE=1 as opted-in and exits non-zero.
+# Recursion-safe: the sentinel suppresses the guard in the reinvoked copy.
+if [ "${HIMMEL_1495_SELF:-0}" != "1" ]; then
+    _armed_log="$(mktemp)"
+    if CR_MERGE_GATE_OK=1 ARMAUTOMERGE=1 HIMMEL_1495_SELF=1 bash "$SCRIPT_DIR/test-merge-on-green.sh" >"$_armed_log" 2>&1; then
+        pass; echo "  hermetic-to-armed-env (self-reinvoke exits 0)"
+    else
+        fail "hermetic-to-armed-env (startup scrub missing?)"; sed 's/^/  armed: /' "$_armed_log" >&2
+    fi
+    rm -f "$_armed_log"
 fi
 
 echo

--- a/scripts/handover/test-worker-lifecycle.sh
+++ b/scripts/handover/test-worker-lifecycle.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# test-worker-lifecycle.sh -- HIMMEL-1463 regression suite for the pre-arm
+# live-worker guard, stale-running reconciliation, and shared-lock cleanup.
+#
+# PID liveness is fully stubbed. No assertion depends on a real process or on
+# the host's MSYS/native pid namespace.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARM="$SCRIPT_DIR/arm-resume.sh"
+RECONCILE="$SCRIPT_DIR/reconcile-workers.sh"
+LOCK="$SCRIPT_DIR/../lib/shared-branch-lock.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "PASS: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "FAIL: $1"; FAILED=$((FAILED + 1)); }
+assert_rc() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$actual" -eq "$expected" ]; then pass "$label"; else fail "$label (expected rc=$expected, got $actual)"; fi
+}
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    case "$haystack" in *"$needle"*) pass "$label" ;; *) fail "$label (missing: $needle)" ;; esac
+}
+assert_file_contains() {
+    local label="$1" needle="$2" file="$3"
+    if grep -qF "$needle" "$file" 2>/dev/null; then pass "$label"; else fail "$label ($file missing: $needle)"; fi
+}
+
+TMP="$(mktemp -d -t worker-lifecycle.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+export WORKER_BRIDGE_ROOT="$TMP/bridge"
+mkdir -p "$WORKER_BRIDGE_ROOT/glm-sessions" "$WORKER_BRIDGE_ROOT/claudex-sessions"
+
+PID_STUB="$TMP/pid-alive"
+cat > "$PID_STUB" <<'EOF'
+#!/usr/bin/env bash
+case ",${LIVE_PIDS:-}," in
+    *",$1,"*) exit 0 ;;
+esac
+case ",${UNPROBEABLE_PIDS:-}," in
+    *",$1,"*) exit 2 ;;
+    *) exit 1 ;;
+esac
+EOF
+chmod +x "$PID_STUB"
+export WORKER_PID_ALIVE_CMD="$PID_STUB"
+
+WORK_REPO="$TMP/work-repo"
+mkdir -p "$WORK_REPO"
+git init -q "$WORK_REPO"
+HANDOVER_DIR="$TMP/state/handovers"
+mkdir -p "$HANDOVER_DIR"
+git init -q "$TMP/state"
+HANDOVER="$HANDOVER_DIR/himmel-1463.md"
+cat > "$HANDOVER" <<EOF
+---
+resume_cwd: $WORK_REPO
+---
+# HIMMEL-1463 test handover
+EOF
+
+export HANDOVER_DIR
+export WORKSPACE_TRUST_CONFIG="$TMP/claude-trust.json"
+export HIMMEL_FLOW_RUNS_LEDGER="$TMP/flow-runs.jsonl"
+export SKILL_TELEMETRY_DIR="$TMP/telemetry"
+export ARM_BRIDGE_LIVE=0
+export ARM_MAX_SLOTS=0
+
+SCHED_STUB="$TMP/sched-stub"
+mkdir -p "$SCHED_STUB"
+for cmd in schtasks atq powershell; do
+    cat > "$SCHED_STUB/$cmd" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$SCHED_STUB/$cmd"
+done
+cat > "$SCHED_STUB/at" <<'EOF'
+#!/usr/bin/env bash
+cat >/dev/null
+exit 0
+EOF
+cat > "$SCHED_STUB/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$SCHED_STUB/at" "$SCHED_STUB/claude"
+
+NEAR_HHMM=$(node -e 'const d = new Date(Date.now() + 5 * 60 * 1000); process.stdout.write(String(d.getHours()).padStart(2, "0") + ":" + String(d.getMinutes()).padStart(2, "0"))')
+
+# T1: a running row with a stub-live pid blocks and is listed.
+LIVE_DIR="$WORKER_BRIDGE_ROOT/glm-sessions/glm-live"
+mkdir -p "$LIVE_DIR"
+cat > "$LIVE_DIR/meta.json" <<'EOF'
+{
+  "status": "running",
+  "pid": 111,
+  "started_at": "2026-08-03T00:00:00Z",
+  "lane": "glm",
+  "task_name": "live-guard"
+}
+EOF
+out=$(PATH="$SCHED_STUB:$PATH" LIVE_PIDS=111 bash "$ARM" --time "$NEAR_HHMM" --handover "$HANDOVER" 2>&1)
+rc=$?
+assert_rc "T1 live worker blocks arm" 10 "$rc"
+assert_contains "T1 refusal lists task" "task=live-guard pid=111" "$out"
+assert_contains "T1 refusal names override" "ARM_WITH_LIVE_WORKERS=1" "$out"
+assert_file_contains "T1 live metadata remains running" '"status": "running"' "$LIVE_DIR/meta.json"
+rm -rf "$LIVE_DIR"
+
+# T2: a dead running row is reconciled before the guard, then the arm proceeds.
+DEAD_DIR="$WORKER_BRIDGE_ROOT/claudex-sessions/claudex-dead"
+mkdir -p "$DEAD_DIR"
+cat > "$DEAD_DIR/meta.json" <<'EOF'
+{
+  "status": "running",
+  "pid": 222,
+  "started_at": "2026-08-03T00:00:00Z",
+  "lane": "codex",
+  "task_name": "dead-row",
+  "preserve_me": "yes"
+}
+EOF
+out=$(TMPDIR="$TMP" PATH="$SCHED_STUB:$PATH" LIVE_PIDS='' RECONCILE_GRACE_SECS=0 bash "$ARM" --time "$NEAR_HHMM" --handover "$HANDOVER" 2>&1)
+rc=$?
+assert_rc "T2 dead row is reconciled and arm proceeds" 0 "$rc"
+assert_contains "T2 reconciliation is reported" "reconcile-workers: orphaned codex/dead-row pid=222" "$out"
+assert_contains "T2 scheduler was still armed" "RESUME ARMED" "$out"
+assert_file_contains "T2 metadata marked orphaned" '"status": "orphaned"' "$DEAD_DIR/meta.json"
+assert_file_contains "T2 unrelated metadata preserved" '"preserve_me": "yes"' "$DEAD_DIR/meta.json"
+rm -rf "$DEAD_DIR"
+
+# T3: shared locks are released only when their own holder pid is dead.
+LOCK_REPO="$TMP/lock-repo"
+mkdir -p "$LOCK_REPO"
+git init -q "$LOCK_REPO"
+git -C "$LOCK_REPO" config user.email test@example.com
+git -C "$LOCK_REPO" config user.name "Test User"
+: > "$LOCK_REPO/README.md"
+git -C "$LOCK_REPO" add README.md
+git -C "$LOCK_REPO" commit -q -m init
+
+KEEP_DIR="$WORKER_BRIDGE_ROOT/glm-sessions/glm-keep-lock"
+DROP_DIR="$WORKER_BRIDGE_ROOT/claudex-sessions/claudex-drop-lock"
+mkdir -p "$KEEP_DIR" "$DROP_DIR"
+cat > "$KEEP_DIR/meta.json" <<EOF
+{"status":"running","pid":333,"lane":"glm","task_name":"keep-lock","shared_branch":"feat/keep-lock","repo_dir":"$LOCK_REPO"}
+EOF
+cat > "$DROP_DIR/meta.json" <<EOF
+{"status":"running","pid":555,"lane":"codex","task_name":"drop-lock","shared_branch":"feat/drop-lock","repo_dir":"$LOCK_REPO"}
+EOF
+SHARED_BRANCH_LOCK_HOLDER_PID=444 bash "$LOCK" acquire "$LOCK_REPO" "feat/keep-lock" glm >/dev/null 2>&1
+SHARED_BRANCH_LOCK_HOLDER_PID=666 bash "$LOCK" acquire "$LOCK_REPO" "feat/drop-lock" codex >/dev/null 2>&1
+KEEP_LOCK=$(git -C "$LOCK_REPO" rev-parse --path-format=absolute --git-common-dir)/himmel-shared-branch/feat-keep-lock.lock
+DROP_LOCK=$(git -C "$LOCK_REPO" rev-parse --path-format=absolute --git-common-dir)/himmel-shared-branch/feat-drop-lock.lock
+out=$(LIVE_PIDS=444 RECONCILE_GRACE_SECS=0 bash "$RECONCILE" 2>&1)
+rc=$?
+assert_rc "T3 reconciliation succeeds" 0 "$rc"
+if [ -d "$KEEP_LOCK" ]; then pass "T3 live holder lock retained"; else fail "T3 live holder lock was removed"; fi
+if [ ! -d "$DROP_LOCK" ]; then pass "T3 dead holder lock released"; else fail "T3 dead holder lock remains"; fi
+assert_contains "T3 dead-holder release reported" "released shared lock feat/drop-lock" "$out"
+assert_file_contains "T3 live-holder worker still orphaned" '"status": "orphaned"' "$KEEP_DIR/meta.json"
+assert_file_contains "T3 dead-holder worker orphaned" '"status": "orphaned"' "$DROP_DIR/meta.json"
+bash "$LOCK" release "$LOCK_REPO" "feat/keep-lock" >/dev/null 2>&1
+rm -rf "$KEEP_DIR" "$DROP_DIR"
+
+# T3b: a confirmed-dead worker with fresh metadata is still settling. Its row
+# and shared lock stay untouched until the terminal writer's grace expires.
+SETTLING_DIR="$WORKER_BRIDGE_ROOT/claudex-sessions/claudex-settling"
+mkdir -p "$SETTLING_DIR"
+cat > "$SETTLING_DIR/meta.json" <<EOF
+{"status":"running","pid":999,"lane":"codex","task_name":"fresh-row","shared_branch":"feat/settling","repo_dir":"$LOCK_REPO"}
+EOF
+SHARED_BRANCH_LOCK_HOLDER_PID=999 bash "$LOCK" acquire "$LOCK_REPO" "feat/settling" codex >/dev/null 2>&1
+SETTLING_LOCK=$(git -C "$LOCK_REPO" rev-parse --path-format=absolute --git-common-dir)/himmel-shared-branch/feat-settling.lock
+out=$(LIVE_PIDS='' bash "$RECONCILE" 2>&1)
+rc=$?
+assert_rc "T3b fresh dead-pid reconciliation succeeds safely" 0 "$rc"
+assert_contains "T3b settling row is reported" "settling codex/fresh-row pid=999" "$out"
+assert_file_contains "T3b settling metadata remains running" '"status":"running"' "$SETTLING_DIR/meta.json"
+if [ -d "$SETTLING_LOCK" ]; then pass "T3b settling lock retained"; else fail "T3b settling lock was removed"; fi
+out=$(LIVE_PIDS='' bash "$RECONCILE" --list-live 2>&1)
+assert_contains "T3b settling row remains guard-visible" "task=fresh-row pid=999 state=settling" "$out"
+bash "$LOCK" release "$LOCK_REPO" "feat/settling" >/dev/null 2>&1
+rm -rf "$SETTLING_DIR"
+
+# T4: a failed worker census leaves the row and lock untouched, warns, and
+# remains guard-visible as unprobeable/possibly alive.
+UNPROBEABLE_DIR="$WORKER_BRIDGE_ROOT/claudex-sessions/claudex-unprobeable"
+mkdir -p "$UNPROBEABLE_DIR"
+cat > "$UNPROBEABLE_DIR/meta.json" <<EOF
+{"status":"running","pid":888,"lane":"codex","task_name":"census-failed","shared_branch":"feat/unprobeable","repo_dir":"$LOCK_REPO"}
+EOF
+SHARED_BRANCH_LOCK_HOLDER_PID=888 bash "$LOCK" acquire "$LOCK_REPO" "feat/unprobeable" codex >/dev/null 2>&1
+UNPROBEABLE_LOCK=$(git -C "$LOCK_REPO" rev-parse --path-format=absolute --git-common-dir)/himmel-shared-branch/feat-unprobeable.lock
+out=$(TMPDIR="$TMP" PATH="$SCHED_STUB:$PATH" LIVE_PIDS='' UNPROBEABLE_PIDS=888 bash "$ARM" --time "$NEAR_HHMM" --handover "$HANDOVER" 2>&1)
+rc=$?
+assert_rc "T4 unprobeable worker blocks arm" 10 "$rc"
+assert_contains "T4 census failure warns" "WARN reconcile-workers: unprobeable codex/census-failed pid=888" "$out"
+assert_contains "T4 census summary marks unprobeable" "task=census-failed pid=888 state=unprobeable" "$out"
+assert_contains "T4 guard says possibly alive" "live or unprobeable (possibly alive)" "$out"
+assert_file_contains "T4 unprobeable metadata remains running" '"status":"running"' "$UNPROBEABLE_DIR/meta.json"
+if [ -d "$UNPROBEABLE_LOCK" ]; then pass "T4 unprobeable lock retained"; else fail "T4 unprobeable lock was removed"; fi
+bash "$LOCK" release "$LOCK_REPO" "feat/unprobeable" >/dev/null 2>&1
+rm -rf "$UNPROBEABLE_DIR"
+
+# T5: a live-meta write fallback with no pid is also unprobeable, never dead.
+MARKER_DIR="$WORKER_BRIDGE_ROOT/claudex-sessions/claudex-marker"
+mkdir -p "$MARKER_DIR"
+cat > "$MARKER_DIR/meta.json" <<'EOF'
+{"status":"running","pid_probe":"unprobeable","lane":"codex","task_name":"meta-write-failed"}
+EOF
+out=$(LIVE_PIDS='' UNPROBEABLE_PIDS='' bash "$RECONCILE" 2>&1)
+rc=$?
+assert_rc "T5 missing-pid reconciliation succeeds safely" 0 "$rc"
+assert_contains "T5 missing-pid row warns unprobeable" "unprobeable codex/meta-write-failed pid=absent" "$out"
+assert_file_contains "T5 missing-pid metadata remains running" '"status":"running"' "$MARKER_DIR/meta.json"
+out=$(LIVE_PIDS='' UNPROBEABLE_PIDS='' bash "$RECONCILE" --list-live 2>&1)
+assert_contains "T5 missing-pid row remains guard-visible" "task=meta-write-failed pid=absent state=unprobeable" "$out"
+rm -rf "$MARKER_DIR"
+
+# T6: the explicit bypass warns loudly, lists workers, and still arms.
+BYPASS_DIR="$WORKER_BRIDGE_ROOT/claudex-sessions/claudex-bypass"
+mkdir -p "$BYPASS_DIR"
+cat > "$BYPASS_DIR/meta.json" <<'EOF'
+{"status":"running","pid":777,"lane":"codex","task_name":"bypass-live"}
+EOF
+out=$(TMPDIR="$TMP" PATH="$SCHED_STUB:$PATH" LIVE_PIDS=777 ARM_WITH_LIVE_WORKERS=1 bash "$ARM" --time "$NEAR_HHMM" --handover "$HANDOVER" --force 2>&1)
+rc=$?
+assert_rc "T6 explicit bypass still arms" 0 "$rc"
+assert_contains "T6 bypass warning is loud" "WARN arm-resume: ARM_WITH_LIVE_WORKERS=1" "$out"
+assert_contains "T6 bypass warning lists worker" "task=bypass-live pid=777" "$out"
+assert_contains "T6 bypass reaches scheduler success" "RESUME ARMED" "$out"
+assert_file_contains "T6 live bypass metadata remains running" '"status":"running"' "$BYPASS_DIR/meta.json"
+
+echo "---"
+echo "PASSED=$PASSED FAILED=$FAILED"
+if [ "$FAILED" -eq 0 ]; then
+    echo "SUITE-EXIT=0"
+    exit 0
+fi
+echo "SUITE-EXIT=1"
+exit 1

--- a/scripts/hooks/test-auto-arm-on-cap.sh
+++ b/scripts/hooks/test-auto-arm-on-cap.sh
@@ -8,11 +8,13 @@ set -u -o pipefail
 HOOK="$(cd "$(dirname "$0")" && pwd)/auto-arm-on-cap.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
-# Hermetic lane env (HIMMEL-733): the hook now passes through on non-Claude
-# lane signals. Strip any such signal inherited from the RUNNING session
-# (e.g. a z.ai shell or a codex runtime) so baseline tests exercise the
-# Claude-lane paths; Test 1b re-sets them explicitly per case.
+# Hermetic lane/env knobs: operator overrides from the RUNNING session must not
+# change the shipped-default contract exercised below. Test 1b and individual
+# cases re-set the values they cover explicitly.
 unset ANTHROPIC_BASE_URL HERMES_ENGINE CODEX_ADAPTER CODEX_THREAD_ID
+unset AUTO_ARM_DISABLE AUTO_ARM_THRESHOLD AUTO_ARM_CACHE AUTO_ARM_STATE_DIR
+unset AUTO_ARM_CHECK_INTERVAL AUTO_ARM_MAX_CACHE_AGE AUTO_ARM_MAX_ARM_FAILURES
+unset AUTO_ARM_STALE_ESCALATE_AGE AUTO_ARM_STALE_MIN_CHECKS AUTO_ARM_BIN
 # Isolate the quota-gauge ledger so threshold-trip tests never pollute the
 # operator's real ~/.himmel/quota-gauge.jsonl (HIMMEL-687).
 export HIMMEL_QUOTA_GAUGE_LEDGER="$TMP/quota-gauge.jsonl"

--- a/scripts/hooks/test-block-unresolved-cr-merge.sh
+++ b/scripts/hooks/test-block-unresolved-cr-merge.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 # Tests for scripts/hooks/block-unresolved-cr-merge.sh (HIMMEL-936). Hermetic.
 set -uo pipefail
+
+# HIMMEL-1495 — an --automerge-armed launching shell carries ARMAUTOMERGE=1 +
+# CR_MERGE_GATE_OK=1 by design; an ambient value in the operator's shell must
+# not decide the result (the 34e/34f precedent in test-check-ci.sh,
+# generalized). This hook sources cr_merge_gate, which short-circuits to allow
+# on CR_MERGE_GATE_OK=1 (cr-merge-gate.sh:166), so without this scrub every CR
+# block-case below inherits the bypass and reads rc 0 (the CI-gate-only cases
+# still block — the CI gate is independent of CR_MERGE_GATE_OK, HIMMEL-1043).
+unset ARMAUTOMERGE CR_MERGE_GATE_OK
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOK="$SCRIPT_DIR/block-unresolved-cr-merge.sh"
 TMP="$(mktemp -d)"
@@ -81,6 +91,22 @@ t() { # t <name> <expected-rc> <tool> <command>
   else fail=$((fail+1)); echo "FAIL $name (rc=$rc want=$want)"; sed 's/^/  err: /' "$TMP/err-$name"; fi
 }
 
+# HIMMEL-1495 hermeticity probe — when this suite re-execs itself under the
+# armed bypass env (see the guard at the end), short-circuit here: the startup
+# unset has already scrubbed ARMAUTOMERGE/CR_MERGE_GATE_OK, so a CR block
+# fixture must STILL block. Exit 0 = scrub held (hook rc EXACTLY 2, the block
+# code); any other rc — 0 = the bypass leaked and the hook failed open, else =
+# a broken fixture/hook — exits 1 so an errored probe can never falsely
+# validate the guard. Keeps the reinvoked copy to ONE hook invocation.
+if [ "${HIMMEL_1495_SELF:-0}" = "1" ]; then
+    export GH_STUB_LOG="$TMP/armed-probe.log"; : > "$GH_STUB_LOG"
+    export GH_STUB_MODE=unresolved
+    probe_rc=0
+    payload Bash "gh pr merge 42 --squash" | bash "$HOOK" >/dev/null 2>&1 || probe_rc=$?
+    [ "$probe_rc" = "2" ] || exit 1
+    exit 0
+fi
+
 GH_STUB_MODE=unresolved t merge-with-unresolved-blocks   2 Bash "gh pr merge 42 --squash"
 GH_STUB_MODE=clean      t merge-clean-allows             0 Bash "gh pr merge 42 --squash"
 GH_STUB_MODE=error      t api-error-fails-open           0 Bash "gh pr merge 42 --squash"
@@ -138,6 +164,21 @@ grep -q "block-red-ci-merge" "$TMP/err-merge-over-red-ci-blocks" || { echo "FAIL
 # HIMMEL-1072: an absent review must say so — "no CodeRabbit status" is the
 # actionable half; a bare "blocked" would read as a false-block and get bypassed.
 grep -qi "has not reviewed" "$TMP/err-absent-review-blocks" || { echo "FAIL absent-review reason missing"; fail=$((fail+1)); }
+
+# HIMMEL-1495 hermeticity guard — prove the startup scrub holds. Re-run this
+# suite in a subprocess EXPORTING the exact armed bypass env an
+# --automerge-armed shell carries; the reinvoked copy's startup unset must
+# neutralize it, so its probe block-case still blocks and it exits 0. Remove
+# the startup `unset ARMAUTOMERGE CR_MERGE_GATE_OK` and the reinvoked copy's
+# CR block-case instead fails open (rc 0) and exits non-zero. Recursion-safe:
+# the sentinel suppresses the guard in the reinvoked copy.
+if [ "${HIMMEL_1495_SELF:-0}" != "1" ]; then
+    if CR_MERGE_GATE_OK=1 ARMAUTOMERGE=1 HIMMEL_1495_SELF=1 bash "$SCRIPT_DIR/test-block-unresolved-cr-merge.sh" >"$TMP/armed.log" 2>&1; then
+        pass=$((pass+1)); echo "ok   hermetic-to-armed-env (self-reinvoke exits 0)"
+    else
+        fail=$((fail+1)); echo "FAIL hermetic-to-armed-env (startup scrub missing?)"; sed 's/^/  armed: /' "$TMP/armed.log"
+    fi
+fi
 
 echo "pass=$pass fail=$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/hooks/test-quota-gauge-claude-writer.sh
+++ b/scripts/hooks/test-quota-gauge-claude-writer.sh
@@ -13,6 +13,13 @@
 # the real scheduler, the real cache, or the real ledger.
 set -u -o pipefail
 
+# Exercise the shipped watchdog defaults, not operator/lane overrides inherited
+# from the session running this suite.
+unset ANTHROPIC_BASE_URL HERMES_ENGINE CODEX_ADAPTER CODEX_THREAD_ID
+unset AUTO_ARM_DISABLE AUTO_ARM_THRESHOLD AUTO_ARM_CACHE AUTO_ARM_STATE_DIR
+unset AUTO_ARM_CHECK_INTERVAL AUTO_ARM_MAX_CACHE_AGE AUTO_ARM_MAX_ARM_FAILURES
+unset AUTO_ARM_STALE_ESCALATE_AGE AUTO_ARM_STALE_MIN_CHECKS AUTO_ARM_BIN
+
 HOOK="$(cd "$(dirname "$0")" && pwd)/auto-arm-on-cap.sh"
 # Repo root, so an out-of-tree baseline copy (T24) still resolves the hook's
 # sibling libs via the hook's $CLAUDE_PROJECT_DIR/scripts/lib fallback.

--- a/scripts/lib/proc-tree.sh
+++ b/scripts/lib/proc-tree.sh
@@ -26,16 +26,20 @@
 # USAGE (source it, then call):
 #   . scripts/lib/proc-tree.sh
 #   set -m; some_command & pid=$!; set +m
-#   proc_tree_terminate "$pid" [grace-seconds]
+#   proc_tree_terminate "$pid" [grace-seconds] [expected-identity]
 #   wait "$pid" 2>/dev/null    # caller reaps; this helper never does
 #
-# proc_tree_terminate returns 0 when the group is gone by the time it returns
-# and 1 when something survived every escalation (a caller that cares can say
-# so in its report; there is no further lever to pull).
+# proc_tree_terminate returns 0 when the group is gone by the time it returns,
+# 1 when something survived every verified escalation, and 2 when a supplied
+# expected identity is empty or cannot be confirmed before the next signal.
+# proc_tree_group_terminate is the leader-exited variant: it signals only
+# identity-verified observed member pids, never an unowned numeric group id.
 #
-# COVERAGE lives in scripts/ci/test-suite-concurrency.sh (cases 5 and 5b: a
-# wedged descendant is reaped, and a TERM-ignoring suite is still killed),
-# exercised through the one caller rather than duplicated here. A standalone
+# COVERAGE lives in scripts/ci/test-suite-concurrency.sh (cases 4b-4e, 5, and
+# 5b: empty/recycled identities refuse unsafe signals, leader-exit members are
+# revalidated, a wedged descendant is reaped, and a TERM-ignoring suite is still
+# killed). The process cases are exercised through
+# the one caller rather than duplicated here. A standalone
 # unit suite would have to spawn and reap its own processes a second time, and
 # the ticket this helper comes from is about shell suites taking too long.
 #
@@ -56,11 +60,64 @@ proc_tree_winpid() {
     cat "/proc/$1/winpid" 2>/dev/null
 }
 
+# proc_tree_process_identity <pid> -- print a stable start-time identity for a
+# live process. POSIX uses start time + command; Git Bash maps its pid to the
+# native Windows pid and reads the full-resolution Get-Process StartTime.
+proc_tree_process_identity() {
+    local pid="$1" value="" winpid="" pwsh_bin="" candidate
+    [ -n "$pid" ] || return 1
+
+    if proc_tree_is_windows; then
+        winpid=$(proc_tree_winpid "$pid")
+        case "$winpid" in ''|*[!0-9]*) return 1 ;; esac
+        for candidate in pwsh pwsh.exe powershell.exe powershell; do
+            if command -v "$candidate" >/dev/null 2>&1; then
+                pwsh_bin=$candidate
+                break
+            fi
+        done
+        [ -n "$pwsh_bin" ] || return 1
+        value=$("$pwsh_bin" -NoProfile -NonInteractive -Command "try { (Get-Process -Id $winpid -ErrorAction Stop).StartTime.ToUniversalTime().Ticks } catch { exit 1 }" 2>/dev/null) || value=""
+        [ -n "$value" ] || return 1
+        printf 'win:%s:%s\n' "$winpid" "$value"
+        return 0
+    fi
+
+    value=$(LC_ALL=C ps -p "$pid" -o lstart= -o command= 2>/dev/null) || value=""
+    [ -n "$value" ] || return 1
+    printf 'posix:%s\n' "$value"
+}
+
+# proc_tree_process_alive <pid> -- 0 when the numeric pid currently names a
+# live process. This is deliberately identity-free so callers can distinguish a
+# confirmed exit from a live process whose identity no longer matches.
+proc_tree_process_alive() {
+    local pid="$1"
+    [ -n "$pid" ] || return 1
+    if proc_tree_is_windows; then
+        [ -d "/proc/$pid" ]
+    else
+        kill -0 "$pid" 2>/dev/null
+    fi
+}
+
+# proc_tree_process_identity_matches <pid> <identity> -- 0 when the live
+# process still has the launch identity, 1 on confirmed mismatch/exit, and 2
+# when the identity probe is unavailable. Callers may wait through rc 2, but
+# must never signal unless they received rc 0.
+proc_tree_process_identity_matches() {
+    local pid="$1" expected="$2" actual=""
+    [ -n "$expected" ] || return 2
+    proc_tree_process_alive "$pid" || return 1
+    actual=$(proc_tree_process_identity "$pid") || return 2
+    [ "$actual" = "$expected" ]
+}
+
 # proc_tree_group_members <pgid> -- print the pids still in a process group,
-# one per line. Prints nothing when the group is empty OR when neither `ps`
-# form works -- callers treat "no members" as "cannot see any", which is why
-# proc_tree_terminate escalates unconditionally rather than only when it can
-# observe a survivor.
+# one per line. Prints nothing when the group is empty and returns nonzero when
+# the process table cannot be read. Existing liveness callers treat either as
+# "cannot see any"; snapshot callers inspect the status so an observation
+# failure can never become a falsely definitive empty survivor set.
 #
 # NOT `ps -g <pgid>`: POSIX defines -g as select-by-SESSION-leader, and procps
 # overloads it with effective-group-name, so it is the wrong axis on Linux and
@@ -81,7 +138,7 @@ proc_tree_winpid() {
 # reaps quickly enough that it has not been observed.
 _PROC_TREE_PS_MODE=""
 proc_tree_group_members() {
-    local pgid="$1"
+    local pgid="$1" table=""
     if [ -z "$_PROC_TREE_PS_MODE" ]; then
         # The probe asks only whether the FORM works: this shell is always in
         # the table, so an empty result means unsupported, not "no processes".
@@ -92,11 +149,12 @@ proc_tree_group_members() {
         fi
     fi
     if [ "$_PROC_TREE_PS_MODE" = "posix" ]; then
-        ps -e -o pid=,pgid=,stat= 2>/dev/null |
-            awk -v g="$pgid" '$2==g && $3 !~ /^Z/ { print $1 }'
+        table=$(ps -e -o pid=,pgid=,stat= 2>/dev/null) || return 1
+        printf '%s\n' "$table" | awk -v g="$pgid" '$2==g && $3 !~ /^Z/ { print $1 }'
         return 0
     fi
-    ps 2>/dev/null | awk -v g="$pgid" 'NR>1 && $3==g { print $1 }'
+    table=$(ps 2>/dev/null) || return 1
+    printf '%s\n' "$table" | awk -v g="$pgid" 'NR>1 && $3==g { print $1 }'
 }
 
 # proc_tree_group_alive <pgid> -- 0 when at least one process is still in the
@@ -108,24 +166,39 @@ proc_tree_group_alive() {
     [ -n "$(proc_tree_group_members "$1")" ]
 }
 
-# proc_tree_terminate <pid> [grace-seconds] -- TERM the group, wait out the
-# grace period, KILL the group, and only THEN check whether anything is left.
-# On Windows a survivor gets one more pass through `taskkill /F` on its
-# Windows pid, which does not go through the MSYS signal layer at all.
-#
-# The escalation is unconditional up to KILL: a group signal that silently
-# reached nothing looks identical to one that worked, so "did TERM succeed?"
-# is not a question worth asking. KILL cannot be blocked or handled, so
-# anything alive after it is a signal-delivery failure, not a stubborn
-# process -- which is precisely when the Windows path earns its keep.
+# proc_tree_terminate <pid> [grace-seconds] [expected-identity] -- TERM the
+# group, wait out the grace period, KILL the group, and only THEN check whether
+# anything is left. When expected-identity is supplied, the leader identity is
+# revalidated immediately before every group signal, and a failed group signal
+# never falls back to the bare pid. Windows fallback targets only survivors
+# whose current identity can be captured and immediately revalidated.
 proc_tree_terminate() {
-    local pid="$1" grace="${2:-3}" survivor w
+    local pid="$1" grace="${2:-3}" expected_identity="${3:-}" survivor survivor_identity w guarded=0 identity_unverified=0
+    local member member_identity i leader_identity_rc survivor_verified=0
+    local -a member_pids=() member_identities=()
     [ -n "$pid" ] || return 0
+    [ "$#" -ge 3 ] && guarded=1
 
-    # Negative pid = the whole group. The bare-pid fallback covers a shell
-    # without job control, where killing the wrapper still beats killing
-    # nothing.
-    kill -TERM -"$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null
+    if [ "$guarded" -eq 1 ]; then
+        proc_tree_process_identity_matches "$pid" "$expected_identity" || return 2
+        # The leader can honor TERM while a descendant ignores it. Snapshot every
+        # observable member identity before TERM so an exited/recycled leader does
+        # not strand survivors or authorize signals to newly-reused numeric pids.
+        for member in $(proc_tree_group_members "$pid"); do
+            member_identity=$(proc_tree_process_identity "$member") || member_identity=''
+            [ -n "$member_identity" ] || continue
+            member_pids[${#member_pids[@]}]="$member"
+            member_identities[${#member_identities[@]}]="$member_identity"
+        done
+        if ! kill -TERM -"$pid" 2>/dev/null; then
+            proc_tree_group_alive "$pid" || return 0
+            return 2
+        fi
+    else
+        # Without an ownership identity, preserve the legacy best-effort bare-pid
+        # fallback for callers that did not establish a dedicated process group.
+        kill -TERM -"$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null
+    fi
 
     # Sleep the grace out flat rather than polling it away. Reading the
     # process table costs seconds on a loaded Windows box -- the state this
@@ -134,7 +207,37 @@ proc_tree_terminate() {
     # nothing downstream needs to know precisely when it stopped needing it.
     sleep "$grace"
 
-    kill -KILL -"$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null
+    proc_tree_group_alive "$pid" || return 0
+    if [ "$guarded" -eq 1 ]; then
+        # The original leader may exit and its numeric pid may be recycled during
+        # the TERM grace. If it still matches, the group signal remains owned. If
+        # not, escalate only member pids whose pre-TERM identities still match.
+        leader_identity_rc=0
+        proc_tree_process_identity_matches "$pid" "$expected_identity" || leader_identity_rc=$?
+        if [ "$leader_identity_rc" -eq 0 ]; then
+            if ! kill -KILL -"$pid" 2>/dev/null; then
+                proc_tree_group_alive "$pid" || return 0
+                return 2
+            fi
+        else
+            i=0
+            while [ "$i" -lt "${#member_pids[@]}" ]; do
+                member=${member_pids[$i]}
+                member_identity=${member_identities[$i]}
+                if proc_tree_process_identity_matches "$member" "$member_identity"; then
+                    survivor_verified=1
+                    kill -KILL "$member" 2>/dev/null || true
+                fi
+                i=$((i + 1))
+            done
+            [ "$survivor_verified" -eq 1 ] || return 2
+            sleep 1
+            proc_tree_group_alive "$pid" || return 0
+            return 1
+        fi
+    else
+        kill -KILL -"$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null
+    fi
     sleep 1
 
     # ONE table read, after the only signal that cannot be ignored. Anything
@@ -143,6 +246,13 @@ proc_tree_terminate() {
 
     if proc_tree_is_windows; then
         for survivor in $(proc_tree_group_members "$pid"); do
+            if [ "$guarded" -eq 1 ]; then
+                survivor_identity=$(proc_tree_process_identity "$survivor") || survivor_identity=''
+                if [ -z "$survivor_identity" ] || ! proc_tree_process_identity_matches "$survivor" "$survivor_identity"; then
+                    identity_unverified=1
+                    continue
+                fi
+            fi
             w=$(proc_tree_winpid "$survivor")
             [ -n "$w" ] || continue
             # MSYS_NO_PATHCONV: without it MSYS rewrites the /PID and /F
@@ -153,5 +263,64 @@ proc_tree_terminate() {
         proc_tree_group_alive "$pid" || return 0
     fi
 
+    [ "$identity_unverified" -eq 0 ] || return 2
+    return 1
+}
+
+# proc_tree_group_terminate <pgid> [grace-seconds] -- clean descendants after
+# their leader exits. HIMMEL-1474 r4/r12: snapshot each observed member with
+# its identity, then revalidate that member immediately before every PID signal.
+# Never signal the unowned numeric group id or use a blind Windows tree-kill.
+proc_tree_group_terminate() {
+    local pid="$1" grace="${2:-3}" member member_identity i identity_unverified=0
+    local -a member_pids=() member_identities=()
+    [ -n "$pid" ] || return 0
+    proc_tree_group_alive "$pid" || return 0
+
+    for member in $(proc_tree_group_members "$pid"); do
+        member_identity=$(proc_tree_process_identity "$member") || member_identity=''
+        if [ -z "$member_identity" ]; then
+            identity_unverified=1
+            continue
+        fi
+        member_pids[${#member_pids[@]}]="$member"
+        member_identities[${#member_identities[@]}]="$member_identity"
+    done
+
+    i=0
+    while [ "$i" -lt "${#member_pids[@]}" ]; do
+        member=${member_pids[$i]}
+        member_identity=${member_identities[$i]}
+        if proc_tree_process_identity_matches "$member" "$member_identity"; then
+            kill -TERM "$member" 2>/dev/null || true
+        else
+            identity_unverified=1
+        fi
+        i=$((i + 1))
+    done
+    sleep "$grace"
+    if ! proc_tree_group_alive "$pid"; then
+        [ "$identity_unverified" -eq 0 ] || return 2
+        return 0
+    fi
+
+    i=0
+    while [ "$i" -lt "${#member_pids[@]}" ]; do
+        member=${member_pids[$i]}
+        member_identity=${member_identities[$i]}
+        if proc_tree_process_identity_matches "$member" "$member_identity"; then
+            kill -KILL "$member" 2>/dev/null || true
+        else
+            identity_unverified=1
+        fi
+        i=$((i + 1))
+    done
+    sleep 1
+    if ! proc_tree_group_alive "$pid"; then
+        [ "$identity_unverified" -eq 0 ] || return 2
+        return 0
+    fi
+
+    [ "$identity_unverified" -eq 0 ] || return 2
     return 1
 }

--- a/scripts/lib/render-lease.sh
+++ b/scripts/lib/render-lease.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+# scripts/lib/render-lease.sh -- the render lease registry (HIMMEL-1509).
+#
+# WHY: the static :00 launch-window rule is RETIRED. Renders and the orphan
+# sweep now coordinate DYNAMICALLY through this registry: every codex
+# adversarial render acquires a per-branch lease at launch, the sweep reads the
+# registry before it may kill anything, and the same lease doubles as the
+# same-branch launch claim (subsumes HIMMEL-1496's TOCTOU: two concurrent
+# kickoffs on one branch race no further than one atomic mkdir).
+#
+# LAYOUT (one directory per lease, under the registry root):
+#   <registry>/<branch-slug>/lease.record   KEY<TAB>VALUE lines (see below)
+#   <registry>/<branch-slug>/heartbeat      ISO-8601 UTC, rewritten ~60s by
+#                                           codex-render-client-lease.ps1
+#   <registry>/<branch-slug>/tokens         cxc broker tokens observed for the
+#                                           render's cwd (ps1-written, optional)
+#   <registry>/.registry.lock/              cross-writer mutex (mkdir = lock)
+#   <registry>/kill-ledger.jsonl            append-only sweep evidence ledger
+#                                           (written/consumed by
+#                                           sweep-codex-orphans.ps1)
+# lease.record keys: branch, worktree (native/mixed path form), acquired_by
+# (wrapper msys pid), started_at (ISO UTC), leader_pid (msys), leader_winpid
+# (native, Windows only), leader_identity (proc_tree_process_identity string),
+# status (launching|running), claim_nonce (this acquisition's identity - see
+# release below).
+#
+# THE LOCK: mkdir is the only acquisition primitive -- never scan-then-create.
+# Lease acquisition itself is one mkdir of the lease dir; the registry-level
+# .registry.lock only serializes claim/reclaim against the sweep's
+# read-before-kill pass. Lock owner is tagged with its pid SPACE
+# ("msys:<pid>" here, "win:<pid>" from PowerShell) because the two runtimes
+# cannot verify each other's pids. Stale-break disposition (HIMMEL-1509 r4):
+# a same-space owner probed ALIVE is NEVER broken -- not even by age (a slow
+# sweep or mid-claim launcher legitimately holds the lock; contenders wait
+# out their retries and refuse); a same-space owner probed DEAD is broken
+# immediately; only a cross-space or unverifiable owner falls back to the
+# AGE break (RENDER_LEASE_LOCK_STALE_SECS), and each break says which
+# disposition fired.
+#
+# FAIL-CLOSED POSTURE (every rc documented on its function):
+#   * only a CONFIRMED-dead holder is reclaimed; an unverifiable holder refuses;
+#   * an unusable registry refuses the launch instead of launching untracked;
+#   * release happens ONLY on a verified-clean exit (the launcher calls it from
+#     its cleanup-rc==0 path); every other exit leaves the lease as evidence
+#     for the sweep/orchestrator to adjudicate;
+#   * release removes ONLY this process's own acquisition (HIMMEL-1509 r9):
+#     claim stamps a claim_nonce into the record and remembers it in-process;
+#     release verifies the on-disk nonce still matches before rm - a former
+#     holder whose stale lease was reclaimed can never delete a successor's
+#     live lease (the lease-release sibling of the r7 lock-release rule).
+#
+# REQUIRES: scripts/lib/proc-tree.sh sourced first (identity primitives).
+# CONVENTIONS: bash 3.2-safe (no mapfile/associative arrays), ASCII only,
+# same as proc-tree.sh. No comment line may BEGIN with the linter's name.
+# COVERAGE: scripts/lib/test-render-lease.sh (unit) plus
+# scripts/cr/test-run-codex-adversarial.sh (launcher integration).
+
+render_lease_registry_dir() {
+    printf '%s\n' "${RENDER_LEASE_DIR:-$HOME/.claude/handover/bridge/render-leases}"
+}
+
+# render_lease_slug <branch> -- filesystem-safe INJECTIVE slug (HIMMEL-1509
+# r6, codex-2). [A-Za-z0-9._-] passes through; every other BYTE becomes
+# '+HH' (two uppercase hex; '/' -> +2F, '+' itself -> +2B). Because '+' can
+# only ever appear as the start of a fixed-width +HH escape, the map parses
+# uniquely left-to-right: distinct branches (e.g. feat/a+b vs feat/a/b) can
+# NEVER share a lease dir. Byte-wise under LC_ALL=C so multibyte input
+# encodes per byte and every escape stays exactly two hex digits.
+# Mirrored EXACTLY by Get-RenderLeaseSlug in sweep-codex-orphans.ps1.
+render_lease_slug() {
+    local branch="$1" out='' ch i len
+    local LC_ALL=C
+    len=${#branch}
+    i=0
+    while [ "$i" -lt "$len" ]; do
+        ch=${branch:$i:1}
+        case "$ch" in
+            [A-Za-z0-9._-]) out="$out$ch" ;;
+            *) out=$(printf '%s+%02X' "$out" "'$ch") ;;
+        esac
+        i=$((i + 1))
+    done
+    printf '%s\n' "$out"
+}
+
+# render_lease_dir_for <branch> -- print the lease dir, or fail (rc 1, no
+# output) for a branch whose slug would escape or alias the registry root.
+render_lease_dir_for() {
+    local slug
+    slug=$(render_lease_slug "$1")
+    case "$slug" in
+        ''|.|..) return 1 ;;
+    esac
+    printf '%s/%s\n' "$(render_lease_registry_dir)" "$slug"
+}
+
+_render_lease_mtime() {
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null
+}
+
+# _render_lease_secs <value> -- print the value when it is a positive integer,
+# else 600 (HIMMEL-1509 r7: env knobs must be validated BEFORE they reach
+# shell arithmetic; same fallback contract as the sweep's env resolvers).
+# Shared by every env read (RENDER_LEASE_TTL_SECS, RENDER_LEASE_LOCK_STALE_SECS).
+_render_lease_secs() {
+    case "$1" in
+        ''|*[!0-9]*) printf '600\n'; return 0 ;;
+    esac
+    if [ "$1" -gt 0 ] 2>/dev/null; then
+        printf '%s\n' "$1"
+    else
+        printf '600\n'
+    fi
+}
+
+# _render_lease_delay <value> -- print the value when it is a simple
+# non-negative decimal (0 and fractions are legitimate retry DELAYS, unlike
+# the seconds knobs), else the 0.5 default (HIMMEL-1509 r9, codex-3: the last
+# raw RENDER_LEASE_* numeric env read - garbage must never reach sleep).
+_render_lease_delay() {
+    case "$1" in
+        ''|*[!0-9.]*|.|.*|*.|*.*.*) printf '0.5\n' ;;
+        *) printf '%s\n' "$1" ;;
+    esac
+}
+
+# _render_lease_pid_alive <pid> -- rc 0 alive, 1 confirmed dead,
+# 2 unverifiable (helper missing). Never treats "cannot check" as dead.
+_render_lease_pid_alive() {
+    command -v proc_tree_process_alive >/dev/null 2>&1 || return 2
+    if proc_tree_process_alive "$1"; then return 0; fi
+    return 1
+}
+
+# render_lease_lock_acquire -- rc 0 acquired, 1 contended (held by a live or
+# unverifiable owner through every retry), 2 registry unusable.
+# Stale-break disposition (r4): verified-live same-space owner -> NEVER
+# broken (age included); confirmed-dead same-space owner -> broken
+# immediately; cross-space/unverifiable owner -> age break only.
+render_lease_lock_acquire() {
+    local registry lock attempt owner opid stale owner_live alive_rc mtime now stale_secs
+    registry=$(render_lease_registry_dir)
+    mkdir -p "$registry" 2>/dev/null || return 2
+    [ -d "$registry" ] || return 2
+    lock="$registry/.registry.lock"
+    # r7 codex-2: validate the env knob BEFORE it reaches arithmetic - garbage
+    # must fall back to the 600s default, never collapse or error the check.
+    stale_secs=$(_render_lease_secs "${RENDER_LEASE_LOCK_STALE_SECS:-}")
+    # Same validation contract for the retry-count knob (panel r7 codex-1):
+    # garbage must fall back to the default, never error out of the loop.
+    local max_attempts
+    case "${RENDER_LEASE_LOCK_ATTEMPTS:-}" in
+        ''|*[!0-9]*) max_attempts=10 ;;
+        0) max_attempts=10 ;;
+        *) max_attempts="$RENDER_LEASE_LOCK_ATTEMPTS" ;;
+    esac
+    # And for the retry delay (r9 codex-3): validated before it reaches sleep.
+    local delay_secs
+    delay_secs=$(_render_lease_delay "${RENDER_LEASE_LOCK_DELAY_SECS:-}")
+    attempt=0
+    while [ "$attempt" -lt "$max_attempts" ]; do
+        if mkdir "$lock" 2>/dev/null; then
+            printf 'msys:%s\n' "$$" > "$lock/owner.pid" 2>/dev/null || true
+            return 0
+        fi
+        stale=0
+        owner_live=0
+        owner=$(cat "$lock/owner.pid" 2>/dev/null)
+        case "$owner" in
+            msys:*)
+                opid=${owner#msys:}
+                case "$opid" in
+                    ''|*[!0-9]*) ;;
+                    *)
+                        alive_rc=0
+                        _render_lease_pid_alive "$opid" || alive_rc=$?
+                        case "$alive_rc" in
+                            0) owner_live=1 ;;
+                            1) stale=1 ;;
+                        esac
+                        ;;
+                esac
+                ;;
+        esac
+        if [ "$stale" -eq 1 ]; then
+            echo "render-lease: breaking registry lock held by confirmed-dead owner ($owner): $lock" >&2
+        elif [ "$owner_live" -eq 0 ]; then
+            # Cross-space or unverifiable owner: age is the only safe judge.
+            # A verified-live owner never reaches this branch.
+            mtime=$(_render_lease_mtime "$lock")
+            case "$mtime" in
+                ''|*[!0-9]*) ;;
+                *)
+                    now=$(date +%s)
+                    if [ $((now - mtime)) -gt "$stale_secs" ]; then
+                        stale=1
+                        echo "render-lease: age-breaking registry lock with cross-space/unverifiable owner ('$owner', older than ${stale_secs}s): $lock" >&2
+                    fi
+                    ;;
+            esac
+        fi
+        [ "$stale" -eq 1 ] && rm -rf "$lock" 2>/dev/null
+        attempt=$((attempt + 1))
+        sleep "$delay_secs"
+    done
+    return 1
+}
+
+# render_lease_lock_release -- remove the registry lock ONLY when its owner
+# record names this process (HIMMEL-1509 r7, codex-1): a former holder whose
+# lock was broken must never delete a successor's newly acquired lock. A
+# mismatched or unreadable owner leaves the lock in place (the dead-owner /
+# age breaks self-heal it) and says so loudly.
+render_lease_lock_release() {
+    local lock owner
+    lock="$(render_lease_registry_dir)/.registry.lock"
+    [ -e "$lock" ] || return 0
+    owner=$(tr -d '[:space:]' < "$lock/owner.pid" 2>/dev/null)
+    if [ "$owner" = "msys:$$" ]; then
+        rm -rf "$lock" 2>/dev/null || true
+        return 0
+    fi
+    echo "render-lease: NOT releasing registry lock: owner record '${owner:-<unreadable>}' is not this process (msys:$$) - it was re-acquired after a break; leaving it to its owner: $lock" >&2
+    return 0
+}
+
+# render_lease_field <lease_dir> <key> -- print the recorded value (empty when
+# absent/unreadable). Everything after the FIRST tab is the value (r7 glm-3:
+# exact parity with the PS twin's Substring-after-first-tab parse, so a
+# tab-bearing value can never diverge between the twins).
+render_lease_field() {
+    awk -F'\t' -v k="$2" '$1==k { sub(/^[^\t]*\t/, ""); print; exit }' "$1/lease.record" 2>/dev/null
+}
+
+# _render_lease_write_record <dir> <branch> <worktree> <leader_pid>
+#   <leader_winpid> <leader_identity> <status> [claim_nonce] -- atomic tmp+mv
+# rewrite. started_at and claim_nonce are preserved from an existing record
+# when not supplied, so bind keeps both the launch time and the acquisition
+# identity (r9).
+_render_lease_write_record() {
+    local dir="$1" branch="$2" worktree="$3" leader_pid="$4" leader_winpid="$5" leader_identity="$6" status="$7" claim_nonce="${8:-}"
+    local tmpf="$dir/lease.record.tmp.$$" started_at
+    started_at=$(render_lease_field "$dir" started_at)
+    [ -n "$started_at" ] || started_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+    [ -n "$claim_nonce" ] || claim_nonce=$(render_lease_field "$dir" claim_nonce)
+    {
+        printf 'branch\t%s\n' "$branch" &&
+        printf 'worktree\t%s\n' "$worktree" &&
+        printf 'acquired_by\t%s\n' "$$" &&
+        printf 'started_at\t%s\n' "$started_at" &&
+        printf 'leader_pid\t%s\n' "$leader_pid" &&
+        printf 'leader_winpid\t%s\n' "$leader_winpid" &&
+        printf 'leader_identity\t%s\n' "$leader_identity" &&
+        printf 'status\t%s\n' "$status" &&
+        printf 'claim_nonce\t%s\n' "$claim_nonce"
+    } > "$tmpf" 2>/dev/null || { rm -f "$tmpf"; return 1; }
+    mv -f "$tmpf" "$dir/lease.record" 2>/dev/null || { rm -f "$tmpf"; return 1; }
+    return 0
+}
+
+# render_lease_heartbeat_fresh <lease_dir> <ttl_secs> -- rc 0 when the lease
+# still shows recent life. Uses the heartbeat file's mtime, falling back to
+# lease.record's own mtime (a POSIX render never starts the ps1 heartbeat; its
+# freshly-written record must still read as live). An unreadable mtime reads
+# as FRESH: the caller is deciding whether it may steal the lease, and a lost
+# probe must never become a reason to reclaim more eagerly.
+render_lease_heartbeat_fresh() {
+    local anchor="$1/heartbeat" ttl="$2" mtime now
+    [ -e "$anchor" ] || anchor="$1/lease.record"
+    [ -e "$anchor" ] || return 1
+    mtime=$(_render_lease_mtime "$anchor")
+    case "$mtime" in ''|*[!0-9]*) return 0 ;; esac
+    now=$(date +%s)
+    [ $((now - mtime)) -le "$ttl" ]
+}
+
+# _render_lease_holder_state <lease_dir> -- rc 0 live, 1 stale (confirmed dead,
+# reclaimable), 2 unverifiable (fail-closed: treat as held).
+_render_lease_holder_state() {
+    local lease_dir="$1" leader_pid leader_identity acquired_by rc
+    [ -r "$lease_dir/lease.record" ] || return 2
+    if render_lease_heartbeat_fresh "$lease_dir" "$(_render_lease_secs "${RENDER_LEASE_TTL_SECS:-}")"; then
+        return 0
+    fi
+    leader_pid=$(render_lease_field "$lease_dir" leader_pid)
+    leader_identity=$(render_lease_field "$lease_dir" leader_identity)
+    if [ -n "$leader_pid" ] && [ -n "$leader_identity" ]; then
+        rc=0
+        proc_tree_process_identity_matches "$leader_pid" "$leader_identity" || rc=$?
+        case "$rc" in
+            0) return 0 ;;
+            1) return 1 ;;
+            *) return 2 ;;
+        esac
+    fi
+    # Launching-status record: the wrapper pid is the only anchor.
+    acquired_by=$(render_lease_field "$lease_dir" acquired_by)
+    case "$acquired_by" in
+        ''|*[!0-9]*) return 2 ;;
+    esac
+    rc=0
+    _render_lease_pid_alive "$acquired_by" || rc=$?
+    case "$rc" in
+        0) return 0 ;;
+        1) return 1 ;;
+        *) return 2 ;;
+    esac
+}
+
+# render_lease_claim <branch> <worktree> -- atomically acquire the per-branch
+# launch claim. rc 0 acquired; 1 refused (live/unverifiable holder, or lock
+# contention); 2 registry unusable. Only a CONFIRMED-dead holder is reclaimed
+# (loudly, on stderr); everything doubtful refuses.
+render_lease_claim() {
+    local branch="$1" worktree="$2" lease_dir state_rc lock_rc claim_nonce
+    lease_dir=$(render_lease_dir_for "$branch") || return 2
+    lock_rc=0
+    render_lease_lock_acquire || lock_rc=$?
+    if [ "$lock_rc" -ne 0 ]; then
+        [ "$lock_rc" -eq 2 ] && return 2
+        return 1
+    fi
+    if [ -e "$lease_dir" ]; then
+        state_rc=0
+        _render_lease_holder_state "$lease_dir" || state_rc=$?
+        if [ "$state_rc" -ne 1 ]; then
+            render_lease_lock_release
+            return 1
+        fi
+        echo "render-lease: reclaiming stale lease for branch '$branch' (holder confirmed dead): $lease_dir" >&2
+        rm -rf "$lease_dir" 2>/dev/null
+    fi
+    if ! mkdir "$lease_dir" 2>/dev/null; then
+        render_lease_lock_release
+        return 2
+    fi
+    # r9 codex-1: this acquisition's identity. Remembered in-process so
+    # release can verify the on-disk lease is STILL our claim (not identity
+    # material - just a collision-resistant marker for one acquisition).
+    claim_nonce="$$-$(date +%s)-$RANDOM"
+    if ! _render_lease_write_record "$lease_dir" "$branch" "$worktree" "" "" "" launching "$claim_nonce"; then
+        rm -rf "$lease_dir" 2>/dev/null
+        render_lease_lock_release
+        return 2
+    fi
+    _RENDER_LEASE_CLAIM_NONCE=$claim_nonce
+    render_lease_lock_release
+    return 0
+}
+
+# render_lease_bind <branch> <leader_pid> <leader_winpid> <leader_identity> --
+# record the identity-verified leader on an already-held lease (no registry
+# lock: the lease dir is single-writer by acquisition). rc 0 bound, 1 failed.
+render_lease_bind() {
+    local branch="$1" lease_dir worktree
+    lease_dir=$(render_lease_dir_for "$branch") || return 1
+    [ -d "$lease_dir" ] || return 1
+    worktree=$(render_lease_field "$lease_dir" worktree)
+    _render_lease_write_record "$lease_dir" "$branch" "$worktree" "$2" "$3" "$4" running
+}
+
+# render_lease_release <branch> -- drop the lease, ONLY when it is still this
+# process's own acquisition (HIMMEL-1509 r9, codex-1): the on-disk claim_nonce
+# must match the nonce remembered by OUR claim. A former holder whose stale
+# lease was reclaimed by a successor must never delete the successor's live
+# lease - mismatch (or no in-process claim, or an unreadable record) leaves
+# the lease loudly. Callers still invoke this ONLY on a verified-clean exit.
+render_lease_release() {
+    local lease_dir disk_nonce disk_owner
+    lease_dir=$(render_lease_dir_for "$1") || return 0
+    [ -e "$lease_dir" ] || return 0
+    disk_nonce=$(render_lease_field "$lease_dir" claim_nonce)
+    if [ -n "${_RENDER_LEASE_CLAIM_NONCE:-}" ] && [ "$disk_nonce" = "$_RENDER_LEASE_CLAIM_NONCE" ]; then
+        rm -rf "$lease_dir" 2>/dev/null || true
+        return 0
+    fi
+    disk_owner=$(render_lease_field "$lease_dir" acquired_by)
+    echo "render-lease: NOT releasing lease for branch '$1': on-disk claim is not this process's acquisition (reclaimed by acquired_by=${disk_owner:-<unreadable>}); leaving it to its owner: $lease_dir" >&2
+    return 0
+}
+
+# render_lease_probe <branch> -- read-only pre-flight for launch sites.
+# rc 0 = no live claim (absent, or holder confirmed dead so a fresh claim
+# would reclaim); rc 1 = held (live or unverifiable). Never mutates.
+render_lease_probe() {
+    local lease_dir state_rc
+    lease_dir=$(render_lease_dir_for "$1") || return 0
+    [ -e "$lease_dir" ] || return 0
+    state_rc=0
+    _render_lease_holder_state "$lease_dir" || state_rc=$?
+    [ "$state_rc" -eq 1 ] || return 1
+    return 0
+}

--- a/scripts/lib/shared-branch-lock.sh
+++ b/scripts/lib/shared-branch-lock.sh
@@ -48,14 +48,12 @@
 # "free" would not be.
 #
 # NO AUTO-STEAL, NO PID-LIVENESS PROBING: this file deliberately does not
-# try to detect a crashed holder (no `kill -0`). Windows-native PIDs under
-# MSYS bash do not map cleanly onto the POSIX pid space `kill -0` expects,
-# so a liveness probe would be unreliable in exactly the environment this
-# repo runs on -- a false "the holder is dead, steal the lock" is a
-# single-writer violation, which is worse than a false "still held". Stale
-# locks (crashed dispatcher, killed session) are cleared by a human or a
-# supervising process running `release` explicitly. `acquire`'s rc-11
-# message says so.
+# try to detect a crashed holder itself. Windows-native PIDs under MSYS bash
+# do not map cleanly onto the POSIX pid space `kill -0` expects, so that check
+# belongs to the cross-namespace reconciler (reconcile-workers.sh). Acquire
+# records SHARED_BRANCH_LOCK_HOLDER_PID when its dispatcher supplies one;
+# otherwise it preserves the historical diagnostic fallback of this shell's
+# pid. Stale locks are cleared by the reconciler or an explicit release.
 #
 # CONVENTIONS: bash 3.2-safe (no associative arrays, no ${var,,}, no
 # mapfile). `set -uo pipefail`, not -e -- callers care about specific exit
@@ -146,11 +144,15 @@ shared_branch_lock_acquire() {
     # (rc 2, C2), and the operator needs the real message for the latter.
     if _sbl_a_mkerr="$(mkdir "$_sbl_a_lockdir" 2>&1)"; then
         _sbl_a_now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        _sbl_a_holder_pid="${SHARED_BRANCH_LOCK_HOLDER_PID:-$$}"
+        case "$_sbl_a_holder_pid" in
+            ''|*[!0-9]*|0) _sbl_a_holder_pid="$$" ;;
+        esac
         # owner.json is DIAGNOSTIC -- the lock is held by the dir itself. A
         # write failure here does not un-hold the lock, so warn and keep rc 0
         # (I4) rather than failing an acquire that actually succeeded.
         if ! printf '{"pid":%s,"lane":"%s","branch":"%s","acquired_at":"%s"}\n' \
-            "$$" \
+            "$_sbl_a_holder_pid" \
             "$(_sbl_json_escape "$_sbl_a_lane")" \
             "$(_sbl_json_escape "$_sbl_a_branch")" \
             "$_sbl_a_now" \

--- a/scripts/lib/test-cr-merge-gate.sh
+++ b/scripts/lib/test-cr-merge-gate.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Tests for scripts/lib/cr-merge-gate.sh (HIMMEL-936). Hermetic: gh is stubbed.
 set -uo pipefail
+
+# HIMMEL-1495 — an --automerge-armed launching shell carries ARMAUTOMERGE=1 +
+# CR_MERGE_GATE_OK=1 by design; an ambient value in the operator's shell must
+# not decide the result (the 34e/34f precedent in test-check-ci.sh,
+# generalized). cr_merge_gate short-circuits to allow on CR_MERGE_GATE_OK=1
+# (cr-merge-gate.sh:166) before any gh call, so without this scrub every
+# block-case below inherits the bypass and reads rc 0.
+unset ARMAUTOMERGE CR_MERGE_GATE_OK
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -118,6 +127,22 @@ git -C "$TMP/repo" init --quiet >/dev/null 2>&1
 git -C "$TMP/repo" remote add origin https://github.com/o/r.git
 git -C "$TMP/repo" config --local himmel.coderabbit true
 cd "$TMP/repo" || { echo "FATAL: cannot cd to the test repo"; exit 1; }
+
+# HIMMEL-1495 hermeticity probe — when this suite re-execs itself under the
+# armed bypass env (see the guard at the end), short-circuit here: the startup
+# unset has already scrubbed ARMAUTOMERGE/CR_MERGE_GATE_OK, so a block fixture
+# must STILL block. Exit 0 = scrub held (rc EXACTLY 2, the block code); any
+# other rc — 0 = the bypass leaked and cr_merge_gate failed open, else = a
+# broken fixture/gate — exits 1 so an errored probe can never falsely validate
+# the guard. Keeps the reinvoked copy to ONE gate call.
+if [ "${HIMMEL_1495_SELF:-0}" = "1" ]; then
+    export GH_STUB_LOG="$TMP/armed-probe.log"; : > "$GH_STUB_LOG"
+    export GH_STUB_MODE=unresolved
+    probe_rc=0
+    cr_merge_gate 42 o/r >/dev/null 2>&1 || probe_rc=$?
+    [ "$probe_rc" = "2" ] || exit 1
+    exit 0
+fi
 
 t() { # t <name> <expected-rc> — runs cr_merge_gate 42 o/r with current env
   local name="$1" want="$2" rc=0
@@ -353,6 +378,21 @@ grep -qi "unresolved" "$TMP/out-unresolved-cr-thread-blocks" || { echo "FAIL blo
 # degradation notes land on stderr on both fail-open shapes
 grep -qi "degraded" "$TMP/err-gh-error-selector-unresolvable" || { echo "FAIL degradation note missing (rc3)"; fail=$((fail+1)); }
 grep -qi "degraded" "$TMP/err-downstream-api-error-fails-open" || { echo "FAIL degradation note missing (rc0)"; fail=$((fail+1)); }
+
+# HIMMEL-1495 hermeticity guard — prove the startup scrub holds. Re-run this
+# whole suite in a subprocess EXPORTING the exact armed bypass env an
+# --automerge-armed shell carries; the reinvoked copy's own startup unset must
+# neutralize it, so its block-cases still block and it exits 0. Remove the
+# startup `unset ARMAUTOMERGE CR_MERGE_GATE_OK` and this reinvocation instead
+# fails its block-cases (rc 0) and exits non-zero. Recursion-safe: the sentinel
+# suppresses the guard in the reinvoked copy.
+if [ "${HIMMEL_1495_SELF:-0}" != "1" ]; then
+    if CR_MERGE_GATE_OK=1 ARMAUTOMERGE=1 HIMMEL_1495_SELF=1 bash "$SCRIPT_DIR/test-cr-merge-gate.sh" >"$TMP/armed.log" 2>&1; then
+        pass=$((pass+1)); echo "ok   hermetic-to-armed-env (self-reinvoke exits 0)"
+    else
+        fail=$((fail+1)); echo "FAIL hermetic-to-armed-env (startup scrub missing?)"; sed 's/^/  armed: /' "$TMP/armed.log"
+    fi
+fi
 
 echo "pass=$pass fail=$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/lib/test-render-lease.sh
+++ b/scripts/lib/test-render-lease.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/lib/render-lease.sh (HIMMEL-1509). Hermetic: the
+# registry lives in a mktemp dir and the proc-tree identity primitives are
+# stubbed, so no real process is probed or signaled and no shared state is
+# touched. Launcher integration is covered by
+# scripts/cr/test-run-codex-adversarial.sh.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/himmel-render-lease.XXXXXX")"
+fails=0
+
+cleanup() { rm -rf "$tmp"; }
+trap cleanup EXIT
+
+check() {
+    if [ "$2" = "$3" ]; then
+        echo "ok - $1"
+    else
+        echo "FAIL - $1: got [$2] want [$3]"
+        fails=$((fails + 1))
+    fi
+}
+
+# Stub proc-tree primitives BEFORE sourcing the lib (it requires them sourced
+# first). Liveness: the current shell and one magic pid are alive, everything
+# else is confirmed dead. Identity: driven by STUB_IDENTITY_RC.
+STUB_IDENTITY_RC=1
+proc_tree_process_alive() {
+    [ "$1" = "$$" ] && return 0
+    [ "$1" = "424242" ] && return 0
+    return 1
+}
+proc_tree_process_identity_matches() {
+    return "$STUB_IDENTITY_RC"
+}
+
+# shellcheck source=render-lease.sh
+# shellcheck disable=SC1091
+. "$HERE/render-lease.sh"
+
+export RENDER_LEASE_LOCK_ATTEMPTS=2
+export RENDER_LEASE_LOCK_DELAY_SECS=0
+
+# --- slug + dir mapping (r6: INJECTIVE +HH byte encoding) ---------------------
+check "slash branch slugs to +2F" "$(render_lease_slug 'feat/himmel-1509-x')" "feat+2Fhimmel-1509-x"
+check "hostile chars hex-encode per byte" "$(render_lease_slug 'a b!c')" "a+20b+21c"
+check "literal plus escapes the escape" "$(render_lease_slug 'feat/a+b')" "feat+2Fa+2Bb"
+check "aliasing branches stay distinct" "$(render_lease_slug 'feat/a/b')" "feat+2Fa+2Fb"
+check "slug map is deterministic" "$(render_lease_slug 'feat/a+b')" "$(render_lease_slug 'feat/a+b')"
+rc=0; render_lease_dir_for '' >/dev/null 2>&1 || rc=$?
+check "empty branch has no lease dir" "$rc" "1"
+rc=0; render_lease_dir_for '.' >/dev/null 2>&1 || rc=$?
+check "dot branch has no lease dir" "$rc" "1"
+
+# --- claim / probe / bind / release lifecycle ---------------------------------
+export RENDER_LEASE_DIR="$tmp/reg-lifecycle"
+rc=0; render_lease_claim 'feat/leg' "$tmp/wt" 2>/dev/null || rc=$?
+check "fresh claim acquires" "$rc" "0"
+lease_dir="$RENDER_LEASE_DIR/feat+2Fleg"
+check "claim writes branch field" "$(render_lease_field "$lease_dir" branch)" "feat/leg"
+check "claim writes worktree field" "$(render_lease_field "$lease_dir" worktree)" "$tmp/wt"
+check "claim records launching status" "$(render_lease_field "$lease_dir" status)" "launching"
+check "claim releases the registry lock" "$(test -e "$RENDER_LEASE_DIR/.registry.lock" && echo held || echo released)" "released"
+
+rc=0; render_lease_probe 'feat/leg' || rc=$?
+check "probe sees the fresh lease as held" "$rc" "1"
+rc=0; render_lease_claim 'feat/leg' "$tmp/wt" 2>/dev/null || rc=$?
+check "second claim on a fresh lease refuses" "$rc" "1"
+check "refused claim leaves the record intact" "$(render_lease_field "$lease_dir" status)" "launching"
+
+started_before=$(render_lease_field "$lease_dir" started_at)
+rc=0; render_lease_bind 'feat/leg' 4242 5252 'win:5252:637000000000000000' || rc=$?
+check "bind succeeds on a held lease" "$rc" "0"
+check "bind records running status" "$(render_lease_field "$lease_dir" status)" "running"
+check "bind records leader pid" "$(render_lease_field "$lease_dir" leader_pid)" "4242"
+check "bind records leader winpid" "$(render_lease_field "$lease_dir" leader_winpid)" "5252"
+check "bind records leader identity" "$(render_lease_field "$lease_dir" leader_identity)" "win:5252:637000000000000000"
+check "bind preserves started_at" "$(render_lease_field "$lease_dir" started_at)" "$started_before"
+
+render_lease_release 'feat/leg'
+check "release removes the lease dir" "$(test -e "$lease_dir" && echo present || echo gone)" "gone"
+rc=0; render_lease_probe 'feat/leg' || rc=$?
+check "probe after release reports free" "$rc" "0"
+rc=0; render_lease_bind 'feat/leg' 1 2 x 2>/dev/null || rc=$?
+check "bind without a held lease fails" "$rc" "1"
+
+# --- staleness adjudication (fail-closed: only CONFIRMED dead is reclaimed) ---
+make_stale_lease() {
+    # <registry> <slug> <leader_pid> <leader_identity>
+    local dir="$1/$2"
+    mkdir -p "$dir"
+    printf 'branch\tfeat/stale\nworktree\t%s\nacquired_by\t999999\nstarted_at\t2020-01-01T00:00:00Z\nleader_pid\t%s\nleader_winpid\t\nleader_identity\t%s\nstatus\trunning\n' \
+        "$tmp/wt" "$3" "$4" > "$dir/lease.record"
+    touch -t 202001010000 "$dir/lease.record"
+}
+
+export RENDER_LEASE_DIR="$tmp/reg-stale-dead"
+make_stale_lease "$RENDER_LEASE_DIR" feat+2Fstale 999999 'win:999999:1'
+STUB_IDENTITY_RC=1
+rc=0; render_lease_probe 'feat/stale' || rc=$?
+check "probe reports a confirmed-dead stale lease free" "$rc" "0"
+rc=0; render_lease_claim 'feat/stale' "$tmp/wt" 2>"$tmp/reclaim.stderr" || rc=$?
+check "claim reclaims a confirmed-dead stale lease" "$rc" "0"
+check "reclaim announces itself" "$(grep -Fc 'reclaiming stale lease' "$tmp/reclaim.stderr" 2>/dev/null)" "1"
+check "reclaimed lease has a fresh record" "$(render_lease_field "$RENDER_LEASE_DIR/feat+2Fstale" status)" "launching"
+
+export RENDER_LEASE_DIR="$tmp/reg-stale-unverifiable"
+make_stale_lease "$RENDER_LEASE_DIR" feat+2Fstale 999999 'win:999999:1'
+STUB_IDENTITY_RC=2
+rc=0; render_lease_probe 'feat/stale' || rc=$?
+check "probe treats an unverifiable holder as held" "$rc" "1"
+rc=0; render_lease_claim 'feat/stale' "$tmp/wt" 2>/dev/null || rc=$?
+check "claim refuses an unverifiable holder" "$rc" "1"
+check "unverifiable lease record is preserved" "$(render_lease_field "$RENDER_LEASE_DIR/feat+2Fstale" status)" "running"
+
+export RENDER_LEASE_DIR="$tmp/reg-stale-live"
+make_stale_lease "$RENDER_LEASE_DIR" feat+2Fstale 999999 'win:999999:1'
+STUB_IDENTITY_RC=0
+rc=0; render_lease_claim 'feat/stale' "$tmp/wt" 2>/dev/null || rc=$?
+check "claim refuses a live-leader stale-heartbeat lease" "$rc" "1"
+STUB_IDENTITY_RC=1
+
+# Launching-phase record: no leader anchor yet, wrapper pid is the authority.
+export RENDER_LEASE_DIR="$tmp/reg-launching"
+mkdir -p "$RENDER_LEASE_DIR/feat+2Fyoung"
+printf 'branch\tfeat/young\nworktree\t%s\nacquired_by\t999999\nstarted_at\t2020-01-01T00:00:00Z\nleader_pid\t\nleader_winpid\t\nleader_identity\t\nstatus\tlaunching\n' \
+    "$tmp/wt" > "$RENDER_LEASE_DIR/feat+2Fyoung/lease.record"
+touch -t 202001010000 "$RENDER_LEASE_DIR/feat+2Fyoung/lease.record"
+rc=0; render_lease_probe 'feat/young' || rc=$?
+check "stale launching record with dead wrapper is free" "$rc" "0"
+mkdir -p "$RENDER_LEASE_DIR/feat+2Falive"
+printf 'branch\tfeat/alive\nworktree\t%s\nacquired_by\t424242\nstarted_at\t2020-01-01T00:00:00Z\nleader_pid\t\nleader_winpid\t\nleader_identity\t\nstatus\tlaunching\n' \
+    "$tmp/wt" > "$RENDER_LEASE_DIR/feat+2Falive/lease.record"
+touch -t 202001010000 "$RENDER_LEASE_DIR/feat+2Falive/lease.record"
+rc=0; render_lease_probe 'feat/alive' || rc=$?
+check "stale launching record with live wrapper stays held" "$rc" "1"
+
+# --- heartbeat freshness ------------------------------------------------------
+mkdir -p "$tmp/hb-lease"
+printf 'x' > "$tmp/hb-lease/heartbeat"
+rc=0; render_lease_heartbeat_fresh "$tmp/hb-lease" 600 || rc=$?
+check "just-written heartbeat is fresh" "$rc" "0"
+touch -t 202001010000 "$tmp/hb-lease/heartbeat"
+rc=0; render_lease_heartbeat_fresh "$tmp/hb-lease" 600 || rc=$?
+check "2020 heartbeat is stale" "$rc" "1"
+
+# --- registry failure + lock behavior (fail-closed) ---------------------------
+printf 'not a dir' > "$tmp/blocker"
+export RENDER_LEASE_DIR="$tmp/blocker/reg"
+rc=0; render_lease_claim 'feat/x' "$tmp/wt" 2>/dev/null || rc=$?
+check "unusable registry refuses with rc 2" "$rc" "2"
+
+export RENDER_LEASE_DIR="$tmp/reg-lock-held"
+mkdir -p "$RENDER_LEASE_DIR/.registry.lock"
+printf 'msys:%s\n' "$$" > "$RENDER_LEASE_DIR/.registry.lock/owner.pid"
+rc=0; render_lease_claim 'feat/x' "$tmp/wt" 2>/dev/null || rc=$?
+check "live-owner lock contention refuses with rc 1" "$rc" "1"
+check "contended lock is preserved" "$(test -d "$RENDER_LEASE_DIR/.registry.lock" && echo held || echo broken)" "held"
+
+export RENDER_LEASE_DIR="$tmp/reg-lock-dead"
+mkdir -p "$RENDER_LEASE_DIR/.registry.lock"
+printf 'msys:999999\n' > "$RENDER_LEASE_DIR/.registry.lock/owner.pid"
+rc=0; render_lease_claim 'feat/x' "$tmp/wt" 2>"$tmp/lock-dead.stderr" || rc=$?
+check "dead-owner lock is broken and claim proceeds" "$rc" "0"
+check "dead-owner break names its disposition" "$(grep -Fc 'confirmed-dead owner' "$tmp/lock-dead.stderr" 2>/dev/null)" "1"
+
+export RENDER_LEASE_DIR="$tmp/reg-lock-foreign"
+mkdir -p "$RENDER_LEASE_DIR/.registry.lock"
+printf 'win:12345\n' > "$RENDER_LEASE_DIR/.registry.lock/owner.pid"
+rc=0; render_lease_claim 'feat/x' "$tmp/wt" 2>/dev/null || rc=$?
+check "fresh cross-space lock is never pid-broken" "$rc" "1"
+
+# --- r4 stale-break disposition (verified-live owner is NEVER age-broken) -----
+export RENDER_LEASE_DIR="$tmp/reg-lock-live-aged"
+mkdir -p "$RENDER_LEASE_DIR/.registry.lock"
+printf 'msys:%s\n' "$$" > "$RENDER_LEASE_DIR/.registry.lock/owner.pid"
+touch -t 202001010000 "$RENDER_LEASE_DIR/.registry.lock"
+rc=0; render_lease_claim 'feat/x' "$tmp/wt" 2>/dev/null || rc=$?
+check "aged lock with verified-live owner refuses, never breaks" "$rc" "1"
+check "verified-live owner's aged lock is preserved" "$(test -d "$RENDER_LEASE_DIR/.registry.lock" && echo held || echo broken)" "held"
+
+export RENDER_LEASE_DIR="$tmp/reg-lock-foreign-aged"
+mkdir -p "$RENDER_LEASE_DIR/.registry.lock"
+printf 'win:12345\n' > "$RENDER_LEASE_DIR/.registry.lock/owner.pid"
+touch -t 202001010000 "$RENDER_LEASE_DIR/.registry.lock"
+rc=0; render_lease_claim 'feat/x' "$tmp/wt" 2>"$tmp/lock-foreign-aged.stderr" || rc=$?
+check "aged cross-space lock is age-broken and claim proceeds" "$rc" "0"
+check "cross-space age-break names its disposition" "$(grep -Fc 'age-breaking registry lock' "$tmp/lock-foreign-aged.stderr" 2>/dev/null)" "1"
+
+export RENDER_LEASE_DIR="$tmp/reg-lock-unverifiable-aged"
+mkdir -p "$RENDER_LEASE_DIR/.registry.lock"
+printf 'msys:not-a-pid\n' > "$RENDER_LEASE_DIR/.registry.lock/owner.pid"
+touch -t 202001010000 "$RENDER_LEASE_DIR/.registry.lock"
+rc=0; render_lease_claim 'feat/x' "$tmp/wt" 2>/dev/null || rc=$?
+check "aged unverifiable-owner lock is age-broken" "$rc" "0"
+
+export RENDER_LEASE_DIR="$tmp/reg-lock-unverifiable-fresh"
+mkdir -p "$RENDER_LEASE_DIR/.registry.lock"
+printf 'msys:not-a-pid\n' > "$RENDER_LEASE_DIR/.registry.lock/owner.pid"
+rc=0; render_lease_claim 'feat/x' "$tmp/wt" 2>/dev/null || rc=$?
+check "fresh unverifiable-owner lock refuses" "$rc" "1"
+
+# --- r7: owner-verified release (a broken-then-superseded holder must never
+# delete a successor's lock) --------------------------------------------------
+export RENDER_LEASE_DIR="$tmp/reg-release-foreign"
+mkdir -p "$RENDER_LEASE_DIR/.registry.lock"
+printf 'msys:424242\n' > "$RENDER_LEASE_DIR/.registry.lock/owner.pid"
+render_lease_lock_release 2>"$tmp/release-foreign.stderr"
+check "release leaves a successor's lock intact" "$(test -d "$RENDER_LEASE_DIR/.registry.lock" && echo held || echo removed)" "held"
+check "refused release names the owner mismatch" "$(grep -Fc 'NOT releasing registry lock' "$tmp/release-foreign.stderr" 2>/dev/null)" "1"
+mkdir -p "$RENDER_LEASE_DIR/self-lock-probe"
+rm -rf "$RENDER_LEASE_DIR/.registry.lock"
+mkdir -p "$RENDER_LEASE_DIR/.registry.lock"
+printf 'msys:%s\n' "$$" > "$RENDER_LEASE_DIR/.registry.lock/owner.pid"
+render_lease_lock_release 2>/dev/null
+check "release removes this process's own lock" "$(test -e "$RENDER_LEASE_DIR/.registry.lock" && echo held || echo removed)" "removed"
+
+# --- r7: env knobs validated before arithmetic --------------------------------
+check "secs validator: garbage -> 600" "$(_render_lease_secs 'abc')" "600"
+check "secs validator: empty -> 600" "$(_render_lease_secs '')" "600"
+check "secs validator: zero -> 600" "$(_render_lease_secs '0')" "600"
+check "secs validator: valid honored" "$(_render_lease_secs '1800')" "1800"
+
+export RENDER_LEASE_DIR="$tmp/reg-lock-garbage-env-aged"
+mkdir -p "$RENDER_LEASE_DIR/.registry.lock"
+printf 'win:12345\n' > "$RENDER_LEASE_DIR/.registry.lock/owner.pid"
+touch -t 202001010000 "$RENDER_LEASE_DIR/.registry.lock"
+rc=0
+RENDER_LEASE_LOCK_STALE_SECS='not-a-number' render_lease_claim 'feat/x' "$tmp/wt" 2>"$tmp/garbage-env.stderr" || rc=$?
+check "garbage stale env falls back to default (aged lock still breaks)" "$rc" "0"
+check "garbage stale env reports the default threshold" "$(grep -Fc 'older than 600s' "$tmp/garbage-env.stderr" 2>/dev/null)" "1"
+export RENDER_LEASE_DIR="$tmp/reg-lock-garbage-env-fresh"
+mkdir -p "$RENDER_LEASE_DIR/.registry.lock"
+printf 'win:12345\n' > "$RENDER_LEASE_DIR/.registry.lock/owner.pid"
+rc=0
+RENDER_LEASE_LOCK_STALE_SECS='not-a-number' render_lease_claim 'feat/x' "$tmp/wt" 2>/dev/null || rc=$?
+check "garbage stale env never collapses the threshold (fresh lock refuses)" "$rc" "1"
+
+export RENDER_LEASE_DIR="$tmp/reg-ttl-honored"
+mkdir -p "$RENDER_LEASE_DIR/feat+2Fttl"
+printf 'branch\tfeat/ttl\nworktree\t%s\nacquired_by\t999999\nstarted_at\t2026-01-01T00:00:00Z\nleader_pid\t\nleader_winpid\t\nleader_identity\t\nstatus\tlaunching\n' \
+    "$tmp/wt" > "$RENDER_LEASE_DIR/feat+2Fttl/lease.record"
+sleep 2
+rc=0; render_lease_probe 'feat/ttl' || rc=$?
+check "fresh record under default TTL stays held" "$rc" "1"
+rc=0; RENDER_LEASE_TTL_SECS=1 render_lease_probe 'feat/ttl' || rc=$?
+check "valid short TTL is honored (dead-wrapper record frees)" "$rc" "0"
+rc=0; RENDER_LEASE_TTL_SECS='garbage' render_lease_probe 'feat/ttl' || rc=$?
+check "garbage TTL env falls back to the 600s default" "$rc" "1"
+
+# --- r7: first-tab field split (PS twin parity on tab-bearing values) ---------
+mkdir -p "$tmp/tab-lease"
+printf 'worktree\tval\twith\ttabs\nstatus\trunning\n' > "$tmp/tab-lease/lease.record"
+tab_expected=$(printf 'val\twith\ttabs')
+check "field parse keeps everything after the FIRST tab" "$(render_lease_field "$tmp/tab-lease" worktree)" "$tab_expected"
+check "field parse still isolates ordinary values" "$(render_lease_field "$tmp/tab-lease" status)" "running"
+
+# --- r9: nonce-verified lease release (a reclaimed-away holder must never
+# delete a successor's live lease) ---------------------------------------------
+export RENDER_LEASE_DIR="$tmp/reg-r9-release"
+rc=0; render_lease_claim 'feat/r9' "$tmp/wt" 2>/dev/null || rc=$?
+check "r9 claim acquires" "$rc" "0"
+r9_dir="$RENDER_LEASE_DIR/feat+2Fr9"
+r9_nonce=$(render_lease_field "$r9_dir" claim_nonce)
+check "claim stamps a claim nonce" "$(test -n "$r9_nonce" && echo stamped || echo missing)" "stamped"
+render_lease_bind 'feat/r9' 4242 5252 'win:5252:1' || true
+check "bind preserves the claim nonce" "$(render_lease_field "$r9_dir" claim_nonce)" "$r9_nonce"
+# A successor reclaims the branch (fresh record, its own nonce); the former
+# holder's later clean exit must NOT delete it.
+printf 'branch\tfeat/r9\nworktree\t%s\nacquired_by\t999999\nstarted_at\t2026-01-01T00:00:00Z\nleader_pid\t\nleader_winpid\t\nleader_identity\t\nstatus\tlaunching\nclaim_nonce\tsuccessor-nonce\n' \
+    "$tmp/wt" > "$r9_dir/lease.record"
+render_lease_release 'feat/r9' 2>"$tmp/r9-release.stderr"
+check "release leaves a successor's reclaimed lease intact" "$(test -d "$r9_dir" && echo held || echo removed)" "held"
+check "refused lease release names the reclaim" "$(grep -Fc 'NOT releasing lease' "$tmp/r9-release.stderr" 2>/dev/null)" "1"
+# Restore our own acquisition record: the normal self-release still works.
+printf 'branch\tfeat/r9\nworktree\t%s\nacquired_by\t%s\nstarted_at\t2026-01-01T00:00:00Z\nleader_pid\t\nleader_winpid\t\nleader_identity\t\nstatus\tlaunching\nclaim_nonce\t%s\n' \
+    "$tmp/wt" "$$" "$r9_nonce" > "$r9_dir/lease.record"
+render_lease_release 'feat/r9' 2>/dev/null
+check "self-release still removes our own lease" "$(test -e "$r9_dir" && echo held || echo removed)" "removed"
+# A process that never claimed anything can never release a lease.
+mkdir -p "$RENDER_LEASE_DIR/feat+2Fr9b"
+printf 'branch\tfeat/r9b\nworktree\t%s\nacquired_by\t999999\nstarted_at\t2026-01-01T00:00:00Z\nleader_pid\t\nleader_winpid\t\nleader_identity\t\nstatus\tlaunching\nclaim_nonce\tother-nonce\n' \
+    "$tmp/wt" > "$RENDER_LEASE_DIR/feat+2Fr9b/lease.record"
+unset _RENDER_LEASE_CLAIM_NONCE
+render_lease_release 'feat/r9b' 2>/dev/null
+check "claimless process cannot release any lease" "$(test -d "$RENDER_LEASE_DIR/feat+2Fr9b" && echo held || echo removed)" "held"
+
+# --- r9: the delay knob is validated before it reaches sleep ------------------
+check "delay validator: garbage -> 0.5" "$(_render_lease_delay 'abc')" "0.5"
+check "delay validator: empty -> 0.5" "$(_render_lease_delay '')" "0.5"
+check "delay validator: zero allowed" "$(_render_lease_delay '0')" "0"
+check "delay validator: fraction allowed" "$(_render_lease_delay '0.25')" "0.25"
+check "delay validator: double-dot -> 0.5" "$(_render_lease_delay '1.2.3')" "0.5"
+check "delay validator: trailing dot -> 0.5" "$(_render_lease_delay '5.')" "0.5"
+export RENDER_LEASE_DIR="$tmp/reg-delay-junk"
+mkdir -p "$RENDER_LEASE_DIR/.registry.lock"
+printf 'msys:%s\n' "$$" > "$RENDER_LEASE_DIR/.registry.lock/owner.pid"
+rc=0
+RENDER_LEASE_LOCK_DELAY_SECS='junk' RENDER_LEASE_LOCK_ATTEMPTS=2 render_lease_claim 'feat/x' "$tmp/wt" 2>/dev/null || rc=$?
+check "garbage delay env falls back and still refuses cleanly" "$rc" "1"
+
+if [ "$fails" -eq 0 ]; then
+    echo "ALL PASS"
+else
+    echo "$fails FAILED"
+    exit 1
+fi

--- a/scripts/statusline/test-usage-cache-contract.sh
+++ b/scripts/statusline/test-usage-cache-contract.sh
@@ -29,6 +29,13 @@
 # shellcheck disable=SC2329  # same as SC2317 (alias in newer shellcheck versions)
 set -uo pipefail
 
+# Exercise the shipped watchdog defaults, not operator/lane overrides inherited
+# from the session running this suite.
+unset ANTHROPIC_BASE_URL HERMES_ENGINE CODEX_ADAPTER CODEX_THREAD_ID
+unset AUTO_ARM_DISABLE AUTO_ARM_THRESHOLD AUTO_ARM_CACHE AUTO_ARM_STATE_DIR
+unset AUTO_ARM_CHECK_INTERVAL AUTO_ARM_MAX_CACHE_AGE AUTO_ARM_MAX_ARM_FAILURES
+unset AUTO_ARM_STALE_ESCALATE_AGE AUTO_ARM_STALE_MIN_CHECKS AUTO_ARM_BIN
+
 # grepq <text> [grep-args...] — a `grep -q` test against <text> with NO
 # pipeline. printf/echo-into-`grep -q` is a trap under this file's
 # `set -o pipefail`: grep -q exits the instant it matches, the producer

--- a/scripts/telegram/quota-gauge.test.ts
+++ b/scripts/telegram/quota-gauge.test.ts
@@ -299,13 +299,30 @@ test("T2 buildGlmRow(null) -> invisible row, used_pct null, no throw", () => {
   expect(row.note).toContain("invisible");
 });
 
-test("T3 isGlmPeak boundaries 13:59 / 14:00 / 17:59 / 18:00 UTC+8 (AC8)", () => {
+test("T3 isGlmPeak hour boundaries 13:59 / 14:00 / 17:59 / 18:00 UTC+8 (AC8)", () => {
   // a UTC instant whose UTC+8 wall-clock hour is `utc8h` -> UTC hour = utc8h-8.
-  const at = (utc8h: number, m: number) => Date.UTC(2026, 6, 4, (utc8h - 8 + 24) % 24, m, 0);
+  // Anchored on a WEEKDAY (2026-07-06 Mon) so the hour rule is isolated from
+  // the weekday rule (weekends are 1× all day — HIMMEL-1479).
+  const at = (utc8h: number, m: number) => Date.UTC(2026, 6, 6, (utc8h - 8 + 24) % 24, m, 0);
   expect(isGlmPeak(at(13, 59))).toBe(false);
   expect(isGlmPeak(at(14, 0))).toBe(true);
   expect(isGlmPeak(at(17, 59))).toBe(true);
   expect(isGlmPeak(at(18, 0))).toBe(false);
   // glm_peak is a bool on GLM rows (never null there); non-GLM rows carry null
   expect(buildGlmRow({ percentage: 1, nextResetTime: NOW_MS, level: "pro" }, NOW_MS).glm_peak).not.toBeNull();
+});
+
+test("T3b isGlmPeak weekday rule — weekends are 1× all day (HIMMEL-1479)", () => {
+  // SGT (UTC+8) wall-clock instant: day/hour/min are SGT; subtract 8h for UTC
+  // (Date.UTC normalizes the negative hour). 2026-07-10 Fri, 07-11 Sat, 07-13 Mon.
+  const sgt = (day: number, h: number, m = 0) => Date.UTC(2026, 6, day, h - 8, m, 0);
+  // weekend INSIDE the peak hours → NOT peak (the bug this fixes)
+  expect(isGlmPeak(sgt(11, 15))).toBe(false);  // Saturday 15:00 SGT, inside [14,18)
+  // weekday inside the peak hours → peak (existing behavior preserved)
+  expect(isGlmPeak(sgt(10, 15))).toBe(true);   // Friday 15:00 SGT
+  expect(isGlmPeak(sgt(13, 14))).toBe(true);   // Monday 14:00 SGT
+  // boundary: Fri 17:59 SGT peak; the instant SGT rolls to Sat 00:00 → not peak.
+  // Sat 00:00 SGT = Fri 16:00 UTC — exercises the UTC+8 (not UTC) weekday calc.
+  expect(isGlmPeak(sgt(10, 17, 59))).toBe(true);  // Friday 17:59 SGT
+  expect(isGlmPeak(sgt(11, 0, 0))).toBe(false);   // Saturday 00:00 SGT (= Fri 16:00 UTC)
 });

--- a/scripts/telegram/quota-gauge.ts
+++ b/scripts/telegram/quota-gauge.ts
@@ -168,11 +168,19 @@ export const GLM_PEAK_START_H = 14;
 export const GLM_PEAK_END_H = 18;
 export const GLM_PEAK_TZ_OFFSET_H = 8;
 
-// True iff `nowMs`, converted to UTC+8, falls in [14:00, 18:00). Pure — derives
-// the UTC+8 hour from the absolute instant, never reads a lane/arm/dispatch.
+// True iff `nowMs`, converted to UTC+8, falls in [14:00, 18:00) on a WEEKDAY
+// (Mon–Fri). Pure — derives the UTC+8 hour + weekday from the absolute instant
+// (DST-immune: UTC+8 is z.ai-fixed), never reads a lane/arm/dispatch. Weekends
+// bill 1× all day, so a Sat/Sun inside the peak hours is NOT peak (HIMMEL-1479).
 export function isGlmPeak(nowMs: number): boolean {
   const utc8Hour = Math.floor(((nowMs / 3600000) + GLM_PEAK_TZ_OFFSET_H) % 24 + 24) % 24;
-  return utc8Hour >= GLM_PEAK_START_H && utc8Hour < GLM_PEAK_END_H;
+  if (utc8Hour < GLM_PEAK_START_H || utc8Hour >= GLM_PEAK_END_H) return false;
+  // UTC+8 weekday. Days since the Unix epoch in UTC+8 wall-clock; 1970-01-01
+  // was a Thursday, so a JS-getDay-style weekday (Sun=0..Sat=6) = (4 + days) % 7.
+  // Sat=6, Sun=0 → weekdays Mon–Fri are 1..5.
+  const utc8Days = Math.floor((nowMs + GLM_PEAK_TZ_OFFSET_H * 3600000) / 86400000);
+  const utc8Day = (((4 + utc8Days) % 7) + 7) % 7;
+  return utc8Day >= 1 && utc8Day <= 5;
 }
 
 // Map the GLM monitor-endpoint reading to a canonical row. `null` (usage

--- a/scripts/telegram/spawn-claudex.test.ts
+++ b/scripts/telegram/spawn-claudex.test.ts
@@ -2,7 +2,7 @@
 import { expect, test, spyOn } from "bun:test";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import {
   claudexSessionRoot,
@@ -30,6 +30,7 @@ import {
   claudexLauncherPath,
   buildClaudexRunArgs,
   claudexChildEnv,
+  writeClaudexLiveMeta,
   executeClaudexRun,
 } from "./spawn-claudex";
 import { BASH_BIN } from "./run";
@@ -990,6 +991,41 @@ const seedRunningMeta = () => {
   writeFileSync(metaPath, JSON.stringify(runningMeta, null, 2));
   return { dir, metaPath, runningMeta };
 };
+
+test("executeClaudexRun: onSpawn publishes the live worker pid while status stays running", async () => {
+  const { dir, metaPath, runningMeta } = seedRunningMeta();
+  try {
+    let liveMeta: any;
+    const run = (async (_p: string, _c: string, _opts: unknown, onSpawn: (pid: number) => void) => {
+      onSpawn(321);
+      liveMeta = JSON.parse(readFileSync(metaPath, "utf8"));
+      return { code: 0, capped: false, blocked: false, timedOut: false, pid: 321, tail: "" };
+    }) as any;
+    await executeClaudexRun({ run, prompt: "p", worktree: "/wt", repoRoot: "/repo", sessionDir: dir, metaPath, runningMeta });
+    expect(liveMeta.status).toBe("running");
+    expect(liveMeta.pid).toBe(321);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("writeClaudexLiveMeta: replace failure is loud and atomically leaves an unprobeable running marker", () => {
+  const { dir, metaPath, runningMeta } = seedRunningMeta();
+  const stderr = spyOn(console, "error").mockImplementation(() => {});
+  try {
+    writeClaudexLiveMeta(metaPath, runningMeta, { pid: 321 }, (tmpPath, _destPath, json) => {
+      writeFileSync(tmpPath, json);
+      throw new Error("rename denied");
+    });
+    const marker = JSON.parse(readFileSync(metaPath, "utf8"));
+    expect(marker.status).toBe("running");
+    expect(marker.pid).toBeUndefined();
+    expect(marker.pid_probe).toBe("unprobeable");
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("worker liveness is unprobeable and must be treated as possibly alive"));
+    expect(existsSync(`${metaPath}.tmp-${process.pid}`)).toBe(false);
+  } finally {
+    stderr.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test("executeClaudexRun: a THROWING run() transitions meta running->failed(-1) then rethrows", async () => {
   const { dir, metaPath, runningMeta } = seedRunningMeta();

--- a/scripts/telegram/spawn-claudex.ts
+++ b/scripts/telegram/spawn-claudex.ts
@@ -25,7 +25,7 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawn } from "bun";
 import { BASH_BIN, REPO_ROOT, killTree, detectContentFilter, type PermissionMode } from "./run";
-import { transcriptDirFor, poisonPushUrl, ensureWorkspaceTrust, preflightWindowCheck, measureOverheadChars, finalMeta, POISON_SENTINEL, resolveProfileSettings, teardownMintedWorktree, DEFAULT_LANE_PROFILE, mintRetaskNonce, composeRetaskBlock, composeBashShapeWarning, composeOutboxWriteHint, composeWorkerSettings, refuseBypassPermissions, refuseUnknownPermissionMode, isHelpFlag } from "./spawn-glm";
+import { transcriptDirFor, poisonPushUrl, ensureWorkspaceTrust, preflightWindowCheck, measureOverheadChars, finalMeta, POISON_SENTINEL, resolveProfileSettings, teardownMintedWorktree, DEFAULT_LANE_PROFILE, mintRetaskNonce, composeRetaskBlock, composeBashShapeWarning, composeOutboxWriteHint, composeWorkerSettings, refuseBypassPermissions, refuseUnknownPermissionMode, isHelpFlag, writeLiveWorkerMeta } from "./spawn-glm";
 // HIMMEL-1040 plugin profiles: same per-dispatch lean-profile injection as the
 // GLM lane. spawn-claudex dispatches through scripts/claude-codex, which already
 // screens + forwards --settings — so the resolved payload just rides its argv.
@@ -609,12 +609,13 @@ export type ClaudexRunResult = { code: number; capped: boolean; blocked: boolean
 // run.log persistence). NOT unit-tested directly (it launches a real
 // process) — executeClaudexRun below takes it as an injected dependency so
 // tests stub it and never launch claude-codex/claude for real.
-export async function runClaudexSession(prompt: string, cwd: string, opts: { permMode?: PermissionMode; effort?: EffortLevel; repoRoot: string; settings?: string }): Promise<ClaudexRunResult> {
+export async function runClaudexSession(prompt: string, cwd: string, opts: { permMode?: PermissionMode; effort?: EffortLevel; repoRoot: string; settings?: string }, onSpawn?: (pid: number) => void): Promise<ClaudexRunResult> {
   const launcherPath = claudexLauncherPath(opts.repoRoot);
   const { cmd } = buildClaudexRunArgs(launcherPath, prompt, opts.permMode, opts.settings);
   const env = claudexChildEnv(process.env, opts.effort);
   const p = spawn(cmd, { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe", env });
   const pid = p.pid;
+  onSpawn?.(pid);
   const timeoutMs = Number(process.env.RUN_TIMEOUT_MS ?? 30 * 60 * 1000);
   let timedOut = false;
   const timer = setTimeout(() => { timedOut = true; killTree(pid, (s) => p.kill(s as any)); }, timeoutMs);
@@ -628,20 +629,37 @@ export async function runClaudexSession(prompt: string, cwd: string, opts: { per
   return { code: timedOut ? -1 : code, capped: detectClaudexCap(tail), blocked: detectContentFilter(tail), timedOut, pid, tail };
 }
 
+export function writeClaudexLiveMeta(
+  metaPath: string,
+  runningMeta: Record<string, unknown>,
+  extra: Record<string, unknown>,
+  replace?: (tmpPath: string, destPath: string, json: string) => void,
+): void {
+  if (replace) writeLiveWorkerMeta(metaPath, runningMeta, extra, "spawn-claudex", replace);
+  else writeLiveWorkerMeta(metaPath, runningMeta, extra, "spawn-claudex");
+}
+
 // The run-and-record step (mirrors spawn-glm's executeRun, minus the
 // prompt-too-long classification and cap-guard resume scheduling — both
 // GLM-specific / deferred here). meta.json ALWAYS leaves "running": the
 // success path writes finalMeta (done/failed/capped/blocked/timeout), and a
 // thrown run() writes {status:"failed", exit_code:-1} THEN rethrows.
 export async function executeClaudexRun(deps: {
-  run: (prompt: string, cwd: string, opts: { permMode?: PermissionMode; effort?: EffortLevel; repoRoot: string; settings?: string }) => Promise<ClaudexRunResult>;
+  run: (prompt: string, cwd: string, opts: { permMode?: PermissionMode; effort?: EffortLevel; repoRoot: string; settings?: string }, onSpawn?: (pid: number) => void) => Promise<ClaudexRunResult>;
   prompt: string; worktree: string; permMode?: PermissionMode; effort?: EffortLevel; repoRoot: string;
   sessionDir: string; metaPath: string; runningMeta: Record<string, unknown>;
   // HIMMEL-1040: the resolved --settings plugin-profile payload (undefined = operator / no injection).
   settings?: string;
 }): Promise<{ code: number }> {
+  const recordLivePid = (pid: number) => {
+    // Match spawn-glm's live metadata contract: arm-resume can only protect a
+    // running claudex worker if meta.json stops advertising the bootstrap pid 0.
+    // Write-then-rename keeps concurrent census readers off partial JSON; a
+    // failed replace leaves an explicit unprobeable marker, never pid:0.
+    writeClaudexLiveMeta(deps.metaPath, deps.runningMeta, { pid });
+  };
   try {
-    const res = await deps.run(deps.prompt, deps.worktree, { permMode: deps.permMode, effort: deps.effort, repoRoot: deps.repoRoot, settings: deps.settings });
+    const res = await deps.run(deps.prompt, deps.worktree, { permMode: deps.permMode, effort: deps.effort, repoRoot: deps.repoRoot, settings: deps.settings }, recordLivePid);
     // run.log append is COSMETIC persistence — isolated so an I/O failure here
     // never flips a successful run to failed (mirrors spawn-glm's executeRun).
     if (res.tail !== undefined) {
@@ -676,7 +694,10 @@ export async function runClaudexSharedDispatch(p: {
   // still releases the lock). Absent ⇒ skipped (own-mode / tests).
   revalidateClean?: () => { ok: true } | { ok: false; reason: string };
 }): Promise<{ ok: true; code: number } | { ok: false; reason: string }> {
-  const acquire = Bun.spawnSync([BASH_BIN, p.lockScript, "acquire", p.repoDir, p.branch, "codex"], { stdout: "pipe", stderr: "pipe" });
+  const acquire = Bun.spawnSync([BASH_BIN, p.lockScript, "acquire", p.repoDir, p.branch, "codex"], {
+    stdout: "pipe", stderr: "pipe",
+    env: { ...process.env, SHARED_BRANCH_LOCK_HOLDER_PID: String(process.pid) },
+  });
   if (acquire.exitCode !== 0) return { ok: false, reason: acquire.stderr.toString().trim() || `spawn-claudex: shared-branch-lock acquire failed (rc=${acquire.exitCode})` };
   let priorPushUrl: string | undefined;
   let poisoned = false;

--- a/scripts/telegram/spawn-glm.test.ts
+++ b/scripts/telegram/spawn-glm.test.ts
@@ -1,5 +1,5 @@
 // scripts/telegram/spawn-glm.test.ts
-import { expect, test, beforeEach } from "bun:test";
+import { expect, test, beforeEach, spyOn } from "bun:test";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
@@ -21,6 +21,7 @@ import {
   runSharedDispatch,
   finalMeta,
   parseArgs,
+  writeLiveWorkerMeta,
   executeRun,
   computeResumeAt,
   toArmHHMM,
@@ -1024,6 +1025,26 @@ const seedRunningMeta = () => {
   writeFileSync(metaPath, JSON.stringify(runningMeta, null, 2));
   return { dir, metaPath, runningMeta };
 };
+
+test("writeLiveWorkerMeta: replace failure atomically leaves an unprobeable running marker", () => {
+  const { dir, metaPath, runningMeta } = seedRunningMeta();
+  const stderr = spyOn(console, "error").mockImplementation(() => {});
+  try {
+    writeLiveWorkerMeta(metaPath, runningMeta, { pid: 321 }, "spawn-glm", (tmpPath, _destPath, json) => {
+      writeFileSync(tmpPath, json);
+      throw new Error("rename denied");
+    });
+    const marker = JSON.parse(readFileSync(metaPath, "utf8"));
+    expect(marker.status).toBe("running");
+    expect(marker.pid).toBeUndefined();
+    expect(marker.pid_probe).toBe("unprobeable");
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("worker liveness is unprobeable and must be treated as possibly alive"));
+    expect(existsSync(`${metaPath}.tmp-${process.pid}`)).toBe(false);
+  } finally {
+    stderr.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test("executeRun: a THROWING runSession transitions meta running→failed(-1) then rethrows", async () => {
   const { dir, metaPath, runningMeta } = seedRunningMeta();

--- a/scripts/telegram/spawn-glm.ts
+++ b/scripts/telegram/spawn-glm.ts
@@ -4,7 +4,7 @@
 // paths), run.log persistence from the returned tail, meta.json transitions.
 // Sessions live under <BRIDGE_ROOT>/glm-sessions/ — the live poller scans ONLY
 // <root>/sessions/, so nothing here can be double-spawned or Telegram-flushed.
-import { existsSync, mkdirSync, writeFileSync, appendFileSync, readFileSync, statSync, renameSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync, appendFileSync, readFileSync, statSync, renameSync, unlinkSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
@@ -712,6 +712,37 @@ export function detectPromptTooLong(tail: string): boolean {
   return /prompt is too long/i.test(tail);
 }
 
+type LiveMetaReplace = (tmpPath: string, metaPath: string, json: string) => void;
+
+// Publish live worker metadata atomically. If the replace fails, pid:0 is the
+// unsafe fallback: downstream census reads it as dead. Rewrite a loud,
+// explicitly-unprobeable running marker instead, so reconciliation and arming
+// fail toward POSSIBLY ALIVE until the terminal metadata write succeeds.
+export function writeLiveWorkerMeta(
+  metaPath: string,
+  runningMeta: Record<string, unknown>,
+  extra: Record<string, unknown>,
+  label: string,
+  replace: LiveMetaReplace = (tmpPath, destPath, json) => {
+    writeFileSync(tmpPath, json);
+    renameSync(tmpPath, destPath);
+  },
+): void {
+  const tmpPath = `${metaPath}.tmp-${process.pid}`;
+  try {
+    replace(tmpPath, metaPath, JSON.stringify({ ...runningMeta, ...extra }, null, 2));
+  } catch (e) {
+    console.error(`ERR ${label}: live meta.json update failed; worker liveness is unprobeable and must be treated as possibly alive: ${String((e as any)?.message ?? e)}`);
+    const marker = { ...runningMeta, ...extra, status: "running", pid_probe: "unprobeable" };
+    delete marker.pid;
+    try {
+      writeFileSync(tmpPath, JSON.stringify(marker, null, 2));
+      renameSync(tmpPath, metaPath);
+    } catch (markerError) { console.error(`ERR ${label}: could not write the unprobeable live-worker marker: ${String((markerError as any)?.message ?? markerError)}`); }
+    try { unlinkSync(tmpPath); } catch (_) {}
+  }
+}
+
 // The run-and-record step, extracted so the meta-transition contract is
 // testable with an injected runSession. meta.json ALWAYS leaves "running": the
 // success path writes finalMeta (done/failed/capped/blocked), and a thrown
@@ -751,12 +782,7 @@ export async function executeRun(deps: {
     // landing mid-truncate could see a partial object (e.g. started_at present,
     // last_output_at not yet written), which the stall check misreads as a
     // spurious STALLED on a healthy worker. rename() is atomic within a dir.
-    try {
-      const tmpPath = `${deps.metaPath}.tmp-${process.pid}`;
-      writeFileSync(tmpPath, JSON.stringify({ ...deps.runningMeta, ...extra }, null, 2));
-      renameSync(tmpPath, deps.metaPath);
-    }
-    catch (e) { console.error(`spawn-glm: live meta.json update failed (non-fatal): ${String((e as any)?.message ?? e)}`); }
+    writeLiveWorkerMeta(deps.metaPath, deps.runningMeta, extra, "spawn-glm");
   };
   const observe: RunObserver = {
     onSpawn: (pid) => { livePid = pid; writeRunningMeta({ pid, last_output_at: new Date().toISOString() }); },
@@ -862,7 +888,10 @@ export async function runSharedDispatch(p: {
   repoDir: string; worktree: string; branch: string; needsWorktreeAdd: boolean;
   lockScript: string; gitAdd: () => void; runBody: () => Promise<number>;
 }): Promise<{ ok: true; code: number } | { ok: false; reason: string }> {
-  const acquire = Bun.spawnSync([BASH_BIN, p.lockScript, "acquire", p.repoDir, p.branch, "glm"], { stdout: "pipe", stderr: "pipe" });
+  const acquire = Bun.spawnSync([BASH_BIN, p.lockScript, "acquire", p.repoDir, p.branch, "glm"], {
+    stdout: "pipe", stderr: "pipe",
+    env: { ...process.env, SHARED_BRANCH_LOCK_HOLDER_PID: String(process.pid) },
+  });
   if (acquire.exitCode !== 0) return { ok: false, reason: acquire.stderr.toString().trim() || `spawn-glm: shared-branch-lock acquire failed (rc=${acquire.exitCode})` };
   let priorPushUrl: string | undefined;
   // CR round 2 F5: only true once poisonPushUrl has actually completed — gates

--- a/scripts/test-check-ci.sh
+++ b/scripts/test-check-ci.sh
@@ -51,6 +51,14 @@
 #   52. leading-zero wait 007 (silent octal) → normalized to decimal 7, rc 0
 set -uo pipefail
 
+# HIMMEL-1495 — an --automerge-armed launching shell carries ARMAUTOMERGE=1 +
+# CR_MERGE_GATE_OK=1 by design; an ambient value in the operator's shell must
+# not decide the result (the 34e/34f precedent that lives in THIS file,
+# generalized to the armed-session bypass pair). check-ci.sh does not consult
+# either var today, so this is defense-in-depth for the day a sourced lib reads
+# one — case 58 below pins today's insensitivity.
+unset ARMAUTOMERGE CR_MERGE_GATE_OK
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$SCRIPT_DIR/check-ci.sh"
 
@@ -73,7 +81,7 @@ cat > "$STUBDIR/gh" <<'EOF'
 #!/usr/bin/env bash
 # gh stub for test-check-ci.sh — checks behavior via GH_STUB_MODE, probe/watch/
 # api/review/comment counters via GH_STUB_COUNT / GH_STUB_WATCH / GH_STUB_API /
-# GH_STUB_REVIEWS / GH_STUB_COMMENTS files, unresolved-thread count via
+# GH_STUB_STATUSES / GH_STUB_REVIEWS / GH_STUB_COMMENTS files, unresolved-thread count via
 # GH_STUB_THREADS ("fail" makes the graphql call
 # error; "paged" puts the unresolved thread on page two). graphql pages are
 # echoed in the script's parsed shape: "<count> <hasNextPage> <endCursor>".
@@ -100,6 +108,15 @@ if [ "$cmd" = "api" ]; then
                 # refusal lives ONLY in .description — which this reader used to
                 # drop, making a declined review byte-identical to a clean one.
                 cr-skipped)     echo '[{"context":"CodeRabbit","state":"success","description":"Review skipped: automatic reviews are disabled","created_at":"2026-07-16T19:10:05Z","creator":{"id":136622811,"login":"coderabbitai[bot]","type":"Bot"}}]' ;;
+                cr-desc-error)
+                    s=$(cat "$GH_STUB_STATUSES" 2>/dev/null)
+                    s=${s:-0}
+                    echo $((s+1)) > "$GH_STUB_STATUSES"
+                    if [ "$s" -eq 0 ]; then
+                        echo '[{"context":"CodeRabbit","state":"success","description":"Review skipped: automatic reviews are disabled","created_at":"2026-07-16T19:10:05Z","creator":{"id":136622811,"login":"coderabbitai[bot]","type":"Bot"}}]'
+                    else
+                        echo "statuses boom" >&2; exit 1
+                    fi ;;
                 # The positive control for the pair: the SAME state with a real
                 # review. Without it the skip assertion could be satisfied by
                 # breaking `success` outright, which would pass while making the
@@ -322,7 +339,7 @@ case "$GH_STUB_MODE" in
     watch-error)
         if [ "$is_watch" -eq 1 ]; then echo "HTTP 401: Bad credentials (https://api.github.com/graphql)" >&2; exit 1; fi
         exit 8 ;;
-    cr-absent|cr-pending|cr-failure|cr-spoofed|cr-query-error|cr-paged|cr-skipped|cr-completed|cr-nearmiss|cr-ratelimited|cr-unknownword|cr-substrmatch)
+    cr-absent|cr-pending|cr-failure|cr-spoofed|cr-query-error|cr-paged|cr-skipped|cr-desc-error|cr-completed|cr-nearmiss|cr-ratelimited|cr-unknownword|cr-substrmatch)
         # Checks are GREEN and threads are clean in every one of these — the
         # verdict must turn entirely on CodeRabbit's status (HIMMEL-1072).
         if [ "$is_watch" -eq 1 ]; then echo "All checks were successful"; exit 0; fi
@@ -368,6 +385,7 @@ run() {
     : > "$STUBDIR/watch"
     : > "$STUBDIR/api"
     : > "$STUBDIR/headc"
+    : > "$STUBDIR/statuses"
     : > "$STUBDIR/reviews"
     : > "$STUBDIR/comments"
     PATH="$STUBDIR:$PATH" \
@@ -377,6 +395,7 @@ run() {
         GH_STUB_WATCH="$STUBDIR/watch" \
         GH_STUB_API="$STUBDIR/api" \
         GH_STUB_HEADC="$STUBDIR/headc" \
+        GH_STUB_STATUSES="$STUBDIR/statuses" \
         GH_STUB_REVIEWS="$STUBDIR/reviews" \
         GH_STUB_COMMENTS="$STUBDIR/comments" \
         GH_STUB_HEAD="$HEAD_OVERRIDE" \
@@ -395,6 +414,13 @@ run() {
     SETTLE_OVERRIDE=0; THREADS_OVERRIDE=0; POLL_OVERRIDE=0; HEAD_OVERRIDE=stable; DECISION_OVERRIDE=null
     ESCALATE_WAIT_OVERRIDE=0; ESCALATE_POLL_OVERRIDE=0
     CR_PROFILE_OVERRIDE=""; CR_APP_OVERRIDE=1
+}
+
+run_in_repo() {
+    local repo="$1" previous="$PWD"; shift
+    cd "$repo" || { echo "FATAL: cannot cd to ledger fixture repo" >&2; exit 1; }
+    run "$@"
+    cd "$previous" || { echo "FATAL: cannot cd back from ledger fixture repo" >&2; exit 1; }
 }
 
 assert_rc()      { if [ "$RC" -eq "$1" ]; then pass "$2"; else fail "$2" "rc=$RC want $1"; fi; }
@@ -702,32 +728,64 @@ assert_rc 0 "34d skip-ish wording on a COMPLETED review does not block"
 # default at all. (CR review of this branch, 2026-07-28.)
 unset CR_OK_DESC_RE CR_SKIP_DESC_RE
 
-run cr-ratelimited
+# Exact-head ledger fixtures for every panel-carry shape below. The empty repo
+# proves no rows preserve the existing fail-closed verdict; the clean repo has
+# one responder at the fixture head and no blocking finding.
+EMPTY_LEDGER_REPO=$(mktemp -d "$STUBDIR/empty-ledger.XXXXXX")
+git -C "$EMPTY_LEDGER_REPO" init --quiet
+git -C "$EMPTY_LEDGER_REPO" -c user.email=t@t -c user.name=t commit --allow-empty -m seed --quiet --no-verify
+: > "$EMPTY_LEDGER_REPO/.git/cr-critic-scores.jsonl"
+LEDGER_REPO=$(mktemp -d "$STUBDIR/clean-ledger.XXXXXX")
+git -C "$LEDGER_REPO" init --quiet
+git -C "$LEDGER_REPO" -c user.email=t@t -c user.name=t commit --allow-empty -m seed --quiet --no-verify
+printf '%s\n' '{"kind":"avail","ts":"2026-08-03T00:00:00Z","branch":"feat/x","head":"sha1","model":"codex","status":"ok","artifact":"diff","perspective":"off","responding_model":"gpt-5.5"}' > "$LEDGER_REPO/.git/cr-critic-scores.jsonl"
+DIRTY_LEDGER_REPO=$(mktemp -d "$STUBDIR/dirty-ledger.XXXXXX")
+git -C "$DIRTY_LEDGER_REPO" init --quiet
+git -C "$DIRTY_LEDGER_REPO" -c user.email=t@t -c user.name=t commit --allow-empty -m seed --quiet --no-verify
+printf '%s\n' \
+    '{"kind":"avail","ts":"2026-08-03T00:00:00Z","branch":"feat/x","head":"sha1","model":"codex","status":"ok","artifact":"diff","perspective":"off","responding_model":"gpt-5.5"}' \
+    '{"kind":"finding","ts":"2026-08-03T00:00:01Z","branch":"feat/x","head":"sha1","finding_id":"H1506-test","severity":"crit","verdict":"confirmed","artifact":"diff","perspective":"off"}' \
+    > "$DIRTY_LEDGER_REPO/.git/cr-critic-scores.jsonl"
+
+# HIMMEL-1506: automatic-reviews-disabled wording is panel-carriable at the
+# exact head, but an explicitly empty ledger preserves the existing exit-2
+# message and remedy.
+run_in_repo "$EMPTY_LEDGER_REPO" cr-skipped
+assert_rc 2 "34b2 disabled wording with no ledger rows stays blocked"
+assert_err_has "@coderabbitai review" "34b2 disabled-wording remedy is unchanged"
+run_in_repo "$LEDGER_REPO" cr-skipped
+assert_rc 0 "34b3 disabled wording with a clean exact-head panel is carried"
+assert_out_has "reports automatic reviews are disabled" "34b3 distinct disabled-signal carry line surfaced"
+assert_out_has "carried responders=1 models=codex" "34b3 carry evidence surfaced"
+
+# A description read failure is also an absent App signal: clean exact-head
+# panel evidence carries it; no ledger rows keep the prior cannot-evaluate path.
+run_in_repo "$EMPTY_LEDGER_REPO" cr-desc-error
+assert_rc 2 "34b4 unreadable description with no ledger rows stays blocked"
+assert_err_has "description could not be read" "34b4 unreadable-description message is unchanged"
+run_in_repo "$LEDGER_REPO" cr-desc-error
+assert_rc 0 "34b5 unreadable description with a clean exact-head panel is carried"
+assert_out_has "description is unreadable" "34b5 distinct unreadable-description carry line surfaced"
+assert_out_has "carried responders=1 models=codex" "34b5 carry evidence surfaced"
+
+run_in_repo "$EMPTY_LEDGER_REPO" cr-ratelimited
 assert_rc 2 "34e rate-limited CodeRabbit review with no panel evidence is not certifiable"
 assert_err_has "rate-limited" "34e rate-limit reason surfaced"
 assert_err_has "did NOT carry the gate" "34e names the missing panel evidence (HIMMEL-1465)"
 
 # 34e2 (HIMMEL-1465) — the SAME rate-limited decline, but a CLEAN critic panel
 # recorded at the head in the CR ledger: the panel carries the gate and the
-# verdict certifies. A SCRATCH repo pins the ledger — cr-ledger-evidence.sh
-# deliberately reads only <git-common-dir>/cr-critic-scores.jsonl of the CWD
-# repo (never an env-pointed path), so the real checkout's ledger must not
-# decide this case. Head "sha1" matches by exact string equality in atHead
-# (it is not hex, so it can never prefix-resolve to anything else).
-LEDGER_REPO=$(mktemp -d "$STUBDIR/ledgerrepo.XXXXXX")
-git -C "$LEDGER_REPO" init --quiet
-git -C "$LEDGER_REPO" -c user.email=t@t -c user.name=t commit --allow-empty -m seed --quiet --no-verify
-printf '%s\n' '{"kind":"avail","ts":"2026-08-03T00:00:00Z","branch":"feat/x","head":"sha1","model":"codex","status":"ok","artifact":"diff","perspective":"off","responding_model":"gpt-5.5"}' > "$LEDGER_REPO/.git/cr-critic-scores.jsonl"
-PRE_34E2_PWD=$PWD
-cd "$LEDGER_REPO" || { echo "FATAL: cannot cd to 34e2 scratch repo" >&2; exit 1; }
-run cr-ratelimited
-cd "$PRE_34E2_PWD" || { echo "FATAL: cannot cd back from 34e2 scratch repo" >&2; exit 1; }
+# verdict certifies. The exact audit line is pinned byte-for-byte.
+run_in_repo "$LEDGER_REPO" cr-ratelimited
 assert_rc 0 "34e2 rate-limited App with a clean panel at the head is panel-carried (HIMMEL-1465)"
-assert_out_has "the critic panel carries the gate" "34e2 carried-gate audit line surfaced"
+assert_out_has "check-ci: CodeRabbit is rate-limited on head sha1 of PR #42; the critic panel carries the gate (carried responders=1 models=codex) — not failing the verdict on the App (HIMMEL-1465)." "34e2 existing rate-limit carry line is byte-identical"
 
 run cr-unknownword
 assert_rc 2 "34f an UNENUMERATED success wording fails closed, not open"
 assert_err_has "does not say the review completed" "34f allow-list reason surfaced"
+run_in_repo "$LEDGER_REPO" cr-unknownword
+assert_rc 0 "34f2 unenumerated skip wording with a clean exact-head panel is carried"
+assert_out_has "posted skip-classified wording" "34f2 distinct generic-skip carry line surfaced"
 
 # 34g — the escape hatch that makes the allow-list safe to ship. If CodeRabbit
 # renames its success description, every PR blocks at once; the operator must be
@@ -762,9 +820,9 @@ assert_err_has "does not say the review completed" "34h allow-list reason surfac
 # widens the allow-list during an outage using the OLD documented recipe
 # (no anchors) re-admits the exact substring hole 34h just closed, on the
 # recovery path most likely to be exercised during that same drift. The
-# documented recipe (scripts/lib/cr-signal.sh's OUTAGE ESCAPE HATCH block,
-# scripts/check-ci.sh's skipped-arm operator message) is fixed here to carry
-# its own ^(...)$ anchors; CR_OK_DESC_RE stays unanchored IN CODE — forcing
+# documented recipe (scripts/lib/cr-signal.sh's OUTAGE ESCAPE HATCH block) is
+# fixed here to carry its own ^(...)$ anchors; CR_OK_DESC_RE stays unanchored
+# IN CODE — forcing
 # an anchor there would break 34g's already-shipped loose partial-phrase
 # widening (a bare keyword matching an unenumerated FULL sentence), so the
 # anchors live in the recipe operators copy, not in code. Pins that following
@@ -815,10 +873,26 @@ assert_err_has "could not read CodeRabbit's review-body findings" "38 body-query
 # 39 — incremental-silent: CodeRabbit concluded on sha1 but emitted no review
 # object there, while a prior head carries outside-diff findings. This is the
 # resolvable rc 4 state, not the genuinely unreadable rc 2 state.
-run body-a2
+run_in_repo "$EMPTY_LEDGER_REPO" body-a2
 assert_rc 4 "39 incremental-silent body state rc 4"
 assert_err_has "@coderabbitai full review" "39 full-review resolution printed"
 assert_verdict 4 "39 un-maskable exit 4 verdict line"
+
+# HIMMEL-1502/1506: when the current-head review object is the ONLY missing
+# signal, resolved threads + a clean exact-head panel carry the gate. Either
+# unresolved threads or absent panel evidence preserves the prior block.
+run_in_repo "$LEDGER_REPO" body-a2
+assert_rc 0 "39b absent head review object with resolved threads and clean panel is carried"
+assert_out_has "check-ci: review object absent at head sha1 of PR #42; threads resolved; panel carries — HIMMEL-1502/1506 (carried responders=1 models=codex)." "39b exit-4 carry line byte-identical"
+assert_out_has "carried responders=1 models=codex" "39b exit-4 carry evidence surfaced"
+THREADS_OVERRIDE=2
+run_in_repo "$LEDGER_REPO" body-a2
+assert_rc 3 "39c unresolved threads still block despite clean panel evidence"
+assert_err_has "2 unresolved review thread(s)" "39c unresolved-thread reason is unchanged"
+THREADS_OVERRIDE=
+run_in_repo "$DIRTY_LEDGER_REPO" body-a2
+assert_rc 4 "39d a blocking panel finding keeps the absent-review-object arm blocked"
+assert_err_has "@coderabbitai full review" "39d dirty-ledger exit-4 remedy is unchanged"
 
 # 40 — --threads-only now ALSO runs the body gate (previously skipped head
 # binding entirely, S1 was invisible here too): an outside-diff finding
@@ -868,7 +942,7 @@ assert_out_has "all checks green + all review threads resolved" "43 benign shape
 
 # 44 — opt-in escalation posts one full-review request carrying the per-head
 # marker, then a clean review object appears on the immediate bounded re-read.
-run body-a2-escalate --escalate
+run_in_repo "$EMPTY_LEDGER_REPO" body-a2-escalate --escalate
 assert_rc 0 "44 escalation resolves incremental-silent state"
 posts=$(cat "$STUBDIR/comments" 2>/dev/null); posts=${posts:-0}
 if [ "$posts" -eq 1 ]; then pass "44 escalation posts exactly once"; else fail "44 escalation posts exactly once" "posts=$posts want 1"; fi
@@ -881,7 +955,7 @@ fi
 
 # 45 — a retry on the same head sees the exact marker and waits without
 # posting again; the subsequent read can still complete the normal gate.
-run body-a2-marker --escalate
+run_in_repo "$EMPTY_LEDGER_REPO" body-a2-marker --escalate
 assert_rc 0 "45 existing marker still evaluates the refreshed review"
 posts=$(cat "$STUBDIR/comments" 2>/dev/null); posts=${posts:-0}
 if [ "$posts" -eq 0 ]; then pass "45 existing marker suppresses duplicate post"; else fail "45 existing marker suppresses duplicate post" "posts=$posts want 0"; fi
@@ -889,7 +963,7 @@ assert_err_has "already requested" "45 existing marker path is surfaced"
 
 # 46 — bounded escalation never turns a missing review object into success.
 # A zero-second budget makes the timeout immediate and hermetic.
-run body-a2-timeout --escalate
+run_in_repo "$EMPTY_LEDGER_REPO" body-a2-timeout --escalate
 assert_rc 4 "46 escalation timeout rc 4"
 assert_err_has "DO-NOT-MERGE" "46 timeout is loud and merge-blocking"
 assert_verdict 4 "46 timeout prints exit 4 verdict"
@@ -902,21 +976,21 @@ assert_verdict 4 "46 timeout prints exit 4 verdict"
 # the fallen-back 120s poll (HIMMEL-1219).
 ESCALATE_WAIT_OVERRIDE=soon
 ESCALATE_POLL_OVERRIDE=0
-run body-a2-escalate --escalate
+run_in_repo "$EMPTY_LEDGER_REPO" body-a2-escalate --escalate
 assert_rc 0 "47 invalid escalation tuning still evaluates"
 assert_err_has "CR_ESCALATE_WAIT='soon'" "47 invalid wait warns + falls back"
 assert_err_has "CR_ESCALATE_POLL=0 is invalid" "47 zero poll vs positive wait warns + falls back"
 
 # 48 — escalation resolves only unreadability. A refreshed review carrying a
 # real outside-diff finding still flows through the normal rc 3 body gate.
-run body-a2-escalate-outside --escalate
+run_in_repo "$EMPTY_LEDGER_REPO" body-a2-escalate-outside --escalate
 assert_rc 3 "48 escalated outside-diff finding still blocks"
 assert_err_has "outside-diff-range finding" "48 refreshed finding reaches normal evaluation"
 
 # 49 — a full review may also create inline threads after the normal thread
 # snapshot. Escalation must re-run that gate before it can certify success.
 THREADS_OVERRIDE=escalatethread
-run body-a2-escalate --escalate
+run_in_repo "$EMPTY_LEDGER_REPO" body-a2-escalate --escalate
 assert_rc 3 "49 escalated inline finding still blocks"
 assert_err_has "unresolved review thread" "49 full-review thread re-check runs"
 
@@ -924,7 +998,7 @@ assert_err_has "unresolved review thread" "49 full-review thread re-check runs"
 # back before the loop, so the stale-review fixture gets no API-hammering burst.
 ESCALATE_WAIT_OVERRIDE=1
 ESCALATE_POLL_OVERRIDE=0
-run body-a2-timeout --escalate
+run_in_repo "$EMPTY_LEDGER_REPO" body-a2-timeout --escalate
 assert_rc 4 "50 zero escalation poll still times out"
 assert_err_has "CR_ESCALATE_POLL=0 is invalid" "50 zero escalation poll warns + falls back"
 reads=$(cat "$STUBDIR/reviews" 2>/dev/null); reads=${reads:-0}
@@ -941,7 +1015,7 @@ fi
 # case proves 08 reaches a normal rc 4 timeout instead of erroring (HIMMEL-1219).
 ESCALATE_WAIT_OVERRIDE=08
 ESCALATE_POLL_OVERRIDE=0
-run body-a2-timeout --escalate
+run_in_repo "$EMPTY_LEDGER_REPO" body-a2-timeout --escalate
 assert_rc 4 "51 leading-zero wait 08 evaluates (no octal crash)"
 assert_err_has "waiting up to 8s" "51 wait 08 normalized to decimal 8"
 if printf '%s' "$ERR" | grep -F -- "value too great for base" >/dev/null; then
@@ -956,7 +1030,7 @@ fi
 # 7s rather than the literal "007s" (HIMMEL-1219).
 ESCALATE_WAIT_OVERRIDE=007
 ESCALATE_POLL_OVERRIDE=0
-run body-a2-escalate --escalate
+run_in_repo "$EMPTY_LEDGER_REPO" body-a2-escalate --escalate
 assert_rc 0 "52 leading-zero wait 007 still evaluates"
 assert_err_has "waiting up to 7s" "52 wait 007 normalized to decimal 7 (not octal)"
 
@@ -1009,7 +1083,18 @@ else
     pass "57 disarmed gate is silent about CodeRabbit"
 fi
 
+# 58 — HIMMEL-1495 hermeticity canary. This certifier does not consult the
+# armed-session bypass env (ARMAUTOMERGE/CR_MERGE_GATE_OK), so a block fixture
+# STILL blocks (rc 2) with both exported into the suite's env — pinning that
+# insensitivity so a future change wiring either var into check-ci.sh fails
+# HERE (the block-case reads rc 0) rather than failing every block-case open.
+# The startup unset above is the matching defense-in-depth.
+export ARMAUTOMERGE=1 CR_MERGE_GATE_OK=1
+run cr-absent
+assert_rc 2 "58 armed bypass env does not open a block-case (HIMMEL-1495)"
+unset ARMAUTOMERGE CR_MERGE_GATE_OK
+
 echo
 echo "ran $COUNT cases; PASS=$PASS FAIL=$FAIL"
-if [ "$COUNT" -ne 67 ]; then echo "CASE-COUNT MISMATCH: ran $COUNT want 67"; exit 1; fi
+if [ "$COUNT" -ne 76 ]; then echo "CASE-COUNT MISMATCH: ran $COUNT want 76"; exit 1; fi
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Wave 2i

Thirteen tickets, every one adversarially reviewed on the private side
(multi-critic panels + codex adversarial passes, evidence in the private CR
ledger; the two protocol arcs earned 14 and 9 review rounds respectively):

| Ticket | What |
|---|---|
| HIMMEL-1474 | Render liveness: identity-anchored ownership lifecycle for codex adversarial renders — launch handshake, per-record cleanup status, survivor-anchor recovery, no bare-pid signals (14 review rounds) |
| HIMMEL-1509 | Render lease registry: per-branch atomic lease claim, validated sweep (live/stale/unverifiable disposition under a registry lock), kill-ledger + `-FromLedger` orchestrator verb; carries HIMMEL-1496's launch-claim TOCTOU closure (9 review rounds) |
| HIMMEL-1506 | check-ci: every absent-App signal (rate-limit / disabled / unreadable description / absent review object) carries on clean exact-head critic-panel evidence, fail-closed otherwise |
| HIMMEL-1494 | critic-panel: self-appended CR-ledger evidence + `--worktree` mode with empty-diff refusal |
| HIMMEL-1495 | Gate suites self-scrub the armed-session bypass env; hermeticity probes prove block-cases still block |
| HIMMEL-1492 | propagate-public: transform-aware byte-verify + converged-path auto-skip, fail-closed preserved; raw auto-skip candidates are charset-validated before any exclude pathspec is built (injection guard) |
| HIMMEL-1485 | leg-timeline: per-leg critical-path reconstruction (dispatch→land, gate wait/run, wall-clock split) |
| HIMMEL-1463 | Worker lifecycle: pre-arm guard + stale-running reconciler + lock cleanup |
| HIMMEL-1458/1484 | Shell-suite health: hermetic env, documented SKIPs, reship coverage restored |
| HIMMEL-1490 | arm-resume telemetry: measured gap_sec alongside the long_gap flag |
| HIMMEL-1479 | isGlmPeak: UTC+8 weekday check (weekends are 1x) |

Byte-verified against the private range end-to-end by the fail-closed ship
pipeline (transform-aware as of HIMMEL-1492, which ships inside this wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer coordination for concurrent review renders, including stale-session recovery and verified cleanup.
  * Added worktree-aware critic-panel reviews with structured findings, availability records, and ledger support.
  * Added worker reconciliation and a read-only timeline tool for clearer session activity and handover diagnostics.

* **Bug Fixes**
  * Improved protection against terminating unrelated or reused processes.
  * Corrected peak-period detection to exclude weekends and honor UTC+8 boundaries.
  * Strengthened review evidence handling when external signals are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->