### PR TITLE
fix(cr): [HIMMEL-2917] review-round promote counts an unadjudicated finding row as still-open instead of skipping it silently

### DIFF
--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -755,7 +755,8 @@ Steps:
    per-finding one: STOP, report the exact stderr line, repair the cause, and
    re-run `promote` — never hand-amend anything as a workaround.
    A `still-open <id>@<sha> (unadjudicated)` line (HIMMEL-2917) means a
-   finding row nobody dispositioned at all — no `verdict`, no amend. A
+   finding row with no effective verdict after applying amendments — nobody
+   dispositioned it at all. A
    finding fixed within THIS round must be amended `fixed` at step 4.5,
    naming the fixing sha, never left with no verdict for `promote` to find
    later. The summary line is not evidence the ledger is clean until every

--- a/.claude/commands/pr-check.md
+++ b/.claude/commands/pr-check.md
@@ -754,6 +754,12 @@ Steps:
    ledger write failure) is an infrastructure failure, not a
    per-finding one: STOP, report the exact stderr line, repair the cause, and
    re-run `promote` — never hand-amend anything as a workaround.
+   A `still-open <id>@<sha> (unadjudicated)` line (HIMMEL-2917) means a
+   finding row nobody dispositioned at all — no `verdict`, no amend. A
+   finding fixed within THIS round must be amended `fixed` at step 4.5,
+   naming the fixing sha, never left with no verdict for `promote` to find
+   later. The summary line is not evidence the ledger is clean until every
+   row prints as `promoted` or `skip-terminal`.
 
 6. If either `N > 0`, or step 4.8 reported `threads_rc != 0`:
    - Leave the marker in place.

--- a/scripts/cr/review-round.sh
+++ b/scripts/cr/review-round.sh
@@ -153,10 +153,11 @@ fi
 # tagged `(unadjudicated)`: nobody looked, so the round cannot be certified
 # clean over it either — never counted as WARN (that means a human already
 # disagreed) and never silently skipped (HIMMEL-2917).
-# Exit 0 = nothing left agreed; exit 3 = one or more rows are still-open (the
-# caller's round was not actually clean for that finding); exit 1 = a
-# malformed ledger row or a ledger write failure; exit 2 = --head does not
-# resolve to a commit; exit 5 = the CR ledger file itself is missing.
+# Exit 0 = no still-open findings; exit 3 = one or more rows are still-open
+# (the caller's round was not actually clean for that finding, whether it was
+# left agreed or never adjudicated at all); exit 1 = a malformed ledger row
+# or a ledger write failure; exit 2 = --head does not resolve to a commit;
+# exit 5 = the CR ledger file itself is missing.
 if [ "$verb" = "promote" ]; then
     if ! full_head="$(git rev-parse --verify --quiet "$head_sha^{commit}" 2>/dev/null)" || [ -z "$full_head" ]; then
         echo "review-round: --head $head_sha does not resolve to a commit" >&2

--- a/scripts/cr/review-round.sh
+++ b/scripts/cr/review-round.sh
@@ -149,6 +149,10 @@ fi
 # left agreed (counted as still-open) rather than guessed at. Idempotent: a
 # second run sees the fixed amend via the same effective-state merge and
 # skip-terminals it, writing nothing.
+# A row whose effective verdict is EMPTY (no amend at all) is also still-open,
+# tagged `(unadjudicated)`: nobody looked, so the round cannot be certified
+# clean over it either — never counted as WARN (that means a human already
+# disagreed) and never silently skipped (HIMMEL-2917).
 # Exit 0 = nothing left agreed; exit 3 = one or more rows are still-open (the
 # caller's round was not actually clean for that finding); exit 1 = a
 # malformed ledger row or a ledger write failure; exit 2 = --head does not
@@ -252,6 +256,7 @@ for (const row of findingRows) {
   let action;
   if (verdict === "fixed" || verdict === "disproved" || verdict === "deferred") action = "skip-terminal";
   else if (verdict === "conflict" || verdict === "unaddressed") action = "warn-unadjudicated";
+  else if (verdict === "") action = "still-open-unadjudicated";
   else if (verdict !== "agreed") continue;
   else if (resolvesToHead(row.head)) {
     // codex-1, HIMMEL-2911 CR round 1: a finding raised (and agreed) AT the
@@ -323,6 +328,10 @@ process.stdout.write(JSON.stringify({malformed: 0}));
                 ;;
             still-open)
                 echo "still-open ${id}@${row_head8}"
+                still_open=$((still_open + 1))
+                ;;
+            still-open-unadjudicated)
+                echo "still-open ${id}@${row_head8} (unadjudicated)"
                 still_open=$((still_open + 1))
                 ;;
             skip-terminal)

