### PR TITLE
fix(hooks): [HIMMEL-2927] block-chokepoint-env-prefix denies env -u / --unset and an in-shell unset or export -n that clears a registered seam

### DIFF
--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -1751,7 +1751,12 @@ segment, and a seam assignment counts ONLY as a leading assignment of that
 SAME segment. Fails OPEN on anything unresolvable (missing `jq`,
 missing/malformed registry, an internal error) — a belt around chokepoints
 whose bare invocations are already governed by allow-rules + the classifier,
-never a general env-var ban. Known residual (accepted, unchanged posture,
+never a general env-var ban. Also denies clearing a registered seam with no
+assignment word: `env -u NAME`/`--unset NAME`/`--unset=NAME` (same segment,
+via `env`'s option grammar) and, cross-segment by design, an in-shell `unset
+NAME` or `export -n NAME` anywhere earlier in the payload — carried forward
+to every LATER segment only, never denying the invoked-program token itself
+(HIMMEL-2927). Known residual (accepted, unchanged posture,
 HIMMEL-912): deliberately case-varied paths/vars, a path assembled from
 shell variables, PowerShell-native `$env:` syntax, `sudo`/`xargs`/`find
 -exec` wrappers, and string reconstruction deeper than the bounded

--- a/scripts/hooks/block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/block-chokepoint-env-prefix.sh
@@ -967,24 +967,36 @@ scan_segment() {
                 # UNSET_NAMES back in before each scan_segment call) --
                 # `unset` is a shell builtin, never itself a chokepoint.
                 #
-                # codex-1 (pr-check round 2): `-f` targets a FUNCTION, never
-                # a variable -- alone, `unset -f NAME` leaves NAME's
+                # codex-1 (pr-check round 2/3): `-f` targets a FUNCTION,
+                # never a variable -- alone, `unset -f NAME` leaves NAME's
                 # variable/environment state untouched; combined with -v (or
                 # given as a separate word alongside -v) bash refuses
                 # ("cannot simultaneously unset...") and touches nothing
-                # either (verified on real bash). A `-f` anywhere among this
-                # invocation's options therefore means no variable is
-                # cleared: fold no names forward.
+                # either (verified on real bash). Only a LEADING `-f`
+                # counts, though: bash's own option parsing stops at the
+                # first non-option word or at `--`, so a trailing `-f` is
+                # just a literal NAME to (fail to) unset, not a flag --
+                # `unset -- HIMMEL_CONSOLE_LEG -f` and
+                # `unset HIMMEL_CONSOLE_LEG -f` both still clear
+                # HIMMEL_CONSOLE_LEG (verified). Scanning the WHOLE word
+                # list for `f` (an earlier fix did this) wrongly skipped
+                # exactly that clear.
                 k=$((j + 1))
                 saw_f=0
                 while [ "$k" -lt "$nw" ]; do
                     case "${W[$k]}" in
-                    -*) case "${W[$k]#-}" in *f*) saw_f=1 ;; esac ;;
+                    --) k=$((k + 1)); break ;;
+                    -*)
+                        opt="${W[$k]#-}"
+                        case "$opt" in
+                        *[!fvn]*) break ;;
+                        esac
+                        case "$opt" in *f*) saw_f=1 ;; esac
+                        k=$((k + 1)) ;;
+                    *) break ;;
                     esac
-                    k=$((k + 1))
                 done
                 if [ "$saw_f" = 0 ]; then
-                    k=$((j + 1))
                     while [ "$k" -lt "$nw" ]; do
                         case "${W[$k]}" in
                         -*) ;;

--- a/scripts/hooks/block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/block-chokepoint-env-prefix.sh
@@ -94,6 +94,33 @@
 # misreading the verdict as the operand. No stage can drop or invent
 # a word again without breaking the encoding visibly.
 #
+# HIMMEL-2927 (the unassigned-clear class): `env -u NAME` / `env --unset
+# NAME` / `env --unset=NAME` clear a registered seam with no assignment
+# word, and an in-shell `unset NAME` / `export -n NAME` clears it with no
+# assignment word EITHER, from a DIFFERENT segment than the chokepoint's --
+# both defeat the INVARIANT's "assignment word" test above while producing
+# the exact same effect an env-prefixed VAR=x is denied for. This does not
+# loosen the INVARIANT; it names two more ways a segment's seam state can
+# change, both still resolved against the SAME registered-name set the
+# INVARIANT already checks:
+#   - inside `env`'s option state, `-u`/`--unset`'s operand (attached,
+#     "=", or the next word -- the same operand-class grammar HIMMEL-1803
+#     derives every other env option from) is added to that SEGMENT's
+#     names exactly like a leading assignment word would be -- still SAME
+#     SEGMENT, still gated on `env` being a recognized wrapper.
+#   - `unset NAME` / `export -n NAME`, as a segment's own invoked-program
+#     token, is NOT itself checked against the registry (neither is a
+#     chokepoint path); instead its argument names are recorded and carried
+#     to every LATER segment of the SAME top-level payload's scan_text
+#     walk (never earlier ones -- shell execution order is left to right,
+#     so an unset cannot retroactively clear a segment already run) --
+#     deliberately cross-segment, because unsetting/un-exporting a shell
+#     variable IS a cross-segment effect in the shell itself. Both paths
+#     still gate the deny on check_invocation's membership test against
+#     the matched chokepoint's OWN registered seam list, so a name that is
+#     not a registered seam of anything changes nothing (over-match stays
+#     closed the same way the assignment form closes it).
+#
 # The round-2 '(' carve-out is CLOSED: an unquoted '(' / ')' / backtick
 # (and `$(` / backtick inside double quotes) opens a fresh command
 # position via segmentation, so subshell, $(...), and backtick-wrapped
@@ -461,6 +488,13 @@ deny() {  # deny <script-path> <var-name> -- both from OUR registry, never
 CR=$'\r'
 NL=$'\n'
 
+# HIMMEL-2927: names cleared by an in-shell `unset` or `export -n` seen so
+# far -- accumulates left-to-right across the whole payload, carried to
+# every LATER segment (see scan_text's fold and scan_segment's `unset`/
+# `export` case). `env -u`/`--unset` is scoped to that ONE invocation's
+# child instead -- it feeds the segment-local `names`, not this global.
+UNSET_NAMES=''
+
 # check_invocation <invoked-program word> <assignment-name list> -- the
 # invariant's deny point, and the registry's ONLY reader. Deny iff the
 # invoked-program token IS a registered chokepoint path (exact, or
@@ -530,7 +564,16 @@ env_short_cluster() {
         c=${word:i:1}
         case "$c" in
         i|0|v) i=$((i + 1)); continue ;;
-        u|C|P|a)
+        u)
+            # HIMMEL-2927: same operand shape as C|P|a below, but the
+            # caller records the operand as a candidate seam name.
+            if [ $((i + 1)) -lt "$n" ]; then
+                printf 'unset-attached\n%s\n' "${word:$((i + 1))}"
+            else
+                printf 'unset-next\n\n'
+            fi
+            return 0 ;;
+        C|P|a)
             if [ $((i + 1)) -lt "$n" ]; then
                 printf 'arg-attached\n\n'
             else
