### PR TITLE
fix(hooks): HIMMEL-2946/HIMMEL-2949 single-writer marker + --work-tree operand masking

### DIFF
--- a/scripts/hooks/block-write-into-main-checkout.sh
+++ b/scripts/hooks/block-write-into-main-checkout.sh
@@ -866,8 +866,23 @@ _bwimc_check_canon() {
     repo_root=$(main_checkout_verdict "$canon" 2>/dev/null) || vrc=$?
     case "$vrc" in
         0) return 0 ;;
-        1) _bwimc_deny "main" "$raw" "$canon" "$repo_root" ;;
-        2) _bwimc_deny "primary-feature" "$raw" "$canon" "$repo_root" ;;
+        1|2)
+            # HIMMEL-2946: the deny text below (and _bwimc_cwd_check_sourced's
+            # own copy) recommends `touch "$repo_root/.single-writer"` as the
+            # opt-out for a repo that commits to main by design — but creating
+            # that exact marker IS itself a write on main/primary-feature, so
+            # unexempted it refused its own remedy. Exempt ONLY the exact
+            # root-level basename; a subdirectory entry or a near-miss name
+            # (.single-writer.bak, .single-writerx) still denies.
+            if [ -n "$repo_root" ] && [ "$canon" = "$repo_root/.single-writer" ]; then
+                return 0
+            fi
+            if [ "$vrc" = 1 ]; then
+                _bwimc_deny "main" "$raw" "$canon" "$repo_root"
+            else
+                _bwimc_deny "primary-feature" "$raw" "$canon" "$repo_root"
+            fi
+            ;;
         *) _bwimc_deny "unreadable" "$raw" "$canon" "$repo_root" ;;
     esac
 }

--- a/scripts/hooks/block-write-into-main-checkout.sh
+++ b/scripts/hooks/block-write-into-main-checkout.sh
@@ -1011,6 +1011,14 @@ _bwimc_git_commit_target() {
         if [ "$t" = "-C" ]; then
             i=$((i+1)); v="${toks[$i]:-}"
             r=$(_bwimc_resolve_abs "$v" "$dir") && dir="$r" || _BWIMC_GIT_TARGET_UNRESOLVED=1
+        # HIMMEL-2949: `--work-tree <p>` (two tokens) must skip its own
+        # operand too, exactly like `-C` above — otherwise an operand that
+        # happens to equal the literal string "commit" trips the break check
+        # one token early and a LATER -C is silently never seen. A standalone
+        # --work-tree does not redirect the target itself (see the design
+        # note above this function), so only the operand is skipped here.
+        elif [ "$t" = "--work-tree" ]; then
+            i=$((i+1))
         fi
         i=$((i+1))
     done
@@ -1027,6 +1035,8 @@ _bwimc_git_commit_target() {
             # the break check above one token early and a LATER --git-dir is
             # silently never seen.
             -C) i=$((i+1)) ;;
+            # HIMMEL-2949: same masking risk from `--work-tree`'s own operand.
+            --work-tree) i=$((i+1)) ;;
             --git-dir=*) gitdir_raw="${t#--git-dir=}" ;;
             --git-dir) i=$((i+1)); gitdir_raw="${toks[$i]:-}" ;;
         esac

--- a/scripts/hooks/test-block-write-into-main-checkout.sh
+++ b/scripts/hooks/test-block-write-into-main-checkout.sh
@@ -459,6 +459,37 @@ check_both_reason "23b-xi git -C \"\$(pwd)\" commit (unresolvable -C, cwd=wt) fa
 check_both "23b-xii git -C commit --git-dir=primary/.git commit (-C value is literally \"commit\", masks --git-dir from the scan) denies" block \
     "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git -C commit --git-dir=$FIX/primary/.git commit -m x\",\"cwd\":\"$FIX/wt\"}}"
 
