### PR TITLE
fix(setup,himmelctl): [HIMMEL-2905] shell-safe hook command path; clone-target suite asserts per platform

### DIFF
--- a/scripts/himmelctl/test/test-wizard-himmel-clone-target.sh
+++ b/scripts/himmelctl/test/test-wizard-himmel-clone-target.sh
@@ -34,6 +34,9 @@
 #   e. ...and still reads n/a on a devOverlay:false (plain adopter) record, and
 #      an item WITHOUT contributorScopes reads n/a on both. Without (e) the
 #      change would be a blanket turn-everything-on.
+#   a4. platform control — the remedy assertion in a/a2 follows uname, so Git
+#      Bash asserts the pwsh rendering the diagnostic actually prints there
+#      instead of reddening on correct behaviour (HIMMEL-2905).
 
 set -euo pipefail
 
@@ -89,6 +92,28 @@ run_install() {
       "$node_bin" "$wizard" install --dry-run "$@" </dev/null 2>&1 )
 }
 
+# overlay_remedy_ok <output> <posix_literal> <win_regex> — does <output> name the
+# contributor primitive the diagnostic renders on THIS platform?
+#
+# HIMMEL-2905: bin.js prints displayCommand(deriveOverlayCommand()), which is
+# `bash <clone>/scripts/setup.sh` on POSIX but
+# `<pwsh> -ExecutionPolicy Bypass -File <clone>\scripts\setup.ps1` on win32 —
+# CodeRabbit round 1 on #605, because `bash …setup.ps1` is unrunnable there.
+# Asserting the POSIX rendering unconditionally therefore REJECTS correct
+# behaviour under Git Bash and reddens this suite (and its parent
+# scripts/test-adopt.sh) on a platform CI does not run. The Windows arm matches
+# the invariant part of the line rather than a full literal: resolvePowershell()
+# picks the interpreter at runtime, so the leading argv element is not
+# predictable. Returns an rc instead of calling fail(), so case a4 below can
+# exercise BOTH arms.
+overlay_remedy_ok() {
+  local _out="$1" _posix="$2" _win="$3"
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) grepq "$_out" -E -- "$_win" ;;
+    *)                    grepq "$_out" -F -- "$_posix" ;;
+  esac
+}
+
 # ── case a: RED control — project scope inside the himmel clone is refused ──
 cloneA="$work/a-clone"; make_clone_fixture "$cloneA"
 homeA="$work/a-home"; mkdir -p "$homeA"
@@ -111,15 +136,14 @@ grepq "$outA" 'not valid inside the himmel checkout' \
 cloneA_w=$(winpath "$cloneA")
 grepq "$outA" -F "$cloneA_w" \
   || fail "case a: the refusal must NAME the checkout it refused ($cloneA_w): $outA"
-# On POSIX the contributor primitive is `bash <clone>/scripts/setup.sh`. That
-# string is NOT hardcoded in bin.js — it is rendered from
+# The contributor primitive is NOT hardcoded in bin.js — it is rendered from
 # deriveOverlayCommand(), the same derivation that would actually spawn it, so
-# on Windows the line carries pwsh + -ExecutionPolicy Bypass -File setup.ps1
-# instead of the unrunnable `bash …setup.ps1` (CodeRabbit round 1). Case a3
-# below is the platform-independent control for that; this asserts the POSIX
-# rendering the runner can actually observe.
-grepq "$outA" -F "bash $cloneA_w/scripts/setup.sh" \
-  || fail "case a: the remedy must name the checkout's own scripts/setup.sh (the contributor primitive): $outA"
+# the line carries `bash <clone>/scripts/setup.sh` on POSIX and pwsh +
+# -ExecutionPolicy Bypass -File setup.ps1 on Windows (CodeRabbit round 1).
+# Assert whichever this platform actually renders — see overlay_remedy_ok()
+# (HIMMEL-2905). Case a3 below is the platform-independent control.
+overlay_remedy_ok "$outA" "bash $cloneA_w/scripts/setup.sh" '-ExecutionPolicy Bypass -File .*setup[.]ps1' \
+  || fail "case a: the remedy must name the checkout's own scripts/setup.sh (the contributor primitive) in this platform's rendering: $outA"
 # The node command must be ABSOLUTE (CR round 3): the refusal fires from
 # whatever subdirectory the operator ran it in — which is where they paste it
 # back — and a relative `node scripts/himmelctl/bin.js` only resolves from the
@@ -180,11 +204,41 @@ set -e
 [ "$rcA2" -ne 0 ] \
   || fail "case a2: --scope project inside a himmel clone whose path contains a space should still be refused (got rc=$rcA2): $outA2"
 cloneA2_w=$(winpath "$cloneA2")
-grepq "$outA2" -F "bash '$cloneA2_w/scripts/setup.sh'" \
-  || fail "case a2: a setup.sh path containing a space must be SHELL-QUOTED in the remedy, or the printed command runs the wrong thing: $outA2"
+overlay_remedy_ok "$outA2" "bash '$cloneA2_w/scripts/setup.sh'" "-ExecutionPolicy Bypass -File '[^']*a2 clone with space[^']*setup[.]ps1'" \
+  || fail "case a2: a setup path containing a space must be SHELL-QUOTED in the remedy, or the printed command runs the wrong thing: $outA2"
 grepq "$outA2" -F "node '$cloneA2_w/scripts/himmelctl/bin.js'" \
   || fail "case a2: the bin.js path containing a space must be SHELL-QUOTED in the remedy too: $outA2"
 echo "ok: case a2 — a checkout path with a space is refused and both remedy commands stay shell-quoted"
+
+# ── case a4: platform control for a/a2 — the assertion arm follows uname ──
+# The bug HIMMEL-2905 closes is a FALSE red on a platform CI does not run (the
+# shell suites are ubuntu-only), so it cannot be reproduced by running this
+# suite here. Exercise overlay_remedy_ok() itself instead, against synthetic
+# renderings, with and without a `uname` that reports Git Bash. The LAST check
+# is the RED control: before the fix the POSIX literal was asserted
+# unconditionally, so a POSIX rendering under a Git-Bash uname PASSED — which
+# is precisely the false red a contributor hits. The stub lives inside this
+# case only; nothing below it runs with a doctored PATH.
+a4_posix_line="derived: bash /x/scripts/setup.sh"
+a4_pwsh_line="derived: /usr/bin/pwsh -ExecutionPolicy Bypass -File /x/scripts/setup.ps1"
+a4_posix_lit="bash /x/scripts/setup.sh"
+a4_win_re='-ExecutionPolicy Bypass -File .*setup[.]ps1'
+a4_stub="$work/a4-uname-stub"; mkdir -p "$a4_stub"
+printf '#!/usr/bin/env bash\nprintf "MINGW64_NT-10.0-22631\\n"\n' > "$a4_stub/uname"
+chmod +x "$a4_stub/uname"
+overlay_remedy_ok "$a4_posix_line" "$a4_posix_lit" "$a4_win_re" \
+  || fail "case a4: on POSIX the bash rendering must satisfy the remedy assertion"
+overlay_remedy_ok "$a4_pwsh_line" "$a4_posix_lit" "$a4_win_re" \
+  && fail "case a4: on POSIX the pwsh rendering must NOT satisfy it — the two arms must be distinguishable"
+# shellcheck disable=SC2030,SC2031  # deliberately subshell-LOCAL: the uname stub must not leak past this case
+( PATH="$a4_stub:$PATH"; hash -r 2>/dev/null || true
+  overlay_remedy_ok "$a4_pwsh_line" "$a4_posix_lit" "$a4_win_re" ) \
+  || fail "case a4: under a Git-Bash uname the pwsh rendering must satisfy the remedy assertion"
+# shellcheck disable=SC2030,SC2031  # deliberately subshell-LOCAL: the uname stub must not leak past this case
+( PATH="$a4_stub:$PATH"; hash -r 2>/dev/null || true
+  overlay_remedy_ok "$a4_posix_line" "$a4_posix_lit" "$a4_win_re" ) \
+  && fail "case a4: under a Git-Bash uname the POSIX rendering must FAIL — asserting it unconditionally is the false red HIMMEL-2905 fixes"
+echo "ok: case a4 — the remedy assertion selects its arm from uname (Git Bash asserts the pwsh rendering, POSIX the bash one)"
 
 # ── case c: scope control — user scope inside the clone is unaffected ───────
 cloneC="$work/c-clone"; make_clone_fixture "$cloneC"

