### PR TITLE
fix(cr): [HIMMEL-2906] fingerprint fold classifies identifier components inside expressions (fp3)

### DIFF
--- a/scripts/cr/finding-fingerprint.js
+++ b/scripts/cr/finding-fingerprint.js
@@ -33,9 +33,14 @@ function isCodeToken(token) {
 // bracket or comma is exactly the kind of boundary that should not merge two
 // components' case decisions.
 function foldTokenCase(token) {
+  // codex-1, HIMMEL-2906 round 1: the separator spans (whatever falls
+  // outside [A-Za-z0-9_$.]) are prose too — a non-ASCII letter like `É` is
+  // itself outside that class, so leaving separators unfolded let case-only
+  // Unicode prose (`Échec` vs `échec`) escape the fold. Every piece lowercases
+  // unless it is itself an identifier-shaped component.
   return token
     .split(/([^A-Za-z0-9_$.]+)/)
-    .map((piece, index) => (index % 2 === 1 ? piece : (isCodeToken(piece) ? piece : piece.toLowerCase())))
+    .map((piece, index) => (index % 2 === 0 && isCodeToken(piece) ? piece : piece.toLowerCase()))
     .join('');
 }
 

--- a/scripts/cr/finding-fingerprint.js
+++ b/scripts/cr/finding-fingerprint.js
@@ -25,12 +25,26 @@ function isCodeToken(token) {
     /^[A-Za-z0-9_$]+(?:\.[A-Za-z0-9_$]+)+$/.test(core);
 }
 
+// HIMMEL-2906: an identifier embedded in an expression — `config.LOGLEVEL(value)`
+// — fails isCodeToken on the WHOLE token: edge-trimming only strips the two
+// outer edges, so the trailing `)` survives internally and breaks the anchored
+// dotted-name regex. Split on everything outside identifier/dot characters so
+// each component (`config.LOGLEVEL`, `value`) is classified on its own; a
+// bracket or comma is exactly the kind of boundary that should not merge two
+// components' case decisions.
+function foldTokenCase(token) {
+  return token
+    .split(/([^A-Za-z0-9_$.]+)/)
+    .map((piece, index) => (index % 2 === 1 ? piece : (isCodeToken(piece) ? piece : piece.toLowerCase())))
+    .join('');
+}
+
 function foldClaimCase(value) {
   return String(value)
     .split(/(`[^`]*`)/)
     .map((part, index) => (index % 2 === 1
       ? part
-      : part.split(/(\s+)/).map((token) => (isCodeToken(token) ? token : token.toLowerCase())).join('')))
+      : part.split(/(\s+)/).map((token) => foldTokenCase(token)).join('')))
     .join('');
 }
 
@@ -75,11 +89,12 @@ function findingFingerprint(slug, file, text) {
   const digest = crypto.createHash('sha256')
     .update(`${normalizedSlug}${normalizedAnchor}${normalizedClaim}`, 'utf8')
     .digest('hex');
-  // fp2 (HIMMEL-2901): the claim fold changed, so a pre-2901 fp1 row must
-  // never match a claim hashed under the new rules. The ledger is append-only:
-  // old rows keep their fp1 identity and simply stop inheriting across the
+  // fp3 (HIMMEL-2906): the claim fold changed again (component-level case
+  // classification inside expressions), so a pre-2906 fp2 row must never
+  // match a claim hashed under the new rules. The ledger is append-only: old
+  // rows keep their fp1/fp2 identity and simply stop inheriting across the
   // version boundary.
-  return `fp2:${digest}`;
+  return `fp3:${digest}`;
 }
 
 module.exports = {

--- a/scripts/cr/ledger-append.sh
+++ b/scripts/cr/ledger-append.sh
@@ -331,13 +331,18 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TE
   // case-intact, fold everything else. Parity with finding-fingerprint.js.
   const isCodeToken=(t)=>{const c=t.replace(/^[^A-Za-z0-9_$]+/,"").replace(/[^A-Za-z0-9_$]+$/,"");
     return c?(/[a-z][A-Z]/.test(c)||c.includes("_")||/^[A-Za-z0-9_$]+(?:\.[A-Za-z0-9_$]+)+$/.test(c)):false;};
-  const foldClaimCase=(v)=>String(v).split(/(`[^`]*`)/).map((p,i)=>i%2===1?p:p.split(/(\s+)/).map(t=>isCodeToken(t)?t:t.toLowerCase()).join("")).join("");
+  // HIMMEL-2906: classify identifier COMPONENTS inside an expression
+  // (`config.LOGLEVEL(value)`) rather than the whole token — parity with
+  // foldTokenCase in finding-fingerprint.js.
+  const foldTokenCase=(t)=>t.split(/([^A-Za-z0-9_$.]+)/).map((p,i)=>i%2===1?p:(isCodeToken(p)?p:p.toLowerCase())).join("");
+  const foldClaimCase=(v)=>String(v).split(/(`[^`]*`)/).map((p,i)=>i%2===1?p:p.split(/(\s+)/).map(t=>foldTokenCase(t)).join("")).join("");
   const foldClaim=(v)=>foldClaimCase(String(v==null?"":v).replace(/\s+/g," ").trim());
   const normalizeClaim=(v)=>foldClaim(String(v==null?"":v).replace(/^\s*-\s*\[[^\]]+\]\s*:\s*/,"").replace(/\s*\[[^\]\r\n]+:\d+(?:-\d+)?\]\s*$/,"") );
   const findingFingerprint=(slug,file,text)=>{
     const s=foldWhitespace(slug), a=normalizeFileAnchor(file), c=normalizeClaim(text);
     if(!s||!c) return "";
-    return "fp2:"+crypto.createHash("sha256").update([s,a,c].join(String.fromCharCode(31)),"utf8").digest("hex");
+    // fp3 (HIMMEL-2906): old fp1/fp2 rows keep their identity, append-only.
+    return "fp3:"+crypto.createHash("sha256").update([s,a,c].join(String.fromCharCode(31)),"utf8").digest("hex");
   };
   const led=e.LEDGER;
   // HIMMEL-2078: batch rows carry spec.text straight from a caller-built JSON

--- a/scripts/cr/ledger-append.sh
+++ b/scripts/cr/ledger-append.sh
@@ -333,8 +333,10 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TE
     return c?(/[a-z][A-Z]/.test(c)||c.includes("_")||/^[A-Za-z0-9_$]+(?:\.[A-Za-z0-9_$]+)+$/.test(c)):false;};
   // HIMMEL-2906: classify identifier COMPONENTS inside an expression
   // (`config.LOGLEVEL(value)`) rather than the whole token — parity with
-  // foldTokenCase in finding-fingerprint.js.
-  const foldTokenCase=(t)=>t.split(/([^A-Za-z0-9_$.]+)/).map((p,i)=>i%2===1?p:(isCodeToken(p)?p:p.toLowerCase())).join("");
+  // foldTokenCase in finding-fingerprint.js. codex-1 round 1: separator spans
+  // fold too (a non-ASCII letter is itself outside [A-Za-z0-9_$.]), or
+  // case-only Unicode prose escapes the fold.
+  const foldTokenCase=(t)=>t.split(/([^A-Za-z0-9_$.]+)/).map((p,i)=>i%2===0&&isCodeToken(p)?p:p.toLowerCase()).join("");
   const foldClaimCase=(v)=>String(v).split(/(`[^`]*`)/).map((p,i)=>i%2===1?p:p.split(/(\s+)/).map(t=>foldTokenCase(t)).join("")).join("");
   const foldClaim=(v)=>foldClaimCase(String(v==null?"":v).replace(/\s+/g," ").trim());
   const normalizeClaim=(v)=>foldClaim(String(v==null?"":v).replace(/^\s*-\s*\[[^\]]+\]\s*:\s*/,"").replace(/\s*\[[^\]\r\n]+:\d+(?:-\d+)?\]\s*$/,"") );

