### PR TITLE
fix(git): [HIMMEL-2934] sanctioned restore-to-head shape for RED-control discards

### DIFF
--- a/docs/handover/leg-preface.md
+++ b/docs/handover/leg-preface.md
@@ -81,6 +81,9 @@ tool-permission envelope.
 
 RED first, always — one assertion that fails *before* the implementation
 exists, pasted, then green. A control that cannot fail is not evidence.
+To restore a tracked file to HEAD use `bash scripts/git/restore-to-head.sh
+<path>` — `git checkout -- <path>` is a settings deny and `git restore`
+prompts; the script saves the outgoing diff first.
 
 **Impacted suites = every suite that references a file you touched**
 (`git grep -l` from the worktree), not the suites in the directory you edited.

--- a/docs/handover/leg-preface.md
+++ b/docs/handover/leg-preface.md
@@ -83,7 +83,7 @@ RED first, always — one assertion that fails *before* the implementation
 exists, pasted, then green. A control that cannot fail is not evidence.
 To restore a tracked file to HEAD use `bash scripts/git/restore-to-head.sh
 <path>` — `git checkout -- <path>` is a settings deny and `git restore`
-prompts; the script saves the outgoing diff first.
+prompts; the script saves the outgoing content first (a plain copy).
 
 **Impacted suites = every suite that references a file you touched**
 (`git grep -l` from the worktree), not the suites in the directory you edited.

--- a/docs/internals/stuck-playbook.md
+++ b/docs/internals/stuck-playbook.md
@@ -60,9 +60,11 @@ several turns to this on 2026-09-12.
 **What to do:** `bash scripts/git/restore-to-head.sh <path> [<path>...]` —
 one literal command, no `cd`/`$()`/compound operators. It refuses globs,
 untracked paths, directories, and paths outside the current worktree, and it
-saves the outgoing diff for every dirty path to `${TMPDIR:-/tmp}/restore-to-head/`
-before restoring, so the discard is recoverable via `git apply`. Never try
-bare `git checkout -- <path>` or `git restore` yourself to work around this.
+saves the outgoing content for every dirty path — a plain copy, not a diff —
+to a fresh `${TMPDIR:-/tmp}/restore-to-head.XXXXXX/` directory before
+restoring, so the discard is recoverable via `cp` (staged content that
+differs from HEAD is saved separately via `git show`). Never try bare
+`git checkout -- <path>` or `git restore` yourself to work around this.
 
 ---
 

--- a/docs/internals/stuck-playbook.md
+++ b/docs/internals/stuck-playbook.md
@@ -48,6 +48,24 @@ operator, don't reshape to dodge it.
 
 ---
 
+## Symptom: a leg needs a tracked file back at HEAD and `git checkout -- <path>` is denied (HIMMEL-2934)
+
+Every TDD RED control needs a way to restore a dirtied tracked file to HEAD
+before implementing, but `Bash(git checkout -- *)` is a `deny` entry in
+`.claude/settings.json` (a deny beats any allow, so an allow rule cannot fix
+this) and `git restore` matches no rule at all, so it falls to the classifier
+and resolves as a silent headless DENY (HIMMEL-203). N158 and N159 each lost
+several turns to this on 2026-09-12.
+
+**What to do:** `bash scripts/git/restore-to-head.sh <path> [<path>...]` —
+one literal command, no `cd`/`$()`/compound operators. It refuses globs,
+untracked paths, directories, and paths outside the current worktree, and it
+saves the outgoing diff for every dirty path to `${TMPDIR:-/tmp}/restore-to-head/`
+before restoring, so the discard is recoverable via `git apply`. Never try
+bare `git checkout -- <path>` or `git restore` yourself to work around this.
+
+---
+
 ## Symptom: a Jira write fell through to the classifier and was DENIED (HIMMEL-205 / 203)
 
 In auto-mode the `auto-approve-safe-bash` hook grants the Jira CLI wholesale —

--- a/scripts/git/restore-to-head.sh
+++ b/scripts/git/restore-to-head.sh
@@ -8,7 +8,7 @@
 # and paths outside the current worktree — everything bare checkout would
 # silently accept.
 #
-# Backups are PLAIN COPIES, not diffs: a per-file worktree copy (`cp -p`,
+# Backups are PLAIN COPIES, not diffs: a per-file worktree copy (`cp -RPp`,
 # mode preserved) and, when the index differs from HEAD, the staged blob
 # (`git show`) plus its `git ls-files -s` mode line. A diff/patch-based
 # backup depends on git actually being able to reproduce and re-apply a
@@ -88,15 +88,24 @@ for rel in "${RELS[@]}"; do
         continue
     fi
 
-    echo "$n $rel" >> "$MANIFEST"
-
     saved_wt=""
+    wt_deleted=0
     if [ "$wt_differs" -eq 1 ]; then
-        saved_wt="$RUN_DIR/$n.worktree"
-        if ! cp -p "$TOPLEVEL/$rel" "$saved_wt"; then
-            echo "restore-to-head: could not back up worktree content for '$rel' to '$saved_wt' -- aborting without discarding it" >&2
-            exit 2
+        if [ ! -L "$TOPLEVEL/$rel" ] && [ ! -e "$TOPLEVEL/$rel" ]; then
+            wt_deleted=1
+        else
+            saved_wt="$RUN_DIR/$n.worktree"
+            # Preserve the link itself, including dangling links; never use -L/-H.
+            if ! cp -RPp "$TOPLEVEL/$rel" "$saved_wt"; then
+                echo "restore-to-head: could not back up worktree content for '$rel' to '$saved_wt' -- aborting without discarding it" >&2
+                exit 2
+            fi
         fi
+    fi
+    if [ "$wt_deleted" -eq 1 ]; then
+        echo "$n $rel deleted" >> "$MANIFEST"
+    else
+        echo "$n $rel" >> "$MANIFEST"
     fi
 
     saved_idx=""
@@ -114,7 +123,9 @@ for rel in "${RELS[@]}"; do
     fi
 
     git -C "$TOPLEVEL" checkout HEAD -- ":(literal)$rel"
-    if [ -n "$saved_wt" ]; then
+    if [ "$wt_deleted" -eq 1 ]; then
+        echo "restored $rel (worktree deletion recorded: $MANIFEST)"
+    elif [ -n "$saved_wt" ]; then
         echo "restored $rel (saved worktree copy: $saved_wt)"
     else
         echo "restored $rel (staged-only change; saved separately: $saved_idx)"

