### PR TITLE
fix(template): [HIMMEL-2903] luna-upgrade baseline is a per-file snapshot in the stamp, git history demoted to fallback; a failing git log fails closed

### DIFF
--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/CHANGELOG.md
+++ b/templates/luna-second-brain/CHANGELOG.md
@@ -8,7 +8,7 @@ Version history for the luna-second-brain vault template (published as
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [0.4.23] — 2026-09-10
+## [0.4.24] — 2026-09-10
 
 ### Fixed
 - **The local-edit baseline is a per-file content snapshot in the stamp; the
@@ -26,9 +26,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   failure resolving the stamp commit (shallow clone, corrupt index, permission
   error) used to be indistinguishable from "no stamp commit", which meant no
   baseline, which meant the pre-HIMMEL-2886 silent overwrite. It now withholds
-  the write and says so, matching the `cat-file`/`show` steps. A repo with no
-  commits yet is still a legitimately absent baseline, not an error, so the
-  first upgrade of a freshly `git init`-ed vault proceeds as before.
+  the write and says so, matching the `cat-file`/`show` steps. The HEAD gate
+  in front of it reads the exact return code: `rev-parse --verify -q HEAD`
+  exits 1 for "HEAD names no commit" (a legitimately absent baseline — the
+  first upgrade of a freshly `git init`-ed vault proceeds as before) and
+  otherwise for an operational refs failure, which withholds like any other.
+- **A snapshot scratch file that cannot be created aborts the run
+  (HIMMEL-2903).** The stamp is rewritten wholesale, so proceeding without a
+  snapshot would strip the `files` map a vault already has and silently demote
+  it to the poisonable git baseline. The abort happens before the first write,
+  so nothing is modified and a re-run is clean.
 - **The withheld-file line names which baseline spoke.** Every "local edits
   withheld" line ends in `[baseline: snapshot]` or `[baseline: git]`, and the
   snapshot form prints the recorded and on-disk shas.

--- a/templates/luna-second-brain/CHANGELOG.md
+++ b/templates/luna-second-brain/CHANGELOG.md
@@ -8,7 +8,7 @@ Version history for the luna-second-brain vault template (published as
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [0.4.24] — 2026-09-10
+## [0.4.25] — 2026-09-10
 
 ### Fixed
 - **The local-edit baseline is a per-file content snapshot in the stamp; the
@@ -31,11 +31,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   exits 1 for "HEAD names no commit" (a legitimately absent baseline — the
   first upgrade of a freshly `git init`-ed vault proceeds as before) and
   otherwise for an operational refs failure, which withholds like any other.
-- **A snapshot scratch file that cannot be created aborts the run
-  (HIMMEL-2903).** The stamp is rewritten wholesale, so proceeding without a
-  snapshot would strip the `files` map a vault already has and silently demote
-  it to the poisonable git baseline. The abort happens before the first write,
-  so nothing is modified and a re-run is clean.
+- **Snapshot persistence fails closed at every step (HIMMEL-2903).** The stamp
+  is rewritten wholesale, so any run that proceeds without a complete snapshot
+  strips the `files` map a vault already has and silently demotes it to the
+  poisonable git baseline. A scratch file that cannot be CREATED aborts before
+  the first write (nothing is modified, a re-run is clean); a row that cannot
+  be APPENDED, or a scratch file that cannot be READ BACK at stamp time, leaves
+  the existing stamp untouched and exits non-zero rather than writing a weaker
+  one.
 - **The withheld-file line names which baseline spoke.** Every "local edits
   withheld" line ends in `[baseline: snapshot]` or `[baseline: git]`, and the
   snapshot form prints the recorded and on-disk shas.

--- a/templates/luna-second-brain/CHANGELOG.md
+++ b/templates/luna-second-brain/CHANGELOG.md
@@ -8,6 +8,31 @@ Version history for the luna-second-brain vault template (published as
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.4.23] — 2026-09-10
+
+### Fixed
+- **The local-edit baseline is a per-file content snapshot in the stamp; the
+  vault's git history is now only the fallback (HIMMEL-2903).**
+  `.vault-template.json` gained a `files: {"<rel>": "sha256:<hex>"}` map,
+  written at the end of every successful upgrade, recording what the template
+  put in each "overwrite"-class file. `scripts/upgrade.sh` compares against
+  that map first. The git baseline it replaces was poisonable: a vault-local
+  edit committed in the SAME commit that advances the stamp — what a batching
+  autosync does — became the baseline itself, so the next upgrade saw no
+  divergence and silently overwrote the edit. Vaults stamped before this
+  version have no map and keep the git behaviour until their next upgrade
+  writes one.
+- **A failing `git log` no longer fails open (HIMMEL-2903).** An operational
+  failure resolving the stamp commit (shallow clone, corrupt index, permission
+  error) used to be indistinguishable from "no stamp commit", which meant no
+  baseline, which meant the pre-HIMMEL-2886 silent overwrite. It now withholds
+  the write and says so, matching the `cat-file`/`show` steps. A repo with no
+  commits yet is still a legitimately absent baseline, not an error, so the
+  first upgrade of a freshly `git init`-ed vault proceeds as before.
+- **The withheld-file line names which baseline spoke.** Every "local edits
+  withheld" line ends in `[baseline: snapshot]` or `[baseline: git]`, and the
+  snapshot form prints the recorded and on-disk shas.
+
 ## [0.4.22] — 2026-09-10
 
 ### Fixed

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.24"
+    "version": "0.4.25"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.22"
+    "version": "0.4.23"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.23"
+    "version": "0.4.24"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/scripts/test-upgrade.sh
+++ b/templates/luna-second-brain/scripts/test-upgrade.sh
@@ -686,5 +686,96 @@ fi
 bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --yes >/dev/null 2>&1; t32_rc=$?
 assert_eq "T32 first upgrade of a commitless vault still writes the template file" "$(sha_of "$T/.gitleaks.toml")" "$(sha_of "$V/.gitleaks.toml")"
 assert_eq "T32 first upgrade of a commitless vault exits 0" "0" "$t32_rc"
+
+# ---------------------------------------------------------------------------
+# T33 (HIMMEL-2903, CR round 1 codex-1): the HEAD gate must read the EXACT rc.
+# `rev-parse --verify -q HEAD` exits 1 for "HEAD names no commit" (T32's
+# legitimately absent baseline) but 128 for an operational refs failure — an
+# unreadable refs backend, say. Collapsing the two lets a refs-layer error
+# masquerade as a fresh vault and fail OPEN, the same hole the git-log gate
+# closes one step down. Simulated with a PATH stub `git` that fails ONLY for
+# `rev-parse --verify` (so `--is-inside-work-tree` still succeeds and the
+# block is actually entered).
+T="$TMP/t33-tmpl"; V="$TMP/t33-vault"
+make_template "$T" "0.9.0"
+printf 'gitleaks-content-v1\n' > "$T/.gitleaks.toml"
+mkdir -p "$V"; cp -r "$T/." "$V/"; rm -f "$V/marketplace/.claude-plugin/marketplace.json"
+stamp_vault "$V" "0.9.0"
+git -C "$V" init -q
+git -C "$V" config user.email "test@example.com"
+git -C "$V" config user.name "Test"
+git -C "$V" add -A
+git -C "$V" commit -q -m "initial stamp 0.9.0"
+printf 'gitleaks-content-v1\nlocal-allowlist-line\n' > "$V/.gitleaks.toml"
+git -C "$V" add -A
+git -C "$V" commit -q -m "local edit after the stamp"
+printf '{"metadata":{"version":"1.0.0"}}\n' > "$T/marketplace/.claude-plugin/marketplace.json"
+printf 'gitleaks-content-v2\n' > "$T/.gitleaks.toml"
+t33_stub="$TMP/t33-stub"; mkdir -p "$t33_stub"
+t33_real_git="$(command -v git)"
+# shellcheck disable=SC2016  # the single-quoted lines are the STUB's source, not this shell's
+{
+    echo '#!/usr/bin/env bash'
+    echo 'saw_rp=0; saw_verify=0'
+    echo 'for a in "$@"; do'
+    echo '    [ "$a" = "rev-parse" ] && saw_rp=1'
+    echo '    [ "$a" = "--verify" ] && saw_verify=1'
+    echo 'done'
+    echo 'if [ "$saw_rp" = 1 ] && [ "$saw_verify" = 1 ]; then echo "fatal: simulated refs failure" >&2; exit 128; fi'
+    printf 'exec "%s" "$@"\n' "$t33_real_git"
+} > "$t33_stub/git"
+chmod +x "$t33_stub/git"
+# The stub must fail rev-parse --verify with 128 (NOT 1 — a 1 would be the
+# legitimate no-commit answer and would prove nothing) and leave the
+# work-tree probe working, or the case passes for the wrong reason.
+t33_verify_rc=$(PATH="$t33_stub:$PATH" git -C "$V" rev-parse --verify -q HEAD >/dev/null 2>&1; echo $?)
+assert_eq "T33 setup: the stub fails rev-parse --verify with 128, not 1" "128" "$t33_verify_rc"
+assert_eq "T33 setup: the stub leaves --is-inside-work-tree working" "true" "$(PATH="$t33_stub:$PATH" git -C "$V" rev-parse --is-inside-work-tree 2>/dev/null)"
+t33_pre_sha=$(sha_of "$V/.gitleaks.toml")
+t33_out=$(PATH="$t33_stub:$PATH" bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --yes 2>&1); t33_rc=$?
+assert_eq "T33 an operational rev-parse failure withholds the write (fails closed)" "$t33_pre_sha" "$(sha_of "$V/.gitleaks.toml")"
+case "$t33_out" in
+    *"could not determine the upgrade baseline (git rev-parse failed) — withholding .gitleaks.toml as a precaution"*)
+        pass "T33 names rev-parse (not git log) as the failed baseline step" ;;
+    *) fail "T33 names rev-parse (not git log) as the failed baseline step" "got: $t33_out" ;;
+esac
+if [ "$t33_rc" -ne 0 ]; then pass "T33 apply exits non-zero (not a clean upgrade)"; else fail "T33 apply exits non-zero (not a clean upgrade)" "rc=0"; fi
+
+# ---------------------------------------------------------------------------
+# T34 (HIMMEL-2903, CR round 1 codex-2): a snapshot scratch file that cannot be
+# created must ABORT before the first write. The stamp is rewritten wholesale,
+# so proceeding would strip the `files` map the vault already has — silently
+# demoting it back to the poisonable git baseline. Simulated by pointing TMPDIR
+# at a path that is not a directory, which is what makes mktemp fail.
+T="$TMP/t34-tmpl"; V="$TMP/t34-vault"
+make_template "$T" "0.9.0"
+printf 'gitleaks-content-v1\n' > "$T/.gitleaks.toml"
+mkdir -p "$V"; cp -r "$T/." "$V/"
+stamp_vault "$V" "0.1.0"
+# A first upgrade under the current template records the snapshot to protect.
+bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --yes >/dev/null 2>&1
+t34_files_before=$("$PY" -c 'import json,sys; print(len(json.load(open(sys.argv[1])).get("files",{})))' "$V/.vault-template.json" 2>/dev/null)
+if [ "${t34_files_before:-0}" -gt 0 ]; then
+    pass "T34 setup: the vault carries a content snapshot to protect"
+else
+    fail "T34 setup: the vault carries a content snapshot to protect" "files keys=$t34_files_before"
+fi
+t34_stamp_before=$(sha_of "$V/.vault-template.json")
+printf '{"metadata":{"version":"1.0.0"}}\n' > "$T/marketplace/.claude-plugin/marketplace.json"
+printf 'gitleaks-content-v2\n' > "$T/.gitleaks.toml"
+t34_notdir="$TMP/t34-not-a-dir"; printf 'x\n' > "$t34_notdir"
+# Precondition: mktemp really does fail under this TMPDIR (otherwise the case
+# would "pass" without ever exercising the abort).
+t34_mktemp_rc=$(TMPDIR="$t34_notdir" mktemp >/dev/null 2>&1; echo $?)
+if [ "$t34_mktemp_rc" -ne 0 ]; then pass "T34 setup: mktemp fails under the broken TMPDIR"; else fail "T34 setup: mktemp fails under the broken TMPDIR" "rc=0"; fi
+t34_gitleaks_before=$(sha_of "$V/.gitleaks.toml")
+t34_out=$(TMPDIR="$t34_notdir" bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --yes 2>&1); t34_rc=$?
+assert_eq "T34 a failed snapshot scratch file aborts rather than writing" "$t34_gitleaks_before" "$(sha_of "$V/.gitleaks.toml")"
+assert_eq "T34 the existing stamp (and its snapshot) is left intact" "$t34_stamp_before" "$(sha_of "$V/.vault-template.json")"
+assert_eq "T34 the abort exits 2" "2" "$t34_rc"
+case "$t34_out" in
+    *"aborting before any change"*) pass "T34 says it aborted before changing anything" ;;
+    *) fail "T34 says it aborted before changing anything" "got: $t34_out" ;;
+esac
 echo
 if [ "$FAILED" -eq 0 ]; then echo "All upgrade tests passed."; else echo "$FAILED test(s) failed."; exit 1; fi

