### PR TITLE
test(handover): [HIMMEL-2908] LG4 DST guard is deterministic -- a fixed spring-forward day under a pinned zone proves the detector fires

### DIFF
--- a/scripts/handover/test-arm-resume-long-gap.sh
+++ b/scripts/handover/test-arm-resume-long-gap.sh
@@ -300,15 +300,27 @@ PY
 # to a fixed mid-year date instead: no tzdata table places a DST transition
 # in mid-June, so this never lands in a gap or fold, on any date the suite
 # actually runs on.
-read -r _lg4_0005_epoch _lg4_1234_epoch _lg4_0000_epoch < <(python3 -c '
+#
+# HIMMEL-2908: extracted so the SAME construction can be replayed below
+# against a known DST spring-forward day (deterministic guard), not just
+# the pinned mid-June anchor. Also emits an epoch for local 02:30, unused
+# by the mid-June fixtures but consumed by that replay.
+lg4_fixture_epochs() {
+    python3 - "$1" "$2" "$3" <<'PY'
 import datetime
-now = datetime.datetime(datetime.date.today().year, 6, 15)
+import sys
+
+year, month, day = (int(x) for x in sys.argv[1:4])
+anchor = datetime.datetime(year, month, day)
 print(
-    int(now.replace(hour=0, minute=5, second=0, microsecond=0).timestamp()),
-    int(now.replace(hour=12, minute=34, second=0, microsecond=0).timestamp()),
-    int(now.replace(hour=0, minute=0, second=0, microsecond=0).timestamp()),
+    int(anchor.replace(hour=0, minute=5, second=0, microsecond=0).timestamp()),
+    int(anchor.replace(hour=12, minute=34, second=0, microsecond=0).timestamp()),
+    int(anchor.replace(hour=0, minute=0, second=0, microsecond=0).timestamp()),
+    int(anchor.replace(hour=2, minute=30, second=0, microsecond=0).timestamp()),
 )
-')
+PY
+}
+read -r _lg4_0005_epoch _lg4_1234_epoch _lg4_0000_epoch _lg4_0230_epoch < <(lg4_fixture_epochs "$(date +%Y)" 6 15)
 # HIMMEL-2877: regression guard for the fixture itself, independent of
 # lg4_wrap_hhmm - round-trip the epoch back through localtime and confirm
 # it still reads 00:05. A future edit that reintroduces a "today"-based
@@ -322,6 +334,58 @@ else
     echo "FAIL LG4 fixture epoch round-trips to $_lg4_0005_roundtrip, not 00:05 -- fixture date may sit inside a DST gap/fold"
     FAILED=$((FAILED + 1))
 fi
+# HIMMEL-2908: the round-trip guard just above is honest but weak -- it only
+# fires if the suite happens to run ON a real DST transition day, since on
+# an ordinary day a reintroduced datetime.date.today() round-trips cleanly
+# too. Make the catch deterministic by replaying lg4_fixture_epochs against
+# a KNOWN spring-forward day (Europe/Berlin's last Sunday of March, where
+# local 02:00-02:59 do not exist) regardless of what day the suite actually
+# runs on. TZ is set only for these subprocess invocations, never exported
+# for the rest of the suite.
+if _lg4_dst_tzdata_missing=$(python3 -c '
+import sys
+try:
+    from zoneinfo import ZoneInfo
+    ZoneInfo("Europe/Berlin")
+except Exception as e:
+    print(e)
+    sys.exit(1)
+' 2>&1); then
+    read -r _lg4_dst_year _lg4_dst_month _lg4_dst_day < <(python3 -c '
+import datetime
+year = datetime.date.today().year
+d = datetime.date(year, 3, 31)
+while d.weekday() != 6:
+    d -= datetime.timedelta(days=1)
+print(d.year, d.month, d.day)
+')
+    read -r _lg4_dst_0005_epoch _lg4_dst_1234_epoch _lg4_dst_0000_epoch _lg4_dst_0230_epoch < <(TZ=Europe/Berlin lg4_fixture_epochs "$_lg4_dst_year" "$_lg4_dst_month" "$_lg4_dst_day")
+    _lg4_dst_0005_roundtrip=$(TZ=Europe/Berlin python3 -c "import datetime, sys; print(datetime.datetime.fromtimestamp(int(sys.argv[1])).strftime('%H:%M'))" "$_lg4_dst_0005_epoch")
+    if [ "$_lg4_dst_0005_roundtrip" = "00:05" ]; then
+        echo "PASS LG4 DST transition-day fixture epoch (00:05) round-trips cleanly outside the gap"
+    else
+        echo "FAIL LG4 DST transition-day fixture epoch (00:05) round-tripped to $_lg4_dst_0005_roundtrip, not 00:05"
+        FAILED=$((FAILED + 1))
+    fi
+    _lg4_dst_1234_roundtrip=$(TZ=Europe/Berlin python3 -c "import datetime, sys; print(datetime.datetime.fromtimestamp(int(sys.argv[1])).strftime('%H:%M'))" "$_lg4_dst_1234_epoch")
+    if [ "$_lg4_dst_1234_roundtrip" = "12:34" ]; then
+        echo "PASS LG4 DST transition-day fixture epoch (12:34) round-trips cleanly outside the gap"
+    else
+        echo "FAIL LG4 DST transition-day fixture epoch (12:34) round-tripped to $_lg4_dst_1234_roundtrip, not 12:34"
+        FAILED=$((FAILED + 1))
+    fi
+    _lg4_dst_0230_roundtrip=$(TZ=Europe/Berlin python3 -c "import datetime, sys; print(datetime.datetime.fromtimestamp(int(sys.argv[1])).strftime('%H:%M'))" "$_lg4_dst_0230_epoch")
+    if [ "$_lg4_dst_0230_roundtrip" != "02:30" ]; then
+        echo "PASS LG4 DST transition-day guard fires: local 02:30 (inside the spring-forward gap) round-trips to $_lg4_dst_0230_roundtrip, not 02:30 -- a reintroduced today-based fixture landing here would be caught deterministically"
+    else
+        echo "FAIL LG4 DST transition-day guard did not fire: local 02:30 round-tripped cleanly to 02:30 -- a reintroduced today-based fixture landing in this gap would silently pass"
+        FAILED=$((FAILED + 1))
+    fi
+    unset _lg4_dst_year _lg4_dst_month _lg4_dst_day _lg4_dst_0005_epoch _lg4_dst_1234_epoch _lg4_dst_0000_epoch _lg4_dst_0230_epoch _lg4_dst_0005_roundtrip _lg4_dst_1234_roundtrip _lg4_dst_0230_roundtrip
+else
+    echo "SKIP LG4 DST transition-day guard: Europe/Berlin tzdata unavailable ($_lg4_dst_tzdata_missing)"
+fi
+unset _lg4_dst_tzdata_missing
 _lg4_0005_hhmm=$(lg4_wrap_hhmm "$_lg4_0005_epoch")
 if [ "$_lg4_0005_hhmm" = "00:00" ]; then
     echo "PASS LG4 fixture local 00:05 stays inside today (00:00)"
@@ -356,7 +420,7 @@ _lg4_midnight_reason=$(lg4_wrap_hhmm "$_lg4_0000_epoch" 2>&1)
 _lg4_midnight_rc=$?
 assert_rc "LG4 fixture exact midnight signals skip" 10 "$_lg4_midnight_rc"
 assert_contains "LG4 fixture exact midnight names the skip reason" "exact local midnight has no earlier same-day HH:MM" "$_lg4_midnight_reason"
-unset _lg4_0005_epoch _lg4_1234_epoch _lg4_0000_epoch _lg4_0005_roundtrip _lg4_0005_hhmm _lg4_0005_rolled _lg4_1234_hhmm _lg4_midnight_reason _lg4_midnight_rc
+unset _lg4_0005_epoch _lg4_1234_epoch _lg4_0000_epoch _lg4_0230_epoch _lg4_0005_roundtrip _lg4_0005_hhmm _lg4_0005_rolled _lg4_1234_hhmm _lg4_midnight_reason _lg4_midnight_rc
 
 # HIMMEL-2877 (E1): WRAP_HHMM used to be captured ONCE here, before LG1-LG3
 # run below - each of which shells out to python3 and arm-resume, taking

--- a/scripts/handover/test-arm-resume-long-gap.sh
+++ b/scripts/handover/test-arm-resume-long-gap.sh
@@ -342,13 +342,26 @@ fi
 # local 02:00-02:59 do not exist) regardless of what day the suite actually
 # runs on. TZ is set only for these subprocess invocations, never exported
 # for the rest of the suite.
-if _lg4_dst_tzdata_missing=$(python3 -c '
+if _lg4_dst_tzdata_missing=$(TZ=Europe/Berlin python3 -c '
+import datetime
 import sys
+
 try:
     from zoneinfo import ZoneInfo
     ZoneInfo("Europe/Berlin")
 except Exception as e:
     print(e)
+    sys.exit(1)
+
+# codex-2 (HIMMEL-2908 pr-check round 1): the zoneinfo check above only
+# proves the tzdata TABLE exists, not that this Python/OS actually honors
+# TZ for naive datetime.timestamp()/fromtimestamp() (notably native Windows
+# Python, whose C runtime does not parse IANA TZ names) -- verify against a
+# fixed reference epoch (1970-01-01 00:00 UTC, pre-DST, so the expected
+# offset is a plain UTC+1) before trusting the assertions below.
+probe = datetime.datetime.fromtimestamp(0).strftime("%H:%M")
+if probe != "01:00":
+    print(f"TZ=Europe/Berlin not honored by this Python/OS (epoch 0 -> {probe}, expected 01:00)")
     sys.exit(1)
 ' 2>&1); then
     read -r _lg4_dst_year _lg4_dst_month _lg4_dst_day < <(python3 -c '
@@ -374,8 +387,13 @@ print(d.year, d.month, d.day)
         echo "FAIL LG4 DST transition-day fixture epoch (12:34) round-tripped to $_lg4_dst_1234_roundtrip, not 12:34"
         FAILED=$((FAILED + 1))
     fi
-    _lg4_dst_0230_roundtrip=$(TZ=Europe/Berlin python3 -c "import datetime, sys; print(datetime.datetime.fromtimestamp(int(sys.argv[1])).strftime('%H:%M'))" "$_lg4_dst_0230_epoch")
-    if [ "$_lg4_dst_0230_roundtrip" != "02:30" ]; then
+    # codex-1 (HIMMEL-2908 pr-check round 1): assert success on `!=`, so a
+    # failed/empty conversion (which is also != "02:30") must be its own
+    # branch rather than silently reading as PASS.
+    if ! _lg4_dst_0230_roundtrip=$(TZ=Europe/Berlin python3 -c "import datetime, sys; print(datetime.datetime.fromtimestamp(int(sys.argv[1])).strftime('%H:%M'))" "$_lg4_dst_0230_epoch"); then
+        echo "FAIL LG4 DST transition-day guard: round-trip conversion command failed for local 02:30"
+        FAILED=$((FAILED + 1))
+    elif [ "$_lg4_dst_0230_roundtrip" != "02:30" ]; then
         echo "PASS LG4 DST transition-day guard fires: local 02:30 (inside the spring-forward gap) round-trips to $_lg4_dst_0230_roundtrip, not 02:30 -- a reintroduced today-based fixture landing here would be caught deterministically"
     else
         echo "FAIL LG4 DST transition-day guard did not fire: local 02:30 round-tripped cleanly to 02:30 -- a reintroduced today-based fixture landing in this gap would silently pass"


### PR DESCRIPTION
## Summary

HIMMEL-2877 (#608) pinned the LG4 self-test fixtures to a fixed mid-June date and added a round-trip guard against a reintroduced "today"-based construction. The guard is honest but weak: it only fires if CI happens to run ON an actual DST transition day, since on an ordinary day a reintroduced `datetime.date.today()` round-trips cleanly too.

Extracted the fixture construction into `lg4_fixture_epochs(year, month, day)` (`scripts/handover/test-arm-resume-long-gap.sh`) so it can be replayed against a KNOWN spring-forward day (Europe/Berlin's last Sunday of March, where local 02:00-02:59 do not exist), independent of the day the suite actually runs on. New assertions confirm 00:05/12:34 still round-trip cleanly outside the gap, and that 02:30 (inside the gap) round-trips to 03:30 -- proving the detector fires. TZ is scoped to the individual python invocations, never exported for the rest of the suite. Loudly SKIPs if Europe/Berlin tzdata is unavailable, or if the TZ env var isn't actually honored by this Python/OS.

## Pre-rebuttal (known-findings check)

`known-findings.sh --diff` flagged `[octal-leading-zero]` on three `FAILED=$((FAILED + 1))` lines. Disproved: `FAILED` is an internal counter starting at 0 and incrementing by 1, never carrying a leading zero (date/user input), so there is no octal-parsing hazard.

## RED/GREEN evidence

- Baseline GREEN before the change (pre-existing suite, E2-fixed since #608).
- RED: temporarily made `lg4_fixture_epochs` ignore its args and fall back to `date.today()`. Result: the new 02:30 (inside-the-gap) assertion FAILED ("round-tripped cleanly to 02:30"), while the **pre-existing** round-trip guard still spuriously PASSED -- since today (2026-09-10) is not a transition day. This is exactly the weakness HIMMEL-2908 describes.
- Restored (diff against the pre-mutation copy confirmed byte-identical); re-ran GREEN.
- shellcheck initially flagged SC2181 (`$?` indirection on the tzdata-availability check); fixed to `if cmd; then`; re-shellcheck clean.
- Impacted suites (every suite referencing the touched file) green via quiet-run: `test-arm-resume-proxy.sh`, `test-worker-lifecycle.sh`.

## CR review (2 rounds, both adjudicated)

- **Round 1 (2 Suggestions, codex):** (1) the 02:30 gap check asserted success on `!=`, so a failed/empty conversion would silently read as PASS -- fixed by splitting a dedicated failure branch. (2) the zoneinfo availability probe only proved the tzdata table exists, not that this Python/OS actually honors `TZ` for naive datetime conversions (notably native Windows Python) -- fixed by adding a fixed-epoch (0 -> expected 01:00 CET) probe before trusting the assertions. Both fixed in a follow-up commit; ledger amended `agreed`.
- **Round 2 (1 Suggestion, codex):** the deterministic replay validates the extracted helper against a supplied transition date, but doesn't separately assert the real-fixture call site still passes the literal `6 15` rather than a live date. Genuinely additive, out of this ticket's scope -- deferred to HIMMEL-2914; ledger amended `deferred`.

## Test plan

- [x] `bash scripts/quiet-run.sh <name> -- bash scripts/handover/test-arm-resume-long-gap.sh` green, including the new LG4 DST-transition-day PASS lines
- [x] RED reproduction (reintroduced `date.today()`) shows the new assertion catching the regression the old guard misses
- [x] Impacted suites (`test-arm-resume-proxy.sh`, `test-worker-lifecycle.sh`) green via quiet-run
- [x] shellcheck clean
- [x] Critic panel clean after 2 rounds (0 Critical / 0 Important), both Suggestion rounds adjudicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CVpbTFb8JbA2N9pzh1Xag