### PR TITLE
fix(git): [HIMMEL-2963] fail closed on restore errors and document safe recovery

### DIFF
--- a/docs/internals/stuck-playbook.md
+++ b/docs/internals/stuck-playbook.md
@@ -66,7 +66,7 @@ restoring. To recover, use the run directory and file number recorded in MANIFES
 
 Regular file: `rm -f <path> && cp -p <RUN_DIR>/<n>.worktree <path>`
 Symlink: `cp -RPp <RUN_DIR>/<n>.worktree <path>`
-Staged content: `cp -p <RUN_DIR>/<n>.index <path>` then `git add <path>`.
+Staged content: `rm -f <path> && cp -p <RUN_DIR>/<n>.index <path>` then `git add <path>`.
 
 Never try bare `git checkout -- <path>` or `git restore` yourself to work around this.
 

--- a/docs/internals/stuck-playbook.md
+++ b/docs/internals/stuck-playbook.md
@@ -64,7 +64,7 @@ saves the outgoing content for every dirty path — a plain copy, not a diff —
 to a fresh `${TMPDIR:-/tmp}/restore-to-head.XXXXXX/` directory before
 restoring. To recover, use the run directory and file number recorded in MANIFEST:
 
-Regular file: `cp -p <RUN_DIR>/<n>.worktree <path>`
+Regular file: `rm -f <path> && cp -p <RUN_DIR>/<n>.worktree <path>`
 Symlink: `cp -RPp <RUN_DIR>/<n>.worktree <path>`
 Staged content: `cp -p <RUN_DIR>/<n>.index <path>` then `git add <path>`.
 

--- a/docs/internals/stuck-playbook.md
+++ b/docs/internals/stuck-playbook.md
@@ -62,9 +62,13 @@ one literal command, no `cd`/`$()`/compound operators. It refuses globs,
 untracked paths, directories, and paths outside the current worktree, and it
 saves the outgoing content for every dirty path — a plain copy, not a diff —
 to a fresh `${TMPDIR:-/tmp}/restore-to-head.XXXXXX/` directory before
-restoring, so the discard is recoverable via `cp` (staged content that
-differs from HEAD is saved separately via `git show`). Never try bare
-`git checkout -- <path>` or `git restore` yourself to work around this.
+restoring. To recover, use the run directory and file number recorded in MANIFEST:
+
+Regular file: `cp -p <RUN_DIR>/<n>.worktree <path>`
+Symlink: `cp -RPp <RUN_DIR>/<n>.worktree <path>`
+Staged content: `cp -p <RUN_DIR>/<n>.index <path>` then `git add <path>`.
+
+Never try bare `git checkout -- <path>` or `git restore` yourself to work around this.
 
 ---
 

--- a/scripts/git/restore-to-head.sh
+++ b/scripts/git/restore-to-head.sh
@@ -31,7 +31,7 @@ dirty path's worktree content and staged index content first. Refuses glob
 arguments, untracked paths, directories, and paths outside the current worktree.
 
 Recovery (use the run directory and file number recorded in MANIFEST):
-Regular file: `cp -p <RUN_DIR>/<n>.worktree <path>`
+Regular file: `rm -f <path> && cp -p <RUN_DIR>/<n>.worktree <path>`
 Symlink: `cp -RPp <RUN_DIR>/<n>.worktree <path>`
 Staged content: `cp -p <RUN_DIR>/<n>.index <path>` then `git add <path>`.
 EOF

--- a/scripts/git/restore-to-head.sh
+++ b/scripts/git/restore-to-head.sh
@@ -33,7 +33,7 @@ arguments, untracked paths, directories, and paths outside the current worktree.
 Recovery (use the run directory and file number recorded in MANIFEST):
 Regular file: `rm -f <path> && cp -p <RUN_DIR>/<n>.worktree <path>`
 Symlink: `cp -RPp <RUN_DIR>/<n>.worktree <path>`
-Staged content: `cp -p <RUN_DIR>/<n>.index <path>` then `git add <path>`.
+Staged content: `rm -f <path> && cp -p <RUN_DIR>/<n>.index <path>` then `git add <path>`.
 EOF
 }
 

