### PR TITLE
fix(himmelctl): [HIMMEL-2883] dogfood fixes — launcher shim, status rc, cadence rc 3, second-brain probe

### DIFF
--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -1536,8 +1536,9 @@ you ever want the per-turn review back.
 ### Install sequence
 
 ```bash
-# 1. obsidian-second-brain — manual clone (no marketplace)
-git clone https://github.com/eugeniughelbur/obsidian-second-brain ~/.claude/plugins/obsidian-second-brain
+# 1. obsidian-second-brain — manual clone (no marketplace); Claude Code loads
+#    user skills from ~/.claude/skills/, not ~/.claude/plugins/ (HIMMEL-2891)
+git clone https://github.com/eugeniughelbur/obsidian-second-brain ~/.claude/skills/obsidian-second-brain
 
 # 2. himmel marketplace (carries handover + obsidian-triage + claude-obsidian)
 # inside Claude Code:

--- a/scripts/himmelctl/bin.js
+++ b/scripts/himmelctl/bin.js
@@ -3270,8 +3270,12 @@ function applyLunaSectionsStep(answers) {
           const cmd = { argv: argv };
           const armRc = runSpawn(cmd);
           result.cadenceResults = result.cadenceResults || {};
-          result.cadenceResults[row.id] = { ran: true, rc: armRc, argvDisplay: displayCommand(cmd) };
-          if (armRc !== 0) result.rc = 1;
+          // HIMMEL-2885: rc 3 is the script's own dedup refusal — the unit is
+          // ALREADY armed, which is the converged state install wanted. Never
+          // pass --force here (that would re-arm/re-time the operator's
+          // existing crontab); read rc 3 as already-converged, not a failure.
+          result.cadenceResults[row.id] = { ran: true, rc: armRc, alreadyArmed: armRc === 3, argvDisplay: displayCommand(cmd) };
+          if (armRc !== 0 && armRc !== 3) result.rc = 1;
         } catch (e) {
           console.error(`himmelctl: WARN: ${row.id} cadence arm failed: ${e.message}`);
           result.cadenceResults = result.cadenceResults || {};

--- a/scripts/himmelctl/bin.js
+++ b/scripts/himmelctl/bin.js
@@ -4529,7 +4529,12 @@ function applyHimmelctlPathShim(args) {
 
   try {
     fs.mkdirSync(binDir, { recursive: true });
-    const jsBody = `'use strict';\n// ${SHIM_MARKER}\nrequire(${JSON.stringify(target)});\n`;
+    // HIMMEL-2883: re-exec bin.js as a child process rather than require()ing
+    // it — a require() runs with require.main === himmelctl.js, so bin.js's
+    // own `if (require.main === module)` guard (HIMMEL-2438) never fires and
+    // main() silently never runs (rc 0, no output). A child process always
+    // has its own require.main === itself, so the guard passes as intended.
+    const jsBody = `'use strict';\n// ${SHIM_MARKER}\nconst { status } = require('child_process').spawnSync(process.execPath, [${JSON.stringify(target)}, ...process.argv.slice(2)], { stdio: 'inherit' });\nprocess.exit(status === null ? 1 : status);\n`;
     if (!writeMarkedLauncher(path.join(binDir, 'himmelctl.js'), jsBody)) return false;
     if (platform === 'win32') {
       const cmdBody = `@echo off\r\nREM ${SHIM_MARKER}\r\nnode "%~dp0himmelctl.js" %*\r\n`;

--- a/scripts/himmelctl/lib/adopter-profile.js
+++ b/scripts/himmelctl/lib/adopter-profile.js
@@ -1340,6 +1340,11 @@ function buildSummary(answers, laneRows, opts) {
                 `${label} armed — ${arm.argvDisplay}`,
                 `${label} — would arm: ${arm.argvDisplay}`,
               ));
