### PR TITLE
fix(template): [HIMMEL-2918] luna-upgrade snapshot loading and digest capture fail closed — an unreadable snapshot withholds, an empty digest refuses the stamp

### DIFF
--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/CHANGELOG.md
+++ b/templates/luna-second-brain/CHANGELOG.md
@@ -8,7 +8,7 @@ Version history for the luna-second-brain vault template (published as
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [0.4.26] — 2026-09-10
+## [0.4.27] — 2026-09-10
 
 ### Fixed
 - **The HIMMEL-2903 snapshot now fails closed on load, and on a failed digest
@@ -23,7 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   successfully and then dropped without warning by the stamp writer,
   producing an incomplete map under a clean exit code. It now validates the
   digest and counts the failure, so the partial-upgrade guard refuses the
-  stamp.
+  stamp. The loader also tests `files` key *presence* before reading its
+  value, so an explicit `"files": null` is rejected as unusable rather than
+  conflated with the legitimate "no `files` key at all" legacy case.
 
 ## [0.4.25] — 2026-09-10
 

--- a/templates/luna-second-brain/CHANGELOG.md
+++ b/templates/luna-second-brain/CHANGELOG.md
@@ -8,6 +8,23 @@ Version history for the luna-second-brain vault template (published as
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.4.26] — 2026-09-10
+
+### Fixed
+- **The HIMMEL-2903 snapshot now fails closed on load, and on a failed digest
+  capture, too (HIMMEL-2918).** Two gaps left from that ticket's round-3 CR
+  findings: (1) the stamp's `files` map reader treated a JSON/read error, a
+  non-dict top level, and a `files` value that wasn't a dict all the same as
+  the one legitimate empty case — a legacy stamp with no `files` key at all —
+  silently reverting every file to the poisonable git fallback. It now
+  withholds instead, the same way a failing `git log` already does. (2)
+  `record_snapshot` checked the digest only against the literal `MISSING`; a
+  failing `sha256sum` still leaves an empty string, which was appended
+  successfully and then dropped without warning by the stamp writer,
+  producing an incomplete map under a clean exit code. It now validates the
+  digest and counts the failure, so the partial-upgrade guard refuses the
+  stamp.
+
 ## [0.4.25] — 2026-09-10
 
 ### Fixed

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.26"
+    "version": "0.4.27"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.25"
+    "version": "0.4.26"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/scripts/test-upgrade.sh
+++ b/templates/luna-second-brain/scripts/test-upgrade.sh
@@ -864,5 +864,146 @@ t36_out=$(PATH="$t36_stub:$PATH" bash "$UPGRADE" --template-dir "$T" --vault-dir
 assert_eq "T36 an unreadable snapshot leaves the stamp byte-identical" "$t36_stamp_before" "$(sha_of "$V/.vault-template.json")"
 assert_eq "T36 the existing snapshot survives intact" "$t36_keys_before" "$(snap_keys "$V/.vault-template.json")"
 if [ "$t36_rc" -ne 0 ]; then pass "T36 exits non-zero rather than stamping"; else fail "T36 exits non-zero rather than stamping" "rc=0, out: $t36_out"; fi
+
+# ---------------------------------------------------------------------------
+# T37 (HIMMEL-2918, round-3 pair item 1): a stamp whose `files` value is
+# present but unusable (a string, not a dict) must fail CLOSED, not be read
+# as an empty map — which would silently revert to the git fallback, exactly
+# the scenario T30 exists to close. Same poisoning as T30 (the local edit and
+# the stamp advance land in ONE commit, so the git baseline the fallback would
+# read already carries the edit and cannot see it as a divergence): if the
+# malformed `files` value were misread as "nothing to withhold", the poisoned
+# git baseline would let the edit through.
+T="$TMP/t37-tmpl"; V="$TMP/t37-vault"
+make_template "$T" "0.9.0"
+printf 'gitleaks-content-v1\n' > "$T/.gitleaks.toml"
+mkdir -p "$V"; cp -r "$T/." "$V/"; rm -f "$V/marketplace/.claude-plugin/marketplace.json"
+stamp_vault "$V" "0.1.0"
+git -C "$V" init -q
+git -C "$V" config user.email "test@example.com"
+git -C "$V" config user.name "Test"
+git -C "$V" add -A
+git -C "$V" commit -q -m "initial"
+# Upgrade #1 brings the vault to 0.9.0 AND records the content snapshot.
+bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --yes >/dev/null 2>&1
+t37_snap_before=$("$PY" -c 'import json,sys; print(json.load(open(sys.argv[1])).get("files",{}).get(".gitleaks.toml",""))' "$V/.vault-template.json" 2>/dev/null)
+if [ -n "$t37_snap_before" ]; then pass "T37 setup: the vault carries a content snapshot to corrupt"; else fail "T37 setup: the vault carries a content snapshot to corrupt" "empty"; fi
+# The POISONING commit: the vault-local edit and the advanced stamp land in
+# ONE commit, so the commit the git path resolves as the baseline already
+# carries the edit.
+printf 'gitleaks-content-v1\nlocal-allowlist-line\n' > "$V/.gitleaks.toml"
+git -C "$V" add -A
+git -C "$V" commit -q -m "autosync: local allowlist line + stamp 0.9.0"
+t37_stamp_commit=$(git -C "$V" log -1 --format=%H -- .vault-template.json)
+git -C "$V" show "$t37_stamp_commit:./.gitleaks.toml" > "$TMP/t37-git-baseline" 2>/dev/null
+assert_eq "T37 setup: the git baseline is poisoned (it already carries the edit)" "$(sha_of "$V/.gitleaks.toml")" "$(sha_of "$TMP/t37-git-baseline")"
+# Corrupt the stamp's `files` value in place: present, but not a dict.
+"$PY" - "$V/.vault-template.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p, encoding="utf-8"))
+d["files"] = "not-a-dict"
+with open(p, "w", encoding="utf-8") as fh:
+    json.dump(d, fh)
+PY
+# A newer template that changes the same file.
+printf '{"metadata":{"version":"1.0.0"}}\n' > "$T/marketplace/.claude-plugin/marketplace.json"
+printf 'gitleaks-content-v2\n' > "$T/.gitleaks.toml"
+t37_pre_sha=$(sha_of "$V/.gitleaks.toml")
+t37_out=$(bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --yes 2>&1); t37_rc=$?
+assert_eq "T37 a malformed files map withholds the write (fails closed)" "$t37_pre_sha" "$(sha_of "$V/.gitleaks.toml")"
+case "$t37_out" in
+    *"could not determine the upgrade baseline (snapshot unreadable) — withholding .gitleaks.toml as a precaution"*)
+        pass "T37 names the unreadable snapshot in the withheld line" ;;
+    *) fail "T37 names the unreadable snapshot in the withheld line" "got: $t37_out" ;;
+esac
+if [ "$t37_rc" -ne 0 ]; then pass "T37 apply exits non-zero (not a clean upgrade)"; else fail "T37 apply exits non-zero (not a clean upgrade)" "rc=0"; fi
+
+# ---------------------------------------------------------------------------
+# T37b (HIMMEL-2918): the one LEGITIMATE empty map — a legacy stamp with no
+# `files` key at all (predates the snapshot) — must still fall back to the
+# git baseline exactly as before this ticket. T37 above proves the failure
+# cases now withhold; this proves the fix didn't also break the one case that
+# is supposed to fall through.
+T="$TMP/t37b-tmpl"; V="$TMP/t37b-vault"
+make_template "$T" "0.9.0"
+printf 'gitleaks-content-v1\n' > "$T/.gitleaks.toml"
+mkdir -p "$V"; cp -r "$T/." "$V/"; rm -f "$V/marketplace/.claude-plugin/marketplace.json"
+stamp_vault "$V" "0.9.0"
+git -C "$V" init -q
+git -C "$V" config user.email "test@example.com"
+git -C "$V" config user.name "Test"
+git -C "$V" add -A
+git -C "$V" commit -q -m "initial stamp 0.9.0"
+printf 'gitleaks-content-v1\nlocal-allowlist-line\n' > "$V/.gitleaks.toml"
+git -C "$V" add -A
+git -C "$V" commit -q -m "local edit after the stamp"
+printf '{"metadata":{"version":"1.0.0"}}\n' > "$T/marketplace/.claude-plugin/marketplace.json"
+printf 'gitleaks-content-v2\n' > "$T/.gitleaks.toml"
+t37b_dry=$(bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --dry-run 2>&1)
+case "$t37b_dry" in
+    *"local edits withheld (not overwritten): .gitleaks.toml"*"[baseline: git]"*)
+        pass "T37b a legacy stamp (no files key) still falls back to the git baseline" ;;
+    *) fail "T37b a legacy stamp (no files key) still falls back to the git baseline" "got: $t37b_dry" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# T38 (HIMMEL-2918, round-3 pair item 2): record_snapshot must fail CLOSED on
+# an empty digest, not just on the literal "MISSING". A sha256sum failure mid-
+# run still leaves `cut` exiting 0 on no input, so sha_of returns "" — the
+# row for that file would be appended anyway and silently dropped later by
+# the stamp writer's `if tab and rel and sha`, leaving an incomplete map under
+# a clean rc.
+#
+# A stub that fails EVERY sha256sum call against the target file is too
+# blunt: sha_of(dst) is also called earlier, by the plan/execute diff check
+# and by has_local_edit's snapshot-baseline comparison — breaking those turns
+# an empty digest into a false LOCAL-EDIT withhold, which also exits non-zero
+# and would make this case pass for the wrong reason (the vacuous-control
+# trap HIMMEL-2903 was already caught in once). A normal run calls sha256sum
+# on the target file exactly 5 times — the diff check + the snapshot compare,
+# once each in the plan pass and again in the execute pass, then record_snapshot's
+# own capture last — so the stub only fails the 5th call, passing the first 4
+# through to the real sha256sum.
+T="$TMP/t38-tmpl"; V="$TMP/t38-vault"
+t35_fixture "$T" "$V"
+t38_keys_before=$(snap_keys "$V/.vault-template.json")
+if [ "${t38_keys_before:-0}" -gt 0 ]; then pass "T38 setup: the vault carries a complete content snapshot"; else fail "T38 setup: the vault carries a complete content snapshot" "keys=$t38_keys_before"; fi
+t38_stamp_before=$(sha_of "$V/.vault-template.json")
+t38_target="$V/.gitleaks.toml"
+t38_stub="$TMP/t38-stub"; mkdir -p "$t38_stub"
+t38_real_sha256sum="$(command -v sha256sum)"
+t38_count_file="$TMP/t38-count"; : > "$t38_count_file"
+# shellcheck disable=SC2016  # the single-quoted lines are the STUB's source, not this shell's
+{
+    echo '#!/usr/bin/env bash'
+    printf 'target=%s\n' "$t38_target"
+    printf 'countfile=%s\n' "$t38_count_file"
+    echo 'match=0'
+    echo 'for a in "$@"; do [ "$a" = "$target" ] && match=1; done'
+    echo 'if [ "$match" = 1 ]; then'
+    printf '%s\n' '    printf "x\n" >> "$countfile"'
+    echo '    n=$(wc -l < "$countfile")'
+    echo '    if [ "$n" -ge 5 ]; then echo "sha256sum: simulated read failure" >&2; exit 1; fi'
+    echo 'fi'
+    printf 'exec "%s" "$@"\n' "$t38_real_sha256sum"
+} > "$t38_stub/sha256sum"
+chmod +x "$t38_stub/sha256sum"
+# Precondition: the stub really does pass a NON-target file through untouched
+# (or the case proves nothing).
+t38_other=$(PATH="$t38_stub:$PATH" sha256sum "$T/.gitleaks.toml" 2>/dev/null | cut -d' ' -f1)
+if [ -n "$t38_other" ]; then pass "T38 setup: the stub passes other files through"; else fail "T38 setup: the stub passes other files through" "empty"; fi
+t38_out=$(PATH="$t38_stub:$PATH" bash "$UPGRADE" --template-dir "$T" --vault-dir "$V" --yes 2>&1); t38_rc=$?
+t38_calls=$(wc -l < "$t38_count_file")
+assert_eq "T38 setup: the target file's sha256sum was called exactly 5 times, and the 5th failed" "5" "$t38_calls"
+assert_eq "T38 the pre-existing stamp is left byte-identical" "$t38_stamp_before" "$(sha_of "$V/.vault-template.json")"
+assert_eq "T38 the pre-existing snapshot map is untouched" "$t38_keys_before" "$(snap_keys "$V/.vault-template.json")"
+if [ "$t38_rc" -ne 0 ]; then pass "T38 exits non-zero rather than stamping an incomplete snapshot"; else fail "T38 exits non-zero rather than stamping an incomplete snapshot" "rc=0, out: $t38_out"; fi
+case "$t38_out" in
+    *"could not record the content snapshot for .gitleaks.toml"*)
+        pass "T38 warns about the unrecordable digest" ;;
+    *) fail "T38 warns about the unrecordable digest" "got: $t38_out" ;;
+esac
+
 echo
 if [ "$FAILED" -eq 0 ]; then echo "All upgrade tests passed."; else echo "$FAILED test(s) failed."; exit 1; fi

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -237,11 +237,11 @@ except Exception:
     sys.exit(1)
 if not isinstance(d, dict):
     sys.exit(1)