--- a/scripts/cr/test-finding-reraise.sh
+++ b/scripts/cr/test-finding-reraise.sh
@@ -28,10 +28,10 @@ assert_lacks() {
     case "$1" in *"$2"*) fail "$3 (unexpected '$2')" ;; *) pass "$3" ;; esac
 }
 assert_fingerprint() {
-    if grep -qE '^fp2:[0-9a-f]{64}$' <<< "$1"; then
+    if grep -qE '^fp3:[0-9a-f]{64}$' <<< "$1"; then
         pass "$2"
     else
-        fail "$2 (got '$1', want fp2:<64 lowercase hex>)"
+        fail "$2 (got '$1', want fp3:<64 lowercase hex>)"
     fi
 }
 
@@ -790,6 +790,86 @@ run_panel 5 'THE HANDLER reads config.LOGLEVEL. [scripts/cr/case.sh:95]' imp "$t
 assert_eq "$?" "0" "dotted-sentence prose-case panel run succeeds"
 assert_has "$(cat "$tmp/ds5.out")" "RE-RAISE (r3 disproved)" \
     "prose case around an identical dotted identifier still folds onto one fingerprint"
+
+# HIMMEL-2906: an identifier embedded in an expression is still an identifier —
+# isCodeToken classified the WHOLE token, so the trailing `)` in
+# `config.LOGLEVEL(value)` broke the anchored dotted-name regex and both cases
+# folded together (fp2). fp3 classifies components split on non-identifier
+# characters instead.
+checkout_branch expression-identifier-case
+head_ei3="$(advance_head expression-identifier-r3)"
+set_registry critic-a
+ei_claim='The handler reads config.LOGLEVEL(value) [scripts/cr/case.sh:100]'
+run_panel 3 "$ei_claim" imp "$tmp/ei3.out" "$tmp/ei3.err"
+assert_eq "$?" "0" "expression-identifier seed panel run succeeds"
+id_ei3="$(finding_id_at expression-identifier-case "$head_ei3")"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch expression-identifier-case --head "$head_ei3" \
+        --id "$id_ei3" --set verdict=disproved --reason 'the LOGLEVEL(value) claim is disproved'
+) >/dev/null 2>"$tmp/ei3-amend.err"
+assert_eq "$?" "0" "expression-identifier fixture accepts the disproof"
+advance_head expression-identifier-r4 >/dev/null
+run_panel 4 'The handler reads config.loglevel(value) [scripts/cr/case.sh:110]' imp "$tmp/ei4.out" "$tmp/ei4.err"
+assert_eq "$?" "0" "expression-identifier case panel run succeeds"
+assert_has "$(cat "$tmp/ei4.out")" "## Important Issues (1 found)" \
+    "an identifier embedded in a call expression is fingerprint-significant"
+assert_lacks "$(cat "$tmp/ei4.out")" "RE-RAISE (" \
+    "a differing embedded identifier does not inherit a disposition through the call expression"
+advance_head expression-identifier-r5 >/dev/null
+run_panel 5 'THE HANDLER reads config.LOGLEVEL(value) [scripts/cr/case.sh:100]' imp "$tmp/ei5.out" "$tmp/ei5.err"
+assert_eq "$?" "0" "expression-identifier prose-case panel run succeeds"
+assert_has "$(cat "$tmp/ei5.out")" "RE-RAISE (r3 disproved)" \
+    "prose case around an identical embedded identifier still folds onto one fingerprint"
+
+# Bracket/comma-joined components each keep their own case verdict — a
+# separator between two identifier-shaped fragments must not merge their case
+# decisions into one whole-token classification.
+checkout_branch bracket-comma-identifier-case
+head_bc3="$(advance_head bracket-comma-r3)"
+set_registry critic-a
+bc_claim='items[0].fooBar, other_Thing disagree [scripts/cr/case.sh:120]'
+run_panel 3 "$bc_claim" imp "$tmp/bc3.out" "$tmp/bc3.err"
+assert_eq "$?" "0" "bracket-comma seed panel run succeeds"
+id_bc3="$(finding_id_at bracket-comma-identifier-case "$head_bc3")"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch bracket-comma-identifier-case --head "$head_bc3" \
+        --id "$id_bc3" --set verdict=disproved --reason 'the fooBar/other_Thing claim is disproved'
+) >/dev/null 2>"$tmp/bc3-amend.err"
+assert_eq "$?" "0" "bracket-comma fixture accepts the disproof"
+advance_head bracket-comma-r4 >/dev/null
+run_panel 4 'items[0].foobar, other_thing disagree [scripts/cr/case.sh:130]' imp "$tmp/bc4.out" "$tmp/bc4.err"
+assert_eq "$?" "0" "bracket-comma case panel run succeeds"
+assert_has "$(cat "$tmp/bc4.out")" "## Important Issues (1 found)" \
+    "each bracket/comma-joined component is fingerprint-significant on its own"
+assert_lacks "$(cat "$tmp/bc4.out")" "RE-RAISE (" \
+    "differing bracket/comma-joined components do not inherit a disposition"
+advance_head bracket-comma-r5 >/dev/null
+run_panel 5 'ITEMS[0].fooBar, other_Thing DISAGREE [scripts/cr/case.sh:140]' imp "$tmp/bc5.out" "$tmp/bc5.err"
+assert_eq "$?" "0" "bracket-comma prose-case panel run succeeds"
+assert_has "$(cat "$tmp/bc5.out")" "RE-RAISE (r3 disproved)" \
+    "prose case around identical bracket/comma-joined components still folds onto one fingerprint"
+
+# The deliberate 2901 rule stands: an ALL-CAPS word outside backticks is
+# indistinguishable from prose emphasis, so it still folds even under fp3.
+checkout_branch prose-caps-still-fold
+head_pc3="$(advance_head prose-caps-r3)"
+set_registry critic-a
+run_panel 3 'CACHE cleanup needed [scripts/cr/case.sh:150]' imp "$tmp/pc3.out" "$tmp/pc3.err"
+assert_eq "$?" "0" "prose-caps seed panel run succeeds"
+id_pc3="$(finding_id_at prose-caps-still-fold "$head_pc3")"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch prose-caps-still-fold --head "$head_pc3" \
+        --id "$id_pc3" --set verdict=disproved --reason 'the CACHE claim is disproved'
+) >/dev/null 2>"$tmp/pc3-amend.err"
+assert_eq "$?" "0" "prose-caps fixture accepts the disproof"
+advance_head prose-caps-r4 >/dev/null
+run_panel 4 'cache cleanup needed [scripts/cr/case.sh:160]' imp "$tmp/pc4.out" "$tmp/pc4.err"
+assert_eq "$?" "0" "prose-caps lowercase panel run succeeds"
+assert_has "$(cat "$tmp/pc4.out")" "RE-RAISE (r3 disproved)" \
+    "an ALL-CAPS prose word outside backticks still folds onto the lowercase claim"
 
 # The writer's standalone fingerprint copy must agree with the shared helper on
 # the case rules too, or a row it writes never matches a claim the panel reads.

