### PR TITLE
feat(cr): [HIMMEL-2896] ledger fingerprints findings and records dispositions; the panel marks verbatim re-raises of disproved/deferred findings instead of re-litigating them

### DIFF
--- a/scripts/cr/critic-panel.sh
+++ b/scripts/cr/critic-panel.sh
@@ -1035,6 +1035,7 @@ global_id=0
 agg_crit=""
 agg_imp=""
 agg_sug=""
+agg_reraise=""
 agg_drop=""
 agg_drop_blocking=""
 # member_parsed record separator (HIMMEL-1871 round 6): \034, matching the
@@ -1172,11 +1173,16 @@ _append_panel_ledger() {
     # spool fields (file paths, severities) flow through JSON.stringify rather
     # than hand-built quoting.
     _apl_have_findings=0
+    [ -s "$PANEL_SPOOL_DIR/.finding-enriched.jsonl" ] && _apl_have_findings=1
     for _apl_spool in "$PANEL_SPOOL_DIR"/finding.*; do
         if [ -f "$_apl_spool" ]; then _apl_have_findings=1; fi
     done
     if [ "$_apl_have_findings" -eq 1 ]; then
         _apl_batch_file="$PANEL_SPOOL_DIR/.finding-batch.jsonl"
+        : > "$_apl_batch_file"
+        if [ -s "$PANEL_SPOOL_DIR/.finding-enriched.jsonl" ]; then
+            cp "$PANEL_SPOOL_DIR/.finding-enriched.jsonl" "$_apl_batch_file"
+        fi
         # Hand node the spool CONTENT on stdin and take the JSONL back on
         # stdout - never a PATH through the environment. Git-Bash rewrites
         # POSIX-looking paths in env vars when it spawns a native node.exe; it
@@ -1189,7 +1195,7 @@ _append_panel_ledger() {
         # boundary as a path now, so there is nothing left to rewrite.
         if { for _apl_spool in "$PANEL_SPOOL_DIR"/finding.*; do
                  if [ -f "$_apl_spool" ]; then cat "$_apl_spool"; fi
-             done; } | REVIEW_BRANCH="$REVIEW_BRANCH" REVIEW_HEAD="$REVIEW_HEAD" node -e '
+             done; } | REVIEW_BRANCH="$REVIEW_BRANCH" REVIEW_HEAD="$REVIEW_HEAD" CR_REVIEW_ROUND="${CR_REVIEW_ROUND:-}" node -e '
             const e=process.env;
             const lines=require("fs").readFileSync(0,"utf8").split("\n").filter(Boolean);
             const out=[];
@@ -1204,11 +1210,12 @@ _append_panel_ledger() {
               if(!id) continue;
               const row={branch:e.REVIEW_BRANCH,head:e.REVIEW_HEAD,
                 model,id,severity,file,line:ln,verdict:""};
+              if(/^[1-9][0-9]*$/.test(e.CR_REVIEW_ROUND||"")) row.round=Number(e.CR_REVIEW_ROUND);
               if(text) row.text=text;
               out.push(JSON.stringify(row));
             }
             process.stdout.write(out.length?out.join("\n")+"\n":"");
-        ' > "$_apl_batch_file"; then
+        ' >> "$_apl_batch_file"; then
             if [ -s "$_apl_batch_file" ]; then
                 CR_LEDGER="$PANEL_LEDGER" bash "$LEDGER_APPEND" finding --batch-file "$_apl_batch_file" || _apl_failed=1
             fi
@@ -1949,11 +1956,41 @@ ROWSEOF
     done
 fi
 
+# Match current findings against the latest durable disposition for the same
+# branch + fingerprint + artifact + perspective. On success the helper writes
+# one enriched JSONL batch for persistence and active/reraise render spools. If
+# lookup fails, leave the original aggregates and raw finding spools untouched:
+# findings remain active and visible rather than being silently suppressed.
+_have_panel_findings=0
+for _rf_spool in "$PANEL_SPOOL_DIR"/finding.*; do
+    [ -f "$_rf_spool" ] && _have_panel_findings=1
+done
+if [ "$_have_panel_findings" -eq 1 ]; then
+    if { for _rf_spool in "$PANEL_SPOOL_DIR"/finding.*; do
+             [ -f "$_rf_spool" ] && cat "$_rf_spool"
+         done; } | CR_LEDGER="$PANEL_LEDGER" REVIEW_BRANCH="$REVIEW_BRANCH" REVIEW_HEAD="$REVIEW_HEAD" \
+             CR_REVIEW_ROUND="${CR_REVIEW_ROUND:-}" PANEL_SPOOL_DIR="$PANEL_SPOOL_DIR" \
+             node "$SCRIPT_DIR/finding-reraise.js" > "$PANEL_SPOOL_DIR/.finding-enriched.jsonl"; then
+        agg_crit="$(cat "$PANEL_SPOOL_DIR/.active-crit")"
+        agg_imp="$(cat "$PANEL_SPOOL_DIR/.active-imp")"
+        agg_sug="$(cat "$PANEL_SPOOL_DIR/.active-sug")"
+        agg_reraise="$(cat "$PANEL_SPOOL_DIR/.reraises")"
+        for _rf_spool in "$PANEL_SPOOL_DIR"/finding.*; do
+            [ -f "$_rf_spool" ] && rm -f "$_rf_spool"
+        done
+    else
+        echo "critic-panel.sh: disposition lookup failed; leaving every finding active" >&2
+        rm -f "$PANEL_SPOOL_DIR/.finding-enriched.jsonl" "$PANEL_SPOOL_DIR/.active-crit" \
+            "$PANEL_SPOOL_DIR/.active-imp" "$PANEL_SPOOL_DIR/.active-sug" "$PANEL_SPOOL_DIR/.reraises"
+    fi
+fi
+
 # Count bullets per section
-nc=0; ni=0; ns=0; nd=0
+nc=0; ni=0; ns=0; nr=0; nd=0
 [ -n "$agg_crit" ] && nc="$(printf '%s\n' "$agg_crit" | grep -c '^- ')" || nc=0
 [ -n "$agg_imp"  ] && ni="$(printf '%s\n' "$agg_imp"  | grep -c '^- ')" || ni=0
 [ -n "$agg_sug"  ] && ns="$(printf '%s\n' "$agg_sug"  | grep -c '^- ')" || ns=0
+[ -n "$agg_reraise" ] && nr="$(printf '%s\n' "$agg_reraise" | grep -c '^- ')" || nr=0
 [ -n "$agg_drop" ] && nd="$(printf '%s\n' "$agg_drop" | grep -c '^- ')" || nd=0
 
 # Rejected blocking citations are a completed response, not member unavailability:
@@ -2067,6 +2104,11 @@ if [ "$responded" -ge 1 ]; then
     printf '\n'
     printf '## Suggestions (%d found)\n' "$ns"
     [ -n "$agg_sug" ] && printf '%s\n' "$agg_sug"
+    if [ "$nr" -gt 0 ]; then
+        printf '\n'
+        printf '## Already Dispositioned Re-raises (%d found)\n' "$nr"
+        printf '%s\n' "$agg_reraise"
+    fi
     if [ "$nd" -gt 0 ]; then
         printf '\n'
         printf '## Dropped Citations (%d dropped)\n' "$nd"

--- a/scripts/cr/critic-panel.sh
+++ b/scripts/cr/critic-panel.sh
@@ -1181,7 +1181,7 @@ _append_panel_ledger() {
         _apl_batch_file="$PANEL_SPOOL_DIR/.finding-batch.jsonl"
         : > "$_apl_batch_file"
         if [ -s "$PANEL_SPOOL_DIR/.finding-enriched.jsonl" ]; then
-            cp "$PANEL_SPOOL_DIR/.finding-enriched.jsonl" "$_apl_batch_file"
+            cp "$PANEL_SPOOL_DIR/.finding-enriched.jsonl" "$_apl_batch_file" || _apl_failed=1
         fi
         # Hand node the spool CONTENT on stdin and take the JSONL back on
         # stdout - never a PATH through the environment. Git-Bash rewrites

--- a/scripts/cr/finding-fingerprint.js
+++ b/scripts/cr/finding-fingerprint.js
@@ -10,7 +10,9 @@ function foldWhitespace(value) {
 }
 
 function normalizeFileAnchor(file) {
-  return foldWhitespace(file)
+  return String(file == null ? '' : file)
+    .replace(/\s+/g, ' ')
+    .trim()
     .replace(/\\/g, '/')
     .replace(/^\.\//, '')
     .replace(/:(?:l)?\d+(?:-\d+)?$/i, '');

--- a/scripts/cr/finding-fingerprint.js
+++ b/scripts/cr/finding-fingerprint.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const crypto = require('crypto');
+
+function foldWhitespace(value) {
+  return String(value == null ? '' : value)
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeFileAnchor(file) {
+  return foldWhitespace(file)
+    .replace(/\\/g, '/')
+    .replace(/^\.\//, '')
+    .replace(/:(?:l)?\d+(?:-\d+)?$/i, '');
+}
+
+function scrubClaim(text) {
+  return String(text == null ? '' : text)
+    .replace(/[\r\n]/g, ' ')
+    .replace(/[0-9]{8,10}:[A-Za-z0-9_-]{35}/g, '[REDACTED]')
+    .replace(/(Bearer|bearer) [A-Za-z0-9._-]{16,}/g, '$1 [REDACTED]')
+    .replace(/sk-[A-Za-z0-9][A-Za-z0-9_-]{15,}/g, '[REDACTED]')
+    .replace(/AKIA[0-9A-Z]{16}/g, '[REDACTED]')
+    .replace(/([Aa][Pp][Ii][_-]?[Kk]ey|[Tt]oken|[Ss]ecret)[ \t]*[:=][ \t]*[A-Za-z0-9._-]{12,}/g, '$1=[REDACTED]');
+}
+
+function normalizeClaim(text) {
+  let claim = scrubClaim(text)
+    .replace(/^\s*-\s*\[[^\]]+\]\s*:\s*/, '');
+
+  // Finding citations are trailing [file:line] tokens. Remove only their line
+  // coordinates; every number in the prose claim remains fingerprint-significant.
+  claim = claim.replace(/\s*\[[^\]\r\n]+:\d+(?:-\d+)?\]\s*$/, '');
+  return foldWhitespace(claim);
+}
+
+function findingFingerprint(slug, file, text) {
+  const normalizedSlug = foldWhitespace(slug);
+  const normalizedAnchor = normalizeFileAnchor(file);
+  const normalizedClaim = normalizeClaim(text);
+  if (!normalizedSlug || !normalizedClaim) return '';
+  const digest = crypto.createHash('sha256')
+    .update(`${normalizedSlug}${normalizedAnchor}${normalizedClaim}`, 'utf8')
+    .digest('hex');
+  return `fp1:${digest}`;
+}
+
+module.exports = {
+  findingFingerprint,
+  normalizeClaim,
+  normalizeFileAnchor,
+};

--- a/scripts/cr/finding-reraise.js
+++ b/scripts/cr/finding-reraise.js
@@ -22,6 +22,10 @@ function validRound(value) {
   return /^[1-9][0-9]*$/.test(String(value == null ? '' : value));
 }
 
+function severityRank(value) {
+  return { sug: 1, imp: 2, crit: 3 }[String(value || '')] || 0;
+}
+
 function validDeferred(row) {
   return row.verdict === 'deferred' &&
     /^[A-Z][A-Z0-9]*-[0-9]+$/.test(String(row.deferred_to || '')) &&
@@ -46,7 +50,19 @@ for (const row of ledgerRows) {
     const sourceKey = findingKey(row.head, row.finding_id, row.artifact, row.perspective);
     states.set(sourceKey, state);
     if (state.fingerprint && state.verdict) {
-      latest.set(dispositionKey(state), { ...state, _sourceKey: sourceKey });
+      const key = dispositionKey(state);
+      const previous = latest.get(key);
+      const event = { ...state, _sourceKey: sourceKey };
+      if (!event.disposition_severity) {
+        const previousRound = previous && (previous.disposition_round || previous.round);
+        if (previous && validRound(state.disposition_round) &&
+            String(previousRound) === String(state.disposition_round)) {
+          event.disposition_severity = previous.disposition_severity || previous.severity;
+        } else {
+          event.disposition_severity = state.severity;
+        }
+      }
+      latest.set(key, event);
     }
     continue;
   }
@@ -80,7 +96,7 @@ for (const row of ledgerRows) {
   }
 
   if (Object.prototype.hasOwnProperty.call(row.set, 'verdict') && target.fingerprint && target.verdict) {
-    const event = { ...target, _sourceKey: targetKey };
+    const event = { ...target, disposition_severity: target.severity, _sourceKey: targetKey };
     if (validRound(target.round)) event.disposition_round = Number(target.round);
     latest.set(dispositionKey(event), event);
     continue;
@@ -91,12 +107,17 @@ for (const row of ledgerRows) {
   // still authoritative; never revive an older verdict over a newer row.
   if (target.fingerprint &&
       (Object.prototype.hasOwnProperty.call(row.set, 'reason') ||
-       Object.prototype.hasOwnProperty.call(row.set, 'deferred_to'))) {
+       Object.prototype.hasOwnProperty.call(row.set, 'deferred_to') ||
+       Object.prototype.hasOwnProperty.call(row.set, 'severity'))) {
     const key = dispositionKey(target);
     const current = latest.get(key);
     if (current && current._sourceKey === targetKey) {
       if (Object.prototype.hasOwnProperty.call(row.set, 'reason')) current.reason = target.reason;
       if (Object.prototype.hasOwnProperty.call(row.set, 'deferred_to')) current.deferred_to = target.deferred_to;
+      if (Object.prototype.hasOwnProperty.call(row.set, 'severity')) {
+        current.severity = target.severity;
+        current.disposition_severity = target.severity;
+      }
     }
   }
 }
@@ -116,7 +137,11 @@ for (const line of input) {
     ? latest.get([e.REVIEW_BRANCH, fingerprint, artifact, perspective].join(keySep))
     : null;
   const sourceRound = prior && (prior.disposition_round || prior.round);
+  const dispositionSeverity = prior && (prior.disposition_severity || prior.severity);
+  const currentSeverityRank = severityRank(severity);
+  const dispositionSeverityRank = severityRank(dispositionSeverity);
   const suppress = Boolean(prior && validRound(sourceRound) &&
+    currentSeverityRank && dispositionSeverityRank && currentSeverityRank <= dispositionSeverityRank &&
     (prior.verdict === 'disproved' || validDeferred(prior)));
 
   const row = {
@@ -137,6 +162,7 @@ for (const line of input) {
   if (suppress) {
     row.verdict = prior.verdict;
     row.disposition_round = Number(sourceRound);
+    row.disposition_severity = dispositionSeverity;
     if (prior.reason) row.reason = prior.reason;
     if (prior.deferred_to) row.deferred_to = prior.deferred_to;
     const ticket = prior.verdict === 'deferred' && prior.deferred_to ? ` [${prior.deferred_to}]` : '';

--- a/scripts/cr/finding-reraise.js
+++ b/scripts/cr/finding-reraise.js
@@ -1,0 +1,154 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { findingFingerprint } = require('./finding-fingerprint');
+
+const e = process.env;
+const sep = String.fromCharCode(28);
+const keySep = String.fromCharCode(31);
+const artifact = 'diff';
+const perspective = 'off';
+
+function findingKey(head, id, rowArtifact, rowPerspective) {
+  return [head, id, rowArtifact || 'diff', rowPerspective || 'off'].join(keySep);
+}
+
+function dispositionKey(row) {
+  return [row.branch, row.fingerprint, row.artifact || 'diff', row.perspective || 'off'].join(keySep);
+}
+
+function validRound(value) {
+  return /^[1-9][0-9]*$/.test(String(value == null ? '' : value));
+}
+
+function validDeferred(row) {
+  return row.verdict === 'deferred' &&
+    /^[A-Z][A-Z0-9]*-[0-9]+$/.test(String(row.deferred_to || '')) &&
+    Boolean(String(row.reason || '').trim());
+}
+
+let ledgerRows = [];
+try {
+  ledgerRows = fs.existsSync(e.CR_LEDGER)
+    ? fs.readFileSync(e.CR_LEDGER, 'utf8').split('\n').filter(Boolean).map(JSON.parse)
+    : [];
+} catch (err) {
+  process.stderr.write(`finding-reraise: cannot read ledger: ${err.message}\n`);
+  process.exit(2);
+}
+
+const states = new Map();
+const latest = new Map();
+for (const row of ledgerRows) {
+  if (row.kind === 'finding') {
+    const state = { ...row };
+    const sourceKey = findingKey(row.head, row.finding_id, row.artifact, row.perspective);
+    states.set(sourceKey, state);
+    if (state.fingerprint && state.verdict) {
+      latest.set(dispositionKey(state), { ...state, _sourceKey: sourceKey });
+    }
+    continue;
+  }
+  if (row.kind !== 'amend' || !row.set || typeof row.set !== 'object') continue;
+  const targetKey = findingKey(row.target_head, row.finding_id, row.artifact, row.perspective);
+  const target = states.get(targetKey);
+  if (!target) continue;
+
+  const oldFile = target.file;
+  const oldFingerprint = target.fingerprint;
+  const oldDispositionKey = oldFingerprint ? dispositionKey(target) : '';
+  Object.assign(target, row.set);
+
+  // The fingerprint includes the file anchor, but the durable text may be a
+  // truncated display copy. A file correction therefore invalidates the old
+  // identity rather than guessing a replacement fingerprint from incomplete
+  // claim material. The invalidation is itself the latest identity event, so
+  // an occurrence at the old anchor fails active.
+  const fileChanged = Object.prototype.hasOwnProperty.call(row.set, 'file') && target.file !== oldFile;
+  if (fileChanged) {
+    if (oldDispositionKey) {
+      latest.set(oldDispositionKey, {
+        ...target,
+        fingerprint: oldFingerprint,
+        verdict: 'identity-changed',
+        _sourceKey: targetKey,
+      });
+    }
+    target.fingerprint = '';
+    continue;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(row.set, 'verdict') && target.fingerprint && target.verdict) {
+    const event = { ...target, _sourceKey: targetKey };
+    if (validRound(target.round)) event.disposition_round = Number(target.round);
+    latest.set(dispositionKey(event), event);
+    continue;
+  }
+
+  // Metadata-only amendments may refine the current disposition, but they do
+  // not become a new adjudication event. Update only when this exact source is
+  // still authoritative; never revive an older verdict over a newer row.
+  if (target.fingerprint &&
+      (Object.prototype.hasOwnProperty.call(row.set, 'reason') ||
+       Object.prototype.hasOwnProperty.call(row.set, 'deferred_to'))) {
+    const key = dispositionKey(target);
+    const current = latest.get(key);
+    if (current && current._sourceKey === targetKey) {
+      if (Object.prototype.hasOwnProperty.call(row.set, 'reason')) current.reason = target.reason;
+      if (Object.prototype.hasOwnProperty.call(row.set, 'deferred_to')) current.deferred_to = target.deferred_to;
+    }
+  }
+}
+
+const active = { crit: [], imp: [], sug: [] };
+const reraises = [];
+const enriched = [];
+const input = fs.readFileSync(0, 'utf8').split('\n').filter(Boolean);
+for (const line of input) {
+  const parts = line.split(sep);
+  const [model, id, severity, file, lineNumber] = parts;
+  const text = parts.slice(5).join(sep);
+  if (!id) continue;
+
+  const fingerprint = findingFingerprint(model, file, text);
+  const prior = fingerprint
+    ? latest.get([e.REVIEW_BRANCH, fingerprint, artifact, perspective].join(keySep))
+    : null;
+  const sourceRound = prior && (prior.disposition_round || prior.round);
+  const suppress = Boolean(prior && validRound(sourceRound) &&
+    (prior.verdict === 'disproved' || validDeferred(prior)));
+
+  const row = {
+    branch: e.REVIEW_BRANCH,
+    head: e.REVIEW_HEAD,
+    model,
+    id,
+    severity,
+    file,
+    line: lineNumber,
+    verdict: '',
+    artifact,
+    perspective,
+    text,
+  };
+  if (validRound(e.CR_REVIEW_ROUND)) row.round = Number(e.CR_REVIEW_ROUND);
+
+  if (suppress) {
+    row.verdict = prior.verdict;
+    row.disposition_round = Number(sourceRound);
+    if (prior.reason) row.reason = prior.reason;
+    if (prior.deferred_to) row.deferred_to = prior.deferred_to;
+    const ticket = prior.verdict === 'deferred' && prior.deferred_to ? ` [${prior.deferred_to}]` : '';
+    reraises.push(`${text} — RE-RAISE (r${sourceRound} ${prior.verdict})${ticket}`);
+  } else if (active[severity]) {
+    active[severity].push(text);
+  }
+  enriched.push(JSON.stringify(row));
+}
+
+for (const severity of Object.keys(active)) {
+  fs.writeFileSync(path.join(e.PANEL_SPOOL_DIR, `.active-${severity}`), active[severity].join('\n'));
+}
+fs.writeFileSync(path.join(e.PANEL_SPOOL_DIR, '.reraises'), reraises.join('\n'));
+process.stdout.write(enriched.length ? `${enriched.join('\n')}\n` : '');

--- a/scripts/cr/ledger-append.sh
+++ b/scripts/cr/ledger-append.sh
@@ -480,6 +480,14 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TE
         process.stderr.write("ledger-append.sh: batch row "+sid+" is missing required field(s) ("+missingFields.join(",")+") - refusing this row.\n");
         anyFail=true; continue;
       }
+      const positiveInteger=(v)=>(typeof v==="number"&&Number.isInteger(v)&&v>0)
+          ||(typeof v==="string"&&/^[1-9][0-9]*$/.test(v));
+      const invalidRoundFields=["round","disposition_round"].filter(f=>f in spec&&!positiveInteger(spec[f]));
+      if(invalidRoundFields.length){
+        process.stderr.write("ledger-append.sh: batch row "+sid+" has invalid positive-integer field(s) ("
+          +invalidRoundFields.map(f=>f+"="+JSON.stringify(spec[f])).join(",")+") - refusing this row.\n");
+        anyFail=true; continue;
+      }
       const keyRow=(o)=>o.kind==="finding"&&headsMatch(o.head,shead)&&o.finding_id===sid
           &&(o.artifact||"diff")===artifact&&(o.perspective||"off")===perspective;
       const rec={kind:"finding",ts:spec.ts||e.TS,branch:spec.branch,head:shead,model:spec.model,
@@ -492,6 +500,7 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TE
       if(spec.round) rec.round=Number(spec.round);
       if(spec.disposition_round) rec.disposition_round=Number(spec.disposition_round);
       else if(spec.verdict&&spec.round) rec.disposition_round=Number(spec.round);
+      if(spec.disposition_severity) rec.disposition_severity=spec.disposition_severity;
       if(spec.text){
         const fullText=scrubSecrets(String(spec.text).replace(/[\r\n]/g," "));
         rec.fingerprint=findingFingerprint(spec.model,spec.file,fullText);
@@ -527,7 +536,8 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TE
         // claims sharing the same 500-char display prefix still refuse), but
         // ignored when either side predates fingerprints or omits text.
         const compareFingerprint=("fingerprint" in priorEff)&&("fingerprint" in rec);
-        const norm=(o)=>{const c={...o}; delete c.ts; if(!compareFingerprint) delete c.fingerprint; delete c.round; delete c.disposition_round; if(ignoreText) delete c.text; return JSON.stringify(Object.keys(c).sort().map(k=>[k,c[k]]));};
+        const compareDispositionSeverity=("disposition_severity" in priorEff)&&("disposition_severity" in rec);
+        const norm=(o)=>{const c={...o}; delete c.ts; if(!compareFingerprint) delete c.fingerprint; if(!compareDispositionSeverity) delete c.disposition_severity; delete c.round; delete c.disposition_round; if(ignoreText) delete c.text; return JSON.stringify(Object.keys(c).sort().map(k=>[k,c[k]]));};
         if(norm(priorEff)!==norm(rec)){
           const priorWithVerdict={...priorEff,verdict:rec.verdict};
           if(rec.reason) priorWithVerdict.reason=rec.reason;
@@ -709,7 +719,8 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TE
       // claims sharing the same 500-char display prefix still refuse), but
       // ignored when either side predates fingerprints or omits text.
       const compareFingerprint=("fingerprint" in priorEff)&&("fingerprint" in rec);
-      const norm=(o)=>{const c={...o}; delete c.ts; if(!compareFingerprint) delete c.fingerprint; delete c.round; delete c.disposition_round; if(ignoreText) delete c.text; return JSON.stringify(Object.keys(c).sort().map(k=>[k,c[k]]));};
+      const compareDispositionSeverity=("disposition_severity" in priorEff)&&("disposition_severity" in rec);
+      const norm=(o)=>{const c={...o}; delete c.ts; if(!compareFingerprint) delete c.fingerprint; if(!compareDispositionSeverity) delete c.disposition_severity; delete c.round; delete c.disposition_round; if(ignoreText) delete c.text; return JSON.stringify(Object.keys(c).sort().map(k=>[k,c[k]]));};
       if(norm(priorEff)!==norm(rec)){
         const priorWithVerdict={...priorEff,verdict:rec.verdict};
         if(rec.reason) priorWithVerdict.reason=rec.reason;

--- a/scripts/cr/ledger-append.sh
+++ b/scripts/cr/ledger-append.sh
@@ -315,7 +315,7 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TE
   // script without adjacent JS files. test-ledger-append.sh locks single/batch
   // parity while test-finding-reraise.sh covers the shared panel helper.
   const foldWhitespace=(v)=>String(v==null?"":v).toLowerCase().replace(/\s+/g," ").trim();
-  const normalizeFileAnchor=(v)=>foldWhitespace(v).replace(/\\/g,"/").replace(/^\.\//,"").replace(/:(?:l)?\d+(?:-\d+)?$/i,"");
+  const normalizeFileAnchor=(v)=>String(v==null?"":v).replace(/\s+/g," ").trim().replace(/\\/g,"/").replace(/^\.\//,"").replace(/:(?:l)?\d+(?:-\d+)?$/i,"");
   const normalizeClaim=(v)=>foldWhitespace(String(v==null?"":v).replace(/^\s*-\s*\[[^\]]+\]\s*:\s*/,"").replace(/\s*\[[^\]\r\n]+:\d+(?:-\d+)?\]\s*$/,"") );
   const findingFingerprint=(slug,file,text)=>{
     const s=foldWhitespace(slug), a=normalizeFileAnchor(file), c=normalizeClaim(text);
@@ -522,9 +522,12 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TE
         // write for the same id DOES carry text and must still be compared,
         // so a genuinely different finding under the same id keeps refusing.
         const ignoreText=!("text" in rec);
-        // Additive observation metadata is not part of the historical content
-        // comparison. Same-head retries preserve the first stored values.
-        const norm=(o)=>{const c={...o}; delete c.ts; delete c.fingerprint; delete c.round; delete c.disposition_round; if(ignoreText) delete c.text; return JSON.stringify(Object.keys(c).sort().map(k=>[k,c[k]]));};
+        // Round fields are observation metadata, not historical content.
+        // Fingerprint is compared when BOTH rows have one (so different full
+        // claims sharing the same 500-char display prefix still refuse), but
+        // ignored when either side predates fingerprints or omits text.
+        const compareFingerprint=("fingerprint" in priorEff)&&("fingerprint" in rec);
+        const norm=(o)=>{const c={...o}; delete c.ts; if(!compareFingerprint) delete c.fingerprint; delete c.round; delete c.disposition_round; if(ignoreText) delete c.text; return JSON.stringify(Object.keys(c).sort().map(k=>[k,c[k]]));};
         if(norm(priorEff)!==norm(rec)){
           const priorWithVerdict={...priorEff,verdict:rec.verdict};
           if(rec.reason) priorWithVerdict.reason=rec.reason;
@@ -701,9 +704,12 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TE
       // --batch-file block above - ignore text only when rec (the incoming
       // write) omits it, never unconditionally.
       const ignoreText=!("text" in rec);
-      // Additive observation metadata is not part of the historical content
-      // comparison. Same-head retries preserve the first stored values.
-      const norm=(o)=>{const c={...o}; delete c.ts; delete c.fingerprint; delete c.round; delete c.disposition_round; if(ignoreText) delete c.text; return JSON.stringify(Object.keys(c).sort().map(k=>[k,c[k]]));};
+      // Round fields are observation metadata, not historical content.
+      // Fingerprint is compared when BOTH rows have one (so different full
+      // claims sharing the same 500-char display prefix still refuse), but
+      // ignored when either side predates fingerprints or omits text.
+      const compareFingerprint=("fingerprint" in priorEff)&&("fingerprint" in rec);
+      const norm=(o)=>{const c={...o}; delete c.ts; if(!compareFingerprint) delete c.fingerprint; delete c.round; delete c.disposition_round; if(ignoreText) delete c.text; return JSON.stringify(Object.keys(c).sort().map(k=>[k,c[k]]));};
       if(norm(priorEff)!==norm(rec)){
         const priorWithVerdict={...priorEff,verdict:rec.verdict};
         if(rec.reason) priorWithVerdict.reason=rec.reason;

--- a/scripts/cr/ledger-append.sh
+++ b/scripts/cr/ledger-append.sh
@@ -67,6 +67,7 @@ esac
 
 branch="" head="" model="" responding_model="" id="" severity="" file="" line="" verdict="" status="" artifact="diff" perspective="off"
 prompt_chars="" response_chars="" reason="" detail="" deferred_to="" set_pairs="" attempt_num="" duration_secs="" batch_file="" text=""
+round="" disposition_round=""
 while [ $# -gt 0 ]; do case "$1" in
   --branch) branch="$2"; shift 2;; --head) head="$2"; shift 2;;
   --model) model="$2"; shift 2;; --responding-model) responding_model="$2"; shift 2;;
@@ -79,6 +80,8 @@ while [ $# -gt 0 ]; do case "$1" in
   --reason) reason="$2"; shift 2;; --detail) detail="$2"; shift 2;;
   --deferred-to) deferred_to="$2"; shift 2;;
   --text) text="$2"; shift 2;;
+  --round) round="$2"; shift 2;;
+  --disposition-round) disposition_round="$2"; shift 2;;
   --set) set_pairs="$set_pairs$2"$'\n'; shift 2;;
   --attempt) attempt_num="$2"; shift 2;; --duration-secs) duration_secs="$2"; shift 2;;
   --batch-file) batch_file="$2"; shift 2;;
@@ -130,6 +133,12 @@ fi
 
 case "$artifact" in diff|spec|plan) ;; *) echo "ledger-append.sh: --artifact must be diff|spec|plan" >&2; exit 2;; esac
 case "$perspective" in on|off) ;; *) echo "ledger-append.sh: --perspective must be on|off" >&2; exit 2;; esac