-files = d.get("files")
-if files is None:
+if "files" not in d:
     sys.exit(0)  # legacy stamp, no `files` key at all — fall back to git.
+files = d.get("files")
 if not isinstance(files, dict):
-    sys.exit(1)
+    sys.exit(1)  # present but unusable (e.g. explicit `"files": null`) — an error, not legacy.
 for rel in sorted(files):
     sha = files[rel]
     # A rel with a tab/newline in it would corrupt the row format; such a path

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -214,19 +214,34 @@ fi
 # no associative arrays). A stamp without a `files` map (any vault last
 # upgraded before this version) yields an empty map and the git baseline
 # carries, exactly as before; the first upgrade under this version writes one.
+# BASELINE_ERROR / BASELINE_ERROR_REASON are also set by the git-log checks
+# below (HIMMEL-2886/2903); initialized here so a snapshot-load failure isn't
+# clobbered back to 0 by that later block.
+BASELINE_ERROR=0
+BASELINE_ERROR_REASON=""
 SNAPSHOT_MAP=""
 if [ -f "$STAMP" ]; then
-    SNAPSHOT_MAP="$("$PYTHON" - "$STAMP" 2>/dev/null <<'PY'
+    # HIMMEL-2918: the python heredoc's rc distinguishes the one legitimate
+    # empty map (no `files` key at all — a legacy stamp, rc 0) from an
+    # unreadable/malformed one (rc != 0: a JSON/read error, a non-dict top
+    # level, or a `files` value that isn't a dict). Collapsing those was
+    # fail-OPEN: an empty SNAPSHOT_MAP is indistinguishable from "nothing to
+    # withhold", reverting every file to the poisonable git fallback
+    # HIMMEL-2903 exists to replace. Fail CLOSED instead, the same way a
+    # failing `git log` already does below.
+    if ! SNAPSHOT_MAP="$("$PYTHON" - "$STAMP" 2>/dev/null <<'PY'
 import json, sys
 try:
     d = json.load(open(sys.argv[1], encoding="utf-8"))
 except Exception:
