### PR TITLE
fix(scripts): [HIMMEL-2967] quiet-run.sh path guard: refuse '..' argv components and require tracked test-*.sh for suite runs

### DIFF
--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -1800,6 +1800,12 @@ Fails OPEN on anything this
 hook cannot evaluate (missing `jq`, unparseable JSON, non-Bash tool) — a
 workflow nudge, not a security fence. Bypass: `QUIET_RUN_BYPASS=1`
 (launching shell, session-sticky). Spec: `scripts/hooks/test-require-quiet-run.sh`.
+`scripts/quiet-run.sh` itself (HIMMEL-2967) fails closed on any argv element
+with a `..` path component and, for the label `suite` when argv is
+`bash <path> …`, requires `<path>` to be a git-tracked `test-*.sh` — closing the
+gap where a `permissions.allow` tail-glob rule (HIMMEL-2959) admits the literal
+label + directory but quiet-run itself performed no path validation before
+exec.
 
 ### `block-docker-privesc.sh` — root-equivalent container guard (HIMMEL-441)
 

--- a/docs/internals/enforcement.md
+++ b/docs/internals/enforcement.md
@@ -1805,7 +1805,11 @@ with a `..` path component and, for the label `suite` when argv is
 `bash <path> …`, requires `<path>` to be a git-tracked `test-*.sh` — closing the
 gap where a `permissions.allow` tail-glob rule (HIMMEL-2959) admits the literal
 label + directory but quiet-run itself performed no path validation before
-exec.
+exec. The tracked-file check itself only applies inside a git repository —
+outside one (no `.git` discoverable) it prints a skip note and lets the
+command through unchecked, since there is no tracked-vs-untracked distinction
+to enforce; any OTHER `git rev-parse` failure (git absent, a transient error)
+still fails closed.
 
 ### `block-docker-privesc.sh` — root-equivalent container guard (HIMMEL-441)
 

--- a/scripts/quiet-run.sh
+++ b/scripts/quiet-run.sh
@@ -44,13 +44,21 @@ if [ "$LABEL" = "suite" ] && [ "${1:-}" = "bash" ]; then
             exit 2
             ;;
     esac
-    if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    if TOPLEVEL_ERR=$(git rev-parse --show-toplevel 2>&1 1>/dev/null); then
         if ! git --literal-pathspecs ls-files --error-unmatch -- "$SUITE_PATH" >/dev/null 2>&1; then
             echo "ERR quiet-run: label 'suite' requires a tracked test-*.sh, got: $SUITE_PATH" >&2
             exit 2
         fi
     else
-        echo "quiet-run: not a git repo — skipping tracked-file check for label 'suite'" >&2
+        case "$TOPLEVEL_ERR" in
+            *"not a git repository"*)
+                echo "quiet-run: not a git repo — skipping tracked-file check for label 'suite'" >&2
+                ;;
+            *)
+                echo "ERR quiet-run: label 'suite' tracked-file check failed unexpectedly: $TOPLEVEL_ERR" >&2
+                exit 2
+                ;;
+        esac
     fi
 fi
 

--- a/scripts/quiet-run.sh
+++ b/scripts/quiet-run.sh
@@ -44,7 +44,7 @@ if [ "$LABEL" = "suite" ] && [ "${1:-}" = "bash" ]; then
             exit 2
             ;;
     esac
-    if TOPLEVEL_ERR=$(git rev-parse --show-toplevel 2>&1 1>/dev/null); then
+    if TOPLEVEL_ERR=$(LC_ALL=C git rev-parse --show-toplevel 2>&1 1>/dev/null); then
         if ! git --literal-pathspecs ls-files --error-unmatch -- "$SUITE_PATH" >/dev/null 2>&1; then
             echo "ERR quiet-run: label 'suite' requires a tracked test-*.sh, got: $SUITE_PATH" >&2
             exit 2

--- a/scripts/quiet-run.sh
+++ b/scripts/quiet-run.sh
@@ -51,7 +51,7 @@ if [ "$LABEL" = "suite" ] && [ "${1:-}" = "bash" ]; then
         fi
     else
         case "$TOPLEVEL_ERR" in
-            *"not a git repository"*)
+            *"not a git repository (or any"*)
                 echo "quiet-run: not a git repo — skipping tracked-file check for label 'suite'" >&2
                 ;;
             *)

--- a/scripts/quiet-run.sh
+++ b/scripts/quiet-run.sh
@@ -25,6 +25,35 @@ if [ "$1" != "--" ]; then
 fi
 shift
 
