### PR TITLE
fix(hooks): [HIMMEL-2940] advisory-hook suites clear the lean-leg env in their preamble so they pass inside a --profile leg

### DIFF
--- a/scripts/hooks/test-graphify-freshness-advisory.sh
+++ b/scripts/hooks/test-graphify-freshness-advisory.sh
@@ -2,6 +2,11 @@
 # test-graphify-freshness-advisory.sh — three-state contract (HIMMEL-1643)
 # shellcheck disable=SC2015,SC2164 # compact status assertions; fixture cd's are into mktemp -d dirs this script just created
 set -uo pipefail
+# The suite owns every case's env; an ambient leg shell (HIMMEL_LEAN_LEG=1
+# under --profile leg-impl, HIMMEL-2940) must not silently turn every
+# unmarked case into a lean-leg case. Only the two explicit T9/T9b lean
+# cases below set it themselves.
+unset LEG_LANE LEG_CONTEXT LEG_REPO LEG_EFFORT HEADED_ARM_LAUNCHER HEADED_ARM_LAUNCHER_ENV HEADED_ARM_RECORDER IMPL_GUARD_OK INLINE_IMPL_OK HIMMEL_CONSOLE_LEG HIMMEL_LEAN_LEG LEG_PROFILE LEG_PROFILE_SETTINGS LEG_PROFILE_PREFACE LEG_PROFILE_MCP_CONFIG 2>/dev/null || true
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOK="$HERE/graphify-freshness-advisory.sh"
 PASS=0; FAIL=0
@@ -19,6 +24,31 @@ mk_graph() { # $1=out-dir  $2=age-days
     # backdate graph.json by N days (python3 is already a hook dependency)
     python3 -c 'import os,sys,time; t=time.time()-float(sys.argv[2])*86400; os.utime(sys.argv[1],(t,t))' "$1/graph.json" "$2"
 }
+
+# --selftest-hermetic replays exactly one benign, non-silent (stale) case and
+# exits — used only by the guard case below, recursing into THIS file once
+# with a controlled ambient env, never the full numbered-case suite.
+if [ "${1:-}" = "--selftest-hermetic" ]; then
+    mk_graph "$tmp/selftest/graphify-out" 5
+    GRAPHIFY_ADVISORY_OUT="$tmp/selftest/graphify-out" bash "$HOOK"
+    exit 0
+fi
+
+echo "== suite hermeticity (HIMMEL-2940) =="
+# A leg's ambient HIMMEL_LEAN_LEG=1 must not reach the hook invocation before
+# the preamble unset above has a chance to clear it — so this recurses with
+# that var set exactly the way a lean-leg caller sets it (before this file's
+# own preamble runs), not via a T9-style case override.
+# Each recursion gets its own `mktemp -d` fixture dir, so the raw outputs
+# differ by that random path alone even with no leak — normalize it out
+# before comparing.
+leaked="$(HIMMEL_LEAN_LEG=1 bash "$0" --selftest-hermetic | sed -E 's#[^ ]*/selftest#SELFTEST_DIR#g')"
+clean="$(bash "$0" --selftest-hermetic | sed -E 's#[^ ]*/selftest#SELFTEST_DIR#g')"
+if [ "$leaked" = "$clean" ] && [ -n "$leaked" ]; then
+    pass "suite is hermetic to a lean-leg caller"
+else
+    fail "suite is hermetic to a lean-leg caller (leaked='$leaked' clean='$clean')"
+fi
 
 # T1 fresh -> silent, rc 0
 mk_graph "$tmp/fresh/graphify-out" 0

