### PR TITLE
fix(cr): [HIMMEL-2901] adjudication round, severity amend through inheritance, case-preserving fingerprints

### DIFF
--- a/scripts/cr/finding-fingerprint.js
+++ b/scripts/cr/finding-fingerprint.js
@@ -15,7 +15,10 @@ function foldWhitespace(value) {
 // An ALL-CAPS word outside backticks is indistinguishable from prose emphasis
 // ("CACHE cleanup"), so it still folds; put a constant in backticks to keep it.
 function isCodeToken(token) {
-  const core = token.replace(/^[^A-Za-z0-9_$.]+/, '').replace(/[^A-Za-z0-9_$.]+$/, '');
+  // Trim surrounding prose punctuation, the dot included: a sentence-ending
+  // `config.LOGLEVEL.` is still a dotted identifier, and leaving the period on
+  // stopped the dotted rule matching it at all (codex-1, HIMMEL-2901 round 1).
+  const core = token.replace(/^[^A-Za-z0-9_$]+/, '').replace(/[^A-Za-z0-9_$]+$/, '');
   if (!core) return false;
   return /[a-z][A-Z]/.test(core) ||
     core.includes('_') ||

--- a/scripts/cr/finding-fingerprint.js
+++ b/scripts/cr/finding-fingerprint.js
@@ -9,6 +9,32 @@ function foldWhitespace(value) {
     .trim();
 }
 
+// HIMMEL-2901: case inside code is identity, case in prose is noise. A token
+// keeps its case when it is identifier-shaped — camelCase, snake_case, or a
+// dotted name — and everything inside a backtick span keeps its case verbatim.
+// An ALL-CAPS word outside backticks is indistinguishable from prose emphasis
+// ("CACHE cleanup"), so it still folds; put a constant in backticks to keep it.
+function isCodeToken(token) {
+  const core = token.replace(/^[^A-Za-z0-9_$.]+/, '').replace(/[^A-Za-z0-9_$.]+$/, '');
+  if (!core) return false;
+  return /[a-z][A-Z]/.test(core) ||
+    core.includes('_') ||
+    /^[A-Za-z0-9_$]+(?:\.[A-Za-z0-9_$]+)+$/.test(core);
+}
+
+function foldClaimCase(value) {
+  return String(value)
+    .split(/(`[^`]*`)/)
+    .map((part, index) => (index % 2 === 1
+      ? part
+      : part.split(/(\s+)/).map((token) => (isCodeToken(token) ? token : token.toLowerCase())).join('')))
+    .join('');
+}
+
+function foldClaim(value) {
+  return foldClaimCase(String(value == null ? '' : value).replace(/\s+/g, ' ').trim());
+}
+
 function normalizeFileAnchor(file) {
   return String(file == null ? '' : file)
     .replace(/\s+/g, ' ')
@@ -35,7 +61,7 @@ function normalizeClaim(text) {
   // Finding citations are trailing [file:line] tokens. Remove only their line
   // coordinates; every number in the prose claim remains fingerprint-significant.
   claim = claim.replace(/\s*\[[^\]\r\n]+:\d+(?:-\d+)?\]\s*$/, '');
-  return foldWhitespace(claim);
+  return foldClaim(claim);
 }
 
 function findingFingerprint(slug, file, text) {
@@ -46,7 +72,11 @@ function findingFingerprint(slug, file, text) {
   const digest = crypto.createHash('sha256')
     .update(`${normalizedSlug}${normalizedAnchor}${normalizedClaim}`, 'utf8')
     .digest('hex');
-  return `fp1:${digest}`;
+  // fp2 (HIMMEL-2901): the claim fold changed, so a pre-2901 fp1 row must
+  // never match a claim hashed under the new rules. The ledger is append-only:
+  // old rows keep their fp1 identity and simply stop inheriting across the
+  // version boundary.
+  return `fp2:${digest}`;
 }
 
 module.exports = {

--- a/scripts/cr/finding-reraise.js
+++ b/scripts/cr/finding-reraise.js
@@ -63,15 +63,21 @@ for (const row of ledgerRows) {
       const key = dispositionKey(state);
       const previous = latest.get(key);
       const event = { ...state, _sourceKey: sourceKey };
+      // A row that carries the PREVIOUS event's disposition round did not
+      // adjudicate anything: it inherited that disposition as a re-raise.
+      const previousRound = previous && (previous.disposition_round || previous.round);
+      const inherited = Boolean(previous && validRound(state.disposition_round) &&
+        String(previousRound) === String(state.disposition_round));
       if (!event.disposition_severity) {
-        const previousRound = previous && (previous.disposition_round || previous.round);
-        if (previous && validRound(state.disposition_round) &&
-            String(previousRound) === String(state.disposition_round)) {
-          event.disposition_severity = previous.disposition_severity || previous.severity;
-        } else {
-          event.disposition_severity = state.severity;
-        }
+        event.disposition_severity = inherited
+          ? (previous.disposition_severity || previous.severity)
+          : state.severity;
       }
+      // HIMMEL-2901: remember WHICH adjudication this inherited from, so a
+      // later correction to that original row still reaches the ceiling it
+      // handed down. `previous._originKey` collapses a chain of re-raises onto
+      // the one row that was actually adjudicated.
+      if (inherited) event._originKey = previous._originKey || previous._sourceKey;
       latest.set(key, event);
     }
     continue;
@@ -124,11 +130,19 @@ for (const row of ledgerRows) {
        Object.prototype.hasOwnProperty.call(row.set, 'severity'))) {
     const key = dispositionKey(target);
     const current = latest.get(key);
-    if (current && current._sourceKey === targetKey) {
+    // HIMMEL-2901: the amended row is authoritative either because it IS the
+    // current event, or because the current event merely inherited its
+    // disposition from it. Any other row of the same fingerprint is a
+    // bystander and must not move the ceiling.
+    const isCurrent = Boolean(current && current._sourceKey === targetKey);
+    const isOrigin = Boolean(current && !isCurrent && current._originKey === targetKey);
+    if (isCurrent || isOrigin) {
       if (Object.prototype.hasOwnProperty.call(row.set, 'reason')) current.reason = target.reason;
       if (Object.prototype.hasOwnProperty.call(row.set, 'deferred_to')) current.deferred_to = target.deferred_to;
       if (Object.prototype.hasOwnProperty.call(row.set, 'severity')) {
-        current.severity = target.severity;
+        // The inherited row's own observed severity stays its own; only the
+        // DISPOSITION ceiling it carries forward is corrected.
+        if (isCurrent) current.severity = target.severity;
         current.disposition_severity = target.severity;
       }
     }

--- a/scripts/cr/finding-reraise.js
+++ b/scripts/cr/finding-reraise.js
@@ -44,11 +44,21 @@ try {
 
 const states = new Map();
 const latest = new Map();
+// HIMMEL-2901: "first seen" is the earliest round this fingerprint was ever
+// OBSERVED on this branch, derived rather than persisted. An inherited re-raise
+// carries its own observation round, so reading `round` off the latest event
+// would report a later re-raise as the first sighting.
+const firstSeen = new Map();
 for (const row of ledgerRows) {
   if (row.kind === 'finding') {
     const state = { ...row };
     const sourceKey = findingKey(row.head, row.finding_id, row.artifact, row.perspective);
     states.set(sourceKey, state);
+    if (state.fingerprint && validRound(state.round)) {
+      const seenKey = dispositionKey(state);
+      const seen = firstSeen.get(seenKey);
+      if (seen === undefined || Number(state.round) < seen) firstSeen.set(seenKey, Number(state.round));
+    }
     if (state.fingerprint && state.verdict) {
       const key = dispositionKey(state);
       const previous = latest.get(key);
@@ -97,7 +107,10 @@ for (const row of ledgerRows) {
 
   if (Object.prototype.hasOwnProperty.call(row.set, 'verdict') && target.fingerprint && target.verdict) {
     const event = { ...target, disposition_severity: target.severity, _sourceKey: targetKey };
-    if (validRound(target.round)) event.disposition_round = Number(target.round);
+    // HIMMEL-2901: the amend states the round it adjudicated in. The producer
+    // round remains the fallback so pre-2901 amends keep rendering as before.
+    if (validRound(row.disposition_round)) event.disposition_round = Number(row.disposition_round);
+    else if (validRound(target.round)) event.disposition_round = Number(target.round);
     latest.set(dispositionKey(event), event);
     continue;
   }
@@ -133,10 +146,12 @@ for (const line of input) {
   if (!id) continue;
 
   const fingerprint = findingFingerprint(model, file, text);
-  const prior = fingerprint
-    ? latest.get([e.REVIEW_BRANCH, fingerprint, artifact, perspective].join(keySep))
-    : null;
+  const priorKey = fingerprint
+    ? [e.REVIEW_BRANCH, fingerprint, artifact, perspective].join(keySep)
+    : '';
+  const prior = priorKey ? latest.get(priorKey) : null;
   const sourceRound = prior && (prior.disposition_round || prior.round);
+  const firstSeenRound = priorKey ? firstSeen.get(priorKey) : undefined;
   const dispositionSeverity = prior && (prior.disposition_severity || prior.severity);
   const currentSeverityRank = severityRank(severity);
   const dispositionSeverityRank = severityRank(dispositionSeverity);
@@ -166,7 +181,12 @@ for (const line of input) {
     if (prior.reason) row.reason = prior.reason;
     if (prior.deferred_to) row.deferred_to = prior.deferred_to;
     const ticket = prior.verdict === 'deferred' && prior.deferred_to ? ` [${prior.deferred_to}]` : '';
-    reraises.push(`${text} — RE-RAISE (r${sourceRound} ${prior.verdict})${ticket}`);
+    // HIMMEL-2901: name both rounds only when the finding was adjudicated in a
+    // later round than it was first seen in; otherwise one round is the truth.
+    const rounds = validRound(firstSeenRound) && String(firstSeenRound) !== String(sourceRound)
+      ? `first seen r${firstSeenRound} · dispositioned r${sourceRound}`
+      : `r${sourceRound}`;
+    reraises.push(`${text} — RE-RAISE (${rounds} ${prior.verdict})${ticket}`);
   } else if (active[severity]) {
     active[severity].push(text);
   }

--- a/scripts/cr/ledger-append.sh
+++ b/scripts/cr/ledger-append.sh
@@ -329,7 +329,7 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TE
   // HIMMEL-2901: case inside code is identity, case in prose is noise - keep
   // backtick spans and identifier-shaped tokens (camelCase, snake_case, dotted)
   // case-intact, fold everything else. Parity with finding-fingerprint.js.
-  const isCodeToken=(t)=>{const c=t.replace(/^[^A-Za-z0-9_$.]+/,"").replace(/[^A-Za-z0-9_$.]+$/,"");
+  const isCodeToken=(t)=>{const c=t.replace(/^[^A-Za-z0-9_$]+/,"").replace(/[^A-Za-z0-9_$]+$/,"");
     return c?(/[a-z][A-Z]/.test(c)||c.includes("_")||/^[A-Za-z0-9_$]+(?:\.[A-Za-z0-9_$]+)+$/.test(c)):false;};
   const foldClaimCase=(v)=>String(v).split(/(`[^`]*`)/).map((p,i)=>i%2===1?p:p.split(/(\s+)/).map(t=>isCodeToken(t)?t:t.toLowerCase()).join("")).join("");
   const foldClaim=(v)=>foldClaimCase(String(v==null?"":v).replace(/\s+/g," ").trim());

--- a/scripts/cr/ledger-append.sh
+++ b/scripts/cr/ledger-append.sh
@@ -326,11 +326,18 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TE
   // parity while test-finding-reraise.sh covers the shared panel helper.
   const foldWhitespace=(v)=>String(v==null?"":v).toLowerCase().replace(/\s+/g," ").trim();
   const normalizeFileAnchor=(v)=>String(v==null?"":v).replace(/\s+/g," ").trim().replace(/\\/g,"/").replace(/^\.\//,"").replace(/:(?:l)?\d+(?:-\d+)?$/i,"");
-  const normalizeClaim=(v)=>foldWhitespace(String(v==null?"":v).replace(/^\s*-\s*\[[^\]]+\]\s*:\s*/,"").replace(/\s*\[[^\]\r\n]+:\d+(?:-\d+)?\]\s*$/,"") );
+  // HIMMEL-2901: case inside code is identity, case in prose is noise - keep
+  // backtick spans and identifier-shaped tokens (camelCase, snake_case, dotted)
+  // case-intact, fold everything else. Parity with finding-fingerprint.js.
+  const isCodeToken=(t)=>{const c=t.replace(/^[^A-Za-z0-9_$.]+/,"").replace(/[^A-Za-z0-9_$.]+$/,"");
+    return c?(/[a-z][A-Z]/.test(c)||c.includes("_")||/^[A-Za-z0-9_$]+(?:\.[A-Za-z0-9_$]+)+$/.test(c)):false;};
+  const foldClaimCase=(v)=>String(v).split(/(`[^`]*`)/).map((p,i)=>i%2===1?p:p.split(/(\s+)/).map(t=>isCodeToken(t)?t:t.toLowerCase()).join("")).join("");
+  const foldClaim=(v)=>foldClaimCase(String(v==null?"":v).replace(/\s+/g," ").trim());
+  const normalizeClaim=(v)=>foldClaim(String(v==null?"":v).replace(/^\s*-\s*\[[^\]]+\]\s*:\s*/,"").replace(/\s*\[[^\]\r\n]+:\d+(?:-\d+)?\]\s*$/,"") );
   const findingFingerprint=(slug,file,text)=>{
     const s=foldWhitespace(slug), a=normalizeFileAnchor(file), c=normalizeClaim(text);
     if(!s||!c) return "";
-    return "fp1:"+crypto.createHash("sha256").update([s,a,c].join(String.fromCharCode(31)),"utf8").digest("hex");
+    return "fp2:"+crypto.createHash("sha256").update([s,a,c].join(String.fromCharCode(31)),"utf8").digest("hex");
   };
   const led=e.LEDGER;
   // HIMMEL-2078: batch rows carry spec.text straight from a caller-built JSON

--- a/scripts/cr/ledger-append.sh
+++ b/scripts/cr/ledger-append.sh
@@ -140,6 +140,16 @@ for _round_value in "$round" "$disposition_round"; do
   fi
 done
 
+# HIMMEL-2901: an adjudication written during a /pr-check pass belongs to THAT
+# round, not to the round that produced the finding. --disposition-round states
+# it explicitly; CR_REVIEW_ROUND is the ambient fallback for the amend verb, so
+# a gate that already exports the round does not have to thread a flag through.
+# Ambient input is not a flag: an unusable value is ignored, never a refusal.
+if [ "$kind" = "amend" ] && [ -z "$disposition_round" ] &&
+   expr "${CR_REVIEW_ROUND:-}" : '^[1-9][0-9]*$' >/dev/null 2>&1; then
+  disposition_round="$CR_REVIEW_ROUND"
+fi
+
 # A deferral is only honest if it is TRACKED. Validate the ticket key here so a
 # typo cannot silently produce a deferral the gate then rejects for reasons the
 # caller has to reverse-engineer.
@@ -639,6 +649,12 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TE
     }
     const rec={kind:"amend",ts:e.TS,branch:e.BRANCH,target_head:target.head,finding_id:e.ID,
                artifact:e.ARTIFACT,perspective:e.PERSPECTIVE,set,reason:e.REASON};
+    // HIMMEL-2901: the round a verdict was ADJUDICATED in is not the round the
+    // finding was produced in. Record it on the amend event so the reader can
+    // render "first seen rN / dispositioned rM" instead of reporting the
+    // producer round as the disposition round. Only an amend that actually
+    // sets a verdict is an adjudication; a bookkeeping amend carries no round.
+    if(e.DISPOSITION_ROUND&&set.verdict) rec.disposition_round=Number(e.DISPOSITION_ROUND);
     fs.appendFileSync(led, JSON.stringify(rec)+"\n");
     process.stderr.write("ledger-append.sh: amended "+e.ID+" at "+e.HEAD_.slice(0,8)+" -> "
       +JSON.stringify(set)+"\n");

--- a/scripts/cr/test-finding-reraise.sh
+++ b/scripts/cr/test-finding-reraise.sh
@@ -763,6 +763,34 @@ assert_eq "$?" "0" "bare-identifier prose-case panel run succeeds"
 assert_has "$(cat "$tmp/bi5.out")" "RE-RAISE (r3 disproved)" \
     "identical identifiers with different prose case still fold onto one fingerprint"
 
+# A dotted identifier that ENDS a sentence is still an identifier: the trailing
+# period is prose punctuation, not part of the name (codex-1, round 1).
+checkout_branch dotted-sentence-end
+head_ds3="$(advance_head dotted-sentence-r3)"
+set_registry critic-a
+ds_claim='The handler reads config.LOGLEVEL. [scripts/cr/case.sh:80]'
+run_panel 3 "$ds_claim" imp "$tmp/ds3.out" "$tmp/ds3.err"
+assert_eq "$?" "0" "dotted-sentence seed panel run succeeds"
+id_ds3="$(finding_id_at dotted-sentence-end "$head_ds3")"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch dotted-sentence-end --head "$head_ds3" \
+        --id "$id_ds3" --set verdict=disproved --reason 'the LOGLEVEL claim is disproved'
+) >/dev/null 2>"$tmp/ds3-amend.err"
+assert_eq "$?" "0" "dotted-sentence fixture accepts the disproof"
+advance_head dotted-sentence-r4 >/dev/null
+run_panel 4 'The handler reads config.loglevel. [scripts/cr/case.sh:90]' imp "$tmp/ds4.out" "$tmp/ds4.err"
+assert_eq "$?" "0" "dotted-sentence case panel run succeeds"
+assert_has "$(cat "$tmp/ds4.out")" "## Important Issues (1 found)" \
+    "a sentence-ending dotted identifier keeps its case-significance"
+assert_lacks "$(cat "$tmp/ds4.out")" "RE-RAISE (" \
+    "a differing dotted identifier does not inherit a disposition through trailing punctuation"
+advance_head dotted-sentence-r5 >/dev/null
+run_panel 5 'THE HANDLER reads config.LOGLEVEL. [scripts/cr/case.sh:95]' imp "$tmp/ds5.out" "$tmp/ds5.err"
+assert_eq "$?" "0" "dotted-sentence prose-case panel run succeeds"
+assert_has "$(cat "$tmp/ds5.out")" "RE-RAISE (r3 disproved)" \
+    "prose case around an identical dotted identifier still folds onto one fingerprint"
+
 # The writer's standalone fingerprint copy must agree with the shared helper on
 # the case rules too, or a row it writes never matches a claim the panel reads.
 checkout_branch code-case-parity

--- a/scripts/cr/test-finding-reraise.sh
+++ b/scripts/cr/test-finding-reraise.sh
@@ -187,6 +187,8 @@ assert_has "$r5_out" "## Already Dispositioned Re-raises (1 found)" "r5 re-raise
 assert_has "$r5_out" "RE-RAISE (r4 disproved)" "r5 re-raise names the original round and verdict"
 assert_eq "$(ledger_value reraised "$head_r5" fingerprint)" "$fp_r4" "line/case/whitespace changes keep the fingerprint stable"
 assert_eq "$(ledger_value reraised "$head_r5" verdict)" "disproved" "r5 re-raise persists the inherited disposition"
+# HIMMEL-2901: this fixture amends with no adjudication round, so disposition_round
+# stays the producer round — the documented fallback that keeps pre-2901 rows rendering.
 assert_eq "$(ledger_value reraised "$head_r5" disposition_round)" "4" "r5 re-raise preserves the original disposition round"
 
 # A later explicit fixed disposition supersedes the old disproof. Fixed never
@@ -305,6 +307,7 @@ run_panel 9 'CACHE cleanup must retain 2 generations [scripts/cr/cache.sh:90]' s
 assert_eq "$?" "0" "r9 deferred re-raise panel run succeeds"
 assert_has "$(cat "$tmp/d9.out")" "RE-RAISE (r7 deferred)" "r9 still reports r7 rather than chaining through r8"
 assert_has "$(cat "$tmp/d9.out")" "## Suggestions (0 found)" "r9 deferred re-raise remains outside suggestion tally"
+# HIMMEL-2901: same no-adjudication-round fallback, carried across two re-raises.
 assert_eq "$(ledger_value deferred "$head_d9" disposition_round)" "7" "r9 durable row preserves r7 as disposition source"
 
 advance_head d10-changed-claim >/dev/null
@@ -551,6 +554,70 @@ process.stdout.write(String(finding.fingerprint||""));
 ')"
 assert_eq "$compat_shape" "1,1" "verdict-only compatibility uses an amend, not a duplicate finding"
 assert_fingerprint "$compat_fp" "original fingerprint survives verdict-only adjudication"
+
+# HIMMEL-2901 item 1: the round a verdict was ADJUDICATED in is its own field.
+# The finding keeps its first-seen observation round; the amend that sets the
+# verdict records the round of the /pr-check pass that wrote it, explicitly via
+# --disposition-round or from CR_REVIEW_ROUND. "First seen" is derived by the
+# reader as the earliest observation round across rows sharing this
+# branch+fingerprint, so an inherited re-raise never reports itself as first
+# seen. Rendering names both rounds only when they differ.
+checkout_branch adjudication-round
+head_ar4="$(advance_head adjudication-r4)"
+set_registry critic-a
+ar_claim='Adjudication round claim [scripts/cr/adjudication.sh:12]'
+run_panel 4 "$ar_claim" imp "$tmp/ar4.out" "$tmp/ar4.err"
+assert_eq "$?" "0" "adjudication-round seed panel run succeeds"
+id_ar4="$(finding_id_at adjudication-round "$head_ar4")"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch adjudication-round --head "$head_ar4" \
+        --id "$id_ar4" --set verdict=disproved --disposition-round 5 \
+        --reason 'disproved in the r5 pass'
+) >/dev/null 2>"$tmp/ar-amend.err"
+assert_eq "$?" "0" "amend accepts an explicit adjudication round"
+head_ar6="$(advance_head adjudication-r6)"
+run_panel 6 "$ar_claim" imp "$tmp/ar6.out" "$tmp/ar6.err"
+assert_eq "$?" "0" "adjudication-round re-raise panel run succeeds"
+ar6_out="$(cat "$tmp/ar6.out")"
+assert_has "$ar6_out" "RE-RAISE (first seen r4 · dispositioned r5 disproved)" \
+    "re-raise names the first-seen round and the adjudication round when they differ"
+assert_has "$ar6_out" "## Important Issues (0 found)" "explicit adjudication round still suppresses the re-raise"
+assert_eq "$(ledger_value adjudication-round "$head_ar6" disposition_round)" "5" \
+    "durable re-raise row carries the adjudication round, not the producer round"
+assert_eq "$(ledger_value adjudication-round "$head_ar6" round)" "6" \
+    "durable re-raise row keeps its own observation round"
+
+# The next round must not report the r6 re-raise as first seen: first-seen is
+# the earliest observation of the fingerprint, r4.
+advance_head adjudication-r7 >/dev/null
+run_panel 7 "$ar_claim" imp "$tmp/ar7.out" "$tmp/ar7.err"
+assert_eq "$?" "0" "adjudication-round second re-raise panel run succeeds"
+assert_has "$(cat "$tmp/ar7.out")" "RE-RAISE (first seen r4 · dispositioned r5 disproved)" \
+    "first-seen round does not chain through the inherited re-raise"
+
+# CR_REVIEW_ROUND supplies the adjudication round when the flag is omitted:
+# an adjudication written during an r5 pass is an r5 disposition.
+checkout_branch adjudication-env
+head_ae3="$(advance_head adjudication-env-r3)"
+set_registry critic-a
+ae_claim='Ambient adjudication round claim [scripts/cr/adjudication.sh:40]'
+run_panel 3 "$ae_claim" imp "$tmp/ae3.out" "$tmp/ae3.err"
+assert_eq "$?" "0" "ambient adjudication seed panel run succeeds"
+id_ae3="$(finding_id_at adjudication-env "$head_ae3")"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" CR_REVIEW_ROUND=5 bash "$LEDGER_APPEND" amend --branch adjudication-env \
+        --head "$head_ae3" --id "$id_ae3" --set verdict=disproved --reason 'disproved during the r5 pass'
+) >/dev/null 2>"$tmp/ae-amend.err"
+assert_eq "$?" "0" "amend accepts an ambient adjudication round"
+head_ae6="$(advance_head adjudication-env-r6)"
+run_panel 6 "$ae_claim" imp "$tmp/ae6.out" "$tmp/ae6.err"
+assert_eq "$?" "0" "ambient adjudication re-raise panel run succeeds"
+assert_has "$(cat "$tmp/ae6.out")" "RE-RAISE (first seen r3 · dispositioned r5 disproved)" \
+    "CR_REVIEW_ROUND supplies the adjudication round when --disposition-round is omitted"
+assert_eq "$(ledger_value adjudication-env "$head_ae6" disposition_round)" "5" \
+    "ambient adjudication round reaches the durable row"
 
 # Sanity: every current panel run wrote one durable finding row; none was
 # silently dropped merely because it rendered in the already-dispositioned block.

--- a/scripts/cr/test-finding-reraise.sh
+++ b/scripts/cr/test-finding-reraise.sh
@@ -28,10 +28,10 @@ assert_lacks() {
     case "$1" in *"$2"*) fail "$3 (unexpected '$2')" ;; *) pass "$3" ;; esac
 }
 assert_fingerprint() {
-    if grep -qE '^fp1:[0-9a-f]{64}$' <<< "$1"; then
+    if grep -qE '^fp2:[0-9a-f]{64}$' <<< "$1"; then
         pass "$2"
     else
-        fail "$2 (got '$1', want fp1:<64 lowercase hex>)"
+        fail "$2 (got '$1', want fp2:<64 lowercase hex>)"
     fi
 }
 
@@ -690,6 +690,98 @@ run_panel 5 "$us_claim" imp "$tmp/us5.out" "$tmp/us5.err"
 assert_eq "$?" "0" "bystander-amend panel run succeeds"
 assert_has "$(cat "$tmp/us5.out")" "## Important Issues (0 found)" \
     "amending a row that is not the origin leaves the inherited ceiling intact"
+
+# HIMMEL-2901 item 3: case inside code-bearing fragments is identity. Folding
+# the whole claim to lowercase made `Foo` and `foo` at the same anchor one
+# fingerprint, so each inherited the other's disposition. Prose case still
+# folds — that is the dedup value the fold exists for.
+checkout_branch code-case
+head_cc3="$(advance_head code-case-r3)"
+set_registry critic-a
+# shellcheck disable=SC2016  # backticks here are markdown code spans in the claim text, not command substitution
+cc_claim='Check the `Foo` handler [scripts/cr/case.sh:10]'
+run_panel 3 "$cc_claim" imp "$tmp/cc3.out" "$tmp/cc3.err"
+assert_eq "$?" "0" "code-case seed panel run succeeds"
+id_cc3="$(finding_id_at code-case "$head_cc3")"
+fp_cc3="$(ledger_value code-case "$head_cc3" fingerprint)"
+assert_fingerprint "$fp_cc3" "code-case seed persists a versioned fingerprint"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch code-case --head "$head_cc3" \
+        --id "$id_cc3" --set verdict=disproved --reason 'the Foo handler claim is disproved'
+) >/dev/null 2>"$tmp/cc3-amend.err"
+assert_eq "$?" "0" "code-case fixture accepts the disproof"
+
+head_cc4="$(advance_head code-case-r4)"
+# shellcheck disable=SC2016  # backticks here are markdown code spans in the claim text, not command substitution
+run_panel 4 'Check the `foo` handler [scripts/cr/case.sh:20]' imp "$tmp/cc4.out" "$tmp/cc4.err"
+assert_eq "$?" "0" "backtick-case panel run succeeds"
+assert_has "$(cat "$tmp/cc4.out")" "## Important Issues (1 found)" \
+    "a different identifier case inside backticks is a different claim"
+assert_lacks "$(cat "$tmp/cc4.out")" "RE-RAISE (" "backtick case does not inherit the other claim's disposition"
+if [ "$(ledger_value code-case "$head_cc4" fingerprint)" != "$fp_cc3" ]; then
+    pass "backtick identifier case is fingerprint-significant"
+else
+    fail "backtick identifier case is fingerprint-significant"
+fi
+
+head_cc5="$(advance_head code-case-r5)"
+# shellcheck disable=SC2016  # backticks here are markdown code spans in the claim text, not command substitution
+run_panel 5 'CHECK   the `Foo` HANDLER [scripts/cr/case.sh:30]' imp "$tmp/cc5.out" "$tmp/cc5.err"
+assert_eq "$?" "0" "prose-case panel run succeeds"
+assert_has "$(cat "$tmp/cc5.out")" "RE-RAISE (r3 disproved)" \
+    "prose case and whitespace still fold onto the same fingerprint"
+assert_eq "$(ledger_value code-case "$head_cc5" fingerprint)" "$fp_cc3" \
+    "prose-only case changes keep the fingerprint stable"
+
+# Identifier shapes outside backticks are code too: camelCase and snake_case
+# carry meaning that lowercasing destroys.
+checkout_branch bare-identifier-case
+head_bi3="$(advance_head bare-identifier-r3)"
+set_registry critic-a
+bi_claim='The fooBar token and FOO_BAR constant disagree [scripts/cr/case.sh:50]'
+run_panel 3 "$bi_claim" imp "$tmp/bi3.out" "$tmp/bi3.err"
+assert_eq "$?" "0" "bare-identifier seed panel run succeeds"
+id_bi3="$(finding_id_at bare-identifier-case "$head_bi3")"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch bare-identifier-case --head "$head_bi3" \
+        --id "$id_bi3" --set verdict=disproved --reason 'the identifier claim is disproved'
+) >/dev/null 2>"$tmp/bi3-amend.err"
+assert_eq "$?" "0" "bare-identifier fixture accepts the disproof"
+advance_head bare-identifier-r4 >/dev/null
+run_panel 4 'The foobar token and foo_bar constant disagree [scripts/cr/case.sh:60]' imp \
+    "$tmp/bi4.out" "$tmp/bi4.err"
+assert_eq "$?" "0" "bare-identifier case panel run succeeds"
+assert_has "$(cat "$tmp/bi4.out")" "## Important Issues (1 found)" \
+    "camelCase and snake_case identifier case is fingerprint-significant"
+assert_lacks "$(cat "$tmp/bi4.out")" "RE-RAISE (" "differing identifiers do not inherit a disposition"
+advance_head bare-identifier-r5 >/dev/null
+run_panel 5 'the fooBar token and FOO_BAR constant DISAGREE [scripts/cr/case.sh:70]' imp \
+    "$tmp/bi5.out" "$tmp/bi5.err"
+assert_eq "$?" "0" "bare-identifier prose-case panel run succeeds"
+assert_has "$(cat "$tmp/bi5.out")" "RE-RAISE (r3 disproved)" \
+    "identical identifiers with different prose case still fold onto one fingerprint"
+
+# The writer's standalone fingerprint copy must agree with the shared helper on
+# the case rules too, or a row it writes never matches a claim the panel reads.
+checkout_branch code-case-parity
+head_ccp="$(advance_head code-case-parity-seed)"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" finding --branch code-case-parity --head "$head_ccp" \
+        --model critic-a --id code-case-parity-1 --severity imp --file scripts/cr/case.sh --line 10 \
+        --verdict disproved --round 3 \
+        --text '- [code-case-parity-1]: Check the `Foo` handler in fooBar [scripts/cr/case.sh:10]'
+) >/dev/null 2>"$tmp/code-case-parity-seed.err"
+assert_eq "$?" "0" "code-case parity fixture writes through the standalone writer"
+advance_head code-case-parity-current >/dev/null
+# shellcheck disable=SC2016  # backticks here are markdown code spans in the claim text, not command substitution
+run_panel 4 'CHECK the `Foo` HANDLER in fooBar [scripts/cr/case.sh:90]' imp \
+    "$tmp/ccp.out" "$tmp/ccp.err"
+assert_eq "$?" "0" "code-case parity panel run succeeds"
+assert_has "$(cat "$tmp/ccp.out")" "RE-RAISE (r3 disproved)" \
+    "writer and panel helper agree on which fragments keep their case"
 
 # Sanity: every current panel run wrote one durable finding row; none was
 # silently dropped merely because it rendered in the already-dispositioned block.

--- a/scripts/cr/test-finding-reraise.sh
+++ b/scripts/cr/test-finding-reraise.sh
@@ -619,6 +619,78 @@ assert_has "$(cat "$tmp/ae6.out")" "RE-RAISE (first seen r3 · dispositioned r5 
 assert_eq "$(ledger_value adjudication-env "$head_ae6" disposition_round)" "5" \
     "ambient adjudication round reaches the durable row"
 
+# HIMMEL-2901 item 2: a severity correction to the ORIGINAL adjudication must
+# reach the inherited re-raise that now carries the ceiling. Without it, an
+# Important corrected to Suggestion keeps its Important ceiling forever and a
+# genuine later Important occurrence is wrongly suppressed.
+checkout_branch inherited-severity
+head_is3="$(advance_head inherited-severity-r3)"
+set_registry critic-a
+is_claim='Inherited ceiling claim [scripts/cr/inherit.sh:15]'
+run_panel 3 "$is_claim" imp "$tmp/is3.out" "$tmp/is3.err"
+assert_eq "$?" "0" "inherited-severity seed panel run succeeds"
+id_is3="$(finding_id_at inherited-severity "$head_is3")"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch inherited-severity --head "$head_is3" \
+        --id "$id_is3" --set verdict=disproved --reason 'Important claim disproved'
+) >/dev/null 2>"$tmp/is3-amend.err"
+assert_eq "$?" "0" "inherited-severity fixture accepts the Important disproof"
+head_is4="$(advance_head inherited-severity-r4)"
+run_panel 4 "$is_claim" imp "$tmp/is4.out" "$tmp/is4.err"
+assert_eq "$?" "0" "inherited-severity re-raise panel run succeeds"
+assert_has "$(cat "$tmp/is4.out")" "## Important Issues (0 found)" "the re-raise inherits the Important disproof"
+assert_eq "$(ledger_value inherited-severity "$head_is4" disposition_severity)" "imp" \
+    "the inherited row carries the Important ceiling"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch inherited-severity --head "$head_is3" \
+        --id "$id_is3" --set severity=sug --reason 'the original was over-rated; it is a Suggestion'
+) >/dev/null 2>"$tmp/is-severity-amend.err"
+assert_eq "$?" "0" "severity correction to the original adjudication writes"
+advance_head inherited-severity-r5 >/dev/null
+run_panel 5 "$is_claim" imp "$tmp/is5.out" "$tmp/is5.err"
+assert_eq "$?" "0" "corrected-ceiling panel run succeeds"
+assert_has "$(cat "$tmp/is5.out")" "## Important Issues (1 found)" \
+    "a severity correction to the original adjudication lowers the inherited ceiling"
+assert_lacks "$(cat "$tmp/is5.out")" "RE-RAISE (" \
+    "an Important above the corrected Suggestion ceiling requires renewed adjudication"
+
+# Negative control: an amend to a DIFFERENT row of the same fingerprint that is
+# not the origin of the active disposition must leave the ceiling alone.
+checkout_branch unrelated-severity
+head_us3="$(advance_head unrelated-severity-r3)"
+set_registry critic-a
+us_claim='Unrelated ceiling claim [scripts/cr/inherit.sh:60]'
+run_panel 3 "$us_claim" imp "$tmp/us3.out" "$tmp/us3.err"
+assert_eq "$?" "0" "unrelated-severity seed panel run succeeds"
+id_us3="$(finding_id_at unrelated-severity "$head_us3")"
+us_head_other="3333333333333333333333333333333333333333"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch unrelated-severity --head "$head_us3" \
+        --id "$id_us3" --set verdict=disproved --reason 'Important claim disproved'
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" finding --branch unrelated-severity --head "$us_head_other" \
+        --model critic-a --id unrelated-1 --severity imp --file scripts/cr/inherit.sh --line 60 \
+        --verdict '' --round 3 --text "- [unrelated-1]: $us_claim"
+) >/dev/null 2>"$tmp/us-seed.err"
+assert_eq "$?" "0" "unrelated-severity fixture seeds a same-fingerprint bystander row"
+advance_head unrelated-severity-r4 >/dev/null
+run_panel 4 "$us_claim" imp "$tmp/us4.out" "$tmp/us4.err"
+assert_eq "$?" "0" "unrelated-severity re-raise panel run succeeds"
+assert_has "$(cat "$tmp/us4.out")" "## Important Issues (0 found)" "the bystander does not disturb the inheritance"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch unrelated-severity --head "$us_head_other" \
+        --id unrelated-1 --set severity=sug --reason 'correct an unrelated row of the same claim'
+) >/dev/null 2>"$tmp/us-severity-amend.err"
+assert_eq "$?" "0" "bystander severity amendment writes"
+advance_head unrelated-severity-r5 >/dev/null
+run_panel 5 "$us_claim" imp "$tmp/us5.out" "$tmp/us5.err"
+assert_eq "$?" "0" "bystander-amend panel run succeeds"
+assert_has "$(cat "$tmp/us5.out")" "## Important Issues (0 found)" \
+    "amending a row that is not the origin leaves the inherited ceiling intact"
+
 # Sanity: every current panel run wrote one durable finding row; none was
 # silently dropped merely because it rendered in the already-dispositioned block.
 assert_eq "$(finding_count_at reraised "$head_r5")" "1" "disproved re-raise remains a durable current-head row"

--- a/scripts/cr/test-ledger-append.sh
+++ b/scripts/cr/test-ledger-append.sh
@@ -1012,4 +1012,21 @@ check "batch numeric/string round controls normalize to numbers" "$(L="$BRVL" no
 check "batch numeric/string disposition-round controls normalize to numbers" "$(L="$BRVL" node -e 'const r=require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").filter(Boolean).map(JSON.parse);console.log(r.filter(x=>x.disposition_round!==undefined).map(x=>typeof x.disposition_round+":"+x.disposition_round).sort().join(","))')" "number:4,number:5"
 check "batch absent round metadata remains absent" "$(L="$BRVL" node -e 'const r=require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").filter(Boolean).map(JSON.parse).find(x=>x.finding_id==="round-absent");console.log(("round" in r)+","+("disposition_round" in r))')" "false,false"
 
+# HIMMEL-2901: an amend that sets a VERDICT records the round it adjudicated in,
+# explicitly or from the ambient CR_REVIEW_ROUND. A bookkeeping amend is not an
+# adjudication, so it records no round at all.
+ARL="$tmp/amend-round.jsonl"
+AR_HEAD=$(printf '%040d' 90123)
+CR_LEDGER="$ARL" bash "$LA" finding --branch b --head "$AR_HEAD" --model critic-a --id amend-round --severity imp --file f --line 20 --verdict '' --round 4 --text '- [amend-round]: adjudication round claim [f:20]'
+CR_LEDGER="$ARL" bash "$LA" amend --branch b --head "$AR_HEAD" --id amend-round --set verdict=disproved --disposition-round 5 --reason 'disproved in the r5 pass' 2>"$tmp/amend-round.err"
+check "amend accepts an explicit adjudication round" "$?" "0"
+CR_LEDGER="$ARL" CR_REVIEW_ROUND=7 bash "$LA" amend --branch b --head "$AR_HEAD" --id amend-round --set verdict=fixed --reason 'repaired during the r7 pass' 2>"$tmp/amend-round-env.err"
+check "amend accepts an ambient adjudication round" "$?" "0"
+CR_LEDGER="$ARL" CR_REVIEW_ROUND=9 bash "$LA" amend --branch b --head "$AR_HEAD" --id amend-round --set 'reason=bookkeeping only' --reason 'clarify the record' 2>"$tmp/amend-round-book.err"
+check "bookkeeping amend still writes" "$?" "0"
+check "verdict amends carry their adjudication round; a bookkeeping amend carries none" "$(L="$ARL" node -e 'const r=require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").map(JSON.parse);console.log(r.filter(x=>x.kind==="amend").map(x=>String(x.disposition_round)).join(","))')" "5,7,undefined"
+CR_LEDGER="$ARL" CR_REVIEW_ROUND=nope bash "$LA" amend --branch b --head "$AR_HEAD" --id amend-round --set verdict=disproved --reason 'ambient round is unusable' 2>"$tmp/amend-round-bad.err"
+check "an unusable ambient round is ignored, not refused" "$?" "0"
+check "an unusable ambient round records no adjudication round" "$(L="$ARL" node -e 'const r=require("fs").readFileSync(process.env.L,"utf8").trim().split("\n").map(JSON.parse);const a=r.filter(x=>x.kind==="amend").pop();console.log(String(a.disposition_round))')" "undefined"
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
Three CR-ledger residuals the codex panel raised in rounds 4–5 of #604 (HIMMEL-2896) and the console deferred here by explicit disposition. One branch, one commit per item, plus one CR-round fix.

## 1. `disposition_round` is the adjudication round (`c0bbc4e2`)

A verdict amendment derived `disposition_round` from the finding's own observation round, so a finding first seen in r4 and adjudicated in r5 rendered as "r4 disproved" — the ledger named the round that produced the claim, not the round that settled it.

- `ledger-append.sh` records `disposition_round` on an amend that sets a **verdict**, from `--disposition-round` or, when the flag is omitted, from the ambient `CR_REVIEW_ROUND` of the pass writing it. A bookkeeping amend is not an adjudication and records no round; an unusable ambient value is ignored rather than refused, because ambient input is not a flag.
- `finding-reraise.js` prefers the amend's round and falls back to the producer round, so pre-2901 rows keep rendering exactly as before.
- **First seen is derived, not persisted**: the earliest observation round across rows sharing branch+fingerprint, so an inherited re-raise never reports itself as the first sighting. The line names both rounds only when they differ — `RE-RAISE (first seen r4 · dispositioned r5 disproved)`.

**RED** — 5 new assertions failed on the pre-change tree (`disposition_round` got `4`, want `5`; the two-round render absent). Writer-level control: replaying both amends through the `HEAD` copy of `ledger-append.sh` recorded `undefined,undefined` where the suite wants `5,7`.
**GREEN** — `PASS test-finding-reraise`, `ALL PASS test-ledger-append`.

The existing r5/r9 assertions keep their producer-round expectations — those fixtures amend with no adjudication round, which is exactly the documented fallback — and now carry a comment naming this ticket.

## 2. A severity amend to the original row reaches its inherited re-raise (`3f999adc`)

Once a verbatim re-raise inherited a disposition it became the latest event for that fingerprint, and the metadata-only amend path stopped matching the row that was actually adjudicated (`current._sourceKey === targetKey` is false after inheritance). An Important later corrected to Suggestion kept its Important ceiling, and a genuine later Important occurrence was wrongly suppressed.

Inherited events now carry `_originKey` — the source key of the row whose disposition they inherited, collapsed through `previous._originKey` so a chain of re-raises still points at the ONE adjudicated row. A metadata-only amend applies when the amended row is the current event **or** is that origin; every other row of the same fingerprint stays a bystander. Only the disposition ceiling is corrected through the origin path; the inherited row's own observed severity remains its own. The newer-adjudication invariant holds — the origin path fires only when the current event inherited from the amended row.

Inheritance detection now runs independently of whether the row already carries a `disposition_severity`; it previously lived inside the `if (!event.disposition_severity)` branch, which a persisted inherited row — the exact row this fix is about — always skips. That branch's severity outcome is unchanged.

**RED** — the ceiling-correction assertion and its `RE-RAISE` control failed pre-change (the r5 Important stayed suppressed). The bystander negative control passed before and after, so it pins behaviour rather than the fix.
**GREEN** — `PASS test-finding-reraise`.

## 3. Fingerprints keep case inside code fragments, `fp1` → `fp2` (`9700b2b6`)

The claim fold lowercased everything, so `` `Foo` `` and `` `foo` `` at the same anchor were one fingerprint and each inherited the other's disposition.

A token keeps its case when it is identifier-shaped (camelCase, snake_case, dotted), and everything inside a backtick span keeps its case verbatim. Prose case still folds — `Check`/`check`, `CACHE cleanup`/`Cache cleanup` remain one claim. An ALL-CAPS word outside backticks is indistinguishable from prose emphasis, so it folds too; backticks are how a constant keeps its case. The rules are mirrored into `ledger-append.sh`'s standalone fingerprint copy, and a new parity case seeds through the writer and re-raises through the panel helper so a future divergence fails loudly.

**Format bump `fp1` → `fp2`**: the fold changed, so a pre-2901 row must never false-match a claim hashed under the new rules. The ledger is append-only and old rows are **not** rewritten — they keep their `fp1` identity and stop inheriting across the version boundary. Accepted cost: a finding adjudicated before this change and re-raised after it comes back active and needs one re-adjudication.

**RED** — 8 assertions failed pre-change: the backtick and camelCase/snake_case claims inherited dispositions they should not have, and the `fp2` shape assertions read `fp1`.
**GREEN** — `PASS test-finding-reraise`.

## 4. CR round 1 fix — trailing prose punctuation hid a dotted identifier (`327d8caf`)

codex-1 (Important), verified against the code before agreeing: `.` was inside the character class `isCodeToken` trims from a token's edges, so a sentence-ending `config.LOGLEVEL.` kept its period, failed the anchored dotted-name rule, and folded to `config.loglevel.` — the exact case-collapse fp2 exists to stop. Reproduced directly: `normalizeClaim` returned `"the handler reads config.loglevel."` for both spellings.

The edge trim now strips `.` along with the other prose punctuation. camelCase was never affected (`fooBar.` already matched the lower-then-upper rule) and a trailing comma already trimmed; the period was the one in-class character. Ordinary prose is unchanged — "check the end." has no interior dot and still folds. Mirrored into the standalone writer copy; three regression cases added.

## Review

- **Round 1** — codex (`gpt-6-astra`), 0 Critical / 1 Important / 0 Suggestions. The Important is item 4 above: agreed, verified, fixed inline.
- **Round 2** — codex, 0 Critical / 0 Important / 1 Suggestion, on the fixed head. The Suggestion is the next shape in the same heuristic class: an identifier embedded in a call expression outside backticks (`config.LOGLEVEL(value)`) still fails the whole-token rules and folds. Verified as real, then **deferred by explicit disposition to HIMMEL-2906** — not by the round cap. It is Suggestion severity; this PR had already spent its one inline CR fix on the round-1 Important in the same module; and a same-module heuristic refined round after round is the rising-rounds signal. The backtick escape hatch already covers the case verbatim today. HIMMEL-2906 carries the component-classification fix, its regression cases and its `fp3` bump.
- `known-findings.sh --diff` flagged one checklist item: `finding-fingerprint.js` changed with no paired `test-finding-fingerprint.sh`. Deliberate and pre-rebutted — the fingerprint helper has never had a paired suite; it is tested end-to-end through `scripts/cr/test-finding-reraise.sh`, which is where every fold rule in this PR is asserted (backtick case, camelCase, snake_case, dotted, sentence-ending dotted, prose-case folding, and writer/panel parity).

## Evidence

- `bash scripts/quiet-run.sh … -- bash scripts/cr/test-finding-reraise.sh` → `PASS test-finding-reraise`
- `… -- bash scripts/cr/test-ledger-append.sh` → `ALL PASS`
- Impacted suites — every suite referencing a touched file (`git grep -l` over `scripts/**/test-*.sh`, `tests/`), all `OK` after each item and after the CR fix: `test-finding-reraise`, `test-ledger-append`, `test-clear-cr-marker`, `test-codex-adv-harvest`, `test-cr-scores`, `test-critic-panel-instrumentation`, `test-critic-panel-triviality`, `test-critic-panel`, `test-handover-bridge`, `test-pr-check-context`, `test-pr-check-rounds`, `test-pr-check-run`, `test-write-verdicts`, `test-cr-high-risk-diff`
- `shellcheck` clean on `ledger-append.sh`, `test-finding-reraise.sh`, `test-ledger-append.sh`; `node --check` clean on `finding-reraise.js`, `finding-fingerprint.js`

Attestation trailers are in the first commit. No ledger rows are rewritten or deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJbT4AAwrwPfDJACtFDVJb
