### PR TITLE
fix(qmd): [HIMMEL-2506] qmd-bin.sh resolves the better-sqlite3 binding from prebuilds/

### DIFF
--- a/scripts/lib/qmd-bin.sh
+++ b/scripts/lib/qmd-bin.sh
@@ -74,7 +74,22 @@ _qmd_build_stamp() { printf '%s\n' "$(_qmd_fork_dir)/.himmel-build-ok"; }
 # explicitly UNDER NODE (node's ABI is the one that matters); qmd_fork_served
 # treats a non-loadable binding as not-served so a broken install converges on
 # the next install pass.
-_qmd_sqlite_binding() { printf '%s\n' "$(_qmd_fork_dir)/node_modules/better-sqlite3/build/Release/better_sqlite3.node"; }
+_qmd_sqlite_binding() {
+  local sqlite_dir platform_arch binding
+  sqlite_dir="$(_qmd_fork_dir)/node_modules/better-sqlite3"
+  binding="$sqlite_dir/build/Release/better_sqlite3.node"
+  if [ -f "$binding" ]; then
+    printf '%s\n' "$binding"
+    return 0
+  fi
+  platform_arch="$(node -p "process.platform + '-' + process.arch" 2>/dev/null)" || return 1
+  for binding in "$sqlite_dir/prebuilds/$platform_arch"*.node; do
+    [ -f "$binding" ] || continue
+    printf '%s\n' "$binding"
+    return 0
+  done
+  return 1
+}
 
 # True when the node-side better-sqlite3 binding actually LOADS -- an
 # existence-only check would bless a wrong-ABI or corrupt artifact (file
