### PR TITLE
feat(cr): [HIMMEL-2911] agreed findings are promoted to fixed after a clean /pr-check round

### DIFF
--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -748,9 +748,11 @@ Steps:
    ```
    Paste its summary line. Exit 0 = done. Exit 3 = it printed each
    `still-open <id>@<sha>` finding that re-raised at this head — name those in
-   the report and leave them `agreed`. Any other non-zero: fall back to a hand
-   `ledger-append.sh amend --set verdict=fixed` for the finding it could not
-   resolve.
+   the report and leave them `agreed` (never hand-amend a re-raised finding to
+   `fixed`). Any other non-zero (a malformed ledger row, an unresolvable
+   `--head`, or a ledger write failure) is an infrastructure failure, not a
+   per-finding one: STOP, report the exact stderr line, repair the cause, and
+   re-run `promote` — never hand-amend anything as a workaround.
 
 6. If either `N > 0`, or step 4.8 reported `threads_rc != 0`:
    - Leave the marker in place.

--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -741,6 +741,17 @@ Steps:
      a commit landed after the review, so re-run `/pr-check` on the new HEAD.
      Do NOT fall back to `rm`.
 
+   **Promote agreed findings to fixed (HIMMEL-2911).** Once the marker cleared
+   above, terminalize every finding still `agreed` on this branch:
+   ```bash
+   bash "<himmel_dir>/scripts/cr/review-round.sh" promote --branch '<branch>' --head <head>
+   ```
+   Paste its summary line. Exit 0 = done. Exit 3 = it printed each
+   `still-open <id>@<sha>` finding that re-raised at this head — name those in
+   the report and leave them `agreed`. Any other non-zero: fall back to a hand
+   `ledger-append.sh amend --set verdict=fixed` for the finding it could not
+   resolve.
+
 6. If either `N > 0`, or step 4.8 reported `threads_rc != 0`:
    - Leave the marker in place.
    - Surface the Critical / Important findings (and any unresolved-thread count) to the user.

--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -747,10 +747,11 @@ Steps:
    bash "<himmel_dir>/scripts/cr/review-round.sh" promote --branch '<branch>' --head <head>
    ```
    Paste its summary line. Exit 0 = done. Exit 3 = it printed each
-   `still-open <id>@<sha>` finding that re-raised at this head — name those in
-   the report and leave them `agreed` (never hand-amend a re-raised finding to
-   `fixed`). Any other non-zero (a malformed ledger row, an unresolvable
-   `--head`, or a ledger write failure) is an infrastructure failure, not a
+   `still-open <id>@<sha>` finding it left `agreed` — a genuine re-raise, a
+   same-head or non-ancestor commit, or a finding it could not safely check —
+   name those in the report and never hand-amend one of them to `fixed`. Any
+   other non-zero (a malformed ledger row, an unresolvable `--head`, or a
+   ledger write failure) is an infrastructure failure, not a
    per-finding one: STOP, report the exact stderr line, repair the cause, and
    re-run `promote` — never hand-amend anything as a workaround.
 

--- a/scripts/cr/review-round.sh
+++ b/scripts/cr/review-round.sh
@@ -127,20 +127,23 @@ fi
 # not re-running it), every `finding` row on --branch whose LATEST amend
 # (joined on target_head + finding_id + artifact + perspective — NOT branch,
 # since pre-HIMMEL-2911 rows can carry branch:"") is `agreed` is promoted to
-# `fixed` UNLESS it is re-raised at --head: another finding row on the same
-# branch, at --head, sharing the same stored `fingerprint` (ledger-append.sh
-# already computes this at write time — promote reads it, never recomputes
-# it). A row's own identity (head, finding_id, artifact, perspective) is
-# excluded from its own re-raise check, so a finding raised and agreed AT
-# --head itself (never re-raised anywhere else) is promoted too — the
-# acceptance bar is "no agreed row survives a clean round", not merely "no
-# agreed row from an earlier head survives". Terminal rows (fixed/disproved/
-# deferred) are left untouched; conflict/unaddressed were never agreed and are
-# only WARNed. A finding whose stored fingerprint is empty (pre-fingerprint
-# row, or no --text was ever supplied) cannot be safely checked for re-raise,
-# so it is conservatively left agreed (counted as still-open) rather than
-# guessed at. Idempotent: a second run sees the fixed amend via the same
-# effective-state merge and skip-terminals it, writing nothing.
+# `fixed` UNLESS (a) its OWN row is recorded exactly at --head — a finding
+# raised and agreed in the very round being certified clean has had no later
+# commit that could have fixed it, so it is left agreed rather than stamped
+# resolved on zero evidence (codex-1, HIMMEL-2911 CR round 1) — or (b) it is
+# re-raised at --head: a DIFFERENT finding row on the same branch, at --head,
+# sharing the same stored `fingerprint` (ledger-append.sh already computes
+# this at write time — promote reads it, never recomputes it) whose OWN
+# effective verdict is still live (empty/agreed/conflict/unaddressed, never
+# fixed/disproved/deferred — codex-2, HIMMEL-2911 CR round 1: a matching
+# occurrence that is itself already dispositioned is not an open re-raise).
+# Terminal rows (fixed/disproved/deferred) are left untouched; conflict/
+# unaddressed were never agreed and are only WARNed. A finding whose stored
+# fingerprint is empty (pre-fingerprint row, or no --text was ever supplied)
+# cannot be safely checked for re-raise, so it is conservatively left agreed
+# (counted as still-open) rather than guessed at. Idempotent: a second run
+# sees the fixed amend via the same effective-state merge and skip-terminals
+# it, writing nothing.
 # Exit 0 = nothing left agreed; exit 3 = one or more rows are still-open (the
 # caller's round was not actually clean for that finding); exit 1 = a
 # malformed ledger row or a ledger write failure.
