### PR TITLE
fix(lanes): [HIMMEL-2942] collectMcpServerDefs refuses to copy a server definition that references CLAUDE_PLUGIN_ROOT

### DIFF
--- a/scripts/lanes/plugin-profiles.mjs
+++ b/scripts/lanes/plugin-profiles.mjs
@@ -396,6 +396,22 @@ export function mcpServersForProfile(registry, name) {
 // or skipped entry — a leg silently missing its one allowed server is worse
 // than a leg that never launches. Returns the ready-to-write --mcp-config
 // object shape: {"mcpServers": {...}}.
+// A def loaded FROM a plugin manifest has ${CLAUDE_PLUGIN_ROOT} expanded by
+// Claude at launch; a def copied out into a standalone --mcp-config file does
+// not get that expansion, so a command/args/env value still containing the
+// literal token would silently break rather than resolve — refuse instead.
+const PLUGIN_ROOT_TOKEN = '${CLAUDE_PLUGIN_ROOT}';
+const hasToken = (v) => typeof v === 'string' && v.includes(PLUGIN_ROOT_TOKEN);
+function refuseIfPluginRootRef(name, def) {
+  let hit;
+  if (hasToken(def.command)) hit = 'command';
+  else if (Array.isArray(def.args) && def.args.some(hasToken)) hit = 'args';
+  else if (def.env && typeof def.env === 'object' && Object.values(def.env).some(hasToken)) hit = 'env';
+  if (hit) {
+    throw new Error(`plugin-profiles: mcpServers entry "${name}" cannot be copied out of its plugin manifest: field "${hit}" references ${PLUGIN_ROOT_TOKEN}, which only expands for a server Claude loads directly from a plugin`);
+  }
+}
+
 export function collectMcpServerDefs(names, { homeConfigPath, repoMcpPath, marketplaceDir }) {
   if (names.length === 0) return { mcpServers: {} };
   const readDefs = (path) => {
@@ -407,12 +423,19 @@ export function collectMcpServerDefs(names, { homeConfigPath, repoMcpPath, marke
   const repo = readDefs(repoMcpPath);
   const mcpServers = {};
   for (const name of names) {
-    if (Object.hasOwn(home, name)) { mcpServers[name] = home[name]; continue; }
-    if (Object.hasOwn(repo, name)) { mcpServers[name] = repo[name]; continue; }
-    const manifestPath = join(marketplaceDir, name, '.mcp.json');
-    const manifest = readDefs(manifestPath);
-    if (Object.hasOwn(manifest, name)) { mcpServers[name] = manifest[name]; continue; }
-    throw new Error(`plugin-profiles: mcpServers entry "${name}" is not defined in ${homeConfigPath}, ${repoMcpPath}, or ${manifestPath}`);
+    let def;
+    if (Object.hasOwn(home, name)) { def = home[name]; }
+    else if (Object.hasOwn(repo, name)) { def = repo[name]; }
+    else {
+      const manifestPath = join(marketplaceDir, name, '.mcp.json');
+      const manifest = readDefs(manifestPath);
+      if (!Object.hasOwn(manifest, name)) {
+        throw new Error(`plugin-profiles: mcpServers entry "${name}" is not defined in ${homeConfigPath}, ${repoMcpPath}, or ${manifestPath}`);
+      }
+      def = manifest[name];
+    }
+    refuseIfPluginRootRef(name, def);
+    mcpServers[name] = def;
   }
   return { mcpServers };
 }

--- a/scripts/lanes/plugin-profiles.mjs
+++ b/scripts/lanes/plugin-profiles.mjs
@@ -462,6 +462,7 @@ if (import.meta.url === `file://${process.argv[1]}` || process.argv[1] === fileU
     const name = argv[0];
     if (!name) die(2, 'usage: plugin-profiles.mjs <profile> [--add-plugins a@m,b@m] | --mcp-servers | --mcp-config | --list | --validate');
     if (argv[1] === '--mcp-servers') {
+      if (argv.length > 2) die(2, `plugin-profiles: unknown argument "${argv[2]}"`);
       const registry = loadRegistry();
       const errs = validateRegistry(registry);
       if (errs.length) die(2, 'plugin-profiles: registry invalid:\n  - ' + errs.join('\n  - '));
@@ -469,6 +470,7 @@ if (import.meta.url === `file://${process.argv[1]}` || process.argv[1] === fileU
       process.exit(0);
     }
     if (argv[1] === '--mcp-config') {
+      if (argv.length > 2) die(2, `plugin-profiles: unknown argument "${argv[2]}"`);
       const registry = loadRegistry();
       const errs = validateRegistry(registry);
       if (errs.length) die(2, 'plugin-profiles: registry invalid:\n  - ' + errs.join('\n  - '));

--- a/scripts/lanes/tests/plugin-profiles.test.mjs
+++ b/scripts/lanes/tests/plugin-profiles.test.mjs
@@ -547,6 +547,27 @@ test('CLI: --mcp-config resolves leg-impl\'s qmd definition from the marketplace
   assert.deepEqual(JSON.parse(run.stdout), { mcpServers: { qmd: { type: 'http', url: 'http://localhost:8181/mcp' } } });
 });
 
+test('CLI: --mcp-servers / --mcp-config reject trailing argv instead of silently ignoring it', () => {
+  const cli = join(dirname(fileURLToPath(import.meta.url)), '..', 'plugin-profiles.mjs');
+  const home = makeTmpDir('pp-cli-mcp-trailing-home-');
+  const env = { ...process.env, HOME: home, USERPROFILE: home };
+  const mcpConfigRun = spawnSync(process.execPath, [cli, 'leg-impl', '--mcp-config', '--add-plugins', 'x@y'], { encoding: 'utf8', env });
+  assert.equal(mcpConfigRun.status, 2);
+  assert.match(mcpConfigRun.stderr, /unknown argument/);
+  const mcpServersRun = spawnSync(process.execPath, [cli, 'leg-impl', '--mcp-servers', 'extra'], { encoding: 'utf8', env });
+  assert.equal(mcpServersRun.status, 2);
+  assert.match(mcpServersRun.stderr, /unknown argument/);
+});
+
+test('CLI: --mcp-config alone (no trailing argv) still succeeds', () => {
+  const cli = join(dirname(fileURLToPath(import.meta.url)), '..', 'plugin-profiles.mjs');
+  const cwd = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+  const home = makeTmpDir('pp-cli-mcp-trailing-ok-home-');
+  const run = spawnSync(process.execPath, [cli, 'leg-impl', '--mcp-config'], { encoding: 'utf8', cwd, env: { ...process.env, HOME: home, USERPROFILE: home } });
+  assert.equal(run.status, 0, run.stderr);
+  assert.ok(JSON.parse(run.stdout).mcpServers);
+});
+
 test('validateRegistry: a profile naming an id in both drop and enable is an error', () => {
   const bad = { ...SCHEMA_REG, profiles: { ...SCHEMA_REG.profiles, both: { enable: ['enabled@m'], drop: ['enabled@m'] } } };
   assert.ok(validateRegistry(bad).some((e) => /"both" drop id "enabled@m" is also in enable/.test(e)));

--- a/scripts/lanes/tests/plugin-profiles.test.mjs
+++ b/scripts/lanes/tests/plugin-profiles.test.mjs
@@ -473,6 +473,61 @@ test('collectMcpServerDefs: a name found nowhere refuses rather than hand-writin
   );
 });
 
+test('collectMcpServerDefs: refuses to copy a definition whose args reference ${CLAUDE_PLUGIN_ROOT}', () => {
+  const dir = makeTmpDir('pp-mcp-defs-pluginroot-args-');
+  const marketplaceDir = join(dir, 'marketplace', 'plugins');
+  mkdirSync(join(marketplaceDir, 'telegram-himmel'), { recursive: true });
+  writeFileSync(join(marketplaceDir, 'telegram-himmel', '.mcp.json'), JSON.stringify({
+    mcpServers: { 'telegram-himmel': { type: 'stdio', command: 'node', args: ['${CLAUDE_PLUGIN_ROOT}/server.js'] } },
+  }));
+  assert.throws(
+    () => collectMcpServerDefs(['telegram-himmel'], { homeConfigPath: join(dir, 'home.json'), repoMcpPath: join(dir, '.mcp.json'), marketplaceDir }),
+    /plugin-profiles:.*"telegram-himmel".*args.*CLAUDE_PLUGIN_ROOT/s,
+  );
+});
+
+test('collectMcpServerDefs: refuses a ${CLAUDE_PLUGIN_ROOT} reference in command or env too', () => {
+  const dir = makeTmpDir('pp-mcp-defs-pluginroot-cmdenv-');
+  const marketplaceDir = join(dir, 'marketplace', 'plugins');
+  mkdirSync(join(marketplaceDir, 'cmd-ref'), { recursive: true });
+  writeFileSync(join(marketplaceDir, 'cmd-ref', '.mcp.json'), JSON.stringify({
+    mcpServers: { 'cmd-ref': { type: 'stdio', command: '${CLAUDE_PLUGIN_ROOT}/bin/run', args: [] } },
+  }));
+  assert.throws(
+    () => collectMcpServerDefs(['cmd-ref'], { homeConfigPath: join(dir, 'home.json'), repoMcpPath: join(dir, '.mcp.json'), marketplaceDir }),
+    /plugin-profiles:.*"cmd-ref".*command.*CLAUDE_PLUGIN_ROOT/s,
+  );
+
+  mkdirSync(join(marketplaceDir, 'env-ref'), { recursive: true });
+  writeFileSync(join(marketplaceDir, 'env-ref', '.mcp.json'), JSON.stringify({
+    mcpServers: { 'env-ref': { type: 'stdio', command: 'node', args: ['server.js'], env: { FOO: '${CLAUDE_PLUGIN_ROOT}/data' } } },
+  }));
+  assert.throws(
+    () => collectMcpServerDefs(['env-ref'], { homeConfigPath: join(dir, 'home.json'), repoMcpPath: join(dir, '.mcp.json'), marketplaceDir }),
+    /plugin-profiles:.*"env-ref".*env.*CLAUDE_PLUGIN_ROOT/s,
+  );
+});
+
+test('collectMcpServerDefs: a command-based def with no ${CLAUDE_PLUGIN_ROOT} reference, and an http def, still copy through unchanged', () => {
+  const dir = makeTmpDir('pp-mcp-defs-control-');
+  const marketplaceDir = join(dir, 'marketplace', 'plugins');
+  mkdirSync(join(marketplaceDir, 'plain-cmd'), { recursive: true });
+  writeFileSync(join(marketplaceDir, 'plain-cmd', '.mcp.json'), JSON.stringify({
+    mcpServers: { 'plain-cmd': { type: 'stdio', command: 'node', args: ['/abs/server.js'], env: { FOO: 'bar' } } },
+  }));
+  mkdirSync(join(marketplaceDir, 'plain-http'), { recursive: true });
+  writeFileSync(join(marketplaceDir, 'plain-http', '.mcp.json'), JSON.stringify({
+    mcpServers: { 'plain-http': { type: 'http', url: 'http://localhost:9/mcp' } },
+  }));
+  const cfg = collectMcpServerDefs(['plain-cmd', 'plain-http'], { homeConfigPath: join(dir, 'home.json'), repoMcpPath: join(dir, '.mcp.json'), marketplaceDir });
+  assert.deepEqual(cfg, {
+    mcpServers: {
+      'plain-cmd': { type: 'stdio', command: 'node', args: ['/abs/server.js'], env: { FOO: 'bar' } },
+      'plain-http': { type: 'http', url: 'http://localhost:9/mcp' },
+    },
+  });
+});
+
 test('CLI: --mcp-servers prints the profile\'s allowlist, or null when the field is absent', () => {
   const cli = join(dirname(fileURLToPath(import.meta.url)), '..', 'plugin-profiles.mjs');
   const okRun = spawnSync(process.execPath, [cli, 'leg-impl', '--mcp-servers'], { encoding: 'utf8' });


### PR DESCRIPTION
## Summary

Fixes two linked issues in `scripts/lanes/plugin-profiles.mjs` found as panel suggestions from PR #646 (HIMMEL-2935):

- **HIMMEL-2942**: `collectMcpServerDefs` copies a resolved MCP server definition byte-for-byte into a standalone `--mcp-config` file. Claude Code only expands `${CLAUDE_PLUGIN_ROOT}` for a server it loads directly from a plugin manifest — a command-based server whose `command`/`args`/`env` still contains the literal token loses that expansion once copied out. Rather than implement expansion here (which would bake a station-local absolute path derived from the marketplace dir — not the installed-plugin root — into a leg-carried file), this fails closed: the function now throws a `plugin-profiles:`-prefixed error naming the server and the offending field.

- **HIMMEL-2941**: the `--mcp-servers` and `--mcp-config` CLI branches returned before the fail-closed trailing-argv loop below them, so trailing argv (e.g. an accidental `--add-plugins x@y` after `--mcp-config`) was silently ignored instead of rejected. Both branches now reject any argv beyond `argv[1]` with the same `unknown argument` / `die(2)` pattern the rest of the CLI already uses.

## Test cases (RED → GREEN)

1. `collectMcpServerDefs: refuses to copy a definition whose args reference ${CLAUDE_PLUGIN_ROOT}` — RED before, GREEN after (HIMMEL-2942)
2. `collectMcpServerDefs: refuses a ${CLAUDE_PLUGIN_ROOT} reference in command or env too` — RED before, GREEN after (HIMMEL-2942)
3. `collectMcpServerDefs: a command-based def with no ${CLAUDE_PLUGIN_ROOT} reference, and an http def, still copy through unchanged` — control, GREEN throughout
4. `CLI: --mcp-servers / --mcp-config reject trailing argv instead of silently ignoring it` — RED before, GREEN after (HIMMEL-2941)
5. `CLI: --mcp-config alone (no trailing argv) still succeeds` — control, GREEN throughout

## Verification

- Full `scripts/lanes/tests/plugin-profiles.test.mjs` suite green (`node --test --test-reporter=dot`)
- `node --check` clean on both commits
- Real-run check: `node scripts/lanes/plugin-profiles.mjs leg-impl --mcp-config` still emits the current production `qmd` (http) definition byte-identical — no regression to the existing allowlist
- Impacted sibling suite `scripts/handover/console-kit/test-headed-arm-leg.sh` — 27/27 assertions pass

## Round table

`/pr-check`: critic panel round 1/3, codex (gpt-6-astra) responded, 0 Critical / 0 Important / 0 Suggestions. codex-adv skipped (not high-risk, HIMMEL-2707). Marker cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LA9P8tqsro3JbtbdShAtve