### PR TITLE
fix(test): [HIMMEL-2902] himmel-update suites scope HIMMELCTL_CACHE_DIR and clear HIMMEL_UPDATE_CHANNEL

### DIFF
--- a/scripts/himmelctl/test/test-update-autostash.sh
+++ b/scripts/himmelctl/test/test-update-autostash.sh
@@ -43,6 +43,13 @@ SRC_SCRIPTS="$(dirname "$SCRIPT")"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# HIMMEL-2902: scope the profile lookup to this suite's own tmp dir and clear
+# any inherited channel so a station's real install profile (e.g. channel:
+# stable) cannot steer these plain-pull scenarios.
+export HIMMELCTL_CACHE_DIR="$TMP/himmelctl-cache"
+mkdir -p "$HIMMELCTL_CACHE_DIR"
+unset HIMMEL_UPDATE_CHANNEL
+
 pass=0
 fail=0
 assert_pass() { pass=$((pass + 1)); echo "  PASS: $1"; }
@@ -142,6 +149,32 @@ run_update_pull() {   # <clone> ; caller sets HIMMEL_UPDATE_AUTOSTASH in env
             "$(git stash list | wc -l | tr -d ' ')"
     )
 }
+
+# --selftest-hermetic builds one scenario and replays it through
+# run_update_pull, printing the result line — used only by the guard case
+# below, recursing into THIS file once with a controlled ambient env, never
+# the full suite.
+if [ "${1:-}" = "--selftest-hermetic" ]; then
+    build_scenario f.txt other.txt other-local
+    HIMMEL_UPDATE_AUTOSTASH=1 run_update_pull "$CLONE"
+    exit 0
+fi
+
+echo "== suite hermeticity (HIMMEL-2902) =="
+# A station's real install-profile.json (channel: stable) must not leak into
+# these plain-pull scenarios via an inherited HIMMELCTL_CACHE_DIR — this
+# recurses with a station-like profile ambient exactly the way a caller's
+# shell would carry it, before this file's own preamble override (above) runs.
+STATION_DIR="$TMP/station-profile"
+mkdir -p "$STATION_DIR"
+printf '{"channel":"stable"}\n' > "$STATION_DIR/install-profile.json"
+station="$(HIMMELCTL_CACHE_DIR="$STATION_DIR" bash "$0" --selftest-hermetic)"; station_rc=$?
+clean="$(bash "$0" --selftest-hermetic)"; clean_rc=$?
+if [ "$station_rc" -eq 0 ] && [ "$clean_rc" -eq 0 ] && [ "$station" = "$clean" ] && grepq "$station" 'status=updated'; then
+    assert_pass "suite is hermetic to a station install profile"
+else
+    assert_fail "suite is hermetic to a station install profile (station_rc=$station_rc clean_rc=$clean_rc station='$station' clean='$clean')"
+fi
 
 # ─── T1: default (env unset) + dirty → refuses ───────────────────────────────
 echo "T1: dirty tree, env unset → refuses to pull"

--- a/scripts/test-himmel-update.sh
+++ b/scripts/test-himmel-update.sh
@@ -35,6 +35,13 @@ fi
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# HIMMEL-2902: scope the profile lookup to this suite's own tmp dir and clear
+# any inherited channel so a station's real install profile (e.g. channel:
+# stable) cannot steer these plain --check scenarios.
+export HIMMELCTL_CACHE_DIR="$TMP/himmelctl-cache"
+mkdir -p "$HIMMELCTL_CACHE_DIR"
+unset HIMMEL_UPDATE_CHANNEL
+
 pass=0
 fail=0
 assert_pass() { pass=$((pass + 1)); echo "  PASS: $1"; }
@@ -112,6 +119,31 @@ make_repo_behind() {
     cp "$src_scripts/lib/load-dotenv.sh"       "$clone/scripts/lib/load-dotenv.sh"
     CHECKOUT_DIR="$clone"
 }
+
+# --selftest-hermetic builds one behind=2 mock clone and replays --check on
+# it, printing its output — used only by the guard case below, recursing into
+# THIS file once with a controlled ambient env, never the full suite.
+if [ "${1:-}" = "--selftest-hermetic" ]; then
+    make_repo_behind 2
+    bash "$CHECKOUT_DIR/scripts/himmel-update.sh" --check 2>&1
+    exit 0
+fi
+
+echo "== suite hermeticity (HIMMEL-2902) =="
+# A station's real install-profile.json (channel: stable) must not leak into
+# these plain --check scenarios via an inherited HIMMELCTL_CACHE_DIR — this
+# recurses with a station-like profile ambient exactly the way a caller's
+# shell would carry it, before this file's own preamble override (above) runs.
+STATION_DIR="$TMP/station-profile"
+mkdir -p "$STATION_DIR"
+printf '{"channel":"stable"}\n' > "$STATION_DIR/install-profile.json"
+station="$(HIMMELCTL_CACHE_DIR="$STATION_DIR" bash "$0" --selftest-hermetic)"; station_rc=$?
+clean="$(bash "$0" --selftest-hermetic)"; clean_rc=$?
+if [ "$station_rc" -eq 0 ] && [ "$clean_rc" -eq 0 ] && grepq "$station" 'behind:   2' && grepq "$clean" 'behind:   2'; then
+    assert_pass "suite is hermetic to a station install profile"
+else
+    assert_fail "suite is hermetic to a station install profile (station_rc=$station_rc clean_rc=$clean_rc station='$station' clean='$clean')"
+fi
 
 # ─── Test 1: --check, behind=2 ───────────────────────────────────────────────
 echo "Test 1: --check behind=2 → reports count + /himmel-update"

