### PR TITLE
fix(template): [HIMMEL-2956] upgrade suite heredoc checker honours tab-indented <<- terminators

### DIFF
--- a/templates/luna-second-brain/.vault-template.json
+++ b/templates/luna-second-brain/.vault-template.json
@@ -1,5 +1,5 @@
 {
   "template": "luna-second-brain",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "upgraded_at": "2026-07-13T00:00:00Z"
 }

--- a/templates/luna-second-brain/CHANGELOG.md
+++ b/templates/luna-second-brain/CHANGELOG.md
@@ -8,6 +8,13 @@ Version history for the luna-second-brain vault template (published as
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.4.29] — 2026-09-12
+
+### Fixed
+- The upgrade suite's structural bash-3.2 heredoc checker now honours a
+  `<<-` opener's tab-indented terminator instead of silently skipping it
+  (HIMMEL-2956, follow-up to HIMMEL-2952).
+
 ## [0.4.28] — 2026-09-12
 
 ### Fixed

--- a/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
+++ b/templates/luna-second-brain/marketplace/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "luna-brain — OSS Obsidian vault skeleton for Claude Code workflows. This marketplace ships NO plugins: Steph Ango's obsidian skill pack installs from its own upstream marketplace (obsidian@obsidian-skills) because kepano publishes no tags and a bare-SHA pin is not installable (HIMMEL-435/449); claude-obsidian ships via the himmel marketplace; pair with obsidian-second-brain (installed via its upstream install.sh) for PARA capture skills. metadata.version below is the template version read by scripts/upgrade.sh.",
-    "version": "0.4.28"
+    "version": "0.4.29"
   },
   "plugins": []
 }

