### PR TITLE
fix(hooks): [HIMMEL-2939] close let/declare/read/printf-v seam-clearing bypasses in chokepoint-env-prefix

### DIFF
--- a/scripts/hooks/block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/block-chokepoint-env-prefix.sh
@@ -831,7 +831,11 @@ scan_segment() {
     # tracking (fail-closed, same direction as the assignment fold above).
     if [[ $seg == *'$['* ]]; then
         bracket_rest="$seg"
-        while [[ $bracket_rest =~ ([A-Za-z_][A-Za-z0-9_]*)= ]]; do
+        # HIMMEL-2939 CR round (codex-1): a bare `NAME=` regex missed legacy
+        # arithmetic's compound-assignment operators (`$[NAME*=0]`,
+        # `$[NAME+=0]`, ...) -- the char run between the identifier and `=`
+        # is now optional, not absent, matching every `let` operator form.
+        while [[ $bracket_rest =~ ([A-Za-z_][A-Za-z0-9_]*)[-+*/%^\<\>\&|]{0,2}= ]]; do
             UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[1]}"
             bracket_rest="${bracket_rest#*"${BASH_REMATCH[0]}"}"
         done
@@ -1073,13 +1077,24 @@ scan_segment() {
             let|declare|typeset|readonly)
                 # HIMMEL-2939: same fail-closed simplification as `unset`/
                 # `export` above -- every remaining word that does not start
-                # with `-`, `=`-suffix stripped, is a candidate name, full
-                # stop (declare -p NAME denies too, a documented over-deny).
+                # with `-` names a candidate: take the LEADING identifier only
+                # (declare -p NAME denies too, a documented over-deny). A
+                # trailing `%%=*` strip is not enough here -- `let` accepts
+                # compound arithmetic assignment (`NAME*=0`, `NAME+=0`, ...),
+                # none of which contain a bare `=` right after the name, so
+                # stripping from the first `=` left the operator glued onto
+                # the name and missed the registered var (CR round on
+                # HIMMEL-2939: codex-1). Matching the identifier PREFIX
+                # instead is correct for every remaining shape too.
                 k=$((j + 1))
                 while [ "$k" -lt "$nw" ]; do
                     case "${W[$k]}" in
                     -*) ;;
-                    *) UNSET_NAMES="$UNSET_NAMES ${W[$k]%%=*}" ;;
+                    *)
+                        if [[ "${W[$k]}" =~ ^([A-Za-z_][A-Za-z0-9_]*) ]]; then
+                            UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[1]}"
+                        fi
+                        ;;
                     esac
                     k=$((k + 1))
                 done

--- a/scripts/hooks/block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/block-chokepoint-env-prefix.sh
@@ -147,6 +147,25 @@
 # inspection -- `export SEAM=1` denies too, a documented arming-direction
 # over-deny).
 #
+# HIMMEL-2939 (the fourth clearing shape): `let`/`declare`/`typeset`/
+# `readonly` all assign in the CURRENT shell exactly like a plain assignment
+# word (HIMMEL-2933) does, `printf -v NAME` and `read NAME` write a shell
+# variable the same way, and the legacy `$[NAME=0]` arithmetic construct
+# assigns too, all with no `unset`/`export -n`/`env -u`/plain assignment in
+# sight. Same fail-closed posture, resolved against the SAME registered-name
+# set: for `let`/`declare`/`typeset`/`readonly`/`read`, every remaining word
+# that does not start with `-`, `=`-suffix stripped, is a candidate name
+# (declare -p NAME denies too -- documented over-deny, no option-validity
+# model); for `printf`, only `-v`'s operand (attached `-vNAME` or the next
+# word) is a candidate -- printf's other arguments are format/data, not
+# names. All fold into UNSET_NAMES for later segments exactly like `unset`
+# does. `$[...]` is not a segmentation boundary (unlike `$(`/backtick) --
+# a segment containing the literal `$[` anywhere has every `NAME=` word in
+# it folded into UNSET_NAMES too, no bracket-depth tracking, same fail-closed
+# direction. `local` is function-scoped and cannot precede a top-level
+# chokepoint, so it is not modelled; `mapfile`/`readarray` target arrays,
+# never a scalar seam, so they are not modelled either.
+#
 # The round-2 '(' carve-out is CLOSED: an unquoted '(' / ')' / backtick
 # (and `$(` / backtick inside double quotes) opens a fresh command
 # position via segmentation, so subshell, $(...), and backtick-wrapped
@@ -803,7 +822,20 @@ scan_segment() {
     local phase="${4:-start}"
     local env_endopts=0 lo_out lo_verdict lo_operand
     local cluster_out cluster_verdict cluster_operand
+    local bracket_rest
     names="$inames"
+    # HIMMEL-2939: `$[NAME=0]` (legacy arithmetic expansion) is not a
+    # segmentation boundary the way `$(`/backtick are, so it never opens a
+    # fresh command position to scan on its own -- fold every `NAME=` word
+    # found anywhere in a segment carrying the literal `$[`, no bracket-depth
+    # tracking (fail-closed, same direction as the assignment fold above).
+    if [[ $seg == *'$['* ]]; then
+        bracket_rest="$seg"
+        while [[ $bracket_rest =~ ([A-Za-z_][A-Za-z0-9_]*)= ]]; do
+            UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[1]}"
+            bracket_rest="${bracket_rest#*"${BASH_REMATCH[0]}"}"
+        done
+    fi
     # ':'-sentinel stream (r6): a blank line is a stream artifact (no
     # word); the line ':' is a zero-length word and MUST take its slot in
     # W -- real getopt consumes it as an operand (env -a '' SEAM=1 cmd
