### PR TITLE
feat: [HIMMEL-1461] measure the uncapped skill-routing listing

### DIFF
--- a/scripts/lanes/skill-cost.mjs
+++ b/scripts/lanes/skill-cost.mjs
@@ -1,0 +1,313 @@
+// scripts/lanes/skill-cost.mjs
+// HIMMEL-1461 phase 0 — measure the UNCAPPED skill-routing listing. Claude
+// Code applies its context-dependent cap later; `/context` remains the only
+// authority for the post-cap figure.
+import {
+  readdirSync,
+  readFileSync,
+  statSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import {
+  basename,
+  extname,
+  join,
+  resolve,
+} from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROUTING_TEXT_CAP = 1536;
+const PLUGIN_SCAN_MAX_DEPTH = 6;
+const SCOPES = [
+  'plugin-skills',
+  'project-commands',
+  'project-skills',
+  'user-commands',
+  'user-skills',
+];
+const UNCAPPED_CAVEAT = 'UNCAPPED listing size; `/context` is the only authority for the post-cap figure.';
+
+const compareText = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+
+function directoryEntries(path) {
+  try {
+    return readdirSync(path, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === 'ENOENT' || error?.code === 'ENOTDIR') return [];
+    throw error;
+  }
+}
+
+function statThroughLink(path) {
+  try {
+    return statSync(path);
+  } catch (error) {
+    // A broken user-skill link is common enough to be an invalid entry, not a
+    // reason to lose the rest of the measurement.
+    if (error?.code === 'ENOENT' || error?.code === 'EACCES' || error?.code === 'EPERM') return null;
+    throw error;
+  }
+}
+
+function isDirectoryEntry(entry, path) {
+  if (entry.isDirectory()) return true;
+  return entry.isSymbolicLink() && statThroughLink(path)?.isDirectory() === true;
+}
+
+function isFileEntry(entry, path) {
+  if (entry.isFile()) return true;
+  return entry.isSymbolicLink() && statThroughLink(path)?.isFile() === true;
+}
+
+function decodeScalar(value) {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return trimmed.slice(1, -1);
+    }
+  }
+  if (trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1).replaceAll("''", "'");
+  }
+  return trimmed;
+}
+
+// This intentionally reads only the three routing fields. It is not a YAML
+// parser, but it does join indented continuation/folded lines so wrapped skill
+// descriptions are measured as one scalar instead of being silently truncated
+// at the first physical line.
+export function readSkillFrontmatter(markdown) {
+  const frontmatter = markdown.match(/^﻿?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/)?.[1];
+  const fields = { name: '', description: '', whenToUse: '' };
+  if (frontmatter === undefined) return fields;
+
+  const lines = frontmatter.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(/^(name|description|when_to_use)\s*:\s*(.*)$/);
+    if (!match) continue;
+
+    const [, yamlKey, first] = match;
+    const parts = [];
+    if (!/^[>|][+-]?$/.test(first.trim()) && first.trim()) parts.push(first.trim());
+
+    while (i + 1 < lines.length) {
+      const next = lines[i + 1];
+      if (next.trim() === '') {
+        i++;
+        continue;
+      }
+      if (!/^[ \t]+/.test(next)) break;
+      parts.push(next.trim());
+      i++;
+    }
+
+    const key = yamlKey === 'when_to_use' ? 'whenToUse' : yamlKey;
+    fields[key] = decodeScalar(parts.join(' ').replace(/\s+/g, ' ').trim());
+  }
+  return fields;
+}
+
+function makeEntry(scope, markdownPath, fallbackName, symlinked) {
+  const markdown = readFileSync(markdownPath, 'utf8');
+  const frontmatter = readSkillFrontmatter(markdown);
+  const name = frontmatter.name || fallbackName;
+  const routingText = `${frontmatter.description} ${frontmatter.whenToUse}`;
+  const countedRoutingChars = Math.min(routingText.length, ROUTING_TEXT_CAP);
+  return {
+    scope,
+    name,
+    description: frontmatter.description,
+    whenToUse: frontmatter.whenToUse,
+    chars: name.length + 2 + countedRoutingChars,
+    routingChars: routingText.length,
+    countedRoutingChars,
+    truncated: routingText.length > ROUTING_TEXT_CAP,
+    bodyBytes: statSync(markdownPath).size,
+    symlinked,
+    path: resolve(markdownPath),
+  };
+}
+
+function scanSkillDirectory(root, scope) {
+  const entries = [];
+  for (const entry of directoryEntries(root)) {
+    const entryPath = join(root, entry.name);
+    if (!isDirectoryEntry(entry, entryPath)) continue;
+    const skillMd = join(entryPath, 'SKILL.md');
+    if (statThroughLink(skillMd)?.isFile() !== true) continue;
+    entries.push(makeEntry(scope, skillMd, entry.name, entry.isSymbolicLink()));
+  }
+  return entries;
+}
+
+function scanCommands(root, scope) {
+  const entries = [];
+  for (const entry of directoryEntries(root)) {
+    if (extname(entry.name).toLowerCase() !== '.md') continue;
+    const entryPath = join(root, entry.name);
+    if (!isFileEntry(entry, entryPath)) continue;
+    entries.push(makeEntry(scope, entryPath, basename(entry.name, extname(entry.name)), entry.isSymbolicLink()));
+  }
+  return entries;
+}
+
+function findPluginSkillDirectories(root) {
+  const skillDirectories = [];
+  const visited = new Set();
+
+  function walk(path, depth) {
+    const pathStat = statThroughLink(path);
+    if (!pathStat?.isDirectory()) return;
+    const identity = `${pathStat.dev}:${pathStat.ino}`;
+    if (visited.has(identity)) return;
+    visited.add(identity);
+
+    for (const entry of directoryEntries(path)) {
+      if (entry.name.startsWith('temp_git_')) continue;
+      const entryPath = join(path, entry.name);
+      if (!isDirectoryEntry(entry, entryPath)) continue;
+      if (entry.name === 'skills') {
+        skillDirectories.push(entryPath);
+        continue;
+      }
+      if (depth < PLUGIN_SCAN_MAX_DEPTH) walk(entryPath, depth + 1);
+    }
+  }
+
+  walk(root, 0);
+  return skillDirectories;
+}
+
+export function scanSkillCosts(options = {}) {
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const configDir = resolve(options.configDir ?? join(homedir(), '.claude'));
+  const entries = [
+    ...scanSkillDirectory(join(configDir, 'skills'), 'user-skills'),
+    ...scanCommands(join(configDir, 'commands'), 'user-commands'),
+    ...scanSkillDirectory(join(cwd, '.claude', 'skills'), 'project-skills'),
+    ...scanCommands(join(cwd, '.claude', 'commands'), 'project-commands'),
+  ];
+  for (const skillsDir of findPluginSkillDirectories(join(configDir, 'plugins'))) {
+    entries.push(...scanSkillDirectory(skillsDir, 'plugin-skills'));
+  }
+
+  return entries.sort((a, b) => (
+    compareText(a.scope, b.scope)
+    || compareText(a.name, b.name)
+    || compareText(a.path, b.path)
+  ));
+}
+
+function emptyScope(scope) {
+  return {
+    scope,
+    entries: 0,
+    chars: 0,
+    estimatedTokens: 0,
+    bodyBytes: 0,
+    bodyKB: 0,
+    symlinked: 0,
+    truncated: 0,
+  };
+}
+
+export function summarizeSkillCosts(entries) {
+  const byScope = new Map(SCOPES.map((scope) => [scope, emptyScope(scope)]));
+  const total = emptyScope('TOTAL');
+
+  for (const entry of entries) {
+    if (!byScope.has(entry.scope)) byScope.set(entry.scope, emptyScope(entry.scope));
+    const scope = byScope.get(entry.scope);
+    for (const summary of [scope, total]) {
+      summary.entries++;
+      summary.chars += entry.chars;
+      summary.bodyBytes += entry.bodyBytes;
+      summary.symlinked += entry.symlinked ? 1 : 0;
+      summary.truncated += entry.truncated ? 1 : 0;
+    }
+  }
+
+  for (const summary of [...byScope.values(), total]) {
+    summary.estimatedTokens = summary.chars / 4;
+    summary.bodyKB = summary.bodyBytes / 1024;
+  }
+
+  return {
+    measurement: 'uncapped',
+    caveat: UNCAPPED_CAVEAT,
+    scopes: [...byScope.values()].sort((a, b) => compareText(a.scope, b.scope)),
+    total,
+  };
+}
+
+function formatTable(summary) {
+  const rows = [...summary.scopes, summary.total];
+  const headers = ['scope', 'entries', 'uncapped chars', 'est. tokens (chars/4)', 'body KB', 'symlinked', 'truncated'];
+  const values = rows.map((row) => [
+    row.scope,
+    String(row.entries),
+    String(row.chars),
+    Number.isInteger(row.estimatedTokens) ? String(row.estimatedTokens) : row.estimatedTokens.toFixed(1),
+    row.bodyKB.toFixed(1),
+    String(row.symlinked),
+    String(row.truncated),
+  ]);
+  const widths = headers.map((header, index) => Math.max(header.length, ...values.map((row) => row[index].length)));
+  const line = (row) => row.map((value, index) => (
+    index === 0 ? value.padEnd(widths[index]) : value.padStart(widths[index])
+  )).join('  ');
+  return [
+    'UNCAPPED skill listing cost',
+    line(headers),
+    line(widths.map((width) => '-'.repeat(width))),
+    ...values.map(line),
+    summary.caveat,
+  ].join('\n');
+}
+
+function parseCliArgs(argv) {
+  const options = {};
+  let mode = 'table';
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--estimate' || arg === '--json') {
+      if (mode !== 'table') throw new Error(`${arg} cannot be combined with --${mode}`);
+      mode = arg.slice(2);
+      continue;
+    }
+    if (arg === '--cwd' || arg === '--config-dir') {
+      if (argv[i + 1] === undefined) throw new Error(`${arg} requires a value`);
+      const key = arg === '--cwd' ? 'cwd' : 'configDir';
+      options[key] = argv[++i];
+      continue;
+    }
+    throw new Error(`unknown argument "${arg}"`);
+  }
+  return { mode, options };
+}
+
+function runCli(argv) {
+  const { mode, options } = parseCliArgs(argv);
+  const entries = scanSkillCosts(options);
+  const summary = summarizeSkillCosts(entries);
+  if (mode === 'json') {
+    process.stdout.write(JSON.stringify({ entries, summary }, null, 2) + '\n');
+    return;
+  }
+  if (mode === 'estimate') {
+    process.stdout.write(`UNCAPPED total: ${summary.total.chars} chars (${summary.total.estimatedTokens} estimated tokens at chars/4)\n${summary.caveat}\n`);
+    return;
+  }
+  process.stdout.write(formatTable(summary) + '\n');
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    runCli(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`skill-cost: ${error?.message ?? error}\n`);
+    process.exit(2);
+  }
+}

