### PR TITLE
fix: [HIMMEL-1344] arms-registry keys on a canonical handover identity, written and consumed in lockstep

### DIFF
--- a/scripts/handover/arm-resume.sh
+++ b/scripts/handover/arm-resume.sh
@@ -464,6 +464,38 @@ command -v telemetry_emit >/dev/null 2>&1 || telemetry_emit() { return 0; }
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/../lib/handover-path.sh" 2>/dev/null || true
 command -v handover_root >/dev/null 2>&1 || handover_root() { return 2; }
+# Identity helpers are optional under the same fail-open contract. If this lib
+# is absent or only partially deployed, degrade to the pre-HIMMEL-1304 raw-path
+# identity instead of aborting under set -e; registry probes then use an
+# absolute raw key and retain their existing WARN-and-skip behaviour.
+command -v _arm_realpath >/dev/null 2>&1 || _arm_realpath() { printf '%s\n' "$1"; }
+command -v _arm_identity_path >/dev/null 2>&1 || _arm_identity_path() { printf '%s' "$1"; }
+command -v _arm_registry_identity_root >/dev/null 2>&1 || _arm_registry_identity_root() { printf '%s' "$1"; }
+command -v _arm_registry_identity_path >/dev/null 2>&1 || _arm_registry_identity_path() { printf 'absolute:%s' "$1"; }
+# The registry SCAN helper needs a fallback too (HIMMEL-1344 codex-adv round).
+# The scans below call it unconditionally, and a partially-deployed
+# handover-path.sh that predates HIMMEL-1344 exports handover_root + the JSON
+# helpers but NOT this matcher — so without this the scan aborts under set -e,
+# and with an initially empty registry that abort lands AFTER the scheduler has
+# already been written: an irreversible action reported as a failure, inviting a
+# duplicate retry. Degrade to a raw exact-match instead: a miss only weakens
+# duplicate detection back to the pre-HIMMEL-1304 behaviour, which is strictly
+# safer than aborting post-schedule.
+# Mirrors the real contract: the result is returned in the global
+# $_HP_ARMS_MATCH (1 = this record identifies the handover), NOT the exit
+# status, which is always 0. A miss degrades duplicate detection to the
+# pre-HIMMEL-1304 behaviour; escaped (e.g. backslash) spellings simply do not
+# match here, which is a weaker probe, never a wrong abort.
+_HP_ARMS_MATCH=0
+command -v _hp_arms_record_matches_path >/dev/null 2>&1 || _hp_arms_record_matches_path() {
+    local _hp_raw_marker
+    _HP_ARMS_MATCH=0
+    _hp_json_escape "$2"; _hp_raw_marker="\"handover\":\"$_HP_ESC\""
+    case "$1" in
+        *"$_hp_raw_marker"*) _HP_ARMS_MATCH=1 ;;
+    esac
+    return 0
+}
 
 # HIMMEL_HEADROOM_PROXY flag parser (HIMMEL-901): same fail-open contract as
 # the two libs above — an absent/broken lib just means the .env fallback
@@ -526,47 +558,9 @@ _arm_nested_cmd_escape() {
     printf '%s' "$v"
 }
 
-# Canonicalise a path, tolerating non-existent ones: GNU realpath -m, else
-# armored python3 pathlib, else the input unchanged (best effort — matches
-# the prior inline fallback chains).
-_arm_realpath() {
-    local _p=""
-    _p=$(realpath -m "$1" 2>/dev/null) || _p=""
-    if [ -z "$_p" ]; then
-        if py_armor_capture -c 'import sys,pathlib;print(pathlib.Path(sys.argv[1]).resolve(strict=False))' "$1" 2>/dev/null; then
-            _p="$PY_ARMOR_OUT"
-        fi
-    fi
-    [ -n "$_p" ] || _p="$1"
-    printf '%s\n' "$_p"
-}
-
-# _arm_identity_path <path> — the CANONICAL identity of a handover: the single
-# value every dedup key is derived from (HIMMEL-1304). The scheduler row name
-# IS the dedup key, so two spellings of one handover that produce two names arm
-# TWO slots for the same file — the double-fire this guard exists to prevent.
-#
-# _arm_realpath alone is NOT enough on Windows, verified on the operator's box:
-# it collapses relative / ./ / .. / symlink spellings, but PRESERVES whichever
-# drive form was typed, so `C:/x`, `C:\x` and `/c/x` stay three distinct
-# strings for one file. cygpath -u folds all three onto the /c/... form. Then
-# case-fold, because NTFS is case-insensitive and `C:/Users` vs `C:/users` name
-# the same file. Case-folding is scoped to Windows deliberately: on Linux two
-# spellings differing only in case are genuinely two different files, so
-# folding there would MERGE distinct handovers into one slot — the opposite bug.
-# (macOS is case-insensitive by default but can be formatted case-sensitive;
-# left unfolded rather than guessed, so macOS keeps its pre-1304 behaviour.)
-_arm_identity_path() {
-    local _p
-    _p=$(_arm_realpath "$1")
-    if [ "$PLATFORM" = windows ]; then
-        if command -v cygpath >/dev/null 2>&1; then
-            _p=$(cygpath -u "$_p" 2>/dev/null) || _p=$(_arm_realpath "$1")
-        fi
-        _p=$(printf '%s' "$_p" | tr '[:upper:]' '[:lower:]')
-    fi
-    printf '%s' "$_p"
-}
+# _arm_realpath / _arm_identity_path live in ../lib/handover-path.sh so the
+# scheduler-row identity and the cross-script arms-registry key share one
+# canonicalizer (HIMMEL-1304/HIMMEL-1344).
 
 # _arm_path_hash <canonical-path> — a short stable digest of the canonical
 # identity: the collision-proof half of the task name (HIMMEL-1304). The
@@ -2399,41 +2393,29 @@ fi
 # naming the hosts (no non-zero exit -- the arm already happened; the
 # warning is the value). Do not re-raise this as a race bug.
 
-# _arm_registry_foreign_hits <registry-file> <handover-path> <this-host> --
-# print a "; "-joined summary of every registry line recording an arm for
-# <handover-path> on a host OTHER than <this-host> (empty = none). Always
-# rc 0 (errexit-safe: the loop ends in string ops, nothing unguarded).
-# HIMMEL-882: a consumed arm no longer has a record at all (queue-lock.sh's
-# acquire DROPS this host's record(s) at session start -- retention, round
-# 3), and any legacy '"fired":"true"'-marked line from the earlier marking
-# revision is skipped here (and GC'd by the next locked rewrite) -- this is
-# what lets a re-arm from another host stop hard-refusing (rc=8) once the
-# original arm has actually fired, instead of forever.
+# _arm_registry_foreign_hits <registry-file> <handover-path> <handover-key>
+# <handover-root> <this-host> -- print a "; "-joined summary of every registry
+# line recording an arm for this canonical handover on a host OTHER than
+# <this-host> (empty = none). HIMMEL-1344: new lines match the durable
+# root-relative handover-key; legacy raw-only lines match exact raw or a
+# best-effort canonicalized raw path through the shared migration helper.
+# HIMMEL-882: consumed records are dropped, and legacy fired-marked lines are
+# skipped here until the next locked rewrite garbage-collects them.
 _arm_registry_foreign_hits() {
-    local _reg="$1" _ho="$2" _this_host="$3"
-    local _needle _this_esc _hits="" _line _rhost _rfire _rtask
-    # Both needles are JSON-escaped with the shared writer-side escape so an
-    # escaped stored value (e.g. a backslash Windows path, doubled on write)
-    # compares equal (round-2 -- raw-vs-escaped never matches).
-    _hp_json_escape "$_ho"
-    _needle="\"handover\":\"$_HP_ESC\""
+    local _reg="$1" _ho="$2" _key="$3" _root="$4" _this_host="$5"
+    local _this_esc _hits="" _line _rhost _rfire _rtask
     _hp_json_escape "$_this_host"; _this_esc="$_HP_ESC"
     [ -f "$_reg" ] || { printf '%s' ""; return 0; }
     # `|| [ -n "$_line" ]`: read returns 1 at EOF-without-newline while
     # still filling the variable -- without the guard a final record
     # lacking a trailing newline would be invisible to this scan.
-    # Field extraction is the shared pure-bash _hp_json_field (round-3:
-    # zero forks per line; the grep|head|sed pipelines this replaces cost
-    # ~185-200ms/LINE on Windows/Git-Bash).
     while IFS= read -r _line || [ -n "$_line" ]; do
         [ -z "$_line" ] && continue
         case "$_line" in
-            *"$_needle"*) ;;
-            *) continue ;;
-        esac
-        case "$_line" in
             *'"fired":"true"'*) continue ;;
         esac
+        _hp_arms_record_matches_path "$_line" "$_ho" "$_key" "$_root"
+        [ "$_HP_ARMS_MATCH" -eq 1 ] || continue
         _hp_json_field "$_line" host; _rhost="$_HP_FIELD"
         [ -z "$_rhost" ] && continue
         [ "$_rhost" = "$_this_esc" ] && continue
@@ -2524,8 +2506,9 @@ _arm_registry_mutex_release() {
 }
 
 # _arm_registry_replace_and_append <registry-file> <host> <handover-path>
-# <new-record-line> -- HIMMEL-882: drop any existing line whose host AND
-# handover match (this host's own prior record(s) for this same handover),
+# <handover-key> <handover-root> <new-record-line> -- HIMMEL-882/HIMMEL-1344:
+# drop any existing line whose host AND canonical handover identity match
+# (this host's own prior record(s) for this same handover),
 # GC any legacy '"fired":"true"'-marked line in passing (retention, round
 # 3 -- fired records are inert; both rewriters drop them so the registry
 # stays O(active arms)), then append <new-record-line>. Without the prune,
