### PR TITLE
fix(handover): HIMMEL-2889 signal-root digest + HIMMEL-2881 work-dir TOCTOU hardening

### DIFF
--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -398,7 +398,7 @@ _console_dir_component_unsafe() {
     fi
     [ "$sticky" -eq 1 ] || return 0  # writable, no sticky bit: unsafe
     local owner
-    owner=$(stat -c %u "$1" 2>/dev/null || stat -f %u "$1" 2>/dev/null)
+    owner=$(stat -c %u "$1" 2>/dev/null || stat -f %u "$1" 2>/dev/null)  # gnu-ok: GNU stat -c is paired with the BSD stat -f fallback on this same line
     [ -n "$owner" ] || return 0  # unreadable owner: fail closed, treat as unsafe
     [ "$owner" = "0" ] && return 1  # root-owned sticky dir: safe (e.g. plain /tmp)
     [ "$owner" = "$(id -u)" ] && return 1  # self-owned sticky dir: safe

--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -15,16 +15,22 @@
 # Env seams: HANDOVER_DIR / USER_SLUG / JIRA_PROJECT_KEY (via .env, see
 # load-dotenv.sh); CONSOLE_BUCKET, CONSOLE_DOC, CONSOLE_MODEL,
 # CONSOLE_FILL_PERCENT, CONSOLE_TEMPLATE_DIR, CONSOLE_WORK_DIR (default:
-# ${TMPDIR:-/tmp}/himmel-console-<uid>, per-uid rather than a predictable
-# shared path), CONSOLE_HEADED_ARM, CONSOLE_ARM_FOREGROUND (test seam: run
-# the arm in the foreground instead of detaching it).
+# $XDG_RUNTIME_DIR/himmel-console when set and owned by this uid, else
+# ${TMPDIR:-/tmp}/himmel-console-<uid>; an override is validated the same as
+# the default — see HIMMEL-2881 below), CONSOLE_HEADED_ARM,
+# CONSOLE_ARM_FOREGROUND (test seam: run the arm in the foreground instead of
+# detaching it).
 # Flag seams: --name (both commands; on next it selects which chain to
 # continue) --arm --dry-run --model --bucket --prefix --deadline-min --doc
 # (next only). See `-h`/`--help` for the full surface.
 #
 # Exit codes: 0 ok; 1 usage/state error (letters A-Z exhausted, no
 # predecessor found, an unresolved {{PLACEHOLDER}} survived a render); 2
-# unresolved handover root / user slug / a missing template file.
+# unresolved handover root / user slug / a missing template file / no
+# sha256 hasher available to derive the per-chain digest (HIMMEL-2889); 3
+# the work dir (default or CONSOLE_WORK_DIR) exists but is a symlink, is not
+# owned by this user, is group/other-writable, or could not be created
+# (HIMMEL-2881).
 #
 # Platform guard (gitbash-only): POSIX bash 3.2+; --arm launches through
 # konsole (Linux/KDE, via headed-arm.sh), so no .ps1 twin — the Windows
@@ -270,22 +276,114 @@ date="$(date +%F)"
 state_dir="$root/$slug/$bucket"
 model="${MODEL:-${CONSOLE_MODEL:-claude-fable-5-1}}"
 fill_percent="${CONSOLE_FILL_PERCENT:-45}"
-# The uid suffix prevents collision between DIFFERENT users on a shared
-# host; it does NOT prevent deliberate pre-creation of this exact path by
-# another local user (mkdir -p accepts an existing dir regardless of who
-# made it). A stable path is required by design here — the arming side and
-# the touching side must agree on the signal path across separate
-# invocations — so a fresh mktemp per run is not available as a fix; real
-# hardening (ownership + symlink checks, or XDG_RUNTIME_DIR) is tracked
-# separately: HIMMEL-2881. CONSOLE_WORK_DIR still overrides this outright.
-workdir="${CONSOLE_WORK_DIR:-${TMPDIR:-/tmp}/himmel-console-$(id -u)}"
-# Namespaced by chain identity (slug+bucket), NOT just session name: the
-# session name is keyed on <PREFIX>-nextleg-<date><letter>-<name> only (the
-# established, fleet-wide convention — out of scope to change), so two
-# chains that differ just by bucket but share prefix/date/letter/name would
-# otherwise collide on the SAME signal/log path and touching one chain's
-# signal could arm the other's successor.
-chain_dir="$workdir/${slug}-${bucket}"
+
+# _console_sha256_8 <string> -- first 8 hex chars of sha256(<string>). Small
+# per-script helper, matching the repo's own convention of duplicating this
+# rather than centralizing it (already inlined the same way in
+# queue-lock.sh's _ql_digest_of, artifact-sync.sh's sha256_of, and
+# arm-resume.sh). Fails closed (exit 2, alongside this script's other
+# unresolved-root/tooling cases) rather than silently falling back to an
+# unhashed or truncated root, which would reopen the exact collision this
+# digest exists to prevent.
+_console_sha256_8() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "$1" | sha256sum | cut -d' ' -f1 | cut -c1-8
+    elif command -v shasum >/dev/null 2>&1; then
+        printf '%s' "$1" | shasum -a 256 | cut -d' ' -f1 | cut -c1-8
+    else
+        err "no sha256 hasher available (need sha256sum or shasum) to derive the per-chain work-dir digest"
+        exit 2
+    fi
+}
+
+# HIMMEL-2889: two consoles under DIFFERENT $HANDOVER_DIR roots that happen
+# to agree on slug/bucket/prefix/date/letter/name would otherwise collide on
+# the same signal/log path — touching one chain's signal could arm the
+# other's successor. Folding a digest of the RESOLVED, CANONICALIZED root
+# into the chain dir name fixes that; canonicalizing first (via the same
+# _arm_realpath already used to normalize the root elsewhere) means two
+# spellings of one root (a symlink alias, a trailing slash) still digest
+# identically instead of splitting one chain's history in two.
+root_canon="$(_arm_realpath "$root")"
+root_digest="$(_console_sha256_8 "$root_canon")"
+
+# HIMMEL-2881: the default work dir is a PREDICTABLE path
+# (${TMPDIR:-/tmp}/himmel-console-<uid>) another local user could pre-create
+# — as a directory they own, or as a symlink elsewhere — before this
+# process's first run; `mkdir -p` silently accepts an existing directory
+# regardless of who made it or what it actually resolves to. Prefer
+# $XDG_RUNTIME_DIR/himmel-console (already a per-user 0700 directory on
+# systemd hosts) when it is set AND already owned by this uid; otherwise
+# fall back to the uid-qualified /tmp path. Modeled directly on
+# headed-arm.sh's LOCKDIR hardening (HIMMEL-2545): `-L` before `-d` before
+# `-O` (plain test operators, no stat/uid comparison needed), then a
+# stat-based permission-bit check for the GNU/BSD split. Exit 3 is a new,
+# distinct code for this whole class of refusal — never conflated with the
+# exit-1 usage errors or the exit-2 unresolved-root/tooling errors above.
+if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -d "$XDG_RUNTIME_DIR" ] && [ -O "$XDG_RUNTIME_DIR" ]; then
+    _console_default_workdir="$XDG_RUNTIME_DIR/himmel-console"
+else
+    _console_default_workdir="${TMPDIR:-/tmp}/himmel-console-$(id -u)"
+fi
+# CONSOLE_WORK_DIR is a durable test/operator seam, not an escape hatch from
+# this hardening: an override is exactly as reachable by another local user
+# guessing or being told the path as the default is, so it goes through the
+# SAME validation rather than being trusted outright.
+workdir="${CONSOLE_WORK_DIR:-$_console_default_workdir}"
+
+# console_workdir_ensure <dir> -- create at 0700 if absent, then validate
+# regardless of how it came to exist. `mkdir -p` is a documented no-op on a
+# path that already exists, so a hostile pre-created directory (or symlink)
+# survives it untouched — the validation below is what actually has to catch
+# that, which is also why a passing directory is never chmod'd here: fixing
+# up an existing hostile dir's mode would let it pass while the attacker
+# still owns it, laundering exactly the thing this check exists to catch.
+console_workdir_ensure() {
+    local d="$1"
+    if [ ! -e "$d" ] && [ ! -L "$d" ]; then
+        # shellcheck disable=SC2174
+        if ! mkdir -p -m 0700 "$d" 2>/dev/null; then
+            err "cannot create work dir '$d' — refusing to silently proceed without a directory this process actually controls (HIMMEL-2881)"
+            exit 3
+        fi
+        return 0
+    fi
+    if [ -L "$d" ]; then
+        err "refusing to use work dir '$d' — it is a SYMLINK, so this process does not control what it actually resolves to (HIMMEL-2881)"
+        exit 3
+    fi
+    if [ ! -d "$d" ]; then
+        err "refusing to use work dir '$d' — it is not a directory (HIMMEL-2881)"
+        exit 3
+    fi
+    if [ ! -O "$d" ]; then
+        err "refusing to use work dir '$d' — it is not owned by this user (HIMMEL-2881)"
+        exit 3
+    fi
+    local mode
+    mode=$(stat -c %a "$d" 2>/dev/null || stat -f %Lp "$d" 2>/dev/null)  # gnu-ok: GNU stat -c is paired with the BSD stat -f fallback on this same line
+    if [ -z "$mode" ]; then
+        err "refusing to use work dir '$d' — could not read its permission bits (HIMMEL-2881)"
+        exit 3
+    fi
+    local oth="${mode: -1}" grp="${mode%?}"
+    grp="${grp: -1}"
+    case "$oth$grp" in
+        *2*|*3*|*6*|*7*)
+            err "refusing to use work dir '$d' — it is group- or world-writable (HIMMEL-2881)"
+            exit 3
+            ;;
+    esac
+}
+console_workdir_ensure "$workdir"
+
+# Namespaced by chain identity (slug+bucket+root digest), NOT just session
+# name: the session name is keyed on <PREFIX>-nextleg-<date><letter>-<name>
+# only (the established, fleet-wide convention — out of scope to change), so
+# two chains that differ just by bucket, or just by handover root, but share
+# everything else would otherwise collide on the SAME signal/log path and
+# touching one chain's signal could arm the other's successor.
+chain_dir="$workdir/${slug}-${bucket}-${root_digest}"
 # 10# forces base-10: DEADLINE_MIN passed the digits-only check above, but a
 # leading zero (e.g. "08") is otherwise read as octal in arithmetic context,
 # and 8/9 are not valid octal digits.