@@ -573,9 +616,15 @@ env_short_cluster() {
 #   flag   -- consumes nothing (-i/--ignore-environment, -0/--null,
 #             -v/--debug, --list-signal-handling, --help, --version).
 #   arg    -- mandatory operand, separate word or "--name=VAL" attached:
-#             DATA for the scan to step over (a var to unset, a dir, an
-#             argv[0], an alternate path) -- never command position
-#             (-u/--unset, -C/--chdir, --argv0).
+#             DATA for the scan to step over (a dir, an argv[0], an
+#             alternate path) -- never command position (-C/--chdir,
+#             --argv0).
+#   unset  -- mandatory operand, same shape as `arg` (separate word or
+#             "--name=VAL" attached), but the operand is also a candidate
+#             SEAM NAME (HIMMEL-2927): `env -u`/`--unset` clears it with no
+#             assignment word, the same effect an env-prefixed VAR=x is
+#             denied for -- so its operand is added to the segment's names
+#             like a leading assignment word would be (-u/--unset).
 #   optarg -- optional operand, "=" spelling ONLY (GNU getopt: an
 #             optional long-option argument cannot be a separate word;
 #             the next word stays an operand/command word)
@@ -590,7 +639,7 @@ ENV_LONG_OPTS='
 ignore-environment|flag
 null|flag
 debug|flag
-unset|arg
+unset|unset
 chdir|arg
 argv0|arg
 block-signal|optarg
@@ -664,6 +713,12 @@ EOF
         if [ "$hasval" = "1" ]; then printf 'consume-attached\n\n'
         elif [ "$cls" = "arg" ]; then printf 'consume-next\n\n'
         else printf 'flag\n\n'; fi ;;
+    unset)
+        # HIMMEL-2927: same operand shape as `arg`, but the caller records
+        # the operand as a candidate seam name (env -u/--unset clears it
+        # with no assignment word).
+        if [ "$hasval" = "1" ]; then printf 'unset-attached\n%s\n' "$val"
+        else printf 'unset-next\n\n'; fi ;;
     split)
         if [ "$hasval" = "1" ]; then printf 'split-attached\n%s\n' "$val"
         else printf 'split-next\n\n'; fi ;;
@@ -791,6 +846,18 @@ scan_segment() {
                     flag)             j=$((j + 1)); continue ;;
                     consume-next)     j=$((j + 2)); continue ;;
                     consume-attached) j=$((j + 1)); continue ;;
+                    unset-attached)
+                        # HIMMEL-2927: `--unset=NAME` clears NAME for THIS
+                        # env invocation's own command -- same segment,
+                        # recorded like a leading assignment word.
+                        names="$names $lo_operand"
+                        j=$((j + 1)); continue ;;
+                    unset-next)
+                        # HIMMEL-2927: `--unset NAME` (separate operand).
+                        if [ $((j + 1)) -lt "$nw" ]; then
+                            names="$names ${W[$((j + 1))]}"
+                        fi
+                        j=$((j + 2)); continue ;;
                     split-next)
                         j=$((j + 1))
                         [ "$j" -lt "$nw" ] || return 0
@@ -831,6 +898,17 @@ scan_segment() {
                     esac
                     case "$cluster_verdict" in
                     arg-next) j=$((j + 2)); continue ;;
+                    unset-attached)
+                        # HIMMEL-2927: attached `-uNAME` clears NAME for
+                        # THIS env invocation's own command -- same segment.
+                        names="$names $cluster_operand"
+                        j=$((j + 1)); continue ;;
+                    unset-next)
+                        # HIMMEL-2927: separate `-u NAME` (or mid-cluster).
+                        if [ $((j + 1)) -lt "$nw" ]; then
+                            names="$names ${W[$((j + 1))]}"
+                        fi
+                        j=$((j + 2)); continue ;;
                     split-attached)
                         rest=''
                         k=$((j + 1))
@@ -883,6 +961,38 @@ scan_segment() {
                 # Grouping/keyword openers start a fresh simple command:
                 # assignments after them DO lead it.
                 asg_ok=1; j=$((j + 1)); continue ;;
+            unset)
+                # HIMMEL-2927: `unset NAME [NAME...]` clears NAME for every
+                # LATER segment of this payload (scan_text folds
+                # UNSET_NAMES back in before each scan_segment call) --
+                # `unset` is a shell builtin, never itself a chokepoint.
+                k=$((j + 1))
+                while [ "$k" -lt "$nw" ]; do
+                    case "${W[$k]}" in
+                    -*) ;;
+                    *) UNSET_NAMES="$UNSET_NAMES ${W[$k]}" ;;
+                    esac
+                    k=$((k + 1))
+                done
+                return 0 ;;
+            export)
+                # HIMMEL-2927: `export -n NAME` strips NAME's export
+                # attribute -- it no longer reaches a later chokepoint's
+                # environment. Plain `export NAME[=val]` (no -n) still
+                # exports; leave that shape alone.
+                k=$((j + 1))
+                if [ "$k" -lt "$nw" ] && [ "${W[$k]}" = "-n" ]; then
+                    k=$((k + 1))
+                    while [ "$k" -lt "$nw" ]; do
+                        case "${W[$k]}" in
+                        -*) ;;
+                        *) UNSET_NAMES="$UNSET_NAMES ${W[$k]%%=*}" ;;
+                        esac
+                        k=$((k + 1))
+                    done
+                    return 0
+                fi
+                ;;
             esac
             # The invoked-program token of this segment. Words beyond it
             # are arguments and never match (the finding-4 direction).