@@ -2538,9 +2521,10 @@ _arm_registry_mutex_release() {
 # cover a CONCURRENT rewriter, so the whole read-filter-rewrite runs under
 # the OWNER-TOKENED _arm_registry_mutex_acquire mkdir-CAS mutex shared with
 # queue-lock.sh's consume, and the mv happens only while the owner token
-# still names us. Needles are escaped with the shared _hp_json_escape
-# (round-2 -- the stored values are JSON-escaped; raw-vs-escaped never
-# matches). rc 1 on mutex timeout, mid-rewrite theft, or any write failure
+# still names us. Path matching delegates to the shared dual-format helper:
+# canonical handover-key for new lines, exact/canonicalized raw fallback for
+# legacy lines already on disk. rc 1 on mutex timeout, mid-rewrite theft, or
+# any write failure
 # (caller WARNs and moves on); rc 0 on success. Single unlock point:
 # failures only set _rc and fall through to the token-checked release
 # (which WARNs about a theft). round-4 (sfh-2): on a write failure (not a
@@ -2550,8 +2534,8 @@ _arm_registry_mutex_release() {
 # timeout; empty on success or on a mutex-timeout/theft failure.
 _ARM_REGISTRY_REPLACE_ERR=""
 _arm_registry_replace_and_append() {
-    local _reg="$1" _host="$2" _ho="$3" _new="$4"
-    local _tmp="$_reg.tmp.$$" _tok _cur _line _l_host _l_ho _host_esc _ho_esc _rc=0 _werr=""
+    local _reg="$1" _host="$2" _ho="$3" _key="$4" _root="$5" _new="$6"
+    local _tmp="$_reg.tmp.$$" _tok _cur _line _l_host _host_esc _rc=0 _werr=""
     _ARM_REGISTRY_REPLACE_ERR=""
     if ! _arm_registry_mutex_acquire "$_reg"; then
         echo "WARN arm-resume: could not lock the arms registry ($_reg.lock) -- skipping the registry rewrite for this arm (a mutex stuck from a crashed writer self-expires after 60s)" >&2
@@ -2559,7 +2543,6 @@ _arm_registry_replace_and_append() {
     fi
     _tok="$_ARM_REGISTRY_MUTEX_TOKEN"
     _hp_json_escape "$_host"; _host_esc="$_HP_ESC"
-    _hp_json_escape "$_ho";   _ho_esc="$_HP_ESC"
     # round-4 (sfh-2): capture stderr instead of discarding it -- see
     # queue-lock.sh's twin for the rationale (2>/dev/null made a real write
     # failure read identically to a mutex timeout/theft).
@@ -2576,10 +2559,12 @@ _arm_registry_replace_and_append() {
                 case "$_line" in
                     *'"fired":"true"'*) continue ;;   # GC legacy fired-marked line
                 esac
-                _hp_json_field "$_line" host;     _l_host="$_HP_FIELD"
-                _hp_json_field "$_line" handover; _l_ho="$_HP_FIELD"
-                if [ "$_l_host" = "$_host_esc" ] && [ "$_l_ho" = "$_ho_esc" ]; then
-                    continue   # superseded by $_new -- drop
+                _hp_json_field "$_line" host; _l_host="$_HP_FIELD"
+                if [ "$_l_host" = "$_host_esc" ]; then
+                    _hp_arms_record_matches_path "$_line" "$_ho" "$_key" "$_root"
+                    if [ "$_HP_ARMS_MATCH" -eq 1 ]; then
+                        continue   # superseded by $_new -- drop
+                    fi
                 fi
                 printf '%s\n' "$_line" >> "$_tmp" || { _rc=1; break; }
             done < "$_reg"
@@ -2900,8 +2885,10 @@ else
     fi
 
     HIMMEL_856_ARMS_REGISTRY="$HIMMEL_856_HR_ROOT/.locks/arms.jsonl"
+    _arm_registry_root=$(_arm_registry_identity_root "$HIMMEL_856_HR_ROOT")
+    _arm_registry_key=$(_arm_registry_identity_path "$HANDOVER_PATH" "$HIMMEL_856_HR_ROOT")
     if [ -f "$HIMMEL_856_ARMS_REGISTRY" ]; then
-        _arm_dup_hits=$(_arm_registry_foreign_hits "$HIMMEL_856_ARMS_REGISTRY" "$HANDOVER_PATH" "$(_arm_hostname)")
+        _arm_dup_hits=$(_arm_registry_foreign_hits "$HIMMEL_856_ARMS_REGISTRY" "$HANDOVER_PATH" "$_arm_registry_key" "$_arm_registry_root" "$(_arm_hostname)")
         if [ -n "$_arm_dup_hits" ]; then
             if [ "${ARM_DUP_OK:-}" = "1" ]; then
                 echo "WARN arm-resume: this handover already has a PENDING arm on another host ($_arm_dup_hits) -- arming anyway (ARM_DUP_OK=1)" >&2
@@ -3899,14 +3886,16 @@ if [ -n "${HIMMEL_856_HR_ROOT:-}" ]; then
     # Values are escaped with the shared _hp_json_escape (round-3) -- the
     # SAME transform every reader's needle uses, so escaped-vs-escaped
     # comparisons hold by construction.
-    _hp_json_escape "$_arm_host";     _arm_rec_host="$_HP_ESC"
-    _hp_json_escape "$HANDOVER_PATH"; _arm_rec_ho="$_HP_ESC"
-    _hp_json_escape "$AT_STAMP";      _arm_rec_fire="$_HP_ESC"
-    _hp_json_escape "$TASK_NAME";     _arm_rec_task="$_HP_ESC"
-    _arm_new_record=$(printf '{"host":"%s","handover":"%s","fire-at":"%s","task-name":"%s"}' \
-        "$_arm_rec_host" "$_arm_rec_ho" "$_arm_rec_fire" "$_arm_rec_task")
-    unset _arm_rec_host _arm_rec_ho _arm_rec_fire _arm_rec_task
-    if ! _arm_registry_replace_and_append "$HIMMEL_856_HR_ROOT/.locks/arms.jsonl" "$_arm_host" "$HANDOVER_PATH" "$_arm_new_record"; then
+    _hp_json_escape "$_arm_host";         _arm_rec_host="$_HP_ESC"
+    _hp_json_escape "$HANDOVER_PATH";      _arm_rec_ho="$_HP_ESC"
+    _hp_json_escape "$_arm_registry_key"; _arm_rec_key="$_HP_ESC"
+    _hp_json_escape "${_ho_ticket:-}";   _arm_rec_ticket="$_HP_ESC"
+    _hp_json_escape "$AT_STAMP";         _arm_rec_fire="$_HP_ESC"
+    _hp_json_escape "$TASK_NAME";        _arm_rec_task="$_HP_ESC"
+    _arm_new_record=$(printf '{"host":"%s","handover":"%s","handover-key":"%s","ticket":"%s","fire-at":"%s","task-name":"%s"}' \
+        "$_arm_rec_host" "$_arm_rec_ho" "$_arm_rec_key" "$_arm_rec_ticket" "$_arm_rec_fire" "$_arm_rec_task")
+    unset _arm_rec_host _arm_rec_ho _arm_rec_key _arm_rec_ticket _arm_rec_fire _arm_rec_task
+    if ! _arm_registry_replace_and_append "$HIMMEL_856_HR_ROOT/.locks/arms.jsonl" "$_arm_host" "$HANDOVER_PATH" "$_arm_registry_key" "$_arm_registry_root" "$_arm_new_record"; then
         # round-4 (sfh-2): fold the first line of the captured write error
         # (if any -- empty on a mutex timeout/theft) so this WARN reads
         # differently from those cases.
@@ -3922,7 +3911,7 @@ if [ -n "${HIMMEL_856_HR_ROOT:-}" ]; then
     # hosts double-armed. No non-zero exit -- the arm already happened;
     # the queue lock at session start is the layer that serializes the
     # actual double-fire.
-    _arm_post_hits=$(_arm_registry_foreign_hits "$HIMMEL_856_HR_ROOT/.locks/arms.jsonl" "$HANDOVER_PATH" "$_arm_host")
+    _arm_post_hits=$(_arm_registry_foreign_hits "$HIMMEL_856_HR_ROOT/.locks/arms.jsonl" "$HANDOVER_PATH" "$_arm_registry_key" "$_arm_registry_root" "$_arm_host")
     if [ -n "$_arm_post_hits" ]; then
         {
             echo "=================================================================="
@@ -3936,7 +3925,7 @@ if [ -n "${HIMMEL_856_HR_ROOT:-}" ]; then
             echo "=================================================================="
         } >&2
     fi
-    unset _arm_host _arm_post_hits
+    unset _arm_host _arm_post_hits _arm_registry_key _arm_registry_root
 fi
 
 cat <<EOF

--- a/scripts/handover/fixtures/handover-path-pre-himmel-1344.sh
+++ b/scripts/handover/fixtures/handover-path-pre-himmel-1344.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Test-owned partial-deployment fixture. It deliberately provides the resolver
+# and JSON helper contract that arm-resume.sh / queue-lock.sh already depended
+# on before HIMMEL-1344, but no HIMMEL-1344 identity or record-matcher helpers.
+
+handover_root() {
+    if [ -n "${HANDOVER_DIR:-}" ] && [ -d "$HANDOVER_DIR" ]; then
+        ( cd "$HANDOVER_DIR" && pwd )
+        return 0
+    fi
+    return 2
+}
+
+handover_root_ensure() {
+    handover_root
+}
+
+_HP_ESC=""
+_hp_json_escape() {
+    _HP_ESC="${1//\\/\\\\}"
+    _HP_ESC="${_HP_ESC//\"/\\\"}"
+}
+
+_HP_FIELD=""
+_hp_json_field() {
+    local _hp_rest _hp_chunk _hp_bs
+    _HP_FIELD=""
+    case "$1" in
+        *"\"$2\":\""*) ;;
+        *) return 0 ;;
+    esac
+    _hp_rest="${1#*"\"$2\":\""}"
+    while :; do
+        _hp_chunk="${_hp_rest%%\"*}"
+        if [ "$_hp_chunk" = "$_hp_rest" ]; then
+            _HP_FIELD=""
+            return 0
+        fi
+        _HP_FIELD="$_HP_FIELD$_hp_chunk"
+        _hp_rest="${_hp_rest#*\"}"
+        _hp_bs="${_hp_chunk##*[!\\]}"
+        if [ $(( ${#_hp_bs} % 2 )) -eq 0 ]; then
+            return 0
+        fi
+        _HP_FIELD="$_HP_FIELD\""
+    done
+}

--- a/scripts/handover/queue-lock.sh
+++ b/scripts/handover/queue-lock.sh
@@ -124,6 +124,41 @@ _QL_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/handover-path.sh
 # shellcheck disable=SC1091
 . "$_QL_SCRIPT_DIR/../lib/handover-path.sh"
+# _arm_registry_identity_path / _hp_arms_record_matches_path are NEW in
+# HIMMEL-1344 (see the registry-lifecycle comment above
+# _ql_arms_registry_retire_fired). The source above is NOT fail-open --
+# a missing/broken lib still aborts queue-lock.sh outright -- but a
+# partially-deployed lib (an OLDER pre-HIMMEL-1344 handover-path.sh that
+# still parses and exports handover_root + the JSON helpers, just not
+# these two identity helpers) sources cleanly and would otherwise let the
+# CONSUME path (_ql_arms_registry_retire_fired, called from every
+# `acquire`) call an undefined function under `set -uo pipefail`: the
+# empty $key from a missing `_arm_registry_identity_path` is harmless, but
+# `_HP_ARMS_MATCH` would stay completely unset and the `-u` reference to
+# it below aborts the whole acquire -- an irreversible action (the lock
+# dir may already be created) reported as a failure. Mirrors the
+# arm-resume.sh fallback for the exact same partial-deployment scenario
+# (scripts/handover/arm-resume.sh, near its own `_arm_registry_identity_path`
+# guard) so both the write and consume sides degrade the same way instead
+# of one surviving and the other aborting.
+command -v _arm_registry_identity_root >/dev/null 2>&1 || _arm_registry_identity_root() { printf '%s' "$1"; }
+command -v _arm_registry_identity_path >/dev/null 2>&1 || _arm_registry_identity_path() { printf 'absolute:%s' "$1"; }
+# Mirrors the real contract: the result is returned in the global
+# $_HP_ARMS_MATCH (1 = this record identifies the handover), NOT the exit
+# status, which is always 0. A miss just degrades duplicate-record
+# retirement to a no-op for that record (it stays PENDING and gets
+# retired later, same fail-open posture as every other branch in
+# _ql_arms_registry_retire_fired), never a wrong abort.
+_HP_ARMS_MATCH=0
+command -v _hp_arms_record_matches_path >/dev/null 2>&1 || _hp_arms_record_matches_path() {
+    local _hp_raw_marker
+    _HP_ARMS_MATCH=0
+    _hp_json_escape "$2"; _hp_raw_marker="\"handover\":\"$_HP_ESC\""
+    case "$1" in
+        *"$_hp_raw_marker"*) _HP_ARMS_MATCH=1 ;;
+    esac
+    return 0
+}
 # shellcheck source=../lib/py-armor.sh
 # shellcheck disable=SC1091
 . "$_QL_SCRIPT_DIR/../lib/py-armor.sh"
@@ -280,8 +315,9 @@ _ql_lockdir() {
 # mutex-expiry hazard -- consumed records are DROPPED, and any legacy
 # '"fired":"true"'-marked line (written by the earlier marking revision) is
 # garbage-collected in passing. Both rewriters GC this way, so the file
-# stays O(active arms). Matches by host+handover only (not task-name/
-# fire-at) so it also clears earlier SAME-host records left by a re-arm/
+# stays O(active arms). Matches by host+canonical handover identity only (not
+# task-name/fire-at), with raw-field fallback for pre-HIMMEL-1344 records, so
+# it also clears earlier SAME-host records left by a re-arm/
 # --force replace that never itself fired (arm-resume.sh additionally
 # prunes those at re-schedule time -- see its own HIMMEL-882 comment).
 #
@@ -300,7 +336,7 @@ _ql_lockdir() {
 # 60s staleness expiry gets reclaimed; its snapshot is then stale and its
 # blind mv/rmdir would corrupt the reclaimer's generation).
 _ql_arms_registry_retire_fired() {
-    local ho="$1" root reg host tmp tok cur line l_host l_ho host_esc ho_esc changed=0 failed=0 stolen=0 wfail_err=""
+    local ho="$1" root registry_root reg key host tmp tok cur line l_host host_esc changed=0 failed=0 stolen=0 wfail_err=""
     # handover_root failure here would require an external race (the root
     # deleted out from under us mid-acquire): _ql_lockdir already resolved
     # this same root moments earlier via handover_root_ensure, so this is
@@ -311,16 +347,18 @@ _ql_arms_registry_retire_fired() {
     [ -n "$root" ] || return 0
     reg="$root/.locks/arms.jsonl"
     [ -f "$reg" ] || return 0
+    registry_root=$(_arm_registry_identity_root "$root")
+    key=$(_arm_registry_identity_path "$ho" "$root")
     if ! _ql_arms_mutex_acquire "$reg"; then
         echo "WARN queue-lock: could not lock the arms registry ($reg.lock) -- skipping the consume; this host's arm record stays PENDING (a later acquire or same-host re-arm clears it; a mutex stuck from a crashed writer self-expires after 60s)" >&2
         return 0
     fi
     tok="$_QL_ARMS_MUTEX_TOKEN"
-    # Compare ESCAPED-vs-ESCAPED (round-2): the registry stores JSON-escaped
-    # values, so the needles get the same transform before comparing.
+    # Host stays escaped-vs-escaped. Path identity delegates to the shared
+    # dual-format matcher: canonical root-relative handover-key for new records,
+    # exact/canonicalized raw fallback for records already on disk (HIMMEL-1344).
     host=$(_ql_hostname)
     _hp_json_escape "$host"; host_esc="$_HP_ESC"
-    _hp_json_escape "$ho";   ho_esc="$_HP_ESC"
     tmp="$reg.tmp.$$"
     # round-4 (sfh-2): capture stderr instead of discarding it, so a real
     # write failure (disk full / permission denied / RO-fs / AV lock) folds
@@ -339,11 +377,13 @@ _ql_arms_registry_retire_fired() {
             case "$line" in
                 *'"fired":"true"'*) changed=1; continue ;;   # GC legacy fired-marked line
             esac
-            _hp_json_field "$line" host;     l_host="$_HP_FIELD"
-            _hp_json_field "$line" handover; l_ho="$_HP_FIELD"
-            if [ "$l_host" = "$host_esc" ] && [ "$l_ho" = "$ho_esc" ]; then
-                changed=1
-                continue   # consumed: this acquire IS the arm's session start
+            _hp_json_field "$line" host; l_host="$_HP_FIELD"
+            if [ "$l_host" = "$host_esc" ]; then
+                _hp_arms_record_matches_path "$line" "$ho" "$key" "$registry_root"
+                if [ "$_HP_ARMS_MATCH" -eq 1 ]; then
+                    changed=1
+                    continue   # consumed: this acquire IS the arm's session start
+                fi
             fi
             printf '%s\n' "$line" >> "$tmp" || failed=1
             [ "$failed" -eq 1 ] && break
@@ -401,6 +441,11 @@ _ql_arms_registry_retire_fired() {
 # was, say, 56s old when this contender started is not yet stale at
 # tries==0 but would previously never be re-checked, burning the whole
 # retry budget instead of reclaiming it; a failed probe never clears).
+# The staleness threshold is NAMED so the stress test can assert against the
+# real lease instead of duplicating a magic 60 (HIMMEL-1344 CR round). Keep the
+# `_QL_ARMS_MUTEX_STALE_SECS=<n>` spelling on one line: test-queue-lock.sh reads
+# this value straight out of the source and fails loudly if it stops matching.
+_QL_ARMS_MUTEX_STALE_SECS=60
 _QL_ARMS_MUTEX_TOKEN=""
 _ql_arms_mutex_acquire() {
     local reg="$1" lockd tries=0 m now tok
@@ -435,7 +480,7 @@ _ql_arms_mutex_acquire() {
         if [ $(( tries % 10 )) -eq 0 ]; then
             m=$(py_armor_mtime "$lockd") || m=""
             now=$(_ql_now_epoch)
-            if [ -n "$m" ] && [ -n "$now" ] && [ $(( now - m )) -ge 60 ]; then
+            if [ -n "$m" ] && [ -n "$now" ] && [ $(( now - m )) -ge "$_QL_ARMS_MUTEX_STALE_SECS" ]; then
                 rm -rf "$lockd" 2>/dev/null
             fi
         fi

--- a/scripts/handover/test-arm-resume-queue-lock.sh
+++ b/scripts/handover/test-arm-resume-queue-lock.sh
@@ -17,6 +17,12 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ARM="$SCRIPT_DIR/arm-resume.sh"
 QL="$SCRIPT_DIR/queue-lock.sh"
+# shellcheck source=../lib/py-armor.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/py-armor.sh"
+# shellcheck source=../lib/handover-path.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/handover-path.sh"
 
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
@@ -33,13 +39,24 @@ unset QUEUE_LOCK_TAKEOVER QUEUE_LOCK_TTL_SECONDS ARM_DUP_OK 2>/dev/null || true
 # hits the HIMMEL-1365 temp-target refusal (rc=12). Same shield
 # test-arm-resume.sh carries (HIMMEL-1623).
 export ARM_TEMP_CWD_OK=1
+# Worker-census shield (HIMMEL-1622/#1635, same as test-arm-resume.sh): point
+# the live-lane-worker census at an isolated empty root under $TMP, or every
+# REAL-arm case here refuses rc=10 whenever a GLM/claudex lane worker (or a
+# codex render) is live on the machine — the exact suites-reading-machine-wide-
+# state class that produced this suite's shifting 8/13/18-fail reds under
+# parallel lane load (leg 7, 2026-08-09).
+export WORKER_BRIDGE_ROOT="$TMP/worker-bridge-shield"
 
 # A near future time keeps these queue-lock fixtures inside the HIMMEL-1475
-# explicit-HH:MM long-gap limit.
-FUTURE_TIME=$(python3 -c 'import datetime; print((datetime.datetime.now()+datetime.timedelta(minutes=30)).strftime("%H:%M"))')
+# explicit-HH:MM long-gap limit. Computed LAZILY at each use, never once at
+# suite start: a compute-once value goes STALE when earlier sections run long
+# (observed: >30 min under parallel lane load), and a stale HH:MM parses as
+# TOMORROW -> ~24h gap -> spurious long-gap rc=9 across every arm fixture.
+future_time() { python3 -c 'import datetime; print((datetime.datetime.now()+datetime.timedelta(minutes=30)).strftime("%H:%M"))'; }
 HO="$HANDOVER_DIR/HIMMEL-856-test/next-session-1.md"
 mkdir -p "$(dirname "$HO")"
 printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 test handover\n' > "$HO"
+HO_KEY=$(_arm_registry_identity_path "$HO" "$HANDOVER_DIR")
 
 FAILED=0
 # On a mismatch, dump the arm's captured combined output (every call site
@@ -136,33 +153,33 @@ chmod +x "$SCHED_STUB/schtasks" "$SCHED_STUB/atq" "$SCHED_STUB/at" \
 export PATH="$SCHED_STUB:$PATH"
 
 # --- T1: no lock, no registry -> plain dry-run arm succeeds -----------------
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO" --dry-run 2>&1)
 rc=$?
 assert_rc "T1: no lock/registry, dry-run arm" 0 "$rc"
 
 # --- T2: queue lock FRESH -> arm refused rc=7 --------------------------------
 bash "$QL" acquire "$HO" "live-session" >/dev/null 2>&1
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO" --dry-run 2>&1)
 rc=$?
 assert_rc "T2: FRESH queue lock refuses arm" 7 "$rc"
 assert_contains "T2: stderr names the live holder" "live-session" "$out"
 assert_contains "T2: stderr names the override" "QUEUE_LOCK_TAKEOVER" "$out"
 
 # --- T3: QUEUE_LOCK_TAKEOVER=1 overrides the FRESH refusal -> rc=0, WARN ----
-out=$(QUEUE_LOCK_TAKEOVER=1 bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+out=$(QUEUE_LOCK_TAKEOVER=1 bash "$ARM" --time "$(future_time)" --handover "$HO" --dry-run 2>&1)
 rc=$?
 assert_rc "T3: QUEUE_LOCK_TAKEOVER=1 overrides FRESH refusal" 0 "$rc"
 assert_contains "T3: WARN present on override" "WARN arm-resume: queue lock is FRESH" "$out"
 
 # --- T4: release -> arm succeeds again without any override -----------------
 bash "$QL" release "$HO" "live-session" >/dev/null 2>&1
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO" --dry-run 2>&1)
 rc=$?
 assert_rc "T4: arm succeeds after release" 0 "$rc"
 
 # --- T5: STALE queue lock (TTL=0) does NOT refuse the arm --------------------
 bash "$QL" acquire "$HO" "old-session" >/dev/null 2>&1
-out=$(QUEUE_LOCK_TTL_SECONDS=0 bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+out=$(QUEUE_LOCK_TTL_SECONDS=0 bash "$ARM" --time "$(future_time)" --handover "$HO" --dry-run 2>&1)
 rc=$?
 assert_rc "T5: STALE lock (TTL=0) does not block arming" 0 "$rc"
 bash "$QL" release "$HO" "old-session" >/dev/null 2>&1
@@ -172,21 +189,81 @@ mkdir -p "$HANDOVER_DIR/.locks"
 THIS_HOST=$(hostname 2>/dev/null || echo "${COMPUTERNAME:-${HOSTNAME:-unknown-host}}")
 printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-same-host"}\n' \
     "$THIS_HOST" "$HO" > "$HANDOVER_DIR/.locks/arms.jsonl"
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO" --dry-run 2>&1)
 rc=$?
 assert_rc "T6: same-host registry entry is not a cross-machine dup" 0 "$rc"
 
-# --- T7: arms.jsonl entry for a DIFFERENT host, SAME handover -> rc=8 -------
-printf '{"host":"other-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-other-host"}\n' \
-    "$HO" > "$HANDOVER_DIR/.locks/arms.jsonl"
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+# --- T7: a foreign-host NEW-FORMAT record written under another spelling ----
+# still refuses rc=8. The raw field remains for old readers, but the canonical
+# root-relative key is the cross-script/cross-layout identity (HIMMEL-1344).
+HO_ALT="$HANDOVER_DIR/HIMMEL-856-test/../HIMMEL-856-test/next-session-1.md"
+printf '{"host":"other-host","handover":"%s","handover-key":"%s","ticket":"HIMMEL-856","fire-at":"202601010000","task-name":"HIMMEL-Resume-other-host"}\n' \
+    "$HO_ALT" "$HO_KEY" > "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO" --dry-run 2>&1)
 rc=$?
-assert_rc "T7: cross-host pending arm refuses (rc=8)" 8 "$rc"
+assert_rc "T7: cross-host pending arm under another spelling refuses (rc=8)" 8 "$rc"
 assert_contains "T7: stderr names the other host" "other-host" "$out"
 assert_contains "T7: stderr names the override" "ARM_DUP_OK" "$out"
 
+# --- T7b: a legacy raw-only record already on disk gets migration matching --
+printf '{"host":"legacy-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-legacy-host"}\n' \
+    "$HO_ALT" > "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO" --dry-run 2>&1)
+rc=$?
+assert_rc "T7b: legacy alternate-spelling record still refuses during migration" 8 "$rc"
+assert_contains "T7b: refusal names the legacy host" "legacy-host" "$out"
+
+# --- T7c: OLD-library fallback key remains visible to CURRENT readers -------
+# A partial deployment writes absolute:<raw> even for an in-root handover. Once
+# the shared library upgrades, its preferred key becomes root-relative:<path>.
+# A mismatching stored key must therefore fall through to the raw-path rule for
+# every current consumer: foreign scan, same-host prune, and queue consumption.
+HO7C="$HANDOVER_DIR/HIMMEL-856-test/next-session-7c.md"
+printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t7c handover\n' > "$HO7C"
+HO7C_FALLBACK_KEY="absolute:$HO7C"
+printf '{"host":"fallback-foreign-host","handover":"%s","handover-key":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t7c-scan"}\n' \
+    "$HO7C" "$HO7C_FALLBACK_KEY" > "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO7C" --dry-run 2>&1)
+rc=$?
+assert_rc "T7c: current scan sees a pending old-library fallback-key record" 8 "$rc"
+assert_contains "T7c: fallback-key scan names the foreign host" "fallback-foreign-host" "$out"
+
+THIS_HOST=$(hostname 2>/dev/null || echo "${COMPUTERNAME:-${HOSTNAME:-unknown-host}}")
+printf '{"host":"%s","handover":"%s","handover-key":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t7c-prune-old"}\n' \
+    "$THIS_HOST" "$HO7C" "$HO7C_FALLBACK_KEY" > "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO7C" 2>&1)
+rc=$?
+assert_rc "T7c: current re-arm prunes an old-library fallback-key record" 0 "$rc"
+HO7C_KEY=$(_arm_registry_identity_path "$HO7C" "$HANDOVER_DIR")
+if ! grep -q 'HIMMEL-Resume-t7c-prune-old' "$HANDOVER_DIR/.locks/arms.jsonl" \
+    && grep -qF "\"handover-key\":\"$HO7C_KEY\"" "$HANDOVER_DIR/.locks/arms.jsonl" \
+    && [ "$(wc -l < "$HANDOVER_DIR/.locks/arms.jsonl")" -eq 1 ]; then
+    echo "PASS T7c: current prune replaced the fallback-key record exactly once"
+else
+    echo "FAIL T7c: current prune left or duplicated the fallback-key record ($(cat "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null))"
+    FAILED=$((FAILED + 1))
+fi
+
+printf '{"host":"%s","handover":"%s","handover-key":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t7c-consume-old"}\n' \
+    "$THIS_HOST" "$HO7C" "$HO7C_FALLBACK_KEY" > "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(bash "$QL" acquire "$HO7C" "t7c-consumer" 2>&1)
+rc=$?
+assert_rc "T7c: current queue-lock acquire consumes a fallback-key record" 0 "$rc"
+if [ ! -s "$HANDOVER_DIR/.locks/arms.jsonl" ]; then
+    echo "PASS T7c: queue-lock consumption retired the fallback-key record"
+else
+    echo "FAIL T7c: queue-lock consumption left the fallback-key record ($(cat "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null))"
+    FAILED=$((FAILED + 1))
+fi
+bash "$QL" release "$HO7C" "t7c-consumer" >/dev/null 2>&1
+rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
+
+# Restore the new-format row for the override case below.
+printf '{"host":"other-host","handover":"%s","handover-key":"%s","ticket":"HIMMEL-856","fire-at":"202601010000","task-name":"HIMMEL-Resume-other-host"}\n' \
+    "$HO_ALT" "$HO_KEY" > "$HANDOVER_DIR/.locks/arms.jsonl"
+
 # --- T8: ARM_DUP_OK=1 overrides the cross-host refusal -> rc=0, WARN --------
-out=$(ARM_DUP_OK=1 bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+out=$(ARM_DUP_OK=1 bash "$ARM" --time "$(future_time)" --handover "$HO" --dry-run 2>&1)
 rc=$?
 assert_rc "T8: ARM_DUP_OK=1 overrides cross-host refusal" 0 "$rc"
 assert_contains "T8: WARN present on override" "WARN arm-resume: this handover already has a PENDING arm" "$out"
@@ -196,20 +273,22 @@ OTHER_HO="$HANDOVER_DIR/HIMMEL-856-test/next-session-2.md"
 : > "$OTHER_HO"
 printf '{"host":"other-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-unrelated"}\n' \
     "$OTHER_HO" > "$HANDOVER_DIR/.locks/arms.jsonl"
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" --dry-run 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO" --dry-run 2>&1)
 rc=$?
 assert_rc "T9: registry entry for a DIFFERENT handover is not a false-positive dup" 0 "$rc"
 rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
 
 # --- T10: a REAL (non-dry-run) arm against the stubbed scheduler appends a
 #          well-formed line to arms.jsonl ------------------------------------
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO" 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO" 2>&1)
 rc=$?
 assert_rc "T10: stubbed real arm succeeds" 0 "$rc"
 if [ -f "$HANDOVER_DIR/.locks/arms.jsonl" ] \
     && grep -q "\"handover\":\"$HO\"" "$HANDOVER_DIR/.locks/arms.jsonl" \
+    && grep -qF "\"handover-key\":\"$HO_KEY\"" "$HANDOVER_DIR/.locks/arms.jsonl" \
+    && grep -qF '"ticket":"HIMMEL-856"' "$HANDOVER_DIR/.locks/arms.jsonl" \
     && grep -q '"task-name":"HIMMEL-Resume-' "$HANDOVER_DIR/.locks/arms.jsonl"; then
-    echo "PASS T10: arms.jsonl gained a well-formed record for this arm"
+    echo "PASS T10: arms.jsonl gained raw+canonical+ticket fields for this arm"
 else
     echo "FAIL T10: arms.jsonl missing/malformed after a real arm ($(cat "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null || echo MISSING))"
     FAILED=$((FAILED + 1))
@@ -229,7 +308,7 @@ HO11="$HANDOVER_DIR/HIMMEL-856-test/next-session-11.md"
 printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t11 handover\n' > "$HO11"
 printf '{"host":"rival-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-rival"}\n' \
     "$HO11" > "$HANDOVER_DIR/.locks/arms.jsonl"
-out=$(ARM_DUP_OK=1 bash "$ARM" --time "$FUTURE_TIME" --handover "$HO11" 2>&1)
+out=$(ARM_DUP_OK=1 bash "$ARM" --time "$(future_time)" --handover "$HO11" 2>&1)
 rc=$?
 assert_rc "T11: double-armed arm still succeeds (warning is advisory)" 0 "$rc"
 assert_contains "T11: post-append DOUBLE-ARM warning fires" "DOUBLE-ARM DETECTED" "$out"
@@ -247,7 +326,7 @@ rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
 # --- T12: no false post-append warning on a clean single-host arm -----------
 HO12="$HANDOVER_DIR/HIMMEL-856-test/next-session-12.md"
 printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t12 handover\n' > "$HO12"
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO12" 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO12" 2>&1)
 rc=$?
 assert_rc "T12: clean single-host arm succeeds" 0 "$rc"
 assert_not_contains "T12: no DOUBLE-ARM warning on a clean arm" "DOUBLE-ARM DETECTED" "$out"
@@ -264,17 +343,50 @@ cp "$SCRIPT_DIR/../lib/handover-path.sh" "$FAKE/lib/handover-path.sh"
 cp "$SCRIPT_DIR/../lib/telemetry.sh" "$FAKE/lib/telemetry.sh" 2>/dev/null || true
 HO13="$HANDOVER_DIR/HIMMEL-856-test/next-session-13.md"
 printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t13 handover\n' > "$HO13"
-out=$(bash "$FAKE/handover/arm-resume.sh" --time "$FUTURE_TIME" --handover "$HO13" --dry-run 2>&1)
+out=$(bash "$FAKE/handover/arm-resume.sh" --time "$(future_time)" --handover "$HO13" --dry-run 2>&1)
 rc=$?
 assert_rc "T13: arm proceeds with queue-lock.sh missing" 0 "$rc"
 assert_contains "T13: WARN names the missing queue-lock.sh" "queue-lock.sh not found" "$out"
+
+# --- T13b: missing handover-path.sh degrades to raw identity, never aborts ---
+# The library is fail-open, but its identity helpers are used before the
+# optional registry write. Remove it from the doctored tree and keep the
+# registry absent so this focused dry-run exercises the fallback definitions.
+rm -f "$FAKE/lib/handover-path.sh" "$HANDOVER_DIR/.locks/arms.jsonl"
+out=$(bash "$FAKE/handover/arm-resume.sh" --time "$(future_time)" --handover "$HO13" --dry-run 2>&1)
+rc=$?
+assert_rc "T13b: arm proceeds with handover-path.sh absent" 0 "$rc"
+assert_contains "T13b: dry-run reaches the completion banner" "dry-run complete" "$out"
+
+# --- T13c: PARTIAL deployment — library present but PRE-HIMMEL-1344 ----------
+# The gap T13b cannot see (codex-adv round): removing the whole library makes
+# the registry path skip entirely, so it never exercises the scan helpers. The
+# real skew is a library that resolves handover_root fine and exports the JSON
+# globals/helpers, but deliberately lacks the HIMMEL-1344 identity + matcher.
+# This test-owned fixture pins that exact old-library property; deriving it
+# from main would silently stop exercising the fallback after this branch merges.
+PRE_1344_LIB="$SCRIPT_DIR/fixtures/handover-path-pre-himmel-1344.sh"
+if cp "$PRE_1344_LIB" "$FAKE/lib/handover-path.sh" \
+    && ! grep -q '^_arm_registry_identity_path()' "$FAKE/lib/handover-path.sh" \
+    && ! grep -q '^_hp_arms_record_matches_path()' "$FAKE/lib/handover-path.sh"; then
+    mkdir -p "$HANDOVER_DIR/.locks"
+    printf '{"handover":"%s","state":"PENDING"}\n' "$HO13" > "$HANDOVER_DIR/.locks/arms.jsonl"
+    out=$(bash "$FAKE/handover/arm-resume.sh" --time "$(future_time)" --handover "$HO13" --dry-run 2>&1)
+    rc=$?
+    assert_rc "T13c: arm proceeds against a pre-1344 handover-path.sh" 0 "$rc"
+    assert_contains "T13c: dry-run reaches the completion banner" "dry-run complete" "$out"
+else
+    echo "FAIL T13c: pre-1344 fixture missing or unexpectedly defines HIMMEL-1344 helpers"
+    FAILED=$((FAILED + 1))
+fi
+rm -f "$FAKE/lib/handover-path.sh" "$HANDOVER_DIR/.locks/arms.jsonl"
 
 # --- T14: unexpected queue-lock status rc -> WARN + arm proceeds (imp-b) ----
 # Same isolated tree, now with a stub queue-lock.sh that exits rc=5 (not
 # 0/11/12): the check must WARN 'proceeding' instead of silently treating
 # a broken status probe as a verified-free queue.
 printf '#!/usr/bin/env bash\necho "stub queue-lock exploded" >&2\nexit 5\n' > "$FAKE/handover/queue-lock.sh"
-out=$(bash "$FAKE/handover/arm-resume.sh" --time "$FUTURE_TIME" --handover "$HO13" --dry-run 2>&1)
+out=$(bash "$FAKE/handover/arm-resume.sh" --time "$(future_time)" --handover "$HO13" --dry-run 2>&1)
 rc=$?
 assert_rc "T14: arm proceeds despite a broken status probe" 0 "$rc"
 assert_contains "T14: WARN reports the unexpected status rc" "queue-lock status failed (rc=5)" "$out"
@@ -287,17 +399,25 @@ assert_contains "T14: WARN reports the unexpected status rc" "queue-lock status 
 # for the NEXT host that tries to arm this same handover.
 HO15="$HANDOVER_DIR/HIMMEL-856-test/next-session-15.md"
 printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t15 handover\n' > "$HO15"
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO15" 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO15" 2>&1)
 rc=$?
 assert_rc "T15: first real arm succeeds" 0 "$rc"
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO15" 2>&1)
+HO15_ALT="$HANDOVER_DIR/HIMMEL-856-test/../HIMMEL-856-test/next-session-15.md"
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO15_ALT" 2>&1)
 rc=$?
