### PR TITLE
feat: [HIMMEL-1529][HIMMEL-1539] trust shadow ledger — blind decision recording

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,14 @@ jobs:
         with:
           node-version: '22'
       - run: node --test "scripts/lanes/tests/**/*.test.mjs"
+      # HIMMEL-1529: same shape — a zero-dependency node:test suite outside any
+      # package.json. Listed explicitly because nothing globs for it; an
+      # unlisted suite is a suite nobody runs.
+      #
+      # `ls` first because `node --test` reports zero tests and exits 0 when the
+      # glob matches nothing: a renamed or deleted suite would go green with
+      # nothing executed. `ls` on an unexpanded pattern fails, so the step does.
+      - run: ls scripts/trust/tests/*.test.mjs && node --test "scripts/trust/tests/*.test.mjs"
 
   bun-suites:
     runs-on: ubuntu-latest

--- a/scripts/trust/README.md
+++ b/scripts/trust/README.md
@@ -23,9 +23,11 @@ artefact, and this is the one figure the programme is gated on.
 ## Wiring (operator action — `.claude/settings.json` is deny-listed to agents)
 
 `Edit(**/.claude/settings.json)` is an explicit deny rule, so an agent cannot
-wire this itself. Add these three entries by hand. Nothing else changes, and
-each is a new array element rather than an edit to an existing one, so it
-merges cleanly against in-flight hook-wiring branches.
+wire this itself. Add these **six** entries by hand — three appended to existing
+arrays (`PreToolUse`, `PostToolUse`) or added as `Notification`, plus the three
+outcome/permission keys HIMMEL-1539 added. Nothing else changes, and each is a
+new array element or a new top-level key rather than an edit to an existing one,
+so it merges cleanly against in-flight hook-wiring branches.
 
 `PreToolUse` — append at the end of the array:
 
@@ -62,6 +64,73 @@ himmel-ops plugin owns the existing Notification hook and is untouched):
 ]
 ```
 
+`PostToolUseFailure`, `PermissionDenied`, `PermissionRequest` — three more new
+top-level keys (HIMMEL-1539). Without them a failed call and a denied call both
+land in `unresolved`, which corrupts the outcome data by construction:
+
+```json
+"PostToolUseFailure": [
+  {
+    "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit",
+    "hooks": [
+      { "type": "command", "command": "node \"$CLAUDE_PROJECT_DIR/scripts/trust/shadow-ledger.mjs\" postfail", "timeout": 10 }
+    ]
+  }
+],
+"PermissionDenied": [
+  {
+    "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit",
+    "hooks": [
+      { "type": "command", "command": "node \"$CLAUDE_PROJECT_DIR/scripts/trust/shadow-ledger.mjs\" denied", "timeout": 10 }
+    ]
+  }
+],
+"PermissionRequest": [
+  {
+    "hooks": [
+      { "type": "command", "command": "node \"$CLAUDE_PROJECT_DIR/scripts/trust/shadow-ledger.mjs\" permreq", "timeout": 10 }
+    ]
+  }
+]
+```
+
+**Matchers: two of the three carry one, `PermissionRequest` deliberately does
+not.** Verified against the Claude Code hook reference — `PostToolUseFailure`,
+`PermissionRequest` and `PermissionDenied` are all tool events whose matcher
+filters on tool name, exactly like `PreToolUse`/`PostToolUse`. So `postfail` and
+`denied` carry the same matcher as the `PostToolUse` block above. `permreq` is
+left unmatched ON PURPOSE: an approval interrupt counts whatever tool raised it,
+and that row carries no request payload to classify. The recorder also filters
+internally (`postfail`/`denied` record only `RECORDED_TOOLS`), so the matcher is
+belt-and-braces there rather than the only guard.
+
+**`PermissionDenied` does NOT mean "every denial".** The hook reference is
+explicit that it fires *when a tool call is denied by the auto mode classifier*.
+A manual operator denial, a `deny` permission rule, and a `PreToolUse` block do
+**not** raise it. The recorded verdict is therefore named
+`denied_auto_classifier`, and `report` labels it *AUTO-MODE CLASSIFIER denials
+ONLY* — those other denial sources still land in `unresolved`. Naming it plain
+`denied` would have been the same mistake this whole ticket is about: a partial
+signal wearing a name that reads as complete coverage.
+
+`PermissionRequest` fires when a tool call **needs a permission decision** — and
+that is not the same as a human being interrupted. In an armed or otherwise
+unattended session the event still fires with nobody present; this programme
+measured that directly (W0 probe P5: a hook returning `ask` hung for 902 s on a
+dialog no one could answer). So `report` calls the figure permission-request
+**events**, never a direct interrupt count — labelling it otherwise would
+inflate the gate number exactly in the unattended runs this harness does most.
+
+It is recorded and reported **alongside** the Notification-derived count, not
+swapped in as the gate number: two independent estimators of one quantity are
+how you find out which is right, and silently switching would replace a measured
+figure with an unvalidated one while destroying the comparison that would have
+settled it. HIMMEL-1539 raised this as a design input for HIMMEL-1530;
+collecting both is what makes that decision evidence-based. `permission_mode` is
+persisted on the row as the only interactivity-adjacent signal available — it is
+**stored, not interpreted**, and no count splits on it until that distinction
+can actually be shown.
+
 The commands invoke `node` directly rather than `bash`, so they are not exposed
 to the Windows bash-resolution failure behind HIMMEL-1516/1526 (bare `bash`
 resolving to the system32 WSL stub or the zero-byte WindowsApps alias).
@@ -78,12 +147,40 @@ and the whole claim of the ticket is that it is not one. Ten seconds is well
 above the bounded lock budget and well below anything an operator would sit
 through.
 
-**One thing this wiring does NOT observe.** `PostToolUseFailure` and
-`PermissionDenied` are real hook events carrying `tool_use_id`, and they are not
-wired here, so a failed call and a denied call both land in `unresolved` rather
-than as distinct outcomes. That is a known limitation of R0, not an oversight —
-tracked in HIMMEL-1539, together with the recorder-health gaps. Read the
-`unresolved` count with that in mind.
+**What `unresolved` still means.** With all six blocks wired it is a call with no
+terminal outcome observed — stranded or crashed. If the failure/denial keys are
+NOT pasted, denials and failures fall back into it. The report cannot tell a
+wired-and-quiet harness from an unwired one, so its wording keeps both readings.
+
+**When the recorder loses an event, `report` says so.** Lock exhaustion and
+failed appends are recorded to `drops.jsonl`, a file deliberately outside the
+ledger's lock and hash chain — the events it holds are exactly the ones the
+ledger could not hold. **Any recorded drop suppresses the weekly rate**, and
+drops are deliberately NOT expired by timestamp — two review rounds showed a
+clock cannot be trusted to expire a known loss (a non-string `ts` escaped the
+window, and a backward clock step re-dated an in-window failure as old, both
+restoring a confident rate over missing events). An abandoned torn tail
+suppresses it too.
+
+There is deliberately **no acknowledgement path that restores the rate**.
+Deleting `drops.jsonl` does not make the lost event exist: the window still
+covers a gap, so the rate would return over data known to be incomplete.
+Restoring one honestly requires a durable `valid_since` checkpoint that moves
+the observation window past the loss — tracked in **HIMMEL-1547**, together with
+the collector-liveness heartbeat it shares machinery with. The hash chain can only attest rows that landed; it
+is structurally blind to rows that never did, and before HIMMEL-1539 that
+blindness produced an understated rate that looked exactly like a quiet week.
+
+**The residual blind spot, stated rather than papered over.** `drops.jsonl`
+lives on the same volume as the ledger, so a volume-wide failure — ENOSPC, inode
+exhaustion, a directory permission change — can lose the ledger event *and* its
+drop row together. Recovery then leaves a chain that validates cleanly over an
+incomplete history. This is not fully solvable by a second file on the same
+disk, so it is documented instead of claimed away. What IS handled: a health
+channel that exists but cannot be READ (EACCES/EIO) counts as a drop and
+suppresses the rate, rather than reading as "no drops" — unknown must never
+present as clean. Set `HIMMEL_TRUST_LEDGER_DIR` to a volume you monitor if this
+residual matters for your deployment.
 
 ## Where the ledger lives
 

--- a/scripts/trust/README.md
+++ b/scripts/trust/README.md
@@ -1,0 +1,198 @@
+# scripts/trust — the R0 shadow ledger (HIMMEL-1529)
+
+An append-only, hash-chained record of approval-shaped decisions. **Zero
+behaviour change**: it emits no permission decision, so adding or removing it
+moves nothing about how prompts flow. It only records.
+
+## The number this exists to produce
+
+**Approval-interrupts per week.** Nobody currently knows it, and it is the gate
+on whether the rest of the trust programme is worth building. Below roughly ten
+per week the small version is not the first increment — it is the end state, and
+the graduated ladder should never be built.
+
+```sh
+node scripts/trust/shadow-ledger.mjs report
+node scripts/trust/shadow-ledger.mjs report --days 7 --json
+```
+
+`report` refuses to state a weekly rate from a window shorter than a day. A
+twenty-minute sample scaled up yields a confident six-figure number that is pure
+artefact, and this is the one figure the programme is gated on.
+
+## Wiring (operator action — `.claude/settings.json` is deny-listed to agents)
+
+`Edit(**/.claude/settings.json)` is an explicit deny rule, so an agent cannot
+wire this itself. Add these three entries by hand. Nothing else changes, and
+each is a new array element rather than an edit to an existing one, so it
+merges cleanly against in-flight hook-wiring branches.
+
+`PreToolUse` — append at the end of the array:
+
+```json
+{
+  "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit",
+  "hooks": [
+    { "type": "command", "command": "node \"$CLAUDE_PROJECT_DIR/scripts/trust/shadow-ledger.mjs\" pre", "timeout": 10 }
+  ]
+}
+```
+
+`PostToolUse` — append at the end of the array:
+
+```json
+{
+  "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit",
+  "hooks": [
+    { "type": "command", "command": "node \"$CLAUDE_PROJECT_DIR/scripts/trust/shadow-ledger.mjs\" post", "timeout": 10 }
+  ]
+}
+```
+
+`Notification` — a new top-level hook key (settings.json has none today; the
+himmel-ops plugin owns the existing Notification hook and is untouched):
+
+```json
+"Notification": [
+  {
+    "hooks": [
+      { "type": "command", "command": "node \"$CLAUDE_PROJECT_DIR/scripts/trust/shadow-ledger.mjs\" notify", "timeout": 10 }
+    ]
+  }
+]
+```
+
+The commands invoke `node` directly rather than `bash`, so they are not exposed
+to the Windows bash-resolution failure behind HIMMEL-1516/1526 (bare `bash`
+resolving to the system32 WSL stub or the zero-byte WindowsApps alias).
+`$CLAUDE_PROJECT_DIR` is quoted, as every existing hook command in
+`.claude/settings.json` quotes it: an unquoted expansion word-splits on a
+project path containing a space, and the hook then fails open — losing
+observations silently, which is the one failure mode a measurement tool must
+not have.
+
+`"timeout": 10` is not decoration. A command hook **defaults to 600 seconds**,
+so a stalled home-directory syscall in the `PreToolUse` hook would hold every
+matching tool call for ten minutes — which would make this a behaviour change,
+and the whole claim of the ticket is that it is not one. Ten seconds is well
+above the bounded lock budget and well below anything an operator would sit
+through.
+
+**One thing this wiring does NOT observe.** `PostToolUseFailure` and
+`PermissionDenied` are real hook events carrying `tool_use_id`, and they are not
+wired here, so a failed call and a denied call both land in `unresolved` rather
+than as distinct outcomes. That is a known limitation of R0, not an oversight —
+tracked in HIMMEL-1539, together with the recorder-health gaps. Read the
+`unresolved` count with that in mind.
+
+## Where the ledger lives
+
+`~/.claude/himmel/trust/ledger.jsonl`, overridable with
+`HIMMEL_TRUST_LEDGER_DIR`. Outside the repo on purpose: it is machine-local
+measurement, not source.
+
+## Record shape
+
+| field | meaning |
+|---|---|
+| `ts` | ISO timestamp |
+| `kind` | `request` (PreToolUse) · `outcome` (PostToolUse) · `notification` (Notification) |
+| `ref` | joins a request to its outcome — the harness's `tool_use_id`, or a `d:`-prefixed derived hash when absent |
+| `class` | verb × target-pattern, e.g. `bash:git push`, `write:.sh` |
+| `target` / `target_hash` | coarse handle + sha256 of the full request |
+| `requester_lane` / `lane_config_hash` | who asked, under which lane registry |
+| `shadow_verdict` | the blind verdict — `allow` · `deny` · `abstain` |
+| `actual_verdict` | `executed`, stamped by the later event |
+| `notification_type` | recorded verbatim; classified at report time, not here |
+| `prev_hash` / `hash` | the chain |
+
+Commands and file contents are **not** stored — only the coarse class and a
+hash. A ledger that holds transcripts becomes an unread lake; this one holds
+decisions and outcomes and points at sessions.
+
+The subcommand half of a Bash class is kept only when the token itself is a
+**known subcommand of a known family** (`git push`, `npm run`, `docker build`).
+Validating the family is not enough: runner commands like `node`, `npx`, `bun`
+and `dotnet` take a path or a package as their second token, so
+`npx https://alice:TOKEN@github.com/acme/x` would have persisted a whole
+credential-bearing URL. Validating the token means an unrecognised word — which
+is exactly where secrets live — is always dropped. Runner families are absent
+from the table entirely, and leading `VAR=val` assignments are stripped for the
+same reason.
+
+`report` also refuses to publish a rate over a **damaged ledger**. It counts
+unreadable rows (an unterminated *final* line is a normal in-flight append; any
+other is real damage) and verifies every chain link, because silently skipping a
+torn row and then printing a confident number yields a plausible, understated
+result with nothing to signal it. This is the read path using the chain, not
+the standalone verification tooling the ticket defers — it is what makes that
+deferral safe.
+
+## Four things not to get wrong
+
+**1. Blind means written before the prompt is routed.** The record is chained
+and flushed by the same hook process, before it exits toward the permission
+layer. If the operator could see the harness's guess while deciding, any
+agreement rate would measure anchoring rather than competence — and the evidence
+would be worthless in a way that is invisible when it is worthless. Never move
+the write after the decision, and never surface `shadow_verdict` in an
+operator-visible string. Note that a hook's `permissionDecisionReason` **is**
+rendered verbatim in operator-visible UI; this hook emits no such field.
+
+**2. Never `ask`.** Under `defaultMode: auto` nothing normally prompts, so a
+silent hook is harmless — but a hook returning `ask` reintroduces the dialog
+auto mode exists to remove, and in an armed session that dialog is unanswerable
+and unbounded (measured: 902.5s, still blocked when killed; not an auto-deny).
+This hook defers by emitting nothing at all, and a source-text test pins that
+`permissionDecision`, `ask` and `hookSpecificOutput` appear nowhere in the file.
+
+**3. Not every notification is an approval interrupt.** Notification also fires
+for idle-wait timeouts and elicitation dialogs (see
+`scripts/hooks/telegram-notification.sh`, which documents the same surface), so
+counting them all would inflate the gate number. The hook records **every**
+notification with its type and the classification happens in `report` — because
+a hook-side filter fails in the dangerous direction: if the type vocabulary
+ever changes, it would silently record nothing and the gate number would read
+zero, indistinguishable from a genuinely quiet week. Filtering at report time
+means an unrecognised type appears in the `other notifications` breakdown
+instead of vanishing, and old rows can be reclassified without re-collecting.
+
+**4. A missing outcome row is not a denial.** A Pre/Post pair alone cannot tell
+denied from stranded from crashed, so `report` counts those rows as
+`unresolved` and says so, rather than folding them into a denial count. The
+`interrupt` rows are what make the gate number directly observable instead of
+inferred.
+
+## What the shadow verdict is, and is not
+
+A small deterministic rule engine — **not** a model judgement, because a hook
+cannot call a model and must not try. It answers a narrow question: is this
+request provably safe, provably refused, or contested? Contested gets `abstain`,
+which is the honest answer for exactly the cases a trust ladder would have to
+adjudicate.
+
+It deliberately does **not** re-implement `scripts/hooks/auto-approve-safe-bash.sh`.
+That hook is the production gate and owns its own edge cases; a second copy here
+would drift and the ledger would end up measuring the drift.
+
+So: the **interrupt count is the product**. Agreement rate between shadow and
+actual is a secondary output, is dominated by the abstain class, and `report`
+prints that caveat next to the number.
+
+## Deliberately deferred
+
+Chain **verification** tooling and keyed signatures. Chained writes are one line
+per record and cheap; a verifier is not needed while the threat model is model
+drift and confusion rather than an adversary with filesystem access. Signing, if
+it ever lands, is done by the launcher/hook process on behalf of the dispatch
+identity — never by the agent, whose context is readable and exfiltratable.
+
+Lane attribution is best-effort: no dispatcher exports a lane marker today, so
+most rows read `primary`. It improves the day `spawn-*` export `HIMMEL_LANE`;
+it is not guessed from cwd, because a worktree does not imply a lane.
+
+## Tests
+
+```sh
+node --test "scripts/trust/tests/*.test.mjs"
+```