+for _round_value in "$round" "$disposition_round"; do
+  if [ -n "$_round_value" ] && ! expr "$_round_value" : '^[1-9][0-9]*$' >/dev/null 2>&1; then
+    echo "ledger-append.sh: --round/--disposition-round must be positive integers (got '$_round_value')" >&2
+    exit 2
+  fi
+done
 
 # A deferral is only honest if it is TRACKED. Validate the ticket key here so a
 # typo cannot silently produce a deferral the gate then rejects for reasons the
@@ -192,8 +201,8 @@ if [ "$kind" = "amend" ]; then
         esac ;;
       verdict=*)
         case "${_pair#verdict=}" in
-          agreed|disproved|conflict|unaddressed|deferred) ;;
-          *) echo "ledger-append.sh: --set verdict= must be agreed|disproved|conflict|unaddressed|deferred (got '${_pair#verdict=}')" >&2; exit 2;;
+          agreed|disproved|conflict|unaddressed|deferred|fixed) ;;
+          *) echo "ledger-append.sh: --set verdict= must be agreed|disproved|conflict|unaddressed|deferred|fixed (got '${_pair#verdict=}')" >&2; exit 2;;
         esac ;;
       head=*)
         # Re-keying is the point of this key (a finding mis-keyed onto the head
@@ -272,6 +281,11 @@ if [ -n "$detail" ]; then
   detail="$(printf '%s' "$detail" | cut -c1-200)"
 fi
 