@@ -902,7 +1012,11 @@ scan_text() {
     [ "$depth" -le 5 ] || return 0
     while IFS= read -r seg; do
         [[ $seg =~ [^[:space:]] ]] || continue
-        scan_segment "$seg" "$inames" "$depth"
+        # HIMMEL-2927: an in-shell `unset`/`export -n` or an `env -u`/
+        # `--unset` in an EARLIER segment clears a name for every LATER
+        # segment in this same payload -- fold the accumulator in fresh
+        # each iteration so it reflects only what ran before this segment.
+        scan_segment "$seg" "$inames $UNSET_NAMES" "$depth"
     done <<<"$(segment_cmd "$text")"
     return 0
 }

--- a/scripts/hooks/block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/block-chokepoint-env-prefix.sh
@@ -121,6 +121,21 @@
 #     not a registered seam of anything changes nothing (over-match stays
 #     closed the same way the assignment form closes it).
 #
+# `unset`/`export -n`'s OWN option scanning (scan_segment's `unset)` and
+# `export)` arms) went through three CR rounds each finding the next edge
+# a bash-option-VALIDITY model missed (-fn, the -f leading/trailing
+# boundary, `--`, `-x`) -- round 5's ruling stopped modelling validity at
+# all: for `unset`, or an `export` carrying `-n` anywhere in its leading
+# run of option-shaped words (`--` and combined forms included), every
+# remaining word that does not start with `-` is a candidate name, full
+# stop -- no charset check, no leading-vs-trailing distinction, no
+# invalid-option branch. This is DELIBERATELY fail-closed rather than
+# fail-open: an invalid invocation (`unset -x NAME`) is denied too
+# (documented over-deny -- real bash would refuse it and touch nothing
+# anyway, so denying it here costs nothing and removes a parser this
+# guard has no business re-implementing). Over-deny is the safe direction
+# for a guard; a false ALLOW is the defect class this ticket exists for.
+#
 # The round-2 '(' carve-out is CLOSED: an unquoted '(' / ')' / backtick
 # (and `$(` / backtick inside double quotes) opens a fresh command
 # position via segmentation, so subshell, $(...), and backtick-wrapped
@@ -962,105 +977,57 @@ scan_segment() {
                 # assignments after them DO lead it.
                 asg_ok=1; j=$((j + 1)); continue ;;
             unset)
-                # HIMMEL-2927: `unset NAME [NAME...]` clears NAME for every
-                # LATER segment of this payload (scan_text folds
-                # UNSET_NAMES back in before each scan_segment call) --
-                # `unset` is a shell builtin, never itself a chokepoint.
-                #
-                # codex-1 (pr-check round 2/3): `-f` targets a FUNCTION,
-                # never a variable -- alone, `unset -f NAME` leaves NAME's
-                # variable/environment state untouched; combined with -v (or
-                # given as a separate word alongside -v) bash refuses
-                # ("cannot simultaneously unset...") and touches nothing
-                # either (verified on real bash). Only a LEADING `-f`
-                # counts, though: bash's own option parsing stops at the
-                # first non-option word or at `--`, so a trailing `-f` is
-                # just a literal NAME to (fail to) unset, not a flag --
-                # `unset -- HIMMEL_CONSOLE_LEG -f` and
-                # `unset HIMMEL_CONSOLE_LEG -f` both still clear
-                # HIMMEL_CONSOLE_LEG (verified). Scanning the WHOLE word
-                # list for `f` (an earlier fix did this) wrongly skipped
-                # exactly that clear.
-                #
-                # coderabbitai (real review, PR #635): bash validates ALL
-                # options before acting on any of them -- an invalid option
-                # (anything outside -f/-v/-n, e.g. `unset -x NAME`) makes
-                # bash refuse the WHOLE invocation and touch nothing
-                # (verified: NAME stays set). The option-scan loop already
-                # `break`s on that word, but the operand loop below used to
-                # run anyway from that same `k`, still recording later bare
-                # words into UNSET_NAMES -- an over-denial. `invalid_opt`
-                # tracks that case so the operand loop is skipped entirely.
+                # HIMMEL-2927 (ruling, pr-check round 5): FAIL-CLOSED by
+                # construction, not by modelling unset's option grammar --
+                # three rounds each found the next edge a validity model
+                # missed (-fn, -f -n boundary, `--`, `-x`), so this stops
+                # re-implementing bash's option parser. Every remaining word
+                # that does NOT start with `-` is a candidate name; a word
+                # that starts with `-` (a bare `--` included) is skipped as
+                # option-shaped and nothing else about it is inspected --
+                # no charset check, no leading-vs-trailing boundary, no
+                # invalid-option branch. This also denies an INVALID
+                # invocation (`unset -x NAME`) -- a documented over-deny:
+                # real bash would refuse that invocation and touch nothing,
+                # so denying it here costs nothing and removes a whole class
+                # of parser edge to get wrong (over-deny is the safe
+                # direction for a guard; a false ALLOW is the defect class
+                # this ticket exists for).
                 k=$((j + 1))
-                saw_f=0
-                invalid_opt=0
                 while [ "$k" -lt "$nw" ]; do
                     case "${W[$k]}" in
-                    --) k=$((k + 1)); break ;;
-                    -*)
-                        opt="${W[$k]#-}"
-                        case "$opt" in
-                        *[!fvn]*) invalid_opt=1; break ;;
-                        esac
-                        case "$opt" in *f*) saw_f=1 ;; esac
-                        k=$((k + 1)) ;;
-                    *) break ;;
+                    -*) ;;
+                    *) UNSET_NAMES="$UNSET_NAMES ${W[$k]}" ;;
                     esac
+                    k=$((k + 1))
                 done
-                if [ "$invalid_opt" = 0 ] && [ "$saw_f" = 0 ]; then
-                    while [ "$k" -lt "$nw" ]; do
-                        case "${W[$k]}" in
-                        -*) ;;
-                        *) UNSET_NAMES="$UNSET_NAMES ${W[$k]}" ;;
-                        esac
-                        k=$((k + 1))
-                    done
-                fi
                 return 0 ;;
             export)
