### PR TITLE
fix(cr): [HIMMEL-2864] known-findings root bin.js, leak-classes NTFS skip, test-tmpdir shared exit handler

### DIFF
--- a/scripts/cr/known-findings.sh
+++ b/scripts/cr/known-findings.sh
@@ -162,7 +162,7 @@ if (MODE === "diff") {
         const isEntryPoint = base === "bin";
         if (!tests.some(t => {
           const tDir = path.posix.dirname(t);
-          if (tDir !== dir && !tDir.startsWith(dir + "/")) return false;
+          if (dir !== "." && tDir !== dir && !tDir.startsWith(dir + "/")) return false;
           return isEntryPoint || pair.test(baseName(t));
         })) where.push(f);
       }

--- a/scripts/cr/test-known-findings.sh
+++ b/scripts/cr/test-known-findings.sh
@@ -125,6 +125,29 @@ out5="$(cd "$repo" && bash "$SCRIPT" --diff "HEAD~1...HEAD" 2>&1)"
 not_contains "diff5: bin.js entry point paired with any changed test/ dir file" "$out5" "scripts/himmelctl/bin.js"
 contains "diff5 RED control: a non-bin source in the same dir still needs its own pair" "$out5" "scripts/himmelctl/wizard.js"
 
+# Change 5 (HIMMEL-2864 finding 1): the containment check
+# (tDir !== dir && !tDir.startsWith(dir + "/")) must special-case dir === "."
+# for a truly ROOT-level bin.js entry point -- path.posix.dirname of a root
+# file is ".", so a test under test/ (dirname "test") satisfies neither
+# tDir !== dir NOR tDir.startsWith("./") without that case, wrongly flagging
+# it as unpaired. The shipped test-coverage-gap class's globs all require a
+# "scripts/" or "marketplace/" prefix, so this path is unreachable through
+# the default JSON (dormant per the ticket) -- exercised here with a minimal
+# custom class whose globs allow a bare "bin.js".
+cat > "$tmp/root-bin-kf.json" <<'KFJSON'
+{"classes":[{"id":"root-bin-gap","kind":"checklist","title":"t","source":"s","globs":["bin.js"],"detector":{"type":"no-test-change"},"learning_match":null,"canonical":"c","coverage":"c","prompt":false,"evidence":{}}]}
+KFJSON
+rootrepo="$tmp/rootrepo"; mkdir -p "$rootrepo/test"
+( cd "$rootrepo" && git init -q . && git config user.email t@t && git config user.name t && git config commit.gpgsign false ) || { echo "FAIL - root-bin fixture init"; exit 1; }
+printf '#!/usr/bin/env node\nconsole.log("root bin v1");\n' > "$rootrepo/bin.js"
+printf '#!/usr/bin/env bash\necho v1\n' > "$rootrepo/test/test-root.sh"
+( cd "$rootrepo" && git add -A && git commit -qm base ) || { echo "FAIL - root-bin fixture base commit"; exit 1; }
+printf '#!/usr/bin/env node\nconsole.log("root bin v2");\n' > "$rootrepo/bin.js"
+printf '#!/usr/bin/env bash\necho v2\n' > "$rootrepo/test/test-root.sh"
+( cd "$rootrepo" && git add -A && git commit -qm change ) || { echo "FAIL - root-bin fixture change commit"; exit 1; }
+out6="$(cd "$rootrepo" && KNOWN_FINDINGS_FILE="$tmp/root-bin-kf.json" bash "$SCRIPT" --diff "HEAD~1...HEAD" 2>&1)"
+not_contains "diff6: a ROOT-level bin.js (dir \".\") is paired by any changed test/ dir file" "$out6" "bin.js"
+
 # Empty / clean diff
 out3="$(cd "$repo" && bash "$SCRIPT" --diff "HEAD...HEAD" 2>&1)"; rc3=$?
 check "clean diff exits 0" "$rc3" "0"

--- a/scripts/guardrails/test-leak-classes.sh
+++ b/scripts/guardrails/test-leak-classes.sh
@@ -30,8 +30,15 @@ SCRIPT="$REPO_ROOT/scripts/guardrails/leak-classes.sh"
 . "$REPO_ROOT/scripts/lib/red-control.sh"
 
 failures=0
+skips=0
 pass() { printf '  PASS  %s\n' "$1"; }
 fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures+1)); }