+# Fingerprints use the complete scrubbed claim before the persisted display
+# text is capped. Only the digest is retained; the uncapped value never reaches
+# the ledger.
+raw_text=""
+
 # --text (HIMMEL-2078): the panel's own one-line prose bullet for a finding, so
 # an unadjudicated finding is still legible after the panel transcript is
 # gone. Same flatten-then-scrub-then-cap shape as --detail above, just a
@@ -279,6 +293,7 @@ fi
 if [ -n "$text" ]; then
   text="$(printf '%s' "$text" | tr '\n\r' '  ')"
   text="$(scrub_secrets "$text")"
+  raw_text="$text"
   text="$(printf '%s' "$text" | cut -c1-500)"
 fi
 
@@ -292,9 +307,21 @@ ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 KIND="$kind" BRANCH="$branch" HEAD_="$head" RAW_HEAD="$raw_head" MODEL="$model" RESPONDING_MODEL="$responding_model" ID="$id" SEV="$severity" \
 FILE="$file" LINE="$line" VERDICT="$verdict" STATUS="$status" BATCH_FILE="$batch_file" \
 PROMPT_CHARS="$prompt_chars" RESPONSE_CHARS="$response_chars" TS="$ts" LEDGER="$ledger" ARTIFACT="$artifact" PERSPECTIVE="$perspective" \
-ATTEMPT_NUM="$attempt_num" DURATION_SECS="$duration_secs" \
-REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" SET_PAIRS="$set_pairs" node -e '
-  const fs=require("fs"), cp=require("child_process"), e=process.env;
+ATTEMPT_NUM="$attempt_num" DURATION_SECS="$duration_secs" ROUND="$round" DISPOSITION_ROUND="$disposition_round" \
+REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TEXT="$raw_text" SET_PAIRS="$set_pairs" node -e '
+  const fs=require("fs"), cp=require("child_process"), crypto=require("crypto"), e=process.env;
+  // Keep this small inline copy in parity with finding-fingerprint.js. The
+  // writer is intentionally standalone: anchor/fixture flows copy this one
+  // script without adjacent JS files. test-ledger-append.sh locks single/batch
+  // parity while test-finding-reraise.sh covers the shared panel helper.
+  const foldWhitespace=(v)=>String(v==null?"":v).toLowerCase().replace(/\s+/g," ").trim();
+  const normalizeFileAnchor=(v)=>foldWhitespace(v).replace(/\\/g,"/").replace(/^\.\//,"").replace(/:(?:l)?\d+(?:-\d+)?$/i,"");
+  const normalizeClaim=(v)=>foldWhitespace(String(v==null?"":v).replace(/^\s*-\s*\[[^\]]+\]\s*:\s*/,"").replace(/\s*\[[^\]\r\n]+:\d+(?:-\d+)?\]\s*$/,"") );
+  const findingFingerprint=(slug,file,text)=>{
+    const s=foldWhitespace(slug), a=normalizeFileAnchor(file), c=normalizeClaim(text);
+    if(!s||!c) return "";
+    return "fp1:"+crypto.createHash("sha256").update([s,a,c].join(String.fromCharCode(31)),"utf8").digest("hex");
+  };
   const led=e.LEDGER;
   // HIMMEL-2078: batch rows carry spec.text straight from a caller-built JSON
   // file, bypassing the bash-side --text scrub/flatten/cap above entirely —
@@ -462,7 +489,14 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" SET_PA
       if(spec.reason) rec.reason=spec.reason;
       if(spec.detail) rec.detail=spec.detail;
       if(spec.deferred_to) rec.deferred_to=spec.deferred_to;