-                # HIMMEL-2927: `export -n NAME` strips NAME's export
-                # attribute -- it no longer reaches a later chokepoint's
-                # environment. Plain `export NAME[=val]` (no -n) still
-                # exports; leave that shape alone. bash's export flags are
-                # exactly -f/-n/-p, combinable and order-independent
-                # (`-np`, `-pn` genuinely strip -n's effect -- verified on
-                # bash), so a cluster is recognized by its CHARACTER SET,
-                # not by an exact "-n" match; a word outside that set is an
-                # unrecognized/invalid option and is left alone per this
-                # guard's fail-open posture (real bash errors on it rather
-                # than stripping anything).
-                #
-                # codex-1 (pr-check round 2): `-f` requires the target to be
-                # a FUNCTION -- combined with `-n` (same word, e.g. `-fn`,
-                # or a separate word, e.g. `-f -n`) real bash errors
-                # ("not a function") on a plain variable and strips
-                # nothing, same as `-f` alone (verified). So `-n` only
-                # strips when NO word in this invocation's options carried
-                # an `f`.
-                #
-                # coderabbitai (real review, PR #635): same validate-then-
-                # execute rule as `unset` above -- `export -n -x NAME`
-                # errors on the invalid `-x` and never strips NAME's export
-                # attribute (verified). `invalid_opt` skips the operand
-                # loop in that case instead of still recording NAME.
+                # HIMMEL-2927 (ruling, pr-check round 5): same fail-closed
+                # simplification as `unset` above. If this export segment
+                # carries `-n` ANYWHERE in its leading run of option-shaped
+                # words (every word starting with `-`, `--` included,
+                # combined forms included, up to the first word that does
+                # NOT start with `-`), then every remaining word that does
+                # not start with `-` is a candidate name -- full stop, no
+                # charset check, no invalid-option branch. An invalid
+                # cluster (`export -n -x NAME`) is denied too, same
+                # documented over-deny posture. Plain `export NAME[=val]`
+                # (no `-n` anywhere in the leading cluster) is left alone --
+                # that shape still exports; falls through to the unchanged
+                # assignment path below.
                 k=$((j + 1))
                 saw_n=0
-                saw_f=0
-                invalid_opt=0
-                while [ "$k" -lt "$nw" ]; do
-                    case "${W[$k]}" in
+                m=$k
+                while [ "$m" -lt "$nw" ]; do
+                    case "${W[$m]}" in
                     -*)
-                        opt="${W[$k]#-}"
-                        case "$opt" in
-                        *[!fnp]*) invalid_opt=1; break ;;
-                        esac
-                        case "$opt" in *f*) saw_f=1 ;; esac
-                        case "$opt" in *n*) saw_n=1 ;; esac
-                        k=$((k + 1)) ;;
+                        case "${W[$m]#-}" in *n*) saw_n=1 ;; esac
+                        m=$((m + 1)) ;;
                     *) break ;;
                     esac
                 done
-                if [ "$invalid_opt" = 0 ] && [ "$saw_n" = 1 ] && [ "$saw_f" = 0 ]; then
+                if [ "$saw_n" = 1 ]; then
                     while [ "$k" -lt "$nw" ]; do
                         case "${W[$k]}" in
                         -*) ;;

--- a/scripts/hooks/block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/block-chokepoint-env-prefix.sh
@@ -966,14 +966,33 @@ scan_segment() {
                 # LATER segment of this payload (scan_text folds
                 # UNSET_NAMES back in before each scan_segment call) --
                 # `unset` is a shell builtin, never itself a chokepoint.
+                #
+                # codex-1 (pr-check round 2): `-f` targets a FUNCTION, never
+                # a variable -- alone, `unset -f NAME` leaves NAME's
+                # variable/environment state untouched; combined with -v (or
+                # given as a separate word alongside -v) bash refuses
+                # ("cannot simultaneously unset...") and touches nothing
+                # either (verified on real bash). A `-f` anywhere among this
+                # invocation's options therefore means no variable is
+                # cleared: fold no names forward.
                 k=$((j + 1))
+                saw_f=0
                 while [ "$k" -lt "$nw" ]; do
                     case "${W[$k]}" in
-                    -*) ;;
-                    *) UNSET_NAMES="$UNSET_NAMES ${W[$k]}" ;;
+                    -*) case "${W[$k]#-}" in *f*) saw_f=1 ;; esac ;;
                     esac
                     k=$((k + 1))
                 done
+                if [ "$saw_f" = 0 ]; then
+                    k=$((j + 1))
+                    while [ "$k" -lt "$nw" ]; do
+                        case "${W[$k]}" in
+                        -*) ;;
+                        *) UNSET_NAMES="$UNSET_NAMES ${W[$k]}" ;;
+                        esac
+                        k=$((k + 1))
+                    done
+                fi
                 return 0 ;;
             export)
                 # HIMMEL-2927: `export -n NAME` strips NAME's export
@@ -981,27 +1000,37 @@ scan_segment() {
                 # environment. Plain `export NAME[=val]` (no -n) still
                 # exports; leave that shape alone. bash's export flags are
                 # exactly -f/-n/-p, combinable and order-independent
-                # (`-np`, `-pn`, `-fn` all genuinely strip -n's effect --
-                # verified on bash), so a cluster is recognized by its
-                # CHARACTER SET, not by an exact "-n" match; a word outside
-                # that set is an unrecognized/invalid option and is left
-                # alone per this guard's fail-open posture (real bash
-                # errors on it rather than stripping anything).
+                # (`-np`, `-pn` genuinely strip -n's effect -- verified on
+                # bash), so a cluster is recognized by its CHARACTER SET,
+                # not by an exact "-n" match; a word outside that set is an
+                # unrecognized/invalid option and is left alone per this
+                # guard's fail-open posture (real bash errors on it rather
+                # than stripping anything).
+                #
+                # codex-1 (pr-check round 2): `-f` requires the target to be
+                # a FUNCTION -- combined with `-n` (same word, e.g. `-fn`,
+                # or a separate word, e.g. `-f -n`) real bash errors
+                # ("not a function") on a plain variable and strips
+                # nothing, same as `-f` alone (verified). So `-n` only
+                # strips when NO word in this invocation's options carried
+                # an `f`.
                 k=$((j + 1))
                 saw_n=0
+                saw_f=0
                 while [ "$k" -lt "$nw" ]; do
                     case "${W[$k]}" in
                     -*)
                         opt="${W[$k]#-}"
                         case "$opt" in
                         *[!fnp]*) break ;;
