### PR TITLE
fix(evals): [HIMMEL-2938] natural-language RED-control prompt and out-of-scope-query grader

### DIFF
--- a/docs/internals/testing.md
+++ b/docs/internals/testing.md
@@ -174,9 +174,12 @@ Three suites ship under HIMMEL-2931:
   two separate calls) — the original `scoped-query` grader's `min: 1` only
   proved one of the two was in scope and never checked the other. A
   `graders/no-out-of-scope-query.md` grader now asserts `min: 0, max: 0` on
-  any call whose `collections` value is *not* exactly `["himmel"]`
-  (`"collections":\s*(?!\[\s*"himmel"\s*\])\[`), so a genuinely out-of-scope
-  call fails the run regardless of how many in-scope calls also happened. A
+  any call whose full input does *not* contain `collections` scoped to
+  exactly `["himmel"]`
+  (`^(?!.*"collections":\s*\[\s*"himmel"\s*\]).*$`), so a genuinely
+  out-of-scope call — including one that omits `collections` entirely, which
+  an earlier `"collections":`-substring form of this regex missed (CR round 1)
+  — fails the run regardless of how many in-scope calls also happened. A
   `max: 1` on `scoped-query` itself was tried and reverted — re-verified
   (2026-09-12) against the real 2-calls-per-run behavior, it produced a false
   failure (`called 2x, expected 1..1`) even though both calls were correctly

--- a/docs/internals/testing.md
+++ b/docs/internals/testing.md
@@ -136,19 +136,26 @@ Three suites ship under HIMMEL-2931:
   `context.scaffold_script: fixture.sh`, which `claude plugin eval` will not
   run without that flag.
 - `marketplace/plugins/obsidian-triage/evals/read-link-vault-first/` — a