--- a/scripts/cr/test-pr-check-rounds.sh
+++ b/scripts/cr/test-pr-check-rounds.sh
@@ -437,6 +437,14 @@ CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" amend \
     --branch promote --head "$promote_head_b" --id find-g2 \
     --set verdict=disproved --reason "not reproducible at this head"
 
+# (m) no amend at all, no verdict on the finding row (the exact #617 shape:
+# HIMMEL-2917) -> still-open, tagged unadjudicated: nobody dispositioned it,
+# so the round is not certified clean over it either.
+CR_LEDGER="$promote_ledger" bash "$fx/scripts/cr/ledger-append.sh" finding \
+    --branch promote --head "$promote_head_a" --model stub --id find-m \
+    --severity sug --file promote.txt --line 9 --verdict "" \
+    --text "tidy up the promote fixture mu"
+
 promote_out1="$(cd "$repo" && bash "$fx/scripts/cr/review-round.sh" promote --branch promote --head "$promote_head_b")"; promote_rc1=$?
 assert_eq "$promote_rc1" "3" "promote exits 3 while a re-raised finding is still open"
 assert_has "$promote_out1" "promoted find-a@" "promote (a) not-re-raised agreed finding is promoted"
@@ -447,6 +455,7 @@ assert_has "$promote_out1" "still-open find-f@" "promote (f) same-head agreed fi
 assert_has "$promote_out1" "promoted find-g@" "promote (g) an earlier agreed finding promotes when its head-H reappearance is already disproved"
 assert_has "$promote_out1" "still-open find-h@" "promote (h) a deferred head-H reappearance keeps the earlier agreed finding still-open"
 assert_has "$promote_out1" "still-open find-i@" "promote (i) a finding on a non-ancestor commit is never promoted"
+assert_has "$promote_out1" "$(printf 'still-open find-m@%s (unadjudicated)' "$(printf '%s' "$promote_head_a" | cut -c1-8)")" "promote (m) an unadjudicated finding (no verdict, no amend) is still-open, tagged (unadjudicated), not silently skipped"
 promote_ledger_content="$(cat "$promote_ledger" 2>/dev/null)"
 assert_has "$promote_ledger_content" '"finding_id":"find-a"' "promoted amend targets find-a"
 assert_has "$promote_ledger_content" '"verdict":"fixed"' "promote writes a fixed verdict"
@@ -462,6 +471,9 @@ assert_lacks "$promote_out2" "promoted find-a@" "second promote run does not re-
 assert_has "$promote_out2" "skip-terminal find-a@" "second promote run reports find-a as already terminal"
 find_a_amends_2="$(LEDGER="$promote_ledger" node -e 'const fs=require("fs"),e=process.env;let n=0;for(const l of fs.readFileSync(e.LEDGER,"utf8").trim().split("\n")){const o=JSON.parse(l);if(o.kind==="amend"&&o.finding_id==="find-a"&&o.set&&o.set.verdict==="fixed")n++}process.stdout.write(String(n))')"
 assert_eq "$find_a_amends_2" "1" "second promote run writes zero new amends for find-a"
+assert_has "$promote_out2" "still-open find-m@" "second promote run still reports find-m as unadjudicated"
+find_m_amends="$(LEDGER="$promote_ledger" node -e 'const fs=require("fs"),e=process.env;let n=0;for(const l of fs.readFileSync(e.LEDGER,"utf8").trim().split("\n")){const o=JSON.parse(l);if(o.kind==="amend"&&o.finding_id==="find-m")n++}process.stdout.write(String(n))')"
+assert_eq "$find_m_amends" "0" "an unadjudicated (empty-verdict) row is never written to"
 
 # CR_LEDGER pin (codex-1, HIMMEL-2911 CR round 4): an ambient CR_LEDGER in the
 # caller's environment must not redirect the amend write to a different file


