### PR TITLE
fix(handover): [HIMMEL-2869] merge-on-green allows the configured public origin under branch protection

### DIFF
--- a/.claude/commands/drift-fix.md
+++ b/.claude/commands/drift-fix.md
@@ -338,11 +338,13 @@ green CI is necessary, never sufficient.
 Watch CI to green, then hand the merge to the tooling that respects branch
 protection — never merge past it:
 
-Armed auto-merge (`ARMAUTOMERGE=1`, `scripts/handover/merge-on-green.sh`)
-hard-refuses (exit 12) any repo not confirmed PRIVATE, and `origin` has been
-public since the HIMMEL-2705 cutover — so that path is **unavailable** on this
-repo until HIMMEL-2869 lands; until then, use `scripts/handover/pr-merge.sh`
-(plain-first).
+Armed auto-merge (`ARMAUTOMERGE=1`, `scripts/handover/merge-on-green.sh`) admits
+a repo confirmed PRIVATE, or the ONE configured public origin when a live read
+shows branch protection with required status checks on the base branch
+(HIMMEL-2869) — `origin` is that origin, so the armed path is available here.
+Any other public repo, and an unreadable or check-less protection read, still
+refuse (exit 12). `scripts/handover/pr-merge.sh` (plain-first) remains the
+alternative.
 
 **Never `--admin`, never a force-merge, never a branch-protection override.** If
 the merge is refused for want of an approval, that is the rule working: leave

--- a/.claude/commands/drift-fix.md
+++ b/.claude/commands/drift-fix.md
@@ -340,11 +340,11 @@ protection — never merge past it:
 
 Armed auto-merge (`ARMAUTOMERGE=1`, `scripts/handover/merge-on-green.sh`) admits
 a repo confirmed PRIVATE, or the ONE configured public origin when a live read
-shows branch protection with required status checks on the base branch
-(HIMMEL-2869) — `origin` is that origin, so the armed path is available here.
-Any other public repo, and an unreadable or check-less protection read, still
-refuse (exit 12). `scripts/handover/pr-merge.sh` (plain-first) remains the
-alternative.
+shows branch protection on the base branch with BOTH `enforce_admins` enabled
+and a non-empty required-status-checks list (HIMMEL-2869) — `origin` is that
+origin, so the armed path is available here. Any other public repo, and an
+unreadable or check-less protection read, still refuse (exit 12).
+`scripts/handover/pr-merge.sh` (plain-first) remains the alternative.
 
 **Never `--admin`, never a force-merge, never a branch-protection override.** If
 the merge is refused for want of an approval, that is the rule working: leave

--- a/.claude/commands/fork-resync.md
+++ b/.claude/commands/fork-resync.md
@@ -167,9 +167,12 @@ Same as `/drift-fix` steps 6–9:
 - Commit with attestation trailers in the FIRST commit — `Platforms tested:` and
   `Security reviewed:` — earned by actually running step 5.
 - `/pr-check` until CR is clean, open the PR, watch CI green.
-- Merge via `scripts/handover/merge-on-green.sh` (armed) or
-  `scripts/handover/pr-merge.sh`. **The ≥1-approval rule applies to this cadence
-  exactly as it does to a human PR** — green CI is necessary, never sufficient.
+- Merge via `scripts/handover/merge-on-green.sh` (armed — it admits a
+  confirmed-private repo, or the ONE configured public origin under
+  live-verified branch protection, HIMMEL-2869; a fork that is neither is
+  refused, exit 12) or `scripts/handover/pr-merge.sh`. **The ≥1-approval rule
+  applies to this cadence exactly as it does to a human PR** — green CI is
+  necessary, never sufficient.
   Never `--admin`, never a branch-protection override. A merge refused for want
   of an approval is the rule working: leave the PR open, report `awaiting
   approval`, and stop. That is a successful run — the re-sync is captured in a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,7 @@ Step-by-step, with the enforcing file:
 | Push | `git push` | pre-push stage: attestation trailers, npm audit, no-push-to-main, and `scripts/hooks/check-cr-before-push.sh` writes a **CR marker** recording that a review is owed |
 | Review | `/pr-check` | multi-agent panel (`.claude/commands/pr-check.md`); a clean result clears the marker |
 | Open PR | `gh pr create` | `scripts/hooks/check-cr-marker-on-pr-create.sh` blocks while the marker exists |
-| Merge | `gh pr merge`, or Telegram `/mergepub <pr> <sha12>` (`merge-public-on-green.sh`); armed auto-merge (`merge-on-green.sh`, `ARMAUTOMERGE=1`) is private-repo-only and currently refuses here (HIMMEL-2869) | `scripts/hooks/block-unresolved-cr-merge.sh` — CI green + zero unresolved review threads. Branch protection is also active on `main` (required status checks, squash-only + 1 approving review + code-owner review, `enforce_admins`, no force-push/deletion); this hook is one gate among several, not the whole gate |
+| Merge | `gh pr merge`, or Telegram `/mergepub <pr> <sha12>` (`merge-public-on-green.sh`); armed auto-merge (`merge-on-green.sh`, `ARMAUTOMERGE=1`) admits a confirmed-private repo, or the ONE configured public origin under live-verified branch protection with required status checks (HIMMEL-2869) | `scripts/hooks/block-unresolved-cr-merge.sh` — CI green + zero unresolved review threads. Branch protection is also active on `main` (required status checks, squash-only + 1 approving review + code-owner review, `enforce_admins`, no force-push/deletion); this hook is one gate among several, not the whole gate |
 | Handover | `/handover` | state written to your handover store (`docs/internals/handover-system.md`) |
 
 ### 2.2 What happens on every tool call
@@ -358,7 +358,7 @@ each bridged var's own comment there names its bridging reader.
 | `CR_REQUIRE_CROSS_MODEL` | OFF | `.env` (bridged) | opt-in cross-model floor (HIMMEL-1237): require ≥1 non-Claude critic `avail … ok` at the SHA before the CR marker clears — makes the claude-only floor above insufficient. Bridged from `.env` by `scripts/cr/clear-cr-marker.sh` itself (gate 3b); a live-env value wins |
 | `CRITIC_TIMEOUT_SECS` / `CRITIC_PARALLEL` / `CRITIC_PANEL_TIERS` / `CR_TRIVIALITY_OVERRIDE` / `CR_USAGE_LOG` | 240s / sequential / `free` / heuristic / off | env | panel cost/scope tuning (`scripts/cr/critic-panel.sh`, `.claude/commands/pr-check.md`) |
 | `scripts/cr/critics.local.json` | — | file (gitignored) | per-machine critic overlay; `"drop": true` removes a base row |