--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -381,14 +381,26 @@ workdir="${CONSOLE_WORK_DIR:-$_console_default_workdir}"
 # expected to need a sticky-bit exception: a systemd-provided one is 0700,
 # and an operator-provided one is a config choice, not a shared temp dir).
 _console_dir_component_unsafe() {
+    local owner
+    owner=$(stat -c %u "$1" 2>/dev/null || stat -f %u "$1" 2>/dev/null)  # gnu-ok: GNU stat -c is paired with the BSD stat -f fallback on this same line
+    [ -n "$owner" ] || return 0  # unreadable owner: fail closed, treat as unsafe
+    if [ "$owner" != "0" ] && [ "$owner" != "$(id -u)" ]; then
+        # HIMMEL-2881 round 5 (codex-1 panel finding): an attacker-owned
+        # directory is unsafe REGARDLESS of its current permission bits --
+        # its owner can chmod it to add write access (or already has owner
+        # write access even at e.g. mode 0755) at any point after this
+        # check runs, so ownership by neither root nor us is disqualifying
+        # on its own, before even looking at group/world-writable bits.
+        return 0
+    fi
     local mode
     mode=$(stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null)  # gnu-ok: GNU stat -c is paired with the BSD stat -f fallback on this same line
     [ -n "$mode" ] || return 0  # unreadable bits: fail closed, treat as unsafe
     local oth="${mode: -1}" grp="${mode%?}"
     grp="${grp: -1}"
     case "$oth$grp" in
-        *2*|*3*|*6*|*7*) : ;;  # group/world-writable -- fall through to the sticky+owner check
-        *) return 1 ;;  # not group/world-writable at all: safe regardless of sticky/owner
+        *2*|*3*|*6*|*7*) : ;;  # group/world-writable -- fall through to the sticky check
+        *) return 1 ;;  # trusted owner, not group/world-writable: safe
     esac
     local sticky=0
     if [ "${#mode}" -ge 4 ]; then
@@ -396,13 +408,8 @@ _console_dir_component_unsafe() {
             1|3|5|7) sticky=1 ;;
         esac
     fi
-    [ "$sticky" -eq 1 ] || return 0  # writable, no sticky bit: unsafe
-    local owner
-    owner=$(stat -c %u "$1" 2>/dev/null || stat -f %u "$1" 2>/dev/null)  # gnu-ok: GNU stat -c is paired with the BSD stat -f fallback on this same line
-    [ -n "$owner" ] || return 0  # unreadable owner: fail closed, treat as unsafe
-    [ "$owner" = "0" ] && return 1  # root-owned sticky dir: safe (e.g. plain /tmp)
-    [ "$owner" = "$(id -u)" ] && return 1  # self-owned sticky dir: safe
-    return 0  # sticky but owned by neither root nor us: the owner can still rename/unlink our entry
+    [ "$sticky" -eq 1 ] && return 1  # trusted owner + sticky: non-owners can't rename/unlink our entry: safe
+    return 0  # trusted owner but group/world-writable without sticky: other non-owning local users could tamper
 }
 # _console_ancestor_unsafe <dir> -- true if <dir> or any of its existing
 # ancestors is unsafe per _console_dir_component_unsafe. HIMMEL-2881 round 4
@@ -425,7 +432,15 @@ _console_ancestor_unsafe() {
     done
     return 1
 }
-_console_workdir_parent="$(dirname "$workdir")"
+# HIMMEL-2881 round 5 (codex-2 panel finding): the ancestor walk is a
+# lexical `dirname` loop -- on a RELATIVE workdir (e.g. CONSOLE_WORK_DIR=work)
+# `dirname` stops at "." after one step ("." is its own dirname), so only the
+# current working directory itself is ever checked, never anything above it.
+# Canonicalizing to an absolute path first (the same _arm_realpath already
+# used to normalize the handover root above) makes the walk always reach the
+# real filesystem root regardless of how workdir was spelled.
+_console_workdir_abs="$(_arm_realpath "$workdir")"
+_console_workdir_parent="$(dirname "$_console_workdir_abs")"
 if _console_ancestor_unsafe "$_console_workdir_parent"; then
     err "refusing to use work dir '$workdir' — its parent directory '$_console_workdir_parent' (or an ancestor of it) is group- or world-writable without adequate sticky-bit/ownership protection, so another local user could replace it out from under this process (HIMMEL-2881)"
     exit 3

--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -463,6 +463,39 @@ if [ -L "$workdir" ]; then
 fi
 workdir="$_console_workdir_abs"
 
+# _console_mkdir_chain_safe <dir> -- create <dir> and every missing ancestor
+# ONE COMPONENT AT A TIME (never a single `mkdir -p`), validating ownership
+# of each component the instant it exists -- whether because this call just
+# created it or because it was already there. HIMMEL-2881 round 7 (codex-1
+# panel finding): `_console_ancestor_unsafe` above only walks EXISTING
+# ancestors -- a missing one is skipped on the assumption that `mkdir -p`
+# will create it safely -- but `mkdir -p` silently adopts any ancestor an
+# attacker races into existence between that walk and this create step, with
+# NO ownership check of its own, and that attacker-owned ancestor can later
+# be used to replace the whole subtree beneath it. Building the chain
+# top-down with plain `mkdir` (no -p) closes the window: each `mkdir` either
+# succeeds (so this process owns the new directory, created at mode 0700 --
+# unconditionally safe) or fails because the component already exists, in
+# which case it is validated exactly like a pre-existing ancestor before
+# anything is created beneath it.
+_console_mkdir_chain_safe() {
+    local target="$1" prefix="$1" p
+    local -a missing=()
+    while [ ! -e "$prefix" ]; do
+        missing=("$prefix" "${missing[@]}")
+        prefix="$(dirname "$prefix")"
+        [ "$prefix" = "/" ] && break
+    done
+    for p in "${missing[@]}"; do
+        # shellcheck disable=SC2174
+        if ! mkdir -m 0700 "$p" 2>/dev/null; then
+            if [ -L "$p" ] || [ ! -d "$p" ] || _console_dir_component_unsafe "$p"; then
+                err "refusing to use work dir '$target' — could not safely create ancestor '$p': it was raced into existence by something this process does not control (HIMMEL-2881)"
+                exit 3
+            fi
+        fi
+    done
+}
 # console_workdir_ensure <dir> -- create at 0700 if absent, then ALWAYS
 # validate what actually exists at $d afterward -- never return early on a
 # bare mkdir success. `mkdir -p` is a documented no-op on a path that already
