### PR TITLE
fix(template): [HIMMEL-2952] make luna upgrade parse under bash 3.2

### DIFF
--- a/scripts/himmel-update.sh
+++ b/scripts/himmel-update.sh
@@ -983,7 +983,7 @@ update_luna_template() {
         return 0
     fi
     STATUS_luna_template="failed"
-    DETAIL_luna_template="upgrade.sh exited $rc — see docs/luna, resolve any _CLAUDE.md.template-merge conflict"
+    if [ -f "$vault/_CLAUDE.md.template-merge" ]; then DETAIL_luna_template="upgrade.sh exited $rc — see docs/luna, resolve any _CLAUDE.md.template-merge conflict"; else DETAIL_luna_template="upgrade.sh exited $rc — ${out%%$'\n'*}"; fi
     return 1
 }
 

--- a/scripts/test-himmel-update-axis-b.sh
+++ b/scripts/test-himmel-update-axis-b.sh
@@ -186,6 +186,28 @@ assert_not_contains "--only did NOT run the jira dist rebuild" "\\[3/6\\]" "$OUT
 assert_contains "--only still prints the status table" "==> update chain status" "$OUT"
 
 echo ""
+echo "Test 2b: luna template failure reports the diagnostic, not a phantom conflict"
+make_mock_clone
+LUNA_CLONE="$CHECKOUT_DIR"
+LUNA_VAULT="$TMP/luna-vault"; mkdir -p "$LUNA_VAULT" "$LUNA_CLONE/templates/luna-second-brain/scripts"
+cat > "$LUNA_CLONE/templates/luna-second-brain/scripts/upgrade.sh" <<'UPGRADE'
+#!/usr/bin/env bash
+echo 'syntax error near unexpected token' >&2
+echo 'second diagnostic line' >&2
+exit 2
+UPGRADE
+git -C "$LUNA_CLONE" add -A
+git -C "$LUNA_CLONE" commit --quiet -m "failing upgrade fixture"
+OUT="$(LUNA_VAULT_PATH="$LUNA_VAULT" run_update "$LUNA_CLONE" "$TMP/luna-home" "$STUB1" --only luna_template)"; RC=$?
+assert_eq "luna parse failure exits nonzero" "1" "$RC"
+assert_contains "luna failure table carries the first diagnostic" 'luna_template  *failed  *upgrade.sh exited 2.*syntax error near unexpected token' "$OUT"
+assert_not_contains "luna failure without sidecar gives no conflict hint" 'resolve any _CLAUDE.md.template-merge conflict' "$OUT"
+: > "$LUNA_VAULT/_CLAUDE.md.template-merge"
+OUT="$(LUNA_VAULT_PATH="$LUNA_VAULT" run_update "$LUNA_CLONE" "$TMP/luna-home" "$STUB1" --only luna_template)"; RC=$?
+assert_eq "luna failure with sidecar still exits nonzero" "1" "$RC"
+assert_contains "luna failure with sidecar retains the conflict hint" 'resolve any _CLAUDE.md.template-merge conflict' "$OUT"
+
+echo ""
 echo "Test 3: --only pull honours the dirty-tree pre-check"
 printf 'dirty\n' >> "$CLONE1/file.txt"
 OUT="$(run_update "$CLONE1" "$FH1" "$STUB1" --only pull)"; RC=$?

