### PR TITLE
feat(ci): [HIMMEL-2872] shard shell-unit across a 6-runner matrix behind the unchanged shell-unit (ubuntu-latest) required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,15 @@ on:
   # PR gating (HIMMEL-594): the cheap ubuntu-only jobs run on every PR so a
   # non-conventional commit, a secret, a shellcheck warning, or a failing shell
   # suite blocks merge. The EXPENSIVE multi-OS matrix stays nightly-only — the
-  # shell-unit matrix below expands to windows+macOS only on `schedule`
+  # shell-unit-shard matrix below expands to windows+macOS only on `schedule`
   # (or a dispatch with force_all_os), so a PR never triggers the paid legs.
+  # `shell-unit` itself (HIMMEL-2872) is the aggregating gate over that
+  # matrix — see its own comment block below.
   pull_request:
   # Post-merge verification (HIMMEL-511): re-run the cheap ubuntu gates when code
   # lands on main, catching anything that reached main outside the PR path. The
-  # shell-unit matrix stays ubuntu-only on `push` (the paid windows/macOS legs are
-  # schedule-only), so this adds no multi-OS cost.
+  # shell-unit-shard matrix stays ubuntu-only on `push` (the paid windows/macOS
+  # legs are schedule-only), so this adds no multi-OS cost.
   push:
     branches: [main]
   workflow_dispatch:
@@ -410,13 +412,25 @@ jobs:
   # scoped to the non-ubuntu legs): their per-suite PASS/FAIL is advisory in the
   # job log while ubuntu stays the required gate. Tightening the new OSes to
   # gating-green is the data-driven follow-up (HIMMEL-494 phase 3).
-  shell-unit:
+  #
+  # This is the working matrix — 6-way sharded per OS (HIMMEL-2872) so the
+  # ubuntu legs finish in parallel instead of serially. `shell-unit` below is
+  # the aggregating gate that rolls this matrix up into the one required
+  # check-run context branch protection names.
+  shell-unit-shard:
     strategy:
       fail-fast: false
       matrix:
         os: ${{ (github.event_name == 'schedule' || inputs.force_all_os)
                && fromJSON('["ubuntu-latest","windows-latest","macos-latest"]')
                || fromJSON('["ubuntu-latest"]') }}
+        # shard: [1..6] fans run-shell-tests.sh across 6 runners (HIMMEL-2872).
+        # The `6` here and the `/6` in the run step below are two spellings of
+        # the same number — GitHub Actions has no way to derive one from the
+        # other (strategy.job-total counts os×shard, not shard alone), so a
+        # change to the shard count must edit both or the split silently stops
+        # being a partition.
+        shard: [1, 2, 3, 4, 5, 6]
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
     steps:
@@ -466,7 +480,7 @@ jobs:
       # SUITE_CHANGED_SINCE: only on pull_request, where a base SHA exists —
       # a docs-only PR then skips the whole corpus (run-shell-tests.sh's own
       # docs-only fast lane); push/schedule/dispatch have no PR base to diff.
-      - run: bash scripts/ci/run-shell-tests.sh
+      - run: bash scripts/ci/run-shell-tests.sh --shard ${{ matrix.shard }}/6
         env:
           FAIL_LOG_DIR: failed-suite-logs
           SUITE_TIER_MODE: ${{ (github.event_name == 'schedule' || inputs.force_all_os) && 'all' || 'fast' }}
@@ -475,7 +489,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: shell-unit-failed-logs-${{ matrix.os }}
+          name: shell-unit-failed-logs-${{ matrix.os }}-shard${{ matrix.shard }}
           path: failed-suite-logs/
           if-no-files-found: ignore
           retention-days: 14
@@ -525,3 +539,41 @@ jobs:
       #
       # - name: Focus/tick correlator suite
       #   run: node --test scripts/observability/focus-tick-correlate.test.mjs
+
+  # Aggregating gate (HIMMEL-2872). Four things worth knowing before touching
+  # this job:
+  #
+  # 1. The single-value `os` matrix below is deliberate and load-bearing: it
+  #    is what makes the check-run context `shell-unit (ubuntu-latest)` rather
+  #    than a bare `shell-unit`, keeping the required branch-protection
+  #    context byte-for-byte identical to what it was before the work above
+  #    was sharded. Sharding the work must not rename the gate.
+  # 2. `needs.shell-unit-shard.result` is the matrix ROLLUP, `success` only
+  #    when every leg that CAN fail the matrix succeeded. A job-level
+  #    `continue-on-error` failure (the nightly windows/macOS legs) is NOT
+  #    counted against that rollup, so those legs stay advisory exactly as
+  #    they are today — this job never has to name any OS itself.
+  # 3. `if: always()` plus the explicit `!= success` test below is the
+  #    fail-CLOSED shape: `failure`, `cancelled` AND `skipped` all redden this
+  #    job. A bare `needs:` without `always()` would SKIP this job whenever a
+  #    shard failed — and a required check that never reports leaves the PR
+  #    hanging rather than red.
+  # 4. No checkout, no setup: this job is a verdict, not work.
+  shell-unit:
+    needs: shell-unit-shard
+    if: always()
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Every gating shell-unit shard must have passed
+        env:
+          SHARDS_RESULT: ${{ needs.shell-unit-shard.result }}
+        run: |
+          echo "shell-unit-shard matrix rollup: $SHARDS_RESULT"
+          if [ "$SHARDS_RESULT" != "success" ]; then
+            echo "::error::shell-unit shards did not all pass (matrix rollup: $SHARDS_RESULT) — see the shell-unit-shard jobs on this run."
+            exit 1
+          fi
+          echo "OK: every gating shell-unit shard passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,8 +413,11 @@ jobs:
   # job log while ubuntu stays the required gate. Tightening the new OSes to
   # gating-green is the data-driven follow-up (HIMMEL-494 phase 3).
   #
-  # This is the working matrix — 6-way sharded per OS (HIMMEL-2872) so the
-  # ubuntu legs finish in parallel instead of serially. `shell-unit` below is
+  # This is the working matrix — sharded per OS (HIMMEL-2872) so the ubuntu
+  # legs finish in parallel instead of serially. The shard COUNT is spelled in
+  # exactly two places, both below and both of which must agree: the `shard:`
+  # matrix list and the `--shard …/<n>` run argument. Deliberately not repeated
+  # here — a third copy is a third thing to forget. `shell-unit` below is
   # the aggregating gate that rolls this matrix up into the one required
   # check-run context branch protection names.
   shell-unit-shard:
@@ -424,13 +427,18 @@ jobs:
         os: ${{ (github.event_name == 'schedule' || inputs.force_all_os)
                && fromJSON('["ubuntu-latest","windows-latest","macos-latest"]')
                || fromJSON('["ubuntu-latest"]') }}