--- a/scripts/git/restore-to-head.sh
+++ b/scripts/git/restore-to-head.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# restore-to-head.sh <path>... — the sanctioned shape for restoring one or
+# more tracked files to HEAD in a leg (HIMMEL-2934). `git checkout -- <path>`
+# is a `deny` entry in .claude/settings.json and `git restore` falls through
+# unmatched to the classifier, resolving as a silent headless DENY. This
+# script does the same restore but saves the outgoing diff first, so the
+# discard is recoverable, and refuses globs, untracked paths, directories,
+# and paths outside the current worktree — everything bare checkout would
+# silently accept.
+#
+# Platform guard (gitbash-only): Git Bash on Windows / any POSIX bash 3.2+.
+# Pure git + POSIX shell; no .ps1 twin needed.
+set -uo pipefail
+
+usage() {
+    cat <<'EOF'
+usage: restore-to-head.sh <path> [<path>...]
+
+Restores one or more tracked files to HEAD, saving the outgoing diff for
+each dirty path first (recoverable via `git apply`). Refuses glob
+arguments, untracked paths, directories, and paths outside the current
+worktree.
+EOF
+}
+
+[ $# -ge 1 ] || { usage >&2; exit 2; }
+case "$1" in -h|--help) usage; exit 0 ;; esac
+
+TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "restore-to-head: not inside a git repository" >&2; exit 2; }
+
+for arg in "$@"; do
+    case "$arg" in
+        *'*'*|*'?'*|*'['*) echo "restore-to-head: refusing glob argument '$arg'" >&2; exit 2 ;;
+        .|..|*/) echo "restore-to-head: refusing '$arg'" >&2; exit 2 ;;
+    esac
+done
+
+RELS=()
+for arg in "$@"; do
+    case "$arg" in
+        /*) abs="$arg" ;;
+        *)  abs="$PWD/$arg" ;;
+    esac
+    case "$abs" in
+        "$TOPLEVEL"/*) : ;;
+        *) echo "restore-to-head: '$arg' resolves outside this worktree ($TOPLEVEL)" >&2; exit 2 ;;
+    esac
+    [ -d "$abs" ] && { echo "restore-to-head: '$arg' is a directory" >&2; exit 2; }
+    rel="${abs#"$TOPLEVEL"/}"
+    git ls-files --error-unmatch -- "$rel" >/dev/null 2>&1 || {
+        echo "restore-to-head: '$arg' is untracked -- refusing (never rm)" >&2; exit 2; }
+    RELS+=("$rel")
+done
+
+SAVE_DIR="${TMPDIR:-/tmp}/restore-to-head"
+mkdir -p "$SAVE_DIR"
+STAMP=$(date +%s)
+
+for rel in "${RELS[@]}"; do
+    if [ -n "$(git diff -- "$rel")" ]; then
+        patch="$SAVE_DIR/${STAMP}-$(basename "$rel").patch"
+        git diff -- "$rel" > "$patch"
+        git checkout -- "$rel"
+        echo "restored $rel (saved diff: $patch)"
+    else
+        echo "restore-to-head: '$rel' already matches HEAD -- no-op"
+    fi
+done
+
+remaining=$(git diff --stat -- "${RELS[@]}")
+[ -z "$remaining" ]

--- a/scripts/git/restore-to-head.sh
+++ b/scripts/git/restore-to-head.sh
@@ -57,36 +57,54 @@ for arg in "$@"; do
     RELS+=("$rel")
 done
 
-SAVE_DIR="${TMPDIR:-/tmp}/restore-to-head"
-RUN_DIR="$SAVE_DIR/$(date +%s)-$$"
-mkdir -p "$RUN_DIR"
+RUN_DIR=$(mktemp -d "${TMPDIR:-/tmp}/restore-to-head.XXXXXX") || {
+    echo "restore-to-head: could not create a private backup directory under ${TMPDIR:-/tmp}" >&2
+    exit 2
+}
 
 for rel in "${RELS[@]}"; do
-    if [ -n "$(git -C "$TOPLEVEL" diff --binary HEAD -- ":(literal)$rel")" ]; then
+    wt_diff=$(git -C "$TOPLEVEL" diff --binary HEAD -- ":(literal)$rel")
+    idx_diff=$(git -C "$TOPLEVEL" diff --binary --cached HEAD -- ":(literal)$rel")
+    if [ -z "$wt_diff" ] && [ -z "$idx_diff" ]; then
+        echo "restore-to-head: '$rel' already matches HEAD -- no-op"
+        continue
+    fi
+
+    patch=""
+    if [ -n "$wt_diff" ]; then
         patch="$RUN_DIR/$rel.patch"
         mkdir -p "$(dirname "$patch")"
         if ! git -C "$TOPLEVEL" diff --binary HEAD -- ":(literal)$rel" > "$patch" || [ ! -s "$patch" ]; then
             echo "restore-to-head: could not write backup for '$rel' to '$patch' -- aborting without discarding it" >&2
             exit 2
         fi
-        if [ -n "$(git -C "$TOPLEVEL" diff --binary -- ":(literal)$rel")" ] \
-            && [ -n "$(git -C "$TOPLEVEL" diff --binary --cached HEAD -- ":(literal)$rel")" ]; then
-            staged_blob="$RUN_DIR/$rel.staged-blob"
-            if ! git -C "$TOPLEVEL" show ":$rel" > "$staged_blob" 2>/dev/null || [ ! -s "$staged_blob" ]; then
-                echo "restore-to-head: could not back up staged index content for '$rel' -- aborting without discarding it" >&2
-                exit 2
-            fi
-            echo "restore-to-head: '$rel' also has staged content that differs from the worktree (saved separately: $staged_blob)" >&2
+    fi
+
+    staged_blob=""
+    if [ -n "$idx_diff" ]; then
+        staged_blob="$RUN_DIR/$rel.staged-blob"
+        mkdir -p "$(dirname "$staged_blob")"
+        if ! git -C "$TOPLEVEL" show ":$rel" > "$staged_blob" 2>/dev/null; then
+            echo "restore-to-head: could not back up staged index content for '$rel' -- aborting without discarding it" >&2
+            exit 2
         fi
-        git -C "$TOPLEVEL" checkout HEAD -- ":(literal)$rel"
+        echo "restore-to-head: '$rel' has staged content that differs from HEAD (saved separately: $staged_blob)" >&2
+    fi
+
+    git -C "$TOPLEVEL" checkout HEAD -- ":(literal)$rel"
+    if [ -n "$patch" ]; then
         echo "restored $rel (saved diff: $patch)"
     else
-        echo "restore-to-head: '$rel' already matches HEAD -- no-op"
+        echo "restored $rel (staged-only change; saved separately: $staged_blob)"
     fi
 done
 
 for rel in "${RELS[@]}"; do
-    remaining=$(git -C "$TOPLEVEL" diff --stat HEAD -- ":(literal)$rel") || {
+    remaining_wt=$(git -C "$TOPLEVEL" diff --stat HEAD -- ":(literal)$rel") || {
         echo "restore-to-head: could not verify '$rel' is clean after restore" >&2; exit 2; }
-    [ -z "$remaining" ] || { echo "restore-to-head: '$rel' still differs from HEAD after restore" >&2; exit 2; }
+    remaining_idx=$(git -C "$TOPLEVEL" diff --cached --stat HEAD -- ":(literal)$rel") || {
+        echo "restore-to-head: could not verify '$rel' index is clean after restore" >&2; exit 2; }
+    if [ -n "$remaining_wt" ] || [ -n "$remaining_idx" ]; then
+        echo "restore-to-head: '$rel' still differs from HEAD after restore" >&2; exit 2
+    fi
 done

--- a/scripts/git/restore-to-head.sh
+++ b/scripts/git/restore-to-head.sh
@@ -48,7 +48,7 @@ for arg in "$@"; do
     esac
     [ -d "$abs" ] && { echo "restore-to-head: '$arg' is a directory" >&2; exit 2; }
     rel="${abs#"$TOPLEVEL"/}"
-    git ls-files --error-unmatch -- "$rel" >/dev/null 2>&1 || {
+    git -C "$TOPLEVEL" ls-files --error-unmatch -- "$rel" >/dev/null 2>&1 || {
         echo "restore-to-head: '$arg' is untracked -- refusing (never rm)" >&2; exit 2; }
     RELS+=("$rel")
 done
@@ -58,15 +58,19 @@ mkdir -p "$SAVE_DIR"
 STAMP=$(date +%s)
 
 for rel in "${RELS[@]}"; do
-    if [ -n "$(git diff -- "$rel")" ]; then
-        patch="$SAVE_DIR/${STAMP}-$(basename "$rel").patch"
-        git diff -- "$rel" > "$patch"
-        git checkout -- "$rel"
+    if [ -n "$(git -C "$TOPLEVEL" diff --binary HEAD -- "$rel")" ]; then
+        safe_name=$(printf '%s' "$rel" | tr '/' '_')
+        patch="$SAVE_DIR/${STAMP}-${safe_name}.patch"
+        if ! git -C "$TOPLEVEL" diff --binary HEAD -- "$rel" > "$patch" || [ ! -s "$patch" ]; then
+            echo "restore-to-head: could not write backup for '$rel' to '$patch' -- aborting without discarding it" >&2
+            exit 2
+        fi
+        git -C "$TOPLEVEL" checkout HEAD -- "$rel"
         echo "restored $rel (saved diff: $patch)"
     else
         echo "restore-to-head: '$rel' already matches HEAD -- no-op"
     fi
 done
 
-remaining=$(git diff --stat -- "${RELS[@]}")
+remaining=$(git -C "$TOPLEVEL" diff --stat HEAD -- "${RELS[@]}")
 [ -z "$remaining" ]

--- a/scripts/git/restore-to-head.sh
+++ b/scripts/git/restore-to-head.sh
@@ -3,10 +3,20 @@
 # more tracked files to HEAD in a leg (HIMMEL-2934). `git checkout -- <path>`
 # is a `deny` entry in .claude/settings.json and `git restore` falls through
 # unmatched to the classifier, resolving as a silent headless DENY. This
-# script does the same restore but saves the outgoing diff first, so the
+# script does the same restore but saves the outgoing content first, so the
 # discard is recoverable, and refuses globs, untracked paths, directories,
 # and paths outside the current worktree — everything bare checkout would
 # silently accept.
+#
+# Backups are PLAIN COPIES, not diffs: a per-file worktree copy (`cp -p`,
+# mode preserved) and, when the index differs from HEAD, the staged blob
+# (`git show`) plus its `git ls-files -s` mode line. A diff/patch-based
+# backup depends on git actually being able to reproduce and re-apply a
+# patch — a configured external-diff/textconv driver can make `git diff`
+# emit nonempty, non-applicable output, and a unified diff cannot carry an
+# index-only mode or type change at all. A plain copy has neither failure
+# mode: recovery is `cp` back, which no diff driver, binary content or mode
+# bit can defeat (HIMMEL-2934 round 5, codex-1/codex-4).
 #
 # Platform guard (gitbash-only): Git Bash on Windows / any POSIX bash 3.2+.
 # Pure git + POSIX shell; no .ps1 twin needed.
@@ -16,10 +26,10 @@ usage() {
     cat <<'EOF'
 usage: restore-to-head.sh <path> [<path>...]
 
-Restores one or more tracked files to HEAD, saving the outgoing diff for
-each dirty path first (recoverable via `git apply`). Refuses glob
-arguments, untracked paths, directories, and paths outside the current
-worktree.
+Restores one or more tracked files to HEAD, saving a plain copy of each
+dirty path's worktree content and staged index content first (recoverable
+via `cp` / `git show`). Refuses glob arguments, untracked paths,
+directories, and paths outside the current worktree.
 EOF
 }
 
@@ -61,48 +71,60 @@ RUN_DIR=$(mktemp -d "${TMPDIR:-/tmp}/restore-to-head.XXXXXX") || {
     echo "restore-to-head: could not create a private backup directory under ${TMPDIR:-/tmp}" >&2
     exit 2
 }
+MANIFEST="$RUN_DIR/MANIFEST"
+: > "$MANIFEST"
 
+n=0
 for rel in "${RELS[@]}"; do
-    wt_diff=$(git -C "$TOPLEVEL" diff --binary HEAD -- ":(literal)$rel")
-    idx_diff=$(git -C "$TOPLEVEL" diff --binary --cached HEAD -- ":(literal)$rel")
-    if [ -z "$wt_diff" ] && [ -z "$idx_diff" ]; then
+    n=$((n + 1))
+
+    wt_differs=1
+    git -C "$TOPLEVEL" diff --no-ext-diff --no-textconv --quiet HEAD -- ":(literal)$rel" && wt_differs=0
+    idx_differs=1
+    git -C "$TOPLEVEL" diff --no-ext-diff --no-textconv --quiet --cached HEAD -- ":(literal)$rel" && idx_differs=0
+
+    if [ "$wt_differs" -eq 0 ] && [ "$idx_differs" -eq 0 ]; then
         echo "restore-to-head: '$rel' already matches HEAD -- no-op"
         continue
     fi
 
-    patch=""
-    if [ -n "$wt_diff" ]; then
-        patch="$RUN_DIR/$rel.patch"
-        mkdir -p "$(dirname "$patch")"
-        if ! git -C "$TOPLEVEL" diff --binary HEAD -- ":(literal)$rel" > "$patch" || [ ! -s "$patch" ]; then
-            echo "restore-to-head: could not write backup for '$rel' to '$patch' -- aborting without discarding it" >&2
+    echo "$n $rel" >> "$MANIFEST"
+
+    saved_wt=""
+    if [ "$wt_differs" -eq 1 ]; then
+        saved_wt="$RUN_DIR/$n.worktree"
+        if ! cp -p "$TOPLEVEL/$rel" "$saved_wt"; then
+            echo "restore-to-head: could not back up worktree content for '$rel' to '$saved_wt' -- aborting without discarding it" >&2
             exit 2
         fi
     fi
 
-    staged_blob=""
-    if [ -n "$idx_diff" ]; then
-        staged_blob="$RUN_DIR/$rel.staged-blob"
-        mkdir -p "$(dirname "$staged_blob")"
-        if ! git -C "$TOPLEVEL" show ":$rel" > "$staged_blob" 2>/dev/null; then
+    saved_idx=""
+    if [ "$idx_differs" -eq 1 ]; then
+        saved_idx="$RUN_DIR/$n.index"
+        if ! git -C "$TOPLEVEL" show ":$rel" > "$saved_idx" 2>/dev/null; then
             echo "restore-to-head: could not back up staged index content for '$rel' -- aborting without discarding it" >&2
             exit 2
         fi
-        echo "restore-to-head: '$rel' has staged content that differs from HEAD (saved separately: $staged_blob)" >&2
+        if ! git -C "$TOPLEVEL" ls-files -s -- ":(literal)$rel" > "$RUN_DIR/$n.index-mode"; then
+            echo "restore-to-head: could not back up staged index mode for '$rel' -- aborting without discarding it" >&2
+            exit 2
+        fi
+        echo "restore-to-head: '$rel' has staged content that differs from HEAD (saved separately: $saved_idx)" >&2
     fi
 
     git -C "$TOPLEVEL" checkout HEAD -- ":(literal)$rel"
-    if [ -n "$patch" ]; then
-        echo "restored $rel (saved diff: $patch)"
+    if [ -n "$saved_wt" ]; then
+        echo "restored $rel (saved worktree copy: $saved_wt)"
     else
-        echo "restored $rel (staged-only change; saved separately: $staged_blob)"
+        echo "restored $rel (staged-only change; saved separately: $saved_idx)"
     fi
 done
 
 for rel in "${RELS[@]}"; do
-    remaining_wt=$(git -C "$TOPLEVEL" diff --stat HEAD -- ":(literal)$rel") || {
+    remaining_wt=$(git -C "$TOPLEVEL" diff --no-ext-diff --no-textconv --stat HEAD -- ":(literal)$rel") || {
         echo "restore-to-head: could not verify '$rel' is clean after restore" >&2; exit 2; }
-    remaining_idx=$(git -C "$TOPLEVEL" diff --cached --stat HEAD -- ":(literal)$rel") || {
+    remaining_idx=$(git -C "$TOPLEVEL" diff --no-ext-diff --no-textconv --cached --stat HEAD -- ":(literal)$rel") || {
         echo "restore-to-head: could not verify '$rel' index is clean after restore" >&2; exit 2; }
     if [ -n "$remaining_wt" ] || [ -n "$remaining_idx" ]; then
         echo "restore-to-head: '$rel' still differs from HEAD after restore" >&2; exit 2

--- a/scripts/git/restore-to-head.sh
+++ b/scripts/git/restore-to-head.sh
@@ -29,10 +29,14 @@ case "$1" in -h|--help) usage; exit 0 ;; esac
 TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null) || {
     echo "restore-to-head: not inside a git repository" >&2; exit 2; }
 
+git -C "$TOPLEVEL" rev-parse --verify -q HEAD >/dev/null 2>&1 || {
+    echo "restore-to-head: HEAD does not exist yet (unborn repository) -- nothing to restore to" >&2; exit 2; }
+
 for arg in "$@"; do
     case "$arg" in
         *'*'*|*'?'*|*'['*) echo "restore-to-head: refusing glob argument '$arg'" >&2; exit 2 ;;
         .|..|*/) echo "restore-to-head: refusing '$arg'" >&2; exit 2 ;;
