### PR TITLE
fix(handover): [HIMMEL-2919] merge-on-green refuses a console-spawned leg's merge without the console's GO file for the certified head; launcher exports HIMMEL_CONSOLE_LEG=1; go.sh writes the evidence

### DIFF
--- a/docs/handover/running-a-console.md
+++ b/docs/handover/running-a-console.md
@@ -125,6 +125,12 @@ threat model and the verbatim block:
 green at that exact head, zero unresolved review threads, attestation trailers
 in the first commit) → `GO` → the leg merges and reports `MERGED #<n> → <sha>`.
 The console pulls the primary and the leg closes out its ticket.
+The console sends GO by first running `bash scripts/handover/console-kit/go.sh
+<pr> <full head sha>` — the file IS the GO, the SendMessage is the
+notification: a leg launched by `headed-arm-leg.sh` carries
+`HIMMEL_CONSOLE_LEG=1`, and `merge-on-green.sh` refuses it (exit 17) without a
+GO for the exact head it certifies, so a push after GO needs a fresh one
+(HIMMEL-2919).
 
 An armed merge stops at "awaiting approval" wherever branch protection requires
 a review the automation identity cannot give — on a single-maintainer repo the

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -3753,6 +3753,7 @@ opposite ways — this script's pin NARROWS what a human-only,
 `CLAUDECODE`-self-refusing chokepoint may touch, while merge-on-green's WIDENS a
 boundary an agent runs under.
 `merge-on-green.sh` exits 17 (`policy-refused`) on a fresh pre-merge `BLOCKED` + `REVIEW_REQUIRED` policy read after green checks or an explicit GitHub base-branch policy rejection at merge time; if no automation identity can satisfy the required review, the merge is a human admin action; on this repo the operator relaxed `protect-main` on 2026-09-09 (HIMMEL-2887).
+It also exits 17 (`policy-refused phase=console-go`) when `HIMMEL_CONSOLE_LEG` is set — exported by `console-kit/headed-arm-leg.sh` into every console-spawned leg — and `<handover_root>/.locks/go/<pr>.<certified head sha>` is missing or does not carry `head=<that sha>`; only the console writes it, via `console-kit/go.sh` (which refuses under the marker), and `scripts/chokepoints.json` registers the marker so a per-call `HIMMEL_CONSOLE_LEG=` prefix is denied (HIMMEL-2919).
 That is why merge-on-green deliberately does NOT
 reuse this script's `CR_PUBLIC_REPO`: an env-overridable constant costs nothing
 on a narrowing pin and would be a widening seam on the other. Supports

