### PR TITLE
fix(hooks): [HIMMEL-2557] run-hook-with-bash propagates the child's status on an EPIPE stdin write instead of failing closed as failed-to-start

### DIFF
--- a/marketplace/plugins/himmel-ops/hooks/run-hook-with-bash.js
+++ b/marketplace/plugins/himmel-ops/hooks/run-hook-with-bash.js
@@ -422,6 +422,16 @@ function readAllStdin() {
   }
 }
 
+// HIMMEL-2557: spawnSync surfaces EPIPE on the parent's stdin WRITE when the
+// child exits before draining it (a guard that returns on its first line, or
+// the write racing the child's exit under load — 2d687f9c, main red
+// 2026-09-12). The child still ran to completion, so its own status/stdout/
+// stderr are the real verdict; only a numeric status proves it actually
+// exited — EPIPE with a null status stays fail-closed like any other error.
+function isRecoverableEpipe(result) {
+  return Boolean(result.error) && result.error.code === 'EPIPE' && typeof result.status === 'number';
+}
+
 // Returns the exit code rather than calling process.exit(): on Windows a pipe
 // stdout is ASYNC, so exiting immediately after a write can truncate the very
 // JSON decision this exists to deliver. The caller sets process.exitCode and
@@ -576,7 +586,7 @@ function runChain(members, lifecycle = false) {
       maxBuffer: MEMBER_MAX_BUFFER,
       windowsHide: true,   // HIMMEL-2043: no console flash per hook call
     });
