### PR TITLE
fix(lib): [HIMMEL-2913] SessionStart dedup also recognises a legacy raw-basename command so a metacharacter basename migrates instead of duplicating

### DIFF
--- a/scripts/lib/test-wire-pretooluse-hooks.ps1
+++ b/scripts/lib/test-wire-pretooluse-hooks.ps1
@@ -111,6 +111,18 @@ Set-SessionStartHook -SettingsPath $s9c -Prefix 'C:/moved' -HookBasename 'we"ird
 Check 'quote in basename: re-wire dedups' (JqVal $s9c '[.hooks.SessionStart[].hooks[]] | length') '1'
 Check 'quote in basename: re-wire repoints' (JqVal $s9c '.hooks.SessionStart[0].hooks[0].command') 'bash "C:/moved/scripts/hooks/we\"ird-hook.sh"'
 
+# 9c. HIMMEL-2913: an entry wired by a PREVIOUS release carries the RAW
+# (unescaped) basename in its command -- shesc() on the basename postdates
+# HIMMEL-2905. A needle derived only from the escaped form cannot match that
+# legacy text, so a re-wire APPENDS the repaired hook beside the old malformed
+# one instead of replacing it. RED before the fix: 2 hook objects survive.
+$s9d = Join-Path $td 's9d.json'
+$legacyCmd = 'bash "C:/old/scripts/hooks/we"ird-hook.sh"'
+& jq -n --arg cmd $legacyCmd '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":$cmd}]}]}}' | Set-Content $s9d -Encoding utf8
+Set-SessionStartHook -SettingsPath $s9d -Prefix 'C:/himmel' -HookBasename 'we"ird-hook.sh' | Out-Null
+Check 'legacy raw basename: dedup replaces, not appends' (JqVal $s9d '[.hooks.SessionStart[].hooks[]] | length') '1'
+Check 'legacy raw basename: repointed to the escaped command' (JqVal $s9d '.hooks.SessionStart[0].hooks[0].command') 'bash "C:/himmel/scripts/hooks/we\"ird-hook.sh"'
+
 # 10. NEGATIVE control for 9 (load-bearing): the project-scope prefix is the
 # literal, UNEXPANDED $CLAUDE_PROJECT_DIR that Claude Code expands at hook-fire
 # time. Escaping its `$` would point every project-scope hook at a path that

--- a/scripts/lib/test-wire-pretooluse-hooks.sh
+++ b/scripts/lib/test-wire-pretooluse-hooks.sh
@@ -175,6 +175,22 @@ check "quote in basename: re-wire repoints at the new clone path" \
   "$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$s8f3" 2>/dev/null)" \
   'bash "C:/moved/scripts/hooks/we\"ird-hook.sh"'
 
+# 8f4. HIMMEL-2913: an entry wired by a PREVIOUS release carries the RAW
+# (unescaped) basename in its command -- shesc() on the basename postdates
+# HIMMEL-2905. A needle derived only from the escaped form cannot match that
+# legacy text, so a re-wire APPENDS the repaired hook beside the old malformed
+# one instead of replacing it. RED before the fix: 2 hook objects survive.
+s8f4="$td/s8f4.json"
+legacy_cmd='bash "C:/old/scripts/hooks/we"ird-hook.sh"'
+jq -n --arg cmd "$legacy_cmd" \
+  '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":$cmd}]}]}}' > "$s8f4"
+( . "$wire"; wire_sessionstart_hook "$s8f4" "C:/himmel" 'we"ird-hook.sh' 0 >/dev/null 2>&1 ) || true
+check "legacy raw basename: dedup replaces, not appends" \
+  "$(jq -r '[.hooks.SessionStart[].hooks[]] | length' "$s8f4" 2>/dev/null)" "1"
+check "legacy raw basename: repointed to the escaped command" \
+  "$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$s8f4" 2>/dev/null)" \
+  'bash "C:/himmel/scripts/hooks/we\"ird-hook.sh"'
+
 # 8g. NEGATIVE control for 8f (load-bearing): the project-scope prefix is the
 # LITERAL, unexpanded `$CLAUDE_PROJECT_DIR` -- Claude Code expands it at
 # hook-fire time. Escaping it (`\$CLAUDE_PROJECT_DIR`) or single-quoting it