-      if(spec.text) rec.text=truncText(spec.text);
+      if(spec.round) rec.round=Number(spec.round);
+      if(spec.disposition_round) rec.disposition_round=Number(spec.disposition_round);
+      else if(spec.verdict&&spec.round) rec.disposition_round=Number(spec.round);
+      if(spec.text){
+        const fullText=scrubSecrets(String(spec.text).replace(/[\r\n]/g," "));
+        rec.fingerprint=findingFingerprint(spec.model,spec.file,fullText);
+        rec.text=fullText.length>500?fullText.slice(0,500):fullText;
+      }
 
       const priorMatches=parsed.filter(o=>keyRow(o)||keyRow(effective(o)));
       if(priorMatches.length>1){
@@ -488,7 +522,9 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" SET_PA
         // write for the same id DOES carry text and must still be compared,
         // so a genuinely different finding under the same id keeps refusing.
         const ignoreText=!("text" in rec);
-        const norm=(o)=>{const c={...o}; delete c.ts; if(ignoreText) delete c.text; return JSON.stringify(Object.keys(c).sort().map(k=>[k,c[k]]));};
+        // Additive observation metadata is not part of the historical content
+        // comparison. Same-head retries preserve the first stored values.
+        const norm=(o)=>{const c={...o}; delete c.ts; delete c.fingerprint; delete c.round; delete c.disposition_round; if(ignoreText) delete c.text; return JSON.stringify(Object.keys(c).sort().map(k=>[k,c[k]]));};
         if(norm(priorEff)!==norm(rec)){
           const priorWithVerdict={...priorEff,verdict:rec.verdict};
           if(rec.reason) priorWithVerdict.reason=rec.reason;
@@ -603,7 +639,13 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" SET_PA
     if(e.REASON) rec.reason=e.REASON;
     if(e.DETAIL) rec.detail=e.DETAIL;
     if(e.DEFERRED_TO) rec.deferred_to=e.DEFERRED_TO;
-    if(e.TEXT) rec.text=truncText(e.TEXT);
+    if(e.ROUND) rec.round=Number(e.ROUND);
+    if(e.DISPOSITION_ROUND) rec.disposition_round=Number(e.DISPOSITION_ROUND);
+    else if(e.VERDICT&&e.ROUND) rec.disposition_round=Number(e.ROUND);
+    if(e.RAW_TEXT){
+      rec.fingerprint=findingFingerprint(e.MODEL,e.FILE,e.RAW_TEXT);
+      rec.text=truncText(e.TEXT);
+    }
     // A re-append that CHANGES the record is the wedge this ticket is about:
     // the old code hit the dedup key, wrote nothing, and exited 0, so the
     // caller believed the severity had been corrected while the gate kept
@@ -659,7 +701,9 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" SET_PA
       // --batch-file block above - ignore text only when rec (the incoming
       // write) omits it, never unconditionally.
       const ignoreText=!("text" in rec);
-      const norm=(o)=>{const c={...o}; delete c.ts; if(ignoreText) delete c.text; return JSON.stringify(Object.keys(c).sort().map(k=>[k,c[k]]));};
+      // Additive observation metadata is not part of the historical content
+      // comparison. Same-head retries preserve the first stored values.
+      const norm=(o)=>{const c={...o}; delete c.ts; delete c.fingerprint; delete c.round; delete c.disposition_round; if(ignoreText) delete c.text; return JSON.stringify(Object.keys(c).sort().map(k=>[k,c[k]]));};
       if(norm(priorEff)!==norm(rec)){
         const priorWithVerdict={...priorEff,verdict:rec.verdict};
         if(rec.reason) priorWithVerdict.reason=rec.reason;

--- a/scripts/cr/panel-first-pass.sh
+++ b/scripts/cr/panel-first-pass.sh
@@ -164,7 +164,7 @@ else
     # CR_USAGE_LOG=1 (HIMMEL-485): each critic logs a chars/4 ESTIMATED usage
     # ledger record. No CRITIC_PANEL_TIERS here (HIMMEL-558): the panel
     # resolves tiers from the exported CR_PROFILE.
-    panel_findings=$(printf '%s' "$diff_out" | CR_USAGE_LOG=1 bash "$HIMMEL_ROOT/scripts/cr/critic-panel.sh" --head "$HEAD_SHA" --branch "$BRANCH" --base "$db" --base-sha "$db_sha" 2>"$panel_tmp")
+    panel_findings=$(printf '%s' "$diff_out" | CR_USAGE_LOG=1 CR_REVIEW_ROUND="$review_round" bash "$HIMMEL_ROOT/scripts/cr/critic-panel.sh" --head "$HEAD_SHA" --branch "$BRANCH" --base "$db" --base-sha "$db_sha" 2>"$panel_tmp")
     panel_rc=$?
     panel_avail_lines=$(cat "$panel_tmp"); rm -f "$panel_tmp"
     if [ "$panel_rc" -eq 7 ]; then
@@ -196,7 +196,7 @@ PINABORT
             retry_diff=$(rtk proxy git diff "$db_sha...$HEAD_SHA" 2>/dev/null) || retry_diff=""
             if [ -n "$retry_diff" ]; then
                 retry_tmp=$(mktemp -t cr-panel-avail.XXXXXX)
-                panel_findings=$(printf '%s' "$retry_diff" | CR_USAGE_LOG=1 bash "$HIMMEL_ROOT/scripts/cr/critic-panel.sh" --head "$HEAD_SHA" --branch "$BRANCH" --base "$db" --base-sha "$db_sha" 2>"$retry_tmp")
+                panel_findings=$(printf '%s' "$retry_diff" | CR_USAGE_LOG=1 CR_REVIEW_ROUND="$review_round" bash "$HIMMEL_ROOT/scripts/cr/critic-panel.sh" --head "$HEAD_SHA" --branch "$BRANCH" --base "$db" --base-sha "$db_sha" 2>"$retry_tmp")
                 panel_rc=$?
                 panel_avail_lines=$(cat "$retry_tmp"); rm -f "$retry_tmp"
                 # The retry is a SECOND panel invocation, so it has its own

--- a/scripts/cr/test-critic-panel.sh
+++ b/scripts/cr/test-critic-panel.sh
@@ -746,6 +746,38 @@ check "LA: every row is stamped with the reviewed head" "$(printf '%s\n' "$ledge
 check "LA: every emitted finding self-appended" "$(printf '%s\n' "$ledger_summary" | sed -n 's/^findings=//p')" "4"
 check "LA: raw finding verdicts are empty" "$(printf '%s\n' "$ledger_summary" | sed -n 's/^empty-verdicts=//p')" "yes"
 
+# Test LAC: once disposition classification succeeds, raw finding spools are
+# removed and the enriched JSONL is the only remaining source of finding rows.
+# A failed enriched->batch copy must therefore survive the later successful
+# empty raw-spool conversion and make the panel uncertified (rc 5), never rc 0.
+LAC_LEDGER="$tmp/panel-copy-fail-ledger.jsonl"
+: > "$LAC_LEDGER"
+LAC_BIN="$tmp/panel-copy-fail-bin"
+mkdir -p "$LAC_BIN"
+LAC_CP_LOG="$tmp/panel-copy-fail.log"
+REAL_CP="$(command -v cp)"
+cat > "$LAC_BIN/cp" <<CPEOF
+#!/usr/bin/env bash
+printf '%s|%s\n' "\${1:-}" "\${2:-}" >> "$LAC_CP_LOG"
+case "\${1:-}" in
+    */.finding-enriched.jsonl) exit 73 ;;
+esac
+exec "$REAL_CP" "\$@"
+CPEOF
+chmod +x "$LAC_BIN/cp"
+lac_rc=0
+PATH="$LAC_BIN:$PATH" CR_LEDGER="$LAC_LEDGER" CRITIC_LEDGER_APPEND="$HERE/ledger-append.sh" \
+    CRITICS_JSON="$tmp/critics-all.json" CRITIC_FIRST_PASS="$STUB" \
+    bash "$PANEL" <<< "$DIFF" > "$tmp/lac-out" 2> "$tmp/lac-err" || lac_rc=$?
+lac_out="$(cat "$tmp/lac-out")"
+lac_log="$(cat "$LAC_CP_LOG" 2>/dev/null)"
+check "LAC: enriched finding copy failure makes panel uncertified" "$lac_rc" "5"
+check_contains "LAC: critic produced a raw finding before persistence" "$lac_out" "[qwen3coder-1]:"
+check_contains "LAC: injected failure reached the enriched JSONL source" "$lac_log" "/.finding-enriched.jsonl|"
+check_contains "LAC: injected failure targeted the finding batch destination" "$lac_log" "/.finding-batch.jsonl"
+check_contains "LAC: panel reports failed ledger certification" "$(cat "$tmp/lac-err")" "CR-ledger append failed"
+check "LAC: failed copy writes no finding rows" "$(grep -c '\"kind\":\"finding\"' "$LAC_LEDGER" || true)" "0"
+
 # Test LAP: parallel mode self-appends the SAME ledger evidence as sequential
 # (HIMMEL-1494 r3; per-member spool files r4). The evidence path flows through
 # PER-MEMBER spool files (avail.<slug>/finding.<slug>), one per member, not a

--- a/scripts/cr/test-finding-reraise.sh
+++ b/scripts/cr/test-finding-reraise.sh
@@ -370,6 +370,68 @@ run_panel 4 "$deferred_claim" sug "$tmp/control.out" "$tmp/control.err"
 assert_eq "$?" "0" "artifact/perspective control panel run succeeds"
 assert_has "$(cat "$tmp/control.out")" "## Suggestions (1 found)" "different artifact/perspective controls stay visible"
 
+# File systems and Git can distinguish path case. Claim/slug case still folds,
+# but Foo.js and foo.js are different fingerprint anchors.
+checkout_branch path-case
+head_case_seed="$(advance_head path-case-seed)"
+set_registry critic-a
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" finding --branch path-case --head "$head_case_seed" \
+        --model critic-a --id case-1 --severity imp --file scripts/cr/Foo.js --line 10 \
+        --verdict disproved --round 3 --text '- [case-1]: Case-sensitive anchor claim [scripts/cr/Foo.js:10]'
+) >/dev/null 2>"$tmp/path-case-seed.err"
+assert_eq "$?" "0" "path-case fixture writes the uppercase anchor"
+advance_head path-case-current >/dev/null
+run_panel 4 'case-sensitive anchor claim [scripts/cr/foo.js:80]' imp "$tmp/path-case.out" "$tmp/path-case.err"
+assert_eq "$?" "0" "different path-case panel run succeeds"
+assert_has "$(cat "$tmp/path-case.out")" "## Important Issues (1 found)" "Foo.js and foo.js remain distinct anchors"
+assert_lacks "$(cat "$tmp/path-case.out")" "RE-RAISE (" "different path case does not inherit disposition"
+
+checkout_branch path-case-parity
+head_case_parity="$(advance_head path-case-parity-seed)"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" finding --branch path-case-parity --head "$head_case_parity" \
+        --model critic-a --id case-parity-1 --severity imp --file ./scripts/cr/Foo.js --line 10 \
+        --verdict disproved --round 3 --text '- [case-parity-1]: Case-sensitive anchor claim [./scripts/cr/Foo.js:10]'
+) >/dev/null 2>"$tmp/path-case-parity-seed.err"
+assert_eq "$?" "0" "same-case parity fixture writes through the standalone writer"
+advance_head path-case-parity-current >/dev/null
+run_panel 4 'CASE-sensitive   anchor CLAIM [scripts/cr/Foo.js:90]' imp "$tmp/path-case-parity.out" "$tmp/path-case-parity.err"
+assert_eq "$?" "0" "same-case parity panel run succeeds"
+assert_has "$(cat "$tmp/path-case-parity.out")" "RE-RAISE (r3 disproved)" "same path case normalizes identically across writer and panel helper"
+
+# Re-key amendments remain addressed by the original append-only target key.
+# A later verdict invoked through the corrected effective head still stores the
+# original target_head, so the reader must not move its working map.
+checkout_branch rekey-map
+rekey_old="1111111111111111111111111111111111111111"
+rekey_new="2222222222222222222222222222222222222222"
+rekey_claim='Re-keyed finding remains fixed [scripts/cr/rekey.sh:10]'
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" finding --branch rekey-map --head "$rekey_old" \
+        --model critic-a --id rekey-1 --severity imp --file scripts/cr/rekey.sh --line 10 \
+        --verdict disproved --round 3 --text "- [rekey-1]: $rekey_claim"
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch rekey-map --head "$rekey_old" \
+        --id rekey-1 --set head="$rekey_new" --reason 'correct effective head'
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch rekey-map --head "$rekey_new" \
+        --id rekey-1 --set verdict=fixed --reason 'fix through effective head'
+) >/dev/null 2>"$tmp/rekey-map.err"
+assert_eq "$?" "0" "re-key plus effective-head fixed amendments succeed"
+rekey_target="$(LEDGER="$ledger" node -e '
+const rows=require("fs").readFileSync(process.env.LEDGER,"utf8").trim().split("\n").map(JSON.parse);
+const row=rows.filter(r=>r.kind==="amend"&&r.finding_id==="rekey-1"&&r.set&&r.set.verdict==="fixed").pop()||{};
+process.stdout.write(String(row.target_head||""));
+')"
+assert_eq "$rekey_target" "$rekey_old" "effective-head verdict persists the original target_head"
+advance_head rekey-map-current >/dev/null
+run_panel 4 "$rekey_claim" imp "$tmp/rekey-map.out" "$tmp/rekey-map-panel.err"
+assert_eq "$?" "0" "re-key regression panel run succeeds"
+assert_has "$(cat "$tmp/rekey-map.out")" "## Important Issues (1 found)" "re-keyed latest fixed disposition remains active"
+assert_lacks "$(cat "$tmp/rekey-map.out")" "RE-RAISE (" "re-key map is not moved away from original target key"
+
 # Legacy/textless findings have no fingerprint and are ignored safely rather
 # than guessed into a match.
 checkout_branch legacy