--- a/scripts/cr/test-finding-reraise.sh
+++ b/scripts/cr/test-finding-reraise.sh
@@ -871,6 +871,27 @@ assert_eq "$?" "0" "prose-caps lowercase panel run succeeds"
 assert_has "$(cat "$tmp/pc4.out")" "RE-RAISE (r3 disproved)" \
     "an ALL-CAPS prose word outside backticks still folds onto the lowercase claim"
 
+# codex-1, HIMMEL-2906 round 1: a non-ASCII letter is itself outside
+# [A-Za-z0-9_$.], so leaving component-splitting's separator spans unfolded
+# let case-only Unicode prose escape the fold entirely.
+checkout_branch unicode-prose-still-folds
+head_up3="$(advance_head unicode-prose-r3)"
+set_registry critic-a
+run_panel 3 'Échec critique detected [scripts/cr/case.sh:170]' imp "$tmp/up3.out" "$tmp/up3.err"
+assert_eq "$?" "0" "unicode-prose seed panel run succeeds"
+id_up3="$(finding_id_at unicode-prose-still-folds "$head_up3")"
+(
+    cd "$repo" || exit 1
+    CR_LEDGER="$ledger" bash "$LEDGER_APPEND" amend --branch unicode-prose-still-folds --head "$head_up3" \
+        --id "$id_up3" --set verdict=disproved --reason 'the Echec claim is disproved'
+) >/dev/null 2>"$tmp/up3-amend.err"
+assert_eq "$?" "0" "unicode-prose fixture accepts the disproof"
+advance_head unicode-prose-r4 >/dev/null
+run_panel 4 'échec critique detected [scripts/cr/case.sh:180]' imp "$tmp/up4.out" "$tmp/up4.err"
+assert_eq "$?" "0" "unicode-prose lowercase panel run succeeds"
+assert_has "$(cat "$tmp/up4.out")" "RE-RAISE (r3 disproved)" \
+    "a non-ASCII prose word outside backticks still folds onto the lowercase claim"
+
 # The writer's standalone fingerprint copy must agree with the shared helper on
 # the case rules too, or a row it writes never matches a claim the panel reads.
 checkout_branch code-case-parity


