### PR TITLE
test(console): [HIMMEL-2893] close vacuous-green holes; leg launcher releases the inline guard

### DIFF
--- a/.claude/commands/console.md
+++ b/.claude/commands/console.md
@@ -1,6 +1,6 @@
 ---
 description: Start a console session (new) or hand it over (next) — writes the doc, takes the queue lock, prints the launch line.
-argument-hint: new|next [--name <slug>] [--arm] [--dry-run] [--doc <path>] [--model <m>]
+argument-hint: new|next [--bucket <slug>] [--name <slug>] [--arm] [--dry-run] [--doc <path>] [--model <m>]
 ---
 
 A **console** is a long-running session that dispatches implementation legs,
@@ -20,7 +20,8 @@ bash scripts/handover/console/console.sh $ARGUMENTS
   overwrites.
 - `/console next` — from a running console, write the successor stub (letter
   bumped, pointed at this console and its HANDOFF) plus this console's
-  `-HANDOFF.md` skeleton. Run it at 45 % context fill.
+  `-HANDOFF.md` skeleton. Run it at 45 % context fill or after 90 k input
+  tokens in one turn.
 - `--arm` — also arm the session headed via `scripts/handover/headed-arm.sh`,
   on a signal file plus a deadline; prints the arm log path.
 - `--dry-run` — print what it would write, prefixed `would-`, and touch nothing.

--- a/scripts/handover/console-kit/headed-arm-leg.sh
+++ b/scripts/handover/console-kit/headed-arm-leg.sh
@@ -141,12 +141,13 @@ if [ -n "${LEG_REPO:-}" ]; then
     export HEADED_ARM_REPO
 fi
 
-# IMPL_GUARD_OK=1: the leg-only env headed-arm.sh's own child-env block
-# (shared with the console lane) does not set. Exported into THIS process's
-# environment so it survives unchanged through konsole's `-e env -u ...`
-# invocation inside headed-arm.sh, which only unsets the three HIMMEL-2545
-# vars and otherwise inherits its own environment as-is.
+# IMPL_GUARD_OK=1 / INLINE_IMPL_OK=1: leg-only env for
+# guard-implementor-dispatch / orchestrator-inline-guard (HIMMEL-2879).
+# headed-arm.sh's shared console/leg child-env block does not set these.
+# Export into THIS process so both survive konsole's `-e env -u ...`, which
+# only unsets the three HIMMEL-2545 vars and otherwise inherits as-is.
 export IMPL_GUARD_OK=1
+export INLINE_IMPL_OK=1
 # headed-arm.sh builds one argv array for both native and recorder launches and
 # refuses exit 2 if this exact pair is absent. This is the final resolved-argv
 # guard; the context-value check above gives the earlier operator-facing error.
@@ -164,8 +165,8 @@ fi
 if [ "$DRY_RUN" -eq 1 ]; then
     printf 'headed-arm-leg: would exec: %s %s %s %s %s %s %s %s\n' \
         "$HEADED_ARM" "$NAME" "$DOC" "$SIGNAL" "$DEADLINE" "$LOG" "$MODEL" "$CONTEXT"
-    printf 'headed-arm-leg: env IMPL_GUARD_OK=%s HEADED_ARM_REPO=%s\n' \
-        "$IMPL_GUARD_OK" "${HEADED_ARM_REPO:-<derived by headed-arm.sh>}"
+    printf 'headed-arm-leg: env IMPL_GUARD_OK=%s INLINE_IMPL_OK=%s HEADED_ARM_REPO=%s\n' \
+        "$IMPL_GUARD_OK" "$INLINE_IMPL_OK" "${HEADED_ARM_REPO:-<derived by headed-arm.sh>}"
     printf 'headed-arm-leg: lane=%s launcher=%s launcher-env=%s\n' \
         "$LANE" "${HEADED_ARM_LAUNCHER:-claude (native default)}" "${HEADED_ARM_LAUNCHER_ENV:-<none>}"
     exit 0