--- a/scripts/cr/test-finding-reraise.sh
+++ b/scripts/cr/test-finding-reraise.sh
@@ -1,0 +1,430 @@
+#!/usr/bin/env bash
+# Focused TDD acceptance tests for stable finding fingerprints and durable
+# branch-scoped re-raise dispositions (HIMMEL-2896). No critic/API calls.
+# Platform guard: requires Bash (Git Bash on Windows), Git and Node; invoke
+# with bash rather than PowerShell. Verified locally on Linux.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PANEL="$HERE/critic-panel.sh"
+LEDGER_APPEND="$HERE/ledger-append.sh"
+ROUND="$HERE/review-round.sh"
+# shellcheck source=../lib/fixture-tempdir.sh
+# shellcheck disable=SC1091
+. "$HERE/../lib/fixture-tempdir.sh"
+tmp="$(fixture_mktemp_dir)" || exit 1
+trap 'rm -rf "$tmp"' EXIT
+fails=0
+
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'FAIL - %s\n' "$1" >&2; fails=$((fails + 1)); }
+assert_eq() {
+    if [ "$1" = "$2" ]; then pass "$3"; else fail "$3 (got '$1', want '$2')"; fi
+}
+assert_has() {
+    case "$1" in *"$2"*) pass "$3" ;; *) fail "$3 (missing '$2')" ;; esac
+}
+assert_lacks() {
+    case "$1" in *"$2"*) fail "$3 (unexpected '$2')" ;; *) pass "$3" ;; esac
+}
+assert_fingerprint() {
+    if grep -qE '^fp1:[0-9a-f]{64}$' <<< "$1"; then
+        pass "$2"
+    else
+        fail "$2 (got '$1', want fp1:<64 lowercase hex>)"
+    fi
+}
+
+repo="$tmp/repo"
+mkdir -p "$repo"
+(
+    fixture_enter_git_init_dir "$repo" || exit 1
+    git -c init.defaultBranch=main init -q
+    git config user.name tester
+    git config user.email tester@example.invalid
+    git config commit.gpgsign false
+    printf 'base\n' > src.txt
+    git add src.txt
+    git commit -q -m base
+) || { fail "fixture repository setup"; exit 1; }
+
+git_dir="$(git -C "$repo" rev-parse --path-format=absolute --git-common-dir)"
+ledger="$git_dir/cr-critic-scores.jsonl"
+: > "$ledger"
+
+stub="$tmp/stub-cfp.sh"
+cat > "$stub" <<'STUB'
+#!/usr/bin/env bash
+slug="critic"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --slug) slug="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+cat >/dev/null
+printf '# %s First-Pass Review\n\n' "$slug"
+case "${FINDING_SEVERITY:-imp}" in
+    crit)
+        printf '## Critical Issues (1 found)\n- [%s-1]: %s\n## Important Issues (0 found)\n## Suggestions (0 found)\n' "$slug" "$FINDING_CLAIM"
+        ;;
+    imp)
+        printf '## Critical Issues (0 found)\n## Important Issues (1 found)\n- [%s-1]: %s\n## Suggestions (0 found)\n' "$slug" "$FINDING_CLAIM"
+        ;;
+    sug)
+        printf '## Critical Issues (0 found)\n## Important Issues (0 found)\n## Suggestions (1 found)\n- [%s-1]: %s\n' "$slug" "$FINDING_CLAIM"
+        ;;
+    clean)
+        printf '## Critical Issues (0 found)\n## Important Issues (0 found)\n## Suggestions (0 found)\n'
+        ;;
+esac
+STUB
+chmod +x "$stub"
+
+registry="$tmp/critics.json"
+set_registry() {
+    printf '{"panel":[{"slug":"%s","model":"fake/model","tier":"free"}]}\n' "$1" > "$registry"
+}
+
+DIFF='diff --git a/src.txt b/src.txt
+index 0000000..1111111 100644
+--- a/src.txt
++++ b/src.txt
+@@ -1 +1,2 @@
+ base
++change'
+
+checkout_branch() {
+    branch="$1"
+    if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
+        git -C "$repo" checkout -q "$branch"
+    else
+        git -C "$repo" checkout -q -b "$branch" main
+    fi
+}
+
+advance_head() {
+    marker="$1"
+    printf '%s\n' "$marker" >> "$repo/src.txt"
+    git -C "$repo" add src.txt
+    git -C "$repo" commit -q -m "$marker"
+    git -C "$repo" rev-parse HEAD
+}
+
+run_panel() {
+    round="$1"
+    claim="$2"
+    severity="$3"
+    out_file="$4"
+    err_file="$5"
+    (
+        cd "$repo" || exit 1
+        printf '%s' "$DIFF" | CR_PROFILE=free CR_LEDGER="$ledger" CRITIC_LEDGER_APPEND="$LEDGER_APPEND" \
+            CRITICS_JSON="$registry" CRITIC_FIRST_PASS="$stub" \
+            CR_REVIEW_ROUND="$round" FINDING_CLAIM="$claim" FINDING_SEVERITY="$severity" \
+            bash "$PANEL" --head "$(git rev-parse HEAD)" --branch "$(git branch --show-current)" \
+            > "$out_file" 2> "$err_file"
+    )
+}
+
+ledger_value() {
+    branch="$1" head="$2" field="$3"
+    BRANCH="$branch" HEAD_="$head" FIELD="$field" LEDGER="$ledger" node -e '
+const fs=require("fs"),e=process.env;
+const rows=fs.readFileSync(e.LEDGER,"utf8").split("\n").filter(Boolean).map(JSON.parse);
+const row=rows.filter(r=>r.kind==="finding"&&r.branch===e.BRANCH&&r.head===e.HEAD_).pop()||{};
+const value=row[e.FIELD];
+process.stdout.write(value===undefined?"<absent>":String(value));
+'
+}
+
+finding_id_at() {
+    branch="$1" head="$2"
+    BRANCH="$branch" HEAD_="$head" LEDGER="$ledger" node -e '
+const fs=require("fs"),e=process.env;
+const rows=fs.readFileSync(e.LEDGER,"utf8").split("\n").filter(Boolean).map(JSON.parse);
+const row=rows.filter(r=>r.kind==="finding"&&r.branch===e.BRANCH&&r.head===e.HEAD_).pop()||{};
+process.stdout.write(String(row.finding_id||""));
+'
+}
+
+finding_count_at() {
+    branch="$1" head="$2"
+    BRANCH="$branch" HEAD_="$head" LEDGER="$ledger" node -e '
+const fs=require("fs"),e=process.env;
+const rows=fs.readFileSync(e.LEDGER,"utf8").split("\n").filter(Boolean).map(JSON.parse);
+process.stdout.write(String(rows.filter(r=>r.kind==="finding"&&r.branch===e.BRANCH&&r.head===e.HEAD_).length));
+'
+}
+
+# Stable fingerprint + durable disproved re-raise. Citation line movement,
+# claim case, and whitespace fold; meaningful claim numbers remain identity.
+checkout_branch reraised
+head_r4="$(advance_head r4)"
+set_registry critic-a
+claim_r4='N117 retry 3 times can duplicate the ledger row [scripts/cr/example.sh:117]'
+run_panel 4 "$claim_r4" imp "$tmp/r4.out" "$tmp/r4.err"
+assert_eq "$?" "0" "r4 producer panel run succeeds"
+id_r4="$(finding_id_at reraised "$head_r4")"
+assert_eq "$id_r4" "critic-a-1" "r4 fixture produces the expected finding id"
+fp_r4="$(ledger_value reraised "$head_r4" fingerprint)"
+assert_fingerprint "$fp_r4" "r4 finding persists a stable fingerprint"
+assert_eq "$(ledger_value reraised "$head_r4" round)" "4" "r4 finding persists its review round"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch reraised --head "$head_r4" \
+        --id "$id_r4" --set verdict=disproved --reason 'N117 premise disproved'
+) >/dev/null 2>"$tmp/r4-amend.err"
+assert_eq "$?" "0" "initial finding accepts a durable disproved disposition"
+
+head_r5="$(advance_head r5)"
+claim_r5='  n117   RETRY  3 TIMES can duplicate the ledger row   [scripts/cr/example.sh:204]'
+run_panel 5 "$claim_r5" imp "$tmp/r5.out" "$tmp/r5.err"
+assert_eq "$?" "0" "r5 producer panel run succeeds"
+r5_out="$(cat "$tmp/r5.out")"
+assert_has "$r5_out" "## Important Issues (0 found)" "r5 disproved re-raise is excluded from the severity tally"
+assert_has "$r5_out" "## Already Dispositioned Re-raises (1 found)" "r5 re-raise stays visible in a separate block"
+assert_has "$r5_out" "RE-RAISE (r4 disproved)" "r5 re-raise names the original round and verdict"
+assert_eq "$(ledger_value reraised "$head_r5" fingerprint)" "$fp_r4" "line/case/whitespace changes keep the fingerprint stable"
+assert_eq "$(ledger_value reraised "$head_r5" verdict)" "disproved" "r5 re-raise persists the inherited disposition"
+assert_eq "$(ledger_value reraised "$head_r5" disposition_round)" "4" "r5 re-raise preserves the original disposition round"
+
+# A later explicit fixed disposition supersedes the old disproof. Fixed never
+# suppresses a fresh occurrence, which is treated as a regression.
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch reraised --head "$head_r4" \
+        --id critic-a-1 --set verdict=fixed --reason 'the implementation was repaired after r5'
+) >/dev/null 2>"$tmp/fixed-amend.err"
+assert_eq "$?" "0" "fixed is a durable explicit disposition"
+head_r6="$(advance_head r6)"
+run_panel 6 "$claim_r4" imp "$tmp/r6.out" "$tmp/r6.err"
+assert_eq "$?" "0" "r6 fixed-regression panel run succeeds"
+r6_out="$(cat "$tmp/r6.out")"
+assert_has "$r6_out" "## Important Issues (1 found)" "latest fixed disposition does not suppress a regression"
+assert_lacks "$r6_out" "RE-RAISE (" "fixed regression remains in the normal findings block"
+assert_eq "$(ledger_value reraised "$head_r6" verdict)" "" "fixed regression lands as a fresh unadjudicated row"
+
+# Different claim at the same anchor: changing a meaningful claim number must
+# change identity; citation line numbers alone were the only numbers removed.
+head_r7="$(advance_head r7)"
+claim_r7='N118 retry 3 times can duplicate the ledger row [scripts/cr/example.sh:117]'
+run_panel 7 "$claim_r7" imp "$tmp/r7.out" "$tmp/r7.err"
+assert_eq "$?" "0" "r7 changed-claim panel run succeeds"
+assert_has "$(cat "$tmp/r7.out")" "## Important Issues (1 found)" "different claim at the same anchor stays visible"
+if [ "$(ledger_value reraised "$head_r7" fingerprint)" != "$fp_r4" ]; then
+    pass "meaningful N117/N118 claim numbers remain fingerprint-significant"
+else
+    fail "meaningful N117/N118 claim numbers remain fingerprint-significant"
+fi
+
+# A non-verdict amendment to an older row must not revive its adjudication
+# after a newer row superseded the fingerprint to fixed.
+checkout_branch disposition-order
+head_order3="$(advance_head order-r3)"
+set_registry critic-a
+order_claim='Stable ordering claim [scripts/cr/order.sh:30]'
+run_panel 3 "$order_claim" imp "$tmp/order3.out" "$tmp/order3.err"
+assert_eq "$?" "0" "ordering seed panel run succeeds"
+id_order3="$(finding_id_at disposition-order "$head_order3")"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch disposition-order --head "$head_order3" \
+        --id "$id_order3" --set verdict=disproved --reason 'initial ordering claim disproved'
+) >/dev/null 2>"$tmp/order3-amend.err"
+assert_eq "$?" "0" "ordering fixture accepts initial disproof"
+head_order4="$(advance_head order-r4)"
+run_panel 4 "$order_claim" imp "$tmp/order4.out" "$tmp/order4.err"
+assert_eq "$?" "0" "ordering re-raise panel run succeeds"
+id_order4="$(finding_id_at disposition-order "$head_order4")"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch disposition-order --head "$head_order4" \
+        --id "$id_order4" --set verdict=fixed --reason 'newer occurrence was fixed'
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch disposition-order --head "$head_order3" \
+        --id "$id_order3" --set 'reason=older bookkeeping correction' --reason 'clarify old row only'
+) >/dev/null 2>"$tmp/order-latest.err"
+assert_eq "$?" "0" "non-verdict amendment fixture writes successfully"
+advance_head order-r5 >/dev/null
+run_panel 5 "$order_claim" imp "$tmp/order5.out" "$tmp/order5.err"
+assert_eq "$?" "0" "post-amend ordering panel run succeeds"
+assert_has "$(cat "$tmp/order5.out")" "## Important Issues (1 found)" "older non-verdict amend does not revive superseded disproof"
+assert_lacks "$(cat "$tmp/order5.out")" "RE-RAISE (" "newer fixed disposition remains authoritative"
+
+# Changing the file identity through an amendment invalidates the old
+# fingerprint. The full original claim may have been truncated, so the reader
+# must fail active rather than recompute a potentially false new identity.
+checkout_branch amended-anchor
+head_anchor3="$(advance_head anchor-r3)"
+set_registry critic-a
+anchor_claim='Anchor-specific claim [scripts/cr/old-anchor.sh:40]'
+run_panel 3 "$anchor_claim" imp "$tmp/anchor3.out" "$tmp/anchor3.err"
+assert_eq "$?" "0" "anchor seed panel run succeeds"
+id_anchor3="$(finding_id_at amended-anchor "$head_anchor3")"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch amended-anchor --head "$head_anchor3" \
+        --id "$id_anchor3" --set verdict=disproved --reason 'old anchor disposition'
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch amended-anchor --head "$head_anchor3" \
+        --id "$id_anchor3" --set file=scripts/cr/new-anchor.sh --reason 'correct the finding anchor'
+) >/dev/null 2>"$tmp/anchor-amend.err"
+assert_eq "$?" "0" "file-identity amendment fixture writes successfully"
+advance_head anchor-r4 >/dev/null
+run_panel 4 "$anchor_claim" imp "$tmp/anchor4.out" "$tmp/anchor4.err"
+assert_eq "$?" "0" "post-file-amend panel run succeeds"
+assert_has "$(cat "$tmp/anchor4.out")" "## Important Issues (1 found)" "file amendment invalidates the old fingerprint disposition"
+assert_lacks "$(cat "$tmp/anchor4.out")" "RE-RAISE (" "changed identity fails active instead of inheriting old anchor"
+
+# Deferred disposition carries its valid ticket and original round through
+# repeated r8/r9 re-raises. The r9 row must still point to r7, not chain to r8.
+checkout_branch deferred
+head_d7="$(advance_head d7)"
+set_registry critic-a
+deferred_claim='Cache cleanup must retain 2 generations [scripts/cr/cache.sh:70]'
+run_panel 7 "$deferred_claim" sug "$tmp/d7.out" "$tmp/d7.err"
+assert_eq "$?" "0" "r7 deferred producer panel run succeeds"
+id_d7="$(finding_id_at deferred "$head_d7")"
+assert_eq "$id_d7" "critic-a-1" "r7 deferred fixture produces the expected finding id"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch deferred --head "$head_d7" \
+        --id "$id_d7" --set verdict=deferred --set deferred_to=HIMMEL-9007 \
+        --set 'reason=Tracked outside this branch.' --reason 'defer the accepted follow-up'
+) >/dev/null 2>"$tmp/d7-amend.err"
+assert_eq "$?" "0" "r7 finding accepts a tracked deferred disposition"
+
+head_d8="$(advance_head d8)"
+run_panel 8 'cache cleanup must retain 2 generations [scripts/cr/cache.sh:80]' sug "$tmp/d8.out" "$tmp/d8.err"
+assert_eq "$?" "0" "r8 deferred re-raise panel run succeeds"
+assert_has "$(cat "$tmp/d8.out")" "RE-RAISE (r7 deferred)" "r8 reports the original deferred disposition"
+assert_has "$(cat "$tmp/d8.out")" "## Suggestions (0 found)" "r8 deferred re-raise is excluded from suggestion tally"
+assert_eq "$(ledger_value deferred "$head_d8" deferred_to)" "HIMMEL-9007" "r8 durable row carries the defer ticket"
+
+head_d9="$(advance_head d9)"
+run_panel 9 'CACHE cleanup must retain 2 generations [scripts/cr/cache.sh:90]' sug "$tmp/d9.out" "$tmp/d9.err"
+assert_eq "$?" "0" "r9 deferred re-raise panel run succeeds"
+assert_has "$(cat "$tmp/d9.out")" "RE-RAISE (r7 deferred)" "r9 still reports r7 rather than chaining through r8"
+assert_has "$(cat "$tmp/d9.out")" "## Suggestions (0 found)" "r9 deferred re-raise remains outside suggestion tally"
+assert_eq "$(ledger_value deferred "$head_d9" disposition_round)" "7" "r9 durable row preserves r7 as disposition source"
+
+advance_head d10-changed-claim >/dev/null
+run_panel 10 'CACHE cleanup must retain 3 generations [scripts/cr/cache.sh:90]' sug "$tmp/d10.out" "$tmp/d10.err"
+assert_eq "$?" "0" "changed deferred-claim panel run succeeds"
+assert_has "$(cat "$tmp/d10.out")" "## Suggestions (1 found)" "different claim at a settled anchor remains active"
+assert_lacks "$(cat "$tmp/d10.out")" "RE-RAISE (" "different claim is not inherited from the settled fingerprint"
+
+# The HIMMEL-2780 consumer is review-round.sh, not critic-panel.sh. A settled
+# current-head suggestion must not consume the round-4 suggestion cap or demand
+# a fresh ticket. Seed only the branch counter; no marker/clear path is reached
+# when the current finding is already resolved.
+mkdir -p "$git_dir/cr-review-rounds"
+printf '4\n' > "$git_dir/cr-review-rounds/deferred.round"
+(
+    cd "$repo" || exit 1
+    bash "$ROUND" defer --branch deferred --head "$head_d9"
+) >"$tmp/cap.out" 2>"$tmp/cap.err"
+assert_eq "$?" "0" "settled deferred re-raise does not consume the HIMMEL-2780 cap"
+assert_lacks "$(cat "$tmp/cap.err")" "no valid defer ticket" "settled cap path does not request another ticket"
+
+# Branch, critic, and artifact/perspective are controls outside the fingerprint
+# equality itself. Each mismatch must leave the current finding active.
+checkout_branch other-branch
+advance_head other >/dev/null
+set_registry critic-a
+run_panel 10 "$deferred_claim" sug "$tmp/other.out" "$tmp/other.err"
+assert_eq "$?" "0" "other-branch panel run succeeds"
+assert_has "$(cat "$tmp/other.out")" "## Suggestions (1 found)" "same fingerprint on another branch stays visible"
+
+checkout_branch other-critic
+head_oc_seed="$(advance_head oc-seed)"
+set_registry critic-a
+run_panel 3 "$deferred_claim" sug "$tmp/oc-seed.out" "$tmp/oc-seed.err"
+assert_eq "$?" "0" "other-critic seed panel run succeeds"
+id_oc_seed="$(finding_id_at other-critic "$head_oc_seed")"
+assert_eq "$id_oc_seed" "critic-a-1" "other-critic seed produces the expected id"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch other-critic --head "$head_oc_seed" \
+        --id "$id_oc_seed" --set verdict=disproved --reason 'critic-a claim disproved'
+) >/dev/null 2>&1
+advance_head oc-current >/dev/null
+set_registry critic-b
+run_panel 4 "$deferred_claim" sug "$tmp/oc.out" "$tmp/oc.err"
+assert_eq "$?" "0" "different-critic panel run succeeds"
+assert_has "$(cat "$tmp/oc.out")" "## Suggestions (1 found)" "same claim from a different critic stays visible"
+
+checkout_branch controls
+head_control_seed="$(advance_head control-seed)"
+set_registry critic-a
+# Use the real writer so the spec/on row gets the same production fingerprint.
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" finding --branch controls --head "$head_control_seed" \
+        --model critic-a --id control-1 --severity sug --file scripts/cr/cache.sh --line 70 \
+        --verdict disproved --artifact spec --perspective on --round 3 \
+        --text "- [control-1]: $deferred_claim"
+) >/dev/null 2>"$tmp/control-seed.err"
+assert_eq "$?" "0" "control fixture writes a fingerprinted spec/perspective row"
+advance_head control-current >/dev/null
+run_panel 4 "$deferred_claim" sug "$tmp/control.out" "$tmp/control.err"
+assert_eq "$?" "0" "artifact/perspective control panel run succeeds"
+assert_has "$(cat "$tmp/control.out")" "## Suggestions (1 found)" "different artifact/perspective controls stay visible"
+
+# Legacy/textless findings have no fingerprint and are ignored safely rather
+# than guessed into a match.
+checkout_branch legacy
+head_legacy_seed="$(advance_head legacy-seed)"
+printf '{"kind":"finding","ts":"2020-01-01T00:00:00Z","branch":"legacy","head":"%s","model":"critic-a","finding_id":"legacy-1","severity":"sug","file":"scripts/cr/cache.sh","line":70,"verdict":"disproved","artifact":"diff","perspective":"off"}\n' "$head_legacy_seed" >> "$ledger"
+advance_head legacy-current >/dev/null
+set_registry critic-a
+run_panel 4 "$deferred_claim" sug "$tmp/legacy.out" "$tmp/legacy.err"
+assert_eq "$?" "0" "legacy-textless panel run succeeds"
+assert_has "$(cat "$tmp/legacy.out")" "## Suggestions (1 found)" "legacy textless input is safe and remains visible"
+
+# Additive fingerprint/round fields must not alter the existing dedup key or
+# break a textless verdict-only reappend. Same (head,id,artifact,perspective)
+# still dedups; an incoming adjudication omitting additive fields auto-amends.
+checkout_branch ledger-compat
+head_lc="$(advance_head ledger-compat)"
+compat="$tmp/compat.jsonl"
+: > "$compat"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$compat" bash "$LEDGER_APPEND" finding --branch ledger-compat --head "$head_lc" \
+        --model critic-a --id critic-a-1 --severity imp --file scripts/cr/example.sh --line 117 \
+        --verdict '' --round 4 --text "- [critic-a-1]: $claim_r4"
+    CR_LEDGER="$compat" bash "$LEDGER_APPEND" finding --branch ledger-compat --head "$head_lc" \
+        --model critic-a --id critic-a-1 --severity imp --file scripts/cr/example.sh --line 117 \
+        --verdict '' --round 4 --text "- [critic-a-1]: $claim_r4"
+) >/dev/null 2>"$tmp/compat-dedup.err"
+assert_eq "$(wc -l < "$compat" | tr -d ' ')" "1" "additive fields leave the finding dedup key unchanged"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$compat" bash "$LEDGER_APPEND" finding --branch ledger-compat --head "$head_lc" \
+        --model critic-a --id critic-a-1 --severity imp --file scripts/cr/example.sh --line 117 \
+        --verdict disproved
+) >/dev/null 2>"$tmp/compat-verdict.err"
+assert_eq "$?" "0" "textless verdict-only reappend remains compatible"
+compat_shape="$(LEDGER="$compat" node -e '
+const rows=require("fs").readFileSync(process.env.LEDGER,"utf8").split("\n").filter(Boolean).map(JSON.parse);
+process.stdout.write(rows.filter(r=>r.kind==="finding").length+","+rows.filter(r=>r.kind==="amend").length);
+')"
+compat_fp="$(LEDGER="$compat" node -e '
+const rows=require("fs").readFileSync(process.env.LEDGER,"utf8").split("\n").filter(Boolean).map(JSON.parse);
+const finding=rows.find(r=>r.kind==="finding")||{};
+process.stdout.write(String(finding.fingerprint||""));
+')"
+assert_eq "$compat_shape" "1,1" "verdict-only compatibility uses an amend, not a duplicate finding"
+assert_fingerprint "$compat_fp" "original fingerprint survives verdict-only adjudication"
+
+# Sanity: every current panel run wrote one durable finding row; none was
+# silently dropped merely because it rendered in the already-dispositioned block.
+assert_eq "$(finding_count_at reraised "$head_r5")" "1" "disproved re-raise remains a durable current-head row"
+assert_eq "$(finding_count_at deferred "$head_d8")" "1" "deferred r8 re-raise remains a durable current-head row"
+assert_eq "$(finding_count_at deferred "$head_d9")" "1" "deferred r9 re-raise remains a durable current-head row"
+
+if [ "$fails" -gt 0 ]; then
+    printf 'FAIL test-finding-reraise (%s failures)\n' "$fails" >&2
+    exit 1
+fi
+printf 'PASS test-finding-reraise\n'