-                        *n*) saw_n=1 ;;
                         esac
+                        case "$opt" in *f*) saw_f=1 ;; esac
+                        case "$opt" in *n*) saw_n=1 ;; esac
                         k=$((k + 1)) ;;
                     *) break ;;
                     esac
                 done
-                if [ "$saw_n" = 1 ]; then
+                if [ "$saw_n" = 1 ] && [ "$saw_f" = 0 ]; then
                     while [ "$k" -lt "$nw" ]; do
                         case "${W[$k]}" in
                         -*) ;;

--- a/scripts/hooks/block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/block-chokepoint-env-prefix.sh
@@ -979,10 +979,29 @@ scan_segment() {
                 # HIMMEL-2927: `export -n NAME` strips NAME's export
                 # attribute -- it no longer reaches a later chokepoint's
                 # environment. Plain `export NAME[=val]` (no -n) still
-                # exports; leave that shape alone.
+                # exports; leave that shape alone. bash's export flags are
+                # exactly -f/-n/-p, combinable and order-independent
+                # (`-np`, `-pn`, `-fn` all genuinely strip -n's effect --
+                # verified on bash), so a cluster is recognized by its
+                # CHARACTER SET, not by an exact "-n" match; a word outside
+                # that set is an unrecognized/invalid option and is left
+                # alone per this guard's fail-open posture (real bash
+                # errors on it rather than stripping anything).
                 k=$((j + 1))
-                if [ "$k" -lt "$nw" ] && [ "${W[$k]}" = "-n" ]; then
-                    k=$((k + 1))
+                saw_n=0
+                while [ "$k" -lt "$nw" ]; do
+                    case "${W[$k]}" in
+                    -*)
+                        opt="${W[$k]#-}"
+                        case "$opt" in
+                        *[!fnp]*) break ;;
+                        *n*) saw_n=1 ;;
+                        esac
+                        k=$((k + 1)) ;;
+                    *) break ;;
+                    esac
+                done
+                if [ "$saw_n" = 1 ]; then
                     while [ "$k" -lt "$nw" ]; do
                         case "${W[$k]}" in
                         -*) ;;

--- a/scripts/hooks/block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/block-chokepoint-env-prefix.sh
@@ -981,22 +981,33 @@ scan_segment() {
                 # HIMMEL_CONSOLE_LEG (verified). Scanning the WHOLE word
                 # list for `f` (an earlier fix did this) wrongly skipped
                 # exactly that clear.
+                #
+                # coderabbitai (real review, PR #635): bash validates ALL
+                # options before acting on any of them -- an invalid option
+                # (anything outside -f/-v/-n, e.g. `unset -x NAME`) makes
+                # bash refuse the WHOLE invocation and touch nothing
+                # (verified: NAME stays set). The option-scan loop already
+                # `break`s on that word, but the operand loop below used to
+                # run anyway from that same `k`, still recording later bare
+                # words into UNSET_NAMES -- an over-denial. `invalid_opt`
+                # tracks that case so the operand loop is skipped entirely.
                 k=$((j + 1))
                 saw_f=0
+                invalid_opt=0
                 while [ "$k" -lt "$nw" ]; do
                     case "${W[$k]}" in
                     --) k=$((k + 1)); break ;;
                     -*)
                         opt="${W[$k]#-}"
                         case "$opt" in
-                        *[!fvn]*) break ;;
+                        *[!fvn]*) invalid_opt=1; break ;;
                         esac
                         case "$opt" in *f*) saw_f=1 ;; esac
                         k=$((k + 1)) ;;
                     *) break ;;
                     esac
                 done
-                if [ "$saw_f" = 0 ]; then
+                if [ "$invalid_opt" = 0 ] && [ "$saw_f" = 0 ]; then
                     while [ "$k" -lt "$nw" ]; do
                         case "${W[$k]}" in
                         -*) ;;
@@ -1026,15 +1037,22 @@ scan_segment() {
                 # nothing, same as `-f` alone (verified). So `-n` only
                 # strips when NO word in this invocation's options carried
                 # an `f`.
+                #
+                # coderabbitai (real review, PR #635): same validate-then-
+                # execute rule as `unset` above -- `export -n -x NAME`
+                # errors on the invalid `-x` and never strips NAME's export
+                # attribute (verified). `invalid_opt` skips the operand
+                # loop in that case instead of still recording NAME.
                 k=$((j + 1))
                 saw_n=0
                 saw_f=0
+                invalid_opt=0
                 while [ "$k" -lt "$nw" ]; do
                     case "${W[$k]}" in
                     -*)
                         opt="${W[$k]#-}"
                         case "$opt" in
-                        *[!fnp]*) break ;;
+                        *[!fnp]*) invalid_opt=1; break ;;
                         esac
                         case "$opt" in *f*) saw_f=1 ;; esac
                         case "$opt" in *n*) saw_n=1 ;; esac
@@ -1042,7 +1060,7 @@ scan_segment() {
                     *) break ;;
                     esac
                 done
-                if [ "$saw_n" = 1 ] && [ "$saw_f" = 0 ]; then
+                if [ "$invalid_opt" = 0 ] && [ "$saw_n" = 1 ] && [ "$saw_f" = 0 ]; then
                     while [ "$k" -lt "$nw" ]; do
                         case "${W[$k]}" in
                         -*) ;;

--- a/scripts/hooks/test-block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/test-block-chokepoint-env-prefix.sh
@@ -146,36 +146,40 @@ assert_deny "export -pn (reordered cluster); then the chokepoint" "$(j "export -
 assert_allow "env -u UNREGISTERED name stays allowed"             "$(j "env -u SOME_OTHER_VAR bash $MERGE_ON_GREEN 1")"
 assert_allow "unset with no chokepoint in the payload"            "$(j "unset HIMMEL_CONSOLE_LEG; echo hi")"
 assert_allow "env -u registered name, non-chokepoint program"     "$(j "env -u HIMMEL_CONSOLE_LEG bash scripts/some/unregistered-script.sh")"
