### PR TITLE
test(ci): [HIMMEL-2812] fix vacuous hermetic-PATH fail-open assertion in check-plugin-drift suite

### DIFF
--- a/scripts/test-check-plugin-drift.sh
+++ b/scripts/test-check-plugin-drift.sh
@@ -224,7 +224,7 @@ fi
 #    run the script, dirname for its `$(dirname "$0")` ROOT resolution) and
 #    deliberately excluding gh, then assert the precondition that gh really is
 #    unreachable under that PATH before trusting the run.
-NOGH_BIN="$(mktemp -d)"
+NOGH_BIN="$(mktemp -d "${TMPDIR:-/tmp}/nogh-bin.XXXXXX")"
 ln -s "$(command -v bash)" "$NOGH_BIN/bash"
 ln -s "$(command -v dirname)" "$NOGH_BIN/dirname"
 if PATH="$NOGH_BIN" command -v gh >/dev/null 2>&1; then

--- a/scripts/test-check-plugin-drift.sh
+++ b/scripts/test-check-plugin-drift.sh
@@ -224,20 +224,23 @@ fi
 #    run the script, dirname for its `$(dirname "$0")` ROOT resolution) and
 #    deliberately excluding gh, then assert the precondition that gh really is
 #    unreachable under that PATH before trusting the run.
-NOGH_BIN="$(mktemp -d "${TMPDIR:-/tmp}/nogh-bin.XXXXXX")"
-ln -s "$(command -v bash)" "$NOGH_BIN/bash"
-ln -s "$(command -v dirname)" "$NOGH_BIN/dirname"
-if PATH="$NOGH_BIN" command -v gh >/dev/null 2>&1; then
-  bad "fail-open fixture precondition failed: gh still reachable under stub PATH"
-else
-  fo_out="$(PATH="$NOGH_BIN" bash "$SCRIPT" 2>&1)"; fo_rc=$?
-  if [ "$fo_rc" -eq 0 ] && grepq "$fo_out" "fail-open"; then
-    ok "fail-open: gh absent -> exit 0 + skip message"
+if NOGH_BIN="$(mktemp -d "${TMPDIR:-/tmp}/nogh-bin.XXXXXX")"; then
+  ln -s "$(command -v bash)" "$NOGH_BIN/bash"
+  ln -s "$(command -v dirname)" "$NOGH_BIN/dirname"
+  if PATH="$NOGH_BIN" command -v gh >/dev/null 2>&1; then
+    bad "fail-open fixture precondition failed: gh still reachable under stub PATH"
   else
-    bad "fail-open broken: rc=$fo_rc out=$fo_out"
+    fo_out="$(PATH="$NOGH_BIN" bash "$SCRIPT" 2>&1)"; fo_rc=$?
+    if [ "$fo_rc" -eq 0 ] && grepq "$fo_out" "fail-open"; then
+      ok "fail-open: gh absent -> exit 0 + skip message"
+    else
+      bad "fail-open broken: rc=$fo_rc out=$fo_out"
+    fi
   fi
+  rm -rf "$NOGH_BIN"
+else
+  bad "fail-open fixture: mktemp -d failed"
 fi
-rm -rf "$NOGH_BIN"
 
 # 5b. Malformed vendored-fork UPSTREAM_PIN: a fork pin missing the generic
 #     fields must mark the run incomplete, never skip into a false all-current.

--- a/scripts/test-check-plugin-drift.sh
+++ b/scripts/test-check-plugin-drift.sh
@@ -217,12 +217,27 @@ fi
 
 # 5. Fail-open path, deterministically (hide gh from PATH). The script's headline
 #    safety property: gh absent -> exit 0 + skip, so CI / fresh clones never break.