@@ -93,10 +108,6 @@ _qmd_sqlite_binding_ok() {
   local probe probe_out
   _QMD_BINDING_PROBE_ERR=""
   command -v node >/dev/null 2>&1 || return 0
-  if [ ! -f "$(_qmd_sqlite_binding)" ]; then
-    _QMD_BINDING_PROBE_ERR="binding file missing: $(_qmd_sqlite_binding)"
-    return 1
-  fi
   probe="$(_qmd_fork_dir)/.himmel-binding-probe.cjs"
   printf "new (require('better-sqlite3'))(':memory:');\nconsole.log('qmd-binding-ok');\n" > "$probe" 2>/dev/null || return 1
   probe_out="$(node "$probe" 2>&1)"
@@ -105,6 +116,9 @@ _qmd_sqlite_binding_ok() {
     return 0
   fi
   _QMD_BINDING_PROBE_ERR="$probe_out"
+  if [ ! -f "$(_qmd_sqlite_binding)" ]; then
+    _QMD_BINDING_PROBE_ERR="no binding found under build/Release or prebuilds/: $probe_out"
+  fi
   return 1
 }
 
@@ -369,7 +383,7 @@ qmd_fork_served() {
 # falls through to update+rebuild+re-link on a stale/older/pin-drifted or
 # unstamped (failed/interrupted prior build) clone.
 qmd_install() {
-  local fork_dir ref repo global_dir origin_url
+  local fork_dir ref repo global_dir origin_url prebuild
 
   fork_dir="$(_qmd_fork_dir)"
   ref="$(_qmd_fork_ref)"
@@ -490,8 +504,15 @@ qmd_install() {
   # load-check is the real gate, and every external command here must stay
   # set-e-safe for callers.
   if command -v node >/dev/null 2>&1 && ! _qmd_sqlite_binding_ok; then
+    # 13.x bundles prebuilds; node-gyp is a no-op when they exist (HIMMEL-2506).
+    for prebuild in "$fork_dir/node_modules/better-sqlite3/prebuilds/"*.node; do
+      [ -f "$prebuild" ] || continue
+      echo "  WARNING: better-sqlite3 packaged binding not loadable under node: $prebuild" >&2
+      printf '    %s\n' "$_QMD_BINDING_PROBE_ERR" >&2
+      return 1
+    done
     echo "  Fetching better-sqlite3 native binding for node (bun blocks its postinstall)..."
-    rm -f -- "$(_qmd_sqlite_binding)"
+    rm -f -- "$fork_dir/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
     ( cd "$fork_dir/node_modules/better-sqlite3" && node ../prebuild-install/bin.js ) || true
     if ! _qmd_sqlite_binding_ok; then
       echo "  WARNING: better-sqlite3 native binding still not loadable under node - node-run qmd cannot open its index." >&2

--- a/scripts/lib/test-qmd-bin.sh
+++ b/scripts/lib/test-qmd-bin.sh
@@ -323,6 +323,7 @@ cat > "$id2/bin/node" <<'STUB'
 #!/usr/bin/env bash
 echo "NODE $*" >> "${NODE_LOG:?}"
 case "$1" in
+  -p) printf '%s\n' "${STUB_NODE_PLATFORM_ARCH:-linux-x64}" ;;
   */prebuild-install/bin.js)
     [ "${STUB_NODE_FETCH_RC:-0}" -eq 0 ] || exit "$STUB_NODE_FETCH_RC"
     mkdir -p build/Release
@@ -330,8 +331,11 @@ case "$1" in
     exit 0
     ;;
   *.himmel-binding-probe.cjs)
-    [ "${STUB_NODE_PROBE_RC:-0}" -eq 0 ] || exit "$STUB_NODE_PROBE_RC"
-    if [ -f "$(dirname "$1")/node_modules/better-sqlite3/build/Release/better_sqlite3.node" ]; then
+    if [ "${STUB_NODE_PROBE_RC:-0}" -ne 0 ]; then
+      echo 'stub binding load failed: wrong ABI' >&2
+      exit "$STUB_NODE_PROBE_RC"
+    fi
+    if [ "${STUB_NODE_PROBE_OK:-0}" = 1 ] || [ -f "$(dirname "$1")/node_modules/better-sqlite3/build/Release/better_sqlite3.node" ]; then
       echo "qmd-binding-ok"
       exit 0
     fi
@@ -345,6 +349,12 @@ chmod +x "$id2/bin/node"
 git_log="$id2/git-calls"
 bun_log="$id2/bun-calls"
 node_log="$id2/node-calls"
+node_gyp_log="$id2/node-gyp-calls"
+# Never let a repair regression invoke the host's node-gyp or npx/network.
+for cmd in node-gyp npx; do
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "%s"\nexit 1\n' "$node_gyp_log" > "$id2/bin/$cmd"
+  chmod +x "$id2/bin/$cmd"
+done
 qmd_install_env() { # $1 = HOME dir, remaining = the command to run under it
   local home="$1"; shift
   : > "$git_log"; : > "$bun_log"; : > "$node_log"
@@ -700,6 +710,65 @@ assert "binding fetch-fail: WARNs not-loadable with the manual command" grep -qi
 # leave fresh_home converged for any later assertions.
 out=$(qmd_install_env "$fresh_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
 assert "binding gate: fresh_home re-converged" grep -q '^RC=0$' <<<"$out"
+
+echo "[test-qmd-bin] packaged better-sqlite3 prebuilds (HIMMEL-2506)"
+# Catch the legacy-path early return and attempts to repair a packaged binary.
+prebuild_home="$id2/prebuild-only"
+sqlite_dir="$prebuild_home/.himmel/qmd-fork/node_modules/better-sqlite3"
+platform_arch="$(node -p "process.platform + '-' + process.arch")"
+mkdir -p "$prebuild_home/.himmel/qmd-fork/.git" "$sqlite_dir/prebuilds"
+prebuild="$sqlite_dir/prebuilds/$platform_arch.node"
+: > "$prebuild"
+: > "$node_gyp_log"
+out=$(STUB_NODE_PLATFORM_ARCH="$platform_arch" qmd_install_env "$prebuild_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; _qmd_sqlite_binding')
+assert "prebuild resolver: selects current platform without build/" test "$out" = "$prebuild"
+assert "prebuild resolver: queries platform and arch once" test "$(grep -c '^NODE -p ' "$node_log")" -eq 1
+out=$(STUB_NODE_PROBE_OK=1 qmd_install_env "$prebuild_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+assert "prebuild install: healthy probe succeeds" grep -q '^RC=0$' <<<"$out"
+assert "prebuild install: verified without creating build/" test ! -d "$sqlite_dir/build"
+assert "prebuild install: no prebuild-install fetch" test "$(grep -c 'prebuild-install/bin.js' "$node_log")" -eq 0
+assert "prebuild install: no node-gyp rebuild" test ! -s "$node_gyp_log"
+rc=0
+STUB_NODE_PROBE_OK=1 qmd_install_env "$prebuild_home" bash "$SCRIPT_DIR/qmd-bin.sh" fork-served >/dev/null 2>&1 || rc=$?
+assert "prebuild verify: fork-served accepts healthy prebuild" test "$rc" -eq 0
+
+# A packaged but unloadable binary must survive and retain its real diagnostic.
+out=$(STUB_NODE_PROBE_RC=1 qmd_install_env "$prebuild_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; qmd_install; echo "RC=$?"' 2>&1)
+assert "prebuild failure: returns nonzero" grep -q '^RC=1$' <<<"$out"
+assert "prebuild failure: preserves probe error" grep -q 'stub binding load failed: wrong ABI' <<<"$out"
+assert "prebuild failure: names packaged binary" grep -Fq "$prebuild" <<<"$out"
+assert "prebuild failure: preserves packaged binary" test -f "$prebuild"
+assert "prebuild failure: no prebuild-install fetch" test "$(grep -c 'prebuild-install/bin.js' "$node_log")" -eq 0
+assert "prebuild failure: no node-gyp rebuild" test ! -s "$node_gyp_log"
+assert "prebuild failure: no success stamp" test ! -f "$prebuild_home/.himmel/qmd-fork/.himmel-build-ok"
+
+# Darwin suffix spelling, and legacy build/Release takes precedence if present.
+rm -f "$prebuild"
+prebuild="$sqlite_dir/prebuilds/darwin-arm64+arm64.node"
+: > "$prebuild"
+out=$(STUB_NODE_PLATFORM_ARCH=darwin-arm64 qmd_install_env "$prebuild_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; _qmd_sqlite_binding')
+assert "prebuild resolver: accepts darwin architecture suffix" test "$out" = "$prebuild"
+mkdir -p "$sqlite_dir/build/Release"
+legacy_binding="$sqlite_dir/build/Release/better_sqlite3.node"
+: > "$legacy_binding"
+out=$(qmd_install_env "$prebuild_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; _qmd_sqlite_binding')
+assert "legacy resolver: build/Release takes precedence" test "$out" = "$legacy_binding"
+rm -f "$prebuild"
+rc=0
+qmd_install_env "$prebuild_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; _qmd_sqlite_binding_ok' || rc=$?
+assert "legacy control: load probe still succeeds without prebuilds" test "$rc" -eq 0
+
+# File discovery is advisory: the package loader, not our path list, decides.
+rm -f "$legacy_binding"
+# shellcheck disable=SC2016
+# Probe diagnostics expand inside the spawned bash, not in the parent suite.
+out=$(STUB_NODE_PROBE_RC=1 qmd_install_env "$prebuild_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; _qmd_sqlite_binding_ok; echo "RC=$?"; printf "%s\n" "$_QMD_BINDING_PROBE_ERR"' 2>&1)
+assert "missing binding: returns nonzero" grep -q '^RC=1$' <<<"$out"
+assert "missing binding: diagnoses both candidate locations" grep -q 'no binding found under build/Release or prebuilds/' <<<"$out"
+assert "missing binding: preserves load failure" grep -q 'stub binding load failed: wrong ABI' <<<"$out"
+rc=0
+STUB_NODE_PROBE_OK=1 qmd_install_env "$prebuild_home" bash -c '. "'"$SCRIPT_DIR"'/qmd-bin.sh"; _qmd_sqlite_binding_ok' || rc=$?
+assert "advisory discovery: successful loader overrides absent candidates" test "$rc" -eq 0
 
 echo "[test-qmd-bin] qmd_register_collection() add / idempotent-skip / warn (HIMMEL-752)"
 # Hermetic stub env: a fake `qmd` on PATH (no bun-qmd.js, no bun -> qmd_cmd


### PR DESCRIPTION
## Summary

- Resolve better-sqlite3 bindings from legacy `build/Release` or packaged `prebuilds/<platform>-<arch>*.node` files.
- Keep discovery advisory: the real Node load probe remains the installation acceptance gate.
- Preserve unloadable packaged binaries, report the probe error and packaged path, and skip the existing prebuild-install repair when packaged binaries exist.

Ticket: HIMMEL-2506

Fixes #628

## Verification

The implementation session recorded RED/GREEN before committing. This shipping session verified the exact pushed head and reran qmd-bin tests and shellcheck.

| Case | Before | After |
| --- | --- | --- |
| Prebuild-only resolver without build/ | RED: legacy path returned | GREEN: packaged binding selected |
| Prebuild-only install with successful probe | RED: missing binding / repair attempted | GREEN: install and fork-served succeed, no repair |
| Legacy build/Release without prebuilds | Control passes | GREEN: unchanged load behavior and precedence |
| No candidate and failing probe | Fails closed | GREEN: nonzero status, both locations diagnosed, probe error retained |

Additional fixtures cover unloadable packaged binary preservation, successful loader overriding absent discovery candidates, and a single platform/architecture query per resolution. Darwin suffixes such as `darwin-arm64+arm64.node` are stubbed; native macOS was not tested.

- Fresh `scripts/lib/test-qmd-bin.sh`: 167 pass / 0 fail.
- Fresh `shellcheck -x scripts/lib/qmd-bin.sh scripts/lib/test-qmd-bin.sh`: passed.
- Implementation-session `git diff --check`: passed.
- Consumer suites passed in the implementation session: test-fix-qmd-stub, test-wizard-deps, test-wizard-ensure, test-wizard-status-golden (no regeneration), test-qmd-cadence, test-qmd-reindex, test-ensure-qmd-daemon, test-adopt, test-himmel-update-chain.
- Known baseline: `scripts/test-check-plugin-drift.sh:220` fails on unchanged main because `PATH=/usr/bin:/bin` does not hide `/usr/bin/gh`; the gh-absent fixture returns rc=3. Tracked as HIMMEL-2812, no unrelated changes here.

## Review rounds

| Round | Head | Panel | CodeRabbit | CI |
| --- | --- | --- | --- | --- |
| 1 | `130337de88037103268e4df3c3fd7f173128466d` | 0 Critical / 0 Important / 1 Suggestion, deferred to HIMMEL-2955; marker cleared | Fresh exact-head review; 1 Minor deferred to HIMMEL-2955, thread resolved | All checks GREEN; check-ci exit=0 |

Panel responder: codex (`gpt-6-astra`), diff base `a76fb013b3f056b2f05104505ee4d2f3a4008542`. Companion adversarial pass skipped by its non-high-risk policy; no Claude reviewer agents. Known-findings round-1 hits: 0. Cumulative codex agreed rate: 25% across 1,432 findings.

Deferred `codex-1` to HIMMEL-2955: the any-platform packaged-binary guard also suppresses fallback when only foreign-platform binaries exist. Platform-specific repair is a separate tracked follow-up to the current packaged-binary preservation contract. Every panel finding is terminal: 0 still-open, 1 skip-terminal.

CodeRabbit Minor: libc-aware `linuxmusl` discovery and simulated-musl coverage are also tracked in HIMMEL-2955. Verified against the package loader: this affects advisory discovery/failure diagnostics, not successful musl loading, because the real require-based probe remains the acceptance gate. Replied in-thread and resolved as a tracked deferral, not as fixed.

Post-creation gate: `check-ci: all checks green + all review threads resolved (PR #668 @ 130337de88037103268e4df3c3fd7f173128466d); fresh coderabbitai review @ 130337de88037103268e4df3c3fd7f173128466d`. Exit=0. Handover bridges skipped because no active registered item resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native binding detection across compiled and platform-specific prebuilt versions.
  * Installation now reports clearer diagnostics when bindings are missing or cannot be loaded.
  * Prevented replacement attempts when a packaged prebuild is present but unusable.
  * Preserved valid existing bindings while avoiding unintended build-tool execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