--- a/scripts/handover/console-kit/test-headed-arm-leg.sh
+++ b/scripts/handover/console-kit/test-headed-arm-leg.sh
@@ -16,7 +16,7 @@
 #        HEADED_ARM_PROC seams headed-arm.sh's own suite uses (the wrapper
 #        execs the real headed-arm.sh, so this proves the non-dry path carries
 #        --autocompact 200000); LEG_CONTEXT=1m refuses before headed-arm runs.
-#   10. IMPL_GUARD_OK=1 reaches the konsole invocation's own process
+#   10. IMPL_GUARD_OK=1 and INLINE_IMPL_OK=1 reach konsole's own process
 #       environment (the leg-only env headed-arm.sh's child-env block does
 #       not set).
 #   11. LEG_REPO reaches headed-arm.sh's --workdir.
@@ -36,7 +36,7 @@ SCRIPT="$HERE/headed-arm-leg.sh"
 HEADED_ARM="$HERE/../headed-arm.sh"
 # The suite owns every launcher input; an ambient leg shell must not silently
 # turn default-native cases into claudex cases.
-unset LEG_LANE LEG_CONTEXT LEG_REPO HEADED_ARM_LAUNCHER HEADED_ARM_LAUNCHER_ENV HEADED_ARM_RECORDER 2>/dev/null || true
+unset LEG_LANE LEG_CONTEXT LEG_REPO LEG_EFFORT HEADED_ARM_LAUNCHER HEADED_ARM_LAUNCHER_ENV HEADED_ARM_RECORDER IMPL_GUARD_OK INLINE_IMPL_OK 2>/dev/null || true
 
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/headed-arm-leg-test.XXXXXX")" || { echo "FAIL: mktemp -d failed" >&2; exit 1; }
 trap 'rm -rf "$tmp"' EXIT
@@ -51,7 +51,7 @@ PAST=$(( $(date +%s) - 100 ))
 
 # mk_launch_stubs <dir> <name> - konsole/pgrep/proc stubs, same shape
 # headed-arm.sh's own suite (test-headed-arm.sh) uses: konsole records its
-# FULL argv AND, filtered to the two non-secret guard vars (codex-1 review
+# FULL argv AND, filtered to the three non-secret guard vars (codex-1 review
 # finding: dumping the WHOLE inherited environment to disk would also write
 # exported credentials into the fixture directory), whether they reached its
 # own environment - the IMPL_GUARD_OK propagation case needs that, since