### PR DESCRIPTION
## Summary

`scripts/cr/finding-fingerprint.js`'s `isCodeToken` (landed as fp2 in #607/HIMMEL-2901) classifies a WHOLE whitespace-delimited token after edge-trimming prose punctuation. An identifier embedded in a call expression fails every rule: `config.LOGLEVEL(value)` edge-trims to `config.LOGLEVEL(value` — the internal `(` breaks the anchored dotted-name regex — so `config.LOGLEVEL(value)` and `config.loglevel(value)` folded to one fingerprint and could inherit each other's disposition.

fp3 splits each non-backtick token on characters outside `[A-Za-z0-9_$.]` and classifies each resulting component independently with the existing camelCase/snake_case/dotted rules, instead of the whole token. Identical change applied to the standalone inline copy in `scripts/cr/ledger-append.sh` (parity enforced by the writer/panel test already in `test-finding-reraise.sh`).

## Regression cases added (`scripts/cr/test-finding-reraise.sh`)

- (a) `config.LOGLEVEL(value)` vs `config.loglevel(value)` at the same anchor do **not** share a fingerprint — RED under fp2, GREEN under fp3.
- (b) Prose case around an identical embedded identifier (`The handler reads config.LOGLEVEL(value)` vs `THE HANDLER reads config.LOGLEVEL(value)`) still folds onto one fingerprint (RE-RAISE fires).
- (c) Bracket/comma-joined components (`items[0].fooBar, other_Thing` vs `items[0].foobar, other_thing`) each keep their own case verdict.
- (d) A plain ALL-CAPS prose word outside backticks still folds (the deliberate HIMMEL-2901 rule) — confirmed unbroken by the refactor.