@@ -1038,6 +1070,54 @@ scan_segment() {
                 done
                 return 0
                 ;;
+            let|declare|typeset|readonly)
+                # HIMMEL-2939: same fail-closed simplification as `unset`/
+                # `export` above -- every remaining word that does not start
+                # with `-`, `=`-suffix stripped, is a candidate name, full
+                # stop (declare -p NAME denies too, a documented over-deny).
+                k=$((j + 1))
+                while [ "$k" -lt "$nw" ]; do
+                    case "${W[$k]}" in
+                    -*) ;;
+                    *) UNSET_NAMES="$UNSET_NAMES ${W[$k]%%=*}" ;;
+                    esac
+                    k=$((k + 1))
+                done
+                return 0 ;;
+            read)
+                # HIMMEL-2939: `read NAME [NAME2 ...]` assigns every operand
+                # name -- same fail-closed word scan (a `-p`/`-d` option's
+                # OWN operand is folded too, documented over-deny, no
+                # option-argument modelling).
+                k=$((j + 1))
+                while [ "$k" -lt "$nw" ]; do
+                    case "${W[$k]}" in
+                    -*) ;;
+                    *) UNSET_NAMES="$UNSET_NAMES ${W[$k]%%=*}" ;;
+                    esac
+                    k=$((k + 1))
+                done
+                return 0 ;;
+            printf)
+                # HIMMEL-2939: unlike unset/export/read, printf's other
+                # words are a format string and data, not names -- only
+                # `-v`'s operand (attached or the next word) is a candidate.
+                k=$((j + 1))
+                while [ "$k" -lt "$nw" ]; do
+                    case "${W[$k]}" in
+                    -v)
+                        if [ $((k + 1)) -lt "$nw" ]; then
+                            UNSET_NAMES="$UNSET_NAMES ${W[$((k + 1))]%%=*}"
+                        fi
+                        k=$((k + 2)); continue ;;
+                    -v?*)
+                        UNSET_NAMES="$UNSET_NAMES ${W[$k]#-v}"
+                        k=$((k + 1)); continue ;;
+                    -*) k=$((k + 1)); continue ;;
+                    *) break ;;
+                    esac
+                done
+                return 0 ;;
             esac
             # The invoked-program token of this segment. Words beyond it
             # are arguments and never match (the finding-4 direction).

--- a/scripts/hooks/block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/block-chokepoint-env-prefix.sh
@@ -822,7 +822,7 @@ scan_segment() {
     local phase="${4:-start}"
     local env_endopts=0 lo_out lo_verdict lo_operand
     local cluster_out cluster_verdict cluster_operand
-    local bracket_rest
+    local bracket_rest wrest
     names="$inames"
     # HIMMEL-2939: `$[NAME=0]` (legacy arithmetic expansion) is not a
     # segmentation boundary the way `$(`/backtick are, so it never opens a
@@ -836,6 +836,21 @@ scan_segment() {
         # `$[NAME+=0]`, ...) -- the char run between the identifier and `=`
         # is now optional, not absent, matching every `let` operator form.
         while [[ $bracket_rest =~ ([A-Za-z_][A-Za-z0-9_]*)[-+*/%^\<\>\&|]{0,2}= ]]; do
+            UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[1]}"
+            bracket_rest="${bracket_rest#*"${BASH_REMATCH[0]}"}"
+        done
+        # HIMMEL-2939 CR round (codex-2): `++`/`--` prefix or postfix in a
+        # legacy `$[...]` arithmetic expansion WRITES the operand without
+        # ever producing a bare `=` -- `$[--HIMMEL_CONSOLE_LEG]` cleared the
+        # seam and the `=`-anchored fold above never saw it. Fold both
+        # orders as separate passes over the whole segment.
+        bracket_rest="$seg"
+        while [[ $bracket_rest =~ (\+\+|--)([A-Za-z_][A-Za-z0-9_]*) ]]; do
+            UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[2]}"
+            bracket_rest="${bracket_rest#*"${BASH_REMATCH[0]}"}"
+        done
+        bracket_rest="$seg"
+        while [[ $bracket_rest =~ ([A-Za-z_][A-Za-z0-9_]*)(\+\+|--) ]]; do
             UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[1]}"
             bracket_rest="${bracket_rest#*"${BASH_REMATCH[0]}"}"
         done
@@ -1077,15 +1092,20 @@ scan_segment() {
             let|declare|typeset|readonly)
                 # HIMMEL-2939: same fail-closed simplification as `unset`/
                 # `export` above -- every remaining word that does not start
-                # with `-` names a candidate: take the LEADING identifier only
-                # (declare -p NAME denies too, a documented over-deny). A
-                # trailing `%%=*` strip is not enough here -- `let` accepts
-                # compound arithmetic assignment (`NAME*=0`, `NAME+=0`, ...),
-                # none of which contain a bare `=` right after the name, so
-                # stripping from the first `=` left the operator glued onto
-                # the name and missed the registered var (CR round on
-                # HIMMEL-2939: codex-1). Matching the identifier PREFIX
-                # instead is correct for every remaining shape too.
+                # with `-` names a candidate: take the LEADING identifier
+                # (declare -p NAME denies too, a documented over-deny) as the
+                # baseline candidate, matching every remaining shape without
+                # inspecting `=`. Two more scans handle shapes the
+                # leading-only match cannot reach (CR round on HIMMEL-2939,
+                # codex-1/codex-2): a single `let` operand can comma-join
+                # multiple arithmetic assignments
+                # (`let 'x=0,HIMMEL_CONSOLE_LEG=0'` -- everything after the
+                # first comma is invisible to a leading-only match), and a
+                # PREFIX `++`/`--` (`let '++HIMMEL_CONSOLE_LEG'`) starts with
+                # the operator, not the identifier, so the leading-only match
+                # cannot see it either (a postfix form like `NAME++` is
+                # already covered, since the identifier IS the leading
+                # token there).
                 k=$((j + 1))
                 while [ "$k" -lt "$nw" ]; do
                     case "${W[$k]}" in