-    sys.exit(0)
+    sys.exit(1)
 if not isinstance(d, dict):
-    sys.exit(0)
+    sys.exit(1)
 files = d.get("files")
+if files is None:
+    sys.exit(0)  # legacy stamp, no `files` key at all — fall back to git.
 if not isinstance(files, dict):
-    sys.exit(0)
+    sys.exit(1)
 for rel in sorted(files):
     sha = files[rel]
     # A rel with a tab/newline in it would corrupt the row format; such a path
@@ -234,7 +249,11 @@ for rel in sorted(files):
     if isinstance(sha, str) and isinstance(rel, str) and not (set("\t\n\r") & set(rel)):
         print("%s\t%s" % (rel, sha))
 PY
-)"
+)"; then
+        SNAPSHOT_MAP=""
+        BASELINE_ERROR=1
+        BASELINE_ERROR_REASON="snapshot unreadable"
+    fi
 fi
 
 # snapshot_sha <rel>: echo the recorded "sha256:<hex>" for <rel>, or nothing.
@@ -309,8 +328,8 @@ STAMP_COMMIT=""
 # means "no baseline" means the pre-HIMMEL-2886 silent overwrite, which is the
 # exact failure this detection exists to close. has_local_edit fails CLOSED on
 # a cat-file/show error already; this makes the `git log` step consistent.
