### PR TITLE
fix(claude-hud): [HIMMEL-2944] isolate test suite from bun-specific behavior

### DIFF
--- a/marketplace/plugins/claude-hud/VENDORED.manifest
+++ b/marketplace/plugins/claude-hud/VENDORED.manifest
@@ -346,7 +346,7 @@ e08fe93072cd361cceb5049480dbd16a816532df  src/windows-git-worker.ts
 9fb0280926c9d0048c3d0f7f4a076eb27104acab  tests/claudex-lane.test.js
 9ca8b68e5e5ece7454caf319808e5ad903e32183  tests/config.test.js
 9258e1ec365f2aa55e55f18f793e444595886085  tests/context-cache.test.js
-2fcb2db7370b613fdb0d315b5a38ae3ac2ca4bbb  tests/core.test.js
+d03daa482aefa6e5298f274c07332440ce708bcd  tests/core.test.js
 d740f68a6d1a8022ab8e769fbf52ece0ea78678d  tests/cost-coverage.test.js
 57e563f59d5d435d4bd00e239b45f219c054627f  tests/custom-line-cmd.test.js
 7391d19f97cafb89d51a0fb39423459c3e5304d8  tests/daily-cost.test.js
@@ -363,7 +363,7 @@ d1c485d742ba019e64c22aa5c1b0e3a90a14159b  tests/git-runner.test.js
 62755edd38e81af7e2230b5ce521b7e459b5a04a  tests/git.test.js
 edc35d9c69a071a5eb77720c3b5912d59ffa42f6  tests/i18n.test.js
 3fd1825c8c1940bcade7b34fb97d1599f389f59d  tests/identity-coverage.test.js
-9f00f99c70e0e3de8e52dc02589f5cee94ffa469  tests/index.test.js
+a99fd9e192b1dc0c699b756eafc9cdac81665c1d  tests/index.test.js
 82c0691ad72f9262cf87c86754b35130a3f6f5ec  tests/integration.test.js
 ec57a4788527bb09049b8d3e8a57576ae8371a2d  tests/jj.test.js
 97eea31e309ace99950a6bb76baf3bf970d4da07  tests/label-align.test.js

--- a/marketplace/plugins/claude-hud/VENDORED.manifest
+++ b/marketplace/plugins/claude-hud/VENDORED.manifest
@@ -346,7 +346,7 @@ e08fe93072cd361cceb5049480dbd16a816532df  src/windows-git-worker.ts
 9fb0280926c9d0048c3d0f7f4a076eb27104acab  tests/claudex-lane.test.js
 9ca8b68e5e5ece7454caf319808e5ad903e32183  tests/config.test.js
 9258e1ec365f2aa55e55f18f793e444595886085  tests/context-cache.test.js
-d03daa482aefa6e5298f274c07332440ce708bcd  tests/core.test.js
+5233f557606d8075ec74efaf2e08b00bf4908342  tests/core.test.js
 d740f68a6d1a8022ab8e769fbf52ece0ea78678d  tests/cost-coverage.test.js
 57e563f59d5d435d4bd00e239b45f219c054627f  tests/custom-line-cmd.test.js
 7391d19f97cafb89d51a0fb39423459c3e5304d8  tests/daily-cost.test.js
@@ -363,7 +363,7 @@ d1c485d742ba019e64c22aa5c1b0e3a90a14159b  tests/git-runner.test.js
 62755edd38e81af7e2230b5ce521b7e459b5a04a  tests/git.test.js
 edc35d9c69a071a5eb77720c3b5912d59ffa42f6  tests/i18n.test.js
 3fd1825c8c1940bcade7b34fb97d1599f389f59d  tests/identity-coverage.test.js
-a99fd9e192b1dc0c699b756eafc9cdac81665c1d  tests/index.test.js
+fb70eb84946c5dba7879997c50ca7b62ecacc474  tests/index.test.js
 82c0691ad72f9262cf87c86754b35130a3f6f5ec  tests/integration.test.js
 ec57a4788527bb09049b8d3e8a57576ae8371a2d  tests/jj.test.js
 97eea31e309ace99950a6bb76baf3bf970d4da07  tests/label-align.test.js

--- a/marketplace/plugins/claude-hud/VENDORED.md
+++ b/marketplace/plugins/claude-hud/VENDORED.md
@@ -16,7 +16,7 @@ fork_repo:            https://github.com/yotamleo/claude-hud   # public fork (HI
 upstream_repo:        https://github.com/jarrodwatts/claude-hud
 pinned_commit:        939eb66485832dead1b0a28a954f76f7aa2bdb06  # main HEAD (HIMMEL-2274, issue #518)
 pinned_upstream_tree: a9f550fa2eee50682133bc654caaa8a951cf3483  # git tree of pinned_commit (provenance)
