### PR TITLE
fix(guardrails): [HIMMEL-2951] drop ada/somebody/yotamleo from ALLOW_HOME_NAMES

### DIFF
--- a/scripts/guardrails/leak-classes.sh
+++ b/scripts/guardrails/leak-classes.sh
@@ -86,11 +86,14 @@
 #   <reason>` marker instead (scripts/telegram/spawn-glm.test.ts, scripts/
 #   trust/shadow-ledger.mjs + its test, scripts/himmelctl/lib/install-engine.js,
 #   scripts/parity/test-ps-twin-oem-encoding.ps1, docs/internals/
-#   environment-gotchas.md, and this file's own doc comments). jarrod, ada,
-#   somebody and yotamleo stay in this list for now -- their only fixture
-#   dependents sit under directories this batch may not touch (a vendored
-#   tree, and hook-integrity/lanes fences); tracked in a HIMMEL-2825
-#   follow-up ticket.
+#   environment-gotchas.md, and this file's own doc comments). HIMMEL-2951
+#   removed 3 more (ada, somebody, yotamleo -- yotamleo being the operator's
+#   real username, the highest-value one) the same way, across scripts/hooks/,
+#   scripts/lanes/tests/, and scripts/test-uninstall-guard.sh. jarrod stays in
+#   this list for now -- its only fixture dependents (13 lines in the
+#   vendored marketplace/plugins/claude-hud/tests/render.test.js) need the
+#   VENDORED.manifest re-hash + fork-delta ceremony first; tracked in
+#   HIMMEL-2958.
 #   leaktestuser, leaker, testop, testuser, test, osboxes, nulleak, name,
 #   yourname, wineonlyuser, shouldnotleak, realop, quarantoken, priorleak,
 #   posixuser, profileonlyuser, unixonlyuser, fakeuser, myvault, op, ops,
@@ -176,7 +179,7 @@ HOSTNAME_HITS=()
 # ---- home-path allowlist (see header for rationale) ----
 # shellcheck disable=SC2016 # single-quoted on purpose: $user/${user}/$env:username
 # are literal placeholder tokens this list matches against, not expansions.