-        # shard: [1..6] fans run-shell-tests.sh across 6 runners (HIMMEL-2872).
-        # The `6` here and the `/6` in the run step below are two spellings of
+        # shard: [1..8] fans run-shell-tests.sh across 8 runners (HIMMEL-2872).
+        # The `8` here and the `/8` in the run step below are two spellings of
         # the same number — GitHub Actions has no way to derive one from the
         # other (strategy.job-total counts os×shard, not shard alone), so a
         # change to the shard count must edit both or the split silently stops
-        # being a partition.
-        shard: [1, 2, 3, 4, 5, 6]
+        # being a partition. Went from 6 to 8 because 6 measured an 18m23s
+        # slowest shard (3m18s fastest) — round-robin, not the count, dumped
+        # the corpus's two heaviest suites onto one shard (719s of its 1065s);
+        # replaying measured durations predicts 9.9m at 8 but 10.7m at 12, so
+        # more shards isn't monotonically better — a duration-aware split is
+        # the real fix (follow-up).
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
     steps:
@@ -480,7 +488,7 @@ jobs:
       # SUITE_CHANGED_SINCE: only on pull_request, where a base SHA exists —
       # a docs-only PR then skips the whole corpus (run-shell-tests.sh's own
       # docs-only fast lane); push/schedule/dispatch have no PR base to diff.
-      - run: bash scripts/ci/run-shell-tests.sh --shard ${{ matrix.shard }}/6
+      - run: bash scripts/ci/run-shell-tests.sh --shard ${{ matrix.shard }}/8
         env:
           FAIL_LOG_DIR: failed-suite-logs
           SUITE_TIER_MODE: ${{ (github.event_name == 'schedule' || inputs.force_all_os) && 'all' || 'fast' }}

--- a/scripts/ci/run-shell-tests.sh
+++ b/scripts/ci/run-shell-tests.sh
@@ -2521,6 +2521,15 @@ if [ "$shard_given" -eq 1 ]; then
   # kill the run with a bash arithmetic error instead of this readable refusal.
   case "$_shard_i" in ''|*[!0-9]*) _shard_bad=1 ;; esac
   case "$_shard_n" in ''|*[!0-9]*) _shard_bad=1 ;; esac
