### PR TITLE
docs(upstream-file): step 4 builds in a linked worktree, unshallows before the CR pre-push gate [HIMMEL-2926]

### DIFF
--- a/.claude/commands/upstream-file.md
+++ b/.claude/commands/upstream-file.md
@@ -130,9 +130,30 @@ distinguishes from self-verification).
   create it (`gh repo fork <upstream> --clone=false`) before cloning.
 - Toolchain preconditions first: verify the repo's build/test tools exist
   (`bun`/`node`/`make`/python — read its CI + CONTRIBUTING) before cloning.
-- Fresh clone; branch cut from **current upstream default branch** — never from
-  the fork's own drifted main. Two PRs → two independent clones (no
-  shared-worktree resets; each branch provably cut from clean main).
+- Fresh clone, **full depth** (never `--depth 1` — a shallow clone breaks the
+  CR pre-push gate later, see below); branch cut from **current upstream
+  default branch** — never from the fork's own drifted main. Two PRs → two
+  independent clones (no shared-worktree resets; each branch provably cut
+  from clean main).
+- **Build in a linked worktree of the clone, never in the clone itself**
+  (HIMMEL-2926): the clone is a primary checkout, so the first edit inside it
+  is refused by `block-edit-on-main` (worktree-isolation shape). Cut a linked
+  worktree and edit there instead: `git -C <clone-path> worktree add
+  <clone-path>-wt-<slug> -b <branch> origin/<default>`. The clone itself
+  stays detached at `origin/<default>`; the worktree
+  (`<clone-path>-wt-<slug>`) is the cwd for every edit and for the separate
+  `/pr-check` session below. The clone's own `.single-writer` opt-out does
+  **not** fix this — `block-write-into-main-checkout` refuses to create that
+  file in the clone too (HIMMEL-2946, filed, unresolved); don't try it.
+- **Depth rule:** if you're starting from an existing `--depth 1` clone,
+  `git fetch --unshallow origin` then `git fetch fork` BEFORE step 6's push.
+  A shallow clone shares no history with the fork, so the CR pre-push gate
+  refuses twice: first `no tracking ref refs/remotes/fork/main for pushed
+  remote 'fork'` (its own remedy: `git fetch fork`), then `cannot compute
+  diff vs refs/remotes/fork/main (<sha>) … no merge base` (remedy: unshallow
+  origin, re-fetch fork, retry the push once — no `SKIP_CR`, no
+  `--no-verify`). Recognise both texts verbatim; cloning full depth up front
+  avoids hitting them at all.
 - **Never cherry-pick a fork/vendored commit** — not even `-n`. Hand-apply the
   hunks and author a fresh commit message in the upstream repo's own style.
   Fork commits carry internal ticket IDs and internal diff context; a
@@ -315,3 +336,5 @@ after publication as redundant defense only.
 | Testing only after the change | Without a clean-main baseline you can't attribute failures. Baseline → change → parity. |
 | Dupe-checking only open PRs | Closed PRs, issues, and dependabot PRs are where the dupes live. `--state all`, issues AND PRs. |
 | Auto-picking the security channel | Disclosure under the operator's identity is not retractable. Draft; operator submits. |
+| Editing straight in the throwaway clone | It's a primary checkout on main; `block-edit-on-main` refuses the first edit. Build in a linked worktree instead. |
+| Cloning `--depth 1` and pushing to the fork later | No merge base with the fork means the CR pre-push gate refuses twice. Clone full depth, or unshallow before step 6. |

--- a/.claude/commands/upstream-file.md
+++ b/.claude/commands/upstream-file.md
@@ -292,8 +292,10 @@ after publication as redundant defense only.
 
 ## 6. File
 
