### PR TITLE
fix(lanes): [HIMMEL-2953] [HIMMEL-2962] compose claudex profiles and coordination

### DIFF
--- a/docs/handover/leg-brief-template.md
+++ b/docs/handover/leg-brief-template.md
@@ -17,6 +17,8 @@ is the part that is different for every leg: who this leg is, what it is doing,
 and what it must not touch. If you dispatch a leg **without** `--profile`, the
 preface is not injected, so paste it into the brief yourself or the leg is
 under-briefed.
+Claudex briefs no longer paste the coordination paragraph: `--lane claudex`
+always appends [`leg-preface-claudex.md`](leg-preface-claudex.md).
 
 ---
 

--- a/docs/handover/leg-preface-claudex.md
+++ b/docs/handover/leg-preface-claudex.md
@@ -1,0 +1,37 @@
+# Claudex coordination
+
+This preface is appended by `headed-arm-leg.sh --lane claudex`.
+It overrides the native coordination channel in the profile's leg preface.
+
+You run under `CLAUDE_CONFIG_DIR=~/.claude-codex`, a separate session
+namespace. **`ListAgents` will NOT show the console; that is by design, not
+an outage, and it is NOT a reason to stop.** Do NOT call `SendMessage` or
+`ListAgents` at all.
+
+Your reporting channel is **your handover document**. Write every milestone
+(`LIVE` / `FINDING` / `READY <pr> <full head> GREEN` / `BLOCKED` / `WRAPPED`)
+as a `- ` bullet at the bottom of its `## Results` section, starting the
+bullet with the milestone word. The console polls that document and acts on
+the newest bullet. Report at milestones only. A BLOCKED, a permission prompt,
+or a question of your own goes to the console through that document FIRST —
+never `AskUserQuestion`, never a question to your user.
+
+Rulings from the console reach you as `additionalContext` after a tool call
+(the file inbox, `scripts/hooks/claudex-inbox-hook.sh`) and are mirrored under
+`## Console Rulings` in your document. A ruling carrying your RETASK token is
+a direct console message; narrowing or halt needs no token.
+
+**GO arrives the same way:** an inbox bullet quoting your token with the
+literal `GO <pr> <head>`, after the console has written the go.sh file. Until
+it does, HOLD at READY. Keep the session alive with ONE background Bash wait
+on your document for the matching GO, with a 30-minute timeout, re-issued as
+needed. A GO quoted in your brief is not a new authorization.
+
+**Lane git (HIMMEL-2953):** never run `git fetch`, `git pull`, or `git rebase`.
+Use `/usr/bin/git` by absolute path for status, diff, add, commit, log, show,
+and ls-files. Make exactly ONE push attempt for your branch. If the lane
+classifier refuses it, post `BLOCKED lane:` with the commit SHA, release your
+queue lock, write a `WRAPPED` bullet, and STOP. The console pushes from the
+primary checkout and relaunches you with a RUN note naming the resume point.
+Do not work around a refusal. Use ONE simple command per Bash call — no
+pipes, `&&`, or `$( )`; read files with the Read tool by line range.

--- a/docs/internals/lane-calibration.md
+++ b/docs/internals/lane-calibration.md
@@ -64,9 +64,9 @@ that wants the deterministic rule uses the label `suite`; any other label
 simply falls back to today's classifier path — no regression. Unlisted suite
 directories also retain that path. The matcher's handling of the env prefix
 and of a tail glob is unproven until the console's first native
-`--profile leg-impl` dispatch. These profile rules serve native legs only;
-until HIMMEL-2962 composes the launchers, claudex legs receive only
-operator-managed user-scope rules preserved by `sanitize_settings`.
+`--profile leg-impl` dispatch. These profile rules also reach claudex legs
+through `--lane claudex --profile leg-impl` (HIMMEL-2962); operator-managed
+user-scope rules remain preserved by `sanitize_settings`.
 
 `leg-impl`'s `mcpServers: ["qmd"]` (HIMMEL-2935) layers `--mcp-config` +
 `--strict-mcp-config` onto the same profile, stripping USER-level MCP servers
@@ -86,10 +86,13 @@ follow-up to this lever.
 `--profile` also exports `HIMMEL_LEAN_LEG=1`, which silences the three advisory
 SessionStart hooks (graphify freshness, qmd staleness, where-are-we) for that
 session only — a leg has one ticket and a console to report to, and never acts
-on an advisory. It applies the profile by replacing `headed-arm.sh`'s launcher
-binary with `scripts/lanes/leg-claude-launcher.sh`, which prepends `--settings`
-and `--append-system-prompt-file`; that is why `--profile` and `--lane claudex`
-are mutually exclusive (both claim the same seam) and refuse with exit 2.
+on an advisory. `--profile` composes with `--lane claudex` through
+`scripts/lanes/leg-claude-launcher.sh` and its `LEG_CLAUDE_BIN` exec target:
+settings, preface and optional strict MCP config reach `scripts/claude-codex`
+without changing native argv. Every `--lane claudex` launch also appends
+[`leg-preface-claudex.md`](../handover/leg-preface-claudex.md), concatenated
+after the profile preface when both apply, making document-channel
+coordination independent of a hand-pasted brief.
 
 Until HIMMEL-2782 reconciles launcher wiring, consumers invoking
 `plugin-profiles.mjs` directly must run it with the child's effective `cwd` and