@@ -1094,6 +1114,16 @@ scan_segment() {
                         if [[ "${W[$k]}" =~ ^([A-Za-z_][A-Za-z0-9_]*) ]]; then
                             UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[1]}"
                         fi
+                        wrest="${W[$k]}"
+                        while [[ $wrest =~ ([A-Za-z_][A-Za-z0-9_]*)[-+*/%^\<\>\&|]{0,2}= ]]; do
+                            UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[1]}"
+                            wrest="${wrest#*"${BASH_REMATCH[0]}"}"
+                        done
+                        wrest="${W[$k]}"
+                        while [[ $wrest =~ (\+\+|--)([A-Za-z_][A-Za-z0-9_]*) ]]; do
+                            UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[2]}"
+                            wrest="${wrest#*"${BASH_REMATCH[0]}"}"
+                        done
                         ;;
                     esac
                     k=$((k + 1))

--- a/scripts/hooks/block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/block-chokepoint-env-prefix.sh
@@ -822,37 +822,31 @@ scan_segment() {
     local phase="${4:-start}"
     local env_endopts=0 lo_out lo_verdict lo_operand
     local cluster_out cluster_verdict cluster_operand
-    local bracket_rest wrest
+    local n
     names="$inames"
-    # HIMMEL-2939: `$[NAME=0]` (legacy arithmetic expansion) is not a
-    # segmentation boundary the way `$(`/backtick are, so it never opens a
-    # fresh command position to scan on its own -- fold every `NAME=` word
-    # found anywhere in a segment carrying the literal `$[`, no bracket-depth
-    # tracking (fail-closed, same direction as the assignment fold above).
+    # HIMMEL-2939 (collapse, CR round 4 -- console ruling on the pattern
+    # that parked HIMMEL-2929 and ended #635 at round 5): `$[NAME=0]`
+    # (legacy arithmetic expansion) is not a segmentation boundary the way
+    # `$(`/backtick are, so it never opens a fresh command position of its
+    # own. Three straight rounds each found the next arithmetic-operator
+    # shape a validity model missed (bare `=`, compound `*=`/`+=`, prefix
+    # AND postfix `++`/`--`) -- there is always one more operator. STOP
+    # parsing `$[...]`'s grammar: any registered seam var (across every
+    # chokepoint, not just the one this payload happens to target --
+    # ALL_SEAM_VARS, computed once from the registry) occurring anywhere
+    # in a segment carrying the literal `$[`, WORD-BOUNDED (the char
+    # before/after is not `[A-Za-z0-9_]`, so a longer name sharing the
+    # registered name's PREFIX does not match), folds forward -- no
+    # bracket-depth tracking, no operator inspection at all. Documented
+    # over-deny: `$[HIMMEL_CONSOLE_LEG+1]` (reads the seam, does not clear
+    # it) denies too -- costs nothing; a false ALLOW is the defect class
+    # this ticket exists for.
     if [[ $seg == *'$['* ]]; then
-        bracket_rest="$seg"
-        # HIMMEL-2939 CR round (codex-1): a bare `NAME=` regex missed legacy
-        # arithmetic's compound-assignment operators (`$[NAME*=0]`,
-        # `$[NAME+=0]`, ...) -- the char run between the identifier and `=`
-        # is now optional, not absent, matching every `let` operator form.
-        while [[ $bracket_rest =~ ([A-Za-z_][A-Za-z0-9_]*)[-+*/%^\<\>\&|]{0,2}= ]]; do
-            UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[1]}"
-            bracket_rest="${bracket_rest#*"${BASH_REMATCH[0]}"}"
-        done
-        # HIMMEL-2939 CR round (codex-2): `++`/`--` prefix or postfix in a
-        # legacy `$[...]` arithmetic expansion WRITES the operand without
-        # ever producing a bare `=` -- `$[--HIMMEL_CONSOLE_LEG]` cleared the
-        # seam and the `=`-anchored fold above never saw it. Fold both
-        # orders as separate passes over the whole segment.
-        bracket_rest="$seg"
-        while [[ $bracket_rest =~ (\+\+|--)([A-Za-z_][A-Za-z0-9_]*) ]]; do
-            UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[2]}"
-            bracket_rest="${bracket_rest#*"${BASH_REMATCH[0]}"}"
-        done
-        bracket_rest="$seg"
-        while [[ $bracket_rest =~ ([A-Za-z_][A-Za-z0-9_]*)(\+\+|--) ]]; do
-            UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[1]}"
-            bracket_rest="${bracket_rest#*"${BASH_REMATCH[0]}"}"
+        for n in $ALL_SEAM_VARS; do
+            [ -n "$n" ] || continue
+            if [[ $seg =~ (^|[^A-Za-z0-9_])"$n"($|[^A-Za-z0-9_]) ]]; then
+                UNSET_NAMES="$UNSET_NAMES $n"
+            fi
         done
     fi
     # ':'-sentinel stream (r6): a blank line is a stream artifact (no
@@ -1090,39 +1084,34 @@ scan_segment() {
                 return 0
                 ;;
             let|declare|typeset|readonly)