--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/CHANGELOG.md
+++ b/templates/luna-second-brain/CHANGELOG.md
@@ -8,6 +8,11 @@ Version history for the luna-second-brain vault template (published as
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.4.28] — 2026-09-12
+
+### Fixed
+- `upgrade.sh` now parses under macOS bash 3.2 (GitHub #627 / HIMMEL-2952).
+
 ## [0.4.27] — 2026-09-10
 
 ### Fixed

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.27"
+    "version": "0.4.28"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/scripts/test-upgrade.sh
+++ b/templates/luna-second-brain/scripts/test-upgrade.sh
@@ -40,6 +40,78 @@ fi
 TMP=$(mktemp -d -t luna-upgrade.XXXXXX)
 trap 'rm -rf "$TMP"' EXIT
 
+# Bash 3.2 scans quotes even inside a quoted heredoc nested in $(...). The
+# structural fallback covers the command-substitution/heredoc form used here,
+# including a newline between the substitution opener and the command.
+check_nested_heredoc_quotes() {
+    "$PY" - "$1" <<'PY'
+import pathlib, re, sys
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+pattern = re.compile(r"\$\([^)]*?<<(-?)\s*'([A-Za-z_][A-Za-z_0-9]*)'[^\n]*\n(.*?)^\2[ \t]*$", re.M | re.S)
+failed = False
+for match in pattern.finditer(text):
+    body = match.group(3)
+    for quote in ("'", "`"):
+        if body.count(quote) % 2:
+            line = text.count("\n", 0, match.start()) + 1
+            print("%s:%s: unbalanced %r in nested heredoc" % (sys.argv[1], line, quote))
+            failed = True
+sys.exit(1 if failed else 0)
+PY
+}
+
+cat > "$TMP/bash32-repro.sh" <<'REPRO'
+#!/usr/bin/env bash
+M="$(python3 - 2>/dev/null <<'PY'
+# this script's own writer
+PY
+)"
+echo "tail (paren)"
+REPRO
+check_nested_heredoc_quotes "$UPGRADE"; rc=$?
+assert_eq "T0 upgrade nested heredocs have balanced quotes" "0" "$rc"
+check_nested_heredoc_quotes "$TMP/bash32-repro.sh"; rc=$?
+assert_eq "T0 structural RED control rejects reporter repro" "1" "$rc"
+"$PY" - "$TMP" <<'PY'
+import pathlib, sys
+root = pathlib.Path(sys.argv[1])
+repro = (root / "bash32-repro.sh").read_text(encoding="utf-8")
+(root / "bash32-fixed.sh").write_text(repro.replace("script's", "script"), encoding="utf-8")
+(root / "bash32-backtick.sh").write_text(repro.replace("script's", "script`s"), encoding="utf-8")
+(root / "bash32-multiline.sh").write_text(repro.replace("$(python3", "$(\npython3"), encoding="utf-8")
+PY
+check_nested_heredoc_quotes "$TMP/bash32-fixed.sh"; rc=$?
+assert_eq "T0 structural control accepts repaired repro" "0" "$rc"
+for fixture in backtick multiline; do
+    check_nested_heredoc_quotes "$TMP/bash32-$fixture.sh"; rc=$?
+    assert_eq "T0 structural RED control rejects $fixture repro" "1" "$rc"
+done
+
+bash32="${BASH32:-}"
+if [ -z "$bash32" ]; then
+    for candidate in bash-3.2 bash32 bash3.2 bash /bin/bash; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            case "$("$candidate" --version 2>/dev/null)" in
+                *'version 3.2.'*) bash32="$candidate"; break ;;
+            esac
+        fi
+    done
+fi
+if [ -n "$bash32" ]; then
+    # The version variables must expand in the candidate interpreter.
+    # shellcheck disable=SC2016
+    if [ "$("$bash32" -c 'printf "%s.%s" "${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}"')" = "3.2" ]; then
+        "$bash32" -n "$UPGRADE"; rc=$?
+        assert_eq "T0 real bash 3.2 parses upgrade" "0" "$rc"
+        "$bash32" -n "$TMP/bash32-repro.sh" 2>/dev/null; rc=$?
+        assert_eq "T0 real bash 3.2 rejects reporter repro" "2" "$rc"
+    else
+        fail "T0 bash 3.2 interpreter" "$bash32 is not bash 3.2"
+    fi
+else
+    echo "SKIP T0 real bash 3.2 — not available; structural gate ran"
+fi
+
 sha_of() { if [ -f "$1" ]; then "${SHA256[@]}" "$1" | cut -d' ' -f1; else echo MISSING; fi; }
 
 # Build a minimal but representative template fixture at $1 with version $2.

--- a/templates/luna-second-brain/scripts/upgrade.sh
+++ b/templates/luna-second-brain/scripts/upgrade.sh
@@ -238,14 +238,14 @@ except Exception:
 if not isinstance(d, dict):
     sys.exit(1)
 if "files" not in d:
-    sys.exit(0)  # legacy stamp, no `files` key at all — fall back to git.
+    sys.exit(0)  # legacy stamp, no files key at all — fall back to git.
 files = d.get("files")
 if not isinstance(files, dict):