+  # Bound the digit-string LENGTH before $(( )) converts it. Bash arithmetic
+  # is 64-bit and wraps SILENTLY on overflow (rc=0, no diagnostic), so a
+  # 20-digit <n> becomes a small positive number that then PASSES the range
+  # test below and selects a different partition — the run reports green over
+  # a split nobody asked for, which is precisely the silent misconfiguration
+  # this refusal exists to catch. Ten or more digits is refused outright: that
+  # is far below the wrap point and absurdly above any real shard count.
+  case "$_shard_i" in ??????????*) _shard_bad=1 ;; esac
+  case "$_shard_n" in ??????????*) _shard_bad=1 ;; esac
   if [ "$_shard_bad" -eq 0 ]; then
     shard_total=$((10#$_shard_n))
     shard_offset=$((10#$_shard_i - 1))

--- a/scripts/ci/run-shell-tests.sh
+++ b/scripts/ci/run-shell-tests.sh
@@ -43,6 +43,7 @@
 #                                                        # SUITE_REPORT_PR=N; HIMMEL-2383) —
 #                                                        # never default-on, never posted
 #                                                        # without one of these set
+#   --shard <i>/<n>      run only slice <i> of <n> of the final run list
 #
 #   Flags may appear before or after the scan-root.
 #   scan-root defaults to "scripts" when omitted.
@@ -61,8 +62,9 @@
 #             (a resolved-to-nothing scan root is a misconfiguration, not a
 #             pass — HIMMEL-1128), OR the run budget expired with suites still
 #             unrun; 2 — REFUSED, either another full-suite run already holds
-#             the machine lock (HIMMEL-1338) or SUITE_TIER_MODE was set to
-#             something other than fast/extended/all (HIMMEL-2120);
+#             the machine lock (HIMMEL-1338), SUITE_TIER_MODE was set to
+#             something other than fast/extended/all (HIMMEL-2120), or --shard
+#             was given a malformed <i>/<n> value (HIMMEL-2872);
 #             3 — ABORTED, the scan root vanished or was replaced under the
 #             live run (HIMMEL-2517); 4 — ABORTED, an rc=127 storm means
 #             almost nothing here could execute (HIMMEL-2517); 5 — EXPIRED,
@@ -2405,6 +2407,11 @@ suite_lock_release() {
 # --------------------------------------------------------------------------
 list_only=0
 scan=""
+# Shard selection (HIMMEL-2872). Flag-only, no env default: the CI workflow is
+# the only caller and an ambient SUITE_SHARD would be one more way for a stray
+# export to silently narrow an unrelated run's plan.
+shard_spec=""
+shard_given=0
 # OPT-IN conditional filter (HIMMEL-1589). Env is the default; the flag overrides.
 changed_since="${SUITE_CHANGED_SINCE:-}"
 # OPT-IN after-report PR comment (HIMMEL-2383). Env is the default; the flag
@@ -2450,6 +2457,15 @@ while [ "$#" -gt 0 ]; do
       report_pr="$2"
       shift 2
       ;;
+    --shard)
+      if [ "$#" -lt 2 ]; then
+        echo "run-shell-tests.sh: --shard requires an argument of the form <i>/<n>" >&2
+        exit 2
+      fi
+      shard_spec="$2"
+      shard_given=1
+      shift 2
+      ;;
     -*)
       echo "run-shell-tests.sh: unknown flag: $1" >&2
       exit 1
@@ -2479,6 +2495,45 @@ case "$report_pr" in
     fi
     ;;
 esac
+
+# Resolve --shard (HIMMEL-2872). <i>/<n> selects one slice of the FINAL run
+# list so CI can fan this job across n runners behind one aggregating check.
+#
+# REFUSED (rc 2, this runner's bad-configuration-value code — the same one an
+# invalid SUITE_TIER_MODE takes) rather than ignored: a typo'd spec that fell
+# through to a full run would multiply the CI bill by n while every shard
+# reported green over the same 466 suites, hiding the misconfiguration behind
+# a pass. $shard_given, not `[ -n "$shard_spec" ]`, so `--shard ''` is a
+# refusal too and not a silent no-op.
+shard_total=0     # 0 = sharding off, every suite runs
+shard_offset=0    # 0-based form of <i>, compared against the run-list index
+if [ "$shard_given" -eq 1 ]; then
+  _shard_bad=0
+  case "$shard_spec" in
+    */*/*) _shard_bad=1 ;;   # more than one separator
+    */*)   ;;                # the only accepted shape
+    *)     _shard_bad=1 ;;   # no separator at all
+  esac
+  _shard_i="${shard_spec%%/*}"
+  _shard_n="${shard_spec#*/}"
+  # Digits only — no sign, no whitespace, nothing empty. The `10#` below is
+  # what makes a leading zero safe: bare $((08)) is a base-8 literal and would
+  # kill the run with a bash arithmetic error instead of this readable refusal.
+  case "$_shard_i" in ''|*[!0-9]*) _shard_bad=1 ;; esac
+  case "$_shard_n" in ''|*[!0-9]*) _shard_bad=1 ;; esac
+  if [ "$_shard_bad" -eq 0 ]; then
+    shard_total=$((10#$_shard_n))
+    shard_offset=$((10#$_shard_i - 1))
+    if [ "$shard_total" -lt 1 ] || [ "$shard_offset" -lt 0 ] || \
+       [ "$shard_offset" -ge "$shard_total" ]; then
+      _shard_bad=1
+    fi
+  fi
+  if [ "$_shard_bad" -eq 1 ]; then
+    printf "run-shell-tests.sh: --shard must be <i>/<n> with 1 <= i <= n and n >= 1, got '%s'\n" "$shard_spec" >&2
+    exit 2
+  fi
+fi
 
 # Apply default scan root after parsing so a leading --list doesn't collide.
 scan="${scan%/}"      # strip any trailing slash so the relpath prefix-strip works
@@ -2785,6 +2840,10 @@ if [ "$list_only" -eq 0 ]; then
 fi
 
 pass=0 fail=0 skip=0 ran=0
+# Counts run-eligible suites (post every skip filter) for the --shard split
+# below; advances for every one of them regardless of which shard claims it
+# (HIMMEL-2872).
+run_index=0
 # HIMMEL-2517 — how many failures were rc=127 (command or path not found).
 rc127=0
 failed_suites=""
@@ -2887,6 +2946,10 @@ if [ "$docs_only_skip_active" -eq 1 ]; then
   plan_narrowed=1
   plan_narrowed_why="${plan_narrowed_why}docs-only fast lane, "
 fi
+if [ "$shard_total" -gt 0 ]; then
+  plan_narrowed=1
+  plan_narrowed_why="${plan_narrowed_why}--shard ${shard_spec}, "
+fi
 plan_narrowed_why="${plan_narrowed_why%, }"
 
 # fd 3, not stdin. With `done < "$suites_file"` the loop BODY inherits the
@@ -2964,6 +3027,31 @@ while IFS= read -r suite <&3; do
     skip=$((skip + 1))
     printf '[SKIP] %s — capability: %s not on PATH — %s\n' "$suite" "$_cap_tool" "$_cap_reason"
     continue
+  fi
+
+  # Shard filter (HIMMEL-2872) — LAST, after every filter above, so the split
+  # is over the FINAL run list. Splitting raw discovery instead would let a
+  # host's SKIP_LIST/tier/capability skips fall unevenly across shards, so one
+  # runner carries the corpus while five idle.
+  #
+  # Round-robin on the run-list index, not a contiguous block. Discovery is
+  # `sort`ed and every filter above is deterministic, so shard i selects the
+  # same suites on every runner and the shards are an EXACT partition: their
+  # union is the unsharded run list and they are pairwise disjoint. Anything
+  # weaker drops suites off the gate while all n shards report green — the
+  # HIMMEL-1128 false-green class, reached through the parallelism instead of
+  # through discovery. Round-robin also balances by construction here: 466
+  # suites, a 52s maximum, and most of them under 5s.
+  #
+  # $run_index counts run-ELIGIBLE suites and advances for EVERY one of them,
+  # whether or not this shard claims it. That shared counter is precisely what
+  # makes the partition exact — a per-shard counter would not.
+  #
+  # A duration-ledger bin-pack is the follow-up; round-robin is v1.
+  if [ "$shard_total" -gt 0 ]; then
+    _shard_mine=$(( run_index % shard_total == shard_offset ))
+    run_index=$((run_index + 1))
+    [ "$_shard_mine" -eq 1 ] || continue
   fi
 
   if [ "$list_only" -eq 1 ]; then
@@ -3397,6 +3485,11 @@ if [ "$ran" -eq 0 ]; then
   if [ "$docs_only_skip_active" -eq 1 ]; then
     echo "OK: docs-only diff — 0 shell suites needed ($skip skipped)"
     exit 0
+  fi
+  if [ "$shard_total" -gt 0 ]; then
+    printf 'ERROR: shard %s ran 0 suites under scan root "%s" — refusing to report green. The run list held %s suite(s) across %s shard(s), so this shard was assigned nothing: either the shard count exceeds the run list, or every suite it was assigned was skipped. Both are misconfigurations, not a pass.\n' \
+      "$shard_spec" "$scan" "$run_index" "$shard_total" >&2
+    exit 1
   fi
   printf 'ERROR: no suites ran under scan root "%s" (all discovered suites were skipped) — refusing to report green.\n' "$scan" >&2
   exit 1

--- a/scripts/ci/test-run-shell-tests.sh
+++ b/scripts/ci/test-run-shell-tests.sh
@@ -2880,7 +2880,14 @@ SHEOF
 run_lines() { grep -F '[RUN ] ' <<< "$1" | sed 's/^\[RUN \] //'; }
 
 # 22a — the union of --list --shard i/3 equals plain --list, pairwise disjoint.
-sb22a=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22a.XXXXXX"); mk_shard_sandbox "$sb22a" 7
+#
+# An unchecked mktemp -d here leaves the sandbox variable empty, and every
+# fixture write below then resolves against that empty path — the filesystem
+# root — instead of an isolated sandbox; fail (not a silent skip) is used so
+# a failed allocation reddens the suite rather than passing quietly.
+sb22a=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22a.XXXXXX") || { fail "22a: mktemp failed"; sb22a=""; }
+if [ -n "$sb22a" ]; then
+mk_shard_sandbox "$sb22a" 7
 full22a=$(run_lines "$(bash "$RUNNER" --list "$sb22a" 2>&1)")
 s122a=$(run_lines "$(bash "$RUNNER" --list --shard 1/3 "$sb22a" 2>&1)")
 s222a=$(run_lines "$(bash "$RUNNER" --list --shard 2/3 "$sb22a" 2>&1)")
@@ -2910,6 +2917,7 @@ else
   fail "22c: --shard 1/1 diverged from the full plan; full='$full22a' got='$one22c'"
 fi
 rm -rf "$sb22a"
+fi
 
 # 22d — malformed values are REFUSED at rc 2 (the runner's "bad configuration
 # value" code, the same one an invalid SUITE_TIER_MODE takes), never silently
@@ -2919,7 +2927,9 @@ rm -rf "$sb22a"
 # bash arithmetic wraps silently on 64-bit overflow (rc=0, no diagnostic), so
 # without that bound '1/18446744073709551618' converts to a valid-looking
 # '1/2' and quietly runs a partition nobody asked for.
-sb22d=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22d.XXXXXX"); mk_shard_sandbox "$sb22d" 3
+sb22d=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22d.XXXXXX") || { fail "22d: mktemp failed"; sb22d=""; }
+if [ -n "$sb22d" ]; then
+mk_shard_sandbox "$sb22d" 3
 for spec22d in '0/3' '4/3' 'abc' '1/0' '1/2/3' '/3' '1/' '-1/3' '1/-3' 'x/y' '' '3' \
                '1/18446744073709551618' '1/99999999999999999999' '99999999999999999999/3'; do
   out22d=$(bash "$RUNNER" --list --shard "$spec22d" "$sb22d" 2>&1); rc22d=$?
@@ -2937,10 +2947,13 @@ else
   fail "22d: --shard with no argument -> expected rc 2, got rc=$rc22d2; out: $out22d2"
 fi
 rm -rf "$sb22d"
+fi
 
 # 22e — a shard that is assigned NOTHING is a refusal, not a pass. This is the
 # n > run-list-length case, which is the shape a mis-sized CI matrix takes.
-sb22e=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22e.XXXXXX"); mk_shard_sandbox "$sb22e" 2
+sb22e=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22e.XXXXXX") || { fail "22e: mktemp failed"; sb22e=""; }
+if [ -n "$sb22e" ]; then
+mk_shard_sandbox "$sb22e" 2
 out22e=$(bash "$RUNNER" --shard 3/3 "$sb22e" 2>&1); rc22e=$?
 if [ "$rc22e" -eq 1 ] && grepq "$out22e" -F 'shard 3/3 ran 0 suites'; then
   pass "22e: an empty shard refuses (exit 1) and names itself"
@@ -2956,6 +2969,7 @@ else
   fail "22e: expected shards 1/3 and 2/3 to pass; rc1=$rc22e1 rc2=$rc22e2; out1: $out22e1 out2: $out22e2"
 fi
 rm -rf "$sb22e"
+fi
 
 # 22f — the docs-only fast lane still reports a genuine pass PER SHARD. Every
 # shard legitimately runs zero suites there, so 22e's refusal must not fire.
@@ -2967,8 +2981,10 @@ rm -rf "$sb22e"
 # $GIT_FAKE_DIFF — a "docs-only" case that quietly stops being docs-only the
 # moment the checkout has an uncommitted change. Fixtures stay local to the
 # case that reads them, exactly as this file's header says.
-sb22f=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22f.XXXXXX"); mk_docs_sandbox "$sb22f"
-fakebin22f=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22f-fakebin.XXXXXX")
+sb22f=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22f.XXXXXX") || { fail "22f: mktemp failed"; sb22f=""; }
+fakebin22f=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22f-fakebin.XXXXXX") || { fail "22f: mktemp failed (fake git fixture)"; fakebin22f=""; }
+if [ -n "$sb22f" ] && [ -n "$fakebin22f" ]; then
+mk_docs_sandbox "$sb22f"
 cat > "$fakebin22f/git" <<'SHEOF'
 #!/usr/bin/env bash
 case "$1" in
@@ -3002,13 +3018,16 @@ for i22f in 1 2 3; do
 done
 [ "$ok22f" -eq 1 ] && pass "22f: every shard reports the docs-only fast-lane pass, not the empty-shard refusal"
 rm -rf "$sb22f" "$fakebin22f"
+fi
 
 # 22g — the split is taken AFTER the skip filters, not over raw discovery.
 # Five run-eligible suites (s2..s6) across 2 shards must land 3/2. The
 # discriminator is deliberate: a PRE-filter split of s1..s6 gives shard 1
 # {s1,s3,s5} -> {s3,s5} once s1 is skipped away, while the POST-filter split
 # this ticket specifies gives shard 1 {s2,s4,s6}.
-sb22g=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22g.XXXXXX"); mk_shard_sandbox "$sb22g" 6
+sb22g=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22g.XXXXXX") || { fail "22g: mktemp failed"; sb22g=""; }
+if [ -n "$sb22g" ]; then
+mk_shard_sandbox "$sb22g" 6
 g122g=$(run_lines "$(bash "$RUNNER" --list --skip-extra test-s1.sh --shard 1/2 "$sb22g" 2>&1)")
 g222g=$(run_lines "$(bash "$RUNNER" --list --skip-extra test-s1.sh --shard 2/2 "$sb22g" 2>&1)")
 want1_22g=$(printf '%s/test-s2.sh\n%s/test-s4.sh\n%s/test-s6.sh' "$sb22g" "$sb22g" "$sb22g")
@@ -3027,10 +3046,13 @@ else
   fail "22g: expected a [SKIP] line for test-s1.sh on shard 2/2; out: $skip22g"
 fi
 rm -rf "$sb22g"
+fi
 
 # 22h — EXECUTION, not just planning: a shard runs only its own suites, and a
 # failure inside one shard reddens that shard alone.
-sb22h=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22h.XXXXXX"); mk_shard_sandbox "$sb22h" 4
+sb22h=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22h.XXXXXX") || { fail "22h: mktemp failed"; sb22h=""; }
+if [ -n "$sb22h" ]; then
+mk_shard_sandbox "$sb22h" 4
 cat > "$sb22h/test-s2.sh" <<'SHEOF'
 #!/usr/bin/env bash
 touch "${0%.sh}.sentinel"
@@ -3049,6 +3071,7 @@ else
   fail "22h: expected shard1 green without running s2, shard2 red running s2; rc1=$rc22h1 s2-in-shard1=$ran22h1 rc2=$rc22h2; out1: $out22h1 out2: $out22h2"
 fi
 rm -rf "$sb22h"
+fi
 
 # --------------------------------------------------------------------------
 # Final tally

--- a/scripts/ci/test-run-shell-tests.sh
+++ b/scripts/ci/test-run-shell-tests.sh
@@ -2914,9 +2914,14 @@ rm -rf "$sb22a"
 # 22d — malformed values are REFUSED at rc 2 (the runner's "bad configuration
 # value" code, the same one an invalid SUITE_TIER_MODE takes), never silently
 # ignored: a typo'd shard spec that fell through to a full run would multiply
-# the CI bill by n and hide the misconfiguration behind a green.
+# the CI bill by n and hide the misconfiguration behind a green. The three
+# oversized specs at the end are the RED control for the digit-length bound:
+# bash arithmetic wraps silently on 64-bit overflow (rc=0, no diagnostic), so
+# without that bound '1/18446744073709551618' converts to a valid-looking
+# '1/2' and quietly runs a partition nobody asked for.
 sb22d=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22d.XXXXXX"); mk_shard_sandbox "$sb22d" 3
-for spec22d in '0/3' '4/3' 'abc' '1/0' '1/2/3' '/3' '1/' '-1/3' '1/-3' 'x/y' '' '3'; do
+for spec22d in '0/3' '4/3' 'abc' '1/0' '1/2/3' '/3' '1/' '-1/3' '1/-3' 'x/y' '' '3' \
+               '1/18446744073709551618' '1/99999999999999999999' '99999999999999999999/3'; do
   out22d=$(bash "$RUNNER" --list --shard "$spec22d" "$sb22d" 2>&1); rc22d=$?
   if [ "$rc22d" -eq 2 ] && grepq "$out22d" -F -- '--shard'; then
     pass "22d: --shard '$spec22d' -> refused rc 2"

--- a/scripts/ci/test-run-shell-tests.sh
+++ b/scripts/ci/test-run-shell-tests.sh
@@ -2846,6 +2846,206 @@ fi
 rm -rf "$sb21f"
 
 # --------------------------------------------------------------------------
+# Case 22 (HIMMEL-2872) — --shard <i>/<n> partitions the run list.
+#
+# The shard split is what lets CI's shell-unit job fan out across a runner
+# matrix, so the property that has to hold is EXACTNESS, not "roughly even":
+# the union of shards 1..n must equal the unsharded run list and the shards
+# must be pairwise disjoint. Anything weaker silently drops suites off the
+# gate — the HIMMEL-1128 false-green class, reached through the parallelism
+# instead of through discovery.
+#
+# The split is taken AFTER SKIP_LIST/--skip-extra/tier/conditional/capability
+# filtering (22g pins that), so a host that skips a suite does not leave a
+# hole in one shard's share; and a shard that ends up running NOTHING is a
+# refusal, not a pass (22e) — except under the docs-only fast lane, where zero
+# is the whole corpus's honest answer (22f).
+# --------------------------------------------------------------------------
+echo "== Case 22 (HIMMEL-2872): --shard partitions the run list =="
+
+mk_shard_sandbox() {  # $1 = dir, $2 = count — test-s1.sh .. test-s<count>.sh
+  mkdir -p "$1"
+  local _i
+  for _i in $(seq 1 "$2"); do
+    cat > "$1/test-s${_i}.sh" <<'SHEOF'
+#!/usr/bin/env bash
+touch "${0%.sh}.sentinel"
+exit 0
+SHEOF
+    chmod +x "$1/test-s${_i}.sh"
+  done
+}
+
+# run_lines <output> — just the [RUN ] suite paths, one per line.
+run_lines() { grep -F '[RUN ] ' <<< "$1" | sed 's/^\[RUN \] //'; }
+
+# 22a — the union of --list --shard i/3 equals plain --list, pairwise disjoint.
+sb22a=$(mktemp -d); mk_shard_sandbox "$sb22a" 7
+full22a=$(run_lines "$(bash "$RUNNER" --list "$sb22a" 2>&1)")
+s122a=$(run_lines "$(bash "$RUNNER" --list --shard 1/3 "$sb22a" 2>&1)")
+s222a=$(run_lines "$(bash "$RUNNER" --list --shard 2/3 "$sb22a" 2>&1)")
+s322a=$(run_lines "$(bash "$RUNNER" --list --shard 3/3 "$sb22a" 2>&1)")
+union22a=$(printf '%s\n%s\n%s\n' "$s122a" "$s222a" "$s322a" | grep -v '^$' | sort)
+dupes22a=$(printf '%s\n%s\n%s\n' "$s122a" "$s222a" "$s322a" | grep -v '^$' | sort | uniq -d)
+if [ "$union22a" = "$(sort <<< "$full22a")" ] && [ -z "$dupes22a" ] \
+   && [ -n "$s122a" ] && [ -n "$s222a" ] && [ -n "$s322a" ]; then
+  pass "22a: shards 1..3 union to the full run list, pairwise disjoint, none empty"
+else
+  fail "22a: partition broken; full='$full22a' s1='$s122a' s2='$s222a' s3='$s322a' dupes='$dupes22a'"
+fi
+
+# 22b — deterministic: the same shard planned twice is byte-identical.
+again22b=$(run_lines "$(bash "$RUNNER" --list --shard 2/3 "$sb22a" 2>&1)")
+if [ "$s222a" = "$again22b" ]; then
+  pass "22b: --list --shard 2/3 is deterministic across invocations"
+else
+  fail "22b: shard 2/3 differed between runs; first='$s222a' second='$again22b'"
+fi
+
+# 22c — --shard 1/1 is inert: the same plan as no --shard at all.
+one22c=$(run_lines "$(bash "$RUNNER" --list --shard 1/1 "$sb22a" 2>&1)")
+if [ "$one22c" = "$full22a" ]; then
+  pass "22c: --shard 1/1 plans exactly the unsharded run list"
+else
+  fail "22c: --shard 1/1 diverged from the full plan; full='$full22a' got='$one22c'"
+fi
+rm -rf "$sb22a"
+
+# 22d — malformed values are REFUSED at rc 2 (the runner's "bad configuration
+# value" code, the same one an invalid SUITE_TIER_MODE takes), never silently
+# ignored: a typo'd shard spec that fell through to a full run would multiply
+# the CI bill by n and hide the misconfiguration behind a green.
+sb22d=$(mktemp -d); mk_shard_sandbox "$sb22d" 3
+for spec22d in '0/3' '4/3' 'abc' '1/0' '1/2/3' '/3' '1/' '-1/3' '1/-3' 'x/y' '' '3'; do
+  out22d=$(bash "$RUNNER" --list --shard "$spec22d" "$sb22d" 2>&1); rc22d=$?
+  if [ "$rc22d" -eq 2 ] && grepq "$out22d" -F -- '--shard'; then
+    pass "22d: --shard '$spec22d' -> refused rc 2"
+  else
+    fail "22d: --shard '$spec22d' -> expected rc 2 with a --shard message, got rc=$rc22d; out: $out22d"
+  fi
+done
+# ...and a missing argument entirely.
+out22d2=$(bash "$RUNNER" --list "$sb22d" --shard 2>&1); rc22d2=$?
+if [ "$rc22d2" -eq 2 ] && grepq "$out22d2" -F -- '--shard'; then
+  pass "22d: --shard with no argument -> refused rc 2"
+else
+  fail "22d: --shard with no argument -> expected rc 2, got rc=$rc22d2; out: $out22d2"
+fi
+rm -rf "$sb22d"
+
+# 22e — a shard that is assigned NOTHING is a refusal, not a pass. This is the
+# n > run-list-length case, which is the shape a mis-sized CI matrix takes.
+sb22e=$(mktemp -d); mk_shard_sandbox "$sb22e" 2
+out22e=$(bash "$RUNNER" --shard 3/3 "$sb22e" 2>&1); rc22e=$?
+if [ "$rc22e" -eq 1 ] && grepq "$out22e" -F 'shard 3/3 ran 0 suites'; then
+  pass "22e: an empty shard refuses (exit 1) and names itself"
+else
+  fail "22e: expected exit 1 naming shard 3/3; rc=$rc22e out: $out22e"
+fi
+# The control: the two shards that DO get a suite still pass.
+out22e1=$(bash "$RUNNER" --shard 1/3 "$sb22e" 2>&1); rc22e1=$?
+out22e2=$(bash "$RUNNER" --shard 2/3 "$sb22e" 2>&1); rc22e2=$?
+if [ "$rc22e1" -eq 0 ] && [ "$rc22e2" -eq 0 ]; then
+  pass "22e: the non-empty shards of the same run still pass"
+else
+  fail "22e: expected shards 1/3 and 2/3 to pass; rc1=$rc22e1 rc2=$rc22e2; out1: $out22e1 out2: $out22e2"
+fi
+rm -rf "$sb22e"
+
+# 22f — the docs-only fast lane still reports a genuine pass PER SHARD. Every
+# shard legitimately runs zero suites there, so 22e's refusal must not fire.
+#
+# This case builds its OWN fake `git` rather than reaching for Case 15's
+# $fakebin15: that fixture is torn down at the end of Case 15, so a borrowed
+# PATH entry here contributes NOTHING, `command -v git` resolves to the real
+# system git, and the runner diffs the ACTUAL worktree instead of
+# $GIT_FAKE_DIFF — a "docs-only" case that quietly stops being docs-only the
+# moment the checkout has an uncommitted change. Fixtures stay local to the
+# case that reads them, exactly as this file's header says.
+sb22f=$(mktemp -d); mk_docs_sandbox "$sb22f"
+fakebin22f=$(mktemp -d)
+cat > "$fakebin22f/git" <<'SHEOF'
+#!/usr/bin/env bash
+case "$1" in
+  rev-parse)
+    _ref=
+    for _a in "$@"; do _ref="$_a"; done
+    case "$_ref" in
+      -*) exit 1 ;;
+      *) printf 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n'; exit 0 ;;
+    esac
+    ;;
+  diff)
+    [ -f "${GIT_FAKE_DIFF:-}" ] && cat "${GIT_FAKE_DIFF:-}"
+    ;;
+  ls-files)
+    [ -f "${GIT_FAKE_UNTRACKED:-}" ] && cat "${GIT_FAKE_UNTRACKED:-}"
+    ;;
+esac
+exit 0
+SHEOF
+chmod +x "$fakebin22f/git"
+diff22f="$sb22f/diff.txt"; printf 'docs/foo.md\nREADME.md\n' > "$diff22f"
+ok22f=1
+for i22f in 1 2 3; do
+  out22f=$(GIT_FAKE_DIFF="$diff22f" PATH="$fakebin22f:$PATH" \
+    bash "$RUNNER" "$sb22f" --changed-since HEAD --shard "$i22f/3" 2>&1); rc22f=$?
+  if [ "$rc22f" -ne 0 ] || ! grepq "$out22f" -F "docs-only diff — 0 shell suites needed"; then
+    ok22f=0
+    fail "22f: shard $i22f/3 on a docs-only diff -> expected the fast-lane pass; rc=$rc22f out: $out22f"
+  fi
+done
+[ "$ok22f" -eq 1 ] && pass "22f: every shard reports the docs-only fast-lane pass, not the empty-shard refusal"
+rm -rf "$sb22f" "$fakebin22f"
+
+# 22g — the split is taken AFTER the skip filters, not over raw discovery.
+# Five run-eligible suites (s2..s6) across 2 shards must land 3/2. The
+# discriminator is deliberate: a PRE-filter split of s1..s6 gives shard 1
+# {s1,s3,s5} -> {s3,s5} once s1 is skipped away, while the POST-filter split
+# this ticket specifies gives shard 1 {s2,s4,s6}.
+sb22g=$(mktemp -d); mk_shard_sandbox "$sb22g" 6
+g122g=$(run_lines "$(bash "$RUNNER" --list --skip-extra test-s1.sh --shard 1/2 "$sb22g" 2>&1)")
+g222g=$(run_lines "$(bash "$RUNNER" --list --skip-extra test-s1.sh --shard 2/2 "$sb22g" 2>&1)")
+want1_22g=$(printf '%s/test-s2.sh\n%s/test-s4.sh\n%s/test-s6.sh' "$sb22g" "$sb22g" "$sb22g")
+want2_22g=$(printf '%s/test-s3.sh\n%s/test-s5.sh' "$sb22g" "$sb22g")
+if [ "$g122g" = "$want1_22g" ] && [ "$g222g" = "$want2_22g" ]; then
+  pass "22g: the shard split is over the filtered run list, not raw discovery"
+else
+  fail "22g: expected shard1={s2,s4,s6} shard2={s3,s5} (post-filter); got shard1='$g122g' shard2='$g222g'"
+fi
+# The skipped suite is still REPORTED by every shard — a shard's log must not
+# look like the suite does not exist.
+skip22g=$(bash "$RUNNER" --list --skip-extra test-s1.sh --shard 2/2 "$sb22g" 2>&1)
+if grepq "$skip22g" -F 'test-s1.sh' && grepq "$skip22g" -F '[SKIP]'; then
+  pass "22g: a skipped suite is still reported on a shard that was not assigned it"
+else
+  fail "22g: expected a [SKIP] line for test-s1.sh on shard 2/2; out: $skip22g"
+fi
+rm -rf "$sb22g"
+
+# 22h — EXECUTION, not just planning: a shard runs only its own suites, and a
+# failure inside one shard reddens that shard alone.
+sb22h=$(mktemp -d); mk_shard_sandbox "$sb22h" 4
+cat > "$sb22h/test-s2.sh" <<'SHEOF'
+#!/usr/bin/env bash
+touch "${0%.sh}.sentinel"
+exit 1
+SHEOF
+chmod +x "$sb22h/test-s2.sh"
+# Sorted run list is s1,s2,s3,s4 -> shard 1/2 = {s1,s3}, shard 2/2 = {s2,s4}.
+out22h1=$(bash "$RUNNER" --shard 1/2 "$sb22h" 2>&1); rc22h1=$?
+ran22h1=$([ -f "$sb22h/test-s2.sentinel" ] && echo yes || echo no)
+rm -f "$sb22h"/*.sentinel
+out22h2=$(bash "$RUNNER" --shard 2/2 "$sb22h" 2>&1); rc22h2=$?
+if [ "$rc22h1" -eq 0 ] && [ "$ran22h1" = no ] && [ "$rc22h2" -eq 1 ] \
+   && [ -f "$sb22h/test-s2.sentinel" ] && [ ! -f "$sb22h/test-s1.sentinel" ]; then
+  pass "22h: each shard executes only its own suites; a red suite reddens its shard alone"
+else
+  fail "22h: expected shard1 green without running s2, shard2 red running s2; rc1=$rc22h1 s2-in-shard1=$ran22h1 rc2=$rc22h2; out1: $out22h1 out2: $out22h2"
+fi
+rm -rf "$sb22h"
+
+# --------------------------------------------------------------------------
 # Final tally
 # --------------------------------------------------------------------------
 echo

--- a/scripts/ci/test-run-shell-tests.sh
+++ b/scripts/ci/test-run-shell-tests.sh
@@ -2880,7 +2880,7 @@ SHEOF
 run_lines() { grep -F '[RUN ] ' <<< "$1" | sed 's/^\[RUN \] //'; }
 
 # 22a — the union of --list --shard i/3 equals plain --list, pairwise disjoint.
-sb22a=$(mktemp -d); mk_shard_sandbox "$sb22a" 7
+sb22a=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22a.XXXXXX"); mk_shard_sandbox "$sb22a" 7
 full22a=$(run_lines "$(bash "$RUNNER" --list "$sb22a" 2>&1)")
 s122a=$(run_lines "$(bash "$RUNNER" --list --shard 1/3 "$sb22a" 2>&1)")
 s222a=$(run_lines "$(bash "$RUNNER" --list --shard 2/3 "$sb22a" 2>&1)")
@@ -2915,7 +2915,7 @@ rm -rf "$sb22a"
 # value" code, the same one an invalid SUITE_TIER_MODE takes), never silently
 # ignored: a typo'd shard spec that fell through to a full run would multiply
 # the CI bill by n and hide the misconfiguration behind a green.
-sb22d=$(mktemp -d); mk_shard_sandbox "$sb22d" 3
+sb22d=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22d.XXXXXX"); mk_shard_sandbox "$sb22d" 3
 for spec22d in '0/3' '4/3' 'abc' '1/0' '1/2/3' '/3' '1/' '-1/3' '1/-3' 'x/y' '' '3'; do
   out22d=$(bash "$RUNNER" --list --shard "$spec22d" "$sb22d" 2>&1); rc22d=$?
   if [ "$rc22d" -eq 2 ] && grepq "$out22d" -F -- '--shard'; then
@@ -2935,7 +2935,7 @@ rm -rf "$sb22d"
 
 # 22e — a shard that is assigned NOTHING is a refusal, not a pass. This is the
 # n > run-list-length case, which is the shape a mis-sized CI matrix takes.
-sb22e=$(mktemp -d); mk_shard_sandbox "$sb22e" 2
+sb22e=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22e.XXXXXX"); mk_shard_sandbox "$sb22e" 2
 out22e=$(bash "$RUNNER" --shard 3/3 "$sb22e" 2>&1); rc22e=$?
 if [ "$rc22e" -eq 1 ] && grepq "$out22e" -F 'shard 3/3 ran 0 suites'; then
   pass "22e: an empty shard refuses (exit 1) and names itself"
@@ -2962,8 +2962,8 @@ rm -rf "$sb22e"
 # $GIT_FAKE_DIFF — a "docs-only" case that quietly stops being docs-only the
 # moment the checkout has an uncommitted change. Fixtures stay local to the
 # case that reads them, exactly as this file's header says.
-sb22f=$(mktemp -d); mk_docs_sandbox "$sb22f"
-fakebin22f=$(mktemp -d)
+sb22f=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22f.XXXXXX"); mk_docs_sandbox "$sb22f"
+fakebin22f=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22f-fakebin.XXXXXX")
 cat > "$fakebin22f/git" <<'SHEOF'
 #!/usr/bin/env bash
 case "$1" in
@@ -3003,7 +3003,7 @@ rm -rf "$sb22f" "$fakebin22f"
 # discriminator is deliberate: a PRE-filter split of s1..s6 gives shard 1
 # {s1,s3,s5} -> {s3,s5} once s1 is skipped away, while the POST-filter split
 # this ticket specifies gives shard 1 {s2,s4,s6}.
-sb22g=$(mktemp -d); mk_shard_sandbox "$sb22g" 6
+sb22g=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22g.XXXXXX"); mk_shard_sandbox "$sb22g" 6
 g122g=$(run_lines "$(bash "$RUNNER" --list --skip-extra test-s1.sh --shard 1/2 "$sb22g" 2>&1)")
 g222g=$(run_lines "$(bash "$RUNNER" --list --skip-extra test-s1.sh --shard 2/2 "$sb22g" 2>&1)")
 want1_22g=$(printf '%s/test-s2.sh\n%s/test-s4.sh\n%s/test-s6.sh' "$sb22g" "$sb22g" "$sb22g")
@@ -3025,7 +3025,7 @@ rm -rf "$sb22g"
 
 # 22h — EXECUTION, not just planning: a shard runs only its own suites, and a
 # failure inside one shard reddens that shard alone.
-sb22h=$(mktemp -d); mk_shard_sandbox "$sb22h" 4
+sb22h=$(mktemp -d "${TMPDIR:-/tmp}/rst-case22h.XXXXXX"); mk_shard_sandbox "$sb22h" 4
 cat > "$sb22h/test-s2.sh" <<'SHEOF'
 #!/usr/bin/env bash
 touch "${0%.sh}.sentinel"


### PR DESCRIPTION
## Why

`shell-unit (ubuntu-latest)` was the long pole on every PR: **467 suites run serially on one runner, 42m32s** of suite time against a sub-minute setup (run [34392571059](https://github.com/yotamleo/Himmel/actions/runs/34392571059), 19:01:36Z → 19:44:08Z). Every other job in this workflow finishes in 7 minutes or less, so the whole PR run was paced by this one job.

This is item 2 of HIMMEL-2872. Item 1 (a prebuilt GHCR container image) buys roughly a minute of setup and stays open as its own leg — the sharding is the actual time win.

## What changed

### `scripts/ci/run-shell-tests.sh` — `--shard <i>/<n>`

The split is taken as the **last** filter in the execution loop, after `SKIP_LIST` / `--skip-extra` / tier / conditional / capability — so it partitions the **final run list**, not raw discovery. Splitting discovery instead would let a host's skips fall unevenly across shards, leaving one runner carrying the corpus while five idle.

It is round-robin on a **shared** run-eligible index that advances for every eligible suite regardless of which shard claims it. That shared counter is what makes the shards an exact partition: their union is the unsharded run list and they are pairwise disjoint. Anything weaker drops suites off the gate while all *n* shards report green — HIMMEL-1128's false-green class, reached through the parallelism instead of through discovery.

Two refusals keep that honest:

- A **malformed `<i>/<n>` exits 2** — this runner's bad-configuration-value code, the same one an invalid `SUITE_TIER_MODE` takes. Falling through to a full run would multiply the CI bill by *n* while hiding the typo behind a pass. `--shard ''` is a refusal too, not a silent no-op.
- A **shard that runs zero suites exits 1** and names itself. The one exception is the docs-only fast lane, where zero is the whole corpus's honest answer and stays a genuine pass (HIMMEL-2166).

Sharding also sets `plan_narrowed`, so a shard's partial plan can never write or clear the scan-root-wide resume cursor (HIMMEL-2243 FIX 8).

### `.github/workflows/ci.yml`

The working job becomes **`shell-unit-shard`** (the existing `os` matrix × `shard: [1..8]`), with per-shard artifact names so the jobs cannot collide on one upload. The count is spelled in exactly two places that must agree — the matrix list and the `--shard …/<n>` argument — and deliberately nowhere else; a third copy in prose had already gone stale within this PR, so it was removed rather than updated.

A new aggregating job keeps the name **`shell-unit`** with a single-value `os` matrix, purely so its check-run context stays **`shell-unit (ubuntu-latest)` byte-for-byte**. That is one of the ten required contexts in `main`'s classic branch protection, and **no branch-protection or ruleset change is part of this PR** — preserving the name is the whole point.

The aggregator fails **closed**: `if: always()` plus an explicit `!= success` over `needs.shell-unit-shard.result` reddens on `failure`, `cancelled` **and** `skipped`. A bare `needs:` without `always()` would *skip* the job whenever a shard failed, and a required check that never reports leaves the PR hanging rather than red. A job-level `continue-on-error` failure is not counted against the matrix rollup, so the nightly windows/macOS legs stay advisory exactly as they are today without the aggregator naming any OS.

Suite locks are unaffected: shards run on separate runners, so the machine-wide `/tmp/himmel-shell-suite-*.lock` has no cross-shard contention to resolve.

## Evidence

Written RED first. `scripts/ci/test-run-shell-tests.sh` Case 22 (8 sub-cases, 47 assertions) failed 23/23 against the unmodified runner, with no pre-existing case affected. After the change:

| Check | Result |
|---|---|
| `scripts/ci/test-run-shell-tests.sh` | `OK: all cases passed` — 190 PASS, 0 FAIL |
| `scripts/ci/test-suite-concurrency.sh` (sibling suite over the same runner) | `OK: all cases passed` |
| `shellcheck --severity=warning` on both changed shell files | clean |
| `yaml.safe_load(.github/workflows/ci.yml)` | OK |

Real-corpus partition probe. Run at `n=6`, before CI measurement moved the shipped count to 8 — what it establishes is the *exactness* property, which is independent of `n`:

```
shard 1: 78   shard 4: 78
shard 2: 78   shard 5: 78
shard 3: 78   shard 6: 77      union 467, duplicates 0
full --list: 467              union == full (byte-identical when sorted)
```

The load-bearing sub-cases: **22g** is the discriminator that pins the split as post-filter rather than over raw discovery (a `--skip-extra`'d suite must not consume a shard slot); **22e** pins the empty-shard refusal; **22f** pins the docs-only fast lane still reporting a genuine pass per shard.

## Measured on this PR's own run

A PR runs its own workflow file, so the sharded `shell-unit` is what gates this PR — the run below is the evidence, not a projection.

**The invariant this PR is built around holds.** On run [34408076490](https://github.com/yotamleo/Himmel/actions/runs/34408076490):

```
$ gh api repos/yotamleo/Himmel/commits/d026803c/check-runs \
    --jq '.check_runs[]|select(.name=="shell-unit (ubuntu-latest)")|.conclusion'
success
```

The required context still exists under that exact name on a sharded head, so classic branch protection resolves with no protection or ruleset change. All ten required contexts are present.

**Timing, at the 6 shards this PR first shipped:** 42m32s serial → **18m35s** whole-run. A real 2.3x, but above the 10-minute target and about half the predicted win.

```
shard 3   3m18s      shard 2   8m31s
shard 5   4m05s      shard 6   9m23s
shard 4   4m57s      shard 1  18m23s   <- long pole
shell-unit (aggregator)  4s
```

The shard count was not the cause. Round-robin placed the corpus's two heaviest suites on the same shard — `scripts/ci/test-run-shell-tests.sh` (389s) and `scripts/hooks/test-block-write-into-main-checkout.sh` (330s), 719s of shard 1's 1065s, against an 8.1m even share.

Replaying the measured per-suite durations over the same run list (466 suites, 2685s serial) is what set the new count:

| n | round-robin slowest | duration-aware slowest |
|---|---|---|
| 6 | 17.8m *(measured 18m23s — the model tracks)* | 7.5m |
| 8 | 9.9m | 6.5m |
| 10 | 9.0m | 6.5m |
| 12 | **10.7m** | 6.5m |
| 16 | 9.0m | 6.5m |

Two things follow, and both outlive this PR:

1. **Round-robin's balance is not monotonic in `n`.** Twelve shards is *worse* than eight. Raising the count is a dice roll against the modulo, not a tuning knob — so "it got slow, add shards" is not a valid response to a future regression here.
2. **The hard floor is 389s (6.5m)** — the single longest suite. No split of any width goes below it. A duration-aware split *reaches* that floor at n=8; round-robin never gets below 9.0m at any `n` tried.

So this PR ships **n=8**, which is the pre-authorised contingency rather than the fix: it lands near target by luck of the modulo, not by construction. The durable fix is the bin-pack, filed with this run's ledger attached. Both numbers are stated above and in the re-measure below.

## Known follow-ups (deliberately not in this PR)

- **HIMMEL-2894 — duration-ledger bin-pack.** The actual fix for the imbalance above. Filed with the 466-row `suite<TAB>seconds` ledger from run 34408076490 **attached**, plus the regeneration recipe, so that leg starts from data instead of a re-measure. Kept out of here because it needs a committed ledger, new assignment logic and its own CR round, against an already-green 2.3x win.
- **HIMMEL-2895 — split `scripts/ci/test-run-shell-tests.sh`.** It is the 389s floor. Sharding is what turned that runtime from "slow but parallel with everything else" into a floor on the whole job; until it is split, 6.5m bounds `shell-unit` no matter how good the assignment gets.
- **HIMMEL-2880** — `scripts/ci-orchestrator/` models the CI topology by job name (`act-matrix.json` key `ci:shell-unit`, `src/dedup.ts` `CODE_MATRIX_JOBS`), so this rename staleifies both. Nothing goes red, because nothing gates `act-matrix.json` against `ci.yml`'s job list — that missing gate is the second half of the ticket.
- **HIMMEL-2872 item 1** — the prebuilt GHCR CI image, its own leg. The ticket stays In Progress.

Platforms tested: linux
Security reviewed: manual — no new secrets or network reach; the `--shard` value is digits-validated before any arithmetic and never reaches a shell command; `matrix.shard` is a static literal list, not event-controlled input, so the new interpolations carry no workflow script-injection surface; the aggregating job fails closed on failure/cancelled/skipped, takes no checkout, and inherits the workflow's `contents: read`; no branch-protection or ruleset change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6jo72GY8hMDCu8Wb2GpJ5
