### PR TITLE
fix(himmelctl): [HIMMEL-2890] bridge-health poller-count on Linux/macOS

### DIFF
--- a/docs/setup/new-machine.md
+++ b/docs/setup/new-machine.md
@@ -853,7 +853,7 @@ for something never turned on:
 | `luna-sources` | each configured fetch-health source, via `fetch-health.py --probe <source>` |
 | `phi-coherence` | a `.salus` marker under the vault vs. its listing in `phi-roots` — reports `degraded` on a mismatch, **never red** |
 | `engine-allowlist` | armed cadence legs' required engines against `cadence-approve-engines.sh --print-engine-list` |
-| `bridge-health` | `access.json` + a live `getMe` call + exactly one `getUpdates` consumer (it counts `poller.ts` command lines anchored to THIS checkout, so a supervisor plus its poller child is one consumer, not two). The consumer count is Windows-CIM-only today: elsewhere it reports `degraded` naming process identity as unverified, never a silent pass |
+| `bridge-health` | `access.json` + a live `getMe` call + exactly one `getUpdates` consumer (it counts `poller.ts` command lines anchored to THIS checkout, so a supervisor plus its poller child is one consumer, not two). Windows uses CIM; Linux/macOS prefer `systemctl --user show telegram-bridge.service` and walk its MainPID's children (`pgrep -f <poller path>` when no unit exists). Any other platform reports `degraded` naming process identity as unverified, never a silent pass |
 | `bridge-persistence` | whether bridge persistence will actually survive a restart |
 
 `bridge-persistence` is pass/warn/opt-in — it never reports a hard red once

--- a/scripts/himmelctl/lib/probes.js
+++ b/scripts/himmelctl/lib/probes.js
@@ -2714,12 +2714,140 @@ function pollerLineIsThisCheckout(line, thisCheckoutAnchor) {
   return normalizeForPollerAnchorMatch(token) === thisCheckoutAnchor;
 }
 
