### PR TITLE
fix(ci-orchestrator): [HIMMEL-2880] model shell-unit-shard as the matrix job, add ci.yml coverage gate

### DIFF
--- a/scripts/ci-orchestrator/act-matrix.json
+++ b/scripts/ci-orchestrator/act-matrix.json
@@ -1,10 +1,18 @@
 {
-  "ci:secret-scan": { "fidelity": "act-faithful", "os": ["linux"], "heavy": false },
-  "ci:leak-classes": { "fidelity": "act-faithful", "os": ["linux"], "heavy": false },
-  "ci:commit-lint": { "fidelity": "needs-shim", "os": ["linux"], "heavy": false, "shim": "act lacks the pull_request base.sha context; supply the range base via an -e event.json / ACT_* env so check-commit-range.sh has a base to walk." },
-  "ci:lint": { "fidelity": "act-faithful", "os": ["linux"], "heavy": false },
-  "ci:node-suites": { "fidelity": "act-faithful", "os": ["linux"], "heavy": false },
-  "ci:bun-suites": { "fidelity": "needs-shim", "os": ["linux"], "heavy": true, "shim": "oven-sh/setup-bun needs bun present in the act container image; provision bun (custom image or a pre-step) or the job errors on setup-bun." },
-  "ci:security-scan": { "fidelity": "needs-shim", "os": ["linux"], "heavy": true, "shim": "needs bun (setup-bun) AND network egress for the pinned gitleaks download; provision bun + allow the gitleaks release fetch in the act image." },
-  "ci:shell-unit": { "fidelity": "act-faithful", "os": ["linux", "windows", "macos"], "heavy": true, "shim": "only the linux leg is act-eligible; the windows/macos legs are gha-only (act is Linux/Docker-only) and route to native GHA." }
+  "jobs": {
+    "ci:secret-scan": { "fidelity": "act-faithful", "os": ["linux"], "heavy": false },
+    "ci:leak-classes": { "fidelity": "act-faithful", "os": ["linux"], "heavy": false },
+    "ci:commit-lint": { "fidelity": "needs-shim", "os": ["linux"], "heavy": false, "shim": "act lacks the pull_request base.sha context; supply the range base via an -e event.json / ACT_* env so check-commit-range.sh has a base to walk." },
+    "ci:lint": { "fidelity": "act-faithful", "os": ["linux"], "heavy": false },
+    "ci:node-suites": { "fidelity": "act-faithful", "os": ["linux"], "heavy": false },
+    "ci:bun-suites": { "fidelity": "needs-shim", "os": ["linux"], "heavy": true, "shim": "oven-sh/setup-bun needs bun present in the act container image; provision bun (custom image or a pre-step) or the job errors on setup-bun." },
+    "ci:security-scan": { "fidelity": "needs-shim", "os": ["linux"], "heavy": true, "shim": "needs bun (setup-bun) AND network egress for the pinned gitleaks download; provision bun + allow the gitleaks release fetch in the act image." },
+    "ci:shell-unit-shard": { "fidelity": "act-faithful", "os": ["linux", "windows", "macos"], "heavy": true, "shim": "only the linux leg is act-eligible; the windows/macos legs are gha-only (act is Linux/Docker-only) and route to native GHA." },
+    "ci:shell-unit": { "fidelity": "act-faithful", "os": ["linux"], "heavy": false }
+  },
+  "intentionallyAbsent": {
+    "ci:lanes-and-trust-suites": "HIMMEL-2880: not yet act-classified — needs a full-history checkout (fetch-depth 0) act does not replicate; falls through to hosted routing without an act-exec fast path until someone verifies it under act.",
+    "ci:guardrail-matrices": "HIMMEL-2880: not yet act-classified — no known act blocker, just never surveyed; falls through to hosted routing without an act-exec fast path until classified.",
+    "ci:doc-invariants": "HIMMEL-2880: not yet act-classified — no-ops without the gitignored .himmel-dev marker and only meaningfully gates the public post-propagation tree, not a private PR; falls through to hosted routing without an act-exec fast path until classified."
+  }
 }

