### PR TITLE
fix(check-ci): [HIMMEL-2907] a slow healthy shard no longer reads as cannot-evaluate; pending jobs named; default cap 900 s

### DIFF
--- a/scripts/check-ci.sh
+++ b/scripts/check-ci.sh
@@ -29,8 +29,9 @@
 #                   watch can go green before a slower workflow has created
 #                   its check run at all. One settle round bounds that window;
 #                   a workflow that registers even later is out of scope.
-#   --max-wait <sec> bound on each `gh pr checks --watch` round (default 540;
-#                   0 = unbounded, today's behaviour). HIMMEL-2062: CodeRabbit
+#   --max-wait <sec> bound on each `gh pr checks --watch` round (default 900,
+#                   HIMMEL-2907 — the measured slowest shell-unit shard runs
+#                   12m16s-12m45s; 0 = unbounded, today's behaviour). HIMMEL-2062: CodeRabbit
 #                   leaves its rollup row "pending"/"Review queued" long after
 #                   every other check — and, when armed, its own gate status —
 #                   is decidable, so the watch keeps polling well past a 10-
@@ -113,8 +114,8 @@
 #   CHECK_CI_SLEEP_CMD     — the command every wall-clock wait in this script
 #                            goes through (default `sleep`); hermetic suites set
 #                            it to `:` so a simulated poll costs no real seconds
-#   CHECK_CI_MAX_WAIT      — default for --max-wait (flag wins; default 540, 0 =
-#                            unbounded; HIMMEL-2062)
+#   CHECK_CI_MAX_WAIT      — default for --max-wait (flag wins; default 900, 0 =
+#                            unbounded; HIMMEL-2062, raised in HIMMEL-2907)
 #   CR_ESCALATE_WAIT       — --escalate total wait budget (default 600)
 #   CR_ESCALATE_POLL       — --escalate seconds between re-reads (default 120)
 #   CR_PROFILE=none        — this repo has no CodeRabbit: skip the required-signal
@@ -168,7 +169,7 @@ env: CR_PROFILE=none skips the required-CodeRabbit-signal + body-findings + revi
      CR_BOT_LOGINS sets the review-author logins the freshness gate treats as the bot (default coderabbitai)
      CR_ESCALATE_WAIT / CR_ESCALATE_POLL tune --escalate for absent or stale-anchor reviews (defaults 600 / 120 seconds)
      CHECK_CI_SLEEP_CMD replaces the command every wall-clock wait runs (default sleep; hermetic suites set it to :)
-     CHECK_CI_MAX_WAIT sets --max-wait's default (default 540 seconds, 0 = unbounded; HIMMEL-2062)
+     CHECK_CI_MAX_WAIT sets --max-wait's default (default 900 seconds, 0 = unbounded; HIMMEL-2062, raised in HIMMEL-2907)
 note: "armed" above means the required-CodeRabbit-signal + body-findings + review-freshness gates are active —
       DISARMED by default. On a repo that has the CodeRabbit App, arm it once:  git config --local himmel.coderabbit true
       CR_APP=1|0 overrides; CR_PROFILE=none outranks both. On a disarmed repo the CodeRabbit-conditional
@@ -197,7 +198,9 @@ ESCALATE=0
 _cr_head_status_ok=0
 GRACE=180
 SETTLE="${CHECK_CI_SETTLE:-30}"
-MAX_WAIT="${CHECK_CI_MAX_WAIT:-540}"
+# Default 900s (HIMMEL-2907): the measured slowest shell-unit shard runs
+# 12m16s-12m45s, over the prior 540s default.
+MAX_WAIT="${CHECK_CI_MAX_WAIT:-900}"
 POLL="${CHECK_CI_POLL_INTERVAL:-10}"
 # Sleep seam (HIMMEL-1953). EVERY wall-clock wait below goes through this one
 # command word so a hermetic suite can inject `:` and never burn real seconds on

--- a/scripts/check-ci.sh
+++ b/scripts/check-ci.sh
@@ -428,7 +428,25 @@ watch_decidable() {
     return 0
 }
 