+skip() { printf '  SKIP  %s\n' "$1"; skips=$((skips+1)); }
+# T9j/T9k-T9m build filenames containing ", newline, TAB, CR -- all rejected
+# by NTFS. Skip those fixture blocks LOUDLY under Windows Git-Bash (MINGW/
+# MSYS/CYGWIN) rather than let mkdir/git add fail silently into a false
+# green (HIMMEL-2864 finding 2).
+is_windows_ntfs() { case "$(uname -s 2>/dev/null || echo x)" in MINGW*|MSYS*|CYGWIN*) return 0 ;; *) return 1 ;; esac; }
 
 if ! WS="$(mktemp -d "${TMPDIR:-/tmp}/leak-classes-test.XXXXXX")"; then
     echo "test-leak-classes: mktemp -d failed" >&2
@@ -713,6 +720,9 @@ fi
 # git ("b/weird\"quote.txt"), which the same plain ${f#b/} strip does not
 # match at all -- the finding used to cite the raw, still-escaped header text
 # instead of the real filename. It must now cite the real, unescaped name.
+if is_windows_ntfs; then
+    skip "T9j (windows: NTFS filename)"
+else
 r=$(new_repo)
 printf 'home path /home/alexphantom/leak here\n' > "$r/weird\"quote.txt"  # leak-allow: home-path test fixture
 git -C "$r" add .
@@ -722,6 +732,7 @@ if [ "$SCAN_RC" -eq 1 ] && grepq "$SCAN_OUT" -F 'weird"quote.txt:1' \
     pass "T9j --staged: a quote-containing filename is unquoted before being cited in a finding"
 else
     fail "T9j --staged quoted-path finding attribution (rc=$SCAN_RC) out=$SCAN_OUT"
+fi
 fi
 
 # T9k: a filename ending in a literal trailing newline byte must decode to
@@ -733,6 +744,9 @@ fi
 # trailing newline byte would silently vanish right there and the file would
 # wrongly inherit the shorter name's exemption (/pr-check panel round 1,
 # codex-1).
+if is_windows_ntfs; then
+    skip "T9k (windows: NTFS filename)"
+else
 r=$(new_repo)
 printf 'short.txt\n' > "$r/.leak-classes-ignore"
 nlname=$'short.txt\n'
@@ -744,6 +758,7 @@ if [ "$SCAN_RC" -eq 1 ] && grepq "$SCAN_OUT" -F "home-path"; then
 else
     fail "T9k --staged trailing-newline sentinel (rc=$SCAN_RC) out=$SCAN_OUT"
 fi
+fi
 
 # T9l: a filename containing a literal (non-trailing) TAB byte gets fully
 # C-quoted by git with a backslash-t escape ("b/weird\ttab.txt"); the escape
@@ -754,6 +769,9 @@ fi
 # shell word, so inlining it directly on the replacement side of a
 # double-quoted `${var//pattern/replacement}` silently fails to decode at
 # all).
+if is_windows_ntfs; then
+    skip "T9l (windows: NTFS filename)"
+else
 r=$(new_repo)
 printf '%s\n' 'weird\ttab.txt' > "$r/.leak-classes-ignore"
 tabname=$'weird\ttab.txt'
@@ -765,6 +783,7 @@ if [ "$SCAN_RC" -eq 1 ] && grepq "$SCAN_OUT" -F "home-path"; then
 else
     fail "T9l --staged embedded-tab decode (rc=$SCAN_RC) out=$SCAN_OUT"
 fi
+fi
 
 # T9m: a filename containing a literal carriage-return byte gets fully
 # C-quoted by git with a backslash-r escape ("b/weird\rcr.txt"); the escape
@@ -772,6 +791,9 @@ fi
 # `\` and `r` (/pr-check panel round 2, codex-1: unquote_diff_path decoded
 # only \\ \" \t \n, leaving git's other named C escapes -- \r \a \b \v \f --
 # undecoded and open to the same collision as T9l's \t case).
+if is_windows_ntfs; then
+    skip "T9m (windows: NTFS filename)"
+else
 r=$(new_repo)
 printf '%s\n' 'weird\rcr.txt' > "$r/.leak-classes-ignore"
 crname=$'weird\rcr.txt'
@@ -782,6 +804,7 @@ if [ "$SCAN_RC" -eq 1 ] && grepq "$SCAN_OUT" -F "home-path"; then
     pass "T9m --staged: a decoded name's embedded \\r escape becomes a real CR byte, not a literal backslash-r collision with an unrelated exact-file ignore entry"
 else
     fail "T9m --staged embedded-cr decode (rc=$SCAN_RC) out=$SCAN_OUT"