@@ -197,10 +200,18 @@ for (const o of rows) {
 }
 const findingRows = rows.filter((o) => o.kind === "finding" && o.branch === e.BRANCH);
 const atHead = findingRows.filter((o) => resolvesToHead(o.head));
+// Only a LIVE occurrence at --head is a genuine re-raise (codex-2, HIMMEL-2911
+// CR round 1): a matching finding at --head that is itself already
+// fixed/disproved/deferred is a DISPOSITIONED instance, not an open one, and
+// must not keep an older agreed row still-open forever just because its
+// fingerprint once reappeared.
+const liveVerdicts = new Set(["", "agreed", "conflict", "unaddressed"]);
 const fpAtHead = new Map();
 for (const o of atHead) {
   if (!o.fingerprint) continue;
   const idKey = [o.head, o.finding_id, o.artifact || "diff", o.perspective || "off"].join(SEP);
+  const effectiveAtHead = Object.assign({}, o, amendsByKey.get(idKey) || {});
+  if (!liveVerdicts.has(String(effectiveAtHead.verdict || "").trim())) continue;
   if (!fpAtHead.has(o.fingerprint)) fpAtHead.set(o.fingerprint, new Set());
   fpAtHead.get(o.fingerprint).add(idKey);
 }
@@ -213,7 +224,16 @@ for (const row of findingRows) {
   if (verdict === "fixed" || verdict === "disproved" || verdict === "deferred") action = "skip-terminal";
   else if (verdict === "conflict" || verdict === "unaddressed") action = "warn-unadjudicated";
   else if (verdict !== "agreed") continue;
-  else {
+  else if (resolvesToHead(row.head)) {
+    // codex-1, HIMMEL-2911 CR round 1: a finding raised (and agreed) AT the
+    // very head being asserted clean has had no later commit that could have
+    // fixed it — promoting it here would stamp an untouched, still-present
+    // issue as resolved on zero evidence. Leave it agreed; it needs a real
+    // disposition (a follow-up fix at a fresh head, or a deferral), the same
+    // way the round-4 cap defers a same-head pending suggestion instead of
+    // fabricating a fix for it.
+    action = "still-open";
+  } else {
     const fp = effective.fingerprint || "";
     const present = fp ? fpAtHead.get(fp) : null;
     const reraised = !fp || (present && [...present].some((k) => k !== idKey));

--- a/scripts/cr/review-round.sh
+++ b/scripts/cr/review-round.sh
@@ -309,7 +309,7 @@ process.stdout.write(JSON.stringify({malformed: 0}));
         row_head8="$(printf '%s' "$row_head" | cut -c1-8)"
         case "$action" in
             promote)
-                if ! bash "$SCRIPT_DIR/ledger-append.sh" amend \
+                if ! CR_LEDGER="$ledger" bash "$SCRIPT_DIR/ledger-append.sh" amend \
                     --branch "$row_branch" --head "$row_head" --id "$id" \
                     --artifact "$row_artifact" --perspective "$row_perspective" \
                     --set verdict=fixed \

--- a/scripts/cr/review-round.sh
+++ b/scripts/cr/review-round.sh
@@ -12,6 +12,7 @@ HIMMEL_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 usage() {
     echo "usage: review-round.sh start --branch <name>" >&2
     echo "       review-round.sh defer --branch <name> --head <sha> [--defer-to <ticket>]" >&2
+    echo "       review-round.sh promote --branch <name> --head <sha>" >&2
     exit 2
 }
 
@@ -33,6 +34,7 @@ done
 case "$verb" in
     start) [ -z "$head_sha" ] || usage ;;
     defer) [ -n "$head_sha" ] || usage ;;
+    promote) [ -n "$head_sha" ] || usage ;;
     *) usage ;;
 esac
 
@@ -114,6 +116,179 @@ if [ "$verb" = "start" ]; then
         exit 5
     fi
     printf '%s\n' "$round"