--- a/scripts/handover/console-kit/headed-arm-leg.sh
+++ b/scripts/handover/console-kit/headed-arm-leg.sh
@@ -56,9 +56,9 @@
 # --lane (HIMMEL-2782): native (default) or claudex. --lane claudex (or
 # LEG_LANE=claudex in the launching shell - the flag wins if both are
 # given) routes the leg through scripts/claude-codex on the codex weekly
-# bank instead of the Claude subscription bank: it sets headed-arm.sh's
-# HEADED_ARM_LAUNCHER to the claudex binary (seam: HEADED_ARM_LEG_CLAUDEX_BIN,
-# default ../../claude-codex next to this script), turns on the `script`
+# bank instead of the Claude subscription bank: it routes headed-arm.sh's
+# HEADED_ARM_LAUNCHER through the preface shim to the claudex binary (seam:
+# HEADED_ARM_LEG_CLAUDEX_BIN, default ../../claude-codex), turns on the `script`
 # tty recorder (HEADED_ARM_RECORDER=1 - load-bearing: konsole -e output is
 # otherwise lost and a silent claudex death is undiagnosable), and exports
 # CLAUDEX_LANE_OK=1 + CLAUDE_CODE_EFFORT_LEVEL=${LEG_EFFORT:-medium} into the
@@ -252,9 +252,6 @@ if [ -n "$PROFILE" ]; then
     export LEG_PROFILE_SETTINGS="$PROFILE_SETTINGS"
     export LEG_PROFILE_PREFACE="$LEG_PREFACE"
     export HEADED_ARM_LAUNCHER="$LEG_SHIM"
-    if [ "$LANE" = "claudex" ]; then
-        export LEG_CLAUDE_BIN="$CLAUDEX_BIN"
-    fi
     # Lean SessionStart (HIMMEL-2830): the three advisory hooks go quiet. Only
     # the exact value 1 leans - the hooks are fail-open by construction.
     export HIMMEL_LEAN_LEG=1
@@ -277,13 +274,38 @@ if [ -n "$PROFILE" ]; then
     fi
 fi
 
+# HIMMEL-2953: every claudex leg gets its document-channel coordination
+# rules, even without a profile. Claude accepts one preface file, so a
+# profiled leg gets its own concatenation, with the lane override last.
+if [ "$LANE" = "claudex" ]; then
+    CLAUDEX_PREFACE="$HERE/../../../docs/handover/leg-preface-claudex.md"
+    export HEADED_ARM_LAUNCHER="${HEADED_ARM_LEG_SHIM:-$HERE/../../lanes/leg-claude-launcher.sh}"
+    export LEG_CLAUDE_BIN="$CLAUDEX_BIN"
+    for _leg_need in "$CLAUDEX_PREFACE" "$HEADED_ARM_LAUNCHER"; do
+        if [ ! -f "$_leg_need" ]; then
+            echo "headed-arm-leg: --lane claudex: required file missing: $_leg_need" >&2
+            exit 2
+        fi
+    done
+    if [ -n "$PROFILE" ]; then
+        LEG_PROFILE_PREFACE="$(dirname "$LOG")/$NAME.leg-preface.md"
+        export LEG_PROFILE_PREFACE
+    else
+        export LEG_PROFILE_PREFACE="$CLAUDEX_PREFACE"
+    fi
+fi
+
 if [ "$DRY_RUN" -eq 1 ]; then
     printf 'headed-arm-leg: would exec: %s %s %s %s %s %s %s %s\n' \
         "$HEADED_ARM" "$NAME" "$DOC" "$SIGNAL" "$DEADLINE" "$LOG" "$MODEL" "$CONTEXT"
     printf 'headed-arm-leg: env IMPL_GUARD_OK=%s INLINE_IMPL_OK=%s HIMMEL_CONSOLE_LEG=%s HEADED_ARM_REPO=%s\n' \
         "$IMPL_GUARD_OK" "$INLINE_IMPL_OK" "$HIMMEL_CONSOLE_LEG" "${HEADED_ARM_REPO:-<derived by headed-arm.sh>}"
-    printf 'headed-arm-leg: lane=%s launcher=%s launcher-env=%s\n' \
+    printf 'headed-arm-leg: lane=%s launcher=%s launcher-env=%s' \
         "$LANE" "${HEADED_ARM_LAUNCHER:-claude (native default)}" "${HEADED_ARM_LAUNCHER_ENV:-<none>}"
+    if [ "$LANE" = "claudex" ]; then
+        printf ' exec-target=%s preface=%s' "$LEG_CLAUDE_BIN" "$LEG_PROFILE_PREFACE"
+    fi
+    printf '\n'
     # Printed ONLY under --profile: with the flag omitted this whole line is
     # absent and the dry-run report is byte-identical to the pre-HIMMEL-2830
     # one, matching the argv guarantee it describes.
@@ -302,6 +324,13 @@ if [ -n "$PROFILE" ]; then
         exit 2
     fi
     chmod 600 "$PROFILE_SETTINGS" 2>/dev/null || true
+    if [ "$LANE" = "claudex" ]; then
+        if ! cat "$LEG_PREFACE" "$CLAUDEX_PREFACE" > "$LEG_PROFILE_PREFACE"; then
+            echo "headed-arm-leg: --lane claudex: cannot write preface to $LEG_PROFILE_PREFACE" >&2
+            exit 2
+        fi
+        chmod 600 "$LEG_PROFILE_PREFACE" 2>/dev/null || true
+    fi
     if [ -n "${LEG_PROFILE_MCP_CONFIG:-}" ]; then
         if ! printf '%s\n' "$MCP_CONFIG_JSON" > "$LEG_PROFILE_MCP_CONFIG"; then
             echo "headed-arm-leg: --profile $PROFILE: cannot write mcp config to $LEG_PROFILE_MCP_CONFIG" >&2