--- a/scripts/cr/test-finding-reraise.sh
+++ b/scripts/cr/test-finding-reraise.sh
@@ -326,6 +326,79 @@ printf '4\n' > "$git_dir/cr-review-rounds/deferred.round"
 assert_eq "$?" "0" "settled deferred re-raise does not consume the HIMMEL-2780 cap"
 assert_lacks "$(cat "$tmp/cap.err")" "no valid defer ticket" "settled cap path does not request another ticket"
 
+# A disposition at Suggestion severity does not authorize silently suppressing
+# the same claim when a later critic raises it as Important.
+checkout_branch deferred
+advance_head d11-severity-escalation >/dev/null
+run_panel 11 "$deferred_claim" imp "$tmp/d11.out" "$tmp/d11.err"
+assert_eq "$?" "0" "severity-escalated deferred panel run succeeds"
+assert_has "$(cat "$tmp/d11.out")" "## Important Issues (1 found)" "deferred Suggestion re-raised as Important requires adjudication"
+assert_lacks "$(cat "$tmp/d11.out")" "RE-RAISE (" "severity escalation remains in the active findings block"
+
+# Same/lower severities remain suppressed against the ORIGINAL adjudicated
+# ceiling. An inherited lower-severity row must not narrow that ceiling for the
+# next round; only a later increase above it becomes active.
+checkout_branch severity-ceiling
+head_sc3="$(advance_head severity-ceiling-r3)"
+set_registry critic-a
+severity_claim='Severity ceiling claim [scripts/cr/severity.sh:30]'
+run_panel 3 "$severity_claim" imp "$tmp/sc3.out" "$tmp/sc3.err"
+assert_eq "$?" "0" "severity ceiling seed panel run succeeds"
+id_sc3="$(finding_id_at severity-ceiling "$head_sc3")"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch severity-ceiling --head "$head_sc3" \
+        --id "$id_sc3" --set verdict=disproved --reason 'Important claim disproved'
+) >/dev/null 2>"$tmp/sc3-amend.err"
+assert_eq "$?" "0" "severity ceiling fixture accepts Important disproof"
+head_sc4="$(advance_head severity-ceiling-r4)"
+run_panel 4 "$severity_claim" sug "$tmp/sc4.out" "$tmp/sc4.err"
+assert_eq "$?" "0" "lower severity panel run succeeds"
+assert_has "$(cat "$tmp/sc4.out")" "## Suggestions (0 found)" "lower Suggestion remains suppressed"
+assert_eq "$(ledger_value severity-ceiling "$head_sc4" disposition_severity)" "imp" "lower re-raise persists original Important severity ceiling"
+advance_head severity-ceiling-r5 >/dev/null
+run_panel 5 "$severity_claim" imp "$tmp/sc5.out" "$tmp/sc5.err"
+assert_eq "$?" "0" "same severity panel run succeeds"
+assert_has "$(cat "$tmp/sc5.out")" "## Important Issues (0 found)" "same Important severity remains suppressed after lower inherited row"
+advance_head severity-ceiling-r6 >/dev/null
+run_panel 6 "$severity_claim" crit "$tmp/sc6.out" "$tmp/sc6.err"
+assert_eq "$?" "0" "higher severity panel run succeeds"
+assert_has "$(cat "$tmp/sc6.out")" "## Critical Issues (1 found)" "Critical escalation above original Important ceiling is active"
+assert_lacks "$(cat "$tmp/sc6.out")" "RE-RAISE (" "Critical escalation requires renewed adjudication"
+
+# Missing or unknown adjudicated severity is conservative: there is no safe
+# ceiling to compare, so a current canonical finding remains active.
+checkout_branch severity-unknown
+head_su3="$(advance_head severity-unknown-seed)"
+unknown_claim='Unknown severity claim [scripts/cr/severity.sh:70]'
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" finding --branch severity-unknown --head "$head_su3" \
+        --model critic-a --id severity-unknown-1 --severity mystery --file scripts/cr/severity.sh --line 70 \
+        --verdict disproved --round 3 --text "- [severity-unknown-1]: $unknown_claim"
+) >/dev/null 2>"$tmp/severity-unknown-seed.err"
+assert_eq "$?" "0" "unknown severity fixture writes"
+advance_head severity-unknown-current >/dev/null
+run_panel 4 "$unknown_claim" imp "$tmp/severity-unknown.out" "$tmp/severity-unknown.err"
+assert_eq "$?" "0" "unknown prior severity panel run succeeds"
+assert_has "$(cat "$tmp/severity-unknown.out")" "## Important Issues (1 found)" "unknown prior severity fails active"
+assert_lacks "$(cat "$tmp/severity-unknown.out")" "RE-RAISE (" "unknown prior severity is not inherited"
+
+checkout_branch severity-missing
+head_sm3="$(advance_head severity-missing-seed)"
+missing_claim='Missing severity claim [scripts/cr/severity.sh:80]'
+missing_fp="$(MODEL=critic-a FILE_=scripts/cr/severity.sh TEXT_="- [severity-missing-1]: $missing_claim" HELPER="$HERE/finding-fingerprint.js" node -e '
+const {findingFingerprint}=require(process.env.HELPER);
+process.stdout.write(findingFingerprint(process.env.MODEL,process.env.FILE_,process.env.TEXT_));
+')"
+printf '{"kind":"finding","ts":"2020-01-01T00:00:00Z","branch":"severity-missing","head":"%s","model":"critic-a","finding_id":"severity-missing-1","file":"scripts/cr/severity.sh","line":80,"verdict":"disproved","round":3,"disposition_round":3,"fingerprint":"%s","artifact":"diff","perspective":"off","text":"- [severity-missing-1]: %s"}\n' \
+    "$head_sm3" "$missing_fp" "$missing_claim" >> "$ledger"
+advance_head severity-missing-current >/dev/null
+run_panel 4 "$missing_claim" imp "$tmp/severity-missing.out" "$tmp/severity-missing.err"
+assert_eq "$?" "0" "missing prior severity panel run succeeds"
+assert_has "$(cat "$tmp/severity-missing.out")" "## Important Issues (1 found)" "missing prior severity fails active"
+assert_lacks "$(cat "$tmp/severity-missing.out")" "RE-RAISE (" "missing prior severity is not inherited"
+
 # Branch, critic, and artifact/perspective are controls outside the fingerprint
 # equality itself. Each mismatch must leave the current finding active.
 checkout_branch other-branch