@@ -478,11 +511,7 @@ workdir="$_console_workdir_abs"
 console_workdir_ensure() {
     local d="$1"
     if [ ! -e "$d" ] && [ ! -L "$d" ]; then
-        # shellcheck disable=SC2174
-        if ! mkdir -p -m 0700 "$d" 2>/dev/null; then
-            err "cannot create work dir '$d' — refusing to silently proceed without a directory this process actually controls (HIMMEL-2881)"
-            exit 3
-        fi
+        _console_mkdir_chain_safe "$d"
     fi
     if [ -L "$d" ]; then
         err "refusing to use work dir '$d' — it is a SYMLINK, so this process does not control what it actually resolves to (HIMMEL-2881)"

--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -486,6 +486,19 @@ _console_mkdir_chain_safe() {
         prefix="$(dirname "$prefix")"
         [ "$prefix" = "/" ] && break
     done
+    # HIMMEL-2881 round 8 (codex-1 panel finding on the round-7 fix): the
+    # scan above just stops at the first EXISTING directory and hands it to
+    # the create loop below as a trusted base -- but "existing" only means
+    # existing NOW, at scan time, not at the time the OUTER ancestor-unsafe
+    # walk (which ran before this function was ever called) last looked. An
+    # attacker who races a brand-new ancestor into existence in that window
+    # becomes this scan's stopping point and would otherwise never be
+    # checked at all. Re-running the same ancestor walk against it here --
+    # right before it is trusted -- closes that window.
+    if _console_ancestor_unsafe "$prefix"; then
+        err "refusing to use work dir '$target' — its ancestor '$prefix' (or one above it) is unsafe, and appeared after the initial check ran (HIMMEL-2881)"
+        exit 3
+    fi
     for p in "${missing[@]}"; do
         # shellcheck disable=SC2174
         if ! mkdir -m 0700 "$p" 2>/dev/null; then

--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -357,6 +357,48 @@ fi
 # SAME validation rather than being trusted outright.
 workdir="${CONSOLE_WORK_DIR:-$_console_default_workdir}"
 
+# _console_parent_unsafe <dir> -- true if <dir> is group- or world-writable
+# AND lacks the sticky bit. HIMMEL-2881 round 3 (codex-1 panel finding):
+# console_workdir_ensure (below) validates only $workdir itself, in every
+# one of its three origins -- the XDG_RUNTIME_DIR default, a CONSOLE_WORK_DIR
+# override, or the TMPDIR fallback. The XDG_RUNTIME_DIR case alone got a
+# parent check (the `if` above deciding whether to prefer it) in round 2;
+# the override and TMPDIR-fallback parents were left unchecked, so another
+# local user with write access to either parent could still swap the
+# (already-validated) work dir out from under this process, same as the
+# XDG_RUNTIME_DIR case. A sticky bit changes that: it restores per-entry
+# protection inside an otherwise world-writable directory (only an entry's
+# owner, the directory owner, or root may rename/unlink it), which is
+# exactly what makes plain /tmp (mode 1777) a safe TMPDIR-fallback parent
+# despite being world-writable -- so this check must exempt sticky
+# directories, unlike the plain group/world-writable check the
+# XDG_RUNTIME_DIR preference above uses (XDG_RUNTIME_DIR is never expected
+# to need a sticky-bit exception: a systemd-provided one is 0700, and an
+# operator-provided one is a config choice, not a shared temp dir).
+_console_parent_unsafe() {
+    local mode
+    mode=$(stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null)  # gnu-ok: GNU stat -c is paired with the BSD stat -f fallback on this same line
+    [ -n "$mode" ] || return 0  # unreadable bits: fail closed, treat as unsafe
+    local sticky=0
+    if [ "${#mode}" -ge 4 ]; then
+        case "${mode:0:1}" in
+            1|3|5|7) sticky=1 ;;
+        esac
+    fi
+    [ "$sticky" -eq 1 ] && return 1
+    local oth="${mode: -1}" grp="${mode%?}"
+    grp="${grp: -1}"
+    case "$oth$grp" in
+        *2*|*3*|*6*|*7*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+_console_workdir_parent="$(dirname "$workdir")"
+if [ -d "$_console_workdir_parent" ] && _console_parent_unsafe "$_console_workdir_parent"; then
+    err "refusing to use work dir '$workdir' — its parent directory '$_console_workdir_parent' is group- or world-writable without a sticky bit, so another local user could replace it out from under this process (HIMMEL-2881)"
+    exit 3
+fi
+
 # console_workdir_ensure <dir> -- create at 0700 if absent, then ALWAYS
 # validate what actually exists at $d afterward -- never return early on a
 # bare mkdir success. `mkdir -p` is a documented no-op on a path that already

--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -445,6 +445,23 @@ if _console_ancestor_unsafe "$_console_workdir_parent"; then
     err "refusing to use work dir '$workdir' — its parent directory '$_console_workdir_parent' (or an ancestor of it) is group- or world-writable without adequate sticky-bit/ownership protection, so another local user could replace it out from under this process (HIMMEL-2881)"
     exit 3
 fi
+# HIMMEL-2881 round 6 (codex-1 panel finding): ancestor validation above ran
+# against the CANONICALIZED path, but every use below this point (creation,
+# chain_dir) previously kept the ORIGINAL $workdir spelling -- if a symlink
+# in one of workdir's own path components resolved to a safe tree at
+# validation time, an attacker could repoint that symlink before the actual
+# create/access below, and the two would silently diverge. Adopting the
+# already-validated canonical path for every subsequent use closes that
+# window: what was checked is exactly what gets used. This MUST run before
+# the reassignment below: `realpath -m` resolves a symlink at $workdir's own
+# last component away entirely, so console_workdir_ensure's own -L check
+# would never see it once $workdir has already been replaced by its
+# resolved form (case 27's pre-created-symlink-as-workdir regression).
+if [ -L "$workdir" ]; then
+    err "refusing to use work dir '$workdir' — it is a SYMLINK, so this process does not control what it actually resolves to (HIMMEL-2881)"
+    exit 3
+fi
+workdir="$_console_workdir_abs"
 
 # console_workdir_ensure <dir> -- create at 0700 if absent, then ALWAYS
 # validate what actually exists at $d afterward -- never return early on a

--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -307,20 +307,46 @@ _console_sha256_8() {
 root_canon="$(_arm_realpath "$root")"
 root_digest="$(_console_sha256_8 "$root_canon")"
 
+# _console_group_or_world_writable <dir> -- true if <dir>'s own permission
+# bits allow group or other write. HIMMEL-2881 round 2 (codex-1 panel
+# finding): console_workdir_ensure only ever validates the CHILD it creates
+# ($XDG_RUNTIME_DIR/himmel-console); it never checks the PARENT
+# ($XDG_RUNTIME_DIR itself). Unix permission semantics mean write access to
+# a directory controls its entries regardless of the entries' own
+# permissions (absent a sticky bit, which /tmp has but an arbitrary
+# XDG_RUNTIME_DIR is not guaranteed to), so a group- or world-writable
+# parent lets another local user swap the child out from under this
+# process even after the child passed its own validation. A separate
+# helper (rather than folding this into console_workdir_ensure) keeps that
+# already-tested function's exact error-message wording untouched.
+_console_group_or_world_writable() {
+    local mode
+    mode=$(stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null)  # gnu-ok: GNU stat -c is paired with the BSD stat -f fallback on this same line
+    [ -n "$mode" ] || return 0  # unreadable bits: fail closed, treat as writable so the caller falls back
+    local oth="${mode: -1}" grp="${mode%?}"
+    grp="${grp: -1}"
+    case "$oth$grp" in
+        *2*|*3*|*6*|*7*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # HIMMEL-2881: the default work dir is a PREDICTABLE path
 # (${TMPDIR:-/tmp}/himmel-console-<uid>) another local user could pre-create
 # — as a directory they own, or as a symlink elsewhere — before this
 # process's first run; `mkdir -p` silently accepts an existing directory
 # regardless of who made it or what it actually resolves to. Prefer
 # $XDG_RUNTIME_DIR/himmel-console (already a per-user 0700 directory on
-# systemd hosts) when it is set AND already owned by this uid; otherwise
-# fall back to the uid-qualified /tmp path. Modeled directly on
-# headed-arm.sh's LOCKDIR hardening (HIMMEL-2545): `-L` before `-d` before
-# `-O` (plain test operators, no stat/uid comparison needed), then a
-# stat-based permission-bit check for the GNU/BSD split. Exit 3 is a new,
-# distinct code for this whole class of refusal — never conflated with the
-# exit-1 usage errors or the exit-2 unresolved-root/tooling errors above.
-if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -d "$XDG_RUNTIME_DIR" ] && [ -O "$XDG_RUNTIME_DIR" ]; then
+# systemd hosts) when it is set AND already owned by this uid AND not
+# itself group- or world-writable; otherwise fall back to the uid-qualified
+# /tmp path. Modeled directly on headed-arm.sh's LOCKDIR hardening
+# (HIMMEL-2545): `-L` before `-d` before `-O` (plain test operators, no
+# stat/uid comparison needed), then a stat-based permission-bit check for
+# the GNU/BSD split. Exit 3 is a new, distinct code for this whole class of
+# refusal — never conflated with the exit-1 usage errors or the exit-2
+# unresolved-root/tooling errors above.
+if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -d "$XDG_RUNTIME_DIR" ] && [ -O "$XDG_RUNTIME_DIR" ] \
+    && ! _console_group_or_world_writable "$XDG_RUNTIME_DIR"; then
     _console_default_workdir="$XDG_RUNTIME_DIR/himmel-console"
 else
     _console_default_workdir="${TMPDIR:-/tmp}/himmel-console-$(id -u)"

--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -331,13 +331,18 @@ fi
 # SAME validation rather than being trusted outright.
 workdir="${CONSOLE_WORK_DIR:-$_console_default_workdir}"
 
-# console_workdir_ensure <dir> -- create at 0700 if absent, then validate
-# regardless of how it came to exist. `mkdir -p` is a documented no-op on a
-# path that already exists, so a hostile pre-created directory (or symlink)
-# survives it untouched — the validation below is what actually has to catch
-# that, which is also why a passing directory is never chmod'd here: fixing
-# up an existing hostile dir's mode would let it pass while the attacker
-# still owns it, laundering exactly the thing this check exists to catch.
+# console_workdir_ensure <dir> -- create at 0700 if absent, then ALWAYS
+# validate what actually exists at $d afterward -- never return early on a
+# bare mkdir success. `mkdir -p` is a documented no-op on a path that already
+# exists (including one whose last component is a symlink resolving to a
+# directory), so a hostile dir/symlink planted in the TOCTOU window between
+# the existence check below and the mkdir call would otherwise be silently
+# trusted; falling through into the same checks a pre-existing directory gets
+# closes that race, since -L/-O/permission-bits are evaluated on whatever is
+# actually at $d now, not on what mkdir believes it created. This is also why
+# a passing directory is never chmod'd here: fixing up an existing hostile
+# dir's mode would let it pass while the attacker still owns it, laundering
+# exactly the thing this check exists to catch.
 console_workdir_ensure() {
     local d="$1"
     if [ ! -e "$d" ] && [ ! -L "$d" ]; then
@@ -346,7 +351,6 @@ console_workdir_ensure() {
             err "cannot create work dir '$d' — refusing to silently proceed without a directory this process actually controls (HIMMEL-2881)"
             exit 3
         fi
-        return 0
     fi
     if [ -L "$d" ]; then
         err "refusing to use work dir '$d' — it is a SYMLINK, so this process does not control what it actually resolves to (HIMMEL-2881)"

--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -357,45 +357,77 @@ fi
 # SAME validation rather than being trusted outright.
 workdir="${CONSOLE_WORK_DIR:-$_console_default_workdir}"
 
-# _console_parent_unsafe <dir> -- true if <dir> is group- or world-writable
-# AND lacks the sticky bit. HIMMEL-2881 round 3 (codex-1 panel finding):
-# console_workdir_ensure (below) validates only $workdir itself, in every
-# one of its three origins -- the XDG_RUNTIME_DIR default, a CONSOLE_WORK_DIR
-# override, or the TMPDIR fallback. The XDG_RUNTIME_DIR case alone got a
-# parent check (the `if` above deciding whether to prefer it) in round 2;
-# the override and TMPDIR-fallback parents were left unchecked, so another
-# local user with write access to either parent could still swap the
-# (already-validated) work dir out from under this process, same as the
-# XDG_RUNTIME_DIR case. A sticky bit changes that: it restores per-entry
-# protection inside an otherwise world-writable directory (only an entry's
-# owner, the directory owner, or root may rename/unlink it), which is
-# exactly what makes plain /tmp (mode 1777) a safe TMPDIR-fallback parent
-# despite being world-writable -- so this check must exempt sticky
-# directories, unlike the plain group/world-writable check the
-# XDG_RUNTIME_DIR preference above uses (XDG_RUNTIME_DIR is never expected
-# to need a sticky-bit exception: a systemd-provided one is 0700, and an
-# operator-provided one is a config choice, not a shared temp dir).
-_console_parent_unsafe() {
+# _console_dir_component_unsafe <dir> -- true if <dir> is group- or
+# world-writable AND (lacks the sticky bit OR the sticky bit is present but
+# <dir> is owned by neither root nor us). HIMMEL-2881 round 3 (codex-1
+# panel finding): console_workdir_ensure (below) validates only $workdir
+# itself, in every one of its three origins -- the XDG_RUNTIME_DIR default,
+# a CONSOLE_WORK_DIR override, or the TMPDIR fallback. The XDG_RUNTIME_DIR
+# case alone got a parent check (the `if` above deciding whether to prefer
+# it) in round 2; the override and TMPDIR-fallback parents were left
+# unchecked, so another local user with write access to either parent could
+# still swap the (already-validated) work dir out from under this process,
+# same as the XDG_RUNTIME_DIR case. A sticky bit changes that: it restores
+# per-entry protection inside an otherwise world-writable directory -- but
+# ONLY against users who are neither the entry's owner, the directory's
+# owner, nor root; the directory's OWNER can still rename/unlink entries
+# inside their own directory regardless of the sticky bit (round 4,
+# codex-1 panel finding), so a sticky directory owned by an attacker is not
+# actually safe -- the exemption must also require the directory itself be
+# owned by root or by us. This is exactly what makes plain /tmp (mode 1777,
+# root-owned) a safe TMPDIR-fallback parent despite being world-writable,
+# and is why the plain group/world-writable check the XDG_RUNTIME_DIR
+# preference above uses needs no such exemption (XDG_RUNTIME_DIR is never
+# expected to need a sticky-bit exception: a systemd-provided one is 0700,
+# and an operator-provided one is a config choice, not a shared temp dir).
+_console_dir_component_unsafe() {
     local mode
     mode=$(stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null)  # gnu-ok: GNU stat -c is paired with the BSD stat -f fallback on this same line
     [ -n "$mode" ] || return 0  # unreadable bits: fail closed, treat as unsafe
+    local oth="${mode: -1}" grp="${mode%?}"
+    grp="${grp: -1}"
+    case "$oth$grp" in
+        *2*|*3*|*6*|*7*) : ;;  # group/world-writable -- fall through to the sticky+owner check
+        *) return 1 ;;  # not group/world-writable at all: safe regardless of sticky/owner
+    esac
     local sticky=0
     if [ "${#mode}" -ge 4 ]; then
         case "${mode:0:1}" in
             1|3|5|7) sticky=1 ;;
         esac
     fi
-    [ "$sticky" -eq 1 ] && return 1
-    local oth="${mode: -1}" grp="${mode%?}"
-    grp="${grp: -1}"
-    case "$oth$grp" in
-        *2*|*3*|*6*|*7*) return 0 ;;
-        *) return 1 ;;
-    esac
+    [ "$sticky" -eq 1 ] || return 0  # writable, no sticky bit: unsafe
+    local owner
+    owner=$(stat -c %u "$1" 2>/dev/null || stat -f %u "$1" 2>/dev/null)
+    [ -n "$owner" ] || return 0  # unreadable owner: fail closed, treat as unsafe
+    [ "$owner" = "0" ] && return 1  # root-owned sticky dir: safe (e.g. plain /tmp)
+    [ "$owner" = "$(id -u)" ] && return 1  # self-owned sticky dir: safe
+    return 0  # sticky but owned by neither root nor us: the owner can still rename/unlink our entry
+}
+# _console_ancestor_unsafe <dir> -- true if <dir> or any of its existing
+# ancestors is unsafe per _console_dir_component_unsafe. HIMMEL-2881 round 4
+# (codex-2 panel finding): checking only the immediate parent leaves the
+# REST of the ancestor chain unchecked -- a local user with write access to
+# a GRANDPARENT (or higher) can rename/replace that ancestor, substituting
+# the entire subtree beneath it (including an immediate parent that, in
+# isolation, looks perfectly safe), so every existing ancestor up to the
+# filesystem root must be checked, not just the nearest one. A non-existent
+# ancestor is skipped (mirroring the existing single-parent check): `mkdir -p`
+# will create it, and its own ancestors are still walked and checked.
+_console_ancestor_unsafe() {
+    local d="$1" prev=""
+    while [ "$d" != "$prev" ]; do
+        if [ -d "$d" ] && _console_dir_component_unsafe "$d"; then
+            return 0
+        fi
+        prev="$d"
+        d="$(dirname "$d")"
+    done
+    return 1
 }
 _console_workdir_parent="$(dirname "$workdir")"