-assert_rc "T15: second real arm (re-arm, same host) succeeds" 0 "$rc"
-n=$(grep -c "\"handover\":\"$HO15\"" "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null || echo 0)
+assert_rc "T15: second real arm under another spelling succeeds" 0 "$rc"
+HO15_KEY=$(_arm_registry_identity_path "$HO15" "$HANDOVER_DIR")
+# No `|| echo 0`: on a no-match `grep -c` ALREADY prints 0 and then exits 1, so
+# the fallback would append a SECOND line and make n="0\n0" -- which turns the
+# `-eq` below into a bash integer-expression error and swallows the FAIL T15
+# diagnostic exactly when it is needed. Tolerate the nonzero rc instead, and
+# default only when grep printed nothing at all (missing file, rc=2).
+n=$(grep -cF "\"handover-key\":\"$HO15_KEY\"" "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null) || true
+[ -n "$n" ] || n=0
 if [ "$n" -eq 1 ]; then
-    echo "PASS T15: exactly one record survives repeated same-host re-arms (got $n)"
+    echo "PASS T15: canonical same-host re-arm leaves exactly one registry record (got $n)"
 else
-    echo "FAIL T15: expected exactly 1 record after 2 same-host re-arms, got $n ($(cat "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null))"
+    echo "FAIL T15: expected exactly 1 canonical record after alternate-spelling re-arm, got $n ($(cat "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null))"
     FAILED=$((FAILED + 1))
 fi
 rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
