### PR TITLE
fix(update): [HIMMEL-2822] himmel-update restarts running hermes-gateway user units after the hermes-agent checkout moves

### DIFF
--- a/docs/hermes-runbook.md
+++ b/docs/hermes-runbook.md
@@ -292,7 +292,10 @@ applying it. The step resolves the install root from `HERMES_HOME` (else
 `%LOCALAPPDATA%\hermes`) and operates on its `hermes-agent/` subdir; it skips
 cleanly and never fails the himmel update when hermes isn't installed. After an
 update, **restart the hermes gateway** (`hermes gateway restart`, when no
-session is running) to pick up changes.
+session is running) to pick up changes — on Linux, `/himmel-update` now does
+this for you: it restarts any running `hermes-gateway-*.service` user units
+once the checkout actually moves, or prints the command to run by hand when
+`systemctl` isn't available.
 
 **Upstream force-pushes `main` (HIMMEL-2139).** So the checkout regularly stops
 being a fast-forward of upstream through no fault of ours, and the update step

--- a/scripts/himmel-update.sh
+++ b/scripts/himmel-update.sh
@@ -345,7 +345,7 @@ restart_hermes_gateways() {
         return 0
     fi
     local units unit
-    units=$(systemctl --user list-units 'hermes-gateway-*' --plain --no-legend 2>/dev/null | awk '{print $1}')
+    units=$(systemctl --user list-units 'hermes-gateway-*' --state=running --plain --no-legend 2>/dev/null | awk '{print $1}')
     [ -z "$units" ] && return 0
     echo "    hermes checkout moved — restarting running hermes-gateway units..."
     while IFS= read -r unit; do

--- a/scripts/himmel-update.sh
+++ b/scripts/himmel-update.sh
@@ -216,6 +216,8 @@ update_hermes() {
     # (already empty under -q) to /dev/null — set -e safe via the &&/|| form.
     # LC_ALL=C pins git's diagnostics to English, because the offline
     # classification below matches English phrases.
+    local head_before
+    head_before=$(git -C "$src" rev-parse HEAD 2>/dev/null || echo "?")
     local fetch_err fetch_rc
     fetch_err=$(LC_ALL=C git -C "$src" fetch -q "$remote" "$merge_ref" 2>&1 >/dev/null) && fetch_rc=0 || fetch_rc=$?
     if [ "$fetch_rc" -ne 0 ]; then
@@ -323,6 +325,37 @@ update_hermes() {
     else
         echo "    note: hermes venv python not found — code pulled, but run 'pip install -e .' in the venv if pyproject changed."
     fi
+    local head_after
+    head_after=$(git -C "$src" rev-parse HEAD 2>/dev/null || echo "?")
+    restart_hermes_gateways "$head_before" "$head_after"
+    return 0
+}
+
+# restart_hermes_gateways <old_head> <new_head> — HIMMEL-2822: a running
+# hermes-gateway-*.service keeps stale modules in memory and lazily imports a
+# NEW one on the next agent turn, so a checkout move that leaves the gateway
+# running silently ImportErrors until a manual restart. No-op when the
+# checkout did not actually move; never aborts the update chain on a restart
+# failure (a stale-but-running gateway beats an aborted update).
+restart_hermes_gateways() {
+    local old_head="$1" new_head="$2"
+    [ "$old_head" = "$new_head" ] && return 0
+    if ! command -v systemctl >/dev/null 2>&1; then
+        echo "    note: hermes-gateway units may be running pre-pull code — systemctl not found; restart by hand: systemctl --user restart hermes-gateway-<profile>.service"
+        return 0
+    fi
+    local units unit
+    units=$(systemctl --user list-units 'hermes-gateway-*' --plain --no-legend 2>/dev/null | awk '{print $1}')
+    [ -z "$units" ] && return 0
+    echo "    hermes checkout moved — restarting running hermes-gateway units..."
+    while IFS= read -r unit; do
+        [ -z "$unit" ] && continue
+        if systemctl --user restart "$unit" >/dev/null 2>&1; then
+            echo "    restarted $unit"
+        else
+            echo "    warn: failed to restart $unit — run 'systemctl --user restart $unit' by hand." >&2
+        fi
+    done <<< "$units"
     return 0
 }
 

--- a/scripts/test-himmel-update-hermes.sh
+++ b/scripts/test-himmel-update-hermes.sh
@@ -45,6 +45,35 @@ run_hermes_check_bounded() {
   fi
 }
 
+# mk_systemctl_stub <dir> <unit>... — writes a fake `systemctl` into <dir>
+# that logs every invocation's argv (one line per call) to
+# <dir>/systemctl.log, answers `--user list-units ... --plain --no-legend`
+# with the given fixture unit lines, and answers `--user restart <unit>`
+# with rc=1 when <unit> equals $SYSTEMCTL_STUB_FAIL_UNIT (read at RUNTIME,
+# by the generated stub — not expanded here), else rc=0. Never the real
+# systemd bus, so safe to run against this station's live hermes-gateway
+# units (HIMMEL-2822 do-not).
+mk_systemctl_stub() {
+  local dir="$1"; shift
+  mkdir -p "$dir"
+  : > "$dir/units.txt"
+  local u
+  for u in "$@"; do
+    printf '%s loaded active running fixture\n' "$u" >> "$dir/units.txt"
+  done
+  cat > "$dir/systemctl" <<EOF
+#!/bin/sh
+printf '%s\n' "\$*" >> "$dir/systemctl.log"
+if [ "\$1" = "--user" ] && [ "\$2" = "list-units" ]; then
+  cat "$dir/units.txt"
+elif [ "\$1" = "--user" ] && [ "\$2" = "restart" ]; then
+  [ "\$3" = "\${SYSTEMCTL_STUB_FAIL_UNIT:-}" ] && exit 1
+fi
+exit 0
+EOF
+  chmod +x "$dir/systemctl"
+}
+
 # HERMES_HOME is the install ROOT; the git checkout is its hermes-agent/ subdir.
 
 # Case 1: install root with no hermes-agent checkout → "not installed" skip.
@@ -353,6 +382,118 @@ if grepq "$out" "AppData"; then
 else
   echo "ok: default root resolution never falls back to \$HOME/AppData/Local on Linux/macOS"
 fi
+
+# ── restart_hermes_gateways() — HIMMEL-2822 ─────────────────────────────────
+# himmel-update fast-forwards the hermes-agent checkout but the running
+# hermes-gateway-*.service units keep old modules in memory until restarted
+# (09-08 ImportError incident). These cases drive update_hermes via a
+# systemctl STUB on PATH — never the real systemd bus (do-not: this station
+# has both units live).
+GW1=hermes-gateway-grow_agent.service
+GW2=hermes-gateway-himmel_agent.service
+
+# Case 13: apply path, checkout genuinely moves → ONE restart per listed
+# unit, and the output names each restarted unit.
+bare13="$tmp/bare13/NousResearch/hermes-agent.git"
+mkdir -p "$bare13"; git init -q --bare "$bare13"
+seed13="$tmp/seed13"
+git clone -q "$bare13" "$seed13"
+git -C "$seed13" config user.email "test@test.test"; git -C "$seed13" config user.name "Test"
+printf 'v1\n' > "$seed13/f.txt"; git -C "$seed13" add f.txt; git -C "$seed13" commit --quiet -m v1
+defbranch13=$(git -C "$seed13" rev-parse --abbrev-ref HEAD)
+git -C "$seed13" push --quiet origin "HEAD:$defbranch13"
+git clone -q "$bare13" "$tmp/moved13/hermes-agent"
+printf 'v2\n' > "$seed13/f.txt"; git -C "$seed13" add f.txt; git -C "$seed13" commit --quiet -m v2
+git -C "$seed13" push --quiet origin "HEAD:$defbranch13"
+want13=$(git -C "$seed13" rev-parse HEAD)
+stub13="$tmp/stub13"
+mk_systemctl_stub "$stub13" "$GW1" "$GW2"
+out=$(PATH="$stub13:$PATH" HERMES_HOME="$tmp/moved13" update_hermes apply 2>&1)
+got13=$(git -C "$tmp/moved13/hermes-agent" rev-parse HEAD)
+if [ "$got13" = "$want13" ]; then echo "ok: gateway-restart fixture: checkout genuinely moved"; else echo "FAIL: gateway-restart fixture HEAD was '$got13', expected '$want13'"; fail=1; fi
+check "checkout moved: restarted $GW1" "restarted $GW1" "$out"
+check "checkout moved: restarted $GW2" "restarted $GW2" "$out"
+restarts13=$(grep -c -- '--user restart' "$stub13/systemctl.log" 2>/dev/null) || true
+restarts13=${restarts13:-0}
+if [ "$restarts13" -eq 2 ]; then echo "ok: exactly one restart call per listed unit"; else echo "FAIL: expected 2 restart calls, stub log shows $restarts13"; cat "$stub13/systemctl.log" 2>/dev/null; fail=1; fi
+
+# Case 14: apply path, checkout already current (no move) → ZERO systemctl
+# calls — the control proving restart is gated on movement, not on every run.
+bare14="$tmp/bare14/NousResearch/hermes-agent.git"
+mkdir -p "$bare14"; git init -q --bare "$bare14"
+seed14="$tmp/seed14"
+git clone -q "$bare14" "$seed14"
+git -C "$seed14" config user.email "test@test.test"; git -C "$seed14" config user.name "Test"
+printf 'v1\n' > "$seed14/f.txt"; git -C "$seed14" add f.txt; git -C "$seed14" commit --quiet -m v1
+defbranch14=$(git -C "$seed14" rev-parse --abbrev-ref HEAD)
+git -C "$seed14" push --quiet origin "HEAD:$defbranch14"
+git clone -q "$bare14" "$tmp/current14/hermes-agent"
+stub14="$tmp/stub14"
+mk_systemctl_stub "$stub14" "$GW1" "$GW2"
+out=$(PATH="$stub14:$PATH" HERMES_HOME="$tmp/current14" update_hermes apply 2>&1)
+if [ -s "$stub14/systemctl.log" ]; then echo "FAIL: no-move apply invoked systemctl"; cat "$stub14/systemctl.log"; fail=1; else echo "ok: no-move apply -> zero systemctl calls"; fi
+
+# Case 15: --check mode never touches systemctl (read-only contract).
+bare15="$tmp/bare15/NousResearch/hermes-agent.git"
+mkdir -p "$bare15"; git init -q --bare "$bare15"
+seed15="$tmp/seed15"
+git clone -q "$bare15" "$seed15"
+git -C "$seed15" config user.email "test@test.test"; git -C "$seed15" config user.name "Test"
+printf 'v1\n' > "$seed15/f.txt"; git -C "$seed15" add f.txt; git -C "$seed15" commit --quiet -m v1
+defbranch15=$(git -C "$seed15" rev-parse --abbrev-ref HEAD)
+git -C "$seed15" push --quiet origin "HEAD:$defbranch15"
+git clone -q "$bare15" "$tmp/checkgw15/hermes-agent"
+stub15="$tmp/stub15"
+mk_systemctl_stub "$stub15" "$GW1" "$GW2"
+out=$(PATH="$stub15:$PATH" HERMES_HOME="$tmp/checkgw15" update_hermes check 2>&1)
+if [ -s "$stub15/systemctl.log" ]; then echo "FAIL: --check invoked systemctl"; cat "$stub15/systemctl.log"; fail=1; else echo "ok: --check -> zero systemctl calls"; fi
+
+# Case 16: apply path, checkout moves, NO systemctl anywhere on PATH (scrub
+# it — a curated symlink PATH, same NOGH trick as test-himmel-doctor.sh,
+# since this station's real systemctl must never run in this suite) → no
+# failure, and the output carries the loud advisory naming the exact
+# restart shape the operator must run by hand.
+bare16="$tmp/bare16/NousResearch/hermes-agent.git"
+mkdir -p "$bare16"; git init -q --bare "$bare16"
+seed16="$tmp/seed16"
+git clone -q "$bare16" "$seed16"
+git -C "$seed16" config user.email "test@test.test"; git -C "$seed16" config user.name "Test"
+printf 'v1\n' > "$seed16/f.txt"; git -C "$seed16" add f.txt; git -C "$seed16" commit --quiet -m v1
+defbranch16=$(git -C "$seed16" rev-parse --abbrev-ref HEAD)
+git -C "$seed16" push --quiet origin "HEAD:$defbranch16"
+git clone -q "$bare16" "$tmp/nosysctl16/hermes-agent"
+printf 'v2\n' > "$seed16/f.txt"; git -C "$seed16" add f.txt; git -C "$seed16" commit --quiet -m v2
+git -C "$seed16" push --quiet origin "HEAD:$defbranch16"
+NOSYSTEMCTL="$tmp/no-systemctl-path"; mkdir -p "$NOSYSTEMCTL"
+for _tool in bash sh git grep sed awk tr cut head tail cat mktemp mkdir dirname basename rm mv cp chmod wc sort ln uname id date env expr find xargs which python3 pip3 timeout readlink realpath; do
+  _p="$(command -v "$_tool" 2>/dev/null)" && ln -sf "$_p" "$NOSYSTEMCTL/$_tool" 2>/dev/null
+done
+rc=0
+out=$(PATH="$NOSYSTEMCTL" HERMES_HOME="$tmp/nosysctl16" update_hermes apply 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then echo "ok: no-systemctl apply -> exit 0"; else echo "FAIL: no-systemctl apply -> exit $rc"; printf '%s\n' "$out"; fail=1; fi
+check "no systemctl on PATH: loud advisory names exact restart shape" "systemctl --user restart hermes-gateway-<profile>\\.service" "$out"
+
+# Case 17: apply path, restart fails for ONE unit → reported FAILED-to-restart
+# with the by-hand command, chain NOT aborted (rc 0), and the OTHER unit
+# still restarts.
+bare17="$tmp/bare17/NousResearch/hermes-agent.git"
+mkdir -p "$bare17"; git init -q --bare "$bare17"
+seed17="$tmp/seed17"
+git clone -q "$bare17" "$seed17"
+git -C "$seed17" config user.email "test@test.test"; git -C "$seed17" config user.name "Test"
+printf 'v1\n' > "$seed17/f.txt"; git -C "$seed17" add f.txt; git -C "$seed17" commit --quiet -m v1
+defbranch17=$(git -C "$seed17" rev-parse --abbrev-ref HEAD)
+git -C "$seed17" push --quiet origin "HEAD:$defbranch17"
+git clone -q "$bare17" "$tmp/failrestart17/hermes-agent"
+printf 'v2\n' > "$seed17/f.txt"; git -C "$seed17" add f.txt; git -C "$seed17" commit --quiet -m v2
+git -C "$seed17" push --quiet origin "HEAD:$defbranch17"
+stub17="$tmp/stub17"
+mk_systemctl_stub "$stub17" "$GW1" "$GW2"
+rc=0
+out=$(PATH="$stub17:$PATH" HERMES_HOME="$tmp/failrestart17" SYSTEMCTL_STUB_FAIL_UNIT="$GW1" update_hermes apply 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then echo "ok: one restart failing -> exit 0 (chain not aborted)"; else echo "FAIL: one restart failing -> exit $rc"; printf '%s\n' "$out"; fail=1; fi
+check "failed restart names the by-hand command for $GW1" "systemctl --user restart $GW1" "$out"
+check "other unit still restarted" "restarted $GW2" "$out"
 
 # ── report_cadence_stale() — stale cadence runner nudge (HIMMEL-588/969) ─────
 # Same lib seams; *_BAT_DIR point at fixture runner dirs.


### PR DESCRIPTION
## Why

On 2026-09-08, `himmel-update` fast-forwarded `~/.hermes/hermes-agent`, but the
two long-running gateway user units (`hermes-gateway-grow_agent.service`,
`hermes-gateway-himmel_agent.service`) kept the OLD Python modules loaded in
memory and lazily imported a NEW one on the next message:
`ImportError: cannot import name 'normalize_budget_warning_ratio'` — repeating
on every message until someone ran `systemctl --user restart` by hand. The
updater itself was correct; it just left running gateways silently on
pre-pull code.

## What changed

`scripts/himmel-update.sh`: new `restart_hermes_gateways(old_head, new_head)`,
called from `update_hermes()` on the apply path after the editable-refresh
step, on both the ff-merge and the force-push-resync branches. No-op when the
heads are equal. Lists running `hermes-gateway-*` user units via
`systemctl --user list-units 'hermes-gateway-*' --state=running`, restarts
each, prints `restarted <unit>` per unit, and warns with the by-hand command
per failed unit without aborting the rest. Advisory-only (no restart attempt)
when `systemctl` isn't on PATH (Windows/macOS have no `.ps1` twin for this
script and no systemd user units). No new env var or opt-out flag; `--check`
stays read-only.

## Tests (RED first)

Added to `test-himmel-update-hermes.sh`:
- (a) checkout genuinely moves → each running unit restarted, named in output
- (b) checkout already current (no move) → zero restarts (control)
- (c) `--check` mode → zero `systemctl` calls (control, read-only contract)
- (d) checkout moves, no `systemctl` on PATH → loud advisory line, no failure
- (e) checkout moves, one unit's restart fails → that unit reported FAILED
  with the by-hand command, chain not aborted, other unit still restarted

(a)/(d)/(e) RED before the implementation, (b)/(c) GREEN throughout as
controls. All GREEN after implementing.

## Round table

| Round | Reviewer | Severity | Finding | Verdict | Disposition |
|---|---|---|---|---|---|
| 1 (head `14a7e884`) | codex-1 | Important | Unconditional restart could interrupt active sessions | disproved | RESUME.md mandates unconditional restart, no opt-out — deliberate stale-vs-interrupted tradeoff |
| 1 (head `14a7e884`) | codex-2 | Important | `list-units` without `--state=` includes FAILED units | agreed | Fixed in `a39cc271` (added `--state=running`) |
| 1 (head `14a7e884`) | codex-3 | Suggestion | `2>/dev/null` masks a genuine listing failure as "no gateways" | agreed | Re-raised/re-adjudicated as round-2 codex-2 below |
| 2 (head `a39cc271`) | codex-1 | Important | Same unconditional-restart concern | disproved | Same rationale as round 1 |
| 2 (head `a39cc271`) | codex-2 | Suggestion | `2>/dev/null` masks a genuine listing failure | agreed | Tracked for auto-filing as a follow-up nit (one inline CR-fix per PR already used) |

Known-findings checklist: the "no test changed" heuristic flagged a false
positive — the paired suite (`test-himmel-update-hermes.sh`) was in fact
updated with the RED-first cases above.

CodeRabbit: GitHub-App-only (HIMMEL-2704); requested via a single
`@coderabbitai review` comment after this PR opens.

## Verification

- `test-himmel-update-hermes.sh`: 0 FAIL
- `test-himmel-update-axis-b.sh`: 107 passed, 0 failed
- `test-himmel-update-chain.sh`: 42 passed, 0 failed
- `test-himmel-update.sh`: 94 passed, 0 failed
- `shellcheck -x scripts/himmel-update.sh scripts/test-himmel-update-hermes.sh`: rc=0
- `himmel-update.sh --check`: verified read-only (advisory path only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJEQJah9VwdnbPbuE3vmgJ