--- a/scripts/handover/console-kit/headed-arm-leg.sh
+++ b/scripts/handover/console-kit/headed-arm-leg.sh
@@ -104,10 +104,9 @@
 # roster-shaped (~40k of a 74.3k first-turn floor is tool + MCP schemas), so a
 # second or third "profile by skill set" would resolve to the same manifest -
 # see the _comment in plugin-profiles.json.
-# --profile is REFUSED with exit 2 on --lane claudex: that lane replaces the
-# launcher binary with scripts/claude-codex, so both cannot own
-# HEADED_ARM_LAUNCHER. Silently letting one win would produce a leg that is
-# neither lean nor on the codex bank.
+# --profile composes with --lane claudex (HIMMEL-2962): the shim prepends
+# profile flags, then execs scripts/claude-codex via LEG_CLAUDE_BIN. The
+# backend and its guarded argument screen remain in the launch path.
 # Seams: HEADED_ARM_LEG_PROFILES overrides the plugin-profiles.mjs resolver
 # path, HEADED_ARM_LEG_PREFACE the preface file, HEADED_ARM_LEG_SHIM the
 # launcher shim - all script-relative by default, all so the suite can drive
@@ -156,15 +155,6 @@ case "$LANE" in
         exit 2
         ;;
 esac
-
-# --profile and --lane claudex both want to own HEADED_ARM_LAUNCHER (see the
-# header). Refuse rather than pick a winner: either outcome is a leg the
-# operator did not ask for.
-if [ -n "$PROFILE" ] && [ "$LANE" = "claudex" ]; then
-    usage
-    echo "headed-arm-leg: --profile is not available on --lane claudex: both replace headed-arm.sh's launcher binary (the profile shim vs scripts/claude-codex), so only one can apply. Drop --profile, or run this leg on the native lane." >&2
-    exit 2
-fi
 
 if [ "$#" -lt 5 ]; then
     usage
@@ -262,6 +252,9 @@ if [ -n "$PROFILE" ]; then
     export LEG_PROFILE_SETTINGS="$PROFILE_SETTINGS"
     export LEG_PROFILE_PREFACE="$LEG_PREFACE"
     export HEADED_ARM_LAUNCHER="$LEG_SHIM"
+    if [ "$LANE" = "claudex" ]; then
+        export LEG_CLAUDE_BIN="$CLAUDEX_BIN"
+    fi
     # Lean SessionStart (HIMMEL-2830): the three advisory hooks go quiet. Only
     # the exact value 1 leans - the hooks are fail-open by construction.
     export HIMMEL_LEAN_LEG=1

--- a/scripts/handover/console-kit/test-headed-arm-leg.sh
+++ b/scripts/handover/console-kit/test-headed-arm-leg.sh
@@ -378,7 +378,7 @@ contains "full launch, --lane claudex: CLAUDE_CODE_EFFORT_LEVEL=medium reaches t
 # --append-system-prompt-file and execs the real claude. Three things must
 # hold, and each is a separate case below: the child really does get both
 # flags; omitting --profile changes nothing; and --profile on --lane claudex
-# is refused rather than silently losing one of the two launchers.
+# composes both launchers rather than silently losing one.
 
 # 17a. The shim itself, driven directly: this is the only place the CHILD
 # cmdline is observable (the konsole stub records the launch command but never
@@ -509,14 +509,58 @@ check "an unknown profile name is refused with exit 2" "$rc" "2"
 rc=0; out="$(timeout 5 bash "$SCRIPT" --profile 2>&1)" || rc=$?  # gnu-ok: bounds a usage-path regression; this suite exercises Linux/KDE-only headed-arm.sh
 check "usage: --profile with no value -> exit 2 (not an infinite loop)" "$rc" "2"
 
-# 17d. --profile + --lane claudex: both replace the launcher binary, so one
-# would silently win. Refuse instead.
+# 17d. HIMMEL-2962: composition must carry the profile through the claudex
+# backend, not silently select one launcher. Execute the real wrapper + shim
+# against recording endpoints (never launch Claude or a terminal).
 rc=0; out="$(bash "$SCRIPT" --dry-run --lane claudex --profile leg-impl HIMMEL-9999-leg some/doc.md /tmp/nosig 99999999999 /tmp/leg.log 2>&1)" || rc=$?
-check "--profile with --lane claudex: exit 2" "$rc" "2"
-contains "--profile with --lane claudex: the refusal says why in one line" "$out" \
-  "--profile is not available on --lane claudex"
+check "--profile with --lane claudex: exit 0" "$rc" "0"
+contains "composed dry-run: profile settings reported" "$out" "profile=leg-impl settings="
+contains "composed dry-run: claudex lane retained" "$out" "lane=claudex"
 rc=0; out="$(LEG_LANE=claudex LEG_PROFILE=leg-impl bash "$SCRIPT" --dry-run HIMMEL-9999-leg some/doc.md /tmp/nosig 99999999999 /tmp/leg.log 2>&1)" || rc=$?