-if [ -d "$_console_workdir_parent" ] && _console_parent_unsafe "$_console_workdir_parent"; then
-    err "refusing to use work dir '$workdir' — its parent directory '$_console_workdir_parent' is group- or world-writable without a sticky bit, so another local user could replace it out from under this process (HIMMEL-2881)"
+if _console_ancestor_unsafe "$_console_workdir_parent"; then
+    err "refusing to use work dir '$workdir' — its parent directory '$_console_workdir_parent' (or an ancestor of it) is group- or world-writable without adequate sticky-bit/ownership protection, so another local user could replace it out from under this process (HIMMEL-2881)"
     exit 3
 fi
 

--- a/scripts/handover/console/test-console.sh
+++ b/scripts/handover/console/test-console.sh
@@ -946,4 +946,50 @@ check "41 raced intermediate ancestor of CONSOLE_WORK_DIR: refuses with a distin
 check "41 raced intermediate ancestor of CONSOLE_WORK_DIR: stderr names the cause" "$([ "$(printf '%s\n' "$out41" | grep -ci ancestor)" -ge 1 ] && echo yes || echo no)" "yes"
 check "41 raced intermediate ancestor of CONSOLE_WORK_DIR: never created the work dir beneath the raced ancestor" "$([ -e "$target41" ] && echo yes || echo no)" "no"
 