@@ -310,7 +430,7 @@ HO16="$HANDOVER_DIR/HIMMEL-856-test/next-session-16.md"
 printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t16 handover\n' > "$HO16"
 printf '{"host":"other-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-fired","fired":"true"}\n' \
     "$HO16" > "$HANDOVER_DIR/.locks/arms.jsonl"
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO16" --dry-run 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO16" --dry-run 2>&1)
 rc=$?
 assert_rc "T16: fired foreign-host record no longer blocks re-arm" 0 "$rc"
 assert_not_contains "T16: no rc=8 PENDING-arm refusal for a fired record" "already has a PENDING arm" "$out"
@@ -324,7 +444,7 @@ HO17="$HANDOVER_DIR/HIMMEL-856-test/next-session-17b.md"
 printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t17 handover\n' > "$HO17"
 printf '{"host":"other-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-still-live"}\n' \
     "$HO17" > "$HANDOVER_DIR/.locks/arms.jsonl"
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO17" --dry-run 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO17" --dry-run 2>&1)
 rc=$?
 assert_rc "T17: still-live (unfired) foreign-host record still refuses rc=8" 8 "$rc"
 rm -f "$HANDOVER_DIR/.locks/arms.jsonl"
@@ -338,7 +458,7 @@ printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t18 handover\n' > "$HO18"
     printf '{"host":"fired-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t18-fired","fired":"true"}\n' "$HO18"
     printf '{"host":"pending-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t18-pending"}\n' "$HO18"
 } > "$HANDOVER_DIR/.locks/arms.jsonl"
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO18" --dry-run 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO18" --dry-run 2>&1)
 rc=$?
 assert_rc "T18: mixed registry still refuses on the PENDING record" 8 "$rc"
 assert_contains "T18: refusal names the pending host" "pending-host" "$out"