--- a/scripts/himmelctl/test/test-wizard-himmel-clone-target.sh
+++ b/scripts/himmelctl/test/test-wizard-himmel-clone-target.sh
@@ -214,28 +214,37 @@ echo "ok: case a2 — a checkout path with a space is refused and both remedy co
 # The bug HIMMEL-2905 closes is a FALSE red on a platform CI does not run (the
 # shell suites are ubuntu-only), so it cannot be reproduced by running this
 # suite here. Exercise overlay_remedy_ok() itself instead, against synthetic
-# renderings, with and without a `uname` that reports Git Bash. The LAST check
-# is the RED control: before the fix the POSIX literal was asserted
-# unconditionally, so a POSIX rendering under a Git-Bash uname PASSED — which
-# is precisely the false red a contributor hits. The stub lives inside this
-# case only; nothing below it runs with a doctored PATH.
+# renderings under a STUBBED uname — BOTH arms stubbed, never the host's own
+# (CR round 1, [codex-1]): asserting the POSIX arm against the real `uname`
+# would itself fail under Git Bash, where the Windows arm is selected — the
+# very platform this case exists to protect. The LAST check is the RED control:
+# before the fix the POSIX literal was asserted unconditionally, so a POSIX
+# rendering under a Git-Bash uname PASSED, which is precisely the false red a
+# contributor hits. Each stub lives inside its own subshell; nothing below this
+# case runs with a doctored PATH.
 a4_posix_line="derived: bash /x/scripts/setup.sh"
 a4_pwsh_line="derived: /usr/bin/pwsh -ExecutionPolicy Bypass -File /x/scripts/setup.ps1"
 a4_posix_lit="bash /x/scripts/setup.sh"
 a4_win_re='-ExecutionPolicy Bypass -File .*setup[.]ps1'
-a4_stub="$work/a4-uname-stub"; mkdir -p "$a4_stub"
-printf '#!/usr/bin/env bash\nprintf "MINGW64_NT-10.0-22631\\n"\n' > "$a4_stub/uname"
-chmod +x "$a4_stub/uname"
-overlay_remedy_ok "$a4_posix_line" "$a4_posix_lit" "$a4_win_re" \
-  || fail "case a4: on POSIX the bash rendering must satisfy the remedy assertion"
-overlay_remedy_ok "$a4_pwsh_line" "$a4_posix_lit" "$a4_win_re" \
-  && fail "case a4: on POSIX the pwsh rendering must NOT satisfy it — the two arms must be distinguishable"
+a4_posix_stub="$work/a4-uname-posix"; mkdir -p "$a4_posix_stub"
+printf '#!/usr/bin/env bash\nprintf "Linux\\n"\n' > "$a4_posix_stub/uname"
+a4_win_stub="$work/a4-uname-mingw"; mkdir -p "$a4_win_stub"
+printf '#!/usr/bin/env bash\nprintf "MINGW64_NT-10.0-22631\\n"\n' > "$a4_win_stub/uname"
+chmod +x "$a4_posix_stub/uname" "$a4_win_stub/uname"
 # shellcheck disable=SC2030,SC2031  # deliberately subshell-LOCAL: the uname stub must not leak past this case