+# --- 42: an ancestor an attacker races into existence AFTER the outer
+# ancestor-unsafe walk concludes "safe" but BEFORE _console_mkdir_chain_safe's
+# own missing-component scan runs is silently trusted as that scan's stopping
+# point, with no validation of its own (HIMMEL-2881 round 8, codex-1 panel
+# finding on the round-7 fix): the scan's `while [ ! -e "$prefix" ]` loop
+# just stops at the first EXISTING directory it meets and hands it to the
+# create loop as a trusted base -- but "existing" only means existing NOW,
+# at scan time, not at the time the outer walk last looked. A real race
+# cannot be scheduled deterministically, so (mirroring cases 30/34/37's
+# technique) a PATH stub for `stat` simulates the race winner: the instant
+# the outer ancestor-unsafe walk examines the LAST existing ancestor it will
+# see before concluding "safe", the stub plants the next-level-down ancestor
+# at an insecure, self-owned mode (0777, no sticky bit) as a side effect,
+# then returns the real `stat` output for the path it was actually asked
+# about -- exactly what a raced attacker directory materializing in that
+# exact window would look like.
+tmp42="$tmp/c42"
+mkdir -p "$tmp42/bin"
+chmod 0700 "$tmp42"
+mid42="$tmp42/mid"
+target42="$tmp42/mid/workdir"
+real_stat42="$(command -v stat)"
+cat > "$tmp42/bin/stat" <<STUB_EOF
+#!/usr/bin/env bash
+if [ ! -e "$tmp42/.raced42" ]; then
+    for a in "\$@"; do
+        if [ "\$a" = "$tmp42" ]; then
+            : > "$tmp42/.raced42"
+            mkdir -m 0777 "$mid42" 2>/dev/null
+            break
+        fi
+    done
+fi
+exec "$real_stat42" "\$@"
+STUB_EOF
+chmod +x "$tmp42/bin/stat"
+rc42=0
+out42="$( ( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    CONSOLE_WORK_DIR="$target42" \
+    PATH="$tmp42/bin:$PATH" \
+    bash "$C" new --bucket wdancestor42 --dry-run ) 2>&1 )"; rc42=$?
+check "42 ancestor raced in between the outer walk and the create scan: refuses with a distinct exit code" "$rc42" "3"
+check "42 ancestor raced in between the outer walk and the create scan: stderr names the cause" "$([ "$(printf '%s\n' "$out42" | grep -ci ancestor)" -ge 1 ] && echo yes || echo no)" "yes"
+check "42 ancestor raced in between the outer walk and the create scan: never created the work dir beneath the raced ancestor" "$([ -e "$target42" ] && echo yes || echo no)" "no"
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/handover/console/test-console.sh
+++ b/scripts/handover/console/test-console.sh
@@ -755,4 +755,67 @@ out33="$( ( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR -u CONSOLE_WORK_DIR \
 check "33 TMPDIR-fallback under an insecure TMPDIR: refuses with a distinct exit code" "$rc33" "3"
 check "33 TMPDIR-fallback under an insecure TMPDIR: stderr names the cause" "$(printf '%s\n' "$out33" | grep -ci parent)" "1"
 
+# --- 34: a sticky PARENT owned by neither root nor us must still be refused
+# (HIMMEL-2881 round 4, codex-1 panel finding) -- the round-3 fix exempted
+# any sticky directory, but the sticky bit only protects entries from users
+# who are NOT the directory's own owner; the owner can still rename/unlink
+# entries inside their own directory regardless of the sticky bit, so a
+# sticky directory owned by an attacker is not actually safe. A real
+# attacker-owned fixture cannot be built without root, so a PATH stub for
+# `stat` reports a foreign uid for this one fixture path while every other
+# `stat` call (including console.sh's own real ones on other paths) passes
+# through to the real binary unchanged.
+tmp34="$tmp/c34"
+mkdir -p "$tmp34/bin" "$tmp34/attacker-owned"
+chmod 1777 "$tmp34/attacker-owned"
+real_stat34="$(command -v stat)"
+cat > "$tmp34/bin/stat" <<STUB_EOF
+#!/usr/bin/env bash
+if [ "\$1" = "-c" ] && [ "\$3" = "$tmp34/attacker-owned" ]; then
+    case "\$2" in
+        %a) echo 1777; exit 0 ;;
+        %u) echo 31337; exit 0 ;;
+    esac
+fi
+exec "$real_stat34" "\$@"
+STUB_EOF
+chmod +x "$tmp34/bin/stat"
+out34="$( ( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR -u CONSOLE_WORK_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    TMPDIR="$tmp34/attacker-owned" \
+    PATH="$tmp34/bin:$PATH" \
+    bash "$C" new --bucket wdparent34 --dry-run ) 2>&1 )"; rc34=$?
+check "34 sticky but attacker-owned parent: refuses with a distinct exit code" "$rc34" "3"
+check "34 sticky but attacker-owned parent: stderr names the cause" "$(printf '%s\n' "$out34" | grep -ci parent)" "1"
+
+# --- 35 (control): a sticky parent owned by US (the real /tmp shape) must
+# still be accepted -- proves the round-4 ownership check does not regress
+# the plain /tmp case the round-3 sticky exemption exists for.
+tmp35="$tmp/c35"
+mkdir -p "$tmp35/self-owned"
+chmod 1777 "$tmp35/self-owned"
+rc35=0
+( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR -u CONSOLE_WORK_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    TMPDIR="$tmp35/self-owned" \
+    bash "$C" new --bucket wdparent35 --dry-run ) >/dev/null 2>&1 || rc35=$?
+check "35 sticky self-owned parent (real /tmp analogue): accepted" "$rc35" "0"
+
+# --- 36: an insecure GRANDPARENT must be refused even when the immediate
+# parent looks safe on its own (HIMMEL-2881 round 4, codex-2 panel finding)
+# -- checking only the immediate parent leaves the rest of the ancestor
+# chain unchecked; a local user with write access to a grandparent can
+# rename/replace it, substituting the entire subtree including an
+# otherwise-safe immediate parent.
+tmp36="$tmp/c36"
+mkdir -p "$tmp36/grandparent/parent"
+chmod 0777 "$tmp36/grandparent"
+chmod 0700 "$tmp36/grandparent/parent"
+out36="$( ( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    CONSOLE_WORK_DIR="$tmp36/grandparent/parent/work" \
+    bash "$C" new --bucket wdparent36 --dry-run ) 2>&1 )"; rc36=$?
+check "36 insecure grandparent despite safe immediate parent: refuses with a distinct exit code" "$rc36" "3"
+check "36 insecure grandparent despite safe immediate parent: stderr names the cause" "$(printf '%s\n' "$out36" | grep -ci parent)" "1"
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/handover/console/test-console.sh
+++ b/scripts/handover/console/test-console.sh
@@ -47,12 +47,29 @@ root="$tmp/handovers"
 mkdir -p "$root"
 today="$(date +%F)"
 
+# root_digest_of <canonical-root> -- mirrors console.sh's _console_sha256_8:
+# first 8 hex chars of the sha256 of the resolved, canonicalized handover
+# root (HIMMEL-2889). $root is already canonical here (built via `pwd -P`
+# above), so no realpath step is needed for fixture roots.
+root_digest_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "$1" | sha256sum | cut -d' ' -f1 | cut -c1-8
+    else
+        printf '%s' "$1" | shasum -a 256 | cut -d' ' -f1 | cut -c1-8
+    fi
+}
+root_digest="$(root_digest_of "$root")"
+
 console_root() {  # console_root <root> <args...> -- invoke console.sh with
                   # cwd pinned to the fixture repo, against an ARBITRARY
                   # handover root (used by cases exercising a non-default
-                  # root, e.g. one containing a space).
+                  # root, e.g. one containing a space). CONSOLE_WORK_DIR is
+                  # pinned to an isolated fixture dir so the eager work-dir
+                  # hardening (HIMMEL-2881) never touches, and every case
+                  # here never collides on, the REAL live
+                  # /tmp/himmel-console-<uid> tree other running consoles use.
     local r="$1"; shift
-    ( cd "$fixture_repo" && HANDOVER_DIR="$r" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO bash "$C" "$@" )
+    ( cd "$fixture_repo" && HANDOVER_DIR="$r" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO CONSOLE_WORK_DIR="$tmp/defaultwork" bash "$C" "$@" )
 }
 
 console() { console_root "$root" "$@"; }
@@ -145,10 +162,11 @@ HANDOVER_DIR="$root" bash "$QL" release "$doc6bSrc" "$token6ba" >/dev/null 2>&1
 # --- 7: next --arm with a stub arm target ------------------------------
 doc7A="$root/tester/armrepo/DEMO-nextleg-${today}A-console.md"
 session7B="DEMO-nextleg-${today}B-console"
-# Signal/log live under a chain-identity subdir ($slug-$bucket), not
+# Signal/log live under a chain-identity subdir ($slug-$bucket-$digest), not
 # $workdir directly -- see codex-2 round-2 (bucket-only-differing chains
-# must not collide on the same signal/log path).
-log7B="$tmp/work/tester-armrepo/launch-${session7B}.log"
+# must not collide on the same signal/log path) and HIMMEL-2889 (chains under
+# DIFFERENT handover roots must not collide either, hence the root digest).
+log7B="$tmp/work/tester-armrepo-${root_digest}/launch-${session7B}.log"
 
 cat > "$tmp/stub-arm.sh" <<'STUB'
 #!/usr/bin/env bash
@@ -384,6 +402,22 @@ log17b="$(printf '%s\n' "$out17b" | sed -n 's/.*log=\([^ ]*\).*/\1/p' | head -n 
 check "17 signal path differs when only --bucket differs" "$([ -n "$sig17a" ] && [ "$sig17a" != "$sig17b" ] && echo yes)" "yes"
 check "17 log path differs when only --bucket differs" "$([ -n "$log17a" ] && [ "$log17a" != "$log17b" ] && echo yes)" "yes"
 