--- a/scripts/chokepoints.json
+++ b/scripts/chokepoints.json
@@ -3,7 +3,10 @@
     "seam_env_vars": ["CR_REQUIRE_CROSS_MODEL"]
   },
   "scripts/handover/merge-on-green.sh": {
-    "seam_env_vars": ["ARMAUTOMERGE", "MERGE_ON_GREEN_LOG"]
+    "seam_env_vars": ["ARMAUTOMERGE", "MERGE_ON_GREEN_LOG", "HIMMEL_CONSOLE_LEG", "HANDOVER_DIR"]
+  },
+  "scripts/handover/console-kit/go.sh": {
+    "seam_env_vars": ["HIMMEL_CONSOLE_LEG"]
   },
   "scripts/lanes/stop-worker.sh": {
     "seam_env_vars": ["STOP_WORKER_GRACE_SECS", "STOP_WORKER_BRIDGE_ROOT_OVERRIDE"]

--- a/scripts/handover/console-kit/go.sh
+++ b/scripts/handover/console-kit/go.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# scripts/handover/console-kit/go.sh - write the console's GO for one PR head
+# (HIMMEL-2919). The file IS the GO: merge-on-green.sh, run from a
+# console-spawned leg (HIMMEL_CONSOLE_LEG=1, exported by headed-arm-leg.sh),
+# refuses with exit 17 unless <handover_root>/.locks/go/<pr>.<head sha> exists
+# and carries head=<that sha>. The console's SendMessage GO is only the
+# notification. A GO binds ONE head: a push after it needs a fresh GO.
+#
+# Usage: go.sh <pr-number> <full-40-hex-head-sha>
+# Prints the written path. Re-running overwrites (idempotent).
+#
+# Exit codes:
+#   0  written
+#   1  handover root unresolvable, or the write failed
+#   2  usage (arg count, non-digit PR, sha not exactly 40 lowercase hex)
+#   3  refused: run from a console-spawned leg - a leg never writes its own GO
+#
+# Platform guard (gitbash-only): POSIX bash 3.2+, same as headed-arm-leg.sh.
+set -u
+
+usage() {
+    echo "usage: go.sh <pr-number> <full-40-hex-head-sha>" >&2
+}
+
+if [ "$#" -ne 2 ]; then
+    usage
+    exit 2
+fi
+PR="$1"; SHA="$2"
+
+case "$PR" in
+    ''|0*|*[!0123456789]*)
+        usage
+        echo "go: pr-number must be digits without a leading zero (got '$PR')" >&2
+        exit 2 ;;
+esac
+case "$SHA" in
+    *[!0123456789abcdef]*) SHA_OK=0 ;;
+    *) SHA_OK=1 ;;
+esac
+if [ "$SHA_OK" -ne 1 ] || [ "${#SHA}" -ne 40 ]; then
+    usage
+    echo "go: head sha must be the full 40-char lowercase hex sha (got '$SHA')" >&2
+    exit 2
+fi
+
+# Same truthiness as merge-on-green.sh's _truthy.
+case "$(printf '%s' "${HIMMEL_CONSOLE_LEG:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
+    ''|0|false|off|no) ;;
+    *)
+        echo "go: refusing - this is a console-spawned leg (HIMMEL_CONSOLE_LEG is set); only the console writes a GO. Send READY to your console and wait for GO." >&2
+        exit 3 ;;
+esac
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib/handover-path.sh
+# shellcheck disable=SC1091
+if ! . "$HERE/../../lib/handover-path.sh"; then
+    echo "go: cannot load scripts/lib/handover-path.sh" >&2
+    exit 1
+fi
+if ! ROOT=$(handover_root); then
+    echo "go: cannot resolve the handover root (set HANDOVER_DIR)" >&2
+    exit 1
+fi
+
+DIR="$ROOT/.locks/go"
+DEST="$DIR/$PR.$SHA"
+BY="${CONSOLE_SESSION_NAME:-${USER:-$(id -un 2>/dev/null || echo unknown)}@$(hostname 2>/dev/null || uname -n)}"
+BY=$(printf '%s' "$BY" | tr -d '\r\n')
+AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+if ! mkdir -p "$DIR" || ! TMP=$(mktemp "$DIR/.go.XXXXXX"); then
+    echo "go: cannot create a temp file under $DIR" >&2
+    exit 1
+fi
+if ! printf 'pr=%s\nhead=%s\nby=%s\nat=%s\n' "$PR" "$SHA" "$BY" "$AT" > "$TMP" || ! mv -f "$TMP" "$DEST"; then
+    rm -f "$TMP"
+    echo "go: could not write $DEST" >&2
+    exit 1
+fi
+printf '%s\n' "$DEST"

--- a/scripts/handover/console-kit/headed-arm-leg.sh
+++ b/scripts/handover/console-kit/headed-arm-leg.sh
@@ -148,6 +148,10 @@ fi
 # only unsets the three HIMMEL-2545 vars and otherwise inherits as-is.
 export IMPL_GUARD_OK=1
 export INLINE_IMPL_OK=1
+# HIMMEL_CONSOLE_LEG=1 (HIMMEL-2919): marks the launched process as a
+# console-spawned leg, both lanes. merge-on-green.sh then merges only on the
+# console's GO file (console-kit/go.sh), and go.sh refuses to run under it.
+export HIMMEL_CONSOLE_LEG=1
 # headed-arm.sh builds one argv array for both native and recorder launches and
 # refuses exit 2 if this exact pair is absent. This is the final resolved-argv
 # guard; the context-value check above gives the earlier operator-facing error.
@@ -165,8 +169,8 @@ fi
 if [ "$DRY_RUN" -eq 1 ]; then
     printf 'headed-arm-leg: would exec: %s %s %s %s %s %s %s %s\n' \
         "$HEADED_ARM" "$NAME" "$DOC" "$SIGNAL" "$DEADLINE" "$LOG" "$MODEL" "$CONTEXT"
-    printf 'headed-arm-leg: env IMPL_GUARD_OK=%s INLINE_IMPL_OK=%s HEADED_ARM_REPO=%s\n' \
-        "$IMPL_GUARD_OK" "$INLINE_IMPL_OK" "${HEADED_ARM_REPO:-<derived by headed-arm.sh>}"
+    printf 'headed-arm-leg: env IMPL_GUARD_OK=%s INLINE_IMPL_OK=%s HIMMEL_CONSOLE_LEG=%s HEADED_ARM_REPO=%s\n' \
+        "$IMPL_GUARD_OK" "$INLINE_IMPL_OK" "$HIMMEL_CONSOLE_LEG" "${HEADED_ARM_REPO:-<derived by headed-arm.sh>}"
     printf 'headed-arm-leg: lane=%s launcher=%s launcher-env=%s\n' \
         "$LANE" "${HEADED_ARM_LAUNCHER:-claude (native default)}" "${HEADED_ARM_LAUNCHER_ENV:-<none>}"
     exit 0