-ALLOW_HOME_NAMES=' you user <user> $user ${user} me <me> example <you> %username% $env:username %s leaktestuser leaker testop testuser test osboxes nulleak name <name> yourname wineonlyuser shouldnotleak realop quarantoken priorleak posixuser profileonlyuser unixonlyuser fakeuser myvault op ops otheruser fakeop jarrod ada somebody yotamleo runneradmin fake-sensitive-scriptpath-marker ... parity mismatched plainhome whoever msysuser fixture runner other current-user '
+ALLOW_HOME_NAMES=' you user <user> $user ${user} me <me> example <you> %username% $env:username %s leaktestuser leaker testop testuser test osboxes nulleak name <name> yourname wineonlyuser shouldnotleak realop quarantoken priorleak posixuser profileonlyuser unixonlyuser fakeuser myvault op ops otheruser fakeop jarrod runneradmin fake-sensitive-scriptpath-marker ... parity mismatched plainhome whoever msysuser fixture runner other current-user '
 
 home_name_allowed() {
     local name="$1"

--- a/scripts/guardrails/test-leak-classes.sh
+++ b/scripts/guardrails/test-leak-classes.sh
@@ -434,7 +434,7 @@ fi
 # still saw the bare name. Confirm an allowlisted name stays allowlisted
 # when immediately followed by each of those shapes.
 r=$(new_repo)
-printf '"/home/ada", (/home/ada) and `/home/ada`\n' > "$r/quoted-allowed.txt"  # leak-allow: home-path test fixture
+printf '"/home/otheruser", (/home/otheruser) and `/home/otheruser`\n' > "$r/quoted-allowed.txt"  # leak-allow: home-path test fixture
 git -C "$r" add quoted-allowed.txt
 scan "$r" --tree
 if [ "$SCAN_RC" -eq 0 ] && [ -z "$(strip_hostname_skip "$SCAN_OUT")" ]; then
@@ -542,6 +542,41 @@ if [ "$SCAN_RC" -eq 1 ] && grepq "$SCAN_OUT" -F "home-path" && grepq "$SCAN_OUT"
     pass "T1u home-path: a genuine home path still flagged alongside a regex-literal line"
 else
     fail "T1u home-path RED-preserving control (rc=$SCAN_RC) out=$SCAN_OUT"
+fi
+
+# T1v (HIMMEL-2951): finishes HIMMEL-2825's ALLOW_HOME_NAMES drift for the
+# three residual names removed here (ada, somebody, yotamleo -- the fourth,
+# jarrod, stays allowlisted pending a vendored-tree follow-up). Same proof as
+# T1e: an unmarked home path under one of these formerly-allowlisted names is
+# now flagged like any other real name.
+r=$(new_repo)
+printf 'HOME=/home/ada\n' > "$r/removed-allowlist2.txt"  # leak-allow: home-path test fixture
+printf 'HOME=/home/somebody\n' >> "$r/removed-allowlist2.txt"  # leak-allow: home-path test fixture
+printf 'HOME=/home/yotamleo\n' >> "$r/removed-allowlist2.txt"  # leak-allow: home-path test fixture
+git -C "$r" add removed-allowlist2.txt
+scan "$r" --tree
+if [ "$SCAN_RC" -eq 1 ] && grepq "$SCAN_OUT" -F "home-path" &&
+    grepq "$SCAN_OUT" -F "removed-allowlist2.txt:1" &&
+    grepq "$SCAN_OUT" -F "removed-allowlist2.txt:2" &&
+    grepq "$SCAN_OUT" -F "removed-allowlist2.txt:3"; then
+    pass "T1v home-path: formerly-allowlisted names (ada, somebody, yotamleo) are now each flagged unless marked"
+else
+    fail "T1v home-path removed-allowlist-names control (rc=$SCAN_RC) out=$SCAN_OUT"
+fi
+
+# T1v2: ...and the same three names stay clean when their own fixture lines
+# carry the leak-allow marker -- proving the per-line convention is a working
+# replacement for all three, not just a removal.
+r=$(new_repo)
+printf 'HOME=/home/ada  # leak-allow: home-path test fixture\n' > "$r/marked2.txt"
+printf 'HOME=/home/somebody  # leak-allow: home-path test fixture\n' >> "$r/marked2.txt"
+printf 'HOME=/home/yotamleo  # leak-allow: home-path test fixture\n' >> "$r/marked2.txt"
+git -C "$r" add marked2.txt
+scan "$r" --tree
+if [ "$SCAN_RC" -eq 0 ] && [ -z "$(strip_hostname_skip "$SCAN_OUT")" ]; then
+    pass "T1v2 home-path: same three formerly-allowlisted names stay clean with their own leak-allow marker"
+else
+    fail "T1v2 home-path marked-fixture control (rc=$SCAN_RC) out=$SCAN_OUT"
 fi
 
 echo "== redaction =="

--- a/scripts/hooks/check-settings-portability.sh
+++ b/scripts/hooks/check-settings-portability.sh
@@ -79,15 +79,15 @@ selftest() {
         exit 1
     fi
 }
-selftest "$ABS_PATTERN" '      "command": "C:/Users/somebody/.local/bin/tool run",' ABS_PATTERN
-selftest "$ABS_PATTERN" '      "command": "/home/somebody/bin/tool run",' ABS_PATTERN
+selftest "$ABS_PATTERN" '      "command": "C:/Users/somebody/.local/bin/tool run",' ABS_PATTERN  # leak-allow: home-path fixture username, not a real path
+selftest "$ABS_PATTERN" '      "command": "/home/somebody/bin/tool run",' ABS_PATTERN  # leak-allow: home-path fixture username, not a real path
 # The backslash member of `[/\]` specifically — a regex flavour that read that
 # bracket as an escaped `]` would silently stop matching Windows-style paths
 # while the forward-slash probe above kept passing.
-selftest "$ABS_PATTERN" '      "command": "C:\\Users\\somebody\\bin\\tool run",' ABS_PATTERN
+selftest "$ABS_PATTERN" '      "command": "C:\\Users\\somebody\\bin\\tool run",' ABS_PATTERN  # leak-allow: home-path fixture username, not a real path
 # A home directory on another drive leaks a username exactly as hard, and
 # /root is the same class on Linux — both were missed by a C:-only pattern.
-selftest "$ABS_PATTERN" '      "command": "D:/Users/somebody/bin/tool run",' ABS_PATTERN
+selftest "$ABS_PATTERN" '      "command": "D:/Users/somebody/bin/tool run",' ABS_PATTERN  # leak-allow: home-path fixture username, not a real path
 selftest "$ABS_PATTERN" '      "command": "/root/bin/tool run",' ABS_PATTERN
 selftest "$EXE_PATTERN" '      "command": "tool.EXE hook-check"' EXE_PATTERN
 # A `.exe` reached only by crossing a JSON-escaped quote — the shape `[^"]*`

--- a/scripts/hooks/test-check-settings-portability.sh
+++ b/scripts/hooks/test-check-settings-portability.sh
@@ -68,7 +68,7 @@ JSON
 }
 
 # --- RED: the three shapes the gate exists to refuse ------------------------