+            } else if (arm.alreadyArmed) {
+              // HIMMEL-2885: rc 3 is the script's own dedup refusal — already
+              // converged, not a failure. Reads as skipped, never manual —
+              // "re-run to retry" would loop forever against a healthy machine.
+              skipped.push(`${label} — already armed (rc 3)`);
             } else {
               manual.push({
                 what: `${label} — ${scriptBase} arm exited rc=${arm.rc}`,

--- a/scripts/himmelctl/lib/status-report.js
+++ b/scripts/himmelctl/lib/status-report.js
@@ -367,13 +367,15 @@ function statusReport({ manifest, scope, targetPath, answers, itemIds, state: pa
         severity = 'n/a';
         detail = `${probe.detail} — opt-in (bash scripts/setup-hooks.sh --guardrail-mode global --yes, or run 'himmelctl ensure' interactively to consent + auto-wire)`;
       }
-      // HIMMEL-1100: obsidian-second-brain is a MANUAL clone only — no himmel
-      // script ever installs it (docs/setup/new-machine.md: "manual clone,
-      // NOT in himmel marketplace"), the same "no automated path exists"
-      // shape as graphify-mcp/doc-guard-map above.
+      // HIMMEL-1100/2891: obsidian-second-brain is a MANUAL clone only — no
+      // himmel script ever installs it (docs/setup/new-machine.md: "manual
+      // clone, NOT in himmel marketplace"), the same "no automated path
+      // exists" shape as graphify-mcp/doc-guard-map above. It is cloned to
+      // ~/.claude/skills/ — that is where Claude Code loads user skills
+      // from; a ~/.claude/plugins/ clone would never be read (HIMMEL-2891).
       if (item.id === 'obsidian-second-brain') {
         severity = 'n/a';
-        detail = `${probe.detail} — opt-in (manual clone: git clone https://github.com/eugeniughelbur/obsidian-second-brain ~/.claude/plugins/obsidian-second-brain)`;
+        detail = `${probe.detail} — opt-in (manual clone: git clone https://github.com/eugeniughelbur/obsidian-second-brain ~/.claude/skills/obsidian-second-brain)`;
       }
       // HIMMEL-1100 round 5 (glm-3): gemini-cli is an optional second-opinion
       // lane (gemini-subagent, /x-read family), not core tooling every

--- a/scripts/himmelctl/test/test-himmelctl-path-shim.sh
+++ b/scripts/himmelctl/test/test-himmelctl-path-shim.sh
@@ -489,4 +489,30 @@ SHIM_CALL_LOG="$(winpath "$work/caseI-shim-calls.log")" \
   || fail "caseI: shim written after a failed adopt.sh must still target this checkout"
 echo "ok: caseI failed adopt.sh still applies the PATH shim and points the adopter at himmelctl ensure"
 
+# ── J: HIMMEL-2883 — the generated launcher RE-EXECS bin.js, so bin.js's own
+# `require.main === module` guard (HIMMEL-2438) still fires. Pre-fix the
+# generated himmelctl.js did `require(target)`, which runs with
+# require.main === himmelctl.js (the launcher), not the target — so a
+# guarded main() never ran: silent no-op, empty stdout, rc 0. The other
+# fixtures in this file stub bin.js with UNGUARDED top-level code (it runs
+# the instant it's require()'d), which would mask exactly this bug class —
+# this fixture mirrors the real guard shape instead.
+fixtureJ="$work/caseJ-checkout"; binJ="$work/caseJ-bin"; mkdir -p "$binJ"
+build_update_fixture "$fixtureJ"
+cat > "$fixtureJ/scripts/himmelctl/bin.js" <<'STUB'
+'use strict';
+function main() {
+  process.stdout.write('himmelctl: guarded main ran\n');
+}
+if (require.main === module) {
+  main();
+}
+STUB
+run_update "$fixtureJ" "$binJ" linux "$(winpath "$binJ"):$PATH" >/dev/null
+outJ=$("$binJ/himmelctl" --help 2>&1); rcJ=$?
+[ -n "$outJ" ] || fail "caseJ: generated launcher produced no output — the require.main===module guard (HIMMEL-2438) swallowed main() (rc=$rcJ)"
+[ "$rcJ" -eq 0 ] || fail "caseJ: generated launcher should exit 0 (got rc=$rcJ): $outJ"
+grepq "$outJ" 'guarded main ran' || fail "caseJ: generated launcher did not run the guarded main() (got: $outJ)"
+echo "ok: caseJ generated launcher re-execs bin.js so the require.main===module guard (HIMMEL-2438) still fires"
+
 echo "PASS"

--- a/scripts/himmelctl/test/test-wizard-luna-sections.sh
+++ b/scripts/himmelctl/test/test-wizard-luna-sections.sh
@@ -791,6 +791,65 @@ grepq "$(cat "$profileApply")" 'TELEGRAM_AUTO_ACTIONS' \
 echo "ok: V12 TELEGRAM_AUTO_ACTIONS is absent from the bridge .env and the profile, both before and after the run"
 
 # ═══════════════════════════════════════════════════════════════════════════
+# caseArmRc3 (HIMMEL-2885) — pipeline-cadence.sh arm exits rc=3 (its own
+# dedup refusal: the unit is already armed) on an otherwise-healthy machine.
+# RED (pre-fix): rc=3 was treated as a failure — overall install rc=1, and
+# the cadence landed in `still manual` with a "re-run to retry" loop. Fixed:
+# rc=3 reads as already-converged — overall rc=0, cadence lands in `skipped`.
+# ═══════════════════════════════════════════════════════════════════════════
+
+stubArmRc3="$work/stubArmRc3"; mkdir -p "$stubArmRc3"
+make_python_stub "$stubArmRc3"
+pathArmRc3=$(build_path "$stubArmRc3" bash jq python3 npm -- python)
+make_git_stub "$stubArmRc3" "https://github.com/someone/other-repo.git"
+homeArmRc3="$work/homeArmRc3"; mkdir -p "$homeArmRc3"
+
+fixtureRepoArmRc3="$work/fixture-repo-armrc3"; mkdir -p "$fixtureRepoArmRc3/scripts/luna"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$fixtureRepoArmRc3/scripts/adopt.sh"
+chmod +x "$fixtureRepoArmRc3/scripts/adopt.sh"
+cat > "$fixtureRepoArmRc3/scripts/luna/pipeline-cadence.sh" <<STUB
+#!/usr/bin/env bash
+echo "ERR pipeline-cadence: HIMMEL-Pipeline-* crontab entries already armed" >&2
+exit 3
+STUB
+chmod +x "$fixtureRepoArmRc3/scripts/luna/pipeline-cadence.sh"
+
+vaultPathArmRc3="$(winpath "$work/vaultArmRc3")"
+configPathArmRc3="$(winpath "$work/config-armrc3.json")"
+profileArmRc3="$work/profileArmRc3.json"
+cat > "$profileArmRc3" <<JSON
+{
+  "role": "adopter", "tier": "standard", "scope": "user",
+  "vault": { "mode": "default-template", "path": "$vaultPathArmRc3" },
+  "handover": { "mode": "inline", "path": "" },
+  "pluginSet": "lean", "lanes": [], "lanesMeaningful": true, "alwaysOn": false,
+  "luna": { "cadenceEnabled": true, "phiDeclared": false },
+  "secretsWalk": "skip",
+  "bridge": { "enabled": false }
+}
+JSON
+
+set +e
+outArmRc3=$(PATH="$pathArmRc3" HOME="$homeArmRc3" USERPROFILE="$(winpath "$homeArmRc3")" HIMMELCTL_INTERACTIVE=0 \
+  HIMMELCTL_REPO_ROOT="$(winpath "$fixtureRepoArmRc3")" \
+  HIMMEL_LUNA_CONFIG_PATH="$configPathArmRc3" \
+  HIMMELCTL_CACHE_DIR="$(winpath "$work/cache-armrc3")" \
+  HIMMELCTL_BIN_DIR="$(winpath "$work/bin-armrc3")" \
+  "$node_bin" "$wizard" install --from-profile "$(winpath "$profileArmRc3")" </dev/null 2>&1)
+rcArmRc3=$?
+set -e
+[ "$rcArmRc3" -eq 0 ] || fail "caseArmRc3: an arm rc=3 (already converged) must not fail the overall install (got rc=$rcArmRc3): $outArmRc3"
+grepq "$outArmRc3" 'already armed (rc 3)' \
+  || fail "caseArmRc3: skipped section should read 'already armed (rc 3)' (got: $outArmRc3)"
+skippedBlockArmRc3=$(printf '%s' "$outArmRc3" | sed -n '/^skipped:/,/^$/p')
+grepq "$skippedBlockArmRc3" -F -- '  - luna cadence — already armed (rc 3)' \
+  || fail "caseArmRc3: 'already armed (rc 3)' should be under skipped:, not still manual (got skipped block: $skippedBlockArmRc3)"
+manualBlockArmRc3=$(printf '%s' "$outArmRc3" | sed -n '/^still manual/,$p')
+grepq "$manualBlockArmRc3" -F -- 'arm exited rc=3' \
+  && fail "caseArmRc3: rc=3 must NOT land in still manual (retry loop) (got: $manualBlockArmRc3)"
+echo "ok: caseArmRc3 cadence arm rc=3 (already armed) reads as skipped/converged; overall install rc stays 0"
+
+# ═══════════════════════════════════════════════════════════════════════════
 # caseSecretsProbe (RETASK stage1-build-6d2e) — the three luna-sources secrets
 # walk verdicts, precisely: a configured+healthy source reports ok/configured;
 # a configured-but-broken source surfaces the PROBE'S OWN reason and is never

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -2325,7 +2325,11 @@ echo "$outLunaEmpty" | jq -e '.actual == "absent"' >/dev/null \
 echo "ok: luna-sources — an empty configured-sources list reads absent"
 
 # ── file-exists: {homePath} placeholder (obsidian-second-brain) — HIMMEL-1100
-osb_home_present="$work/osb-home-present"; mkdir -p "$osb_home_present/.claude/plugins/obsidian-second-brain/.git"
+# HIMMEL-2891: the skill is deployed (and loaded by Claude Code) from
+# ~/.claude/skills/, never ~/.claude/plugins/ — the probe path was pointed at
+# a location nothing ever clones to; a plugins-dir fixture here reads absent
+# post-fix (RED control for the probe-path fix).
+osb_home_present="$work/osb-home-present"; mkdir -p "$osb_home_present/.claude/skills/obsidian-second-brain/.git"
 outOSBp=$("$node_bin" -e "
 const { runProbe } = require('$probes_lib_w');
 const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));

--- a/scripts/install/manifest.json
+++ b/scripts/install/manifest.json
@@ -393,7 +393,7 @@
       "scopes": ["user"],
       "profiles": ["luna", "all"],
       "deps": [],
-      "probe": { "type": "file-exists", "path": "{homePath}/.claude/plugins/obsidian-second-brain/.git" },
+      "probe": { "type": "file-exists", "path": "{homePath}/.claude/skills/obsidian-second-brain/.git" },
       "removable": "full-offboard-only",
       "offboard": "advise"
     },


### PR DESCRIPTION
## Why

The console dogfooded `himmelctl install` on the operator's Linux station and hit three small, adopter-facing bugs, each verified live and re-verified in this PR.

## What changed

### HIMMEL-2883 — generated launcher was a silent no-op
`himmelctl.js` (the PATH launcher install/update writes) `require()`d `bin.js`, but `bin.js` only runs `main()` under `if (require.main === module)` (the HIMMEL-2438 guard). Under `require()`, `require.main` is the launcher, not `bin.js` — so the guard never fired and `main()` silently never ran: empty stdout, rc 0, for every `himmelctl <command>` run through an installed launcher.

Fixed: the generated shim now re-execs `bin.js` as a child process (`spawnSync` + argv passthrough + `stdio:'inherit'`) instead of requiring it — a child process always has its own `require.main === itself`.

`docs/setup/migrating.md`'s documented `status` exit code (2, with no install record) turned out to already match the code — `cmdStatus` already returns 2 and an existing test (`test-wizard-status-cmd.sh` case d) already covers it. No code change needed there.

### HIMMEL-2885 — cadence arm rc 3 (already armed) read as a failure
`pipeline-cadence.sh`/`qmd-cadence.sh` `arm` exit 3 as their own dedup refusal when the unit is already armed — the converged state install wanted, not a failure. `himmelctl install` treated any non-zero arm rc as a failure, so a healthy, already-armed machine got `rc 1` and a `still manual — re-run to retry` line that loops forever against the same rc 3.

Fixed: rc 3 no longer flips the overall install rc, and renders under `skipped: ... already armed (rc 3)` instead of `still manual`. Never passes `--force` (that would re-arm/re-time the operator's existing crontab). rc 1/2/4+ are still failures.

### HIMMEL-2891 — obsidian-second-brain probe pointed at the wrong directory
The manifest probed `~/.claude/plugins/obsidian-second-brain/.git`, but Claude Code loads user skills from `~/.claude/skills/` — where the skill is actually cloned and live on the operator's own reference machine. `himmelctl status` read it as `n/a` with clone advice that would have produced a second, dead copy.

Fixed the probe path, the printed clone advice, and the matching path in `docs/setup/new-machine.md`'s install sequence, all to `~/.claude/skills/obsidian-second-brain`.

## Evidence

- New RED controls: `caseJ` (test-himmelctl-path-shim.sh, HIMMEL-2883), `caseArmRc3` (test-wizard-luna-sections.sh, HIMMEL-2885), updated present/absent fixture (test-wizard-probes.sh, HIMMEL-2891). `known-findings.sh --diff`'s test-coverage-gap checklist hit on `adopter-profile.js`/`status-report.js` is addressed by these — the behavior is tested end-to-end in `test-wizard-luna-sections.sh`/`test-wizard-probes.sh` (the file these two libs share their cadence/probe coverage with), not in a same-named paired test file.
- HIMMEL-2883's shim fix verified against a pristine pre-fix copy of the real `bin.js` (not a stub) to confirm the exact silent-no-op symptom reproduces, then confirmed the fix resolves it — both against production code.
- `bash scripts/install/manifest-lint.mjs` — OK (46 items).
- All 41 impacted suites (every suite referencing `bin.js`, `adopter-profile.js`, `status-report.js`, or `manifest.json`) run individually — all green.
- Verified live on the operator's own station: `himmelctl status` now reads `obsidian-second-brain` green against the real skills-dir clone; the fixed shim (built from this branch's real `bin.js`) prints full `--help` output and correct `status` output (rc 0/2 as appropriate).
- `/pr-check`: critic panel (codex, paid tier) responded clean — 0 Critical, 0 Important, 0 Suggestions. Marker cleared.

## Out of scope (separate tickets)
HIMMEL-2892 (adopt.sh merge / shared install-profile), HIMMEL-2890 (Linux poller-count), HIMMEL-2886 (luna template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSMkKfMv5ncdU8E5L6RU9h