### PR TITLE
fix(himmelctl): [HIMMEL-2936] bridge-health poller-count verifies a bare-token candidate's cwd against the checkout before counting it

### DIFF
--- a/scripts/himmelctl/lib/probes.js
+++ b/scripts/himmelctl/lib/probes.js
@@ -2889,8 +2889,15 @@ function posixCandidateIsThisCheckout(cmdline, pid, thisCheckoutAnchor, checkout
   } catch (e) {
     return { counted: false, excludedNote: `pid ${pid} bare-token cwd unreadable (${e.code || e.message})` };
   }
-  const normCwd = normalizeForPollerAnchorMatch(cwd);
-  const normRoot = normalizeForPollerAnchorMatch(checkoutRoot);
+  // Case-SENSITIVE on purpose, unlike the pathed-token branch above: this
+  // compares two POSIX filesystem paths (a live cwd readlink, this
+  // checkout's own root), where Linux paths are case-sensitive by design —
+  // normalizeForPollerAnchorMatch's lowercasing exists for the pathed-token
+  // anchor, which also has to match a case-insensitive Windows CommandLine.
+  // Lowercasing here would fold e.g. /work/Himmel and /work/himmel together
+  // and could count a foreign checkout as this one (CR gap, HIMMEL-2936).
+  const normCwd = cwd.replace(/\\/g, '/');
+  const normRoot = checkoutRoot.replace(/\\/g, '/');
   if (normCwd === normRoot) return { counted: true };
   if (normCwd.startsWith(`${normRoot}/`)) {
     // A worktree's own directory lives nested under its primary checkout

--- a/scripts/himmelctl/lib/probes.js
+++ b/scripts/himmelctl/lib/probes.js
@@ -2891,7 +2891,18 @@ function posixCandidateIsThisCheckout(cmdline, pid, thisCheckoutAnchor, checkout
   }
   const normCwd = normalizeForPollerAnchorMatch(cwd);
   const normRoot = normalizeForPollerAnchorMatch(checkoutRoot);
-  if (normCwd === normRoot || normCwd.startsWith(`${normRoot}/`)) return { counted: true };
+  if (normCwd === normRoot) return { counted: true };
+  if (normCwd.startsWith(`${normRoot}/`)) {
+    // A worktree's own directory lives nested under its primary checkout
+    // (<primary>/.claude/worktrees/<branch>/...), so a plain prefix match
+    // would also count a poller from a DIFFERENT, nested worktree checkout
+    // as this checkout's own -- the exact cross-checkout false duplicate
+    // this fix exists to close, one level deeper (CR gap, HIMMEL-2936).
+    if (normCwd.slice(normRoot.length).startsWith('/.claude/worktrees/')) {
+      return { counted: false, excludedNote: `pid ${pid} bare-token cwd is a nested worktree checkout (${cwd})` };
+    }
+    return { counted: true };
+  }
   return { counted: false, excludedNote: `pid ${pid} bare-token cwd is a different checkout (${cwd})` };
 }
 