-check "the same conflict via the env equivalents: exit 2" "$rc" "2"
+check "composition via the env equivalents: exit 0" "$rc" "0"
+
+composed="$tmp/composed launch"; mkdir -p "$composed"
+cat > "$composed/headed" <<'HEADED_EOF'
+#!/usr/bin/env bash
+read -r -a lane_env <<< "${HEADED_ARM_LAUNCHER_ENV:-}"
+exec env ${lane_env[@]+"${lane_env[@]}"} "$HEADED_ARM_LAUNCHER" --model "$6" --autocompact 200000 -n "$1" "load $2 and continue"
+HEADED_EOF
+cat > "$composed/claude-codex" <<'CLAUDEX_EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$(dirname "$0")/args"
+printf '%s\n' "${CLAUDEX_LANE_OK:-}" "${CLAUDE_CODE_EFFORT_LEVEL:-}" > "$(dirname "$0")/lane-env"
+CLAUDEX_EOF
+cat > "$composed/profiles.mjs" <<'PROFILE_EOF'
+switch (process.argv[3]) {
+  case '--mcp-servers': console.log('["qmd"]'); break;
+  case '--mcp-config': console.log('{"mcpServers":{"qmd":{"type":"http","url":"http://localhost:8181/mcp"}}}'); break;
+  default: console.log('{"enabledPlugins":{},"permissions":{"allow":["Bash(bash scripts/handover/merge-on-green.sh:*)"]}}');
+}
+PROFILE_EOF
+chmod 755 "$composed/headed" "$composed/claude-codex"
+rc=0
+HEADED_ARM_LEG_TARGET="$composed/headed" HEADED_ARM_LEG_CLAUDEX_BIN="$composed/claude-codex" \
+HEADED_ARM_LEG_PROFILES="$composed/profiles.mjs" HEADED_ARM_LEG_PREFLIGHT="$PROCEED_PREFLIGHT" LEG_EFFORT=high \
+  bash "$SCRIPT" --lane claudex --profile leg-impl HIMMEL-composed "some/doc.md" "$composed/signal" "$PAST" "$composed/log" >/dev/null 2>&1 || rc=$?
+check "composition: real wrapper + shim reaches claudex" "$rc" "0"
+check "composition: lane env reaches the backend" "$(cat "$composed/lane-env" 2>/dev/null || true)" "$(printf '1\nhigh')"
+rc=0
+node - "$composed" "$HERE/../../../docs/handover/leg-preface.md" <<'NODE' || rc=$?
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const [dir, preface] = process.argv.slice(2);
+assert.deepStrictEqual(fs.readFileSync(`${dir}/args`, 'utf8').trimEnd().split('\n'), [
+  '--settings', `${dir}/HIMMEL-composed.leg-settings.json`,
+  '--append-system-prompt-file', preface,
+  '--mcp-config', `${dir}/HIMMEL-composed.leg-mcp.json`, '--strict-mcp-config',
+  '--model', 'gpt-6-astra', '--autocompact', '200000', '-n', 'HIMMEL-composed', 'load some/doc.md and continue',
+]);
+const settings = JSON.parse(fs.readFileSync(`${dir}/HIMMEL-composed.leg-settings.json`, 'utf8'));
+assert.ok(settings.permissions.allow.includes('Bash(bash scripts/handover/merge-on-green.sh:*)'));
+assert.deepStrictEqual(JSON.parse(fs.readFileSync(`${dir}/HIMMEL-composed.leg-mcp.json`, 'utf8')),
+  {mcpServers: {qmd: {type: 'http', url: 'http://localhost:8181/mcp'}}});
+NODE
+check "composition: all profile flags, argv order and gate settings survive" "$rc" "0"
 
 # --- 18 (HIMMEL-2935). --profile's mcpServers allowlist: --mcp-config +
 # --strict-mcp-config narrow the leg's MCP surface to exactly the named

--- a/scripts/handover/console-kit/test-headed-arm-leg.sh
+++ b/scripts/handover/console-kit/test-headed-arm-leg.sh
@@ -37,7 +37,7 @@ SCRIPT="$HERE/headed-arm-leg.sh"
 HEADED_ARM="$HERE/../headed-arm.sh"
 # The suite owns every launcher input; an ambient leg shell must not silently
 # turn default-native cases into claudex cases.
-unset LEG_LANE LEG_CONTEXT LEG_REPO LEG_EFFORT HEADED_ARM_LAUNCHER HEADED_ARM_LAUNCHER_ENV HEADED_ARM_RECORDER IMPL_GUARD_OK INLINE_IMPL_OK HIMMEL_CONSOLE_LEG HIMMEL_LEAN_LEG LEG_PROFILE LEG_PROFILE_SETTINGS LEG_PROFILE_PREFACE LEG_PROFILE_MCP_CONFIG 2>/dev/null || true
+unset LEG_LANE LEG_CONTEXT LEG_REPO LEG_EFFORT HEADED_ARM_LAUNCHER HEADED_ARM_LAUNCHER_ENV HEADED_ARM_RECORDER IMPL_GUARD_OK INLINE_IMPL_OK HIMMEL_CONSOLE_LEG HIMMEL_LEAN_LEG LEG_CLAUDE_BIN LEG_PROFILE LEG_PROFILE_SETTINGS LEG_PROFILE_PREFACE LEG_PROFILE_MCP_CONFIG 2>/dev/null || true
 
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/headed-arm-leg-test.XXXXXX")" || { echo "FAIL: mktemp -d failed" >&2; exit 1; }
 trap 'rm -rf "$tmp"' EXIT