--- a/scripts/git/restore-to-head.sh
+++ b/scripts/git/restore-to-head.sh
@@ -27,9 +27,13 @@ usage() {
 usage: restore-to-head.sh <path> [<path>...]
 
 Restores one or more tracked files to HEAD, saving a plain copy of each
-dirty path's worktree content and staged index content first (recoverable
-via `cp` / `git show`). Refuses glob arguments, untracked paths,
-directories, and paths outside the current worktree.
+dirty path's worktree content and staged index content first. Refuses glob
+arguments, untracked paths, directories, and paths outside the current worktree.
+
+Recovery (use the run directory and file number recorded in MANIFEST):
+Regular file: `cp -p <RUN_DIR>/<n>.worktree <path>`
+Symlink: `cp -RPp <RUN_DIR>/<n>.worktree <path>`
+Staged content: `cp -p <RUN_DIR>/<n>.index <path>` then `git add <path>`.
 EOF
 }
 
@@ -72,7 +76,10 @@ RUN_DIR=$(mktemp -d "${TMPDIR:-/tmp}/restore-to-head.XXXXXX") || {
     exit 2
 }
 MANIFEST="$RUN_DIR/MANIFEST"
-: > "$MANIFEST"
+if ! : > "$MANIFEST"; then
+    echo "restore-to-head: could not create deletion manifest '$MANIFEST'" >&2
+    exit 2
+fi
 
 n=0
 for rel in "${RELS[@]}"; do
@@ -103,9 +110,15 @@ for rel in "${RELS[@]}"; do
         fi
     fi
     if [ "$wt_deleted" -eq 1 ]; then
-        echo "$n $rel deleted" >> "$MANIFEST"
+        if ! printf '%s %s deleted\n' "$n" "$rel" >> "$MANIFEST"; then
+            echo "restore-to-head: could not record deletion for '$rel' -- aborting before restore" >&2
+            exit 2
+        fi
     else
-        echo "$n $rel" >> "$MANIFEST"
+        if ! printf '%s %s\n' "$n" "$rel" >> "$MANIFEST"; then
+            echo "restore-to-head: could not update manifest for '$rel' -- aborting before restore" >&2
+            exit 2
+        fi
     fi
 
     saved_idx=""
@@ -122,7 +135,10 @@ for rel in "${RELS[@]}"; do
         echo "restore-to-head: '$rel' has staged content that differs from HEAD (saved separately: $saved_idx)" >&2
     fi
 
-    git -C "$TOPLEVEL" checkout HEAD -- ":(literal)$rel"
+    if ! git -C "$TOPLEVEL" checkout HEAD -- ":(literal)$rel"; then
+        echo "restore-to-head: could not restore '$rel'; saved backups remain in '$RUN_DIR'" >&2
+        exit 2
+    fi
     if [ "$wt_deleted" -eq 1 ]; then
         echo "restored $rel (worktree deletion recorded: $MANIFEST)"
     elif [ -n "$saved_wt" ]; then

--- a/scripts/git/test-restore-to-head.sh
+++ b/scripts/git/test-restore-to-head.sh
@@ -364,6 +364,118 @@ else
 fi
 reset_wt
 