--- a/scripts/hooks/test-graphify-freshness-advisory.sh
+++ b/scripts/hooks/test-graphify-freshness-advisory.sh
@@ -31,7 +31,7 @@ mk_graph() { # $1=out-dir  $2=age-days
 if [ "${1:-}" = "--selftest-hermetic" ]; then
     mk_graph "$tmp/selftest/graphify-out" 5
     GRAPHIFY_ADVISORY_OUT="$tmp/selftest/graphify-out" bash "$HOOK"
-    exit 0
+    exit $?
 fi
 
 echo "== suite hermeticity (HIMMEL-2940) =="
@@ -41,13 +41,14 @@ echo "== suite hermeticity (HIMMEL-2940) =="
 # own preamble runs), not via a T9-style case override.
 # Each recursion gets its own `mktemp -d` fixture dir, so the raw outputs
 # differ by that random path alone even with no leak — normalize it out
-# before comparing.
-leaked="$(HIMMEL_LEAN_LEG=1 bash "$0" --selftest-hermetic | sed -E 's#[^ ]*/selftest#SELFTEST_DIR#g')"
-clean="$(bash "$0" --selftest-hermetic | sed -E 's#[^ ]*/selftest#SELFTEST_DIR#g')"
-if [ "$leaked" = "$clean" ] && [ -n "$leaked" ]; then
+# before comparing. `pipefail` (set above) makes $? after the sed pipe
+# reflect the bash recursion's own exit status, not sed's.
+leaked="$(HIMMEL_LEAN_LEG=1 bash "$0" --selftest-hermetic | sed -E 's#[^ ]*/selftest#SELFTEST_DIR#g')"; leaked_rc=$?
+clean="$(bash "$0" --selftest-hermetic | sed -E 's#[^ ]*/selftest#SELFTEST_DIR#g')"; clean_rc=$?
+if [ "$leaked_rc" -eq 0 ] && [ "$clean_rc" -eq 0 ] && [ "$leaked" = "$clean" ] && [ -n "$leaked" ]; then
     pass "suite is hermetic to a lean-leg caller"
 else
-    fail "suite is hermetic to a lean-leg caller (leaked='$leaked' clean='$clean')"
+    fail "suite is hermetic to a lean-leg caller (leaked_rc=$leaked_rc clean_rc=$clean_rc leaked='$leaked' clean='$clean')"
 fi
 
 # T1 fresh -> silent, rc 0

--- a/scripts/hooks/test-inject-where-are-we.sh
+++ b/scripts/hooks/test-inject-where-are-we.sh
@@ -86,7 +86,7 @@ if [ "${1:-}" = "--selftest-hermetic" ]; then
     HIMMEL_REPO="$HERMETIC_ROOT" WHERE_ARE_WE_STATE_DIR="$st" \
         WHERE_ARE_WE_BRANCH_OVERRIDE=main \
         HIMMEL_WHERE_ARE_WE=1 bash "$HOOK" </dev/null 2>/dev/null
-    exit 0
+    exit $?
 fi
 
 echo "== suite hermeticity (HIMMEL-2940) =="
@@ -96,13 +96,14 @@ echo "== suite hermeticity (HIMMEL-2940) =="
 # own preamble runs), not via the lean-leg case's own override further down.
 # Each recursion gets its own `mktemp -d` fixture dir, so the raw outputs
 # differ by that random path alone even with no leak — normalize it out
-# before comparing.
-leaked="$(HIMMEL_LEAN_LEG=1 bash "$0" --selftest-hermetic | sed -E 's#[^ ]*/selftest#SELFTEST_DIR#g')"
-clean="$(bash "$0" --selftest-hermetic | sed -E 's#[^ ]*/selftest#SELFTEST_DIR#g')"
-if [ "$leaked" = "$clean" ] && [ -n "$leaked" ]; then
+# before comparing. `pipefail` (set above) makes $? after the sed pipe
+# reflect the bash recursion's own exit status, not sed's.
+leaked="$(HIMMEL_LEAN_LEG=1 bash "$0" --selftest-hermetic | sed -E 's#[^ ]*/selftest#SELFTEST_DIR#g')"; leaked_rc=$?
+clean="$(bash "$0" --selftest-hermetic | sed -E 's#[^ ]*/selftest#SELFTEST_DIR#g')"; clean_rc=$?
+if [ "$leaked_rc" -eq 0 ] && [ "$clean_rc" -eq 0 ] && [ "$leaked" = "$clean" ] && [ -n "$leaked" ]; then
     pass "suite is hermetic to a lean-leg caller"
 else
-    fail "suite is hermetic to a lean-leg caller (leaked='$leaked' clean='$clean')"
+    fail "suite is hermetic to a lean-leg caller (leaked_rc=$leaked_rc clean_rc=$clean_rc leaked='$leaked' clean='$clean')"
 fi
 
 # --- Case 1: OFF → no output, exit 0 ----------------------------------------

--- a/scripts/hooks/test-inject-where-are-we.sh
+++ b/scripts/hooks/test-inject-where-are-we.sh
@@ -12,6 +12,12 @@
 # Exit: 0 = all cases pass, 1 = at least one failed.
 set -uo pipefail
 
+# The suite owns every case's env; an ambient leg shell (HIMMEL_LEAN_LEG=1
+# under --profile leg-impl, HIMMEL-2940) must not silently turn every
+# unmarked case into a lean-leg case. Only the two explicit lean cases below
+# set it themselves.
+unset LEG_LANE LEG_CONTEXT LEG_REPO LEG_EFFORT HEADED_ARM_LAUNCHER HEADED_ARM_LAUNCHER_ENV HEADED_ARM_RECORDER IMPL_GUARD_OK INLINE_IMPL_OK HIMMEL_CONSOLE_LEG HIMMEL_LEAN_LEG LEG_PROFILE LEG_PROFILE_SETTINGS LEG_PROFILE_PREFACE LEG_PROFILE_MCP_CONFIG 2>/dev/null || true
+
 # grepq <text> [grep-args...] — a `grep -q` test against <text> with NO
 # pipeline. printf/echo-into-`grep -q` is a trap under this file's
 # `set -o pipefail`: grep -q exits the instant it matches, the producer
@@ -71,6 +77,33 @@ seed_ledger() {
     mkdir -p "$dir"
     printf '%s\n' '{"ts":"2026-01-01T00:00:00Z","source":"jira","key":"HIMMEL-9","kind":"ticket","status":"in-progress"}' > "$dir/ledger.jsonl"
 }
+
+# --selftest-hermetic replays exactly one benign, non-silent (digest-route)
+# case and exits — used only by the guard case below, recursing into THIS
+# file once with a controlled ambient env, never the full numbered-case suite.
+if [ "${1:-}" = "--selftest-hermetic" ]; then
+    st="$TMP/selftest"; seed_ledger "$st"; touch "$st/.refreshed-at"
+    HIMMEL_REPO="$HERMETIC_ROOT" WHERE_ARE_WE_STATE_DIR="$st" \
+        WHERE_ARE_WE_BRANCH_OVERRIDE=main \
+        HIMMEL_WHERE_ARE_WE=1 bash "$HOOK" </dev/null 2>/dev/null
+    exit 0
+fi
+
+echo "== suite hermeticity (HIMMEL-2940) =="
+# A leg's ambient HIMMEL_LEAN_LEG=1 must not reach the hook invocation before
+# the preamble unset above has a chance to clear it — so this recurses with
+# that var set exactly the way a lean-leg caller sets it (before this file's
+# own preamble runs), not via the lean-leg case's own override further down.
+# Each recursion gets its own `mktemp -d` fixture dir, so the raw outputs
+# differ by that random path alone even with no leak — normalize it out
+# before comparing.
+leaked="$(HIMMEL_LEAN_LEG=1 bash "$0" --selftest-hermetic | sed -E 's#[^ ]*/selftest#SELFTEST_DIR#g')"
+clean="$(bash "$0" --selftest-hermetic | sed -E 's#[^ ]*/selftest#SELFTEST_DIR#g')"
+if [ "$leaked" = "$clean" ] && [ -n "$leaked" ]; then
+    pass "suite is hermetic to a lean-leg caller"
+else
+    fail "suite is hermetic to a lean-leg caller (leaked='$leaked' clean='$clean')"
+fi
 
 # --- Case 1: OFF → no output, exit 0 ----------------------------------------
 state1="$TMP/s1"; seed_ledger "$state1"

--- a/scripts/hooks/test-qmd-staleness-notice.sh
+++ b/scripts/hooks/test-qmd-staleness-notice.sh
@@ -124,7 +124,7 @@ run() {
 # with a controlled ambient env, never the full ~50-case suite.
 if [ "${1:-}" = "--selftest-hermetic" ]; then
     run 3 'GUARD-BANNER-SELFTEST'
-    exit 0
+    exit $?
 fi
 
 echo "== suite hermeticity (HIMMEL-2940) =="
@@ -132,12 +132,12 @@ echo "== suite hermeticity (HIMMEL-2940) =="
 # preamble unset above has a chance to clear it — so this recurses with that
 # var set exactly the way a lean-leg caller sets it (before this file's own
 # preamble runs), not via a case override.
-leaked="$(HIMMEL_LEAN_LEG=1 bash "$0" --selftest-hermetic)"
-clean="$(bash "$0" --selftest-hermetic)"
-if [ "$leaked" = "$clean" ] && [ -n "$leaked" ]; then
+leaked="$(HIMMEL_LEAN_LEG=1 bash "$0" --selftest-hermetic)"; leaked_rc=$?
+clean="$(bash "$0" --selftest-hermetic)"; clean_rc=$?
+if [ "$leaked_rc" -eq 0 ] && [ "$clean_rc" -eq 0 ] && [ "$leaked" = "$clean" ] && [ -n "$leaked" ]; then
     pass "suite is hermetic to a lean-leg caller"
 else
-    fail "suite is hermetic to a lean-leg caller (leaked='$leaked' clean='$clean')"
+    fail "suite is hermetic to a lean-leg caller (leaked_rc=$leaked_rc clean_rc=$clean_rc leaked='$leaked' clean='$clean')"
 fi
 
 echo "== silent paths (only these two) =="

--- a/scripts/hooks/test-qmd-staleness-notice.sh
+++ b/scripts/hooks/test-qmd-staleness-notice.sh
@@ -16,6 +16,12 @@
 # Exit codes: 0 all pass; 1 at least one fail.
 set -uo pipefail
 
+# The suite owns every case's env; an ambient leg shell (HIMMEL_LEAN_LEG=1
+# under --profile leg-impl, HIMMEL-2940) must not silently turn every
+# unmarked case into a lean-leg case. Only the two explicit lean cases below
+# set it themselves.
+unset LEG_LANE LEG_CONTEXT LEG_REPO LEG_EFFORT HEADED_ARM_LAUNCHER HEADED_ARM_LAUNCHER_ENV HEADED_ARM_RECORDER IMPL_GUARD_OK INLINE_IMPL_OK HIMMEL_CONSOLE_LEG HIMMEL_LEAN_LEG LEG_PROFILE LEG_PROFILE_SETTINGS LEG_PROFILE_PREFACE LEG_PROFILE_MCP_CONFIG 2>/dev/null || true
+
 HOOK="$(cd "$(dirname "$0")" && pwd)/qmd-staleness-notice.sh"
 
 FAILED=0
@@ -112,6 +118,27 @@ run() {
     env FAKE_RC="$rc" FAKE_SAY="$say" FAKE_ARGV_FILE="$ARGV_FILE" QMD_STALENESS_CACHE_TTL=0 "$@" \
         bash "$SANDBOX/hooks/qmd-staleness-notice.sh" </dev/null 2>/dev/null
 }
+
+# --selftest-hermetic replays exactly one benign, non-silent run() case and
+# exits — used only by the guard case below, recursing into THIS file once
+# with a controlled ambient env, never the full ~50-case suite.
+if [ "${1:-}" = "--selftest-hermetic" ]; then
+    run 3 'GUARD-BANNER-SELFTEST'
+    exit 0
+fi
+
+echo "== suite hermeticity (HIMMEL-2940) =="
+# A leg's ambient HIMMEL_LEAN_LEG=1 must not reach run()'s env call before the
+# preamble unset above has a chance to clear it — so this recurses with that
+# var set exactly the way a lean-leg caller sets it (before this file's own
+# preamble runs), not via a case override.
+leaked="$(HIMMEL_LEAN_LEG=1 bash "$0" --selftest-hermetic)"
+clean="$(bash "$0" --selftest-hermetic)"
+if [ "$leaked" = "$clean" ] && [ -n "$leaked" ]; then
+    pass "suite is hermetic to a lean-leg caller"
+else
+    fail "suite is hermetic to a lean-leg caller (leaked='$leaked' clean='$clean')"
+fi
 
 echo "== silent paths (only these two) =="
 # A healthy index prints NOTHING: every line a SessionStart hook emits is paid


### PR DESCRIPTION
## Summary

`test-qmd-staleness-notice.sh`, `test-graphify-freshness-advisory.sh` and
`test-inject-where-are-we.sh` forward whatever `HIMMEL_LEAN_LEG` (and sibling
`LEG_*` vars) the calling shell carries into every case that does not
explicitly override it. A leg launched via `--profile leg-impl` (HIMMEL-2830,
#642) carries `HIMMEL_LEAN_LEG=1` ambient, so every impl leg saw these three
suites red and had to hand-exclude them from any impacted-suite sweep. The
hooks' own lean-leg behaviour is correct and untouched — only the suites'
env hygiene changes.

Each suite now unsets the same `LEG_*` list `test-headed-arm-leg.sh` (#646)
already clears, at the top of its own preamble, and gains a new
**"suite is hermetic to a lean-leg caller"** case (first in file) that
recurses into the suite once with `HIMMEL_LEAN_LEG=1` ambient and once clean
via a `--selftest-hermetic` flag that replays exactly one benign case —
never the whole suite.

## RED (ambient `HIMMEL_LEAN_LEG=1`, own shell) vs control (`env -u HIMMEL_LEAN_LEG`)

| Suite | RED (ambient) | Control (`env -u`) |
|---|---|---|
| test-qmd-staleness-notice.sh | 49 FAIL / 81 cases | 0 FAIL / 81 |
| test-graphify-freshness-advisory.sh | 8 failed / 17 | 0 failed / 17 |
| test-inject-where-are-we.sh | FAILED=8 / 14 | FAILED=0 / 14 |

## GREEN (post-fix, +1 new hermeticity case per suite)

| Suite | Plain (ambient env) | `env -u HIMMEL_LEAN_LEG` |
|---|---|---|
| test-qmd-staleness-notice.sh | 82 PASS / 0 FAIL | 82 / 0 |
| test-graphify-freshness-advisory.sh | 18 passed / 0 failed | 18 / 0 |
| test-inject-where-are-we.sh | PASSED=15 / FAILED=0 | 15 / 0 |

Impacted-suite sweep (`git grep -l 'test-qmd-staleness-notice\|test-graphify-freshness-advisory\|test-inject-where-are-we' scripts/ docs/`): no other suite executes or depends on these three — only doc references (`docs/internals/enforcement.md`), a timing file (`scripts/ci/suite-durations.tsv`), and the hooks' own header comments naming their paired test file. Nothing else to run.

`shellcheck -x` rc=0 on all three touched files.

Diff: 3 files changed, 90 insertions(+), 0 deletions — no case rewrites, no logic beyond the preamble + one new guard case per suite.

## Out of scope (by design)

- The hooks themselves (`qmd-staleness-notice.sh`, `graphify-freshness-advisory.sh`, `inject-where-are-we.sh`) — their lean-leg silence is correct (HIMMEL-2830/#642).
- The two pre-existing explicit lean-leg cases per suite — untouched, still pass.
- `test-headed-arm-leg.sh` — already fixed in #646.

## Test plan

- [x] RED measured on ambient env before the fix (table above)
- [x] Control measured with `env -u HIMMEL_LEAN_LEG` before the fix (table above)
- [x] GREEN measured after the fix, both ambient and `env -u` (table above)
- [x] New hermeticity guard case added first-in-file per suite
- [x] `shellcheck -x` clean on all touched files
- [x] Impacted-suite sweep run, nothing further found

🤖 Generated with [Claude Code](https://claude.com/claude-code)