+        :*) echo "restore-to-head: refusing magic-pathspec argument '$arg'" >&2; exit 2 ;;
     esac
 done
 
@@ -48,29 +52,41 @@ for arg in "$@"; do
     esac
     [ -d "$abs" ] && { echo "restore-to-head: '$arg' is a directory" >&2; exit 2; }
     rel="${abs#"$TOPLEVEL"/}"
-    git -C "$TOPLEVEL" ls-files --error-unmatch -- "$rel" >/dev/null 2>&1 || {
+    git -C "$TOPLEVEL" ls-files --error-unmatch -- ":(literal)$rel" >/dev/null 2>&1 || {
         echo "restore-to-head: '$arg' is untracked -- refusing (never rm)" >&2; exit 2; }
     RELS+=("$rel")
 done
 
 SAVE_DIR="${TMPDIR:-/tmp}/restore-to-head"
-mkdir -p "$SAVE_DIR"
-STAMP=$(date +%s)
+RUN_DIR="$SAVE_DIR/$(date +%s)-$$"
+mkdir -p "$RUN_DIR"
 
 for rel in "${RELS[@]}"; do
-    if [ -n "$(git -C "$TOPLEVEL" diff --binary HEAD -- "$rel")" ]; then
-        safe_name=$(printf '%s' "$rel" | tr '/' '_')
-        patch="$SAVE_DIR/${STAMP}-${safe_name}.patch"
-        if ! git -C "$TOPLEVEL" diff --binary HEAD -- "$rel" > "$patch" || [ ! -s "$patch" ]; then
+    if [ -n "$(git -C "$TOPLEVEL" diff --binary HEAD -- ":(literal)$rel")" ]; then
+        patch="$RUN_DIR/$rel.patch"
+        mkdir -p "$(dirname "$patch")"
+        if ! git -C "$TOPLEVEL" diff --binary HEAD -- ":(literal)$rel" > "$patch" || [ ! -s "$patch" ]; then
             echo "restore-to-head: could not write backup for '$rel' to '$patch' -- aborting without discarding it" >&2
             exit 2
         fi
-        git -C "$TOPLEVEL" checkout HEAD -- "$rel"
+        if [ -n "$(git -C "$TOPLEVEL" diff --binary -- ":(literal)$rel")" ] \
+            && [ -n "$(git -C "$TOPLEVEL" diff --binary --cached HEAD -- ":(literal)$rel")" ]; then
+            staged_blob="$RUN_DIR/$rel.staged-blob"
+            if ! git -C "$TOPLEVEL" show ":$rel" > "$staged_blob" 2>/dev/null || [ ! -s "$staged_blob" ]; then
+                echo "restore-to-head: could not back up staged index content for '$rel' -- aborting without discarding it" >&2
+                exit 2
+            fi
+            echo "restore-to-head: '$rel' also has staged content that differs from the worktree (saved separately: $staged_blob)" >&2
+        fi
+        git -C "$TOPLEVEL" checkout HEAD -- ":(literal)$rel"
         echo "restored $rel (saved diff: $patch)"
     else
         echo "restore-to-head: '$rel' already matches HEAD -- no-op"
     fi
 done
 
-remaining=$(git -C "$TOPLEVEL" diff --stat HEAD -- "${RELS[@]}")
-[ -z "$remaining" ]
+for rel in "${RELS[@]}"; do
+    remaining=$(git -C "$TOPLEVEL" diff --stat HEAD -- ":(literal)$rel") || {
+        echo "restore-to-head: could not verify '$rel' is clean after restore" >&2; exit 2; }
+    [ -z "$remaining" ] || { echo "restore-to-head: '$rel' still differs from HEAD after restore" >&2; exit 2; }
+done

--- a/scripts/git/test-restore-to-head.sh
+++ b/scripts/git/test-restore-to-head.sh
@@ -336,6 +336,34 @@ fi
 reset_wt
 (cd "$WT" && git reset -q --hard main)
 
+# --- (u) a retargeted tracked symlink is backed up as the link, not its referent.
+(cd "$WT" && ln -s tracked.txt link && git add link && git commit -qm 'tracked symlink fixture')
+ln -sfn tracked2.txt "$WT/link"
+out=$(run link 2>&1); rc=$?
+wt_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.worktree' | head -1)
+if [ "$rc" -eq 0 ] && [ "$(readlink "$WT/link")" = "tracked.txt" ] && [ -L "$wt_path" ] && [ "$(readlink "$wt_path")" = "tracked2.txt" ]; then
+    pass "(u) retargeted symlink restored with the outgoing link preserved in backup"
+else
+    fail "(u) rc=$rc wt_path='$wt_path' (expected HEAD link restored and backup symlink targeting tracked2.txt)"
+fi
+reset_wt
+(cd "$WT" && git reset -q --hard main)
+
+# --- (v) an unstaged deletion is recorded, then the file is restored from HEAD.
+DELETED_BACKUPS="$TMP/deleted-backups"
+mkdir -p "$DELETED_BACKUPS"
+rm "$WT/tracked.txt"
+out=$(cd "$WT" && TMPDIR="$DELETED_BACKUPS" bash "$SUT" tracked.txt 2>&1); rc=$?
+manifest=$(find "$DELETED_BACKUPS" -name MANIFEST)
+content=$(cat "$WT/tracked.txt" 2>/dev/null)
+n_copies=$(find "$DELETED_BACKUPS" -name '*.worktree' | wc -l | tr -d ' ')
+if [ "$rc" -eq 0 ] && [ "$content" = "base" ] && [ "$n_copies" -eq 0 ] && grep -qx '1 tracked.txt deleted' "$manifest"; then
+    pass "(v) unstaged deletion restored and recorded as deleted without a worktree copy"
+else
+    fail "(v) rc=$rc content='$content' n_copies=$n_copies out='$out' (expected HEAD file restored and deleted manifest row)"
+fi
+reset_wt
+
 echo "---"
 if [ "$FAILED" -gt 0 ]; then
     echo "test-restore-to-head: $FAILED FAILURE(S)"

--- a/scripts/git/test-restore-to-head.sh
+++ b/scripts/git/test-restore-to-head.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Hermetic tests for restore-to-head.sh (HIMMEL-2934).
+#
+# WHY THIS EXISTS: `git checkout -- <path>` is a settings.json `deny` entry
+# (.claude/settings.json:108) and `git restore` falls through unmatched to
+# the classifier, resolving as a silent headless DENY (HIMMEL-203). Neither
+# is a sanctioned way for a leg to run the RED half of a TDD control (restore
+# a tracked file to HEAD, run the suite, expect the predicted failure).
+# restore-to-head.sh is the sanctioned shape: it does the same restore but
+# saves the outgoing diff first, so the discard is recoverable, and it
+# refuses everything bare checkout would silently accept (globs, untracked
+# paths, paths outside the current worktree).
+#
+# Runs in a throwaway PRIMARY repo plus a linked WORKTREE built under
+# mktemp -d, never the real repo, so it never touches real history.
+#
+# Platform guard (gitbash-only): Git Bash on Windows / any POSIX bash 3.2+.
+# Pure git + POSIX shell; no .ps1 twin needed.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SUT="$HERE/restore-to-head.sh"
+TMP="$(mktemp -d -t restore-to-head-test.XXXXXX)"
+trap 'rm -rf "$TMP" 2>/dev/null || true' EXIT
+
+FAILED=0
+pass() { echo "PASS $1"; }
+fail() { echo "FAIL $1"; FAILED=$((FAILED + 1)); }
+
+PRIMARY="$TMP/primary"
+WT="$TMP/wt"
+mkdir -p "$PRIMARY"
+(
+    cd "$PRIMARY" || exit 2
+    git init -q -b main .
+    git config user.email t@t.t; git config user.name t; git config commit.gpgsign false
+    printf 'base\n' > tracked.txt
+    printf 'base2\n' > tracked2.txt
+    mkdir -p sub
+    printf '#!/bin/sh\necho hi\n' > sub/a.sh
+    printf '#!/bin/sh\necho bye\n' > sub/b.sh
+    git add tracked.txt tracked2.txt sub/a.sh sub/b.sh
+    git commit -qm base
+    git worktree add -q -b work "$WT" main
+)
+
+# --- (h) documented RED control: the deny pattern matches a LEG's command
+# line, not this script's own internal call. Assert the script's internal
+# invocation is present as source text (not something a caller types).
+if [ -f "$SUT" ]; then
+    if grep -q 'git checkout -- ' "$SUT"; then
+        pass "(h) script carries the internal checkout call (deny matches the LEG's line, not this child process)"
+    else
+        fail "(h) script does not contain the expected internal 'git checkout -- ' call"
+    fi
+else
+    fail "(h) $SUT does not exist yet"
+fi
+
+run() { (cd "$WT" && bash "$SUT" "$@"); }
+
+reset_wt() { (cd "$WT" && git checkout -q main -- . 2>/dev/null; git clean -qfd 2>/dev/null); }
+
+# --- (a) dirty one tracked file -> restored, recoverable via saved diff
+printf 'dirty\n' > "$WT/tracked.txt"
+out=$(run tracked.txt); rc=$?
+stat_out=$(cd "$WT" && git diff --stat -- tracked.txt)
+if [ "$rc" -eq 0 ] && [ -z "$stat_out" ]; then
+    pass "(a) rc=0 and tree clean after restore"
+else
+    fail "(a) rc=$rc stat='$stat_out'"
+fi
+patch_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.patch' | head -1)
+if [ -n "$patch_path" ] && [ -f "$patch_path" ]; then
+    if (cd "$WT" && git apply --check "$patch_path" 2>/dev/null); then
+        pass "(a) saved diff applies cleanly (discard is recoverable)"
+    else
+        fail "(a) saved diff at $patch_path does not apply cleanly"
+    fi
+else
+    fail "(a) no saved-diff path found in output: $out"
+fi
+reset_wt
+
+# --- (b) two paths in one call -> both restored, one saved-diff each
+printf 'dirty1\n' > "$WT/tracked.txt"
+printf 'dirty2\n' > "$WT/tracked2.txt"
+out=$(run tracked.txt tracked2.txt); rc=$?
+stat_out=$(cd "$WT" && git diff --stat -- tracked.txt tracked2.txt)
+n_patches=$(printf '%s\n' "$out" | grep -c '\.patch')
+if [ "$rc" -eq 0 ] && [ -z "$stat_out" ] && [ "$n_patches" -eq 2 ]; then
+    pass "(b) two paths both restored, one saved-diff each"
+else
+    fail "(b) rc=$rc stat='$stat_out' n_patches=$n_patches"
+fi
+reset_wt
+
+# --- (c) a glob argument is refused, tree untouched
+printf 'dirty\n' > "$WT/tracked.txt"
+run '*.sh' >/dev/null 2>&1; rc=$?
+stat_out=$(cd "$WT" && git diff --stat -- tracked.txt)
+if [ "$rc" -ne 0 ] && [ -n "$stat_out" ]; then
+    pass "(c) glob argument refused, tree untouched"
+else
+    fail "(c) rc=$rc stat='$stat_out' (expected refusal, tree still dirty)"
+fi
+run '.' >/dev/null 2>&1; rc_dot=$?
+if [ "$rc_dot" -ne 0 ]; then
+    pass "(c) '.' argument refused"
+else
+    fail "(c) '.' argument was NOT refused (rc=$rc_dot)"
+fi
+reset_wt
+
+# --- (d) a path outside the current worktree is refused, tree untouched
+printf 'dirty\n' > "$PRIMARY/tracked.txt"
+run "$PRIMARY/tracked.txt" >/dev/null 2>&1; rc=$?
+stat_out=$(cd "$PRIMARY" && git diff --stat -- tracked.txt)
+if [ "$rc" -ne 0 ] && [ -n "$stat_out" ]; then
+    pass "(d) path outside the worktree refused, tree untouched"
+else
+    fail "(d) rc=$rc stat='$stat_out' (expected refusal)"
+fi
+(cd "$PRIMARY" && git checkout -q -- tracked.txt)
+
+# --- (e) an untracked path is refused, message names it untracked
+printf 'new\n' > "$WT/untracked.txt"
+out=$(run untracked.txt 2>&1); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi 'untracked'; then
+    pass "(e) untracked path refused, message names it untracked"
+else
+    fail "(e) rc=$rc out='$out' (expected refusal naming it untracked)"
+fi
+if [ -f "$WT/untracked.txt" ]; then
+    pass "(e) untracked file was never removed"
+else
+    fail "(e) untracked file was deleted -- must never rm"
+fi
+rm -f "$WT/untracked.txt"
+
+# --- (f) a clean tracked file is a no-op, says so, no saved-diff written
+before_count=$(find "${TMPDIR:-/tmp}/restore-to-head" -name '*.patch' 2>/dev/null | wc -l | tr -d ' ')
+out=$(run tracked.txt); rc=$?
+after_count=$(find "${TMPDIR:-/tmp}/restore-to-head" -name '*.patch' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$rc" -eq 0 ] && [ "$before_count" -eq "$after_count" ]; then
+    pass "(f) clean tracked file is a no-op, no saved-diff written"
+else
+    fail "(f) rc=$rc before=$before_count after=$after_count out='$out'"
+fi
+
+# --- (g) no arguments -> usage, rc != 0
+out=$(run 2>&1); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi 'usage'; then
+    pass "(g) no arguments prints usage and exits non-zero"
+else
+    fail "(g) rc=$rc out='$out' (expected usage + non-zero)"
+fi
+
+echo "---"
+if [ "$FAILED" -gt 0 ]; then
+    echo "test-restore-to-head: $FAILED FAILURE(S)"
+    exit 1
+fi
+echo "test-restore-to-head: all cases pass"

--- a/scripts/git/test-restore-to-head.sh
+++ b/scripts/git/test-restore-to-head.sh
@@ -7,9 +7,10 @@
 # is a sanctioned way for a leg to run the RED half of a TDD control (restore
 # a tracked file to HEAD, run the suite, expect the predicted failure).
 # restore-to-head.sh is the sanctioned shape: it does the same restore but
-# saves the outgoing diff first, so the discard is recoverable, and it
-# refuses everything bare checkout would silently accept (globs, untracked
-# paths, paths outside the current worktree).
+# saves the outgoing content first (a plain copy, not a diff — round 5,
+# codex-1/codex-4), so the discard is recoverable, and it refuses everything
+# bare checkout would silently accept (globs, untracked paths, paths outside
+# the current worktree).
 #
 # Runs in a throwaway PRIMARY repo plus a linked WORKTREE built under
 # mktemp -d, never the real repo, so it never touches real history.
@@ -71,7 +72,7 @@ run() { (cd "$WT" && TMPDIR="$BACKUPS" bash "$SUT" "$@"); }
 
 reset_wt() { (cd "$WT" && git checkout -q main -- . 2>/dev/null; git clean -qfd 2>/dev/null); }
 
-# --- (a) dirty one tracked file -> restored, recoverable via saved diff
+# --- (a) dirty one tracked file -> restored, recoverable via saved copy
 printf 'dirty\n' > "$WT/tracked.txt"
 out=$(run tracked.txt); rc=$?
 stat_out=$(cd "$WT" && git diff --stat -- tracked.txt)
@@ -80,28 +81,24 @@ if [ "$rc" -eq 0 ] && [ -z "$stat_out" ]; then
 else
     fail "(a) rc=$rc stat='$stat_out'"
 fi
-patch_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.patch' | head -1)
-if [ -n "$patch_path" ] && [ -f "$patch_path" ]; then
-    if (cd "$WT" && git apply --check "$patch_path" 2>/dev/null); then
-        pass "(a) saved diff applies cleanly (discard is recoverable)"
-    else
-        fail "(a) saved diff at $patch_path does not apply cleanly"
-    fi
+wt_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.worktree' | head -1)
+if [ -n "$wt_path" ] && [ -f "$wt_path" ] && [ "$(cat "$wt_path")" = "dirty" ]; then
+    pass "(a) saved worktree copy reproduces the discarded content exactly (discard is recoverable)"
 else
-    fail "(a) no saved-diff path found in output: $out"
+    fail "(a) no usable saved copy at '$wt_path' in output: $out"
 fi
 reset_wt
 
-# --- (b) two paths in one call -> both restored, one saved-diff each
+# --- (b) two paths in one call -> both restored, one saved copy each
 printf 'dirty1\n' > "$WT/tracked.txt"
 printf 'dirty2\n' > "$WT/tracked2.txt"
 out=$(run tracked.txt tracked2.txt); rc=$?
 stat_out=$(cd "$WT" && git diff --stat -- tracked.txt tracked2.txt)
-n_patches=$(printf '%s\n' "$out" | grep -c '\.patch')
-if [ "$rc" -eq 0 ] && [ -z "$stat_out" ] && [ "$n_patches" -eq 2 ]; then
-    pass "(b) two paths both restored, one saved-diff each"
+n_copies=$(printf '%s\n' "$out" | grep -c '\.worktree')
+if [ "$rc" -eq 0 ] && [ -z "$stat_out" ] && [ "$n_copies" -eq 2 ]; then
+    pass "(b) two paths both restored, one saved copy each"
 else
-    fail "(b) rc=$rc stat='$stat_out' n_patches=$n_patches"
+    fail "(b) rc=$rc stat='$stat_out' n_copies=$n_copies"
 fi
 reset_wt
 
@@ -148,12 +145,12 @@ else
 fi
 rm -f "$WT/untracked.txt"
 
-# --- (f) a clean tracked file is a no-op, says so, no saved-diff written
-before_count=$(find "$BACKUPS/restore-to-head" -name '*.patch' 2>/dev/null | wc -l | tr -d ' ')
+# --- (f) a clean tracked file is a no-op, says so, no saved copy written
+before_count=$(find "$BACKUPS" -name '*.worktree' 2>/dev/null | wc -l | tr -d ' ')
 out=$(run tracked.txt); rc=$?
-after_count=$(find "$BACKUPS/restore-to-head" -name '*.patch' 2>/dev/null | wc -l | tr -d ' ')
+after_count=$(find "$BACKUPS" -name '*.worktree' 2>/dev/null | wc -l | tr -d ' ')
 if [ "$rc" -eq 0 ] && [ "$before_count" -eq "$after_count" ]; then
-    pass "(f) clean tracked file is a no-op, no saved-diff written"
+    pass "(f) clean tracked file is a no-op, no saved copy written"
 else
     fail "(f) rc=$rc before=$before_count after=$after_count out='$out'"
 fi
@@ -183,14 +180,16 @@ else
 fi
 reset_wt
 
-# --- (j) same basename in different directories -> distinct, non-colliding backups (codex-2)
+# --- (j) same basename in different directories -> distinct, non-colliding
+# backups (codex-2). Numeric per-run backup names make collision structurally
+# impossible regardless of the paths' basenames.
 printf 'dirty-sub\n' > "$WT/sub/a.sh"
 printf 'dirty-other\n' > "$WT/other/a.sh"
 out=$(run sub/a.sh other/a.sh); rc=$?
-patches=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.patch')
-n_unique=$(printf '%s\n' "$patches" | sort -u | wc -l | tr -d ' ')
+copies=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.worktree')
+n_unique=$(printf '%s\n' "$copies" | sort -u | wc -l | tr -d ' ')
 ok_sub=0; ok_other=0
-for p in $patches; do
+for p in $copies; do
     grep -q 'dirty-sub' "$p" 2>/dev/null && ok_sub=1
     grep -q 'dirty-other' "$p" 2>/dev/null && ok_other=1
 done
@@ -201,18 +200,15 @@ else
 fi
 reset_wt
 
-# --- (k) binary file diff is actually recoverable via the saved patch (codex-3)
+# --- (k) binary file content is recoverable byte-for-byte via the saved copy
+# (codex-3). A plain copy needs no reconstruction step at all -- the point.
 printf '\000\001\002bindirty\n' > "$WT/bin.dat"
 out=$(run bin.dat); rc=$?
-patch_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.patch' | head -1)
-recon="$TMP/recon"
-rm -rf "$recon"; mkdir -p "$recon"
-(cd "$recon" && git init -q -b main . && git config user.email t@t.t && git config user.name t && git config commit.gpgsign false && cp "$PRIMARY/bin.dat" . && git add bin.dat && git commit -qm base && git apply "$patch_path" && cmp -s bin.dat <(printf '\000\001\002bindirty\n'))
-recon_rc=$?
-if [ "$rc" -eq 0 ] && [ -n "$patch_path" ] && [ "$recon_rc" -eq 0 ]; then
-    pass "(k) binary file's saved patch reconstructs the dirty content exactly"
+wt_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.worktree' | head -1)
+if [ "$rc" -eq 0 ] && [ -n "$wt_path" ] && cmp -s "$wt_path" <(printf '\000\001\002bindirty\n'); then
+    pass "(k) binary file's saved copy reconstructs the dirty content exactly"
 else
-    fail "(k) rc=$rc patch_path='$patch_path' recon_rc=$recon_rc (binary diff not recoverable)"
+    fail "(k) rc=$rc wt_path='$wt_path' (binary content not recoverable)"
 fi
 reset_wt
 
@@ -267,11 +263,11 @@ fi
 (cd "$WT" && printf 'staged-mid\n' > tracked.txt && git add tracked.txt && printf 'worktree-final\n' > tracked.txt)
 out=$(run tracked.txt 2>&1); rc=$?
 content=$(cat "$WT/tracked.txt")
-staged_blob_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.staged-blob' | head -1)
-if [ "$rc" -eq 0 ] && [ "$content" = "base" ] && [ -n "$staged_blob_path" ] && [ -f "$staged_blob_path" ] && [ "$(cat "$staged_blob_path")" = "staged-mid" ]; then
+idx_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.index' | head -1)
+if [ "$rc" -eq 0 ] && [ "$content" = "base" ] && [ -n "$idx_path" ] && [ -f "$idx_path" ] && [ "$(cat "$idx_path")" = "staged-mid" ]; then
     pass "(p) staged content differing from the worktree is separately backed up before the discard"
 else
-    fail "(p) rc=$rc content='$content' staged_blob_path='$staged_blob_path' (expected the staged 'staged-mid' content recoverable, not silently lost)"
+    fail "(p) rc=$rc content='$content' idx_path='$idx_path' (expected the staged 'staged-mid' content recoverable, not silently lost)"
 fi
 reset_wt
 (cd "$WT" && git reset -q --hard main)
@@ -294,8 +290,8 @@ reset_wt
 # /tmp path another local user could pre-create or symlink) (round-3 codex-2)
 printf 'dirty\n' > "$WT/tracked.txt"
 out=$(run tracked.txt); rc=$?
-patch_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.patch' | head -1)
-run_dir=$(dirname "$patch_path")
+wt_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.worktree' | head -1)
+run_dir=$(dirname "$wt_path")
 mode=$(stat -c '%a' "$run_dir" 2>/dev/null || stat -f '%Lp' "$run_dir" 2>/dev/null)
 if [ "$rc" -eq 0 ] && [ "$mode" = "700" ]; then
     pass "(r) backup run directory is a private mktemp directory (mode 700)"
@@ -303,6 +299,42 @@ else
     fail "(r) rc=$rc run_dir='$run_dir' mode='$mode' (expected a private mktemp-created directory, mode 700)"
 fi
 reset_wt
+
+# --- (s) a configured external diff driver's arbitrary human-readable output
+# must never leak into the saved backup (round-4 codex-1). The backup is now
+# a plain `cp -p` of the worktree file, which never invokes a diff driver at
+# all, so the saved copy must be the raw discarded content, byte for byte --
+# never the driver's stand-in text.
+(cd "$WT" && git config diff.faketool.command 'echo NOT-A-REAL-PATCH >&2; echo NOT-A-REAL-PATCH')
+printf 'tracked.txt diff=faketool\n' > "$WT/.gitattributes"
+printf 'dirty-ext-diff\n' > "$WT/tracked.txt"
+out=$(run tracked.txt 2>&1); rc=$?
+wt_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.worktree' | head -1)
+if [ "$rc" -eq 0 ] && [ -n "$wt_path" ] && [ -f "$wt_path" ] && [ "$(cat "$wt_path")" = "dirty-ext-diff" ]; then
+    pass "(s) saved backup bypasses a configured external diff driver and stays the raw discarded content"
+else
+    fail "(s) rc=$rc wt_path='$wt_path' content='$(cat "$wt_path" 2>/dev/null)' (external diff driver leaked into the saved backup, or content was wrong)"
+fi
+(cd "$WT" && git config --unset diff.faketool.command) 2>/dev/null
+rm -f "$WT/.gitattributes"
+reset_wt
+
+# --- (t) an index-only mode change (e.g. a staged chmod +x with no content
+# change) is captured via its `git ls-files -s` mode line, not silently lost
+# by a content-only backup -- a unified diff cannot carry a mode bit at all
+# (round-5 codex-4).
+(cd "$WT" && chmod +x sub/a.sh && git add sub/a.sh)
+out=$(run sub/a.sh 2>&1); rc=$?
+idx_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.index' | head -1)
+idx_mode_path="${idx_path%.index}.index-mode"
+mode_line=$(cat "$idx_mode_path" 2>/dev/null)
+if [ "$rc" -eq 0 ] && printf '%s' "$mode_line" | grep -q '^100755 '; then
+    pass "(t) index-only mode change is captured via its ls-files mode line"
+else
+    fail "(t) rc=$rc mode_line='$mode_line' idx_mode_path='$idx_mode_path' (expected a 100755 ls-files -s line preserving the staged mode)"
+fi
+reset_wt
+(cd "$WT" && git reset -q --hard main)
 
 echo "---"
 if [ "$FAILED" -gt 0 ]; then

--- a/scripts/git/test-restore-to-head.sh
+++ b/scripts/git/test-restore-to-head.sh
@@ -39,7 +39,11 @@ mkdir -p "$PRIMARY"
     mkdir -p sub
     printf '#!/bin/sh\necho hi\n' > sub/a.sh
     printf '#!/bin/sh\necho bye\n' > sub/b.sh
-    git add tracked.txt tracked2.txt sub/a.sh sub/b.sh
+    mkdir -p other
+    printf '#!/bin/sh\necho other\n' > other/a.sh
+    printf 'base3\n' > tracked3.txt
+    printf '\000\001\002binbase\n' > bin.dat
+    git add tracked.txt tracked2.txt tracked3.txt sub/a.sh sub/b.sh other/a.sh bin.dat
     git commit -qm base
     git worktree add -q -b work "$WT" main
 )
@@ -155,6 +159,77 @@ if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi 'usage'; then
 else
     fail "(g) rc=$rc out='$out' (expected usage + non-zero)"
 fi
+
+# --- (i) backup write failure must NOT be followed by a discard (codex-1)
+RO="$TMP/ro"
+mkdir -p "$RO"
+chmod 555 "$RO"
+printf 'dirty\n' > "$WT/tracked.txt"
+out=$(cd "$WT" && TMPDIR="$RO" bash "$SUT" tracked.txt 2>&1); rc=$?
+content=$(cat "$WT/tracked.txt")
+chmod 755 "$RO"
+if [ "$rc" -ne 0 ] && [ "$content" = "dirty" ]; then
+    pass "(i) unwritable backup dir aborts before discarding the dirty file"
+else
+    fail "(i) rc=$rc content='$content' (expected refusal, file left dirty -- backup dir was unwritable)"
+fi
+reset_wt
+
+# --- (j) same basename in different directories -> distinct, non-colliding backups (codex-2)
+printf 'dirty-sub\n' > "$WT/sub/a.sh"
+printf 'dirty-other\n' > "$WT/other/a.sh"
+out=$(run sub/a.sh other/a.sh); rc=$?
+patches=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.patch')
+n_unique=$(printf '%s\n' "$patches" | sort -u | wc -l | tr -d ' ')
+ok_sub=0; ok_other=0
+for p in $patches; do
+    grep -q 'dirty-sub' "$p" 2>/dev/null && ok_sub=1
+    grep -q 'dirty-other' "$p" 2>/dev/null && ok_other=1
+done
+if [ "$rc" -eq 0 ] && [ "$n_unique" -eq 2 ] && [ "$ok_sub" -eq 1 ] && [ "$ok_other" -eq 1 ]; then
+    pass "(j) same-basename files in different dirs get distinct, non-colliding backups"
+else
+    fail "(j) rc=$rc n_unique=$n_unique ok_sub=$ok_sub ok_other=$ok_other out='$out'"
+fi
+reset_wt
+
+# --- (k) binary file diff is actually recoverable via the saved patch (codex-3)
+printf '\000\001\002bindirty\n' > "$WT/bin.dat"
+out=$(run bin.dat); rc=$?
+patch_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.patch' | head -1)
+recon="$TMP/recon"
+rm -rf "$recon"; mkdir -p "$recon"
+(cd "$recon" && git init -q -b main . && git config user.email t@t.t && git config user.name t && git config commit.gpgsign false && cp "$PRIMARY/bin.dat" . && git add bin.dat && git commit -qm base && git apply "$patch_path" && cmp -s bin.dat <(printf '\000\001\002bindirty\n'))
+recon_rc=$?
+if [ "$rc" -eq 0 ] && [ -n "$patch_path" ] && [ "$recon_rc" -eq 0 ]; then
+    pass "(k) binary file's saved patch reconstructs the dirty content exactly"
+else
+    fail "(k) rc=$rc patch_path='$patch_path' recon_rc=$recon_rc (binary diff not recoverable)"
+fi
+reset_wt
+
+# --- (l) a staged-only change (index != HEAD) is restored to HEAD, not left at index (codex-4)
+(cd "$WT" && printf 'staged-only\n' > tracked.txt && git add tracked.txt)
+out=$(run tracked.txt); rc=$?
+content=$(cat "$WT/tracked.txt")
+if [ "$rc" -eq 0 ] && [ "$content" = "base" ]; then
+    pass "(l) staged-only change restored all the way to HEAD"
+else
+    fail "(l) rc=$rc content='$content' (expected HEAD content 'base', script only compares to the index)"
+fi
+reset_wt
+(cd "$WT" && git reset -q --hard main)
+
+# --- (m) invocation from a subdirectory resolves paths correctly (codex-5)
+printf 'dirty-from-sub\n' > "$WT/sub/a.sh"
+out=$(cd "$WT/sub" && bash "$SUT" a.sh 2>&1); rc=$?
+content=$(cat "$WT/sub/a.sh")
+if [ "$rc" -eq 0 ] && [ "$content" != "dirty-from-sub" ]; then
+    pass "(m) invocation from a subdirectory correctly restores the file"
+else
+    fail "(m) rc=$rc content='$content' (expected restore to succeed when invoked from inside a subdirectory)"
+fi
+reset_wt
 
 echo "---"
 if [ "$FAILED" -gt 0 ]; then

--- a/scripts/git/test-restore-to-head.sh
+++ b/scripts/git/test-restore-to-head.sh
@@ -20,7 +20,11 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 SUT="$HERE/restore-to-head.sh"
-TMP="$(mktemp -d -t restore-to-head-test.XXXXXX)"
+TMP="$(mktemp -d -t restore-to-head-test.XXXXXX)" || { echo "test-restore-to-head: mktemp failed" >&2; exit 2; }
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+    echo "test-restore-to-head: mktemp produced no usable directory" >&2
+    exit 2
+fi
 trap 'rm -rf "$TMP" 2>/dev/null || true' EXIT
 
 FAILED=0
@@ -47,7 +51,7 @@ mkdir -p "$PRIMARY" "$BACKUPS"
     git add tracked.txt tracked2.txt tracked3.txt sub/a.sh sub/b.sh other/a.sh bin.dat
     git commit -qm base
     git worktree add -q -b work "$WT" main
-)
+) || { echo "test-restore-to-head: repo setup failed" >&2; exit 2; }
 
 # --- (h) documented RED control: the deny pattern matches a LEG's command
 # line, not this script's own internal call. Assert the actual checkout