--- a/templates/luna-second-brain/scripts/test-upgrade.sh
+++ b/templates/luna-second-brain/scripts/test-upgrade.sh
@@ -777,5 +777,92 @@ case "$t34_out" in
     *"aborting before any change"*) pass "T34 says it aborted before changing anything" ;;
     *) fail "T34 says it aborted before changing anything" "got: $t34_out" ;;
 esac
+
+
+# ---------------------------------------------------------------------------
+# T35/T36 (HIMMEL-2903, CR round 2): snapshot persistence must fail CLOSED on
+# BOTH sides of the scratch file. The stamp is rewritten wholesale, so a run
+# that records the snapshot only partially (append fails) or cannot read it
+# back (read fails) would replace a complete baseline with a partial or absent
+# one — the poisoned-baseline hole reopened from the other end.
+#
+# Isolating that needs a failure that touches ONLY the snapshot scratch file:
+# a blanket read-only TMPDIR breaks the file writes and the _CLAUDE.md 3-way
+# too, so the run fails for an unrelated reason and the case proves nothing.
+# Hence a PATH stub `mktemp` that recognises the snapshot's OWN template
+# (`luna-upgrade-snapshot.XXXXXX`) and hands back a file with a hostile mode,
+# passing every other mktemp call through untouched.
+#
+# mk_mktemp_stub <dir> <mode> — a stub that chmods only the snapshot file.
+mk_mktemp_stub() {
+    local dir="$1" mode="$2" real; real="$(command -v mktemp)"
+    mkdir -p "$dir"
+    # shellcheck disable=SC2016  # the single-quoted lines are the STUB's source, not this shell's
+    {
+        echo '#!/usr/bin/env bash'
+        printf 'real=%s\n' "$real"
+        printf 'mode=%s\n' "$mode"
+        echo 'for a in "$@"; do'
+        echo '    if [ "$a" = "luna-upgrade-snapshot.XXXXXX" ]; then'
+        echo '        f="$("$real" "$@")" || exit $?'
+        echo '        chmod "$mode" "$f" || exit 1'
+        printf '%s\n' '        printf "%s\\n" "$f"'
+        echo '        exit 0'
+        echo '    fi'
+        echo 'done'
+        echo 'exec "$real" "$@"'
+    } > "$dir/mktemp"
+    chmod +x "$dir/mktemp"
+}
+
+# t35_fixture <tmpl> <vault> — a vault already carrying a complete snapshot,
+# plus a newer template that changes one overwrite-class file.
+t35_fixture() {
+    local t="$1" v="$2"
+    make_template "$t" "0.9.0"
+    printf 'gitleaks-content-v1\n' > "$t/.gitleaks.toml"
+    mkdir -p "$v"; cp -r "$t/." "$v/"
+    stamp_vault "$v" "0.1.0"
+    bash "$UPGRADE" --template-dir "$t" --vault-dir "$v" --yes >/dev/null 2>&1
+    printf '{"metadata":{"version":"1.0.0"}}\n' > "$t/marketplace/.claude-plugin/marketplace.json"
+    printf 'gitleaks-content-v2\n' > "$t/.gitleaks.toml"
+}
+
+snap_keys() { "$PY" -c 'import json,sys; print(len(json.load(open(sys.argv[1])).get("files",{})))' "$1" 2>/dev/null; }
+
+# --- T35: the APPEND half. A read-only scratch file (0444) means every
+# record_snapshot row is dropped; the run must refuse to stamp.
+T="$TMP/t35-tmpl"; V="$TMP/t35-vault"
+t35_fixture "$T" "$V"
+t35_keys_before=$(snap_keys "$V/.vault-template.json")
+if [ "${t35_keys_before:-0}" -gt 0 ]; then pass "T35 setup: the vault carries a complete content snapshot"; else fail "T35 setup: the vault carries a complete content snapshot" "keys=$t35_keys_before"; fi
+t35_stamp_before=$(sha_of "$V/.vault-template.json")
+t35_stub="$TMP/t35-stub"; mk_mktemp_stub "$t35_stub" 0444
+# Precondition: the stub really does hand back an unappendable snapshot file,
+# and really does pass a NON-snapshot mktemp through writable (or the case
+# would be the blanket-failure control it exists to replace).
+t35_probe=$(PATH="$t35_stub:$PATH" mktemp -t luna-upgrade-snapshot.XXXXXX)
+if printf 'x\n' >> "$t35_probe" 2>/dev/null; then fail "T35 setup: the stub's snapshot file rejects appends" "append succeeded"; else pass "T35 setup: the stub's snapshot file rejects appends"; fi
+t35_other=$(PATH="$t35_stub:$PATH" mktemp)
+if printf 'x\n' >> "$t35_other" 2>/dev/null; then pass "T35 setup: the stub passes other mktemp calls through writable"; else fail "T35 setup: the stub passes other mktemp calls through writable" "append failed"; fi
+t35_out=$(PATH="$t35_stub:$PATH" bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --yes 2>&1); t35_rc=$?
+assert_eq "T35 an unrecordable snapshot leaves the stamp byte-identical" "$t35_stamp_before" "$(sha_of "$V/.vault-template.json")"
+assert_eq "T35 the existing snapshot survives intact" "$t35_keys_before" "$(snap_keys "$V/.vault-template.json")"
+if [ "$t35_rc" -ne 0 ]; then pass "T35 exits non-zero rather than stamping"; else fail "T35 exits non-zero rather than stamping" "rc=0, out: $t35_out"; fi
+
+# --- T36: the READ half. A write-only scratch file (0200) records fine but
+# cannot be read back at stamp time; the stamp must not be written without it.
+T="$TMP/t36-tmpl"; V="$TMP/t36-vault"
+t35_fixture "$T" "$V"
+t36_keys_before=$(snap_keys "$V/.vault-template.json")
+t36_stamp_before=$(sha_of "$V/.vault-template.json")
+t36_stub="$TMP/t36-stub"; mk_mktemp_stub "$t36_stub" 0200
+t36_probe=$(PATH="$t36_stub:$PATH" mktemp -t luna-upgrade-snapshot.XXXXXX)
+if printf 'x\n' >> "$t36_probe" 2>/dev/null; then pass "T36 setup: the stub's snapshot file accepts appends"; else fail "T36 setup: the stub's snapshot file accepts appends" "append failed"; fi
+if cat "$t36_probe" >/dev/null 2>&1; then fail "T36 setup: the stub's snapshot file rejects reads" "read succeeded"; else pass "T36 setup: the stub's snapshot file rejects reads"; fi
+t36_out=$(PATH="$t36_stub:$PATH" bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --yes 2>&1); t36_rc=$?
+assert_eq "T36 an unreadable snapshot leaves the stamp byte-identical" "$t36_stamp_before" "$(sha_of "$V/.vault-template.json")"
+assert_eq "T36 the existing snapshot survives intact" "$t36_keys_before" "$(snap_keys "$V/.vault-template.json")"
+if [ "$t36_rc" -ne 0 ]; then pass "T36 exits non-zero rather than stamping"; else fail "T36 exits non-zero rather than stamping" "rc=0, out: $t36_out"; fi
 echo
 if [ "$FAILED" -eq 0 ]; then echo "All upgrade tests passed."; else echo "$FAILED test(s) failed."; exit 1; fi