-- Push to the EXISTING fork (`git remote add fork <fork-url>`; `git fetch
-  fork`; `git push -u fork <branch>`); open cross-fork PRs: `gh pr create --repo <upstream> --head
+- Push to the EXISTING fork (`git remote add fork <fork-url>` — skip this if
+  the depth-rule recovery above already added it, or `git remote add fork`
+  errors "remote fork already exists"; `git fetch fork`; `git push -u fork
+  <branch>`); open cross-fork PRs: `gh pr create --repo <upstream> --head
   <fork-owner>:<branch> --title "<title>" --body-file <path>` (body via file,
   never inline; `--title` is required — `gh pr create` errors non-interactively
   without it). `--head <user>:<branch>` takes the fork's OWNER login, not an

--- a/.claude/commands/upstream-file.md
+++ b/.claude/commands/upstream-file.md
@@ -138,9 +138,12 @@ distinguishes from self-verification).
 - **Build in a linked worktree of the clone, never in the clone itself**
   (HIMMEL-2926): the clone is a primary checkout, so the first edit inside it
   is refused by `block-edit-on-main` (worktree-isolation shape). Cut a linked
-  worktree and edit there instead: `git -C <clone-path> worktree add
-  <clone-path>-wt-<slug> -b <branch> origin/<default>`. The clone itself
-  stays detached at `origin/<default>`; the worktree
+  worktree and edit there instead: `git -C <clone-path> checkout --detach
+  origin/<default>` (a fresh clone starts on a local `<default>` branch, not
+  detached — do this first so the claim below holds), then `git -C
+  <clone-path> worktree add <clone-path>-wt-<slug> -b <branch>
+  origin/<default>`. The clone itself now sits detached at
+  `origin/<default>`; the worktree
   (`<clone-path>-wt-<slug>`) is the cwd for every edit and for the separate
   `/pr-check` session below. The clone's own `.single-writer` opt-out does
   **not** fix this — `block-write-into-main-checkout` refuses to create that
@@ -154,8 +157,11 @@ distinguishes from self-verification).
   refs/remotes/fork/main for pushed remote 'fork'` (its own remedy: `git
   fetch fork`), then `cannot compute diff vs refs/remotes/fork/main (<sha>)
   … no merge base` (remedy: unshallow origin, re-fetch fork, retry the push
-  once — no `SKIP_CR`, no `--no-verify`). Recognise both texts verbatim;
-  cloning full depth up front avoids hitting them at all.
+  once — no `SKIP_CR`, no `--no-verify`). Recognise both texts verbatim.
+  Cloning full depth up front avoids the merge-base failure, but not the
+  missing-tracking-ref one — that one only goes away once `fork` is added
+  and fetched, which step 6 does before its first push regardless of clone
+  depth.
 - **Never cherry-pick a fork/vendored commit** — not even `-n`. Hand-apply the
   hunks and author a fresh commit message in the upstream repo's own style.
   Fork commits carry internal ticket IDs and internal diff context; a
@@ -286,8 +292,8 @@ after publication as redundant defense only.
 
 ## 6. File
 