-  **RED control**: with the plugin, `/obsidian-triage:read-link` must read a
-  seeded fixture clip and never call `WebFetch` (`tool_used: WebFetch, min: 0,
-  max: 0, arm: both`); without the plugin, the same prompt has no reason to
-  stay off `WebFetch`. Both arms use a fixture vault under the suite dir —
-  never the real `~/Documents/luna`. **Finding (2026-09-12 run):** WITH
-  passed clean (score 1, vault content surfaced, 0 WebFetch calls). WITHOUT
-  scored 0.5 but *not* for the intended reason — Claude Code's slash-command
-  dispatcher intercepts the unrecognized `/obsidian-triage:read-link` line and
-  returns a synthetic "Unknown command" response before any model turn runs,
-  so the WITHOUT arm never gets a chance to reach for `WebFetch` at all. The
-  numeric delta is real but doesn't demonstrate the tool-use asymmetry this
-  control is meant to probe; a slash-command-first prompt structurally cannot
-  produce a meaningful no-plugin baseline under `--ablation with-without`.
+  **RED control**: with the plugin, reading the seeded fixture clip must never
+  call `WebFetch` (`tool_used: WebFetch, min: 0, max: 0, arm: both`); without
+  the plugin, the same prompt has no reason to stay off `WebFetch`. Both arms
+  use a fixture vault under the suite dir — never the real
+  `~/Documents/luna`. **`prompt.md` is natural language, not a leading
+  `/obsidian-triage:read-link` line** (HIMMEL-2938) — a literal slash command
+  made Claude Code's dispatcher intercept the unrecognized command in the
+  WITHOUT arm and return a synthetic "Unknown command" response before any
+  model turn ran, so that arm never got a chance to reach for `WebFetch` at
+  all. **Re-verified (2026-09-12, HIMMEL-2938):** WITH scored 1.00 clean (3/3
+  runs, vault content surfaced, 0 WebFetch calls). WITHOUT scored 0.67 (2/3
+  runs still found the fixture content directly via the generically-granted
+  `Bash`/`Grep`/`Read` tools without calling `WebFetch`, since the prompt
+  necessarily names the `./vault-fixture` path so the WITH arm's lookup CLI
+  can find it; 1/3 runs failed for the intended reason — `WebFetch called 1x`
+  and `vault-content-surfaced: pattern not found`). The dispatcher gap is
+  fixed (every run now reaches a real model turn); the WITHOUT arm no longer
+  fails deterministically because a no-plugin agent can sometimes replicate
+  the vault-first behavior by hand with the same generic tools — a residual
+  limitation of this suite design, not the dispatcher bug this round fixed.
 - `marketplace/plugins/qmd/evals/collections-scoping/` — a natural-language
   prompt asserting the `qmd` MCP `query` tool is called with a `collections`
   scope, against a suite-wide **mock** (`evals/mocks/qmd/`, including a
@@ -161,7 +168,21 @@ Three suites ship under HIMMEL-2931:
   pass a call whose `collections` array held extra collections, or was empty
   with "himmel" appearing elsewhere in the JSON-stringified input — tightened
   to `"collections":\s*\[\s*"himmel"\s*\]` to assert the scope is exactly
-  `["himmel"]`.
+  `["himmel"]`. **Hardened further (HIMMEL-2938):** every WITH-only run makes
+  **2** calls to `mcp__plugin_qmd_qmd__query` (the mock's `query` tool takes
+  one query string, so the model issues its lex- and vec-style sub-queries as
+  two separate calls) — the original `scoped-query` grader's `min: 1` only
+  proved one of the two was in scope and never checked the other. A
+  `graders/no-out-of-scope-query.md` grader now asserts `min: 0, max: 0` on
+  any call whose `collections` value is *not* exactly `["himmel"]`
+  (`"collections":\s*(?!\[\s*"himmel"\s*\])\[`), so a genuinely out-of-scope
+  call fails the run regardless of how many in-scope calls also happened. A
+  `max: 1` on `scoped-query` itself was tried and reverted — re-verified
+  (2026-09-12) against the real 2-calls-per-run behavior, it produced a false
+  failure (`called 2x, expected 1..1`) even though both calls were correctly
+  scoped (`no-out-of-scope-query` passed 0x violations across all 3 runs) —
+  bounding the *count* of in-scope calls is the wrong lever when a legitimate
+  turn makes more than one of them; asserting zero out-of-scope calls is not.
 
 ### Assumptions this round shipped on (unanswered by the operator)
 

--- a/marketplace/plugins/obsidian-triage/evals/read-link-vault-first/prompt.md
+++ b/marketplace/plugins/obsidian-triage/evals/read-link-vault-first/prompt.md
@@ -4,8 +4,9 @@ allowed_tools: [Bash, Glob, Grep, Read, WebFetch, Skill]
 tags: [smoke, red-control]
 ---
 
-/obsidian-triage:read-link https://example.com/deep-dive-article
+Someone sent me this article — can you read it and give me a quick
+summary? https://example.com/deep-dive-article
 
-Note: the vault for this session is not at the default location — it lives
+The vault for this session is not at the default location — it lives
 at `./vault-fixture` (relative to your working directory). Pass
-`--vault ./vault-fixture` to the lookup CLI in step 1.
+`--vault ./vault-fixture` to whatever tool you use to check it.

--- a/marketplace/plugins/qmd/evals/collections-scoping/graders/no-out-of-scope-query.md
+++ b/marketplace/plugins/qmd/evals/collections-scoping/graders/no-out-of-scope-query.md
@@ -1,0 +1,10 @@
+---
+type: tool_used
+tool: mcp__plugin_qmd_qmd__query
+input_match: '"collections":\s*(?!\[\s*"himmel"\s*\])\['
+min: 0
+max: 0
+---
+
+Rejects any `query` call scoped outside `["himmel"]` — `scoped-query.md`'s
+`min: 1` only proves one call was in scope and misses the others (HIMMEL-2938).

--- a/marketplace/plugins/qmd/evals/collections-scoping/graders/no-out-of-scope-query.md
+++ b/marketplace/plugins/qmd/evals/collections-scoping/graders/no-out-of-scope-query.md
@@ -1,10 +1,14 @@
 ---
 type: tool_used
 tool: mcp__plugin_qmd_qmd__query
-input_match: '"collections":\s*(?!\[\s*"himmel"\s*\])\['
+input_match: '^(?!.*"collections":\s*\[\s*"himmel"\s*\]).*$'
 min: 0
 max: 0
 ---
 
 Rejects any `query` call scoped outside `["himmel"]` — `scoped-query.md`'s
 `min: 1` only proves one call was in scope and misses the others (HIMMEL-2938).
+The regex is a whole-input negative match (not a `"collections":` substring
+match): it also catches a call that omits the `collections` key entirely,
+which the substring form let through since an absent key never contains the
+literal text `"collections":` at all (CR round 1 on this PR).


### PR DESCRIPTION
## Summary

Fixes two real defects in the plugin eval suites shipped under HIMMEL-2931
(found in PR #644's round-2 review), each re-verified with a billed
`claude plugin eval` run:

1. **`obsidian-triage/read-link-vault-first`** — the RED-control prompt used
   a leading slash command, so the WITHOUT arm never reached a model turn
   (Claude Code's dispatcher intercepted the unrecognized command and
   returned a synthetic "Unknown command" response). Rewrote `prompt.md` as
   natural language.
2. **`qmd/collections-scoping`** — the `scoped-query` grader's `min: 1` only
   proved one of the WITH arm's two `query` calls was in-scope and never
   checked the other. Added a `no-out-of-scope-query` grader that fails the
   run on any call scoped outside `["himmel"]`.

A CR-round-1 finding on this PR (codex, Important) noted the new grader's
regex only matched calls carrying an explicit `"collections":` key, missing
a call that omits `collections` entirely (legal per the mock's tool schema,
and exactly the out-of-scope leak the grader exists to catch). Fixed inline
by switching to a whole-input negative match; verified with synthetic regex
unit tests against exact/wrong/missing/extra-collections call shapes (no
4th billed run — a static regex correctness fix within already-verified
behavior).

## Eval runs (3 billed, per the HIMMEL-2938 budget)

- **Run 1** — `read-link-vault-first` WITH+WITHOUT pair: WITH **1.00** (3/3,
  vault content surfaced, 0 WebFetch calls). WITHOUT **0.67** (2/3 still
  found the fixture via generic Bash/Grep/Read tools without the plugin,
  since the prompt necessarily names `./vault-fixture`; 1/3 failed for the
  intended reason — `WebFetch called 1x`, `vault-content-surfaced: pattern
  not found`). Dispatcher gap is fixed (every run now reaches a real model
  turn); the residual WITHOUT-arm noise is a suite-design limitation, not
  the dispatcher bug this round fixed.
- **Run 2** — `collections-scoping` WITH-only (`--ablation none`, 3
  replicates): every run made 2 `mcp__plugin_qmd_qmd__query` calls;
  `no-out-of-scope-query` passed 0x violations across all 3 runs, proving
  both calls were in-scope.
- **Run 3** — tried `max: 1` on `scoped-query` itself first; same run showed
  it's the wrong lever (`called 2x, expected 1..1` — a false failure on
  legitimate lex+vec sub-query behavior) and was reverted, keeping
  `scoped-query` at its original `min: 1`-only form and relying on the new
  `no-out-of-scope-query` grader instead.

`evals/results/` directories are gitignored (authored in HIMMEL-2931's own
commit #644) and are not committed; evidence is captured in
`docs/internals/testing.md`.

## Bank

- Before (LIVE): `five_hour=10.0 seven_day=37.0`
- After (this PR): `five_hour=17.0 seven_day=39.0`

## Round table

| Round | Reviewer | Finding | Verdict |
|---|---|---|---|
| 1 | codex (critic panel, docs-audit lane) | `no-out-of-scope-query` regex misses calls that omit `collections` entirely (Important) | agreed, fixed inline (this PR, whole-input negative match) |
| 2 | codex (critic panel, docs-audit lane) | — | clean (0 critical / 0 important / 0 suggestions) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnZDUbqivNTovVGtFd1LsS
