### PR TITLE
fix(template,luna-upgrade): [HIMMEL-2886] template carries the vault allowlists; upgrade surfaces local config hunks

### DIFF
--- a/scripts/luna-upgrade-all.sh
+++ b/scripts/luna-upgrade-all.sh
@@ -398,6 +398,15 @@ has_conflict_line() {
 }
 
 # ---------------------------------------------------------------------------
+# has_local_edit_line <text>: exit 0 if any plan line is a LOCAL-EDIT
+# (HIMMEL-2886: a template-owned "overwrite"-class file the vault edited
+# locally since its last upgrade — upgrade.sh withheld the write).
+has_local_edit_line() {
+    local text="$1"
+    printf '%s\n' "$text" | grep -qE '^ +LOCAL-EDIT'
+}
+
+# ---------------------------------------------------------------------------
 # cmd_sweep: discover vaults, classify, dry-run, emit table.
 cmd_sweep() {
     local vaults
@@ -482,6 +491,8 @@ cmd_sweep() {
 
                         if has_conflict_line "$dry_out"; then
                             state="conflict"
+                        elif has_local_edit_line "$dry_out"; then
+                            state="local-config-edits"
                         elif has_plan_lines "$dry_out"; then
                             state="clean-upgrade"
                         else
@@ -559,7 +570,7 @@ backup_vault() {
         # Plan lines start with 2 spaces then a class token; skip non-plan and REPORT
         case "$line" in
             "  "REPORT*) continue ;;
-            "  "WRITE*|"  "MERGE-JSON*|"  "MERGE-3WAY*)
+            "  "WRITE*|"  "MERGE-JSON*|"  "MERGE-3WAY*|"  "LOCAL-EDIT*)
                 # Strip leading whitespace, then grab the second space-delimited field
                 local stripped; stripped="$(printf '%s' "$line" | sed 's/^[[:space:]]*//')"
                 # Rel path is everything after the first whitespace-delimited token
@@ -750,7 +761,7 @@ cmd_apply() {
     # Run upgrade.sh --yes
     local upgrade_rc
     upgrade_rc=0
-    bash "$UPGRADE" --template-dir "$TEMPLATE_DIR" --vault-dir "$vault" --yes 2>&1 \
+    bash "$UPGRADE" --template-dir "$TEMPLATE_DIR" --vault-dir "$vault" --backup-dir "$backup_dest" --yes 2>&1 \
         || upgrade_rc=$?
 
     case "$upgrade_rc" in

--- a/scripts/luna-upgrade-all.sh
+++ b/scripts/luna-upgrade-all.sh
@@ -403,7 +403,10 @@ has_conflict_line() {
 # locally since its last upgrade — upgrade.sh withheld the write).
 has_local_edit_line() {
     local text="$1"
-    printf '%s\n' "$text" | grep -qE '^ +LOCAL-EDIT'
+    # Here-string, not `printf | grep -q` (pipefail-ok would still need a
+    # justification comment; a here-string is simply immune to the
+    # early-exit-SIGPIPE pipefail trap on this small dry-run-plan input).
+    grep -qE '^ +LOCAL-EDIT' <<< "$text"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/test-luna-upgrade-all.sh
+++ b/scripts/test-luna-upgrade-all.sh
@@ -1437,11 +1437,14 @@ git -C "$T30_VAULT" init -q
 git -C "$T30_VAULT" config user.email "test@example.com"
 git -C "$T30_VAULT" config user.name "Test"
 git -C "$T30_VAULT" add -A
-git -C "$T30_VAULT" commit -q -m "initial stamp 0.9.0"
+git -C "$T30_VAULT" commit -q -m "initial stamp 0.9.0"; t30_commit1_rc=$?
+assert_eq "T30 setup: initial commit landed" "0" "$t30_commit1_rc"
 # Committed local edit (clean git status afterwards) — the actual incident shape.
 printf 'gitleaks-content-v1\nlocal-allowlist-line\n' > "$T30_VAULT/.gitleaks.toml"
 git -C "$T30_VAULT" add -A
-git -C "$T30_VAULT" commit -q -m "add local allowlist line"
+git -C "$T30_VAULT" commit -q -m "add local allowlist line"; t30_commit2_rc=$?
+assert_eq "T30 setup: local-edit commit landed" "0" "$t30_commit2_rc"
+assert_eq "T30 setup: working tree is clean (matches the incident's shape)" "" "$(git -C "$T30_VAULT" status --porcelain)"
 # Bump the template so an upgrade is available, changing .gitleaks.toml too.
 printf '{"metadata":{"version":"1.0.0"}}\n' > "$T30_TMPL/marketplace/.claude-plugin/marketplace.json"
 printf 'gitleaks-content-v2\n' > "$T30_TMPL/.gitleaks.toml"

--- a/scripts/test-luna-upgrade-all.sh
+++ b/scripts/test-luna-upgrade-all.sh
@@ -1422,6 +1422,38 @@ assert_eq "T-RESOLVE: template-less checkout apply exits 0" 0 "$tr_d_rc"
 assert_eq "T-RESOLVE: HIMMEL_REPO beats the \$HOME scan" A "$tr_d_marker"
 
 # ===========================================================================
+# T30 (HIMMEL-2886): sweep must NOT classify a vault clean-upgrade when it has
+# a committed local edit to a template-owned "overwrite"-class file since its
+# last stamped upgrade — matching the real incident (luna-upgrade-all apply
+# on ~/Documents/luna, 2026-09-09): git status was CLEAN (the edit was
+# committed), yet the .gitleaks.toml/.pre-commit-config.yaml local hunks were
+# silently reverted and the run reported clean-upgrade.
+T30_TMPL="$TMP/t30-tmpl"; make_template "$T30_TMPL" "0.9.0"
+printf 'gitleaks-content-v1\n' > "$T30_TMPL/.gitleaks.toml"
+T30_ROOTS="$TMP/t30-roots"; mkdir -p "$T30_ROOTS"
+T30_VAULT="$T30_ROOTS/vault"
+make_luna_vault "$T30_VAULT" "0.9.0" "$T30_TMPL"
+git -C "$T30_VAULT" init -q
+git -C "$T30_VAULT" config user.email "test@example.com"
+git -C "$T30_VAULT" config user.name "Test"
+git -C "$T30_VAULT" add -A
+git -C "$T30_VAULT" commit -q -m "initial stamp 0.9.0"
+# Committed local edit (clean git status afterwards) — the actual incident shape.
+printf 'gitleaks-content-v1\nlocal-allowlist-line\n' > "$T30_VAULT/.gitleaks.toml"
+git -C "$T30_VAULT" add -A
+git -C "$T30_VAULT" commit -q -m "add local allowlist line"
+# Bump the template so an upgrade is available, changing .gitleaks.toml too.
+printf '{"metadata":{"version":"1.0.0"}}\n' > "$T30_TMPL/marketplace/.claude-plugin/marketplace.json"
+printf 'gitleaks-content-v2\n' > "$T30_TMPL/.gitleaks.toml"
+
+t30_sweep=$(run_engine sweep --porcelain --template-dir "$T30_TMPL" --roots "$T30_ROOTS" 2>&1)
+t30_line=$(printf '%s\n' "$t30_sweep" | grep "$T30_VAULT" | head -1)
+case "$t30_line" in
+    local-config-edits*) pass "T30 sweep classifies local-config-edits, not clean-upgrade" ;;
+    *) fail "T30 sweep classifies local-config-edits, not clean-upgrade" "got: $t30_line" ;;
+esac
+
+# ===========================================================================
 echo
 if [ "$FAILED" -eq 0 ]; then
     echo "All luna-upgrade-all tests passed."

--- a/templates/luna-second-brain/.gitleaks.toml
+++ b/templates/luna-second-brain/.gitleaks.toml
@@ -23,6 +23,15 @@ paths = [
 # curl-auth-header false positive for this one literal only. Anchored (^…$)
 # so it suppresses ONLY the exact constant — a prefixed/suffixed bearer
 # credential (himmel-local-claudex-<real-secret>) is still caught.
+# queue-lock release tokens (himmel scripts/handover/queue-lock.sh) are written
+# into each leg's LIVE bullet on purpose (HIMMEL-2813 workaround: autocompact
+# loses them otherwise). Their default shape is <host>-<arch>-pid<N>, e.g.
+# `cachyos-x8664-pid199036` — a process id, not a credential — but the
+# generic-api-key rule flags the line ("release-token: `...`") on entropy, and
+# that refusal silently stalls the github-sync autosync commit (2026-09-09,
+# console 03F: staged for 40 min, three missed syncs). Anchored to that exact
+# shape only.
 regexes = [
   '''^himmel-local-claudex$''',
+  '''^[a-z0-9]+-[a-z0-9]+-pid[0-9]+$''',
 ]

--- a/templates/luna-second-brain/.pre-commit-config.yaml
+++ b/templates/luna-second-brain/.pre-commit-config.yaml
@@ -46,6 +46,12 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
+        # Console kits under handovers/**/specs/console-kit-*/ are archived
+        # ad-hoc monitor/arm scripts copied out of a session scratchpad so
+        # they survive a host reboot — not shipped code. Linting them here
+        # stalled the Obsidian github-sync sweep on 2026-09-07 (the sweep
+        # commits with hooks on; one SC2009/SC2034 warning = no commits).
+        exclude: ^handovers/.*/specs/console-kit-[^/]+/
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.2

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.9",
+  "version": "0.4.15",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/CHANGELOG.md
+++ b/templates/luna-second-brain/CHANGELOG.md
@@ -8,6 +8,15 @@ Version history for the luna-second-brain vault template (published as
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.4.16] — 2026-09-10
+
+### Fixed
+- **`scripts/upgrade.sh` no longer silently overwrites a vault-local edit to a
+  template-owned config file (HIMMEL-2886).** See the luna-upgrade-all commit
+  for the full mechanism (STAMP_COMMIT-based local-edit detection); this bump
+  ships the fix in `scripts/upgrade.sh` itself, which is template-owned and
+  self-refreshes on every vault's next upgrade.
+
 ## [0.4.15] — 2026-09-10
 
 ### Added

--- a/templates/luna-second-brain/CHANGELOG.md
+++ b/templates/luna-second-brain/CHANGELOG.md
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **`luna-upgrade-all apply` no longer silently overwrites a vault-local edit to a
   template-owned config file (HIMMEL-2886).** For an "overwrite"-class file the vault
   has committed a local edit to since its last stamped upgrade, the run now withholds
-  that one write, prints `local edits overwritten: <file> (backup: <path>)` with the
+  that one write, prints `local edits withheld (not overwritten): <file> (backup: <path>)` with the
   lost hunk's diff, and does not classify the run `clean-upgrade` (or write the version
   stamp) until the edit is reconciled by hand.
 

--- a/templates/luna-second-brain/CHANGELOG.md
+++ b/templates/luna-second-brain/CHANGELOG.md
@@ -8,6 +8,28 @@ Version history for the luna-second-brain vault template (published as
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.4.15] — 2026-09-10
+
+### Added
+- **`.gitleaks.toml` carries the queue-lock release-token allowlist (HIMMEL-2886).**
+  Every leg writes a release token shaped `<host>-<arch>-pid<N>` into its handover
+  doc's LIVE bullet by design (HIMMEL-2813); without this anchored regex, gitleaks'
+  generic-api-key rule flags the line on entropy and blocks the vault's github-sync
+  autosync commit. Previously a vault-local fix only — `/luna-upgrade` silently
+  reverted it (pure overwrite, nothing printed) because the template didn't carry it.
+- **`.pre-commit-config.yaml` carries the console-kit shellcheck exclude (HIMMEL-2886).**
+  Archived console-kit scripts under `handovers/**/specs/console-kit-*/` are scratchpad
+  copies, not shipped code; linting them stalled the same autosync sweep. Same silent-
+  revert history as above.
+
+### Fixed
+- **`luna-upgrade-all apply` no longer silently overwrites a vault-local edit to a
+  template-owned config file (HIMMEL-2886).** For an "overwrite"-class file the vault
+  has committed a local edit to since its last stamped upgrade, the run now withholds
+  that one write, prints `local edits overwritten: <file> (backup: <path>)` with the
+  lost hunk's diff, and does not classify the run `clean-upgrade` (or write the version
+  stamp) until the edit is reconciled by hand.
+
 ## [0.3.1] — 2026-07-28
 
 ### Changed

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.17"
+    "version": "0.4.18"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.18"
+    "version": "0.4.19"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.16"
+    "version": "0.4.17"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.15"
+    "version": "0.4.16"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.14"
+    "version": "0.4.15"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.19"
+    "version": "0.4.20"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/scripts/test-upgrade.sh
+++ b/templates/luna-second-brain/scripts/test-upgrade.sh
@@ -538,15 +538,15 @@ case "$t29_dry" in
     *) fail "T29 dry-run surfaces LOCAL-EDIT for .gitleaks.toml" "got: $t29_dry" ;;
 esac
 case "$t29_dry" in
-    *"local edits overwritten: .gitleaks.toml"*) pass "T29 dry-run prints local-edits-overwritten line" ;;
-    *) fail "T29 dry-run prints local-edits-overwritten line" "got: $t29_dry" ;;
+    *"local edits withheld (not overwritten): .gitleaks.toml"*) pass "T29 dry-run prints local-edits-withheld line" ;;
+    *) fail "T29 dry-run prints local-edits-withheld line" "got: $t29_dry" ;;
 esac
 
 t29_out=$(bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --backup-dir "$TMP/t29-backup" --yes 2>&1)
 t29_rc=$?
 assert_eq "T29 apply does NOT overwrite the locally-edited file" "$t29_pre_sha" "$(sha_of "$V/.gitleaks.toml")"
 case "$t29_out" in
-    *"local edits overwritten: .gitleaks.toml (backup: $TMP/t29-backup/.gitleaks.toml)"*)
+    *"local edits withheld (not overwritten): .gitleaks.toml (backup: $TMP/t29-backup/.gitleaks.toml)"*)
         pass "T29 apply names the backup path" ;;
     *) fail "T29 apply names the backup path" "got: $t29_out" ;;
 esac

--- a/templates/luna-second-brain/scripts/test-upgrade.sh
+++ b/templates/luna-second-brain/scripts/test-upgrade.sh
@@ -503,5 +503,60 @@ assert_eq "T28 first-population seeds absent manifest.json" "$(sha_of "$T/.obsid
 assert_eq "T28 first-population seeds absent main.js"       "$(sha_of "$T/.obsidian/plugins/obsidian-local-rest-api/main.js")"       "$(sha_of "$V2/.obsidian/plugins/obsidian-local-rest-api/main.js")"
 assert_eq "T28 first-population seeds absent styles.css"    "$(sha_of "$T/.obsidian/plugins/obsidian-local-rest-api/styles.css")"    "$(sha_of "$V2/.obsidian/plugins/obsidian-local-rest-api/styles.css")"
 
+# ---------------------------------------------------------------------------
+# T29 (HIMMEL-2886): a template-owned "overwrite"-class file the vault
+# COMMITTED a local edit to since its last stamped upgrade must not be
+# silently clobbered — the actual incident (luna-upgrade-all apply on
+# ~/Documents/luna, 2026-09-09) had a CLEAN git status (the edit was
+# committed), so a dirty-tree check alone can't catch it; the fixture
+# reproduces that shape (git-tracked, clean, edit committed after the stamp).
+T="$TMP/t29-tmpl"; V="$TMP/t29-vault"
+make_template "$T" "0.9.0"
+printf 'gitleaks-content-v1\n' > "$T/.gitleaks.toml"
+mkdir -p "$V"; cp -r "$T/." "$V/"; rm -f "$V/marketplace/.claude-plugin/marketplace.json"
+stamp_vault "$V" "0.9.0"
+git -C "$V" init -q
+git -C "$V" config user.email "test@example.com"
+git -C "$V" config user.name "Test"
+git -C "$V" add -A
+git -C "$V" commit -q -m "initial stamp 0.9.0"
+# The vault-local edit, COMMITTED (git status is clean afterwards) — matches
+# the real incident, not an uncommitted-dirty-tree case (already guarded
+# elsewhere).
+printf 'gitleaks-content-v1\nlocal-allowlist-line\n' > "$V/.gitleaks.toml"
+git -C "$V" add -A
+git -C "$V" commit -q -m "add local allowlist line"
+# Bump the template so an upgrade is available, and change its .gitleaks.toml
+# too (a genuine incoming template change, not just a version bump).
+printf '{"metadata":{"version":"1.0.0"}}\n' > "$T/marketplace/.claude-plugin/marketplace.json"
+printf 'gitleaks-content-v2\n' > "$T/.gitleaks.toml"
+
+t29_pre_sha=$(sha_of "$V/.gitleaks.toml")
+t29_dry=$(bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --dry-run 2>&1)
+case "$t29_dry" in
+    *"LOCAL-EDIT"*".gitleaks.toml"*) pass "T29 dry-run surfaces LOCAL-EDIT for .gitleaks.toml" ;;
+    *) fail "T29 dry-run surfaces LOCAL-EDIT for .gitleaks.toml" "got: $t29_dry" ;;
+esac
+case "$t29_dry" in
+    *"local edits overwritten: .gitleaks.toml"*) pass "T29 dry-run prints local-edits-overwritten line" ;;
+    *) fail "T29 dry-run prints local-edits-overwritten line" "got: $t29_dry" ;;
+esac
+
+t29_out=$(bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --backup-dir "$TMP/t29-backup" --yes 2>&1)
+t29_rc=$?
+assert_eq "T29 apply does NOT overwrite the locally-edited file" "$t29_pre_sha" "$(sha_of "$V/.gitleaks.toml")"
+case "$t29_out" in
+    *"local edits overwritten: .gitleaks.toml (backup: $TMP/t29-backup/.gitleaks.toml)"*)
+        pass "T29 apply names the backup path" ;;
+    *) fail "T29 apply names the backup path" "got: $t29_out" ;;
+esac
+if [ "$t29_rc" -ne 0 ]; then
+    pass "T29 apply exits non-zero (not a clean upgrade)"
+else
+    fail "T29 apply exits non-zero (not a clean upgrade)" "rc=0, out: $t29_out"
+fi
+t29_stamp=$("$PY" -c 'import json,sys; print(json.load(open(sys.argv[1])).get("version",""))' "$V/.vault-template.json" 2>/dev/null)
+assert_eq "T29 stamp NOT advanced while a local edit is withheld" "0.9.0" "$t29_stamp"
+
 echo
 if [ "$FAILED" -eq 0 ]; then echo "All upgrade tests passed."; else echo "$FAILED test(s) failed."; exit 1; fi

--- a/templates/luna-second-brain/scripts/test-upgrade.sh
+++ b/templates/luna-second-brain/scripts/test-upgrade.sh
@@ -519,13 +519,16 @@ git -C "$V" init -q
 git -C "$V" config user.email "test@example.com"
 git -C "$V" config user.name "Test"
 git -C "$V" add -A
-git -C "$V" commit -q -m "initial stamp 0.9.0"
+git -C "$V" commit -q -m "initial stamp 0.9.0"; t29_commit1_rc=$?
+assert_eq "T29 setup: initial commit landed" "0" "$t29_commit1_rc"
 # The vault-local edit, COMMITTED (git status is clean afterwards) — matches
 # the real incident, not an uncommitted-dirty-tree case (already guarded
 # elsewhere).
 printf 'gitleaks-content-v1\nlocal-allowlist-line\n' > "$V/.gitleaks.toml"
 git -C "$V" add -A
-git -C "$V" commit -q -m "add local allowlist line"
+git -C "$V" commit -q -m "add local allowlist line"; t29_commit2_rc=$?
+assert_eq "T29 setup: local-edit commit landed" "0" "$t29_commit2_rc"
+assert_eq "T29 setup: working tree is clean (matches the incident's shape, not a dirty-tree case)" "" "$(git -C "$V" status --porcelain)"
 # Bump the template so an upgrade is available, and change its .gitleaks.toml
 # too (a genuine incoming template change, not just a version bump).
 printf '{"metadata":{"version":"1.0.0"}}\n' > "$T/marketplace/.claude-plugin/marketplace.json"

--- a/templates/luna-second-brain/scripts/test-vault-git.sh
+++ b/templates/luna-second-brain/scripts/test-vault-git.sh
@@ -238,6 +238,64 @@ else
     ;;
   esac
   assert_eq "D9 near-miss token NOT in committed tree" "$d8_before" "$(git_in "$VC" rev-parse HEAD)"
+  # D8's blocked near-miss file is still sitting UNCOMMITTED in the working
+  # tree — leaving it would re-trip gitleaks on every later autosync in this
+  # phase (D10+), for a reason unrelated to what each of those tests checks.
+  rm -f "$VC/30-Resources/proxy-token-extra.md"
+
+  # D10-D11 (HIMMEL-2886): the template carries the queue-lock release-token
+  # allowlist. Every leg writes a release token shaped `<host>-<arch>-pid<N>`
+  # into its handover doc's LIVE bullet (HIMMEL-2813); without this regex
+  # gitleaks' generic-api-key rule flags it on entropy and blocks the sync
+  # commit (console 03F lost 40 min / three syncs to exactly this, 2026-09-09,
+  # before the vault carried a LOCAL fix — this proves the TEMPLATE now ships
+  # it, so the next luna-upgrade converges every vault onto it).
+  # (No backticks/`$` in this literal: this test file is itself copied into
+  # the vault fixture's scripts/ tree and shellchecked there — SC2016 would
+  # fire on a single-quoted string that LOOKS like it wants to expand.)
+  printf 'release-token: cachyos-x8664-pid199036\n' >"$VC/30-Resources/release-token.md"
+  (cd "$VC" && LUNA_VAULT_AUTOSYNC=1 bash "$VC/scripts/vault-autosync.sh") >/dev/null 2>&1
+  assert_ok "D10 release-token allowlist: autosync commits (exit 0)" "$?"
+  assert_eq "D11 release-token note IS in committed tree" "1" \
+    "$(git_in "$VC" ls-tree -r HEAD --name-only | grep -c 'release-token\.md' || true)"
+
+  # D12-D13 (HIMMEL-2886): the template carries the console-kit shellcheck
+  # exclude. Archived console-kit scripts under handovers/**/specs/console-kit-*/
+  # are scratchpad copies, not shipped code; linting them stalled the vault's
+  # github-sync sweep (console 03F, 2026-09-07: one SC2086 warning = no commits).
+  mkdir -p "$VC/handovers/x/himmel/specs/console-kit-02I"
+  # Heredoc with a quoted delimiter (not printf/single-quoted) so this file's
+  # OWN shellcheck pass (it's copied into the fixture's scripts/ tree too)
+  # doesn't flag the intentionally-unquoted $HOME in the fixture's body.
+  cat <<'CONSOLE_KIT_FIXTURE' >"$VC/handovers/x/himmel/specs/console-kit-02I/foo.sh"
+#!/usr/bin/env bash
+echo $HOME
+CONSOLE_KIT_FIXTURE
+  (cd "$VC" && LUNA_VAULT_AUTOSYNC=1 bash "$VC/scripts/vault-autosync.sh") >/dev/null 2>&1
+  assert_ok "D12 console-kit shellcheck exclude: autosync commits (exit 0)" "$?"
+  assert_eq "D13 console-kit script IS in committed tree" "1" \
+    "$(git_in "$VC" ls-tree -r HEAD --name-only | grep -c 'console-kit-02I/foo\.sh' || true)"
+
+  # D14: negative control — the SAME shellcheck violation OUTSIDE the excluded
+  # path is still blocked (the exclude is scoped, not a blanket shellcheck
+  # disable).
+  d14_before=$(git_in "$VC" rev-parse HEAD)
+  cat <<'UNEXCLUDED_FIXTURE' >"$VC/check-something.sh"
+#!/usr/bin/env bash
+echo $HOME
+UNEXCLUDED_FIXTURE
+  d14_out=$( (cd "$VC" && LUNA_VAULT_AUTOSYNC=1 bash "$VC/scripts/vault-autosync.sh") 2>&1 ); d14_rc=$?
+  assert_nz "D14 same violation outside console-kit path still blocked" "$d14_rc"
+  case "$d14_out" in
+  *shellcheck*"command not found"* | *shellcheck*"executable file not found"*)
+    fail "D14b block attributable to shellcheck" "shellcheck unavailable — the lint never ran"
+    ;;
+  *)
+    assert_eq "D14b block attributable to shellcheck" "yes" \
+      "$(yn "$(printf '%s' "$d14_out" | grep -qE 'SC[0-9]{4}' && echo 0 || echo 1)")"
+    ;;
+  esac
+  assert_eq "D15 unexcluded script NOT committed" "$d14_before" "$(git_in "$VC" rev-parse HEAD)"
 
   # =========================================================================
   # Phase E — clone-with-remote (no marker, PAST unborn HEAD): autosync must

--- a/templates/luna-second-brain/scripts/test-vault-git.sh
+++ b/templates/luna-second-brain/scripts/test-vault-git.sh
@@ -292,7 +292,7 @@ UNEXCLUDED_FIXTURE
     ;;
   *)
     assert_eq "D14b block attributable to shellcheck" "yes" \
-      "$(yn "$(printf '%s' "$d14_out" | grep -qE 'SC[0-9]{4}' && echo 0 || echo 1)")"
+      "$(yn "$(grep -qE 'SC[0-9]{4}' <<< "$d14_out" && echo 0 || echo 1)")"
     ;;
   esac
   assert_eq "D15 unexcluded script NOT committed" "$d14_before" "$(git_in "$VC" rev-parse HEAD)"

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -246,16 +246,20 @@ fi
 # upgraded via a git-tracked flow), has no baseline to compare against, so
 # falls back to the pre-existing overwrite behavior.
 STAMP_COMMIT=""
-if [ -d "$VAULT_DIR/.git" ]; then
+# `git rev-parse --is-inside-work-tree`, not `[ -d "$VAULT_DIR/.git" ]`: a
+# worktree or a submodule has a `.git` FILE (a `gitdir: <path>` pointer), not
+# a directory, so the directory-only check silently fell back to the
+# pre-existing overwrite behavior for exactly those vaults.
+if git -C "$VAULT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     STAMP_COMMIT="$(git -C "$VAULT_DIR" log -1 --format=%H -- .vault-template.json 2>/dev/null)"
 fi
 
 # has_local_edit <rel> <dst> [print]: exit 0 iff <dst> differs from what was
 # committed at STAMP_COMMIT for <rel>. No stamp commit, or the file didn't
 # exist there (new template-owned file), means no baseline => not a local
-# edit. With [print]=1, also emits the "local edits overwritten" line + a
-# unified diff of the lost hunk — called once per file (the planning pass
-# only; the execute pass re-detects the same files but must not re-print).
+# edit. With [print]=1, also emits the "local edits withheld" line + a
+# unified diff of the withheld hunk — called once per file (the planning
+# pass only; the execute pass re-detects the same files but must not re-print).
 has_local_edit() {
     local rel="$1" dst="$2" print="${3:-0}"
     [ -n "$STAMP_COMMIT" ] || return 1
@@ -269,9 +273,9 @@ has_local_edit() {
     dst_sha="$(sha_of "$dst")"
     if [ "$committed_sha" != "$dst_sha" ]; then
         if [ "$print" = 1 ]; then
-            local backup_note="n/a — dry-run"
+            local backup_note="none (no --backup-dir given for this run)"
             [ -n "$BACKUP_DIR" ] && backup_note="$BACKUP_DIR/$rel"
-            echo "  local edits overwritten: $rel (backup: $backup_note)"
+            echo "  local edits withheld (not overwritten): $rel (backup: $backup_note)"
             if command -v diff >/dev/null 2>&1; then
                 diff -u "$committed" "$dst" | sed 's/^/    /'
             fi

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -24,6 +24,9 @@
 #                       (no banner, no plan, no changes), then exit 0.
 #   --dry-run           print the plan, make zero filesystem changes.
 #   --yes               skip the confirm prompt (used by the /luna-upgrade skill).
+#   --backup-dir DIR    (optional) the pre-computed backup dest for this run,
+#                       named in the local-edit-withheld message so an operator
+#                       can recover the pre-upgrade file (HIMMEL-2886).
 #
 # Version source = the template's marketplace/.claude-plugin/marketplace.json
 # metadata.version. The vault records its level in .vault-template.json; a
@@ -41,12 +44,14 @@ VAULT_DIR=""
 DRY_RUN=0
 ASSUME_YES=0
 CHECK_ONLY=0
+BACKUP_DIR=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --template-dir) TEMPLATE_DIR="${2:-}"; shift 2 ;;
         --vault-dir)    VAULT_DIR="${2:-}"; shift 2 ;;
+        --backup-dir)   BACKUP_DIR="${2:-}"; shift 2 ;;
         --dry-run)      DRY_RUN=1; shift ;;
         --check)        CHECK_ONLY=1; shift ;;
         --yes|-y)       ASSUME_YES=1; shift ;;
@@ -64,6 +69,8 @@ upgrade.sh — content-preserving vault/template upgrade (HIMMEL-389)
                       (no banner, no plan, no changes), then exit 0.
   --dry-run           print the plan, make zero filesystem changes.
   --yes, -y           skip the confirm prompt.
+  --backup-dir DIR    (optional) pre-computed backup dest, named in the
+                      local-edit-withheld message.
 
 Refreshes template-owned files (scripts, .obsidian config, plugin assets, docs)
 WITHOUT touching user content (journal, notes, clips). Version source = the
@@ -228,6 +235,55 @@ if [ "$VAULT_VERSION" = "$TEMPLATE_VERSION" ] || ! ver_lt "$VAULT_VERSION" "$TEM
 fi
 
 # ---------------------------------------------------------------------------
+# Local-edit detection (HIMMEL-2886): an "overwrite"-class file the vault
+# itself has diverged on since its last stamped upgrade must not be silently
+# clobbered — the template's own committed history has no view of vault-local
+# edits, but the VAULT's git history does. STAMP_COMMIT is the last commit
+# that wrote .vault-template.json (i.e. the vault's last upgrade); comparing
+# a file's content there against its content NOW tells us whether the vault
+# edited it locally after that upgrade (vs. the file only ever having been
+# template-driven). A vault with no git repo, or no such commit (never
+# upgraded via a git-tracked flow), has no baseline to compare against, so
+# falls back to the pre-existing overwrite behavior.
+STAMP_COMMIT=""
+if [ -d "$VAULT_DIR/.git" ]; then
+    STAMP_COMMIT="$(git -C "$VAULT_DIR" log -1 --format=%H -- .vault-template.json 2>/dev/null)"
+fi
+
+# has_local_edit <rel> <dst> [print]: exit 0 iff <dst> differs from what was
+# committed at STAMP_COMMIT for <rel>. No stamp commit, or the file didn't
+# exist there (new template-owned file), means no baseline => not a local
+# edit. With [print]=1, also emits the "local edits overwritten" line + a
+# unified diff of the lost hunk — called once per file (the planning pass
+# only; the execute pass re-detects the same files but must not re-print).
+has_local_edit() {
+    local rel="$1" dst="$2" print="${3:-0}"
+    [ -n "$STAMP_COMMIT" ] || return 1
+    [ -f "$dst" ] || return 1
+    local committed; committed="$(mktemp)"
+    if ! git -C "$VAULT_DIR" show "$STAMP_COMMIT:$rel" > "$committed" 2>/dev/null; then
+        rm -f "$committed"; return 1
+    fi
+    local committed_sha dst_sha
+    committed_sha="$(sha_of "$committed")"
+    dst_sha="$(sha_of "$dst")"
+    if [ "$committed_sha" != "$dst_sha" ]; then
+        if [ "$print" = 1 ]; then
+            local backup_note="n/a — dry-run"
+            [ -n "$BACKUP_DIR" ] && backup_note="$BACKUP_DIR/$rel"
+            echo "  local edits overwritten: $rel (backup: $backup_note)"
+            if command -v diff >/dev/null 2>&1; then
+                diff -u "$committed" "$dst" | sed 's/^/    /'
+            fi
+        fi
+        rm -f "$committed"
+        return 0
+    fi
+    rm -f "$committed"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
 # Per-file classification. Returns one of:
 #   overwrite | jsonmerge | skipexists | threeway | report | skip
 # Extensible per-profile (HIMMEL-389 scope §8): a future wiki profile keys off
@@ -275,7 +331,7 @@ PLUGINS_SETUP_PRIOR_SHA="$(sha_of "$VAULT_DIR/$PLUGINS_SETUP_REL")"
 # ---------------------------------------------------------------------------
 # Build + print plan, then execute (unless --dry-run). One pass over the
 # template-owned files; user content is never enumerated so it can't be touched.
-n_write=0 n_skip_identical=0 n_skip_exists=0 n_jsonmerge=0 n_report=0 n_threeway=0
+n_write=0 n_skip_identical=0 n_skip_exists=0 n_jsonmerge=0 n_report=0 n_threeway=0 n_local_edit=0
 WRITE_FAILURES=0
 declare -a PLAN
 
@@ -412,8 +468,13 @@ process() {
             skip) ;;
             overwrite)
                 if [ "$(sha_of "$src")" != "$(sha_of "$dst")" ]; then
-                    PLAN+=("WRITE        $rel"); n_write=$((n_write+1))
-                    [ "$execute" = 1 ] && { write_file "$src" "$dst" || WRITE_FAILURES=$((WRITE_FAILURES+1)); }
+                    if has_local_edit "$rel" "$dst" "$((1 - execute))"; then
+                        PLAN+=("LOCAL-EDIT   $rel (vault has local edits since last upgrade — NOT overwritten)")
+                        n_local_edit=$((n_local_edit+1))
+                    else
+                        PLAN+=("WRITE        $rel"); n_write=$((n_write+1))
+                        [ "$execute" = 1 ] && { write_file "$src" "$dst" || WRITE_FAILURES=$((WRITE_FAILURES+1)); }
+                    fi
                 else
                     n_skip_identical=$((n_skip_identical+1))
                 fi ;;
@@ -461,7 +522,7 @@ process 0
 if [ "${#PLAN[@]}" -eq 0 ]; then
     echo "No template-owned files differ — vault content is current. Writing version stamp."
 else
-    echo "Plan ($((n_write)) write, $n_jsonmerge json-merge, $n_threeway _CLAUDE.md, $n_report report, $n_skip_identical identical, $n_skip_exists user-kept):"
+    echo "Plan ($((n_write)) write, $n_jsonmerge json-merge, $n_threeway _CLAUDE.md, $n_report report, $n_skip_identical identical, $n_skip_exists user-kept, $n_local_edit local-edit-withheld):"
     printf '  %s\n' "${PLAN[@]}"
 fi
 echo ""
@@ -480,7 +541,7 @@ fi
 
 # --- Execute pass ---
 PLAN=()
-n_write=0 n_skip_identical=0 n_skip_exists=0 n_jsonmerge=0 n_report=0 n_threeway=0
+n_write=0 n_skip_identical=0 n_skip_exists=0 n_jsonmerge=0 n_report=0 n_threeway=0 n_local_edit=0
 WRITE_FAILURES=0
 CLAUDE_MERGE_RESULT=""
 process 1
@@ -524,11 +585,12 @@ fi
 # target version — leave the stamp behind so a re-run re-processes (and
 # re-alerts) instead of a "current" stamp silently masking the gap. The stamp
 # is the last write, so an aborted run also re-runs cleanly (idempotent).
-if [ "$WRITE_FAILURES" -gt 0 ] || [ "$CLAUDE_MERGE_RESULT" = "conflict" ] || [ "$CLAUDE_MERGE_RESULT" = "error" ]; then
+if [ "$WRITE_FAILURES" -gt 0 ] || [ "$n_local_edit" -gt 0 ] || [ "$CLAUDE_MERGE_RESULT" = "conflict" ] || [ "$CLAUDE_MERGE_RESULT" = "error" ]; then
     echo "" >&2
     echo "upgrade: NOT writing the version stamp — the vault is partially upgraded" >&2