-vendored_tree_hash:   7293cd093d8d29d8d016e613a0d80f8eeec284adb639cf87404cbc6f8b5dbdf0  # sha256 over VENDORED.manifest
+vendored_tree_hash:   fdc1f10bf6ada8051cb67498590fd7782dff76b4e29a151895bf7398d9f8f458  # sha256 over VENDORED.manifest
 vendored_at:          2026-08-30
 ```
 
@@ -82,6 +82,16 @@ protected: editing it without bumping the pin trips the guard.
   treats each query as a distinct module) — fixed by spawning a real
   `node dist/index.js` child process, matching the plugin's other CLI
   tests. No `src/`/`dist/` change; pin bump is test-file-only.
+  **CR round 1 follow-up:** the `spyOn` fix's static `import { spyOn } from
+  'bun:test'` broke `npm test` (`node --test`) with
+  `ERR_UNSUPPORTED_ESM_URL_SCHEME`, since `bun:test` isn't resolvable under
+  plain Node — fixed by loading it dynamically and only when
+  `typeof Bun !== 'undefined'`, falling back to plain `process.env.HOME`
+  mutation under Node (safe there, since Node's `os.homedir()` re-reads
+  `HOME` on every call). Also added the missing `result.status === 0`
+  assertion to the spawned-child test, matching every other `spawnSync`
+  test in `tests/integration.test.js`. Verified green under both
+  `node --test` and `bun test`.
 
 - **Landed (Phase 3.3, HIMMEL-718, `extra-cmd`=B — see the plan §Decisions):** a
   generic `customLineCommand` capability. When `display.customLineCommand` is set

--- a/marketplace/plugins/claude-hud/VENDORED.md
+++ b/marketplace/plugins/claude-hud/VENDORED.md
@@ -16,7 +16,7 @@ fork_repo:            https://github.com/yotamleo/claude-hud   # public fork (HI
 upstream_repo:        https://github.com/jarrodwatts/claude-hud
 pinned_commit:        939eb66485832dead1b0a28a954f76f7aa2bdb06  # main HEAD (HIMMEL-2274, issue #518)
 pinned_upstream_tree: a9f550fa2eee50682133bc654caaa8a951cf3483  # git tree of pinned_commit (provenance)
-vendored_tree_hash:   c8f103ce089d7b14a23075be81842bf7c1a497aed79da23f4541d8f5f2768e52  # sha256 over VENDORED.manifest
+vendored_tree_hash:   7293cd093d8d29d8d016e613a0d80f8eeec284adb639cf87404cbc6f8b5dbdf0  # sha256 over VENDORED.manifest
 vendored_at:          2026-08-30
 ```
 
@@ -63,6 +63,25 @@ protected: editing it without bumping the pin trips the guard.
 > makes the drift guard protect *more* upstream files, not fewer.
 
 ## Fork delta