--- a/templates/luna-second-brain/scripts/test-upgrade.sh
+++ b/templates/luna-second-brain/scripts/test-upgrade.sh
@@ -561,5 +561,130 @@ fi
 t29_stamp=$("$PY" -c 'import json,sys; print(json.load(open(sys.argv[1])).get("version",""))' "$V/.vault-template.json" 2>/dev/null)
 assert_eq "T29 stamp NOT advanced while a local edit is withheld" "0.9.0" "$t29_stamp"
 
+
+# ---------------------------------------------------------------------------
+# T30 (HIMMEL-2903): the local-edit baseline is a per-file content SNAPSHOT
+# recorded in the stamp, not the vault's git history — so an edit committed in
+# the SAME commit that advances the stamp (a batching autosync, exactly what
+# the luna github-sync plugin does every 10 min) is still caught. The git path
+# structurally cannot see this case: that commit IS the baseline it reads, and
+# it already contains the edit.
+T="$TMP/t30-tmpl"; V="$TMP/t30-vault"
+make_template "$T" "0.9.0"
+printf 'gitleaks-content-v1\n' > "$T/.gitleaks.toml"
+mkdir -p "$V"; cp -r "$T/." "$V/"; rm -f "$V/marketplace/.claude-plugin/marketplace.json"
+stamp_vault "$V" "0.1.0"
+git -C "$V" init -q
+git -C "$V" config user.email "test@example.com"
+git -C "$V" config user.name "Test"
+git -C "$V" add -A
+git -C "$V" commit -q -m "initial"
+# Upgrade #1 brings the vault to 0.9.0 AND records the content snapshot.
+bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --yes >/dev/null 2>&1
+t30_snap=$("$PY" -c 'import json,sys; print(json.load(open(sys.argv[1])).get("files",{}).get(".gitleaks.toml",""))' "$V/.vault-template.json" 2>/dev/null)
+assert_eq "T30 stamp records a content snapshot for .gitleaks.toml" "sha256:$(sha_of "$V/.gitleaks.toml")" "$t30_snap"
+# The POISONING commit: the vault-local edit and the advanced stamp land in ONE
+# commit, so the commit the git path resolves as the baseline already carries
+# the edit.
+printf 'gitleaks-content-v1\nlocal-allowlist-line\n' > "$V/.gitleaks.toml"
+git -C "$V" add -A
+git -C "$V" commit -q -m "autosync: local allowlist line + stamp 0.9.0"
+t30_stamp_commit=$(git -C "$V" log -1 --format=%H -- .vault-template.json)
+git -C "$V" show "$t30_stamp_commit:./.gitleaks.toml" > "$TMP/t30-git-baseline" 2>/dev/null
+assert_eq "T30 setup: the git baseline is poisoned (it already carries the edit)" "$(sha_of "$V/.gitleaks.toml")" "$(sha_of "$TMP/t30-git-baseline")"
+# A newer template that changes the same file.
+printf '{"metadata":{"version":"1.0.0"}}\n' > "$T/marketplace/.claude-plugin/marketplace.json"
+printf 'gitleaks-content-v2\n' > "$T/.gitleaks.toml"
+t30_pre_sha=$(sha_of "$V/.gitleaks.toml")
+t30_dry=$(bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --dry-run 2>&1)
+case "$t30_dry" in
+    *"local edits withheld (not overwritten): .gitleaks.toml"*"[baseline: snapshot]"*)
+        pass "T30 dry-run withholds .gitleaks.toml naming the snapshot provenance" ;;
+    *) fail "T30 dry-run withholds .gitleaks.toml naming the snapshot provenance" "got: $t30_dry" ;;
+esac
+# A file whose content still MATCHES its snapshot is not a local edit — the
+# snapshot must not withhold every differing file indiscriminately.
+case "$t30_dry" in
+    *"withheld (not overwritten): marketplace/.claude-plugin/marketplace.json"*)
+        fail "T30 dry-run still WRITES an unedited snapshot-matching file" "marketplace.json was withheld" ;;
+    *"WRITE        marketplace/.claude-plugin/marketplace.json"*)
+        pass "T30 dry-run still WRITES an unedited snapshot-matching file" ;;
+    *) fail "T30 dry-run still WRITES an unedited snapshot-matching file" "got: $t30_dry" ;;
+esac
+bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --yes >/dev/null 2>&1; t30_rc=$?
+assert_eq "T30 apply does NOT overwrite the edit the git baseline cannot see" "$t30_pre_sha" "$(sha_of "$V/.gitleaks.toml")"
+if [ "$t30_rc" -ne 0 ]; then pass "T30 apply exits non-zero (not a clean upgrade)"; else fail "T30 apply exits non-zero (not a clean upgrade)" "rc=0"; fi
+
+# ---------------------------------------------------------------------------
+# T31 (HIMMEL-2903): an OPERATIONAL `git log` failure (shallow clone, corrupt
+# index, permission error) must fail CLOSED, like the cat-file/show steps
+# already do — not be read as "no baseline" and fall through to the pre-2886
+# silent overwrite. Simulated with a PATH stub `git` that fails ONLY for `log`.
+T="$TMP/t31-tmpl"; V="$TMP/t31-vault"
+make_template "$T" "0.9.0"
+printf 'gitleaks-content-v1\n' > "$T/.gitleaks.toml"
+mkdir -p "$V"; cp -r "$T/." "$V/"; rm -f "$V/marketplace/.claude-plugin/marketplace.json"
+# A PRE-snapshot stamp (3 keys, no "files") — the git path is the only baseline.
+stamp_vault "$V" "0.9.0"
+git -C "$V" init -q
+git -C "$V" config user.email "test@example.com"
+git -C "$V" config user.name "Test"
+git -C "$V" add -A
+git -C "$V" commit -q -m "initial stamp 0.9.0"
+printf 'gitleaks-content-v1\nlocal-allowlist-line\n' > "$V/.gitleaks.toml"
+git -C "$V" add -A
+git -C "$V" commit -q -m "local edit after the stamp"
+printf '{"metadata":{"version":"1.0.0"}}\n' > "$T/marketplace/.claude-plugin/marketplace.json"
+printf 'gitleaks-content-v2\n' > "$T/.gitleaks.toml"
+t31_stub="$TMP/t31-stub"; mkdir -p "$t31_stub"
+t31_real_git="$(command -v git)"
+# shellcheck disable=SC2016  # the single-quoted lines are the STUB's source, not this shell's
+{
+    echo '#!/usr/bin/env bash'
+    echo 'for a in "$@"; do'
+    echo '    if [ "$a" = "log" ]; then echo "fatal: simulated git log failure" >&2; exit 128; fi'
+    echo 'done'
+    printf 'exec "%s" "$@"\n' "$t31_real_git"
+} > "$t31_stub/git"
+chmod +x "$t31_stub/git"
+# The stub must actually do what the case claims: fail for `log`, pass every
+# other subcommand through (a stub that broke ALL of git would "pass" this case
+# for the wrong reason).
+t31_log_rc=$(PATH="$t31_stub:$PATH" git -C "$V" log -1 --format=%H >/dev/null 2>&1; echo $?)
+assert_eq "T31 setup: the stub makes git log fail operationally" "128" "$t31_log_rc"
+assert_eq "T31 setup: the stub passes other subcommands through" "true" "$(PATH="$t31_stub:$PATH" git -C "$V" rev-parse --is-inside-work-tree 2>/dev/null)"
+t31_pre_sha=$(sha_of "$V/.gitleaks.toml")
+t31_out=$(PATH="$t31_stub:$PATH" bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --yes 2>&1); t31_rc=$?
+assert_eq "T31 a failing git log withholds the write (fails closed)" "$t31_pre_sha" "$(sha_of "$V/.gitleaks.toml")"
+case "$t31_out" in
+    *"could not determine the upgrade baseline (git log failed) — withholding .gitleaks.toml as a precaution"*)
+        pass "T31 names the failed baseline in the withheld line" ;;
+    *) fail "T31 names the failed baseline in the withheld line" "got: $t31_out" ;;
+esac
+if [ "$t31_rc" -ne 0 ]; then pass "T31 apply exits non-zero (not a clean upgrade)"; else fail "T31 apply exits non-zero (not a clean upgrade)" "rc=0"; fi
+
+# ---------------------------------------------------------------------------
+# T32 (HIMMEL-2903): the fail-closed git-log gate must NOT fire on a vault whose
+# repo simply has no commits yet — `git log` exits 128 there too ("does not have
+# any commits yet"), but that is a legitimately absent baseline, not an
+# operational failure. A blanket rc!=0 check would withhold every file on the
+# first upgrade of a freshly `git init`-ed vault.
+T="$TMP/t32-tmpl"; V="$TMP/t32-vault"
+make_template "$T" "1.0.0"
+printf 'gitleaks-content-v2\n' > "$T/.gitleaks.toml"
+mkdir -p "$V"; cp -r "$T/." "$V/"
+printf 'gitleaks-content-v1\n' > "$V/.gitleaks.toml"
+stamp_vault "$V" "0.9.0"
+git -C "$V" init -q
+git -C "$V" config user.email "test@example.com"
+git -C "$V" config user.name "Test"
+if git -C "$V" rev-parse --verify -q HEAD >/dev/null 2>&1; then
+    fail "T32 setup: the vault repo has no commits yet" "HEAD resolves"
+else
+    pass "T32 setup: the vault repo has no commits yet"
+fi
+bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --yes >/dev/null 2>&1; t32_rc=$?
+assert_eq "T32 first upgrade of a commitless vault still writes the template file" "$(sha_of "$T/.gitleaks.toml")" "$(sha_of "$V/.gitleaks.toml")"
+assert_eq "T32 first upgrade of a commitless vault exits 0" "0" "$t32_rc"
 echo
 if [ "$FAILED" -eq 0 ]; then echo "All upgrade tests passed."; else echo "$FAILED test(s) failed."; exit 1; fi

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -310,6 +310,7 @@ STAMP_COMMIT=""
 # exact failure this detection exists to close. has_local_edit fails CLOSED on
 # a cat-file/show error already; this makes the `git log` step consistent.
 BASELINE_ERROR=0
