### PR TITLE
feat: [HIMMEL-1246][HIMMEL-1613][HIMMEL-1635][HIMMEL-1337][HIMMEL-1630] leg-4/5 batch: lane playbook, CR-ledger supersede, session telemetry live, arm preflight, cli-proxy pin heal

### DIFF
--- a/docs/tool-adoption/lane-adoption-playbook.md
+++ b/docs/tool-adoption/lane-adoption-playbook.md
@@ -1,0 +1,318 @@
+# Lane-adoption playbook (HIMMEL-1246)
+
+> Sibling of [`rubric.md`](rubric.md), not a replacement for it. The rubric
+> decides whether to adopt a **community TOOL** (a skill, hook, MCP server).
+> This playbook is for a different object: a **model LANE** — an entry in
+> `scripts/lanes/lanes.json` an operator or the dispatch guard can route
+> implementation work to (GLM, claudex, a future frontier model). A lane is
+> not evaluated once and filed away like a tool ADR; it is **profiled and
+> tailored per axis**, then measured into readiness. Reference the rubric for
+> the general trust-posture/measurement vocabulary (§2, §4) — it isn't
+> repeated here.
+
+## Why
+
+Every lane this project has onboarded arrived with the same failure shape:
+the harness inherited some OTHER lane's tuning — a timeout sized for Codex's
+latency, a context-compaction default sized for a 200k-token model, an
+identity file that hardcodes a different provider's name — and the new lane
+either timed out spuriously, compacted early, or ran under an
+under-specified persona, before anyone measured what the new lane actually
+needed. The GLM onboarding (HIMMEL-1241 epic) is the worked example this
+playbook generalizes: each axis below is a knob GLM's rollout tripped over,
+with the fix now checked into the repo as evidence of what "profile it, then
+tailor it" looks like in practice.
+
+**The rule, once per axis: PROFILE the new lane's real behavior before you
+TAILOR any config to it.** Never inherit another lane's number.
+
+## How to use this
+
+Run the seven axes below against the new lane, in order, before it earns any
+default routing. Each axis names what to *measure* on the new lane and what
+*config/code knob* the measurement feeds. Where the axis has GLM evidence
+already in the repo, it's cited by path/line so you can see the pattern
+before repeating it. Where the brief for this ticket named a ticket number
+this worktree could not find checked into the repo, that's flagged as a
+discrepancy rather than guessed at — treat those as open follow-up tickets,
+not yet-landed evidence.
+
+---
+
+## 1. Latency budget
+
+**Profile:** the new lane's real wall-clock response time and payload size
+under a representative task — not a number carried over from another lane.
+
+**Tailor:** `CRITIC_TIMEOUT_SECS` in `scripts/cr/critic-panel.sh` (default
+`240`, set at line ~214: `CRITIC_TIMEOUT_SECS="${CRITIC_TIMEOUT_SECS:-240}"`)
+is the per-critic-member wall-clock timeout applied to every model in the CR
+panel, regardless of which backend answers. It also supports a **per-row
+override** (`_resolve_member_timeout`, line ~316) — use that to give one lane
+its own number instead of bumping the shared default for everyone.
+
+**GLM evidence:** `glm-5.2[1m]` measured **~205s / 23KB** response on a real
+panel run — close enough to the 240s ceiling that real-world variance tips it
+into a **spurious timeout** (HIMMEL-1245). The 240s constant itself predates
+GLM (`CHANGELOG.md`: "[HIMMEL-558] raise CRITIC_TIMEOUT_SECS default 150
+to 240s") — it was sized around the panel's existing (Codex-class) members,
+then a new lane inherited it without being measured against it.
+
+**Action:** before wiring a new lane into any dispatcher with a hardcoded
+wall-clock bound, measure its typical response latency and size, then set a
+per-lane override rather than trusting the shared default to fit.
+
+**Discrepancy flagged:** HIMMEL-1245 is not cited anywhere in-repo (no
+comment, no CHANGELOG line) — the 240s constant and its HIMMEL-558 origin are
+real and grounded (`scripts/cr/critic-panel.sh`), but the GLM
+timeout-measurement finding itself is evidence carried in this ticket's brief,
+not yet landed as a code comment or test. Treat it as the motivating
+observation, not as something you can `grep` and confirm today.
+
+---
+
+## 2. Context window
+
+**Profile:** the lane's real backend context ceiling AND its **cost-optimal**
+operating window — these are not the same number. `scripts/lanes/lanes.json`'s
+`$context-note` states the distinction explicitly: `contextWindow` is "the
+lane's cost-optimal default operating window... don't route work that won't
+fit" — codex lanes default to 272k even though the real backend window is
+~372k, because 272k is the 2x-pricing cliff, not a hard ceiling.
+
+**Tailor:** two separate config points, not one — there's no automatic
+projection from one to the other:
+- `lanes.json`'s per-lane `contextWindow` field (`glm`: 1000000, `claudex`:
+  272000, `haiku`: 200000 — see the registry) feeds the lane **resolver**
+  (`scripts/lanes/resolve.mjs`), which uses it for display/routing decisions
+  (the `/lanes` `[ctx: N]` annotation, dispatch-guard fit checks) — it does
+  not set any env var itself.
+- `CLAUDE_CODE_AUTO_COMPACT_WINDOW` (the Claude Code env var that actually
+  controls when the harness starts compacting) is set by the **launcher**
+  from its own env knob: the GLM launcher's `GLM_CONTEXT_WINDOW` and
+  `spawn-glm --context big|small` preset (`docs/glm-offload.md`): `big` =
+  `glm-5.2[1m]` + `CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000`; `small` =
+  `glm-5.2` + 200000; the codex lane's twin, `CODEX_CONTEXT_WINDOW`
+  (`docs/tooling-catalog.md` `claude-codex` section); and the routed lane's
+  `ROUTED_CONTEXT_WINDOW`.
+
+Configure both for a new lane — the registry value and the launcher env
+knob — since neither derives the other; setting only one leaves the other
+silently stale.
+
+**GLM evidence:** without an explicit window, Claude Code assumes its ~200k
+default for an unrecognized model slug and compacts/rejects early — the
+documented "prompt too long" deaths in `docs/glm-offload.md`. Setting
+`CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000` for the `[1m]` GLM variant fixed it.
+
+**Action:** never let a new lane's model slug silently fall through to Claude
+Code's built-in default window. Look up (or benchmark) the backend's real
+ceiling, decide the cost-optimal operating point, and set the
+auto-compact-window knob explicitly — same pattern as `glm`/`claudex` above.
+
+---
+
+## 3. SOUL/persona
+
+**Profile:** does the new lane get its own identity file matched to its
+actual capability tier, or does it inherit an identity written for a
+different provider, or default to a persona sized for a weaker role?
+
+**Tailor:** two SOUL assets already exist in `scripts/hermes/assets/`, and
+neither is a drop-in fit for a new frontier lane:
+- `himmel-agent.SOUL.md` — the **senior** identity, installed onto the
+  `himmel_agent` hermes profile by `scripts/hermes/install-himmel-profile.sh`.
+  Its opening line hardcodes the provider: *"running as the **main tier** on
+  Codex (GPT-5.5)"* — and the installer's own profile description literally
+  reads *"himmel's main-tier orchestrator (Codex/GPT-5.5)"*
+  (`install-himmel-profile.sh` line 97). This SOUL is **Codex-provider-bound**
+  by construction, not generic.
+- `free-tier.SOUL.md` — the **junior, read-only** identity for free critics
+  (`qwen3-coder-plus` anchor): terse, ~32K context budget, JSON-only output
+  contract, explicitly "You do not write code to disk, run git, open PRs."
+
+**GLM evidence:** a frontier lane dispatched under `himmel-agent.SOUL.md`
+verbatim inherits a false provider claim; dispatched under
+`free-tier.SOUL.md` it inherits a read-only ceiling that under-drives a
+full-capability model. Neither fits — the fix is a **per-lane senior
+profile**: clone the senior SOUL's structure (identity, working principles,
+precedence ladder, hard limits) but swap the provider-specific line for the
+new lane's actual backend.
+
+**Discrepancy flagged:** the brief cites HIMMEL-559 for this axis, but the
+in-repo HIMMEL-559 (`scripts/agents-md/debrand.json`) is a **different,
+related** problem: it's the CLAUDE.md → AGENTS.md debranding pass that
+neutralizes Fable-specific identity language (*"the Fable main thread"* →
+*"the main thread"*) so a non-Claude driver reading the shared `CLAUDE.md`
+doesn't misidentify itself. That's about a Codex/GPT session correctly
+NOT reading Claude-branded prose as its own identity — the opposite move
+from authoring a dedicated senior SOUL for a new provider. Both are
+persona-correctness work; they are not the same change.
+
+---
+
+## 4. Prompt family
+
+**Profile:** which scaffolding family the new lane's model name resolves to.
+
+**Tailor:** `family_for_model()` in `scripts/cr/critic-first-pass.sh`
+(lines 88–101) — a `case` statement mapping a lowercased model-name substring
+to `gpt | open | claude`, each with different prompt scaffolding (GPT/codex:
+explicit non-contradiction + spec tags; open: rigid format-obedience because
+open models "drift from the contract and over-report"; Claude: XML +
+IMPORTANT markers). Order matters — `gpt-oss`/`gptoss` must match before the
+real-GPT branch or they'd be misfiled.
+
+**GLM evidence:** `*glm*` falls into the `open` family bucket (alongside
+qwen/kimi/deepseek/mistral/llama) — rigid format-obedience scaffolding, the
+same bucket the unknown-model fallback (`*) echo open ;;`) defaults to as
+"the safest default."
+
+**Action:** before wiring a new lane's model name into `critic-first-pass.sh`
+or any prompt-family-aware caller, check which branch its name resolves to.
+An unmatched name silently lands in `open` — verify that's actually the right
+scaffolding for the new model's failure modes, don't assume the fallback is
+correct just because it doesn't error.
+
+---
+
+## 5. Harness choice
+
+**Profile:** does the task need a fire-and-forget one-shot dispatch, or a
+full himmel-harness session (worktree, hooks, guardrails, durable
+transcript)? Measure the actual requirement — isolation, durability,
+per-dispatch model control — don't default to whichever is easiest to wire.
+
+**Tailor:** two structurally different spawn shapes exist:
+- **Hermes one-shot** (`scripts/hermes/invoke.sh` / `dispatch-trusted.sh`) —
+  no worktree, no internal timeout by design (the caller wraps it), `-z`
+  auto-approval with a `todo`-only default toolset. Cheapest to dispatch,
+  weakest isolation.
+- **Full-session `cc-<lane>`** (`scripts/claude-glm`, `scripts/claude-codex`)
+  — runs the complete Claude Code harness (skills, hooks, guardrails,
+  worktrees) over the lane's backend. Dedicated worktree + branch, durable
+  session artifacts, native Claude Code hook coverage.
+
+**Evidence:** `docs/internals/worker-spawn-matrix.md` (HIMMEL-749) is the
+grounded comparison — a full matrix of worktree isolation, guard/hook
+coverage, per-dispatch model selection, session artifacts, push/PR authority,
+permission handling, and supervision signal across all five spawn paths
+(native Hermes subagent, Hermes one-shot, external Claude Code worker,
+GLM worker, Codex worker). Its verdict: "the Hermes one-shot lane has the
+clearest model/toolset selector... the GLM worker has the clearest worker
+artifact contract" — the two shapes trade off differently, and the matrix
+names which cells are `UNVERIFIED` per path rather than assuming parity.
+
+**Discrepancy flagged:** the brief cites HIMMEL-1113 for this axis. No
+HIMMEL-1113 reference exists anywhere in this repo (clean grep across code
+and docs). The comparison this axis needs is fully grounded instead by
+HIMMEL-749's `worker-spawn-matrix.md` — cite that as the evidence base;
+treat HIMMEL-1113 as a ticket number this worktree could not corroborate.
+
+---
+
+## 6. Trust/egress posture
+
+**Profile:** is the new lane's provider declared in the egress matrix at
+all? If not, every corpus defaults to deny for it.
+
+**Tailor:** `scripts/guardrails/egress-matrix.json` is keyed by **provider ×
+corpus × purpose — there is no lane axis.** What to do depends on whether the
+new lane's backend is already a declared provider:
+1. **Provider already declared** (e.g. another lane already runs on
+   `zai-glm`): add nothing to `providers`. Reusing it means the new lane
+   automatically inherits every existing `rules` row for that provider,
+   across every corpus — review those rows before onboarding, since a rule
+   scoped to the existing lane's use case now also covers the new one. If
+   the new lane needs different clearance, give it a distinct provider
+   identity instead of reusing the shared one.
+2. **Provider genuinely new:** add a `providers` entry (region + one-line
+   note — see the `zai-glm` / `openai-codex` rows for the shape), then
+   explicit `rules` rows for each corpus the lane needs (`corpus` x
+   `provider` x `purpose` → `allow` / `allow+log` / `conditional` / `deny`).
+3. Nothing at all, if the lane should stay denied everywhere for now — the
+   file's own `"default": "deny"` already covers that.
+
+**GLM evidence:** `zai-glm` is declared (`"region": "CN", "note": "GLM Coding
+Plan impl lanes"`) with narrow, dated, ticketed rules — e.g.
+`luna-personal` × `zai-glm` × `extraction` is `allow+log`, ratified
+2026-07-17 (HIMMEL-1122) with a measured comparison against the prior
+incumbent recorded directly in the `why` field. `handover-state` ×
+`zai-glm` × `inference` is `conditional` on "brief-scoped... never bulk
+corpus runs." **PHI (`salus` corpus) is hard-denied for every provider with
+no override, structurally** — this doesn't change per lane.
+
+**Action:** before a new lane touches any vault or handover corpus, check
+whether its provider is already declared. An **undeclared provider is
+default-DENY** (`"default": "deny"`, `scripts/guardrails/egress-matrix.json`
+line 176) — add its provider row and the specific per-corpus rules it needs.
+A **declared** provider is different: reusing it is not free, since the
+matrix has no lane axis and every existing rule for that provider now also
+covers the new lane — review those rows for fit rather than assuming they
+were written with this lane's use case in mind, and register a distinct
+provider identity if they don't fit.
+
+---
+
+## 7. Measure before trust
+
+**Profile:** run the rubric's measurement protocol against the new lane on
+real work, and clear the **structural readiness gate** before it earns
+default routing — readiness is measured, never asserted.
+
+**Tailor:**
+- The measurement method: `docs/tool-adoption/rubric.md` §4 (baseline vs
+  treatment on outcome-per-session signals, not token count) — the same
+  protocol this playbook's sibling doc uses for tools, reused here for lanes.
+- The structural gate: `scripts/lanes/lane-readiness.mjs` +
+  `readiness.passesRequired` in `scripts/lanes/lanes.json` (HIMMEL-1626).
+  Readiness is computed from **trailing consecutive PASS rows** in the
+  verify-return ledger (HIMMEL-1621, `scripts/lanes/verify-return.mjs`) —
+  a single FAILED row resets the streak to zero. A lane below its gate reads
+  `down`, and the dispatch guard (`scripts/hooks/guard-implementor-dispatch.sh`)
+  treats `down` as **skip-toward-another-lane**, never as a hard refusal.
+
+**GLM evidence:** `lanes.json`'s `$readiness-note` records the live operator
+ruling (2026-08-07): **glm gated at 10 consecutive passes** (down since the
+HIMMEL-1575 startup-hang class was found), **claudex on probation at 5**
+consecutive passes to graduate. A lane can be fully *funded* (quota
+available) while still *not ready* (an operator ruling holds it down) —
+funding and readiness are deliberately different questions
+(`lane-readiness.mjs` header comment).
+
+**Action:** don't route default work to a new lane on the strength of a
+pitch or a single successful dispatch. Register it in `lanes.json` with a
+`readiness.passesRequired` gate, let the verify-return ledger accumulate real
+passes, and only drop the gate (or raise `passesRequired` back up on a
+regression) once the trailing-pass evidence supports it. Treat this as the
+**dispatch gate**, not the whole of "measure before trust" — clearing it only
+shows the lane's dispatches keep passing their own verify-return checks; it
+says nothing about outcome-per-session on real work. Run the rubric §4
+measurement independently and don't let a clean pass streak substitute for it.
+
+**Discrepancy flagged:** the brief cites HIMMEL-1118 for the benchmark step.
+No HIMMEL-1118 reference exists anywhere in this repo. The grounded
+artifacts for "measure before trust" are the rubric's own protocol
+(HIMMEL-200, `docs/tool-adoption/rubric.md` §4) and the concrete structural
+gate that now backs it (HIMMEL-1626, `scripts/lanes/lane-readiness.mjs`) —
+cite those; treat HIMMEL-1118 as an open ticket this worktree could not
+corroborate against checked-in evidence.
+
+---
+
+## Summary checklist
+
+Run in order; each row's "tailor" artifact is where the fix lands.
+
+| # | Axis | Profile (measure) | Tailor (config/code) |
+|---|------|--------------------|-----------------------|
+| 1 | Latency budget | Real wall-clock + payload size on representative work | `CRITIC_TIMEOUT_SECS` / per-row override in `scripts/cr/critic-panel.sh` |
+| 2 | Context window | Real backend ceiling vs cost-optimal operating point | `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, `lanes.json` `contextWindow`, lane-specific `*_CONTEXT_WINDOW` env |
+| 3 | SOUL/persona | Capability tier the lane actually has | A per-lane senior SOUL cloned from `himmel-agent.SOUL.md`'s structure, provider line swapped |
+| 4 | Prompt family | Which family bucket the model name resolves to | `family_for_model()` in `scripts/cr/critic-first-pass.sh` |
+| 5 | Harness choice | Isolation/durability the task actually needs | Hermes one-shot vs full-session `cc-<lane>` launcher — see `docs/internals/worker-spawn-matrix.md` |
+| 6 | Trust/egress posture | Which corpora the lane is cleared against | `scripts/guardrails/egress-matrix.json` — provider entry + explicit rules |
+| 7 | Measure before trust | Outcome-per-session over real work, sustained (rubric §4 — independent of the dispatch gate below) | Structural **dispatch gate**: `readiness.passesRequired` in `scripts/lanes/lanes.json` + `scripts/lanes/lane-readiness.mjs` (a trailing verify-return PASS streak, not outcome evidence) |
+
+Ground every number on the new lane itself. An inherited default is exactly
+the failure this playbook exists to catch.

--- a/docs/tool-adoption/rubric.md
+++ b/docs/tool-adoption/rubric.md
@@ -4,7 +4,9 @@
 > optimizers, memory layers, PreToolUse hooks, MCP servers, skills).
 > Part of the HIMMEL-199 framework: this rubric decides; the registry
 > (`registry.md`, HIMMEL-201) records the decision so it
-> isn't re-litigated.
+> isn't re-litigated. Onboarding a model **lane** instead of a tool (GLM,
+> claudex, a future frontier model)? See the sibling
+> [`lane-adoption-playbook.md`](lane-adoption-playbook.md) (HIMMEL-1246).
 
 ## Why
 

--- a/scripts/cr/ledger-append.sh
+++ b/scripts/cr/ledger-append.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 # scripts/cr/ledger-append.sh — deduped JSONL writer for the CR critic ledger
-# (HIMMEL-415). Findings dedup on (head,finding_id); avail + usage dedup on
-# (head,model). The `usage` kind (HIMMEL-485) records an ESTIMATED token count
+# (HIMMEL-415). Findings dedup on (head,finding_id); usage dedups on
+# (head,model). `avail` dedups on (head,model) too, but MONOTONE-SUPERSEDES
+# rather than flatly deduping (HIMMEL-1613): a critic that times out on run 1
+# and succeeds on run 2 at the same head used to have its run-2 `ok` silently
+# dropped by the dedup, permanently wedging clear-cr-marker's gate 3 at that
+# SHA. unavailable -> ok is now appended as a real improvement; an identical
+# repeat stays a quiet no-op; ok -> unavailable (a downgrade that could dodge a
+# real blocker) is refused/dropped, same as a plain duplicate. See the avail
+# branch below for the transition logic. The `usage` kind (HIMMEL-485) records an ESTIMATED token count
 # (chars/4 of the prompt+response) for the paid codex critic — hermes does not
 # expose real usage through the one-shot chokepoint, so this is a cost SIGNAL,
 # not a billed figure (every usage record carries "estimated":true).
@@ -266,7 +273,31 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" SET_PAIRS="$set_pai
     if(e.RESPONDING_MODEL) rec.responding_model=e.RESPONDING_MODEL;
     if(e.REASON) rec.reason=e.REASON;
     if(e.DETAIL) rec.detail=e.DETAIL;
-    dup=existing.some(l=>{try{const o=JSON.parse(l);return o.kind==="avail"&&o.head===e.HEAD_&&o.model===e.MODEL&&(o.artifact||"diff")===e.ARTIFACT&&(o.perspective||"off")===e.PERSPECTIVE;}catch{return false;}});
+    // Monotone supersede (HIMMEL-1613). The dedup key is still (head,model,
+    // artifact,perspective), but the STATUS transition decides the outcome:
+    // the ledger is append-only, so the LAST matching line is the current
+    // effective record. Only an EXACT-status repeat is a quiet no-op (the
+    // pre-existing idempotent-rerun contract). unavailable -> ok is a genuine
+    // improvement (the fix this ticket exists for) and gets appended.
+    // ok -> unavailable is a downgrade - a later transient failure must never
+    // erase an earlier success, since that could dodge a real blocker - so it
+    // is refused/dropped with its own message, same as the plain dedup above.
+    const priorAvail=existing.map(l=>{try{return JSON.parse(l);}catch{return null;}})
+        .filter(o=>o&&o.kind==="avail"&&o.head===e.HEAD_&&o.model===e.MODEL
+            &&(o.artifact||"diff")===e.ARTIFACT&&(o.perspective||"off")===e.PERSPECTIVE)
+        .pop();
+    if(!priorAvail){
+      dup=false;
+    } else if(priorAvail.status===e.STATUS){
+      dup=true;
+    } else if(priorAvail.status==="unavailable"&&e.STATUS==="ok"){
+      dup=false;
+    } else {
+      process.stderr.write("ledger-append.sh: avail record for "+e.MODEL+" at head "
+        +String(e.HEAD_).slice(0,8)+" would DOWNGRADE status "+priorAvail.status+"->"+e.STATUS
+        +" - refusing (an avail record may only improve unavailable->ok, never regress; HIMMEL-1613). Nothing written.\n");
+      process.exit(0);
+    }
   }
   // avail/usage keep the quiet-dedup contract: /pr-check re-runs them on the
   // same head as a matter of course, and turning that into an error would

--- a/scripts/cr/test-clear-cr-marker.sh
+++ b/scripts/cr/test-clear-cr-marker.sh
@@ -499,6 +499,39 @@ run_clear "$tmp" 14 "Codex no avail-ok evidence → exit 14"
 if marker_exists "$tmp"; then pass; else fail "Codex no-responder path: marker must REMAIN"; fi
 rm -rf "$tmp"
 
+# 4f-1/4f-2. HIMMEL-1613 incident fixture: a critic (glm) that TIMED OUT on
+# run 1 and SUCCEEDED on run 2 at the SAME head used to have its run-2
+# avail-ok silently dropped by ledger-append.sh's flat (head,model) dedup,
+# permanently wedging this gate at that SHA. ledger-append.sh now
+# monotone-supersedes (unavailable -> ok appends); this exercises the real
+# writer via append_ledger, then asserts the chokepoint reads the resulting
+# ledger correctly.
+make_repo
+write_marker "$tmp" "$sha"
+append_ledger "$tmp" "glm times out on run 1" avail \
+    --branch feat/x --head "$sha" --model glm --status unavailable
+append_ledger "$tmp" "glm succeeds on run 2 at the SAME head" avail \
+    --branch feat/x --head "$sha" --model glm --status ok
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 0 "HIMMEL-1613: avail unavailable-then-ok at the same head clears"
+if marker_exists "$tmp"; then fail "HIMMEL-1613 fixture: marker should be GONE"; else pass; fi
+rm -rf "$tmp"
+
+# Negative: once a critic has recorded ok, a LATER unavailable attempt for the
+# same head must never un-clear the gate — ledger-append.sh refuses to write
+# the downgrade, so a branch that already cleared cannot be wedged retroactively
+# by a subsequent flaky/rate-limited re-run.
+make_repo
+write_marker "$tmp" "$sha"
+append_ledger "$tmp" "glm succeeds first" avail \
+    --branch feat/x --head "$sha" --model glm --status ok
+append_ledger "$tmp" "glm later attempt times out (must not downgrade)" avail \
+    --branch feat/x --head "$sha" --model glm --status unavailable
+stub_gh "$tmp" ""; stub_check_ci "$tmp" 0
+run_clear "$tmp" 0 "HIMMEL-1613: a later ok->unavailable attempt does not un-clear"
+if marker_exists "$tmp"; then fail "HIMMEL-1613 negative: marker should be GONE"; else pass; fi
+rm -rf "$tmp"
+
 # 4g-4j. Claude-only floor / availability escape hatch (HIMMEL-1224). The gate
 # must be adopter-portable: a config with ZERO external critics (no codex / glm /
 # CodeRabbit) still clears on the session's own diff review, recorded as

--- a/scripts/cr/test-ledger-append.sh
+++ b/scripts/cr/test-ledger-append.sh
@@ -24,6 +24,27 @@ CR_LEDGER="$L" bash "$LA" avail --branch b --head H5 --model qwen3coder --respon
 check "avail responding_model does not change dedup key" "$(grep -c '"kind":"avail".*"head":"H5"' "$L")" "1"
 check "avail stores first responding_model" "$(L="$L" node -e 'const o=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).find(r=>r.kind==="avail"&&r.head==="H5");console.log(o.model+","+o.responding_model)')" "qwen3coder,qwen-flash"
 
+# ── HIMMEL-1613: avail monotone supersede — a timeout on run 1 followed by a
+# success on run 2 at the SAME (head,model) used to hit the flat dedup above
+# and get silently dropped, permanently wedging clear-cr-marker at that SHA.
+AV="$tmp/avail-supersede.jsonl"
+CR_LEDGER="$AV" bash "$LA" avail --branch b --head SH1 --model glm --status unavailable --reason quota-5h
+CR_LEDGER="$AV" bash "$LA" avail --branch b --head SH1 --model glm --status ok
+check "avail unavailable->ok appends (not dropped)" "$(grep -c '"kind":"avail".*"head":"SH1"' "$AV")" "2"
+check "avail unavailable->ok: the ok row is the effective (last) record" "$(L="$AV" node -e 'const rs=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).filter(r=>r.kind==="avail"&&r.head==="SH1");console.log(rs[rs.length-1].status)')" "ok"
+
+# A downgrade (ok -> unavailable) must be refused/dropped: a later transient
+# failure must never erase an earlier success (that could dodge a blocker).
+CR_LEDGER="$AV" bash "$LA" avail --branch b --head SH1 --model glm --status unavailable --reason later-failure 2>"$tmp/downgrade.err"
+check "avail ok->unavailable downgrade exits 0 (quiet refusal, not an error)" "$?" "0"
+check "avail ok->unavailable downgrade writes NOTHING" "$(grep -c '"kind":"avail".*"head":"SH1"' "$AV")" "2"
+check "avail ok->unavailable downgrade names the reason" "$(grep -c 'DOWNGRADE' "$tmp/downgrade.err")" "1"
+check "avail downgrade leaves the ok row as the last record" "$(L="$AV" node -e 'const rs=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).filter(r=>r.kind==="avail"&&r.head==="SH1");console.log(rs[rs.length-1].status)')" "ok"
+
+# An identical repeat is still a quiet no-op (idempotent /pr-check re-runs).
+CR_LEDGER="$AV" bash "$LA" avail --branch b --head SH1 --model glm --status ok
+check "avail identical repeat after supersede still dedups" "$(grep -c '"kind":"avail".*"head":"SH1"' "$AV")" "2"
+
 # ── usage kind (HIMMEL-485): chars/4 token estimate, dedup on (head,model) ──
 CR_LEDGER="$L" bash "$LA" usage --branch b --head H1 --model codex --prompt-chars 4000 --response-chars 800
 CR_LEDGER="$L" bash "$LA" usage --branch b --head H1 --model codex --prompt-chars 4000 --response-chars 800

--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -90,6 +90,17 @@
 #                           through this seam instead of relying on PATH
 #                           resolution order (HIMMEL-1610). Same shape as the
 #                           GH_CMD seam in graph-publish / the forge backends.
+#                           Left at its default, arm-resume also tries a fast
+#                           PowerShell wildcard listing first (HIMMEL-1337)
+#                           before falling back to a full `schtasks /query`.
+#   ARM_TICKET_DUP_OK       Exact value 1 overrides the HIMMEL-1329 ticket-level
+#                           mutex refusal (rc 13) -- arms anyway when this
+#                           ticket already has another slot under a different
+#                           handover. Env twin of --force for this check.
+#   ARM_VAULT_CWD_OK        Exact value 1 overrides the HIMMEL-1330 single-writer
+#                           auto-detected-cwd refusal (rc 14) -- arms anyway
+#                           into a vault/state repo with no explicit
+#                           --cwd/--worktree/resume_cwd:.
 #
 # Exit codes:
 #   0  scheduler armed (or printed under --dry-run)
@@ -139,6 +150,19 @@
 #      with a live or unprobeable pid (HIMMEL-1463). Unprobeable fails closed as
 #      possibly alive. Wait for them or explicitly set ARM_WITH_LIVE_WORKERS=1
 #      to accept that session exit may kill them.
+#   13 ticket-dup refused — this ticket already has another armed resume slot
+#      under a DIFFERENT handover file (HIMMEL-1329). The identity dedup (rc 3)
+#      only catches the SAME handover armed twice; this catches two handovers
+#      naming the same ticket. Pass --force or set ARM_TICKET_DUP_OK=1 for a
+#      deliberate parallel leg on the same ticket.
+#   14 vault-cwd refused — no --cwd/--worktree/resume_cwd: named a work repo,
+#      so the auto-detected cwd (the handover's own git toplevel) would be
+#      used, and that directory is a SINGLE-WRITER repo (HIMMEL-1330) — e.g. a
+#      himmel/code handover parked in the luna vault, about to arm INSIDE the
+#      vault and inherit its direct-to-main commit behavior. Set
+#      'resume_cwd: <work-repo>' in the handover frontmatter, pass
+#      --cwd/--worktree, or set ARM_VAULT_CWD_OK=1 if arming into the vault is
+#      genuinely intended. --dry-run is exempt.
 set -euo pipefail
 
 RESUME_TIME=""
@@ -1021,6 +1045,37 @@ _validate_key() {
 # Each `grep` is `|| true`-guarded — grep exits 1 on no-match and `set -o
 # pipefail` would otherwise abort the assignment. The last command (src-4's
 # `if`, rc 0 whether or not it fires) keeps the function errexit-safe.