--- a/scripts/lib/wire-pretooluse-hooks.ps1
+++ b/scripts/lib/wire-pretooluse-hooks.ps1
@@ -211,13 +211,17 @@ function Set-SessionStartHook {
         [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
         $global:OutputEncoding = [System.Text.UTF8Encoding]::new($false)
         $base = Read-SettingsBase -SettingsPath $SettingsPath -Who 'wire-pretooluse-hooks'
+        # HIMMEL-2913: an entry wired by a PREVIOUS release (pre-2905) carries
+        # the RAW, unescaped basename, which $needle alone cannot match, so
+        # $legacy widens the dedup to also catch and replace that older text.
         $filter = $WireHookCmdJq + @'
 hookcmd($pfx; $hook) as $cmd
 | ("scripts/hooks/" + shesc($hook)) as $needle
+| ("scripts/hooks/" + $hook) as $legacy
 | .hooks = (.hooks // {})
 | .hooks.SessionStart = ((.hooks.SessionStart // [])
     | map(.hooks = ((.hooks // [])
-        | map(select((.command // "") | contains($needle) | not))))
+        | map(select((.command // "") | (contains($needle) or contains($legacy)) | not))))
     | map(select((.hooks | length) > 0)))
 | (.hooks.SessionStart | map(has("matcher") | not) | index(true)) as $idx
 | if $idx == null

--- a/scripts/lib/wire-pretooluse-hooks.sh
+++ b/scripts/lib/wire-pretooluse-hooks.sh
@@ -205,15 +205,19 @@ wire_sessionstart_hook() {
   # the needle from the same shesc() the command uses makes disagreement
   # impossible, and `contains` needs no regex-escaping at all, which the old
   # `${basename//./[.]}` only ever did for `.` anyway.
+  # HIMMEL-2913: an entry wired by a PREVIOUS release (pre-2905) carries the
+  # RAW, unescaped basename, which $needle alone cannot match, so $legacy
+  # widens the dedup to also catch and replace that older text.
   # shellcheck disable=SC2016  # a jq program: $pfx/$hook/$cmd are jq bindings
   printf '%s' "$base" | jq --arg pfx "$pfx" --arg hook "$basename" \
     "$WIRE_HOOK_CMD_JQ"'
     hookcmd($pfx; $hook) as $cmd
     | ("scripts/hooks/" + shesc($hook)) as $needle
+    | ("scripts/hooks/" + $hook) as $legacy
     | .hooks = (.hooks // {})
     | .hooks.SessionStart = ((.hooks.SessionStart // [])
         | map(.hooks = ((.hooks // [])
-            | map(select((.command // "") | contains($needle) | not))))
+            | map(select((.command // "") | (contains($needle) or contains($legacy)) | not))))
         | map(select((.hooks | length) > 0)))
     | (.hooks.SessionStart | map(has("matcher") | not) | index(true)) as $idx
     | if $idx == null


### PR DESCRIPTION
## Summary
Deferred from HIMMEL-2905 / PR #612 round-4 critic panel (Suggestion severity, past the 3-round cap).

`wire_sessionstart_hook` derives its dedup needle from `shesc($hook)` (the escaped basename). An entry wired by a PREVIOUS release carries the RAW basename, so for a metacharacter basename the needle misses that legacy text and a re-wire APPENDS the repaired hook instead of REPLACING the old malformed one. Unreachable with any basename himmel has ever wired — every caller passes a literal, and `shesc()` is the identity on those — so this is behaviour-neutral for every real caller, which is why it's a two-line fix rather than a redesign.

## Fix
Widens the dedup `select()` to also match `"scripts/hooks/" + $hook` (the raw, unescaped form), identically in `wire-pretooluse-hooks.sh` (~L214-221) and its `.ps1` twin (~L216-224) — the jq fragment is shared verbatim between them.

## RED/GREEN
- RED: seeded a settings.json with a hand-written legacy SessionStart entry `bash "C:/old/scripts/hooks/we"ird-hook.sh"` (raw, unescaped basename), then re-wired the same basename `we"ird-hook.sh`. Before the fix: 2 hook objects survive (the legacy one alongside the new one).
- GREEN: exactly 1 object remains, repointed to the new escaped command. All existing cases (8f/8f2/8f3/8g and the rest of the 34-case suite) still pass.

## Twin-diff proof
The needle block (bash L214-221 vs ps1 L218-224, syntax stripped) diffs byte-identical:
```
$ diff <(sed -n '214,220p' wire-pretooluse-hooks.sh | sed -e 's/^ *//' -e 's/^| //') \
       <(sed -n '218,224p' wire-pretooluse-hooks.ps1 | sed -e 's/^ *//' -e 's/^| //')
(no output)
```

## Evidence
- `bash scripts/quiet-run.sh wire -- bash scripts/lib/test-wire-pretooluse-hooks.sh` → `ALL PASS` (34/34)
- Impacted suites (`git grep -l 'wire-pretooluse-hooks' -- 'scripts/**/test-*.sh' 'scripts/test-*.sh'`), all green via quiet-run: `test-unwire-pretooluse-hooks.sh`, `test-setup-wire.sh`, `test-detect-hook-dup.sh`, the four himmelctl wizard suites, `test-e2e-symmetry.sh`, `test-uninstall.sh`. `test-install-symmetry-vm.sh` needs VM ssh infra and was not run locally.
- `shellcheck` clean on both touched bash files.
- **ps1 test case (mirrored 9c) is untested — no pwsh on this host.** The parity gate checks structure, not results.
- `/pr-check` round 1/3: codex critic panel (gpt-6-astra) responded, 0 Critical/Important/Suggestion findings. Marker cleared.

## Test plan
- [x] Bash wire suite RED→GREEN
- [x] Impacted suites green
- [x] shellcheck clean
- [x] Twin jq-fragment byte-diff
- [x] /pr-check cross-model panel clean
- [ ] ps1 suite run on Windows (out of scope for this host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129GxRjm1aD1CaPbGoQ4Yj5