-    if (result.error) {
+    if (result.error && !isRecoverableEpipe(result)) {
       // A member that outran a LIMIT of ours is not a launcher failure. Two
       // limits reach here: the per-member timeout, and the output buffer (a
       // single hook keeps `stdio: 'inherit'` and has no buffer at all, so
@@ -701,7 +711,7 @@ function main() {
     process.exit(2);
   }
   const result = spawnSync(bash, hookArgs, { input, stdio: ['pipe', 'inherit', 'inherit'], env: process.env, windowsHide: true });   // HIMMEL-2043
-  if (result.error) {
+  if (result.error && !isRecoverableEpipe(result)) {
     process.stderr.write(`run-hook-with-bash: failed to start ${bash}: ${result.error.message}\n`);
     process.exit(2);
   }
@@ -713,6 +723,7 @@ module.exports = {
   MIN_MEMBER_TIMEOUT_MS,
   MUST_RUN_CHAIN_MEMBERS,
   isKnownBadWindowsBash,
+  isRecoverableEpipe,
   isUsable,
   mergeHookOutputs,
   resolveBash,

--- a/scripts/hooks/run-hook-with-bash.js
+++ b/scripts/hooks/run-hook-with-bash.js
@@ -422,6 +422,16 @@ function readAllStdin() {
   }
 }
 
+// HIMMEL-2557: spawnSync surfaces EPIPE on the parent's stdin WRITE when the
+// child exits before draining it (a guard that returns on its first line, or
+// the write racing the child's exit under load — 2d687f9c, main red
+// 2026-09-12). The child still ran to completion, so its own status/stdout/
+// stderr are the real verdict; only a numeric status proves it actually
+// exited — EPIPE with a null status stays fail-closed like any other error.
+function isRecoverableEpipe(result) {
+  return Boolean(result.error) && result.error.code === 'EPIPE' && typeof result.status === 'number';
+}
+
 // Returns the exit code rather than calling process.exit(): on Windows a pipe
 // stdout is ASYNC, so exiting immediately after a write can truncate the very
 // JSON decision this exists to deliver. The caller sets process.exitCode and
@@ -576,7 +586,7 @@ function runChain(members, lifecycle = false) {
       maxBuffer: MEMBER_MAX_BUFFER,
       windowsHide: true,   // HIMMEL-2043: no console flash per hook call
     });
-    if (result.error) {
+    if (result.error && !isRecoverableEpipe(result)) {
       // A member that outran a LIMIT of ours is not a launcher failure. Two
       // limits reach here: the per-member timeout, and the output buffer (a
       // single hook keeps `stdio: 'inherit'` and has no buffer at all, so
@@ -701,7 +711,7 @@ function main() {
     process.exit(2);
   }
   const result = spawnSync(bash, hookArgs, { input, stdio: ['pipe', 'inherit', 'inherit'], env: process.env, windowsHide: true });   // HIMMEL-2043
-  if (result.error) {
+  if (result.error && !isRecoverableEpipe(result)) {
     process.stderr.write(`run-hook-with-bash: failed to start ${bash}: ${result.error.message}\n`);
     process.exit(2);
   }
@@ -713,6 +723,7 @@ module.exports = {
   MIN_MEMBER_TIMEOUT_MS,
   MUST_RUN_CHAIN_MEMBERS,
   isKnownBadWindowsBash,
+  isRecoverableEpipe,
   isUsable,
   mergeHookOutputs,
   resolveBash,

--- a/scripts/hooks/run-hook-with-bash.test.mjs
+++ b/scripts/hooks/run-hook-with-bash.test.mjs
@@ -14,6 +14,7 @@ const {
   MIN_MEMBER_TIMEOUT_MS,
   MUST_RUN_CHAIN_MEMBERS,
   isKnownBadWindowsBash,
+  isRecoverableEpipe,
   isUsable,
   mergeHookOutputs,
   resolveBash,
@@ -499,6 +500,64 @@ test('a member that overflows the output buffer is skipped, not turned into a de
     assert.equal(ran(dir, 'allow.sh'), true, 'the chain must continue past an overflowing member');
     assert.equal(JSON.parse(result.stdout).hookSpecificOutput.permissionDecision, 'allow');
   });
+});
+
+// -------------------------------------------------- HIMMEL-2557: EPIPE-with-status is not a launcher failure
+//
+// spawnSync surfaces EPIPE on the parent's stdin WRITE when the child exits
+// before draining it (a guard that returns on its first line, or the write
+// racing the child's exit under load — 2d687f9c, main red 2026-09-12). The
+// child still ran to completion, so its own status/stdout/stderr are the real
+// verdict. A payload well past the 64 KiB pipe buffer makes the write land
+// after the fixture has already closed its stdin and exited, reproducing the
+// race deterministically instead of relying on scheduler timing.
+const EPIPE_PAYLOAD = JSON.stringify({
+  hook_event_name: 'PreToolUse',
+  tool_name: 'Bash',
+  tool_input: { command: 'a'.repeat(300 * 1024) },
+});
+
+function epipeFixture(name, body) {
+  const dir = makeTmpDir('hook-bash-epipe-');
+  const script = join(dir, name);
+  writeFileSync(script, `#!/usr/bin/env bash\n${body}\n`);
+  chmodSync(script, 0o755);
+  return script;
+}
+
+test('a chain member that exits without reading stdin still ALLOWS on an EPIPE write', () => {
+  const script = epipeFixture('exit-without-reading-allow.sh', 'exec 0<&-\nexit 0');
+  const result = runChain(dirname(script), [script], EPIPE_PAYLOAD);
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stderr, /failed to start/);
+});
+
+test('a chain member that exits without reading stdin still DENIES on an EPIPE write', () => {
+  const script = epipeFixture('exit-without-reading-deny.sh', "exec 0<&-\necho '⛔ fixture deny' >&2\nexit 2");
+  const result = runChain(dirname(script), [script], EPIPE_PAYLOAD);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /⛔ fixture deny/);
+  assert.doesNotMatch(result.stderr, /failed to start/);
+});
+
+test('a lone (non-chain) hook that exits without reading stdin still ALLOWS on an EPIPE write', () => {
+  const script = epipeFixture('exit-without-reading-allow.sh', 'exec 0<&-\nexit 0');
+  const result = spawnSync(process.execPath, [LAUNCHER, script], { encoding: 'utf8', input: EPIPE_PAYLOAD });
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stderr, /failed to start/);
+});
+
+// CONTROL: only EPIPE with a NUMERIC status (proof the child actually exited)
+// may fall through. Every other spawn error, and EPIPE with a null status (the
+// child never exited — e.g. it was itself killed), stays fail-closed. Exercised
+// as a unit test on the extracted predicate rather than end-to-end: system bash
+// always resolves on this box, so there is no way to force a genuine non-EPIPE
+// `result.error` out of the real launcher without corrupting the system's own
+// /bin/bash — the boundary the predicate encodes is the actual thing at risk.
+test('isRecoverableEpipe only accepts EPIPE paired with a numeric status', () => {
+  assert.equal(isRecoverableEpipe({ error: { code: 'EPIPE' }, status: null }), false);
+  assert.equal(isRecoverableEpipe({ error: { code: 'ENOENT' }, status: 0 }), false);
+  assert.equal(isRecoverableEpipe({ error: { code: 'EPIPE' }, status: 2 }), true);
 });
 
 // -------------------------------------------------- must-run vs skippable (HIMMEL-2060)


### PR DESCRIPTION
## Summary

Fixes HIMMEL-2557 — `run-hook-with-bash.js` fails closed ("failed to start ...
EPIPE") when a chain member or lone hook legitimately exits before the
launcher finishes writing its stdin payload, even though the child's own
exit status/stdout/stderr are the real, valid verdict.

**Root cause:** the launcher hands the whole hook payload to
`spawnSync(..., { input })`. A member that exits before draining stdin (a
guard that returns on its first line, or the write racing the child's exit
under load) makes the parent's pipe write fail with `EPIPE`. `spawnSync`
still sets `result.status`/`result.stdout`/`result.stderr` from the child's
real run, but both error branches treated *any* `result.error` as
"failed to start" and denied the tool call — turning a legitimate ALLOW
into a spurious DENY. This hit main at 2d687f9c (#659), green on rerun, and
hit five times on 2026-09-05 under suite load.

**Fix:** extracted `isRecoverableEpipe(result)` — true only when
`error.code === 'EPIPE'` AND `typeof status === 'number'` (proof the child
actually exited) — and guarded both spawn-error sites (chain member and
lone-hook) with it. Every other spawn error, and EPIPE with a null status,
is unchanged and stays fail-closed. No retry loop: the fall-through makes
ticket item 3 unnecessary. Net ~14 lines.

## Evidence

**Probe** (pre-fix, confirms the mechanism): spawning a fixture that closes
stdin and exits 0, with a 300 KiB payload, gives `result.error.code=EPIPE`,
`result.status=0` (typeof number) on Node v24.20.0.

**RED (HEAD, pre-fix):** `node --test run-hook-with-bash.test.mjs` → 47
pass / 4 fail — exactly the 4 new cases:
- (a) chain-ALLOW: rc=2 + `failed to start ... EPIPE` (expected rc=0)
- (b) chain-DENY: got the generic `failed to start` text instead of the
  fixture's own deny text
- (c) lone-hook ALLOW: rc=2 + `failed to start` (expected rc=0)
- (control) `isRecoverableEpipe is not a function`

**GREEN (post-fix):** same suite → 51 pass / 0 fail (47 pre-existing + 4
new), `node --check` clean.

**Case (e) deviation:** the brief asked for an end-to-end CLI test pointing
the launcher at a hook whose interpreter cannot start. `resolveBash()`
always resolves a real, pre-validated system bash (checked via
`statSync`+`accessSync(X_OK)`) before any `spawnSync` call on this box, so
forcing a genuine non-EPIPE `result.error` would require corrupting the
system's own `/usr/bin/bash` — unsafe and out of scope. Substituted a
direct unit test on the extracted `isRecoverableEpipe` predicate instead:
EPIPE+null-status→false, ENOENT+status→false, EPIPE+status→true. This
predicate test pins the exact boundary the fix narrows.

**Lifecycle path (~L492–535):** left untouched per scope. It builds its own
`spawnSync` call with the same input-write shape, so it likely has the same
latent EPIPE-vs-status issue — but that is an unverified claim and a
separate fix if confirmed; not addressed here.

**Control comparison** (same fixture/payload, only the code differs):
- worktree (fixed): `rc=0`, clean
- primary (unfixed): `rc=2`, `run-hook-with-bash: failed to start /usr/bin/bash: spawnSync /usr/bin/bash EPIPE`

**Impacted suites:** `run-hook-with-bash.test.mjs` (51/0),
`test-hook-rewrite-integrity.sh` (OK), `bench-hook-stack.test.mjs` (OK).
`git grep -l 'run-hook-with-bash'` also hits wire-inventory / wizard / codex
suites, but those only reference the launcher's path string (wiring checks,
fixture filenames) — none of them actually spawn it, so nothing else
exercises the changed code paths.

## Out of scope (per ticket / brief)

- A retry loop (ticket item 3) — the fall-through makes it unnecessary.
- The ETIMEDOUT/ENOBUFS branch and `MUST_RUN` semantics — unchanged.
- The lifecycle path (see above) — left untouched.
- `docs/internals/enforcement.md` doesn't currently document the fail-closed
  spawn-error path, so no doc edit was needed.

## Test plan

- [x] `node --test scripts/hooks/run-hook-with-bash.test.mjs` — 51/0
- [x] `bash scripts/hooks/test-hook-rewrite-integrity.sh` — OK
- [x] `node --test scripts/hooks/bench-hook-stack.test.mjs` — OK
- [x] `node --check scripts/hooks/run-hook-with-bash.js` — clean
- [x] Control: fixed vs unfixed rc comparison (above)
- [x] `/pr-check` — critic panel round 1/3, codex responded clean (0/0/0), marker cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZ2dv6KYASmU1Tvye68uxL