+BASELINE_ERROR_REASON=""
 # `git rev-parse --is-inside-work-tree`, not `[ -d "$VAULT_DIR/.git" ]`: a
 # worktree or a submodule has a `.git` FILE (a `gitdir: <path>` pointer), not
 # a directory, so the directory-only check silently fell back to the
@@ -319,11 +320,25 @@ if git -C "$VAULT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     # ("does not have any commits yet"). That is a legitimately absent
     # baseline, not an operational failure — without this gate the first
     # upgrade of a freshly `git init`-ed vault would withhold every file.
-    if ! git -C "$VAULT_DIR" rev-parse --verify -q HEAD >/dev/null 2>&1; then
-        : # no commits yet — no baseline, same as a vault with no repo at all
+    #
+    # The gate reads the EXACT rc, not merely non-zero: `rev-parse --verify -q`
+    # exits 1 for "HEAD names no commit" (an unborn branch, or a HEAD ref with
+    # nothing behind it — git itself cannot tell those apart, and both are a
+    # genuinely absent baseline), and exits otherwise (128) for an operational
+    # failure such as an unreadable refs backend. Collapsing the two would let
+    # a refs-layer error masquerade as a fresh vault and fail OPEN, which is
+    # the same hole this block closes one step further down.
+    git -C "$VAULT_DIR" rev-parse --verify -q HEAD >/dev/null 2>&1
+    head_rc=$?
+    if [ "$head_rc" -eq 1 ]; then
+        : # HEAD names no commit — no baseline, like a vault with no repo
+    elif [ "$head_rc" -ne 0 ]; then
+        BASELINE_ERROR=1
+        BASELINE_ERROR_REASON="git rev-parse failed"
     elif ! STAMP_COMMIT="$(git -C "$VAULT_DIR" log -1 --format=%H -- .vault-template.json 2>/dev/null)"; then
         STAMP_COMMIT=""
         BASELINE_ERROR=1