+    exit 0
+fi
+
+# promote (HIMMEL-2911): the /pr-check flow writes verdict=agreed as a leg-agrees
+# intermediate (write-verdicts.sh + step 4.5's ledger-append.sh amend) and
+# nothing ever promotes it to a terminal verdict — until now it was only ever
+# hand-amended to `fixed`. Given a CLEAN round at --head (the caller asserts
+# this — promote does not itself re-check the panel, same posture as `defer`
+# not re-running it), every `finding` row on --branch whose LATEST amend
+# (joined on target_head + finding_id + artifact + perspective — NOT branch,
+# since pre-HIMMEL-2911 rows can carry branch:"") is `agreed` is promoted to
+# `fixed` UNLESS it is re-raised at --head: another finding row on the same
+# branch, at --head, sharing the same stored `fingerprint` (ledger-append.sh
+# already computes this at write time — promote reads it, never recomputes
+# it). A row's own identity (head, finding_id, artifact, perspective) is
+# excluded from its own re-raise check, so a finding raised and agreed AT
+# --head itself (never re-raised anywhere else) is promoted too — the
+# acceptance bar is "no agreed row survives a clean round", not merely "no
+# agreed row from an earlier head survives". Terminal rows (fixed/disproved/
+# deferred) are left untouched; conflict/unaddressed were never agreed and are
+# only WARNed. A finding whose stored fingerprint is empty (pre-fingerprint
+# row, or no --text was ever supplied) cannot be safely checked for re-raise,
+# so it is conservatively left agreed (counted as still-open) rather than
+# guessed at. Idempotent: a second run sees the fixed amend via the same
+# effective-state merge and skip-terminals it, writing nothing.
+# Exit 0 = nothing left agreed; exit 3 = one or more rows are still-open (the
+# caller's round was not actually clean for that finding); exit 1 = a
+# malformed ledger row or a ledger write failure.
+if [ "$verb" = "promote" ]; then
+    if ! full_head="$(git rev-parse --verify --quiet "$head_sha^{commit}" 2>/dev/null)" || [ -z "$full_head" ]; then
+        echo "review-round: --head $head_sha does not resolve to a commit" >&2
+        exit 2
+    fi
+    ledger="$git_dir/cr-critic-scores.jsonl"
+    if [ ! -f "$ledger" ]; then
+        echo "review-round: CR ledger is missing at $ledger" >&2
+        exit 5
+    fi
+    decisions_tmp="$(mktemp -t cr-promote-decisions.XXXXXX)" || { echo "review-round: cannot create scratch state" >&2; exit 1; }
+    analysis="$(FULL_HEAD="$full_head" LEDGER="$ledger" BRANCH="$branch" DECISIONS_FILE="$decisions_tmp" node -e '
+const fs = require("fs"), cp = require("child_process"), e = process.env;
+const lines = fs.readFileSync(e.LEDGER, "utf8").split("\n").filter(Boolean);
+const SEP = String.fromCharCode(31);
+let malformed = 0;
+const rows = [];
+for (const line of lines) {
+  let o;
+  try { o = JSON.parse(line); } catch { malformed++; continue; }
+  rows.push(o);
+}
+if (malformed !== 0) {
+  process.stdout.write(JSON.stringify({malformed}));
+  process.exit(0);
+}
+const resolveCache = new Map();
+function resolvesToHead(value) {
+  const h = String(value || "");
+  if (h === e.FULL_HEAD) return true;
+  if (!/^[0-9a-f]{7,64}$/i.test(h)) return false;
+  if (!resolveCache.has(h)) {
+    let resolved = "";
+    try {
+      resolved = cp.execFileSync("git", ["rev-parse", "--verify", "--quiet", h + "^{commit}"],
+        {encoding: "utf8", stdio: ["ignore", "pipe", "ignore"]}).trim();
+    } catch { resolved = ""; }
+    resolveCache.set(h, resolved);
+  }
+  return resolveCache.get(h) === e.FULL_HEAD;
+}
+// Merge every amend.set for a (target_head, finding_id, artifact, perspective)
+// key in ledger (chronological) order — a later amend field wins, a field a
+// later amend never touched keeps its earlier value. Same shape as
+// ledger-append.shs own amendsByKey/effective().
+const amendsByKey = new Map();
+for (const o of rows) {
+  if (o.kind !== "amend" || !o.set || typeof o.set !== "object") continue;
+  const k = [o.target_head, o.finding_id, o.artifact || "diff", o.perspective || "off"].join(SEP);
+  amendsByKey.set(k, Object.assign({}, amendsByKey.get(k) || {}, o.set));
+}
+const findingRows = rows.filter((o) => o.kind === "finding" && o.branch === e.BRANCH);
+const atHead = findingRows.filter((o) => resolvesToHead(o.head));
+const fpAtHead = new Map();
+for (const o of atHead) {
+  if (!o.fingerprint) continue;
+  const idKey = [o.head, o.finding_id, o.artifact || "diff", o.perspective || "off"].join(SEP);
+  if (!fpAtHead.has(o.fingerprint)) fpAtHead.set(o.fingerprint, new Set());
+  fpAtHead.get(o.fingerprint).add(idKey);
+}
+const outLines = [];
+for (const row of findingRows) {
+  const idKey = [row.head, row.finding_id, row.artifact || "diff", row.perspective || "off"].join(SEP);
+  const effective = Object.assign({}, row, amendsByKey.get(idKey) || {});
+  const verdict = String(effective.verdict || "").trim();
+  let action;
+  if (verdict === "fixed" || verdict === "disproved" || verdict === "deferred") action = "skip-terminal";
+  else if (verdict === "conflict" || verdict === "unaddressed") action = "warn-unadjudicated";
+  else if (verdict !== "agreed") continue;
+  else {
+    const fp = effective.fingerprint || "";
+    const present = fp ? fpAtHead.get(fp) : null;
+    const reraised = !fp || (present && [...present].some((k) => k !== idKey));
+    action = reraised ? "still-open" : "promote";
+  }
+  outLines.push(JSON.stringify({
+    action, id: row.finding_id, head: row.head, branch: row.branch,
+    artifact: row.artifact || "diff", perspective: row.perspective || "off", verdict,
+  }));
+}
+fs.writeFileSync(e.DECISIONS_FILE, outLines.length ? outLines.join("\n") + "\n" : "");
+process.stdout.write(JSON.stringify({malformed: 0}));
+' 2>/dev/null)"
+    node_rc=$?
+    malformed="$(printf '%s' "$analysis" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(String(JSON.parse(s).malformed)))' 2>/dev/null)" || malformed=""
+    if [ "$node_rc" -ne 0 ] || [ -z "$malformed" ]; then
+        rm -f "$decisions_tmp"
+        echo "review-round: could not evaluate the ledger for promotion" >&2
+        exit 1
+    fi
+    if [ "$malformed" -ne 0 ]; then
+        rm -f "$decisions_tmp"
+        echo "review-round: malformed CR ledger row(s) — refusing automatic promotion" >&2
+        exit 1
+    fi
+    head8="$(printf '%s' "$full_head" | cut -c1-8)"
+    promoted=0 still_open=0 skip_terminal=0 warn_count=0 write_fail=0
+    while IFS= read -r decision || [ -n "$decision" ]; do
+        [ -n "$decision" ] || continue
+        action="$(printf '%s' "$decision" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).action))' 2>/dev/null)" || action=""
+        id="$(printf '%s' "$decision" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).id))' 2>/dev/null)" || id=""
+        row_head="$(printf '%s' "$decision" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).head))' 2>/dev/null)" || row_head=""
+        row_branch="$(printf '%s' "$decision" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).branch))' 2>/dev/null)" || row_branch=""
+        row_artifact="$(printf '%s' "$decision" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).artifact))' 2>/dev/null)" || row_artifact=""
+        row_perspective="$(printf '%s' "$decision" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).perspective))' 2>/dev/null)" || row_perspective=""
+        row_verdict="$(printf '%s' "$decision" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).verdict))' 2>/dev/null)" || row_verdict=""
+        if [ -z "$action" ] || [ -z "$id" ] || [ -z "$row_head" ]; then
+            write_fail=1
+            break
+        fi
+        row_head8="$(printf '%s' "$row_head" | cut -c1-8)"
+        case "$action" in
+            promote)
+                if ! bash "$SCRIPT_DIR/ledger-append.sh" amend \
+                    --branch "$row_branch" --head "$row_head" --id "$id" \
+                    --artifact "$row_artifact" --perspective "$row_perspective" \
+                    --set verdict=fixed \
+                    --reason "Promoted from agreed: no re-raise at clean round head $head8 (HIMMEL-2911)"; then
+                    write_fail=1
+                    break
+                fi
+                echo "promoted ${id}@${row_head8}"
+                promoted=$((promoted + 1))
+                ;;
+            still-open)
+                echo "still-open ${id}@${row_head8}"
+                still_open=$((still_open + 1))
+                ;;
+            skip-terminal)
+                echo "skip-terminal ${id}@${row_head8} (verdict=${row_verdict})"
+                skip_terminal=$((skip_terminal + 1))
+                ;;
+            warn-unadjudicated)
+                echo "WARN unadjudicated ${id}@${row_head8} (verdict=${row_verdict})"
+                warn_count=$((warn_count + 1))
+                ;;
+        esac
+    done < "$decisions_tmp"
+    rm -f "$decisions_tmp"
+    if [ "$write_fail" -ne 0 ]; then
+        echo "review-round: ledger write failed during promotion" >&2
+        exit 1
+    fi
+    echo "review-round promote: $promoted promoted, $still_open still-open, $skip_terminal skip-terminal, $warn_count warn (head $head8)"
+    [ "$still_open" -eq 0 ] || exit 3
     exit 0
 fi
 

