### PR TITLE
fix(himmelctl): [HIMMEL-2947] bridge-health cwd comparison canonicalizes both sides so a symlinked checkout root still counts its own poller

### DIFF
--- a/scripts/himmelctl/lib/probes.js
+++ b/scripts/himmelctl/lib/probes.js
@@ -2896,8 +2896,18 @@ function posixCandidateIsThisCheckout(cmdline, pid, thisCheckoutAnchor, checkout
   // anchor, which also has to match a case-insensitive Windows CommandLine.
   // Lowercasing here would fold e.g. /work/Himmel and /work/himmel together
   // and could count a foreign checkout as this one (CR gap, HIMMEL-2936).
-  const normCwd = cwd.replace(/\\/g, '/');
-  const normRoot = checkoutRoot.replace(/\\/g, '/');
+  // A checkout reached through a symlink (e.g. `~/himmel -> /data/himmel`)
+  // has checkoutRoot as the symlink path while the kernel's cwd readlink is
+  // always already the physical path -- realpath both sides so either one
+  // being a symlink doesn't defeat the match (HIMMEL-2947). A side that
+  // fails to resolve (racily-removed dir) keeps its normalized string, so
+  // the fail-safe exclusion below still applies rather than throwing.
+  let realCwd = cwd;
+  try { realCwd = fs.realpathSync(cwd); } catch (e) { /* keep the normalized string */ }
+  let realRoot = checkoutRoot;
+  try { realRoot = fs.realpathSync(checkoutRoot); } catch (e) { /* keep the normalized string */ }
+  const normCwd = realCwd.replace(/\\/g, '/');
+  const normRoot = realRoot.replace(/\\/g, '/');
   if (normCwd === normRoot) return { counted: true };
   if (normCwd.startsWith(`${normRoot}/`)) {
     // A worktree's own directory lives nested under its primary checkout

--- a/scripts/himmelctl/test/test-wizard-probes.sh
+++ b/scripts/himmelctl/test/test-wizard-probes.sh
@@ -5061,6 +5061,69 @@ else
 fi
 rm -f "$bh_posix_state/no-unit"
 
+# ── control (f) HIMMEL-2947: the checkout is reached through a SYMLINK --
+# ctx.repoRoot is the symlink path, a bare-token candidate's cwd readlink is
+# the REAL (physical) path the symlink points at (exactly what the kernel
+# hands back, since cwd readlinks are always already-canonical) -- must still
+# be counted as this checkout's own poller ──────────────────────────────────
+sym_real_root="$work/sym-real-root"; rm -rf "$sym_real_root"; mkdir -p "$sym_real_root"
+sym_link_root="$work/sym-link-root"; rm -f "$sym_link_root"; ln -sf "$sym_real_root" "$sym_link_root"
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9201"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
+ln -sf "$sym_real_root" "$bh_proc_root/9201/cwd"
+rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
+outBHlinuxT=$(BH_PGREP_N=1 run_bh_posix "$sym_link_root")
+if bh_posix_log_has "pgrep -f"; then
+  echo "$outBHlinuxT" | jq -e '.actual == "present"' >/dev/null \
+    || fail "bridge-health (Linux): a bare-token sweep match must be counted when the checkout root is a symlink and the cwd readlink is the real path it resolves to (got: $outBHlinuxT)"
+  echo "$outBHlinuxT" | jq -e '.detail | contains("1 poller")' >/dev/null \
+    || fail "bridge-health (Linux): symlinked-checkout-root match should read count 1 (got: $outBHlinuxT)"
+  echo "ok: bridge-health (Linux) — bare-token sweep match is counted when the checkout root is a symlink and cwd is its real target (HIMMEL-2947)"
+else
+  echo "SKIP: bridge-health (Linux) control (f) HIMMEL-2947: no evidence in the stub log that pgrep actually spawned on this host"
+fi
+rm -f "$bh_posix_state/no-unit"
+
+# ── control (g) HIMMEL-2947: the mirror of (f) -- ctx.repoRoot is the REAL
+# (physical) path, a bare-token candidate's cwd readlink is the SYMLINK path
+# pointing at it -- must also be counted ────────────────────────────────────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9201"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
+ln -sf "$sym_link_root" "$bh_proc_root/9201/cwd"
+rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
+outBHlinuxU=$(BH_PGREP_N=1 run_bh_posix "$sym_real_root")
+if bh_posix_log_has "pgrep -f"; then
+  echo "$outBHlinuxU" | jq -e '.actual == "present"' >/dev/null \
+    || fail "bridge-health (Linux): a bare-token sweep match must be counted when the cwd readlink is a symlink resolving to the checkout's real root (got: $outBHlinuxU)"
+  echo "$outBHlinuxU" | jq -e '.detail | contains("1 poller")' >/dev/null \
+    || fail "bridge-health (Linux): symlinked-cwd match should read count 1 (got: $outBHlinuxU)"
+  echo "ok: bridge-health (Linux) — bare-token sweep match is counted when cwd is a symlink resolving to the checkout's real root (HIMMEL-2947)"
+else
+  echo "SKIP: bridge-health (Linux) control (g) HIMMEL-2947: no evidence in the stub log that pgrep actually spawned on this host"
+fi
+rm -f "$bh_posix_state/no-unit"
+
+# ── control (h) HIMMEL-2947: a bare-token candidate whose cwd readlink target
+# does not exist on disk (racily-removed directory) must not throw -- falls
+# back to the uncanonicalized comparison and stays excluded, fail-safe ──────
+rm -rf "$bh_proc_root"; mkdir -p "$bh_proc_root/9201"
+printf '%s\0' bun poller.ts > "$bh_proc_root/9201/cmdline"
+ln -sf "$work/himmel-2947-does-not-exist" "$bh_proc_root/9201/cwd"
+rm -f "$bh_posix_log"; : > "$bh_posix_state/no-unit"
+outBHlinuxV=$(BH_PGREP_N=1 run_bh_posix)
+if bh_posix_log_has "pgrep -f"; then
+  echo "$outBHlinuxV" | jq -e '.actual == "absent"' >/dev/null \
+    || fail "bridge-health (Linux): a bare-token sweep match whose cwd target does not exist must not be counted and must not throw (got: $outBHlinuxV)"
+  echo "$outBHlinuxV" | jq -e '.detail | contains("0 poller")' >/dev/null \
+    || fail "bridge-health (Linux): nonexistent-cwd-target exclusion should read count 0 (got: $outBHlinuxV)"
+  echo "$outBHlinuxV" | jq -e '.detail | contains("9201")' >/dev/null \
+    || fail "bridge-health (Linux): detail should name the excluded pid 9201 (got: $outBHlinuxV)"
+  echo "ok: bridge-health (Linux) — sweep bare-token match whose cwd target does not exist is excluded fail-safe without throwing, count 0, detail names 9201 (HIMMEL-2947)"
+else
+  echo "SKIP: bridge-health (Linux) control (h) HIMMEL-2947: no evidence in the stub log that pgrep actually spawned on this host"
+fi
+rm -f "$bh_posix_state/no-unit"
+
 # ── bridge-persistence — HIMMEL-2176 Stage-1 PR-C, status item S6 ───────────
 # Contract (spec §3.5): logon task (win) / systemd unit + linger (linux)
 # present when bridge.enabled; warn when enabled but persistence is absent.


### PR DESCRIPTION
## Why

`posixCandidateIsThisCheckout` in `scripts/himmelctl/lib/probes.js` compares the live `/proc/<pid>/cwd` readlink against `ctx.repoRoot` after only a `\`→`/` normalization — no path canonicalization. The kernel's `cwd` readlink is always already the physical (fully-resolved) path, but `ctx.repoRoot` is whatever string the caller passed in, which can be a symlink (e.g. `~/himmel -> /data/himmel`). When a checkout is reached through such a symlink, the bare-string comparison never matches and a genuine `poller.ts` process is excluded from the bridge-health poller count, producing a false "degraded"/"absent" status.

## Change

Canonicalize both sides with `fs.realpathSync` immediately before the comparison, each independently wrapped in try/catch so an unresolvable path (e.g. a racily-removed directory) falls back to the normalized string rather than throwing — preserving the existing fail-safe exclusion behavior. No call-site changes: all three callers already pass `ctx.repoRoot` unchanged.

## RED → GREEN

| Control | Case | Pre-fix | Post-fix |
|---|---|---|---|
| (f) | symlinked `checkoutRoot`, physical `cwd` target | excluded (RED) | counted (GREEN) |
| (g) | physical `checkoutRoot`, symlinked `cwd` target | excluded (RED) | counted (GREEN) |
| (h) | `cwd` readlink target does not exist | excluded (baseline, no throw) | excluded (baseline, no throw) |

Controls (a)–(e) (pre-existing, including the HIMMEL-2936 case-sensitivity control) are unchanged and stay green.

## Non-goals

- HIMMEL-2945 (macOS / no-`/proc` fallback path) — untouched.
- The Windows CIM branch — untouched.
- No changes to call sites, exclusion messages, or nested-worktree/foreign-checkout detail strings for controls (a)–(e).

## Verification

- Full `test-wizard-probes.sh` suite: green.
- `node --check scripts/himmelctl/lib/probes.js`: pass.
- `test-suite-hermeticity.sh`: pass.
- All 6 suites referencing the two touched files: green.
- `shellcheck -x scripts/himmelctl/test/test-wizard-probes.sh`: rc=0.
- `/pr-check`: critic panel (codex) responded, 0 Critical / 0 Important / 0 Suggestions. Marker cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHZGyMxMnrV3Z6SJpLW83a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved checkout detection when symbolic links are used, helping bridge health checks correctly identify poller processes.
  - Safely handles missing working-directory targets without errors and reports no matching pollers when appropriate.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->