--- a/scripts/himmelctl/lib/probes.js
+++ b/scripts/himmelctl/lib/probes.js
@@ -2867,7 +2867,35 @@ function escapeEreMetachars(s) {
 // sweep, see its call site) — either way, identity is decided below by
 // pollerLineIsThisCheckout, never by the breadth of this pattern. Returns
 // { pids: [...verified] } or { error }.
-function posixVerifiedPgrepMatches(matchPattern, procRoot, env, anchor) {
+// A bare `poller.ts` token carries no path to anchor against, so a
+// same-named process from a DIFFERENT checkout launched the same
+// hand-launched way also matches the system-wide sweep (HIMMEL-2936,
+// following the sweep-widening in HIMMEL-2932). Before counting a
+// bare-token candidate, verify its own cwd -- not just its argv --
+// resolves inside this checkout. A pathed token is unaffected: identity
+// there is already decided by the anchor comparison below, no cwd read
+// needed.
+function posixCandidateIsThisCheckout(cmdline, pid, thisCheckoutAnchor, checkoutRoot, procRoot) {
+  const token = extractPollerToken(cmdline);
+  if (!token) return { counted: false };
+  const sepIdx = Math.max(token.lastIndexOf('/'), token.lastIndexOf('\\'));
+  if (sepIdx !== -1) {
+    return { counted: Boolean(thisCheckoutAnchor) && normalizeForPollerAnchorMatch(token) === thisCheckoutAnchor };
+  }
+  if (!checkoutRoot) return { counted: false };
+  let cwd;
+  try {
+    cwd = fs.readlinkSync(path.join(procRoot, String(pid), 'cwd'));
+  } catch (e) {
+    return { counted: false, excludedNote: `pid ${pid} bare-token cwd unreadable (${e.code || e.message})` };
+  }
+  const normCwd = normalizeForPollerAnchorMatch(cwd);
+  const normRoot = normalizeForPollerAnchorMatch(checkoutRoot);
+  if (normCwd === normRoot || normCwd.startsWith(`${normRoot}/`)) return { counted: true };
+  return { counted: false, excludedNote: `pid ${pid} bare-token cwd is a different checkout (${cwd})` };
+}
+
+function posixVerifiedPgrepMatches(matchPattern, procRoot, env, anchor, checkoutRoot) {
   const pgrepBin = which('pgrep', env);
   if (!pgrepBin) return { pids: null };
   const r = spawnProbeSync(pgrepBin, ['-f', escapeEreMetachars(matchPattern)], { env, encoding: 'utf8' });
@@ -2875,12 +2903,15 @@ function posixVerifiedPgrepMatches(matchPattern, procRoot, env, anchor) {
   if (r.status !== 0 && r.status !== 1) return { error: new Error(`pgrep exited rc=${r.status}`) };
   const candidates = (r.stdout || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
   const verified = [];
+  const excludedNotes = [];
   for (const pid of candidates) {
     const cmdline = posixCmdline(pid, procRoot, env);
     if (cmdline === null) return { error: new Error(`could not read cmdline for pgrep-matched pid ${pid}`) };
-    if (pollerLineIsThisCheckout(cmdline, anchor)) verified.push(pid);
+    const verdict = posixCandidateIsThisCheckout(cmdline, pid, anchor, checkoutRoot, procRoot);
+    if (verdict.counted) verified.push(pid);
+    else if (verdict.excludedNote) excludedNotes.push(verdict.excludedNote);
   }
-  return { pids: verified };
+  return { pids: verified, excludedNotes };
 }
 
 // The system-wide sweep matches on this broad basename-only substring,
@@ -2936,9 +2967,13 @@ function probeBridgePollerCountPosix(ctx) {
         if (unreadable.length > 0) {
           return { actual: 'degraded', detail: `could not read cmdline for pid(s) ${unreadable.map((c) => c.pid).join(', ')} in telegram-bridge.service MainPID ${mainPid}'s process tree — process identity is UNVERIFIED, not assumed healthy` };
         }
-        const verifiedPids = new Set(
-          cmdlines.filter((c) => pollerLineIsThisCheckout(c.cmdline, thisCheckoutAnchor)).map((c) => c.pid),
-        );
+        const verifiedPids = new Set();
+        const treeExcludedNotes = [];
+        for (const c of cmdlines) {
+          const verdict = posixCandidateIsThisCheckout(c.cmdline, c.pid, thisCheckoutAnchor, ctx.repoRoot, procRoot);
+          if (verdict.counted) verifiedPids.add(c.pid);
+          else if (verdict.excludedNote) treeExcludedNotes.push(verdict.excludedNote);
+        }
 
         // MainPID can itself BE the poller (no wrapper) — a genuine
         // read failure here degrades, but a missing cmdline (MainPID has
@@ -2948,8 +2983,10 @@ function probeBridgePollerCountPosix(ctx) {
         if (mainCmdline.error) {
           return { actual: 'degraded', detail: `could not read cmdline for telegram-bridge.service MainPID ${mainPid}: ${mainCmdline.error.message} — process identity is UNVERIFIED, not assumed healthy` };
         }
-        if (mainCmdline.cmdline !== null && pollerLineIsThisCheckout(mainCmdline.cmdline, thisCheckoutAnchor)) {
-          verifiedPids.add(mainPid);
+        if (mainCmdline.cmdline !== null) {
+          const mainVerdict = posixCandidateIsThisCheckout(mainCmdline.cmdline, mainPid, thisCheckoutAnchor, ctx.repoRoot, procRoot);
+          if (mainVerdict.counted) verifiedPids.add(mainPid);
+          else if (mainVerdict.excludedNote) treeExcludedNotes.push(mainVerdict.excludedNote);
         }
 
         // HIMMEL-1555 duplicate-poller class: a manually-launched poller
@@ -2962,7 +2999,7 @@ function probeBridgePollerCountPosix(ctx) {
         // that constant's comment for why the sweep needs the broader,
         // unanchored pattern.
         if (pollerPath) {
-          const sweep = posixVerifiedPgrepMatches(POLLER_SWEEP_PATTERN, procRoot, env, thisCheckoutAnchor);
+          const sweep = posixVerifiedPgrepMatches(POLLER_SWEEP_PATTERN, procRoot, env, thisCheckoutAnchor, ctx.repoRoot);
           if (sweep.error) {
             return { actual: 'degraded', detail: `could not run the system-wide pgrep sweep for telegram-bridge.service: ${sweep.error.message} — process identity is UNVERIFIED, not assumed healthy` };
           }
@@ -2970,9 +3007,13 @@ function probeBridgePollerCountPosix(ctx) {
             return { actual: 'degraded', detail: 'no pgrep on PATH to run the system-wide sweep for telegram-bridge.service (HIMMEL-1555 class) — process identity is UNVERIFIED, not assumed healthy' };
           }
           sweep.pids.forEach((pid) => verifiedPids.add(pid));
+          if (sweep.excludedNotes) treeExcludedNotes.push(...sweep.excludedNotes);
         }
 
-        return posixPollerVerdict(verifiedPids.size, 'via systemd MainPID process tree + system-wide sweep');
+        const source = treeExcludedNotes.length > 0
+          ? `via systemd MainPID process tree + system-wide sweep; excluded: ${treeExcludedNotes.join('; ')}`
+          : 'via systemd MainPID process tree + system-wide sweep';
+        return posixPollerVerdict(verifiedPids.size, source);
       }
       // LoadState absent/not-found -- systemd genuinely doesn't know this unit; fall through to the pgrep -f fallback below.
     }
@@ -2987,11 +3028,14 @@ function probeBridgePollerCountPosix(ctx) {
   if (!pollerPath) {
     return { actual: 'degraded', detail: 'poller-count check needs ctx.repoRoot to anchor pgrep -f, none provided' };
   }
-  const fallback = posixVerifiedPgrepMatches(pollerPath, procRoot, env, thisCheckoutAnchor);
+  const fallback = posixVerifiedPgrepMatches(pollerPath, procRoot, env, thisCheckoutAnchor, ctx.repoRoot);
   if (fallback.error) {
     return { actual: 'degraded', detail: `pgrep poller-count query failed: ${fallback.error.message}` };
   }
-  return posixPollerVerdict(fallback.pids.length, 'via pgrep -f, no systemd unit found');
+  const fallbackSource = fallback.excludedNotes && fallback.excludedNotes.length > 0
+    ? `via pgrep -f, no systemd unit found; excluded: ${fallback.excludedNotes.join('; ')}`
+    : 'via pgrep -f, no systemd unit found';
+  return posixPollerVerdict(fallback.pids.length, fallbackSource);
 }
 
 function probeBridgePollerCount(ctx) {

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -5015,6 +5015,29 @@ else
   echo "SKIP: bridge-health (Linux) control (c) HIMMEL-2936: no evidence in the stub log that systemctl actually spawned on this host"
 fi
 
+# ── control (d) HIMMEL-2936 (codex-1 CR fix): a bare-token candidate whose
+# cwd resolves to a NESTED worktree checkout under this checkout's own root
+# (<checkoutRoot>/.claude/worktrees/<other>/...) must NOT be counted as this
+# checkout's own -- a plain prefix match would otherwise re-admit exactly the
+# cross-checkout false duplicate this fix exists to close, one level deeper ──
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9201"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
+ln -sf "${repo_root}/.claude/worktrees/feat-some-other-checkout" "$bh_proc_root/9201/cwd"
+rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
+outBHlinuxR=$(BH_PGREP_N=1 run_bh_posix)
+if bh_posix_log_has "pgrep -f"; then
+  echo "$outBHlinuxR" | jq -e '.actual == "absent"' >/dev/null \
+    || fail "bridge-health (Linux): a bare-token sweep match whose cwd is a NESTED worktree checkout must not be counted as this checkout's (got: $outBHlinuxR)"
+  echo "$outBHlinuxR" | jq -e '.detail | contains("0 poller")' >/dev/null \
+    || fail "bridge-health (Linux): nested-worktree exclusion should read count 0 (got: $outBHlinuxR)"
+  echo "$outBHlinuxR" | jq -e '.detail | contains("9201")' >/dev/null \
+    || fail "bridge-health (Linux): detail should name the excluded nested-worktree pid 9201 (got: $outBHlinuxR)"
+  echo "ok: bridge-health (Linux) — sweep bare-token match whose cwd is a nested worktree checkout is excluded, count 0, detail names 9201 (HIMMEL-2936 codex-1)"
+else
+  echo "SKIP: bridge-health (Linux) control (d) HIMMEL-2936: no evidence in the stub log that pgrep actually spawned on this host"
+fi
+rm -f "$bh_posix_state/no-unit"
+
 # ── bridge-persistence — HIMMEL-2176 Stage-1 PR-C, status item S6 ───────────
 # Contract (spec §3.5): logon task (win) / systemd unit + linger (linux)
 # present when bridge.enabled; warn when enabled but persistence is absent.

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -5038,6 +5038,29 @@ else
 fi
 rm -f "$bh_posix_state/no-unit"
 
+# ── control (e) HIMMEL-2936 (CodeRabbit CR fix): a bare-token candidate whose
+# cwd matches this checkout's root ONLY case-insensitively must NOT be counted
+# -- POSIX paths are case-sensitive, so lowercasing the comparison (as the
+# pathed-token branch's anchor helper does, for Windows' benefit) would fold
+# a same-named-different-case DIFFERENT directory into this checkout ────────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9201"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
+ln -sf "${repo_root^^}" "$bh_proc_root/9201/cwd"
+rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
+outBHlinuxS=$(BH_PGREP_N=1 run_bh_posix)
+if bh_posix_log_has "pgrep -f"; then
+  echo "$outBHlinuxS" | jq -e '.actual == "absent"' >/dev/null \
+    || fail "bridge-health (Linux): a bare-token sweep match whose cwd differs from this checkout's root only by case must not be counted (got: $outBHlinuxS)"
+  echo "$outBHlinuxS" | jq -e '.detail | contains("0 poller")' >/dev/null \
+    || fail "bridge-health (Linux): case-mismatch exclusion should read count 0 (got: $outBHlinuxS)"
+  echo "$outBHlinuxS" | jq -e '.detail | contains("9201")' >/dev/null \
+    || fail "bridge-health (Linux): detail should name the excluded case-mismatched pid 9201 (got: $outBHlinuxS)"
+  echo "ok: bridge-health (Linux) — sweep bare-token match whose cwd differs only by case is excluded, count 0, detail names 9201 (HIMMEL-2936 CodeRabbit)"
+else
+  echo "SKIP: bridge-health (Linux) control (e) HIMMEL-2936: no evidence in the stub log that pgrep actually spawned on this host"
+fi
+rm -f "$bh_posix_state/no-unit"
+
 # ── bridge-persistence — HIMMEL-2176 Stage-1 PR-C, status item S6 ───────────
 # Contract (spec §3.5): logon task (win) / systemd unit + linger (linux)
 # present when bridge.enabled; warn when enabled but persistence is absent.

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -4616,6 +4616,7 @@ other_checkout_posix="/home/testuser/github/himmel/.claude/worktrees/feat-some-o
 rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9002"
 printf '9002\n' > "$bh_proc_root/9001/task/9001/children"
 printf '%s\0' bun poller.ts > "$bh_proc_root/9002/cmdline"
+ln -sf "$repo_root" "$bh_proc_root/9002/cwd"
 rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
 outBHlinuxA=$(BH_PGREP_N=0 run_bh_posix)
 if bh_posix_log_has "show telegram-bridge.service"; then
@@ -4648,6 +4649,8 @@ rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9
 printf '9002 9003\n' > "$bh_proc_root/9001/task/9001/children"
 printf '%s\0' bun poller.ts > "$bh_proc_root/9002/cmdline"
 printf '%s\0' bun poller.ts > "$bh_proc_root/9003/cmdline"
+ln -sf "$repo_root" "$bh_proc_root/9002/cwd"
+ln -sf "$repo_root" "$bh_proc_root/9003/cwd"
 rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
 outBHlinuxC=$(BH_PGREP_N=0 run_bh_posix)
 if bh_posix_log_has "show telegram-bridge.service"; then
@@ -4714,6 +4717,7 @@ fi
 
 rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9201"
 printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
+ln -sf "$repo_root" "$bh_proc_root/9201/cwd"
 rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
 outBHlinuxE1=$(BH_PGREP_N=1 run_bh_posix)
 if bh_posix_log_has "pgrep -f"; then
@@ -4727,6 +4731,8 @@ fi
 rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9201" "$bh_proc_root/9202"
 printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
 printf '%s\0' bun poller.ts > "$bh_proc_root/9202/cmdline"
+ln -sf "$repo_root" "$bh_proc_root/9201/cwd"
+ln -sf "$repo_root" "$bh_proc_root/9202/cwd"
 rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
 outBHlinuxE2=$(BH_PGREP_N=2 run_bh_posix)
 if bh_posix_log_has "pgrep -f"; then
@@ -4746,6 +4752,7 @@ rm -f "$bh_posix_state/no-unit"
 rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001"
 printf '\n' > "$bh_proc_root/9001/task/9001/children"
 printf '%s\0' bun poller.ts > "$bh_proc_root/9001/cmdline"
+ln -sf "$repo_root" "$bh_proc_root/9001/cwd"
 rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
 outBHlinuxF=$(BH_PGREP_N=0 run_bh_posix)
 if bh_posix_log_has "show telegram-bridge.service"; then
@@ -4766,6 +4773,7 @@ printf '9002\n' > "$bh_proc_root/9001/task/9001/children"
 printf '9003\n' > "$bh_proc_root/9002/task/9002/children"
 printf '%s\0' bash wrapper.sh > "$bh_proc_root/9002/cmdline"
 printf '%s\0' bun poller.ts > "$bh_proc_root/9003/cmdline"
+ln -sf "$repo_root" "$bh_proc_root/9003/cwd"
 rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
 outBHlinuxG=$(BH_PGREP_N=0 run_bh_posix)
 if bh_posix_log_has "show telegram-bridge.service"; then
@@ -4792,6 +4800,7 @@ printf '%s\0' bash wrapper.sh > "$bh_proc_root/9002/cmdline"
 printf '%s\0' bash wrapper.sh > "$bh_proc_root/9003/cmdline"
 printf '%s\0' bash wrapper.sh > "$bh_proc_root/9004/cmdline"
 printf '%s\0' bun poller.ts > "$bh_proc_root/9005/cmdline"
+ln -sf "$repo_root" "$bh_proc_root/9005/cwd"
 rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
 outBHlinuxL=$(BH_PGREP_N=0 run_bh_posix)
 if bh_posix_log_has "show telegram-bridge.service"; then
@@ -4813,6 +4822,8 @@ rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9
 printf '9002\n' > "$bh_proc_root/9001/task/9001/children"
 printf '%s\0' bun poller.ts > "$bh_proc_root/9002/cmdline"
 printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
+ln -sf "$repo_root" "$bh_proc_root/9002/cwd"
+ln -sf "$repo_root" "$bh_proc_root/9201/cwd"
 rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
 outBHlinuxH=$(BH_PGREP_N=1 run_bh_posix)
 if bh_posix_log_has "show telegram-bridge.service"; then
@@ -4856,6 +4867,7 @@ fi
 rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9201" "$bh_proc_root/9202"
 printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
 printf '%s\0' bun "${other_checkout_posix}/scripts/telegram/poller.ts" > "$bh_proc_root/9202/cmdline"
+ln -sf "$repo_root" "$bh_proc_root/9201/cwd"
 rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
 outBHlinuxJ=$(BH_PGREP_N=2 run_bh_posix)
 if bh_posix_log_has "pgrep -f"; then
@@ -4924,6 +4936,7 @@ cp "$bh_posix_stub/bun" "$bh_posix_stub_nopgrep/bun"
 rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9002"
 printf '9002\n' > "$bh_proc_root/9001/task/9001/children"
 printf '%s\0' bun poller.ts > "$bh_proc_root/9002/cmdline"
+ln -sf "$repo_root" "$bh_proc_root/9002/cwd"
 rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
 outBHlinuxN=$(PATH="$bh_posix_stub_nopgrep:$(scrub_path "$PATH" systemctl pgrep)" BH_STUB_LOG="$(winpath "$bh_posix_log")" BH_STUB_STATE="$(winpath "$bh_posix_state")" "$node_bin" -e "
 const { runProbe } = require('$probes_lib_w');
@@ -4938,6 +4951,68 @@ if bh_posix_log_has "show telegram-bridge.service"; then
   echo "ok: bridge-health (Linux) — pgrep missing from PATH during the system-wide sweep reads degraded, not silently tree-only"
 else
   echo "SKIP: bridge-health (Linux) case (n): no evidence in the stub log that systemctl actually spawned on this host"
+fi
+
+# ── control (a) HIMMEL-2936: system-wide sweep with two bare-token matches,
+# one whose /proc/<pid>/cwd resolves inside this checkout and one whose cwd
+# resolves to a DIFFERENT checkout -> only the in-checkout one counts,
+# present, and the detail names the excluded foreign-cwd pid ──────────────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9201" "$bh_proc_root/9202"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9202/cmdline"
+ln -sf "$repo_root" "$bh_proc_root/9201/cwd"
+ln -sf "$other_checkout_posix" "$bh_proc_root/9202/cwd"
+rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
+outBHlinuxO=$(BH_PGREP_N=2 run_bh_posix)
+if bh_posix_log_has "pgrep -f"; then
+  echo "$outBHlinuxO" | jq -e '.actual == "present"' >/dev/null \
+    || fail "bridge-health (Linux): a bare-token sweep match whose cwd is a DIFFERENT checkout must not be counted as this checkout's (got: $outBHlinuxO)"
+  echo "$outBHlinuxO" | jq -e '.detail | contains("1 poller")' >/dev/null \
+    || fail "bridge-health (Linux): cwd-verified sweep count should name 1, not 2 (got: $outBHlinuxO)"
+  echo "$outBHlinuxO" | jq -e '.detail | contains("9202")' >/dev/null \
+    || fail "bridge-health (Linux): detail should name the excluded foreign-cwd pid 9202 (got: $outBHlinuxO)"
+  echo "ok: bridge-health (Linux) — sweep bare-token match with a foreign cwd is excluded via cwd check, count 1, detail names 9202 (HIMMEL-2936)"
+else
+  echo "SKIP: bridge-health (Linux) control (a) HIMMEL-2936: no evidence in the stub log that pgrep actually spawned on this host"
+fi
+rm -f "$bh_posix_state/no-unit"
+
+# ── control (b) HIMMEL-2936: system-wide sweep, one bare-token match whose
+# /proc/<pid>/cwd is unreadable (process exited / no cwd symlink) -> not
+# counted, fail-safe, detail names the pid ─────────────────────────────────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9201"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
+rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
+outBHlinuxP=$(BH_PGREP_N=1 run_bh_posix)
+if bh_posix_log_has "pgrep -f"; then
+  echo "$outBHlinuxP" | jq -e '.actual == "absent"' >/dev/null \
+    || fail "bridge-health (Linux): a bare-token sweep match with an unreadable cwd must not be counted (fail-safe) (got: $outBHlinuxP)"
+  echo "$outBHlinuxP" | jq -e '.detail | contains("0 poller")' >/dev/null \
+    || fail "bridge-health (Linux): fail-safe exclusion should read count 0 (got: $outBHlinuxP)"
+  echo "$outBHlinuxP" | jq -e '.detail | contains("9201")' >/dev/null \
+    || fail "bridge-health (Linux): detail should name the excluded pid 9201 with the unreadable-cwd reason (got: $outBHlinuxP)"
+  echo "ok: bridge-health (Linux) — sweep bare-token match with an unreadable cwd is excluded fail-safe, count 0, detail names 9201 (HIMMEL-2936)"
+else
+  echo "SKIP: bridge-health (Linux) control (b) HIMMEL-2936: no evidence in the stub log that pgrep actually spawned on this host"
+fi
+rm -f "$bh_posix_state/no-unit"
+
+# ── control (c) HIMMEL-2936: a tree-scoped child with an ABSOLUTE path token
+# matching the anchor is still counted exactly as before, with no cwd
+# fixture at all -- proves the anchored-path branch never reads cwd ────────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9001/task/9001" "$bh_proc_root/9002"
+printf '9002\n' > "$bh_proc_root/9001/task/9001/children"
+printf '%s\0' bun "${repo_root_w}/scripts/telegram/poller.ts" > "$bh_proc_root/9002/cmdline"
+rm -f "$bh_posix_log" "$bh_posix_state/no-unit"; echo 9001 > "$bh_posix_state/mainpid"; echo active > "$bh_posix_state/activestate"
+outBHlinuxQ=$(BH_PGREP_N=0 run_bh_posix)
+if bh_posix_log_has "show telegram-bridge.service"; then
+  echo "$outBHlinuxQ" | jq -e '.actual == "present"' >/dev/null \
+    || fail "bridge-health (Linux): an absolute-path child matching the anchor must still be counted with no cwd read (got: $outBHlinuxQ)"
+  echo "$outBHlinuxQ" | jq -e '.detail | contains("1 poller")' >/dev/null \
+    || fail "bridge-health (Linux): absolute-path match detail should name the count 1 (got: $outBHlinuxQ)"
+  echo "ok: bridge-health (Linux) — an absolute-path child matching the anchor is counted without any cwd read (HIMMEL-2936 control)"
+else
+  echo "SKIP: bridge-health (Linux) control (c) HIMMEL-2936: no evidence in the stub log that systemctl actually spawned on this host"
 fi
 
 # ── bridge-persistence — HIMMEL-2176 Stage-1 PR-C, status item S6 ───────────


### PR DESCRIPTION
## Summary

`pollerLineIsThisCheckout` / the POSIX bare-token sweep in `scripts/himmelctl/lib/probes.js` was miscounting a same-named bare `poller.ts` process from a **different checkout** as belonging to "this checkout." A bare-token candidate (no path segment in its `cmdline`) was accepted purely on cmdline shape, with no verification that it was actually running from this checkout.

This PR verifies a bare-token candidate PID's `/proc/<pid>/cwd` against the checkout root before counting it, via a new `posixCandidateIsThisCheckout` helper shared by the three POSIX call sites (tree-children filter, MainPID-itself check, sweep call site, no-unit fallback call site). The Windows CIM branch is unchanged (out of scope — no `/proc` there).

Follow-up commit `3cbe934a` closes a CR gap in the first commit's fix itself: himmel worktrees live *nested* under their primary checkout (`<primary>/.claude/worktrees/<branch>/...`), so a plain `cwd` prefix match against the checkout root would re-admit a poller from a **different, nested worktree checkout** as this checkout's own — the exact cross-checkout false duplicate this fix exists to close, one level deeper. Candidates whose cwd falls under a `.claude/worktrees/` segment beneath the checkout root are now excluded.

## Test plan

- [x] RED: control (a)/(b)/(c) (bare-token foreign-cwd exclusion, unreadable-cwd fail-safe exclusion, absolute-path match doesn't read cwd) + control (d) (nested-worktree-checkout exclusion) in `scripts/himmelctl/test/test-wizard-probes.sh`, all failing before their respective fix and passing after.
- [x] `node --check scripts/himmelctl/lib/probes.js` — SYNTAX_OK
- [x] `shellcheck -x scripts/himmelctl/test/test-wizard-probes.sh` — clean
- [x] `bash scripts/quiet-run.sh wizard-probes-suite -- bash scripts/himmelctl/test/test-wizard-probes.sh` — GREEN
- [x] Impacted suites (every suite referencing `probes.js` / `test-wizard-probes.sh`, via `git grep -l`) — all GREEN:
  - `scripts/himmelctl/test/test-suite-hermeticity.sh`
  - `scripts/himmelctl/test/test-wizard-luna-sections.sh`
  - `scripts/himmelctl/test/test-wizard-status-golden.sh`
  - `scripts/himmelctl/test/test-wizard-statusreport.sh`
  - `scripts/install/test-himmel-ops-plugin-enablement.sh`
  - `scripts/install/test-mcp-profile-providers.sh`
  - `scripts/install/test-observability-stack-manifest.sh`
  - `scripts/test-adopt.sh`

macOS: no `pgrep`/`/proc` behavior difference from Linux for this path (both are POSIX `/proc`-having or BSD-`pgrep`-having — this repo's macOS lane shares the POSIX branch under test here). Windows: unaffected, CIM branch untouched.

## CR notes

- `known-findings.sh --diff` flagged `[test-coverage-gap] source changed, no test changed` for `probes.js` — false positive: `test-wizard-probes.sh` gained 98 lines in the same `main...HEAD` range (`git diff --stat` confirms). Pre-rebutted here per the runbook.
- Critic panel round 1 (head `a4e6667e`): `[codex-1]` (nested-worktree cwd false positive) — **agreed**, fixed in `3cbe934a` + new control (d). `[codex-2]` (unreadable cwd not counted, argued should "degrade" instead) — **disproved**: this is exactly the ticket's own explicit contract (control (b): bare-token with unreadable/missing cwd → not counted, fail-safe against overcounting).
- Critic panel round 2 (head `3cbe934a`): `[codex-1]` (unreadable-cwd-as-exclusion could mask an undercounted duplicate) — **disproved**, same fail-safe-by-design rationale as round 1's `[codex-2]`; the ticket deliberately prefers undercounting over a false duplicate alarm from an unverifiable process. `[codex-2]` (Suggestion: only recognizes `.claude/worktrees/`, not other hypothetical nested-checkout conventions like `.worktrees/other`) — **disproved**: `.claude/worktrees/<branch>` is himmel's fixed, documented worktree convention; no other nested pattern occurs in this codebase, so guarding against a hypothetical one is out of scope per this ticket's simplicity mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzMVCsRQrQkvimWKsqnVeQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved poller detection on Linux by validating process working directories.
  - Excluded poller processes from unrelated checkouts, nested worktrees, or inaccessible directories.
  - Preserved detection for processes using explicit checkout paths.
  - Poller-count diagnostics now include details about excluded processes.

- **Tests**
  - Added coverage for checkout identity validation and filtering of invalid process matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->