@@ -69,7 +69,7 @@ mk_launch_stubs() {
   cat > "$dir/konsole" <<'KONSOLE_EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$(dirname "$0")/record"
-env | grep -E '^(IMPL_GUARD_OK|HEADED_ARM_REQUIRED_AUTOCOMPACT)=' > "$(dirname "$0")/env-record"
+env | grep -E '^(IMPL_GUARD_OK|INLINE_IMPL_OK|HEADED_ARM_REQUIRED_AUTOCOMPACT)=' > "$(dirname "$0")/env-record"
 : > "$(dirname "$0")/confirmable"
 sleep 5
 KONSOLE_EOF
@@ -169,6 +169,7 @@ check "dry-run default: exit 0" "$rc" "0"
 ends_with "dry-run default: context=standard, no LEG_CONTEXT" "$out" "standard"
 not_contains "dry-run default: no [1m] suffix in the would-exec line" "$out" "[1m]"
 contains "dry-run default: reports IMPL_GUARD_OK=1" "$out" "IMPL_GUARD_OK=1"
+contains "dry-run default: reports INLINE_IMPL_OK=1" "$out" "INLINE_IMPL_OK=1"
 
 rc=0; out="$(LEG_CONTEXT=1m bash "$SCRIPT" --dry-run HIMMEL-9999-leg some/doc.md /tmp/nosig 99999999999 /tmp/leg.log claude-sonnet-5 2>&1)" || rc=$?
 check "dry-run LEG_CONTEXT=1m: refused with exit 2" "$rc" "2"
@@ -234,6 +235,7 @@ check "full launch, LEG_CONTEXT=1m: headed-arm was never invoked" "$rec9" ""
 # --- 10. IMPL_GUARD_OK reaches the konsole invocation's own environment ----
 env8="$(cat "$d8/env-record" 2>/dev/null || true)"
 contains "full launch: IMPL_GUARD_OK=1 in the konsole invocation's env" "$env8" "IMPL_GUARD_OK=1"
+contains "full launch: INLINE_IMPL_OK=1 in the konsole invocation's env" "$env8" "INLINE_IMPL_OK=1"
 not_contains "full launch: internal autocompact requirement does not leak into the launched leg" "$env8" "HEADED_ARM_REQUIRED_AUTOCOMPACT="
 
 # --- 12. RED control: mutate the ACTUAL headed-arm launch renderer to drop

--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -527,6 +527,11 @@ cmd_next() {
     fi
     set +C
 
+    # This invocation owns the exclusively claimed stub. Any abort before
+    # both renders finish (including render_template's exit) must remove it
+    # so a repaired template or directory can be retried without hand cleanup.
+    trap 'rm -f "$doc"' EXIT
+
     # `next` never acquires a lock itself (the successor takes its own at
     # ACTION ZERO) — so, unlike `new`, there is no real token to carry here.
     # An honest, explicit placeholder rather than an empty string: the
@@ -584,19 +589,10 @@ cmd_next() {
             echo "handoff: $predecessor_handoff (exists — left unchanged)"
         else
             err "could not create HANDOFF at $predecessor_handoff — this is not a collision (the file does not exist); check permissions on $(dirname "$predecessor_handoff")"
-            # Make `next` atomic on this abort path: $doc was claimed by
-            # THIS invocation's own exclusive create above — a
-            # pre-existing successor doc would already have exited via the
-            # "already exists" guard, so reaching here means it is ours to
-            # remove, never a stub some other run left behind. Leaving it
-            # in place would otherwise strand the operator mid-handover: a
-            # retry after fixing permissions would hit that same
-            # already-exists guard and refuse, forcing a hand-delete at
-            # the worst possible moment (context nearly full).
-            rm -f "$doc"
             exit 1
         fi
     fi
+    trap - EXIT
 
     echo "launch: claude --model $model --autocompact auto -n $session \"load $doc and continue\""
 

--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -326,13 +326,20 @@ cmd_new() {
     # refuse an existing target instead of overwriting it; on a collision
     # (either a real pre-existing doc or a losing race) this advances to the
     # next letter rather than failing.
-    local letter doc claimed=0
+    local letter doc create_error claimed=0
     set -C
     for letter in {A..Z}; do
         doc="$state_dir/${prefix}-nextleg-${date}${letter}-${name}.md"
-        if : 2>/dev/null > "$doc"; then
+        if create_error="$( { : > "$doc"; } 2>&1 )"; then
             claimed=1
             break
+        fi
+        # Only an existing document (or symlink reserved by another caller)
+        # is a collision. Other failures must keep their actual diagnostic.
+        if [ ! -f "$doc" ] && [ ! -L "$doc" ]; then
+            set +C
+            err "could not create console doc $doc: $create_error"
+            exit 1
         fi
     done
     set +C
@@ -469,7 +476,7 @@ cmd_next() {
     # HANDOFF sits beside the predecessor's OWN doc, not in $state_dir — a
     # --doc pointing outside $state_dir (a different bucket, a different
     # root entirely) must still get its HANDOFF written next to it.
-    local predecessor_dir predecessor_handoff predecessor_handoff_ref
+    local predecessor_dir predecessor_handoff predecessor_handoff_ref successor_doc_ref
     predecessor_dir="$(dirname "$predecessor_doc")"
     # Canonicalise: a RELATIVE --doc outside $state_dir would otherwise
     # leave predecessor_handoff_ref relative too, breaking the "absolute
@@ -488,8 +495,10 @@ cmd_next() {
     # and never find it.
     if [ "$predecessor_dir" = "$state_dir" ]; then
         predecessor_handoff_ref="$(basename "$predecessor_handoff")"
+        successor_doc_ref="$(basename "$doc")"
     else
         predecessor_handoff_ref="$predecessor_handoff"
+        successor_doc_ref="$doc"
     fi
     local fill_signal="$chain_dir/sig-$session"
     local log="$chain_dir/launch-$session.log"
@@ -570,7 +579,7 @@ cmd_next() {
             PREDECESSOR_LETTER "$predecessor_letter" \
             LETTER "$successor_letter" \
             PREDECESSOR "$predecessor_base" \
-            SUCCESSOR_DOC "$(basename "$doc")" \
+            SUCCESSOR_DOC "$successor_doc_ref" \
             REPO "$repo" \
             BUCKET "$bucket" \
             KIT "$kit"

--- a/scripts/handover/console/test-console.sh
+++ b/scripts/handover/console/test-console.sh
@@ -24,6 +24,8 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 C="$HERE/console.sh"
 REPO_REAL="$(cd "$HERE/../../.." && pwd)"
 QL="$REPO_REAL/scripts/handover/queue-lock.sh"
+# shellcheck source=../../lib/permission-test.sh
+. "$HERE/../../lib/permission-test.sh"
 
 # Templated (BSD/macOS mktemp requires one); refuse loudly on failure BEFORE
 # the EXIT trap is registered — an empty $tmp would otherwise make the trap
@@ -175,14 +177,31 @@ leak_free() {
 # unrelated
 # leak, or a line that merely LOOKS token-shaped, still fails loudly.
 known_tokens=("$token1" "$token4" "$token6a" "$token6ba" "$token7a")
-leak_lines="$(grep -rniE "$BANNED" "$root" 2>/dev/null)"
-leak_residual="$(printf '%s\n' "$leak_lines" | grep -vE -- '-pid[0-9]+')"
-check "8 no leak under the temp handover root (excluding release-token lines)" \
+token_residual() {
+    local token
+    for token in "$@"; do
+        [ -n "$token" ] || { echo "empty release-token capture" >&2; return 2; }
+    done
+    # Match the entire indented token line in console-template.md, not a
+    # substring. Scan raw content, without grep's filename/line prefixes.
+    grep -vxFf <(printf '   %s\n' "$@") || [ "$?" -eq 1 ]
+}
+token_rc=0
+token_residual "${known_tokens[@]}" </dev/null || token_rc=$?
+check "8 every known release token was actually captured" "$token_rc" "0"
+leak_lines="$(grep -rhEi "$BANNED" "$root" 2>/dev/null)"
+leak_residual="$(printf '%s\n' "$leak_lines" | token_residual "${known_tokens[@]}")"
+check "8 no leak under the temp handover root (excluding exact release-token lines)" \
     "$(printf '%s\n' "$leak_residual" | grep -c .)" "0"
-token_lines="$(printf '%s\n' "$leak_lines" | grep -E -- '-pid[0-9]+')"
-unaccounted_token_lines="$(printf '%s\n' "$token_lines" | grep -vFf <(printf '%s\n' "${known_tokens[@]}"))"
-check "8 every release-token line found matches a token 'new' actually printed" \
-    "$(printf '%s\n' "$unaccounted_token_lines" | grep -c .)" "0"
+check "8 exact known token line is exempt" \
+    "$(printf '   %s\n' "$token1" | token_residual "${known_tokens[@]}")" ""
+# A legitimate token must not hide an unrelated banned value on the same line.
+mixed_line="   $token1 ${BANNED%%|*}"
+check "8 negative control: a known token plus a banned value remains a leak" \
+    "$(printf '%s\n' "$mixed_line" | token_residual "${known_tokens[@]}")" "$mixed_line"
+empty_rc=0
+printf '%s\n' "$mixed_line" | token_residual "$token1" "" >/dev/null 2>&1 || empty_rc=$?
+check "8 negative control: an empty token capture is rejected" "$empty_rc" "2"
 check "8 no leak in console.sh" "$(leak_free "$C")" "yes"
 check "8 no leak in test-console.sh" "$(leak_free "$HERE/test-console.sh")" "yes"
 check "8 no leak in console-template.md" "$(leak_free "$REPO_REAL/docs/handover/console-template.md")" "yes"
@@ -407,11 +426,13 @@ out24a="$(console new --bucket rodir)"
 token24a="$(token_of "$out24a")"
 doc24A="$root/tester/rodir/DEMO-nextleg-${today}A-console.md"
 chmod 555 "$root/tester/rodir"
-rc24=0
-out24b="$(console next --bucket rodst --doc "$doc24A" 2>&1)" || rc24=$?
+if test_dir_unwritable "$root/tester/rodir" "24 non-writable predecessor dir"; then
+    rc24=0
+    out24b="$(console next --bucket rodst --doc "$doc24A" 2>&1)" || rc24=$?
+    check "24 non-writable predecessor dir: next --doc exits non-zero" "$([ "$rc24" -ne 0 ] && echo yes)" "yes"
+    check "24 non-writable predecessor dir: no launch line printed" "$(printf '%s\n' "$out24b" | grep -c '^launch: ')" "0"
+fi
 chmod 755 "$root/tester/rodir"
-check "24 non-writable predecessor dir: next --doc exits non-zero" "$([ "$rc24" -ne 0 ] && echo yes)" "yes"
-check "24 non-writable predecessor dir: no launch line printed" "$(printf '%s\n' "$out24b" | grep -c '^launch: ')" "0"
 HANDOVER_DIR="$root" bash "$QL" release "$doc24A" "$token24a" >/dev/null 2>&1
 
 # --- 25: next is ATOMIC on the HANDOFF-create abort path -- it must not
@@ -426,18 +447,46 @@ doc25B="$root/tester/atomicdst/DEMO-nextleg-${today}B-console.md"
 handoff25A="$root/tester/atomicsrc/DEMO-nextleg-${today}A-console-HANDOFF.md"
 
 chmod 555 "$root/tester/atomicsrc"
-rc25=0
-console next --bucket atomicdst --doc "$doc25A" >/dev/null 2>&1 || rc25=$?
-check "25 step1: aborts non-zero" "$([ "$rc25" -ne 0 ] && echo yes)" "yes"
-check "25 step2: leaves no successor stub" "$([ -f "$doc25B" ] && echo yes || echo no)" "no"
+if test_dir_unwritable "$root/tester/atomicsrc" "25 HANDOFF-create abort / no stub / retry"; then
+    rc25=0
+    console next --bucket atomicdst --doc "$doc25A" >/dev/null 2>&1 || rc25=$?
+    check "25 step1: aborts non-zero" "$([ "$rc25" -ne 0 ] && echo yes)" "yes"
+    check "25 step2: leaves no successor stub" "$([ -f "$doc25B" ] && echo yes || echo no)" "no"
 
-chmod 755 "$root/tester/atomicsrc"
-rc25b=0
-console next --bucket atomicdst --doc "$doc25A" >/dev/null 2>&1 || rc25b=$?
-check "25 step3 (the control): the identical retry now succeeds" "$rc25b" "0"
-check "25 step3: the retry actually wrote the successor doc" "$([ -f "$doc25B" ] && echo yes)" "yes"
-check "25 step3: the retry actually wrote the HANDOFF" "$([ -f "$handoff25A" ] && echo yes)" "yes"
+    chmod 755 "$root/tester/atomicsrc"
+    rc25b=0
+    console next --bucket atomicdst --doc "$doc25A" >/dev/null 2>&1 || rc25b=$?
+    check "25 step3 (the control): the identical retry now succeeds" "$rc25b" "0"
+    check "25 step3: the retry actually wrote the successor doc" "$([ -f "$doc25B" ] && echo yes)" "yes"
+    check "25 step3: the retry actually wrote the HANDOFF" "$([ -f "$handoff25A" ] && echo yes)" "yes"
+else
+    chmod 755 "$root/tester/atomicsrc"
+fi
 HANDOVER_DIR="$root" bash "$QL" release "$doc25A" "$token25a" >/dev/null 2>&1
+
+# --- 25b: the same abort / no stub / retry chain through HANDOFF rendering.
+# An unresolved placeholder fails after the successor was already rendered.
+render_tpl_dir="$tmp/render-failure-templates"
+mkdir -p "$render_tpl_dir" "$root/tester/rendersrc"
+cp "$REPO_REAL/docs/handover/console-template.md" "$render_tpl_dir/console-template.md"
+printf '{{BROKEN_PLACEHOLDER}}\n' > "$render_tpl_dir/console-handoff-template.md"
+doc25bA="$root/tester/rendersrc/DEMO-nextleg-${today}A-console.md"
+doc25bB="$root/tester/renderdst/DEMO-nextleg-${today}B-console.md"
+handoff25bA="$root/tester/rendersrc/DEMO-nextleg-${today}A-console-HANDOFF.md"
+printf 'predecessor\n' > "$doc25bA"
+rc25c=0
+out25c="$(CONSOLE_TEMPLATE_DIR="$render_tpl_dir" console next --bucket renderdst --doc "$doc25bA" 2>&1)" || rc25c=$?
+check "25b step1: render aborts with exit 1" "$rc25c" "1"
+check "25b step1: failure names the unresolved placeholder" "$(printf '%s\n' "$out25c" | grep -c 'unresolved placeholder {{BROKEN_PLACEHOLDER}}')" "1"
+check "25b step1: render failure prints no launch line" "$(printf '%s\n' "$out25c" | grep -c '^launch: ')" "0"
+check "25b step2: leaves no successor stub" "$([ -e "$doc25bB" ] && echo yes || echo no)" "no"
+check "25b step2: leaves no partial HANDOFF" "$([ -e "$handoff25bA" ] && echo yes || echo no)" "no"
+cp "$REPO_REAL/docs/handover/console-handoff-template.md" "$render_tpl_dir/console-handoff-template.md"
+rc25d=0
+CONSOLE_TEMPLATE_DIR="$render_tpl_dir" console next --bucket renderdst --doc "$doc25bA" >/dev/null 2>&1 || rc25d=$?
+check "25b step3 (the control): retry with repaired template succeeds" "$rc25d" "0"
+check "25b step3: retry wrote the successor doc" "$([ -s "$doc25bB" ] && echo yes)" "yes"
+check "25b step3: retry wrote the HANDOFF" "$([ -s "$handoff25bA" ] && echo yes)" "yes"
 
 # --- 26: {{RELEASE_TOKEN}} carries the REAL acquired token into the doc on
 # --arm -- the one path that had no other way to deliver it to the launched

--- a/scripts/handover/console/test-console.sh
+++ b/scripts/handover/console/test-console.sh
@@ -31,6 +31,7 @@ QL="$REPO_REAL/scripts/handover/queue-lock.sh"
 # the EXIT trap is registered — an empty $tmp would otherwise make the trap
 # clean up the wrong thing.
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/console-test.XXXXXX")" || { echo "test-console: mktemp -d failed" >&2; exit 1; }
+tmp="$(cd "$tmp" && pwd -P)"
 trap 'rm -rf "$tmp"' EXIT
 
 fails=0
@@ -122,6 +123,14 @@ check "6b next --doc still writes the successor stub into its own state_dir" "$(
 check "6b next --doc writes the HANDOFF beside the predecessor" "$([ -f "$handoff6bSrc" ] && echo yes)" "yes"
 check "6b next --doc does not write the HANDOFF into the successor's state_dir" "$([ -f "$handoff6bWrong" ] && echo yes || echo no)" "no"
 check "6b successor stub names a resolvable (absolute) HANDOFF reference" "$(grep -cF "$handoff6bSrc" "$doc6bDst")" "1"
+# shellcheck disable=SC2016 # Match literal Markdown backticks, not command substitution.
+successor6b_ref="$(sed -n 's/^Run ACTION ZERO from `\([^`]*\)` unchanged.*/\1/p' "$handoff6bSrc")"
+check "6b HANDOFF names the absolute cross-bucket successor" "$successor6b_ref" "$doc6bDst"
+case "$successor6b_ref" in
+    /*) successor6b_path="$successor6b_ref" ;;
+    *) successor6b_path="$(dirname "$handoff6bSrc")/$successor6b_ref" ;;
+esac
+check "6b successor reference resolves from the HANDOFF directory" "$([ -f "$successor6b_path" ] && echo yes)" "yes"
 HANDOVER_DIR="$root" bash "$QL" release "$doc6bSrc" "$token6ba" >/dev/null 2>&1
 
 # --- 7: next --arm with a stub arm target ------------------------------
@@ -324,6 +333,34 @@ check "16 new advances past an already-claimed letter" "$([ -f "$racetest_docB" 
 sum_racetestA_after="$(cksum < "$racetest_docA")"
 check "16 the already-claimed doc is left untouched" "$sum_racetestA_before" "$sum_racetestA_after"
 HANDOVER_DIR="$root" bash "$QL" release "$racetest_docB" "$token16" >/dev/null 2>&1
+
+# --- 16b: exhaustion requires 26 real collisions, not arbitrary I/O errors.
+mkdir -p "$root/tester/exhausted"
+for letter16 in {A..Z}; do
+    printf 'claimed\n' > "$root/tester/exhausted/DEMO-nextleg-${today}${letter16}-console.md"
+done
+rc16b=0
+out16b="$(console new --bucket exhausted 2>&1)" || rc16b=$?
+check "16b all 26 claimed letters: exits 1" "$rc16b" "1"
+check "16b all 26 claimed letters: reports exhaustion" "$(printf '%s\n' "$out16b" | grep -c 'all 26 letters')" "1"
+
+# A directory at candidate A is EISDIR, not an existing console document.
+blocked16A="$root/tester/createerror/DEMO-nextleg-${today}A-console.md"
+mkdir -p "$blocked16A"
+rc16c=0
+out16c="$(LC_ALL=C console new --bucket createerror 2>&1)" || rc16c=$?
+check "16c non-collision at A: exits 1" "$rc16c" "1"
+check "16c non-collision at A: reports the underlying error" "$(printf '%s\n' "$out16c" | grep -ci 'is a directory')" "1"
+check "16c non-collision at A: never tries B" "$([ -e "$root/tester/createerror/DEMO-nextleg-${today}B-console.md" ] && echo yes || echo no)" "no"
+check "16c non-collision at A: does not report exhaustion" "$(printf '%s\n' "$out16c" | grep -c 'all 26 letters')" "0"
+
+# ENAMETOOLONG cannot be confused with any pre-existing candidate (even as root).
+long16_name="$(printf '%0260d' 0)"
+rc16d=0
+out16d="$(LC_ALL=C console new --bucket longname --name "$long16_name" 2>&1)" || rc16d=$?
+check "16d non-collision with no candidate: exits 1" "$rc16d" "1"
+check "16d non-collision with no candidate: reports the underlying error" "$(printf '%s\n' "$out16d" | grep -ci 'file name too long')" "1"
+check "16d non-collision with no candidate: does not report exhaustion" "$(printf '%s\n' "$out16d" | grep -c 'all 26 letters')" "0"
 
 # --- 17: chains differing only by --bucket get different signal/log paths
 # The session-name shape (<PREFIX>-nextleg-<date><letter>-<name>) is

--- a/scripts/lib/permission-test.sh
+++ b/scripts/lib/permission-test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# permission-test.sh — effective directory-write control for shell suites
+# (HIMMEL-2893). Source after creating the fixture and removing write bits.
+# Platform guard (gitbash-only): POSIX shell-test helper; no .ps1 twin.
+
+# test_dir_unwritable <directory> <case label>
+# A successful probe means chmod did not build the intended fixture (root or
+# ACL passthrough). The caller must restore permissions even when skipping.
+test_dir_unwritable() {
+    local probe
+    if probe="$(mktemp "$1/.write-probe.XXXXXX" 2>/dev/null)"; then
+        rm -f "$probe"
+        printf 'SKIP - %s: chmod did not deny directory writes (root or filesystem permissions)\n' "$2"
+        return 1
+    fi
+    return 0
+}


### PR DESCRIPTION
## Summary

Closes HIMMEL-2893, HIMMEL-2879 and HIMMEL-2897 in three ticket-specific commits. Forward-fixes the [seven findings posted after PR #599 merged](https://github.com/yotamleo/Himmel/pull/599#pullrequestreview-5160589704); all were verified against current main.

- **HIMMEL-2893:** require exact, whole-line release-token exemptions; reject empty captures; loudly skip permission fixtures when chmod does not actually deny writes; share successor-stub cleanup across HANDOFF create/render aborts so repaired-template retry works.
- **HIMMEL-2879:** export `INLINE_IMPL_OK=1` beside `IMPL_GUARD_OK=1` in the leg launcher only, with dry-run and actual child-environment coverage. This is the pre-HIMMEL-2830 stopgap. Guard hooks and the shared console launcher are unchanged. The suite clears inherited guard flags and `LEG_EFFORT` to make its assertions independent of the launching leg.
- **HIMMEL-2897:** make cross-bucket `SUCCESSOR_DOC` references absolute, distinguish failed creation from 26 confirmed collisions, canonicalize test TMPDIR, and document both handoff triggers plus `--bucket`. Empty-token and permission-probe findings overlap the HIMMEL-2893 commit.

### Shared permission helper

Extracted `scripts/lib/permission-test.sh:test_dir_unwritable` after finding analogous chmod-based directory fixtures in `scripts/himmelctl/test/test-himmelctl-path-shim.sh`, `scripts/telegram/test-restart-bridge.sh`, `scripts/test-adopt.sh`, and `scripts/test-uninstall.sh`. This PR adopts it in console cases 24/25 only; unrelated suites are not refactored. Both branches were exercised: native unprivileged Linux runs execute the assertions; a controlled no-op-chmod fixture produces named SKIPs for case 24 and all of case 25, then passes. No actual root or Windows run was performed.

## Verification

All tests run through `scripts/quiet-run.sh`, against temporary roots and stub launchers only.

| Control | Before fix | After fix |
|---|---|---|
| Known token + unrelated banned value; empty token capture | Both negative controls failed | Both pass; exact token line remains exempt |
| chmod cannot deny writes | 5 failing assertions | Two named SKIPs; native permission assertions still pass |
| Broken HANDOFF template → abort → no stub → retry | 3 failures, including stranded stub and failed retry | Complete recovery chain passes |
| Inline guard flag in dry-run / child environment | Both missing-flag assertions failed | Both guard flags arrive |
| Cross-bucket ACTION ZERO, EISDIR, ENAMETOOLONG | 7 failures | All pass; 26-real-collision exhaustion remains covered |
| Symlinked TMPDIR | 2 additional path assertion failures | Entire suite passes |

- `bash scripts/handover/console/test-console.sh`: **ALL PASS**, also with symlinked TMPDIR and ineffective chmod fixtures.
- `bash scripts/handover/console-kit/test-headed-arm-leg.sh`: **PASS**.
- Reference search found these two impacted suites; both were run. Full local shell suite intentionally not run.
- ShellCheck: clean on all five changed shell files. `git diff --check`: clean. Commit/push gates passed.
- Known-findings checklist: helper has no separate paired suite; its effective-write and skip branches are verified through the console suite runs described above.
- `/pr-check`: **round 1 of 3**, 1/1 critic responded (`codex`, responding model `gpt-6-astra`), **0 critical / 0 important / 0 suggestions**. Adversarial runner skipped as not high-risk (HIMMEL-2707). Same-family local review. CodeRabbit was requested once for this head and returned the following status verbatim: `CodeRabbit | success | Review rate limited`. It did not review the code; the green status is not review evidence. No second trigger was sent. No PR existed during the local thread gate, so that gate was not run; post-PR CI/thread verification and final console verification remain pending.
- `known-findings: round-1 hits = 0`.

## Scope and safety

No changes to `scripts/hooks/`, `merge-on-green.sh`, root `CLAUDE.md`, `README.md`, or `docs/handover/running-a-console.md`. Existing successor documents remain protected by exclusive creation. Cleanup is registered only after this invocation owns the stub, and disarmed before launch. No console command was run against a live handover root.

Platforms tested: linux
Security reviewed: manual — owned-stub cleanup, exact token accounting, fixture-scoped permission probe, existing audited leg-only implementation override

🤖 Generated with [Claude Code](https://claude.com/claude-code)