@@ -361,10 +481,10 @@ else
     printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t19 handover\n' > "$HO19"
 fi
 HO19_ESC=$(printf '%s' "$HO19" | sed -e 's/\\/\\\\/g')
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO19" 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO19" 2>&1)
 rc=$?
 assert_rc "T19: first arm with a backslash path succeeds" 0 "$rc"
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO19" 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO19" 2>&1)
 rc=$?
 assert_rc "T19: second arm (re-arm) with a backslash path succeeds" 0 "$rc"
 n=$(grep -cF "\"handover\":\"$HO19_ESC\"" "$HANDOVER_DIR/.locks/arms.jsonl" 2>/dev/null || echo 0)
@@ -386,7 +506,7 @@ mkdir -p "$HD20/HIMMEL-856-test"
 : > "$HD20/.locks"   # a FILE squatting on the .locks DIR path
 HO20="$HD20/HIMMEL-856-test/next-session-20.md"
 printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t20 handover\n' > "$HO20"
-out=$(HANDOVER_DIR="$HD20" bash "$ARM" --time "$FUTURE_TIME" --handover "$HO20" 2>&1)
+out=$(HANDOVER_DIR="$HD20" bash "$ARM" --time "$(future_time)" --handover "$HO20" 2>&1)
 rc=$?
 assert_rc "T20: arm still succeeds when the registry root is unwritable" 0 "$rc"
 assert_contains "T20: WARN names the failed registry append" "failed to append the arms.jsonl registry record" "$out"