--- a/scripts/cr/test-ledger-append.sh
+++ b/scripts/cr/test-ledger-append.sh
@@ -983,4 +983,33 @@ CR_LEDGER="$RLGB" bash "$LA" finding --batch-file "$RLGBF" 2>"$tmp/round-legacy-
 check "batch retry dedups a legacy text row lacking additive fields" "$?" "0"
 check "batch legacy retry writes no replacement row" "$(wc -l < "$RLGB" | tr -d ' ')" "1"
 
+# Batch round metadata follows the positive-integer CLI contract. Invalid rows
+# are refused individually while valid siblings still append (batch partial
+# success, not all-or-nothing).
+BRVF="$tmp/batch-round-validation-rows.jsonl"
+BRVL="$tmp/batch-round-validation.jsonl"
+BRV_HEAD=$(printf '%040d' 78901)
+# shellcheck disable=SC2016  # JavaScript template literals, not shell expansion.
+HEAD_="$BRV_HEAD" OUT="$BRVF" node -e '
+const fs=require("fs"),e=process.env;
+const base={branch:"b",head:e.HEAD_,model:"critic-a",severity:"imp",file:"f",line:1,verdict:"",text:"- [round-validation]: claim [f:1]"};
+const rows=[];
+for(const [label,value] of [["zero",0],["negative",-1],["fractional",1.5],["nonnumeric","nope"]]){
+  rows.push({...base,id:`round-${label}`,round:value});
+  rows.push({...base,id:`disposition-round-${label}`,disposition_round:value});
+}
+rows.push({...base,id:"round-number",round:2});
+rows.push({...base,id:"round-string",round:"3"});
+rows.push({...base,id:"disposition-round-number",disposition_round:4});
+rows.push({...base,id:"disposition-round-string",disposition_round:"5"});
+rows.push({...base,id:"round-absent"});
+fs.writeFileSync(e.OUT,rows.map(JSON.stringify).join("\n")+"\n");
+'
+CR_LEDGER="$BRVL" bash "$LA" finding --batch-file "$BRVF" 2>"$tmp/batch-round-validation.err"
+check "batch invalid round metadata yields partial-success rc3" "$?" "3"
+check "batch invalid round rows are refused and valid/absent controls append" "$(L="$BRVL" node -e 'const r=require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").filter(Boolean).map(JSON.parse);console.log(r.map(x=>x.finding_id).sort().join(","))')" "disposition-round-number,disposition-round-string,round-absent,round-number,round-string"
+check "batch numeric/string round controls normalize to numbers" "$(L="$BRVL" node -e 'const r=require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").filter(Boolean).map(JSON.parse);console.log(r.filter(x=>x.round!==undefined).map(x=>typeof x.round+":"+x.round).sort().join(","))')" "number:2,number:3"
+check "batch numeric/string disposition-round controls normalize to numbers" "$(L="$BRVL" node -e 'const r=require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").filter(Boolean).map(JSON.parse);console.log(r.filter(x=>x.disposition_round!==undefined).map(x=>typeof x.disposition_round+":"+x.disposition_round).sort().join(","))')" "number:4,number:5"
+check "batch absent round metadata remains absent" "$(L="$BRVL" node -e 'const r=require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").filter(Boolean).map(JSON.parse).find(x=>x.finding_id==="round-absent");console.log(("round" in r)+","+("disposition_round" in r))')" "false,false"
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/cr/test-ledger-append.sh
+++ b/scripts/cr/test-ledger-append.sh
@@ -922,6 +922,27 @@ check "fingerprint single/batch parity" "$(A="$FPS" B="$FPB" node -e 'const fs=r
 check "long claims persist the same capped display text" "$(L="$FPB" node -e 'const r=require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").map(JSON.parse);console.log(r[0].text===r[1].text)')" "true"
 check "long claim suffix remains fingerprint-significant before truncation" "$(L="$FPB" node -e 'const r=require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").map(JSON.parse);console.log(r[0].fingerprint!==r[1].fingerprint)')" "true"
 
+# When both rows carry fingerprints, they remain part of content comparison:
+# the same dedup key must loudly refuse claims that differ only after the
+# persisted 500-character display prefix.
+FPC="$tmp/fingerprint-collision-single.jsonl"
+CR_LEDGER="$FPC" bash "$LA" finding --branch b --head FPC1 --model critic-a --id fp-collision --severity imp --file f --line 11 --verdict '' --round 4 --text "$FP_TEXT_A"
+CR_LEDGER="$FPC" bash "$LA" finding --branch b --head FPC1 --model critic-a --id fp-collision --severity imp --file f --line 11 --verdict '' --round 5 --text "$FP_TEXT_B" 2>"$tmp/fingerprint-collision-single.err"
+check "single same-key long-suffix collision refuses" "$?" "3"
+check "single long-suffix refusal preserves the first row" "$(wc -l < "$FPC" | tr -d ' ')" "1"
+
+FPCB="$tmp/fingerprint-collision-batch.jsonl"
+FPCBF="$tmp/fingerprint-collision-batch-rows.jsonl"
+FPC_HEAD=$(printf '%040d' 56789)
+FP_TEXT_A="$FP_TEXT_A" FP_TEXT_B="$FP_TEXT_B" HEAD_="$FPC_HEAD" OUT="$FPCBF" node -e '
+const fs=require("fs"),e=process.env;
+const base={branch:"b",head:e.HEAD_,model:"critic-a",id:"fp-collision",severity:"imp",file:"f",line:11,verdict:""};
+fs.writeFileSync(e.OUT,[{...base,round:4,text:e.FP_TEXT_A},{...base,round:5,text:e.FP_TEXT_B}].map(JSON.stringify).join("\n")+"\n");
+'
+CR_LEDGER="$FPCB" bash "$LA" finding --batch-file "$FPCBF" 2>"$tmp/fingerprint-collision-batch.err"
+check "batch same-key long-suffix collision refuses" "$?" "3"
+check "batch long-suffix refusal preserves the first row" "$(wc -l < "$FPCB" | tr -d ' ')" "1"
+
 # Review round is observation metadata, not finding content identity. A retry at
 # the same head preserves the first observed round in both writer paths.
 RSL="$tmp/round-single.jsonl"

--- a/scripts/cr/test-ledger-append.sh
+++ b/scripts/cr/test-ledger-append.sh
@@ -902,4 +902,64 @@ check "batch mode scrubs a secret in text" "$(L="$BFT" node -e 'const o=require(
 check "batch mode scrubs a token split across an embedded newline" "$(L="$BFT" node -e 'const o=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).find(r=>r.finding_id==="bt-5");console.log(o.text.includes("apikeyvalue1234567890")+","+o.text.includes("[REDACTED]"))')" "false,true"  # gitleaks:allow (fake fixture)
 check "batch mode scrubs a token split across a lone carriage return" "$(L="$BFT" node -e 'const o=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).find(r=>r.finding_id==="bt-6");console.log(o.text.includes("zxywvutsrqponmlkjihg")+","+o.text.includes("[REDACTED]"))')" "false,true"  # gitleaks:allow (fake fixture)
 