@@ -162,14 +166,16 @@ else
     fail "(g) rc=$rc out='$out' (expected usage + non-zero)"
 fi
 
-# --- (i) backup write failure must NOT be followed by a discard (codex-1)
-RO="$TMP/ro"
-mkdir -p "$RO"
-chmod 555 "$RO"
+# --- (i) backup write failure must NOT be followed by a discard (codex-1).
+# TMPDIR points at a plain FILE, not a directory, so creating the backup dir
+# under it fails deterministically (ENOTDIR) regardless of user or platform
+# permission semantics (chmod 555 is unreliable as root / under Git Bash --
+# round-3 codex-5).
+RO="$TMP/ro-file"
+: > "$RO"
 printf 'dirty\n' > "$WT/tracked.txt"
 out=$(cd "$WT" && TMPDIR="$RO" bash "$SUT" tracked.txt 2>&1); rc=$?
 content=$(cat "$WT/tracked.txt")
-chmod 755 "$RO"
 if [ "$rc" -ne 0 ] && [ "$content" = "dirty" ]; then
     pass "(i) unwritable backup dir aborts before discarding the dirty file"
 else
@@ -269,6 +275,34 @@ else
 fi
 reset_wt
 (cd "$WT" && git reset -q --hard main)
+
+# --- (q) index differs from HEAD even though the worktree already matches HEAD
+# is still detected and restored, not silently skipped as a no-op (round-3 codex-1)
+(cd "$WT" && printf 'staged-then-reverted\n' > tracked.txt && git add tracked.txt && printf 'base\n' > tracked.txt)
+out=$(run tracked.txt 2>&1); rc=$?
+final_idx_diff=$(cd "$WT" && git diff --cached --stat HEAD -- tracked.txt)
+content=$(cat "$WT/tracked.txt")
+if [ "$rc" -eq 0 ] && [ -z "$final_idx_diff" ] && [ "$content" = "base" ]; then
+    pass "(q) staged content is restored to HEAD even when the worktree already matched HEAD"
+else
+    fail "(q) rc=$rc final_idx_diff='$final_idx_diff' content='$content' (expected the index restored to HEAD, not left dirty)"
+fi
+reset_wt
+(cd "$WT" && git reset -q --hard main)
+
+# --- (r) backup run directory is private (mktemp, not a predictable shared
+# /tmp path another local user could pre-create or symlink) (round-3 codex-2)
+printf 'dirty\n' > "$WT/tracked.txt"
+out=$(run tracked.txt); rc=$?
+patch_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.patch' | head -1)
+run_dir=$(dirname "$patch_path")
+mode=$(stat -c '%a' "$run_dir" 2>/dev/null || stat -f '%Lp' "$run_dir" 2>/dev/null)
+if [ "$rc" -eq 0 ] && [ "$mode" = "700" ]; then
+    pass "(r) backup run directory is a private mktemp directory (mode 700)"
+else
+    fail "(r) rc=$rc run_dir='$run_dir' mode='$mode' (expected a private mktemp-created directory, mode 700)"
+fi
+reset_wt
 
 echo "---"
 if [ "$FAILED" -gt 0 ]; then