@@ -407,7 +527,7 @@ while [ "$t21_i" -lt 6 ]; do
     THIS_HOST=$(hostname 2>/dev/null || echo "${COMPUTERNAME:-${HOSTNAME:-unknown-host}}")
     printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t21-acq"}\n' \
         "$THIS_HOST" "$HOB" > "$HANDOVER_DIR/.locks/arms.jsonl"
-    ( bash "$ARM" --time "$FUTURE_TIME" --handover "$HOA" >/dev/null 2>&1 ) &
+    ( bash "$ARM" --time "$(future_time)" --handover "$HOA" >/dev/null 2>&1 ) &
     ( bash "$QL" acquire "$HOB" "t21-acq-$t21_i" >/dev/null 2>&1 ) &
     wait
     if ! grep -qF "\"handover\":\"$HOA\"" "$HANDOVER_DIR/.locks/arms.jsonl" \
@@ -438,7 +558,7 @@ printf -- '---\nsession_kind: test\n---\n# HIMMEL-856 t22 handover\n' > "$HO22"
     printf '{"host":"other-host","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t22-legacy-fired","fired":"true"}\n' "$HO22"
     printf '{"host":"other-host","handover":"t22-unrelated.md","fire-at":"202601010000","task-name":"HIMMEL-Resume-t22-pending-bystander"}\n'
 } > "$HANDOVER_DIR/.locks/arms.jsonl"
-out=$(bash "$ARM" --time "$FUTURE_TIME" --handover "$HO22" 2>&1)
+out=$(bash "$ARM" --time "$(future_time)" --handover "$HO22" 2>&1)
 rc=$?
 assert_rc "T22: real arm succeeds over a legacy fired record" 0 "$rc"
 if ! grep -q 'HIMMEL-Resume-t22-legacy-fired' "$HANDOVER_DIR/.locks/arms.jsonl" \

--- a/scripts/handover/test-queue-lock.sh
+++ b/scripts/handover/test-queue-lock.sh
@@ -23,6 +23,12 @@ grepq() { local _t="$1"; shift; grep -q "$@" <<< "$_t"; }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB="$SCRIPT_DIR/queue-lock.sh"
+# shellcheck source=../lib/py-armor.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/py-armor.sh"
+# shellcheck source=../lib/handover-path.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/../lib/handover-path.sh"
 
 PASSED=0
 FAILED=0
@@ -590,6 +596,52 @@ else
 fi
 QUEUE_LOCK_FORCE_RELEASE=1 bash "$LIB" release "$HO23" >/dev/null 2>&1
 
+# --- T31: new-format canonical key consumes the RIGHT record (HIMMEL-1344) --
+# The record's raw handover spelling deliberately differs from the acquire
+# argument. Matching must use handover-key, drop only this host's target row,
+# and leave the sibling key untouched. Fired records are retained by deletion
+# in the current format, so disappearance is the consume-on-fire proof.
+HO31="$HANDOVER_DIR/HIMMEL-856-test/next-session-31.md"
+HO31_ALT="$HANDOVER_DIR/HIMMEL-856-test/../HIMMEL-856-test/next-session-31.md"
+HO31_SIB="$HANDOVER_DIR/HIMMEL-856-test/next-session-31b.md"
+: > "$HO31"
+: > "$HO31_SIB"
+HO31_KEY=$(_arm_registry_identity_path "$HO31" "$HANDOVER_DIR")
+HO31_SIB_KEY=$(_arm_registry_identity_path "$HO31_SIB" "$HANDOVER_DIR")
+{
+    printf '{"host":"%s","handover":"%s","handover-key":"%s","ticket":"HIMMEL-1344","fire-at":"202601010000","task-name":"HIMMEL-Resume-t31-target"}\n' \
+        "$THIS_HOST" "$HO31_ALT" "$HO31_KEY"
+    printf '{"host":"%s","handover":"%s","handover-key":"%s","ticket":"HIMMEL-1344","fire-at":"202601010000","task-name":"HIMMEL-Resume-t31-sibling"}\n' \
+        "$THIS_HOST" "$HO31_SIB" "$HO31_SIB_KEY"
+} > "$ARMS_REGISTRY"
+err="$(bash "$LIB" acquire "$HO31" "session-t31" 2>&1 1>/dev/null)"
+rc=$?
+if [ "$rc" -eq 0 ] && ! grep -q 'HIMMEL-Resume-t31-target' "$ARMS_REGISTRY"; then
+    pass "T31: canonical key consumes alternate-spelling target record"
+else
+    fail "T31: canonical target was not consumed (rc=$rc err=$err reg=$(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+if grep -q 'HIMMEL-Resume-t31-sibling' "$ARMS_REGISTRY" && [ "$(wc -l < "$ARMS_REGISTRY")" -eq 1 ]; then
+    pass "T31: sibling canonical key survives untouched"
+else
+    fail "T31: wrong record consumed or sibling corrupted ($(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+bash "$LIB" release "$HO31" "session-t31" >/dev/null 2>&1
+
+# --- T31b: legacy raw-only alternate spelling is still consumed -----------
+# Migration coverage for records written before HIMMEL-1344: no handover-key
+# exists, so acquire must canonicalize the stored raw spelling and retire it.
+printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t31b-legacy"}\n' \
+    "$THIS_HOST" "$HO31_ALT" > "$ARMS_REGISTRY"
+err="$(bash "$LIB" acquire "$HO31" "session-t31b" 2>&1 1>/dev/null)"
+rc=$?
+if [ "$rc" -eq 0 ] && ! grep -q 'HIMMEL-Resume-t31b-legacy' "$ARMS_REGISTRY"; then
+    pass "T31b: legacy raw-only alternate spelling is consumed during migration"
+else
+    fail "T31b: legacy alternate-spelling record was not consumed (rc=$rc err=$err reg=$(cat "$ARMS_REGISTRY" 2>/dev/null))"
+fi
+bash "$LIB" release "$HO31" "session-t31b" >/dev/null 2>&1
+
 # --- T24: the TAKEOVER acquire path also consumes (round-2 addendum) -------
 # T19 covered the fresh-mkdir path only; the stale-takeover branch has its
 # own retire call. Stale fixture per T9/T14: hand-crafted owner.json with
@@ -814,6 +866,62 @@ fi
 bash "$LIB" release "$HO28" "session-t28" >/dev/null 2>&1
 rm -f "$ARMS_REGISTRY"
 
+# --- T28b: SAME-HOST legacy rewrite against the real mutex lease -----------
+# T28 above measures the fork-FREE path only: its 299 bystanders are
+# other-host, and queue-lock.sh calls _hp_arms_record_matches_path exclusively
+# for rows whose host matches this one, so those bystanders never reach the
+# matcher at all. The expensive path is same-host legacy rows: each one that
+# does not match exactly falls through to the canonical-migration fallback,
+# which spends a command substitution on _arm_registry_identity_path, and that
+# forks realpath plus cygpath/tr on Windows -- per record, INSIDE the arms
+# mutex. Blowing the mutex lease is not a slow test, it is a discarded rewrite:
+# the arm stays pending-but-unregistered, or a fired record never clears.
+#
+# So this case is deliberately pinned to the LEASE, not to an ambition
+# (HIMMEL-1344 CR round). It ALWAYS prints the measurement, WARNs at the
+# halfway mark so a slow drift is visible before it bites, and FAILs only when
+# the rewrite approaches the lease itself -- the point at which the behaviour
+# under test genuinely breaks. That is why a wall-clock bound is legitimate
+# here and is not a second T28 (see HIMMEL-1661): crossing it IS the failure
+# mode, and the budget is an order of magnitude above the noise.
+t28b_lease=$(sed -n 's/^_QL_ARMS_MUTEX_STALE_SECS=\([0-9][0-9]*\).*/\1/p' "$LIB" | head -1)
+if [ -z "$t28b_lease" ]; then
+    fail "T28b: cannot read _QL_ARMS_MUTEX_STALE_SECS from $LIB -- the lease constant moved or was renamed; re-point this test at it"
+else
+    HO28B="$HANDOVER_DIR/HIMMEL-856-test/next-session-28b.md"
+    : > "$HO28B"
+    {
+        printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t28b-mine"}\n' "$THIS_HOST" "$HO28B"
+        t28b_i=0
+        while [ "$t28b_i" -lt 299 ]; do
+            # SAME host, legacy shape (no handover-key) -> every one of these
+            # reaches the canonicalizing fallback.
+            printf '{"host":"%s","handover":"%s/bystander-%s.md","fire-at":"202601010000","task-name":"HIMMEL-Resume-t28b-b%s"}\n' "$THIS_HOST" "$HANDOVER_DIR" "$t28b_i" "$t28b_i"
+            t28b_i=$((t28b_i + 1))
+        done
+    } > "$ARMS_REGISTRY"
+    t28b_start=$(date +%s)
+    bash "$LIB" acquire "$HO28B" "session-t28b" >/dev/null 2>&1
+    t28b_elapsed=$(( $(date +%s) - t28b_start ))
+    t28b_warn=$(( t28b_lease / 2 ))
+    echo "MEASURE T28b: 300-row SAME-HOST legacy rewrite took ${t28b_elapsed}s (mutex lease ${t28b_lease}s, warn >${t28b_warn}s)"
+    if [ "$t28b_elapsed" -ge "$t28b_lease" ]; then
+        fail "T28b: same-host legacy rewrite took ${t28b_elapsed}s, at/over the ${t28b_lease}s mutex lease -- the rewrite can be discarded and an arm left pending-but-unregistered"
+    else
+        if [ "$t28b_elapsed" -gt "$t28b_warn" ]; then
+            echo "WARN T28b: ${t28b_elapsed}s is past half the ${t28b_lease}s lease -- per-record forking is trending toward the lease; see the hoist/memoize follow-up"
+        fi
+        pass "T28b: same-host legacy rewrite stayed under the ${t28b_lease}s mutex lease (${t28b_elapsed}s)"
+    fi
+    if [ "$(wc -l < "$ARMS_REGISTRY")" -eq 299 ] && ! grep -q 't28b-mine' "$ARMS_REGISTRY"; then
+        pass "T28b: all 299 same-host bystanders survive, the matching record was consumed"
+    else
+        fail "T28b: registry wrong after same-host rewrite ($(wc -l < "$ARMS_REGISTRY") lines)"
+    fi
+    bash "$LIB" release "$HO28B" "session-t28b" >/dev/null 2>&1
+    rm -f "$ARMS_REGISTRY"
+fi
+
 # --- T29: escaped-quote + backslash values round-trip (round-3: the -------
 # parity-aware _hp_json_field replaces the round-2 extractor whose values
 # mis-truncated at an escaped quote -- macOS/Linux paths may legally