+        BASELINE_ERROR_REASON="git log failed"
     fi
 fi
 
@@ -375,7 +390,7 @@ has_local_edit() {
 
     # (2) git baseline. A failed `git log` is not a proven absence of one.
     if [ "$BASELINE_ERROR" = 1 ]; then
-        [ "$print" = 1 ] && echo "  could not determine the upgrade baseline (git log failed) — withholding $rel as a precaution"
+        [ "$print" = 1 ] && echo "  could not determine the upgrade baseline ($BASELINE_ERROR_REASON) — withholding $rel as a precaution"
         return 0
     fi
     [ -n "$STAMP_COMMIT" ] || return 1
@@ -718,12 +733,19 @@ if [ "$ASSUME_YES" != 1 ]; then
 fi
 
 # --- Execute pass ---
-# A failed mktemp is not fatal: the run proceeds and simply writes no snapshot,
-# so the NEXT run falls back to the git baseline (the pre-HIMMEL-2903 shape).
+# Without a scratch file there is no snapshot to record — and because the stamp
+# is REWRITTEN wholesale below, a run that proceeds anyway would strip whatever
+# `files` map the vault already had, silently demoting it back to the poisonable
+# git baseline this change exists to replace. So refuse HERE, before the first
+# write: nothing has been touched yet, so the abort leaves the vault exactly as
+# it was and a re-run is clean.
 SNAPSHOT_FILE="$(mktemp 2>/dev/null)"
 if [ -z "$SNAPSHOT_FILE" ] || [ ! -e "$SNAPSHOT_FILE" ]; then
-    SNAPSHOT_FILE=""
-    echo "  WARN: could not create a temp file for the content snapshot; this run's stamp will carry none (the next run falls back to the vault's git history)." >&2
+    echo "upgrade: could not create a temp file for the content snapshot — aborting before any change." >&2
+    echo "  Proceeding would rewrite $STAMP without its content snapshot, dropping the" >&2
+    echo "  local-edit baseline the vault already has. No files were modified; free up" >&2
+    echo "  temp space (or set TMPDIR to a writable directory) and re-run." >&2
+    exit 2
 fi
 PLAN=()
 n_write=0 n_skip_identical=0 n_skip_exists=0 n_jsonmerge=0 n_report=0 n_threeway=0 n_local_edit=0

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -205,6 +205,53 @@ else
     VAULT_VERSION="0.0.0"
 fi
 
+# ---------------------------------------------------------------------------
+# Per-file content snapshot (HIMMEL-2903). The stamp carries a
+# `files: {"<rel>": "sha256:<hex>"}` map of what the template last wrote for
+# every "overwrite"-class file. That is a baseline the VAULT's own git history
+# cannot poison, so it is preferred over the STAMP_COMMIT baseline below.
+# Read once, into newline-separated "<rel><TAB><sha256:hex>" rows (bash 3.2 —
+# no associative arrays). A stamp without a `files` map (any vault last
+# upgraded before this version) yields an empty map and the git baseline
+# carries, exactly as before; the first upgrade under this version writes one.
+SNAPSHOT_MAP=""
+if [ -f "$STAMP" ]; then
+    SNAPSHOT_MAP="$("$PYTHON" - "$STAMP" 2>/dev/null <<'PY'
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    sys.exit(0)
+if not isinstance(d, dict):
+    sys.exit(0)
+files = d.get("files")
+if not isinstance(files, dict):
+    sys.exit(0)
+for rel in sorted(files):
+    sha = files[rel]
+    # A rel with a tab/newline in it would corrupt the row format; such a path
+    # cannot come from this script's own writer, so skip rather than trust it.
+    if isinstance(sha, str) and isinstance(rel, str) and not (set("\t\n\r") & set(rel)):
+        print("%s\t%s" % (rel, sha))
+PY
+)"
+fi
+
+# snapshot_sha <rel>: echo the recorded "sha256:<hex>" for <rel>, or nothing.
+snapshot_sha() {
+    local want="$1" rel sha
+    [ -n "$SNAPSHOT_MAP" ] || return 1
+    while IFS="$(printf '\t')" read -r rel sha; do
+        if [ "$rel" = "$want" ] && [ -n "$sha" ]; then
+            printf '%s' "$sha"
+            return 0
+        fi
+    done <<EOF
+$SNAPSHOT_MAP
+EOF
+    return 1
+}
+
 # semver-ish compare: return 0 iff $1 < $2.
 ver_lt() {
     [ "$1" = "$2" ] && return 1
@@ -246,35 +293,92 @@ fi
 # upgraded via a git-tracked flow), has no baseline to compare against, so
 # falls back to the pre-existing overwrite behavior.
 #
-# Known limitation, tracked as HIMMEL-2903 (not fixed here — flagged by CR,
-# out of scope for a minimal refuse-or-print fix): if a local edit to a
-# template-owned file is committed in the SAME commit that also advances the
-# stamp (e.g. a batching autosync), that commit becomes STAMP_COMMIT itself,
-# so the baseline it reads back already contains the edit. A later run then
-# sees no divergence from that (already-edited) baseline and would silently
-# accept the template's write. Detecting this needs a baseline independent
-# of the vault's own commit history (e.g. a per-file content snapshot
-# alongside .vault-template.json), which is a larger change than this
-# ticket scopes.
+# The git baseline is now the FALLBACK, not the primary one (HIMMEL-2903): it
+# is poisonable. If a local edit to a template-owned file is committed in the
+# SAME commit that also advances the stamp (e.g. a batching autosync — what the
+# luna github-sync plugin does every 10 min), that commit becomes STAMP_COMMIT
+# itself, so the baseline it reads back already contains the edit and a later
+# run sees no divergence. The per-file content snapshot in the stamp
+# (SNAPSHOT_MAP above) is independent of the vault's commit history and is
+# consulted first; the git baseline only answers for files the snapshot has no
+# entry for (a vault whose last upgrade predates the snapshot).
 STAMP_COMMIT=""
+# BASELINE_ERROR: `git log` FAILED operationally (shallow clone, corrupt index,
+# permission error) — distinct from "git ran and found no such commit" (rc 0,
+# empty stdout). Treating the two alike is fail-OPEN: an empty STAMP_COMMIT
+# means "no baseline" means the pre-HIMMEL-2886 silent overwrite, which is the
+# exact failure this detection exists to close. has_local_edit fails CLOSED on
+# a cat-file/show error already; this makes the `git log` step consistent.
+BASELINE_ERROR=0
 # `git rev-parse --is-inside-work-tree`, not `[ -d "$VAULT_DIR/.git" ]`: a
 # worktree or a submodule has a `.git` FILE (a `gitdir: <path>` pointer), not
 # a directory, so the directory-only check silently fell back to the
 # pre-existing overwrite behavior for exactly those vaults.
 if git -C "$VAULT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    STAMP_COMMIT="$(git -C "$VAULT_DIR" log -1 --format=%H -- .vault-template.json 2>/dev/null)"
+    # HEAD gate first: `git log` also exits 128 in a repo with NO commits yet
+    # ("does not have any commits yet"). That is a legitimately absent
+    # baseline, not an operational failure — without this gate the first
+    # upgrade of a freshly `git init`-ed vault would withhold every file.
+    if ! git -C "$VAULT_DIR" rev-parse --verify -q HEAD >/dev/null 2>&1; then
+        : # no commits yet — no baseline, same as a vault with no repo at all
+    elif ! STAMP_COMMIT="$(git -C "$VAULT_DIR" log -1 --format=%H -- .vault-template.json 2>/dev/null)"; then
+        STAMP_COMMIT=""
+        BASELINE_ERROR=1
+    fi
 fi
 
-# has_local_edit <rel> <dst> [print]: exit 0 iff <dst> differs from what was
-# committed at STAMP_COMMIT for <rel>. No stamp commit, or the file didn't
-# exist there (new template-owned file), means no baseline => not a local
-# edit. With [print]=1, also emits the "local edits withheld" line + a
-# unified diff of the withheld hunk — called once per file (the planning
+# withhold_notice <rel> <provenance>: the shared "local edits withheld" line.
+# <provenance> names WHICH baseline spoke (snapshot | git) so an operator
+# reading a --dry-run plan can tell the stamp's content snapshot from the
+# vault-git fallback in one word (HIMMEL-2903).
+withhold_notice() {
+    local rel="$1" prov="$2" backup_note="none (no --backup-dir given for this run)"
+    [ -n "$BACKUP_DIR" ] && backup_note="$BACKUP_DIR/$rel"
+    echo "  local edits withheld (not overwritten): $rel (backup: $backup_note) [baseline: $prov]"
+}
+
+# has_local_edit <rel> <dst> [print]: exit 0 iff <dst> differs from the
+# baseline for <rel> — i.e. the vault edited it since its last upgrade.
+# Baseline resolution order (HIMMEL-2903):
+#   1. the stamp's per-file content snapshot, when it has an entry for <rel>
+#      (authoritative: independent of the vault's commit history);
+#   2. else the content committed at STAMP_COMMIT (the vault's last stamped
+#      upgrade) — the pre-2903 behaviour, kept for vaults stamped before the
+#      snapshot existed, and fail-CLOSED when `git log` itself failed;
+#   3. no baseline at all (no repo, no stamp commit, new template-owned file)
+#      => not a local edit, the pre-existing overwrite behaviour.
+# A file recorded in the snapshot but absent on disk is NOT a local edit —
+# deleted files stay the existing code path's business.
+# With [print]=1, also emits the "local edits withheld" line (+ a unified diff
+# of the withheld hunk on the git path) — called once per file (the planning
 # pass only; the execute pass re-detects the same files but must not re-print).
 has_local_edit() {
     local rel="$1" dst="$2" print="${3:-0}"
-    [ -n "$STAMP_COMMIT" ] || return 1
     [ -f "$dst" ] || return 1
+
+    # (1) Snapshot baseline: the sha the template itself last wrote here.
+    local snap dst_sha
+    if snap="$(snapshot_sha "$rel")" && [ -n "$snap" ]; then
+        dst_sha="sha256:$(sha_of "$dst")"
+        if [ "$snap" != "$dst_sha" ]; then
+            if [ "$print" = 1 ]; then
+                withhold_notice "$rel" "snapshot"
+                # The snapshot is a hash, not content — there is nothing to
+                # diff against, so name both shas instead of printing nothing.
+                echo "    recorded at the last upgrade: $snap"
+                echo "    on disk now:                  $dst_sha"
+            fi
+            return 0
+        fi
+        return 1
+    fi
+
+    # (2) git baseline. A failed `git log` is not a proven absence of one.
+    if [ "$BASELINE_ERROR" = 1 ]; then
+        [ "$print" = 1 ] && echo "  could not determine the upgrade baseline (git log failed) — withholding $rel as a precaution"
+        return 0
+    fi
+    [ -n "$STAMP_COMMIT" ] || return 1
     # `./$rel`, not a bare `$rel`: `git show <rev>:<path>` resolves a path
     # relative to the CURRENT DIRECTORY only when it starts with `./` —
     # a bare path is repo-root-relative, which is the WRONG root whenever
@@ -318,14 +422,12 @@ has_local_edit() {
         [ "$print" = 1 ] && echo "  could not verify local edits for $rel (git show failed) — withholding the write as a precaution"
         return 0
     fi
-    local committed_sha dst_sha
+    local committed_sha
     committed_sha="$(sha_of "$committed")"
     dst_sha="$(sha_of "$dst")"
     if [ "$committed_sha" != "$dst_sha" ]; then
         if [ "$print" = 1 ]; then
-            local backup_note="none (no --backup-dir given for this run)"
-            [ -n "$BACKUP_DIR" ] && backup_note="$BACKUP_DIR/$rel"
-            echo "  local edits withheld (not overwritten): $rel (backup: $backup_note)"
+            withhold_notice "$rel" "git"
             if command -v diff >/dev/null 2>&1; then
                 diff -u "$committed" "$dst" | sed 's/^/    /'
             fi
@@ -376,6 +478,24 @@ write_file() {
 }
 
 sha_of() { if [ -f "$1" ]; then sha256sum "$1" | cut -d' ' -f1; else echo MISSING; fi; }
+
+# Snapshot accumulator (HIMMEL-2903): the execute pass records, for every
+# "overwrite"-class file, the sha of what is in the VAULT once the pass is
+# done — which is what the template just wrote, because the stamp is written
+# ONLY when the run fully succeeded (no withheld edits, no write failures).
+# That sha becomes the next run's baseline, immune to whatever the vault
+# afterwards commits alongside the stamp. A file the template owns but that
+# is absent in the vault records nothing.
+SNAPSHOT_FILE=""
+trap '[ -n "${SNAPSHOT_FILE:-}" ] && rm -f "$SNAPSHOT_FILE"; true' EXIT
+
+record_snapshot() {
+    local rel="$1" dst="$2" s
+    [ -n "$SNAPSHOT_FILE" ] || return 0
+    s="$(sha_of "$dst")"
+    [ "$s" = "MISSING" ] && return 0
+    printf '%s\t%s\n' "$rel" "$s" >> "$SNAPSHOT_FILE"
+}
 
 # Capture the vault's prior PLUGINS-SETUP.md sha BEFORE any overwrite, so the
 # reprint check (step 4) can tell whether the manual-install table changed.
@@ -531,7 +651,11 @@ process() {
                     fi
                 else
                     n_skip_identical=$((n_skip_identical+1))
-                fi ;;
+                fi
+                # Record the post-pass content regardless of the branch taken:
+                # written, identical, or withheld. A withheld file blocks the
+                # stamp write entirely, so its row never reaches a stamp.
+                if [ "$execute" = 1 ]; then record_snapshot "$rel" "$dst"; fi ;;
             skipexists)
                 if [ -f "$dst" ]; then
                     n_skip_exists=$((n_skip_exists+1))
@@ -594,6 +718,13 @@ if [ "$ASSUME_YES" != 1 ]; then
 fi
 
 # --- Execute pass ---
+# A failed mktemp is not fatal: the run proceeds and simply writes no snapshot,
+# so the NEXT run falls back to the git baseline (the pre-HIMMEL-2903 shape).
+SNAPSHOT_FILE="$(mktemp 2>/dev/null)"
+if [ -z "$SNAPSHOT_FILE" ] || [ ! -e "$SNAPSHOT_FILE" ]; then
+    SNAPSHOT_FILE=""
+    echo "  WARN: could not create a temp file for the content snapshot; this run's stamp will carry none (the next run falls back to the vault's git history)." >&2
+fi
 PLAN=()
 n_write=0 n_skip_identical=0 n_skip_exists=0 n_jsonmerge=0 n_report=0 n_threeway=0 n_local_edit=0
 WRITE_FAILURES=0
@@ -648,12 +779,28 @@ if [ "$WRITE_FAILURES" -gt 0 ] || [ "$n_local_edit" -gt 0 ] || [ "$CLAUDE_MERGE_
     exit 1
 fi
 
-if ! "$PYTHON" - "$STAMP" "$TEMPLATE_VERSION" <<'PY'
+if ! "$PYTHON" - "$STAMP" "$TEMPLATE_VERSION" "$SNAPSHOT_FILE" <<'PY'
 import json, sys, datetime
-stamp_p, ver = sys.argv[1], sys.argv[2]
+stamp_p, ver, snap_p = sys.argv[1], sys.argv[2], sys.argv[3]
 now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+stamp = {"template": "luna-second-brain", "version": ver, "upgraded_at": now}
+# files: the per-file content baseline for the next run (HIMMEL-2903). Sorted
+# so the stamp is byte-stable across runs that changed nothing — a vault that
+# autosyncs the stamp should not see a spurious diff every upgrade.
+files = {}
+if snap_p:
+    try:
+        with open(snap_p, encoding="utf-8") as fh:
+            for line in fh:
+                rel, tab, sha = line.rstrip("\n").partition("\t")
+                if tab and rel and sha:
+                    files[rel] = "sha256:" + sha
+    except OSError:
+        files = {}
+if files:
+    stamp["files"] = dict(sorted(files.items()))
 with open(stamp_p, "w", encoding="utf-8") as fh:
-    json.dump({"template": "luna-second-brain", "version": ver, "upgraded_at": now}, fh, indent=2)
+    json.dump(stamp, fh, indent=2)
     fh.write("\n")
 PY
 then

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -504,12 +504,20 @@ sha_of() { if [ -f "$1" ]; then sha256sum "$1" | cut -d' ' -f1; else echo MISSIN
 SNAPSHOT_FILE=""
 trap '[ -n "${SNAPSHOT_FILE:-}" ] && rm -f "$SNAPSHOT_FILE"; true' EXIT
 
+SNAPSHOT_FAILURES=0
 record_snapshot() {
     local rel="$1" dst="$2" s
     [ -n "$SNAPSHOT_FILE" ] || return 0
     s="$(sha_of "$dst")"
     [ "$s" = "MISSING" ] && return 0
-    printf '%s\t%s\n' "$rel" "$s" >> "$SNAPSHOT_FILE"
+    # A dropped row is not cosmetic: the stamp is rewritten wholesale, so a
+    # file whose row never lands loses its snapshot entry and silently reverts
+    # to the poisonable git baseline. Count the failure and let the stamp guard
+    # below refuse the write, the same way a failed file write does.
+    if ! printf '%s\t%s\n' "$rel" "$s" >> "$SNAPSHOT_FILE"; then
+        SNAPSHOT_FAILURES=$((SNAPSHOT_FAILURES+1))
+        echo "  WARN: could not record the content snapshot for $rel" >&2
+    fi
 }
 
 # Capture the vault's prior PLUGINS-SETUP.md sha BEFORE any overwrite, so the
@@ -739,7 +747,7 @@ fi
 # git baseline this change exists to replace. So refuse HERE, before the first
 # write: nothing has been touched yet, so the abort leaves the vault exactly as
 # it was and a re-run is clean.
-SNAPSHOT_FILE="$(mktemp 2>/dev/null)"
+SNAPSHOT_FILE="$(mktemp -t luna-upgrade-snapshot.XXXXXX 2>/dev/null)"
 if [ -z "$SNAPSHOT_FILE" ] || [ ! -e "$SNAPSHOT_FILE" ]; then
     echo "upgrade: could not create a temp file for the content snapshot — aborting before any change." >&2
     echo "  Proceeding would rewrite $STAMP without its content snapshot, dropping the" >&2
@@ -792,10 +800,11 @@ fi
 # target version — leave the stamp behind so a re-run re-processes (and
 # re-alerts) instead of a "current" stamp silently masking the gap. The stamp
 # is the last write, so an aborted run also re-runs cleanly (idempotent).
-if [ "$WRITE_FAILURES" -gt 0 ] || [ "$n_local_edit" -gt 0 ] || [ "$CLAUDE_MERGE_RESULT" = "conflict" ] || [ "$CLAUDE_MERGE_RESULT" = "error" ]; then
+if [ "$WRITE_FAILURES" -gt 0 ] || [ "$n_local_edit" -gt 0 ] || [ "$SNAPSHOT_FAILURES" -gt 0 ] || [ "$CLAUDE_MERGE_RESULT" = "conflict" ] || [ "$CLAUDE_MERGE_RESULT" = "error" ]; then
     echo "" >&2
     echo "upgrade: NOT writing the version stamp — the vault is partially upgraded" >&2
     echo "  (write failures: $WRITE_FAILURES; local edits withheld: $n_local_edit;" >&2
+    echo "  snapshot failures: $SNAPSHOT_FAILURES;" >&2
     echo "  _CLAUDE.md: ${CLAUDE_MERGE_RESULT:-ok}). Resolve the issues above and re-run;" >&2
     echo "  template-owned writes are idempotent." >&2
     exit 1
@@ -811,14 +820,19 @@ stamp = {"template": "luna-second-brain", "version": ver, "upgraded_at": now}
 # autosyncs the stamp should not see a spurious diff every upgrade.
 files = {}
 if snap_p:
+    # An unreadable scratch file must NOT degrade to "no snapshot": the stamp
+    # below is rewritten wholesale, so writing it without the map would strip
+    # the baseline the vault already has. Fail instead — the caller prints the
+    # re-run message and the existing stamp (with its existing map) survives.
     try:
         with open(snap_p, encoding="utf-8") as fh:
             for line in fh:
                 rel, tab, sha = line.rstrip("\n").partition("\t")
                 if tab and rel and sha:
                     files[rel] = "sha256:" + sha
-    except OSError:
-        files = {}
+    except OSError as e:
+        sys.stderr.write("upgrade: could not read the content snapshot (%s)\n" % e)
+        sys.exit(3)
 if files:
     stamp["files"] = dict(sorted(files.items()))
 with open(stamp_p, "w", encoding="utf-8") as fh:


### PR DESCRIPTION
## Summary

`upgrade.sh`'s local-edit detection (HIMMEL-2886) derived its baseline from the **vault's git history**: `STAMP_COMMIT` = the last commit touching `.vault-template.json`, compared against the file's content now. Two holes, both deferred from #606 round 2–4.

**(A) Poisoned baseline.** A vault-local edit committed in the SAME commit that advances the stamp — a batching autosync, exactly what the luna github-sync plugin does every 10 min — *becomes* the baseline. The next run sees no divergence from that already-edited baseline and silently lets the template overwrite the edit.

**(B) `git log` fail-open.** An operational failure (shallow clone, corrupt index, permission error) produced the same empty `STAMP_COMMIT` as "no stamp commit" → no baseline → the pre-2886 silent overwrite, the exact failure 2886 exists to close. `has_local_edit` already fails **closed** on cat-file/show errors; only the `git log` step was inconsistent.

## What changed

- **`.vault-template.json` gains `files: {"<rel>": "sha256:<hex>"}`** — written at the end of every *successful* upgrade, for every "overwrite"-class file, recording what the template just put there. The stamp is only written when the run fully succeeded (no withheld edits, no write failures), so the recorded sha **is** the template's content by construction. The vault's commit history cannot poison it.
- **`has_local_edit` baseline resolution order:** (1) the snapshot entry for `<rel>`; (2) else the git baseline exactly as before; (3) else no baseline → the pre-existing overwrite behaviour. A file in the snapshot but absent on disk is not a local edit. Vaults stamped before 0.4.25 have no map and keep the git behaviour until their next upgrade writes one — the window closes after one run.
- **A failing `git` fails closed:** sets `BASELINE_ERROR`, withholds the write, and names which step failed — for files the snapshot has no entry for. A repo with **no commits yet** is gated out first: `git log` exits 128 there too, but that is a legitimately absent baseline, so the gate reads `rev-parse --verify -q HEAD`'s **exact** rc — 1 means "HEAD names no commit" (fall through, as before), anything else is an operational refs failure and withholds. Without the gate, the first upgrade of a freshly `git init`-ed vault would withhold every file.
- **Snapshot persistence fails closed at every step:** a scratch file that cannot be created aborts before the first write; a row that cannot be appended, or a scratch file that cannot be read back at stamp time, leaves the existing stamp — and its map — byte-identical and exits non-zero. The stamp is rewritten wholesale, so any of these proceeding would strip a baseline the vault already had.
- **Provenance in the plan:** every withheld line now ends in `[baseline: snapshot]` or `[baseline: git]`; the snapshot form prints the recorded and on-disk shas (a hash has no content to diff against).

No new dependency — the stamp is read and written with the python the script already hard-requires (`_resolve_python` gates on it). No new exec surface.

## RED → GREEN

Both controls were written first and run against the **pre-change** engine; both failed there with the *specific* wrong value (the file coming back as the template's content, `sha256:eaeb2358…` = `gitleaks-content-v2`), not a crash or empty output.

| Case | Before the fix | After |
|---|---|---|
| **T30** poisoned baseline — upgrade once (snapshot recorded), then commit the local edit **and** the stamp in ONE commit, then upgrade with a newer template that changes that file | file overwritten to template content, rc **0**; no `files` map in the stamp | withheld, provenance `snapshot`, rc **1** |
| **T31** operational `git log` failure — PATH stub `git` that exits 128 for `log` only (asserted separately: it *does* fail for `log`, and *does* pass other subcommands through) | file overwritten to template content, rc **0** | withheld with `could not determine the upgrade baseline (git log failed)`, rc **1** |
| **T32** commitless repo (pins the HEAD gate, passes on both) | first upgrade writes, rc 0 | unchanged — first upgrade writes, rc 0 |

T30 also asserts that a file whose content still **matches** its snapshot is still WRITE-planned, so the snapshot does not withhold indiscriminately.

## Provenance sample (real template, sandbox vault — never the live vault)

```
--- stamp files map ---
version: 0.4.22
files keys: 40
  .env.example    = sha256:57bc298027553c7cb7b19cafb7ab951585431315609060ec11efcc9cb7e3d028
  .gitleaks.toml  = sha256:e0b8ab3b9daa688f6c77676e8386749052607b03dda006572bbf40411029f36d
  ...
--- dry-run plan, after a poisoning commit + a newer template ---
  local edits withheld (not overwritten): .gitleaks.toml (backup: none (no --backup-dir given for this run)) [baseline: snapshot]
    recorded at the last upgrade: sha256:e0b8ab3b9daa688f6c77676e8386749052607b03dda006572bbf40411029f36d
    on disk now:                  sha256:9b9d18e9013edb923b1066faa9ac6dc2d90b680f18f07b4bfff8c1b8affcc751
Plan (1 write, 0 json-merge, 1 _CLAUDE.md, 0 report, 38 identical, 19 user-kept, 1 local-edit-withheld):
  LOCAL-EDIT   .gitleaks.toml (vault has local edits since last upgrade — NOT overwritten)
```

The git baseline is blind here: that stamp commit's own copy of `.gitleaks.toml` already carries the edit (T30 asserts exactly that as a setup precondition).

## Evidence

- `templates/luna-second-brain/scripts/test-upgrade.sh` — **127 pass** (was 91), "All upgrade tests passed." (The `f247e27d` commit body says 128; the true count is 127.)
- Impacted suites, all green: `test-upgrade-pyresolve.sh`, `test-salus-upgrade.sh`, `scripts/hooks/test-template-version.sh`, `scripts/test-luna-upgrade-all.sh`, `scripts/himmelctl/test/test-wizard-status-upgrade.sh`.
- `shellcheck -x` clean on `upgrade.sh` and the suite.
- **Not run:** `scripts/test-luna-upgrade-vm.sh` — it needs a provisioned VM over ssh. It runs the same `test-upgrade.sh` cases on the VM, and those are green locally.
- **`upgrade.ps1` / `test-upgrade.ps1` untouched, and no pwsh run here** (pre-rebutting the `ps1-twin-parity` known-findings class). Neither is a logic twin. `upgrade.ps1` is a 72-line launcher that locates Git Bash and `exec`s `upgrade.sh` with the same arguments — there is no detection logic in it to mirror, and nothing here alters its argument handling. `test-upgrade.ps1` says so in its own header: it proves only that the launcher wires through, and defers all per-file behaviour to `test-upgrade.sh`, which is where every case in this PR lives.

Template bumped **0.4.22 → 0.4.25** (`.vault-template.json`, `marketplace.json`, `CHANGELOG.md`). The PR ships ONE new version: each CR round folded into the same unreleased entry (0.4.23 → 0.4.24 → 0.4.25) rather than releasing three.

## CR rounds (3, then stopped)

The critic panel (codex) ran three rounds. Every finding was verified against the code before disposition; all five are terminal in the ledger.

| Round | Finding | Disposition |
|---|---|---|
| 1 | HEAD gate collapsed every non-zero `rev-parse --verify` into "no commits yet", so a refs-layer error failed OPEN | **fixed** (`c84df7dd`) — gate branches on the exact rc; the withheld line names which git step failed. T33 |
| 1 | a failed snapshot `mktemp` let the run rewrite the stamp WITHOUT the map, stripping an existing baseline | **fixed** (`c84df7dd`) — aborts rc 2 before the first write. T34 |
| 2 | the same class either side of the scratch file: an unchecked `printf >>` (partial map) and `except OSError: files = {}` (absent map) | **fixed** (`f247e27d`) — append failures join the partial-upgrade guard; an unreadable scratch file exits 3. T35/T36 |
| 3 | snapshot LOADING treats read/JSON errors and a malformed `files` value as an absent baseline; `record_snapshot` accepts an empty digest from a failed `sha_of` | **deferred → HIMMEL-2918** |

Round 3 is the stop-and-defer trigger: three consecutive rounds on ONE code path, each fix surfacing a narrower instance of the same "this step degrades silently instead of failing closed" class rather than a defect in the shipped fix. Both round-3 findings are real, both need a tool or filesystem failure mid-run, and neither regresses behaviour that existed before this ticket — they are gaps in how completely the fail-closed posture was applied. HIMMEL-2918 carries them with the fix shape for each.

**One control was thrown away for being vacuous, not kept.** The first attempt at the round-2 case used a blanket read-only `TMPDIR`, which also broke `write_file`'s `cp` and the `_CLAUDE.md` 3-way — so the run failed for an unrelated reason and the case passed on the *pre-fix* engine too. The shipped T35/T36 isolate the snapshot path with a PATH stub `mktemp` that recognises the snapshot's own template (`luna-upgrade-snapshot.XXXXXX`, named for exactly this reason) and returns a hostile mode, passing every other mktemp call through. Both assert that precondition explicitly. Against the pre-fix engine they go RED with the predicted value: the vault's snapshot drops from **8 keys to 0** while the run exits **0**.

## Operator note

The live luna vault converges on the operator's own `/luna-upgrade` apply (decision (d) on the board) — nothing here touches it, and no run in this PR pointed at `~/Documents/luna`. On that apply the vault's stamp gains its `files` map, and from the run after that the poisoned-baseline case is closed for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zgRycxVnVmWP2RSYK2AP2
