### PR TITLE
fix(handover): [HIMMEL-2861] queue-lock release uses the root recorded at acquire

### DIFF
--- a/scripts/handover/queue-lock.sh
+++ b/scripts/handover/queue-lock.sh
@@ -385,9 +385,17 @@ _ql_registry_path() {
 # what HANDOVER_DIR points at in Mode B). Best effort by design: a missing,
 # unreadable or malformed registry just yields fewer candidates, never an
 # error -- the caller falls back to today's "nothing held" answer. Parsed
-# with sed rather than jq/node so a lock script keeps zero hard runtime
+# with grep/sed rather than jq/node so a lock script keeps zero hard runtime
 # deps; escaped backslashes in a Windows path are folded to "/" (accepted
 # by Git-Bash) so those entries resolve too.
+#
+# `grep -o`, not a `sed -n s///p`: sed matches at most ONCE per LINE and its
+# leading `.*` is greedy, so a registry written as compact single-line JSON
+# (perfectly valid, and what any programmatic rewriter emits) yielded only
+# the LAST repo -- every other repo's root silently dropped out of the
+# candidate list, which is precisely the "lock left unreleasable" failure
+# this whole block exists to fix. `grep -o` emits every occurrence on its
+# own line, so the parse no longer depends on how the JSON is formatted.
 _ql_candidate_roots() {
     if [ -n "${HANDOVER_DIR:-}" ] && [ -d "$HANDOVER_DIR" ]; then
         ( cd "$HANDOVER_DIR" && pwd )
@@ -396,7 +404,8 @@ _ql_candidate_roots() {
     reg=$(_ql_registry_path)
     [ -f "$reg" ] || return 0
     local repo
-    sed -n 's/.*"path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$reg" 2>/dev/null \
+    grep -o '"path"[[:space:]]*:[[:space:]]*"[^"]*"' "$reg" 2>/dev/null \
+        | sed 's/^.*"\([^"]*\)"$/\1/' \
         | sed 's#\\\\#/#g' \
         | while IFS= read -r repo; do
             [ -n "$repo" ] || continue
@@ -436,6 +445,17 @@ _ql_search_roots() {
 $(_ql_candidate_roots)
 EOF
     return 1
+}
+
+# _ql_owner_matches <lockdir> <token> -- rc 0 when this lock dir's
+# owner.json names <token> as the holder. A missing dir, a missing or
+# unreadable owner.json, and a different holder all return non-zero, so
+# callers can use one test for "this is not my lock, wherever it is" and
+# let the existing corrupt-lock / refused-release branches below decide
+# what that means.
+_ql_owner_matches() {
+    [ -f "$1/owner.json" ] || return 1
+    [ "$(_ql_json_field "$1/owner.json" session)" = "$2" ]
 }
 
 # _ql_write_root_marker <lockdir> <root> -- record the root this lock
@@ -977,17 +997,23 @@ queue_lock_heartbeat() {
         } >&2
         return 2
     fi
-    if [ ! -d "$lockdir" ] || [ ! -f "$lockdir/owner.json" ]; then
-        # HIMMEL-2861: the cwd may resolve a different root than the acquire
-        # did (a leg heartbeating from its worktree). Look in the other
-        # roots this machine knows about for a lock owned by THIS token.
+    # HIMMEL-2861: the cwd may resolve a different root than the acquire did
+    # (a leg heartbeating from its worktree). Search the other roots this
+    # machine knows about whenever the lock HERE is not ours -- absent, yes,
+    # but also present-and-held-by-someone-else: two roots can carry the same
+    # slug, and refusing on the local stranger's lock would leave OUR lock in
+    # the other root unrefreshed until its TTL expired.
+    if ! _ql_owner_matches "$lockdir" "$session"; then
         local hb_found
         if hb_found=$(_ql_search_roots "$ho" "$session"); then
             lockdir="$hb_found"
-        else
+        elif [ ! -d "$lockdir" ] || [ ! -f "$lockdir/owner.json" ]; then
             echo "queue-lock: no lock held for this queue -- nothing to heartbeat" >&2
             return 2
         fi
+        # else: a lock IS held here, by someone else, and no lock of ours
+        # lives in any other root -- fall through to the holder check below
+        # for the unchanged rc=2 "held by session=..." refusal.
     fi
     local o_session o_host o_started
     o_session=$(_ql_json_field "$lockdir/owner.json" session)
@@ -1056,16 +1082,17 @@ queue_lock_release() {
         } >&2
         return 2
     fi
-    if [ ! -d "$lockdir" ]; then
-        # HIMMEL-2861: same cross-root resolution as heartbeat. When nothing
-        # is found ANYWHERE this now exits 3 instead of the old silent 0 --
-        # a lock the caller believes it released but did not is exactly the
-        # failure that went unnoticed six times on 2026-09-09, and rc=0 is
-        # what every leg and the console read as "released cleanly".
+    # HIMMEL-2861: same cross-root resolution as heartbeat, on the same
+    # "the lock here is not ours" trigger. When nothing of ours is found
+    # ANYWHERE this now exits 3 instead of the old silent 0 -- a lock the
+    # caller believes it released but did not is exactly the failure that
+    # went unnoticed six times on 2026-09-09, and rc=0 is what every leg and
+    # the console read as "released cleanly".
+    if ! _ql_owner_matches "$lockdir" "$session"; then
         local rel_found
         if rel_found=$(_ql_search_roots "$ho" "$session"); then
             lockdir="$rel_found"
-        else
+        elif [ ! -d "$lockdir" ]; then
             {
                 echo "queue-lock: no lock held for this queue in any known handover root -- nothing was released"
                 echo "searched: $(_ql_candidate_roots | tr '\n' ' ')"
@@ -1073,6 +1100,11 @@ queue_lock_release() {
             } >&2
             return 3
         fi
+        # else: a lock IS held here, by someone else, and no lock of ours
+        # lives in any other root -- fall through to the holder check below
+        # for the unchanged rc=2 "release refused -- held by session=..."
+        # (or, for a lock dir with no readable owner.json, the unchanged
+        # corrupt-lock cleanup).
     fi
     if [ -f "$lockdir/owner.json" ]; then
         local o_session

--- a/scripts/handover/queue-lock.sh
+++ b/scripts/handover/queue-lock.sh
@@ -37,13 +37,17 @@
 # "check" and "create", works on NTFS/Git-Bash without relying on O_EXCL)
 # at:
 #   <handover-root>/.locks/queue/<queue-slug>.lock/
-# containing owner.json (current holder) and, after any takeover,
-# takeovers.log (append-only trail -- the "loud trail" the design
-# principles require instead of failing closed). <handover-root> is
-# resolved via scripts/lib/handover-path.sh's handover_root_ensure, so
-# this follows the same single-root convention every other
-# scripts/handover/*.sh script uses (Mode A inline vs Mode B external
-# HANDOVER_DIR) -- see scripts/handover/CLAUDE.md.
+# containing owner.json (current holder), `owner` (the mkdir-CAS arbiter),
+# `root` (the handover root this lock lives under -- HIMMEL-2861) and,
+# after any takeover, takeovers.log (append-only trail -- the "loud trail"
+# the design principles require instead of failing closed).
+# <handover-root> is resolved via scripts/lib/handover-path.sh's
+# handover_root_ensure, so this follows the same single-root convention
+# every other scripts/handover/*.sh script uses (Mode A inline vs Mode B
+# external HANDOVER_DIR) -- see scripts/handover/CLAUDE.md. Because that
+# resolution is CWD-dependent, release/heartbeat additionally search the
+# other roots this machine knows about -- see the CROSS-ROOT LOCK
+# RESOLUTION block below.
 #
 # QUEUE SLUG: the handover path relativized against the handover root (or
 # used as-is if it doesn't fall under the root), with path separators
@@ -102,11 +106,17 @@
 #                 owner.json rewrite)
 #              2  session token missing, no lock held for this queue, OR
 #                 held by a DIFFERENT session than the token -- refused
-#   release:   0  released (idempotent -- also rc 0 when nothing was held)
+#   release:   0  released
 #              1  usage error / environment failure / rm failed to clear
 #                 an existing lock dir (e.g. an open handle on Windows)
 #              2  session token missing or does not match the current
 #                 holder -- refused (QUEUE_LOCK_FORCE_RELEASE=1 overrides)
+#              3  no lock for this queue in ANY known handover root --
+#                 nothing was released (HIMMEL-2861; this was a silent
+#                 rc=0 before, which callers read as "released cleanly").
+#                 QUEUE_LOCK_FORCE_RELEASE=1 keeps its old rc=0 here: it
+#                 is a cleaner, and its callers loop over locks that may
+#                 already be gone.
 #   status:    0  free
 #              1  usage error / environment failure
 #              11 held, FRESH (owner.json printed to stdout; a CORRUPT
@@ -184,6 +194,12 @@ Usage: queue-lock.sh acquire   <handover-path> [session-id]
 acquire prints "release-token: <token>" on success -- capture it and pass
 it to heartbeat/release (both refuse without it). Lost the token?
 QUEUE_LOCK_FORCE_RELEASE=1 queue-lock.sh release <handover-path>
+
+release/heartbeat find the lock even when the cwd resolves a different
+handover root than the acquire did (HIMMEL-2861) -- they search the roots
+named by HANDOVER_DIR and ~/.claude/handover/registry.json for a lock
+owned by the given token, and WARN naming both roots. A release that finds
+no lock anywhere exits 3, not 0.
 
 status --sweep (HIMMEL-2369) enumerates every held lock under a handover
 ROOT's .locks/queue/ in one shot, flagging any whose heartbeat exceeds
@@ -271,11 +287,14 @@ _ql_json_field_str() {
 # NOTE: "/" folds to "__", so a path containing a literal "__" collides
 # with the same path using "/" at that spot -- theoretical only; the repo
 # handover naming convention never produces "__" in a path component.
-_ql_slug() {
-    local p="${1//\\//}"
+# _ql_slug_for_root <handover-path> <root> -- the slug the given root would
+# use for this handover. Split out of _ql_slug (HIMMEL-2861) because the
+# cross-root search has to ask that question of a root that is NOT the one
+# handover_root resolves here: the slug is the path relativized against ITS
+# root, so the same document slugs differently under two different roots.
+_ql_slug_for_root() {
+    local p="${1//\\//}" root="${2:-}"
     p="${p%.md}"
-    local root=""
-    root=$(handover_root 2>/dev/null) || root=""
     if [ -n "$root" ]; then
         root="${root//\\//}"
         case "$p" in
@@ -289,6 +308,12 @@ _ql_slug() {
     # fold above; the repo handover naming convention never produces two
     # distinct paths differing only in which separator they use.
     printf '%s' "$p" | tr -c 'A-Za-z0-9_-' '-'
+}
+
+_ql_slug() {
+    local root=""
+    root=$(handover_root 2>/dev/null) || root=""
+    _ql_slug_for_root "$1" "$root"
 }
 
 # _ql_write_owner -- ATOMIC owner.json write (HIMMEL-856 CR, C3): write to
@@ -324,6 +349,102 @@ _ql_lockdir() {
     local slug
     slug=$(_ql_slug "$ho")
     printf '%s/.locks/queue/%s.lock' "$root" "$slug"
+}
+
+# CROSS-ROOT LOCK RESOLUTION (HIMMEL-2861) ----------------------------------
+#
+# WHY: `acquire` runs with the queue's handover root in scope (in Mode B,
+# HANDOVER_DIR exported on the command line), but the matching `release` at
+# wrap is routinely issued from a leg's WORKTREE cwd with that env gone.
+# handover_root then resolves a DIFFERENT root -- the repo's inline
+# handovers/ -- the lookup misses a root it never looked in, and the caller
+# is told nothing was held (silently, rc=0) while the real lock stays HELD.
+# Six legs orphaned their locks that way on 2026-09-09; the console had to
+# force-release all six. Per the enforcement-strength convention
+# (HIMMEL-195) the second drift escalates to STRUCTURAL: the script itself
+# now looks in the other roots this machine knows about instead of relying
+# on every caller to remember the env prefix.
+#
+# SAFETY: reaching into another root is gated on the OWNER TOKEN -- a
+# candidate lock is accepted only when its owner.json session matches the
+# token the caller already had to supply. That is the same proof the
+# same-root path demands, so this widens WHERE the lock is looked for and
+# never WHOSE lock may be touched. The token-less force-release path gets
+# no search for exactly this reason (see queue_lock_release).
+
+# _ql_registry_path -- the handover repos registry. HANDOVER_REGISTRY is
+# the same override resolve-active-item.sh and arm-resume.sh honour.
+_ql_registry_path() {
+    printf '%s' "${HANDOVER_REGISTRY:-$HOME/.claude/handover/registry.json}"
+}
+
+# _ql_candidate_roots -- print, one per line, the handover roots worth
+# searching. HANDOVER_DIR first, then every registered repo's inline
+# handovers/ dir (a registry entry's "path" is the REPO root; its handover
+# root is that repo's handovers/ -- handover_root's own Mode A default, and
+# what HANDOVER_DIR points at in Mode B). Best effort by design: a missing,
+# unreadable or malformed registry just yields fewer candidates, never an
+# error -- the caller falls back to today's "nothing held" answer. Parsed
+# with sed rather than jq/node so a lock script keeps zero hard runtime
+# deps; escaped backslashes in a Windows path are folded to "/" (accepted
+# by Git-Bash) so those entries resolve too.
+_ql_candidate_roots() {
+    if [ -n "${HANDOVER_DIR:-}" ] && [ -d "$HANDOVER_DIR" ]; then
+        ( cd "$HANDOVER_DIR" && pwd )
+    fi
+    local reg
+    reg=$(_ql_registry_path)
+    [ -f "$reg" ] || return 0
+    local repo
+    sed -n 's/.*"path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$reg" 2>/dev/null \
+        | sed 's#\\\\#/#g' \
+        | while IFS= read -r repo; do
+            [ -n "$repo" ] || continue
+            [ -d "$repo/handovers" ] || continue
+            ( cd "$repo/handovers" && pwd )
+        done
+}
+
+# _ql_search_roots <handover-path> <token> -- print the lock dir for this
+# queue found under a root OTHER than the cwd-resolved one and owned by
+# <token>, or nothing (rc 1). Emits exactly ONE WARN naming both roots when
+# it finds one, so the mismatch is visible in the leg's wrap output instead
+# of being silently papered over. The recorded root comes from the lock's
+# own `root` marker when present; a lock dir written by the pre-HIMMEL-2861
+# script has no marker, so the candidate root itself is named instead --
+# that is the whole backward-compat story for old lock dirs.
+_ql_search_roots() {
+    local ho="$1" token="$2"
+    [ -n "$token" ] || return 1
+    local cwd_root=""
+    cwd_root=$(handover_root 2>/dev/null) || cwd_root=""
+    local root slug cand recorded
+    while IFS= read -r root; do
+        [ -n "$root" ] || continue
+        [ "$root" = "$cwd_root" ] && continue
+        slug=$(_ql_slug_for_root "$ho" "$root")
+        cand="$root/.locks/queue/$slug.lock"
+        [ -f "$cand/owner.json" ] || continue
+        [ "$(_ql_json_field "$cand/owner.json" session)" = "$token" ] || continue
+        recorded=""
+        [ -f "$cand/root" ] && recorded=$(cat "$cand/root" 2>/dev/null)
+        [ -n "$recorded" ] || recorded="$root"
+        echo "WARN queue-lock: cwd resolves root ${cwd_root:-<unresolved>}, lock recorded root $recorded -- using $recorded" >&2
+        printf '%s' "$cand"
+        return 0
+    done <<EOF
+$(_ql_candidate_roots)
+EOF
+    return 1
+}
+
+# _ql_write_root_marker <lockdir> <root> -- record the root this lock
+# actually lives under. Best-effort ON PURPOSE: the cross-root search keys
+# off the owner token, not this file, and every pre-HIMMEL-2861 lock dir
+# lacks it, so a write failure costs one diagnostic line in a WARN -- never
+# the acquire, which by then holds a valid, released-normally lock.
+_ql_write_root_marker() {
+    printf '%s\n' "$2" > "$1/root" 2>/dev/null || true
 }
 
 # _ql_arms_registry_retire_fired <handover-path> -- HIMMEL-882 registry
@@ -604,9 +725,13 @@ queue_lock_acquire() {
         return 1
     fi
     session="${session:-$(_ql_default_session)}"
-    local host now
+    local host now lock_root
     host=$(_ql_hostname)
     now=$(_ql_now_iso)
+    # _ql_lockdir succeeded, so handover_root resolves too (its _ensure
+    # variant created the Mode A dir if it was missing). HIMMEL-2861: this
+    # is the root the lock is about to live under, recorded inside it.
+    lock_root=$(handover_root 2>/dev/null) || lock_root=""
 
     # Check the parent mkdir explicitly so a permission failure reports its
     # true cause instead of surfacing later as a misleading lock-mkdir
@@ -627,6 +752,7 @@ queue_lock_acquire() {
                 echo "queue-lock: acquire FAILED -- owner.json could not be written; the lock dir was removed, nothing is acquired" >&2
                 return 1
             fi
+            _ql_write_root_marker "$lockdir" "$lock_root"
             echo "queue-lock: acquired (session=$session host=$host)"
             _ql_arms_registry_retire_fired "$ho"
             echo "release-token: $session"
@@ -796,6 +922,7 @@ queue_lock_acquire() {
             printf '%s took over from session=%s host=%s started=%s heartbeat=%s reason=%s new_session=%s new_host=%s\n' \
                 "$now" "$o_session" "$o_host" "$o_started" "$o_heartbeat" "$reason" "$session" "$host" \
                 >> "$lockdir/takeovers.log"
+            _ql_write_root_marker "$lockdir" "$lock_root"
             _ql_takeover_claim_release "$claim" "$claim_token" || true
             echo "queue-lock: took over ($reason) -- previous holder: session=$o_session host=$o_host" >&2
             echo "queue-lock: acquired (session=$session host=$host)"
@@ -851,8 +978,16 @@ queue_lock_heartbeat() {
         return 2
     fi
     if [ ! -d "$lockdir" ] || [ ! -f "$lockdir/owner.json" ]; then
-        echo "queue-lock: no lock held for this queue -- nothing to heartbeat" >&2
-        return 2
+        # HIMMEL-2861: the cwd may resolve a different root than the acquire
+        # did (a leg heartbeating from its worktree). Look in the other
+        # roots this machine knows about for a lock owned by THIS token.
+        local hb_found
+        if hb_found=$(_ql_search_roots "$ho" "$session"); then
+            lockdir="$hb_found"
+        else
+            echo "queue-lock: no lock held for this queue -- nothing to heartbeat" >&2
+            return 2
+        fi
     fi
     local o_session o_host o_started
     o_session=$(_ql_json_field "$lockdir/owner.json" session)
@@ -922,7 +1057,22 @@ queue_lock_release() {
         return 2
     fi
     if [ ! -d "$lockdir" ]; then
-        return 0
+        # HIMMEL-2861: same cross-root resolution as heartbeat. When nothing
+        # is found ANYWHERE this now exits 3 instead of the old silent 0 --
+        # a lock the caller believes it released but did not is exactly the
+        # failure that went unnoticed six times on 2026-09-09, and rc=0 is
+        # what every leg and the console read as "released cleanly".
+        local rel_found
+        if rel_found=$(_ql_search_roots "$ho" "$session"); then
+            lockdir="$rel_found"
+        else
+            {
+                echo "queue-lock: no lock held for this queue in any known handover root -- nothing was released"
+                echo "searched: $(_ql_candidate_roots | tr '\n' ' ')"
+                echo "If a lock IS held elsewhere, re-run with the acquiring root exported: HANDOVER_DIR=<root> queue-lock.sh release <handover-path> <token>"
+            } >&2
+            return 3
+        fi
     fi
     if [ -f "$lockdir/owner.json" ]; then
         local o_session

--- a/scripts/handover/test-queue-lock.sh
+++ b/scripts/handover/test-queue-lock.sh
@@ -131,13 +131,18 @@ else
     fail "T5: release by holder session rc=0 + gone (got rc=$rc, dir-exists=$([ -d "$lockdir" ] && echo yes || echo no))"
 fi
 
-# --- T6: release of an absent lock (with a token) is idempotent (rc 0) ------
-bash "$LIB" release "$HO1" "any-token" >/dev/null 2>&1
+# --- T6: release of an absent lock (with a token) reports it, rc 3 ---------
+# CONTRACT CHANGE (HIMMEL-2861): this used to be a silent rc=0 "idempotent"
+# release. Idempotency was indistinguishable from the failure it hid -- a
+# release that looked in the wrong handover root also found nothing and
+# also said 0, so six legs on 2026-09-09 reported a clean wrap over a lock
+# that was still HELD. Nothing-released is now its own exit code.
+out="$(bash "$LIB" release "$HO1" "any-token" 2>&1)"
 rc=$?
-if [ "$rc" -eq 0 ]; then
-    pass "T6: release of absent lock rc=0 (idempotent)"
+if [ "$rc" -eq 3 ]; then
+    pass "T6: release of absent lock rc=3 (nothing was released)"
 else
-    fail "T6: release of absent lock rc=0 (got $rc)"
+    fail "T6: release of absent lock rc=3 (got $rc: $out)"
 fi
 
 # --- T7: status free -> rc 0, "free" ----------------------------------------
@@ -1433,6 +1438,180 @@ else
     fail "T45: escaping did not neutralize the space/newline session values (out=$out)"
 fi
 rm -rf "$SPACE_LOCKDIR" "$NL_LOCKDIR"
+
+# --- T46-T52: cross-root release/heartbeat (HIMMEL-2861) --------------------
+# Six legs on 2026-09-09 wrapped with `release <doc> <token>` reporting
+# nothing held (rc=0) while the lock they had acquired stayed HELD: the
+# acquire ran with HANDOVER_DIR exported, the release at wrap was issued
+# from the leg's WORKTREE cwd WITHOUT it, handover_root then resolved that
+# repo's inline handovers/ instead, and the lookup missed a root it never
+# looked in. T46b is that reproduction -- RED against the pre-fix script.
+X_STATE="$TMPDIR_ROOT/2861-state"          # the state repo holding the real root
+mkdir -p "$X_STATE/handovers/yotamleo/himmel"
+X_ROOT="$(cd "$X_STATE/handovers" && pwd)" # the root the acquire runs under
+X_DOC="$X_ROOT/yotamleo/himmel/HIMMEL-2861-legN114-RESUME.md"
+: > "$X_DOC"
+X_LOCKDIR="$X_ROOT/.locks/queue/yotamleo__himmel__HIMMEL-2861-legN114-RESUME.lock"
+
+# The leg's worktree: its OWN inline handovers/ is what handover_root
+# resolves to once HANDOVER_DIR is gone.
+X_WT="$TMPDIR_ROOT/2861-worktree"
+mkdir -p "$X_WT/handovers"
+git -C "$X_WT" init -q >/dev/null 2>&1
+
+# Registries: one naming the state repo (so the fallback has a candidate),
+# one naming nobody (the negative control). HANDOVER_REGISTRY keeps both
+# hermetic -- the real $HOME registry is never read.
+X_REG="$TMPDIR_ROOT/2861-registry.json"
+printf '{"repos":{"state":{"path":"%s","user":"yotamleo","branch_prefix":"handover/"}}}\n' \
+    "$X_STATE" > "$X_REG"
+X_REG_EMPTY="$TMPDIR_ROOT/2861-registry-empty.json"
+printf '{"repos":{}}\n' > "$X_REG_EMPTY"
+
+# release/heartbeat exactly as a leg issues them at wrap: from the worktree
+# cwd, HANDOVER_DIR gone, token in hand.
+x_from_worktree() {
+    (
+        cd "$X_WT" || exit 9
+        unset HANDOVER_DIR
+        HANDOVER_REGISTRY="$1" bash "$LIB" "$2" "$X_DOC" "$3" 2>&1
+    )
+}
+
+x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "legN114" 2>/dev/null \
+    | sed -n 's/^release-token: //p')"
+if [ "$x_tok" = "legN114" ] && [ -f "$X_LOCKDIR/owner.json" ]; then
+    pass "T46: setup -- acquire under the state root holds the lock"
+else
+    fail "T46: setup -- acquire under the state root did not hold the lock (tok='$x_tok')"
+fi
+
+# --- T46a: NEGATIVE CONTROL -- no candidate root names the real root -------
+# The cross-root fallback must not conjure a lock out of nowhere: with a
+# registry that knows nothing, the same release still finds nothing. This
+# is what makes T46b evidence about the registry candidate specifically.
+out="$(x_from_worktree "$X_REG_EMPTY" release "$x_tok")"
+rc=$?
+if [ "$rc" -ne 0 ] && [ -f "$X_LOCKDIR/owner.json" ]; then
+    pass "T46a: negative control -- unknown root: release rc=$rc (non-zero) and the lock stays HELD"
+else
+    fail "T46a: negative control -- expected non-zero + lock intact (rc=$rc, lock=$([ -f "$X_LOCKDIR/owner.json" ] && echo held || echo GONE): $out)"
+fi
+
+# --- T46b: the HIMMEL-2861 reproduction -- release from the worktree cwd ---
+out="$(x_from_worktree "$X_REG" release "$x_tok")"
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    pass "T46b: release from a worktree cwd without HANDOVER_DIR rc=0"
+else
+    fail "T46b: release from a worktree cwd without HANDOVER_DIR rc=0 (got $rc: $out)"
+fi
+if [ ! -d "$X_LOCKDIR" ]; then
+    pass "T46b: the lock under the ACQUIRE-time root is actually released"
+else
+    fail "T46b: the lock under the acquire-time root is STILL HELD -- the release looked in the wrong root ($out)"
+fi
+if grepq "$out" '^WARN queue-lock: cwd resolves root ' \
+    && grepq "$out" -F "$X_WT/handovers" && grepq "$out" -F "$X_ROOT"; then
+    pass "T46b: ONE WARN names both the cwd-resolved root and the recorded root"
+else
+    fail "T46b: WARN missing or does not name both roots: $out"
+fi
+if [ "$(printf '%s\n' "$out" | grep -c '^WARN queue-lock: cwd resolves root ')" -eq 1 ]; then
+    pass "T46b: the cross-root WARN is printed exactly once"
+else
+    fail "T46b: the cross-root WARN is not printed exactly once: $out"
+fi
+
+# --- T47: heartbeat resolves across roots the same way ---------------------
+x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "legN114hb" 2>/dev/null \
+    | sed -n 's/^release-token: //p')"
+out="$(x_from_worktree "$X_REG" heartbeat "$x_tok")"
+rc=$?
+if [ "$rc" -eq 0 ] && grepq "$(cat "$X_LOCKDIR/owner.json" 2>/dev/null)" '"session":"legN114hb"'; then
+    pass "T47: heartbeat from a worktree cwd refreshes the lock under the acquire-time root"
+else
+    fail "T47: heartbeat from a worktree cwd rc=0 expected (got $rc: $out)"
+fi
+HANDOVER_DIR="$X_ROOT" bash "$LIB" release "$X_DOC" "$x_tok" >/dev/null 2>&1
+
+# --- T48: a genuine no-lock release exits NON-ZERO -------------------------
+# Pre-2861 this was a silent rc=0, which every leg and the console read as
+# "released cleanly" -- the exact reason six orphaned locks went unnoticed.
+out="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" release "$X_DOC" "nobody-holds-this" 2>&1)"
+rc=$?
+if [ "$rc" -ne 0 ]; then
+    pass "T48: release with no lock anywhere exits non-zero (rc=$rc)"
+else
+    fail "T48: release with no lock anywhere still exits 0 -- a lost lock reads as clean"
+fi
+if grepq "$out" -i 'no lock held'; then
+    pass "T48: it says so on stderr"
+else
+    fail "T48: no 'no lock held' message: $out"
+fi
+
+# --- T49: BACKWARD COMPAT -- a lock dir written by the pre-2861 script -----
+# (no `root` marker file) must still status/heartbeat/release normally.
+x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "legacy-sess" 2>/dev/null \
+    | sed -n 's/^release-token: //p')"
+rm -f "$X_LOCKDIR/root"
+HANDOVER_DIR="$X_ROOT" bash "$LIB" status "$X_DOC" >/dev/null 2>&1
+t49_status_rc=$?
+HANDOVER_DIR="$X_ROOT" bash "$LIB" heartbeat "$X_DOC" "$x_tok" >/dev/null 2>&1
+t49_hb_rc=$?
+out="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" release "$X_DOC" "$x_tok" 2>&1)"
+t49_rel_rc=$?
+if [ "$t49_status_rc" -eq 11 ] && [ "$t49_hb_rc" -eq 0 ] && [ "$t49_rel_rc" -eq 0 ] \
+    && [ ! -d "$X_LOCKDIR" ]; then
+    pass "T49: an old-format lock dir (no root marker) still status/heartbeat/releases (11/0/0)"
+else
+    fail "T49: old-format lock dir broke (status=$t49_status_rc heartbeat=$t49_hb_rc release=$t49_rel_rc: $out)"
+fi
+
+# --- T50: acquire records the resolved root inside the lock dir ------------
+x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "root-marker" 2>/dev/null \
+    | sed -n 's/^release-token: //p')"
+if [ -f "$X_LOCKDIR/root" ] && [ "$(cat "$X_LOCKDIR/root" 2>/dev/null)" = "$X_ROOT" ]; then
+    pass "T50: acquire records the resolved root in <lockdir>/root"
+else
+    fail "T50: <lockdir>/root missing or wrong (got '$(cat "$X_LOCKDIR/root" 2>/dev/null)', want '$X_ROOT')"
+fi
+
+# --- T51: the stdout contract survives -- release-token is the LAST line ---
+# The console kit greps this line out of the acquire output; a WARN or any
+# other addition must never land after it.
+HANDOVER_DIR="$X_ROOT" bash "$LIB" release "$X_DOC" "$x_tok" >/dev/null 2>&1
+out="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "last-line" 2>/dev/null)"
+if [ "$(printf '%s\n' "$out" | tail -1)" = "release-token: last-line" ]; then
+    pass "T51: 'release-token: <token>' is still the LAST stdout line of acquire"
+else
+    fail "T51: acquire's last stdout line is not the release-token line (got: $out)"
+fi
+
+# --- T52: the force-release path is unchanged -- cwd root only, rc=0 -------
+# QUEUE_LOCK_FORCE_RELEASE has no token, so it gets no cross-root search
+# (nothing would prove the foreign lock is the caller's); it still exits 0
+# on nothing-found, which is what the console's sweep-and-force loop reads.
+out="$(
+    cd "$X_WT" || exit 9
+    unset HANDOVER_DIR
+    QUEUE_LOCK_FORCE_RELEASE=1 HANDOVER_REGISTRY="$X_REG" bash "$LIB" release "$X_DOC" 2>&1
+)"
+rc=$?
+if [ "$rc" -eq 0 ] && [ -f "$X_LOCKDIR/owner.json" ]; then
+    pass "T52: force-release stays cwd-root-only and rc=0 on nothing-found (unchanged)"
+else
+    fail "T52: force-release path changed (rc=$rc, lock=$([ -f "$X_LOCKDIR/owner.json" ] && echo held || echo GONE): $out)"
+fi
+out="$(HANDOVER_DIR="$X_ROOT" QUEUE_LOCK_FORCE_RELEASE=1 bash "$LIB" release "$X_DOC" 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ] && [ ! -d "$X_LOCKDIR" ] \
+    && grepq "$(cat "$X_ROOT/.locks/queue/takeovers.log" 2>/dev/null)" 'FORCED RELEASE of session=last-line'; then
+    pass "T52: force-release under the right root still releases and logs to takeovers.log"
+else
+    fail "T52: force-release under the right root regressed (rc=$rc: $out)"
+fi
 
 echo "---"
 echo "PASSED=$PASSED FAILED=$FAILED"

--- a/scripts/handover/test-queue-lock.sh
+++ b/scripts/handover/test-queue-lock.sh
@@ -1657,7 +1657,10 @@ x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "mine-elsewhere" 2>
 # so a hand-built path would land where the cwd root never looks and would
 # test nothing. Its lock dir is then the only one under that root.
 x_from_worktree "$X_REG_EMPTY" acquire "a-stranger" >/dev/null 2>&1
-X_WT_LOCKDIR="$(find "$X_WT/handovers/.locks/queue" -maxdepth 1 -name '*.lock' -type d 2>/dev/null | head -1)"
+X_WT_LOCKDIR=""
+for x_d in "$X_WT/handovers/.locks/queue/"*.lock; do
+    if [ -d "$x_d" ]; then X_WT_LOCKDIR="$x_d"; break; fi
+done
 if [ -n "$X_WT_LOCKDIR" ] && grepq "$(cat "$X_WT_LOCKDIR/owner.json" 2>/dev/null)" '"session":"a-stranger"'; then
     pass "T54: setup -- a stranger holds this queue's slug under the WORKTREE's own root"
 else

--- a/scripts/handover/test-queue-lock.sh
+++ b/scripts/handover/test-queue-lock.sh
@@ -1613,6 +1613,85 @@ else
     fail "T52: force-release under the right root regressed (rc=$rc: $out)"
 fi
 
+# --- T53: a COMPACT single-line registry yields EVERY repo, not just the ---
+# last (HIMMEL-2861 CR round 1, codex-1). A line-anchored `sed -n s///p`
+# matches at most once per line and its leading `.*` is greedy, so compact
+# JSON -- valid, and what any programmatic rewriter emits -- dropped every
+# repo but the last out of the candidate list, leaving those roots' locks
+# unreleasable from another cwd.
+X_REG_COMPACT="$TMPDIR_ROOT/2861-registry-compact.json"
+mkdir -p "$TMPDIR_ROOT/2861-decoy/handovers"
+printf '{"repos":{"decoy":{"path":"%s"},"state":{"path":"%s"}}}\n' \
+    "$TMPDIR_ROOT/2861-decoy" "$X_STATE" > "$X_REG_COMPACT"
+x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "compact-reg" 2>/dev/null \
+    | sed -n 's/^release-token: //p')"
+out="$(x_from_worktree "$X_REG_COMPACT" release "$x_tok")"
+rc=$?
+if [ "$rc" -eq 0 ] && [ ! -d "$X_LOCKDIR" ]; then
+    pass "T53: a compact one-line registry still yields the state root (every entry parsed, not just the last)"
+else
+    fail "T53: compact registry dropped the non-final repo entry (rc=$rc: $out)"
+fi
+# The state repo is deliberately the LAST entry above; put it FIRST to prove
+# the parse is not simply picking one fixed position.
+printf '{"repos":{"state":{"path":"%s"},"decoy":{"path":"%s"}}}\n' \
+    "$X_STATE" "$TMPDIR_ROOT/2861-decoy" > "$X_REG_COMPACT"
+x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "compact-reg-2" 2>/dev/null \
+    | sed -n 's/^release-token: //p')"
+out="$(x_from_worktree "$X_REG_COMPACT" release "$x_tok")"
+rc=$?
+if [ "$rc" -eq 0 ] && [ ! -d "$X_LOCKDIR" ]; then
+    pass "T53: ...and when the state repo is the FIRST compact entry too"
+else
+    fail "T53: compact registry dropped the leading repo entry (rc=$rc: $out)"
+fi
+
+# --- T54: a STRANGER's lock on the same slug in the cwd root does not -----
+# hide our own lock in another root (HIMMEL-2861 CR round 1, codex-2).
+# Two roots can carry the same slug; the cross-root search must trigger on
+# "the lock here is not ours", not merely on "there is no lock here".
+x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "mine-elsewhere" 2>/dev/null \
+    | sed -n 's/^release-token: //p')"
+# The stranger's lock is acquired by a REAL acquire from the worktree cwd,
+# not hand-placed: the slug is the doc path relativized against ITS OWN root,
+# so a hand-built path would land where the cwd root never looks and would
+# test nothing. Its lock dir is then the only one under that root.
+x_from_worktree "$X_REG_EMPTY" acquire "a-stranger" >/dev/null 2>&1
+X_WT_LOCKDIR="$(find "$X_WT/handovers/.locks/queue" -maxdepth 1 -name '*.lock' -type d 2>/dev/null | head -1)"
+if [ -n "$X_WT_LOCKDIR" ] && grepq "$(cat "$X_WT_LOCKDIR/owner.json" 2>/dev/null)" '"session":"a-stranger"'; then
+    pass "T54: setup -- a stranger holds this queue's slug under the WORKTREE's own root"
+else
+    fail "T54: setup -- the stranger's acquire under the worktree root did not take (dir='$X_WT_LOCKDIR')"
+fi
+
+out="$(x_from_worktree "$X_REG" heartbeat "$x_tok")"
+rc=$?
+if [ "$rc" -eq 0 ] && grepq "$(cat "$X_LOCKDIR/owner.json" 2>/dev/null)" '"session":"mine-elsewhere"'; then
+    pass "T54: heartbeat looks past a stranger's same-slug lock in the cwd root and refreshes ours"
+else
+    fail "T54: heartbeat stopped at the stranger's lock (rc=$rc: $out)"
+fi
+out="$(x_from_worktree "$X_REG" release "$x_tok")"
+rc=$?
+if [ "$rc" -eq 0 ] && [ ! -d "$X_LOCKDIR" ] && [ -f "$X_WT_LOCKDIR/owner.json" ]; then
+    pass "T54: release takes OUR lock in the other root and leaves the stranger's untouched"
+else
+    fail "T54: release did not resolve past the stranger's lock (rc=$rc, stranger=$([ -f "$X_WT_LOCKDIR/owner.json" ] && echo intact || echo REMOVED): $out)"
+fi
+
+# --- T55: NEGATIVE CONTROL for T54 -- a stranger's lock with no lock of ---
+# ours anywhere still gets today's rc=2 refusal, never a silent pass and
+# never a cross-root steal.
+out="$(x_from_worktree "$X_REG" release "not-my-token")"
+rc=$?
+if [ "$rc" -eq 2 ] && grepq "$out" 'held by session=a-stranger' && [ -f "$X_WT_LOCKDIR/owner.json" ]; then
+    pass "T55: negative control -- a stranger's lock and no lock of ours still refuses rc=2, lock intact"
+else
+    fail "T55: expected rc=2 'held by session=a-stranger' with the lock intact (rc=$rc: $out)"
+fi
+rm -f "$X_WT_LOCKDIR/owner.json"
+rmdir "$X_WT_LOCKDIR" 2>/dev/null || true
+
 echo "---"
 echo "PASSED=$PASSED FAILED=$FAILED"
 [ "$FAILED" = 0 ]


### PR DESCRIPTION
## HIMMEL-2861 — queue-lock release resolves the root recorded at acquire, not the cwd's

### The failure

Six legs on 2026-09-09 (N96, N98, N100, N101, N102, N107) wrapped with
`queue-lock.sh release <doc> <token>` reporting nothing held (**rc=0**) while
`status --sweep` still showed their lock **HELD**. The console force-released all
six (`takeovers.log` carries six FORCED entries between 08:2x and 11:5x).

Cause, **verified at code level and reproduced**, not taken on the ticket's word:

- `acquire` runs with the queue's handover root in scope (`HANDOVER_DIR` exported).
- The matching `release` at wrap is issued from the leg's **worktree cwd**, without it.
- `handover_root` then resolves that repo's inline `handovers/` instead, the slug
  lookup misses a root it never looked in — and the old code answered a miss with a
  **silent rc=0**, indistinguishable from a clean release.

Per HIMMEL-195 the second drift escalates to structural: the script now finds the
lock instead of relying on every caller to remember the env prefix.

### The change (`scripts/handover/queue-lock.sh`)

1. `acquire` records the resolved root in `<lockdir>/root` (both the fresh and the
   takeover path).
2. `release` / `heartbeat` **search the other roots this machine knows about** —
   `HANDOVER_DIR`, then each repo in `~/.claude/handover/registry.json`
   (`HANDOVER_REGISTRY` overrides, the same knob `resolve-active-item.sh` /
   `arm-resume.sh` honour) — whenever the lock under the cwd-resolved root is not
   ours, and print exactly ONE
   `WARN queue-lock: cwd resolves root A, lock recorded root B -- using B`.
3. Reaching into another root is gated on the **owner token**: a candidate is accepted
   only when its `owner.json` session matches the token the caller already had to
   supply. This widens *where* the lock is looked for, never *whose* lock may be
   touched — the same proof the same-root path already demands.
4. A release that finds nothing of ours in **any** root now exits **3**. Contract
   change: the old rc=0 was read as "released cleanly" by every leg and by the
   console, which is precisely why six orphaned locks went unnoticed. `T6` previously
   asserted that rc=0 and is updated with the reason inline.

The registry is parsed with `grep -o` + `sed`, not jq/node, so a lock script keeps
zero hard runtime deps; a missing/unreadable/malformed registry just yields fewer
candidates (fail-open to today's "nothing held" answer).

### Deliberately unchanged

- **`release-token: <token>` stays the LAST stdout line of `acquire`** — the console
  kit greps it. Verbatim proof:

  ```
  $ HANDOVER_DIR=<tmp> queue-lock.sh acquire <doc> proof-sess
  queue-lock: acquired (session=proof-sess host=cachyos-x8664)
  release-token: proof-sess
  ```

- **`status --sweep` output shape** — unchanged, same run:

  ```
  slug=yotamleo__himmel__PROOF-RESUME session=proof-sess host=cachyos-x8664 age=0s status=OK
  ```

- **`QUEUE_LOCK_FORCE_RELEASE=1` + `takeovers.log`** — the force path has no token to
  prove ownership of a foreign lock, so it gets **no** cross-root search and keeps its
  rc=0 on nothing-found (its callers loop over locks that may already be gone).
  Asserted by `T52`.
- **Backward compatible** — a lock dir written by today's script (no `root` marker)
  still `status`/`heartbeat`/`release`s normally: **`T49`**, asserting 11/0/0 after
  `rm -f <lockdir>/root`.
- No `.ps1` twin of `queue-lock.sh` exists → documented skip for the
  bash-3.2-safe + `.ps1` twins rule.

### Tests

`scripts/handover/test-queue-lock.sh` — **120 pass / 0 fail** (104 / 10 before the
fix). Every fixture runs against `mktemp -d` roots plus a `HANDOVER_REGISTRY`
override — never the real handover root, never `$HOME`.

| id | asserts |
|---|---|
| T46a | **negative control** — a registry naming no matching root still finds nothing, lock stays HELD |
| T46b | **the reproduction** — release from a worktree cwd without `HANDOVER_DIR` releases the acquire-time lock, one WARN naming both roots (RED pre-fix) |
| T47 | heartbeat resolves across roots the same way |
| T48 | a genuine no-lock release exits non-zero and says so |
| T49 | old-format lock dir (no `root` marker) still status/heartbeat/releases |
| T50 | `acquire` records the resolved root |
| T51 | `release-token:` is still the last stdout line |
| T52 | force-release path unchanged (cwd-root-only, rc=0, still logs to takeovers.log) |
| T53 | a compact one-line registry yields every repo — run with the state repo both last and first |
| T54 | a stranger's same-slug lock in the cwd root does not hide ours in another root |
| T55 | **negative control for T54** — a stranger's lock with no lock of ours still refuses rc=2, lock intact |

Impacted suites (every suite referencing a changed file), all run:

| suite | rc |
|---|---|
| `handover/test-queue-lock.sh` | 0 |
| `handover/test-leg-resume-brief.sh` | 0 |
| `handover/test-worker-lifecycle.sh` | 0 |
| `handover/console-kit/test-tick.sh` | 0 |
| `lib/test-handover-path.sh` | 0 |
| `handover/test-arm-resume-probe.sh` | 0 |
| `handover/test-arm-resume-identity.sh` | 0 |
| `handover/test-arm-resume-long-gap.sh` | 0 |
| `handover/test-arm-resume-proxy.sh` | 0 |
| `ci/test-suite-concurrency.sh` | 0 |
| `handover/test-arm-resume-queue-lock.sh` | 1 — **pre-existing red, not this change** |
| `handover/test-arm-resume.sh` | 1 — **pre-existing red, not this change** (and `[SKIP]`ped by the CI runner) |

Both reds were verified against a **pristine `git archive HEAD`** tree on this
station: `test-arm-resume-queue-lock.sh` fails the same `T15`/`T19`
(`expected rc=0, got rc=3`, arm-resume `at`-job dedup) there, and
`test-arm-resume.sh` fails **the identical set of test ids** at HEAD (220 fails) as
on this branch (219) — i.e. this branch has one fewer. Out of scope here; tracked
console-side.

`shellcheck -x` clean on both changed files. `bash scripts/ci/run-shell-tests.sh --list`
confirms the plan still lists `test-queue-lock.sh` and skips `test-arm-resume.sh`.

### CR rounds

**Round 1** (codex panel, head `23869bc8`): 0 Critical, **2 Important** — both
verified against the code and reproduced in isolation, then fixed in `f743d421`:

- `codex-1` — **agreed.** The registry parser was `sed -n 's/.*"path"…/\1/p'`: sed
  matches at most once per line and its leading `.*` is greedy, so a compact
  single-line registry yielded only the LAST repo and every other root silently left
  the candidate list. Proof: `{"repos":{"a":{"path":"/tmp/A"},"b":{"path":"/tmp/B"}}}`
  → `/tmp/B` only, before; `/tmp/A` + `/tmp/B`, after. Now parsed with `grep -o`, so
  formatting no longer matters. Covered by **T53**, which runs the state repo both
  LAST (the ordering the old greedy parse happened to survive) and FIRST (the one it
  dropped) — the ordering is the control.
- `codex-2` — **agreed.** The cross-root search only ran when NO lock existed under
  the cwd root, so a stranger holding the same slug there made `release` refuse rc=2
  while our lock in the other root stayed held to TTL. The trigger is now "the lock
  here is not ours". Isolated control: against `23869bc8` the scenario printed
  `release refused -- held by session=stranger` with our lock still held; with
  `f743d421` it releases ours and leaves the stranger's intact. Covered by **T54**,
  with **T55** as its negative control.

`known-findings` then flagged `[gnu-only-utility]` on the T54 fixture's
`find -maxdepth`; replaced with a glob + `[ -d ]` in `95745161`.

**Round 2** (codex panel, head `95745161`): 0 Critical, 0 Important, **1
Suggestion** — severity fell rather than rose.

- `codex-1` — **deferred → HIMMEL-2868.** The candidate-root parser folds `\\` (the
  Windows doubled backslash, the case that occurs) but not `\/`, `\"` or `\uXXXX`.
  Real, and deliberately not fixed here: it is Suggestion severity, no writer in this
  repo emits those escapes (`/handover register` goes through `JSON.stringify`), the
  failure mode is fail-open and now **loud** (rc=3 naming every root searched, not the
  silent rc=0 that hid the original incident), and a full JSON string decoder inside a
  zero-dep lock script is the speculative complexity this repo's rules exclude. The
  ticket carries the scope if it is picked up.

`orphan-check`: 0 unaddressed candidates. Marker cleared by `clear-cr-marker.sh`
(rc=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dCS71uAsNjqwoHLrdJBrN