@@ -927,6 +1035,36 @@ else
     fail "T33: post-rm arbiter loser damaged winner state (out=$t33_out)"
 fi
 rm -rf "$LOCKDIR33" "${LOCKDIR33}.claim"
+
+# --- T34: consume path survives a pre-HIMMEL-1344 handover-path.sh ---------
+# queue-lock.sh's fallbacks must let `acquire` survive a partially-deployed
+# library that still exports handover_root + JSON helpers but deliberately
+# lacks the HIMMEL-1344 identity + matcher. The test-owned fixture pins that
+# property; deriving it from main would silently stop testing skew after merge.
+FAKE_QL="$TMPDIR_ROOT/fake-ql-pre1344"
+PRE_1344_LIB="$SCRIPT_DIR/fixtures/handover-path-pre-himmel-1344.sh"
+mkdir -p "$FAKE_QL/handover" "$FAKE_QL/lib"
+cp "$SCRIPT_DIR/queue-lock.sh" "$FAKE_QL/handover/queue-lock.sh"
+cp "$SCRIPT_DIR/../lib/py-armor.sh" "$FAKE_QL/lib/py-armor.sh"
+if cp "$PRE_1344_LIB" "$FAKE_QL/lib/handover-path.sh" \
+    && ! grep -q '^_arm_registry_identity_path()' "$FAKE_QL/lib/handover-path.sh" \
+    && ! grep -q '^_hp_arms_record_matches_path()' "$FAKE_QL/lib/handover-path.sh"; then
+    HO34="$HANDOVER_DIR/HIMMEL-856-test/next-session-34.md"
+    : > "$HO34"
+    printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t34"}\n' \
+        "$THIS_HOST" "$HO34" > "$ARMS_REGISTRY"
+    err="$(bash "$FAKE_QL/handover/queue-lock.sh" acquire "$HO34" "session-t34" 2>&1 1>/dev/null)"
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+        pass "T34: acquire against a pre-1344 handover-path.sh does not abort"
+    else
+        fail "T34: acquire against a pre-1344 handover-path.sh aborted (rc=$rc: $err)"
+    fi
+    bash "$FAKE_QL/handover/queue-lock.sh" release "$HO34" "session-t34" >/dev/null 2>&1
+else
+    fail "T34: pre-1344 fixture missing or unexpectedly defines HIMMEL-1344 helpers"
+fi
+rm -f "$ARMS_REGISTRY"
 
 echo "---"
 echo "PASSED=$PASSED FAILED=$FAILED"

--- a/scripts/lib/handover-path.sh
+++ b/scripts/lib/handover-path.sh
@@ -103,6 +103,135 @@ handover_mode() {
     fi
 }
 
+# Canonicalise a path, tolerating non-existent ones: GNU realpath -m, else
+# armored python3 pathlib, else the input unchanged (best effort). Shared by
+# arm-resume.sh's scheduler identity and the arms-registry contract so those
+# two keys cannot drift (HIMMEL-1304/HIMMEL-1344).
+_arm_realpath() {
+    local _p=""
+    _p=$(realpath -m "$1" 2>/dev/null) || _p=""
+    if [ -z "$_p" ] && command -v py_armor_capture >/dev/null 2>&1; then
+        if py_armor_capture -c 'import sys,pathlib;print(pathlib.Path(sys.argv[1]).resolve(strict=False))' "$1" 2>/dev/null; then
+            _p="$PY_ARMOR_OUT"
+        fi
+    fi
+    [ -n "$_p" ] || _p="$1"
+    printf '%s\n' "$_p"
+}
+
+# _hp_ascii_lower <value> -- fold ASCII into $_HP_LOWER without a subprocess.
+# bash 3.2 has no ${value,,}; arms-registry rewrites cannot afford a `tr` fork
+# for every row that reaches the migration matcher.
+_HP_LOWER=""
+_hp_ascii_lower() {
+    local _hp_s="$1" _hp_i=0 _hp_ch _hp_prefix
+    local _hp_upper=ABCDEFGHIJKLMNOPQRSTUVWXYZ _hp_lower=abcdefghijklmnopqrstuvwxyz
+    _HP_LOWER=""
+    while [ "$_hp_i" -lt "${#_hp_s}" ]; do
+        _hp_ch="${_hp_s:$_hp_i:1}"
+        case "$_hp_ch" in
+            [A-Z])
+                _hp_prefix="${_hp_upper%%"$_hp_ch"*}"
+                _hp_ch="${_hp_lower:${#_hp_prefix}:1}"
+                ;;
+        esac
+        _HP_LOWER="$_HP_LOWER$_hp_ch"
+        _hp_i=$((_hp_i + 1))
+    done
+}
+
+# _arm_identity_path <path> -- the canonical handover identity first shipped
+# in arm-resume.sh for scheduler-row dedup (HIMMEL-1304). It lives in this
+# shared library now because queue-lock.sh must consume the exact same identity
+# from arms.jsonl (HIMMEL-1344). On Windows, cygpath folds C:/, C:\ and /c/
+# spellings together, then case-folding matches NTFS semantics; POSIX paths
+# retain case because it can distinguish real files there.
+_arm_identity_path() {
+    local _p _platform="${PLATFORM:-}" _os
+    _p=$(_arm_realpath "$1")
+    if [ -z "$_platform" ]; then
+        _os="${OSTYPE:-$(uname -s 2>/dev/null || echo unknown)}"
+        case "$_os" in
+            msys*|cygwin*|win32*|MINGW*) _platform=windows ;;
+            linux*|Linux*)               _platform=linux ;;
+            darwin*|Darwin*)             _platform=macos ;;
+        esac
+    fi
+    if [ "$_platform" = windows ]; then
+        if command -v cygpath >/dev/null 2>&1; then
+            _p=$(cygpath -u "$_p" 2>/dev/null) || _p=$(_arm_realpath "$1")
+        fi
+        _hp_ascii_lower "$_p"; _p="$_HP_LOWER"
+    fi
+    printf '%s' "$_p"
+}
+
+# _arm_registry_identity_root <handover-root> -- canonicalize the loop-invariant
+# root once before an arms-registry scan/rewrite.
+_arm_registry_identity_root() {
+    _arm_identity_path "$1"
+}
+
+# _arm_registry_identity_from_canonical <canonical-handover> <canonical-root>
+# -- format the durable cross-machine key without re-canonicalizing either path.
+_arm_registry_identity_from_canonical() {
+    local _ho="$1" _root="$2" _key
+    case "$_ho" in
+        "$_root"/*)
+            # Root-relative keys ARE folded on every platform: this is the
+            # cross-machine dedup key, and a Windows peer can legitimately spell
+            # the same in-root handover with different case. Both sides must
+            # fold or they disagree. State the cost of that collision at full
+            # strength rather than at its mildest (CR round, [glm-2]): across
+            # hosts it is a refusal, overridable with --force, but a SAME-HOST
+            # re-arm goes through _arm_registry_replace_and_append, which
+            # retires the colliding record — so on a case-sensitive filesystem
+            # two in-root handovers differing only by case would silently cost
+            # one of them its pending row, not merely earn a refusal. That is
+            # accepted because the line above is a real precondition, not a
+            # hope: case-distinct sibling handovers do not legitimately coexist
+            # inside one handover root. Folding is still right for the branch
+            # that must survive a Windows peer spelling the same file
+            # differently; NOT folding here would trade this bounded,
+            # out-of-contract collision for the unbounded in-contract failure
+            # the ticket exists to prevent (two machines disagreeing on the key
+            # and both firing). The absolute branch below folds nothing,
+            # precisely because it makes no cross-machine promise to keep.
+            _key="root-relative:${_ho#"$_root"/}"
+            _hp_ascii_lower "$_key"
+            printf '%s' "$_HP_LOWER"
+            ;;
+        *)
+            # Absolute (outside-root) keys keep their case. This branch already
+            # carries the documented cross-layout limitation — it makes no
+            # cross-machine promise — so folding buys nothing here, while on a
+            # case-sensitive filesystem it would ERASE a distinction that really
+            # exists: /work/Foo.md and /work/foo.md are two different files with
+            # two different scheduler identities, and one folded key would let
+            # a re-arm prune or a queue-lock consume retire the OTHER handover's
+            # pending record (HIMMEL-1344 codex-adv round).
+            printf 'absolute:%s' "$_ho"
+            ;;
+    esac
+}
+
+# _arm_registry_identity_path_from_root <handover-path> <canonical-root> --
+# canonicalize only the row path; callers hoist the root out of hot loops.
+_arm_registry_identity_path_from_root() {
+    local _ho
+    _ho=$(_arm_identity_path "$1")
+    _arm_registry_identity_from_canonical "$_ho" "$2"
+}
+
+# _arm_registry_identity_path <handover-path> <handover-root> -- durable
+# cross-machine arms-registry key (HIMMEL-1344). Paths under the handover root
+# are stored ROOT-RELATIVE; outside-root paths retain a canonical absolute key.
+_arm_registry_identity_path() {
+    local _root
+    _root=$(_arm_registry_identity_root "$2")
+    _arm_registry_identity_path_from_root "$1" "$_root"
+}
+
 # --- flat-JSON helpers for the handover lock/registry files (HIMMEL-882) ---
 # Shared by scripts/handover/queue-lock.sh and scripts/handover/arm-resume.sh
 # (both already source this lib) for owner.json and the cross-machine arms
@@ -158,4 +287,103 @@ _hp_json_field() {
         fi
         _HP_FIELD="$_HP_FIELD\""   # odd parity: escaped quote, keep scanning
     done
+}
+
+# _hp_json_unescape <escaped-value> -- inverse of _hp_json_escape into
+# $_HP_UNESC. The writer emits only \\ and \" escapes, so a small pure-bash
+# scanner is sufficient and avoids a process per legacy registry line.
+_HP_UNESC=""
+_hp_json_unescape() {
+    local _hp_s="$1" _hp_i=0 _hp_ch
+    _HP_UNESC=""
+    while [ "$_hp_i" -lt "${#_hp_s}" ]; do
+        _hp_ch="${_hp_s:$_hp_i:1}"
+        if [ "$_hp_ch" = "\\" ] && [ $((_hp_i + 1)) -lt "${#_hp_s}" ]; then
+            _hp_i=$((_hp_i + 1))
+            _hp_ch="${_hp_s:$_hp_i:1}"
+        fi
+        _HP_UNESC="$_HP_UNESC$_hp_ch"
+        _hp_i=$((_hp_i + 1))
+    done
+}
+
+# _hp_path_quick_normalize <path> <fold-case> <windows-separators> -- cheap
+# legacy-row filter into $_HP_PATH_NORM. It deliberately does not resolve the
+# filesystem; false positives only spend one rare canonicalization, while the
+# basename/symlink gate below rejects ordinary unrelated rows without a fork.
+_HP_PATH_NORM=""
+_hp_path_quick_normalize() {
+    _HP_PATH_NORM="$1"
+    if [ "$3" -eq 1 ]; then
+        _HP_PATH_NORM="${_HP_PATH_NORM//\\//}"
+    fi
+    if [ "$2" -eq 1 ]; then
+        _hp_ascii_lower "$_HP_PATH_NORM"; _HP_PATH_NORM="$_HP_LOWER"
+    fi
+}
+
+# _hp_arms_record_matches_path <json-line> <raw-path> <registry-key>
+# <canonical-root> -- set $_HP_ARMS_MATCH to 1 when an arms.jsonl record
+# identifies this handover. New records match the canonical handover-key.
+# Legacy raw-only records first take a fork-free normalized path/basename gate;
+# only plausible aliases fall back to filesystem canonicalization. A
+# nonmatching key also falls through for partial-deployment compatibility.
+_HP_ARMS_MATCH=0
+_hp_arms_record_matches_path() {
+    local _hp_line="$1" _hp_raw="$2" _hp_key="$3" _hp_root="$4"
+    local _hp_stored_key _hp_stored_raw _hp_key_esc _hp_raw_esc _hp_legacy_key
+    local _hp_stored_norm _hp_raw_norm _hp_stored_leaf _hp_raw_leaf
+    local _hp_fold=0 _hp_windows=0
+    _HP_ARMS_MATCH=0
+
+    _hp_json_escape "$_hp_key"; _hp_key_esc="$_HP_ESC"
+    _hp_json_field "$_hp_line" handover-key; _hp_stored_key="$_HP_FIELD"
+    if [ -n "$_hp_stored_key" ] && [ "$_hp_stored_key" = "$_hp_key_esc" ]; then
+        _HP_ARMS_MATCH=1
+        return 0
+    fi
+
+    _hp_json_field "$_hp_line" handover; _hp_stored_raw="$_HP_FIELD"
+    [ -n "$_hp_stored_raw" ] || return 0
+    _hp_json_escape "$_hp_raw"; _hp_raw_esc="$_HP_ESC"
+    if [ "$_hp_stored_raw" = "$_hp_raw_esc" ]; then
+        _HP_ARMS_MATCH=1
+        return 0
+    fi
+
+    _hp_json_unescape "$_hp_stored_raw"
+    case "${PLATFORM:-}:${OSTYPE:-}" in
+        windows:*|*:msys*|*:cygwin*|*:win32*|*:MINGW*) _hp_windows=1 ;;
+    esac
+    case "$_hp_key" in
+        root-relative:*) _hp_fold=1 ;;
+        *) _hp_fold="$_hp_windows" ;;
+    esac
+    _hp_path_quick_normalize "$_HP_UNESC" "$_hp_fold" "$_hp_windows"
+    _hp_stored_norm="$_HP_PATH_NORM"
+    _hp_path_quick_normalize "$_hp_raw" "$_hp_fold" "$_hp_windows"
+    _hp_raw_norm="$_HP_PATH_NORM"
+    if [ "$_hp_stored_norm" = "$_hp_raw_norm" ]; then
+        _HP_ARMS_MATCH=1
+        return 0
+    fi
+
+    _hp_stored_leaf="${_hp_stored_norm##*/}"
+    _hp_raw_leaf="${_hp_raw_norm##*/}"
+    # Probe BOTH sides for a symlink, not just the stored one. The gate exists to
+    # reject unrelated rows without a fork, and differing leaf names are the cheap
+    # signal for that -- but a symlink on EITHER side can legitimately make two
+    # different leaf names denote one file. Testing only the stored path made the
+    # gate asymmetric: a queried handover that is itself a symlink to a
+    # differently-named target, whose target spelling is what the registry stored,
+    # was rejected here even though the canonical keys below would have matched --
+    # a missed duplicate-arm on the foreign scan and a stale same-host record that
+    # survives the rewrite. (CR round 1: panel [codex-1] + CodeRabbit, agreed.)
+    if [ "$_hp_stored_leaf" != "$_hp_raw_leaf" ] \
+        && [ ! -L "$_HP_UNESC" ] && [ ! -L "$_hp_raw" ]; then
+        return 0
+    fi
+    _hp_legacy_key=$(_arm_registry_identity_path_from_root "$_HP_UNESC" "$_hp_root")
+    [ "$_hp_legacy_key" = "$_hp_key" ] && _HP_ARMS_MATCH=1
+    return 0
 }