--- a/scripts/cr/review-round.sh
+++ b/scripts/cr/review-round.sh
@@ -134,16 +134,21 @@ fi
 # re-raised at --head: a DIFFERENT finding row on the same branch, at --head,
 # sharing the same stored `fingerprint` (ledger-append.sh already computes
 # this at write time — promote reads it, never recomputes it) whose OWN
-# effective verdict is still live (empty/agreed/conflict/unaddressed, never
-# fixed/disproved/deferred — codex-2, HIMMEL-2911 CR round 1: a matching
-# occurrence that is itself already dispositioned is not an open re-raise).
-# Terminal rows (fixed/disproved/deferred) are left untouched; conflict/
-# unaddressed were never agreed and are only WARNed. A finding whose stored
-# fingerprint is empty (pre-fingerprint row, or no --text was ever supplied)
-# cannot be safely checked for re-raise, so it is conservatively left agreed
-# (counted as still-open) rather than guessed at. Idempotent: a second run
-# sees the fixed amend via the same effective-state merge and skip-terminals
-# it, writing nothing.
+# effective verdict is still live (empty/agreed/conflict/unaddressed/deferred,
+# never fixed/disproved — codex-2, HIMMEL-2911 CR round 1: a matching
+# occurrence that is itself already fixed/disproved is not an open re-raise;
+# codex-1, HIMMEL-2911 CR round 3: `deferred` stays live — it means the issue
+# is REAL and tracked, so it must not let an older occurrence be stamped
+# fixed) — or (c) --head is not actually a git descendant of that finding own
+# head (codex-2, HIMMEL-2911 CR round 3: an unrelated or divergent --head
+# never reviewed past that commit, so its absence there is not evidence of
+# anything). Terminal rows (fixed/disproved/deferred) are left untouched;
+# conflict/unaddressed were never agreed and are only WARNed. A finding whose
+# stored fingerprint is empty (pre-fingerprint row, or no --text was ever
+# supplied) cannot be safely checked for re-raise, so it is conservatively
+# left agreed (counted as still-open) rather than guessed at. Idempotent: a
+# second run sees the fixed amend via the same effective-state merge and
+# skip-terminals it, writing nothing.
 # Exit 0 = nothing left agreed; exit 3 = one or more rows are still-open (the
 # caller's round was not actually clean for that finding); exit 1 = a
 # malformed ledger row or a ledger write failure.
@@ -188,6 +193,26 @@ function resolvesToHead(value) {
   }
   return resolveCache.get(h) === e.FULL_HEAD;
 }
+// codex-2, HIMMEL-2911 CR round 3: "not re-raised at --head" is only
+// meaningful evidence of a fix when --head actually descends from the
+// finding own commit — otherwise an unrelated or divergent clean head
+// (a stale/incomparable --head) would let a later, never-reviewed commit
+// findings get marked fixed with no real evidence either way.
+const ancestorCache = new Map();
+function isAncestorOfHead(commit) {
+  const h = String(commit || "");
+  if (!h) return false;
+  if (h === e.FULL_HEAD) return true;
+  if (!ancestorCache.has(h)) {
+    let ok = false;
+    try {
+      cp.execFileSync("git", ["merge-base", "--is-ancestor", h, e.FULL_HEAD], {stdio: "ignore"});
+      ok = true;
+    } catch { ok = false; }
+    ancestorCache.set(h, ok);
+  }
+  return ancestorCache.get(h);
+}
 // Merge every amend.set for a (target_head, finding_id, artifact, perspective)
 // key in ledger (chronological) order — a later amend field wins, a field a
 // later amend never touched keeps its earlier value. Same shape as