+# --- 17b: case 17's sibling -- chains under DIFFERENT handover roots that
+# otherwise agree on slug/bucket/prefix/date/letter/name must not collide
+# on the same signal/log path either (HIMMEL-2889). Same $root twice would
+# reuse letter A on the second call, so use two disjoint fixture roots.
+root17b1="$tmp/handovers-17b1"
+root17b2="$tmp/handovers-17b2"
+mkdir -p "$root17b1" "$root17b2"
+out17c="$(console_root "$root17b1" new --bucket samebucket --dry-run --arm)"
+out17d="$(console_root "$root17b2" new --bucket samebucket --dry-run --arm)"
+sig17c="$(printf '%s\n' "$out17c" | sed -n 's/.*signal=\([^ ]*\).*/\1/p' | head -n 1)"
+sig17d="$(printf '%s\n' "$out17d" | sed -n 's/.*signal=\([^ ]*\).*/\1/p' | head -n 1)"
+log17c="$(printf '%s\n' "$out17c" | sed -n 's/.*log=\([^ ]*\).*/\1/p' | head -n 1)"
+log17d="$(printf '%s\n' "$out17d" | sed -n 's/.*log=\([^ ]*\).*/\1/p' | head -n 1)"
+check "17b signal path differs when only HANDOVER_DIR differs" "$([ -n "$sig17c" ] && [ "$sig17c" != "$sig17d" ] && echo yes)" "yes"
+check "17b log path differs when only HANDOVER_DIR differs" "$([ -n "$log17c" ] && [ "$log17c" != "$log17d" ] && echo yes)" "yes"
+
 # --- 18: next --doc <missing predecessor> refuses rather than fabricate -
 before18="$(find "$root" -type f -not -path "$root/.locks/*" | sort)"
 missing_doc="$root/tester/missingrepo/DEMO-nextleg-${today}A-console.md"
@@ -573,5 +607,55 @@ check "26 the token embedded in the doc matches the printed token" "$token26_in_
 rc26=0
 HANDOVER_DIR="$root" bash "$QL" release "$doc26" "$token26_in_doc" >/dev/null 2>&1 || rc26=$?
 check "26 the control: release using the token read out of the document succeeds" "$rc26" "0"
+
+# --- 27: default work dir refuses a pre-created SYMLINK (HIMMEL-2881) --
+# Another local user could symlink the predictable default path elsewhere
+# before this process's first run; the eager work-dir hardening must catch
+# it regardless of --arm. TMPDIR is pointed at an isolated fixture dir (never
+# real /tmp) and XDG_RUNTIME_DIR is unset so the TMPDIR-fallback branch of
+# the resolution is the one under test.
+tmp27="$tmp/c27"
+mkdir -p "$tmp27/real-elsewhere"
+ln -s "$tmp27/real-elsewhere" "$tmp27/himmel-console-$(id -u)"
+rc27=0
+out27="$( ( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR -u CONSOLE_WORK_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO TMPDIR="$tmp27" \
+    bash "$C" new --bucket wdlinktest --dry-run ) 2>&1 )" || rc27=$?
+check "27 symlinked default work dir: refuses with a distinct exit code" "$rc27" "3"
+check "27 symlinked default work dir: stderr names the cause" "$(printf '%s\n' "$out27" | grep -ci symlink)" "1"
+check "27 symlinked default work dir: never followed into real-elsewhere" "$([ -n "$(find "$tmp27/real-elsewhere" -mindepth 1 2>/dev/null)" ] && echo yes || echo no)" "no"
+
+# --- 28: default work dir refuses a directory owned by a DIFFERENT uid
+# (HIMMEL-2881) -- skipped cleanly (never faked) if this host offers no way
+# to arrange one without privileges we do not have.
+if ! command -v sudo >/dev/null 2>&1 || ! sudo -n true >/dev/null 2>&1; then
+    echo "ok - SKIPPED: default work dir owned by another uid (no passwordless privilege escalation on this host to arrange one - sudo -n true failed)"
+else
+    tmp28="$tmp/c28"
+    mkdir -p "$tmp28/himmel-console-$(id -u)"
+    if sudo -n chown nobody:nobody "$tmp28/himmel-console-$(id -u)" >/dev/null 2>&1; then
+        rc28=0
+        out28="$( ( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR -u CONSOLE_WORK_DIR \
+            HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO TMPDIR="$tmp28" \
+            bash "$C" new --bucket wdotheruid --dry-run ) 2>&1 )" || rc28=$?
+        check "28 default work dir owned by another uid: refuses with a distinct exit code" "$rc28" "3"
+        check "28 default work dir owned by another uid: stderr names the cause" "$(printf '%s\n' "$out28" | grep -ci owned)" "1"
+        sudo -n chown "$(id -u):$(id -g)" "$tmp28/himmel-console-$(id -u)" >/dev/null 2>&1
+    else
+        echo "ok - SKIPPED: default work dir owned by another uid (sudo -n chown to nobody:nobody failed - no usable privilege on this host)"
+    fi
+fi
+
+# --- 29: two spellings of the SAME handover root (a symlink alias) must
+# digest to the SAME chain dir (HIMMEL-2889) -- canonicalization has to
+# happen before hashing, or a symlinked root would silently degrade back
+# into the very collision the digest exists to prevent.
+root29_link="$tmp/handovers-symlink"
+ln -s "$root" "$root29_link"
+out29a="$(console_root "$root" new --bucket digestsame --dry-run --arm)"
+out29b="$(console_root "$root29_link" new --bucket digestsame --dry-run --arm)"
+sig29a="$(printf '%s\n' "$out29a" | sed -n 's/.*signal=\([^ ]*\).*/\1/p' | head -n 1)"
+sig29b="$(printf '%s\n' "$out29b" | sed -n 's/.*signal=\([^ ]*\).*/\1/p' | head -n 1)"
+check "29 root spelled via a symlink alias yields the SAME signal path" "$([ -n "$sig29a" ] && [ "$sig29a" = "$sig29b" ] && echo yes)" "yes"
 
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/handover/console/test-console.sh
+++ b/scripts/handover/console/test-console.sh
@@ -695,4 +695,30 @@ check "30 work-dir creation TOCTOU: refuses with a distinct exit code" "$rc30" "
 check "30 work-dir creation TOCTOU: stderr names the cause" "$(printf '%s\n' "$out30" | grep -ci symlink)" "1"
 check "30 work-dir creation TOCTOU: never followed into elsewhere-30" "$([ -n "$(find "$tmp30/elsewhere-30" -mindepth 1 2>/dev/null)" ] && echo yes || echo no)" "no"
 
+# --- 31: XDG_RUNTIME_DIR itself group- or world-writable must NOT be
+# trusted for the default work dir (HIMMEL-2881 round 2, codex-1 panel
+# finding) -- console_workdir_ensure only validates the CHILD
+# ($XDG_RUNTIME_DIR/himmel-console) it creates; a local user with write
+# access to the PARENT can still unlink/replace that child after
+# validation completes (Unix permission semantics: write access to a
+# directory controls its entries regardless of the entries' own
+# permissions, absent a sticky bit like /tmp's). The selection must not
+# prefer $XDG_RUNTIME_DIR when the directory itself is group- or
+# world-writable; it must fall back to the uid-qualified TMPDIR path
+# instead, exactly as it already does for a non-owned $XDG_RUNTIME_DIR.
+tmp31="$tmp/c31"
+mkdir -p "$tmp31/xdg" "$tmp31/tmp"
+chmod 0777 "$tmp31/xdg"
+out31="$( ( cd "$fixture_repo" && env -u CONSOLE_WORK_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    XDG_RUNTIME_DIR="$tmp31/xdg" TMPDIR="$tmp31/tmp" \
+    bash "$C" new --bucket wdgwtest --dry-run --arm ) 2>&1 )"
+sig31="$(printf '%s\n' "$out31" | sed -n 's/.*signal=\([^ ]*\).*/\1/p' | head -n 1)"
+case "$sig31" in
+    "$tmp31/xdg/himmel-console/"*) sig31_branch=rejected ;;
+    "$tmp31/tmp/himmel-console-$(id -u)/"*) sig31_branch=fallback ;;
+    *) sig31_branch="other:$sig31" ;;
+esac
+check "31 group/world-writable XDG_RUNTIME_DIR is not preferred" "$sig31_branch" "fallback"
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/handover/console/test-console.sh
+++ b/scripts/handover/console/test-console.sh
@@ -818,4 +818,63 @@ out36="$( ( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR \
 check "36 insecure grandparent despite safe immediate parent: refuses with a distinct exit code" "$rc36" "3"
 check "36 insecure grandparent despite safe immediate parent: stderr names the cause" "$(printf '%s\n' "$out36" | grep -ci parent)" "1"
 