-                # HIMMEL-2939: same fail-closed simplification as `unset`/
-                # `export` above -- every remaining word that does not start
-                # with `-` names a candidate: take the LEADING identifier
-                # (declare -p NAME denies too, a documented over-deny) as the
-                # baseline candidate, matching every remaining shape without
-                # inspecting `=`. Two more scans handle shapes the
-                # leading-only match cannot reach (CR round on HIMMEL-2939,
-                # codex-1/codex-2): a single `let` operand can comma-join
-                # multiple arithmetic assignments
-                # (`let 'x=0,HIMMEL_CONSOLE_LEG=0'` -- everything after the
-                # first comma is invisible to a leading-only match), and a
-                # PREFIX `++`/`--` (`let '++HIMMEL_CONSOLE_LEG'`) starts with
-                # the operator, not the identifier, so the leading-only match
-                # cannot see it either (a postfix form like `NAME++` is
-                # already covered, since the identifier IS the leading
-                # token there).
+                # HIMMEL-2939 (collapse, CR round 4 -- console ruling, same
+                # shape as #635 round 5 and the HIMMEL-2929 park): three
+                # straight rounds each found the next `let` operator shape a
+                # validity model missed (bare `=`, compound `*=`/`+=`,
+                # comma-joined `,NAME=`, prefix `++`, postfix AFTER a comma)
+                # -- modelling this grammar never terminates, there is
+                # always one more operator. STOP: do not parse `=`, commas,
+                # `++`/`--` or leading identifiers at all. Any registered
+                # seam var (across every chokepoint -- ALL_SEAM_VARS,
+                # computed once from the registry) occurring anywhere in a
+                # remaining non-option word, WORD-BOUNDED (the char
+                # before/after is not `[A-Za-z0-9_]`, so a longer name
+                # sharing the registered name's PREFIX does not match),
+                # folds forward regardless of assignment shape (`declare -p
+                # NAME` denies too, a documented over-deny). Documented
+                # over-deny: `let x=HIMMEL_CONSOLE_LEG+1` (reads the seam,
+                # does not clear it) denies too -- costs nothing; a false
+                # ALLOW is the defect class this ticket exists for.
                 k=$((j + 1))
                 while [ "$k" -lt "$nw" ]; do
                     case "${W[$k]}" in
                     -*) ;;
                     *)
-                        if [[ "${W[$k]}" =~ ^([A-Za-z_][A-Za-z0-9_]*) ]]; then
-                            UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[1]}"
-                        fi
-                        wrest="${W[$k]}"
-                        while [[ $wrest =~ ([A-Za-z_][A-Za-z0-9_]*)[-+*/%^\<\>\&|]{0,2}= ]]; do
-                            UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[1]}"
-                            wrest="${wrest#*"${BASH_REMATCH[0]}"}"
-                        done
-                        wrest="${W[$k]}"
-                        while [[ $wrest =~ (\+\+|--)([A-Za-z_][A-Za-z0-9_]*) ]]; do
-                            UNSET_NAMES="$UNSET_NAMES ${BASH_REMATCH[2]}"
-                            wrest="${wrest#*"${BASH_REMATCH[0]}"}"
+                        for n in $ALL_SEAM_VARS; do
+                            [ -n "$n" ] || continue
+                            if [[ "${W[$k]}" =~ (^|[^A-Za-z0-9_])"$n"($|[^A-Za-z0-9_]) ]]; then
+                                UNSET_NAMES="$UNSET_NAMES $n"
+                            fi
                         done
                         ;;
                     esac
@@ -1130,33 +1119,60 @@ scan_segment() {
                 done
                 return 0 ;;
             read)
-                # HIMMEL-2939: `read NAME [NAME2 ...]` assigns every operand
-                # name -- same fail-closed word scan (a `-p`/`-d` option's
-                # OWN operand is folded too, documented over-deny, no
-                # option-argument modelling).
+                # HIMMEL-2939 (collapse, CR round 4 continued -- console
+                # ruling): `read NAME [NAME2 ...]` assigns every operand
+                # name, but an operand can also be an ARRAY-ELEMENT form
+                # (`NAME[0]`) -- whole-word capture folded the literal
+                # "NAME[0]" text, which never exact-matched the registered
+                # "NAME" in check_invocation. Same fix as `let`/`declare`/
+                # `$[...]`: word-bounded substring match against
+                # ALL_SEAM_VARS instead of capturing the whole word (a
+                # `-p`/`-d` option's OWN operand is scanned too, documented
+                # over-deny, no option-argument modelling).
                 k=$((j + 1))
                 while [ "$k" -lt "$nw" ]; do
                     case "${W[$k]}" in
                     -*) ;;
-                    *) UNSET_NAMES="$UNSET_NAMES ${W[$k]%%=*}" ;;
+                    *)
+                        for n in $ALL_SEAM_VARS; do
+                            [ -n "$n" ] || continue
+                            if [[ "${W[$k]}" =~ (^|[^A-Za-z0-9_])"$n"($|[^A-Za-z0-9_]) ]]; then
+                                UNSET_NAMES="$UNSET_NAMES $n"
+                            fi
+                        done
+                        ;;
                     esac
                     k=$((k + 1))
                 done
                 return 0 ;;
             printf)
-                # HIMMEL-2939: unlike unset/export/read, printf's other
-                # words are a format string and data, not names -- only
-                # `-v`'s operand (attached or the next word) is a candidate.
+                # HIMMEL-2939 (collapse, CR round 4 continued -- console
+                # ruling): unlike unset/export/read, printf's other words are
+                # a format string and data, not names -- only `-v`'s operand
+                # (attached or the next word) is a candidate, but that
+                # operand can also be an array-element form (`NAME[0]`) --
+                # same word-bounded substring match against ALL_SEAM_VARS as
+                # the `read` arm, instead of capturing the whole word.
                 k=$((j + 1))
                 while [ "$k" -lt "$nw" ]; do
                     case "${W[$k]}" in
                     -v)
                         if [ $((k + 1)) -lt "$nw" ]; then