--- a/scripts/ci-orchestrator/src/act-matrix.ts
+++ b/scripts/ci-orchestrator/src/act-matrix.ts
@@ -21,12 +21,19 @@ export type ActFidelity = "act-faithful" | "needs-shim" | "gha-only";
 export type OsName = "linux" | "windows" | "macos";
 
 // Keyed by "workflow:job" (workflow = the ci.yml file basename `ci`). `os` is an
-// ARRAY because one job (shell-unit) fans to linux+windows+macos via
+// ARRAY because one job (shell-unit-shard) fans to linux+windows+macos via
 // `runs-on: ${{ matrix.os }}` — the superset it can produce (B4). Routing then
 // decides each OS leg independently (act-exec is eligible only for the linux leg
 // AND when fidelity !== "gha-only").
 export type ActMatrixEntry = { fidelity: ActFidelity; os: OsName[]; heavy: boolean; shim?: string };
 export type ActMatrix = Record<string, ActMatrixEntry>;
+
+// act-matrix.json's on-disk shape: `jobs` is the classification ActMatrix
+// consumed by routing.ts/dedup.ts; `intentionallyAbsent` (HIMMEL-2880) names
+// every ci.yml job deliberately left out of `jobs`, one-line reason each — the
+// coverage gate (ci-coverage.ts) treats a ci.yml job as covered iff it is a key
+// in one of the two.
+export type ActMatrixFile = { jobs: ActMatrix; intentionallyAbsent: Record<string, string> };
 
 // Resolve the committed act-matrix.json (package root, one dir up from src/).
 function matrixPath(): string {
@@ -34,12 +41,19 @@ function matrixPath(): string {
   return join(here, "..", "act-matrix.json");
 }
 
+function loadFile(path: string): ActMatrixFile {
+  const raw = readFileSync(path, "utf8");
+  return JSON.parse(raw) as ActMatrixFile;
+}
+
 // Load the committed matrix. Pure read; throws if the file is missing/malformed
 // (a corrupt matrix must fail loud, not route silently on an empty table).
 export function loadMatrix(path: string = matrixPath()): ActMatrix {
-  const raw = readFileSync(path, "utf8");
-  const parsed = JSON.parse(raw) as ActMatrix;
-  return parsed;
+  return loadFile(path).jobs;
+}
+
+export function loadIntentionallyAbsent(path: string = matrixPath()): Record<string, string> {
+  return loadFile(path).intentionallyAbsent;
 }
 
 // The doc-safe "light gate" job names and the heavy code-matrix job names are

--- a/scripts/ci-orchestrator/src/ci-coverage.ts
+++ b/scripts/ci-orchestrator/src/ci-coverage.ts
@@ -1,0 +1,34 @@
+// scripts/ci-orchestrator/src/ci-coverage.ts
+// HIMMEL-2880 — structural coverage gate: every job id in ci.yml must be
+// modeled in act-matrix.json's `jobs` or listed in its `intentionallyAbsent`,
+// or a rename/add in ci.yml drifts the orchestrator's topology model with no
+// signal (exactly what happened to `shell-unit` under HIMMEL-2872).
+import { readFileSync } from "node:fs";
+
+// Extract top-level job ids from a GitHub Actions workflow's `jobs:` block.
+// Deliberately not a full YAML parser (none is a repo dependency yet — see
+// package.json): job ids are exactly-2-space-indented keys under the
+// top-level `jobs:` line, which is how every job in this repo's ci.yml is
+// authored. A line at column 0 after `jobs:` ends the block (next top-level
+// key), so this only breaks if ci.yml stops being flow-style-free at depth 1.
+export function extractJobIds(yaml: string): string[] {
+  const lines = yaml.split("\n");
+  const jobsLine = lines.findIndex((l) => /^jobs:\s*$/.test(l));
+  if (jobsLine === -1) throw new Error("no top-level 'jobs:' key found");
+  const ids: string[] = [];
+  for (const line of lines.slice(jobsLine + 1)) {
+    if (/^\S/.test(line)) break;
+    const m = line.match(/^ {2}([A-Za-z0-9_-]+):/);
+    if (m) ids.push(m[1]);
+  }
+  return ids;
+}
+
+export function loadWorkflowJobIds(path: string): string[] {
+  return extractJobIds(readFileSync(path, "utf8"));
+}
+
+// missing is empty iff act-matrix.json's model is current with ci.yml.
+export function checkCoverage(jobKeys: string[], modeled: Set<string>, intentionallyAbsent: Set<string>): { missing: string[] } {
+  return { missing: jobKeys.filter((k) => !modeled.has(k) && !intentionallyAbsent.has(k)) };
+}

--- a/scripts/ci-orchestrator/src/ci-coverage.ts
+++ b/scripts/ci-orchestrator/src/ci-coverage.ts
@@ -10,13 +10,16 @@ import { readFileSync } from "node:fs";
 // package.json): job ids are exactly-2-space-indented keys under the
 // top-level `jobs:` line, which is how every job in this repo's ci.yml is
 // authored. A line at column 0 after `jobs:` ends the block (next top-level
-// key), so this only breaks if ci.yml stops being flow-style-free at depth 1.
+// key) — blank lines and column-0 comments are valid YAML inside the block
+// and don't end it, so this only breaks if ci.yml stops being flow-style-free
+// at depth 1.
 export function extractJobIds(yaml: string): string[] {
   const lines = yaml.split("\n");
   const jobsLine = lines.findIndex((l) => /^jobs:\s*$/.test(l));
   if (jobsLine === -1) throw new Error("no top-level 'jobs:' key found");
   const ids: string[] = [];
   for (const line of lines.slice(jobsLine + 1)) {
+    if (/^\s*$/.test(line) || /^\s*#/.test(line)) continue;
     if (/^\S/.test(line)) break;
     const m = line.match(/^ {2}([A-Za-z0-9_-]+):/);
     if (m) ids.push(m[1]);

--- a/scripts/ci-orchestrator/src/dedup.ts
+++ b/scripts/ci-orchestrator/src/dedup.ts
@@ -14,7 +14,7 @@ import { type JobAttrs, type JobState } from "./ledger.js";
 // by discovery so rule (2) never dedup-reuses them). Named constants, not inferred.
 export const DOC_SAFE_JOBS = new Set<string>(["secret-scan", "commit-lint", "lint"]);
 // The heavy code-matrix jobs dropped on a doc-only diff.
-export const CODE_MATRIX_JOBS = new Set<string>(["node-suites", "bun-suites", "security-scan", "shell-unit"]);
+export const CODE_MATRIX_JOBS = new Set<string>(["node-suites", "bun-suites", "security-scan", "shell-unit-shard"]);
 
 export type SubmissionPlan = {
   enqueue: JobAttrs[];

--- a/scripts/ci-orchestrator/tests/act-matrix.test.ts
+++ b/scripts/ci-orchestrator/tests/act-matrix.test.ts
@@ -1,24 +1,15 @@
 import { describe, test, expect } from "vitest";
-import { loadMatrix } from "../src/act-matrix.js";
+import { loadMatrix, loadIntentionallyAbsent } from "../src/act-matrix.js";
 
-// The eight real jobs in .github/workflows/ci.yml (keyed "ci:<job>").
-const REAL_JOBS = [
-  "ci:secret-scan",
-  "ci:leak-classes",
-  "ci:commit-lint",
-  "ci:lint",
-  "ci:node-suites",
-  "ci:bun-suites",
-  "ci:security-scan",
-  "ci:shell-unit",
-];
-
+// Full ci.yml job-set coverage (every job present or intentionally-absent) is
+// tests/ci-coverage.test.ts's job — this file only checks the SHAPE of what's
+// modeled, not which jobs are.
 describe("act-matrix", () => {
-  test("loadMatrix returns a well-formed entry for every real ci.yml job", () => {
+  test("loadMatrix returns a well-formed entry for every modeled job", () => {
     const m = loadMatrix();
-    for (const key of REAL_JOBS) {
-      const e = m[key];
-      expect(e, `missing ${key}`).toBeDefined();
+    expect(Object.keys(m).length).toBeGreaterThan(0);
+    for (const [key, e] of Object.entries(m)) {
+      expect(key, "job key must be workflow:job").toMatch(/^ci:/);
       expect(e.fidelity).toMatch(/^(act-faithful|needs-shim|gha-only)$/);
       expect(Array.isArray(e.os)).toBe(true);
       expect(e.os.length).toBeGreaterThan(0);
@@ -27,13 +18,20 @@ describe("act-matrix", () => {
     }
   });
 
-  test("shell-unit is the multi-OS job (linux+windows+macos)", () => {
+  test("shell-unit-shard is the heavy multi-OS matrix job; shell-unit is the cheap aggregator (HIMMEL-2880)", () => {
     const m = loadMatrix();
-    expect(m["ci:shell-unit"].os).toEqual(["linux", "windows", "macos"]);
+    expect(m["ci:shell-unit-shard"].os).toEqual(["linux", "windows", "macos"]);
+    expect(m["ci:shell-unit-shard"].heavy).toBe(true);
+    expect(m["ci:shell-unit"].os).toEqual(["linux"]);
+    expect(m["ci:shell-unit"].heavy).toBe(false);
   });
 
-  test("matrix covers exactly the real ci.yml job set (no invented jobs)", () => {
-    const m = loadMatrix();
-    expect(Object.keys(m).sort()).toEqual([...REAL_JOBS].sort());
+  test("loadIntentionallyAbsent returns a non-empty reason for every entry", () => {
+    const absent = loadIntentionallyAbsent();
+    for (const [key, reason] of Object.entries(absent)) {
+      expect(key).toMatch(/^ci:/);
+      expect(typeof reason).toBe("string");
+      expect(reason.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/scripts/ci-orchestrator/tests/adapters-private-gha.test.ts
+++ b/scripts/ci-orchestrator/tests/adapters-private-gha.test.ts
@@ -7,7 +7,7 @@ import { type JobAttrs } from "../src/ledger.js";
 const T0 = "2026-07-05T00:00:00Z";
 function job(over: Partial<JobAttrs> = {}): JobAttrs {
   return {
-    id: "j", headSha: "HEADSHA", runSha: "HEADSHA", workflow: "ci", job: "shell-unit", required: true,
+    id: "j", headSha: "HEADSHA", runSha: "HEADSHA", workflow: "ci", job: "shell-unit-shard", required: true,
     needsSecrets: true, publicSafe: false, os: "windows", heavy: true, deterministic: false,
     treeHash: "t", enqueuedAt: T0, ...over,
   };
@@ -85,7 +85,7 @@ describe("private-gha-hosted (dispatched, sparing)", () => {
     };
     const a = makePrivateGhaHostedAdapter({ exec, repo: "o/r" });
     const r = await a.dispatch(job());
-    expect(r.runId).toContain("dispatch-HEADSHA-shell-unit-windows");
+    expect(r.runId).toContain("dispatch-HEADSHA-shell-unit-shard-windows");
     expect(calls.some((c) => c.includes("workflow"))).toBe(true);
   });
 });

--- a/scripts/ci-orchestrator/tests/ci-coverage.test.ts
+++ b/scripts/ci-orchestrator/tests/ci-coverage.test.ts
@@ -13,6 +13,13 @@ describe("extractJobIds", () => {
     const yaml = "name: X\non:\n  push:\njobs:\n  a:\n    runs-on: ubuntu-latest\n  b:\n    runs-on: ubuntu-latest\n";
     expect(extractJobIds(yaml)).toEqual(["a", "b"]);
   });
+
+  // A column-0 comment or blank line is valid YAML inside the jobs: block
+  // and must not be mistaken for the next top-level key (HIMMEL-2880 CR).
+  test("does not stop at a column-0 comment or blank line inside jobs:", () => {
+    const yaml = "jobs:\n  a:\n    runs-on: ubuntu-latest\n\n# a column-0 comment\n  b:\n    runs-on: ubuntu-latest\n";
+    expect(extractJobIds(yaml)).toEqual(["a", "b"]);
+  });
 });
 
 describe("ci-coverage gate", () => {

--- a/scripts/ci-orchestrator/tests/ci-coverage.test.ts
+++ b/scripts/ci-orchestrator/tests/ci-coverage.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { extractJobIds, checkCoverage, loadWorkflowJobIds } from "../src/ci-coverage.js";
+import { loadMatrix, loadIntentionallyAbsent } from "../src/act-matrix.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const CI_YML = join(here, "..", "..", "..", ".github", "workflows", "ci.yml");
+const FIXTURE_WITH_EXTRA_JOB = join(here, "fixtures", "ci-coverage", "ci-with-extra-job.yml");
+
+describe("extractJobIds", () => {
+  test("parses top-level job ids under the jobs: key only", () => {
+    const yaml = "name: X\non:\n  push:\njobs:\n  a:\n    runs-on: ubuntu-latest\n  b:\n    runs-on: ubuntu-latest\n";
+    expect(extractJobIds(yaml)).toEqual(["a", "b"]);
+  });
+});
+
+describe("ci-coverage gate", () => {
+  test("every job in the real ci.yml is modeled in act-matrix.json or intentionally-absent", () => {
+    const jobKeys = loadWorkflowJobIds(CI_YML).map((id) => `ci:${id}`);
+    const modeled = new Set(Object.keys(loadMatrix()));
+    const absent = new Set(Object.keys(loadIntentionallyAbsent()));
+    const { missing } = checkCoverage(jobKeys, modeled, absent);
+    expect(missing, `unmodeled ci.yml jobs: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  // RED control (HIMMEL-2880): a coverage gate that can never fail is the
+  // vacuous-pass class — this proves it fails when ci.yml carries a job the
+  // real act-matrix.json neither models nor lists as intentionally-absent.
+  test("RED control: a ci.yml job absent from both lists fails the gate", () => {
+    const jobKeys = loadWorkflowJobIds(FIXTURE_WITH_EXTRA_JOB).map((id) => `ci:${id}`);
+    const modeled = new Set(Object.keys(loadMatrix()));
+    const absent = new Set(Object.keys(loadIntentionallyAbsent()));
+    const { missing } = checkCoverage(jobKeys, modeled, absent);
+    expect(missing).toEqual(["ci:totally-new-job"]);
+  });
+});

--- a/scripts/ci-orchestrator/tests/client.test.ts
+++ b/scripts/ci-orchestrator/tests/client.test.ts
@@ -5,11 +5,11 @@ import { type LaneAvailability } from "../src/routing.js";
 import { type ActMatrix } from "../src/act-matrix.js";
 
 const T0 = "2026-07-05T00:00:00Z";
-const MATRIX: ActMatrix = { "ci:shell-unit": { fidelity: "act-faithful", os: ["linux", "windows", "macos"], heavy: true } };
+const MATRIX: ActMatrix = { "ci:shell-unit-shard": { fidelity: "act-faithful", os: ["linux", "windows", "macos"], heavy: true } };
 
 function job(over: Partial<JobAttrs> = {}): JobAttrs {
   return {
-    id: "j", headSha: "HEAD", runSha: "HEAD", workflow: "ci", job: "shell-unit", required: false,
+    id: "j", headSha: "HEAD", runSha: "HEAD", workflow: "ci", job: "shell-unit-shard", required: false,
     needsSecrets: false, publicSafe: false, os: "windows", heavy: true, deterministic: false,
     treeHash: "t", enqueuedAt: T0, ...over,
   };

--- a/scripts/ci-orchestrator/tests/dedup.test.ts
+++ b/scripts/ci-orchestrator/tests/dedup.test.ts
@@ -66,10 +66,10 @@ describe("planSubmission", () => {
   });
 
   test("os leg is part of dedup identity (same job, different os → not reused)", () => {
-    const a = job({ job: "shell-unit", os: "linux", treeHash: "abc" });
+    const a = job({ job: "shell-unit-shard", os: "linux", treeHash: "abc" });
     const prior = new Map([[a.id, { attrs: a, status: "done" as const, conclusion: "success" }]]);
     const { enqueue, reused } = planSubmission(
-      [job({ job: "shell-unit", os: "windows", treeHash: "abc", deterministic: true })],
+      [job({ job: "shell-unit-shard", os: "windows", treeHash: "abc", deterministic: true })],
       ["src/x.ts"],
       prior,
     );

--- a/scripts/ci-orchestrator/tests/fixtures/ci-coverage/ci-with-extra-job.yml
+++ b/scripts/ci-orchestrator/tests/fixtures/ci-coverage/ci-with-extra-job.yml
@@ -1,0 +1,12 @@
+name: CI
+on:
+  pull_request:
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo scan
+  totally-new-job:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo new

--- a/scripts/ci-orchestrator/tests/routing.test.ts
+++ b/scripts/ci-orchestrator/tests/routing.test.ts
@@ -6,7 +6,7 @@ import { type ActMatrix } from "../src/act-matrix.js";
 const MATRIX: ActMatrix = {
   "ci:lint": { fidelity: "act-faithful", os: ["linux"], heavy: false },
   "ci:security-scan": { fidelity: "needs-shim", os: ["linux"], heavy: true },
-  "ci:shell-unit": { fidelity: "act-faithful", os: ["linux", "windows", "macos"], heavy: true },
+  "ci:shell-unit-shard": { fidelity: "act-faithful", os: ["linux", "windows", "macos"], heavy: true },
 };
 
 function lanes(over: Partial<LaneAvailability> = {}): LaneAvailability {
@@ -64,27 +64,27 @@ describe("route — the decision table", () => {
   });
 
   test("win/mac required needsSecrets, with headroom → private-gha-hosted", () => {
-    const d = route({ ...base, job: job({ job: "shell-unit", os: "windows", required: true, needsSecrets: true, heavy: true }) });
+    const d = route({ ...base, job: job({ job: "shell-unit-shard", os: "windows", required: true, needsSecrets: true, heavy: true }) });
     expect(d.lane).toBe("private-gha-hosted");
   });
 
   test("win/mac required, NO private headroom → defer (never silently skip)", () => {
-    const d = route({ ...base, job: job({ job: "shell-unit", os: "windows", required: true, needsSecrets: true, heavy: true }), privateMinutesHeadroom: false });
+    const d = route({ ...base, job: job({ job: "shell-unit-shard", os: "windows", required: true, needsSecrets: true, heavy: true }), privateMinutesHeadroom: false });
     expect(d.lane).toBe("defer");
   });
 
   test("public-safe non-required, github up → public-fork", () => {
-    const d = route({ ...base, job: job({ job: "shell-unit", os: "windows", publicSafe: true, heavy: true }) });
+    const d = route({ ...base, job: job({ job: "shell-unit-shard", os: "windows", publicSafe: true, heavy: true }) });
     expect(d.lane).toBe("public-fork");
   });
 
   test("public-safe non-required, github DOWN → defer (fork needs github)", () => {
-    const d = route({ ...base, job: job({ job: "shell-unit", os: "windows", publicSafe: true, heavy: true }), githubUp: false });
+    const d = route({ ...base, job: job({ job: "shell-unit-shard", os: "windows", publicSafe: true, heavy: true }), githubUp: false });
     expect(d.lane).toBe("defer");
   });
 
   test("local-exec only when shared/drain AND load below threshold", () => {
-    const j = job({ job: "shell-unit", os: "windows", heavy: true }); // not act-eligible, not public-safe
+    const j = job({ job: "shell-unit-shard", os: "windows", heavy: true }); // not act-eligible, not public-safe
     expect(route({ ...base, job: j, workProfile: "drain", loadBelowThreshold: true }).lane).toBe("local-exec");
     expect(route({ ...base, job: j, workProfile: "drain", loadBelowThreshold: false }).lane).toBe("defer");
     expect(route({ ...base, job: j, workProfile: "focus", loadBelowThreshold: true }).lane).toBe("defer");


### PR DESCRIPTION
## Why

HIMMEL-2872 renamed the working shell-unit CI job to `shell-unit-shard` (an
os×shard matrix) and introduced a cheap aggregator job that kept the name
`shell-unit` purely to preserve the required-check-run context. The
orchestrator's topology model never caught up:
`scripts/ci-orchestrator/act-matrix.json`'s `ci:shell-unit` key and
`scripts/ci-orchestrator/src/dedup.ts`'s `CODE_MATRIX_JOBS` still described
the OLD heavy/multi-OS job under the name `shell-unit`, so the orchestrator
was routing/deduping the wrong job under that name — with no test able to
catch a repeat of this class of drift.

## Before / after

| | Before | After |
|---|---|---|
| `act-matrix.json` `ci:shell-unit` | heavy, multi-OS (linux/windows/macos) | cheap aggregator, linux-only |
| `act-matrix.json` `ci:shell-unit-shard` | absent | heavy, multi-OS matrix job (the real work) |
| `dedup.ts` `CODE_MATRIX_JOBS` | `shell-unit` | `shell-unit-shard` |
| ci.yml ↔ act-matrix.json coverage | no structural check | `ci-coverage.ts` gate + RED-control test |

## Coverage gate

Added `scripts/ci-orchestrator/src/ci-coverage.ts`: extracts every top-level
job id from `.github/workflows/ci.yml` and asserts each one is either modeled
in `act-matrix.json` or explicitly listed as intentionally-absent. A RED-control
fixture (`tests/fixtures/ci-coverage/ci-with-extra-job.yml`) proves the gate
actually fails when a ci.yml job is unmodeled — closing the vacuous-pass class
that let the HIMMEL-2872 rename go unnoticed in the first place.

## CR fix (round 1)

`extractJobIds`'s block-ending check originally treated any column-0 line as
ending the `jobs:` block, including a column-0 YAML comment — which is valid
YAML inside the block and would have silently truncated job extraction. Fixed
to skip blank/comment lines before checking for the real block-ending
top-level key; covered by a new test.

## Verification

```
$ cd scripts/ci-orchestrator && npx tsc --noEmit && npm test
```
All tests pass, including:
- `ci-coverage gate > every job in the real ci.yml is modeled...` (GREEN — proves current coverage)
- `ci-coverage gate > RED control: a ci.yml job absent from both lists fails the gate` (proves the gate is not vacuous)
- `act-matrix > shell-unit-shard is the heavy multi-OS matrix job; shell-unit is the cheap aggregator`

## Scope

Touches only `scripts/ci-orchestrator/**`. Does not touch `.github/workflows/ci.yml`,
`scripts/ci/`, or `scripts/hooks/`.

## CR

`/pr-check` round 2, clean: 0 Critical, 0 Important. Two round-1 Suggestions and
two round-2 Suggestions recorded (non-blocking); the one round-1 Important
finding was fixed inline (see above) rather than deferred.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVywXER4wsqzoRkJsJybqU