+// ── Linux/macOS poller-count (HIMMEL-2890) ──────────────────────────────────
+// Unlike the Windows branch's binary present/absent (a foreign checkout's
+// commandline carries no path in the common bare-token shape, so "duplicate"
+// and "zero" collapse to the same "not exactly 1" bucket there), the ticket's
+// contract here is a genuine 3-way split: 1 = present (green), 0 = absent
+// (red, unit active but no poller), >1 = degraded (duplicate pollers,
+// HIMMEL-1555 class) — "same object shape [as Windows]" means the returned
+// `{actual, detail}` fields, not the same present/absent enum mapping.
+//
+// Prefers `systemctl --user show telegram-bridge.service` (MainPID +
+// ActiveState + LoadState) when systemd is present and knows the unit;
+// otherwise (no systemctl on PATH, or LoadState=not-found — genuinely no
+// unit registered) falls back to `pgrep -f <resolved poller path>`, per the
+// ticket's explicit adopters-running-the-bridge-by-hand case (e).
+//
+// Child enumeration: `/proc/<pid>/task/*/children` on Linux (walking every
+// thread's children file, since a single-threaded MainPID's own children
+// file lives at task/<mainpid>/children) — overridable via ctx.procRoot
+// (test-only seam) since a real hermetic test cannot fabricate genuine PIDs.
+// Where ctx.procRoot doesn't exist as a real directory (macOS has no /proc
+// at all), falls back to `pgrep -P <pid>` for children and `ps -o args= -p`
+// for each child's argv — HIMMEL-1532's existing checkout-path anchor
+// (extractPollerToken/pollerLineIsThisCheckout above) matches equally well
+// against a POSIX argv string as against a Windows CommandLine, so no new
+// matching logic is needed here.
+function posixProcRoot(ctx) {
+  return (ctx && ctx.procRoot) || '/proc';
+}
+
+function posixChildPids(pid, procRoot, env) {
+  if (fs.existsSync(procRoot)) {
+    const taskDir = path.join(procRoot, String(pid), 'task');
+    let tids;
+    try {
+      tids = fs.readdirSync(taskDir);
+    } catch (_e) {
+      return null;
+    }
+    const pids = new Set();
+    for (const tid of tids) {
+      try {
+        const raw = fs.readFileSync(path.join(taskDir, tid, 'children'), 'utf8');
+        raw.split(/\s+/).filter(Boolean).forEach((p) => pids.add(p));
+      } catch (_e) { /* thread exited between readdir and read — skip */ }
+    }
+    return Array.from(pids);
+  }
+  const pgrepBin = which('pgrep', env);
+  if (!pgrepBin) return null;
+  const r = spawnProbeSync(pgrepBin, ['-P', String(pid)], { env, encoding: 'utf8' });
+  if (r.error || (r.status !== 0 && r.status !== 1)) return null; // pgrep rc=1 == no matches, not a failure
+  return (r.stdout || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+}
+
+function posixCmdline(pid, procRoot, env) {
+  if (fs.existsSync(procRoot)) {
+    try {
+      const raw = fs.readFileSync(path.join(procRoot, String(pid), 'cmdline'));
+      return raw.toString('utf8').split('\0').filter(Boolean).join(' ');
+    } catch (_e) {
+      return null;
+    }
+  }
+  const r = spawnProbeSync('ps', ['-o', 'args=', '-p', String(pid)], { env, encoding: 'utf8' });
+  if (r.error || r.status !== 0) return null;
+  return (r.stdout || '').trim();
+}
+
+function posixPollerVerdict(n, source) {
+  if (n === 1) return { actual: 'present', detail: `1 poller.ts process running for this checkout (${source}; a supervisor parent, if any, is not counted)` };
+  if (n === 0) return { actual: 'absent', detail: `0 poller.ts process(es) running for this checkout (${source}; expected exactly 1)` };
+  return { actual: 'degraded', detail: `${n} poller.ts processes running for this checkout (${source}; expected exactly 1 — duplicate pollers, HIMMEL-1555 class)` };
+}
+
+function probeBridgePollerCountPosix(ctx) {
+  const env = ctx.env || process.env;
+  const procRoot = posixProcRoot(ctx);
+  const thisCheckoutAnchor = ctx.repoRoot
+    ? normalizeForPollerAnchorMatch(path.join(ctx.repoRoot, 'scripts', 'telegram', 'poller.ts'))
+    : null;
+
+  const systemctlBin = which('systemctl', env);
+  if (systemctlBin) {
+    const show = spawnProbeSync(systemctlBin, ['--user', 'show', 'telegram-bridge.service', '-p', 'MainPID', '-p', 'ActiveState', '-p', 'LoadState'], { env, encoding: 'utf8' });
+    if (show.timedOut) return { actual: 'degraded', detail: `poller-count probe timed out after ${probeTimeoutSecs(show)}s` };
+    if (show.error) return { actual: 'degraded', detail: `spawn error: ${show.error.message}` };
+    if (show.status === 0) {
+      const props = {};
+      (show.stdout || '').split(/\r?\n/).forEach((line) => {
+        const m = /^([A-Za-z]+)=(.*)$/.exec(line);
+        if (m) props[m[1]] = m[2];
+      });
+      if (props.LoadState && props.LoadState !== 'not-found') {
+        if (props.ActiveState !== 'active' || !props.MainPID || props.MainPID === '0') {
+          return { actual: 'absent', detail: `telegram-bridge.service is not active (ActiveState=${props.ActiveState || 'unknown'}) — 0 poller.ts processes running for this checkout` };
+        }
+        const childPids = posixChildPids(props.MainPID, procRoot, env);
+        if (childPids === null) {
+          return { actual: 'degraded', detail: `could not enumerate child processes of telegram-bridge.service MainPID ${props.MainPID} — process identity is UNVERIFIED, not assumed healthy` };
+        }
+        const lines = childPids.map((pid) => posixCmdline(pid, procRoot, env)).filter(Boolean);
+        const n = lines.filter((line) => pollerLineIsThisCheckout(line, thisCheckoutAnchor)).length;
+        return posixPollerVerdict(n, 'via systemd MainPID children');
+      }
+      // LoadState absent/not-found -- systemd genuinely doesn't know this unit; fall through to the pgrep -f fallback below.
+    }
+  }
+
+  const pgrepBin = which('pgrep', env);
+  if (!pgrepBin) {
+    return {
+      actual: 'degraded',
+      detail: 'poller-count check unavailable — no telegram-bridge.service systemd unit and no pgrep on PATH; process identity is UNVERIFIED, not assumed healthy',
+    };
+  }
+  if (!ctx.repoRoot) {
+    return { actual: 'degraded', detail: 'poller-count check needs ctx.repoRoot to anchor pgrep -f, none provided' };
+  }
+  const pollerPath = path.join(ctx.repoRoot, 'scripts', 'telegram', 'poller.ts');
+  const r = spawnProbeSync(pgrepBin, ['-f', pollerPath], { env, encoding: 'utf8' });
+  if (r.timedOut) return { actual: 'degraded', detail: `poller-count probe timed out after ${probeTimeoutSecs(r)}s` };
+  if (r.error) return { actual: 'degraded', detail: `spawn error: ${r.error.message}` };
+  if (r.status !== 0 && r.status !== 1) return { actual: 'degraded', detail: `pgrep poller-count query exited rc=${r.status}` };
+  const n = (r.stdout || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean).length;
+  return posixPollerVerdict(n, 'via pgrep -f, no systemd unit found');
+}
+
 function probeBridgePollerCount(ctx) {
   const platform = ctx.platform || process.platform;
   if (platform !== 'win32') {
+    if (platform === 'linux' || platform === 'darwin') return probeBridgePollerCountPosix(ctx);
     return {
       actual: 'degraded',
-      detail: `poller-count check not implemented on '${platform}' — Windows-CIM-only today (HIMMEL-2176); process identity is UNVERIFIED here, not assumed healthy`,
+      detail: `poller-count check not implemented on '${platform}' — Windows/Linux/macOS only today (HIMMEL-2176/HIMMEL-2890); process identity is UNVERIFIED here, not assumed healthy`,
     };
   }
   const env = ctx.env || process.env;

--- a/scripts/himmelctl/lib/probes.js
+++ b/scripts/himmelctl/lib/probes.js
@@ -2814,8 +2814,12 @@ function probeBridgePollerCountPosix(ctx) {
         if (childPids === null) {
           return { actual: 'degraded', detail: `could not enumerate child processes of telegram-bridge.service MainPID ${props.MainPID} — process identity is UNVERIFIED, not assumed healthy` };
         }
-        const lines = childPids.map((pid) => posixCmdline(pid, procRoot, env)).filter(Boolean);
-        const n = lines.filter((line) => pollerLineIsThisCheckout(line, thisCheckoutAnchor)).length;
+        const cmdlines = childPids.map((pid) => ({ pid, cmdline: posixCmdline(pid, procRoot, env) }));
+        const unreadable = cmdlines.filter((c) => c.cmdline === null);
+        if (unreadable.length > 0) {
+          return { actual: 'degraded', detail: `could not read cmdline for child pid(s) ${unreadable.map((c) => c.pid).join(', ')} of telegram-bridge.service MainPID ${props.MainPID} — process identity is UNVERIFIED, not assumed healthy` };
+        }
+        const n = cmdlines.filter((c) => pollerLineIsThisCheckout(c.cmdline, thisCheckoutAnchor)).length;
         return posixPollerVerdict(n, 'via systemd MainPID children');
       }
       // LoadState absent/not-found -- systemd genuinely doesn't know this unit; fall through to the pgrep -f fallback below.

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -4431,12 +4431,16 @@ echo "$outBH2" | jq -e '.actual == "absent"' >/dev/null \
   || fail "bridge-health: 2 poller.ts processes (a supervisor+2 pollers or a duplicate) should read absent (fail) (got: $outBH2)"
 echo "ok: bridge-health — 2 poller.ts processes (never exactly 1) reads absent (fail), never a false present"
 
-outBHposix=$(run_bh 'bun.exe poller.ts' linux)
+# HIMMEL-2890: linux/darwin now have a real implementation (see the
+# dedicated Linux poller-count block below) — this case now covers a
+# platform NEITHER Windows-CIM NOR the new POSIX path supports at all, so
+# the generic "not implemented" degraded fallback still has live coverage.
+outBHposix=$(run_bh 'bun.exe poller.ts' freebsd)
 echo "$outBHposix" | jq -e '.actual == "degraded"' >/dev/null \
-  || fail "bridge-health: a non-win32 platform must read a LOUD degraded (HIMMEL-1128), never a silent present just because the token/access checks pass (got: $outBHposix)"
+  || fail "bridge-health: a platform with no poller-count implementation at all must read a LOUD degraded (HIMMEL-1128), never a silent present just because the token/access checks pass (got: $outBHposix)"
 echo "$outBHposix" | jq -e '.detail | test("not implemented"; "i")' >/dev/null \
-  || fail "bridge-health: the POSIX-degraded detail should name the limitation explicitly (got: $outBHposix)"
-echo "ok: bridge-health — a non-Windows platform reads a LOUD degraded naming the poller-count limitation, never a silent pass"
+  || fail "bridge-health: the not-implemented-platform degraded detail should name the limitation explicitly (got: $outBHposix)"
+echo "ok: bridge-health — a platform with no poller-count implementation at all reads a LOUD degraded naming the limitation, never a silent pass"
 
 # CR fix (codex-4, retask stage1-build-6d2e): a poller.ts token explicitly
 # PATHED to THIS checkout's own root (mixed-slash form, matching winpath's
@@ -4506,6 +4510,174 @@ outBHsupervisorPlusChild=$(run_bh "$(printf 'bun.exe supervisor.ts\nbun.exe poll
 echo "$outBHsupervisorPlusChild" | jq -e '.actual == "present"' >/dev/null \
   || fail "bridge-health: a supervisor.ts line alongside its poller.ts child must still read exactly 1 consumer (got: $outBHsupervisorPlusChild)"
 echo "ok: bridge-health — a supervisor-plus-child pair still reads as exactly one poller.ts consumer"
+
+# ── bridge-health poller-count — Linux/macOS (HIMMEL-2890) ──────────────────
+# Unlike Windows' binary present/absent, the Linux/macOS contract is a
+# genuine 3-way split: 1 = present, 0 = absent, >1 = degraded (duplicate
+# pollers, HIMMEL-1555 class). Prefers `systemctl --user show
+# telegram-bridge.service -p MainPID -p ActiveState -p LoadState` when
+# systemd knows the unit, walking MainPID's children via a fixture
+# `/proc`-shaped tree (ctx.procRoot, a test-only seam — a real hermetic test
+# cannot fabricate genuine PIDs); LoadState=not-found (systemd genuinely
+# doesn't know this unit) falls back to `pgrep -f <resolved poller path>`.
+# Same stub-log SKIP-gate convention as the bridge-persistence Linux block
+# above (bp_stub_log_has) — a real Linux/macOS host runs every assertion for
+# real; a host where an extensionless bash-shebang stub can't spawn SKIPs
+# rather than faking a pass.
+bh_posix_stub="$work/bh-posix-stub"
+build_hermetic_bin "$bh_posix_stub" bun cat
+bh_posix_log="$work/bh-posix-stub.log"
+bh_posix_state="$work/bh-posix-stub-state"; mkdir -p "$bh_posix_state"
+bh_proc_root="$work/bh-proc-root"
+
+cat > "$bh_posix_stub/systemctl" <<'STUB'
+#!/usr/bin/env bash
+: "${BH_STUB_LOG:?}"
+echo "systemctl $*" >> "$BH_STUB_LOG"
+case "$*" in
+  "--user show telegram-bridge.service -p MainPID -p ActiveState -p LoadState")
+    if [ -f "${BH_STUB_STATE:?}/no-unit" ]; then
+      echo "LoadState=not-found"
+      exit 0
+    fi
+    echo "MainPID=$(cat "${BH_STUB_STATE:?}/mainpid" 2>/dev/null || echo 0)"
+    echo "ActiveState=$(cat "${BH_STUB_STATE:?}/activestate" 2>/dev/null || echo inactive)"
+    echo "LoadState=loaded"
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$bh_posix_stub/systemctl"
+
+cat > "$bh_posix_stub/pgrep" <<'STUB'
+#!/usr/bin/env bash
+: "${BH_STUB_LOG:?}"
+echo "pgrep $*" >> "$BH_STUB_LOG"
+n="${BH_PGREP_N:-0}"
+if [ "$n" -le 0 ]; then exit 1; fi
+i=1
+while [ "$i" -le "$n" ]; do echo "$((9200 + i))"; i=$((i + 1)); done
+exit 0
+STUB
+chmod +x "$bh_posix_stub/pgrep"
+
+bh_posix_log_has() { [ -f "$bh_posix_log" ] && grep -qF "$1" "$bh_posix_log"; }
+
+run_bh_posix() {
+  local pathVal
+  pathVal="$bh_posix_stub:$(scrub_path "$PATH" systemctl pgrep)"
+  PATH="$pathVal" BH_STUB_LOG="$(winpath "$bh_posix_log")" BH_STUB_STATE="$(winpath "$bh_posix_state")" \
+    BH_PGREP_N="${BH_PGREP_N:-0}" "$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'bridge-health');
+const ctx = { repoRoot: '$repo_root_w', targetPath: '$(winpath "$bh_dir")', scope: 'project', platform: 'linux', procRoot: '$(winpath "$bh_proc_root")', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+"
+}
+
+other_checkout_posix="/home/testuser/github/himmel/.claude/worktrees/feat-some-other-checkout"
+
+# ── case (a): unit active, one matching child -> present, count 1 ─────────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9002"
+printf '9002\n' > "$bh_proc_root/9001/task/9001/children"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9002/cmdline"
+rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
+outBHlinuxA=$(BH_PGREP_N=0 run_bh_posix)
+if bh_posix_log_has "show telegram-bridge.service"; then
+  echo "$outBHlinuxA" | jq -e '.actual == "present"' >/dev/null \
+    || fail "bridge-health (Linux): unit active + exactly 1 matching child should read present (got: $outBHlinuxA)"
+  echo "$outBHlinuxA" | jq -e '.detail | contains("1 poller")' >/dev/null \
+    || fail "bridge-health (Linux): present detail should name the count 1 (got: $outBHlinuxA)"
+  echo "ok: bridge-health (Linux) — unit active, one matching child reads present, count 1"
+else
+  echo "SKIP: bridge-health (Linux) case (a): no evidence in the stub log that systemctl actually spawned on this host"
+fi
+
+# ── case (b): unit active, no matching child -> absent, count 0 ───────────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001"
+printf '\n' > "$bh_proc_root/9001/task/9001/children"
+rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
+outBHlinuxB=$(BH_PGREP_N=0 run_bh_posix)
+if bh_posix_log_has "show telegram-bridge.service"; then
+  echo "$outBHlinuxB" | jq -e '.actual == "absent"' >/dev/null \
+    || fail "bridge-health (Linux): unit active + no matching child should read absent (got: $outBHlinuxB)"
+  echo "$outBHlinuxB" | jq -e '.detail | contains("0 poller")' >/dev/null \
+    || fail "bridge-health (Linux): absent detail should name the count 0 (got: $outBHlinuxB)"
+  echo "ok: bridge-health (Linux) — unit active, no matching child reads absent, count 0"
+else
+  echo "SKIP: bridge-health (Linux) case (b): no evidence in the stub log that systemctl actually spawned on this host"
+fi
+
+# ── case (c): two matching children -> degraded, count 2 (HIMMEL-1555) ────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9002" "$bh_proc_root/9003"
+printf '9002 9003\n' > "$bh_proc_root/9001/task/9001/children"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9002/cmdline"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9003/cmdline"
+rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
+outBHlinuxC=$(BH_PGREP_N=0 run_bh_posix)
+if bh_posix_log_has "show telegram-bridge.service"; then
+  echo "$outBHlinuxC" | jq -e '.actual == "degraded"' >/dev/null \
+    || fail "bridge-health (Linux): 2 matching children should read degraded, never present/absent (got: $outBHlinuxC)"
+  echo "$outBHlinuxC" | jq -e '.detail | contains("2 poller")' >/dev/null \
+    || fail "bridge-health (Linux): degraded detail should name the count 2 (got: $outBHlinuxC)"
+  echo "ok: bridge-health (Linux) — two matching children reads degraded, count 2 (duplicate pollers, HIMMEL-1555 class)"
+else
+  echo "SKIP: bridge-health (Linux) case (c): no evidence in the stub log that systemctl actually spawned on this host"
+fi
+
+# ── case (d): a child running a poller from a DIFFERENT checkout -> not
+# counted (HIMMEL-1532 control) ─────────────────────────────────────────────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9002"
+printf '9002\n' > "$bh_proc_root/9001/task/9001/children"
+printf '%s\0' bun "${other_checkout_posix}/scripts/telegram/poller.ts" > "$bh_proc_root/9002/cmdline"
+rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
+outBHlinuxD=$(BH_PGREP_N=0 run_bh_posix)
+if bh_posix_log_has "show telegram-bridge.service"; then
+  echo "$outBHlinuxD" | jq -e '.actual == "absent"' >/dev/null \
+    || fail "bridge-health (Linux): a child poller pathed to a DIFFERENT checkout must not be counted as this one's (got: $outBHlinuxD)"
+  echo "$outBHlinuxD" | jq -e '.detail | contains("0 poller")' >/dev/null \
+    || fail "bridge-health (Linux): a foreign-checkout child should read as 0 for THIS checkout (got: $outBHlinuxD)"
+  echo "ok: bridge-health (Linux) — a child poller pathed to a DIFFERENT checkout is excluded, never counted as this checkout's"
+else
+  echo "SKIP: bridge-health (Linux) case (d): no evidence in the stub log that systemctl actually spawned on this host"
+fi
+
+# ── case (e): no systemd unit at all -> pgrep -f fallback over the resolved
+# poller path, same 0/1/>1 mapping ──────────────────────────────────────────
+rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
+outBHlinuxE0=$(BH_PGREP_N=0 run_bh_posix)
+if bh_posix_log_has "pgrep -f"; then
+  echo "$outBHlinuxE0" | jq -e '.actual == "absent"' >/dev/null \
+    || fail "bridge-health (Linux): no systemd unit + 0 pgrep matches should read absent (got: $outBHlinuxE0)"
+  echo "ok: bridge-health (Linux) — no systemd unit, pgrep -f fallback with 0 matches reads absent"
+else
+  echo "SKIP: bridge-health (Linux) case (e/0): no evidence in the stub log that pgrep actually spawned on this host"
+fi
+
+rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
+outBHlinuxE1=$(BH_PGREP_N=1 run_bh_posix)
+if bh_posix_log_has "pgrep -f"; then
+  echo "$outBHlinuxE1" | jq -e '.actual == "present"' >/dev/null \
+    || fail "bridge-health (Linux): no systemd unit + 1 pgrep match should read present (got: $outBHlinuxE1)"
+  echo "ok: bridge-health (Linux) — no systemd unit, pgrep -f fallback with 1 match reads present"
+else
+  echo "SKIP: bridge-health (Linux) case (e/1): no evidence in the stub log that pgrep actually spawned on this host"
+fi
+
+rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
+outBHlinuxE2=$(BH_PGREP_N=2 run_bh_posix)
+if bh_posix_log_has "pgrep -f"; then
+  echo "$outBHlinuxE2" | jq -e '.actual == "degraded"' >/dev/null \
+    || fail "bridge-health (Linux): no systemd unit + 2 pgrep matches should read degraded (got: $outBHlinuxE2)"
+  echo "$outBHlinuxE2" | jq -e '.detail | contains("2 poller")' >/dev/null \
+    || fail "bridge-health (Linux): pgrep-fallback degraded detail should name the count 2, not just a generic not-implemented degraded (got: $outBHlinuxE2)"
+  echo "ok: bridge-health (Linux) — no systemd unit, pgrep -f fallback with 2 matches reads degraded, count 2"
+else
+  echo "SKIP: bridge-health (Linux) case (e/2): no evidence in the stub log that pgrep actually spawned on this host"
+fi
+rm -f "$bh_posix_state/no-unit"
 
 # ── bridge-persistence — HIMMEL-2176 Stage-1 PR-C, status item S6 ───────────
 # Contract (spec §3.5): logon task (win) / systemd unit + linger (linux)

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -4525,7 +4525,22 @@ echo "ok: bridge-health — a supervisor-plus-child pair still reads as exactly 
 # real; a host where an extensionless bash-shebang stub can't spawn SKIPs
 # rather than faking a pass.
 bh_posix_stub="$work/bh-posix-stub"
-build_hermetic_bin "$bh_posix_stub" bun cat
+build_hermetic_bin "$bh_posix_stub" cat
+# bridge-health is a composite probe (accessResult + getMeResult +
+# pollerResult, see probeBridgeHealth) — runProbe below exercises the WHOLE
+# item, not poller-count in isolation, so the getMe sub-check's real `bun`
+# child process is on the critical path too. build_hermetic_bin only links
+# the REAL binary (by design, HIMMEL-2535); a real bun genuinely calling
+# Telegram's API would make this fixture's verdict depend on live network
+# reachability and a real bot token, neither of which this suite controls.
+# Fake it the same way the Windows-lane `$bh_stub/bun` above already does
+# (unconditional `ok:testbot`) so only the poller-count sub-result under
+# test varies across cases (a)-(e).
+cat > "$bh_posix_stub/bun" <<'STUB'
+#!/usr/bin/env bash
+echo "ok:testbot"
+STUB
+chmod +x "$bh_posix_stub/bun"
 bh_posix_log="$work/bh-posix-stub.log"
 bh_posix_state="$work/bh-posix-stub-state"; mkdir -p "$bh_posix_state"
 bh_proc_root="$work/bh-proc-root"

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -4644,6 +4644,26 @@ else
   echo "SKIP: bridge-health (Linux) case (d): no evidence in the stub log that systemctl actually spawned on this host"
 fi
 
+# ── case (d2): a child pid whose cmdline cannot be read -> degraded, never
+# silently dropped from the count (process identity must be UNVERIFIED, not
+# assumed healthy) ──────────────────────────────────────────────────────────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9002"
+printf '9002 9003\n' > "$bh_proc_root/9001/task/9001/children"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9002/cmdline"
+# 9003 has no cmdline file at all -- simulates the process exiting between
+# the children-list read and the cmdline read, or a permission failure.
+rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
+outBHlinuxD2=$(BH_PGREP_N=0 run_bh_posix)
+if bh_posix_log_has "show telegram-bridge.service"; then
+  echo "$outBHlinuxD2" | jq -e '.actual == "degraded"' >/dev/null \
+    || fail "bridge-health (Linux): a child pid with an unreadable cmdline must read degraded, never be silently dropped from the count (got: $outBHlinuxD2)"
+  echo "$outBHlinuxD2" | jq -e '.detail | contains("could not read cmdline")' >/dev/null \
+    || fail "bridge-health (Linux): degraded detail should name the unreadable-cmdline cause (got: $outBHlinuxD2)"
+  echo "ok: bridge-health (Linux) — a child pid with an unreadable cmdline reads degraded, not silently dropped"
+else
+  echo "SKIP: bridge-health (Linux) case (d2): no evidence in the stub log that systemctl actually spawned on this host"
+fi
+
 # ── case (e): no systemd unit at all -> pgrep -f fallback over the resolved
 # poller path, same 0/1/>1 mapping ──────────────────────────────────────────
 rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"


### PR DESCRIPTION
## Summary
- Implements the `bridge-health` status item's `poller-count` check on Linux/macOS in `scripts/himmelctl/lib/probes.js`, matching the existing Windows-CIM implementation's `{actual, detail}` shape.
- Unlike Windows' binary present/absent, Linux/macOS is a genuine 3-way split (1=present, 0=absent, >1=degraded, HIMMEL-1555 class): prefers `systemctl --user show telegram-bridge.service`, walks MainPID's children via `/proc`, falls back to `pgrep -f` over the resolved poller path when systemd doesn't know the unit. Reuses the existing HIMMEL-1532 checkout-path anchoring (`pollerLineIsThisCheckout`) unchanged.
- Follow-up commit (round-1 `/pr-check` fix, codex-2): a child pid whose `/proc/<pid>/cmdline` cannot be read now reads `degraded` naming the pid, instead of being silently dropped from the count.
- Updated `docs/setup/new-machine.md`.

## CR gate
Two `/pr-check` rounds, 0 blocking. Three Important + one Suggestion design-scope findings (round 2: recursive/immediate-children walk scope, no system-wide duplicate check once systemd owns MainPID, unescaped `pgrep -f` fallback matching) verified real but inherent to the MainPID-children-walk design this ticket's contract specified — deferred to HIMMEL-2932 per HIMMEL-2375 rather than redesigning the counting algorithm and RED-phase fixtures in this PR.

## Test plan
- [x] `bash scripts/himmelctl/test/test-wizard-probes.sh` — GREEN, including new RED-phase Linux cases (a)-(e) plus (d2) for the unreadable-cmdline fix.
- [x] Impacted suites re-run clean.
- [x] Live station check on this Linux host: `green  bridge-health  token getMe ok; access.json schema ok; 1 poller.ts process running for this checkout (via systemd MainPID children; a supervisor parent, if any, is not counted)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wJCBWE5sfknquRk2rWRHe