-                            UNSET_NAMES="$UNSET_NAMES ${W[$((k + 1))]%%=*}"
+                            for n in $ALL_SEAM_VARS; do
+                                [ -n "$n" ] || continue
+                                if [[ "${W[$((k + 1))]}" =~ (^|[^A-Za-z0-9_])"$n"($|[^A-Za-z0-9_]) ]]; then
+                                    UNSET_NAMES="$UNSET_NAMES $n"
+                                fi
+                            done
                         fi
                         k=$((k + 2)); continue ;;
                     -v?*)
-                        UNSET_NAMES="$UNSET_NAMES ${W[$k]#-v}"
+                        for n in $ALL_SEAM_VARS; do
+                            [ -n "$n" ] || continue
+                            if [[ "${W[$k]#-v}" =~ (^|[^A-Za-z0-9_])"$n"($|[^A-Za-z0-9_]) ]]; then
+                                UNSET_NAMES="$UNSET_NAMES $n"
+                            fi
+                        done
                         k=$((k + 1)); continue ;;
                     -*) k=$((k + 1)); continue ;;
                     *) break ;;
@@ -1207,6 +1223,17 @@ scan_text() {
 # its only consumer. An empty/unreadable registry allows (fail-open).
 REG_LINES=$(jq -r 'to_entries[] | "\(.key)\t\((.value.seam_env_vars // []) | join(" "))"' "$REGISTRY" 2>/dev/null) || REG_LINES=''
 [ -n "$REG_LINES" ] || exit 0
+
+# HIMMEL-2939 (collapse, CR round 4): every seam var name across every
+# chokepoint, flattened once -- scan_segment's `let`/`declare`/`$[...]`
+# folds check membership against THIS (the registry's own var set), never
+# against `$names` (the per-segment accumulator check_invocation reads,
+# not a source of truth for "is this name registered anywhere").
+ALL_SEAM_VARS=''
+while IFS=$'\t' read -r _reg_path _reg_vars; do
+    _reg_vars=${_reg_vars%"$CR"}
+    ALL_SEAM_VARS="$ALL_SEAM_VARS $_reg_vars"
+done <<<"$REG_LINES"
 
 scan_text "$cmd_flat" "" 0
 

--- a/scripts/hooks/block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/block-chokepoint-env-prefix.sh
@@ -1094,27 +1094,34 @@ scan_segment() {
                 # `++`/`--` or leading identifiers at all. Any registered
                 # seam var (across every chokepoint -- ALL_SEAM_VARS,
                 # computed once from the registry) occurring anywhere in a
-                # remaining non-option word, WORD-BOUNDED (the char
-                # before/after is not `[A-Za-z0-9_]`, so a longer name
-                # sharing the registered name's PREFIX does not match),
-                # folds forward regardless of assignment shape (`declare -p
-                # NAME` denies too, a documented over-deny). Documented
-                # over-deny: `let x=HIMMEL_CONSOLE_LEG+1` (reads the seam,
-                # does not clear it) denies too -- costs nothing; a false
-                # ALLOW is the defect class this ticket exists for.
+                # remaining word, WORD-BOUNDED (the char before/after is not
+                # `[A-Za-z0-9_]`, so a longer name sharing the registered
+                # name's PREFIX does not match), folds forward regardless of
+                # assignment shape (`declare -p NAME` denies too, a
+                # documented over-deny). Documented over-deny: `let
+                # x=HIMMEL_CONSOLE_LEG+1` (reads the seam, does not clear
+                # it) denies too -- costs nothing; a false ALLOW is the
+                # defect class this ticket exists for.
+                #
+                # CR round 5 (console ruling): round 4 still skipped every
+                # dash-prefixed word (`-*) ;;`) as if it were an option --
+                # that skip IS grammar modelling in disguise. `let`
+                # evaluates each operand as arithmetic, where a LEADING `--`
+                # after the `--` option-terminator is the prefix-decrement
+                # operator, not a flag: `let -- '--HIMMEL_CONSOLE_LEG'`
+                # genuinely decrements the seam (verified live) and the
+                # dash-skip hid it from the scan. Deleted: every remaining
+                # word, dash-prefixed or not, goes through the word-bounded
+                # scan unconditionally -- `-` is outside `[A-Za-z0-9_]`, so
+                # the word-boundary match already handles it correctly.
                 k=$((j + 1))
                 while [ "$k" -lt "$nw" ]; do
-                    case "${W[$k]}" in
-                    -*) ;;
-                    *)
-                        for n in $ALL_SEAM_VARS; do
-                            [ -n "$n" ] || continue
-                            if [[ "${W[$k]}" =~ (^|[^A-Za-z0-9_])"$n"($|[^A-Za-z0-9_]) ]]; then
-                                UNSET_NAMES="$UNSET_NAMES $n"
-                            fi
-                        done
-                        ;;
-                    esac
+                    for n in $ALL_SEAM_VARS; do
+                        [ -n "$n" ] || continue
+                        if [[ "${W[$k]}" =~ (^|[^A-Za-z0-9_])"$n"($|[^A-Za-z0-9_]) ]]; then
+                            UNSET_NAMES="$UNSET_NAMES $n"
+                        fi
+                    done
                     k=$((k + 1))
                 done
                 return 0 ;;