-    sys.exit(1)  # present but unusable (e.g. explicit `"files": null`) — an error, not legacy.
+    sys.exit(1)  # present but unusable (e.g. explicit "files": null) — an error, not legacy.
 for rel in sorted(files):
     sha = files[rel]
     # A rel with a tab/newline in it would corrupt the row format; such a path
-    # cannot come from this script's own writer, so skip rather than trust it.
+    # cannot come from the writer in this script, so skip rather than trust it.
     if isinstance(sha, str) and isinstance(rel, str) and not (set("\t\n\r") & set(rel)):
         print("%s\t%s" % (rel, sha))
 PY


### PR DESCRIPTION
## Summary

Fixes #627. Tracks HIMMEL-2952.

- Remove apostrophe/backtick characters from three Python comments in the quoted heredoc nested inside the snapshot-map command substitution; Python behavior is unchanged.
- Add structural positive/negative regression controls, plus a real Bash 3.2 syntax check when `BASH32` or a detected Bash 3.2 interpreter is available.
- Report the first captured diagnostic when an upgrade fails without a `_CLAUDE.md.template-merge` sidecar; retain the conflict hint when the sidecar exists.
- Bump both template version anchors to 0.4.28 and add the changelog entry.

## Reporter reproduction

```sh
#!/usr/bin/env bash
M="$(python3 - 2>/dev/null <<'PY'
# this script's own writer
PY
)"
echo "tail (paren)"
```

The reporter demonstrated that Bash 3.2 misparses the apostrophe inside this nested heredoc. Bash 5 accepting it is not evidence of Bash 3.2 compatibility.

## Verification

- RED before the repair: the upgrade structural check rejected the original production script and the reporter fixture. The axis-b suite failed its diagnostic/no-phantom-conflict assertions.
- GREEN after the repair: full `templates/luna-second-brain/scripts/test-upgrade.sh`; the reporter, unmatched-backtick, and multiline-substitution negative controls remain rejected, and the repaired fixture is accepted.
- Fresh verification at `6f091270a0f85327bb59714b60c8aaf0dc455a64`: upgrade suite PASS; `scripts/test-himmel-update-axis-b.sh` PASS (112 assertions); `shellcheck -x` on all four touched shell files PASS; committed diff whitespace check PASS.
- Earlier implementation verification: upgrade Python-resolution, salus upgrade, update-chain, luna-upgrade-all, template-version, wizard dependencies/status-upgrade, upstream tool upgrade/drift cadence suites PASS; Python luna-upgrade skill VM unit suite PASS (31 tests).
- Actual Bash 3.2 and Darwin execution were unavailable on the Linux station. The structural controls are the compatibility evidence here, not a claim of execution on macOS. PowerShell and provisioned-VM end-to-end tests were not run.

## Heredoc audit and known-findings disposition

- `upgrade.sh:232` nested `PY`: removed comment apostrophe and paired backticks at lines 241, 244, and 248.
- `USAGE` at line 59 and standalone `PY` blocks at lines 574 and 846 are not inside command substitutions and were left unchanged.
- PowerShell twins are deliberately unchanged: this patch repairs Bash parsing and introduces Bash-specific syntax controls, with no change to the shared Python algorithm.
- The chain behavior is tested in `scripts/test-himmel-update-axis-b.sh`; the conventional paired-test-name detector does not recognize this existing axis suite.

## Review

| Round | Head | Source | Critical | Important | Suggestions | Disposition |
|---|---|---|---:|---:|---:|---|
| 1 of 3 | `6f091270a0f85327bb59714b60c8aaf0dc455a64` | codex panel | 0 | 0 | 1 | `codex-1` deferred to HIMMEL-2956 |

The confirmed suggestion concerns a structural-checker gap for tab-indented `<<-` closing delimiters. The production heredoc repaired here uses a column-zero terminator. HIMMEL-2956 tracks the additional matcher support and negative control; the finding has a terminal, ticketed deferral in the review ledger. The adversarial companion was skipped by the configured not-high-risk gate. No unaddressed findings or phase-A orphans remain. The pre-PR review marker cleared; post-PR CodeRabbit review and CI are separate pending checks.

Platforms tested: linux
Security reviewed: manual — comment text, parse gate, failure diagnostic and version metadata; no production execution surface change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