-( PATH="$a4_stub:$PATH"; hash -r 2>/dev/null || true
+( PATH="$a4_posix_stub:$PATH"; hash -r 2>/dev/null || true
+  overlay_remedy_ok "$a4_posix_line" "$a4_posix_lit" "$a4_win_re" ) \
+  || fail "case a4: under a POSIX uname the bash rendering must satisfy the remedy assertion"
+# shellcheck disable=SC2030,SC2031  # deliberately subshell-LOCAL: the uname stub must not leak past this case
+( PATH="$a4_posix_stub:$PATH"; hash -r 2>/dev/null || true
+  overlay_remedy_ok "$a4_pwsh_line" "$a4_posix_lit" "$a4_win_re" ) \
+  && fail "case a4: under a POSIX uname the pwsh rendering must NOT satisfy it — the two arms must be distinguishable"
+# shellcheck disable=SC2030,SC2031  # deliberately subshell-LOCAL: the uname stub must not leak past this case
+( PATH="$a4_win_stub:$PATH"; hash -r 2>/dev/null || true
   overlay_remedy_ok "$a4_pwsh_line" "$a4_posix_lit" "$a4_win_re" ) \
   || fail "case a4: under a Git-Bash uname the pwsh rendering must satisfy the remedy assertion"
 # shellcheck disable=SC2030,SC2031  # deliberately subshell-LOCAL: the uname stub must not leak past this case
-( PATH="$a4_stub:$PATH"; hash -r 2>/dev/null || true
+( PATH="$a4_win_stub:$PATH"; hash -r 2>/dev/null || true
   overlay_remedy_ok "$a4_posix_line" "$a4_posix_lit" "$a4_win_re" ) \
   && fail "case a4: under a Git-Bash uname the POSIX rendering must FAIL — asserting it unconditionally is the false red HIMMEL-2905 fixes"
 echo "ok: case a4 — the remedy assertion selects its arm from uname (Git Bash asserts the pwsh rendering, POSIX the bash one)"

--- a/scripts/lib/test-wire-pretooluse-hooks.ps1
+++ b/scripts/lib/test-wire-pretooluse-hooks.ps1
@@ -105,6 +105,11 @@ Check 'quote in prefix: SessionStart path is shell-escaped' (JqVal $s9b '.hooks.
 $s9c = Join-Path $td 's9c.json'
 Set-SessionStartHook -SettingsPath $s9c -Prefix 'C:/himmel' -HookBasename 'we"ird-hook.sh' | Out-Null
 Check 'quote in basename: basename is shell-escaped' (JqVal $s9c '.hooks.SessionStart[0].hooks[0].command') 'bash "C:/himmel/scripts/hooks/we\"ird-hook.sh"'
+# ...and the DEDUP needle is derived from that same escaped string, so a
+# re-wire still REPLACES rather than appending (CR round 3, [codex-1]).
+Set-SessionStartHook -SettingsPath $s9c -Prefix 'C:/moved' -HookBasename 'we"ird-hook.sh' | Out-Null
+Check 'quote in basename: re-wire dedups' (JqVal $s9c '[.hooks.SessionStart[].hooks[]] | length') '1'
+Check 'quote in basename: re-wire repoints' (JqVal $s9c '.hooks.SessionStart[0].hooks[0].command') 'bash "C:/moved/scripts/hooks/we\"ird-hook.sh"'
 
 # 10. NEGATIVE control for 9 (load-bearing): the project-scope prefix is the
 # literal, UNEXPANDED $CLAUDE_PROJECT_DIR that Claude Code expands at hook-fire

--- a/scripts/lib/test-wire-pretooluse-hooks.ps1
+++ b/scripts/lib/test-wire-pretooluse-hooks.ps1
@@ -99,6 +99,13 @@ $s9b = Join-Path $td 's9b.json'
 Set-SessionStartHook -SettingsPath $s9b -Prefix '/opt/we"ird/clone' -HookBasename 'inject-initiative.sh' | Out-Null
 Check 'quote in prefix: SessionStart path is shell-escaped' (JqVal $s9b '.hooks.SessionStart[0].hooks[0].command') 'bash "/opt/we\"ird/clone/scripts/hooks/inject-initiative.sh"'
 
+# 9b. CodeRabbit on PR #612: the hook BASENAME goes through the same escaper.
+# It is an ARGUMENT of Set-SessionStartHook, not a hardcoded literal like the
+# trio's names, so leaving it unescaped covered only half the composer's input.
+$s9c = Join-Path $td 's9c.json'
+Set-SessionStartHook -SettingsPath $s9c -Prefix 'C:/himmel' -HookBasename 'we"ird-hook.sh' | Out-Null
+Check 'quote in basename: basename is shell-escaped' (JqVal $s9c '.hooks.SessionStart[0].hooks[0].command') 'bash "C:/himmel/scripts/hooks/we\"ird-hook.sh"'
+
 # 10. NEGATIVE control for 9 (load-bearing): the project-scope prefix is the
 # literal, UNEXPANDED $CLAUDE_PROJECT_DIR that Claude Code expands at hook-fire
 # time. Escaping its `$` would point every project-scope hook at a path that

--- a/scripts/lib/test-wire-pretooluse-hooks.ps1
+++ b/scripts/lib/test-wire-pretooluse-hooks.ps1
@@ -1,7 +1,9 @@
 # test-wire-pretooluse-hooks.ps1 -- committed PS test for wire-pretooluse-hooks.ps1.
 # Covers: PreToolUse trio wired + forward-slashed/quoted; dedup-by-basename across
 # a clone-path change (SC8); rtk guard preserved; SessionStart shared-array merge +
-# sibling survival; idempotent; invalid JSON refused. Run:
+# sibling survival; idempotent; invalid JSON refused; the hook path is
+# SHELL-ESCAPED while the project-scope $CLAUDE_PROJECT_DIR literal survives
+# unexpanded (HIMMEL-2905). Run:
 #   pwsh -File test-wire-pretooluse-hooks.ps1
 
 $ErrorActionPreference = 'Stop'
@@ -80,6 +82,33 @@ $threw = $false
 try { Set-PretooluseHooks -SettingsPath $s8 -Prefix 'C:/himmel' | Out-Null } catch { $threw = $true }
 if ($threw) { Write-Host 'ok - refuses invalid JSON' } else { Write-Host 'FAIL: invalid JSON not refused'; $fails++ }
 Check 'invalid file unchanged' ((Get-Content $s8 -Raw).Trim()) 'nope {'
+
+# 9. HIMMEL-2905: a prefix carrying shell metacharacters is SHELL-ESCAPED for
+# the double-quoted context the command lands in — twin of case 8f in
+# test-wire-pretooluse-hooks.sh. Pre-fix the composer emitted
+# `bash "/opt/we"ird/clone/.../X.sh"`, whose unmatched quote is a syntax error,
+# so the hook never ran and every installed guard was silently inert there.
+# Asserted as a string equality rather than the bash twin's `bash -n -c`
+# round-trip, so the case needs no bash on PATH; the bash twin carries the
+# round-trip proof.
+$s9 = Join-Path $td 's9.json'
+Set-PretooluseHooks -SettingsPath $s9 -Prefix '/opt/we"ird/clone' | Out-Null
+Check 'quote in prefix: block still wired' (JqVal $s9 '.hooks.PreToolUse | length') '3'
+Check 'quote in prefix: path is shell-escaped' (JqVal $s9 '.hooks.PreToolUse[0].hooks[0].command') 'bash "/opt/we\"ird/clone/scripts/hooks/auto-approve-safe-bash.sh"'
+$s9b = Join-Path $td 's9b.json'
+Set-SessionStartHook -SettingsPath $s9b -Prefix '/opt/we"ird/clone' -HookBasename 'inject-initiative.sh' | Out-Null
+Check 'quote in prefix: SessionStart path is shell-escaped' (JqVal $s9b '.hooks.SessionStart[0].hooks[0].command') 'bash "/opt/we\"ird/clone/scripts/hooks/inject-initiative.sh"'
+
+# 10. NEGATIVE control for 9 (load-bearing): the project-scope prefix is the
+# literal, UNEXPANDED $CLAUDE_PROJECT_DIR that Claude Code expands at hook-fire
+# time. Escaping its `$` would point every project-scope hook at a path that
+# does not exist. Without this case, 9 would pass on a blanket escape.
+$s10 = Join-Path $td 's10.json'
+Set-PretooluseHooks -SettingsPath $s10 -Prefix '$CLAUDE_PROJECT_DIR' | Out-Null
+Check 'project scope: unexpanded literal kept' (JqVal $s10 '.hooks.PreToolUse[0].hooks[0].command') 'bash "$CLAUDE_PROJECT_DIR/scripts/hooks/auto-approve-safe-bash.sh"'
+$s10b = Join-Path $td 's10b.json'
+Set-SessionStartHook -SettingsPath $s10b -Prefix '$CLAUDE_PROJECT_DIR' -HookBasename 'inject-initiative.sh' | Out-Null
+Check 'project scope: SessionStart keeps the literal' (JqVal $s10b '.hooks.SessionStart[0].hooks[0].command') 'bash "$CLAUDE_PROJECT_DIR/scripts/hooks/inject-initiative.sh"'
 
 Remove-Item -Recurse -Force $td
 if ($fails -eq 0) { Write-Host 'ALL PASS' } else { Write-Host "$fails FAILED"; exit 1 }

--- a/scripts/lib/test-wire-pretooluse-hooks.sh
+++ b/scripts/lib/test-wire-pretooluse-hooks.sh
@@ -126,8 +126,49 @@ s8f="$td/s8f.json"
 printf '%s' '{}' > "$s8f"
 bash "$wire" "$s8f" '/opt/we"ird/clone' >/dev/null 2>&1 || true
 check "quote in prefix: block still wired" "$(jq -r '.hooks.PreToolUse | length' "$s8f" 2>/dev/null)" "3"
-check "quote in prefix: prefix survives verbatim in the command" \
-  "$(jq -r '[.hooks.PreToolUse[].hooks[].command | select(contains("/opt/we\"ird/clone"))] | length' "$s8f" 2>/dev/null)" "3"
+# HIMMEL-2905: one layer further out than the JSON. The command is a SHELL
+# string, so the prefix must survive a shell round-trip too -- the pre-fix lib
+# emitted `bash "/opt/we"ird/clone/scripts/hooks/X.sh"`, whose unmatched quote
+# is a syntax error, so the hook (and with it every installed guard) was
+# silently inert on such a checkout. Assert the two properties that matter:
+# the command PARSES, and the single argument a shell would hand to bash is
+# exactly the intended path. RED before the fix: `bash -n -c` exits 2.
+cmd8f=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$s8f" 2>/dev/null)
+if bash -n -c "$cmd8f" 2>/dev/null; then echo "ok - quote in prefix: command parses as shell"
+else echo "FAIL - quote in prefix: command does not parse as shell: [$cmd8f]"; fails=$((fails+1)); fi
+# `${cmd8f#bash }` is the quoted path exactly as written; printf echoes what
+# the shell actually resolved it to -- no eval of the hook itself.
+check "quote in prefix: path round-trips through the shell" \
+  "$(bash -c "printf '%s\n' ${cmd8f#bash }" 2>/dev/null)" \
+  '/opt/we"ird/clone/scripts/hooks/auto-approve-safe-bash.sh'
+# ...and the SessionStart composer, which builds its command the same way.
+s8f2="$td/s8f2.json"
+( . "$wire"; wire_sessionstart_hook "$s8f2" '/opt/we"ird/clone' "inject-initiative.sh" 0 >/dev/null 2>&1 ) || true
+cmd8f2=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$s8f2" 2>/dev/null)
+if bash -n -c "$cmd8f2" 2>/dev/null; then echo "ok - quote in prefix: SessionStart command parses as shell"
+else echo "FAIL - quote in prefix: SessionStart command does not parse as shell: [$cmd8f2]"; fails=$((fails+1)); fi
+check "quote in prefix: SessionStart path round-trips" \
+  "$(bash -c "printf '%s\n' ${cmd8f2#bash }" 2>/dev/null)" \
+  '/opt/we"ird/clone/scripts/hooks/inject-initiative.sh'
+
+# 8g. NEGATIVE control for 8f (load-bearing): the project-scope prefix is the
+# LITERAL, unexpanded `$CLAUDE_PROJECT_DIR` -- Claude Code expands it at
+# hook-fire time. Escaping it (`\$CLAUDE_PROJECT_DIR`) or single-quoting it
+# would kill that expansion and point every project-scope hook at a
+# nonexistent path. Without this case, 8f would pass on a blanket escape.
+s8g="$td/s8g.json"
+bash "$wire" "$s8g" '$CLAUDE_PROJECT_DIR' >/dev/null
+# shellcheck disable=SC2016  # the literal, UNEXPANDED $CLAUDE_PROJECT_DIR is the assertion
+check "project scope: unexpanded \$CLAUDE_PROJECT_DIR kept verbatim" \
+  "$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$s8g")" \
+  'bash "$CLAUDE_PROJECT_DIR/scripts/hooks/auto-approve-safe-bash.sh"'
+s8g2="$td/s8g2.json"
+# shellcheck disable=SC2016  # the literal, UNEXPANDED $CLAUDE_PROJECT_DIR is the assertion
+( . "$wire"; wire_sessionstart_hook "$s8g2" '$CLAUDE_PROJECT_DIR' "inject-initiative.sh" 0 >/dev/null )
+# shellcheck disable=SC2016  # the literal, UNEXPANDED $CLAUDE_PROJECT_DIR is the assertion
+check "project scope: SessionStart keeps the literal too" \
+  "$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$s8g2")" \
+  'bash "$CLAUDE_PROJECT_DIR/scripts/hooks/inject-initiative.sh"'
 
 # 9. invalid JSON -> refused, file unchanged.
 s9="$td/s9.json"

