### PR TITLE
fix(himmelctl): [HIMMEL-2932] bridge-health poller-count hardening on Linux/macOS

### DIFF
--- a/scripts/himmelctl/lib/probes.js
+++ b/scripts/himmelctl/lib/probes.js
@@ -2743,29 +2743,72 @@ function posixProcRoot(ctx) {
   return (ctx && ctx.procRoot) || '/proc';
 }
 
-function posixChildPids(pid, procRoot, env) {
+// Direct (one-level) children of `pid`. Returns:
+//   { pids: [...] }  on success
+//   { pids: null }   child enumeration is genuinely unavailable (no /proc,
+//                    no pgrep on PATH) — the caller reads this as UNVERIFIED
+//   { error }        a thread's children file exists but failed to read for
+//                     a reason OTHER than the thread having exited between
+//                     readdir and read (GH #639) — e.g. EACCES must not be
+//                     silently folded into "no children"; a persistent read
+//                     failure would otherwise mask an undercount as healthy.
+function posixDirectChildPids(pid, procRoot, env) {
   if (fs.existsSync(procRoot)) {
     const taskDir = path.join(procRoot, String(pid), 'task');
     let tids;
     try {
       tids = fs.readdirSync(taskDir);
     } catch (_e) {
-      return null;
+      return { pids: [] };
     }
     const pids = new Set();
     for (const tid of tids) {
       try {
         const raw = fs.readFileSync(path.join(taskDir, tid, 'children'), 'utf8');
         raw.split(/\s+/).filter(Boolean).forEach((p) => pids.add(p));
-      } catch (_e) { /* thread exited between readdir and read — skip */ }
+      } catch (e) {
+        if (e && e.code === 'ENOENT') continue; // thread exited between readdir and read
+        return { error: e };
+      }
     }
-    return Array.from(pids);
+    return { pids: Array.from(pids) };
   }
   const pgrepBin = which('pgrep', env);
-  if (!pgrepBin) return null;
+  if (!pgrepBin) return { pids: null };
   const r = spawnProbeSync(pgrepBin, ['-P', String(pid)], { env, encoding: 'utf8' });
-  if (r.error || (r.status !== 0 && r.status !== 1)) return null; // pgrep rc=1 == no matches, not a failure
-  return (r.stdout || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  if (r.error || (r.status !== 0 && r.status !== 1)) return { pids: null }; // pgrep rc=1 == no matches, not a failure
+  return { pids: (r.stdout || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean) };
+}
+
+// Depth-bounded BFS over the descendant tree rooted at `pid` (NOT including
+// pid itself) — a poller can run directly as MainPID, or nested under a
+// wrapper/supervisor grandchild-or-deeper, so walking only one level of
+// children (the prior behaviour) misses both shapes (CR gap, HIMMEL-2932).
+// The depth bound keeps this finite against a pathological/cyclic fixture
+// while comfortably covering any realistic supervisor nesting.
+const POLLER_DESCENDANT_MAX_DEPTH = 4;
+
+function posixDescendantPids(rootPid, procRoot, env) {
+  const seen = new Set([String(rootPid)]);
+  const descendants = [];
+  let frontier = [String(rootPid)];
+  for (let depth = 0; depth < POLLER_DESCENDANT_MAX_DEPTH && frontier.length > 0; depth++) {
+    const next = [];
+    for (const pid of frontier) {
+      const r = posixDirectChildPids(pid, procRoot, env);
+      if (r.error) return { error: r.error };
+      if (r.pids === null) return { pids: null };
+      for (const child of r.pids) {
+        if (!seen.has(child)) {
+          seen.add(child);
+          descendants.push(child);
+          next.push(child);
+        }
+      }
+    }
+    frontier = next;
+  }
+  return { pids: descendants };
 }
 
 function posixCmdline(pid, procRoot, env) {
@@ -2782,6 +2825,59 @@ function posixCmdline(pid, procRoot, env) {
   return (r.stdout || '').trim();
 }
 
+// Like posixCmdline, but distinguishes "no such file" (ENOENT — the pid has
+// genuinely exited, or simply carries no cmdline of its own) from any other
+// read failure. Used ONLY for MainPID's own cmdline: unlike a descendant
+// pid (where any unreadable cmdline makes process identity UNVERIFIED —
+// case d2), MainPID is already independently confirmed alive via
+// ActiveState=active, so a missing cmdline just means "not itself the
+// poller"; a genuine error (e.g. EACCES) still degrades.
+function posixOptionalCmdline(pid, procRoot, env) {
+  if (fs.existsSync(procRoot)) {
+    try {
+      const raw = fs.readFileSync(path.join(procRoot, String(pid), 'cmdline'));
+      return { cmdline: raw.toString('utf8').split('\0').filter(Boolean).join(' ') };
+    } catch (e) {
+      if (e && e.code === 'ENOENT') return { cmdline: null };
+      return { error: e };
+    }
+  }
+  const r = spawnProbeSync('ps', ['-o', 'args=', '-p', String(pid)], { env, encoding: 'utf8' });
+  if (r.error) return { error: r.error };
+  if (r.status !== 0) return { cmdline: null }; // no such pid — not an error, just not this
+  return { cmdline: (r.stdout || '').trim() };
+}
+
+// Escapes POSIX ERE metacharacters so a resolved filesystem path (which may
+// contain '.', '+', '(', etc.) is matched by `pgrep -f` as literal text
+// rather than being reinterpreted as regex syntax (CR gap, HIMMEL-2932).
+function escapeEreMetachars(s) {
+  return s.replace(/[.[\]()*+?{}|^$\\]/g, '\\$&');
+}
+
+// Runs `pgrep -f <escaped pollerPath>` and verifies EACH matched pid's
+// cmdline through the existing checkout-anchor helper rather than trusting
+// pgrep's raw match count (CR gap, HIMMEL-2932) — pgrep -f matches on any
+// substring, so a raw count can both over-count (a foreign checkout whose
+// path happens to contain this one's, or an unrelated process that mentions
+// the path in an argument) in principle, and gives no anchor verification
+// at all otherwise. Returns { pids: [...verified] } or { error }.
+function posixVerifiedPgrepMatches(pollerPath, procRoot, env, anchor) {
+  const pgrepBin = which('pgrep', env);
+  if (!pgrepBin) return { pids: null };
+  const r = spawnProbeSync(pgrepBin, ['-f', escapeEreMetachars(pollerPath)], { env, encoding: 'utf8' });
+  if (r.error) return { error: r.error };
+  if (r.status !== 0 && r.status !== 1) return { error: new Error(`pgrep exited rc=${r.status}`) };
+  const candidates = (r.stdout || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const verified = [];
+  for (const pid of candidates) {
+    const cmdline = posixCmdline(pid, procRoot, env);
+    if (cmdline === null) return { error: new Error(`could not read cmdline for pgrep-matched pid ${pid}`) };
+    if (pollerLineIsThisCheckout(cmdline, anchor)) verified.push(pid);
+  }
+  return { pids: verified };
+}
+
 function posixPollerVerdict(n, source) {
   if (n === 1) return { actual: 'present', detail: `1 poller.ts process running for this checkout (${source}; a supervisor parent, if any, is not counted)` };
   if (n === 0) return { actual: 'absent', detail: `0 poller.ts process(es) running for this checkout (${source}; expected exactly 1)` };
@@ -2794,6 +2890,7 @@ function probeBridgePollerCountPosix(ctx) {
   const thisCheckoutAnchor = ctx.repoRoot
     ? normalizeForPollerAnchorMatch(path.join(ctx.repoRoot, 'scripts', 'telegram', 'poller.ts'))
     : null;
+  const pollerPath = ctx.repoRoot ? path.join(ctx.repoRoot, 'scripts', 'telegram', 'poller.ts') : null;
 
   const systemctlBin = which('systemctl', env);
   if (systemctlBin) {
@@ -2810,39 +2907,69 @@ function probeBridgePollerCountPosix(ctx) {
         if (props.ActiveState !== 'active' || !props.MainPID || props.MainPID === '0') {
           return { actual: 'absent', detail: `telegram-bridge.service is not active (ActiveState=${props.ActiveState || 'unknown'}) — 0 poller.ts processes running for this checkout` };
         }
-        const childPids = posixChildPids(props.MainPID, procRoot, env);
-        if (childPids === null) {
-          return { actual: 'degraded', detail: `could not enumerate child processes of telegram-bridge.service MainPID ${props.MainPID} — process identity is UNVERIFIED, not assumed healthy` };
+        const mainPid = props.MainPID;
+        const descendants = posixDescendantPids(mainPid, procRoot, env);
+        if (descendants.error) {
+          return { actual: 'degraded', detail: `could not enumerate the process tree of telegram-bridge.service MainPID ${mainPid}: ${descendants.error.message} — process identity is UNVERIFIED, not assumed healthy` };
         }
-        const cmdlines = childPids.map((pid) => ({ pid, cmdline: posixCmdline(pid, procRoot, env) }));
+        if (descendants.pids === null) {
+          return { actual: 'degraded', detail: `could not enumerate the process tree of telegram-bridge.service MainPID ${mainPid} — process identity is UNVERIFIED, not assumed healthy` };
+        }
+        const cmdlines = descendants.pids.map((pid) => ({ pid, cmdline: posixCmdline(pid, procRoot, env) }));
         const unreadable = cmdlines.filter((c) => c.cmdline === null);
         if (unreadable.length > 0) {
-          return { actual: 'degraded', detail: `could not read cmdline for child pid(s) ${unreadable.map((c) => c.pid).join(', ')} of telegram-bridge.service MainPID ${props.MainPID} — process identity is UNVERIFIED, not assumed healthy` };
+          return { actual: 'degraded', detail: `could not read cmdline for pid(s) ${unreadable.map((c) => c.pid).join(', ')} in telegram-bridge.service MainPID ${mainPid}'s process tree — process identity is UNVERIFIED, not assumed healthy` };
         }
-        const n = cmdlines.filter((c) => pollerLineIsThisCheckout(c.cmdline, thisCheckoutAnchor)).length;
-        return posixPollerVerdict(n, 'via systemd MainPID children');
+        const verifiedPids = new Set(
+          cmdlines.filter((c) => pollerLineIsThisCheckout(c.cmdline, thisCheckoutAnchor)).map((c) => c.pid),
+        );
+
+        // MainPID can itself BE the poller (no wrapper) — a genuine
+        // read failure here degrades, but a missing cmdline (MainPID has
+        // already been confirmed alive via ActiveState=active) just means
+        // it isn't itself the poller.
+        const mainCmdline = posixOptionalCmdline(mainPid, procRoot, env);
+        if (mainCmdline.error) {
+          return { actual: 'degraded', detail: `could not read cmdline for telegram-bridge.service MainPID ${mainPid}: ${mainCmdline.error.message} — process identity is UNVERIFIED, not assumed healthy` };
+        }
+        if (mainCmdline.cmdline !== null && pollerLineIsThisCheckout(mainCmdline.cmdline, thisCheckoutAnchor)) {
+          verifiedPids.add(mainPid);
+        }
+
+        // HIMMEL-1555 duplicate-poller class: a manually-launched poller
+        // running OUTSIDE this systemd unit's tree is invisible to a
+        // tree-scoped count by construction — sweep system-wide via
+        // pgrep -f (same anchor verification as the no-unit fallback
+        // below) and union by verified pid, mirroring the Windows CIM
+        // branch's system-wide scope.
+        if (pollerPath) {
+          const sweep = posixVerifiedPgrepMatches(pollerPath, procRoot, env, thisCheckoutAnchor);
+          if (sweep.error) {
+            return { actual: 'degraded', detail: `could not run the system-wide pgrep sweep for telegram-bridge.service: ${sweep.error.message} — process identity is UNVERIFIED, not assumed healthy` };
+          }
+          if (sweep.pids) sweep.pids.forEach((pid) => verifiedPids.add(pid));
+        }
+
+        return posixPollerVerdict(verifiedPids.size, 'via systemd MainPID process tree + system-wide sweep');
       }
       // LoadState absent/not-found -- systemd genuinely doesn't know this unit; fall through to the pgrep -f fallback below.
     }
   }
 
-  const pgrepBin = which('pgrep', env);
-  if (!pgrepBin) {
+  if (!which('pgrep', env)) {
     return {
       actual: 'degraded',
       detail: 'poller-count check unavailable — no telegram-bridge.service systemd unit and no pgrep on PATH; process identity is UNVERIFIED, not assumed healthy',
     };
   }
-  if (!ctx.repoRoot) {
+  if (!pollerPath) {
     return { actual: 'degraded', detail: 'poller-count check needs ctx.repoRoot to anchor pgrep -f, none provided' };
   }
-  const pollerPath = path.join(ctx.repoRoot, 'scripts', 'telegram', 'poller.ts');
-  const r = spawnProbeSync(pgrepBin, ['-f', pollerPath], { env, encoding: 'utf8' });
-  if (r.timedOut) return { actual: 'degraded', detail: `poller-count probe timed out after ${probeTimeoutSecs(r)}s` };
-  if (r.error) return { actual: 'degraded', detail: `spawn error: ${r.error.message}` };
-  if (r.status !== 0 && r.status !== 1) return { actual: 'degraded', detail: `pgrep poller-count query exited rc=${r.status}` };
-  const n = (r.stdout || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean).length;
-  return posixPollerVerdict(n, 'via pgrep -f, no systemd unit found');
+  const fallback = posixVerifiedPgrepMatches(pollerPath, procRoot, env, thisCheckoutAnchor);
+  if (fallback.error) {
+    return { actual: 'degraded', detail: `pgrep poller-count query failed: ${fallback.error.message}` };
+  }
+  return posixPollerVerdict(fallback.pids.length, 'via pgrep -f, no systemd unit found');
 }
 
 function probeBridgePollerCount(ctx) {

--- a/scripts/himmelctl/lib/probes.js
+++ b/scripts/himmelctl/lib/probes.js
@@ -2758,8 +2758,9 @@ function posixDirectChildPids(pid, procRoot, env) {
     let tids;
     try {
       tids = fs.readdirSync(taskDir);
-    } catch (_e) {
-      return { pids: [] };
+    } catch (e) {
+      if (e && e.code === 'ENOENT') return { pids: [] }; // pid has no task dir (exited or never existed)
+      return { error: e }; // e.g. EACCES -- must not be silently folded into "no children" (GH #639)
     }
     const pids = new Set();
     for (const tid of tids) {
@@ -2855,17 +2856,21 @@ function escapeEreMetachars(s) {
   return s.replace(/[.[\]()*+?{}|^$\\]/g, '\\$&');
 }
 
-// Runs `pgrep -f <escaped pollerPath>` and verifies EACH matched pid's
+// Runs `pgrep -f <escaped matchPattern>` and verifies EACH matched pid's
 // cmdline through the existing checkout-anchor helper rather than trusting
 // pgrep's raw match count (CR gap, HIMMEL-2932) — pgrep -f matches on any
 // substring, so a raw count can both over-count (a foreign checkout whose
 // path happens to contain this one's, or an unrelated process that mentions
 // the path in an argument) in principle, and gives no anchor verification
-// at all otherwise. Returns { pids: [...verified] } or { error }.
-function posixVerifiedPgrepMatches(pollerPath, procRoot, env, anchor) {
+// at all otherwise. `matchPattern` may be the resolved absolute poller path
+// (anchored fallback) or a broad basename-only substring (system-wide
+// sweep, see its call site) — either way, identity is decided below by
+// pollerLineIsThisCheckout, never by the breadth of this pattern. Returns
+// { pids: [...verified] } or { error }.
+function posixVerifiedPgrepMatches(matchPattern, procRoot, env, anchor) {
   const pgrepBin = which('pgrep', env);
   if (!pgrepBin) return { pids: null };
-  const r = spawnProbeSync(pgrepBin, ['-f', escapeEreMetachars(pollerPath)], { env, encoding: 'utf8' });
+  const r = spawnProbeSync(pgrepBin, ['-f', escapeEreMetachars(matchPattern)], { env, encoding: 'utf8' });
   if (r.error) return { error: r.error };
   if (r.status !== 0 && r.status !== 1) return { error: new Error(`pgrep exited rc=${r.status}`) };
   const candidates = (r.stdout || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
@@ -2877,6 +2882,17 @@ function posixVerifiedPgrepMatches(pollerPath, procRoot, env, anchor) {
   }
   return { pids: verified };
 }
+
+// The system-wide sweep matches on this broad basename-only substring,
+// NOT the resolved absolute poller path, so a manually-launched duplicate
+// with no path in its own argv -- e.g. `bun poller.ts` run from its own
+// script directory, which is how a genuine poller is actually invoked (see
+// the Windows CIM branch's identical `-match 'poller\.ts'` query) -- is
+// still a pgrep -f candidate (CR gap, HIMMEL-2932). Anchoring the sweep on
+// the absolute path instead would make it blind to exactly the realistic
+// duplicate-poller shape it exists to catch. Identity is still decided by
+// pollerLineIsThisCheckout below, not by this pattern's breadth.
+const POLLER_SWEEP_PATTERN = 'poller.ts';
 
 function posixPollerVerdict(n, source) {
   if (n === 1) return { actual: 'present', detail: `1 poller.ts process running for this checkout (${source}; a supervisor parent, if any, is not counted)` };
@@ -2941,9 +2957,12 @@ function probeBridgePollerCountPosix(ctx) {
         // tree-scoped count by construction — sweep system-wide via
         // pgrep -f (same anchor verification as the no-unit fallback
         // below) and union by verified pid, mirroring the Windows CIM
-        // branch's system-wide scope.
+        // branch's system-wide scope. Matched on POLLER_SWEEP_PATTERN, NOT
+        // the resolved pollerPath used by the no-unit fallback below — see
+        // that constant's comment for why the sweep needs the broader,
+        // unanchored pattern.
         if (pollerPath) {
-          const sweep = posixVerifiedPgrepMatches(pollerPath, procRoot, env, thisCheckoutAnchor);
+          const sweep = posixVerifiedPgrepMatches(POLLER_SWEEP_PATTERN, procRoot, env, thisCheckoutAnchor);
           if (sweep.error) {
             return { actual: 'degraded', detail: `could not run the system-wide pgrep sweep for telegram-bridge.service: ${sweep.error.message} — process identity is UNVERIFIED, not assumed healthy` };
           }

--- a/scripts/himmelctl/lib/probes.js
+++ b/scripts/himmelctl/lib/probes.js
@@ -2966,7 +2966,10 @@ function probeBridgePollerCountPosix(ctx) {
           if (sweep.error) {
             return { actual: 'degraded', detail: `could not run the system-wide pgrep sweep for telegram-bridge.service: ${sweep.error.message} — process identity is UNVERIFIED, not assumed healthy` };
           }
-          if (sweep.pids) sweep.pids.forEach((pid) => verifiedPids.add(pid));
+          if (sweep.pids === null) {
+            return { actual: 'degraded', detail: 'no pgrep on PATH to run the system-wide sweep for telegram-bridge.service (HIMMEL-1555 class) — process identity is UNVERIFIED, not assumed healthy' };
+          }
+          sweep.pids.forEach((pid) => verifiedPids.add(pid));
         }
 
         return posixPollerVerdict(verifiedPids.size, 'via systemd MainPID process tree + system-wide sweep');

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -4579,7 +4579,25 @@ chmod +x "$bh_posix_stub/pgrep"
 
 bh_posix_log_has() { [ -f "$bh_posix_log" ] && grep -qF "$1" "$bh_posix_log"; }
 
+# Independent (bash-native, not a reuse of the JS implementation under test)
+# ERE-metacharacter escaper -- used only to compute the EXPECTED escaped
+# literal for case (i) below, so that test isn't just re-asserting the same
+# regex against itself.
+escape_ere() {
+  local s="$1" out="" c i
+  for (( i=0; i<${#s}; i++ )); do
+    c="${s:i:1}"
+    case "$c" in
+      '.'|'['|']'|'('|')'|'*'|'+'|'?'|'{'|'}'|'|'|'^'|'$'|\\) out+="\\$c" ;;
+      *) out+="$c" ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
 run_bh_posix() {
+  local repoRootOverride="${1:-$repo_root_w}"
+  local platformOverride="${2:-linux}"
   local pathVal
   pathVal="$bh_posix_stub:$(scrub_path "$PATH" systemctl pgrep)"
   PATH="$pathVal" BH_STUB_LOG="$(winpath "$bh_posix_log")" BH_STUB_STATE="$(winpath "$bh_posix_state")" \
@@ -4587,7 +4605,7 @@ run_bh_posix() {
 const { runProbe } = require('$probes_lib_w');
 const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
 const item = manifest.items.find((i) => i.id === 'bridge-health');
-const ctx = { repoRoot: '$repo_root_w', targetPath: '$(winpath "$bh_dir")', scope: 'project', platform: 'linux', procRoot: '$(winpath "$bh_proc_root")', env: process.env };
+const ctx = { repoRoot: '$(winpath "$repoRootOverride")', targetPath: '$(winpath "$bh_dir")', scope: 'project', platform: '$platformOverride', procRoot: '$(winpath "$bh_proc_root")', env: process.env };
 console.log(JSON.stringify(runProbe(item, ctx)));
 "
 }
@@ -4680,8 +4698,11 @@ else
 fi
 
 # ── case (e): no systemd unit at all -> pgrep -f fallback over the resolved
-# poller path, same 0/1/>1 mapping ──────────────────────────────────────────
-rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
+# poller path, same 0/1/>1 mapping. Since the pgrep -f fallback now verifies
+# each matched pid's cmdline (CR gap 3b) rather than trusting the raw match
+# count, a cmdline fixture matching THIS checkout is required at each
+# synthetic pid the pgrep stub returns (9200+i for i in 1..BH_PGREP_N) ──────
+rm -rf "$bh_proc_root"; rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
 outBHlinuxE0=$(BH_PGREP_N=0 run_bh_posix)
 if bh_posix_log_has "pgrep -f"; then
   echo "$outBHlinuxE0" | jq -e '.actual == "absent"' >/dev/null \
@@ -4691,6 +4712,8 @@ else
   echo "SKIP: bridge-health (Linux) case (e/0): no evidence in the stub log that pgrep actually spawned on this host"
 fi
 
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9201"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
 rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
 outBHlinuxE1=$(BH_PGREP_N=1 run_bh_posix)
 if bh_posix_log_has "pgrep -f"; then
@@ -4701,6 +4724,9 @@ else
   echo "SKIP: bridge-health (Linux) case (e/1): no evidence in the stub log that pgrep actually spawned on this host"
 fi
 
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9201" "$bh_proc_root/9202"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9202/cmdline"
 rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
 outBHlinuxE2=$(BH_PGREP_N=2 run_bh_posix)
 if bh_posix_log_has "pgrep -f"; then
@@ -4713,6 +4739,149 @@ else
   echo "SKIP: bridge-health (Linux) case (e/2): no evidence in the stub log that pgrep actually spawned on this host"
 fi
 rm -f "$bh_posix_state/no-unit"
+
+# ── case (f): MainPID itself IS the poller.ts process (no wrapper) -> present,
+# count 1 (CR gap 1, HIMMEL-2932: previously only MainPID's CHILDREN were
+# tested, never MainPID's own cmdline) ──────────────────────────────────────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001"
+printf '\n' > "$bh_proc_root/9001/task/9001/children"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9001/cmdline"
+rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
+outBHlinuxF=$(BH_PGREP_N=0 run_bh_posix)
+if bh_posix_log_has "show telegram-bridge.service"; then
+  echo "$outBHlinuxF" | jq -e '.actual == "present"' >/dev/null \
+    || fail "bridge-health (Linux): a poller.ts running directly AS MainPID (no wrapper child) must be counted (got: $outBHlinuxF)"
+  echo "$outBHlinuxF" | jq -e '.detail | contains("1 poller")' >/dev/null \
+    || fail "bridge-health (Linux): MainPID-is-the-poller detail should name the count 1 (got: $outBHlinuxF)"
+  echo "ok: bridge-health (Linux) — MainPID itself running poller.ts (no wrapper) reads present, count 1"
+else
+  echo "SKIP: bridge-health (Linux) case (f): no evidence in the stub log that systemctl actually spawned on this host"
+fi
+
+# ── case (g): poller.ts nested under a wrapper GRANDCHILD (MainPID -> wrapper
+# -> poller.ts), two levels deep -> present, count 1 (CR gap 1: previously
+# only one level of children was walked) ────────────────────────────────────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9002/task/9002" "$bh_proc_root/9003"
+printf '9002\n' > "$bh_proc_root/9001/task/9001/children"
+printf '9003\n' > "$bh_proc_root/9002/task/9002/children"
+printf '%s\0' bash wrapper.sh > "$bh_proc_root/9002/cmdline"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9003/cmdline"
+rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
+outBHlinuxG=$(BH_PGREP_N=0 run_bh_posix)
+if bh_posix_log_has "show telegram-bridge.service"; then
+  echo "$outBHlinuxG" | jq -e '.actual == "present"' >/dev/null \
+    || fail "bridge-health (Linux): a poller.ts nested under a wrapper GRANDCHILD of MainPID must be counted, not just direct children (got: $outBHlinuxG)"
+  echo "$outBHlinuxG" | jq -e '.detail | contains("1 poller")' >/dev/null \
+    || fail "bridge-health (Linux): grandchild-nested poller detail should name the count 1 (got: $outBHlinuxG)"
+  echo "ok: bridge-health (Linux) — poller.ts nested under a wrapper grandchild of MainPID reads present, count 1"
+else
+  echo "SKIP: bridge-health (Linux) case (g): no evidence in the stub log that systemctl actually spawned on this host"
+fi
+
+# ── case (l): poller.ts nested exactly at hop-4 from MainPID (the configured
+# depth bound) via a chain of wrapper processes -> present, count 1 (CR gap
+# 1: proves the recursive walk genuinely goes deeper than 2 levels, not just
+# one extra hop) ─────────────────────────────────────────────────────────────
+rm -rf "$bh_proc_root"
+mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9002/task/9002" "$bh_proc_root/9003/task/9003" "$bh_proc_root/9004/task/9004" "$bh_proc_root/9005"
+printf '9002\n' > "$bh_proc_root/9001/task/9001/children"
+printf '9003\n' > "$bh_proc_root/9002/task/9002/children"
+printf '9004\n' > "$bh_proc_root/9003/task/9003/children"
+printf '9005\n' > "$bh_proc_root/9004/task/9004/children"
+printf '%s\0' bash wrapper.sh > "$bh_proc_root/9002/cmdline"
+printf '%s\0' bash wrapper.sh > "$bh_proc_root/9003/cmdline"
+printf '%s\0' bash wrapper.sh > "$bh_proc_root/9004/cmdline"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9005/cmdline"
+rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
+outBHlinuxL=$(BH_PGREP_N=0 run_bh_posix)
+if bh_posix_log_has "show telegram-bridge.service"; then
+  echo "$outBHlinuxL" | jq -e '.actual == "present"' >/dev/null \
+    || fail "bridge-health (Linux): a poller.ts nested 4 hops below MainPID (the depth bound) must still be counted (got: $outBHlinuxL)"
+  echo "$outBHlinuxL" | jq -e '.detail | contains("1 poller")' >/dev/null \
+    || fail "bridge-health (Linux): depth-4-nested poller detail should name the count 1 (got: $outBHlinuxL)"
+  echo "ok: bridge-health (Linux) — poller.ts nested 4 hops below MainPID (depth bound) reads present, count 1"
+else
+  echo "SKIP: bridge-health (Linux) case (l): no evidence in the stub log that systemctl actually spawned on this host"
+fi
+
+# ── case (h): unit active with exactly 1 IN-TREE matching child, PLUS a
+# manually-launched duplicate poller running OUTSIDE the systemd unit's tree
+# (the HIMMEL-1555 class this check exists for) -> degraded, count 2 (CR gap
+# 2: system-wide pgrep sweep unioned with the tree-scoped count, mirroring
+# the Windows CIM branch's system-wide scope) ───────────────────────────────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9002" "$bh_proc_root/9201"
+printf '9002\n' > "$bh_proc_root/9001/task/9001/children"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9002/cmdline"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
+rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
+outBHlinuxH=$(BH_PGREP_N=1 run_bh_posix)
+if bh_posix_log_has "show telegram-bridge.service"; then
+  echo "$outBHlinuxH" | jq -e '.actual == "degraded"' >/dev/null \
+    || fail "bridge-health (Linux): a duplicate poller running OUTSIDE the systemd unit's process tree must be found by the system-wide sweep and unioned in, not missed (got: $outBHlinuxH)"
+  echo "$outBHlinuxH" | jq -e '.detail | contains("2 poller")' >/dev/null \
+    || fail "bridge-health (Linux): tree+sweep degraded detail should name the count 2 (got: $outBHlinuxH)"
+  echo "ok: bridge-health (Linux) — an out-of-tree duplicate poller found via the system-wide pgrep sweep is unioned with the tree-scoped count, reading degraded, count 2 (HIMMEL-1555 class)"
+else
+  echo "SKIP: bridge-health (Linux) case (h): no evidence in the stub log that systemctl actually spawned on this host"
+fi
+
+# ── case (i): pgrep -f fallback ERE-escapes metacharacters in the resolved
+# poller path before use (CR gap 3a, HIMMEL-2932) -- an unescaped repoRoot
+# containing '.', '+', '(' would otherwise be interpreted as regex syntax by
+# pgrep -f rather than literal path characters ──────────────────────────────
+erepath_dir="$work/erepath+dot.paren(1)"
+poller_path_i="$erepath_dir/scripts/telegram/poller.ts"
+escaped_poller_path_i="$(escape_ere "$poller_path_i")"
+rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
+BH_PGREP_N=0 run_bh_posix "$erepath_dir" >/dev/null
+if bh_posix_log_has "pgrep -f"; then
+  bh_posix_log_has "pgrep -f $escaped_poller_path_i" \
+    || fail "bridge-health (Linux): pgrep -f fallback must ERE-escape metacharacters in the resolved poller path (expected escaped '$escaped_poller_path_i' in log: $(cat "$bh_posix_log" 2>/dev/null))"
+  echo "ok: bridge-health (Linux) — pgrep -f fallback ERE-escapes metacharacters ('.', '+', '(', ')') in the resolved poller path"
+else
+  echo "SKIP: bridge-health (Linux) case (i): no evidence in the stub log that pgrep actually spawned on this host"
+fi
+
+# ── case (j): pgrep -f fallback verifies EACH matched pid's cmdline through
+# the existing checkout-anchor helper instead of trusting pgrep's raw match
+# count (CR gap 3b) -- 2 raw pgrep matches, but only 1 actually belongs to
+# this checkout, must read present/1, not degraded/2 ────────────────────────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9201" "$bh_proc_root/9202"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
+printf '%s\0' bun "${other_checkout_posix}/scripts/telegram/poller.ts" > "$bh_proc_root/9202/cmdline"
+rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
+outBHlinuxJ=$(BH_PGREP_N=2 run_bh_posix)
+if bh_posix_log_has "pgrep -f"; then
+  echo "$outBHlinuxJ" | jq -e '.actual == "present"' >/dev/null \
+    || fail "bridge-health (Linux): pgrep -f fallback must verify each matched pid's cmdline rather than trusting the raw match count -- 2 raw matches but only 1 belongs to this checkout must read present (got: $outBHlinuxJ)"
+  echo "$outBHlinuxJ" | jq -e '.detail | contains("1 poller")' >/dev/null \
+    || fail "bridge-health (Linux): cmdline-verified fallback detail should name the count 1, not the raw pgrep count 2 (got: $outBHlinuxJ)"
+  echo "ok: bridge-health (Linux) — pgrep -f fallback verifies matched pids' cmdlines, excluding a foreign-checkout match from the count"
+else
+  echo "SKIP: bridge-health (Linux) case (j): no evidence in the stub log that pgrep actually spawned on this host"
+fi
+
+# ── case (k): a NON-ENOENT failure (EACCES) reading a thread's children file
+# reads degraded, never silently folded into "thread exited" (GH #639) ──────
+if [ "$(id -u)" -eq 0 ]; then
+  echo "SKIP: bridge-health (Linux) case (k): running as root, chmod 000 does not deny root reads"
+else
+  rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9001/task/9004" "$bh_proc_root/9002"
+  printf '9002\n' > "$bh_proc_root/9001/task/9001/children"
+  printf '9003\n' > "$bh_proc_root/9001/task/9004/children"
+  chmod 000 "$bh_proc_root/9001/task/9004/children"
+  printf '%s\0' bun poller.ts > "$bh_proc_root/9002/cmdline"
+  rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
+  outBHlinuxK=$(BH_PGREP_N=0 run_bh_posix)
+  chmod 644 "$bh_proc_root/9001/task/9004/children"
+  if bh_posix_log_has "show telegram-bridge.service"; then
+    echo "$outBHlinuxK" | jq -e '.actual == "degraded"' >/dev/null \
+      || fail "bridge-health (Linux): an EACCES reading a thread's children file must read degraded, never be silently folded into 'thread exited' (GH #639) (got: $outBHlinuxK)"
+    echo "ok: bridge-health (Linux) — an EACCES reading a thread's children file reads degraded (GH #639), not silently treated as an exited thread"
+  else
+    echo "SKIP: bridge-health (Linux) case (k): no evidence in the stub log that systemctl actually spawned on this host"
+  fi
+fi
 
 # ── bridge-persistence — HIMMEL-2176 Stage-1 PR-C, status item S6 ───────────
 # Contract (spec §3.5): logon task (win) / systemd unit + linger (linux)

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -4912,6 +4912,34 @@ else
   fi
 fi
 
+# ── case (n): systemd unit active + in-tree count verified, but pgrep is NOT
+# on PATH for the system-wide sweep -> degraded, never silently falling back
+# to the tree-only count as if the sweep had found nothing (CR gap,
+# HIMMEL-2932 round-2 finding) ───────────────────────────────────────────────
+bh_posix_stub_nopgrep="$work/bh-posix-stub-nopgrep"
+rm -rf "$bh_posix_stub_nopgrep"
+build_hermetic_bin "$bh_posix_stub_nopgrep" cat
+cp "$bh_posix_stub/systemctl" "$bh_posix_stub_nopgrep/systemctl"
+cp "$bh_posix_stub/bun" "$bh_posix_stub_nopgrep/bun"
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9002"
+printf '9002\n' > "$bh_proc_root/9001/task/9001/children"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9002/cmdline"
+rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
+outBHlinuxN=$(PATH="$bh_posix_stub_nopgrep:$(scrub_path "$PATH" systemctl pgrep)" BH_STUB_LOG="$(winpath "$bh_posix_log")" BH_STUB_STATE="$(winpath "$bh_posix_state")" "$node_bin" -e "
+const { runProbe } = require('$probes_lib_w');
+const manifest = JSON.parse(require('fs').readFileSync('$manifest_w', 'utf8'));
+const item = manifest.items.find((i) => i.id === 'bridge-health');
+const ctx = { repoRoot: '$(winpath "$repo_root_w")', targetPath: '$(winpath "$bh_dir")', scope: 'project', platform: 'linux', procRoot: '$(winpath "$bh_proc_root")', env: process.env };
+console.log(JSON.stringify(runProbe(item, ctx)));
+")
+if bh_posix_log_has "show telegram-bridge.service"; then
+  echo "$outBHlinuxN" | jq -e '.actual == "degraded"' >/dev/null \
+    || fail "bridge-health (Linux): pgrep missing from PATH during the system-wide sweep must read degraded, never silently fall back to the tree-only count (got: $outBHlinuxN)"
+  echo "ok: bridge-health (Linux) — pgrep missing from PATH during the system-wide sweep reads degraded, not silently tree-only"
+else
+  echo "SKIP: bridge-health (Linux) case (n): no evidence in the stub log that systemctl actually spawned on this host"
+fi
+
 # ── bridge-persistence — HIMMEL-2176 Stage-1 PR-C, status item S6 ───────────
 # Contract (spec §3.5): logon task (win) / systemd unit + linger (linux)
 # present when bridge.enabled; warn when enabled but persistence is absent.

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -4821,6 +4821,13 @@ if bh_posix_log_has "show telegram-bridge.service"; then
   echo "$outBHlinuxH" | jq -e '.detail | contains("2 poller")' >/dev/null \
     || fail "bridge-health (Linux): tree+sweep degraded detail should name the count 2 (got: $outBHlinuxH)"
   echo "ok: bridge-health (Linux) — an out-of-tree duplicate poller found via the system-wide pgrep sweep is unioned with the tree-scoped count, reading degraded, count 2 (HIMMEL-1555 class)"
+  # the sweep must match on a broad basename-only pattern, NOT the resolved
+  # absolute poller path -- the realistic out-of-tree duplicate (fixture
+  # cmdline above is a bare `bun poller.ts`, no path) has no path substring
+  # for an absolute-path pgrep -f to match against (CR gap, HIMMEL-2932).
+  bh_posix_log_has 'pgrep -f poller\.ts' \
+    || fail "bridge-health (Linux): the system-wide sweep must pgrep -f on a broad 'poller.ts' pattern, not the resolved absolute path, so a bare (pathless) duplicate invocation is still a candidate (log: $(cat "$bh_posix_log" 2>/dev/null))"
+  echo "ok: bridge-health (Linux) — the system-wide sweep matches on a broad basename-only pattern, catching a pathless duplicate invocation"
 else
   echo "SKIP: bridge-health (Linux) case (h): no evidence in the stub log that systemctl actually spawned on this host"
 fi
@@ -4880,6 +4887,28 @@ else
     echo "ok: bridge-health (Linux) — an EACCES reading a thread's children file reads degraded (GH #639), not silently treated as an exited thread"
   else
     echo "SKIP: bridge-health (Linux) case (k): no evidence in the stub log that systemctl actually spawned on this host"
+  fi
+fi
+
+# ── case (m): a NON-ENOENT failure (EACCES) LISTING a descendant's task/
+# directory itself (not reading a children file inside it, that's case (k))
+# reads degraded, never silently folded into "no children" (GH #639, one
+# level up from case (k) in the same function) ──────────────────────────────
+if [ "$(id -u)" -eq 0 ]; then
+  echo "SKIP: bridge-health (Linux) case (m): running as root, chmod 000 does not deny root reads"
+else
+  rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9002/task/9002"
+  printf '9002\n' > "$bh_proc_root/9001/task/9001/children"
+  chmod 000 "$bh_proc_root/9002/task"
+  rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
+  outBHlinuxM=$(BH_PGREP_N=0 run_bh_posix)
+  chmod 755 "$bh_proc_root/9002/task"
+  if bh_posix_log_has "show telegram-bridge.service"; then
+    echo "$outBHlinuxM" | jq -e '.actual == "degraded"' >/dev/null \
+      || fail "bridge-health (Linux): an EACCES listing a descendant's task/ directory must read degraded, never be silently folded into 'no children' (GH #639) (got: $outBHlinuxM)"
+    echo "ok: bridge-health (Linux) — an EACCES listing a descendant's task/ directory reads degraded (GH #639), not silently treated as no children"
+  else
+    echo "SKIP: bridge-health (Linux) case (m): no evidence in the stub log that systemctl actually spawned on this host"
   fi
 fi
 


### PR DESCRIPTION
## Summary

Hardens `probeBridgePollerCountPosix` (bridge-health poller-count check on Linux/macOS) against four deferred CR findings from PR #638 and GH issue #639:

1. Recurse the descendant process tree from MainPID (depth-bounded, 4) instead of one level, and also test MainPID's own cmdline.
2. After a systemd-scoped count, also run a system-wide `pgrep -f` sweep (matched on a broad basename pattern) and union/dedupe by verified identity, to catch a manually-launched duplicate poller outside the systemd unit's tree (HIMMEL-1555 class) — mirroring the Windows CIM branch's system-wide scope.
3. In the `pgrep -f` fallback, escape ERE metacharacters in the resolved poller path, and verify each matched PID's cmdline through the existing `pollerLineIsThisCheckout` anchor helper instead of trusting pgrep's raw match count.
4. (GH #639) Treat a non-ENOENT (e.g. EACCES) failure reading a thread's `children` file as `degraded`, not silently as "thread exited."

## CR follow-ups (rounds 2-3)

- Round 1: `posixDirectChildPids`'s outer `readdirSync` catch folded EACCES into "no children" — fixed to degrade; `posixVerifiedPgrepMatches`'s pattern was un-escaped for the sweep's broad match — renamed the param and documented the tradeoff (`POLLER_SWEEP_PATTERN`).
- Round 2: a missing `pgrep` binary during the system-wide sweep silently fell back to the tree-only count instead of degrading — fixed (`sweep.pids === null` now returns `degraded`).
- Round 3: same codex-1 finding recurred (bare-token cwd-unverified match, a pre-existing HIMMEL-1532 tradeoff shared across 3+ call sites, out of this PR's four defined gaps) — deferred to HIMMEL-2936.

## Test plan

- [x] `bash scripts/quiet-run.sh wizard-probes-suite -- bash scripts/himmelctl/test/test-wizard-probes.sh` — GREEN, all bridge-health Linux/POSIX fixture cases (a)-(n) pass (none skipped on this host).
- [x] RED confirmed against unmodified HEAD before implementing (per ship-flow contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEL6kpuXjuaTdUVGGyAnbX