+# --- (w) a failed second checkout must not discard the third path.
+FAULT_BIN="$TMP/fault-bin"
+mkdir -p "$FAULT_BIN"
+REAL_GIT=$(command -v git)
+export REAL_GIT
+cat > "$FAULT_BIN/git" <<'EOF'
+#!/usr/bin/env bash
+if [ "$3" = checkout ] && [ "$6" = ':(literal)tracked2.txt' ]; then
+    lock=$("$REAL_GIT" -C "$2" rev-parse --git-path index.lock)
+    : > "$lock"
+    "$REAL_GIT" "$@"
+    rc=$?
+    rm "$lock"
+    exit "$rc"
+fi
+exec "$REAL_GIT" "$@"
+EOF
+chmod +x "$FAULT_BIN/git"
+printf 'dirty-first\n' > "$WT/tracked.txt"
+printf 'dirty-second\n' > "$WT/tracked2.txt"
+printf 'dirty-third\n' > "$WT/tracked3.txt"
+out=$(cd "$WT" && PATH="$FAULT_BIN:$PATH" TMPDIR="$BACKUPS" bash "$SUT" tracked.txt tracked2.txt tracked3.txt 2>&1); rc=$?
+wt_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.worktree' | head -1)
+run_dir="${wt_path%/*}"
+if [ "$rc" -eq 2 ] && [ "$(cat "$WT/tracked.txt")" = base ] &&
+    [ "$(cat "$WT/tracked2.txt")" = dirty-second ] && [ "$(cat "$WT/tracked3.txt")" = dirty-third ] &&
+    [ -f "$run_dir/2.worktree" ] && printf '%s\n' "$out" | grep -Fq "saved backups remain in '$run_dir'"; then
+    pass "(w) checkout failure stops before later paths change and names the saved backups"
+else
+    fail "(w) rc=$rc third='$(cat "$WT/tracked3.txt")' out='$out' (expected immediate stop with backup location)"
+fi
+reset_wt
+
+# --- (x) a run directory exists, but MANIFEST creation fails before restore.
+cat > "$FAULT_BIN/mktemp" <<'EOF'
+#!/usr/bin/env bash
+mkdir -p "$FAULT_RUN/MANIFEST" || exit 1
+printf '%s\n' "$FAULT_RUN"
+EOF
+chmod +x "$FAULT_BIN/mktemp"
+FAULT_RUN="$TMP/manifest-create"
+printf 'dirty-manifest\n' > "$WT/tracked.txt"
+out=$(cd "$WT" && PATH="$FAULT_BIN:$PATH" FAULT_RUN="$FAULT_RUN" bash "$SUT" tracked.txt 2>&1); rc=$?
+if [ -d "$FAULT_RUN" ] && [ -d "$FAULT_RUN/MANIFEST" ] &&
+    [ "$rc" -eq 2 ] && [ "$(cat "$WT/tracked.txt")" = dirty-manifest ] &&
+    printf '%s\n' "$out" | grep -q 'could not create deletion manifest'; then
+    pass "(x) failed MANIFEST creation aborts before discarding dirty bytes"
+else
+    fail "(x) rc=$rc content='$(cat "$WT/tracked.txt")' out='$out' (expected MANIFEST failure after run directory creation)"
+fi
+reset_wt
+
+# --- (y) fail append only AFTER successful MANIFEST creation, for both row types.
+cat > "$FAULT_BIN/mktemp" <<'EOF'
+#!/usr/bin/env bash
+mkdir -p "$FAULT_RUN" || exit 1
+printf '%s\n' "$FAULT_RUN"
+EOF
+cat > "$FAULT_BIN/git" <<'EOF'
+#!/usr/bin/env bash
+if [ "$3" = diff ] && [ "$7" = --cached ]; then
+    [ -f "$FAULT_RUN/MANIFEST" ] && [ ! -s "$FAULT_RUN/MANIFEST" ] || exit 99
+    mv "$FAULT_RUN/MANIFEST" "$FAULT_RUN/created-manifest" || exit 99
+    mkdir "$FAULT_RUN/MANIFEST" || exit 99
+fi
+exec "$REAL_GIT" "$@"
+EOF
+for row in deleted present; do
+    FAULT_RUN="$TMP/manifest-append-$row"
+    if [ "$row" = deleted ]; then
+        rm "$WT/tracked.txt"
+    else
+        printf 'dirty-append\n' > "$WT/tracked.txt"
+    fi
+    out=$(cd "$WT" && PATH="$FAULT_BIN:$PATH" FAULT_RUN="$FAULT_RUN" bash "$SUT" tracked.txt 2>&1); rc=$?
+    if [ -f "$FAULT_RUN/created-manifest" ] && [ -d "$FAULT_RUN/MANIFEST" ] && [ "$rc" -eq 2 ] &&
+        { { [ "$row" = deleted ] && [ ! -e "$WT/tracked.txt" ]; } ||
+          { [ "$row" = present ] && [ "$(cat "$WT/tracked.txt")" = dirty-append ]; }; } &&
+        printf '%s\n' "$out" | grep -q 'aborting before restore'; then
+        pass "(y) failed $row MANIFEST append aborts before restore"
+    else
+        fail "(y) $row rc=$rc out='$out' (expected successful creation, failed append, and untouched path)"
+    fi
+    reset_wt
+done
+
+# --- (z) execute the usage's recovery commands, not a test-owned substitute.
+printf 'recover-dirty\n' > "$WT/tracked.txt"
+rm "$WT/tracked2.txt"
+ln -s "$WT/tracked3.txt" "$WT/tracked2.txt"
+out=$(run tracked.txt tracked2.txt 2>&1); rc=$?
+wt_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.worktree' | head -1)
+run_dir="${wt_path%/*}"
+help=$(bash "$SUT" --help)
+file_cmd=$(printf '%s\n' "$help" | sed -n "s/^Regular file: \`\(.*\)\`$/\1/p")
+link_cmd=$(printf '%s\n' "$help" | sed -n "s/^Symlink: \`\(.*\)\`$/\1/p")
+file_cmd=${file_cmd//<RUN_DIR>/\"$run_dir\"}
+file_cmd=${file_cmd//<n>/1}
+file_cmd=${file_cmd//<path>/\"$WT\/tracked.txt\"}
+link_cmd=${link_cmd//<RUN_DIR>/\"$run_dir\"}
+link_cmd=${link_cmd//<n>/2}
+link_cmd=${link_cmd//<path>/\"$WT\/tracked2.txt\"}
+if [ "$rc" -eq 0 ] && [ -n "$file_cmd" ] && [ -n "$link_cmd" ] &&
+    bash -c "$file_cmd" && bash -c "$link_cmd" &&
+    [ "$(cat "$WT/tracked.txt")" = recover-dirty ] && [ -L "$WT/tracked2.txt" ] &&
+    [ "$(readlink "$WT/tracked2.txt")" = "$WT/tracked3.txt" ] && [ "$(cat "$WT/tracked3.txt")" = base3 ]; then
+    pass "(z) documented commands recover regular bytes and outgoing symlink identity and target"
+else
+    fail "(z) rc=$rc file_cmd='$file_cmd' link_cmd='$link_cmd' (expected executable recovery commands preserving bytes and link)"
+fi
+reset_wt
+
 echo "---"
 if [ "$FAILED" -gt 0 ]; then
     echo "test-restore-to-head: $FAILED FAILURE(S)"

--- a/scripts/git/test-restore-to-head.sh
+++ b/scripts/git/test-restore-to-head.sh
@@ -365,6 +365,28 @@ if [ "$rc" -eq 0 ] && [ -L "$WT/link" ] && [ -n "$file_cmd" ] &&
 else
     fail "(u2) rc=$rc target='$(cat "$WT/tracked.txt")' (expected regular file recovery with target untouched)"
 fi
+
+# --- (u3) recovering staged regular bytes over a HEAD symlink must not overwrite its target.
+rm "$WT/link"
+printf 'recover-staged\n' > "$WT/link"
+(cd "$WT" && git add link)
+printf 'different-worktree\n' > "$WT/link"
+out=$(run link 2>&1); rc=$?
+idx_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.index' | head -1)
+run_dir="${idx_path%/*}"
+help=$(bash "$SUT" --help)
+index_cmd=$(printf '%s\n' "$help" | sed -n "s/^Staged content: \`\(.*\)\` then \`\(.*\)\`\.$/\1 \&\& \2/p")
+index_cmd=${index_cmd//<RUN_DIR>/\"$run_dir\"}
+index_cmd=${index_cmd//<n>/1}
+index_cmd=${index_cmd//<path>/\"$WT\/link\"}
+if [ "$rc" -eq 0 ] && [ -L "$WT/link" ] && [ -n "$index_cmd" ] &&
+    (cd "$WT" && bash -c "$index_cmd") && [ ! -L "$WT/link" ] &&
+    [ "$(cat "$WT/link")" = recover-staged ] && [ "$(cat "$WT/tracked.txt")" = base ] &&
+    [ "$(git -C "$WT" show :link)" = recover-staged ]; then
+    pass "(u3) documented staged recovery replaces the HEAD symlink and stages saved bytes without changing its target"
+else
+    fail "(u3) rc=$rc target='$(cat "$WT/tracked.txt")' (expected staged regular file recovery with target untouched)"
+fi
 reset_wt
 (cd "$WT" && git reset -q --hard main)
 

--- a/scripts/git/test-restore-to-head.sh
+++ b/scripts/git/test-restore-to-head.sh
@@ -346,6 +346,25 @@ if [ "$rc" -eq 0 ] && [ "$(readlink "$WT/link")" = "tracked.txt" ] && [ -L "$wt_
 else
     fail "(u) rc=$rc wt_path='$wt_path' (expected HEAD link restored and backup symlink targeting tracked2.txt)"
 fi
+
+# --- (u2) recovering a regular file over a HEAD symlink must not overwrite its target.
+rm "$WT/link"
+printf 'recover-regular\n' > "$WT/link"
+out=$(run link 2>&1); rc=$?
+wt_path=$(printf '%s\n' "$out" | grep -o '/[^ ]*\.worktree' | head -1)
+run_dir="${wt_path%/*}"
+help=$(bash "$SUT" --help)
+file_cmd=$(printf '%s\n' "$help" | sed -n "s/^Regular file: \`\(.*\)\`$/\1/p")
+file_cmd=${file_cmd//<RUN_DIR>/\"$run_dir\"}
+file_cmd=${file_cmd//<n>/1}
+file_cmd=${file_cmd//<path>/\"$WT\/link\"}
+if [ "$rc" -eq 0 ] && [ -L "$WT/link" ] && [ -n "$file_cmd" ] &&
+    bash -c "$file_cmd" && [ ! -L "$WT/link" ] &&
+    [ "$(cat "$WT/link")" = recover-regular ] && [ "$(cat "$WT/tracked.txt")" = base ]; then
+    pass "(u2) documented regular-file recovery replaces the HEAD symlink without changing its target"
+else
+    fail "(u2) rc=$rc target='$(cat "$WT/tracked.txt")' (expected regular file recovery with target untouched)"
+fi
 reset_wt
 (cd "$WT" && git reset -q --hard main)
 


### PR DESCRIPTION
## Summary

Addresses the three deferred CodeRabbit findings from PR #647 under HIMMEL-2963, plus the two verified destination-symlink recovery corrections found during local review.

| Original finding | Fix |
| --- | --- |
| [Checkout failure — Major](https://github.com/yotamleo/Himmel/pull/647#discussion_r3996220487) | Check checkout status, exit 2 immediately, name the saved backup directory, and do not discard later paths. |
| [MANIFEST writes — Major](https://github.com/yotamleo/Himmel/pull/647#discussion_r3996220484) | Check MANIFEST creation and both printf append branches before checkout; abort on write failure. |
| [Symlink recovery docs — Minor](https://github.com/yotamleo/Himmel/pull/647#discussion_r3996220481) | Replace generic recovery prose with tested regular-file, symlink and staged-byte commands in usage and stuck-playbook. |

Regular-file and staged-byte recovery unlink the destination before copying, preventing a restored HEAD symlink from redirecting the copy into its referent. Symlink recovery preserves the saved link itself using `cp -RPp`.

## Verification

All 32 checks in `scripts/git/test-restore-to-head.sh` pass on Linux at `e5f49915a9e5350ce4f321aadb206e91a9902275`. Both changed shell files pass `shellcheck -x`; `git diff --check main...HEAD` passes. Bash 3.2 runtime, macOS and Windows were not tested. The impacted-reference scan found no other test suite; leg-preface has no inaccurate recovery sentence and is unchanged. Root `CLAUDE.md` net change: zero. First commit and both follow-ups carry platform and manual security-review attestations.

| Regression | RED evidence before its fix | GREEN assertion |
| --- | --- | --- |
| w | Second checkout failed, yet third path became `base3`. | Exit 2; first restored, second and third dirty content preserved; backup location reported. |
| x | MANIFEST was a directory, yet exit 0 and dirty bytes discarded. | Run directory exists; MANIFEST creation fails; dirty bytes remain. |
| y, deleted | MANIFEST creation succeeded, append failed, deleted path was restored anyway. | Exit 2; deleted path stays absent. |
| y, present | MANIFEST creation succeeded, append failed, present dirty path was restored anyway. | Exit 2; dirty bytes remain. |
| z | Usage exposed no executable exact recovery commands. | Commands extracted from usage recover regular bytes and symlink identity/target. |
| u2 | Documented regular-file recovery changed the HEAD symlink referent to `recover-regular`. | Recovered regular file has saved bytes and the referent remains `base`. |
| u3 | Documented staged recovery changed the HEAD symlink referent to `recover-staged`. | Saved staged bytes recovered and staged; referent remains `base`; distinct outgoing worktree bytes are not substituted. |

The MANIFEST fault-injection rows establish failure after successful run-directory creation; append rows additionally prove successful empty MANIFEST creation before replacing it with a directory. A blanket unwritable TMPDIR is not used as a substitute.

## Review rounds and dispositions

| Round | Reviewed head | Responder | Critical / Important / Suggestions | Disposition |
| --- | --- | --- | --- | --- |
| 1 | `91ece8fc8ffe3c90bd5228f3b7282c39d96b201c` | codex / gpt-6-astra | 0 / 1 / 0 | `codex-1`: regular-file destination-symlink overwrite fixed by `88c4fa10d26b644832abe05a5520e74d9b8525d4`; u2 RED→GREEN. |
| 2 | `88c4fa10d26b644832abe05a5520e74d9b8525d4` | codex / gpt-6-astra | 0 / 1 / 0 | `codex-1`: staged-copy destination-symlink overwrite fixed by `e5f49915a9e5350ce4f321aadb206e91a9902275`; u3 RED→GREEN. Original index mode/type remains in HIMMEL-2966. |
| 3 of 3 | `e5f49915a9e5350ce4f321aadb206e91a9902275` | codex / gpt-6-astra | 0 / 0 / 1 | `codex-1`: known staged index-mode/type limitation confirmed and terminal deferred to open HIMMEL-2966. No further inline fix. |

Round 3 captured base main `7cdda7dc904a95c2454b54243ed8b239e9a1b491`. Ledger promotion reports 0 promoted, 0 still-open, 3 skip-terminal, 0 warnings. The pre-PR CR marker cleared at the exact reviewed head. This does not claim CodeRabbit App threads or public CI are already green; those checks follow PR creation.

RULING 1: an added fixture hard-reset copy caused a suite-run classifier refusal. The added line was removed and the rows use dirty/staged fixture state; the pre-existing reset line is untouched. RED was captured before production/doc edits.

RULING 2: the second narrow CR correction was explicitly authorized because the staged-copy recipe repeated the verified data-loss class. Its scope was destination unlinking in both texts plus u3; mode-aware recovery was explicitly deferred.

**Known limitation — HIMMEL-2966 remains open independently:** staged recovery currently restores blob bytes, not the original saved Git file mode/type. A staged symlink can become a regular file containing link-target text, and an executable mode is not reconstructed. The successor owns consuming `.index-mode`, a mode/type-aware recipe, executable/symlink RED controls, and matching documentation. This PR does not claim that limitation fixed.

Known-findings pre-review: the three `grep -q` sites consume small, bounded captured fixture diagnostics from fixed invocations, not an unbounded streaming producer; the SIGPIPE-on-large-producer class is not exercised by these sites. `known-findings: round-1 hits = 0`. Codex adversarial pass explicitly skipped as not high-risk; no Claude reviewer agents dispatched. Codex all-time agreed rate at this review: 25% across 1444 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