## RED/GREEN evidence

Reverted the fix locally (`git show HEAD:<file>` over both touched source files) and reran the suite — 6 failures, including the 3 new fp3-boundary assertions plus the 3 `assert_fingerprint` prefix checks (bumped to expect `fp3:`). Restored the fix — suite back to `PASS test-finding-reraise` (0 failures).

## CR round 1 (codex-1, Suggestion, fixed inline)

The panel caught a real regression in the first cut: component-splitting treated every non-`[A-Za-z0-9_$.]` character — including non-ASCII letters like `É` — as an unfolded separator, so `Échec` and `échec` produced different fingerprints. Fixed by lowercasing every piece unless it is itself an identifier-shaped component (ASCII punctuation separators have no case, so this is a no-op for the expression cases above). Added a regression case (`unicode-prose-still-folds`) and re-verified both suites GREEN. Round 2 panel: 0 Critical / 0 Important / 0 Suggestions.

## fp3 boundary note

Same append-only rule as HIMMEL-2901: old fp1/fp2 ledger rows keep their identity and simply stop inheriting across the version boundary — never rewritten.

## Parity note

The writer's standalone inline copy in `ledger-append.sh` was updated identically (same split + per-component classification + separator fold), verified via the existing writer/panel parity test plus a direct manual fingerprint comparison between the two implementations.

## Verification

- `bash scripts/cr/test-finding-reraise.sh` — PASS
- `bash scripts/cr/test-ledger-append.sh` — ALL PASS
- 13 additional impacted suites (every suite referencing `ledger-append`) — all GREEN
- `node --check scripts/cr/finding-fingerprint.js` — OK
- `shellcheck scripts/cr/ledger-append.sh scripts/cr/test-finding-reraise.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHKo5LdfaRvR4A3FrH51vM