@@ -1129,19 +1136,19 @@ scan_segment() {
                 # ALL_SEAM_VARS instead of capturing the whole word (a
                 # `-p`/`-d` option's OWN operand is scanned too, documented
                 # over-deny, no option-argument modelling).
+                #
+                # CR round 5 (console ruling): same `-*) ;;` deletion as the
+                # `let` arm above, for consistency -- no option-shape
+                # modelling anywhere in this collapse, every remaining word
+                # goes through the scan unconditionally.
                 k=$((j + 1))
                 while [ "$k" -lt "$nw" ]; do
-                    case "${W[$k]}" in
-                    -*) ;;
-                    *)
-                        for n in $ALL_SEAM_VARS; do
-                            [ -n "$n" ] || continue
-                            if [[ "${W[$k]}" =~ (^|[^A-Za-z0-9_])"$n"($|[^A-Za-z0-9_]) ]]; then
-                                UNSET_NAMES="$UNSET_NAMES $n"
-                            fi
-                        done
-                        ;;
-                    esac
+                    for n in $ALL_SEAM_VARS; do
+                        [ -n "$n" ] || continue
+                        if [[ "${W[$k]}" =~ (^|[^A-Za-z0-9_])"$n"($|[^A-Za-z0-9_]) ]]; then
+                            UNSET_NAMES="$UNSET_NAMES $n"
+                        fi
+                    done
                     k=$((k + 1))
                 done
                 return 0 ;;

--- a/scripts/hooks/test-block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/test-block-chokepoint-env-prefix.sh
@@ -221,6 +221,15 @@ assert_deny "\$((NAME=0)) control (pre-existing, via the \$( carve-out)" "$(j "\
 # Over-match control: unaffected.
 assert_allow "let x=1 (no seam) stays allowed"                   "$(j "let x=1; bash $MERGE_ON_GREEN 1")"
 
+# --- HIMMEL-2939 CR round (codex-1): compound arithmetic-assignment
+# operators glued onto the name (`let NAME*=0`) escaped both the `%%=*`
+# suffix-strip (left `NAME*` as the folded name, which never matches the
+# registered `NAME`) and the `$[...]` bracket regex's bare `NAME=` match
+# (no `=` immediately follows the identifier). Fixed by matching the
+# LEADING identifier instead of stripping from the first `=`. ---
+assert_deny "let NAME*=0 (compound arithmetic op) assigns the seam"        "$(j "let HIMMEL_CONSOLE_LEG*=0; bash $MERGE_ON_GREEN 1")"
+assert_deny "legacy \$[NAME*=0] (compound arithmetic op) assigns the seam" "$(j "echo \$[HIMMEL_CONSOLE_LEG*=0]; bash $MERGE_ON_GREEN 1")"
+
 # --- CR ROUND 1 (HIMMEL-1746): the env-prefix must bind to the chokepoint's
 # OWN command segment. The pre-fix predicate tested "path found anywhere"
 # AND "assignment found anywhere" over the whole compound, which false-denied

--- a/scripts/hooks/test-block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/test-block-chokepoint-env-prefix.sh
@@ -243,6 +243,36 @@ assert_deny "let postfix NAME-- assigns the seam"                   "$(j "let 'H
 assert_deny "legacy \$[--NAME] (prefix decrement) assigns the seam" "$(j "echo \$[--HIMMEL_CONSOLE_LEG]; bash $MERGE_ON_GREEN 1")"
 assert_deny "legacy \$[NAME++] (postfix increment) assigns the seam" "$(j "echo \$[HIMMEL_CONSOLE_LEG++]; bash $MERGE_ON_GREEN 1")"
 
+# --- HIMMEL-2939 CR round 4 (collapse, console ruling): three straight
+# rounds each found the next `let` arithmetic-operator shape (bare `=`,
+# compound `*=`, comma-join, prefix `++`, now postfix AFTER a comma) a
+# validity model missed -- codex-1 this round: `let 'x=0,NAME--'` still
+# escaped because the comma-joined scan only matched `=` or prefix
+# `++`/`--`, not postfix after a comma. Ruling: stop parsing `let`
+# grammar entirely -- any registered seam name occurring anywhere in a
+# remaining word, WORD-BOUNDED (the char before/after is not
+# [A-Za-z0-9_]), folds forward regardless of assignment shape. Documented
+# over-deny: reading the seam without clearing it denies too -- costs
+# nothing, and a false ALLOW is the defect class this ticket exists for.
+# The word-boundary control (a longer name sharing the registered name's
+# PREFIX) stays ALLOW. ---
+assert_deny "let comma-joined THEN postfix (NAME-- after comma) assigns the seam" "$(j "let 'x=0,HIMMEL_CONSOLE_LEG--'; bash $MERGE_ON_GREEN 1")"
+assert_deny "let x=NAME+1 (reads, does not clear -- documented over-deny)" "$(j "let 'x=HIMMEL_CONSOLE_LEG+1'; bash $MERGE_ON_GREEN 1")"
+assert_allow "let NAME_LONGER=0 (word boundary -- shares the registered name's PREFIX, not equal)" "$(j "let HIMMEL_CONSOLE_LEGACY=0; bash $MERGE_ON_GREEN 1")"
+
+# --- HIMMEL-2939 (collapse, round 4 continued -- console ruling named
+# `printf -v` and `read` for the SAME treatment as `let`/`declare`/`$[...]`):
+# both builtins also accept an ARRAY-ELEMENT operand (`NAME[0]`), which bash
+# assigns into NAME exactly like a bare `NAME` operand -- but the pre-collapse
+# code captured the whole word (`${W[$k]%%=*}`) as the candidate, so
+# `HIMMEL_CONSOLE_LEG[0]` was folded as the literal 8-byte-longer name
+# "HIMMEL_CONSOLE_LEG[0]", which never exact-matches the registered
+# "HIMMEL_CONSOLE_LEG" in check_invocation. Same fix: word-bounded substring
+# match against ALL_SEAM_VARS instead of whole-word capture. ---
+assert_deny "read NAME[0] (array-element assignment) assigns the seam"        "$(j "read HIMMEL_CONSOLE_LEG[0] <<< 0; bash $MERGE_ON_GREEN 1")"
+assert_deny "printf -v NAME[0] (array-element assignment) writes the seam"    "$(j "printf -v HIMMEL_CONSOLE_LEG[0] 0; bash $MERGE_ON_GREEN 1")"
+assert_allow "read NAME_LONGER (word boundary -- shares the PREFIX, not equal)" "$(j "read HIMMEL_CONSOLE_LEGACY <<< 0; bash $MERGE_ON_GREEN 1")"
+
 # --- CR ROUND 1 (HIMMEL-1746): the env-prefix must bind to the chokepoint's
 # OWN command segment. The pre-fix predicate tested "path found anywhere"
 # AND "assignment found anywhere" over the whole compound, which false-denied

