### PR TITLE
fix(console): [HIMMEL-2888] /console next inherits the predecessor's --model

### DIFF
--- a/docs/handover/console-template.md
+++ b/docs/handover/console-template.md
@@ -148,14 +148,17 @@ own end-of-session hook still writing — it prunes on the next sweep.
 
 At **{{FILL_PERCENT}} % fill or 90 k input in one turn**, hand over:
 
-1. `/console next --arm --doc "{{STATE_DIR}}/{{SESSION_NAME}}.md" --bucket {{BUCKET}} --prefix {{PREFIX}}`
+1. `/console next --arm --doc "{{STATE_DIR}}/{{SESSION_NAME}}.md" --bucket {{BUCKET}} --prefix {{PREFIX}} --model {{MODEL}}`
    — writes the successor stub, writes this console's `-HANDOFF.md` skeleton,
-   and arms the successor. **Name your own document bucket and prefix explicitly.**
-   Without `--doc`, `next` hands over from the highest-lettered doc it finds,
-   which is the wrong one the moment another `new` has run or a successor
-   already exists; without `--bucket` and `--prefix` it resolves those from the
-   environment and writes the successor into the wrong bucket, or under the
-   wrong key, rather than continuing this chain. It prints
+   and arms the successor. **Name your own document, bucket, prefix and model
+   explicitly.** Without `--doc`, `next` hands over from the highest-lettered
+   doc it finds, which is the wrong one the moment another `new` has run or a
+   successor already exists; without `--bucket` and `--prefix` it resolves
+   those from the environment and writes the successor into the wrong bucket,
+   or under the wrong key, rather than continuing this chain; without
+   `--model` it re-resolves the model from `CONSOLE_MODEL` or the built-in
+   default instead of continuing on **{{MODEL}}**, the model this console
+   itself runs on. It prints
    the successor's signal path on its `armed:` line — **that** is the path
    step 3 touches, not this console's own `{{FILL_SIGNAL}}` (which fired when
    *this* session launched and nothing waits on it any more).

--- a/docs/handover/running-a-console.md
+++ b/docs/handover/running-a-console.md
@@ -146,15 +146,18 @@ back when it lands.
 Consoles hand over at **45 % context fill, or 90 k input tokens in one turn**.
 
 ```bash
-/console next --arm --doc <this console's own doc> --bucket <its bucket> --prefix <its prefix>
+/console next --arm --doc <this console's own doc> --bucket <its bucket> --prefix <its prefix> --model <its model>
 ```
 
-**Name your own document, bucket and prefix explicitly.** Without `--doc`,
-`next` hands over from the highest-lettered doc it can find — the wrong one as
-soon as another `new` has run or a successor already exists; without
-`--bucket` and `--prefix` it re-resolves those from the environment and writes
-the successor into the wrong bucket, or under the wrong key. The rendered
-console doc carries the exact command with all three already filled in.
+**Name your own document, bucket, prefix and model explicitly.** Without
+`--doc`, `next` hands over from the highest-lettered doc it can find — the
+wrong one as soon as another `new` has run or a successor already exists;
+without `--bucket` and `--prefix` it re-resolves those from the environment
+and writes the successor into the wrong bucket, or under the wrong key;
+without `--model` it re-resolves the model from `CONSOLE_MODEL` or the
+built-in default instead of continuing on the model this console itself runs
+on. The rendered console doc carries the exact command with all four already
+filled in.
 
 `next` writes the successor stub (letter bumped, pointed at this console and
 its HANDOFF) and the predecessor's `-HANDOFF.md` skeleton, and arms the