+# --- 37: an attacker-owned parent that is NOT group/world-writable (e.g.
+# mode 0755) must still be refused (HIMMEL-2881 round 5, codex-1 panel
+# finding) -- the round-4 fix only added an ownership check on the STICKY
+# branch; a non-writable-by-group/other directory was still accepted
+# regardless of owner, but the owner of a directory can chmod it (or may
+# already have owner-only write access at 0755) at any time after this
+# check runs, so ownership by neither root nor us is disqualifying even
+# when the current bits look tight. Same stat PATH-stub technique as case 34
+# (no root available to build a real attacker-owned fixture).
+tmp37="$tmp/c37"
+mkdir -p "$tmp37/bin" "$tmp37/attacker-0755"
+chmod 0755 "$tmp37/attacker-0755"
+real_stat37="$(command -v stat)"
+cat > "$tmp37/bin/stat" <<STUB_EOF
+#!/usr/bin/env bash
+if [ "\$1" = "-c" ] && [ "\$2" = "%u" ] && [ "\$3" = "$tmp37/attacker-0755" ]; then
+    echo 31337; exit 0
+fi
+exec "$real_stat37" "\$@"
+STUB_EOF
+chmod +x "$tmp37/bin/stat"
+out37="$( ( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR -u CONSOLE_WORK_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    TMPDIR="$tmp37/attacker-0755" \
+    PATH="$tmp37/bin:$PATH" \
+    bash "$C" new --bucket wdparent37 --dry-run ) 2>&1 )"; rc37=$?
+check "37 attacker-owned non-writable (0755) parent: refuses with a distinct exit code" "$rc37" "3"
+check "37 attacker-owned non-writable (0755) parent: stderr names the cause" "$(printf '%s\n' "$out37" | grep -ci parent)" "1"
+
+# --- 38 (control): a self-owned, non-writable (0755) parent must still be
+# accepted -- proves the round-5 ownership-first reordering does not
+# regress the ordinary, non-shared TMPDIR-fallback case.
+tmp38="$tmp/c38"
+mkdir -p "$tmp38/self-0755"
+chmod 0755 "$tmp38/self-0755"
+rc38=0
+( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR -u CONSOLE_WORK_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    TMPDIR="$tmp38/self-0755" \
+    bash "$C" new --bucket wdparent38 --dry-run ) >/dev/null 2>&1 || rc38=$?
+check "38 self-owned non-writable (0755) parent: accepted" "$rc38" "0"
+
+# --- 39: a RELATIVE CONSOLE_WORK_DIR must still walk the real ancestor
+# chain above the current working directory (HIMMEL-2881 round 5, codex-2
+# panel finding) -- a lexical `dirname` loop on a relative path like "work"
+# stops at "." (dirname(".") is itself "."), so only the cwd is ever
+# checked; canonicalizing to an absolute path first is required to reach an
+# insecure ancestor sitting above cwd.
+tmp39="$tmp/c39"
+mkdir -p "$tmp39/insecure-ancestor/cwd-dir"
+chmod 0777 "$tmp39/insecure-ancestor"
+chmod 0700 "$tmp39/insecure-ancestor/cwd-dir"
+out39="$( ( cd "$tmp39/insecure-ancestor/cwd-dir" && env -u XDG_RUNTIME_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    CONSOLE_WORK_DIR="work" \
+    bash "$C" new --bucket wdparent39 --dry-run ) 2>&1 )"; rc39=$?
+check "39 relative CONSOLE_WORK_DIR under an insecure ancestor: refuses with a distinct exit code" "$rc39" "3"
+check "39 relative CONSOLE_WORK_DIR under an insecure ancestor: stderr names the cause" "$(printf '%s\n' "$out39" | grep -ci parent)" "1"
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/handover/console/test-console.sh
+++ b/scripts/handover/console/test-console.sh
@@ -900,4 +900,50 @@ check "40 symlink ancestor in CONSOLE_WORK_DIR: dry-run succeeds" "$rc40" "0"
 check "40 symlink ancestor in CONSOLE_WORK_DIR: signal path resolves through the real target" "$(printf '%s\n' "$out40" | grep -c "signal=$tmp40/real-target/subdir/")" "1"
 check "40 symlink ancestor in CONSOLE_WORK_DIR: signal path never embeds the symlink spelling" "$(printf '%s\n' "$out40" | grep -c "signal=$tmp40/linky/")" "0"
 
+# --- 41: a MISSING intermediate ancestor of CONSOLE_WORK_DIR is skipped by
+# the ancestor-walk above (nothing to validate yet) and then created by a
+# single `mkdir -p` alongside the work dir itself, with no ownership check
+# of its own (HIMMEL-2881 round 7, codex-1 panel finding). A local attacker
+# who races to plant that ancestor between the walk and the create call gets
+# it silently adopted, then owns a directory in this process's path that was
+# never validated. A real race cannot be scheduled deterministically, so
+# (mirroring case 30's technique) a PATH stub for `mkdir` simulates the race
+# winner: the first time console.sh's own code tries to create anything
+# under the test's tmp tree, the stub plants the intermediate ancestor
+# itself at an insecure, self-owned mode (0777, no sticky bit) BEFORE
+# forwarding the original call to the real `mkdir` -- exactly what a raced
+# attacker directory would look like by the time this process next touches
+# that path.
+tmp41="$tmp/c41"
+mkdir -p "$tmp41/bin"
+chmod 0700 "$tmp41"
+mid41="$tmp41/mid"
+target41="$tmp41/mid/workdir"
+real_mkdir41="$(command -v mkdir)"
+cat > "$tmp41/bin/mkdir" <<STUB_EOF
+#!/usr/bin/env bash
+if [ ! -e "$tmp41/.raced41" ]; then
+    for a in "\$@"; do
+        case "\$a" in
+            "$tmp41"/*)
+                : > "$tmp41/.raced41"
+                "$real_mkdir41" -m 0777 -p "$mid41" 2>/dev/null
+                break
+                ;;
+        esac
+    done
+fi
+exec "$real_mkdir41" "\$@"
+STUB_EOF
+chmod +x "$tmp41/bin/mkdir"
+rc41=0
+out41="$( ( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    CONSOLE_WORK_DIR="$target41" \
+    PATH="$tmp41/bin:$PATH" \
+    bash "$C" new --bucket wdancestor41 --dry-run ) 2>&1 )"; rc41=$?
+check "41 raced intermediate ancestor of CONSOLE_WORK_DIR: refuses with a distinct exit code" "$rc41" "3"
+check "41 raced intermediate ancestor of CONSOLE_WORK_DIR: stderr names the cause" "$([ "$(printf '%s\n' "$out41" | grep -ci ancestor)" -ge 1 ] && echo yes || echo no)" "yes"
+check "41 raced intermediate ancestor of CONSOLE_WORK_DIR: never created the work dir beneath the raced ancestor" "$([ -e "$target41" ] && echo yes || echo no)" "no"
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/handover/console/test-console.sh
+++ b/scripts/handover/console/test-console.sh
@@ -658,4 +658,41 @@ sig29a="$(printf '%s\n' "$out29a" | sed -n 's/.*signal=\([^ ]*\).*/\1/p' | head 
 sig29b="$(printf '%s\n' "$out29b" | sed -n 's/.*signal=\([^ ]*\).*/\1/p' | head -n 1)"
 check "29 root spelled via a symlink alias yields the SAME signal path" "$([ -n "$sig29a" ] && [ "$sig29a" = "$sig29b" ] && echo yes)" "yes"
 
+# --- 30: work-dir creation TOCTOU (HIMMEL-2881 round 2, codex-1 panel
+# finding) -- if another local process wins the race between console.sh's
+# `[ ! -e ]` absence check and its `mkdir -p` call, planting a directory or
+# symlink first, `mkdir -p` treats the path as already-satisfied and returns
+# 0 without creating anything; console_workdir_ensure must not trust that
+# silent success and skip validation -- it must always re-check what is
+# actually at the path afterward. A real race cannot be scheduled
+# deterministically, so a PATH stub for `mkdir` simulates the race winner:
+# it plants a symlink at the exact target path (mirroring what a hostile
+# local user's pre-created symlink looks like once `mkdir -p` sees the path
+# as already existing) and exits 0 -- exactly what the real `mkdir -p` does
+# in that situation -- instead of ever actually creating the target
+# directory.
+tmp30="$tmp/c30"
+mkdir -p "$tmp30/bin" "$tmp30/elsewhere-30"
+target30="$tmp30/himmel-console-$(id -u)"
+real_mkdir30="$(command -v mkdir)"
+cat > "$tmp30/bin/mkdir" <<STUB_EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+    if [ "\$a" = "$target30" ]; then
+        ln -s "$tmp30/elsewhere-30" "$target30"
+        exit 0
+    fi
+done
+exec "$real_mkdir30" "\$@"
+STUB_EOF
+chmod +x "$tmp30/bin/mkdir"
+rc30=0
+out30="$( ( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR -u CONSOLE_WORK_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO TMPDIR="$tmp30" \
+    PATH="$tmp30/bin:$PATH" \
+    bash "$C" new --bucket wdtoctou --dry-run ) 2>&1 )" || rc30=$?
+check "30 work-dir creation TOCTOU: refuses with a distinct exit code" "$rc30" "3"
+check "30 work-dir creation TOCTOU: stderr names the cause" "$(printf '%s\n' "$out30" | grep -ci symlink)" "1"
+check "30 work-dir creation TOCTOU: never followed into elsewhere-30" "$([ -n "$(find "$tmp30/elsewhere-30" -mindepth 1 2>/dev/null)" ] && echo yes || echo no)" "no"
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/handover/console/test-console.sh
+++ b/scripts/handover/console/test-console.sh
@@ -721,4 +721,38 @@ case "$sig31" in
 esac
 check "31 group/world-writable XDG_RUNTIME_DIR is not preferred" "$sig31_branch" "fallback"
 