+# _pending_checks_report — HIMMEL-2907: names (and counts) the checks still in
+# the "pending" bucket, for the one-time cap-extension notice and the
+# cannot-evaluate line below — a reader should see "shell-unit-shard (ubuntu-
+# latest, 7)" instead of a bare "checks still pending". Fail-safe like
+# watch_decidable: an unreadable/unparsable probe reports zero names rather
+# than fabricating any; callers fall back to generic wording.
+_pending_checks_report() {
+    # shellcheck disable=SC2016  # jq expression, not a shell expansion
+    pr_checks --json bucket,name --jq \
+        '[.[] | select(.bucket == "pending")] as $p | "\($p | length)", ($p | map(.name) | join(", "))' \
+        2>/dev/null
+}
+
 watch_round() {
+    # $1 — extensions still allowed this call (HIMMEL-2907): 1 (default, the
+    # outer caller) permits ONE more full --max-wait round on a cap-with-
+    # pending verdict before refusing; the recursive self-call below passes 0
+    # so a second cap-with-pending exits 2 instead of extending forever.
+    local extend_ok="${1:-1}"
     # Runs one `gh pr checks --watch --fail-fast`, BOUNDED (HIMMEL-2062):
     # foreground would block a session's tool wrapper past its own timeout
     # even after the verdict is decidable, because CodeRabbit's rollup row can
@@ -705,10 +723,27 @@ watch_round() {
     fi
 
     # Cap ONLY: a cap reached with non-CodeRabbit work still pending is not a
-    # decidable verdict — refuse rather than certify green over an unfinished
-    # check. The "decidable" stop already proved this true, so it never hits.
+    # decidable verdict on its own. HIMMEL-2907: nothing failed here (the
+    # check above already returned otherwise) — a slow-but-healthy shard
+    # still mid-run must not read as "cannot evaluate" on the FIRST cap. So
+    # extend once: run one more full --max-wait round before refusing. Only a
+    # SECOND cap-with-pending (extend_ok=0, the recursive call below) exits 2
+    # — the "decidable" stop already proved a bare terminal-check set never
+    # hits this branch, so it never hits.
     if [ "$stopped" = cap ] && ! watch_decidable; then
-        echo "check-ci: watch cap reached with non-CodeRabbit checks still pending — cannot evaluate the gate; re-run (raise --max-wait). Do NOT infer state from log absence — verify directly: gh pr view <PR> --json state (HIMMEL-2206)" >&2
+        local report pending_n pending_names
+        report=$(_pending_checks_report)
+        pending_n=${report%%$'\n'*}
+        case "$pending_n" in
+            ''|*[!0-9]*) pending_n=0; pending_names="" ;;
+            *) pending_names=${report#*$'\n'} ;;
+        esac
+        if [ "$extend_ok" -eq 1 ]; then
+            echo "check-ci: WAITING ${pending_n} pending (${pending_names:-unnamed}) — extending once (HIMMEL-2907)" >&2
+            watch_round 0
+            return $?
+        fi
+        echo "check-ci: watch cap reached with non-CodeRabbit checks still pending (${pending_names:-unnamed}) — cannot evaluate the gate; re-run (raise --max-wait). Do NOT infer state from log absence — verify directly: gh pr view <PR> --json state (HIMMEL-2206)" >&2
         exit 2
     fi
 

--- a/scripts/test-check-ci.sh
+++ b/scripts/test-check-ci.sh
@@ -494,6 +494,23 @@ case " $* " in
         # "CHECKCI_OK\n<pending names>" shape.
         case " $* " in
             *"bucket,name"*)
+                # HIMMEL-2907: _pending_checks_report's --jq is a DIFFERENT
+                # shape over these SAME --json bucket,name fields —
+                # "<count>\n<names>", no CHECKCI_OK sentinel — distinguished
+                # here by its unique "length" substring (nested inside the
+                # bucket,name match so the plain fail-bucket-count probe,
+                # which also says "length" but never "bucket,name", is
+                # untouched) so the WAITING/cannot-evaluate naming cases get
+                # real pending-check data instead of watch_decidable's shape.
+                case " $* " in
+                    *"length"*)
+                        case "$GH_STUB_MODE" in
+                            blocking-cr-decidable) printf '1\nCodeRabbit\n' ;;
+                            blocking-cr-substring) printf '1\ncoderabbit-extra\n' ;;
+                            *) printf '1\nunit-tests\n' ;;
+                        esac
+                        exit 0 ;;
+                esac
                 case "$GH_STUB_MODE" in
                     blocking-cr-decidable) printf 'CHECKCI_OK\nCodeRabbit\n' ;;
                     # codex-2, HIMMEL-2062 CR round 1: a pending check whose
@@ -529,7 +546,7 @@ case " $* " in
             # shapes (0 failed) — the cap/decidable path must not misread the
             # generic default (1 failed, meant for the red-confirm caller) as
             # a red verdict. blocking-cap-red is the one case that IS red.