--- a/scripts/test-himmel-update.sh
+++ b/scripts/test-himmel-update.sh
@@ -126,7 +126,7 @@ make_repo_behind() {
 if [ "${1:-}" = "--selftest-hermetic" ]; then
     make_repo_behind 2
     bash "$CHECKOUT_DIR/scripts/himmel-update.sh" --check 2>&1
-    exit 0
+    exit $?
 fi
 
 echo "== suite hermeticity (HIMMEL-2902) =="


### PR DESCRIPTION
## Summary

Both `scripts/himmelctl/test/test-update-autostash.sh` and `scripts/test-himmel-update.sh` were failing on this station only — CI stays green because the runner has no install profile.

**Root cause (not the ticket's "init.defaultBranch / branch: master" hypothesis):** `himmel-update.sh`'s `_resolve_update_channel` reads env `HIMMEL_UPDATE_CHANNEL`, then the profile at `${HIMMELCTL_CACHE_DIR:-$HOME/.claude/himmel}/install-profile.json`. This station's real profile says `"channel": "stable"`. Neither suite scoped `HIMMELCTL_CACHE_DIR` in its preamble, so every case that expected the "unset channel → plain branch pull" path actually ran on `channel=stable` against a tag-less fixture: `update_pull` printed "no stable release yet — nothing to follow" (`status=skipped`), and `--check` printed a `channel:`/`branch:` line instead of `behind:`.

Fix: each suite's preamble now scopes `HIMMELCTL_CACHE_DIR` to its own fresh tmp dir and clears `HIMMEL_UPDATE_CHANNEL`, so no case can inherit a station's real profile. Cases that set either explicitly (the channel-following tests) are unchanged. Added one guard case per suite, first in file — "suite is hermetic to a station install profile" — that simulates a station profile (`{"channel":"stable"}`) ambient on the caller and asserts the suite's own preamble override wins. Pattern follows N168's `--selftest-hermetic` recursion (#649), scoped to the plain-pull scenario only, never a full-suite recursion.

`himmel-update.sh` itself is untouched — the resolver is correct; a station with a real profile should follow it.

## RED table (before fix, this station)

| suite | plain (station ambient) | control (`HIMMELCTL_CACHE_DIR=<fresh>`) |
|---|---|---|
| test-update-autostash.sh | 8 passed, 6 failed (T2×2, T3×4) | 14 passed, 0 failed |
| test-himmel-update.sh | 86 passed, 7 failed (behind×5, unset-channel×2) | 93 passed, 0 failed |

## GREEN table (after fix)

| suite | plain (station ambient) | control (fresh dir) |
|---|---|---|
| test-update-autostash.sh | 15 passed, 0 failed | 15 passed, 0 failed |
| test-himmel-update.sh | 94 passed, 0 failed | 94 passed, 0 failed |

`shellcheck -x` rc=0 on both files.

## Impacted-suite sweep

`git grep -l 'test-update-autostash\|test-himmel-update' scripts/ docs/ .github/` → only `run-shell-tests.sh` (run-list entries, doesn't source them) and comment-only mentions in sibling suites (test-himmel-update-axis-b/chain/hermes, test-check-marketplace-source-hermetic, test-cadence-format, test-update-marketplaces). `test-plugin-test.sh` is not among them, as expected. Nothing else to run.

## CR round table

| round | head | result |
|---|---|---|
| 1 | `22e226c3` | 1 Suggestion (`codex-1`: `--selftest-hermetic` swallowed a real `--check` failure as exit 0) — verified, fixed in `0d2e3a1f`, promoted to `fixed` |
| 2 | `0d2e3a1f` | clean — 0 Critical / 0 Important / 0 Suggestions |

## Out of scope

`himmel-update.sh` itself, the reds-baseline files, any other suite, the ticket's "assert on the resolved default branch" idea (`channel_checkout` already does that).

## Test plan

- [x] RED reproduced on this station before the fix
- [x] Control (`HIMMELCTL_CACHE_DIR=<fresh>`) already green, isolating the cause
- [x] Both suites green plain and with a fresh cache dir after the fix
- [x] `shellcheck -x` clean on both files
- [x] Impacted-suite sweep run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3SG63S8MA6yD3ESViLBFS