@@ -202,10 +227,13 @@ const findingRows = rows.filter((o) => o.kind === "finding" && o.branch === e.BR
 const atHead = findingRows.filter((o) => resolvesToHead(o.head));
 // Only a LIVE occurrence at --head is a genuine re-raise (codex-2, HIMMEL-2911
 // CR round 1): a matching finding at --head that is itself already
-// fixed/disproved/deferred is a DISPOSITIONED instance, not an open one, and
-// must not keep an older agreed row still-open forever just because its
-// fingerprint once reappeared.
-const liveVerdicts = new Set(["", "agreed", "conflict", "unaddressed"]);
+// fixed/disproved is a DISPOSITIONED instance, not an open one, and must not
+// keep an older agreed row still-open forever just because its fingerprint
+// once reappeared. deferred stays LIVE (codex-1, HIMMEL-2911 CR round 3):
+// deferred means the issue is REAL and tracked, never fixed, so a deferred
+// reappearance must not let an older agreed occurrence of the SAME issue be
+// promoted to fixed — that would be a false claim the code changed.
+const liveVerdicts = new Set(["", "agreed", "conflict", "unaddressed", "deferred"]);
 const fpAtHead = new Map();
 for (const o of atHead) {
   if (!o.fingerprint) continue;
@@ -232,6 +260,10 @@ for (const row of findingRows) {
     // disposition (a follow-up fix at a fresh head, or a deferral), the same
     // way the round-4 cap defers a same-head pending suggestion instead of
     // fabricating a fix for it.
+    action = "still-open";
+  } else if (!isAncestorOfHead(row.head)) {
+    // Not an ancestor of --head: the clean round at --head never actually
+    // reviewed past this commit, so its absence there proves nothing.
     action = "still-open";
   } else {
     const fp = effective.fingerprint || "";

--- a/scripts/cr/review-round.sh
+++ b/scripts/cr/review-round.sh
@@ -151,7 +151,8 @@ fi
 # skip-terminals it, writing nothing.
 # Exit 0 = nothing left agreed; exit 3 = one or more rows are still-open (the
 # caller's round was not actually clean for that finding); exit 1 = a
-# malformed ledger row or a ledger write failure.
+# malformed ledger row or a ledger write failure; exit 2 = --head does not
+# resolve to a commit; exit 5 = the CR ledger file itself is missing.
 if [ "$verb" = "promote" ]; then
     if ! full_head="$(git rev-parse --verify --quiet "$head_sha^{commit}" 2>/dev/null)" || [ -z "$full_head" ]; then
         echo "review-round: --head $head_sha does not resolve to a commit" >&2

--- a/scripts/cr/test-pr-check-rounds.sh
+++ b/scripts/cr/test-pr-check-rounds.sh
@@ -322,6 +322,89 @@ calls="$(cat "$PANEL_CALLS" 2>/dev/null)"
 expected_prefix="$(printf '%s\n%s\n%s\n%s' "$head1" "$head2" "$head3" "$other_head")"
 assert_has "$calls" "$expected_prefix" "early rounds run the actual captured heads"
 
+# review-round.sh promote (HIMMEL-2911): agreed findings absent at a clean
+# round head become terminal `fixed` amends, idempotently.
+promote_ledger="$git_dir/cr-critic-scores.jsonl"
+git -C "$repo" checkout -q -b promote main
+printf 'promote-a\n' > "$repo/promote.txt"
+git -C "$repo" add promote.txt
+git -C "$repo" commit -q -m promote-a
+promote_head_a="$(git -C "$repo" rev-parse promote)"
+printf 'promote-b\n' >> "$repo/promote.txt"
+git -C "$repo" commit -q -am promote-b
+promote_head_b="$(git -C "$repo" rev-parse promote)"
+
+# (a) agreed, not re-raised at the clean head -> promoted to fixed.
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
+    --branch promote --head "$promote_head_a" --model stub --id find-a \
+    --severity sug --file promote.txt --line 1 --verdict "" \
+    --text "tidy up the promote fixture alpha"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
+    --branch promote --head "$promote_head_a" --id find-a \
+    --set verdict=agreed --reason "leg agrees with alpha"
+
+# (b) agreed, re-raised (same fingerprint reappears) at the clean head -> still-open.
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
+    --branch promote --head "$promote_head_a" --model stub --id find-b \
+    --severity sug --file promote.txt --line 2 --verdict "" \
+    --text "tidy up the promote fixture beta"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
+    --branch promote --head "$promote_head_a" --id find-b \
+    --set verdict=agreed --reason "leg agrees with beta"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
+    --branch promote --head "$promote_head_b" --model stub --id find-b2 \
+    --severity sug --file promote.txt --line 2 --verdict "" \
+    --text "tidy up the promote fixture beta"
+
+# (c) already terminal (fixed) -> untouched.
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
+    --branch promote --head "$promote_head_a" --model stub --id find-c \
+    --severity sug --file promote.txt --line 3 --verdict "" \
+    --text "tidy up the promote fixture gamma"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
+    --branch promote --head "$promote_head_a" --id find-c \
+    --set verdict=fixed --reason "already fixed by hand"
+
+# (d) deferred -> untouched, deferred_to intact.
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
+    --branch promote --head "$promote_head_a" --model stub --id find-d \
+    --severity sug --file promote.txt --line 4 --verdict "" \
+    --text "tidy up the promote fixture delta"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
+    --branch promote --head "$promote_head_a" --id find-d \
+    --set verdict=deferred --set deferred_to=HIMMEL-9010 --reason "deferred by hand"
+
+promote_out1="$(cd "$repo" && bash "$fx/scripts/cr/review-round.sh" promote --branch promote --head "$promote_head_b")"; promote_rc1=$?
+assert_eq "$promote_rc1" "3" "promote exits 3 while a re-raised finding is still open"
+assert_has "$promote_out1" "promoted find-a@" "promote (a) not-re-raised agreed finding is promoted"
+assert_has "$promote_out1" "still-open find-b@" "promote (b) re-raised agreed finding stays open"
+assert_has "$promote_out1" "skip-terminal find-c@" "promote (c) already-fixed row is skipped"
+assert_has "$promote_out1" "skip-terminal find-d@" "promote (d) deferred row is skipped"
+promote_ledger_content="$(cat "$promote_ledger" 2>/dev/null)"
+assert_has "$promote_ledger_content" '"finding_id":"find-a"' "promoted amend targets find-a"
+assert_has "$promote_ledger_content" '"verdict":"fixed"' "promote writes a fixed verdict"
+assert_has "$promote_ledger_content" 'Promoted from agreed: no re-raise at clean round head' "promote amend carries the promotion reason"
+assert_has "$promote_ledger_content" '"deferred_to":"HIMMEL-9010"' "promote (d) leaves deferred_to intact"
+find_a_amends="$(LEDGER="$promote_ledger" node -e 'const fs=require("fs"),e=process.env;let n=0;for(const l of fs.readFileSync(e.LEDGER,"utf8").trim().split("\n")){const o=JSON.parse(l);if(o.kind==="amend"&&o.finding_id==="find-a"&&o.set&&o.set.verdict==="fixed")n++}process.stdout.write(String(n))')"
+assert_eq "$find_a_amends" "1" "promote (a) writes exactly one fixed amend"
+
+# (e) second run is idempotent: no new amend, same decisions.
+promote_out2="$(cd "$repo" && bash "$fx/scripts/cr/review-round.sh" promote --branch promote --head "$promote_head_b")"; promote_rc2=$?
+assert_eq "$promote_rc2" "3" "second promote run still reports the unresolved re-raise"
+assert_lacks "$promote_out2" "promoted find-a@" "second promote run does not re-promote find-a"
+assert_has "$promote_out2" "skip-terminal find-a@" "second promote run reports find-a as already terminal"
+find_a_amends_2="$(LEDGER="$promote_ledger" node -e 'const fs=require("fs"),e=process.env;let n=0;for(const l of fs.readFileSync(e.LEDGER,"utf8").trim().split("\n")){const o=JSON.parse(l);if(o.kind==="amend"&&o.finding_id==="find-a"&&o.set&&o.set.verdict==="fixed")n++}process.stdout.write(String(n))')"
+assert_eq "$find_a_amends_2" "1" "second promote run writes zero new amends for find-a"
+
+# Negative control: a malformed ledger row refuses automatic promotion and writes nothing.
+promote_lines_before="$(wc -l < "$promote_ledger" | tr -d ' ')"
+printf 'not-json-at-all\n' >> "$promote_ledger"
+(cd "$repo" && bash "$fx/scripts/cr/review-round.sh" promote --branch promote --head "$promote_head_b" >/dev/null 2>"$tmp/promote3.err"); promote_rc3=$?
+promote_lines_after="$(wc -l < "$promote_ledger" | tr -d ' ')"
+assert_eq "$promote_rc3" "1" "a malformed ledger row makes promote exit 1"
+assert_has "$(cat "$tmp/promote3.err")" "malformed CR ledger row" "malformed-ledger refusal names the reason"
+assert_eq "$promote_lines_after" "$((promote_lines_before + 1))" "malformed-ledger run appends nothing beyond the injected garbage line"
+
 if [ "$fails" -gt 0 ]; then
     printf 'FAIL test-pr-check-rounds (%s failures)\n' "$fails" >&2
     exit 1

--- a/scripts/cr/test-pr-check-rounds.sh
+++ b/scripts/cr/test-pr-check-rounds.sh
@@ -463,6 +463,22 @@ assert_has "$promote_out2" "skip-terminal find-a@" "second promote run reports f
 find_a_amends_2="$(LEDGER="$promote_ledger" node -e 'const fs=require("fs"),e=process.env;let n=0;for(const l of fs.readFileSync(e.LEDGER,"utf8").trim().split("\n")){const o=JSON.parse(l);if(o.kind==="amend"&&o.finding_id==="find-a"&&o.set&&o.set.verdict==="fixed")n++}process.stdout.write(String(n))')"
 assert_eq "$find_a_amends_2" "1" "second promote run writes zero new amends for find-a"
 
+# CR_LEDGER pin (codex-1, HIMMEL-2911 CR round 4): an ambient CR_LEDGER in the
+# caller's environment must not redirect the amend write to a different file
+# than the one promote just read and evaluated.
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
+    --branch promote --head "$promote_head_a" --model stub --id find-j \
+    --severity sug --file promote.txt --line 8 --verdict "" \
+    --text "tidy up the promote fixture kappa"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
+    --branch promote --head "$promote_head_a" --id find-j \
+    --set verdict=agreed --reason "leg agrees with kappa"
+bogus_ledger="$tmp/bogus-ledger-shouldnt-be-used.jsonl"
+promote_out_env="$(cd "$repo" && CR_LEDGER="$bogus_ledger" bash "$fx/scripts/cr/review-round.sh" promote --branch promote --head "$promote_head_b")"
+assert_has "$promote_out_env" "promoted find-j@" "an ambient CR_LEDGER does not stop promote reading the real ledger"
+if [ -e "$bogus_ledger" ]; then fail "ambient CR_LEDGER redirected the amend write"; else pass "ambient CR_LEDGER never gets a write"; fi
+assert_has "$(cat "$promote_ledger" 2>/dev/null)" '"finding_id":"find-j"' "find-j's fixed amend lands in the real ledger promote evaluated"
+
 # Negative control: a malformed ledger row refuses automatic promotion and writes nothing.
 promote_lines_before="$(wc -l < "$promote_ledger" | tr -d ' ')"
 printf 'not-json-at-all\n' >> "$promote_ledger"

--- a/scripts/cr/test-pr-check-rounds.sh
+++ b/scripts/cr/test-pr-check-rounds.sh
@@ -374,6 +374,41 @@ CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
     --branch promote --head "$promote_head_a" --id find-d \
     --set verdict=deferred --set deferred_to=HIMMEL-9010 --reason "deferred by hand"
 
+# (h) agreed at an earlier head, its fingerprint reappears at the clean head
+# but that reappearance is deferred, not resolved (codex-1, HIMMEL-2911 CR
+# round 3) -> still-open: deferred means the issue is still real.
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
+    --branch promote --head "$promote_head_a" --model stub --id find-h \
+    --severity sug --file promote.txt --line 7 --verdict "" \
+    --text "tidy up the promote fixture theta"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
+    --branch promote --head "$promote_head_a" --id find-h \
+    --set verdict=agreed --reason "leg agrees with theta"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
+    --branch promote --head "$promote_head_b" --model stub --id find-h2 \
+    --severity sug --file promote.txt --line 7 --verdict "" \
+    --text "tidy up the promote fixture theta"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
+    --branch promote --head "$promote_head_b" --id find-h2 \
+    --set verdict=deferred --set deferred_to=HIMMEL-9011 --reason "tracked, out of scope"
+
+# (i) agreed on a DIVERGENT commit that is not an ancestor of the clean head
+# (codex-2, HIMMEL-2911 CR round 3) -> still-open even with no fingerprint
+# match: --head never reviewed past that commit, so its absence proves nothing.
+git -C "$repo" checkout -q -b promote-divergent main
+printf 'divergent\n' > "$repo/divergent.txt"
+git -C "$repo" add divergent.txt
+git -C "$repo" commit -q -m divergent
+promote_head_divergent="$(git -C "$repo" rev-parse promote-divergent)"
+git -C "$repo" checkout -q promote
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
+    --branch promote --head "$promote_head_divergent" --model stub --id find-i \
+    --severity sug --file divergent.txt --line 1 --verdict "" \
+    --text "tidy up the promote fixture iota"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
+    --branch promote --head "$promote_head_divergent" --id find-i \
+    --set verdict=agreed --reason "leg agrees with iota"
+
 # (f) agreed AT the clean head itself (codex-1, HIMMEL-2911 CR round 1) ->
 # still-open: no later commit could have fixed a finding raised THIS round.
 CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
@@ -410,6 +445,8 @@ assert_has "$promote_out1" "skip-terminal find-c@" "promote (c) already-fixed ro
 assert_has "$promote_out1" "skip-terminal find-d@" "promote (d) deferred row is skipped"
 assert_has "$promote_out1" "still-open find-f@" "promote (f) same-head agreed finding is never auto-fixed"
 assert_has "$promote_out1" "promoted find-g@" "promote (g) an earlier agreed finding promotes when its head-H reappearance is already disproved"
+assert_has "$promote_out1" "still-open find-h@" "promote (h) a deferred head-H reappearance keeps the earlier agreed finding still-open"
+assert_has "$promote_out1" "still-open find-i@" "promote (i) a finding on a non-ancestor commit is never promoted"
 promote_ledger_content="$(cat "$promote_ledger" 2>/dev/null)"
 assert_has "$promote_ledger_content" '"finding_id":"find-a"' "promoted amend targets find-a"
 assert_has "$promote_ledger_content" '"verdict":"fixed"' "promote writes a fixed verdict"

--- a/scripts/cr/test-pr-check-rounds.sh
+++ b/scripts/cr/test-pr-check-rounds.sh
@@ -374,12 +374,42 @@ CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
     --branch promote --head "$promote_head_a" --id find-d \
     --set verdict=deferred --set deferred_to=HIMMEL-9010 --reason "deferred by hand"
 
+# (f) agreed AT the clean head itself (codex-1, HIMMEL-2911 CR round 1) ->
+# still-open: no later commit could have fixed a finding raised THIS round.
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
+    --branch promote --head "$promote_head_b" --model stub --id find-f \
+    --severity sug --file promote.txt --line 5 --verdict "" \
+    --text "tidy up the promote fixture zeta"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
+    --branch promote --head "$promote_head_b" --id find-f \
+    --set verdict=agreed --reason "leg agrees with zeta"
+
+# (g) agreed at an earlier head, its fingerprint reappears at the clean head
+# but that reappearance is already disproved (codex-2, HIMMEL-2911 CR round
+# 1) -> promoted: a DISPOSITIONED occurrence is not a live re-raise.
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
+    --branch promote --head "$promote_head_a" --model stub --id find-g \
+    --severity sug --file promote.txt --line 6 --verdict "" \
+    --text "tidy up the promote fixture eta"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
+    --branch promote --head "$promote_head_a" --id find-g \
+    --set verdict=agreed --reason "leg agrees with eta"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
+    --branch promote --head "$promote_head_b" --model stub --id find-g2 \
+    --severity sug --file promote.txt --line 6 --verdict "" \
+    --text "tidy up the promote fixture eta"
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
+    --branch promote --head "$promote_head_b" --id find-g2 \
+    --set verdict=disproved --reason "not reproducible at this head"
+
 promote_out1="$(cd "$repo" && bash "$fx/scripts/cr/review-round.sh" promote --branch promote --head "$promote_head_b")"; promote_rc1=$?
 assert_eq "$promote_rc1" "3" "promote exits 3 while a re-raised finding is still open"
 assert_has "$promote_out1" "promoted find-a@" "promote (a) not-re-raised agreed finding is promoted"
 assert_has "$promote_out1" "still-open find-b@" "promote (b) re-raised agreed finding stays open"
 assert_has "$promote_out1" "skip-terminal find-c@" "promote (c) already-fixed row is skipped"
 assert_has "$promote_out1" "skip-terminal find-d@" "promote (d) deferred row is skipped"
+assert_has "$promote_out1" "still-open find-f@" "promote (f) same-head agreed finding is never auto-fixed"
+assert_has "$promote_out1" "promoted find-g@" "promote (g) an earlier agreed finding promotes when its head-H reappearance is already disproved"
 promote_ledger_content="$(cat "$promote_ledger" 2>/dev/null)"
 assert_has "$promote_ledger_content" '"finding_id":"find-a"' "promoted amend targets find-a"
 assert_has "$promote_ledger_content" '"verdict":"fixed"' "promote writes a fixed verdict"


### PR DESCRIPTION
## Summary

Closes HIMMEL-2911 (split from HIMMEL-2909 item 2). `/pr-check` writes
`verdict=agreed` as a leg-agrees intermediate but nothing ever promoted it to
a terminal verdict — every PR needed a hand `ledger-append.sh amend --set
verdict=fixed` before GO. This adds `review-round.sh promote`, a small,
idempotent step that closes that gap, and wires it into `/pr-check` step 5
right after `clear-cr-marker.sh` clears.

## Semantics

Given a CLEAN round at `--head` (caller-asserted — promote never re-checks
the panel itself, same posture as the existing `defer` verb), every `finding`
row on `--branch` whose latest amend is `agreed` is promoted to `fixed`
**unless**:
- its own row is recorded exactly at `--head` (no later commit could have
  fixed it — nothing to promote on zero evidence),
- it is re-raised at `--head`: another finding shares its stored
  `fingerprint` and its own effective verdict is still live
  (empty/agreed/conflict/unaddressed/**deferred**),
- `--head` is not a git descendant of the finding's own head (an unrelated
  or divergent head proves nothing about that finding), or
- the row has no stored fingerprint (can't safely check re-raise).

Terminal rows (fixed/disproved/deferred) are untouched; conflict/unaddressed
were never agreed and are only WARNed. Idempotent — a second run at the same
head writes nothing.

Exit 0 = nothing left agreed; exit 3 = one or more rows still-open; exit 1 =
malformed ledger / write failure; exit 2 = unresolvable `--head`; exit 5 =
missing ledger.

## Evidence

- RED-first fixtures in `test-pr-check-rounds.sh`: not-re-raised agreed →
  promoted; re-raised agreed → still-open; already-fixed → untouched;
  deferred → untouched, `deferred_to` intact; same-head agreed → still-open;
  disproved-reappearance → promoted; deferred-reappearance → still-open;
  non-ancestor commit → still-open; ambient `CR_LEDGER` can't redirect the
  write; second run → idempotent (0 new writes); malformed ledger row → exit
  1, nothing written. All pass.
- Impacted suites green: `test-finding-reraise.sh`, `test-panel-first-pass.sh`,
  `test-ledger-append.sh`, `test-clear-cr-marker.sh`.
- shellcheck clean on both touched shell files.
- Live dry-check on this branch after a real clean `/pr-check` round (head
  `1638ab10`): `review-round promote: 0 promoted, 0 still-open, 0
  skip-terminal, 0 warn` — accurate: this branch's own adjudications went
  through `write-verdicts.sh` scratch rather than a persisted `amend
  --set verdict=agreed`, so there are no `agreed` rows on it to promote. The
  output is the true state of this branch's own ledger rows, which is what
  the live check asks for.

## Known-findings note

`known-findings.sh --diff` flags a `test-coverage-gap` checklist item on
`scripts/cr/review-round.sh` every round. It's a detector miss, not a real
gap: `review-round.sh` has no `test-review-round.sh` twin — its paired suite
has always been `test-pr-check-rounds.sh`, which this diff extends with 12
new fixtures covering every new flag/branch/exit code the promote verb adds.

## CR history (7 rounds — this diff touches `scripts/cr/`, so branch
self-review ran against this branch's own copy at each head)

1. codex-1/codex-2 (Important): same-head promotion faked a fix with no
   evidence; a fixed/disproved-only re-raise check let a fixed/disproved
   reappearance keep an older row open forever the wrong direction (actually:
   allowed promotion when it shouldn't have distinguished disproved from
   deferred) — fixed in `31e05189`'s follow-up `0ff94e3e`.
2. codex-1 (Important): the promote-fallback prose applied the same
   hand-amend advice to promote's systemic-failure exits — split in
   `a3c8b4b0`.
3. codex-1 (Important) + codex-2 (Suggestion): a deferred reappearance was
   treated as dispositioned rather than live, and no ancestor check existed
   on the older row's head — fixed in `433295c0`.
4. codex-1 (Suggestion): an ambient `CR_LEDGER` could redirect the amend
   write away from the ledger promote evaluated — fixed in `762d46ba`.
5. codex-1 (Suggestion): docs said exit 3 always means "re-raised", missing
   the other three still-open reasons — fixed in `baa43b5d`.
6. codex-1 (Suggestion): the exit-code comment omitted 2 and 5 — fixed in
   `1638ab10`.
7. Clean (0/0/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9d5WvjcEf1oDbKjVatv68