--- a/scripts/handover/console-kit/test-go.sh
+++ b/scripts/handover/console-kit/test-go.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015  # A && B || C is intentional in check()/contains(), as in test-headed-arm-leg.sh
+# scripts/handover/console-kit/test-go.sh - suite for go.sh (HIMMEL-2919), the
+# console's GO-evidence writer that merge-on-green.sh's console-GO gate reads.
+# test-merge-on-green.sh drives the reader end to end with GO files written by
+# THIS script; this suite pins the writer's own contract:
+#   1. usage: arg count, non-digit / leading-zero PR, sha not 40 lowercase hex -> exit 2.
+#   2. write: path printed, file fields pr= / head= / by= / at= (ISO-8601 UTC).
+#   3. by= falls back to <user>@<host> without CONSOLE_SESSION_NAME.
+#   4. idempotent: a re-run overwrites in place, no temp file left behind.
+#   5. HIMMEL_CONSOLE_LEG set -> exit 3, nothing written (a leg never writes its own GO).
+#   6. unresolvable handover root -> exit 1.
+#
+# Platform guard (gitbash-only): POSIX bash 3.2+.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/go.sh"
+unset HIMMEL_CONSOLE_LEG CONSOLE_SESSION_NAME 2>/dev/null || true
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/go-test.XXXXXX")" || { echo "FAIL: mktemp -d failed" >&2; exit 1; }
+trap 'rm -rf "$tmp"' EXIT
+tmp="$(cd "$tmp" && pwd)"
+fails=0
+grepq() { local _t="$1"; shift; grep -q "$@" <<< "$_t"; }
+check()    { [ "$2" = "$3" ] && echo "ok - $1" || { echo "FAIL - $1: [$2]!=[$3]"; fails=$((fails+1)); }; }
+contains() { grepq "$2" -F -e "$3" && echo "ok - $1" || { echo "FAIL - $1: output does not contain [$3]"; fails=$((fails+1)); }; }
+
+SHA=0123456789abcdef0123456789abcdef01234567
+ROOT="$tmp/root"; mkdir -p "$ROOT"
+GO="$ROOT/.locks/go/77.$SHA"
+
+# --- 1. usage --------------------------------------------------------------
+for args in "" "77" "77 $SHA extra" "x1 $SHA" "077 $SHA" "77 ${SHA%?}" "77 ${SHA}0" \
+            "77 0123456789ABCDEF0123456789abcdef01234567" "77 g123456789abcdef0123456789abcdef01234567"; do
+  rc=0
+  # shellcheck disable=SC2086  # word-splitting the args string IS the point
+  HANDOVER_DIR="$ROOT" bash "$SCRIPT" $args >/dev/null 2>&1 || rc=$?
+  check "usage: [$args] -> exit 2" "$rc" "2"
+done
+check "usage: nothing written" "$(ls -A "$ROOT")" ""
+
+# --- 2. write ----------------------------------------------------------------
+rc=0; out="$(HANDOVER_DIR="$ROOT" CONSOLE_SESSION_NAME=console-x bash "$SCRIPT" 77 "$SHA" 2>&1)" || rc=$?
+check "write: exit 0" "$rc" "0"
+check "write: prints the GO path" "$out" "$GO"
+body="$(cat "$GO" 2>/dev/null || true)"
+contains "write: pr= field" "$body" "pr=77"
+contains "write: head= field" "$body" "head=$SHA"
+contains "write: by= is the console session name" "$body" "by=console-x"
+grepq "$body" -Ex 'at=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z' \
+  && echo "ok - write: at= is ISO-8601 UTC" || { echo "FAIL - write: at= not ISO-8601 UTC: [$body]"; fails=$((fails+1)); }
+
+# --- 3. by= fallback ---------------------------------------------------------
+rc=0; HANDOVER_DIR="$ROOT" bash "$SCRIPT" 78 "$SHA" >/dev/null 2>&1 || rc=$?
+check "fallback: exit 0" "$rc" "0"
+grepq "$(cat "$ROOT/.locks/go/78.$SHA" 2>/dev/null)" -Ex 'by=[^@]+@.+' \
+  && echo "ok - fallback: by=<user>@<host>" || { echo "FAIL - fallback: by= not <user>@<host>"; fails=$((fails+1)); }
+
+# --- 4. idempotent rewrite ---------------------------------------------------
+rc=0; HANDOVER_DIR="$ROOT" CONSOLE_SESSION_NAME=console-y bash "$SCRIPT" 77 "$SHA" >/dev/null 2>&1 || rc=$?
+check "rewrite: exit 0" "$rc" "0"
+contains "rewrite: overwritten in place" "$(cat "$GO" 2>/dev/null)" "by=console-y"
+check "rewrite: one head= line, not appended" "$(grep -c '^head=' "$GO" 2>/dev/null)" "1"
+leftover=0
+for f in "$ROOT/.locks/go"/.go.*; do [ -e "$f" ] && leftover=$((leftover+1)); done
+check "rewrite: no temp file left behind" "$leftover" "0"
+
+# --- 5. a console-spawned leg cannot write its own GO ------------------------
+LEGROOT="$tmp/legroot"; mkdir -p "$LEGROOT"
+rc=0; out="$(HANDOVER_DIR="$LEGROOT" HIMMEL_CONSOLE_LEG=1 bash "$SCRIPT" 77 "$SHA" 2>&1)" || rc=$?
+check "leg marker: exit 3" "$rc" "3"
+contains "leg marker: names the reason" "$out" "console-spawned leg"
+check "leg marker: nothing written" "$(ls -A "$LEGROOT")" ""
+rc=0; HANDOVER_DIR="$LEGROOT" HIMMEL_CONSOLE_LEG=0 bash "$SCRIPT" 77 "$SHA" >/dev/null 2>&1 || rc=$?
+check "leg marker: a falsy marker is no marker" "$rc" "0"
+
+# --- 6. unresolvable handover root -------------------------------------------
+rc=0; HANDOVER_DIR="$tmp/absent" bash "$SCRIPT" 77 "$SHA" >/dev/null 2>&1 || rc=$?
+check "no root: exit 1" "$rc" "1"
+
+echo "---"
+if [ "$fails" -eq 0 ]; then
+  echo "PASS - test-go.sh"
+  exit 0
+else
+  echo "FAIL - test-go.sh ($fails failure(s))"
+  exit 1
+fi

