### PR TITLE
docs(playbook,console): [HIMMEL-2898] stuck-playbook names the two classifier denies claudex legs hit; running-a-console carries the inbox-only channel and the idle-leg Monitor rule

### DIFF
--- a/docs/handover/running-a-console.md
+++ b/docs/handover/running-a-console.md
@@ -86,6 +86,27 @@ explicit model**: an unnamed one draws on the scarcer parent quota. Tier and
 effort guidance, including the console's own wake-up budget, is in
 [`../internals/lane-calibration.md`](../internals/lane-calibration.md).
 
+## Claudex legs: the inbox is the only channel
+
+A `--lane claudex` leg (`headed-arm-leg.sh`, HIMMEL-2782) runs under
+`~/.claude-codex`, which keeps it out of the session registry `ListAgents`
+reads on both ends — `SendMessage` reaches it in neither direction, even
+though its socket is alive. The only channel either way is the file inbox
+(`inbox-send.sh`, HIMMEL-2788): console → leg is `inbox-send.sh <leg-session>
+--file <path>`, delivered as `PostToolUse`/`SessionStart` additionalContext on
+the leg's next tool call; leg → console is the same script addressed to the
+console's own session name. `AskUserQuestion` reaches nobody on a claudex leg
+while the operator is away — every claudex brief must say so and give the leg
+the console's exact session name (HIMMEL-2898 item 1).
+
+Inbox delivery is **tool-call-gated**, so a leg that ends its turn on
+`BLOCKED` or a question goes idle and never sees the answer on its own.
+Standing rule (console 03H, 2026-09-10 01:18): every claudex leg arms a
+persistent `Monitor` on `tail -n 0 -F <handover-root>/inbox/<session>.md` at
+LIVE, before anything else — carry that line verbatim in the claudex brief
+preface. A structural fix (registry entry, or an idle-wake path) is still
+open on HIMMEL-2898 items 1 and 2.
+
 ## Rulings
 
 A leg that hits something it cannot decide reports to the console, not to the

--- a/docs/internals/stuck-playbook.md
+++ b/docs/internals/stuck-playbook.md
@@ -264,6 +264,42 @@ the re-run.
 
 ---
 
+## Symptom: a new test suite's one-line invocation is refused as a recursive-delete deny (HIMMEL-2898)
+
+A one-line `bash <suite> … | grep … | tail` can get refused by the
+destructive-command classifier even though the line names no delete flag of
+its own: many suites' standard cleanup trap (`rm -rf "$TMPDIR"` or similar)
+lives in the suite's own source, and the classifier reads that trap text when
+the suite is unfamiliar and the invocation is compound (piped/redirected).
+Confirmed once (HIMMEL-2898 item 4, N125's `test-finding-reraise.sh`); the
+same suite ran clean when invoked through `quiet-run.sh`.
+
+**What to do:** run every suite — new or old — only through `bash
+scripts/quiet-run.sh <name> -- bash <suite>` as **one literal command**, never
+a hand-rolled compound. This is already the sanctioned shape in every leg
+brief.
+
+---
+
+## Symptom: a message or log bullet quoting a guarded flag is refused by `block-destructive-commands`
+
+`inbox-send.sh <session> '<text>'` and a `printf`-built log bullet are Bash
+commands like any other, so `block-destructive-commands` inspects the **whole
+command string**, including a quoted TEXT argument — not just the binary
+being invoked. Quoting a guarded flag (e.g. naming the force-push flag, or
+echoing a suite's `rm -rf` cleanup line) gets refused even though the flag
+never runs. Confirmed twice (HIMMEL-2898 item 5): a leg's `inbox-send.sh`
+call and a console's `printf` log bullet, both denied for quoting text only.
+
+**What to do:** write the text with the **Write tool** first, then pass it by
+path — `inbox-send.sh <session> --file <path>` for a message, `cat >>` from a
+Write-tool file for a doc/log bullet — never inline a guarded spelling into a
+Bash argv. Treat `--file` as the **default** for any `inbox-send.sh` message
+longer than one line or quoting any command, not a fallback for when the bare
+form fails.
+
+---
+
 ## Why this is a playbook, not a `CLAUDE.md` rule
 
 Root `CLAUDE.md` is **state, not a prompt** — frame-shaping invariants only, paid


### PR DESCRIPTION
## Summary

Docs-only follow-up to HIMMEL-2898's six harness-seam findings from the first three claudex legs. Takes only the documentation-shaped items — 1 (its doc half), 2, 4, 5. Items 3 (allow-rule for the write-verdicts shape), 6 (bank-preflight FLEET under-read) and 7 (path seam — pending operator decision) stay open on the ticket.

- **Item 4** — `docs/internals/stuck-playbook.md`: new entry for the recursive-delete deny a new test suite's compound Bash line trips (the classifier reads the suite's own cleanup trap); recovery = `quiet-run.sh` as one literal command.
- **Item 5** — `docs/internals/stuck-playbook.md`: new entry for `block-destructive-commands` refusing a message/log bullet that merely *quotes* a guarded flag; recovery = write the text with the Write tool and pass it by path (`inbox-send.sh --file`), documented as the default for any multi-line or command-quoting message.
- **Item 1 (doc half)** — `docs/handover/running-a-console.md`: new "Claudex legs: the inbox is the only channel" section — claudex sessions are invisible to `ListAgents` both ways, so the file inbox (`inbox-send.sh`) is the only channel in either direction; `AskUserQuestion` reaches nobody on an unattended claudex leg.
- **Item 2** — same section: inbox delivery is tool-call-gated, so an idle leg on `BLOCKED` or a question never sees the answer; standing rule is every claudex leg arms a persistent `Monitor` on its inbox file at LIVE.

## Evidence

- `pre-commit run --files docs/internals/stuck-playbook.md docs/handover/running-a-console.md` — clean (via `quiet-run.sh`).
- `git diff --stat` — only the two docs files changed, 57 insertions, 0 deletions.
- No docs-freshness or markdownlint gate exists in this repo (checked `.pre-commit-config.yaml`); pre-commit above is the full applicable gate.
- Docs-only diff: neither the `Security reviewed` gate (skips `.md`/`docs/**`) nor the `Platforms tested` gate (only fires on `scripts/**`/shell) applies — confirmed by reading both gate scripts.
- `/pr-check` docs-audit lane: cross-model panel (codex) responded clean (0/0/0), Claude self-review clean, marker cleared.

## Still open on HIMMEL-2898

Items 3, 6, 7 — not in scope for this docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JE6zwsQdkm221uPQKdMgk1