--- a/scripts/lanes/tests/skill-cost.test.mjs
+++ b/scripts/lanes/tests/skill-cost.test.mjs
@@ -1,0 +1,198 @@
+// scripts/lanes/tests/skill-cost.test.mjs
+// HIMMEL-1461 phase 0 — hermetic coverage for the UNCAPPED skill-listing
+// measurement, especially Windows junctions (the common user-skill shape).
+import { after, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  readSkillFrontmatter,
+  scanSkillCosts,
+  summarizeSkillCosts,
+} from '../skill-cost.mjs';
+
+const ROOT = mkdtempSync(join(tmpdir(), 'skill-cost-'));
+const CWD = join(ROOT, 'repo');
+const CONFIG_DIR = join(ROOT, 'config');
+const LONG_DESCRIPTION = 'x'.repeat(1600);
+
+function write(path, content) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function skill(frontmatter, body = '# Fixture\n') {
+  return `---\n${frontmatter}\n---\n${body}`;
+}
+
+write(join(CONFIG_DIR, 'skills', 'plain', 'SKILL.md'), skill([
+  'name: plain-user',
+  'description: Plain user skill',
+  'when_to_use: Use for fixtures',
+].join('\n')));
+write(join(CONFIG_DIR, 'skills', 'not-a-skill', 'README.md'), '# No SKILL.md\n');
+
+write(join(CONFIG_DIR, 'commands', 'user-command.md'), skill([
+  'description: User command description',
+  'when_to_use: Run the user command fixture',
+].join('\n')));
+
+write(join(CWD, '.claude', 'skills', 'long', 'SKILL.md'), skill([
+  'name: long-project',
+  `description: ${LONG_DESCRIPTION}`,
+  'when_to_use: now',
+].join('\n')));
+write(join(CWD, '.claude', 'skills', 'missing-skill-md', 'README.md'), '# Ignored\n');
+
+write(join(CWD, '.claude', 'commands', 'flat-command.md'), skill([
+  'description: Flat command description',
+  'when_to_use: Run the fixture command',
+].join('\n')));
+write(join(CWD, '.claude', 'commands', 'nested', 'ignored.md'), skill('description: Nested commands are not entries'));
+write(join(CWD, '.claude', 'commands', 'not-markdown.txt'), 'ignored\n');
+
+write(join(CONFIG_DIR, 'plugins', 'cache', 'market', 'plugin', '1.0.0', 'skills', 'folded', 'SKILL.md'), skill([
+  'name: folded-plugin',
+  'description: >',
+  '  first wrapped line',
+  '  second wrapped line',
+  'when_to_use: >-',
+  '  when folding',
+  '  matters',
+].join('\n')));
+write(join(CONFIG_DIR, 'plugins', 'temp_git_checkout', 'skills', 'ignored-plugin', 'SKILL.md'), skill([
+  'name: ignored-plugin',
+  'description: Temporary checkout must not count',
+].join('\n')));
+
+const linkedTarget = join(ROOT, 'linked-target');
+write(join(linkedTarget, 'SKILL.md'), skill([
+  'name: linked-user',
+  'description: Junction-backed user skill',
+  'when_to_use: Prove links are resolved',
+].join('\n')));
+mkdirSync(join(CONFIG_DIR, 'skills'), { recursive: true });
+let junctionError;
+try {
+  symlinkSync(linkedTarget, join(CONFIG_DIR, 'skills', 'linked'), 'junction');
+} catch (error) {
+  junctionError = error;
+}
+
+after(() => rmSync(ROOT, { recursive: true, force: true }));
+
+const scan = () => scanSkillCosts({ cwd: CWD, configDir: CONFIG_DIR });
+
+test('frontmatter reader joins folded and continued routing scalars', () => {
+  const fields = readSkillFrontmatter(skill([
+    'name: wrapped',
+    'description: first physical line',
+    '  second physical line',
+    'when_to_use: >',
+    '  use when',
+    '  wrapping matters',
+  ].join('\n')));
+  assert.deepEqual(fields, {
+    name: 'wrapped',
+    description: 'first physical line second physical line',
+    whenToUse: 'use when wrapping matters',
+  });
+});
+
+test('scan applies each root\'s entry rules to the fixture tree only', () => {
+  const entries = scan();
+  const names = entries.map((entry) => entry.name);
+  const expected = ['flat-command', 'folded-plugin', 'long-project', 'plain-user', 'user-command'];
+  if (!junctionError) expected.push('linked-user');
+  assert.deepEqual([...names].sort(), expected.sort());
+
+  assert.ok(!names.includes('not-a-skill'));
+  assert.ok(!names.includes('missing-skill-md'));
+  assert.ok(!names.includes('ignored'));
+  assert.ok(!names.includes('ignored-plugin'));
+
+  assert.equal(entries.find((entry) => entry.name === 'flat-command').scope, 'project-commands');
+  assert.equal(entries.find((entry) => entry.name === 'user-command').scope, 'user-commands');
+  assert.equal(entries.find((entry) => entry.name === 'folded-plugin').description, 'first wrapped line second wrapped line');
+  assert.ok(entries.every((entry) => entry.bodyBytes > 0));
+});
+
+test('listing arithmetic caps routing text at 1536 chars and reports truncation', () => {
+  const entry = scan().find((candidate) => candidate.name === 'long-project');
+  assert.equal(entry.truncated, true);
+  assert.equal(entry.countedRoutingChars, 1536);
+  assert.equal(entry.routingChars, LONG_DESCRIPTION.length + ' '.length + 'now'.length);
+  assert.equal(entry.chars, 'long-project'.length + 2 + 1536);
+});
+
+test('summary reports per-scope and uncapped totals from fixture entries', () => {
+  const entries = scan();
+  const summary = summarizeSkillCosts(entries);
+  assert.equal(summary.measurement, 'uncapped');
+  assert.match(summary.caveat, /UNCAPPED/);
+  assert.equal(summary.total.entries, 5 + (junctionError ? 0 : 1));
+  assert.equal(summary.total.chars, entries.reduce((sum, entry) => sum + entry.chars, 0));
+  assert.equal(summary.total.estimatedTokens, summary.total.chars / 4);
+  assert.equal(summary.total.truncated, 1);
+  assert.equal(summary.scopes.find((scope) => scope.scope === 'project-commands').entries, 1);
+  assert.equal(summary.scopes.find((scope) => scope.scope === 'user-commands').entries, 1);
+  assert.equal(summary.scopes.find((scope) => scope.scope === 'plugin-skills').entries, 1);
+});
+
+test('a junction-backed user skill is counted and marked symlinked', (t) => {
+  if (junctionError) {
+    t.skip(`junction creation unavailable; symlink assertions skipped explicitly: ${junctionError.message}`);
+    return;
+  }
+  const linked = scan().find((entry) => entry.name === 'linked-user');
+  assert.ok(linked, 'the symlinked skill directory must survive directory validation');
+  assert.equal(linked.scope, 'user-skills');
+  assert.equal(linked.symlinked, true);
+  assert.equal(summarizeSkillCosts(scan()).total.symlinked, 1);
+});
+
+test('two scans of the same tree are deeply deterministic', () => {
+  const entries = scan();
+  assert.deepEqual(entries, scan());
+
+  const expectedOrder = [
+    'plugin-skills:folded-plugin',
+    'project-commands:flat-command',
+    'project-skills:long-project',
+    'user-commands:user-command',
+  ];
+  if (!junctionError) expectedOrder.push('user-skills:linked-user');
+  expectedOrder.push('user-skills:plain-user');
+  assert.deepEqual(entries.map((entry) => `${entry.scope}:${entry.name}`), expectedOrder);
+});
+
+test('CLI table, estimate, and JSON modes label the measurement uncapped', () => {
+  const cli = join(dirname(fileURLToPath(import.meta.url)), '..', 'skill-cost.mjs');
+  const run = (mode = []) => spawnSync(process.execPath, [cli, ...mode, '--cwd', CWD, '--config-dir', CONFIG_DIR], { encoding: 'utf8' });
+
+  const table = run();
+  assert.equal(table.status, 0, table.stderr);
+  assert.match(table.stdout, /UNCAPPED skill listing cost/);
+  assert.match(table.stdout, /est\. tokens \(chars\/4\)/);
+  assert.match(table.stdout, /TOTAL/);
+
+  const estimate = run(['--estimate']);
+  assert.equal(estimate.status, 0, estimate.stderr);
+  assert.match(estimate.stdout, /^UNCAPPED total: \d+ chars/);
+  assert.match(estimate.stdout, /post-cap figure/);
+
+  const json = run(['--json']);
+  assert.equal(json.status, 0, json.stderr);
+  const parsed = JSON.parse(json.stdout);
+  assert.equal(parsed.summary.measurement, 'uncapped');
+  assert.equal(parsed.entries.length, 5 + (junctionError ? 0 : 1));
+});