--- a/scripts/handover/console-kit/test-headed-arm-leg.sh
+++ b/scripts/handover/console-kit/test-headed-arm-leg.sh
@@ -16,9 +16,10 @@
 #        HEADED_ARM_PROC seams headed-arm.sh's own suite uses (the wrapper
 #        execs the real headed-arm.sh, so this proves the non-dry path carries
 #        --autocompact 200000); LEG_CONTEXT=1m refuses before headed-arm runs.
-#   10. IMPL_GUARD_OK=1 and INLINE_IMPL_OK=1 reach konsole's own process
-#       environment (the leg-only env headed-arm.sh's child-env block does
-#       not set).
+#   10. IMPL_GUARD_OK=1, INLINE_IMPL_OK=1 and HIMMEL_CONSOLE_LEG=1 (HIMMEL-2919,
+#       the marker merge-on-green's console-GO gate keys on) reach konsole's
+#       own process environment (the leg-only env headed-arm.sh's child-env
+#       block does not set).
 #   11. LEG_REPO reaches headed-arm.sh's --workdir.
 #   12. RED control: a mutant headed-arm renderer with --autocompact removed is
 #       refused on the full non-dry launch path before konsole runs.
@@ -36,7 +37,7 @@ SCRIPT="$HERE/headed-arm-leg.sh"
 HEADED_ARM="$HERE/../headed-arm.sh"
 # The suite owns every launcher input; an ambient leg shell must not silently
 # turn default-native cases into claudex cases.
-unset LEG_LANE LEG_CONTEXT LEG_REPO LEG_EFFORT HEADED_ARM_LAUNCHER HEADED_ARM_LAUNCHER_ENV HEADED_ARM_RECORDER IMPL_GUARD_OK INLINE_IMPL_OK 2>/dev/null || true
+unset LEG_LANE LEG_CONTEXT LEG_REPO LEG_EFFORT HEADED_ARM_LAUNCHER HEADED_ARM_LAUNCHER_ENV HEADED_ARM_RECORDER IMPL_GUARD_OK INLINE_IMPL_OK HIMMEL_CONSOLE_LEG 2>/dev/null || true
 
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/headed-arm-leg-test.XXXXXX")" || { echo "FAIL: mktemp -d failed" >&2; exit 1; }
 trap 'rm -rf "$tmp"' EXIT
