### PR TITLE
fix(hooks): [HIMMEL-2933] block-chokepoint-env-prefix denies an earlier-segment assignment or export that clears a registered seam

### DIFF
--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -1756,7 +1756,13 @@ assignment word: `env -u NAME`/`--unset NAME`/`--unset=NAME` (same segment,
 via `env`'s option grammar) and, cross-segment by design, an in-shell `unset
 NAME` or `export -n NAME` anywhere earlier in the payload — carried forward
 to every LATER segment only, never denying the invoked-program token itself
-(HIMMEL-2927). Known residual (accepted, unchanged posture,
+(HIMMEL-2927). The same cross-segment carry covers a plain or exported
+ASSIGNMENT with no `unset`/`export -n`/`env -u` in sight: an earlier segment
+consumed entirely as leading assignment words (`SEAM=0;`, `SEAM=;`, two such
+words in a row) folds those names forward exactly like `unset`, and `export
+NAME[=val]` folds unconditionally regardless of `-n` — no value inspection,
+so `export SEAM=1` (re-arming) denies too, a documented over-deny in the
+arming direction (HIMMEL-2933). Known residual (accepted, unchanged posture,
 HIMMEL-912): deliberately case-varied paths/vars, a path assembled from
 shell variables, PowerShell-native `$env:` syntax, `sudo`/`xargs`/`find
 -exec` wrappers, and string reconstruction deeper than the bounded

--- a/scripts/hooks/block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/block-chokepoint-env-prefix.sh
@@ -136,6 +136,17 @@
 # guard has no business re-implementing). Over-deny is the safe direction
 # for a guard; a false ALLOW is the defect class this ticket exists for.
 #
+# HIMMEL-2933 (the third clearing shape): a plain or exported ASSIGNMENT in
+# an earlier segment -- `SEAM=0;` / `export SEAM=;` / `export SEAM=0 &&` --
+# clears a registered seam with no `unset`/`export -n`/`env -u` in sight
+# either. A segment consumed ENTIRELY as leading assignment words (no
+# command word ever reached) is folded into UNSET_NAMES the same way
+# `unset`/`export -n` are; `export NAME[=val]`, `-n` or not, is folded
+# unconditionally too (`export` never leads into a command position, so
+# every non-option word after it is a name, fail-closed, no value
+# inspection -- `export SEAM=1` denies too, a documented arming-direction
+# over-deny).
+#
 # The round-2 '(' carve-out is CLOSED: an unquoted '(' / ')' / backtick
 # (and `$(` / backtick inside double quotes) opens a fresh command
 # position via segmentation, so subshell, $(...), and backtick-wrapped
@@ -1003,40 +1014,29 @@ scan_segment() {
                 done
                 return 0 ;;
             export)
-                # HIMMEL-2927 (ruling, pr-check round 5): same fail-closed
-                # simplification as `unset` above. If this export segment
-                # carries `-n` ANYWHERE in its leading run of option-shaped
-                # words (every word starting with `-`, `--` included,
-                # combined forms included, up to the first word that does
-                # NOT start with `-`), then every remaining word that does
-                # not start with `-` is a candidate name -- full stop, no
-                # charset check, no invalid-option branch. An invalid
-                # cluster (`export -n -x NAME`) is denied too, same
-                # documented over-deny posture. Plain `export NAME[=val]`
-                # (no `-n` anywhere in the leading cluster) is left alone --
-                # that shape still exports; falls through to the unchanged
-                # assignment path below.
+                # HIMMEL-2927/HIMMEL-2933 (ruling, pr-check round 5 + the
+                # 2933 extension): same fail-closed simplification as
+                # `unset` above, now applied whether or not `-n` is present.
+                # `export -n NAME` un-exports NAME (the child no longer
+                # inherits it -- the unset direction); `export NAME[=val]`
+                # (over)writes NAME's exported value, and `export NAME`
+                # alone re-exports its CURRENT value unchanged -- but with
+                # no value inspection, either shape is recorded the same
+                # fail-closed way (documented arming-direction over-deny:
+                # `export SEAM=1` denies too). `export` never leads into a
+                # command position of its own, so every remaining
+                # non-option word (name stripped of its optional `=value`)
+                # is a candidate, full stop -- no charset check, no
+                # invalid-option branch.
                 k=$((j + 1))
-                saw_n=0
-                m=$k
-                while [ "$m" -lt "$nw" ]; do
-                    case "${W[$m]}" in
-                    -*)
-                        case "${W[$m]#-}" in *n*) saw_n=1 ;; esac
-                        m=$((m + 1)) ;;
-                    *) break ;;
+                while [ "$k" -lt "$nw" ]; do
+                    case "${W[$k]}" in
+                    -*) ;;
+                    *) UNSET_NAMES="$UNSET_NAMES ${W[$k]%%=*}" ;;
                     esac
+                    k=$((k + 1))
                 done
-                if [ "$saw_n" = 1 ]; then
-                    while [ "$k" -lt "$nw" ]; do
-                        case "${W[$k]}" in
-                        -*) ;;
-                        *) UNSET_NAMES="$UNSET_NAMES ${W[$k]%%=*}" ;;
-                        esac
-                        k=$((k + 1))
-                    done
-                    return 0
-                fi
+                return 0
                 ;;
             esac
             # The invoked-program token of this segment. Words beyond it
@@ -1046,6 +1046,18 @@ scan_segment() {
             ;;
         esac
     done
+    # HIMMEL-2933: a segment consumed ENTIRELY as leading assignment words
+    # (phase never left "start", no command word was ever reached) is a
+    # bare shell assignment -- `SEAM=0;` / `SEAM=0 OTHER=1;` with nothing
+    # after -- which bash runs in the CURRENT shell, so it persists to
+    # every LATER segment exactly like `unset`/`export -n` (HIMMEL-2927).
+    # Fold this segment's collected names into the same accumulator. `env`/
+    # `interp` phases exhausting the same way do NOT persist (an env-scoped
+    # assignment with no trailing command doesn't export or set anything)
+    # and are excluded by the phase check.
+    if [ "$phase" = "start" ] && [ "$asg_ok" = "1" ]; then
+        UNSET_NAMES="$UNSET_NAMES $names"
+    fi
     return 0
 }
 

--- a/scripts/hooks/test-block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/test-block-chokepoint-env-prefix.sh
@@ -146,7 +146,26 @@ assert_deny "export -pn (reordered cluster); then the chokepoint" "$(j "export -
 assert_allow "env -u UNREGISTERED name stays allowed"             "$(j "env -u SOME_OTHER_VAR bash $MERGE_ON_GREEN 1")"
 assert_allow "unset with no chokepoint in the payload"            "$(j "unset HIMMEL_CONSOLE_LEG; echo hi")"
 assert_allow "env -u registered name, non-chokepoint program"     "$(j "env -u HIMMEL_CONSOLE_LEG bash scripts/some/unregistered-script.sh")"
-assert_allow "export NAME=1 (no -n): unchanged assignment path"  "$(j "export HIMMEL_CONSOLE_LEG=1; bash $MERGE_ON_GREEN 1")"
+
+# --- HIMMEL-2933: the third way to clear a registered seam from an earlier
+# segment -- a plain or exported ASSIGNMENT, with no `unset`/`export -n`/
+# `env -u` in sight. `SEAM=0;`/`SEAM=;` is a segment consumed ENTIRELY as
+# leading assignment words with no command word ever reached -- bash runs
+# that in the current shell and it persists to every LATER segment, the
+# same cross-segment effect HIMMEL-2927 folds `unset`/`export -n` into.
+# `export SEAM=`/`export SEAM=0 &&` sets it AND exports it; `export SEAM`
+# alone (no `=`) re-exports an already-set value unchanged, but is recorded
+# anyway -- fail-closed, no value inspection, same posture as HIMMEL-2927. ---
+assert_deny "bare assignment; then the chokepoint (SEAM=0;)"      "$(j "HIMMEL_CONSOLE_LEG=0; bash $MERGE_ON_GREEN 1")"
+assert_deny "bare assignment to empty; then the chokepoint"       "$(j "HIMMEL_CONSOLE_LEG=; bash $MERGE_ON_GREEN 1")"
+assert_deny "two assignment words in the earlier segment"         "$(j "HIMMEL_CONSOLE_LEG=0 OTHER=1; bash $MERGE_ON_GREEN 1")"
+assert_deny "export to empty; then the chokepoint"                "$(j "export HIMMEL_CONSOLE_LEG=; bash $MERGE_ON_GREEN 1")"
+assert_deny "export SEAM=0 && the chokepoint"                     "$(j "export HIMMEL_CONSOLE_LEG=0 && bash $MERGE_ON_GREEN 1")"
+assert_deny "export NAME=1 (no -n): also denies (arming-direction over-deny)" "$(j "export HIMMEL_CONSOLE_LEG=1; bash $MERGE_ON_GREEN 1")"
+assert_deny "export bare NAME (already-set, no =): recorded fail-closed" "$(j "export HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+# Over-match controls: unaffected.
+assert_allow "unrelated bare assignment; then the chokepoint"     "$(j "OTHER_VAR=0; bash $MERGE_ON_GREEN 1")"
+assert_allow "chokepoint FIRST; bare assignment in a LATER segment" "$(j "bash $MERGE_ON_GREEN 1; HIMMEL_CONSOLE_LEG=0")"
 
 # HIMMEL-2927 ruling (pr-check round 5): unset/export option-VALIDITY
 # modelling is GONE. Three CR rounds each found the next edge a validity


### PR DESCRIPTION
## Summary
- HIMMEL-2927 (#635) taught `block-chokepoint-env-prefix.sh` that an earlier-segment `unset NAME` / `export -n NAME` / `env -u NAME` clears a registered seam for every later segment. A third shape of the same class was still ALLOWED: an earlier-segment plain or exported **assignment** — `SEAM=0;`, `SEAM=;`, `export SEAM=;`, `export SEAM=0 &&` — silently disarms the chokepoint's seam check before it reaches the guarded invocation (e.g. `merge-on-green.sh`, which gates on truthiness of the seam).
- Fix in `scan_segment`/`scan_text`: (a) a segment consumed entirely as leading assignment words folds each name into `UNSET_NAMES` at segment-exit, same as `unset`; (b) the `export)` arm now folds every remaining word's name into `UNSET_NAMES` unconditionally (previously only under `-n`) — no value inspection, so `export SEAM=1` (re-arming) also denies, a documented over-deny in the arming direction. One clause added to `docs/internals/enforcement.md` next to #635's.
- Not in scope: HIMMEL-2929 (subshell-scope over-denial, separate ticket on this same file), any change to `scripts/chokepoints.json`, value inspection, or modelling bash's assignment/export grammar beyond the leading-word scan already in place.

## RED control (captured against HEAD's unmodified hook)
`bash scripts/quiet-run.sh cpe-red -- bash scripts/hooks/test-block-chokepoint-env-prefix.sh` → `FAILED: 7 of 171 cases failed`:
- bare assignment; then the chokepoint (SEAM=0;)
- bare assignment to empty; then the chokepoint
- two assignment words in the earlier segment
- export to empty; then the chokepoint
- export SEAM=0 && the chokepoint
- export NAME=1 (no -n): also denies (arming-direction over-deny)
- export bare NAME (already-set, no =): recorded fail-closed

## Green
- `bash scripts/quiet-run.sh cpe-green -- bash scripts/hooks/test-block-chokepoint-env-prefix.sh` → OK, 171/171.
- `shellcheck -x scripts/hooks/block-chokepoint-env-prefix.sh` → rc=0.
- Impacted suites (every suite referencing the hook): `test-block-chokepoint-env-prefix.sh` OK, `test-crlf-boundary.sh` OK, `test-block-tail-pipe-on-gates.sh` OK, `test-ws5-invariants.sh` OK.
- `run-hook-with-bash.test.mjs`: 46/47 pass. The one failure (`verifyProjectHookIntegrity denies a pinned script whose on-disk content drifted...`) is confirmed pre-existing on `main` — `git diff main -- scripts/hooks/hook-integrity.js scripts/hooks/run-hook-with-bash.test.mjs scripts/hooks/run-hook-with-bash.js` is empty, so none of those files are touched by this PR's diff. Filed as a separate finding, not fixed here (out of scope for HIMMEL-2933).

## Round table
- `/pr-check` round 1 of 3: critic panel (paid tier, codex/`gpt-6-astra`) responded — 0 Critical / 0 Important / 0 Suggestions. No codex adversarial pass (dormant, `CODEX_ADV_OK` unset). 0 orphan candidates. Marker cleared: `clear-cr-marker CLEARED branch=fix/himmel-2933-chokepoint-assign-clear sha=a185a3d7fc6ff23bc4a26b73dddc2ad2a47eb1bb responders=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)