--- a/scripts/hooks/test-block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/test-block-chokepoint-env-prefix.sh
@@ -230,6 +230,19 @@ assert_allow "let x=1 (no seam) stays allowed"                   "$(j "let x=1; 
 assert_deny "let NAME*=0 (compound arithmetic op) assigns the seam"        "$(j "let HIMMEL_CONSOLE_LEG*=0; bash $MERGE_ON_GREEN 1")"
 assert_deny "legacy \$[NAME*=0] (compound arithmetic op) assigns the seam" "$(j "echo \$[HIMMEL_CONSOLE_LEG*=0]; bash $MERGE_ON_GREEN 1")"
 
+# --- HIMMEL-2939 CR round 2 (codex-1): a single `let` operand can comma-join
+# multiple arithmetic assignments -- everything after the first comma was
+# invisible to the leading-identifier-only match (codex-1). (codex-2):
+# `++`/`--` prefix or postfix WRITES the operand without ever producing a
+# bare `=`, so the `=`-anchored `let`/`declare` leading match and the
+# `$[...]` bracket-fold both missed it. Fixed by adding comma-joined and
+# prefix/postfix inc/dec fold passes at both sites. ---
+assert_deny "let comma-joined assignment (NAME after comma) assigns the seam" "$(j "let 'x=0,HIMMEL_CONSOLE_LEG=0'; bash $MERGE_ON_GREEN 1")"
+assert_deny "let prefix ++NAME assigns the seam"                    "$(j "let '++HIMMEL_CONSOLE_LEG'; bash $MERGE_ON_GREEN 1")"
+assert_deny "let postfix NAME-- assigns the seam"                   "$(j "let 'HIMMEL_CONSOLE_LEG--'; bash $MERGE_ON_GREEN 1")"
+assert_deny "legacy \$[--NAME] (prefix decrement) assigns the seam" "$(j "echo \$[--HIMMEL_CONSOLE_LEG]; bash $MERGE_ON_GREEN 1")"
+assert_deny "legacy \$[NAME++] (postfix increment) assigns the seam" "$(j "echo \$[HIMMEL_CONSOLE_LEG++]; bash $MERGE_ON_GREEN 1")"
+
 # --- CR ROUND 1 (HIMMEL-1746): the env-prefix must bind to the chokepoint's
 # OWN command segment. The pre-fix predicate tested "path found anywhere"
 # AND "assignment found anywhere" over the whole compound, which false-denied

--- a/scripts/hooks/test-block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/test-block-chokepoint-env-prefix.sh
@@ -200,6 +200,27 @@ assert_deny "unset NAME -f (both readings still clear the seam)"    "$(j "unset 
 assert_deny "unset -x NAME (documented over-deny -- bash refuses, touches nothing)" "$(j "unset -x HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
 assert_deny "export -n -x NAME (documented over-deny -- bash refuses, touches nothing)" "$(j "export -n -x HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
 
+# --- HIMMEL-2939 (the fourth clearing shape): six MORE ways an earlier
+# segment clears a registered seam with no `unset`/`export -n`/`env -u`/plain
+# assignment in sight -- `let`/`declare`/`typeset`/`printf -v`/`read` all
+# assign in the CURRENT shell, and the legacy `$[NAME=0]` arithmetic
+# construct assigns too. Same fail-closed posture as HIMMEL-2927/2933: no
+# option-validity model, every non-option word (after any `-v` for `printf`)
+# is a candidate name, folded into UNSET_NAMES for later segments. The
+# `$((SEAM=0))` control (already denied via the existing `$(` carve-out,
+# unrelated to this change) stays DENY. ---
+assert_deny "legacy \$[NAME=0] arithmetic assigns the seam"      "$(j "echo \$[HIMMEL_CONSOLE_LEG=0]; bash $MERGE_ON_GREEN 1")"
+assert_deny "let NAME=0 assigns the seam"                        "$(j "let HIMMEL_CONSOLE_LEG=0; bash $MERGE_ON_GREEN 1")"
+assert_deny "declare NAME=0 assigns the seam"                    "$(j "declare HIMMEL_CONSOLE_LEG=0; bash $MERGE_ON_GREEN 1")"
+assert_deny "typeset NAME= assigns the seam to empty"            "$(j "typeset HIMMEL_CONSOLE_LEG=; bash $MERGE_ON_GREEN 1")"
+assert_deny "printf -v NAME writes the seam"                     "$(j "printf -v HIMMEL_CONSOLE_LEG 0; bash $MERGE_ON_GREEN 1")"
+assert_deny "read NAME <<< 0 writes the seam"                    "$(j "read HIMMEL_CONSOLE_LEG <<< 0; bash $MERGE_ON_GREEN 1")"
+assert_deny "read -r a NAME b (name anywhere in read's word list)" "$(j "read -r a HIMMEL_CONSOLE_LEG b <<< '1 2 3'; bash $MERGE_ON_GREEN 1")"
+assert_deny "declare -p NAME (documented over-deny -- no -p inspection)" "$(j "declare -p HIMMEL_CONSOLE_LEG; bash $MERGE_ON_GREEN 1")"
+assert_deny "\$((NAME=0)) control (pre-existing, via the \$( carve-out)" "$(j "\$((HIMMEL_CONSOLE_LEG=0)); bash $MERGE_ON_GREEN 1")"
+# Over-match control: unaffected.
+assert_allow "let x=1 (no seam) stays allowed"                   "$(j "let x=1; bash $MERGE_ON_GREEN 1")"
+
 # --- CR ROUND 1 (HIMMEL-1746): the env-prefix must bind to the chokepoint's
 # OWN command segment. The pre-fix predicate tested "path found anywhere"
 # AND "assignment found anywhere" over the whole compound, which false-denied