+fi
 fi
 
 echo "== the real pre-commit hook fires (not just the script directly) =="
@@ -1138,7 +1161,11 @@ fi
 echo
 echo "== summary =="
 if [ "$failures" -eq 0 ]; then
-    echo "ALL PASS"
+    if [ "$skips" -gt 0 ]; then
+        echo "ALL PASS ($skips skipped)"
+    else
+        echo "ALL PASS"
+    fi
     exit 0
 else
     echo "$failures FAILURE(S)"

--- a/scripts/lib/test-tmpdir.mjs
+++ b/scripts/lib/test-tmpdir.mjs
@@ -8,14 +8,23 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+const dirs = new Set();
+let exitHandlerRegistered = false;
+
 export function makeTmpDir(prefix) {
   const dir = mkdtempSync(join(tmpdir(), prefix));
-  process.on('exit', () => {
-    try {
-      rmSync(dir, { recursive: true, force: true });
-    } catch {
-      /* best-effort cleanup */
-    }
-  });
+  dirs.add(dir);
+  if (!exitHandlerRegistered) {
+    exitHandlerRegistered = true;
+    process.on('exit', () => {
+      for (const d of dirs) {
+        try {
+          rmSync(d, { recursive: true, force: true });
+        } catch {
+          /* best-effort cleanup */
+        }
+      }
+    });
+  }
   return dir;
 }

--- a/scripts/lib/test-tmpdir.test.mjs
+++ b/scripts/lib/test-tmpdir.test.mjs
@@ -1,0 +1,13 @@
+// scripts/lib/test-tmpdir.test.mjs — HIMMEL-2864 finding 3: makeTmpDir()
+// used to register a new process.on('exit') listener per call; suites
+// calling it 10+ times in one process trip Node's MaxListenersExceededWarning.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { makeTmpDir } from './test-tmpdir.mjs';
+
+test('makeTmpDir() registers at most one shared exit listener across many calls', () => {
+  const before = process.listenerCount('exit');
+  for (let i = 0; i < 15; i++) makeTmpDir('himmel-test-tmpdir-listener-leak-');
+  const after = process.listenerCount('exit');
+  assert.ok(after - before <= 1, `exit listener count grew by ${after - before}, expected <= 1`);
+});


### PR DESCRIPTION
## Summary
- `known-findings.sh`: the no-test-change containment check now special-cases `dir === "."` so a root-level `bin.js` entry point's tests under `test/` are not wrongly rejected as a missing pair (currently dormant — no root-level `bin.js` exists in the repo today).
- `test-leak-classes.sh`: T9j/T9k–T9m fixtures (filenames with `"`, newline, TAB, CR) skip loudly under Windows Git-Bash (NTFS rejects them), counted in the run summary — verified both green on Linux and that the skip path actually fires under a faked `MINGW*` `uname`.
- `test-tmpdir.mjs`: `makeTmpDir()` now registers one shared `process.on('exit')` handler over a module-level `Set` of dirs instead of a new listener per call — new regression test asserts `process.listenerCount('exit')` grows by ≤ 1 across 15 calls.

Fixes 3 verified-real, non-blocking CodeRabbit findings from public #587 (ticket: HIMMEL-2864).

## Test plan
- [x] `bash scripts/cr/test-known-findings.sh` — RED (new fixture) confirmed pre-fix, GREEN post-fix
- [x] `bash scripts/guardrails/test-leak-classes.sh` — GREEN on Linux; SKIP path confirmed firing under a simulated `MINGW64_NT` `uname`, counted in the summary
- [x] `node --test --test-reporter=dot scripts/lib/test-tmpdir.test.mjs` — RED confirmed pre-fix, GREEN post-fix
- [x] `node --test --test-reporter=dot "scripts/lanes/tests/**/*.test.mjs"` — full impacted suite green
- [x] `bash scripts/ci/run-shell-tests.sh --list` — plan unaffected
- [x] `shellcheck` clean on all modified shell files

Security reviewed: manual — reviewed the full diff for input handling, command injection, secrets exposure; none of the three fixes touch untrusted input or add a new surface (test/fixture code only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBEuyDG6sz6XwU7fWPjJLc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test-pair validation so source files at the repository root can correctly match tests in subdirectories.

- **Tests**
  - Added regression coverage for root-level entry points and test pairing.
  - Improved cross-platform test handling by safely skipping incompatible filename cases on Windows and reporting skipped tests.

- **Chores**
  - Improved temporary-directory cleanup by consolidating cleanup handling and ensuring all created directories are removed when the process exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->