### PR DESCRIPTION
## Summary
`review-round.sh promote` (landed in #617 at 89be61d4) classifies every `finding` row on `--branch` by its effective verdict: terminal → `skip-terminal`, `conflict`/`unaddressed` → WARN, `agreed` → promote / still-open. A row whose effective verdict is EMPTY — no amend at all, no `verdict` on the row — fell through silently: neither counted nor printed. On #617 itself eight such rows existed, the dry-check printed all zeros, and the console had to name eight `fixed` amends by hand before GO.

Fix: an empty effective verdict is now classified `still-open-unadjudicated`, printed as `still-open <id>@<sha> (unadjudicated)`, and counted toward `still_open` — the summary line can never read all-zero while un-dispositioned rows exist on the branch.

## RED/GREEN proof
RED (fixture (m) present, fix reverted): `ERR quiet-run rounds-red exit=1`, exactly 2 FAIL:
- `FAIL - promote (m) an unadjudicated finding (no verdict, no amend) is still-open, tagged (unadjudicated), not silently skipped (missing 'still-open find-m@d9a88086 (unadjudicated)'; got: promoted find-a@d9a88086`
- `FAIL - second promote run still reports find-m as unadjudicated (missing 'still-open find-m@'; got: skip-terminal find-a@d9a88086 (verdict=fixed)`

GREEN (fix reapplied): `OK quiet-run rounds-green (11s)`.

## Impacted suites
- `scripts/cr/test-pr-check-rounds.sh` — OK (already green above)
- `scripts/cr/test-finding-reraise.sh` — OK
- `scripts/cr/test-panel-first-pass.sh` — OK
- `shellcheck scripts/cr/review-round.sh` — clean
- `scripts/handover/test-arm-resume.sh` — 40 FAIL, host-environmental (this Linux host has no working Windows scheduler shim: rc=2-shaped failures cascade from the arm mechanism itself through the schtasks/crontab/.bat-dependent cases). First three: `W5 non-dry worktree arm exits 0 — expected rc=0, got rc=2`; `W8 reuse existing worktree exits 0 (cmd not called) — expected rc=0, got rc=2`; `1330 explicit --cwd bypasses the vault guard — expected rc=0, got rc=3`. This suite references `review-round` only incidentally and is green on CI for main at 008f9a49 — not chased locally; CI carries it.

## known-findings self-review
`known-findings.sh --diff` flagged a `test-coverage-gap` checklist hit for `scripts/cr/review-round.sh`: the detector's paired-suite-by-name heuristic looks for `test-review-round.sh`, which doesn't exist — the promote verb's actual test coverage lives in `scripts/cr/test-pr-check-rounds.sh`, which this diff does modify (fixture (m) + 2 new assertions, plus a 3rd covering the live dry-check shape). False positive, verified.

## `/pr-check` (critic panel, paid tier — codex)
Round 1 @5c680c65: 0 Critical, 0 Important, 2 Suggestions:
- `[codex-1]`: stale exit-0 contract comment ("nothing left agreed" → should read "no still-open findings" now that an empty-verdict row can drive exit 3 alone). **Real, trivial — fixed** in a follow-up commit (comment-only).
- `[codex-2]`: wants an isolated fixture where an empty-verdict row is the ONLY nonterminal row, to independently prove it alone drives exit 3. **Disproved** — the exit-3 decision (`review-round.sh:353`, `[ "$still_open" -eq 0 ] || exit 3`) is a single generic check on the aggregate counter, already exercised by the existing find-f/h/i assertions; the RED/GREEN control above already isolates the still-open-unadjudicated classification and counting themselves (fixture (m) fails RED on exactly those two assertions with the fix reverted). An isolated single-row fixture would add no new code-path coverage.

Round 2 @ec5b8e1a (after the codex-1 fix commit): 0/0/0 clean. `clear-cr-marker.sh` CLEARED, responders=1.

**Live dry-check proof (this ticket's own acceptance test):**
```
$ bash scripts/cr/review-round.sh promote --branch fix/himmel-2917-promote-empty-verdict --head ec5b8e1a
skip-terminal codex-1@5c680c65 (verdict=fixed)
skip-terminal codex-2@5c680c65 (verdict=disproved)
review-round promote: 0 promoted, 0 still-open, 2 skip-terminal, 0 warn (head ec5b8e1a)
```
Matching ledger rows:
```json
{"kind":"finding","branch":"fix/himmel-2917-promote-empty-verdict","head":"5c680c65c9369cbf0eb8754cf91cb0067161255c","model":"codex","finding_id":"codex-1","severity":"sug","file":"scripts/cr/review-round.sh","line":156,"verdict":""}
{"kind":"finding","branch":"fix/himmel-2917-promote-empty-verdict","head":"5c680c65c9369cbf0eb8754cf91cb0067161255c","model":"codex","finding_id":"codex-2","severity":"sug","file":"scripts/cr/test-pr-check-rounds.sh","line":455,"verdict":""}
{"kind":"amend","target_head":"5c680c65c9369cbf0eb8754cf91cb0067161255c","finding_id":"codex-1","set":{"verdict":"fixed"},"reason":"fixed at ec5b8e1a — comment corrected to no still-open findings"}
{"kind":"amend","target_head":"5c680c65c9369cbf0eb8754cf91cb0067161255c","finding_id":"codex-2","set":{"verdict":"disproved"},"reason":"disproved by /pr-check step 3.2 ..."}
```
Exactly the ticket's ask: the summary line never reads all-zero while rows exist — both findings print as `skip-terminal` because both carry a real terminal verdict, never left unadjudicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Y8tZCwzCwE3yYAu2sQWQv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Promotion now clearly identifies findings without a verdict or amendment as **unadjudicated**.
  - Unadjudicated findings remain open and prevent promotion from being marked complete.
  - Findings fixed during the current review round must be explicitly amended to **fixed** before promotion.
  - Repeated promotion attempts preserve the finding’s open status instead of silently ignoring it.

- **Documentation**
  - Clarified promotion requirements and the meaning of unadjudicated findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->