### PR TITLE
docs(handover): [HIMMEL-2937] brief template: write the release token in backticks, never bare in prose

### DIFF
--- a/docs/handover/leg-brief-template.md
+++ b/docs/handover/leg-brief-template.md
@@ -32,7 +32,11 @@ template_version: 3
 > `<branch>`, cut from `<base sha>`.** Your RETASK token is
 > `<console letter>-N<n>-<hex>`; your console is **`<console session name>`**;
 > your handover root is `<HANDOVER_DIR>` and the queue lock you must hold is on
-> THIS document. <Any per-leg deviation from the standing leg preface — a
+> THIS document. Write its release token into your LIVE bullet exactly as
+> `queue-lock.sh` prints it — in backticks, never bare in prose and never
+> followed by punctuation — a bare token defeats the vault's anchored gitleaks
+> allowlist and stalls the handover auto-commit (HIMMEL-2910, HIMMEL-2937).
+> <Any per-leg deviation from the standing leg preface — a
 > required bypass env var already set in your launching shell, a lane that is
 > not native, a suite that must be run a particular way — goes here, in this
 > paragraph, and nowhere else.>


### PR DESCRIPTION
## Summary
- `docs/handover/leg-brief-template.md`: after "the queue lock you must hold is on THIS document", adds the sentence telling a leg to write the release token into its LIVE bullet exactly as `queue-lock.sh` prints it — in backticks, never bare in prose or followed by punctuation.

## Why
HIMMEL-2910 (#613) landed the regex half (`queue-lock.sh` prints the backticked form and the vault's gitleaks allowlist is anchored). The human-facing half was left open: nothing told a leg *how* to write the token, so legs wrote it bare in prose, sometimes with trailing punctuation, defeating the anchored allowlist and stalling the handover auto-commit.

## Test plan
- [x] `git diff --stat` — one file, `docs/handover/leg-brief-template.md`
- [x] `bash scripts/handover/console/test-console.sh` (the only suite that references the file) — GREEN
- [x] `/pr-check` docs-audit lane — cross-model panel (codex) 0/0/0, marker cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPVdQYxRVYfGMFY3E7Lehu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the leg brief template to require recording the release token in the LIVE bullet using the specified formatting.
  - This supports automated handover commits and compliance with secret-scanning requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->