--- a/scripts/git/test-restore-to-head.sh
+++ b/scripts/git/test-restore-to-head.sh
@@ -29,7 +29,8 @@ fail() { echo "FAIL $1"; FAILED=$((FAILED + 1)); }
 
 PRIMARY="$TMP/primary"
 WT="$TMP/wt"
-mkdir -p "$PRIMARY"
+BACKUPS="$TMP/backups"
+mkdir -p "$PRIMARY" "$BACKUPS"
 (
     cd "$PRIMARY" || exit 2
     git init -q -b main .
@@ -49,19 +50,20 @@ mkdir -p "$PRIMARY"
 )
 
 # --- (h) documented RED control: the deny pattern matches a LEG's command
-# line, not this script's own internal call. Assert the script's internal
-# invocation is present as source text (not something a caller types).
+# line, not this script's own internal call. Assert the actual checkout
+# invocation is present as EXECUTABLE code (not merely mentioned in a
+# comment, which the header itself does for documentation purposes).
 if [ -f "$SUT" ]; then
-    if grep -q 'git checkout -- ' "$SUT"; then
-        pass "(h) script carries the internal checkout call (deny matches the LEG's line, not this child process)"
+    if grep -v '^[[:space:]]*#' "$SUT" | grep -q 'checkout HEAD -- '; then
+        pass "(h) script carries the internal checkout call as executable code, not just a comment"
     else