### PR DESCRIPTION
## What

Adds `scripts/lanes/skill-cost.mjs`, a zero-dependency Node scanner that measures
the **skill/command routing listing** — the block of `name: description` lines the
harness injects into every session before the first turn.

Per scope (plugin skills, project skills, project commands, user skills, user
commands) it reports entry count, uncapped listing characters, an estimated token
cost, and how many entries were reached through a symlink.

```
node scripts/lanes/skill-cost.mjs            # table
node scripts/lanes/skill-cost.mjs --json     # machine-readable
node scripts/lanes/skill-cost.mjs --estimate # uncapped size
```

## Why

Nothing measured this surface, so any argument about trimming a worker's tool
provisioning was unfalsifiable. This is the measurement step: it turns "the
listing is probably big" into a number you can diff after a change.

## Notes for reviewers

- **Symlinks are the trap.** `Dirent.isDirectory()` returns false for a symlinked
  directory. A naive scan under-reports badly (5 of 22 on one real machine). The
  scanner stats *through* links and tracks the symlinked count separately.
- **`ROUTING_TEXT_CAP = 1536`** matches the documented listing truncation. It is
  deliberately not 1024.
- **Permission errors are swallowed, not fatal** — an unreadable entry under a
  scanned root must not abort the whole scan.
- **Tests are fixture-based** (`scripts/lanes/tests/fixtures/skill-cost/`), never
  asserted against the host's real skill tree, so they are deterministic
  everywhere. 7/7 green.

Platforms tested: windows
Security reviewed: manual


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to measure skill and command listing costs across configured locations and plugins.
  * Supports table, estimate, and JSON output formats.
  * Provides totals and breakdowns by scope, including token estimates and description sizes.
  * Handles missing directories, symlinks, metadata parsing, custom paths, and invalid arguments.

* **Tests**
  * Added coverage for metadata parsing, filtering, ordering, symlink handling, aggregation, and all output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->