+# --- 32: a CONSOLE_WORK_DIR override sitting under a group/world-writable,
+# non-sticky PARENT must be refused (HIMMEL-2881 round 3, codex-1 panel
+# finding) -- console_workdir_ensure only ever validates the override path
+# itself, never its parent; an override is exactly as reachable by another
+# local user as the default path, so an insecure parent lets that user
+# swap the (validated) override directory out from under this process the
+# same way an insecure XDG_RUNTIME_DIR could. A sticky bit (as /tmp
+# normally has) would neutralize this, which is why the fixture parent is
+# deliberately NOT sticky (0777, not 1777).
+tmp32="$tmp/c32"
+mkdir -p "$tmp32/parent"
+chmod 0777 "$tmp32/parent"
+out32="$( ( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    CONSOLE_WORK_DIR="$tmp32/parent/work" \
+    bash "$C" new --bucket wdparent32 --dry-run ) 2>&1 )"; rc32=$?
+check "32 CONSOLE_WORK_DIR under an insecure parent: refuses with a distinct exit code" "$rc32" "3"
+check "32 CONSOLE_WORK_DIR under an insecure parent: stderr names the cause" "$(printf '%s\n' "$out32" | grep -ci parent)" "1"
+
+# --- 33: the TMPDIR-fallback work dir's parent (normally /tmp, sticky) must
+# be checked the same way when TMPDIR itself is overridden to a
+# group/world-writable, non-sticky directory (HIMMEL-2881 round 3, codex-1
+# panel finding, TMPDIR half). No XDG_RUNTIME_DIR and no CONSOLE_WORK_DIR
+# override, so the default TMPDIR-fallback path is exercised directly.
+tmp33="$tmp/c33"
+mkdir -p "$tmp33/insecure-tmp"
+chmod 0777 "$tmp33/insecure-tmp"
+out33="$( ( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR -u CONSOLE_WORK_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    TMPDIR="$tmp33/insecure-tmp" \
+    bash "$C" new --bucket wdparent33 --dry-run ) 2>&1 )"; rc33=$?
+check "33 TMPDIR-fallback under an insecure TMPDIR: refuses with a distinct exit code" "$rc33" "3"
+check "33 TMPDIR-fallback under an insecure TMPDIR: stderr names the cause" "$(printf '%s\n' "$out33" | grep -ci parent)" "1"
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/scripts/handover/console/test-console.sh
+++ b/scripts/handover/console/test-console.sh
@@ -877,4 +877,27 @@ out39="$( ( cd "$tmp39/insecure-ancestor/cwd-dir" && env -u XDG_RUNTIME_DIR \
 check "39 relative CONSOLE_WORK_DIR under an insecure ancestor: refuses with a distinct exit code" "$rc39" "3"
 check "39 relative CONSOLE_WORK_DIR under an insecure ancestor: stderr names the cause" "$(printf '%s\n' "$out39" | grep -ci parent)" "1"
 
+# --- 40: a symlink ANCESTOR of CONSOLE_WORK_DIR must be resolved ONCE and
+# the canonical form reused for every subsequent operation (HIMMEL-2881
+# round 6, codex-1 panel finding). console_workdir_ensure already refuses
+# $workdir itself being a symlink, but a symlink one level UP (workdir's
+# own last component still a plain, not-yet-existing directory) isn't
+# caught by that -- ancestor validation ran against the canonicalized path,
+# while creation/chain_dir previously kept the ORIGINAL, still-symlinked
+# spelling, so a swapped symlink between check and use could redirect
+# actual filesystem access to an unvalidated location. Proven here by
+# asserting the printed --dry-run --arm paths resolve through the REAL
+# target, never through the symlink spelling.
+tmp40="$tmp/c40"
+mkdir -p "$tmp40/real-target"
+chmod 0700 "$tmp40/real-target"
+ln -s "$tmp40/real-target" "$tmp40/linky"
+out40="$( ( cd "$fixture_repo" && env -u XDG_RUNTIME_DIR \
+    HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    CONSOLE_WORK_DIR="$tmp40/linky/subdir" \
+    bash "$C" new --bucket wdparent40 --dry-run --arm ) 2>&1 )"; rc40=$?
+check "40 symlink ancestor in CONSOLE_WORK_DIR: dry-run succeeds" "$rc40" "0"
+check "40 symlink ancestor in CONSOLE_WORK_DIR: signal path resolves through the real target" "$(printf '%s\n' "$out40" | grep -c "signal=$tmp40/real-target/subdir/")" "1"
+check "40 symlink ancestor in CONSOLE_WORK_DIR: signal path never embeds the symlink spelling" "$(printf '%s\n' "$out40" | grep -c "signal=$tmp40/linky/")" "0"
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
## Summary

- **HIMMEL-2889**: folds a deterministic digest of the resolved, canonicalized handover root into the per-chain console work-dir name, so two chains resolving to different roots never collide on the same signal/log directory.
- **HIMMEL-2881**: hardens `console_workdir_ensure()` against pre-creation or ancestor manipulation by another local user. The default/overridden console work dir now refuses loudly (exit code 3) rather than silently adopting or following anything it does not control.

## HIMMEL-2881 round-by-round (critic panel, `CR_PROFILE=paid`)

Eight rounds of adversarial review against the TOCTOU class, each fixing a genuine Important finding the previous round's fix left open:

1. `d1332480` — parent-dir check must require trusted ownership, not just non-group/world-writable.
2. `e10e8aa4` — annotate the new ownership stat call (chore, no behavior change).
3. `f1c6ffc1` — gate parent-dir safety on ownership first, before the writability bits.
4. `b293e871` — reuse the validated canonical path for work-dir creation instead of re-deriving it.
5. `f5fe38c8` — refuse a group- or world-writable `XDG_RUNTIME_DIR`.
6. `bb6a9edb` — generalize work-dir parent-writability checks to the full ancestor chain.
7. `fa6116d3` — `_console_ancestor_unsafe` only validates EXISTING ancestors; a missing one was created via `mkdir -p`, which silently adopts anything raced into existence between the check and the create with no ownership validation of its own. Fixed with `_console_mkdir_chain_safe()`, which creates the missing chain one component at a time (never `-p`), validating ownership the instant each component exists.
8. `9644b80c` — round 7's own fix had a residual gap: its missing-component scan stops at the first *currently* existing ancestor and trusts it as the create loop's base, but that ancestor could have been raced into existence in the window between the earlier `_console_ancestor_unsafe` walk and this scan. Fixed by re-running `_console_ancestor_unsafe` against that boundary immediately before it is trusted.

Round 9 (final, this head): 0 Critical, 0 Important, 0 Suggestions. CR marker cleared.

Every round followed strict TDD — a RED test proving the gap before the fix, GREEN after, full 140-case suite re-run each time with no regressions. Cases 27–42 in `scripts/handover/console/test-console.sh` cover the work-dir hardening (symlinks, TOCTOU races, insecure/sticky/attacker-owned parents and grandparents, group/world-writable `XDG_RUNTIME_DIR`/`TMPDIR`).

## Cap disposition

Nine rounds total on the 2881 hardening path, each narrower than the last: TOCTOU on the create branch → XDG_RUNTIME_DIR permission bits → parent-dir ownership + full ancestor walk → per-ancestor ownership/canonicalization → missing-ancestor creation → the round-8 residual race on the scan boundary. Round 9 came back clean (0/0/0), closing the path.

All 12 ledger findings recorded across rounds 1–8 are now adjudicated: 10 `fixed` (each resolved by the very next commit in the chain above), and 2 `disproved` — both Suggestions asking to "explicitly propagate" canonicalization/hashing/digest failures out of a command substitution. `console.sh` has carried `set -euo pipefail` since before round 1 (line 38), and a failing command inside a plain-assignment command substitution (`x=$(cmd)`, not part of an `if`/`&&`/`||`/negation) already triggers `errexit` — verified directly (`bash -c 'set -e; f(){ return 3; }; x=$(f)'` exits 3). The failure mode the findings describe does not occur.

Follow-up candidate, no ticket needed: the ownership/mode-bit parser (`stat -c %a ... || stat -f %Lp ...` plus the digit-classification that follows) is duplicated three times (`console.sh:324`, `397`, `542`). Worth a shared helper next time this file is touched; not part of this PR's scope.

## Out of scope / follow-up

`scripts/handover/console-kit/` (including `headed-arm-leg.sh`, owned by leg N159/HIMMEL-2830, and `tick.sh`) is untouched — it has no call site into `console_workdir_ensure`/`_console_mkdir_chain_safe` today, but if a future change gives it one, the same TOCTOU hardening applies and should be tracked under HIMMEL-2830 rather than reimplemented locally.

## Test plan

- [x] `bash scripts/quiet-run.sh <label> -- bash scripts/handover/console/test-console.sh` — 140/140 ALL PASS
- [x] `shellcheck scripts/handover/console/console.sh` — clean
- [x] `/pr-check` round 9 — 0 Critical, 0 Important, marker cleared
- [x] CI green — 24/24 required checks passing
- [x] CodeRabbit review — rate-limited at this head (HIMMEL-1465 fallback: clean local critic panel carries the gate); 0 review threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZX6yQXD3L8EqZzLAFBXDJ