-        fail "(h) script does not contain the expected internal 'git checkout -- ' call"
+        fail "(h) script does not contain the expected internal checkout call outside of comments"
     fi
 else
     fail "(h) $SUT does not exist yet"
 fi
 
-run() { (cd "$WT" && bash "$SUT" "$@"); }
+run() { (cd "$WT" && TMPDIR="$BACKUPS" bash "$SUT" "$@"); }
 
 reset_wt() { (cd "$WT" && git checkout -q main -- . 2>/dev/null; git clean -qfd 2>/dev/null); }
 
@@ -143,9 +145,9 @@ fi
 rm -f "$WT/untracked.txt"
 
 # --- (f) a clean tracked file is a no-op, says so, no saved-diff written
-before_count=$(find "${TMPDIR:-/tmp}/restore-to-head" -name '*.patch' 2>/dev/null | wc -l | tr -d ' ')
+before_count=$(find "$BACKUPS/restore-to-head" -name '*.patch' 2>/dev/null | wc -l | tr -d ' ')
 out=$(run tracked.txt); rc=$?
-after_count=$(find "${TMPDIR:-/tmp}/restore-to-head" -name '*.patch' 2>/dev/null | wc -l | tr -d ' ')
+after_count=$(find "$BACKUPS/restore-to-head" -name '*.patch' 2>/dev/null | wc -l | tr -d ' ')
 if [ "$rc" -eq 0 ] && [ "$before_count" -eq "$after_count" ]; then
     pass "(f) clean tracked file is a no-op, no saved-diff written"
 else