@@ -69,7 +70,7 @@ mk_launch_stubs() {
   cat > "$dir/konsole" <<'KONSOLE_EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$(dirname "$0")/record"
-env | grep -E '^(IMPL_GUARD_OK|INLINE_IMPL_OK|HEADED_ARM_REQUIRED_AUTOCOMPACT)=' > "$(dirname "$0")/env-record"
+env | grep -E '^(IMPL_GUARD_OK|INLINE_IMPL_OK|HIMMEL_CONSOLE_LEG|HEADED_ARM_REQUIRED_AUTOCOMPACT)=' > "$(dirname "$0")/env-record"
 : > "$(dirname "$0")/confirmable"
 sleep 5
 KONSOLE_EOF
@@ -136,8 +137,8 @@ run_leg() {
   # shell (e.g. running this suite from inside an already-armed leg) before
   # invoking the wrapper, so case 10's propagation assertion can only pass
   # because the wrapper's own `export IMPL_GUARD_OK=1` ran - not because the
-  # value was already there.
-  IMPL_GUARD_OK='' \
+  # value was already there. HIMMEL_CONSOLE_LEG likewise (HIMMEL-2919).
+  IMPL_GUARD_OK='' HIMMEL_CONSOLE_LEG='' \
   HEADED_ARM_LEG_TARGET="$HEADED_ARM" \
   HEADED_ARM_LEG_PREFLIGHT="$preflight" \
   KONSOLE_CMD="$stubdir/konsole" PGREP_CMD="$stubdir/pgrep" \
@@ -170,6 +171,7 @@ ends_with "dry-run default: context=standard, no LEG_CONTEXT" "$out" "standard"
 not_contains "dry-run default: no [1m] suffix in the would-exec line" "$out" "[1m]"
 contains "dry-run default: reports IMPL_GUARD_OK=1" "$out" "IMPL_GUARD_OK=1"
 contains "dry-run default: reports INLINE_IMPL_OK=1" "$out" "INLINE_IMPL_OK=1"
+contains "dry-run default: reports HIMMEL_CONSOLE_LEG=1" "$out" "HIMMEL_CONSOLE_LEG=1"
 
 rc=0; out="$(LEG_CONTEXT=1m bash "$SCRIPT" --dry-run HIMMEL-9999-leg some/doc.md /tmp/nosig 99999999999 /tmp/leg.log claude-sonnet-5 2>&1)" || rc=$?
 check "dry-run LEG_CONTEXT=1m: refused with exit 2" "$rc" "2"
@@ -236,6 +238,7 @@ check "full launch, LEG_CONTEXT=1m: headed-arm was never invoked" "$rec9" ""
 env8="$(cat "$d8/env-record" 2>/dev/null || true)"
 contains "full launch: IMPL_GUARD_OK=1 in the konsole invocation's env" "$env8" "IMPL_GUARD_OK=1"
 contains "full launch: INLINE_IMPL_OK=1 in the konsole invocation's env" "$env8" "INLINE_IMPL_OK=1"
+contains "full launch: HIMMEL_CONSOLE_LEG=1 in the konsole invocation's env" "$env8" "HIMMEL_CONSOLE_LEG=1"
 not_contains "full launch: internal autocompact requirement does not leak into the launched leg" "$env8" "HEADED_ARM_REQUIRED_AUTOCOMPACT="
 
 # --- 12. RED control: mutate the ACTUAL headed-arm launch renderer to drop

--- a/scripts/handover/merge-on-green.sh
+++ b/scripts/handover/merge-on-green.sh
@@ -112,12 +112,25 @@
 #       refused (an unauditable merge must not proceed)
 #   17  policy-refused: base branch policy explicitly prohibits the merge, or
 #       green checks still leave BLOCKED + REVIEW_REQUIRED before merging —
-#       refused; an unsatisfiable review rule needs a human admin action
+#       refused; an unsatisfiable review rule needs a human admin action.
+#       HIMMEL-2919: also returned when HIMMEL_CONSOLE_LEG is truthy and the
+#       console's GO file for this PR at the certified head is missing, stale
+#       or unresolvable — checked after check-ci, before any merge call, on
+#       --dry-run too (see the console-GO gate below)
 #
 # Environment:
 #   ARMAUTOMERGE           Must be truthy (1/true/on/yes) to enable at all.
 #   MERGE_ON_GREEN_LOG     Audit-log path override. Default:
 #                          "$(git rev-parse --git-dir)/merge-on-green.log".
+#   HIMMEL_CONSOLE_LEG     Exported (=1) by console-kit/headed-arm-leg.sh into
+#                          every console-spawned leg. Truthy => the merge needs
+#                          <handover_root>/.locks/go/<pr>.<certified head sha>
+#                          containing head=<that sha>, written by the console
+#                          via console-kit/go.sh (HIMMEL-2919). Unset/falsy =>
+#                          no GO gate.
+#   HANDOVER_DIR           Where handover_root resolves that GO file
+#                          (scripts/lib/handover-path.sh); read only under
+#                          HIMMEL_CONSOLE_LEG.
 #
 # GATE INTEGRITY (coderabbit): `gh` and `check-ci.sh` are NOT environment-
 # overridable — a contaminated/inherited launching environment must not be able
@@ -474,6 +487,30 @@ if [ "$ci_rc" -ne 0 ]; then
     echo "merge-on-green: check-ci gate did not pass (exit $ci_rc) — not merging. Address the gate, then re-run." >&2
     audit "REFUSED reason=gate-not-green gate=check-ci:$ci_rc repo=$nwo pr=#$pr_num sha=$sha"
     exit 14
+fi
+
+# HIMMEL-2919 — console-GO gate. A console-spawned leg (headed-arm-leg.sh
+# exports HIMMEL_CONSOLE_LEG=1) merges ONLY on its console's GO: a file the
+# console writes with console-kit/go.sh under the handover root, bound to THIS
+# PR and to the head sha check-ci just certified — the same $sha
+# --match-head-commit pins below. The evidence is a file, never an env value
+# the leg could set on its own merge line. Placed before the marker clear so a
+# refused leg mutates nothing, and before the DRY_RUN branch so a dry run
+# reports the refusal too. Unset marker: skipped whole — the resolver is not
+# even sourced, so operator sessions are unchanged.
+if _truthy "${HIMMEL_CONSOLE_LEG:-}"; then
+    go_root=""
+    # shellcheck source=scripts/lib/handover-path.sh
+    # shellcheck disable=SC1091
+    if . "$SCRIPT_DIR/../lib/handover-path.sh" 2>/dev/null; then
+        go_root=$(handover_root 2>/dev/null) || go_root=""
+    fi
+    go_file="${go_root:-<unresolved handover root>}/.locks/go/$pr_num.$sha"
+    if [ -z "$go_root" ] || ! grep -qxF "head=$sha" "$go_file" 2>/dev/null; then
+        echo "merge-on-green: PR #$pr_num at $sha has no console GO ($go_file) — you are a console-spawned leg; send READY to your console and wait for GO; a GO for an older head is stale, never reuse it" >&2
+        audit "REFUSED reason=policy-refused phase=console-go repo=$nwo pr=#$pr_num sha=$sha go=$go_file"
+        exit 17
+    fi
 fi
 
 # MARKER CLEAR (HIMMEL-1346) — a merge used to leave the branch's cr-pending

--- a/scripts/handover/test-merge-on-green.sh
+++ b/scripts/handover/test-merge-on-green.sh
@@ -17,6 +17,10 @@ set -uo pipefail
 # retained; this is the startup defense-in-depth + the CR_MERGE_GATE_OK scrub
 # for the day a sourced lib reads it.)
 unset ARMAUTOMERGE CR_MERGE_GATE_OK
+# HIMMEL-2919: a console-spawned leg's shell carries HIMMEL_CONSOLE_LEG=1, which
+# arms the console-GO gate — ambient, it would refuse every merge case below.
+# Its own line: RC-2 below mutates the line above by exact match.
+unset HIMMEL_CONSOLE_LEG
 
 # grepq <text> [grep-args...] — a `grep -q` test against <text> with NO
 # pipeline. printf/echo-into-`grep -q` is a trap under this file's
@@ -187,6 +191,8 @@ mog_build_fixture() {
     # the source fails, CR_STATE falls back to `unknown`, and every cr= assertion
     # below would pass while testing nothing.
     cp "$SCRIPT_DIR/../lib/cr-available.sh" "$tmp/scripts/lib/cr-available.sh"
+    # HIMMEL-2919: the console-GO gate resolves the GO file under handover_root.
+    cp "$SCRIPT_DIR/../lib/handover-path.sh" "$tmp/scripts/lib/handover-path.sh"
     if [ "${NO_CHECK_CI:-0}" != "1" ]; then
         printf '#!/usr/bin/env bash\nexit %s\n' "${STUB_CI_RC:-0}" > "$tmp/scripts/check-ci.sh"
         chmod +x "$tmp/scripts/check-ci.sh"
@@ -2168,6 +2174,72 @@ else
     # a merge). A future change that made `broken` fail closed fails HERE.
     assert_audit_has "2380-5: a broken marker warns but does not block the merge" "MERGED repo="
 fi
+
+# --- 2919. Console-GO gate — a console-spawned leg (HIMMEL_CONSOLE_LEG=1) merges
+# only on a console-written GO file for the certified head ------------------
+GO_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/mog-go.XXXXXX")
+GO_ROOT=$(cd "$GO_ROOT" && pwd)
+GO_SHA=0123456789abcdef0123456789abcdef01234567
+GO_OLD=fedcba9876543210fedcba9876543210fedcba98
+GO_WRITER="$SCRIPT_DIR/console-kit/go.sh"
+no_merge_call() {
+    if [ "$(grep -c '^pr merge ' "$LAST_GH_LOG")" -eq 0 ]; then pass; else fail "$1 (expected zero merge calls)"; fi
+}
+
+# 2919-a — marker set, no GO file: refused before any merge call.
+HIMMEL_CONSOLE_LEG=1 HANDOVER_DIR="$GO_ROOT" STUB_SHA="$GO_SHA" \
+    run_mog 17 "2919-a: console leg without a GO file → exit 17"
+assert_err_has "2919-a: stderr names the expected GO path" "has no console GO ($GO_ROOT/.locks/go/77.$GO_SHA)"
+assert_audit_has "2919-a: audited as a policy refusal" "REFUSED reason=policy-refused phase=console-go"
+assert_audit_lacks "2919-a: no merge intent recorded" "MERGING"
+no_merge_call "2919-a: no merge call"
+
+# 2919-a2 — same on --dry-run: a dry run must report the refusal, not "would merge".
+HIMMEL_CONSOLE_LEG=1 HANDOVER_DIR="$GO_ROOT" STUB_SHA="$GO_SHA" \
+    run_mog 17 "2919-a2: dry-run console leg without a GO file → exit 17" -- --dry-run
+assert_audit_lacks "2919-a2: no DRYRUN would-merge line" "DRYRUN"
+
+# 2919-a3 — an unresolvable handover root fails CLOSED, never "no gate".
+HIMMEL_CONSOLE_LEG=1 HANDOVER_DIR="$GO_ROOT/absent" STUB_SHA="$GO_SHA" \
+    run_mog 17 "2919-a3: console leg with an unresolvable handover root → exit 17"
+no_merge_call "2919-a3: no merge call"
+
+# 2919-b — marker set, GO written by the console's own writer for the certified
+# head: proceeds exactly like the unmarked happy path (2919-d's gh log).
+HANDOVER_DIR="$GO_ROOT" bash "$GO_WRITER" 77 "$GO_SHA" >/dev/null 2>&1
+HIMMEL_CONSOLE_LEG=1 HANDOVER_DIR="$GO_ROOT" STUB_SHA="$GO_SHA" \
+    run_mog 0 "2919-b: console leg with a GO for the certified head → merged"
+assert_merge_has "2919-b: merge pins the certified head" "--match-head-commit $GO_SHA"
+assert_audit_has "2919-b: MERGED recorded" "MERGED repo="
+GO_B_GHLOG=$(cat "$LAST_GH_LOG")
+
+# 2919-c — only a STALE GO (an older head) exists: refused.
+rm -f "$GO_ROOT/.locks/go/77.$GO_SHA"
+HANDOVER_DIR="$GO_ROOT" bash "$GO_WRITER" 77 "$GO_OLD" >/dev/null 2>&1
+HIMMEL_CONSOLE_LEG=1 HANDOVER_DIR="$GO_ROOT" STUB_SHA="$GO_SHA" \
+    run_mog 17 "2919-c: console leg with only a stale GO → exit 17"
+assert_err_has "2919-c: stderr says a stale GO is never reused" "a GO for an older head is stale"
+no_merge_call "2919-c: no merge call"
+
+# 2919-c2 — the stale GO RENAMED onto the certified head's path still carries
+# head=<old sha>: the content binding refuses it.
+mv "$GO_ROOT/.locks/go/77.$GO_OLD" "$GO_ROOT/.locks/go/77.$GO_SHA"
+HIMMEL_CONSOLE_LEG=1 HANDOVER_DIR="$GO_ROOT" STUB_SHA="$GO_SHA" \
+    run_mog 17 "2919-c2: a stale GO renamed to the certified path → exit 17"
+no_merge_call "2919-c2: no merge call"
+rm -f "$GO_ROOT/.locks/go/77.$GO_SHA"
+
+# 2919-d — marker unset, no GO file: the operator path is unchanged, and the gate
+# adds no gh call of its own (2919-b's gh log is byte-identical).
+HANDOVER_DIR="$GO_ROOT" STUB_SHA="$GO_SHA" run_mog 0 "2919-d: marker unset, no GO → merged (operator path unchanged)"
+assert_audit_lacks "2919-d: no console-go refusal" "console-go"
+if [ "$(cat "$LAST_GH_LOG")" = "$GO_B_GHLOG" ]; then pass; else fail "2919-b/d: the gated merge's gh calls differ from the unmarked merge's"; fi
+
+# 2919-d2 — a falsy marker is the unset marker (same truthiness as ARMAUTOMERGE).
+HIMMEL_CONSOLE_LEG=0 HANDOVER_DIR="$GO_ROOT" STUB_SHA="$GO_SHA" \
+    run_mog 0 "2919-d2: HIMMEL_CONSOLE_LEG=0, no GO → merged"
+rm -rf "$GO_ROOT"
+
 echo
 echo "merge-on-green: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Why

A console-spawned leg could merge on its own, reading HIMMEL_INITIATIVE's `merge` step, before its console had sent GO. Asking it in prose is not enough. This PR makes the GO a structural gate on merge-on-green (HIMMEL-2919).

## What

- **Launcher**: `console-kit/headed-arm-leg.sh` exports `HIMMEL_CONSOLE_LEG=1` into every leg, on both lanes. It is shown in `--dry-run` too.
- **Writer**: `console-kit/go.sh <pr> <full-40-hex-sha>` (new). The console runs it to send GO. The file IS the GO; the SendMessage only notifies the leg. The write is atomic (mktemp + mv) and idempotent. It exits 3 under `HIMMEL_CONSOLE_LEG`, so a leg cannot write its own GO.
- **Gate**: in `merge-on-green.sh`, when the marker is truthy, the gate sits right after check-ci certifies `$sha` and before the CR-marker clear, DRY_RUN and the merge. It requires `<handover_root>/.locks/go/<pr>.<sha>` to contain `head=<sha>`. Otherwise it exits **17**, with audit line `REFUSED reason=policy-refused phase=console-go …` and this stderr:
  `merge-on-green: PR #<n> at <sha> has no console GO (<path>) — you are a console-spawned leg; send READY to your console and wait for GO; a GO for an older head is stale, never reuse it`
  When the marker is unset, the gate is skipped entirely. It does not even source the resolver, and the gh call log is byte-identical (case 2919-d).
- **Registry**: `scripts/chokepoints.json` registers `HIMMEL_CONSOLE_LEG` and `HANDOVER_DIR` as merge-on-green seams, plus `HIMMEL_CONSOLE_LEG` on go.sh. `block-chokepoint-env-prefix` therefore denies a per-call `HIMMEL_CONSOLE_LEG=0 bash …merge-on-green.sh` bypass.
- **Docs**: the Merges section of `docs/handover/running-a-console.md`, and the exit-17 paragraph in `docs/internals/enforcement.md`.

### GO-file shape

```
<handover_root>/.locks/go/<pr>.<full head sha>
pr=<n>
head=<full head sha>
by=<CONSOLE_SESSION_NAME | user@host>
at=<YYYY-MM-DDTHH:MM:SSZ>
```

## RED first

Pre-implementation run of the new cases (merge-on-green 311 passed / 15 failed):

```
FAIL: 2919-a: console leg without a GO file → exit 17 — expected exit 17, got 0 (err: <none>)
```

## Suites (after)

| suite | result |
|---|---|
| test-merge-on-green.sh | 305 → **326 passed, 0 failed** |
| console-kit/test-go.sh (new) | PASS |
| console-kit/test-headed-arm-leg.sh | PASS |
| hooks/test-block-chokepoint-env-prefix.sh | all 141 cases passed |
| hooks/test-crlf-boundary.sh | 85 passed, 0 failed |
| cr/test-clear-cr-marker.sh | 291 passed, 0 failed |
| hooks/test-inject-initiative.sh | 102 passed, 0 failed |
| console/test-console.sh | ALL PASS |
| test-pr-merge.sh | PASS |
| hooks/test-block-tail-pipe-on-gates.sh | all cases passed |
| lib/test-cr-high-risk-diff.sh | 43 passed, 0 failed |
| test-merge-public-on-green.sh | 68 passed, 0 failed |

shellcheck is clean on every touched script.

New merge-on-green cases:

| case | setup | expected |
|---|---|---|
| 2919-a | no GO | 17, no merge |
| 2919-a2 | dry-run | 17 |
| 2919-a3 | unresolvable root | 17 |
| 2919-b | GO for the head | merged with `--match-head-commit` |
| 2919-c | stale GO only | 17 |
| 2919-c2 | stale content under the right name | 17 |
| 2919-d | marker unset | 0, gh log identical |
| 2919-d2 | `HIMMEL_CONSOLE_LEG=0` | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQKGaHRUFR7BUqzeK1pnpV