+
+- **Test-only station isolation fixes (HIMMEL-2944, 2026-09-12):** two bugs in
+  `tests/core.test.js` / `tests/index.test.js` made `bun test` fail on any
+  station with a populated `~/.claude.json` (19 cases), even though the
+  suite is green in CI (it never runs there — network-bound, excluded by
+  `scripts/ci/run-shell-tests.sh`). (1) 18 `countConfigs` fixtures mutated
+  `process.env.HOME` to redirect the counter at a fixture temp dir, but
+  bun's `os.homedir()` reads `HOME` once at process startup and never
+  re-reads it (Node's does) — fixed with a shared `withHome(homeDir)`
+  helper that `spyOn(os, 'homedir')` (`bun:test`) instead, which works
+  because `config-reader.ts` already does a namespace import
+  (`import * as os from 'node:os'`) that `spyOn` can intercept. (2) the
+  entrypoint test relied on re-importing `dist/index.js` with a
+  cache-busting query string to force a second module evaluation, but
+  bun's dynamic `import()` resolves distinct query strings to the same
+  cached module and evaluates it only once per process (Node's ESM loader
+  treats each query as a distinct module) — fixed by spawning a real
+  `node dist/index.js` child process, matching the plugin's other CLI
+  tests. No `src/`/`dist/` change; pin bump is test-file-only.
 
 - **Landed (Phase 3.3, HIMMEL-718, `extra-cmd`=B — see the plan §Decisions):** a
   generic `customLineCommand` capability. When `display.customLineCommand` is set

--- a/marketplace/plugins/claude-hud/tests/core.test.js
+++ b/marketplace/plugins/claude-hud/tests/core.test.js
@@ -1,5 +1,4 @@
 import { test } from 'node:test';
-import { spyOn } from 'bun:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, readFile, readdir, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -14,6 +13,11 @@ import { getContextPercent, getBufferedPercent, getModelName, getProviderLabel, 
 import { estimateSessionCost, resolveSessionCost, formatUsd } from '../dist/cost.js';
 import * as fs from 'node:fs';
 
+// bun:test is only importable under bun; a static import breaks `node --test`
+// (npm test) with ERR_UNSUPPORTED_ESM_URL_SCHEME, so it's loaded dynamically
+// and only when actually running under bun.
+const bunSpyOn = typeof Bun !== 'undefined' ? (await import('bun:test')).spyOn : null;
+
 function restoreEnvVar(name, value) {
   if (value === undefined) {
     delete process.env[name];
@@ -24,15 +28,16 @@ function restoreEnvVar(name, value) {
 
 // bun's os.homedir() caches process.env.HOME at process startup and ignores
 // later mutations (unlike Node's, which reads it fresh every call), so
-// countConfigs()'s internal os.homedir() calls need a real spy, not just an
-// env var mutation, to pick up a fixture's temp home dir under bun test.
+// countConfigs()'s internal os.homedir() calls need a real spy under bun
+// test; under Node, os.homedir() re-reads HOME on every call, so the env
+// mutation alone is enough there.
 function withHome(homeDir) {
   const originalHome = process.env.HOME;
-  const homedirSpy = spyOn(os, 'homedir').mockReturnValue(homeDir);
+  const homedirSpy = bunSpyOn ? bunSpyOn(os, 'homedir').mockReturnValue(homeDir) : null;
   process.env.HOME = homeDir;
   return {
     restore() {
-      homedirSpy.mockRestore();
+      homedirSpy?.mockRestore();
       restoreEnvVar('HOME', originalHome);
     },
   };

--- a/marketplace/plugins/claude-hud/tests/core.test.js
+++ b/marketplace/plugins/claude-hud/tests/core.test.js
@@ -1,7 +1,9 @@
 import { test } from 'node:test';
+import { spyOn } from 'bun:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, readFile, readdir, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
+import * as os from 'node:os';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -18,6 +20,22 @@ function restoreEnvVar(name, value) {
     return;
   }
   process.env[name] = value;
+}
+
+// bun's os.homedir() caches process.env.HOME at process startup and ignores
+// later mutations (unlike Node's, which reads it fresh every call), so
+// countConfigs()'s internal os.homedir() calls need a real spy, not just an
+// env var mutation, to pick up a fixture's temp home dir under bun test.
+function withHome(homeDir) {
+  const originalHome = process.env.HOME;
+  const homedirSpy = spyOn(os, 'homedir').mockReturnValue(homeDir);
+  process.env.HOME = homeDir;
+  return {
+    restore() {
+      homedirSpy.mockRestore();
+      restoreEnvVar('HOME', originalHome);
+    },
+  };
 }
 
 async function getTranscriptCacheFile(configDir) {
@@ -2247,8 +2265,7 @@ test('parseTranscript invalidates transcript cache entries from older cache vers
 test('countConfigs honors project and global config locations', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
   const projectDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-project-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude', 'rules', 'nested'), { recursive: true });
@@ -2282,7 +2299,7 @@ test('countConfigs honors project and global config locations', async () => {
     assert.equal(counts.mcpCount, 4);
     assert.equal(counts.hooksCount, 2);
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
     await rm(projectDir, { recursive: true, force: true });
   }
@@ -2415,8 +2432,7 @@ test('countConfigs still counts project .claude when cwd is home and CLAUDE_CONF
 
 test('countConfigs avoids home cwd double-counting across counters and keeps CLAUDE.local.md', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude', 'rules'), { recursive: true });
@@ -2441,15 +2457,14 @@ test('countConfigs avoids home cwd double-counting across counters and keeps CLA
     assert.equal(trailingSlashCounts.mcpCount, 1);
     assert.equal(trailingSlashCounts.hooksCount, 1);
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });
 
 test('countConfigs excludes disabled user-scope MCPs', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -2469,7 +2484,7 @@ test('countConfigs excludes disabled user-scope MCPs', async () => {
     const counts = await countConfigs();
     assert.equal(counts.mcpCount, 2); // 3 - 1 disabled = 2
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });
@@ -2477,8 +2492,7 @@ test('countConfigs excludes disabled user-scope MCPs', async () => {
 test('countConfigs excludes disabled project .mcp.json servers', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
   const projectDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-project-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -2500,7 +2514,7 @@ test('countConfigs excludes disabled project .mcp.json servers', async () => {
     const counts = await countConfigs(projectDir);
     assert.equal(counts.mcpCount, 2); // 4 - 2 disabled = 2
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
     await rm(projectDir, { recursive: true, force: true });
   }
@@ -2508,8 +2522,7 @@ test('countConfigs excludes disabled project .mcp.json servers', async () => {
 
 test('countConfigs handles all MCPs disabled', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -2529,7 +2542,7 @@ test('countConfigs handles all MCPs disabled', async () => {
     const counts = await countConfigs();
     assert.equal(counts.mcpCount, 0); // All disabled
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });
@@ -2612,8 +2625,7 @@ test('countConfigs skips dangling links, cycles, and duplicate symlink targets',
 
 test('countConfigs ignores non-string values in disabledMcpServers', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -2633,7 +2645,7 @@ test('countConfigs ignores non-string values in disabledMcpServers', async () =>
     const counts = await countConfigs();
     assert.equal(counts.mcpCount, 2); // Only 'server2' disabled, server1 and server3 remain
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });
@@ -2641,8 +2653,7 @@ test('countConfigs ignores non-string values in disabledMcpServers', async () =>
 test('countConfigs counts same-named servers in different scopes separately', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
   const projectDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-project-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -2666,7 +2677,7 @@ test('countConfigs counts same-named servers in different scopes separately', as
     // 'shared-server' counted in BOTH scopes (user + project) = 4 total
     assert.equal(counts.mcpCount, 4);
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
     await rm(projectDir, { recursive: true, force: true });
   }
@@ -2674,8 +2685,7 @@ test('countConfigs counts same-named servers in different scopes separately', as
 
 test('countConfigs uses case-sensitive matching for disabled servers', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -2696,7 +2706,7 @@ test('countConfigs uses case-sensitive matching for disabled servers', async () 
     // Both servers should still be enabled (case mismatch means not disabled)
     assert.equal(counts.mcpCount, 2);
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });
@@ -2706,8 +2716,7 @@ test('countConfigs uses case-sensitive matching for disabled servers', async () 
 // https://github.com/jarrodwatts/claude-hud/issues/3
 test('Issue #3: MCP count updates correctly when servers are disabled', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-home-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -2770,7 +2779,7 @@ test('Issue #3: MCP count updates correctly when servers are disabled', async ()
     counts = await countConfigs();
     assert.equal(counts.mcpCount, 0, 'Should show 0 MCPs when all are disabled');
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });
@@ -2783,8 +2792,7 @@ async function getConfigCacheDir(configDir) {
 
 test('countConfigs cache: second call uses cache (mtime unchanged)', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-cc-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -2817,15 +2825,14 @@ test('countConfigs cache: second call uses cache (mtime unchanged)', async () =>
     assert.equal(second.claudeMdCount, 1);
     assert.equal(second.mcpCount, 1);
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });
 
 test('countConfigs cache: miss on file modification (mtime changes)', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-cc-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -2852,15 +2859,14 @@ test('countConfigs cache: miss on file modification (mtime changes)', async () =
     const second = await countConfigs();
     assert.equal(second.mcpCount, 3, 'Should detect updated settings.json');
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });
 
 test('countConfigs cache: miss on file creation (CLAUDE.md appears)', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-cc-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -2874,15 +2880,14 @@ test('countConfigs cache: miss on file creation (CLAUDE.md appears)', async () =
     const second = await countConfigs();
     assert.equal(second.claudeMdCount, 1, 'Should detect newly created CLAUDE.md');
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });
 
 test('countConfigs cache: miss on file deletion (CLAUDE.md removed)', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-cc-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -2897,7 +2902,7 @@ test('countConfigs cache: miss on file deletion (CLAUDE.md removed)', async () =
     const second = await countConfigs();
     assert.equal(second.claudeMdCount, 0, 'Should detect deleted CLAUDE.md');
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });
@@ -2931,8 +2936,7 @@ test('countConfigs cache: isolation between different cwds', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-cc-'));
   const projectA = await mkdtemp(path.join(tmpdir(), 'claude-hud-projA-'));
   const projectB = await mkdtemp(path.join(tmpdir(), 'claude-hud-projB-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -2950,7 +2954,7 @@ test('countConfigs cache: isolation between different cwds', async () => {
     const cacheFiles = fs.readdirSync(cacheDir);
     assert.ok(cacheFiles.length >= 2, 'Should have separate cache files for different cwds');
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
     await rm(projectA, { recursive: true, force: true });
     await rm(projectB, { recursive: true, force: true });
@@ -2988,8 +2992,7 @@ test('countConfigs cache: isolation between different CLAUDE_CONFIG_DIRs', async
 
 test('countConfigs cache: corrupted cache file handled gracefully', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-cc-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -3010,15 +3013,14 @@ test('countConfigs cache: corrupted cache file handled gracefully', async () => 
     const second = await countConfigs();
     assert.equal(second.claudeMdCount, 1, 'Should recompute correctly after cache corruption');
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });
 
 test('countConfigs cache: malformed cache payload falls back to fresh recompute', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-cc-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -3058,15 +3060,14 @@ test('countConfigs cache: malformed cache payload falls back to fresh recompute'
     assert.equal(second.mcpCount, 0);
     assert.equal(second.hooksCount, 0);
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });
 
 test('countConfigs cache: first invocation without cache dir', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-cc-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -3089,15 +3090,14 @@ test('countConfigs cache: first invocation without cache dir', async () => {
     // Cache dir should now be created
     assert.ok(fs.existsSync(cacheDir), 'config-cache should be created after first call');
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });
 
 test('countConfigs cache: works without cwd (user scope only)', async () => {
   const homeDir = await mkdtemp(path.join(tmpdir(), 'claude-hud-cc-'));
-  const originalHome = process.env.HOME;
-  process.env.HOME = homeDir;
+  const home = withHome(homeDir);
 
   try {
     await mkdir(path.join(homeDir, '.claude'), { recursive: true });
@@ -3122,7 +3122,7 @@ test('countConfigs cache: works without cwd (user scope only)', async () => {
     assert.equal(second.claudeMdCount, 1);
     assert.equal(second.mcpCount, 2);
   } finally {
-    process.env.HOME = originalHome;
+    home.restore();
     await rm(homeDir, { recursive: true, force: true });
   }
 });

--- a/marketplace/plugins/claude-hud/tests/index.test.js
+++ b/marketplace/plugins/claude-hud/tests/index.test.js
@@ -174,6 +174,7 @@ test("index entrypoint runs when executed directly", async (t) => {
     if (skipIfSpawnBlocked(result, t)) return;
 
     assert.equal(result.error, undefined, result.error?.message);
+    assert.equal(result.status, 0, result.stderr || "non-zero exit");
     assert.ok(
       result.stdout.includes("[claude-hud] Initializing..."),
       result.stderr || result.stdout,

--- a/marketplace/plugins/claude-hud/tests/index.test.js
+++ b/marketplace/plugins/claude-hud/tests/index.test.js
@@ -1,19 +1,19 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import { tmpdir } from "node:os";
-import { fileURLToPath } from "node:url";
 import { DEFAULT_CONFIG } from "../dist/config.js";
 import { setLanguage } from "../dist/i18n/index.js";
 import { formatSessionDuration, main, resolveVcsStatus } from "../dist/index.js";
 
-function restoreEnvVar(name, value) {
-  if (value === undefined) {
-    delete process.env[name];
-    return;
+function skipIfSpawnBlocked(result, t) {
+  if (result.error?.code === "EPERM") {
+    t.skip("spawnSync is blocked by sandbox policy in this environment");
+    return true;
   }
-  process.env[name] = value;
+  return false;
 }
 
 function makeConfig(overrides = {}) {
@@ -151,38 +151,36 @@ test("main logs unknown error for non-Error throws", async () => {
   assert.ok(logs.some((line) => line.includes("Unknown error")));
 });
 
-test("index entrypoint runs when executed directly", async () => {
-  const originalArgv = [...process.argv];
-  const originalIsTTY = process.stdin.isTTY;
-  const originalLog = console.log;
-  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
-  const logs = [];
+test("index entrypoint runs when executed directly", async (t) => {
+  // bun's dynamic import() resolves distinct query-string suffixes to the
+  // same cached module and evaluates its top-level code only once per
+  // process (unlike Node's ESM loader, which treats each query string as a
+  // fresh module registration) — so the old re-import-with-cache-buster
+  // idiom can't force a second run of dist/index.js's auto-invoke guard
+  // under bun test. Spawning a real `node dist/index.js` child process (the
+  // plugin's actual documented invocation, matching the other CLI tests in
+  // tests/integration.test.js) sidesteps that entirely: each spawn is a
+  // fresh process with its own module graph.
   const { dir, cleanup } = await createTempConfigDir({ language: "en" });
 
   try {
-    process.env.CLAUDE_CONFIG_DIR = dir;
-    setLanguage("en");
-    const moduleUrl = new URL("../dist/index.js", import.meta.url);
-    process.argv[1] = fileURLToPath(moduleUrl);
-    Object.defineProperty(process.stdin, "isTTY", {
-      value: true,
-      configurable: true,
+    const result = spawnSync("node", ["dist/index.js"], {
+      cwd: path.resolve(process.cwd()),
+      input: "",
+      encoding: "utf8",
+      env: { ...process.env, CLAUDE_CONFIG_DIR: dir, LANG: "C" },
     });
-    console.log = (...args) => logs.push(args.join(" "));
-    await import(`${moduleUrl}?entry=${Date.now()}`);
-    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    if (skipIfSpawnBlocked(result, t)) return;
+
+    assert.equal(result.error, undefined, result.error?.message);
+    assert.ok(
+      result.stdout.includes("[claude-hud] Initializing..."),
+      result.stderr || result.stdout,
+    );
   } finally {
-    console.log = originalLog;
-    process.argv = originalArgv;
-    restoreEnvVar("CLAUDE_CONFIG_DIR", originalConfigDir);
-    Object.defineProperty(process.stdin, "isTTY", {
-      value: originalIsTTY,
-      configurable: true,
-    });
     await cleanup();
   }
-
-  assert.ok(logs.some((line) => line.includes("[claude-hud] Initializing...")));
 });
 
 test("main executes the happy path", async () => {


### PR DESCRIPTION
## Summary
- Isolates `marketplace/plugins/claude-hud`'s test suite from bun-specific behavior that diverges from Node, so `npm test` (`node --test`) passes cleanly and matches how the suite runs under bun.
- `os.homedir()` caching: bun caches `os.homedir()`'s read of `HOME` at process startup and never re-reads it, unlike Node, which re-reads `HOME` on every call. `tests/core.test.js`'s `withHome()` helper now spies on `os.homedir()` under bun (via `bun:test`'s `spyOn`) in addition to mutating `process.env.HOME`, so `countConfigs()`'s internal `os.homedir()` calls see the right value under both runtimes.
- Entrypoint test: `tests/index.test.js`'s "index entrypoint runs when executed directly" test now spawns a real child process instead of relying on bun's dynamic `import()` query-string cache-busting (which Node's ESM loader doesn't support the same way).
- CR round-1 follow-up: the first fix's `withHome()` used a static top-level `import { spyOn } from 'bun:test'`, which throws `ERR_UNSUPPORTED_ESM_URL_SCHEME` under `node --test` — breaking the plugin's own documented `npm test` script. Now loaded via a top-level-await dynamic `import('bun:test')` gated on `typeof Bun !== 'undefined'`, so it resolves to `null` (and the code falls back to plain env mutation, which is correct under Node) rather than throwing.
- `tests/index.test.js` also gained a `result.status === 0` assertion on the entrypoint test, matching the convention every other `spawnSync` test in `tests/integration.test.js` already follows.
- Test-only change (no `src/`/`dist/` diff); the vendored-fork drift guard's `VENDORED.md`/`VENDORED.manifest` are updated accordingly.

## Test plan
- [x] `bash scripts/plugin-test.sh claude-hud` — 1123 pass / 0 fail (1129 across 38 files, pre-existing skips unchanged)
- [x] `node --test tests/core.test.js` — 156/156 pass
- [x] `node --test tests/index.test.js` — 34/34 pass
- [x] Reproduced `ERR_UNSUPPORTED_ESM_URL_SCHEME` on the pre-fix `bun:test` static import under plain `node --test`, confirmed the dynamic-import fix resolves it
- [x] `/pr-check` CR gate: 2 rounds, falling severity (round 1: 1 Important fixed + 1 Suggestion fixed + 1 Suggestion disproved; round 2: 0 Critical/Important, 1 Suggestion disproved as a restatement) — converged, marker cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTE7oLK8L9toNGoJb4rCaq