@@ -222,7 +224,7 @@ reset_wt
 
 # --- (m) invocation from a subdirectory resolves paths correctly (codex-5)
 printf 'dirty-from-sub\n' > "$WT/sub/a.sh"
-out=$(cd "$WT/sub" && bash "$SUT" a.sh 2>&1); rc=$?
+out=$(cd "$WT/sub" && TMPDIR="$BACKUPS" bash "$SUT" a.sh 2>&1); rc=$?
 content=$(cat "$WT/sub/a.sh")
 if [ "$rc" -eq 0 ] && [ "$content" != "dirty-from-sub" ]; then
     pass "(m) invocation from a subdirectory correctly restores the file"
@@ -230,6 +232,43 @@ else
     fail "(m) rc=$rc content='$content' (expected restore to succeed when invoked from inside a subdirectory)"
 fi
 reset_wt
+
+# --- (n) a magic pathspec argument cannot bypass the directory refusal (round-2 codex-3)
+printf 'dirty-sub-a\n' > "$WT/sub/a.sh"
+printf 'dirty-sub-b\n' > "$WT/sub/b.sh"
+run ':(top)sub' >/dev/null 2>&1; rc=$?
+content_a=$(cat "$WT/sub/a.sh")
+content_b=$(cat "$WT/sub/b.sh")
+if [ "$rc" -ne 0 ] && [ "$content_a" = "dirty-sub-a" ] && [ "$content_b" = "dirty-sub-b" ]; then
+    pass "(n) magic-pathspec argument refused, directory contents untouched"
+else
+    fail "(n) rc=$rc content_a='$content_a' content_b='$content_b' (expected refusal, both files still dirty)"
+fi
+reset_wt
+
+# --- (o) an unborn repository (no HEAD yet) is refused, not silently a no-op (round-2 codex-4)
+UNBORN="$TMP/unborn"
+mkdir -p "$UNBORN"
+(cd "$UNBORN" && git init -q -b main . && git config user.email t@t.t && git config user.name t && git config commit.gpgsign false && printf 'x\n' > f.txt && git add f.txt)
+out=$(cd "$UNBORN" && TMPDIR="$BACKUPS" bash "$SUT" f.txt 2>&1); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi 'HEAD'; then
+    pass "(o) unborn repository is refused with a clear error, not a silent no-op"
+else
+    fail "(o) rc=$rc out='$out' (expected refusal naming the missing HEAD)"
+fi
+
+# --- (p) staged content that differs from the worktree is backed up too, not silently discarded (round-2 codex-2)
+(cd "$WT" && printf 'staged-mid\n' > tracked.txt && git add tracked.txt && printf 'worktree-final\n' > tracked.txt)
+out=$(run tracked.txt 2>&1); rc=$?
+content=$(cat "$WT/tracked.txt")
+staged_blob_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.staged-blob' | head -1)
+if [ "$rc" -eq 0 ] && [ "$content" = "base" ] && [ -n "$staged_blob_path" ] && [ -f "$staged_blob_path" ] && [ "$(cat "$staged_blob_path")" = "staged-mid" ]; then
+    pass "(p) staged content differing from the worktree is separately backed up before the discard"
+else
+    fail "(p) rc=$rc content='$content' staged_blob_path='$staged_blob_path' (expected the staged 'staged-mid' content recoverable, not silently lost)"
+fi
+reset_wt
+(cd "$WT" && git reset -q --hard main)
 
 echo "---"
 if [ "$FAILED" -gt 0 ]; then