-write_settings "$TMP/.claude/settings.json" '"C:/Users/somebody/.local/bin/graphify.EXE hook-guard search"'
+write_settings "$TMP/.claude/settings.json" '"C:/Users/somebody/.local/bin/graphify.EXE hook-guard search"'  # leak-allow: home-path fixture username, not a real path
 case_rc "windows absolute user path refused" 1 "$TMP/.claude/settings.json"
 
 write_settings "$TMP/.claude/settings.local.json" '"/home/osboxes/.local/bin/graphify hook-guard read"'
@@ -121,7 +121,7 @@ printf '%s\n' '{"hooks":{"PreToolUse":[{"hooks":[{"command":"graphify.EXE hook-c
 case_rc "minified JSON: .EXE command still refused" 1 "$TMP/.claude/settings.json"
 
 # --- coverage the C:-only / line-only rules used to miss ---------------------
-write_settings "$TMP/.claude/settings.json" '"D:/Users/somebody/.local/bin/tool run"'
+write_settings "$TMP/.claude/settings.json" '"D:/Users/somebody/.local/bin/tool run"'  # leak-allow: home-path fixture username, not a real path
 case_rc "absolute path on a NON-C drive refused" 1 "$TMP/.claude/settings.json"
 
 write_settings "$TMP/.claude/settings.json" '"/root/.local/bin/tool run"'
@@ -172,7 +172,7 @@ JSON
 case_rc "multi-line portable command passes" 0 "$TMP/.codex/hooks.json"
 
 # --- scope control: a violation in a file this gate does not own ------------
-write_settings "$TMP/other/notes.json" '"C:/Users/somebody/.local/bin/graphify.EXE hook-guard search"'
+write_settings "$TMP/other/notes.json" '"C:/Users/somebody/.local/bin/graphify.EXE hook-guard search"'  # leak-allow: home-path fixture username, not a real path
 case_rc "violation outside the scanned filenames is ignored" 0 "$TMP/other/notes.json"
 
 # --- the regression guard: this repo's own tracked files --------------------

--- a/scripts/hooks/test-guard-console-dispatch.sh
+++ b/scripts/hooks/test-guard-console-dispatch.sh
@@ -99,7 +99,7 @@ BARE_FILENAME_TRANSCRIPT="$TMP/bare-filename.jsonl"
 printf '%s\n' '{"type":"user","message":{"content":"See notes-console.md for context."}}' > "$BARE_FILENAME_TRANSCRIPT"
 
 REAL_HANDOVER_TRANSCRIPT="$TMP/real-handover.jsonl"
