### PR TITLE
test(handover): [HIMMEL-2877] deterministic case-14 dedup race + fixture races

### DIFF
--- a/scripts/handover/test-arm-resume-long-gap.sh
+++ b/scripts/handover/test-arm-resume-long-gap.sh
@@ -289,15 +289,39 @@ print(candidate.strftime("%H:%M"))
 PY
 }
 
+# HIMMEL-2877: these three fixtures used to be built on datetime.now() (i.e.
+# "today"). On a day the local zone falls into a DST spring-forward gap,
+# local wall-clock 00:05 (or the other two clock times) can be a NONEXISTENT
+# or ambiguous local time, and naive datetime.timestamp()'s handling of that
+# is platform/tzdata-dependent - it can silently round-trip to a different
+# HH:MM than the one asked for, drifting these assertions on transition
+# days only. None of these three cases care what day it is (lg4_wrap_hhmm
+# only reasons about hour/minute and same-day-vs-crossed-date), so pin them
+# to a fixed mid-year date instead: no tzdata table places a DST transition
+# in mid-June, so this never lands in a gap or fold, on any date the suite
+# actually runs on.
 read -r _lg4_0005_epoch _lg4_1234_epoch _lg4_0000_epoch < <(python3 -c '
 import datetime
-now = datetime.datetime.now()
+now = datetime.datetime(datetime.date.today().year, 6, 15)
 print(
     int(now.replace(hour=0, minute=5, second=0, microsecond=0).timestamp()),
     int(now.replace(hour=12, minute=34, second=0, microsecond=0).timestamp()),
     int(now.replace(hour=0, minute=0, second=0, microsecond=0).timestamp()),
 )
 ')
+# HIMMEL-2877: regression guard for the fixture itself, independent of
+# lg4_wrap_hhmm - round-trip the epoch back through localtime and confirm
+# it still reads 00:05. A future edit that reintroduces a "today"-based
+# construction would only drift on an actual DST gap/fold day; this catches
+# that class outright instead of leaving it to intermittently fail the
+# assertions below for a reason nobody would trace back to the fixture.
+_lg4_0005_roundtrip=$(python3 -c "import datetime, sys; print(datetime.datetime.fromtimestamp(int(sys.argv[1])).strftime('%H:%M'))" "$_lg4_0005_epoch")
+if [ "$_lg4_0005_roundtrip" = "00:05" ]; then
+    echo "PASS LG4 fixture epoch round-trips to the intended 00:05 (no DST gap/fold drift)"
+else
+    echo "FAIL LG4 fixture epoch round-trips to $_lg4_0005_roundtrip, not 00:05 -- fixture date may sit inside a DST gap/fold"
+    FAILED=$((FAILED + 1))
+fi
 _lg4_0005_hhmm=$(lg4_wrap_hhmm "$_lg4_0005_epoch")
 if [ "$_lg4_0005_hhmm" = "00:00" ]; then
     echo "PASS LG4 fixture local 00:05 stays inside today (00:00)"
@@ -332,7 +356,7 @@ _lg4_midnight_reason=$(lg4_wrap_hhmm "$_lg4_0000_epoch" 2>&1)
 _lg4_midnight_rc=$?
 assert_rc "LG4 fixture exact midnight signals skip" 10 "$_lg4_midnight_rc"
 assert_contains "LG4 fixture exact midnight names the skip reason" "exact local midnight has no earlier same-day HH:MM" "$_lg4_midnight_reason"
-unset _lg4_0005_epoch _lg4_1234_epoch _lg4_0000_epoch _lg4_0005_hhmm _lg4_0005_rolled _lg4_1234_hhmm _lg4_midnight_reason _lg4_midnight_rc
+unset _lg4_0005_epoch _lg4_1234_epoch _lg4_0000_epoch _lg4_0005_roundtrip _lg4_0005_hhmm _lg4_0005_rolled _lg4_1234_hhmm _lg4_midnight_reason _lg4_midnight_rc
 
 LG4_SKIP_REASON=
 WRAP_HHMM=$(lg4_wrap_hhmm "$(python3 -c 'import time; print(int(time.time()))')" 2>"$TMP/lg4-wrap-reason")

--- a/scripts/handover/test-arm-resume-long-gap.sh
+++ b/scripts/handover/test-arm-resume-long-gap.sh
@@ -358,17 +358,31 @@ assert_rc "LG4 fixture exact midnight signals skip" 10 "$_lg4_midnight_rc"
 assert_contains "LG4 fixture exact midnight names the skip reason" "exact local midnight has no earlier same-day HH:MM" "$_lg4_midnight_reason"
 unset _lg4_0005_epoch _lg4_1234_epoch _lg4_0000_epoch _lg4_0005_roundtrip _lg4_0005_hhmm _lg4_0005_rolled _lg4_1234_hhmm _lg4_midnight_reason _lg4_midnight_rc
 
-LG4_SKIP_REASON=
-WRAP_HHMM=$(lg4_wrap_hhmm "$(python3 -c 'import time; print(int(time.time()))')" 2>"$TMP/lg4-wrap-reason")
-_lg4_wrap_rc=$?
-if [ "$_lg4_wrap_rc" -eq 10 ]; then
-    LG4_SKIP_REASON=$(<"$TMP/lg4-wrap-reason")
-elif [ "$_lg4_wrap_rc" -ne 0 ]; then
-    echo "FAIL LG4 fixture helper failed unexpectedly (rc=$_lg4_wrap_rc)"
-    FAILED=$((FAILED + 1))
-    LG4_SKIP_REASON="fixture helper failed unexpectedly"
-fi
-unset _lg4_wrap_rc
+# HIMMEL-2877 (E1): WRAP_HHMM used to be captured ONCE here, before LG1-LG3
+# run below - each of which shells out to python3 and arm-resume, taking
+# real wall-clock seconds under load. lg4_wrap_hhmm's "stays inside today"
+# vs. "rolls to tomorrow" clamp is a snapshot relative to the wall-clock AT
+# CAPTURE time, but the case needs it to still hold relative to arm-resume's
+# OWN `date +%s` read at CONSUMPTION time. A capture near a midnight
+# boundary (e.g. 00:03, clamped to "00:00") that is only actually consumed
+# minutes later (after LG1-3) is consumed against a `now` that has moved
+# forward - "00:00 today" can go from ~1430 min in the past (refused) to
+# well under the 60-min silent threshold, flipping LG4's expected rc=9 into
+# a spurious rc=0. This is the exact HIMMEL-1879/1756 class near_hhmm() was
+# already turned into a function to fix, a few lines up - recompute
+# immediately before use instead of capturing early.
+compute_wrap_hhmm() {
+    LG4_SKIP_REASON=
+    WRAP_HHMM=$(lg4_wrap_hhmm "$(python3 -c 'import time; print(int(time.time()))')" 2>"$TMP/lg4-wrap-reason")
+    local _rc=$?
+    if [ "$_rc" -eq 10 ]; then
+        LG4_SKIP_REASON=$(<"$TMP/lg4-wrap-reason")
+    elif [ "$_rc" -ne 0 ]; then
+        echo "FAIL LG4 fixture helper failed unexpectedly (rc=$_rc)"
+        FAILED=$((FAILED + 1))
+        LG4_SKIP_REASON="fixture helper failed unexpectedly"
+    fi
+}
 
 # ---------------------------------------------------------------------------
 # LG1: gap > 60 min, no --long-gap -> REFUSED (rc 9) + the loud WARN.
@@ -409,6 +423,7 @@ assert_not_contains "LG3 no rc-9 refusal text under --long-gap" "rc=9" "$out"
 #      (no +1 day) would compute a ~-10 min gap -> <=60 -> NOT refused, failing
 #      this case. This is the "550 min, not negative" correctness guard.
 # ---------------------------------------------------------------------------
+compute_wrap_hhmm
 if [ -n "$LG4_SKIP_REASON" ]; then
     echo "SKIP LG4 — $LG4_SKIP_REASON"
 else

--- a/scripts/handover/test-headed-arm.sh
+++ b/scripts/handover/test-headed-arm.sh
@@ -426,13 +426,35 @@ d14="$tmp/c14"; mk_stub "$d14" 1  # konsole stub unused either way; the real ass
 mkdir -p "$d14/locks/HIMMEL-donedeal.lock"
 date +%s > "$d14/locks/HIMMEL-donedeal.lock/acquired"
 _fake_claude_proc "$d14" "HIMMEL-donedeal"
+# HIMMEL-2877: the stub marks its own first call (an existence-only sync
+# file, same pattern as mk_matcher_pgrep above) so the releaser below fires
+# the instant the launcher's claim-retry loop has actually started polling,
+# instead of guessing a fixed wall-clock delay that can land before the
+# loop starts or after its ~2s budget expires under CI load.
 cat > "$d14/pgrep" <<'PGREP_EOF'
 #!/usr/bin/env bash
+: > "$(dirname "$0")/first-pgrep-call"
 if [ -e "$(dirname "$0")/session-now-running" ]; then echo 9001; exit 0; fi
 exit 1
 PGREP_EOF
 chmod 755 "$d14/pgrep"
-( sleep 0.3; rm -rf "$d14/locks/HIMMEL-donedeal.lock"; : > "$d14/session-now-running" ) &
+# HIMMEL-2877: flip pgrep-match BEFORE clearing the lock (the old order was
+# reversed). The claim-retry loop always checks pgrep before ever
+# attempting to claim the lock in the SAME iteration, so with the match
+# already true, the lock can never be observed free without that same (or
+# an earlier) iteration having already taken the "already running" exit.
+# The old order raced: a scheduling gap between clearing the lock and
+# setting the flag let a contender claim the freed lock first and fall
+# through to the DIFFERENT "appeared after this arm claimed the lock" log
+# line - or, with a wider gap, actually invoke konsole for a real duplicate
+# launch. Reproduced both outcomes with an exaggerated gap; this order
+# closes it regardless of gap width (see HIMMEL-2877 commit body).
+(
+  n=0
+  while [ ! -e "$d14/first-pgrep-call" ] && [ "$n" -lt 100 ]; do sleep 0.02; n=$((n+1)); done
+  : > "$d14/session-now-running"
+  rm -rf "$d14/locks/HIMMEL-donedeal.lock"
+) &
 rc14=0
 KONSOLE_CMD="$d14/konsole" PGREP_CMD="$d14/pgrep" HEADED_ARM_REPO="$REPO" HEADED_ARM_LOCK_DIR="$d14/locks" HEADED_ARM_PROC="$d14/proc" \
   bash "$SCRIPT" "HIMMEL-donedeal" "doc14.md" "$d14/signal-never" "$PAST" "$d14/log" >/dev/null 2>&1 || rc14=$?
@@ -441,7 +463,7 @@ settle
 if [ -s "$d14/record" ]; then echo "FAIL - retry backs off on a genuine dedup: konsole must NOT be invoked"; fails=$((fails+1))
 else echo "ok - retry backs off on a genuine dedup: konsole not invoked"; fi
 log14="$(cat "$d14/log" 2>/dev/null || true)"
-contains "retry backs off on a genuine dedup: log says already running" "$log14" "already running"
+contains "retry backs off on a genuine dedup: log names the claim-retry loop's dedup line" "$log14" "a session named HIMMEL-donedeal is already running - not launching"
 
 # --- 15 (r2-codex-4). the suite's OWN mktemp failure must abort loudly,
 # never silently continue with an empty $tmp --------------------------------

--- a/scripts/handover/test-headed-arm.sh
+++ b/scripts/handover/test-headed-arm.sh
@@ -426,35 +426,38 @@ d14="$tmp/c14"; mk_stub "$d14" 1  # konsole stub unused either way; the real ass
 mkdir -p "$d14/locks/HIMMEL-donedeal.lock"
 date +%s > "$d14/locks/HIMMEL-donedeal.lock/acquired"
 _fake_claude_proc "$d14" "HIMMEL-donedeal"
-# HIMMEL-2877: the stub marks its own first call (an existence-only sync
-# file, same pattern as mk_matcher_pgrep above) so the releaser below fires
-# the instant the launcher's claim-retry loop has actually started polling,
-# instead of guessing a fixed wall-clock delay that can land before the
-# loop starts or after its ~2s budget expires under CI load.
-cat > "$d14/pgrep" <<'PGREP_EOF'
+# HIMMEL-2877 (panel round 1, codex-1): a SEPARATE background releaser that
+# reacts to a sync file still races the very check it exists to
+# synchronize with - whichever session_confirmed() call the releaser
+# reacted to necessarily observed "no match" (that observation is what
+# triggered the reaction, in a different process), so a claim_lock()
+# attempted in that SAME iteration can still win before the releaser's own
+# writes land. No fixed delay, sync file or write-order can close that:
+# the releaser is fundamentally a second process reacting after the fact.
+#
+# The only way to make the flip and the lock-release indivisible is to do
+# both from the SAME statement in the SAME process as the check itself -
+# so the pgrep stub counts its own invocations and, once a chosen call
+# arrives, releases the lock and reports the match synchronously, before
+# returning. Nothing else can run in between because there is no "in
+# between": it is one shell script, no backgrounding. Calls 1-2 are the
+# pre-loop dedup check (line ~575) and the retry loop's first genuine
+# no-match/claim-fails iteration (lock still real); call 3 is the retry
+# loop's second iteration, where THIS SAME invocation removes the lock and
+# reports the match - the loop's if/exit-0 branch returns immediately on a
+# match, so claim_lock() is never even reached on that iteration.
+cat > "$d14/pgrep" <<PGREP_EOF
 #!/usr/bin/env bash
-: > "$(dirname "$0")/first-pgrep-call"
-if [ -e "$(dirname "$0")/session-now-running" ]; then echo 9001; exit 0; fi
+n=\$(( \$(cat "$d14/pgrep-calls" 2>/dev/null || echo 0) + 1 ))
+printf '%s' "\$n" > "$d14/pgrep-calls"
+if [ "\$n" -ge 3 ]; then
+    rm -rf "$d14/locks/HIMMEL-donedeal.lock"
+    echo 9001
+    exit 0
+fi
 exit 1
 PGREP_EOF
 chmod 755 "$d14/pgrep"
-# HIMMEL-2877: flip pgrep-match BEFORE clearing the lock (the old order was
-# reversed). The claim-retry loop always checks pgrep before ever
-# attempting to claim the lock in the SAME iteration, so with the match
-# already true, the lock can never be observed free without that same (or
-# an earlier) iteration having already taken the "already running" exit.
-# The old order raced: a scheduling gap between clearing the lock and
-# setting the flag let a contender claim the freed lock first and fall
-# through to the DIFFERENT "appeared after this arm claimed the lock" log
-# line - or, with a wider gap, actually invoke konsole for a real duplicate
-# launch. Reproduced both outcomes with an exaggerated gap; this order
-# closes it regardless of gap width (see HIMMEL-2877 commit body).
-(
-  n=0
-  while [ ! -e "$d14/first-pgrep-call" ] && [ "$n" -lt 100 ]; do sleep 0.02; n=$((n+1)); done
-  : > "$d14/session-now-running"
-  rm -rf "$d14/locks/HIMMEL-donedeal.lock"
-) &
 rc14=0
 KONSOLE_CMD="$d14/konsole" PGREP_CMD="$d14/pgrep" HEADED_ARM_REPO="$REPO" HEADED_ARM_LOCK_DIR="$d14/locks" HEADED_ARM_PROC="$d14/proc" \
   bash "$SCRIPT" "HIMMEL-donedeal" "doc14.md" "$d14/signal-never" "$PAST" "$d14/log" >/dev/null 2>&1 || rc14=$?


### PR DESCRIPTION
## Summary

- **Item 1 (case 14):** `test-headed-arm.sh` case 14 seeded a background releaser that cleared a lock, THEN flipped a pgrep-match flag, after a fixed 0.3s sleep. The launcher's claim-retry loop always checks pgrep before attempting to claim the lock, so a scheduling gap between those two writes could land on a different (but equally correct) log phrase, or — under a wider gap — an actual duplicate konsole launch. First fix synced the releaser to the launcher's first pgrep call, but `/pr-check` round 1 (codex-1, Important) correctly found that a *separate reacting process* still races the check it synchronizes with. Final fix: the pgrep stub itself counts its own invocations and, on the chosen call, releases the lock and reports the match in the same synchronous statement — race-free by construction, not by timing.
- **Item 2 (E1):** `test-arm-resume-long-gap.sh`'s LG4 case captured its `WRAP_HHMM` fixture once, before LG1-3 ran (each spending real wall-clock time) — the same capture-before-consumption class HIMMEL-1879/1756 already fixed for `near_hhmm()`. Turned it into `compute_wrap_hhmm()`, called immediately before LG4 uses it.
- **Item 3 (E2):** the same suite's LG4 self-test fixtures (00:05, 12:34, exact midnight) were built on `datetime.now()` ("today"), which on a DST spring-forward transition day risks a nonexistent/ambiguous local time drifting the fixture. Pinned to a fixed mid-June date instead, plus a standing round-trip regression assertion.

## Evidence

- `scripts/handover/test-headed-arm.sh`: baseline green pre-change; green after both item-1 fixes; 20/20 clean on a local repeat loop (both before and after the CR-driven rework).
- RED control (scratchpad, not shipped) reproduced case 14's original flake by widening the gap between the background releaser's two writes: 0/20 clean on the pre-fix write order at gap≥0.03s (wrong log phrase, or an actual duplicate konsole launch).
- `scripts/handover/test-arm-resume-long-gap.sh`: 37/37 pass after items 2 and 3.
- E2 RED control: attempted with a real historical DST transition (Sao Paulo 2018-11-04 midnight spring-forward) — not reproducible on this platform (glibc mktime normalizes the gap); the fix removes the "today" dependency regardless, and the new round-trip assertion stands as the durable guard (flagged as a Suggestion in `/pr-check` round 2 — the assertion doesn't catch every possible regression of this class; disclosed here rather than overclaiming).
- E1 RED control: arm-resume has no clock-override seam; modeled its documented `--time` rule in isolation — no observable rc flip reproduced at delays up to 30 min. Fix applied defensively (same class as the already-fixed `near_hhmm()`).
- Impacted suites (reference the touched files) all green: `console-kit/test-headed-arm-leg.sh`, `scripts/lib/test-bank-preflight.sh`, `test-arm-resume-proxy.sh`, `test-worker-lifecycle.sh`.
- `shellcheck` clean on both touched files.
- `known-findings.sh --diff` pre-rebuttal: flagged `octal-leading-zero` on `test-arm-resume-long-gap.sh:323,382` — both are decimal `[ ]` comparisons / an integer counter increment in arithmetic context, not octal-risk leading-zero operands; non-issue per the class's own documented rebuttal.
- `/pr-check`: round 1 found one real Important finding (codex-1, the background-releaser race above) — fixed in a follow-up commit; round 2 clean (0 Critical/Important, 1 non-blocking Suggestion on the E2 round-trip assertion's coverage, disclosed above). Marker cleared at `fd59a06c`.

**Not in this PR:** `headed-arm.sh`'s dedup mechanism, the T15/T19 race in `test-arm-resume-queue-lock.sh` (confirmed unrelated to E1 after investigation), anything under `scripts/cr/`, `scripts/adopt.sh`/`scripts/himmelctl/`. Test-only changes throughout — no launcher/production behaviour change.

Platforms tested: linux
Security reviewed: manual — test-only; no launcher behaviour change; no new exec surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cCzxEv9MuVRdeSiZeT41V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved handover test reliability around date handling, midnight-boundary calculations, and local-time conversions.
  - Added validation to detect fixture drift and ensure expected failures are reported clearly.
  - Strengthened session and lock-handling coverage by making retry scenarios deterministic.
  - Updated assertions to verify the correct claim-retry deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->