--- a/scripts/handover/console/console.sh
+++ b/scripts/handover/console/console.sh
@@ -677,7 +677,8 @@ cmd_new() {
         KIT "$kit" \
         FILL_SIGNAL "$fill_signal" \
         FILL_PERCENT "$fill_percent" \
-        RELEASE_TOKEN "$release_token"
+        RELEASE_TOKEN "$release_token" \
+        MODEL "$model"
 
     printf '%s\n' "$lock_out"
 
@@ -842,7 +843,8 @@ cmd_next() {
         KIT "$kit" \
         FILL_SIGNAL "$fill_signal" \
         FILL_PERCENT "$fill_percent" \
-        RELEASE_TOKEN "none yet — acquire your own at ACTION ZERO and record it here"
+        RELEASE_TOKEN "none yet — acquire your own at ACTION ZERO and record it here" \
+        MODEL "$model"
 
     echo "doc: $doc"
     echo "session: $session"

--- a/scripts/handover/console/test-console.sh
+++ b/scripts/handover/console/test-console.sh
@@ -992,4 +992,34 @@ check "42 ancestor raced in between the outer walk and the create scan: refuses 
 check "42 ancestor raced in between the outer walk and the create scan: stderr names the cause" "$([ "$(printf '%s\n' "$out42" | grep -ci ancestor)" -ge 1 ] && echo yes || echo no)" "yes"
 check "42 ancestor raced in between the outer walk and the create scan: never created the work dir beneath the raced ancestor" "$([ -e "$target42" ] && echo yes || echo no)" "no"
 
+# --- 43: the rendered "Handing over" line must carry --model <resolved> --
+# same class as HIMMEL-2873 rounds 3-4 (--bucket, then --prefix): the doc
+# tells its own console what to literally run at handover, so any flag
+# missing from that line is a flag the next `console next` invocation never
+# receives, and re-resolves from CONSOLE_MODEL / the built-in default
+# instead of inheriting (HIMMEL-2888). CONSOLE_MODEL is deliberately set to
+# a DIFFERENT value than --model on every invocation below, so a fallback
+# to the environment shows up as the wrong string landing in the doc.
+doc43A="$root/tester/modelbucket/DEMO-nextleg-${today}A-console.md"
+out43a="$( ( cd "$fixture_repo" && HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    CONSOLE_MODEL=envdefault-model \
+    bash "$C" new --bucket modelbucket --model custom-model-x ) )"
+token43a="$(token_of "$out43a")"
+check "43 new's own rendered handover line carries --model <given>" "$(grep -c -- '--model custom-model-x' "$doc43A")" "1"
+check "43 new's rendered handover line does not carry CONSOLE_MODEL instead" "$(grep -c -- '--model envdefault-model' "$doc43A")" "0"
+
+# next, invoked the way the line above actually instructs (no --model of its
+# own is available to a copy-pasting operator/console unless THIS fix put
+# one there) but run here with an explicit --model so the successor's own
+# resolved model is known -- under a CONSOLE_MODEL that again differs, to
+# prove the successor's rendered doc carries the given --model forward
+# rather than re-deriving it from the environment.
+doc43B="$root/tester/modelbucket/DEMO-nextleg-${today}B-console.md"
+( cd "$fixture_repo" && HANDOVER_DIR="$root" USER_SLUG=tester JIRA_PROJECT_KEY=DEMO \
+    CONSOLE_MODEL=envdefault-model \
+    bash "$C" next --bucket modelbucket --model custom-model-x ) >/dev/null
+check "43 next's rendered successor doc carries --model <given>" "$(grep -c -- '--model custom-model-x' "$doc43B")" "1"
+check "43 next's rendered successor doc does not carry CONSOLE_MODEL instead" "$(grep -c -- '--model envdefault-model' "$doc43B")" "0"
+HANDOVER_DIR="$root" bash "$QL" release "$doc43A" "$token43a" >/dev/null 2>&1
+
 [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }


### PR DESCRIPTION
## Why

`/console new --model <m>` starts a console on an explicit model, but the rendered handover document's own instruction to run `/console next --arm --doc … --bucket … --prefix …` omits `--model`. When a successor console copy-pastes that exact command, `console.sh next` re-resolves the model through its own precedence (`--model` → `CONSOLE_MODEL` env → built-in default) instead of inheriting the predecessor's model — silently landing the chain on the wrong model/lane/quota pool.

Third instance of this omission class: `--bucket` was fixed at HIMMEL-2873 round 3, `--prefix` at round 4. This closes the same gap for `--model`.

## Change

- `scripts/handover/console/console.sh`: both `render_template` call sites (`cmd_new`, `cmd_next`) now supply `MODEL "$model"`.
- `docs/handover/console-template.md`: the "Handing over" section's rendered handover line now carries `--model {{MODEL}}`, with prose explaining the consequence of omitting it.
- `docs/handover/running-a-console.md`: mirrors the same change (fenced example line + explanatory paragraph).
- The separate "Dispatching a leg" section's `<model>` argument is operator-supplied at leg-launch time, not a template placeholder — confirmed via grep, left unchanged (explicit ticket scope).

## RED control

Added test 43 to `scripts/handover/console/test-console.sh`, run against pre-fix code with `CONSOLE_MODEL` deliberately set to a *different* value than `--model` on every invocation:

```
FAIL - 43 new's own rendered handover line carries --model <given>: [0]!=[1]
FAIL - 43 next's rendered successor doc carries --model <given>: [0]!=[1]
```

Exactly the two new assertions failed — nothing else broke.

## Verification

- `bash scripts/handover/console/test-console.sh` → `ALL PASS` (post-fix, including all 4 new assertions for test 43).
- Impacted suites also green: `scripts/handover/test-queue-lock.sh`, `scripts/hooks/test-guard-console-dispatch.sh`.
- `shellcheck -x scripts/handover/console/console.sh` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7vV498cYdBjA964hjz95M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Console handovers now preserve the explicitly selected model when continuing to a new console.
  * Handover instructions now clearly identify the document, bucket, prefix, and model to use.
  * Prevents unintended fallback to environment or default model settings when a model is specified.

* **Tests**
  * Added coverage confirming explicit model values take precedence over environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->