### PR TITLE
chore(upstreams): [HIMMEL-2924] bump graphify pin 0.9.57 -> 0.9.58 and cli-proxy-api pin 7.2.155 -> 7.2.158 (fork-drift sweep)

### DIFF
--- a/scripts/lib/graphify-bin.sh
+++ b/scripts/lib/graphify-bin.sh
@@ -50,7 +50,7 @@
 # (HIMMEL-891) -- without carrying a fork. A pin bump is a reviewed change to this
 # line, paired with `synced_base` in scripts/upstreams.json so the nightly
 # fork-drift guard stays truthful.
-_graphify_version() { printf '%s\n' "${GRAPHIFY_VERSION:-0.9.57}"; }
+_graphify_version() { printf '%s\n' "${GRAPHIFY_VERSION:-0.9.58}"; }
 _graphify_pypi_name() { printf '%s\n' "graphifyy"; }
 # The default `uv tool install` package spec includes the native Kimi backend's
 # runtime dependencies (openai + tiktoken). Recorded non-empty extras are still

--- a/scripts/setup/cli-proxy-lane.ps1
+++ b/scripts/setup/cli-proxy-lane.ps1
@@ -63,7 +63,7 @@ $Cfg     = Join-Path $Dir 'config.yaml'
 $Vbs     = Join-Path $Dir 'start-hidden.vbs'   # GUI-subsystem launcher the logon task runs (HIMMEL-1822)
 $ApiKey  = 'himmel-local-claudex'   # local proxy token; must match config.yaml api-keys
 $Port    = 8317
-$Version = '7.2.155'
+$Version = '7.2.158'
 $Release = "https://github.com/router-for-me/CLIProxyAPI/releases/download/v$Version/CLIProxyAPI_${Version}_windows_amd64.zip"
 
 function Test-OAuth {

--- a/scripts/upstreams.json
+++ b/scripts/upstreams.json
@@ -139,7 +139,7 @@
       "kind": "tag_release",
       "mode": "base",
       "tracked_repo": "Graphify-Labs/graphify",
-      "synced_base": "0.9.57",
+      "synced_base": "0.9.58",
       "latest_source": "release",
       "version_pin": { "file": "scripts/lib/graphify-bin.sh", "template": "GRAPHIFY_VERSION:-{version}" },
       "tier": "A",
@@ -150,7 +150,7 @@
       "kind": "tag_release",
       "mode": "base",
       "tracked_repo": "router-for-me/CLIProxyAPI",
-      "synced_base": "7.2.155",
+      "synced_base": "7.2.158",
       "version_pin": { "file": "scripts/setup/cli-proxy-lane.ps1", "template": "$Version = '{version}'" },
       "tier": "A",
       "note": "CLIProxyAPI codex-lane proxy (HOST process on 127.0.0.1:8317; installed + run by scripts/setup/cli-proxy-lane.ps1). Added to the nightly drift machinery (HIMMEL-1451) so a new upstream release SURFACES as a drift finding instead of needing manual surgery: v7.2.77 threw ~3-min bursts of instant upstream 502s every ~25 min that killed codex-adv renders (Claude Code retries 502s but the companion's render turn does not), and the validated fix was a manual swap to v7.2.113 -- both legs completed clean that night. AUTO-BUMP policy is deliberately SURFACE-ONLY and matches the existing rows' conservatism: apply-drift-bump.sh moves the in-repo pin literal ($Version in cli-proxy-lane.ps1) and synced_base TOGETHER; the drift leg lands that as a PR. Since HIMMEL-2134 (#1928), himmel-update.sh's advisory sync_cli_proxy step DOES roll the host itself, machine-local and pin-aware: every run compares the host's live version stamp to this pin and, when genuinely behind, runs cli-proxy-lane.ps1 -Install -Restart -- never downgrades and never guesses on an uncomparable stamp (rc 1/2 both leave the host alone), and the lane's own Assert-BounceSafe refuses to bounce a live codex-lane render rather than kill it. -Force is the override for the refused-bounce case specifically (it bypasses Assert-BounceSafe only); no pwsh on PATH or an unparseable stamp instead want a plain manual -Install -Restart run on the host, or an immediate roll ahead of the next update. Default tag-mode (highest stable tag, prereleases excluded -- CLIProxyAPI tags are monotonic, so no latest_source override is needed); synced_base lacks the leading 'v' but the guard normalizes both sides before comparing (v7.2.115 tag == 7.2.115 base). tracked_repo is the TRUE upstream (router-for-me/CLIProxyAPI)."


### PR DESCRIPTION
## Why

The nightly fork-drift guard read two `mode: base` rows BEHIND on 2026-09-11 (weekly-reset shift, console 03N running `/drift-fix` by hand per the operator's resume scope):

- `graphify: BEHIND (Graphify-Labs/graphify latest tag v0.9.58; installed 0.9.57 — upgrade) [A]`
- `cli-proxy-api: BEHIND (router-for-me/CLIProxyAPI latest tag v7.2.158; installed 7.2.155 — upgrade) [A]`

## What

`scripts/upstreams/apply-drift-bump.sh` moved each in-repo pin literal together with its `synced_base` (rc=0 both):

- `BUMP graphify 0.9.57 -> 0.9.58 (files: scripts/upstreams.json, scripts/lib/graphify-bin.sh)`
- `BUMP cli-proxy-api 7.2.155 -> 7.2.158 (files: scripts/upstreams.json, scripts/setup/cli-proxy-lane.ps1)`

No hand edits. `check-plugin-drift.sh` re-run from the worktree reads both rows `CURRENT`.

## Evidence

- `test-apply-drift-bump.sh`: all checks passed
- `test-graphify-bin.sh`: pass=401 fail=0
- `test-cli-proxy-lane.sh`: 50 passed, 0 failed

## Not in this PR (same sweep)

- rtk 0.48.0 -> 0.49.0: `apply-tool-upgrade.sh rtk --unattended` rc=4 (binary did not advance) — the HIMMEL-2607 Arch/user-local gap; left for the operator.
- claude-obsidian v2.1.1-himmel.1 -> v2.2.0: fork resync CONFLICTS because upstream merged our PR #178 — fork collapse handled on its own ticket.
- The machine-side `himmel-update --only cli_proxy` roll to 7.2.158 runs after this merges (it reads main's pin).

Ticket: HIMMEL-2924

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default Graphify tooling to version 0.9.58.
  * Updated the CLI proxy setup to version 7.2.158.
  * Existing version override support remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->