### PR TITLE
fix(handover): [HIMMEL-2964] test-arm-resume-queue-lock.sh T15/T19 reset only sched-stub.tasks, never sched-stub.atdir

### DIFF
--- a/scripts/handover/test-arm-resume-queue-lock.sh
+++ b/scripts/handover/test-arm-resume-queue-lock.sh
@@ -33,9 +33,6 @@ trap 'rm -rf "$TMP"' EXIT
 # against THIS machine's own ambient process table and can spuriously
 # refuse (rc=22) on a host that genuinely has >= HIMMEL_FLEET_CAP `-n
 # HIMMEL-*` sessions running — noise unrelated to what this suite tests.
-# This suite's own known baseline red (a T15 spelling-canonicalization
-# failure, pre-existing at 434c5a51) is untouched by this stub — it is not
-# this ticket's to fix.
 FLEET_PS_STUB="$TMP/no-fleet-ps.sh"
 printf '%s\n' '#!/usr/bin/env bash' 'true' > "$FLEET_PS_STUB"
 chmod +x "$FLEET_PS_STUB"
@@ -517,7 +514,13 @@ HO15_ALT="$HANDOVER_DIR/HIMMEL-856-test/../HIMMEL-856-test/next-session-15.md"
 # clear the scheduler, which is what "always exit 0" used to mean. arms.jsonl is
 # deliberately NOT cleared -- the record from the first arm is the thing the
 # assertion below expects the re-arm to REPLACE.
+# HIMMEL-2964: clearing sched-stub.tasks alone only resets the Windows
+# schtasks stub. On POSIX (ubuntu/macOS CI) arm-resume's dedup check queries
+# atq, which reads sched-stub.atdir -- a leftover job file there still names
+# the same derived task, so the second arm hit a real (if here unwanted)
+# same-task dedup refusal (rc=3). Clear both stores.
 : > "$TMP/sched-stub.tasks"
+rm -rf "$TMP/sched-stub.atdir"
 out=$(bash "$ARM" --time "$(future_time)" --handover "$HO15_ALT" 2>&1)
 rc=$?
 assert_rc "T15: second real arm under another spelling succeeds" 0 "$rc"
@@ -601,7 +604,9 @@ rc=$?
 assert_rc "T19: first arm with a backslash path succeeds" 0 "$rc"
 # Same reason as T15: clear the (now registering) stub scheduler so the re-arm
 # is not refused as its own duplicate. arms.jsonl stays -- it is what is under test.
+# HIMMEL-2964: both stores, same reason as T15.
 : > "$TMP/sched-stub.tasks"
+rm -rf "$TMP/sched-stub.atdir"
 out=$(bash "$ARM" --time "$(future_time)" --handover "$HO19" 2>&1)
 rc=$?
 assert_rc "T19: second arm (re-arm) with a backslash path succeeds" 0 "$rc"


### PR DESCRIPTION
## Summary

The nightly slow-tier gating run (`SUITE_TIER_MODE=all`, cron 17 7 UTC) has been red on the ubuntu shard four nights running (2026-09-09 → 09-12: run ids 34691448056 and three preceding) on two assertions of `scripts/handover/test-arm-resume-queue-lock.sh`: T15 ("second real arm under another spelling succeeds") and T19 ("second arm (re-arm) with a backslash path succeeds"), both expecting rc=0 from `arm-resume.sh` on a second arm of the same handover and getting rc=3.

## Root cause

Both rows reset only `sched-stub.tasks` (the Windows schtasks stub store) before re-arming, never `sched-stub.atdir` (the POSIX at/atq stub store). `arm-resume.sh`'s POSIX dedup check queries `atq`, which reads `sched-stub.atdir` — the first arm's job file was still sitting there under the same derived task name, so the second arm was legitimately refused as a same-task duplicate (rc=3) by a **stale test stub**, not a real dedup bug in `arm-resume.sh` or `queue-lock.sh`.

Exit site: the POSIX `atq`-backed dedup check in `arm-resume.sh` (grep `exit 3`/`rc=3`/dedup) — confirmed by adding a temporary trace in a scratch copy, never committed.

## Fix

`scripts/handover/test-arm-resume-queue-lock.sh` only — the sole file touched:
- T15 (~L520) and T19 (~L610): the second store is now cleared too, right alongside the existing `sched-stub.tasks` truncation.
- Removed the now-false line-36 comment claiming a "pre-existing" T15 red at `434c5a51` (that claim predated this diagnosis and no longer applies).

RED confirmed on pre-fix code (rc=3, the exact reported failure) → GREEN post-fix, full suite green under `SUITE_TIER_MODE=all SUITE_LOCK_WAIT=60 bash scripts/quiet-run.sh suite -- bash scripts/handover/test-arm-resume-queue-lock.sh`.

## Impacted-suites sweep

`git grep -l 'arm-resume\.sh\|queue-lock\.sh' -- scripts | grep -E 'test-.*\.sh$'` (~26 suites) run foreground from the worktree: all green except two, both pre-existing and unrelated:
- `test-guard-implementor-dispatch.sh`: 1 pre-existing FAIL (rc=141 SIGPIPE on an unrelated jq-missing check), no arm-resume/queue-lock reference in this diff.
- `test-arm-resume.sh`: 40 pre-existing FAIL rows, reproduced byte-identical across two isolated runs (one with `FLEET_CAP_OK=1`, ruling out HIMMEL-2765 fleet-cap contamination as a confound). File-scope isolation: this fix touches only `test-arm-resume-queue-lock.sh`'s `SCHED_STUB`/`sched-stub.atdir` mechanism, which `test-arm-resume.sh` never uses (it stubs via its own separate `lapseN-stub-bin` mechanism). Row `2192` already tracked as HIMMEL-2406; remaining 39 filed fresh as **HIMMEL-2968**.

## CR

Cross-model panel (codex, paid tier): round 1, 1/1 critic responded, 0 Critical/Important/Suggestion findings. Marker cleared clean (`clear-cr-marker.sh` exit 0). No CodeRabbit App threads yet — will re-request review and watch CI to green per standard flow.

## Test plan
- [x] `SUITE_TIER_MODE=all SUITE_LOCK_WAIT=60 bash scripts/quiet-run.sh suite -- bash scripts/handover/test-arm-resume-queue-lock.sh` green (was red on T15/T19 pre-fix)
- [x] ~26 impacted suites swept foreground, verdicts recorded above
- [x] `shellcheck -x` clean, bash 3.2-safe
- [ ] Nightly slow-tier gating run at 07:17Z is the real-world proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQrRB4ghn2oC4JPUkNtSii