--- a/scripts/hooks/test-block-chokepoint-env-prefix.sh
+++ b/scripts/hooks/test-block-chokepoint-env-prefix.sh
@@ -273,6 +273,17 @@ assert_deny "read NAME[0] (array-element assignment) assigns the seam"        "$
 assert_deny "printf -v NAME[0] (array-element assignment) writes the seam"    "$(j "printf -v HIMMEL_CONSOLE_LEG[0] 0; bash $MERGE_ON_GREEN 1")"
 assert_allow "read NAME_LONGER (word boundary -- shares the PREFIX, not equal)" "$(j "read HIMMEL_CONSOLE_LEGACY <<< 0; bash $MERGE_ON_GREEN 1")"
 
+# --- HIMMEL-2939 CR round 5 (console ruling): the round-4 collapse still
+# skipped every dash-prefixed word (`-*) ;;`) in the let/declare/typeset/
+# readonly and read arms before scanning, reasoning it was an option/flag.
+# That skip is itself an unwanted grammar model: bash's `let` treats a
+# LEADING `--` on an operand, after the `--` option-terminator word, as the
+# prefix-decrement operator, not a flag -- `let -- '--HIMMEL_CONSOLE_LEG'`
+# genuinely decrements the seam (verified live). Fix: delete the skip: every
+# remaining word, dash-prefixed or not, goes through the word-bounded scan. ---
+assert_deny "let -- '--NAME' (arithmetic prefix-decrement operand; dash-skip hid it)" "$(j "let -- '--HIMMEL_CONSOLE_LEG'; bash $MERGE_ON_GREEN 1")"
+assert_allow "let -- x=1 (control -- no seam name present)" "$(j "let -- x=1; bash $MERGE_ON_GREEN 1")"
+
 # --- CR ROUND 1 (HIMMEL-1746): the env-prefix must bind to the chokepoint's
 # OWN command segment. The pre-fix predicate tested "path found anywhere"
 # AND "assignment found anywhere" over the whole compound, which false-denied


### PR DESCRIPTION
## Summary

`scripts/hooks/block-chokepoint-env-prefix.sh` denies a Bash tool call that
clears a registered "seam" env var before launching a shell that would
otherwise inherit it. Five CR rounds each found the next `let`/`declare`/
`$[...]`/`printf -v`/`read` operand shape a validity-modelling approach
missed — the same "stop parsing grammar" pattern that ended #635 at round 5
and parked HIMMEL-2929.

- Round 1 (`0b41b530`): folds `let`/`declare`/`typeset`/`readonly`/`printf -v`/
  `read` and legacy `$[V=]` assignments into the seam-clearing set.
- Round 2 (`6b78e3d8`): closes the compound arithmetic-assignment bypass
  (`let NAME*=0`, `$[NAME*=0]`).
- Round 3 (`547db722`): closes comma-joined `let` operands and prefix/postfix
  `++`/`--` bypasses.
- Round 4 (`53d88db8`, console ruling): stops parsing assignment grammar
  entirely — any registered seam-var name occurring anywhere in a remaining
  word, word-bounded, folds forward regardless of assignment shape.
- Round 5 (`2062b112`): round 4's collapse still skipped every dash-prefixed
  word (`-*) ;;`) as if it were an option/flag — itself a grammar model in
  disguise. Bash's `let` treats a leading `--` *after* the `--`
  option-terminator as the prefix-decrement operator, not a flag:
  `let -- '--HIMMEL_CONSOLE_LEG'` genuinely decrements the seam (verified
  live) and the dash-skip hid it from the scan. Deleted the skip in both the
  `let|declare|typeset|readonly` and `read` arms — every remaining word,
  dash-prefixed or not, now goes through the existing word-bounded scan
  unconditionally.

Each round is RED-first: a failing regression test reproducing the exact
bypass, then the minimal fix, then green.

## Deferred (out of scope for this PR)

CR round 5's panel raised one further Important finding (codex-1):
`mapfile -t NAME <<< 0`/`readarray` converts a scalar seam var into an array,
which bash does not export to child processes, bypassing the deny with no
name folded into `UNSET_NAMES`. Verified this is a **pre-existing main-ALLOW
shape**, not a regression — the identical payload against `main`'s copy of
the hook also returns rc=0 (mapfile/readarray are not modelled by any arm on
either branch). This branch only ever moves shapes ALLOW→DENY relative to
main and does not touch mapfile/readarray handling, so it ships with this
finding deferred to **HIMMEL-2943** rather than parked.

## Test plan

- [x] `scripts/hooks/test-block-chokepoint-env-prefix.sh` — 196/196 passing
      (2 new round-5 cases: `let -- '--NAME'` → DENY, `let -- x=1` → ALLOW)
- [x] `shellcheck` clean on the modified hook
- [x] Regression controls re-verified DENY post-fix (no ALLOW flip on any
      main-DENY shape): `bash -c '(unset ...)'`, `eval '(unset ...)'`,
      `echo $((NAME=0))`, `: $((NAME=0))`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171MHGDyCKhZTxvUDJ8ZsC9