+# _infer_ticket_strict <handover_path> -- HIMMEL-1329: sets the global
+# $_ho_ticket_strict to _infer_ticket's src-1 (frontmatter `ticket:`) match
+# ONLY, or empty on a miss. A dedicated function rather than a side-channel
+# variable set from inside _infer_ticket: _infer_ticket is always invoked as
+# `$(_infer_ticket ...)` (command substitution), which forks a SUBSHELL --
+# any variable a subshell sets is invisible to the caller once it exits, so a
+# first attempt at this that had _infer_ticket set a side-channel global
+# internally silently never worked (verified: _ho_ticket_strict read back
+# empty on every call). This function must therefore be invoked as a PLAIN
+# statement, never via `$(...)`, so it runs in the current shell.
+#
+# src-2/3/4 (worktree branch, H1 title, chain-dir name) are documented as
+# best-effort cosmetic naming heuristics -- "a non-conventional slug that
+# merely looks keyed yields a cosmetically-wrong row name only" -- never
+# meant to carry semantic weight for a BLOCKING check. The ticket-level mutex
+# reads $_ho_ticket_strict, not _infer_ticket's combined return value, so a
+# handover whose H1 merely MENTIONS a ticket for documentation (e.g. this
+# suite's own "# HIMMEL-1304 test handover" fixtures) can't false-positive a
+# refusal against an unrelated handover.
+_ho_ticket_strict=""
+_infer_ticket_strict() {
+    local _ho="$1" _raw _key
+    _raw=$(awk '/^---[[:space:]]*$/{c++; next} c==1' "$_ho" \
+        | sed -n 's/^ticket:[[:space:]]*//p' | head -1) || true
+    _raw="${_raw%"${_raw##*[![:space:]]}"}"   # rtrim (incl trailing \r)
+    _raw="${_raw#\'}" ; _raw="${_raw%\'}"
+    _raw="${_raw#\"}" ; _raw="${_raw%\"}"
+    _key=$(_validate_key "$_raw")
+    _ho_ticket_strict="$_key"
+}
+
 _infer_ticket() {
     local _ho="$1" _raw _key _stem
     # src-1: ticket: frontmatter (same awk/sed/rtrim/unquote idiom as resume_cwd:).
@@ -1310,6 +1365,35 @@ else
         if [ "$_fm_cwd_found" -eq 0 ]; then
             echo "WARN arm-resume: no --cwd and no 'resume_cwd:' in handover frontmatter — defaulting cwd to '$RESUME_CWD'. For cross-repo handovers (handover in one repo, work in another) set 'resume_cwd: <work-repo>' in the handover frontmatter or pass --cwd." >&2
         fi
+        # HIMMEL-1330: a handover parked inside a SINGLE-WRITER repo (the luna
+        # vault, or any other repo that commits straight to main by design --
+        # see the repo-root `.single-writer` marker) and carrying no explicit
+        # --cwd/--worktree/resume_cwd: auto-detects its cwd as THAT repo. A
+        # WARN alone is not enough here: nothing reads an unattended arm's
+        # stderr until after the fact, so this has silently armed himmel work
+        # INSIDE the luna vault, picking up its direct-to-main commit
+        # behavior for work that was never meant to land there. Refuse
+        # outright unless the operator opts in -- an explicit --cwd/--worktree/
+        # resume_cwd: already skips this whole fallback block (see above), and
+        # ARM_VAULT_CWD_OK=1 is the escape hatch for a genuine vault arm.
+        # --dry-run stays side-effect-free (preview only, matches the
+        # HIMMEL-1365 temp-path guard's own --dry-run exemption).
+        if [ -f "$RESUME_CWD/.single-writer" ] && [ "${ARM_VAULT_CWD_OK:-}" != "1" ]; then
+            if [ "$DRY_RUN" -eq 1 ]; then
+                echo "DRY arm-resume: would REFUSE to arm -- auto-detected cwd '$RESUME_CWD' is a single-writer repo with no explicit --cwd/--worktree/resume_cwd: (HIMMEL-1330); a real arm exits 14 unless ARM_VAULT_CWD_OK=1 is set." >&2
+            else
+                {
+                    echo "ERR arm-resume: refusing to arm -- the auto-detected cwd is a SINGLE-WRITER repo (HIMMEL-1330):"
+                    echo "    $RESUME_CWD"
+                    echo "No --cwd, --worktree, or 'resume_cwd:' frontmatter named a work repo, so this"
+                    echo "arm would default INSIDE the vault/state repo -- picking up its direct-to-main"
+                    echo "commit behavior for work that likely belongs in a different repo."
+                    echo "Set 'resume_cwd: <work-repo>' in the handover frontmatter, pass --cwd/--worktree,"
+                    echo "or set ARM_VAULT_CWD_OK=1 if arming INTO the vault is genuinely intended."
+                } >&2
+                exit 14
+            fi
+        fi
     fi
     unset _fm_cwd _fm_cwd_found
 fi
@@ -1340,6 +1424,12 @@ fi
 # convention so broad cross-route dedup (the HIMMEL-Resume- prefix grep)
 # still matches between routes.
 _ho_ticket=$(_infer_ticket "$HANDOVER_PATH")
+# HIMMEL-1329: the strict, frontmatter-only ticket (see _infer_ticket_strict
+# above) -- what the ticket-level mutex keys on, deliberately narrower than
+# $_ho_ticket (which also feeds the best-effort naming/HIMMEL-1331
+# ticket-status paths). Called as a PLAIN statement, NOT `$(...)` -- see the
+# function's own comment for why a subshell would silently lose this.
+_infer_ticket_strict "$HANDOVER_PATH"
 # HIMMEL-1304: derive the identity from the CANONICAL path, not the path as
 # typed, and make the suffix injective. Pre-1304 this read $HANDOVER_PATH
 # directly, which broke dedup in BOTH directions at once:
@@ -1406,7 +1496,13 @@ fi
 # and the session/tab title can never disagree.
 SESSION_NAME=$(_compose_arm_name "$_ho_ticket" "$HANDOVER_PATH" title)
 FLOW_RUN_NOTE=$(_infer_slug "$HANDOVER_PATH")
-unset _ho_ticket _path_suffix _name_seg _ho_ident _path_hash _path_readable _path_suffix_legacy _name_seg_legacy
+# HIMMEL-1329/1331 fix: _ho_ticket is kept alive (NOT unset here) -- it is
+# read again below by the HIMMEL-1329 ticket-level mutex and by the
+# HIMMEL-1331 shipped-work preflight's ticket-status probe. Pre-fix this was
+# unset right here and both later readers silently saw an empty string
+# (`${_ho_ticket:-}`), so the shipped-preflight's Jira ticket-status check
+# was permanently dead code — confirmed by grep: no test exercised it.
+unset _path_suffix _name_seg _ho_ident _path_hash _path_readable _path_suffix_legacy _name_seg_legacy
 
 # Pre-trust the resolved cwd (HIMMEL-386) so the fired relaunch doesn't stall
 # on Claude Code's interactive workspace-trust prompt ("Is this a project you
@@ -1452,6 +1548,16 @@ _crontab_list() {
         else
             crontab -l 2>/dev/null | grep -E "# ${TASK_NAME}$" || true
         fi
+    elif [ "$scope" = ticket ]; then
+        # HIMMEL-1329: any OTHER handover's slot for this same ticket. Reads
+        # the STRICT (frontmatter-only) ticket, not the best-effort combined
+        # one -- see _infer_ticket_strict. Ticket keys are validated by
+        # _validate_key to [A-Z][A-Z0-9]*-[0-9]+ — no BRE specials, so it's
+        # safe to interpolate directly. Matches the marker mid-line (not
+        # anchored to EOL like the `task` case above) because this scans for
+        # a SUBSTRING of the identity, not an exact one.
+        [ -n "${_ho_ticket_strict:-}" ] || return 0
+        crontab -l 2>/dev/null | grep -E "# HIMMEL-Resume-${_ho_ticket_strict}(-|\$)" || true
     else
         crontab -l 2>/dev/null | grep -F 'HIMMEL-Resume-' || true
     fi
@@ -1476,12 +1582,71 @@ _crontab_list() {
 # MSYS_NO_PATHCONV=1 is per-call (HIMMEL-125): without it gitbash mangles each
 # /flag into a Windows-rooted path and schtasks rejects the call; scoping it to
 # this one command keeps it off the later git -C in RESUME_CWD resolution.
+# HIMMEL-1337: `schtasks /query` enumerates the operator's ENTIRE Task
+# Scheduler library, not just the ~9 HIMMEL-Resume-* jobs this script cares
+# about. Reported live: 219 real scheduled tasks on the machine turned a
+# single --dry-run into a 5+ minute wait -- schtasks.exe's per-task overhead
+# scales with the TOTAL task count (a well-documented Windows quirk), and
+# `/tn` does not accept a wildcard, so schtasks itself cannot filter
+# server-side. `Get-ScheduledTask -TaskName 'HIMMEL-*'` CAN: it is COM-backed
+# (not the legacy schtasks.exe path) and resolves the wildcard before
+# returning anything, so the ~9 matches come back fast regardless of how many
+# unrelated tasks share the machine. Emits lines shaped exactly like schtasks'
+# own `/fo CSV /nh` output ("\Name","NextRunTime","Ready") so every downstream
+# parser (list_existing / list_collision_candidates) needs no change at all.
+#
+# Gated on SCHTASKS_CMD being the untouched default: every existing test that
+# fabricates scheduler state pins SCHTASKS_CMD to its own stub path
+# (HIMMEL-1610), so this fast path never intercepts a test's simulated CSV --
+# it only activates for a real, unstubbed arm. Bounded by `timeout` and
+# fail-open on any error/timeout/absence: a slow or missing `powershell`
+# falls straight through to the pre-1337 full schtasks scan below, never
+# blocks an arm.
+_win_fast_task_csv() {
+    [ "${SCHTASKS_CMD:-schtasks}" = "schtasks" ] || return 1
+    command -v powershell >/dev/null 2>&1 || return 1
+    local _script _out _rc
+    # Backtick-escaped double-quotes inside a PS double-quoted string + -f
+    # formatting (no PS single-quotes anywhere): a bash single-quoted wrapper
+    # cannot contain a literal `'`, and char+string concatenation semantics in
+    # PowerShell are ambiguous enough to not rely on -- this sidesteps both.
+    # shellcheck disable=SC2016  # single-quoted on purpose -- this is PowerShell source, not bash; $ must NOT expand here
+    _script='
+Get-ScheduledTask -TaskName "HIMMEL-*" -ErrorAction SilentlyContinue | ForEach-Object {
+    $nrt = "N/A"
+    try {
+        $info = $_ | Get-ScheduledTaskInfo -ErrorAction Stop
+        if ($info.NextRunTime) { $nrt = $info.NextRunTime.ToString("M/d/yyyy h:mm:ss tt") }
+    } catch {}
+    Write-Output ("`"\{0}`",`"{1}`",`"Ready`"" -f $_.TaskName, $nrt)
+}
+'
+    if command -v timeout >/dev/null 2>&1; then
+        _out=$(timeout "${ARM_PREFLIGHT_TIMEOUT:-5}" powershell -NoProfile -NonInteractive -Command "$_script" 2>/dev/null)
+    else
+        _out=$(powershell -NoProfile -NonInteractive -Command "$_script" 2>/dev/null)
+    fi
+    _rc=$?
+    [ "$_rc" -eq 0 ] || return 1
+    printf '%s\n' "$_out"
+}
+
 _SCHTASKS_CACHE_DONE=""
 _SCHTASKS_CSV=""
 _SCHTASKS_RC=0
 _SCHTASKS_NAMES=""
 _ensure_schtasks_cache() {
     [ -n "$_SCHTASKS_CACHE_DONE" ] && return 0
+    if _SCHTASKS_CSV=$(_win_fast_task_csv); then
+        _SCHTASKS_RC=0
+        # shellcheck disable=SC1003  # `"\\'` strips both quote and literal backslash from the path-prefixed task names (same construct as the schtasks-CSV branch below)
+        _SCHTASKS_NAMES=$(printf '%s\n' "$_SCHTASKS_CSV" \
+            | grep -o '"\\\?HIMMEL-Resume-[^"]*"' 2>/dev/null \
+            | tr -d '"\\' \
+            | sort -u || true)
+        _SCHTASKS_CACHE_DONE=1
+        return 0
+    fi
     local err_file
     err_file=$(mktemp -t arm-resume.err.XXXXXX)
     _SCHTASKS_CSV=$(MSYS_NO_PATHCONV=1 "${SCHTASKS_CMD:-schtasks}" /query /fo CSV /nh 2>"$err_file")
@@ -1516,6 +1681,17 @@ list_existing() {
                 # Matches the current identity OR the pre-HIMMEL-1304 one, so an
                 # already-armed slot survives the upgrade as a dedup hit.
                 printf '%s\n' "$_SCHTASKS_NAMES" | _arm_own_identity_match
+            elif [ "$scope" = ticket ]; then
+                # HIMMEL-1329: any OTHER handover's slot for this same ticket,
+                # keyed on the STRICT frontmatter-only ticket (see
+                # _infer_ticket_strict). _compose_arm_name always puts a
+                # present ticket FIRST in the task-name segment
+                # (HIMMEL-Resume-<TICKET>-...), so a prefix match right after
+                # the HIMMEL-Resume- marker finds it regardless of which
+                # slug/session/path-hash follows.
+                if [ -n "${_ho_ticket_strict:-}" ]; then
+                    printf '%s\n' "$_SCHTASKS_NAMES" | grep -E "^HIMMEL-Resume-${_ho_ticket_strict}(-|\$)" || true
+                fi
             else
                 printf '%s\n' "$_SCHTASKS_NAMES"
             fi
@@ -1557,6 +1733,13 @@ list_existing() {
                         # lockstep — including the legacy-name migration arm.
                         if at -c "$job_id" 2>/dev/null \
                             | _arm_own_identity_match '# ' | grep -q .; then
+                            printf 'at-job-%s\n' "$job_id"
+                        fi
+                    elif [ "$scope" = ticket ]; then
+                        # HIMMEL-1329: same STRICT ticket-prefix scan as the
+                        # crontab/windows cases above, applied to the at-job body.
+                        if [ -n "${_ho_ticket_strict:-}" ] && at -c "$job_id" 2>/dev/null \
+                            | grep -qE "# HIMMEL-Resume-${_ho_ticket_strict}(-|\$)"; then
                             printf 'at-job-%s\n' "$job_id"
                         fi
                     else
@@ -2041,6 +2224,60 @@ if [ -n "$existing" ]; then
     fi
 fi
 
+# ---------------------------------------------------------------------------
+# HIMMEL-1329 -- ticket-level mutex.
+#
+# The dedup block above matches on the DERIVED task name, which folds in the
+# handover's own slug and a hash of its canonical path (HIMMEL-1304). Two
+# DIFFERENT handover files naming the SAME ticket -- a worktree handover and a
+# state-repo handover both for HIMMEL-999, say -- therefore produce two
+# DIFFERENT task names and sail straight past the check above: each arms its
+# own slot for work that, underneath, is the same ticket. Since
+# _compose_arm_name always places a present ticket FIRST in the task-name
+# segment, a broader "does any OTHER slot's name start with this ticket"
+# scan catches it regardless of which slug/session/path-hash follows.
+#
+# Own-identity matches (this handover's own prior slot, on a --force re-arm)
+# are excluded here -- those were already resolved by the dedup/--force block
+# above; this check only fires on a slot belonging to a genuinely DIFFERENT
+# handover.
+#
+# Keyed on the STRICT frontmatter-only ticket ($_ho_ticket_strict), not the
+# best-effort combined one ($_ho_ticket also used for naming/HIMMEL-1331):
+# _infer_ticket's other sources (worktree branch, H1 title, chain-dir name)
+# are documented as cosmetic-only best-effort guesses, and a handover whose
+# H1 merely MENTIONS a ticket for documentation purposes (not as a real work
+# association) must not false-positive a blocking refusal against an
+# unrelated handover that happens to share the same mention.
+if [ -n "${_ho_ticket_strict:-}" ]; then
+    _ticket_hits=""
+    while IFS= read -r _tmarker; do
+        [ -z "$_tmarker" ] && continue
+        [ "$_tmarker" = "$TASK_NAME" ] && continue
+        [ -n "${TASK_NAME_LEGACY:-}" ] && [ "$_tmarker" = "$TASK_NAME_LEGACY" ] && continue
+        _ticket_hits="${_ticket_hits:+$_ticket_hits
+}    $_tmarker"
+    done <<< "$(list_existing ticket)"
+    if [ -n "$_ticket_hits" ]; then
+        if [ "$FORCE" -eq 1 ] || [ "${ARM_TICKET_DUP_OK:-}" = "1" ]; then
+            {
+                echo "WARN arm-resume: ticket $_ho_ticket_strict already has another armed resume slot under a DIFFERENT handover -- arming anyway:"
+                printf '%s\n' "$_ticket_hits"
+            } >&2
+        else
+            {
+                echo "ERR arm-resume: refusing to arm -- ticket $_ho_ticket_strict already has another armed resume slot under a DIFFERENT handover (HIMMEL-1329):"
+                printf '%s\n' "$_ticket_hits"
+                echo "Arming the same ticket twice from two handover files risks two concurrent"
+                echo "sessions racing the same work. If this is a deliberate second leg (e.g. a"
+                echo "parallel sub-task on the same ticket), pass --force or set ARM_TICKET_DUP_OK=1."
+            } >&2
+            exit 13
+        fi
+    fi
+    unset _ticket_hits _tmarker
+fi
+
 # Soft slot cap (HIMMEL-340): WARN — never block — when arming would push the
 # machine past ARM_MAX_SLOTS concurrent resume slots. Each fired slot is
 # another concurrent claude process + API spend, so the operator gets a
@@ -2444,8 +2681,11 @@ _arm_shipped_preflight() {
 
     # (a) TICKET STATUS. The Jira CLI is an untracked build artifact
     # (scripts/jira/dist/index.js), so it is routinely absent in a worktree --
-    # skip quietly rather than nag on every arm.
-    _jira="$SCRIPT_DIR/../jira/dist/index.js"
+    # skip quietly rather than nag on every arm. ARM_JIRA_CLI is a test seam
+    # (same shape as SCHTASKS_CMD/GH_CMD elsewhere in this file): a worktree
+    # never has dist/ built, so a test exercising this branch has no other way
+    # to point it at a fixture CLI.
+    _jira="${ARM_JIRA_CLI:-$SCRIPT_DIR/../jira/dist/index.js}"
     if [ -n "$_ticket" ] && [ -f "$_jira" ] && command -v node >/dev/null 2>&1; then
         _status=$(_arm_probe node "$_jira" get "$_ticket" | head -1 | awk -F'\t' '{print $3}') || _status=""
         case "$_status" in

--- a/scripts/handover/test-arm-resume-proxy.sh
+++ b/scripts/handover/test-arm-resume-proxy.sh
@@ -106,7 +106,19 @@ cat > "$SCHED_STUB/at" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-chmod +x "$SCHED_STUB/schtasks" "$SCHED_STUB/atq" "$SCHED_STUB/at"
+# HIMMEL-1337: arm-resume now tries a fast PowerShell wildcard listing before
+# `schtasks /query`, whenever SCHTASKS_CMD is left at its default -- exactly
+# the shape every call in this suite uses (no test here sets SCHTASKS_CMD).
+# Without this stub, `command -v powershell` would fall through this dir to
+# the REAL system powershell.exe, making these dry-run assertions depend on
+# whatever is ACTUALLY scheduled on the host. Same "unavailable" fail-open
+# stub the sibling suites (test-arm-resume.sh, -identity.sh, -long-gap.sh,
+# -queue-lock.sh) already use for this exact reason.
+cat > "$SCHED_STUB/powershell" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$SCHED_STUB/schtasks" "$SCHED_STUB/atq" "$SCHED_STUB/at" "$SCHED_STUB/powershell"
 
 # ---------------------------------------------------------------------------
 # T1: flag OFF (env unset, no repo-root .env signal) -- Windows dry-run .bat

--- a/scripts/handover/test-arm-resume.sh
+++ b/scripts/handover/test-arm-resume.sh
@@ -2912,6 +2912,216 @@ mk_gh_stub '1428	MERGED	UNKNOWN'
 _a1331 --dry-run; assert_not_11 "1331 --dry-run skips the shipped preflight" "$?"
 
 # ---------------------------------------------------------------------------
+# HIMMEL-1331 (bug fix, part of the 1329/1330/1331 trio) — the TICKET-STATUS
+# half of the shipped preflight ((a) in _arm_shipped_preflight) was dead code:
+# _ho_ticket was `unset` right after TASK_NAME derivation but read again later
+# via `${_ho_ticket:-}`, so it was always empty and the Done/Closed/wont-do/
+# wont-fix check never ran. Confirmed before this fix: none of the (a)-(h)
+# cases above exercise it — every one only drives the PR/branch half. Fixed
+# by keeping _ho_ticket alive. ARM_JIRA_CLI is a new test seam (added
+# alongside the fix, same shape as GH_CMD/SCHTASKS_CMD) pointing the probe at
+# a fixture CLI — this worktree has no built scripts/jira/dist/index.js to
+# test against otherwise.
+# ---------------------------------------------------------------------------
+if command -v node >/dev/null 2>&1; then
+    R1331B="$TMP/h1331b"
+    mkdir -p "$R1331B/repo"
+    ( cd "$R1331B/repo" && git init -q -b feat/ticket-status-thing . \
+        && git config user.email t@t.t && git config user.name t \
+        && git config commit.gpgsign false \
+        && git commit -q --allow-empty -m seed ) >/dev/null 2>&1
+    JIRA_FAKE="$TMP/h1331b/jira-fake.js"
+    cat > "$JIRA_FAKE" <<'EOF'
+#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === 'get') {
+    console.log(args[1] + '\tsome summary\t' + (process.env.FAKE_JIRA_STATUS || 'Open'));
+}
+EOF
+    HO_1331B="$R1331B/repo-handover.md"
+    printf -- '---\nticket: HIMMEL-9002\nresume_cwd: %s\n---\n\n# HIMMEL-9002 ticket-status thing\n' \
+        "$R1331B/repo" > "$HO_1331B"
+
+    _a1331b() {
+        local status="$1"; shift
+        out=$(TMPDIR="$TMP" GH_CMD=/nonexistent/gh ARM_JIRA_CLI="$JIRA_FAKE" \
+            FAKE_JIRA_STATUS="$status" SCHTASKS_CMD="$ARMED_STUB/schtasks" PATH="$ARMED_STUB:$PATH" \
+            bash "$ARM" --time "$(future_time)" --handover "$HO_1331B" "$@" 2>&1)
+    }
+
+    _a1331b Done; rc=$?
+    assert_rc "1331b Done ticket status refuses (rc=11)" 11 "$rc"
+    assert_contains "1331b ERR names the ticket" "HIMMEL-9002" "$out"
+
+    _a1331b "In Progress"; assert_not_11 "1331b In-Progress ticket does not trip the preflight" "$?"
+
+    _a1331b Done --force; assert_not_11 "1331b --force overrides the ticket-status refusal" "$?"
+
+    ARM_SHIPPED_OK=1 _a1331b Done; assert_not_11 "1331b ARM_SHIPPED_OK=1 overrides the ticket-status refusal" "$?"
+else
+    echo "PASS 1331b skipped — node not available on this host"
+fi
+
+# ---------------------------------------------------------------------------
+# HIMMEL-1329 — ticket-level mutex: the SAME ticket armed twice via TWO
+# DIFFERENT handover files must be refused, even though each handover's own
+# derived TASK_NAME differs (so the per-handover dedup above, rc 3, never
+# sees it).
+# ---------------------------------------------------------------------------
+R1329="$TMP/h1329"
+mkdir -p "$R1329/repo"
+( cd "$R1329/repo" && git init -q . \
+    && git config user.email t@t.t && git config user.name t \
+    && git config commit.gpgsign false \
+    && git commit -q --allow-empty -m seed ) >/dev/null 2>&1
+SCHED_DB_1329="$TMP/h1329-sched.db"; SCHED_DB_DIR_1329="$TMP/h1329-sched.atdir"
+: > "$SCHED_DB_1329"; mkdir -p "$SCHED_DB_DIR_1329"
+# Each sub-case below gets its OWN handover file for the SAME ticket: re-
+# arming the SAME file would hit the per-handover dedup (rc 3) first and
+# never reach the ticket-level check this section is testing.
+HO_1329_A="$R1329/leg-a.md"
+HO_1329_B="$R1329/leg-b.md"
+HO_1329_D="$R1329/leg-d-force.md"
+HO_1329_E="$R1329/leg-e-env-override.md"
+HO_1329_C="$R1329/leg-c-unrelated.md"
+printf -- '---\nticket: HIMMEL-9003\nresume_cwd: %s\n---\n\n# HIMMEL-9003 leg A\n' "$R1329/repo" > "$HO_1329_A"
+printf -- '---\nticket: HIMMEL-9003\nresume_cwd: %s\n---\n\n# HIMMEL-9003 leg B\n' "$R1329/repo" > "$HO_1329_B"
+printf -- '---\nticket: HIMMEL-9003\nresume_cwd: %s\n---\n\n# HIMMEL-9003 leg D\n' "$R1329/repo" > "$HO_1329_D"
+printf -- '---\nticket: HIMMEL-9003\nresume_cwd: %s\n---\n\n# HIMMEL-9003 leg E\n' "$R1329/repo" > "$HO_1329_E"
+printf -- '---\nticket: HIMMEL-9004\nresume_cwd: %s\n---\n\n# HIMMEL-9004 unrelated\n' "$R1329/repo" > "$HO_1329_C"
+
+_a1329() {
+    local ho="$1"; shift
+    out=$(TMPDIR="$TMP" GH_CMD=/nonexistent/gh SCHED_DB="$SCHED_DB_1329" SCHED_DB_DIR="$SCHED_DB_DIR_1329" \
+        SCHTASKS_CMD="$STATEFUL_STUB/schtasks" PATH="$STATEFUL_STUB:$PATH" \
+        bash "$ARM" --time "$(future_time)" --handover "$ho" "$@" 2>&1)
+}
+
+_a1329 "$HO_1329_A"; rc=$?
+assert_rc "1329 first leg (handover A) arms cleanly (rc=0)" 0 "$rc"
+
+_a1329 "$HO_1329_B"; rc=$?
+assert_rc "1329 second leg (handover B, SAME ticket) refuses (rc=13)" 13 "$rc"
+assert_contains "1329 ERR names the ticket" "HIMMEL-9003" "$out"
+assert_contains "1329 ERR points at the override" "ARM_TICKET_DUP_OK=1" "$out"
+
+_a1329 "$HO_1329_D" --force; rc=$?
+assert_rc "1329 --force overrides the ticket-dup refusal" 0 "$rc"
+
+out=$(TMPDIR="$TMP" GH_CMD=/nonexistent/gh SCHED_DB="$SCHED_DB_1329" SCHED_DB_DIR="$SCHED_DB_DIR_1329" \
+    ARM_TICKET_DUP_OK=1 SCHTASKS_CMD="$STATEFUL_STUB/schtasks" PATH="$STATEFUL_STUB:$PATH" \
+    bash "$ARM" --time "$(future_time)" --handover "$HO_1329_E" 2>&1)
+rc=$?
+assert_rc "1329 ARM_TICKET_DUP_OK=1 overrides the ticket-dup refusal" 0 "$rc"
+
+_a1329 "$HO_1329_C"; rc=$?
+assert_rc "1329 leaves an unrelated ticket alone" 0 "$rc"
+
+# ---------------------------------------------------------------------------
+# HIMMEL-1330 — refuse to auto-detect a SINGLE-WRITER repo as the launch cwd.
+# A handover with no --cwd/--worktree/resume_cwd:, sitting inside a repo
+# marked `.single-writer` (the luna vault shape), must not silently arm
+# INSIDE that repo.
+# ---------------------------------------------------------------------------
+R1330="$TMP/h1330"
+mkdir -p "$R1330/vault/handovers"
+git init -q "$R1330/vault" >/dev/null 2>&1
+touch "$R1330/vault/.single-writer"
+HO_1330="$R1330/vault/handovers/no-resume-cwd.md"
+printf -- '---\nsession_kind: test\n---\n\n# no resume_cwd handover\n' > "$HO_1330"
+
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO_1330" --dry-run 2>&1)
+rc=$?
+assert_rc "1330 dry-run does not hard-fail (preview only)" 0 "$rc"
+assert_contains "1330 dry-run warns about the vault refusal" "would REFUSE to arm" "$out"
+
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO_1330" 2>&1)
+rc=$?
+assert_rc "1330 real arm refuses into a single-writer repo (rc=14)" 14 "$rc"
+# The ERR text names the cwd as the script resolved it, which on Git-Bash is
+# the Windows form (C:/Users/.../AppData/Local/Temp/tmp.X/h1330/vault) while
+# $R1330 holds the MSYS form (/tmp/tmp.X/h1330/vault) -- and `realpath -m`
+# here converts NEITHER into the other, so reconstructing the expected string
+# is host-specific either way. Assert the distinctive tail instead: it is
+# present verbatim in both spellings, on any host.
+assert_contains "1330 ERR names the vault path" "h1330/vault" "$out"
+assert_contains "1330 ERR points at the override" "ARM_VAULT_CWD_OK=1" "$out"
+
+out=$(ARM_VAULT_CWD_OK=1 GH_CMD=/nonexistent/gh TMPDIR="$TMP" SCHTASKS_CMD="$ARMED_STUB/schtasks" PATH="$ARMED_STUB:$PATH" \
+    bash "$ARM" --time "$(future_time)" --handover "$HO_1330" 2>&1)
+rc=$?
+assert_rc "1330 ARM_VAULT_CWD_OK=1 overrides the vault refusal" 0 "$rc"
+
+out=$(GH_CMD=/nonexistent/gh TMPDIR="$TMP" SCHTASKS_CMD="$ARMED_STUB/schtasks" PATH="$ARMED_STUB:$PATH" \
+    bash "$ARM" --time "$(future_time)" --handover "$HO_1330" --cwd "$WORK_REPO" 2>&1)
+rc=$?
+assert_rc "1330 explicit --cwd bypasses the vault guard" 0 "$rc"
+
+HO_1330B="$R1330/vault/handovers/with-resume-cwd.md"
+printf -- '---\nsession_kind: test\nresume_cwd: %s\n---\n\n# has resume_cwd\n' "$WORK_REPO" > "$HO_1330B"
+out=$(GH_CMD=/nonexistent/gh TMPDIR="$TMP" SCHTASKS_CMD="$ARMED_STUB/schtasks" PATH="$ARMED_STUB:$PATH" \
+    bash "$ARM" --time "$(future_time)" --handover "$HO_1330B" 2>&1)
+rc=$?
+assert_rc "1330 resume_cwd: frontmatter bypasses the vault guard" 0 "$rc"
+
+NORMAL_HO_1330=$(make_handover)
+out=$(GH_CMD=/nonexistent/gh TMPDIR="$TMP" SCHTASKS_CMD="$ARMED_STUB/schtasks" PATH="$ARMED_STUB:$PATH" \
+    bash "$ARM" --time "$(future_time)" --handover "$NORMAL_HO_1330" 2>&1)
+rc=$?
+assert_rc "1330 leaves a normal auto-detected cwd alone" 0 "$rc"
+
+# ---------------------------------------------------------------------------
+# HIMMEL-1337 — dedup/listing must not enumerate the ENTIRE Task Scheduler
+# library. On Windows, arm-resume now tries a wildcard-filtered PowerShell
+# listing FIRST (when SCHTASKS_CMD is left at its untouched default) and only
+# falls back to the full `schtasks /query` scan if that is unavailable.
+# Proven here by fabricating a job through the PowerShell stub ONLY — if the
+# fast path is not wired up, the dedup-any check below would see an EMPTY
+# scheduler (the trap schtasks stub, invoked only as a fallback, returns
+# nothing) and rc would be 0, not 3.
+# ---------------------------------------------------------------------------
+FAST1337="$TMP/fast1337-bin"
+mkdir -p "$FAST1337"
+SCHTASKS_CALL_LOG_1337="$TMP/fast1337-schtasks.log"; rm -f "$SCHTASKS_CALL_LOG_1337"
+cat > "$FAST1337/schtasks" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$SCHTASKS_CALL_LOG_1337"
+exit 0
+EOF
+cat > "$FAST1337/powershell" <<'EOF'
+#!/usr/bin/env bash
+printf '"\\HIMMEL-Resume-fast1337-marker","1/1/2026 12:00:00 AM","Ready"\n'
+EOF
+chmod +x "$FAST1337/schtasks" "$FAST1337/powershell"
+
+HO_1337=$(make_handover "$WORK_REPO")
+out=$(env -u SCHTASKS_CMD PATH="$FAST1337:$PATH" OSTYPE=msys \
+    bash "$ARM" --time "$(future_time)" --handover "$HO_1337" --dedup-any --dry-run 2>&1)
+rc=$?
+assert_rc "1337 dedup-any dry-run sees the powershell-sourced job (rc=3)" 3 "$rc"
+assert_contains "1337 ERR names the powershell-sourced job" "HIMMEL-Resume-fast1337-marker" "$out"
+if [ -s "$SCHTASKS_CALL_LOG_1337" ]; then
+    echo "FAIL 1337 the slow full schtasks /query path was still invoked"
+    FAILED=$((FAILED + 1))
+else
+    echo "PASS 1337 the slow full schtasks /query path was bypassed (fast PowerShell path used)"
+fi
+
+# Regression: with SCHTASKS_CMD explicitly pinned (the pattern every OTHER
+# test in this suite uses), the fast path must NOT intercept — the schtasks
+# stub's own CSV is what gets read, byte-identical to pre-1337 behavior.
+out=$(SCHTASKS_CMD="$FAST1337/schtasks" PATH="$FAST1337:$PATH" OSTYPE=msys \
+    bash "$ARM" --time "$(future_time)" --handover "$(make_handover "$WORK_REPO")" --dedup-any --dry-run 2>&1)
+rc=$?
+assert_rc "1337 pinned SCHTASKS_CMD arms cleanly (its stub CSV is empty)" 0 "$rc"
+if [ -s "$SCHTASKS_CALL_LOG_1337" ]; then
+    echo "PASS 1337 pinned SCHTASKS_CMD still routes through the schtasks stub"
+else
+    echo "FAIL 1337 pinned SCHTASKS_CMD unexpectedly bypassed its own stub"
+    FAILED=$((FAILED + 1))
+fi
+
+# ---------------------------------------------------------------------------
 # HIMMEL-1603 — an arm must never be created without a registry record just
 # because the CWD does not map to a handover root.
 #

--- a/scripts/hooks/wire-hook-bash.test.mjs
+++ b/scripts/hooks/wire-hook-bash.test.mjs
@@ -129,7 +129,14 @@ test('refuses a known hook script in the wrong inventory entry', () => {
 test('refuses a missing owned hook script without writing', () => {
   withFixture((fixture) => {
     const settings = JSON.parse(readFileSync(fixture, 'utf8'));
-    settings.hooks.PostToolUse[0].hooks.pop();
+    // Remove the OWNED hook specifically, not just the last array element:
+    // HIMMEL-1635 coexists in this same PostToolUse "Agent" group by
+    // appending its own foreign hook after auto-arm-on-subagent-cap.sh, so a
+    // blind .pop() would remove that coexisting foreign hook instead of
+    // simulating the missing-owned-script case this test is about.
+    const hooks = settings.hooks.PostToolUse[0].hooks;
+    const ownedIndex = hooks.findIndex((h) => h.command.includes('/scripts/hooks/'));
+    hooks.splice(ownedIndex, 1);
     writeFileSync(fixture, `${JSON.stringify(settings, null, 2)}\n`);
     const before = readFileSync(fixture, 'utf8');
 

--- a/scripts/observability/README.md
+++ b/scripts/observability/README.md
@@ -511,7 +511,7 @@ one):
   recorded series. **No Alertmanager is installed in this stack**, so
   nothing here is ever delivered from Prometheus's side — purely
   self-visibility + testability.
-- `provisioning/alerting/rules.yaml` — the same 9 rules re-implemented in
+- `provisioning/alerting/rules.yaml` — the same 10 rules re-implemented in
   Grafana's file-provisioning dialect (query `data` + a `__expr__` threshold
   condition; structurally different from Prometheus's `expr:`/`for:` rule
   format, so it can't just include the file above). **This is what actually
@@ -537,9 +537,9 @@ depend on the failing component itself (the design's acceptance test, §5):
 | 4-day silently-disabled scheduled task | `HimmelScheduledTaskDisabled` + `HimmelFlowLastSuccessAgeExceeded` | No — `Get-ScheduledTask`, independent of the flow itself |
 | The exporter/collector itself dying | `HimmelWatcherDown` (`up == 0`) | No — Prometheus's own scrape health, not the exporter's output |
 
-Two more rules extend coverage past the 918 postmortem: `HimmelAgentTreeRamRunaway`
-and `HimmelOrphanProcesses` (host-level, design §4) and
-`HimmelLunaInboxBacklogRising` (pipeline-level, design §3).
+Four more rules extend coverage past the 918 postmortem: `HimmelAgentTreeRamRunaway`
+and `HimmelOrphanProcesses` (host-level, design §4), `HimmelLunaInboxBacklogRising`
+(pipeline-level, design §3), and `HimmelSessionDead` (session-level, HIMMEL-1052/1635).
 
 ### Delivery choice — F3, reusing the bridge's bot token
 
@@ -601,9 +601,6 @@ these can carry ledger `note` free text; `flow-exporter.ts` never turns
 - A second delivery channel split by `severity` (`page` vs `warn`) — one
   flat policy today; the labels are there if an operator wants to add a
   nested route later.
-- A `session_dead_total > 0` rule — the HIMMEL-1052 session families landed
-  with the alert deliberately left to this rule set; placing it is a small
-  follow-up on top of the 9 rules above.
 - In-loop subagent *step* counting. The session substrate gives
   start/running/end + outcome, not "3rd of 5 planned steps": there is no
   existing signal for that, and producing one would need subagents to

--- a/scripts/observability/README.md
+++ b/scripts/observability/README.md
@@ -565,6 +565,9 @@ alerting` logged with no error, and the provisioning API confirmed all 9
 rules, the datasource, the contact point (token redacted, present), and the
 notification policy loaded correctly. No real Telegram send was exercised
 (fake token) — that step is for the operator to confirm on first real run.
+(That live check predates the 10th rule: HIMMEL-1635 later added
+`HimmelSessionDead`, verified by promtool and the both-dialect suites — the
+live provisioning check above has not been rerun since.)
 An operator who prefers a separate bot can set both env vars to a different
 token/chat before running the installer; a pre-set value is left alone.
 

--- a/scripts/observability/alerts.rules.test.yml
+++ b/scripts/observability/alerts.rules.test.yml
@@ -213,3 +213,20 @@ tests:
               severity: warn
             exp_annotations:
               summary: 'Luna inbox backlog stage unprocessed has risen over the last 3 days'
+
+  # HimmelSessionDead: a stale-transcript unpaired-start session, gauge-based
+  # (no increase()) — present from minute 0 in this fixture, same shape as
+  # HimmelFlowRunStalled.
+  - interval: 1m
+    input_series:
+      - series: 'session_dead_total{host="workstation1"}'
+        values: '1x10'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: HimmelSessionDead
+        exp_alerts:
+          - exp_labels:
+              host: workstation1
+              severity: page
+            exp_annotations:
+              summary: 'Host workstation1 has 1 dead session(s)'

--- a/scripts/observability/alerts.rules.yml
+++ b/scripts/observability/alerts.rules.yml
@@ -134,3 +134,18 @@ groups:
           severity: warn
         annotations:
           summary: 'Luna inbox backlog stage {{ $labels.stage }} has risen over the last 3 days'
+
+      # HIMMEL-1635 follow-up to the HIMMEL-1052 session families: a session
+      # with an unpaired start row whose transcript went stale — crashed,
+      # killed, or wedged. `session_dead_total` is a plain per-host GAUGE
+      # (flow-exporter.ts), so this is a level check, not increase() — same
+      # shape as HimmelFlowRunStalled: the exporter's own staleness threshold
+      # has already elapsed by the time this fires, a completed terminal fact
+      # observed after the fact, not a rate.
+      - alert: HimmelSessionDead
+        expr: session_dead_total > 0
+        for: 0m
+        labels:
+          severity: page
+        annotations:
+          summary: 'Host {{ $labels.host }} has {{ $value }} dead session(s)'

--- a/scripts/observability/provisioning/alerting/rules.yaml
+++ b/scripts/observability/provisioning/alerting/rules.yaml
@@ -281,3 +281,33 @@ groups:
           severity: warn
         annotations:
           summary: 'Luna inbox backlog stage {{ $labels.stage }} has risen over the last 3 days'
+
+      # HIMMEL-1635 follow-up to the HIMMEL-1052 session families — kept
+      # byte-identical in PromQL to alerts.rules.yml's HimmelSessionDead.
+      - uid: himmel_session_dead
+        title: "Session dead"
+        condition: B
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: session_dead_total
+              instant: true
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+              datasource: { type: __expr__, uid: __expr__ }
+              refId: B
+        noDataState: NoData
+        execErrState: Alerting
+        for: 0m
+        labels:
+          severity: page
+        annotations:
+          summary: 'Host {{ $labels.host }} has {{ $values.A }} dead session(s)'

--- a/scripts/observability/wire-session-telemetry-hooks.mjs
+++ b/scripts/observability/wire-session-telemetry-hooks.mjs
@@ -1,0 +1,509 @@
+#!/usr/bin/env node
+// wire-session-telemetry-hooks.mjs — HIMMEL-1635: install/remove the
+// HIMMEL-1052 session-telemetry writer's four hook entries in
+// `.claude/settings.json`.
+//
+// WHY THIS EXISTS
+// session-run-hook.ts shipped with its wiring documented in README.md's
+// "Wiring the writer" section as four JSON blocks to paste by hand. The
+// trust ledger (HIMMEL-1551) shipped the same way first and paid for it:
+// three chain legs measured zero rows because nothing ever pasted the
+// blocks in. A capability that ships behind a manual paste is a capability
+// that does not ship. This makes the wiring reviewable in a PR, versioned,
+// idempotent, and reversible — modeled directly on
+// scripts/trust/wire-trust-hooks.mjs (HIMMEL-1551).
+//
+// WHY A SCRIPT IS ALLOWED TO WRITE A DENY-LISTED FILE
+// `Edit(**/.claude/settings.json)` is deny-listed so nothing edits it ad hoc.
+// A reviewed script with a narrow, asserted mutation is the sanctioned path;
+// an agent's free-form Edit is not. That distinction only holds while the
+// assertions below hold, so they are unconditional.
+//
+// COEXISTENCE WITH OTHER SANCTIONED WRITERS
+// wire-hook-bash.mjs (HIMMEL-1516/1552) owns PreToolUse/PostToolUse/
+// SessionStart, but only commands matching its own `scripts/hooks/*.sh`
+// routing pattern — a `bun .../session-run-hook.ts` command never matches
+// that pattern, so it is invisible to wire-hook-bash's owned-inventory count
+// (own-only validation, HIMMEL-1552 style) and the two writers never
+// disagree about it. wire-trust-hooks.mjs owns its own `shadow-ledger.mjs`
+// commands the same way. All three hold the SAME shared lock
+// (scripts/lib/settings-lock.mjs) across their read -> transform -> write,
+// so they serialise rather than race.
+//
+// The PostToolUse "Agent" matcher group already carries
+// auto-arm-on-subagent-cap.sh's hook (wired by wire-hook-bash). This script
+// APPENDS its own hook into that existing group rather than creating a
+// second "Agent" group — ownership below is tracked per HOOK OBJECT, not
+// per group (the wire-hook-bash model), specifically so two independent
+// writers can share one matcher group without either refusing the other's
+// hook or disturbing it.
+//
+// USAGE
+//   node wire-session-telemetry-hooks.mjs            # install (idempotent)
+//   node wire-session-telemetry-hooks.mjs --off      # remove (idempotent)
+//   node wire-session-telemetry-hooks.mjs --check    # report, write nothing
+//   node wire-session-telemetry-hooks.mjs [--...] <settings-path>
+
+import {
+  existsSync, readFileSync, renameSync, unlinkSync, writeFileSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { acquireLock } from '../lib/settings-lock.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// `"timeout": 10` is not decoration. A command hook defaults to 600 SECONDS,
+// so a stalled writer (a full disk, a wedged filesystem) would hold every
+// matching tool call for ten minutes — the one failure mode a fail-open
+// telemetry writer must never cause. See session-run-hook.ts's own header:
+// it is designed to always exit 0 fast, but the hook-side timeout is the
+// backstop if that design is ever violated.
+const TIMEOUT = 10;
+
+// $CLAUDE_PROJECT_DIR is QUOTED inside the command string deliberately: an
+// unquoted expansion word-splits on a project path containing a space, and
+// the hook then fails open — losing observations silently, which is the one
+// failure mode a measurement tool must not have.
+const WRITER_PATH = '"$CLAUDE_PROJECT_DIR/scripts/observability/session-run-hook.ts"';
+
+// The four entries, exactly as documented in README.md's "Wiring the
+// writer" (HIMMEL-1052). `matcher: null` means no matcher key is emitted —
+// SessionStart/SessionEnd fire on every session lifecycle event regardless
+// of which tool (if any) is involved, so narrowing with a matcher would open
+// a gap.
+export const ENTRIES = [
+  { event: 'SessionStart', matcher: null, verb: 'session-start' },
+  { event: 'SessionEnd', matcher: null, verb: 'session-end' },
+  { event: 'PreToolUse', matcher: 'Agent', verb: 'subagent-start' },
+  { event: 'PostToolUse', matcher: 'Agent', verb: 'subagent-end' },
+];
+
+const commandFor = (verb) => `bun ${WRITER_PATH} ${verb}`;
+
+function hookFor(spec) {
+  return { type: 'command', command: commandFor(spec.verb), timeout: TIMEOUT };
+}
+
+// Deliberately QUOTE-INSENSITIVE and argument-insensitive at the recognition
+// stage (mirrors wire-trust-hooks' isLedgerCommand): a command that merely
+// INVOKES this writer, in any shape, is enough to be treated as "ours" for
+// walking purposes. Exact-match against the canonical string decides
+// wired-vs-not; this decides who a hook object belongs to at all.
+const isWriterCommand = (cmd) => typeof cmd === 'string' && cmd.includes('/scripts/observability/session-run-hook.ts');
+
+// Does this hook object carry OUR exact canonical command for this spec
+// (verb-specific, not just "any session-run-hook.ts invocation")?
+function isOurs(hook, spec) {
+  return !!hook && isWriterCommand(hook.command) && hook.command === commandFor(spec.verb);
+}
+
+// Does this hook object match the canonical wiring EXACTLY — command AND
+// timeout, nothing extra? Command equality alone is not enough: a
+// hand-pasted entry could carry the right command with NO timeout, and a
+// command hook defaults to 600 seconds.
+function matchesCanonical(hook, spec) {
+  return JSON.stringify(hook) === JSON.stringify(hookFor(spec));
+}
+
+// A group "matches" a spec's matcher if its `matcher` key equals the spec's
+// (both absent/null for SessionStart+SessionEnd, both the literal string for
+// PreToolUse/PostToolUse "Agent"). Distinguishes matcher-less groups from a
+// group whose matcher happens to be the empty string, which JSON permits.
+function matcherMatches(group, spec) {
+  const groupMatcher = group && Object.prototype.hasOwnProperty.call(group, 'matcher')
+    ? group.matcher
+    : null;
+  return groupMatcher === spec.matcher;
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseJson(text, label) {
+  try {
+    return JSON.parse(text);
+  } catch (e) {
+    fail(`${label} is not valid JSON: ${e.message}`);
+  }
+}
+
+// Same one-layer-short trap wire-trust-hooks documents: the `hooks`
+// CONTAINER and the settings ROOT must both be validated, not just the
+// per-event arrays, or a malformed shape is silently destroyed by
+// `{ ...settings }` / `{ ...hooks }` spreading it into a garbage
+// index-keyed object.
+function assertHooksContainer(settings) {
+  if (settings === null || typeof settings !== 'object' || Array.isArray(settings)) {
+    fail('settings root is not a JSON object — refusing to overwrite an unrecognised shape');
+  }
+  const h = settings.hooks;
+  if (h === undefined) return;
+  if (h === null || typeof h !== 'object' || Array.isArray(h)) {
+    fail('hooks is not an object — refusing to overwrite an unrecognised shape');
+  }
+}
+
+function assertEventShape(settings, event) {
+  const list = settings.hooks?.[event];
+  if (list !== undefined && !Array.isArray(list)) {
+    fail(`hooks.${event} is not an array — refusing to overwrite an unrecognised shape`);
+  }
+}
+
+function assertGroupShape(settings, event) {
+  const list = settings.hooks?.[event];
+  if (!Array.isArray(list)) return;
+  list.forEach((group, i) => {
+    if (!group || !Array.isArray(group.hooks)) {
+      fail(`hooks.${event}[${i}].hooks must be an array — refusing to overwrite an unrecognised shape`);
+    }
+  });
+}
+
+// SECURITY GATE, unconditional. This script is trusted only because it
+// refuses any change to the permission policy.
+function assertPermissionsUnchanged(before, after) {
+  const a = JSON.stringify(before?.permissions ?? null);
+  const b = JSON.stringify(after?.permissions ?? null);
+  if (a !== b) fail('permissions changed — refusing to write');
+}
+
+// Nothing outside `hooks` may differ. Cheap, total, and it catches an entire
+// class of mistake (a stray key, a dropped section) that no targeted
+// assertion would — same invariant wire-trust-hooks holds.
+function assertOnlyHooksChanged(before, after) {
+  const strip = (o) => {
+    const copy = { ...o };
+    delete copy.hooks;
+    return JSON.stringify(copy);
+  };
+  if (strip(before) !== strip(after)) fail('a non-hook section changed — refusing to write');
+}
+
+// Find every hook object matching this spec across every group under
+// event whose matcher matches the spec's. Returns [{ groupIndex, hookIndex }].
+function findOurs(settings, spec) {
+  const list = settings.hooks?.[spec.event];
+  if (!Array.isArray(list)) return [];
+  const found = [];
+  list.forEach((group, groupIndex) => {
+    if (!matcherMatches(group, spec)) return;
+    const hooks = Array.isArray(group.hooks) ? group.hooks : [];
+    hooks.forEach((hook, hookIndex) => {
+      if (isOurs(hook, spec)) found.push({ groupIndex, hookIndex });
+    });
+  });
+  return found;
+}
+
+export function install(settings) {
+  assertHooksContainer(settings);
+  for (const spec of ENTRIES) assertEventShape(settings, spec.event);
+  for (const spec of ENTRIES) assertGroupShape(settings, spec.event);
+  const next = structuredClone(settings);
+  next.hooks = next.hooks ? { ...next.hooks } : {};
+  let changed = 0;
+
+  for (const spec of ENTRIES) {
+    const matches = findOurs(next, spec);
+    const list = Array.isArray(next.hooks[spec.event]) ? [...next.hooks[spec.event]] : [];
+    next.hooks[spec.event] = list;
+
+    if (matches.length === 0) {
+      // Nothing of ours exists yet. If an existing group already carries this
+      // spec's matcher (e.g. PostToolUse's pre-existing "Agent" group), append
+      // our hook into THAT group rather than creating a second one sharing the
+      // same matcher — never disturbing its existing hook(s). Otherwise, this
+      // spec gets its own dedicated new group so it never has to guess which
+      // matcher-less group (if several exist) it should join.
+      const targetGroupIndex = spec.matcher !== null
+        ? list.findIndex((g) => matcherMatches(g, spec))
+        : -1;
+      if (targetGroupIndex === -1) {
+        const group = spec.matcher === null ? { hooks: [hookFor(spec)] } : { matcher: spec.matcher, hooks: [hookFor(spec)] };
+        list.push(group);
+      } else {
+        const group = { ...list[targetGroupIndex] };
+        group.hooks = [...group.hooks, hookFor(spec)];
+        list[targetGroupIndex] = group;
+      }
+      changed += 1;
+      continue;
+    }
+
+    // Converge to exactly ONE canonical hook per spec. Repair the first match
+    // if it drifted from canonical (missing timeout, etc); drop any extras —
+    // a duplicate would fire the writer twice per event.
+    const [first, ...extras] = matches;
+    const firstGroup = { ...list[first.groupIndex] };
+    const firstHooks = [...firstGroup.hooks];
+    if (!matchesCanonical(firstHooks[first.hookIndex], spec)) {
+      firstHooks[first.hookIndex] = hookFor(spec);
+      changed += 1;
+    }
+    firstGroup.hooks = firstHooks;
+    list[first.groupIndex] = firstGroup;
+
+    // Extras may span multiple groups; remove them, grouping by groupIndex.
+    // Same-group extras (sharing first.groupIndex) are handled against the
+    // already-updated firstHooks/firstGroup above.
+    const sameGroupExtraIdx = extras
+      .filter((e) => e.groupIndex === first.groupIndex)
+      .map((e) => e.hookIndex);
+    if (sameGroupExtraIdx.length > 0) {
+      const kept = list[first.groupIndex].hooks.filter(
+        (_, i) => i === first.hookIndex || !sameGroupExtraIdx.includes(i),
+      );
+      list[first.groupIndex] = { ...list[first.groupIndex], hooks: kept };
+      changed += sameGroupExtraIdx.length;
+    }
+
+    const extrasByGroup = new Map();
+    for (const e of extras) {
+      if (e.groupIndex === first.groupIndex) continue; // handled above
+      if (!extrasByGroup.has(e.groupIndex)) extrasByGroup.set(e.groupIndex, []);
+      extrasByGroup.get(e.groupIndex).push(e.hookIndex);
+    }
+    for (const [groupIndex, hookIndices] of extrasByGroup) {
+      const g = list[groupIndex];
+      const kept = g.hooks.filter((_, i) => !hookIndices.includes(i));
+      changed += hookIndices.length;
+      list[groupIndex] = kept.length === 0 ? null : { ...g, hooks: kept };
+    }
+    next.hooks[spec.event] = list.filter((g) => g !== null);
+  }
+
+  return { settings: next, changed };
+}
+
+export function remove(settings) {
+  assertHooksContainer(settings);
+  for (const spec of ENTRIES) assertEventShape(settings, spec.event);
+  for (const spec of ENTRIES) assertGroupShape(settings, spec.event);
+  const next = structuredClone(settings);
+  if (!next.hooks) return { settings: next, changed: 0 };
+  next.hooks = { ...next.hooks };
+  let removed = 0;
+
+  for (const spec of ENTRIES) {
+    const list = next.hooks[spec.event];
+    if (!Array.isArray(list)) continue;
+    const nextList = [];
+    for (const group of list) {
+      if (!matcherMatches(group, spec)) {
+        nextList.push(group);
+        continue;
+      }
+      const hooks = Array.isArray(group.hooks) ? group.hooks : [];
+      const removedHere = hooks.filter((h) => isOurs(h, spec)).length;
+      if (removedHere === 0) {
+        nextList.push(group);
+        continue;
+      }
+      removed += removedHere;
+      const kept = hooks.filter((h) => !isOurs(h, spec));
+      // Drop the whole group only if OUR removal emptied it — a group that
+      // still holds somebody else's hook (the PostToolUse "Agent" group's
+      // auto-arm-on-subagent-cap.sh entry) must survive with just our hook
+      // stripped out.
+      if (kept.length > 0) {
+        nextList.push({ ...group, hooks: kept });
+      }
+      // else: drop the group entirely (it was ours alone).
+    }
+    if (nextList.length > 0) {
+      next.hooks[spec.event] = nextList;
+    } else {
+      // Documented normalization (same as wire-trust-hooks): an event array
+      // that ends up empty after our removal is dropped entirely rather than
+      // left as `[]`. Equivalent to every consumer; harmless for an event key
+      // (SessionEnd) this script itself created.
+      delete next.hooks[spec.event];
+    }
+  }
+
+  if (removed > 0 && Object.keys(next.hooks).length === 0) delete next.hooks;
+  return { settings: next, changed: removed };
+}
+
+// "Wired" means canonical, not merely present.
+export function statusOf(settings) {
+  let duplicates = 0;
+  const present = ENTRIES.filter((spec) => {
+    const matches = findOurs(settings, spec);
+    if (matches.length > 1) duplicates += matches.length - 1;
+    return matches.some((m) => {
+      const group = settings.hooks[spec.event][m.groupIndex];
+      return matchesCanonical(group.hooks[m.hookIndex], spec);
+    });
+  });
+  return { wired: present.length, total: ENTRIES.length, duplicates };
+}
+
+// Serialize exactly as the file already is — 2-space indent, trailing
+// newline — so an install produces a minimal diff instead of reformatting
+// the whole file into the review.
+const serialize = (obj) => `${JSON.stringify(obj, null, 2)}\n`;
+
+function parseArgs(argv) {
+  let off = false;
+  let check = false;
+  const paths = [];
+  for (const arg of argv) {
+    if (arg === '--off') off = true;
+    else if (arg === '--check') check = true;
+    else if (arg.startsWith('-')) fail(`unknown option: ${arg}`);
+    else paths.push(arg);
+  }
+  if (paths.length > 1) fail('only one settings path may be supplied');
+  return { off, check, settingsPath: paths[0] };
+}
+
+// Same ambiguity refusal as wire-trust-hooks: no path argument and no
+// CLAUDE_PROJECT_DIR while standing in a DIFFERENT project (one with its own
+// .claude/) is refused rather than silently wiring the wrong checkout.
+function defaultSettingsPath() {
+  const fromEnv = process.env.CLAUDE_PROJECT_DIR;
+  if (fromEnv) return join(fromEnv, '.claude', 'settings.json');
+  const own = resolve(HERE, '..', '..');
+  const cwdProject = resolve(process.cwd());
+  if (cwdProject !== own && existsSync(join(cwdProject, '.claude'))) {
+    fail(
+      `ambiguous target: you are in ${cwdProject}, which has its own .claude/, but this `
+      + `script lives in ${own}. Refusing to guess which one you meant — pass the settings `
+      + 'path explicitly, or set CLAUDE_PROJECT_DIR.',
+    );
+  }
+  return join(own, '.claude', 'settings.json');
+}
+
+// The hooks resolve `$CLAUDE_PROJECT_DIR/scripts/observability/session-run-
+// hook.ts` AT RUNTIME against whatever project the session is rooted in.
+// Existence is a precondition on install (never on --off/--check — removing
+// dead wiring, or reporting on it, must still work against a project that
+// never had the writer).
+function writerPathFor(settingsPath) {
+  return join(dirname(dirname(settingsPath)), 'scripts', 'observability', 'session-run-hook.ts');
+}
+
+function assertWriterPresent(settingsPath) {
+  const writer = writerPathFor(settingsPath);
+  if (!existsSync(writer)) {
+    fail(
+      `no writer at ${writer} — these hooks would resolve to a file this project `
+      + 'does not have, and would record nothing while reporting as wired. '
+      + 'Run this from a checkout with scripts/observability/session-run-hook.ts, '
+      + 'or pass that checkout\'s settings path.',
+    );
+  }
+}
+
+// Atomic replace, because the destination is the deny-listed settings file: a
+// truncating in-place write that is interrupted leaves it invalid, and an
+// invalid settings.json takes every hook down with it.
+export function writeAtomic(settingsPath, expectedBytes, output) {
+  const current = readFileSync(settingsPath, 'utf8');
+  if (current !== expectedBytes) {
+    fail(`${settingsPath} changed while this ran — refusing to overwrite another writer`);
+  }
+  const tmp = `${settingsPath}.wire-session-telemetry.${process.pid}.tmp`;
+  try {
+    writeFileSync(tmp, output, 'utf8');
+    renameSync(tmp, settingsPath);
+  } catch (e) {
+    try { unlinkSync(tmp); } catch { /* nothing left to clean up */ }
+    throw e;
+  }
+}
+
+async function main() {
+  let releaseLock;
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const settingsPath = resolve(args.settingsPath || defaultSettingsPath());
+    // Hold the shared settings lock across the WHOLE read -> transform ->
+    // write/rename sequence, so this writer and the other sanctioned writers
+    // (wire-hook-bash, wire-trust-hooks) serialise rather than race.
+    releaseLock = await acquireLock(settingsPath);
+    const input = readFileSync(settingsPath, 'utf8');
+    const before = parseJson(input, settingsPath);
+
+    if (!args.off && !args.check) {
+      assertWriterPresent(settingsPath);
+    }
+
+    // Reversibility is asserted on BYTES, and this script reserializes with a
+    // FIXED 2-space indent + trailing newline — byte-stable only for a file
+    // already in that shape. Prove the round-trip on the UNCHANGED input
+    // before writing, and refuse rather than reformat (same guard as
+    // wire-trust-hooks, for the same reason: --off could not restore a
+    // reformatted file byte-for-byte).
+    if (!args.check && serialize(before) !== input) {
+      const crlf = input.includes('\r\n');
+      fail(
+        `${settingsPath} is formatted differently from how this script serializes JSON `
+        + `(${crlf ? 'CRLF line endings; this script writes LF' : '2-space indent, trailing newline'}), `
+        + 'so writing it would reformat the whole file and `--off` could not restore it '
+        + 'byte-for-byte. Refusing: the reversibility guarantee is the point. '
+        + (crlf
+          ? 'Convert it to LF line endings first, or wire by hand.'
+          : 'Reformat the file to 2-space indent first, or wire by hand.'),
+      );
+    }
+
+    const status = statusOf(before);
+    const { wired, total } = status;
+    const { settings: after, changed } = args.off ? remove(before) : install(before);
+
+    assertPermissionsUnchanged(before, after);
+    assertOnlyHooksChanged(before, after);
+
+    const verb = args.off ? 'removed' : 'added';
+    if (args.check) {
+      const dupes = status.duplicates;
+      process.stdout.write(
+        `wire-session-telemetry-hooks: ${wired}/${total} entries wired in ${settingsPath}; `
+        + `would have ${verb} ${changed}; wrote nothing\n`
+        + (dupes > 0
+          ? `  ⚠ ${dupes} DUPLICATE owned entr${dupes === 1 ? 'y' : 'ies'} — each records the same `
+            + 'event twice. Run `install` to converge.\n'
+          : '')
+        + (!args.off && !existsSync(writerPathFor(settingsPath))
+          ? `  ⚠ no writer at ${writerPathFor(settingsPath)} — install would REFUSE here; `
+            + 'these hooks would record nothing while reporting as wired.\n'
+          : ''),
+      );
+      return;
+    }
+    if (changed === 0) {
+      process.stdout.write(
+        `wire-session-telemetry-hooks: ${settingsPath} already ${args.off ? 'unwired' : 'wired'} `
+        + `(${wired}/${total}); no change made\n`,
+      );
+      return;
+    }
+
+    writeAtomic(settingsPath, input, serialize(after));
+    process.stdout.write(
+      `wire-session-telemetry-hooks: ${verb} ${changed} entr${changed === 1 ? 'y' : 'ies'} in ${settingsPath}; `
+      + 'permissions unchanged.\n',
+    );
+    if (!args.off) {
+      process.stdout.write(
+        '  Hooks take effect on the next matching event — no restart needed. The ledger fills\n'
+        + '  at ~/.himmel/session-runs.jsonl (override: HIMMEL_SESSION_RUNS_LEDGER); check for\n'
+        + '  non-zero rows after your next session/subagent activity.\n',
+      );
+    }
+  } catch (error) {
+    process.stderr.write(`wire-session-telemetry-hooks: REFUSED — ${error.message}\n`);
+    process.exitCode = 1;
+  } finally {
+    if (releaseLock) releaseLock();
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/observability/wire-session-telemetry-hooks.test.mjs
+++ b/scripts/observability/wire-session-telemetry-hooks.test.mjs
@@ -1,0 +1,387 @@
+// HIMMEL-1635 — the suite is the spec for the session-telemetry wiring
+// script. Mirrors scripts/trust/tests/wire-trust-hooks.test.mjs's approach:
+// the properties that matter, in order:
+//   1. it is REVERSIBLE byte-for-byte;
+//   2. it is IDEMPOTENT in both directions;
+//   3. it never touches permissions, and never disturbs anybody else's
+//      hooks — including a hook sharing its OWN matcher group (the
+//      PostToolUse "Agent" coexistence case this ticket exists for).
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { after, before, describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  install, remove, statusOf, writeAtomic,
+} from './wire-session-telemetry-hooks.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(HERE, 'wire-session-telemetry-hooks.mjs');
+const REAL_WRITER = path.join(HERE, 'session-run-hook.ts');
+
+let TMP;
+before(() => { TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'wire-session-telemetry-')); });
+after(() => { try { fs.rmSync(TMP, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+// A settings file shaped like the real one: existing PreToolUse/PostToolUse/
+// SessionStart hooks belonging to OTHER writers (wire-hook-bash-shaped and
+// trust-ledger-shaped), including the PostToolUse "Agent" matcher group this
+// script must append into, never replace.
+const BASE = {
+  permissions: {
+    allow: ['Bash(git status)'],
+    deny: ['Edit(**/.claude/settings.json)'],
+  },
+  hooks: {
+    PreToolUse: [
+      { matcher: 'Bash', hooks: [{ type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/scripts/hooks/run-hook-with-bash.js" "$CLAUDE_PROJECT_DIR/scripts/hooks/guard.sh"' }] },
+      { matcher: 'Bash|Edit|Write|MultiEdit|NotebookEdit', hooks: [{ type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/scripts/trust/shadow-ledger.mjs" pre', timeout: 10 }] },
+    ],
+    PostToolUse: [
+      { matcher: 'Agent', hooks: [{ type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/scripts/hooks/run-hook-with-bash.js" "$CLAUDE_PROJECT_DIR/scripts/hooks/auto-arm-on-subagent-cap.sh"' }] },
+    ],
+    SessionStart: [
+      { hooks: [{ type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/scripts/hooks/run-hook-with-bash.js" "$CLAUDE_PROJECT_DIR/scripts/hooks/check-update-available.sh"', timeout: 15 }] },
+      { hooks: [{ type: 'command', command: 'node "$CLAUDE_PROJECT_DIR/scripts/trust/shadow-ledger.mjs" heartbeat', timeout: 10 }] },
+    ],
+  },
+};
+
+const serialize = (o) => `${JSON.stringify(o, null, 2)}\n`;
+
+// A fixture is a whole fake PROJECT: the hooks resolve the writer relative to
+// the settings file's project root, and install refuses when it is absent.
+function fixture(name, obj = BASE, { withWriter = true } = {}) {
+  const root = path.join(TMP, name);
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+  if (withWriter) {
+    fs.mkdirSync(path.join(root, 'scripts', 'observability'), { recursive: true });
+    fs.copyFileSync(REAL_WRITER, path.join(root, 'scripts', 'observability', 'session-run-hook.ts'));
+  }
+  const p = path.join(root, '.claude', 'settings.json');
+  fs.writeFileSync(p, serialize(obj), 'utf8');
+  return p;
+}
+
+const run = (args, file) => spawnSync(process.execPath, [SCRIPT, ...args, file], { encoding: 'utf8' });
+
+describe('reversibility — install then remove round-trips byte for byte', () => {
+  test('install then --off restores the file exactly', () => {
+    const f = fixture('roundtrip');
+    const original = fs.readFileSync(f, 'utf8');
+
+    const on = run([], f);
+    assert.equal(on.status, 0, on.stderr);
+    assert.notEqual(fs.readFileSync(f, 'utf8'), original, 'install must actually change something');
+
+    const off = run(['--off'], f);
+    assert.equal(off.status, 0, off.stderr);
+    assert.equal(fs.readFileSync(f, 'utf8'), original);
+  });
+
+  test('a settings file with no hooks section round-trips exactly', () => {
+    const f = fixture('nohooks-roundtrip', { permissions: { defaultMode: 'auto' } });
+    const original = fs.readFileSync(f, 'utf8');
+    run([], f);
+    assert.equal(statusOf(JSON.parse(fs.readFileSync(f, 'utf8'))).wired, 4);
+    run(['--off'], f);
+    assert.equal(fs.readFileSync(f, 'utf8'), original);
+  });
+
+  test('removal leaves no empty event keys behind (SessionEnd is our own new key)', () => {
+    const f = fixture('nokeys');
+    run([], f);
+    assert.equal('SessionEnd' in JSON.parse(fs.readFileSync(f, 'utf8')).hooks, true);
+    run(['--off'], f);
+    const s = JSON.parse(fs.readFileSync(f, 'utf8'));
+    assert.equal('SessionEnd' in s.hooks, false, 'SessionEnd must be gone, not left as []');
+    assert.equal(Array.isArray(s.hooks.PreToolUse), true);
+    assert.equal(Array.isArray(s.hooks.PostToolUse), true);
+    assert.equal(Array.isArray(s.hooks.SessionStart), true);
+  });
+});
+
+describe('coexistence — the PostToolUse "Agent" group is shared, not replaced', () => {
+  test('our hook is appended into the existing Agent group, its sibling untouched', () => {
+    const { settings } = install(BASE);
+    const agentGroups = settings.hooks.PostToolUse.filter((g) => g.matcher === 'Agent');
+    assert.equal(agentGroups.length, 1, 'no second Agent group is created');
+    assert.equal(agentGroups[0].hooks.length, 2, 'the existing hook plus ours');
+    assert.deepEqual(agentGroups[0].hooks[0], BASE.hooks.PostToolUse[0].hooks[0], 'the pre-existing hook is byte-identical');
+    assert.match(agentGroups[0].hooks[1].command, /session-run-hook\.ts" subagent-end/);
+  });
+
+  test('removing ours leaves the sibling hook and the group itself in place', () => {
+    const { settings: on } = install(BASE);
+    const { settings: off } = remove(on);
+    assert.deepEqual(off.hooks.PostToolUse, BASE.hooks.PostToolUse);
+  });
+
+  test('PreToolUse gets its OWN new "Agent" group (none pre-existing)', () => {
+    const { settings } = install(BASE);
+    const agentGroups = settings.hooks.PreToolUse.filter((g) => g.matcher === 'Agent');
+    assert.equal(agentGroups.length, 1);
+    assert.equal(agentGroups[0].hooks.length, 1);
+    assert.match(agentGroups[0].hooks[0].command, /subagent-start/);
+    // The two pre-existing PreToolUse groups (foreign, trust-ledger) survive.
+    assert.deepEqual(settings.hooks.PreToolUse[0], BASE.hooks.PreToolUse[0]);
+    assert.deepEqual(settings.hooks.PreToolUse[1], BASE.hooks.PreToolUse[1]);
+  });
+
+  test('SessionStart gets its own dedicated group, existing groups untouched', () => {
+    const { settings } = install(BASE);
+    assert.equal(settings.hooks.SessionStart.length, 3);
+    assert.deepEqual(settings.hooks.SessionStart[0], BASE.hooks.SessionStart[0]);
+    assert.deepEqual(settings.hooks.SessionStart[1], BASE.hooks.SessionStart[1]);
+    assert.match(settings.hooks.SessionStart[2].hooks[0].command, /session-start/);
+    assert.equal('matcher' in settings.hooks.SessionStart[2], false);
+  });
+});
+
+describe('idempotence', () => {
+  test('installing twice changes nothing the second time', () => {
+    const f = fixture('idem-on');
+    run([], f);
+    const afterFirst = fs.readFileSync(f, 'utf8');
+    const second = run([], f);
+    assert.equal(second.status, 0);
+    assert.match(second.stdout, /already wired/);
+    assert.equal(fs.readFileSync(f, 'utf8'), afterFirst);
+  });
+
+  test('removing twice changes nothing the second time', () => {
+    const f = fixture('idem-off');
+    run([], f);
+    run(['--off'], f);
+    const afterFirst = fs.readFileSync(f, 'utf8');
+    const second = run(['--off'], f);
+    assert.equal(second.status, 0);
+    assert.match(second.stdout, /already unwired/);
+    assert.equal(fs.readFileSync(f, 'utf8'), afterFirst);
+  });
+
+  test('a hand-pasted entry missing its timeout is REPAIRED, not reported wired', () => {
+    const handPasted = {
+      ...BASE,
+      hooks: {
+        ...BASE.hooks,
+        SessionEnd: [{ hooks: [{ type: 'command', command: 'bun "$CLAUDE_PROJECT_DIR/scripts/observability/session-run-hook.ts" session-end' }] }],
+      },
+    };
+    assert.equal(statusOf(handPasted).wired, 0, 'present without a timeout is not canonical, and the other three are absent');
+    const { settings, changed } = install(handPasted);
+    assert.equal(changed, 4, 'the malformed SessionEnd entry is repaired, plus the 3 missing entries added');
+    assert.equal(settings.hooks.SessionEnd[0].hooks[0].timeout, 10);
+    assert.equal(settings.hooks.SessionEnd.length, 1, 'repaired in place, not duplicated');
+  });
+
+  test('a duplicate entry is collapsed to exactly one', () => {
+    const { settings: on } = install(BASE);
+    const dupeGroup = structuredClone(on.hooks.PreToolUse.find((g) => g.matcher === 'Agent'));
+    on.hooks.PreToolUse.push(dupeGroup);
+    const { settings, changed } = install(on);
+    assert.equal(changed, 1, 'the extra is removed and counted');
+    assert.equal(settings.hooks.PreToolUse.filter((g) => g.matcher === 'Agent').length, 1);
+    assert.equal(statusOf(settings).wired, 4);
+  });
+});
+
+describe('what it must never touch', () => {
+  test('permissions are unchanged by install and by remove', () => {
+    const f = fixture('perms');
+    for (const args of [[], ['--off']]) {
+      run(args, f);
+      const s = JSON.parse(fs.readFileSync(f, 'utf8'));
+      assert.deepEqual(s.permissions, BASE.permissions);
+    }
+  });
+
+  test('foreign hooks under events we own survive install and remove', () => {
+    const f = fixture('foreign');
+    run([], f);
+    run(['--off'], f);
+    const s = JSON.parse(fs.readFileSync(f, 'utf8'));
+    assert.deepEqual(s.hooks.PreToolUse[0], BASE.hooks.PreToolUse[0]);
+    assert.deepEqual(s.hooks.PreToolUse[1], BASE.hooks.PreToolUse[1]);
+  });
+});
+
+describe('the wiring it produces', () => {
+  test('all four entries wired', () => {
+    const { settings } = install(BASE);
+    const { wired, total } = statusOf(settings);
+    assert.equal(total, 4);
+    assert.equal(wired, 4);
+  });
+
+  test('every entry carries an explicit 10s timeout', () => {
+    const { settings } = install(BASE);
+    for (const list of Object.values(settings.hooks)) {
+      for (const entry of list) {
+        for (const h of entry.hooks) {
+          if (!h.command.includes('session-run-hook.ts')) continue;
+          assert.equal(h.timeout, 10, `missing timeout on: ${h.command}`);
+        }
+      }
+    }
+  });
+
+  test('$CLAUDE_PROJECT_DIR is quoted in every command', () => {
+    const { settings } = install(BASE);
+    for (const list of Object.values(settings.hooks)) {
+      for (const entry of list) {
+        for (const h of entry.hooks) {
+          if (!h.command.includes('session-run-hook.ts')) continue;
+          assert.match(h.command, /"\$CLAUDE_PROJECT_DIR\/scripts\/observability\/session-run-hook\.ts"/);
+        }
+      }
+    }
+  });
+
+  test('it invokes bun, and the four verbs are exactly the README-documented set', () => {
+    const { settings } = install(BASE);
+    const cmds = Object.values(settings.hooks).flat()
+      .flatMap((e) => e.hooks.map((h) => h.command))
+      .filter((c) => c.includes('session-run-hook.ts'));
+    assert.equal(cmds.length, 4);
+    for (const c of cmds) assert.match(c, /^bun "/);
+    const verbs = cmds.map((c) => c.trim().split(/\s+/).pop()).sort();
+    assert.deepEqual(verbs, ['session-end', 'session-start', 'subagent-end', 'subagent-start']);
+  });
+});
+
+describe('--check writes nothing', () => {
+  test('it reports state and leaves the file alone', () => {
+    const f = fixture('check');
+    const original = fs.readFileSync(f, 'utf8');
+    const r = run(['--check'], f);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /0\/4 entries wired/);
+    assert.match(r.stdout, /wrote nothing/);
+    assert.equal(fs.readFileSync(f, 'utf8'), original);
+  });
+
+  test('it reports full wiring after an install', () => {
+    const f = fixture('check-after');
+    run([], f);
+    const r = run(['--check'], f);
+    assert.match(r.stdout, /4\/4 entries wired/);
+  });
+});
+
+describe('it will not wire hooks that point at a writer that is not there', () => {
+  test('install REFUSES when the writer is absent', () => {
+    const f = fixture('adopted', BASE, { withWriter: false });
+    const original = fs.readFileSync(f, 'utf8');
+    const r = run([], f);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /no writer at/);
+    assert.equal(fs.readFileSync(f, 'utf8'), original, 'nothing is written');
+  });
+
+  test('--off and --check still work without a writer', () => {
+    const withHooks = fixture('adopted-cleanup');
+    run([], withHooks);
+    const wired = fs.readFileSync(withHooks, 'utf8');
+
+    const stranded = fixture('adopted-stranded', JSON.parse(wired), { withWriter: false });
+    assert.equal(run(['--check'], stranded).status, 0);
+    const off = run(['--off'], stranded);
+    assert.equal(off.status, 0, off.stderr);
+    assert.equal(statusOf(JSON.parse(fs.readFileSync(stranded, 'utf8'))).wired, 0);
+  });
+});
+
+describe('the write is atomic and concurrency-checked', () => {
+  test('writeAtomic REFUSES when the file no longer matches the snapshot', () => {
+    const f = fixture('concurrent');
+    const onDisk = fs.readFileSync(f, 'utf8');
+    assert.throws(
+      () => writeAtomic(f, `${onDisk}// stale snapshot`, '{"clobbered":true}\n'),
+      /changed while this ran/,
+    );
+    assert.equal(fs.readFileSync(f, 'utf8'), onDisk, 'the other writer survives');
+  });
+
+  test('no temp file is left behind', () => {
+    const f = fixture('notemp');
+    run([], f);
+    const leftovers = fs.readdirSync(path.dirname(f)).filter((n) => n.includes('.tmp'));
+    assert.deepEqual(leftovers, []);
+  });
+});
+
+describe('it refuses rather than guessing', () => {
+  test('invalid JSON is refused, not rewritten', () => {
+    const f = path.join(TMP, 'broken.json');
+    fs.writeFileSync(f, '{ not json', 'utf8');
+    const r = run([], f);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /REFUSED/);
+    assert.equal(fs.readFileSync(f, 'utf8'), '{ not json', 'the file is untouched');
+  });
+
+  test('a corrupted settings file (invalid JSON) is refused on --off and --check too', () => {
+    const f = path.join(TMP, 'broken2.json');
+    fs.writeFileSync(f, '{"hooks": [1,2,', 'utf8');
+    for (const args of [['--off'], ['--check']]) {
+      const r = run(args, f);
+      assert.equal(r.status, 1, `${args[0]} must refuse`);
+      assert.match(r.stderr, /REFUSED/);
+    }
+    assert.equal(fs.readFileSync(f, 'utf8'), '{"hooks": [1,2,', 'the file is untouched');
+  });
+
+  test('an unknown option is refused', () => {
+    const f = fixture('badopt');
+    const r = run(['--yolo'], f);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /unknown option/);
+  });
+
+  test('a non-array hook value is REFUSED, not silently replaced', () => {
+    const weird = { ...BASE, hooks: { ...BASE.hooks, Notification: { legacy: 'shape' } } };
+    const f = fixture('weird-shape', weird);
+    const original = fs.readFileSync(f, 'utf8');
+    const r = run([], f);
+    assert.equal(r.status, 0, 'Notification is not one of our events, so it is never inspected');
+    assert.notEqual(fs.readFileSync(f, 'utf8'), original);
+    const s = JSON.parse(fs.readFileSync(f, 'utf8'));
+    assert.deepEqual(s.hooks.Notification, { legacy: 'shape' }, 'left completely alone');
+  });
+
+  test('a non-object hooks CONTAINER is refused, not spread', () => {
+    for (const bad of [['a'], 'nope', 42]) {
+      const f = fixture(`bad-container-${typeof bad}-${Array.isArray(bad)}`, { ...BASE, hooks: bad });
+      const original = fs.readFileSync(f, 'utf8');
+      const r = run([], f);
+      assert.equal(r.status, 1, `hooks=${JSON.stringify(bad)} must be refused`);
+      assert.match(r.stderr, /hooks is not an object/);
+      assert.equal(fs.readFileSync(f, 'utf8'), original, 'the original survives');
+    }
+  });
+
+  test('an ARRAY settings root is refused, not silently serialized away', () => {
+    const f = fixture('array-root', []);
+    const original = fs.readFileSync(f, 'utf8');
+    const r = run([], f);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /settings root is not a JSON object/);
+    assert.doesNotMatch(r.stdout, /added/, 'and must not claim it added anything');
+    assert.equal(fs.readFileSync(f, 'utf8'), original, 'the original survives');
+  });
+
+  test('one of our OWN event arrays being non-array is refused', () => {
+    const bad = { ...BASE, hooks: { ...BASE.hooks, SessionStart: 'nope' } };
+    const f = fixture('bad-own-event', bad);
+    const original = fs.readFileSync(f, 'utf8');
+    const r = run([], f);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /hooks\.SessionStart is not an array/);
+    assert.equal(fs.readFileSync(f, 'utf8'), original);
+  });
+});

--- a/scripts/setup/cli-proxy-lane.ps1
+++ b/scripts/setup/cli-proxy-lane.ps1
@@ -62,7 +62,7 @@ $Exe     = Join-Path $Dir 'cli-proxy-api.exe'
 $Cfg     = Join-Path $Dir 'config.yaml'
 $ApiKey  = 'himmel-local-claudex'   # local proxy token; must match config.yaml api-keys
 $Port    = 8317
-$Version = '7.2.122'
+$Version = '7.2.123'
 $Release = "https://github.com/router-for-me/CLIProxyAPI/releases/download/v$Version/CLIProxyAPI_${Version}_windows_amd64.zip"
 
 function Test-OAuth {

--- a/scripts/upstreams.json
+++ b/scripts/upstreams.json
@@ -150,7 +150,7 @@
       "kind": "tag_release",
       "mode": "base",
       "tracked_repo": "router-for-me/CLIProxyAPI",
-      "synced_base": "7.2.122",
+      "synced_base": "7.2.123",
       "version_pin": { "file": "scripts/setup/cli-proxy-lane.ps1", "template": "$Version = '{version}'" },
       "tier": "A",
       "note": "CLIProxyAPI codex-lane proxy (HOST process on 127.0.0.1:8317; installed + run by scripts/setup/cli-proxy-lane.ps1). Added to the nightly drift machinery (HIMMEL-1451) so a new upstream release SURFACES as a drift finding instead of needing manual surgery: v7.2.77 threw ~3-min bursts of instant upstream 502s every ~25 min that killed codex-adv renders (Claude Code retries 502s but the companion's render turn does not), and the validated fix was a manual swap to v7.2.113 -- both legs completed clean that night. AUTO-BUMP policy is deliberately SURFACE-ONLY and matches the existing rows' conservatism: apply-drift-bump.sh moves the in-repo pin literal ($Version in cli-proxy-lane.ps1) and synced_base TOGETHER, but NOTHING here restarts the running proxy -- bumping the pin does NOT swap a live instance. The drift leg lands the pin bump as a PR, and the operator runs cli-proxy-lane.ps1 -Install + -Restart (HIMMEL-1451 lifecycle verbs) to actually roll the host. Default tag-mode (highest stable tag, prereleases excluded -- CLIProxyAPI tags are monotonic, so no latest_source override is needed); synced_base lacks the leading 'v' but the guard normalizes both sides before comparing (v7.2.115 tag == 7.2.115 base). tracked_repo is the TRUE upstream (router-for-me/CLIProxyAPI)."


### PR DESCRIPTION
## Batch propagation — HIMMEL-654 leg 4/5 (base `351b9f20`)

Five private merges in one squash, verified base parity (public main mirrored private at `351b9f20` modulo carve-outs):

| Private PR | Ticket(s) | What |
|---|---|---|
| #1622 | HIMMEL-1246 | `docs/tool-adoption/lane-adoption-playbook.md` — 7-axis profile-then-tailor checklist for onboarding a model lane, GLM as the worked example |
| #1623 | HIMMEL-1613 | CR ledger `avail` rows monotone-supersede on `(head, model)`: `unavailable → ok` appends, `ok → unavailable` refused — a timed-out-then-succeeded critic no longer wedges a branch (170/170) |
| #1624 | HIMMEL-1635 | Session telemetry live: sanctioned wire-script (`install`/`--off`/`--check`, settings lock, own-entries-only) for the 4 session-run hook entries; `HimmelSessionDead` alert in both dialects (30/30 + 13/13 + 8/8 + promtool) |
| #1625 | HIMMEL-1337 +1329/1330/1331 | Arm fire-time preflight: fast dedup scan, ticket mutex, single-writer cwd refusal; suite verified solo (V4b/V6c = documented HIMMEL-1609 clean-main red only) |
| #1626 | HIMMEL-1630 | Corrective cli-proxy-api pin bump 7.2.122 → 7.2.123 — the v7.2.122 tag has no published release, so `-Install` 404'd; v7.2.123 is released and installable |

Propagated via `scripts/propagate-public.sh ship` (fail-closed leak scan + byte-verify). Public merge is operator-authorized (`/mergepub`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guidance for evaluating and adopting model lanes.
  * Added automatic session-dead alerting in Grafana and Prometheus.
  * Added tools for managing session telemetry hooks.
  * Improved handover safeguards with duplicate-ticket detection, status checks, repository protections, and Windows scheduler support.
* **Bug Fixes**
  * Corrected availability tracking to prevent downgrades.
  * Preserved unrelated hooks during validation.
* **Documentation**
  * Updated observability and adoption guidance.
* **Tests**
  * Expanded coverage for availability, handovers, telemetry, and alerting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->