--- a/scripts/lib/test-wire-pretooluse-hooks.sh
+++ b/scripts/lib/test-wire-pretooluse-hooks.sh
@@ -163,6 +163,17 @@ else echo "FAIL - quote in basename: command does not parse as shell: [$cmd8f3]"
 check "quote in basename: path round-trips through the shell" \
   "$(bash -c "printf '%s\n' ${cmd8f3#bash }" 2>/dev/null)" \
   'C:/himmel/scripts/hooks/we"ird-hook.sh'
+# ...and the DEDUP test must still recognise the command it just wrote (CR
+# round 3, [codex-1]). Escaping the basename without re-deriving the needle
+# from the same escaped string left the pattern unable to match its own
+# output, so a re-run APPENDED instead of replacing. RED before that fix:
+# 2 hook objects here, at the OLD path.
+( . "$wire"; wire_sessionstart_hook "$s8f3" "C:/moved" 'we"ird-hook.sh' 0 >/dev/null 2>&1 ) || true
+check "quote in basename: re-wire dedups (no double-wire)" \
+  "$(jq -r '[.hooks.SessionStart[].hooks[]] | length' "$s8f3" 2>/dev/null)" "1"
+check "quote in basename: re-wire repoints at the new clone path" \
+  "$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$s8f3" 2>/dev/null)" \
+  'bash "C:/moved/scripts/hooks/we\"ird-hook.sh"'
 
 # 8g. NEGATIVE control for 8f (load-bearing): the project-scope prefix is the
 # LITERAL, unexpanded `$CLAUDE_PROJECT_DIR` -- Claude Code expands it at