--- a/scripts/trust/shadow-ledger.mjs
+++ b/scripts/trust/shadow-ledger.mjs
@@ -1,0 +1,934 @@
+#!/usr/bin/env node
+// shadow-ledger.mjs — HIMMEL-1529 R0: blind decision recording, zero behaviour change.
+//
+// WHAT THIS IS
+// An append-only, hash-chained decision record written from Claude Code hooks.
+// For every approval-shaped decision point it records the request (class,
+// target, requester lane, lane-config hash) and this harness's OWN blind
+// verdict, then DEFERS — it emits no permissionDecision, so nothing about the
+// prompt flow moves. Removing it changes no behaviour; adding it changes no
+// behaviour. It only records.
+//
+// WHY "BLIND" IS THE WHOLE POINT
+// The shadow verdict is computed, hash-chained and flushed to disk BEFORE this
+// process exits and the request continues to the permission layer. Ordering is
+// mechanical, not conventional. If the operator could see the harness's guess
+// while deciding, any agreement rate would measure anchoring rather than
+// competence — and the evidence would be worthless in a way that is invisible
+// when it is worthless. Do not "optimise" the write to happen after the
+// decision, and do not surface shadow_verdict in any operator-facing string.
+//
+// WHAT THE SHADOW VERDICT IS — AND IS NOT (read before trusting a number)
+// It is a small, deterministic rule engine (see shadowVerdict below). It is NOT
+// a model judgement — a hook cannot call a model, and must not try. It answers
+// a narrow question: "is this request provably safe / provably refused under
+// the harness's own current rules, or is it contested?" Contested requests get
+// `abstain`, and abstain is the honest answer for exactly the cases a trust
+// ladder would have to adjudicate.
+//
+// Consequence, stated plainly so nobody over-reads the output: the PRIMARY
+// product of this ledger is the INTERRUPT COUNT — approval-interrupts per week,
+// the number HIMMEL-1529 exists to produce and which nobody currently knows.
+// Agreement rate between shadow and actual is a SECONDARY output and is
+// dominated by the abstain class; `report` prints it with that caveat attached.
+//
+// WHO SIGNS
+// The hook process, on behalf of the dispatch identity — never the agent. A
+// model cannot hold a key: its context is readable and exfiltratable. In R0
+// "signing" is the hash chain only; keyed signatures and chain-verification
+// tooling are deliberately deferred (the threat model here is model drift and
+// confusion, not an adversary with filesystem access).
+//
+// FAIL-OPEN, ALWAYS
+// This hook must never block, deny, delay or ASK. A hook that returns `ask`
+// reintroduces the permission dialog that `defaultMode: auto` exists to remove,
+// and in an armed session that dialog is unanswerable and unbounded (measured:
+// 902.5s, still blocked when killed). Every failure path here exits 0 with
+// empty stdout. There is no code path in this file that prints a
+// permissionDecision.
+//
+// PRIVACY
+// Commands and file contents are NOT stored. `target` keeps a coarse handle
+// (verb + subverb, or a repo-relative path) and `target_hash` a sha256 of the
+// full request, so identical requests correlate without the ledger becoming a
+// transcript lake. Records point at sessions; they do not embed them.
+//
+// USAGE (hooks wire these; see scripts/trust/README.md)
+//   node shadow-ledger.mjs pre      < PreToolUse payload
+//   node shadow-ledger.mjs post     < PostToolUse payload
+//   node shadow-ledger.mjs notify   < Notification payload
+//   node shadow-ledger.mjs report [--days N] [--json]
+
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const GENESIS = '0'.repeat(64);
+const LOCK_TRIES = 40;
+const LOCK_WAIT_MS = 5;
+// Below this, `report` shows the raw count and refuses to state a weekly rate.
+const MIN_EXTRAPOLATION_DAYS = 1;
+// A lock older than this cannot be held by a live writer (the critical section
+// is sub-millisecond) — see breakStaleLock.
+const STALE_LOCK_MS = 5000;
+// Initial tail-read window for lastRecord; grows until a record parses.
+const TAIL_WINDOW_BYTES = 16384;
+
+// --- locations ---------------------------------------------------------------
+
+export function ledgerDir() {
+  const override = process.env.HIMMEL_TRUST_LEDGER_DIR;
+  if (override && override.trim()) return override.trim();
+  return path.join(os.homedir(), '.claude', 'himmel', 'trust');
+}
+
+export function ledgerPath() {
+  return path.join(ledgerDir(), 'ledger.jsonl');
+}
+
+// --- hashing -----------------------------------------------------------------
+
+const sha256 = (s) => createHash('sha256').update(s, 'utf8').digest('hex');
+
+// Canonical form: keys sorted, `hash` excluded. Two records with the same
+// content always hash the same regardless of insertion order.
+export function canonical(record) {
+  const out = {};
+  for (const k of Object.keys(record).sort()) {
+    if (k === 'hash') continue;
+    out[k] = record[k];
+  }
+  return JSON.stringify(out);
+}
+
+export function chainHash(prevHash, record) {
+  return sha256(`${prevHash}\n${canonical(record)}`);
+}
+
+// --- ledger IO ---------------------------------------------------------------
+
+// Last complete line without reading the whole file. The ledger is expected to
+// stay small (one line per decision), but O(file) per tool call is a latency
+// bug waiting to happen, so read a tail window instead.
+export function lastRecord(file = ledgerPath()) {
+  let fd;
+  try {
+    fd = fs.openSync(file, 'r');
+  } catch {
+    return null;
+  }
+  try {
+    const size = fs.fstatSync(fd).size;
+    if (size === 0) return null;
+    // Grow the tail window until a record parses or the whole file is read.
+    // A fixed window silently FORKS the chain: if the last record is larger
+    // than the window, its head is clipped, it fails to parse, and we fall
+    // back to an EARLIER record — so the next append chains to a stale
+    // prev_hash and the break is invisible. Correctness cannot depend on
+    // records staying small.
+    for (let window = Math.min(size, TAIL_WINDOW_BYTES); ; window = Math.min(size, window * 4)) {
+      const buf = Buffer.alloc(window);
+      fs.readSync(fd, buf, 0, window, size - window);
+      const lines = buf.toString('utf8').split('\n').filter((l) => l.trim());
+      // Walk backwards: the FIRST line may be clipped, the last is the newest.
+      for (let i = lines.length - 1; i >= 0; i--) {
+        try {
+          return JSON.parse(lines[i]);
+        } catch {
+          /* keep walking */
+        }
+      }
+      if (window >= size) return null; // whole file read, nothing parses
+    }
+  } catch {
+    return null;
+  } finally {
+    try {
+      fs.closeSync(fd);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// Exclusive-create lock. Several sessions append concurrently; without this two
+// records can claim the same prev_hash and silently fork the chain. Bounded
+// retry, then give up and DROP the record — a missing row is recoverable, a
+// blocked tool call is not.
+function pidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return e.code === 'EPERM'; // exists but owned by another user
+  }
+}
+
+// A lock holder that dies between open and unlink (SIGKILL, a killed hook, a
+// crashed session) leaves the file behind forever — and without reclamation
+// that is TERMINAL: every later call burns its retries and drops its record,
+// so recording stops permanently and silently, which is the worst failure this
+// file can have.
+//
+// Age alone is NOT sufficient evidence of death: a writer that is merely slow,
+// SIGSTOPped, or resuming from hibernation would lose exclusivity and the two
+// writers would fork the chain — trading a loud wedge for silent corruption,
+// which is the worse bargain. So the lock records its owner pid and is broken
+// only when the pid is genuinely gone AND the file is older than STALE_LOCK_MS.
+//
+// The read→unlink gap is a real TOCTOU: another process could reclaim and
+// re-create the lock in between, and we would delete ITS lock. Re-reading the
+// content immediately before unlinking narrows that to the window where a
+// reclaimer writes an identical pid+timestamp, which cannot happen (the pid is
+// gone and the stamp is fresh). It is a narrowing, not an atomicity proof —
+// stated plainly rather than claimed away.
+function breakStaleLock(lock) {
+  try {
+    const before = fs.readFileSync(lock, 'utf8');
+    const [pidStr, tsStr] = before.split(/\s+/);
+    const pid = Number(pidStr);
+    const stamped = Number(tsStr);
+    const age = Date.now() - (Number.isFinite(stamped) ? stamped : fs.statSync(lock).mtimeMs);
+    if (age <= STALE_LOCK_MS) return;
+    if (Number.isFinite(pid) && pid > 0 && pidAlive(pid)) return; // slow, not dead
+    if (fs.readFileSync(lock, 'utf8') !== before) return;         // someone reclaimed it
+    fs.unlinkSync(lock);
+  } catch {
+    /* vanished or unreadable — the next openSync decides */
+  }
+}
+
+function withLock(fn) {
+  const lock = path.join(ledgerDir(), '.ledger.lock');
+  for (let i = 0; i < LOCK_TRIES; i++) {
+    let fd;
+    let token;
+    try {
+      fd = fs.openSync(lock, 'wx');
+      // Stamp ownership so a later reclaimer can prove death rather than infer
+      // it from age. Written inside the exclusive create, before any work.
+      token = `${process.pid} ${Date.now()}`;
+      fs.writeSync(fd, token);
+    } catch {
+      breakStaleLock(lock);
+      // Busy-wait without a timer: hooks are synchronous and this is <200ms
+      // worst case. Atomics.wait needs a SharedArrayBuffer view.
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, LOCK_WAIT_MS);
+      continue;
+    }
+    try {
+      return fn();
+    } finally {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+      try {
+        // Release ONLY a lock this writer still owns. An unconditional unlink
+        // deletes whatever is at the pathname — including a replacement lock a
+        // reclaimer took after deciding we were dead, which would put two
+        // writers in the critical section and fork the chain.
+        if (fs.readFileSync(lock, 'utf8') === token) fs.unlinkSync(lock);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  return null;
+}
+
+export function append(partial) {
+  return withLock(() => {
+    const prev = lastRecord();
+    const prev_hash = prev && typeof prev.hash === 'string' ? prev.hash : GENESIS;
+    const record = { ...partial, prev_hash };
+    record.hash = chainHash(prev_hash, record);
+    // Heal a torn final line before appending. Without this, a record written
+    // after an interrupted append is GLUED onto the partial line — so the
+    // damage swallows the new record too, and a recoverable one-line loss
+    // becomes an ongoing one. `lastRecord` already tolerates the torn line; the
+    // write path has to as well.
+    let prefix = '';
+    try {
+      const size = fs.statSync(ledgerPath()).size;
+      if (size > 0) {
+        const fd = fs.openSync(ledgerPath(), 'r');
+        const tail = Buffer.alloc(1);
+        fs.readSync(fd, tail, 0, 1, size - 1);
+        fs.closeSync(fd);
+        if (tail.toString('utf8') !== '\n') prefix = '\n';
+      }
+    } catch {
+      /* no file yet, or unreadable — the append below decides */
+    }
+    fs.appendFileSync(ledgerPath(), `${prefix}${JSON.stringify(record)}\n`, 'utf8');
+    return record;
+  });
+}
+
+// --- request classification --------------------------------------------------
+
+// Tools that can execute or mutate. Read/Grep/Glob never reach the permission
+// layer in this harness, so recording them would bury the signal in noise —
+// the "unread lake" failure the ticket warns about.
+export const RECORDED_TOOLS = ['Bash', 'Edit', 'Write', 'MultiEdit', 'NotebookEdit'];
+
+// Mirrors auto-approve-safe-bash.sh's read-only set. Several of these have a
+// write-capable or exec-capable flag (`sort -o`, `find -exec`, `xxd -r`) and
+// are gated by hasWriteFlag below — the same pairing the production hook uses.
+// Keeping the sets aligned is the point: a shadow verdict that disagrees with
+// the production gate on the same command measures its own drift.
+const READ_ONLY_BINS = new Set([
+  'cat', 'tac', 'head', 'tail', 'nl', 'wc', 'cut', 'tr', 'sort', 'uniq', 'comm',
+  'grep', 'egrep', 'fgrep', 'rg', 'jq', 'file', 'stat', 'ls', 'tree', 'du', 'df',
+  'realpath', 'readlink', 'basename', 'dirname', 'pwd', 'echo', 'printf', 'date',
+  'seq', 'true', 'false', 'which', 'type', 'printenv', 'diff', 'cmp',
+  'sha256sum', 'md5sum', 'cd', 'find', 'xxd', 'od', 'hexdump', 'strings', 'base64',
+]);
+
+const GIT_READ_SUBCMDS = new Set([
+  'status', 'log', 'diff', 'show', 'rev-parse', 'rev-list', 'describe', 'blame',
+  'shortlog', 'ls-files', 'ls-tree', 'cat-file', 'for-each-ref', 'merge-base',
+  'show-ref', 'version',
+]);
+
+// Per-family VALIDATED subcommand sets. The second token is kept only when it
+// is a known subcommand of that family — never merely because the family is
+// recognised.
+//
+// A family allowlist alone was not enough, and the gap is instructive: runner
+// commands like `node`, `npx`, `bun` and `dotnet` take a PATH or a PACKAGE as
+// their second token, not a verb. `npx https://alice:TOKEN@github.com/acme/x`
+// would have persisted the whole credential-bearing URL, and
+// `node /home/alice/clients/acme/deploy.mjs` a private path. Validating the
+// token itself is the boundary: anything not on the list is dropped, so an
+// unrecognised token — which is exactly where secrets live — can never land in
+// the ledger. Runner families are therefore absent entirely: verb-only.
+const SUBVERB_FAMILIES = new Map([
+  ['git', new Set(['status', 'log', 'diff', 'show', 'add', 'commit', 'push', 'pull',
+    'fetch', 'merge', 'rebase', 'checkout', 'switch', 'branch', 'tag', 'stash',
+    'reset', 'clean', 'clone', 'remote', 'worktree', 'restore', 'cherry-pick',
+    'revert', 'rev-parse', 'ls-files', 'blame', 'apply', 'bisect', 'config'])],
+  ['gh', new Set(['pr', 'issue', 'repo', 'run', 'workflow', 'release', 'api',
+    'auth', 'label', 'gist', 'search', 'cache', 'secret'])],
+  ['npm', new Set(['run', 'install', 'ci', 'test', 'publish', 'audit', 'exec',
+    'link', 'update', 'outdated', 'ls', 'pack', 'version'])],
+  ['pnpm', new Set(['run', 'install', 'add', 'test', 'exec', 'update', 'publish'])],
+  ['yarn', new Set(['run', 'install', 'add', 'test', 'publish', 'upgrade'])],
+  ['docker', new Set(['build', 'run', 'ps', 'exec', 'compose', 'images', 'pull',
+    'push', 'logs', 'stop', 'start', 'rm', 'rmi', 'inspect', 'volume', 'network'])],
+  ['cargo', new Set(['build', 'test', 'run', 'check', 'clippy', 'fmt', 'add',
+    'publish', 'update', 'bench', 'doc'])],
+  ['kubectl', new Set(['get', 'apply', 'delete', 'describe', 'logs', 'exec',
+    'rollout', 'scale', 'port-forward', 'config'])],
+  ['terraform', new Set(['init', 'plan', 'apply', 'destroy', 'validate', 'fmt', 'show'])],
+  ['systemctl', new Set(['status', 'start', 'stop', 'restart', 'enable', 'disable',
+    'reload', 'list-units'])],
+]);
+
+// A bare command name. Deliberately narrow — see the verb check in `classify`.
+const PLAIN_COMMAND = /^[A-Za-z0-9._+-]+$/;
+
+// verb x target-pattern. Coarse on purpose: the class is what gets counted, so
+// it has to be stable across sessions and free of one-off detail.
+export function classify(toolName, toolInput = {}) {
+  if (toolName === 'Bash') {
+    const cmd = String(toolInput.command ?? '');
+    const words = cmd.trim().split(/\s+/).filter(Boolean);
+    // Drop leading VAR=val assignments so `FOO=1 git push` classifies as git —
+    // and never let the assignment itself (which holds a value) become the verb.
+    let i = 0;
+    while (i < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words[i])) i++;
+    const raw = words[i] ?? '';
+    // Basename only: `/usr/local/bin/git` and `git` are the same class, and an
+    // absolute path can itself carry a revealing directory layout.
+    const base = raw ? path.basename(raw) : '';
+    // The verb is persisted VERBATIM, so it has to BE a plain command name.
+    // Whitespace splitting cannot see a quoted assignment VALUE that contains a
+    // space: `TOKEN='x SECRET123' git status` splits to `TOKEN='x` /
+    // `SECRET123'` / `git`, the assignment loop stops at the second fragment,
+    // and the SECRET became the verb — written to the ledger in cleartext.
+    // The subcommand half is allowlist-validated for exactly this reason; the
+    // verb half was not. An unrecognisable verb is dropped to `unknown` and only
+    // the hash is kept, because ambiguity is precisely where secrets live.
+    const verb = PLAIN_COMMAND.test(base) ? base : '';
+    if (base && !verb) {
+      return { class: 'bash:unknown', target: 'unknown', target_hash: sha256(cmd) };
+    }
+    const next = words[i + 1];
+    const known = SUBVERB_FAMILIES.get(verb);
+    const sub = known && next && known.has(next) ? next : '';
+    const target = [verb, sub].filter(Boolean).join(' ');
+    return { class: `bash:${target || 'empty'}`, target, target_hash: sha256(cmd) };
+  }
+  // Extension only — NOT the parent directory. A directory basename leaks the
+  // same class of thing a command argument does: client, project and customer
+  // names (`/work/clients/AcmeCorp/x.ts`). The privacy promise has to hold on
+  // the file side too, and `target_hash` still distinguishes individual paths
+  // for correlation without naming any of them.
+  const file = String(toolInput.file_path ?? toolInput.notebook_path ?? '');
+  const ext = path.extname(file) || '(none)';
+  return {
+    class: `${toolName.toLowerCase()}:${ext}`,
+    target: ext,
+    target_hash: sha256(file),
+  };
+}
+
+// --- the blind verdict -------------------------------------------------------
+
+// One definition of "this path is git metadata", shared by the file-tool branch
+// and the redirect branch. Two copies drifted once already: the redirect copy
+// only matched a cwd-relative `.git/`, so the absolute form was never denied.
+// A trailing `.git` with no separator is the worktree POINTER FILE — rewriting
+// it repoints the worktree at another repository, the same refusal class.
+const GIT_METADATA_PATH = /(^|[\\/])\.git([\\/]|$)/;
+// The word after `>` or `>>`, ending at whitespace or a control operator.
+// `&\d+` is matched first and deliberately: there the `&` belongs to the target
+// (fd duplication, `2>&1`), everywhere else it separates commands.
+const REDIRECT_TARGET = />>?\s*(&\d+|[^\s;|&]*)/g;
+
+// Deliberately small and deliberately NOT a re-implementation of
+// auto-approve-safe-bash.sh. That hook is the production gate and owns its own
+// 486 lines of edge cases; duplicating them here would create two rule sets that
+// drift apart and a ledger that measures the drift. This answers the narrower
+// question described in the file header, and says `abstain` whenever it is not
+// certain. Abstain is a real answer, not a failure.
+export function shadowVerdict(toolName, toolInput = {}) {
+  if (toolName !== 'Bash') {
+    // A write into .git/ is the ONE provable refusal here. Writes elsewhere —
+    // including outside the repo — are ordinary (scratchpads, temp dirs), so
+    // they are contested, not denied. Claiming more than this in the comment
+    // would describe a rule the code does not implement, and a shadow verdict
+    // is only worth what its stated basis is.
+    const file = String(toolInput.file_path ?? toolInput.notebook_path ?? '');
+    if (GIT_METADATA_PATH.test(file)) return 'deny';
+    return 'abstain';
+  }
+
+  const cmd = String(toolInput.command ?? '');
+  if (!cmd.trim()) return 'abstain';
+
+  // Everything below that reads STRUCTURE — where a segment ends, where a
+  // redirect points — reads it off a QUOTE-MASKED copy, so a separator or a `>`
+  // inside a quoted argument is the literal text it is.
+  const masked = maskQuoted(cmd);
+
+  // A bare `&` is a real command separator: in `ls & rm file` the `rm` runs, so
+  // treating the line as one `ls` segment produced a false `allow` — the most
+  // damaging error this function can make. Excluded via lookaround are the
+  // forms where `&` is part of a redirect (`2>&1`, `>&2`, `&>file`) or the
+  // logical `&&`, both of which must stay attached to their segment.
+  //
+  // The separators are LOCATED on `masked` and the text is SLICED from `cmd`:
+  // splitting the raw string made `echo "x && git push --force origin main"`
+  // two segments, the second of which runs `git push --force` — a false `deny`
+  // on a line that runs `echo`. Segment CONTENT stays raw so argument matching
+  // below is unchanged; only the boundaries come from the masked copy.
+  const spans = [];
+  let cut = 0;
+  for (const sep of masked.matchAll(/\|\||&&|[|;\n]|(?<![<>&])&(?![&>])/g)) {
+    spans.push(cmd.slice(cut, sep.index));
+    cut = sep.index + sep[0].length;
+  }
+  spans.push(cmd.slice(cut));
+  const segments = spans.map((s) => s.trim()).filter(Boolean);
+  if (!segments.length) return 'abstain';
+
+  // Tokenise each segment down to the binary it actually runs, so both the deny
+  // and the allow rules see argv rather than raw text.
+  const parsed = segments.map((seg) => {
+    const words = seg.split(/\s+/).filter(Boolean);
+    let i = 0;
+    let unsafeEnv = false;
+    while (i < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words[i])) {
+      // Only locale/timezone assignments are innocuous. LD_PRELOAD,
+      // GIT_EXTERNAL_DIFF, BASH_ENV, NODE_OPTIONS, PAGER and friends turn a
+      // "read" command into arbitrary execution — `LD_PRELOAD=/tmp/evil.so ls`
+      // is not `ls`. auto-approve-safe-bash.sh takes exactly this stance, and a
+      // shadow verdict that disagrees with the production gate on the same
+      // command is measuring its own drift. Allowlist, because the dangerous
+      // set is open-ended.
+      if (!/^(LANG|LANGUAGE|LC_[A-Z]+|TZ)=/.test(words[i])) unsafeEnv = true;
+      i++;
+    }
+    const raw = words[i];
+    return { bin: raw ? path.basename(raw) : '', args: words.slice(i + 1), unsafeEnv };
+  });
+
+  // Provably refused shapes. Kept to cases the harness already hard-blocks, so
+  // a `deny` here is a prediction the ledger can actually be scored against.
+  //
+  // Matched PER SEGMENT against the resolved binary, never against the raw
+  // command string. A whole-string regex classified `echo "git push --force"`
+  // as a denied force-push — the words appear, but the segment runs `echo`.
+  // A verdict engine that reads text instead of argv measures its own parsing.
+  for (const { bin, args } of parsed) {
+    if (bin !== 'git') continue;
+    const sub = gitSubcommand(args);
+    if (sub === 'push' && isForcePush(args)) return 'deny';
+    if (sub === 'commit' && args.includes('--amend')) return 'deny';
+  }
+  // A redirect INTO git metadata is a denial wherever the file lives. Matching
+  // `>\s*\.git[\\/]` only recognised a target written relative to the cwd, so
+  // `> /repo/.git/config` and `> ../.git/config` recorded `abstain` — the
+  // documented deny, silently missing on the absolute form. The target is
+  // extracted the same way the write check below extracts it, and tested with
+  // GIT_METADATA_PATH, the SAME predicate the file-tool branch uses, so the two
+  // paths cannot drift apart on what counts as git metadata.
+  for (const [, target] of masked.matchAll(REDIRECT_TARGET)) {
+    if (GIT_METADATA_PATH.test(target)) return 'deny';
+  }
+
+  // Substitution is checked on the RAW text, deliberately: `"$(ls)"` still
+  // expands inside double quotes, so masking here would under-detect. Erring
+  // toward `abstain` costs nothing; missing a dynamic command costs a wrong
+  // `allow`.
+  if (/\$\(|`|<\(|>\(/.test(cmd)) return 'abstain';
+  // Any redirect to a real file is a write. The target is EXTRACTED and then
+  // compared, rather than excluded by a lookahead: in `>>?\s*(?!\/dev\/null|&\d)`
+  // the `\s*` backtracks to zero width, so the lookahead ran against the SPACE
+  // and the exclusion silently did not apply to the spaced form. That made
+  // `ls > /dev/null` a false `abstain`, and — because the unspaced form is the
+  // only one the lookahead ever saw — `>/dev/null.bak` a false `allow`, which is
+  // the damaging direction.
+  // The target ends at whitespace OR a control operator, so `>/dev/null; pwd`
+  // does not extract `/dev/null;` and lose the exclusion. `&\d+` is matched
+  // first and deliberately: there the `&` belongs to the target (fd duplication,
+  // `2>&1`), everywhere else it separates.
+  for (const [, target] of masked.matchAll(REDIRECT_TARGET)) {
+    if (target === '/dev/null' || /^&\d+$/.test(target)) continue;
+    return 'abstain';
+  }
+
+  for (const { bin, args, unsafeEnv } of parsed) {
+    if (!bin) return 'abstain';
+    if (unsafeEnv) return 'abstain';
+    if (bin === 'git') {
+      const sub = gitSubcommand(args);
+      if (!GIT_READ_SUBCMDS.has(sub)) return 'abstain';
+      continue;
+    }
+    if (!READ_ONLY_BINS.has(bin)) return 'abstain';
+    if (hasWriteFlag(bin, args)) return 'abstain';
+  }
+  return 'allow';
+}
+
+// Several nominally read-only binaries have a flag that writes a file or runs a
+// command — `sort -o out.txt` writes, `find -exec` executes. The production
+// guard gates each of these; without the same gate `allow` would be false on
+// commands that are not reads at all.
+function hasWriteFlag(bin, args) {
+  const has = (...names) => args.some((a) => names.some((n) => a === n || a.startsWith(`${n}=`)));
+  switch (bin) {
+    case 'sort': case 'tree': case 'base64':
+      return has('-o', '--output') || args.some((a) => /^-o./.test(a));
+    case 'find':
+      return has('-exec', '-execdir', '-ok', '-okdir', '-delete', '-fprint',
+        '-fprintf', '-fprint0', '-fls');
+    case 'file':
+      return has('-C', '--compile');
+    case 'xxd':
+      // `xxd in out` writes: a second positional is an output file.
+      return has('-r', '-revert') || args.filter((a) => !a.startsWith('-')).length >= 2;
+    default:
+      return false;
+  }
+}
+
+// Blanks the contents of quoted spans (keeping length, so nothing shifts) so
+// structural characters inside them are not mistaken for shell syntax.
+function maskQuoted(s) {
+  let out = '';
+  let quote = null;
+  let escaped = false;
+  for (const ch of s) {
+    // A backslash escapes the next character everywhere EXCEPT inside single
+    // quotes, where it is literal. Ignoring it treated the escaped quote in
+    // `echo \'> out` as an opening delimiter, which swallowed the `>` — a real
+    // file write recorded as provably read-only, the most damaging error here.
+    // Both the backslash and what it escapes are masked: neither can be
+    // structure, so neither may be read as any.
+    if (escaped) { out += ' '; escaped = false; continue; }
+    if (quote !== "'" && ch === '\\') { out += ' '; escaped = true; continue; }
+    if (quote) {
+      out += ch === quote ? ch : ' ';
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"') { quote = ch; out += ch; continue; }
+    out += ch;
+  }
+  return out;
+}
+
+// `--force-with-lease` is the sanctioned form and is NOT a force-push here.
+// The `+` refspec prefix is: `git push origin +main` force-updates the remote
+// ref with no flag at all, which a flag-only check misses entirely.
+// auto-approve-safe-bash.sh treats `+main` as a force target for the same
+// reason; a classifier that disagrees with the production gate on the same
+// command is measuring nothing useful.
+function isForcePush(args) {
+  // Bare --force is checked FIRST. `--force-with-lease --force` is NOT the safe
+  // form: the bare flag clobbers without the stale-tip check whatever else is
+  // present, and auto-approve-safe-bash.sh refuses that combination outright.
+  // Returning early on the lease flag let the dangerous form read as safe.
+  if (args.some((a) => a === '--force' || a === '-f')) return true;
+  if (args.some((a) => a === '--force-with-lease' || a.startsWith('--force-with-lease='))) return false;
+  return args.some((a) => /^\+[^-]/.test(a));
+}
+
+// The subcommand, skipping git's GLOBAL flags. Some of them take a SEPARATE
+// argument (`git -C repo push`), so a naive "first non-flag word" reads `repo`
+// as the subcommand and misses the push entirely — which silently downgraded
+// `git -C repo push --force` from deny to abstain.
+function gitSubcommand(args) {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '-C' || a === '--git-dir' || a === '--work-tree' || a === '--namespace' || a === '-c') {
+      i += 1;               // consumes the next word
+      continue;
+    }
+    if (a.startsWith('-')) continue;   // =-forms and simple flags
+    return a;
+  }
+  return '';
+}
+
+// --- provenance --------------------------------------------------------------
+
+// Best-effort. No dispatcher currently exports a lane marker, so most rows will
+// read `primary`; attribution improves the day spawn-* export HIMMEL_LANE, and
+// is deliberately not guessed from cwd here (a worktree does not imply a lane).
+export function requesterLane() {
+  const explicit = process.env.HIMMEL_LANE;
+  if (explicit && explicit.trim()) return explicit.trim();
+  if (process.env.CLAUDE_CODE_EFFORT_LEVEL) return 'claudex';
+  const base = process.env.ANTHROPIC_BASE_URL ?? '';
+  if (/z\.ai|bigmodel/i.test(base)) return 'glm';
+  return 'primary';
+}
+
+// Pins WHICH lane registry was in force when the decision was recorded, so a
+// later routing change cannot silently rewrite the meaning of old rows.
+export function laneConfigHash(projectDir = process.env.CLAUDE_PROJECT_DIR) {
+  if (!projectDir) return null;
+  try {
+    const f = path.join(projectDir, 'scripts', 'lanes', 'lanes.json');
+    return sha256(fs.readFileSync(f, 'utf8')).slice(0, 16);
+  } catch {
+    return null;
+  }
+}
+
+// --- hook entry points -------------------------------------------------------
+
+function readStdin() {
+  try {
+    return fs.readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function parsePayload() {
+  const raw = readStdin();
+  if (!raw.trim()) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+// Correlates a PreToolUse row with its PostToolUse outcome. Prefer the harness's
+// own `tool_use_id`, which is unique per call and present on both events. The
+// derived fallback hashes only session + tool + request content, so two
+// IDENTICAL calls in one session collapse onto one ref — and since outcomes are
+// matched as a set, a single success would then mark every duplicate executed,
+// hiding a denial or a strand behind its twin. The fallback stays for payloads
+// that lack the field, and is marked in the record so the ambiguity is visible
+// rather than assumed away.
+export function refFor(payload, cls) {
+  if (payload.tool_use_id) return String(payload.tool_use_id);
+  return `d:${sha256(`${payload.session_id ?? ''}\n${payload.tool_name ?? ''}\n${cls.target_hash}`).slice(0, 16)}`;
+}
+
+export function cmdPre(payload, now) {
+  const tool = payload.tool_name ?? '';
+  if (!RECORDED_TOOLS.includes(tool)) return null;
+  const cls = classify(tool, payload.tool_input ?? {});
+  return append({
+    ts: now,
+    kind: 'request',
+    ref: refFor(payload, cls),
+    session_id: payload.session_id ?? null,
+    tool,
+    class: cls.class,
+    target: cls.target,
+    target_hash: cls.target_hash,
+    requester_lane: requesterLane(),
+    lane_config_hash: laneConfigHash(),
+    permission_mode: payload.permission_mode ?? null,
+    shadow_verdict: shadowVerdict(tool, payload.tool_input ?? {}),
+    actual_verdict: null,
+  });
+}
+
+export function cmdPost(payload, now) {
+  const tool = payload.tool_name ?? '';
+  if (!RECORDED_TOOLS.includes(tool)) return null;
+  const cls = classify(tool, payload.tool_input ?? {});
+  // The DECISION, recorded alongside the event. A Pre/Post pair alone cannot
+  // tell denied from stranded from crashed, so `executed` is asserted only
+  // where it is observed; the absence of this row is never read as "denied".
+  return append({
+    ts: now,
+    kind: 'outcome',
+    ref: refFor(payload, cls),
+    session_id: payload.session_id ?? null,
+    actual_verdict: 'executed',
+  });
+}
+
+export function cmdNotify(payload, now) {
+  // Record EVERY notification, and classify at report time rather than here.
+  // Notification does not fire only for permission prompts — the harness also
+  // raises it for idle-wait timeouts and elicitation dialogs (see
+  // scripts/hooks/telegram-notification.sh, which documents the same surface),
+  // so counting them all as approval interrupts inflates the one number this
+  // ledger exists to produce.
+  //
+  // Filtering in the hook would be worse than filtering in the report: if the
+  // type vocabulary is not what we expect, a hook-side filter silently records
+  // NOTHING and the gate number reads zero with no way to tell that apart from
+  // a genuinely quiet week. Recording everything and classifying later means an
+  // unrecognised type shows up in the report's breakdown instead of vanishing,
+  // and old rows can be reclassified without re-collecting them.
+  return append({
+    ts: now,
+    kind: 'notification',
+    session_id: payload.session_id ?? null,
+    notification_type: payload.notification_type ?? null,
+  });
+}
+
+// Which notification types count as an approval interrupt. Deliberately a loose
+// substring match, not an exact string: undercounting the gate metric is the
+// expensive error, and anything it does NOT match is still surfaced by name in
+// the report so a vocabulary change is visible rather than silent.
+export function isApprovalInterrupt(notificationType) {
+  return /permission|approval/i.test(String(notificationType ?? ''));
+}
+
+// --- report ------------------------------------------------------------------
+
+export function readAll(file = ledgerPath()) {
+  return readLedger(file).records;
+}
+
+// Reads the ledger AND reports whether it can be trusted. Silently skipping a
+// torn line and then publishing a confident rate is the failure this guards:
+// a killed append or a disk fault turns an interior record into garbage, later
+// rows still parse, and the gate number comes out plausible but understated
+// with nothing to indicate it. The chain exists precisely to detect that, so
+// the read path checks it — this is not the standalone verification tooling the
+// ticket defers, it is the report refusing to publish a number it cannot stand
+// behind.
+export function readLedger(file = ledgerPath()) {
+  let text;
+  try {
+    text = fs.readFileSync(file, 'utf8');
+  } catch {
+    return { records: [], malformed: 0, brokenLinks: 0, intact: true };
+  }
+  const lines = text.split('\n');
+  const records = [];
+  let malformed = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    try {
+      records.push(JSON.parse(line));
+    } catch {
+      // An unterminated FINAL line is a torn in-flight append and is expected.
+      // Anywhere else it is real damage and must be counted, not swallowed.
+      if (i !== lines.length - 1) malformed += 1;
+    }
+  }
+  let brokenLinks = 0;
+  let prev = GENESIS;
+  for (const r of records) {
+    if (r.prev_hash !== prev || r.hash !== chainHash(r.prev_hash, r)) brokenLinks += 1;
+    prev = r.hash;
+  }
+  return { records, malformed, brokenLinks, intact: malformed === 0 && brokenLinks === 0 };
+}
+
+export function summarize(records, sinceIso, nowIso = new Date().toISOString(), integrity = null) {
+  const rows = sinceIso ? records.filter((r) => (r.ts ?? '') >= sinceIso) : records;
+  const requests = rows.filter((r) => r.kind === 'request');
+  const notifications = rows.filter((r) => r.kind === 'notification');
+  const interrupts = notifications.filter((r) => isApprovalInterrupt(r.notification_type));
+
+  // COUNT outcomes per ref rather than testing set membership. Membership lets
+  // ONE outcome mark every request sharing that ref as executed, which silently
+  // undercounts unresolved prompts — and refs are shared whenever the harness
+  // gives us no `tool_use_id` and we fall back to a derived (`d:`) hash. Two
+  // identical calls with one success are one executed and one unresolved, and
+  // this is the field whose whole job is to keep that distinction.
+  const outcomesByRef = new Map();
+  for (const r of rows) {
+    if (r.kind === 'outcome') outcomesByRef.set(r.ref, (outcomesByRef.get(r.ref) ?? 0) + 1);
+  }
+  const budget = new Map(outcomesByRef);
+  let executedCount = 0;
+  for (const r of requests) {
+    const left = budget.get(r.ref) ?? 0;
+    if (left > 0) {
+      budget.set(r.ref, left - 1);
+      executedCount += 1;
+    }
+  }
+
+  // Every notification type NOT counted as an interrupt, by name. This is the
+  // safety net on the loose match above: if the harness's vocabulary changes,
+  // the missed types appear here instead of the gate number quietly reading 0.
+  const uncounted = {};
+  for (const n of notifications) {
+    if (isApprovalInterrupt(n.notification_type)) continue;
+    const k = n.notification_type ?? '(none)';
+    uncounted[k] = (uncounted[k] ?? 0) + 1;
+  }
+
+  const span = observedDays(records, sinceIso, nowIso);
+  const byClass = {};
+  const byVerdict = { allow: 0, deny: 0, abstain: 0 };
+  for (const r of requests) {
+    byClass[r.class] = (byClass[r.class] ?? 0) + 1;
+    if (r.shadow_verdict in byVerdict) byVerdict[r.shadow_verdict] += 1;
+  }
+  return {
+    span_days: span,
+    requests: requests.length,
+    interrupts: interrupts.length,
+    // Refuse to extrapolate from a window shorter than a day. A 20-minute
+    // sample scaled to a week produces a confident six-figure number that is
+    // pure artefact — and this is the one figure the whole programme is gated
+    // on, so it has to be null until it is real. The same refusal applies when
+    // the ledger is damaged: missing rows understate the rate invisibly, so an
+    // unproven chain publishes no rate at all.
+    interrupts_per_week: span >= MIN_EXTRAPOLATION_DAYS && (integrity?.intact ?? true)
+      ? +(interrupts.length * 7 / span).toFixed(1)
+      : null,
+    integrity: integrity
+      ? { intact: integrity.intact, malformed: integrity.malformed, broken_links: integrity.brokenLinks }
+      : null,
+    notifications: notifications.length,
+    uncounted_notification_types: uncounted,
+    executed: executedCount,
+    unresolved: requests.length - executedCount,
+    shadow_verdicts: byVerdict,
+    top_classes: Object.entries(byClass).sort((a, b) => b[1] - a[1]).slice(0, 10),
+  };
+}
+
+// The OBSERVATION window, not the spread between the first and last event.
+// Event spread is biased short at both ends — the first event lands some time
+// after the recorder was installed and the last some time before now — and it
+// collapses to zero for a quiet week, which would report an infinite-looking
+// rate from two adjacent events. Both errors push the rate UP, on the single
+// figure the trust programme is gated on. The window runs from `since` (when
+// the caller asked for one) or the first record ever seen (the best available
+// proxy for install time) through to now.
+function observedDays(allRecords, sinceIso, nowIso) {
+  const first = allRecords.map((r) => r.ts).filter(Boolean).sort()[0];
+  const startIso = sinceIso ?? first;
+  if (!startIso) return 0;
+  // A `--days N` window that predates the ledger is not N days of observation.
+  const start = Math.max(Date.parse(startIso), first ? Date.parse(first) : -Infinity);
+  const ms = Date.parse(nowIso) - start;
+  return Number.isFinite(ms) ? Math.max(ms / 86400000, 0) : 0;
+}
+
+function printReport(summary) {
+  const l = [];
+  l.push('shadow ledger — HIMMEL-1529 R0');
+  l.push(`  window            ${summary.span_days.toFixed(1)} days`);
+  l.push(`  requests recorded ${summary.requests}`);
+  const damaged = summary.integrity && !summary.integrity.intact;
+  l.push(`  APPROVAL INTERRUPTS ${summary.interrupts}` +
+    (summary.interrupts_per_week !== null
+      ? `  (${summary.interrupts_per_week}/week)`
+      : damaged
+        ? '  (LEDGER DAMAGED — no rate published)'
+        : '  (window under a day — no weekly rate yet)'));
+  if (damaged) {
+    l.push(`  ⚠ INTEGRITY  ${summary.integrity.malformed} unreadable row(s), ` +
+      `${summary.integrity.broken_links} broken chain link(s) — rows are MISSING, so every`);
+    l.push('               count below is a floor, not a measurement.');
+  }
+  const un = Object.entries(summary.uncounted_notification_types ?? {});
+  if (un.length) {
+    l.push(`  other notifications ${un.map(([k, v]) => `${k}=${v}`).join(' ')}   (NOT counted as interrupts)`);
+  }
+  l.push(`  executed          ${summary.executed}`);
+  l.push(`  unresolved        ${summary.unresolved}   (denied OR stranded OR crashed — not distinguishable)`);
+  l.push(`  shadow verdicts   allow=${summary.shadow_verdicts.allow} deny=${summary.shadow_verdicts.deny} abstain=${summary.shadow_verdicts.abstain}`);
+  l.push('  NOTE: agreement rate is dominated by the abstain class and is NOT the');
+  l.push('        gate number. The gate number is APPROVAL INTERRUPTS per week.');
+  if (summary.top_classes.length) {
+    l.push('  top classes:');
+    for (const [k, v] of summary.top_classes) l.push(`    ${String(v).padStart(5)}  ${k}`);
+  }
+  return l.join('\n');
+}
+
+// --- main --------------------------------------------------------------------
+
+function main(argv) {
+  const cmd = argv[0];
+  const now = new Date().toISOString();
+
+  if (cmd === 'report') {
+    const days = Number(argv[argv.indexOf('--days') + 1]);
+    const since = argv.includes('--days') && Number.isFinite(days)
+      ? new Date(Date.now() - days * 86400000).toISOString()
+      : null;
+    const led = readLedger();
+    const summary = summarize(led.records, since, new Date().toISOString(), led);
+    process.stdout.write(argv.includes('--json')
+      ? `${JSON.stringify(summary, null, 2)}\n`
+      : `${printReport(summary)}\n`);
+    return 0;
+  }
+
+  // Hook paths from here down. Every one of them is fail-open and silent.
+  const payload = parsePayload();
+  if (!payload) return 0;
+  try {
+    fs.mkdirSync(ledgerDir(), { recursive: true });
+  } catch {
+    return 0;
+  }
+  if (cmd === 'pre') cmdPre(payload, now);
+  else if (cmd === 'post') cmdPost(payload, now);
+  else if (cmd === 'notify') cmdNotify(payload, now);
+  return 0;
+}
+
+// Never let a throw escape into the hook's exit code: a non-zero PreToolUse exit
+// BLOCKS the tool call, which is the one thing this file must never do.
+if (import.meta.url === `file://${process.argv[1]}` ||
+    process.argv[1]?.endsWith('shadow-ledger.mjs')) {
+  let code = 0;
+  try {
+    code = main(process.argv.slice(2));
+  } catch {
+    code = 0;
+  }
+  process.exit(code);
+}

--- a/scripts/trust/shadow-ledger.mjs
+++ b/scripts/trust/shadow-ledger.mjs
@@ -56,6 +56,9 @@
 // USAGE (hooks wire these; see scripts/trust/README.md)
 //   node shadow-ledger.mjs pre      < PreToolUse payload
 //   node shadow-ledger.mjs post     < PostToolUse payload
+//   node shadow-ledger.mjs postfail < PostToolUseFailure payload
+//   node shadow-ledger.mjs denied   < PermissionDenied payload
+//   node shadow-ledger.mjs permreq  < PermissionRequest payload
 //   node shadow-ledger.mjs notify   < Notification payload
 //   node shadow-ledger.mjs report [--days N] [--json]
 
@@ -85,6 +88,14 @@ export function ledgerDir() {
 
 export function ledgerPath() {
   return path.join(ledgerDir(), 'ledger.jsonl');
+}
+
+// Recorder health, kept in a SEPARATE file from the ledger on purpose. The
+// events it records are the ones the ledger could not record, so anything that
+// shares the ledger's lock or its hash chain would be silent in exactly the
+// case it exists to report.
+export function healthPath() {
+  return path.join(ledgerDir(), 'drops.jsonl');
 }
 
 // --- hashing -----------------------------------------------------------------
@@ -199,6 +210,56 @@ function breakStaleLock(lock) {
   }
 }
 
+// A write this recorder could not perform. Fail-open stays the contract — the
+// caller still gets null and the tool call still proceeds — but the loss stops
+// being INVISIBLE. Without this the hash chain still validates (it validates the
+// rows that landed, never the rows that never did), so a contention spike or an
+// ENOSPC produces an understated rate that looks exactly like a quiet week.
+//
+// Deliberately reason CODES only, never the exception text: an error message can
+// carry a path or a command fragment, and this file does not store those.
+export function recordDrop(reason) {
+  try {
+    fs.mkdirSync(ledgerDir(), { recursive: true });
+    fs.appendFileSync(
+      healthPath(),
+      `${JSON.stringify({ ts: new Date().toISOString(), reason })}\n`,
+      'utf8',
+    );
+  } catch {
+    /* nothing further to try; the counter is a floor, and fail-open still holds */
+  }
+}
+
+// Is somebody mid-append RIGHT NOW? Only a live lock holder can be, and only
+// that case makes an unterminated final line innocent — see readLedger.
+//
+// Every uncertain branch answers NO (no lock, unreadable lock, unparseable
+// owner, stale stamp). That direction is deliberate: answering NO turns a torn
+// tail into declared damage, which SUPPRESSES the rate. The failure it avoids is
+// publishing a confident number over a missing row, and between "refuse to
+// publish" and "publish short" a measurement tool must pick the first.
+// The lock is derived from the LEDGER FILE's own directory, not from
+// ledgerDir(). readLedger accepts an arbitrary path, and asking the default
+// directory about some other ledger's writer would answer a question nobody
+// asked — innocently exempting a torn tail because an unrelated ledger happened
+// to be mid-append.
+function liveWriterPresent(file = ledgerPath()) {
+  const lock = path.join(path.dirname(file), '.ledger.lock');
+  let raw;
+  try {
+    raw = fs.readFileSync(lock, 'utf8');
+  } catch {
+    return false; // no lock file at all — nobody is writing
+  }
+  const [pidStr, tsStr] = raw.split(/\s+/);
+  const stamped = Number(tsStr);
+  // A stale stamp means the holder is long gone even if the pid got recycled.
+  if (!Number.isFinite(stamped) || Date.now() - stamped > STALE_LOCK_MS) return false;
+  const pid = Number(pidStr);
+  return Number.isFinite(pid) && pid > 0 ? pidAlive(pid) : false;
+}
+
 function withLock(fn) {
   const lock = path.join(ledgerDir(), '.ledger.lock');
   for (let i = 0; i < LOCK_TRIES; i++) {
@@ -219,6 +280,13 @@ function withLock(fn) {
     }
     try {
       return fn();
+    } catch {
+      // The write itself failed (ENOSPC, a transient permission fault, a full
+      // inode table). Previously this propagated to the top-level fail-open
+      // handler, which swallowed it and exited 0 — correct for the tool call,
+      // silent for the measurement. Record the loss, then keep failing open.
+      recordDrop('append_failed');
+      return null;
     } finally {
       try {
         fs.closeSync(fd);
@@ -236,6 +304,8 @@ function withLock(fn) {
       }
     }
   }
+  // Retries exhausted under sustained contention. The record is gone; say so.
+  recordDrop('lock_exhausted');
   return null;
 }
 
@@ -678,19 +748,84 @@ export function cmdPre(payload, now) {
   });
 }
 
-export function cmdPost(payload, now) {
+// The DECISION, recorded alongside the event. `actual_verdict` is asserted only
+// where it is OBSERVED; the absence of an outcome row is never read as "denied".
+//
+// One recorder for all three terminal outcomes rather than three near-copies.
+// The lesson this file already paid for twice (HIMMEL-1529 CR rounds 3 and 4):
+// when several call sites make the same structural read, converting them one at
+// a time moves the defect down a layer instead of fixing it, and every move
+// looks like a fix because the test just written passes.
+function recordOutcome(payload, now, verdict) {
   const tool = payload.tool_name ?? '';
   if (!RECORDED_TOOLS.includes(tool)) return null;
   const cls = classify(tool, payload.tool_input ?? {});
-  // The DECISION, recorded alongside the event. A Pre/Post pair alone cannot
-  // tell denied from stranded from crashed, so `executed` is asserted only
-  // where it is observed; the absence of this row is never read as "denied".
   return append({
     ts: now,
     kind: 'outcome',
     ref: refFor(payload, cls),
     session_id: payload.session_id ?? null,
-    actual_verdict: 'executed',
+    actual_verdict: verdict,
+  });
+}
+
+export function cmdPost(payload, now) {
+  return recordOutcome(payload, now, 'executed');
+}
+
+// PostToolUseFailure — the call RAN and failed. Distinct from a denial: the
+// harness let it through, so it is not an approval interrupt and must not be
+// counted as one. Before this was wired it landed in `unresolved` alongside
+// genuine denials, which corrupted the agreement data by construction.
+export function cmdPostFailure(payload, now) {
+  return recordOutcome(payload, now, 'executed_failed');
+}
+
+// PermissionDenied — the call was REFUSED by the AUTO-MODE CLASSIFIER, and
+// only by it. Verified against the Claude Code hook reference: the event fires
+// "when a tool call is denied by the auto mode classifier". A manual operator
+// denial, a `deny` permission rule, and a PreToolUse block do NOT raise it, so
+// those requests still land in `unresolved`.
+//
+// The verdict is named for what it actually observes rather than for
+// "denied" in general. A short name that overstates its own scope is how a
+// partial signal gets read as complete coverage — the same failure class as a
+// weekly rate computed over rows that silently went missing.
+export function cmdDenied(payload, now) {
+  return recordOutcome(payload, now, 'denied_auto_classifier');
+}
+
+// PermissionRequest — fires when a tool call NEEDS a permission decision.
+//
+// Read that literally, because the tempting reading is wrong: "a decision was
+// needed" is NOT "a human was interrupted". In an armed or otherwise unattended
+// session the event still fires and nobody is there to be interrupted — this
+// programme measured that directly (W0 probe P5: a hook returning `ask` hung
+// for 902 s on a dialog no one could answer). Counting these as operator
+// interrupts would inflate the one number the whole thing is gated on, with the
+// inflation concentrated in exactly the unattended runs this harness does most.
+//
+// So the count is reported as permission-request EVENTS, beside the
+// Notification-derived figure rather than as a replacement for it. Two
+// independent estimators of one quantity are how you find out which is right;
+// silently switching to the new surface would replace a measured number with an
+// unvalidated one and destroy the comparison. HIMMEL-1539 raised the choice as
+// a design input for HIMMEL-1530 — collecting both is what makes that decision
+// evidence-based instead of another round of argument.
+//
+// `permission_mode` is persisted because it is the only interactivity-adjacent
+// signal on the payload. It is stored, NOT interpreted: no count here claims to
+// separate a real dialog from an unattended one until that can be shown.
+//
+// No RECORDED_TOOLS filter, on purpose: a permission decision counts whatever
+// tool raised it, and this row carries no request payload to classify.
+export function cmdPermissionRequest(payload, now) {
+  return append({
+    ts: now,
+    kind: 'permission_request',
+    session_id: payload.session_id ?? null,
+    tool: payload.tool_name ?? null,
+    permission_mode: payload.permission_mode ?? null,
   });
 }
 
@@ -738,26 +873,92 @@ export function readAll(file = ledgerPath()) {
 // the read path checks it — this is not the standalone verification tooling the
 // ticket defers, it is the report refusing to publish a number it cannot stand
 // behind.
-export function readLedger(file = ledgerPath()) {
-  let text;
-  try {
-    text = fs.readFileSync(file, 'utf8');
-  } catch {
-    return { records: [], malformed: 0, brokenLinks: 0, intact: true };
-  }
+// One parse of the ledger text. Split out so the torn-tail path can re-read a
+// stable snapshot and run the IDENTICAL classification over it — re-deriving
+// the parse for the retry is how the two copies drift apart.
+function parseLedgerText(text) {
   const lines = text.split('\n');
   const records = [];
   let malformed = 0;
+  let torn = 0;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (!line.trim()) continue;
     try {
-      records.push(JSON.parse(line));
+      const parsed = JSON.parse(line);
+      // A successfully PARSED value is not necessarily a usable ROW. `null`,
+      // `42` and `"x"` are all valid JSON, and every consumer downstream
+      // dereferences `.kind` — so an unvalidated row threw a TypeError that the
+      // fail-open handler turned into exit 0 with empty stdout. Corruption
+      // produced neither a report nor a warning. Shape is damage, not a crash.
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        malformed += 1;
+        continue;
+      }
+      records.push(parsed);
     } catch {
-      // An unterminated FINAL line is a torn in-flight append and is expected.
-      // Anywhere else it is real damage and must be counted, not swallowed.
-      if (i !== lines.length - 1) malformed += 1;
+      // An unterminated FINAL line MAY be a torn in-flight append. Anywhere
+      // else it is unambiguous damage.
+      if (i === lines.length - 1) torn += 1;
+      else malformed += 1;
     }
+  }
+  return { records, malformed, torn };
+}
+
+// Bounded wait for the writer lock to be released, so the retry above reads a
+// snapshot nobody is mid-append into. Bounded because a reader must never hang
+// on a wedged writer: if the budget runs out we simply re-read and judge what
+// is there, which fails toward declaring damage.
+function waitForLockToClear(file) {
+  const idle = new Int32Array(new SharedArrayBuffer(4)); // hoisted: one buffer, not one per retry
+  for (let i = 0; i < LOCK_TRIES; i++) {
+    if (!liveWriterPresent(file)) return;
+    Atomics.wait(idle, 0, 0, LOCK_WAIT_MS);
+  }
+}
+
+export function readLedger(file = ledgerPath()) {
+  let text;
+  try {
+    text = fs.readFileSync(file, 'utf8');
+  } catch (e) {
+    // Same rule as readDrops: a ledger that does not exist yet is genuinely
+    // empty and intact. A ledger that exists but cannot be READ is unknown,
+    // and unknown must not present as clean.
+    if (e && e.code === 'ENOENT') {
+      return { records: [], malformed: 0, torn: 0, brokenLinks: 0, unreadable: false, intact: true };
+    }
+    // [glm round 4] A file that cannot be OPENED is not a row that failed to
+    // parse. Reporting it as `malformed: 1` suppressed the rate correctly but
+    // printed "1 unreadable row(s)" over a file with zero rows — a true verdict
+    // reached through a false statement, in the one surface this ticket exists
+    // to make honest.
+    return { records: [], malformed: 0, torn: 0, brokenLinks: 0, unreadable: true, intact: false };
+  }
+  let { records, malformed, torn } = parseLedgerText(text);
+  // A torn tail MAY be an append that is in flight right now and about to
+  // complete. Liveness decides whether to WAIT for it — never whether to
+  // forgive it. Forgiving on liveness alone was wrong twice over: a live lock
+  // does not tie its holder to THIS fragment (a later writer would briefly
+  // absolve an abandoned one it never created), and a report racing an
+  // incomplete append could publish before that row landed.
+  //
+  // So: give the writer a bounded chance to finish, re-read a stable snapshot,
+  // and then judge what is actually on disk. After the wait there is no
+  // exemption at all — a tail that still does not parse is damage, whoever
+  // holds the lock. A completing append heals the file by prefixing a newline
+  // to its own record, which turns an abandoned fragment into an INTERIOR
+  // line, so it is still counted, just as `malformed` instead of `torn`.
+  if (torn > 0 && liveWriterPresent(file)) {
+    waitForLockToClear(file);
+    let retext;
+    try {
+      retext = fs.readFileSync(file, 'utf8');
+    } catch {
+      retext = null;
+    }
+    if (retext !== null) ({ records, malformed, torn } = parseLedgerText(retext));
   }
   let brokenLinks = 0;
   let prev = GENESIS;
@@ -765,34 +966,161 @@ export function readLedger(file = ledgerPath()) {
     if (r.prev_hash !== prev || r.hash !== chainHash(r.prev_hash, r)) brokenLinks += 1;
     prev = r.hash;
   }
-  return { records, malformed, brokenLinks, intact: malformed === 0 && brokenLinks === 0 };
+  return {
+    records,
+    malformed,
+    torn,
+    brokenLinks,
+    unreadable: false,
+    intact: malformed === 0 && brokenLinks === 0 && torn === 0,
+  };
 }
 
-export function summarize(records, sinceIso, nowIso = new Date().toISOString(), integrity = null) {
+// Drops recorded by `recordDrop`. A line that does not parse still COUNTS as a
+// drop: it is evidence the recorder was in trouble, and discarding it would
+// restore the exact blindness this channel exists to remove. Such a line has no
+// usable timestamp, so it is treated as in-window by `summarize`.
+export function readDrops(file = healthPath()) {
+  let text;
+  try {
+    text = fs.readFileSync(file, 'utf8');
+  } catch (e) {
+    // ENOENT is the ordinary healthy case: no drops have ever been recorded.
+    // ANY OTHER error (EACCES, EIO, a directory in the way) means the health
+    // channel cannot be read, and "cannot read" must never present as "no
+    // drops" — that is fail-OPEN on the one channel whose whole job is to
+    // report losses. Surface it as a drop so the rate is suppressed.
+    if (e && e.code === 'ENOENT') return [];
+    return [{ ts: null, reason: 'health_channel_unreadable' }];
+  }
+  const out = [];
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      out.push(JSON.parse(line));
+    } catch {
+      out.push({ ts: null, reason: 'unparseable_drop_row' });
+    }
+  }
+  return out;
+}
+
+export function summarize(
+  records,
+  sinceIso,
+  nowIso = new Date().toISOString(),
+  integrity = null,
+  drops = [],
+) {
   const rows = sinceIso ? records.filter((r) => (r.ts ?? '') >= sinceIso) : records;
-  const requests = rows.filter((r) => r.kind === 'request');
+  // Correlation runs over the FULL history; the window is applied to the
+  // RESULTS. Filtering requests first was wrong: an outcome belonging to a
+  // pre-cutoff request would be left unclaimed, and the first in-window request
+  // sharing its derived ref would consume it — reporting an execution that
+  // request never had. Its rightful owner has to be present to claim it.
+  const allRequests = [];
+  records.forEach((r, idx) => {
+    if (r.kind === 'request') allRequests.push({ ...r, __idx: idx });
+  });
   const notifications = rows.filter((r) => r.kind === 'notification');
   const interrupts = notifications.filter((r) => isApprovalInterrupt(r.notification_type));
+  const permissionRequests = rows.filter((r) => r.kind === 'permission_request');
+
+  // A drop with no USABLE timestamp counts as in-window: it cannot be ruled
+  // out, and the whole point of this channel is to stop unprovable losses
+  // reading as zero. Same direction as everything else here — when unsure,
+  // suppress.
+  //
+  // A recorded drop suppresses the rate for as long as the drop row exists.
+  // Drops are deliberately NOT expired by timestamp.
+  //
+  // There is deliberately NO acknowledgement path that restores the rate.
+  // Rotating `drops.jsonl` was briefly documented as one and is not: the lost
+  // event is still missing from the window afterwards, so the rate would come
+  // back over data known to be incomplete — laundering the loss instead of
+  // resolving it. Restoring a rate honestly needs a durable `valid_since`
+  // checkpoint that moves the window PAST the loss, which is tracked in
+  // HIMMEL-1547 along with the collector-liveness heartbeat it shares
+  // machinery with.
+  //
+  // Two rounds of review taught this the expensive way. Expiring on wall-clock
+  // first let a truthy-but-non-string `ts` escape the window, then let a
+  // BACKWARD CLOCK STEP across the cutoff re-date an in-window failure as old —
+  // both producing dropped_writes=0 and a confident rate over a ledger with
+  // known missing events, which is precisely the false-clean this channel
+  // exists to prevent. There is no durable proof a drop predates the window
+  // (that is what HIMMEL-1547's checkpoint would provide), so the honest
+  // options are "suppress until acknowledged" or "trust a clock we have twice
+  // shown we cannot trust". Deleting the comparison also deletes the boundary,
+  // which is the lesson this subsystem keeps re-teaching.
+  const droppedWrites = drops.length;
 
   // COUNT outcomes per ref rather than testing set membership. Membership lets
-  // ONE outcome mark every request sharing that ref as executed, which silently
+  // ONE outcome mark every request sharing that ref as resolved, which silently
   // undercounts unresolved prompts — and refs are shared whenever the harness
   // gives us no `tool_use_id` and we fall back to a derived (`d:`) hash. Two
   // identical calls with one success are one executed and one unresolved, and
   // this is the field whose whole job is to keep that distinction.
+  //
+  // Outcomes are now VERDICT-BEARING, so the per-ref budget holds the verdicts
+  // in arrival order and each request consumes the next one, rather than
+  // decrementing an anonymous counter.
+  // Built from ALL records, keyed by ref, carrying row position — see the
+  // ordering note in the match loop for why position and not `ts`.
   const outcomesByRef = new Map();
-  for (const r of rows) {
-    if (r.kind === 'outcome') outcomesByRef.set(r.ref, (outcomesByRef.get(r.ref) ?? 0) + 1);
+  records.forEach((r, idx) => {
+    if (r.kind !== 'outcome') return;
+    const entry = { idx, verdict: r.actual_verdict };
+    const q = outcomesByRef.get(r.ref);
+    if (q) q.push(entry);
+    else outcomesByRef.set(r.ref, [entry]);
+  });
+  const cursor = new Map();
+  const outcomes = { executed: 0, executed_failed: 0, denied_auto_classifier: 0, other: 0 };
+  // Pass 1 — assign outcomes across ALL requests, in ledger order.
+  const verdictFor = new Map();
+  for (const r of allRequests) {
+    const q = outcomesByRef.get(r.ref);
+    if (!q) continue;
+    let i = cursor.get(r.ref) ?? 0;
+    // An outcome must FOLLOW the request it resolves, and "follows" means
+    // LEDGER ROW POSITION — never wall-clock. The ledger is append-only and
+    // hash-chained, so position IS causal order; `ts` only approximates it and
+    // fails at both boundaries. Equal timestamps (millisecond precision, and
+    // a hook pair can share a millisecond) made an orphan outcome consumable
+    // by a later request, re-creating the very bug this guard was added for;
+    // and a backward clock adjustment of 1 ms made a genuine outcome look
+    // like it preceded its own request, losing it. Both were measured.
+    //
+    // Without any ordering guard at all, a `--days` cutoff slicing between a
+    // request and its outcome leaves an orphan outcome that a later request
+    // sharing the ref consumes — inventing an execution and hiding a real
+    // unresolved. Refs are shared exactly when the harness gives no
+    // `tool_use_id` and the derived `d:` fallback applies, which is the same
+    // population `unresolved` exists to keep honest.
+    while (i < q.length && q[i].idx <= r.__idx) i += 1;
+    cursor.set(r.ref, i);
+    if (i >= q.length) continue;
+    cursor.set(r.ref, i + 1);
+    verdictFor.set(r.__idx, q[i].verdict);
   }
-  const budget = new Map(outcomesByRef);
-  let executedCount = 0;
+  // Pass 2 — count only the requests inside the reporting window.
+  const requests = sinceIso
+    ? allRequests.filter((r) => (r.ts ?? '') >= sinceIso)
+    : allRequests;
   for (const r of requests) {
-    const left = budget.get(r.ref) ?? 0;
-    if (left > 0) {
-      budget.set(r.ref, left - 1);
-      executedCount += 1;
-    }
+    const v = verdictFor.get(r.__idx);
+    if (v === undefined) continue;
+    // An unrecognised verdict is surfaced as `other`, never folded into
+    // `executed`. Same rule as uncounted_notification_types: a vocabulary this
+    // file does not control must show up by name rather than vanish into the
+    // most flattering bucket.
+    if (v === 'executed' || v === 'executed_failed' || v === 'denied_auto_classifier') outcomes[v] += 1;
+    else outcomes.other += 1;
   }
+  const resolved = outcomes.executed + outcomes.executed_failed
+    + outcomes.denied_auto_classifier + outcomes.other;
+  const executedCount = outcomes.executed;
 
   // Every notification type NOT counted as an interrupt, by name. This is the
   // safety net on the loose match above: if the harness's vocabulary changes,
@@ -820,17 +1148,38 @@ export function summarize(records, sinceIso, nowIso = new Date().toISOString(), 
     // pure artefact — and this is the one figure the whole programme is gated
     // on, so it has to be null until it is real. The same refusal applies when
     // the ledger is damaged: missing rows understate the rate invisibly, so an
-    // unproven chain publishes no rate at all.
-    interrupts_per_week: span >= MIN_EXTRAPOLATION_DAYS && (integrity?.intact ?? true)
-      ? +(interrupts.length * 7 / span).toFixed(1)
-      : null,
+    // unproven chain publishes no rate at all. And the same again for a window
+    // with KNOWN dropped writes — the events are gone, the surviving chain still
+    // validates, and a rate computed over it would be short by an unknown amount.
+    interrupts_per_week:
+      span >= MIN_EXTRAPOLATION_DAYS && (integrity?.intact ?? true) && droppedWrites === 0
+        ? +(interrupts.length * 7 / span).toFixed(1)
+        : null,
     integrity: integrity
-      ? { intact: integrity.intact, malformed: integrity.malformed, broken_links: integrity.brokenLinks }
+      ? {
+        intact: integrity.intact,
+        malformed: integrity.malformed,
+        torn: integrity.torn ?? 0,
+        broken_links: integrity.brokenLinks,
+        unreadable: integrity.unreadable ?? false,
+      }
       : null,
+    dropped_writes: droppedWrites,
+    health_channel_unreadable: drops.some((d) => d && d.reason === 'health_channel_unreadable'),
     notifications: notifications.length,
     uncounted_notification_types: uncounted,
+    // Permission-request EVENTS, from PermissionRequest. NOT a count of human
+    // interruptions: the event fires whenever a decision is needed, including
+    // in unattended sessions where nobody is present to be interrupted.
+    // Reported beside the Notification-derived `interrupts` so the two
+    // estimators can be compared on real data; neither is the gate number by
+    // fiat.
+    permission_request_events: permissionRequests.length,
     executed: executedCount,
-    unresolved: requests.length - executedCount,
+    executed_failed: outcomes.executed_failed,
+    denied_auto_classifier: outcomes.denied_auto_classifier,
+    outcome_other: outcomes.other,
+    unresolved: requests.length - resolved,
     shadow_verdicts: byVerdict,
     top_classes: Object.entries(byClass).sort((a, b) => b[1] - a[1]).slice(0, 10),
   };
@@ -860,23 +1209,56 @@ function printReport(summary) {
   l.push(`  window            ${summary.span_days.toFixed(1)} days`);
   l.push(`  requests recorded ${summary.requests}`);
   const damaged = summary.integrity && !summary.integrity.intact;
+  const dropped = (summary.dropped_writes ?? 0) > 0;
   l.push(`  APPROVAL INTERRUPTS ${summary.interrupts}` +
     (summary.interrupts_per_week !== null
       ? `  (${summary.interrupts_per_week}/week)`
-      : damaged
-        ? '  (LEDGER DAMAGED — no rate published)'
-        : '  (window under a day — no weekly rate yet)'));
-  if (damaged) {
-    l.push(`  ⚠ INTEGRITY  ${summary.integrity.malformed} unreadable row(s), ` +
-      `${summary.integrity.broken_links} broken chain link(s) — rows are MISSING, so every`);
-    l.push('               count below is a floor, not a measurement.');
+      : dropped
+        ? '  (WRITES DROPPED — no rate published)'
+        : damaged
+          ? '  (LEDGER DAMAGED — no rate published)'
+          : '  (window under a day — no weekly rate yet)'));
+  if (damaged && summary.integrity.unreadable) {
+    l.push('  ⚠ INTEGRITY  the ledger file EXISTS but could not be read (permissions, I/O, or a');
+    l.push('               directory in its place). Nothing below was measured — no rate is published.');
+  } else if (damaged) {
+    l.push(`  ⚠ INTEGRITY  ${summary.integrity.malformed} unparseable row(s), ` +
+      `${summary.integrity.torn} abandoned torn tail(s), ` +
+      `${summary.integrity.broken_links} broken chain link(s) —`);
+    l.push('               rows are MISSING, so every count below is a floor, not a measurement.');
+  }
+  if (dropped) {
+    l.push(`  ⚠ DROPPED WRITES  ${summary.dropped_writes} event(s) the recorder could not write`);
+    l.push('               (see drops.jsonl). The surviving chain still validates — it can only');
+    l.push('               attest rows that landed — so these counts are a floor. Drops do NOT');
+    l.push('               expire, and deleting drops.jsonl does not make the lost event exist —');
+    l.push('               restoring a rate honestly needs the checkpoint in HIMMEL-1547.');
+    if (summary.health_channel_unreadable) {
+      l.push('               The health channel itself could not be READ, so the drop count is');
+      l.push('               a floor on the floor.');
+    }
   }
   const un = Object.entries(summary.uncounted_notification_types ?? {});
   if (un.length) {
     l.push(`  other notifications ${un.map(([k, v]) => `${k}=${v}`).join(' ')}   (NOT counted as interrupts)`);
   }
+  if (summary.permission_request_events !== undefined) {
+    l.push(`  permission-request events ${summary.permission_request_events}   (a decision was NEEDED —`);
+    l.push('                        NOT proof anyone was interrupted; unattended sessions fire this too)');
+  }
   l.push(`  executed          ${summary.executed}`);
-  l.push(`  unresolved        ${summary.unresolved}   (denied OR stranded OR crashed — not distinguishable)`);
+  l.push(`  executed (failed) ${summary.executed_failed ?? 0}   (ran and failed — NOT an approval interrupt)`);
+  l.push(`  denied (auto)     ${summary.denied_auto_classifier ?? 0}   (AUTO-MODE CLASSIFIER denials ONLY —`);
+  l.push('                        manual denials, deny rules and PreToolUse blocks do NOT appear here)');
+  if ((summary.outcome_other ?? 0) > 0) {
+    l.push(`  outcome (other)   ${summary.outcome_other}   (UNRECOGNISED verdict — vocabulary changed?)`);
+  }
+  // Denials and failures are only observed if their hooks are wired, and even
+  // wired, PermissionDenied covers ONE denial source. This file cannot tell a
+  // wired-and-quiet harness from an unwired one, so the caveat stays rather
+  // than claiming a completeness the events do not provide.
+  l.push(`  unresolved        ${summary.unresolved}   (no terminal outcome seen — stranded, crashed,`);
+  l.push('                        a non-auto-classifier denial, or an unwired failure/denial hook)');
   l.push(`  shadow verdicts   allow=${summary.shadow_verdicts.allow} deny=${summary.shadow_verdicts.deny} abstain=${summary.shadow_verdicts.abstain}`);
   l.push('  NOTE: agreement rate is dominated by the abstain class and is NOT the');
   l.push('        gate number. The gate number is APPROVAL INTERRUPTS per week.');
@@ -899,7 +1281,7 @@ function main(argv) {
       ? new Date(Date.now() - days * 86400000).toISOString()
       : null;
     const led = readLedger();
-    const summary = summarize(led.records, since, new Date().toISOString(), led);
+    const summary = summarize(led.records, since, new Date().toISOString(), led, readDrops());
     process.stdout.write(argv.includes('--json')
       ? `${JSON.stringify(summary, null, 2)}\n`
       : `${printReport(summary)}\n`);
@@ -916,6 +1298,9 @@ function main(argv) {
   }
   if (cmd === 'pre') cmdPre(payload, now);
   else if (cmd === 'post') cmdPost(payload, now);
+  else if (cmd === 'postfail') cmdPostFailure(payload, now);
+  else if (cmd === 'denied') cmdDenied(payload, now);
+  else if (cmd === 'permreq') cmdPermissionRequest(payload, now);
   else if (cmd === 'notify') cmdNotify(payload, now);
   return 0;
 }
@@ -924,11 +1309,28 @@ function main(argv) {
 // BLOCKS the tool call, which is the one thing this file must never do.
 if (import.meta.url === `file://${process.argv[1]}` ||
     process.argv[1]?.endsWith('shadow-ledger.mjs')) {
+  const argv = process.argv.slice(2);
   let code = 0;
   try {
-    code = main(process.argv.slice(2));
-  } catch {
-    code = 0;
+    code = main(argv);
+  } catch (e) {
+    // Fail-open is a HOOK contract: a non-zero PreToolUse exit blocks the tool
+    // call. `report` is not a hook — it is the operator reading the instrument,
+    // and swallowing its exceptions turned ledger corruption into exit 0 with
+    // empty stdout, which reads as "nothing to report" rather than "could not
+    // report". Silence is the one answer this file must never give about
+    // itself.
+    if (argv[0] === 'report') {
+      process.stderr.write(`shadow-ledger report FAILED: ${e && e.message ? e.message : e}\n`);
+      code = 1;
+    } else {
+      code = 0;
+    }
   }
-  process.exit(code);
+  // `process.exitCode`, NOT `process.exit()`. `report` writes its output to
+  // stdout, and process.exit() can truncate a pending write when stdout is a
+  // pipe — which is how this is always read in practice. Truncating the report
+  // would reintroduce exactly the silence rounds 6 and 7 closed, by a different
+  // mechanism. Setting the code and letting Node exit naturally flushes first.
+  process.exitCode = code;
 }

--- a/scripts/trust/tests/shadow-ledger.test.mjs
+++ b/scripts/trust/tests/shadow-ledger.test.mjs
@@ -1,0 +1,866 @@
+// HIMMEL-1529 — the suite is the spec for the R0 shadow ledger.
+//
+// The three properties that matter, in order:
+//   1. it NEVER emits a permission decision (and above all never `ask`);
+//   2. the blind verdict is on disk BEFORE the process exits toward the
+//      permission layer;
+//   3. it never blocks — every malformed input still exits 0.
+// Everything else is bookkeeping.
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { after, before, describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  append, canonical, chainHash, classify, isApprovalInterrupt, lastRecord,
+  readAll, readLedger, refFor, shadowVerdict, summarize, RECORDED_TOOLS,
+} from '../shadow-ledger.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(HERE, '..', 'shadow-ledger.mjs');
+
+let TMP;
+// [glm-6]: every freshDir() is tracked so the suite does not leave a directory
+// per test case behind in the system temp dir on every run.
+const CASE_DIRS = [];
+before(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'shadow-ledger-'));
+  process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+});
+after(() => {
+  for (const d of [...CASE_DIRS, TMP]) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+function freshDir() {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'shadow-ledger-case-'));
+  CASE_DIRS.push(d);
+  return d;
+}
+
+function runHook(args, stdin, dir) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    input: stdin,
+    encoding: 'utf8',
+    env: { ...process.env, HIMMEL_TRUST_LEDGER_DIR: dir },
+  });
+}
+
+const PRE_BASH = JSON.stringify({
+  session_id: 's1',
+  tool_name: 'Bash',
+  tool_input: { command: 'git push --force origin main' },
+  permission_mode: 'auto',
+});
+
+// --- 1. the hard constraint --------------------------------------------------
+
+describe('never decides', () => {
+  test('pre/post/notify all exit 0 with EMPTY stdout — no decision emitted', () => {
+    const dir = freshDir();
+    for (const [cmd, payload] of [
+      ['pre', PRE_BASH],
+      ['post', PRE_BASH],
+      ['notify', JSON.stringify({ session_id: 's1', notification_type: 'permission' })],
+    ]) {
+      const r = runHook([cmd], payload, dir);
+      assert.equal(r.status, 0, `${cmd} must exit 0`);
+      assert.equal(r.stdout, '', `${cmd} must emit nothing on stdout`);
+    }
+  });
+
+  // A source-text pin, not a behavioural one: `ask` reintroduces the dialog
+  // `defaultMode: auto` exists to remove, and in an armed session that dialog is
+  // unanswerable and unbounded (measured at 902.5s, still blocked when killed).
+  // Behavioural tests only prove the paths they exercise; this proves the string
+  // is not in the file at all.
+  test('source contains no permissionDecision of any kind', () => {
+    const src = fs.readFileSync(SCRIPT, 'utf8');
+    const code = src.split('\n').filter((l) => !l.trim().startsWith('//')).join('\n');
+    assert.ok(!/permissionDecision/.test(code), 'must never emit permissionDecision');
+    assert.ok(!/["']ask["']/.test(code), 'must never emit an `ask` decision');
+    assert.ok(!/hookSpecificOutput/.test(code), 'must not shape a hook decision payload');
+  });
+});
+
+// --- 2. blind ordering -------------------------------------------------------
+
+describe('blind ordering', () => {
+  test('the shadow verdict is durably on disk when the process exits', () => {
+    const dir = freshDir();
+    const r = runHook(['pre'], PRE_BASH, dir);
+    assert.equal(r.status, 0);
+    // Read from a SEPARATE process's perspective: if the write were deferred or
+    // buffered past exit, this file would not exist yet.
+    const rows = readAll(path.join(dir, 'ledger.jsonl'));
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].kind, 'request');
+    assert.equal(rows[0].shadow_verdict, 'deny');
+    assert.equal(rows[0].actual_verdict, null, 'actual is unknown at request time');
+  });
+
+  test('the request row carries the full record shape', () => {
+    const dir = freshDir();
+    runHook(['pre'], PRE_BASH, dir);
+    const [row] = readAll(path.join(dir, 'ledger.jsonl'));
+    for (const k of ['ts', 'class', 'requester_lane', 'lane_config_hash', 'target',
+      'shadow_verdict', 'actual_verdict', 'prev_hash', 'hash']) {
+      assert.ok(k in row, `missing field ${k}`);
+    }
+  });
+
+  test('no transcript, no raw command, is stored', () => {
+    const dir = freshDir();
+    runHook(['pre'], PRE_BASH, dir);
+    const text = fs.readFileSync(path.join(dir, 'ledger.jsonl'), 'utf8');
+    assert.ok(!text.includes('--force'), 'raw command text must not reach the ledger');
+    assert.ok(text.includes('git push'), 'the coarse class handle should survive');
+  });
+});
+
+// --- 3. fail-open ------------------------------------------------------------
+
+describe('fail-open', () => {
+  for (const [name, stdin] of [
+    ['empty stdin', ''],
+    ['not json', 'this is not json'],
+    ['json but not an object', '"hello"'],
+    ['object with no tool', '{}'],
+    ['null tool_input', '{"tool_name":"Bash","tool_input":null}'],
+  ]) {
+    test(`${name} → exit 0, silent`, () => {
+      const r = runHook(['pre'], stdin, freshDir());
+      assert.equal(r.status, 0);
+      assert.equal(r.stdout, '');
+    });
+  }
+
+  test('an unwritable ledger dir still exits 0', () => {
+    const r = runHook(['pre'], PRE_BASH, path.join(os.devNull, 'nope', 'nested'));
+    assert.equal(r.status, 0);
+    assert.equal(r.stdout, '');
+  });
+
+  test('unknown subcommand exits 0', () => {
+    const r = runHook(['wat'], PRE_BASH, freshDir());
+    assert.equal(r.status, 0);
+  });
+});
+
+// --- 4. the hash chain -------------------------------------------------------
+
+describe('hash chain', () => {
+  test('genesis, linkage, and order-independent canonicalisation', () => {
+    const dir = freshDir();
+    process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+    fs.mkdirSync(dir, { recursive: true });
+    const a = append({ ts: '2026-08-04T00:00:00.000Z', kind: 'request', n: 1 });
+    const b = append({ ts: '2026-08-04T00:00:01.000Z', kind: 'request', n: 2 });
+    assert.equal(a.prev_hash, '0'.repeat(64), 'first record chains to genesis');
+    assert.equal(b.prev_hash, a.hash, 'second record chains to the first');
+    assert.equal(lastRecord().hash, b.hash);
+    // canonical() sorts keys, so field order cannot change a hash.
+    assert.equal(
+      canonical({ b: 2, a: 1, hash: 'x' }),
+      canonical({ a: 1, b: 2, hash: 'y' }),
+    );
+    process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+  });
+
+  test('tampering with a record breaks its hash', () => {
+    const rec = { ts: 'x', kind: 'request', class: 'bash:ls' };
+    const h = chainHash('0'.repeat(64), rec);
+    assert.notEqual(h, chainHash('0'.repeat(64), { ...rec, class: 'bash:rm' }));
+    assert.notEqual(h, chainHash('f'.repeat(64), rec), 'prev_hash is bound in');
+  });
+
+  // [glm-2] regression. A lock holder killed between open and unlink used to
+  // wedge the ledger PERMANENTLY: every later call burned all its retries and
+  // dropped its record, so recording stopped for good, silently — and this
+  // harness kills hook processes as a matter of course.
+  test('a stale lock left by a killed writer is reclaimed, not fatal', () => {
+    const dir = freshDir();
+    process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+    fs.mkdirSync(dir, { recursive: true });
+    const lock = path.join(dir, '.ledger.lock');
+    fs.writeFileSync(lock, '');
+    const old = Date.now() - 60_000;
+    fs.utimesSync(lock, old / 1000, old / 1000);
+
+    const rec = append({ ts: 'x', kind: 'request' });
+    assert.ok(rec, 'append must succeed after reclaiming the stale lock');
+    assert.equal(fs.existsSync(lock), false, 'the lock is released again');
+    process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+  });
+
+  test('a FRESH lock is respected — reclamation is not a free-for-all', () => {
+    const dir = freshDir();
+    process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, '.ledger.lock'), '');   // held right now
+    assert.equal(append({ ts: 'x', kind: 'request' }), null, 'must not steal a live lock');
+    process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+  });
+
+  // [codex-2] regression. Age alone is not evidence of death: a merely slow or
+  // SIGSTOPped writer would lose exclusivity and the two writers would fork the
+  // chain — trading a loud wedge for silent corruption, the worse bargain.
+  test('an OLD lock owned by a LIVE pid is not broken', () => {
+    const dir = freshDir();
+    process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+    fs.mkdirSync(dir, { recursive: true });
+    const lock = path.join(dir, '.ledger.lock');
+    // Our own pid is alive by definition; stamp it as very old.
+    fs.writeFileSync(lock, `${process.pid} ${Date.now() - 600_000}`);
+    assert.equal(append({ ts: 'x', kind: 'request' }), null, 'a live owner keeps the lock');
+    assert.ok(fs.existsSync(lock), 'the lock survives');
+    process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+  });
+
+  test('an OLD lock owned by a DEAD pid is reclaimed', () => {
+    const dir = freshDir();
+    process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+    fs.mkdirSync(dir, { recursive: true });
+    const lock = path.join(dir, '.ledger.lock');
+    // PID 2^22 is above every platform's pid_max — reliably not a live process.
+    fs.writeFileSync(lock, `4194304 ${Date.now() - 600_000}`);
+    assert.ok(append({ ts: 'x', kind: 'request' }), 'a dead owner releases the lock');
+    process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+  });
+
+  test('the lock records its owner so death can be proven, not inferred', () => {
+    const dir = freshDir();
+    process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+    fs.mkdirSync(dir, { recursive: true });
+    let seen = '';
+    const lock = path.join(dir, '.ledger.lock');
+    // Observe the lock's contents from inside the critical section.
+    const orig = fs.appendFileSync;
+    fs.appendFileSync = (...a) => { seen = fs.readFileSync(lock, 'utf8'); return orig(...a); };
+    try {
+      append({ ts: 'x', kind: 'request' });
+    } finally {
+      fs.appendFileSync = orig;
+    }
+    assert.match(seen, new RegExp(`^${process.pid} \\d+$`), 'pid + timestamp are stamped');
+    process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+  });
+
+  // [glm-3] regression. A record larger than the tail window used to be clipped
+  // and unparseable, so the next append chained to an EARLIER record — a fork
+  // that leaves no trace at the point it happens.
+  test('a record larger than the tail window does not fork the chain', () => {
+    const dir = freshDir();
+    process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+    fs.mkdirSync(dir, { recursive: true });
+    append({ ts: 'a', kind: 'request' });
+    const big = append({ ts: 'b', kind: 'request', target: 'x'.repeat(40_000) });
+    const next = append({ ts: 'c', kind: 'request' });
+    assert.equal(next.prev_hash, big.hash, 'chains to the oversized record, not past it');
+    process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+  });
+
+  // [codex-adv round 2] regression. An unconditional unlink on release deletes
+  // whatever sits at the pathname — including a replacement lock a reclaimer
+  // took after deciding we were dead, putting two writers in the section.
+  test('release does not delete a lock this writer no longer owns', () => {
+    const dir = freshDir();
+    process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+    fs.mkdirSync(dir, { recursive: true });
+    const lock = path.join(dir, '.ledger.lock');
+    // Simulate a reclaimer replacing our lock mid-critical-section.
+    const orig = fs.appendFileSync;
+    fs.appendFileSync = (...a) => { fs.writeFileSync(lock, 'other-owner 1'); return orig(...a); };
+    try {
+      append({ ts: 'x', kind: 'request' });
+    } finally {
+      fs.appendFileSync = orig;
+    }
+    assert.equal(fs.readFileSync(lock, 'utf8'), 'other-owner 1', "the other writer's lock survives");
+    fs.unlinkSync(lock);
+    process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+  });
+
+  // [codex-adv round 2] regression. Skipping a torn interior row and then
+  // publishing a confident rate is the failure: the number comes out plausible
+  // but understated, with nothing to signal it.
+  describe('a damaged ledger cannot publish a rate', () => {
+    test('an interior torn row is counted, a torn FINAL row is not', () => {
+      const dir = freshDir();
+      process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+      fs.mkdirSync(dir, { recursive: true });
+      const f = path.join(dir, 'ledger.jsonl');
+      append({ ts: 'a', kind: 'request' });
+      fs.appendFileSync(f, '{"torn":\n');          // interior damage
+      append({ ts: 'b', kind: 'request' });
+      let led = readLedger(f);
+      assert.equal(led.malformed, 1);
+      assert.equal(led.intact, false);
+
+      const dir2 = freshDir();
+      process.env.HIMMEL_TRUST_LEDGER_DIR = dir2;
+      fs.mkdirSync(dir2, { recursive: true });
+      const f2 = path.join(dir2, 'ledger.jsonl');
+      append({ ts: 'a', kind: 'request' });
+      fs.appendFileSync(f2, '{"in-flight":');      // torn FINAL line: expected
+      led = readLedger(f2);
+      assert.equal(led.malformed, 0, 'an unterminated last line is a normal in-flight append');
+      assert.equal(led.intact, true);
+      process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+    });
+
+    test('a tampered row breaks the chain and suppresses the rate', () => {
+      const rows = [
+        { ts: '2026-07-28T00:00:00.000Z', kind: 'notification', notification_type: 'permission_prompt' },
+      ];
+      const damaged = { intact: false, malformed: 2, brokenLinks: 1 };
+      const s = summarize(rows, null, '2026-08-04T00:00:00.000Z', damaged);
+      assert.equal(s.interrupts, 1, 'the raw count is still shown');
+      assert.equal(s.interrupts_per_week, null, 'but no rate is published');
+      assert.equal(s.integrity.intact, false);
+    });
+
+    test('the report says the ledger is damaged rather than implying a floor is a measurement', () => {
+      const dir = freshDir();
+      fs.mkdirSync(dir, { recursive: true });
+      const f = path.join(dir, 'ledger.jsonl');
+      process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+      append({ ts: 'a', kind: 'request' });
+      fs.appendFileSync(f, '{"torn":\n');
+      append({ ts: 'b', kind: 'request' });
+      process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+      const r = runHook(['report'], '', dir);
+      assert.equal(r.status, 0);
+      assert.match(r.stdout, /LEDGER DAMAGED/);
+      assert.match(r.stdout, /INTEGRITY/);
+    });
+  });
+
+  // Without healing, a record written after an interrupted append is GLUED onto
+  // the partial line — the damage swallows the new record too, turning a
+  // recoverable one-line loss into an ongoing one.
+  test('an append after a torn final line does not glue onto it', () => {
+    const dir = freshDir();
+    process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+    fs.mkdirSync(dir, { recursive: true });
+    const f = path.join(dir, 'ledger.jsonl');
+    const a = append({ ts: 'a', kind: 'request' });
+    fs.appendFileSync(f, '{"in-flight":');        // no trailing newline
+    const b = append({ ts: 'b', kind: 'request' });
+    const led = readLedger(f);
+    assert.equal(led.records.length, 2, 'both real records survive');
+    assert.equal(led.records[1].hash, b.hash);
+    assert.equal(b.prev_hash, a.hash);
+    assert.equal(led.malformed, 1, 'the torn line is now interior damage and is COUNTED');
+    process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+  });
+
+  test('a torn trailing line does not break the next append', () => {
+    const dir = freshDir();
+    process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+    fs.mkdirSync(dir, { recursive: true });
+    const a = append({ ts: 't', kind: 'request' });
+    fs.appendFileSync(path.join(dir, 'ledger.jsonl'), '{"partial":\n');
+    const b = append({ ts: 'u', kind: 'request' });
+    assert.equal(b.prev_hash, a.hash, 'chains to the last PARSEABLE record');
+    process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+  });
+});
+
+// --- 5. classification + verdict ---------------------------------------------
+
+describe('classification', () => {
+  test('bash class is verb x subverb, not the whole command', () => {
+    const c = classify('Bash', { command: 'git push --force origin main' });
+    assert.equal(c.class, 'bash:git push');
+    assert.equal(c.target, 'git push');
+  });
+
+  test('identical commands share a target_hash, different ones do not', () => {
+    const a = classify('Bash', { command: 'ls -la' });
+    const b = classify('Bash', { command: 'ls -la' });
+    const c = classify('Bash', { command: 'ls -l' });
+    assert.equal(a.target_hash, b.target_hash);
+    assert.notEqual(a.target_hash, c.target_hash);
+  });
+
+  // [codex-adv] regression. Keeping the second token for EVERY binary stored
+  // arguments verbatim, and arguments carry secrets — this made the ledger
+  // itself a credential store while the README promised the opposite.
+  test('a secret-bearing argument never reaches the target field', () => {
+    const c = classify('Bash', { command: 'curl https://api.example.com/v1?token=SECRET123' });
+    assert.equal(c.class, 'bash:curl');
+    assert.equal(c.target, 'curl');
+    assert.ok(!JSON.stringify(c).includes('SECRET123'));
+  });
+
+  test('known command families still keep their subcommand', () => {
+    assert.equal(classify('Bash', { command: 'git push origin x' }).class, 'bash:git push');
+    assert.equal(classify('Bash', { command: 'npm run build' }).class, 'bash:npm run');
+  });
+
+  // [codex-adv round 2] regression. A family allowlist was not enough: runner
+  // commands take a PATH or PACKAGE as their second token, not a verb, so
+  // recognising the family still persisted the argument verbatim.
+  test('runner commands never record their second token', () => {
+    for (const [cmd, secret] of [
+      ['npx https://alice:TOKEN123@github.com/acme/private-tool', 'TOKEN123'],
+      ['node /home/alice/clients/acme/deploy.mjs', 'acme'],
+      ['bun /srv/secret-client/run.ts', 'secret-client'],
+      ['dotnet /opt/AcmeCorp/Private.dll', 'AcmeCorp'],
+    ]) {
+      const c = classify('Bash', { command: cmd });
+      assert.ok(!JSON.stringify(c).includes(secret), `${cmd} leaked into the ledger`);
+    }
+    assert.equal(classify('Bash', { command: 'npx some-pkg' }).class, 'bash:npx');
+  });
+
+  // [codex-adv round 3] regression, and the same class a THIRD time. The
+  // subcommand half was allowlist-validated; the VERB half was not. Whitespace
+  // splitting cannot see a quoted assignment value containing a space, so the
+  // fragment after the space became the verb and was persisted verbatim.
+  test('a quoted assignment value never becomes the verb', () => {
+    for (const cmd of [
+      "TOKEN='x SECRET123' git status",
+      'TOKEN="x SECRET123" git status',
+      "AWS_SECRET='a b' npm run build",
+    ]) {
+      const c = classify('Bash', { command: cmd });
+      assert.equal(c.class, 'bash:unknown', `${cmd} classified as ${c.class}`);
+      assert.ok(!JSON.stringify(c).includes('SECRET123'), `${cmd} leaked into the ledger`);
+      assert.ok(!JSON.stringify(c).includes('a b'), `${cmd} leaked into the ledger`);
+    }
+    // An unquoted assignment is still stripped and the real verb still kept.
+    assert.equal(classify('Bash', { command: 'LANG=C git log' }).class, 'bash:git log');
+  });
+
+  // The token itself is validated, so an unrecognised second word — which is
+  // where secrets live — is dropped even for a recognised family.
+  test('an unknown subcommand of a known family is dropped', () => {
+    const c = classify('Bash', { command: 'git https://user:PASS@host/repo.git' });
+    assert.equal(c.class, 'bash:git');
+    assert.ok(!JSON.stringify(c).includes('PASS'));
+  });
+
+  test('leading assignments and absolute paths normalise to the binary', () => {
+    // The assignment holds a VALUE, so it must never become the verb.
+    assert.equal(classify('Bash', { command: 'TOKEN=abc123 git status' }).class, 'bash:git status');
+    assert.equal(classify('Bash', { command: '/usr/local/bin/git status' }).class, 'bash:git status');
+    assert.ok(!JSON.stringify(classify('Bash', { command: 'TOKEN=abc123 git status' })).includes('abc123'));
+  });
+
+  test('file tools classify by extension, not by full path', () => {
+    const c = classify('Write', { file_path: '/repo/scripts/hooks/thing.sh' });
+    assert.equal(c.class, 'write:.sh');
+    assert.equal(c.target, '.sh');
+  });
+
+  // A directory basename leaks the same class of thing a command argument does.
+  test('a file target never names the parent directory', () => {
+    const c = classify('Edit', { file_path: '/work/clients/AcmeCorp/deploy.ts' });
+    assert.ok(!JSON.stringify(c).includes('AcmeCorp'));
+    assert.ok(!JSON.stringify(c).includes('clients'));
+  });
+
+  test('read-shaped tools are not recorded at all', () => {
+    assert.ok(!RECORDED_TOOLS.includes('Read'));
+    assert.ok(!RECORDED_TOOLS.includes('Grep'));
+    const dir = freshDir();
+    runHook(['pre'], JSON.stringify({
+      session_id: 's', tool_name: 'Read', tool_input: { file_path: '/x.txt' },
+    }), dir);
+    assert.equal(readAll(path.join(dir, 'ledger.jsonl')).length, 0);
+  });
+});
+
+describe('shadow verdict', () => {
+  const bash = (command) => shadowVerdict('Bash', { command });
+
+  test('provably read-only pipelines → allow', () => {
+    assert.equal(bash('ls -la'), 'allow');
+    assert.equal(bash('git status'), 'allow');
+    assert.equal(bash('cat a.txt | grep foo | wc -l'), 'allow');
+    assert.equal(bash('LANG=C git log --oneline -5'), 'allow');
+  });
+
+  test('hard-blocked shapes → deny', () => {
+    assert.equal(bash('git push --force origin main'), 'deny');
+    assert.equal(bash('git commit --amend -m x'), 'deny');
+    assert.equal(shadowVerdict('Write', { file_path: '/repo/.git/config' }), 'deny');
+  });
+
+  test('force-with-lease is NOT the denied shape', () => {
+    assert.notEqual(bash('git push --force-with-lease origin feat/x'), 'deny');
+  });
+
+  // The lease flag does not launder a bare --force: the bare flag clobbers
+  // without the stale-tip check whatever else is on the line, and the
+  // production guard refuses that combination outright.
+  test('--force-with-lease alongside a bare --force is still a force push', () => {
+    assert.equal(bash('git push --force-with-lease --force origin main'), 'deny');
+    assert.equal(bash('git push --force --force-with-lease origin main'), 'deny');
+  });
+
+  // Some git global flags take a SEPARATE argument, so "first non-flag word"
+  // read `repo` as the subcommand and missed the push entirely.
+  test('a global flag with its own argument does not hide the subcommand', () => {
+    assert.equal(bash('git -C repo push --force origin main'), 'deny');
+    assert.equal(bash('git --git-dir /r/.git push --force origin main'), 'deny');
+    assert.equal(bash('git -C repo status'), 'allow');
+  });
+
+  test('contested shapes → abstain, never a guess', () => {
+    assert.equal(bash('node build.mjs'), 'abstain');
+    assert.equal(bash('echo hi > out.txt'), 'abstain');
+    assert.equal(bash('cat $(which node)'), 'abstain');
+    assert.equal(bash('git commit -m wip'), 'abstain');
+    assert.equal(shadowVerdict('Edit', { file_path: '/repo/src/a.ts' }), 'abstain');
+    assert.equal(bash(''), 'abstain');
+  });
+
+  test('a safe head with an unsafe tail is contested', () => {
+    assert.equal(bash('ls && rm -rf /tmp/x'), 'abstain');
+  });
+
+  // A bare `&` is a real separator — the `rm` in `ls & rm file` RUNS. Treating
+  // the line as one `ls` segment produced a false `allow`, the most damaging
+  // error this function can make.
+  test('a bare & separator is not swallowed into the preceding segment', () => {
+    assert.equal(bash('ls & rm file'), 'abstain');
+    assert.equal(bash('cat a & node b.js'), 'abstain');
+  });
+
+  test('an & that belongs to a redirect stays attached', () => {
+    assert.equal(bash('grep x f 2>&1'), 'allow');
+    assert.equal(bash('ls >/dev/null 2>&1'), 'allow');
+  });
+
+  // The exclusion used to be a lookahead after `\s*`, which backtracks to zero
+  // width: it was tested against the SPACE, so it never applied to the spaced
+  // form, and a path merely PREFIXED by /dev/null slipped through to `allow`.
+  test('the /dev/null exclusion is the whole target, spaced or not', () => {
+    assert.equal(bash('ls > /dev/null'), 'allow');
+    assert.equal(bash('ls >/dev/null'), 'allow');
+    assert.equal(bash('ls >/dev/null.bak'), 'abstain');
+    assert.equal(bash('ls > /dev/nullish'), 'abstain');
+    // A control operator ends the target; it is not part of the filename.
+    assert.equal(bash('ls >/dev/null; pwd'), 'allow');
+    assert.equal(bash('ls >/dev/null | cat'), 'allow');
+  });
+
+  // `.git` with no trailing separator is the worktree pointer FILE; rewriting it
+  // repoints the worktree at another repository.
+  test('the .git worktree pointer file is a denial, not an abstain', () => {
+    assert.equal(shadowVerdict('Edit', { file_path: '/repo/.git' }), 'deny');
+    assert.equal(shadowVerdict('Write', { file_path: 'C:\\repo\\.git' }), 'deny');
+    // A file that merely starts with `.git` is ordinary.
+    assert.equal(shadowVerdict('Edit', { file_path: '/repo/.gitignore' }), 'abstain');
+  });
+
+  // A wrong `deny` corrupts the evidence exactly as a wrong `allow` does.
+  test('a quoted redirect is literal text, not a redirect', () => {
+    assert.notEqual(bash('echo "> .git/config"'), 'deny');
+    assert.notEqual(bash("grep -r '> .git/hooks' docs"), 'deny');
+    // The real thing still denies.
+    assert.equal(bash('echo x > .git/config'), 'deny');
+  });
+
+  // [codex-3] regression. A whole-string regex classified `echo "git push
+  // --force"` as a denied force-push: the words are there, but the segment runs
+  // `echo`. A verdict engine that reads text instead of argv measures its own
+  // parsing, and every such row is a false `deny` in the evidence.
+  test('quoted text that merely MENTIONS a denied command is not a denial', () => {
+    assert.notEqual(bash('echo "git push --force"'), 'deny');
+    assert.notEqual(bash('grep -r "git commit --amend" docs'), 'deny');
+  });
+
+  // [codex-1] regression. Per-segment matching fixed the whole-string regex, but
+  // the SEGMENT SPLIT still ran on raw text — so a separator INSIDE quotes cut
+  // the line, and the tail fragment ran `git push --force`. Same false-deny
+  // class, one layer down: the boundaries must come from the masked copy too.
+  test('a control operator inside quotes does not split the command', () => {
+    assert.notEqual(bash('echo "x && git push --force origin main"'), 'deny');
+    assert.notEqual(bash('grep -r "a | git push --force b" docs'), 'deny');
+    assert.equal(bash("echo 'x; git commit --amend'"), 'allow');
+    // An UNquoted separator still splits.
+    assert.equal(bash('echo x && git push --force origin main'), 'deny');
+  });
+
+  // [codex-adv-5] regression. maskQuoted ignored backslash escaping, so the
+  // escaped quote in `echo \'> out` read as an opening delimiter and swallowed
+  // the `>`. A real file write recorded as provably read-only.
+  test('an escaped quote cannot hide a redirect', () => {
+    assert.equal(bash("echo \\'> out"), 'abstain');
+    assert.equal(bash('echo \\"> out'), 'abstain');
+    // Inside single quotes a backslash is literal, so the quote still closes.
+    assert.equal(bash("echo 'a\\' > /dev/null"), 'allow');
+    // Inside double quotes it escapes, so this quote does NOT close.
+    assert.notEqual(bash('echo "a\\"b > f"'), 'abstain');
+  });
+
+  // [codex-2] regression. The redirect deny matched only a cwd-relative `.git/`,
+  // so the absolute and parent-relative forms recorded `abstain` — the
+  // documented denial, silently missing.
+  test('a redirect into git metadata denies wherever the file lives', () => {
+    assert.equal(bash('echo x > /repo/.git/config'), 'deny');
+    assert.equal(bash('echo x > ../.git/config'), 'deny');
+    assert.equal(bash('echo x > .git/config'), 'deny');
+    // The worktree pointer file, same predicate as the file-tool branch.
+    assert.equal(bash('echo x > /repo/.git'), 'deny');
+    // A file that merely starts with `.git` is an ordinary write.
+    assert.equal(bash('echo x > /repo/.gitignore'), 'abstain');
+  });
+
+  test('the deny still fires on the real thing in any segment', () => {
+    assert.equal(bash('git push --force origin main'), 'deny');
+    assert.equal(bash('cd /repo && git push --force origin main'), 'deny');
+    assert.equal(bash('/usr/bin/git push --force origin main'), 'deny');
+  });
+
+  // [glm-5] regression. `git push origin +main` force-updates the remote with
+  // no flag at all, so a flag-only check missed it entirely.
+  test('a + refspec is a force push even with no --force flag', () => {
+    assert.equal(bash('git push origin +main'), 'deny');
+    assert.equal(bash('git push origin +refs/heads/main'), 'deny');
+    assert.notEqual(bash('git push origin main'), 'deny');
+  });
+
+  // [codex-adv round 2] regression. `allow` claims "provably safe", so it must
+  // not drift from the production guard on the same command.
+  describe('allow does not drift from auto-approve-safe-bash', () => {
+    test('an execution-hijacking env assignment is never allowed', () => {
+      assert.equal(bash('LD_PRELOAD=/tmp/evil.so ls'), 'abstain');
+      assert.equal(bash('GIT_EXTERNAL_DIFF=/tmp/evil git diff'), 'abstain');
+      assert.equal(bash('BASH_ENV=/tmp/evil grep x f'), 'abstain');
+      assert.equal(bash('NODE_OPTIONS=--require=/tmp/e git status'), 'abstain');
+    });
+
+    test('locale and timezone assignments stay allowed', () => {
+      assert.equal(bash('LANG=C git log'), 'allow');
+      assert.equal(bash('LC_ALL=C sort f'), 'allow');
+      assert.equal(bash('TZ=UTC date'), 'allow');
+    });
+
+    test('a write-capable flag on a read-only binary is not a read', () => {
+      assert.equal(bash('sort input.txt -o output.txt'), 'abstain');
+      assert.equal(bash('find . -name x -delete'), 'abstain');
+      assert.equal(bash('find . -exec rm {} ;'), 'abstain');
+      assert.equal(bash('xxd -r dump.hex out.bin'), 'abstain');
+      assert.equal(bash('file -C -m custom.mgc'), 'abstain');
+      // The plain read forms stay allowed.
+      assert.equal(bash('sort input.txt'), 'allow');
+      assert.equal(bash('find . -name x'), 'allow');
+    });
+  });
+});
+
+// --- 6. outcome correlation + report -----------------------------------------
+
+describe('outcome + report', () => {
+  test('pre and post agree on a ref so they can be joined', () => {
+    const payload = { session_id: 's1', tool_name: 'Bash', tool_input: { command: 'ls' } };
+    const cls = classify('Bash', payload.tool_input);
+    assert.equal(refFor(payload, cls), refFor(payload, cls));
+    const dir = freshDir();
+    runHook(['pre'], JSON.stringify(payload), dir);
+    runHook(['post'], JSON.stringify(payload), dir);
+    const rows = readAll(path.join(dir, 'ledger.jsonl'));
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].ref, rows[1].ref);
+    assert.equal(rows[1].actual_verdict, 'executed');
+    assert.equal(rows[1].prev_hash, rows[0].hash, 'the outcome extends the chain');
+  });
+
+  // [codex-adv] regression. Without tool_use_id, two IDENTICAL calls in one
+  // session collapsed onto one ref — and because outcomes are matched as a set,
+  // one success marked BOTH executed, hiding a denial behind its twin.
+  test('tool_use_id keeps repeated identical calls distinct', () => {
+    const base = { session_id: 's1', tool_name: 'Bash', tool_input: { command: 'ls' } };
+    const cls = classify('Bash', base.tool_input);
+    const a = refFor({ ...base, tool_use_id: 'toolu_a' }, cls);
+    const b = refFor({ ...base, tool_use_id: 'toolu_b' }, cls);
+    assert.notEqual(a, b, 'distinct calls must not share a ref');
+    assert.equal(a, 'toolu_a');
+  });
+
+  test('the derived fallback is marked so the ambiguity stays visible', () => {
+    const base = { session_id: 's1', tool_name: 'Bash', tool_input: { command: 'ls' } };
+    const r = refFor(base, classify('Bash', base.tool_input));
+    assert.match(r, /^d:/, 'a derived ref is distinguishable from a real tool_use_id');
+  });
+
+  // [codex-1 round 2] regression. Outcomes were matched by SET membership, so
+  // one outcome marked every request sharing that ref executed. Refs are shared
+  // whenever the harness gives no tool_use_id and the derived fallback applies —
+  // exactly the case the unresolved count exists to expose.
+  test('one outcome cannot mark TWO same-ref requests executed', () => {
+    const rows = [
+      { ts: '2026-07-28T00:00:00.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-07-28T00:00:01.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-07-28T00:00:02.000Z', kind: 'outcome', ref: 'd:same' },
+    ];
+    const s = summarize(rows, null, '2026-08-04T00:00:00.000Z');
+    assert.equal(s.requests, 2);
+    assert.equal(s.executed, 1, 'one outcome means one executed');
+    assert.equal(s.unresolved, 1, 'the other stays visible');
+  });
+
+  test('two outcomes for two same-ref requests resolve both', () => {
+    const rows = [
+      { ts: '2026-07-28T00:00:00.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-07-28T00:00:01.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-07-28T00:00:02.000Z', kind: 'outcome', ref: 'd:same' },
+      { ts: '2026-07-28T00:00:03.000Z', kind: 'outcome', ref: 'd:same' },
+    ];
+    const s = summarize(rows, null, '2026-08-04T00:00:00.000Z');
+    assert.equal(s.executed, 2);
+    assert.equal(s.unresolved, 0);
+  });
+
+  test('one outcome does NOT mark a second identical request executed', () => {
+    const dir = freshDir();
+    const mk = (id) => JSON.stringify({
+      session_id: 's1', tool_use_id: id, tool_name: 'Bash', tool_input: { command: 'ls' },
+    });
+    runHook(['pre'], mk('toolu_1'), dir);
+    runHook(['pre'], mk('toolu_2'), dir);
+    runHook(['post'], mk('toolu_1'), dir);   // only the FIRST one ran
+    const s = summarize(readAll(path.join(dir, 'ledger.jsonl')));
+    assert.equal(s.requests, 2);
+    assert.equal(s.executed, 1);
+    assert.equal(s.unresolved, 1, 'the un-executed twin must remain visible');
+  });
+
+  const WEEK_ROWS = [
+    { ts: '2026-07-28T00:00:00.000Z', kind: 'request', ref: 'a', class: 'bash:ls', shadow_verdict: 'allow' },
+    { ts: '2026-07-28T00:00:01.000Z', kind: 'outcome', ref: 'a' },
+    { ts: '2026-07-29T00:00:00.000Z', kind: 'request', ref: 'b', class: 'bash:node x', shadow_verdict: 'abstain' },
+    { ts: '2026-07-29T00:00:02.000Z', kind: 'notification', notification_type: 'permission_prompt' },
+    { ts: '2026-08-04T00:00:00.000Z', kind: 'request', ref: 'c', class: 'bash:ls', shadow_verdict: 'allow' },
+  ];
+
+  test('the report counts interrupts per week and refuses to guess the rest', () => {
+    const s = summarize(WEEK_ROWS, null, '2026-08-04T00:00:00.000Z');
+    assert.equal(s.requests, 3);
+    assert.equal(s.interrupts, 1);
+    assert.equal(s.executed, 1);
+    // b and c never produced an outcome row. That is NOT "denied" — it is
+    // denied OR stranded OR crashed, and the field name says so.
+    assert.equal(s.unresolved, 2);
+    assert.equal(s.span_days, 7);
+    assert.equal(s.interrupts_per_week, 1);
+    assert.deepEqual(s.shadow_verdicts, { allow: 2, deny: 0, abstain: 1 });
+    assert.deepEqual(s.top_classes[0], ['bash:ls', 2]);
+  });
+
+  test('a sub-day window reports the raw count but REFUSES a weekly rate', () => {
+    // A 20-minute sample scaled to a week yields a confident six-figure number
+    // that is pure artefact — and this is the figure the programme is gated on.
+    const s = summarize([
+      { ts: '2026-08-04T08:00:00.000Z', kind: 'request', ref: 'a', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-08-04T08:20:00.000Z', kind: 'notification', notification_type: 'permission_prompt' },
+    ], null, '2026-08-04T08:20:00.000Z');
+    assert.equal(s.interrupts, 1);
+    assert.equal(s.interrupts_per_week, null);
+  });
+
+  // [codex-1] regression. The window is the OBSERVATION period, not the spread
+  // between first and last event. Spread is biased short at both ends and both
+  // errors inflate the rate — on the figure the programme is gated on.
+  test('the window runs to NOW, not to the last event', () => {
+    // Same events, but three quiet days have passed since the last one. The
+    // old spread-based span said 7 days and 1/week; the truth is 10 days.
+    const s = summarize(WEEK_ROWS, null, '2026-08-07T00:00:00.000Z');
+    assert.equal(s.span_days, 10);
+    assert.equal(s.interrupts_per_week, 0.7);
+  });
+
+  test('a quiet window with clustered events does not report an inflated rate', () => {
+    // Two events a minute apart, a week of observation. Spread-based span was
+    // ~0.0007 days → 10,080/week. The observation window is what is real.
+    const s = summarize([
+      { ts: '2026-07-28T00:00:00.000Z', kind: 'notification', notification_type: 'permission_prompt' },
+      { ts: '2026-07-28T00:01:00.000Z', kind: 'notification', notification_type: 'permission_prompt' },
+    ], null, '2026-08-04T00:00:00.000Z');
+    assert.equal(s.span_days, 7);
+    assert.equal(s.interrupts_per_week, 2);
+  });
+
+  test('--days N cannot claim more observation than the ledger holds', () => {
+    // Asking for 7 days of a ledger that only started 2 days ago is 2 days of
+    // evidence, not 7 — otherwise the rate is silently divided by too much.
+    const s = summarize(
+      [{ ts: '2026-08-02T00:00:00.000Z', kind: 'notification', notification_type: 'permission_prompt' }],
+      '2026-07-28T00:00:00.000Z',
+      '2026-08-04T00:00:00.000Z',
+    );
+    assert.equal(s.span_days, 2);
+  });
+
+  // [codex-adv] regression, the most consequential one: Notification does NOT
+  // fire only for permission prompts. Counting idle-wait timeouts and
+  // elicitation dialogs as approval interrupts inflates the exact number the
+  // trust programme is gated on.
+  describe('only permission notifications count as interrupts', () => {
+    test('classification', () => {
+      assert.ok(isApprovalInterrupt('permission_prompt'));
+      assert.ok(isApprovalInterrupt('tool_permission'));
+      assert.ok(!isApprovalInterrupt('idle_prompt'));
+      assert.ok(!isApprovalInterrupt('auth_success'));
+      assert.ok(!isApprovalInterrupt('elicitation'));
+      assert.ok(!isApprovalInterrupt(null));
+    });
+
+    test('the gate number counts only the permission ones', () => {
+      const s = summarize([
+        { ts: '2026-07-28T00:00:00.000Z', kind: 'notification', notification_type: 'permission_prompt' },
+        { ts: '2026-07-30T00:00:00.000Z', kind: 'notification', notification_type: 'idle_prompt' },
+        { ts: '2026-08-01T00:00:00.000Z', kind: 'notification', notification_type: 'auth_success' },
+      ], null, '2026-08-04T00:00:00.000Z');
+      assert.equal(s.notifications, 3);
+      assert.equal(s.interrupts, 1, 'idle + auth are not approval pressure');
+      assert.equal(s.interrupts_per_week, 1);
+    });
+
+    // The safety net on the loose match: an unrecognised vocabulary must be
+    // VISIBLE, not silently absent. A hook-side filter would have made a
+    // changed type-name read as a genuinely quiet week.
+    test('uncounted types are reported by name, never silently dropped', () => {
+      const s = summarize([
+        { ts: '2026-07-28T00:00:00.000Z', kind: 'notification', notification_type: 'some_new_type' },
+        { ts: '2026-07-29T00:00:00.000Z', kind: 'notification', notification_type: 'some_new_type' },
+        { ts: '2026-07-30T00:00:00.000Z', kind: 'notification', notification_type: null },
+      ], null, '2026-08-04T00:00:00.000Z');
+      assert.equal(s.interrupts, 0);
+      assert.deepEqual(s.uncounted_notification_types, { some_new_type: 2, '(none)': 1 });
+    });
+
+    test('the notify hook records every type, filtering happens at report time', () => {
+      const dir = freshDir();
+      runHook(['notify'], JSON.stringify({ session_id: 's', notification_type: 'idle_prompt' }), dir);
+      const [row] = readAll(path.join(dir, 'ledger.jsonl'));
+      assert.equal(row.kind, 'notification');
+      assert.equal(row.notification_type, 'idle_prompt', 'recorded, so it can be reclassified later');
+    });
+  });
+
+  test('report runs on an empty ledger without throwing', () => {
+    const r = runHook(['report'], '', freshDir());
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /APPROVAL INTERRUPTS 0/);
+    assert.match(r.stdout, /no weekly rate yet/);
+  });
+
+  test('report --json is machine-readable', () => {
+    const dir = freshDir();
+    runHook(['pre'], PRE_BASH, dir);
+    const r = runHook(['report', '--json'], '', dir);
+    assert.equal(r.status, 0);
+    assert.equal(JSON.parse(r.stdout).requests, 1);
+  });
+});