--- a/templates/luna-second-brain/scripts/test-upgrade.sh
+++ b/templates/luna-second-brain/scripts/test-upgrade.sh
@@ -47,7 +47,12 @@ check_nested_heredoc_quotes() {
     "$PY" - "$1" <<'PY'
 import pathlib, re, sys
 text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
-pattern = re.compile(r"\$\([^)]*?<<(-?)\s*'([A-Za-z_][A-Za-z_0-9]*)'[^\n]*\n(.*?)^\2[ \t]*$", re.M | re.S)
+# Group 1 captures the '-' of a <<- opener, or is None (not merely empty)
+# for plain <<. Bash strips leading TABS from a <<- terminator line only;
+# a plain << terminator must stay at column zero. (?(1)\t*) applies that
+# asymmetry: tabs before the terminator are permitted only when group 1
+# actually matched '-' (HIMMEL-2956).
+pattern = re.compile(r"\$\([^)]*?<<(-)?\s*'([A-Za-z_][A-Za-z_0-9]*)'[^\n]*\n(.*?)^(?(1)\t*)\2[ \t]*$", re.M | re.S)
 failed = False
 for match in pattern.finditer(text):
     body = match.group(3)
@@ -79,6 +84,25 @@ repro = (root / "bash32-repro.sh").read_text(encoding="utf-8")
 (root / "bash32-fixed.sh").write_text(repro.replace("script's", "script"), encoding="utf-8")
 (root / "bash32-backtick.sh").write_text(repro.replace("script's", "script`s"), encoding="utf-8")
 (root / "bash32-multiline.sh").write_text(repro.replace("$(python3", "$(\npython3"), encoding="utf-8")
+# <<- opener with a TAB-indented terminator: bash strips the leading tab,
+# so this is a real, unbalanced heredoc (HIMMEL-2956 negative control).
+tab_repro = repro.replace("<<'PY'", "<<-'PY'")
+tab_repro = tab_repro.replace("\n# this script's own writer\n", "\n\t# this script's own writer\n")
+tab_repro = tab_repro.replace("\nPY\n", "\n\tPY\n")
+(root / "bash32-tab-repro.sh").write_text(tab_repro, encoding="utf-8")
+# Same <<- + tab-terminator shape, but balanced — proves the fix matches
+# the tab terminator without spuriously flagging it every time.
+(root / "bash32-tab-fixed.sh").write_text(tab_repro.replace("script's", "script"), encoding="utf-8")
+# Plain << (no dash) with a TAB-indented "PY" line before the real,
+# column-zero terminator: bash never strips tabs for a plain heredoc, so
+# that tab-indented line is body text, not a terminator. The checker must
+# keep scanning past it to the real terminator and still catch the
+# unmatched apostrophe in the body (HIMMEL-2956 positive control).
+notab_guard = repro.replace(
+    "<<'PY'\n# this script's own writer\n",
+    "<<'PY'\n\tPY\n# this script's own writer\n",
+)
+(root / "bash32-notab-guard.sh").write_text(notab_guard, encoding="utf-8")
 PY
 check_nested_heredoc_quotes "$TMP/bash32-fixed.sh"; rc=$?
 assert_eq "T0 structural control accepts repaired repro" "0" "$rc"
@@ -86,6 +110,14 @@ for fixture in backtick multiline; do
     check_nested_heredoc_quotes "$TMP/bash32-$fixture.sh"; rc=$?
     assert_eq "T0 structural RED control rejects $fixture repro" "1" "$rc"
 done
+
+# HIMMEL-2956: <<- permits a TAB-indented terminator; plain << does not.
+check_nested_heredoc_quotes "$TMP/bash32-tab-repro.sh"; rc=$?
+assert_eq "T0 structural RED control rejects tab-indented <<- terminator repro" "1" "$rc"
+check_nested_heredoc_quotes "$TMP/bash32-tab-fixed.sh"; rc=$?
+assert_eq "T0 structural control accepts balanced <<- tab-terminator repro" "0" "$rc"
+check_nested_heredoc_quotes "$TMP/bash32-notab-guard.sh"; rc=$?
+assert_eq "T0 structural control still requires column-zero terminator for plain << (tab line is not a terminator)" "1" "$rc"
 
 bash32="${BASH32:-}"
 if [ -z "$bash32" ]; then


### PR DESCRIPTION
## Summary
- `check_nested_heredoc_quotes()` in `templates/luna-second-brain/scripts/test-upgrade.sh`'s bash-3.2 structural heredoc checker required a heredoc terminator at column zero regardless of opener — but bash strips leading **tabs** (only) from a `<<-` terminator line, so a `<<-'PY'` heredoc with a tab-indented `\tPY` terminator was silently treated as still-open, masking a genuinely unmatched apostrophe in the body.
- Follow-up to HIMMEL-2952 (which fixed bash-3.2 parsing of `upgrade.sh` itself); this ticket hardens the checker `test-upgrade.sh` uses to guard against regressions.

## Root cause
The regex's dash-capture group `(-?)` always participates in the match (empty string or `-`, never `None`), so a Python `(?(1)...)` conditional keyed off it could never distinguish "no dash" from "dash but it matched empty" — there was no way to express "tabs allowed only for `<<-`".

## Fix
- Changed the capture to `(-)?` (a genuinely optional group, `None` when absent) and used `(?(1)\t*)` before the terminator match, so leading tabs are permitted only when the opener was `<<-`.
- Added three fixture/control pairs:
  - `bash32-tab-repro.sh` — `<<-` with a tab-indented terminator and a genuine unmatched apostrophe (RED control — must be rejected).
  - `bash32-tab-fixed.sh` — same shape, balanced (must be accepted).
  - `bash32-notab-guard.sh` — plain `<<` (no dash) with a tab-indented decoy line before the real column-zero terminator (regression guard — proves the fix doesn't over-loosen the no-dash case).

## Verification
- RED-first TDD: reverted only the regex line to the buggy pattern, confirmed the new control genuinely failed (`FAIL T0 structural RED control rejects tab-indented <<- terminator repro — expected '1', got '0'`), then restored the fix and reran to full GREEN.
- `bash templates/luna-second-brain/scripts/test-upgrade.sh` — all tests pass, including the three new T0 controls.
- `scripts/test-luna-upgrade-all.sh` — GREEN (independent, does not duplicate the checker).
- `scripts/test-luna-upgrade-vm.sh` — SKIP (requires an SSH-reachable VM not available in this environment; out of scope for this fix).
- `shellcheck` + `git diff --check` — clean.
- Confirmed `templates/luna-second-brain/scripts/upgrade.sh` (the production script) contains no `<<-` heredocs — this is a pure test-suite hardening change with zero behavioral risk to production code.

## Version bump
The template carries its version in **two files that move together**: `marketplace/.claude-plugin/marketplace.json` `metadata.version` (read by `scripts/check-template-version.sh`) and `templates/luna-second-brain/.vault-template.json` `version` (the field `scripts/upgrade.sh` reads on the vault side — corrected after an earlier claim in this PR body that the latter was unowned/skip-class, which was wrong: T26 in `test-upgrade.sh` guards exactly this pair staying in sync). Both bumped 0.4.28 → 0.4.29, plus the `CHANGELOG.md` entry.

## /pr-check
- Round 1 of 3 (head `ce81c3b2`) — critic panel (codex, paid tier) responded clean: 0 Critical / 0 Important / 0 Suggestions. Marker cleared.
- Round 2 of 3 (head `a6f2989f`, follow-up commit bumping `.vault-template.json`) — critic panel (codex, paid tier) responded clean: 0 Critical / 0 Important / 0 Suggestions. Marker cleared. `check-ci`: all checks green, all review threads resolved, CodeRabbit rate-limited at this head (panel carries the gate, HIMMEL-1465).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wvn5RxGhCR3Kq3oWwxTPUs