+# 23b-xiii (HIMMEL-2949): same shape as 23b-xii but for --work-tree's OWN
+# operand instead of -C's — neither scan loop skips it, so when that operand
+# is literally the string "commit", the "stop at commit" break check fires
+# one token early and the LATER -C (which real git honours) is never seen.
+# Confirmed against real git: `git --work-tree commit -C <primary> status`
+# from the worktree cwd reports "On branch main" (the PRIMARY's branch).
+check_both_reason "23b-xiii git --work-tree commit -C primary commit (--work-tree's operand is literally \"commit\", masks a later -C) denies, names the -C target" \
+    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git --work-tree commit -C $FIX/primary commit -q -m x\",\"cwd\":\"$FIX/wt\"}}" \
+    "$FIX/primary"
+
+# 23b-xiv (HIMMEL-2949): the `--work-tree=<p>` compound-token form does not
+# have a separate operand to mask anything, but pins that a LITERAL value of
+# "commit" inside the compound token does not itself confuse the scan, and a
+# later --git-dir is still honoured.
+check_both "23b-xiv git --work-tree=commit --git-dir=primary/.git commit (compound --work-tree= form, --git-dir still resolves) denies" block \
+    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git --work-tree=commit --git-dir=$FIX/primary/.git commit -q -m x\",\"cwd\":\"$FIX/wt\"}}"
+
+# 23b-xv (HIMMEL-2949 control): a legitimate standalone `--work-tree <p>` (no
+# --git-dir, no -C) stays a no-op for target resolution per the :970 design
+# note — HEAD still moves in whatever repo cwd resolves to, so this must keep
+# ALLOWing exactly like row 23.
+check_both "23b-xv git --work-tree \$FIX/wt commit (cwd=wt, standalone --work-tree) still allows (control)" allow \
+    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git --work-tree $FIX/wt commit -q -m x\",\"cwd\":\"$FIX/wt\"}}"
+
+# 23b-xvi (HIMMEL-2949 control): --work-tree's operand "commit" must not be
+# mistaken for the subcommand even when a -C ALSO appears earlier and already
+# resolves harmlessly to cwd — the fix must not overreact and start denying
+# a genuinely allowed shape.
+check_both "23b-xvi git -C wt --work-tree commit commit (-C already resolves to wt, --work-tree operand is \"commit\") still allows (control)" allow \
+    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git -C $FIX/wt --work-tree commit commit -q -m x\",\"cwd\":\"$FIX/wt\"}}"
+
 # 24. handovers/ carve-out (main_checkout_verdict's own exemption).
 check_both "24 cat > primary/handovers/x.md (handovers carve-out)" allow \
     "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cat > $FIX/primary/handovers/x.md\",\"cwd\":\"$FIX/primary\"}}"

--- a/scripts/hooks/test-block-write-into-main-checkout.sh
+++ b/scripts/hooks/test-block-write-into-main-checkout.sh
@@ -252,14 +252,34 @@ check_both "7 mv primary/scripts/x.sh wt/ (source inside primary denies)" block 
 check_both "8 rm primary/scripts/x.sh" block \
     "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rm $FIX/primary/scripts/x.sh\",\"cwd\":\"$FIX/primary\"}}"
 
-# 9. touch.
-check_both "9 touch primary/.single-writer" block \
+# 9 (HIMMEL-2946): touch creating the repo-root .single-writer opt-out itself
+# must ALLOW — this is the exact catch-22 the hook's own deny text (line
+# 842/1054) recommends as the remedy, then refused (not yet present in
+# primary — .single-writer is only in the exclude file, not touched on disk).
+check_both "9 touch primary/.single-writer (creating the opt-out itself) allows (HIMMEL-2946)" allow \
     "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"touch $FIX/primary/.single-writer\",\"cwd\":\"$FIX/primary\"}}"
 
-# 10. redirect onto the .single-writer marker's own name (not yet present in
-# primary — .single-writer is only in the exclude file, not touched on disk).
-check_both "10 echo > primary/.single-writer" block \
+# 10 (HIMMEL-2946): redirect onto the same exact name — same exemption.
+check_both "10 echo > primary/.single-writer (creating the opt-out itself) allows (HIMMEL-2946)" allow \
     "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo x > $FIX/primary/.single-writer\",\"cwd\":\"$FIX/primary\"}}"