-BASELINE_ERROR=0
-BASELINE_ERROR_REASON=""
+# (Initialized above, before the snapshot-load block, so a snapshot failure
+# there isn't clobbered back to 0 here — HIMMEL-2918.)
 # `git rev-parse --is-inside-work-tree`, not `[ -d "$VAULT_DIR/.git" ]`: a
 # worktree or a submodule has a `.git` FILE (a `gitdir: <path>` pointer), not
 # a directory, so the directory-only check silently fell back to the
@@ -510,6 +529,20 @@ record_snapshot() {
     [ -n "$SNAPSHOT_FILE" ] || return 0
     s="$(sha_of "$dst")"
     [ "$s" = "MISSING" ] && return 0
+    # HIMMEL-2918: a failing sha256sum still leaves `cut` exiting 0 on no
+    # input, so `s` can come back "" here — checked only against MISSING
+    # above, an empty (or otherwise malformed) digest slipped past silently
+    # and produced an incomplete <rel><TAB> row that the stamp writer's
+    # `if tab and rel and sha` later drops without warning. Reject anything
+    # that isn't a 64-char lowercase hex digest before it is ever written.
+    case "$s" in
+        *[!0-9a-f]*|"") s="" ;;
+    esac
+    if [ -z "$s" ] || [ "${#s}" -ne 64 ]; then
+        SNAPSHOT_FAILURES=$((SNAPSHOT_FAILURES+1))
+        echo "  WARN: could not record the content snapshot for $rel (invalid digest)" >&2
+        return 0
+    fi
     # A dropped row is not cosmetic: the stamp is rewritten wholesale, so a
     # file whose row never lands loses its snapshot entry and silently reverts
     # to the poisonable git baseline. Count the failure and let the stamp guard