-fo_out="$(PATH=/usr/bin:/bin bash "$SCRIPT" 2>&1)"; fo_rc=$?
-if [ "$fo_rc" -eq 0 ] && grepq "$fo_out" "fail-open"; then
-  ok "fail-open: gh absent -> exit 0 + skip message"
+#    A system-directory PATH (e.g. /usr/bin:/bin) does NOT hide gh — gh, jq, git,
+#    sha256sum etc. all live in /usr/bin on this station (HIMMEL-2524's inverse
+#    mistake: hiding by directory re-admits the very tool named). Build a minimal
+#    stub dir instead, naming only what this fail-open path itself needs (bash to
+#    run the script, dirname for its `$(dirname "$0")` ROOT resolution) and
+#    deliberately excluding gh, then assert the precondition that gh really is
+#    unreachable under that PATH before trusting the run.
+NOGH_BIN="$(mktemp -d)"
+ln -s "$(command -v bash)" "$NOGH_BIN/bash"
+ln -s "$(command -v dirname)" "$NOGH_BIN/dirname"
+if PATH="$NOGH_BIN" command -v gh >/dev/null 2>&1; then
+  bad "fail-open fixture precondition failed: gh still reachable under stub PATH"
 else
-  bad "fail-open broken: rc=$fo_rc out=$fo_out"
+  fo_out="$(PATH="$NOGH_BIN" bash "$SCRIPT" 2>&1)"; fo_rc=$?
+  if [ "$fo_rc" -eq 0 ] && grepq "$fo_out" "fail-open"; then
+    ok "fail-open: gh absent -> exit 0 + skip message"
+  else
+    bad "fail-open broken: rc=$fo_rc out=$fo_out"
+  fi
 fi
+rm -rf "$NOGH_BIN"
 
 # 5b. Malformed vendored-fork UPSTREAM_PIN: a fork pin missing the generic
 #     fields must mark the run incomplete, never skip into a false all-current.


### PR DESCRIPTION
## Summary
- Swept every himmel shell suite for the "vacuous-by-hermetic-PATH" assertion class named in HIMMEL-2812 — `[ -z "$(cmd ...)" ]` silently passing when `cmd` is unreachable on a scrubbed PATH, rather than because the property genuinely holds.
- 19 suites checked; every other `PATH=`/`scrub_path` override found is scoped to a single subprocess (`PATH=... cmd` / `env PATH=... cmd`), which never persists into a later assertion in the same suite's ambient shell — so those are not vacuous.
- **One real hit**: `scripts/test-check-plugin-drift.sh:220` (fail-open fixture) built its stub PATH as `/usr/bin:/bin` — a system directory that does NOT hide `gh` on this station (`gh`/`jq`/`git`/`sha256sum`/`bash`/`dirname` are all co-located in `/usr/bin`, the HIMMEL-2524 inverse mistake). Fixed by building a minimal stub dir naming only the tools the fail-open path itself needs (`bash`, `dirname`), asserting the precondition that `gh` is genuinely unreachable under it before trusting the run, and proving both directions with a planted-fake-`gh` RED/GREEN control.
- Follow-up commits (CR round + known-findings self-review, same PR): mktemp portability template, and checking `mktemp -d`'s own exit status before building paths on its result.

## Follow-up
- Filed HIMMEL-2957 — a structural-guard ticket describing (not implementing) a detector for this assertion class: flag only *ambient-scope* PATH mutations co-occurring with an emptiness assertion, explicitly excluding the safe per-subprocess `PATH=... cmd` idiom used throughout this codebase.

## Test plan
- [x] `shellcheck -x scripts/test-check-plugin-drift.sh` — clean
- [x] `bash scripts/quiet-run.sh check-plugin-drift-suite -- bash scripts/test-check-plugin-drift.sh` — OK, 0 FAIL
- [x] RED: confirmed the pre-fix `/usr/bin:/bin` stub does not hide `gh` on this station; GREEN: confirmed the new stub dir hides `gh` (`command -v gh` fails) and a planted fake `gh` in the stub dir makes the precondition check correctly fail — the guard is real and falsifiable
- [x] `/pr-check` cross-model critic panel: round 1 raised one Important (unchecked `mktemp -d` failure), fixed inline; round 2 clean, 1/1 responded, marker cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jUD6Edx8YXoYmapvnko9U