-            blocking-cr-decidable|blocking-cap-pending|blocking-cr-substring) echo 0 ;;
+            blocking-cr-decidable|blocking-cap-pending|blocking-cr-substring|blocking-cap-extend) echo 0 ;;
             blocking-cap-red) echo 1 ;;
             *) echo 1 ;;
         esac
@@ -616,6 +633,19 @@ case "$GH_STUB_MODE" in
         exit 8 ;;
     blocking-cap-red)
         if [ "$is_watch" -eq 1 ]; then sleep 3; echo "X ci fail"; exit 1; fi
+        exit 8 ;;
+    blocking-cap-extend)
+        # HIMMEL-2907: round 1 runs past the cap exactly like blocking-cap-
+        # pending (a healthy shard still mid-run); round 2 — check-ci.sh's
+        # one-time extension — resolves green immediately, the same shape a
+        # real slow-but-healthy shard finishing during the extra --max-wait
+        # window would produce.
+        if [ "$is_watch" -eq 1 ]; then
+            w=$(cat "$GH_STUB_WATCH" 2>/dev/null); w=${w:-0}
+            echo $((w+1)) > "$GH_STUB_WATCH"
+            if [ "$w" -eq 0 ]; then sleep 3; fi
+            echo "All checks were successful"; exit 0
+        fi
         exit 8 ;;
     *)
         echo "gh stub: unknown GH_STUB_MODE '$GH_STUB_MODE'" >&2; exit 99 ;;
@@ -2085,6 +2115,44 @@ else
     fail "106b the TERM trap itself actually executes on early stop" "term-trap-fired marker never appeared — the trap did not run"
 fi
 
+# --- HIMMEL-2907: a cap reached with nothing failed extends ONCE for one more
+# full --max-wait round before refusing — a slow-but-healthy shard (shell-unit
+# shard 7, 12m16s-12m45s) must not read as "cannot evaluate" on the first cap.
+
+# 2907-a — RED control: the pending shard finishes during the one-time
+# extension (round 1 hits the cap with the check still running; round 2 —
+# the extension — resolves green). Today this is rc 2; after the fix rc 0,
+# with the WAITING notice naming the count and the still-pending job.
+run blocking-cap-extend --max-wait 1
+assert_rc 0 "2907-a a slow-but-healthy shard resolves after the one-time extension"
+assert_err_has "WAITING 1 pending (unit-tests) — extending once (HIMMEL-2907)" "2907-a WAITING notice names the pending count and job"
+assert_out_has "all checks green + all review threads resolved" "2907-a eventual green verdict"
+
+# 2907-b — negative control: a check that stays pending PAST the extension
+# (blocking-cap-pending, same stub cases 97/100/101 exercise) must still exit
+# 2 — exactly ONE "WAITING" notice is emitted, proving the extension is not
+# infinite — and the final cannot-evaluate line names the pending job.
+run blocking-cap-pending --max-wait 1
+assert_rc 2 "2907-b a check that never resolves still exits 2 after the one extension"
+waiting_count=$(printf '%s' "$ERR" | grep -c "WAITING")
+if [ "$waiting_count" -eq 1 ]; then
+    pass "2907-b extends exactly once, not infinitely"
+else
+    fail "2907-b extends exactly once, not infinitely" "WAITING appeared $waiting_count times, want 1"
+fi
+assert_err_has "still pending (unit-tests)" "2907-b the exit-2 line names the pending job"
+
+# 2907-c — negative control: a FAILED check alongside a pending one at cap
+# must red_exit immediately (the failed-bucket probe is checked before the
+# extend decision) — no WAITING notice, no extension.
+run blocking-cap-red --max-wait 1
+assert_rc 1 "2907-c a failed check at cap still exits 1 immediately"
+if printf '%s' "$ERR" | grep -iF -- "WAITING" >/dev/null; then
+    fail "2907-c no WAITING notice on a genuinely red cap" "stderr: $ERR"
+else
+    pass "2907-c no WAITING notice on a genuinely red cap"
+fi
+
 # --- HIMMEL-2278: the machine-generated-PR class ----------------------------
 #
 # Baseline for every case here: `cr-absent` — checks green, threads clean, and
@@ -2329,5 +2397,5 @@ unset CR_CLI_MARKER
 
 echo
 echo "ran $COUNT cases; PASS=$PASS FAIL=$FAIL"
-if [ "$COUNT" -ne 144 ]; then echo "CASE-COUNT MISMATCH: ran $COUNT want 144"; exit 1; fi
+if [ "$COUNT" -ne 147 ]; then echo "CASE-COUNT MISMATCH: ran $COUNT want 147"; exit 1; fi
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/test-check-ci.sh
+++ b/scripts/test-check-ci.sh
@@ -2153,6 +2153,14 @@ else
     pass "2907-c no WAITING notice on a genuinely red cap"
 fi
 