--- a/scripts/lib/test-handover-path.sh
+++ b/scripts/lib/test-handover-path.sh
@@ -154,6 +154,48 @@ line7d='{"other":"value"}'
 _hp_json_field "$line7d" key
 assert_eq "T7d absent key resets _HP_FIELD to empty (miss branch)" "" "$_HP_FIELD"
 
+# T7e: the inverse used by legacy arms-registry migration preserves adjacent
+# backslashes and quotes exactly.
+_hp_json_unescape "$esc7b"
+assert_eq "T7e escaped registry value decodes to the original raw value" "$raw7b" "$_HP_UNESC"
+
+# T8 (HIMMEL-1344): registry identity is canonical, root-relative, and
+# uniformly case-folded. The scheduler canonicalizer remains platform-specific,
+# while the durable registry key must compare identically across machines.
+ROOT8A="$TMP/layout-a/handovers"
+ROOT8B="$TMP/layout-b/handovers"
+mkdir -p "$ROOT8A/HIMMEL-1344-test" "$ROOT8B/HIMMEL-1344-test"
+HO8A="$ROOT8A/HIMMEL-1344-test/next-session-1.md"
+HO8B="$ROOT8B/HIMMEL-1344-test/next-session-1.md"
+: > "$HO8A"
+: > "$HO8B"
+key8a=$(_arm_registry_identity_path "$ROOT8A/HIMMEL-1344-test/../HIMMEL-1344-test/next-session-1.md" "$ROOT8A")
+key8b=$(_arm_registry_identity_path "$HO8B" "$ROOT8B")
+expected8="root-relative:himmel-1344-test/next-session-1.md"
+assert_eq "T8a alternate spelling canonicalizes to the folded root-relative key" "$expected8" "$key8a"
+assert_eq "T8b different absolute layouts share one registry key" "$key8a" "$key8b"
+MIXED8="$ROOT8A/HiMmEl-1344-TeSt/NeXt-SeSsIoN-1.Md"
+key8_linux=$(PLATFORM=linux _arm_registry_identity_path "$MIXED8" "$ROOT8A")
+key8_windows=$(PLATFORM=windows _arm_registry_identity_path "$MIXED8" "$ROOT8A")
+assert_eq "T8c mixed-case registry key is equal across simulated platforms" "$key8_linux" "$key8_windows"
+assert_eq "T8d mixed-case root-relative remainder is uniformly folded" "$expected8" "$key8_linux"
+# T8e/T8f (HIMMEL-1344 codex-adv round): the outside-root `absolute:` branch
+# PRESERVES case. It makes no cross-machine promise (documented cross-layout
+# limitation), so folding buys nothing there — while on a case-sensitive
+# filesystem it would collapse two genuinely distinct files onto one registry
+# key and let one handover's re-arm retire the other's pending record.
+outside8=$(PLATFORM=linux _arm_registry_identity_path "$TMP/Outside.MD" "$ROOT8A")
+outside8_expected=$(PLATFORM=linux _arm_identity_path "$TMP/Outside.MD")
+outside8_expected=$(printf 'absolute:%s' "$outside8_expected")
+assert_eq "T8e outside-root absolute fallback preserves case" "$outside8_expected" "$outside8"
+outside8_lower=$(PLATFORM=linux _arm_registry_identity_path "$TMP/outside.md" "$ROOT8A")
+if [ "$outside8" != "$outside8_lower" ]; then
+    echo "PASS T8f case-distinct outside-root handovers keep distinct registry keys"
+else
+    echo "FAIL T8f outside-root Foo.md and foo.md collapsed to one key '$outside8'"
+    FAILED=$((FAILED + 1))
+fi
+
 if [ "$FAILED" -gt 0 ]; then
     echo "---"
     echo "FAIL $FAILED case(s)"


### PR DESCRIPTION
## Summary

Public propagation of private PR #1657 (HIMMEL-1344) — the arms registry keys on a canonical handover identity.

- `scripts/lib/handover-path.sh` canonical key: in-root paths → `root-relative:<suffix>` (ASCII-folded — the cross-machine dedup key); outside-root → `absolute:<canonical>` (case preserved). `arm-resume.sh` and `queue-lock.sh` write and consume it in lockstep, with a record-both migration for partially upgraded fleets.
- Fixes the duplicate-autonomous-resume failure: two spellings of one handover (`C:/` vs `/c/`, NTFS case, trailing slash, symlink alias) no longer produce two registry keys.
- Performance: loop-invariant + fork-free canonicalization (300-row legacy rewrite 445s → 3s against a 60s mutex lease); `T28b` pins the budget to the real lease constant.

## Known limitation (tracked)

Legacy arms records cannot migrate across differing root layouts — pre-existing behavior, deferred to HIMMEL-1699.

## Provenance

- Private squash: `c6950d80` (PR #1657); suites: test-handover-path PASS, test-queue-lock 77/0, test-arm-resume-queue-lock 0 failed; panel 2/2 (codex, glm) 0 blocking.
- Shipped via `propagate-public.sh` (code-only delta, fail-closed leak scan + byte-verify).
- Ordering note: propagated ahead of private #1666, whose `arm-resume.sh` diff builds on this commit (byte-verify demanded the intermediate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
