### PR TITLE
chore: [HIMMEL-1642] bump graphify pin 0.9.32 -> 0.9.36 (fork-drift #518)

### DIFF
--- a/scripts/lib/graphify-bin.sh
+++ b/scripts/lib/graphify-bin.sh
@@ -50,7 +50,7 @@
 # (HIMMEL-891) -- without carrying a fork. A pin bump is a reviewed change to this
 # line, paired with `synced_base` in scripts/upstreams.json so the nightly
 # fork-drift guard stays truthful.
-_graphify_version() { printf '%s\n' "${GRAPHIFY_VERSION:-0.9.32}"; }
+_graphify_version() { printf '%s\n' "${GRAPHIFY_VERSION:-0.9.36}"; }
 _graphify_pypi_name() { printf '%s\n' "graphifyy"; }
 # The `uv tool install` package spec: `graphifyy==<version>`.
 _graphify_pinned_source() { printf '%s==%s\n' "$(_graphify_pypi_name)" "$(_graphify_version)"; }

--- a/scripts/upstreams.json
+++ b/scripts/upstreams.json
@@ -139,7 +139,7 @@
       "kind": "tag_release",
       "mode": "base",
       "tracked_repo": "Graphify-Labs/graphify",
-      "synced_base": "0.9.32",
+      "synced_base": "0.9.36",
       "latest_source": "release",
       "version_pin": { "file": "scripts/lib/graphify-bin.sh", "template": "GRAPHIFY_VERSION:-{version}" },
       "tier": "A",


### PR DESCRIPTION
## Summary

Fork-drift bump for the graphify pin, 0.9.32 -> 0.9.36 (nightly drift guard, tracking issue #518).

Two-file mechanical bump moved by `apply-drift-bump.sh`:

- `scripts/lib/graphify-bin.sh` — `GRAPHIFY_VERSION` literal 0.9.32 -> 0.9.36
- `scripts/upstreams.json` — `synced_base` moved to 0.9.36

Post-bump the drift guard re-run reads graphify CURRENT; this closes the graphify line of #518.

## Verification

- `test-apply-drift-bump.sh` — all pass
- `test-graphify-bin.sh` — 115/115

Ticket: HIMMEL-1642


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Graphify version to 0.9.36.
  * Kept support for overriding the default version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->