### PR TITLE
docs: [HIMMEL-2875] adoption trail — private-era content audit, Pages config and public URL links

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Two ways to get himmel — pick based on what you're doing:
 1. **Add himmel to an existing repo** (most common) — the portable core: hooks
    + guardrails + worktree workflow + marketplace plugins/skills. Follow
    [`docs/getting-started.md`](docs/getting-started.md) for the ~15-minute
-   walkthrough instead of this section.
+   walkthrough instead of this section, or see the eight-level
+   [adoption trail](https://yotamleo.github.io/Himmel/adoption-trail.html)
+   for what each stage of adoption changes.
 2. **Run / develop himmel standalone** — the contributor path, heavier
    prereqs. The rest of this Quickstart documents this path.
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ Two ways to get himmel — pick based on what you're doing:
    + guardrails + worktree workflow + marketplace plugins/skills. Follow
    [`docs/getting-started.md`](docs/getting-started.md) for the ~15-minute
    walkthrough instead of this section, or see the eight-level
-   [adoption trail](https://yotamleo.github.io/Himmel/adoption-trail.html)
-   for what each stage of adoption changes.
+   [adoption trail](docs/adoption-trail.html) for what each stage of adoption
+   changes (also at
+   [yotamleo.github.io/Himmel/adoption-trail.html](https://yotamleo.github.io/Himmel/adoption-trail.html)
+   once GitHub Pages is enabled).
 2. **Run / develop himmel standalone** — the contributor path, heavier
    prereqs. The rest of this Quickstart documents this path.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Map of the `docs/` tree. New here? Start at **[getting-started.md](getting-start
 ## Start here
 
 - [why-himmel.md](why-himmel.md) — the case for the harness: the five failure modes it exists for, the evidence, and what it costs you.
-- [adoption-trail.html](adoption-trail.html) — the eight-level adoption trail, as a page you open in a browser: what each level turns on, what it changes, and what it does not.
+- [adoption-trail.html](adoption-trail.html) — the eight-level adoption trail, as a page you open in a browser: what each level turns on, what it changes, and what it does not. Public URL (once Pages is enabled): https://yotamleo.github.io/Himmel/adoption-trail.html
 - [architecture.md](architecture.md) — five diagrams: the enforcement layers, the handover system, the fleet/console model, the Jira seam, the observability chain.
 - [getting-started.md](getting-started.md) — clone to your first PR-gated loop in ~15 minutes.
 - [daily-loop.md](daily-loop.md) — one full loop (worktree → PR → merge → clean → handover), with every hook and gate explained where it fires.

--- a/docs/adoption-trail.html
+++ b/docs/adoption-trail.html
@@ -604,7 +604,7 @@
     the plan first.
     Click any level marker to track where you are — it's remembered on
     this device only.
-    <br>This page:
+    <br>Public URL, once GitHub Pages is enabled:
     <a href="https://yotamleo.github.io/Himmel/adoption-trail.html" class="mono">yotamleo.github.io/Himmel/adoption-trail.html</a>
   </footer>
 </div>

--- a/docs/adoption-trail.html
+++ b/docs/adoption-trail.html
@@ -249,10 +249,10 @@
         end-to-end Linux walkthrough, are in
         <a href="setup/new-machine.md">setup/new-machine.md</a>; the narrative
         version is <a href="getting-started.md">getting-started.md</a>.</p>
-        <p class="note">This page lives in the private himmel repo and is not
-        part of what the public clone gives you, which also trails private main
-        by however long the current propagation batch has been open. Read the
-        trail here; expect the clone to be a little behind it.</p>
+        <p class="note">This page ships in <span class="mono">docs/</span> in
+        the public himmel repo, at
+        <a href="https://yotamleo.github.io/Himmel/adoption-trail.html">yotamleo.github.io/Himmel/adoption-trail.html</a>
+        once GitHub Pages is enabled; until then, open it from your clone.</p>
         <div class="chipgroup"><span class="glabel">himmel brings</span>
           <ul class="chips">
             <li><button class="chip" data-detail="himmel-ops">himmel-ops</button></li>
@@ -604,6 +604,8 @@
     the plan first.
     Click any level marker to track where you are — it's remembered on
     this device only.
+    <br>This page:
+    <a href="https://yotamleo.github.io/Himmel/adoption-trail.html" class="mono">yotamleo.github.io/Himmel/adoption-trail.html</a>
   </footer>
 </div>
 


### PR DESCRIPTION
## Summary

Audits the whole `docs/` tree (everything GitHub Pages would serve) for private-era content ahead of enabling Pages, and prepares the flip.

**Audit method:** grep for a string list (`/home/overlord`, `overlord`, `himmel-private`, `Documents/luna`, `cachyos`, `OVERLORD8`, `ha1`, `ubuntu_new`, `.himmel/`) plus a manual read of the trail-adjacent pages (`docs/adoption-trail.html`, `docs/getting-started.md`, `docs/setup/install.md`, `docs/README.md`, `README.md`).

**Result:** 81 string-list hits total, all in `docs/internals/`, `docs/setup/new-machine.md`, `docs/setup/vms.md`, `docs/luna/`, `docs/tooling-catalog.md`, `docs/voice.md`, `docs/operator-conventions.md` — classified **OK-PROVENANCE** (documented adopter-generic path conventions like `~/.himmel/` and `~/Documents/luna`, plus station names used as evidence in setup/internals decision records). Zero hits in the trail-adjacent adopter pages. Zero **EXCLUDE**-class findings.

The one real **FIX**-class leak was caught by manual read, not the grep list: `docs/adoption-trail.html`'s own note said the page "lives in the private himmel repo" and trails "private main" via a propagation batch — stale since the himmel-2869 public cutover (himmel origin has been public since 2026-09-09, propagation retired). Replaced with the public-repo framing and the pending Pages URL.

**Pages prep:**
- Added `docs/.nojekyll` rather than `docs/_config.yml`'s `exclude:` list — `docs/internals/handover-system.md` and `docs/tooling-catalog.md` contain literal `{{ }}` (e.g. `{{USER_SLUG}}`, `${{ secrets.* }}`) that Jekyll's Liquid engine would try to parse. `.nojekyll` serves the whole tree as static files with no build step, avoiding that landmine. No `_config.yml` needed since there were zero EXCLUDE-class findings.
- Wired the future public URL (`https://yotamleo.github.io/Himmel/adoption-trail.html`) into the trail's own footer/note, `docs/README.md`, and `README.md`'s Quickstart — the README link points at the local `docs/adoption-trail.html` file with the pending Pages URL noted alongside, per a CR finding below, so new adopters aren't sent to a page that may still 404.

**Not done (operator action):** enabling Pages itself is a repo setting change, left to the operator:
```
gh api -X POST repos/yotamleo/Himmel/pages -f build_type=legacy -f 'source[branch]=main' -f 'source[path]=/docs'
```
or Settings → Pages → Source: `main` / `/docs` in the GitHub UI. Verify with:
```
curl -sI https://yotamleo.github.io/Himmel/adoption-trail.html   # expect 200
```

**Trade-off vs. a claude.ai artifact:** a hosted artifact would be live in seconds with zero repo/CI involvement, but it forks the trail from its source of truth (this file in `docs/`) — every future edit would need to be copied twice, and the two would drift silently. GitHub Pages costs one operator setting flip and then serves the tracked file directly: one edit, one source, no drift. Recommend Pages.

**Parallel-leg state at time of write:** HIMMEL-2874 (claude-hud cache-expiry) was already merged, so the trail's statusline detail already describes the cache-expiry clock as shipped. HIMMEL-2873 (`docs/handover/running-a-console.md`) was not yet merged, so the trail does not link it — follow-up once it lands.

## Verification
- Audit grep: 0 FIX-class hits in `docs/adoption-trail.html`, `docs/getting-started.md`, `docs/setup/install.md`, `docs/README.md`, `README.md` (re-run after the fix).
- `bash scripts/guardrails/leak-classes.sh --tree` → exit 0.
- `bash scripts/docs/check-llms-links.sh llms.txt` / `docs/setup/install.md`, `bash scripts/docs/check-doc-terms.sh llms.txt docs/setup/install.md docs/setup/migrating.md` → all exit 0 (the doc-invariants CI checks that touch adjacent files; none of the checks needing the destructive orphan-checkout step apply, since no `CLAUDE.md`/commands/skills files changed).
- Served `docs/` via `python3 -m http.server` locally, confirmed `adoption-trail.html` returns 200; manually reviewed the CSS's light/dark handling (dark-first `:root`, `prefers-color-scheme`-guarded override, `[data-theme]` override) — did not get a visual browser screenshot (no browser-automation tool available in this session), noting that explicitly rather than claiming visual confirmation.
- `/pr-check` (docs-audit lane, `CR_REQUIRE_CROSS_MODEL=1`): cross-model critic panel (codex, `gpt-6-astra`) returned 0 Critical/Important, 1 Suggestion — the README-links-directly-to-a-maybe-404-URL point above — fixed and agreed. Marker cleared clean.

## Test plan
- [ ] CI green (`shell-unit`, `doc-invariants`, `commit-lint`)
- [ ] CodeRabbit App review clean (threads resolved)
- [ ] Operator flips Pages with the command above and confirms `curl` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PF3pwx76LGnzq6LjucDT5y