-printf '%s\n' '{"type":"user","message":{"content":"Loaded handover: /home/yotamleo/state/handovers/yotamleo/himmel/HIMMEL-2323-console.md — resume from there."}}' > "$REAL_HANDOVER_TRANSCRIPT"
+printf '%s\n' '{"type":"user","message":{"content":"Loaded handover: /home/yotamleo/state/handovers/yotamleo/himmel/HIMMEL-2323-console.md — resume from there."}}' > "$REAL_HANDOVER_TRANSCRIPT"  # leak-allow: home-path operator username in a dispatch fixture
 
 # HIMMEL-2323 CR round 2 [w1-2323-b7d2] [codex-2]: the scan must be scoped to
 # the FIRST USER TURN, not any early line — a system prompt, tool result, or

--- a/scripts/lanes/tests/bench-aggregate-tokens.test.mjs
+++ b/scripts/lanes/tests/bench-aggregate-tokens.test.mjs
@@ -22,20 +22,20 @@ const HAIKU_SAMPLE = join(TEST_DIR, 'fixtures', 'bench-transcripts', 'haiku-samp
 const LUNA_SAMPLE = join(TEST_DIR, 'fixtures', 'bench-transcripts', 'luna-sample.jsonl');
 
 test('windowsDriveFormPath converts a Git-Bash POSIX mount path and passes through a native form', () => {
-  assert.equal(windowsDriveFormPath('/c/Users/ada/AppData/Local/Temp'), 'C:\\Users\\ada\\AppData\\Local\\Temp');
-  assert.equal(windowsDriveFormPath('C:\\Users\\ada'), 'C:\\Users\\ada'); // already native, no-op
+  assert.equal(windowsDriveFormPath('/c/Users/ada/AppData/Local/Temp'), 'C:\\Users\\ada\\AppData\\Local\\Temp');  // leak-allow: home-path fixture username, not a real path
+  assert.equal(windowsDriveFormPath('C:\\Users\\ada'), 'C:\\Users\\ada'); // already native, no-op  // leak-allow: home-path fixture username, not a real path
 });
 
 test('cwdToProjectSlug matches the empirically-verified real ~/.claude/projects encoding', () => {
   // Verified against a real directory on this machine (username neutralized,
   // HIMMEL-1730 — the transform is username-agnostic, only the literal changed):
-  // C:\Users\ada\AppData\Local\Temp -> C--Users-ada-AppData-Local-Temp
-  assert.equal(cwdToProjectSlug('/c/Users/ada/AppData/Local/Temp', 'win32'), 'C--Users-ada-AppData-Local-Temp');
-  assert.equal(cwdToProjectSlug('C:\\Users\\ada\\AppData\\Local\\Temp', 'win32'), 'C--Users-ada-AppData-Local-Temp');
+  // C:\Users\ada\AppData\Local\Temp -> C--Users-ada-AppData-Local-Temp  // leak-allow: home-path fixture username, not a real path
+  assert.equal(cwdToProjectSlug('/c/Users/ada/AppData/Local/Temp', 'win32'), 'C--Users-ada-AppData-Local-Temp');  // leak-allow: home-path fixture username, not a real path
+  assert.equal(cwdToProjectSlug('C:\\Users\\ada\\AppData\\Local\\Temp', 'win32'), 'C--Users-ada-AppData-Local-Temp');  // leak-allow: home-path fixture username, not a real path
 });
 
 test('cwdToProjectSlug is a no-op path-shape conversion off Windows', () => {
-  assert.equal(cwdToProjectSlug('/home/ada/project', 'linux'), 'home-ada-project');
+  assert.equal(cwdToProjectSlug('/home/ada/project', 'linux'), 'home-ada-project');  // leak-allow: home-path fixture username, not a real path
 });
 
 test('sumTranscriptUsage sums the committed synthetic sample fixtures correctly', () => {

--- a/scripts/test-uninstall-guard.sh
+++ b/scripts/test-uninstall-guard.sh
@@ -99,7 +99,7 @@ fi
 # Without these a guard that refused everything would pass every row above.
 allowed "$TMP/deep/cache"
 allowed "$HOME/.claude/himmel"
-allowed 'C:/Users/somebody/.claude/himmel'   # a drive SUBPATH, not a root
+allowed 'C:/Users/somebody/.claude/himmel'   # a drive SUBPATH, not a root  # leak-allow: home-path fixture username, not a real path
 allowed "$TMP/does-not-exist"               # absent target: nothing to refuse
 
 # ── protected_path (HIMMEL-2505): the fixed hard-refuse allowlist ───────────


### PR DESCRIPTION
## Summary

Finishes HIMMEL-2825's `ALLOW_HOME_NAMES` cleanup: removes `ada`, `somebody` and `yotamleo` (the operator's real username — the highest-value residual name to close) from the global exemption list in `scripts/guardrails/leak-classes.sh`, replacing each with a same-line `# leak-allow: home-path <reason>` marker on their fixture dependents. `jarrod`'s only dependents sit in a vendored tree (`marketplace/plugins/claude-hud/tests/render.test.js`) that needs the `VENDORED.manifest` re-hash + fork-delta ceremony — deferred to **HIMMEL-2958**.

## Site table

| Name | File | Lines |
|---|---|---|
| somebody | `scripts/hooks/check-settings-portability.sh` | 82, 83, 87, 90 |
| somebody | `scripts/hooks/test-check-settings-portability.sh` | 71, 124, 175 |
| somebody | `scripts/test-uninstall-guard.sh` | 102 (found via re-grep — not in the original ticket table) |
| yotamleo | `scripts/hooks/test-guard-console-dispatch.sh` | 102 |
| ada | `scripts/lanes/tests/bench-aggregate-tokens.test.mjs` | 25 (×2), 26 (×2), 32, 33, 34, 38 |

## RED → GREEN

- New `T1v`/`T1v2` cases in `test-leak-classes.sh` (modelled on `T1e`/`T1e2`): unmarked `/home/{ada,somebody,yotamleo}` lines flagged; same lines with the marker stay clean. Confirmed RED against the pre-change allowlist, GREEN after.
- `T1r`'s punctuation-adjacent-allowlisted-name fixture switched from `ada` (no longer allowlisted) to `otheruser`.
- `scripts/guardrails/leak-classes.sh --tree` and `--staged`: rc=0.
- Impacted suites, all green: `test-leak-classes.sh`, `test-check-settings-portability.sh`, `test-guard-console-dispatch.sh`, `node --test bench-aggregate-tokens.test.mjs` (9/9), `test-plugin-hook-bash-wiring.sh`, `test-uninstall-guard.sh`, `test-hook-rewrite-integrity.sh` + `test-record-hook-integrity.sh` (bypass removed).
- shellcheck -x rc=0 on every touched `.sh`.

## jarrod deferral

Filed **HIMMEL-2958** — vendored-tree follow-up (13 lines in `render.test.js` + manifest re-hash ceremony).

## CR

`/pr-check` clean — critic panel (codex, paid tier) round 1/3: 0 Critical, 0 Important, 0 Suggestions. Claude-only floor not needed (codex responded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015isPdis1tzrbv1QL62LUvj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of previously allowlisted home-path names when they appear without explicit approval.
  - Preserved support for individually approved paths through inline annotations.

- **Tests**
  - Added regression coverage confirming unapproved names are flagged and approved fixtures remain valid.
  - Clarified intentional sample paths across Unix and Windows formats to prevent false positives.
  - Updated related validation scenarios without changing their runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->