### PR TITLE
fix(template,handover): [HIMMEL-2910] release-token allowlist tolerates trailing punctuation; queue-lock prints the backticked form

### DIFF
--- a/.claude/commands/console.md
+++ b/.claude/commands/console.md
@@ -26,7 +26,8 @@ bash scripts/handover/console/console.sh $ARGUMENTS
   on a signal file plus a deadline; prints the arm log path.
 - `--dry-run` — print what it would write, prefixed `would-`, and touch nothing.
 
-Record the printed `release-token:` line in the console's first Results bullet:
+Record the printed `release-token: ` line — now backticked around the token
+itself (HIMMEL-2910) — in the console's first Results bullet verbatim:
 releasing the lock at wrap requires it.
 
 Linux/macOS only — `--arm` launches through konsole. The Windows station arms

--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -376,6 +376,13 @@ cmd_new() {
         exit 1
     fi
     release_token="$(printf '%s\n' "$lock_out" | sed -n 's/^release-token: //p')"
+    # HIMMEL-2910: acquire now prints the token backticked
+    # ("release-token: `<token>`"), so this extraction would otherwise embed
+    # the backticks into {{RELEASE_TOKEN}} too -- strip a matched pair.
+    # Tolerates the pre-2910 bare form too -- a no-op when there are no
+    # backticks to strip.
+    release_token="${release_token#\`}"
+    release_token="${release_token%\`}"
     if [ -z "$release_token" ]; then
         err "queue-lock acquire for $doc reported success but printed no release-token line — refusing to render a document with an empty or bogus token"
         exit 1

--- a/scripts/handover/console/test-console.sh
+++ b/scripts/handover/console/test-console.sh
@@ -57,7 +57,16 @@ console_root() {  # console_root <root> <args...> -- invoke console.sh with
 
 console() { console_root "$root" "$@"; }
 
-token_of() { printf '%s\n' "$1" | sed -n 's/^release-token: //p'; }
+# HIMMEL-2910: acquire prints the token backticked
+# ("release-token: `<token>`"); strip a matched pair so callers get the bare
+# token either way -- a no-op on the pre-2910 bare form.
+token_of() {
+    local t
+    t="$(printf '%s\n' "$1" | sed -n 's/^release-token: //p')"
+    t="${t#\`}"
+    t="${t%\`}"
+    printf '%s' "$t"
+}
 
 # --- 1/2/3/4: new, placeholder cleanliness, lock lifecycle, idempotent bump
 docA="$root/tester/demorepo/DEMO-nextleg-${today}A-console.md"

--- a/scripts/handover/queue-lock.sh
+++ b/scripts/handover/queue-lock.sh
@@ -1203,6 +1203,11 @@ queue_lock_heartbeat() {
         echo "queue-lock: could not resolve handover root" >&2
         return 1
     fi
+    # HIMMEL-2910: strip a matched backtick pair from an ARGV token only --
+    # a recalled token (below) is already the exact raw value persisted at
+    # acquire time, so stripping it too would misidentify a session whose
+    # OWN id happens to start/end with a backtick (panel finding, round 1).
+    session="$(_ql_strip_backticks "$session")"
     # HIMMEL-2813: no token on argv -- try the per-session file before
     # refusing. An argv token always wins (this only runs when there is
     # none), and a recall that finds nothing falls through to the unchanged
@@ -1210,7 +1215,6 @@ queue_lock_heartbeat() {
     if [ -z "$session" ]; then
         session=$(_ql_token_recall "$ho") || session=""
     fi
-    session="$(_ql_strip_backticks "$session")"
     # C1: the token is MANDATORY -- a token-less heartbeat could refresh
     # (and keep alive) another session's lock.
     if [ -z "$session" ]; then
@@ -1293,6 +1297,11 @@ queue_lock_release() {
         # forcing session is a cleaner, not the holder wrapping up.
         return 0
     fi
+    # HIMMEL-2910: strip a matched backtick pair from an ARGV token only --
+    # a recalled token (below) is already the exact raw value persisted at
+    # acquire time, so stripping it too would misidentify a session whose
+    # OWN id happens to start/end with a backtick (panel finding, round 1).
+    session="$(_ql_strip_backticks "$session")"
     # HIMMEL-2813: no token on argv -- try the per-session file before
     # refusing. This runs AFTER the force-release block above, so that path
     # is untouched, and only when argv carried nothing, so an explicit token
@@ -1301,7 +1310,6 @@ queue_lock_release() {
     if [ -z "$session" ]; then
         session=$(_ql_token_recall "$ho") || session=""
     fi
-    session="$(_ql_strip_backticks "$session")"
     # C1: the token is MANDATORY -- a token-less release would rm another
     # session's LIVE lock (the exact incident class this script prevents).
     # Separate script invocations cannot re-derive a stable per-session id,

--- a/scripts/handover/queue-lock.sh
+++ b/scripts/handover/queue-lock.sh
@@ -21,7 +21,11 @@
 #
 # TOKEN CONTRACT (HIMMEL-856 CR, C1): `acquire` records a session token in
 # owner.json (the given session-id, or a generated "<hostname>-pid<pid>")
-# and PRINTS it as the last stdout line: "release-token: <token>". The
+# and PRINTS it as the last stdout line: "release-token: `<token>`" (the
+# token itself backticked -- HIMMEL-2910: a bare, unquoted token copy-pasted
+# into a handover doc followed by sentence punctuation reads as part of the
+# "secret" to gitleaks' generic-api-key rule; the backticks delimit the
+# capture so the copy-paste shape is safe by construction). The
 # caller must capture that line and pass the token to `heartbeat` and
 # `release` -- both REFUSE (rc=2, holder info printed) without it or with
 # a token that does not match the current holder. The token is mandatory
@@ -96,7 +100,7 @@
 # EXIT CODES:
 #   acquire:   0  lock acquired (fresh dir, stale takeover, or forced
 #                 takeover -- stderr says which); the last stdout line is
-#                 "release-token: <token>"
+#                 "release-token: `<token>`"
 #              1  usage error, OR a genuine environment failure (handover
 #                 root unresolvable, mkdir failed for a reason other than
 #                 "already held", owner.json could not be written -- the
@@ -195,8 +199,10 @@ Usage: queue-lock.sh acquire   <handover-path> [session-id]
        queue-lock.sh status    <handover-path>
        queue-lock.sh status --sweep [<handover-dir>]
 
-acquire prints "release-token: <token>" on success -- capture it and pass
-it to heartbeat/release (both refuse without it). Lost the token to an
+acquire prints "release-token: `<token>`" (backticked -- HIMMEL-2910) on
+success -- capture it and pass it to heartbeat/release (both refuse without
+it, and both accept the token with or without surrounding backticks). Lost
+the token to an
 autocompact? acquire also persisted it under
 <XDG_RUNTIME_DIR>/himmel-queue-lock/ (HIMMEL-2813), so a heartbeat/release
 with NO token on argv reads it back and says so on stderr. Only when THAT
@@ -256,6 +262,25 @@ _ql_hostname() {
 }
 
 _ql_default_session() { printf '%s-pid%s' "$(_ql_hostname)" "$$"; }
+
+# _ql_strip_backticks <token> -- HIMMEL-2910: acquire prints the token
+# backticked ("release-token: `<token>`") so a leg copy-pasting the line
+# into a markdown handover doc can't have gitleaks capture trailing
+# punctuation into the "secret". heartbeat/release therefore accept the
+# token exactly as printed -- backticked -- as well as the pre-2910 bare
+# form, so a caller need not hand-strip anything either way. Strips ONLY
+# when BOTH a leading and trailing backtick are present (never a single
+# stray one), so a token that itself starts or ends with a backtick -- never
+# actually produced by this script, but not to rule out for an external
+# caller -- is not silently mangled.
+_ql_strip_backticks() {
+    local t="$1"
+    if [ "${#t}" -ge 2 ] && [ "${t#\`}" != "$t" ] && [ "${t%\`}" != "$t" ]; then
+        t="${t#\`}"
+        t="${t%\`}"
+    fi
+    printf '%s' "$t"
+}
 
 # JSON escape/extract now delegate to the shared pure-bash helpers in
 # scripts/lib/handover-path.sh (_hp_json_escape / _hp_json_field, HIMMEL-882
@@ -970,7 +995,7 @@ queue_lock_acquire() {
             _ql_token_persist "$ho" "$session"
             echo "queue-lock: acquired (session=$session host=$host)"
             _ql_arms_registry_retire_fired "$ho"
-            echo "release-token: $session"
+            echo "release-token: \`$session\`"
             return 0
         elif [ ! -e "$lockdir/owner" ]; then
             # Owner create failed with NO winner branded (ENOSPC/ACL/IO --
@@ -1143,7 +1168,7 @@ queue_lock_acquire() {
             echo "queue-lock: took over ($reason) -- previous holder: session=$o_session host=$o_host" >&2
             echo "queue-lock: acquired (session=$session host=$host)"
             _ql_arms_registry_retire_fired "$ho"
-            echo "release-token: $session"
+            echo "release-token: \`$session\`"
             return 0
         fi
         # Lost the rm->mkdir gap to a fresh acquirer -- it owns the lock.
@@ -1185,11 +1210,12 @@ queue_lock_heartbeat() {
     if [ -z "$session" ]; then
         session=$(_ql_token_recall "$ho") || session=""
     fi
+    session="$(_ql_strip_backticks "$session")"
     # C1: the token is MANDATORY -- a token-less heartbeat could refresh
     # (and keep alive) another session's lock.
     if [ -z "$session" ]; then
         {
-            echo "queue-lock: heartbeat requires the session token printed by acquire (release-token: <token>)"
+            echo "queue-lock: heartbeat requires the session token printed by acquire (release-token: \`<token>\`)"
             echo "usage: queue-lock.sh heartbeat <handover-path> <session-token>"
             if [ -f "$lockdir/owner.json" ]; then
                 echo "current holder:"
@@ -1275,13 +1301,14 @@ queue_lock_release() {
     if [ -z "$session" ]; then
         session=$(_ql_token_recall "$ho") || session=""
     fi
+    session="$(_ql_strip_backticks "$session")"
     # C1: the token is MANDATORY -- a token-less release would rm another
     # session's LIVE lock (the exact incident class this script prevents).
     # Separate script invocations cannot re-derive a stable per-session id,
     # so a re-derived default would "prove" nothing.
     if [ -z "$session" ]; then
         {
-            echo "queue-lock: release requires the session token printed by acquire (release-token: <token>)"
+            echo "queue-lock: release requires the session token printed by acquire (release-token: \`<token>\`)"
             echo "usage: queue-lock.sh release <handover-path> <session-token>"
             if [ -f "$lockdir/owner.json" ]; then
                 echo "current holder:"

--- a/scripts/handover/queue-lock.sh
+++ b/scripts/handover/queue-lock.sh
@@ -266,13 +266,13 @@ _ql_default_session() { printf '%s-pid%s' "$(_ql_hostname)" "$$"; }
 # _ql_strip_backticks <token> -- HIMMEL-2910: acquire prints the token
 # backticked ("release-token: `<token>`") so a leg copy-pasting the line
 # into a markdown handover doc can't have gitleaks capture trailing
-# punctuation into the "secret". heartbeat/release therefore accept the
-# token exactly as printed -- backticked -- as well as the pre-2910 bare
-# form, so a caller need not hand-strip anything either way. Strips ONLY
-# when BOTH a leading and trailing backtick are present (never a single
-# stray one), so a token that itself starts or ends with a backtick -- never
-# actually produced by this script, but not to rule out for an external
-# caller -- is not silently mangled.
+# punctuation into the "secret". Strips ONLY when BOTH a leading and
+# trailing backtick are present (never a single stray one), so a token
+# that itself starts or ends with a backtick -- never actually produced by
+# this script, but not to rule out for an external caller -- is not
+# silently mangled. A candidate this reduces to empty (e.g. the 2-char
+# literal "``") is exactly the case _ql_token_matches below exists to
+# refuse rather than treat as "no token given" -- see its comment.
 _ql_strip_backticks() {
     local t="$1"
     if [ "${#t}" -ge 2 ] && [ "${t#\`}" != "$t" ] && [ "${t%\`}" != "$t" ]; then
@@ -280,6 +280,26 @@ _ql_strip_backticks() {
         t="${t%\`}"
     fi
     printf '%s' "$t"
+}
+
+# _ql_token_matches <candidate> <owner-value> -- rc 0 when <candidate> IS
+# the holder's token, accepting it either exactly as stored (the pre-2910
+# bare form, or a recalled token, or a caller-chosen id that happens to
+# itself start/end with a backtick) OR with one matched pair of backticks
+# stripped (the copy-paste shape acquire now prints). Tried in that order
+# and ONLY that order -- CR round 2 (codex-1): normalizing <candidate>
+# before this comparison, as an earlier revision did, collapses the 2-char
+# literal "``" to empty and made an explicitly wrong argv token
+# indistinguishable from "no token was given", which then fell through to
+# a token-file RECALL instead of being refused. Comparing both forms
+# against the SAME unmodified <candidate> here means a degenerate explicit
+# token still fails both comparisons and is correctly refused, while an
+# exact match (including one on a self-backticked id, CR round 1) is
+# always tried FIRST and never overridden by the stripped form.
+_ql_token_matches() {
+    local candidate="$1" owner="$2"
+    [ "$candidate" = "$owner" ] && return 0
+    [ "$(_ql_strip_backticks "$candidate")" = "$owner" ]
 }
 
 # JSON escape/extract now delegate to the shared pure-bash helpers in
@@ -466,7 +486,7 @@ _ql_search_roots() {
         slug=$(_ql_slug_for_root "$ho" "$root")
         cand="$root/.locks/queue/$slug.lock"
         [ -f "$cand/owner.json" ] || continue
-        [ "$(_ql_json_field "$cand/owner.json" session)" = "$token" ] || continue
+        _ql_token_matches "$token" "$(_ql_json_field "$cand/owner.json" session)" || continue
         recorded=""
         [ -f "$cand/root" ] && recorded=$(cat "$cand/root" 2>/dev/null)
         [ -n "$recorded" ] || recorded="$root"
@@ -667,14 +687,15 @@ _ql_token_forget() {
 }
 
 # _ql_owner_matches <lockdir> <token> -- rc 0 when this lock dir's
-# owner.json names <token> as the holder. A missing dir, a missing or
-# unreadable owner.json, and a different holder all return non-zero, so
-# callers can use one test for "this is not my lock, wherever it is" and
-# let the existing corrupt-lock / refused-release branches below decide
-# what that means.
+# owner.json names <token> as the holder (HIMMEL-2910: via
+# _ql_token_matches, so a backticked <token> matches its bare stored form
+# too). A missing dir, a missing or unreadable owner.json, and a different
+# holder all return non-zero, so callers can use one test for "this is not
+# my lock, wherever it is" and let the existing corrupt-lock /
+# refused-release branches below decide what that means.
 _ql_owner_matches() {
     [ -f "$1/owner.json" ] || return 1
-    [ "$(_ql_json_field "$1/owner.json" session)" = "$2" ]
+    _ql_token_matches "$2" "$(_ql_json_field "$1/owner.json" session)"
 }
 
 # _ql_write_root_marker <lockdir> <root> -- record the root this lock
@@ -1203,11 +1224,6 @@ queue_lock_heartbeat() {
         echo "queue-lock: could not resolve handover root" >&2
         return 1
     fi
-    # HIMMEL-2910: strip a matched backtick pair from an ARGV token only --
-    # a recalled token (below) is already the exact raw value persisted at
-    # acquire time, so stripping it too would misidentify a session whose
-    # OWN id happens to start/end with a backtick (panel finding, round 1).
-    session="$(_ql_strip_backticks "$session")"
     # HIMMEL-2813: no token on argv -- try the per-session file before
     # refusing. An argv token always wins (this only runs when there is
     # none), and a recall that finds nothing falls through to the unchanged
@@ -1252,10 +1268,16 @@ queue_lock_heartbeat() {
     o_session=$(_ql_json_field "$lockdir/owner.json" session)
     o_host=$(_ql_json_field "$lockdir/owner.json" host)
     o_started=$(_ql_json_field "$lockdir/owner.json" started)
-    if [ "$session" != "$o_session" ]; then
+    # HIMMEL-2910: _ql_token_matches, not a bare `!=`, so a backticked argv
+    # token matches its bare owner.json form too (see the helper's comment
+    # for why an EARLIER, now-removed revision that stripped $session before
+    # this point was wrong). On a match, normalize to the owner's own
+    # canonical value -- nothing downstream needs $session's original form.
+    if ! _ql_token_matches "$session" "$o_session"; then
         echo "queue-lock: heartbeat refused -- held by session=$o_session, not '$session'" >&2
         return 2
     fi
+    session="$o_session"
     if ! _ql_write_owner "$lockdir" "$o_session" "$o_host" "$ho" "$o_started" "$(_ql_now_iso)"; then
         echo "queue-lock: heartbeat FAILED -- owner.json could not be rewritten atomically (the previous heartbeat stays in effect)" >&2
         return 1
@@ -1297,11 +1319,6 @@ queue_lock_release() {
         # forcing session is a cleaner, not the holder wrapping up.
         return 0
     fi
-    # HIMMEL-2910: strip a matched backtick pair from an ARGV token only --
-    # a recalled token (below) is already the exact raw value persisted at
-    # acquire time, so stripping it too would misidentify a session whose
-    # OWN id happens to start/end with a backtick (panel finding, round 1).
-    session="$(_ql_strip_backticks "$session")"
     # HIMMEL-2813: no token on argv -- try the per-session file before
     # refusing. This runs AFTER the force-release block above, so that path
     # is untouched, and only when argv carried nothing, so an explicit token
@@ -1355,10 +1372,16 @@ queue_lock_release() {
     if [ -f "$lockdir/owner.json" ]; then
         local o_session
         o_session=$(_ql_json_field "$lockdir/owner.json" session)
-        if [ -n "$o_session" ] && [ "$o_session" != "$session" ]; then
+        # HIMMEL-2910: _ql_token_matches, not a bare `!=` -- see the
+        # heartbeat function's identical comment. Normalize to the owner's
+        # canonical value on a match so _ql_token_forget below compares the
+        # PERSISTED file's exact content, not whatever form the caller
+        # happened to pass.
+        if [ -n "$o_session" ] && ! _ql_token_matches "$session" "$o_session"; then
             echo "queue-lock: release refused -- held by session=$o_session, not '$session' (QUEUE_LOCK_FORCE_RELEASE=1 to force)" >&2
             return 2
         fi
+        [ -n "$o_session" ] && session="$o_session"
     fi
     rm -rf "$lockdir" 2>/dev/null
     if [ -d "$lockdir" ]; then

--- a/scripts/handover/test-queue-lock.sh
+++ b/scripts/handover/test-queue-lock.sh
@@ -116,6 +116,25 @@ else
 fi
 bash "$LIB" acquire "$HO1" "session-a" >/dev/null 2>&1
 
+# --- T1e (HIMMEL-2910 round-1 CR fix): a RECALLED token whose own value
+# legitimately starts/ends with a backtick is not mangled by the strip --
+# it applies to an ARGV-supplied token only, never to one recovered from the
+# per-session persistence file (HIMMEL-2813), which is already the exact
+# raw value acquire stored in owner.json.
+HO1E="$HANDOVER_DIR/HIMMEL-856-test/next-session-1e.md"
+mkdir -p "$(dirname "$HO1E")"
+: > "$HO1E"
+LOCKDIR1E="$HANDOVER_DIR/.locks/queue/HIMMEL-856-test__next-session-1e.lock"
+# shellcheck disable=SC2016  # a literal backtick-quoted session id, not command substitution
+bash "$LIB" acquire "$HO1E" '`selfquoted`' >/dev/null 2>&1
+bash "$LIB" release "$HO1E" >/dev/null 2>&1
+t1e_rc=$?
+if [ "$t1e_rc" -eq 0 ] && [ ! -d "$LOCKDIR1E" ]; then
+    pass "T1e: a token-less release recalls a self-backticked session id unmangled and releases"
+else
+    fail "T1e: token-less release of a self-backticked session id failed (rc=$t1e_rc)"
+fi
+
 # --- T2: second acquire while FRESH -> rc 2, holder info + override hint ----
 err="$(bash "$LIB" acquire "$HO1" "session-b" 2>&1 1>/dev/null)"
 rc=$?

--- a/scripts/handover/test-queue-lock.sh
+++ b/scripts/handover/test-queue-lock.sh
@@ -21,6 +21,17 @@ set -uo pipefail
 # so the status is grep's own verdict alone. (HIMMEL-1430.)
 grepq() { local _t="$1"; shift; grep -q "$@" <<< "$_t"; }
 
+# _tq_bare_token <release-token-line-value> -- HIMMEL-2910: acquire now
+# prints the token backticked ("release-token: `<token>`"); this recovers
+# the bare token from either that shape or the pre-2910 bare one, the way
+# every real consumer (console.sh, the console-kit) must.
+_tq_bare_token() {
+    local t="$1"
+    t="${t#\`}"
+    t="${t%\`}"
+    printf '%s' "$t"
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB="$SCRIPT_DIR/queue-lock.sh"
 # shellcheck source=../lib/py-armor.sh
@@ -76,11 +87,34 @@ if [ -f "$lockdir/owner.json" ] \
 else
     fail "T1: owner.json missing/incomplete ($(cat "$lockdir/owner.json" 2>/dev/null || echo 'MISSING'))"
 fi
-if grepq "$out" '^release-token: session-a$'; then
-    pass "T1: acquire prints the release-token line"
+# shellcheck disable=SC2016  # backticks are a literal part of the expected output, not command substitution
+if grepq "$out" '^release-token: `session-a`$'; then
+    pass "T1: acquire prints the release-token line, token backticked (HIMMEL-2910)"
 else
-    fail "T1: acquire output missing 'release-token: session-a' (got: $out)"
+    fail "T1: acquire output missing 'release-token: \`session-a\`' (got: $out)"
 fi
+
+# --- T1b-T1d (HIMMEL-2910): the backticked release-token line is a safe
+# copy-paste shape, and every reader tolerates BOTH it and the pre-2910
+# bare form.
+if [ "$(_tq_bare_token "$(printf '%s\n' "$out" | sed -n 's/^release-token: //p')")" = "session-a" ]; then
+    pass "T1b: a reader recovers the bare token from the backticked line"
+else
+    fail "T1b: bare-token recovery from the backticked line failed (out=$out)"
+fi
+if [ "$(_tq_bare_token 'release-token-old-style')" = "release-token-old-style" ]; then
+    pass "T1c: the reader is a no-op on an already-bare token (old bare line still parses)"
+else
+    fail "T1c: the reader mangled an already-bare token"
+fi
+bash "$LIB" release "$HO1" '`session-a`' >/dev/null 2>&1
+t1d_rc=$?
+if [ "$t1d_rc" -eq 0 ] && [ ! -d "$lockdir" ]; then
+    pass "T1d: release accepts the token AS PRINTED -- backticks and all -- not just the stripped bare form"
+else
+    fail "T1d: release rejected the backticked-argv token (rc=$t1d_rc)"
+fi
+bash "$LIB" acquire "$HO1" "session-a" >/dev/null 2>&1
 
 # --- T2: second acquire while FRESH -> rc 2, holder info + override hint ----
 err="$(bash "$LIB" acquire "$HO1" "session-b" 2>&1 1>/dev/null)"
@@ -691,6 +725,21 @@ else
 fi
 bash "$LIB" release "$HO24" "session-t24" >/dev/null 2>&1
 
+# --- T24b (HIMMEL-2910): the TAKEOVER path also prints the backticked line -
+# T24 only checked stderr; this checks stdout on the same stale-takeover
+# branch (queue_lock_acquire's second release-token print site).
+mkdir -p "$LOCKDIR24"
+printf '{"session":"dead-session-2","host":"old-host","handover":"%s","started":"2020-01-01T00:00:00Z","heartbeat":"2020-01-01T00:00:00Z"}\n' \
+    "$HO24" > "$LOCKDIR24/owner.json"
+t24b_out="$(bash "$LIB" acquire "$HO24" "session-t24b" 2>/dev/null)"
+# shellcheck disable=SC2016  # backticks are a literal part of the expected output, not command substitution
+if [ "$(printf '%s\n' "$t24b_out" | tail -1)" = 'release-token: `session-t24b`' ]; then
+    pass "T24b: the takeover-path acquire also prints the backticked release-token line"
+else
+    fail "T24b: takeover-path release-token line not backticked (got: $t24b_out)"
+fi
+bash "$LIB" release "$HO24" "session-t24b" >/dev/null 2>&1
+
 # --- T25: concurrent rewriters lose no record (round-2 High) ---------------
 # Two acquires on DIFFERENT handovers race the SAME arms.jsonl (one
 # registry per handover root); pre-mutex, both did read-filter-rewrite-mv
@@ -735,7 +784,8 @@ HO26="$HANDOVER_DIR/HIMMEL-856-test/next-session-26.md"
 printf '{"host":"%s","handover":"%s","fire-at":"202601010000","task-name":"HIMMEL-Resume-t26-failopen"}\n' \
     "$THIS_HOST" "$HO26" > "$ARMS_REGISTRY"
 t26_out=$(bash -c '. "$1"; mkdir -p "$2.tmp.$$"; queue_lock_acquire "$3" "sess-t26"; rc=$?; rmdir "$2.tmp.$$" 2>/dev/null; echo "RC=$rc"' _ "$LIB" "$ARMS_REGISTRY" "$HO26" 2>&1)
-if grepq "$t26_out" 'RC=0' && grepq "$t26_out" 'release-token: sess-t26'; then
+# shellcheck disable=SC2016  # backticks are a literal part of the expected output, not command substitution
+if grepq "$t26_out" 'RC=0' && grepq "$t26_out" 'release-token: `sess-t26`'; then
     pass "T26: acquire still succeeds when the registry rewrite cannot start"
 else
     fail "T26: acquire failed on a registry write failure (out=$t26_out)"
@@ -1498,6 +1548,7 @@ x_from_worktree() {
 
 x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "legN114" 2>/dev/null \
     | sed -n 's/^release-token: //p')"
+x_tok="$(_tq_bare_token "$x_tok")"
 if [ "$x_tok" = "legN114" ] && [ -f "$X_LOCKDIR/owner.json" ]; then
     pass "T46: setup -- acquire under the state root holds the lock"
 else
@@ -1544,6 +1595,7 @@ fi
 # --- T47: heartbeat resolves across roots the same way ---------------------
 x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "legN114hb" 2>/dev/null \
     | sed -n 's/^release-token: //p')"
+x_tok="$(_tq_bare_token "$x_tok")"
 out="$(x_from_worktree "$X_REG" heartbeat "$x_tok")"
 rc=$?
 if [ "$rc" -eq 0 ] && grepq "$(cat "$X_LOCKDIR/owner.json" 2>/dev/null)" '"session":"legN114hb"'; then
@@ -1573,6 +1625,7 @@ fi
 # (no `root` marker file) must still status/heartbeat/release normally.
 x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "legacy-sess" 2>/dev/null \
     | sed -n 's/^release-token: //p')"
+x_tok="$(_tq_bare_token "$x_tok")"
 rm -f "$X_LOCKDIR/root"
 HANDOVER_DIR="$X_ROOT" bash "$LIB" status "$X_DOC" >/dev/null 2>&1
 t49_status_rc=$?
@@ -1590,6 +1643,7 @@ fi
 # --- T50: acquire records the resolved root inside the lock dir ------------
 x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "root-marker" 2>/dev/null \
     | sed -n 's/^release-token: //p')"
+x_tok="$(_tq_bare_token "$x_tok")"
 if [ -f "$X_LOCKDIR/root" ] && [ "$(cat "$X_LOCKDIR/root" 2>/dev/null)" = "$X_ROOT" ]; then
     pass "T50: acquire records the resolved root in <lockdir>/root"
 else
@@ -1601,8 +1655,9 @@ fi
 # other addition must never land after it.
 HANDOVER_DIR="$X_ROOT" bash "$LIB" release "$X_DOC" "$x_tok" >/dev/null 2>&1
 out="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "last-line" 2>/dev/null)"
-if [ "$(printf '%s\n' "$out" | tail -1)" = "release-token: last-line" ]; then
-    pass "T51: 'release-token: <token>' is still the LAST stdout line of acquire"
+# shellcheck disable=SC2016  # backticks are a literal part of the expected output, not command substitution
+if [ "$(printf '%s\n' "$out" | tail -1)" = 'release-token: `last-line`' ]; then
+    pass "T51: 'release-token: \`<token>\`' is still the LAST stdout line of acquire"
 else
     fail "T51: acquire's last stdout line is not the release-token line (got: $out)"
 fi
@@ -1643,6 +1698,7 @@ printf '{"repos":{"decoy":{"path":"%s"},"state":{"path":"%s"}}}\n' \
     "$TMPDIR_ROOT/2861-decoy" "$X_STATE" > "$X_REG_COMPACT"
 x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "compact-reg" 2>/dev/null \
     | sed -n 's/^release-token: //p')"
+x_tok="$(_tq_bare_token "$x_tok")"
 out="$(x_from_worktree "$X_REG_COMPACT" release "$x_tok")"
 rc=$?
 if [ "$rc" -eq 0 ] && [ ! -d "$X_LOCKDIR" ]; then
@@ -1656,6 +1712,7 @@ printf '{"repos":{"state":{"path":"%s"},"decoy":{"path":"%s"}}}\n' \
     "$X_STATE" "$TMPDIR_ROOT/2861-decoy" > "$X_REG_COMPACT"
 x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "compact-reg-2" 2>/dev/null \
     | sed -n 's/^release-token: //p')"
+x_tok="$(_tq_bare_token "$x_tok")"
 out="$(x_from_worktree "$X_REG_COMPACT" release "$x_tok")"
 rc=$?
 if [ "$rc" -eq 0 ] && [ ! -d "$X_LOCKDIR" ]; then
@@ -1670,6 +1727,7 @@ fi
 # "the lock here is not ours", not merely on "there is no lock here".
 x_tok="$(HANDOVER_DIR="$X_ROOT" bash "$LIB" acquire "$X_DOC" "mine-elsewhere" 2>/dev/null \
     | sed -n 's/^release-token: //p')"
+x_tok="$(_tq_bare_token "$x_tok")"
 # The stranger's lock is acquired by a REAL acquire from the worktree cwd,
 # not hand-placed: the slug is the doc path relativized against ITS OWN root,
 # so a hand-built path would land where the cwd root never looks and would
@@ -1743,7 +1801,8 @@ p_token_file() {
 
 # --- T56: acquire persists the token; a token-less release uses it ---------
 out="$(p_ql acquire "$P_DOC" "persist-a" 2>&1)"
-if grepq "$out" '^release-token: persist-a$' && [ -n "$(p_token_file)" ]; then
+# shellcheck disable=SC2016  # backticks are a literal part of the expected output, not command substitution
+if grepq "$out" '^release-token: `persist-a`$' && [ -n "$(p_token_file)" ]; then
     pass "T56: acquire persists the token to the per-session file"
 else
     fail "T56: no token file after acquire (out=$out)"
@@ -1888,7 +1947,8 @@ p64_written=0
 for f in "$P_XDG_BAD/himmel-queue-lock"/*; do
     [ -f "$f" ] && p64_written=1
 done
-if [ "$rc" -eq 0 ] && grepq "$out" '^release-token: bad-dir-sess$' && [ "$p64_written" -eq 0 ]; then
+# shellcheck disable=SC2016  # backticks are a literal part of the expected output, not command substitution
+if [ "$rc" -eq 0 ] && grepq "$out" '^release-token: `bad-dir-sess`$' && [ "$p64_written" -eq 0 ]; then
     pass "T64: a world-writable token dir is declined -- acquire still succeeds, no token written into it"
 else
     fail "T64: token leaked into a 0777 dir, or acquire broke (rc=$rc written=$p64_written: $out)"
@@ -1985,7 +2045,8 @@ s67_written=0
 for f in "$S_XDG/himmel-queue-lock"/*; do
     [ -f "$f" ] && s67_written=1
 done
-if [ "$rc" -eq 0 ] && grepq "$out" '^release-token: no-scope-sess$' && [ "$s67_written" -eq 0 ]; then
+# shellcheck disable=SC2016  # backticks are a literal part of the expected output, not command substitution
+if [ "$rc" -eq 0 ] && grepq "$out" '^release-token: `no-scope-sess`$' && [ "$s67_written" -eq 0 ]; then
     pass "T67: with no resolvable scope, acquire still succeeds and persists NOTHING"
 else
     fail "T67: expected a clean acquire with no token written (rc=$rc written=$s67_written: $out)"

--- a/templates/luna-second-brain/.gitleaks.toml
+++ b/templates/luna-second-brain/.gitleaks.toml
@@ -30,8 +30,11 @@ paths = [
 # generic-api-key rule flags the line ("release-token: `...`") on entropy, and
 # that refusal silently stalls the github-sync autosync commit (2026-09-09,
 # console 03F: staged for 40 min, three missed syncs). Anchored to that exact
-# shape only.
+# shape, plus one optional trailing sentence-punctuation character (HIMMEL-2910:
+# a leg's bare, unbacktick-quoted `release-token=<token>.` let gitleaks capture
+# the trailing "." into the secret, missing the anchor) — a suffixed real
+# credential is still caught, only that shape.
 regexes = [
   '''^himmel-local-claudex$''',
-  '''^[a-z0-9]+-[a-z0-9]+-pid[0-9]+$''',
+  '''^[a-z0-9]+-[a-z0-9]+-pid[0-9]+[.,;:)]?$''',
 ]

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/CHANGELOG.md
+++ b/templates/luna-second-brain/CHANGELOG.md
@@ -8,6 +8,18 @@ Version history for the luna-second-brain vault template (published as
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.4.21] — 2026-09-10
+
+### Fixed
+- **`.gitleaks.toml`'s release-token allowlist tolerates trailing sentence
+  punctuation (HIMMEL-2910).** The anchored regex added in HIMMEL-2886
+  (`^[a-z0-9]+-[a-z0-9]+-pid[0-9]+$`) missed a token followed by punctuation
+  — a leg writing `release-token=<token>.` (no backticks) into its LIVE
+  bullet let gitleaks' generic-api-key rule capture the trailing `.` into
+  the secret, stalling a real autosync commit for 30 min. Widened to allow
+  one optional trailing `[.,;:)]` character; a suffixed real credential is
+  still caught.
+
 ## [0.4.16] — 2026-09-10
 
 ### Fixed

--- a/templates/luna-second-brain/CHANGELOG.md
+++ b/templates/luna-second-brain/CHANGELOG.md
@@ -8,6 +8,15 @@ Version history for the luna-second-brain vault template (published as
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.4.22] — 2026-09-10
+
+### Fixed
+- **`test-vault-git.sh`'s D11e near-miss assertion avoids a pipefail SIGPIPE
+  risk (HIMMEL-2910 follow-up).** `grep -q` under `set -o pipefail` can
+  SIGPIPE its producer on an early match, flipping a real gitleaks-blocked
+  finding to read as a test failure; captures the pipeline into a variable
+  first instead of piping into `grep -q` directly.
+
 ## [0.4.21] — 2026-09-10
 
 ### Fixed

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.21"
+    "version": "0.4.22"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.20"
+    "version": "0.4.21"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/scripts/test-vault-git.sh
+++ b/templates/luna-second-brain/scripts/test-vault-git.sh
@@ -259,6 +259,39 @@ else
   assert_eq "D11 release-token note IS in committed tree" "1" \
     "$(git_in "$VC" ls-tree -r HEAD --name-only | grep -c 'release-token\.md' || true)"
 
+  # D11b-D11c (HIMMEL-2910): the allowlist tolerates one trailing
+  # sentence-punctuation character after the token. A leg that writes the
+  # token bare (no backticks) into a LIVE bullet followed by sentence
+  # punctuation let gitleaks capture that trailing character into the
+  # secret, missing the pre-2910 anchor, and stalled a real autosync for
+  # 30 min (2026-09-10). This proves the widened regex still lets that
+  # shape through.
+  # Fixture split the same way D8's near-miss is (see its comment above):
+  # this file is ALSO scanned by himmel's own top-level gitleaks pre-commit
+  # hook (which carries none of the template's release-token allowlist), so
+  # the token-plus-punctuation literal is passed as a printf ARGUMENT rather
+  # than inlined into the format string -- byte-identical fixture content,
+  # without a "release-token: <secret-shaped-value>" line sitting in this
+  # test's own source for the generic-api-key rule to catch.
+  printf 'release-token: %s\n' 'cachyos-x8664-pid199037.' >"$VC/30-Resources/release-token-punct.md"
+  (cd "$VC" && LUNA_VAULT_AUTOSYNC=1 bash "$VC/scripts/vault-autosync.sh") >/dev/null 2>&1
+  assert_ok "D11b trailing-punctuation release-token allowlist: autosync commits (exit 0)" "$?"
+  assert_eq "D11c trailing-punctuation release-token note IS in committed tree" "1" \
+    "$(git_in "$VC" ls-tree -r HEAD --name-only | grep -c 'release-token-punct\.md' || true)"
+
+  # D11d-D11f (HIMMEL-2910): a real-looking suffixed near-miss of the SAME
+  # token shape must still be blocked -- the widened regex must not have
+  # opened the anchor past one optional trailing punctuation character.
+  # Same printf-argument split as D11b above, for the same reason.
+  d11_before=$(git_in "$VC" rev-parse HEAD)
+  printf 'release-token: %s\n' 'cachyos-x8664-pid199037-abc' >"$VC/30-Resources/release-token-nearmiss.md"
+  d11d_out=$( (cd "$VC" && LUNA_VAULT_AUTOSYNC=1 bash "$VC/scripts/vault-autosync.sh") 2>&1 ); d11d_rc=$?
+  assert_nz "D11d release-token near-miss (suffixed) still blocked (non-zero)" "$d11d_rc"
+  printf '%s\n' "$d11d_out" | grep -qE 'leaks found: *[1-9][0-9]*'
+  assert_ok "D11e release-token near-miss block attributable to gitleaks (secret scan)" "$?"
+  assert_eq "D11f release-token near-miss NOT in committed tree" "$d11_before" "$(git_in "$VC" rev-parse HEAD)"
+  rm -f "$VC/30-Resources/release-token-nearmiss.md"
+
   # D12-D13 (HIMMEL-2886): the template carries the console-kit shellcheck
   # exclude. Archived console-kit scripts under handovers/**/specs/console-kit-*/
   # are scratchpad copies, not shipped code; linting them stalled the vault's

--- a/templates/luna-second-brain/scripts/test-vault-git.sh
+++ b/templates/luna-second-brain/scripts/test-vault-git.sh
@@ -287,8 +287,11 @@ else
   printf 'release-token: %s\n' 'cachyos-x8664-pid199037-abc' >"$VC/30-Resources/release-token-nearmiss.md"
   d11d_out=$( (cd "$VC" && LUNA_VAULT_AUTOSYNC=1 bash "$VC/scripts/vault-autosync.sh") 2>&1 ); d11d_rc=$?
   assert_nz "D11d release-token near-miss (suffixed) still blocked (non-zero)" "$d11d_rc"
-  printf '%s\n' "$d11d_out" | grep -qE 'leaks found: *[1-9][0-9]*'
-  assert_ok "D11e release-token near-miss block attributable to gitleaks (secret scan)" "$?"
+  # pipefail-ok note (known-findings grep-q-pipe-under-pipefail): captured
+  # into a variable first, not `| grep -q` directly, so a SIGPIPE'd printf
+  # under `set -o pipefail` can never flip this to non-zero on a real match.
+  d11e_leak=$(printf '%s\n' "$d11d_out" | grep -E 'leaks found: *[1-9][0-9]*')
+  assert_ok "D11e release-token near-miss block attributable to gitleaks (secret scan)" "$([ -n "$d11e_leak" ] && echo 0 || echo 1)"
   assert_eq "D11f release-token near-miss NOT in committed tree" "$d11_before" "$(git_in "$VC" rev-parse HEAD)"
   rm -f "$VC/30-Resources/release-token-nearmiss.md"
 


### PR DESCRIPTION
## Summary

Two fixes for HIMMEL-2910 (found by console 03J, 2026-09-10: a leg's release-token, written bare and followed by sentence punctuation into its LIVE bullet, tripped gitleaks' `generic-api-key` rule and stalled the luna vault's autosync commit for 30 min).

**Item 1 — the template allowlist tolerates trailing sentence punctuation**
- `templates/luna-second-brain/.gitleaks.toml`: widened the anchored release-token regex from `^[a-z0-9]+-[a-z0-9]+-pid[0-9]+$` to `^[a-z0-9]+-[a-z0-9]+-pid[0-9]+[.,;:)]?$` — one optional trailing punctuation character, still anchored.
- Template bumped 0.4.20 → 0.4.22 (`.vault-template.json`, `marketplace.json`), CHANGELOG entries added.
- RED/GREEN: `test-vault-git.sh` D11b-D11f against the real gitleaks binary — a trailing-punctuation token now commits clean; a suffixed near-miss of the same shape is still blocked.

**Item 2 — queue-lock prints the safe (backticked) shape**
- `scripts/handover/queue-lock.sh` `acquire` now prints `release-token: \`<token>\`` (backticked) on both its code paths (fresh acquire and stale-takeover).
- `heartbeat`/`release` accept the token exactly as printed (backticked) as well as the pre-2910 bare form, via a `_ql_token_matches` helper that tries an exact match first, then a backtick-stripped one, against the SAME unmodified candidate — it never normalizes the token before checking whether one was supplied at all (a CR-round-2 fix: an earlier revision that stripped eagerly let the 2-char literal `` `` `` normalize to empty and silently fall through to a persisted-token recall instead of refusing an explicit wrong token).
- Every consumer that parses the printed line strips a matched backtick pair before use: `console.sh` (the token embedded into `{{RELEASE_TOKEN}}`) and `test-console.sh`'s `token_of()`.
- `.claude/commands/console.md` updated to name the backticked shape (`docs/handover/` is out of scope for this ticket per the leg brief).
- No `.ps1` twin of `queue-lock.sh` or `console.sh` exists.

## CR review (3 rounds via the critic panel, all adjudicated)

- **Round 1 (Suggestion, codex-1):** stripping backticks from a *recalled* token (not just an argv one) could mangle a caller-chosen session id that itself starts/ends with a backtick. Fixed by scoping the strip to argv-supplied tokens only.
- **Round 2 (Important, codex-1 + Suggestion, codex-2):** the round-1 fix's eager stripping let an explicit wrong token (`` `` ``) normalize to empty and fall through to recall instead of being refused; the same eager-strip design also risked the round-1 self-backticked-id case. Both fixed together by a redesign: a new `_ql_token_matches` helper tries exact-then-stripped against the unmodified candidate, never normalizing `$session` before the "was a token given" check.
- **Round 3:** clean (0 Critical / 0 Important / 0 Suggestions).

## Known-findings pre-rebuttal

- `[ps1-twin-parity]`: `templates/luna-second-brain/scripts/test-vault-git.sh` changed without touching its `.ps1` twin. Not a real gap — the twin's own header states "the exhaustive behaviour (gate matrix, secret-block) is covered by the bash [twin]"; the `.ps1` only smoke-tests a minimal subset and never carried the Phase D gitleaks matrix (confirmed: HIMMEL-2886 also only touched the `.sh` file for the same reason).

## Test plan

- [x] RED/GREEN verified against the real `gitleaks` binary for item 1 (`test-vault-git.sh` D11b-D11f)
- [x] RED/GREEN verified via real subprocess invocations for item 2 (`test-queue-lock.sh` T1/T1b-T1e/T24b/T26/T51/T56/T64/T67), plus empirical manual verification of both CR-round fixes against a real acquire/release round-trip
- [x] All impacted suites green via quiet-run: `test-vault-git.sh`, `test-upgrade.sh`, `test-salus-upgrade.sh`, `test-lesson-write-fence.sh`, `test-wizard-{adopter-profile,derive,probes}.sh`, `test-check-template-himmel-plugins.sh`, `test-template-version.sh`, `test-resync-fork.sh`, `test-queue-lock.sh`, `test-console.sh`, `test-suite-concurrency.sh`, `console-kit/test-tick.sh`, `test-arm-resume-{identity,probe,proxy}.sh`, `test-leg-resume-brief.sh`, `test-worker-lifecycle.sh`, `test-handover-path.sh`
- [x] `test-arm-resume-queue-lock.sh`'s pre-existing T15/T19 red (documented in that file as pre-existing at `434c5a51`, not this ticket's to fix) reproduced against the pre-fix `queue-lock.sh` too — confirmed unrelated to this change
- [x] shellcheck clean on every touched shell file
- [x] gitleaks clean on the staged diff of every commit
- [x] Critic panel clean after 3 rounds, all findings adjudicated and resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDz5HeoVGFgca84yUufm1R