--- a/scripts/trust/tests/shadow-ledger.test.mjs
+++ b/scripts/trust/tests/shadow-ledger.test.mjs
@@ -16,8 +16,9 @@ import { after, before, describe, test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
-  append, canonical, chainHash, classify, isApprovalInterrupt, lastRecord,
-  readAll, readLedger, refFor, shadowVerdict, summarize, RECORDED_TOOLS,
+  append, canonical, chainHash, classify, healthPath, isApprovalInterrupt,
+  lastRecord, readAll, readDrops, readLedger, refFor, shadowVerdict, summarize,
+  RECORDED_TOOLS,
 } from '../shadow-ledger.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -290,7 +291,7 @@ describe('hash chain', () => {
   // publishing a confident rate is the failure: the number comes out plausible
   // but understated, with nothing to signal it.
   describe('a damaged ledger cannot publish a rate', () => {
-    test('an interior torn row is counted, a torn FINAL row is not', () => {
+    test('an interior torn row is counted as malformed', () => {
       const dir = freshDir();
       process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
       fs.mkdirSync(dir, { recursive: true });
@@ -298,19 +299,88 @@ describe('hash chain', () => {
       append({ ts: 'a', kind: 'request' });
       fs.appendFileSync(f, '{"torn":\n');          // interior damage
       append({ ts: 'b', kind: 'request' });
-      let led = readLedger(f);
+      const led = readLedger(f);
       assert.equal(led.malformed, 1);
       assert.equal(led.intact, false);
+      process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+    });
 
-      const dir2 = freshDir();
-      process.env.HIMMEL_TRUST_LEDGER_DIR = dir2;
-      fs.mkdirSync(dir2, { recursive: true });
-      const f2 = path.join(dir2, 'ledger.jsonl');
+    // [HIMMEL-1539] A torn FINAL line used to be exempted UNCONDITIONALLY as a
+    // normal in-flight append. That is true only while a writer is alive to heal
+    // it. Abandoned — a killed hook, a power loss — nothing ever heals it, the
+    // event is permanently lost, and the ledger read `intact` forever. On a
+    // quiet ledger, where one lost event moves the rate most, it could stay
+    // missing indefinitely under a confidently published number.
+    // [codex-adv round 1] A live writer buys the fragment a bounded WAIT, never
+    // forgiveness. Liveness of some lock holder does not tie that holder to
+    // THIS fragment — a later writer would briefly absolve an abandoned one it
+    // never created — and a report racing an incomplete append must not publish
+    // before the row lands. So after the wait, a tail that still does not parse
+    // is damage no matter who holds the lock.
+    test('a live writer does NOT make a torn tail intact — it only buys a wait', () => {
+      const dir = freshDir();
+      process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+      fs.mkdirSync(dir, { recursive: true });
+      const f = path.join(dir, 'ledger.jsonl');
       append({ ts: 'a', kind: 'request' });
-      fs.appendFileSync(f2, '{"in-flight":');      // torn FINAL line: expected
-      led = readLedger(f2);
-      assert.equal(led.malformed, 0, 'an unterminated last line is a normal in-flight append');
-      assert.equal(led.intact, true);
+      fs.appendFileSync(f, '{"never-completed":');
+      // A lock owned by THIS process, freshly stamped: a genuinely live writer
+      // that nonetheless never completes the fragment.
+      fs.writeFileSync(path.join(dir, '.ledger.lock'), `${process.pid} ${Date.now()}`);
+      const led = readLedger(f);
+      assert.equal(led.torn, 1, 'the wait expired and the fragment still does not parse');
+      assert.equal(led.intact, false);
+      process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+    });
+
+    test('a fragment healed into an interior line is still counted', () => {
+      const dir = freshDir();
+      process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+      fs.mkdirSync(dir, { recursive: true });
+      const f = path.join(dir, 'ledger.jsonl');
+      append({ ts: 'a', kind: 'request' });
+      fs.appendFileSync(f, '{"torn":');
+      // A completing append heals the file by prefixing a newline to its OWN
+      // record — that does not recover the lost event, it just stops the damage
+      // swallowing the next one. The fragment becomes INTERIOR, so it must
+      // still show up, as `malformed` rather than `torn`.
+      append({ ts: 'b', kind: 'request' });
+      const led = readLedger(f);
+      assert.equal(led.torn, 0);
+      assert.equal(led.malformed, 1, 'healing is not recovery — the event stays lost and counted');
+      assert.equal(led.intact, false);
+      process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+    });
+
+    test('an ABANDONED torn FINAL row is damage and suppresses the rate', () => {
+      const dir = freshDir();
+      process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+      fs.mkdirSync(dir, { recursive: true });
+      const f = path.join(dir, 'ledger.jsonl');
+      append({ ts: '2026-07-28T00:00:00.000Z', kind: 'notification', notification_type: 'permission_prompt' });
+      fs.appendFileSync(f, '{"abandoned":');       // no lock file => no live writer
+      const led = readLedger(f);
+      assert.equal(led.torn, 1, 'nothing will ever heal this fragment');
+      assert.equal(led.intact, false);
+      const s = summarize(led.records, null, '2026-08-04T00:00:00.000Z', led);
+      assert.equal(s.interrupts, 1, 'the raw count is still shown');
+      assert.equal(s.interrupts_per_week, null, 'but a ledger missing an event publishes no rate');
+      process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+    });
+
+    test('a torn FINAL row under a STALE lock is still damage', () => {
+      const dir = freshDir();
+      process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+      fs.mkdirSync(dir, { recursive: true });
+      const f = path.join(dir, 'ledger.jsonl');
+      append({ ts: 'a', kind: 'request' });
+      fs.appendFileSync(f, '{"abandoned":');
+      // Our own pid — alive — but stamped long ago. Liveness of the PID is not
+      // evidence the LOCK is held; a recycled pid must not exempt the fragment.
+      fs.writeFileSync(path.join(dir, '.ledger.lock'), `${process.pid} ${Date.now() - 600000}`);
+      const led = readLedger(f);
+      assert.equal(led.torn, 1, 'a stale stamp means the holder is long gone');
+      assert.equal(led.intact, false);
       process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
     });
 
@@ -702,7 +772,7 @@ describe('outcome + report', () => {
     const rows = [
       { ts: '2026-07-28T00:00:00.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
       { ts: '2026-07-28T00:00:01.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
-      { ts: '2026-07-28T00:00:02.000Z', kind: 'outcome', ref: 'd:same' },
+      { ts: '2026-07-28T00:00:02.000Z', kind: 'outcome', ref: 'd:same', actual_verdict: 'executed' },
     ];
     const s = summarize(rows, null, '2026-08-04T00:00:00.000Z');
     assert.equal(s.requests, 2);
@@ -714,8 +784,8 @@ describe('outcome + report', () => {
     const rows = [
       { ts: '2026-07-28T00:00:00.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
       { ts: '2026-07-28T00:00:01.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
-      { ts: '2026-07-28T00:00:02.000Z', kind: 'outcome', ref: 'd:same' },
-      { ts: '2026-07-28T00:00:03.000Z', kind: 'outcome', ref: 'd:same' },
+      { ts: '2026-07-28T00:00:02.000Z', kind: 'outcome', ref: 'd:same', actual_verdict: 'executed' },
+      { ts: '2026-07-28T00:00:03.000Z', kind: 'outcome', ref: 'd:same', actual_verdict: 'executed' },
     ];
     const s = summarize(rows, null, '2026-08-04T00:00:00.000Z');
     assert.equal(s.executed, 2);
@@ -738,7 +808,7 @@ describe('outcome + report', () => {
 
   const WEEK_ROWS = [
     { ts: '2026-07-28T00:00:00.000Z', kind: 'request', ref: 'a', class: 'bash:ls', shadow_verdict: 'allow' },
-    { ts: '2026-07-28T00:00:01.000Z', kind: 'outcome', ref: 'a' },
+    { ts: '2026-07-28T00:00:01.000Z', kind: 'outcome', ref: 'a', actual_verdict: 'executed' },
     { ts: '2026-07-29T00:00:00.000Z', kind: 'request', ref: 'b', class: 'bash:node x', shadow_verdict: 'abstain' },
     { ts: '2026-07-29T00:00:02.000Z', kind: 'notification', notification_type: 'permission_prompt' },
     { ts: '2026-08-04T00:00:00.000Z', kind: 'request', ref: 'c', class: 'bash:ls', shadow_verdict: 'allow' },
@@ -862,5 +932,527 @@ describe('outcome + report', () => {
     const r = runHook(['report', '--json'], '', dir);
     assert.equal(r.status, 0);
     assert.equal(JSON.parse(r.stdout).requests, 1);
+  });
+});
+
+// --- HIMMEL-1539: the recorder can say when it recorded NOTHING ---------------
+//
+// All three gaps this block covers failed in the SAME direction — the gate
+// number came out understated with nothing to signal it — which is the one
+// failure mode HIMMEL-1529's own README argues is worse than having no
+// instrument at all, because the number still looks like a number.
+
+describe('dropped writes are visible, not silent', () => {
+  test('lock exhaustion records a drop instead of losing the event silently', () => {
+    const dir = freshDir();
+    process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+    fs.mkdirSync(dir, { recursive: true });
+    // A lock held by a LIVE pid with a FRESH stamp: breakStaleLock must not
+    // reclaim it, so withLock burns its retries and gives the record up.
+    fs.writeFileSync(path.join(dir, '.ledger.lock'), `${process.pid} ${Date.now()}`);
+
+    const result = append({ ts: 'a', kind: 'request' });
+    assert.equal(result, null, 'the append is given up — fail-open, never block');
+
+    const drops = readDrops(path.join(dir, 'drops.jsonl'));
+    assert.equal(drops.length, 1, 'and the loss is RECORDED');
+    assert.equal(drops[0].reason, 'lock_exhausted');
+    process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+  });
+
+  test('a failed append records a drop rather than being swallowed by fail-open', () => {
+    const dir = freshDir();
+    process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+    fs.mkdirSync(dir, { recursive: true });
+    // A directory where the ledger file belongs: every write to it throws.
+    // Previously the exception reached the top-level fail-open handler, which
+    // exited 0 and said nothing — correct for the tool call, silent for the
+    // measurement.
+    fs.mkdirSync(path.join(dir, 'ledger.jsonl'), { recursive: true });
+
+    const result = append({ ts: 'a', kind: 'request' });
+    assert.equal(result, null);
+
+    const drops = readDrops(path.join(dir, 'drops.jsonl'));
+    assert.equal(drops.length, 1);
+    assert.equal(drops[0].reason, 'append_failed');
+    process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+  });
+
+  test('a window with dropped writes publishes NO rate', () => {
+    const rows = [
+      { ts: '2026-07-28T00:00:00.000Z', kind: 'notification', notification_type: 'permission_prompt' },
+    ];
+    const intact = { intact: true, malformed: 0, torn: 0, brokenLinks: 0 };
+    const clean = summarize(rows, null, '2026-08-04T00:00:00.000Z', intact, []);
+    assert.equal(clean.interrupts_per_week, 1, 'a clean window still reports a rate');
+
+    const dropped = summarize(rows, null, '2026-08-04T00:00:00.000Z', intact, [
+      { ts: '2026-07-30T00:00:00.000Z', reason: 'lock_exhausted' },
+    ]);
+    assert.equal(dropped.interrupts, 1, 'the raw count is still shown');
+    assert.equal(dropped.dropped_writes, 1);
+    assert.equal(
+      dropped.interrupts_per_week, null,
+      'the chain validates the rows that LANDED; it cannot attest the ones that never did',
+    );
+  });
+
+  test('an unparseable drop row still counts as a drop', () => {
+    const dir = freshDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const f = path.join(dir, 'drops.jsonl');
+    fs.writeFileSync(f, '{"ts":"2026-08-01T00:00:00.000Z","reason":"lock_exhausted"}\n{"tor\n');
+    const drops = readDrops(f);
+    assert.equal(drops.length, 2, 'discarding it would restore the exact blindness this removes');
+    assert.equal(drops[1].ts, null);
+    // Drops are not expired by timestamp at all (round 6), so BOTH count —
+    // the readable one and the one whose row could not be parsed.
+    const s = summarize([], '2026-08-04T00:00:00.000Z', '2026-08-05T00:00:00.000Z', null, drops);
+    assert.equal(s.dropped_writes, 2, 'a recorded loss counts regardless of what its ts claims');
+  });
+
+  // [codex-adv round 5] A truthy-but-unusable `ts` defeated the window filter:
+  // {"ts":123} is valid JSON, so readDrops kept it verbatim, `!d.ts` was false,
+  // and `123 >= "2026-..."` compared false — excluding a KNOWN recorder failure
+  // and restoring the rate it was supposed to suppress.
+  test('a malformed drop timestamp cannot restore a suppressed rate', () => {
+    const rows = [
+      { ts: '2026-07-28T00:00:00.000Z', kind: 'notification', notification_type: 'permission_prompt' },
+    ];
+    const intact = { intact: true, malformed: 0, torn: 0, brokenLinks: 0 };
+    for (const badTs of [123, null, undefined, {}, 'not-a-date', '']) {
+      const s = summarize(rows, '2026-07-01T00:00:00.000Z', '2026-08-04T00:00:00.000Z', intact,
+        [{ ts: badTs, reason: 'append_failed' }]);
+      assert.equal(s.dropped_writes, 1, `ts=${JSON.stringify(badTs)} must still count`);
+      assert.equal(s.interrupts_per_week, null, `ts=${JSON.stringify(badTs)} must suppress the rate`);
+    }
+  });
+
+  // [codex-adv round 6] `null`, `42` and `"x"` are all valid JSON. Every
+  // consumer dereferences `.kind`, so an unvalidated row threw a TypeError that
+  // the fail-open handler turned into exit 0 with EMPTY stdout — corruption
+  // producing neither a report nor a warning.
+  test('a valid-JSON non-object row is damage, not a crash', () => {
+    const dir = freshDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const f = path.join(dir, 'ledger.jsonl');
+    fs.writeFileSync(f, 'null\n42\n"x"\n[1,2]\n');
+    const led = readLedger(f);
+    assert.equal(led.records.length, 0);
+    assert.equal(led.malformed, 4, 'each unusable shape is counted');
+    assert.equal(led.intact, false);
+  });
+
+  test('report still produces output over a corrupted ledger', () => {
+    const dir = freshDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'ledger.jsonl'), 'null\n');
+    const r = runHook(['report'], '', dir);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /shadow ledger/, 'corruption must not yield silent empty output');
+    assert.match(r.stdout, /INTEGRITY/);
+  });
+
+  // [CodeRabbit App] process.exit() can truncate a pending stdout write when
+  // stdout is a pipe — which is how report is always read. A truncated report
+  // is the same silence rounds 6 and 7 closed, reached by another route.
+  test('a LARGE report survives the pipe intact', () => {
+    const dir = freshDir();
+    fs.mkdirSync(dir, { recursive: true });
+    // Enough distinct classes to push the report well past a pipe buffer's
+    // first chunk, so a truncating exit would visibly cut the tail off.
+    for (let i = 0; i < 400; i++) {
+      runHook(['pre'], JSON.stringify({
+        session_id: 's1', tool_use_id: `t${i}`, tool_name: 'Bash',
+        tool_input: { command: `echo case-${i}` },
+      }), dir);
+    }
+    const r = runHook(['report'], '', dir);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /shadow ledger/, 'the head is present');
+    // The NOTE block is the last thing printed before the class table, so its
+    // presence proves the tail was not cut off.
+    assert.match(r.stdout, /gate number is APPROVAL INTERRUPTS per week/, 'the tail survived');
+    assert.match(r.stdout, /requests recorded 400/);
+  });
+
+  test('report FAILS LOUDLY rather than exiting 0 with nothing', () => {
+    // Fail-open is a HOOK contract; `report` is the operator reading the
+    // instrument. A directory where the ledger belongs makes readLedger flag
+    // it unreadable, which must still print — never a silent exit 0.
+    const dir = freshDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(path.join(dir, 'ledger.jsonl'), { recursive: true });
+    const r = runHook(['report'], '', dir);
+    assert.equal(r.status, 0);
+    assert.notEqual(r.stdout.trim(), '', 'silence is the one answer this file must not give');
+  });
+
+  // [codex-adv round 6] Drops are no longer expired by timestamp AT ALL. A
+  // backward clock step across the cutoff re-dated an in-window failure as old,
+  // producing dropped_writes=0 and a confident rate over known-missing events.
+  // There is no durable proof a drop predates a window, so a recorded drop
+  // suppresses until an operator acknowledges it by rotating drops.jsonl.
+  test('a drop does not expire on wall-clock, however old it looks', () => {
+    const rows = [
+      { ts: '2026-08-02T00:00:00.000Z', kind: 'notification', notification_type: 'permission_prompt' },
+    ];
+    const intact = { intact: true, malformed: 0, torn: 0, brokenLinks: 0 };
+    const s = summarize(rows, '2026-08-01T00:00:00.000Z', '2026-08-04T00:00:00.000Z', intact,
+      [{ ts: '2026-07-01T00:00:00.000Z', reason: 'append_failed' }]);
+    assert.equal(s.dropped_writes, 1);
+    assert.equal(s.interrupts_per_week, null, 'a clock cannot be trusted to expire a known loss');
+  });
+
+  // [codex-adv round 7] Round 6 documented "rotate drops.jsonl to acknowledge",
+  // which LAUNDERS the loss: the missing event is still absent from the window,
+  // but the rate returns. Reproduced — null with a drop, 0/week immediately
+  // after rotation. There is now deliberately no acknowledgement path that
+  // restores a rate; doing it honestly needs HIMMEL-1547's checkpoint.
+  test('the report does not offer a recovery that launders the loss', () => {
+    const dir = freshDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'drops.jsonl'),
+      '{"ts":"2026-08-01T00:00:00.000Z","reason":"append_failed"}\n');
+    const r = runHook(['report'], '', dir);
+    assert.match(r.stdout, /Drops do NOT/);
+    assert.match(r.stdout, /HIMMEL-1547/);
+    assert.doesNotMatch(r.stdout, /acknowledge them by rotating/);
+  });
+
+  test('report names the drop channel instead of implying a floor is a measurement', () => {
+    const dir = freshDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'drops.jsonl'),
+      '{"ts":"2026-08-01T00:00:00.000Z","reason":"append_failed"}\n',
+    );
+    const r = runHook(['report'], '', dir);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /DROPPED WRITES/);
+    assert.match(r.stdout, /no rate published/);
+  });
+
+  // [codex-adv round 1, high] recordDrop writes beside the ledger, so a
+  // volume-wide failure can lose the ledger event AND its drop row together.
+  // That residual is documented, not claimed away. What IS fixed: a health
+  // channel that exists but cannot be READ must not read as "no drops".
+  test('an UNREADABLE health channel counts as a drop, never as clean', () => {
+    const dir = freshDir();
+    fs.mkdirSync(dir, { recursive: true });
+    // A directory where drops.jsonl belongs: readFileSync throws EISDIR, not
+    // ENOENT — i.e. the channel exists but cannot be read.
+    fs.mkdirSync(path.join(dir, 'drops.jsonl'), { recursive: true });
+    const drops = readDrops(path.join(dir, 'drops.jsonl'));
+    assert.equal(drops.length, 1);
+    assert.equal(drops[0].reason, 'health_channel_unreadable');
+
+    const rows = [
+      { ts: '2026-07-28T00:00:00.000Z', kind: 'notification', notification_type: 'permission_prompt' },
+    ];
+    const intact = { intact: true, malformed: 0, torn: 0, brokenLinks: 0 };
+    const s = summarize(rows, null, '2026-08-04T00:00:00.000Z', intact, drops);
+    assert.equal(s.interrupts_per_week, null, 'unknown must not present as clean');
+    assert.equal(s.health_channel_unreadable, true);
+  });
+
+  test('a MISSING health channel is the ordinary healthy case', () => {
+    const dir = freshDir();
+    fs.mkdirSync(dir, { recursive: true });
+    // ENOENT means no drop has ever been recorded — that is genuinely clean,
+    // and must NOT suppress the rate or the gate becomes unusable.
+    assert.deepEqual(readDrops(path.join(dir, 'drops.jsonl')), []);
+  });
+
+  test('an unreadable LEDGER does not read as an empty intact one', () => {
+    const dir = freshDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(path.join(dir, 'ledger.jsonl'), { recursive: true });
+    const led = readLedger(path.join(dir, 'ledger.jsonl'));
+    assert.equal(led.intact, false, 'cannot-read is unknown, not clean');
+    // [glm round 4] An unopenable FILE is not an unparseable ROW. Counting it
+    // as malformed suppressed the rate correctly but printed "1 unreadable
+    // row(s)" over a file with zero rows — a true verdict via a false claim.
+    assert.equal(led.unreadable, true);
+    assert.equal(led.malformed, 0, 'there are no rows to be malformed');
+  });
+
+  test('the report distinguishes an unreadable FILE from unparseable ROWS', () => {
+    const dir = freshDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(path.join(dir, 'ledger.jsonl'), { recursive: true });
+    const r = runHook(['report'], '', dir);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /could not be read/);
+    assert.doesNotMatch(r.stdout, /unparseable row/);
+  });
+
+  test('a ledger that does not exist yet IS intact', () => {
+    const dir = freshDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const led = readLedger(path.join(dir, 'ledger.jsonl'));
+    assert.equal(led.intact, true);
+    assert.deepEqual(led.records, []);
+  });
+
+  test('healthPath is a different file from the ledger', () => {
+    const dir = freshDir();
+    process.env.HIMMEL_TRUST_LEDGER_DIR = dir;
+    // The drop channel must not share the ledger's lock or its chain: the events
+    // it records are precisely the ones the ledger could not record.
+    assert.notEqual(healthPath(), path.join(dir, 'ledger.jsonl'));
+    process.env.HIMMEL_TRUST_LEDGER_DIR = TMP;
+  });
+});
+
+describe('failed and denied calls get a terminal outcome', () => {
+  const CALL = JSON.stringify({
+    session_id: 's1',
+    tool_use_id: 'toolu_x',
+    tool_name: 'Bash',
+    tool_input: { command: 'ls' },
+  });
+
+  test('PostToolUseFailure records executed_failed, not a silent unresolved', () => {
+    const dir = freshDir();
+    runHook(['pre'], CALL, dir);
+    runHook(['postfail'], CALL, dir);
+    const rows = readAll(path.join(dir, 'ledger.jsonl'));
+    assert.equal(rows.length, 2);
+    assert.equal(rows[1].actual_verdict, 'executed_failed');
+    assert.equal(rows[1].prev_hash, rows[0].hash, 'the outcome extends the chain');
+
+    const s = summarize(rows);
+    assert.equal(s.executed_failed, 1);
+    assert.equal(s.unresolved, 0, 'a call that ran and failed is RESOLVED');
+    assert.equal(s.executed, 0, 'and it is not counted as a success');
+  });
+
+  test('PermissionDenied records an AUTO-CLASSIFIER-scoped denial', () => {
+    const dir = freshDir();
+    runHook(['pre'], CALL, dir);
+    runHook(['denied'], CALL, dir);
+    const rows = readAll(path.join(dir, 'ledger.jsonl'));
+    // [codex-adv round 1] The hook reference is explicit that PermissionDenied
+    // fires only "when a tool call is denied by the auto mode classifier" —
+    // manual denials, deny rules and PreToolUse blocks do NOT raise it. The
+    // verdict is named for what it actually observes; a plain `denied` would
+    // read as complete denial coverage, which is the exact failure class this
+    // ticket exists to remove.
+    assert.equal(rows[1].actual_verdict, 'denied_auto_classifier');
+    const s = summarize(rows);
+    assert.equal(s.denied_auto_classifier, 1);
+    assert.equal(s.unresolved, 0);
+  });
+
+  test('the report does not claim denial coverage it does not have', () => {
+    const dir = freshDir();
+    runHook(['pre'], CALL, dir);
+    runHook(['denied'], CALL, dir);
+    const r = runHook(['report'], '', dir);
+    assert.match(r.stdout, /AUTO-MODE CLASSIFIER denials ONLY/);
+    assert.match(r.stdout, /manual denials, deny rules and PreToolUse blocks do NOT appear here/);
+  });
+
+  test('failures and denials no longer collapse into one bucket', () => {
+    // The defect: with only PostToolUse wired, BOTH of these landed in
+    // `unresolved` alongside genuine strands, so actual_verdict data was
+    // corrupted by construction — a failure is not an approval interrupt and a
+    // denial is.
+    const rows = [
+      { ts: '2026-07-28T00:00:00.000Z', kind: 'request', ref: 'a', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-07-28T00:00:01.000Z', kind: 'request', ref: 'b', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-07-28T00:00:02.000Z', kind: 'request', ref: 'c', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-07-28T00:00:03.000Z', kind: 'outcome', ref: 'a', actual_verdict: 'executed' },
+      { ts: '2026-07-28T00:00:04.000Z', kind: 'outcome', ref: 'b', actual_verdict: 'executed_failed' },
+      { ts: '2026-07-28T00:00:05.000Z', kind: 'outcome', ref: 'c', actual_verdict: 'denied_auto_classifier' },
+    ];
+    const s = summarize(rows, null, '2026-08-04T00:00:00.000Z');
+    assert.deepEqual(
+      { e: s.executed, f: s.executed_failed, d: s.denied_auto_classifier, u: s.unresolved },
+      { e: 1, f: 1, d: 1, u: 0 },
+    );
+  });
+
+  test('an UNRECOGNISED verdict surfaces as other, never as executed', () => {
+    // Same rule as uncounted_notification_types: a vocabulary this file does not
+    // control must show up by name rather than vanish into the flattering bucket.
+    const rows = [
+      { ts: '2026-07-28T00:00:00.000Z', kind: 'request', ref: 'a', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-07-28T00:00:01.000Z', kind: 'outcome', ref: 'a', actual_verdict: 'teleported' },
+    ];
+    const s = summarize(rows, null, '2026-08-04T00:00:00.000Z');
+    assert.equal(s.executed, 0);
+    assert.equal(s.outcome_other, 1);
+    assert.equal(s.unresolved, 0, 'it IS resolved — just not by a verdict we know');
+  });
+
+  test('the outcome verdict is consumed per request, not shared across a ref', () => {
+    // The per-ref budget still holds under verdict-bearing outcomes: two
+    // same-ref requests with one denial are one denied and one unresolved.
+    const rows = [
+      { ts: '2026-07-28T00:00:00.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-07-28T00:00:01.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-07-28T00:00:02.000Z', kind: 'outcome', ref: 'd:same', actual_verdict: 'denied_auto_classifier' },
+    ];
+    const s = summarize(rows, null, '2026-08-04T00:00:00.000Z');
+    assert.equal(s.denied_auto_classifier, 1);
+    assert.equal(s.unresolved, 1);
+  });
+
+  // [codex-adv round 2] A `--days` cutoff that slices between a request and its
+  // outcome leaves an ORPHAN outcome inside the window. Before this fix a later
+  // request sharing the derived `d:` ref consumed it — codex's reproduction
+  // returned executed=1/unresolved=0 for a request that never ran.
+  test('an orphan outcome cannot resolve a LATER request', () => {
+    const rows = [
+      // The earlier call's request is outside the window; only its outcome is in.
+      { ts: '2026-07-30T00:00:00.000Z', kind: 'outcome', ref: 'd:same', actual_verdict: 'executed' },
+      // A later, identical call that never produced an outcome of its own.
+      { ts: '2026-07-31T00:00:00.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
+    ];
+    const s = summarize(rows, '2026-07-29T00:00:00.000Z', '2026-08-05T00:00:00.000Z');
+    assert.equal(s.requests, 1);
+    assert.equal(s.executed, 0, 'an outcome that PRECEDES a request is not its outcome');
+    assert.equal(s.unresolved, 1, 'the un-executed request must stay visible');
+  });
+
+  // [codex-adv round 3] Wall-clock does not prove ordering. Row position does —
+  // the ledger is append-only and hash-chained. These are the two boundaries
+  // where a `ts` comparison broke, both measured on the previous fix.
+  test('an EQUAL timestamp does not let an orphan outcome be consumed', () => {
+    const rows = [
+      { ts: '2026-07-31T00:00:00.000Z', kind: 'outcome', ref: 'd:same', actual_verdict: 'executed' },
+      { ts: '2026-07-31T00:00:00.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
+    ];
+    const s = summarize(rows, null, '2026-08-05T00:00:00.000Z');
+    assert.equal(s.executed, 0, 'the outcome sits EARLIER in the ledger; it cannot be this request\'s');
+    assert.equal(s.unresolved, 1);
+  });
+
+  test('a BACKWARD clock adjustment does not lose a real outcome', () => {
+    const rows = [
+      { ts: '2026-07-31T00:00:00.002Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
+      // Physically after the request, but stamped 1 ms earlier by a clock step.
+      { ts: '2026-07-31T00:00:00.001Z', kind: 'outcome', ref: 'd:same', actual_verdict: 'executed' },
+    ];
+    const s = summarize(rows, null, '2026-08-05T00:00:00.000Z');
+    assert.equal(s.executed, 1, 'row position says it followed, and row position is the truth');
+    assert.equal(s.unresolved, 0);
+  });
+
+  // [codex-adv round 4] Correlation must run over the FULL history, with the
+  // window applied to the RESULTS. Filtering requests first left the pre-cutoff
+  // request's outcome unclaimed, and the in-window request sharing its derived
+  // ref consumed it — reporting an execution that request never had.
+  test('an outcome belonging to a PRE-CUTOFF request cannot be stolen', () => {
+    const rows = [
+      // Owner, before the cutoff.
+      { ts: '2026-07-20T00:00:00.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
+      // A new request after the cutoff, sharing the derived ref.
+      { ts: '2026-08-01T00:00:00.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
+      // The FIRST request's outcome, landing after the second request started.
+      { ts: '2026-08-02T00:00:00.000Z', kind: 'outcome', ref: 'd:same', actual_verdict: 'executed' },
+    ];
+    const s = summarize(rows, '2026-07-30T00:00:00.000Z', '2026-08-05T00:00:00.000Z');
+    assert.equal(s.requests, 1, 'only the post-cutoff request is counted');
+    assert.equal(s.executed, 0, 'its predecessor claimed that outcome');
+    assert.equal(s.unresolved, 1);
+  });
+
+  test('an outcome outside the window still resolves an in-window request', () => {
+    // Outcomes are deliberately NOT window-filtered: a request just inside the
+    // cutoff must still be resolvable by its own outcome.
+    const rows = [
+      { ts: '2026-07-31T00:00:00.000Z', kind: 'request', ref: 'r1', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-08-01T00:00:00.000Z', kind: 'outcome', ref: 'r1', actual_verdict: 'executed' },
+    ];
+    const s = summarize(rows, '2026-07-30T00:00:00.000Z', '2026-08-05T00:00:00.000Z');
+    assert.equal(s.executed, 1);
+    assert.equal(s.unresolved, 0);
+  });
+
+  test('an outcome that follows its request still resolves it', () => {
+    // The guard must not over-correct: ordinary same-ref pairs still match.
+    const rows = [
+      { ts: '2026-07-31T00:00:00.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-07-31T00:00:01.000Z', kind: 'outcome', ref: 'd:same', actual_verdict: 'executed' },
+      { ts: '2026-07-31T00:00:02.000Z', kind: 'request', ref: 'd:same', class: 'bash:ls', shadow_verdict: 'allow' },
+      { ts: '2026-07-31T00:00:03.000Z', kind: 'outcome', ref: 'd:same', actual_verdict: 'denied_auto_classifier' },
+    ];
+    const s = summarize(rows, null, '2026-08-05T00:00:00.000Z');
+    assert.equal(s.executed, 1);
+    assert.equal(s.denied_auto_classifier, 1);
+    assert.equal(s.unresolved, 0);
+  });
+
+  test('the failure and denial hooks still never emit a permission decision', () => {
+    const dir = freshDir();
+    for (const verb of ['postfail', 'denied', 'permreq']) {
+      const r = runHook([verb], CALL, dir);
+      assert.equal(r.status, 0, `${verb} exits 0`);
+      assert.equal(r.stdout.trim(), '', `${verb} writes nothing to stdout`);
+    }
+  });
+});
+
+describe('PermissionRequest is an EVENT count, not an interrupt count', () => {
+  test('it is recorded and counted separately from the Notification proxy', () => {
+    const dir = freshDir();
+    runHook(['permreq'], JSON.stringify({ session_id: 's1', tool_name: 'Bash' }), dir);
+    runHook(['notify'], JSON.stringify({ session_id: 's1', notification_type: 'permission_prompt' }), dir);
+    const s = summarize(readAll(path.join(dir, 'ledger.jsonl')));
+    assert.equal(s.permission_request_events, 1, 'the event count');
+    assert.equal(s.interrupts, 1, 'the Notification-derived count, kept independent');
+  });
+
+  // [codex-adv round 2] The event fires when a decision is NEEDED, which is not
+  // the same as a human being interrupted — W0 probe P5 measured an `ask`
+  // hanging 902 s in an armed session with nobody present to answer. Labelling
+  // the count a direct interrupt observation would inflate the gate number
+  // precisely in the unattended runs this harness does most.
+  test('the report does not claim these are human interruptions', () => {
+    const dir = freshDir();
+    runHook(['permreq'], JSON.stringify({ session_id: 's1', tool_name: 'Bash' }), dir);
+    const r = runHook(['report'], '', dir);
+    assert.match(r.stdout, /permission-request events/);
+    assert.match(r.stdout, /NOT proof anyone was interrupted/);
+  });
+
+  test('permission_mode is persisted but not interpreted', () => {
+    const dir = freshDir();
+    runHook(['permreq'], JSON.stringify({
+      session_id: 's1', tool_name: 'Bash', permission_mode: 'auto',
+    }), dir);
+    const rows = readAll(path.join(dir, 'ledger.jsonl'));
+    // Stored as the only interactivity-adjacent signal on the payload. No count
+    // splits on it yet — that would claim a distinction not yet demonstrated.
+    assert.equal(rows[0].permission_mode, 'auto');
+  });
+
+  test('it does NOT silently become the gate number', () => {
+    // Two independent estimators of one quantity are how you find out which is
+    // right. Swapping the gate metric onto the new surface would replace a
+    // measured number with an unvalidated one and destroy the comparison.
+    const rows = [
+      { ts: '2026-07-28T00:00:00.000Z', kind: 'permission_request', tool: 'Bash' },
+      { ts: '2026-07-29T00:00:00.000Z', kind: 'permission_request', tool: 'Bash' },
+    ];
+    const s = summarize(rows, null, '2026-08-04T00:00:00.000Z');
+    assert.equal(s.permission_request_events, 2);
+    assert.equal(s.interrupts, 0, 'interrupts still counts Notification rows only');
+    assert.equal(s.interrupts_per_week, 0);
+  });
+
+  test('an interrupt on a non-recorded tool is still an interrupt', () => {
+    // No RECORDED_TOOLS filter: the row carries no request payload to classify,
+    // and an approval interrupt counts whatever tool raised it.
+    const dir = freshDir();
+    runHook(['permreq'], JSON.stringify({ session_id: 's1', tool_name: 'WebFetch' }), dir);
+    const rows = readAll(path.join(dir, 'ledger.jsonl'));
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].kind, 'permission_request');
+    assert.equal(rows[0].tool, 'WebFetch');
   });
 });


### PR DESCRIPTION
feat: [HIMMEL-1529][HIMMEL-1539] trust shadow ledger — blind decision recording that can say when it recorded nothing

An append-only, hash-chained decision record written from Claude Code hooks. For
every approval-shaped decision point it records the request (class, coarse
target, requester lane) and the harness's OWN blind verdict, then DEFERS — it
emits no permissionDecision, so nothing about the prompt flow moves. Adding it
changes no behaviour; removing it changes no behaviour. It only records.

It exists to answer one question nobody currently has a number for: how many
approval interrupts a week does running an agent harness actually cost?

## Why "blind" is the whole point

The shadow verdict is computed, hash-chained and flushed to disk BEFORE the
process exits and the request continues to the permission layer. That ordering
is mechanical, not conventional. If the operator could see the harness's guess
while deciding, any agreement rate would measure anchoring rather than
competence — and the evidence would be worthless in a way that is invisible when
it is worthless.

## It never blocks, and never asks

Every failure path exits 0 with empty stdout. There is no code path that prints
a permissionDecision. A hook that returns `ask` reintroduces the dialog that
auto mode exists to remove, and in an unattended session that dialog is
unanswerable and unbounded — measured at 902 s, still blocked when killed.

## Saying when it recorded NOTHING

The harder half. Every way this recorder could lose events pushed the number in
the same direction with nothing to signal it, and an instrument wrong in a
plausible direction is worse than no instrument, because the number still looks
like a number.

- **Dropped writes are visible.** Lock exhaustion and failed appends are recorded
  to a health channel deliberately outside the ledger's own lock and hash chain —
  the events it holds are exactly the ones the ledger could not hold, so a channel
  sharing either would be silent in the one case it exists to report. Any recorded
  drop suppresses the published rate. The hash chain can only attest rows that
  LANDED; it is structurally blind to rows that never did.
- **An abandoned torn tail is damage, not "in flight".** Liveness decides whether
  to WAIT for a writer, never whether to forgive one: the reader waits for the
  lock to clear, re-reads a stable snapshot, and judges what is actually on disk.
  Every uncertain branch answers in the direction that refuses to publish.
- **Failed and denied calls get terminal outcomes** instead of collapsing into
  `unresolved`, and the names are scoped to what the events actually observe.
  `PermissionDenied` fires only for auto-mode classifier denials. `PermissionRequest`
  fires when a decision is NEEDED — which is not a human being interrupted, since
  unattended sessions raise it with nobody present; it is reported as an event
  count beside the notification-derived figure, never swapped in as the headline
  metric. Two independent estimators are how you find out which one is right.

Correlation between a request and its outcome is ordered by LEDGER ROW POSITION,
never wall-clock: the ledger is append-only, so position is causal order, while
timestamps fail at both boundaries (equal milliseconds, and backward clock steps).

## Privacy

Commands and file contents are NOT stored. The record keeps a coarse handle
(verb + subverb, or a repo-relative path) and a sha256 of the full request, so
identical requests correlate without the ledger becoming a transcript lake.
Records point at sessions; they do not embed them.

## Wiring

A deliberate manual step, documented in scripts/trust/README.md: six hook
entries, each invoking `node` directly so it is not exposed to bare-`bash`
resolution failures on Windows, each with an explicit 10 s timeout (a command
hook defaults to 600 s, and a stalled hook would make this a behaviour change —
which the whole claim of the design is that it is not).

Tests: 115, covering lock exhaustion, append failure, unreadable vs missing
health channel and ledger, torn-tail liveness, the terminal verdicts, correlation
boundaries, valid-JSON corruption, and that the report never answers with silence.

Platforms tested: windows
Security reviewed: manual


[HIMMEL-1529]: https://yotamleo.atlassian.net/browse/HIMMEL-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