-| `ARMAUTOMERGE` | OFF | env | arms `merge-on-green.sh` (private auto-merge — full condition list in [§3.3](#33-merge--publish-gates)); refuses on this repo since `origin` is public (HIMMEL-2869) |
+| `ARMAUTOMERGE` | OFF | env | arms `merge-on-green.sh` (full condition list in [§3.3](#33-merge--publish-gates)); admits a confirmed-private repo, or the configured public origin under live-verified branch protection with required status checks (HIMMEL-2869) |
 | `MERGE_ON_GREEN_LOG` | `<gitdir>/merge-on-green.log` | env | auto-merge audit log path |
 
 **himmel's own review posture (HIMMEL-1299, operator decision 2026-07-28;
@@ -403,13 +403,14 @@ default subset:
   points but cannot widen what any hook allows
   (`scripts/hooks/inject-initiative.sh`). The `merge` leg, when active,
   self-merges the PR once CR-clean via the plain
-  `scripts/handover/pr-merge.sh` squash-merge. `ARMAUTOMERGE=1` would instead
-  route it through the CI-certified `merge-on-green.sh` chokepoint, but that
-  chokepoint hard-refuses (exit 12) any repo that is not confirmed PRIVATE,
-  and `origin` has been public since the HIMMEL-2705 cutover — so on this
-  repo the `1` branch does not merge at all, it refuses; the armed path stays
-  unavailable on this repo until HIMMEL-2869 lands; until then the operator
-  merges at READY. The `public` leg is retired
+  `scripts/handover/pr-merge.sh` squash-merge. `ARMAUTOMERGE=1` instead routes
+  it through the CI-certified `merge-on-green.sh` chokepoint, which admits a
+  repo confirmed PRIVATE, or the ONE configured public origin when a live read
+  shows branch protection with required status checks on the base branch
+  (HIMMEL-2869). `origin` has been that configured origin since the HIMMEL-2705
+  cutover, so the `1` branch merges here. Any other public repo, and a
+  protection read that is missing, empty or unreadable, still refuse (exit 12).
+  The `public` leg is retired
   (HIMMEL-2705 cutover) — `origin` IS the public repo, so the `merge` leg above
   already lands the public change; `public` is a documented no-op kept only so
   the token still resolves.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,7 +294,7 @@ per-hook behavior: [internals/enforcement.md](internals/enforcement.md).
 | Gate | Class | How it is satisfied |
 |---|---|---|
 | Session merge gate (`block-unresolved-cr-merge`) | auth-gated | CI green + zero unresolved review threads on the head SHA (`scripts/hooks/block-unresolved-cr-merge.sh`). Branch protection is also active on `main`: 10 required status checks (strict — branch must be up to date), `enforce_admins`, no force-push, no deletion, and — via the separate `protect-main` ruleset rather than classic branch protection — squash-only merges, 1 approving review, and code-owner review required. So this hook is one gate among several, not the whole gate. As a session hook it gates merges issued *inside a Claude session*; an operator merging from a bare terminal or the GitHub UI is outside its reach — by design, since the operator is the authority it protects. It also fails **open** on degraded evaluation (missing `jq`, unparseable hook input) — a guardrail layered on top of forge-side branch protection, not a replacement for it |
-| Private auto-merge (`scripts/handover/merge-on-green.sh`) | auth-gated, opt-in | `ARMAUTOMERGE` truthy **and** all of: same repo, repo verified private, PR base == default branch, `check-ci.sh` exit 0, base/privacy re-verified fresh pre-merge, audit log writable, merge pinned to the certified head SHA (`--match-head-commit`), MERGED state confirmed by polling |
+| Armed auto-merge (`scripts/handover/merge-on-green.sh`) | auth-gated, opt-in | `ARMAUTOMERGE` truthy **and** all of: same repo, PR base == default branch, `check-ci.sh` exit 0, audit log writable, merge pinned to the certified head SHA (`--match-head-commit`), MERGED state confirmed by polling — **and** a repo test satisfied either way: the repo is verified PRIVATE, **or** it is the ONE configured public origin (`HIMMEL_PUBLIC_ORIGIN_NWO`, a fixed literal in the script) and a live read shows branch protection with required status checks on the base branch (HIMMEL-2869). Any other public repo, and a protection read that is missing, empty or unreadable, refuse (exit 12). Base, privacy **and** protection are each re-verified fresh immediately pre-merge, never reused from the first pass |
 | Public merge (`scripts/merge-public-on-green.sh`, via Telegram `/mergepub`) | HARD human-authorization | operator-typed, non-forwarded `/mergepub <pr> <sha12>`; SHA must prefix-match the live head at read *and* fresh pre-merge re-verify; `check-ci.sh` exit 0 is the only pass; the script refuses outright if `CLAUDECODE` is set (i.e. if any agent tries to run it) |
 | `check-ci.sh` (the watcher those gates call) | mechanism, not a veto | exit 0 = green + threads resolved + no changes-requested; 1 = red; 2 = cannot evaluate; 3 = unresolved threads / changes requested; 4 = CodeRabbit concluded incrementally with no head review while a prior head had outside-diff findings (request a full review or `--escalate`) |
 
@@ -565,8 +565,10 @@ opt-in except the cap watchdogs (rung 2), which ship enabled with the hooks:
    with the hooks); kill with `AUTO_ARM_DISABLE=1`.
 3. **Arming** (`arm-resume.sh`, `/handover-arm-resume`, Telegram `/arm`) — a
    scheduled task relaunches `claude` with a handover at a chosen time.
-4. **Private auto-merge** (`ARMAUTOMERGE=1` + `merge-on-green.sh`) — merges a
-   green, thread-resolved private PR without a human click.
+4. **Armed auto-merge** (`ARMAUTOMERGE=1` + `merge-on-green.sh`) — merges a
+   green, thread-resolved PR without a human click, on a private repo or on
+   the one configured public origin under live-verified branch protection
+   (full condition list in [§3.3](#33-merge--publish-gates)).
 5. **Overnight mode** (`/overnight-shift --limit N`) — dispatches scoped
    tickets as parallel agents that branch, build, self-review, and open PRs.
    Halt with `/stop` (marker file polled between dispatches).
@@ -653,7 +655,7 @@ tables; this is the layer level.)
 | Layer | Off switch | Scope |
 |---|---|---|
 | Initiative mode | leave/unset `HIMMEL_INITIATIVE` (default OFF); per-repo override: `"env": { "HIMMEL_INITIATIVE": "" }` in that repo's `.claude/settings.json` | session start |
-| Private auto-merge | leave/unset `ARMAUTOMERGE` (default OFF) | per shell |
+| Armed auto-merge | leave/unset `ARMAUTOMERGE` (default OFF) | per shell |
 | Cap watchdogs (auto-arm) | `AUTO_ARM_DISABLE=1` (+ `AUTO_ARM_SUBAGENT_DISABLE=1`) | launching shell |
 | A scheduled resume | `scripts/handover/arm-resume.sh --dry-run` to inspect; delete the `HIMMEL-Resume-*` scheduled task (schtasks / `at` / crontab) | OS scheduler |
 | Recurring vault cadence | `scripts/luna/pipeline-cadence.sh disarm` | OS scheduler |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,7 @@ Step-by-step, with the enforcing file:
 | Push | `git push` | pre-push stage: attestation trailers, npm audit, no-push-to-main, and `scripts/hooks/check-cr-before-push.sh` writes a **CR marker** recording that a review is owed |
 | Review | `/pr-check` | multi-agent panel (`.claude/commands/pr-check.md`); a clean result clears the marker |
 | Open PR | `gh pr create` | `scripts/hooks/check-cr-marker-on-pr-create.sh` blocks while the marker exists |
-| Merge | `gh pr merge`, or Telegram `/mergepub <pr> <sha12>` (`merge-public-on-green.sh`); armed auto-merge (`merge-on-green.sh`, `ARMAUTOMERGE=1`) admits a confirmed-private repo, or the ONE configured public origin under live-verified branch protection with required status checks (HIMMEL-2869) | `scripts/hooks/block-unresolved-cr-merge.sh` — CI green + zero unresolved review threads. Branch protection is also active on `main` (required status checks, squash-only + 1 approving review + code-owner review, `enforce_admins`, no force-push/deletion); this hook is one gate among several, not the whole gate |
+| Merge | `gh pr merge`, or Telegram `/mergepub <pr> <sha12>` (`merge-public-on-green.sh`); armed auto-merge (`merge-on-green.sh`, `ARMAUTOMERGE=1`) admits a confirmed-private repo, or the ONE configured public origin under live-verified branch protection — `enforce_admins` enabled and required status checks present (HIMMEL-2869) | `scripts/hooks/block-unresolved-cr-merge.sh` — CI green + zero unresolved review threads. Branch protection is also active on `main` (required status checks, squash-only + 1 approving review + code-owner review, `enforce_admins`, no force-push/deletion); this hook is one gate among several, not the whole gate |
 | Handover | `/handover` | state written to your handover store (`docs/internals/handover-system.md`) |
 
 ### 2.2 What happens on every tool call
@@ -294,7 +294,7 @@ per-hook behavior: [internals/enforcement.md](internals/enforcement.md).
 | Gate | Class | How it is satisfied |
 |---|---|---|
 | Session merge gate (`block-unresolved-cr-merge`) | auth-gated | CI green + zero unresolved review threads on the head SHA (`scripts/hooks/block-unresolved-cr-merge.sh`). Branch protection is also active on `main`: 10 required status checks (strict — branch must be up to date), `enforce_admins`, no force-push, no deletion, and — via the separate `protect-main` ruleset rather than classic branch protection — squash-only merges, 1 approving review, and code-owner review required. So this hook is one gate among several, not the whole gate. As a session hook it gates merges issued *inside a Claude session*; an operator merging from a bare terminal or the GitHub UI is outside its reach — by design, since the operator is the authority it protects. It also fails **open** on degraded evaluation (missing `jq`, unparseable hook input) — a guardrail layered on top of forge-side branch protection, not a replacement for it |
-| Armed auto-merge (`scripts/handover/merge-on-green.sh`) | auth-gated, opt-in | `ARMAUTOMERGE` truthy **and** all of: same repo, PR base == default branch, `check-ci.sh` exit 0, audit log writable, merge pinned to the certified head SHA (`--match-head-commit`), MERGED state confirmed by polling — **and** a repo test satisfied either way: the repo is verified PRIVATE, **or** it is the ONE configured public origin (`HIMMEL_PUBLIC_ORIGIN_NWO`, a fixed literal in the script) and a live read shows branch protection with required status checks on the base branch (HIMMEL-2869). Any other public repo, and a protection read that is missing, empty or unreadable, refuse (exit 12). Base, privacy **and** protection are each re-verified fresh immediately pre-merge, never reused from the first pass |
+| Armed auto-merge (`scripts/handover/merge-on-green.sh`) | auth-gated, opt-in | `ARMAUTOMERGE` truthy **and** all of: same repo, PR base == default branch, `check-ci.sh` exit 0, audit log writable, merge pinned to the certified head SHA (`--match-head-commit`), MERGED state confirmed by polling — **and** a repo test satisfied either way: the repo is verified PRIVATE, **or** it is the ONE configured public origin (`HIMMEL_PUBLIC_ORIGIN_NWO`, a fixed literal in the script) and a live read shows branch protection on the base branch with BOTH `enforce_admins` enabled and a non-empty required-status-checks list (HIMMEL-2869). Any other public repo, and a protection read that is missing, empty or unreadable, refuse (exit 12). Base, privacy **and** protection are each re-verified fresh immediately pre-merge, never reused from the first pass |
 | Public merge (`scripts/merge-public-on-green.sh`, via Telegram `/mergepub`) | HARD human-authorization | operator-typed, non-forwarded `/mergepub <pr> <sha12>`; SHA must prefix-match the live head at read *and* fresh pre-merge re-verify; `check-ci.sh` exit 0 is the only pass; the script refuses outright if `CLAUDECODE` is set (i.e. if any agent tries to run it) |
 | `check-ci.sh` (the watcher those gates call) | mechanism, not a veto | exit 0 = green + threads resolved + no changes-requested; 1 = red; 2 = cannot evaluate; 3 = unresolved threads / changes requested; 4 = CodeRabbit concluded incrementally with no head review while a prior head had outside-diff findings (request a full review or `--escalate`) |
 
@@ -358,7 +358,7 @@ each bridged var's own comment there names its bridging reader.
 | `CR_REQUIRE_CROSS_MODEL` | OFF | `.env` (bridged) | opt-in cross-model floor (HIMMEL-1237): require ≥1 non-Claude critic `avail … ok` at the SHA before the CR marker clears — makes the claude-only floor above insufficient. Bridged from `.env` by `scripts/cr/clear-cr-marker.sh` itself (gate 3b); a live-env value wins |
 | `CRITIC_TIMEOUT_SECS` / `CRITIC_PARALLEL` / `CRITIC_PANEL_TIERS` / `CR_TRIVIALITY_OVERRIDE` / `CR_USAGE_LOG` | 240s / sequential / `free` / heuristic / off | env | panel cost/scope tuning (`scripts/cr/critic-panel.sh`, `.claude/commands/pr-check.md`) |
 | `scripts/cr/critics.local.json` | — | file (gitignored) | per-machine critic overlay; `"drop": true` removes a base row |
-| `ARMAUTOMERGE` | OFF | env | arms `merge-on-green.sh` (full condition list in [§3.3](#33-merge--publish-gates)); admits a confirmed-private repo, or the configured public origin under live-verified branch protection with required status checks (HIMMEL-2869) |
+| `ARMAUTOMERGE` | OFF | env | arms `merge-on-green.sh` (full condition list in [§3.3](#33-merge--publish-gates)); admits a confirmed-private repo, or the configured public origin under live-verified branch protection — `enforce_admins` enabled and required status checks present (HIMMEL-2869) |
 | `MERGE_ON_GREEN_LOG` | `<gitdir>/merge-on-green.log` | env | auto-merge audit log path |
 
 **himmel's own review posture (HIMMEL-1299, operator decision 2026-07-28;
@@ -406,8 +406,9 @@ default subset:
   `scripts/handover/pr-merge.sh` squash-merge. `ARMAUTOMERGE=1` instead routes
   it through the CI-certified `merge-on-green.sh` chokepoint, which admits a
   repo confirmed PRIVATE, or the ONE configured public origin when a live read
-  shows branch protection with required status checks on the base branch
-  (HIMMEL-2869). `origin` has been that configured origin since the HIMMEL-2705
+  shows branch protection on the base branch with BOTH `enforce_admins` enabled
+  and a non-empty required-status-checks list (HIMMEL-2869). `origin` has been
+  that configured origin since the HIMMEL-2705
   cutover, so the `1` branch merges here. Any other public repo, and a
   protection read that is missing, empty or unreadable, still refuse (exit 12).
   The `public` leg is retired

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -3745,8 +3745,15 @@ structure but with the binding INVERTED (public-pinned, not private-only) — se
    `CLAUDECODE` env marker is present; the bridge spawns this script's env
    WITHOUT that marker, so this can only fire on an agent-initiated call.
 Deliberately a SEPARATE script from `merge-on-green.sh`, not a shared "which
-repo class" switch — the private-only guard there is a safety boundary, and a
-flag that inverts a safety boundary is the failure mode this avoids. Supports
+repo class" switch — the repo guard there is a safety boundary, and a flag that
+inverts a safety boundary is the failure mode this avoids. HIMMEL-2869 widened
+that guard to admit ONE named public origin under live-verified branch
+protection, which does not soften this reasoning: the two bindings still point
+opposite ways — this script's pin NARROWS what a human-only,
+`CLAUDECODE`-self-refusing chokepoint may touch, while merge-on-green's WIDENS a
+boundary an agent runs under. That is why merge-on-green deliberately does NOT
+reuse this script's `CR_PUBLIC_REPO`: an env-overridable constant costs nothing
+on a narrowing pin and would be a widening seam on the other. Supports
 `--dry-run` (every gate runs, no merge fires) for manual/terminal shakedown; the
 Telegram command grammar has no dry-run variant. The repo name itself carries
 no secret (himmel is a single public repo) — only the activation flag +

--- a/scripts/handover/merge-on-green.sh
+++ b/scripts/handover/merge-on-green.sh
@@ -258,7 +258,7 @@ public_origin_merge_allowed() {
         return 1
     fi
     prot=$("$GH" api "repos/$nwo/branches/$branch/protection" \
-            --jq '"\(.enforce_admins.enabled // false)|\((.required_status_checks.contexts // []) | length)|\((.required_status_checks.checks // []) | length)"' 2>/dev/null || true)
+            --jq '"\(.enforce_admins.enabled // false)|\((.required_status_checks.contexts // []) | length)|\((.required_status_checks.checks // []) | length)"' 2>/dev/null || true)  # jq-alt-ok: every `//` default here is the FAIL-CLOSED answer, so swallowing false is harmless — absent, null and false all yield the value that REFUSES (enforce_admins must equal the string "true"; an empty contexts/checks list means zero required checks). has() would be weaker, not stronger: it would read a present-but-false enforce_admins as satisfied.
     if [ -z "$prot" ]; then
         PUBLIC_ORIGIN_DETAIL="unreadable"
         return 1

--- a/scripts/handover/merge-on-green.sh
+++ b/scripts/handover/merge-on-green.sh
@@ -11,7 +11,9 @@
 # specific standing allow-rule — `Bash(bash scripts/handover/merge-on-green.sh:*)`
 # — never a raw `gh pr merge` (still classifier-blocked) and never a permission
 # widening. It merges ONLY on: opt-in (ARMAUTOMERGE=1) AND a PRIVATE github repo
-# AND the PR targets that repo's DEFAULT branch (HIMMEL-1080, coderabbit public
+# — or, HIMMEL-2869, the ONE configured public origin, live-verified under
+# branch protection with required status checks — AND the PR targets that repo's
+# DEFAULT branch (HIMMEL-1080, coderabbit public
 # round: repo-bound alone still let it merge a PR against ANY base, even though
 # inject-initiative.sh documents the scope as "squash-merge to PRIVATE main")
 # AND check-ci.sh exit 0 (all checks green + all review threads resolved + no
@@ -87,6 +89,10 @@
 #       branch is not the repo's default branch (undeterminable counts too) —
 #       refused fail-closed. Also returned by the pre-merge re-verification of
 #       the same binding (see above) if the base changed after the gate.
+#       HIMMEL-2869: also returned when the repo is public and is NOT the
+#       configured public origin, or IS the configured public origin but its
+#       branch protection is unreadable or lacks required status checks —
+#       at either the guard-2b check or the pre-merge re-check.
 #   13  cannot resolve the PR, its head SHA, or a well-formed metadata line
 #       (six pipe-joined fields incl. the head branch) — refused
 #   14  check-ci gate not green (unresolved threads / red CI / changes requested)
@@ -122,6 +128,24 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GH="gh"
 CHECK_CI="$SCRIPT_DIR/../check-ci.sh"
+# The ONE public repo armed auto-merge may target (HIMMEL-2869). Deliberately a
+# fixed literal, NOT environment-overridable: the GATE INTEGRITY paragraph above
+# forbids an env seam on a merge gate, and this one would be the WIDENING kind —
+# a contaminated launching environment could point the lever at an arbitrary
+# public repo, which is precisely what the one-named-repo relaxation exists to
+# prevent. Tests exercise this shipped value through the stub `gh`'s reported
+# nwo, never through an override.
+#
+# Not a reuse of `merge-public-on-green.sh`'s CR_PUBLIC_REPO (same default,
+# different name on purpose): that lever's binding is public-PINNED — the pin
+# NARROWS what a human-only, CLAUDECODE-self-refusing Telegram chokepoint may
+# touch, so an ambient override there costs nothing an agent could reach. Here
+# the binding WIDENS a safety boundary instead, so sharing that name or its
+# overridability would smuggle a widening seam in under a narrowing one's
+# reputation. docs/internals/enforcement.md already records keeping the two
+# scripts separate rather than building a shared "which repo class" switch;
+# this constant staying its own fixed literal is that decision holding.
+HIMMEL_PUBLIC_ORIGIN_NWO="yotamleo/Himmel"
 # The repo's ONE CodeRabbit-availability answer (scripts/lib/cr-available.sh).
 # Fixed in-repo sibling, resolved like CHECK_CI above and for the same reason.
 # shellcheck source=scripts/lib/cr-available.sh
@@ -191,6 +215,65 @@ audit_preflight() {
     [ -z "$logf" ] && return 0
     ( printf '' >>"$logf" ) 2>/dev/null && return 0
     return 1
+}
+
+# Branch-protection detail for the refusal message/audit line, set by
+# public_origin_merge_allowed below.
+PUBLIC_ORIGIN_REASON=""
+PUBLIC_ORIGIN_DETAIL=""
+
+# public_origin_merge_allowed <nwo> <default-branch> [reason-suffix]
+#
+# HIMMEL-2869. The private-only boundary (guard 2b / the pre-merge re-check)
+# widens to admit ONE named public repo — the configured public origin — and
+# ONLY while GitHub itself is enforcing required status checks on the branch
+# being merged into. That protection is the whole basis of the relaxation: on a
+# private repo the blast radius of a bad armed merge is internal, on a public
+# one it is not, so the lever leans on a server-side gate the agent cannot
+# weaken. Fail CLOSED on every unreadable field — a 404, an empty body, a
+# protection object without required_status_checks, or an empty contexts/checks
+# list all refuse, never "assume protected".
+#
+# Reads the CLASSIC protection endpoint, and reads ONLY required_status_checks
+# + enforce_admins from it. It deliberately infers NOTHING about reviews: on
+# this repo the approval requirement (1 approving review + code-owner review)
+# lives in a RULESET (`protect-main`), so `/branches/main/protection` returns
+# `required_pull_request_reviews: null` even though approvals ARE enforced.
+# That null is CORRECT — do not "fix" it, and do not gate this helper on
+# approvals. GitHub enforces the ruleset at `gh pr merge` time; a merge refused
+# there for want of an approval is a FINDING to report, never something to
+# bypass (which is also why this lever never passes `--admin`). Rulesets may
+# ADD to protection, never replace it, so the classic read stays authoritative
+# for the checks this gate requires.
+public_origin_merge_allowed() {
+    local nwo="$1" branch="$2" suffix="${3:-}" prot admins rest n_contexts n_checks
+    PUBLIC_ORIGIN_DETAIL=""
+    if [ "$nwo" != "$HIMMEL_PUBLIC_ORIGIN_NWO" ]; then
+        PUBLIC_ORIGIN_REASON="not-private${suffix}"
+        return 1
+    fi
+    PUBLIC_ORIGIN_REASON="not-protected${suffix}"
+    if [ -z "$branch" ]; then
+        PUBLIC_ORIGIN_DETAIL="no-branch"
+        return 1
+    fi
+    prot=$("$GH" api "repos/$nwo/branches/$branch/protection" \
+            --jq '"\(.enforce_admins.enabled // false)|\((.required_status_checks.contexts // []) | length)|\((.required_status_checks.checks // []) | length)"' 2>/dev/null || true)
+    if [ -z "$prot" ]; then
+        PUBLIC_ORIGIN_DETAIL="unreadable"
+        return 1
+    fi
+    admins=${prot%%|*}
+    rest=${prot#*|}
+    n_contexts=${rest%%|*}
+    n_checks=${rest##*|}
+    case "$n_contexts" in ''|*[!0-9]*) n_contexts=0 ;; esac
+    case "$n_checks" in ''|*[!0-9]*) n_checks=0 ;; esac
+    PUBLIC_ORIGIN_DETAIL="enforce_admins=$admins required_checks=$((n_contexts + n_checks))"
+    [ "$admins" = "true" ] || return 1
+    [ "$((n_contexts + n_checks))" -gt 0 ] || return 1
+    PUBLIC_ORIGIN_REASON=""
+    return 0
 }
 
 # 1. Opt-in guard — the operator's standing authorization (launching shell only).
@@ -306,13 +389,17 @@ fi
 # defaultBranchRef is NULLABLE (a repo can have no default branch) — coalesce
 # to "" (CodeRabbit) so a null field reads as "undeterminable" below instead of
 # jq's literal "null" string slipping past the -z check as a non-empty value.
+#
+# HIMMEL-2869: the boundary widens for ONE named public repo (the configured
+# public origin), and only while it is live-verified under branch protection
+# with required status checks — see public_origin_merge_allowed above.
 repo_meta=$("$GH" repo view "$nwo" --json isPrivate,defaultBranchRef \
         --jq '"\(.isPrivate)|\(.defaultBranchRef.name // "")"' 2>/dev/null || true)
 is_private=${repo_meta%%|*}
 default_branch=${repo_meta#*|}
-if [ "$is_private" != "true" ]; then
-    echo "merge-on-green: repo $nwo is not confirmed PRIVATE (isPrivate='${is_private:-<unknown>}') — refusing. Public propagation stays an operator/bridge step." >&2
-    audit "REFUSED reason=not-private repo=$nwo isPrivate=${is_private:-unknown}"
+if [ "$is_private" != "true" ] && ! public_origin_merge_allowed "$nwo" "$default_branch"; then
+    echo "merge-on-green: repo $nwo is not confirmed PRIVATE (isPrivate='${is_private:-<unknown>}') and is not the configured public origin ($HIMMEL_PUBLIC_ORIGIN_NWO) under branch protection with required status checks (${PUBLIC_ORIGIN_DETAIL:-n/a}) — refusing." >&2
+    audit "REFUSED reason=$PUBLIC_ORIGIN_REASON repo=$nwo isPrivate=${is_private:-unknown} protection=${PUBLIC_ORIGIN_DETAIL:-n/a}"
     exit 12
 fi
 
@@ -459,6 +546,12 @@ clear_cr_marker_for_branch() {
 # 2b's combined query). The private-only boundary (guard 2b) is subject to the
 # SAME CI-wait staleness window as the base binding — a repo made PUBLIC during
 # the check-ci watch would otherwise merge on the stale guard-2b isPrivate.
+#
+# HIMMEL-2869: the guard-2b widening is re-verified here too, and the
+# protection READ is re-done FRESH — never the guard-2b PUBLIC_ORIGIN_* result
+# — because branch protection can be weakened during check-ci.sh's multi-minute
+# watch exactly like isPrivate and the base can (the same staleness class the
+# comment above already describes for those two).
 fresh_base=$("$GH" pr view "$pr_num" --repo "$nwo" --json baseRefName --jq '.baseRefName' 2>/dev/null || true)
 fresh_repo_meta=$("$GH" repo view "$nwo" --json isPrivate,defaultBranchRef \
         --jq '"\(.isPrivate)|\(.defaultBranchRef.name // "")"' 2>/dev/null || true)
@@ -469,9 +562,9 @@ if [ -z "$fresh_base" ] || [ -z "$fresh_default" ]; then
     audit "REFUSED reason=base-branch-undeterminable pr_base=${fresh_base:-empty} default_branch=${fresh_default:-empty} repo=$nwo pr=#$pr_num"
     exit 12
 fi
-if [ "$fresh_private" != "true" ]; then
-    echo "merge-on-green: repo $nwo is no longer confirmed PRIVATE (isPrivate='${fresh_private:-<unknown>}') right before merging — refusing. A repo made public during the CI wait must not auto-merge." >&2
-    audit "REFUSED reason=not-private-premerge repo=$nwo isPrivate=${fresh_private:-unknown} pr=#$pr_num"
+if [ "$fresh_private" != "true" ] && ! public_origin_merge_allowed "$nwo" "$fresh_default" "-premerge"; then
+    echo "merge-on-green: repo $nwo is no longer confirmed PRIVATE (isPrivate='${fresh_private:-<unknown>}') and is not the configured public origin ($HIMMEL_PUBLIC_ORIGIN_NWO) under branch protection with required status checks (${PUBLIC_ORIGIN_DETAIL:-n/a}) right before merging — refusing. A repo made public, or a public origin whose protection weakened, during the CI wait must not auto-merge." >&2
+    audit "REFUSED reason=$PUBLIC_ORIGIN_REASON repo=$nwo isPrivate=${fresh_private:-unknown} protection=${PUBLIC_ORIGIN_DETAIL:-n/a} pr=#$pr_num"
     exit 12
 fi
 if [ "$fresh_base" != "$fresh_default" ] || [ "$fresh_base" != "$pr_base" ]; then

--- a/scripts/handover/test-merge-on-green.sh
+++ b/scripts/handover/test-merge-on-green.sh
@@ -630,6 +630,12 @@ STUB_CWD_FAIL=1 run_mog 12 "unresolvable cwd repo → exit 12 fail-closed"
 # enforce_admins off, the `checks` list shape, a DIFFERENT public repo, the
 # non-seam of the constant, the private-repo regression anchor, and the
 # pre-merge re-read catching protection weakened during the CI wait.
+#
+# jq availability is checked ONCE here, locally to this block (the file's
+# shared `have_jq` guard is computed further down, after this block, and this
+# block needs it before that point) — hoisted here rather than probed
+# separately in each of 2869-1b and 2869-7 below, which both need it.
+have_jq_2869=0; command -v jq >/dev/null 2>&1 && have_jq_2869=1
 
 # 2869-1. The configured public origin, under branch protection with required
 # status checks → proceeds to the merge exactly like a private repo would.
@@ -639,6 +645,28 @@ assert_merge_has "2869-1: merge pins the certified sha" "--match-head-commit pub
 assert_merge_has "2869-1: merge uses --squash" "--squash"
 assert_gh_has "2869-1: reads branch protection on the configured origin" "api repos/yotamleo/Himmel/branches/main/protection"
 assert_audit_has "2869-1: audit records the merge" "MERGED"
+
+# 2869-1b ([codex-1], CR round 1). Every other allow-path case above (2869-1,
+# 2869-3c) feeds the stub its PRE-JOINED "enforce_admins|contexts|checks"
+# string, so the script's own `--jq` filter never runs on the MERGE direction
+# at all — 2869-7 below is the only case that runs real JSON through the
+# real filter, and it is itself a refusal (null required_status_checks). A
+# filter mutated to reject every real response (e.g. contexts/checks length
+# forced to 0) would therefore leave the WHOLE suite green: it still refuses
+# 2869-7 "correctly" and never touches the pre-joined-string cases at all.
+# This case is the allow-direction twin of 2869-7: realistic GitHub-shaped
+# protection JSON (the actual `repos/.../branches/main/protection` response
+# shape, `strict` + a `contexts` array of real-looking check names) through
+# the script's OWN filter, asserting the result is one the gate ACCEPTS.
+if [ "$have_jq_2869" = "1" ]; then
+    STUB_NWO="yotamleo/Himmel" STUB_CWD_NWO="yotamleo/Himmel" STUB_PRIVATE=false STUB_SHA="jqok01" \
+        STUB_PROTECTION_JSON='{"enforce_admins":{"enabled":true},"required_status_checks":{"strict":true,"contexts":["lint","shell-unit (ubuntu-latest)","shellcheck"]}}' \
+        run_mog 0 "realistic protected-branch JSON through the real filter → merged"
+    assert_merge_has "2869-1b: merge pins the certified sha" "--match-head-commit jqok01"
+    assert_gh_has "2869-1b: reads branch protection on the configured origin" "api repos/yotamleo/Himmel/branches/main/protection"
+else
+    echo "  SKIP: jq not installed — realistic protected-branch-JSON allow case (HIMMEL-2869, [codex-1])"
+fi
 
 # 2869-2. Protection unreadable (404 / API failure) → refuse, no merge.
 STUB_NWO="yotamleo/Himmel" STUB_CWD_NWO="yotamleo/Himmel" STUB_PRIVATE=false STUB_PROTECTION_FAIL=1 \
@@ -719,9 +747,10 @@ assert_audit_has "2869-6a: audits not-protected-premerge" "reason=not-protected-
 # response) must coalesce through the script's own `// []` filter to an empty
 # list, not slip past as "protected" — proven via REAL jq against synthetic
 # JSON, same technique as the STUB_DEFAULT_BRANCH_NULL cases further below.
-# jq availability is checked locally (the file's shared `have_jq` guard is
-# computed further down, after this block) rather than reusing that variable.
-have_jq_2869=0; command -v jq >/dev/null 2>&1 && have_jq_2869=1
+# The allow-direction twin of this refusal is 2869-1b above; both share the
+# ONE have_jq_2869 probe computed at the top of this HIMMEL-2869 block rather
+# than each probing separately (the file's own shared `have_jq` guard is
+# computed further down, after this block, so it isn't reused here either).
 if [ "$have_jq_2869" = "1" ]; then
     STUB_NWO="yotamleo/Himmel" STUB_CWD_NWO="yotamleo/Himmel" STUB_PRIVATE=false \
         STUB_PROTECTION_JSON='{"enforce_admins":{"enabled":true},"required_status_checks":null}' \

--- a/scripts/handover/test-merge-on-green.sh
+++ b/scripts/handover/test-merge-on-green.sh
@@ -94,6 +94,16 @@ fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1" >&2; }
 #                        STUB_DEFAULT_BRANCH_NULL uses, so a `required_status_checks:
 #                        null` payload proves the script's `// []` coalesce rather
 #                        than a hand-picked stub string.
+#   STUB_PROTECTION_JSON_PREMERGE  overrides the JSON replayed on the PRE-MERGE
+#                        protection read only. Unset, it falls back to
+#                        STUB_PROTECTION_JSON, so an existing single-JSON case is
+#                        unaffected. Exists because STUB_PROTECTION_JSON alone is
+#                        replayed verbatim on BOTH reads (coderabbit round-1
+#                        nitpick): without this seam, a case setting
+#                        STUB_PROTECTION_JSON together with STUB_PROTECTION_PREMERGE
+#                        would silently exercise UNCHANGED protection across both
+#                        reads — STUB_PROTECTION_PREMERGE would be dead, and the
+#                        case would prove nothing about the pre-merge re-read.
 #   STUB_CI_RC          exit code of the stub check-ci. Default 0.
 #   STUB_MERGE_FAIL=1   `gh pr merge` exits 1 (generic failure).
 #   STUB_POST_STATE     PR state the post-merge re-query returns. Default MERGED.
@@ -367,8 +377,15 @@ case "$verb" in
                     fi
                 else
                     [ "${STUB_PROTECTION_PREMERGE_FAIL:-0}" = "1" ] && { echo "gh: protection unreadable" >&2; exit 1; }
-                    if [ -n "${STUB_PROTECTION_JSON:-}" ]; then
-                        printf '%s' "$STUB_PROTECTION_JSON" | jq -r "$jqexpr"
+                    # STUB_PROTECTION_JSON_PREMERGE overrides the JSON replayed
+                    # on THIS (second) read only — `-` (not `:-`) so an
+                    # explicitly-empty override is preserved, mirroring
+                    # STUB_PROTECTION_PREMERGE's own relation to STUB_PROTECTION
+                    # just below. Falls back to STUB_PROTECTION_JSON when unset,
+                    # so existing single-JSON cases are unaffected.
+                    json_val_premerge="${STUB_PROTECTION_JSON_PREMERGE-${STUB_PROTECTION_JSON:-}}"
+                    if [ -n "$json_val_premerge" ]; then
+                        printf '%s' "$json_val_premerge" | jq -r "$jqexpr"
                     else
                         printf '%s' "${STUB_PROTECTION_PREMERGE-${STUB_PROTECTION-true|10|0}}"
                     fi

--- a/scripts/handover/test-merge-on-green.sh
+++ b/scripts/handover/test-merge-on-green.sh
@@ -75,6 +75,25 @@ fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1" >&2; }
 #                        null JSON, so this proves the coalesce fix rather than
 #                        a hand-picked stub string.
 #   STUB_DEFAULT_BRANCH_PREMERGE_NULL=1  same, for the FIX-1 pre-merge query.
+#   STUB_PROTECTION      the guard-2b branch-protection read (HIMMEL-2869), as
+#                        the pre-joined shape the script's own --jq emits:
+#                        "<enforce_admins.enabled>|<#contexts>|<#checks>".
+#                        Default "true|10|0" (the live yotamleo/Himmel shape:
+#                        enforce_admins on, 10 required contexts). Only read on
+#                        the non-private path — a private repo never reaches it.
+#   STUB_PROTECTION_FAIL=1  the guard-2b `gh api .../protection` exits 1 (404 /
+#                        no protection / unreadable) → the guard must fail closed.
+#   STUB_PROTECTION_PREMERGE       same, for the pre-merge protection re-read.
+#                        Default = STUB_PROTECTION. Set it to simulate protection
+#                        being weakened during the check-ci watch.
+#   STUB_PROTECTION_PREMERGE_FAIL=1  the pre-merge protection re-read exits 1 →
+#                        refuse (protection removed during the CI wait).
+#   STUB_PROTECTION_JSON  raw protection JSON fed through the SCRIPT'S OWN --jq
+#                        filter (captured from argv) via real jq, instead of the
+#                        pre-joined STUB_PROTECTION string — the same technique
+#                        STUB_DEFAULT_BRANCH_NULL uses, so a `required_status_checks:
+#                        null` payload proves the script's `// []` coalesce rather
+#                        than a hand-picked stub string.
 #   STUB_CI_RC          exit code of the stub check-ci. Default 0.
 #   STUB_MERGE_FAIL=1   `gh pr merge` exits 1 (generic failure).
 #   STUB_POST_STATE     PR state the post-merge re-query returns. Default MERGED.
@@ -184,6 +203,7 @@ mog_build_fixture() {
 echo "$*" >> "$GH_LOG"
 verb="$1 $2"
 repo_arg="${3:-}"
+api_path="${2:-}"
 json=""
 jqexpr=""
 while [ $# -gt 0 ]; do case "$1" in --json) json="${2:-}";; --jq) jqexpr="${2:-}";; esac; shift; done
@@ -315,6 +335,46 @@ case "$verb" in
     "pr merge")
         [ "${STUB_MERGE_FAIL:-0}" = "1" ] && { echo "merge conflict / head moved" >&2; exit 1; }
         echo "merged"
+        ;;
+    "api repos/"*)
+        # HIMMEL-2869 — public_origin_merge_allowed's branch-protection read.
+        # Match ONLY the classic protection endpoint; anything else this stub
+        # does not recognize fails closed like every other unhandled shape.
+        case "$api_path" in
+            */branches/*/protection)
+                if [ -z "$jqexpr" ]; then
+                    echo "gh stub: 'api repos/.../protection' missing required --jq expression" >&2
+                    exit 93
+                fi
+                # Queried TWICE per run when the widened path is reached: guard
+                # 2b (query time) and the pre-merge re-check (HIMMEL-2869 mirrors
+                # the isPrivate/defaultBranchRef routing above). Routed by call
+                # ORDER via the gh argv log — this call is already appended at
+                # the top of the stub, so the match count is 1 on the first call,
+                # 2 on the second.
+                n=$(grep -c '/protection' "$GH_LOG" 2>/dev/null || echo 1)
+                if [ "${n:-1}" -le 1 ]; then
+                    [ "${STUB_PROTECTION_FAIL:-0}" = "1" ] && { echo "gh: protection unreadable" >&2; exit 1; }
+                    if [ -n "${STUB_PROTECTION_JSON:-}" ]; then
+                        # Real protection JSON through the SCRIPT'S OWN --jq
+                        # filter via real jq, same technique STUB_DEFAULT_BRANCH_NULL
+                        # uses — proves the script's own `// []` coalesce.
+                        printf '%s' "$STUB_PROTECTION_JSON" | jq -r "$jqexpr"
+                    else
+                        # `-` not `:-`: an explicitly-empty STUB_PROTECTION must
+                        # be preserved so a fail-closed empty-body case is reachable.
+                        printf '%s' "${STUB_PROTECTION-true|10|0}"
+                    fi
+                else
+                    [ "${STUB_PROTECTION_PREMERGE_FAIL:-0}" = "1" ] && { echo "gh: protection unreadable" >&2; exit 1; }
+                    if [ -n "${STUB_PROTECTION_JSON:-}" ]; then
+                        printf '%s' "$STUB_PROTECTION_JSON" | jq -r "$jqexpr"
+                    else
+                        printf '%s' "${STUB_PROTECTION_PREMERGE-${STUB_PROTECTION-true|10|0}}"
+                    fi
+                fi ;;
+            *) echo "gh stub: unhandled 'api' path: $api_path" >&2; exit 90 ;;
+        esac
         ;;
     *) echo "gh stub: unsupported command: $*" >&2; exit 90 ;;
 esac
@@ -560,6 +620,117 @@ assert_gh_lacks "cross-repo: no merge attempted" "pr merge"
 
 # 5c. Cannot resolve cwd repo → fail closed (exit 12).
 STUB_CWD_FAIL=1 run_mog 12 "unresolvable cwd repo → exit 12 fail-closed"
+
+# ── HIMMEL-2869: public-origin merge relaxation ──────────────────────────────
+# Guard 2b's private-only boundary widens to admit ONE named public repo (the
+# configured public origin, `public_origin_merge_allowed`'s
+# HIMMEL_PUBLIC_ORIGIN_NWO) while GitHub itself is enforcing required status
+# checks on the branch being merged into. These cases exercise the widened
+# path and every fail-closed edge: unreadable protection, no required checks,
+# enforce_admins off, the `checks` list shape, a DIFFERENT public repo, the
+# non-seam of the constant, the private-repo regression anchor, and the
+# pre-merge re-read catching protection weakened during the CI wait.
+
+# 2869-1. The configured public origin, under branch protection with required
+# status checks → proceeds to the merge exactly like a private repo would.
+STUB_NWO="yotamleo/Himmel" STUB_CWD_NWO="yotamleo/Himmel" STUB_PRIVATE=false STUB_SHA="pubok01" \
+    run_mog 0 "configured public origin under branch protection → merged"
+assert_merge_has "2869-1: merge pins the certified sha" "--match-head-commit pubok01"
+assert_merge_has "2869-1: merge uses --squash" "--squash"
+assert_gh_has "2869-1: reads branch protection on the configured origin" "api repos/yotamleo/Himmel/branches/main/protection"
+assert_audit_has "2869-1: audit records the merge" "MERGED"
+
+# 2869-2. Protection unreadable (404 / API failure) → refuse, no merge.
+STUB_NWO="yotamleo/Himmel" STUB_CWD_NWO="yotamleo/Himmel" STUB_PRIVATE=false STUB_PROTECTION_FAIL=1 \
+    run_mog 12 "public origin, protection unreadable → exit 12"
+assert_gh_lacks "2869-2: no merge attempted" "pr merge"
+assert_audit_has "2869-2: audits not-protected" "reason=not-protected"
+
+# 2869-2b. The empty-body twin of 2869-2's 404: a protection endpoint that
+# answers with NOTHING (rather than a non-zero gh exit) must refuse exactly
+# like one that errors, never be read as "protected". The stub preserves an
+# explicitly-empty STUB_PROTECTION (`-`, not `:-`) so this path is reachable.
+STUB_NWO="yotamleo/Himmel" STUB_CWD_NWO="yotamleo/Himmel" STUB_PRIVATE=false STUB_PROTECTION="" \
+    run_mog 12 "public origin, empty protection body → exit 12"
+assert_gh_lacks "2869-2b: no merge attempted" "pr merge"
+assert_audit_has "2869-2b: audits not-protected" "reason=not-protected"
+
+# 2869-3. Protection present but NO required status checks → refuse. This is
+# the gate the whole relaxation leans on.
+STUB_NWO="yotamleo/Himmel" STUB_CWD_NWO="yotamleo/Himmel" STUB_PRIVATE=false STUB_PROTECTION="true|0|0" \
+    run_mog 12 "public origin, no required checks → exit 12"
+assert_gh_lacks "2869-3: no merge attempted" "pr merge"
+assert_audit_has "2869-3: audits not-protected" "reason=not-protected"
+
+# 2869-3b. enforce_admins off → refuse, even with required checks present.
+STUB_NWO="yotamleo/Himmel" STUB_CWD_NWO="yotamleo/Himmel" STUB_PRIVATE=false STUB_PROTECTION="false|10|0" \
+    run_mog 12 "public origin, enforce_admins off → exit 12"
+assert_gh_lacks "2869-3b: no merge attempted" "pr merge"
+assert_audit_has "2869-3b: audits not-protected" "reason=not-protected"
+
+# 2869-3c. GitHub's newer `checks` list (instead of `contexts`) also satisfies
+# the gate — both required-status-check shapes count.
+STUB_NWO="yotamleo/Himmel" STUB_CWD_NWO="yotamleo/Himmel" STUB_PRIVATE=false STUB_PROTECTION="true|0|10" STUB_SHA="checksok01" \
+    run_mog 0 "public origin, protection via 'checks' list → merged"
+assert_merge_has "2869-3c: merge pins the certified sha" "--match-head-commit checksok01"
+
+# 2869-4. Some OTHER public repo — not the configured origin — refuses on
+# identity alone, before spending an API read on protection.
+STUB_NWO="someone/Himmel" STUB_CWD_NWO="someone/Himmel" STUB_PRIVATE=false \
+    run_mog 12 "other public repo → exit 12"
+assert_gh_lacks "2869-4: no merge attempted" "pr merge"
+assert_audit_has "2869-4: audits not-private" "reason=not-private"
+assert_gh_lacks "2869-4: refuses on identity before reading protection" "/protection"
+
+# 2869-4b. The constant is deliberately NOT env-overridable: a stray
+# HIMMEL_PUBLIC_ORIGIN_NWO in the ambient environment must not widen the gate.
+STUB_NWO="someone/Himmel" STUB_CWD_NWO="someone/Himmel" STUB_PRIVATE=false HIMMEL_PUBLIC_ORIGIN_NWO="someone/Himmel" \
+    run_mog 12 "ambient HIMMEL_PUBLIC_ORIGIN_NWO does not widen the gate → exit 12"
+assert_gh_lacks "2869-4b: no merge attempted" "pr merge"
+assert_audit_has "2869-4b: audits not-private" "reason=not-private"
+
+# 2869-5. Regression anchor: a private repo is unaffected, and does not pay
+# the protection round-trip at all.
+STUB_PRIVATE=true STUB_NWO="acme/private-repo" STUB_CWD_NWO="acme/private-repo" STUB_SHA="privok01" \
+    run_mog 0 "private repo unaffected → merged"
+assert_gh_lacks "2869-5: private repo never reads protection" "/protection"
+
+# 2869-6. Pre-merge re-read: guard 2b passes, but protection is GONE by the
+# pre-merge re-check (the CI wait window) → refuse.
+STUB_NWO="yotamleo/Himmel" STUB_CWD_NWO="yotamleo/Himmel" STUB_PRIVATE=false STUB_SHA="protrace01" \
+    STUB_PROTECTION="true|10|0" STUB_PROTECTION_PREMERGE_FAIL=1 \
+    run_mog 12 "protection removed during the CI wait → exit 12"
+assert_gh_lacks "2869-6: no merge attempted" "pr merge"
+assert_audit_has "2869-6: audits not-protected-premerge" "reason=not-protected-premerge"
+
+# 2869-6a. Same window, but protection stays readable and merely loses its
+# required checks rather than the endpoint disappearing.
+STUB_NWO="yotamleo/Himmel" STUB_CWD_NWO="yotamleo/Himmel" STUB_PRIVATE=false STUB_SHA="protrace02" \
+    STUB_PROTECTION="true|10|0" STUB_PROTECTION_PREMERGE="true|0|0" \
+    run_mog 12 "required checks removed during the CI wait → exit 12"
+assert_gh_lacks "2869-6a: no merge attempted" "pr merge"
+assert_audit_has "2869-6a: audits not-protected-premerge" "reason=not-protected-premerge"
+
+# 2869-6b. Existing case 9e2 below ("repo made PUBLIC during the CI wait") uses
+# the default STUB_NWO=owner/repo — not the configured origin — so it must
+# still refuse for not-private-premerge; verified there, nothing to add here.
+
+# 2869-7. `required_status_checks: null` (the field absent from the API
+# response) must coalesce through the script's own `// []` filter to an empty
+# list, not slip past as "protected" — proven via REAL jq against synthetic
+# JSON, same technique as the STUB_DEFAULT_BRANCH_NULL cases further below.
+# jq availability is checked locally (the file's shared `have_jq` guard is
+# computed further down, after this block) rather than reusing that variable.
+have_jq_2869=0; command -v jq >/dev/null 2>&1 && have_jq_2869=1
+if [ "$have_jq_2869" = "1" ]; then
+    STUB_NWO="yotamleo/Himmel" STUB_CWD_NWO="yotamleo/Himmel" STUB_PRIVATE=false \
+        STUB_PROTECTION_JSON='{"enforce_admins":{"enabled":true},"required_status_checks":null}' \
+        run_mog 12 "null required_status_checks → exit 12 not-protected"
+    assert_gh_lacks "2869-7: no merge attempted" "pr merge"
+    assert_audit_has "2869-7: audits not-protected" "reason=not-protected"
+else
+    echo "  SKIP: jq not installed — null required_status_checks case (HIMMEL-2869)"
+fi
 
 # 6. Cannot read head SHA → refuse (exit 13).
 STUB_SHA="" run_mog 13 "empty head SHA → exit 13"
@@ -1737,6 +1908,77 @@ if [ "${HIMMEL_1495_SELF:-0}" != "1" ]; then
         fail "RC-2 setup: mutation of the startup unset line was not reproduced cleanly (pre=$rc2_pre post=$rc2_post diff_lines=$rc2_diff)"
     fi
     rm -f "$rc2_mutant"
+fi
+
+# RC-4 (HIMMEL-2869) — the guard-2b widening ("&& ! public_origin_merge_allowed
+# ...") is a single conditional line; prove it is load-bearing rather than
+# vacuously present. Revert JUST that line to the pre-2869 private-only form
+# and confirm case 2869-1's fixture (the configured public origin, protected —
+# which the real script merges) now refuses with the OLD reason instead.
+# shellcheck disable=SC2016  # literal match/replacement against
+# merge-on-green.sh's own source text (unexpanded $is_private/$nwo/etc.) --
+# not a shell expansion.
+rc4_widened_line='if [ "$is_private" != "true" ] && ! public_origin_merge_allowed "$nwo" "$default_branch"; then'
+# shellcheck disable=SC2016  # same reason as above -- literal source text.
+rc4_reverted_line='if [ "$is_private" != "true" ]; then'
+rc4_mutant=$(mktemp "${TMPDIR:-/tmp}/mog-2869-rc4-mutant.XXXXXX")
+if [ -z "$rc4_mutant" ] || [ ! -f "$rc4_mutant" ]; then
+    fail "RC-4 setup: mktemp produced no mutant-script file — refusing to build the fixture on an empty root"
+else
+    awk -v line="$rc4_widened_line" -v repl="$rc4_reverted_line" \
+        '$0==line{print repl; next}{print}' "$MOG" > "$rc4_mutant"
+    rc4_pre=$(grep -Fxc -- "$rc4_widened_line" "$MOG")
+    rc4_post=$(grep -Fxc -- "$rc4_widened_line" "$rc4_mutant")
+    # A SUBSTITUTION (one line replaced by a different line), not a deletion
+    # like RC-2's — `diff` reports that as one `<` (old line) plus one `>`
+    # (new line), i.e. 2, the same shape RC-1's own substitution mutant checks
+    # for above; a bare deletion (RC-2's shape) would be 1.
+    rc4_diff=$(diff "$MOG" "$rc4_mutant" | grep -c '^[<>]')
+    if [ "$rc4_pre" -eq 1 ] && [ "$rc4_post" -eq 0 ] && [ "$rc4_diff" -eq 2 ]; then
+        rc4_tmp=$(mktemp -d "${TMPDIR:-/tmp}/mog-2869-rc4-fixture.XXXXXX")
+        if [ -z "$rc4_tmp" ] || [ ! -d "$rc4_tmp" ]; then
+            fail "RC-4 fixture setup: mktemp -d produced no sandbox — refusing to build fixture paths on an empty root"
+        else
+            rc4_gh="$rc4_tmp/gh.log"; : > "$rc4_gh"
+            rc4_clear="$rc4_tmp/clear.log"; : > "$rc4_clear"
+            rc4_audit="$rc4_tmp/audit.log"
+            MOG_SRC="$rc4_mutant" mog_build_fixture "$rc4_tmp"
+            red_control_run --cwd "$rc4_tmp" \
+                --env GH_LOG="$rc4_gh" --env CLEAR_LOG="$rc4_clear" --env MERGE_ON_GREEN_LOG="$rc4_audit" \
+                --env PATH="$rc4_tmp/bin:$PATH" --env MERGE_ON_GREEN_SLEEP_CMD=: \
+                --env ARMAUTOMERGE=1 --env STUB_NWO="yotamleo/Himmel" --env STUB_CWD_NWO="yotamleo/Himmel" \
+                --env STUB_PRIVATE=false --env STUB_SHA="pubok01" \
+                -- bash "$rc4_tmp/scripts/handover/merge-on-green.sh"
+            # Discriminate on whether the MERGE FIRED, not on the audit
+            # reason= field: the mutant touches ONLY the `if` line, not the
+            # audit call below it — which still reads $PUBLIC_ORIGIN_REASON,
+            # a variable public_origin_merge_allowed (now unreached,
+            # short-circuited by the reverted condition) never populates. That
+            # field reads "" on BOTH the wrong side (refused) and the correct
+            # side (merged, no REFUSED line at all) — zero discriminating
+            # power, the exact "looks identical to one that genuinely
+            # exercised the mutation" trap red-control.sh's own header warns
+            # about. Anchored like merge_line() above (`^pr merge( |$)`), not
+            # a bare substring, so a `--json`-shaped mention could never
+            # satisfy it.
+            rc4_merged=no
+            grep -Eq '^pr merge( |$)' "$rc4_gh" 2>/dev/null && rc4_merged=yes
+            if red_control_assert --label "RC-4" --expect-rc 12 \
+                --observed     "rc=$RED_CONTROL_RC merged=$rc4_merged" \
+                --expect-wrong "rc=12 merged=no" \
+                --correct      "rc=0 merged=yes" \
+                --note "without the guard-2b widening, the configured public origin's protected-branch merge (case 2869-1's fixture) never fires at all"
+            then
+                pass
+            else
+                fail "RC-4 mutant: RED control did not hold (see the RED-control diagnostic above)"
+            fi
+            rm -rf "$rc4_tmp"
+        fi
+    else
+        fail "RC-4 setup: mutation of the guard-2b widening line was not reproduced cleanly (pre=$rc4_pre post=$rc4_post diff_lines=$rc4_diff)"
+    fi
+    rm -f "$rc4_mutant"
 fi
 
 

--- a/scripts/hooks/initiative-runbook.md
+++ b/scripts/hooks/initiative-runbook.md
@@ -49,13 +49,19 @@ Steps run in this canonical order; only the tokens on the pointer's
   Armed auto-merge (`ARMAUTOMERGE=1`, HIMMEL-1042) is
   `bash scripts/handover/merge-on-green.sh` (exactly, to match the standing
   allow-rule) — it gates on `check-ci.sh` green + a certified head SHA and
-  merges only then, but it also hard-refuses (exit 12) any repo that is not
-  confirmed PRIVATE, and `origin` has been public since the HIMMEL-2705
-  cutover — so on this repo the armed path is **unavailable** until
-  HIMMEL-2869 lands; until then, use `scripts/handover/pr-merge.sh` instead
-  (plain-first; defer to the operator on real branch protection; never
-  `--admin`). Advisory — branch protection still applies. A blocked gate on
-  this branch parks it and moves to the next queue item — never retry-loop;
+  merges only then. It admits a NON-private repo only when that repo is the ONE
+  configured public origin AND a live read shows branch protection with
+  required status checks on the base branch (HIMMEL-2869); any other public
+  repo, and a protection read that is missing, empty or unreadable, still
+  refuse (exit 12). `origin` is that configured origin, so the armed path IS
+  available on this repo. The protection read is re-done fresh immediately
+  before merging, and every other gate is unchanged. Never `--admin`: the
+  approval requirement lives in the ruleset and GitHub enforces it at merge
+  time, so a merge refused for want of an approval is the rule working — leave
+  the PR open and report it. `scripts/handover/pr-merge.sh` (plain-first)
+  remains the alternative. Advisory — branch protection still applies.
+  A blocked gate on this branch parks it and moves to the next queue item —
+  never retry-loop;
   see
   [Park protocol](../../docs/handover/overnight-mode.md#park-protocol-himmel-2128).
 

--- a/scripts/hooks/initiative-runbook.md
+++ b/scripts/hooks/initiative-runbook.md
@@ -50,11 +50,12 @@ Steps run in this canonical order; only the tokens on the pointer's
   `bash scripts/handover/merge-on-green.sh` (exactly, to match the standing
   allow-rule) — it gates on `check-ci.sh` green + a certified head SHA and
   merges only then. It admits a NON-private repo only when that repo is the ONE
-  configured public origin AND a live read shows branch protection with
-  required status checks on the base branch (HIMMEL-2869); any other public
-  repo, and a protection read that is missing, empty or unreadable, still
-  refuse (exit 12). `origin` is that configured origin, so the armed path IS
-  available on this repo. The protection read is re-done fresh immediately
+  configured public origin AND a live read shows branch protection on the base
+  branch with BOTH `enforce_admins` enabled and a non-empty
+  required-status-checks list (HIMMEL-2869); any other public repo, and a
+  protection read that is missing, empty or unreadable, still refuse (exit 12).
+  `origin` is that configured origin, so the armed path IS available on this
+  repo. The protection read is re-done fresh immediately
   before merging, and every other gate is unchanged. Never `--admin`: the
   approval requirement lives in the ruleset and GitHub enforces it at merge
   time, so a merge refused for want of an approval is the rule working — leave


### PR DESCRIPTION
## Why

`scripts/handover/merge-on-green.sh` hard-refused any repo not confirmed PRIVATE. Since the HIMMEL-2705 cutover made `origin` the public `yotamleo/Himmel`, it exits 12 with `reason=not-private` on **every** PR — the armed auto-merge path has been dead repo-wide. Surfaced as `[codex-1]` by the critic panel on HIMMEL-2865, verified in source, adjudicated `agreed`.

## What changed

The private-only boundary widens for **exactly one named public repo**, and only while GitHub itself is enforcing required status checks on the branch being merged into. One helper, `public_origin_merge_allowed`, is used by **both** guard 2b and the pre-merge re-check:

| Step | Behaviour | Audit reason |
|---|---|---|
| Identity | repo must equal `HIMMEL_PUBLIC_ORIGIN_NWO` (a fixed literal). Checked **first**, so any other public repo refuses before spending an API read | `not-private` |
| Protection | live `gh api repos/<nwo>/branches/<default>/protection`: `enforce_admins.enabled == true` **and** a non-empty `contexts` **or** `checks` list | `not-protected` |
| Pre-merge | the same predicate, **re-read fresh** — never guard 2b's cached result | `not-private-premerge` / `not-protected-premerge` |

Fail-closed on every unreadable field: 404, empty body, absent `required_status_checks` (`// []` coalesce), non-numeric counts, or an undeterminable default branch all refuse. Nothing is ever assumed protected.

The re-read at the pre-merge site is the point of that site: branch protection can be weakened during `check-ci.sh`'s multi-minute watch exactly as `isPrivate` and the base can.

**Every other gate is untouched** — `ARMAUTOMERGE` opt-in, `check-ci.sh` exit 0, CR review at head, `--match-head-commit` head binding, base == default branch, audit-sink preflight, `MERGED` confirmed by polling. No `--admin` is added.

## Two deliberate design calls

**The constant is not environment-overridable.** The file's own GATE INTEGRITY contract forbids env seams on the merge gate, and this one would be the *widening* kind — an ambient value would re-enable the arbitrary-public-repo merge this change exists to prevent. Case `2869-4b` pins the non-seam: it exports a stray `HIMMEL_PUBLIC_ORIGIN_NWO` and asserts the outcome does not change.

**It is not a reuse of `merge-public-on-green.sh`'s `CR_PUBLIC_REPO`** (same default value, different name on purpose). That lever's pin *narrows* what a human-only, `CLAUDECODE`-self-refusing chokepoint may touch, so its overridability costs nothing an agent could reach. Here the binding *widens* a safety boundary, so sharing the name or its overridability would smuggle a widening seam in under a narrowing one's reputation. `docs/internals/enforcement.md` already records keeping the two scripts separate rather than building a shared "which repo class" switch.

## Reviews are GitHub's to enforce, not this script's

On this repo the approval requirement (1 approving review + code-owner review) lives in the **ruleset** `protect-main`, so `/branches/main/protection` returns `required_pull_request_reviews: null` even though approvals **are** enforced. The helper therefore reads only `required_status_checks` + `enforce_admins` and infers nothing about reviews — with a comment saying exactly that, so the null is not later "fixed". A `gh pr merge` refused for want of an approval is a finding to report, never something to bypass.

Precondition verified live: `enforce_admins=true`, `strict=true`, **10 required contexts and 10 checks**.

## Tests

`272 passed, 0 failed` (was 258 before this branch). 12 new cases: the positive path, both required-check shapes (`contexts`-only and `checks`-only), unreadable / empty-body / no-checks / `enforce_admins`-off refusals, a different public repo, the constant's non-seam, the private-repo regression anchor (which must not pay the protection round-trip at all), both pre-merge re-read failure modes, and a `required_status_checks: null` payload driven through the script's **own** `--jq` filter via real `jq`.

**RED control.** Captured before `merge-on-green.sh` was touched, case `2869-1` failed:

```
FAIL: configured public origin under branch protection → merged — expected exit 0, got 12
  (err: merge-on-green: repo yotamleo/Himmel is not confirmed PRIVATE (isPrivate='false') — refusing.)
merge-on-green: 252 passed, 13 failed
```

`RC-4` makes that permanent: it builds a scratch mutant with just the guard-2b line reverted to the private-only form and asserts the **specific** predicted wrong value, on two independent dimensions —

```
RC-4 RED confirmed: the mutant ran (rc=12) and produced the predicted wrong value
rc=12 merged=no (the real script produces rc=0 merged=yes)
```

so the positive case cannot pass vacuously. The stub `gh` grows a protection arm that fails closed on any api path it does not recognize.

**CR round 1 raised one Suggestion, `[codex-1]`, and it was right** — every allow-path case fed the stub its *pre-joined* protection string, so the script's own `--jq` filter only ever ran on `2869-7`, a **refusal** case. A filter mutated to reject every real response would have left the whole suite green. Fixed rather than deferred, as case `2869-1b`: realistic GitHub-shaped protection JSON through the real filter, asserting a value the gate **accepts**. Confirmed non-vacuous out-of-band before committing — against a scratch mutant forcing both length computations to 0, exactly the two `2869-1b` assertions fail (270/2) while `2869-7` and `RC-4` stay green.

Also green: `shellcheck` 0.11.0 clean on both files, and all 14 other suites referencing `merge-on-green.sh` (including `scripts/ci/test-run-shell-tests.sh`).

## Follow-up in this PR

Five doc sites still describe the helper as private-only and say the armed path is "unavailable until HIMMEL-2869 lands". They are reconciled in a second commit once HIMMEL-2865 merges, to avoid colliding with the branch editing them right now.

Ticket: HIMMEL-2869

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbdmjWg3PceNCjQwcfNJJ3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The configured public repository can now pass the merge gate when required branch protections are enabled.
  * Protection settings are revalidated immediately before merging.

* **Bug Fixes**
  * Public repositories with missing, unreadable, weakened, or malformed protection settings are safely refused.
  * Merge refusals and audit messages now distinguish unsupported public repositories from inadequate protection.

* **Documentation**
  * Updated merge guidance to describe public-origin eligibility and protection requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->