+
+# 10b (HIMMEL-2946): the exemption is EXACT-BASENAME-AT-ROOT only — a
+# subdirectory entry of the same basename must still deny.
+check_both "10b touch primary/scripts/.single-writer (not the repo root) still denies" block \
+    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"touch $FIX/primary/scripts/.single-writer\",\"cwd\":\"$FIX/primary\"}}"
+
+# 10c (HIMMEL-2946): near-miss basenames at the root must still deny — the
+# exemption is the exact string ".single-writer", not a prefix/suffix match.
+check_both "10c touch primary/.single-writer.bak (near-miss basename) still denies" block \
+    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"touch $FIX/primary/.single-writer.bak\",\"cwd\":\"$FIX/primary\"}}"
+check_both "10d echo > primary/.single-writerx (near-miss basename) still denies" block \
+    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo x > $FIX/primary/.single-writerx\",\"cwd\":\"$FIX/primary\"}}"
+
+# 10e (HIMMEL-2946): the exemption is by DESTINATION, not cwd — an absolute
+# path into the primary's root marker from a DIFFERENT cwd (the worktree)
+# must allow exactly like row 9.
+check_both "10e touch \$FIX/primary/.single-writer from cwd=wt (destination-based, not cwd-based) allows" allow \
+    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"touch $FIX/primary/.single-writer\",\"cwd\":\"$FIX/wt\"}}"
 
 # 11. git commit, cwd = primary (main) — BOTH wirings agree (is_on_main and
 # main_checkout_verdict both fire on plain "on main").


### PR DESCRIPTION
## Summary

Two related bugs in `block-write-into-main-checkout.sh`, fixed as two commits.

**HIMMEL-2946** — the hook's own deny text recommends `touch "$repo_root/.single-writer"` as the opt-out marker for repos that commit straight to main by design, but creating that file IS itself a write into main on a repo that doesn't have the marker yet — so the hook denied its own documented escape hatch (catch-22 hit by `/upstream-file` step 4 on a fresh throwaway clone). Fix: `_bwimc_check_canon` exempts a destination whose canonical path is EXACTLY `<repo_root>/.single-writer` — exact basename at the repo root only, destination-based (not cwd-based), so a subdir `.single-writer`, a near-miss basename (`.single-writer.bak`, `.single-writerx`), or a write from a worktree cwd into the marker's absolute primary-repo path are all still governed by the normal exemption logic (the last case still allows, since the exemption is destination-based).

**HIMMEL-2949** — `_bwimc_git_commit_target`'s two argv-scan loops (tracking `-C` and `--git-dir`) each break at the first token equal to `"commit"`, and neither skips `--work-tree`'s own two-token operand. So `git --work-tree commit -C <primary> commit -q -m x` from an allowed worktree cwd breaks the scan on the literal `"commit"` (`--work-tree`'s operand) before ever seeing the later `-C <primary>` — the hook falls back to reporting the cwd as the commit target while real git actually commits into `<primary>`, producing a false ALLOW. This bypass also exists on unmodified main (no `-C`-awareness at all there); the fix only tightens. Fix: both loops skip `--work-tree <p>`'s operand symmetrically to the existing `-C` handling.

## Verification

- RED baseline (unmodified hook): 8 rows failed as predicted (marker-creation rows for 2946; the `--work-tree`-masking row for 2949), all controls green — confirmed both bugs are real and isolated to the predicted rows.
- Both fixes applied; `shellcheck -x` clean on both.
- Full suite: 901 passed, 0 failed.
- Direct probes on both the worktree's patched hook and the unmodified primary hook confirm the RED/GREEN contrast: row (a) `touch <repo>/.single-writer` — rc=2 (block) on primary, rc=0 (allow) on the fix; row (f) `git --work-tree commit -C <target> commit` — rc=0 (false allow, target lost) on primary, rc=2 (block, naming the resolved `-C` target) on the fix.
- Impacted-suites sweep (every suite referencing `block-write-into-main-checkout`): `test-lib.sh`, `test-block-terminal-write-fence.sh`, `test-crlf-boundary.sh` — all green. `test-hook-rewrite-integrity.sh` (90/0) and `run-hook-with-bash.test.mjs` (47/0) — both fully green under `env -u HIMMEL_HOOK_INTEGRITY_BYPASS_OK` (the bypass var needed to edit hook files makes these two integrity-guard suites fail identically on ANY tree if left set — a vacuous control; unset, both are clean).
- `/pr-check`: critic panel round 1 of 3 clean — 0 Critical / 0 Important / 0 Suggestions. Marker cleared.

## Commits

1. `fix(hooks): [HIMMEL-2946] block-write-into-main-checkout exempts creating the repo-root .single-writer opt-out it recommends`
2. `fix(hooks): [HIMMEL-2949] block-write-into-main-checkout skips --work-tree's operand in both commit-target scan loops`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNsLR32tmN21J7LJb6HZdX

[HIMMEL-2946]: https://yotamleo.atlassian.net/browse/HIMMEL-2946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