-- Push to the EXISTING fork (`git remote add fork <fork-url>`; `git push -u
-  fork <branch>`); open cross-fork PRs: `gh pr create --repo <upstream> --head
+- Push to the EXISTING fork (`git remote add fork <fork-url>`; `git fetch
+  fork`; `git push -u fork <branch>`); open cross-fork PRs: `gh pr create --repo <upstream> --head
   <fork-owner>:<branch> --title "<title>" --body-file <path>` (body via file,
   never inline; `--title` is required — `gh pr create` errors non-interactively
   without it). `--head <user>:<branch>` takes the fork's OWNER login, not an

--- a/.claude/commands/upstream-file.md
+++ b/.claude/commands/upstream-file.md
@@ -146,14 +146,16 @@ distinguishes from self-verification).
   **not** fix this — `block-write-into-main-checkout` refuses to create that
   file in the clone too (HIMMEL-2946, filed, unresolved); don't try it.
 - **Depth rule:** if you're starting from an existing `--depth 1` clone,
-  `git fetch --unshallow origin` then `git fetch fork` BEFORE step 6's push.
-  A shallow clone shares no history with the fork, so the CR pre-push gate
-  refuses twice: first `no tracking ref refs/remotes/fork/main for pushed
-  remote 'fork'` (its own remedy: `git fetch fork`), then `cannot compute
-  diff vs refs/remotes/fork/main (<sha>) … no merge base` (remedy: unshallow
-  origin, re-fetch fork, retry the push once — no `SKIP_CR`, no
-  `--no-verify`). Recognise both texts verbatim; cloning full depth up front
-  avoids hitting them at all.
+  `git remote add fork <fork-url>` (step 6's remote, added here early — a
+  bare `git fetch fork` with no `fork` remote configured fails before the
+  gate even runs), then `git fetch --unshallow origin`, then `git fetch fork`
+  BEFORE step 6's push. A shallow clone shares no history with the fork, so
+  the CR pre-push gate refuses twice: first `no tracking ref
+  refs/remotes/fork/main for pushed remote 'fork'` (its own remedy: `git
+  fetch fork`), then `cannot compute diff vs refs/remotes/fork/main (<sha>)
+  … no merge base` (remedy: unshallow origin, re-fetch fork, retry the push
+  once — no `SKIP_CR`, no `--no-verify`). Recognise both texts verbatim;
+  cloning full depth up front avoids hitting them at all.
 - **Never cherry-pick a fork/vendored commit** — not even `-n`. Hand-apply the
   hunks and author a fresh commit message in the upstream repo's own style.
   Fork commits carry internal ticket IDs and internal diff context; a
@@ -168,7 +170,9 @@ distinguishes from self-verification).
   to our own repos.
 - **Baseline before change:** run the repo's OWN gates (its lint + test
   scripts, from its `package.json`/`Makefile`/CI — not assumed equivalents) on
-  the clean clone first, redirected (never piped through `tee` — that makes
+  the clean clone first (a read-only run — no edits — so this is the one
+  explicit exception to "never build in the clone itself" above; it needs no
+  worktree), redirected (never piped through `tee` — that makes
   `$?` tee's exit code and can mask a failing gate): `<gate-cmd> >
   <scratchpad>/<name>.log 2>&1; rc=$?`, writing the log to the scratchpad,
   NEVER into the clone (release tooling and CI reject dirty trees). A non-zero
@@ -186,8 +190,11 @@ distinguishes from self-verification).
   (HIMMEL-2226, operator ruling 2026-08-31) — cwd alone selects the repo
   under review, and no `cd` can stand in for that, so the review is NOT a
   continuation of the session that just built and armed the clone. Start a
-  **separate session whose cwd IS `<clone-path>`** and run a bare
-  `/pr-check` there; its 0a-adopter step resolves the himmel scripts from
+  **separate session whose cwd IS `<clone-path>-wt-<slug>`** (the linked
+  worktree, never the detached clone — `/pr-check` selects the repo, branch
+  and `HEAD` from its own session cwd, and the clone itself has no branch
+  checked out) and run a bare `/pr-check` there; its 0a-adopter step
+  resolves the himmel scripts from
   the gate just armed above. This is in addition to the adversarial review
   on security fixes (step 3), not instead of it.
 


### PR DESCRIPTION
## Summary

The first fully-gated cross-fork PR filing (HIMMEL-2426 leg N152, 2026-09-11) hit three gaps in `.claude/commands/upstream-file.md` step 4 ("Build"). This PR closes the two DOCS gaps; the third is a hook-side fix deferred to a follow-up ticket.

1. **Gap 1 (closed here)** — step 4 cloned upstream and cut the feature branch directly in that clone. The clone is a primary checkout, so the first `Edit` there was refused by `block-edit-on-main` (worktree-isolation shape). **Fix:** step 4 now prescribes cutting the branch in a **linked worktree** of the throwaway clone (`git -C <clone> worktree add <clone>-wt-<slug> -b <branch> origin/<default>`), with the clone itself left detached at `origin/<default>` and the worktree used as the cwd for the session that runs `/pr-check`.
2. **Gap 3 (closed here)** — the runbook's `--depth 1` shallow clone has no merge base with the fork, so the CR pre-push gate refused the cross-fork push twice ("no tracking ref refs/remotes/fork/main", then "cannot compute diff vs refs/remotes/fork/main … no merge base"). **Fix:** step 4 now prescribes cloning full depth, or running `git fetch --unshallow origin` + `git fetch fork` before step 6's push if a shallow clone already exists. Verified live on N152: after unshallowing, merge-base resolved (`fd760435`) and the third push was accepted with no `SKIP_CR`.
3. **Gap 2 (deferred, NOT in this PR)** — `block-write-into-main-checkout` refuses `touch <repo>/.single-writer`, the opt-out the hook itself recommends. This is a hook-side fix that collides with a concurrently-live leg (HIMMEL-2884) on the same hook, so it's out of scope here. Filed as a follow-up: **HIMMEL-2946** ("block-write-into-main-checkout: exempt repo-root .single-writer or stop recommending it"). Step 4 now has a one-line pointer telling the reader not to attempt the `.single-writer` remedy and citing HIMMEL-2946 instead.

## CR round table

- Lane: docs-audit (lighter charter — accuracy / dead-links / staleness / examples / consistency).
- Round 1 (head `ab383bf4`): CodeRabbit App review raised 3 threads; all 3 verified against the file and fixed in that same commit. docs-audit critic panel raised 2 Suggestions (clone-detach claim inaccurate; full-depth doesn't avoid the missing-tracking-ref failure) — both verified real and fixed in `64fbb445`.
- Round 2 (head `64fbb445`): docs-audit critic panel raised 1 further Suggestion (step 6's fork remote may already exist from the depth-rule recovery) — verified and fixed in `a0b5e0be`.
- Round 3 (head `a0b5e0be`, current): docs-audit critic panel → **0 Critical, 0 Important, 0 Suggestions** — converged. All 3 original CodeRabbit review threads resolved via GraphQL (fixes verified against current file content first). CodeRabbit re-requested once (`@coderabbitai review`) at this head; rate-limited, critic panel carries the gate per HIMMEL-1465.
- `check-ci`: all checks green + 0 unresolved review threads on PR #658 @ `a0b5e0bed29afc1a59c71a49ead1df42156c0551`.
- Marker: cleared (`clear-cr-marker.sh` → CR clean).
- Orphan check: 0 orphans. Promote: 0 to promote (no candidates raised).

## Test plan

- [x] `node scripts/lanes/skill-cost.mjs --check-positional-args .claude/commands/upstream-file.md` → rc=0
- [x] `git diff --stat` scoped to `.claude/commands/upstream-file.md` only (+26/-3)
- [x] Every fenced command in the new text is copy-pasteable (no bare placeholders inside backticks beyond the runbook's existing `<clone-path>` style)
- [x] Impacted suites: `git grep -l 'upstream-file' scripts/ docs/ .github/` → no `test-*.sh` beyond the skill-cost CI check already covered above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01755JwBxerRUwVmkjqW5JDD
