### PR TITLE
fix(cr): [HIMMEL-2909] ledger amend inherits the finding's branch; refuses an empty branch

### DIFF
--- a/scripts/cr/ledger-append.sh
+++ b/scripts/cr/ledger-append.sh
@@ -661,7 +661,27 @@ REASON="$reason" DETAIL="$detail" DEFERRED_TO="$deferred_to" TEXT="$text" RAW_TE
       if(k==="line") v=Number(v)||v;
       set[k]=v;
     }
-    const rec={kind:"amend",ts:e.TS,branch:e.BRANCH,target_head:target.head,finding_id:e.ID,
+    // HIMMEL-2909: --branch is not required on amend (unlike finding/avail/
+    // usage), so a caller that omits it used to write branch:"" — a
+    // branch-scoped read then sees the finding but not its disposition. `set`
+    // never carries `branch` (not in the allowed --set keys), so target.branch
+    // is always the original, un-amended branch of the targeted finding row —
+    // inherit it first. Fall back to the current checkout only when the
+    // target itself has none (a legacy pre-branch row); refuse rather than
+    // ever write "" again.
+    let branch=e.BRANCH;
+    if(!branch){
+      branch=target.branch||"";
+      if(!branch){
+        try{ branch=cp.execFileSync("git",["branch","--show-current"],{encoding:"utf8",stdio:["ignore","pipe","ignore"]}).trim(); }
+        catch{ branch=""; }
+      }
+      if(!branch){
+        process.stderr.write("ledger-append.sh: amend for "+e.ID+" has no --branch, the target finding row carries none, and the current checkout is not on a branch (detached HEAD) - refusing to write an empty branch (HIMMEL-2909).\n");
+        process.exit(3);
+      }
+    }
+    const rec={kind:"amend",ts:e.TS,branch,target_head:target.head,finding_id:e.ID,
                artifact:e.ARTIFACT,perspective:e.PERSPECTIVE,set,reason:e.REASON};
     // HIMMEL-2901: the round a verdict was ADJUDICATED in is not the round the
     // finding was produced in. Record it on the amend event so the reader can

--- a/scripts/cr/test-ledger-append.sh
+++ b/scripts/cr/test-ledger-append.sh
@@ -468,6 +468,38 @@ check "the original finding line is untouched" "$(L="$AM" node -e 'const o=requi
 check "amend records the target + the set" "$(L="$AM" node -e 'const o=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).find(r=>r.kind==="amend");console.log(o.target_head+","+o.finding_id+","+o.set.severity)')" "AH1,codex-adv-1,sug"
 check "amend records the reason" "$(L="$AM" node -e 'const o=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).find(r=>r.kind==="amend");console.log(o.reason)')" "out of diff, pre-existing, already public"
 
+# HIMMEL-2909: amend without --branch used to write branch:"" — a
+# branch-scoped read then sees the finding but not its disposition. It must
+# inherit the branch of the finding row it targets (never "").
+check "amend without --branch inherits the finding's branch" "$(L="$AM" node -e 'const o=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).find(r=>r.kind==="amend");console.log(o.branch)')" "b"
+
+# Control: an explicit --branch is never overridden by inheritance.
+BR="$tmp/branch-inherit.jsonl"; : > "$BR"
+CR_LEDGER="$BR" bash "$LA" finding --branch origin-branch --head BH1 --model m --id find-br-1 --severity imp --file f --line 3 --verdict agreed
+CR_LEDGER="$BR" bash "$LA" amend --branch explicit-branch --head BH1 --id find-br-1 --set severity=sug --reason "explicit branch must win"
+check "amend with an explicit --branch keeps it (never overridden)" "$(L="$BR" node -e 'const o=require("fs").readFileSync(process.env.L,"utf8").trim().split(String.fromCharCode(10)).map(JSON.parse).find(r=>r.kind==="amend");console.log(o.branch)')" "explicit-branch"
+
+# Negative: the target finding row itself carries no branch (a legacy
+# pre-branch row) and the cwd is not on a branch (detached HEAD) — no branch
+# to inherit and no fallback, so this must refuse loudly rather than write "".
+DET="$tmp/detached-repo"; mkdir -p "$DET"
+git -C "$DET" init -q
+git -C "$DET" -c user.email=t@t.example -c user.name=t commit -q --allow-empty -m init
+git -C "$DET" checkout -q --detach HEAD
+NB="$tmp/no-branch-target.jsonl"; : > "$NB"
+CR_LEDGER="$NB" bash "$LA" finding --head NBH1 --model m --id find-nb-1 --severity imp --file f --line 3 --verdict agreed
+(cd "$DET" && CR_LEDGER="$NB" bash "$LA" amend --head NBH1 --id find-nb-1 --set severity=sug --reason "no branch to inherit, detached HEAD") 2>"$tmp/no-branch.err"
+check "amend refuses when the target has no branch and HEAD is detached (HIMMEL-2909)" "$?" "3"
+check "amend refusal on a branchless target names the reason" "$(grep -c 'is not on a branch' "$tmp/no-branch.err")" "1"
+check "amend refusal on a branchless target wrote nothing" "$(wc -l < "$NB" | tr -d ' ')" "1"
+
+# Negative (ticket-exact fixture): no matching finding row at all, also run
+# from a detached HEAD — must still refuse (the pre-existing "nothing
+# amended" refusal), never fall through to writing an empty branch.
+(cd "$DET" && CR_LEDGER="$NB" bash "$LA" amend --head NBH1 --id no-such-finding --set severity=sug --reason x) 2>"$tmp/no-match-detached.err"
+check "amend with no matching row + detached HEAD still refuses" "$?" "3"
+check "amend with no matching row + detached HEAD wrote nothing" "$(wc -l < "$NB" | tr -d ' ')" "1"
+
 # The whole point of the verb: it must NEVER report success without writing.
 CR_LEDGER="$AM" bash "$LA" amend --head AH1 --id no-such-finding --set severity=sug --reason x 2>"$tmp/noop.err"
 check "amend with no target exits non-zero" "$?" "3"


### PR DESCRIPTION
## Item 1 — amend inherits the branch (shipped)

`scripts/cr/ledger-append.sh amend` wrote `branch:""` whenever `--branch` was
omitted (default), because the manual `/pr-check` amend shape in
`.claude/commands/pr-check.md` never passes it (finding rows always carry
theirs). A branch-scoped read then sees the finding but not its
disposition — the console misread #608/#609 exactly this way tonight.

**Fix:** `amend` now inherits the target finding row's branch when
`--branch` is absent (`--set` never touches `branch`, so the row's original
value is always authoritative); falls back to `git branch --show-current`
only when the row itself carries none; refuses loudly (rc=3) rather than
ever write `""` again. An explicit `--branch` is never overridden.

**RED/GREEN** (`scripts/cr/test-ledger-append.sh`):
- amend without `--branch` against a seeded finding row → the amend row's
  branch equals the finding's
- explicit `--branch` still wins (control)
- target has no branch + detached HEAD (no fallback) → refuses with a
  HIMMEL-2909-tagged error
- ticket-exact fixture: no matching row + detached HEAD → still refuses
  (pre-existing "nothing amended" refusal, verified to still hold)

**Evidence:** `test-ledger-append.sh` GREEN plus every impacted suite
(`git grep -l ledger-append -- 'scripts/**/test-*.sh'`): `test-clear-cr-marker`,
`test-codex-adv-harvest`, `test-cr-scores`, `test-critic-panel-instrumentation`,
`test-critic-panel-triviality`, `test-critic-panel`, `test-finding-reraise`,
`test-handover-bridge`, `test-pr-check-context`, `test-pr-check-rounds`,
`test-pr-check-run`, `test-write-verdicts`, `test-quota-gauge-claude-writer`,
`test-cr-high-risk-diff` — all GREEN through `quiet-run`. `shellcheck` clean
on both touched files (no JS touched).

## Item 2 — NOT shipped here (see FINDING to console)

The ticket describes "the step that persists verdicts when the marker
clears" auto-promoting `agreed` findings to a terminal `fixed`/`disproved`/
`deferred` verdict read from "the verdict file." Investigation found:

- `write-verdicts.sh` (the only verdict-file writer) validates exactly
  `agreed|disproved|conflict|unaddressed|deferred` — it never writes or
  accepts `fixed`.
- `clear-cr-marker.sh` has **zero** ledger-write calls — it is read-only; the
  runbook (`pr-check.md` step 4.5) has the *session* run `ledger-append.sh
  amend` by hand before invoking the gate. (`fixed` IS a real, precedented
  ledger verdict — seen live in this branch's own historical rows — it's
  just set manually via `amend`, never through the verdict-file mechanism
  the ticket describes.)

So there is no existing "persist step" to extend with a ~60-line patch; it
would mean designing a new post-clear hook into a 1142-line gate script,
which is a real design decision, not a bugfix. Per this leg's own contract
("if the persist step lives in a place where this is not test-only-cheap,
post FINDING with the shape and ship item 1 alone"), item 1 ships alone and
item 2's shape is being handed to the console/ticket for a follow-up.

## /pr-check evidence

Round 1/3, codex critic responded clean (0 crit / 0 imp / 0 sug). Marker
cleared via `clear-cr-marker.sh` — `CR clean — marker cleared`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DD4r3QYzSuHYL88opG5LL8