-    echo "  (write failures: $WRITE_FAILURES; _CLAUDE.md: ${CLAUDE_MERGE_RESULT:-ok}). Resolve the" >&2
-    echo "  issues above and re-run; template-owned writes are idempotent." >&2
+    echo "  (write failures: $WRITE_FAILURES; local edits withheld: $n_local_edit;" >&2
+    echo "  _CLAUDE.md: ${CLAUDE_MERGE_RESULT:-ok}). Resolve the issues above and re-run;" >&2
+    echo "  template-owned writes are idempotent." >&2
     exit 1
 fi
 

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -245,6 +245,16 @@ fi
 # template-driven). A vault with no git repo, or no such commit (never
 # upgraded via a git-tracked flow), has no baseline to compare against, so
 # falls back to the pre-existing overwrite behavior.
+#
+# Known limitation (not fixed here — flagged by CR, out of scope for a
+# minimal refuse-or-print fix): if a local edit to a template-owned file is
+# committed in the SAME commit that also advances the stamp (e.g. a batching
+# autosync), that commit becomes STAMP_COMMIT itself, so the baseline it
+# reads back already contains the edit. A later run then sees no divergence
+# from that (already-edited) baseline and would silently accept the
+# template's write. Detecting this needs a baseline independent of the
+# vault's own commit history (e.g. a per-file content snapshot alongside
+# .vault-template.json), which is a larger change than this ticket scopes.
 STAMP_COMMIT=""
 # `git rev-parse --is-inside-work-tree`, not `[ -d "$VAULT_DIR/.git" ]`: a
 # worktree or a submodule has a `.git` FILE (a `gitdir: <path>` pointer), not
@@ -264,9 +274,33 @@ has_local_edit() {
     local rel="$1" dst="$2" print="${3:-0}"
     [ -n "$STAMP_COMMIT" ] || return 1
     [ -f "$dst" ] || return 1
+    # `./$rel`, not a bare `$rel`: `git show <rev>:<path>` resolves a path
+    # relative to the CURRENT DIRECTORY only when it starts with `./` —
+    # a bare path is repo-root-relative, which is the WRONG root whenever
+    # VAULT_DIR is a subdirectory of a larger enclosing repo (verified: a
+    # bare path there errors "path exists, but not <rel>" and git's own
+    # hint names the `./` form).
+    #
+    # Existence check FIRST, and distinct from retrieval below: a file
+    # genuinely absent at STAMP_COMMIT (a new template-owned file) must
+    # return 1 same as always, but an OPERATIONAL failure retrieving a file
+    # that does exist there (a broken git object, or mktemp below failing to
+    # give us anywhere to write) must NOT be read the same way — silently
+    # falling through to "no local edit" on an error is the exact silent-
+    # overwrite failure mode this function exists to close, just via a
+    # different path. Fail CLOSED (withhold) on an operational error instead.
+    if ! git -C "$VAULT_DIR" cat-file -e "$STAMP_COMMIT:./$rel" 2>/dev/null; then
+        return 1
+    fi
     local committed; committed="$(mktemp)"
-    if ! git -C "$VAULT_DIR" show "$STAMP_COMMIT:$rel" > "$committed" 2>/dev/null; then
-        rm -f "$committed"; return 1
+    if [ -z "$committed" ] || [ ! -e "$committed" ]; then
+        [ "$print" = 1 ] && echo "  could not verify local edits for $rel (mktemp failed) — withholding the write as a precaution"
+        return 0
+    fi
+    if ! git -C "$VAULT_DIR" show "$STAMP_COMMIT:./$rel" > "$committed" 2>/dev/null; then
+        rm -f "$committed"
+        [ "$print" = 1 ] && echo "  could not verify local edits for $rel (git show failed) — withholding the write as a precaution"
+        return 0
     fi
     local committed_sha dst_sha
     committed_sha="$(sha_of "$committed")"

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -246,15 +246,16 @@ fi
 # upgraded via a git-tracked flow), has no baseline to compare against, so
 # falls back to the pre-existing overwrite behavior.
 #
-# Known limitation (not fixed here — flagged by CR, out of scope for a
-# minimal refuse-or-print fix): if a local edit to a template-owned file is
-# committed in the SAME commit that also advances the stamp (e.g. a batching
-# autosync), that commit becomes STAMP_COMMIT itself, so the baseline it
-# reads back already contains the edit. A later run then sees no divergence
-# from that (already-edited) baseline and would silently accept the
-# template's write. Detecting this needs a baseline independent of the
-# vault's own commit history (e.g. a per-file content snapshot alongside
-# .vault-template.json), which is a larger change than this ticket scopes.
+# Known limitation, tracked as HIMMEL-2903 (not fixed here — flagged by CR,
+# out of scope for a minimal refuse-or-print fix): if a local edit to a
+# template-owned file is committed in the SAME commit that also advances the
+# stamp (e.g. a batching autosync), that commit becomes STAMP_COMMIT itself,
+# so the baseline it reads back already contains the edit. A later run then
+# sees no divergence from that (already-edited) baseline and would silently
+# accept the template's write. Detecting this needs a baseline independent
+# of the vault's own commit history (e.g. a per-file content snapshot
+# alongside .vault-template.json), which is a larger change than this
+# ticket scopes.
 STAMP_COMMIT=""
 # `git rev-parse --is-inside-work-tree`, not `[ -d "$VAULT_DIR/.git" ]`: a
 # worktree or a submodule has a `.git` FILE (a `gitdir: <path>` pointer), not
@@ -289,8 +290,23 @@ has_local_edit() {
     # falling through to "no local edit" on an error is the exact silent-
     # overwrite failure mode this function exists to close, just via a
     # different path. Fail CLOSED (withhold) on an operational error instead.
-    if ! git -C "$VAULT_DIR" cat-file -e "$STAMP_COMMIT:./$rel" 2>/dev/null; then
-        return 1
+    local cat_err
+    if ! cat_err="$(git -C "$VAULT_DIR" cat-file -e "$STAMP_COMMIT:./$rel" 2>&1)"; then
+        case "$cat_err" in
+            *"does not exist"*)
+                # Legitimately absent at the stamp commit (a new
+                # template-owned file) — not a local edit.
+                return 1
+                ;;
+            *)
+                # Any OTHER cat-file failure (corrupt object, invalid
+                # STAMP_COMMIT, etc.) is an operational error, not a proven
+                # absence — fail CLOSED rather than silently allowing the
+                # write through on a failure we cannot interpret.
+                [ "$print" = 1 ] && echo "  could not verify local edits for $rel (git cat-file failed) — withholding the write as a precaution"
+                return 0
+                ;;
+        esac
     fi
     local committed; committed="$(mktemp)"
     if [ -z "$committed" ] || [ ! -e "$committed" ]; then