-# codex-1 control: an invalid export flag (real bash errors, strips
-# nothing) must NOT be treated as -n -- fail-open on the unrecognized
-# shape, per this guard's documented posture.
-assert_allow "export -nx (invalid flag) stays allowed"            "$(j "export -nx HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
-# codex-1 (pr-check round 2): `-f` requires the target to be a FUNCTION --
-# `unset -f NAME` on a variable-only NAME touches nothing, and `export -fn`/
-# `-nf`/`-f -n` errors ("not a function") on a plain variable and strips
-# nothing either (verified on real bash), same as `-f` alone. Both must stay
-# allowed: the guard must not treat a function-only op as clearing a
-# variable's environment state.
-assert_allow "unset -f (function-only) stays allowed"             "$(j "unset -f HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
-assert_allow "export -fn (combined with -f) stays allowed"        "$(j "export -fn HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
-assert_allow "export -nf (reordered, combined with -f) allowed"   "$(j "export -nf HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
-assert_allow "export -f -n (separate words) stays allowed"        "$(j "export -f -n HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
-# codex-1 (pr-check round 3): bash's option parsing for `unset` stops at the
-# first non-option word or at `--` -- a `-f` AFTER that boundary is a
-# literal NAME, not a flag, so the seam still gets cleared and must still
-# be denied. An earlier fix scanned the whole payload for `f` and wrongly
-# allowed these (verified on real bash: both still unset the name).
-assert_deny "unset -- NAME -f (trailing -f is a name, not a flag)" "$(j "unset -- HIMMEL_CONSOLE_LEG -f; bash $MERGE_ON_GREEN 1")"
-assert_deny "unset NAME -f (no --, trailing -f is still a name)"  "$(j "unset HIMMEL_CONSOLE_LEG -f; bash $MERGE_ON_GREEN 1")"
+assert_allow "export NAME=1 (no -n): unchanged assignment path"  "$(j "export HIMMEL_CONSOLE_LEG=1; bash $MERGE_ON_GREEN 1")"
 
-# coderabbitai (real review, PR #635): bash validates ALL options before
-# acting on any -- an invalid option (outside -f/-v/-n for unset, -f/-n/-p
-# for export) makes bash refuse the WHOLE invocation and touch nothing
-# (verified on real bash: NAME stays set/exported). The option-scan loop
-# breaks on the invalid word, but the operand loop used to run anyway from
-# that same position and still record a later bare NAME -- an over-denial.
-assert_allow "unset -x NAME (invalid option aborts, NAME untouched)"      "$(j "unset -x HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
-assert_allow "export -n -x NAME (invalid option aborts, export intact)"  "$(j "export -n -x HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+# HIMMEL-2927 ruling (pr-check round 5): unset/export option-VALIDITY
+# modelling is GONE. Three CR rounds each found the next edge a validity
+# model missed (-fn, the -f leading/trailing boundary, `--`, `-x`), and
+# round 5 surfaced a genuine BYPASS in the validity model itself
+# (`export -n -- NAME` -- real bash treats `--` as ending option parsing
+# and still strips NAME's export attribute, but a validity-charset model
+# read the bare `--` as an invalid option and skipped recording the
+# clear). The ruling: stop re-implementing bash's option parser. For
+# `unset`, or an `export` carrying `-n` anywhere in its leading run of
+# option-shaped words (`--` and combined forms included), EVERY remaining
+# word that does not start with `-` is a candidate name, full stop -- no
+# charset check, no leading-vs-trailing distinction, no invalid-option
+# branch. Consequence, deliberate: several shapes previously modelled
+# (correctly, at the time) as ALLOWED now DENY too -- documented
+# over-deny, since real bash would refuse or no-op these invocations
+# anyway, so denying them here costs nothing and removes a parser this
+# guard has no business re-implementing. Over-deny is the safe direction
+# for a guard; a false ALLOW (codex-1's `export -n -- NAME` finding) is
+# the defect class this ticket exists for.
+assert_deny "export -n -- NAME (-- ends options; the leading -n still carries -- codex-1's bypass)" "$(j "export -n -- HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+assert_deny "export -nx (unrecognized flag; the leading -n still carries)" "$(j "export -nx HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+assert_deny "unset -f (documented over-deny -- bash would touch nothing)" "$(j "unset -f HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+assert_deny "export -fn (documented over-deny -- bash errors, strips nothing)" "$(j "export -fn HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+assert_deny "export -nf (documented over-deny, reordered)"        "$(j "export -nf HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+assert_deny "export -f -n (documented over-deny, separate words)" "$(j "export -f -n HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+# The simplified scanner does not track any leading-vs-trailing boundary
+# either -- every non-option word anywhere after `unset` is a candidate,
+# so both readings of these already denied (unaffected by the ruling).
+assert_deny "unset -- NAME -f (both readings still clear the seam)" "$(j "unset -- HIMMEL_CONSOLE_LEG -f; bash $MERGE_ON_GREEN 1")"
+assert_deny "unset NAME -f (both readings still clear the seam)"    "$(j "unset HIMMEL_CONSOLE_LEG -f; bash $MERGE_ON_GREEN 1")"
+assert_deny "unset -x NAME (documented over-deny -- bash refuses, touches nothing)" "$(j "unset -x HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+assert_deny "export -n -x NAME (documented over-deny -- bash refuses, touches nothing)" "$(j "export -n -x HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
 
 # --- CR ROUND 1 (HIMMEL-1746): the env-prefix must bind to the chokepoint's
 # OWN command segment. The pre-fix predicate tested "path found anywhere"

--- a/scripts/hooks/test-block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/test-block-chokepoint-env-prefix.sh
@@ -150,6 +150,16 @@ assert_allow "env -u registered name, non-chokepoint program"     "$(j "env -u H
 # nothing) must NOT be treated as -n -- fail-open on the unrecognized
 # shape, per this guard's documented posture.
 assert_allow "export -nx (invalid flag) stays allowed"            "$(j "export -nx HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+# codex-1 (pr-check round 2): `-f` requires the target to be a FUNCTION --