+# 2907-d — the default --max-wait is now 900s, covering the measured slowest
+# shell-unit shard (12m16s-12m45s) with margin.
+if grep -Fq 'CHECK_CI_MAX_WAIT:-900' "$SCRIPT"; then
+    pass "2907-d default --max-wait raised to 900s"
+else
+    fail "2907-d default --max-wait raised to 900s" "MAX_WAIT default is not 900 in $SCRIPT"
+fi
+
 # --- HIMMEL-2278: the machine-generated-PR class ----------------------------
 #
 # Baseline for every case here: `cr-absent` — checks green, threads clean, and


### PR DESCRIPTION
## Summary

`scripts/check-ci.sh` bounds each `gh pr checks --watch` round with `--max-wait` (default `CHECK_CI_MAX_WAIT`, HIMMEL-2062). The `shell-unit-shard (ubuntu-latest, 7)` job alone runs 12m16s–12m45s (measured on #605), so a watch started while it is mid-run expired the 540s cap and `check-ci` exited **2 "cannot evaluate"** with 19/20 checks green and nothing red — happened twice on #605.

- **Item 1 — extend once.** On cap expiry, if nothing failed and only non-CodeRabbit checks remain `in_progress`/`queued`, `watch_round` now prints `check-ci: WAITING <n> pending (<names>) — extending once (HIMMEL-2907)` and runs one more full `--max-wait` round before refusing. Only a **second** cap-with-pending exits 2.
- **Item 2 — name the pending jobs.** The exit-2 "cannot evaluate" line (and the WAITING notice) now name the still-pending checks via a new `_pending_checks_report` helper, so a reader sees `shell-unit-shard (ubuntu-latest, 7)` instead of a bare line.
- **Item 3 — default cap raised 540s → 900s**, covering the measured slowest shard with margin. `--max-wait`/`CHECK_CI_MAX_WAIT` overrides and `0` (unbounded) are unchanged.

Not in scope: the shard duration itself (HIMMEL-2895), sharding (HIMMEL-2872), merge-on-green's own logic, CodeRabbit handling.

## Evidence

`scripts/test-check-ci.sh` — new cases 2907-a/b/c/d:
- **2907-a (RED→GREEN)**: a stub pending past a tiny `--max-wait`, then flipping to green on the extension round — today exit 2, after the fix exit 0 with the WAITING line present.
- **2907-b (negative control)**: a stub that never resolves still exits 2 — exactly ONE `WAITING` notice (no infinite extension), and the exit-2 line names the pending job.
- **2907-c (negative control)**: a failed check alongside a pending one at cap exits 1 immediately via the existing `red_exit` path — no WAITING notice.
- **2907-d**: pins the new 900s default.

Full suite: 147 cases / 320 assertions, 0 failures. shellcheck clean. Impacted suites (every suite referencing `check-ci`, including the two that consume its exit code) all green: `scripts/handover/test-merge-on-green.sh`, `scripts/cr/test-clear-cr-marker.sh`, `scripts/test-check-ci-forks-probe.sh`, `scripts/test-merge-public-on-green.sh`, `scripts/ci/test-orphan-census.sh`, `scripts/cr/test-cr-tune.sh`, `scripts/cr/test-pr-check-run.sh`, `scripts/graphify/test-graph-cadence.sh`, `scripts/hooks/test-block-tail-pipe-on-gates.sh`, `scripts/hooks/test-block-unresolved-cr-merge.sh`, `scripts/hooks/test-require-quiet-run.sh`, `scripts/lib/test-cr-available.sh`, `scripts/lib/test-cr-high-risk-diff.sh`, `scripts/lib/test-cr-merge-gate.sh`, `scripts/lib/test-cr-review-freshness.sh`.

`/pr-check`: critic panel (codex, paid tier) responded with 0 Critical / 0 Important / 0 Suggestions. CR marker cleared.

This PR's own CI will exercise the new cap for real (public shell-unit shards) — will note the observed behavior once it runs.

## Test plan

- [x] `scripts/test-check-ci.sh` — 147/147 cases, 0 failures
- [x] shellcheck clean on `scripts/check-ci.sh` and `scripts/test-check-ci.sh`
- [x] every suite referencing `check-ci` (impacted suites) green
- [x] `/pr-check` critic panel clean, CR marker cleared
- [ ] observe this PR's own CI run for the extend-once/900s behavior live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fNiy9dETMFYD8EX2VwMg2