### PR TITLE
fix(hooks): [HIMMEL-2923] PreToolUse denies AskUserQuestion for console-spawned legs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -194,6 +194,16 @@
         ]
       },
       {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ -f \"$CLAUDE_PROJECT_DIR/scripts/lib/run-node.sh\" ]; then command -p sh \"$CLAUDE_PROJECT_DIR/scripts/lib/run-node.sh\" \"$CLAUDE_PROJECT_DIR/scripts/hooks/run-hook-with-bash.js\" \"$CLAUDE_PROJECT_DIR/scripts/hooks/block-leg-askuserquestion.sh\"; else node \"$CLAUDE_PROJECT_DIR/scripts/hooks/run-hook-with-bash.js\" \"$CLAUDE_PROJECT_DIR/scripts/hooks/block-leg-askuserquestion.sh\"; fi",
+            "timeout": 15
+          }
+        ]
+      },
+      {
         "matcher": "mcp__plugin_atlassian_atlassian__.*",
         "hooks": [
           {

--- a/docs/handover/running-a-console.md
+++ b/docs/handover/running-a-console.md
@@ -85,6 +85,9 @@ many readers but exactly one writer per artifact. And **every dispatch names an
 explicit model**: an unnamed one draws on the scarcer parent quota. Tier and
 effort guidance, including the console's own wake-up budget, is in
 [`../internals/lane-calibration.md`](../internals/lane-calibration.md).
+`headed-arm-leg.sh` exports `HIMMEL_CONSOLE_LEG=1`, which
+`block-leg-askuserquestion.sh` (HIMMEL-2923) uses to structurally deny
+`AskUserQuestion` on the leg, rather than relying on the brief's prose NEVER.
 
 ## Claudex legs: the inbox is the only channel
 

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -2530,6 +2530,17 @@ checkout workers branch from having pulled the merge. Spec:
 > arm (settings-chain entries are `Bash`/`PowerShell`-only), and a `--chain`
 > member cannot carry `--fail-closed-when`.
 
+### `block-leg-askuserquestion.sh` — console-spawned-leg AskUserQuestion deny (HIMMEL-2923)
+
+Fires on `AskUserQuestion`, keyed on `HIMMEL_CONSOLE_LEG=1` (set by the
+console's launcher, `scripts/handover/console-kit/headed-arm-leg.sh`,
+HIMMEL-2919). A leg launched headed by a console runs in a window nobody
+answers — two legs parked on this call in 2026-09-10, one for 77 minutes.
+Second drift on prose → structural. Denies with a message naming SendMessage
+to the console as the replacement. Workflow nudge, not a security fence: fails
+open on missing `jq`, malformed, or empty stdin so it never locks an operator
+session out of the tool. Inert until HIMMEL-2919's launcher export lands.
+
 ### `block-backend-tier.sh` — service-agnostic backend-routing guard (HIMMEL-400)
 
 Fires on `mcp__plugin_atlassian_atlassian__*` tool calls (and any other

--- a/scripts/hooks/block-leg-askuserquestion.sh
+++ b/scripts/hooks/block-leg-askuserquestion.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# block-leg-askuserquestion.sh — PreToolUse hook (matcher "AskUserQuestion"):
+# denies AskUserQuestion for a console-spawned leg (HIMMEL-2923). A leg
+# launched headed by a console (scripts/handover/console-kit/headed-arm-leg.sh,
+# HIMMEL-2919, exports HIMMEL_CONSOLE_LEG=1 in the launching shell) runs in a
+# window nobody answers: two legs parked on an AskUserQuestion call on
+# 2026-09-10 — one 77 minutes with its diff already complete, the other
+# despite an explicit NEVER in its brief. Second drift on prose -> structural
+# (root CLAUDE.md "Adding a rule").
+#
+# Scope: inert until HIMMEL-2919's launcher export lands. Until then
+# HIMMEL_CONSOLE_LEG is never set and this hook always falls through to
+# allow — that is expected, not a bug.
+#
+# Workflow nudge, not a security fence (scripts/hooks/CLAUDE.md "Fail-open vs
+# fail-closed"): fails OPEN on anything it cannot parse (missing jq, malformed
+# or empty stdin), so a hook bug never locks an operator's own session out of
+# AskUserQuestion.
+#
+# Bypass: unset HIMMEL_CONSOLE_LEG in the launching shell (session-sticky; a
+# per-call prefix does not reach this hook process).
+#
+# Platform guard (gitbash-only): plain env var + jq, no git/path work; runs
+# unchanged under Git Bash on Windows or POSIX bash 3.2+. No .ps1 twin needed.
+#
+# Hook I/O: JSON on stdin. exit 0 = allow, exit 2 = deny (stderr plus a
+# structured hookSpecificOutput.permissionDecision on stdout — same
+# belt-and-braces idiom as guard-console-dispatch.sh).
+set -uo pipefail
+
+[ "${HIMMEL_CONSOLE_LEG:-0}" = "1" ] || exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+[ "$tool" = "AskUserQuestion" ] || exit 0
+
+deny_msg="You are a console-spawned leg; nobody answers in this window. Ask the console by SendMessage (your brief names it), or wait with ONE foreground blocking command / a foreground until-loop. (HIMMEL-2923)"
+
+reason=$(printf '%s' "$deny_msg" | jq -Rs . 2>/dev/null) \
+    || reason='"block-leg-askuserquestion: console-spawned leg denied AskUserQuestion"'
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$reason"
+printf '%s\n' "$deny_msg" >&2
+exit 2

--- a/scripts/hooks/test-block-leg-askuserquestion.sh
+++ b/scripts/hooks/test-block-leg-askuserquestion.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Smoke suite for scripts/hooks/block-leg-askuserquestion.sh (HIMMEL-2923):
+# a console-spawned leg (HIMMEL_CONSOLE_LEG=1, set by HIMMEL-2919's launcher)
+# calling AskUserQuestion is denied — nobody answers in that window. Covers:
+# marker+tool -> deny, marker unset -> allow, marker+other tool -> allow,
+# malformed/empty stdin -> allow (fail-open; a hook crash must never lock an
+# operator out).
+#
+# bash 3.2-safe. Platform guard (gitbash-only): plain env var + jq checks, no
+# git/path work; runs unchanged under Git Bash on Windows. No .ps1 twin needed.
+set -uo pipefail
+
+HOOKS="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$HOOKS/block-leg-askuserquestion.sh"
+[ -f "$HOOK" ] || { echo "hook not found: $HOOK" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not on PATH"; exit 0; }
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad() { fail=$((fail+1)); printf '  FAIL %s\n' "$1"; }
+
+# check <label> <block|allow> <json> [ENV=val ...]
+check() {
+    local label="$1" expect="$2" json="$3"; shift 3
+    local rc got
+    printf '%s' "$json" | env "$@" bash "$HOOK" >/dev/null 2>&1
+    rc=$?
+    case "$rc" in
+        0) got=allow ;;
+        2) got=block ;;
+        *) got="?(rc=$rc)" ;;
+    esac
+    if [ "$got" = "$expect" ]; then ok "$label"; else
+        bad "$label - expected $expect got $got"; fi
+}
+
+echo "== marker set + AskUserQuestion -> deny =="
+check "marker + AskUserQuestion -> deny" block \
+    '{"tool_name":"AskUserQuestion","tool_input":{"questions":[]}}' \
+    HIMMEL_CONSOLE_LEG=1
+out="$(printf '%s' '{"tool_name":"AskUserQuestion","tool_input":{"questions":[]}}' | env HIMMEL_CONSOLE_LEG=1 bash "$HOOK" 2>&1 >/dev/null)"
+case "$out" in
+    *SendMessage*HIMMEL-2923*) ok "deny text names SendMessage and the ticket" ;;
+    *) bad "deny text missing SendMessage/HIMMEL-2923 - got: $out" ;;
+esac
+
+echo "== marker unset -> allow (operator sessions keep the tool) =="
+check "no marker + AskUserQuestion -> allow" allow \
+    '{"tool_name":"AskUserQuestion","tool_input":{"questions":[]}}'
+
+echo "== marker set + a different tool_name -> allow =="
+check "marker + Write -> allow" allow \
+    '{"tool_name":"Write","tool_input":{"file_path":"x.txt"}}' \
+    HIMMEL_CONSOLE_LEG=1
+
+echo "== malformed/empty stdin -> allow (fail-open) =="
+check "marker + malformed JSON -> allow" allow \
+    '{not json' \
+    HIMMEL_CONSOLE_LEG=1
+check "marker + empty stdin -> allow" allow \
+    '' \
+    HIMMEL_CONSOLE_LEG=1
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/hooks/wire-hook-bash.mjs
+++ b/scripts/hooks/wire-hook-bash.mjs
@@ -86,6 +86,10 @@ export const EXPECTED_SCRIPT_ORDER = Object.freeze([
   // chain above: it does not guard MultiEdit, and widening a guard's matcher is
   // not something a launch-count refactor gets to do.
   'orchestrator-inline-guard.sh',
+  // PreToolUse `AskUserQuestion` — its own matcher (HIMMEL-2923): denies a
+  // console-spawned leg (HIMMEL_CONSOLE_LEG=1, HIMMEL-2919's launcher export)
+  // from calling AskUserQuestion — nobody answers in that window.
+  'block-leg-askuserquestion.sh',
   // PreToolUse, one entry each.
   'block-backend-tier.sh',
   'auto-arm-on-cap.sh',


### PR DESCRIPTION
## Summary
A console-spawned leg (launched headed by `scripts/handover/console-kit/headed-arm-leg.sh`) runs in a window nobody answers. Twice on 2026-09-10 a leg called `AskUserQuestion` anyway — one parked 77 minutes with its diff already complete, the other despite an explicit "NEVER" in its brief. Second drift on prose escalates to structural (`CLAUDE.md` "Adding a rule"). This PR adds a PreToolUse hook that denies `AskUserQuestion` when the launcher marker `HIMMEL_CONSOLE_LEG=1` is set, naming SendMessage-to-console as the replacement.

## Changes
- `scripts/hooks/block-leg-askuserquestion.sh` (new) — denies `AskUserQuestion` when `HIMMEL_CONSOLE_LEG=1`; fails open on missing `jq`, malformed/empty stdin (workflow nudge, not a security fence).
- `.claude/settings.json` — new PreToolUse entry, matcher `AskUserQuestion`, same `run-node.sh`/`run-hook-with-bash.js` conditional shape as its neighbours.
- `scripts/hooks/wire-hook-bash.mjs` — registered in `EXPECTED_SCRIPT_ORDER`; `--check` passes clean.
- `scripts/hooks/test-block-leg-askuserquestion.sh` (new) — RED-then-GREEN suite.
- `docs/internals/enforcement.md`, `docs/handover/running-a-console.md` — one section / one sentence.

## RED line
Before the hook existed, the deny case failed as expected:
```
FAIL marker + AskUserQuestion -> deny - expected block got allow
```
Suite is GREEN after the hook was written (6/6 passing via `scripts/quiet-run.sh`).

## Dependency note (HIMMEL-2919)
This hook is **inert** until sibling ticket HIMMEL-2919 lands the `HIMMEL_CONSOLE_LEG=1` export in `headed-arm-leg.sh`. Until then the marker is never set and the hook always allows — expected, not a bug.

## Codex lane
`.codex/hooks.json` and `.codex/README.md` were checked — no `AskUserQuestion`-equivalent tool exists in the codex lane, so intentionally no change there.

## CR
Paid codex critic was quota-exhausted this window (`reason=quota-5h`) — `/pr-check` fell through to the Claude-only review floor (HIMMEL-1224): self-reviewed the full diff, 0 Critical/Important findings, marker cleared on that evidence (`clear-cr-marker: CLEARED ... responders=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fez4pmAgehmBJCcy1Bkp1S