+# `unset -f NAME` on a variable-only NAME touches nothing, and `export -fn`/
+# `-nf`/`-f -n` errors ("not a function") on a plain variable and strips
+# nothing either (verified on real bash), same as `-f` alone. Both must stay
+# allowed: the guard must not treat a function-only op as clearing a
+# variable's environment state.
+assert_allow "unset -f (function-only) stays allowed"             "$(j "unset -f HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+assert_allow "export -fn (combined with -f) stays allowed"        "$(j "export -fn HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+assert_allow "export -nf (reordered, combined with -f) allowed"   "$(j "export -nf HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+assert_allow "export -f -n (separate words) stays allowed"        "$(j "export -f -n HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
 
 # --- CR ROUND 1 (HIMMEL-1746): the env-prefix must bind to the chokepoint's
 # OWN command segment. The pre-fix predicate tested "path found anywhere"

--- a/scripts/hooks/test-block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/test-block-chokepoint-env-prefix.sh
@@ -168,6 +168,15 @@ assert_allow "export -f -n (separate words) stays allowed"        "$(j "export -
 assert_deny "unset -- NAME -f (trailing -f is a name, not a flag)" "$(j "unset -- HIMMEL_CONSOLE_LEG -f; bash $MERGE_ON_GREEN 1")"
 assert_deny "unset NAME -f (no --, trailing -f is still a name)"  "$(j "unset HIMMEL_CONSOLE_LEG -f; bash $MERGE_ON_GREEN 1")"
 
+# coderabbitai (real review, PR #635): bash validates ALL options before
+# acting on any -- an invalid option (outside -f/-v/-n for unset, -f/-n/-p
+# for export) makes bash refuse the WHOLE invocation and touch nothing
+# (verified on real bash: NAME stays set/exported). The option-scan loop
+# breaks on the invalid word, but the operand loop used to run anyway from
+# that same position and still record a later bare NAME -- an over-denial.
+assert_allow "unset -x NAME (invalid option aborts, NAME untouched)"      "$(j "unset -x HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+assert_allow "export -n -x NAME (invalid option aborts, export intact)"  "$(j "export -n -x HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+
 # --- CR ROUND 1 (HIMMEL-1746): the env-prefix must bind to the chokepoint's
 # OWN command segment. The pre-fix predicate tested "path found anywhere"
 # AND "assignment found anywhere" over the whole compound, which false-denied

--- a/scripts/hooks/test-block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/test-block-chokepoint-env-prefix.sh
@@ -160,6 +160,13 @@ assert_allow "unset -f (function-only) stays allowed"             "$(j "unset -f
 assert_allow "export -fn (combined with -f) stays allowed"        "$(j "export -fn HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
 assert_allow "export -nf (reordered, combined with -f) allowed"   "$(j "export -nf HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
 assert_allow "export -f -n (separate words) stays allowed"        "$(j "export -f -n HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+# codex-1 (pr-check round 3): bash's option parsing for `unset` stops at the
+# first non-option word or at `--` -- a `-f` AFTER that boundary is a
+# literal NAME, not a flag, so the seam still gets cleared and must still
+# be denied. An earlier fix scanned the whole payload for `f` and wrongly
+# allowed these (verified on real bash: both still unset the name).
+assert_deny "unset -- NAME -f (trailing -f is a name, not a flag)" "$(j "unset -- HIMMEL_CONSOLE_LEG -f; bash $MERGE_ON_GREEN 1")"
+assert_deny "unset NAME -f (no --, trailing -f is still a name)"  "$(j "unset HIMMEL_CONSOLE_LEG -f; bash $MERGE_ON_GREEN 1")"
 
 # --- CR ROUND 1 (HIMMEL-1746): the env-prefix must bind to the chokepoint's
 # OWN command segment. The pre-fix predicate tested "path found anywhere"

--- a/scripts/hooks/test-block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/test-block-chokepoint-env-prefix.sh
@@ -119,6 +119,28 @@ ${SW_VAR}=9 bash $STOP_WORKER --list")"
 assert_deny "\$CLAUDE_PROJECT_DIR-qualified path"       "$(j "${MOG_VAR}=1 bash \"\$CLAUDE_PROJECT_DIR/$MERGE_ON_GREEN\"")"
 assert_deny "PowerShell tool carrying the same shape"   "$(jp "${MOG_VAR}=1 bash $MERGE_ON_GREEN")"
 
+# --- HIMMEL-2927: `env -u`/`--unset` and an in-shell `unset`/`export -n`
+# clear a registered seam with no assignment word, so the assignment
+# predicate above never fires -- same defect class as VAR=x, inside the
+# registered set. HIMMEL_CONSOLE_LEG is a registered seam of
+# merge-on-green.sh (chokepoints.json) and, since #630, is what makes
+# merge-on-green.sh require the console's GO file -- clearing it unguarded
+# silently disarms the HIMMEL-2919 gate. `unset`/`export -n` are cross-segment
+# by design (the shell effect crosses segments too), so the chokepoint's
+# segment can come later in the same payload. ---
+assert_deny "env -u clears a registered seam"                    "$(j "env -u HIMMEL_CONSOLE_LEG bash $MERGE_ON_GREEN 1")"
+assert_deny "env --unset=NAME clears a registered seam"          "$(j "env --unset=HIMMEL_CONSOLE_LEG bash $MERGE_ON_GREEN 1")"
+assert_deny "env --unset NAME (separate operand) clears a seam"  "$(j "env --unset HIMMEL_CONSOLE_LEG bash $MERGE_ON_GREEN 1")"
+assert_deny "in-shell unset; then the chokepoint"                 "$(j "unset HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+assert_deny "in-shell unset && then the chokepoint"               "$(j "unset HIMMEL_CONSOLE_LEG && bash $MERGE_ON_GREEN 1")"
+assert_deny "export -n; then the chokepoint"                      "$(j "export -n HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+# Over-match controls: these must stay ALLOWED -- the widened predicate is
+# scoped to REGISTERED seam names of a chokepoint actually in the SAME
+# payload, never a general env/unset ban.
+assert_allow "env -u UNREGISTERED name stays allowed"             "$(j "env -u SOME_OTHER_VAR bash $MERGE_ON_GREEN 1")"
+assert_allow "unset with no chokepoint in the payload"            "$(j "unset HIMMEL_CONSOLE_LEG; echo hi")"
+assert_allow "env -u registered name, non-chokepoint program"     "$(j "env -u HIMMEL_CONSOLE_LEG bash scripts/some/unregistered-script.sh")"
+
 # --- CR ROUND 1 (HIMMEL-1746): the env-prefix must bind to the chokepoint's
 # OWN command segment. The pre-fix predicate tested "path found anywhere"
 # AND "assignment found anywhere" over the whole compound, which false-denied