### PR DESCRIPTION
## Summary

Round-3 deferred pair from HIMMEL-2903 (#620, three consecutive CR rounds on one code path = stop and defer). Both are narrow — each needs a tool/filesystem failure mid-run — and neither regresses pre-2903 behaviour; they are gaps in how completely that ticket's fail-closed posture was applied.

**(1) Snapshot LOADING degraded silently.** The `SNAPSHOT_MAP` python heredoc exited 0 with an *empty* map on three distinct conditions it couldn't tell apart: a JSON/read error, a non-dict top level, and a `files` value present but not a dict. Only "no `files` key at all" (a legacy stamp) is the legitimate empty case. The other three silently reverted the vault to the poisonable git fallback — exactly what HIMMEL-2903 exists to replace.

**(2) `record_snapshot` accepted an empty digest.** `s="$(sha_of "$dst")"` was checked only against the literal `MISSING`. If `sha256sum` itself failed, `cut` still exits 0 on no input, so the row `<rel><TAB>` was appended *successfully* (`SNAPSHOT_FAILURES` stayed 0) and the stamp writer's `if tab and rel and sha` silently dropped it — an incomplete map under a clean rc.

## What changed

- The snapshot loader now uses the python heredoc's own exit code: `0` with no `files` key = legacy stamp, fall back to git as before; any other failure mode (JSON error, non-dict top level, non-dict `files`, including an explicit `"files": null"`) sets `BASELINE_ERROR="snapshot unreadable"` and withholds every file, reusing the exact same withhold message shape a failing `git log` already produces (**no new format invented** — `--check`/`--dry-run` output is unchanged in shape).
- `BASELINE_ERROR` / `BASELINE_ERROR_REASON` init moved above the snapshot-load block so a snapshot failure there isn't clobbered back to 0 by the later git-baseline block's own init.
- `record_snapshot` now validates the digest is non-empty and a 64-char lowercase hex string before appending; an invalid one increments `SNAPSHOT_FAILURES` (same treatment as a write failure), so the existing partial-upgrade guard refuses the stamp.

## RED → GREEN

- **T37**: a stamp whose `files` is a string (present, unusable) + a locally-edited file whose git baseline is poisoned (same setup as T30 — the edit and the stamp advance land in one commit). Pre-fix: the file is silently overwritten, rc 0. Post-fix: withheld with `could not determine the upgrade baseline (snapshot unreadable) — withholding .gitleaks.toml as a precaution`, rc non-zero.
- **T37b**: a stamp with no `files` key at all still falls back to git exactly as before — pins that the legacy path wasn't broken by the fix.
- **T38**: a PATH-stub `sha256sum` that fails only the file's *record_snapshot* call. A blanket per-file stub also breaks the earlier local-edit comparison and produces a false LOCAL-EDIT withhold (fails for the wrong reason) — isolated by invocation count instead (the target file's digest is computed 5 times in a normal run: the plan-pass diff check + local-edit compare, the same two again in the execute pass, then `record_snapshot`'s own capture last; only the 5th is failed). Pre-fix: run exits 0, the stamp's `files` map drops from 8 keys to 7. Post-fix: `SNAPSHOT_FAILURES` ≥ 1, the guard refuses the stamp, the pre-existing 8-key map is left byte-identical.

`templates/luna-second-brain/scripts/test-upgrade.sh`: **140 pass** (was 127), "All upgrade tests passed."

Impacted suites, all green: `test-upgrade-pyresolve.sh`, `test-salus-upgrade.sh`, `scripts/hooks/test-template-version.sh`, `scripts/test-luna-upgrade-all.sh`, `scripts/himmelctl/test/test-wizard-status-upgrade.sh`.

`shellcheck -x` clean on `upgrade.sh` and the suite.

**Not run**: `scripts/test-luna-upgrade-vm.sh` — needs a provisioned VM.

**`upgrade.ps1`** is untouched — a Git-Bash launcher that `exec`s `upgrade.sh`, not a logic twin; no pwsh run here.

Template bumped **0.4.25 → 0.4.27** (`.vault-template.json`, `marketplace.json`, `CHANGELOG.md`), folded into ONE unreleased CHANGELOG entry across the two commits per this repo's convention.

## CR round (codex, paid panel)

| Round | Finding | Disposition |
|---|---|---|
| 1 | `d.get("files")` conflates an absent `files` key with an explicit `"files": null` — both return `None`, so a malformed-but-present null value was misread as the legacy fallback case instead of failing closed | **fixed** (2nd commit) — key presence is now tested before reading the value |
| 2 | clean, 0/0/0 | — |

## Test plan

- [x] `bash scripts/quiet-run.sh <name> -- bash templates/luna-second-brain/scripts/test-upgrade.sh` — 140 pass
- [x] Impacted suite set (5) all green through quiet-run
- [x] `shellcheck -x` on `upgrade.sh` + `test-upgrade.sh`
- [x] RED verified against pre-fix code for T37/T37b/T38 before the fix landed
- [x] `/pr-check` clean (2 rounds, 1 finding fixed and promoted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbWnMiSeWaJa6hE9wtU4yJ