### PR DESCRIPTION
## Why

`Bash(git checkout -- *)` is a `deny` entry in `.claude/settings.json` — a deny beats any allow, so an allow rule cannot be the fix. `git restore` falls through to the classifier and has been denied in headless legs. Every leg's RED control (restore a pre-fix file to HEAD, prove the predicted failure) needs a sanctioned shape.

This PR adds `bash scripts/git/restore-to-head.sh <path>...`: it saves outgoing content before restoring tracked paths, refuses globs, untracked paths, directories and paths outside the current worktree, and documents the invocation in the stuck playbook and leg preface. No settings changes.

The scripts use bash-3.2-compatible syntax and GNU/BSD-compatible backup flags; no PowerShell twin is added. Linux is verified; macOS/BSD and Git Bash were not executed. Git Bash mode-test portability remains explicitly deferred below.

## Design history (rounds 1–5)

Rounds 1–3 saved a `git diff` patch per dirty path. Review identified that configured external-diff/textconv output need not be applicable, and index-only mode/type changes need separate capture. Round 5 switched to plain worktree copies plus staged blobs (`git show`) and index mode lines (`git ls-files -s`). Round 5 then identified the symlink and unstaged-deletion defects fixed below; the draft was temporarily parked pending an operator scope decision.

## Un-parked 2026-09-12 (operator ruling)

The operator authorized the minimal A/B fix and one additional panel round, without redesigning the backup format.

- **A — Critical, outgoing symlink retarget lost:** `cp -p` followed the symlink and saved referent bytes. `cp -RPp` now preserves the outgoing link object, including its target text, rather than following it.
- **B — Important, unstaged deletion could not be restored:** copying a missing source aborted. An absent non-symlink worktree path now gets a `deleted` MANIFEST row, skips the nonexistent copy and proceeds to restoration. The output names that manifest.
- Rebased branch head before the fix: `1d1b1cb58178ddf49479cff73f62ea31040195b4`, based on `856f4b29ae3d348d1dc8bcf41caeef77701c39d3`.
- Reviewed fix head: `64ccbc68203398be129bcbb7e54edc777c0dc2bc`.
- Round-6 captured diff base: `7ec688039c64eb6421e011baa26ba30e4754ef97` (`main`).

### RED → GREEN evidence

- **(u)** Retargeted tracked symlink: RED returned rc=0 but saved a regular file instead of the outgoing link. GREEN restores the HEAD link and verifies that the backup is a symlink retaining the outgoing target.
- **(v)** Unstaged deletion: RED returned rc=2 because copying the missing source failed. GREEN returns rc=0, restores the HEAD content, records `1 tracked.txt deleted`, and creates no worktree copy.
- RED log: `/tmp/quiet-run-rth-run4-red-20260912-134437-1039865.log`.
- GREEN log: `/tmp/quiet-run-rth-run5-green-20260912-141607-1174211.log` — `test-restore-to-head: all cases pass`, including every pre-existing assertion and rows u/v. These are local operator logs, not downloadable CI artifacts.
- `shellcheck -x` on both scripts and `git diff --check` passed in run 5; pre-commit and commit-msg gates passed. Linux/security attestation trailers are present. No additional source edits in run 6.

## Test coverage

`scripts/git/test-restore-to-head.sh` uses throwaway repositories and a linked worktree, never real history. Coverage includes dirty and clean paths, multiple paths, rejected globs/directories/outside/untracked paths, no-argument usage, backup-creation failure before discard, same-basename isolation, binary copies, staged/worktree divergence, subdirectory invocation, magic pathspecs, unborn repositories, private backup directories, external diff drivers, index modes, outgoing symlink retargets, and unstaged deletion.

## Round table

| Round | Critical | Important | Suggestion |
|---|---|---|---|
| 1 | 3 | 2 | 0 |
| 2 | 2 | 2 | 2 |
| 3 | 0 | 3 | 2 |
| 4 (post-redirect trigger) | 0 | 0 | 4 |
| 5 | 1 | 1 | 1 |
| 6 (un-parked head) | 0 | 0 | 2 |

Earlier-round counts above are retained from the existing PR history. The current ledger audit reports **27 terminal findings, 0 still-open**, rather than deriving its count from that historical table. Historical round-5 A/B rows retain their terminal deferred disposition; their implementations and passing regression evidence are documented above.

Round 6: codex responded successfully (`gpt-6-astra`), 0 blocking findings. The adversarial companion skipped under its not-high-risk policy; no Claude reviewer agents were dispatched. Both suggestions are verified and deferred to **HIMMEL-2934** under the operator's one-round cap:

1. Staged deletion removes the index entry, so the helper currently rejects the path even if it exists in HEAD. Supporting staged deletion and its missing index state is outside the unstaged-deletion fix.
2. The executable-mode fixture uses `chmod` plus `git add`, which is brittle under `core.fileMode=false`. Explicit index-mode staging is a follow-up; Linux's current fixture passed.

`review-round promote: 0 promoted, 0 still-open, 27 skip-terminal, 0 warn (head 64ccbc68)`.

Known-findings pre-check: the arithmetic counter starts at integer zero; the flagged `stat` invocation already has a BSD fallback; the flagged grep pipes consume small fixed fixture outputs. No additional changes needed. Known-findings round-1 class hits in this round: 0.

The CR marker cleared at this exact head. The thread gate returned 0: all existing review threads resolved. CodeRabbit reports automatic reviews disabled; the critic panel carries that absent App signal, and a manual review will be requested once at this head. Final CI/head verification still gates readiness and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a utility for safely restoring specified tracked files to the latest committed version while preserving recoverable worktree and staged content.
  * The utility validates paths and repository state, rejects unsafe inputs, skips clean files, and reports backup locations.

* **Documentation**
  * Added guidance for using the restoration utility, including supported arguments, backup behavior, and troubleshooting steps when standard Git commands are unavailable.

* **Tests**
  * Added comprehensive coverage for restoration, backups, staged changes, binary files, symlinks, deletions, worktrees, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->