### PR DESCRIPTION
## Summary

Two fixes for HIMMEL-2886 (found by console 03G dogfooding `himmelctl install`, 2026-09-09: `luna-upgrade-all.sh apply` 0.4.13→0.4.14, classified `clean-upgrade`, silently overwrote two vault-local edits to template-owned config — a pure -21 line deletion, nothing printed).

**Fix A — the template carries the allowlists**
- `templates/luna-second-brain/.gitleaks.toml`: the anchored regex for queue-lock release tokens (`^[a-z0-9]+-[a-z0-9]+-pid[0-9]+$`), written into every leg's handover LIVE bullet by design (HIMMEL-2813).
- `templates/luna-second-brain/.pre-commit-config.yaml`: the shellcheck exclude for archived console-kit scripts under `handovers/**/specs/console-kit-*/`.
- Both files now diff empty against `~/Documents/luna`'s live copies (verified below).

**Fix B — `luna-upgrade` surfaces local edits instead of silently overwriting them**
- `upgrade.sh` resolves the last commit that wrote `.vault-template.json` (the vault's last upgrade stamp) and, for an "overwrite"-class file that differs from the template, compares the vault's *current* file against what was committed there at that stamp. A divergence means the vault edited it locally since the last upgrade — matches the real incident, which had a **clean** git status (the edit was committed, not dirty), so the existing dirty-tree precondition never caught it.
- The write is withheld (refuse, not merge — out of scope per the ticket), `local edits withheld (not overwritten): <file> (backup: <path>)` prints with a unified diff of the withheld hunk, and the version stamp is not written (re-run keeps re-surfacing it).
- `luna-upgrade-all.sh`: `cmd_apply` passes the backup dest as `--backup-dir` so the message names a real recovery path; `cmd_sweep` gains a `local-config-edits` porcelain state (between `conflict` and `clean-upgrade`) so a fleet sweep doesn't falsely report the vault clean.
- A vault with no git repo, or no upgrade-stamp commit, keeps the pre-existing overwrite behavior (test-upgrade.sh T2 unchanged). Detection also works for worktree/submodule vaults (`.git` as a file, not a directory) and vaults nested inside a larger enclosing repo (git-show path resolution fix).

## CR review (3 rounds + round-4 cap, all via the critic panel)

- **Round 1:** fixed a worktree/submodule detection gap and inaccurate diagnostic wording.
- **Round 2:** fixed a repo-root-relative `git show` path bug (verified empirically) and made baseline-retrieval failures fail closed instead of silently permitting an overwrite.
- **Round 3:** extended the fail-closed handling to the `git cat-file` existence check itself (same class of gap, one layer earlier).
- **Round 4 (cap):** one remaining Suggestion (harden the `git log` stamp-lookup exit-status check the same way) deferred to **HIMMEL-2903**, which also tracks a known, out-of-scope limitation flagged in rounds 2-3: a local edit committed in the *same* commit as the stamp becomes part of the baseline itself. Fixing that needs a baseline independent of the vault's own commit history — a larger design change than this ticket's minimal refuse-or-print fix.
- Known-findings self-review (pre-panel) surfaced 3 pre-existing/non-issues, disproven: `octal-leading-zero` (decimal `[ ]` comparisons, not arithmetic context), `mktemp-no-template` (matches this file's own pervasive pre-existing convention, 12+ call sites), `ps1-twin-parity` (all touched `.ps1` twins are thin Git-Bash argument-forwarders with no logic of their own — verified by reading each).

## RED/GREEN evidence

- `templates/luna-second-brain/scripts/test-vault-git.sh` D10-D15 (Fix A): a scaffolded vault fixture run through the *real* gitleaks/pre-commit/shellcheck binaries — a release-token line and a console-kit script both commit clean; the same script *outside* the excluded path is still blocked (negative control). Verified red against the pre-fix config, green against the fix.
- `templates/luna-second-brain/scripts/test-upgrade.sh` T29 (Fix B): a git-tracked vault fixture commits a local edit to `.gitleaks.toml` after its stamp, then the template bumps — verified red (silent overwrite, exit 0) against the pre-fix `process()`, green (withheld, printed, non-zero exit, stamp not advanced) against the fix.
- `scripts/test-luna-upgrade-all.sh` T30 (Fix B): the same fixture through `sweep --porcelain` — asserts `local-config-edits`, not `clean-upgrade`.
- `--check`/dry-run against the **real** `~/Documents/luna` vault (read-only, never `apply`), re-verified after every CR round: `0 local-edit-withheld`; `.gitleaks.toml`/`.pre-commit-config.yaml` diff empty against the template; `sweep --porcelain` reports `clean-upgrade` — confirms no false positives on the actual vault.
- Fixed a pre-existing red (`T26`, marketplace.json/`.vault-template.json` seed version drift, unrelated to this ticket) as a byproduct of the version bumps this change already required.

Full impacted-suite run (quiet-run, all green), re-run after every commit: `test-upgrade.sh`, `test-vault-git.sh`, `test-luna-upgrade-all.sh`, `test-salus-upgrade.sh`, `test-upgrade-pyresolve.sh`. shellcheck clean on every touched file.

`templates/luna-second-brain/` propagates to the public `luna-brain` repo as a separate post-merge step.

## Test plan

- [x] RED/GREEN verified for both fixes against real tool binaries (gitleaks, pre-commit, shellcheck) — not vacuous
- [x] All impacted suites pass (listed above), re-verified after each CR round
- [x] `--check`/dry-run against the real live vault confirms zero false positives and byte-identical config
- [x] shellcheck clean on every touched shell file
- [x] Critic panel clean (3 rounds + round-4 cap, remaining Suggestion deferred to HIMMEL-2903)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C575ndwEf8u3fasvoszVEk