### PR TITLE
chore(upstreams): [HIMMEL-2866] bump graphify 0.9.56 -> 0.9.57 and cli-proxy-api 7.2.154 -> 7.2.155 (fork-drift #518)

### DIFF
--- a/scripts/lib/graphify-bin.sh
+++ b/scripts/lib/graphify-bin.sh
@@ -50,7 +50,7 @@
 # (HIMMEL-891) -- without carrying a fork. A pin bump is a reviewed change to this
 # line, paired with `synced_base` in scripts/upstreams.json so the nightly
 # fork-drift guard stays truthful.
-_graphify_version() { printf '%s\n' "${GRAPHIFY_VERSION:-0.9.56}"; }
+_graphify_version() { printf '%s\n' "${GRAPHIFY_VERSION:-0.9.57}"; }
 _graphify_pypi_name() { printf '%s\n' "graphifyy"; }
 # The default `uv tool install` package spec includes the native Kimi backend's
 # runtime dependencies (openai + tiktoken). Recorded non-empty extras are still

--- a/scripts/setup/cli-proxy-lane.ps1
+++ b/scripts/setup/cli-proxy-lane.ps1
@@ -63,7 +63,7 @@ $Cfg     = Join-Path $Dir 'config.yaml'
 $Vbs     = Join-Path $Dir 'start-hidden.vbs'   # GUI-subsystem launcher the logon task runs (HIMMEL-1822)
 $ApiKey  = 'himmel-local-claudex'   # local proxy token; must match config.yaml api-keys
 $Port    = 8317
-$Version = '7.2.154'
+$Version = '7.2.155'
 $Release = "https://github.com/router-for-me/CLIProxyAPI/releases/download/v$Version/CLIProxyAPI_${Version}_windows_amd64.zip"
 
 function Test-OAuth {

--- a/scripts/upstreams.json
+++ b/scripts/upstreams.json
@@ -139,7 +139,7 @@
       "kind": "tag_release",
       "mode": "base",
       "tracked_repo": "Graphify-Labs/graphify",
-      "synced_base": "0.9.56",
+      "synced_base": "0.9.57",
       "latest_source": "release",
       "version_pin": { "file": "scripts/lib/graphify-bin.sh", "template": "GRAPHIFY_VERSION:-{version}" },
       "tier": "A",
@@ -150,7 +150,7 @@
       "kind": "tag_release",
       "mode": "base",
       "tracked_repo": "router-for-me/CLIProxyAPI",
-      "synced_base": "7.2.154",
+      "synced_base": "7.2.155",
       "version_pin": { "file": "scripts/setup/cli-proxy-lane.ps1", "template": "$Version = '{version}'" },
       "tier": "A",
       "note": "CLIProxyAPI codex-lane proxy (HOST process on 127.0.0.1:8317; installed + run by scripts/setup/cli-proxy-lane.ps1). Added to the nightly drift machinery (HIMMEL-1451) so a new upstream release SURFACES as a drift finding instead of needing manual surgery: v7.2.77 threw ~3-min bursts of instant upstream 502s every ~25 min that killed codex-adv renders (Claude Code retries 502s but the companion's render turn does not), and the validated fix was a manual swap to v7.2.113 -- both legs completed clean that night. AUTO-BUMP policy is deliberately SURFACE-ONLY and matches the existing rows' conservatism: apply-drift-bump.sh moves the in-repo pin literal ($Version in cli-proxy-lane.ps1) and synced_base TOGETHER; the drift leg lands that as a PR. Since HIMMEL-2134 (#1928), himmel-update.sh's advisory sync_cli_proxy step DOES roll the host itself, machine-local and pin-aware: every run compares the host's live version stamp to this pin and, when genuinely behind, runs cli-proxy-lane.ps1 -Install -Restart -- never downgrades and never guesses on an uncomparable stamp (rc 1/2 both leave the host alone), and the lane's own Assert-BounceSafe refuses to bounce a live codex-lane render rather than kill it. -Force is the override for the refused-bounce case specifically (it bypasses Assert-BounceSafe only); no pwsh on PATH or an unparseable stamp instead want a plain manual -Install -Restart run on the host, or an immediate roll ahead of the next update. Default tag-mode (highest stable tag, prereleases excluded -- CLIProxyAPI tags are monotonic, so no latest_source override is needed); synced_base lacks the leading 'v' but the guard normalizes both sides before comparing (v7.2.115 tag == 7.2.115 base). tracked_repo is the TRUE upstream (router-for-me/CLIProxyAPI)."


### PR DESCRIPTION
## What

Mechanical drift-fix bump of two `tag_release`/`mode: base` upstream pins, applied by `scripts/upstreams/apply-drift-bump.sh` (moves the in-repo pin literal and `synced_base` together, never hand-edited):

- **graphify**: `check-plugin-drift.sh` reported `BEHIND (Graphify-Labs/graphify latest tag v0.9.57; installed 0.9.56 — upgrade)` → bumped 0.9.56 → 0.9.57 (`scripts/upstreams.json`, `scripts/lib/graphify-bin.sh`)
- **cli-proxy-api**: `check-plugin-drift.sh` reported `BEHIND (router-for-me/CLIProxyAPI latest tag v7.2.155; installed 7.2.154 — upgrade)` → bumped 7.2.154 → 7.2.155 (`scripts/upstreams.json`, `scripts/setup/cli-proxy-lane.ps1`)

Both entries re-verified `CURRENT` against the guard after the bump. Tracking issue: fork-drift #518.

Applied by the `/drift-fix` runbook run by hand as the **HIMMEL-2866** re-verification of that runbook on the post-cutover single-repo flow (this is the first run of the runbook since `origin` became the public repo).

## known-findings checklist (step 2.8, both non-issues — deliberately not fixed)

- **ps1-twin-parity** (`cli-proxy-lane.ps1` changed, `cli-proxy-lane.sh` twin unchanged): deliberate — the registry's `version_pin.file` for `cli-proxy-api` names only `cli-proxy-lane.ps1`; `apply-drift-bump.sh` only ever touches the file the registry names. The `.sh` twin carries its own independent pin, out of scope for this mechanical drift bump.
- **test-coverage-gap** (`graphify-bin.sh`, `cli-proxy-lane.ps1` changed, no new test): the change is a pin-literal value only, no new behavior. The mechanism that applied it is already exercised by `scripts/upstreams/test-apply-drift-bump.sh` (ran clean — "all checks passed") and `scripts/lib/test-graphify-bin.sh` (ran clean — pass=401 fail=0).

## Test plan

- [x] `bash scripts/check-plugin-drift.sh` — both entries CURRENT after the bump
- [x] `bash scripts/upstreams/test-apply-drift-bump.sh` — all checks passed
- [x] `bash scripts/lib/test-graphify-bin.sh` — pass=401 fail=0
- [x] `/pr-check` — critic panel (codex, paid) responded, 0 findings; marker cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lg5KQJqhMpYwzuLthYScTh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the bundled Graphify tooling to version 0.9.57.
  - Updated the bundled CLI proxy tooling to version 7.2.155.
  - Existing version override options remain supported.
  - Tracked tooling versions are now consistent across setup and release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->