--- a/scripts/hooks/test-block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/test-block-chokepoint-env-prefix.sh
@@ -134,12 +134,22 @@ assert_deny "env --unset NAME (separate operand) clears a seam"  "$(j "env --uns
 assert_deny "in-shell unset; then the chokepoint"                 "$(j "unset HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
 assert_deny "in-shell unset && then the chokepoint"               "$(j "unset HIMMEL_CONSOLE_LEG && bash $MERGE_ON_GREEN 1")"
 assert_deny "export -n; then the chokepoint"                      "$(j "export -n HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+# codex-1 (pr-check round 1): export's flags (-f/-n/-p) combine and
+# reorder freely -- `-np`/`-pn` genuinely strip the export attribute in
+# real bash (verified), same as a bare `-n`, so a combined cluster must
+# be recognized too, not just the exact word "-n".
+assert_deny "export -np (combined cluster); then the chokepoint"  "$(j "export -np HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+assert_deny "export -pn (reordered cluster); then the chokepoint" "$(j "export -pn HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
 # Over-match controls: these must stay ALLOWED -- the widened predicate is
 # scoped to REGISTERED seam names of a chokepoint actually in the SAME
 # payload, never a general env/unset ban.
 assert_allow "env -u UNREGISTERED name stays allowed"             "$(j "env -u SOME_OTHER_VAR bash $MERGE_ON_GREEN 1")"
 assert_allow "unset with no chokepoint in the payload"            "$(j "unset HIMMEL_CONSOLE_LEG; echo hi")"
 assert_allow "env -u registered name, non-chokepoint program"     "$(j "env -u HIMMEL_CONSOLE_LEG bash scripts/some/unregistered-script.sh")"
+# codex-1 control: an invalid export flag (real bash errors, strips
+# nothing) must NOT be treated as -n -- fail-open on the unrecognized
+# shape, per this guard's documented posture.
+assert_allow "export -nx (invalid flag) stays allowed"            "$(j "export -nx HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
 
 # --- CR ROUND 1 (HIMMEL-1746): the env-prefix must bind to the chokepoint's
 # OWN command segment. The pre-fix predicate tested "path found anywhere"


### PR DESCRIPTION
## Summary

`scripts/hooks/block-chokepoint-env-prefix.sh` guards a registered chokepoint seam env var (e.g. `HIMMEL_CONSOLE_LEG`, `merge-on-green.sh`'s GO-file requirement from #630/HIMMEL-2919) against a prefix assignment that clears it (`VAR= cmd`). HIMMEL-2927 reported two unguarded shapes that clear the seam **without** an assignment word at all, disarming the chokepoint before it runs:

- `env -u VAR`/`env --unset VAR` ahead of a chokepoint invocation
- an in-shell `unset VAR` or `export -n VAR` earlier in the same payload

This PR denies all three shapes.

The `unset`/`export` scanner no longer models bash's option-VALIDITY grammar (which flag combinations are legal, `-f` before vs. after the first operand, `--` as an option terminator, etc.). Three review rounds each found the next edge that model missed, and round 5 surfaced a genuine bypass in it: `export -n -- NAME` ends option parsing at `--` and still strips `NAME`'s export attribute on real bash, but the charset-validity scan read the bare `--` as an invalid option and skipped the clear. Per that round's ruling, the scanner is now deliberately crude and fail-closed by construction: for `unset`, or an `export` carrying `-n` anywhere in its leading run of option-shaped words, every remaining word that does not start with `-` is a candidate seam name — no charset check, no leading-vs-trailing distinction, no invalid-option branch. This over-denies a few shapes real bash refuses or no-ops anyway (`unset -f NAME`, `unset -x NAME`, `export -n -x NAME`), which costs nothing since those invocations never touch the seam either way. Over-deny is the safe direction for a guard; a false ALLOW is the defect class this ticket exists for.

## Commits
- `f6e7d8ea` — original 9-case implementation (env -u/--unset, unset, export -n)
- `3e1e534a` — recognize export's combined `-n` option clusters (`-np`/`-pn`/`-fn`)
- `e2f20d1a` — `unset -f`/`export -f` never touch a variable's env state, so they must not clear a seam
- `f9a00904` — `unset`'s `-f` flag only counts before the first operand or `--`, matching bash's own option parsing (fixes the bypass the prior commit introduced)
- `16beaa0c` — reject invalid short-option combinations rather than silently skipping them
- `b7a9e791` — stop modelling `unset`/`export` option validity; fail-closed by construction instead (fixes the `export -n -- NAME` bypass the validity model missed; shrinks the scanner from 110 to 62 lines)

## Cap disposition
This branch ran 6 `/pr-check` rounds against a 3-round cap. Each round through round 5 found a genuine edge in the option-validity model (see commit history above); round 5's ruling replaced that model with the deliberately crude fail-closed version in `b7a9e791`, and round 6 confirmed it: 0 new Critical/Important findings, the diff shrank as predicted, and the only Suggestion is the pre-existing subshell-scope item below, re-deferred to the same ticket. Same path, simplified at the end; HIMMEL-2929 deferred.

## Deferred (out of scope for this PR)
`UNSET_NAMES` folds every observed clear forward into all later payload segments with no subshell-scope awareness, so `(unset HIMMEL_CONSOLE_LEG); bash scripts/merge-on-green.sh 1` is denied even though the subshell's `unset` can't affect the parent shell. This is a false-DENY (safe direction), not a bypass, and a correct fix needs subshell-depth tracking in the hand-rolled tokenizer — tracked as HIMMEL-2929, deferred past this PR's `/pr-check` round cap.

## Test plan
- [x] `bash scripts/hooks/test-block-chokepoint-env-prefix.sh` — 163/163 passing
- [x] `shellcheck` clean on both changed hook files
- [x] `/pr-check` clean at round 6 (deferred finding tracked to HIMMEL-2929)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened enforcement for protected environment variables by blocking attempts to clear them through `env -u`, shell `unset`, and `export -n`.
  - Enforcement now applies consistently across later command segments and supports common option ordering.
  - Unregistered variables, unrelated commands, invalid options, and function-only operations remain unaffected.

- **Documentation**
  - Updated enforcement documentation to describe supported variable-clearing scenarios and their command-segment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