--- a/scripts/lib/test-wire-pretooluse-hooks.sh
+++ b/scripts/lib/test-wire-pretooluse-hooks.sh
@@ -151,6 +151,19 @@ check "quote in prefix: SessionStart path round-trips" \
   "$(bash -c "printf '%s\n' ${cmd8f2#bash }" 2>/dev/null)" \
   '/opt/we"ird/clone/scripts/hooks/inject-initiative.sh'
 
+# 8f2. CodeRabbit on PR #612: the hook BASENAME goes through the same escaper.
+# It is an ARGUMENT of wire_sessionstart_hook (and of the --sessionstart CLI),
+# not a hardcoded literal like the trio's names, so leaving it unescaped made
+# the rule cover only half its own input. Same two properties as 8f.
+s8f3="$td/s8f3.json"
+( . "$wire"; wire_sessionstart_hook "$s8f3" "C:/himmel" 'we"ird-hook.sh' 0 >/dev/null 2>&1 ) || true
+cmd8f3=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$s8f3" 2>/dev/null)
+if bash -n -c "$cmd8f3" 2>/dev/null; then echo "ok - quote in basename: command parses as shell"
+else echo "FAIL - quote in basename: command does not parse as shell: [$cmd8f3]"; fails=$((fails+1)); fi
+check "quote in basename: path round-trips through the shell" \
+  "$(bash -c "printf '%s\n' ${cmd8f3#bash }" 2>/dev/null)" \
+  'C:/himmel/scripts/hooks/we"ird-hook.sh'
+
 # 8g. NEGATIVE control for 8f (load-bearing): the project-scope prefix is the
 # LITERAL, unexpanded `$CLAUDE_PROJECT_DIR` -- Claude Code expands it at
 # hook-fire time. Escaping it (`\$CLAUDE_PROJECT_DIR`) or single-quoting it

--- a/scripts/lib/wire-pretooluse-hooks.ps1
+++ b/scripts/lib/wire-pretooluse-hooks.ps1
@@ -185,8 +185,9 @@ function Set-SessionStartHook {
     $pfx = $Prefix.Replace('\', '/')
     # The command is composed by jq (hookcmd), never by PowerShell string
     # interpolation, so it carries exactly the same shell escaping as the
-    # PreToolUse trio and the bash twin (HIMMEL-2905).
-    $basepat = "scripts/hooks/" + ($HookBasename -replace '\.', '[.]')
+    # PreToolUse trio and the bash twin (HIMMEL-2905). The dedup test is built
+    # from the SAME escaped string inside the same jq program (CR round 3), so
+    # the two can never disagree and no regex-escaping is needed.
     if ($DryRun) { Write-Host "DRY: merge SessionStart hook $HookBasename into $SettingsPath (prefix: $Prefix)"; return }
 
     # Captured native stdout is decoded via [Console]::OutputEncoding, the
@@ -212,10 +213,11 @@ function Set-SessionStartHook {
         $base = Read-SettingsBase -SettingsPath $SettingsPath -Who 'wire-pretooluse-hooks'
         $filter = $WireHookCmdJq + @'
 hookcmd($pfx; $hook) as $cmd
+| ("scripts/hooks/" + shesc($hook)) as $needle
 | .hooks = (.hooks // {})
 | .hooks.SessionStart = ((.hooks.SessionStart // [])
     | map(.hooks = ((.hooks // [])
-        | map(select((.command // "") | test($basepat) | not))))
+        | map(select((.command // "") | contains($needle) | not))))
     | map(select((.hooks | length) > 0)))
 | (.hooks.SessionStart | map(has("matcher") | not) | index(true)) as $idx
 | if $idx == null
@@ -223,7 +225,7 @@ hookcmd($pfx; $hook) as $cmd
   else .hooks.SessionStart[$idx].hooks += [{"type":"command","command":$cmd}]
   end
 '@
-        $out = $base | jq --indent 2 --arg pfx $pfx --arg hook $HookBasename --arg basepat $basepat $filter
+        $out = $base | jq --indent 2 --arg pfx $pfx --arg hook $HookBasename $filter
         if ($LASTEXITCODE -ne 0) { throw "wire-pretooluse-hooks: jq transform failed" }
         Write-SettingsAtomic -SettingsPath $SettingsPath -Json ($out -join "`n")
         Write-Host "  wired SessionStart $HookBasename -> $SettingsPath"

--- a/scripts/lib/wire-pretooluse-hooks.ps1
+++ b/scripts/lib/wire-pretooluse-hooks.ps1
@@ -8,7 +8,9 @@
 #
 # Dedup is by hook BASENAME with REPLACE semantics (a re-run repairs a bad/moved
 # install, never double-wires). Forward-slashes + quotes the hook path so a
-# Windows backslash path does not collapse when the hook command is parsed.
+# Windows backslash path does not collapse when the hook command is parsed, and
+# SHELL-ESCAPES it for the double-quoted context it lands in (HIMMEL-2905) --
+# see $WireHookCmdJq below.
 #
 # The PreToolUse block MERGES; it is never regenerated (HIMMEL-2892). himmel
 # owns exactly one field of an entry it installed -- that entry's `command`.
@@ -25,6 +27,32 @@ param(
     [string]$Prefix,
     [switch]$DryRun
 )
+
+# The hook-command composer, VERBATIM twin of WIRE_HOOK_CMD_JQ in
+# wire-pretooluse-hooks.sh -- keep the two byte-identical. Both the PreToolUse
+# specs and the SessionStart hook object are built through it.
+#
+# HIMMEL-2892 round 6 / HIMMEL-2905: jq escapes the JSON layer, but the
+# `command` it carries is a SHELL string Claude Code hands to a shell. It lands
+# inside DOUBLE quotes, where exactly four characters keep their meaning -- `\`,
+# `"`, `$` and a backtick -- so shesc() backslash-escapes those four and nothing
+# else. Before this, a checkout at e.g. `/opt/we"ird/clone` yielded
+# `bash "/opt/we"ird/clone/.../X.sh"`, whose unmatched quote is a syntax error:
+# the hook never ran and every installed guard was silently inert there.
+#
+# The ONE exemption is the project-scope prefix, the literal UNEXPANDED
+# `$CLAUDE_PROJECT_DIR` that Claude Code expands at hook-fire time -- escaping
+# its `$` would point every project-scope hook at a path that does not exist.
+$WireHookCmdJq = @'
+  def shesc($p):
+    $p | split("\\") | join("\\\\")
+       | split("\"") | join("\\\"")
+       | split("$")  | join("\\$")
+       | split("`")  | join("\\`");
+  def hookcmd($pfx; $rel):
+    "bash \"" + (if $pfx == "$CLAUDE_PROJECT_DIR" then $pfx else shesc($pfx) end)
+    + "/scripts/hooks/" + $rel + "\"";
+'@
 
 function Read-SettingsBase {
     param([Parameter(Mandatory = $true)][string]$SettingsPath, [string]$Who)
@@ -70,9 +98,9 @@ function Set-PretooluseHooks {
     # JSON malformed; jq then rejects --argjson outright and the settings file
     # goes unwired while the caller reads success. The jq program below is the
     # bash twin's, verbatim.
-    $specsProgram = @'
+    $specsProgram = $WireHookCmdJq + @'
     def spec($name; $matcher):
-      ("bash \"" + $pfx + "/scripts/hooks/" + $name + ".sh\"") as $cmd
+      hookcmd($pfx; $name + ".sh") as $cmd
       | { pat: ("scripts/hooks/" + $name + "[.]sh"),
           cmd: $cmd,
           stanza: { matcher: $matcher, hooks: [ { type: "command", command: $cmd } ] } };
@@ -153,7 +181,9 @@ function Set-SessionStartHook {
     )
     if (-not (Get-Command jq -ErrorAction SilentlyContinue)) { throw "wire-pretooluse-hooks: jq required" }
     $pfx = $Prefix.Replace('\', '/')
-    $cmd = "bash `"$pfx/scripts/hooks/$HookBasename`""
+    # The command is composed by jq (hookcmd), never by PowerShell string
+    # interpolation, so it carries exactly the same shell escaping as the
+    # PreToolUse trio and the bash twin (HIMMEL-2905).
     $basepat = "scripts/hooks/" + ($HookBasename -replace '\.', '[.]')
     if ($DryRun) { Write-Host "DRY: merge SessionStart hook $HookBasename into $SettingsPath (prefix: $Prefix)"; return }
 
@@ -178,8 +208,9 @@ function Set-SessionStartHook {
         [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
         $global:OutputEncoding = [System.Text.UTF8Encoding]::new($false)
         $base = Read-SettingsBase -SettingsPath $SettingsPath -Who 'wire-pretooluse-hooks'
-        $filter = @'
-.hooks = (.hooks // {})
+        $filter = $WireHookCmdJq + @'
+hookcmd($pfx; $hook) as $cmd
+| .hooks = (.hooks // {})
 | .hooks.SessionStart = ((.hooks.SessionStart // [])
     | map(.hooks = ((.hooks // [])
         | map(select((.command // "") | test($basepat) | not))))
@@ -190,7 +221,7 @@ function Set-SessionStartHook {
   else .hooks.SessionStart[$idx].hooks += [{"type":"command","command":$cmd}]
   end
 '@
-        $out = $base | jq --indent 2 --arg cmd $cmd --arg basepat $basepat $filter
+        $out = $base | jq --indent 2 --arg pfx $pfx --arg hook $HookBasename --arg basepat $basepat $filter
         if ($LASTEXITCODE -ne 0) { throw "wire-pretooluse-hooks: jq transform failed" }
         Write-SettingsAtomic -SettingsPath $SettingsPath -Json ($out -join "`n")
         Write-Host "  wired SessionStart $HookBasename -> $SettingsPath"

--- a/scripts/lib/wire-pretooluse-hooks.ps1
+++ b/scripts/lib/wire-pretooluse-hooks.ps1
@@ -43,6 +43,8 @@ param(
 # The ONE exemption is the project-scope prefix, the literal UNEXPANDED
 # `$CLAUDE_PROJECT_DIR` that Claude Code expands at hook-fire time -- escaping
 # its `$` would point every project-scope hook at a path that does not exist.
+# $rel, the hook BASENAME, gets no exemption: it is an ARGUMENT of the public
+# Set-SessionStartHook, not a hardcoded literal (CodeRabbit, PR #612).
 $WireHookCmdJq = @'
   def shesc($p):
     $p | split("\\") | join("\\\\")
@@ -51,7 +53,7 @@ $WireHookCmdJq = @'
        | split("`")  | join("\\`");
   def hookcmd($pfx; $rel):
     "bash \"" + (if $pfx == "$CLAUDE_PROJECT_DIR" then $pfx else shesc($pfx) end)
-    + "/scripts/hooks/" + $rel + "\"";
+    + "/scripts/hooks/" + shesc($rel) + "\"";
 '@
 
 function Read-SettingsBase {

--- a/scripts/lib/wire-pretooluse-hooks.sh
+++ b/scripts/lib/wire-pretooluse-hooks.sh
@@ -17,6 +17,9 @@
 # (`bash C:\Users\...\X.sh`) collapses when the hook command is parsed by a shell
 # (`\U`->`U`), so the hook silently never fires.
 #
+# The command is a SHELL string, so the path is also SHELL-ESCAPED for the
+# double-quoted context it lands in -- see WIRE_HOOK_CMD_JQ below (HIMMEL-2905).
+#
 # Dedup is by hook BASENAME with REPLACE semantics: re-running overwrites a
 # previously-wired (incl. broken backslash, or moved-clone) himmel hook rather
 # than appending a duplicate -- so a re-run repairs a bad install and never
@@ -41,6 +44,41 @@
 # Source it to call the functions directly, or invoke via bash (the BASH_SOURCE
 # guard below dispatches `wire-pretooluse-hooks.sh <settings> <prefix>`).
 set -euo pipefail
+
+# The hook-command composer, shared verbatim with the PowerShell twin
+# (wire-pretooluse-hooks.ps1) -- BOTH the PreToolUse specs and the SessionStart
+# hook object are built through it, so the two composers can never drift.
+#
+# HIMMEL-2892 round 6 / HIMMEL-2905: the JSON layer is escaped by jq, but the
+# `command` it carries is a SHELL string that Claude Code hands to a shell. It
+# lands inside DOUBLE quotes, where exactly four characters keep their meaning
+# -- `\`, `"`, `$` and a backtick -- so shesc() backslash-escapes those four
+# and nothing else. Before this, a checkout at e.g. `/opt/we"ird/clone` yielded
+# `bash "/opt/we"ird/clone/.../X.sh"`, whose unmatched quote is a syntax error:
+# the hook never ran and every installed guard was silently inert there.
+# (Backslashes are already forward-slashed by the callers; escaping them keeps
+# the rule complete for the double-quoted context rather than relying on that.)
+#
+# The ONE exemption is the project-scope prefix, which is the literal,
+# UNEXPANDED `$CLAUDE_PROJECT_DIR` -- Claude Code expands it at hook-fire time,
+# so escaping its `$` (or single-quoting the whole path) would point every
+# project-scope hook at a path that does not exist. That literal is a fixed,
+# metacharacter-free string by construction, so passing it through untouched is
+# safe. Escaping-in-double-quotes rather than switching to single quotes also
+# keeps the emitted command byte-identical for every ordinary path, so the
+# consumers that pattern-match it (unwire, detect-hook-dup, setup-wire) and
+# every already-installed settings.json are unaffected.
+# shellcheck disable=SC2016  # a jq program: $p/$pfx/$rel are jq bindings, not shell expansions
+WIRE_HOOK_CMD_JQ='
+  def shesc($p):
+    $p | split("\\") | join("\\\\")
+       | split("\"") | join("\\\"")
+       | split("$")  | join("\\$")
+       | split("`")  | join("\\`");
+  def hookcmd($pfx; $rel):
+    "bash \"" + (if $pfx == "$CLAUDE_PROJECT_DIR" then $pfx else shesc($pfx) end)
+    + "/scripts/hooks/" + $rel + "\"";
+'
 
 # The merge program, shared verbatim with the PowerShell twin
 # (wire-pretooluse-hooks.ps1) so the two can never drift. For each spec, walk
@@ -97,9 +135,9 @@ wire_pretooluse_hooks() {
   # alike. Shared verbatim with the PowerShell twin.
   local specs
   # shellcheck disable=SC2016  # a jq program: $pfx/$cmd/$name/$matcher are jq bindings, not shell expansions
-  specs=$(jq -n --arg pfx "$pfx" '
+  specs=$(jq -n --arg pfx "$pfx" "$WIRE_HOOK_CMD_JQ"'
     def spec($name; $matcher):
-      ("bash \"" + $pfx + "/scripts/hooks/" + $name + ".sh\"") as $cmd
+      hookcmd($pfx; $name + ".sh") as $cmd
       | { pat: ("scripts/hooks/" + $name + "[.]sh"),
           cmd: $cmd,
           stanza: { matcher: $matcher, hooks: [ { type: "command", command: $cmd } ] } };
@@ -136,7 +174,9 @@ wire_sessionstart_hook() {
   command -v jq >/dev/null 2>&1 || { echo "wire-pretooluse-hooks: jq required" >&2; return 1; }
   # shellcheck disable=SC1003
   local pfx="${prefix//'\'//}"
-  local cmd="bash \"${pfx}/scripts/hooks/${basename}\""
+  # The command is composed by jq (hookcmd), not by bash string interpolation,
+  # so the SessionStart hook carries exactly the same shell escaping as the
+  # PreToolUse trio and the PowerShell twin (HIMMEL-2905).
   local basepat="scripts/hooks/${basename//./[.]}"
   if [[ "$dry_run" -eq 1 ]]; then
     echo "DRY: merge SessionStart hook $basename into $settings (prefix: $prefix)"
@@ -150,8 +190,11 @@ wire_sessionstart_hook() {
     return 1
   fi
   [ -z "$(printf '%s' "$base" | tr -d '[:space:]')" ] && base="{}"
-  printf '%s' "$base" | jq --arg cmd "$cmd" --arg basepat "$basepat" '
-    .hooks = (.hooks // {})
+  # shellcheck disable=SC2016  # a jq program: $pfx/$hook/$cmd/$basepat are jq bindings
+  printf '%s' "$base" | jq --arg pfx "$pfx" --arg hook "$basename" --arg basepat "$basepat" \
+    "$WIRE_HOOK_CMD_JQ"'
+    hookcmd($pfx; $hook) as $cmd
+    | .hooks = (.hooks // {})
     | .hooks.SessionStart = ((.hooks.SessionStart // [])
         | map(.hooks = ((.hooks // [])
             | map(select((.command // "") | test($basepat) | not))))

--- a/scripts/lib/wire-pretooluse-hooks.sh
+++ b/scripts/lib/wire-pretooluse-hooks.sh
@@ -182,8 +182,9 @@ wire_sessionstart_hook() {
   local pfx="${prefix//'\'//}"
   # The command is composed by jq (hookcmd), not by bash string interpolation,
   # so the SessionStart hook carries exactly the same shell escaping as the
-  # PreToolUse trio and the PowerShell twin (HIMMEL-2905).
-  local basepat="scripts/hooks/${basename//./[.]}"
+  # PreToolUse trio and the PowerShell twin (HIMMEL-2905). The dedup test is
+  # built from the SAME escaped string, inside the same jq program, so the two
+  # can never disagree — see the filter below.
   if [[ "$dry_run" -eq 1 ]]; then
     echo "DRY: merge SessionStart hook $basename into $settings (prefix: $prefix)"
     return
@@ -196,14 +197,23 @@ wire_sessionstart_hook() {
     return 1
   fi
   [ -z "$(printf '%s' "$base" | tr -d '[:space:]')" ] && base="{}"
-  # shellcheck disable=SC2016  # a jq program: $pfx/$hook/$cmd/$basepat are jq bindings
-  printf '%s' "$base" | jq --arg pfx "$pfx" --arg hook "$basename" --arg basepat "$basepat" \
+  # Dedup is a LITERAL substring test on the ESCAPED basename, not a regex on
+  # the raw one (CR round 3, [codex-1]). Escaping the basename in the command
+  # (the CodeRabbit fix above) left the old `test("scripts/hooks/<raw>[.]sh")`
+  # pattern unable to match its own output, so a re-run APPENDED a duplicate
+  # instead of replacing — measured: 2 hook objects after two wires. Deriving
+  # the needle from the same shesc() the command uses makes disagreement
+  # impossible, and `contains` needs no regex-escaping at all, which the old
+  # `${basename//./[.]}` only ever did for `.` anyway.
+  # shellcheck disable=SC2016  # a jq program: $pfx/$hook/$cmd are jq bindings
+  printf '%s' "$base" | jq --arg pfx "$pfx" --arg hook "$basename" \
     "$WIRE_HOOK_CMD_JQ"'
     hookcmd($pfx; $hook) as $cmd
+    | ("scripts/hooks/" + shesc($hook)) as $needle
     | .hooks = (.hooks // {})
     | .hooks.SessionStart = ((.hooks.SessionStart // [])
         | map(.hooks = ((.hooks // [])
-            | map(select((.command // "") | test($basepat) | not))))
+            | map(select((.command // "") | contains($needle) | not))))
         | map(select((.hooks | length) > 0)))
     | (.hooks.SessionStart | map(has("matcher") | not) | index(true)) as $idx
     | if $idx == null

--- a/scripts/lib/wire-pretooluse-hooks.sh
+++ b/scripts/lib/wire-pretooluse-hooks.sh
@@ -64,7 +64,13 @@ set -euo pipefail
 # so escaping its `$` (or single-quoting the whole path) would point every
 # project-scope hook at a path that does not exist. That literal is a fixed,
 # metacharacter-free string by construction, so passing it through untouched is
-# safe. Escaping-in-double-quotes rather than switching to single quotes also
+# safe. $rel — the hook BASENAME — carries no such exemption and is escaped
+# unconditionally: it is an ARGUMENT of the public wire_sessionstart_hook (and
+# of the `--sessionstart` CLI), not a hardcoded literal like the trio's names,
+# so the rule has to cover it or it is only half a rule (CodeRabbit, PR #612).
+# Every real basename is metacharacter-free, so this changes no emitted command.
+#
+# Escaping-in-double-quotes rather than switching to single quotes also
 # keeps the emitted command byte-identical for every ordinary path, so the
 # consumers that pattern-match it (unwire, detect-hook-dup, setup-wire) and
 # every already-installed settings.json are unaffected.
@@ -77,7 +83,7 @@ WIRE_HOOK_CMD_JQ='
        | split("`")  | join("\\`");
   def hookcmd($pfx; $rel):
     "bash \"" + (if $pfx == "$CLAUDE_PROJECT_DIR" then $pfx else shesc($pfx) end)
-    + "/scripts/hooks/" + $rel + "\"";
+    + "/scripts/hooks/" + shesc($rel) + "\"";
 '
 
 # The merge program, shared verbatim with the PowerShell twin


### PR DESCRIPTION
Closes the two Important findings the round-6 critic panel on [#605](https://github.com/yotamleo/Himmel/pull/605) raised and console 03J deferred to HIMMEL-2905. Both were verified real against the code before any edit.

## 1. `wire-pretooluse-hooks` shell-escapes the hook path (`5fa77cb`)

The `command` a wired hook carries is a **shell** string, not only a JSON one. jq escaped the JSON layer in #605; the layer outside it was still open. With a clone prefix containing `"`, `$`, a backtick or `\`, the composer emitted

```
bash "/opt/we"ird/clone/scripts/hooks/auto-approve-safe-bash.sh"
```

— an unmatched quote, so the hook never executed and **every installed guard was silently inert on such a checkout**. Pre-existing, not a regression: the JSON fix only made the write succeed far enough for this layer to matter.

Both twins now compose *every* hook command — the PreToolUse trio **and** the SessionStart object — through one shared jq fragment, `WIRE_HOOK_CMD_JQ`, byte-identical in `wire-pretooluse-hooks.sh` and `.ps1` (verified by diffing the two extracted fragments). It backslash-escapes exactly the four characters that keep their meaning inside double quotes (`\`, `"`, `$`, backtick) and exempts the one prefix that must not be escaped: the literal, **unexpanded** `$CLAUDE_PROJECT_DIR` that Claude Code expands at hook-fire time.

**Deviation from the ticket's suggested shape, on purpose.** HIMMEL-2905 proposed single-quoting the path with `'\''`. Escaping inside the existing double quotes achieves the same shell-safety while leaving the emitted command **byte-identical for every metacharacter-free path** — so the consumers that pattern-match it (`unwire`, `detect-hook-dup`, `setup-wire`) and every already-installed `settings.json` are untouched. Single-quoting would have rewritten every user-scope command in the fleet for no added safety.

**RED → GREEN.** Case `8f` extended rather than duplicated, per the ticket. Measured against the pre-fix lib:

```
FAIL - quote in prefix: command does not parse as shell: [bash "/opt/we"ird/clone/scripts/hooks/auto-approve-safe-bash.sh"]
FAIL - quote in prefix: path round-trips through the shell: []!=[/opt/we"ird/clone/scripts/hooks/auto-approve-safe-bash.sh]
FAIL - quote in prefix: SessionStart command does not parse as shell: [bash "/opt/we"ird/clone/scripts/hooks/inject-initiative.sh"]
FAIL - quote in prefix: SessionStart path round-trips: []!=[/opt/we"ird/clone/scripts/hooks/inject-initiative.sh]
4 FAILED
```

After: `ALL PASS`. The two properties asserted are the ones that matter — the command **parses** (`bash -n -c`, rc 0) and the single argument a shell would hand to `bash` **equals** the intended path.

New case `8g` is the load-bearing negative control: the project-scope command must still read `bash "$CLAUDE_PROJECT_DIR/scripts/hooks/…"` verbatim — unescaped, unquoted — for both composers. It is green before *and* after, which is what makes 8f's pass mean something rather than proving a blanket escape.

The `.ps1` twin is mirrored but **untested on this station** (no `pwsh` here). What was verified: the shared jq fragment is byte-identical to the bash one, and both of the twin's composed jq programs were extracted and run through `jq` directly — they compile and emit the same escaped command as the bash lib.

## 2. Clone-target suite asserts the contributor command per platform (`a0da2ec`)

`test-wizard-himmel-clone-target.sh` cases a and a2 asserted `bash <clone>/scripts/setup.sh` unconditionally. But the diagnostic renders `displayCommand(deriveOverlayCommand())`, which on win32 is `<pwsh> -ExecutionPolicy Bypass -File <clone>\scripts\setup.ps1` — CodeRabbit's own round-1 fix on #605, since `bash …setup.ps1` is unrunnable there. So under Git Bash the suite (and its parent `scripts/test-adopt.sh`) **rejects correct behaviour**. Latent, not live: the shell suites run ubuntu-only in CI, so this bites a contributor, never a PR.

Both assertions now go through `overlay_remedy_ok()`, which picks its arm from `uname -s` with the `MINGW*|MSYS*|CYGWIN*` idiom the suite already uses. The Windows arm matches the invariant part of the line rather than a full literal — `resolvePowershell()` picks the interpreter at runtime. Case a3, the platform-**independent** source assertion that the command is derived and not hardcoded, stays unconditional.

**RED control (case a4).** The bug is a false red on a platform CI does not run, so it cannot be reproduced by running the suite here. a4 exercises `overlay_remedy_ok()` itself against synthetic renderings, with and without a `uname` stub reporting Git Bash. Measured against the old unconditional assertion:

```
FAIL: case a4: under a Git-Bash uname the pwsh rendering must satisfy the remedy assertion
```

and green after. The stub is confined to two subshells inside that case; nothing below it runs with a doctored `PATH`.

## Twin parity + CR round 1

`known-findings.sh --diff` flagged `[ps1-twin-parity]`: the lib's `.ps1` was mirrored but its **test** twin was not, so the PowerShell side of the escaping rule had no coverage. `e2cb61a` adds cases 9 and 10 to `test-wire-pretooluse-hooks.ps1` — the twins of 8f and 8g — asserted as string equality rather than the bash twin's `bash -n -c` round-trip, so they need no bash on PATH.

Round 1 of the critic panel raised one Important, verified real and fixed in `1495205`: case a4's two POSIX controls ran against the **host's** `uname`, so under Git Bash they would take the Windows arm and fail — on the very platform the change exists to unredden. Both arms are now stubbed, making all four checks host-independent. Verified by extracting the a4 block with the suite's own `grepq`/`overlay_remedy_ok` definitions and running it under `uname -s` = `Linux` and under a `MINGW64` stub (passes under both); the pre-fix shape fails under the MINGW stub, which is the finding.

Round 2 returned 0 Critical / 0 Important and one Suggestion, **deferred to [HIMMEL-2912](https://github.com/yotamleo/Himmel)** with an explicit disposition rather than fixed blind: the Windows arm matches `-ExecutionPolicy Bypass -File .*setup[.]ps1`, so it does not pin the refused checkout's own path. Splicing the checkout path in is not a one-liner — `deriveOverlayCommand()` renders win32 paths with **backslashes** (`path.join`) while the suite's `winpath()` bridge is `cygpath -m` (**forward** slashes), and `displayCommand()` shell-quotes any element containing whitespace. Writing that expectation blind on a Linux station would ship an unverifiable Windows-only assertion — the same latent false-red class this PR closes. It needs a Git Bash / pwsh host (HIMMEL-2860). Recorded in the CR ledger as `deferred -> HIMMEL-2912` with the reason.

## Evidence

Every suite through `scripts/quiet-run.sh`. Baselines taken on `ce042107` before any edit — all five green — then re-run after.

| Suite | Result |
|---|---|
| `scripts/lib/test-wire-pretooluse-hooks.sh` | ALL PASS (RED first: 4 failures) |
| `scripts/himmelctl/test/test-wizard-himmel-clone-target.sh` | PASS (RED first: case a4) |
| `scripts/lib/test-setup-wire.sh` | ALL PASS |
| `scripts/lib/test-unwire-pretooluse-hooks.sh` | ALL PASS |
| `scripts/lib/test-detect-hook-dup.sh` | ALL PASS |
| `scripts/test-adopt.sh` (parent of the clone-target suite) | PASS |
| `scripts/test-e2e-symmetry.sh` | PASS |
| `scripts/test-uninstall.sh` | PASS |
| `scripts/himmelctl/test/test-wizard-ensure.sh` | PASS |
| `scripts/himmelctl/test/test-wizard-ensure-disable.sh` | PASS |
| `scripts/himmelctl/test/test-wizard-install-engine.sh` | PASS |
| `scripts/himmelctl/test/test-wizard-recorded-profile.sh` | PASS |

Impacted set derived from `git grep -l` over the changed basenames, not a directory sweep. `shellcheck -x` clean on all three touched shell files at the CI gate's `--severity=warning` *and* at pre-commit's default severity (two targeted `disable=` directives, each with its reason: the literal `$CLAUDE_PROJECT_DIR` in the 8g assertions, and the deliberately subshell-local `PATH` in a4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLxyZC9wXEZSSrEv88iWvX


[HIMMEL-2912]: https://yotamleo.atlassian.net/browse/HIMMEL-2912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PreToolUse and SessionStart hook setup across Bash, PowerShell, POSIX, and Windows environments.
  * Hook paths containing spaces, quotes, backslashes, dollar signs, or backticks are now handled more reliably.
  * Preserved project-directory variables correctly during hook command generation.
  * Improved contributor guidance when project-level hook configuration is refused.
  * Added cross-platform validation to reduce false failures, including under Git Bash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->