@@ -70,7 +70,7 @@ mk_launch_stubs() {
   cat > "$dir/konsole" <<'KONSOLE_EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$(dirname "$0")/record"
-env | grep -E '^(IMPL_GUARD_OK|INLINE_IMPL_OK|HIMMEL_CONSOLE_LEG|HEADED_ARM_REQUIRED_AUTOCOMPACT|HIMMEL_LEAN_LEG|LEG_PROFILE_SETTINGS|LEG_PROFILE_PREFACE|LEG_PROFILE_MCP_CONFIG)=' > "$(dirname "$0")/env-record"
+env | grep -E '^(IMPL_GUARD_OK|INLINE_IMPL_OK|HIMMEL_CONSOLE_LEG|HEADED_ARM_REQUIRED_AUTOCOMPACT|HIMMEL_LEAN_LEG|LEG_CLAUDE_BIN|LEG_PROFILE_SETTINGS|LEG_PROFILE_PREFACE|LEG_PROFILE_MCP_CONFIG)=' > "$(dirname "$0")/env-record"
 : > "$(dirname "$0")/confirmable"
 sleep 5
 KONSOLE_EOF
@@ -363,7 +363,9 @@ wait_record "$d16" || true
 rec16="$(cat "$d16/record" 2>/dev/null || true)"
 check "full launch, --lane claudex: exit 0" "$rc" "0"
 contains "full launch, --lane claudex: wrapped in script(1) with the SAME log path, appending (-a)" "$rec16" "script -q -a -f $d16/log -c"
-contains "full launch, --lane claudex: the claude-codex stub path reaches the recorded argv" "$rec16" "$claudex_stub"
+contains "full launch, --lane claudex: the preface shim reaches the recorded argv" "$rec16" "leg-claude-launcher.sh"
+contains "full launch, --lane claudex: the shim retains the claudex backend" \
+  "$(cat "$d16/env-record" 2>/dev/null || true)" "LEG_CLAUDE_BIN=$claudex_stub"
 not_contains "full launch, --lane claudex: launcher not force-wrapped in bash (execs via its own shebang)" "$rec16" "bash $claudex_stub"
 contains "full launch, --lane claudex: --model defaults to gpt-6-astra" "$rec16" "--model gpt-6-astra"
 contains "full launch, --lane claudex: --autocompact 200000 (standard context ceiling)" "$rec16" "--autocompact 200000"
@@ -548,7 +550,11 @@ rc=0
 node - "$composed" "$HERE/../../../docs/handover/leg-preface.md" <<'NODE' || rc=$?
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
-const [dir, preface] = process.argv.slice(2);
+const [dir, profilePreface] = process.argv.slice(2);
+const preface = `${dir}/HIMMEL-composed.leg-preface.md`;
+const claudexPreface = profilePreface.replace('leg-preface.md', 'leg-preface-claudex.md');
+assert.strictEqual(fs.readFileSync(preface, 'utf8'),
+  fs.readFileSync(profilePreface, 'utf8') + fs.readFileSync(claudexPreface, 'utf8'));
 assert.deepStrictEqual(fs.readFileSync(`${dir}/args`, 'utf8').trimEnd().split('\n'), [
   '--settings', `${dir}/HIMMEL-composed.leg-settings.json`,
   '--append-system-prompt-file', preface,
@@ -560,7 +566,25 @@ assert.ok(settings.permissions.allow.includes('Bash(bash scripts/handover/merge-
 assert.deepStrictEqual(JSON.parse(fs.readFileSync(`${dir}/HIMMEL-composed.leg-mcp.json`, 'utf8')),
   {mcpServers: {qmd: {type: 'http', url: 'http://localhost:8181/mcp'}}});
 NODE
-check "composition: all profile flags, argv order and gate settings survive" "$rc" "0"
+check "composition: both prefaces, all profile flags, argv order and gate settings survive" "$rc" "0"
+
+# Without a profile, claudex gains exactly the coordination preface pair.
+rc=0
+HEADED_ARM_LEG_TARGET="$composed/headed" HEADED_ARM_LEG_CLAUDEX_BIN="$composed/claude-codex" \
+HEADED_ARM_LEG_PREFLIGHT="$PROCEED_PREFLIGHT" \
+  bash "$SCRIPT" --lane claudex HIMMEL-unprofiled "some/doc.md" "$composed/signal" "$PAST" "$composed/log" >/dev/null 2>&1 || rc=$?
+check "unprofiled claudex: launcher succeeds" "$rc" "0"
+rc=0
+node - "$composed" "$HERE/../../../docs/handover/leg-preface-claudex.md" <<'NODE' || rc=$?
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const [dir, preface] = process.argv.slice(2);
+assert.deepStrictEqual(fs.readFileSync(`${dir}/args`, 'utf8').trimEnd().split('\n'), [
+  '--append-system-prompt-file', preface,
+  '--model', 'gpt-6-astra', '--autocompact', '200000', '-n', 'HIMMEL-unprofiled', 'load some/doc.md and continue',
+]);
+NODE
+check "unprofiled claudex: exactly one added preface pair, other argv unchanged" "$rc" "0"
 
 # --- 18 (HIMMEL-2935). --profile's mcpServers allowlist: --mcp-config +
 # --strict-mcp-config narrow the leg's MCP surface to exactly the named

--- a/scripts/hooks/rtk-hook-guard.sh
+++ b/scripts/hooks/rtk-hook-guard.sh
@@ -16,8 +16,8 @@
 # predicate rtk rejects (-not/-exec/-o/-a/-delete/!/\(…\)) or silently
 # drops (-prune), it suppresses the rewrite — empty output means the
 # original command runs unmodified through the normal permission flow.
-# Simple finds and every other command keep rtk's rewrite verbatim:
-# zero token regression.
+# Simple finds and other commands keep rtk's rewrite verbatim, except
+# claudex git rewrites (HIMMEL-2953; see the lane suppression below).
 #
 # Rejected-token set verified against rtk 0.40.0 (see
 # test-rtk-hook-guard.sh). -prune is included although rtk only warns
@@ -41,6 +41,19 @@ command -v rtk >/dev/null 2>&1 || exit 0
 
 out=$(printf '%s' "$payload" | rtk hook claude 2>/dev/null) || exit 0
 [ -n "$out" ] || exit 0
+
+# HIMMEL-2953: the claudex classifier cannot establish the executable behind
+# `rtk git`. Keep git in its original permission flow, never emit an allow.
+# CLAUDE_CONFIG_DIR is exported by claude-codex, including non-headed launches.
+# Scan conservatively before extraction so missing jq / output-shape drift
+# cannot resurrect the wrapper. A false positive only loses token savings.
+config_dir="${CLAUDE_CONFIG_DIR:-}"
+config_dir="${config_dir%/}"
+if [ "${config_dir##*/}" = ".claude-codex" ]; then
+    case "$out" in
+        *'"rtk git '*) exit 0 ;;
+    esac
+fi
 
 # Extract the rewritten command VALUE and scan only that (HIMMEL-264).
 # Scanning rtk's whole JSON output was brittle to output-shape drift: a

--- a/scripts/hooks/test-rtk-hook-guard.sh
+++ b/scripts/hooks/test-rtk-hook-guard.sh
@@ -40,6 +40,9 @@
 
 set -euo pipefail
 
+# The native controls must not inherit the lane running this suite.
+unset CLAUDE_CONFIG_DIR
+
 # grepq <text> [grep-args...] — a `grep -q` test against <text> with NO
 # pipeline. printf/echo-into-`grep -q` is a trap under this file's
 # `set -o pipefail`: grep -q exits the instant it matches, the producer
@@ -150,6 +153,32 @@ for cmd in 'git status' 'sort -o out.txt in.txt' 'ls -a /tmp'; do
         assert_fail "expected rtk rewrite for '$cmd', got: $out"
     fi
 done
+
+# HIMMEL-2953: a git rewrite hides the executable from the claudex
+# classifier. Suppression must not grant permission or affect native savings.
+echo "Test 3b: claudex git stays in the original permission flow"
+for config in '/tmp/.claude-codex' '/tmp/.claude-codex/'; do
+    out=$(CLAUDE_CONFIG_DIR="$config" run_hook 'git fetch origin')
+    if [ -z "$out" ]; then
+        assert_pass "claudex git rewrite suppressed: $config"
+    else
+        assert_fail "expected empty claudex git output, got: $out"
+    fi
+done
+for config in '' '/tmp/.claude' '/tmp/.claude-codex-other'; do
+    out=$(CLAUDE_CONFIG_DIR="$config" run_hook 'git fetch origin')
+    if grepq "$out" '"rtk git fetch origin"'; then
+        assert_pass "native git rewrite preserved: $config"
+    else
+        assert_fail "expected native git rewrite, got: $out"
+    fi
+done
+out=$(CLAUDE_CONFIG_DIR='/tmp/.claude-codex' run_hook 'ls -a /tmp')
+if grepq "$out" '"rtk ls -a /tmp"'; then
+    assert_pass "claudex non-git rewrite preserved"
+else
+    assert_fail "expected claudex non-git rewrite, got: $out"
+fi
 
 # ---------- 4. rtk silent (compound shell command) ----------
 echo "Test 4: rtk emits nothing → guard emits nothing"

--- a/scripts/lanes/leg-claude-launcher.sh
+++ b/scripts/lanes/leg-claude-launcher.sh
@@ -49,7 +49,9 @@
 #                           which is exactly why the file is never hand-typed
 #                           (see plugin-profiles.mjs's collectMcpServerDefs).
 # Seam: LEG_CLAUDE_BIN overrides the `claude` binary this execs (default:
-# `claude` from PATH) so a suite can point it at a recording stub.
+# `claude` from PATH). headed-arm-leg.sh sets it to scripts/claude-codex on
+# the claudex lane so all profile flags reach that backend (HIMMEL-2962);
+# suites can point it at a recording stub.
 #
 # Platform: POSIX bash 3.2+ (macOS ships 3.2) - hence the
 # ${PRE[@]+"${PRE[@]}"} empty-array expansion, which 3.2 needs under `set -u`.

--- a/scripts/test-claude-codex.sh
+++ b/scripts/test-claude-codex.sh
@@ -81,6 +81,29 @@ assert.deepStrictEqual(seeded.permissions, source.permissions);
 assert.ok(!Object.hasOwn(seeded, 'model'));
 NODE
 
+# HIMMEL-2962: profile flags already pass through the screen. Pin their
+# positions and operand boundaries at the actual claude exec, not the seeder.
+setup
+cat > "$BIN/claude" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$HOME/forwarded-args"
+MOCK
+for flag in --append-system-prompt-file --mcp-config --strict-mcp-config; do
+  args=(--model gpt-6-astra "$flag")
+  [ "$flag" = --strict-mcp-config ] || args+=("$WORK/profile file")
+  args+=(-n HIMMEL-forward "load doc and continue")
+  run_launcher "profile flag forwarded: $flag" "${args[@]}"
+  node - "$FAKEHOME/forwarded-args" "${args[@]}" <<'NODE' || FAILS=$((FAILS + 1))
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+assert.deepStrictEqual(fs.readFileSync(process.argv[2], 'utf8').trimEnd().split('\n'), process.argv.slice(3));
+NODE
+done
+for flag in --bare --safe-mode --setting-sources; do
+  run_launcher_expect "harness integrity flag still refused: $flag" 3 'REFUSED' "$flag"
+done
+run_launcher_expect 'backend settings override still refused' 3 'REFUSED' --settings '{"env":{"ANTHROPIC_BASE_URL":"https://other.invalid"}}'
+
 # A named model reaches the load-bearing seeded CLAUDE.md stanza at the file end.
 setup
 MODEL="gpt-5.6-terra"


### PR DESCRIPTION
## Summary

- **HIMMEL-2953 fault 1:** leave git commands unwrapped on the claudex config namespace, preserving the normal permission flow (no allow decision).
- **HIMMEL-2962:** compose `--profile` with `--lane claudex` through the existing `LEG_CLAUDE_BIN` shim seam. Settings, preface and optional strict MCP configuration reach the backend together.
- **HIMMEL-2953 fault 2:** always inject the claudex coordination preface; concatenate it after the profile preface when both apply. Native argv stays unchanged.

## Fault-1 diagnosis

Native and seeded PreToolUse hook chains have the same order: rtk guard, then the skip-wrapper/auto-approval chain. `scripts/claude-codex:343–350,384–386` mirrors hooks and strips model/backend environment, not hook order. `scripts/hooks/guardrail-skip-in-himmel.js:51–66` reads project directory/settings, not `CLAUDE_CONFIG_DIR`; `scripts/hooks/auto-approve-safe-bash.sh:106–136` excludes fetch from local-read approvals and does not unwrap rtk or branch on the lane. Thus the reported refusal is downstream classifier handling of the rtk wrapper, not evidence of reversed hook order. A real fetch was deliberately not run.

`scripts/hooks/rtk-hook-guard.sh:45–59` now suppresses `rtk git` output when the config-directory basename is `.claude-codex`, normalizing repeated trailing slashes with a root-preserving loop. This variable is exported by the backend, covering direct and headed launches. Native git and claudex non-git rewrites remain intact; suppression never grants permission and preserves fail-open behavior.

## Launch composition and argv

Let `ORIGINAL` be `--model <model> --autocompact 200000 -n <name> <prompt>`.

| Shape | Before | After |
|---|---|---|
| Native, no profile | `claude ORIGINAL` | Identical |
| Native, profile | `claude --settings SETTINGS --append-system-prompt-file PROFILE_PREFACE [MCP_FLAGS] ORIGINAL` | Identical |
| Claudex, no profile | `claude-codex ORIGINAL` | Shim execs `claude-codex --append-system-prompt-file CLAUDEX_PREFACE ORIGINAL` |
| Claudex + profile | Refused, exit 2 | Shim execs `claude-codex --settings SETTINGS --append-system-prompt-file COMBINED_PREFACE [MCP_FLAGS] ORIGINAL` |

`MCP_FLAGS` is `--mcp-config MCP_JSON --strict-mcp-config` when the profile declares MCP servers. The combined file contains the profile preface first, claudex coordination second, with exactly one preface flag. Tests pin each argument boundary, including paths containing spaces, lane/effort environment, seeded permission gate, MCP definitions and concatenation order.

**No claude-codex change needed, forwarding pinned by rows.** Its existing argument screen already forwards all three requested preface/MCP flags. No production PowerShell change or mirrored patch was necessary. The existing PowerShell suite characterizes seeding only, whereas the added Bash rows characterize existing exec forwarding for the Linux/KDE-only headed caller. Local PowerShell suites were not executed; the GitHub Windows bun job passed, which does not establish PowerShell-suite coverage.

## RED → GREEN

- Hook: baseline 25/25; two new claudex git-suppression rows failed before the change, then 31/31 passed, including native and non-git controls.
- App correction at `6aca15bdf188e191ec3ab47b8c59407ee398e0ab`: double-trailing-slash row RED (31 passed / 1 failed, `/tmp/quiet-run-suite-20260912-195745-4145249.log`) → GREEN 32/32 (`/tmp/quiet-run-suite-20260912-195817-4152104.log`). Run 3 exact-head rerun also GREEN 32/32 (`/tmp/quiet-run-suite-20260912-201822-229773.log`).
- Composition: seven assertions failed against the previous mutual-exclusion refusal, then passed after composing the existing shim/backend seams.
- Preface: two new combined-file/no-profile argv assertions failed before injection, then passed.
- Forwarding: all three flag characterization rows were already GREEN before any backend edit; four integrity-refusal controls remain GREEN. These are characterization tests, not claimed RED regressions.

## Impacted-suite verification

All local suites below ran on Linux in the implementation session. The three directly affected shell suites, shellcheck and diff-check were rerun at `33b3056a`; after the hook-only correction, the hook and reconciliation suites plus shellcheck, wiring and diff checks passed at `6aca15bd`. Run 3 reverified the hook suite and committed diff, and all GitHub CI jobs passed at `6aca15bd`. No live leg, model call through the launcher, or proxy launch was used for these tests: recording endpoints are stubs.

| Suite/check | Verdict |
|---|---|
| `scripts/hooks/test-rtk-hook-guard.sh` | GREEN 32/32 at `6aca15bd`, including Run 3 rerun |
| `scripts/handover/console-kit/test-headed-arm-leg.sh` | GREEN; rerun at `33b3056a` |
| `scripts/test-claude-codex.sh` | GREEN; rerun at `33b3056a` |
| `scripts/hooks/test-reconcile-rtk-hook.sh` | GREEN; rerun after hook correction |
| `scripts/lib/test-wire-pretooluse-hooks.sh` | GREEN |
| `scripts/handover/console-kit/test-go.sh` | GREEN |
| `scripts/hooks/test-codex-run-hook.sh` | GREEN 57/57 |
| `scripts/hooks/test-qmd-staleness-notice.sh` | GREEN |
| `scripts/lib/test-setup-wire.sh` | GREEN |
| `scripts/lib/test-unwire-pretooluse-hooks.sh` | GREEN |
| `scripts/machine-setup/test-ubuntu-settings-jq.sh` | GREEN 24/24 |
| `scripts/machine-setup/test-ubuntu-shim.sh` | GREEN |
| `scripts/test-adopt.sh` | GREEN |
| `scripts/test-e2e-symmetry.sh` | GREEN |
| `scripts/test-uninstall.sh` | GREEN |
| `scripts/handover/test-template-operator-gated-clause.sh` | GREEN |
| `scripts/handover/test-headed-arm.sh` | GREEN with HEADED_ARM_* cleared; red under the claudex launcher env = pre-existing, HIMMEL-2969. Cross-UID fixture SKIPPED (no sudo). Suite and production file untouched. |
| `scripts/hooks/guardrail-block.test.mjs` + `wire-hook-bash.test.mjs` | GREEN, Node |
| `scripts/lanes/tests/**/*.test.mjs` | GREEN, documented Node invocation |
| `scripts/telegram/spawn-claudex.test.ts` | GREEN 131/131, bun |
| `node scripts/hooks/wire-hook-bash.mjs --check` | GREEN; already wired, no write |
| `shellcheck -x` on all six touched shell files | GREEN; touched correction files also passed |
| `git diff --check main...HEAD` | GREEN at `6aca15bd` |
| `graphify update .` | GREEN, AST-only after implementation and correction; generated graph remains ignored |
| Local Windows `.ps1` suites | NOT RUN; no pwsh on this Linux host |
| GitHub CI at `6aca15bd` | All jobs pass, including Linux and Windows bun jobs |

## Review rounds

| Round | Head | Reviewer | Critical / Important / Suggestions | Disposition |
|---|---|---|---|---|
| 1 of 3 | `33b3056ab6aad4e89755fe5812cb13a9fb322032` | codex panel, responding model gpt-6-astra | 0 / 0 / 0 | Marker cleared; orphan-check 0 |
| App review | `33b3056ab6aad4e89755fe5812cb13a9fb322032` | CodeRabbit | 0 / 2 / 0 | Hook fixed in `6aca15bd`; documentation reconciliation deferred to open HIMMEL-2971; both threads resolved |
| 2 of 3 | `6aca15bdf188e191ec3ab47b8c59407ee398e0ab` | codex panel, responding model gpt-6-astra | 0 / 0 / 0 | Exact-head panel carries the rate-limited App gate per console adjudication; marker cleared; orphan-check 0; 0 still-open / 2 skip-terminal |

Captured panel base for both rounds: `d61f000c23bec996ddf1318d55057ead37ba2aa3`. Codex adversarial companion was dormant by configured `CODEX_ADV_OK` (not launched); Claude reviewer agents were not enabled. No new findings or nits from round 2. All-time codex agreed=25%, availability=99%; zero candidates this round.

The manual App request at `6aca15bd` returned **`Review rate limited`**, not a substantive fresh review. The existing gate accepts the actual clean exact-head codex panel under HIMMEL-1465, without an override. Its full CI check returned exit 0 during marker clearance. The gate also reports `fresh coderabbitai review @ 6aca15bdf188e191ec3ab47b8c59407ee398e0ab`; this is an empty reply-associated review object, **not** an independent full App review. No unresolved App threads remain. Console adjudication accepted the exact-head panel carry and issued GO for the exact head. The gated merge completed as `baa7efdaa4903fe029a90955530c70dee4525918` at 2026-09-12T18:27:20Z.

Known-findings round-1 hits = 0; round 2 has no candidates. The octal detector hit is a constant `FAILS + 1`, not a leading-zero input. `leg-claude-launcher.sh` changes only explanatory comments; its composition behavior is exercised by the wrapper suite. PowerShell coverage distinction is noted above. Doc-freshness additionally suggested `docs/internals/enforcement.md`; this advisory did not widen the approved documentation scope.

## Limits and follow-up

- Socket bridge not done — document-channel coordination is now structurally injected.
- Live profiled claudex proof remains for the console's next actual `--lane claudex --profile` dispatch; stub coverage is not live matcher proof.
- Push-rule deny-pair work is not part of this PR and remains separately owned.
- HIMMEL-2971 reconciles the no-parking documentation with the intentional READY → GO merge boundary. Removing that boundary was declined, and CodeRabbit withdrew that proposed remedy.
- Four commits total: three implementation commits plus the single permitted hook CR fix. Run 3 added no commits. First commit contains Linux/security attestations; its initial PowerShell-mirroring wording reflects the original brief, superseded by the verified no-backend-change result above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated Claudex handover guidance, including coordination, milestone reporting, authorization, and lane operating rules.
  * Claudex launches now support profile combinations, coordinated prefaces, settings, and MCP configuration.
  * Dry runs provide clearer launcher, target, and preface details.
* **Bug Fixes**
  * Improved Git command handling under Claudex configurations to preserve normal permission checks.
  * Added validation to reject unsupported backend overrides and harness-control flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