+# HIMMEL-2896: fingerprint the complete claim before the 500-character display
+# cap. Claims whose persisted text is identical but whose suffix differs must
+# not collide. Single-row and batch writers must derive the same fingerprint.
+FP_PREFIX="$(printf 'x%.0s' $(seq 1 520))"
+FP_TEXT_A="${FP_PREFIX}A [f:11]"
+FP_TEXT_B="${FP_PREFIX}B [f:22]"
+FPS="$tmp/fingerprint-single.jsonl"
+CR_LEDGER="$FPS" bash "$LA" finding --branch b --head FP1 --model critic-a --id fp-1 --severity imp --file f --line 11 --verdict '' --round 4 --text "$FP_TEXT_A"
+FPB="$tmp/fingerprint-batch.jsonl"
+FPBF="$tmp/fingerprint-batch-rows.jsonl"
+FP_TEXT_A="$FP_TEXT_A" FP_TEXT_B="$FP_TEXT_B" BHEAD="$BHEAD" OUT="$FPBF" node -e '
+const fs=require("fs"),e=process.env;
+const base={branch:"b",head:e.BHEAD,model:"critic-a",severity:"imp",file:"f",verdict:"",round:4};
+fs.writeFileSync(e.OUT,[{...base,id:"fp-a",line:11,text:e.FP_TEXT_A},{...base,id:"fp-b",line:22,text:e.FP_TEXT_B}].map(JSON.stringify).join("\n")+"\n");
+'
+CR_LEDGER="$FPB" bash "$LA" finding --batch-file "$FPBF"
+check "fingerprint single/batch parity" "$(A="$FPS" B="$FPB" node -e 'const fs=require("fs");const a=JSON.parse(fs.readFileSync(process.env.A,"utf8"));const b=fs.readFileSync(process.env.B,"utf8").trim().split("\n").map(JSON.parse)[0];console.log(a.fingerprint===b.fingerprint)')" "true"
+check "long claims persist the same capped display text" "$(L="$FPB" node -e 'const r=require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").map(JSON.parse);console.log(r[0].text===r[1].text)')" "true"
+check "long claim suffix remains fingerprint-significant before truncation" "$(L="$FPB" node -e 'const r=require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").map(JSON.parse);console.log(r[0].fingerprint!==r[1].fingerprint)')" "true"
+
+# Review round is observation metadata, not finding content identity. A retry at
+# the same head preserves the first observed round in both writer paths.
+RSL="$tmp/round-single.jsonl"
+CR_LEDGER="$RSL" bash "$LA" finding --branch b --head ROUND1 --model critic-a --id round-1 --severity imp --file f --line 9 --verdict '' --round 4 --text '- [round-1]: stable retry claim [f:9]'
+CR_LEDGER="$RSL" bash "$LA" finding --branch b --head ROUND1 --model critic-a --id round-1 --severity imp --file f --line 9 --verdict '' --round 5 --text '- [round-1]: stable retry claim [f:9]' 2>"$tmp/round-single.err"
+check "single same-head retry ignores changed round" "$?" "0"
+check "single same-head retry preserves first round" "$(L="$RSL" node -e 'const r=JSON.parse(require("fs").readFileSync(process.env.L,"utf8"));console.log(r.round+","+require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").length)')" "4,1"
+
+RBB="$tmp/round-batch-rows.jsonl"
+RBL="$tmp/round-batch.jsonl"
+RHEAD=$(printf '%040d' 67890)
+printf '{"branch":"b","head":"%s","model":"critic-a","id":"round-b","severity":"imp","file":"f","line":9,"verdict":"","round":4,"text":"- [round-b]: stable retry claim [f:9]"}\n' "$RHEAD" > "$RBB"
+printf '{"branch":"b","head":"%s","model":"critic-a","id":"round-b","severity":"imp","file":"f","line":9,"verdict":"","round":5,"text":"- [round-b]: stable retry claim [f:9]"}\n' "$RHEAD" >> "$RBB"
+CR_LEDGER="$RBL" bash "$LA" finding --batch-file "$RBB" 2>"$tmp/round-batch.err"
+check "batch same-head retry ignores changed round" "$?" "0"
+check "batch same-head retry preserves first round" "$(L="$RBL" node -e 'const r=JSON.parse(require("fs").readFileSync(process.env.L,"utf8"));console.log(r.round+","+require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").length)')" "4,1"
+
+RVL="$tmp/round-verdict.jsonl"
+CR_LEDGER="$RVL" bash "$LA" finding --branch b --head ROUND2 --model critic-a --id round-v --severity imp --file f --line 10 --verdict '' --round 4 --text '- [round-v]: adjudicated retry claim [f:10]'
+CR_LEDGER="$RVL" bash "$LA" finding --branch b --head ROUND2 --model critic-a --id round-v --severity imp --file f --line 10 --verdict disproved --round 5 2>"$tmp/round-verdict.err"
+check "verdict-only retry may supply a later round" "$?" "0"
+check "verdict-only later round appends amend and preserves producer round" "$(L="$RVL" node -e 'const r=require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").map(JSON.parse);console.log(r.filter(x=>x.kind==="finding").length+","+r.filter(x=>x.kind==="amend").length+","+r[0].round)')" "1,1,4"
+
+# Pre-fingerprint rows remain idempotent when a new writer supplies additive
+# fingerprint/round metadata; append-only compatibility preserves the old row.
+LEGACY_TEXT='- [legacy-round]: legacy claim [f:12]'
+RLG="$tmp/round-legacy.jsonl"
+printf '{"kind":"finding","ts":"2020-01-01T00:00:00Z","branch":"b","head":"LEGACY1","model":"critic-a","finding_id":"legacy-round","severity":"imp","file":"f","line":12,"verdict":"","artifact":"diff","perspective":"off","text":"%s"}\n' "$LEGACY_TEXT" > "$RLG"
+CR_LEDGER="$RLG" bash "$LA" finding --branch b --head LEGACY1 --model critic-a --id legacy-round --severity imp --file f --line 12 --verdict '' --round 6 --text "$LEGACY_TEXT" 2>"$tmp/round-legacy.err"
+check "single retry dedups a legacy text row lacking additive fields" "$?" "0"
+check "single legacy retry writes no replacement row" "$(wc -l < "$RLG" | tr -d ' ')" "1"
+
+RLGB="$tmp/round-legacy-batch.jsonl"
+printf '{"kind":"finding","ts":"2020-01-01T00:00:00Z","branch":"b","head":"%s","model":"critic-a","finding_id":"legacy-batch","severity":"imp","file":"f","line":12,"verdict":"","artifact":"diff","perspective":"off","text":"%s"}\n' "$RHEAD" "$LEGACY_TEXT" > "$RLGB"
+RLGBF="$tmp/round-legacy-batch-rows.jsonl"
+printf '{"branch":"b","head":"%s","model":"critic-a","id":"legacy-batch","severity":"imp","file":"f","line":12,"verdict":"","round":6,"text":"%s"}\n' "$RHEAD" "$LEGACY_TEXT" > "$RLGBF"
+CR_LEDGER="$RLGB" bash "$LA" finding --batch-file "$RLGBF" 2>"$tmp/round-legacy-batch.err"
+check "batch retry dedups a legacy text row lacking additive fields" "$?" "0"
+check "batch legacy retry writes no replacement row" "$(wc -l < "$RLGB" | tr -d ' ')" "1"
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/cr/test-pr-check-rounds.sh
+++ b/scripts/cr/test-pr-check-rounds.sh
@@ -38,8 +38,9 @@ chmod +x "$fx/scripts/cr/panel-first-pass.sh" "$fx/scripts/cr/ledger-append.sh" 
 SCRIPT="$fx/scripts/cr/panel-first-pass.sh"
 
 PANEL_CALLS="$tmp/panel-calls"
+PANEL_ROUNDS="$tmp/panel-rounds"
 CLEAR_CALLS="$tmp/clear-calls"
-export PANEL_CALLS CLEAR_CALLS
+export PANEL_CALLS PANEL_ROUNDS CLEAR_CALLS
 cat > "$fx/scripts/cr/critic-panel.sh" <<'STUB'
 #!/usr/bin/env bash
 head_sha=""
@@ -53,6 +54,7 @@ while [ $# -gt 0 ]; do
 done
 cat >/dev/null
 printf '%s\n' "$head_sha" >> "$PANEL_CALLS"
+printf '%s\n' "${CR_REVIEW_ROUND:-<absent>}" >> "$PANEL_ROUNDS"
 ledger="$(git rev-parse --git-common-dir)/cr-critic-scores.jsonl"
 CR_LEDGER="$ledger" bash "$(dirname "$0")/ledger-append.sh" avail \
     --branch "$branch" --head "$head_sha" --model stub --status ok || exit $?
@@ -158,6 +160,7 @@ git -C "$repo" push -q origin feature
 out3="$(cd "$repo" && bash "$SCRIPT" --head "$head3" --branch feature 2>"$tmp/err3")"; rc3=$?
 assert_eq "$rc3" "0" "merge-forward run succeeds"
 assert_has "$out3" "pr-check: round 3 of 3 on feature" "merge-forward retains the branch counter"
+assert_eq "$(cat "$PANEL_ROUNDS")" "$(printf '1\n2\n3')" "panel receives each persisted branch review round"
 
 git -C "$repo" checkout -q -b other main
 printf 'other\n' > "$repo/other.txt"


### PR DESCRIPTION
## Summary

Implements HIMMEL-2896: persist stable finding fingerprints and review rounds, consult append-only branch disposition history, and display settled repeats in **Already Dispositioned Re-raises**. Repeated findings stay durable current-head evidence but do not inflate active severity counts or consume the HIMMEL-2780 cap. `fixed` never suppresses a possible regression; severity increases require renewed adjudication.

Fingerprint inputs are critic slug, normalized case-preserving file anchor, and the full scrubbed claim before the 500-character display cap. Existing finding identity keys and monotone availability semantics remain unchanged. Existing finding verdicts and amendment rows provide dispositions; no ledger migration, row deletion, or rewrite.

### Round propagation

Previously, `panel-first-pass.sh` incremented the branch counter without passing it into finding rows. This PR propagates `CR_REVIEW_ROUND` through both panel invocations. Because `review-round.sh defer` reads effective **current-head** verdicts, suppressed repeats also retain current-head rows with inherited dispositions; render-only changes would not satisfy that contract. Distinguishing a later adjudication round from the producer round remains deferred below.

## Motivation

HIMMEL-2873 comment 28127 (2026-09-10) records nine review rounds on PR #599: 24 agreed/fixed, two disproved, nine deferred. Settled findings returned verbatim:

- r7 codex-3 repeated r4 codex-4, already disproved.
- r8 codex-2 repeated r7 codex-1, already deferred to HIMMEL-2889.
- r9 codex-1 repeated that deferred finding.

Roughly two paid rounds were spent relitigating settled findings. This change consults earlier dispositions without hiding the repeated evidence.

## Verification

Four commits, with Linux/security attestations in the **first** commit:

| Commit | RED → GREEN evidence |
| --- | --- |
| `589491ca` | Initial acceptance: 21 feature failures after fixture correctness checks; retry/history regression controls also observed RED before repair. |
| `843341d3` | Same-key long-suffix collisions and case-distinct file anchors: two failures in each suite, then GREEN. |
| `56ccb1e8` | Severity escalation: seven failures; invalid batch rounds: four failures; then GREEN. |
| `860de1ef` | Failed enriched-batch copy: incorrect rc 0 and absent certification error, then rc 5 with explicit failure. Raw-finding and exact copy-path controls passed. |

All **23 referencing suites plus `test-known-findings.sh`** passed on the final code. The coordinator independently reran the focused regression suites after each fix, including the final critic-panel suite. Shellcheck passed on all seven touched shell files; both JS syntax checks, `git diff --check`, and commit/push gates passed. No full local shell-suite run; Linux only was runtime-tested. All tests use isolated ledgers and stub critic seams, with no live critic calls.

The remaining same-basename coverage checklist flags are covered by `test-finding-reraise.sh` integration tests and `test-pr-check-rounds.sh` round propagation tests.

## Review history and provenance

**r1 2 fixed/1 disproved · r2 2 fixed · r4 1 fixed + 1 deferred · r5 2 deferred**

- r1's corrected-head finding was disproved with the real writer: lookup through a corrected effective head still persists the original `target_head`, so the existing original-key map applies the later `fixed` verdict. Durable regression coverage was added.
- r2 was run directly by the operator after this session's paid-panel invocation was permission-refused.
- The console independently ran and adjudicated r4/r5. The initially proposed cap deferral of r4's Important copy failure was withdrawn: Important findings remain blocking at every round. That issue was fixed in commit four.
- Final-head r5 at `860de1efc00784051f3b5606b06ac68917d8666c`: codex/gpt-6-astra responded; one Important and one Suggestion received explicit tracked dispositions. Both verdict files and ledger amendments were verified; the marker is absent.

This PR changes its own CR tooling. The trusted primary-checkout context script logged delegation before using this branch's CR scripts. The paid panel is gpt-6-astra, the same family as the implementation lane, under the accepted console arrangement. The adversarial pass was dormant/absent, not a failed or completed review. CodeRabbit and the console's Claude-side review remain separate post-PR checks.

## Explicit follow-ups — HIMMEL-2901

Four findings entered the ticket history; the copy-failure item is now fixed, leaving **three unresolved**:

1. **Important — correcting original severity after inheritance:** once an inherited event becomes latest, a severity amendment to the original adjudication can be ignored. An obsolete Important ceiling can then suppress a later Important occurrence. The console explicitly deferred this as a scope/risk decision to the inherited-provenance follow-up, **not under the round cap**. The repeat remains visibly rendered, but its blocking tally can still be wrong in that sequence.
2. **Suggestion — adjudication-round provenance:** a later verdict is labeled with the producer round, not a separately persisted adjudication round. Producer-round propagation itself is implemented here.
3. **Suggestion — claim case folding:** case-sensitive identifiers/literals such as `Foo` and `foo` in the same file can share a claim fingerprint. Code-bearing-fragment normalization remains a follow-up.

These three are deferred, not fixed or disproved. Legacy/textless findings, missing reliable rounds, and unknown severity remain active rather than guessing historical identity. Deferred suppression requires a valid ticket and nonempty reason.

Platforms tested: linux
Security reviewed: manual — ledger read/write only; no new network calls; suppression annotates and re-tallies, never deletes a ledger row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