+for arg in "$@"; do
+    case "$arg" in
+        ..|../*|*/..|*/../*)
+            echo "ERR quiet-run: refusing '..' path component in argv: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ "$LABEL" = "suite" ] && [ "${1:-}" = "bash" ]; then
+    SUITE_PATH="${2:-}"
+    BASENAME="${SUITE_PATH##*/}"
+    case "$BASENAME" in
+        test-*.sh) : ;;
+        *)
+            echo "ERR quiet-run: label 'suite' requires a tracked test-*.sh, got: $SUITE_PATH" >&2
+            exit 2
+            ;;
+    esac
+    if git rev-parse --show-toplevel >/dev/null 2>&1; then
+        if ! git ls-files --error-unmatch -- "$SUITE_PATH" >/dev/null 2>&1; then
+            echo "ERR quiet-run: label 'suite' requires a tracked test-*.sh, got: $SUITE_PATH" >&2
+            exit 2
+        fi
+    else
+        echo "quiet-run: not a git repo — skipping tracked-file check for label 'suite'" >&2
+    fi
+fi
+
 LOG="${TMPDIR:-/tmp}/quiet-run-${LABEL}-$(date +%Y%m%d-%H%M%S)-$$.log"
 
 {

--- a/scripts/quiet-run.sh
+++ b/scripts/quiet-run.sh
@@ -45,7 +45,8 @@ if [ "$LABEL" = "suite" ] && [ "${1:-}" = "bash" ]; then
             ;;
     esac
     if TOPLEVEL_ERR=$(LC_ALL=C git rev-parse --show-toplevel 2>&1 1>/dev/null); then
-        if ! git --literal-pathspecs ls-files --error-unmatch -- "$SUITE_PATH" >/dev/null 2>&1; then
+        TRACKED_MATCH=$(git --literal-pathspecs ls-files -- "$SUITE_PATH" 2>/dev/null)
+        if [ "$TRACKED_MATCH" != "$SUITE_PATH" ]; then
             echo "ERR quiet-run: label 'suite' requires a tracked test-*.sh, got: $SUITE_PATH" >&2
             exit 2
         fi

--- a/scripts/quiet-run.sh
+++ b/scripts/quiet-run.sh
@@ -45,7 +45,7 @@ if [ "$LABEL" = "suite" ] && [ "${1:-}" = "bash" ]; then
             ;;
     esac
     if git rev-parse --show-toplevel >/dev/null 2>&1; then
-        if ! git ls-files --error-unmatch -- "$SUITE_PATH" >/dev/null 2>&1; then
+        if ! git --literal-pathspecs ls-files --error-unmatch -- "$SUITE_PATH" >/dev/null 2>&1; then
             echo "ERR quiet-run: label 'suite' requires a tracked test-*.sh, got: $SUITE_PATH" >&2
             exit 2
         fi

--- a/scripts/test-quiet-run.sh
+++ b/scripts/test-quiet-run.sh
@@ -18,12 +18,14 @@ QUIET_RUN="$REPO_ROOT/scripts/quiet-run.sh"
 PRE_FIX_BASE="541a866b34d8b93942b1556145e2e5d97c4ee390"
 
 FAILED=0
-SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/test-quiet-run.XXXXXX")"
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/test-quiet-run.XXXXXX")" || { echo "FAIL: mktemp -d failed" >&2; exit 1; }
 UNTRACKED_ABS=""
+GLOB_UNTRACKED_ABS=""
 # shellcheck disable=SC2329,SC2317
 cleanup() {
     rm -rf "$SCRATCH"
     [ -n "$UNTRACKED_ABS" ] && rm -f "$UNTRACKED_ABS"
+    [ -n "$GLOB_UNTRACKED_ABS" ] && rm -f "$GLOB_UNTRACKED_ABS"
 }
 trap cleanup EXIT
 
@@ -104,6 +106,34 @@ assert_contains "untracked suite refusal message" "requires a tracked test-*.sh"
 OUT=$(cd "$REPO_ROOT" && bash "$QUIET_RUN" suite -- bash scripts/hooks/test-require-quiet-run.sh 2>&1)
 RC=$?
 assert_rc "suite with tracked test-*.sh" 0 "$RC"
+
+# 6b. RED/GREEN: git ls-files pathspec-glob bypass (codex-1 finding, round 2).
+# A literal argv path containing pathspec-glob metacharacters (e.g. a filename
+# that is literally "test-*.sh") can satisfy a bare
+# `git ls-files --error-unmatch -- "$SUITE_PATH"` by glob-matching some OTHER
+# tracked test-*.sh file, even though the literal path bash actually executes
+# is an untracked, attacker-controlled file. --literal-pathspecs disables the
+# wildcard interpretation. RED runs against the pre-this-fix committed head
+# (which already has the tracked-file guard, but without --literal-pathspecs)
+# to prove the bypass is real; GREEN proves the fixed script refuses it.
+GLOB_BASE="85af3389bc8782f669aaea7047cf03321736b1d9"
+GLOB_VULN="$SCRATCH/quiet-run-globvuln.sh"
+git -C "$REPO_ROOT" show "$GLOB_BASE:scripts/quiet-run.sh" > "$GLOB_VULN"
+chmod +x "$GLOB_VULN"
+
+GLOB_UNTRACKED_REL="scripts/hooks/test-*.sh"
+GLOB_UNTRACKED_ABS="$REPO_ROOT/$GLOB_UNTRACKED_REL"
+printf '#!/usr/bin/env bash\necho hi\n' > "$GLOB_UNTRACKED_ABS"
+chmod +x "$GLOB_UNTRACKED_ABS"
+
+OUT=$(cd "$REPO_ROOT" && bash "$GLOB_VULN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
+RC=$?
+assert_rc "RED: glob-pathspec bypass executes against pre-fix guard" 0 "$RC"
+
+OUT=$(cd "$REPO_ROOT" && bash "$QUIET_RUN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
+RC=$?
+assert_rc "GREEN: glob-pathspec bypass refused by --literal-pathspecs fix" 2 "$RC"
+assert_contains "GREEN: glob-pathspec refusal message" "requires a tracked test-*.sh" "$OUT"
 
 # 7. label "suite" with `node --test <tracked file>` is unaffected - the
 # tracked-file check applies only when argv is `bash <path> ...`; node

--- a/scripts/test-quiet-run.sh
+++ b/scripts/test-quiet-run.sh
@@ -18,7 +18,7 @@ QUIET_RUN="$REPO_ROOT/scripts/quiet-run.sh"
 PRE_FIX_BASE="541a866b34d8b93942b1556145e2e5d97c4ee390"
 
 FAILED=0
-SCRATCH="$(mktemp -d)"
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/test-quiet-run.XXXXXX")"
 UNTRACKED_ABS=""
 # shellcheck disable=SC2329,SC2317
 cleanup() {

--- a/scripts/test-quiet-run.sh
+++ b/scripts/test-quiet-run.sh
@@ -21,11 +21,12 @@ FAILED=0
 SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/test-quiet-run.XXXXXX")" || { echo "FAIL: mktemp -d failed" >&2; exit 1; }
 UNTRACKED_ABS=""
 GLOB_UNTRACKED_ABS=""
+GLOB_CREATED=0
 # shellcheck disable=SC2329,SC2317
 cleanup() {
     rm -rf "$SCRATCH"
     [ -n "$UNTRACKED_ABS" ] && rm -f "$UNTRACKED_ABS"
-    [ -n "$GLOB_UNTRACKED_ABS" ] && rm -f "$GLOB_UNTRACKED_ABS"
+    [ "$GLOB_CREATED" -eq 1 ] && rm -f "$GLOB_UNTRACKED_ABS"
 }
 trap cleanup EXIT
 
@@ -123,17 +124,23 @@ chmod +x "$GLOB_VULN"
 
 GLOB_UNTRACKED_REL="scripts/hooks/test-*.sh"
 GLOB_UNTRACKED_ABS="$REPO_ROOT/$GLOB_UNTRACKED_REL"
-printf '#!/usr/bin/env bash\necho hi\n' > "$GLOB_UNTRACKED_ABS"
-chmod +x "$GLOB_UNTRACKED_ABS"
+if [ -e "$GLOB_UNTRACKED_ABS" ]; then
+    echo "FAIL: $GLOB_UNTRACKED_ABS already exists - refusing to clobber a pre-existing file for this test" >&2
+    FAILED=$((FAILED + 1))
+else
+    printf '#!/usr/bin/env bash\necho hi\n' > "$GLOB_UNTRACKED_ABS"
+    chmod +x "$GLOB_UNTRACKED_ABS"
+    GLOB_CREATED=1
 
-OUT=$(cd "$REPO_ROOT" && bash "$GLOB_VULN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
-RC=$?
-assert_rc "RED: glob-pathspec bypass executes against pre-fix guard" 0 "$RC"
+    OUT=$(cd "$REPO_ROOT" && bash "$GLOB_VULN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
+    RC=$?
+    assert_rc "RED: glob-pathspec bypass executes against pre-fix guard" 0 "$RC"
 
-OUT=$(cd "$REPO_ROOT" && bash "$QUIET_RUN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
-RC=$?
-assert_rc "GREEN: glob-pathspec bypass refused by --literal-pathspecs fix" 2 "$RC"
-assert_contains "GREEN: glob-pathspec refusal message" "requires a tracked test-*.sh" "$OUT"
+    OUT=$(cd "$REPO_ROOT" && bash "$QUIET_RUN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
+    RC=$?
+    assert_rc "GREEN: glob-pathspec bypass refused by --literal-pathspecs fix" 2 "$RC"
+    assert_contains "GREEN: glob-pathspec refusal message" "requires a tracked test-*.sh" "$OUT"
+fi
 
 # 7. label "suite" with `node --test <tracked file>` is unaffected - the
 # tracked-file check applies only when argv is `bash <path> ...`; node

--- a/scripts/test-quiet-run.sh
+++ b/scripts/test-quiet-run.sh
@@ -58,14 +58,18 @@ assert_contains() {
 # 541a866b34d8b93942b1556145e2e5d97c4ee390) executes - proves the control
 # can actually fail before asserting the fixed script blocks it.
 PRE_FIX="$SCRATCH/quiet-run-prefix.sh"
-git -C "$REPO_ROOT" show "$PRE_FIX_BASE:scripts/quiet-run.sh" > "$PRE_FIX"
-chmod +x "$PRE_FIX"
 mkdir -p "$SCRATCH/red-log" "$SCRATCH/green-log"
+if ! git -C "$REPO_ROOT" show "$PRE_FIX_BASE:scripts/quiet-run.sh" > "$PRE_FIX" 2>/dev/null; then
+    echo "FAIL: could not extract $PRE_FIX_BASE:scripts/quiet-run.sh (missing git object - shallow clone or squash merge?)" >&2
+    FAILED=$((FAILED + 1))
+else
+    chmod +x "$PRE_FIX"
 
-OUT=$(cd "$REPO_ROOT" && TMPDIR="$SCRATCH/red-log" bash "$PRE_FIX" suite -- bash scripts/hooks/test-x/../../evil.sh 2>&1)
-RC=$?
-assert_rc "RED: traversal executes against pre-fix script" 127 "$RC"
-assert_contains "RED: traversal exit=127 surfaced (i.e. it ran)" "exit=127" "$OUT"
+    OUT=$(cd "$REPO_ROOT" && TMPDIR="$SCRATCH/red-log" bash "$PRE_FIX" suite -- bash scripts/hooks/test-x/../../evil.sh 2>&1)
+    RC=$?
+    assert_rc "RED: traversal executes against pre-fix script" 127 "$RC"
+    assert_contains "RED: traversal exit=127 surfaced (i.e. it ran)" "exit=127" "$OUT"
+fi
 
 # 2. GREEN: same shape against the FIXED script is refused before exec -
 # rc=2, refusal line, and no log file created (proves it never reached exec).
@@ -119,27 +123,32 @@ assert_rc "suite with tracked test-*.sh" 0 "$RC"
 # to prove the bypass is real; GREEN proves the fixed script refuses it.
 GLOB_BASE="85af3389bc8782f669aaea7047cf03321736b1d9"
 GLOB_VULN="$SCRATCH/quiet-run-globvuln.sh"
-git -C "$REPO_ROOT" show "$GLOB_BASE:scripts/quiet-run.sh" > "$GLOB_VULN"
-chmod +x "$GLOB_VULN"
-
-GLOB_UNTRACKED_REL="scripts/hooks/test-*.sh"
-GLOB_UNTRACKED_ABS="$REPO_ROOT/$GLOB_UNTRACKED_REL"
-if [ -e "$GLOB_UNTRACKED_ABS" ]; then
-    echo "FAIL: $GLOB_UNTRACKED_ABS already exists - refusing to clobber a pre-existing file for this test" >&2
+if ! git -C "$REPO_ROOT" show "$GLOB_BASE:scripts/quiet-run.sh" > "$GLOB_VULN" 2>/dev/null; then
+    echo "FAIL: could not extract $GLOB_BASE:scripts/quiet-run.sh (missing git object - shallow clone or squash merge?)" >&2
     FAILED=$((FAILED + 1))
 else
-    printf '#!/usr/bin/env bash\necho hi\n' > "$GLOB_UNTRACKED_ABS"
-    chmod +x "$GLOB_UNTRACKED_ABS"
-    GLOB_CREATED=1
+    chmod +x "$GLOB_VULN"
 
-    OUT=$(cd "$REPO_ROOT" && bash "$GLOB_VULN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
-    RC=$?
-    assert_rc "RED: glob-pathspec bypass executes against pre-fix guard" 0 "$RC"
+    GLOB_UNTRACKED_REL="scripts/hooks/test-*.sh"
+    GLOB_UNTRACKED_ABS="$REPO_ROOT/$GLOB_UNTRACKED_REL"
+    if [ -e "$GLOB_UNTRACKED_ABS" ]; then
+        echo "FAIL: $GLOB_UNTRACKED_ABS already exists - refusing to clobber a pre-existing file for this test" >&2
+        FAILED=$((FAILED + 1))
+    elif ! printf '#!/usr/bin/env bash\necho hi\n' > "$GLOB_UNTRACKED_ABS" 2>/dev/null; then
+        echo "SKIP: filesystem rejects a literal '*' in a filename (e.g. Windows/NTFS) - glob-pathspec bypass fixture not applicable here" >&2
+    else
+        chmod +x "$GLOB_UNTRACKED_ABS"
+        GLOB_CREATED=1
 
-    OUT=$(cd "$REPO_ROOT" && bash "$QUIET_RUN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
-    RC=$?
-    assert_rc "GREEN: glob-pathspec bypass refused by --literal-pathspecs fix" 2 "$RC"
-    assert_contains "GREEN: glob-pathspec refusal message" "requires a tracked test-*.sh" "$OUT"
+        OUT=$(cd "$REPO_ROOT" && bash "$GLOB_VULN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
+        RC=$?
+        assert_rc "RED: glob-pathspec bypass executes against pre-fix guard" 0 "$RC"
+
+        OUT=$(cd "$REPO_ROOT" && bash "$QUIET_RUN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
+        RC=$?
+        assert_rc "GREEN: glob-pathspec bypass refused by --literal-pathspecs fix" 2 "$RC"
+        assert_contains "GREEN: glob-pathspec refusal message" "requires a tracked test-*.sh" "$OUT"
+    fi
 fi
 
 # 7. label "suite" with `node --test <tracked file>` is unaffected - the

--- a/scripts/test-quiet-run.sh
+++ b/scripts/test-quiet-run.sh
@@ -226,6 +226,33 @@ RC=$?
 assert_rc "broken GIT_DIR: fails closed, not skipped" 2 "$RC"
 assert_contains "broken GIT_DIR: unexpected-failure message" "failed unexpectedly" "$OUT"
 
+# 10. Directory-pathspec bypass (codex-1, round 7): `git ls-files -- <path>`
+# matches a pathspec against index entries by directory-prefix too, not just
+# exact file paths. If the tracked history once held a directory literally
+# named like a test-*.sh file (e.g. "test-x.sh/inner.sh" tracked), an
+# attacker who replaces that directory in the working tree with an untracked
+# plain file of the same name could pass the old --error-unmatch check
+# (prefix match still succeeds) while the file bash actually executes is
+# untracked. Requiring the ls-files output to equal SUITE_PATH exactly closes
+# this. Built as a throwaway nested repo, not the real himmel history.
+DIRBYPASS="$SCRATCH/dirbypass"
+mkdir -p "$DIRBYPASS"
+git -C "$DIRBYPASS" init -q
+git -C "$DIRBYPASS" config user.email test@example.com
+git -C "$DIRBYPASS" config user.name test
+mkdir -p "$DIRBYPASS/test-x.sh"
+printf 'tracked\n' > "$DIRBYPASS/test-x.sh/inner.sh"
+git -C "$DIRBYPASS" add test-x.sh/inner.sh
+git -C "$DIRBYPASS" commit -q -m "tracked dir named like a test-*.sh file"
+rm -rf "${DIRBYPASS:?}/test-x.sh"
+printf '#!/usr/bin/env bash\necho pwned\n' > "$DIRBYPASS/test-x.sh"
+chmod +x "$DIRBYPASS/test-x.sh"
+cp "$QUIET_RUN" "$DIRBYPASS/quiet-run.sh"
+OUT=$(cd "$DIRBYPASS" && bash quiet-run.sh suite -- bash test-x.sh 2>&1)
+RC=$?
+assert_rc "directory-pathspec bypass refused" 2 "$RC"
+assert_contains "directory-pathspec bypass refusal message" "requires a tracked test-*.sh" "$OUT"
+
 echo ""
 if [ "$FAILED" -eq 0 ]; then
     echo "All quiet-run.sh guard cases passed."

--- a/scripts/test-quiet-run.sh
+++ b/scripts/test-quiet-run.sh
@@ -210,6 +210,22 @@ OUT=$(cd "$NOTREPO" && GIT_CEILING_DIRECTORIES="$SCRATCH" bash quiet-run.sh suit
 RC=$?
 assert_rc "outside git repo: '..' still refused" 2 "$RC"
 
+# 9. A broken/invalid git repository pointer (codex-1, round 6) must fail
+# closed, not be treated as "no repo, skip the check" - git's diagnostic for
+# an invalid gitdir also contains the substring "not a git repository", but
+# with a different, more specific shape ("not a git repository: <path>")
+# than genuine absence ("not a git repository (or any parent/of the parent
+# directories)"). A caller with corrupted git metadata must not be able to
+# smuggle an untracked suite past the tracked-file check.
+BROKENGIT="$SCRATCH/brokengit"
+mkdir -p "$BROKENGIT/scripts"
+cp "$QUIET_RUN" "$BROKENGIT/quiet-run.sh"
+printf '#!/usr/bin/env bash\necho hi\n' > "$BROKENGIT/scripts/test-x.sh"
+OUT=$(cd "$BROKENGIT" && GIT_DIR="$SCRATCH/does-not-exist" bash quiet-run.sh suite -- bash scripts/test-x.sh 2>&1)
+RC=$?
+assert_rc "broken GIT_DIR: fails closed, not skipped" 2 "$RC"
+assert_contains "broken GIT_DIR: unexpected-failure message" "failed unexpectedly" "$OUT"
+
 echo ""
 if [ "$FAILED" -eq 0 ]; then
     echo "All quiet-run.sh guard cases passed."

--- a/scripts/test-quiet-run.sh
+++ b/scripts/test-quiet-run.sh
@@ -15,7 +15,6 @@ set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 QUIET_RUN="$REPO_ROOT/scripts/quiet-run.sh"
-PRE_FIX_BASE="541a866b34d8b93942b1556145e2e5d97c4ee390"
 
 FAILED=0
 SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/test-quiet-run.XXXXXX")" || { echo "FAIL: mktemp -d failed" >&2; exit 1; }
@@ -54,22 +53,36 @@ assert_contains() {
     esac
 }
 
-# 1. RED control: the traversal shape against the PRE-FIX script (base
-# 541a866b34d8b93942b1556145e2e5d97c4ee390) executes - proves the control
-# can actually fail before asserting the fixed script blocks it.
+# 1. RED control: the traversal shape against a SELF-CONTAINED pre-fix
+# fixture (no argv path validation at all, matching the guard's absence
+# before HIMMEL-2967) executes - proves the control can actually fail
+# before asserting the fixed script blocks it. Self-contained rather than
+# extracted from a historical commit (codex-1, round 4): a `git show
+# <sha>:path` extraction depends on that object being reachable, which a
+# shallow clone or squash-merged checkout may not have.
 PRE_FIX="$SCRATCH/quiet-run-prefix.sh"
 mkdir -p "$SCRATCH/red-log" "$SCRATCH/green-log"
-if ! git -C "$REPO_ROOT" show "$PRE_FIX_BASE:scripts/quiet-run.sh" > "$PRE_FIX" 2>/dev/null; then
-    echo "FAIL: could not extract $PRE_FIX_BASE:scripts/quiet-run.sh (missing git object - shallow clone or squash merge?)" >&2
-    FAILED=$((FAILED + 1))
+cat > "$PRE_FIX" <<'PRE_FIX_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LABEL="$1"; shift
+shift
+LOG="${TMPDIR:-/tmp}/quiet-run-prefix-red.log"
+if "$@" >>"$LOG" 2>&1; then
+    echo "OK quiet-run $LABEL (log: $LOG)"
+    exit 0
 else
-    chmod +x "$PRE_FIX"
-
-    OUT=$(cd "$REPO_ROOT" && TMPDIR="$SCRATCH/red-log" bash "$PRE_FIX" suite -- bash scripts/hooks/test-x/../../evil.sh 2>&1)
     RC=$?
-    assert_rc "RED: traversal executes against pre-fix script" 127 "$RC"
-    assert_contains "RED: traversal exit=127 surfaced (i.e. it ran)" "exit=127" "$OUT"
+    echo "ERR quiet-run $LABEL exit=$RC (log: $LOG)" >&2
+    exit $RC
 fi
+PRE_FIX_EOF
+chmod +x "$PRE_FIX"
+
+OUT=$(cd "$REPO_ROOT" && TMPDIR="$SCRATCH/red-log" bash "$PRE_FIX" suite -- bash scripts/hooks/test-x/../../evil.sh 2>&1)
+RC=$?
+assert_rc "RED: traversal executes against pre-fix script" 127 "$RC"
+assert_contains "RED: traversal exit=127 surfaced (i.e. it ran)" "exit=127" "$OUT"
 
 # 2. GREEN: same shape against the FIXED script is refused before exec -
 # rc=2, refusal line, and no log file created (proves it never reached exec).
@@ -118,37 +131,58 @@ assert_rc "suite with tracked test-*.sh" 0 "$RC"
 # `git ls-files --error-unmatch -- "$SUITE_PATH"` by glob-matching some OTHER
 # tracked test-*.sh file, even though the literal path bash actually executes
 # is an untracked, attacker-controlled file. --literal-pathspecs disables the
-# wildcard interpretation. RED runs against the pre-this-fix committed head
-# (which already has the tracked-file guard, but without --literal-pathspecs)
-# to prove the bypass is real; GREEN proves the fixed script refuses it.
-GLOB_BASE="85af3389bc8782f669aaea7047cf03321736b1d9"
+# wildcard interpretation. RED runs against a SELF-CONTAINED fixture that
+# reproduces the pre-this-fix tracked-file check (same logic, minus
+# --literal-pathspecs) to prove the bypass is real; GREEN proves the fixed
+# script refuses it. Self-contained rather than extracted from a historical
+# commit (codex-1, round 4): a `git show <sha>:path` extraction depends on
+# that object being reachable, which a shallow clone or squash-merged
+# checkout may not have.
 GLOB_VULN="$SCRATCH/quiet-run-globvuln.sh"
-if ! git -C "$REPO_ROOT" show "$GLOB_BASE:scripts/quiet-run.sh" > "$GLOB_VULN" 2>/dev/null; then
-    echo "FAIL: could not extract $GLOB_BASE:scripts/quiet-run.sh (missing git object - shallow clone or squash merge?)" >&2
-    FAILED=$((FAILED + 1))
-else
-    chmod +x "$GLOB_VULN"
-
-    GLOB_UNTRACKED_REL="scripts/hooks/test-*.sh"
-    GLOB_UNTRACKED_ABS="$REPO_ROOT/$GLOB_UNTRACKED_REL"
-    if [ -e "$GLOB_UNTRACKED_ABS" ]; then
-        echo "FAIL: $GLOB_UNTRACKED_ABS already exists - refusing to clobber a pre-existing file for this test" >&2
-        FAILED=$((FAILED + 1))
-    elif ! printf '#!/usr/bin/env bash\necho hi\n' > "$GLOB_UNTRACKED_ABS" 2>/dev/null; then
-        echo "SKIP: filesystem rejects a literal '*' in a filename (e.g. Windows/NTFS) - glob-pathspec bypass fixture not applicable here" >&2
-    else
-        chmod +x "$GLOB_UNTRACKED_ABS"
-        GLOB_CREATED=1
-
-        OUT=$(cd "$REPO_ROOT" && bash "$GLOB_VULN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
-        RC=$?
-        assert_rc "RED: glob-pathspec bypass executes against pre-fix guard" 0 "$RC"
-
-        OUT=$(cd "$REPO_ROOT" && bash "$QUIET_RUN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
-        RC=$?
-        assert_rc "GREEN: glob-pathspec bypass refused by --literal-pathspecs fix" 2 "$RC"
-        assert_contains "GREEN: glob-pathspec refusal message" "requires a tracked test-*.sh" "$OUT"
+cat > "$GLOB_VULN" <<'GLOB_VULN_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LABEL="$1"; shift
+shift
+if [ "$LABEL" = "suite" ] && [ "${1:-}" = "bash" ]; then
+    SUITE_PATH="${2:-}"
+    BASENAME="${SUITE_PATH##*/}"
+    case "$BASENAME" in
+        test-*.sh) : ;;
+        *)
+            echo "ERR quiet-run: label 'suite' requires a tracked test-*.sh, got: $SUITE_PATH" >&2
+            exit 2
+            ;;
+    esac
+    if ! git ls-files --error-unmatch -- "$SUITE_PATH" >/dev/null 2>&1; then
+        echo "ERR quiet-run: label 'suite' requires a tracked test-*.sh, got: $SUITE_PATH" >&2
+        exit 2
     fi
+fi
+echo "OK quiet-run $LABEL"
+exit 0
+GLOB_VULN_EOF
+chmod +x "$GLOB_VULN"
+
+GLOB_UNTRACKED_REL="scripts/hooks/test-*.sh"
+GLOB_UNTRACKED_ABS="$REPO_ROOT/$GLOB_UNTRACKED_REL"
+if [ -e "$GLOB_UNTRACKED_ABS" ]; then
+    echo "FAIL: $GLOB_UNTRACKED_ABS already exists - refusing to clobber a pre-existing file for this test" >&2
+    FAILED=$((FAILED + 1))
+elif ! printf '#!/usr/bin/env bash\necho hi\n' > "$GLOB_UNTRACKED_ABS" 2>/dev/null; then
+    echo "SKIP: filesystem rejects a literal '*' in a filename (e.g. Windows/NTFS) - glob-pathspec bypass fixture not applicable here" >&2
+else
+    chmod +x "$GLOB_UNTRACKED_ABS"
+    GLOB_CREATED=1
+
+    OUT=$(cd "$REPO_ROOT" && bash "$GLOB_VULN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
+    RC=$?
+    assert_rc "RED: glob-pathspec bypass executes against pre-fix guard" 0 "$RC"
+
+    OUT=$(cd "$REPO_ROOT" && bash "$QUIET_RUN" suite -- bash "$GLOB_UNTRACKED_REL" 2>&1)
+    RC=$?
+    assert_rc "GREEN: glob-pathspec bypass refused by --literal-pathspecs fix" 2 "$RC"
+    assert_contains "GREEN: glob-pathspec refusal message" "requires a tracked test-*.sh" "$OUT"
 fi
 
 # 7. label "suite" with `node --test <tracked file>` is unaffected - the
@@ -159,16 +193,20 @@ RC=$?
 assert_rc "suite with node --test <tracked file> unaffected" 0 "$RC"
 
 # 8. Outside a git repo, the tracked-file check is skipped (does not break
-# non-repo callers) but the '..' guard still applies.
+# non-repo callers) but the '..' guard still applies. GIT_CEILING_DIRECTORIES
+# pins discovery to SCRATCH itself (codex-2, round 4): without it, a TMPDIR
+# that happens to live inside a checkout lets git discover that ANCESTOR
+# repo instead of finding none, so this case would fail despite quiet-run.sh
+# behaving correctly.
 NOTREPO="$SCRATCH/notrepo"
 mkdir -p "$NOTREPO/scripts"
 cp "$QUIET_RUN" "$NOTREPO/quiet-run.sh"
 printf '#!/usr/bin/env bash\necho hi\n' > "$NOTREPO/scripts/test-x.sh"
-OUT=$(cd "$NOTREPO" && bash quiet-run.sh suite -- bash scripts/test-x.sh 2>&1)
+OUT=$(cd "$NOTREPO" && GIT_CEILING_DIRECTORIES="$SCRATCH" bash quiet-run.sh suite -- bash scripts/test-x.sh 2>&1)
 RC=$?
 assert_rc "outside git repo: tracked check skipped" 0 "$RC"
 assert_contains "outside git repo: skip note" "skipping tracked-file check" "$OUT"
-OUT=$(cd "$NOTREPO" && bash quiet-run.sh suite -- bash scripts/../evil.sh 2>&1)
+OUT=$(cd "$NOTREPO" && GIT_CEILING_DIRECTORIES="$SCRATCH" bash quiet-run.sh suite -- bash scripts/../evil.sh 2>&1)
 RC=$?
 assert_rc "outside git repo: '..' still refused" 2 "$RC"
 

--- a/scripts/test-quiet-run.sh
+++ b/scripts/test-quiet-run.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Tests for scripts/quiet-run.sh's argv path guard (HIMMEL-2967): refuses
+# ".." path components in any argv element, and (label "suite" only) requires
+# a git-tracked test-*.sh when argv is `bash <path> ...`.
+#
+# Usage: bash scripts/test-quiet-run.sh
+#
+# Platform guard (gitbash-only): Git Bash on Windows / any POSIX bash 3.2+.
+# Pure bash + coreutils + git; no .ps1 twin needed.
+#
+# Exit codes:
+#   0 - all cases passed
+#   1 - at least one case failed
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+QUIET_RUN="$REPO_ROOT/scripts/quiet-run.sh"
+PRE_FIX_BASE="541a866b34d8b93942b1556145e2e5d97c4ee390"
+
+FAILED=0
+SCRATCH="$(mktemp -d)"
+UNTRACKED_ABS=""
+# shellcheck disable=SC2329,SC2317
+cleanup() {
+    rm -rf "$SCRATCH"
+    [ -n "$UNTRACKED_ABS" ] && rm -f "$UNTRACKED_ABS"
+}
+trap cleanup EXIT
+
+assert_rc() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS $label (rc=$actual)"
+    else
+        echo "FAIL $label - expected rc=$expected, got rc=$actual"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    case "$haystack" in
+        *"$needle"*)
+            echo "PASS $label (message matches)"
+            ;;
+        *)
+            echo "FAIL $label - message did not contain: $needle"
+            echo "  got: $haystack"
+            FAILED=$((FAILED + 1))
+            ;;
+    esac
+}
+
+# 1. RED control: the traversal shape against the PRE-FIX script (base
+# 541a866b34d8b93942b1556145e2e5d97c4ee390) executes - proves the control
+# can actually fail before asserting the fixed script blocks it.
+PRE_FIX="$SCRATCH/quiet-run-prefix.sh"
+git -C "$REPO_ROOT" show "$PRE_FIX_BASE:scripts/quiet-run.sh" > "$PRE_FIX"
+chmod +x "$PRE_FIX"
+mkdir -p "$SCRATCH/red-log" "$SCRATCH/green-log"
+
+OUT=$(cd "$REPO_ROOT" && TMPDIR="$SCRATCH/red-log" bash "$PRE_FIX" suite -- bash scripts/hooks/test-x/../../evil.sh 2>&1)
+RC=$?
+assert_rc "RED: traversal executes against pre-fix script" 127 "$RC"
+assert_contains "RED: traversal exit=127 surfaced (i.e. it ran)" "exit=127" "$OUT"
+
+# 2. GREEN: same shape against the FIXED script is refused before exec -
+# rc=2, refusal line, and no log file created (proves it never reached exec).
+OUT=$(cd "$REPO_ROOT" && TMPDIR="$SCRATCH/green-log" bash "$QUIET_RUN" suite -- bash scripts/hooks/test-x/../../evil.sh 2>&1)
+RC=$?
+assert_rc "GREEN: traversal refused by fixed script" 2 "$RC"
+assert_contains "GREEN: refusal message" "refusing '..' path component" "$OUT"
+if [ -n "$(ls -A "$SCRATCH/green-log" 2>/dev/null)" ]; then
+    echo "FAIL GREEN: refused traversal must not create a log file"
+    FAILED=$((FAILED + 1))
+else
+    echo "PASS GREEN: no log file created for refused traversal"
+fi
+
+# 3. A ".." element under a non-suite label is refused too - the guard
+# applies to every label, not just suite.
+OUT=$(cd "$REPO_ROOT" && bash "$QUIET_RUN" npm-install -- bash scripts/foo/../bar.sh 2>&1)
+RC=$?
+assert_rc "non-suite label with '..' component" 2 "$RC"
+assert_contains "non-suite '..' refusal message" "refusing '..' path component" "$OUT"
+
+# 4. A literal ".." inside a filename (not a path component) is not a
+# traversal and must stay accepted.
+OUT=$(cd "$REPO_ROOT" && bash "$QUIET_RUN" mylabel -- printf 'a..b' 2>&1)
+RC=$?
+assert_rc "'a..b' filename-shaped element accepted" 0 "$RC"
+
+# 5. label "suite" with an untracked test-*.sh is refused (created under the
+# repo tree, never git-added).
+UNTRACKED_REL="scripts/hooks/test-untracked-quiet-run-2967-$$.sh"
+UNTRACKED_ABS="$REPO_ROOT/$UNTRACKED_REL"
+printf '#!/usr/bin/env bash\necho hi\n' > "$UNTRACKED_ABS"
+OUT=$(cd "$REPO_ROOT" && bash "$QUIET_RUN" suite -- bash "$UNTRACKED_REL" 2>&1)
+RC=$?
+assert_rc "suite with untracked test-*.sh" 2 "$RC"
+assert_contains "untracked suite refusal message" "requires a tracked test-*.sh" "$OUT"
+
+# 6. label "suite" with a tracked test-*.sh passes.
+OUT=$(cd "$REPO_ROOT" && bash "$QUIET_RUN" suite -- bash scripts/hooks/test-require-quiet-run.sh 2>&1)
+RC=$?
+assert_rc "suite with tracked test-*.sh" 0 "$RC"
+
+# 7. label "suite" with `node --test <tracked file>` is unaffected - the
+# tracked-file check applies only when argv is `bash <path> ...`; node
+# suites stay on the classifier path exactly as before this change.
+OUT=$(cd "$REPO_ROOT" && bash "$QUIET_RUN" suite -- node --test scripts/lanes/tests/plugin-profiles.test.mjs 2>&1)
+RC=$?
+assert_rc "suite with node --test <tracked file> unaffected" 0 "$RC"
+
+# 8. Outside a git repo, the tracked-file check is skipped (does not break
+# non-repo callers) but the '..' guard still applies.
+NOTREPO="$SCRATCH/notrepo"
+mkdir -p "$NOTREPO/scripts"
+cp "$QUIET_RUN" "$NOTREPO/quiet-run.sh"
+printf '#!/usr/bin/env bash\necho hi\n' > "$NOTREPO/scripts/test-x.sh"
+OUT=$(cd "$NOTREPO" && bash quiet-run.sh suite -- bash scripts/test-x.sh 2>&1)
+RC=$?
+assert_rc "outside git repo: tracked check skipped" 0 "$RC"
+assert_contains "outside git repo: skip note" "skipping tracked-file check" "$OUT"
+OUT=$(cd "$NOTREPO" && bash quiet-run.sh suite -- bash scripts/../evil.sh 2>&1)
+RC=$?
+assert_rc "outside git repo: '..' still refused" 2 "$RC"
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+    echo "All quiet-run.sh guard cases passed."
+    exit 0
+else
+    echo "$FAILED case(s) failed."
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- `scripts/quiet-run.sh` refuses any argv element containing a `..` path component (any label), and, for `bash <path> ...` under label `suite`, requires `<path>` to resolve to a git-tracked `test-*.sh`.
- The tracked-file check disables pathspec-glob interpretation, requires an exact index-entry match (closing a directory-prefix bypass), and fails closed — not open — on any git error other than genuine repository absence (including a broken `.git` pointer or invalid `GIT_DIR`, and independent of git's message locale).
- `scripts/test-quiet-run.sh` covers all of the above with RED/GREEN pairs; regression fixtures are self-contained (no dependency on specific historical commit objects, so they hold under shallow clones / squash-merged checkouts).

## Review history
This branch went 8 rounds against the CR panel (cap is 3) as each fix surfaced a narrower edge case in the same tracked-file check. Every Critical/Important finding across all 8 rounds was fixed in code (never deferred — the cap disposition path only permits deferring Suggestion/nit rows). One Suggestion from round 8 (`codex-1`, `scripts/quiet-run.sh:51`: the exact-match check normalizes neither `./`-prefixed nor absolute suite paths, so a legitimately tracked path given in either form would be falsely rejected) was deferred under the round cap to **HIMMEL-2970** — it's a false-rejection/usability edge case, not a security bypass, and every current call site in this repo passes plain relative paths.

### Known pre-existing false positive (not from this PR)
`[octal-leading-zero]` fires on unrelated lines in this diff's context per the CR gate's known-findings list; correctly left unfixed per that convention.

## Test plan
- [x] `shellcheck scripts/quiet-run.sh scripts/test-quiet-run.sh` clean
- [x] `bash scripts/quiet-run.sh suite -- bash scripts/test-quiet-run.sh` — 22/22 cases pass
- [x] `/pr-check` clean at head `26a46842` (8 panel rounds; ledger: 15 fixed, 1 deferred to HIMMEL-2970)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUkRZ2eExQFYjaW9j9zS9p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation that blocks unsafe path traversal in command arguments.
  - Restricted suite script execution to appropriately named, tracked test files when running inside a Git repository.
  - Improved handling of non-repository environments and invalid Git metadata by failing safely.

- **Documentation**
  - Documented the new command validation rules and execution behavior.

- **Tests**
  - Added comprehensive coverage for path validation, Git repository scenarios, bypass attempts, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->